### PR TITLE
Remove version from windows dev release url

### DIFF
--- a/scripts/generate-releases-manifest.mjs
+++ b/scripts/generate-releases-manifest.mjs
@@ -151,7 +151,7 @@ if ( isDevBuild ) {
 	const windowsReleaseInfo = await getWindowsReleaseInfo();
 	releasesData[ 'dev' ][ 'win32' ] = {
 		sha: windowsReleaseInfo.sha1,
-		url: `${ cdnURL }/${ baseName }-win32-v${ version }-${ currentCommit }-full.nupkg`,
+		url: `${ cdnURL }/${ baseName }-win32-${ currentCommit }-full.nupkg`,
 		size: windowsReleaseInfo.size,
 	};
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Proposed Changes

I propose to remove version from the Windows dev build URL as only commit is used for dev builds.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Merge and confirm deb build URLs are correct in the manifest file.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
