### PR TITLE
Fix: Sidebar layout breaks on specific languages

### DIFF
--- a/src/components/main-sidebar.tsx
+++ b/src/components/main-sidebar.tsx
@@ -61,7 +61,7 @@ function SidebarAuthFooter() {
 			<Button
 				aria-description={ isOffline ? offlineMessage : '' }
 				aria-disabled={ isOffline }
-				className="flex gap-x-2 items-center justify-between w-full text-white rounded !px-0 py-1 h-auto active:!text-white hover:!text-white hover:underline"
+				className="flex gap-x-2 justify-between w-full text-white rounded !px-0 py-1 h-auto active:!text-white hover:!text-white hover:underline items-end"
 				onClick={ () => {
 					if ( isOffline ) {
 						return;
@@ -70,7 +70,8 @@ function SidebarAuthFooter() {
 				} }
 			>
 				<WordPressLogo />
-				<div className="text-xs">{ __( 'Log in' ) }</div>
+
+				<div className="text-xs text-right">{ __( 'Log in' ) }</div>
 			</Button>
 		</Tooltip>
 	);


### PR DESCRIPTION
Closes #https://github.com/Automattic/studio/issues/40

## Proposed Changes

This PR aligns the WordPress logo and `Log in` so that the layout is more consistent in multiple languages.

Before            |  After
:-------------------------:|:-------------------------:
![](https://github.com/Automattic/studio/assets/25575134/fc47cc43-bd47-40f5-b0e6-682883914df6)  |  ![](https://github.com/Automattic/studio/assets/25575134/af778bce-12be-4efd-90dd-fa60686fe794)

## Testing Instructions

* Pull the changes from this branch locally
* Select the language in your system to be `French`
* Start the app with `nvm use && npm install && npm start`
* Observe that the words `Se connecter` are aligned in the sidebar are aligned to the right and towards the bottom
* Quit the app
* Try switching the languages to other such as `Spanish`, `Polish`, `English` and confirm that the `Log in` either remains on one line (when the word is short, or is aligned to the right when there are two lines)

**Notes**

* You can find a bit more discussions regarding [this issue here](https://github.com/Automattic/studio/issues/40#issuecomment-2096259251). I initially considered making the sidebar more dynamic and size it based on what is inside it to keep everything on the same line but decided against it because:
- it might look too overpowering if the words are too long for the `Log in` in some languages;
- it might affect how it looks like on other operating systems. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
