### PR TITLE
Add copy button to demo site URL

### DIFF
--- a/src/components/content-tab-snapshots.tsx
+++ b/src/components/content-tab-snapshots.tsx
@@ -160,20 +160,13 @@ function SnapshotRow( {
 				<div className="text-black a8c-subtitle-small demo-site-name">{ selectedSite.name }</div>
 				<Badge>{ __( 'Demo site' ) }</Badge>
 			</div>
-			<div className="flex">
-				<Button
-					className="mt-1 !p-0 h-auto text-a8c-blueberry"
-					onClick={ () => getIpcApi().openURL( urlWithHTTPS ) }
-					variant="link"
-				>
-					{ urlWithHTTPS }
-				</Button>
-				<CopyTextButton
-					text={ urlWithHTTPS }
-					label={ `${ urlWithHTTPS }, ${ __( 'Copy site url to clipboard' ) }` }
-					copyConfirmation={ __( 'Copied!' ) }
-				/>
-			</div>
+			<CopyTextButton
+				text={ urlWithHTTPS }
+				label={ `${ urlWithHTTPS }, ${ __( 'Copy site url to clipboard' ) }` }
+				copyConfirmation={ __( 'Copied!' ) }
+			>
+				{ urlWithHTTPS }
+			</CopyTextButton>
 			<div className="mt-2 text-a8c-gray-70 whitespace-nowrap overflow-hidden truncate flex-1">
 				{ sprintf( __( 'Expires in %s' ), countDown ) }
 			</div>

--- a/src/components/content-tab-snapshots.tsx
+++ b/src/components/content-tab-snapshots.tsx
@@ -17,6 +17,7 @@ import { cx } from '../lib/cx';
 import { getIpcApi } from '../lib/get-ipc-api';
 import { Badge } from './badge';
 import Button from './button';
+import { CopyTextButton } from './copy-text-button';
 import offlineIcon from './offline-icon';
 import ProgressBar from './progress-bar';
 import { ScreenshotDemoSite } from './screenshot-demo-site';
@@ -159,13 +160,20 @@ function SnapshotRow( {
 				<div className="text-black a8c-subtitle-small demo-site-name">{ selectedSite.name }</div>
 				<Badge>{ __( 'Demo site' ) }</Badge>
 			</div>
-			<Button
-				className="mt-1 !p-0 h-auto text-a8c-blueberry"
-				onClick={ () => getIpcApi().openURL( urlWithHTTPS ) }
-				variant="link"
-			>
-				{ urlWithHTTPS }
-			</Button>
+			<div className="flex">
+				<Button
+					className="mt-1 !p-0 h-auto text-a8c-blueberry"
+					onClick={ () => getIpcApi().openURL( urlWithHTTPS ) }
+					variant="link"
+				>
+					{ urlWithHTTPS }
+				</Button>
+				<CopyTextButton
+					text={ urlWithHTTPS }
+					label={ `${ urlWithHTTPS }, ${ __( 'Copy site url to clipboard' ) }` }
+					copyConfirmation={ __( 'Copied!' ) }
+				/>
+			</div>
 			<div className="mt-2 text-a8c-gray-70 whitespace-nowrap overflow-hidden truncate flex-1">
 				{ sprintf( __( 'Expires in %s' ), countDown ) }
 			</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to:

* https://github.com/Automattic/studio/issues/56

## Proposed Changes

Adds copy button to easily copy demo site URLs, using the same behavior for copying text on the Settings tab.

<img width="649" alt="Screenshot 2024-04-29 at 5 18 36 pm" src="https://github.com/Automattic/studio/assets/643285/d88aee30-7305-4d26-a2cb-aca248945fdf">


## Testing Instructions

1) Add a site from the sidebar, and then add a demo site from the new site's Share tab. 
2) Once the demo site is created, click the copy icon next to the URL (screenshot above). 
3) Observe that the URL is copied to the clipboard.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
