### PR TITLE
fix: Improve button style consistency

### DIFF
--- a/src/components/add-site.tsx
+++ b/src/components/add-site.tsx
@@ -4,7 +4,6 @@ import { useI18n } from '@wordpress/react-i18n';
 import { FormEvent, useCallback, useEffect, useState } from 'react';
 import { useAddSite } from '../hooks/use-add-site';
 import { useIpcListener } from '../hooks/use-ipc-listener';
-import { cx } from '../lib/cx';
 import { generateSiteName } from '../lib/generate-site-name';
 import { getIpcApi } from '../lib/get-ipc-api';
 import Button from './button';
@@ -14,25 +13,6 @@ import { SiteForm } from './site-form';
 interface AddSiteProps {
 	className?: string;
 }
-
-/**
- * The arbitrary Tailwind variants below (e.g., `[&.is-secondary]`) are used to
- * achieve the specificity required to override the default button styles
- * without `!important`, which often creates specificity collisions.
- */
-const buttonStyles = `
-add-site
-text-white
-[&.components-button]:hover:text-black
-[&.components-button]:hover:bg-gray-100
-[&.components-button]:active:text-black
-[&.components-button]:active:bg-gray-100
-[&.components-button]:shadow-[inset_0_0_0_1px_white]
-[&.components-button.add-site]:focus:shadow-[inset_0_0_0_1px_white]
-[&.components-button]:focus-visible:outline-none
-[&.components-button.add-site]:focus-visible:shadow-[inset_0_0_0_1px_#3858E9]
-[&.components-button]:focus-visible:shadow-a8c-blueberry
-`.replace( /\n/g, ' ' );
 
 export default function AddSite( { className }: AddSiteProps ) {
 	const { __ } = useI18n();
@@ -152,7 +132,7 @@ export default function AddSite( { className }: AddSiteProps ) {
 					</SiteForm>
 				</Modal>
 			) }
-			<Button className={ cx( buttonStyles, className ) } onClick={ openModal }>
+			<Button variant="outlined" className={ className } onClick={ openModal }>
 				{ __( 'Add site' ) }
 			</Button>
 		</>

--- a/src/components/button.tsx
+++ b/src/components/button.tsx
@@ -11,9 +11,11 @@ import { cx } from '../lib/cx';
 type MappedOmit< T, K extends PropertyKey > = { [ P in keyof T as Exclude< P, K > ]: T[ P ] };
 
 export type ButtonProps = MappedOmit< ComponentProps< typeof Button >, 'variant' > & {
-	variant?: 'primary' | 'secondary' | 'tertiary' | 'link' | 'icon';
+	variant?: ButtonVariant;
 	truncate?: boolean;
 };
+
+type ButtonVariant = 'primary' | 'secondary' | 'tertiary' | 'outlined' | 'link' | 'icon';
 
 /**
  * The arbitrary Tailwind variants below (e.g., `[&.is-secondary]`) are used to
@@ -59,17 +61,18 @@ const secondaryStyles = `
 [&.is-secondary:not(:focus)]:aria-disabled:hover:shadow-a8c-gray-5
 `.replace( /\n/g, ' ' );
 
-const tertiaryStyles = `
-[&.is-tertiary]:text-white
-[&.is-tertiary]:bg-gray-700
-[&.is-tertiary]:focus:bg-gray-600
-[&.is-tertiary]:focus:text-white
-[&.is-tertiary:not(.is-destructive,:disabled,[aria-disabled=true])]:hover:bg-gray-600
-[&.is-tertiary:not(.is-destructive,:disabled,[aria-disabled=true])]:hover:text-white
-[&.is-tertiary]:hover:bg-white
-[&.is-tertiary]:hover:text-white
-[&.is-tertiary]:disabled:bg-gray-700
-[&.is-tertiary]:disabled:text-a8c-gray-50
+const outlinedStyles = `
+outlined
+text-white
+[&.components-button]:hover:text-black
+[&.components-button]:hover:bg-gray-100
+[&.components-button]:active:text-black
+[&.components-button]:active:bg-gray-100
+[&.components-button]:shadow-[inset_0_0_0_1px_white]
+[&.components-button.outlined]:focus:shadow-[inset_0_0_0_1px_white]
+[&.components-button]:focus-visible:outline-none
+[&.components-button.outlined]:focus-visible:shadow-[inset_0_0_0_1px_#3858E9]
+[&.components-button]:focus-visible:shadow-a8c-blueberry
 `.replace( /\n/g, ' ' );
 
 const destructiveStyles = `
@@ -95,6 +98,19 @@ hover:bg-white
 hover:bg-opacity-10
 `.replace( /\n/g, ' ' );
 
+/**
+ * Filter out custom values from the `variant` prop to avoid passing invalid
+ * values to the core WordPress components.
+ *
+ * @param variant - The button variant.
+ * @returns The variant value or, if the value is a Studio-specific, `undefined`.
+ */
+function sansCustomValues( variant: ButtonVariant | undefined ) {
+	return !! variant && [ 'outlined', 'icon' ].includes( variant )
+		? undefined
+		: ( variant as Exclude< ButtonVariant, 'outlined' | 'icon' > | undefined );
+}
+
 export default function ButtonComponent( {
 	className,
 	variant,
@@ -115,12 +131,12 @@ export default function ButtonComponent( {
 	return (
 		<Button
 			{ ...props }
-			variant={ variant === 'icon' ? undefined : variant }
+			variant={ sansCustomValues( variant ) }
 			className={ cx(
 				baseStyles,
 				variant === 'primary' && primaryStyles,
 				variant === 'secondary' && secondaryStyles,
-				variant === 'tertiary' && tertiaryStyles,
+				variant === 'outlined' && outlinedStyles,
 				variant === 'link' && linkStyles,
 				variant === 'icon' && iconStyles,
 				props.isDestructive && destructiveStyles,

--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -77,7 +77,7 @@ const ActionButton = ( {
 		<Button
 			onClick={ handleClick }
 			variant="outlined"
-			className="mr-2 font-sans select-none"
+			className="h-auto mr-2 !px-2.5 py-0.5 font-sans select-none"
 			disabled={ disabled }
 		>
 			{ icon }

--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -76,7 +76,7 @@ const ActionButton = ( {
 	return (
 		<Button
 			onClick={ handleClick }
-			variant="tertiary"
+			variant="outlined"
 			className="mr-2 font-sans select-none"
 			disabled={ disabled }
 		>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Relates to https://github.com/Automattic/studio/pull/214#discussion_r1635129557.

## Proposed Changes

Introduce a new `outlined` button variant.

Overloading the in-use `tertiary` button variant styles resulted in
unexpected and inconsistent styles in the UI --- e.g., the "Add site"
dialog. Introducing a new `outlined` variant achieves the original goal
of a new button style that is now used in both the sidebar and AI
assistant code blocks.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Expected outline button styles display**

1. Verify the sidebar's "Add site" button renders correct styles.
1. Navigate to the "Assistant" tab.
1. Send a "Show me some code" message.
1. Verify the "Copy" and "Run"[^1] buttons render correct styles.

| Before | After |
| - | - |
| ![before-inline-code](https://github.com/Automattic/studio/assets/438664/0d3217ed-b855-4b6e-afc9-06b399525420) | ![after-inline-code](https://github.com/Automattic/studio/assets/438664/f1a11032-9e9c-4146-83bf-4e56c3b4f97c) |

[^1]: The "Run" button is currently commented in the source code and thus hidden. 

**Expected tertiary button styles display**

1. Click "Add site."
1. Verify the "Cancel" button renders correct styles.

| Before | After |
| - | - |
| ![before-add-site](https://github.com/Automattic/studio/assets/438664/0693e9bd-7b21-4f3b-a908-ba5cead820a9) | ![after-add-site](https://github.com/Automattic/studio/assets/438664/0d11a792-ee46-49db-95be-d14581f0be16) |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
