### PR TITLE
Studio: Fix incorrect offline message displayed alongside "delete site" link

### DIFF
--- a/src/components/delete-site.tsx
+++ b/src/components/delete-site.tsx
@@ -19,6 +19,11 @@ const DeleteSite = () => {
 		'This site has active demo sites that cannot be deleted without an internet connection.'
 	);
 
+	const { snapshots } = useSiteDetails();
+	const snapshotsOnSite = snapshots.filter(
+		( snapshot ) => snapshot.localSiteId === selectedSite?.id
+	);
+
 	const handleDeleteSite = async () => {
 		if ( ! selectedSite ) {
 			return;
@@ -65,12 +70,17 @@ const DeleteSite = () => {
 			? `${ name.substring( 0, MAX_LENGTH_SITE_TITLE - 3 ) }...`
 			: name;
 
-	const isSiteDeletionDisabled = ! selectedSite || isOffline || isDeleting;
+	const isSiteDeletionDisabled =
+		! selectedSite || ( isOffline && snapshotsOnSite.length > 0 ) || isDeleting;
 
 	return (
-		<Tooltip disabled={ ! isOffline } icon={ offlineIcon } text={ offlineMessage }>
+		<Tooltip
+			disabled={ ! ( isOffline && snapshotsOnSite.length > 0 ) }
+			icon={ offlineIcon }
+			text={ offlineMessage }
+		>
 			<Button
-				aria-description={ isOffline ? offlineMessage : '' }
+				aria-description={ isOffline && snapshotsOnSite.length > 0 ? offlineMessage : '' }
 				aria-disabled={ isSiteDeletionDisabled }
 				onClick={ () => {
 					if ( isSiteDeletionDisabled ) {

--- a/src/components/tests/content-tab-settings.test.tsx
+++ b/src/components/tests/content-tab-settings.test.tsx
@@ -112,7 +112,7 @@ describe( 'ContentTabSettings', () => {
 		expect( copyText ).toHaveBeenCalledWith( 'test-password' );
 	} );
 
-	it( 'disables delete site button when offlin and there is at least one snapshot present for the site', async () => {
+	it( 'disables delete site button when offline and there is at least one snapshot present for the site', async () => {
 		( useOffline as jest.Mock ).mockReturnValue( true );
 
 		// Mock snapshots to include a snapshot for the selected site

--- a/src/components/tests/content-tab-settings.test.tsx
+++ b/src/components/tests/content-tab-settings.test.tsx
@@ -123,7 +123,6 @@ describe( 'ContentTabSettings', () => {
 			isDeleting: false,
 		} );
 		render( <ContentTabSettings selectedSite={ selectedSite } /> );
-		screen.debug();
 		const deleteSiteButton = await screen.findByRole( 'button', { name: 'Delete site' } );
 		expect( deleteSiteButton ).toHaveAttribute( 'aria-disabled', 'true' );
 		fireEvent.mouseOver( deleteSiteButton );

--- a/src/hooks/use-site-details.tsx
+++ b/src/hooks/use-site-details.tsx
@@ -17,7 +17,7 @@ interface SiteDetailsContext {
 	startServer: ( id: string ) => Promise< void >;
 	stopServer: ( id: string ) => Promise< void >;
 	stopAllRunningSites: () => Promise< void >;
-	deleteSite: ( id: string, removeLocal: boolean, deleteSnapshots?: boolean ) => Promise< void >;
+	deleteSite: ( id: string, removeLocal: boolean ) => Promise< void >;
 	loadingServer: Record< string, boolean >;
 	loadingSites: boolean;
 	isDeleting: boolean;
@@ -133,24 +133,15 @@ function useDeleteSite() {
 		async (
 			siteId: string,
 			removeLocal: boolean,
-			snapshots: Snapshot[],
-			deleteSnapshots?: boolean
+			snapshots: Snapshot[]
 		): Promise< SiteDetails[] | undefined > => {
 			if ( ! siteId ) {
 				return;
 			}
 
-			// Default deleteSnapshots to true
-			const shouldDeleteSnapshots = deleteSnapshots ?? true;
-
-			let allSiteRemovePromises;
-			if ( shouldDeleteSnapshots ) {
-				allSiteRemovePromises = Promise.allSettled(
-					snapshots.map( ( snapshot ) => deleteSnapshot( snapshot ) )
-				);
-			} else {
-				allSiteRemovePromises = Promise.resolve( [] );
-			}
+			const allSiteRemovePromises = Promise.allSettled(
+				snapshots.map( ( snapshot ) => deleteSnapshot( snapshot ) )
+			);
 
 			try {
 				setIsLoading( ( loading ) => ( { ...loading, [ siteId ]: true } ) );

--- a/src/hooks/use-site-details.tsx
+++ b/src/hooks/use-site-details.tsx
@@ -138,7 +138,6 @@ function useDeleteSite() {
 			if ( ! siteId ) {
 				return;
 			}
-
 			const allSiteRemovePromises = Promise.allSettled(
 				snapshots.map( ( snapshot ) => deleteSnapshot( snapshot ) )
 			);

--- a/src/hooks/use-site-details.tsx
+++ b/src/hooks/use-site-details.tsx
@@ -133,14 +133,24 @@ function useDeleteSite() {
 		async (
 			siteId: string,
 			removeLocal: boolean,
-			snapshots: Snapshot[]
+			snapshots: Snapshot[],
+			deleteSnapshots?: boolean // Parameter without default value in the signature
 		): Promise< SiteDetails[] | undefined > => {
 			if ( ! siteId ) {
 				return;
 			}
-			const allSiteRemovePromises = Promise.allSettled(
-				snapshots.map( ( snapshot ) => deleteSnapshot( snapshot ) )
-			);
+
+			// Default deleteSnapshots to true
+			const shouldDeleteSnapshots = deleteSnapshots ?? true;
+
+			let allSiteRemovePromises;
+			if ( shouldDeleteSnapshots ) {
+				allSiteRemovePromises = Promise.allSettled(
+					snapshots.map( ( snapshot ) => deleteSnapshot( snapshot ) )
+				);
+			} else {
+				allSiteRemovePromises = Promise.resolve( [] );
+			}
 
 			try {
 				setIsLoading( ( loading ) => ( { ...loading, [ siteId ]: true } ) );

--- a/src/hooks/use-site-details.tsx
+++ b/src/hooks/use-site-details.tsx
@@ -17,7 +17,7 @@ interface SiteDetailsContext {
 	startServer: ( id: string ) => Promise< void >;
 	stopServer: ( id: string ) => Promise< void >;
 	stopAllRunningSites: () => Promise< void >;
-	deleteSite: ( id: string, removeLocal: boolean ) => Promise< void >;
+	deleteSite: ( id: string, removeLocal: boolean, deleteSnapshots?: boolean ) => Promise< void >;
 	loadingServer: Record< string, boolean >;
 	loadingSites: boolean;
 	isDeleting: boolean;
@@ -134,7 +134,7 @@ function useDeleteSite() {
 			siteId: string,
 			removeLocal: boolean,
 			snapshots: Snapshot[],
-			deleteSnapshots?: boolean // Parameter without default value in the signature
+			deleteSnapshots?: boolean
 		): Promise< SiteDetails[] | undefined > => {
 			if ( ! siteId ) {
 				return;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->
Closes https://github.com/Automattic/dotcom-forge/issues/7144

## Proposed Changes

This PR does the following:

* it allows to delete a local site that does not have any demo sites when the user is offline
* it adjusts the offline message on the `Delete site` link to be displayed only when the user has a local site with snapshots

## Testing Instructions

* Pull the changes from this branch
* Start the app with `nvm use && npm install && npm start`
* Create a local site
* Create a second local site and add a demo site for this one
* Disable your device's internet connection (in my case, I disabled WIFI)
* Navigate to `Settings` tab for a local site that has a demo site associated with it
* Observe that the `Delete site` link is disabled and the offline message appears:

<img width="872" alt="Screenshot 2024-05-17 at 11 35 04 AM" src="https://github.com/Automattic/studio/assets/25575134/7800f4de-f290-4ecd-8308-5a5551bf0742">

* Navigate to another local site that does not have a demo site associated with it
* Observe that the `Delete site` link is available under `Settings` tab
* Click on `Delete site` 
* Confirm that the local site was deleted

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
