### PR TITLE
Studio: Mark messages as failed to send

### DIFF
--- a/src/components/chat-message.tsx
+++ b/src/components/chat-message.tsx
@@ -27,6 +27,7 @@ export interface ChatMessageProps {
 		time: string
 	) => void;
 	isUnauthenticated?: boolean;
+	failedMessage?: boolean;
 }
 
 export const ChatMessage = ( {
@@ -39,6 +40,7 @@ export const ChatMessage = ( {
 	blocks,
 	updateMessage,
 	isUnauthenticated,
+	failedMessage,
 }: ChatMessageProps ) => {
 	return (
 		<div
@@ -55,9 +57,10 @@ export const ChatMessage = ( {
 				role="group"
 				aria-labelledby={ id }
 				className={ cx(
-					'inline-block p-3 rounded border border-gray-300 overflow-x-auto select-text',
+					'inline-block p-3 rounded border overflow-x-auto select-text',
 					isUnauthenticated ? 'lg:max-w-[90%]' : 'lg:max-w-[70%]', // Apply different max-width for unauthenticated view
-					! isUser ? 'bg-white' : 'bg-white/45'
+					! isUser ? 'bg-white' : 'bg-white/45',
+					failedMessage ? 'border-[#FACFD2] bg-[#F7EBEC]' : 'border-gray-300'
 				) }
 			>
 				<div className="relative">

--- a/src/components/chat-message.tsx
+++ b/src/components/chat-message.tsx
@@ -58,8 +58,8 @@ export const ChatMessage = ( {
 				className={ cx(
 					'inline-block p-3 rounded border overflow-x-auto select-text',
 					isUnauthenticated ? 'lg:max-w-[90%]' : 'lg:max-w-[70%]', // Apply different max-width for unauthenticated view
-					! isUser ? 'bg-white' : 'bg-white/45',
-					failedMessage ? 'border-[#FACFD2] bg-[#F7EBEC]' : 'border-gray-300'
+					failedMessage ? 'border-[#FACFD2] bg-[#F7EBEC]' : ! isUser ? 'bg-white' : 'bg-white/45',
+					! failedMessage && 'border-gray-300'
 				) }
 			>
 				<div className="relative">

--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -25,6 +25,23 @@ interface ContentTabAssistantProps {
 	selectedSite: SiteDetails;
 }
 
+const ErrorNotice = ( {
+	hasError,
+}: {
+	handleSend: ( messageToSend?: string ) => void;
+	messageContent: string;
+	hasError: boolean;
+} ) => {
+	const { __ } = useI18n();
+	if ( ! hasError ) return null;
+
+	return (
+		<div className="text-a8c-gray-50 flex justify-end py-2 text-xs">
+			{ __( "Oops! We couldn't get a response from the assistant." ) }
+		</div>
+	);
+};
+
 const UsageLimitReached = () => {
 	const { daysUntilReset } = usePromptUsage();
 

--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -112,6 +112,7 @@ const AuthenticatedView = memo(
 							updateMessage={ updateMessage }
 							messageId={ message.id }
 							blocks={ message.blocks }
+							failedMessage={ message.failedMessage }
 						>
 							{ message.content }
 						</ChatMessage>

--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -104,8 +104,9 @@ const AuthenticatedView = memo(
 		return (
 			<>
 				{ messages.map( ( message, index ) => (
-					<React.Fragment key={ index }>
+					<>
 						<ChatMessage
+							key={ index }
 							id={ `message-chat-${ index }` }
 							isUser={ message.role === 'user' }
 							projectPath={ path }
@@ -117,7 +118,7 @@ const AuthenticatedView = memo(
 							{ message.content }
 						</ChatMessage>
 						{ message.failedMessage && <ErrorNotice /> }
-					</React.Fragment>
+					</>
 				) ) }
 				{ isAssistantThinking && (
 					<ChatMessage isUser={ false } id="message-thinking">

--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -192,8 +192,9 @@ export function ContentTabAssistant( { selectedSite }: ContentTabAssistantProps 
 
 	const handleSend = async ( messageToSend?: string ) => {
 		const chatMessage = messageToSend || input;
+		let messageId;
 		if ( chatMessage.trim() ) {
-			const messageId = addMessage( chatMessage, 'user', chatId ); // Get the new message ID
+			messageId = addMessage( chatMessage, 'user', chatId ); // Get the new message ID
 			setInput( '' );
 			try {
 				const { message, chatId: fetchedChatId } = await fetchAssistant(
@@ -208,7 +209,7 @@ export function ContentTabAssistant( { selectedSite }: ContentTabAssistantProps 
 					addMessage( message, 'assistant', chatId ?? fetchedChatId );
 				}
 			} catch ( error ) {
-				if ( messageId ) {
+				if ( typeof messageId !== 'undefined' ) {
 					updateFailedMessage( messageId, true );
 				}
 			}

--- a/src/hooks/use-assistant.ts
+++ b/src/hooks/use-assistant.ts
@@ -39,9 +39,8 @@ export const useAssistant = ( instanceId: string ) => {
 
 	const addMessage = useCallback(
 		( content: string, role: 'user' | 'assistant', chatId?: string ) => {
-			let newMessageId;
+			const newMessageId = messages.length;
 			setMessages( ( prevMessages ) => {
-				newMessageId = prevMessages.length; // Calculate the new message ID
 				const updatedMessages = [
 					...prevMessages,
 					{ content, role, id: newMessageId, createdAt: Date.now() },
@@ -62,7 +61,7 @@ export const useAssistant = ( instanceId: string ) => {
 
 			return newMessageId; // Return the new message ID
 		},
-		[ instanceId ]
+		[ instanceId, messages.length ]
 	);
 
 	const updateMessage = useCallback(

--- a/src/hooks/use-assistant.ts
+++ b/src/hooks/use-assistant.ts
@@ -12,6 +12,7 @@ export type Message = {
 		codeBlockContent?: string;
 	}[];
 	createdAt: number; // Unix timestamp
+	failedMessage?: boolean;
 };
 
 const chatIdStoreKey = ( instanceId: string ) => `ai_chat_id_${ instanceId }`;
@@ -38,10 +39,12 @@ export const useAssistant = ( instanceId: string ) => {
 
 	const addMessage = useCallback(
 		( content: string, role: 'user' | 'assistant', chatId?: string ) => {
+			let newMessageId;
 			setMessages( ( prevMessages ) => {
+				newMessageId = prevMessages.length; // Calculate the new message ID
 				const updatedMessages = [
 					...prevMessages,
-					{ content, role, id: prevMessages.length, createdAt: Date.now() },
+					{ content, role, id: newMessageId, createdAt: Date.now() },
 				];
 				localStorage.setItem(
 					chatMessagesStoreKey( instanceId ),
@@ -56,6 +59,8 @@ export const useAssistant = ( instanceId: string ) => {
 				}
 				return chatId;
 			} );
+
+			return newMessageId; // Return the new message ID
 		},
 		[ instanceId ]
 	);
@@ -94,6 +99,23 @@ export const useAssistant = ( instanceId: string ) => {
 		[ instanceId ]
 	);
 
+	const updateFailedMessage = useCallback(
+		( id: number, failedMessage: boolean ) => {
+			setMessages( ( prevMessages ) => {
+				const updatedMessages = prevMessages.map( ( message ) => {
+					if ( message.id !== id ) return message;
+					return { ...message, failedMessage };
+				} );
+				localStorage.setItem(
+					chatMessagesStoreKey( instanceId ),
+					JSON.stringify( updatedMessages )
+				);
+				return updatedMessages;
+			} );
+		},
+		[ instanceId ]
+	);
+
 	const clearMessages = useCallback( () => {
 		setMessages( [] );
 		setChatId( undefined );
@@ -107,8 +129,9 @@ export const useAssistant = ( instanceId: string ) => {
 			addMessage,
 			updateMessage,
 			clearMessages,
+			updateFailedMessage,
 			chatId,
 		} ),
-		[ addMessage, clearMessages, messages, updateMessage, chatId ]
+		[ addMessage, clearMessages, messages, updateMessage, updateFailedMessage, chatId ]
 	);
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to https://github.com/Automattic/studio/pull/297
Related to https://github.com/Automattic/dotcom-forge/issues/7668

## Proposed Changes

This PR marks messages as failed to send and adds the notice under these messages. Please not that this PR does not implement `Try again` functionality:

<img width="1123" alt="Screenshot 2024-06-27 at 8 57 51 PM" src="https://github.com/Automattic/studio/assets/25575134/814bd4e1-3d40-4b0d-8e26-ea45ac65b536">
   
## Testing Instructions

* Pull the changes from this branch locally
* Modify the URL for the API to be invalid in `src/hooks/use-assistant-api.ts` on lines 50-54:

```
						{
							path: '/studio-app/ai-assistant/cht',
							apiNamespace: 'wpcom/v2',
							body,
						},
```
* Navigate to the Assistant tab
* Try sending either a message or use an example prompt
* Observe that error message `Oops! We couldn't get a response from the assistant` appears under the message that fails to send
* Navigate to a different tab and come back to AI Assistant
* Confirm that the notice of the failed message persists 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] 