### PR TITLE
Bump default PHP version to `8.1`

### DIFF
--- a/src/tests/ipc-handlers.test.ts
+++ b/src/tests/ipc-handlers.test.ts
@@ -59,7 +59,7 @@ describe( 'createSite', () => {
 			id: expect.any( String ),
 			name: 'Test',
 			path: '/test',
-			phpVersion: '8.0',
+			phpVersion: '8.1',
 			running: false,
 		} );
 	} );

--- a/vendor/wp-now/src/constants.ts
+++ b/vendor/wp-now/src/constants.ts
@@ -17,7 +17,7 @@ export const DEFAULT_PORT = 8881;
 /**
  * The default PHP version to use when running the WP Now server.
  */
-export const DEFAULT_PHP_VERSION = '8.0';
+export const DEFAULT_PHP_VERSION = '8.1';
 
 /**
  * The default WordPress version to use when running the WP Now server.


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to https://github.com/Automattic/studio/pull/225.

## Proposed Changes

- Bump default PHP version to `8.1`. This change is driven by the fact that version `8.0` already reached its end-of-life by 2024 ([reference](https://www.php.net/supported-versions.php)).

> [!NOTE]
> Sites created before this change will have PHP version `8.0`. This PR doesn't aim to migrate them to the new default value.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create a new site.
2. Go to the Settings tab.
3. Observe that the PHP version is `8.1`.
4. Open WP admin and navigate to `wp-admin/site-health.php?tab=debug`.
5. Open the Server section.
6. Observe that the PHP version is `8.1`.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
