### PR TITLE
Studio: Fix alignment of the unauthenticated view

### DIFF
--- a/src/components/chat-message.tsx
+++ b/src/components/chat-message.tsx
@@ -33,6 +33,7 @@ interface ChatMessageProps {
 		status: 'success' | 'error',
 		time: string
 	) => void;
+	isUnauthenticated?: boolean;
 }
 
 interface InlineCLIProps {
@@ -64,6 +65,7 @@ export const ChatMessage = ( {
 	projectPath,
 	blocks,
 	updateMessage,
+	isUnauthenticated,
 }: ChatMessageProps ) => {
 	const CodeBlock = ( props: JSX.IntrinsicElements[ 'code' ] & ExtraProps ) => {
 		const content = String( props.children ).trim();
@@ -157,7 +159,8 @@ export const ChatMessage = ( {
 				role="group"
 				aria-labelledby={ id }
 				className={ cx(
-					'inline-block p-3 rounded border border-gray-300 lg:max-w-[70%] overflow-x-auto select-text',
+					'inline-block p-3 rounded border border-gray-300 overflow-x-auto select-text',
+					isUnauthenticated ? 'lg:max-w-[90%]' : 'lg:max-w-[70%]', // Apply different max-width for unauthenticated view
 					! isUser ? 'bg-white' : 'bg-white/45'
 				) }
 			>

--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -106,7 +106,12 @@ const AuthenticatedView = memo(
 );
 
 const UnauthenticatedView = ( { onAuthenticate }: { onAuthenticate: () => void } ) => (
-	<ChatMessage id="message-unauthenticated" className="w-full" isUser={ false }>
+	<ChatMessage
+		id="message-unauthenticated"
+		className="w-full"
+		isUser={ false }
+		isUnauthenticated={ true }
+	>
 		<div className="mb-3 a8c-label-semibold">{ __( 'Hold up!' ) }</div>
 		<div className="mb-1">
 			{ __( 'You need to log in to your WordPress.com account to use the assistant.' ) }

--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -207,7 +207,7 @@ export function ContentTabAssistant( { selectedSite }: ContentTabAssistantProps 
 				data-testid="assistant-chat"
 				className={ cx(
 					'flex-1 overflow-y-auto p-8 flex flex-col-reverse',
-					! isAuthenticated && 'flex items-end'
+					! isAuthenticated && 'flex items-start'
 				) }
 			>
 				<div className="mt-auto">


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/7864

## Proposed Changes

This PR fixes the alignment of the unauthenticated view to the left of the screen to be consistent with the design.

Before:

<img width="1015" alt="Screenshot 2024-06-21 at 10 07 59 AM" src="https://github.com/Automattic/studio/assets/25575134/974d45e3-d076-41e8-a29f-e059e254b594">

After:

<img width="871" alt="Screenshot 2024-06-21 at 10 51 28 AM" src="https://github.com/Automattic/studio/assets/25575134/771fe4c1-5a2a-4ee6-ac6d-b562601f89cf">



## Testing Instructions

* Pull the changes from this branch locally
* Start the app with the AI Assistant: `STUDIO_AI=true npm start`
* Navigate to the AI Assistant
* Log out of your WordPress.com account from Studio app
* Confirm that the logged out view aligns the log in screen to the left and is consistent with the design
* Confirm that nothing else breaks when you are logged in and send messages

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
