### PR TITLE
Add application menu on Windows

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -36,9 +36,7 @@ export default function App() {
 			) }
 			spacing="0"
 		>
-			{ isWindows() && (
-				<WindowsTitlebar className="h-titlebar-win flex-shrink-0 app-no-drag-region" />
-			) }
+			{ isWindows() && <WindowsTitlebar className="h-titlebar-win flex-shrink-0" /> }
 			<HStack spacing="0" alignment="left" className="flex-grow">
 				<MainSidebar className="basis-52 flex-shrink-0 h-full" />
 				<main

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -36,7 +36,9 @@ export default function App() {
 			) }
 			spacing="0"
 		>
-			{ isWindows() && <WindowsTitlebar className="h-titlebar-win flex-shrink-0" /> }
+			{ isWindows() && (
+				<WindowsTitlebar className="h-titlebar-win flex-shrink-0 app-no-drag-region" />
+			) }
 			<HStack spacing="0" alignment="left" className="flex-grow">
 				<MainSidebar className="basis-52 flex-shrink-0 h-full" />
 				<main

--- a/src/components/windows-titlebar.tsx
+++ b/src/components/windows-titlebar.tsx
@@ -14,12 +14,12 @@ export default function WindowsTitlebar( { className }: { className?: string } )
 				onClick={ () => {
 					getIpcApi().popupAppMenu();
 				} }
-				className="!p-2"
+				className="!px-3 !py-2 app-no-drag-region"
 			>
-				<Icon icon={ menu } className="text-white" />
+				<Icon icon={ menu } className="text-white" size={ 18 } />
 			</Button>
 
-			<div className="flex gap-2">
+			<div className="flex gap-2 app-drag">
 				<img src={ appIcon } alt="" className="w-[16px] flex-shrink-0" />
 				<h1 className="text-xs">{ getAppGlobals().appName }</h1>
 			</div>

--- a/src/components/windows-titlebar.tsx
+++ b/src/components/windows-titlebar.tsx
@@ -1,13 +1,28 @@
 import { __experimentalHStack as HStack } from '@wordpress/components';
+import { Icon, menu } from '@wordpress/icons';
 import appIcon from '../../assets/titlebar-icon.svg';
 import { getAppGlobals } from '../lib/app-globals';
 import { cx } from '../lib/cx';
+import { getIpcApi } from '../lib/get-ipc-api';
+import Button from './button';
 
 export default function WindowsTitlebar( { className }: { className?: string } ) {
 	return (
-		<HStack alignment="left" className={ cx( 'bg-chrome text-white pl-4', className ) } spacing="4">
-			<img src={ appIcon } alt="" className="w-[16px] flex-shrink-0" />
-			<h1 className="text-xs">{ getAppGlobals().appName }</h1>
+		<HStack alignment="left" className={ cx( 'bg-chrome text-white', className ) } spacing="2">
+			<Button
+				variant="icon"
+				onClick={ () => {
+					getIpcApi().popupAppMenu();
+				} }
+				className="!p-2"
+			>
+				<Icon icon={ menu } className="text-white" />
+			</Button>
+
+			<div className="flex gap-2">
+				<img src={ appIcon } alt="" className="w-[16px] flex-shrink-0" />
+				<h1 className="text-xs">{ getAppGlobals().appName }</h1>
+			</div>
 		</HStack>
 	);
 }

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -32,6 +32,7 @@ import {
 	removeLegacySqliteIntegrationPlugin,
 } from './lib/sqlite-versions';
 import { writeLogToFile, type LogLevel } from './logging';
+import { popupMenu } from './menu';
 import { SiteServer, createSiteWorkingDirectory } from './site-server';
 import { DEFAULT_SITE_PATH, getServerFilesPath, getSiteThumbnailPath } from './storage/paths';
 import { loadUserData, saveUserData } from './storage/user-data';
@@ -607,4 +608,8 @@ export async function showNotification(
 	options: Electron.NotificationConstructorOptions
 ) {
 	new Notification( options ).show();
+}
+
+export function popupAppMenu( _event: IpcMainInvokeEvent ) {
+	popupMenu();
 }

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -17,7 +17,27 @@ export function setupMenu( mainWindow: BrowserWindow | null ) {
 		Menu.setApplicationMenu( null );
 		return;
 	}
+	const menu = getAppMenu( mainWindow );
+	if ( process.platform === 'darwin' ) {
+		Menu.setApplicationMenu( menu );
+		return;
+	}
+	// Make menu accessible in development for non-macOS platforms
+	if ( process.env.NODE_ENV === 'development' ) {
+		mainWindow?.setMenu( menu );
+		return;
+	}
+	Menu.setApplicationMenu( null );
+}
 
+export function popupMenu() {
+	withMainWindow( ( window ) => {
+		const menu = getAppMenu( window );
+		menu.popup();
+	} );
+}
+
+function getAppMenu( mainWindow: BrowserWindow | null ) {
 	const crashTestMenuItems: MenuItemConstructorOptions[] = [
 		{
 			label: __( 'Test Hard Crash (dev only)' ),
@@ -40,7 +60,7 @@ export function setupMenu( mainWindow: BrowserWindow | null ) {
 		{ type: 'separator' },
 	];
 
-	const menu = Menu.buildFromTemplate( [
+	return Menu.buildFromTemplate( [
 		{
 			label: app.name, // macOS ignores this name and uses the name from the .plist
 			role: 'appMenu',
@@ -132,15 +152,4 @@ export function setupMenu( mainWindow: BrowserWindow | null ) {
 			],
 		},
 	] );
-
-	if ( process.platform === 'darwin' ) {
-		Menu.setApplicationMenu( menu );
-		return;
-	}
-	// Make menu accessible in development for non-macOS platforms
-	if ( process.env.NODE_ENV === 'development' ) {
-		mainWindow?.setMenu( menu );
-		return;
-	}
-	Menu.setApplicationMenu( null );
 }

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -88,9 +88,13 @@ function getAppMenu( mainWindow: BrowserWindow | null ) {
 					},
 				},
 				{ type: 'separator' },
-				{ role: 'services' },
+				...( process.platform === 'win32'
+					? []
+					: [ { role: 'services' } as MenuItemConstructorOptions ] ),
 				{ type: 'separator' },
-				{ role: 'hide' },
+				...( process.platform === 'win32'
+					? []
+					: [ { role: 'hide' } as MenuItemConstructorOptions ] ),
 				{ type: 'separator' },
 				...( process.env.NODE_ENV === 'development' ? crashTestMenuItems : [] ),
 				{ type: 'separator' },
@@ -109,19 +113,27 @@ function getAppMenu( mainWindow: BrowserWindow | null ) {
 						} );
 					},
 				},
-				{
-					label: __( 'Close Window' ),
-					accelerator: 'CommandOrControl+W',
-					click: ( _menuItem, browserWindow ) => {
-						browserWindow?.close();
-					},
-					enabled: !! mainWindow && ! mainWindow.isDestroyed(),
-				},
+				...( process.platform === 'win32'
+					? []
+					: [
+							{
+								label: __( 'Close Window' ),
+								accelerator: 'CommandOrControl+W',
+								click: ( _menuItem, browserWindow ) => {
+									browserWindow?.close();
+								},
+								enabled: !! mainWindow && ! mainWindow.isDestroyed(),
+							} as MenuItemConstructorOptions,
+					  ] ),
 			],
 		},
-		{
-			role: 'editMenu',
-		},
+		...( process.platform === 'win32'
+			? []
+			: [
+					{
+						role: 'editMenu',
+					} as MenuItemConstructorOptions,
+			  ] ),
 		{
 			role: 'viewMenu',
 			submenu: [
@@ -133,13 +145,17 @@ function getAppMenu( mainWindow: BrowserWindow | null ) {
 				{ role: 'togglefullscreen' },
 			],
 		},
-		{
-			role: 'windowMenu',
-			// We can't remove all of the items which aren't relevant to us (anything for
-			// managing multiple window instances), but this seems to remove as many of
-			// them as we can.
-			submenu: [ { role: 'minimize' }, { role: 'zoom' } ],
-		},
+		...( process.platform === 'win32'
+			? []
+			: [
+					{
+						role: 'windowMenu',
+						// We can't remove all of the items which aren't relevant to us (anything for
+						// managing multiple window instances), but this seems to remove as many of
+						// them as we can.
+						submenu: [ { role: 'minimize' }, { role: 'zoom' } ],
+					} as MenuItemConstructorOptions,
+			  ] ),
 		{
 			role: 'help',
 			submenu: [

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -48,6 +48,7 @@ const api: IpcApi = {
 	// Use .send instead of .invoke because logging is fire-and-forget
 	logRendererMessage: ( level: LogLevel, ...args: any[] ) =>
 		ipcRenderer.send( 'logRendererMessage', level, ...args ),
+	popupAppMenu: () => ipcRenderer.invoke( 'popupAppMenu' ),
 };
 
 contextBridge.exposeInMainWorld( 'ipcApi', api );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to 7084-gh-Automattic/dotcom-forge.

## Proposed Changes

- Separate menu creation from `setupMenu` function to a new function `getAppMenu`. This function will be used when setting up the application menu on macOS and when displaying the app menu as a context menu on Windows.
- Create `popupMenu` to display the app menu as a context menu.
- Add button to `WindowsTitlebar` component. This button will trigger the context menu.

| App | Open app menu |
|--------|--------|
| <img width=400 src=https://github.com/Automattic/studio/assets/14905380/e88ada9c-cd44-420d-9827-60226a48367e>| <img width=400 src=https://github.com/Automattic/studio/assets/14905380/fb1d14e6-4c7f-45b2-818a-124500f4cbaa> |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Windows
- Open the app.
- Observe that in the title bar there's a button on the top-left corner.
- Click on the menu button.
- Observe a context menu is displayed with the same items as the application menu on macOS.
- Click on some if the items to check the menu works as expected.

### macOS
- Open the app.
- Observe the application menu is displayed as in previous versions.
- Observe no menu button is displayed in the title bar.
- Click on some if the items to check the menu works as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
