### PR TITLE
Remove test timers related to code block

### DIFF
--- a/src/components/tests/ai-clear-history-reminder.test.tsx
+++ b/src/components/tests/ai-clear-history-reminder.test.tsx
@@ -14,6 +14,7 @@ describe( 'AIClearHistoryReminder', () => {
 		window.HTMLElement.prototype.scrollIntoView = jest.fn();
 		clearInput = jest.fn();
 		jest.clearAllMocks();
+		jest.useFakeTimers();
 		jest.setSystemTime( MOCKED_TIME );
 	} );
 

--- a/src/components/tests/assistant-code-block.test.tsx
+++ b/src/components/tests/assistant-code-block.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, act } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { getIpcApi } from '../../lib/get-ipc-api';
 import createCodeComponent from '../assistant-code-block';
 
@@ -100,10 +100,9 @@ describe( 'createCodeComponent', () => {
 
 			expect( screen.getByText( 'Running...' ) ).toBeVisible();
 
-			// Run code execution measurement timer
-			await act( () => jest.runAllTimersAsync() );
-
-			expect( screen.queryByText( 'Running...' ) ).not.toBeInTheDocument();
+			await waitFor( () => {
+				expect( screen.queryByText( 'Running...' ) ).not.toBeInTheDocument();
+			} );
 		} );
 
 		it( 'should display the output of the successfully executed code', async () => {
@@ -114,11 +113,10 @@ describe( 'createCodeComponent', () => {
 
 			fireEvent.click( screen.getByText( 'Run' ) );
 
-			// Run code execution measurement timer
-			await act( () => jest.runAllTimersAsync() );
-
-			expect( screen.getByText( 'Success' ) ).toBeVisible();
-			expect( screen.getByText( 'Mock success' ) ).toBeVisible();
+			await waitFor( () => {
+				expect( screen.getByText( 'Success' ) ).toBeVisible();
+				expect( screen.getByText( 'Mock success' ) ).toBeVisible();
+			} );
 		} );
 
 		it( 'should display the output of the failed code execution', async () => {
@@ -129,11 +127,10 @@ describe( 'createCodeComponent', () => {
 
 			fireEvent.click( screen.getByText( 'Run' ) );
 
-			// Run code execution measurement timer
-			await act( () => jest.runAllTimersAsync() );
-
-			expect( screen.getByText( 'Error' ) ).toBeVisible();
-			expect( screen.getByText( 'Mock error' ) ).toBeVisible();
+			await waitFor( () => {
+				expect( screen.getByText( 'Error' ) ).toBeVisible();
+				expect( screen.getByText( 'Mock error' ) ).toBeVisible();
+			} );
 		} );
 	} );
 

--- a/src/components/tests/assistant-code-block.test.tsx
+++ b/src/components/tests/assistant-code-block.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { act, render, screen, fireEvent } from '@testing-library/react';
 import { getIpcApi } from '../../lib/get-ipc-api';
 import createCodeComponent from '../assistant-code-block';
 
@@ -89,6 +89,14 @@ describe( 'createCodeComponent', () => {
 	} );
 
 	describe( 'when the "run" button is clicked', () => {
+		beforeEach( () => {
+			jest.useFakeTimers();
+		} );
+
+		afterEach( () => {
+			jest.useRealTimers();
+		} );
+
 		it( 'should display an activity indicator while running code', async () => {
 			( getIpcApi as jest.Mock ).mockReturnValue( {
 				executeWPCLiInline: jest.fn().mockResolvedValue( { stdout: 'Mock success', stderr: '' } ),
@@ -100,9 +108,9 @@ describe( 'createCodeComponent', () => {
 
 			expect( screen.getByText( 'Running...' ) ).toBeVisible();
 
-			await waitFor( () => {
-				expect( screen.queryByText( 'Running...' ) ).not.toBeInTheDocument();
-			} );
+			await act( () => jest.runOnlyPendingTimersAsync() );
+
+			expect( screen.queryByText( 'Running...' ) ).not.toBeInTheDocument();
 		} );
 
 		it( 'should display the output of the successfully executed code', async () => {
@@ -113,10 +121,10 @@ describe( 'createCodeComponent', () => {
 
 			fireEvent.click( screen.getByText( 'Run' ) );
 
-			await waitFor( () => {
-				expect( screen.getByText( 'Success' ) ).toBeVisible();
-				expect( screen.getByText( 'Mock success' ) ).toBeVisible();
-			} );
+			await act( () => jest.runOnlyPendingTimersAsync() );
+
+			expect( screen.getByText( 'Success' ) ).toBeVisible();
+			expect( screen.getByText( 'Mock success' ) ).toBeVisible();
 		} );
 
 		it( 'should display the output of the failed code execution', async () => {
@@ -127,10 +135,10 @@ describe( 'createCodeComponent', () => {
 
 			fireEvent.click( screen.getByText( 'Run' ) );
 
-			await waitFor( () => {
-				expect( screen.getByText( 'Error' ) ).toBeVisible();
-				expect( screen.getByText( 'Mock error' ) ).toBeVisible();
-			} );
+			await act( () => jest.runOnlyPendingTimersAsync() );
+
+			expect( screen.getByText( 'Error' ) ).toBeVisible();
+			expect( screen.getByText( 'Mock error' ) ).toBeVisible();
 		} );
 	} );
 

--- a/src/components/tests/content-tab-assistant.test.tsx
+++ b/src/components/tests/content-tab-assistant.test.tsx
@@ -110,7 +110,6 @@ describe( 'ContentTabAssistant', () => {
 		const storageKey = 'ai_chat_messages';
 		localStorage.setItem( storageKey, JSON.stringify( { [ runningSite.id ]: initialMessages } ) );
 		render( <ContentTabAssistant selectedSite={ runningSite } /> );
-		jest.advanceTimersByTime( MIMIC_CONVERSATION_DELAY + 1000 );
 		await waitFor( () => {
 			expect( screen.getByText( 'Initial message 1' ) ).toBeVisible();
 			expect( screen.getByText( 'Initial message 2' ) ).toBeVisible();
@@ -214,7 +213,6 @@ describe( 'ContentTabAssistant', () => {
 		act( () => {
 			fireEvent.change( textInput, { target: { value: 'New message' } } );
 			fireEvent.keyDown( textInput, { key: 'Enter', code: 'Enter' } );
-			jest.advanceTimersByTime( MIMIC_CONVERSATION_DELAY + 1000 );
 		} );
 		await waitFor( () => {
 			expect( screen.getByText( 'New message' ) ).toBeVisible();
@@ -325,6 +323,7 @@ describe( 'ContentTabAssistant', () => {
 	test( 'clears history via reminder when last message is two hours old', async () => {
 		const MOCKED_TIME = 1718882159928;
 		const TWO_HOURS_DIFF = 2 * 60 * 60 * 1000;
+		jest.useFakeTimers();
 		jest.setSystemTime( MOCKED_TIME );
 
 		const storageKey = 'ai_chat_messages';
@@ -369,6 +368,7 @@ describe( 'ContentTabAssistant', () => {
 			},
 			{ timeout: MIMIC_CONVERSATION_DELAY + 1000 }
 		);
+		jest.useRealTimers();
 	} );
 
 	test( 'renders notices by importance', async () => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

- Follow-up of https://github.com/Automattic/studio/pull/308

## Proposed Changes

- This PR fixes some timers running detected by running `npm run test -- --detectOpenHandles`. Do not fixes all the cases though.

I've observed that running `npm run test` throws this warning:

> A worker process has failed to exit gracefully and has been force exited. This is likely caused by tests leaking due to improper teardown. Try running with --detectOpenHandles to find leaks. Active timers can also cause this, ensure that .unref() was called on them.

This warning already existed in a704e04702e646a6f1b8012a92f4e49c5a670e9c before merging  https://github.com/Automattic/studio/pull/308

After debugging with `npm run test -- --detectOpenHandles`, I got some warning that I've addressed in this PR.

<img width="1838" alt="Screenshot 2024-07-23 at 17 35 53" src="https://github.com/user-attachments/assets/7e7c2295-d75b-400b-b72a-20b9e901e143">

<img width="1834" alt="Screenshot 2024-07-23 at 17 35 46" src="https://github.com/user-attachments/assets/1caf0a7a-a854-4ac8-9bf9-751359e1e455">

<img width="1829" alt="Screenshot 2024-07-23 at 17 35 15" src="https://github.com/user-attachments/assets/f1afef74-7e24-4791-99c9-8cdf320954b0">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run `npm run test -- --detectOpenHandles`
- Observe the tests pass
- Observe there is are no warnings pointing to specific files.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
