### PR TITLE
Increase site server process timeout for messages

### DIFF
--- a/src/lib/site-server-process.ts
+++ b/src/lib/site-server-process.ts
@@ -9,7 +9,7 @@ declare const SITE_SERVER_PROCESS_MODULE_PATH: string;
 
 export type MessageName = 'start-server' | 'stop-server' | 'run-php';
 
-const DEFAULT_RESPONSE_TIMEOUT = 25000;
+const DEFAULT_RESPONSE_TIMEOUT = 120000;
 
 export default class SiteServerProcess {
 	lastMessageId = 0;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->
Related issue: https://github.com/Automattic/dotcom-forge/issues/7061

## Proposed Changes

- Increase the timeout duration for waiting for messages from the site server process. This adjustment ensures that sites can be created successfully even if the process takes longer than anticipated. Notably, on Windows, site creation can occasionally require up to 30 seconds.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Open the app on Windows (it's recommended that it's a medium/slow machine).
- Create a site.
- Observe the site is created.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
