### PR TITLE
Always show scrollbars in tab panels when content overflows

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -60,22 +60,31 @@ blockquote {
 	background: theme( 'colors.black' );
 }
 
-/* Customize scrollbar area for the sites sidebar */
-.sites-scrollbar::-webkit-scrollbar {
+/* Customize scrollbar area for the sites sidebar and tab panel */
+.sites-scrollbar::-webkit-scrollbar,
+.components-tab-panel__tab-content::-webkit-scrollbar {
 	background: transparent;
 	width: 10px;
 }
 
-/* Customize srollbar thumb appearance for the sites sidebar */
+/* Customize srollbar thumb appearance for the sites sidebar and tab panel */
 .sites-scrollbar::-webkit-scrollbar-thumb {
 	background: #ffffff26;
 	border-radius: 10px;
 	border: 2px solid rgba( 30, 30, 30, 1 );
 }
+.components-tab-panel__tab-content::-webkit-scrollbar-thumb {
+	background: #7f7f7f;
+	border-radius: 10px;
+	border: 2px solid white;
+}
 
 /* Add hover effect to thumb appearance on the scrollbar */
 .sites-scrollbar::-webkit-scrollbar-thumb:hover {
 	background: rgba( 255, 255, 255, 0.5 );
+}
+.components-tab-panel__tab-content::-webkit-scrollbar-thumb:hover {
+	background: #484848;
 }
 
 /* Avoid selecting text on dropdown menu, like preview links */


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to https://github.com/Automattic/studio/pull/225#issuecomment-2172736451.

## Proposed Changes

- Override tab panel styles to customize the scrollbar. This is the same approach we used for the sidebar but using different colors.


https://github.com/Automattic/studio/assets/14905380/4a966249-09d6-4998-8e6c-de92b6ce1146



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Open the app.
- Resize the window to the minimum size.
- Navigate to the Settings tab.
- Observe the content overflows.
- Observe the scrollbar is always displayed.
- Observe the content can be scrolled.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
