### PR TITLE
Studio: Download the latest wp-cli and bundle it

### DIFF
--- a/scripts/download-wp-server-files.ts
+++ b/scripts/download-wp-server-files.ts
@@ -17,6 +17,12 @@ const FILES_TO_DOWNLOAD = [
 		description: 'SQLite files',
 		url: 'https://downloads.wordpress.org/plugin/sqlite-database-integration.zip',
 	},
+	{
+		name: 'wp-cli',
+		description: 'WP-CLI phar file',
+		url: 'https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar',
+		destinationPath: path.join( WP_SERVER_FILES_PATH, 'wp-cli' ),
+	},
 ];
 
 const downloadFile = async ( {
@@ -75,8 +81,13 @@ const downloadFile = async ( {
 		} );
 	} );
 
-	console.log( `[${ name }] Extracting files from zip ...` );
-	await extract( zipPath, { dir: extractedPath } );
+	if ( name === 'wp-cli' ) {
+		console.log( `[${ name }] Moving WP-CLI to destination ...` );
+		fs.moveSync( zipPath, path.join( extractedPath, 'wp-cli.phar' ), { overwrite: true } );
+	} else {
+		console.log( `[${ name }] Extracting files from zip ...` );
+		await extract( zipPath, { dir: extractedPath } );
+	}
 	console.log( `[${ name }] Files extracted` );
 };
 

--- a/src/setup-wp-server-files.ts
+++ b/src/setup-wp-server-files.ts
@@ -49,28 +49,9 @@ async function copyBundledSqlite() {
 	await recursiveCopyDirectory( bundledSqlitePath, getSqlitePath() );
 }
 
-async function copyBundledWPCLI() {
-	const bundledWPCLIInstalled = await fs.pathExists( getWpCliPath() );
-	console.log( `Copying bundled WP-CLI...` );
-	console.log( bundledWPCLIInstalled );
-	if ( bundledWPCLIInstalled ) {
-		return;
-	}
-	const bundledWPCLIPath = path.join( getResourcesPath(), 'wp-files', 'wp-cli', 'wp-cli.phar' );
-	await fs.copyFile( bundledWPCLIPath, getWpCliPath() );
-}
-
-async function updateLatestWPCLI() {
-	const shouldOverwrite = true;
-	const res = await downloadWPCLI( shouldOverwrite );
-	console.log( `WP-CLI downloaded:`, res );
-}
-
 export default async function setupWPServerFiles() {
 	await copyBundledLatestWPVersion();
 	await copyBundledSqlite();
-	await copyBundledWPCLI();
 	await updateLatestWordPressVersion();
 	await updateLatestSqliteVersion();
-	await updateLatestWPCLI();
 }

--- a/src/setup-wp-server-files.ts
+++ b/src/setup-wp-server-files.ts
@@ -2,8 +2,9 @@ import path from 'path';
 import fs from 'fs-extra';
 import semver from 'semver';
 import { SQLITE_FILENAME } from '../vendor/wp-now/src/constants';
-import { getWordPressVersionPath } from '../vendor/wp-now/src/download';
+import { downloadWPCLI, getWordPressVersionPath } from '../vendor/wp-now/src/download';
 import getSqlitePath from '../vendor/wp-now/src/get-sqlite-path';
+import getWpCliPath from '../vendor/wp-now/src/get-wp-cli-path';
 import { recursiveCopyDirectory } from './lib/fs-utils';
 import { updateLatestSqliteVersion } from './lib/sqlite-versions';
 import {
@@ -48,9 +49,28 @@ async function copyBundledSqlite() {
 	await recursiveCopyDirectory( bundledSqlitePath, getSqlitePath() );
 }
 
+async function copyBundledWPCLI() {
+	const bundledWPCLIInstalled = await fs.pathExists( getWpCliPath() );
+	console.log( `Copying bundled WP-CLI...` );
+	console.log( bundledWPCLIInstalled );
+	if ( bundledWPCLIInstalled ) {
+		return;
+	}
+	const bundledWPCLIPath = path.join( getResourcesPath(), 'wp-files', 'wp-cli', 'wp-cli.phar' );
+	await fs.copyFile( bundledWPCLIPath, getWpCliPath() );
+}
+
+async function updateLatestWPCLI() {
+	const shouldOverwrite = true;
+	const res = await downloadWPCLI( shouldOverwrite );
+	console.log( `WP-CLI downloaded:`, res );
+}
+
 export default async function setupWPServerFiles() {
 	await copyBundledLatestWPVersion();
 	await copyBundledSqlite();
+	await copyBundledWPCLI();
 	await updateLatestWordPressVersion();
 	await updateLatestSqliteVersion();
+	await updateLatestWPCLI();
 }

--- a/vendor/wp-now/src/download.ts
+++ b/vendor/wp-now/src/download.ts
@@ -53,10 +53,11 @@ async function downloadFile({
 	url,
 	destinationFilePath,
 	itemName,
+	overwrite = false,
 }): Promise<DownloadFileAndUnzipResult> {
 	let statusCode = 0;
 	try {
-		if (fs.existsSync(destinationFilePath)) {
+		if (fs.existsSync(destinationFilePath) && !overwrite ) {
 			return { downloaded: false, statusCode: 0 };
 		}
 		fs.ensureDirSync(path.dirname(destinationFilePath));
@@ -90,11 +91,12 @@ async function downloadFile({
 	}
 }
 
-export async function downloadWPCLI() {
+export async function downloadWPCLI( overwrite = false ) {
 	return downloadFile({
 		url: WP_CLI_URL,
 		destinationFilePath: getWpCliPath(),
 		itemName: 'wp-cli',
+		overwrite,
 	});
 }
 

--- a/vendor/wp-now/src/get-wp-cli-path.ts
+++ b/vendor/wp-now/src/get-wp-cli-path.ts
@@ -1,13 +1,13 @@
 import path from 'path';
-import getWpNowPath from './get-wp-now-path';
 import getWpCliTmpPath from './get-wp-cli-tmp-path';
+import { getResourcesPath } from '../../../src/storage/paths';
 
 /**
  * The path for wp-cli phar file within the WP Now folder.
  */
 export default function getWpCliPath() {
 	if (process.env.NODE_ENV !== 'test') {
-		return path.join(getWpNowPath(), 'wp-cli.phar');
+	  return path.join( getResourcesPath(), 'wp-files', 'wp-cli', 'wp-cli.phar' );
 	}
 	return path.join(getWpCliTmpPath(), 'wp-cli.phar');
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/7320

## Proposed Changes

This PR do the following:
1. Adds wp-cli in the studio bundle.
2. Extract and update it when the user starts the app.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Run `nvm use && npm i`
2. Notice that the WP-CLI has been downloaded in `wp-files/wp-cli` folder.
3. Run `npm run package`
4. Ensure that `wp-cli.phar` exists in `./out/<architecture>/resources` folder under `wp-files` folder.
5. Start studio app.
6. Ensure that the `wp-cli.phar` is updated and is now located under `~/.config/Studio/server-files` directory.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
