### PR TITLE
Studio: handle the case of the blocked user in the user settings modal

### DIFF
--- a/src/components/user-settings.tsx
+++ b/src/components/user-settings.tsx
@@ -79,7 +79,7 @@ const SnapshotInfo = ( {
 			<div className="flex gap-3 flex-row items-center w-full">
 				{ snapshotCreationBlocked ? (
 					<div className="text-a8c-gray-70">
-						{ __( 'Demo sites are not available for your account' ) }
+						{ __( 'Demo sites are not available for your account.' ) }
 					</div>
 				) : (
 					<>

--- a/src/components/user-settings.tsx
+++ b/src/components/user-settings.tsx
@@ -74,11 +74,11 @@ const SnapshotInfo = ( {
 	const isOffline = useOffline();
 	const offlineMessage = __( 'Deleting demo sites requires an internet connection.' );
 	return (
-		<div className="flex gap-3 flex-col">
+		<div className={ cx( 'flex flex-col', ! snapshotCreationBlocked && 'gap-3' ) }>
 			<h2 className="a8c-label-semibold">{ __( 'Demo sites' ) }</h2>
 			<div className="flex gap-3 flex-row items-center w-full">
 				{ snapshotCreationBlocked ? (
-					<div className="text-a8c-gray-70">
+					<div className="text-[#757575]">
 						{ __( 'Demo sites are not available for your account.' ) }
 					</div>
 				) : (

--- a/src/components/user-settings.tsx
+++ b/src/components/user-settings.tsx
@@ -64,6 +64,8 @@ const SnapshotInfo = ( {
 	isDeleting?: boolean;
 } ) => {
 	const { __ } = useI18n();
+
+	const { snapshotCreationBlocked } = useSnapshots();
 	const menuItemStyles = cx(
 		'[&_span]:min-w-0 [&_span]:p-[1px]',
 		isDisabled &&
@@ -75,69 +77,76 @@ const SnapshotInfo = ( {
 		<div className="flex gap-3 flex-col">
 			<h2 className="a8c-label-semibold">{ __( 'Demo sites' ) }</h2>
 			<div className="flex gap-3 flex-row items-center w-full">
-				<div className="flex w-full flex-col gap-2">
-					<div className="flex w-full flex-row justify-between gap-8 ">
-						<div className="flex flex-row items-center text-right">
-							{ isDeleting && <Spinner className="!mt-0 !mx-2" /> }
-							<span className="text-a8c-gray-70">
-								{ sprintf( __( '%1s of %2s active demo sites' ), siteCount, siteLimit ) }
-							</span>
-						</div>
+				{ snapshotCreationBlocked ? (
+					<div className="text-a8c-gray-70">
+						{ __( 'Demo sites are not available for your account' ) }
 					</div>
-					<ProgressBar value={ siteCount } maxValue={ siteLimit } />
-				</div>
-				<DropdownMenu
-					className={
-						'ml-auto flex items-center [&_button:first-child]:p-0 [&_button:first-child]:min-w-6 [&_button:first-child]:h-6'
-					}
-					popoverProps={ { position: 'bottom left', resize: true } }
-					icon={ <Icon icon={ moreVertical }></Icon> }
-					size={ 24 }
-					label={ __( 'More options' ) }
-				>
-					{ ( { onClose }: { onClose: () => void } ) => {
-						return (
-							<MenuGroup>
-								<Tooltip
-									disabled={ ! isOffline }
-									icon={ offlineIcon }
-									text={ offlineMessage }
-									placement="bottom"
-								>
-									<MenuItem
-										aria-description={ isOffline ? offlineMessage : '' }
-										/**
-										 * Because there is a single menu item, the `aria-disabled`
-										 * attribute is used rather than `disabled` so that screen
-										 * readers can focus the item to announce its disabled state.
-										 * Otherwise, dropdown toggle would toggle an empty menu.
-										 */
-										aria-disabled={ isDisabled }
-										icon={ trash }
-										iconPosition="left"
-										isDestructive
-										className={ menuItemStyles }
-										onClick={ () => {
-											if ( isDisabled ) {
-												return;
-											}
+				) : (
+					<>
+						<div className="flex w-full flex-col gap-2">
+							<div className="flex w-full flex-row justify-between gap-8">
+								<div className="flex flex-row items-center text-right">
+									{ isDeleting && <Spinner className="!mt-0 !mx-2" /> }
+									<span className="text-a8c-gray-70">
+										{ sprintf( __( '%1s of %2s active demo sites' ), siteCount, siteLimit ) }
+									</span>
+								</div>
+							</div>
+							<ProgressBar value={ siteCount } maxValue={ siteLimit } />
+						</div>
+						<DropdownMenu
+							className={
+								'ml-auto flex items-center [&_button:first-child]:p-0 [&_button:first-child]:min-w-6 [&_button:first-child]:h-6'
+							}
+							popoverProps={ { position: 'bottom left', resize: true } }
+							icon={ <Icon icon={ moreVertical }></Icon> }
+							size={ 24 }
+							label={ __( 'More options' ) }
+						>
+							{ ( { onClose }: { onClose: () => void } ) => {
+								return (
+									<MenuGroup>
+										<Tooltip
+											disabled={ ! isOffline }
+											icon={ offlineIcon }
+											text={ offlineMessage }
+											placement="bottom"
+										>
+											<MenuItem
+												aria-description={ isOffline ? offlineMessage : '' }
+												/**
+												 * Because there is a single menu item, the `aria-disabled`
+												 * attribute is used rather than `disabled` so that screen
+												 * readers can focus the item to announce its disabled state.
+												 * Otherwise, dropdown toggle would toggle an empty menu.
+												 */
+												aria-disabled={ isDisabled }
+												icon={ trash }
+												iconPosition="left"
+												isDestructive
+												className={ menuItemStyles }
+												onClick={ () => {
+													if ( isDisabled ) {
+														return;
+													}
 
-											onRemoveSnapshots();
-											onClose();
-										} }
-									>
-										{ __( 'Delete all demo sites' ) }
-									</MenuItem>
-								</Tooltip>
-							</MenuGroup>
-						);
-					} }
-				</DropdownMenu>
+													onRemoveSnapshots();
+													onClose();
+												} }
+											>
+												{ __( 'Delete all demo sites' ) }
+											</MenuItem>
+										</Tooltip>
+									</MenuGroup>
+								);
+							} }
+						</DropdownMenu>
+					</>
+				) }
 			</div>
 		</div>
 	);
 };
-
 function PromptInfo() {
 	const { __ } = useI18n();
 	const { promptCount = 0, promptLimit = LIMIT_OF_PROMPTS_PER_USER } = usePromptUsage();

--- a/src/components/user-settings.tsx
+++ b/src/components/user-settings.tsx
@@ -78,7 +78,7 @@ const SnapshotInfo = ( {
 			<h2 className="a8c-label-semibold">{ __( 'Demo sites' ) }</h2>
 			<div className="flex gap-3 flex-row items-center w-full">
 				{ snapshotCreationBlocked ? (
-					<div className="text-[#757575]">
+					<div className="text-a8c-gray-70">
 						{ __( 'Demo sites are not available for your account.' ) }
 					</div>
 				) : (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/8464

## Proposed Changes

This PR adds a UI to the `User Settings` for the case when the user is blocked. RToz6tIuQ7nlZrikBte4GU-fi-4061_331330

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to the User Report Card for your own user
* Use the `Disable site creation` button (at the bottom of the User Report Card) to block your user from creating demo sites
* Pull the changes from this branch
* Start the app with `nvm use && npm install && npm start`
* Make sure to log in with the user that you just blocked from creating sites
* Click on the user settings in the bottom left corner
* Confirm that you see the message that your account is not allowed to create demo sites:

<img width="425" alt="Screenshot 2024-08-01 at 2 35 25 PM" src="https://github.com/user-attachments/assets/736e8772-5600-46ba-af52-9bb4c7da083c">

* Navigate to the User Report Card for your own user
* Use the `Enable site creation` button
* Restart the app
* Open the user settings
* Confirm that you can see the count for the demo sites

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?