### PR TITLE
Studio: fix error with new message id

### DIFF
--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -103,11 +103,10 @@ const AuthenticatedView = memo(
 
 		return (
 			<>
-				{ messages.map( ( message, index ) => (
-					<>
+				{ messages.map( ( message ) => (
+					<div key={ message.id }>
 						<ChatMessage
-							key={ index }
-							id={ `message-chat-${ index }` }
+							id={ `message-chat-${ message.id }` }
 							isUser={ message.role === 'user' }
 							siteId={ siteId }
 							updateMessage={ updateMessage }
@@ -118,7 +117,7 @@ const AuthenticatedView = memo(
 							{ message.content }
 						</ChatMessage>
 						{ message.failedMessage && <ErrorNotice /> }
-					</>
+					</div>
 				) ) }
 				{ isAssistantThinking && (
 					<ChatMessage isUser={ false } id="message-thinking">

--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -2,7 +2,7 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { Icon, external } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
-import React, { useState, useEffect, useRef, memo } from 'react';
+import React, { useState, useEffect, useRef, memo, Fragment } from 'react';
 import { AI_GUIDELINES_URL } from '../constants';
 import { useAssistant, Message as MessageType } from '../hooks/use-assistant';
 import { useAssistantApi } from '../hooks/use-assistant-api';
@@ -104,7 +104,7 @@ const AuthenticatedView = memo(
 		return (
 			<>
 				{ messages.map( ( message ) => (
-					<div key={ message.id }>
+					<Fragment key={ message.id }>
 						<ChatMessage
 							id={ `message-chat-${ message.id }` }
 							isUser={ message.role === 'user' }
@@ -117,7 +117,7 @@ const AuthenticatedView = memo(
 							{ message.content }
 						</ChatMessage>
 						{ message.failedMessage && <ErrorNotice /> }
-					</div>
+					</Fragment>
 				) ) }
 				{ isAssistantThinking && (
 					<ChatMessage isUser={ false } id="message-thinking">

--- a/src/hooks/use-assistant.ts
+++ b/src/hooks/use-assistant.ts
@@ -23,8 +23,12 @@ const chatMessagesStoreKey = 'ai_chat_messages';
 
 export const useAssistant = ( instanceId: string ) => {
 	const [ messagesDict, setMessagesDict ] = useState< MessageDict >( {} );
-	const [ chatIdDict, setChatIdDict ] = useState< ChatIdDict >( {} );
-	const nextMessageIdRef = useRef< { [ key: string ]: number } >( {} );
+	const [ chatIdDict, setChatIdDict ] = useState< ChatIdDict >( {
+		[ instanceId ]: undefined,
+	} );
+	const nextMessageIdRef = useRef< { [ key: string ]: number } >( {
+		[ instanceId ]: -1, // The first message should have id 0, as we do +1 when we add message
+	} );
 
 	useEffect( () => {
 		const storedMessages = localStorage.getItem( chatMessagesStoreKey );
@@ -51,7 +55,7 @@ export const useAssistant = ( instanceId: string ) => {
 				const prevMessages = prevDict[ instanceId ] || [];
 				const updatedMessages = [
 					...prevMessages,
-					{ id: newMessageId, content, role, chatId, createdAt: Date.now() },
+					{ content, role, id: newMessageId, chatId, createdAt: Date.now() },
 				];
 				const newDict = { ...prevDict, [ instanceId ]: updatedMessages };
 				localStorage.setItem( chatMessagesStoreKey, JSON.stringify( newDict ) );

--- a/src/hooks/use-assistant.ts
+++ b/src/hooks/use-assistant.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 
 export type Message = {
 	id?: number;
@@ -24,13 +24,18 @@ const chatMessagesStoreKey = 'ai_chat_messages';
 export const useAssistant = ( instanceId: string ) => {
 	const [ messagesDict, setMessagesDict ] = useState< MessageDict >( {} );
 	const [ chatIdDict, setChatIdDict ] = useState< ChatIdDict >( {} );
+	const nextMessageIdRef = useRef< { [ key: string ]: number } >( {} );
 
 	useEffect( () => {
 		const storedMessages = localStorage.getItem( chatMessagesStoreKey );
 		const storedChatIds = localStorage.getItem( chatIdStoreKey );
 
 		if ( storedMessages ) {
-			setMessagesDict( JSON.parse( storedMessages ) );
+			const parsedMessages: MessageDict = JSON.parse( storedMessages );
+			setMessagesDict( parsedMessages );
+			Object.entries( parsedMessages ).forEach( ( [ key, messages ] ) => {
+				nextMessageIdRef.current[ key ] = messages.length;
+			} );
 		}
 		if ( storedChatIds ) {
 			setChatIdDict( JSON.parse( storedChatIds ) );
@@ -39,13 +44,14 @@ export const useAssistant = ( instanceId: string ) => {
 
 	const addMessage = useCallback(
 		( content: string, role: 'user' | 'assistant', chatId?: string ) => {
-			const messages = messagesDict[ instanceId ] || [];
-			const newMessageId = messages.length;
+			const newMessageId = nextMessageIdRef.current[ instanceId ] + 1;
+			nextMessageIdRef.current[ instanceId ] = newMessageId;
+
 			setMessagesDict( ( prevDict ) => {
 				const prevMessages = prevDict[ instanceId ] || [];
 				const updatedMessages = [
 					...prevMessages,
-					{ content, role, id: newMessageId, createdAt: Date.now() },
+					{ id: newMessageId, content, role, chatId, createdAt: Date.now() },
 				];
 				const newDict = { ...prevDict, [ instanceId ]: updatedMessages };
 				localStorage.setItem( chatMessagesStoreKey, JSON.stringify( newDict ) );
@@ -63,7 +69,7 @@ export const useAssistant = ( instanceId: string ) => {
 
 			return newMessageId; // Return the new message ID
 		},
-		[ instanceId, messagesDict ]
+		[ instanceId ]
 	);
 
 	const updateMessage = useCallback(
@@ -127,6 +133,7 @@ export const useAssistant = ( instanceId: string ) => {
 			localStorage.setItem( chatIdStoreKey, JSON.stringify( rest ) );
 			return rest;
 		} );
+		nextMessageIdRef.current[ instanceId ] = 0;
 	}, [ instanceId ] );
 
 	return useMemo(


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/7999

## Proposed Changes

This pr  fixes the following:
- All messages get the same id.
- Because of the introduction of the <ErrorNotice/> component, and because those two, were not wrapped with a div, the key attributed wasn't working, resulting in errors. (The shorthanded version of the fragment component doesn't accept key attribute, besides that, the key attribute is no ChatMessage right now )

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Open Studio
- Clean all your messagese
- Add messages
- Ensure that each one of them has a unique id
- Switch between different sites, and ensure the message ids are correct
- Ensure that by visiting assistant tab, and reloading the page you don't get any errors in developer console

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
