### PR TITLE
Update Sentry release param to use app version

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,7 @@ Sentry.init( {
 	dsn: 'https://97693275b2716fb95048c6d12f4318cf@o248881.ingest.sentry.io/4506612776501248',
 	debug: true,
 	enabled: process.env.NODE_ENV !== 'development',
-	release: COMMIT_HASH,
+	release: app.getVersion() ? app.getVersion() : COMMIT_HASH,
 } );
 
 // Handle creating/removing shortcuts on Windows when installing/uninstalling.


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/6671

Ensures Sentry events reference the release version, when available.

## Proposed Changes

Updates `Sentry.init` params to pass the release version (via `app.getVersion()`). If there is no release version, the commit hash is used (matching current behavior). 

## Testing Instructions

Log Sentry.init values locally to observe app release version. 

https://github.com/Automattic/studio/blob/ecc7e629a8e3570929d544eb7ea62fedc4d4ad40/src/index.ts#L28-L33

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
