### PR TITLE
Add a mu-plugin to enable permalinks without index.php in the URL

### DIFF
--- a/vendor/wp-now/src/download.ts
+++ b/vendor/wp-now/src/download.ts
@@ -314,6 +314,12 @@ set_error_handler(function($severity, $message, $file, $line) {
 	add_action('after_setup_theme', 'check_current_theme_availability');
 `);
 
+	fs.writeFile(
+		path.join(muPluginsPath, '0-permalinks.php'),
+		`<?php
+			// Support permalinks without "index.php"
+			add_filter( 'got_url_rewrite', '__return_true' );
+	`);
 }
 
 export function getWordPressVersionPath(wpVersion: string) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

- Closes https://github.com/Automattic/studio/issues/142

## Proposed Changes

- Add a mu-plugin that enables having permalinks without the `index.php` in the URL.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Apply this PR in your local machine
- Run `nvm use && npm install && npm start`
- In an existing or new site access `Settings` > `Permalinks`: `/wp-admin/options-permalink.php`
- Observe the given options does not have `index.php`
- Select any permalink
- Access the forntend page, click on the menu item Sample in the frontend.

| Before | After |
|--------|--------|
|  <img width="1357" alt="permalinks-before" src="https://github.com/Automattic/studio/assets/779993/b3be8bfa-cec2-4800-bf24-fa5a8f0ec9a0"> | <img width="1303" alt="permalinks-after" src="https://github.com/Automattic/studio/assets/779993/dadd3155-d714-409b-b5c6-914aaaaebb77"> |


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
