### PR TITLE
Improve validation of `wp-cli` commands that contain placeholder content

### DIFF
--- a/src/components/assistant-code-block.tsx
+++ b/src/components/assistant-code-block.tsx
@@ -17,7 +17,7 @@ type ContextProps = Pick<
 
 type CodeBlockProps = JSX.IntrinsicElements[ 'code' ] & ExtraProps;
 
-const PLACEHOLDER_CHAR_BEGIN = [ '<', '[', '{' ];
+const PLACEHOLDER_CHAR_BEGIN = [ '<', '[', '{', '(' ];
 
 export default function createCodeComponent( contextProps: ContextProps ) {
 	return ( props: CodeBlockProps ) => <CodeBlock { ...contextProps } { ...props } />;

--- a/src/components/tests/assistant-code-block.test.tsx
+++ b/src/components/tests/assistant-code-block.test.tsx
@@ -54,6 +54,11 @@ describe( 'createCodeComponent', () => {
 			<CodeBlock className="language-bash" children="wp plugin activate {example-plugin}" />
 		);
 		expect( screen.queryByText( 'Run' ) ).not.toBeInTheDocument();
+
+		render(
+			<CodeBlock className="language-bash" children="wp plugin activate (example-plugin)" />
+		);
+		expect( screen.queryByText( 'Run' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'should hide the "run" button for ineligible wp-cli commands with multiple wp-cli invocations', () => {

--- a/src/components/tests/assistant-code-block.test.tsx
+++ b/src/components/tests/assistant-code-block.test.tsx
@@ -43,7 +43,16 @@ describe( 'createCodeComponent', () => {
 		render(
 			<CodeBlock className="language-bash" children="wp plugin activate <example-plugin>" />
 		);
+		expect( screen.queryByText( 'Run' ) ).not.toBeInTheDocument();
 
+		render(
+			<CodeBlock className="language-bash" children="wp plugin activate [example-plugin]" />
+		);
+		expect( screen.queryByText( 'Run' ) ).not.toBeInTheDocument();
+
+		render(
+			<CodeBlock className="language-bash" children="wp plugin activate {example-plugin}" />
+		);
 		expect( screen.queryByText( 'Run' ) ).not.toBeInTheDocument();
 	} );
 
@@ -51,6 +60,12 @@ describe( 'createCodeComponent', () => {
 		render( <CodeBlock className="language-bash" children="wp --version wp --version" /> );
 
 		expect( screen.queryByText( 'Run' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'should display the "run" button for elligble wp-cli commands that contain a placeholder char', () => {
+		render( <CodeBlock className="language-bash" children="wp eval 'var_dump(3 < 4);'" /> );
+
+		expect( screen.getByText( 'Run' ) ).toBeInTheDocument();
 	} );
 
 	describe( 'when the "run" button is clicked', () => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to https://github.com/Automattic/studio/pull/305 and https://github.com/Automattic/studio/pull/232#discussion_r1654495584.

## Proposed Changes

- Parse `wp-cli` command arguments in `CodeBlock` component. This way we can detect placeholder characters more accurately.
- Mark a `wp-cli` command as not eligible to be executed if any of its arguments start with a placeholder character.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run the command `STUDIO_AI=true npm start`.
- Select a site and navigate to the AI assistant tab.
- Send the prompt `Show me how to get wordpress version via command`.
- Observe the AI responds with the command `wp core version`.
- Observe the command displays the Run button.
- Send the prompt `Share a generic command to active a theme`.
- Observe the AI responds with the command `wp theme activate {SLUG}` (or similar placeholder format).
- Observe the command doesn't display the Run button.
- Send the prompt `Can you display the generic command with all possible combinations of placeholder characters? Each in a separate command.`.
- Observe the AI responds with different commands with placeholder characters.
- Observe that the commands don't display the Run button.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
