### PR TITLE
fix: Failed site creation resets the directory

### DIFF
--- a/jest-setup.ts
+++ b/jest-setup.ts
@@ -8,11 +8,6 @@ if ( typeof window !== 'undefined' ) {
 
 nock.disableNetConnect();
 
-// Jest runs in standard Node, not Electron. @sentry/electron doesn't work in Node.
-jest.mock( '@sentry/electron/main', () => ( {
-	captureException: jest.fn(),
-} ) );
-
 // We consider the app to be online by default.
 jest.mock( './src/hooks/use-offline', () => ( {
 	useOffline: jest.fn().mockReturnValue( false ),

--- a/src/__mocks__/@sentry/electron/main.ts
+++ b/src/__mocks__/@sentry/electron/main.ts
@@ -1,0 +1,2 @@
+export const addBreadcrumb = jest.fn();
+export const captureException = jest.fn();

--- a/src/__mocks__/electron.ts
+++ b/src/__mocks__/electron.ts
@@ -1,0 +1,14 @@
+export const app = {
+	getFetch: jest.fn(),
+	getPath: jest.fn( ( name ) => `/path/to/app/${ name }` ),
+	getName: jest.fn( () => 'App Name' ),
+	getPreferredSystemLanguages: jest.fn( () => [ 'en-US' ] ),
+};
+
+export const BrowserWindow = {
+	fromWebContents: jest.fn( () => ( {
+		webContents: {
+			send: jest.fn(),
+		},
+	} ) ),
+};

--- a/src/__mocks__/electron.ts
+++ b/src/__mocks__/electron.ts
@@ -12,3 +12,8 @@ export const BrowserWindow = {
 		},
 	} ) ),
 };
+
+export const shell = {
+	openExternal: jest.fn(),
+	trashItem: jest.fn(),
+};

--- a/src/__mocks__/fs.ts
+++ b/src/__mocks__/fs.ts
@@ -1,0 +1,40 @@
+type Fs = typeof import('fs');
+interface MockedFs extends Fs {
+	__setFileContents: ( path: string, fileContents: string | string[] ) => void;
+}
+
+const fs = jest.createMockFromModule< MockedFs >( 'fs' );
+const fsPromises = jest.createMockFromModule< typeof import('fs/promises') >( 'fs/promises' );
+
+fs.promises = fsPromises;
+
+const mockFiles: Record< string, string | string[] > = {};
+fs.__setFileContents = ( path: string, fileContents: string | string[] ) => {
+	mockFiles[ path ] = fileContents;
+};
+
+( fs.promises.readFile as jest.Mock ).mockImplementation(
+	async ( path: string ): Promise< string > => {
+		const fileContents = mockFiles[ path ];
+
+		if ( typeof fileContents === 'string' ) {
+			return fileContents;
+		}
+
+		return '';
+	}
+);
+
+( fs.promises.readdir as jest.Mock ).mockImplementation(
+	async ( path: string ): Promise< Array< string > > => {
+		const dirContents = mockFiles[ path ];
+
+		if ( Array.isArray( dirContents ) ) {
+			return dirContents;
+		}
+
+		return [];
+	}
+);
+
+module.exports = fs;

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -129,7 +129,14 @@ export async function createSite(
 	}
 
 	if ( ( await pathExists( path ) ) && ( await isEmptyDir( path ) ) ) {
-		await createSiteWorkingDirectory( path );
+		try {
+			await createSiteWorkingDirectory( path );
+		} catch ( error ) {
+			// If site creation failed, remove the generated files and re-throw the
+			// error so it can be handled by the caller.
+			shell.trashItem( path );
+			throw error;
+		}
 	}
 
 	const details = {

--- a/src/lib/tests/locale.test.ts
+++ b/src/lib/tests/locale.test.ts
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment node
+ */
 import { app } from 'electron';
 import { createI18n } from '@wordpress/i18n';
 import { getLocaleData, getSupportedLocale } from '../locale';

--- a/src/lib/tests/passwords.test.ts
+++ b/src/lib/tests/passwords.test.ts
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment node
+ */
 import { createPassword, decodePassword } from '../passwords';
 
 describe( 'createPassword', () => {

--- a/src/lib/tests/sanitize-for-logging.test.ts
+++ b/src/lib/tests/sanitize-for-logging.test.ts
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment node
+ */
 import { sanitizeForLogging, sanitizeUnstructuredData } from '../sanitize-for-logging';
 
 describe( 'sanitizeForLogging', () => {

--- a/src/lib/tests/site-language.test.ts
+++ b/src/lib/tests/site-language.test.ts
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment node
+ */
 import { app } from 'electron';
 import { getPreferredSiteLanguage } from '../site-language';
 

--- a/src/lib/tests/site-language.test.ts
+++ b/src/lib/tests/site-language.test.ts
@@ -1,13 +1,6 @@
 import { app } from 'electron';
 import { getPreferredSiteLanguage } from '../site-language';
 
-jest.mock( 'electron', () => ( {
-	app: {
-		getPreferredSystemLanguages: jest.fn( () => [ 'en' ] ),
-		getPath: jest.fn(),
-	},
-} ) );
-
 const originalFetch = global.fetch;
 
 function mockPreferredLanguages( languages: string[] ) {

--- a/src/lib/tests/sort-sites.test.ts
+++ b/src/lib/tests/sort-sites.test.ts
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment node
+ */
 // To run tests, execute `npm run test -- src/lib/sort-sites.test.ts` from the root directory
 import { sortSites } from '../sort-sites';
 

--- a/src/storage/tests/user-data.test.ts
+++ b/src/storage/tests/user-data.test.ts
@@ -18,13 +18,6 @@ jest.mock( 'fs', () => ( {
 	existsSync: () => true,
 } ) );
 
-jest.mock( 'electron', () => ( {
-	app: {
-		getFetch: jest.fn(),
-		getPath: jest.fn(),
-		getName: jest.fn(),
-	},
-} ) );
 jest.mock( 'path', () => ( {
 	join: jest.fn(),
 } ) );

--- a/src/tests/ipc-handlers.test.ts
+++ b/src/tests/ipc-handlers.test.ts
@@ -1,0 +1,65 @@
+/**
+ * @jest-environment node
+ */
+import { shell, IpcMainInvokeEvent } from 'electron';
+import fs from 'fs';
+import { createSite } from '../ipc-handlers';
+import { isEmptyDir, pathExists } from '../lib/fs-utils';
+import { SiteServer, createSiteWorkingDirectory } from '../site-server';
+
+jest.mock( 'fs' );
+jest.mock( '../lib/fs-utils' );
+jest.mock( '../site-server' );
+
+( SiteServer.create as jest.Mock ).mockImplementation( ( details ) => ( {
+	start: jest.fn(),
+	details,
+	updateSiteDetails: jest.fn(),
+	updateCachedThumbnail: jest.fn( () => Promise.resolve() ),
+} ) );
+( createSiteWorkingDirectory as jest.Mock ).mockResolvedValue( true );
+
+const mockUserData = {
+	sites: [],
+};
+( fs as MockedFs ).__setFileContents(
+	'/path/to/app/appData/App Name/appdata-v1.json',
+	JSON.stringify( mockUserData )
+);
+// Assume the provided site path is a directory
+( fs.promises.stat as jest.Mock ).mockResolvedValue( {
+	isDirectory: () => true,
+} );
+
+const mockIpcMainInvokeEvent = {} as IpcMainInvokeEvent;
+
+describe( 'createSite', () => {
+	it( 'should create a site', async () => {
+		( isEmptyDir as jest.Mock ).mockResolvedValue( true );
+		( pathExists as jest.Mock ).mockResolvedValue( true );
+		const [ site ] = await createSite( mockIpcMainInvokeEvent, '/test', 'Test' );
+
+		expect( site ).toEqual( {
+			adminPassword: expect.any( String ),
+			id: expect.any( String ),
+			name: 'Test',
+			path: '/test',
+			running: false,
+		} );
+	} );
+
+	describe( 'when the site path started as an empty directory', () => {
+		it( 'should reset the directory when site creation fails', () => {
+			( isEmptyDir as jest.Mock ).mockResolvedValue( true );
+			( pathExists as jest.Mock ).mockResolvedValue( true );
+			( createSiteWorkingDirectory as jest.Mock ).mockImplementation( () => {
+				throw new Error( 'Intentional test error' );
+			} );
+
+			createSite( mockIpcMainInvokeEvent, '/test', 'Test' ).catch( () => {
+				expect( shell.trashItem ).toHaveBeenCalledTimes( 1 );
+				expect( shell.trashItem ).toHaveBeenCalledWith( '/test' );
+			} );
+		} );
+	} );
+} );

--- a/src/tests/site-server.test.ts
+++ b/src/tests/site-server.test.ts
@@ -21,13 +21,6 @@ jest.mock( '../../vendor/wp-now/src', () => ( {
 	),
 } ) );
 
-jest.mock( 'electron', () => ( {
-	app: {
-		getPreferredSystemLanguages: jest.fn( () => [ 'en-US' ] ),
-		getPath: jest.fn( () => '/path/to/app' ),
-	},
-} ) );
-
 describe( 'SiteServer', () => {
 	describe( 'start', () => {
 		it( 'should throw if the server starts with a non-WordPress mode', async () => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to https://github.com/Automattic/studio/pull/4#discussion_r1583424647.

## Proposed Changes

- Reintroduce directory reset when site creation fails to simplify retrying.
- Refactor manual mocks to share foundational module mocks.
- Refactor `fs` mocks to support reading different files.
- Run main process tests in the Node.js environment for more realistic results
  and faster runs.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

In addition to the following, exploratory/regression testing around site creation is welcome.

**Failed site creation resets the directory**

1. Checkout the proposed changes.
1. Apply the below intentional error diff.
1. `npm start`
1. Click "Add site" in the bottom-left corner.
1. Click "Add site" in the modal.
1. Verify a helpful error message is displayed.
1. Verify the failed site directory is moved to the OS trash.
1. Click the "local path" input and select the default `Studio` directory.
1. Click "Add site" in the modal.
1. Verify the site is successfully created and server started.

<details><summary>Intentional error diff</summary>

```diff
diff --git a/src/site-server.ts b/src/site-server.ts
index 4ac8ab3..563926b 100644
--- a/src/site-server.ts
+++ b/src/site-server.ts
@@ -16,6 +16,8 @@ import { getSiteThumbnailPath } from './storage/paths';
 
 const servers = new Map< string, SiteServer >();
 
+let forceFailure = true;
+
 export async function createSiteWorkingDirectory(
 	path: string,
 	wpVersion = 'latest'
@@ -28,6 +30,11 @@ export async function createSiteWorkingDirectory(
 	await purgeWpConfig( wpVersion );
 	await recursiveCopyDirectory( getWordPressVersionPath( wpVersion ), path );
 
+	if ( forceFailure ) {
+		forceFailure = false;
+		throw new Error( 'Simulated failure' );
+	}
+
 	return true;
 }
 

```

</details>

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
