### PR TITLE
Studio: Unable to send messages to AI when switching sites

### DIFF
--- a/src/components/tests/content-tab-assistant.test.tsx
+++ b/src/components/tests/content-tab-assistant.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import { useAuth } from '../../hooks/use-auth';
 import { useFetchWelcomeMessages } from '../../hooks/use-fetch-welcome-messages';
 import { ContentTabAssistant } from '../content-tab-assistant';
@@ -101,8 +101,8 @@ describe( 'ContentTabAssistant', () => {
 	} );
 
 	test( 'saves and retrieves conversation from localStorage', async () => {
-		const storageKey = `ai_chat_messages_${ runningSite.id }`;
-		localStorage.setItem( storageKey, JSON.stringify( initialMessages ) );
+		const storageKey = 'ai_chat_messages';
+		localStorage.setItem( storageKey, JSON.stringify( { [ runningSite.id ]: initialMessages } ) );
 		render( <ContentTabAssistant selectedSite={ runningSite } /> );
 		expect( screen.getByText( 'Initial message 1' ) ).toBeVisible();
 		expect( screen.getByText( 'Initial message 2' ) ).toBeVisible();
@@ -112,8 +112,8 @@ describe( 'ContentTabAssistant', () => {
 		expect( screen.getByText( 'New message' ) ).toBeVisible();
 		await waitFor( () => {
 			const storedMessages = JSON.parse( localStorage.getItem( storageKey ) || '[]' );
-			expect( storedMessages ).toHaveLength( 3 );
-			expect( storedMessages[ 2 ].content ).toBe( 'New message' );
+			expect( storedMessages[ runningSite.id ] ).toHaveLength( 3 );
+			expect( storedMessages[ runningSite.id ][ 2 ].content ).toBe( 'New message' );
 		} );
 	} );
 

--- a/src/components/tests/content-tab-assistant.test.tsx
+++ b/src/components/tests/content-tab-assistant.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { useAuth } from '../../hooks/use-auth';
 import { useFetchWelcomeMessages } from '../../hooks/use-fetch-welcome-messages';
 import { ContentTabAssistant } from '../content-tab-assistant';

--- a/src/hooks/tests/use-assistant.test.ts
+++ b/src/hooks/tests/use-assistant.test.ts
@@ -27,8 +27,8 @@ describe( 'useAssistant', () => {
 			{ content: 'Hi there', role: 'assistant' },
 		];
 		localStorage.setItem(
-			`ai_chat_messages_${ selectedSiteId }`,
-			JSON.stringify( initialMessages )
+			`ai_chat_messages`,
+			JSON.stringify( { [ selectedSiteId ]: initialMessages } )
 		);
 
 		const { result } = renderHook( () => useAssistant( selectedSiteId ) );
@@ -46,8 +46,10 @@ describe( 'useAssistant', () => {
 		expect( result.current.messages ).toEqual( [
 			{ content: 'Hello', role: 'user', id: 0, createdAt: MOCKED_TIME },
 		] );
-		expect( localStorage.getItem( `ai_chat_messages_${ selectedSiteId }` ) ).toEqual(
-			JSON.stringify( [ { content: 'Hello', role: 'user', id: 0, createdAt: MOCKED_TIME } ] )
+		expect( localStorage.getItem( `ai_chat_messages` ) ).toEqual(
+			JSON.stringify( {
+				[ selectedSiteId ]: [ { content: 'Hello', role: 'user', id: 0, createdAt: MOCKED_TIME } ],
+			} )
 		);
 	} );
 
@@ -62,8 +64,6 @@ describe( 'useAssistant', () => {
 		} );
 
 		expect( result.current.messages ).toEqual( [] );
-		expect( localStorage.getItem( `ai_chat_messages_${ selectedSiteId }` ) ).toEqual(
-			JSON.stringify( [] )
-		);
+		expect( localStorage.getItem( 'ai_chat_messages' ) ).toEqual( JSON.stringify( {} ) );
 	} );
 } );

--- a/src/hooks/use-assistant.ts
+++ b/src/hooks/use-assistant.ts
@@ -41,7 +41,7 @@ export const useAssistant = ( instanceId: string ) => {
 		( content: string, role: 'user' | 'assistant', chatId?: string ) => {
 			const messages = messagesDict[ instanceId ] || [];
 			const newMessageId = messages.length;
-			setMessageDict( ( prevDict ) => {
+			setMessagesDict( ( prevDict ) => {
 				const prevMessages = prevDict[ instanceId ] || [];
 				const updatedMessages = [
 					...prevMessages,

--- a/src/hooks/use-assistant.ts
+++ b/src/hooks/use-assistant.ts
@@ -14,47 +14,48 @@ export type Message = {
 	createdAt: number; // Unix timestamp
 };
 
-const chatIdStoreKey = ( instanceId: string ) => `ai_chat_id_${ instanceId }`;
-const chatMessagesStoreKey = ( instanceId: string ) => `ai_chat_messages_${ instanceId }`;
+export type MessageDict = { [ key: string ]: Message[] };
+export type ChatIdDict = { [ key: string ]: string | undefined };
+
+const chatIdStoreKey = 'ai_chat_ids';
+const chatMessagesStoreKey = 'ai_chat_messages';
 
 export const useAssistant = ( instanceId: string ) => {
-	const [ messages, setMessages ] = useState< Message[] >( [] );
-	const [ chatId, setChatId ] = useState< string | undefined >( undefined );
+	const [ messagesDict, setMessagesDict ] = useState< MessageDict >( {} );
+	const [ chatIdDict, setChatIdDict ] = useState< ChatIdDict >( {} );
 
 	useEffect( () => {
-		const storedChat = localStorage.getItem( chatMessagesStoreKey( instanceId ) );
-		const storedChatId = localStorage.getItem( chatIdStoreKey( instanceId ) );
-		if ( storedChat ) {
-			setMessages( JSON.parse( storedChat ) );
-		} else {
-			setMessages( [] );
+		const storedMessages = localStorage.getItem( chatMessagesStoreKey );
+		const storedChatIds = localStorage.getItem( chatIdStoreKey );
+
+		if ( storedMessages ) {
+			setMessagesDict( JSON.parse( storedMessages ) );
 		}
-		if ( storedChatId ) {
-			setChatId( storedChatId );
-		} else {
-			setChatId( undefined );
+		if ( storedChatIds ) {
+			setChatIdDict( JSON.parse( storedChatIds ) );
 		}
-	}, [ instanceId ] );
+	}, [] );
 
 	const addMessage = useCallback(
 		( content: string, role: 'user' | 'assistant', chatId?: string ) => {
-			setMessages( ( prevMessages ) => {
+			setMessagesDict( ( prevDict ) => {
+				const prevMessages = prevDict[ instanceId ] || [];
 				const updatedMessages = [
 					...prevMessages,
 					{ content, role, id: prevMessages.length, createdAt: Date.now() },
 				];
-				localStorage.setItem(
-					chatMessagesStoreKey( instanceId ),
-					JSON.stringify( updatedMessages )
-				);
-				return updatedMessages;
+				const newDict = { ...prevDict, [ instanceId ]: updatedMessages };
+				localStorage.setItem( chatMessagesStoreKey, JSON.stringify( newDict ) );
+				return newDict;
 			} );
 
-			setChatId( ( prevChatId ) => {
-				if ( prevChatId !== chatId && chatId ) {
-					localStorage.setItem( chatIdStoreKey( instanceId ), JSON.stringify( chatId ) );
+			setChatIdDict( ( prevDict ) => {
+				if ( prevDict[ instanceId ] !== chatId && chatId ) {
+					const newDict = { ...prevDict, [ instanceId ]: chatId };
+					localStorage.setItem( chatIdStoreKey, JSON.stringify( newDict ) );
+					return newDict;
 				}
-				return chatId;
+				return prevDict;
 			} );
 		},
 		[ instanceId ]
@@ -68,7 +69,8 @@ export const useAssistant = ( instanceId: string ) => {
 			cliStatus?: 'success' | 'error',
 			cliTime?: string
 		) => {
-			setMessages( ( prevMessages ) => {
+			setMessagesDict( ( prevDict ) => {
+				const prevMessages = prevDict[ instanceId ] || [];
 				const updatedMessages = prevMessages.map( ( message ) => {
 					if ( message.id !== id ) return message;
 					const updatedBlocks = ( message.blocks || [] ).map( ( block ) =>
@@ -84,31 +86,36 @@ export const useAssistant = ( instanceId: string ) => {
 					}
 					return { ...message, blocks: updatedBlocks };
 				} );
-				localStorage.setItem(
-					chatMessagesStoreKey( instanceId ),
-					JSON.stringify( updatedMessages )
-				);
-				return updatedMessages;
+				const newDict = { ...prevDict, [ instanceId ]: updatedMessages };
+				localStorage.setItem( chatMessagesStoreKey, JSON.stringify( newDict ) );
+				return newDict;
 			} );
 		},
 		[ instanceId ]
 	);
 
 	const clearMessages = useCallback( () => {
-		setMessages( [] );
-		setChatId( undefined );
-		localStorage.setItem( chatMessagesStoreKey( instanceId ), JSON.stringify( [] ) );
-		localStorage.removeItem( chatIdStoreKey( instanceId ) );
+		setMessagesDict( ( prevDict ) => {
+			const { [ instanceId ]: _, ...rest } = prevDict;
+			localStorage.setItem( chatMessagesStoreKey, JSON.stringify( rest ) );
+			return rest;
+		} );
+
+		setChatIdDict( ( prevDict ) => {
+			const { [ instanceId ]: _, ...rest } = prevDict;
+			localStorage.setItem( chatIdStoreKey, JSON.stringify( rest ) );
+			return rest;
+		} );
 	}, [ instanceId ] );
 
 	return useMemo(
 		() => ( {
-			messages,
+			messages: messagesDict[ instanceId ] || [],
 			addMessage,
 			updateMessage,
 			clearMessages,
-			chatId,
+			chatId: chatIdDict[ instanceId ],
 		} ),
-		[ addMessage, clearMessages, messages, updateMessage, chatId ]
+		[ messagesDict, instanceId, addMessage, updateMessage, clearMessages, chatIdDict ]
 	);
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/7956

## Proposed Changes

This PR fixes a bug, where switching sites when using the AI Assistant can result in failures and content displayed on the wrong site.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check that you have at least two sites and they don't have an ongoing chat with AI.
3. Select one site and navigate to the assistant tab.
4. Send a message to the AI.
5. Before getting a response, select another site.
6. Ensure that the message is not shown on an incorrect site after retrieving it, and there are no API errors.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
