### PR TITLE
feat: Avoid Assistant navigating to stopped sites

### DIFF
--- a/src/components/chat-message.tsx
+++ b/src/components/chat-message.tsx
@@ -6,6 +6,7 @@ import Markdown, { ExtraProps } from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import stripAnsi from 'strip-ansi';
 import { useExecuteWPCLI } from '../hooks/use-execute-cli';
+import { useSiteDetails } from '../hooks/use-site-details';
 import { cx } from '../lib/cx';
 import { getIpcApi } from '../lib/get-ipc-api';
 import Button from './button';
@@ -185,16 +186,24 @@ export const ChatMessage = ( {
 function Anchor( props: JSX.IntrinsicElements[ 'a' ] & ExtraProps ) {
 	const { href } = props;
 	const { node, ...propsSansNode } = props;
+	const { selectedSite, startServer } = useSiteDetails();
 
 	return (
 		<a
 			{ ...propsSansNode }
-			onClick={ ( e ) => {
+			onClick={ async ( e ) => {
 				if ( ! href ) {
 					return;
 				}
 
 				e.preventDefault();
+
+				const urlForStoppedSite =
+					/^https?:\/\/localhost/.test( href ) && selectedSite && ! selectedSite.running;
+				if ( urlForStoppedSite ) {
+					await startServer( selectedSite?.id );
+				}
+
 				try {
 					getIpcApi().openURL( href );
 				} catch ( error ) {

--- a/src/components/chat-message.tsx
+++ b/src/components/chat-message.tsx
@@ -1,4 +1,5 @@
 import * as Sentry from '@sentry/react';
+import { speak } from '@wordpress/a11y';
 import { Spinner } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useEffect } from 'react';
@@ -185,12 +186,16 @@ export const ChatMessage = ( {
 
 function Anchor( props: JSX.IntrinsicElements[ 'a' ] & ExtraProps ) {
 	const { href } = props;
-	const { node, ...propsSansNode } = props;
-	const { selectedSite, startServer } = useSiteDetails();
+	const { node, className, ...filteredProps } = props;
+	const { selectedSite, startServer, loadingServer } = useSiteDetails();
 
 	return (
 		<a
-			{ ...propsSansNode }
+			{ ...filteredProps }
+			className={ cx(
+				className,
+				selectedSite && loadingServer[ selectedSite.id ] && 'animate-pulse duration-100 cursor-wait'
+			) }
 			onClick={ async ( e ) => {
 				if ( ! href ) {
 					return;
@@ -201,6 +206,7 @@ function Anchor( props: JSX.IntrinsicElements[ 'a' ] & ExtraProps ) {
 				const urlForStoppedSite =
 					/^https?:\/\/localhost/.test( href ) && selectedSite && ! selectedSite.running;
 				if ( urlForStoppedSite ) {
+					speak( __( 'Starting the server before opening the site link' ) );
 					await startServer( selectedSite?.id );
 				}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/7868.

## Proposed Changes

**feat: Avoid links to stopped sites**
Mitigate user confusion that may result from an Assistant link to a
stopped sites by starting the site prior to navigating to the linked
site.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Navigating to stopped sites successfully loads the site**
1. Stop a site's server.
1. Ask the Assistant for a link to the site; e.g. "Where do I find my site's WP Admin?"
1. Click the provided link.
1. Verify the site's server is started prior to the web browser opening to visit
   the site URL.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
