### PR TITLE
Local Environment: Dont send event if destroyed

### DIFF
--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -211,7 +211,7 @@ export async function startServer(
 
 	const parentWindow = BrowserWindow.fromWebContents( event.sender );
 	await server.start();
-	if ( parentWindow && ! parentWindow.isDestroyed() ) {
+	if ( parentWindow && ! parentWindow.isDestroyed() && ! event.sender.isDestroyed() ) {
 		parentWindow.webContents.send( 'theme-details-changed', id, server.details.themeDetails );
 	}
 	server.updateCachedThumbnail().then( () => sendThumbnailChangedEvent( event, id ) );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/6876

## Proposed Changes

This PR fixes an error where when an event by BrowserWindow is sent and the window/event is destroyed, an unhandled error occurs.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Add a site. 
2. Ensure Studio is displaying the site's _Overview_ panel. 
3. Open WP Admin. 
4. Navigate to _Appearance_. 
5. Activate a different theme. 
6. Switch focus to the Studio app window. 
7. Once Studio begins showing a skeleton UI to communicate its fetching new theme details, quickly close the window before fetching completes. 
8. Observe the app successfully exits without an error. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
