### PR TITLE
Studio: Reclaim unavailable port after site deletion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
 				"archiver": "^6.0.1",
 				"compressible": "2.0.18",
 				"compression": "1.7.4",
+				"cross-port-killer": "^1.4.0",
 				"date-fns": "^3.3.1",
 				"electron-squirrel-startup": "^1.0.0",
 				"express": "4.19.2",
@@ -8610,6 +8611,14 @@
 			"resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
 			"integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
 			"dev": true
+		},
+		"node_modules/cross-port-killer": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/cross-port-killer/-/cross-port-killer-1.4.0.tgz",
+			"integrity": "sha512-ujqfftKsSeorFMVI6JP25xMBixHEaDWVK+NarRZAGnJjR5AhebRQU+g+k/Lj8OHwM6f+wrrs8u5kkCdI7RLtxQ==",
+			"bin": {
+				"kill-port": "source/cli.js"
+			}
 		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.3",
@@ -27135,6 +27144,11 @@
 			"resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
 			"integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
 			"dev": true
+		},
+		"cross-port-killer": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/cross-port-killer/-/cross-port-killer-1.4.0.tgz",
+			"integrity": "sha512-ujqfftKsSeorFMVI6JP25xMBixHEaDWVK+NarRZAGnJjR5AhebRQU+g+k/Lj8OHwM6f+wrrs8u5kkCdI7RLtxQ=="
 		},
 		"cross-spawn": {
 			"version": "7.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8626,6 +8626,12 @@
 			"integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
 			"dev": true
 		},
+		"node_modules/cross-dirname": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/cross-dirname/-/cross-dirname-0.1.0.tgz",
+			"integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
+			"dev": true
+		},
 		"node_modules/cross-port-killer": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/cross-port-killer/-/cross-port-killer-1.4.0.tgz",
@@ -8633,12 +8639,6 @@
 			"bin": {
 				"kill-port": "source/cli.js"
 			}
-		},
-		"node_modules/cross-dirname": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/cross-dirname/-/cross-dirname-0.1.0.tgz",
-			"integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
-			"dev": true
 		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.3",
@@ -27192,16 +27192,16 @@
 			"integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
 			"dev": true
 		},
-		"cross-port-killer": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/cross-port-killer/-/cross-port-killer-1.4.0.tgz",
-			"integrity": "sha512-ujqfftKsSeorFMVI6JP25xMBixHEaDWVK+NarRZAGnJjR5AhebRQU+g+k/Lj8OHwM6f+wrrs8u5kkCdI7RLtxQ=="
-		},
 		"cross-dirname": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/cross-dirname/-/cross-dirname-0.1.0.tgz",
 			"integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
 			"dev": true
+		},
+		"cross-port-killer": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/cross-port-killer/-/cross-port-killer-1.4.0.tgz",
+			"integrity": "sha512-ujqfftKsSeorFMVI6JP25xMBixHEaDWVK+NarRZAGnJjR5AhebRQU+g+k/Lj8OHwM6f+wrrs8u5kkCdI7RLtxQ=="
 		},
 		"cross-spawn": {
 			"version": "7.0.3",

--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
 		"archiver": "^6.0.1",
 		"compressible": "2.0.18",
 		"compression": "1.7.4",
+		"cross-port-killer": "^1.4.0",
 		"date-fns": "^3.3.1",
 		"electron-squirrel-startup": "^1.0.0",
 		"express": "4.19.2",

--- a/src/lib/port-finder.ts
+++ b/src/lib/port-finder.ts
@@ -85,7 +85,7 @@ class PortFinder {
 				} )
 				.finally( () => {
 					// Ensure port finder cycles through newly reclaimed ports by removing
-					// from unavailable ports list and resetting #searchPort.
+					// from #unavailablePorts list and resetting #searchPort.
 					this.#unavailablePorts = this.#unavailablePorts.filter(
 						( unavailablePort ) => unavailablePort !== port
 					);

--- a/src/lib/port-finder.ts
+++ b/src/lib/port-finder.ts
@@ -72,6 +72,12 @@ class PortFinder {
 			this.#unavailablePorts.push( port );
 		}
 	}
+
+	public reclaimUnavailablePort( port?: number ): void {
+		this.#unavailablePorts = this.#unavailablePorts.filter(
+			( unavailablePort ) => unavailablePort !== port
+		);
+	}
 }
 
 export const portFinder = PortFinder.getInstance();

--- a/src/lib/port-finder.ts
+++ b/src/lib/port-finder.ts
@@ -85,11 +85,11 @@ class PortFinder {
 				} )
 				.finally( () => {
 					// Ensure port finder cycles through newly reclaimed ports by removing
-					// from #unavailablePorts list and resetting #searchPort.
+					// from #unavailablePorts list and resetting #openPort.
 					this.#unavailablePorts = this.#unavailablePorts.filter(
 						( unavailablePort ) => unavailablePort !== port
 					);
-					this.#searchPort = DEFAULT_PORT;
+					this.#openPort = DEFAULT_PORT;
 				} );
 		}
 	}

--- a/src/lib/port-finder.ts
+++ b/src/lib/port-finder.ts
@@ -74,7 +74,7 @@ class PortFinder {
 		}
 	}
 
-	public reclaimUnavailablePort( port?: number ): void {
+	public releasePort( port?: number ): void {
 		if ( port && this.#unavailablePorts.includes( port ) ) {
 			killPort( port )
 				.then( () => {

--- a/src/site-server.ts
+++ b/src/site-server.ts
@@ -60,7 +60,7 @@ export class SiteServer {
 		}
 		await this.stop();
 		servers.delete( this.details.id );
-		portFinder.reclaimUnavailablePort( this.details.port );
+		portFinder.releasePort( this.details.port );
 	}
 
 	async start() {

--- a/src/site-server.ts
+++ b/src/site-server.ts
@@ -60,6 +60,7 @@ export class SiteServer {
 		}
 		await this.stop();
 		servers.delete( this.details.id );
+		portFinder.reclaimUnavailablePort( this.details.port );
 	}
 
 	async start() {


### PR DESCRIPTION
Fixes: 7366-gh-Automattic/dotcom-forge

## Proposed Changes

- With the changes in this PR, ports are now released when a site is deleted and the Studio app will re-use them if users create more sites.
- The following main steps were necessary to achieve this:
  - Kill the processes associated with the port, so that it's fully released and not lingering in a `CLOSED` state following the site deletion.
  - Remove port from [Studio's running list of unavailable ports](https://github.com/Automattic/studio/blob/9b5d9472e39d1e6b45861e9d4926db35e35d3556/src/lib/port-finder.ts#L70).
  - Reset [the default port used](https://github.com/Automattic/studio/blob/9b5d9472e39d1e6b45861e9d4926db35e35d3556/src/lib/port-finder.ts#L7) so that the app cycles through the newly available port.
 
## Testing Instructions

- Create a new site in the Studio app and make a note of the port via the local URL (e.g. `8881`).
- Verify the port is in use by running `lsof -i :8881` in the command line (replace `8881` with your site's port). 
- In Studio, navigate to the Settings tab and delete the site.
- Verify the port is now free by running `lsof -i :8881` in the command line (again, replacing `8881` with your site's port).
- Create another new site in the Studio app and verify that the app uses the port associated with the deleted site (i.e. `8881` in our examples). 

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?