### PR TITLE
Studio: Disable 'Add site' button when site is being added

### DIFF
--- a/src/components/add-site.tsx
+++ b/src/components/add-site.tsx
@@ -135,7 +135,12 @@ export default function AddSite( { className }: AddSiteProps ) {
 					</SiteForm>
 				</Modal>
 			) }
-			<Button variant="outlined" className={ className } onClick={ openModal }>
+			<Button
+				variant="outlined"
+				className={ className }
+				onClick={ openModal }
+				disabled={ isSiteAdding }
+			>
 				{ __( 'Add site' ) }
 			</Button>
 		</>

--- a/src/components/add-site.tsx
+++ b/src/components/add-site.tsx
@@ -97,6 +97,9 @@ export default function AddSite( { className }: AddSiteProps ) {
 	);
 
 	useIpcListener( 'add-site', () => {
+		if ( isSiteAdding ) {
+			return;
+		}
 		openModal();
 	} );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/8342

## Proposed Changes

This PR does the two following things:

*  'Add site' button is disabled when site is being added
*  User can't open 'Add site' form using keyboard shortcut when site is being added

## Testing Instructions

* Pull the changes from this PR locally
* Start the app with `nvm use && npm install && npm start`
* Click on `Add site` in the sidebar and start the process
* Observe that you can see a loading screen
* Observe that `Add site` button is disabled while the new site is being created and you can't trigger the modal:

<img width="638" alt="Screenshot 2024-07-19 at 12 19 56 PM" src="https://github.com/user-attachments/assets/da2d6463-3aad-4089-a464-4cdd0e8d1c60">

* Click on `Add site` in the sidebar and start the process again
* Press `cmd + N` on your keyboard 
* Confirm that `Add site` modal does not appear
* Wait for the site to be created 
* Press `cmd + N` on your keyboard 
* Confirm that `Add site` modal appears

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
