### PR TITLE
 Studio: Add the initial welcome prompts UI component

### DIFF
--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -241,7 +241,6 @@ export function ContentTabAssistant( { selectedSite }: ContentTabAssistantProps 
 		fetchWelcomeMessages,
 	} = useFetchWelcomeMessages();
 	const [ input, setInput ] = useState< string >( '' );
-	const [ examplePromptsVisible, setExamplePromptsVisible ] = useState( true );
 	const endOfMessagesRef = useRef< HTMLDivElement >( null );
 	const { isAuthenticated, authenticate } = useAuth();
 	const isOffline = useOffline();
@@ -251,18 +250,11 @@ export function ContentTabAssistant( { selectedSite }: ContentTabAssistantProps 
 		fetchWelcomeMessages();
 	}, [ fetchWelcomeMessages, selectedSite ] );
 
-	useEffect( () => {
-		if ( messages.length === 0 ) {
-			setExamplePromptsVisible( true );
-		}
-	}, [ selectedSite, messages ] );
-
 	const handleSend = async ( messageToSend?: string ) => {
 		const message = messageToSend || input;
 		if ( message.trim() ) {
 			addMessage( message, 'user' );
 			setInput( '' );
-			setExamplePromptsVisible( false ); // Hide example prompts after one is clicked or a message is sent
 			try {
 				const { message: assistantMessage } = await fetchAssistant( [
 					...messages,
@@ -315,7 +307,7 @@ export function ContentTabAssistant( { selectedSite }: ContentTabAssistantProps 
 					<>
 						<WelcomeComponent
 							onExampleClick={ ( prompt ) => handleSend( prompt ) }
-							showExamplePrompts={ examplePromptsVisible }
+							showExamplePrompts={ messages.length === 0 }
 							messages={ welcomeMessages }
 							examplePrompts={ examplePrompts }
 						/>

--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -248,38 +248,37 @@ export function ContentTabAssistant( { selectedSite }: ContentTabAssistantProps 
 	const isOffline = useOffline();
 	const { __ } = useI18n();
 
-
 	useEffect( () => {
 		fetchWelcomeMessages();
 	}, [ fetchWelcomeMessages, selectedSite ] );
 
-const handleSend = async (messageToSend?: string) => {
-	const chatMessage = messageToSend || input;
-	if (chatMessage.trim()) {
-		addMessage(chatMessage, 'user', chatId);
-		setInput('');
-		try {
-			const { message, chatId: fetchedChatId } = await fetchAssistant(chatId, [
-				...messages,
-				{ content: chatMessage, role: 'user' },
-			]);
-			if (message) {
-				addMessage(message, 'assistant', chatId ?? fetchedChatId);
+	const handleSend = async ( messageToSend?: string ) => {
+		const chatMessage = messageToSend || input;
+		if ( chatMessage.trim() ) {
+			addMessage( chatMessage, 'user', chatId );
+			setInput( '' );
+			try {
+				const { message, chatId: fetchedChatId } = await fetchAssistant( chatId, [
+					...messages,
+					{ content: chatMessage, role: 'user' },
+				] );
+				if ( message ) {
+					addMessage( message, 'assistant', chatId ?? fetchedChatId );
+				}
+			} catch ( error ) {
+				setTimeout(
+					() =>
+						getIpcApi().showMessageBox( {
+							type: 'warning',
+							message: __( 'Failed to send message' ),
+							detail: __( "We couldn't send the latest message. Please try again." ),
+							buttons: [ __( 'OK' ) ],
+						} ),
+					100
+				);
 			}
-		} catch (error) {
-			setTimeout(
-				() =>
-					getIpcApi().showMessageBox({
-						type: 'warning',
-						message: __('Failed to send message'),
-						detail: __("We couldn't send the latest message. Please try again."),
-						buttons: [__('OK')],
-					}),
-				100
-			);
 		}
-	}
-};
+	};
 
 	const handleKeyDown = ( e: React.KeyboardEvent< HTMLTextAreaElement > ) => {
 		if ( e.key === 'Enter' ) {

--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -235,6 +235,7 @@ export function ContentTabAssistant( { selectedSite }: ContentTabAssistantProps 
 	const { messages, addMessage, clearMessages } = useAssistant( selectedSite.name );
 	const { fetchAssistant, isLoading: isAssistantThinking } = useAssistantApi();
 	const [ input, setInput ] = useState< string >( '' );
+	const [ showWelcome, setShowWelcome ] = useState( true );
 	const endOfMessagesRef = useRef< HTMLDivElement >( null );
 	const { isAuthenticated, authenticate } = useAuth();
 	const isOffline = useOffline();
@@ -244,6 +245,7 @@ export function ContentTabAssistant( { selectedSite }: ContentTabAssistantProps 
 		const message = messageToSend || input;
 		if ( message.trim() ) {
 			addMessage( message, 'user' );
+			setShowWelcome( false );
 			setInput( '' );
 			try {
 				const { message: assistantMessage } = await fetchAssistant( [
@@ -285,6 +287,12 @@ export function ContentTabAssistant( { selectedSite }: ContentTabAssistantProps 
 		}
 	}, [ messages ] );
 
+	useEffect( () => {
+		if ( messages.length > 0 ) {
+			setShowWelcome( false );
+		}
+	}, [ messages ] );
+
 	const disabled = isOffline || ! isAuthenticated;
 
 	return (
@@ -295,8 +303,14 @@ export function ContentTabAssistant( { selectedSite }: ContentTabAssistantProps 
 			>
 				{ isAuthenticated ? (
 					<>
-						<WelcomeComponent onExampleClick={ ( prompt ) => handleSend( prompt ) } />
-						<AuthenticatedView messages={ messages } isAssistantThinking={ isAssistantThinking } />
+						{ showWelcome ? (
+							<WelcomeComponent onExampleClick={ ( prompt ) => handleSend( prompt ) } />
+						) : (
+							<AuthenticatedView
+								messages={ messages }
+								isAssistantThinking={ isAssistantThinking }
+							/>
+						) }
 						<div ref={ endOfMessagesRef } />
 					</>
 				) : (

--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -14,6 +14,7 @@ import { getIpcApi } from '../lib/get-ipc-api';
 import { AIInput } from './ai-input';
 import { MessageThinking } from './assistant-thinking';
 import Button from './button';
+import { WelcomeMessagePrompt } from './welcome-message-prompt';
 
 interface ContentTabAssistantProps {
 	selectedSite: SiteDetails;
@@ -294,6 +295,7 @@ export function ContentTabAssistant( { selectedSite }: ContentTabAssistantProps 
 			>
 				{ isAuthenticated ? (
 					<>
+						<WelcomeMessagePrompt />
 						<AuthenticatedView messages={ messages } isAssistantThinking={ isAssistantThinking } />
 						<div ref={ endOfMessagesRef } />
 					</>

--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -14,8 +14,7 @@ import { getIpcApi } from '../lib/get-ipc-api';
 import { AIInput } from './ai-input';
 import { MessageThinking } from './assistant-thinking';
 import Button from './button';
-import { WelcomeMessagePrompt } from './welcome-message-prompt';
-
+import WelcomeComponent from './welcome-message-prompt';
 interface ContentTabAssistantProps {
 	selectedSite: SiteDetails;
 }
@@ -295,7 +294,7 @@ export function ContentTabAssistant( { selectedSite }: ContentTabAssistantProps 
 			>
 				{ isAuthenticated ? (
 					<>
-						<WelcomeMessagePrompt />
+						<WelcomeComponent />
 						<AuthenticatedView messages={ messages } isAssistantThinking={ isAssistantThinking } />
 						<div ref={ endOfMessagesRef } />
 					</>

--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -301,7 +301,10 @@ export function ContentTabAssistant( { selectedSite }: ContentTabAssistantProps 
 		<div className="h-full flex flex-col bg-gray-50">
 			<div
 				data-testid="assistant-chat"
-				className={ cx( 'flex-1 overflow-y-auto p-8', ! isAuthenticated && 'flex items-end' ) }
+				className={ cx(
+					'flex-1 overflow-y-auto p-8',
+					( ! isAuthenticated || showWelcome ) && 'flex items-end'
+				) }
 			>
 				{ isAuthenticated ? (
 					<>

--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -240,17 +240,18 @@ export function ContentTabAssistant( { selectedSite }: ContentTabAssistantProps 
 	const isOffline = useOffline();
 	const { __ } = useI18n();
 
-	const handleSend = async () => {
-		if ( input.trim() ) {
-			addMessage( input, 'user' );
+	const handleSend = async ( messageToSend?: string ) => {
+		const message = messageToSend || input;
+		if ( message.trim() ) {
+			addMessage( message, 'user' );
 			setInput( '' );
 			try {
-				const { message } = await fetchAssistant( [
+				const { message: assistantMessage } = await fetchAssistant( [
 					...messages,
-					{ content: input, role: 'user' },
+					{ content: message, role: 'user' },
 				] );
-				if ( message ) {
-					addMessage( message, 'assistant' );
+				if ( assistantMessage ) {
+					addMessage( assistantMessage, 'assistant' );
 				}
 			} catch ( error ) {
 				setTimeout(
@@ -294,7 +295,7 @@ export function ContentTabAssistant( { selectedSite }: ContentTabAssistantProps 
 			>
 				{ isAuthenticated ? (
 					<>
-						<WelcomeComponent />
+						<WelcomeComponent onExampleClick={ ( prompt ) => handleSend( prompt ) } />
 						<AuthenticatedView messages={ messages } isAssistantThinking={ isAssistantThinking } />
 						<div ref={ endOfMessagesRef } />
 					</>
@@ -306,7 +307,7 @@ export function ContentTabAssistant( { selectedSite }: ContentTabAssistantProps 
 				disabled={ disabled }
 				input={ input }
 				setInput={ setInput }
-				handleSend={ handleSend }
+				handleSend={ () => handleSend() }
 				handleKeyDown={ handleKeyDown }
 				clearInput={ clearInput }
 				isAssistantThinking={ isAssistantThinking }

--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -288,10 +288,12 @@ export function ContentTabAssistant( { selectedSite }: ContentTabAssistantProps 
 	}, [ messages ] );
 
 	useEffect( () => {
-		if ( messages.length > 0 ) {
+		if ( messages.length === 0 ) {
+			setShowWelcome( true );
+		} else {
 			setShowWelcome( false );
 		}
-	}, [ messages ] );
+	}, [ selectedSite, messages ] );
 
 	const disabled = isOffline || ! isAuthenticated;
 

--- a/src/components/tests/content-tab-assistant.test.tsx
+++ b/src/components/tests/content-tab-assistant.test.tsx
@@ -5,6 +5,12 @@ import { ContentTabAssistant } from '../content-tab-assistant';
 jest.mock( '../../hooks/use-theme-details' );
 jest.mock( '../../hooks/use-auth' );
 
+jest.mock( '../../lib/app-globals', () => ( {
+	getAppGlobals: () => ( {
+		locale: jest.fn,
+	} ),
+} ) );
+
 const runningSite = {
 	name: 'Test Site',
 	port: 8881,

--- a/src/components/welcome-message-prompt.tsx
+++ b/src/components/welcome-message-prompt.tsx
@@ -1,0 +1,30 @@
+import { cx } from '../lib/cx';
+
+interface WelcomeMessagePromptProps {
+	onClick?: () => void;
+	children?: React.ReactNode;
+	className?: string;
+}
+
+interface ExampleMessahgePromptProps {
+	onClick?: () => void;
+	children: React.ReactNode;
+	className?: string;
+}
+
+export const WelcomeMessagePrompt = ( {
+	onClick,
+	children,
+	className,
+}: WelcomeMessagePromptProps ) => (
+	<div className={ cx( 'flex mt-4' ) }>
+		<div
+			className={ cx(
+				'inline-block p-3 rounded border border-gray-300 lg:max-w-[70%] select-text'
+			) }
+			onClick={ onClick }
+		>
+			<p className="text-lg text-gray-600">Big burrito</p>
+		</div>
+	</div>
+);

--- a/src/components/welcome-message-prompt.tsx
+++ b/src/components/welcome-message-prompt.tsx
@@ -1,6 +1,4 @@
 import { arrowRight } from '@wordpress/icons';
-import { useEffect } from 'react';
-import { useFetchWelcomeMessages } from '../hooks/use-fetch-welcome-messages';
 import { cx } from '../lib/cx';
 
 interface WelcomeMessagePromptProps {
@@ -12,6 +10,13 @@ interface ExampleMessagePromptProps {
 	onClick?: () => void;
 	children: React.ReactNode;
 	className?: string;
+}
+
+interface WelcomeComponentProps {
+	onExampleClick: ( prompt: string ) => void;
+	showExamplePrompts: boolean;
+	messages: string[];
+	examplePrompts: string[];
 }
 
 export const WelcomeMessagePrompt = ( { children, className }: WelcomeMessagePromptProps ) => (
@@ -53,13 +58,12 @@ export const ExampleMessagePrompt = ( {
 	</div>
 );
 
-const WelcomeComponent = ( { onExampleClick }: { onExampleClick: ( prompt: string ) => void } ) => {
-	const { messages, examplePrompts, fetchWelcomeMessages } = useFetchWelcomeMessages();
-
-	useEffect( () => {
-		fetchWelcomeMessages();
-	}, [ fetchWelcomeMessages ] );
-
+const WelcomeComponent = ( {
+	onExampleClick,
+	showExamplePrompts,
+	messages,
+	examplePrompts,
+}: WelcomeComponentProps ) => {
 	return (
 		<div>
 			{ messages.map( ( message, index ) => (
@@ -67,16 +71,18 @@ const WelcomeComponent = ( { onExampleClick }: { onExampleClick: ( prompt: strin
 					{ message }
 				</WelcomeMessagePrompt>
 			) ) }
-			{ examplePrompts.map( ( prompt, index ) => (
-				<ExampleMessagePrompt
-					key={ index }
-					className="example-prompt"
-					onClick={ () => onExampleClick( prompt ) }
-				>
-					{ prompt }
-				</ExampleMessagePrompt>
-			) ) }
+			{ showExamplePrompts &&
+				examplePrompts.map( ( prompt, index ) => (
+					<ExampleMessagePrompt
+						key={ index }
+						className="example-prompt"
+						onClick={ () => onExampleClick( prompt ) }
+					>
+						{ prompt }
+					</ExampleMessagePrompt>
+				) ) }
 		</div>
 	);
 };
+
 export default WelcomeComponent;

--- a/src/components/welcome-message-prompt.tsx
+++ b/src/components/welcome-message-prompt.tsx
@@ -37,10 +37,11 @@ export const ExampleMessagePrompt = ( {
 	<div className={ cx( 'flex mt-4' ) }>
 		<div
 			className={ cx(
-				'inline-block p-3 rounded border border-gray-300 lg:max-w-[70%] select-text',
+				'inline-block p-3 rounded border border-gray-300 lg:max-w-[70%] select-text cursor-pointer',
 				className
 			) }
 			onClick={ onClick }
+			role="button"
 		>
 			<div className="assistant-markdown flex items-center">
 				<span className={ cx( 'mr-2', 'w-4 h-4 flex items-center justify-center' ) }>

--- a/src/components/welcome-message-prompt.tsx
+++ b/src/components/welcome-message-prompt.tsx
@@ -20,7 +20,7 @@ interface WelcomeComponentProps {
 }
 
 export const WelcomeMessagePrompt = ( { children, className }: WelcomeMessagePromptProps ) => (
-	<div className={ cx( 'flex mt-4' ) }>
+	<div className={ cx( 'flex mt-2' ) }>
 		<div
 			className={ cx(
 				'inline-block p-3 rounded border border-gray-300 lg:max-w-[70%] select-text bg-white',
@@ -39,7 +39,7 @@ export const ExampleMessagePrompt = ( {
 	children,
 	className,
 }: ExampleMessagePromptProps ) => (
-	<div className={ cx( 'flex mt-4' ) }>
+	<div className={ cx( 'flex mt-2' ) }>
 		<div
 			className={ cx(
 				'inline-block p-3 rounded border border-gray-300 lg:max-w-[70%] select-text cursor-pointer',

--- a/src/components/welcome-message-prompt.tsx
+++ b/src/components/welcome-message-prompt.tsx
@@ -1,9 +1,9 @@
+import { arrowRight } from '@wordpress/icons';
 import { useEffect } from 'react';
 import { useFetchWelcomeMessages } from '../hooks/use-fetch-welcome-messages';
 import { cx } from '../lib/cx';
 
 interface WelcomeMessagePromptProps {
-	onClick?: () => void;
 	children?: React.ReactNode;
 	className?: string;
 }
@@ -14,18 +14,13 @@ interface ExampleMessagePromptProps {
 	className?: string;
 }
 
-export const WelcomeMessagePrompt = ( {
-	onClick,
-	children,
-	className,
-}: WelcomeMessagePromptProps ) => (
+export const WelcomeMessagePrompt = ( { children, className }: WelcomeMessagePromptProps ) => (
 	<div className={ cx( 'flex mt-4' ) }>
 		<div
 			className={ cx(
 				'inline-block p-3 rounded border border-gray-300 lg:max-w-[70%] select-text bg-white',
 				className
 			) }
-			onClick={ onClick }
 		>
 			<div className="assistant-markdown">
 				<p>{ children }</p>
@@ -47,8 +42,11 @@ export const ExampleMessagePrompt = ( {
 			) }
 			onClick={ onClick }
 		>
-			<div className="assistant-markdown">
-				<p>{ children }</p>
+			<div className="assistant-markdown flex items-center">
+				<span className={ cx( 'mr-2', 'w-4 h-4 flex items-center justify-center' ) }>
+					{ arrowRight }
+				</span>
+				<p className="inline">{ children }</p>
 			</div>
 		</div>
 	</div>

--- a/src/components/welcome-message-prompt.tsx
+++ b/src/components/welcome-message-prompt.tsx
@@ -52,7 +52,7 @@ export const ExampleMessagePrompt = ( {
 	</div>
 );
 
-const WelcomeComponent = () => {
+const WelcomeComponent = ( { onExampleClick }: { onExampleClick: ( prompt: string ) => void } ) => {
 	const { messages, examplePrompts, fetchWelcomeMessages } = useFetchWelcomeMessages();
 
 	useEffect( () => {
@@ -67,12 +67,15 @@ const WelcomeComponent = () => {
 				</WelcomeMessagePrompt>
 			) ) }
 			{ examplePrompts.map( ( prompt, index ) => (
-				<ExampleMessagePrompt key={ index } className="example-prompt">
+				<ExampleMessagePrompt
+					key={ index }
+					className="example-prompt"
+					onClick={ () => onExampleClick( prompt ) }
+				>
 					{ prompt }
 				</ExampleMessagePrompt>
 			) ) }
 		</div>
 	);
 };
-
 export default WelcomeComponent;

--- a/src/components/welcome-message-prompt.tsx
+++ b/src/components/welcome-message-prompt.tsx
@@ -42,7 +42,7 @@ export const ExampleMessagePrompt = ( {
 	<div className={ cx( 'flex mt-2' ) }>
 		<div
 			className={ cx(
-				'inline-block p-3 rounded border border-gray-300 lg:max-w-[70%] select-text cursor-pointer',
+				'inline-block px-3 py-2 rounded border border-gray-300 lg:max-w-[70%] select-text cursor-pointer',
 				className
 			) }
 			onClick={ onClick }

--- a/src/components/welcome-message-prompt.tsx
+++ b/src/components/welcome-message-prompt.tsx
@@ -22,12 +22,14 @@ export const WelcomeMessagePrompt = ( {
 	<div className={ cx( 'flex mt-4' ) }>
 		<div
 			className={ cx(
-				'inline-block p-3 rounded border border-gray-300 lg:max-w-[70%] select-text',
+				'inline-block p-3 rounded border border-gray-300 lg:max-w-[70%] select-text bg-white',
 				className
 			) }
 			onClick={ onClick }
 		>
-			<p className="text-lg text-gray-600">{ children }</p>
+			<div className="assistant-markdown">
+				<p>{ children }</p>
+			</div>
 		</div>
 	</div>
 );
@@ -45,7 +47,9 @@ export const ExampleMessagePrompt = ( {
 			) }
 			onClick={ onClick }
 		>
-			<p className="text-lg text-gray-600">{ children }</p>
+			<div className="assistant-markdown">
+				<p>{ children }</p>
+			</div>
 		</div>
 	</div>
 );

--- a/src/components/welcome-message-prompt.tsx
+++ b/src/components/welcome-message-prompt.tsx
@@ -42,7 +42,7 @@ export const ExampleMessagePrompt = ( {
 	<div className={ cx( 'flex mt-2' ) }>
 		<div
 			className={ cx(
-				'inline-block px-3 py-2 rounded border border-gray-300 lg:max-w-[70%] select-text cursor-pointer',
+				'inline-block px-3 py-2 rounded border border-gray-300 lg:max-w-[70%] select-text cursor-pointer focus:border-a8c-blueberry hover:border-a8c-blueberry',
 				className
 			) }
 			onClick={ onClick }

--- a/src/components/welcome-message-prompt.tsx
+++ b/src/components/welcome-message-prompt.tsx
@@ -42,14 +42,14 @@ export const ExampleMessagePrompt = ( {
 	<div className={ cx( 'flex mt-2' ) }>
 		<div
 			className={ cx(
-				'inline-block px-3 py-2 rounded border border-gray-300 lg:max-w-[70%] select-text cursor-pointer focus:border-a8c-blueberry hover:border-a8c-blueberry',
+				'inline-block px-3 py-2 rounded border border-gray-300 lg:max-w-[70%] select-text cursor-pointer focus:border-a8c-blueberry hover:border-a8c-blueberry hover:text-a8c-blueberry hover:fill-a8c-blueberry',
 				className
 			) }
 			onClick={ onClick }
 			role="button"
 		>
 			<div className="assistant-markdown flex items-center">
-				<span className={ cx( 'mr-2', 'w-4 h-4 flex items-center justify-center' ) }>
+				<span className={ cx( 'mr-2 w-4 h-4 flex items-center justify-center' ) }>
 					{ arrowRight }
 				</span>
 				<p className="inline">{ children }</p>

--- a/src/components/welcome-message-prompt.tsx
+++ b/src/components/welcome-message-prompt.tsx
@@ -1,3 +1,5 @@
+import { useEffect } from 'react';
+import { useFetchWelcomeMessages } from '../hooks/use-fetch-welcome-messages';
 import { cx } from '../lib/cx';
 
 interface WelcomeMessagePromptProps {
@@ -6,7 +8,7 @@ interface WelcomeMessagePromptProps {
 	className?: string;
 }
 
-interface ExampleMessahgePromptProps {
+interface ExampleMessagePromptProps {
 	onClick?: () => void;
 	children: React.ReactNode;
 	className?: string;
@@ -20,11 +22,55 @@ export const WelcomeMessagePrompt = ( {
 	<div className={ cx( 'flex mt-4' ) }>
 		<div
 			className={ cx(
-				'inline-block p-3 rounded border border-gray-300 lg:max-w-[70%] select-text'
+				'inline-block p-3 rounded border border-gray-300 lg:max-w-[70%] select-text',
+				className
 			) }
 			onClick={ onClick }
 		>
-			<p className="text-lg text-gray-600">Big burrito</p>
+			<p className="text-lg text-gray-600">{ children }</p>
 		</div>
 	</div>
 );
+
+export const ExampleMessagePrompt = ( {
+	onClick,
+	children,
+	className,
+}: ExampleMessagePromptProps ) => (
+	<div className={ cx( 'flex mt-4' ) }>
+		<div
+			className={ cx(
+				'inline-block p-3 rounded border border-gray-300 lg:max-w-[70%] select-text',
+				className
+			) }
+			onClick={ onClick }
+		>
+			<p className="text-lg text-gray-600">{ children }</p>
+		</div>
+	</div>
+);
+
+const WelcomeComponent = () => {
+	const { messages, examplePrompts, fetchWelcomeMessages } = useFetchWelcomeMessages();
+
+	useEffect( () => {
+		fetchWelcomeMessages();
+	}, [ fetchWelcomeMessages ] );
+
+	return (
+		<div>
+			{ messages.map( ( message, index ) => (
+				<WelcomeMessagePrompt key={ index } className="welcome-message">
+					{ message }
+				</WelcomeMessagePrompt>
+			) ) }
+			{ examplePrompts.map( ( prompt, index ) => (
+				<ExampleMessagePrompt key={ index } className="example-prompt">
+					{ prompt }
+				</ExampleMessagePrompt>
+			) ) }
+		</div>
+	);
+};
+
+export default WelcomeComponent;

--- a/src/hooks/use-fetch-welcome-messages.ts
+++ b/src/hooks/use-fetch-welcome-messages.ts
@@ -1,5 +1,6 @@
 import * as Sentry from '@sentry/electron/renderer';
 import { useState, useCallback } from 'react';
+import { getAppGlobals } from '../lib/app-globals';
 import { useAuth } from './use-auth';
 
 interface WelcomeMessageResponse {
@@ -11,6 +12,7 @@ export const useFetchWelcomeMessages = () => {
 	const { client } = useAuth();
 	const [ messages, setMessages ] = useState< string[] >( [] );
 	const [ examplePrompts, setExamplePrompts ] = useState< string[] >( [] );
+	const locale = getAppGlobals().locale;
 
 	const fetchWelcomeMessages = useCallback( async () => {
 		if ( ! client?.req ) {
@@ -20,6 +22,7 @@ export const useFetchWelcomeMessages = () => {
 			const response = await client.req.get( {
 				path: '/studio-app/ai-assistant/welcome',
 				apiNamespace: 'wpcom/v2',
+				params: { locale },
 			} );
 
 			const data = response as WelcomeMessageResponse;
@@ -32,7 +35,7 @@ export const useFetchWelcomeMessages = () => {
 			Sentry.captureException( error );
 			console.error( error );
 		}
-	}, [ client ] );
+	}, [ client, locale ] );
 
 	return { messages, examplePrompts, fetchWelcomeMessages };
 };

--- a/src/hooks/use-fetch-welcome-messages.ts
+++ b/src/hooks/use-fetch-welcome-messages.ts
@@ -1,0 +1,38 @@
+import * as Sentry from '@sentry/electron/renderer';
+import { useState, useCallback } from 'react';
+import { useAuth } from './use-auth';
+
+interface WelcomeMessageResponse {
+	messages: string[];
+	example_prompts: string[];
+}
+
+export const useFetchWelcomeMessages = () => {
+	const { client } = useAuth();
+	const [ messages, setMessages ] = useState< string[] >( [] );
+	const [ examplePrompts, setExamplePrompts ] = useState< string[] >( [] );
+
+	const fetchWelcomeMessages = useCallback( async () => {
+		if ( ! client?.req ) {
+			return;
+		}
+		try {
+			const response = await client.req.get( {
+				path: '/studio-app/ai-assistant/welcome',
+				apiNamespace: 'wpcom/v2',
+			} );
+
+			const data = response as WelcomeMessageResponse;
+
+			if ( data ) {
+				setMessages( data.messages || [] );
+				setExamplePrompts( data.example_prompts || [] );
+			}
+		} catch ( error ) {
+			Sentry.captureException( error );
+			console.error( error );
+		}
+	}, [ client ] );
+
+	return { messages, examplePrompts, fetchWelcomeMessages };
+};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/7411

## Proposed Changes

This PR adds a welcome component that offers two welcome messages and three prompts:

* the welcome component is displayed when the user is starting the chat
* if the user already has some messages in their chat that they had before, the welcome component is not displayed
* if you click on one of the prompts such as "How do I improve the performace of my site" (that has an arrow right by it), it sends the message to Assistant and the welcome component disappears starting the chat

## Testing Instructions

- Pull the changes from this branch locally
- Start the app with the AI assistant:  `STUDIO_AI=true npm start`
- Create a new site to ensure that you get a fresh chat
- Observe that the welcome component appears
- Try clicking on one of the prompts
- Confirm that the message gets sent to the assistant
- Confirm that the welcome component disappears and the conversation with the assistant starts  

<img width="1156" alt="Capture d’écran, le 2024-06-13 à 16 51 19" src="https://github.com/Automattic/studio/assets/25575134/60e96997-f919-434d-a523-1669244dfef8">

**Some notes**

* This PR does not have the functionality for clearing the messages and resetting the welcome component (I will implement it as a part of https://github.com/Automattic/dotcom-forge/issues/7697)
* Because we are making the request to the backend and not using localStorage, you will see that there is a slight delay for the welcome component to appear - 2-3 seconds. There is nothing really we can do with the speed of it but perhaps we can improve the UI with some sort of loading spinner before the initial prompts load
* At the moment, when you select one of the prompts or add your own message, the welcome component disappears. Should we keep it in the conversation or keep this current behavior? I did not see the indication in the issue description

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
 