### PR TITLE
Use the OS native dialog to confirm a site deletion

### DIFF
--- a/src/components/delete-site.tsx
+++ b/src/components/delete-site.tsx
@@ -46,6 +46,7 @@ const DeleteSite = () => {
 				await deleteSite( selectedSite.id, checkboxChecked );
 			} catch ( error ) {
 				await showErrorMessageBox( error, trimmedSiteTitle );
+				Sentry.captureException( error );
 			}
 		}
 	};
@@ -57,7 +58,6 @@ const DeleteSite = () => {
 			detail: sprintf( __( "We couldn't delete the site '%s'. Please try again" ), siteTitle ),
 			buttons: [ __( 'OK' ) ],
 		} );
-		Sentry.captureException( error );
 	};
 
 	const getTrimmedSiteTitle = ( name: string ) =>

--- a/src/components/delete-site.tsx
+++ b/src/components/delete-site.tsx
@@ -1,11 +1,9 @@
-import { FormToggle } from '@wordpress/components';
-import { sprintf } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
-import { useState, useCallback } from 'react';
 import { useOffline } from '../hooks/use-offline';
 import { useSiteDetails } from '../hooks/use-site-details';
+import { getIpcApi } from '../lib/get-ipc-api';
 import Button from './button';
-import Modal from './modal';
 import offlineIcon from './offline-icon';
 import Tooltip from './tooltip';
 
@@ -13,101 +11,67 @@ const MAX_LENGTH_SITE_TITLE = 35;
 
 const DeleteSite = () => {
 	const { __ } = useI18n();
-	const { selectedSite, deleteSite, isDeleting, deleteError } = useSiteDetails();
+	const { selectedSite, deleteSite, isDeleting } = useSiteDetails();
 	const isOffline = useOffline();
-	const [ needsConfirmation, setNeedsConfirmation ] = useState( false );
-	const [ deleteLocalFiles, setDeleteLocalFiles ] = useState( false );
-
-	let trimmedSiteTitle;
-	if ( selectedSite ) {
-		trimmedSiteTitle =
-			selectedSite.name.length > MAX_LENGTH_SITE_TITLE
-				? `${ selectedSite.name.substring( 0, MAX_LENGTH_SITE_TITLE - 3 ) }...`
-				: selectedSite.name;
-	}
 
 	const offlineMessage = __(
 		'This site has active demo sites that cannot be deleted without an internet connection.'
 	);
-	const isSiteDeletionDisabled = ! selectedSite || isOffline;
 
-	const resetLocalState = useCallback( () => {
-		setDeleteLocalFiles( false );
-		setNeedsConfirmation( false );
-	}, [] );
+	const handleDeleteSite = async () => {
+		if ( ! selectedSite ) {
+			return;
+		}
 
-	const onSiteDelete = useCallback(
-		async ( id: string, deleteLocalFiles: boolean ) => {
+		const DELETE_BUTTON_INDEX = 0;
+		const CANCEL_BUTTON_INDEX = 1;
+
+		const { response, checkboxChecked } = await getIpcApi().showMessageBox( {
+			type: 'warning',
+			message: sprintf( __( 'Delete %s' ), getTrimmedSiteTitle( selectedSite.name ) ),
+			detail: __(
+				"The site's database, along with all posts, pages, comments, and media, will be lost."
+			),
+			buttons: [ __( 'Delete site' ), __( 'Cancel' ) ],
+			cancelId: CANCEL_BUTTON_INDEX,
+			checkboxLabel: __( 'Delete site files from my computer' ),
+			checkboxChecked: false,
+		} );
+
+		if ( response === DELETE_BUTTON_INDEX ) {
+			console.log( 'Delete site', selectedSite?.id, checkboxChecked );
 			try {
-				await deleteSite( id, deleteLocalFiles );
-				setNeedsConfirmation( false );
+				await deleteSite( selectedSite.id, checkboxChecked );
 			} catch ( e ) {
 				/* empty */
 			}
-		},
-		[ deleteSite ]
-	);
+		}
+	};
+
+	const getTrimmedSiteTitle = ( name: string ) =>
+		name.length > MAX_LENGTH_SITE_TITLE
+			? `${ name.substring( 0, MAX_LENGTH_SITE_TITLE - 3 ) }...`
+			: name;
+
+	const isSiteDeletionDisabled = ! selectedSite || isOffline || isDeleting;
 
 	return (
-		<>
-			{ needsConfirmation && selectedSite?.id && (
-				<Modal
-					size="medium"
-					title={ sprintf( __( 'Delete %s' ), trimmedSiteTitle ) }
-					closeButtonLabel={ __( 'Close' ) }
-					isDismissible
-					onRequestClose={ resetLocalState }
-				>
-					<p>
-						{ __(
-							"The site's database, along with all posts, pages, comments, and media, will be lost."
-						) }
-					</p>
-					<div className="my-6">
-						<label className="flex items-center gap-x-chrome">
-							<FormToggle
-								checked={ deleteLocalFiles }
-								onChange={ () => setDeleteLocalFiles( ! deleteLocalFiles ) }
-							/>
-							<span>{ __( 'Delete site files from my computer' ) }</span>
-						</label>
-					</div>
-					{ deleteError && <p className="text-red-500">{ deleteError }</p> }
-					<div className="flex flex-row justify-end gap-x-5">
-						<Button disabled={ isDeleting } onClick={ resetLocalState } variant="tertiary">
-							{ __( 'Cancel' ) }
-						</Button>
-						<Button
-							disabled={ isDeleting }
-							onClick={ () => {
-								resetLocalState();
-								onSiteDelete( selectedSite.id, deleteLocalFiles );
-							} }
-							isDestructive
-							variant="primary"
-						>
-							{ __( 'Delete site' ) }
-						</Button>
-					</div>
-				</Modal>
-			) }
-			<Tooltip disabled={ ! isOffline } icon={ offlineIcon } text={ offlineMessage }>
-				<Button
-					aria-description={ isOffline ? offlineMessage : '' }
-					aria-disabled={ isSiteDeletionDisabled }
-					onClick={ () => {
-						if ( isSiteDeletionDisabled ) {
-							return;
-						}
-						setNeedsConfirmation( true );
-					} }
-					variant="link"
-					isDestructive
-				>
-					{ __( 'Delete site' ) }
-				</Button>
-			</Tooltip>
-		</>
+		<Tooltip disabled={ ! isOffline } icon={ offlineIcon } text={ offlineMessage }>
+			<Button
+				aria-description={ isOffline ? offlineMessage : '' }
+				aria-disabled={ isSiteDeletionDisabled }
+				onClick={ () => {
+					if ( isSiteDeletionDisabled ) {
+						return;
+					}
+					handleDeleteSite();
+				} }
+				variant="link"
+				isDestructive
+			>
+				{ __( 'Delete site' ) }
+			</Button>
+		</Tooltip>
 	);
 };
 export default DeleteSite;

--- a/src/components/delete-site.tsx
+++ b/src/components/delete-site.tsx
@@ -39,7 +39,6 @@ const DeleteSite = () => {
 		} );
 
 		if ( response === DELETE_BUTTON_INDEX ) {
-			console.log( 'Delete site', selectedSite?.id, checkboxChecked );
 			try {
 				await deleteSite( selectedSite.id, checkboxChecked );
 			} catch ( e ) {

--- a/src/hooks/use-site-details.tsx
+++ b/src/hooks/use-site-details.tsx
@@ -4,14 +4,6 @@ import { createContext, useCallback, useContext, useEffect, useMemo, useState } 
 import { getIpcApi } from '../lib/get-ipc-api';
 import { useDeleteSnapshot } from './use-delete-snapshot';
 
-export interface DeleteSiteErrorResponse {
-	error: string;
-	status: number;
-	statusCode: number;
-	name: string;
-	message: string;
-}
-
 interface SiteDetailsContext {
 	selectedSite: SiteDetails | null;
 	updateSite: ( site: SiteDetails ) => Promise< void >;
@@ -29,7 +21,6 @@ interface SiteDetailsContext {
 	loadingServer: Record< string, boolean >;
 	loadingSites: boolean;
 	isDeleting: boolean;
-	deleteError: string;
 	uploadingSites: { [ siteId: string ]: boolean };
 	setUploadingSites: React.Dispatch< React.SetStateAction< { [ siteId: string ]: boolean } > >;
 }
@@ -49,7 +40,6 @@ export const siteDetailsContext = createContext< SiteDetailsContext >( {
 	stopAllRunningSites: async () => undefined,
 	deleteSite: async () => undefined,
 	isDeleting: false,
-	deleteError: '',
 	loadingServer: {},
 	loadingSites: true,
 	uploadingSites: {},
@@ -137,7 +127,6 @@ function useSnapshots() {
 
 function useDeleteSite() {
 	const [ isLoading, setIsLoading ] = useState< Record< string, boolean > >( {} );
-	const [ error, setError ] = useState< Record< string, string > >( {} );
 	const { deleteSnapshot } = useDeleteSnapshot( { displayAlert: false } );
 
 	const deleteSite = useCallback(
@@ -154,22 +143,19 @@ function useDeleteSite() {
 			);
 
 			try {
-				setError( ( errors ) => ( { ...errors, [ siteId ]: '' } ) );
 				setIsLoading( ( loading ) => ( { ...loading, [ siteId ]: true } ) );
 				const newSites = await getIpcApi().deleteSite( siteId, removeLocal );
 				await allSiteRemovePromises;
 				return newSites;
 			} catch ( error ) {
-				const newError = new Error( 'Failed to delete local files' );
-				setError( ( errors ) => ( { ...errors, [ siteId ]: newError.message } ) );
-				throw newError;
+				throw new Error( 'Failed to delete local files' );
 			} finally {
 				setIsLoading( ( loading ) => ( { ...loading, [ siteId ]: false } ) );
 			}
 		},
 		[ deleteSnapshot ]
 	);
-	return { deleteSite, isLoading, error };
+	return { deleteSite, isLoading };
 }
 
 export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
@@ -187,7 +173,7 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 	);
 	const { selectedSiteId, setSelectedSiteId } = useSelectedSite( firstSite?.id );
 	const { snapshots, addSnapshot, removeSnapshot, updateSnapshot } = useSnapshots();
-	const { deleteSite, isLoading: isDeleting, error: deleteError } = useDeleteSite();
+	const { deleteSite, isLoading: isDeleting } = useDeleteSite();
 	const [ uploadingSites, setUploadingSites ] = useState< SiteDetailsContext[ 'uploadingSites' ] >(
 		{}
 	);
@@ -314,7 +300,6 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 			loadingServer,
 			deleteSite: onDeleteSite,
 			isDeleting: selectedSiteId ? isDeleting[ selectedSiteId ] : false,
-			deleteError: selectedSiteId ? deleteError[ selectedSiteId ] : '',
 			loadingSites,
 			uploadingSites,
 			setUploadingSites,
@@ -336,7 +321,6 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 			onDeleteSite,
 			selectedSiteId,
 			isDeleting,
-			deleteError,
 			loadingSites,
 			uploadingSites,
 		]

--- a/src/hooks/use-site-details.tsx
+++ b/src/hooks/use-site-details.tsx
@@ -222,7 +222,8 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 			const newSites = await deleteSite( id, removeLocal, siteSnapshots );
 			if ( newSites ) {
 				setData( newSites );
-				setSelectedSiteId( newSites[ 0 ].id );
+				const selectedSite = newSites.length ? newSites[ 0 ].id : '';
+				setSelectedSiteId( selectedSite );
 			}
 		},
 		[ deleteSite, setSelectedSiteId, snapshots ]


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/6672

## Proposed Changes

- Replace the WordPress modal component with a OS native dialog to confirm the deletion of a site.
- Fix small bug in `onDeleteSite` where when `newSites` is empty, we try to access index 0 which causes an error.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Create a site
- Go to the site settings and click on 'Delete site' at the bottom of the settings page.
- Ensure that a system native dialog appears.
   - Try to cancel and ensure the site is not deleted
   - Click on Delete site and confirm the site is deleted but the files are not.
   - Click on delete site and check "Delete site files from my computer" and ensure that the files are deleted. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
