### PR TITLE
fix: Prevent resubmissions of pending site addition

### DIFF
--- a/src/components/add-site.tsx
+++ b/src/components/add-site.tsx
@@ -144,7 +144,7 @@ export default function AddSite( { className }: AddSiteProps ) {
 								type="submit"
 								variant="primary"
 								isBusy={ isAddingSite }
-								disabled={ !! error || ! siteName?.trim() }
+								disabled={ isAddingSite || !! error || ! siteName?.trim() }
 							>
 								{ isAddingSite ? __( 'Adding site…' ) : __( 'Add site' ) }
 							</Button>

--- a/src/components/tests/add-site.test.tsx
+++ b/src/components/tests/add-site.test.tsx
@@ -228,4 +228,25 @@ describe( 'AddSite', () => {
 			);
 		} );
 	} );
+
+	it( 'should disable submissions while the site is being added', async () => {
+		const user = userEvent.setup();
+		mockGenerateProposedSitePath.mockResolvedValue( {
+			path: '/default_path/my-wordpress-website',
+			name: 'My WordPress Website',
+			isEmpty: true,
+			isWordPress: false,
+		} );
+		mockCreateSite.mockImplementationOnce( () => {
+			return new Promise( () => {
+				// no-op
+			} );
+		} );
+		render( <AddSite /> );
+
+		await user.click( screen.getByRole( 'button', { name: 'Add site' } ) );
+		await user.click( screen.getByRole( 'button', { name: 'Add site' } ) );
+
+		expect( screen.getByRole( 'button', { name: 'Adding site…' } ) ).toBeDisabled();
+	} );
 } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Proposed Changes

Disable the submit button when a site addition is pending.

Without disabling the submit button, one can resubmit the form which
displays an unexpected error and/or results in duplicative site
directories.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Click "Add site."
1. Click "Add site" within the modal.
1. Quickly click "Adding site…"
1. Verify an error is not displayed and the site addition succeeds.


https://github.com/Automattic/studio/assets/438664/b256743d-5ae9-4acd-b315-51eae474eba5

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
