### PR TITLE
Remove gap on the right side of Overview tab

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -40,9 +40,6 @@ export default function App() {
 			<HStack spacing="0" alignment="left" className="flex-grow">
 				<MainSidebar className="basis-52 flex-shrink-0 h-full" />
 				<main
-					style={ {
-						scrollbarGutter: 'stable',
-					} }
 					data-testid="site-content"
 					className="py-8 pr-8 bg-white overflow-y-auto h-full flex-grow rounded-chrome"
 				>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Resolves Automattic/dotcom-forge#6993

## Proposed Changes

Removes gap on right side of Windows screen due scrollbarGutter style values.


## Testing Instructions

1. Start Studio and navigate to Overview screen
2. For both platforms, observe gap on right side of screen is not present

#### Before
<img width="50%" alt="Screenshot_2024-05-14_at_10_59_31 pm" src="https://github.com/Automattic/studio/assets/643285/9ad1e112-bbb2-423d-aff0-bb3dba5d8faa">


#### After
Windows | macOS
-|-
<img width="930" alt="Screenshot 2024-05-14 at 10 50 51 pm" src="https://github.com/Automattic/studio/assets/643285/538a735b-1fcb-4097-ae11-c4cb18c8ee0b"> |  <img width="940" alt="Screenshot 2024-05-14 at 10 51 40 pm" src="https://github.com/Automattic/studio/assets/643285/736d581b-e34f-44e9-b89d-f07c93b28485">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
