### PR TITLE
Allow user to speed up sites on Windows programmatically

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
 				"fs-extra": "11.1.1",
 				"hpagent": "1.2.0",
 				"semver": "^7.6.0",
+				"sudo-prompt": "^9.2.1",
 				"unzipper": "0.10.11",
 				"wpcom": "^5.4.2",
 				"yargs": "17.7.2"
@@ -18629,8 +18630,7 @@
 		"node_modules/sudo-prompt": {
 			"version": "9.2.1",
 			"resolved": "https://registry.npmjs.org/sudo-prompt/-/sudo-prompt-9.2.1.tgz",
-			"integrity": "sha512-Mu7R0g4ig9TUuGSxJavny5Rv0egCEtpZRNMrZaYS1vxkiIxGiGUwoezU3LazIQ+KE04hTrTfNPgxU5gzi7F5Pw==",
-			"dev": true
+			"integrity": "sha512-Mu7R0g4ig9TUuGSxJavny5Rv0egCEtpZRNMrZaYS1vxkiIxGiGUwoezU3LazIQ+KE04hTrTfNPgxU5gzi7F5Pw=="
 		},
 		"node_modules/sumchecker": {
 			"version": "3.0.1",
@@ -34641,8 +34641,7 @@
 		"sudo-prompt": {
 			"version": "9.2.1",
 			"resolved": "https://registry.npmjs.org/sudo-prompt/-/sudo-prompt-9.2.1.tgz",
-			"integrity": "sha512-Mu7R0g4ig9TUuGSxJavny5Rv0egCEtpZRNMrZaYS1vxkiIxGiGUwoezU3LazIQ+KE04hTrTfNPgxU5gzi7F5Pw==",
-			"dev": true
+			"integrity": "sha512-Mu7R0g4ig9TUuGSxJavny5Rv0egCEtpZRNMrZaYS1vxkiIxGiGUwoezU3LazIQ+KE04hTrTfNPgxU5gzi7F5Pw=="
 		},
 		"sumchecker": {
 			"version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
 		"fs-extra": "11.1.1",
 		"hpagent": "1.2.0",
 		"semver": "^7.6.0",
+		"sudo-prompt": "^9.2.1",
 		"unzipper": "0.10.11",
 		"wpcom": "^5.4.2",
 		"yargs": "17.7.2"

--- a/src/components/onboarding.tsx
+++ b/src/components/onboarding.tsx
@@ -72,6 +72,14 @@ export default function Onboarding() {
 	const handleSubmit = useCallback(
 		async ( event: FormEvent ) => {
 			event.preventDefault();
+
+			// Prompt the user to enable optimizations on Windows
+			try {
+				await getIpcApi().promptWindowsSpeedUpSites( { skipIfAlreadyPrompted: true } );
+			} catch ( error ) {
+				console.error( error );
+			}
+
 			try {
 				await handleAddSiteClick();
 				speak( siteAddedMessage );

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -9,6 +9,7 @@ export const WINDOWS_TITLEBAR_HEIGHT = 32;
 export const ABOUT_WINDOW_WIDTH = 284;
 export const ABOUT_WINDOW_HEIGHT = 284;
 export const STUDIO_DOCS_URL = `https://developer.wordpress.com/docs/developer-tools/studio/`;
+export const STUDIO_DOCS_WINDOWS_SPEED_UP_SITES_URL = `${ STUDIO_DOCS_URL }#15-how-can-i-make-studio-faster-on-windows-`;
 export const BUG_REPORT_URL =
 	'https://github.com/Automattic/studio/issues/new?assignees=&labels=Needs+triage%2C%5BType%5D+Bug&projects=&template=bug_report.yml';
 export const FEATURE_REQUEST_URL =

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -9,7 +9,6 @@ export const WINDOWS_TITLEBAR_HEIGHT = 32;
 export const ABOUT_WINDOW_WIDTH = 284;
 export const ABOUT_WINDOW_HEIGHT = 284;
 export const STUDIO_DOCS_URL = `https://developer.wordpress.com/docs/developer-tools/studio/`;
-export const STUDIO_DOCS_WINDOWS_SPEED_UP_SITES_URL = `${ STUDIO_DOCS_URL }#15-how-can-i-make-studio-faster-on-windows-`;
 export const BUG_REPORT_URL =
 	'https://github.com/Automattic/studio/issues/new?assignees=&labels=Needs+triage%2C%5BType%5D+Bug&projects=&template=bug_report.yml';
 export const FEATURE_REQUEST_URL =

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -32,6 +32,7 @@ import {
 	isSqlLiteInstalled,
 	removeLegacySqliteIntegrationPlugin,
 } from './lib/sqlite-versions';
+import * as windowsHelpers from './lib/windows-helpers';
 import { writeLogToFile, type LogLevel } from './logging';
 import { popupMenu } from './menu';
 import { SiteServer, createSiteWorkingDirectory } from './site-server';
@@ -614,4 +615,11 @@ export async function showNotification(
 
 export function popupAppMenu( _event: IpcMainInvokeEvent ) {
 	popupMenu();
+}
+
+export async function promptWindowsSpeedUpSites(
+	_event: IpcMainInvokeEvent,
+	{ skipIfAlreadyPrompted }: { skipIfAlreadyPrompted: boolean }
+) {
+	await windowsHelpers.promptWindowsSpeedUpSites( { skipIfAlreadyPrompted } );
 }

--- a/src/lib/windows-helpers.ts
+++ b/src/lib/windows-helpers.ts
@@ -28,7 +28,7 @@ export async function promptWindowsSpeedUpSites( {
 		buttons,
 		title: __( 'Want to speed up sites?' ),
 		message: __(
-			'If the Real-Time Protection Service of Windows Defender is enabled on your machine, it may slow down the process of creating and starting a site.\n\nFor optimal performance, we recommend excluding the Studio app from this service. The app can do this automatically for you.'
+			'If the Real-Time Protection Service of Microsoft Defender is enabled on your machine, it may slow down the process of creating and starting a site.\n\nFor optimal performance, we recommend excluding the Studio app from this service. The app can do this automatically for you.'
 		),
 		cancelId: buttons.indexOf( NOT_INTERESTED ),
 	} );

--- a/src/lib/windows-helpers.ts
+++ b/src/lib/windows-helpers.ts
@@ -41,7 +41,17 @@ export async function promptWindowsSpeedUpSites( {
 				...userData,
 				promptWindowsSpeedUpResult: 'yes',
 			} );
-			await excludeProcessInWindowsDefender();
+			try {
+				await excludeProcessInWindowsDefender();
+			} catch ( _error ) {
+				await dialog.showMessageBox( {
+					type: 'error',
+					title: __( 'Something went wrong' ),
+					message: __(
+						'The configuration couldn\'t be changed to speed up sites.\n\nTo initiate this process again, please go to "Help > How can I make Studio faster?" in the application menu.'
+					),
+				} );
+			}
 			break;
 		case buttons.indexOf( MANUAL_UPDATE ):
 			// Will be done manually by the user

--- a/src/lib/windows-helpers.ts
+++ b/src/lib/windows-helpers.ts
@@ -47,7 +47,7 @@ export async function promptWindowsSpeedUpSites( {
 					type: 'error',
 					title: __( 'Something went wrong' ),
 					message: __(
-						'The configuration couldn\'t be changed to speed up sites.\n\nTo initiate this process again, please go to "Help > How can I make Studio faster?" in the application menu.'
+						'The configuration couldn\'t be changed to speed up site creation.\n\nTo initiate this process again, please go to "Help > How can I make Studio faster?" in the application menu.'
 					),
 				} );
 			}

--- a/src/lib/windows-helpers.ts
+++ b/src/lib/windows-helpers.ts
@@ -26,9 +26,9 @@ export async function promptWindowsSpeedUpSites( {
 	const { response } = await dialog.showMessageBox( {
 		type: 'question',
 		buttons,
-		title: __( 'Want to speed up sites?' ),
+		title: __( 'Want to speed up site creation?' ),
 		message: __(
-			'If the Real-Time Protection Service of Microsoft Defender is enabled on your machine, it may slow down the process of creating and starting a site.\n\nFor optimal performance, we recommend excluding the Studio app from this service. The app can do this automatically for you.'
+			"Microsoft Defender's Real-time protection may slow site creation.\n\nTo create sites quickly, we recommend disabling Real-time protection for the Studio app."
 		),
 		cancelId: buttons.indexOf( NOT_INTERESTED ),
 	} );

--- a/src/lib/windows-helpers.ts
+++ b/src/lib/windows-helpers.ts
@@ -30,7 +30,7 @@ export async function promptWindowsSpeedUpSites( {
 		buttons,
 		title: __( 'Want to speed up sites?' ),
 		message: __(
-			"If the Real-Time Protection Service of Windows Defender is enabled on your machine, it may slow down the process of creating and starting a site.\n\nTo enhance site speed, it's recommended adjusting the configuration accordingly.\n\nThe app can do this automatically for you, or alternatively, you can follow the documentation."
+			'If the Real-Time Protection Service of Windows Defender is enabled on your machine, it may slow down the process of creating and starting a site.\n\nFor optimal performance, we recommend excluding the Studio app from this service.\n\nThe app can do this automatically for you, or alternatively, you can follow the documentation.'
 		),
 		cancelId: buttons.indexOf( NOT_INTERESTED ),
 	} );

--- a/src/lib/windows-helpers.ts
+++ b/src/lib/windows-helpers.ts
@@ -19,11 +19,11 @@ export async function promptWindowsSpeedUpSites( {
 		return;
 	}
 
-	const NOT_INTERESTED = __( "I'm not interested." );
-	const MANUAL_UPDATE = __( "I'll do it my own by following the documentation." );
 	const AUTOMATIC_UPDATE = __( 'Sounds good, do it for me.' );
+	const MANUAL_UPDATE = __( "I'll do it my own by following the documentation." );
+	const NOT_INTERESTED = __( "I'm not interested." );
 
-	const buttons = [ NOT_INTERESTED, MANUAL_UPDATE, AUTOMATIC_UPDATE ];
+	const buttons = [ AUTOMATIC_UPDATE, NOT_INTERESTED, MANUAL_UPDATE ];
 
 	const { response } = await dialog.showMessageBox( {
 		type: 'question',
@@ -32,6 +32,7 @@ export async function promptWindowsSpeedUpSites( {
 		message: __(
 			"If the Real-Time Protection Service of Windows Defender is enabled on your machine, it may slow down the process of creating and starting a site.\n\nTo enhance site speed, it's recommended adjusting the configuration accordingly.\n\nThe app can do this automatically for you, or alternatively, you can follow the documentation."
 		),
+		cancelId: buttons.indexOf( NOT_INTERESTED ),
 	} );
 
 	switch ( response ) {

--- a/src/lib/windows-helpers.ts
+++ b/src/lib/windows-helpers.ts
@@ -23,7 +23,7 @@ export async function promptWindowsSpeedUpSites( {
 	const MANUAL_UPDATE = __( "I'll do it my own by following the documentation." );
 	const NOT_INTERESTED = __( "I'm not interested." );
 
-	const buttons = [ AUTOMATIC_UPDATE, NOT_INTERESTED, MANUAL_UPDATE ];
+	const buttons = [ AUTOMATIC_UPDATE, MANUAL_UPDATE, NOT_INTERESTED ];
 
 	const { response } = await dialog.showMessageBox( {
 		type: 'question',

--- a/src/lib/windows-helpers.ts
+++ b/src/lib/windows-helpers.ts
@@ -1,4 +1,5 @@
 import { app, dialog, shell } from 'electron';
+import path from 'path';
 import { __ } from '@wordpress/i18n';
 import sudo from 'sudo-prompt';
 import { STUDIO_DOCS_WINDOWS_SPEED_UP_SITES_URL } from '../constants';
@@ -61,9 +62,15 @@ export async function promptWindowsSpeedUpSites( {
 }
 
 export async function excludeProcessInWindowsDefender() {
-	const command = `PowerShell -NoProfile -ExecutionPolicy Bypass -Command "Add-MpPreference -ExclusionProcess ${ app.getPath(
-		'exe'
-	) }"`;
+	let exePath = app.getPath( 'exe' );
+	// When the app is packaged, the exe path points to "%appdata%\Local\studio\app-{app-version}\Studio.exe".
+	// To avoid updating this configuration on each update, we use a wilcard in the path to include all versions.
+	if ( app.isPackaged ) {
+		const exeFilename = path.basename( app.getPath( 'exe' ) );
+		const exeDir = path.dirname( app.getPath( 'exe' ) );
+		exePath = path.join( exeDir, '..', 'app-*', exeFilename );
+	}
+	const command = `PowerShell -NoProfile -ExecutionPolicy Bypass -Command "Add-MpPreference -ExclusionProcess ${ exePath }"`;
 	const options = {
 		name: 'Studio app',
 	};

--- a/src/lib/windows-helpers.ts
+++ b/src/lib/windows-helpers.ts
@@ -36,7 +36,7 @@ export async function promptWindowsSpeedUpSites( {
 
 	switch ( response ) {
 		case buttons.indexOf( AUTOMATIC_UPDATE ):
-			//
+			// Update Windows Defender configuration
 			await saveUserData( {
 				...userData,
 				promptWindowsSpeedUpResult: 'yes',

--- a/src/lib/windows-helpers.ts
+++ b/src/lib/windows-helpers.ts
@@ -2,7 +2,6 @@ import { app, dialog, shell } from 'electron';
 import path from 'path';
 import { __ } from '@wordpress/i18n';
 import sudo from 'sudo-prompt';
-import { STUDIO_DOCS_WINDOWS_SPEED_UP_SITES_URL } from '../constants';
 import { loadUserData, saveUserData } from '../storage/user-data';
 
 export async function promptWindowsSpeedUpSites( {
@@ -20,17 +19,16 @@ export async function promptWindowsSpeedUpSites( {
 	}
 
 	const AUTOMATIC_UPDATE = __( 'Sounds good, do it for me.' );
-	const MANUAL_UPDATE = __( "I'll do it my own by following the documentation." );
 	const NOT_INTERESTED = __( "I'm not interested." );
 
-	const buttons = [ AUTOMATIC_UPDATE, MANUAL_UPDATE, NOT_INTERESTED ];
+	const buttons = [ AUTOMATIC_UPDATE, NOT_INTERESTED ];
 
 	const { response } = await dialog.showMessageBox( {
 		type: 'question',
 		buttons,
 		title: __( 'Want to speed up sites?' ),
 		message: __(
-			'If the Real-Time Protection Service of Windows Defender is enabled on your machine, it may slow down the process of creating and starting a site.\n\nFor optimal performance, we recommend excluding the Studio app from this service.\n\nThe app can do this automatically for you, or alternatively, you can follow the documentation.'
+			'If the Real-Time Protection Service of Windows Defender is enabled on your machine, it may slow down the process of creating and starting a site.\n\nFor optimal performance, we recommend excluding the Studio app from this service. The app can do this automatically for you.'
 		),
 		cancelId: buttons.indexOf( NOT_INTERESTED ),
 	} );
@@ -53,14 +51,6 @@ export async function promptWindowsSpeedUpSites( {
 					),
 				} );
 			}
-			break;
-		case buttons.indexOf( MANUAL_UPDATE ):
-			// Will be done manually by the user
-			await saveUserData( {
-				...userData,
-				promptWindowsSpeedUpResult: 'manual',
-			} );
-			await shell.openExternal( STUDIO_DOCS_WINDOWS_SPEED_UP_SITES_URL );
 			break;
 		case buttons.indexOf( NOT_INTERESTED ):
 			// Skip it, user is not interested

--- a/src/lib/windows-helpers.ts
+++ b/src/lib/windows-helpers.ts
@@ -1,0 +1,79 @@
+import { app, dialog, shell } from 'electron';
+import { __ } from '@wordpress/i18n';
+import sudo from 'sudo-prompt';
+import { STUDIO_DOCS_WINDOWS_SPEED_UP_SITES_URL } from '../constants';
+import { loadUserData, saveUserData } from '../storage/user-data';
+
+export async function promptWindowsSpeedUpSites( {
+	skipIfAlreadyPrompted,
+}: {
+	skipIfAlreadyPrompted: boolean;
+} ) {
+	const userData = await loadUserData();
+
+	if (
+		process.platform !== 'win32' ||
+		( skipIfAlreadyPrompted && typeof userData.promptWindowsSpeedUpResult !== 'undefined' )
+	) {
+		return;
+	}
+
+	const NOT_INTERESTED = __( "I'm not interested." );
+	const MANUAL_UPDATE = __( "I'll do it my own by following the documentation." );
+	const AUTOMATIC_UPDATE = __( 'Sounds good, do it for me.' );
+
+	const buttons = [ NOT_INTERESTED, MANUAL_UPDATE, AUTOMATIC_UPDATE ];
+
+	const { response } = await dialog.showMessageBox( {
+		type: 'question',
+		buttons,
+		title: __( 'Want to speed up sites?' ),
+		message: __(
+			"If the Real-Time Protection Service of Windows Defender is enabled on your machine, it may slow down the process of creating and starting a site.\n\nTo enhance site speed, it's recommended adjusting the configuration accordingly.\n\nThe app can do this automatically for you, or alternatively, you can follow the documentation."
+		),
+	} );
+
+	switch ( response ) {
+		case buttons.indexOf( AUTOMATIC_UPDATE ):
+			//
+			await saveUserData( {
+				...userData,
+				promptWindowsSpeedUpResult: 'yes',
+			} );
+			await excludeProcessInWindowsDefender();
+			break;
+		case buttons.indexOf( MANUAL_UPDATE ):
+			// Will be done manually by the user
+			await saveUserData( {
+				...userData,
+				promptWindowsSpeedUpResult: 'manual',
+			} );
+			await shell.openExternal( STUDIO_DOCS_WINDOWS_SPEED_UP_SITES_URL );
+			break;
+		case buttons.indexOf( NOT_INTERESTED ):
+			// Skip it, user is not interested
+			await saveUserData( {
+				...userData,
+				promptWindowsSpeedUpResult: 'no',
+			} );
+			break;
+	}
+}
+
+export async function excludeProcessInWindowsDefender() {
+	const command = `PowerShell -NoProfile -ExecutionPolicy Bypass -Command "Add-MpPreference -ExclusionProcess ${ app.getPath(
+		'exe'
+	) }"`;
+	const options = {
+		name: 'Studio app',
+	};
+	await new Promise< void >( ( resolve, reject ) =>
+		sudo.exec( command, options, function ( error ) {
+			if ( error ) {
+				reject( error );
+				return;
+			}
+			resolve();
+		} )
+	);
+}

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -9,9 +9,9 @@ import {
 import { __ } from '@wordpress/i18n';
 import { openAboutWindow } from './about-menu/open-about-menu';
 import { BUG_REPORT_URL, FEATURE_REQUEST_URL, STUDIO_DOCS_URL } from './constants';
+import { promptWindowsSpeedUpSites } from './lib/windows-helpers';
 import { withMainWindow } from './main-window';
 import { isUpdateReadyToInstall, manualCheckForUpdates } from './updates';
-import { promptWindowsSpeedUpSites } from './lib/windows-helpers';
 
 export function setupMenu( mainWindow: BrowserWindow | null ) {
 	if ( ! mainWindow && process.platform !== 'darwin' ) {

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -11,6 +11,7 @@ import { openAboutWindow } from './about-menu/open-about-menu';
 import { BUG_REPORT_URL, FEATURE_REQUEST_URL, STUDIO_DOCS_URL } from './constants';
 import { withMainWindow } from './main-window';
 import { isUpdateReadyToInstall, manualCheckForUpdates } from './updates';
+import { promptWindowsSpeedUpSites } from './lib/windows-helpers';
 
 export function setupMenu( mainWindow: BrowserWindow | null ) {
 	if ( ! mainWindow && process.platform !== 'darwin' ) {
@@ -165,6 +166,17 @@ function getAppMenu( mainWindow: BrowserWindow | null ) {
 						shell.openExternal( STUDIO_DOCS_URL );
 					},
 				},
+				{ type: 'separator' },
+				...( process.platform === 'win32'
+					? [
+							{
+								label: __( 'How can I make Studio faster?' ),
+								click: () => {
+									promptWindowsSpeedUpSites( { skipIfAlreadyPrompted: false } );
+								},
+							},
+					  ]
+					: [] ),
 				{ type: 'separator' },
 				{
 					label: __( 'Report an Issue' ),

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -4,6 +4,7 @@
 import '@sentry/electron/preload';
 import { contextBridge, ipcRenderer } from 'electron';
 import type { LogLevel } from './logging';
+import { promptWindowsSpeedUpSites } from './lib/windows-helpers';
 
 const api: IpcApi = {
 	archiveSite: ( id: string ) => ipcRenderer.invoke( 'archiveSite', id ),
@@ -49,6 +50,8 @@ const api: IpcApi = {
 	logRendererMessage: ( level: LogLevel, ...args: any[] ) =>
 		ipcRenderer.send( 'logRendererMessage', level, ...args ),
 	popupAppMenu: () => ipcRenderer.invoke( 'popupAppMenu' ),
+	promptWindowsSpeedUpSites: ( ...args: Parameters< typeof promptWindowsSpeedUpSites > ) =>
+		ipcRenderer.invoke( 'promptWindowsSpeedUpSites', ...args ),
 };
 
 contextBridge.exposeInMainWorld( 'ipcApi', api );

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -3,8 +3,8 @@
 
 import '@sentry/electron/preload';
 import { contextBridge, ipcRenderer } from 'electron';
-import type { LogLevel } from './logging';
 import { promptWindowsSpeedUpSites } from './lib/windows-helpers';
+import type { LogLevel } from './logging';
 
 const api: IpcApi = {
 	archiveSite: ( id: string ) => ipcRenderer.invoke( 'archiveSite', id ),

--- a/src/storage/storage-types.ts
+++ b/src/storage/storage-types.ts
@@ -23,4 +23,4 @@ export interface PersistedUserData extends Omit< UserData, 'sites' > {
 	sites: Omit< StoppedSiteDetails, 'running' >[];
 }
 
-export type PromptWindowsSpeedUpResult = 'yes' | 'manual' | 'no';
+export type PromptWindowsSpeedUpResult = 'yes' | 'no';

--- a/src/storage/storage-types.ts
+++ b/src/storage/storage-types.ts
@@ -11,6 +11,7 @@ export interface UserData {
 			[ stat: string ]: number;
 		};
 	};
+	promptWindowsSpeedUpResult?: PromptWindowsSpeedUpResult;
 }
 
 export interface PersistedUserData extends Omit< UserData, 'sites' > {
@@ -21,3 +22,5 @@ export interface PersistedUserData extends Omit< UserData, 'sites' > {
 	// won't persist `name`.
 	sites: Omit< StoppedSiteDetails, 'running' >[];
 }
+
+export type PromptWindowsSpeedUpResult = 'yes' | 'manual' | 'no';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

> [!NOTE]
> This PR is a proposal to solve 7013-gh-Automattic/dotcom-forge. I'd appreciate any feedback on the proposal and the messaging. Thanks 🙇 !

## Proposed Changes

- Add `sudo-prompt` package to prompt the user for admin permission actions.
- Add a Windows-only helper function to prompt the user to speed up sites. We'll provide three options:
    - Update Windows Defender configuration automatically. This will require admin permissions.
    - Open the Developer documentation that explains how to do it manually.
    - Skip the step.
- Update onboarding logic to prompt the user to speed up sites when creating the first site.
- Add a menu option under the Help section to allow users to trigger again the prompt to speed up sites.

![Screenshot 2024-06-11 145127](https://github.com/Automattic/studio/assets/14905380/76b29178-ccb9-4010-935d-cca04ef26ad6)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Windows

#### No Optimizations

1. Remove app data by deleting the folder located at `%appdata%\Studio`.
2. Remove all created sites.
3. Open the app.
4. Observe that the onboarding screen is shown.
5. Click on the Add Site button.
6. Observe a dialog is displayed with two options.
7. Click on the second option to skip it.
8. Observe the site takes a significant time to be created.

#### Speed Up Sites Optimization

1. Remove app data by deleting the folder located at `%appdata%\Studio`.
2. Remove all created sites.
3. Open the app.
4. Observe that the onboarding screen is shown.
5. Click on the Add Site button.
6. Observe a dialog is displayed with two options.
7. Click on the first option to automatically speed up sites.
8. Observe the OS prompts for admin permission.
9. Observe the site creation is faster than the previous test case.

#### ~~Manual Optimization~~

1. ~~Remove app data by deleting the folder located at `%appdata%\Studio`.~~
2. ~~Remove all created sites.~~
3. ~~Open the app.~~
4. ~~Observe that the onboarding screen is shown.~~
5. ~~Click on the Add Site button.~~
6. ~~Observe a dialog is displayed with three options.~~
7. ~~Click on the second option to display documentation.~~
8. ~~Observe the browser is opened and show documentation about how to speed up sites on Windows.~~
9. ~~Observe the site is created in the meantime.~~

#### Prompt Only Displayed First Time

1. Remove app data by deleting the folder located at `%appdata%\Studio`.
2. Remove all created sites.
3. Open the app.
4. Observe that the onboarding screen is shown.
5. Click on the Add Site button.
6. Observe a dialog is displayed with two options.
7. Click on the second option to skip it
8. Observe the site is created.
9. Delete the site created.
10. Observe the onboarding screen is displayed again.
11. Click on the Add Site button.
12. Observe the prompt to speed up sites is not displayed. 

#### Help Section

1. Open the app.
2. Open the application menu (located in the top bar).
3. Click on Help button.
4. Observe the item "How can I make Studio faster?" is displayed.
5. Click on it.
6. Observe a dialog is displayed with two options.

### macOS

#### No Dialog Displayed

1. Remove app data by deleting the folder located at `$HOME/Library/Application Support/Studio`.
2. Remove all created sites.
3. Open the app.
4. Observe that the onboarding screen is shown.
5. Click on the Add Site button.
6. Observe no dialog is displayed and that the site is created

#### No New Help Option

1. Open the app.
2. Click on the Help button in the application menu.
3. Observe the there's no item related to how to make Studio app faster.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
