### PR TITLE
Open find with SQL file selected on export database

### DIFF
--- a/src/components/content-tab-import-export.tsx
+++ b/src/components/content-tab-import-export.tsx
@@ -23,6 +23,13 @@ export const ExportSite = ( { selectedSite }: { selectedSite: SiteDetails } ) =>
 	const { exportState, exportFullSite, exportDatabase } = useImportExport();
 	const { [ selectedSite.id ]: currentProgress } = exportState;
 
+	const handleExport = async ( exportFunction: typeof exportFullSite | typeof exportDatabase ) => {
+		const exportPath = await exportFunction( selectedSite );
+		if ( exportPath ) {
+			getIpcApi().showItemInFolder( exportPath );
+		}
+	};
+
 	return (
 		<div className="flex flex-col gap-4">
 			<div>
@@ -38,24 +45,11 @@ export const ExportSite = ( { selectedSite }: { selectedSite: SiteDetails } ) =>
 				</div>
 			) : (
 				<div className="flex flex-row gap-4">
-					<Button
-						onClick={ async () => {
-							const exportPath = await exportFullSite( selectedSite );
-							if ( exportPath ) {
-								getIpcApi().showItemInFolder( exportPath );
-							}
-						} }
-						variant="primary"
-					>
+					<Button onClick={ () => handleExport( exportFullSite ) } variant="primary">
 						{ __( 'Export entire site' ) }
 					</Button>
 					<Button
-						onClick={ async () => {
-							const exportPath = await exportDatabase( selectedSite );
-							if ( exportPath ) {
-								getIpcApi().showItemInFolder( exportPath );
-							}
-						} }
+						onClick={ () => handleExport( exportDatabase ) }
 						type="submit"
 						variant="secondary"
 						className="!text-a8c-blueberry !shadow-a8c-blueberry"

--- a/src/components/content-tab-import-export.tsx
+++ b/src/components/content-tab-import-export.tsx
@@ -50,7 +50,12 @@ export const ExportSite = ( { selectedSite }: { selectedSite: SiteDetails } ) =>
 						{ __( 'Export entire site' ) }
 					</Button>
 					<Button
-						onClick={ () => exportDatabase( selectedSite ) }
+						onClick={ async () => {
+							const exportPath = await exportDatabase( selectedSite );
+							if ( exportPath ) {
+								getIpcApi().showItemInFolder( exportPath );
+							}
+						} }
 						type="submit"
 						variant="secondary"
 						className="!text-a8c-blueberry !shadow-a8c-blueberry"


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

- Related: https://github.com/automattic/dotcom-forge/issues/8365
- Follow up: https://github.com/Automattic/studio/pull/406

## Proposed Changes

- In addition of opening the Finder when we export the full site, let's also open it when we export only the database.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run the app with command `STUDIO_IMPORT_EXPORT=true npm start`.
- Select a site.
- Open the Import/Export tab.
- Export a database
- Observe the finder opens with the exported file selected.
- Try Export entire site
- Observe the finder opens with the zip file selected.


https://github.com/user-attachments/assets/219004fa-9cf5-4450-8bd3-a8d2fac09840



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?