### PR TITLE
Use Tooltip props object for disabled update button

### DIFF
--- a/src/components/content-tab-snapshots.tsx
+++ b/src/components/content-tab-snapshots.tsx
@@ -21,7 +21,7 @@ import { CopyTextButton } from './copy-text-button';
 import offlineIcon from './offline-icon';
 import ProgressBar from './progress-bar';
 import { ScreenshotDemoSite } from './screenshot-demo-site';
-import Tooltip from './tooltip';
+import Tooltip, { TooltipProps } from './tooltip';
 
 interface ContentTabSnapshotsProps {
 	selectedSite: SiteDetails;
@@ -164,6 +164,18 @@ function SnapshotRow( {
 			</div>
 		);
 	}
+
+	let tooltipContent: Partial< TooltipProps & { text?: string } > = {};
+	if ( isOffline ) {
+		tooltipContent = {
+			icon: offlineIcon,
+			text: updateDemoSiteOfflineMessage,
+		};
+	} else if ( snapshotCreationBlocked ) {
+		tooltipContent = { text: blockedUserMessage };
+	}
+	const isUpdateDisabled = isOffline || snapshotCreationBlocked;
+
 	return (
 		<div className="self-stretch flex-col px-4 py-3">
 			<div className="flex gap-2 items-center">
@@ -192,23 +204,13 @@ function SnapshotRow( {
 					</div>
 				) : (
 					<>
-						<Tooltip
-							disabled={ ! ( isOffline || snapshotCreationBlocked ) }
-							{ ...( isOffline && { icon: offlineIcon } ) }
-							text={ isOffline ? updateDemoSiteOfflineMessage : blockedUserMessage }
-						>
+						<Tooltip disabled={ ! isUpdateDisabled } { ...tooltipContent }>
 							<Button
-								aria-description={
-									snapshotCreationBlocked
-										? blockedUserMessage
-										: isOffline
-										? updateDemoSiteOfflineMessage
-										: ''
-								}
-								aria-disabled={ isOffline || snapshotCreationBlocked }
+								aria-description={ tooltipContent?.text || '' }
+								aria-disabled={ isUpdateDisabled }
 								variant="primary"
 								onClick={ () => {
-									if ( isOffline || snapshotCreationBlocked ) {
+									if ( isUpdateDisabled ) {
 										return;
 									}
 									handleUpdateDemoSite();

--- a/src/components/tooltip.tsx
+++ b/src/components/tooltip.tsx
@@ -1,7 +1,7 @@
 import { Icon, Popover } from '@wordpress/components';
 import { PropsWithChildren, useState } from 'react';
 
-interface TooltipProps
+export interface TooltipProps
 	extends Pick< React.ComponentProps< typeof Popover >, 'placement' | 'className' > {
 	icon?: JSX.Element;
 	text?: string | JSX.Element;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

- Related to https://github.com/Automattic/studio/pull/354

## Proposed Changes

- Simplify logic on update check
- It also solves a weird edge case where we displayed a wrong message after enabling the network

See the screencast:

https://github.com/user-attachments/assets/37d43d74-6d26-4026-8991-fe49e8226c9b



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- See https://github.com/Automattic/studio/pull/354

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?