### PR TITLE
fix: Ensure non-destroyed window exists for authentication event handler

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -12,6 +12,7 @@ module.exports = {
 	},
 	testEnvironment: 'jsdom',
 	globals: {
+		COMMIT_HASH: 'mock-hash',
 		MAIN_WINDOW_WEBPACK_ENTRY: 'main-window-webpack-entry',
 		MAIN_WINDOW_PRELOAD_WEBPACK_ENTRY: 'main-window-preload-webpack-entry',
 	},

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -11,6 +11,10 @@ module.exports = {
 		],
 	},
 	testEnvironment: 'jsdom',
+	globals: {
+		MAIN_WINDOW_WEBPACK_ENTRY: 'main-window-webpack-entry',
+		MAIN_WINDOW_PRELOAD_WEBPACK_ENTRY: 'main-window-preload-webpack-entry',
+	},
 	testRegex: '(/tests/.*|(\\.|/)(test|spec))\\.tsx?$',
 	moduleFileExtensions: [ 'ts', 'tsx', 'js', 'jsx', 'json', 'node' ],
 	globalSetup: '<rootDir>/jest-global-setup.ts',

--- a/src/__mocks__/@sentry/electron/main.ts
+++ b/src/__mocks__/@sentry/electron/main.ts
@@ -1,2 +1,3 @@
+export const init = jest.fn();
 export const addBreadcrumb = jest.fn();
 export const captureException = jest.fn();

--- a/src/__mocks__/electron.ts
+++ b/src/__mocks__/electron.ts
@@ -1,8 +1,21 @@
+export const ipcMain = {
+	emit: jest.fn(),
+	on: jest.fn(),
+};
+
 export const app = {
 	getFetch: jest.fn(),
 	getPath: jest.fn( ( name ) => `/path/to/app/${ name }` ),
 	getName: jest.fn( () => 'App Name' ),
 	getLocale: jest.fn( () => 'en-US' ),
+	setName: jest.fn(),
+	getVersion: jest.fn( () => '0.0.0' ),
+	getPreferredSystemLanguages: jest.fn( () => [ 'en-US' ] ),
+	requestSingleInstanceLock: jest.fn( () => true ),
+	on: jest.fn(),
+	setAppLogsPath: jest.fn(),
+	setAsDefaultProtocolClient: jest.fn(),
+	enableSandbox: jest.fn(),
 };
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -31,4 +44,9 @@ export const Menu = {
 export const shell = {
 	openExternal: jest.fn(),
 	trashItem: jest.fn(),
+};
+
+export const autoUpdater = {
+	setFeedURL: jest.fn(),
+	on: jest.fn(),
 };

--- a/src/__mocks__/electron.ts
+++ b/src/__mocks__/electron.ts
@@ -5,13 +5,27 @@ export const app = {
 	getLocale: jest.fn( () => 'en-US' ),
 };
 
-export const BrowserWindow = {
-	fromWebContents: jest.fn( () => ( {
-		isDestroyed: jest.fn( () => false ),
-		webContents: {
-			send: jest.fn(),
-		},
-	} ) ),
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+export function BrowserWindow() {}
+BrowserWindow.prototype.loadURL = jest.fn();
+BrowserWindow.prototype.isDestroyed = jest.fn( () => false );
+BrowserWindow.prototype.on = jest.fn();
+BrowserWindow.prototype.webContents = {
+	on: jest.fn(),
+	send: jest.fn(),
+};
+BrowserWindow.fromWebContents = jest.fn( () => ( {
+	isDestroyed: jest.fn( () => false ),
+	webContents: {
+		send: jest.fn(),
+	},
+} ) );
+BrowserWindow.getAllWindows = jest.fn( () => [] );
+BrowserWindow.getFocusedWindow = jest.fn();
+
+export const Menu = {
+	buildFromTemplate: jest.fn(),
+	setApplicationMenu: jest.fn(),
 };
 
 export const shell = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -153,7 +153,7 @@ async function appBoot() {
 					if ( customProtocolParameter ) {
 						onAuthorizationCallback( customProtocolParameter );
 					}
-				} )();
+				} );
 			} );
 		}
 	}

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ import packageJson from '../package.json';
 import * as ipcHandlers from './ipc-handlers';
 import { bumpAggregatedUniqueStat } from './lib/bump-stats';
 import { getLocaleData, getSupportedLocale } from './lib/locale';
-import { PROTOCOL_PREFIX, handleAuthCallback, setupAuthCallbackHandler } from './lib/oauth';
+import { PROTOCOL_PREFIX, handleAuthCallback, setUpAuthCallbackHandler } from './lib/oauth';
 import { setupLogging } from './logging';
 import { createMainWindow, withMainWindow } from './main-window';
 import {
@@ -222,7 +222,7 @@ async function appBoot() {
 		setupIpc();
 
 		createMainWindow();
-		setupAuthCallbackHandler();
+		setUpAuthCallbackHandler();
 
 		bumpAggregatedUniqueStat( 'local-environment-launch-uniques', process.platform, 'weekly' );
 	} );

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,6 +63,8 @@ async function appBoot() {
 
 	setupCustomProtocolHandler();
 
+	setUpAuthCallbackHandler();
+
 	setupLogging();
 
 	setupUpdates();
@@ -222,7 +224,6 @@ async function appBoot() {
 		setupIpc();
 
 		createMainWindow();
-		setUpAuthCallbackHandler();
 
 		bumpAggregatedUniqueStat( 'local-environment-launch-uniques', process.platform, 'weekly' );
 	} );

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,6 +61,8 @@ async function appBoot() {
 
 	Menu.setApplicationMenu( null );
 
+	setupCustomProtocolHandler();
+
 	setupLogging();
 
 	setupUpdates();
@@ -158,16 +160,6 @@ async function appBoot() {
 		}
 	}
 
-	function handleAuthOnStartup() {
-		if ( process.argv.length > 1 ) {
-			const argv = process.argv;
-			const customProtocolParameter = argv?.find( ( arg ) => arg.startsWith( PROTOCOL_PREFIX ) );
-			if ( customProtocolParameter ) {
-				onAuthorizationCallback( customProtocolParameter );
-			}
-		}
-	}
-
 	app.on( 'ready', async () => {
 		// Set translations based on supported locale
 		const locale = getSupportedLocale();
@@ -228,11 +220,9 @@ async function appBoot() {
 		}
 
 		setupIpc();
-		setupCustomProtocolHandler();
 
 		createMainWindow();
 		setupAuthCallbackHandler();
-		handleAuthOnStartup();
 
 		bumpAggregatedUniqueStat( 'local-environment-launch-uniques', process.platform, 'weekly' );
 	} );

--- a/src/lib/oauth.ts
+++ b/src/lib/oauth.ts
@@ -105,7 +105,7 @@ export function authenticate(): void {
 	shell.openExternal( authUrl );
 }
 
-export function setupAuthCallbackHandler() {
+export function setUpAuthCallbackHandler() {
 	ipcMain.on( 'auth-callback', ( _event, { token, error } ) => {
 		withMainWindow( ( mainWindow ) => {
 			if ( error ) {

--- a/src/lib/oauth.ts
+++ b/src/lib/oauth.ts
@@ -115,6 +115,6 @@ export function setupAuthCallbackHandler() {
 					mainWindow.webContents.send( 'auth-updated', { token } );
 				} );
 			}
-		} )();
+		} );
 	} );
 }

--- a/src/lib/oauth.ts
+++ b/src/lib/oauth.ts
@@ -1,6 +1,7 @@
-import { ipcMain, shell, BrowserWindow } from 'electron';
+import { ipcMain, shell } from 'electron';
 import * as Sentry from '@sentry/electron/main';
 import wpcom from 'wpcom';
+import { withMainWindow } from '../main-window';
 import { loadUserData, saveUserData } from '../storage/user-data';
 
 export interface StoredToken {
@@ -104,14 +105,16 @@ export function authenticate(): void {
 	shell.openExternal( authUrl );
 }
 
-export function setupAuthCallbackHandler( mainWindow: BrowserWindow ) {
-	ipcMain.on( 'auth-callback', ( event, { token, error } ) => {
-		if ( error ) {
-			mainWindow?.webContents.send( 'auth-updated', { error: error } );
-		} else {
-			storeToken( token ).then( () => {
-				mainWindow?.webContents.send( 'auth-updated', { token } );
-			} );
-		}
+export function setupAuthCallbackHandler() {
+	ipcMain.on( 'auth-callback', ( _event, { token, error } ) => {
+		withMainWindow( ( mainWindow ) => {
+			if ( error ) {
+				mainWindow.webContents.send( 'auth-updated', { error: error } );
+			} else {
+				storeToken( token ).then( () => {
+					mainWindow.webContents.send( 'auth-updated', { token } );
+				} );
+			}
+		} )();
 	} );
 }

--- a/src/lib/tests/oauth.test.ts
+++ b/src/lib/tests/oauth.test.ts
@@ -1,0 +1,51 @@
+/**
+ * @jest-environment node
+ */
+import { ipcMain } from 'electron';
+import fs from 'fs';
+import { withMainWindow } from '../../main-window';
+import { loadUserData, saveUserData } from '../../storage/user-data';
+import { setUpAuthCallbackHandler } from '../oauth';
+
+jest.mock( 'fs' );
+jest.mock( '../../main-window' );
+jest.mock( '../../storage/user-data' );
+
+const mockUserData = {
+	sites: [],
+};
+( fs as MockedFs ).__setFileContents(
+	'/path/to/app/appData/App Name/appdata-v1.json',
+	JSON.stringify( mockUserData )
+);
+
+describe( 'setUpAuthCallbackHandler', () => {
+	it( 'should set up auth callback handler', async () => {
+		let authCallback: ( ...args: any[] ) => void = jest.fn();
+		( ipcMain.on as jest.Mock ).mockImplementationOnce( ( _event, callback ) => {
+			authCallback = callback;
+		} );
+		const mockSend = jest.fn();
+		( withMainWindow as jest.Mock ).mockImplementationOnce( ( callback ) => {
+			callback( {
+				webContents: {
+					send: mockSend,
+				},
+			} );
+		} );
+		const loadData = Promise.resolve( {} );
+		( loadUserData as jest.Mock ).mockReturnValueOnce( loadData );
+		const saveData = Promise.resolve( {} );
+		( saveUserData as jest.Mock ).mockReturnValueOnce( saveData );
+
+		setUpAuthCallbackHandler();
+		const mockToken = { email: 'mock-email' };
+		authCallback( null, { token: mockToken, error: null } );
+		await ( async () => {
+			await loadData;
+			await saveData;
+		} )();
+
+		expect( mockSend ).toHaveBeenCalledWith( 'auth-updated', { token: mockToken } );
+	} );
+} );

--- a/src/main-window.ts
+++ b/src/main-window.ts
@@ -122,22 +122,20 @@ function getOSWindowOptions(): Partial< BrowserWindowConstructorOptions > {
 
 export function withMainWindow< T = void >(
 	callback: ( window: BrowserWindow ) => T | undefined
-): () => T | undefined {
-	return function (): T | undefined {
-		if ( mainWindow && ! mainWindow.isDestroyed() ) {
-			return callback( mainWindow );
-		}
+): T | undefined {
+	if ( mainWindow && ! mainWindow.isDestroyed() ) {
+		return callback( mainWindow );
+	}
 
-		const windows = BrowserWindow.getAllWindows();
-		if ( windows.length > 0 ) {
-			mainWindow = BrowserWindow.getFocusedWindow() || windows[ 0 ];
-			return callback( mainWindow );
-		}
+	const windows = BrowserWindow.getAllWindows();
+	if ( windows.length > 0 ) {
+		mainWindow = BrowserWindow.getFocusedWindow() || windows[ 0 ];
+		return callback( mainWindow );
+	}
 
-		const newWindow = createMainWindow();
-		mainWindow = newWindow;
-		newWindow.webContents.on( 'did-finish-load', () => {
-			return callback( newWindow );
-		} );
-	};
+	const newWindow = createMainWindow();
+	mainWindow = newWindow;
+	newWindow.webContents.on( 'did-finish-load', () => {
+		return callback( newWindow );
+	} );
 }

--- a/src/main-window.ts
+++ b/src/main-window.ts
@@ -120,22 +120,22 @@ function getOSWindowOptions(): Partial< BrowserWindowConstructorOptions > {
 	}
 }
 
-export function withMainWindow< T = void >(
-	callback: ( window: BrowserWindow ) => T | undefined
-): T | undefined {
+export function withMainWindow( callback: ( window: BrowserWindow ) => void ): void {
 	if ( mainWindow && ! mainWindow.isDestroyed() ) {
-		return callback( mainWindow );
+		callback( mainWindow );
+		return;
 	}
 
 	const windows = BrowserWindow.getAllWindows();
 	if ( windows.length > 0 ) {
 		mainWindow = BrowserWindow.getFocusedWindow() || windows[ 0 ];
-		return callback( mainWindow );
+		callback( mainWindow );
+		return;
 	}
 
 	const newWindow = createMainWindow();
 	mainWindow = newWindow;
 	newWindow.webContents.on( 'did-finish-load', () => {
-		return callback( newWindow );
+		callback( newWindow );
 	} );
 }

--- a/src/main-window.ts
+++ b/src/main-window.ts
@@ -139,3 +139,11 @@ export function withMainWindow( callback: ( window: BrowserWindow ) => void ): v
 		callback( newWindow );
 	} );
 }
+
+/**
+ * Reset the main window reference. Exported for testing as resetting modules
+ * with Jest while preserving manual Electron mocks proved quite difficult.
+ */
+export function __resetMainWindow() {
+	mainWindow = null;
+}

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -60,7 +60,7 @@ export function setupMenu( mainWindow: BrowserWindow | null ) {
 					click: () => {
 						withMainWindow( ( window ) => {
 							window.webContents.send( 'user-settings' );
-						} )();
+						} );
 					},
 				},
 				{ type: 'separator' },
@@ -82,7 +82,7 @@ export function setupMenu( mainWindow: BrowserWindow | null ) {
 					click: () => {
 						withMainWindow( ( window ) => {
 							window.webContents.send( 'add-site' );
-						} )();
+						} );
 					},
 				},
 				{

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -88,9 +88,8 @@ export function setupMenu( mainWindow: BrowserWindow | null ) {
 				{
 					label: __( 'Close Window' ),
 					accelerator: 'CommandOrControl+W',
-					click: ( menuItem, browserWindow ) => {
+					click: ( _menuItem, browserWindow ) => {
 						browserWindow?.close();
-						setupMenu( null );
 					},
 					enabled: !! mainWindow && ! mainWindow.isDestroyed(),
 				},

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -23,6 +23,8 @@ it( 'should boot successfully', () => {
 
 it( 'should handle authentication deep links', () => {
 	jest.isolateModules( async () => {
+		const originalProcessPlatform = process.platform;
+		Object.defineProperty( process, 'platform', { value: 'darwin' } );
 		// eslint-disable-next-line @typescript-eslint/no-empty-function
 		let openUrl: ( ...args: any[] ) => void = () => {};
 		const mockIpcMainEmit = jest.fn();
@@ -61,5 +63,7 @@ it( 'should handle authentication deep links', () => {
 		expect( mockIpcMainEmit ).toHaveBeenCalledWith( 'auth-callback', null, {
 			token: mockAuthResult,
 		} );
+
+		Object.defineProperty( process, 'platform', { value: originalProcessPlatform } );
 	} );
 } );

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -1,0 +1,65 @@
+/**
+ * @jest-environment node
+ */
+import fs from 'fs';
+
+jest.mock( 'fs' );
+jest.mock( 'file-stream-rotator' );
+
+const mockUserData = {
+	sites: [],
+};
+( fs as MockedFs ).__setFileContents(
+	'/path/to/app/appData/App Name/appdata-v1.json',
+	JSON.stringify( mockUserData )
+);
+( fs as MockedFs ).__setFileContents( '/path/to/app/temp/com.wordpress.studio/', '' );
+
+it( 'should boot successfully', () => {
+	jest.isolateModules( () => {
+		expect( () => require( '../index' ) ).not.toThrow();
+	} );
+} );
+
+it( 'should handle authentication deep links', () => {
+	jest.isolateModules( async () => {
+		// eslint-disable-next-line @typescript-eslint/no-empty-function
+		let openUrl: ( ...args: any[] ) => void = () => {};
+		const mockIpcMainEmit = jest.fn();
+		jest.doMock( 'electron', () => {
+			const electron = jest.genMockFromModule( 'electron' ) as typeof import('electron');
+			return {
+				...electron,
+				ipcMain: {
+					...electron.ipcMain,
+					emit: mockIpcMainEmit,
+				},
+				app: {
+					...electron.app,
+					on: jest.fn( ( event, callback ) => {
+						if ( event === 'open-url' ) {
+							openUrl = callback;
+						}
+					} ),
+				},
+			};
+		} );
+		const mockAuthResult = { email: 'mock-email', displayName: 'mock-display-name' };
+		const mockResolvedValue = Promise.resolve( mockAuthResult );
+		const mockHandleAuthCallback = jest.fn( () => mockResolvedValue );
+		jest.doMock( '../lib/oauth', () => ( {
+			setUpAuthCallbackHandler: jest.fn(),
+			handleAuthCallback: mockHandleAuthCallback,
+		} ) );
+		require( '../index' );
+
+		const mockHash = '#access_token=1234&expires_in=1';
+		openUrl( {}, `wpcom-local-dev://auth${ mockHash }` );
+		await mockHandleAuthCallback;
+
+		expect( mockHandleAuthCallback ).toHaveBeenCalledWith( mockHash );
+		expect( mockIpcMainEmit ).toHaveBeenCalledWith( 'auth-callback', null, {
+			token: mockAuthResult,
+		} );
+	} );
+} );

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -55,7 +55,7 @@ it( 'should handle authentication deep links', () => {
 
 		const mockHash = '#access_token=1234&expires_in=1';
 		openUrl( {}, `wpcom-local-dev://auth${ mockHash }` );
-		await mockHandleAuthCallback;
+		await mockResolvedValue;
 
 		expect( mockHandleAuthCallback ).toHaveBeenCalledWith( mockHash );
 		expect( mockIpcMainEmit ).toHaveBeenCalledWith( 'auth-callback', null, {

--- a/src/tests/main-window.test.ts
+++ b/src/tests/main-window.test.ts
@@ -1,0 +1,86 @@
+/**
+ * @jest-environment node
+ */
+import { BrowserWindow } from 'electron';
+import fs from 'fs';
+import { createMainWindow, withMainWindow, __resetMainWindow } from '../main-window';
+
+jest.mock( 'fs' );
+
+const mockUserData = {
+	sites: [],
+};
+( fs as MockedFs ).__setFileContents(
+	'/path/to/app/appData/App Name/appdata-v1.json',
+	JSON.stringify( mockUserData )
+);
+
+describe( 'withMainWindow', () => {
+	let createdWindow: BrowserWindow;
+
+	beforeEach( () => {
+		createdWindow = createMainWindow();
+	} );
+
+	afterEach( () => {
+		__resetMainWindow();
+	} );
+
+	it( 'passes the main window to the callback when the reference is set', () => {
+		const callback = jest.fn();
+
+		withMainWindow( callback );
+
+		expect( callback ).toHaveBeenCalledWith( createdWindow );
+	} );
+
+	it( 'passes the focused window to the callback when the reference is destroyed', () => {
+		const callback = jest.fn();
+		const mockWindow1 = { foo: 'foo' };
+		const mockWindow2 = { bar: 'bar' };
+		( createdWindow.isDestroyed as jest.Mock ).mockReturnValue( true );
+		( BrowserWindow.getFocusedWindow as jest.Mock ).mockReturnValueOnce( mockWindow2 );
+		( BrowserWindow.getAllWindows as jest.Mock ).mockReturnValueOnce( [
+			mockWindow1,
+			mockWindow2,
+		] );
+
+		withMainWindow( callback );
+
+		expect( callback ).toHaveBeenCalledWith( mockWindow2 );
+	} );
+
+	it( 'passes the first window to the callback when the reference is destroyed and no window is focused', () => {
+		const callback = jest.fn();
+		const mockWindow1 = { bim: 'bim' };
+		const mockWindow2 = { bam: 'bam' };
+		( createdWindow.isDestroyed as jest.Mock ).mockReturnValue( true );
+		( BrowserWindow.getAllWindows as jest.Mock ).mockReturnValueOnce( [
+			mockWindow1,
+			mockWindow2,
+		] );
+
+		withMainWindow( callback );
+
+		expect( callback ).toHaveBeenCalledWith( mockWindow1 );
+	} );
+
+	it( 'passes the main window to the callback when no non-destroyed windows exist', () => {
+		const callback = jest.fn();
+		// eslint-disable-next-line @typescript-eslint/no-empty-function
+		let didFinishLoad: ( ...args: any[] ) => void = () => {};
+		( createdWindow.isDestroyed as jest.Mock ).mockReturnValue( true );
+		( BrowserWindow.prototype.webContents.on as jest.Mock ).mockImplementation(
+			( _event, callback ) => {
+				didFinishLoad = callback;
+			}
+		);
+
+		withMainWindow( callback );
+		didFinishLoad();
+
+		// Assert any `BrowserWindow` as mocking the return of `createMainWindow`
+		// within `withMainWindow` is difficult.
+		expect( callback ).toHaveBeenCalledWith( expect.any( BrowserWindow ) );
+	} );
+} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/6906.
Fixes https://github.com/Automattic/studio/issues/14.

## Proposed Changes

Replace a cached main window reference with a more robust implementation of the
pre-existing `withMainWindow` utility used by the menu creation logic. The new
approach ensures a non-destroyed window is available whenever an event handler
attempts to reference it by accessing or creating the window within the event
handler, rather than using a main window reference that was passed when the
event handler was registered.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**1. Authentication flow succeeds after closing and re-opening Studio's window**

1. Launch Studio. 
2. Close the Studio window. 
3. Open a new Studio window (e.g., click the dock icon). 
4. Complete the WPCOM authentication flow, allowing the browser to open the Studio app. 
5. Verify the Studio app becomes focused and the correct authenticated state is displayed. 

**2. Authentication flow succeeds after quitting Studio**

> [!IMPORTANT]
> This test case requires uninstalling all other Studio app installs before testing and using a build from `npm run make`. 

1. Launch Studio. 
2. Begin the WPCOM authentication flow, then quit the Studio app before continuing. 
3. Complete the WPCOM authentication flow, allowing the browser to open the Studio app. 
4. Verify the Studio app launches, becomes focused, and the correct authenticated state is displayed. 

**3. Studio menu items have not regressed**

Verify the various menu items — `Add Site...`, `Settings...`, `Close Window`, etc — continue to function as expected both with and without an active Studio window open. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
