### PR TITLE
Change `toBeInTheDocument` assertions in unit tests with `toBeVisible`

### DIFF
--- a/src/components/tests/add-site.test.tsx
+++ b/src/components/tests/add-site.test.tsx
@@ -156,16 +156,16 @@ describe( 'AddSite', () => {
 		await user.click( screen.getByDisplayValue( 'My WordPress Website' ) );
 		await user.type( screen.getByDisplayValue( 'My WordPress Website' ), ' mutated' );
 
-		expect( screen.getByDisplayValue( 'My WordPress Website mutated' ) ).toBeInTheDocument();
+		expect( screen.getByDisplayValue( 'My WordPress Website mutated' ) ).toBeVisible();
 		expect(
 			screen.getByDisplayValue( '/default_path/my-wordpress-website-mutated' )
-		).toBeInTheDocument();
+		).toBeVisible();
 
 		await userEvent.keyboard( '{Escape}' );
 		await user.click( screen.getByRole( 'button', { name: 'Add site' } ) );
 
-		expect( screen.getByDisplayValue( 'My WordPress Website' ) ).toBeInTheDocument();
-		expect( screen.getByDisplayValue( '/default_path/my-wordpress-website' ) ).toBeInTheDocument();
+		expect( screen.getByDisplayValue( 'My WordPress Website' ) ).toBeVisible();
+		expect( screen.getByDisplayValue( '/default_path/my-wordpress-website' ) ).toBeVisible();
 	} );
 
 	it( 'should reset to the proposed path when the path is set to default app directory', async () => {
@@ -203,7 +203,7 @@ describe( 'AddSite', () => {
 
 		expect(
 			screen.getByDisplayValue( '/default_path/my-wordpress-website-mutated' )
-		).toBeInTheDocument();
+		).toBeVisible();
 	} );
 
 	it( 'should display a helpful error message when an error occurs while creating the site', async () => {

--- a/src/components/tests/ai-clear-history-reminder.test.tsx
+++ b/src/components/tests/ai-clear-history-reminder.test.tsx
@@ -31,7 +31,7 @@ describe( 'AIClearHistoryReminder', () => {
 		};
 		render( <AIClearHistoryReminder lastMessage={ message } clearInput={ clearInput } /> );
 
-		expect( screen.getByText( /This conversation is over two hours old./ ) ).toBeInTheDocument();
+		expect( screen.getByText( /This conversation is over two hours old./ ) ).toBeVisible();
 	} );
 
 	it( 'should warn then clear conversations', async () => {

--- a/src/components/tests/ai-input.test.tsx
+++ b/src/components/tests/ai-input.test.tsx
@@ -51,7 +51,7 @@ describe( 'AIInput Component', () => {
 	} );
 
 	it( 'renders the component', () => {
-		expect( screen.getByTestId( 'ai-input-textarea' ) ).toBeInTheDocument();
+		expect( screen.getByTestId( 'ai-input-textarea' ) ).toBeVisible();
 	} );
 
 	it( 'focuses on the textarea when not disabled', () => {

--- a/src/components/tests/assistant-code-block.test.tsx
+++ b/src/components/tests/assistant-code-block.test.tsx
@@ -16,7 +16,7 @@ describe( 'createCodeComponent', () => {
 	it( 'should render inline styles for language-generic code', () => {
 		render( <CodeBlock children="example-code" /> );
 
-		expect( screen.getByText( 'example-code' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'example-code' ) ).toBeVisible();
 		expect( screen.queryByText( 'Copy' ) ).not.toBeInTheDocument();
 		expect( screen.queryByText( 'Run' ) ).not.toBeInTheDocument();
 	} );
@@ -24,13 +24,13 @@ describe( 'createCodeComponent', () => {
 	it( 'should display a "copy" button for language-specific code', () => {
 		render( <CodeBlock className="language-bash" children="wp --version" /> );
 
-		expect( screen.getByText( 'Copy' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Copy' ) ).toBeVisible();
 	} );
 
 	it( 'should display the "run" button for eligible wp-cli commands without placeholder content', () => {
 		render( <CodeBlock className="language-bash" children="wp --version" /> );
 
-		expect( screen.getByText( 'Run' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Run' ) ).toBeVisible();
 	} );
 
 	it( 'should hide the "run" button for ineligible non-wp-cli code', () => {
@@ -67,7 +67,7 @@ describe( 'createCodeComponent', () => {
 
 			fireEvent.click( screen.getByText( 'Run' ) );
 
-			expect( screen.getByText( 'Running...' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Running...' ) ).toBeVisible();
 
 			// Run code execution measurement timer
 			await act( () => jest.runAllTimersAsync() );
@@ -86,8 +86,8 @@ describe( 'createCodeComponent', () => {
 			// Run code execution measurement timer
 			await act( () => jest.runAllTimersAsync() );
 
-			expect( screen.getByText( 'Success' ) ).toBeInTheDocument();
-			expect( screen.getByText( 'Mock success' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Success' ) ).toBeVisible();
+			expect( screen.getByText( 'Mock success' ) ).toBeVisible();
 		} );
 
 		it( 'should display the output of the failed code execution', async () => {
@@ -101,8 +101,8 @@ describe( 'createCodeComponent', () => {
 			// Run code execution measurement timer
 			await act( () => jest.runAllTimersAsync() );
 
-			expect( screen.getByText( 'Error' ) ).toBeInTheDocument();
-			expect( screen.getByText( 'Mock error' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Error' ) ).toBeVisible();
+			expect( screen.getByText( 'Mock error' ) ).toBeVisible();
 		} );
 	} );
 
@@ -138,8 +138,8 @@ describe( 'createCodeComponent', () => {
 			const CodeBlock = createCodeComponent( contextProps );
 			render( <CodeBlock className="language-bash" children="wp --version" /> );
 
-			expect( screen.getByText( 'Success' ) ).toBeInTheDocument();
-			expect( screen.getByText( 'Mock success' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Success' ) ).toBeVisible();
+			expect( screen.getByText( 'Mock success' ) ).toBeVisible();
 		} );
 	} );
 } );

--- a/src/components/tests/content-tab-assistant.test.tsx
+++ b/src/components/tests/content-tab-assistant.test.tsx
@@ -96,7 +96,7 @@ describe( 'ContentTabAssistant', () => {
 	test( 'renders guideline section', () => {
 		render( <ContentTabAssistant selectedSite={ runningSite } /> );
 		const guideLines = getGuidelinesLink();
-		expect( guideLines ).toBeInTheDocument();
+		expect( guideLines ).toBeVisible();
 		expect( guideLines ).toHaveTextContent( 'Powered by experimental AI. Learn more' );
 	} );
 
@@ -207,28 +207,28 @@ describe( 'ContentTabAssistant', () => {
 	test( 'renders Welcome messages and example prompts when the conversation is starte', () => {
 		render( <ContentTabAssistant selectedSite={ runningSite } /> );
 		expect( mockFetchWelcomeMessages ).toHaveBeenCalledTimes( 1 );
-		expect( screen.getByText( 'Welcome to our service!' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'How to create a WordPress site' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'How to clear cache' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'How to install a plugin' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Welcome to our service!' ) ).toBeVisible();
+		expect( screen.getByText( 'How to create a WordPress site' ) ).toBeVisible();
+		expect( screen.getByText( 'How to clear cache' ) ).toBeVisible();
+		expect( screen.getByText( 'How to install a plugin' ) ).toBeVisible();
 	} );
 
 	test( 'renders the selected prompt of Welcome messages and confirms other prompts are removed', async () => {
 		render( <ContentTabAssistant selectedSite={ runningSite } /> );
 
-		expect( screen.getByText( 'Welcome to our service!' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'How to create a WordPress site' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'How to install a plugin' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Welcome to our service!' ) ).toBeVisible();
+		expect( screen.getByText( 'How to create a WordPress site' ) ).toBeVisible();
+		expect( screen.getByText( 'How to install a plugin' ) ).toBeVisible();
 
 		const samplePrompt = await screen.findByRole( 'button', {
 			name: 'How to create a WordPress site',
 		} );
-		expect( samplePrompt ).toBeInTheDocument();
+		expect( samplePrompt ).toBeVisible();
 		fireEvent.click( samplePrompt );
 
 		// Check if the selected prompt is still present and other prompts are removed
-		expect( screen.getByText( 'Welcome to our service!' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'How to create a WordPress site' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Welcome to our service!' ) ).toBeVisible();
+		expect( screen.getByText( 'How to create a WordPress site' ) ).toBeVisible();
 		expect( screen.queryByText( 'How to clear cache' ) ).not.toBeInTheDocument();
 		expect( screen.queryByText( 'How to install a plugin' ) ).not.toBeInTheDocument();
 	} );

--- a/src/components/tests/content-tab-assistant.test.tsx
+++ b/src/components/tests/content-tab-assistant.test.tsx
@@ -88,7 +88,7 @@ describe( 'ContentTabAssistant', () => {
 	test( 'renders placeholder text input', () => {
 		render( <ContentTabAssistant selectedSite={ runningSite } /> );
 		const textInput = getInput();
-		expect( textInput ).toBeInTheDocument();
+		expect( textInput ).toBeVisible();
 		expect( textInput ).toBeEnabled();
 		expect( textInput.placeholder ).toBe( 'What would you like to learn?' );
 	} );
@@ -104,12 +104,12 @@ describe( 'ContentTabAssistant', () => {
 		const storageKey = `ai_chat_messages_${ runningSite.id }`;
 		localStorage.setItem( storageKey, JSON.stringify( initialMessages ) );
 		render( <ContentTabAssistant selectedSite={ runningSite } /> );
-		expect( screen.getByText( 'Initial message 1' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Initial message 2' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Initial message 1' ) ).toBeVisible();
+		expect( screen.getByText( 'Initial message 2' ) ).toBeVisible();
 		const textInput = getInput();
 		fireEvent.change( textInput, { target: { value: 'New message' } } );
 		fireEvent.keyDown( textInput, { key: 'Enter', code: 'Enter' } );
-		expect( screen.getByText( 'New message' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'New message' ) ).toBeVisible();
 		await waitFor( () => {
 			const storedMessages = JSON.parse( localStorage.getItem( storageKey ) || '[]' );
 			expect( storedMessages ).toHaveLength( 3 );
@@ -128,10 +128,10 @@ describe( 'ContentTabAssistant', () => {
 			authenticate,
 		} ) );
 		render( <ContentTabAssistant selectedSite={ runningSite } /> );
-		expect( screen.getByText( 'Hold up!' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Hold up!' ) ).toBeVisible();
 		expect(
 			screen.getByText( 'You need to log in to your WordPress.com account to use the assistant.' )
-		).toBeInTheDocument();
+		).toBeVisible();
 	} );
 
 	test( 'allows authentication from Assistant chat', () => {
@@ -146,7 +146,7 @@ describe( 'ContentTabAssistant', () => {
 		} ) );
 		render( <ContentTabAssistant selectedSite={ runningSite } /> );
 		const loginButton = screen.getByRole( 'button', { name: 'Log in to WordPress.com' } );
-		expect( loginButton ).toBeInTheDocument();
+		expect( loginButton ).toBeVisible();
 		fireEvent.click( loginButton );
 		expect( authenticate ).toHaveBeenCalledTimes( 1 );
 	} );

--- a/src/components/tests/content-tab-settings.test.tsx
+++ b/src/components/tests/content-tab-settings.test.tsx
@@ -47,15 +47,15 @@ describe( 'ContentTabSettings', () => {
 	test( 'renders site details correctly', () => {
 		render( <ContentTabSettings selectedSite={ selectedSite } /> );
 
-		expect( screen.getByRole( 'heading', { name: 'Site details' } ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Test Site' ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'heading', { name: 'Site details' } ) ).toBeVisible();
+		expect( screen.getByText( 'Test Site' ) ).toBeVisible();
 		expect(
 			screen.getByRole( 'button', { name: 'localhost:8881, Copy site url to clipboard' } )
 		).toHaveTextContent( 'localhost:8881' );
 		expect(
 			screen.getByRole( 'button', { name: '/path/to/site, Open local path' } )
-		).toBeInTheDocument();
-		expect( screen.getByText( '7.7.7' ) ).toBeInTheDocument();
+		).toBeVisible();
+		expect( screen.getByText( '7.7.7' ) ).toBeVisible();
 		expect(
 			screen.getByRole( 'button', {
 				name: 'localhost:8881/wp-admin, Copy wp-admin url to clipboard',
@@ -68,7 +68,7 @@ describe( 'ContentTabSettings', () => {
 		render( <ContentTabSettings selectedSite={ selectedSite } /> );
 
 		const pathButton = screen.getByRole( 'button', { name: '/path/to/site, Open local path' } );
-		expect( pathButton ).toBeInTheDocument();
+		expect( pathButton ).toBeVisible();
 		await user.click( pathButton );
 		expect( openLocalPath ).toHaveBeenCalledWith( '/path/to/site' );
 	} );
@@ -86,7 +86,7 @@ describe( 'ContentTabSettings', () => {
 		const urlButton = screen.getByRole( 'button', {
 			name: 'localhost:8881, Copy site url to clipboard',
 		} );
-		expect( urlButton ).toBeInTheDocument();
+		expect( urlButton ).toBeVisible();
 		await user.click( urlButton );
 		expect( copyText ).toHaveBeenCalledTimes( 1 );
 		expect( copyText ).toHaveBeenCalledWith( 'http://localhost:8881' );
@@ -94,7 +94,7 @@ describe( 'ContentTabSettings', () => {
 		const wpAdminButton = screen.getByRole( 'button', {
 			name: 'localhost:8881/wp-admin, Copy wp-admin url to clipboard',
 		} );
-		expect( wpAdminButton ).toBeInTheDocument();
+		expect( wpAdminButton ).toBeVisible();
 		await user.click( wpAdminButton );
 		expect( copyText ).toHaveBeenCalledTimes( 2 );
 		expect( copyText ).toHaveBeenCalledWith( 'http://localhost:8881/wp-admin' );
@@ -107,7 +107,7 @@ describe( 'ContentTabSettings', () => {
 		const adminPasswordButton = screen.getByRole( 'button', {
 			name: 'Copy admin password to clipboard',
 		} );
-		expect( adminPasswordButton ).toBeInTheDocument();
+		expect( adminPasswordButton ).toBeVisible();
 		await user.click( adminPasswordButton );
 		expect( copyText ).toHaveBeenCalledTimes( 1 );
 		expect( copyText ).toHaveBeenCalledWith( 'test-password' );
@@ -143,7 +143,7 @@ describe( 'ContentTabSettings', () => {
 			const adminPasswordButton = screen.getByRole( 'button', {
 				name: 'Copy admin password to clipboard',
 			} );
-			expect( adminPasswordButton ).toBeInTheDocument();
+			expect( adminPasswordButton ).toBeVisible();
 			await user.click( adminPasswordButton );
 			expect( copyText ).toHaveBeenCalledTimes( 1 );
 			expect( copyText ).toHaveBeenCalledWith( 'password' );

--- a/src/components/tests/content-tab-snapshots.test.tsx
+++ b/src/components/tests/content-tab-snapshots.test.tsx
@@ -65,7 +65,7 @@ describe( 'ContentTabSnapshots', () => {
 		} );
 		render( <ContentTabSnapshots selectedSite={ selectedSite } /> );
 		const loginButton = screen.getByRole( 'button', { name: 'Log in to WordPress.com' } );
-		expect( loginButton ).toBeInTheDocument();
+		expect( loginButton ).toBeVisible();
 		await user.click( loginButton );
 		expect( authenticate ).toHaveBeenCalledTimes( 1 );
 	} );
@@ -80,7 +80,7 @@ describe( 'ContentTabSnapshots', () => {
 		} );
 		render( <ContentTabSnapshots selectedSite={ selectedSite } /> );
 		const createSnapshotButton = screen.getByRole( 'button', { name: 'Add demo site' } );
-		expect( createSnapshotButton ).toBeInTheDocument();
+		expect( createSnapshotButton ).toBeVisible();
 		await user.click( createSnapshotButton );
 		expect( archiveSite ).toHaveBeenCalledTimes( 1 );
 	} );
@@ -104,7 +104,7 @@ describe( 'ContentTabSnapshots', () => {
 			uploadingSites: {},
 		} );
 		render( <ContentTabSnapshots selectedSite={ selectedSite } /> );
-		expect( screen.getByRole( 'button', { name: 'https://fake-site.fake' } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: 'https://fake-site.fake' } ) ).toBeVisible();
 	} );
 
 	test( 'hide the list of demo sites that do not belong to the selected site', () => {
@@ -156,7 +156,7 @@ describe( 'ContentTabSnapshots', () => {
 		} );
 		render( <ContentTabSnapshots selectedSite={ selectedSite } /> );
 		const createSnapshotButton = screen.getByRole( 'button', { name: 'Add demo site' } );
-		expect( createSnapshotButton ).toBeInTheDocument();
+		expect( createSnapshotButton ).toBeVisible();
 		await user.click( createSnapshotButton );
 		expect( archiveSite ).toHaveBeenCalledTimes( 1 );
 	} );
@@ -183,7 +183,7 @@ describe( 'ContentTabSnapshots', () => {
 		} );
 		render( <ContentTabSnapshots selectedSite={ selectedSite } /> );
 		const createSnapshotButton = screen.getByRole( 'button', { name: 'Add demo site' } );
-		expect( createSnapshotButton ).toBeInTheDocument();
+		expect( createSnapshotButton ).toBeVisible();
 		expect( createSnapshotButton ).toHaveAttribute( 'aria-disabled', 'true' );
 		await user.click( createSnapshotButton );
 		expect( archiveSite ).toHaveBeenCalledTimes( 0 );
@@ -213,7 +213,7 @@ describe( 'ContentTabSnapshots', () => {
 		render( <ContentTabSnapshots selectedSite={ selectedSite } /> );
 
 		const updateButton = await screen.findByRole( 'button', { name: 'Update demo site' } );
-		expect( updateButton ).toBeInTheDocument();
+		expect( updateButton ).toBeVisible();
 		await user.click( updateButton );
 
 		expect( updateDemoSiteMock ).toHaveBeenCalledTimes( 1 );
@@ -245,7 +245,7 @@ describe( 'ContentTabSnapshots', () => {
 		render( <ContentTabSnapshots selectedSite={ selectedSite } /> );
 
 		const updateButton = await screen.findByRole( 'button', { name: 'Update demo site' } );
-		expect( updateButton ).toBeInTheDocument();
+		expect( updateButton ).toBeVisible();
 		await user.click( updateButton );
 
 		expect( updateDemoSiteMock ).not.toHaveBeenCalled();
@@ -287,7 +287,7 @@ describe( 'ContentTabSnapshots', () => {
 		render( <ContentTabSnapshots selectedSite={ selectedSite } /> );
 
 		const deleteSnapshotButton = screen.getByRole( 'button', { name: 'Delete demo site' } );
-		expect( deleteSnapshotButton ).toBeInTheDocument();
+		expect( deleteSnapshotButton ).toBeVisible();
 		await user.click( deleteSnapshotButton );
 
 		expect( deleteSnapshotMock ).toHaveBeenCalledWith( {
@@ -323,7 +323,7 @@ describe( 'ContentTabSnapshots', () => {
 		render( <ContentTabSnapshots selectedSite={ selectedSite } /> );
 
 		const deleteSnapshotButton = screen.getByRole( 'button', { name: 'Delete demo site' } );
-		expect( deleteSnapshotButton ).toBeInTheDocument();
+		expect( deleteSnapshotButton ).toBeVisible();
 		await user.click( deleteSnapshotButton );
 
 		expect( deleteSnapshotMock ).not.toHaveBeenCalled();
@@ -435,7 +435,7 @@ describe( 'AddDemoSiteWithProgress', () => {
 		render( <ContentTabSnapshots selectedSite={ { ...selectedSite, id: 'site-id-1' } } /> );
 		const addDemoSiteButton = screen.queryByRole( 'button', { name: 'Add demo site' } );
 		expect( addDemoSiteButton ).not.toBeInTheDocument();
-		expect( screen.getByText( "We're creating your demo site." ) ).toBeInTheDocument();
+		expect( screen.getByText( "We're creating your demo site." ) ).toBeVisible();
 	} );
 
 	test( 'Progressbar is present when the second snapshot is being created', async () => {
@@ -443,7 +443,7 @@ describe( 'AddDemoSiteWithProgress', () => {
 		render( <ContentTabSnapshots selectedSite={ { ...selectedSite, id: 'site-id-1' } } /> );
 		const addDemoSiteButton = screen.queryByRole( 'button', { name: 'Add demo site' } );
 		expect( addDemoSiteButton ).not.toBeInTheDocument();
-		expect( screen.getByText( "We're creating your new demo site." ) ).toBeInTheDocument();
+		expect( screen.getByText( "We're creating your new demo site." ) ).toBeVisible();
 	} );
 
 	test( 'Button is enabled when no snapshots and no other site is being archived', async () => {

--- a/src/components/tests/content-tab-snapshots.test.tsx
+++ b/src/components/tests/content-tab-snapshots.test.tsx
@@ -130,7 +130,7 @@ describe( 'ContentTabSnapshots', () => {
 			screen.getByText( 'Get feedback from anyone', {
 				exact: false,
 			} )
-		).toBeInTheDocument();
+		).toBeVisible();
 		expect( screen.queryByText( 'fake-site.fake' ) ).not.toBeInTheDocument();
 	} );
 

--- a/src/components/tests/copy-text-button.test.tsx
+++ b/src/components/tests/copy-text-button.test.tsx
@@ -18,7 +18,7 @@ describe( 'CopyTextButton', () => {
 
 	test( 'the button is present, and not the confirmation', () => {
 		render( <CopyTextButton text="Sample Text" copyConfirmation="Copied!" /> );
-		expect( screen.getByRole( 'button', { name: 'copy to clipboard' } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: 'copy to clipboard' } ) ).toBeVisible();
 		expect( screen.queryByRole( 'alert' ) ).toBe( null );
 	} );
 
@@ -27,7 +27,7 @@ describe( 'CopyTextButton', () => {
 		const mockCopyText = jest.fn();
 		( getIpcApi as jest.Mock ).mockReturnValue( { copyText: mockCopyText } );
 		render( <CopyTextButton text="Sample Text" copyConfirmation="Copied!" /> );
-		expect( screen.getByRole( 'button', { name: 'copy to clipboard' } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: 'copy to clipboard' } ) ).toBeVisible();
 		await user.click( screen.getByRole( 'button' ) );
 		expect( screen.getByRole( 'alert' ) ).toHaveTextContent( 'Copied!' );
 		expect( mockCopyText ).toHaveBeenCalledWith( 'Sample Text' );

--- a/src/components/tests/edit-site.test.tsx
+++ b/src/components/tests/edit-site.test.tsx
@@ -24,7 +24,7 @@ describe( 'EditSite', () => {
 	it( 'should dismiss the modal when the cancel button is activated via keyboard', async () => {
 		const user = userEvent.setup();
 		await user.click( screen.getByRole( 'button', { name: 'Edit site name' } ) );
-		expect( screen.queryByRole( 'dialog' ) ).toBeInTheDocument();
+		expect( screen.queryByRole( 'dialog' ) ).toBeVisible();
 
 		await userEvent.tab();
 		await userEvent.keyboard( '{Enter}' );

--- a/src/components/tests/gravatar.test.tsx
+++ b/src/components/tests/gravatar.test.tsx
@@ -17,7 +17,7 @@ describe( 'Gravatar', () => {
 		render( <Gravatar /> );
 		await waitFor( () => {
 			const image = screen.getByAltText( 'User avatar' );
-			expect( image ).toBeInTheDocument();
+			expect( image ).toBeVisible();
 			expect( image ).toHaveAttribute(
 				'src',
 				'https://www.gravatar.com/avatar/efc7b0f52253614d24531995d89c6d3dcf36bedcf6357a28f034c2597d84266b?d=https://s0.wp.com/i/studio-app/profile-icon.png'

--- a/src/components/tests/header.test.tsx
+++ b/src/components/tests/header.test.tsx
@@ -48,7 +48,7 @@ describe( 'Header', () => {
 		await user.click( startButton );
 
 		expect( mockedGetIpcApi().startServer ).toHaveBeenCalledTimes( 1 );
-		expect( screen.getByText( 'Stop' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Stop' ) ).toBeVisible();
 	} );
 
 	describe( 'when starting a server fails', () => {
@@ -70,7 +70,7 @@ describe( 'Header', () => {
 			await user.click( startButton );
 
 			expect( mockedGetIpcApi().startServer ).toHaveBeenCalledTimes( 1 );
-			expect( screen.getByText( 'Start' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Start' ) ).toBeVisible();
 			expect( mockedGetIpcApi().showMessageBox ).toHaveBeenCalledTimes( 1 );
 			expect( mockedGetIpcApi().showMessageBox ).toHaveBeenCalledWith( {
 				type: 'error',

--- a/src/components/tests/main-sidebar.test.tsx
+++ b/src/components/tests/main-sidebar.test.tsx
@@ -63,7 +63,7 @@ describe( 'MainSidebar Footer', () => {
 	it( 'Has add site button', async () => {
 		( useAuth as jest.Mock ).mockReturnValue( { isAuthenticated: false } );
 		await act( async () => render( <MainSidebar /> ) );
-		expect( screen.getByRole( 'button', { name: 'Add site' } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: 'Add site' } ) ).toBeVisible();
 	} );
 
 	it( 'Test unauthenticated footer has the Log in button', async () => {
@@ -71,7 +71,7 @@ describe( 'MainSidebar Footer', () => {
 		const authenticate = jest.fn();
 		( useAuth as jest.Mock ).mockReturnValue( { isAuthenticated: false, authenticate } );
 		await act( async () => render( <MainSidebar /> ) );
-		expect( screen.getByRole( 'button', { name: 'Log in' } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: 'Log in' } ) ).toBeVisible();
 		await user.click( screen.getByRole( 'button', { name: 'Log in' } ) );
 		expect( authenticate ).toHaveBeenCalledTimes( 1 );
 	} );
@@ -80,7 +80,7 @@ describe( 'MainSidebar Footer', () => {
 		( useAuth as jest.Mock ).mockReturnValue( { isAuthenticated: true } );
 		await act( async () => render( <MainSidebar /> ) );
 		expect( screen.queryByRole( 'button', { name: 'Log in' } ) ).not.toBeInTheDocument();
-		expect( screen.getByRole( 'button', { name: 'Account' } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: 'Account' } ) ).toBeVisible();
 	} );
 
 	it( 'applies className prop', async () => {
@@ -92,7 +92,7 @@ describe( 'MainSidebar Footer', () => {
 
 	it( 'shows a "Stop All" button when there are running sites', async () => {
 		await act( async () => render( <MainSidebar /> ) );
-		expect( screen.getByRole( 'button', { name: 'Stop all' } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: 'Stop all' } ) ).toBeVisible();
 	} );
 
 	it( 'disables log in button when offline', async () => {
@@ -123,22 +123,22 @@ describe( 'MainSidebar Footer', () => {
 describe( 'MainSidebar Site Menu', () => {
 	it( 'renders the list of sites', async () => {
 		await act( async () => render( <MainSidebar /> ) );
-		expect( screen.getByRole( 'button', { name: 'test-1' } ) ).toBeInTheDocument();
-		expect( screen.getByRole( 'button', { name: 'test-2' } ) ).toBeInTheDocument();
-		expect( screen.getByRole( 'button', { name: 'test-3' } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: 'test-1' } ) ).toBeVisible();
+		expect( screen.getByRole( 'button', { name: 'test-2' } ) ).toBeVisible();
+		expect( screen.getByRole( 'button', { name: 'test-3' } ) ).toBeVisible();
 	} );
 
 	it( 'has "start site" buttons when sites are not running', async () => {
 		await act( async () => render( <MainSidebar /> ) );
-		expect( screen.getByRole( 'button', { name: 'start test-1 site' } ) ).toBeInTheDocument();
-		expect( screen.getByRole( 'button', { name: 'start test-2 site' } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: 'start test-1 site' } ) ).toBeVisible();
+		expect( screen.getByRole( 'button', { name: 'start test-2 site' } ) ).toBeVisible();
 	} );
 
 	it( 'starts a site', async () => {
 		const user = userEvent.setup();
 		await act( async () => render( <MainSidebar /> ) );
 		const greenDotFirstSite = screen.getByRole( 'button', { name: 'start test-1 site' } );
-		expect( greenDotFirstSite ).toBeInTheDocument();
+		expect( greenDotFirstSite ).toBeVisible();
 		await user.click( greenDotFirstSite );
 		expect( siteDetailsMocked.startServer ).toHaveBeenCalledWith(
 			'0e9e237b-335a-43fa-b439-9b078a618512'
@@ -149,7 +149,7 @@ describe( 'MainSidebar Site Menu', () => {
 		const user = userEvent.setup();
 		await act( async () => render( <MainSidebar /> ) );
 		const greenDotFirstSite = screen.getByRole( 'button', { name: 'stop test-3 site' } );
-		expect( greenDotFirstSite ).toBeInTheDocument();
+		expect( greenDotFirstSite ).toBeVisible();
 		await user.click( greenDotFirstSite );
 		expect( siteDetailsMocked.stopServer ).toHaveBeenCalledWith(
 			'0e9e237b-335a-43fa-b439-9b078a613333'

--- a/src/components/tests/site-content-tabs.test.tsx
+++ b/src/components/tests/site-content-tabs.test.tsx
@@ -57,11 +57,9 @@ describe( 'SiteContentTabs', () => {
 			loadingServer: {},
 		} );
 		await act( async () => render( <SiteContentTabs /> ) );
-		expect( screen.queryByRole( 'tab', { name: 'Overview', selected: true } ) ).toBeInTheDocument();
-		expect( screen.queryByRole( 'tab', { name: 'Share', selected: false } ) ).toBeInTheDocument();
-		expect(
-			screen.queryByRole( 'tab', { name: 'Settings', selected: false } )
-		).toBeInTheDocument();
+		expect( screen.queryByRole( 'tab', { name: 'Overview', selected: true } ) ).toBeVisible();
+		expect( screen.queryByRole( 'tab', { name: 'Share', selected: false } ) ).toBeVisible();
+		expect( screen.queryByRole( 'tab', { name: 'Settings', selected: false } ) ).toBeVisible();
 		expect( screen.queryByRole( 'tab', { name: 'Assistant', selected: false } ) ).toBeNull();
 	} );
 	it( 'should render a "No Site" screen if selected site is absent', async () => {
@@ -77,7 +75,7 @@ describe( 'SiteContentTabs', () => {
 		expect( screen.queryByRole( 'tab', { name: 'Launchpad' } ) ).toBeNull();
 		expect( screen.queryByRole( 'tab', { name: 'Publish' } ) ).toBeNull();
 		expect( screen.queryByRole( 'tab', { name: 'Export' } ) ).toBeNull();
-		expect( screen.getByText( 'Select a site to view details.' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Select a site to view details.' ) ).toBeVisible();
 	} );
 	it( 'should not render the Assistant tab if assistantEnabled is not enabled', async () => {
 		( useSiteDetails as jest.Mock ).mockReturnValue( {

--- a/src/components/tests/site-management-actions.test.tsx
+++ b/src/components/tests/site-management-actions.test.tsx
@@ -55,6 +55,6 @@ describe( 'SiteManagementActions', () => {
 				selectedSite={ { running: false, id: 'site-1' } as SiteDetails }
 			/>
 		);
-		expect( screen.getByRole( 'button', { name: 'Start' } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: 'Start' } ) ).toBeVisible();
 	} );
 } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to https://github.com/Automattic/studio/pull/293#discussion_r1654357099.

## Proposed Changes

- Update element presence assertions in unit tests to use `toBeVisible` expectation. Note that we'll still use `toBeInTheDocument` when checking if an element is not present.
- The rationale to use `toBeVisible` instead of `toBeInTheDocument` is mainly because the latter only ensures that the element exists in the DOM but not that it's visible which is closer to the user experience.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Observer that all CI jobs pass.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
