### PR TITLE
Improve logic for checking valid exporters

### DIFF
--- a/src/lib/import-export/export/export-manager.ts
+++ b/src/lib/import-export/export/export-manager.ts
@@ -18,6 +18,9 @@ export async function exportBackup(
 				removeExportListeners();
 			}
 			break;
+		} else {
+			onEvent( { event: ExportEvents.EXPORT_ERROR, data: null } );
+			throw new Error( 'No suitable exporter found for the site' );
 		}
 	}
 }

--- a/src/lib/import-export/export/exporters/default-exporter.ts
+++ b/src/lib/import-export/export/exporters/default-exporter.ts
@@ -45,12 +45,22 @@ export class DefaultExporter extends EventEmitter implements Exporter {
 			return false;
 		}
 
-		const requiredPaths = [ 'wp-content', 'wp-includes', 'wp-load.php', 'wp-config.php' ];
+		const requiredPaths = [
+			{ path: 'wp-content', isDir: true },
+			{ path: 'wp-includes', isDir: true },
+			{ path: 'wp-load.php', isDir: false },
+			{ path: 'wp-config.php', isDir: false },
+		];
 
 		this.siteFiles = await this.getSiteFiles();
 
 		return requiredPaths.every( ( requiredPath ) =>
-			this.siteFiles.some( ( file ) => file.includes( requiredPath ) )
+			this.siteFiles.some( ( file ) => {
+				const relativePath = path.relative( this.options.site.path, file );
+				return requiredPath.isDir
+					? relativePath.startsWith( requiredPath.path )
+					: relativePath === requiredPath.path;
+			} )
 		);
 	}
 

--- a/src/lib/import-export/tests/export/export-manager.test.ts
+++ b/src/lib/import-export/tests/export/export-manager.test.ts
@@ -60,4 +60,32 @@ describe( 'exportBackup', () => {
 		expect( MockExporter2 ).toHaveBeenCalledWith( mockExportOptions );
 		expect( ExportMethod2 ).toHaveBeenCalled();
 	} );
+
+	it( 'fails if no exporter is found', async () => {
+		const ExportMethod1 = jest.fn();
+		const MockExporter1 = jest.fn( () => ( {
+			canHandle: jest.fn().mockResolvedValue( false ),
+			export: ExportMethod1,
+			on: jest.fn(),
+			emit: jest.fn(),
+		} ) );
+
+		const ExportMethod2 = jest.fn();
+		const MockExporter2 = jest.fn( () => ( {
+			canHandle: jest.fn().mockResolvedValue( false ),
+			export: ExportMethod2,
+			on: jest.fn(),
+			emit: jest.fn(),
+		} ) );
+
+		const exporters: NewExporter[] = [ MockExporter1, MockExporter2 ];
+		await expect( exportBackup( mockExportOptions, jest.fn(), exporters ) ).rejects.toThrow(
+			'No suitable exporter found for the site'
+		);
+
+		expect( MockExporter1 ).toHaveBeenCalledWith( mockExportOptions );
+		expect( ExportMethod1 ).not.toHaveBeenCalled();
+		expect( MockExporter2 ).toHaveBeenCalledWith( mockExportOptions );
+		expect( ExportMethod2 ).not.toHaveBeenCalled();
+	} );
 } );

--- a/src/lib/import-export/tests/export/exporters/default-exporter.test.ts
+++ b/src/lib/import-export/tests/export/exporters/default-exporter.test.ts
@@ -53,7 +53,7 @@ describe( 'DefaultExporter', () => {
 		{ path: '/path/to/site/wp-content/plugins/plugin1', name: 'plugin1.php', isFile: () => true },
 		{ path: '/path/to/site/wp-content/themes/theme1', name: 'index.php', isFile: () => true },
 		{ path: '/path/to/site/wp-includes/index.php', name: 'index.php', isFile: () => true },
-		{ path: '/path/to/site/wp-load.php', name: 'wp-load.php', isFile: () => true },
+		{ path: '/path/to/site', name: 'wp-load.php', isFile: () => true },
 	];
 
 	( fsPromises.readdir as jest.Mock ).mockResolvedValue( mockFiles );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to 8409-gh-Automattic/dotcom-forge.

## Proposed Changes

- Update the logic to determine a valid export. Specifically, the matching of required paths, which we weren't checking full paths for files (e.g. `wp-config.php`).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run the app with the command `STUDIO_IMPORT_EXPORT=true npm start`.
- Select a site/Create a site.
- Navigate to the Import/Export tab.
- Click on Export entire site.
- Observe the export process succeeds.
- Open the site's folder via the Finder button located in the Overview tab.
- Remove the file `wp-config.php`.
- Click again on Export entire site.
- Observe that the export process fails and that an error message is shown.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
