### PR TITLE
Ensure visual start/stop cues are visible to keyboard-only users

### DIFF
--- a/src/components/action-button.tsx
+++ b/src/components/action-button.tsx
@@ -51,7 +51,7 @@ export const ActionButton = ( {
 	iconSize = 10,
 }: ActionButtonProps ) => {
 	const { __ } = useI18n();
-	const [ isHovered, setIsHovered ] = useState( false );
+	const [ isUserHighlighting, setIsUserHighlighting ] = useState( false );
 	const containerRef = useRef< HTMLDivElement >( null );
 	const [ resizeListener, sizes ] = useResizeObserver();
 	const minSize = useRef( { width: MIN_WIDTH, height: 0 } );
@@ -60,7 +60,7 @@ export const ActionButton = ( {
 	if ( isLoading ) {
 		state = 'loading';
 	} else if ( isRunning ) {
-		if ( isHovered ) {
+		if ( isUserHighlighting ) {
 			state = 'stop';
 		} else {
 			state = 'running';
@@ -122,6 +122,7 @@ export const ActionButton = ( {
 		case 'stop':
 			buttonLabel = __( 'Stop' );
 			buttonProps = {
+				'aria-label': __( 'Server is running, click to stop.' ),
 				icon: <StopIcon height={ iconSize } width={ iconSize } />,
 				className: cx(
 					defaultButtonClassName,
@@ -142,8 +143,10 @@ export const ActionButton = ( {
 		<div
 			ref={ containerRef }
 			className={ cx( className, 'relative' ) }
-			onMouseEnter={ () => setIsHovered( true ) }
-			onMouseLeave={ () => setIsHovered( false ) }
+			onMouseEnter={ () => setIsUserHighlighting( true ) }
+			onMouseLeave={ () => setIsUserHighlighting( false ) }
+			onFocus={ () => setIsUserHighlighting( true ) }
+			onBlur={ () => setIsUserHighlighting( false ) }
 		>
 			{ resizeListener }
 			<Button { ...defaultButtonProps } { ...buttonProps }>

--- a/src/components/site-menu.tsx
+++ b/src/components/site-menu.tsx
@@ -63,7 +63,7 @@ function ButtonToRun( { running, id, name }: Pick< SiteDetails, 'running' | 'id'
 			{ /* Circle */ }
 			<div
 				className={ cx(
-					'w-2.5 h-2.5 transition-opacity group-hover:opacity-0 border-[0.5px]',
+					'w-2.5 h-2.5 transition-opacity group-hover:opacity-0 group-focus:opacity-0 border-[0.5px]',
 					'row-start-1 col-start-1 place-self-center',
 					classCircle,
 					loadingServer[ id ] && 'animate-pulse border-[#00BA3775] bg-[#1ED15A75] duration-100',
@@ -77,7 +77,7 @@ function ButtonToRun( { running, id, name }: Pick< SiteDetails, 'running' | 'id'
 			{ ! loadingServer[ id ] && (
 				<div
 					className={ cx(
-						'opacity-0 transition-opacity group-hover:opacity-100',
+						'opacity-0 transition-opacity group-hover:opacity-100 group-focus:opacity-100',
 						'row-start-1 col-start-1 place-self-center'
 					) }
 				>
@@ -93,9 +93,9 @@ function SiteItem( { site }: { site: SiteDetails } ) {
 	return (
 		<li
 			className={ cx(
-				'flex flex-row min-w-[168px] h-8 hover:bg-[#ffffff0C] rounded transition-all',
+				'flex flex-row min-w-[168px] h-8 hover:bg-[#ffffff0C] focus:bg-[#ffffff0C] rounded transition-all',
 				isMac() ? 'mx-5' : 'mx-4',
-				isSelected && 'bg-[#ffffff19] hover:bg-[#ffffff19]'
+				isSelected && 'bg-[#ffffff19] hover:bg-[#ffffff19] focus:bg-[#ffffff19]'
 			) }
 		>
 			<button


### PR DESCRIPTION
Related to 6658-gh-Automattic/dotcom-forge

## Proposed Changes

At the moment, there are some visual cues when users hover over the start/stop buttons to indicate what the buttons do when they're clicked. These cues aren't visible to keyboard-only users, hover. With this PR, the cues are now visible to keyboard-only users. 

Recording:

https://github.com/Automattic/studio/assets/2998162/0ff27006-5030-459f-846d-20228b84c47f

## Testing Instructions

- Tab through the Studio app using your keyboard.
- For sites that _aren't_ running:
  - Tab over the dark circle in the sidebar and verify the circle turns into a green triangle, indicating that the site's server will be started when clicked.
- For sites that _are_ running:
  - Tab over the green circle in the sidebar and verify the circle turns into a red square, indicating that the site will be stopped when clicked.
  - Tab over the "Running" button in the upper right of the select site's window. Verify that it turns into a "Stop" button to indicate the site will be stopped when clicked. 

>  [!NOTE]
> An [aria-label has been added](https://github.com/Automattic/studio/blob/a2d2ed8b20467011d94dc459d2d95846446e402d/src/components/action-button.tsx#L125) to the "Stop" button to ensure there is no confusion for screen-reader users. For users who rely on screen readers, this text will state that the site is running and the button is for use to stop the site. 

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?