### PR TITLE
Open export file folder at export completion

### DIFF
--- a/src/components/content-tab-import-export.tsx
+++ b/src/components/content-tab-import-export.tsx
@@ -22,6 +22,7 @@ interface ContentTabImportExportProps {
 export const ExportSite = ( { selectedSite }: { selectedSite: SiteDetails } ) => {
 	const { exportState, exportFullSite, exportDatabase } = useImportExport();
 	const { [ selectedSite.id ]: currentProgress } = exportState;
+
 	return (
 		<div className="flex flex-col gap-4">
 			<div>
@@ -37,7 +38,15 @@ export const ExportSite = ( { selectedSite }: { selectedSite: SiteDetails } ) =>
 				</div>
 			) : (
 				<div className="flex flex-row gap-4">
-					<Button onClick={ () => exportFullSite( selectedSite ) } variant="primary">
+					<Button
+						onClick={ async () => {
+							const exportPath = await exportFullSite( selectedSite );
+							if ( exportPath ) {
+								getIpcApi().showItemInFolder( exportPath );
+							}
+						} }
+						variant="primary"
+					>
 						{ __( 'Export entire site' ) }
 					</Button>
 					<Button

--- a/src/hooks/use-import-export.tsx
+++ b/src/hooks/use-import-export.tsx
@@ -18,8 +18,8 @@ type ProgressState = {
 interface ImportExportContext {
 	importState: ProgressState;
 	exportState: ProgressState;
-	exportFullSite: ( selectedSite: SiteDetails ) => Promise< void >;
-	exportDatabase: ( selectedSite: SiteDetails ) => Promise< void >;
+	exportFullSite: ( selectedSite: SiteDetails ) => Promise< string | undefined >;
+	exportDatabase: ( selectedSite: SiteDetails ) => Promise< string | undefined >;
 }
 
 const DEFAULT_STATE = {
@@ -39,7 +39,7 @@ export const ImportExportProvider = ( { children }: { children: React.ReactNode 
 	const [ exportState, setExportState ] = useState< ProgressState >( {} );
 
 	const exportSite = useCallback(
-		async ( selectedSite: SiteDetails, options: ExportOptions ) => {
+		async ( selectedSite: SiteDetails, options: ExportOptions ): Promise< string | undefined > => {
 			if ( exportState[ selectedSite.id ] ) {
 				return;
 			}
@@ -57,6 +57,7 @@ export const ImportExportProvider = ( { children }: { children: React.ReactNode 
 				} );
 				// Delay function resolution to ensure complete export message is displayed
 				await new Promise< void >( ( resolve ) => setTimeout( resolve, 500 ) );
+				return options.backupFile;
 			} catch ( error ) {
 				Sentry.captureException( error );
 				await getIpcApi().showMessageBox( {
@@ -77,7 +78,7 @@ export const ImportExportProvider = ( { children }: { children: React.ReactNode 
 	);
 
 	const exportFullSite = useCallback(
-		async ( selectedSite: SiteDetails ) => {
+		async ( selectedSite: SiteDetails ): Promise< string | undefined > => {
 			const fileName = generateBackupFilename( selectedSite.name );
 			const path = await getIpcApi().showSaveAsDialog( {
 				title: __( 'Save backup file' ),
@@ -108,7 +109,7 @@ export const ImportExportProvider = ( { children }: { children: React.ReactNode 
 	);
 
 	const exportDatabase = useCallback(
-		async ( selectedSite: SiteDetails ) => {
+		async ( selectedSite: SiteDetails ): Promise< string | undefined > => {
 			const fileName = generateBackupFilename( selectedSite.name );
 			const path = await getIpcApi().showSaveAsDialog( {
 				title: __( 'Save database file' ),

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -592,6 +592,10 @@ export async function openLocalPath( _event: IpcMainInvokeEvent, path: string ) 
 	shell.openPath( path );
 }
 
+export async function showItemInFolder( _event: IpcMainInvokeEvent, path: string ) {
+	shell.showItemInFolder( path );
+}
+
 export async function getThemeDetails( event: IpcMainInvokeEvent, id: string ) {
 	const server = SiteServer.get( id );
 	if ( ! server ) {

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -40,6 +40,7 @@ const api: IpcApi = {
 	generateProposedSitePath: ( siteName: string ) =>
 		ipcRenderer.invoke( 'generateProposedSitePath', siteName ),
 	openLocalPath: ( path: string ) => ipcRenderer.invoke( 'openLocalPath', path ),
+	showItemInFolder: ( path: string ) => ipcRenderer.invoke( 'showItemInFolder', path ),
 	getThemeDetails: ( id: string ) => ipcRenderer.invoke( 'getThemeDetails', id ),
 	getThumbnailData: ( id: string ) => ipcRenderer.invoke( 'getThumbnailData', id ),
 	getInstalledApps: () => ipcRenderer.invoke( 'getInstalledApps' ),


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to 8365-gh-dotcom-forge/issues.

## Proposed Changes

- Add an IPC handler to show an item in the folder.
- Return export path in export functions.
- When the export completes, open the folder and select the export file.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run the app with command `STUDIO_IMPORT_EXPORT=true npm start`.
- Select a site.
- Navigate to the Import/Export tab.
- Export a site.
- Observe that when the export succeeds, the app opens the folder of the export file and selects it.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
