### PR TITLE
feat: Permanently dismiss clear messages warning

### DIFF
--- a/src/components/ai-clear-history-reminder.tsx
+++ b/src/components/ai-clear-history-reminder.tsx
@@ -53,14 +53,24 @@ function AIClearHistoryReminder( {
 	}, [ showReminder ] );
 
 	const onClearHistory = useCallback( async () => {
+		if ( localStorage.getItem( 'dontShowClearMessagesWarning' ) === 'true' ) {
+			clearInput();
+			return;
+		}
+
 		const CLEAR_CONVERSATION_BUTTON_INDEX = 0;
 		const CANCEL_BUTTON_INDEX = 1;
 
-		const { response } = await getIpcApi().showMessageBox( {
+		const { response, checkboxChecked } = await getIpcApi().showMessageBox( {
 			message: __( 'Are you sure you want to clear the conversation?' ),
+			checkboxLabel: __( "Don't show this warning again" ),
 			buttons: [ __( 'OK' ), __( 'Cancel' ) ],
 			cancelId: CANCEL_BUTTON_INDEX,
 		} );
+
+		if ( checkboxChecked ) {
+			localStorage.setItem( 'dontShowClearMessagesWarning', 'true' );
+		}
 
 		if ( response === CLEAR_CONVERSATION_BUTTON_INDEX ) {
 			clearInput();

--- a/src/components/ai-input.tsx
+++ b/src/components/ai-input.tsx
@@ -82,16 +82,25 @@ export const AIInput = ( {
 	};
 
 	const handleClearConversation = async () => {
+		if ( localStorage.getItem( 'dontShowClearMessagesWarning' ) === 'true' ) {
+			clearInput();
+			return;
+		}
+
 		const CLEAR_CONVERSATION_BUTTON_INDEX = 0;
 		const CANCEL_BUTTON_INDEX = 1;
 
-		const { response } = await getIpcApi().showMessageBox( {
+		const { response, checkboxChecked } = await getIpcApi().showMessageBox( {
 			message: __( 'Are you sure you want to clear the conversation?' ),
+			checkboxLabel: __( "Don't show this warning again" ),
 			buttons: [ __( 'OK' ), __( 'Cancel' ) ],
 			cancelId: CANCEL_BUTTON_INDEX,
 		} );
 
 		if ( response === CLEAR_CONVERSATION_BUTTON_INDEX ) {
+			if ( checkboxChecked ) {
+				localStorage.setItem( 'dontShowClearMessagesWarning', 'true' );
+			}
 			clearInput();
 		}
 	};

--- a/src/components/ai-input.tsx
+++ b/src/components/ai-input.tsx
@@ -97,10 +97,11 @@ export const AIInput = ( {
 			cancelId: CANCEL_BUTTON_INDEX,
 		} );
 
+		if ( checkboxChecked ) {
+			localStorage.setItem( 'dontShowClearMessagesWarning', 'true' );
+		}
+
 		if ( response === CLEAR_CONVERSATION_BUTTON_INDEX ) {
-			if ( checkboxChecked ) {
-				localStorage.setItem( 'dontShowClearMessagesWarning', 'true' );
-			}
 			clearInput();
 		}
 	};

--- a/src/components/ai-input.tsx
+++ b/src/components/ai-input.tsx
@@ -136,6 +136,7 @@ export const AIInput = ( {
 					<>
 						<MenuGroup>
 							<MenuItem
+								isDestructive
 								data-testid="clear-conversation-button"
 								onClick={ () => {
 									handleClearConversation();
@@ -143,9 +144,7 @@ export const AIInput = ( {
 								} }
 							>
 								<Icon className="text-red-600" icon={ reset } />
-								<span className="ltr:pl-2 rtl:pl-2 text-red-600">
-									{ __( 'Clear conversation' ) }
-								</span>
+								<span className="ltr:pl-2 rtl:pl-2">{ __( 'Clear conversation' ) }</span>
 							</MenuItem>
 						</MenuGroup>
 					</>

--- a/src/components/tests/ai-clear-history-reminder.test.tsx
+++ b/src/components/tests/ai-clear-history-reminder.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { getIpcApi } from '../../lib/get-ipc-api';
+import AIClearHistoryReminder from '../ai-clear-history-reminder';
+import type { Message } from '../../hooks/use-assistant';
+
+jest.mock( '../../lib/get-ipc-api' );
+
+describe( 'AIClearHistoryReminder', () => {
+	let clearInput: jest.Mock;
+	const MOCKED_TIME = 1718882159928;
+	const TWO_HOURS_DIFF = 2 * 60 * 60 * 1000;
+
+	beforeEach( () => {
+		window.HTMLElement.prototype.scrollIntoView = jest.fn();
+		clearInput = jest.fn();
+		jest.clearAllMocks();
+		jest.useFakeTimers();
+		jest.setSystemTime( MOCKED_TIME );
+	} );
+
+	afterEach( () => {
+		jest.useRealTimers();
+	} );
+
+	it( 'should display a reminder when the conversation is stale', () => {
+		const message: Message = {
+			id: 0,
+			createdAt: MOCKED_TIME - TWO_HOURS_DIFF,
+			content: '',
+			role: 'assistant',
+		};
+		render( <AIClearHistoryReminder lastMessage={ message } clearInput={ clearInput } /> );
+
+		expect( screen.getByText( /This conversation is over two hours old./ ) ).toBeInTheDocument();
+	} );
+
+	it( 'should warn then clear conversations', async () => {
+		( getIpcApi as jest.Mock ).mockReturnValue( {
+			showMessageBox: jest.fn().mockResolvedValue( { response: 0, checkboxChecked: false } ),
+		} );
+		const message: Message = {
+			id: 0,
+			createdAt: MOCKED_TIME - TWO_HOURS_DIFF,
+			content: '',
+			role: 'assistant',
+		};
+		render( <AIClearHistoryReminder lastMessage={ message } clearInput={ clearInput } /> );
+
+		fireEvent.click( screen.getByText( /Clear the history/ ) );
+
+		await waitFor( () => {
+			expect( getIpcApi().showMessageBox ).toHaveBeenCalledTimes( 1 );
+			expect( clearInput ).toHaveBeenCalledTimes( 1 );
+		} );
+	} );
+
+	it( 'should clear conversations without warning if dismised permanently', async () => {
+		localStorage.setItem( 'dontShowClearMessagesWarning', 'true' );
+		( getIpcApi as jest.Mock ).mockReturnValue( {
+			showMessageBox: jest.fn().mockResolvedValue( { response: 1, checkboxChecked: false } ),
+		} );
+		const message: Message = {
+			id: 0,
+			createdAt: MOCKED_TIME - TWO_HOURS_DIFF,
+			content: '',
+			role: 'assistant',
+		};
+		render( <AIClearHistoryReminder lastMessage={ message } clearInput={ clearInput } /> );
+
+		fireEvent.click( screen.getByText( /Clear the history/ ) );
+
+		expect( getIpcApi().showMessageBox ).not.toHaveBeenCalled();
+		expect( clearInput ).toHaveBeenCalledTimes( 1 );
+	} );
+} );

--- a/src/components/tests/ai-input.test.tsx
+++ b/src/components/tests/ai-input.test.tsx
@@ -101,4 +101,20 @@ describe( 'AIInput Component', () => {
 			expect( clearInput ).toHaveBeenCalled();
 		} );
 	} );
+
+	it( 'should clear messages without warning if the warning was previously dismissed', async () => {
+		localStorage.setItem( 'dontShowClearMessagesWarning', 'true' );
+		const textarea = getInput();
+		const longText = 'Line\n'.repeat( 100 );
+		fireEvent.change( textarea, { target: { value: longText } } );
+
+		const assistantMenu = screen.getByLabelText( 'Assistant Menu' );
+		fireEvent.click( assistantMenu );
+		const clearConversationButton = screen.getByTestId( 'clear-conversation-button' );
+		mockShowMessageBox.mockResolvedValueOnce( { response: 0, checkboxChecked: true } );
+		fireEvent.click( clearConversationButton );
+
+		expect( mockShowMessageBox ).not.toHaveBeenCalled();
+		expect( clearInput ).toHaveBeenCalled();
+	} );
 } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/7854.

## Proposed Changes

- Replace custom styles with built-in destructive styles
- Permanently dismiss clear messages warning

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**1. Menu button warning remains if not permanently dismissed**

1. Engage in conversation with the Assistant.
1. Click the Assistant input menu button (three stacked dots).
1. Click "Clear conversation."
1. Click "OK."
1. Repeat steps 1-3.
1. Verify the warning is presented.

**2. Menu button warning not displayed if permanently dismissed**

1. Engage in conversation with the Assistant.
1. Click the Assistant input menu button (three stacked dots).
1. Click "Clear conversation."
1. Check the "Don't show this warning again" checkbox.
1. Click "OK."
1. Repeat steps 1-3.
1. Verify the warning is *not* presented.

**3. Reminder button warning remains if not permanently dismissed**

<details><summary>Reduce stale conversation threshold diff</summary>

```diff
diff --git a/src/constants.ts b/src/constants.ts
index 7d3b197..b102c60 100644
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -30,4 +30,4 @@ export const DAY_MS = HOUR_MS * 24;
 // AI Assistant constants
 // IMPORTANT: When updating this value, we need to update the string located in `AIClearHistoryReminder` component.
 // Reference: https://github.com/Automattic/studio/blob/3dd5c58cdb7998e458d191e508e8e859177225a9/src/components/ai-clear-history-reminder.tsx#L78
-export const CLEAR_HISTORY_REMINDER_TIME = 2 * HOUR_MS; // In milliseconds
+export const CLEAR_HISTORY_REMINDER_TIME = 10 * 1000; // In milliseconds

```

</details>

1. Apply the stale conversation threshold patch (see above). 
1. Engage in conversation with the Assistant.
1. Wait for 10+ seconds. 
1. Click the stale conversation reminder clear button.
1. Click "Clear conversation."
1. Click "OK."
1. Repeat steps 1-4.
1. Verify the warning is presented.

**4. Reminder button warning not displayed if permanently dismissed**

<details><summary>Reduce stale conversation threshold diff</summary>

```diff
diff --git a/src/constants.ts b/src/constants.ts
index 7d3b197..b102c60 100644
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -30,4 +30,4 @@ export const DAY_MS = HOUR_MS * 24;
 // AI Assistant constants
 // IMPORTANT: When updating this value, we need to update the string located in `AIClearHistoryReminder` component.
 // Reference: https://github.com/Automattic/studio/blob/3dd5c58cdb7998e458d191e508e8e859177225a9/src/components/ai-clear-history-reminder.tsx#L78
-export const CLEAR_HISTORY_REMINDER_TIME = 2 * HOUR_MS; // In milliseconds
+export const CLEAR_HISTORY_REMINDER_TIME = 10 * 1000; // In milliseconds

```

</details>

1. Apply the stale conversation threshold patch (see above). 
1. Engage in conversation with the Assistant.
1. Wait for 10+ seconds. 
1. Click the stale conversation reminder clear button.
1. Click "Clear conversation."
1. Check the "Don't show this warning again" checkbox.
1. Click "OK."
1. Repeat steps 1-4.
1. Verify the warning is *not* presented.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
