### PR TITLE
Fix crash during Slack notification for Release builds

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -74,7 +74,7 @@ steps:
       install_npm_packages
       node ./scripts/generate-releases-manifest.mjs
 
-      echo "--- :fastlane: Distributing Dev Build"
+      echo "--- :fastlane: Distributing Dev Builds"
       install_gems
       bundle exec fastlane distribute_dev_build
     agents:
@@ -128,7 +128,7 @@ steps:
       install_npm_packages
       node ./scripts/generate-releases-manifest.mjs
 
-      echo "--- :fastlane: Distributing Dev Build"
+      echo "--- :fastlane: Distributing Release Builds"
       install_gems
       bundle exec fastlane distribute_release_build
     agents:

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -61,7 +61,8 @@ end
 
 desc 'Ship release build'
 lane :distribute_release_build do |_options|
-  builds = distribute_builds(release_tag: get_required_env('BUILDKITE_TAG'))
+  release_tag = get_required_env('BUILDKITE_TAG')
+  builds = distribute_builds(release_tag: release_tag)
 
   slack(
     username: 'CI Bot',


### PR DESCRIPTION
See: p1715695016251579-slack-C02KLTL3MKM

This should fix a crash in the `distribute_release_build` lane where the call to the `slack(…)` action referenced a `release_tag` variable that was not defined, and thus made the `Fastfile` crash on CI when trying to send the Slack notif as the last step of the pipeline.

## Testing Instructions

Won't really be able to properly test it without doing a new tag and release, so let's wait for that to happen and confirm then that this  fixed the issue entirely.