### PR TITLE
Remove generic types from `handleEvents` function

### DIFF
--- a/src/lib/import-export/export/export-manager.ts
+++ b/src/lib/import-export/export/export-manager.ts
@@ -1,7 +1,7 @@
 import fsPromises from 'fs/promises';
 import path from 'node:path';
 import { ImportExportEventData, handleEvents } from '../types';
-import { ExportEventType, ExportValidatorEvents, ExporterEvents } from './events';
+import { ExportValidatorEvents, ExporterEvents } from './events';
 import { DefaultExporter, SqlExporter } from './exporters';
 import { ExportOptions, ExporterOption } from './types';
 import { WordPressExportValidator } from './validators/wordpress-validator';
@@ -24,19 +24,11 @@ export async function exportBackup(
 
 	for ( const { validator, exporter } of options ) {
 		if ( validator.canHandle( allFiles ) ) {
-			handleEvents< typeof ExportValidatorEvents, ExportEventType >(
-				validator,
-				onEvent,
-				ExportValidatorEvents
-			);
+			handleEvents( validator, onEvent, ExportValidatorEvents );
 			const backupContents = validator.filterFiles( allFiles, exportOptions );
 			const ExporterClass = exporter;
 			const exporterInstance = new ExporterClass( backupContents );
-			handleEvents< typeof ExporterEvents, ExportEventType >(
-				exporterInstance,
-				onEvent,
-				ExporterEvents
-			);
+			handleEvents( exporterInstance, onEvent, ExporterEvents );
 			await exporterInstance.export( exportOptions );
 			break;
 		}

--- a/src/lib/import-export/import/import-manager.ts
+++ b/src/lib/import-export/import/import-manager.ts
@@ -2,7 +2,7 @@ import fsPromises from 'fs/promises';
 import os from 'os';
 import path from 'path';
 import { ImportExportEventData, handleEvents } from '../types';
-import { HandlerEvents, ImportEventType, ImporterEvents, ValidatorEvents } from './events';
+import { HandlerEvents, ImporterEvents, ValidatorEvents } from './events';
 import { BackupHandlerFactory } from './handlers/backup-handler-factory';
 import { DefaultImporter, Importer, ImporterResult } from './importers/importer';
 import { BackupArchiveInfo, NewImporter } from './types';
@@ -22,11 +22,7 @@ export function selectImporter(
 ): Importer | null {
 	for ( const { validator, importer } of options ) {
 		if ( validator.canHandle( allFiles ) ) {
-			handleEvents< typeof ValidatorEvents, ImportEventType >(
-				validator,
-				onEvent,
-				ValidatorEvents
-			);
+			handleEvents( validator, onEvent, ValidatorEvents );
 			const files = validator.parseBackupContents( allFiles, extractionDirectory );
 			return new importer( files );
 		}
@@ -47,12 +43,8 @@ export async function importBackup(
 		const importer = selectImporter( fileList, extractionDirectory, onEvent, options );
 
 		if ( importer ) {
-			handleEvents< typeof HandlerEvents, ImportEventType >(
-				backupHandler,
-				onEvent,
-				HandlerEvents
-			);
-			handleEvents< typeof ImporterEvents, ImportEventType >( importer, onEvent, ImporterEvents );
+			handleEvents( backupHandler, onEvent, HandlerEvents );
+			handleEvents( importer, onEvent, ImporterEvents );
 			await backupHandler.extractFiles( backupFile, extractionDirectory );
 			return await importer.import( sitePath );
 		} else {

--- a/src/lib/import-export/types.ts
+++ b/src/lib/import-export/types.ts
@@ -2,18 +2,17 @@ import { EventEmitter } from 'events';
 import { ExportEventType } from './export/events';
 import { ImportEventType } from './import/events';
 
+export type ImportExportEventType = ImportEventType | ExportEventType;
+
 export interface ImportExportEventData {
-	event: ImportEventType | ExportEventType;
+	event: ImportExportEventType;
 	data: unknown;
 }
 
-export const handleEvents = <
-	T extends Record< string, string >,
-	K extends ImportEventType | ExportEventType,
->(
+export const handleEvents = (
 	emitter: Partial< EventEmitter >,
 	onEvent: ( data: ImportExportEventData ) => void,
-	events: T
+	events: Record< string, string >
 ) => {
 	Object.values( events ).forEach( ( eventName ) => {
 		if ( ! emitter.on ) {
@@ -21,7 +20,7 @@ export const handleEvents = <
 		}
 		emitter.on( eventName, ( data: unknown ) => {
 			onEvent( {
-				event: eventName as K,
+				event: eventName as ImportExportEventType,
 				data,
 			} );
 		} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to https://github.com/Automattic/studio/pull/370#discussion_r1689537803.

## Proposed Changes

- Remove unneeded generic types from the `handlerEvents` function related to import/export.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Follow instructions from https://github.com/Automattic/studio/pull/370 to check that events are emitted.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
