### PR TITLE
Studio: Replace button loading indicator with full window one

### DIFF
--- a/e2e/sites.test.ts
+++ b/e2e/sites.test.ts
@@ -37,17 +37,18 @@ test.describe( 'Servers', () => {
 		await modal.siteNameInput.fill( siteName );
 		await modal.addSiteButton.click();
 
-		const sidebarButton = sidebar.getSiteNavButton( siteName );
-		await expect( sidebarButton ).toBeAttached( { timeout: 30_000 } );
+		const siteTitle = sidebar.getSiteNavButton( siteName );
+		await expect( siteTitle ).toHaveText( siteName );
+
+		// Check the site is running
+		const siteContent = new SiteContent( session.mainWindow, siteName );
+		await expect( siteContent.siteNameHeading ).toBeAttached( { timeout: 30_000 } );
+		expect( await siteContent.siteNameHeading ).toHaveText( siteName );
 
 		// Check a WordPress site has been created
 		expect(
 			await pathExists( path.join( session.homePath, 'Studio', siteName, 'wp-config.php' ) )
 		).toBe( true );
-
-		// Check the site is running
-		const siteContent = new SiteContent( session.mainWindow, siteName );
-		expect( await siteContent.siteNameHeading ).toHaveText( siteName );
 
 		await siteContent.navigateToTab( 'Settings' );
 

--- a/src/components/add-site.tsx
+++ b/src/components/add-site.tsx
@@ -4,6 +4,7 @@ import { useI18n } from '@wordpress/react-i18n';
 import { FormEvent, useCallback, useEffect, useState } from 'react';
 import { useAddSite } from '../hooks/use-add-site';
 import { useIpcListener } from '../hooks/use-ipc-listener';
+import { useSiteDetails } from '../hooks/use-site-details';
 import { generateSiteName } from '../lib/generate-site-name';
 import { getIpcApi } from '../lib/get-ipc-api';
 import Button from './button';
@@ -18,10 +19,10 @@ export default function AddSite( { className }: AddSiteProps ) {
 	const { __ } = useI18n();
 	const [ showModal, setShowModal ] = useState( false );
 	const [ nameSuggested, setNameSuggested ] = useState( false );
+	const { selectedSite } = useSiteDetails();
 
 	const {
 		handleAddSiteClick,
-		isAddingSite,
 		siteName,
 		setSiteName,
 		setProposedSitePath,
@@ -117,16 +118,20 @@ export default function AddSite( { className }: AddSiteProps ) {
 						doesPathContainWordPress={ doesPathContainWordPress }
 					>
 						<div className="flex flex-row justify-end gap-x-5 mt-6">
-							<Button onClick={ closeModal } disabled={ isAddingSite } variant="tertiary">
+							<Button
+								onClick={ closeModal }
+								disabled={ selectedSite?.isAddingSite }
+								variant="tertiary"
+							>
 								{ __( 'Cancel' ) }
 							</Button>
 							<Button
 								type="submit"
 								variant="primary"
-								isBusy={ isAddingSite }
-								disabled={ isAddingSite || !! error || ! siteName?.trim() }
+								isBusy={ selectedSite?.isAddingSite }
+								disabled={ selectedSite?.isAddingSite || !! error || ! siteName?.trim() }
 							>
-								{ isAddingSite ? __( 'Adding site…' ) : __( 'Add site' ) }
+								{ __( 'Add site' ) }
 							</Button>
 						</div>
 					</SiteForm>

--- a/src/components/add-site.tsx
+++ b/src/components/add-site.tsx
@@ -19,7 +19,7 @@ export default function AddSite( { className }: AddSiteProps ) {
 	const { __ } = useI18n();
 	const [ showModal, setShowModal ] = useState( false );
 	const [ nameSuggested, setNameSuggested ] = useState( false );
-	const { selectedSite } = useSiteDetails();
+	const { data } = useSiteDetails();
 
 	const {
 		handleAddSiteClick,
@@ -37,6 +37,8 @@ export default function AddSite( { className }: AddSiteProps ) {
 		usedSiteNames,
 		loadingSites,
 	} = useAddSite();
+
+	const isSiteAdding = data.some( ( site ) => site.isAddingSite );
 
 	const siteAddedMessage = sprintf(
 		// translators: %s is the site name.
@@ -118,18 +120,14 @@ export default function AddSite( { className }: AddSiteProps ) {
 						doesPathContainWordPress={ doesPathContainWordPress }
 					>
 						<div className="flex flex-row justify-end gap-x-5 mt-6">
-							<Button
-								onClick={ closeModal }
-								disabled={ selectedSite?.isAddingSite }
-								variant="tertiary"
-							>
+							<Button onClick={ closeModal } disabled={ isSiteAdding } variant="tertiary">
 								{ __( 'Cancel' ) }
 							</Button>
 							<Button
 								type="submit"
 								variant="primary"
-								isBusy={ selectedSite?.isAddingSite }
-								disabled={ selectedSite?.isAddingSite || !! error || ! siteName?.trim() }
+								isBusy={ isSiteAdding }
+								disabled={ isSiteAdding || !! error || ! siteName?.trim() }
 							>
 								{ __( 'Add site' ) }
 							</Button>

--- a/src/components/add-site.tsx
+++ b/src/components/add-site.tsx
@@ -83,10 +83,10 @@ export default function AddSite( { className }: AddSiteProps ) {
 		async ( event: FormEvent ) => {
 			event.preventDefault();
 			try {
+				closeModal();
 				await handleAddSiteClick();
 				speak( siteAddedMessage );
 				setNameSuggested( false );
-				closeModal();
 			} catch {
 				// No need to handle error here, it's already handled in handleAddSiteClick
 			}

--- a/src/components/onboarding.tsx
+++ b/src/components/onboarding.tsx
@@ -122,7 +122,7 @@ export default function Onboarding() {
 									disabled={ !! error || selectedSite?.isAddingSite }
 									variant="primary"
 								>
-									{ 'Add site' }
+									{ __( 'Add site' ) }
 								</Button>
 							</div>
 						</SiteForm>

--- a/src/components/onboarding.tsx
+++ b/src/components/onboarding.tsx
@@ -4,7 +4,6 @@ import { Icon, wordpress } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { FormEvent, useCallback, useEffect } from 'react';
 import { useAddSite } from '../hooks/use-add-site';
-import { useSiteDetails } from '../hooks/use-site-details';
 import { generateSiteName } from '../lib/generate-site-name';
 import { getIpcApi } from '../lib/get-ipc-api';
 import Button from './button';
@@ -47,8 +46,6 @@ export default function Onboarding() {
 		handleSiteNameChange,
 		handlePathSelectorClick,
 	} = useAddSite();
-
-	const { selectedSite } = useSiteDetails();
 
 	const siteAddedMessage = sprintf(
 		// translators: %s is the site name.
@@ -116,12 +113,7 @@ export default function Onboarding() {
 							onSubmit={ handleSubmit }
 						>
 							<div className="flex flex-row gap-x-5 mt-6">
-								<Button
-									type="submit"
-									isBusy={ selectedSite?.isAddingSite }
-									disabled={ !! error || selectedSite?.isAddingSite }
-									variant="primary"
-								>
+								<Button type="submit" variant="primary">
 									{ __( 'Add site' ) }
 								</Button>
 							</div>

--- a/src/components/onboarding.tsx
+++ b/src/components/onboarding.tsx
@@ -122,7 +122,7 @@ export default function Onboarding() {
 									disabled={ !! error || selectedSite?.isAddingSite }
 									variant="primary"
 								>
-									{ selectedSite?.isAddingSite ? __( 'Adding site…' ) : __( 'Add site' ) }
+									{ 'Add site' }
 								</Button>
 							</div>
 						</SiteForm>

--- a/src/components/onboarding.tsx
+++ b/src/components/onboarding.tsx
@@ -4,6 +4,7 @@ import { Icon, wordpress } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { FormEvent, useCallback, useEffect } from 'react';
 import { useAddSite } from '../hooks/use-add-site';
+import { useSiteDetails } from '../hooks/use-site-details';
 import { generateSiteName } from '../lib/generate-site-name';
 import { getIpcApi } from '../lib/get-ipc-api';
 import Button from './button';
@@ -34,7 +35,6 @@ export default function Onboarding() {
 	const { __ } = useI18n();
 	const {
 		setSiteName,
-		isAddingSite,
 		setProposedSitePath,
 		setSitePath,
 		setError,
@@ -47,6 +47,8 @@ export default function Onboarding() {
 		handleSiteNameChange,
 		handlePathSelectorClick,
 	} = useAddSite();
+
+	const { selectedSite } = useSiteDetails();
 
 	const siteAddedMessage = sprintf(
 		// translators: %s is the site name.
@@ -116,11 +118,11 @@ export default function Onboarding() {
 							<div className="flex flex-row gap-x-5 mt-6">
 								<Button
 									type="submit"
-									isBusy={ isAddingSite }
-									disabled={ !! error || isAddingSite }
+									isBusy={ selectedSite?.isAddingSite }
+									disabled={ !! error || selectedSite?.isAddingSite }
 									variant="primary"
 								>
-									{ isAddingSite ? __( 'Adding site…' ) : __( 'Add site' ) }
+									{ selectedSite?.isAddingSite ? __( 'Adding site…' ) : __( 'Add site' ) }
 								</Button>
 							</div>
 						</SiteForm>

--- a/src/components/site-content-tabs.tsx
+++ b/src/components/site-content-tabs.tsx
@@ -9,6 +9,7 @@ import { ContentTabOverview } from './content-tab-overview';
 import { ContentTabSettings } from './content-tab-settings';
 import { ContentTabSnapshots } from './content-tab-snapshots';
 import Header from './header';
+import { SiteLoadingIndicator } from './site-loading-indicator';
 
 export function SiteContentTabs() {
 	const { selectedSite } = useSiteDetails();
@@ -21,6 +22,10 @@ export function SiteContentTabs() {
 				<p className="text-lg text-gray-600">{ __( 'Select a site to view details.' ) }</p>
 			</div>
 		);
+	}
+
+	if ( selectedSite.isAddingSite ) {
+		return <SiteLoadingIndicator />;
 	}
 
 	return (

--- a/src/components/site-content-tabs.tsx
+++ b/src/components/site-content-tabs.tsx
@@ -25,7 +25,7 @@ export function SiteContentTabs() {
 	}
 
 	if ( selectedSite?.isAddingSite ) {
-		return <SiteLoadingIndicator />;
+		return <SiteLoadingIndicator selectedSiteName={ selectedSite.name } />;
 	}
 
 	return (

--- a/src/components/site-content-tabs.tsx
+++ b/src/components/site-content-tabs.tsx
@@ -24,7 +24,7 @@ export function SiteContentTabs() {
 		);
 	}
 
-	if ( selectedSite.isAddingSite ) {
+	if ( selectedSite?.isAddingSite ) {
 		return <SiteLoadingIndicator />;
 	}
 

--- a/src/components/site-loading-indicator.tsx
+++ b/src/components/site-loading-indicator.tsx
@@ -1,9 +1,27 @@
 import { useI18n } from '@wordpress/react-i18n';
+import { useEffect } from 'react';
+import { useProgressTimer } from '../hooks/use-progress-timer';
+import ProgressBar from './progress-bar';
 
 export function SiteLoadingIndicator() {
 	const { __ } = useI18n();
 
+	const { progress, setProgress } = useProgressTimer( {
+		initialProgress: 5,
+		interval: 1500,
+		maxValue: 95,
+	} );
+
+	useEffect( () => {
+		setProgress( 80 );
+	}, [ setProgress ] );
+
 	return (
-		<div className="flex flex-col w-full h-full app-no-drag-region pt-8 overflow-y-auto"></div>
+		<div className="flex flex-col w-full h-full app-no-drag-region pt-8 overflow-y-auto justify-center items-center">
+			<div className="w-[300px] text-center">
+				<ProgressBar value={ progress } maxValue={ 100 } />
+				<div className="text-a8c-gray-70 a8c-body mt-4">{ __( 'Creating site...' ) }</div>
+			</div>
+		</div>
 	);
 }

--- a/src/components/site-loading-indicator.tsx
+++ b/src/components/site-loading-indicator.tsx
@@ -7,13 +7,23 @@ export function SiteLoadingIndicator( { selectedSiteName }: { selectedSiteName?:
 	const { __ } = useI18n();
 
 	const { progress, setProgress } = useProgressTimer( {
-		initialProgress: 5,
+		initialProgress: 20,
 		interval: 1500,
 		maxValue: 95,
 	} );
 
 	useEffect( () => {
-		setProgress( 80 );
+		const updateProgress = () => {
+			setProgress( ( prev ) => {
+				const increment = Math.random() * 10 + 5;
+				return Math.min( prev + increment, 95 );
+			} );
+		};
+
+		setProgress( 50 );
+		const interval = setInterval( updateProgress, 1000 );
+
+		return () => clearInterval( interval );
 	}, [ setProgress ] );
 
 	return (

--- a/src/components/site-loading-indicator.tsx
+++ b/src/components/site-loading-indicator.tsx
@@ -1,0 +1,9 @@
+import { useI18n } from '@wordpress/react-i18n';
+
+export function SiteLoadingIndicator() {
+	const { __ } = useI18n();
+
+	return (
+		<div className="flex flex-col w-full h-full app-no-drag-region pt-8 overflow-y-auto"></div>
+	);
+}

--- a/src/components/site-loading-indicator.tsx
+++ b/src/components/site-loading-indicator.tsx
@@ -3,7 +3,7 @@ import { useEffect } from 'react';
 import { useProgressTimer } from '../hooks/use-progress-timer';
 import ProgressBar from './progress-bar';
 
-export function SiteLoadingIndicator() {
+export function SiteLoadingIndicator( { selectedSiteName }: { selectedSiteName?: string } ) {
 	const { __ } = useI18n();
 
 	const { progress, setProgress } = useProgressTimer( {
@@ -19,6 +19,7 @@ export function SiteLoadingIndicator() {
 	return (
 		<div className="flex flex-col w-full h-full app-no-drag-region pt-8 overflow-y-auto justify-center items-center">
 			<div className="w-[300px] text-center">
+				<div className="text-black a8c-subtitle-small mb-4">{ selectedSiteName }</div>
 				<ProgressBar value={ progress } maxValue={ 100 } />
 				<div className="text-a8c-gray-70 a8c-body mt-4">{ __( 'Creating site...' ) }</div>
 			</div>

--- a/src/components/site-menu.tsx
+++ b/src/components/site-menu.tsx
@@ -1,4 +1,5 @@
 import { speak } from '@wordpress/a11y';
+import { Spinner } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { useEffect } from 'react';
 import { useSiteDetails } from '../hooks/use-site-details';
@@ -113,7 +114,11 @@ function SiteItem( { site }: { site: SiteDetails } ) {
 			>
 				{ site.name }
 			</button>
-			<ButtonToRun { ...site } />
+			{ site.isAddingSite ? (
+				<Spinner className="!w-2.5 !h-2.5 !top-[6px] !mr-2" />
+			) : (
+				<ButtonToRun { ...site } />
+			) }
 		</li>
 	);
 }

--- a/src/components/tests/add-site.test.tsx
+++ b/src/components/tests/add-site.test.tsx
@@ -205,48 +205,4 @@ describe( 'AddSite', () => {
 			screen.getByDisplayValue( '/default_path/my-wordpress-website-mutated' )
 		).toBeVisible();
 	} );
-
-	it( 'should display a helpful error message when an error occurs while creating the site', async () => {
-		const user = userEvent.setup();
-		mockGenerateProposedSitePath.mockResolvedValue( {
-			path: '/default_path/my-wordpress-website',
-			name: 'My WordPress Website',
-			isEmpty: true,
-			isWordPress: false,
-		} );
-		mockCreateSite.mockImplementation( () => {
-			throw new Error( 'Failed to create site' );
-		} );
-		render( <AddSite /> );
-
-		await user.click( screen.getByRole( 'button', { name: 'Add site' } ) );
-		await user.click( screen.getByRole( 'button', { name: 'Add site' } ) );
-
-		await waitFor( () => {
-			expect( screen.getByRole( 'alert' ) ).toHaveTextContent(
-				'An error occurred while creating the site. Verify your selected local path is an empty directory or an existing WordPress folder and try again. If this problem persists, please contact support.'
-			);
-		} );
-	} );
-
-	it( 'should disable submissions while the site is being added', async () => {
-		const user = userEvent.setup();
-		mockGenerateProposedSitePath.mockResolvedValue( {
-			path: '/default_path/my-wordpress-website',
-			name: 'My WordPress Website',
-			isEmpty: true,
-			isWordPress: false,
-		} );
-		mockCreateSite.mockImplementationOnce( () => {
-			return new Promise( () => {
-				// no-op
-			} );
-		} );
-		render( <AddSite /> );
-
-		await user.click( screen.getByRole( 'button', { name: 'Add site' } ) );
-		await user.click( screen.getByRole( 'button', { name: 'Add site' } ) );
-
-		expect( screen.getByRole( 'button', { name: 'Adding site…' } ) ).toBeDisabled();
-	} );
 } );

--- a/src/hooks/use-add-site.ts
+++ b/src/hooks/use-add-site.ts
@@ -55,16 +55,8 @@ export function useAddSite() {
 			await createSite( path, siteName ?? '' );
 		} catch ( e ) {
 			Sentry.captureException( e );
-			getIpcApi().showMessageBox( {
-				type: 'error',
-				message: __( 'Failed to create site' ),
-				detail: __(
-					'An error occurred while creating the site. Verify your selected local path is an empty directory or an existing WordPress folder and try again. If this problem persists, please contact support.'
-				),
-				buttons: [ __( 'OK' ) ],
-			} );
 		}
-	}, [ createSite, proposedSitePath, siteName, sitePath, __ ] );
+	}, [ createSite, proposedSitePath, siteName, sitePath ] );
 
 	const handleSiteNameChange = useCallback(
 		async ( name: string ) => {

--- a/src/hooks/use-add-site.ts
+++ b/src/hooks/use-add-site.ts
@@ -8,7 +8,6 @@ export function useAddSite() {
 	const { __ } = useI18n();
 	const { createSite, data: sites, loadingSites } = useSiteDetails();
 	const [ error, setError ] = useState( '' );
-	const [ isAddingSite, setIsAddingSite ] = useState( false );
 	const [ siteName, setSiteName ] = useState< string | null >( null );
 	const [ sitePath, setSitePath ] = useState( '' );
 	const [ proposedSitePath, setProposedSitePath ] = useState( '' );
@@ -51,7 +50,6 @@ export function useAddSite() {
 	}, [ __, siteWithPathAlreadyExists, siteName, proposedSitePath ] );
 
 	const handleAddSiteClick = useCallback( async () => {
-		setIsAddingSite( true );
 		try {
 			const path = sitePath ? sitePath : proposedSitePath;
 			await createSite( path, siteName ?? '' );
@@ -62,10 +60,8 @@ export function useAddSite() {
 					'An error occurred while creating the site. Verify your selected local path is an empty directory or an existing WordPress folder and try again. If this problem persists, please contact support.'
 				)
 			);
-			setIsAddingSite( false );
 			throw e;
 		}
-		setIsAddingSite( false );
 	}, [ createSite, proposedSitePath, siteName, sitePath, __ ] );
 
 	const handleSiteNameChange = useCallback(
@@ -103,7 +99,6 @@ export function useAddSite() {
 			handleAddSiteClick,
 			handlePathSelectorClick,
 			handleSiteNameChange,
-			isAddingSite,
 			error: siteWithPathAlreadyExists( sitePath ? sitePath : proposedSitePath )
 				? __(
 						'Another site already exists at this path. Please select an empty directory to create a site.'
@@ -130,7 +125,6 @@ export function useAddSite() {
 			handlePathSelectorClick,
 			siteWithPathAlreadyExists,
 			handleSiteNameChange,
-			isAddingSite,
 			siteName,
 			sitePath,
 			proposedSitePath,

--- a/src/hooks/use-add-site.ts
+++ b/src/hooks/use-add-site.ts
@@ -55,12 +55,14 @@ export function useAddSite() {
 			await createSite( path, siteName ?? '' );
 		} catch ( e ) {
 			Sentry.captureException( e );
-			setError(
-				__(
+			getIpcApi().showMessageBox( {
+				type: 'error',
+				message: __( 'Failed to create site' ),
+				detail: __(
 					'An error occurred while creating the site. Verify your selected local path is an empty directory or an existing WordPress folder and try again. If this problem persists, please contact support.'
-				)
-			);
-			throw e;
+				),
+				buttons: [ __( 'OK' ) ],
+			} );
 		}
 	}, [ createSite, proposedSitePath, siteName, sitePath, __ ] );
 

--- a/src/hooks/use-site-details.tsx
+++ b/src/hooks/use-site-details.tsx
@@ -160,11 +160,12 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 
 	const createSite = useCallback(
 		async ( path: string, siteName?: string ) => {
+			const tempSiteId = 'adding-new-site';
 			setData( ( prevData ) =>
 				sortSites( [
 					...prevData,
 					{
-						id: 'adding-new-site',
+						id: tempSiteId,
 						name: siteName || path,
 						path,
 						running: false,
@@ -173,11 +174,12 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 					},
 				] )
 			);
+			setSelectedSiteId( tempSiteId ); // Set the temporary ID as the selected site
 			const data = await getIpcApi().createSite( path, siteName );
 			setData( data );
 			const newSite = data.find( ( site ) => site.path === path );
 			if ( newSite?.id ) {
-				setSelectedSiteId( newSite.id );
+				setSelectedSiteId( newSite.id ); // Update the selected site to the new site's ID
 			}
 		},
 		[ setSelectedSiteId ]

--- a/src/hooks/use-site-details.tsx
+++ b/src/hooks/use-site-details.tsx
@@ -160,7 +160,7 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 
 	const createSite = useCallback(
 		async ( path: string, siteName?: string ) => {
-			const tempSiteId = 'adding-new-site';
+			const tempSiteId = crypto.randomUUID();
 			setData( ( prevData ) =>
 				sortSites( [
 					...prevData,

--- a/src/hooks/use-site-details.tsx
+++ b/src/hooks/use-site-details.tsx
@@ -10,6 +10,7 @@ import {
 	useState,
 } from 'react';
 import { getIpcApi } from '../lib/get-ipc-api';
+import { sortSites } from '../lib/sort-sites';
 import { useSnapshots } from './use-snapshots';
 
 interface SiteDetailsContext {
@@ -159,6 +160,19 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 
 	const createSite = useCallback(
 		async ( path: string, siteName?: string ) => {
+			setData( ( prevData ) =>
+				sortSites( [
+					...prevData,
+					{
+						id: 'adding-new-site',
+						name: siteName || path,
+						path,
+						running: false,
+						isAddingSite: true,
+						phpVersion: '',
+					},
+				] )
+			);
 			const data = await getIpcApi().createSite( path, siteName );
 			setData( data );
 			const newSite = data.find( ( site ) => site.path === path );

--- a/src/hooks/use-site-details.tsx
+++ b/src/hooks/use-site-details.tsx
@@ -180,7 +180,7 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 					setData( ( prevData ) =>
 						sortSites( prevData.filter( ( site ) => site.id !== tempSiteId ) )
 					);
-				}, 3000 );
+				}, 2000 );
 			};
 
 			const tempSiteId = crypto.randomUUID();

--- a/src/ipc-types.d.ts
+++ b/src/ipc-types.d.ts
@@ -28,6 +28,7 @@ interface StoppedSiteDetails {
 		supportsWidgets: boolean;
 		supportsMenus: boolean;
 	};
+	isAddingSite?: boolean;
 }
 
 interface StartedSiteDetails extends StoppedSiteDetails {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/8167

## Proposed Changes

This PR replaces the loading state on the `Add site` modal with a full screen loading indicator:

<img width="869" alt="Screenshot 2024-07-16 at 9 02 33 AM" src="https://github.com/user-attachments/assets/58209145-11fc-4770-a6b4-acf84405b3cd">

## Testing Instructions

**From "Add site" modal:**

* Pull the changes from this branch
* Start the app with `nvm use && npm install && npm start`
* Click on the `Add site` button to open the modal
* Click on `Add site` to add a site
* Confirm that you see the loading state that takes the whole screen
* Confirm that you see the loading indicator in the sidebar
* Confirm that when you switch to a different site, you see the content tabs as expected
* Confirm that the `Add site` button is blocked for a given site when the site is being created

**From "Onboarding" screen**:

* Pull the changes from this branch
* Start the app with `nvm use && npm install && npm start
* Delete all the sites that you have to trigger the onboarding screen
* Click on `Add site`
* Confirm that you see the loading state that takes the whole screen
* Confirm that you see the loading indicator in the sidebar

**Testing for an error**:

* Apply the following diff:

```
diff --git a/src/ipc-handlers.ts b/src/ipc-handlers.ts
index 95903bb..b2c85d3 100644
--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -130,6 +130,9 @@ export async function createSite(
 ): Promise< SiteDetails[] > {
        const userData = await loadUserData();
        const forceSetupSqlite = false;
+
+       // Introduce an error for testing
+       throw new Error( 'Test Error: This is a forced error for testing purposes.' );
        // We only recursively create the directory if the user has not selected a
        // path from the dialog (and thus they use the "default" or suggested path).
        if ( ! ( await pathExists( path ) ) && path.startsWith( DEFAULT_SITE_PATH ) ) {
```

* Start the app with `nvm use && npm install && npm start`
* Click on the `Add site` button to open the modal
* Click on `Add site` to add a site
* Observe that you see the loading state
* Observe that it throws the dialog with an error
* Observe that the loading state goes away and the site is not created

**Notes**:
* I am not sure what the error handling is supposed to be like according to the design at the moment. For now, I implemented something that seems to make sense and does not look too strange for the user experience. We can open another PR once we have some more clarify on what the design and flow for the error + loading state should look like
* I am planning to more test coverage in a different PR to make this code available for the PR about import interface as soon as possible

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
