### PR TITLE
Improve 'stop all' for long translations

### DIFF
--- a/src/components/running-sites.tsx
+++ b/src/components/running-sites.tsx
@@ -23,7 +23,7 @@ export function RunningSites() {
 					<Button
 						disabled={ runningSites.length === 0 }
 						className={ cx(
-							'[&.is-link]:text-white [&.is-link:disabled]:hover:text-white [&.is-link:not(:disabled)]:hover:text-a8c-gray-10 text-xxs leading-4 !mb-0 shrink-0 items-start'
+							'[&.is-link]:text-white [&.is-link:disabled]:hover:text-white [&.is-link:not(:disabled)]:hover:text-a8c-gray-10 text-xxs leading-4 !mb-0 items-start'
 						) }
 						onClick={ stopAllRunningSites }
 						variant="link"

--- a/src/components/running-sites.tsx
+++ b/src/components/running-sites.tsx
@@ -23,7 +23,7 @@ export function RunningSites() {
 					<Button
 						disabled={ runningSites.length === 0 }
 						className={ cx(
-							'[&.is-link]:text-white [&.is-link:disabled]:hover:text-white [&.is-link:not(:disabled)]:hover:text-a8c-gray-10 text-xxs leading-4 !mb-0 items-start'
+							'[&.is-link]:text-white [&.is-link:disabled]:hover:text-white [&.is-link:not(:disabled)]:hover:text-a8c-gray-10 [&.is-link]:text-right text-xxs leading-4 !mb-0 items-start'
 						) }
 						onClick={ stopAllRunningSites }
 						variant="link"


### PR DESCRIPTION
Related to 6667-gh-Automattic/dotcom-forge

## Proposed Changes

With this PR, some tweaks are made to the 'stop all' button's styles, to ensure it remains visually pleasing with long translations.

Breakdown of the code changes:

- https://github.com/Automattic/studio/pull/12/commits/e9caaa0769e2daf97501fbc7e42a7991c5aedfd7: Removes `shrink-0` to ensure the button's content can overflow onto a new line. (Note, this class was first added in https://github.com/Automattic/studio/commit/49d1c372a8b45fe608ffab35c8dace02d6941826 but no longer seems necessary following https://github.com/Automattic/studio/commit/756a22310fd56d4392f0594991c854126bb6582b.)
- https://github.com/Automattic/studio/pull/12/commits/bc24777be0321713601719263e7af9753c899fa6: Aligns the button's contents to the right. Without this, longer translations appeared to be 'floating' in a way that didn't seem right to me, but I'm open to hearing different perspectives.

## Testing Instructions

- Set locale to a language with longer translations, such as Polish.
- Start the server for at least one site within the Studio app.
- Observe the 'Stop all' button and confirm it looks visually pleasing.

| Before  | After |
| ------------- | ------------- |
| <img src="https://github.com/Automattic/studio/assets/2998162/45a3784e-79cb-4823-9b29-3b96dac12f23" width="100%"> | <img src="https://github.com/Automattic/studio/assets/2998162/8d0bd61a-9902-4837-bc3b-aff2ed5946c8" width="100%"> |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?