### PR TITLE
Studio: Add WordPress Playground link in the About Studio window

### DIFF
--- a/src/about-menu/about-menu.html
+++ b/src/about-menu/about-menu.html
@@ -61,7 +61,7 @@
     margin-bottom: 14px;
   }
 
-  .demo-info {
+  .demo-info, .local-info {
     border-top: 1px solid rgba(220, 220, 222, 1);
     padding-top: 16px;
     width: 236px;
@@ -93,6 +93,9 @@
     </script>
   <div class="demo-info">
     <p>Demo sites powered by<br><a href="https://wordpress.com/hosting/?utm_source=studio&utm_medium=referral&utm_campaign=about_screen" target="_blank">WordPress.com hosting ↗</a></p>
+  </div>
+  <div class="local-info">
+    <p>Local sites powered by<br><a href="https://wordpress.org/playground/" target="_blank">WordPress Playground ↗</a></p>
   </div>
 </body>
 </html>

--- a/src/about-menu/about-menu.html
+++ b/src/about-menu/about-menu.html
@@ -61,7 +61,7 @@
     margin-bottom: 14px;
   }
 
-  .demo-info, .local-info {
+  .info {
     border-top: 1px solid rgba(220, 220, 222, 1);
     padding-top: 16px;
     width: 236px;
@@ -91,10 +91,10 @@
         const version = document.getElementById('version');
         version.innerText = window.appVersion; 
     </script>
-  <div class="demo-info">
+  <div class="info">
     <p>Demo sites powered by<br><a href="https://wordpress.com/hosting/?utm_source=studio&utm_medium=referral&utm_campaign=about_screen" target="_blank">WordPress.com hosting ↗</a></p>
   </div>
-  <div class="local-info">
+  <div class="info">
     <p>Local sites powered by<br><a href="https://wordpress.org/playground/" target="_blank">WordPress Playground ↗</a></p>
   </div>
 </body>

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -7,7 +7,7 @@ export const LIMIT_ARCHIVE_SIZE = 100 * 1024 * 1024; // 100MB
 export const AUTO_UPDATE_INTERVAL_MS = 60 * 60 * 1000;
 export const WINDOWS_TITLEBAR_HEIGHT = 32;
 export const ABOUT_WINDOW_WIDTH = 284;
-export const ABOUT_WINDOW_HEIGHT = 284;
+export const ABOUT_WINDOW_HEIGHT = 350;
 export const STUDIO_DOCS_URL = `https://developer.wordpress.com/docs/developer-tools/studio/`;
 export const BUG_REPORT_URL =
 	'https://github.com/Automattic/studio/issues/new?assignees=&labels=Needs+triage%2C%5BType%5D+Bug&projects=&template=bug_report.yml';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/7614

## Proposed Changes

This PR adds the link to WordPress Playground:  http://w.org/playground to the About Studio window. 

Before             |  After
:-------------------------:|:-------------------------:
![](https://github.com/Automattic/studio/assets/25575134/8755a931-178b-4c64-88a4-4e62df1c19ea)  |  ![](https://github.com/Automattic/studio/assets/25575134/a182225d-6ce1-428d-8d9c-de5156943cd9)

I used the wording from the issue linked above and the design suggestion from the Slack thread mentioned there. Happy to adjust based on the feedback.

## Testing Instructions

- Pull the changes from this branch
- Start the app with `nvm use && npm install && npm start`
- Click on the app
- Click on `Electron > About Studio` menu option in the top bar
- Confirm that you see the link to WordPress Playground and clicking the link brings you to `http://w.org/playground `

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?