### PR TITLE
Studio: Fix console errors on content-tab-assistant-test.tsx

### DIFF
--- a/src/components/tests/content-tab-assistant.test.tsx
+++ b/src/components/tests/content-tab-assistant.test.tsx
@@ -1,15 +1,23 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { useAuth } from '../../hooks/use-auth';
+import { useFetchWelcomeMessages } from '../../hooks/use-fetch-welcome-messages';
 import { ContentTabAssistant } from '../content-tab-assistant';
 
 jest.mock( '../../hooks/use-theme-details' );
 jest.mock( '../../hooks/use-auth' );
+jest.mock( '../../hooks/use-fetch-welcome-messages' );
 
 jest.mock( '../../lib/app-globals', () => ( {
 	getAppGlobals: () => ( {
 		locale: jest.fn,
 	} ),
 } ) );
+
+( useFetchWelcomeMessages as jest.Mock ).mockReturnValue( {
+	messages: [ 'Welcome to our service!', 'How can I help you today?' ],
+	examplePrompts: [ 'Create a WordPress site' ],
+	fetchWelcomeMessages: jest.fn(),
+} );
 
 const runningSite = {
 	name: 'Test Site',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to https://github.com/Automattic/studio/pull/245

## Proposed Changes

This PR fixes the console.error warnings for `content-tab-assistant-test.tsx` that were introduced when the PR mentioned above was merged:

<img width="1394" alt="Capture d’écran, le 2024-06-14 à 15 59 46" src="https://github.com/Automattic/studio/assets/25575134/d5e90737-e30e-463e-ab8b-e28add74214a">

Although the tests are passing, the console throws errors. This happened because I introduced a new hook `use-fetch-welcome-message` that needed to be mocked in `content-tab-assistant`.

## Testing Instructions

- Pull the changes from this branch
- Run `npm run test`
- Observe that there are no warnings coming from `content-tab-assistant-test.tsx`  and all the tests pass
- Alternatively, you can check unit tests in Buildkite and confirm that there is no warnings once all the checks on this PR pass

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
