### PR TITLE
Fix path to RELEASES file to let Buildkite download it

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -72,7 +72,7 @@ steps:
       buildkite-agent artifact download "*.app.zip" .
       buildkite-agent artifact download "*.exe" .
       buildkite-agent artifact download "*.nupkg" .
-      buildkite-agent artifact download "RELEASES" .
+      buildkite-agent artifact download "*/RELEASES" .
 
       echo "--- :node: Generating Release Manifest"
       install_npm_packages
@@ -130,7 +130,7 @@ steps:
       buildkite-agent artifact download "*.zip" .
       buildkite-agent artifact download "*.exe" .
       buildkite-agent artifact download "*.nupkg" .
-      buildkite-agent artifact download "RELEASES" .
+      buildkite-agent artifact download "*/RELEASES" .
 
       echo "--- :node: Generating Release Manifest"
       install_npm_packages


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Follow-up to https://github.com/Automattic/studio/pull/158

## Proposed Changes

Currently step that distributes files can't download RELEASES file:

```
2024-05-24 05:08:06 INFO   Searching for artifacts: "*.app.zip"
--
  | 2024-05-24 05:08:06 INFO   Found 3 artifacts. Starting to download to: /opt/ci/builds/builder/automattic/studio
  | 2024-05-24 05:08:08 INFO   Successfully downloaded "out/Studio-darwin-x64/Studio.app.zip" 173 MiB
  | 2024-05-24 05:08:08 INFO   Successfully downloaded "out/Studio-darwin-arm64/Studio.app.zip" 167 MiB
  | 2024-05-24 05:08:09 INFO   Successfully downloaded "out/Studio-darwin-universal/Studio.app.zip" 244 MiB
  | 2024-05-24 05:08:09 INFO   Searching for artifacts: "*.exe"
  | 2024-05-24 05:08:09 INFO   Found 1 artifacts. Starting to download to: /opt/ci/builds/builder/automattic/studio
  | 2024-05-24 05:08:11 INFO   Successfully downloaded "out/make/squirrel.windows/x64/studio-setup.exe" 173 MiB
  | 2024-05-24 05:08:11 INFO   Searching for artifacts: "*.nupkg"
  | 2024-05-24 05:08:11 INFO   Found 1 artifacts. Starting to download to: /opt/ci/builds/builder/automattic/studio
  | 2024-05-24 05:08:13 INFO   Successfully downloaded "out/make/squirrel.windows/x64/studio-update.nupkg" 174 MiB
  | 2024-05-24 05:08:13 INFO   Searching for artifacts: "RELEASES"
  | fatal: failed to download artifacts: No artifacts found for downloading
  | 🚨 Error: The command exited with status 1
```

I think it accepts full path or wildcard, so when it's set to file name it can't locate it. I'm trying to fix by adding a wildcard.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Merge and check if Distribute Dev Builds goes through.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
