### PR TITLE
Studio: Add translation to demo site expiration date

### DIFF
--- a/src/hooks/use-expiration-date.ts
+++ b/src/hooks/use-expiration-date.ts
@@ -1,3 +1,4 @@
+import { _n, sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import { intervalToDuration, formatDuration, addDays, Duration, addHours } from 'date-fns';
 
@@ -36,28 +37,32 @@ export function useExpirationDate( snapshotDate: number ) {
 			// we show the minutes left.
 			end: addHours( endDate, 1 ),
 		} ),
-		{ format, delimiter: ', ' }
+		{
+			format,
+			delimiter: ', ',
+			locale: {
+				formatDistance: ( token, count ) => {
+					let stringToFormat = '';
+					switch ( token ) {
+						case 'xDays':
+							stringToFormat = _n( '%d day', '%d days', count );
+							break;
+						case 'xHours':
+							stringToFormat = _n( '%d hour', '%d hours', count );
+							break;
+						case 'xMinutes':
+							stringToFormat = _n( '%d minute', '%d minutes', count );
+							break;
+					}
+					return sprintf( stringToFormat, count );
+				},
+			},
+		}
 	);
-
-	// Create static translation values
-
-	const countDownTranslated = [
-		{ key: 'days', value: __( 'days' ) },
-		{ key: 'day', value: __( 'day' ) },
-		{ key: 'hours', value: __( 'hours' ) },
-		{ key: 'hour', value: __( 'hour' ) },
-		{ key: 'minutes', value: __( 'minutes' ) },
-		{ key: 'minute', value: __( 'minute' ) },
-	];
-
-	// Map the translated values to the countDown string
-	const translatedCountDown = countDownTranslated.reduce( ( acc, { key, value } ) => {
-		return acc.replace( key, value );
-	}, countDown );
 
 	return {
 		isExpired,
-		countDown: isExpired ? __( 'Expired' ) : translatedCountDown,
+		countDown: isExpired ? __( 'Expired' ) : countDown,
 		dateString: formatStringDate( snapshotDate ),
 	};
 }

--- a/src/hooks/use-expiration-date.ts
+++ b/src/hooks/use-expiration-date.ts
@@ -5,8 +5,11 @@ import { intervalToDuration, formatDuration, addDays, Duration, addHours } from 
 const HOUR = 1000 * 60 * 60;
 const DAY = HOUR * 24;
 const DURATION_DAYS = 'days';
+const DURATION_DAY = 'day';
 const DURATION_HOURS = 'hours';
+const DURATION_HOUR = 'hour';
 const DURATION_MINUTES = 'minutes';
+const DURATION_MINUTE = 'minute';
 
 function formatStringDate( ms: number ): string {
 	const { locale = 'en' } = window?.appGlobals || {};
@@ -45,8 +48,11 @@ export function useExpirationDate( snapshotDate: number ) {
 	// Translate here for display purposes, not in the logic configuration
 	const translatedCountDown = countDown
 		.replace( 'days', __( DURATION_DAYS ) )
+		.replace( 'day', __( DURATION_DAY ) )
 		.replace( 'hours', __( DURATION_HOURS ) )
-		.replace( 'minutes', __( DURATION_MINUTES ) );
+		.replace( 'hour', __( DURATION_HOUR ) )
+		.replace( 'minutes', __( DURATION_MINUTES ) )
+		.replace( 'minute', __( DURATION_MINUTE ) );
 
 	return {
 		isExpired,

--- a/src/hooks/use-expiration-date.ts
+++ b/src/hooks/use-expiration-date.ts
@@ -45,14 +45,22 @@ export function useExpirationDate( snapshotDate: number ) {
 		} ),
 		{ format, delimiter: ', ' }
 	);
-	// Translate here for display purposes, not in the logic configuration
-	const translatedCountDown = countDown
-		.replace( 'days', __( DURATION_DAYS ) )
-		.replace( 'day', __( DURATION_DAY ) )
-		.replace( 'hours', __( DURATION_HOURS ) )
-		.replace( 'hour', __( DURATION_HOUR ) )
-		.replace( 'minutes', __( DURATION_MINUTES ) )
-		.replace( 'minute', __( DURATION_MINUTE ) );
+
+	// Create static translation values
+
+	const countDownTranslated = [
+		{ key: 'days', value: __( DURATION_DAYS ) },
+		{ key: 'day', value: __( DURATION_DAY ) },
+		{ key: 'hours', value: __( DURATION_HOURS ) },
+		{ key: 'hour', value: __( DURATION_HOUR ) },
+		{ key: 'minutes', value: __( DURATION_MINUTES ) },
+		{ key: 'minute', value: __( DURATION_MINUTE ) },
+	];
+
+	// Map the translated values to the countDown string
+	const translatedCountDown = countDownTranslated.reduce( ( acc, { key, value } ) => {
+		return acc.replace( key, value );
+	}, countDown );
 
 	return {
 		isExpired,

--- a/src/hooks/use-expiration-date.ts
+++ b/src/hooks/use-expiration-date.ts
@@ -28,7 +28,7 @@ export function useExpirationDate( snapshotDate: number ) {
 	const endDate = addDays( snapshotDate, MAX_DAYS );
 	const difference = endDate.getTime() - now.getTime();
 	let isExpired = false;
-	let format: ( keyof Duration )[] = [ DURATION_DAYS, DURATION_HOURS ]; // Keys for logic
+	let format: ( keyof Duration )[] = [ DURATION_DAYS, DURATION_HOURS ];
 	if ( difference < 0 ) {
 		isExpired = true;
 	} else if ( difference < HOUR ) {

--- a/src/hooks/use-expiration-date.ts
+++ b/src/hooks/use-expiration-date.ts
@@ -1,8 +1,12 @@
+import { __ } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import { intervalToDuration, formatDuration, addDays, Duration, addHours } from 'date-fns';
 
 const HOUR = 1000 * 60 * 60;
 const DAY = HOUR * 24;
+const DURATION_DAYS = 'days';
+const DURATION_HOURS = 'hours';
+const DURATION_MINUTES = 'minutes';
 
 function formatStringDate( ms: number ): string {
 	const { locale = 'en' } = window?.appGlobals || {};
@@ -21,26 +25,30 @@ export function useExpirationDate( snapshotDate: number ) {
 	const endDate = addDays( snapshotDate, MAX_DAYS );
 	const difference = endDate.getTime() - now.getTime();
 	let isExpired = false;
-	let format: ( keyof Duration )[] = [ 'days', 'hours' ];
+	let format: ( keyof Duration )[] = [ DURATION_DAYS, DURATION_HOURS ]; // Keys for logic
 	if ( difference < 0 ) {
 		isExpired = true;
 	} else if ( difference < HOUR ) {
-		format = [ 'minutes' ];
+		format = [ DURATION_MINUTES ];
 	} else if ( difference < DAY ) {
-		format = [ 'hours', 'minutes' ];
+		format = [ DURATION_HOURS, DURATION_MINUTES ];
 	}
 	const countDown = formatDuration(
 		intervalToDuration( {
 			start: now,
-			// Add 1 hour to the end date serves us here, as for the last hour
-			// we show the minutes left.
 			end: addHours( endDate, 1 ),
 		} ),
 		{ format, delimiter: ', ' }
 	);
+	// Translate here for display purposes, not in the logic configuration
+	const translatedCountDown = countDown
+		.replace( 'days', __( DURATION_DAYS ) )
+		.replace( 'hours', __( DURATION_HOURS ) )
+		.replace( 'minutes', __( DURATION_MINUTES ) );
+
 	return {
 		isExpired,
-		countDown: isExpired ? __( 'Expired' ) : countDown,
+		countDown: isExpired ? __( 'Expired' ) : translatedCountDown,
 		dateString: formatStringDate( snapshotDate ),
 	};
 }

--- a/src/hooks/use-expiration-date.ts
+++ b/src/hooks/use-expiration-date.ts
@@ -4,12 +4,6 @@ import { intervalToDuration, formatDuration, addDays, Duration, addHours } from 
 
 const HOUR = 1000 * 60 * 60;
 const DAY = HOUR * 24;
-const DURATION_DAYS = 'days';
-const DURATION_DAY = 'day';
-const DURATION_HOURS = 'hours';
-const DURATION_HOUR = 'hour';
-const DURATION_MINUTES = 'minutes';
-const DURATION_MINUTE = 'minute';
 
 function formatStringDate( ms: number ): string {
 	const { locale = 'en' } = window?.appGlobals || {};
@@ -28,13 +22,13 @@ export function useExpirationDate( snapshotDate: number ) {
 	const endDate = addDays( snapshotDate, MAX_DAYS );
 	const difference = endDate.getTime() - now.getTime();
 	let isExpired = false;
-	let format: ( keyof Duration )[] = [ DURATION_DAYS, DURATION_HOURS ];
+	let format: ( keyof Duration )[] = [ 'days', 'hours' ];
 	if ( difference < 0 ) {
 		isExpired = true;
 	} else if ( difference < HOUR ) {
-		format = [ DURATION_MINUTES ];
+		format = [ 'minutes' ];
 	} else if ( difference < DAY ) {
-		format = [ DURATION_HOURS, DURATION_MINUTES ];
+		format = [ 'hours', 'minutes' ];
 	}
 	const countDown = formatDuration(
 		intervalToDuration( {
@@ -49,12 +43,12 @@ export function useExpirationDate( snapshotDate: number ) {
 	// Create static translation values
 
 	const countDownTranslated = [
-		{ key: 'days', value: __( DURATION_DAYS ) },
-		{ key: 'day', value: __( DURATION_DAY ) },
-		{ key: 'hours', value: __( DURATION_HOURS ) },
-		{ key: 'hour', value: __( DURATION_HOUR ) },
-		{ key: 'minutes', value: __( DURATION_MINUTES ) },
-		{ key: 'minute', value: __( DURATION_MINUTE ) },
+		{ key: 'days', value: __( 'days' ) },
+		{ key: 'day', value: __( 'day' ) },
+		{ key: 'hours', value: __( 'hours' ) },
+		{ key: 'hour', value: __( 'hour' ) },
+		{ key: 'minutes', value: __( 'minutes' ) },
+		{ key: 'minute', value: __( 'minute' ) },
 	];
 
 	// Map the translated values to the countDown string

--- a/src/hooks/use-expiration-date.ts
+++ b/src/hooks/use-expiration-date.ts
@@ -1,4 +1,3 @@
-import { __ } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import { intervalToDuration, formatDuration, addDays, Duration, addHours } from 'date-fns';
 

--- a/src/hooks/use-expiration-date.ts
+++ b/src/hooks/use-expiration-date.ts
@@ -36,6 +36,8 @@ export function useExpirationDate( snapshotDate: number ) {
 	const countDown = formatDuration(
 		intervalToDuration( {
 			start: now,
+			// Add 1 hour to the end date serves us here, as for the last hour
+			// we show the minutes left.
 			end: addHours( endDate, 1 ),
 		} ),
 		{ format, delimiter: ', ' }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/6666

## Proposed Changes

This PR makes the demo site expiration date translatable into other languages.

## Testing Instructions

**Testing for a plural value**

* Pull the changes from this branch locally
* Before starting the app, modify the language in `locale.ts` in `getPreferredSystemLanguages` to return Polish:

```
export function getPreferredSystemLanguages() {
	if ( process.platform === 'linux' && process.env.NODE_ENV !== 'test' ) {
			.getPreferredSystemLanguages()
			.filter( ( lang ) => supportedLocales.includes( lang ) );
	}
	return [ 'pl' ];
}
```

* Open `src/translations/local-environment-pl.jed.json` and add the following translations to the file:

```
            "%d hour": [
                "%d godzinę",
                "%d godziny",
                "%d godzin"
            ],
            "%d minute": [
                "%d minutę",
                "%d minuty",
                "%d minut"
            ],
            "%d day": [
                "%d dzień",
                "%d dni",
                "%d dni"
            ]
```
* Start the app with `nvm use && npm install && npm start` (this step is important as we just modified translations)
* Create a demo site
* Confirm that instead of `days` in English, you can see the Polish translation:

<img width="566" alt="Screenshot 2024-04-25 at 2 53 28 PM" src="https://github.com/Automattic/studio/assets/25575134/454926bd-5fe4-46a5-b54d-104f6d5cca3b">

* Close the app completely

**Testing for a singular value**
* In `src/hooks/use-expiration-date.ts`, change the `const endDate` to the following value:

```suggestion
const endDate = new Date(now.getTime() + (1000 * 60 * 60 * 24) + (1000 * 60 * 20));
```
* Start the app with `nvm use && npm install && npm start`
* Create a demo site
* Confirm that instead of `day` in English, you can see the Polish translation:

<img width="572" alt="Screenshot 2024-04-25 at 2 55 22 PM" src="https://github.com/Automattic/studio/assets/25575134/eada1c91-30c9-4b74-8b1b-44be1e07d922">


**Testing for genitive case**

* In `src/hooks/use-expiration-date.ts`, change the `const endDate` to the following value:

```suggestion
const endDate = new Date( now.getTime() + 1000 * 60 * 60 * 26 );
```
* Start the app with `nvm use && npm install && npm start`
* Create a demo site
* Confirm that instead of `day` in English, you can see the Polish translation:

<img width="555" alt="Screenshot 2024-04-25 at 2 57 16 PM" src="https://github.com/Automattic/studio/assets/25575134/4cffce40-cd5f-44ad-98ac-9fe542de7103">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
