### PR TITLE
Studio: add some animation when the Advanced Settings are opened

### DIFF
--- a/src/components/site-form.tsx
+++ b/src/components/site-form.tsx
@@ -294,26 +294,29 @@ export const SiteForm = ( {
 									</div>
 									<div
 										className={ cx(
-											'transition-all duration-500 ease-in-out overflow-hidden',
+											'transition-height duration-500 ease-in-out overflow-hidden',
 											isAdvancedSettingsVisible
 												? 'max-h-96 opacity-100 mb-6'
 												: 'max-h-0 opacity-0 mb-0'
 										) }
 									>
-										{ isAdvancedSettingsVisible && (
-											<label className="flex flex-col gap-1.5 leading-4 p-2">
-												<span onClick={ onSelectPath } className="font-semibold">
-													{ __( 'Local path' ) }
-												</span>
-												<FormPathInputComponent
-													isDisabled={ isPathInputDisabled }
-													doesPathContainWordPress={ doesPathContainWordPress }
-													error={ error }
-													value={ sitePath }
-													onClick={ onSelectPath }
-												/>
-											</label>
-										) }
+										<label
+											className={ cx(
+												'flex flex-col gap-1.5 leading-4 p-2',
+												! isAdvancedSettingsVisible && 'hidden'
+											) }
+										>
+											<span onClick={ onSelectPath } className="font-semibold">
+												{ __( 'Local path' ) }
+											</span>
+											<FormPathInputComponent
+												isDisabled={ isPathInputDisabled }
+												doesPathContainWordPress={ doesPathContainWordPress }
+												error={ error }
+												value={ sitePath }
+												onClick={ onSelectPath }
+											/>
+										</label>
 									</div>
 								</>
 							) }

--- a/src/components/site-form.tsx
+++ b/src/components/site-form.tsx
@@ -241,8 +241,8 @@ export const SiteForm = ( {
 	if ( importExportEnabled ) {
 		return (
 			<form className={ className } onSubmit={ onSubmit }>
-				<div className="flex flex-col gap-6">
-					<label className="flex flex-col gap-1.5 leading-4">
+				<div className="flex flex-col">
+					<label className="flex flex-col gap-1.5 leading-4 mb-6">
 						<span className="font-semibold">{ __( 'Site name' ) }</span>
 						<TextControlComponent
 							onChange={ setSiteName }
@@ -251,7 +251,7 @@ export const SiteForm = ( {
 					</label>
 					{ setFileForImport && (
 						<>
-							<div className="flex flex-col gap-1.5 leading-4">
+							<div className="flex flex-col gap-1.5 leading-4 mb-6">
 								<label className="font-semibold">
 									{ __( 'Import a backup' ) }
 									<span className="font-normal">{ __( ' (optional)' ) }</span>
@@ -281,7 +281,7 @@ export const SiteForm = ( {
 							</div>
 							{ onSelectPath && (
 								<>
-									<div className="flex flex-row">
+									<div className="flex flex-row items-center mb-0">
 										<Button className="pl-0" onClick={ handleAdvancedSettingsClick }>
 											<Icon
 												size={ 24 }
@@ -292,20 +292,29 @@ export const SiteForm = ( {
 											</div>
 										</Button>
 									</div>
-									{ isAdvancedSettingsVisible && (
-										<label className="flex flex-col gap-1.5 leading-4">
-											<span onClick={ onSelectPath } className="font-semibold">
-												{ __( 'Local path' ) }
-											</span>
-											<FormPathInputComponent
-												isDisabled={ isPathInputDisabled }
-												doesPathContainWordPress={ doesPathContainWordPress }
-												error={ error }
-												value={ sitePath }
-												onClick={ onSelectPath }
-											/>
-										</label>
-									) }
+									<div
+										className={ cx(
+											'transition-all duration-500 ease-in-out overflow-hidden',
+											isAdvancedSettingsVisible
+												? 'max-h-96 opacity-100 mb-6'
+												: 'max-h-0 opacity-0 mb-0'
+										) }
+									>
+										{ isAdvancedSettingsVisible && (
+											<label className="flex flex-col gap-1.5 leading-4 p-2">
+												<span onClick={ onSelectPath } className="font-semibold">
+													{ __( 'Local path' ) }
+												</span>
+												<FormPathInputComponent
+													isDisabled={ isPathInputDisabled }
+													doesPathContainWordPress={ doesPathContainWordPress }
+													error={ error }
+													value={ sitePath }
+													onClick={ onSelectPath }
+												/>
+											</label>
+										) }
+									</div>
 								</>
 							) }
 						</>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/8468

## Proposed Changes

This PR adds some animation to the site form for add site so that the opening of the advanced settings looks more smooth.

## Testing Instructions

* Pull the changes from this branch
* Start the app with `STUDIO_IMPORT_EXPORT=true npm start`
* Click on the `Add site` in the sidebar
* Observe the modal appear
* Click on `Advanced settings`
* Observe that they open smoothly

**Notes**:

* We could make it faster or slower; this speed felt okay for me but the opinions might vary

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
