### PR TITLE
Removes reference to Windows waiting list

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Studio is open source and is available to download for free!
 
 **Step 1: Download the App**
 
-[Download Studio for macOS (Intel or Silicon)](https://developer.wordpress.com/studio/) for free today, or get on [the waiting list for the Windows version of Studio](https://developer.wordpress.com/studio-for-windows/).
+[Download Studio for macOS (Intel or Silicon) or Windows](https://developer.wordpress.com/studio/) for free today.
 
 **Step 2: Explore the Documentation**
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->


## Proposed Changes

- Removes the link to the Windows waiting list and adds Windows to the main "download" CTA.

