### PR TITLE
Fix cropped focus outline style for sidebar buttons

### DIFF
--- a/src/components/main-sidebar.tsx
+++ b/src/components/main-sidebar.tsx
@@ -131,7 +131,7 @@ export default function MainSidebar( { className }: MainSidebarProps ) {
 				<div
 					className={ cx(
 						'flex-1 overflow-y-auto sites-scrollbar app-no-drag-region',
-						isMac() ? 'ml-5' : 'ml-4'
+						isMac() ? 'ml-4' : 'ml-3'
 					) }
 				>
 					<SiteMenu />

--- a/src/components/site-menu.tsx
+++ b/src/components/site-menu.tsx
@@ -100,7 +100,7 @@ function SiteItem( { site }: { site: SiteDetails } ) {
 	return (
 		<li
 			className={ cx(
-				'flex flex-row min-w-[168px] h-8 hover:bg-[#ffffff0C] rounded transition-all',
+				'flex flex-row min-w-[168px] h-8 hover:bg-[#ffffff0C] rounded transition-all ml-1',
 				isMac() ? 'mr-5' : 'mr-4',
 				isSelected && 'bg-[#ffffff19] hover:bg-[#ffffff19]'
 			) }


### PR DESCRIPTION
Related to https://github.com/Automattic/studio/pull/82#pullrequestreview-2043579978

## Proposed Changes

- The focus outline style for the sidebar buttons is slightly cropped on the left. The reason for this is that the changes in https://github.com/Automattic/studio/pull/82 removed the button's left margin, leaving no longer space for the extra border to be displayed.
- With this PR, a small amount of left margin is added back to the buttons (this is then subtracted from the main sidebar).

## Testing Instructions

- Navigate through the app using your keyboard and verify that the focus outline style appears as expected, no longer cropped.
- In addition, verify that it's still possible to drag the left border and that the amount of space it's possible to drag isn't _noticeably_ smaller.

| Before  | After |
| ------------- | ------------- |
| <img src="https://github.com/Automattic/studio/assets/2998162/f8b58539-32b0-456d-94a7-f436a6f585c5" width="100%"> | <img src="https://github.com/Automattic/studio/assets/2998162/f519727b-74e1-42d4-9b1a-ab644fae190d" width="100%"> | 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
