### PR TITLE
fix: Improve run code activity indicator alignment

### DIFF
--- a/src/components/assistant-code-block.tsx
+++ b/src/components/assistant-code-block.tsx
@@ -83,7 +83,7 @@ function CodeBlock( props: ContextProps & CodeBlockProps ) {
 			</div>
 			{ isRunning && (
 				<div className="p-3 flex justify-start items-center bg-[#2D3337] text-white">
-					<Spinner className="!text-white [&>circle]:stroke-a8c-gray-60" />
+					<Spinner className="!text-white [&>circle]:stroke-a8c-gray-60 !mt-0" />
 					<span className="ml-2 font-sans">{ __( 'Running...' ) }</span>
 				</div>
 			) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Proposed Changes

Improve UI alignment .The misalignment degrades the perceived quality by users.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

| Before | After |
| - | - |
| <img width="513" alt="raw-before" src="https://github.com/Automattic/studio/assets/438664/8950abe2-4254-46b3-8006-14448808dd22"> | <img width="512" alt="raw-after" src="https://github.com/Automattic/studio/assets/438664/83e2ed40-dd77-4347-b477-7f2cf567481e"> |
| <img width="512" alt="guides-before" src="https://github.com/Automattic/studio/assets/438664/24f717dc-d538-4aa5-9e49-62c0bf3ace5c"> | <img width="510" alt="guides-after" src="https://github.com/Automattic/studio/assets/438664/433ff6ff-f5a6-43b7-baf1-894230450fbc"> |

1. Request the Assistant perform a `wp-cli` action.
1. Click "Run."
1. Verify the activity indicator is aligned with the adjacent "Running..." text.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
