### PR TITLE
fix: Prevent invalid code markup

### DIFF
--- a/src/components/chat-message.tsx
+++ b/src/components/chat-message.tsx
@@ -136,11 +136,9 @@ export const ChatMessage = ( {
 				) }
 			</>
 		) : (
-			<div className="inline-block">
-				<code className={ className } { ...props }>
-					{ children }
-				</code>
-			</div>
+			<code className={ className } { ...props }>
+				{ children }
+			</code>
 		);
 	};
 

--- a/src/components/chat-message.tsx
+++ b/src/components/chat-message.tsx
@@ -96,10 +96,11 @@ export const ChatMessage = ( {
 
 		const { children, className } = props;
 		const match = /language-(\w+)/.exec( className || '' );
+		const { node, ...propsSansNode } = props;
 		return match ? (
 			<>
 				<div className="p-3">
-					<code className={ className } { ...props }>
+					<code className={ className } { ...propsSansNode }>
 						{ children }
 					</code>
 				</div>
@@ -136,7 +137,7 @@ export const ChatMessage = ( {
 				) }
 			</>
 		) : (
-			<code className={ className } { ...props }>
+			<code className={ className } { ...propsSansNode }>
 				{ children }
 			</code>
 		);
@@ -180,10 +181,11 @@ export const ChatMessage = ( {
 
 function Anchor( props: JSX.IntrinsicElements[ 'a' ] & ExtraProps ) {
 	const { href } = props;
+	const { node, ...propsSansNode } = props;
 
 	return (
 		<a
-			{ ...props }
+			{ ...propsSansNode }
 			onClick={ ( e ) => {
 				if ( ! href ) {
 					return;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/7830.

## Proposed Changes

- Remove unnecessary wrapping `div` element from inline code blocks that
  resulted in invalid markup.
- Avoid spreading invalid `node` prop onto HTML elements.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Make a request to the Assistant that results in an inline code block; e.g.,
   "How do I clear my site cache?"
1. When the Assistant responds, verify there are no console errors and no `node`
   attributes on returned `code` or `a` elements.

| Inline Code Block | Invalid `node` Attribute |
| - | - |
| <img width="569" alt="inline-code-block" src="https://github.com/Automattic/studio/assets/438664/c2792e6e-b7f1-48b0-9be2-03e9ab72e301"> | <img width="548" alt="invalid-node-attribute" src="https://github.com/Automattic/studio/assets/438664/fa42c1e5-b26b-472a-90dc-79221dac1d3e"> |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
