### PR TITLE
Fix build CI job by updating macOS images

### DIFF
--- a/.github/workflows/build-installer.yml
+++ b/.github/workflows/build-installer.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - trunk
+      - fix/ci-macos-build-installers # Added only for testing purpose
   pull_request:
     paths:
       - 'installers/**/*'

--- a/.github/workflows/build-installer.yml
+++ b/.github/workflows/build-installer.yml
@@ -20,15 +20,15 @@ jobs:
     strategy:
       matrix:
         os:
-          - macos-latest # Intel
-          - macos-latest-xlarge # Apple Silicon
+          - macos-13 # Intel
+          - macos-14 # Apple Silicon
           - windows-latest
         include:
-          - os: macos-latest
+          - os: macos-13
             file_prefix: 'Studio-'
             file_suffix: '-x64.dmg'
             platform_env: 'FILE_ARCHITECTURE=x64'
-          - os: macos-latest-xlarge
+          - os: macos-14
             file_prefix: 'Studio-'
             file_suffix: '-arm64.dmg'
             platform_env: 'FILE_ARCHITECTURE=arm64'


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Proposed Changes

- Use different macOS images to ensure that we build `x86` and `arm64` architectures:
  - [`macos-13`](https://github.com/actions/runner-images/tree/main?tab=readme-ov-file#available-images): `x86` Intel
  - [`macos-14`](https://github.com/actions/runner-images/tree/main?tab=readme-ov-file#available-images): `arm64` Apple silicon

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Observe that all CI jobs succeed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
