### PR TITLE
Add assistant message for non authenticated users

### DIFF
--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -123,7 +123,7 @@ export function ContentTabAssistant( { selectedSite }: ContentTabAssistantProps 
 						</p>
 						<p className="mb-1.5">
 							{ createInterpolateElement(
-								__( "If you don't have an account yet, <a>create one for free</a>" ),
+								__( "If you don't have an account yet, <a>create one for free</a>." ),
 								{
 									a: (
 										<Button

--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -1,3 +1,4 @@
+import { createInterpolateElement } from '@wordpress/element';
 import { Icon, external } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import React, { useState, useEffect, useRef } from 'react';
@@ -5,6 +6,7 @@ import { useAssistant } from '../hooks/use-assistant';
 import { useAuth } from '../hooks/use-auth';
 import { useOffline } from '../hooks/use-offline';
 import { cx } from '../lib/cx';
+import { getIpcApi } from '../lib/get-ipc-api';
 import Button from './button';
 import { AssistantIcon } from './icons/assistant';
 import { MenuIcon } from './icons/menu';
@@ -16,10 +18,11 @@ interface ContentTabAssistantProps {
 interface MessageProps {
 	children: React.ReactNode;
 	isUser: boolean;
+	className?: string;
 }
 
-export const Message = ( { children, isUser }: MessageProps ) => (
-	<div className={ cx( 'flex mb-2 mt-2', isUser ? 'justify-end' : 'justify-start' ) }>
+export const Message = ( { children, isUser, className }: MessageProps ) => (
+	<div className={ cx( 'flex mb-2 mt-2', isUser ? 'justify-end' : 'justify-start', className ) }>
 		<div
 			className={ cx(
 				'inline-block p-3 rounded-sm border border-gray-300 lg:max-w-[70%] select-text',
@@ -106,11 +109,26 @@ export function ContentTabAssistant( { selectedSite }: ContentTabAssistantProps 
 						</div>
 					</>
 				) : (
-					<Message isUser={ false }>
+					<Message className="w-full" isUser={ false }>
 						<p className="mb-1.5 a8c-label-semibold">{ __( 'Hold up!' ) }</p>
+						<p>
+							{ __( 'You need to log in to your WordPress.com account to use the assistant.' ) }
+						</p>
 						<p className="mb-1.5">
-							{ __(
-								"You need to log in to your WordPress.com account to use the assistant. If you don't have an account yet, create one for free."
+							{ createInterpolateElement(
+								__( "If you don't have an account yet, <a>create one for free</a>" ),
+								{
+									a: (
+										<Button
+											variant="link"
+											onClick={ () =>
+												getIpcApi().openURL(
+													'https://wordpress.com/?utm_source=studio&utm_medium=referral&utm_campaign=assistant_onboarding'
+												)
+											}
+										/>
+									),
+								}
 							) }
 						</p>
 						<p className="mb-3">

--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -90,7 +90,7 @@ export function ContentTabAssistant( { selectedSite }: ContentTabAssistantProps 
 		}
 	}, [ isAuthenticated ] );
 
-	const disabledInput = isOffline || ! isAuthenticated;
+	const disabled = isOffline || ! isAuthenticated;
 	return (
 		<div className="h-full flex flex-col bg-gray-50">
 			<div
@@ -155,7 +155,7 @@ export function ContentTabAssistant( { selectedSite }: ContentTabAssistantProps 
 				<div className="relative flex-1">
 					<input
 						ref={ inputRef }
-						disabled={ disabledInput }
+						disabled={ disabled }
 						type="text"
 						placeholder="Ask Studio WordPress Assistant"
 						className="w-full p-3 rounded-sm border-black border ltr:pl-8 rtl:pr-8 disabled:border-gray-300 disabled:cursor-not-allowed"
@@ -167,7 +167,12 @@ export function ContentTabAssistant( { selectedSite }: ContentTabAssistantProps 
 						<AssistantIcon />
 					</div>
 				</div>
-				<Button aria-label="menu" className="p-2 ml-2 cursor-pointer" onClick={ clearInput }>
+				<Button
+					disabled={ disabled }
+					aria-label="menu"
+					className="p-2 ml-2 cursor-pointer"
+					onClick={ clearInput }
+				>
 					<MenuIcon />
 				</Button>
 			</div>

--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -38,6 +38,7 @@ export function ContentTabAssistant( { selectedSite }: ContentTabAssistantProps 
 	const { messages, addMessage, clearMessages } = useAssistant( selectedSite.name );
 	const [ input, setInput ] = useState< string >( '' );
 	const endOfMessagesRef = useRef< HTMLDivElement >( null );
+	const inputRef = useRef< HTMLInputElement >( null );
 	const { isAuthenticated, authenticate } = useAuth();
 	const isOffline = useOffline();
 	const { __ } = useI18n();
@@ -82,6 +83,12 @@ export function ContentTabAssistant( { selectedSite }: ContentTabAssistantProps 
 			endOfMessagesRef.current.scrollIntoView( { behavior: 'smooth' } );
 		}
 	}, [ messages ] );
+
+	useEffect( () => {
+		if ( isAuthenticated && inputRef.current ) {
+			inputRef.current.focus();
+		}
+	}, [ isAuthenticated ] );
 
 	const disabledInput = isOffline || ! isAuthenticated;
 	return (
@@ -147,6 +154,7 @@ export function ContentTabAssistant( { selectedSite }: ContentTabAssistantProps 
 			>
 				<div className="relative flex-1">
 					<input
+						ref={ inputRef }
 						disabled={ disabledInput }
 						type="text"
 						placeholder="Ask Studio WordPress Assistant"

--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -141,7 +141,7 @@ export function ContentTabAssistant( { selectedSite }: ContentTabAssistantProps 
 						<p className="mb-3">
 							{ __( 'Every account gets 200 prompts included for free each month.' ) }
 						</p>
-						<Button variant="primary" onClick={ () => authenticate() }>
+						<Button variant="primary" onClick={ authenticate }>
 							{ __( 'Log in to WordPress.com' ) }
 							<Icon className="ltr:ml-1 rtl:mr-1 rtl:scale-x-[-1]" icon={ external } size={ 21 } />
 						</Button>

--- a/src/components/tests/content-tab-assistant.test.tsx
+++ b/src/components/tests/content-tab-assistant.test.tsx
@@ -1,7 +1,9 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { useAuth } from '../../hooks/use-auth';
 import { ContentTabAssistant } from '../content-tab-assistant';
 
 jest.mock( '../../hooks/use-theme-details' );
+jest.mock( '../../hooks/use-auth' );
 
 const runningSite = {
 	name: 'Test Site',
@@ -18,10 +20,42 @@ const initialMessages = [
 ];
 
 describe( 'ContentTabAssistant', () => {
+	const clientReqPost = jest.fn().mockResolvedValue( {
+		id: 'chatcmpl-9USNsuhHWYsPAUNiOhOG2970Hjwwb',
+		object: 'chat.completion',
+		created: 1717045976,
+		model: 'test',
+		choices: [
+			{
+				index: 0,
+				message: {
+					role: 'assistant',
+					content:
+						'Hello! How can I assist you today? Are you working on a WordPress project, or do you need help with something specific related to WordPress or WP-CLI?',
+				},
+				logprobs: null,
+				finish_reason: 'stop',
+			},
+		],
+		usage: { prompt_tokens: 980, completion_tokens: 36, total_tokens: 1016 },
+		system_fingerprint: 'fp_777',
+	} );
+
+	const authenticate = jest.fn();
 	beforeEach( () => {
 		jest.clearAllMocks();
 		window.HTMLElement.prototype.scrollIntoView = jest.fn();
 		localStorage.clear();
+		jest.useFakeTimers();
+		( useAuth as jest.Mock ).mockImplementation( () => ( {
+			client: {
+				req: {
+					post: clientReqPost,
+				},
+			},
+			isAuthenticated: true,
+			authenticate,
+		} ) );
 	} );
 
 	test( 'renders placeholder text input', () => {
@@ -29,6 +63,7 @@ describe( 'ContentTabAssistant', () => {
 
 		const textInput = screen.getByPlaceholderText( 'Ask Studio WordPress Assistant' );
 		expect( textInput ).toBeInTheDocument();
+		expect( textInput ).toBeEnabled();
 	} );
 
 	test( 'sends message and receives a simulated response', async () => {
@@ -100,5 +135,71 @@ describe( 'ContentTabAssistant', () => {
 			expect( storedMessages ).toHaveLength( 3 );
 			expect( storedMessages[ 2 ].content ).toBe( 'New message' );
 		} );
+	} );
+
+	test( 'renders assistant chat when authenticated', () => {
+		render( <ContentTabAssistant selectedSite={ runningSite } /> );
+
+		expect(
+			screen.getByText(
+				'Welcome to the Studio assistant. I can help manage your site, debug issues, and navigate your way around the WordPress ecosystem.'
+			)
+		).toBeInTheDocument();
+	} );
+
+	test( 'renders default message when not authenticated', () => {
+		( useAuth as jest.Mock ).mockImplementation( () => ( {
+			client: {
+				req: {
+					post: clientReqPost,
+				},
+			},
+			isAuthenticated: false,
+			authenticate,
+		} ) );
+		render( <ContentTabAssistant selectedSite={ runningSite } /> );
+
+		expect( screen.getByText( 'Hold up!' ) ).toBeInTheDocument();
+		expect(
+			screen.getByText( 'You need to log in to your WordPress.com account to use the assistant.' )
+		).toBeInTheDocument();
+	} );
+
+	test( 'clicks login button when not authenticated', () => {
+		( useAuth as jest.Mock ).mockImplementation( () => ( {
+			client: {
+				req: {
+					post: clientReqPost,
+				},
+			},
+			isAuthenticated: false,
+			authenticate,
+		} ) );
+		render( <ContentTabAssistant selectedSite={ runningSite } /> );
+
+		const loginButton = screen.getByRole( 'button', { name: 'Log in to WordPress.com' } );
+		expect( loginButton ).toBeInTheDocument();
+
+		fireEvent.click( loginButton );
+		expect( authenticate ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( 'disables input and buttons when offline or not authenticated', () => {
+		( useAuth as jest.Mock ).mockImplementation( () => ( {
+			client: {
+				req: {
+					post: clientReqPost,
+				},
+			},
+			isAuthenticated: false,
+			authenticate,
+		} ) );
+		render( <ContentTabAssistant selectedSite={ runningSite } /> );
+
+		const textInput = screen.getByPlaceholderText( 'Ask Studio WordPress Assistant' );
+		const menuIcon = screen.getByLabelText( 'menu' );
+
+		expect( textInput ).toBeDisabled();
+		expect( menuIcon ).toBeDisabled();
 	} );
 } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

- Closes https://github.com/Automattic/dotcom-forge/issues/7410

## Proposed Changes

- Add message for non authenticated users
- It has a link to create a WPcom account similar to Demo sites message
- It has a button to authenticate the users
- The input is disabled if the user is not authenticated or offline

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
- Run `STUDIO_AI=true npm start`
- On the left sidebar click your profile picture to log out
- Click on the AI Assistant tab
- Observe a default message
- Click on the text input and observe it's disabled
- Click on the "create one for free" link and observe the browser opens correctly
- Click on Log in to WordPress.com
- Follow the Auth flow
- Observe you are logged in and you can send messages to the assistant as usual


https://github.com/Automattic/studio/assets/779993/7c1c93e8-d10d-4fbe-8b49-4bc908aa603b



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?