### PR TITLE
Add patches hash to NPM packages cache key

### DIFF
--- a/.buildkite/commands/install-node-dependencies.sh
+++ b/.buildkite/commands/install-node-dependencies.sh
@@ -5,7 +5,13 @@ ARCHITECTURE=$(uname -m)
 NODE_VERSION=$(node --version)
 PACKAGE_HASH=$(hash_file package-lock.json)
 
-CACHEKEY="$BUILDKITE_PIPELINE_SLUG-npm-$PLATFORM-$ARCHITECTURE-node-$NODE_VERSION-$PACKAGE_HASH"
+if [ -d patches ]; then
+  PATCHES_HASH=$(hash_directory patches/)
+else
+  PATCHES_HASH=nopatch
+fi
+
+CACHEKEY="$BUILDKITE_PIPELINE_SLUG-npm-$PLATFORM-$ARCHITECTURE-node-$NODE_VERSION-$PACKAGE_HASH-$PATCHES_HASH"
 
 LOCAL_NPM_CACHE=./vendor/npm
 mkdir -p $LOCAL_NPM_CACHE


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Proposed Changes

I propose adding hash of `patches/` to the NPM cache key to ensure cache is not reused if patches change. Props to @AliSoftware for a solution.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Merge and check if Distribute Dev Builds goes through.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
