### PR TITLE
Update quick actions layout

### DIFF
--- a/src/components/buttons-section.tsx
+++ b/src/components/buttons-section.tsx
@@ -17,7 +17,7 @@ export function ButtonsSection( { buttonsArray, title, className = '' }: Buttons
 	return (
 		<div className="w-full">
 			<h2 className="a8c-subtitle-small mb-3">{ title }</h2>
-			<div className={ cx( 'gap-3', className || 'grid sd:grid-cols-3' ) }>
+			<div className={ cx( 'gap-3', className || 'grid sd:grid-cols-2 lg:grid-cols-3' ) }>
 				{ buttonsArray.map( ( button, index ) => (
 					<Button
 						className={ button.className }

--- a/src/components/content-tab-overview.tsx
+++ b/src/components/content-tab-overview.tsx
@@ -223,7 +223,7 @@ export function ContentTabOverview( { selectedSite }: ContentTabOverviewProps ) 
 	const loading = loadingThemeDetails || loadingThumbnails || initialLoading;
 
 	return (
-		<div className="pb-10 flex max-w-2xl">
+		<div className="pb-10 flex max-w-3xl">
 			<div className="w-52 ltr:mr-8 rtl:ml-8 flex-col justify-start items-start gap-8">
 				<h2 className="mb-3 a8c-subtitle-small">{ __( 'Theme' ) }</h2>
 				<div

--- a/src/components/content-tab-snapshots.tsx
+++ b/src/components/content-tab-snapshots.tsx
@@ -247,7 +247,7 @@ function EmptyGeneric( {
 }: PropsWithChildren< { selectedSite: SiteDetails } > ) {
 	const { __ } = useI18n();
 	return (
-		<div className="pb-10 flex justify-between max-w-2xl gap-4">
+		<div className="pb-10 flex justify-between max-w-3xl gap-4">
 			<div className="flex flex-col">
 				<div className="a8c-subtitle mb-1">{ __( 'Share a demo site' ) }</div>
 				<div className="w-[40ch] text-a8c-gray-70 a8c-body pr-2">


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Fixes #46 

## Proposed Changes

- Update the quick actions section on the Overview tab to use a two-col layout below the `lg` breakpoint. This helps to make the button labels more readable in various translations. The current three-column layout still applies at `lg`.
- Updated the overview tab max-width to use `3xl`. Also updated the demo sites empty state container to match.

At default screen width:

<img width="1012" alt="Screenshot 2024-05-03 at 12 50 29" src="https://github.com/Automattic/studio/assets/417538/4368f19f-9bd1-45c4-b717-76cfd2496757">

At `lg` breakpoint:

<img width="1136" alt="スクリーンショット 2024-05-03 12 50 49" src="https://github.com/Automattic/studio/assets/417538/227003f1-9dc5-4f1a-9ee5-1359fe3fbef7">

It's not possible to account for all translations, so I’ve kept the existing behaviour that truncates long button labels and displays the full label in a tooltip on hover.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Change your system language to Japanese or French.
- Open Studio.
- Add a site.
- Note that the quick actions on the Overview tab use a two-column layout at smaller window sizes.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
