### PR TITLE
Pick right PHP version for sites created before introducing the PHP selector

### DIFF
--- a/src/components/content-tab-settings.tsx
+++ b/src/components/content-tab-settings.tsx
@@ -1,7 +1,6 @@
 import { Icon, file } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { PropsWithChildren } from 'react';
-import { DEFAULT_PHP_VERSION } from '../../vendor/wp-now/src/constants';
 import { useGetWpVersion } from '../hooks/use-get-wp-version';
 import { getIpcApi } from '../lib/get-ipc-api';
 import { decodePassword } from '../lib/passwords';
@@ -32,7 +31,6 @@ export function ContentTabSettings( { selectedSite }: ContentTabSettingsProps ) 
 	// Empty strings account for legacy sites lacking a stored password.
 	const storedPassword = decodePassword( selectedSite.adminPassword ?? '' );
 	const password = storedPassword === '' ? 'password' : storedPassword;
-	const phpVersion = selectedSite.phpVersion ?? DEFAULT_PHP_VERSION;
 	const wpVersion = useGetWpVersion( selectedSite );
 	return (
 		<div className="p-8">
@@ -72,7 +70,7 @@ export function ContentTabSettings( { selectedSite }: ContentTabSettingsProps ) 
 					<SettingsRow label={ __( 'WP Version' ) }>{ wpVersion }</SettingsRow>
 					<SettingsRow label={ __( 'PHP Version' ) }>
 						<div className="flex">
-							<span className="line-clamp-1 break-all">{ phpVersion }</span>
+							<span className="line-clamp-1 break-all">{ selectedSite.phpVersion }</span>
 							<EditPhpVersion />
 						</div>
 					</SettingsRow>

--- a/src/site-server.ts
+++ b/src/site-server.ts
@@ -75,7 +75,7 @@ export class SiteServer {
 			port,
 			adminPassword: decodePassword( this.details.adminPassword ?? '' ),
 			siteTitle: this.details.name,
-			php: this.details.phpVersion ?? DEFAULT_PHP_VERSION,
+			php: this.details.phpVersion,
 		} );
 		const absoluteUrl = `http://localhost:${ port }`;
 		options.absoluteUrl = absoluteUrl;

--- a/src/storage/tests/user-data.test.ts
+++ b/src/storage/tests/user-data.test.ts
@@ -3,11 +3,12 @@
  */
 // To run tests, execute `npm run test -- src/storage/user-data.test.ts` from the root directory
 import fs from 'fs';
+import { UserData } from '../storage-types';
 import { loadUserData } from '../user-data';
 
 jest.mock( 'fs' );
 
-const mockUserData = {
+const mockedUserData = {
 	sites: [
 		{ name: 'Tristan', path: '/to/tristan' },
 		{ name: 'Arthur', path: '/to/arthur' },
@@ -16,14 +17,24 @@ const mockUserData = {
 	snapshots: [],
 };
 
-( fs as MockedFs ).__setFileContents(
-	'/path/to/app/appData/App Name/appdata-v1.json',
-	JSON.stringify( mockUserData )
-);
-// Assume each site path exists
-( fs.existsSync as jest.Mock ).mockReturnValue( true );
+function mockUserData( data: RecursivePartial< UserData > ) {
+	( fs as MockedFs ).__setFileContents(
+		'/path/to/app/appData/App Name/appdata-v1.json',
+		JSON.stringify( data )
+	);
+}
 
 describe( 'loadUserData', () => {
+	beforeEach( () => {
+		mockUserData( mockedUserData );
+		// Assume each site path exists
+		( fs.existsSync as jest.Mock ).mockReturnValue( true );
+	} );
+
+	afterEach( () => {
+		jest.restoreAllMocks();
+	} );
+
 	test( 'loads user data correctly and sorts sites', async () => {
 		const result = await loadUserData();
 
@@ -38,5 +49,18 @@ describe( 'loadUserData', () => {
 		( fs.existsSync as jest.Mock ).mockImplementation( ( path ) => path === '/to/lancelot' );
 		const result = await loadUserData();
 		expect( result.sites.map( ( sites ) => sites.name ) ).toEqual( [ 'Lancelot' ] );
+	} );
+
+	test( 'populates PHP version when unknown', async () => {
+		mockUserData( {
+			sites: [
+				{ name: 'Arthur', path: '/to/arthur', phpVersion: '8.3' },
+				{ name: 'Lancelot', path: '/to/lancelot', phpVersion: '8.1' },
+				{ name: 'Tristan', path: '/to/tristan' },
+			],
+			snapshots: [],
+		} );
+		const result = await loadUserData();
+		expect( result.sites.map( ( site ) => site.phpVersion ) ).toEqual( [ '8.3', '8.1', '8.0' ] );
 	} );
 } );

--- a/src/storage/user-data.ts
+++ b/src/storage/user-data.ts
@@ -1,12 +1,18 @@
 import { app } from 'electron';
 import fs from 'fs';
 import nodePath from 'path';
+import { SupportedPHPVersion, SupportedPHPVersions } from '@php-wasm/universal';
 import * as Sentry from '@sentry/electron/main';
 import { isErrnoException } from '../lib/is-errno-exception';
 import { sanitizeUnstructuredData, sanitizeUserpath } from '../lib/sanitize-for-logging';
 import { sortSites } from '../lib/sort-sites';
 import { getUserDataFilePath } from './paths';
 import type { PersistedUserData, UserData } from './storage-types';
+
+// Before persisting the PHP version of sites, the default PHP version used was 8.0.
+// In case we can't retrieve the PHP version from site details, we assume it was created
+// with version 8.0.
+export const DEFAULT_PHP_VERSION_WHEN_UNKNOWN: SupportedPHPVersion = '8.0';
 
 const migrateUserData = ( appName: string ) => {
 	const appDataPath = app.getPath( 'appData' );
@@ -28,6 +34,17 @@ function migrateUserDataOldName() {
 	migrateUserData( 'Build' );
 }
 
+function populatePhpVersion( sites: SiteDetails[] ) {
+	sites.forEach( ( site ) => {
+		if (
+			typeof site.phpVersion === 'undefined' ||
+			! SupportedPHPVersions.includes( site.phpVersion as SupportedPHPVersion )
+		) {
+			site.phpVersion = DEFAULT_PHP_VERSION_WHEN_UNKNOWN;
+		}
+	} );
+}
+
 export async function loadUserData(): Promise< UserData > {
 	migrateUserDataOldName();
 	const filePath = getUserDataFilePath();
@@ -38,6 +55,7 @@ export async function loadUserData(): Promise< UserData > {
 			const parsed = JSON.parse( asString );
 			const data = fromDiskFormat( parsed );
 			sortSites( data.sites );
+			populatePhpVersion( data.sites );
 			console.log( `Loaded user data from ${ sanitizeUserpath( filePath ) }` );
 			return data;
 		} catch ( err ) {

--- a/src/utility-types.d.ts
+++ b/src/utility-types.d.ts
@@ -1,0 +1,11 @@
+/**
+ * These extra type definitions expand the utility types provided by TypeScript
+ */
+
+type RecursivePartial< T > = {
+	[ P in keyof T ]?: T[ P ] extends ( infer U )[]
+		? RecursivePartial< U >[]
+		: T[ P ] extends object | undefined
+		? RecursivePartial< T[ P ] >
+		: T[ P ];
+};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to https://github.com/Automattic/studio/pull/240#issuecomment-2173667408 and https://github.com/Automattic/studio/pull/225.

## Proposed Changes

- Populate the PHP version for sites without this property specified when loading site details from user data. The PHP version used for those sites is `8.0`, as it was the default version used before https://github.com/Automattic/studio/pull/240 got merged.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### New sites

1. Create a new site.
2. Go to the Settings tab.
3. Observe that the PHP version is `8.1`.
4. Open WP admin and navigate to `wp-admin/site-health.php?tab=debug`.
5. Open the Server section.
6. Observe that the PHP version is `8.1`.

### Old sites

1. Install a version of the Studio app before changes from https://github.com/Automattic/studio/pull/225 were applied.
    - Alternatively, you can edit the file `~/Library/Application\ Support/Studio/appdata-v1.json` and remove `phpVersion` property from sites.
3. Create a new site.
4. Build/install a version with the changes from this PR.
5. Select the previously created site.
6. Go to the Settings tab.
7. Observe that its PHP version is `8.0`.
8. Edit the PHP version.
9. Observe that in the "Edit PHP version" modal, the version `8.0` is selected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
