### PR TITLE
Studio: Clicking the user avatar in settings should got to their WP.com profile

### DIFF
--- a/src/components/user-settings.tsx
+++ b/src/components/user-settings.tsx
@@ -34,6 +34,7 @@ const UserInfo = ( {
 				<Button
 					onClick={ () => getIpcApi().openURL( WPCOM_PROFILE_URL ) }
 					aria-label={ __( 'Profile link' ) }
+					className="py-0 px-0"
 				>
 					<Gravatar detailedDefaultImage isLarge={ true } isBlack />
 				</Button>

--- a/src/components/user-settings.tsx
+++ b/src/components/user-settings.tsx
@@ -3,6 +3,7 @@ import { sprintf } from '@wordpress/i18n';
 import { moreVertical, trash } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { useCallback, useState } from 'react';
+import { WPCOM_PROFILE_URL } from '../constants';
 import { useAuth } from '../hooks/use-auth';
 import { useDeleteSnapshot } from '../hooks/use-delete-snapshot';
 import { useIpcListener } from '../hooks/use-ipc-listener';
@@ -10,6 +11,7 @@ import { useOffline } from '../hooks/use-offline';
 import { useSiteDetails } from '../hooks/use-site-details';
 import { useSiteUsage } from '../hooks/use-site-usage';
 import { cx } from '../lib/cx';
+import { getIpcApi } from '../lib/get-ipc-api';
 import Button from './button';
 import { Gravatar } from './gravatar';
 import Modal from './modal';
@@ -29,7 +31,12 @@ const UserInfo = ( {
 	return (
 		<div className="flex w-full gap-5">
 			<div className="flex w-full items-center gap-[15px]">
-				<Gravatar detailedDefaultImage isLarge={ true } isBlack />
+				<Button
+					onClick={ () => getIpcApi().openURL( WPCOM_PROFILE_URL ) }
+					aria-label={ __( 'Profile link' ) }
+				>
+					<Gravatar detailedDefaultImage isLarge={ true } isBlack />
+				</Button>
 				<div className="flex flex-col">
 					<span className="overflow-ellipsis">{ user?.displayName }</span>
 					<span className="text-[#757575] text-[10px] leading-[10px]">{ user?.email }</span>

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -7,3 +7,4 @@ export const LIMIT_ARCHIVE_SIZE = 100 * 1024 * 1024; // 100MB
 export const AUTO_UPDATE_INTERVAL_MS = 60 * 60 * 1000;
 export const WINDOWS_TITLEBAR_HEIGHT = 32;
 export const STUDIO_DOCS_URL = `https://developer.wordpress.com/docs/developer-tools/studio/`;
+export const WPCOM_PROFILE_URL = `https://wordpress.com/me`;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/6641

## Proposed Changes

This PR adds a link to Gravatar image in the settings modal that brings the user to their WordPress.com account.

## Testing Instructions

* Pull the changes from this branch locally
* Start the app with `nvm use && npm install && npm start`
* Click on the Gravatar image in the right sidebar to open the Settings modal
* Click on the Gravatar icon in the modal
* Confirm that you are brought to your WordPress.com account `https://wordpress.com/me`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
