### PR TITLE
Track first app launches

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -31,8 +31,9 @@ import {
 	needsToMigrateFromWpNowFolder,
 } from './migrations/migrate-from-wp-now-folder';
 import setupWPServerFiles from './setup-wp-server-files';
+import { stopAllServersOnQuit } from './site-server';
+import { loadUserData } from './storage/user-data'; // eslint-disable-next-line import/order
 import { setupUpdates } from './updates';
-import { stopAllServersOnQuit } from './site-server'; // eslint-disable-line import/order
 
 if ( ! isCLI() ) {
 	Sentry.init( {
@@ -257,6 +258,12 @@ async function appBoot() {
 		// Handle CLI commands
 		listenCLICommands();
 		executeCLICommand();
+
+		// Bump stats for the first time the app runs - this is when no lastBumpStats are available
+		const userData = await loadUserData();
+		if ( ! userData.lastBumpStats ) {
+			bumpStat( 'studio-app-launch-first', process.platform );
+		}
 
 		// Bump a stat on each app launch, approximates total app launches
 		bumpStat( 'studio-app-launch-total', process.platform );

--- a/src/lib/bump-stats.ts
+++ b/src/lib/bump-stats.ts
@@ -22,8 +22,6 @@ export function bumpAggregatedUniqueStat(
 			if ( lastBump === null ) {
 				// Bump the stat the first time it's seen
 				bumpStat( group, stat, bumpInDev );
-				// Also, explicitly track the first occurrence by appending `-first`
-				bumpStat( `${ group }-first`, stat, bumpInDev );
 				return true;
 			}
 

--- a/src/lib/tests/bump-stats.test.ts
+++ b/src/lib/tests/bump-stats.test.ts
@@ -81,14 +81,12 @@ describe( 'bumpStat', () => {
 describe( 'bumpAggregatedUniqueStat', () => {
 	test( 'bump stat when it has never been recorded before', async () => {
 		const nock = mockBumpStatRequest( 'usage', 'launch' );
-		const nockFirst = mockBumpStatRequestFirst( 'usage', 'launch' );
 
 		( loadUserData as jest.Mock ).mockResolvedValue( { lastBumpStats: {} } );
 
 		bumpAggregatedUniqueStat( 'usage', 'launch', 'weekly' );
 
 		await waitFor( () => expect( nock.isDone() ).toBe( true ) );
-		await waitFor( () => expect( nockFirst.isDone() ).toBe( true ) );
 	} );
 
 	for ( const [ aggregateBy, currentTime, lastBumpTime ] of [


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to: https://github.com/Automattic/dotcom-forge/issues/7578

We want to track first-time launches of the app. This was already implemented but due to the name of the stat being too long, it was not tracked.

## Proposed Changes

- Remove the `-first` stat that is automatically sent on aggregated bumps in favor of explicitly logging first-time events when needed.
- When no `lastBumpStats` have been set in the userdata, assume it is the first time the app was launched and bump the stat. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
To test that the stat bump is sent successfully, you can monitor the log output of `npm run start`. We need to emulate a first-launch so we need to temporarily remove/move the `appdata-v1.json` file.

- Move your `appdata-v1.json` file somewhere safe.
- Run `npm run start`
- Observe that the stats are sent by verifying that the following is logged:
   - `Would have bumped stat: studio-app-launch-first=darwin`
   - `Would have bumped stat: studio-app-launch-total=darwin`
   - `Would have bumped stat: local-environment-launch-uniques=darwin`
 - Stop the npm run process and start it again. This time observe that only `Would have bumped stat: studio-app-launch-total=darwin` is visible in the logs.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
