### PR TITLE
Add platform to Sentry relase

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import { __, defaultI18n } from '@wordpress/i18n';
 import packageJson from '../package.json';
 import { PROTOCOL_PREFIX } from './constants';
 import * as ipcHandlers from './ipc-handlers';
+import { getPlatformName } from './lib/app-globals';
 import { bumpAggregatedUniqueStat } from './lib/bump-stats';
 import { getLocaleData, getSupportedLocale } from './lib/locale';
 import { handleAuthCallback, setUpAuthCallbackHandler } from './lib/oauth';
@@ -30,7 +31,7 @@ Sentry.init( {
 	dsn: 'https://97693275b2716fb95048c6d12f4318cf@o248881.ingest.sentry.io/4506612776501248',
 	debug: true,
 	enabled: process.env.NODE_ENV !== 'development',
-	release: app.getVersion() ? app.getVersion() : COMMIT_HASH,
+	release: `${ app.getVersion() ? app.getVersion() : COMMIT_HASH }-${ getPlatformName() }`,
 } );
 
 // Handle creating/removing shortcuts on Windows when installing/uninstalling.

--- a/src/lib/app-globals.ts
+++ b/src/lib/app-globals.ts
@@ -12,3 +12,17 @@ export function isMac() {
 export function isWindows() {
 	return getAppGlobals().platform === 'win32';
 }
+
+export function getPlatformName() {
+	const platform = process ? process.platform : getAppGlobals().platform;
+	switch ( platform ) {
+		case 'darwin':
+			return 'macos';
+		case 'win32':
+			return 'windows';
+		case 'linux':
+			return 'linux';
+		default:
+			return 'other';
+	}
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Proposed Changes

- Add platform suffix to the Sentry release name. This will allow us to separate the release metrics based on the platform. Ultimately, this would help us to determine the quality of each platform and prioritize bugs accordingly.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Apply the following patch to analyze a Sentry event data.
```patch
diff --git forkSrcPrefix/src/index.ts forkDstPrefix/src/index.ts
index 5c14c3c5d29c1b5658b8fd5559283d1f16d845c7..2341225c45476ad36b7bb4587f679b496b61e854 100644
--- forkSrcPrefix/src/index.ts
+++ forkDstPrefix/src/index.ts
@@ -30,8 +30,12 @@ import { stopAllServersOnQuit } from './site-server'; // eslint-disable-line imp
 Sentry.init( {
 	dsn: 'https://97693275b2716fb95048c6d12f4318cf@o248881.ingest.sentry.io/4506612776501248',
 	debug: true,
-	enabled: process.env.NODE_ENV !== 'development',
+	enabled: true,
 	release: `${ app.getVersion() ? app.getVersion() : COMMIT_HASH }-${ getPlatformName() }`,
+	beforeSend: ( event ) => {
+		console.log( 'Sentry event - release:', event.release );
+		return null; //This drops the event and nothing will be sent to Sentry
+	},
 } );
 
 // Handle creating/removing shortcuts on Windows when installing/uninstalling.
@@ -71,6 +75,8 @@ async function appBoot() {
 
 	setupUpdates();
 
+	Sentry.captureMessage( 'test' );
+
 	setupWPServerFiles().catch( Sentry.captureException );
 
 	if ( process.defaultApp ) {

```
- Build and run the app.
- Check the console logs and observe that the release property of the Sentry event is logged with the following values depending on the platform used:
    - macOS: `1.0.2-macos`
    - Windows: `1.0.2-windows`
    - Windows: `1.0.2-linux`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
