### PR TITLE
Fix app path when invoking `wp-cli` commands from terminal in macOS

### DIFF
--- a/bin/wp
+++ b/bin/wp
@@ -12,4 +12,4 @@ CLI="wp $COMMAND"
 # Mimic core `wp-cli`'s behavior of using `less` for `help` output.
 PAGER=$(if [ -z "$COMMAND" ] || [[ "$COMMAND" == \'help* ]]; then echo "less -R"; else echo "cat"; fi)
 
-$STUDIO_APP_PATH --cli="$CLI" | $PAGER
+"$STUDIO_APP_PATH" --cli="$CLI" | $PAGER

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -605,7 +605,7 @@ export function openTerminalAtPath( _event: IpcMainInvokeEvent, targetPath: stri
 			const script = `
 			tell application "Terminal"
 				if not application "Terminal" is running then launch
-				do script "clear && export PATH=${ cliPath }:$PATH && export STUDIO_APP_PATH=\\"${ appPath }\\" && cd ${ targetPath }"
+				do script "clear && export PATH=\\"${ cliPath }\\":$PATH && export STUDIO_APP_PATH=\\"${ appPath }\\" && cd ${ targetPath }"
 				activate
 			end tell
 			`;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to 8074-gh-Automattic/dotcom-forge.

## Proposed Changes

- Update script used to invoke `wp-cli` commands through the app in macOS. Specifically, the CLI/Studio app's executable path is now wrapped with quotes to support any character in the path (e.g. spaces, emojis, etc.).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run the app with the command `STUDIO_TERMINAL_WP_CLI=true npm start` on macOS.
- Rename the folder `Studio-darwin-arm64` located in `<PROJECT_PATH>/out` to `1. == Studio app == 🎉`.
- Open the Studio app located in the renamed folder.
- Click on Terminal button.
- Observe the terminal is opened and that no error is logged.
- Run the command `wp theme list`.
- Observe the `wp-cli` command is executed and returns the expected result.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
