### PR TITLE
Studio: remove scroll from the Add site modal

### DIFF
--- a/src/components/add-site.tsx
+++ b/src/components/add-site.tsx
@@ -166,7 +166,7 @@ export default function AddSite( { className }: AddSiteProps ) {
 								<div className="sticky bottom-0 bg-white -mx-8">
 									<div
 										className={ cx(
-											'border-t border-gray-300 py-4 flex flex-row justify-end gap-x-5 mt-6 px-4'
+											'border-t border-gray-300 py-4 flex flex-row justify-end gap-x-5 mt-6 px-8'
 										) }
 									>
 										<Button onClick={ closeModal } disabled={ isSiteAdding } variant="tertiary">

--- a/src/components/add-site.tsx
+++ b/src/components/add-site.tsx
@@ -8,6 +8,7 @@ import { useDragAndDropFile } from '../hooks/use-drag-and-drop-file';
 import { useFeatureFlags } from '../hooks/use-feature-flags';
 import { useIpcListener } from '../hooks/use-ipc-listener';
 import { useSiteDetails } from '../hooks/use-site-details';
+import { cx } from '../lib/cx';
 import { generateSiteName } from '../lib/generate-site-name';
 import { getIpcApi } from '../lib/get-ipc-api';
 import Button from './button';
@@ -145,6 +146,7 @@ export default function AddSite( { className }: AddSiteProps ) {
 						isDismissible
 						focusOnMount="firstContentElement"
 						onRequestClose={ closeModal }
+						className="max-h-[90%] md:max-h-[90%]"
 					>
 						<div ref={ dropRef }>
 							{ isDraggingOver && <DragAndDropOverlay /> }
@@ -161,18 +163,24 @@ export default function AddSite( { className }: AddSiteProps ) {
 								onFileSelected={ handleImportFile }
 								fileError={ fileError }
 							>
-								<div className="sticky bottom-0 bg-white py-4 flex flex-row justify-end gap-x-5">
-									<Button onClick={ closeModal } disabled={ isSiteAdding } variant="tertiary">
-										{ __( 'Cancel' ) }
-									</Button>
-									<Button
-										type="submit"
-										variant="primary"
-										isBusy={ isSiteAdding }
-										disabled={ isSiteAdding || !! error || ! siteName?.trim() }
+								<div className="sticky bottom-0 bg-white -mx-8">
+									<div
+										className={ cx(
+											'border-t border-gray-300 py-4 flex flex-row justify-end gap-x-5 mt-6 px-4'
+										) }
 									>
-										{ __( 'Add site' ) }
-									</Button>
+										<Button onClick={ closeModal } disabled={ isSiteAdding } variant="tertiary">
+											{ __( 'Cancel' ) }
+										</Button>
+										<Button
+											type="submit"
+											variant="primary"
+											isBusy={ isSiteAdding }
+											disabled={ isSiteAdding || !! error || ! siteName?.trim() }
+										>
+											{ __( 'Add site' ) }
+										</Button>
+									</div>
 								</div>
 							</SiteForm>
 						</div>

--- a/src/components/add-site.tsx
+++ b/src/components/add-site.tsx
@@ -161,7 +161,7 @@ export default function AddSite( { className }: AddSiteProps ) {
 								onFileSelected={ handleImportFile }
 								fileError={ fileError }
 							>
-								<div className="flex flex-row justify-end gap-x-5 mt-6">
+								<div className="sticky bottom-0 bg-white py-4 flex flex-row justify-end gap-x-5">
 									<Button onClick={ closeModal } disabled={ isSiteAdding } variant="tertiary">
 										{ __( 'Cancel' ) }
 									</Button>

--- a/src/components/add-site.tsx
+++ b/src/components/add-site.tsx
@@ -8,7 +8,6 @@ import { useDragAndDropFile } from '../hooks/use-drag-and-drop-file';
 import { useFeatureFlags } from '../hooks/use-feature-flags';
 import { useIpcListener } from '../hooks/use-ipc-listener';
 import { useSiteDetails } from '../hooks/use-site-details';
-import { cx } from '../lib/cx';
 import { generateSiteName } from '../lib/generate-site-name';
 import { getIpcApi } from '../lib/get-ipc-api';
 import Button from './button';
@@ -163,24 +162,18 @@ export default function AddSite( { className }: AddSiteProps ) {
 								onFileSelected={ handleImportFile }
 								fileError={ fileError }
 							>
-								<div className="sticky bottom-0 bg-white -mx-8">
-									<div
-										className={ cx(
-											'border-t border-gray-300 py-4 flex flex-row justify-end gap-x-5 mt-6 px-8'
-										) }
+								<div className="flex flex-row justify-end gap-x-5 mt-6">
+									<Button onClick={ closeModal } disabled={ isSiteAdding } variant="tertiary">
+										{ __( 'Cancel' ) }
+									</Button>
+									<Button
+										type="submit"
+										variant="primary"
+										isBusy={ isSiteAdding }
+										disabled={ isSiteAdding || !! error || ! siteName?.trim() }
 									>
-										<Button onClick={ closeModal } disabled={ isSiteAdding } variant="tertiary">
-											{ __( 'Cancel' ) }
-										</Button>
-										<Button
-											type="submit"
-											variant="primary"
-											isBusy={ isSiteAdding }
-											disabled={ isSiteAdding || !! error || ! siteName?.trim() }
-										>
-											{ __( 'Add site' ) }
-										</Button>
-									</div>
+										{ __( 'Add site' ) }
+									</Button>
 								</div>
 							</SiteForm>
 						</div>


### PR DESCRIPTION
Closes https://github.com/Automattic/dotcom-forge/issues/8510

## Proposed Changes

This PR removed the scroll from the `Add site` modal when the Advanced settings are opened by increasing the height of the modal.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
* Start the app with `STUDIO_IMPORT_EXPORT=true npm start`
* Resize the app window to the minimum size 
* Click on the `Add site` button in the left sidebar
* Open the modal for adding a site
* Click on `Advanced settings` 
* Observe that the `Advanced settings` open but no scrollbar appears

# Project Updates

| Before | After |
|--------|-------|
| <img width="913" alt="Screenshot 2024-07-31 at 2 39 16 PM" src="https://github.com/user-attachments/assets/8e2be924-0851-46a3-8655-1b2a92f8bed4"> | <img width="912" alt="Screenshot 2024-07-31 at 2 38 30 PM" src="https://github.com/user-attachments/assets/edbcb499-309c-4f42-91cc-e7bb2e017b73"> |

Initially, I was going to pin the buttons but I opted for increasing the height of the modal to remove the scrollbar completely as it works well for now with the current setup. We can re-visit the pinned buttons when we implement additional fields in the form.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
