### PR TITLE
test: Revert rudimentary console filtering

### DIFF
--- a/jest-setup.ts
+++ b/jest-setup.ts
@@ -29,39 +29,6 @@ if ( typeof window !== 'undefined' ) {
 nock.disableNetConnect();
 nock.enableNetConnect( 'raw.githubusercontent.com' );
 
-/**
- * TODO: Replace this manual filter with a more robust logger that can be
- * disabled for the testing environment. Consider enabling a lint rule that
- * discourages direct use of `console` methods.
- */
-function filteredConsole( level: ( ...args: any[] ) => void ) {
-	const ignoredMessages = [
-		'Loaded user data from ',
-		'Saved user data to ',
-		'Server start',
-		'Would have bumped stat: ',
-		'Starting new session',
-		'App version: ',
-		'Built from commit: mock-hash',
-		'Local timezone: UTC',
-		'App locale: ',
-		'System locale: ',
-		'Used language: ',
-	];
-
-	return ( ...args: any[] ) => {
-		if ( ignoredMessages.some( ( ignoredMessage ) => args[ 0 ].includes( ignoredMessage ) ) ) {
-			return;
-		}
-
-		level( ...args );
-	};
-}
-console.log = filteredConsole( console.log );
-console.error = filteredConsole( console.error );
-console.warn = filteredConsole( console.warn );
-console.info = filteredConsole( console.info );
-
 // We consider the app to be online by default.
 jest.mock( './src/hooks/use-offline', () => ( {
 	useOffline: jest.fn().mockReturnValue( false ),


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Relates to https://github.com/Automattic/studio/pull/316.

## Proposed Changes

**Revert rudimentary console filtering**
While this successfully reduced noise, it introduced indirection when
valid console errors log in tests, making it far more difficult to
decipher where an error originates. This trade-off felt like a
net-negative.

Example indirection in error log, where the stack trace points to the
filter, rather than the error origin itself:

<details><summary>Example error indirection</summary>

```
  console.error
    Warning: Each child in a list should have a unique "key" prop. See https://reactjs.org/link/warning-keys for more information.
        at /Users/davidcalhoun/Sites/a8c/studio/src/components/content-tab-assistant.tsx:76:3
        at div
        at div
        at div
        at ContentTabAssistant (/Users/davidcalhoun/Sites/a8c/studio/src/components/content-tab-assistant.tsx:172:40)

      55 |              }
      56 |
    > 57 |              level( ...args );
         |              ^
      58 |      };
      59 | }
      60 | console.log = filteredConsole( console.log );

      at console.error (jest-setup.ts:57:3)
      at printWarning (node_modules/react/cjs/react-jsx-runtime.development.js:87:30)
      at error (node_modules/react/cjs/react-jsx-runtime.development.js:61:7)
      at validateExplicitKey (node_modules/react/cjs/react-jsx-runtime.development.js:1078:5)
      at validateChildKeys (node_modules/react/cjs/react-jsx-runtime.development.js:1105:11)
      at jsxWithValidation (node_modules/react/cjs/react-jsx-runtime.development.js:1266:15)
      at jsxWithValidationStatic (node_modules/react/cjs/react-jsx-runtime.development.js:1296:12)
      at src/components/content-tab-assistant.tsx:105:4
      at renderWithHooks (node_modules/react-dom/cjs/react-dom.development.js:16305:18)
      at updateFunctionComponent (node_modules/react-dom/cjs/react-dom.development.js:19588:20)
      at updateSimpleMemoComponent (node_modules/react-dom/cjs/react-dom.development.js:19425:10)
      at beginWork (node_modules/react-dom/cjs/react-dom.development.js:21678:16)
      at beginWork$1 (node_modules/react-dom/cjs/react-dom.development.js:27426:14)
      at performUnitOfWork (node_modules/react-dom/cjs/react-dom.development.js:26560:12)
      at workLoopSync (node_modules/react-dom/cjs/react-dom.development.js:26466:5)
      at renderRootSync (node_modules/react-dom/cjs/react-dom.development.js:26434:7)
      at performConcurrentWorkOnRoot (node_modules/react-dom/cjs/react-dom.development.js:25738:74)
      at flushActQueue (node_modules/react/cjs/react.development.js:2667:24)
      at act (node_modules/react/cjs/react.development.js:2582:11)
      at node_modules/@testing-library/react/dist/act-compat.js:46:25
      at renderRoot (node_modules/@testing-library/react/dist/pure.js:161:26)
      at render (node_modules/@testing-library/react/dist/pure.js:247:10)
      at src/components/tests/content-tab-assistant.test.tsx:107:9
      at src/components/tests/content-tab-assistant.test.tsx:8:71
      at Object.<anonymous>.__awaiter (src/components/tests/content-tab-assistant.test.tsx:4:12)
      at Object.<anonymous> (src/components/tests/content-tab-assistant.test.tsx:104:73)
```

</details>

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

N/A, no user-facing changes.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
