### PR TITLE
Studio: Improve the loading progress bar on Windows

### DIFF
--- a/src/components/site-loading-indicator.tsx
+++ b/src/components/site-loading-indicator.tsx
@@ -7,7 +7,7 @@ export function SiteLoadingIndicator( { selectedSiteName }: { selectedSiteName?:
 	const { __ } = useI18n();
 
 	const { progress, setProgress } = useProgressTimer( {
-		initialProgress: 20,
+		initialProgress: 10,
 		interval: 1500,
 		maxValue: 95,
 	} );
@@ -20,7 +20,7 @@ export function SiteLoadingIndicator( { selectedSiteName }: { selectedSiteName?:
 			} );
 		};
 
-		setProgress( 50 );
+		setProgress( 20 );
 		const interval = setInterval( updateProgress, 1000 );
 
 		return () => clearInterval( interval );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Closes: https://github.com/Automattic/dotcom-forge/issues/8340

## Proposed Changes

This PR improves the loading of the progress bar on Windows by setting a starting point earlier. 

## Testing Instructions

* This change would need to be tested on Windows
* Pull the changes from this branch
* Start the app with `STUDIO_IMPORT_EXPORT=true npm start`
* Click on `Add site` in the left sidebar
* Observe the loading progress starting earlier

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
