### PR TITLE
Read stdout and add tests for wp-cli update

### DIFF
--- a/src/lib/wpcli-versions.ts
+++ b/src/lib/wpcli-versions.ts
@@ -25,9 +25,6 @@ export async function isWPCliInstallationOutdated(): Promise< boolean > {
 		return false;
 	}
 
-	console.log( 'Installed WP-CLI version:', installedVersion );
-	console.log( 'Latest WP-CLI version:', latestVersion );
-	console.log( 'Is WP-CLI outdated:', semver.lt( installedVersion, latestVersion ) );
 	try {
 		return semver.lt( installedVersion, latestVersion );
 	} catch ( _error ) {
@@ -56,19 +53,10 @@ async function getLatestWPCliVersion() {
 	return latestWPCliVersionCache || '';
 }
 
-const getWPCliVersionFromInstallation = async () => {
-	const originalConsoleLog = console.log;
-	const logMessages: string[] = [];
-
-	console.log = function ( args ) {
-		logMessages.push( args ); // Capture the log message
-		originalConsoleLog.apply( console, [ args ] ); // Call the original console.log
-	};
-	await executeWPCli( [ '--version' ] );
-	console.log = originalConsoleLog;
-	const lastLogMessage = logMessages.pop();
-	if ( lastLogMessage?.startsWith( 'WP-CLI ' ) ) {
-		const version = lastLogMessage.split( ' ' )[ 1 ];
+export const getWPCliVersionFromInstallation = async () => {
+	const { stdout } = await executeWPCli( '.', [ '--version' ] );
+	if ( stdout?.startsWith( 'WP-CLI ' ) ) {
+		const version = stdout.split( ' ' )[ 1 ];
 		if ( ! version ) {
 			return '';
 		}

--- a/src/setup-wp-server-files.ts
+++ b/src/setup-wp-server-files.ts
@@ -4,6 +4,7 @@ import semver from 'semver';
 import { SQLITE_FILENAME } from '../vendor/wp-now/src/constants';
 import { getWordPressVersionPath } from '../vendor/wp-now/src/download';
 import getSqlitePath from '../vendor/wp-now/src/get-sqlite-path';
+import getWpCliPath from '../vendor/wp-now/src/get-wp-cli-path';
 import { recursiveCopyDirectory } from './lib/fs-utils';
 import { updateLatestSqliteVersion } from './lib/sqlite-versions';
 import {

--- a/src/tests/execute-wp-cli.test.ts
+++ b/src/tests/execute-wp-cli.test.ts
@@ -6,6 +6,10 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import { executeWPCli } from '../../vendor/wp-now/src/execute-wp-cli';
+import {
+	getWPCliVersionFromInstallation,
+	isWPCliInstallationOutdated,
+} from '../lib/wpcli-versions';
 
 describe( 'executeWPCli', () => {
 	const tmpPath = fs.mkdtempSync( path.join( os.tmpdir(), 'studio-test-wp-cli-site' ) );
@@ -23,7 +27,7 @@ describe( 'executeWPCli', () => {
 		const result = await executeWPCli( tmpPath, args );
 
 		expect( result.stdout ).toMatch( /WP-CLI \d+\.\d+\.\d+/ );
-		expect( result.stderr ).toBe( '' );
+		expect( result.stderr ).toBe( '' ); // Example: WP-CLI 2.10.0
 	} );
 
 	it( 'should return error if wp-cli command does not exist', async () => {
@@ -35,5 +39,15 @@ describe( 'executeWPCli', () => {
 		expect( result.stderr ).toContain(
 			"'yoda' is not a registered wp command. See 'wp help' for available commands."
 		);
+	} );
+
+	it( 'should return the correct version of WP-CLI', async () => {
+		const result = await getWPCliVersionFromInstallation();
+		expect( result ).toMatch( /v\d+\.\d+\.\d+/ ); // Example: v2.10.0
+	} );
+
+	it( 'should have the latest wp-cli version installed', async () => {
+		const isOutdated = await isWPCliInstallationOutdated();
+		expect( isOutdated ).toBe( false );
 	} );
 } );

--- a/src/tests/execute-wp-cli.test.ts
+++ b/src/tests/execute-wp-cli.test.ts
@@ -26,8 +26,8 @@ describe( 'executeWPCli', () => {
 
 		const result = await executeWPCli( tmpPath, args );
 
-		expect( result.stdout ).toMatch( /WP-CLI \d+\.\d+\.\d+/ );
-		expect( result.stderr ).toBe( '' ); // Example: WP-CLI 2.10.0
+		expect( result.stdout ).toMatch( /WP-CLI \d+\.\d+\.\d+/ ); // Example: WP-CLI 2.10.0
+		expect( result.stderr ).toBe( '' );
 	} );
 
 	it( 'should return error if wp-cli command does not exist', async () => {

--- a/vendor/wp-now/src/execute-wp-cli.ts
+++ b/vendor/wp-now/src/execute-wp-cli.ts
@@ -1,7 +1,7 @@
 import startWPNow from './wp-now';
 import { downloadWpCli } from './download';
 import getWpCliPath from './get-wp-cli-path';
-import getWpNowConfig from './config';
+import getWpNowConfig, { WPNowMode } from './config';
 import { DEFAULT_PHP_VERSION, DEFAULT_WORDPRESS_VERSION } from './constants';
 import { phpVar } from '@php-wasm/util';
 
@@ -15,8 +15,15 @@ export async function executeWPCli ( projectPath: string, args: string[] ): Prom
 		wp: DEFAULT_WORDPRESS_VERSION,
 		path: projectPath,
 	});
+	let mode = options.mode;
+	if (options.mode !== WPNowMode.WORDPRESS) {
+		// In case of not having the site projectPath,
+		// we use index mode to avoid other logic like downloading WordPress
+		mode = WPNowMode.INDEX;
+	}
 	const { phpInstances, options: wpNowOptions } = await startWPNow({
 		...options,
+		mode,
 		numberOfPhpInstances: 2,
 	});
 	const [, php] = phpInstances;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to https://github.com/Automattic/studio/pull/199

## Proposed Changes

- Replace the way we grab the wp-cli version to use the new stdout
- Add tests

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

-  Tests should pass
- Testing instructions on https://github.com/Automattic/studio/pull/199 should pass

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
