### PR TITLE
fix: Activate event window creation awaits app ready state

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -250,7 +250,7 @@ async function appBoot() {
 		// On OS X it's common to re-create a window in the app when the
 		// dock icon is clicked and there are no other windows open.
 		if ( BrowserWindow.getAllWindows().length === 0 ) {
-			createMainWindow();
+			app.whenReady().then( createMainWindow );
 		}
 	} );
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -250,7 +250,7 @@ async function appBoot() {
 		// On OS X it's common to re-create a window in the app when the
 		// dock icon is clicked and there are no other windows open.
 		if ( BrowserWindow.getAllWindows().length === 0 ) {
-			app.whenReady().then( createMainWindow );
+			app.whenReady().then( createMainWindow ).catch( Sentry.captureException );
 		}
 	} );
 }

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -2,9 +2,11 @@
  * @jest-environment node
  */
 import fs from 'fs';
+import { createMainWindow } from '../main-window';
 
 jest.mock( 'fs' );
 jest.mock( 'file-stream-rotator' );
+jest.mock( '../main-window' );
 
 const mockUserData = {
 	sites: [],
@@ -65,5 +67,35 @@ it( 'should handle authentication deep links', () => {
 		} );
 
 		Object.defineProperty( process, 'platform', { value: originalProcessPlatform } );
+	} );
+} );
+
+it( 'should await the app ready state before creating a window for activate events', () => {
+	jest.isolateModules( async () => {
+		// eslint-disable-next-line @typescript-eslint/no-empty-function
+		let activate: ( ...args: any[] ) => void = () => {};
+		jest.doMock( 'electron', () => {
+			const electron = jest.genMockFromModule( 'electron' ) as typeof import('electron');
+			return {
+				...electron,
+				app: {
+					...electron.app,
+					whenReady: jest.fn( () => Promise.resolve() ),
+					on: jest.fn( ( event, callback ) => {
+						if ( event === 'activate' ) {
+							activate = callback;
+						}
+					} ),
+				},
+			};
+		} );
+		require( '../index' );
+
+		activate();
+
+		expect( createMainWindow ).not.toHaveBeenCalled();
+		// Await the mocked `whenReady` promise resolution
+		await new Promise( process.nextTick );
+		expect( createMainWindow ).toHaveBeenCalled();
 	} );
 } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/7158.

## Proposed Changes

Await the app "ready" state before creating a window within the app "activate"
event handler.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

> [!NOTE]
> The test instructions are a contrived example as the original crash is the result of a race condition between the `ready` and `activate` event handler logic. The instructions rely upon intentionally creating a window within the `will-finish-launching` event handler, which is guaranteed to run _before_ the `ready` event. 

<details><summary>Contrived error diff</summary>

```diff
diff --git a/src/index.ts b/src/index.ts
index 692138e..95272a7 100644
--- a/src/index.ts
+++ b/src/index.ts
@@ -246,7 +246,7 @@ async function appBoot() {
 		stopAllServersOnQuit();
 	} );
 
-	app.on( 'activate', () => {
+	app.on( 'will-finish-launching', () => {
 		// On OS X it's common to re-create a window in the app when the
 		// dock icon is clicked and there are no other windows open.
 		if ( BrowserWindow.getAllWindows().length === 0 ) {

```

</details>

<details><summary>Example window error</summary>

<img width="328" alt="window-error" src="https://github.com/Automattic/studio/assets/438664/03df414a-9143-462b-9760-43c688759610">


</details>

1. Check out the `trunk` branch.
1. Apply the provided diff (see above).
1. Launch the app with `npm start`.
1. Note the app launches with an error.
1. Check out the proposed changes.
1. Repeat steps 2-3.
1. Verify the app launches _without_ an error.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
