### PR TITLE
Add an ellipsis to the site form import file text input

### DIFF
--- a/src/components/site-form.tsx
+++ b/src/components/site-form.tsx
@@ -122,7 +122,7 @@ function FormImportComponent( {
 	error,
 	placeholder,
 }: FormImportComponentProps ) {
-	const fileName = value?.name || '';
+	const fileName = value ? value.name : '';
 
 	const inputFileRef = useRef< HTMLInputElement >( null );
 

--- a/src/components/site-form.tsx
+++ b/src/components/site-form.tsx
@@ -152,7 +152,7 @@ function FormImportComponent( {
 					className={ cx(
 						'flex items-center flex-grow rounded-sm border border-[#949494] focus:border-a8c-blueberry focus:shadow-[0_0_0_0.5px_black] focus:shadow-a8c-blueberry outline-none transition-shadow transition-linear duration-100 [&_.local-path-icon]:focus:border-l-a8c-blueberry [&:disabled]:cursor-not-allowed',
 						error ? 'border-red-500 [&_.local-path-icon]:border-l-red-500' : '',
-						fileName ? 'border-r-0 rounded-r-none' : ''
+						fileName ? 'border-r-0 rounded-r-none focus:border' : ''
 					) }
 					onClick={ () => inputFileRef.current?.click() }
 				>

--- a/src/components/site-form.tsx
+++ b/src/components/site-form.tsx
@@ -122,7 +122,7 @@ function FormImportComponent( {
 	error,
 	placeholder,
 }: FormImportComponentProps ) {
-	const fileName = value ? value.name : '';
+	const fileName = value?.name || '';
 
 	const inputFileRef = useRef< HTMLInputElement >( null );
 
@@ -160,7 +160,7 @@ function FormImportComponent( {
 						aria-hidden="true"
 						disabled={ true }
 						placeholder={ placeholder }
-						className="flex-grow [&_.components-text-control\_\_input]:bg-transparent [&_.components-text-control\_\_input]:border-none [&_input]:pointer-events-none [&_.components-text-control\_\_input]:text-sm w-full"
+						className="flex-grow [&_.components-text-control\_\_input]:bg-transparent [&_.components-text-control\_\_input]:border-none [&_input]:pointer-events-none [&_.components-text-control\_\_input]:text-sm w-full [&_.components-text-control\_\_input]:truncate"
 						value={ fileName }
 						// eslint-disable-next-line @typescript-eslint/no-empty-function
 						onChange={ () => {} }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

- Closes https://github.com/Automattic/dotcom-forge/issues/8490

## Proposed Changes

- Add an ellipsis to the site form import file text input when the file name is too long

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Start the site using `STUDIO_IMPORT_EXPORT=true npm start`
- In the onboarding, when you don't have any site, select a file with a long name to import
- Observe the name is displayed with ellipsis at the end
- Repeat by clicking on "Add site" button to open the form
- Observe the name is displayed with ellipsis at the end
- Repeat steps with a shorter name and observe the full file name is visualized


<img width="1012" alt="import-ellipsis" src="https://github.com/user-attachments/assets/6b33aa7d-7b71-40e2-8f8a-a39c27381a72">


https://github.com/user-attachments/assets/9c3a10e5-3e32-43ec-bdef-1343d3a48584



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?