### PR TITLE
Add feature flag to control integration of `wp-cli` commands in terminal

### DIFF
--- a/src/components/content-tab-overview.tsx
+++ b/src/components/content-tab-overview.tsx
@@ -16,6 +16,7 @@ import {
 import { useI18n } from '@wordpress/react-i18n';
 import { useState } from 'react';
 import { useCheckInstalledApps } from '../hooks/use-check-installed-apps';
+import { useFeatureFlags } from '../hooks/use-feature-flags';
 import { useThemeDetails } from '../hooks/use-theme-details';
 import { isMac } from '../lib/app-globals';
 import { cx } from '../lib/cx';
@@ -134,6 +135,7 @@ function CustomizeSection( {
 }
 
 function ShortcutsSection( { selectedSite }: Pick< ContentTabOverviewProps, 'selectedSite' > ) {
+	const { terminalWpCliEnabled } = useFeatureFlags();
 	const installedApps = useCheckInstalledApps();
 	const buttonsArray: ButtonsSectionProps[ 'buttonsArray' ] = [
 		{
@@ -199,7 +201,9 @@ function ShortcutsSection( { selectedSite }: Pick< ContentTabOverviewProps, 'sel
 		icon: preformatted,
 		onClick: async () => {
 			try {
-				await getIpcApi().openTerminalAtPath( selectedSite.path );
+				await getIpcApi().openTerminalAtPath( selectedSite.path, {
+					wpCliEnabled: terminalWpCliEnabled,
+				} );
 			} catch ( error ) {
 				Sentry.captureException( error );
 				alert( __( 'Could not open the terminal.' ) );

--- a/src/components/tests/content-tab-overview-shortcuts-section.test.tsx
+++ b/src/components/tests/content-tab-overview-shortcuts-section.test.tsx
@@ -122,7 +122,9 @@ describe( 'ShortcutsSection', () => {
 
 		// Assert that the terminal was opened
 		await waitFor( () => {
-			expect( openTerminalAtPathMock ).toHaveBeenCalledWith( selectedSite.path );
+			expect( openTerminalAtPathMock ).toHaveBeenCalledWith( selectedSite.path, {
+				wpCliEnabled: false,
+			} );
 		} );
 	} );
 } );

--- a/src/components/tests/content-tab-overview-shortcuts-section.test.tsx
+++ b/src/components/tests/content-tab-overview-shortcuts-section.test.tsx
@@ -1,6 +1,7 @@
 // To run tests, execute `npm run test -- src/components/tests/content-tab-overview-shortcuts-section.test.tsx` from the root directory
 import { fireEvent, render, waitFor } from '@testing-library/react';
 import { useCheckInstalledApps } from '../../hooks/use-check-installed-apps';
+import { useFeatureFlags } from '../../hooks/use-feature-flags';
 import { useThemeDetails } from '../../hooks/use-theme-details';
 import { getIpcApi } from '../../lib/get-ipc-api';
 import { ContentTabOverview } from '../content-tab-overview';
@@ -19,6 +20,7 @@ const mockGetIpcApi = getIpcApi as jest.Mock;
 jest.mock( '../../hooks/use-check-installed-apps' );
 jest.mock( '../../lib/get-ipc-api' );
 jest.mock( '../../hooks/use-theme-details' );
+jest.mock( '../../hooks/use-feature-flags' );
 
 describe( 'ShortcutsSection', () => {
 	beforeEach( () => {
@@ -29,6 +31,9 @@ describe( 'ShortcutsSection', () => {
 				supportsWidgets: false,
 				supportsMenus: false,
 			},
+		} );
+		( useFeatureFlags as jest.Mock ).mockReturnValue( {
+			terminalWpCliEnabled: false,
 		} );
 	} );
 
@@ -124,6 +129,38 @@ describe( 'ShortcutsSection', () => {
 		await waitFor( () => {
 			expect( openTerminalAtPathMock ).toHaveBeenCalledWith( selectedSite.path, {
 				wpCliEnabled: false,
+			} );
+		} );
+	} );
+
+	it( 'opens terminal with wp-cli integration if feature flag is enabled', async () => {
+		// Mock the `useCheckInstalledApps` hook to simulate terminal being available
+		( useCheckInstalledApps as jest.Mock ).mockReturnValue( {
+			terminal: true,
+			vscode: false,
+			phpstorm: false,
+		} );
+		( useFeatureFlags as jest.Mock ).mockReturnValue( {
+			terminalWpCliEnabled: true,
+		} );
+
+		// Mock the IPC API
+		const openTerminalAtPathMock = jest.fn();
+		mockGetIpcApi.mockReturnValue( {
+			openTerminalAtPath: openTerminalAtPathMock,
+		} );
+
+		// Render the component
+		const { getByText } = render( <ContentTabOverview selectedSite={ selectedSite } /> );
+
+		// Find the terminal button and click it
+		const terminalButton = getByText( 'Terminal' );
+		fireEvent.click( terminalButton );
+
+		// Assert that the terminal was opened
+		await waitFor( () => {
+			expect( openTerminalAtPathMock ).toHaveBeenCalledWith( selectedSite.path, {
+				wpCliEnabled: true,
 			} );
 		} );
 	} );

--- a/src/hooks/use-feature-flags.tsx
+++ b/src/hooks/use-feature-flags.tsx
@@ -4,10 +4,12 @@ import { useAuth } from './use-auth';
 
 export interface FeatureFlagsContextType {
 	assistantEnabled: boolean;
+	terminalWpCliEnabled: boolean;
 }
 
 export const FeatureFlagsContext = createContext< FeatureFlagsContextType >( {
 	assistantEnabled: false,
+	terminalWpCliEnabled: false,
 } );
 
 interface FeatureFlagsProviderProps {
@@ -16,8 +18,10 @@ interface FeatureFlagsProviderProps {
 
 export const FeatureFlagsProvider: React.FC< FeatureFlagsProviderProps > = ( { children } ) => {
 	const assistantEnabledFromGlobals = getAppGlobals().assistantEnabled;
+	const terminalWpCliEnabledFromGlobals = getAppGlobals().terminalWpCliEnabled;
 	const [ featureFlags, setFeatureFlags ] = useState< FeatureFlagsContextType >( {
 		assistantEnabled: assistantEnabledFromGlobals,
+		terminalWpCliEnabled: terminalWpCliEnabledFromGlobals,
 	} );
 	const { isAuthenticated, client } = useAuth();
 
@@ -38,6 +42,8 @@ export const FeatureFlagsProvider: React.FC< FeatureFlagsProviderProps > = ( { c
 				setFeatureFlags( {
 					assistantEnabled:
 						Boolean( flags?.[ 'assistant_enabled' ] ) || assistantEnabledFromGlobals,
+					terminalWpCliEnabled:
+						Boolean( flags?.[ 'terminal_wp_cli_enabled' ] ) || terminalWpCliEnabledFromGlobals,
 				} );
 			} catch ( error ) {
 				console.error( error );
@@ -47,7 +53,7 @@ export const FeatureFlagsProvider: React.FC< FeatureFlagsProviderProps > = ( { c
 		return () => {
 			cancel = true;
 		};
-	}, [ isAuthenticated, client, assistantEnabledFromGlobals ] );
+	}, [ isAuthenticated, client, assistantEnabledFromGlobals, terminalWpCliEnabledFromGlobals ] );
 
 	return (
 		<FeatureFlagsContext.Provider value={ featureFlags }>{ children }</FeatureFlagsContext.Provider>

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -468,6 +468,7 @@ export async function getAppGlobals( _event: IpcMainInvokeEvent ): Promise< AppG
 		appName: app.name,
 		arm64Translation: app.runningUnderARM64Translation,
 		assistantEnabled: process.env.STUDIO_AI === 'true',
+		terminalWpCliEnabled: process.env.STUDIO_TERMINAL_WP_CLI === 'true',
 	};
 }
 

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -587,7 +587,11 @@ export async function getThumbnailData( _event: IpcMainInvokeEvent, id: string )
 	return getImageData( path );
 }
 
-export function openTerminalAtPath( _event: IpcMainInvokeEvent, targetPath: string ) {
+export function openTerminalAtPath(
+	_event: IpcMainInvokeEvent,
+	targetPath: string,
+	{ wpCliEnabled }: { wpCliEnabled?: boolean } = {}
+) {
 	return new Promise< void >( ( resolve, reject ) => {
 		const platform = process.platform;
 		const cliPath = nodePath.join( getResourcesPath(), 'bin' );
@@ -599,20 +603,32 @@ export function openTerminalAtPath( _event: IpcMainInvokeEvent, targetPath: stri
 		let command: string;
 		if ( platform === 'win32' ) {
 			// Windows
-			command = `start cmd /K "set PATH=${ cliPath };%PATH% && set STUDIO_APP_PATH=${ appPath } && cd /d ${ targetPath }"`;
+			if ( wpCliEnabled ) {
+				command = `start cmd /K "set PATH=${ cliPath };%PATH% && set STUDIO_APP_PATH=${ appPath } && cd /d ${ targetPath }"`;
+			} else {
+				command = `start cmd /K "cd /d ${ targetPath }"`;
+			}
 		} else if ( platform === 'darwin' ) {
 			// macOS
-			const script = `
+			if ( wpCliEnabled ) {
+				const script = `
 			tell application "Terminal"
 				if not application "Terminal" is running then launch
 				do script "clear && export PATH=${ cliPath }:$PATH && export STUDIO_APP_PATH=\\"${ appPath }\\" && cd ${ targetPath }"
 				activate
 			end tell
 			`;
-			command = `osascript -e '${ script }'`;
+				command = `osascript -e '${ script }'`;
+			} else {
+				command = `open -a Terminal "${ targetPath }"`;
+			}
 		} else if ( platform === 'linux' ) {
 			// Linux
-			command = `export PATH=${ cliPath }:$PATH && export STUDIO_APP_PATH="${ appPath }" && gnome-terminal -- bash -c 'cd ${ targetPath }; exec bash'`;
+			if ( wpCliEnabled ) {
+				command = `export PATH=${ cliPath }:$PATH && export STUDIO_APP_PATH="${ appPath }" && gnome-terminal -- bash -c 'cd ${ targetPath }; exec bash'`;
+			} else {
+				command = `gnome-terminal --working-directory=${ targetPath }`;
+			}
 		} else {
 			console.error( 'Unsupported platform:', platform );
 			return;

--- a/src/ipc-types.d.ts
+++ b/src/ipc-types.d.ts
@@ -73,6 +73,7 @@ interface AppGlobals {
 	appName: string;
 	arm64Translation: boolean;
 	assistantEnabled: boolean;
+	terminalWpCliEnabled: boolean;
 }
 
 interface IpcListener {

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -42,8 +42,8 @@ const api: IpcApi = {
 	getOnboardingData: () => ipcRenderer.invoke( 'getOnboardingData' ),
 	saveOnboarding: ( onboardingCompleted: boolean ) =>
 		ipcRenderer.invoke( 'saveOnboarding', onboardingCompleted ),
-	openTerminalAtPath: ( targetPath: string ) =>
-		ipcRenderer.invoke( 'openTerminalAtPath', targetPath ),
+	openTerminalAtPath: ( targetPath: string, extraParams: { wpCliEnabled?: boolean } = {} ) =>
+		ipcRenderer.invoke( 'openTerminalAtPath', targetPath, extraParams ),
 	showMessageBox: ( options: Electron.MessageBoxOptions ) =>
 		ipcRenderer.invoke( 'showMessageBox', options ),
 	showNotification: ( options: Electron.NotificationConstructorOptions ) =>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to 8097-gh-Automattic/dotcom-forge.

## Proposed Changes

- Add feature flag `terminalWpCliEnabled` to control when the `wp-cli` integration should be enabled in the terminal.
- Expand IPC handler `openTerminalAtPath` to enable/disable `wp-cli` integration.
- Add test case to cover if `wp-cli` integration is enabled via feature flag.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

> [!NOTE]
> The following testing instructions are meant to be followed in macOS. For other platforms, the paths and commands might differ.

### `wp-cli` integration is disabled (Default behavior)
- Run the app with the command `npm start`.
- Click on the Terminal button.
- Within the terminal, run the command `which wp`.
- If the `wp` command was installed globally, observe that the command returns its location (e.g. `/usr/local/bin/wp`)
- If the `wp` command is not installed, observe that running `wp` results in a failure.

### `wp-cli` integration is enabled via feature flag
- Run the app with the command `STUDIO_TERMINAL_WP_CLI=true npm start`.
- Click on the Terminal button.
- Within the terminal, run the command `which wp`.
- Observe that the command returns the location `<PROJECT_PATH>/local-environment/bin/wp`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
