### PR TITLE
Add direct links to feature request and bug report forms

### DIFF
--- a/src/about-menu/about-menu.html
+++ b/src/about-menu/about-menu.html
@@ -83,7 +83,7 @@
         <p class="links">
           <a href="https://github.com/Automattic/studio" target="_blank">GitHub</a>
           <span class="separator">&middot;</span>
-          <a href="https://github.com/Automattic/studio/issues/new/choose" target="_blank">Report a bug</a>
+          <a href="https://github.com/Automattic/studio/issues/new/choose" target="_blank">Share Feedback</a>
         </p>
   </div>
     <script>

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -9,8 +9,10 @@ export const WINDOWS_TITLEBAR_HEIGHT = 32;
 export const ABOUT_WINDOW_WIDTH = 284;
 export const ABOUT_WINDOW_HEIGHT = 284;
 export const STUDIO_DOCS_URL = `https://developer.wordpress.com/docs/developer-tools/studio/`;
-export const BUG_REPORT_URL = 'https://github.com/Automattic/studio/issues/new?assignees=&labels=Needs+triage%2C%5BType%5D+Bug&projects=&template=bug_report.yml';
-export const FEATURE_REQUEST_URL = 'https://github.com/Automattic/studio/issues/new?assignees=&labels=%5BType%5D+Feature+Request&projects=&template=feature_request.yml&title=Feature+Request%3A';
+export const BUG_REPORT_URL =
+	'https://github.com/Automattic/studio/issues/new?assignees=&labels=Needs+triage%2C%5BType%5D+Bug&projects=&template=bug_report.yml';
+export const FEATURE_REQUEST_URL =
+	'https://github.com/Automattic/studio/issues/new?assignees=&labels=%5BType%5D+Feature+Request&projects=&template=feature_request.yml&title=Feature+Request%3A';
 export const WPCOM_PROFILE_URL = `https://wordpress.com/me`;
 // OAuth constants
 export const CLIENT_ID = '95109';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -9,6 +9,8 @@ export const WINDOWS_TITLEBAR_HEIGHT = 32;
 export const ABOUT_WINDOW_WIDTH = 284;
 export const ABOUT_WINDOW_HEIGHT = 284;
 export const STUDIO_DOCS_URL = `https://developer.wordpress.com/docs/developer-tools/studio/`;
+export const BUG_REPORT_URL = 'https://github.com/Automattic/studio/issues/new?assignees=&labels=Needs+triage%2C%5BType%5D+Bug&projects=&template=bug_report.yml';
+export const FEATURE_REQUEST_URL = 'https://github.com/Automattic/studio/issues/new?assignees=&labels=%5BType%5D+Feature+Request&projects=&template=feature_request.yml&title=Feature+Request%3A';
 export const WPCOM_PROFILE_URL = `https://wordpress.com/me`;
 // OAuth constants
 export const CLIENT_ID = '95109';

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -8,7 +8,7 @@ import {
 } from 'electron';
 import { __ } from '@wordpress/i18n';
 import { openAboutWindow } from './about-menu/open-about-menu';
-import { BUG_REPORT_URL, FEATURE_REQUEST_URL, STUDIO_DOCS_URL} from './constants';
+import { BUG_REPORT_URL, FEATURE_REQUEST_URL, STUDIO_DOCS_URL } from './constants';
 import { withMainWindow } from './main-window';
 import { isUpdateReadyToInstall, manualCheckForUpdates } from './updates';
 

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -8,7 +8,7 @@ import {
 } from 'electron';
 import { __ } from '@wordpress/i18n';
 import { openAboutWindow } from './about-menu/open-about-menu';
-import { STUDIO_DOCS_URL } from './constants';
+import { BUG_REPORT_URL, FEATURE_REQUEST_URL, STUDIO_DOCS_URL} from './constants';
 import { withMainWindow } from './main-window';
 import { isUpdateReadyToInstall, manualCheckForUpdates } from './updates';
 
@@ -163,6 +163,19 @@ function getAppMenu( mainWindow: BrowserWindow | null ) {
 					label: __( 'Studio Help' ),
 					click: () => {
 						shell.openExternal( STUDIO_DOCS_URL );
+					},
+				},
+				{ type: 'separator' },
+				{
+					label: __( 'Report an Issue' ),
+					click: () => {
+						shell.openExternal( BUG_REPORT_URL );
+					},
+				},
+				{
+					label: __( 'Propose a Feature' ),
+					click: () => {
+						shell.openExternal( FEATURE_REQUEST_URL );
 					},
 				},
 			],


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/7459

## Proposed Changes

I propose to add links pointing to bug report and feature request forms, and to change link text in About Studio window to more generic one.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Test if all three links point to the correct locations

<img width="367" alt="Screenshot 2024-05-29 at 14 10 00" src="https://github.com/Automattic/studio/assets/727413/98df68cd-b2ef-4557-9a71-67bfd95735d9">

<img width="396" alt="Screenshot 2024-05-29 at 14 10 06" src="https://github.com/Automattic/studio/assets/727413/dee0c7dd-8944-45cc-86ce-2b57e5a4d5d8">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
