### PR TITLE
Show complete export message in progress bar

### DIFF
--- a/src/hooks/tests/use-import-export.tsx
+++ b/src/hooks/tests/use-import-export.tsx
@@ -176,5 +176,13 @@ describe( 'useImportExport hook', () => {
 				progress: 100,
 			},
 		} );
+
+		emitExportEvent( SITE_ID, ExportEvents.EXPORT_COMPLETE );
+		expect( result.current.exportState ).toEqual( {
+			[ SITE_ID ]: {
+				statusMessage: 'Export completed',
+				progress: 100,
+			},
+		} );
 	} );
 } );

--- a/src/hooks/use-import-export.tsx
+++ b/src/hooks/use-import-export.tsx
@@ -55,6 +55,8 @@ export const ImportExportProvider = ( { children }: { children: React.ReactNode 
 					title: selectedSite.name,
 					body: __( 'Export completed' ),
 				} );
+				// Delay function resolution to ensure complete export message is displayed
+				await new Promise< void >( ( resolve ) => setTimeout( resolve, 500 ) );
 			} catch ( error ) {
 				Sentry.captureException( error );
 				await getIpcApi().showMessageBox( {
@@ -187,6 +189,16 @@ export const ImportExportProvider = ( { children }: { children: React.ReactNode 
 				} ) );
 				break;
 			}
+			case ExportEvents.EXPORT_COMPLETE:
+				setExportState( ( { [ siteId ]: currentProgress, ...rest } ) => ( {
+					...rest,
+					[ siteId ]: {
+						...currentProgress,
+						statusMessage: __( 'Export completed' ),
+						progress: 100,
+					},
+				} ) );
+				break;
 			case ExportEvents.EXPORT_ERROR:
 				setExportState( ( { [ siteId ]: currentProgress, ...rest } ) => ( {
 					...rest,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to https://github.com/Automattic/studio/pull/376/files#r1698196912.

## Proposed Changes

- Delay 500ms the resolution of `exportSite` function.
- Display complete export message in the export progress bar.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Create a site and select it.
- Navigate to the Import/Export tab.
- Click on Export entire site.
- Select a destination for the export and click on Save.
- Observe a progress bar is shown with the progress of the export process.
- Observe that when the export completes, the message "Export completed" is shown in the progress bar.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
