### PR TITLE
Studio: Add UI for clearing chat messages

### DIFF
--- a/src/components/ai-input.tsx
+++ b/src/components/ai-input.tsx
@@ -81,16 +81,16 @@ export const AIInput = ( {
 	};
 
 	const handleClearConversation = async () => {
-		const DELETE_CONVERSATION_BUTTON_INDEX = 0;
-		const CANCEL_DELETE_BUTTON_INDEX = 1;
+		const CLEAR_CONVERSATION_BUTTON_INDEX = 0;
+		const CANCEL_BUTTON_INDEX = 1;
 
 		const { response } = await getIpcApi().showMessageBox( {
 			message: __( 'Are you sure you want to clear the conversation?' ),
 			buttons: [ __( 'Ok' ), __( 'Cancel' ) ],
-			cancelId: CANCEL_DELETE_BUTTON_INDEX,
+			cancelId: CANCEL_BUTTON_INDEX,
 		} );
 
-		if ( response === DELETE_CONVERSATION_BUTTON_INDEX ) {
+		if ( response === CLEAR_CONVERSATION_BUTTON_INDEX ) {
 			clearInput();
 		}
 	};

--- a/src/components/ai-input.tsx
+++ b/src/components/ai-input.tsx
@@ -1,7 +1,7 @@
+import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { Icon, moreVertical, keyboardReturn } from '@wordpress/icons';
+import { Icon, moreVertical, keyboardReturn, reset } from '@wordpress/icons';
 import React, { useRef, useEffect } from 'react';
-import Button from './button';
 import { AssistantIcon } from './icons/assistant';
 
 interface AIInputProps {
@@ -79,6 +79,12 @@ export const AIInput = ( {
 		return isAssistantThinking ? __( 'Generating...' ) : __( 'What would you like to learn?' );
 	};
 
+	const handleClearConversation = () => {
+		if ( window.confirm( __( 'Are you sure you want to clear the conversation?' ) ) ) {
+			clearInput();
+		}
+	};
+
 	return (
 		<div className="px-8 py-5 bg-white flex items-center border border-gray-200">
 			<div className="flex w-full border border-gray-300 rounded-sm focus-within:border-a8c-blueberry">
@@ -101,16 +107,23 @@ export const AIInput = ( {
 						<Icon icon={ keyboardReturn } size={ 13 } fill="#cccccc" />
 					</div>
 				) }
-				<div className="flex items-end py-2 ltr:mr-2 rtl:ml-1">
-					<Button
-						disabled={ disabled }
-						aria-label="menu"
-						className="py-2 px-1 cursor-pointer"
-						onClick={ clearInput }
-					>
-						<Icon icon={ moreVertical } size={ 22 } />
-					</Button>
-				</div>
+				<DropdownMenu icon={ moreVertical } label="Assistant Menu" className="p-2">
+					{ () => (
+						<>
+							<MenuGroup>
+								<MenuItem
+									data-testid="clear-conversation-button"
+									onClick={ handleClearConversation }
+								>
+									<Icon className="text-red-600" icon={ reset } />
+									<span className="ltr:pl-2 rtl:pl-2 text-red-600">
+										{ __( 'Clear Conversation' ) }
+									</span>
+								</MenuItem>
+							</MenuGroup>
+						</>
+					) }
+				</DropdownMenu>
 			</div>
 		</div>
 	);

--- a/src/components/ai-input.tsx
+++ b/src/components/ai-input.tsx
@@ -118,12 +118,15 @@ export const AIInput = ( {
 					</div>
 				) }
 				<DropdownMenu icon={ moreVertical } label="Assistant Menu" className="p-2">
-					{ () => (
+					{ ( { onClose }: { onClose: () => void } ) => (
 						<>
 							<MenuGroup>
 								<MenuItem
 									data-testid="clear-conversation-button"
-									onClick={ handleClearConversation }
+									onClick={ () => {
+										handleClearConversation();
+										onClose();
+									} }
 								>
 									<Icon className="text-red-600" icon={ reset } />
 									<span className="ltr:pl-2 rtl:pl-2 text-red-600">

--- a/src/components/ai-input.tsx
+++ b/src/components/ai-input.tsx
@@ -117,7 +117,7 @@ export const AIInput = ( {
 								>
 									<Icon className="text-red-600" icon={ reset } />
 									<span className="ltr:pl-2 rtl:pl-2 text-red-600">
-										{ __( 'Clear Conversation' ) }
+										{ __( 'Clear conversation' ) }
 									</span>
 								</MenuItem>
 							</MenuGroup>

--- a/src/components/ai-input.tsx
+++ b/src/components/ai-input.tsx
@@ -2,6 +2,7 @@ import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { Icon, moreVertical, keyboardReturn, reset } from '@wordpress/icons';
 import React, { useRef, useEffect } from 'react';
+import { getIpcApi } from '../lib/get-ipc-api';
 import { AssistantIcon } from './icons/assistant';
 
 interface AIInputProps {
@@ -79,8 +80,17 @@ export const AIInput = ( {
 		return isAssistantThinking ? __( 'Generating...' ) : __( 'What would you like to learn?' );
 	};
 
-	const handleClearConversation = () => {
-		if ( window.confirm( __( 'Are you sure you want to clear the conversation?' ) ) ) {
+	const handleClearConversation = async () => {
+		const DELETE_CONVERSATION_BUTTON_INDEX = 0;
+		const CANCEL_DELETE_BUTTON_INDEX = 1;
+
+		const { response } = await getIpcApi().showMessageBox( {
+			message: __( 'Are you sure you want to clear the conversation?' ),
+			buttons: [ __( 'Ok' ), __( 'Cancel' ) ],
+			cancelId: CANCEL_DELETE_BUTTON_INDEX,
+		} );
+
+		if ( response === DELETE_CONVERSATION_BUTTON_INDEX ) {
 			clearInput();
 		}
 	};

--- a/src/components/tests/content-tab-assistant.test.tsx
+++ b/src/components/tests/content-tab-assistant.test.tsx
@@ -76,17 +76,6 @@ describe( 'ContentTabAssistant', () => {
 		expect( textInput.placeholder ).toBe( 'What would you like to learn?' );
 	} );
 
-	test( 'clears input and chat history when MenuIcon is clicked', () => {
-		render( <ContentTabAssistant selectedSite={ runningSite } /> );
-		const textInput = getInput();
-		const menuIcon = screen.getByLabelText( 'menu' );
-		fireEvent.change( textInput, { target: { value: 'Hello, Assistant!' } } );
-		expect( textInput.value ).toBe( 'Hello, Assistant!' );
-		fireEvent.click( menuIcon );
-		expect( textInput.value ).toBe( '' );
-		expect( screen.queryByText( 'Hello, Assistant!' ) ).not.toBeInTheDocument();
-	} );
-
 	test( 'saves and retrieves conversation from localStorage', async () => {
 		const storageKey = `${ runningSite.name }`;
 		localStorage.setItem( storageKey, JSON.stringify( initialMessages ) );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/7697
Related to https://github.com/Automattic/dotcom-forge/issues/7411

## Proposed Changes

This PR adds a dropdown to clear chat messages.

## Testing Instructions

- Pull the changes from this branch
- Start the app with the AI assistant `STUDIO_AI=true npm start`
- Navigate to the assistant tab and start conversation with the AI assistant
- Once there are a couple of messages, click on the three dots by the input field
- Observe the dropdown to `Clear chat history`
- Observe the popup that asks for confirmation to delete the chat (not sure if this is completely necessary to have?)
- Confirm the deletion of the chat history
- Observe that the messages are removed and you are back to seeing the welcome messages and prompts

<img width="1058" alt="Capture d’écran, le 2024-06-14 à 14 12 34" src="https://github.com/Automattic/studio/assets/25575134/0584fdaa-b9f4-45c5-a9f4-707611405bb4">

The was already the PR that attempted this change before so I reused some of the code from https://github.com/Automattic/studio/pull/206/files
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
