### PR TITLE
Remove local userpaths from error reporting

### DIFF
--- a/src/lib/sanitize-for-logging.ts
+++ b/src/lib/sanitize-for-logging.ts
@@ -28,3 +28,14 @@ export function sanitizeUnstructuredData( data: string ): string {
 		return sanitized.replace( new RegExp( `${ sensitiveKey }.*(\n|$)`, 'ig' ), 'REDACTED\n' );
 	}, data );
 }
+
+// Attempts to sanitize a user path by replacing the user's home directory with a tilde.
+// Returns the original path if it does not match the pattern or if it is not a string.
+export function sanitizeUserpath( path: string ): string {
+	// Matches expected user path on macOS
+	if ( typeof path === 'string' && /\/Users\/[^/]+\/Library/.test( path ) ) {
+		return path.replace( /\/Users\/[^/]+(\/Library)/, '~$1' );
+	}
+
+	return path;
+}

--- a/src/lib/sanitize-for-logging.ts
+++ b/src/lib/sanitize-for-logging.ts
@@ -29,13 +29,15 @@ export function sanitizeUnstructuredData( data: string ): string {
 	}, data );
 }
 
-// Attempts to sanitize a user path by replacing the user's home directory with a tilde.
-// Returns the original path if it does not match the pattern or if it is not a string.
+// Attempts to sanitize a user path by redacting the username from the path.
+// Returns the original path in development mode
 export function sanitizeUserpath( path: string ): string {
-	const userPathRegex = /^\/Users\/([^/]+)\//;
-	if ( typeof path === 'string' && userPathRegex.test( path ) ) {
-		return path.replace( userPathRegex, '~/' );
-	}
+	// Disable no-useless-escape to account for both Windows and Unix userpath slash formats
+	// eslint-disable-next-line no-useless-escape
+	const userpathRegex = /^([A-Z]:)?([\\\/])Users\2([^\\\/]+)\2/i;
 
+	if ( typeof path === 'string' && process.env.NODE_ENV !== 'development' ) {
+		return path.replace( userpathRegex, '$1$2Users$2[REDACTED]$2' );
+	}
 	return path;
 }

--- a/src/lib/sanitize-for-logging.ts
+++ b/src/lib/sanitize-for-logging.ts
@@ -36,7 +36,7 @@ export function sanitizeUserpath( path: string ): string {
 	// eslint-disable-next-line no-useless-escape
 	const userpathRegex = /^([A-Z]:)?([\\\/])Users\2([^\\\/]+)\2/i;
 
-	if ( typeof path === 'string' && process.env.NODE_ENV !== 'development' ) {
+	if ( process.env.NODE_ENV !== 'development' ) {
 		return path.replace( userpathRegex, '$1$2Users$2[REDACTED]$2' );
 	}
 	return path;

--- a/src/lib/sanitize-for-logging.ts
+++ b/src/lib/sanitize-for-logging.ts
@@ -32,9 +32,9 @@ export function sanitizeUnstructuredData( data: string ): string {
 // Attempts to sanitize a user path by replacing the user's home directory with a tilde.
 // Returns the original path if it does not match the pattern or if it is not a string.
 export function sanitizeUserpath( path: string ): string {
-	// Matches expected user path on macOS
-	if ( typeof path === 'string' && /\/Users\/[^/]+\/Library/.test( path ) ) {
-		return path.replace( /\/Users\/[^/]+(\/Library)/, '~$1' );
+	const userPathRegex = /^\/Users\/([^/]+)\//;
+	if ( typeof path === 'string' && userPathRegex.test( path ) ) {
+		return path.replace( userPathRegex, '~/' );
 	}
 
 	return path;

--- a/src/lib/tests/sanitize-for-logging.test.ts
+++ b/src/lib/tests/sanitize-for-logging.test.ts
@@ -83,10 +83,18 @@ describe( 'sanitizeUnstructuredData', () => {
 } );
 
 describe( 'sanitizeUserpath', () => {
-	test( 'replaces user path with ~', () => {
+	test( 'redacts userpath on macOS when environment is not development', () => {
+		process.env.NODE_ENV = 'production';
 		const sanitized = sanitizeUserpath( '/Users/username/Library' );
 
-		expect( sanitized ).toEqual( '~/Library' );
+		expect( sanitized ).toEqual( '/Users/[REDACTED]/Library' );
+	} );
+
+	test( 'redacts userpath on Windows when environment is not development', () => {
+		process.env.NODE_ENV = 'production';
+		const sanitized = sanitizeUserpath( 'C:\\Users\\username\\AppData' );
+
+		expect( sanitized ).toEqual( 'C:\\Users\\[REDACTED]\\AppData' );
 	} );
 
 	test( 'does nothing if path does not match', () => {

--- a/src/lib/tests/sanitize-for-logging.test.ts
+++ b/src/lib/tests/sanitize-for-logging.test.ts
@@ -1,4 +1,8 @@
-import { sanitizeForLogging, sanitizeUnstructuredData } from '../sanitize-for-logging';
+import {
+	sanitizeForLogging,
+	sanitizeUnstructuredData,
+	sanitizeUserpath,
+} from '../sanitize-for-logging';
 
 describe( 'sanitizeForLogging', () => {
 	test( 'redacts sensitive strings from objects', () => {
@@ -75,5 +79,19 @@ describe( 'sanitizeUnstructuredData', () => {
 			this line is safe
 			REDACTED
 ` );
+	} );
+} );
+
+describe( 'sanitizeUserpath', () => {
+	test( 'replaces user path with ~', () => {
+		const sanitized = sanitizeUserpath( '/Users/username/Library' );
+
+		expect( sanitized ).toEqual( '~/Library' );
+	} );
+
+	test( 'does nothing if path does not match', () => {
+		const sanitized = sanitizeUserpath( 'not a valid userpath' );
+
+		expect( sanitized ).toEqual( 'not a valid userpath' );
 	} );
 } );

--- a/src/storage/user-data.ts
+++ b/src/storage/user-data.ts
@@ -15,7 +15,9 @@ const migrateUserData = ( appName: string ) => {
 
 	if ( fs.existsSync( oldPath ) && ! fs.existsSync( newPath ) ) {
 		fs.renameSync( oldPath, newPath );
-		console.log( `Moved user data from ${ oldPath } to ${ newPath }` );
+		console.log(
+			`Moved user data from ${ sanitizeUserpath( oldPath ) } to ${ sanitizeUserpath( newPath ) }`
+		);
 	}
 };
 

--- a/src/storage/user-data.ts
+++ b/src/storage/user-data.ts
@@ -3,7 +3,7 @@ import fs from 'fs';
 import nodePath from 'path';
 import * as Sentry from '@sentry/electron/main';
 import { isErrnoException } from '../lib/is-errno-exception';
-import { sanitizeUnstructuredData } from '../lib/sanitize-for-logging';
+import { sanitizeUnstructuredData, sanitizeUserpath } from '../lib/sanitize-for-logging';
 import { sortSites } from '../lib/sort-sites';
 import { getUserDataFilePath } from './paths';
 import type { PersistedUserData, UserData } from './storage-types';
@@ -36,7 +36,7 @@ export async function loadUserData(): Promise< UserData > {
 			const parsed = JSON.parse( asString );
 			const data = fromDiskFormat( parsed );
 			sortSites( data.sites );
-			console.log( `Loaded user data from ${ filePath }` );
+			console.log( `Loaded user data from ${ sanitizeUserpath( filePath ) }` );
 			return data;
 		} catch ( err ) {
 			// Awkward double try-catch needed to have access to the file contents
@@ -67,7 +67,7 @@ export async function saveUserData( data: UserData ): Promise< void > {
 
 	const asString = JSON.stringify( toDiskFormat( data ), null, 2 ) + '\n';
 	await fs.promises.writeFile( filePath, asString, 'utf-8' );
-	console.log( `Saved user data to ${ filePath }` );
+	console.log( `Saved user data to ${ sanitizeUserpath( filePath ) }` );
 }
 
 function toDiskFormat( { sites, ...rest }: UserData ): PersistedUserData {

--- a/src/storage/user-data.ts
+++ b/src/storage/user-data.ts
@@ -59,7 +59,7 @@ export async function loadUserData(): Promise< UserData > {
 				snapshots: [],
 			};
 		}
-		console.error( `Failed to load file ${ filePath }: ${ err }` );
+		console.error( `Failed to load file ${ sanitizeUserpath( filePath ) }: ${ err }` );
 		throw err;
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Resolves Automattic/dotcom-forge#6701

## Proposed Changes
Prevents local userpaths from being logged to error reporting.

- Adds a new function `sanitizeUserpath` to sanitize-for-logging utilities
- Updates user-data `console.log` events to remove matching userpaths from logged events

Currently, the userpath pattern matcher matches `/Users/username/Library/...`, which is the expected userpath on macOS. When release support for other operating systems is added, this userpath matcher can be expanded to cover the new OS userpath patterns.  

## Testing Instructions

To test, observe that usernames are not included in userpaths when **logging** user-data functions:
- [migrateUserData](https://github.com/Automattic/studio/blob/7996f15d3bf281e6efcf4f538b5bd6d11c010550/src/storage/user-data.ts#L11)
- [loadUserData](https://github.com/Automattic/studio/blob/7996f15d3bf281e6efcf4f538b5bd6d11c010550/src/storage/user-data.ts#L31)
- [saveUserData](https://github.com/Automattic/studio/blob/7996f15d3bf281e6efcf4f538b5bd6d11c010550/src/storage/user-data.ts#L75)


### Sentry
These functions can be observed on any Sentry session sending these events:

<img width="765" alt="Screenshot 2024-05-02 at 10 30 34 pm" src="https://github.com/Automattic/studio/assets/643285/b2899ba9-8bdb-4f6a-87c5-0164a5bf081c">

### Local Development
Another more straightforward way to test the changes is to observe the same events when logged while running Studio locally:
<img width="547" alt="Screenshot 2024-05-02 at 10 31 28 pm" src="https://github.com/Automattic/studio/assets/643285/3cdb72bf-339d-44e8-a3db-ffae3dce7e49">





## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
