### PR TITLE
Add text no wrap to display whole wp-cli table results

### DIFF
--- a/src/components/chat-message.tsx
+++ b/src/components/chat-message.tsx
@@ -51,7 +51,7 @@ const InlineCLI = ( { output, status, time }: InlineCLIProps ) => (
 			<span className="text-gray-400">{ time }</span>
 		</div>
 		<pre className="text-white !bg-transparent !m-0 !px-0">
-			<code className="!bg-transparent !mx-0 !px-0">{ output }</code>
+			<code className="!bg-transparent !mx-0 !px-0 !text-nowrap">{ output }</code>
 		</pre>
 	</div>
 );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

- Fixes https://github.com/Automattic/dotcom-forge/issues/7866

## Proposed Changes

- Do not wrap wp-cli results

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run Studio assistant
- Ask "display my plugins"
- Observe the results display the whole table.

| Before | After |
|--------|--------|
|  <img width="600" alt="Screenshot 2024-06-21 at 11 51 43" src="https://github.com/Automattic/studio/assets/779993/adf60cad-f78e-48e1-8803-993f9df890b5"> | <img width="604" alt="Screenshot 2024-06-21 at 11 51 17" src="https://github.com/Automattic/studio/assets/779993/559a1c07-57ef-4457-b21e-532b5bd00912"> |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
