### PR TITLE
i18n: Make aria-label text translatable

### DIFF
--- a/src/components/main-sidebar.tsx
+++ b/src/components/main-sidebar.tsx
@@ -29,7 +29,7 @@ function SidebarAuthFooter() {
 	};
 	if ( isAuthenticated ) {
 		return (
-			<nav aria-label="Global">
+			<nav aria-label={ __( 'Global' ) }>
 				<ul className="flex items-start self-stretch w-full">
 					<li>
 						<Button
@@ -101,7 +101,7 @@ function SidebarToolbar() {
 					}
 				>
 					<Button
-						aria-label="Offline indicator"
+						aria-label={ __( 'Offline indicator' ) }
 						aria-description={ offlineMessage.join( ' ' ) }
 						className="cursor-default"
 						variant="icon"

--- a/src/components/site-menu.tsx
+++ b/src/components/site-menu.tsx
@@ -115,7 +115,7 @@ export default function SiteMenu( { className }: SiteMenuProps ) {
 	const { data } = useSiteDetails();
 	return (
 		<nav
-			aria-label="Sites"
+			aria-label={ __( 'Sites' ) }
 			style={ {
 				scrollbarGutter: 'stable',
 			} }


### PR DESCRIPTION
## Proposed Changes

I noticed that the text in the following three places is not translatable.

### Global

![global](https://github.com/Automattic/studio/assets/54422211/51801502-f9c4-47f5-b7f6-e3e5a289605f)

### Offline Indicator

![offline-indicator](https://github.com/Automattic/studio/assets/54422211/d0059dd8-4e1a-4414-8fed-1e83ca54a2f4)

### Sites

![sites](https://github.com/Automattic/studio/assets/54422211/b6eee8b9-affc-49af-93e0-641e5c11e49d)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

-

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
