### PR TITLE
Fix overflow issue for extremely long site name

### DIFF
--- a/src/components/content-tab-settings.tsx
+++ b/src/components/content-tab-settings.tsx
@@ -40,7 +40,7 @@ export function ContentTabSettings( { selectedSite }: ContentTabSettingsProps ) 
 					</tr>
 					<SettingsRow label={ __( 'Site name' ) }>
 						<div className="flex">
-							<span className="line-clamp-1">{ selectedSite.name }</span>
+							<span className="line-clamp-1 break-all">{ selectedSite.name }</span>
 							<EditSite />
 						</div>
 					</SettingsRow>
@@ -60,7 +60,7 @@ export function ContentTabSettings( { selectedSite }: ContentTabSettingsProps ) 
 							onClick={ () => getIpcApi().openLocalPath( selectedSite.path ) }
 							variant="link"
 						>
-							<span className="line-clamp-1">{ selectedSite.path }</span>
+							<span className="line-clamp-1 break-all">{ selectedSite.path }</span>
 							<Icon size={ 13 } icon={ file } className="shrink-0" />
 						</Button>
 					</SettingsRow>

--- a/src/components/content-tab-snapshots.tsx
+++ b/src/components/content-tab-snapshots.tsx
@@ -157,7 +157,9 @@ function SnapshotRow( {
 	return (
 		<div className="self-stretch flex-col px-4 py-3">
 			<div className="flex gap-2 items-center">
-				<div className="text-black a8c-subtitle-small demo-site-name line-clamp-1 break-all">{ selectedSite.name }</div>
+				<div className="text-black a8c-subtitle-small demo-site-name line-clamp-1 break-all">
+					{ selectedSite.name }
+				</div>
 				<Badge>{ __( 'Demo site' ) }</Badge>
 			</div>
 			<CopyTextButton

--- a/src/components/content-tab-snapshots.tsx
+++ b/src/components/content-tab-snapshots.tsx
@@ -157,7 +157,7 @@ function SnapshotRow( {
 	return (
 		<div className="self-stretch flex-col px-4 py-3">
 			<div className="flex gap-2 items-center">
-				<div className="text-black a8c-subtitle-small demo-site-name">{ selectedSite.name }</div>
+				<div className="text-black a8c-subtitle-small demo-site-name line-clamp-1 break-all">{ selectedSite.name }</div>
 				<Badge>{ __( 'Demo site' ) }</Badge>
 			</div>
 			<CopyTextButton

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -15,7 +15,7 @@ export default function Header() {
 		>
 			{ site && (
 				<div className="flex flex-col">
-					<h1 className="text-xl font-normal max-h-full line-clamp-1">
+					<h1 className="text-xl font-normal max-h-full line-clamp-1 break-all">
 						{ site ? site.name : null }
 					</h1>
 					<div className="flex mt-1 gap-x-4">


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to:

* https://github.com/Automattic/studio/issues/59

## Proposed Changes

Site titles are already displayed as a single line using `line-clamp-1`.

This change uses `line-clamp-1` and `break-all` together to prevent text overflow for long unbroken site strings.


https://github.com/Automattic/studio/assets/643285/2145a83e-35dd-4a61-9a6e-877b5e430ce8



## Testing Instructions

1. Create a site using a very long title (example below)
2. Modify the horizontal dimensions of the Studio app window
3. Observe that the site title does not cause the window to overflow ([example](https://github.com/Automattic/studio/issues/59))

```
MyWordPressWebsiteMyWordPressWebsiteMyWordPressWebsiteMyWordPressWebsiteMyWordPressWebsiteMyWordPressWebsiteMyWordPressWebsiteMyWordPressWebsite
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
