### PR TITLE
Expand minimum window height with title bar height on Windows

### DIFF
--- a/src/main-window.ts
+++ b/src/main-window.ts
@@ -113,6 +113,7 @@ function getOSWindowOptions(): Partial< BrowserWindowConstructorOptions > {
 					symbolColor: 'white',
 					height: WINDOWS_TITLEBAR_HEIGHT,
 				},
+				minHeight: MAIN_MIN_HEIGHT + WINDOWS_TITLEBAR_HEIGHT,
 			};
 
 		default:


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to 7076-gh-automattic/dotcom-forge.

## Proposed Changes

- Expand the minimum window's height with Windows title bar height. This would ensure that the app's content won't overflow.

| Before| After |
|--------|--------|
| <img src=https://github.com/Automattic/studio/assets/14905380/b06f4a02-bfec-4c23-9d3d-3d0a2fe3aee8>| <img src=https://github.com/Automattic/studio/assets/14905380/b5d066a2-df8a-4c51-81d7-f5ac695cbc29>| 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Open the app on Windows.
2. Navigate to Settings tab.
3. Observe that the content doesn't overflow the app's frame (i.e. no scroll is displayed).
4. Observe that the "Delete site" button can be clicked.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
