### PR TITLE
DRY builds S3 upload logic

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,3 +24,6 @@ Metrics/AbcSize:
 
 Metrics/CyclomaticComplexity:
   Exclude: *fastlane
+
+Metrics/PerceivedComplexity:
+  Exclude: *fastlane

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,4 +20,7 @@ Style/AsciiComments:
   Exclude: *fastlane
 
 Metrics/AbcSize:
-  Enabled: false
+  Exclude: *fastlane
+
+Metrics/CyclomaticComplexity:
+  Exclude: *fastlane

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,3 +18,6 @@ Layout/EmptyLines:
 
 Style/AsciiComments:
   Exclude: *fastlane
+
+Metrics/AbcSize:
+  Enabled: false

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -16,6 +16,8 @@ APPLE_TEAM_ID = 'PZYM8XX95Q'
 APPLE_BUNDLE_IDENTIFIER = 'com.automattic.studio'
 APPLE_API_KEY_PATH = File.join(SECRETS_FOLDER, 'app_store_connect_fastlane_api_key.json')
 
+CDN_URL = 'https://cdn.a8c-ci.services'
+
 # Use this instead of getting values from ENV directly
 # It will throw an error if the requested value is missing
 def get_required_env(key)
@@ -52,204 +54,28 @@ lane :notarize_binary do |_options|
     )
   end
 end
+
 desc 'Ship the binary to internal testers'
 lane :distribute_dev_build do |_options|
   commit_metadata = last_git_commit
   commit_hash = commit_metadata[:commit_hash]
-
-  binary_path_mac   = File.join(PROJECT_ROOT_FOLDER, 'out', 'Studio-darwin-universal', 'Studio.app.zip')
-  binary_path_x64   = File.join(PROJECT_ROOT_FOLDER, 'out', 'Studio-darwin-x64', 'Studio.app.zip')
-  binary_path_arm64 = File.join(PROJECT_ROOT_FOLDER, 'out', 'Studio-darwin-arm64', 'Studio.app.zip')
-  binary_path_win32 = File.join(PROJECT_ROOT_FOLDER, 'out', 'make', 'squirrel.windows', 'x64', 'studio-setup.exe')
-
-  manifest_path = File.join(PROJECT_ROOT_FOLDER, 'out', 'releases.json')
   build_number = get_required_env('BUILDKITE_BUILD_NUMBER')
 
-  filename_root = 'studio'
-  hashed_filename_mac   = "#{filename_root}-darwin-universal-#{commit_hash}.app.zip"
-  hashed_filename_x64   = "#{filename_root}-darwin-x64-#{commit_hash}.app.zip"
-  hashed_filename_arm64 = "#{filename_root}-darwin-arm64-#{commit_hash}.app.zip"
-  hashed_filename_win32 = "#{filename_root}-win32-#{commit_hash}.exe"
-
-  latest_filename_mac   = "#{filename_root}-darwin-universal-latest.app.zip"
-  latest_filename_x64   = "#{filename_root}-darwin-x64-latest.app.zip"
-  latest_filename_arm64 = "#{filename_root}-darwin-arm64-latest.app.zip"
-  latest_filename_win32 = "#{filename_root}-win32-latest.exe"
-
-  bucket_folder = 'studio'
-
-  upload_to_s3(
-    bucket: 'a8c-apps-public-artifacts',
-    key: "#{bucket_folder}/#{hashed_filename_mac}",
-    file: binary_path_mac,
-    if_exists: :fail,
-    auto_prefix: false
-  )
-
-  upload_to_s3(
-    bucket: 'a8c-apps-public-artifacts',
-    key: "#{bucket_folder}/#{hashed_filename_x64}",
-    file: binary_path_x64,
-    if_exists: :fail,
-    auto_prefix: false
-  )
-
-  upload_to_s3(
-    bucket: 'a8c-apps-public-artifacts',
-    key: "#{bucket_folder}/#{hashed_filename_arm64}",
-    file: binary_path_arm64,
-    if_exists: :fail,
-    auto_prefix: false
-  )
-
-  upload_to_s3(
-    bucket: 'a8c-apps-public-artifacts',
-    key: "#{bucket_folder}/#{hashed_filename_win32}",
-    file: binary_path_win32,
-    if_exists: :fail,
-    auto_prefix: false
-  )
-
-  upload_to_s3(
-    bucket: 'a8c-apps-public-artifacts',
-    key: "#{bucket_folder}/#{latest_filename_mac}",
-    file: binary_path_mac,
-    if_exists: :replace,
-    auto_prefix: false
-  )
-
-  upload_to_s3(
-    bucket: 'a8c-apps-public-artifacts',
-    key: "#{bucket_folder}/#{latest_filename_x64}",
-    file: binary_path_x64,
-    if_exists: :replace,
-    auto_prefix: false
-  )
-
-  upload_to_s3(
-    bucket: 'a8c-apps-public-artifacts',
-    key: "#{bucket_folder}/#{latest_filename_arm64}",
-    file: binary_path_arm64,
-    if_exists: :replace,
-    auto_prefix: false
-  )
-
-  upload_to_s3(
-    bucket: 'a8c-apps-public-artifacts',
-    key: "#{bucket_folder}/#{latest_filename_win32}",
-    file: binary_path_win32,
-    if_exists: :replace,
-    auto_prefix: false
-  )
-
-  upload_to_s3(
-    bucket: 'a8c-apps-public-artifacts',
-    key: "#{bucket_folder}/releases.json",
-    file: manifest_path,
-    if_exists: :replace,
-    auto_prefix: false
-  )
-
-  # Because we distribute via Cloudfront, we need to invalidate the `latest` build after
-  # each upload, otherwise it'll be stale.
-  clear_cloudfront_cache(
-    paths: [
-      "/#{bucket_folder}/#{latest_filename_mac}",
-      "/#{bucket_folder}/#{latest_filename_x64}",
-      "/#{bucket_folder}/#{latest_filename_arm64}",
-      "/#{bucket_folder}/#{latest_filename_win32}",
-      "/#{bucket_folder}/releases.json"
-    ],
-    commit_hash: "#{commit_hash}-#{build_number}"
-  )
-
-  download_url_mac     = "https://cdn.a8c-ci.services/#{bucket_folder}/#{hashed_filename_mac}"
-  download_url_x64     = "https://cdn.a8c-ci.services/#{bucket_folder}/#{hashed_filename_x64}"
-  download_url_arm64   = "https://cdn.a8c-ci.services/#{bucket_folder}/#{hashed_filename_arm64}"
-  download_url_windows = "https://cdn.a8c-ci.services/#{bucket_folder}/#{hashed_filename_win32}"
-
-  buildkite_annotate(
-    context: 'cdn-link',
-    style: 'info',
-    message: "🔗 Build available for Mac in [Intel](#{download_url_x64}), [Apple Silicon](#{download_url_arm64}), and [Universal](#{download_url_universal}) flavors, and for [Windows](#{download_url_win32})"
-  )
+  distribute_builds(commit_hash:, build_number:)
 end
 
 desc 'Ship release build'
 lane :distribute_release_build do |_options|
   commit_metadata = last_git_commit
   commit_hash = commit_metadata[:commit_hash]
+  release_tag = get_required_env('BUILDKITE_TAG')
+  build_number = get_required_env('BUILDKITE_BUILD_NUMBER')
 
-  binary_path_mac   = File.join(PROJECT_ROOT_FOLDER, 'out', 'Studio-darwin-universal', 'Studio.app.zip')
-  binary_path_x64   = File.join(PROJECT_ROOT_FOLDER, 'out', 'Studio-darwin-x64', 'Studio.app.zip')
-  binary_path_arm64 = File.join(PROJECT_ROOT_FOLDER, 'out', 'Studio-darwin-arm64', 'Studio.app.zip')
-  binary_path_win32 = File.join(PROJECT_ROOT_FOLDER, 'out', 'make', 'squirrel.windows', 'x64', 'studio-setup.exe')
-
-  manifest_path     = File.join(PROJECT_ROOT_FOLDER, 'out', 'releases.json')
-  release_tag       = get_required_env('BUILDKITE_TAG')
-  build_number      = get_required_env('BUILDKITE_BUILD_NUMBER')
-
-  filename_root         = 'studio'
-  tagged_filename_mac   = "#{filename_root}-darwin-universal-#{release_tag}.app.zip"
-  tagged_filename_x64   = "#{filename_root}-darwin-x64-#{release_tag}.app.zip"
-  tagged_filename_arm64 = "#{filename_root}-darwin-arm64-#{release_tag}.app.zip"
-  tagged_filename_win32 = "#{filename_root}-win32-#{release_tag}.exe"
-
-  bucket_folder = 'studio'
-
-  upload_to_s3(
-    bucket: 'a8c-apps-public-artifacts',
-    key: "#{bucket_folder}/#{tagged_filename_mac}",
-    file: binary_path_mac,
-    if_exists: :fail,
-    auto_prefix: false
+  urls = distribute_builds(
+    commit_hash:,
+    build_number:,
+    release_tag:
   )
-
-  upload_to_s3(
-    bucket: 'a8c-apps-public-artifacts',
-    key: "#{bucket_folder}/#{tagged_filename_x64}",
-    file: binary_path_x64,
-    if_exists: :fail,
-    auto_prefix: false
-  )
-
-  upload_to_s3(
-    bucket: 'a8c-apps-public-artifacts',
-    key: "#{bucket_folder}/#{tagged_filename_arm64}",
-    file: binary_path_arm64,
-    if_exists: :fail,
-    auto_prefix: false
-  )
-
-  upload_to_s3(
-    bucket: 'a8c-apps-public-artifacts',
-    key: "#{bucket_folder}/#{tagged_filename_win32}",
-    file: binary_path_win32,
-    if_exists: :fail,
-    auto_prefix: false
-  )
-
-  upload_to_s3(
-    bucket: 'a8c-apps-public-artifacts',
-    key: "#{bucket_folder}/releases.json",
-    file: manifest_path,
-    if_exists: :replace,
-    auto_prefix: false
-  )
-
-  # Because we distribute via Cloudfront, we need to invalidate the manifest file after
-  # each upload, otherwise it'll be stale.
-  clear_cloudfront_cache(
-    paths: [
-      "/#{bucket_folder}/releases.json"
-    ],
-    commit_hash: "#{commit_hash}-#{build_number}"
-  )
-
-  download_url_mac   = "https://cdn.a8c-ci.services/#{bucket_folder}/#{tagged_filename_mac}"
-  download_url_x64   = "https://cdn.a8c-ci.services/#{bucket_folder}/#{tagged_filename_x64}"
-  download_url_arm64 = "https://cdn.a8c-ci.services/#{bucket_folder}/#{tagged_filename_arm64}"
-  download_url_win32 = "https://cdn.a8c-ci.services/#{bucket_folder}/#{tagged_filename_win32}"
 
   slack(
     username: 'CI Bot',
@@ -259,16 +85,155 @@ lane :distribute_release_build do |_options|
     success: true,
     slack_url: get_required_env('SLACK_WEBHOOK'),
     payload: {
-      ':wordpress-white: Studio by WordPress.com Release': "Available for Mac in [Intel](#{download_url_x64}), [Apple Silicon](#{download_url_arm64}), and [Universal](#{download_url_mac}) flavors, and for [Windows](#{download_url_win32})"
+      ':studio-app-icon-mac: Release available for': "Available for Mac in [Intel](#{urls[:x64]}), [Apple Silicon](#{urls[:arm64]}) and [Universal](#{urls[:mac_universal]}) architectures, and for [Windows](#{urls[:windows]})."
     },
     default_payloads: []
   )
+end
+
+def distribute_builds(commit_hash:, build_number:, release_tag: nil)
+  # If we are distributing a build without a tag, i.e. a development build, we also want to update the latest build reference for distribution.
+  update_latest = release_tag.nil?
+  suffix = release_tag.nil? ? commit_hash : release_tag
+
+  builds_folder = File.join(PROJECT_ROOT_FOLDER, 'out')
+
+  binary_path_mac = File.join(builds_folder, 'out', 'Studio-darwin-universal', 'Studio.app.zip')
+  binary_path_x64 = File.join(builds_folder, 'Studio-darwin-x64', 'Studio.app.zip')
+  binary_path_arm64 = File.join(builds_folder, 'Studio-darwin-arm64', 'Studio.app.zip')
+  binary_path_win32 = File.join(builds_folder, 'make', 'squirrel.windows', 'x64', 'studio-setup.exe')
+
+  manifest_path = File.join(builds_folder, 'releases.json')
+
+  filename_root = 'studio'
+  filename_mac = "#{filename_root}-darwin-universal-#{commit_hash}.app.zip"
+  filename_x64   = "#{filename_root}-darwin-x64-#{suffix}.app.zip"
+  filename_arm64 = "#{filename_root}-darwin-arm64-#{suffix}.app.zip"
+  filename_win32 = "#{filename_root}-win32-#{suffix}.exe"
+
+  bucket_folder = 'studio'
+
+  upload_to_s3(
+    bucket: 'a8c-apps-public-artifacts',
+    key: "#{bucket_folder}/#{filename_mac}",
+    file: binary_path_mac,
+    if_exists: :fail,
+    auto_prefix: false
+  )
+
+  upload_to_s3(
+    bucket: 'a8c-apps-public-artifacts',
+    key: "#{bucket_folder}/#{filename_x64}",
+    file: binary_path_x64,
+    if_exists: :fail,
+    auto_prefix: false
+  )
+
+  upload_to_s3(
+    bucket: 'a8c-apps-public-artifacts',
+    key: "#{bucket_folder}/#{filename_arm64}",
+    file: binary_path_arm64,
+    if_exists: :fail,
+    auto_prefix: false
+  )
+
+  upload_to_s3(
+    bucket: 'a8c-apps-public-artifacts',
+    key: "#{bucket_folder}/#{filename_win32}",
+    file: binary_path_win32,
+    if_exists: :fail,
+    auto_prefix: false
+  )
+
+  upload_to_s3(
+    bucket: 'a8c-apps-public-artifacts',
+    key: "#{bucket_folder}/releases.json",
+    file: manifest_path,
+    if_exists: :replace,
+    auto_prefix: false
+  )
+
+  cache_paths_to_clear = [
+    "/#{bucket_folder}/releases.json"
+  ]
+
+  if update_latest
+    latest_filename_mac = "#{filename_root}-darwin-universal-latest.app.zip"
+    latest_filename_x64 = "#{filename_root}-darwin-x64-latest.app.zip"
+    latest_filename_arm64 = "#{filename_root}-darwin-arm64-latest.app.zip"
+    latest_filename_win32 = "#{filename_root}-win32-latest.exe"
+
+    upload_to_s3(
+      bucket: 'a8c-apps-public-artifacts',
+      key: "#{bucket_folder}/#{latest_filename_mac}",
+      file: binary_path_mac,
+      if_exists: :replace,
+      auto_prefix: false
+    )
+
+    upload_to_s3(
+      bucket: 'a8c-apps-public-artifacts',
+      key: "#{bucket_folder}/#{latest_filename_x64}",
+      file: binary_path_x64,
+      if_exists: :replace,
+      auto_prefix: false
+    )
+
+    upload_to_s3(
+      bucket: 'a8c-apps-public-artifacts',
+      key: "#{bucket_folder}/#{latest_filename_arm64}",
+      file: binary_path_arm64,
+      if_exists: :replace,
+      auto_prefix: false
+    )
+
+    upload_to_s3(
+      bucket: 'a8c-apps-public-artifacts',
+      key: "#{bucket_folder}/#{latest_filename_win32}",
+      file: binary_path_win32,
+      if_exists: :replace,
+      auto_prefix: false
+    )
+
+    cache_paths_to_clear += [
+      "/#{bucket_folder}/#{latest_filename_mac}",
+      "/#{bucket_folder}/#{latest_filename_x64}",
+      "/#{bucket_folder}/#{latest_filename_arm64}",
+      "/#{bucket_folder}/#{latest_filename_win32}"
+    ]
+  end
+
+  # Because we distribute via Cloudfront, we need to invalidate the `latest` build after
+  # each upload, otherwise it'll be stale.
+  clear_cloudfront_cache(
+    paths: cache_paths_to_clear,
+    commit_hash: "#{commit_hash}-#{build_number}"
+  )
+
+  # Copy the file into position to be picked up by the Buildkite agent and saved with the job
+  FileUtils.cp(binary_path_mac, File.join(builds_folder, filename_mac))
+  FileUtils.cp(binary_path_x64, File.join(builds_folder, filename_x64))
+  FileUtils.cp(binary_path_arm64, File.join(builds_folder, filename_arm64))
+  FileUtils.cp(binary_path_win32, File.join(builds_folder, filename_win32))
+
+  download_url_mac = "#{CDN_URL}/#{bucket_folder}/#{filename_mac}"
+  download_url_x64 = "#{CDN_URL}/#{bucket_folder}/#{filename_x64}"
+  download_url_arm64 = "#{CDN_URL}/#{bucket_folder}/#{filename_arm64}"
+  download_url_windows = "#{CDN_URL}/#{bucket_folder}/#{filename_win32}"
 
   buildkite_annotate(
     context: 'cdn-link',
     style: 'info',
-    message: "🔗 Build available for Mac in [Intel](#{download_url_x64}), [Apple Silicon](#{download_url_arm64}), and [Universal](#{download_url_mac}) flavors, and for [Windows](#{download_url_win32})"
+    message: "🔗 Build available for Mac in [Intel](#{download_url_x64}), [Apple Silicon](#{download_url_arm64}), and [Universal](#{download_url_mac}) architectures, and for [Windows](#{download_url_win32})."
   )
+
+  # Return the download URLs so callers can use them for further processing or messaging.
+  {
+    mac_universal: download_url_mac,
+    x64: download_url_x64,
+    arm64: download_url_arm64,
+    windows: download_url_windows
+  }
 end
 
 def clear_cloudfront_cache(paths:, commit_hash:)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -94,54 +94,55 @@ def distribute_builds(commit_hash:, build_number:, release_tag: nil)
   # If we are distributing a build without a tag, i.e. a development build, we also want to update the latest build reference for distribution.
   update_latest = release_tag.nil?
   suffix = release_tag.nil? ? commit_hash : release_tag
+  filename_root = 'studio'
+  bucket_folder = 'studio'
 
-  binary_path_mac = File.join(BUILDS_FOLDER, 'Studio-darwin-universal', 'Studio.app.zip')
-  binary_path_x64 = File.join(BUILDS_FOLDER, 'Studio-darwin-x64', 'Studio.app.zip')
-  binary_path_arm64 = File.join(BUILDS_FOLDER, 'Studio-darwin-arm64', 'Studio.app.zip')
-  binary_path_win32 = File.join(BUILDS_FOLDER, 'make', 'squirrel.windows', 'x64', 'studio-setup.exe')
+  builds = {
+    mac_universal: {
+      binary_path: File.join(BUILDS_FOLDER, 'Studio-darwin-universal', 'Studio.app.zip'),
+      filename_core: 'darwin-universal',
+      extension: 'app.zip',
+      name: 'Mac Universal'
+    },
+    x64: {
+      binary_path: File.join(BUILDS_FOLDER, 'Studio-darwin-x64', 'Studio.app.zip'),
+      filename_core: 'darwin-x64',
+      extension: 'app.zip',
+      name: 'Mac Intel'
+    },
+    arm64: {
+      binary_path: File.join(BUILDS_FOLDER, 'Studio-darwin-arm64', 'Studio.app.zip'),
+      filename_core: 'darwin-arm64',
+      extension: 'app.zip',
+      name: 'Mac Apple Silicon'
+    },
+    windows: {
+      binary_path: File.join(BUILDS_FOLDER, 'make', 'squirrel.windows', 'x64', 'studio-setup.exe'),
+      filename_core: 'win32',
+      extension: 'exe',
+      name: 'Windows'
+    }
+  }
+
+  # Add computed fields
+  builds.each do |_, value|
+    value[:filename] = "#{filename_root}-#{value[:filename_core]}-#{suffix}-#{value[:extension]}"
+    value[:cdn_url] = "#{CDN_URL}/#{bucket_folder}/#{value[:filename]}"
+  end
 
   manifest_path = File.join(BUILDS_FOLDER, 'releases.json')
 
-  filename_root = 'studio'
-  filename_mac = "#{filename_root}-darwin-universal-#{commit_hash}.app.zip"
-  filename_x64   = "#{filename_root}-darwin-x64-#{suffix}.app.zip"
-  filename_arm64 = "#{filename_root}-darwin-arm64-#{suffix}.app.zip"
-  filename_win32 = "#{filename_root}-win32-#{suffix}.exe"
-
   bucket_name = 'a8c-apps-public-artifacts'
-  bucket_folder = 'studio'
 
-  upload_to_s3(
-    bucket: bucket_name,
-    key: "#{bucket_folder}/#{filename_mac}",
-    file: binary_path_mac,
-    if_exists: :fail,
-    auto_prefix: false
-  )
-
-  upload_to_s3(
-    bucket: bucket_name,
-    key: "#{bucket_folder}/#{filename_x64}",
-    file: binary_path_x64,
-    if_exists: :fail,
-    auto_prefix: false
-  )
-
-  upload_to_s3(
-    bucket: bucket_name,
-    key: "#{bucket_folder}/#{filename_arm64}",
-    file: binary_path_arm64,
-    if_exists: :fail,
-    auto_prefix: false
-  )
-
-  upload_to_s3(
-    bucket: bucket_name,
-    key: "#{bucket_folder}/#{filename_win32}",
-    file: binary_path_win32,
-    if_exists: :fail,
-    auto_prefix: false
-  )
+  builds.each_value do |build|
+    upload_to_s3(
+      bucket: bucket_name,
+      key: "#{bucket_folder}/#{build[:filename]}",
+      file: build[:binary_path],
+      if_exists: :fail,
+      auto_prefix: false
+    )
+  end
 
   upload_to_s3(
     bucket: bucket_name,
@@ -156,49 +157,19 @@ def distribute_builds(commit_hash:, build_number:, release_tag: nil)
   ]
 
   if update_latest
-    latest_filename_mac = "#{filename_root}-darwin-universal-latest.app.zip"
-    latest_filename_x64 = "#{filename_root}-darwin-x64-latest.app.zip"
-    latest_filename_arm64 = "#{filename_root}-darwin-arm64-latest.app.zip"
-    latest_filename_win32 = "#{filename_root}-win32-latest.exe"
+    builds.each_value do |build|
+      filename = "#{filename_root}-#{build[:filename]}-latest.#{build[:extension]}"
 
-    upload_to_s3(
-      bucket: bucket_name,
-      key: "#{bucket_folder}/#{latest_filename_mac}",
-      file: binary_path_mac,
-      if_exists: :replace,
-      auto_prefix: false
-    )
+      upload_to_s3(
+        bucket: bucket_name,
+        key: "#{bucket_folder}/#{filename}",
+        file: build[:binary_path],
+        if_exists: :replace,
+        auto_prefix: false
+      )
 
-    upload_to_s3(
-      bucket: bucket_name,
-      key: "#{bucket_folder}/#{latest_filename_x64}",
-      file: binary_path_x64,
-      if_exists: :replace,
-      auto_prefix: false
-    )
-
-    upload_to_s3(
-      bucket: bucket_name,
-      key: "#{bucket_folder}/#{latest_filename_arm64}",
-      file: binary_path_arm64,
-      if_exists: :replace,
-      auto_prefix: false
-    )
-
-    upload_to_s3(
-      bucket: bucket_name,
-      key: "#{bucket_folder}/#{latest_filename_win32}",
-      file: binary_path_win32,
-      if_exists: :replace,
-      auto_prefix: false
-    )
-
-    cache_paths_to_clear += [
-      "/#{bucket_folder}/#{latest_filename_mac}",
-      "/#{bucket_folder}/#{latest_filename_x64}",
-      "/#{bucket_folder}/#{latest_filename_arm64}",
-      "/#{bucket_folder}/#{latest_filename_win32}"
-    ]
+      cache_paths_to_clear += ["/#{bucket_folder}/#{filename}"]
+    end
   end
 
   # Because we distribute via Cloudfront, we need to invalidate the manifest
@@ -209,30 +180,20 @@ def distribute_builds(commit_hash:, build_number:, release_tag: nil)
     commit_hash: "#{commit_hash}-#{build_number}"
   )
 
-  # Copy the file into position to be picked up by the Buildkite agent and saved with the job
-  FileUtils.cp(binary_path_mac, File.join(BUILDS_FOLDER, filename_mac))
-  FileUtils.cp(binary_path_x64, File.join(BUILDS_FOLDER, filename_x64))
-  FileUtils.cp(binary_path_arm64, File.join(BUILDS_FOLDER, filename_arm64))
-  FileUtils.cp(binary_path_win32, File.join(BUILDS_FOLDER, filename_win32))
-
-  download_url_mac = "#{CDN_URL}/#{bucket_folder}/#{filename_mac}"
-  download_url_x64 = "#{CDN_URL}/#{bucket_folder}/#{filename_x64}"
-  download_url_arm64 = "#{CDN_URL}/#{bucket_folder}/#{filename_arm64}"
-  download_url_windows = "#{CDN_URL}/#{bucket_folder}/#{filename_win32}"
+  # When publishing a relesea build, copy the file into position to be picked
+  # up by the Buildkite agent and saved with the job.
+  builds.each do |build|
+    FileUtils.cp(build[:binary_path], File.join(BUILDS_FOLDER, "#{build[:filename]}-#{suffix}-#{build[:extension]}"))
+  end
 
   buildkite_annotate(
     context: 'cdn-link',
     style: 'info',
-    message: "🔗 Build available for Mac in [Intel](#{download_url_x64}), [Apple Silicon](#{download_url_arm64}), and [Universal](#{download_url_mac}) architectures, and for [Windows](#{download_url_win32})."
+    message: "🔗 Build available for #{builds.each_value.map { |build| "[#{build[:name]}](#{build[:cdn_url]})" }.join(', ')}"
   )
 
   # Return the download URLs so callers can use them for further processing or messaging.
-  {
-    mac_universal: download_url_mac,
-    x64: download_url_x64,
-    arm64: download_url_arm64,
-    windows: download_url_windows
-  }
+  builds.map { |build| build[:cdn_url] }
 end
 
 def clear_cloudfront_cache(paths:, commit_hash:)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -56,25 +56,12 @@ end
 
 desc 'Ship the binary to internal testers'
 lane :distribute_dev_build do |_options|
-  commit_metadata = last_git_commit
-  commit_hash = commit_metadata[:commit_hash]
-  build_number = get_required_env('BUILDKITE_BUILD_NUMBER')
-
-  distribute_builds(commit_hash:, build_number:)
+  distribute_builds
 end
 
 desc 'Ship release build'
 lane :distribute_release_build do |_options|
-  commit_metadata = last_git_commit
-  commit_hash = commit_metadata[:commit_hash]
-  release_tag = get_required_env('BUILDKITE_TAG')
-  build_number = get_required_env('BUILDKITE_BUILD_NUMBER')
-
-  urls = distribute_builds(
-    commit_hash:,
-    build_number:,
-    release_tag:
-  )
+  builds = distribute_builds(release_tag: get_required_env('BUILDKITE_TAG'))
 
   slack(
     username: 'CI Bot',
@@ -84,13 +71,17 @@ lane :distribute_release_build do |_options|
     success: true,
     slack_url: get_required_env('SLACK_WEBHOOK'),
     payload: {
-      ':studio-app-icon-mac: Release available for': "Available for Mac in [Intel](#{urls[:x64]}), [Apple Silicon](#{urls[:arm64]}) and [Universal](#{urls[:mac_universal]}) architectures, and for [Windows](#{urls[:windows]})."
+      ':studio-app-icon-mac: Release available for': builds.each_value.map { |b| "[#{b[:name]}](#{b[:cdn_url]})" }.join(', ')
     },
     default_payloads: []
   )
 end
 
-def distribute_builds(commit_hash:, build_number:, release_tag: nil)
+def distribute_builds(
+  commit_hash: last_git_commit[:commit_hash],
+  build_number: get_required_env('BUILDKITE_BUILD_NUMBER'),
+  release_tag: nil
+)
   # If we are distributing a build without a tag, i.e. a development build, we also want to update the latest build reference for distribution.
   update_latest = release_tag.nil?
   suffix = release_tag.nil? ? commit_hash : release_tag
@@ -186,7 +177,7 @@ def distribute_builds(commit_hash:, build_number:, release_tag: nil)
 
   # When publishing a relesea build, copy the file into position to be picked
   # up by the Buildkite agent and saved with the job.
-  builds.each do |build|
+  builds.each_value do |build|
     FileUtils.cp(build[:binary_path], File.join(BUILDS_FOLDER, "#{build[:filename]}-#{suffix}-#{build[:extension]}"))
   end
 
@@ -196,8 +187,8 @@ def distribute_builds(commit_hash:, build_number:, release_tag: nil)
     message: "🔗 Build available for #{builds.each_value.map { |build| "[#{build[:name]}](#{build[:cdn_url]})" }.join(', ')}"
   )
 
-  # Return the download URLs so callers can use them for further processing or messaging.
-  builds.map { |build| build[:cdn_url] }
+  # Return the builds data so callers can use them for further processing or messaging.
+  builds
 end
 
 def clear_cloudfront_cache(paths:, commit_hash:)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -108,10 +108,11 @@ def distribute_builds(commit_hash:, build_number:, release_tag: nil)
   filename_arm64 = "#{filename_root}-darwin-arm64-#{suffix}.app.zip"
   filename_win32 = "#{filename_root}-win32-#{suffix}.exe"
 
+  bucket_name = 'a8c-apps-public-artifacts'
   bucket_folder = 'studio'
 
   upload_to_s3(
-    bucket: 'a8c-apps-public-artifacts',
+    bucket: bucket_name,
     key: "#{bucket_folder}/#{filename_mac}",
     file: binary_path_mac,
     if_exists: :fail,
@@ -119,7 +120,7 @@ def distribute_builds(commit_hash:, build_number:, release_tag: nil)
   )
 
   upload_to_s3(
-    bucket: 'a8c-apps-public-artifacts',
+    bucket: bucket_name,
     key: "#{bucket_folder}/#{filename_x64}",
     file: binary_path_x64,
     if_exists: :fail,
@@ -127,7 +128,7 @@ def distribute_builds(commit_hash:, build_number:, release_tag: nil)
   )
 
   upload_to_s3(
-    bucket: 'a8c-apps-public-artifacts',
+    bucket: bucket_name,
     key: "#{bucket_folder}/#{filename_arm64}",
     file: binary_path_arm64,
     if_exists: :fail,
@@ -135,7 +136,7 @@ def distribute_builds(commit_hash:, build_number:, release_tag: nil)
   )
 
   upload_to_s3(
-    bucket: 'a8c-apps-public-artifacts',
+    bucket: bucket_name,
     key: "#{bucket_folder}/#{filename_win32}",
     file: binary_path_win32,
     if_exists: :fail,
@@ -143,7 +144,7 @@ def distribute_builds(commit_hash:, build_number:, release_tag: nil)
   )
 
   upload_to_s3(
-    bucket: 'a8c-apps-public-artifacts',
+    bucket: bucket_name,
     key: "#{bucket_folder}/releases.json",
     file: manifest_path,
     if_exists: :replace,
@@ -161,7 +162,7 @@ def distribute_builds(commit_hash:, build_number:, release_tag: nil)
     latest_filename_win32 = "#{filename_root}-win32-latest.exe"
 
     upload_to_s3(
-      bucket: 'a8c-apps-public-artifacts',
+      bucket: bucket_name,
       key: "#{bucket_folder}/#{latest_filename_mac}",
       file: binary_path_mac,
       if_exists: :replace,
@@ -169,7 +170,7 @@ def distribute_builds(commit_hash:, build_number:, release_tag: nil)
     )
 
     upload_to_s3(
-      bucket: 'a8c-apps-public-artifacts',
+      bucket: bucket_name,
       key: "#{bucket_folder}/#{latest_filename_x64}",
       file: binary_path_x64,
       if_exists: :replace,
@@ -177,7 +178,7 @@ def distribute_builds(commit_hash:, build_number:, release_tag: nil)
     )
 
     upload_to_s3(
-      bucket: 'a8c-apps-public-artifacts',
+      bucket: bucket_name,
       key: "#{bucket_folder}/#{latest_filename_arm64}",
       file: binary_path_arm64,
       if_exists: :replace,
@@ -185,7 +186,7 @@ def distribute_builds(commit_hash:, build_number:, release_tag: nil)
     )
 
     upload_to_s3(
-      bucket: 'a8c-apps-public-artifacts',
+      bucket: bucket_name,
       key: "#{bucket_folder}/#{latest_filename_win32}",
       file: binary_path_win32,
       if_exists: :replace,

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -201,8 +201,9 @@ def distribute_builds(commit_hash:, build_number:, release_tag: nil)
     ]
   end
 
-  # Because we distribute via Cloudfront, we need to invalidate the `latest` build after
-  # each upload, otherwise it'll be stale.
+  # Because we distribute via Cloudfront, we need to invalidate the manifest
+  # and the latest build (if building for release) after each upload, otherwise
+  # it'll be stale.
   clear_cloudfront_cache(
     paths: cache_paths_to_clear,
     commit_hash: "#{commit_hash}-#{build_number}"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -42,8 +42,6 @@ lane :set_up_signing do |_options|
     api_key_path: APPLE_API_KEY_PATH,
     readonly: true
   )
-
-  puts lane_context[SharedValues::MATCH_PROVISIONING_PROFILE_MAPPING]
 end
 
 desc 'Notarize the compiled binary'

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -11,6 +11,7 @@ UI.user_error!('Please run fastlane via `bundle exec`') unless FastlaneCore::Hel
 ########################################################################
 PROJECT_ROOT_FOLDER = File.dirname(File.expand_path(__dir__))
 SECRETS_FOLDER = File.join(Dir.home, '.configure', 'studio', 'secrets')
+BUILDS_FOLDER = File.join(PROJECT_ROOT_FOLDER, 'out')
 
 APPLE_TEAM_ID = 'PZYM8XX95Q'
 APPLE_BUNDLE_IDENTIFIER = 'com.automattic.studio'
@@ -47,7 +48,7 @@ end
 
 desc 'Notarize the compiled binary'
 lane :notarize_binary do |_options|
-  Dir[File.join(PROJECT_ROOT_FOLDER, 'out', '**', 'Studio.app')].each do |path|
+  Dir[File.join(BUILDS_FOLDER, '**', 'Studio.app')].each do |path|
     notarize(
       package: path,
       api_key_path: APPLE_API_KEY_PATH
@@ -96,14 +97,12 @@ def distribute_builds(commit_hash:, build_number:, release_tag: nil)
   update_latest = release_tag.nil?
   suffix = release_tag.nil? ? commit_hash : release_tag
 
-  builds_folder = File.join(PROJECT_ROOT_FOLDER, 'out')
+  binary_path_mac = File.join(BUILDS_FOLDER, 'Studio-darwin-universal', 'Studio.app.zip')
+  binary_path_x64 = File.join(BUILDS_FOLDER, 'Studio-darwin-x64', 'Studio.app.zip')
+  binary_path_arm64 = File.join(BUILDS_FOLDER, 'Studio-darwin-arm64', 'Studio.app.zip')
+  binary_path_win32 = File.join(BUILDS_FOLDER, 'make', 'squirrel.windows', 'x64', 'studio-setup.exe')
 
-  binary_path_mac = File.join(builds_folder, 'out', 'Studio-darwin-universal', 'Studio.app.zip')
-  binary_path_x64 = File.join(builds_folder, 'Studio-darwin-x64', 'Studio.app.zip')
-  binary_path_arm64 = File.join(builds_folder, 'Studio-darwin-arm64', 'Studio.app.zip')
-  binary_path_win32 = File.join(builds_folder, 'make', 'squirrel.windows', 'x64', 'studio-setup.exe')
-
-  manifest_path = File.join(builds_folder, 'releases.json')
+  manifest_path = File.join(BUILDS_FOLDER, 'releases.json')
 
   filename_root = 'studio'
   filename_mac = "#{filename_root}-darwin-universal-#{commit_hash}.app.zip"
@@ -211,10 +210,10 @@ def distribute_builds(commit_hash:, build_number:, release_tag: nil)
   )
 
   # Copy the file into position to be picked up by the Buildkite agent and saved with the job
-  FileUtils.cp(binary_path_mac, File.join(builds_folder, filename_mac))
-  FileUtils.cp(binary_path_x64, File.join(builds_folder, filename_x64))
-  FileUtils.cp(binary_path_arm64, File.join(builds_folder, filename_arm64))
-  FileUtils.cp(binary_path_win32, File.join(builds_folder, filename_win32))
+  FileUtils.cp(binary_path_mac, File.join(BUILDS_FOLDER, filename_mac))
+  FileUtils.cp(binary_path_x64, File.join(BUILDS_FOLDER, filename_x64))
+  FileUtils.cp(binary_path_arm64, File.join(BUILDS_FOLDER, filename_arm64))
+  FileUtils.cp(binary_path_win32, File.join(BUILDS_FOLDER, filename_win32))
 
   download_url_mac = "#{CDN_URL}/#{bucket_folder}/#{filename_mac}"
   download_url_x64 = "#{CDN_URL}/#{bucket_folder}/#{filename_x64}"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -125,12 +125,14 @@ def distribute_builds(commit_hash:, build_number:, release_tag: nil)
   }
 
   # Add computed fields
-  builds.each do |_, value|
-    value[:filename] = "#{filename_root}-#{value[:filename_core]}-#{suffix}-#{value[:extension]}"
-    value[:cdn_url] = "#{CDN_URL}/#{bucket_folder}/#{value[:filename]}"
+  assemble_filename = lambda do |build, filename_suffix|
+    "#{filename_root}-#{build[:filename_core]}-#{filename_suffix}.#{build[:extension]}"
+  end
+  builds.each_value do |build|
+    build[:filename] = assemble_filename.call(build, suffix)
+    build[:cdn_url] = "#{CDN_URL}/#{bucket_folder}/#{build[:filename]}"
   end
 
-  manifest_path = File.join(BUILDS_FOLDER, 'releases.json')
 
   bucket_name = 'a8c-apps-public-artifacts'
 
@@ -144,10 +146,11 @@ def distribute_builds(commit_hash:, build_number:, release_tag: nil)
     )
   end
 
+  manifest_name = 'release.json'
   upload_to_s3(
     bucket: bucket_name,
-    key: "#{bucket_folder}/releases.json",
-    file: manifest_path,
+    key: "#{bucket_folder}/#{manifest_name}",
+    file: File.join(BUILDS_FOLDER, manifest_name),
     if_exists: :replace,
     auto_prefix: false
   )
@@ -158,17 +161,18 @@ def distribute_builds(commit_hash:, build_number:, release_tag: nil)
 
   if update_latest
     builds.each_value do |build|
-      filename = "#{filename_root}-#{build[:filename]}-latest.#{build[:extension]}"
+      filename = assemble_filename.call(build, 'latest')
+      key = "#{bucket_folder}/#{filename}"
 
       upload_to_s3(
         bucket: bucket_name,
-        key: "#{bucket_folder}/#{filename}",
+        key:,
         file: build[:binary_path],
         if_exists: :replace,
         auto_prefix: false
       )
 
-      cache_paths_to_clear += ["/#{bucket_folder}/#{filename}"]
+      cache_paths_to_clear.append("/#{key}")
     end
   end
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Proposed Changes

@wojtekn mentioned that CI builds on `trunk` included the Windows binary, but builds from tags didn't. This PR addresses the issue by DRYing the automation that uploads binaries.

**Update:** I naively assumed the only thing to do was to upload existing files and add links. I was wrong. This PR is now stacked on top of the necessary work that @jkmassel did in #114. Goes to show one should find ways to test things locally...

What remains of this PR is centralizing the builds information in Fastlane in a Hash, so that we can iterate on each build for the S3 uploads etc, instead of copy pasting the call. While we might not need to add new builds, I still think this is a maintenability improvement.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Unfortunately, the only true way to test this is to merge it and check the artifacts, CI annotations, and Slack messages.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors? – N.A.
