### PR TITLE
Studio: Remove unnecessary media query from add site modal

### DIFF
--- a/src/components/add-site.tsx
+++ b/src/components/add-site.tsx
@@ -145,7 +145,7 @@ export default function AddSite( { className }: AddSiteProps ) {
 						isDismissible
 						focusOnMount="firstContentElement"
 						onRequestClose={ closeModal }
-						className="max-h-[90%] md:max-h-[90%]"
+						className="max-h-[90%]"
 					>
 						<div ref={ dropRef }>
 							{ isDraggingOver && <DragAndDropOverlay /> }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to https://github.com/Automattic/studio/pull/402#discussion_r1700331667

## Proposed Changes

This PR removed unnecessary media query from the add site modal for removing the scollbar.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
* Start the app with `STUDIO_IMPORT_EXPORT=true npm start`
* Resize the app window to the minimum size 
* Click on the `Add site` button in the left sidebar
* Open the modal for adding a site
* Click on `Advanced settings` 
* Observe that the `Advanced settings` open but no scrollbar appears

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
