### PR TITLE
Make drag triggers consistent across the app 

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -40,7 +40,7 @@ export default function App() {
 						scrollbarGutter: 'stable',
 					} }
 					data-testid="site-content"
-					className="p-8 bg-white overflow-y-auto h-full flex-grow rounded-chrome app-no-drag-region"
+					className="p-8 bg-white overflow-y-auto h-full flex-grow rounded-chrome"
 				>
 					<SiteContentTabs />
 				</main>

--- a/src/components/main-sidebar.tsx
+++ b/src/components/main-sidebar.tsx
@@ -127,7 +127,7 @@ export default function MainSidebar( { className }: MainSidebarProps ) {
 		>
 			<SidebarToolbar />
 			<div className="flex flex-col h-full">
-				<div className="flex-1 overflow-y-auto sites-scrollbar app-no-drag-region">
+				<div className="flex-1 overflow-y-auto sites-scrollbar">
 					<SiteMenu />
 				</div>
 				<div className="flex flex-col gap-4 pt-5 border-white border-t border-opacity-10 app-no-drag-region">

--- a/src/components/onboarding.tsx
+++ b/src/components/onboarding.tsx
@@ -103,8 +103,8 @@ export default function Onboarding() {
 			</div>
 
 			<div className="w-1/2 bg-white p-[50px] flex flex-col">
-				<div className="h-[569px] flex flex-col justify-center items-start flex-[1_0_0%] gap-8 app-no-drag-region">
-					<div className="flex flex-col items-start self-stretch gap-6">
+				<div className="h-[569px] flex flex-col justify-center items-start flex-[1_0_0%] gap-8">
+					<div className="flex flex-col items-start self-stretch gap-6 app-no-drag-region">
 						<h1 className="font-normal text-xl leading-5">{ __( 'Add your first site' ) }</h1>
 						<SiteForm
 							className="self-stretch"

--- a/src/components/onboarding.tsx
+++ b/src/components/onboarding.tsx
@@ -102,8 +102,8 @@ export default function Onboarding() {
 				<GradientBox />
 			</div>
 
-			<div className="w-1/2 bg-white p-[50px] flex flex-col app-no-drag-region">
-				<div className="h-[569px] flex flex-col justify-center items-start flex-[1_0_0%] gap-8">
+			<div className="w-1/2 bg-white p-[50px] flex flex-col">
+				<div className="h-[569px] flex flex-col justify-center items-start flex-[1_0_0%] gap-8 app-no-drag-region">
 					<div className="flex flex-col items-start self-stretch gap-6">
 						<h1 className="font-normal text-xl leading-5">{ __( 'Add your first site' ) }</h1>
 						<SiteForm

--- a/src/components/site-content-tabs.tsx
+++ b/src/components/site-content-tabs.tsx
@@ -21,7 +21,7 @@ export function SiteContentTabs() {
 	}
 
 	return (
-		<div className="flex flex-col w-full h-full">
+		<div className="flex flex-col w-full h-full app-no-drag-region">
 			<Header />
 			<TabPanel className="mt-6 h-full flex flex-col" tabs={ tabs } orientation="horizontal">
 				{ ( { name } ) => (

--- a/src/components/site-menu.tsx
+++ b/src/components/site-menu.tsx
@@ -120,7 +120,7 @@ export default function SiteMenu( { className }: SiteMenuProps ) {
 				scrollbarGutter: 'stable',
 			} }
 			className={ cx(
-				'w-full overflow-y-auto overflow-x-hidden flex flex-col gap-0.5 pb-4',
+				'w-full overflow-y-auto overflow-x-hidden flex flex-col gap-0.5 pb-4 app-no-drag-region',
 				className
 			) }
 		>


### PR DESCRIPTION
Related to 6805-gh-Automattic/dotcom-forge, https://github.com/Automattic/studio/issues/28, and https://github.com/Automattic/studio/issues/29

## Proposed Changes

- The bordering area of the onboarding and main screens have been made draggable. This is in response to feedback around expecting the top area of the app to always be draggable, as well as expectations for more areas of the app to be draggable than the slim border. 

| Onboarding  | Main screen |
| ------------- | ------------- |
| <img src="https://github.com/Automattic/studio/assets/2998162/2a1c1b9b-c39c-45e9-b468-8b4ec64acccb" width="100%"> | <img src="https://github.com/Automattic/studio/assets/2998162/37d49a24-e5e4-4adb-8190-0b20a1ba08fe" width="100%"> |

- In addition, the left sidebar is now draggable  (excluding the interactive buttons).

<img src="https://github.com/Automattic/studio/assets/2998162/8b9fbce8-213d-49ce-8a20-432485036b46" width="50%">

## Testing Instructions

### Onboarding screen

- Delete any sites from the app to view the onboarding screen.
- Verify it is now possible to drag the top area of the screen's white half, as per the guidance at https://github.com/Automattic/studio/issues/28#issuecomment-2082165541.
- Verify that all components in the "Add your first site" form can still be interacted with. 

### Main screen

- When local sites have been added to the app, verify that the main area of the left sidebar is draggable.
- Also, verify that the bordering areas of the screen's white section can be dragged, in keeping with the onboarding screen.
- Verify that all components can still be interacted with as expected e.g. it should still be possible to click the buttons in the left sidebar. 

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?