### PR TITLE
Studio: Add translation to demo site expiration date - solution 2

### DIFF
--- a/src/hooks/use-expiration-date.ts
+++ b/src/hooks/use-expiration-date.ts
@@ -1,5 +1,25 @@
 import { useI18n } from '@wordpress/react-i18n';
-import { intervalToDuration, formatDuration, addDays, Duration, addHours } from 'date-fns';
+import { intervalToDuration, formatDuration, addDays, Duration, addHours, Locale } from 'date-fns';
+import {
+	es,
+	ar,
+	de,
+	enUS,
+	fr,
+	he,
+	id,
+	it,
+	ja,
+	ko,
+	nl,
+	pl,
+	pt,
+	ru,
+	sv,
+	tr,
+	zhCN,
+	zhTW,
+} from 'date-fns/locale';
 
 const HOUR = 1000 * 60 * 60;
 const DAY = HOUR * 24;
@@ -12,6 +32,35 @@ function formatStringDate( ms: number ): string {
 		year: 'numeric',
 	} );
 	return formatter.format( new Date( ms ) );
+}
+
+interface LocaleMapping {
+	[ key: string ]: Locale;
+}
+
+const localeMapping: LocaleMapping = {
+	es: es,
+	ar: ar,
+	de: de,
+	en: enUS,
+	fr: fr,
+	he: he,
+	id: id,
+	it: it,
+	ja: ja,
+	ko: ko,
+	nl: nl,
+	pl: pl,
+	pt: pt,
+	ru: ru,
+	sv: sv,
+	tr: tr,
+	'zh-CN': zhCN,
+	'zh-TW': zhTW,
+};
+
+function selectDateFnsLocale( locale: string ) {
+	return localeMapping[ locale ] || enUS;
 }
 
 export function useExpirationDate( snapshotDate: number ) {
@@ -29,6 +78,9 @@ export function useExpirationDate( snapshotDate: number ) {
 	} else if ( difference < DAY ) {
 		format = [ 'hours', 'minutes' ];
 	}
+
+	const { locale } = window?.appGlobals || {};
+
 	const countDown = formatDuration(
 		intervalToDuration( {
 			start: now,
@@ -36,7 +88,7 @@ export function useExpirationDate( snapshotDate: number ) {
 			// we show the minutes left.
 			end: addHours( endDate, 1 ),
 		} ),
-		{ format, delimiter: ', ' }
+		{ format, delimiter: ', ', locale: selectDateFnsLocale( locale ) }
 	);
 	return {
 		isExpired,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->
This is alternative solution for  https://github.com/Automattic/dotcom-forge/issues/6666.
More details can be found [in this comment.](https://github.com/Automattic/studio/pull/16#issuecomment-2077335524)

## Proposed Changes

This PR makes the demo site expiration date translatable into other languages.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch locally
* Before starting the app, modify the language in `locale.ts` in `getPreferredSystemLanguages` to return Polish:

```
export function getPreferredSystemLanguages() {
	if ( process.platform === 'linux' && process.env.NODE_ENV !== 'test' ) {
			.getPreferredSystemLanguages()
			.filter( ( lang ) => supportedLocales.includes( lang ) );
	}
	return [ 'pl' ];
}
```

* Start the app with `nvm use && npm install && npm start` (this step is important as we just modified translations)
* Create a demo site
* Confirm that instead of `days` in English, you can see the Polish translation:

<img width="743" alt="Screenshot 2024-04-25 at 4 16 50 PM" src="https://github.com/Automattic/studio/assets/25575134/447c8834-5b17-4f80-9613-3406c6f9d755">

*Testing for a singular value**

* In `src/hooks/use-expiration-date.ts`, change the `const endDate` to the following value:

```suggestion
const endDate = new Date(now.getTime() + (1000 * 60 * 60 * 24) + (1000 * 60 * 20));
```
* Start the app with `nvm use && npm install && npm start`
* Create a demo site
* Confirm that instead of `day` in English, you can see the Polish translation

**Testing for genitive case**

* In `src/hooks/use-expiration-date.ts`, change the `const endDate` to the following value:

```suggestion
const endDate = new Date( now.getTime() + 1000 * 60 * 60 * 26 );
```
* Start the app with `nvm use && npm install && npm start`
* Create a demo site
* Confirm that instead of `day` in English, you can see the Polish translation

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
