### PR TITLE
fix: Improve focus style consistency

### DIFF
--- a/src/components/site-menu.tsx
+++ b/src/components/site-menu.tsx
@@ -100,9 +100,9 @@ function SiteItem( { site }: { site: SiteDetails } ) {
 	return (
 		<li
 			className={ cx(
-				'flex flex-row min-w-[168px] h-8 hover:bg-[#ffffff0C] focus:bg-[#ffffff0C] rounded transition-all',
+				'flex flex-row min-w-[168px] h-8 hover:bg-[#ffffff0C] rounded transition-all',
 				isMac() ? 'mx-5' : 'mx-4',
-				isSelected && 'bg-[#ffffff19] hover:bg-[#ffffff19] focus:bg-[#ffffff19]'
+				isSelected && 'bg-[#ffffff19] hover:bg-[#ffffff19]'
 			) }
 		>
 			<button

--- a/src/components/site-menu.tsx
+++ b/src/components/site-menu.tsx
@@ -70,7 +70,7 @@ function ButtonToRun( { running, id, name }: Pick< SiteDetails, 'running' | 'id'
 			{ /* Circle */ }
 			<div
 				className={ cx(
-					'w-2.5 h-2.5 transition-opacity group-hover:opacity-0 group-focus:opacity-0 border-[0.5px]',
+					'w-2.5 h-2.5 transition-opacity group-hover:opacity-0 group-focus-visible:opacity-0 border-[0.5px]',
 					'row-start-1 col-start-1 place-self-center',
 					classCircle,
 					loadingServer[ id ] && 'animate-pulse border-[#00BA3775] bg-[#1ED15A75] duration-100',
@@ -84,7 +84,7 @@ function ButtonToRun( { running, id, name }: Pick< SiteDetails, 'running' | 'id'
 			{ ! loadingServer[ id ] && (
 				<div
 					className={ cx(
-						'opacity-0 transition-opacity group-hover:opacity-100 group-focus:opacity-100',
+						'opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100',
 						'row-start-1 col-start-1 place-self-center'
 					) }
 				>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Proposed Changes

- Prefer `focus-visible` styles over `focusable` to satisfy prior [design guidance](https://github.com/Automattic/local-environment/pull/192#issuecomment-2025535261). 
- Remove unnecessary styles from seemingly non-focusable `li` element. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
**Verify keyboard focus styles**
1. Interact with the site navigation, starting/stopping sites using a keyboard.
1. Verify focus styles work as expected while using a keyboard.

**Verify pointer/cursor styles**
1. Interact with the site navigation, starting/stopping sites using a
   pointer/cursor/keyboard.
1. Verify the focus styles do not linger after no longer hovering.

| Before | After |
| - | - |
| <video src="https://github.com/Automattic/studio/assets/438664/dfebbc0b-8de1-459c-8f47-4fd1a63519f0" /> | <video src="https://github.com/Automattic/studio/assets/438664/3effd368-87ce-4383-8a37-63843a5010af" /> |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
