### PR TITLE
Exclude test environments from Sentry reporting

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
 		"publish": "electron-forge publish",
 		"lint": "eslint --ext .ts,.tsx,.js,.jsx,.mjs .",
 		"format": "prettier . --write",
-		"test": "NODE_ENV=test jest",
-		"test:watch": "NODE_ENV=test jest --watch",
-		"e2e": "NODE_ENV=test npx playwright install && npx playwright test",
+		"test": "jest",
+		"test:watch": "jest --watch",
+		"e2e": "npx playwright install && npx playwright test",
 		"make-pot": "wp-babel-makepot \"./src/**/*.{js,jsx,ts,tsx}\" --ignore \"**/*.d.ts\" --base \"./src\" --dir \"./out/pots\" --output \"./out/pots/bundle-strings.pot\""
 	},
 	"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
 		"publish": "electron-forge publish",
 		"lint": "eslint --ext .ts,.tsx,.js,.jsx,.mjs .",
 		"format": "prettier . --write",
-		"test": "jest",
-		"test:watch": "jest --watch",
-		"e2e": "npx playwright install && npx playwright test",
+		"test": "NODE_ENV=test jest",
+		"test:watch": "NODE_ENV=test jest --watch",
+		"e2e": "NODE_ENV=test npx playwright install && npx playwright test",
 		"make-pot": "wp-babel-makepot \"./src/**/*.{js,jsx,ts,tsx}\" --ignore \"**/*.d.ts\" --base \"./src\" --dir \"./out/pots\" --output \"./out/pots/bundle-strings.pot\""
 	},
 	"devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,7 @@ import { stopAllServersOnQuit } from './site-server'; // eslint-disable-line imp
 Sentry.init( {
 	dsn: 'https://97693275b2716fb95048c6d12f4318cf@o248881.ingest.sentry.io/4506612776501248',
 	debug: true,
-	enabled: process.env.NODE_ENV !== 'development' && process.env.NODE_ENV !== 'test',
+	enabled: process.env.NODE_ENV !== 'development' && ! process.env.E2E,
 	release: app.getVersion() ? app.getVersion() : COMMIT_HASH,
 } );
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,7 @@ import { stopAllServersOnQuit } from './site-server'; // eslint-disable-line imp
 Sentry.init( {
 	dsn: 'https://97693275b2716fb95048c6d12f4318cf@o248881.ingest.sentry.io/4506612776501248',
 	debug: true,
-	enabled: process.env.NODE_ENV !== 'development',
+	enabled: process.env.NODE_ENV !== 'development' && process.env.NODE_ENV !== 'test',
 	release: app.getVersion() ? app.getVersion() : COMMIT_HASH,
 } );
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,8 @@ import { stopAllServersOnQuit } from './site-server'; // eslint-disable-line imp
 Sentry.init( {
 	dsn: 'https://97693275b2716fb95048c6d12f4318cf@o248881.ingest.sentry.io/4506612776501248',
 	debug: true,
-	enabled: process.env.NODE_ENV !== 'development' && ! process.env.E2E,
+	enabled:
+		process.env.NODE_ENV !== 'development' && process.env.NODE_ENV !== 'test' && ! process.env.E2E,
 	release: app.getVersion() ? app.getVersion() : COMMIT_HASH,
 } );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Proposed Changes

Reduce Sentry noise by excluding test environments:

- Adds `process.env.NODE_ENV !== 'test'` to Sentry init config
- Prepends package.json test commands with `NODE_ENV=test`

## Testing Instructions
Run testing commands like `npm run e2e` or `npm run test` to observe that Sentry events are not reported. 


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
