### PR TITLE
Run wp db export command when exporting site database

### DIFF
--- a/src/components/tests/content-tab-import-export.test.tsx
+++ b/src/components/tests/content-tab-import-export.test.tsx
@@ -97,6 +97,11 @@ describe( 'ContentTabImportExport Import', () => {
 } );
 
 describe( 'ContentTabImportExport Export', () => {
+	beforeEach( () => {
+		// Reset all mocks before each test
+		jest.clearAllMocks();
+	} );
+
 	test( 'should export full site', async () => {
 		render( <ContentTabImportExport selectedSite={ selectedSite } /> );
 

--- a/src/hooks/tests/use-import-export.tsx
+++ b/src/hooks/tests/use-import-export.tsx
@@ -43,9 +43,7 @@ describe( 'useImportExport hook', () => {
 		expect( result.current.exportState ).toEqual( {} );
 		expect( getIpcApi().exportSite ).toHaveBeenCalledWith(
 			{
-				site: {
-					...selectedSite,
-				},
+				site: selectedSite,
 				backupFile: '/path/to/exported-site.tar.gz',
 				includes: { database: true, uploads: true, plugins: true, themes: true },
 			},
@@ -70,9 +68,7 @@ describe( 'useImportExport hook', () => {
 		expect( result.current.exportState ).toEqual( {} );
 		expect( getIpcApi().exportSite ).toHaveBeenCalledWith(
 			{
-				site: {
-					...selectedSite,
-				},
+				site: selectedSite,
 				backupFile: '/path/to/exported-site.tar.gz',
 				includes: { database: true, uploads: true, plugins: true, themes: true },
 			},

--- a/src/hooks/tests/use-import-export.tsx
+++ b/src/hooks/tests/use-import-export.tsx
@@ -89,9 +89,7 @@ describe( 'useImportExport hook', () => {
 		expect( result.current.exportState ).toEqual( {} );
 		expect( getIpcApi().exportSite ).toHaveBeenCalledWith(
 			{
-				site: {
-					...selectedSite,
-				},
+				site: selectedSite,
 				backupFile: '/path/to/exported-database.sql',
 				includes: { database: true, uploads: false, plugins: false, themes: false },
 			},

--- a/src/hooks/tests/use-import-export.tsx
+++ b/src/hooks/tests/use-import-export.tsx
@@ -43,7 +43,9 @@ describe( 'useImportExport hook', () => {
 		expect( result.current.exportState ).toEqual( {} );
 		expect( getIpcApi().exportSite ).toHaveBeenCalledWith(
 			{
-				sitePath: '/test-site',
+				site: {
+					...selectedSite,
+				},
 				backupFile: '/path/to/exported-site.tar.gz',
 				includes: { database: true, uploads: true, plugins: true, themes: true },
 			},
@@ -68,7 +70,9 @@ describe( 'useImportExport hook', () => {
 		expect( result.current.exportState ).toEqual( {} );
 		expect( getIpcApi().exportSite ).toHaveBeenCalledWith(
 			{
-				sitePath: '/test-site',
+				site: {
+					...selectedSite,
+				},
 				backupFile: '/path/to/exported-site.tar.gz',
 				includes: { database: true, uploads: true, plugins: true, themes: true },
 			},
@@ -89,7 +93,9 @@ describe( 'useImportExport hook', () => {
 		expect( result.current.exportState ).toEqual( {} );
 		expect( getIpcApi().exportSite ).toHaveBeenCalledWith(
 			{
-				sitePath: '/test-site',
+				site: {
+					...selectedSite,
+				},
 				backupFile: '/path/to/exported-database.sql',
 				includes: { database: true, uploads: false, plugins: false, themes: false },
 			},

--- a/src/hooks/use-import-export.tsx
+++ b/src/hooks/use-import-export.tsx
@@ -93,7 +93,7 @@ export const ImportExportProvider = ( { children }: { children: React.ReactNode 
 				return;
 			}
 			const options: ExportOptions = {
-				sitePath: selectedSite.path,
+				site: selectedSite,
 				backupFile: path,
 				includes: {
 					database: true,
@@ -124,7 +124,7 @@ export const ImportExportProvider = ( { children }: { children: React.ReactNode 
 				return;
 			}
 			const options: ExportOptions = {
-				sitePath: selectedSite.path,
+				site: selectedSite,
 				backupFile: path,
 				includes: {
 					database: true,

--- a/src/lib/import-export/export/export-database.ts
+++ b/src/lib/import-export/export/export-database.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 import { rename } from 'fs-extra';
 import { SiteServer } from '../../../site-server';
+import { generateBackupFilename } from './generate-backup-filename';
 
 export async function exportDatabaseToFile(
 	site: SiteDetails,
@@ -13,7 +14,7 @@ export async function exportDatabaseToFile(
 	}
 
 	// Generate a temporary file name in the project directory
-	const tempFileName = `temp_export_${ Date.now() }.sql`;
+	const tempFileName = `${ generateBackupFilename( 'db-export' ) }.sql`;
 	const tempFilePath = path.join( site.path, tempFileName );
 
 	// Execute the command to export directly to the temp file
@@ -21,7 +22,7 @@ export async function exportDatabaseToFile(
 
 	if ( stderr ) {
 		console.error( 'Error during export:', stderr );
-		throw new Error( 'Database export failed' );
+		throw new Error( `Database export failed: ${ stderr }` );
 	}
 
 	// Move the file to its final destination

--- a/src/lib/import-export/export/export-database.ts
+++ b/src/lib/import-export/export/export-database.ts
@@ -1,0 +1,31 @@
+import path from 'path';
+import { rename } from 'fs-extra';
+import { SiteServer } from '../../../site-server';
+
+export async function exportDatabaseToFile(
+	site: SiteDetails,
+	finalDestination: string
+): Promise< void > {
+	const server = SiteServer.get( site.id );
+
+	if ( ! server ) {
+		throw new Error( 'Site not found.' );
+	}
+
+	// Generate a temporary file name in the project directory
+	const tempFileName = `temp_export_${ Date.now() }.sql`;
+	const tempFilePath = path.join( site.path, tempFileName );
+
+	// Execute the command to export directly to the temp file
+	const { stderr } = await server.executeWpCliCommand( `db export ${ tempFileName }` );
+
+	if ( stderr ) {
+		console.error( 'Error during export:', stderr );
+		throw new Error( 'Database export failed' );
+	}
+
+	// Move the file to its final destination
+	await rename( tempFilePath, finalDestination );
+
+	console.log( `Database export saved to ${ finalDestination }` );
+}

--- a/src/lib/import-export/export/exporters/default-exporter.ts
+++ b/src/lib/import-export/export/exporters/default-exporter.ts
@@ -150,12 +150,7 @@ export class DefaultExporter extends EventEmitter implements Exporter {
 			const fileName = `db-export-${ timestamp }.sql`;
 			const sqlDumpPath = path.join( tmpFolder, fileName );
 
-			try {
-				await exportDatabaseToFile( this.options.site, sqlDumpPath );
-			} catch ( error ) {
-				console.error( 'ERROR db export', error );
-				this.emit( ExportEvents.EXPORT_ERROR, error );
-			}
+			await exportDatabaseToFile( this.options.site, sqlDumpPath );
 
 			this.archive.file( sqlDumpPath, { name: `sql/${ fileName }` } );
 			this.backup.sqlFiles.push( sqlDumpPath );

--- a/src/lib/import-export/export/exporters/default-exporter.ts
+++ b/src/lib/import-export/export/exporters/default-exporter.ts
@@ -4,9 +4,9 @@ import fsPromises from 'fs/promises';
 import os from 'os';
 import path from 'path';
 import archiver from 'archiver';
-import { format } from 'date-fns';
 import { ExportEvents } from '../events';
 import { exportDatabaseToFile } from '../export-database';
+import { generateBackupFilename } from '../generate-backup-filename';
 import {
 	ExportOptions,
 	BackupContents,
@@ -14,7 +14,6 @@ import {
 	BackupCreateProgressEventData,
 	BackupContentsCategory,
 } from '../types';
-import { generateBackupFilename } from '../generate-backup-filename';
 
 export class DefaultExporter extends EventEmitter implements Exporter {
 	private archive!: archiver.Archiver;

--- a/src/lib/import-export/export/exporters/default-exporter.ts
+++ b/src/lib/import-export/export/exporters/default-exporter.ts
@@ -145,7 +145,7 @@ export class DefaultExporter extends EventEmitter implements Exporter {
 		if ( this.options.includes.database ) {
 			this.emit( ExportEvents.DATABASE_EXPORT_START );
 			const tmpFolder = await fsPromises.mkdtemp( path.join( os.tmpdir(), 'studio_export' ) );
-			const fileName = generateBackupFilename( 'db-export' );
+			const fileName = `${ generateBackupFilename( 'db-export' ) }.sql`;
 			const sqlDumpPath = path.join( tmpFolder, fileName );
 			await exportDatabaseToFile( this.options.site, sqlDumpPath );
 			this.archive.file( sqlDumpPath, { name: `sql/${ fileName }` } );

--- a/src/lib/import-export/export/exporters/default-exporter.ts
+++ b/src/lib/import-export/export/exporters/default-exporter.ts
@@ -14,6 +14,7 @@ import {
 	BackupCreateProgressEventData,
 	BackupContentsCategory,
 } from '../types';
+import { generateBackupFilename } from '../generate-backup-filename';
 
 export class DefaultExporter extends EventEmitter implements Exporter {
 	private archive!: archiver.Archiver;
@@ -144,14 +145,10 @@ export class DefaultExporter extends EventEmitter implements Exporter {
 	private async addDatabase(): Promise< void > {
 		if ( this.options.includes.database ) {
 			this.emit( ExportEvents.DATABASE_EXPORT_START );
-
 			const tmpFolder = await fsPromises.mkdtemp( path.join( os.tmpdir(), 'studio_export' ) );
-			const timestamp = format( new Date(), 'yyyy-MM-dd-HH-mm-ss' );
-			const fileName = `db-export-${ timestamp }.sql`;
+			const fileName = generateBackupFilename( 'db-export' );
 			const sqlDumpPath = path.join( tmpFolder, fileName );
-
 			await exportDatabaseToFile( this.options.site, sqlDumpPath );
-
 			this.archive.file( sqlDumpPath, { name: `sql/${ fileName }` } );
 			this.backup.sqlFiles.push( sqlDumpPath );
 			this.emit( ExportEvents.DATABASE_EXPORT_COMPLETE );

--- a/src/lib/import-export/export/exporters/default-exporter.ts
+++ b/src/lib/import-export/export/exporters/default-exporter.ts
@@ -127,7 +127,7 @@ export class DefaultExporter extends EventEmitter implements Exporter {
 		this.emit( ExportEvents.WP_CONTENT_EXPORT_START );
 		for ( const category of categories ) {
 			for ( const file of this.backup.wpContent[ category ] ) {
-				const relativePath = path.relative( this.options.sitePath, file );
+				const relativePath = path.relative( this.options.site.path, file );
 				this.archive.file( file, { name: relativePath } );
 				this.emit( ExportEvents.WP_CONTENT_EXPORT_PROGRESS, { file: relativePath } );
 			}
@@ -167,7 +167,7 @@ export class DefaultExporter extends EventEmitter implements Exporter {
 			return this.siteFiles;
 		}
 
-		const directoryContents = await fsPromises.readdir( this.options.sitePath, {
+		const directoryContents = await fsPromises.readdir( this.options.site.path, {
 			recursive: true,
 			withFileTypes: true,
 		} );
@@ -194,7 +194,7 @@ export class DefaultExporter extends EventEmitter implements Exporter {
 
 		const siteFiles = await this.getSiteFiles();
 		siteFiles.forEach( ( file ) => {
-			const relativePath = path.relative( options.sitePath, file );
+			const relativePath = path.relative( options.site.path, file );
 			if ( path.basename( file ) === 'wp-config.php' ) {
 				backupContents.wpConfigFile = file;
 			} else if ( relativePath.startsWith( 'wp-content/uploads/' ) && options.includes.uploads ) {

--- a/src/lib/import-export/export/exporters/sql-exporter.ts
+++ b/src/lib/import-export/export/exporters/sql-exporter.ts
@@ -1,4 +1,3 @@
-import * as console from 'console';
 import { EventEmitter } from 'events';
 import { ExportEvents } from '../events';
 import { exportDatabaseToFile } from '../export-database';
@@ -14,7 +13,6 @@ export class SqlExporter extends EventEmitter implements Exporter {
 			await exportDatabaseToFile( this.options.site, this.options.backupFile );
 			this.emit( ExportEvents.EXPORT_COMPLETE );
 		} catch ( error ) {
-			console.error( 'ERROR db export', error );
 			this.emit( ExportEvents.EXPORT_ERROR );
 			throw error;
 		}

--- a/src/lib/import-export/export/exporters/sql-exporter.ts
+++ b/src/lib/import-export/export/exporters/sql-exporter.ts
@@ -2,6 +2,7 @@ import * as console from 'console';
 import { EventEmitter } from 'events';
 import { ExportEvents } from '../events';
 import { ExportOptions, Exporter } from '../types';
+import { getIpcApi } from '../../../get-ipc-api';
 
 export class SqlExporter extends EventEmitter implements Exporter {
 	constructor( private options: ExportOptions ) {
@@ -11,6 +12,18 @@ export class SqlExporter extends EventEmitter implements Exporter {
 		this.emit( ExportEvents.EXPORT_START );
 		console.log( `Database backup created at: ${ this.options.backupFile }` );
 		console.log( 'Database backup options:', this.options );
+
+		const { stdout, stderr } = await getIpcApi().executeWPCLiInline( {
+			siteId: this.options.site.id,
+			args: 'db export',
+		} );
+		if ( stderr ) {
+			console.log( "ERROR", stderr );
+		}
+
+		console.log( stdout );
+
+
 		this.emit( ExportEvents.EXPORT_COMPLETE );
 	}
 

--- a/src/lib/import-export/export/exporters/sql-exporter.ts
+++ b/src/lib/import-export/export/exporters/sql-exporter.ts
@@ -15,7 +15,8 @@ export class SqlExporter extends EventEmitter implements Exporter {
 			this.emit( ExportEvents.EXPORT_COMPLETE );
 		} catch ( error ) {
 			console.error( 'ERROR db export', error );
-			this.emit( ExportEvents.EXPORT_ERROR, error );
+			this.emit( ExportEvents.EXPORT_ERROR );
+			throw error;
 		}
 	}
 

--- a/src/lib/import-export/export/types.ts
+++ b/src/lib/import-export/export/types.ts
@@ -2,7 +2,7 @@ import type { ProgressData } from 'archiver';
 import type { EventEmitter } from 'events';
 
 export interface ExportOptions {
-	sitePath: string;
+	site: SiteDetails;
 	backupFile: string;
 	includes: { [ index in ExportOptionsIncludes ]: boolean };
 }

--- a/src/lib/import-export/tests/export/exporters/default-exporter.test.ts
+++ b/src/lib/import-export/tests/export/exporters/default-exporter.test.ts
@@ -2,7 +2,8 @@ import fs from 'fs';
 import fsPromises from 'fs/promises';
 import os from 'os';
 import archiver from 'archiver';
-import { DefaultExporter } from '../../../export/exporters/default-exporter';
+import { SiteServer } from '../../../../../site-server';
+import { DefaultExporter } from '../../../export/exporters';
 import { ExportOptions, BackupContents } from '../../../export/types';
 
 jest.mock( 'fs' );
@@ -29,6 +30,13 @@ const createMockArchiver = (): jest.Mocked< PartialArchiver > => {
 // Mock archiver module
 jest.mock( 'archiver', () => {
 	return jest.fn( () => createMockArchiver() );
+} );
+
+// Mock SiteServer
+jest.mock( '../../../../../site-server' );
+( SiteServer.get as jest.Mock ).mockReturnValue( {
+	details: { path: '/path/to/site' },
+	executeWpCliCommand: jest.fn().mockReturnValue( { stderr: null } ),
 } );
 
 describe( 'DefaultExporter', () => {
@@ -64,8 +72,8 @@ describe( 'DefaultExporter', () => {
 		mockOptions = {
 			site: {
 				running: false,
-				id: 'site-id',
-				name: 'site-name',
+				id: '123',
+				name: '123',
 				path: '/path/to/site',
 				phpVersion: '7.4',
 			},

--- a/src/lib/import-export/tests/export/exporters/default-exporter.test.ts
+++ b/src/lib/import-export/tests/export/exporters/default-exporter.test.ts
@@ -62,7 +62,13 @@ describe( 'DefaultExporter', () => {
 		};
 
 		mockOptions = {
-			sitePath: '/path/to/site',
+			site: {
+				running: false,
+				id: 'site-id',
+				name: 'site-name',
+				path: '/path/to/site',
+				phpVersion: '7.4',
+			},
 			backupFile: '/path/to/backup.tar.gz',
 			includes: {
 				uploads: true,

--- a/src/lib/import-export/tests/export/exporters/default-exporter.test.ts
+++ b/src/lib/import-export/tests/export/exporters/default-exporter.test.ts
@@ -2,10 +2,10 @@ import fs from 'fs';
 import fsPromises from 'fs/promises';
 import os from 'os';
 import archiver from 'archiver';
+import { format } from 'date-fns';
 import { SiteServer } from '../../../../../site-server';
 import { DefaultExporter } from '../../../export/exporters';
 import { ExportOptions, BackupContents } from '../../../export/types';
-import { format } from 'date-fns';
 
 jest.mock( 'fs' );
 jest.mock( 'fs/promises' );

--- a/src/lib/import-export/tests/export/exporters/default-exporter.test.ts
+++ b/src/lib/import-export/tests/export/exporters/default-exporter.test.ts
@@ -207,9 +207,9 @@ describe( 'DefaultExporter', () => {
 		} );
 		expect( mockArchiver.file ).toHaveBeenNthCalledWith(
 			2,
-			'/tmp/studio_export_123/studio-backup-db-export-2023-07-31-12-00-00',
+			'/tmp/studio_export_123/studio-backup-db-export-2023-07-31-12-00-00.sql',
 			{
-				name: 'sql/studio-backup-db-export-2023-07-31-12-00-00',
+				name: 'sql/studio-backup-db-export-2023-07-31-12-00-00.sql',
 			}
 		);
 	} );
@@ -226,7 +226,7 @@ describe( 'DefaultExporter', () => {
 		await exporter.export();
 
 		expect( fsPromises.unlink ).toHaveBeenCalledWith(
-			'/tmp/studio_export_123/studio-backup-db-export-2023-07-31-12-00-00'
+			'/tmp/studio_export_123/studio-backup-db-export-2023-07-31-12-00-00.sql'
 		);
 	} );
 

--- a/src/lib/import-export/tests/export/exporters/default-exporter.test.ts
+++ b/src/lib/import-export/tests/export/exporters/default-exporter.test.ts
@@ -91,7 +91,7 @@ describe( 'DefaultExporter', () => {
 		jest.clearAllMocks();
 		( SiteServer.get as jest.Mock ).mockReturnValue( {
 			details: { path: '/path/to/site' },
-			executeWpCliCommand: jest.fn().mockReturnValue( { stderr: null } ),
+			executeWpCliCommand: jest.fn().mockResolvedValue( { stderr: null } ),
 		} );
 
 		mockArchiver = createMockArchiver();

--- a/src/lib/import-export/tests/export/exporters/sql-exporter.test.ts
+++ b/src/lib/import-export/tests/export/exporters/sql-exporter.test.ts
@@ -1,6 +1,6 @@
 import { rename } from 'fs-extra';
 import { SiteServer } from '../../../../../site-server';
-import { DefaultExporter, SqlExporter } from '../../../export/exporters';
+import { SqlExporter } from '../../../export/exporters';
 import { ExportOptions } from '../../../export/types';
 
 jest.mock( 'fs' );

--- a/src/lib/import-export/tests/export/exporters/sql-exporter.test.ts
+++ b/src/lib/import-export/tests/export/exporters/sql-exporter.test.ts
@@ -1,0 +1,62 @@
+import { rename } from 'fs-extra';
+import { SiteServer } from '../../../../../site-server';
+import { SqlExporter } from '../../../export/exporters';
+import { ExportOptions } from '../../../export/types';
+
+jest.mock( 'fs' );
+jest.mock( 'fs/promises' );
+jest.mock( 'os' );
+jest.mock( 'fs-extra' );
+
+// Mock SiteServer
+jest.mock( '../../../../../site-server' );
+( SiteServer.get as jest.Mock ).mockReturnValue( {
+	details: { path: '/path/to/site' },
+	executeWpCliCommand: jest.fn().mockReturnValue( { stderr: null } ),
+} );
+
+describe( 'SqlExporter', () => {
+	let exporter: SqlExporter;
+	let mockOptions: ExportOptions;
+
+	beforeEach( () => {
+		mockOptions = {
+			site: {
+				running: false,
+				id: '123',
+				name: '123',
+				path: '/path/to/site',
+				phpVersion: '7.4',
+			},
+			backupFile: '/path/to/backup.sql',
+			includes: {
+				uploads: false,
+				plugins: false,
+				themes: false,
+				database: true,
+			},
+		};
+
+		// Reset all mock implementations
+		jest.clearAllMocks();
+
+		// mock rename
+		( rename as jest.Mock ).mockResolvedValue( null );
+		Date.now = jest.fn( () => 123456 );
+		exporter = new SqlExporter( mockOptions );
+	} );
+
+	it( 'should call rename on the temporary file', async () => {
+		await exporter.export();
+
+		expect( rename ).toHaveBeenCalledWith(
+			'/path/to/site/temp_export_123456.sql',
+			mockOptions.backupFile
+		);
+	} );
+
+	it( 'should return true when canHandle is called', async () => {
+		const canHandle = await exporter.canHandle();
+		expect( canHandle ).toBe( true );
+	} );
+} );

--- a/src/lib/import-export/tests/export/exporters/sql-exporter.test.ts
+++ b/src/lib/import-export/tests/export/exporters/sql-exporter.test.ts
@@ -38,17 +38,17 @@ describe( 'SqlExporter', () => {
 
 		( SiteServer.get as jest.Mock ).mockReturnValue( {
 			details: { path: '/path/to/site' },
-			executeWpCliCommand: jest.fn().mockReturnValue( { stderr: null } ),
+			executeWpCliCommand: jest.fn().mockResolvedValue( { stderr: null } ),
 		} );
-
-		// mock rename
 		( rename as jest.Mock ).mockResolvedValue( null );
+
 		jest.useFakeTimers();
 		jest.setSystemTime( new Date( '2024-08-01T12:00:00Z' ) );
+
 		exporter = new SqlExporter( mockOptions );
 	} );
 
-	afterAll( () => {
+	afterEach( () => {
 		jest.useRealTimers();
 	} );
 

--- a/src/lib/wpcli-versions.ts
+++ b/src/lib/wpcli-versions.ts
@@ -5,6 +5,10 @@ import { executeWPCli } from '../../vendor/wp-now/src/execute-wp-cli';
 import getWpCliPath from '../../vendor/wp-now/src/get-wp-cli-path';
 
 export async function updateLatestWPCliVersion() {
+	// @todo remove before merge
+	if ( process.env.STUDIO_IMPORT_EXPORT === 'true' ) {
+		return;
+	}
 	let shouldOverwrite = false;
 	const pathExist = await fs.pathExists( getWpCliPath() );
 	if ( pathExist ) {

--- a/src/lib/wpcli-versions.ts
+++ b/src/lib/wpcli-versions.ts
@@ -5,10 +5,6 @@ import { executeWPCli } from '../../vendor/wp-now/src/execute-wp-cli';
 import getWpCliPath from '../../vendor/wp-now/src/get-wp-cli-path';
 
 export async function updateLatestWPCliVersion() {
-	// @todo remove before merge
-	if ( process.env.STUDIO_IMPORT_EXPORT === 'true' ) {
-		return;
-	}
 	let shouldOverwrite = false;
 	const pathExist = await fs.pathExists( getWpCliPath() );
 	if ( pathExist ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/8363

## Proposed Changes

This PR adds SQL database export functionality:

- Export SQL only.
- Export SQL and include it in the export archive under the /sql directory.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Replace the wp-cli.phar with [this version](https://github.com/user-attachments/files/16456995/wp-cli.phar.zip). The files can be found in the Studio data directory under server-files.
- Restart studio and try to export the entire site.
- Verify that the archive is created at the desired destination.
- Verify that the archive contains the SQL file.
- Next, try to only export the database.
- Verify that the .SQL file is stored at the desired destination.

ps. The export could be invalid due to a bugfix that has not yet been released. It is best to replace the sqlite integration plugin of the site you're testing with the latest [develop branch](https://github.com/WordPress/sqlite-database-integration).

Afterwards, you might want to remove the `wp-cli.phar` so that Studio automatically downloads the latest stable version again when using the app.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
