### PR TITLE
i18n: Make "VS Code" and "PHPStorm" translatable

### DIFF
--- a/src/components/content-tab-overview.tsx
+++ b/src/components/content-tab-overview.tsx
@@ -161,6 +161,7 @@ function ShortcutsSection( { selectedSite }: Pick< ContentTabOverviewProps, 'sel
 				} catch ( error ) {
 					Sentry.captureException( error );
 					alert(
+// translators: "VS Code" is the brand name for an IDE and does not need to be translated
 						__(
 							"Could not open the site code in VS Code. Please check if it's installed correctly."
 						)

--- a/src/components/content-tab-overview.tsx
+++ b/src/components/content-tab-overview.tsx
@@ -161,7 +161,7 @@ function ShortcutsSection( { selectedSite }: Pick< ContentTabOverviewProps, 'sel
 				} catch ( error ) {
 					Sentry.captureException( error );
 					alert(
-// translators: "VS Code" is the brand name for an IDE and does not need to be translated
+						// translators: "VS Code" is the brand name for an IDE and does not need to be translated
 						__(
 							"Could not open the site code in VS Code. Please check if it's installed correctly."
 						)
@@ -180,7 +180,7 @@ function ShortcutsSection( { selectedSite }: Pick< ContentTabOverviewProps, 'sel
 				} catch ( error ) {
 					Sentry.captureException( error );
 					alert(
-// translators: "PhpStorm" is the brand name for an IDE and does not need to be translated
+						// translators: "PhpStorm" is the brand name for an IDE and does not need to be translated
 						__(
 							"Could not open the site code in PhpStorm. Please check if it's installed correctly."
 						)

--- a/src/components/content-tab-overview.tsx
+++ b/src/components/content-tab-overview.tsx
@@ -152,7 +152,9 @@ function ShortcutsSection( { selectedSite }: Pick< ContentTabOverviewProps, 'sel
 	if ( installedApps.vscode ) {
 		// Use VS Code as a default even if none of the editors are installed
 		buttonsArray.push( {
-			label: __( 'VS Code' ),
+			label:
+				// translators: "VS Code" is the brand name for an IDE and does not need to be translated
+				__( 'VS Code' ),
 			className: 'text-nowrap',
 			icon: code,
 			onClick: async () => {
@@ -171,7 +173,9 @@ function ShortcutsSection( { selectedSite }: Pick< ContentTabOverviewProps, 'sel
 		} );
 	} else if ( installedApps.phpstorm ) {
 		buttonsArray.push( {
-			label: __( 'PhpStorm' ),
+			label:
+				// translators: "PhpStorm" is the brand name for an IDE and does not need to be translated
+				__( 'PhpStorm' ),
 			className: 'text-nowrap',
 			icon: code,
 			onClick: async () => {

--- a/src/components/content-tab-overview.tsx
+++ b/src/components/content-tab-overview.tsx
@@ -179,6 +179,7 @@ function ShortcutsSection( { selectedSite }: Pick< ContentTabOverviewProps, 'sel
 				} catch ( error ) {
 					Sentry.captureException( error );
 					alert(
+// translators: "PhpStorm" is the brand name for an IDE and does not need to be translated
 						__(
 							"Could not open the site code in PhpStorm. Please check if it's installed correctly."
 						)

--- a/src/components/content-tab-overview.tsx
+++ b/src/components/content-tab-overview.tsx
@@ -1,5 +1,5 @@
 import * as Sentry from '@sentry/electron/renderer';
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import {
 	archive,
 	code,
@@ -152,7 +152,7 @@ function ShortcutsSection( { selectedSite }: Pick< ContentTabOverviewProps, 'sel
 	if ( installedApps.vscode ) {
 		// Use VS Code as a default even if none of the editors are installed
 		buttonsArray.push( {
-			label: 'VS Code',
+			label: __( 'VS Code' ),
 			className: 'text-nowrap',
 			icon: code,
 			onClick: async () => {
@@ -161,9 +161,8 @@ function ShortcutsSection( { selectedSite }: Pick< ContentTabOverviewProps, 'sel
 				} catch ( error ) {
 					Sentry.captureException( error );
 					alert(
-						sprintf(
-							__( "Could not open the site code in %s. Please check if it's installed correctly." ),
-							'VS Code'
+						__(
+							"Could not open the site code in VS Code. Please check if it's installed correctly."
 						)
 					);
 				}
@@ -171,7 +170,7 @@ function ShortcutsSection( { selectedSite }: Pick< ContentTabOverviewProps, 'sel
 		} );
 	} else if ( installedApps.phpstorm ) {
 		buttonsArray.push( {
-			label: 'PhpStorm',
+			label: __( 'PhpStorm' ),
 			className: 'text-nowrap',
 			icon: code,
 			onClick: async () => {
@@ -180,9 +179,8 @@ function ShortcutsSection( { selectedSite }: Pick< ContentTabOverviewProps, 'sel
 				} catch ( error ) {
 					Sentry.captureException( error );
 					alert(
-						sprintf(
-							__( "Could not open the site code in %s. Please check if it's installed correctly." ),
-							'PhpStorm'
+						__(
+							"Could not open the site code in PhpStorm. Please check if it's installed correctly."
 						)
 					);
 				}


### PR DESCRIPTION
## Proposed Changes

This PR makes the texts "VS Code" and "PHPstorm" translatable. Since these terms are proper nouns, the text may be the same in any language, but I think all text present in the app should be translatable.


## Testing Instructions

If it is the default language, the Overview tab content should continue to display as before.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
