### PR TITLE
Studio: creating a new site pulls assistant messages from another site

### DIFF
--- a/src/hooks/tests/use-assistant.test.ts
+++ b/src/hooks/tests/use-assistant.test.ts
@@ -43,6 +43,8 @@ describe( 'useAssistant', () => {
 
 		act( () => {
 			result.current.addMessage( 'Hello', 'user' );
+		} );
+		act( () => {
 			result.current.clearMessages();
 		} );
 

--- a/src/hooks/use-assistant.ts
+++ b/src/hooks/use-assistant.ts
@@ -16,10 +16,12 @@ export const useAssistant = ( selectedSiteId: string ) => {
 		if ( storedChat ) {
 			setMessages( JSON.parse( storedChat ) );
 		} else {
-			localStorage.setItem( selectedSiteId, JSON.stringify( [] ) );
+			setMessages( [] );
 		}
 		if ( storedChatId ) {
 			setChatId( storedChatId );
+		} else {
+			setChatId( undefined );
 		}
 	}, [ selectedSiteId ] );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/7762

## Proposed Changes

This PR fixes a bug where when the user creates a new site, it keeps old selected site messages in AI assistant

## Testing Instructions
1. Create a new site.
2. Go to the assistant tab and ask some questions.
3. While being on that tab, add a new site.
4. Ensure that the chat is updated with being in an empty state.
5. Changing back to the old site must still displays the chats.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
