### PR TITLE
feat: Limit permanent warning dismissal to affirmative actions

### DIFF
--- a/src/components/ai-clear-history-reminder.tsx
+++ b/src/components/ai-clear-history-reminder.tsx
@@ -68,11 +68,11 @@ function AIClearHistoryReminder( {
 			cancelId: CANCEL_BUTTON_INDEX,
 		} );
 
-		if ( checkboxChecked ) {
-			localStorage.setItem( 'dontShowClearMessagesWarning', 'true' );
-		}
-
 		if ( response === CLEAR_CONVERSATION_BUTTON_INDEX ) {
+			if ( checkboxChecked ) {
+				localStorage.setItem( 'dontShowClearMessagesWarning', 'true' );
+			}
+
 			clearInput();
 		}
 	}, [ clearInput ] );

--- a/src/components/ai-input.tsx
+++ b/src/components/ai-input.tsx
@@ -97,11 +97,11 @@ export const AIInput = ( {
 			cancelId: CANCEL_BUTTON_INDEX,
 		} );
 
-		if ( checkboxChecked ) {
-			localStorage.setItem( 'dontShowClearMessagesWarning', 'true' );
-		}
-
 		if ( response === CLEAR_CONVERSATION_BUTTON_INDEX ) {
+			if ( checkboxChecked ) {
+				localStorage.setItem( 'dontShowClearMessagesWarning', 'true' );
+			}
+
 			clearInput();
 		}
 	};

--- a/src/components/content-tab-snapshots.tsx
+++ b/src/components/content-tab-snapshots.tsx
@@ -101,11 +101,11 @@ function SnapshotRow( {
 				checkboxChecked: false,
 			} );
 
-			if ( checkboxChecked ) {
-				localStorage.setItem( 'dontShowUpdateWarning', 'true' );
-			}
-
 			if ( response === UPDATE_BUTTON_INDEX ) {
+				if ( checkboxChecked ) {
+					localStorage.setItem( 'dontShowUpdateWarning', 'true' );
+				}
+
 				updateDemoSite( snapshot, selectedSite );
 			}
 		} else {

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -97,7 +97,7 @@ getIpcApi()
 									'Downloading the optimized version of Studio will provide better performance.'
 							  ),
 					checkboxLabel: __( "Don't show this warning again" ),
-					buttons: [ __( 'Download' ), __( 'Cancel' ) ],
+					buttons: [ __( 'Download' ), __( 'Not now' ) ],
 					cancelId: 1,
 				} );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to https://github.com/Automattic/studio/pull/287#issuecomment-2183118650.

## Proposed Changes

**feat: Limit permanent warning dismissal to affirmative actions**
Permanently dismissing a warning while selecting the "cancel" option is
confusing as generally cancelling a dialog does not persist selections.

**feat: Rephrase download optimized version cancel option**
This option is not so much a cancellation, but either a deferment of a
highly-recommended action or an acceptance of actively choosing to not
heed direct advice for solving an system issue. Rephrasing the option to
align with this better communicates the choice and makes the permanent
dismissal option more understandable.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Verify permanent dismissal is disallowed when selecting the "cancel" option**

1. Trigger the display of a warning dialog.
    - Clear AI messages from AI input (see [prior testing steps](https://github.com/Automattic/studio/pull/287)[^1] for details).
    - Clear AI messages from stale conversation warning (see [prior testing steps](https://github.com/Automattic/studio/pull/287)[^1] for details).
    - Update existing Demo site with new content (see [prior testing steps](https://github.com/Automattic/local-environment/pull/242)[^1] for details).
1. Check the "Don't show this warning again" option.
1. Click the "cancel" option.
1. Verify the dialog is displayed after triggering the relevant scenario (step
   1).

[^1]: There is no need to complete all of the linked testing steps, only those related for triggering the relevant warning dialog. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
