### PR TITLE
Add notarization step for release builds

### DIFF
--- a/.buildkite/commands/post-process-binary-for-distribution.sh
+++ b/.buildkite/commands/post-process-binary-for-distribution.sh
@@ -2,7 +2,5 @@
 
 # Prepares an existing binary for distribution and generates its corresponding manifest.
 
-
-
 echo "--- :node: Generate Releases Manifest"
 node ./scripts/generate-releases-manifest.mjs

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -57,7 +57,7 @@ steps:
       install_gems
       bundle exec fastlane distribute_dev_build
     agents:
-      queue: "mac" # 
+      queue: "mac" #
     depends_on:
       - step: "dev-mac"
       - step: "dev-windows"
@@ -74,6 +74,9 @@ steps:
       node ./scripts/confirm-tag-matches-version.mjs
       npm run make:macos-x64
       npm run make:macos-arm64
+
+      echo "--- 📃 Notarizing Binary"
+      bundle exec fastlane notarize_binary
 
       .buildkite/commands/post-process-binary-for-distribution.sh
 


### PR DESCRIPTION
Release builds are currently failing in CI: https://buildkite.com/automattic/studio/builds/456#018f5d26-ea1f-4059-90f8-0b322e2e76c9

In https://github.com/Automattic/studio/pull/85, the `notarize_binary` step was removed from the `post-process-binary-for-distribution.sh` script and added to the dev build pipeline but not to the release build pipeline. This PR adds it to the release build pipeline. 

The build failure was looking for a `Studio.app.zip`, but the .zip isn't created until the notarization step happens.  

## Testing Instructions

This will need to be merged first so that a tagged build can be created in order to test the release build pipeline. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Have you checked for TypeScript, React or other console errors?
