### PR TITLE
Exclude run wp db, shell, and server commands

### DIFF
--- a/src/components/tests/assistant-code-block.test.tsx
+++ b/src/components/tests/assistant-code-block.test.tsx
@@ -66,6 +66,21 @@ describe( 'createCodeComponent', () => {
 
 		expect( screen.queryByText( 'Run' ) ).not.toBeInTheDocument();
 	} );
+	it( 'should hide the "run" button for unsupported commands db', () => {
+		render( <CodeBlock className="language-bash" children="wp db export" /> );
+
+		expect( screen.queryByText( 'Run' ) ).not.toBeInTheDocument();
+	} );
+	it( 'should hide the "run" button for unsupported commands shell', () => {
+		render( <CodeBlock className="language-bash" children="wp shell" /> );
+
+		expect( screen.queryByText( 'Run' ) ).not.toBeInTheDocument();
+	} );
+	it( 'should hide the "run" button for unsupported commands server', () => {
+		render( <CodeBlock className="language-bash" children="wp server" /> );
+
+		expect( screen.queryByText( 'Run' ) ).not.toBeInTheDocument();
+	} );
 
 	it( 'should display the "run" button for elligble wp-cli commands that contain a placeholder char', () => {
 		render( <CodeBlock className="language-bash" children="wp eval 'var_dump(3 < 4);'" /> );

--- a/src/hooks/use-is-valid-wp-cli-inline.ts
+++ b/src/hooks/use-is-valid-wp-cli-inline.ts
@@ -1,6 +1,7 @@
 import { parse } from 'shell-quote';
 
 const PLACEHOLDER_CHAR_BEGIN = [ '<', '[', '{', '(' ];
+const UNSUPPORTED_COMMANDS = [ 'db', 'server', 'shell' ];
 
 export function useIsValidWpCliInline( command: string ) {
 	const wpCliArgs = parse( command )
@@ -14,17 +15,20 @@ export function useIsValidWpCliInline( command: string ) {
 			}
 		} )
 		.filter( Boolean ) as string[];
+	console.log( 'wpCliArgs', wpCliArgs );
 	const wpCommandCount = wpCliArgs.filter( ( arg ) => arg === 'wp' ).length;
 	const containsPath = wpCliArgs.some( ( arg ) => /path/i.test( arg ) || arg.startsWith( '/' ) );
 	const containsPlaceholderArgs = wpCliArgs.some( ( arg ) =>
 		PLACEHOLDER_CHAR_BEGIN.includes( arg[ 0 ] )
 	);
+	const containsUnsupportedCommand = UNSUPPORTED_COMMANDS.includes( wpCliArgs[ 1 ] );
 
 	return (
 		wpCliArgs.length > 0 &&
 		wpCliArgs[ 0 ] === 'wp' &&
 		wpCommandCount === 1 &&
 		! containsPath &&
-		! containsPlaceholderArgs
+		! containsPlaceholderArgs &&
+		! containsUnsupportedCommand
 	);
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

- Closes https://github.com/Automattic/dotcom-forge/issues/7865
- Related to https://github.com/Automattic/dotcom-forge/issues/7728

## Proposed Changes

- Hide run button for `db`, `shell`, and `server` wp subcommands.

## Testing Instructions

- Ask the assistant to display any of these commands. Like: Please use wp-cli to export my database.
- Observe the run button doesn't appear.

- Tests should pass

<img width="952" alt="Screenshot 2024-06-28 at 17 08 32" src="https://github.com/Automattic/studio/assets/779993/2b7d5ad4-483b-4bb0-9d83-c4665c16d49e">


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
