### PR TITLE
Rename unnecessary `cp` during CI distribution

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -179,7 +179,7 @@ def distribute_builds(
   # When publishing a relesea build, copy the file into position to be picked
   # up by the Buildkite agent and saved with the job.
   builds.each_value do |build|
-    FileUtils.cp(build[:binary_path], File.join(BUILDS_FOLDER, "#{build[:filename]}-#{suffix}-#{build[:extension]}"))
+    FileUtils.cp(build[:binary_path], File.join(BUILDS_FOLDER, build[:filename]))
   end
 
   buildkite_annotate(

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -176,12 +176,6 @@ def distribute_builds(
     commit_hash: "#{commit_hash}-#{build_number}"
   )
 
-  # When publishing a relesea build, copy the file into position to be picked
-  # up by the Buildkite agent and saved with the job.
-  builds.each_value do |build|
-    FileUtils.cp(build[:binary_path], File.join(BUILDS_FOLDER, build[:filename]))
-  end
-
   buildkite_annotate(
     context: 'cdn-link',
     style: 'info',

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -62,7 +62,7 @@ end
 desc 'Ship release build'
 lane :distribute_release_build do |_options|
   release_tag = get_required_env('BUILDKITE_TAG')
-  builds = distribute_builds(release_tag: release_tag)
+  builds = distribute_builds(release_tag:)
 
   slack(
     username: 'CI Bot',


### PR DESCRIPTION
Related to #117 and #114 

## Proposed Changes

I originally created this PR to fix an incorrect path in the automation `cp` command, 07f7e4857c73471dbd82d9e82f2e2b9cf5965bb0

```ruby
  # When publishing a release build, copy the file into position to be picked
  # up by the Buildkite agent and saved with the job.
  builds.each_value do |build|
    FileUtils.cp(build[:binary_path], File.join(BUILDS_FOLDER, build[:filename]))
  end
```

But, once I went to look in CI for failures demonstrating what to me looked like a clear error, I couldn't find them.

That made me realize that the `cp` step was a leftover from a previous iteration. In the current setup, we have individual steps for each build and a final step that downloads those artifacts and forwards them to S3.

As such, there shouldn't be any need to copy artifacts anywhere for further processing in Buildkite. Proof of this is that my original code messed up the path for those files, but CI succeeded, showing that there was no further automation looking for the files that were copied.

For reference, below is the original PR description.

<details>
<summary>Original Description</summary>


Related to #117 

## Proposed Changes

I've been using this automation in another app and noticed that the filename to be copied was incorrect.

When working on DRYing the implementation, I didn't notice that the existing code duplicated the logic to assemble the name using root and suffix, etc. Having extracted that logic and its result in the `:filename` property, the computed filename for `cp` had unnecessary repetitions.

## Testing Instructions

I don't have a way to test this in this repo. We'll need to merge and run it.

</details>

## Testing Instructions

As discussed, this removes unused code. We'll see if it works for sure after merging on `trunk`.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors? — N.A.
