### PR TITLE
Remove arrow and improve button CTA on Onboarding screen

### DIFF
--- a/src/components/onboarding.tsx
+++ b/src/components/onboarding.tsx
@@ -11,16 +11,6 @@ import { SiteForm } from './site-form';
 
 const GradientBox = () => {
 	const { __ } = useI18n();
-	const Arrow = () => (
-		<svg width="18" height="13" viewBox="0 0 18 13" fill="none">
-			<path
-				fillRule="evenodd"
-				clipRule="evenodd"
-				d="M11.8061 12.5L10.6181 11.3121L14.7841 7.14603L0.012085 7.14603L0.0120851 5.46603L14.7841 5.46603L10.6181 1.3L11.8061 0.112061L18 6.30603L11.8061 12.5Z"
-				fill="white"
-			/>
-		</svg>
-	);
 	return (
 		<div
 			aria-label={ __( 'Imagine, Create, Design, Code, Build' ) }
@@ -35,7 +25,6 @@ const GradientBox = () => {
 			</div>
 			<div className="text-white tracking-[-0.84px] flex justify-between items-baseline self-stretch">
 				<p>{ __( 'Build' ) }</p>
-				<Arrow />
 			</div>
 		</div>
 	);
@@ -123,7 +112,7 @@ export default function Onboarding() {
 									disabled={ !! error || isAddingSite }
 									variant="primary"
 								>
-									{ isAddingSite ? __( 'Adding site…' ) : __( 'Continue' ) }
+									{ isAddingSite ? __( 'Adding site…' ) : __( 'Add site' ) }
 								</Button>
 							</div>
 						</SiteForm>

--- a/src/components/tests/onboarding.test.tsx
+++ b/src/components/tests/onboarding.test.tsx
@@ -57,7 +57,7 @@ describe( 'Onboarding Component', () => {
 	it( 'renders onboarding screen correctly', () => {
 		const { getByText } = render( <Onboarding /> );
 		expect( getByText( 'Add your first site' ) ).toBeVisible();
-		expect( getByText( 'Continue' ) ).toBeVisible();
+		expect( getByText( 'Add site' ) ).toBeVisible();
 	} );
 
 	it( 'completes onboarding when the final button is clicked', async () => {
@@ -66,7 +66,7 @@ describe( 'Onboarding Component', () => {
 
 		const { getByText } = render( <Onboarding /> );
 
-		await user.click( getByText( 'Continue' ) );
+		await user.click( getByText( 'Add site' ) );
 
 		// Check if handleAddSiteClick has been called and the process to create a new site started
 		await waitFor( () => expect( handleAddSiteClick ).toHaveBeenCalled() );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/7004

## Proposed Changes

I propose to reduce the confusion we observed on the Onboarding screen:
- remove the are that looks like CTA but is not
- change 'Continue' to 'Add site' to make CTA clearer and consistent with the other form

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Remove all sites (or use an `appdata-v1.json` file with emptied sites)
2. Start the Studio
3. Confirm there is no arrow on left side
4. Confirm CTA is now 'Add site'

<img width="1012" alt="Screenshot 2024-05-10 at 08 46 11" src="https://github.com/Automattic/studio/assets/727413/769f14b1-2388-4b9a-a4e2-eae314745b24">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
