### PR TITLE
Define concurrency group to fix manifest generation race condition

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -83,6 +83,9 @@ steps:
       bundle exec fastlane distribute_dev_build
     agents:
       queue: "mac" #
+    concurrency_group: 'studio/release-manifest-update'
+    concurrency: 1
+    concurrency_method: eager
     depends_on:
       - step: "dev-mac"
       - step: "dev-windows"
@@ -141,6 +144,9 @@ steps:
       bundle exec fastlane distribute_release_build
     agents:
       queue: "mac" # 
+    concurrency_group: 'studio/release-manifest-update'
+    concurrency: 1
+    concurrency_method: eager
     depends_on:
       - step: "release-mac"
       - step: "release-windows"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -83,6 +83,8 @@ steps:
       bundle exec fastlane distribute_dev_build
     agents:
       queue: "mac" #
+    # Using concurrency_group to ensure the CI builds from `trunk` & the git tag, which are likely to run at roughly the
+    # same time, don't run into a race condition when downloading+updating+uploading the `releases.json` file from/to S3
     concurrency_group: 'studio/release-manifest-update'
     concurrency: 1
     concurrency_method: eager
@@ -144,6 +146,8 @@ steps:
       bundle exec fastlane distribute_release_build
     agents:
       queue: "mac" # 
+    # Using concurrency_group to ensure the CI builds from `trunk` & the git tag, which are likely to run at roughly the
+    # same time, don't run into a race condition when downloading+updating+uploading the `releases.json` file from/to S3
     concurrency_group: 'studio/release-manifest-update'
     concurrency: 1
     concurrency_method: eager


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Proposed Changes

I propose to define a concurrency group to fix the manifest generation race condition that can occur between trunk and release tag builds.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Merge and confirm manifest is generated and uploaded correctly.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
