### PR TITLE
Studio: Disable site export button when import is in progress 

### DIFF
--- a/src/components/content-tab-import-export.tsx
+++ b/src/components/content-tab-import-export.tsx
@@ -14,6 +14,7 @@ import { cx } from '../lib/cx';
 import { getIpcApi } from '../lib/get-ipc-api';
 import Button from './button';
 import ProgressBar, { ProgressBarWithAutoIncrement } from './progress-bar';
+import Tooltip from './tooltip';
 
 interface ContentTabImportExportProps {
 	selectedSite: SiteDetails;
@@ -22,6 +23,10 @@ interface ContentTabImportExportProps {
 export const ExportSite = ( { selectedSite }: { selectedSite: SiteDetails } ) => {
 	const { exportState, exportFullSite, exportDatabase } = useImportExport();
 	const { [ selectedSite.id ]: currentProgress } = exportState;
+	const isSiteImporting = selectedSite?.importState === 'importing';
+	const importProgressMessage = __(
+		'This site is being imported. Please wait for the import to finish.'
+	);
 
 	return (
 		<div className="flex flex-col gap-4">
@@ -38,25 +43,31 @@ export const ExportSite = ( { selectedSite }: { selectedSite: SiteDetails } ) =>
 				</div>
 			) : (
 				<div className="flex flex-row gap-4">
-					<Button
-						onClick={ async () => {
-							const exportPath = await exportFullSite( selectedSite );
-							if ( exportPath ) {
-								getIpcApi().showItemInFolder( exportPath );
-							}
-						} }
-						variant="primary"
-					>
-						{ __( 'Export entire site' ) }
-					</Button>
-					<Button
-						onClick={ () => exportDatabase( selectedSite ) }
-						type="submit"
-						variant="secondary"
-						className="!text-a8c-blueberry !shadow-a8c-blueberry"
-					>
-						{ __( 'Export database' ) }
-					</Button>
+					<Tooltip text={ importProgressMessage } disabled={ ! isSiteImporting }>
+						<Button
+							onClick={ async () => {
+								const exportPath = await exportFullSite( selectedSite );
+								if ( exportPath ) {
+									getIpcApi().showItemInFolder( exportPath );
+								}
+							} }
+							variant="primary"
+							disabled={ isSiteImporting }
+						>
+							{ __( 'Export entire site' ) }
+						</Button>
+					</Tooltip>
+					<Tooltip text={ importProgressMessage } disabled={ ! isSiteImporting }>
+						<Button
+							onClick={ () => exportDatabase( selectedSite ) }
+							type="submit"
+							variant="secondary"
+							className="!text-a8c-blueberry !shadow-a8c-blueberry"
+							disabled={ isSiteImporting }
+						>
+							{ __( 'Export database' ) }
+						</Button>
+					</Tooltip>
 				</div>
 			) }
 		</div>

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -113,7 +113,6 @@ export async function importSite(
 	if ( ! site ) {
 		throw new Error( 'Site not found.' );
 	}
-	const sitePath = site.details.path;
 	try {
 		const onEvent = ( data: ImportExportEventData ) => {
 			const parentWindow = BrowserWindow.fromWebContents( event.sender );
@@ -121,7 +120,7 @@ export async function importSite(
 				parentWindow.webContents.send( 'on-import', data );
 			}
 		};
-		const result = await importBackup( backupFile, sitePath, onEvent, defaultImporterOptions );
+		const result = await importBackup( backupFile, site.details, onEvent, defaultImporterOptions );
 		if ( result?.meta?.phpVersion ) {
 			await updateSite( event, {
 				...site.details,

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -648,7 +648,11 @@ export async function executeWPCLiInline(
 	{ siteId, args }: { siteId: string; args: string }
 ): Promise< WpCliResult > {
 	if ( SiteServer.isDeleted( siteId ) ) {
-		return { stdout: '', stderr: `Cannot execute command on deleted site ${ siteId }` };
+		return {
+			stdout: '',
+			stderr: `Cannot execute command on deleted site ${ siteId }`,
+			exitCode: 1,
+		};
 	}
 	const server = SiteServer.get( siteId );
 	if ( ! server ) {

--- a/src/lib/import-export/import/import-manager.ts
+++ b/src/lib/import-export/import/import-manager.ts
@@ -33,7 +33,7 @@ export function selectImporter(
 
 export async function importBackup(
 	backupFile: BackupArchiveInfo,
-	sitePath: string,
+	site: SiteDetails,
 	onEvent: ( data: ImportExportEventData ) => void,
 	options: ImporterOption[]
 ): Promise< ImporterResult > {
@@ -49,7 +49,7 @@ export async function importBackup(
 			removeBackupListeners = handleEvents( backupHandler, onEvent, BackupExtractEvents );
 			removeImportListeners = handleEvents( importer, onEvent, ImporterEvents );
 			await backupHandler.extractFiles( backupFile, extractionDirectory );
-			return await importer.import( sitePath );
+			return await importer.import( site.path, site.id );
 		} else {
 			throw new Error( 'No suitable importer found for the given backup file' );
 		}

--- a/src/lib/import-export/import/importers/importer.ts
+++ b/src/lib/import-export/import/importers/importer.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from 'events';
 import fsPromises from 'fs/promises';
 import path from 'path';
-import { rename } from 'fs-extra';
+import { lstat, rename } from 'fs-extra';
 import { SiteServer } from '../../../../site-server';
 import { generateBackupFilename } from '../../export/generate-backup-filename';
 import { ImportEvents } from '../events';
@@ -60,7 +60,6 @@ export class DefaultImporter extends EventEmitter implements Importer {
 		}
 
 		this.emit( ImportEvents.IMPORT_DATABASE_START );
-
 		const sortedSqlFiles = [ ...this.backup.sqlFiles ].sort( ( a, b ) => a.localeCompare( b ) );
 		for ( const sqlFile of sortedSqlFiles ) {
 			const sqlTempFile = `${ generateBackupFilename( 'sql' ) }.sql`;
@@ -91,7 +90,6 @@ export class DefaultImporter extends EventEmitter implements Importer {
 				}
 			}
 		}
-
 		this.emit( ImportEvents.IMPORT_DATABASE_COMPLETE );
 	}
 
@@ -102,6 +100,11 @@ export class DefaultImporter extends EventEmitter implements Importer {
 		const wpContentDir = path.join( rootPath, 'wp-content' );
 		for ( const files of Object.values( wpContent ) ) {
 			for ( const file of files ) {
+				const stats = await lstat( file );
+				// Skip if it's a directory
+				if ( stats.isDirectory() ) {
+					continue;
+				}
 				const relativePath = path.relative( path.join( extractionDirectory, 'wp-content' ), file );
 				const destPath = path.join( wpContentDir, relativePath );
 				await fsPromises.mkdir( path.dirname( destPath ), { recursive: true } );

--- a/src/lib/import-export/import/importers/importer.ts
+++ b/src/lib/import-export/import/importers/importer.ts
@@ -65,8 +65,10 @@ export class DefaultImporter extends EventEmitter implements Importer {
 			const tmpPath = path.join( rootPath, sqlTempFile );
 			await rename( sqlFile, tmpPath );
 			// Execute the command to export directly to the temp file
-			const { stderr } = await server.executeWpCliCommand( `db import ${ sqlTempFile }` );
-			if ( stderr ) {
+			const { stderr, exitCode } = await server.executeWpCliCommand( `db import ${ sqlTempFile }` );
+			console.error( stderr );
+
+			if ( exitCode ) {
 				throw new Error( 'Database import failed' );
 			}
 			await fsPromises.unlink( tmpPath );

--- a/src/lib/import-export/import/importers/importer.ts
+++ b/src/lib/import-export/import/importers/importer.ts
@@ -60,18 +60,36 @@ export class DefaultImporter extends EventEmitter implements Importer {
 		}
 
 		this.emit( ImportEvents.IMPORT_DATABASE_START );
-		for ( const sqlFile of this.backup.sqlFiles ) {
+
+		const sortedSqlFiles = [ ...this.backup.sqlFiles ].sort( ( a, b ) => a.localeCompare( b ) );
+		for ( const sqlFile of sortedSqlFiles ) {
 			const sqlTempFile = `${ generateBackupFilename( 'sql' ) }.sql`;
 			const tmpPath = path.join( rootPath, sqlTempFile );
-			await rename( sqlFile, tmpPath );
-			// Execute the command to export directly to the temp file
-			const { stderr, exitCode } = await server.executeWpCliCommand( `db import ${ sqlTempFile }` );
-			console.error( stderr );
 
-			if ( exitCode ) {
-				throw new Error( 'Database import failed' );
+			try {
+				await rename( sqlFile, tmpPath );
+				// Execute the command to export directly to the temp file
+				const { stderr, exitCode } = await server.executeWpCliCommand(
+					`db import ${ sqlTempFile }`
+				);
+
+				if ( stderr ) {
+					console.error( `Warning during import of ${ sqlFile }:`, stderr );
+				}
+
+				if ( exitCode ) {
+					throw new Error( 'Database import failed' );
+				}
+			} catch ( error ) {
+				console.error( `Error processing ${ sqlFile }:`, error );
+				throw error;
+			} finally {
+				try {
+					await fsPromises.unlink( tmpPath );
+				} catch ( unlinkError ) {
+					console.error( `Failed to delete temporary file ${ tmpPath }:`, unlinkError );
+				}
 			}
-			await fsPromises.unlink( tmpPath );
 		}
 
 		this.emit( ImportEvents.IMPORT_DATABASE_COMPLETE );

--- a/src/lib/import-export/tests/import/import-manager.test.ts
+++ b/src/lib/import-export/tests/import/import-manager.test.ts
@@ -119,7 +119,7 @@ describe( 'importManager', () => {
 			expect( fsPromises.mkdtemp ).toHaveBeenCalledWith( '/tmp/studio_backup' );
 			expect( mockBackupHandler.listFiles ).toHaveBeenCalledWith( mockFile );
 			expect( mockBackupHandler.extractFiles ).toHaveBeenCalledWith( mockFile, mockExtractDir );
-			expect( mockImporter.import ).toHaveBeenCalledWith( mockSite.path );
+			expect( mockImporter.import ).toHaveBeenCalledWith( mockSite.path, mockSite.id );
 			expect( fsPromises.rm ).toHaveBeenCalledWith( mockExtractDir, {
 				recursive: true,
 			} );

--- a/src/lib/import-export/tests/import/import-manager.test.ts
+++ b/src/lib/import-export/tests/import/import-manager.test.ts
@@ -73,7 +73,14 @@ describe( 'importManager', () => {
 			path: '/path/to/backup.tar.gz',
 			type: 'application/gzip',
 		};
-		const mockSitePath = '/path/to/site';
+		const mockSite: SiteDetails = {
+			id: '123',
+			name: 'Site Name',
+			path: '/path/to/site',
+			phpVersion: '7.4',
+			running: false,
+		};
+
 		const mockExtractDir = '/tmp/studio_backup_123456';
 
 		beforeEach( () => {
@@ -107,12 +114,12 @@ describe( 'importManager', () => {
 					importer: MockImporterClass,
 				},
 			];
-			await importBackup( mockFile, mockSitePath, jest.fn(), options );
+			await importBackup( mockFile, mockSite, jest.fn(), options );
 
 			expect( fsPromises.mkdtemp ).toHaveBeenCalledWith( '/tmp/studio_backup' );
 			expect( mockBackupHandler.listFiles ).toHaveBeenCalledWith( mockFile );
 			expect( mockBackupHandler.extractFiles ).toHaveBeenCalledWith( mockFile, mockExtractDir );
-			expect( mockImporter.import ).toHaveBeenCalledWith( mockSitePath );
+			expect( mockImporter.import ).toHaveBeenCalledWith( mockSite.path );
 			expect( fsPromises.rm ).toHaveBeenCalledWith( mockExtractDir, {
 				recursive: true,
 			} );
@@ -130,7 +137,7 @@ describe( 'importManager', () => {
 			( BackupHandlerFactory.create as jest.Mock ).mockReturnValue( mockBackupHandler );
 
 			await expect(
-				importBackup( mockFile, mockSitePath, jest.fn(), [
+				importBackup( mockFile, mockSite, jest.fn(), [
 					{
 						validator: mockValidator,
 						importer: jest.fn(),

--- a/src/lib/import-export/tests/import/importer/default-importer.test.ts
+++ b/src/lib/import-export/tests/import/importer/default-importer.test.ts
@@ -1,6 +1,6 @@
 // To run tests, execute `npm run test -- src/lib/import-export/tests/import/importer/jetpack-importer.test.ts`
 import * as fs from 'fs/promises';
-import { rename } from 'fs-extra';
+import { lstat, rename } from 'fs-extra';
 import { SiteServer } from '../../../../../site-server';
 import { DefaultImporter } from '../../../import/importers';
 import { BackupContents } from '../../../import/types';
@@ -37,6 +37,10 @@ describe( 'JetpackImporter', () => {
 
 		jest.useFakeTimers();
 		jest.setSystemTime( new Date( '2024-08-01T12:00:00Z' ) );
+
+		( lstat as jest.Mock ).mockResolvedValue( {
+			isDirectory: jest.fn().mockReturnValue( false ),
+		} );
 	} );
 
 	afterAll( () => {

--- a/src/lib/import-export/tests/import/importer/default-importer.test.ts
+++ b/src/lib/import-export/tests/import/importer/default-importer.test.ts
@@ -18,6 +18,7 @@ describe( 'JetpackImporter', () => {
 	};
 
 	const mockStudioSitePath = '/path/to/studio/site';
+	const mockStudioSiteId = '123';
 
 	beforeEach( () => {
 		jest.clearAllMocks();
@@ -35,7 +36,7 @@ describe( 'JetpackImporter', () => {
 				} )
 			);
 
-			await importer.import( mockStudioSitePath );
+			await importer.import( mockStudioSitePath, mockStudioSiteId );
 
 			expect( fs.mkdir ).toHaveBeenCalled();
 			expect( fs.copyFile ).toHaveBeenCalledTimes( 3 ); // One for each wp-content file
@@ -47,7 +48,7 @@ describe( 'JetpackImporter', () => {
 			( fs.mkdir as jest.Mock ).mockResolvedValue( undefined );
 			( fs.copyFile as jest.Mock ).mockResolvedValue( undefined );
 
-			await importer.import( mockStudioSitePath );
+			await importer.import( mockStudioSitePath, mockStudioSiteId );
 
 			expect( fs.mkdir ).toHaveBeenCalled();
 			expect( fs.copyFile ).toHaveBeenCalledTimes( 3 );
@@ -60,7 +61,9 @@ describe( 'JetpackImporter', () => {
 			( fs.copyFile as jest.Mock ).mockResolvedValue( undefined );
 			( fs.readFile as jest.Mock ).mockResolvedValue( 'Invalid JSON' );
 
-			await expect( importer.import( mockStudioSitePath ) ).resolves.not.toThrow();
+			await expect(
+				importer.import( mockStudioSitePath, mockStudioSiteId )
+			).resolves.not.toThrow();
 
 			expect( fs.mkdir ).toHaveBeenCalled();
 			expect( fs.copyFile ).toHaveBeenCalledTimes( 3 );

--- a/src/lib/wpcli-versions.ts
+++ b/src/lib/wpcli-versions.ts
@@ -5,7 +5,6 @@ import { executeWPCli } from '../../vendor/wp-now/src/execute-wp-cli';
 import getWpCliPath from '../../vendor/wp-now/src/get-wp-cli-path';
 
 export async function updateLatestWPCliVersion() {
-	return;
 	let shouldOverwrite = false;
 	const pathExist = await fs.pathExists( getWpCliPath() );
 	if ( pathExist ) {

--- a/src/lib/wpcli-versions.ts
+++ b/src/lib/wpcli-versions.ts
@@ -5,6 +5,7 @@ import { executeWPCli } from '../../vendor/wp-now/src/execute-wp-cli';
 import getWpCliPath from '../../vendor/wp-now/src/get-wp-cli-path';
 
 export async function updateLatestWPCliVersion() {
+	return;
 	let shouldOverwrite = false;
 	const pathExist = await fs.pathExists( getWpCliPath() );
 	if ( pathExist ) {

--- a/src/site-server.ts
+++ b/src/site-server.ts
@@ -182,11 +182,11 @@ export class SiteServer {
 			return await this.wpCliExecutor.execute( wpCliArgs as string[] );
 		} catch ( error ) {
 			if ( ( error as MessageCanceled )?.canceled ) {
-				return { stdout: '', stderr: 'wp-cli command canceled' };
+				return { stdout: '', stderr: 'wp-cli command canceled', exitCode: 1 };
 			}
 
 			Sentry.captureException( error );
-			return { stdout: '', stderr: 'error when executing wp-cli command' };
+			return { stdout: '', stderr: 'error when executing wp-cli command', exitCode: 1 };
 		}
 	}
 }

--- a/vendor/wp-now/src/execute-wp-cli.ts
+++ b/vendor/wp-now/src/execute-wp-cli.ts
@@ -74,15 +74,15 @@ export async function executeWPCli( projectPath: string, args: string[] ): Promi
 	// Set site's folder as the current working directory as the terminal will opened in that location.
 	php.chdir(options.documentRoot);
 
-	const stderr = php.readFileAsText(stderrPath).replace('PHP.run() output was: #!/usr/bin/env php', '').trim();
-
 	try {
 		const result = await php.run({
 			scriptPath: runCliPath,
 		});
 
+		const stderr = php.readFileAsText(stderrPath).replace('PHP.run() output was: #!/usr/bin/env php', '').trim();
+
 		return { stdout: result.text.replace('#!/usr/bin/env php', '').trim(), stderr, exitCode: result.exitCode };
 	} catch (error) {
-		return { stdout: '', stderr, exitCode: 1 };
+		return { stdout: '', stderr: error.stderr, exitCode: 1 };
 	}
 }

--- a/vendor/wp-now/src/execute-wp-cli.ts
+++ b/vendor/wp-now/src/execute-wp-cli.ts
@@ -83,6 +83,7 @@ export async function executeWPCli( projectPath: string, args: string[] ): Promi
 
 		return { stdout: result.text.replace('#!/usr/bin/env php', '').trim(), stderr, exitCode: result.exitCode };
 	} catch (error) {
-		return { stdout: '', stderr: error.stderr, exitCode: 1 };
+		const stderr = php.readFileAsText(stderrPath).replace('PHP.run() output was: #!/usr/bin/env php', '').trim();
+		return { stdout: '', stderr: stderr, exitCode: 1 };
 	}
 }

--- a/vendor/wp-now/src/execute-wp-cli.ts
+++ b/vendor/wp-now/src/execute-wp-cli.ts
@@ -74,16 +74,15 @@ export async function executeWPCli( projectPath: string, args: string[] ): Promi
 	// Set site's folder as the current working directory as the terminal will opened in that location.
 	php.chdir(options.documentRoot);
 
+	const stderr = php.readFileAsText(stderrPath).replace('PHP.run() output was: #!/usr/bin/env php', '').trim();
+
 	try {
 		const result = await php.run({
 			scriptPath: runCliPath,
 		});
 
-		const stderr = php.readFileAsText(stderrPath).replace('PHP.run() output was: #!/usr/bin/env php', '').trim();
-
 		return { stdout: result.text.replace('#!/usr/bin/env php', '').trim(), stderr, exitCode: result.exitCode };
 	} catch (error) {
-		const stderr = php.readFileAsText(stderrPath).replace('PHP.run() output was: #!/usr/bin/env php', '').trim();
 		return { stdout: '', stderr, exitCode: 1 };
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/8547

## Proposed Changes

This PR disables the `Export entire site` and `Export database` when site import is in progress.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
*  Download custom [wp-cli.phar here](https://github.com/user-attachments/files/16456950/wp-cli.phar.zip).
*  Unzip and place the wp-cli.phar file inside of the app data's `server-files` directory. Overwrite the existing one if necessary.
* Run `nvm use && npm install && STUDIO_IMPORT_EXPORT=true npm run start` to start Studio.
* Create a new site
* Navigate to `Import/Export` tab
* Select an import file to import (you can use a file that you previously exported from Studio)
* Drag and drop the import file into the Import area and start import
* Observe that `Export entire site` and `Export database` buttons are disabled and you can't click on them while the import is in progress
* Observe that you see the tooltip with a message when you hover over the buttons
* Try switch to another site and confirm that the export is enabled for a different site
* Confirm that when the import is finished, the buttons get enabled and the tooltip goes away

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
