### PR TITLE
Update header styles

### DIFF
--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -15,22 +15,26 @@ export default function Header() {
 		>
 			{ site && (
 				<div className="flex flex-col">
-					<h1 className="text-xl font-normal max-h-full line-clamp-1 break-all">
+					<h1 className="text-xl font-medium max-h-full line-clamp-1 break-all">
 						{ site ? site.name : null }
 					</h1>
 					<div className="flex mt-1 gap-x-4">
 						<Button
 							disabled={ ! site.running }
-							className="[&.is-link]:text-a8c-gray-50 [&.is-link]:hover:text-a8c-gray-90 !px-0 h-0 leading-4"
+							className="[&.is-link]:text-a8c-gray-70 [&.is-link]:hover:text-a8c-blueberry !px-0 h-0 leading-4"
 							onClick={ () => getIpcApi().openSiteURL( site.id, '/wp-admin' ) }
 							variant="link"
 						>
 							{ __( 'WP admin' ) }
-							<Icon icon={ external } className="ltr:ml-1 rtl:mr-1 rtl:scale-x-[-1]" size={ 14 } />
+							<Icon
+								icon={ external }
+								className="ltr:ml-0.5 rtl:mr-0.5 rtl:scale-x-[-1]"
+								size={ 14 }
+							/>
 						</Button>
 						<Button
 							disabled={ ! site.running }
-							className="[&.is-link]:text-a8c-gray-50 [&.is-link]:hover:text-a8c-gray-90 !px-0 h-0 leading-4"
+							className="[&.is-link]:text-a8c-gray-70 [&.is-link]:hover:text-a8c-blueberry !px-0 h-0 leading-4"
 							onClick={ () => getIpcApi().openSiteURL( site.id ) }
 							variant="link"
 						>
@@ -38,7 +42,11 @@ export default function Header() {
 								// translators: "Open site" refers to the action, like "to open site"
 								__( 'Open site' )
 							}
-							<Icon className="ltr:ml-1 rtl:mr-1 rtl:scale-x-[-1]" icon={ external } size={ 14 } />
+							<Icon
+								className="ltr:ml-0.5 rtl:mr-0.5 rtl:scale-x-[-1]"
+								icon={ external }
+								size={ 14 }
+							/>
 						</Button>
 					</div>
 				</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/6977

## Proposed Changes

- Update the header styles to better align with Dotcom and A4A.
- Apply medium font weight to site name.
- Use `gray 70` for header links, and `blueberry` on hover.
- Adjust spacing of external link icons.

| Before | After |
|--------|--------|
| <img width="231" alt="Screenshot 2024-05-08 at 14 01 35" src="https://github.com/Automattic/studio/assets/417538/62112d8e-fab2-4cd3-9f0c-f84265430457"> | <img width="231" alt="Screenshot 2024-05-08 at 14 01 25" src="https://github.com/Automattic/studio/assets/417538/ca6eb5f3-8cb3-4e1a-a032-2e6a9a629ae0"> |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Open Studio
- Note the updated header styles

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
