### PR TITLE
Rename backup handler events

### DIFF
--- a/src/lib/import-export/import/events.ts
+++ b/src/lib/import-export/import/events.ts
@@ -1,8 +1,8 @@
-export const HandlerEvents = {
-	BACKUP_HANDLER_START: 'handler_start',
-	BACKUP_HANDLER_PROGRESS: 'handler_progress',
-	BACKUP_HANDLER_COMPLETE: 'handler_complete',
-	BACKUP_HANDLER_ERROR: 'handler_error',
+export const BackupExtractEvents = {
+	BACKUP_EXTRACT_START: 'backup_extract_start',
+	BACKUP_EXTRACT_PROGRESS: 'backup_extract_progress',
+	BACKUP_EXTRACT_COMPLETE: 'backup_extract_complete',
+	BACKUP_EXTRACT_ERROR: 'backup_extract_error',
 } as const;
 
 export const ValidatorEvents = {
@@ -24,7 +24,7 @@ export const ImporterEvents = {
 } as const;
 
 export const ImportEvents = {
-	...HandlerEvents,
+	...BackupExtractEvents,
 	...ValidatorEvents,
 	...ImporterEvents,
 } as const;

--- a/src/lib/import-export/import/handlers/backup-handler-sql.ts
+++ b/src/lib/import-export/import/handlers/backup-handler-sql.ts
@@ -14,10 +14,10 @@ export class BackupHandlerSql extends EventEmitter implements BackupHandler {
 	}
 
 	async extractFiles( file: BackupArchiveInfo, extractionDirectory: string ): Promise< void > {
-		this.emit( ImportEvents.BACKUP_HANDLER_START );
+		this.emit( ImportEvents.BACKUP_EXTRACT_START );
 		const destPath = path.join( extractionDirectory, path.basename( file.path ) );
-		this.emit( ImportEvents.BACKUP_HANDLER_PROGRESS );
+		this.emit( ImportEvents.BACKUP_EXTRACT_PROGRESS );
 		await fs.promises.copyFile( file.path, destPath );
-		this.emit( ImportEvents.BACKUP_HANDLER_COMPLETE );
+		this.emit( ImportEvents.BACKUP_EXTRACT_COMPLETE );
 	}
 }

--- a/src/lib/import-export/import/handlers/backup-handler-tar-gz.ts
+++ b/src/lib/import-export/import/handlers/backup-handler-tar-gz.ts
@@ -18,19 +18,19 @@ export class BackupHandlerTarGz extends EventEmitter implements BackupHandler {
 
 	async extractFiles( file: BackupArchiveInfo, extractionDirectory: string ): Promise< void > {
 		return new Promise< void >( ( resolve, reject ) => {
-			this.emit( ImportEvents.BACKUP_HANDLER_START );
+			this.emit( ImportEvents.BACKUP_EXTRACT_START );
 			fs.createReadStream( file.path )
 				.pipe( zlib.createGunzip() )
 				.pipe( tar.extract( { cwd: extractionDirectory } ) )
 				.on( 'finish', () => {
-					this.emit( ImportEvents.BACKUP_HANDLER_COMPLETE );
+					this.emit( ImportEvents.BACKUP_EXTRACT_COMPLETE );
 					resolve();
 				} )
 				.on( 'data', () => {
-					this.emit( ImportEvents.BACKUP_HANDLER_PROGRESS );
+					this.emit( ImportEvents.BACKUP_EXTRACT_PROGRESS );
 				} )
 				.on( 'error', ( error ) => {
-					this.emit( ImportEvents.BACKUP_HANDLER_ERROR, { error } );
+					this.emit( ImportEvents.BACKUP_EXTRACT_ERROR, { error } );
 					reject( error );
 				} );
 		} );

--- a/src/lib/import-export/import/handlers/backup-handler-zip.ts
+++ b/src/lib/import-export/import/handlers/backup-handler-zip.ts
@@ -14,16 +14,16 @@ export class BackupHandlerZip extends EventEmitter implements BackupHandler {
 	}
 
 	async extractFiles( file: BackupArchiveInfo, extractionDirectory: string ): Promise< void > {
-		this.emit( ImportEvents.BACKUP_HANDLER_START );
+		this.emit( ImportEvents.BACKUP_EXTRACT_START );
 		return new Promise( ( resolve, reject ) => {
-			this.emit( ImportEvents.BACKUP_HANDLER_PROGRESS );
+			this.emit( ImportEvents.BACKUP_EXTRACT_PROGRESS );
 			const zip = new AdmZip( file.path );
 			zip.extractAllToAsync( extractionDirectory, true, undefined, ( error?: Error ) => {
 				if ( error ) {
-					this.emit( ImportEvents.BACKUP_HANDLER_ERROR, { error } );
+					this.emit( ImportEvents.BACKUP_EXTRACT_ERROR, { error } );
 					reject( error );
 				}
-				this.emit( ImportEvents.BACKUP_HANDLER_COMPLETE );
+				this.emit( ImportEvents.BACKUP_EXTRACT_COMPLETE );
 				resolve();
 			} );
 		} );

--- a/src/lib/import-export/import/import-manager.ts
+++ b/src/lib/import-export/import/import-manager.ts
@@ -2,7 +2,7 @@ import fsPromises from 'fs/promises';
 import os from 'os';
 import path from 'path';
 import { ImportExportEventData, handleEvents } from '../types';
-import { HandlerEvents, ImportEventType, ImporterEvents, ValidatorEvents } from './events';
+import { BackupExtractEvents, ImportEventType, ImporterEvents, ValidatorEvents } from './events';
 import { BackupHandlerFactory } from './handlers/backup-handler-factory';
 import { DefaultImporter, Importer, ImporterResult } from './importers/importer';
 import { BackupArchiveInfo, NewImporter } from './types';
@@ -47,10 +47,10 @@ export async function importBackup(
 		const importer = selectImporter( fileList, extractionDirectory, onEvent, options );
 
 		if ( importer ) {
-			handleEvents< typeof HandlerEvents, ImportEventType >(
+			handleEvents< typeof BackupExtractEvents, ImportEventType >(
 				backupHandler,
 				onEvent,
-				HandlerEvents
+				BackupExtractEvents
 			);
 			handleEvents< typeof ImporterEvents, ImportEventType >( importer, onEvent, ImporterEvents );
 			await backupHandler.extractFiles( backupFile, extractionDirectory );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to https://github.com/Automattic/studio/pull/370#discussion_r1689561950.

## Proposed Changes

- Rename backup handler events.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Follow instructions from https://github.com/Automattic/studio/pull/370.
- When importing a site, observe the following events are logged:
<img width="521" alt="Screenshot 2024-07-24 at 13 38 29" src="https://github.com/user-attachments/assets/6c091fa9-b555-492b-b419-55767b42d0e2">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
