### PR TITLE
Add support for automatic updates of the Windows version

### DIFF
--- a/.buildkite/commands/build-for-windows-dev.ps1
+++ b/.buildkite/commands/build-for-windows-dev.ps1
@@ -8,5 +8,10 @@ node ./scripts/prepare-dev-build-version.mjs
 If ($LastExitCode -ne 0) { Exit $LastExitCode }
 
 npm run make
+
+# Rename NuGet package files with generic name
+$artifactsPath = Get-Item ".\out" | Select-Object -ExpandProperty FullName
+Get-ChildItem -Path $artifactsPath -Recurse -Include "*.nupkg" | Rename-Item -NewName "studio-update.nupkg"
+
 If ($LastExitCode -ne 0) { Exit $LastExitCode }
 

--- a/.buildkite/commands/build-for-windows-release.ps1
+++ b/.buildkite/commands/build-for-windows-release.ps1
@@ -8,5 +8,10 @@ node ./scripts/confirm-tag-matches-version.mjs
 If ($LastExitCode -ne 0) { Exit $LastExitCode }
 
 npm run make
+
+# Rename NuGet package files with generic name
+$artifactsPath = Get-Item ".\out" | Select-Object -ExpandProperty FullName
+Get-ChildItem -Path $artifactsPath -Recurse -Include "*.nupkg" | Rename-Item -NewName "studio-update.nupkg"
+
 If ($LastExitCode -ne 0) { Exit $LastExitCode }
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -60,6 +60,8 @@ steps:
     command: .buildkite/commands/build-for-windows-dev.ps1
     artifact_paths:
       - 'out\**\studio-setup.exe'
+      - 'out\**\studio-update.nupkg'
+      - 'out\**\RELEASES'
     agents:
       queue: "windows"
     if: "build.tag !~ /^v[0-9]+/"
@@ -116,6 +118,8 @@ steps:
       queue: "windows"
     artifact_paths:
       - 'out\**\studio-setup.exe'
+      - 'out\**\studio-update.nupkg'
+      - 'out\**\RELEASES'
     if: "build.tag =~ /^v[0-9]+/"
 
   - label: ':rocket: Publish Release Builds'

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -127,6 +127,8 @@ steps:
       echo "--- :node: Downloading Binaries"
       buildkite-agent artifact download "*.zip" .
       buildkite-agent artifact download "*.exe" .
+      buildkite-agent artifact download "*.nupkg" .
+      buildkite-agent artifact download "RELEASES" .
 
       echo "--- :node: Generating Release Manifest"
       install_npm_packages

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -71,6 +71,8 @@ steps:
       echo "--- :node: Downloading Binaries"
       buildkite-agent artifact download "*.app.zip" .
       buildkite-agent artifact download "*.exe" .
+      buildkite-agent artifact download "*.nupkg" .
+      buildkite-agent artifact download "RELEASES" .
 
       echo "--- :node: Generating Release Manifest"
       install_npm_packages

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -113,12 +113,20 @@ def distribute_builds(
       filename_core: 'win32',
       extension: 'exe',
       name: 'Windows'
+    },
+    windows_update: {
+      binary_path: File.join(BUILDS_FOLDER, 'make', 'squirrel.windows', 'x64', "studio-update.nupkg"),
+      filename_core: 'win32',
+      suffix: 'full',
+      extension: 'nupkg',
+      name: 'Windows Update'
     }
   }
 
   # Add computed fields
   assemble_filename = lambda do |build, filename_suffix|
-    "#{filename_root}-#{build[:filename_core]}-#{filename_suffix}.#{build[:extension]}"
+    build_suffix = build[:suffix].to_s.empty? ? "" : "-#{build[:suffix]}"
+    "#{filename_root}-#{build[:filename_core]}-#{filename_suffix}#{build_suffix}.#{build[:extension]}"
   end
   builds.each_value do |build|
     build[:filename] = assemble_filename.call(build, suffix)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -125,7 +125,7 @@ def distribute_builds(
 
   # Add computed fields
   assemble_filename = lambda do |build, filename_suffix|
-    build_suffix = build[:suffix].to_s.empty? ? "" : "-#{build[:suffix]}"
+    build_suffix = build[:suffix].to_s.empty? ? '' : "-#{build[:suffix]}"
     "#{filename_root}-#{build[:filename_core]}-#{filename_suffix}#{build_suffix}.#{build[:extension]}"
   end
   builds.each_value do |build|

--- a/scripts/generate-releases-manifest.mjs
+++ b/scripts/generate-releases-manifest.mjs
@@ -137,7 +137,7 @@ if ( isDevBuild ) {
 	const windowsReleaseInfo = await getWindowsReleaseInfo();
 	releasesData[ 'dev' ][ 'win32' ] = {
 		sha: windowsReleaseInfo.sha1,
-		url: `${ cdnURL }/${ baseName }-win32-v${ version }-full.nupkg`,
+		url: `${ cdnURL }/${ baseName }-win32-v${ version }-${ currentCommit }-full.nupkg`,
 		size: windowsReleaseInfo.size,
 	};
 

--- a/scripts/generate-releases-manifest.mjs
+++ b/scripts/generate-releases-manifest.mjs
@@ -59,10 +59,19 @@ console.log( 'Downloading current manifest ...' );
 const releasesPath = path.join( __dirname, '..', 'out', 'releases.json' );
 
 async function getWindowsReleaseInfo() {
-	const windowsReleaseInfo = await fs.readFile(
-		path.join( __dirname, '..', 'out', 'make', 'squirrel.windows', 'x64', 'RELEASES' ),
-		'utf8'
-	);
+	let windowsReleaseInfo = {};
+	try {
+		windowsReleaseInfo = await fs.readFile(
+			path.join( __dirname, '..', 'out', 'make', 'squirrel.windows', 'x64', 'RELEASES' ),
+			'utf8'
+		);
+	} catch ( error ) {
+		console.log(
+			`Couldn't read RELEASES file of Windows build, please ensure that the file exists to generate the release manifest.`
+		);
+		process.exit( 1 );
+	}
+
 	const [ _, sha1, filename, size ] = windowsReleaseInfo.match(
 		/([a-zA-Z\d]{40})\s(.*\.nupkg)\s(\d+)/
 	);

--- a/scripts/generate-releases-manifest.mjs
+++ b/scripts/generate-releases-manifest.mjs
@@ -57,6 +57,19 @@ console.log( `Current commit: ${ currentCommit }` );
 console.log( 'Downloading current manifest ...' );
 
 const releasesPath = path.join( __dirname, '..', 'out', 'releases.json' );
+
+async function getWindowsReleaseInfo() {
+	const windowsReleaseInfo = await fs.readFile(
+		path.join( __dirname, '..', 'out', 'make', 'squirrel.windows', 'x64', 'RELEASES' ),
+		'utf8'
+	);
+	const [ _, sha1, filename, size ] = windowsReleaseInfo.match(
+		/([a-zA-Z\d]{40})\s(.*\.nupkg)\s(\d+)/
+	);
+
+	return { sha1, filename, size };
+}
+
 try {
 	await fs.mkdir( path.dirname( releasesPath ) );
 } catch ( err ) {
@@ -121,9 +134,11 @@ if ( isDevBuild ) {
 	};
 
 	// Windows
+	const windowsReleaseInfo = await getWindowsReleaseInfo();
 	releasesData[ 'dev' ][ 'win32' ] = {
-		sha: currentCommit,
-		url: `${ cdnURL }/${ baseName }-win32-${ currentCommit }.exe`,
+		sha: windowsReleaseInfo.sha1,
+		url: `${ cdnURL }/${ baseName }-win32-v${ version }-full.nupkg`,
+		size: windowsReleaseInfo.size,
 	};
 
 	await fs.writeFile( releasesPath, JSON.stringify( releasesData, null, 2 ) );
@@ -149,9 +164,11 @@ if ( isDevBuild ) {
 	};
 
 	// Windows
+	const windowsRelease = await getWindowsReleaseInfo();
 	releasesData[ version ][ 'win32' ] = {
-		sha: currentCommit,
-		url: `${ cdnURL }/${ baseName }-win32-v${ version }.exe`,
+		sha: windowsRelease.sha1,
+		url: `${ cdnURL }/${ baseName }-win32-v${ version }-full.nupkg`,
+		size: windowsRelease.size,
 	};
 
 	await fs.writeFile( releasesPath, JSON.stringify( releasesData, null, 2 ) );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to 7362-gh-Automattic/dotcom-forge.

## Proposed Changes

The process of making Windows builds produces the following files:
- `studio-setup.exe`
- `studio-<VERSION>-full-nupkg`: This file is needed by the [Squirrel auto-updater](https://github.com/Squirrel/Squirrel.Windows/blob/develop/docs/using/update-process.md) to update the app.
- `RELEASES`: Contains release information for the update. The content of this file is used by the [Squirrel auto-updater](https://github.com/Squirrel/Squirrel.Windows/blob/develop/docs/using/update-process.md) to determine if the app needs to be updated and download the update file.

To support updates on Windows, we need to include and process the NuGet package file (`.nupkg`) and `RELEASES` in the build process.

- Rename NuGet package file to a generic name. We are mainly looking for removing the version part so it's easier to manage in the different parts of the build process.
- Upload and download the NuGet package and `RELEASES` files in the Buildkite job.
- Update the release manifest generation script to include the data needed to update the app. Specifically, we need to include the SHA1 (with all the 40 characters) and the file size. It's important to note that the filename needs to conform the format expected by [Squirrel auto-updater](https://github.com/Squirrel/Squirrel.Windows/blob/develop/docs/using/update-process.md) ([reference 1](https://github.com/Squirrel/Squirrel.Windows/blob/51f5e2cb01add79280a53d51e8d0cfa20f8c9f9f/src/Squirrel/ReleaseEntry.cs#L42-L50), [reference 2](https://github.com/Squirrel/Squirrel.Windows/blob/51f5e2cb01add79280a53d51e8d0cfa20f8c9f9f/src/Squirrel/ReleaseExtensions.cs#L13-L26)).

> [!IMPORTANT]
> Once this PR is merged and the release manifest is updated. We need to review and land the diff D149783-code in order to respond with the new fields for Windows updates.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Manifest file
- Run the command `npm run make` to generate a new release build.
- Run the command `node ./scripts/generate-releases-manifest.mjs`.
- Open the manifest file located in `out/releases.json`.
- Observe that for the version set in `package.json`, the entry for `win32` contains the following fields:
    - `sha` (with 40 characters)
    - `url` (the filename ends with `-full.nupkg`)
    - `size` (file size in bytes)
**NOTE:** The values should match the ones from the file `out/make/squirrel.windows/x64/RELEASES`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?