### PR TITLE
Update rendered Markdown styles

### DIFF
--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -151,11 +151,17 @@ export const Message = ( { children, isUser, className }: MessageProps ) => {
 	};
 
 	return (
-		<div className={ cx( 'flex mt-4', isUser ? 'justify-end' : 'justify-start', className ) }>
+		<div
+			className={ cx(
+				'flex mt-4',
+				isUser ? 'justify-end md:ml-24' : 'justify-start md:mr-24',
+				className
+			) }
+		>
 			<div
 				className={ cx(
-					'inline-block p-3 rounded-sm border border-gray-300 lg:max-w-[70%] select-text',
-					! isUser && 'bg-white'
+					'inline-block p-3 rounded border border-gray-300 lg:max-w-[70%] select-text',
+					! isUser ? 'bg-white' : 'bg-white/45'
 				) }
 			>
 				{ typeof children === 'string' ? (

--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -142,7 +142,7 @@ export const Message = ( { children, isUser, className }: MessageProps ) => {
 				) }
 			</>
 		) : (
-			<div className="p-3">
+			<div className="inline-block">
 				<code className={ className } { ...props }>
 					{ children }
 				</code>

--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -154,7 +154,7 @@ export const Message = ( { children, isUser, className }: MessageProps ) => {
 		<div className={ cx( 'flex mt-4', isUser ? 'justify-end' : 'justify-start', className ) }>
 			<div
 				className={ cx(
-					'inline-block p-3 rounded-sm border border-gray-300 lg:max-w-[70%] select-text whitespace-pre-wrap',
+					'inline-block p-3 rounded-sm border border-gray-300 lg:max-w-[70%] select-text',
 					! isUser && 'bg-white'
 				) }
 			>

--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -116,7 +116,7 @@ export const Message = ( { children, isUser, className }: MessageProps ) => {
 						{ children }
 					</code>
 				</div>
-				<div className="p-3 mt-1 flex justify-start items-center">
+				<div className="p-3 pt-1 flex justify-start items-center">
 					<ActionButton
 						primaryLabel={ __( 'Copy' ) }
 						secondaryLabel={ __( 'Copied' ) }

--- a/src/index.css
+++ b/src/index.css
@@ -87,82 +87,103 @@ blockquote {
 	width: 100%;
 }
 
+/* Assistant messages */
 .assistant-markdown {
-	line-height: 1.6;
+	line-height: 1.4;
 	word-wrap: break-word;
 }
 
 .assistant-markdown blockquote {
-	font-weight: bold;
-	margin: 1rem 0;
+	background-color: theme( 'colors.a8c-gray.0' );
+	border-radius: 2px;
+	margin: 0 0 1rem;
 	padding: 0.5rem 1rem;
 }
 
+.assistant-markdown blockquote > blockquote {
+	background-color: theme( 'colors.a8c-gray.5' );
+	margin: 0;
+}
+
+.assistant-markdown p {
+	margin: 0 0 1rem;
+}
+
 .assistant-markdown code {
-	background-color: #f8f8f2;
+	background-color: theme( 'colors.a8c-gray.0' );
 	color: #1D2327;
 	font-family: 'Courier New', Courier, monospace;
 	font-size: 13px;
 	padding: 0.25rem;
 	white-space: pre-wrap;
+	border-radius: 2px;
 }
 
 .assistant-markdown pre {
-	background-color: #1D2327;
+	background-color: theme( 'colors.a8c-gray.90' );
 	border-radius: 5px;
-	margin: 0.5rem 0;
+	margin: 0 0 1rem 0;
 	overflow-x: auto;
 }
 
 .assistant-markdown pre code {
 	background-color: transparent;
-	color: #f8f8f2;
+	color: theme( 'colors.a8c-gray.0' );
 	padding: 0;
 }
 
+.assistant-markdown h1,
+.assistant-markdown h2,
+.assistant-markdown h3,
+.assistant-markdown h4,
+.assistant-markdown h5,
+.assistant-markdown h6 {
+	margin: 1rem 0 .5rem 0;
+}
+
 .assistant-markdown h1 {
-	font-size: 1.5rem;
-	font-weight: bold;
+	font-size: 1.2rem;
+	font-weight: 500;
 }
 
 .assistant-markdown h2 {
-	font-size: 1.25rem;
-	font-weight: bold;
+	font-size: 1.1rem;
+	font-weight: 600;
 }
 
 .assistant-markdown h3 {
-	font-size: 1.125rem;
-	font-weight: bold;
-}
-
-.assistant-markdown h4 {
 	font-size: 1rem;
 	font-weight: bold;
 }
 
-.assistant-markdown h5 {
-	font-size: 0.875rem;
-	font-weight: bold;
-}
-
+.assistant-markdown h4,
+.assistant-markdown h5,
 .assistant-markdown h6 {
-	font-size: 0.85rem;
+	font-size: 0.875rem;
 	font-weight: bold;
 }
 
 .assistant-markdown hr {
 	border: none;
+	border-top: 1px solid theme( 'colors.a8c-gray.5' );
 	margin: 1rem 0;
 }
 
 .assistant-markdown ol {
 	list-style-type: decimal;
-	margin: 1rem 0;
+	margin: 0 0 1rem;
 	padding-left: 1.5rem;
 }
 
 .assistant-markdown ul {
 	list-style-type: disc;
-	margin: 1rem 0;
+	margin: 0 0 1rem;
 	padding-left: 1.5rem;
+}
+
+.assistant-markdown pre:last-child,
+.assistant-markdown p:last-child,
+.assistant-markdown ol:last-child,
+.assistant-markdown ul:last-child {
+	margin-bottom: 0;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -93,6 +93,16 @@ blockquote {
 	word-wrap: break-word;
 }
 
+.assistant-markdown a {
+	color: #3858E9;
+}
+
+.assistant-markdown a:hover,
+.assistant-markdown a:focus {
+	color: #2145E6;
+	text-decoration: underline;
+}
+
 .assistant-markdown blockquote {
 	background-color: theme( 'colors.a8c-gray.0' );
 	border-radius: 2px;

--- a/src/index.css
+++ b/src/index.css
@@ -191,6 +191,13 @@ blockquote {
 	padding-left: 1.5rem;
 }
 
+.assistant-markdown li {
+	margin-bottom: 0.25rem;
+}
+.assistant-markdown li:last-child {
+	margin-bottom: 0;
+}
+
 .assistant-markdown pre:last-child,
 .assistant-markdown p:last-child,
 .assistant-markdown ol:last-child,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/7670

## Proposed Changes

- Cleaned up styles for rendered markdown.
- Added left/right margins to messages.
- Updated background for user messages.

> <img width="516" alt="Screenshot 2024-06-12 at 11 29 55" src="https://github.com/Automattic/studio/assets/417538/f8f8c4d8-5fb0-4d34-babb-261123a646bb">
> <img width="515" alt="Screenshot 2024-06-12 at 11 30 03" src="https://github.com/Automattic/studio/assets/417538/b6cb6dc3-73cf-442d-80df-03ad31da6581">



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Open Studio using `STUDIO_AI=true npm start`
- Switch to the Assistant tab
- Enter a prompt to see example markdown styles:

```
Show me how all markdown elements would look when rendered
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
