### PR TITLE
Fix dev builds upload to match links used in manifest 

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -79,7 +79,7 @@ lane :distribute_release_build do |_options|
 end
 
 def distribute_builds(
-  commit_hash: last_git_commit[:commit_hash],
+  commit_hash: last_git_commit[:abbreviated_commit_hash],
   build_number: get_required_env('BUILDKITE_BUILD_NUMBER'),
   release_tag: nil
 )

--- a/scripts/generate-releases-manifest.mjs
+++ b/scripts/generate-releases-manifest.mjs
@@ -109,7 +109,7 @@ if ( isDevBuild ) {
 	releasesData[ 'dev' ][ 'darwin' ] = releasesData[ 'dev' ][ 'darwin' ] ?? {};
 	releasesData[ 'dev' ][ 'darwin' ][ 'universal' ] = {
 		sha: currentCommit,
-		url: `${ cdnURL }/${ baseName }-darwin-${ currentCommit }.app.zip`,
+		url: `${ cdnURL }/${ baseName }-darwin-universal-${ currentCommit }.app.zip`,
 	};
 	releasesData[ 'dev' ][ 'darwin' ][ 'x64' ] = {
 		sha: currentCommit,
@@ -137,7 +137,7 @@ if ( isDevBuild ) {
 	releasesData[ version ][ 'darwin' ] = releasesData[ version ][ 'darwin' ] ?? {};
 	releasesData[ version ][ 'darwin' ][ 'universal' ] = {
 		sha: currentCommit,
-		url: `${ cdnURL }/${ baseName }-darwin-v${ version }.app.zip`,
+		url: `${ cdnURL }/${ baseName }-darwin-universal-v${ version }.app.zip`,
 	};
 	releasesData[ version ][ 'darwin' ][ 'x64' ] = {
 		sha: currentCommit,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/7339

## Proposed Changes

I propose to:
- add 'universal' in links generated in manifest to match file names used when uploading binaries to CDN: https://github.com/Automattic/studio/blob/1fe21c81aaca4ea71ff91583819df7289ade2758/fastlane/Fastfile#L95

- fix the binary upload code to use short sha instead of full one to match links used in manifest: https://github.com/Automattic/studio/blob/1fe21c81aaca4ea71ff91583819df7289ade2758/scripts/generate-releases-manifest.mjs#L47

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Test if the dev builds links in manifest work after emerging this PR.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
