### PR TITLE
Update delete site modal to delete files by default

### DIFF
--- a/src/components/delete-site.tsx
+++ b/src/components/delete-site.tsx
@@ -43,7 +43,7 @@ const DeleteSite = () => {
 			buttons: [ __( 'Delete site' ), __( 'Cancel' ) ],
 			cancelId: CANCEL_BUTTON_INDEX,
 			checkboxLabel: __( 'Delete site files from my computer' ),
-			checkboxChecked: false,
+			checkboxChecked: true,
 		} );
 
 		if ( response === DELETE_BUTTON_INDEX ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to https://github.com/Automattic/studio/issues/303

## Proposed Changes

I propose to change the delete site modal to automatically check the option to delete site's files.

![Screenshot 2024-07-11 at 12 11 03](https://github.com/Automattic/studio/assets/727413/1123e563-de78-43a9-b15a-4e741bcce4ca)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Add a site
2. Open Settings tab
3. Click 'Delete site'
4. Confirm that option is selected by default
5. Submit and confirm that site's directory was deleted

Then test the opposite, so after unchecking option, site's files should stay.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
