### PR TITLE
Studio: Fix the alignment on the logged out view 

### DIFF
--- a/src/components/chat-message.tsx
+++ b/src/components/chat-message.tsx
@@ -71,9 +71,9 @@ export const ChatMessage = ( {
 		<div
 			className={ cx(
 				'flex mt-4',
-				message.role === 'user'
-					? 'justify-end ltr:md:ml-24 rtl:md:mr-24'
-					: 'justify-start ltr:md:mr-24 rtl:md:ml-24',
+				isUnauthenticated || message.role !== 'user'
+					? 'justify-start ltr:md:mr-24 rtl:md:ml-24'
+					: 'justify-end ltr:md:ml-24 rtl:md:mr-24',
 				className
 			) }
 		>


### PR DESCRIPTION

At the moment, if the user is logged out and tries to use assistant, the logged out view looks broken with the horizontal scrolling present. The logged out view should be aligned to the left of the screen with no scrollbar at the bottom.

## Proposed Changes

Before:

<img width="891" alt="Screenshot 2024-07-10 at 2 01 07 PM" src="https://github.com/Automattic/studio/assets/25575134/ee72a697-276b-4ec8-8928-28faa7057757">

After: 

<img width="1044" alt="Screenshot 2024-07-10 at 2 21 05 PM" src="https://github.com/Automattic/studio/assets/25575134/47de3745-15c3-4743-b3d9-9d7bb6c7f079">

## Testing Instructions

* Pull the changes from this branch locally
* Start the app with `STUDIO_AI=true npm start`
* Make sure you are logged out of your WP.com account
* Navigate to the Assistant tab
* Confirm that the logged out view is aligned to the left with no scrollbar present at the bottom
* Log in and confirm that user and assistant messages look good in the logged in view  

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
