### PR TITLE
Ensure manifest output is displayed under correct group

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -74,8 +74,9 @@ steps:
       buildkite-agent artifact download "*.nupkg" .
       buildkite-agent artifact download "*\\RELEASES" .
 
-      echo "--- :node: Generating Release Manifest"
       .buildkite/commands/install-node-dependencies.sh
+
+      echo "--- :node: Generating Release Manifest"
       IS_DEV_BUILD=true node ./scripts/generate-releases-manifest.mjs
 
       echo "--- :fastlane: Distributing Dev Builds"
@@ -132,8 +133,9 @@ steps:
       buildkite-agent artifact download "*.nupkg" .
       buildkite-agent artifact download "*\\RELEASES" .
 
-      echo "--- :node: Generating Release Manifest"
       .buildkite/commands/install-node-dependencies.sh
+
+      echo "--- :node: Generating Release Manifest"
       node ./scripts/generate-releases-manifest.mjs
 
       echo "--- :fastlane: Distributing Release Builds"


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Proposed Changes

I propose to move comment down to ensure manifest script output is logged under correct group. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Merge and confirm that manifest script output is logged under 'Generating Release Manifest' section.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?