### PR TITLE
Support compressed files that contain a SQL file in importer

### DIFF
--- a/src/lib/import-export/import/handlers/backup-handler-factory.ts
+++ b/src/lib/import-export/import/handlers/backup-handler-factory.ts
@@ -8,6 +8,16 @@ export interface BackupHandler {
 	extractFiles( file: BackupArchiveInfo, extractionDirectory: string ): Promise< void >;
 }
 
+const EXCLUDED_FILES_PATTERNS = [
+	/^__MACOSX\/.*/, // MacOS meta folder
+	/^\..*/, // Unix hidden files at root
+	/\/\..*/, // Unix hidden files at subfolders
+];
+
+export function isFileAllowed( filePath: string ) {
+	return EXCLUDED_FILES_PATTERNS.every( ( pattern ) => ! pattern.test( filePath ) );
+}
+
 export class BackupHandlerFactory {
 	private static zipTypes = [
 		'application/zip',

--- a/src/lib/import-export/import/handlers/backup-handler-tar-gz.ts
+++ b/src/lib/import-export/import/handlers/backup-handler-tar-gz.ts
@@ -2,14 +2,14 @@ import fs from 'fs';
 import zlib from 'zlib';
 import * as tar from 'tar';
 import { BackupArchiveInfo } from '../types';
-import { BackupHandler } from './backup-handler-factory';
+import { BackupHandler, isFileAllowed } from './backup-handler-factory';
 
 export class BackupHandlerTarGz implements BackupHandler {
 	async listFiles( backup: BackupArchiveInfo ): Promise< string[] > {
 		const files: string[] = [];
 		await tar.t( {
 			file: backup.path,
-			onReadEntry: ( entry ) => files.push( entry.path ),
+			onReadEntry: ( entry ) => isFileAllowed( entry.path ) && files.push( entry.path ),
 		} );
 		return files;
 	}

--- a/src/lib/import-export/import/handlers/backup-handler-zip.ts
+++ b/src/lib/import-export/import/handlers/backup-handler-zip.ts
@@ -1,11 +1,14 @@
 import AdmZip from 'adm-zip';
 import { BackupArchiveInfo } from '../types';
-import { BackupHandler } from './backup-handler-factory';
+import { BackupHandler, isFileAllowed } from './backup-handler-factory';
 
 export class BackupHandlerZip implements BackupHandler {
 	async listFiles( backup: BackupArchiveInfo ): Promise< string[] > {
 		const zip = new AdmZip( backup.path );
-		return zip.getEntries().map( ( entry ) => entry.entryName );
+		return zip
+			.getEntries()
+			.map( ( entry ) => entry.entryName )
+			.filter( isFileAllowed );
 	}
 
 	async extractFiles( file: BackupArchiveInfo, extractionDirectory: string ): Promise< void > {

--- a/src/lib/import-export/tests/import/handlers/backup-handler.test.ts
+++ b/src/lib/import-export/tests/import/handlers/backup-handler.test.ts
@@ -67,6 +67,15 @@ describe( 'BackupHandlerFactory', () => {
 	describe( 'listFiles', () => {
 		const archiveFiles = [
 			'index.php',
+			'.hidden-file',
+			'wp-content/.hidden-file',
+			'wp-content/plugins/hello.php',
+			'wp-content/themes/twentytwentyfour/theme.json',
+			'wp-content/uploads/2024/07/image.png',
+			'__MACOSX/meta-file',
+		];
+		const expectedArchiveFiles = [
+			'index.php',
 			'wp-content/plugins/hello.php',
 			'wp-content/themes/twentytwentyfour/theme.json',
 			'wp-content/uploads/2024/07/image.png',
@@ -83,7 +92,7 @@ describe( 'BackupHandlerFactory', () => {
 				archiveFiles.forEach( ( path ) => onReadEntry?.( { path } as tar.ReadEntry ) );
 			} );
 
-			await expect( handler.listFiles( archiveInfo ) ).resolves.toEqual( archiveFiles );
+			await expect( handler.listFiles( archiveInfo ) ).resolves.toEqual( expectedArchiveFiles );
 		} );
 
 		it( 'should list files from a zip archive', async () => {
@@ -99,7 +108,7 @@ describe( 'BackupHandlerFactory', () => {
 					.mockReturnValue( archiveFiles.map( ( file ) => ( { entryName: file } ) ) ),
 			} );
 
-			await expect( handler.listFiles( archiveInfo ) ).resolves.toEqual( archiveFiles );
+			await expect( handler.listFiles( archiveInfo ) ).resolves.toEqual( expectedArchiveFiles );
 		} );
 
 		it( 'should list a single SQL file', async () => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to 8282-gh-Automattic/dotcom-forge.

## Proposed Changes

- I noticed when creating compressed files on macOS that hidden/meta files were also included. To exclude them in the import, I added the function `isFileAllowed` that is used in the different backup handlers to filter those files out. It's important to clean up the backup content when importing SQL-only files, otherwise, the following condition won't be met and the import will fail.
- Update unit tests of `listFiles` to cover the changes, plus fix the issue spotted [here](https://github.com/Automattic/studio/pull/351/files#r1679222686).

https://github.com/Automattic/studio/blob/caa31a018556647e2a5ca33a80012f99e28ed677/src/lib/import-export/import/validators/sql-validator.ts#L7

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Apply the following patch:
```patch
diff --git forkSrcPrefix/src/lib/import-export/import/importers/importer.ts forkDstPrefix/src/lib/import-export/import/importers/importer.ts
index 4ce10b9bc24f5a7193b49ad7b62dbf4ed70bbea9..95a12b57b3e3711be8caa252dddf3193cef3ef33 100644
--- forkSrcPrefix/src/lib/import-export/import/importers/importer.ts
+++ forkDstPrefix/src/lib/import-export/import/importers/importer.ts
@@ -35,6 +35,7 @@ export class DefaultImporter implements Importer {
 
 	protected async importDatabase(): Promise< void > {
 		// will implement in a different ticket
+		console.log( 'Trying to import the following SQL files:', this.backup.sqlFiles );
 	}
 
 	protected async importWpContent( rootPath: string ): Promise< void > {
diff --git forkSrcPrefix/src/components/content-tab-import-export.tsx forkDstPrefix/src/components/content-tab-import-export.tsx
index 436c8bcc281cb9f10501e05e2c965da7e0e0ac27..30acc63733ccf9fb6eab365e1483b1ca31a1c501 100644
--- forkSrcPrefix/src/components/content-tab-import-export.tsx
+++ forkDstPrefix/src/components/content-tab-import-export.tsx
@@ -1,6 +1,46 @@
+import { useEffect, useState } from 'react';
+import { getIpcApi } from '../lib/get-ipc-api';
+import { BackupArchiveInfo } from '../lib/import-export/import/types';
+
 interface ContentTabImportExportProps {
 	selectedSite: SiteDetails;
 }
-export function ContentTabImportExport( _props: ContentTabImportExportProps ) {
-	return null;
+export function ContentTabImportExport( { selectedSite }: ContentTabImportExportProps ) {
+	const [ file, setFile ] = useState< File | null >( null );
+
+	const handleFileChange = ( e: React.ChangeEvent< HTMLInputElement > ) => {
+		const selectedFile = e.target.files ? e.target.files[ 0 ] : null;
+		if ( selectedFile ) {
+			setFile( selectedFile );
+		}
+	};
+
+	useEffect( () => {
+		if ( file ) {
+			console.log( `File ready for import: ${ file.name }` );
+		}
+	}, [ file ] );
+
+	const handleSubmit = () => {
+		if ( file ) {
+			try {
+				const backupFile: BackupArchiveInfo = {
+					type: file.type,
+					path: file.path,
+				};
+				getIpcApi().importSite( { id: selectedSite.id, backupFile } );
+			} catch ( error ) {
+				console.error( 'Error importing site:', error );
+			}
+		} else {
+			console.warn( 'No file selected for import' );
+		}
+	};
+
+	return (
+		<div>
+			<input type="file" onChange={ handleFileChange } />
+			<button onClick={ handleSubmit }>Submit</button>
+		</div>
+	);
 }

```
- Run the command `STUDIO_IMPORT_EXPORT=true npm start`
- Navigate to the tab Import/Export
- Download and extract the content of the compressed file: [backup-files.zip](https://github.com/user-attachments/files/16247647/backup-files.zip).
- For each of the extracted files:
    - Select the file and click Submit.
    - Observe in the logs the entry: _Trying to import the following SQL files:_ [ `<TEMPORAL_FOLDER>/<PATH_TO_FILE>/wp_posts.sql` ].
    - Observe that the path to the SQL file is correct based on the extracted files.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
