### PR TITLE
Refactor E2E tests initialization

### DIFF
--- a/e2e/app.test.ts
+++ b/e2e/app.test.ts
@@ -1,22 +1,26 @@
 import { test, expect } from '@playwright/test';
 import packageJson from '../package.json';
-import { launchApp } from './e2e-helpers';
-import type { ElectronApplication, Page } from 'playwright';
+import { E2ESession } from './e2e-helpers';
+import Onboarding from './page-objects/onboarding';
 
 test.describe( 'Electron app', () => {
-	let electronApp: ElectronApplication;
-	let mainWindow: Page;
+	const session = new E2ESession();
 
 	test.beforeAll( async () => {
-		[ electronApp, mainWindow ] = await launchApp();
+		await session.launch();
 	} );
 
 	test.afterAll( async () => {
-		await electronApp?.close();
+		await session.cleanup();
 	} );
 
 	test( 'should ensure app title is correct.', async () => {
-		const title = await mainWindow.title();
+		const title = await session.mainWindow.title();
 		expect( title ).toBe( packageJson.productName );
+	} );
+
+	test( 'first screen displayed is onboarding', async () => {
+		const onboarding = new Onboarding( session.mainWindow );
+		await expect( onboarding.heading ).toBeVisible();
 	} );
 } );

--- a/e2e/e2e-helpers.ts
+++ b/e2e/e2e-helpers.ts
@@ -46,7 +46,7 @@ export class E2ESession {
 			},
 			timeout: 60_000,
 		} );
-		this.mainWindow = await this.electronApp.firstWindow();
+		this.mainWindow = await this.electronApp.firstWindow( { timeout: 60_000 } );
 	}
 
 	async cleanup() {
@@ -54,30 +54,4 @@ export class E2ESession {
 		// Clean up temporal folder to hold application data
 		fs.rmSync( this.sessionPath, { recursive: true, force: true } );
 	}
-}
-
-export async function launchApp( testEnv: NodeJS.ProcessEnv = {} ) {
-	// find the latest build in the out directory
-	const latestBuild = findLatestBuild();
-
-	// parse the packaged Electron app and find paths and other info
-	const appInfo = parseElectronApp( latestBuild );
-	let executablePath = appInfo.executable;
-	if ( appInfo.platform === 'win32' ) {
-		// `parseElectronApp` function obtains the executable path by finding the first executable from the build folder.
-		// We need to ensure that the executable is the Studio app.
-		executablePath = executablePath.replace( 'Squirrel.exe', 'Studio.exe' );
-	}
-	const electronApp = await electron.launch( {
-		args: [ appInfo.main ], // main file from package.json
-		executablePath, // path to the Electron executable
-		env: {
-			...process.env,
-			...testEnv,
-			E2E: 'true', // allow app to determine whether it's running as an end-to-end test
-		},
-	} );
-	const mainWindow = await electronApp.firstWindow( { timeout: 60_000 } );
-
-	return [ electronApp, mainWindow ] as const;
 }

--- a/e2e/e2e-helpers.ts
+++ b/e2e/e2e-helpers.ts
@@ -1,5 +1,60 @@
+import { randomUUID } from 'crypto';
+import { tmpdir } from 'os';
+import path from 'path';
 import { findLatestBuild, parseElectronApp } from 'electron-playwright-helpers';
-import { _electron as electron } from 'playwright';
+import fs from 'fs-extra';
+import { _electron as electron, Page, ElectronApplication } from 'playwright';
+
+export class E2ESession {
+	electronApp: ElectronApplication;
+	mainWindow: Page;
+
+	sessionPath: string;
+	appDataPath: string;
+	homePath: string;
+
+	async launch( testEnv: NodeJS.ProcessEnv = {} ) {
+		// Create temporal folder to hold application data
+		this.sessionPath = path.join( tmpdir(), `studio-app-e2e-session-${ randomUUID() }` );
+		this.appDataPath = path.join( this.sessionPath, 'appData' );
+		this.homePath = path.join( this.sessionPath, 'home' );
+
+		await fs.mkdir( this.appDataPath, { recursive: true } );
+		await fs.mkdir( this.homePath, { recursive: true } );
+
+		// find the latest build in the out directory
+		const latestBuild = findLatestBuild();
+
+		// parse the packaged Electron app and find paths and other info
+		const appInfo = parseElectronApp( latestBuild );
+		let executablePath = appInfo.executable;
+		if ( appInfo.platform === 'win32' ) {
+			// `parseElectronApp` function obtains the executable path by finding the first executable from the build folder.
+			// We need to ensure that the executable is the Studio app.
+			executablePath = executablePath.replace( 'Squirrel.exe', 'Studio.exe' );
+		}
+
+		this.electronApp = await electron.launch( {
+			args: [ appInfo.main ], // main file from package.json
+			executablePath, // path to the Electron executable
+			env: {
+				...process.env,
+				...testEnv,
+				E2E: 'true', // allow app to determine whether it's running as an end-to-end test
+				E2E_APP_DATA_PATH: this.appDataPath,
+				E2E_HOME_PATH: this.homePath,
+			},
+			timeout: 60_000,
+		} );
+		this.mainWindow = await this.electronApp.firstWindow();
+	}
+
+	async cleanup() {
+		await this.electronApp?.close();
+		// Clean up temporal folder to hold application data
+		fs.rmSync( this.sessionPath, { recursive: true, force: true } );
+	}
+}
 
 export async function launchApp( testEnv: NodeJS.ProcessEnv = {} ) {
 	// find the latest build in the out directory

--- a/e2e/sites.test.ts
+++ b/e2e/sites.test.ts
@@ -1,100 +1,54 @@
-import { randomUUID } from 'crypto';
-import { promises as fs } from 'fs';
 import http from 'http';
-import { tmpdir } from 'os';
 import path from 'path';
 import { test, expect } from '@playwright/test';
 import { pathExists } from '../src/lib/fs-utils';
-import { launchApp } from './e2e-helpers';
+import { E2ESession } from './e2e-helpers';
 import MainSidebar from './page-objects/main-sidebar';
 import Onboarding from './page-objects/onboarding';
 import SiteContent from './page-objects/site-content';
-import type { ElectronApplication, Page } from 'playwright';
 
 const skipTestOnWindows = process.platform === 'win32' ? test.skip : test;
 
 test.describe( 'Servers', () => {
-	let electronApp: ElectronApplication;
-	let mainWindow: Page;
-	const siteName = `test-site-${ randomUUID() }`;
-	const tmpSiteDir = path.join( tmpdir(), siteName );
-	const defaultOnboardingSiteName = 'My WordPress Website';
-	const onboardingTmpSiteDir = path.join(
-		tmpdir(),
-		defaultOnboardingSiteName.replace( /\s/g, '-' )
-	);
+	const session = new E2ESession();
+
+	const siteName = 'E2E-Test-Site';
+	const defaultSiteName = 'My WordPress Website';
 
 	test.beforeAll( async () => {
-		// Print path in error so we can delete it manually if needed.
-		expect( await pathExists( tmpSiteDir ), `Path ${ tmpSiteDir } exists.` ).toBe( false );
-		await fs.mkdir( tmpSiteDir, { recursive: true } );
+		await session.launch();
 
-		// Temporarily launch the app to complete the onboarding process before
-		// interacting with the primary app UI.
-		expect(
-			await pathExists( onboardingTmpSiteDir ),
-			`Path ${ onboardingTmpSiteDir } exists.`
-		).toBe( false );
-		await fs.mkdir( onboardingTmpSiteDir, { recursive: true } );
-		const [ onboardingAppInstance, onboardingMainWindow ] = await launchApp( {
-			E2E_OPEN_FOLDER_DIALOG: onboardingTmpSiteDir,
-		} );
-		const onboarding = new Onboarding( onboardingMainWindow );
-		const sidebar = new MainSidebar( onboardingMainWindow );
-
-		// Await UI visibility before proceeding.
-		await expect( onboarding.heading.or( sidebar.addSiteButton ) ).toBeVisible();
-
-		// If the onboarding heading is present, there are no existing sites and we
-		// must complete the onboarding process.
-		if ( await onboarding.heading.isVisible() ) {
-			await onboarding.selectLocalPathForTesting();
-			await onboarding.continueButton.click();
-
-			const siteContent = new SiteContent( onboardingMainWindow, defaultOnboardingSiteName );
-			await expect( siteContent.siteNameHeading ).toBeVisible( { timeout: 60_000 } );
-		}
-
-		await onboardingAppInstance.close();
-
-		// Relaunch the app but configured to use tmpSiteDir as the path for the local site.
-		[ electronApp, mainWindow ] = await launchApp( { E2E_OPEN_FOLDER_DIALOG: tmpSiteDir } );
+		// Complete onboarding before tests
+		const onboarding = new Onboarding( session.mainWindow );
+		await expect( onboarding.heading ).toBeVisible();
+		// Delay clicking the button to avoid errors due to creating the site too early
+		await session.mainWindow.waitForTimeout( 500 );
+		await onboarding.continueButton.click();
+		const siteContent = new SiteContent( session.mainWindow, defaultSiteName );
+		await expect( siteContent.siteNameHeading ).toBeVisible( { timeout: 60_000 } );
 	} );
 
 	test.afterAll( async () => {
-		await electronApp?.close();
-
-		[ tmpSiteDir, onboardingTmpSiteDir ].forEach( async ( dir ) => {
-			// Check if path exists first, because tmpSiteDir should have been deleted by the test that deletes the site.
-			if ( await pathExists( dir ) ) {
-				try {
-					await fs.rm( dir, { recursive: true } );
-				} catch {
-					throw new Error( `Failed to clean up ${ dir }` );
-				}
-			}
-		} );
+		await session.cleanup();
 	} );
 
 	test( 'create a new site', async () => {
-		const sidebar = new MainSidebar( mainWindow );
+		const sidebar = new MainSidebar( session.mainWindow );
 		const modal = await sidebar.openAddSiteModal();
 
 		await modal.siteNameInput.fill( siteName );
-		await modal.selectLocalPathForTesting();
-		// Can't get the text out of this yet...
-		// expect( await modal.localPathInput.inputValue() ).toBe( tmpSiteDir );
-		// expect( await modal.localPathInput ).toHaveText( tmpSiteDir, { useInnerText: true } );
 		await modal.addSiteButton.click();
 
 		const sidebarButton = sidebar.getSiteNavButton( siteName );
 		await expect( sidebarButton ).toBeAttached( { timeout: 30_000 } );
 
 		// Check a WordPress site has been created
-		expect( await pathExists( path.join( tmpSiteDir, 'wp-config.php' ) ) ).toBe( true );
+		expect(
+			await pathExists( path.join( session.homePath, 'Studio', siteName, 'wp-config.php' ) )
+		).toBe( true );
 
 		// Check the site is running
-		const siteContent = new SiteContent( mainWindow, siteName );
+		const siteContent = new SiteContent( session.mainWindow, siteName );
 		expect( await siteContent.siteNameHeading ).toHaveText( siteName );
 
 		await siteContent.navigateToTab( 'Settings' );
@@ -110,11 +64,11 @@ test.describe( 'Servers', () => {
 	} );
 
 	test( "edit site's settings in wp-admin", async ( { page } ) => {
-		const siteContent = new SiteContent( mainWindow, siteName );
+		const siteContent = new SiteContent( session.mainWindow, siteName );
 		const settingsTab = await siteContent.navigateToTab( 'Settings' );
 
-		const wpAdminUrl = await settingsTab.copyWPAdminUrlToClipboard( electronApp );
-		const frontendUrl = await settingsTab.copySiteUrlToClipboard( electronApp );
+		const wpAdminUrl = await settingsTab.copyWPAdminUrlToClipboard( session.electronApp );
+		const frontendUrl = await settingsTab.copySiteUrlToClipboard( session.electronApp );
 
 		// page.goto opens a browser
 		await page.goto( wpAdminUrl + '/options-general.php' );
@@ -127,24 +81,24 @@ test.describe( 'Servers', () => {
 	} );
 
 	skipTestOnWindows( 'delete site', async () => {
-		const siteContent = new SiteContent( mainWindow, siteName );
+		const siteContent = new SiteContent( session.mainWindow, siteName );
 		const settingsTab = await siteContent.navigateToTab( 'Settings' );
 
 		// Playwright lacks support for interacting with native dialogs, so we mock
 		// the dialog module to simulate the user clicking the "Delete site"
 		// confirmation button with "Delete site files from my computer" checked.
 		// See: https://github.com/microsoft/playwright/issues/21432
-		await electronApp.evaluate( ( { dialog } ) => {
+		await session.electronApp.evaluate( ( { dialog } ) => {
 			dialog.showMessageBox = async () => {
 				return { response: 0, checkboxChecked: true };
 			};
 		} );
 		await settingsTab.openDeleteSiteModal();
 
-		await mainWindow.waitForTimeout( 200 ); // Short pause for site to delete.
+		await session.mainWindow.waitForTimeout( 200 ); // Short pause for site to delete.
 
-		expect( await pathExists( tmpSiteDir ) ).toBe( false );
-		const sidebar = new MainSidebar( mainWindow );
+		expect( await pathExists( path.join( session.homePath, 'Studio', siteName ) ) ).toBe( false );
+		const sidebar = new MainSidebar( session.mainWindow );
 		await expect( sidebar.getSiteNavButton( siteName ) ).not.toBeAttached();
 	} );
 } );

--- a/e2e/sites.test.ts
+++ b/e2e/sites.test.ts
@@ -21,8 +21,6 @@ test.describe( 'Servers', () => {
 		// Complete onboarding before tests
 		const onboarding = new Onboarding( session.mainWindow );
 		await expect( onboarding.heading ).toBeVisible();
-		// Delay clicking the button to avoid errors due to creating the site too early
-		await session.mainWindow.waitForTimeout( 500 );
 		await onboarding.continueButton.click();
 		const siteContent = new SiteContent( session.mainWindow, defaultSiteName );
 		await expect( siteContent.siteNameHeading ).toBeVisible( { timeout: 60_000 } );

--- a/src/storage/paths.ts
+++ b/src/storage/paths.ts
@@ -2,18 +2,37 @@ import { app } from 'electron';
 import path from 'path';
 
 export function getUserDataFilePath(): string {
+	if ( process.env.E2E && process.env.E2E_APP_DATA_PATH ) {
+		return path.join( process.env.E2E_APP_DATA_PATH, app.getName(), 'appdata-v1.json' );
+	}
 	const appDataPath = app.getPath( 'appData' ); // Resolves to ~/Library/Application Support on macOS
 	return path.join( appDataPath, app.getName(), 'appdata-v1.json' );
 }
 
 export function getServerFilesPath(): string {
+	if ( process.env.E2E && process.env.E2E_APP_DATA_PATH ) {
+		return path.join( process.env.E2E_APP_DATA_PATH, app.getName(), 'server-files' );
+	}
 	const appDataPath = app.getPath( 'appData' ); // Resolves to ~/Library/Application Support on macOS
 	return path.join( appDataPath, app.getName(), 'server-files' );
 }
 
-export const DEFAULT_SITE_PATH = path.join( app?.getPath( 'home' ) || '', 'Studio' );
+export const DEFAULT_SITE_PATH = path.join(
+	( process.env.E2E && process.env.E2E_HOME_PATH
+		? process.env.E2E_HOME_PATH
+		: app?.getPath( 'home' ) ) || '',
+	'Studio'
+);
 
 export function getSiteThumbnailPath( siteId: string ): string {
+	if ( process.env.E2E && process.env.E2E_APP_DATA_PATH ) {
+		return path.join(
+			process.env.E2E_APP_DATA_PATH,
+			app.getName(),
+			'thumbnails',
+			`${ siteId }.png`
+		);
+	}
 	const appDataPath = app.getPath( 'appData' );
 	return path.join( appDataPath, app.getName(), 'thumbnails', `${ siteId }.png` );
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to https://github.com/Automattic/studio/pull/258, as it can help address some issues spotted on Windows.

## Proposed Changes

- Before this change, the app ran by the E2E tests used local data which can interfere with the test logic. To avoid this and run E2E tests in isolation, we override the path functions to point to a temporal folder.
- The before/after logic of the E2E tests has been reduced and simplified, as of now all tests start from a clean slate.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### CI
- Observe that all CI jobs pass.

### Local
- Run command `npm run package`.
- Run command `npm run e2e`.
- Observe that all E2E tests pass.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
