### PR TITLE
test: Assert Assistant code block

### DIFF
--- a/jest-setup.ts
+++ b/jest-setup.ts
@@ -34,8 +34,4 @@ jest.mock( './src/hooks/use-offline', () => ( {
 	useOffline: jest.fn().mockReturnValue( false ),
 } ) );
 
-jest.mock( 'strip-ansi', () => ( {
-	default: jest.fn().mockImplementation( ( str: string ) => str ),
-} ) );
-
 global.ResizeObserver = require( 'resize-observer-polyfill' );

--- a/src/__mocks__/strip-ansi.ts
+++ b/src/__mocks__/strip-ansi.ts
@@ -1,0 +1,3 @@
+export default function stripAnsi( str: string ) {
+	return str;
+}

--- a/src/components/assistant-code-block.tsx
+++ b/src/components/assistant-code-block.tsx
@@ -48,7 +48,7 @@ function CodeBlock( props: ContextProps & CodeBlockProps ) {
 				setCliTime( block?.cliTime ?? null );
 			}
 		}
-	}, [ cliOutput, content, setCliOutput, setCliStatus, setCliTime ] );
+	}, [ blocks, cliOutput, content, setCliOutput, setCliStatus, setCliTime ] );
 
 	const { children, className } = props;
 	const match = /language-(\w+)/.exec( className || '' );

--- a/src/components/assistant-code-block.tsx
+++ b/src/components/assistant-code-block.tsx
@@ -1,0 +1,121 @@
+import { Spinner } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useEffect } from 'react';
+import { ExtraProps } from 'react-markdown';
+import stripAnsi from 'strip-ansi';
+import { useExecuteWPCLI } from '../hooks/use-execute-cli';
+import Button from './button';
+import { ChatMessageProps } from './chat-message';
+import { CopyTextButton } from './copy-text-button';
+import { ExecuteIcon } from './icons/execute';
+
+type ContextProps = Pick<
+	ChatMessageProps,
+	'blocks' | 'updateMessage' | 'projectPath' | 'messageId'
+>;
+
+type CodeBlockProps = JSX.IntrinsicElements[ 'code' ] & ExtraProps;
+
+export default function createCodeComponent( contextProps: ContextProps ) {
+	return ( props: CodeBlockProps ) => <CodeBlock { ...contextProps } { ...props } />;
+}
+
+function CodeBlock( props: ContextProps & CodeBlockProps ) {
+	const content = String( props.children ).trim();
+	const containsWPCommand = /\bwp\s/.test( content );
+	const wpCommandCount = ( content.match( /\bwp\s/g ) || [] ).length;
+	const containsSingleWPCommand = wpCommandCount === 1;
+	const containsAngleBrackets = /<.*>/.test( content );
+
+	const { node, blocks, updateMessage, projectPath, messageId, ...htmlAttributes } = props;
+	const {
+		cliOutput,
+		cliStatus,
+		cliTime,
+		isRunning,
+		handleExecute,
+		setCliOutput,
+		setCliStatus,
+		setCliTime,
+	} = useExecuteWPCLI( content, projectPath, updateMessage, messageId );
+
+	useEffect( () => {
+		if ( blocks ) {
+			const block = blocks?.find( ( block ) => block.codeBlockContent === content );
+			if ( block ) {
+				setCliOutput( block?.cliOutput ? stripAnsi( block.cliOutput ) : null );
+				setCliStatus( block?.cliStatus ?? null );
+				setCliTime( block?.cliTime ?? null );
+			}
+		}
+	}, [ cliOutput, content, setCliOutput, setCliStatus, setCliTime ] );
+
+	const { children, className } = props;
+	const match = /language-(\w+)/.exec( className || '' );
+	return match ? (
+		<>
+			<div className="p-3">
+				<code className={ className } { ...htmlAttributes }>
+					{ children }
+				</code>
+			</div>
+			<div className="p-3 pt-1 flex justify-start items-center">
+				<CopyTextButton
+					text={ content }
+					label={ __( 'Copy' ) }
+					copyConfirmation={ __( 'Copied!' ) }
+					showText={ true }
+					variant="outlined"
+					className="h-auto mr-2 !px-2.5 py-0.5 !p-[6px] font-sans select-none"
+					iconSize={ 16 }
+				></CopyTextButton>
+				{ containsWPCommand && containsSingleWPCommand && ! containsAngleBrackets && (
+					<Button
+						icon={ <ExecuteIcon /> }
+						onClick={ handleExecute }
+						disabled={ isRunning }
+						variant="outlined"
+						className="h-auto mr-2 !px-2.5 py-0.5 font-sans select-none"
+					>
+						{ cliOutput ? __( 'Run again' ) : __( 'Run' ) }
+					</Button>
+				) }
+			</div>
+			{ isRunning && (
+				<div className="p-3 flex justify-start items-center bg-[#2D3337] text-white">
+					<Spinner className="!text-white [&>circle]:stroke-a8c-gray-60" />
+					<span className="ml-2 font-sans">{ __( 'Running...' ) }</span>
+				</div>
+			) }
+			{ ! isRunning && cliOutput && cliStatus && (
+				<InlineCLI output={ cliOutput } status={ cliStatus } time={ cliTime } />
+			) }
+		</>
+	) : (
+		<code className={ className } { ...htmlAttributes }>
+			{ children }
+		</code>
+	);
+}
+
+interface InlineCLIProps {
+	output?: string;
+	status?: 'success' | 'error';
+	time?: string | null;
+}
+
+function InlineCLI( { output, status, time }: InlineCLIProps ) {
+	return (
+		<div className="p-3 bg-[#2D3337]">
+			<div className="flex justify-between mb-2 font-sans">
+				<span className={ status === 'success' ? 'text-[#63CE68]' : 'text-[#E66D6C]' }>
+					{ status === 'success' ? __( 'Success' ) : __( 'Error' ) }
+				</span>
+				<span className="text-gray-400">{ time }</span>
+			</div>
+			<pre className="text-white !bg-transparent !m-0 !px-0">
+				<code className="!bg-transparent !mx-0 !px-0 !text-nowrap">{ output }</code>
+			</pre>
+		</div>
+	);
+}

--- a/src/components/chat-message.tsx
+++ b/src/components/chat-message.tsx
@@ -1,20 +1,14 @@
 import * as Sentry from '@sentry/react';
 import { speak } from '@wordpress/a11y';
-import { Spinner } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useEffect } from 'react';
 import Markdown, { ExtraProps } from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import stripAnsi from 'strip-ansi';
-import { useExecuteWPCLI } from '../hooks/use-execute-cli';
 import { useSiteDetails } from '../hooks/use-site-details';
 import { cx } from '../lib/cx';
 import { getIpcApi } from '../lib/get-ipc-api';
-import Button from './button';
-import { CopyTextButton } from './copy-text-button';
-import { ExecuteIcon } from './icons/execute';
+import createCodeComponent from './assistant-code-block';
 
-interface ChatMessageProps {
+export interface ChatMessageProps {
 	children: React.ReactNode;
 	isUser: boolean;
 	id: string;
@@ -38,26 +32,6 @@ interface ChatMessageProps {
 	isUnauthenticated?: boolean;
 }
 
-interface InlineCLIProps {
-	output?: string;
-	status?: 'success' | 'error';
-	time?: string | null;
-}
-
-const InlineCLI = ( { output, status, time }: InlineCLIProps ) => (
-	<div className="p-3 bg-[#2D3337]">
-		<div className="flex justify-between mb-2 font-sans">
-			<span className={ status === 'success' ? 'text-[#63CE68]' : 'text-[#E66D6C]' }>
-				{ status === 'success' ? __( 'Success' ) : __( 'Error' ) }
-			</span>
-			<span className="text-gray-400">{ time }</span>
-		</div>
-		<pre className="text-white !bg-transparent !m-0 !px-0">
-			<code className="!bg-transparent !mx-0 !px-0 !text-nowrap">{ output }</code>
-		</pre>
-	</div>
-);
-
 export const ChatMessage = ( {
 	children,
 	id,
@@ -69,84 +43,6 @@ export const ChatMessage = ( {
 	updateMessage,
 	isUnauthenticated,
 }: ChatMessageProps ) => {
-	const CodeBlock = ( props: JSX.IntrinsicElements[ 'code' ] & ExtraProps ) => {
-		const content = String( props.children ).trim();
-		const containsWPCommand = /\bwp\s/.test( content );
-		const wpCommandCount = ( content.match( /\bwp\s/g ) || [] ).length;
-		const containsSingleWPCommand = wpCommandCount === 1;
-		const containsAngleBrackets = /<.*>/.test( content );
-
-		const {
-			cliOutput,
-			cliStatus,
-			cliTime,
-			isRunning,
-			handleExecute,
-			setCliOutput,
-			setCliStatus,
-			setCliTime,
-		} = useExecuteWPCLI( content, projectPath, updateMessage, messageId );
-
-		useEffect( () => {
-			if ( blocks ) {
-				const block = blocks?.find( ( block ) => block.codeBlockContent === content );
-				if ( block ) {
-					setCliOutput( block?.cliOutput ? stripAnsi( block.cliOutput ) : null );
-					setCliStatus( block?.cliStatus ?? null );
-					setCliTime( block?.cliTime ?? null );
-				}
-			}
-		}, [ cliOutput, content, setCliOutput, setCliStatus, setCliTime ] );
-
-		const { children, className } = props;
-		const match = /language-(\w+)/.exec( className || '' );
-		const { node, ...propsSansNode } = props;
-		return match ? (
-			<>
-				<div className="p-3">
-					<code className={ className } { ...propsSansNode }>
-						{ children }
-					</code>
-				</div>
-				<div className="p-3 pt-1 flex justify-start items-center">
-					<CopyTextButton
-						text={ content }
-						label={ __( 'Copy' ) }
-						copyConfirmation={ __( 'Copied!' ) }
-						showText={ true }
-						variant="outlined"
-						className="h-auto mr-2 !px-2.5 py-0.5 !p-[6px] font-sans select-none"
-						iconSize={ 16 }
-					></CopyTextButton>
-					{ containsWPCommand && containsSingleWPCommand && ! containsAngleBrackets && (
-						<Button
-							icon={ <ExecuteIcon /> }
-							onClick={ handleExecute }
-							disabled={ isRunning }
-							variant="outlined"
-							className="h-auto mr-2 !px-2.5 py-0.5 font-sans select-none"
-						>
-							{ cliOutput ? __( 'Run again' ) : __( 'Run' ) }
-						</Button>
-					) }
-				</div>
-				{ isRunning && (
-					<div className="p-3 flex justify-start items-center bg-[#2D3337] text-white">
-						<Spinner className="!text-white [&>circle]:stroke-a8c-gray-60" />
-						<span className="ml-2 font-sans">{ __( 'Running...' ) }</span>
-					</div>
-				) }
-				{ ! isRunning && cliOutput && cliStatus && (
-					<InlineCLI output={ cliOutput } status={ cliStatus } time={ cliTime } />
-				) }
-			</>
-		) : (
-			<code className={ className } { ...propsSansNode }>
-				{ children }
-			</code>
-		);
-	};
-
 	return (
 		<div
 			className={ cx(
@@ -173,7 +69,16 @@ export const ChatMessage = ( {
 				{ typeof children === 'string' ? (
 					<div className="assistant-markdown">
 						<Markdown
-							components={ { a: Anchor, code: CodeBlock, img: () => null } }
+							components={ {
+								a: Anchor,
+								code: createCodeComponent( {
+									blocks,
+									messageId,
+									projectPath,
+									updateMessage,
+								} ),
+								img: () => null,
+							} }
 							remarkPlugins={ [ remarkGfm ] }
 						>
 							{ children }

--- a/src/components/tests/assistant-code-block.test.tsx
+++ b/src/components/tests/assistant-code-block.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/react';
+import createCodeComponent from '../assistant-code-block';
+
+describe( 'createCodeComponent', () => {
+	const contextProps = {
+		blocks: [],
+		updateMessage: jest.fn(),
+		projectPath: '/path/to/project',
+		messageId: 1,
+	};
+
+	const CodeBlock = createCodeComponent( contextProps );
+
+	it( 'should display a "copy" button for language-specific code', () => {
+		render( <CodeBlock className="language-bash" children="wp --version" /> );
+
+		expect( screen.getByText( 'Copy' ) ).toBeInTheDocument();
+	} );
+} );

--- a/src/components/tests/assistant-code-block.test.tsx
+++ b/src/components/tests/assistant-code-block.test.tsx
@@ -11,6 +11,14 @@ describe( 'createCodeComponent', () => {
 
 	const CodeBlock = createCodeComponent( contextProps );
 
+	it( 'should render inline styles for language-generic code', () => {
+		render( <CodeBlock children="example-code" /> );
+
+		expect( screen.getByText( 'example-code' ) ).toBeInTheDocument();
+		expect( screen.queryByText( 'Copy' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Run' ) ).not.toBeInTheDocument();
+	} );
+
 	it( 'should display a "copy" button for language-specific code', () => {
 		render( <CodeBlock className="language-bash" children="wp --version" /> );
 

--- a/src/components/tests/assistant-code-block.test.tsx
+++ b/src/components/tests/assistant-code-block.test.tsx
@@ -108,4 +108,18 @@ describe( 'createCodeComponent', () => {
 			expect( screen.getByText( 'Mock error' ) ).toBeInTheDocument();
 		} );
 	} );
+
+	describe( 'when the "copy" button is clicked', () => {
+		it( 'should copy the code content to the clipboard', async () => {
+			const mockCopyText = jest.fn();
+			( getIpcApi as jest.Mock ).mockReturnValue( {
+				copyText: mockCopyText,
+			} );
+			render( <CodeBlock className="language-bash" children="wp --version" /> );
+
+			fireEvent.click( screen.getByText( 'Copy' ) );
+
+			expect( mockCopyText ).toHaveBeenCalledWith( 'wp --version' );
+		} );
+	} );
 } );

--- a/src/components/tests/assistant-code-block.test.tsx
+++ b/src/components/tests/assistant-code-block.test.tsx
@@ -11,7 +11,6 @@ describe( 'createCodeComponent', () => {
 		projectPath: '/path/to/project',
 		messageId: 1,
 	};
-
 	const CodeBlock = createCodeComponent( contextProps );
 
 	it( 'should render inline styles for language-generic code', () => {
@@ -120,6 +119,29 @@ describe( 'createCodeComponent', () => {
 			fireEvent.click( screen.getByText( 'Copy' ) );
 
 			expect( mockCopyText ).toHaveBeenCalledWith( 'wp --version' );
+		} );
+	} );
+
+	describe( 'when past block execution output is present', () => {
+		it( 'should display the output of the previously executed code', async () => {
+			const contextProps = {
+				blocks: [
+					{
+						codeBlockContent: 'wp --version',
+						cliOutput: 'Mock success',
+						cliStatus: 'success' as const,
+						cliTime: '2.3s',
+					},
+				],
+				updateMessage: jest.fn(),
+				projectPath: '/path/to/project',
+				messageId: 1,
+			};
+			const CodeBlock = createCodeComponent( contextProps );
+			render( <CodeBlock className="language-bash" children="wp --version" /> );
+
+			expect( screen.getByText( 'Success' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Mock success' ) ).toBeInTheDocument();
 		} );
 	} );
 } );

--- a/src/components/tests/assistant-code-block.test.tsx
+++ b/src/components/tests/assistant-code-block.test.tsx
@@ -27,13 +27,13 @@ describe( 'createCodeComponent', () => {
 		expect( screen.getByText( 'Copy' ) ).toBeInTheDocument();
 	} );
 
-	it( 'should display the "run" button for elligble wp-cli commands without placeholder content', () => {
+	it( 'should display the "run" button for eligible wp-cli commands without placeholder content', () => {
 		render( <CodeBlock className="language-bash" children="wp --version" /> );
 
 		expect( screen.getByText( 'Run' ) ).toBeInTheDocument();
 	} );
 
-	it( 'should hide the "run" button for inellible non-wp-cli code', () => {
+	it( 'should hide the "run" button for ineligible non-wp-cli code', () => {
 		render(
 			<CodeBlock className="language-bash" children="wp plugin activate <example-plugin>" />
 		);
@@ -41,7 +41,7 @@ describe( 'createCodeComponent', () => {
 		expect( screen.queryByText( 'Run' ) ).not.toBeInTheDocument();
 	} );
 
-	it( 'should hide the "run" button for inellible wp-cli commands with placeholder content', () => {
+	it( 'should hide the "run" button for ineligible wp-cli commands with placeholder content', () => {
 		render(
 			<CodeBlock className="language-bash" children="wp plugin activate <example-plugin>" />
 		);
@@ -49,7 +49,7 @@ describe( 'createCodeComponent', () => {
 		expect( screen.queryByText( 'Run' ) ).not.toBeInTheDocument();
 	} );
 
-	it( 'should hide the "run" button for inellible wp-cli commands with multiple wp-cli invocations', () => {
+	it( 'should hide the "run" button for ineligible wp-cli commands with multiple wp-cli invocations', () => {
 		render( <CodeBlock className="language-bash" children="wp --version wp --version" /> );
 
 		expect( screen.queryByText( 'Run' ) ).not.toBeInTheDocument();

--- a/src/components/tests/assistant-code-block.test.tsx
+++ b/src/components/tests/assistant-code-block.test.tsx
@@ -34,9 +34,7 @@ describe( 'createCodeComponent', () => {
 	} );
 
 	it( 'should hide the "run" button for ineligible non-wp-cli code', () => {
-		render(
-			<CodeBlock className="language-bash" children="wp plugin activate <example-plugin>" />
-		);
+		render( <CodeBlock className="language-bash" children="echo 'Hello, World!'" /> );
 
 		expect( screen.queryByText( 'Run' ) ).not.toBeInTheDocument();
 	} );

--- a/src/components/tests/assistant-code-block.test.tsx
+++ b/src/components/tests/assistant-code-block.test.tsx
@@ -16,4 +16,32 @@ describe( 'createCodeComponent', () => {
 
 		expect( screen.getByText( 'Copy' ) ).toBeInTheDocument();
 	} );
+
+	it( 'should display the "run" button for elligble wp-cli commands without placeholder content', () => {
+		render( <CodeBlock className="language-bash" children="wp --version" /> );
+
+		expect( screen.getByText( 'Run' ) ).toBeInTheDocument();
+	} );
+
+	it( 'should hide the "run" button for inellible non-wp-cli code', () => {
+		render(
+			<CodeBlock className="language-bash" children="wp plugin activate <example-plugin>" />
+		);
+
+		expect( screen.queryByText( 'Run' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'should hide the "run" button for inellible wp-cli commands with placeholder content', () => {
+		render(
+			<CodeBlock className="language-bash" children="wp plugin activate <example-plugin>" />
+		);
+
+		expect( screen.queryByText( 'Run' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'should hide the "run" button for inellible wp-cli commands with multiple wp-cli invocations', () => {
+		render( <CodeBlock className="language-bash" children="wp --version wp --version" /> );
+
+		expect( screen.queryByText( 'Run' ) ).not.toBeInTheDocument();
+	} );
 } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/7698.

## Proposed Changes

Refactor the Assistant code block to a separate file to enable automated tests.
This is required as we currently mock `react-markdown` due to its [ESM-only
build](https://github.com/Automattic/studio/pull/261#issuecomment-2173693691).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

N/A, no user-facing changes.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
