### PR TITLE
fix: Catch failed demo site status check errors

### DIFF
--- a/src/hooks/use-delete-snapshot.ts
+++ b/src/hooks/use-delete-snapshot.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/electron/renderer';
 import { useI18n } from '@wordpress/react-i18n';
 import { useCallback, useEffect, useState } from 'react';
 import { useAuth } from './use-auth';
+import { useOffline } from './use-offline';
 import { useSiteDetails } from './use-site-details';
 
 export interface SnapshotStatusResponse {
@@ -17,8 +18,9 @@ export function useDeleteSnapshot( options: { displayAlert?: boolean } = {} ) {
 	const { client } = useAuth();
 	const { removeSnapshot, snapshots, updateSnapshot } = useSiteDetails();
 	const { __ } = useI18n();
+	const isOffline = useOffline();
 	useEffect( () => {
-		if ( ! client?.req ) {
+		if ( ! client?.req || isOffline ) {
 			return;
 		}
 		const deletingSnapshots = snapshots.filter( ( snapshot ) => snapshot.isDeleting );
@@ -48,7 +50,7 @@ export function useDeleteSnapshot( options: { displayAlert?: boolean } = {} ) {
 		return () => {
 			clearInterval( intervalId );
 		};
-	}, [ client?.req, removeSnapshot, snapshots ] );
+	}, [ client?.req, isOffline, removeSnapshot, snapshots ] );
 
 	const deleteSnapshot = useCallback(
 		async ( snapshot: Pick< Snapshot, 'atomicSiteId' > ) => {

--- a/src/hooks/use-delete-snapshot.ts
+++ b/src/hooks/use-delete-snapshot.ts
@@ -29,12 +29,18 @@ export function useDeleteSnapshot( options: { displayAlert?: boolean } = {} ) {
 		const intervalId = setInterval( async () => {
 			for ( const snapshot of deletingSnapshots ) {
 				if ( snapshot.isDeleting ) {
-					const resp: SnapshotStatusResponse = await client.req.get( '/jurassic-ninja/status', {
-						apiNamespace: 'wpcom/v2',
-						site_id: snapshot.atomicSiteId,
-					} );
-					if ( parseInt( resp.is_deleted ) === 1 ) {
-						removeSnapshot( snapshot );
+					try {
+						const resp: SnapshotStatusResponse = await client.req.get( '/jurassic-ninja/status', {
+							apiNamespace: 'wpcom/v2',
+							site_id: snapshot.atomicSiteId,
+						} );
+						if ( parseInt( resp.is_deleted ) === 1 ) {
+							removeSnapshot( snapshot );
+						}
+					} catch ( error ) {
+						// This error occurs in the background, so we report it but do not
+						// alert the user.
+						Sentry.captureException( error );
 					}
 				}
 			}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/6699.

## Proposed Changes

Ensure demo site status check failures do not result in crashes.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create a site.
1. Create a demo site for the site.
1. Delete the demo site.
1. While the deletion request is ongoing, disable your internet connection.
1. Verify the app does not crash.
2. Re-enable your internet connection. 
3. Verify the demo site is successfully deleted and the UI is updated accordingly. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
