### PR TITLE
Studio: Create a new Import / Export tab

### DIFF
--- a/src/components/content-tab-backup.tsx
+++ b/src/components/content-tab-backup.tsx
@@ -1,6 +1,0 @@
-interface ContentTabBackupProps {
-	selectedSite: SiteDetails;
-}
-export function ContentTabBackup( _props: ContentTabBackupProps ) {
-	return null;
-}

--- a/src/components/content-tab-backup.tsx
+++ b/src/components/content-tab-backup.tsx
@@ -1,0 +1,6 @@
+interface ContentTabBackupProps {
+	selectedSite: SiteDetails;
+}
+export function ContentTabBackup( _props: ContentTabBackupProps ) {
+	return null;
+}

--- a/src/components/content-tab-import-export.tsx
+++ b/src/components/content-tab-import-export.tsx
@@ -1,0 +1,6 @@
+interface ContentTabImportExportProps {
+	selectedSite: SiteDetails;
+}
+export function ContentTabImportExport( _props: ContentTabImportExportProps ) {
+	return null;
+}

--- a/src/components/site-content-tabs.tsx
+++ b/src/components/site-content-tabs.tsx
@@ -38,7 +38,7 @@ export function SiteContentTabs() {
 							{ name === 'share' && <ContentTabSnapshots selectedSite={ selectedSite } /> }
 							{ name === 'settings' && <ContentTabSettings selectedSite={ selectedSite } /> }
 							{ name === 'assistant' && <ContentTabAssistant selectedSite={ selectedSite } /> }
-							{ name === 'backup' && <ContentTabImportExport selectedSite={ selectedSite } /> }
+							{ name === 'import-export' && <ContentTabImportExport selectedSite={ selectedSite } /> }
 						</div>
 					) }
 				</TabPanel>

--- a/src/components/site-content-tabs.tsx
+++ b/src/components/site-content-tabs.tsx
@@ -38,7 +38,9 @@ export function SiteContentTabs() {
 							{ name === 'share' && <ContentTabSnapshots selectedSite={ selectedSite } /> }
 							{ name === 'settings' && <ContentTabSettings selectedSite={ selectedSite } /> }
 							{ name === 'assistant' && <ContentTabAssistant selectedSite={ selectedSite } /> }
-							{ name === 'import-export' && <ContentTabImportExport selectedSite={ selectedSite } /> }
+							{ name === 'import-export' && (
+								<ContentTabImportExport selectedSite={ selectedSite } />
+							) }
 						</div>
 					) }
 				</TabPanel>

--- a/src/components/site-content-tabs.tsx
+++ b/src/components/site-content-tabs.tsx
@@ -4,6 +4,7 @@ import { useContentTabs } from '../hooks/use-content-tabs';
 import { useSiteDetails } from '../hooks/use-site-details';
 import { WelcomeMessagesProvider } from '../hooks/use-welcome-messages';
 import { ContentTabAssistant } from './content-tab-assistant';
+import { ContentTabBackup } from './content-tab-backup';
 import { ContentTabOverview } from './content-tab-overview';
 import { ContentTabSettings } from './content-tab-settings';
 import { ContentTabSnapshots } from './content-tab-snapshots';
@@ -37,6 +38,7 @@ export function SiteContentTabs() {
 							{ name === 'share' && <ContentTabSnapshots selectedSite={ selectedSite } /> }
 							{ name === 'settings' && <ContentTabSettings selectedSite={ selectedSite } /> }
 							{ name === 'assistant' && <ContentTabAssistant selectedSite={ selectedSite } /> }
+							{ name === 'backup' && <ContentTabBackup selectedSite={ selectedSite } /> }
 						</div>
 					) }
 				</TabPanel>

--- a/src/components/site-content-tabs.tsx
+++ b/src/components/site-content-tabs.tsx
@@ -4,7 +4,7 @@ import { useContentTabs } from '../hooks/use-content-tabs';
 import { useSiteDetails } from '../hooks/use-site-details';
 import { WelcomeMessagesProvider } from '../hooks/use-welcome-messages';
 import { ContentTabAssistant } from './content-tab-assistant';
-import { ContentTabBackup } from './content-tab-backup';
+import { ContentTabImportExport } from './content-tab-import-export';
 import { ContentTabOverview } from './content-tab-overview';
 import { ContentTabSettings } from './content-tab-settings';
 import { ContentTabSnapshots } from './content-tab-snapshots';
@@ -38,7 +38,7 @@ export function SiteContentTabs() {
 							{ name === 'share' && <ContentTabSnapshots selectedSite={ selectedSite } /> }
 							{ name === 'settings' && <ContentTabSettings selectedSite={ selectedSite } /> }
 							{ name === 'assistant' && <ContentTabAssistant selectedSite={ selectedSite } /> }
-							{ name === 'backup' && <ContentTabBackup selectedSite={ selectedSite } /> }
+							{ name === 'backup' && <ContentTabImportExport selectedSite={ selectedSite } /> }
 						</div>
 					) }
 				</TabPanel>

--- a/src/components/tests/site-content-tabs.test.tsx
+++ b/src/components/tests/site-content-tabs.test.tsx
@@ -31,7 +31,7 @@ jest.mock( '../../lib/app-globals', () => ( {
 
 ( useFeatureFlags as jest.Mock ).mockReturnValue( {
 	assistantEnabled: false,
-	backupEnabled: false,
+	importExportEnabled: false,
 } );
 
 describe( 'SiteContentTabs', () => {
@@ -102,26 +102,26 @@ describe( 'SiteContentTabs', () => {
 		expect( screen.queryByRole( 'tab', { name: 'Assistant' } ) ).toBeVisible();
 	} );
 
-	it( 'should not render the Backup tab if backupEnabled is not enabled', async () => {
+	it( 'should not render the Import/Export tab if importExportEnabled is not enabled', async () => {
 		( useSiteDetails as jest.Mock ).mockReturnValue( {
 			selectedSite,
 			snapshots: [],
 			loadingServer: {},
 		} );
 		await act( async () => render( <SiteContentTabs /> ) );
-		expect( screen.queryByRole( 'tab', { name: 'Backup' } ) ).toBeNull();
+		expect( screen.queryByRole( 'tab', { name: 'Import / Export' } ) ).toBeNull();
 	} );
 
-	it( 'should render the Assistant tab if backupEnabled is enabled', async () => {
+	it( 'should render the Import/Export tab if importExportEnabled is enabled', async () => {
 		( useSiteDetails as jest.Mock ).mockReturnValue( {
 			selectedSite,
 			snapshots: [],
 			loadingServer: {},
 		} );
 		( useFeatureFlags as jest.Mock ).mockReturnValue( {
-			backupEnabled: true,
+			importExportEnabled: true,
 		} );
 		await act( async () => render( <SiteContentTabs /> ) );
-		expect( screen.queryByRole( 'tab', { name: 'Backup' } ) ).toBeVisible();
+		expect( screen.queryByRole( 'tab', { name: 'Import / Export' } ) ).toBeVisible();
 	} );
 } );

--- a/src/components/tests/site-content-tabs.test.tsx
+++ b/src/components/tests/site-content-tabs.test.tsx
@@ -31,6 +31,7 @@ jest.mock( '../../lib/app-globals', () => ( {
 
 ( useFeatureFlags as jest.Mock ).mockReturnValue( {
 	assistantEnabled: false,
+	backupEnabled: false,
 } );
 
 describe( 'SiteContentTabs', () => {
@@ -61,6 +62,7 @@ describe( 'SiteContentTabs', () => {
 		expect( screen.queryByRole( 'tab', { name: 'Share', selected: false } ) ).toBeVisible();
 		expect( screen.queryByRole( 'tab', { name: 'Settings', selected: false } ) ).toBeVisible();
 		expect( screen.queryByRole( 'tab', { name: 'Assistant', selected: false } ) ).toBeNull();
+		expect( screen.queryByRole( 'tab', { name: 'Backup', selected: false } ) ).toBeNull();
 	} );
 	it( 'should render a "No Site" screen if selected site is absent', async () => {
 		( useSiteDetails as jest.Mock ).mockReturnValue( {
@@ -98,5 +100,28 @@ describe( 'SiteContentTabs', () => {
 		} );
 		await act( async () => render( <SiteContentTabs /> ) );
 		expect( screen.queryByRole( 'tab', { name: 'Assistant' } ) ).toBeVisible();
+	} );
+
+	it( 'should not render the Backup tab if backupEnabled is not enabled', async () => {
+		( useSiteDetails as jest.Mock ).mockReturnValue( {
+			selectedSite,
+			snapshots: [],
+			loadingServer: {},
+		} );
+		await act( async () => render( <SiteContentTabs /> ) );
+		expect( screen.queryByRole( 'tab', { name: 'Backup' } ) ).toBeNull();
+	} );
+
+	it( 'should render the Assistant tab if backupEnabled is enabled', async () => {
+		( useSiteDetails as jest.Mock ).mockReturnValue( {
+			selectedSite,
+			snapshots: [],
+			loadingServer: {},
+		} );
+		( useFeatureFlags as jest.Mock ).mockReturnValue( {
+			backupEnabled: true,
+		} );
+		await act( async () => render( <SiteContentTabs /> ) );
+		expect( screen.queryByRole( 'tab', { name: 'Backup' } ) ).toBeVisible();
 	} );
 } );

--- a/src/hooks/use-content-tabs.ts
+++ b/src/hooks/use-content-tabs.ts
@@ -5,7 +5,7 @@ import { useFeatureFlags } from './use-feature-flags';
 
 export function useContentTabs() {
 	const { __ } = useI18n();
-	const { assistantEnabled, backupEnabled } = useFeatureFlags();
+	const { assistantEnabled, importExportEnabled } = useFeatureFlags();
 
 	return useMemo( () => {
 		const tabs: React.ComponentProps< typeof TabPanel >[ 'tabs' ] = [
@@ -26,11 +26,11 @@ export function useContentTabs() {
 			},
 		];
 
-		if ( backupEnabled ) {
+		if ( importExportEnabled ) {
 			tabs.push( {
 				order: 3,
-				name: 'backup',
-				title: __( 'Backup' ),
+				name: 'import-export',
+				title: __( 'Import / Export' ),
 			} );
 		}
 
@@ -45,5 +45,5 @@ export function useContentTabs() {
 		}
 
 		return tabs.sort( ( a, b ) => a.order - b.order );
-	}, [ __, assistantEnabled, backupEnabled ] );
+	}, [ __, assistantEnabled, importExportEnabled ] );
 }

--- a/src/hooks/use-content-tabs.ts
+++ b/src/hooks/use-content-tabs.ts
@@ -5,26 +5,38 @@ import { useFeatureFlags } from './use-feature-flags';
 
 export function useContentTabs() {
 	const { __ } = useI18n();
-	const { assistantEnabled } = useFeatureFlags();
+	const { assistantEnabled, backupEnabled } = useFeatureFlags();
 
 	return useMemo( () => {
 		const tabs: React.ComponentProps< typeof TabPanel >[ 'tabs' ] = [
 			{
+				order: 1,
 				name: 'overview',
 				title: __( 'Overview' ),
 			},
 			{
+				order: 2,
 				name: 'share',
 				title: __( 'Share' ),
 			},
 			{
+				order: 4,
 				name: 'settings',
 				title: __( 'Settings' ),
 			},
 		];
 
+		if ( backupEnabled ) {
+			tabs.push( {
+				order: 3,
+				name: 'backup',
+				title: __( 'Backup' ),
+			} );
+		}
+
 		if ( assistantEnabled ) {
 			tabs.push( {
+				order: 5,
 				name: 'assistant',
 				title: __( 'Assistant' ),
 				className:
@@ -32,6 +44,6 @@ export function useContentTabs() {
 			} );
 		}
 
-		return tabs;
-	}, [ __, assistantEnabled ] );
+		return tabs.sort( ( a, b ) => a.order - b.order );
+	}, [ __, assistantEnabled, backupEnabled ] );
 }

--- a/src/hooks/use-feature-flags.tsx
+++ b/src/hooks/use-feature-flags.tsx
@@ -43,7 +43,6 @@ export const FeatureFlagsProvider: React.FC< FeatureFlagsProviderProps > = ( { c
 				if ( cancel ) {
 					return;
 				}
-				console.log( flags );
 				setFeatureFlags( {
 					assistantEnabled:
 						Boolean( flags?.[ 'assistant_enabled' ] ) || assistantEnabledFromGlobals,

--- a/src/hooks/use-feature-flags.tsx
+++ b/src/hooks/use-feature-flags.tsx
@@ -5,13 +5,13 @@ import { useAuth } from './use-auth';
 export interface FeatureFlagsContextType {
 	assistantEnabled: boolean;
 	terminalWpCliEnabled: boolean;
-	backupEnabled: boolean;
+	importExportEnabled: boolean;
 }
 
 export const FeatureFlagsContext = createContext< FeatureFlagsContextType >( {
 	assistantEnabled: false,
 	terminalWpCliEnabled: false,
-	backupEnabled: false,
+	importExportEnabled: false,
 } );
 
 interface FeatureFlagsProviderProps {
@@ -21,11 +21,11 @@ interface FeatureFlagsProviderProps {
 export const FeatureFlagsProvider: React.FC< FeatureFlagsProviderProps > = ( { children } ) => {
 	const assistantEnabledFromGlobals = getAppGlobals().assistantEnabled;
 	const terminalWpCliEnabledFromGlobals = getAppGlobals().terminalWpCliEnabled;
-	const backupEnabledFromGlobals = getAppGlobals().backupEnabled;
+	const importExportEnabledFromGlobals = getAppGlobals().importExportEnabled;
 	const [ featureFlags, setFeatureFlags ] = useState< FeatureFlagsContextType >( {
 		assistantEnabled: assistantEnabledFromGlobals,
 		terminalWpCliEnabled: terminalWpCliEnabledFromGlobals,
-		backupEnabled: backupEnabledFromGlobals,
+		importExportEnabled: importExportEnabledFromGlobals,
 	} );
 	const { isAuthenticated, client } = useAuth();
 
@@ -48,7 +48,8 @@ export const FeatureFlagsProvider: React.FC< FeatureFlagsProviderProps > = ( { c
 						Boolean( flags?.[ 'assistant_enabled' ] ) || assistantEnabledFromGlobals,
 					terminalWpCliEnabled:
 						Boolean( flags?.[ 'terminal_wp_cli_enabled' ] ) || terminalWpCliEnabledFromGlobals,
-					backupEnabled: Boolean( flags?.[ 'backup_enabled' ] ) || backupEnabledFromGlobals,
+					importExportEnabled:
+						Boolean( flags?.[ 'import_export_enabled' ] ) || importExportEnabledFromGlobals,
 				} );
 			} catch ( error ) {
 				console.error( error );
@@ -63,7 +64,7 @@ export const FeatureFlagsProvider: React.FC< FeatureFlagsProviderProps > = ( { c
 		client,
 		assistantEnabledFromGlobals,
 		terminalWpCliEnabledFromGlobals,
-		backupEnabledFromGlobals,
+		importExportEnabledFromGlobals,
 	] );
 
 	return (

--- a/src/hooks/use-feature-flags.tsx
+++ b/src/hooks/use-feature-flags.tsx
@@ -5,11 +5,13 @@ import { useAuth } from './use-auth';
 export interface FeatureFlagsContextType {
 	assistantEnabled: boolean;
 	terminalWpCliEnabled: boolean;
+	backupEnabled: boolean;
 }
 
 export const FeatureFlagsContext = createContext< FeatureFlagsContextType >( {
 	assistantEnabled: false,
 	terminalWpCliEnabled: false,
+	backupEnabled: false,
 } );
 
 interface FeatureFlagsProviderProps {
@@ -19,9 +21,11 @@ interface FeatureFlagsProviderProps {
 export const FeatureFlagsProvider: React.FC< FeatureFlagsProviderProps > = ( { children } ) => {
 	const assistantEnabledFromGlobals = getAppGlobals().assistantEnabled;
 	const terminalWpCliEnabledFromGlobals = getAppGlobals().terminalWpCliEnabled;
+	const backupEnabledFromGlobals = getAppGlobals().backupEnabled;
 	const [ featureFlags, setFeatureFlags ] = useState< FeatureFlagsContextType >( {
 		assistantEnabled: assistantEnabledFromGlobals,
 		terminalWpCliEnabled: terminalWpCliEnabledFromGlobals,
+		backupEnabled: backupEnabledFromGlobals,
 	} );
 	const { isAuthenticated, client } = useAuth();
 
@@ -39,11 +43,13 @@ export const FeatureFlagsProvider: React.FC< FeatureFlagsProviderProps > = ( { c
 				if ( cancel ) {
 					return;
 				}
+				console.log( flags );
 				setFeatureFlags( {
 					assistantEnabled:
 						Boolean( flags?.[ 'assistant_enabled' ] ) || assistantEnabledFromGlobals,
 					terminalWpCliEnabled:
 						Boolean( flags?.[ 'terminal_wp_cli_enabled' ] ) || terminalWpCliEnabledFromGlobals,
+					backupEnabled: Boolean( flags?.[ 'backup_enabled' ] ) || backupEnabledFromGlobals,
 				} );
 			} catch ( error ) {
 				console.error( error );
@@ -53,7 +59,13 @@ export const FeatureFlagsProvider: React.FC< FeatureFlagsProviderProps > = ( { c
 		return () => {
 			cancel = true;
 		};
-	}, [ isAuthenticated, client, assistantEnabledFromGlobals, terminalWpCliEnabledFromGlobals ] );
+	}, [
+		isAuthenticated,
+		client,
+		assistantEnabledFromGlobals,
+		terminalWpCliEnabledFromGlobals,
+		backupEnabledFromGlobals,
+	] );
 
 	return (
 		<FeatureFlagsContext.Provider value={ featureFlags }>{ children }</FeatureFlagsContext.Provider>

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -469,7 +469,7 @@ export async function getAppGlobals( _event: IpcMainInvokeEvent ): Promise< AppG
 		arm64Translation: app.runningUnderARM64Translation,
 		assistantEnabled: process.env.STUDIO_AI === 'true',
 		terminalWpCliEnabled: process.env.STUDIO_TERMINAL_WP_CLI === 'true',
-		backupEnabled: process.env.STUDIO_BACKUP === 'true',
+		importExportEnabled: process.env.STUDIO_IMPORT_EXPORT === 'true',
 	};
 }
 

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -469,6 +469,7 @@ export async function getAppGlobals( _event: IpcMainInvokeEvent ): Promise< AppG
 		arm64Translation: app.runningUnderARM64Translation,
 		assistantEnabled: process.env.STUDIO_AI === 'true',
 		terminalWpCliEnabled: process.env.STUDIO_TERMINAL_WP_CLI === 'true',
+		backupEnabled: process.env.STUDIO_BACKUP === 'true',
 	};
 }
 

--- a/src/ipc-types.d.ts
+++ b/src/ipc-types.d.ts
@@ -74,6 +74,7 @@ interface AppGlobals {
 	arm64Translation: boolean;
 	assistantEnabled: boolean;
 	terminalWpCliEnabled: boolean;
+	backupEnabled: boolean;
 }
 
 interface IpcListener {

--- a/src/ipc-types.d.ts
+++ b/src/ipc-types.d.ts
@@ -74,7 +74,7 @@ interface AppGlobals {
 	arm64Translation: boolean;
 	assistantEnabled: boolean;
 	terminalWpCliEnabled: boolean;
-	backupEnabled: boolean;
+	importExportEnabled: boolean;
 }
 
 interface IpcListener {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/8155

## Proposed Changes

This PR adds a new "import/export" tab to the UI

## Testing Instructions
1. Run `npm start`
2. Ensure that the new tab is not there
3. Run `STUDIO_IMPORT_EXPORT=true npm start`
4. Ensure that you see the new tab

![image](https://github.com/Automattic/studio/assets/497103/4cc3692e-f318-438f-ba6f-5fe490172913)
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
