### PR TITLE
Demo Sites: Ensure demo site uses WP version same as local site

### DIFF
--- a/src/hooks/tests/use-update-demo-site.test.tsx
+++ b/src/hooks/tests/use-update-demo-site.test.tsx
@@ -12,6 +12,7 @@ jest.mock( '../../lib/get-ipc-api', () => ( {
 	getIpcApi: jest.fn().mockReturnValue( {
 		archiveSite: jest.fn().mockResolvedValue( { zipContent: new Blob( [ 'zipContent' ] ) } ),
 		showMessageBox: jest.fn().mockResolvedValue( { response: 1 } ), // Assuming '1' is the cancel button
+		getWpVersion: jest.fn().mockResolvedValue( '6.5' ),
 	} ),
 } ) );
 jest.mock( '@sentry/electron/renderer', () => ( {
@@ -90,6 +91,7 @@ describe( 'useUpdateDemoSite', () => {
 						type: 'application/zip',
 					} ),
 				],
+				[ 'wordpress_version', '6.5' ],
 			],
 		} );
 

--- a/src/hooks/use-archive-site.ts
+++ b/src/hooks/use-archive-site.ts
@@ -89,6 +89,13 @@ export function useArchiveSite() {
 				type: 'application/zip',
 			} );
 
+			const formData = [ [ 'import', file ] ];
+			const wordpressVersion = await getIpcApi().getWpVersion( siteId );
+			if ( wordpressVersion.length >= 3 ) {
+				// Minimum version length is '6.0'
+				formData.push( [ 'wordpress_version', wordpressVersion ] );
+			}
+
 			try {
 				const response: {
 					atomic_site_id: number;
@@ -99,7 +106,7 @@ export function useArchiveSite() {
 				} = await client.req.post( {
 					path: '/jurassic-ninja/create-new-site-from-zip',
 					apiNamespace: 'wpcom/v2',
-					formData: [ [ 'import', file ] ],
+					formData,
 				} );
 				addSnapshot( {
 					url: response.domain_name,

--- a/src/hooks/use-archive-site.ts
+++ b/src/hooks/use-archive-site.ts
@@ -92,7 +92,6 @@ export function useArchiveSite() {
 			const formData = [ [ 'import', file ] ];
 			const wordpressVersion = await getIpcApi().getWpVersion( siteId );
 			if ( wordpressVersion.length >= 3 ) {
-				// Minimum version length is '6.0'
 				formData.push( [ 'wordpress_version', wordpressVersion ] );
 			}
 

--- a/src/hooks/use-get-wp-version.ts
+++ b/src/hooks/use-get-wp-version.ts
@@ -4,7 +4,7 @@ import { getIpcApi } from '../lib/get-ipc-api';
 export function useGetWpVersion( site: SiteDetails ) {
 	const [ wpVersion, setWpVersion ] = useState( '-' );
 	useEffect( () => {
-		getIpcApi().getWpVersion( site.path ).then( setWpVersion );
-	}, [ site.path, site.running ] );
+		getIpcApi().getWpVersion( site.id ).then( setWpVersion );
+	}, [ site.id, site.running ] );
 	return wpVersion;
 }

--- a/src/hooks/use-update-demo-site.tsx
+++ b/src/hooks/use-update-demo-site.tsx
@@ -39,14 +39,21 @@ export const DemoSiteUpdateProvider: React.FC< DemoSiteUpdateProviderProps > = (
 				type: 'application/zip',
 			} );
 
+			const formData = [
+				[ 'site_id', snapshot.atomicSiteId ],
+				[ 'import', file ],
+			];
+
+			const wordpressVersion = await getIpcApi().getWpVersion( localSite.id );
+			if ( wordpressVersion.length >= 3 ) {
+				formData.push( [ 'wordpress_version', wordpressVersion ] );
+			}
+
 			try {
 				const response = await client.req.post( {
 					path: '/jurassic-ninja/update-site-from-zip',
 					apiNamespace: 'wpcom/v2',
-					formData: [
-						[ 'site_id', snapshot.atomicSiteId ],
-						[ 'import', file ],
-					],
+					formData,
 				} );
 				updateSnapshot( {
 					...snapshot,

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -449,7 +449,12 @@ export async function getAppGlobals( _event: IpcMainInvokeEvent ): Promise< AppG
 	};
 }
 
-export async function getWpVersion( _event: IpcMainInvokeEvent, wordPressPath: string ) {
+export async function getWpVersion( _event: IpcMainInvokeEvent, id: string ) {
+	const server = SiteServer.get( id );
+	if ( ! server ) {
+		return '-';
+	}
+	const wordPressPath = server.details.path;
 	let versionFileContent = '';
 	try {
 		versionFileContent = fs.readFileSync(

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -29,7 +29,7 @@ const api: IpcApi = {
 	copyText: ( text: string ) => ipcRenderer.invoke( 'copyText', text ),
 	getAppGlobals: () => ipcRenderer.invoke( 'getAppGlobals' ),
 	removeTemporalFile: ( path: string ) => ipcRenderer.invoke( 'removeTemporalFile', path ),
-	getWpVersion: ( wordPressPath: string ) => ipcRenderer.invoke( 'getWpVersion', wordPressPath ),
+	getWpVersion: ( id: string ) => ipcRenderer.invoke( 'getWpVersion', id ),
 	generateProposedSitePath: ( siteName: string ) =>
 		ipcRenderer.invoke( 'generateProposedSitePath', siteName ),
 	openLocalPath: ( path: string ) => ipcRenderer.invoke( 'openLocalPath', path ),


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

- Closes https://github.com/Automattic/dotcom-forge/issues/6635

## Proposed Changes

- It sends the local WordPress version when a Demo site is created or updated to match the same wp version

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Apply and sandbox the API D146651-code
- Select any site
- Ideally change your local WordPress version to a different one. You can use `wp core update --version=6.4.1 --force`
- Click on Share tab
- Create a new demo site
- Wait until the process finishes
- Enter on /wp-admin on wp.build site
- Observe the WordPress version matches your local site


https://github.com/Automattic/studio/assets/779993/64fc94c0-419d-48c8-ba2d-c4d993f0f2fa




## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
