### PR TITLE
Studio: Add translators comment for opening a website

### DIFF
--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -35,7 +35,7 @@ export default function Header() {
 							variant="link"
 						>
 							{
-								// translators: "Open site" refers to the action of opening a website
+								// translators: "Open site" refers to the action, like "to open site"
 								__( 'Open site' )
 							}
 							<Icon className="ltr:ml-1 rtl:mr-1 rtl:scale-x-[-1]" icon={ external } size={ 14 } />

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -34,7 +34,10 @@ export default function Header() {
 							onClick={ () => getIpcApi().openSiteURL( site.id ) }
 							variant="link"
 						>
-							{ __( 'Open site' ) }
+							{
+								// translators: "Open site" refers to the action of opening a website
+								__( 'Open site' )
+							}
 							<Icon className="ltr:ml-1 rtl:mr-1 rtl:scale-x-[-1]" icon={ external } size={ 14 } />
 						</Button>
 					</div>


### PR DESCRIPTION
## Proposed Changes

When working on https://github.com/Automattic/studio/pull/93 , I noticed that the translation of `Open site` in French is not correct. `Open site` can mean two things:

* an action: to open a website
* a adjective + noun: a site that is open 

I noticed that in French, this word combination got translated as `a site that is open` instead of the first case. I suggest that we add a translator comment to clarify this.

## Testing Instructions

* Look through the changes in this PR
* Confirm that the translator explanation is clear
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
