### PR TITLE
Fix path resolution of available site translations file

### DIFF
--- a/src/lib/site-language.ts
+++ b/src/lib/site-language.ts
@@ -2,6 +2,7 @@ import path from 'path';
 import { Locale } from '@formatjs/intl-locale';
 import { match } from '@formatjs/intl-localematcher';
 import fs from 'fs-extra';
+import { getResourcesPath } from '../storage/paths';
 import { DEFAULT_LOCALE, getSupportedLocale } from './locale';
 
 interface TranslationsData {
@@ -25,7 +26,8 @@ const defaultTranslation: Translation = {
 const SKIP_LOCALE_TAGS = [ 'formal', 'informal' ];
 
 function getLatestVersionTranslations(): TranslationsData | undefined {
-	const latestVersionTranslationsPath = path.resolve(
+	const latestVersionTranslationsPath = path.join(
+		getResourcesPath(),
 		'wp-files',
 		'latest',
 		'available-site-translations.json'

--- a/src/lib/tests/site-language.test.ts
+++ b/src/lib/tests/site-language.test.ts
@@ -3,7 +3,8 @@ import { getPreferredSiteLanguage } from '../site-language';
 
 jest.mock( 'electron', () => ( {
 	app: {
-		getPreferredSystemLanguages: jest.fn().mockReturnValue( [ 'en' ] ),
+		getPreferredSystemLanguages: jest.fn( () => [ 'en' ] ),
+		getPath: jest.fn(),
 	},
 } ) );
 

--- a/src/storage/paths.ts
+++ b/src/storage/paths.ts
@@ -19,7 +19,7 @@ export function getSiteThumbnailPath( siteId: string ): string {
 }
 
 export function getResourcesPath(): string {
-	if ( process.env.NODE_ENV === 'development' ) {
+	if ( process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test' ) {
 		return process.cwd();
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Addresses https://github.com/Automattic/dotcom-forge/issues/6850,

## Proposed Changes

- Include the app path to retrieve the file `available-site-translations.json`.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Preparation:**
- Build the production mode version by running the command `npm run make:macos-arm64`.
**NOTE:** In case you use a different OS, you can use `npm run make`.
- Watch Studio app logs by running the command `tail -f $HOME/Library/Logs/Studio/current.log`.

### Supported language

1. Change the language of your OS to one of the supported languages ([reference](https://github.com/Automattic/local-environment/blob/d1f19a0b85b218c76bfb2d08cc8f5eac4ad931f9/src/lib/locale.ts#L8-L27)).
2. Open the Studio app.
3. Observe the app is localized to the selected language.
4. Create a site.
5. Observe that no errors are displayed in the Studio app logs.
6. Navigate to WP-Admin of the created site.
7. Observe that the admin panel is translated into the same language as the app.
8. Navigate to Settings -> General (`wp-admin/options-general.php`).
9. Observe the site language is the same language as the app.

### Unsupported language

1. Change the language of your OS to an unsupported language (i.e. one that is not included in [this list](https://github.com/Automattic/local-environment/blob/d1f19a0b85b218c76bfb2d08cc8f5eac4ad931f9/src/lib/locale.ts#L8-L27)).
2. **UPDATE:** Ensure that English is in the second position of the preferred languages.
3. Open the Studio app.
4. Observe the app is localized in English.
5. Create a site.
6. Observe that no errors are displayed in the Studio app logs.
7. Navigate to WP-Admin of the created site.
8. Observe that the admin panel is translated into the same language as the app.
9. Navigate to Settings -> General (`wp-admin/options-general.php`).
10. Observe the site language is the same language as the app.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
