### PR TITLE
build: Suppress sentry-webpack-plugin logs

### DIFF
--- a/webpack.plugins.ts
+++ b/webpack.plugins.ts
@@ -13,9 +13,10 @@ export const plugins: WebpackPluginInstance[] = [
 		},
 	} ),
 	// Sentry must be the last plugin
-	sentryWebpackPlugin( {
-		authToken: process.env.SENTRY_AUTH_TOKEN,
-		org: 'a8c',
-		project: 'studio',
-	} ),
+	!! process.env.SENTRY_AUTH_TOKEN &&
+		sentryWebpackPlugin( {
+			authToken: process.env.SENTRY_AUTH_TOKEN,
+			org: 'a8c',
+			project: 'studio',
+		} ),
 ];


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Proposed Changes

Avoid unnecessary development environment noise from a production-only
plugin.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Verify no logs display when environment variable is undefined**
1. `npm start`
2. Verify no `sentry-webpack-plugin` values display in the server log. 

**Verify logs display when environment variable is defined**
1. `SENTRY_AUTH_TOKEN='mock-value' npm start`
2. Verify `sentry-webpack-plugin` values display in the server log (a Sentry permission error will display due to an invalid token value). 

<img width="1420" alt="sentry-webpack-plugin-logs" src="https://github.com/Automattic/studio/assets/438664/559503dc-5949-4911-975e-87ae126f966d">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
