### PR TITLE
Update site details to allow user to set PHP version

### DIFF
--- a/src/components/tests/content-tab-settings.test.tsx
+++ b/src/components/tests/content-tab-settings.test.tsx
@@ -1,6 +1,7 @@
 // To run tests, execute `npm run test -- src/components/content-tab-settings.test.tsx` from the root directory
 import { fireEvent, render, screen } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
+import { useGetPhpVersion } from '../../hooks/use-get-php-version';
 import { useGetWpVersion } from '../../hooks/use-get-wp-version';
 import { useOffline } from '../../hooks/use-offline';
 import { useSiteDetails } from '../../hooks/use-site-details';
@@ -8,6 +9,7 @@ import { getIpcApi } from '../../lib/get-ipc-api';
 import { ContentTabSettings } from '../content-tab-settings';
 
 jest.mock( '../../hooks/use-get-wp-version' );
+jest.mock( '../../hooks/use-get-php-version' );
 jest.mock( '../../hooks/use-site-details' );
 jest.mock( '../../lib/get-ipc-api' );
 
@@ -28,6 +30,7 @@ describe( 'ContentTabSettings', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
 		( useGetWpVersion as jest.Mock ).mockReturnValue( '7.7.7' );
+		( useGetPhpVersion as jest.Mock ).mockReturnValue( '8.0' );
 		( getIpcApi as jest.Mock ).mockReturnValue( {
 			copyText,
 			openLocalPath,

--- a/src/hooks/use-get-php-version.ts
+++ b/src/hooks/use-get-php-version.ts
@@ -6,6 +6,6 @@ export function useGetPhpVersion( site: SiteDetails ) {
 	const [ phpVersion, setPhpVersion ] = useState( DEFAULT_PHP_VERSION );
 	useEffect( () => {
 		getIpcApi().getPhpVersion( site.id ).then( setPhpVersion );
-	}, [ site.id, site.running ] );
+	}, [ site.id, site.running, site.phpVersion ] );
 	return phpVersion;
 }

--- a/src/site-server.ts
+++ b/src/site-server.ts
@@ -112,6 +112,7 @@ export class SiteServer {
 			...this.details,
 			name: site.name,
 			path: site.path,
+			phpVersion: site.phpVersion,
 		};
 	}
 

--- a/src/tests/ipc-handlers.test.ts
+++ b/src/tests/ipc-handlers.test.ts
@@ -59,6 +59,7 @@ describe( 'createSite', () => {
 			id: expect.any( String ),
 			name: 'Test',
 			path: '/test',
+			phpVersion: '8.0',
 			running: false,
 		} );
 	} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->
Related to:

* Automattic/studio#225

Updates site details to allow user to set PHP version.

https://github.com/Automattic/studio/assets/643285/817f392c-bdca-405c-b12e-ca5eef04367a


## Proposed Changes

- Adds `phpVersion` to `updateSiteDetails` 
- Updates `useGetPhpVersion` to reflect `phpVersion` changes in the UI

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create a new site
2. Observe the site is using the default PHP version `8.0`
3. Start the site server by clicking Start button
4. Navigate to Settings and update the PHP version
5. Observe PHP version is updated in Studio UI
6. When the site is running, verify the PHP version is updated in the Site Health tab
7. Repeat steps for site when server is not running


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
