### PR TITLE
Use sanitizeFilepath when logging Sentry breadcrumbs

### DIFF
--- a/src/storage/user-data.ts
+++ b/src/storage/user-data.ts
@@ -46,7 +46,7 @@ export async function loadUserData(): Promise< UserData > {
 				Sentry.addBreadcrumb( {
 					data: {
 						fileContents: sanitizeUnstructuredData( asString ),
-						filePath,
+						filePath: sanitizeUserpath( filePath ),
 					},
 				} );
 			}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to https://github.com/Automattic/studio/pull/78 and https://github.com/Automattic/dotcom-forge/issues/6701
While reviewing Sentry logs, I noted that there is an additional place where filepaths need to be redacted.


## Proposed Changes
Adds to the behavior introduced in https://github.com/Automattic/studio/pull/78 that sanitizes userpaths in console.log statements. This pr adds the same `sanitizeUserpath` util to filepath values when logging Sentry breadcrumbs, too.

## Testing Instructions

When running locally, log out the value of `sanitizeUserpath` when `Sentry.addBreadcrumb` is logged during user data loading: 

https://github.com/Automattic/studio/blob/4d584adfd52856a20b60367a977567c7cd3e7f81/src/storage/user-data.ts#L45-L52

The value of filepaths should appear as `[REDACTED]`.  [Example error session](https://a8c.sentry.io/issues/5071161787/events/ef50743e9de444da8579fd9343bd270a) where console.log events are using `sanitizeUserpath`, and `Sentry.addBreadcrumb` events are not (marked "generic" in the event logs). 


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
