### PR TITLE
Update Assistant Markdown styles

### DIFF
--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -148,11 +148,9 @@ export function ContentTabAssistant( { selectedSite }: ContentTabAssistantProps 
 		<div className="h-full flex flex-col bg-gray-50">
 			<div
 				data-testid="assistant-chat"
-				className={ cx( 'flex-1 overflow-y-auto py-4', ! isAuthenticated && 'flex items-end' ) }
+				className={ cx( 'flex-1 overflow-y-auto p-8', ! isAuthenticated && 'flex items-end' ) }
 			>
-				<div data-testid="assistant-chat" className="flex-1 overflow-y-auto px-8 py-4">
-					{ isAuthenticated ? renderAuthenticatedView() : renderUnauthenticatedView() }
-				</div>
+				{ isAuthenticated ? renderAuthenticatedView() : renderUnauthenticatedView() }
 			</div>
 			<AIInput
 				disabled={ disabled }

--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -32,7 +32,7 @@ export const Message = ( { children, isUser, className }: MessageProps ) => (
 			) }
 		>
 			{ typeof children === 'string' ? (
-				<div id="assistant-markdown">
+				<div className="assistant-markdown">
 					<Markdown>{ children }</Markdown>
 				</div>
 			) : (

--- a/src/index.css
+++ b/src/index.css
@@ -87,87 +87,94 @@ blockquote {
 	width: 100%;
 }
 
-#assistant-markdown {
+.assistant-markdown {
 	line-height: 1.6;
 	word-wrap: break-word;
 }
 
-#assistant-markdown blockquote {
+.assistant-markdown blockquote {
 	font-weight: bold;
 	margin: 1rem 0;
 	padding: 0.5rem 1rem;
 }
 
-#assistant-markdown code {
-	color: #f8f8f2;
+.assistant-markdown code {
+	background-color: #f8f8f2;
+	color: #1D2327;
 	font-family: 'Courier New', Courier, monospace;
 	font-size: 13px;
-	margin: 1rem 0;
+	padding: 0.25rem;
 	white-space: pre-wrap;
 }
 
-#assistant-markdown h1 {
+.assistant-markdown pre {
+	background-color: #1D2327;
+	border-radius: 5px;
+	margin: 1rem 0;
+	overflow-x: auto;
+	padding: 0.5em;
+}
+
+.assistant-markdown pre code {
+	background-color: transparent;
+	color: #f8f8f2;
+	padding: 0;
+}
+
+.assistant-markdown h1 {
 	font-size: 1.5rem;
 	font-weight: bold;
 	margin-bottom: 0.5rem;
 	margin-top: 1.5rem;
 }
 
-#assistant-markdown h2 {
+.assistant-markdown h2 {
 	font-size: 1.25rem;
 	font-weight: bold;
 	margin-bottom: 0.5rem;
 	margin-top: 1.5rem;
 }
 
-#assistant-markdown h3 {
+.assistant-markdown h3 {
 	font-size: 1.125rem;
 	font-weight: bold;
 	margin-bottom: 0.5rem;
 	margin-top: 1.5rem;
 }
 
-#assistant-markdown h4 {
+.assistant-markdown h4 {
 	font-size: 1rem;
 	font-weight: bold;
 	margin-bottom: 0.5rem;
 	margin-top: 1.5rem;
 }
 
-#assistant-markdown h5 {
+.assistant-markdown h5 {
 	font-size: 0.875rem;
 	font-weight: bold;
 	margin-bottom: 0.5rem;
 	margin-top: 1.5rem;
 }
 
-#assistant-markdown h6 {
+.assistant-markdown h6 {
 	font-size: 0.85rem;
 	font-weight: bold;
 	margin-bottom: 0.5rem;
 	margin-top: 1.5rem;
 }
 
-#assistant-markdown hr {
+.assistant-markdown hr {
 	border: none;
 	margin: 1rem 0;
 }
 
-#assistant-markdown ol {
+.assistant-markdown ol {
 	list-style-type: decimal;
 	margin: 1rem 0;
 	padding-left: 1.5rem;
 }
 
-#assistant-markdown pre {
-	background-color: #1D2327;
-	border-radius: 5px;
-	margin: 1rem 0;
-	overflow-x: auto;
-	padding: 1em;
-}
-
-#assistant-markdown ul {
+.assistant-markdown ul {
 	list-style-type: disc;
 	margin: 1rem 0;
 	padding-left: 1.5rem;


### PR DESCRIPTION
Updates Markdown styles used by Assistant 

## Proposed Changes

- Updates Assistant messages and styles to use `className` instead of `id` ([per discussion on #200](https://github.com/Automattic/studio/pull/200#discussion_r1625163687))
- Updates Markdown CSS styles to differentiate between inline code blocks and fenced code blocks. (Previously, inline code blocks were difficult to read against a light background.)

<img width="1580" alt="code-highlighting-2" src="https://github.com/Automattic/studio/assets/643285/4a1bb609-df10-4202-a505-a7833dab67f6">


## Testing Instructions

- Start app with AI Assistant flag enabled: `STUDIO_AI=true npm start`
- Create a site and navigate to Assistant tab
- Ask Assistant to show examples of both inline code blocks and fenced code blocks
- Observe that inline code blocks are readable

> [!NOTE]  
> I was not able to find an actual example of an inline code block in the designs to reference the colors, but I could have missed it. However, it is technically possible for the Assistant API endpoint to return inline code blocks in Markdown, so we should account for inline code block styles. Open to modifying the color patterns proposed here.  

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
