### PR TITLE
Don't install SQLlite on server start when it wasn't installed already

### DIFF
--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -223,7 +223,12 @@ export async function startServer(
 		return null;
 	}
 
-	if ( ( await isSqlLiteInstalled() ) && ( await isSqliteInstallationOutdated() ) ) {
+	const SQLitePath = `${ server.details.path }/wp-content/mu-plugins/${ SQLITE_FILENAME }`;
+	const hasWpConfig = fs.existsSync( nodePath.join( server.details.path, 'wp-config.php' ) );
+	const sqliteInstalled = await isSqlLiteInstalled( SQLitePath );
+	const sqliteOutdated = sqliteInstalled && ( await isSqliteInstallationOutdated( SQLitePath ) );
+
+	if ( ( ! sqliteInstalled && ! hasWpConfig ) || sqliteOutdated ) {
 		await setupSqliteIntegration( server.details.path );
 	}
 

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -29,6 +29,7 @@ import { sanitizeForLogging } from './lib/sanitize-for-logging';
 import { sortSites } from './lib/sort-sites';
 import {
 	isSqliteInstallationOutdated,
+	isSqlLiteInstalled,
 	removeLegacySqliteIntegrationPlugin,
 } from './lib/sqlite-versions';
 import { writeLogToFile, type LogLevel } from './logging';
@@ -222,11 +223,7 @@ export async function startServer(
 		return null;
 	}
 
-	if (
-		await isSqliteInstallationOutdated(
-			`${ server.details.path }/wp-content/mu-plugins/${ SQLITE_FILENAME }`
-		)
-	) {
+	if ( ( await isSqlLiteInstalled() ) && ( await isSqliteInstallationOutdated() ) ) {
 		await setupSqliteIntegration( server.details.path );
 	}
 

--- a/src/lib/sqlite-versions.ts
+++ b/src/lib/sqlite-versions.ts
@@ -5,14 +5,19 @@ import semver from 'semver';
 import { downloadSqliteIntegrationPlugin } from '../../vendor/wp-now/src/download';
 import getSqlitePath from '../../vendor/wp-now/src/get-sqlite-path';
 
+export async function isSqlLiteInstalled() {
+	const installPath = getSqlitePath();
+	const installedFiles = ( await fs.pathExists( installPath ) )
+		? await fs.readdir( installPath )
+		: [];
+	return installedFiles.length !== 0;
+}
+
 export async function updateLatestSqliteVersion() {
 	let shouldOverwrite = false;
 	const installedPath = getSqlitePath();
-	const installedFiles = ( await fs.pathExists( installedPath ) )
-		? await fs.readdir( installedPath )
-		: [];
-	if ( installedFiles.length !== 0 ) {
-		shouldOverwrite = await isSqliteInstallationOutdated( installedPath );
+	if ( await isSqlLiteInstalled() ) {
+		shouldOverwrite = await isSqliteInstallationOutdated();
 	}
 
 	await downloadSqliteIntegrationPlugin( { overwrite: shouldOverwrite } );
@@ -20,7 +25,8 @@ export async function updateLatestSqliteVersion() {
 	await removeLegacySqliteIntegrationPlugin( installedPath );
 }
 
-export async function isSqliteInstallationOutdated( installationPath: string ): Promise< boolean > {
+export async function isSqliteInstallationOutdated(): Promise< boolean > {
+	const installationPath = getSqlitePath();
 	const installedVersion = getSqliteVersionFromInstallation( installationPath );
 	const latestVersion = await getLatestSqliteVersion();
 

--- a/src/lib/sqlite-versions.ts
+++ b/src/lib/sqlite-versions.ts
@@ -5,8 +5,7 @@ import semver from 'semver';
 import { downloadSqliteIntegrationPlugin } from '../../vendor/wp-now/src/download';
 import getSqlitePath from '../../vendor/wp-now/src/get-sqlite-path';
 
-export async function isSqlLiteInstalled() {
-	const installPath = getSqlitePath();
+export async function isSqlLiteInstalled( installPath: string ) {
 	const installedFiles = ( await fs.pathExists( installPath ) )
 		? await fs.readdir( installPath )
 		: [];
@@ -16,8 +15,8 @@ export async function isSqlLiteInstalled() {
 export async function updateLatestSqliteVersion() {
 	let shouldOverwrite = false;
 	const installedPath = getSqlitePath();
-	if ( await isSqlLiteInstalled() ) {
-		shouldOverwrite = await isSqliteInstallationOutdated();
+	if ( await isSqlLiteInstalled( installedPath ) ) {
+		shouldOverwrite = await isSqliteInstallationOutdated( installedPath );
 	}
 
 	await downloadSqliteIntegrationPlugin( { overwrite: shouldOverwrite } );
@@ -25,8 +24,7 @@ export async function updateLatestSqliteVersion() {
 	await removeLegacySqliteIntegrationPlugin( installedPath );
 }
 
-export async function isSqliteInstallationOutdated(): Promise< boolean > {
-	const installationPath = getSqlitePath();
+export async function isSqliteInstallationOutdated( installationPath: string ): Promise< boolean > {
 	const installedVersion = getSqliteVersionFromInstallation( installationPath );
 	const latestVersion = await getLatestSqliteVersion();
 

--- a/src/tests/ipc-handlers.test.ts
+++ b/src/tests/ipc-handlers.test.ts
@@ -8,7 +8,7 @@ import { SQLITE_FILENAME } from '../../vendor/wp-now/src/constants';
 import { downloadSqliteIntegrationPlugin } from '../../vendor/wp-now/src/download';
 import { createSite, startServer } from '../ipc-handlers';
 import { isEmptyDir, pathExists } from '../lib/fs-utils';
-import { isSqliteInstallationOutdated } from '../lib/sqlite-versions';
+import { isSqliteInstallationOutdated, isSqlLiteInstalled } from '../lib/sqlite-versions';
 import { SiteServer, createSiteWorkingDirectory } from '../site-server';
 
 jest.mock( 'fs' );
@@ -84,6 +84,7 @@ describe( 'startServer', () => {
 		it( 'should update sqlite-database-integration plugin', async () => {
 			const mockSitePath = 'mock-site-path';
 			( isSqliteInstallationOutdated as jest.Mock ).mockResolvedValue( true );
+			( isSqlLiteInstalled as jest.Mock ).mockResolvedValue( true );
 			( SiteServer.get as jest.Mock ).mockReturnValue( {
 				details: { path: mockSitePath },
 				start: jest.fn(),


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/7416

When a site is started (not created), we check if the currently installed version of the SQLite integration is outdated and then try to update it. In the case that the SQLite integration was not installed we only want to install it when there is no wp-config.php file present.

## Proposed Changes

- Check if the SQLite integration was installed before. If not, we don't try to install it.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Download WordPress and create wp-config.php with settings for a local MySQL server.
    A quick way to run local MariaDB is by using docker with:
    `docker run --name local-mariadb -e MYSQL_ROOT_PASSWORD=password -e MYSQL_DATABASE=wordpress_db -e MYSQL_USER=wp_user -e MYSQL_PASSWORD=wp_password -p 3306:3306 -d mariadb:latest`
3. Create site in Studio using the manually downloaded WordPress version
4. Observe that the site uses MySQL and does not install SQLlite after creation.
5. Turn off the site and start it again.
6. Observe that the SQLite integration is not installed.
7. Now stop the server, remove wp-config.php and start the server again.
8. Observe that SQLite is now installed and your wp site is using the SQLite db.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
