### PR TITLE
Studio: Remove a redundant line in styling of error messages

### DIFF
--- a/src/components/chat-message.tsx
+++ b/src/components/chat-message.tsx
@@ -83,7 +83,6 @@ export const ChatMessage = ( {
 				data-testid="chat-message"
 				aria-labelledby={ id }
 				className={ cx(
-					'inline-block p-3 rounded border border-gray-300 overflow-x-auto select-text',
 					'inline-block p-3 rounded border overflow-x-auto select-text',
 					isUnauthenticated ? 'lg:max-w-[90%]' : 'lg:max-w-[70%]',
 					message.failedMessage


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to https://github.com/Automattic/studio/pull/267/files

## Proposed Changes

This PR removes a redundant line in styling of the messages and fixes the styling of the error messages.

**Before**

<img width="373" alt="Screenshot 2024-07-10 at 2 57 51 PM" src="https://github.com/Automattic/studio/assets/25575134/faafa74c-8b13-4f59-a812-652db23b2873">

**After**

<img width="365" alt="Screenshot 2024-07-10 at 2 55 16 PM" src="https://github.com/Automattic/studio/assets/25575134/0516ea0d-9f14-4f03-83b5-e84469c1e494">

## Testing Instructions

* Pull the changes from this branch locally
* Start the app with `STUDIO_AI=true npm start`
* Modify the URL for the API to be invalid in `src/hooks/use-assistant-api.ts` on lines 50-54:

```
						{
							path: '/studio-app/ai-assistant/cht',
							apiNamespace: 'wpcom/v2',
							body,
						},
```
* Navigate to the Assistant tab
* Try sending either a message or use an example prompt
* Observe that error message `Oops! We couldn't get a response from the assistant.` appears the styling of the borders around the message box is red and **not** gray
* Confirm that the styling of regular messages looks good

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
