### PR TITLE
Remove unit tests from GitHub actions

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,30 +1,9 @@
-name: Run Tests
+name: Run E2E Tests
 
 on:
   pull_request:
 
 jobs:
-  unit:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v2
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: 20.9.0
-
-      - name: Install Dependencies
-        run: npm ci
-
-      - name: Run linter
-        run: npm run lint
-
-      - name: Run Unit Tests
-        run: npm run test
-
   e2e:
     strategy:
       matrix:


### PR DESCRIPTION
## Proposed Changes

In https://github.com/Automattic/studio/pull/17 ,
6619e75c96a4ac47ff8fa6727f205c8823d1ca2a , we duplicated the logic to run unit tests and linters on Buildkite.

After running them side by side for a few days, no issues have been reported.

It's now time to remove the GitHub Actions step.

See https://github.com/Automattic/studio/pull/99 and https://github.com/Automattic/studio/pull/76 for the E2E counterpart.

## Testing Instructions

Notice the GH Action build for this PR does not include the `unit` step:

<img width="1277" alt="image" src="https://github.com/Automattic/studio/assets/1218433/6d3ad701-7376-4447-9cbf-6ea5c3e67b26">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors? – N.A.
