### PR TITLE
Studio: Translate "About Studio" modal

### DIFF
--- a/src/about-menu/about-menu.html
+++ b/src/about-menu/about-menu.html
@@ -79,7 +79,7 @@
   <div>  
     <img src="./studio-app-icon.png" alt="Studio App Icon" width="64" height="64">
         <p class="studio-name" id="studio-by-wpcom">Studio by WordPress.com</p>
-        <p class="version" id="version-text">Version</p>
+        <p class="version"><span id="version-text">Version x.y.z</span></p>
         <p class="links">
           <a href="https://github.com/Automattic/studio" target="_blank">GitHub</a>
           <span class="separator">&middot;</span>

--- a/src/about-menu/about-menu.html
+++ b/src/about-menu/about-menu.html
@@ -78,19 +78,19 @@
 <body> 
   <div>  
     <img src="./studio-app-icon.png" alt="Studio App Icon" width="64" height="64">
-        <p class="studio-name">Studio by WordPress.com</p>
-        <p class="version">Version <span id="version"></span></p>
+        <p class="studio-name" id="studio-by-wpcom">Studio by WordPress.com</p>
+        <p class="version"><span id="version-text">Version</span> <span id="version"></span></p>
         <p class="links">
           <a href="https://github.com/Automattic/studio" target="_blank">GitHub</a>
           <span class="separator">&middot;</span>
-          <a href="https://github.com/Automattic/studio/issues/new/choose" target="_blank">Share Feedback</a>
+          <a id="share-feedback" href="https://github.com/Automattic/studio/issues/new/choose" target="_blank">Share Feedback</a>
         </p>
   </div>
   <div class="info">
-    <p>Demo sites powered by<br><a href="https://wordpress.com/hosting/?utm_source=studio&utm_medium=referral&utm_campaign=about_screen" target="_blank">WordPress.com hosting ↗</a></p>
+    <p><span id="demo-sites">Demo sites powered by</span><br><a href="https://wordpress.com/hosting/?utm_source=studio&utm_medium=referral&utm_campaign=about_screen" target="_blank">WordPress.com hosting ↗</a></p>
   </div>
   <div class="info">
-    <p>Local sites powered by<br><a href="https://wordpress.org/playground/" target="_blank">WordPress Playground ↗</a></p>
+    <p><span id="local-sites">Local sites powered by</span><br><a href="https://wordpress.org/playground/" target="_blank">WordPress Playground ↗</a></p>
   </div>
 </body>
 </html>

--- a/src/about-menu/about-menu.html
+++ b/src/about-menu/about-menu.html
@@ -86,11 +86,6 @@
           <a href="https://github.com/Automattic/studio/issues/new/choose" target="_blank">Share Feedback</a>
         </p>
   </div>
-    <script>
-        // Access the version from the injected JavaScript
-        const version = document.getElementById('version');
-        version.innerText = window.appVersion; 
-    </script>
   <div class="info">
     <p>Demo sites powered by<br><a href="https://wordpress.com/hosting/?utm_source=studio&utm_medium=referral&utm_campaign=about_screen" target="_blank">WordPress.com hosting ↗</a></p>
   </div>

--- a/src/about-menu/about-menu.html
+++ b/src/about-menu/about-menu.html
@@ -79,7 +79,7 @@
   <div>  
     <img src="./studio-app-icon.png" alt="Studio App Icon" width="64" height="64">
         <p class="studio-name" id="studio-by-wpcom">Studio by WordPress.com</p>
-        <p class="version"><span id="version-text">Version</span> <span id="version"></span></p>
+        <p class="version" id="version-text">Version</p>
         <p class="links">
           <a href="https://github.com/Automattic/studio" target="_blank">GitHub</a>
           <span class="separator">&middot;</span>

--- a/src/about-menu/open-about-menu.ts
+++ b/src/about-menu/open-about-menu.ts
@@ -1,7 +1,7 @@
 import { BrowserWindow, app, shell } from 'electron';
 import path from 'path';
 import * as Sentry from '@sentry/electron/renderer';
-import { __ } from '@wordpress/i18n';
+import { sprintf, __ } from '@wordpress/i18n';
 import { ABOUT_WINDOW_HEIGHT, ABOUT_WINDOW_WIDTH } from '../constants';
 
 let aboutWindow: BrowserWindow | null = null;
@@ -39,7 +39,7 @@ export function openAboutWindow() {
 
 	aboutWindow.webContents.on( 'dom-ready', () => {
 		if ( aboutWindow ) {
-			const versionText = `${ __( 'Version' ) } ${ packageJson }`;
+			const versionText = sprintf( __( 'Version %s' ), packageJson );
 
 			// Inject version into the about window's HTML
 			aboutWindow.webContents

--- a/src/about-menu/open-about-menu.ts
+++ b/src/about-menu/open-about-menu.ts
@@ -1,5 +1,6 @@
 import { BrowserWindow, app, shell } from 'electron';
 import path from 'path';
+import { __ } from '@wordpress/i18n';
 import { ABOUT_WINDOW_HEIGHT, ABOUT_WINDOW_WIDTH } from '../constants';
 
 let aboutWindow: BrowserWindow | null = null;
@@ -39,7 +40,14 @@ export function openAboutWindow() {
 		if ( aboutWindow ) {
 			// Inject version into the about window's HTML
 			aboutWindow.webContents
-				.executeJavaScript( `document.getElementById('version').innerText = '${ packageJson }'` )
+				.executeJavaScript(
+					`document.getElementById('version').innerText = '${ packageJson }'; 
+					document.getElementById('studio-by-wpcom').innerText = '${ __( 'Studio by WordPress.com' ) }';
+					document.getElementById('version-text').innerText = '${ __( 'Version' ) }'; 
+					document.getElementById('share-feedback').innerText = '${ __( 'Share Feedback' ) }';
+					document.getElementById('demo-sites').innerText = '${ __( 'Demo sites powered by' ) }';
+					document.getElementById('local-sites').innerText = '${ __( 'Local sites powered by' ) }';`
+				)
 				.catch( ( err ) => {
 					console.error( 'Error executing JavaScript:', err );
 				} );

--- a/src/about-menu/open-about-menu.ts
+++ b/src/about-menu/open-about-menu.ts
@@ -1,5 +1,6 @@
 import { BrowserWindow, app, shell } from 'electron';
 import path from 'path';
+import * as Sentry from '@sentry/electron/renderer';
 import { __ } from '@wordpress/i18n';
 import { ABOUT_WINDOW_HEIGHT, ABOUT_WINDOW_WIDTH } from '../constants';
 
@@ -49,6 +50,7 @@ export function openAboutWindow() {
 					document.getElementById('local-sites').innerText = '${ __( 'Local sites powered by' ) }';`
 				)
 				.catch( ( err ) => {
+					Sentry.captureException( err );
 					console.error( 'Error executing JavaScript:', err );
 				} );
 		}

--- a/src/about-menu/open-about-menu.ts
+++ b/src/about-menu/open-about-menu.ts
@@ -39,12 +39,15 @@ export function openAboutWindow() {
 
 	aboutWindow.webContents.on( 'dom-ready', () => {
 		if ( aboutWindow ) {
+			const versionText = `${ __( 'Version' ) } ${ packageJson }`;
+
 			// Inject version into the about window's HTML
 			aboutWindow.webContents
 				.executeJavaScript(
-					`document.getElementById('version').innerText = '${ packageJson }'; 
-					document.getElementById('studio-by-wpcom').innerText = '${ __( 'Studio by WordPress.com' ) }';
-					document.getElementById('version-text').innerText = '${ __( 'Version' ) }'; 
+					`document.getElementById('studio-by-wpcom').innerText = '${ __(
+						'Studio by WordPress.com'
+					) }';
+					document.getElementById('version-text').innerText = '${ versionText }'; 
 					document.getElementById('share-feedback').innerText = '${ __( 'Share Feedback' ) }';
 					document.getElementById('demo-sites').innerText = '${ __( 'Demo sites powered by' ) }';
 					document.getElementById('local-sites').innerText = '${ __( 'Local sites powered by' ) }';`

--- a/src/about-menu/open-about-menu.ts
+++ b/src/about-menu/open-about-menu.ts
@@ -37,28 +37,31 @@ export function openAboutWindow() {
 	// Read package.json and pass version to about window
 	const packageJson = app.getVersion();
 
+	function escapeSingleQuotes( str: string ) {
+		return str.replace( /'/g, "\\'" );
+	}
+
 	aboutWindow.webContents.on( 'dom-ready', () => {
 		if ( aboutWindow ) {
 			const versionText = sprintf( __( 'Version %s' ), packageJson );
+			const studioByWpcomText = escapeSingleQuotes( __( 'Studio by WordPress.com' ) );
+			const shareFeedbackText = escapeSingleQuotes( __( 'Share Feedback' ) );
+			const demoSitesText = escapeSingleQuotes( __( 'Demo sites powered by' ) );
+			const localSitesText = escapeSingleQuotes( __( 'Local sites powered by' ) );
 
-			// Inject version into the about window's HTML
-			aboutWindow.webContents
-				.executeJavaScript(
-					`document.getElementById('studio-by-wpcom').innerText = '${ __(
-						'Studio by WordPress.com'
-					) }';
-					document.getElementById('version-text').innerText = '${ versionText }'; 
-					document.getElementById('share-feedback').innerText = '${ __( 'Share Feedback' ) }';
-					document.getElementById('demo-sites').innerText = '${ __( 'Demo sites powered by' ) }';
-					document.getElementById('local-sites').innerText = '${ __( 'Local sites powered by' ) }';`
-				)
-				.catch( ( err ) => {
-					Sentry.captureException( err );
-					console.error( 'Error executing JavaScript:', err );
-				} );
+			const script = `
+				document.getElementById('studio-by-wpcom').innerText = '${ studioByWpcomText }';
+				document.getElementById('version-text').innerText = '${ versionText }';
+				document.getElementById('share-feedback').innerText = '${ shareFeedbackText }';
+				document.getElementById('demo-sites').innerText = '${ demoSitesText }';
+				document.getElementById('local-sites').innerText = '${ localSitesText }';
+			`;
+			aboutWindow.webContents.executeJavaScript( script ).catch( ( err ) => {
+				Sentry.captureException( err );
+				console.error( 'Error executing JavaScript:', err );
+			} );
 		}
 	} );
-
 	aboutWindow.on( 'closed', () => {
 		aboutWindow = null;
 	} );


### PR DESCRIPTION
Closes https://github.com/Automattic/dotcom-forge/issues/7522
## Proposed Changes

This PR makes the strings in the "About Studio" window translatable.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Pull the changes from this branch locally
- Before starting the app, modify the language in `locale.ts` in `getPreferredSystemLanguages` to return French:
```
export function getPreferredSystemLanguages() {
	if ( process.platform === 'linux' && process.env.NODE_ENV !== 'test' ) {
			.getPreferredSystemLanguages()
			.filter( ( lang ) => supportedLocales.includes( lang ) );
	}
	return [ 'fr' ];
}
```
- Navigate to `src/translations/studio-fr.jed.json` 
- Add the following strings and translations to the file:

```
            "Demo sites powered by": [
                "Sites de démonstration propulsés par"
            ],
            "Local sites powered by": [
                "Sites locaux propulsés par"
            ],
            "Share Feedback": [
                "Partager des commentaires"
            ],
            "Studio by WordPress.com": [
                "Studio par WordPress.com"
            ],
            "Version": [
                "Version"
            ]
```
* Start the app with `nvm use && npm install && npm start`
* Open the About Studio window
* Confirm that the strings are translated to French:

<img width="285" alt="Capture d’écran, le 2024-06-10 à 13 46 09" src="https://github.com/Automattic/studio/assets/25575134/7fb61a29-3af8-4a3c-a645-8c55d2b06b05">

**Notes**:

* I explored refactoring the HTML file into a React component and then rendering it into this custom window but the solution required modifying the app setup in multiple places. I opted for a more straightforward approach considering that that window is fairly static

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
