### PR TITLE
feat: Limit Assistant chat visibility to participants

### DIFF
--- a/src/components/auth-provider.tsx
+++ b/src/components/auth-provider.tsx
@@ -10,7 +10,7 @@ export interface AuthContextType {
 	isAuthenticated: boolean;
 	authenticate: () => Promise< void >; // Adjust based on the actual implementation
 	logout: () => Promise< void >; // Adjust based on the actual implementation
-	user?: { email: string; displayName: string };
+	user?: { id: number | null; email: string; displayName: string };
 }
 
 interface AuthProviderProps {
@@ -42,8 +42,12 @@ const AuthProvider: React.FC< AuthProviderProps > = ( { children } ) => {
 		}
 		setIsAuthenticated( true );
 		setClient( createWpcomClient( token.accessToken ) );
-		if ( token.email || token.displayName ) {
-			setUser( { email: token.email || '', displayName: token.displayName || '' } );
+		if ( token.id || token.email || token.displayName ) {
+			setUser( {
+				id: token.id || null,
+				email: token.email || '',
+				displayName: token.displayName || '',
+			} );
 		}
 	} );
 
@@ -70,8 +74,9 @@ const AuthProvider: React.FC< AuthProviderProps > = ( { children } ) => {
 						return;
 					}
 					setClient( createWpcomClient( token.accessToken ) );
-					if ( token.email || token.displayName ) {
+					if ( token.id || token.email || token.displayName ) {
 						setUser( {
+							id: token.id || null,
 							email: token.email || '',
 							displayName: token.displayName || '',
 						} );

--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -114,7 +114,7 @@ export function ContentTabAssistant( { selectedSite }: ContentTabAssistantProps 
 	const currentSiteChatContext = useChatContext();
 	const { isAuthenticated, authenticate, user } = useAuth();
 	const { messages, addMessage, clearMessages, updateMessage, chatId } = useAssistant(
-		user?.id ? `${ user.id }-${ selectedSite.name }` : selectedSite.name
+		user?.id ? `${ user.id }_${ selectedSite.name }` : selectedSite.name
 	);
 	const { userCanSendMessage } = usePromptUsage();
 	const { fetchAssistant, isLoading: isAssistantThinking } = useAssistantApi( selectedSite.name );

--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -112,8 +112,9 @@ const UnauthenticatedView = ( { onAuthenticate }: { onAuthenticate: () => void }
 
 export function ContentTabAssistant( { selectedSite }: ContentTabAssistantProps ) {
 	const currentSiteChatContext = useChatContext();
+	const { isAuthenticated, authenticate, user } = useAuth();
 	const { messages, addMessage, clearMessages, updateMessage, chatId } = useAssistant(
-		selectedSite.name
+		user?.id ? `${ user.id }-${ selectedSite.name }` : selectedSite.name
 	);
 	const { userCanSendMessage } = usePromptUsage();
 	const { fetchAssistant, isLoading: isAssistantThinking } = useAssistantApi( selectedSite.name );
@@ -123,7 +124,6 @@ export function ContentTabAssistant( { selectedSite }: ContentTabAssistantProps 
 		fetchWelcomeMessages,
 	} = useFetchWelcomeMessages();
 	const [ input, setInput ] = useState< string >( '' );
-	const { isAuthenticated, authenticate } = useAuth();
 	const isOffline = useOffline();
 	const { __ } = useI18n();
 

--- a/src/components/tests/content-tab-assistant.test.tsx
+++ b/src/components/tests/content-tab-assistant.test.tsx
@@ -136,4 +136,42 @@ describe( 'ContentTabAssistant', () => {
 		fireEvent.click( loginButton );
 		expect( authenticate ).toHaveBeenCalledTimes( 1 );
 	} );
+
+	test( 'it stores messages with user-unique keys', async () => {
+		const user1 = { id: 'mock-user-1' };
+		const user2 = { id: 'mock-user-2' };
+		( useAuth as jest.Mock ).mockImplementation( () => ( {
+			client: {
+				req: {
+					post: clientReqPost,
+				},
+			},
+			isAuthenticated: true,
+			authenticate,
+			user: user1,
+		} ) );
+		const { rerender } = render( <ContentTabAssistant selectedSite={ runningSite } /> );
+
+		const textInput = getInput();
+		fireEvent.change( textInput, { target: { value: 'New message' } } );
+		fireEvent.keyDown( textInput, { key: 'Enter', code: 'Enter' } );
+
+		expect( screen.getByText( 'New message' ) ).toBeVisible();
+
+		// Simulate user authentication change
+		( useAuth as jest.Mock ).mockImplementation( () => ( {
+			client: {
+				req: {
+					post: clientReqPost,
+				},
+			},
+			isAuthenticated: true,
+			authenticate,
+			user: user2,
+		} ) );
+
+		rerender( <ContentTabAssistant selectedSite={ runningSite } /> );
+
+		expect( screen.queryByText( 'New message' ) ).toBeNull();
+	} );
 } );

--- a/src/hooks/use-assistant.ts
+++ b/src/hooks/use-assistant.ts
@@ -13,13 +13,13 @@ export type Message = {
 	}[];
 };
 
-export const useAssistant = ( selectedSiteId: string ) => {
+export const useAssistant = ( storeKey: string ) => {
 	const [ messages, setMessages ] = useState< Message[] >( [] );
 	const [ chatId, setChatId ] = useState< string | undefined >( undefined );
 
 	useEffect( () => {
-		const storedChat = localStorage.getItem( selectedSiteId );
-		const storedChatId = localStorage.getItem( `chat_${ selectedSiteId }` );
+		const storedChat = localStorage.getItem( storeKey );
+		const storedChatId = localStorage.getItem( `chat_${ storeKey }` );
 		if ( storedChat ) {
 			setMessages( JSON.parse( storedChat ) );
 		} else {
@@ -30,24 +30,24 @@ export const useAssistant = ( selectedSiteId: string ) => {
 		} else {
 			setChatId( undefined );
 		}
-	}, [ selectedSiteId ] );
+	}, [ storeKey ] );
 
 	const addMessage = useCallback(
 		( content: string, role: 'user' | 'assistant', chatId?: string ) => {
 			setMessages( ( prevMessages ) => {
 				const updatedMessages = [ ...prevMessages, { content, role, id: prevMessages.length } ];
-				localStorage.setItem( selectedSiteId, JSON.stringify( updatedMessages ) );
+				localStorage.setItem( storeKey, JSON.stringify( updatedMessages ) );
 				return updatedMessages;
 			} );
 
 			setChatId( ( prevChatId ) => {
 				if ( prevChatId !== chatId && chatId ) {
-					localStorage.setItem( `chat_${ selectedSiteId }`, JSON.stringify( chatId ) );
+					localStorage.setItem( `chat_${ storeKey }`, JSON.stringify( chatId ) );
 				}
 				return chatId;
 			} );
 		},
-		[ selectedSiteId ]
+		[ storeKey ]
 	);
 
 	const updateMessage = useCallback(
@@ -74,19 +74,19 @@ export const useAssistant = ( selectedSiteId: string ) => {
 					}
 					return { ...message, blocks: updatedBlocks };
 				} );
-				localStorage.setItem( selectedSiteId, JSON.stringify( updatedMessages ) );
+				localStorage.setItem( storeKey, JSON.stringify( updatedMessages ) );
 				return updatedMessages;
 			} );
 		},
-		[ selectedSiteId ]
+		[ storeKey ]
 	);
 
 	const clearMessages = useCallback( () => {
 		setMessages( [] );
 		setChatId( undefined );
-		localStorage.setItem( selectedSiteId, JSON.stringify( [] ) );
-		localStorage.removeItem( `chat_${ selectedSiteId }` );
-	}, [ selectedSiteId ] );
+		localStorage.setItem( storeKey, JSON.stringify( [] ) );
+		localStorage.removeItem( `chat_${ storeKey }` );
+	}, [ storeKey ] );
 
 	return useMemo(
 		() => ( {

--- a/src/lib/oauth.ts
+++ b/src/lib/oauth.ts
@@ -9,6 +9,7 @@ export interface StoredToken {
 	accessToken?: string;
 	expiresIn?: number;
 	expirationTime?: number;
+	id?: number;
 	email?: string;
 	displayName?: string;
 }
@@ -77,9 +78,9 @@ export async function handleAuthCallback( hash: string ): Promise< Error | Store
 	if ( isNaN( expiresIn ) || expiresIn === 0 || ! accessToken ) {
 		return new Error( 'Error while getting token' );
 	}
-	let response: { email?: string; display_name?: string } = {};
+	let response: { ID?: number; email?: string; display_name?: string } = {};
 	try {
-		response = await new wpcom( accessToken ).req.get( '/me?fields=email,display_name' );
+		response = await new wpcom( accessToken ).req.get( '/me?fields=ID,email,display_name' );
 	} catch ( error ) {
 		Sentry.captureException( error );
 	}
@@ -87,6 +88,7 @@ export async function handleAuthCallback( hash: string ): Promise< Error | Store
 		expiresIn,
 		expirationTime: new Date().getTime() + expiresIn * 1000,
 		accessToken,
+		id: response.ID,
 		email: response.email,
 		displayName: response.display_name,
 	};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/7532.

## Proposed Changes

Avoid loading locally stored chat messages from originating from a
different account, as doing so creates a confusing user experience.

No logic was introduced to migrate "legacy" chat conversation stores given this
feature is not publicly available.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

> [!IMPORTANT]
> Because the Assistant feature is currently restricted to internal accounts,
> you will either need two internal accounts or rely upon a modified sandbox API
> that temporarily enables API access for a one-off, secondary account.

**1. Legacy chat messages are not displayed for new authentication sessions**

1. Check out the latest `trunk` branch.
1. Authenticate with a WordPress.com account.
1. Engage the Assistant in conversation.
1. Log out of the current account.
1. Check out the proposed changes. **Note:** Restarting the development server is required. 
1. Authenticate with the same WordPress.com account.
1. Verify the prior conversations are not displayed.

**2. Displayed chat messages are limited to participants**

1. Check out the proposed changes.
1. Authenticate with a WordPress.com account.
1. Engage the Assistant in conversation.
1. Log out of the current account.
1. Log into a _different_ WordPress.com account.
1. Verify the prior conversation is not displayed.
1. Log out of the current account.
1. Log into the first account.
1. Verify the previous conversation is displayed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?

