### PR TITLE
Update site screenshots  to hide scrollbars on Windows

### DIFF
--- a/src/screenshot-window.ts
+++ b/src/screenshot-window.ts
@@ -20,7 +20,16 @@ export function createScreenshotWindow( captureUrl: string ) {
 
 	const waitForCapture = async () => {
 		await finishedLoading;
-		await window.webContents.insertCSS( '::-webkit-scrollbar { display: none; }' );
+		await window.webContents.insertCSS( `
+			body {
+				overflow: hidden;
+				height: 100vh;
+			}
+			::-webkit-scrollbar {
+				display: none;
+			}
+		` );
+
 		await new Promise( ( resolve ) => setTimeout( resolve, 500 ) );
 		return window.webContents.capturePage();
 	};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Resolves Automattic/dotcom-forge#7077

## Proposed Changes

Updates CSS specificity in `createScreenshotWindow` `waitForCapture` to further hide scrollbars on Windows

## Testing Instructions 

1. Create site, and change theme to Seedlet
2. Start site on Windows
3. Observe that screenshot does not contain scrollbars (on macOS, behavior should be unchanged)

> [!NOTE]
> This issue is difficult to replicate consistently. While this change should improve the behavior of not displaying scrollbars in screenshots on Windows, there may be a separate issue where either the theme still overrides the injected CSS, or the screenshot is captured before the extra CSS is injected.

Before | After
-|-
<img width="892" alt="before" src="https://github.com/Automattic/studio/assets/643285/55e2ef10-ed23-4533-8006-7498297d5c4a"> | <img width="894" alt="after" src="https://github.com/Automattic/studio/assets/643285/db3020a4-8db4-45bb-9341-23c4bd4779c4">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
