### PR TITLE
feat: Minimize site form layout shift

### DIFF
--- a/src/components/site-form.tsx
+++ b/src/components/site-form.tsx
@@ -89,7 +89,7 @@ export const SiteForm = ( {
 	children,
 	siteName,
 	setSiteName,
-	sitePath,
+	sitePath = '',
 	onSelectPath,
 	error,
 	doesPathContainWordPress = false,
@@ -116,7 +116,7 @@ export const SiteForm = ( {
 					<span className="font-semibold">{ __( 'Site name' ) }</span>
 					<TextControlComponent onChange={ setSiteName } value={ siteName }></TextControlComponent>
 				</label>
-				{ sitePath && onSelectPath && (
+				{ onSelectPath && (
 					<label className="flex flex-col gap-1.5 leading-4">
 						<span onClick={ onSelectPath } className="font-semibold">
 							{ __( 'Local path' ) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Proposed Changes

**Minimize site form layout shift**
The "Add site" dialog relies upon asynchronous name generation, which
ultimately populates the site path input. Conditionally rendering the
site path input based upon the populated site path value meant the input
popped into place during the modal open animation. Conditionally
rendering the input based upon the event handler only ensures the input
is present throughout the modal open animation.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

> [!TIP]
> Observing the difference in the provided screen recordings below requires slowly dragging the video scrubber. 

| Before | After |
| - | - |
| <img width="1012" alt="initial-open-before" src="https://github.com/Automattic/studio/assets/438664/429070f3-b3d6-4791-b9b6-efaff179efff"> | <img width="1012" alt="initial-open-after" src="https://github.com/Automattic/studio/assets/438664/89805a53-16b8-4469-acaf-b2ebf5c71bcf"> |
| <video src="https://github.com/Automattic/studio/assets/438664/8b363310-ab5c-4195-a311-0e6786e911bd" /> | <video src="https://github.com/Automattic/studio/assets/438664/6e4c996b-29e5-4eca-832f-726b3de164cf" /> |
| | <video src="https://github.com/Automattic/studio/assets/438664/76cd93f3-3f4c-41f0-a644-814ae9e6c3f4" /> |a


**1. Add site dialog always displays site path input**

1. Click "Add site" in the sidebar.
1. Verify the site path input is always in-place, even during the modal
   animation the first time the modal is opened.

**2. Edit site name excludes site path input**

1. Select or add a site.
1. Navigate to the Settings panel.
1. Click "Edit" next to the site name.
1. Verify the site path input is not displayed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
