### PR TITLE
Fix race condition when setting up server files

### DIFF
--- a/src/__mocks__/electron.ts
+++ b/src/__mocks__/electron.ts
@@ -1,6 +1,7 @@
 export const ipcMain = {
 	emit: jest.fn(),
 	on: jest.fn(),
+	handle: jest.fn(),
 };
 
 export const app = {
@@ -16,6 +17,7 @@ export const app = {
 	setAppLogsPath: jest.fn(),
 	setAsDefaultProtocolClient: jest.fn(),
 	enableSandbox: jest.fn(),
+	getSystemLocale: jest.fn(),
 };
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -49,4 +51,13 @@ export const shell = {
 export const autoUpdater = {
 	setFeedURL: jest.fn(),
 	on: jest.fn(),
+};
+
+export const session = {
+	defaultSession: {
+		setPermissionRequestHandler: jest.fn(),
+		webRequest: {
+			onHeadersReceived: jest.fn(),
+		},
+	},
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,8 +72,6 @@ async function appBoot() {
 
 	setupUpdates();
 
-	setupWPServerFiles().catch( Sentry.captureException );
-
 	if ( process.defaultApp ) {
 		if ( process.argv.length >= 2 ) {
 			app.setAsDefaultProtocolClient( PROTOCOL_PREFIX, process.execPath, [
@@ -219,6 +217,8 @@ async function appBoot() {
 				},
 			} );
 		} );
+
+		await setupWPServerFiles().catch( Sentry.captureException );
 
 		if ( await needsToMigrateFromWpNowFolder() ) {
 			await migrateFromWpNowFolder();

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -68,8 +68,8 @@ it( 'should handle authentication deep links', () => {
 	} );
 } );
 
-it( 'should await the app ready state before creating a window for activate events', () => {
-	jest.isolateModules( async () => {
+it( 'should await the app ready state before creating a window for activate events', async () => {
+	await jest.isolateModulesAsync( async () => {
 		// eslint-disable-next-line @typescript-eslint/no-empty-function
 		let activate: ( ...args: any[] ) => void = () => {};
 		jest.doMock( 'electron', () => {
@@ -104,8 +104,8 @@ it( 'should await the app ready state before creating a window for activate even
 	} );
 } );
 
-it( 'should gracefully handle app ready failures when creating a window on activate', () => {
-	jest.isolateModules( async () => {
+it( 'should gracefully handle app ready failures when creating a window on activate', async () => {
+	await jest.isolateModulesAsync( async () => {
 		// eslint-disable-next-line @typescript-eslint/no-empty-function
 		let activate: ( ...args: any[] ) => void = () => {};
 		jest.doMock( 'electron', () => {
@@ -136,11 +136,8 @@ it( 'should gracefully handle app ready failures when creating a window on activ
 
 		activate();
 
-		expect( async () => {
-			// Await the mocked `whenReady` promise resolution
-			await new Promise( process.nextTick );
-			expect( createMainWindowMock ).not.toHaveBeenCalled();
-			expect( captureExceptionMock ).toHaveBeenCalled();
-		} ).not.toThrow();
+		await new Promise( process.nextTick );
+		expect( createMainWindowMock ).not.toHaveBeenCalled();
+		expect( captureExceptionMock ).toHaveBeenCalled();
 	} );
 } );

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -2,9 +2,11 @@
  * @jest-environment node
  */
 import fs from 'fs';
+import { createMainWindow } from '../main-window';
 
 jest.mock( 'fs' );
 jest.mock( 'file-stream-rotator' );
+jest.mock( '../main-window' );
 
 const mockUserData = {
 	sites: [],
@@ -14,6 +16,10 @@ const mockUserData = {
 	JSON.stringify( mockUserData )
 );
 ( fs as MockedFs ).__setFileContents( '/path/to/app/temp/com.wordpress.studio/', '' );
+
+afterEach( () => {
+	jest.clearAllMocks();
+} );
 
 it( 'should boot successfully', () => {
 	jest.isolateModules( () => {
@@ -87,20 +93,14 @@ it( 'should await the app ready state before creating a window for activate even
 				},
 			};
 		} );
-		const createMainWindowMock = jest.fn();
-		jest.doMock( '../main-window', () => {
-			return {
-				createMainWindow: createMainWindowMock,
-			};
-		} );
 		require( '../index' );
 
 		activate();
 
-		expect( createMainWindowMock ).not.toHaveBeenCalled();
+		expect( createMainWindow ).not.toHaveBeenCalled();
 		// Await the mocked `whenReady` promise resolution
 		await new Promise( process.nextTick );
-		expect( createMainWindowMock ).toHaveBeenCalled();
+		expect( createMainWindow ).toHaveBeenCalled();
 	} );
 } );
 
@@ -123,10 +123,6 @@ it( 'should gracefully handle app ready failures when creating a window on activ
 				},
 			};
 		} );
-		const createMainWindowMock = jest.fn();
-		jest.doMock( '../main-window', () => ( {
-			createMainWindow: createMainWindowMock,
-		} ) );
 		const captureExceptionMock = jest.fn();
 		jest.doMock( '@sentry/electron/main', () => ( {
 			init: jest.fn(),
@@ -137,7 +133,7 @@ it( 'should gracefully handle app ready failures when creating a window on activ
 		activate();
 
 		await new Promise( process.nextTick );
-		expect( createMainWindowMock ).not.toHaveBeenCalled();
+		expect( createMainWindow ).not.toHaveBeenCalled();
 		expect( captureExceptionMock ).toHaveBeenCalled();
 	} );
 } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to https://github.com/Automattic/studio/pull/76#issuecomment-2149343524.

## Proposed Changes

- Move the call to `setupWPServerFiles` to the app's ready event handler. This will ensure that the setup finishes before creating the main window and let the user interact with the app.
- Add unit test to cover the case.
- Small refactor in the `index.test.ts` file to address issues with async code.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

> [!NOTE]
> This issue has been spotted when running E2E tests on Windows. It's unlikely that users have encountered this as it's produced by a combination of slow file disk operations and creating a site quickly after the app is launched.

- Remove all site folders to ensure that the app starts on the onboarding screen.
- Remove the folder `$HOME/Library/Application Support/Studio/server-files`.
- Open the app and quickly add a site.
- Observe the site is created successfully.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
