### PR TITLE
Fix crash when deleting a site

### DIFF
--- a/src/components/assistant-code-block.tsx
+++ b/src/components/assistant-code-block.tsx
@@ -10,10 +10,7 @@ import { ChatMessageProps } from './chat-message';
 import { CopyTextButton } from './copy-text-button';
 import { ExecuteIcon } from './icons/execute';
 
-type ContextProps = Pick<
-	ChatMessageProps,
-	'blocks' | 'updateMessage' | 'projectPath' | 'messageId'
->;
+type ContextProps = Pick< ChatMessageProps, 'blocks' | 'updateMessage' | 'siteId' | 'messageId' >;
 
 type CodeBlockProps = JSX.IntrinsicElements[ 'code' ] & ExtraProps;
 
@@ -24,7 +21,7 @@ export default function createCodeComponent( contextProps: ContextProps ) {
 function CodeBlock( props: ContextProps & CodeBlockProps ) {
 	const content = String( props.children ).trim();
 	const isValidWpCliCommand = useIsValidWpCliInline( content );
-	const { node, blocks, updateMessage, projectPath, messageId, ...htmlAttributes } = props;
+	const { node, blocks, updateMessage, siteId, messageId, ...htmlAttributes } = props;
 	const {
 		cliOutput,
 		cliStatus,
@@ -34,7 +31,7 @@ function CodeBlock( props: ContextProps & CodeBlockProps ) {
 		setCliOutput,
 		setCliStatus,
 		setCliTime,
-	} = useExecuteWPCLI( content, projectPath, updateMessage, messageId );
+	} = useExecuteWPCLI( content, siteId, updateMessage, messageId );
 
 	useEffect( () => {
 		if ( blocks ) {

--- a/src/components/chat-message.tsx
+++ b/src/components/chat-message.tsx
@@ -11,7 +11,6 @@ export interface ChatMessageProps {
 	id: string;
 	messageId?: number;
 	className?: string;
-	projectPath?: string;
 	siteId?: string;
 	blocks?: {
 		cliOutput?: string;
@@ -35,7 +34,7 @@ export const ChatMessage = ( {
 	messageId,
 	isUser,
 	className,
-	projectPath,
+	siteId,
 	blocks,
 	updateMessage,
 	isUnauthenticated,
@@ -73,7 +72,7 @@ export const ChatMessage = ( {
 								code: createCodeComponent( {
 									blocks,
 									messageId,
-									projectPath,
+									siteId,
 									updateMessage,
 								} ),
 								img: () => null,

--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -66,7 +66,7 @@ const AuthenticatedView = memo(
 		messages,
 		isAssistantThinking,
 		updateMessage,
-		path,
+		siteId,
 	}: {
 		messages: MessageType[];
 		isAssistantThinking: boolean;
@@ -77,7 +77,7 @@ const AuthenticatedView = memo(
 			cliStatus: 'success' | 'error',
 			cliTime: string
 		) => void;
-		path: string;
+		siteId: string;
 	} ) => {
 		const endOfMessagesRef = useRef< HTMLDivElement >( null );
 
@@ -98,7 +98,7 @@ const AuthenticatedView = memo(
 						key={ index }
 						id={ `message-chat-${ index }` }
 						isUser={ message.role === 'user' }
-						projectPath={ path }
+						siteId={ siteId }
 						updateMessage={ updateMessage }
 						messageId={ message.id }
 						blocks={ message.blocks }
@@ -239,7 +239,7 @@ export function ContentTabAssistant( { selectedSite }: ContentTabAssistantProps 
 									messages={ messages }
 									isAssistantThinking={ isAssistantThinking }
 									updateMessage={ updateMessage }
-									path={ selectedSite.path }
+									siteId={ selectedSite.id }
 								/>
 							) }
 							<OfflineModeView />
@@ -259,7 +259,7 @@ export function ContentTabAssistant( { selectedSite }: ContentTabAssistantProps 
 											messages={ messages }
 											isAssistantThinking={ isAssistantThinking }
 											updateMessage={ updateMessage }
-											path={ selectedSite.path }
+											siteId={ selectedSite.id }
 										/>
 										<UsageLimitReached />
 									</>
@@ -278,7 +278,7 @@ export function ContentTabAssistant( { selectedSite }: ContentTabAssistantProps 
 										messages={ messages }
 										isAssistantThinking={ isAssistantThinking }
 										updateMessage={ updateMessage }
-										path={ selectedSite.path }
+										siteId={ selectedSite.id }
 									/>
 									<ClearHistoryReminder lastMessage={ lastMessage } clearInput={ clearInput } />
 								</>

--- a/src/hooks/use-execute-cli.ts
+++ b/src/hooks/use-execute-cli.ts
@@ -4,7 +4,7 @@ import { getIpcApi } from '../lib/get-ipc-api';
 
 export function useExecuteWPCLI(
 	content: string,
-	projectPath: string | undefined,
+	siteId: string | undefined,
 	updateMessage:
 		| ( (
 				id: number,
@@ -26,7 +26,7 @@ export function useExecuteWPCLI(
 		const startTime = Date.now();
 		const args = content.split( ' ' ).slice( 1 );
 		const result = await getIpcApi().executeWPCLiInline( {
-			projectPath: projectPath || '',
+			siteId: siteId || '',
 			args: args.join( ' ' ),
 		} );
 
@@ -56,7 +56,7 @@ export function useExecuteWPCLI(
 				);
 			}
 		}, 2300 );
-	}, [ content, messageId, projectPath, updateMessage ] );
+	}, [ content, messageId, siteId, updateMessage ] );
 
 	return {
 		cliOutput,

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -571,8 +571,16 @@ export async function saveOnboarding(
 
 export async function executeWPCLiInline(
 	_event: IpcMainInvokeEvent,
-	{ projectPath, args }: { projectPath: string; args: string }
+	{ siteId, args }: { siteId: string; args: string }
 ) {
+	if ( SiteServer.isDeleted( siteId ) ) {
+		return { stdout: '', stderr: `can't execute command on deleted site ${ siteId }` };
+	}
+	const site = SiteServer.get( siteId );
+	if ( ! site ) {
+		throw new Error( 'Site not found.' );
+	}
+
 	const wpCliArgs = parse( args );
 
 	// The parsing of arguments can include shell operators like `>` or `||` that the app don't support.
@@ -584,7 +592,7 @@ export async function executeWPCLiInline(
 	}
 
 	const process = new WpCliProcess();
-	return await process.execute( projectPath, wpCliArgs as string[] );
+	return await process.execute( site.details.path, wpCliArgs as string[] );
 }
 
 export async function getThumbnailData( _event: IpcMainInvokeEvent, id: string ) {

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -573,7 +573,7 @@ export async function executeWPCLiInline(
 	{ siteId, args }: { siteId: string; args: string }
 ): Promise< WpCliResult > {
 	if ( SiteServer.isDeleted( siteId ) ) {
-		return { stdout: '', stderr: `can't execute command on deleted site ${ siteId }` };
+		return { stdout: '', stderr: `Cannot execute command on deleted site ${ siteId }` };
 	}
 	const server = SiteServer.get( siteId );
 	if ( ! server ) {

--- a/src/lib/site-server-process.ts
+++ b/src/lib/site-server-process.ts
@@ -82,7 +82,7 @@ export default class SiteServerProcess {
 			throw Error( 'Server process is not running' );
 		}
 
-		const messageId = +this.lastMessageId;
+		const messageId = this.lastMessageId++;
 		process.postMessage( { message, messageId, data } );
 		return messageId;
 	}

--- a/src/lib/wp-cli-process.ts
+++ b/src/lib/wp-cli-process.ts
@@ -84,7 +84,7 @@ export default class WpCliProcess {
 		}
 		if ( this.ongoingMessages[ originalMessageId ] ) {
 			throw Error(
-				`The response for message ID ${ originalMessageId } from the message '${ originalMessage }' is already being awaited. Please use the 'waitForResponse' function only once per message ID..`
+				`The 'waitForResponse' function was already called for message ID ${ originalMessageId } from the message '${ originalMessage }'. 'waitForResponse' may only be called once per message ID.`
 			);
 		}
 

--- a/src/lib/wp-cli-process.ts
+++ b/src/lib/wp-cli-process.ts
@@ -68,7 +68,7 @@ export default class WpCliProcess {
 			throw Error( 'wp-cli process is not running' );
 		}
 
-		const messageId = +this.lastMessageId;
+		const messageId = this.lastMessageId++;
 		process.postMessage( { message, messageId, data } );
 		return messageId;
 	}

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -37,7 +37,7 @@ const api: IpcApi = {
 	getThemeDetails: ( id: string ) => ipcRenderer.invoke( 'getThemeDetails', id ),
 	getThumbnailData: ( id: string ) => ipcRenderer.invoke( 'getThumbnailData', id ),
 	getInstalledApps: () => ipcRenderer.invoke( 'getInstalledApps' ),
-	executeWPCLiInline: ( options: { projectPath: string; args: string } ) =>
+	executeWPCLiInline: ( options: { siteId: string; args: string } ) =>
 		ipcRenderer.invoke( 'executeWPCLiInline', options ),
 	getOnboardingData: () => ipcRenderer.invoke( 'getOnboardingData' ),
 	saveOnboarding: ( onboardingCompleted: boolean ) =>

--- a/src/site-server.ts
+++ b/src/site-server.ts
@@ -17,6 +17,7 @@ import { createScreenshotWindow } from './screenshot-window';
 import { getSiteThumbnailPath } from './storage/paths';
 
 const servers = new Map< string, SiteServer >();
+const deletedServers: string[] = [];
 
 export async function createSiteWorkingDirectory(
 	path: string,
@@ -48,6 +49,10 @@ export class SiteServer {
 		return servers.get( id );
 	}
 
+	static isDeleted( id: string ) {
+		return deletedServers.includes( id );
+	}
+
 	static create( details: StoppedSiteDetails ): SiteServer {
 		const server = new SiteServer( details );
 		servers.set( details.id, server );
@@ -60,6 +65,7 @@ export class SiteServer {
 			await fs.promises.unlink( thumbnailPath );
 		}
 		await this.stop();
+		deletedServers.push( this.details.id );
 		servers.delete( this.details.id );
 		portFinder.releasePort( this.details.port );
 	}

--- a/src/site-server.ts
+++ b/src/site-server.ts
@@ -175,7 +175,7 @@ export class SiteServer {
 			( arg: unknown ) => typeof arg === 'string' || arg instanceof String
 		);
 		if ( ! isValidCommand ) {
-			throw Error( `Can't execute wp-cli command with arguments: ${ args }` );
+			throw Error( `Cannot execute wp-cli command with arguments: ${ args }` );
 		}
 
 		try {

--- a/src/site-server.ts
+++ b/src/site-server.ts
@@ -13,7 +13,7 @@ import { portFinder } from './lib/port-finder';
 import { sanitizeForLogging } from './lib/sanitize-for-logging';
 import { getPreferredSiteLanguage } from './lib/site-language';
 import SiteServerProcess from './lib/site-server-process';
-import WpCliProcess, { WpCliResult } from './lib/wp-cli-process';
+import WpCliProcess, { MessageCanceled, WpCliResult } from './lib/wp-cli-process';
 import { purgeWpConfig } from './lib/wp-versions';
 import { createScreenshotWindow } from './screenshot-window';
 import { getSiteThumbnailPath } from './storage/paths';
@@ -181,6 +181,10 @@ export class SiteServer {
 		try {
 			return await this.wpCliExecutor.execute( wpCliArgs as string[] );
 		} catch ( error ) {
+			if ( ( error as MessageCanceled )?.canceled ) {
+				return { stdout: '', stderr: 'wp-cli command canceled' };
+			}
+
 			Sentry.captureException( error );
 			return { stdout: '', stderr: 'error when executing wp-cli command' };
 		}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Fixes 7907-gh-Automattic/dotcom-forge.

## Proposed Changes

This PR aims to solve two cases related to executing `wp-cli` commands at the same time a site is being deleted:

- **Problem: Try to mount a PHP instance on a deleted site.**
  - Solution: Identify deleted sites and avoid running the command if the site is deleted.
  - Changes:
    - Add a list of deleted sites to determine when a site has been deleted. Note that this list won't persist across sessions.
    - Since the project path is not a unique value, we need to use site ID as the key for the deleted list when executing commands.
- **Problem: If a command is executed and the site is deleted, the file deletion makes `wp-cli` fail due to the inability to access site files.**
  - Solution: Cancel `wp-cli` processes before deleting the site.
  - Changes:
    - Attach `wp-cli` process to sites. This way we can kill the process before deletion.
    - To simplify the process, we'll instantiate the process per site. This implies refactoring `wp-cli` process.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Preparation:**
- Apply the following patch to log `wp-cli` commands:
```patch
diff --git forkSrcPrefix/src/ipc-handlers.ts forkDstPrefix/src/ipc-handlers.ts
index 3a48313ca9401d63e2608fb2f22a254a1d5802cb..0401b67bb315d7287714b631e7c8683e7d0b0325 100644
--- forkSrcPrefix/src/ipc-handlers.ts
+++ forkDstPrefix/src/ipc-handlers.ts
@@ -573,6 +573,7 @@ export async function executeWPCLiInline(
 	{ siteId, args }: { siteId: string; args: string }
 ): Promise< WpCliResult > {
 	if ( SiteServer.isDeleted( siteId ) ) {
+		console.log( '==== skipping wp-cli command because site is deleted', siteId, args );
 		return { stdout: '', stderr: `can't execute command on deleted site ${ siteId }` };
 	}
 	const server = SiteServer.get( siteId );
diff --git forkSrcPrefix/src/site-server.ts forkDstPrefix/src/site-server.ts
index 2c82b755e1550e455fd5cb628361352bfe8975ee..f94d193f3050e34c5c5c8612e242c182f9622ace 100644
--- forkSrcPrefix/src/site-server.ts
+++ forkDstPrefix/src/site-server.ts
@@ -179,9 +179,13 @@ export class SiteServer {
 		}
 
 		try {
-			return await this.wpCliExecutor.execute( wpCliArgs as string[] );
+			console.log( '==== executing wp-cli command', args );
+			const response = await this.wpCliExecutor.execute( wpCliArgs as string[] );
+			console.log( '==== response wp-cli command', response );
+			return response;
 		} catch ( error ) {
 			if ( ( error as MessageCanceled )?.canceled ) {
+				console.log( '==== wp-cli command canceled', args );
 				return { stdout: '', stderr: 'wp-cli command canceled' };
 			}
 

```

### Chat context fetches plugins and themes
- Open the app.
- Observe that `wp-cli` command `plugin list` is executed successfully for the default selected site.
- Observe that `wp-cli` command `theme list` is executed successfully for the default selected site.
- Add a site or start a site.
- Switch to another app and focus on the Studio again to make the app gain focus.
- Observe that `wp-cli` command `plugin list` is executed successfully for the default selected site.
- Observe that `wp-cli` command `theme list` is executed successfully for the default selected site.

### Delete running site doesn't crash
- Open the app.
- Add a site or start a site.
- Navigate to the Settings tab.
- Click on Delete a site.
- Check Delete site files from my computer.
- Click Delete site.
- Observe the site is deleted and no crash happens.
- Observe that `wp-cli` command `plugin list` is invoked but canceled.
- Observe that `wp-cli` command `theme list` is skipped because the site is deleted.

### Check open processes
- Open the Activity Monitor app on macOS (or an application to list currently running processes).
- Filter by the text `electron`.
- Open the app.
- Observe that there are only two processes with the name Electron Helper.
- Add a site or start a site.
- Observe two new Electron Helper processes are created. One is the site server and the other one is `wp-cli` executor.
- Stop the site.
- Observe one of the Electron Helper processes is removed.
- Delete the site.
- Observe one of the Electron Helper processes is removed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
