### PR TITLE
Add prompt for users to download correct app architecture version

### DIFF
--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -445,6 +445,7 @@ export async function getAppGlobals( _event: IpcMainInvokeEvent ): Promise< AppG
 		locale,
 		localeData,
 		appName: app.name,
+		arm64Translation: app.runningUnderARM64Translation,
 	};
 }
 

--- a/src/ipc-types.d.ts
+++ b/src/ipc-types.d.ts
@@ -70,6 +70,7 @@ interface AppGlobals {
 	locale: string;
 	localeData: LocaleData | null;
 	appName: string;
+	arm64Translation: boolean;
 }
 
 interface IpcListener {

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -91,7 +91,7 @@ getIpcApi()
 					detail:
 						window.appGlobals.platform === 'darwin'
 							? __(
-									'Downloading the Mac silicon version of Studio will provide better performance.'
+									'Downloading the Mac with Apple Silicon Chip version of Studio will provide better performance.'
 							  )
 							: __(
 									'Downloading the optimized version of Studio will provide better performance.'

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -28,7 +28,7 @@
 
 import * as Sentry from '@sentry/electron/renderer';
 import { init as reactInit } from '@sentry/react';
-import { defaultI18n } from '@wordpress/i18n';
+import { __, defaultI18n } from '@wordpress/i18n';
 import { createElement, StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import Root from './components/root';
@@ -81,6 +81,45 @@ getIpcApi()
 	.then( ( appGlobals ) => {
 		// Ensure the app globals are available before any renderer code starts running
 		window.appGlobals = appGlobals;
+
+		// Show warning if running an ARM64 translator
+		if ( appGlobals.arm64Translation && ! localStorage.getItem( 'dontShowARM64Warning' ) ) {
+			const showARM64MessageBox = async () => {
+				const { response, checkboxChecked } = await getIpcApi().showMessageBox( {
+					type: 'warning',
+					message: __( 'This version of Studio is not optimized for your computer' ),
+					detail:
+						window.appGlobals.platform === 'darwin'
+							? __(
+									'Downloading the Mac silicon version of Studio will provide better performance.'
+							  )
+							: __(
+									'Downloading the optimized version of Studio will provide better performance.'
+							  ),
+					checkboxLabel: __( "Don't show this warning again" ),
+					buttons: [ __( 'Download' ), __( 'Cancel' ) ],
+					cancelId: 1,
+				} );
+
+				if ( checkboxChecked ) {
+					localStorage.setItem( 'dontShowARM64Warning', 'true' );
+				}
+
+				switch ( response ) {
+					case 0:
+						// Open Download link
+						await getIpcApi().openURL( `https://developer.wordpress.com/studio/` );
+						break;
+					case 1:
+						// User clicked Cancel
+						break;
+					default:
+						break;
+				}
+			};
+
+			showARM64MessageBox();
+		}
 
 		defaultI18n.setLocaleData( appGlobals.localeData?.locale_data?.messages );
 


### PR DESCRIPTION
## Proposed Changes

Checks Studio architecture and prompts user to download the appropriate version of the app.

- Adds `app.runningUnderARM64Translation` to app globals
- Adds native system prompt to link user to correct app download

<img width="354" alt="Screenshot 2024-04-23 at 6 54 33 pm" src="https://github.com/Automattic/studio/assets/643285/3724a7ef-c3c2-46ba-a0bb-37ca914d1c2a">


## Testing Instructions

- Use the app with an arm64 translated architecture (or set the value of `arm64translation` to true in `ipc-handlers.ts`. 
- Observe the prompt to download the correct version of the app

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?