### PR TITLE
fix: Avoid usage API requests while offline

### DIFF
--- a/src/hooks/tests/use-site-usage.test.ts
+++ b/src/hooks/tests/use-site-usage.test.ts
@@ -2,6 +2,7 @@
 import * as Sentry from '@sentry/electron/renderer';
 import { waitFor, renderHook } from '@testing-library/react';
 import { LIMIT_OF_ZIP_SITES_PER_USER } from '../../constants';
+import { useOffline } from '../../hooks/use-offline';
 import { useAuth } from '../use-auth';
 import { useSiteDetails } from '../use-site-details';
 import { useSiteUsage } from '../use-site-usage';
@@ -65,5 +66,19 @@ describe( 'useSiteUsage', () => {
 			expect( result.current.siteCount ).toBe( 3 );
 			expect( result.current.siteLimit ).toBe( 15 );
 		} );
+	} );
+
+	it( 'should not check usage when lacking an internet connection', () => {
+		( useAuth as jest.Mock ).mockReturnValue( {
+			client: {
+				req: {
+					get: clientReqGet.mockResolvedValue( { site_count: 3, site_limit: 15 } ),
+				},
+			},
+		} );
+		( useOffline as jest.Mock ).mockReturnValue( true );
+		renderHook( () => useSiteUsage() );
+
+		expect( clientReqGet ).not.toHaveBeenCalled();
 	} );
 } );

--- a/src/hooks/use-site-usage.ts
+++ b/src/hooks/use-site-usage.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/electron/renderer';
 import { useCallback, useEffect, useState } from 'react';
 import { LIMIT_OF_ZIP_SITES_PER_USER } from '../constants';
 import { useAuth } from './use-auth';
+import { useOffline } from './use-offline';
 import { useSiteDetails } from './use-site-details';
 
 export function useSiteUsage() {
@@ -10,9 +11,10 @@ export function useSiteUsage() {
 	const [ siteCount, setSiteCount ] = useState( snapshots.length );
 	const [ siteLimit, setSiteLimit ] = useState( LIMIT_OF_ZIP_SITES_PER_USER );
 	const { client } = useAuth();
+	const isOffline = useOffline();
 
 	const fetchSiteUsage = useCallback( async () => {
-		if ( ! client?.req ) {
+		if ( ! client?.req || isOffline ) {
 			return;
 		}
 		setIsLoading( true );
@@ -27,7 +29,7 @@ export function useSiteUsage() {
 		} finally {
 			setIsLoading( false );
 		}
-	}, [ client?.req ] );
+	}, [ client?.req, isOffline ] );
 
 	useEffect( () => {
 		// If client is not ready, fail early


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to [STUDIO-E](https://a8c.sentry.io/issues/4939206389/).

## Proposed Changes

Reduce unnecessary network noise and error reporting by disabling site
usage API requests while offline.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create a site that does not have a demo site. 
2. Disable your system network connection or open the dev tools and throttle the connection to "Offline." 
4. Navigate to the _Share_ pane. 
5. Verify a failed request to the `usage` API endpoint is not made. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
