### PR TITLE
Studio: fix setting menu not open if no sites

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -10,6 +10,7 @@ import MainSidebar from './main-sidebar';
 import Onboarding from './onboarding';
 import { SiteContentTabs } from './site-content-tabs';
 import WindowsTitlebar from './windows-titlebar';
+import UserSettings from './user-settings';
 
 export default function App() {
 	useLocalizationSupport();
@@ -45,6 +46,7 @@ export default function App() {
 				>
 					<SiteContentTabs />
 				</main>
+				<UserSettings />
 			</HStack>
 		</VStack>
 	);

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -9,45 +9,45 @@ import { cx } from '../lib/cx';
 import MainSidebar from './main-sidebar';
 import Onboarding from './onboarding';
 import { SiteContentTabs } from './site-content-tabs';
-import WindowsTitlebar from './windows-titlebar';
 import UserSettings from './user-settings';
+import WindowsTitlebar from './windows-titlebar';
 
 export default function App() {
 	useLocalizationSupport();
 	const { needsOnboarding } = useOnboarding();
 
-	if ( needsOnboarding ) {
-		return (
-			<VStack
-				className={ cx( 'h-screen backdrop-blur-3xl app-drag-region select-none' ) }
-				spacing="0"
-			>
-				{ isWindows() && <WindowsTitlebar className="h-titlebar-win flex-shrink-0" /> }
-				<Onboarding />
-			</VStack>
-		);
-	}
-
 	return (
-		<VStack
-			className={ cx(
-				'h-screen bg-chrome backdrop-blur-3xl ltr:pr-chrome rtl:pl-chrome app-drag-region select-none',
-				isWindows() && 'pt-0 pb-chrome',
-				! isWindows() && 'py-chrome'
-			) }
-			spacing="0"
-		>
-			{ isWindows() && <WindowsTitlebar className="h-titlebar-win flex-shrink-0" /> }
-			<HStack spacing="0" alignment="left" className="flex-grow">
-				<MainSidebar className="basis-52 flex-shrink-0 h-full" />
-				<main
-					data-testid="site-content"
-					className="bg-white h-full flex-grow rounded-chrome overflow-hidden"
+		<>
+			{ needsOnboarding ? (
+				<VStack
+					className={ cx( 'h-screen backdrop-blur-3xl app-drag-region select-none' ) }
+					spacing="0"
 				>
-					<SiteContentTabs />
-				</main>
-				<UserSettings />
-			</HStack>
-		</VStack>
+					{ isWindows() && <WindowsTitlebar className="h-titlebar-win flex-shrink-0" /> }
+					<Onboarding />
+				</VStack>
+			) : (
+				<VStack
+					className={ cx(
+						'h-screen bg-chrome backdrop-blur-3xl ltr:pr-chrome rtl:pl-chrome app-drag-region select-none',
+						isWindows() && 'pt-0 pb-chrome',
+						! isWindows() && 'py-chrome'
+					) }
+					spacing="0"
+				>
+					{ isWindows() && <WindowsTitlebar className="h-titlebar-win flex-shrink-0" /> }
+					<HStack spacing="0" alignment="left" className="flex-grow">
+						<MainSidebar className="basis-52 flex-shrink-0 h-full" />
+						<main
+							data-testid="site-content"
+							className="bg-white h-full flex-grow rounded-chrome overflow-hidden"
+						>
+							<SiteContentTabs />
+						</main>
+					</HStack>
+				</VStack>
+			) }
+			<UserSettings />
+		</>
 	);
 }

--- a/src/components/main-sidebar.tsx
+++ b/src/components/main-sidebar.tsx
@@ -13,7 +13,6 @@ import offlineIcon from './offline-icon';
 import { RunningSites } from './running-sites';
 import SiteMenu from './site-menu';
 import Tooltip from './tooltip';
-import UserSettings from './user-settings';
 import { WordPressLogo } from './wordpress-logo';
 
 interface MainSidebarProps {
@@ -143,7 +142,6 @@ export default function MainSidebar( { className }: MainSidebarProps ) {
 						<div className="mb-[6px]">
 							<SidebarAuthFooter />
 						</div>
-						<UserSettings />
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Fixes https://github.com/Automattic/studio/issues/241


## Proposed Changes

This PR fixes a bug,  where when the user clicks the "Settings" menu item from the onboarding screen, the menu doesn't open.


## Testing Instructions
- If sites exist, delete them all ( or make a backup in a different folder )
- In the onboarding session, click "Studio" > "Settings" from the app menu.
- Ensure that the settings menu, appears
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
