### PR TITLE
Add hover state to site thumbnail

### DIFF
--- a/src/components/content-tab-overview.tsx
+++ b/src/components/content-tab-overview.tsx
@@ -248,9 +248,9 @@ export function ContentTabOverview( { selectedSite }: ContentTabOverviewProps ) 
 					) }
 					{ ! loading && siteRunning && (
 						<button
-							aria-label={ __( 'Open WP Admin' ) }
+							aria-label={ __( 'Open Site' ) }
 							className={ cx( `relative group` ) }
-							onClick={ () => getIpcApi().openSiteURL( selectedSite.id, '/wp-admin' ) }
+							onClick={ () => getIpcApi().openSiteURL( selectedSite.id ) }
 						>
 							<div
 								className={ cx(

--- a/src/components/content-tab-overview.tsx
+++ b/src/components/content-tab-overview.tsx
@@ -264,7 +264,7 @@ export function ContentTabOverview( { selectedSite }: ContentTabOverviewProps ) 
 						>
 							<div
 								className={
-									'opacity-0 group-hover:opacity-90 group-hover:bg-white duration-300 absolute size-full flex justify-center items-center bg-white text-a8c-blueberry'
+									'opacity-0 group-hover:opacity-90 group-hover:bg-white group-focus:opacity-90 group-focus:bg-white duration-300 absolute size-full flex justify-center items-center bg-white text-a8c-blueberry'
 								}
 							>
 								{ __( 'Open site' ) }

--- a/src/components/content-tab-overview.tsx
+++ b/src/components/content-tab-overview.tsx
@@ -229,6 +229,16 @@ export function ContentTabOverview( { selectedSite }: ContentTabOverviewProps ) 
 	const loading = loadingThemeDetails || loadingThumbnails || initialLoading;
 	const siteRunning = selectedSite.running;
 
+	const thumbnailImage = (
+		<img
+			onError={ () => setIsThumbnailError( true ) }
+			onLoad={ () => setIsThumbnailError( false ) }
+			className={ ! isThumbnailError ? 'w-full h-full' : 'absolute invisible' }
+			src={ thumbnailData || '' }
+			alt={ themeDetails?.name }
+		/>
+	);
+
 	return (
 		<div className="p-8 flex max-w-3xl">
 			<div className="w-52 ltr:mr-8 rtl:ml-8 flex-col justify-start items-start gap-8">
@@ -264,24 +274,10 @@ export function ContentTabOverview( { selectedSite }: ContentTabOverviewProps ) 
 									size={ 14 }
 								/>
 							</div>
-							<img
-								onError={ () => setIsThumbnailError( true ) }
-								onLoad={ () => setIsThumbnailError( false ) }
-								className={ ! isThumbnailError ? 'w-full h-full' : 'absolute invisible' }
-								src={ thumbnailData || '' }
-								alt={ themeDetails?.name }
-							/>
+							{ thumbnailImage }
 						</button>
 					) }
-					{ ! loading && ! siteRunning && (
-						<img
-							onError={ () => setIsThumbnailError( true ) }
-							onLoad={ () => setIsThumbnailError( false ) }
-							className={ ! isThumbnailError ? 'w-full h-full' : 'absolute invisible' }
-							src={ thumbnailData || '' }
-							alt={ themeDetails?.name }
-						/>
-					) }
+					{ ! loading && ! siteRunning && thumbnailImage }
 				</div>
 				<div className="flex justify-between items-center w-full">
 					{ loading && <div className={ `w-[100px] min-h-4 ${ skeletonBg }` }></div> }

--- a/src/components/content-tab-overview.tsx
+++ b/src/components/content-tab-overview.tsx
@@ -242,7 +242,7 @@ export function ContentTabOverview( { selectedSite }: ContentTabOverviewProps ) 
 					) }
 				>
 					{ isThumbnailError && ! loading && (
-						<div className="flex items-center justify-center w-full h-full leading-5 text-a8c-gray-50">
+						<div className="flex items-center justify-center w-full h-64 leading-5 text-a8c-gray-50">
 							{ __( 'Preview unavailable' ) }
 						</div>
 					) }

--- a/src/components/content-tab-overview.tsx
+++ b/src/components/content-tab-overview.tsx
@@ -248,7 +248,7 @@ export function ContentTabOverview( { selectedSite }: ContentTabOverviewProps ) 
 					) }
 					{ ! loading && siteRunning && (
 						<button
-							aria-label={ __( 'Open Site' ) }
+							aria-label={ __( 'Open site' ) }
 							className={ cx( `relative group focus-visible:outline-a8c-blueberry` ) }
 							onClick={ () => getIpcApi().openSiteURL( selectedSite.id ) }
 						>
@@ -257,7 +257,7 @@ export function ContentTabOverview( { selectedSite }: ContentTabOverviewProps ) 
 									`opacity-0 group-hover:opacity-90 group-hover:bg-white duration-300 absolute size-full flex justify-center items-center bg-white text-a8c-blueberry`
 								) }
 							>
-								{ __( 'Open Site' ) }
+								{ __( 'Open site' ) }
 								<Icon
 									icon={ external }
 									className="ltr:ml-0.5 rtl:mr-0.5 rtl:scale-x-[-1] fill-a8c-blueberry"

--- a/src/components/content-tab-overview.tsx
+++ b/src/components/content-tab-overview.tsx
@@ -5,6 +5,8 @@ import {
 	code,
 	desktop,
 	edit,
+	external,
+	Icon,
 	layout,
 	navigation,
 	page,
@@ -225,6 +227,7 @@ export function ContentTabOverview( { selectedSite }: ContentTabOverviewProps ) 
 	} = useThemeDetails();
 
 	const loading = loadingThemeDetails || loadingThumbnails || initialLoading;
+	const siteRunning = selectedSite.running;
 
 	return (
 		<div className="p-8 flex max-w-3xl">
@@ -234,7 +237,8 @@ export function ContentTabOverview( { selectedSite }: ContentTabOverviewProps ) 
 					className={ cx(
 						'w-full min-h-40 max-h-60 overflow-hidden rounded-sm border border-a8c-gray-5 bg-a8c-gray-0 mb-2 flex items-center justify-center',
 						loading && skeletonBg,
-						isThumbnailError && 'border-none'
+						isThumbnailError && 'border-none',
+						siteRunning && 'hover:border-a8c-blueberry duration-300'
 					) }
 				>
 					{ isThumbnailError && ! loading && (
@@ -242,7 +246,34 @@ export function ContentTabOverview( { selectedSite }: ContentTabOverviewProps ) 
 							{ __( 'Preview unavailable' ) }
 						</div>
 					) }
-					{ ! loading && (
+					{ ! loading && siteRunning && (
+						<button
+							aria-label={ __( 'Open WP Admin' ) }
+							className={ cx( `relative group` ) }
+							onClick={ () => getIpcApi().openSiteURL( selectedSite.id, '/wp-admin' ) }
+						>
+							<div
+								className={ cx(
+									`opacity-0 group-hover:opacity-90 group-hover:bg-white duration-300 absolute size-full flex justify-center items-center bg-white text-a8c-blueberry`
+								) }
+							>
+								{ __( 'Open Site' ) }
+								<Icon
+									icon={ external }
+									className="ltr:ml-0.5 rtl:mr-0.5 rtl:scale-x-[-1] fill-a8c-blueberry"
+									size={ 14 }
+								/>
+							</div>
+							<img
+								onError={ () => setIsThumbnailError( true ) }
+								onLoad={ () => setIsThumbnailError( false ) }
+								className={ ! isThumbnailError ? 'w-full h-full' : 'absolute invisible' }
+								src={ thumbnailData || '' }
+								alt={ themeDetails?.name }
+							/>
+						</button>
+					) }
+					{ ! loading && ! siteRunning && (
 						<img
 							onError={ () => setIsThumbnailError( true ) }
 							onLoad={ () => setIsThumbnailError( false ) }

--- a/src/components/content-tab-overview.tsx
+++ b/src/components/content-tab-overview.tsx
@@ -236,7 +236,7 @@ export function ContentTabOverview( { selectedSite }: ContentTabOverviewProps ) 
 				<div
 					className={ cx(
 						'w-full min-h-40 max-h-64 rounded-sm border border-a8c-gray-5 bg-a8c-gray-0 mb-2 flex justify-center',
-						loading && skeletonBg,
+						loading && `h-64 ${ skeletonBg }`,
 						isThumbnailError && 'border-none',
 						siteRunning && 'hover:border-a8c-blueberry duration-300'
 					) }

--- a/src/components/content-tab-overview.tsx
+++ b/src/components/content-tab-overview.tsx
@@ -238,7 +238,7 @@ export function ContentTabOverview( { selectedSite }: ContentTabOverviewProps ) 
 						'w-full min-h-40 max-h-64 rounded-sm border border-a8c-gray-5 bg-a8c-gray-0 mb-2 flex justify-center',
 						loading && `h-64 ${ skeletonBg }`,
 						isThumbnailError && 'border-none',
-						siteRunning && 'hover:border-a8c-blueberry duration-300'
+						! loading && siteRunning && 'hover:border-a8c-blueberry duration-300'
 					) }
 				>
 					{ isThumbnailError && ! loading && (

--- a/src/components/content-tab-overview.tsx
+++ b/src/components/content-tab-overview.tsx
@@ -249,13 +249,13 @@ export function ContentTabOverview( { selectedSite }: ContentTabOverviewProps ) 
 					{ ! loading && siteRunning && (
 						<button
 							aria-label={ __( 'Open site' ) }
-							className={ cx( `relative group focus-visible:outline-a8c-blueberry` ) }
+							className={ 'relative group focus-visible:outline-a8c-blueberry' }
 							onClick={ () => getIpcApi().openSiteURL( selectedSite.id ) }
 						>
 							<div
-								className={ cx(
-									`opacity-0 group-hover:opacity-90 group-hover:bg-white duration-300 absolute size-full flex justify-center items-center bg-white text-a8c-blueberry`
-								) }
+								className={
+									'opacity-0 group-hover:opacity-90 group-hover:bg-white duration-300 absolute size-full flex justify-center items-center bg-white text-a8c-blueberry'
+								}
 							>
 								{ __( 'Open site' ) }
 								<Icon

--- a/src/components/content-tab-overview.tsx
+++ b/src/components/content-tab-overview.tsx
@@ -235,7 +235,7 @@ export function ContentTabOverview( { selectedSite }: ContentTabOverviewProps ) 
 				<h2 className="mb-3 a8c-subtitle-small">{ __( 'Theme' ) }</h2>
 				<div
 					className={ cx(
-						'w-full min-h-40 max-h-60 overflow-hidden rounded-sm border border-a8c-gray-5 bg-a8c-gray-0 mb-2 flex items-center justify-center',
+						'w-full min-h-40 max-h-64 rounded-sm border border-a8c-gray-5 bg-a8c-gray-0 mb-2 flex justify-center',
 						loading && skeletonBg,
 						isThumbnailError && 'border-none',
 						siteRunning && 'hover:border-a8c-blueberry duration-300'
@@ -249,7 +249,7 @@ export function ContentTabOverview( { selectedSite }: ContentTabOverviewProps ) 
 					{ ! loading && siteRunning && (
 						<button
 							aria-label={ __( 'Open Site' ) }
-							className={ cx( `relative group` ) }
+							className={ cx( `relative group focus-visible:outline-a8c-blueberry` ) }
 							onClick={ () => getIpcApi().openSiteURL( selectedSite.id ) }
 						>
 							<div


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to https://github.com/Automattic/studio/issues/103

## Proposed Changes

I propose adding a hover state to the site thumbnail to let the user open the site by clicking it.

![Screenshot 2024-07-12 at 16 01 36](https://github.com/user-attachments/assets/2975d6b1-c66a-4253-967a-402d8fe7a886)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Start site
2. Confirm the new thumbnail hover state works as expected
3. Click the thumbnail and confirm it opens the site
4. Stop the site
5. Confirm there is no hover state anymore

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
