### PR TITLE
Studio: AssistantIsThinking triggrers across multiple sites

### DIFF
--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -239,7 +239,7 @@ const UnauthenticatedView = ( { onAuthenticate }: { onAuthenticate: () => void }
 export function ContentTabAssistant( { selectedSite }: ContentTabAssistantProps ) {
 	const { messages, addMessage, chatId, clearMessages } = useAssistant( selectedSite.name );
 	const { userCanSendMessage } = usePromptUsage();
-	const { fetchAssistant, isLoading: isAssistantThinking } = useAssistantApi();
+	const { fetchAssistant, isLoading: isAssistantThinking } = useAssistantApi( selectedSite.name );
 	const {
 		messages: welcomeMessages,
 		examplePrompts,

--- a/src/hooks/tests/use-assistant-api.test.ts
+++ b/src/hooks/tests/use-assistant-api.test.ts
@@ -1,5 +1,4 @@
 import { renderHook, act } from '@testing-library/react';
-import { Message } from '../use-assistant';
 import { useAssistantApi } from '../use-assistant-api';
 import { useAuth } from '../use-auth';
 import { usePromptUsage } from '../use-prompt-usage';
@@ -8,6 +7,7 @@ jest.mock( '../use-auth' );
 jest.mock( '../use-prompt-usage' );
 
 const chatId = 'test-chat-id';
+const siteId = 'test-site-id';
 
 describe( 'useAssistantApi', () => {
 	const clientReqPost = jest.fn();
@@ -53,7 +53,7 @@ describe( 'useAssistantApi', () => {
 		( useAuth as jest.Mock ).mockImplementation( () => ( {
 			client: null,
 		} ) );
-		const { result } = renderHook( () => useAssistantApi() );
+		const { result } = renderHook( () => useAssistantApi( siteId ) );
 
 		await act( async () => {
 			await expect( result.current.fetchAssistant( chatId, [] ) ).rejects.toThrow(
@@ -63,7 +63,7 @@ describe( 'useAssistantApi', () => {
 	} );
 
 	test( 'should return a message from the assistant', async () => {
-		const { result } = renderHook( () => useAssistantApi() );
+		const { result } = renderHook( () => useAssistantApi( siteId ) );
 
 		let response = { message: '' };
 		await act( async () => {
@@ -76,7 +76,7 @@ describe( 'useAssistantApi', () => {
 	} );
 
 	test( 'should throw an error if fetch fails', async () => {
-		const { result } = renderHook( () => useAssistantApi() );
+		const { result } = renderHook( () => useAssistantApi( siteId ) );
 
 		clientReqPost.mockImplementation( ( body, callback ) => {
 			callback( new Error( 'Failed to fetch assistant' ), null );

--- a/src/hooks/use-assistant-api.ts
+++ b/src/hooks/use-assistant-api.ts
@@ -3,9 +3,9 @@ import { Message } from './use-assistant';
 import { useAuth } from './use-auth';
 import { usePromptUsage } from './use-prompt-usage';
 
-export function useAssistantApi() {
+export function useAssistantApi( selectedSiteId: string ) {
 	const { client } = useAuth();
-	const [ isLoading, setIsLoading ] = useState( false );
+	const [ isLoading, setIsLoading ] = useState< Record< string, boolean > >( {} );
 	const { updatePromptUsage } = usePromptUsage();
 
 	const fetchAssistant = useCallback(
@@ -13,7 +13,7 @@ export function useAssistantApi() {
 			if ( ! client ) {
 				throw new Error( 'WPcom client not initialized' );
 			}
-			setIsLoading( true );
+			setIsLoading( ( prev ) => ( { ...prev, [ selectedSiteId ]: true } ) );
 			const body = {
 				messages,
 				chat_id: chatId,
@@ -47,7 +47,7 @@ export function useAssistantApi() {
 				response = data;
 				headers = response_headers;
 			} finally {
-				setIsLoading( false );
+				setIsLoading( ( prev ) => ( { ...prev, [ selectedSiteId ]: false } ) );
 			}
 			const message = response?.choices?.[ 0 ]?.message?.content;
 			updatePromptUsage( {
@@ -56,8 +56,8 @@ export function useAssistantApi() {
 			} );
 			return { message, chatId: response?.id };
 		},
-		[ client, updatePromptUsage ]
+		[ client, selectedSiteId, updatePromptUsage ]
 	);
 
-	return { fetchAssistant, isLoading };
+	return { fetchAssistant, isLoading: isLoading[ selectedSiteId ] };
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/7767

## Proposed Changes

This PR fixes a bug where when the chat "is thinking" , the loading indicator persists across multiple sites.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create two sites.
2. Navigate to Studio AI Assistant tab, of the first one.
3. Submit a prompt to the model; eg: "Give me a 3 paragraph text" ( in order to make the response to slow down and make easier to notice )
4. You should be able to see the "thinking" indicator.
5. Switch to another site.
6. Ensure that the indicator is not there.
7. Now switch to the first one. 
8. Ensure that you still see the indicator..

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
