### PR TITLE
Avoid creating main window before app initialization finishes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,7 @@ import {
 	migrateFromWpNowFolder,
 	needsToMigrateFromWpNowFolder,
 } from './migrations/migrate-from-wp-now-folder';
-import setupWPServerFiles from './setup-wp-server-files';
+import { setupWPServerFiles, updateWPServerFiles } from './setup-wp-server-files';
 import { stopAllServersOnQuit } from './site-server';
 import { loadUserData } from './storage/user-data'; // eslint-disable-next-line import/order
 import { setupUpdates } from './updates';
@@ -53,6 +53,8 @@ const isInInstaller = require( 'electron-squirrel-startup' );
 
 // Ensure we're the only instance of the app running
 const gotTheLock = app.requestSingleInstanceLock( getCLIDataForMainInstance() );
+
+let finishedInitialization = false;
 
 if ( gotTheLock && ! isInInstaller ) {
 	if ( isCLI() ) {
@@ -171,6 +173,10 @@ async function appBoot() {
 		} else {
 			// Handle custom protocol links on Windows and Linux
 			app.on( 'second-instance', ( _event, argv ): void => {
+				if ( ! finishedInitialization ) {
+					return;
+				}
+
 				withMainWindow( ( mainWindow ) => {
 					// CLI commands are likely invoked from other apps, so we need to avoid changing app focus.
 					const isCLI = argv?.find( ( arg ) => arg.startsWith( '--cli=' ) );
@@ -246,13 +252,15 @@ async function appBoot() {
 			} );
 		} );
 
+		setupIpc();
+
 		await setupWPServerFiles().catch( Sentry.captureException );
+		// WordPress server files are updated asynchronously to avoid delaying app initialization
+		updateWPServerFiles().catch( Sentry.captureException );
 
 		if ( await needsToMigrateFromWpNowFolder() ) {
 			await migrateFromWpNowFolder();
 		}
-
-		setupIpc();
 
 		createMainWindow();
 
@@ -270,6 +278,8 @@ async function appBoot() {
 		bumpStat( 'studio-app-launch-total', process.platform );
 		// Bump stat for unique weekly app launch, approximates weekly active users
 		bumpAggregatedUniqueStat( 'local-environment-launch-uniques', process.platform, 'weekly' );
+
+		finishedInitialization = true;
 	} );
 
 	// Quit when all windows are closed, except on macOS. There, it's common
@@ -290,10 +300,14 @@ async function appBoot() {
 	} );
 
 	app.on( 'activate', () => {
-		// On OS X it's common to re-create a window in the app when the
-		// dock icon is clicked and there are no other windows open.
+		if ( ! finishedInitialization ) {
+			return;
+		}
+
 		if ( BrowserWindow.getAllWindows().length === 0 ) {
-			app.whenReady().then( createMainWindow ).catch( Sentry.captureException );
+			// On OS X it's common to re-create a window in the app when the
+			// dock icon is clicked and there are no other windows open.
+			createMainWindow();
 		}
 	} );
 }

--- a/src/setup-wp-server-files.ts
+++ b/src/setup-wp-server-files.ts
@@ -58,10 +58,13 @@ async function copyBundledWPCLI() {
 	const bundledWPCLIPath = path.join( getResourcesPath(), 'wp-files', 'wp-cli', 'wp-cli.phar' );
 	await fs.copyFile( bundledWPCLIPath, getWpCliPath() );
 }
-export default async function setupWPServerFiles() {
+export async function setupWPServerFiles() {
 	await copyBundledLatestWPVersion();
 	await copyBundledSqlite();
 	await copyBundledWPCLI();
+}
+
+export async function updateWPServerFiles() {
 	await updateLatestWordPressVersion();
 	await updateLatestSqliteVersion();
 	await updateLatestWPCliVersion();

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -2,17 +2,19 @@
  * @jest-environment node
  */
 import fs from 'fs';
-import { createMainWindow } from '../main-window';
-import setupWPServerFiles from '../setup-wp-server-files';
+import { createMainWindow, withMainWindow } from '../main-window';
+import { setupWPServerFiles } from '../setup-wp-server-files';
 
 jest.mock( 'fs' );
 jest.mock( 'file-stream-rotator' );
 jest.mock( '../main-window' );
 jest.mock( '../updates' );
 jest.mock( '../lib/bump-stats' );
-jest.mock( '../setup-wp-server-files', () =>
-	jest.fn( () => new Promise< void >( ( resolve ) => resolve() ) )
-);
+jest.mock( '../lib/cli' );
+jest.mock( '../setup-wp-server-files', () => ( {
+	setupWPServerFiles: jest.fn( () => Promise.resolve() ),
+	updateWPServerFiles: jest.fn( () => Promise.resolve() ),
+} ) );
 
 const mockUserData = {
 	sites: [],
@@ -22,6 +24,46 @@ const mockUserData = {
 	JSON.stringify( mockUserData )
 );
 ( fs as MockedFs ).__setFileContents( '/path/to/app/temp/com.wordpress.studio/', '' );
+
+function mockElectron(
+	{
+		appEvents,
+		appMocks,
+		electronMocks,
+	}: {
+		appEvents: string[];
+		electronMocks?: Partial< typeof import('electron') >;
+		appMocks?: Partial< typeof import('electron').app >;
+	} = {
+		appEvents: [],
+	}
+) {
+	const mockedEvents = appEvents.reduce< Record< string, ( ...args: any[] ) => Promise< void > > >(
+		( accum, event ) => {
+			// eslint-disable-next-line @typescript-eslint/no-empty-function
+			return { ...accum, [ event ]: async () => {} };
+		},
+		{}
+	);
+	jest.doMock( 'electron', () => {
+		const electron = jest.genMockFromModule( 'electron' ) as typeof import('electron');
+		return {
+			...electron,
+			...electronMocks,
+			app: {
+				...electron.app,
+				...appMocks,
+				on: jest.fn( ( event, callback ) => {
+					const mockedEventName = Object.keys( mockedEvents ).find( ( key ) => key === event );
+					if ( mockedEventName ) {
+						mockedEvents[ mockedEventName ] = callback;
+					}
+				} ),
+			},
+		};
+	} );
+	return { mockedEvents };
+}
 
 afterEach( () => {
 	jest.clearAllMocks();
@@ -37,26 +79,16 @@ it( 'should handle authentication deep links', () => {
 	jest.isolateModules( async () => {
 		const originalProcessPlatform = process.platform;
 		Object.defineProperty( process, 'platform', { value: 'darwin' } );
-		// eslint-disable-next-line @typescript-eslint/no-empty-function
-		let openUrl: ( ...args: any[] ) => void = () => {};
 		const mockIpcMainEmit = jest.fn();
-		jest.doMock( 'electron', () => {
-			const electron = jest.genMockFromModule( 'electron' ) as typeof import('electron');
-			return {
-				...electron,
+		const electron = jest.genMockFromModule( 'electron' ) as typeof import('electron');
+		const { mockedEvents } = mockElectron( {
+			appEvents: [ 'open-url' ],
+			electronMocks: {
 				ipcMain: {
 					...electron.ipcMain,
 					emit: mockIpcMainEmit,
 				},
-				app: {
-					...electron.app,
-					on: jest.fn( ( event, callback ) => {
-						if ( event === 'open-url' ) {
-							openUrl = callback;
-						}
-					} ),
-				},
-			};
+			},
 		} );
 		const mockAuthResult = { email: 'mock-email', displayName: 'mock-display-name' };
 		const mockResolvedValue = Promise.resolve( mockAuthResult );
@@ -66,6 +98,7 @@ it( 'should handle authentication deep links', () => {
 			handleAuthCallback: mockHandleAuthCallback,
 		} ) );
 		require( '../index' );
+		const { 'open-url': openUrl } = mockedEvents;
 
 		const mockHash = '#access_token=1234&expires_in=1';
 		openUrl( {}, `wpcom-local-dev://auth${ mockHash }` );
@@ -80,89 +113,11 @@ it( 'should handle authentication deep links', () => {
 	} );
 } );
 
-it( 'should await the app ready state before creating a window for activate events', async () => {
-	await jest.isolateModulesAsync( async () => {
-		// eslint-disable-next-line @typescript-eslint/no-empty-function
-		let activate: ( ...args: any[] ) => void = () => {};
-		jest.doMock( 'electron', () => {
-			const electron = jest.genMockFromModule( 'electron' ) as typeof import('electron');
-			return {
-				...electron,
-				app: {
-					...electron.app,
-					whenReady: jest.fn( () => Promise.resolve() ),
-					on: jest.fn( ( event, callback ) => {
-						if ( event === 'activate' ) {
-							activate = callback;
-						}
-					} ),
-				},
-			};
-		} );
-		require( '../index' );
-
-		activate();
-
-		expect( createMainWindow ).not.toHaveBeenCalled();
-		// Await the mocked `whenReady` promise resolution
-		await new Promise( process.nextTick );
-		expect( createMainWindow ).toHaveBeenCalled();
-	} );
-} );
-
-it( 'should gracefully handle app ready failures when creating a window on activate', async () => {
-	await jest.isolateModulesAsync( async () => {
-		// eslint-disable-next-line @typescript-eslint/no-empty-function
-		let activate: ( ...args: any[] ) => void = () => {};
-		jest.doMock( 'electron', () => {
-			const electron = jest.genMockFromModule( 'electron' ) as typeof import('electron');
-			return {
-				...electron,
-				app: {
-					...electron.app,
-					whenReady: jest.fn( () => Promise.reject() ),
-					on: jest.fn( ( event, callback ) => {
-						if ( event === 'activate' ) {
-							activate = callback;
-						}
-					} ),
-				},
-			};
-		} );
-		const captureExceptionMock = jest.fn();
-		jest.doMock( '@sentry/electron/main', () => ( {
-			init: jest.fn(),
-			captureException: captureExceptionMock,
-		} ) );
-		require( '../index' );
-
-		activate();
-
-		await new Promise( process.nextTick );
-		expect( createMainWindow ).not.toHaveBeenCalled();
-		expect( captureExceptionMock ).toHaveBeenCalled();
-	} );
-} );
-
 it( 'should setup server files before creating main window', async () => {
 	await jest.isolateModulesAsync( async () => {
-		// eslint-disable-next-line @typescript-eslint/no-empty-function
-		let ready: ( ...args: any[] ) => Promise< void > = async () => {};
-		jest.doMock( 'electron', () => {
-			const electron = jest.genMockFromModule( 'electron' ) as typeof import('electron');
-			return {
-				...electron,
-				app: {
-					...electron.app,
-					on: jest.fn( ( event, callback ) => {
-						if ( event === 'ready' ) {
-							ready = callback;
-						}
-					} ),
-				},
-			};
-		} );
+		const { mockedEvents } = mockElectron( { appEvents: [ 'ready' ] } );
 		require( '../index' );
+		const { ready } = mockedEvents;
 
 		// Add a mock function to check that `setupWPServerFiles` is resolved before
 		// creating the main window.
@@ -179,5 +134,48 @@ it( 'should setup server files before creating main window', async () => {
 		const createMainWindowOrder = ( createMainWindow as jest.Mock ).mock.invocationCallOrder[ 0 ];
 
 		expect( setupWPServerFilesResolvedOrder ).toBeLessThan( createMainWindowOrder );
+	} );
+} );
+
+it( 'should wait app initialization before creating main window via activate event', async () => {
+	await jest.isolateModulesAsync( async () => {
+		const { mockedEvents } = mockElectron( { appEvents: [ 'ready', 'activate' ] } );
+
+		require( '../index' );
+		const { ready, activate } = mockedEvents;
+
+		await activate();
+		expect( createMainWindow as jest.Mock ).not.toHaveBeenCalled();
+
+		await ready();
+
+		await activate();
+		expect( createMainWindow as jest.Mock ).toHaveBeenCalled();
+	} );
+} );
+
+it( 'should wait app initialization before creating main window via second-instance event', async () => {
+	await jest.isolateModulesAsync( async () => {
+		const { mockedEvents } = mockElectron( { appEvents: [ 'ready', 'second-instance' ] } );
+
+		// The "second-instance" event is only invoked on Windows/Linux platforms.
+		// Therefore, we ensure the initialization is performed on one of those
+		// platforms.
+		const originalProcessPlatform = process.platform;
+		Object.defineProperty( process, 'platform', { value: 'win32' } );
+
+		require( '../index' );
+		const { ready, 'second-instance': secondInstance } = mockedEvents;
+
+		await secondInstance();
+		// "withMainWindow" creates the main window if it doesn't exist
+		expect( withMainWindow as jest.Mock ).not.toHaveBeenCalled();
+
+		await ready();
+
+		await secondInstance();
+		expect( withMainWindow as jest.Mock ).toHaveBeenCalled();
+
+		Object.defineProperty( process, 'platform', { value: originalProcessPlatform } );
 	} );
 } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to 8016-gh-Automattic/dotcom-forge.

## Proposed Changes

- Add a variable to determine when the app finished initialization. This is used in app event handlers `activate` and `second-instance` to avoid creating the main window before the app initialization finishes. 
- Split the logic of `setupWPServerFiles` into two functions to avoid delaying the app initialization. One will handle the preparation of WordPress files by copying the bundled files. Since this is needed for creating sites, it will be run synchronously during the app initialization. The other function will try to update the server files (e.g. WordPress version). Depending on the internet connection, it might incur negatively in the bootup time so it will be executed asynchronously. **This will speed up app initialization and create the main window as soon as possible.**
- Update unit tests that cover app initialization logic. Note that due to the PR changes, some unit tests have been converged into new ones.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### macOS

- Apply the following patch:
```patch
diff --git forkSrcPrefix/src/setup-wp-server-files.ts forkDstPrefix/src/setup-wp-server-files.ts
index 34d3e030f9a43566161f571cce4f0180aba2e1b5..07c174c22ea44daa182557de55a965d428087a0f 100644
--- forkSrcPrefix/src/setup-wp-server-files.ts
+++ forkDstPrefix/src/setup-wp-server-files.ts
@@ -62,6 +62,7 @@ export async function setupWPServerFiles() {
 	await copyBundledLatestWPVersion();
 	await copyBundledSqlite();
 	await copyBundledWPCLI();
+	await new Promise( ( resolve ) => setTimeout( resolve, 10_000 ) );
 }
 
 export async function updateWPServerFiles() {

```
- Run the app with the command `npm start`. 
- Observe the main window is not created.
- Click on the Studio app icon located in the docker.
- Observe the main window is not created and no exceptions are produced.
- Wait 10 seconds and observe the main window is created.

### Windows
- Apply the following patch:
```patch
diff --git forkSrcPrefix/src/setup-wp-server-files.ts forkDstPrefix/src/setup-wp-server-files.ts
index 34d3e030f9a43566161f571cce4f0180aba2e1b5..07c174c22ea44daa182557de55a965d428087a0f 100644
--- forkSrcPrefix/src/setup-wp-server-files.ts
+++ forkDstPrefix/src/setup-wp-server-files.ts
@@ -62,6 +62,7 @@ export async function setupWPServerFiles() {
 	await copyBundledLatestWPVersion();
 	await copyBundledSqlite();
 	await copyBundledWPCLI();
+	await new Promise( ( resolve ) => setTimeout( resolve, 10_000 ) );
 }
 
 export async function updateWPServerFiles() {

```
- Generate the app binary by running the command `npm run make`.
- Open the executable located at `out/Studio-win32-x64/Studio.exe`.
- Observe the main window is not created.
- Open a second time the executable.
- Observe the main window is not created and no exceptions are produced.
- Wait 10 seconds and observe the main window is created.
- Check logs located in `%APPDATA%/Studio/logs` and observe the exception `Error invoking remote method 'getAppGlobals'` is not logged.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
