### PR TITLE
Studio: handle errors when sending messages 

### DIFF
--- a/src/components/chat-message.tsx
+++ b/src/components/chat-message.tsx
@@ -164,7 +164,7 @@ export const ChatMessage = ( {
 					isUnauthenticated ? 'lg:max-w-[90%]' : 'lg:max-w-[70%]', // Apply different max-width for unauthenticated view
 					! isUser ? 'bg-white' : 'bg-white/45',
 					id !== 'message-thinking' && messageId === errorMessageId //Ensure that the styling for error applies only to a message that fails to send
-						? 'text-red-500 bg-red-100 border border-red-500'
+						? 'border border-[#FACFD2] bg-[#F7EBEC]'
 						: ''
 				) }
 			>

--- a/src/components/chat-message.tsx
+++ b/src/components/chat-message.tsx
@@ -34,6 +34,7 @@ interface ChatMessageProps {
 		time: string
 	) => void;
 	isUnauthenticated?: boolean;
+	errorMessageId?: number | null;
 }
 
 interface InlineCLIProps {
@@ -66,6 +67,7 @@ export const ChatMessage = ( {
 	blocks,
 	updateMessage,
 	isUnauthenticated,
+	errorMessageId,
 }: ChatMessageProps ) => {
 	const CodeBlock = ( props: JSX.IntrinsicElements[ 'code' ] & ExtraProps ) => {
 		const content = String( props.children ).trim();
@@ -160,7 +162,10 @@ export const ChatMessage = ( {
 				className={ cx(
 					'inline-block p-3 rounded border border-gray-300 overflow-x-auto select-text',
 					isUnauthenticated ? 'lg:max-w-[90%]' : 'lg:max-w-[70%]', // Apply different max-width for unauthenticated view
-					! isUser ? 'bg-white' : 'bg-white/45'
+					! isUser ? 'bg-white' : 'bg-white/45',
+					id !== 'message-thinking' && messageId === errorMessageId //Ensure that the styling for error applies only to a message that fails to send
+						? 'text-red-500 bg-red-100 border border-red-500'
+						: ''
 				) }
 			>
 				<div className="relative">

--- a/src/components/chat-message.tsx
+++ b/src/components/chat-message.tsx
@@ -34,7 +34,7 @@ interface ChatMessageProps {
 		time: string
 	) => void;
 	isUnauthenticated?: boolean;
-	errorMessageId?: number | null;
+	hasError?: boolean;
 }
 
 interface InlineCLIProps {
@@ -67,7 +67,7 @@ export const ChatMessage = ( {
 	blocks,
 	updateMessage,
 	isUnauthenticated,
-	errorMessageId,
+	hasError,
 }: ChatMessageProps ) => {
 	const CodeBlock = ( props: JSX.IntrinsicElements[ 'code' ] & ExtraProps ) => {
 		const content = String( props.children ).trim();
@@ -160,12 +160,12 @@ export const ChatMessage = ( {
 				role="group"
 				aria-labelledby={ id }
 				className={ cx(
-					'inline-block p-3 rounded border border-gray-300 overflow-x-auto select-text',
+					'inline-block p-3 rounded overflow-x-auto select-text',
 					isUnauthenticated ? 'lg:max-w-[90%]' : 'lg:max-w-[70%]', // Apply different max-width for unauthenticated view
-					! isUser ? 'bg-white' : 'bg-white/45',
-					id !== 'message-thinking' && messageId === errorMessageId //Ensure that the styling for error applies only to a message that fails to send
-						? 'border border-[#FACFD2] bg-[#F7EBEC]'
-						: ''
+					! isUser ? 'bg-white' : '',
+					isUser && ! hasError ? 'bg-white/45' : '',
+					hasError ? 'border-[#FACFD2] bg-[#F7EBEC]' : 'border-gray-300',
+					'border'
 				) }
 			>
 				<div className="relative">

--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -72,11 +72,17 @@ const ErrorNotice = ( {
 } ) => {
 	const { __ } = useI18n();
 	return (
-		<div className="text-a8c-gray-50 flex justify-end py-2">
+		<div className="text-a8c-gray-50 flex justify-end py-2 text-xs">
 			{ createInterpolateElement(
-				__( "Oops. We couldn't get a response from the assistant. <a>Try again</a>" ),
+				__( "Oops! We couldn't get a response from the assistant. <a>Try again</a>" ),
 				{
-					a: <Button variant="link" onClick={ () => handleSend( messageContent, messageId ) } />,
+					a: (
+						<Button
+							variant="link"
+							onClick={ () => handleSend( messageContent, messageId ) }
+							className="text-xs"
+						/>
+					),
 				}
 			) }
 		</div>

--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -72,7 +72,7 @@ const ErrorNotice = ( {
 } ) => {
 	const { __ } = useI18n();
 	return (
-		<div className="flex justify-end h-12 px-2 pt-6 text-a8c-gray-70">
+		<div className="text-a8c-gray-50 flex justify-end py-2">
 			{ createInterpolateElement(
 				__( "Oops. We couldn't get a response from the assistant. <a>Try again</a>" ),
 				{

--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -134,6 +134,7 @@ const AuthenticatedView = memo(
 							updateMessage={ updateMessage }
 							messageId={ message.id }
 							blocks={ message.blocks }
+							errorMessageId={ errorMessageId }
 						>
 							{ message.content }
 						</ChatMessage>

--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -136,6 +136,7 @@ const AuthenticatedView = memo(
 							updateMessage={ updateMessage }
 							messageId={ message.id }
 							blocks={ message.blocks }
+							hasError={ message.id !== undefined ? errorMessages.has( message.id ) : false }
 						>
 							{ message.content }
 						</ChatMessage>

--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -226,7 +226,6 @@ export function ContentTabAssistant( { selectedSite }: ContentTabAssistantProps 
 	const { __ } = useI18n();
 	const lastMessage = messages.length === 0 ? undefined : messages[ messages.length - 1 ];
 
-	const [ isThinking, setIsThinking ] = useState( false );
 	const [ errorNotices, setErrorNotices ] = useState< Set< number > >( getErrorNoticesFromStorage );
 
 	useEffect( () => {
@@ -242,7 +241,6 @@ export function ContentTabAssistant( { selectedSite }: ContentTabAssistantProps 
 		if ( chatMessage.trim() ) {
 			addMessage( chatMessage, 'user', chatId );
 			setInput( '' );
-			setIsThinking( true );
 			try {
 				const { message, chatId: fetchedChatId } = await fetchAssistant(
 					chatId,
@@ -259,9 +257,6 @@ export function ContentTabAssistant( { selectedSite }: ContentTabAssistantProps 
 				}
 			} catch ( error ) {
 				setErrorNotices( ( prev ) => new Set( prev ).add( messages.length ) );
-				setIsThinking( false );
-			} finally {
-				setIsThinking( false );
 			}
 		}
 	};
@@ -297,7 +292,7 @@ export function ContentTabAssistant( { selectedSite }: ContentTabAssistantProps 
 							{ isAuthenticated && messages.length > 0 && (
 								<AuthenticatedView
 									messages={ messages }
-									isAssistantThinking={ isAssistantThinking || isThinking }
+									isAssistantThinking={ isAssistantThinking }
 									updateMessage={ updateMessage }
 									path={ selectedSite.path }
 									handleSend={ handleSend }
@@ -319,7 +314,7 @@ export function ContentTabAssistant( { selectedSite }: ContentTabAssistantProps 
 										/>
 										<AuthenticatedView
 											messages={ messages }
-											isAssistantThinking={ isAssistantThinking || isThinking }
+											isAssistantThinking={ isAssistantThinking }
 											updateMessage={ updateMessage }
 											path={ selectedSite.path }
 											handleSend={ handleSend }
@@ -340,7 +335,7 @@ export function ContentTabAssistant( { selectedSite }: ContentTabAssistantProps 
 									/>
 									<AuthenticatedView
 										messages={ messages }
-										isAssistantThinking={ isAssistantThinking || isThinking }
+										isAssistantThinking={ isAssistantThinking }
 										updateMessage={ updateMessage }
 										path={ selectedSite.path }
 										handleSend={ handleSend }

--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -211,9 +211,8 @@ const UnauthenticatedView = ( { onAuthenticate }: { onAuthenticate: () => void }
 export function ContentTabAssistant( { selectedSite }: ContentTabAssistantProps ) {
 	const currentSiteChatContext = useChatContext();
 	const { isAuthenticated, authenticate, user } = useAuth();
-	const { messages, addMessage, clearMessages, updateMessage, chatId } = useAssistant(
-		user?.id ? `${ user.id }_${ selectedSite.id }` : selectedSite.id
-	);
+	const { messages, addMessage, clearMessages, updateMessage, removeLocalMessage, chatId } =
+		useAssistant( user?.id ? `${ user.id }_${ selectedSite.id }` : selectedSite.id );
 	const { userCanSendMessage } = usePromptUsage();
 	const { fetchAssistant, isLoading: isAssistantThinking } = useAssistantApi( selectedSite.id );
 	const {
@@ -236,9 +235,12 @@ export function ContentTabAssistant( { selectedSite }: ContentTabAssistantProps 
 		saveErrorNoticesToStorage( errorNotices );
 	}, [ errorNotices ] );
 
-	const handleSend = async ( messageToSend?: string ) => {
+	const handleSend = async ( messageToSend?: string, messageId?: number ) => {
 		const chatMessage = messageToSend || input;
 		if ( chatMessage.trim() ) {
+			if ( messageId !== undefined ) {
+				removeLocalMessage( messageId );
+			}
 			addMessage( chatMessage, 'user', chatId );
 			setInput( '' );
 			try {

--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -208,12 +208,11 @@ export function ContentTabAssistant( { selectedSite }: ContentTabAssistantProps 
 	const lastMessage = messages.length === 0 ? undefined : messages[ messages.length - 1 ];
 
 	const [ errorMessageId, setErrorMessageId ] = useState< number | null >( null );
+	const [ isThinking, setIsThinking ] = useState( false );
 
 	useEffect( () => {
 		fetchWelcomeMessages();
 	}, [ fetchWelcomeMessages, selectedSite ] );
-
-	const [ isThinking, setIsThinking ] = useState( false ); // Add this line
 
 	const handleSend = async ( messageToSend?: string, messageId?: number ) => {
 		const chatMessage = messageToSend || input;
@@ -276,7 +275,7 @@ export function ContentTabAssistant( { selectedSite }: ContentTabAssistantProps 
 							{ isAuthenticated && messages.length > 0 && (
 								<AuthenticatedView
 									messages={ messages }
-									isAssistantThinking={ isAssistantThinking }
+									isAssistantThinking={ isAssistantThinking || isThinking }
 									updateMessage={ updateMessage }
 									path={ selectedSite.path }
 									errorMessageId={ errorMessageId }
@@ -298,7 +297,7 @@ export function ContentTabAssistant( { selectedSite }: ContentTabAssistantProps 
 										/>
 										<AuthenticatedView
 											messages={ messages }
-											isAssistantThinking={ isAssistantThinking }
+											isAssistantThinking={ isAssistantThinking || isThinking }
 											updateMessage={ updateMessage }
 											path={ selectedSite.path }
 											errorMessageId={ errorMessageId }
@@ -319,7 +318,7 @@ export function ContentTabAssistant( { selectedSite }: ContentTabAssistantProps 
 									/>
 									<AuthenticatedView
 										messages={ messages }
-										isAssistantThinking={ isAssistantThinking }
+										isAssistantThinking={ isAssistantThinking || isThinking }
 										updateMessage={ updateMessage }
 										path={ selectedSite.path }
 										errorMessageId={ errorMessageId }

--- a/src/hooks/use-assistant.ts
+++ b/src/hooks/use-assistant.ts
@@ -101,14 +101,29 @@ export const useAssistant = ( instanceId: string ) => {
 		localStorage.removeItem( chatIdStoreKey( instanceId ) );
 	}, [ instanceId ] );
 
+	const removeLocalMessage = useCallback(
+		( id: number ) => {
+			setMessages( ( prevMessages ) => {
+				const updatedMessages = prevMessages.filter( ( message ) => message.id !== id );
+				localStorage.setItem(
+					chatMessagesStoreKey( instanceId ),
+					JSON.stringify( updatedMessages )
+				);
+				return updatedMessages;
+			} );
+		},
+		[ instanceId ]
+	);
+
 	return useMemo(
 		() => ( {
 			messages,
 			addMessage,
 			updateMessage,
 			clearMessages,
+			removeLocalMessage,
 			chatId,
 		} ),
-		[ addMessage, clearMessages, messages, updateMessage, chatId ]
+		[ addMessage, clearMessages, messages, updateMessage, removeLocalMessage, chatId ]
 	);
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Closes: https://github.com/Automattic/dotcom-forge/issues/7668

## Proposed Changes

This PR adds UI to the AI assistant for handling errors when there is a failure in the API request:

<img width="998" alt="Screenshot 2024-06-25 at 2 30 53 PM" src="https://github.com/Automattic/studio/assets/25575134/bb4e0dae-5512-4b6e-b2ba-6d0943c3a53b">

## Testing Instructions

* Pull the changes from this branch locally
* Modify the URL for the API to be invalid in `src/hooks/use-assistant-api.ts` on lines 50-54:

```
						{
							path: '/studio-app/ai-assistant/cht',
							apiNamespace: 'wpcom/v2',
							body,
						},
```
* Navigate to the Assistant tab
* Try sending either a message or use an example prompt
* Observe that error message `Oops! We couldn't get a response from the assistant. Try again` appears
* Click on `Try again` link
* Observe that it attempts to send a message again and the thinking mode is on
* Remove the changes from `src/hooks/use-assistant-api.ts` and confirm that sending a message works as expected and nothing is broken in the usual assistant flow

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
