### PR TITLE
Clear import state after creating a new site from a backup

### DIFF
--- a/src/hooks/use-add-site.ts
+++ b/src/hooks/use-add-site.ts
@@ -6,7 +6,7 @@ import { useSiteDetails } from './use-site-details';
 
 export function useAddSite() {
 	const { __ } = useI18n();
-	const { createSite, data: sites, loadingSites, importFile } = useSiteDetails();
+	const { createSite, data: sites, loadingSites, importFile, updateSite } = useSiteDetails();
 	const [ error, setError ] = useState( '' );
 	const [ siteName, setSiteName ] = useState< string | null >( null );
 	const [ sitePath, setSitePath ] = useState( '' );
@@ -56,11 +56,12 @@ export function useAddSite() {
 			const newSite = await createSite( path, siteName ?? '', !! fileForImport );
 			if ( newSite && fileForImport ) {
 				await importFile( fileForImport, newSite );
+				updateSite( { ...newSite, importState: undefined } );
 			}
 		} catch ( e ) {
 			Sentry.captureException( e );
 		}
-	}, [ createSite, fileForImport, importFile, proposedSitePath, siteName, sitePath ] );
+	}, [ createSite, fileForImport, importFile, proposedSitePath, siteName, sitePath, updateSite ] );
 
 	const handleSiteNameChange = useCallback(
 		async ( name: string ) => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

- Closes https://github.com/Automattic/dotcom-forge/issues/8469

## Proposed Changes

- Clear the import state after creating a new site from an import file

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Start Studio `STUDIO_IMPORT_EXPORT=true npm start`
- In the onboarding, when you don't have any site, import a site
- When the overview appears, click on import/export tab
- Observe the state is the regular state instead of the "imported" state
- Repeat the steps by initiating the Add site form


https://github.com/user-attachments/assets/29855e32-e32b-445f-b892-0f5b0b76f743



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?