### PR TITLE
Update export UI wording to avoid saying 'backup'

### DIFF
--- a/src/components/content-tab-import-export.tsx
+++ b/src/components/content-tab-import-export.tsx
@@ -82,7 +82,7 @@ export const ExportSite = ( {
 			<div>
 				<h4 className="a8c-subtitle-small leading-5">{ __( 'Export' ) }</h4>
 				<p className="text-a8c-gray-70 leading-[140%] a8c-helper-text text-[13px]">
-					{ __( 'Export your entire site or just the database.' ) }
+					{ __( 'Export your entire site or only the database.' ) }
 				</p>
 			</div>
 			<div className="gap-4 flex flex-row">

--- a/src/components/content-tab-import-export.tsx
+++ b/src/components/content-tab-import-export.tsx
@@ -82,15 +82,15 @@ export const ExportSite = ( {
 			<div>
 				<h4 className="a8c-subtitle-small leading-5">{ __( 'Export' ) }</h4>
 				<p className="text-a8c-gray-70 leading-[140%] a8c-helper-text text-[13px]">
-					{ __( 'Create a backup of your entire site or export the database.' ) }
+					{ __( 'Export your entire site or just the database.' ) }
 				</p>
 			</div>
 			<div className="gap-4 flex flex-row">
 				<Button onClick={ onExportFullSite } variant="primary">
-					{ __( 'Backup entire site' ) }
+					{ __( 'Export entire site' ) }
 				</Button>
 				<Button onClick={ onExportDatabase } type="submit" variant="secondary">
-					{ __( 'Backup database' ) }
+					{ __( 'Export database' ) }
 				</Button>
 			</div>
 		</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/8427

## Proposed Changes

I propose to change the wording in the Import / Export tab to avoid saying 'backup,' which seems confusing.

![Screenshot 2024-07-23 at 15 52 10](https://github.com/user-attachments/assets/5d1ddc61-c6e3-4fb6-853a-f715f7c65d9b)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Start Studio with feature flag:
```
STUDIO_IMPORT_EXPORT=true npm start
```
2. Confirm that new wording appears in the Import / Export tab.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
