### PR TITLE
Add Windows title bar component to the onboarding screen

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -17,9 +17,13 @@ export default function App() {
 
 	if ( needsOnboarding ) {
 		return (
-			<div className="h-screen backdrop-blur-3xl app-drag-region select-none flex flex-grow">
+			<VStack
+				className={ cx( 'h-screen backdrop-blur-3xl app-drag-region select-none' ) }
+				spacing="0"
+			>
+				{ isWindows() && <WindowsTitlebar className="h-titlebar-win flex-shrink-0" /> }
 				<Onboarding />
-			</div>
+			</VStack>
 		);
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to 6992-gh-automattic/dotcom-forge.

## Proposed Changes

- Add the `WindowsTitlebar` component to the onboarding screen when running the app on Windows.

| Windows | macOS |
|--------|--------|
| <img width=900 src="https://github.com/Automattic/studio/assets/14905380/8f251a48-d35e-40a6-a1a7-4b6cbdc9abb9">| <img width=900 src="https://github.com/Automattic/studio/assets/14905380/9b7a9c44-4d46-4c47-9e19-411a638c3a57"> | 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Preparation:**
- Delete all sites. This can be done by simply deleting the folder `$HOME/Studio`).

### Windows
- Open the app.
- Observe the onboarding screen is displayed.
- Observe the title bar is displayed containing the app's icon and name.

### macOS
- Open the app.
- Observe the onboarding screen is displayed.
- Observe there's no title bar, only the OS buttons to close/minimize/maximize.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
