### PR TITLE
Load feature flags from backend

### DIFF
--- a/src/components/root.tsx
+++ b/src/components/root.tsx
@@ -1,5 +1,6 @@
 import { ChatProvider } from '../hooks/use-chat-context';
 import { InstalledAppsProvider } from '../hooks/use-check-installed-apps';
+import { FeatureFlagsProvider } from '../hooks/use-feature-flags';
 import { OnboardingProvider } from '../hooks/use-onboarding';
 import { PromptUsageProvider } from '../hooks/use-prompt-usage';
 import { SiteDetailsProvider } from '../hooks/use-site-details';
@@ -16,19 +17,21 @@ const Root = () => {
 			<CrashTester />
 			<AuthProvider>
 				<SiteDetailsProvider>
-					<DemoSiteUpdateProvider>
-						<ThemeDetailsProvider>
-							<InstalledAppsProvider>
-								<OnboardingProvider>
-									<PromptUsageProvider>
-										<ChatProvider>
-											<App />
-										</ChatProvider>
-									</PromptUsageProvider>
-								</OnboardingProvider>
-							</InstalledAppsProvider>
-						</ThemeDetailsProvider>
-					</DemoSiteUpdateProvider>
+					<FeatureFlagsProvider>
+						<DemoSiteUpdateProvider>
+							<ThemeDetailsProvider>
+								<InstalledAppsProvider>
+									<OnboardingProvider>
+										<PromptUsageProvider>
+											<ChatProvider>
+												<App />
+											</ChatProvider>
+										</PromptUsageProvider>
+									</OnboardingProvider>
+								</InstalledAppsProvider>
+							</ThemeDetailsProvider>
+						</DemoSiteUpdateProvider>
+					</FeatureFlagsProvider>
 				</SiteDetailsProvider>
 			</AuthProvider>
 		</ErrorBoundary>

--- a/src/components/site-content-tabs.tsx
+++ b/src/components/site-content-tabs.tsx
@@ -2,7 +2,6 @@ import { TabPanel } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
 import { useContentTabs } from '../hooks/use-content-tabs';
 import { useSiteDetails } from '../hooks/use-site-details';
-import { getAppGlobals } from '../lib/app-globals';
 import { ContentTabAssistant } from './content-tab-assistant';
 import { ContentTabOverview } from './content-tab-overview';
 import { ContentTabSettings } from './content-tab-settings';
@@ -13,8 +12,6 @@ export function SiteContentTabs() {
 	const { selectedSite } = useSiteDetails();
 	const tabs = useContentTabs();
 	const { __ } = useI18n();
-
-	const assistantEnabled = getAppGlobals().assistantEnabled;
 
 	if ( ! selectedSite ) {
 		return (
@@ -37,9 +34,7 @@ export function SiteContentTabs() {
 						{ name === 'overview' && <ContentTabOverview selectedSite={ selectedSite } /> }
 						{ name === 'share' && <ContentTabSnapshots selectedSite={ selectedSite } /> }
 						{ name === 'settings' && <ContentTabSettings selectedSite={ selectedSite } /> }
-						{ assistantEnabled && name === 'assistant' && (
-							<ContentTabAssistant selectedSite={ selectedSite } />
-						) }
+						{ name === 'assistant' && <ContentTabAssistant selectedSite={ selectedSite } /> }
 					</div>
 				) }
 			</TabPanel>

--- a/src/components/tests/site-content-tabs.test.tsx
+++ b/src/components/tests/site-content-tabs.test.tsx
@@ -1,4 +1,5 @@
 import { act, render, screen } from '@testing-library/react';
+import { useFeatureFlags } from '../../hooks/use-feature-flags';
 import { useSiteDetails } from '../../hooks/use-site-details';
 import { SiteContentTabs } from '../site-content-tabs';
 
@@ -9,6 +10,7 @@ const selectedSite = {
 	path: '/test-site',
 };
 
+jest.mock( '../../hooks/use-feature-flags' );
 jest.mock( '../../hooks/use-site-details' );
 jest.mock( '../../hooks/use-auth', () => ( {
 	useAuth: () => ( {
@@ -26,12 +28,9 @@ jest.mock( '../../hooks/use-archive-site', () => ( {
 
 jest.mock( '../../lib/get-ipc-api' );
 
-jest.mock( '../../lib/app-globals', () => ( {
-	getAppGlobals: () => ( {
-		assistantEnabled: false,
-	} ),
-	isMac: jest.fn(),
-} ) );
+( useFeatureFlags as jest.Mock ).mockReturnValue( {
+	assistantEnabled: false,
+} );
 
 describe( 'SiteContentTabs', () => {
 	beforeEach( () => {
@@ -85,5 +84,18 @@ describe( 'SiteContentTabs', () => {
 		} );
 		await act( async () => render( <SiteContentTabs /> ) );
 		expect( screen.queryByRole( 'tab', { name: 'Assistant' } ) ).toBeNull();
+	} );
+
+	it( 'should render the Assistant tab if assistantEnabled is enabled', async () => {
+		( useSiteDetails as jest.Mock ).mockReturnValue( {
+			selectedSite,
+			snapshots: [],
+			loadingServer: {},
+		} );
+		( useFeatureFlags as jest.Mock ).mockReturnValue( {
+			assistantEnabled: true,
+		} );
+		await act( async () => render( <SiteContentTabs /> ) );
+		expect( screen.queryByRole( 'tab', { name: 'Assistant' } ) ).toBeVisible();
 	} );
 } );

--- a/src/components/tests/user-settings.test.tsx
+++ b/src/components/tests/user-settings.test.tsx
@@ -1,19 +1,18 @@
 // To run tests, execute `npm run test -- src/components/user-settings.test.tsx` from the root directory
 import { fireEvent, render, screen } from '@testing-library/react';
 import { useAuth } from '../../hooks/use-auth';
+import { useFeatureFlags } from '../../hooks/use-feature-flags';
 import { useIpcListener } from '../../hooks/use-ipc-listener';
 import { useOffline } from '../../hooks/use-offline';
 import UserSettings from '../user-settings';
 
-jest.mock( '../../lib/app-globals', () => ( {
-	getAppGlobals: () => ( {
-		assistantEnabled: false,
-	} ),
-	isMac: jest.fn(),
-} ) );
-
+jest.mock( '../../hooks/use-feature-flags' );
 jest.mock( '../../hooks/use-auth' );
 jest.mock( '../../hooks/use-ipc-listener' );
+
+( useFeatureFlags as jest.Mock ).mockReturnValue( {
+	assistantEnabled: false,
+} );
 
 afterEach( () => {
 	jest.clearAllMocks();

--- a/src/components/user-settings.tsx
+++ b/src/components/user-settings.tsx
@@ -6,12 +6,12 @@ import { useCallback, useState, useEffect } from 'react';
 import { LIMIT_OF_PROMPTS_PER_USER, WPCOM_PROFILE_URL } from '../constants';
 import { useAuth } from '../hooks/use-auth';
 import { useDeleteSnapshot } from '../hooks/use-delete-snapshot';
+import { useFeatureFlags } from '../hooks/use-feature-flags';
 import { useFetchSnapshots } from '../hooks/use-fetch-snapshots';
 import { useIpcListener } from '../hooks/use-ipc-listener';
 import { useOffline } from '../hooks/use-offline';
 import { usePromptUsage } from '../hooks/use-prompt-usage';
 import { useSiteUsage } from '../hooks/use-site-usage';
-import { getAppGlobals } from '../lib/app-globals';
 import { cx } from '../lib/cx';
 import { getIpcApi } from '../lib/get-ipc-api';
 import Button from './button';
@@ -143,7 +143,8 @@ const SnapshotInfo = ( {
 function PromptInfo() {
 	const { __ } = useI18n();
 	const { promptCount = 0, promptLimit = LIMIT_OF_PROMPTS_PER_USER } = usePromptUsage();
-	const assistantEnabled = getAppGlobals().assistantEnabled;
+	const { assistantEnabled } = useFeatureFlags();
+
 	if ( ! assistantEnabled ) {
 		return null;
 	}

--- a/src/hooks/use-content-tabs.ts
+++ b/src/hooks/use-content-tabs.ts
@@ -1,12 +1,11 @@
 import { TabPanel } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
 import { useMemo } from 'react';
-import { getAppGlobals } from '../lib/app-globals';
+import { useFeatureFlags } from './use-feature-flags';
 
 export function useContentTabs() {
 	const { __ } = useI18n();
-
-	const assistantEnabled = getAppGlobals().assistantEnabled;
+	const { assistantEnabled } = useFeatureFlags();
 
 	return useMemo( () => {
 		const tabs: React.ComponentProps< typeof TabPanel >[ 'tabs' ] = [

--- a/src/hooks/use-feature-flags.tsx
+++ b/src/hooks/use-feature-flags.tsx
@@ -1,0 +1,57 @@
+import React, { createContext, useContext, ReactNode, useState, useEffect } from 'react';
+import { useAuth } from './use-auth';
+
+export interface FeatureFlagsContextType {
+	assistantEnabled: boolean;
+}
+
+const defaultFeatureFlags: FeatureFlagsContextType = {
+	assistantEnabled: false,
+};
+
+export const FeatureFlagsContext = createContext< FeatureFlagsContextType >( defaultFeatureFlags );
+
+interface FeatureFlagsProviderProps {
+	children: ReactNode;
+}
+
+export const FeatureFlagsProvider: React.FC< FeatureFlagsProviderProps > = ( { children } ) => {
+	const [ featureFlags, setFeatureFlags ] =
+		useState< FeatureFlagsContextType >( defaultFeatureFlags );
+	const { isAuthenticated, client } = useAuth();
+
+	useEffect( () => {
+		if ( ! isAuthenticated || ! client ) {
+			return;
+		}
+		let cancel = false;
+		async function loadFeatureFlags() {
+			setTimeout( () => {
+				if ( cancel ) {
+					return;
+				}
+				setFeatureFlags( {
+					assistantEnabled: true,
+				} );
+			}, 1000 );
+		}
+		loadFeatureFlags();
+		return () => {
+			cancel = true;
+		};
+	}, [ isAuthenticated, client ] );
+
+	return (
+		<FeatureFlagsContext.Provider value={ featureFlags }>{ children }</FeatureFlagsContext.Provider>
+	);
+};
+
+export const useFeatureFlags = (): FeatureFlagsContextType => {
+	const context = useContext( FeatureFlagsContext );
+
+	if ( ! context ) {
+		throw new Error( 'useFeatureFlags must be used within an FeatureFlagsProvider' );
+	}
+
+	return context;
+};

--- a/src/hooks/use-feature-flags.tsx
+++ b/src/hooks/use-feature-flags.tsx
@@ -36,7 +36,8 @@ export const FeatureFlagsProvider: React.FC< FeatureFlagsProviderProps > = ( { c
 					return;
 				}
 				setFeatureFlags( {
-					assistantEnabled: Boolean( flags?.assistantEnabled ) || assistantEnabledFromGlobals,
+					assistantEnabled:
+						Boolean( flags?.[ 'assistant_enabled' ] ) || assistantEnabledFromGlobals,
 				} );
 			} catch ( error ) {
 				console.error( error );

--- a/src/hooks/use-feature-flags.tsx
+++ b/src/hooks/use-feature-flags.tsx
@@ -1,23 +1,24 @@
 import React, { createContext, useContext, ReactNode, useState, useEffect } from 'react';
+import { getAppGlobals } from '../lib/app-globals';
 import { useAuth } from './use-auth';
 
 export interface FeatureFlagsContextType {
 	assistantEnabled: boolean;
 }
 
-const defaultFeatureFlags: FeatureFlagsContextType = {
+export const FeatureFlagsContext = createContext< FeatureFlagsContextType >( {
 	assistantEnabled: false,
-};
-
-export const FeatureFlagsContext = createContext< FeatureFlagsContextType >( defaultFeatureFlags );
+} );
 
 interface FeatureFlagsProviderProps {
 	children: ReactNode;
 }
 
 export const FeatureFlagsProvider: React.FC< FeatureFlagsProviderProps > = ( { children } ) => {
-	const [ featureFlags, setFeatureFlags ] =
-		useState< FeatureFlagsContextType >( defaultFeatureFlags );
+	const assistantEnabledFromGlobals = getAppGlobals().assistantEnabled;
+	const [ featureFlags, setFeatureFlags ] = useState< FeatureFlagsContextType >( {
+		assistantEnabled: assistantEnabledFromGlobals,
+	} );
 	const { isAuthenticated, client } = useAuth();
 
 	useEffect( () => {
@@ -35,7 +36,7 @@ export const FeatureFlagsProvider: React.FC< FeatureFlagsProviderProps > = ( { c
 					return;
 				}
 				setFeatureFlags( {
-					assistantEnabled: Boolean( flags?.assistantEnabled ),
+					assistantEnabled: Boolean( flags?.assistantEnabled ) || assistantEnabledFromGlobals,
 				} );
 			} catch ( error ) {
 				console.error( error );
@@ -45,7 +46,7 @@ export const FeatureFlagsProvider: React.FC< FeatureFlagsProviderProps > = ( { c
 		return () => {
 			cancel = true;
 		};
-	}, [ isAuthenticated, client ] );
+	}, [ isAuthenticated, client, assistantEnabledFromGlobals ] );
 
 	return (
 		<FeatureFlagsContext.Provider value={ featureFlags }>{ children }</FeatureFlagsContext.Provider>

--- a/src/hooks/use-feature-flags.tsx
+++ b/src/hooks/use-feature-flags.tsx
@@ -21,19 +21,25 @@ export const FeatureFlagsProvider: React.FC< FeatureFlagsProviderProps > = ( { c
 	const { isAuthenticated, client } = useAuth();
 
 	useEffect( () => {
-		if ( ! isAuthenticated || ! client ) {
-			return;
-		}
 		let cancel = false;
 		async function loadFeatureFlags() {
-			setTimeout( () => {
+			if ( ! isAuthenticated || ! client ) {
+				return;
+			}
+			try {
+				const flags = await client.req.get( {
+					path: '/studio-app/feature-flags',
+					apiNamespace: 'wpcom/v2',
+				} );
 				if ( cancel ) {
 					return;
 				}
 				setFeatureFlags( {
-					assistantEnabled: true,
+					assistantEnabled: Boolean( flags?.assistantEnabled ),
 				} );
-			}, 1000 );
+			} catch ( error ) {
+				console.error( error );
+			}
 		}
 		loadFeatureFlags();
 		return () => {

--- a/src/hooks/use-prompt-usage.tsx
+++ b/src/hooks/use-prompt-usage.tsx
@@ -1,8 +1,8 @@
 import * as Sentry from '@sentry/electron/renderer';
 import { useState, useEffect, useCallback, useMemo, createContext, useContext } from 'react';
 import { LIMIT_OF_PROMPTS_PER_USER } from '../constants';
-import { getAppGlobals } from '../lib/app-globals';
 import { useAuth } from './use-auth';
+import { useFeatureFlags } from './use-feature-flags';
 
 type PromptUsage = {
 	promptLimit: number;
@@ -42,7 +42,7 @@ const calculateDaysRemaining = ( quotaResetDate: string ): number => {
 
 export function PromptUsageProvider( { children }: PromptUsageProps ) {
 	const { Provider } = promptUsageContext;
-	const assistantEnabled = getAppGlobals().assistantEnabled;
+	const { assistantEnabled } = useFeatureFlags();
 
 	const [ initiated, setInitiated ] = useState( false );
 	const [ promptLimit, setPromptLimit ] = useState( LIMIT_OF_PROMPTS_PER_USER );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

- Closes https://github.com/Automattic/dotcom-forge/issues/7985

## Proposed Changes

- Create a provider to load the feature flags
- Make request to the backend
- Update tests

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- ~Apply the Diff D153732-code~
- Start studio by running `npm start`
- Log in with you A8C account
- Observe you can access the assistant
- Logout
- Observe you can still access the assistant
- Close the app or Log in with a regular account
- Observe don't have access anymore

We respect the previous feature flag from cli:
- Start studio by running `STUDIO_AI=true npm start`
- Observe the assistant is available for all the accounts

https://github.com/Automattic/studio/assets/779993/594ce110-5057-4d7d-81f4-3944d5a32bcc


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?