### PR TITLE
Open restart nudge if user triggers update check after closing it

### DIFF
--- a/src/updates.ts
+++ b/src/updates.ts
@@ -108,6 +108,9 @@ export function setupUpdates() {
 export async function manualCheckForUpdates() {
 	if ( updaterState === 'waiting-for-restart' ) {
 		// Not a valid state to check for updatees, user should be manually restarting instead
+		// However, let's open the dialog to let them easily restart
+		console.log( 'Update has been already downloaded, proposing to restart again' );
+		await showUpdateReadyToInstallNotice();
 		return;
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to https://github.com/Automattic/studio/issues/277

## Proposed Changes

When there is a new Studio version, Studio asks if user wants to upgrade. If they choose 'Later', and then try using 'Check for Updates' option, nothing will happen.

I propose to add a restart nudge in such a case to ensure that users get feedback when they use 'Check for Updates' again.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Apply patch to simulate downloading restart:

```
diff --git a/src/updates.ts b/src/updates.ts
index 504b48a..27ec600 100644
--- a/src/updates.ts
+++ b/src/updates.ts
@@ -48,6 +48,10 @@ export function setupUpdates() {
 	} );
 
 	autoUpdater.on( 'update-not-available', async () => {
+		updaterState = 'waiting-for-restart';
+		console.log( 'Faking downloading new version' );
+		return await showUpdateReadyToInstallNotice();
+
 		if ( showManualCheckDialogs ) {
 			await showUpdateUnavailableNotice();
 		}

```

2. Start Studio `npm start`
3. Click 'Check for Updates'
4. Confirm that dialog was displayed and 'Faking downloading new version' was logged
5. Click 'Later'
6. Click 'Check for Updates'
7. Confirm that dialog was displayed and 'Update has been already downloaded, proposing to restart again' was logged

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
