### PR TITLE
Add Import progress

### DIFF
--- a/src/components/content-tab-import-export.tsx
+++ b/src/components/content-tab-import-export.tsx
@@ -8,12 +8,11 @@ import { STUDIO_DOCS_URL } from '../constants';
 import { useConfirmationDialog } from '../hooks/use-confirmation-dialog';
 import { useDragAndDropFile } from '../hooks/use-drag-and-drop-file';
 import { useImportExport } from '../hooks/use-import-export';
-import { useIpcListener } from '../hooks/use-ipc-listener';
 import { useSiteDetails } from '../hooks/use-site-details';
 import { cx } from '../lib/cx';
 import { getIpcApi } from '../lib/get-ipc-api';
 import Button from './button';
-import ProgressBar, { ProgressBarWithAutoIncrement } from './progress-bar';
+import ProgressBar from './progress-bar';
 
 interface ContentTabImportExportProps {
 	selectedSite: SiteDetails;
@@ -77,7 +76,9 @@ const InitialImportButton = ( {
 
 const ImportSite = ( props: { selectedSite: SiteDetails } ) => {
 	const { __ } = useI18n();
-	const { importFile, updateSite, startServer, loadingServer } = useSiteDetails();
+	const { startServer, loadingServer } = useSiteDetails();
+	const { importState, importFile, clearImportState } = useImportExport();
+	const { [ props.selectedSite.id ]: currentProgress } = importState;
 	const importConfirmation = useConfirmationDialog( {
 		message: sprintf( __( 'Overwrite %s?' ), props.selectedSite.name ),
 		checkboxLabel: __( "Don't ask again" ),
@@ -120,17 +121,16 @@ const ImportSite = ( props: { selectedSite: SiteDetails } ) => {
 			inputFileRef.current.value = '';
 		}
 	};
-	const clearImportState = () => {
-		delete props.selectedSite.importState;
-		updateSite( props.selectedSite );
+	const onStartAgain = () => {
+		clearImportState( props.selectedSite.id );
 		clearImportFileInput();
 	};
 
 	const startLoadingCursorClassName =
 		loadingServer[ props.selectedSite.id ] && 'animate-pulse duration-100 cursor-wait';
 
-	const isImporting = props.selectedSite.importState === 'importing';
-	const isImported = props.selectedSite.importState === 'imported' && ! isDraggingOver;
+	const isImporting = currentProgress?.progress < 100;
+	const isImported = currentProgress?.progress === 100 && ! isDraggingOver;
 	const isInitial = ! isImporting && ! isImported;
 	return (
 		<div className={ cx( 'flex flex-col w-full', startLoadingCursorClassName ) }>
@@ -156,13 +156,11 @@ const ImportSite = ( props: { selectedSite: SiteDetails } ) => {
 						{ isImporting && (
 							<>
 								<div className="w-[240px]">
-									<ProgressBarWithAutoIncrement
-										initialValue={ 50 }
-										maxValue={ 95 }
-										increment={ 5 }
-									/>
+									<ProgressBar value={ currentProgress.progress } maxValue={ 100 } />
 								</div>
-								<div className="text-a8c-gray-70 a8c-body mt-4">{ __( 'Importing backup…' ) }</div>
+								<div className="text-a8c-gray-70 a8c-body mt-4">
+									{ currentProgress.statusMessage }
+								</div>
 							</>
 						) }
 						{ isImported && (
@@ -176,7 +174,7 @@ const ImportSite = ( props: { selectedSite: SiteDetails } ) => {
 									>
 										{ __( 'Open site ↗' ) }
 									</Button>
-									<Button variant="link" className="!px-2.5 !py-2" onClick={ clearImportState }>
+									<Button variant="link" className="!px-2.5 !py-2" onClick={ onStartAgain }>
 										{ __( 'Start again' ) }
 									</Button>
 								</div>
@@ -208,10 +206,6 @@ const ImportSite = ( props: { selectedSite: SiteDetails } ) => {
 };
 
 export function ContentTabImportExport( { selectedSite }: ContentTabImportExportProps ) {
-	useIpcListener( 'on-import', ( _evt, data: unknown ) => {
-		// This listener will be used to track progress of import when the UI is finished.
-	} );
-
 	return (
 		<div className="flex flex-col p-8 gap-8">
 			<ImportSite selectedSite={ selectedSite } />

--- a/src/components/site-content-tabs.tsx
+++ b/src/components/site-content-tabs.tsx
@@ -27,7 +27,7 @@ export function SiteContentTabs() {
 	}
 
 	if ( selectedSite?.isAddingSite || importState[ selectedSite?.id ]?.isNewSite ) {
-		return <SiteLoadingIndicator selectedSiteName={ selectedSite.name } />;
+		return <SiteLoadingIndicator selectedSite={ selectedSite } />;
 	}
 
 	return (

--- a/src/components/site-content-tabs.tsx
+++ b/src/components/site-content-tabs.tsx
@@ -1,6 +1,7 @@
 import { TabPanel } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
 import { useContentTabs } from '../hooks/use-content-tabs';
+import { useImportExport } from '../hooks/use-import-export';
 import { useSiteDetails } from '../hooks/use-site-details';
 import { WelcomeMessagesProvider } from '../hooks/use-welcome-messages';
 import { ContentTabAssistant } from './content-tab-assistant';
@@ -13,6 +14,7 @@ import { SiteLoadingIndicator } from './site-loading-indicator';
 
 export function SiteContentTabs() {
 	const { selectedSite } = useSiteDetails();
+	const { importState } = useImportExport();
 	const tabs = useContentTabs();
 	const { __ } = useI18n();
 
@@ -24,7 +26,7 @@ export function SiteContentTabs() {
 		);
 	}
 
-	if ( selectedSite?.isAddingSite || selectedSite?.importState === 'new-site-importing' ) {
+	if ( selectedSite?.isAddingSite || importState[ selectedSite?.id ]?.isNewSite ) {
 		return <SiteLoadingIndicator selectedSiteName={ selectedSite.name } />;
 	}
 

--- a/src/components/site-loading-indicator.tsx
+++ b/src/components/site-loading-indicator.tsx
@@ -1,37 +1,25 @@
 import { useI18n } from '@wordpress/react-i18n';
-import { useEffect } from 'react';
-import { useProgressTimer } from '../hooks/use-progress-timer';
-import ProgressBar from './progress-bar';
+import { useImportExport } from '../hooks/use-import-export';
+import ProgressBar, { ProgressBarWithAutoIncrement } from './progress-bar';
 
-export function SiteLoadingIndicator( { selectedSiteName }: { selectedSiteName?: string } ) {
+export function SiteLoadingIndicator( { selectedSite }: { selectedSite: SiteDetails } ) {
 	const { __ } = useI18n();
+	const { importState } = useImportExport();
+	const { [ selectedSite.id ]: currentProgress } = importState;
+	const isImporting = !! currentProgress?.progress;
 
-	const { progress, setProgress } = useProgressTimer( {
-		initialProgress: 10,
-		interval: 1500,
-		maxValue: 95,
-	} );
-
-	useEffect( () => {
-		const updateProgress = () => {
-			setProgress( ( prev ) => {
-				const increment = Math.random() * 10 + 5;
-				return Math.min( prev + increment, 95 );
-			} );
-		};
-
-		setProgress( 20 );
-		const interval = setInterval( updateProgress, 1000 );
-
-		return () => clearInterval( interval );
-	}, [ setProgress ] );
+	const statusMessage = isImporting ? currentProgress.statusMessage : __( 'Creating site...' );
 
 	return (
 		<div className="flex flex-col w-full h-full app-no-drag-region pt-8 overflow-y-auto justify-center items-center">
 			<div className="w-[300px] text-center">
-				<div className="text-black a8c-subtitle-small mb-4">{ selectedSiteName }</div>
-				<ProgressBar value={ progress } maxValue={ 100 } />
-				<div className="text-a8c-gray-70 a8c-body mt-4">{ __( 'Creating site...' ) }</div>
+				<div className="text-black a8c-subtitle-small mb-4">{ selectedSite.name }</div>
+				{ isImporting ? (
+					<ProgressBar value={ currentProgress.progress } maxValue={ 100 } />
+				) : (
+					<ProgressBarWithAutoIncrement initialValue={ 10 } increment={ 10 } maxValue={ 100 } />
+				) }
+				<div className="text-a8c-gray-70 a8c-body mt-4">{ statusMessage }</div>
 			</div>
 		</div>
 	);

--- a/src/components/tests/content-tab-import-export.test.tsx
+++ b/src/components/tests/content-tab-import-export.test.tsx
@@ -21,7 +21,6 @@ const selectedSite: SiteDetails = {
 beforeEach( () => {
 	jest.clearAllMocks();
 	( useSiteDetails as jest.Mock ).mockReturnValue( {
-		importFile: jest.fn(),
 		updateSite: jest.fn(),
 		startServer: jest.fn(),
 		loadingServer: {},
@@ -30,6 +29,8 @@ beforeEach( () => {
 		showMessageBox: jest.fn().mockResolvedValue( { response: 0, checkboxChecked: false } ), // Mock showMessageBox
 	} );
 	( useImportExport as jest.Mock ).mockReturnValue( {
+		importFile: jest.fn(),
+		importState: {},
 		exportFullSite: jest.fn(),
 		exportDatabase: jest.fn(),
 		exportState: {},
@@ -81,7 +82,7 @@ describe( 'ContentTabImportExport Import', () => {
 		fireEvent( dropZone, dropEvent );
 
 		await waitFor( () =>
-			expect( useSiteDetails().importFile ).toHaveBeenCalledWith( file, selectedSite )
+			expect( useImportExport().importFile ).toHaveBeenCalledWith( file, selectedSite )
 		);
 	} );
 
@@ -92,7 +93,7 @@ describe( 'ContentTabImportExport Import', () => {
 
 		await userEvent.upload( fileInput, file );
 
-		expect( useSiteDetails().importFile ).toHaveBeenCalledWith( file, selectedSite );
+		expect( useImportExport().importFile ).toHaveBeenCalledWith( file, selectedSite );
 	} );
 } );
 
@@ -117,6 +118,7 @@ describe( 'ContentTabImportExport Export', () => {
 
 	test( 'should display progress when exporting', async () => {
 		( useImportExport as jest.Mock ).mockReturnValue( {
+			importState: {},
 			exportState: { 'site-id-1': { progress: 5, statusMessage: 'Starting export...' } },
 		} );
 

--- a/src/components/tests/content-tab-import-export.test.tsx
+++ b/src/components/tests/content-tab-import-export.test.tsx
@@ -95,6 +95,19 @@ describe( 'ContentTabImportExport Import', () => {
 
 		expect( useImportExport().importFile ).toHaveBeenCalledWith( file, selectedSite );
 	} );
+
+	test( 'should display progress when importing', async () => {
+		( useImportExport as jest.Mock ).mockReturnValue( {
+			importState: {
+				'site-id-1': { progress: 5, statusMessage: 'Extracting backup…', isNewSite: false },
+			},
+			exportState: {},
+		} );
+
+		render( <ContentTabImportExport selectedSite={ selectedSite } /> );
+		expect( screen.getByText( 'Extracting backup…' ) ).toBeVisible();
+		expect( screen.getByRole( 'progressbar', { value: { now: 5 } } ) ).toBeVisible();
+	} );
 } );
 
 describe( 'ContentTabImportExport Export', () => {

--- a/src/hooks/tests/use-import-export.tsx
+++ b/src/hooks/tests/use-import-export.tsx
@@ -1,6 +1,7 @@
 import { renderHook, act } from '@testing-library/react';
 import { getIpcApi } from '../../lib/get-ipc-api';
 import { ExportEventType, ExportEvents } from '../../lib/import-export/export/events';
+import { ImportEventType, ImportEvents } from '../../lib/import-export/import/events';
 import { ImportExportProvider, useImportExport } from '../use-import-export';
 import { useIpcListener } from '../use-ipc-listener';
 
@@ -29,6 +30,7 @@ beforeEach( () => {
 		showMessageBox: jest.fn().mockResolvedValue( { response: 0, checkboxChecked: false } ),
 		showNotification: jest.fn(),
 		exportSite: jest.fn(),
+		importSite: jest.fn(),
 	} );
 } );
 
@@ -174,6 +176,155 @@ describe( 'useImportExport hook', () => {
 			[ SITE_ID ]: {
 				statusMessage: 'Backing up files...',
 				progress: 100,
+			},
+		} );
+	} );
+
+	it( 'imports site', async () => {
+		const { result } = renderHook( () => useImportExport(), { wrapper } );
+		const file = { path: 'backup.zip', type: 'application/zip' };
+		await act( () => result.current.importFile( file, selectedSite ) );
+		await act( () => result.current.clearImportState( selectedSite.id ) );
+
+		expect( result.current.importState ).toEqual( {} );
+		expect( getIpcApi().importSite ).toHaveBeenCalledWith( {
+			id: SITE_ID,
+			backupFile: {
+				type: 'application/zip',
+				path: 'backup.zip',
+			},
+		} );
+		expect( getIpcApi().showNotification ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				body: 'Import completed',
+			} )
+		);
+	} );
+
+	it( 'shows error message when import fails', async () => {
+		( getIpcApi().importSite as jest.Mock ).mockRejectedValue( 'error' );
+
+		const { result } = renderHook( () => useImportExport(), { wrapper } );
+		const file = { path: 'backup.zip', type: 'application/zip' };
+		await act( () => result.current.importFile( file, selectedSite ) );
+
+		expect( result.current.exportState ).toEqual( {} );
+		expect( getIpcApi().importSite ).toHaveBeenCalledWith( {
+			id: SITE_ID,
+			backupFile: {
+				type: 'application/zip',
+				path: 'backup.zip',
+			},
+		} );
+		expect( getIpcApi().showMessageBox ).toHaveBeenCalledWith(
+			expect.objectContaining( { type: 'error', message: 'Failed importing site' } )
+		);
+	} );
+
+	it( 'does not import if another import is running', async () => {
+		let onEvent: ( ...args: any[] ) => void = jest.fn();
+		( useIpcListener as jest.Mock ).mockImplementation( ( event, callback ) => {
+			if ( event === 'on-import' ) {
+				onEvent = callback;
+			}
+		} );
+		const emitImportEvent = ( siteId: string, event: ImportEventType, data: unknown = {} ) =>
+			act( () => onEvent( null, { event, data }, siteId ) );
+
+		const { result } = renderHook( () => useImportExport(), { wrapper } );
+		const file = { path: 'backup.zip', type: 'application/zip' };
+		await act( () => result.current.importFile( file, selectedSite ) );
+		// Mock import state of selected site
+		emitImportEvent( SITE_ID, ImportEvents.BACKUP_EXTRACT_PROGRESS, { progress: 0.5 } );
+
+		await act( () => result.current.importFile( file, selectedSite ) );
+
+		expect( getIpcApi().importSite ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'updates the import state when receiving import events', async () => {
+		let onEvent: ( ...args: any[] ) => void = jest.fn();
+		( useIpcListener as jest.Mock ).mockImplementation( ( event, callback ) => {
+			if ( event === 'on-import' ) {
+				onEvent = callback;
+			}
+		} );
+		const emitImportEvent = ( siteId: string, event: ImportEventType, data: unknown = {} ) =>
+			act( () => onEvent( null, { event, data }, siteId ) );
+
+		const { result } = renderHook( () => useImportExport(), { wrapper } );
+		const file = { path: 'backup.zip', type: 'application/zip' };
+		await act( () => result.current.importFile( file, selectedSite ) );
+
+		emitImportEvent( SITE_ID, ImportEvents.BACKUP_EXTRACT_START );
+		expect( result.current.importState ).toEqual( {
+			[ SITE_ID ]: {
+				statusMessage: 'Extracting backup…',
+				progress: 5,
+				isNewSite: false,
+			},
+		} );
+
+		emitImportEvent( SITE_ID, ImportEvents.BACKUP_EXTRACT_PROGRESS, { progress: 0.5 } );
+		expect( result.current.importState ).toEqual( {
+			[ SITE_ID ]: {
+				statusMessage: 'Extracting backup files…',
+				progress: 27.5,
+				isNewSite: false,
+			},
+		} );
+
+		emitImportEvent( SITE_ID, ImportEvents.IMPORT_START );
+		expect( result.current.importState ).toEqual( {
+			[ SITE_ID ]: {
+				statusMessage: 'Importing backup…',
+				progress: 55,
+				isNewSite: false,
+			},
+		} );
+
+		emitImportEvent( SITE_ID, ImportEvents.IMPORT_DATABASE_START );
+		expect( result.current.importState ).toEqual( {
+			[ SITE_ID ]: {
+				statusMessage: 'Importing database…',
+				progress: 60,
+				isNewSite: false,
+			},
+		} );
+
+		emitImportEvent( SITE_ID, ImportEvents.IMPORT_DATABASE_COMPLETE );
+		expect( result.current.importState ).toEqual( {
+			[ SITE_ID ]: {
+				statusMessage: 'Importing database…',
+				progress: 80,
+				isNewSite: false,
+			},
+		} );
+
+		emitImportEvent( SITE_ID, ImportEvents.IMPORT_WP_CONTENT_START );
+		expect( result.current.importState ).toEqual( {
+			[ SITE_ID ]: {
+				statusMessage: 'Importing WordPress content…',
+				progress: 80,
+				isNewSite: false,
+			},
+		} );
+
+		emitImportEvent( SITE_ID, ImportEvents.IMPORT_WP_CONTENT_COMPLETE );
+		expect( result.current.importState ).toEqual( {
+			[ SITE_ID ]: {
+				statusMessage: 'Importing WordPress content…',
+				progress: 95,
+				isNewSite: false,
+			},
+		} );
+
+		emitImportEvent( SITE_ID, ImportEvents.IMPORT_COMPLETE );
+		expect( result.current.importState ).toEqual( {
+			[ SITE_ID ]: {
+				statusMessage: 'Importing completed',
+				progress: 100,
+				isNewSite: false,
 			},
 		} );
 	} );

--- a/src/hooks/use-import-export.tsx
+++ b/src/hooks/use-import-export.tsx
@@ -128,7 +128,7 @@ export const ImportExportProvider = ( { children }: { children: React.ReactNode 
 
 		switch ( event ) {
 			case BackupExtractEvents.BACKUP_EXTRACT_PROGRESS: {
-				const progress = ( data as BackupExtractProgressEventData ).progress;
+				const progress = ( data as BackupExtractProgressEventData )?.progress ?? 0;
 				setImportState( ( { [ siteId ]: currentProgress, ...rest } ) => ( {
 					...rest,
 					[ siteId ]: {

--- a/src/hooks/use-import-export.tsx
+++ b/src/hooks/use-import-export.tsx
@@ -95,7 +95,7 @@ export const ImportExportProvider = ( { children }: { children: React.ReactNode 
 				if ( showImportNotification ) {
 					getIpcApi().showNotification( {
 						title: selectedSite.name,
-						body: __( 'Import complete' ),
+						body: __( 'Import completed' ),
 					} );
 				}
 			} catch ( error ) {

--- a/src/hooks/use-import-export.tsx
+++ b/src/hooks/use-import-export.tsx
@@ -6,9 +6,26 @@ import { ExportEvents } from '../lib/import-export/export/events';
 import { generateBackupFilename } from '../lib/import-export/export/generate-backup-filename';
 import { BackupCreateProgressEventData, ExportOptions } from '../lib/import-export/export/types';
 import { ImportExportEventData } from '../lib/import-export/handle-events';
+import {
+	ImporterEvents,
+	BackupExtractEvents,
+	ValidatorEvents,
+} from '../lib/import-export/import/events';
+import {
+	BackupArchiveInfo,
+	BackupExtractProgressEventData,
+} from '../lib/import-export/import/types';
 import { useIpcListener } from './use-ipc-listener';
 
-type ProgressState = {
+type ImportProgressState = {
+	[ siteId: string ]: {
+		statusMessage: string;
+		progress: number;
+		isNewSite?: boolean;
+	};
+};
+
+type ExportProgressState = {
 	[ siteId: string ]: {
 		statusMessage: string;
 		progress: number;
@@ -16,27 +33,182 @@ type ProgressState = {
 };
 
 interface ImportExportContext {
-	importState: ProgressState;
-	exportState: ProgressState;
+	importState: ImportProgressState;
+	importFile: (
+		file: BackupArchiveInfo,
+		selectedSite: SiteDetails,
+		options?: { showImportNotification?: boolean; isNewSite?: boolean }
+	) => Promise< void >;
+	clearImportState: ( siteId: string ) => void;
+	exportState: ExportProgressState;
 	exportFullSite: ( selectedSite: SiteDetails ) => Promise< void >;
 	exportDatabase: ( selectedSite: SiteDetails ) => Promise< void >;
 }
 
-const DEFAULT_STATE = {
+const INITIAL_EXPORT_STATE = {
 	statusMessage: __( 'Starting export...' ),
+	progress: 5,
+};
+const INITIAL_IMPORT_STATE = {
+	statusMessage: __( 'Extracting backup…' ),
 	progress: 5,
 };
 
 const ImportExportContext = createContext< ImportExportContext >( {
 	importState: {},
+	importFile: async () => undefined,
+	clearImportState: () => undefined,
 	exportState: {},
 	exportFullSite: async () => undefined,
 	exportDatabase: async () => undefined,
 } );
 
 export const ImportExportProvider = ( { children }: { children: React.ReactNode } ) => {
-	const [ importState, setImportState ] = useState< ProgressState >( {} );
-	const [ exportState, setExportState ] = useState< ProgressState >( {} );
+	const [ importState, setImportState ] = useState< ImportProgressState >( {} );
+	const [ exportState, setExportState ] = useState< ExportProgressState >( {} );
+
+	const importFile = useCallback(
+		async (
+			file: BackupArchiveInfo,
+			selectedSite: SiteDetails,
+			{
+				showImportNotification = true,
+				isNewSite = false,
+			}: { showImportNotification?: boolean; isNewSite?: boolean } = {}
+		) => {
+			if ( importState[ selectedSite.id ]?.progress < 100 ) {
+				return;
+			}
+
+			setImportState( ( prevState ) => ( {
+				...prevState,
+				[ selectedSite.id ]: { ...INITIAL_IMPORT_STATE, isNewSite },
+			} ) );
+
+			try {
+				const backupFile: BackupArchiveInfo = {
+					type: file.type,
+					path: file.path,
+				};
+				await getIpcApi().importSite( { id: selectedSite.id, backupFile } );
+
+				if ( showImportNotification ) {
+					getIpcApi().showNotification( {
+						title: selectedSite.name,
+						body: __( 'Import complete' ),
+					} );
+				}
+			} catch ( error ) {
+				await getIpcApi().showMessageBox( {
+					type: 'error',
+					message: __( 'Failed importing site' ),
+					detail: __(
+						'An error occurred while importing the site. Verify the file is a valid Jetpack backup or .sql database file and try again. If this problem persists, please contact support.'
+					),
+					buttons: [ __( 'OK' ) ],
+				} );
+				setImportState( ( { [ selectedSite.id ]: currentProgress, ...rest } ) => ( {
+					...rest,
+				} ) );
+			}
+		},
+		[ importState ]
+	);
+
+	const clearImportState = useCallback( ( siteId: string ) => {
+		setImportState( ( { [ siteId ]: currentProgress, ...rest } ) => ( {
+			...rest,
+		} ) );
+	}, [] );
+
+	useIpcListener( 'on-import', ( _, { event, data }: ImportExportEventData, siteId: string ) => {
+		if ( ! siteId ) {
+			return;
+		}
+
+		switch ( event ) {
+			case BackupExtractEvents.BACKUP_EXTRACT_PROGRESS: {
+				const progress = ( data as BackupExtractProgressEventData ).progress;
+				setImportState( ( { [ siteId ]: currentProgress, ...rest } ) => ( {
+					...rest,
+					[ siteId ]: {
+						...currentProgress,
+						statusMessage: __( 'Extracting backup files…' ),
+						progress: 5 + progress * 45, // Backup extraction takes progress from 5% to 50%
+					},
+				} ) );
+				break;
+			}
+			case ImporterEvents.IMPORT_START:
+				setImportState( ( { [ siteId ]: currentProgress, ...rest } ) => ( {
+					...rest,
+					[ siteId ]: {
+						...currentProgress,
+						statusMessage: __( 'Importing backup…' ),
+						progress: 55,
+					},
+				} ) );
+				break;
+			case ImporterEvents.IMPORT_DATABASE_START:
+				setImportState( ( { [ siteId ]: currentProgress, ...rest } ) => ( {
+					...rest,
+					[ siteId ]: {
+						...currentProgress,
+						statusMessage: __( 'Importing database…' ),
+						progress: 60,
+					},
+				} ) );
+				break;
+			case ImporterEvents.IMPORT_DATABASE_COMPLETE:
+				setImportState( ( { [ siteId ]: currentProgress, ...rest } ) => ( {
+					...rest,
+					[ siteId ]: {
+						...currentProgress,
+						progress: 80,
+					},
+				} ) );
+				break;
+			case ImporterEvents.IMPORT_WP_CONTENT_START:
+				setImportState( ( { [ siteId ]: currentProgress, ...rest } ) => ( {
+					...rest,
+					[ siteId ]: {
+						...currentProgress,
+						statusMessage: __( 'Importing WordPress content…' ),
+					},
+				} ) );
+				break;
+			case ImporterEvents.IMPORT_WP_CONTENT_COMPLETE:
+				setImportState( ( { [ siteId ]: currentProgress, ...rest } ) => ( {
+					...rest,
+					[ siteId ]: {
+						...currentProgress,
+						progress: 95,
+					},
+				} ) );
+				break;
+			case ImporterEvents.IMPORT_COMPLETE:
+				setImportState( ( { [ siteId ]: currentProgress, ...rest } ) => ( {
+					...rest,
+					[ siteId ]: {
+						...currentProgress,
+						statusMessage: __( 'Importing completed' ),
+						progress: 100,
+					},
+				} ) );
+				break;
+			case ImporterEvents.IMPORT_ERROR:
+			case BackupExtractEvents.BACKUP_EXTRACT_ERROR:
+			case ValidatorEvents.IMPORT_VALIDATION_ERROR:
+				setImportState( ( { [ siteId ]: currentProgress, ...rest } ) => ( {
+					...rest,
+					[ siteId ]: {
+						...currentProgress,
+						statusMessage: __( 'Import failed. Please try again.' ),
+					},
+				} ) );
+				break;
+		}
+	} );
 
 	const exportSite = useCallback(
 		async ( selectedSite: SiteDetails, options: ExportOptions ) => {
@@ -46,7 +218,7 @@ export const ImportExportProvider = ( { children }: { children: React.ReactNode 
 
 			setExportState( ( prevState ) => ( {
 				...prevState,
-				[ selectedSite.id ]: DEFAULT_STATE,
+				[ selectedSite.id ]: INITIAL_EXPORT_STATE,
 			} ) );
 
 			try {
@@ -143,7 +315,7 @@ export const ImportExportProvider = ( { children }: { children: React.ReactNode 
 
 		switch ( event ) {
 			case ExportEvents.EXPORT_START:
-				setExportState( ( prevState ) => ( { ...prevState, [ siteId ]: DEFAULT_STATE } ) );
+				setExportState( ( prevState ) => ( { ...prevState, [ siteId ]: INITIAL_EXPORT_STATE } ) );
 				break;
 			case ExportEvents.BACKUP_CREATE_START:
 				setExportState( ( { [ siteId ]: currentProgress, ...rest } ) => ( {
@@ -202,11 +374,13 @@ export const ImportExportProvider = ( { children }: { children: React.ReactNode 
 	const context = useMemo< ImportExportContext >(
 		() => ( {
 			importState,
+			importFile,
+			clearImportState,
 			exportState,
 			exportFullSite,
 			exportDatabase,
 		} ),
-		[ importState, exportState, exportFullSite, exportDatabase ]
+		[ importState, importFile, clearImportState, exportState, exportFullSite, exportDatabase ]
 	);
 
 	return (

--- a/src/hooks/use-site-details.tsx
+++ b/src/hooks/use-site-details.tsx
@@ -10,7 +10,6 @@ import {
 	useState,
 } from 'react';
 import { getIpcApi } from '../lib/get-ipc-api';
-import { BackupArchiveInfo } from '../lib/import-export/import/types';
 import { sortSites } from '../lib/sort-sites';
 import { useSnapshots } from './use-snapshots';
 
@@ -33,11 +32,6 @@ interface SiteDetailsContext {
 	isDeleting: boolean;
 	uploadingSites: { [ siteId: string ]: boolean };
 	setUploadingSites: React.Dispatch< React.SetStateAction< { [ siteId: string ]: boolean } > >;
-	importFile: (
-		file: File,
-		selectedSite: SiteDetails,
-		showImportNotification?: boolean
-	) => Promise< void >;
 }
 
 export const siteDetailsContext = createContext< SiteDetailsContext >( {
@@ -55,7 +49,6 @@ export const siteDetailsContext = createContext< SiteDetailsContext >( {
 	loadingSites: true,
 	uploadingSites: {},
 	setUploadingSites: () => undefined,
-	importFile: async () => undefined,
 } );
 
 interface SiteDetailsProviderProps {
@@ -243,55 +236,6 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 		[ setSelectedSiteId ]
 	);
 
-	const importFile = useCallback(
-		async ( file: BackupArchiveInfo, selectedSite: SiteDetails, showImportNotification = true ) => {
-			let finalImportState: ImportSiteState;
-			if (
-				selectedSite.importState === 'importing' ||
-				selectedSite.importState === 'new-site-importing'
-			) {
-				return;
-			}
-			try {
-				setData( ( prevSites ) =>
-					prevSites.map( ( site ) =>
-						site.id === selectedSite.id ? { ...site, importState: 'importing' } : site
-					)
-				);
-				const backupFile: BackupArchiveInfo = {
-					type: file.type,
-					path: file.path,
-				};
-				await getIpcApi().importSite( { id: selectedSite.id, backupFile } );
-
-				if ( showImportNotification ) {
-					getIpcApi().showNotification( {
-						title: selectedSite.name,
-						body: __( 'Import complete' ),
-					} );
-				}
-				finalImportState = 'imported';
-			} catch ( error ) {
-				getIpcApi().showMessageBox( {
-					type: 'error',
-					message: __( 'Failed importing site' ),
-					detail: __(
-						'An error occurred while importing the site. Verify the file is a valid Jetpack backup or .sql database file and try again. If this problem persists, please contact support.'
-					),
-					buttons: [ __( 'OK' ) ],
-				} );
-				finalImportState = undefined;
-			} finally {
-				setData( ( prevSites ) =>
-					prevSites.map( ( site ) =>
-						site.id === selectedSite.id ? { ...site, importState: finalImportState } : site
-					)
-				);
-			}
-		},
-		[]
-	);
-
 	const updateSite = useCallback( async ( site: SiteDetails ) => {
 		const updatedSites = await getIpcApi().updateSite( site );
 		setData( updatedSites );
@@ -366,7 +310,6 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 			loadingSites,
 			uploadingSites,
 			setUploadingSites,
-			importFile,
 		} ),
 		[
 			data,
@@ -383,7 +326,6 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 			isDeleting,
 			loadingSites,
 			uploadingSites,
-			importFile,
 		]
 	);
 

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -118,7 +118,7 @@ export async function importSite(
 		const onEvent = ( data: ImportExportEventData ) => {
 			const parentWindow = BrowserWindow.fromWebContents( event.sender );
 			if ( parentWindow && ! parentWindow.isDestroyed() && ! event.sender.isDestroyed() ) {
-				parentWindow.webContents.send( 'on-import', data );
+				parentWindow.webContents.send( 'on-import', data, id );
 			}
 		};
 		const result = await importBackup( backupFile, sitePath, onEvent, defaultImporterOptions );

--- a/src/ipc-types.d.ts
+++ b/src/ipc-types.d.ts
@@ -11,8 +11,6 @@ interface ShowNotificationOptions extends Electron.NotificationConstructorOption
 	showIcon: boolean;
 }
 
-type ImportSiteState = 'importing' | 'imported' | 'new-site-importing' | undefined;
-
 interface StoppedSiteDetails {
 	running: false;
 
@@ -31,7 +29,6 @@ interface StoppedSiteDetails {
 		supportsMenus: boolean;
 	};
 	isAddingSite?: boolean;
-	importState?: ImportSiteState;
 }
 
 interface StartedSiteDetails extends StoppedSiteDetails {

--- a/src/lib/import-export/import/handlers/backup-handler-tar-gz.ts
+++ b/src/lib/import-export/import/handlers/backup-handler-tar-gz.ts
@@ -17,8 +17,15 @@ export class BackupHandlerTarGz extends EventEmitter implements BackupHandler {
 	}
 
 	async extractFiles( file: BackupArchiveInfo, extractionDirectory: string ): Promise< void > {
-		const totalSize = fs.statSync( file.path ).size;
+		let totalSize: number;
 		let processedSize = 0;
+
+		try {
+			totalSize = fs.statSync( file.path ).size;
+		} catch ( error ) {
+			this.emit( ImportEvents.BACKUP_EXTRACT_ERROR, { error } );
+			throw error;
+		}
 
 		return new Promise< void >( ( resolve, reject ) => {
 			this.emit( ImportEvents.BACKUP_EXTRACT_START );

--- a/src/lib/import-export/import/handlers/backup-handler-tar-gz.ts
+++ b/src/lib/import-export/import/handlers/backup-handler-tar-gz.ts
@@ -36,15 +36,15 @@ export class BackupHandlerTarGz extends EventEmitter implements BackupHandler {
 						progress: processedSize / totalSize,
 					} as BackupExtractProgressEventData );
 				} )
+				.on( 'error', ( error ) => {
+					this.emit( ImportEvents.BACKUP_EXTRACT_ERROR, { error } );
+					reject( error );
+				} )
 				.pipe( zlib.createGunzip() )
 				.pipe( tar.extract( { cwd: extractionDirectory } ) )
 				.on( 'finish', () => {
 					this.emit( ImportEvents.BACKUP_EXTRACT_COMPLETE );
 					resolve();
-				} )
-				.on( 'error', ( error ) => {
-					this.emit( ImportEvents.BACKUP_EXTRACT_ERROR, { error } );
-					reject( error );
 				} );
 		} );
 	}

--- a/src/lib/import-export/import/handlers/backup-handler-zip.ts
+++ b/src/lib/import-export/import/handlers/backup-handler-zip.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from 'events';
 import AdmZip from 'adm-zip';
 import { ImportEvents } from '../events';
-import { BackupArchiveInfo } from '../types';
+import { BackupArchiveInfo, BackupExtractProgressEventData } from '../types';
 import { BackupHandler, isFileAllowed } from './backup-handler-factory';
 
 export class BackupHandlerZip extends EventEmitter implements BackupHandler {
@@ -16,13 +16,18 @@ export class BackupHandlerZip extends EventEmitter implements BackupHandler {
 	async extractFiles( file: BackupArchiveInfo, extractionDirectory: string ): Promise< void > {
 		this.emit( ImportEvents.BACKUP_EXTRACT_START );
 		return new Promise( ( resolve, reject ) => {
-			this.emit( ImportEvents.BACKUP_EXTRACT_PROGRESS );
+			this.emit( ImportEvents.BACKUP_EXTRACT_PROGRESS, {
+				progress: 0,
+			} as BackupExtractProgressEventData );
 			const zip = new AdmZip( file.path );
 			zip.extractAllToAsync( extractionDirectory, true, undefined, ( error?: Error ) => {
 				if ( error ) {
 					this.emit( ImportEvents.BACKUP_EXTRACT_ERROR, { error } );
 					reject( error );
 				}
+				this.emit( ImportEvents.BACKUP_EXTRACT_PROGRESS, {
+					progress: 1,
+				} as BackupExtractProgressEventData );
 				this.emit( ImportEvents.BACKUP_EXTRACT_COMPLETE );
 				resolve();
 			} );

--- a/src/lib/import-export/import/importers/importer.ts
+++ b/src/lib/import-export/import/importers/importer.ts
@@ -25,19 +25,24 @@ export class DefaultImporter extends EventEmitter implements Importer {
 	async import( rootPath: string ): Promise< ImporterResult > {
 		this.emit( ImportEvents.IMPORT_START );
 
-		await this.importDatabase();
-		await this.importWpContent( rootPath );
-		let meta: MetaFileData | undefined;
-		if ( this.backup.metaFile ) {
-			meta = await this.parseMetaFile();
+		try {
+			await this.importDatabase();
+			await this.importWpContent( rootPath );
+			let meta: MetaFileData | undefined;
+			if ( this.backup.metaFile ) {
+				meta = await this.parseMetaFile();
+			}
+			this.emit( ImportEvents.IMPORT_COMPLETE );
+			return {
+				extractionDirectory: this.backup.extractionDirectory,
+				sqlFiles: this.backup.sqlFiles,
+				wpContent: this.backup.wpContent,
+				meta,
+			};
+		} catch ( error ) {
+			this.emit( ImportEvents.IMPORT_ERROR );
+			throw error;
 		}
-		this.emit( ImportEvents.IMPORT_COMPLETE );
-		return {
-			extractionDirectory: this.backup.extractionDirectory,
-			sqlFiles: this.backup.sqlFiles,
-			wpContent: this.backup.wpContent,
-			meta,
-		};
 	}
 
 	protected async importDatabase(): Promise< void > {

--- a/src/lib/import-export/import/types.ts
+++ b/src/lib/import-export/import/types.ts
@@ -24,3 +24,7 @@ export interface BackupArchiveInfo {
 }
 
 export type NewImporter = new ( backup: BackupContents ) => Importer;
+
+export interface BackupExtractProgressEventData {
+	progress: number;
+}

--- a/src/lib/import-export/tests/import/handlers/backup-handler.test.ts
+++ b/src/lib/import-export/tests/import/handlers/backup-handler.test.ts
@@ -132,15 +132,17 @@ describe( 'BackupHandlerFactory', () => {
 			const handler = BackupHandlerFactory.create( archiveInfo );
 			const extractionDirectory = '/tmp/extracted';
 
-			( fs.createReadStream as jest.Mock ).mockReturnValue( {
-				pipe: jest.fn().mockReturnThis(),
-				on: jest.fn().mockImplementation( ( event, callback ) => {
+			const createReadStreamMock: unknown = {
+				on: jest.fn( ( event, callback ) => {
 					if ( event === 'finish' ) {
 						callback();
 					}
-					return this;
+					return createReadStreamMock;
 				} ),
-			} );
+				pipe: jest.fn().mockReturnThis(),
+			};
+			( fs.createReadStream as jest.Mock ).mockReturnValue( createReadStreamMock );
+			( fs.statSync as jest.Mock ).mockResolvedValueOnce( 1000 );
 
 			await expect(
 				handler.extractFiles( archiveInfo, extractionDirectory )


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to 8365-gh-Automattic/dotcom-forge.

## Proposed Changes

- Move import state management and `importFile` function to `useImportExport` hook.
- Use `useImportExport` hook in the import section to display the progress of site import.
- Pass progress information within the backup extraction event. Note that for `zip` files the extraction progress won't be reflected because the library `adm-zip` doesn't expose a mechanism to observe progress. We could support it depending on the libraries used after addressing https://github.com/Automattic/dotcom-forge/issues/8329.
- Update site loading indicator to display progress of import.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Preparation:**

- Run the app with command `STUDIO_IMPORT_EXPORT=true npm start`.
- Create a new site.
- Click on the Terminal button in the Overview tab to open a terminal in the site's folder.
- Run command `cd wp-content/uploads`.
- Run command `for i in {1..30}; do mkfile -n 20m temp$i; done` to increase the size of exportation (this is likely to only work when using macOS).
- Navigate to Import/Export tab.
- Click on Export entire site.

### Import succeeds

- Select a site.
- Navigate to Import/Export tab.
- Drag the previous export file into the app to import it.
- Observe a progress bar is shown with the progress of the import process.
- Select another site.
- Import the same file.
- Observe a progress bar is shown with the progress of the import process.
- Switch back and forth between sites and observe the progress for each site.
- When the import completes, observe a notification is displayed.

### Create a site with import succeeds

- Click on Add site.
- Drag the previous export file into "Select or drop a file".
- Click on Add site to create the site.
- Observe the site loading indicator shows a progress bar during site creation.
- Observe that after the site is created and the import starts, the progress bar resets and shows the progress of the import.
- When the import completes, observe a notification is displayed.

### Create the first site with import succeeds

- Remove all sites and reload the app to start on the onboarding screen.
- Drag the previous export file into the onboarding screen.
- Click on Add site.
- Observe the site loading indicator shows a progress bar during site creation.
- Observe that after the site is created and the import starts, the progress bar resets and shows the progress of the import.
- When the import completes, observe a notification is displayed.

### Extraction fails

- Apply the following patch:
```patch
diff --git forkSrcPrefix/src/lib/import-export/import/handlers/backup-handler-tar-gz.ts forkDstPrefix/src/lib/import-export/import/handlers/backup-handler-tar-gz.ts
index efe27ddcc4cd6b7b96363f6fea556e2c6dfc7d1d..1fe61a71ceae5a6b5594f9b6dc944cb7e335db7d 100644
--- forkSrcPrefix/src/lib/import-export/import/handlers/backup-handler-tar-gz.ts
+++ forkDstPrefix/src/lib/import-export/import/handlers/backup-handler-tar-gz.ts
@@ -29,7 +29,7 @@ export class BackupHandlerTarGz extends EventEmitter implements BackupHandler {
 
 		return new Promise< void >( ( resolve, reject ) => {
 			this.emit( ImportEvents.BACKUP_EXTRACT_START );
-			fs.createReadStream( file.path )
+			fs.createReadStream( file.path + '-error' )
 				.on( 'data', ( chunk ) => {
 					processedSize += chunk.length;
 					this.emit( ImportEvents.BACKUP_EXTRACT_PROGRESS, {

```
- Select a site.
- Navigate to the Import/Export tab.
- Drag the previous export file into the app to import it.
- Observe a progress bar is shown with the progress of the import process.
- Observe an error message is displayed.
- Click on the Ok button.
- Observe the progress bar is no longer shown and the import section gets back to its original state.

### Import fails

- Apply the following patch:
```patch
diff --git forkSrcPrefix/src/lib/import-export/import/importers/importer.ts forkDstPrefix/src/lib/import-export/import/importers/importer.ts
index 2aa9eafb7383322336d4f7e4041abaf1e9634331..1e2b2c90882bfb52ca46986d7776f7286766fd5f 100644
--- forkSrcPrefix/src/lib/import-export/import/importers/importer.ts
+++ forkDstPrefix/src/lib/import-export/import/importers/importer.ts
@@ -26,6 +26,7 @@ export class DefaultImporter extends EventEmitter implements Importer {
 		this.emit( ImportEvents.IMPORT_START );
 
 		try {
+			throw new Error( 'test' );
 			await this.importDatabase();
 			await this.importWpContent( rootPath );
 			let meta: MetaFileData | undefined;

```
- Select a site.
- Navigate to the Import/Export tab.
- Drag the previous export file into the app to import it.
- Observe a progress bar is shown with the progress of the import process.
- Observe an error message is displayed.
- Click on the Ok button.
- Observe the progress bar is no longer shown and the import section gets back to its original state.
 
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
