### PR TITLE
test: Reduce output noise

### DIFF
--- a/jest-setup.ts
+++ b/jest-setup.ts
@@ -29,6 +29,39 @@ if ( typeof window !== 'undefined' ) {
 nock.disableNetConnect();
 nock.enableNetConnect( 'raw.githubusercontent.com' );
 
+/**
+ * TODO: Replace this manual filter with a more robust logger that can be
+ * disabled for the testing environment. Consider enabling a lint rule that
+ * discourages direct use of `console` methods.
+ */
+function filteredConsole( level: ( ...args: any[] ) => void ) {
+	const ignoredMessages = [
+		'Loaded user data from ',
+		'Saved user data to ',
+		'Server start',
+		'Would have bumped stat: ',
+		'Starting new session',
+		'App version: ',
+		'Built from commit: mock-hash',
+		'Local timezone: UTC',
+		'App locale: ',
+		'System locale: ',
+		'Used language: ',
+	];
+
+	return ( ...args: any[] ) => {
+		if ( ignoredMessages.some( ( ignoredMessage ) => args[ 0 ].includes( ignoredMessage ) ) ) {
+			return;
+		}
+
+		level( ...args );
+	};
+}
+console.log = filteredConsole( console.log );
+console.error = filteredConsole( console.error );
+console.warn = filteredConsole( console.warn );
+console.info = filteredConsole( console.info );
+
 // We consider the app to be online by default.
 jest.mock( './src/hooks/use-offline', () => ( {
 	useOffline: jest.fn().mockReturnValue( false ),

--- a/src/components/tests/assistant-code-block.test.tsx
+++ b/src/components/tests/assistant-code-block.test.tsx
@@ -8,7 +8,7 @@ describe( 'createCodeComponent', () => {
 	const contextProps = {
 		blocks: [],
 		updateMessage: jest.fn(),
-		projectPath: '/path/to/project',
+		siteId: '1',
 		messageId: 1,
 	};
 	const CodeBlock = createCodeComponent( contextProps );
@@ -152,7 +152,7 @@ describe( 'createCodeComponent', () => {
 					},
 				],
 				updateMessage: jest.fn(),
-				projectPath: '/path/to/project',
+				siteId: '1',
 				messageId: 1,
 			};
 			const CodeBlock = createCodeComponent( contextProps );

--- a/src/tests/execute-wp-cli.test.ts
+++ b/src/tests/execute-wp-cli.test.ts
@@ -31,6 +31,10 @@ describe( 'executeWPCli', () => {
 	} );
 
 	it( 'should return error if wp-cli command does not exist', async () => {
+		const originalConsoleError = console.error;
+		const originalConsoleWarn = console.warn;
+		console.error = jest.fn();
+		console.warn = jest.fn();
 		const args = [ 'yoda' ];
 
 		const result = await executeWPCli( tmpPath, args );
@@ -39,6 +43,9 @@ describe( 'executeWPCli', () => {
 		expect( result.stderr ).toContain(
 			"'yoda' is not a registered wp command. See 'wp help' for available commands."
 		);
+
+		console.error = originalConsoleError;
+		console.warn = originalConsoleWarn;
 	} );
 
 	it( 'should return the correct version of WP-CLI', async () => {

--- a/src/tests/execute-wp-cli.test.ts
+++ b/src/tests/execute-wp-cli.test.ts
@@ -18,7 +18,7 @@ describe( 'executeWPCli', () => {
 		fs.writeFileSync( path.join( tmpPath, 'index.php' ), '' );
 	} );
 	afterAll( () => {
-		fs.rmdirSync( tmpPath, { recursive: true } );
+		fs.rmSync( tmpPath, { recursive: true } );
 	} );
 
 	it( 'should execute wp-cli version command and return stdout and stderr', async () => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Proposed Changes

Reduce the amount of noise found in test output to decrease the likelihood that we introduce new errors, warnings, or failures without noticing. Long term, we might consider leveraging [`@wordpress/jest-console`](https://github.com/WordPress/gutenberg/tree/6de2f42d09089b041540dbec02f54555c8a6e7f1/packages/jest-console#jest-console) to trigger a test failure whenever console output exists occurs from a test. 

- Prevent invalid React HTML attribute error.
- Exclude expected console error and warning message in test output.
- Replace use of deprecated `fs.rmdir` with `fs.rm`.
- Filter verbose console messages.

Additional context can be found in the body of each commit message. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. `npm run test`
1. Verify test output contains no warnings[^1] or logs.

| Before | After |
| - | - |
| <img width="871" alt="before" src="https://github.com/Automattic/studio/assets/438664/20ab4c47-a0f6-40de-97b7-b2b4c7b667e5"> | <img width="585" alt="after" src="https://github.com/Automattic/studio/assets/438664/6e5e90cc-3531-4370-b170-3f78a58d0e59"> |

[^1]: The one remaining warning relates to an identifiable issue stemming from usage of `@php-wasm/node`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
