### PR TITLE
Fix publishing DMG files to S3

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -104,7 +104,7 @@ def distribute_builds(
       name: 'Mac Universal'
     },
     mac_universal_dmg: {
-      binary_path: File.join(BUILDS_FOLDER, 'Studio-darwin-universal', 'Studio.dmg'),
+      binary_path: File.join(BUILDS_FOLDER, 'Studio-darwin-universal.dmg'),
       filename_core: 'darwin-universal',
       extension: 'dmg',
       name: 'Mac Universal (DMG)'
@@ -116,7 +116,7 @@ def distribute_builds(
       name: 'Mac Intel'
     },
     x64_dmg: {
-      binary_path: File.join(BUILDS_FOLDER, 'Studio-darwin-x64', 'Studio.dmg'),
+      binary_path: File.join(BUILDS_FOLDER, 'Studio-darwin-x64.dmg'),
       filename_core: 'darwin-x64',
       extension: 'dmg',
       name: 'Mac Intel (DMG)'
@@ -128,7 +128,7 @@ def distribute_builds(
       name: 'Mac Apple Silicon'
     },
     arm64_dmg: {
-      binary_path: File.join(BUILDS_FOLDER, 'Studio-darwin-arm64', 'Studio.dmg'),
+      binary_path: File.join(BUILDS_FOLDER, 'Studio-darwin-arm64.dmg'),
       filename_core: 'darwin-arm64',
       extension: 'dmg',
       name: 'Mac Apple Silicon (DMG)'


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Proposed Changes

- Fix the path to DMG files in the step for publishing a release. The paths should point to the same location where the DMG file artifacts are generated:

<img width="380" alt="Screenshot 2024-07-01 at 15 08 12" src="https://github.com/Automattic/studio/assets/14905380/cf9af5e6-ba39-4d71-bcad-0da685d9bac4">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Observe all CI jobs succeed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
