### PR TITLE
Support default full path and filename options for save dialog

### DIFF
--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -314,8 +314,12 @@ export async function showSaveAsDialog( event: IpcMainInvokeEvent, options: Save
 		throw new Error( `No window found for sender of showSaveAsDialog message: ${ event.frameId }` );
 	}
 
+	const defaultPath =
+		options.defaultPath === nodePath.basename( options.defaultPath ?? '' )
+			? nodePath.join( DEFAULT_SITE_PATH, options.defaultPath )
+			: options.defaultPath;
 	const { canceled, filePath } = await dialog.showSaveDialog( parentWindow, {
-		defaultPath: `${ DEFAULT_SITE_PATH }/${ options.defaultPath }`,
+		defaultPath,
 		...options,
 	} );
 	if ( canceled ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to 8409-gh-Automattic/dotcom-forge.

## Proposed Changes

- As mentioned in https://github.com/Automattic/studio/pull/365/files#r1686166080, update the logic to determined the default path of the save dialog to support both full paths and filename options.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run the app with the command `STUDIO_IMPORT_EXPORT=true npm start`.
- Select a site/Create a site.
- Navigate to the Import/Export tab.
- Click on Export entire site.
- Observe that the save dialog populates the filename with the expected value.
- Observe the export process succeeds.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
