### PR TITLE
Add unit tests to cover changing PHP version functionality

### DIFF
--- a/jest-setup.ts
+++ b/jest-setup.ts
@@ -4,6 +4,22 @@ import nock from 'nock';
 if ( typeof window !== 'undefined' ) {
 	// The ipcListener global is usually defined in preload.ts
 	window.ipcListener = { subscribe: jest.fn() };
+
+	// Mock `matchMedia` as it's not implemented in JSDOM
+	// Reference: https://jestjs.io/docs/manual-mocks#mocking-methods-which-are-not-implemented-in-jsdom
+	Object.defineProperty( window, 'matchMedia', {
+		writable: true,
+		value: jest.fn().mockImplementation( ( query ) => ( {
+			matches: false,
+			media: query,
+			onchange: null,
+			addListener: jest.fn(), // deprecated
+			removeListener: jest.fn(), // deprecated
+			addEventListener: jest.fn(),
+			removeEventListener: jest.fn(),
+			dispatchEvent: jest.fn(),
+		} ) ),
+	} );
 }
 
 nock.disableNetConnect();

--- a/src/components/content-tab-settings.tsx
+++ b/src/components/content-tab-settings.tsx
@@ -17,7 +17,7 @@ interface ContentTabSettingsProps {
 
 function SettingsRow( { children, label }: PropsWithChildren< { label: string } > ) {
 	return (
-		<tr className="align-top">
+		<tr className="align-top" aria-label={ label }>
 			<th className="text-nowrap text-a8c-gray-50 pb-4 ltr:pr-6 rtl:pl-6 ltr:text-left rtl:text-right font-normal">
 				{ label }
 			</th>

--- a/src/components/content-tab-settings.tsx
+++ b/src/components/content-tab-settings.tsx
@@ -17,7 +17,7 @@ interface ContentTabSettingsProps {
 
 function SettingsRow( { children, label }: PropsWithChildren< { label: string } > ) {
 	return (
-		<tr className="align-top" aria-label={ label }>
+		<tr className="align-top">
 			<th className="text-nowrap text-a8c-gray-50 pb-4 ltr:pr-6 rtl:pl-6 ltr:text-left rtl:text-right font-normal">
 				{ label }
 			</th>

--- a/src/components/tests/content-tab-settings.test.tsx
+++ b/src/components/tests/content-tab-settings.test.tsx
@@ -191,7 +191,7 @@ describe( 'ContentTabSettings', () => {
 
 			( useGetPhpVersion as jest.Mock ).mockReturnValue( '8.2' );
 			rerender( <ContentTabSettings selectedSite={ selectedSite } /> );
-			expect( within( screen.getByLabelText( 'PHP Version' ) ).getByText( '8.2' ) ).toBeVisible();
+			expect( screen.getByText( '8.2' ) ).toBeVisible();
 		} );
 
 		it( 'changes PHP version and restarts site when site is running', async () => {
@@ -231,7 +231,7 @@ describe( 'ContentTabSettings', () => {
 
 			( useGetPhpVersion as jest.Mock ).mockReturnValue( '8.2' );
 			rerender( <ContentTabSettings selectedSite={ selectedSite } /> );
-			expect( within( screen.getByLabelText( 'PHP Version' ) ).getByText( '8.2' ) ).toBeVisible();
+			expect( screen.getByText( '8.2' ) ).toBeVisible();
 		} );
 	} );
 } );

--- a/src/components/tests/content-tab-settings.test.tsx
+++ b/src/components/tests/content-tab-settings.test.tsx
@@ -1,5 +1,5 @@
 // To run tests, execute `npm run test -- src/components/content-tab-settings.test.tsx` from the root directory
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import { useGetPhpVersion } from '../../hooks/use-get-php-version';
 import { useGetWpVersion } from '../../hooks/use-get-wp-version';
@@ -150,6 +150,88 @@ describe( 'ContentTabSettings', () => {
 			await user.click( adminPasswordButton );
 			expect( copyText ).toHaveBeenCalledTimes( 1 );
 			expect( copyText ).toHaveBeenCalledWith( 'password' );
+		} );
+	} );
+
+	describe( 'PHP version', () => {
+		it( 'changes PHP version when site is not running', async () => {
+			const user = userEvent.setup();
+
+			const updateSite = jest.fn();
+			const startServer = jest.fn();
+			const stopServer = jest.fn();
+			// Mock snapshots to include a snapshot for the selected site
+			( useSiteDetails as jest.Mock ).mockReturnValue( {
+				selectedSite: { ...selectedSite, running: false } as SiteDetails,
+				snapshots: [ { localSiteId: selectedSite.id } ],
+				updateSite,
+				startServer,
+				stopServer,
+			} );
+			( useGetPhpVersion as jest.Mock ).mockReturnValue( '8.0' );
+
+			const { rerender } = render( <ContentTabSettings selectedSite={ selectedSite } /> );
+			await user.click( screen.getByRole( 'button', { name: 'Edit PHP version' } ) );
+			const dialog = screen.getByRole( 'dialog' );
+			expect( dialog ).toBeVisible();
+			await user.selectOptions(
+				within( dialog ).getByRole( 'combobox', {
+					name: 'PHP version',
+				} ),
+				'8.2'
+			);
+			await user.click(
+				within( dialog ).getByRole( 'button', {
+					name: 'Save',
+				} )
+			);
+			expect( updateSite ).toHaveBeenCalledWith( expect.objectContaining( { phpVersion: '8.2' } ) );
+			expect( stopServer ).not.toHaveBeenCalled();
+			expect( startServer ).not.toHaveBeenCalled();
+
+			( useGetPhpVersion as jest.Mock ).mockReturnValue( '8.2' );
+			rerender( <ContentTabSettings selectedSite={ selectedSite } /> );
+			expect( within( screen.getByLabelText( 'PHP Version' ) ).getByText( '8.2' ) ).toBeVisible();
+		} );
+
+		it( 'changes PHP version and restarts site when site is running', async () => {
+			const user = userEvent.setup();
+
+			const updateSite = jest.fn();
+			const startServer = jest.fn();
+			const stopServer = jest.fn();
+			// Mock snapshots to include a snapshot for the selected site
+			( useSiteDetails as jest.Mock ).mockReturnValue( {
+				selectedSite: { ...selectedSite, running: true } as SiteDetails,
+				snapshots: [ { localSiteId: selectedSite.id } ],
+				updateSite,
+				startServer,
+				stopServer,
+			} );
+			( useGetPhpVersion as jest.Mock ).mockReturnValue( '8.0' );
+
+			const { rerender } = render( <ContentTabSettings selectedSite={ selectedSite } /> );
+			await user.click( screen.getByRole( 'button', { name: 'Edit PHP version' } ) );
+			const dialog = screen.getByRole( 'dialog' );
+			expect( dialog ).toBeVisible();
+			await user.selectOptions(
+				within( dialog ).getByRole( 'combobox', {
+					name: 'PHP version',
+				} ),
+				'8.2'
+			);
+			await user.click(
+				within( dialog ).getByRole( 'button', {
+					name: 'Save',
+				} )
+			);
+			expect( updateSite ).toHaveBeenCalledWith( expect.objectContaining( { phpVersion: '8.2' } ) );
+			expect( stopServer ).toHaveBeenCalled();
+			expect( startServer ).toHaveBeenCalled();
+
+			( useGetPhpVersion as jest.Mock ).mockReturnValue( '8.2' );
+			rerender( <ContentTabSettings selectedSite={ selectedSite } /> );
+			expect( within( screen.getByLabelText( 'PHP Version' ) ).getByText( '8.2' ) ).toBeVisible();
 		} );
 	} );
 } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to https://github.com/Automattic/studio/pull/225.

## Proposed Changes

- Add unit tests to cover two cases:
    - Change the PHP version when a site is not running.
    - Change the PHP version when a site is running.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Observe that all CI jobs succeed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
