### PR TITLE
User settings modal: Pass icon to menu item as props instead of as children

### DIFF
--- a/src/components/user-settings.tsx
+++ b/src/components/user-settings.tsx
@@ -115,7 +115,7 @@ const SnapshotInfo = ( {
 										 * Otherwise, dropdown toggle would toggle an empty menu.
 										 */
 										aria-disabled={ isDisabled }
-										icon={ <Icon icon={ trash } /> }
+										icon={ trash }
 										iconPosition="right"
 										isDestructive
 										className={ menuItemStyles }

--- a/src/components/user-settings.tsx
+++ b/src/components/user-settings.tsx
@@ -115,6 +115,7 @@ const SnapshotInfo = ( {
 										 * Otherwise, dropdown toggle would toggle an empty menu.
 										 */
 										aria-disabled={ isDisabled }
+										icon={ <Icon icon={ trash } /> }
 										iconPosition="right"
 										isDestructive
 										className={ menuItemStyles }
@@ -127,7 +128,7 @@ const SnapshotInfo = ( {
 											onClose();
 										} }
 									>
-										<Icon className="mr-2" icon={ trash } /> { __( 'Delete all demo sites' ) }
+										{ __( 'Delete all demo sites' ) }
 									</MenuItem>
 								</Tooltip>
 							</MenuGroup>

--- a/src/components/user-settings.tsx
+++ b/src/components/user-settings.tsx
@@ -116,7 +116,7 @@ const SnapshotInfo = ( {
 										 */
 										aria-disabled={ isDisabled }
 										icon={ trash }
-										iconPosition="right"
+										iconPosition="left"
 										isDestructive
 										className={ menuItemStyles }
 										onClick={ () => {


### PR DESCRIPTION
~~The `iconPosition` prop of the "Delete all demo sites" menu item is `right`, so it seems that the trash icon is expected to be displayed on the right side. [`iconPosition` prop only works when `icon` prop is passed](https://github.com/WordPress/gutenberg/blob/trunk/packages/components/src/menu-item/README.md#iconposition). The current icon is located in the child, so the icon is displayed on the left.~~

The "Delete all demo sites" menu item's icon is used as a child. However, this component supports the `icon` prop, so I used this prop in this PR. At the same time, remove the unnecessary `iconPosition` prop.

## Proposed Changes

| Before| After |
|--------|--------|
| ![image](https://github.com/Automattic/studio/assets/54422211/6d32d8e7-3991-497b-90cc-7f1493673b47) | ![image](https://github.com/Automattic/studio/assets/54422211/b06ac2c0-e4dc-49c4-8a81-3cd42deca8ab) | 


Not much has changed visually, but the height of the menu changes from 38 pixels to 36 pixels. I believe this is the original intended height.

| Before | After |
|--------|-------- |
| ![image](https://github.com/Automattic/studio/assets/54422211/a56def3a-2278-4b5f-ba78-8b8f075736b1) | ![image](https://github.com/Automattic/studio/assets/54422211/3765d3df-80c3-44f5-b55d-eae6dfb3da64) |



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

-

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
