### PR TITLE
feat: Improve Assistant prompt accessibility

### DIFF
--- a/src/components/ai-input.tsx
+++ b/src/components/ai-input.tsx
@@ -1,7 +1,7 @@
 import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { Icon, moreVertical, keyboardReturn, reset } from '@wordpress/icons';
-import React, { useRef, useEffect, useState } from 'react';
+import React, { forwardRef, useRef, useEffect, useState } from 'react';
 import useAiIcon from '../hooks/use-ai-icon';
 import { cx } from '../lib/cx';
 import { getIpcApi } from '../lib/get-ipc-api';
@@ -18,17 +18,18 @@ interface AIInputProps {
 
 const MAX_ROWS = 10;
 
-export const AIInput = ( {
-	disabled,
-	input,
-	setInput,
-	handleSend,
-	handleKeyDown,
-	clearInput,
-	isAssistantThinking,
-}: AIInputProps ) => {
-	const inputRef = useRef< HTMLTextAreaElement >( null );
-
+const UnforwardedAIInput = (
+	{
+		disabled,
+		input,
+		setInput,
+		handleSend,
+		handleKeyDown,
+		clearInput,
+		isAssistantThinking,
+	}: AIInputProps,
+	inputRef: React.RefObject< HTMLTextAreaElement > | React.RefCallback< HTMLTextAreaElement > | null
+) => {
 	const [ isTyping, setIsTyping ] = useState( false );
 	const typingTimeout = useRef< NodeJS.Timeout >();
 
@@ -36,10 +37,10 @@ export const AIInput = ( {
 		useAiIcon();
 
 	useEffect( () => {
-		if ( ! disabled && inputRef.current ) {
-			inputRef.current.focus();
+		if ( ! disabled && inputRef && 'current' in inputRef && inputRef.current ) {
+			inputRef.current?.focus();
 		}
-	}, [ disabled ] );
+	}, [ disabled, inputRef ] );
 
 	useEffect( () => {
 		startStateMachine();
@@ -77,7 +78,7 @@ export const AIInput = ( {
 	const handleInput = ( e: React.ChangeEvent< HTMLTextAreaElement > ) => {
 		setInput( e.target.value );
 
-		if ( inputRef.current ) {
+		if ( inputRef && 'current' in inputRef && inputRef.current ) {
 			// Reset the height of the textarea to auto to recalculate the height
 			inputRef.current.style.height = 'auto';
 
@@ -106,7 +107,7 @@ export const AIInput = ( {
 			}
 			if ( input.trim() !== '' ) {
 				handleSend();
-				if ( inputRef.current ) {
+				if ( inputRef && 'current' in inputRef && inputRef.current ) {
 					// Reset the input height to default when the user sends the message
 					inputRef.current.style.height = 'auto';
 				}
@@ -219,3 +220,5 @@ export const AIInput = ( {
 		</div>
 	);
 };
+
+export const AIInput = forwardRef( UnforwardedAIInput );

--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -156,6 +156,7 @@ const UnauthenticatedView = ( { onAuthenticate }: { onAuthenticate: () => void }
 );
 
 export function ContentTabAssistant( { selectedSite }: ContentTabAssistantProps ) {
+	const inputRef = useRef< HTMLTextAreaElement >( null );
 	const currentSiteChatContext = useChatContext();
 	const { isAuthenticated, authenticate, user } = useAuth();
 	const { messages, addMessage, clearMessages, updateMessage, chatId } = useAssistant(
@@ -250,7 +251,10 @@ export function ContentTabAssistant( { selectedSite }: ContentTabAssistantProps 
 								messages.length > 0 ? (
 									<>
 										<WelcomeComponent
-											onExampleClick={ ( prompt ) => handleSend( prompt ) }
+											onExampleClick={ ( prompt ) => {
+												handleSend( prompt );
+												inputRef.current?.focus();
+											} }
 											showExamplePrompts={ messages.length === 0 }
 											messages={ welcomeMessages }
 											examplePrompts={ examplePrompts }
@@ -269,7 +273,10 @@ export function ContentTabAssistant( { selectedSite }: ContentTabAssistantProps 
 							) : (
 								<>
 									<WelcomeComponent
-										onExampleClick={ ( prompt ) => handleSend( prompt ) }
+										onExampleClick={ ( prompt ) => {
+											handleSend( prompt );
+											inputRef.current?.focus();
+										} }
 										showExamplePrompts={ messages.length === 0 }
 										messages={ welcomeMessages }
 										examplePrompts={ examplePrompts }
@@ -293,6 +300,7 @@ export function ContentTabAssistant( { selectedSite }: ContentTabAssistantProps 
 			<div className="sticky bottom-0 bg-gray-50/[0.8] backdrop-blur-sm w-full px-8 pt-4 flex items-center">
 				<div className="w-full flex flex-col items-center">
 					<AIInput
+						ref={ inputRef }
 						disabled={ disabled }
 						input={ input }
 						setInput={ setInput }

--- a/src/components/tests/ai-input.test.tsx
+++ b/src/components/tests/ai-input.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import React from 'react';
 import { AIInput } from '../ai-input';
 
 const mockShowMessageBox = jest.fn();
@@ -34,11 +35,13 @@ describe( 'AIInput Component', () => {
 		handleKeyDown = jest.fn();
 		setInput = jest.fn();
 		clearInput = jest.fn();
+		const inputRef = React.createRef< HTMLTextAreaElement >();
 
 		jest.clearAllMocks();
 
 		render(
 			<AIInput
+				ref={ inputRef }
 				disabled={ defaultProps.disabled }
 				input={ defaultProps.input }
 				setInput={ setInput }

--- a/src/components/tests/content-tab-assistant.test.tsx
+++ b/src/components/tests/content-tab-assistant.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
 import { useAuth } from '../../hooks/use-auth';
 import { useFetchWelcomeMessages } from '../../hooks/use-fetch-welcome-messages';
 import { ContentTabAssistant } from '../content-tab-assistant';
@@ -211,6 +212,25 @@ describe( 'ContentTabAssistant', () => {
 		expect( screen.getByText( 'How to create a WordPress site' ) ).toBeVisible();
 		expect( screen.getByText( 'How to clear cache' ) ).toBeVisible();
 		expect( screen.getByText( 'How to install a plugin' ) ).toBeVisible();
+	} );
+
+	test( 'should manage the focus state when selecting an example prompt', async () => {
+		jest.useRealTimers();
+		const user = userEvent.setup();
+		render( <ContentTabAssistant selectedSite={ runningSite } /> );
+
+		let textInput = getInput();
+		await user.type( textInput, '[Tab]' );
+		expect( textInput ).not.toHaveFocus();
+
+		const samplePrompt = await screen.findByRole( 'button', {
+			name: 'How to create a WordPress site',
+		} );
+		expect( samplePrompt ).toBeVisible();
+		fireEvent.click( samplePrompt );
+
+		textInput = screen.getByPlaceholderText( 'Thinking about that...' );
+		expect( textInput ).toHaveFocus();
 	} );
 
 	test( 'renders the selected prompt of Welcome messages and confirms other prompts are removed', async () => {

--- a/src/components/welcome-message-prompt.tsx
+++ b/src/components/welcome-message-prompt.tsx
@@ -1,6 +1,7 @@
 import { __ } from '@wordpress/i18n';
 import { arrowRight } from '@wordpress/icons';
 import { cx } from '../lib/cx';
+import Button from './button';
 
 interface WelcomeMessagePromptProps {
 	children?: React.ReactNode;
@@ -48,13 +49,10 @@ export const ExampleMessagePrompt = ( {
 	className,
 }: ExampleMessagePromptProps ) => (
 	<div className={ cx( 'flex mt-2' ) }>
-		<div
-			className={ cx(
-				'inline-block px-3 py-2 rounded border border-gray-300 lg:max-w-[70%] select-text cursor-pointer focus:border-a8c-blueberry hover:border-a8c-blueberry hover:text-a8c-blueberry hover:fill-a8c-blueberry',
-				className
-			) }
+		<Button
+			variant="secondary"
+			className={ cx( '!rounded lg:max-w-[70%]', className ) }
 			onClick={ onClick }
-			role="button"
 		>
 			<div className="assistant-markdown flex items-center">
 				<span className={ cx( 'mr-2 w-4 h-4 flex items-center justify-center' ) }>
@@ -62,7 +60,7 @@ export const ExampleMessagePrompt = ( {
 				</span>
 				<p className="inline">{ children }</p>
 			</div>
-		</div>
+		</Button>
 	</div>
 );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Proposed Changes

Rely upon recommended `button` element rather than emulating it with
various attributes. This ensures the affordance remains accessible.
This includes supporting keyboard navigation via focus, which was not
possible in the previous implementation.

Add focus management that moves focus to the Assistant input 
whenever a Welcome suggestion is selected. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**1. Welcome prompt buttons are focusable**
1. Rely upon keyboard navigation *only* for the following.
1. Navigate to the Assistant tab.
1. Move focus to one of the provided Assistant prompts.
1. Press <kbd>Enter</kbd> to activate the prompt.
1. Verify the Assistant receives and responds to the prompt.

**2. Selecting a welcome prompt manages focus**
1. Rely upon keyboard navigation *only* for the following.
1. Navigate to the Assistant tab.
1. Move focus to one of the provided Assistant prompts.
1. Press <kbd>Enter</kbd> to activate the prompt.
1. Verify focus is moved to the Assistant text area.

| Default Before | Default After |
| - | - |
| <img width="1012" alt="default-before" src="https://github.com/Automattic/studio/assets/438664/a669a239-9a93-433b-831a-051603e874f6"> | <img width="1012" alt="default-after" src="https://github.com/Automattic/studio/assets/438664/789738b2-ac64-414e-aebb-4f31450e8a25"> |

| Hover Before | Hover After |
| - | - |
| <img width="1012" alt="default-hover" src="https://github.com/Automattic/studio/assets/438664/c4a8b1d4-9511-4d31-8ba6-4953c4b45312"> | <img width="1012" alt="hover-after" src="https://github.com/Automattic/studio/assets/438664/a2a8f74f-d6f3-43e8-abd8-ad6f886e3f01"> |

| Focus Before | Focus After |
| - | - |
| N/A, unsupported | <img width="1012" alt="focus-after" src="https://github.com/Automattic/studio/assets/438664/1154bb48-6042-4204-81ba-3d5d0d9cd856"> |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
