### PR TITLE
feat: Automatic sqlite-database-integration upgrade

### DIFF
--- a/scripts/download-wp-server-files.ts
+++ b/scripts/download-wp-server-files.ts
@@ -15,7 +15,7 @@ const FILES_TO_DOWNLOAD = [
 	{
 		name: 'sqlite',
 		description: 'SQLite files',
-		url: 'https://codeload.github.com/WordPress/sqlite-database-integration/zip/refs/heads/main',
+		url: 'https://downloads.wordpress.org/plugin/sqlite-database-integration.zip',
 	},
 ];
 

--- a/src/__mocks__/fs.ts
+++ b/src/__mocks__/fs.ts
@@ -25,6 +25,16 @@ fs.__setFileContents = ( path: string, fileContents: string | string[] ) => {
 	}
 );
 
+( fs.readFileSync as jest.Mock ).mockImplementation( ( path: string ): string => {
+	const fileContents = mockFiles[ path ];
+
+	if ( typeof fileContents === 'string' ) {
+		return fileContents;
+	}
+
+	return '';
+} );
+
 ( fs.promises.readdir as jest.Mock ).mockImplementation(
 	async ( path: string ): Promise< Array< string > > => {
 		const dirContents = mockFiles[ path ];

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -27,7 +27,10 @@ import { createPassword } from './lib/passwords';
 import { phpGetThemeDetails } from './lib/php-get-theme-details';
 import { sanitizeForLogging } from './lib/sanitize-for-logging';
 import { sortSites } from './lib/sort-sites';
-import { isSqliteInstallationOutdated } from './lib/sqlite-versions';
+import {
+	isSqliteInstallationOutdated,
+	removeLegacySqliteIntegrationPlugin,
+} from './lib/sqlite-versions';
 import { writeLogToFile, type LogLevel } from './logging';
 import { SiteServer, createSiteWorkingDirectory } from './site-server';
 import { DEFAULT_SITE_PATH, getServerFilesPath, getSiteThumbnailPath } from './storage/paths';
@@ -107,6 +110,8 @@ async function setupSqliteIntegration( path: string ) {
 	);
 	const sqlitePluginPath = nodePath.join( wpContentPath, 'mu-plugins', SQLITE_FILENAME );
 	copySync( nodePath.join( getServerFilesPath(), SQLITE_FILENAME ), sqlitePluginPath );
+
+	await removeLegacySqliteIntegrationPlugin( sqlitePluginPath );
 }
 
 export async function createSite(

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -27,6 +27,7 @@ import { createPassword } from './lib/passwords';
 import { phpGetThemeDetails } from './lib/php-get-theme-details';
 import { sanitizeForLogging } from './lib/sanitize-for-logging';
 import { sortSites } from './lib/sort-sites';
+import { isSqliteInstallationOutdated } from './lib/sqlite-versions';
 import { writeLogToFile, type LogLevel } from './logging';
 import { SiteServer, createSiteWorkingDirectory } from './site-server';
 import { DEFAULT_SITE_PATH, getServerFilesPath, getSiteThumbnailPath } from './storage/paths';
@@ -105,7 +106,7 @@ async function setupSqliteIntegration( path: string ) {
 		)
 	);
 	const sqlitePluginPath = nodePath.join( wpContentPath, 'mu-plugins', SQLITE_FILENAME );
-	await copySync( nodePath.join( getServerFilesPath(), SQLITE_FILENAME ), sqlitePluginPath );
+	copySync( nodePath.join( getServerFilesPath(), SQLITE_FILENAME ), sqlitePluginPath );
 }
 
 export async function createSite(
@@ -214,6 +215,14 @@ export async function startServer(
 	const server = SiteServer.get( id );
 	if ( ! server ) {
 		return null;
+	}
+
+	if (
+		await isSqliteInstallationOutdated(
+			`${ server.details.path }/wp-content/mu-plugins/${ SQLITE_FILENAME }`
+		)
+	) {
+		await setupSqliteIntegration( server.details.path );
 	}
 
 	const parentWindow = BrowserWindow.fromWebContents( event.sender );

--- a/src/lib/sqlite-versions.ts
+++ b/src/lib/sqlite-versions.ts
@@ -1,5 +1,4 @@
 import path from 'path';
-import * as Sentry from '@sentry/electron/main';
 import fs from 'fs-extra';
 import semver from 'semver';
 import { downloadSqliteIntegrationPlugin } from '../../vendor/wp-now/src/download';

--- a/src/lib/sqlite-versions.ts
+++ b/src/lib/sqlite-versions.ts
@@ -24,9 +24,8 @@ export async function isSqliteInstallationOutdated( installationPath: string ): 
 		const installedVersion = getSqliteVersionFromInstallation( installationPath );
 		const latestVersion = await getLatestSqliteVersion();
 		return semver.lt( installedVersion, latestVersion );
-	} catch ( error ) {
-		Sentry.captureException( error );
-		return true;
+	} catch ( _error ) {
+		return false;
 	}
 }
 

--- a/src/lib/sqlite-versions.ts
+++ b/src/lib/sqlite-versions.ts
@@ -1,0 +1,52 @@
+import path from 'path';
+import fs from 'fs-extra';
+import semver from 'semver';
+import { downloadSqliteIntegrationPlugin } from '../../vendor/wp-now/src/download';
+import getSqlitePath from '../../vendor/wp-now/src/get-sqlite-path';
+
+export async function updateLatestSqliteVersion() {
+	let shouldOverwrite = false;
+	const installedPath = getSqlitePath();
+	const installedFiles = ( await fs.pathExists( installedPath ) )
+		? await fs.readdir( installedPath )
+		: [];
+	const latestVersion = await getLatestSqliteVersion();
+	if ( installedFiles.length !== 0 ) {
+		const installedVersion = getSqliteVersionFromInstallation( installedPath );
+		shouldOverwrite = !! installedVersion && !! latestVersion && installedVersion !== latestVersion;
+	}
+
+	await downloadSqliteIntegrationPlugin( latestVersion, { overwrite: shouldOverwrite } );
+}
+
+function getSqliteVersionFromInstallation( installationPath: string ): string {
+	let versionFileContent = '';
+	try {
+		versionFileContent = fs.readFileSync( path.join( installationPath, 'load.php' ), 'utf8' );
+	} catch ( err ) {
+		return '';
+	}
+	const matches = versionFileContent.match( /\s\*\sVersion:\s*([0-9a-zA-Z.-]+)/ );
+	return matches?.[ 1 ] || '';
+}
+
+async function getLatestSqliteVersion() {
+	const sqliteVersions = await fetchSqliteVersions();
+	return sqliteVersions.latest;
+}
+
+async function fetchSqliteVersions() {
+	try {
+		const response = await fetch(
+			'https://api.github.com/repos/WordPress/sqlite-database-integration/releases'
+		);
+		const data: Record< string, string >[] = await response.json();
+		const versions = data.map( ( release ) => semver.coerce( release.tag_name ) );
+		return {
+			versions,
+			latest: versions[ 0 ]?.version || '',
+		};
+	} catch ( _error ) {
+		return { versions: [], latest: '' };
+	}
+}

--- a/src/setup-wp-server-files.ts
+++ b/src/setup-wp-server-files.ts
@@ -5,6 +5,7 @@ import { SQLITE_FILENAME } from '../vendor/wp-now/src/constants';
 import { getWordPressVersionPath } from '../vendor/wp-now/src/download';
 import getSqlitePath from '../vendor/wp-now/src/get-sqlite-path';
 import { recursiveCopyDirectory } from './lib/fs-utils';
+import { updateLatestSqliteVersion } from './lib/sqlite-versions';
 import {
 	getWordPressVersionFromInstallation,
 	updateLatestWordPressVersion,
@@ -51,4 +52,5 @@ export default async function setupWPServerFiles() {
 	await copyBundledLatestWPVersion();
 	await copyBundledSqlite();
 	await updateLatestWordPressVersion();
+	await updateLatestSqliteVersion();
 }

--- a/src/tests/ipc-handlers.test.ts
+++ b/src/tests/ipc-handlers.test.ts
@@ -95,7 +95,7 @@ describe( 'startServer', () => {
 
 			expect( downloadSqliteIntegrationPlugin ).toHaveBeenCalledTimes( 1 );
 			expect( copySync ).toHaveBeenCalledWith(
-				`/path/to/app/appData/App Name/server-files/sqlite-database-integration-main`,
+				`/path/to/app/appData/App Name/server-files/sqlite-database-integration`,
 				`${ mockSitePath }/wp-content/mu-plugins/${ SQLITE_FILENAME }`
 			);
 		} );

--- a/src/tests/ipc-handlers.test.ts
+++ b/src/tests/ipc-handlers.test.ts
@@ -3,13 +3,20 @@
  */
 import { shell, IpcMainInvokeEvent } from 'electron';
 import fs from 'fs';
-import { createSite } from '../ipc-handlers';
+import { copySync } from 'fs-extra';
+import { SQLITE_FILENAME } from '../../vendor/wp-now/src/constants';
+import { downloadSqliteIntegrationPlugin } from '../../vendor/wp-now/src/download';
+import { createSite, startServer } from '../ipc-handlers';
 import { isEmptyDir, pathExists } from '../lib/fs-utils';
+import { isSqliteInstallationOutdated } from '../lib/sqlite-versions';
 import { SiteServer, createSiteWorkingDirectory } from '../site-server';
 
 jest.mock( 'fs' );
+jest.mock( 'fs-extra' );
 jest.mock( '../lib/fs-utils' );
 jest.mock( '../site-server' );
+jest.mock( '../lib/sqlite-versions' );
+jest.mock( '../../vendor/wp-now/src/download' );
 
 ( SiteServer.create as jest.Mock ).mockImplementation( ( details ) => ( {
 	start: jest.fn(),
@@ -36,10 +43,15 @@ const mockIpcMainInvokeEvent = {
 	// Double assert the type with `unknown` to simplify mocking this value
 } as unknown as IpcMainInvokeEvent;
 
+afterEach( () => {
+	jest.clearAllMocks();
+} );
+
 describe( 'createSite', () => {
 	it( 'should create a site', async () => {
-		( isEmptyDir as jest.Mock ).mockResolvedValue( true );
-		( pathExists as jest.Mock ).mockResolvedValue( true );
+		( isEmptyDir as jest.Mock ).mockResolvedValueOnce( true );
+		( pathExists as jest.Mock ).mockResolvedValueOnce( true );
+
 		const [ site ] = await createSite( mockIpcMainInvokeEvent, '/test', 'Test' );
 
 		expect( site ).toEqual( {
@@ -53,8 +65,8 @@ describe( 'createSite', () => {
 
 	describe( 'when the site path started as an empty directory', () => {
 		it( 'should reset the directory when site creation fails', () => {
-			( isEmptyDir as jest.Mock ).mockResolvedValue( true );
-			( pathExists as jest.Mock ).mockResolvedValue( true );
+			( isEmptyDir as jest.Mock ).mockResolvedValueOnce( true );
+			( pathExists as jest.Mock ).mockResolvedValueOnce( true );
 			( createSiteWorkingDirectory as jest.Mock ).mockImplementation( () => {
 				throw new Error( 'Intentional test error' );
 			} );
@@ -63,6 +75,46 @@ describe( 'createSite', () => {
 				expect( shell.trashItem ).toHaveBeenCalledTimes( 1 );
 				expect( shell.trashItem ).toHaveBeenCalledWith( '/test' );
 			} );
+		} );
+	} );
+} );
+
+describe( 'startServer', () => {
+	describe( 'when sqlite-database-integration plugin is outdated', () => {
+		it( 'should update sqlite-database-integration plugin', async () => {
+			const mockSitePath = 'mock-site-path';
+			( isSqliteInstallationOutdated as jest.Mock ).mockResolvedValue( true );
+			( SiteServer.get as jest.Mock ).mockReturnValue( {
+				details: { path: mockSitePath },
+				start: jest.fn(),
+				updateSiteDetails: jest.fn(),
+				updateCachedThumbnail: jest.fn( () => Promise.resolve() ),
+			} );
+
+			await startServer( mockIpcMainInvokeEvent, 'mock-site-id' );
+
+			expect( downloadSqliteIntegrationPlugin ).toHaveBeenCalledTimes( 1 );
+			expect( copySync ).toHaveBeenCalledWith(
+				`/path/to/app/appData/App Name/server-files/sqlite-database-integration-main`,
+				`${ mockSitePath }/wp-content/mu-plugins/${ SQLITE_FILENAME }`
+			);
+		} );
+	} );
+
+	describe( 'when sqlite-database-integration plugin is up-to-date', () => {
+		it( 'should not update sqlite-database-integration plugin', async () => {
+			( isSqliteInstallationOutdated as jest.Mock ).mockResolvedValue( false );
+			( SiteServer.get as jest.Mock ).mockReturnValue( {
+				details: { path: 'mock-site-path' },
+				start: jest.fn(),
+				updateSiteDetails: jest.fn(),
+				updateCachedThumbnail: jest.fn( () => Promise.resolve() ),
+			} );
+
+			await startServer( mockIpcMainInvokeEvent, 'mock-site-id' );
+
+			expect( downloadSqliteIntegrationPlugin ).not.toHaveBeenCalled();
+			expect( copySync ).not.toHaveBeenCalled();
 		} );
 	} );
 } );

--- a/vendor/wp-now/src/constants.ts
+++ b/vendor/wp-now/src/constants.ts
@@ -7,7 +7,7 @@ export const SQLITE_FILENAME = 'sqlite-database-integration-main';
  * The URL for downloading the "SQLite database integration" WordPress Plugin.
  */
 export const SQLITE_URL =
-	'https://github.com/WordPress/sqlite-database-integration/archive/refs/heads/main.zip';
+	'https://downloads.wordpress.org/plugin/sqlite-database-integration.zip';
 
 /**
  * The default starting port for running the WP Now server.

--- a/vendor/wp-now/src/constants.ts
+++ b/vendor/wp-now/src/constants.ts
@@ -1,7 +1,7 @@
 /**
  * The file name for the SQLite plugin name.
  */
-export const SQLITE_FILENAME = 'sqlite-database-integration-main';
+export const SQLITE_FILENAME = 'sqlite-database-integration';
 
 /**
  * The URL for downloading the "SQLite database integration" WordPress Plugin.

--- a/vendor/wp-now/src/download.ts
+++ b/vendor/wp-now/src/download.ts
@@ -192,25 +192,23 @@ export async function downloadWordPress(
 }
 
 export async function downloadSqliteIntegrationPlugin(
-	version = '',
 	{overwrite}: {overwrite: boolean} = {overwrite: false}
 ) {
 	const finalFolder = getSqlitePath();
 	const tempFolder = path.join(os.tmpdir(), SQLITE_FILENAME);
-	const url = !! version
-		? `https://codeload.github.com/WordPress/sqlite-database-integration/zip/refs/tags/v${ version }`
-		: SQLITE_URL;
 	const { downloaded, statusCode } = await downloadFileAndUnzip({
-		url,
+		url: SQLITE_URL,
 		destinationFolder: tempFolder,
 		checkFinalPath: finalFolder,
 		itemName: 'SQLite',
 		overwrite,
 	});
 	if (downloaded) {
-		const nestedFolder = SQLITE_FILENAME.replace(/main$/, version);
+		// Relocate files from the nested folder lacking the `-main` branch suffix
+		// now that we install release tags instead of the main branch.
+		const nestedFolder = path.join(tempFolder, SQLITE_FILENAME.replace('-main', ''));
 		await fs.ensureDir(path.dirname(finalFolder));
-		await fs.move(path.join(tempFolder, nestedFolder), finalFolder, {
+		await fs.move(nestedFolder, finalFolder, {
 			overwrite: true,
 		});
 	} else if(0 !== statusCode) {

--- a/vendor/wp-now/src/download.ts
+++ b/vendor/wp-now/src/download.ts
@@ -204,9 +204,7 @@ export async function downloadSqliteIntegrationPlugin(
 		overwrite,
 	});
 	if (downloaded) {
-		// Relocate files from the nested folder lacking the `-main` branch suffix
-		// now that we install release tags instead of the main branch.
-		const nestedFolder = path.join(tempFolder, SQLITE_FILENAME.replace('-main', ''));
+		const nestedFolder = path.join(tempFolder, SQLITE_FILENAME);
 		await fs.ensureDir(path.dirname(finalFolder));
 		await fs.move(nestedFolder, finalFolder, {
 			overwrite: true,

--- a/vendor/wp-now/src/download.ts
+++ b/vendor/wp-now/src/download.ts
@@ -191,18 +191,26 @@ export async function downloadWordPress(
 	}
 }
 
-export async function downloadSqliteIntegrationPlugin() {
+export async function downloadSqliteIntegrationPlugin(
+	version = '',
+	{overwrite}: {overwrite: boolean} = {overwrite: false}
+) {
 	const finalFolder = getSqlitePath();
 	const tempFolder = path.join(os.tmpdir(), SQLITE_FILENAME);
+	const url = !! version
+		? `https://codeload.github.com/WordPress/sqlite-database-integration/zip/refs/tags/v${ version }`
+		: SQLITE_URL;
 	const { downloaded, statusCode } = await downloadFileAndUnzip({
-		url: SQLITE_URL,
+		url,
 		destinationFolder: tempFolder,
 		checkFinalPath: finalFolder,
 		itemName: 'SQLite',
+		overwrite,
 	});
 	if (downloaded) {
-		fs.ensureDirSync(path.dirname(finalFolder));
-		fs.moveSync(tempFolder, finalFolder, {
+		const nestedFolder = SQLITE_FILENAME.replace(/main$/, version);
+		await fs.ensureDir(path.dirname(finalFolder));
+		await fs.move(path.join(tempFolder, nestedFolder), finalFolder, {
 			overwrite: true,
 		});
 	} else if(0 !== statusCode) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Resolves https://github.com/Automattic/dotcom-forge/issues/6939.
Fixes https://github.com/Automattic/dotcom-forge/issues/6922. 
Relates to https://github.com/Automattic/dotcom-forge/issues/6598. 
Relates to https://github.com/Automattic/studio/issues/132.
Relates to https://github.com/Automattic/local-environment/pull/245 and https://github.com/Automattic/local-environment/pull/228. 

## Proposed Changes

- Update the `sqlite-databse-integration` installation to the **latest release tag** on app start. 
- Update the `sqlite-databse-integration` installation to the **latest release tag** on site server start. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

> [!IMPORTANT]
> In order to observe the `sqlite-integration-plugin` upgrade, you must first install a legacy version of the plugin.
>
> 1. Check out the `trunk` branch.
> 1. Download a legacy version of `sqlite-integration-plugin` — e.g., [v2.1.9](https://github.com/WordPress/sqlite-database-integration/releases/tag/v2.1.9).
> 1. "Install" the legacy version by replacing the existing copy found in the following locations. 
>
>    **Note:** naming the directory `sqlite-database-integration-main` (legacy name) would simulate testing the rollout of these changes to existing installs/sites; naming the directory `sqlite-database-integration` (new name) would simulate testing an additional SQLite upgrade (second, third, etc) after a previous install (first SQLite upgrade, new site creation using these changes, etc).
>    - **Bundled Installation:** This is found in the cloned repository at `wp-files/sqlite-database-integration-main`.
>    - **Downloaded Installation:** On macOS, this is found in `~/Library/Application\ Support/Studio/server-files/sqlite-database-integration-main`. 
> 1. Start the app server. (Note, you should not run `npm install` at this point as it would update the legacy bundled installation.)
> 1. Create a new site ("Legacy Site").
> 1. Verify the Legacy Site's `wp-content/mu-plugins` directory contains the legacy version of the plugin.

**1: Site actions remain stable without a network connection**
1. Check out the proposed changes.
1. Run `npm install` to download/bundle the latest version of `sqlite-database-integration`.
1. Disable your internet connection. 
1. Start the app server.
1. Create a new site.
1. Verify no errors are thrown during site creation or site server start.

**2: New sites leverage the latest version**
1. Check out the proposed changes.
1. Start the app server.
1. Create a new site. 
1. Verify the `sqlite-integration-plugin` version found in the site's `wp-content/mu-plugins` directory is the [latest release](https://github.com/WordPress/sqlite-database-integration/releases).

**3: Existing sites upgrade when started**
1. Check out the proposed changes.
1. Start the app server.
1. Start the Legacy Site's server.
1. Verify the `sqlite-integration-plugin` version found in the site's `wp-content/mu-plugins` directory is the [latest release](https://github.com/WordPress/sqlite-database-integration/releases).

**4: Woocommerce loads without database query errors**

1. Check out the proposed changes.
1. Start the app server.
1. Install and activate the WooCommerce plugin (Steps outlined in https://github.com/Automattic/dotcom-forge/issues/6922).
1. Verify no database query errors are logged and the plugin page loads successfully. **Note:** If MailPoet is installed and activated, [errors may display](https://github.com/Automattic/studio/issues/132#issuecomment-2120492613). 

**~5: UpdraftPlus loads without database query errors~**

Test case removed as the proposed changes do not address [all errors](https://github.com/WordPress/wordpress-playground/issues/1272#issuecomment-2120820926). 

**6: Fresh Studio installs successfully create and start sites**
1. Delete all existing Studio sites. 
1. Clear out the bundled and downloaded `sqlite-database-integration` installations. 
1. Run `npm install` to download/bundle the latest version of `sqlite-database-integration`.
1. Start the app server. 
1. Create a new site. 
1. Verify the `sqlite-integration-plugin` version found in the site's `wp-content/mu-plugins` directory is the [latest release](https://github.com/WordPress/sqlite-database-integration/releases).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
