### PR TITLE
fix: `aria-disabled` buttons display `not-allowed` cursor

### DIFF
--- a/src/components/button.tsx
+++ b/src/components/button.tsx
@@ -30,6 +30,7 @@ py-2
 rounded-sm
 justify-center
 disabled:cursor-not-allowed
+aria-disabled:cursor-not-allowed
 [&.components-button]:focus:shadow-[inset_0_0_0_1px_transparent]
 [&.components-button]:focus-visible:shadow-[0_0_0_1px_#3858E9]
 [&.components-button]:focus-visible:shadow-a8c-blueberry


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to https://github.com/Automattic/local-environment/pull/291#issuecomment-2063400089.

## Proposed Changes

Better communicate the disabled button state for cursor users.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create a site.
1. Start the site server.
1. Verify the `not-allowed` cursor is displayed when hovering atop the pending
   "Starting..." button.

<img width="142" alt="not-allowed-cursor" src="https://github.com/Automattic/studio/assets/438664/0207fa55-3713-48ae-b016-eca87c4afe67">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
