### PR TITLE
Iterate on launch stats, to include tracking for all and first-time launches

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -228,8 +228,8 @@ async function appBoot() {
 
 		createMainWindow();
 
-		bumpAggregatedUniqueStat( 'local-environment-launch-uniques', process.platform, 'weekly' );
 		bumpStat( 'studio-app-launch', process.platform );
+		bumpAggregatedUniqueStat( 'studio-app-launch-weekly-uniques', process.platform, 'weekly' );
 	} );
 
 	// Quit when all windows are closed, except on macOS. There, it's common

--- a/src/index.ts
+++ b/src/index.ts
@@ -228,7 +228,9 @@ async function appBoot() {
 
 		createMainWindow();
 
+		// Bump a stat on each app launch
 		bumpStat( 'studio-app-launch', process.platform );
+		// Bump stat for unique weekly app launch, approximates weekly active users
 		bumpAggregatedUniqueStat( 'studio-app-launch-weekly-uniques', process.platform, 'weekly' );
 	} );
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -228,10 +228,10 @@ async function appBoot() {
 
 		createMainWindow();
 
-		// Bump a stat on each app launch
-		bumpStat( 'studio-app-launch', process.platform );
+		// Bump a stat on each app launch, approximates total app launches
+		bumpStat( 'studio-app-launch-total', process.platform );
 		// Bump stat for unique weekly app launch, approximates weekly active users
-		bumpAggregatedUniqueStat( 'studio-app-launch-weekly-uniques', process.platform, 'weekly' );
+		bumpAggregatedUniqueStat( 'local-environment-launch-uniques', process.platform, 'weekly' );
 	} );
 
 	// Quit when all windows are closed, except on macOS. There, it's common

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ import packageJson from '../package.json';
 import { PROTOCOL_PREFIX } from './constants';
 import * as ipcHandlers from './ipc-handlers';
 import { getPlatformName } from './lib/app-globals';
-import { bumpAggregatedUniqueStat } from './lib/bump-stats';
+import { bumpAggregatedUniqueStat, bumpStat } from './lib/bump-stats';
 import { getLocaleData, getSupportedLocale } from './lib/locale';
 import { handleAuthCallback, setUpAuthCallbackHandler } from './lib/oauth';
 import { setupLogging } from './logging';
@@ -229,6 +229,7 @@ async function appBoot() {
 		createMainWindow();
 
 		bumpAggregatedUniqueStat( 'local-environment-launch-uniques', process.platform, 'weekly' );
+		bumpStat( 'studio-app-launch', process.platform );
 	} );
 
 	// Quit when all windows are closed, except on macOS. There, it's common

--- a/src/lib/bump-stats.ts
+++ b/src/lib/bump-stats.ts
@@ -20,8 +20,9 @@ export function bumpAggregatedUniqueStat(
 	getLastBump( group, stat )
 		.then( ( lastBump ) => {
 			if ( lastBump === null ) {
+				// Bump the stat the first time it's seen
 				bumpStat( group, stat, bumpInDev );
-				// Track the first occurence of this stat separately
+				// Also, explicitly track the first occurrence by appending `-first`
 				bumpStat( `${ group }-first`, stat, bumpInDev );
 				return true;
 			}
@@ -38,6 +39,7 @@ export function bumpAggregatedUniqueStat(
 				return false;
 			}
 
+			// Bump the stat for subsequent occurrences within the time interval
 			return bumpStat( group, stat, bumpInDev );
 		} )
 		.then( ( didBump ) => {

--- a/src/lib/bump-stats.ts
+++ b/src/lib/bump-stats.ts
@@ -20,7 +20,10 @@ export function bumpAggregatedUniqueStat(
 	getLastBump( group, stat )
 		.then( ( lastBump ) => {
 			if ( lastBump === null ) {
-				return bumpStat( group, stat, bumpInDev );
+				bumpStat( group, stat, bumpInDev );
+				// Track the first occurence of this stat separately
+				bumpStat( `${ group }-first`, stat, bumpInDev );
+				return true;
 			}
 
 			const now = Date.now();

--- a/src/lib/tests/bump-stats.test.ts
+++ b/src/lib/tests/bump-stats.test.ts
@@ -25,6 +25,16 @@ function mockBumpStatRequest( group: string, stat: string ) {
 		.reply( 200 );
 }
 
+function mockBumpStatRequestFirst( group: string, stat: string ) {
+	return nock( 'https://pixel.wp.com' )
+		.get( '/b.gif' )
+		.query( {
+			v: 'wpcom-no-pv',
+			[ `x_${ group }-first` ]: stat,
+		} )
+		.reply( 200 );
+}
+
 function mockCurrentTime( timestamp: number ) {
 	jest.spyOn( Date, 'now' ).mockReturnValue( timestamp );
 }
@@ -71,11 +81,14 @@ describe( 'bumpStat', () => {
 describe( 'bumpAggregatedUniqueStat', () => {
 	test( 'bump stat when it has never been recorded before', async () => {
 		const nock = mockBumpStatRequest( 'usage', 'launch' );
+		const nockFirst = mockBumpStatRequestFirst( 'usage', 'launch' );
+
 		( loadUserData as jest.Mock ).mockResolvedValue( { lastBumpStats: {} } );
 
 		bumpAggregatedUniqueStat( 'usage', 'launch', 'weekly' );
 
 		await waitFor( () => expect( nock.isDone() ).toBe( true ) );
+		await waitFor( () => expect( nockFirst.isDone() ).toBe( true ) );
 	} );
 
 	for ( const [ aggregateBy, currentTime, lastBumpTime ] of [


### PR DESCRIPTION
Related to 7578-gh-Automattic/dotcom-forge

## Proposed Changes

- This PR includes the following proposals for the tracking we have around app launches:
   - Add code comments around the current stat, `local-environment-launch-uniques`, to convey its purpose. A separate issue will be created to potentially rename the stat in the future.
   - Introduce a new stat, `studio-app-launch-total`, that fires every single time the app is launched.
   - Introduce `local-environment-launch-uniques-first`, which will fire first time a unique user first launches the app.

>  [!NOTE]
> I'm keen to hear thoughts around naming. I've spent a bit of time looking closely at this problem, so newer eyes will likely better spot any names that could be made clearer.

## Testing Instructions

- Apply the following patch to ensure the stats are bumped in your local development environment, and that they're logged to the console when they fire:

```patch
diff --git a/src/lib/bump-stats.ts b/src/lib/bump-stats.ts
index 8154cec..05bd77c 100644
--- a/src/lib/bump-stats.ts
+++ b/src/lib/bump-stats.ts
@@ -49,12 +49,15 @@ export function bumpAggregatedUniqueStat(
 }
 
 // Returns true if we attempted to bump the stat
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function bumpStat( group: string, stat: string, bumpInDev = false ) {
-	if ( process.env.E2E || ( process.env.NODE_ENV === 'development' && ! bumpInDev ) ) {
+	if ( process.env.E2E ) {
 		console.info( `Would have bumped stat: ${ group }=${ stat }` );
 		return false;
 	}
 
+	console.log( `Bumped stat: ${ group }=${ stat }` );
+
 	const url = new URL( 'https://pixel.wp.com/b.gif?v=wpcom-no-pv' );
 	url.searchParams.append( `x_${ group }`, stat );
 

```
- In order to mimic a first launch, remove the `Studio` folder found under `Library` → `Application Support`.
- Follow the steps to launch the Studio app. 
- Ensure the following are logged to your console when first launched:
  - `Bumped stat: studio-app-launch-total=darwin`
  -  `Bumped stat: local-environment-launch-uniques=darwin`
  -  `Bumped stat: local-environment-launch-uniques-first=darwin`
- Exit the app and launch it a second time.
- Verify that _only_ the following stat is bumped on the second launch:
  - `Bumped stat: studio-app-launch-total=darwin`

>  [!NOTE]
> An MC page for each stat will be automatically created, but you may not see your stat reflected immediately.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?