### PR TITLE
Studio: Fix spinner color when adding a site 

### DIFF
--- a/src/components/site-menu.tsx
+++ b/src/components/site-menu.tsx
@@ -115,7 +115,7 @@ function SiteItem( { site }: { site: SiteDetails } ) {
 				{ site.name }
 			</button>
 			{ site.isAddingSite ? (
-				<Spinner className="!w-2.5 !h-2.5 !top-[6px] !mr-2" />
+				<Spinner className="!w-2.5 !h-2.5 !top-[6px] !mr-2 [&>circle]:stroke-a8c-gray-70" />
 			) : (
 				<ButtonToRun { ...site } />
 			) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

After merging https://github.com/Automattic/studio/pull/362 , I noticed a small inconsistency in the design - the color of the spinner should be `gray-70`.

**Before**:
<img width="173" alt="Screenshot 2024-07-18 at 9 32 41 AM" src="https://github.com/user-attachments/assets/b9f0fb18-5770-4ec5-b15b-8632114bb836">

**After**:
<img width="218" alt="Screenshot 2024-07-18 at 9 29 17 AM" src="https://github.com/user-attachments/assets/e182f619-6389-4050-9e8f-834f7be35ae8">

## Testing Instructions

* Pull the changes from this branch
* Start the app with `nvm use && npm install && npm start`
* Click on the `Add site` button to open the modal
* Click on `Add site` to add a site
* Confirm that you see the loading indicator in the sidebar with the correct color

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?