### PR TITLE
feat: Improve AI assistant accessibility

### DIFF
--- a/src/components/assistant-thinking.tsx
+++ b/src/components/assistant-thinking.tsx
@@ -1,6 +1,8 @@
+import { __ } from '@wordpress/i18n';
+
 export function MessageThinking() {
 	return (
-		<div className="flex justify-center items-center gap-1 p-0.5">
+		<div aria-label={ __( 'Thinking…' ) } className="flex justify-center items-center gap-1 p-0.5">
 			<div
 				className="animate-pulse h-1.5 w-1.5 bg-a8c-blueberry rounded-full"
 				style={ { animationDelay: '0.2s' } }

--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -1,10 +1,9 @@
-import { speak } from '@wordpress/a11y';
 import { Spinner } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Icon, external, copy } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
-import React, { useState, useEffect, useRef, memo, useMemo } from 'react';
+import React, { useState, useEffect, useRef, memo } from 'react';
 import Markdown, { ExtraProps } from 'react-markdown';
 import { useAssistant, Message as MessageType } from '../hooks/use-assistant';
 import { useAssistantApi } from '../hooks/use-assistant-api';
@@ -293,16 +292,6 @@ export function ContentTabAssistant( { selectedSite }: ContentTabAssistantProps 
 			endOfMessagesRef.current.scrollIntoView( { behavior: 'smooth' } );
 		}
 	}, [ messages ] );
-
-	const latestAssistantMessage = useMemo(
-		() => messages.filter( ( message ) => message.role === 'assistant' ).pop(),
-		[ messages ]
-	);
-	useEffect( () => {
-		if ( latestAssistantMessage ) {
-			speak( `New message, Studio Assistant, ${ latestAssistantMessage.content }` );
-		}
-	}, [ latestAssistantMessage ] );
 
 	const disabled = isOffline || ! isAuthenticated;
 

--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -21,6 +21,7 @@ interface ContentTabAssistantProps {
 }
 
 interface MessageProps {
+	id: string;
 	children: React.ReactNode;
 	isUser: boolean;
 	className?: string;
@@ -86,7 +87,7 @@ const ActionButton = ( {
 	);
 };
 
-export const Message = ( { children, isUser, className }: MessageProps ) => {
+export const Message = ( { children, id, isUser, className }: MessageProps ) => {
 	const [ cliOutput, setCliOutput ] = useState< string | null >( null );
 	const [ cliStatus, setCliStatus ] = useState< 'success' | 'error' | null >( null );
 	const [ cliTime, setCliTime ] = useState< string | null >( null );
@@ -150,8 +151,6 @@ export const Message = ( { children, isUser, className }: MessageProps ) => {
 		);
 	};
 
-	const authorLabel = isUser ? __( 'Your message' ) : __( 'Studio Assistant' );
-
 	return (
 		<div
 			className={ cx(
@@ -161,12 +160,19 @@ export const Message = ( { children, isUser, className }: MessageProps ) => {
 			) }
 		>
 			<div
-				aria-label={ `${ authorLabel }, ${ children }` }
+				id={ id }
+				role="group"
+				aria-labelledby={ id }
 				className={ cx(
 					'inline-block p-3 rounded border border-gray-300 lg:max-w-[70%] select-text',
 					! isUser ? 'bg-white' : 'bg-white/45'
 				) }
 			>
+				<div className="relative">
+					<span className="sr-only">
+						{ isUser ? __( 'Your message' ) : __( 'Studio Assistant' ) },
+					</span>
+				</div>
 				{ typeof children === 'string' ? (
 					<div className="assistant-markdown">
 						<Markdown components={ { code: CodeBlock } }>{ children }</Markdown>
@@ -189,12 +195,12 @@ const AuthenticatedView = memo(
 	} ) => (
 		<>
 			{ messages.map( ( message, index ) => (
-				<Message key={ index } isUser={ message.role === 'user' }>
+				<Message key={ index } id={ `message-${ index }` } isUser={ message.role === 'user' }>
 					{ message.content }
 				</Message>
 			) ) }
 			{ isAssistantThinking && (
-				<Message isUser={ false }>
+				<Message isUser={ false } id="message-thinking">
 					<MessageThinking />
 				</Message>
 			) }

--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -149,6 +149,8 @@ export const Message = ( { children, isUser, className }: MessageProps ) => {
 		);
 	};
 
+	const authorLabel = isUser ? __( 'Your message' ) : __( 'Studio Assistant' );
+
 	return (
 		<div
 			className={ cx(
@@ -158,6 +160,7 @@ export const Message = ( { children, isUser, className }: MessageProps ) => {
 			) }
 		>
 			<div
+				aria-label={ `${ authorLabel }, ${ children }` }
 				className={ cx(
 					'inline-block p-3 rounded border border-gray-300 lg:max-w-[70%] select-text',
 					! isUser ? 'bg-white' : 'bg-white/45'

--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -208,7 +208,7 @@ const AuthenticatedView = memo(
 );
 
 const UnauthenticatedView = ( { onAuthenticate }: { onAuthenticate: () => void } ) => (
-	<Message className="w-full" isUser={ false }>
+	<Message id="message-unauthenticated" className="w-full" isUser={ false }>
 		<div className="mb-3 a8c-label-semibold">{ __( 'Hold up!' ) }</div>
 		<div className="mb-1">
 			{ __( 'You need to log in to your WordPress.com account to use the assistant.' ) }

--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -1,9 +1,10 @@
+import { speak } from '@wordpress/a11y';
 import { Spinner } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Icon, external, copy } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
-import React, { useState, useEffect, useRef, memo } from 'react';
+import React, { useState, useEffect, useRef, memo, useMemo } from 'react';
 import Markdown, { ExtraProps } from 'react-markdown';
 import { useAssistant, Message as MessageType } from '../hooks/use-assistant';
 import { useAssistantApi } from '../hooks/use-assistant-api';
@@ -286,6 +287,16 @@ export function ContentTabAssistant( { selectedSite }: ContentTabAssistantProps 
 			endOfMessagesRef.current.scrollIntoView( { behavior: 'smooth' } );
 		}
 	}, [ messages ] );
+
+	const latestAssistantMessage = useMemo(
+		() => messages.filter( ( message ) => message.role === 'assistant' ).pop(),
+		[ messages ]
+	);
+	useEffect( () => {
+		if ( latestAssistantMessage ) {
+			speak( `New message, Studio Assistant, ${ latestAssistantMessage.content }` );
+		}
+	}, [ latestAssistantMessage ] );
 
 	const disabled = isOffline || ! isAuthenticated;
 

--- a/src/components/icons/assistant.tsx
+++ b/src/components/icons/assistant.tsx
@@ -1,10 +1,16 @@
+import { ReactSVG, SVGProps } from 'react';
+
 interface AssistantIconProps {
 	size?: number;
 }
 
-export function AssistantIcon( { size = 14 }: AssistantIconProps ) {
+export function AssistantIcon( {
+	size = 14,
+	'aria-hidden': ariaHidden,
+}: AssistantIconProps & SVGProps< ReactSVG > ) {
 	return (
 		<svg
+			aria-hidden={ ariaHidden }
 			width={ size }
 			height={ size }
 			viewBox={ `0 0 14 14` }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/7520.

## Proposed Changes

**Hide decorative AI assistant icon from screen readers**
Selecting this description-less, decorative image provides little value for users.

**Communicate message author to screen readers**
Navigating individual lines of text from a back-and-forth conversation is difficult and overwhelming when there are not discernible, navigable grouping or message author labels.

**Communicate the active assistant "thinking" to screen readers**
Without a label, there is no indication that the assistant is actively working to answer a message.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

> [!TIP]
> When using VoiceOver...
> - <kbd>Option</kbd>+<kbd>Control</kbd>+<kbd>Shift</kbd>+<kbd>[Up|Right|Down|Left]</kbd> will navigate between/into/out of content "groups." 
> - <kbd>Option</kbd>+<kbd>Control</kbd>+<kbd>[Up|Right|Down|Left]</kbd> will navigate between individual content elements, depending on the context and settings. 
> - <kbd>Option</kbd>+<kbd>Control</kbd>+<kbd>Space</kbd> will "activate" the selected element, triggering the relevant event handler. 

**Decorative assistant icon is not selectable**

1. Enable a screen reader (e.g., [VoiceOver](https://support.apple.com/guide/voiceover/welcome/mac)). 
2. Navigate to the "Assistant" tab. 
3. Move selection to elements before and after the automatically focused input. 
4. Verify the assistant icon is skipped over and not selectable. 

**Message collection navigation is straightforward and comprehensible**

1. Enable a screen reader (e.g., [VoiceOver](https://support.apple.com/guide/voiceover/welcome/mac)). 
2. Navigate to the "Assistant" tab. 
3. Interact with the assistant — send messages, move selection between various messages, etc. 
4. Verify the message navigation is straightforward and comprehensible, providing clear communication of each message and the author, while also allowing navigation of content within each message. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
