### PR TITLE
Repo Gardening: add workflow and update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,6 @@
 name: Bug Report
 description: Helps us improve our product!
-labels: "Needs triage, bug"
+labels: [ 'Needs triage', '[Type] Bug' ]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,7 @@
 name: Feature Request
 description: Suggest an idea for Studio!
 title: "Feature Request:"
-labels: ["enhancement"]
+labels: ["[Type] Feature Request"]
 body:
   - type: markdown
     attributes:

--- a/.github/workflows/gardening.yml
+++ b/.github/workflows/gardening.yml
@@ -1,0 +1,49 @@
+name: Repo gardening
+
+on:
+  pull_request_target: # When a PR is opened, edited, updated, closed, or a label is added.
+    types: [opened, reopened, synchronize, edited, labeled, closed]
+  issues: # For auto-triage of issues.
+    types: [opened, labeled, reopened, edited, closed]
+  issue_comment: # To gather support references in issue comments.
+    types: [created]
+concurrency:
+  # For pull_request_target, cancel any concurrent jobs with the same type (e.g. "opened", "labeled") and branch.
+  # Don't cancel any for other events, accomplished by grouping on the unique run_id.
+  group: gardening-${{ github.event_name }}-${{ github.event.action }}-${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  repo-gardening:
+    name: 'Assign issues, Clean up labels, and notify Design and Editorial when necessary'
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request_target' || github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
+    timeout-minutes: 10
+
+    steps:
+     - name: Checkout
+       uses: actions/checkout@v3
+
+     - name: Setup Node
+       uses: actions/setup-node@v3
+       with:
+         node-version-file: '.nvmrc'
+
+     - name: Wait for prior instances of the workflow to finish
+       uses: softprops/turnstyle@v1
+       env:
+         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+     - name: 'Run gardening action'
+       uses: automattic/action-repo-gardening@trunk
+       with:
+         github_token: ${{ secrets.GITHUB_TOKEN }}
+         slack_token: ${{ secrets.SLACK_TOKEN }}
+         slack_design_channel: ${{ secrets.SLACK_DESIGN_CHANNEL }}
+         slack_editorial_channel: ${{ secrets.SLACK_EDITORIAL_CHANNEL }}
+         slack_team_channel: ${{ secrets.SLACK_TEAM_CHANNEL }}
+         slack_he_triage_channel: ${{ secrets.SLACK_HE_TRIAGE_CHANNEL }}
+         slack_quality_channel: ${{ secrets.SLACK_QUALITY_CHANNEL }}
+         triage_projects_token: ${{ secrets.PROJECT_AUTOMATION_TOKEN }}
+         project_board_url: ${{ secrets.PROJECT_BOARD_URL }}
+         tasks: 'assignIssues,cleanLabels,notifyDesign,notifyEditorial,flagOss,triageIssues,gatherSupportReferences,replyToCustomersReminder,updateBoard'


### PR DESCRIPTION
Related to https://github.com/Automattic/bugomattic/issues/183

## Proposed Changes

This workflow and the updated issue templates will better match the current bug reporting flow in effect in other repos like wp-calypso and Jetpack.

The workflow is similar to this one:
https://github.com/Automattic/wp-calypso/blob/86b365b9fad1b2736b1eed841dcdec6cb5946252/.github/workflows/gardening.yml

It requires adding new secrets to the repo.

- [x] Add new secrets

## Testing Instructions

This can really only be tested once the PR will be merged.

- The workflow will run on issues and PRs
- It should pass and update teams and labels.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
