### PR TITLE
Fix incorrect preferred locale selection with multiple languages configured

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -61,10 +61,6 @@ const onAuthorizationCallback = ( mainWindow: BrowserWindow | null, url: string 
 async function appBoot() {
 	let mainWindow: BrowserWindow | null = null;
 
-	const locale = getSupportedLocale();
-	const localeData = getLocaleData( locale );
-	defaultI18n.setLocaleData( localeData?.locale_data?.messages );
-
 	app.setName( packageJson.productName );
 
 	Menu.setApplicationMenu( null );
@@ -178,13 +174,17 @@ async function appBoot() {
 	}
 
 	app.on( 'ready', async () => {
+		// Set translations based on supported locale
+		const locale = getSupportedLocale();
+		const localeData = getLocaleData( locale );
+		defaultI18n.setLocaleData( localeData?.locale_data?.messages );
+
 		console.log( `App version: ${ app.getVersion() }` );
 		console.log( `Built from commit: ${ COMMIT_HASH ?? 'undefined' }` );
 		console.log( `Local timezone: ${ Intl.DateTimeFormat().resolvedOptions().timeZone }` );
 		console.log( `App locale: ${ app.getLocale() }` );
 		console.log( `System locale: ${ app.getSystemLocale() }` );
-		console.log( `Preferred languages: ${ app.getPreferredSystemLanguages() }` );
-		console.log( `Used language: ${ getSupportedLocale() }` );
+		console.log( `Used language: ${ locale }` );
 
 		// By default Electron automatically approves all permissions requests (e.g. notifications, webcam)
 		// We'll opt-in to permissions we specifically need instead.

--- a/src/lib/locale.ts
+++ b/src/lib/locale.ts
@@ -41,7 +41,10 @@ export function getPreferredSystemLanguages() {
 }
 
 export function getSupportedLocale(): string {
-	return match( getPreferredSystemLanguages(), supportedLocales, DEFAULT_LOCALE );
+	// `app.getLocale` returns the current application locale, acquired using
+	// Chromium's `l10n_util` library. This value is utilized to determine
+	// the best fit for supported locales.
+	return match( [ app.getLocale() ], supportedLocales, DEFAULT_LOCALE );
 }
 
 export function getLocaleData( locale: string ): LocaleData | null {

--- a/src/lib/locale.ts
+++ b/src/lib/locale.ts
@@ -26,20 +26,6 @@ const supportedLocales = [
 	'zh-tw',
 ];
 
-export function getPreferredSystemLanguages() {
-	if ( process.platform === 'linux' && process.env.NODE_ENV !== 'test' ) {
-		// app.getPreferredSystemLanguages() is implemented by g_get_language_names on Linux.
-		// See: https://developer-old.gnome.org/glib/unstable/glib-I18N.html#g-get-language-names
-		// The language tags returned by this system function are in a format like "en_US" or "en_US.utf8".
-		// When these sorts of tags are passed to Intl.getCanonicalLocales() it throws an error.
-		return app
-			.getPreferredSystemLanguages()
-			.filter( ( lang ) => supportedLocales.includes( lang ) );
-	}
-
-	return app.getPreferredSystemLanguages();
-}
-
 export function getSupportedLocale(): string {
 	// `app.getLocale` returns the current application locale, acquired using
 	// Chromium's `l10n_util` library. This value is utilized to determine

--- a/src/lib/tests/locale.test.ts
+++ b/src/lib/tests/locale.test.ts
@@ -4,69 +4,46 @@ import { getLocaleData, getSupportedLocale } from '../locale';
 
 jest.mock( 'electron', () => ( {
 	app: {
-		getPreferredSystemLanguages: jest.fn().mockReturnValue( [ 'en-US' ] ),
+		getLocale: jest.fn( () => 'en-US' ),
 	},
 } ) );
 
-function mockPreferredLanguages( languages: string[] ) {
-	( app.getPreferredSystemLanguages as jest.Mock ).mockReturnValue( languages );
+function mockAppLocale( language: string ) {
+	( app.getLocale as jest.Mock ).mockReturnValue( language );
 }
 
 describe( 'getSupportedLocale', () => {
 	it( 'converts a language-region pair to a glotpress locale slug', () => {
-		mockPreferredLanguages( [ 'en-US' ] );
+		mockAppLocale( 'en-US' );
 
 		expect( getSupportedLocale() ).toBe( 'en' );
 	} );
 
-	it( 'returns English if preferred language is unsupported', () => {
-		mockPreferredLanguages( [ 'mi-NZ' ] );
+	it( 'returns English if app locale is unsupported', () => {
+		mockAppLocale( 'mi-NZ' );
 
 		expect( getSupportedLocale() ).toBe( 'en' );
-	} );
-
-	it( "falls back to lesser preferred languages if the most preferred isn't supported", () => {
-		mockPreferredLanguages( [ 'mi-NZ', 'fr-FR', 'en-US' ] );
-
-		expect( getSupportedLocale() ).toBe( 'fr' );
-	} );
-
-	it( 'ignores region if the best match is a matching language with a different region', () => {
-		mockPreferredLanguages( [ 'mi-NZ', 'pt-PT' ] );
-
-		expect( getSupportedLocale() ).toBe( 'pt-br' );
-	} );
-
-	it( "prefers an exact language-region match, even if it's lower in the preference order", () => {
-		mockPreferredLanguages( [ 'mi-NZ', 'pt-PT', 'zh-CN' ] );
-
-		expect( getSupportedLocale() ).toBe( 'zh-cn' );
 	} );
 
 	it( 'returns zh-cn variant', () => {
-		mockPreferredLanguages( [ 'zh-cn', 'zh-tw' ] );
+		mockAppLocale( 'zh-cn' );
 
 		expect( getSupportedLocale() ).toBe( 'zh-cn' );
 	} );
 
 	it( 'returns zh-tw variant', () => {
-		mockPreferredLanguages( [ 'zh-tw', 'zh-cn' ] );
+		mockAppLocale( 'zh-tw' );
 
 		expect( getSupportedLocale() ).toBe( 'zh-tw' );
 	} );
 
-	it( "prefers a language with a different region over an exact language _and_ region match which is further down the user's preference list", () => {
-		mockPreferredLanguages( [ 'fr-PL', 'pt-BR' ] );
-		expect( getSupportedLocale() ).toBe( 'fr' );
-	} );
-
 	it( 'returns the Simplified Chinese zh-cn option when the user preference is zh-Hans', () => {
-		mockPreferredLanguages( [ 'zh-NZ', 'zh-Hans' ] );
+		mockAppLocale( 'zh-Hans' );
 		expect( getSupportedLocale() ).toBe( 'zh-cn' );
 	} );
 
 	it( 'returns the Traditional Chinese zh-tw option when the user preference is zh-Hant', () => {
-		mockPreferredLanguages( [ 'zh-Hant' ] );
+		mockAppLocale( 'zh-Hant' );
 		expect( getSupportedLocale() ).toBe( 'zh-tw' );
 	} );
 } );

--- a/src/lib/tests/locale.test.ts
+++ b/src/lib/tests/locale.test.ts
@@ -5,12 +5,6 @@ import { app } from 'electron';
 import { createI18n } from '@wordpress/i18n';
 import { getLocaleData, getSupportedLocale } from '../locale';
 
-jest.mock( 'electron', () => ( {
-	app: {
-		getLocale: jest.fn( () => 'en-US' ),
-	},
-} ) );
-
 function mockAppLocale( language: string ) {
 	( app.getLocale as jest.Mock ).mockReturnValue( language );
 }

--- a/src/lib/tests/site-language.test.ts
+++ b/src/lib/tests/site-language.test.ts
@@ -3,14 +3,14 @@ import { getPreferredSiteLanguage } from '../site-language';
 
 jest.mock( 'electron', () => ( {
 	app: {
-		getPreferredSystemLanguages: jest.fn().mockReturnValue( [ 'en' ] ),
+		getLocale: jest.fn( () => 'en-US' ),
 	},
 } ) );
 
 const originalFetch = global.fetch;
 
-function mockPreferredLanguages( languages: string[] ) {
-	( app.getPreferredSystemLanguages as jest.Mock ).mockReturnValue( languages );
+function mockAppLocale( language: string ) {
+	( app.getLocale as jest.Mock ).mockReturnValue( language );
 }
 
 function mockFetchTranslations( wpVersion: string, translations: string[] ) {
@@ -65,7 +65,7 @@ describe( 'getPreferredSiteLanguage', () => {
 		];
 
 		it( "returns 'en' as default language", async () => {
-			mockPreferredLanguages( [] );
+			mockAppLocale( 'mi-NZ' );
 
 			expect( await getPreferredSiteLanguage() ).toBe( 'en' );
 		} );
@@ -73,7 +73,7 @@ describe( 'getPreferredSiteLanguage', () => {
 		it.each( LATEST_WP_VERSION_LOCALES )(
 			"returns '$expected' for language '$locale'",
 			async ( { locale, expected } ) => {
-				mockPreferredLanguages( [ locale ] );
+				mockAppLocale( locale );
 
 				expect( await getPreferredSiteLanguage() ).toBe( expected );
 			}
@@ -111,17 +111,10 @@ describe( 'getPreferredSiteLanguage', () => {
 			{ locale: 'zh-Hant-TW', expected: 'en' },
 		];
 
-		it( "returns 'en' as default language", async () => {
-			mockPreferredLanguages( [] );
-			mockFetchTranslations( WP_VERSION, AVAILABLE_LOCALES );
-
-			expect( await getPreferredSiteLanguage( WP_VERSION ) ).toBe( 'en' );
-		} );
-
 		it.each( WP_5_0_LOCALES )(
 			"returns '$expected' for language '$locale'",
 			async ( { locale, expected } ) => {
-				mockPreferredLanguages( [ locale ] );
+				mockAppLocale( locale );
 				mockFetchTranslations( WP_VERSION, AVAILABLE_LOCALES );
 
 				expect( await getPreferredSiteLanguage( WP_VERSION ) ).toBe( expected );
@@ -133,7 +126,7 @@ describe( 'getPreferredSiteLanguage', () => {
 				/* NOOP */
 			} );
 
-			mockPreferredLanguages( WP_5_0_LOCALES.map( ( item ) => item.locale ) );
+			mockAppLocale( WP_5_0_LOCALES[ 0 ].locale );
 			mockFetchTranslations( 'unknown', [] );
 
 			expect( await getPreferredSiteLanguage( WP_VERSION ) ).toBe( 'en' );

--- a/src/tests/site-server.test.ts
+++ b/src/tests/site-server.test.ts
@@ -23,7 +23,7 @@ jest.mock( '../../vendor/wp-now/src', () => ( {
 
 jest.mock( 'electron', () => ( {
 	app: {
-		getPreferredSystemLanguages: jest.fn( () => [ 'en-US' ] ),
+		getLocale: jest.fn( () => 'en-US' ),
 		getPath: jest.fn( () => '/path/to/app' ),
 	},
 } ) );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/6698.

## Proposed Changes

- Utilize [Electron's `app.getLocale` function](https://www.electronjs.org/docs/latest/api/app#appgetlocale) as the requested locale to determine the supported locale. This approach supersedes the use of [preferred languages](https://www.electronjs.org/docs/latest/api/app#appgetpreferredsystemlanguages), preventing the selection of an unexpected locale for the app.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Preparation:**
- Add different languages to the preferred languages list on your OS.

### Supported languages
- Change the language of your OS to "English" and the region to a non-English location (e.g. Spain).
- Open the app.
- Observe the app is localized to English.
- Change the language of your OS to "Spanish" and the region to a non-Spanish location (e.g. Australia).
- Open the app.
- Observe the app is localized to Spanish.
- Change the language of your OS to "French" and the region to a non-French location (e.g. Japan).
- Open the app.
- Observe the app is localized to French.

### Unsupported languages
- Change the language of your OS to "Finnish".
- Open the app.
- Observe the app is localized to English.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
