### PR TITLE
fix: Improve site creation error handling

### DIFF
--- a/src/components/site-form.tsx
+++ b/src/components/site-form.tsx
@@ -72,7 +72,7 @@ function FormPathInputComponent( {
 					) }
 				>
 					<Icon
-						className={ error ? 'fill-red-500' : '' }
+						className={ cx( 'shrink-0 basis-4', error ? 'fill-red-500' : '' ) }
 						icon={ error ? warning : tip }
 						width={ 16 }
 						height={ 16 }

--- a/src/components/tests/add-site.test.tsx
+++ b/src/components/tests/add-site.test.tsx
@@ -205,4 +205,27 @@ describe( 'AddSite', () => {
 			screen.getByDisplayValue( '/default_path/my-wordpress-website-mutated' )
 		).toBeInTheDocument();
 	} );
+
+	it( 'should display a helpful error message when an error occurs while creating the site', async () => {
+		const user = userEvent.setup();
+		mockGenerateProposedSitePath.mockResolvedValue( {
+			path: '/default_path/my-wordpress-website',
+			name: 'My WordPress Website',
+			isEmpty: true,
+			isWordPress: false,
+		} );
+		mockCreateSite.mockImplementation( () => {
+			throw new Error( 'Failed to create site' );
+		} );
+		render( <AddSite /> );
+
+		await user.click( screen.getByRole( 'button', { name: 'Add site' } ) );
+		await user.click( screen.getByRole( 'button', { name: 'Add site' } ) );
+
+		await waitFor( () => {
+			expect( screen.getByRole( 'alert' ) ).toHaveTextContent(
+				'An error occurred while creating the site. Verify your selected local path is an empty directory or an existing WordPress folder and try again. If this problem persists, please contact support.'
+			);
+		} );
+	} );
 } );

--- a/src/components/tests/add-site.test.tsx
+++ b/src/components/tests/add-site.test.tsx
@@ -167,4 +167,42 @@ describe( 'AddSite', () => {
 		expect( screen.getByDisplayValue( 'My WordPress Website' ) ).toBeInTheDocument();
 		expect( screen.getByDisplayValue( '/default_path/my-wordpress-website' ) ).toBeInTheDocument();
 	} );
+
+	it( 'should reset to the proposed path when the path is set to default app directory', async () => {
+		const user = userEvent.setup();
+		mockGenerateProposedSitePath.mockImplementation( ( name ) => {
+			const path = `/default_path/${ name.replace( /\s/g, '-' ).toLowerCase() }`;
+			return Promise.resolve( {
+				path,
+				name,
+				isEmpty: true,
+				isWordPress: false,
+			} );
+		} );
+		mockShowOpenFolderDialog.mockResolvedValue( {
+			path: 'populated-non-wordpress-directory',
+			name: 'My WordPress Website',
+			isEmpty: false,
+			isWordPress: false,
+		} );
+		render( <AddSite /> );
+
+		await user.click( screen.getByRole( 'button', { name: 'Add site' } ) );
+		await user.click( screen.getByTestId( 'select-path-button' ) );
+
+		mockShowOpenFolderDialog.mockResolvedValue( {
+			path: '/default_path',
+			name: 'My WordPress Website',
+			isEmpty: false,
+			isWordPress: false,
+		} );
+		await user.click( screen.getByTestId( 'select-path-button' ) );
+		await user.click( screen.getByDisplayValue( 'My WordPress Website' ) );
+		await user.type( screen.getByDisplayValue( 'My WordPress Website' ), ' mutated' );
+		// screen.debug( screen.getByRole( 'dialog' ) );
+
+		expect(
+			screen.getByDisplayValue( '/default_path/my-wordpress-website-mutated' )
+		).toBeInTheDocument();
+	} );
 } );

--- a/src/hooks/use-add-site.ts
+++ b/src/hooks/use-add-site.ts
@@ -53,12 +53,16 @@ export function useAddSite() {
 			const path = sitePath ? sitePath : proposedSitePath;
 			await createSite( path, siteName ?? '' );
 		} catch ( e ) {
-			setError( ( e as Error )?.message );
+			setError(
+				__(
+					'An error occurred while creating the site. Verify your selected local path is an empty directory or an existing WordPress folder and try again. If this problem persists, please contact support.'
+				)
+			);
 			setIsAddingSite( false );
 			throw e;
 		}
 		setIsAddingSite( false );
-	}, [ createSite, proposedSitePath, siteName, sitePath ] );
+	}, [ createSite, proposedSitePath, siteName, sitePath, __ ] );
 
 	const handleSiteNameChange = useCallback(
 		async ( name: string ) => {

--- a/src/hooks/use-add-site.ts
+++ b/src/hooks/use-add-site.ts
@@ -29,11 +29,13 @@ export function useAddSite() {
 			const { path, name, isEmpty, isWordPress } = response;
 			setDoesPathContainWordPress( false );
 			setError( '' );
-			setSitePath( path );
+			const pathResetToDefaultSitePath =
+				path === proposedSitePath.substring( 0, proposedSitePath.lastIndexOf( '/' ) );
+			setSitePath( pathResetToDefaultSitePath ? '' : path );
 			if ( siteWithPathAlreadyExists( path ) ) {
 				return;
 			}
-			if ( ! isEmpty && ! isWordPress ) {
+			if ( ! isEmpty && ! isWordPress && ! pathResetToDefaultSitePath ) {
 				setError(
 					__(
 						'This directory is not empty. Please select an empty directory or an existing WordPress folder.'
@@ -46,7 +48,7 @@ export function useAddSite() {
 				setSiteName( name ?? null );
 			}
 		}
-	}, [ __, siteWithPathAlreadyExists, siteName ] );
+	}, [ __, siteWithPathAlreadyExists, siteName, proposedSitePath ] );
 
 	const handleAddSiteClick = useCallback( async () => {
 		setIsAddingSite( true );

--- a/src/hooks/use-add-site.ts
+++ b/src/hooks/use-add-site.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/electron/renderer';
 import { useI18n } from '@wordpress/react-i18n';
 import { useCallback, useMemo, useState } from 'react';
 import { getIpcApi } from '../lib/get-ipc-api';
@@ -53,6 +54,7 @@ export function useAddSite() {
 			const path = sitePath ? sitePath : proposedSitePath;
 			await createSite( path, siteName ?? '' );
 		} catch ( e ) {
+			Sentry.captureException( e );
 			setError(
 				__(
 					'An error occurred while creating the site. Verify your selected local path is an empty directory or an existing WordPress folder and try again. If this problem persists, please contact support.'

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -118,7 +118,8 @@ export async function createSite(
 		try {
 			fs.mkdirSync( path, { recursive: true } );
 		} catch ( err ) {
-			return userData.sites;
+			Sentry.captureException( err );
+			throw err;
 		}
 	}
 

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -117,9 +117,9 @@ export async function createSite(
 	if ( ! ( await pathExists( path ) ) && path.startsWith( DEFAULT_SITE_PATH ) ) {
 		try {
 			fs.mkdirSync( path, { recursive: true } );
-		} catch ( err ) {
-			Sentry.captureException( err );
-			throw err;
+		} catch ( error ) {
+			Sentry.captureException( error );
+			throw error;
 		}
 	}
 

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -173,7 +173,7 @@ export async function createSite(
 			}
 		} catch ( error ) {
 			Sentry.captureException( error );
-			throw new Error( 'Error creating the site. Please contact support.' );
+			throw error;
 		}
 	}
 

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -137,7 +137,12 @@ export async function createSite(
 	}
 
 	if ( ( await pathExists( path ) ) && ( await isEmptyDir( path ) ) ) {
-		await createSiteWorkingDirectory( path );
+		try {
+			await createSiteWorkingDirectory( path );
+		} catch ( error ) {
+			Sentry.captureException( error );
+			throw error;
+		}
 	}
 
 	const details = {

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -125,7 +125,7 @@ export async function createSite(
 
 	if ( ! ( await isEmptyDir( path ) ) && ! isWordPressDirectory( path ) ) {
 		wasPathEmpty = true;
-		userData.sites;
+		return userData.sites;
 	}
 
 	const allPaths = userData?.sites?.map( ( site ) => site.path ) || [];


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/6590.

## Proposed Changes

- Hoist site creation error handling from the remote method to the renderer to ensure _all_ errors originating from the remote method are caught and reported so that we may monitor escalations. 
- Use a generic, user-friendly error message during site creation to avoid displaying a highly technical error message to users.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Create site from populated, non-WordPress directory**
1. Add a site via onboarding or the add site modal. 
2. Select an empty directory. 
3. Open your file browser and place a folder/file in the directory. 
4. Continue the site creation. 
5. Verify a user-friendly message is displayed. 

**Reset a custom local path to the proposed path**
1. Add a site via onboarding or the add site modal. 
2. Select a non-empty, non-WordPress directory. 
3. Verify a user-friendly error message is displayed. 
4. Select the default site directory path (e.g., `~/Studio` on macOS). 
5. Modify the site name by adding words. 
6. Verify the local path is set to the proposed path with modifications included, and continuing site creations succeeds. 


| Before | After |
| - | - |
| <img width="1012" alt="site-creation-before" src="https://github.com/Automattic/studio/assets/438664/475a79ca-90bd-4a2d-be33-c8d0a497aaf0"> | <img width="1012" alt="site-creation-after" src="https://github.com/Automattic/studio/assets/438664/6b9291ea-6b44-4e0c-ab40-0a5dbfa45fe3"> |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?

