### PR TITLE
Studio: Block add site button when a new site is imported

### DIFF
--- a/src/components/add-site.tsx
+++ b/src/components/add-site.tsx
@@ -6,6 +6,7 @@ import { ACCEPTED_IMPORT_FILE_TYPES } from '../constants';
 import { useAddSite } from '../hooks/use-add-site';
 import { useDragAndDropFile } from '../hooks/use-drag-and-drop-file';
 import { useFeatureFlags } from '../hooks/use-feature-flags';
+import { useImportExport } from '../hooks/use-import-export';
 import { useIpcListener } from '../hooks/use-ipc-listener';
 import { useSiteDetails } from '../hooks/use-site-details';
 import { generateSiteName } from '../lib/generate-site-name';
@@ -46,8 +47,13 @@ export default function AddSite( { className }: AddSiteProps ) {
 		fileForImport,
 		setFileForImport,
 	} = useAddSite();
+	const { importState } = useImportExport();
 
-	const isSiteAdding = data.some( ( site ) => site.isAddingSite );
+	const isAnySiteProcessing = data.some(
+		( site ) =>
+			site.isAddingSite ||
+			( importState[ site.id ]?.progress < 100 && importState[ site.id ]?.isNewSite )
+	);
 
 	const siteAddedMessage = sprintf(
 		// translators: %s is the site name.
@@ -129,7 +135,7 @@ export default function AddSite( { className }: AddSiteProps ) {
 	} );
 
 	useIpcListener( 'add-site', () => {
-		if ( isSiteAdding ) {
+		if ( isAnySiteProcessing ) {
 			return;
 		}
 		openModal();
@@ -163,14 +169,18 @@ export default function AddSite( { className }: AddSiteProps ) {
 								fileError={ fileError }
 							>
 								<div className="flex flex-row justify-end gap-x-5 mt-6">
-									<Button onClick={ closeModal } disabled={ isSiteAdding } variant="tertiary">
+									<Button
+										onClick={ closeModal }
+										disabled={ isAnySiteProcessing }
+										variant="tertiary"
+									>
 										{ __( 'Cancel' ) }
 									</Button>
 									<Button
 										type="submit"
 										variant="primary"
-										isBusy={ isSiteAdding }
-										disabled={ isSiteAdding || !! error || ! siteName?.trim() }
+										isBusy={ isAnySiteProcessing }
+										disabled={ isAnySiteProcessing || !! error || ! siteName?.trim() }
 									>
 										{ __( 'Add site' ) }
 									</Button>
@@ -183,7 +193,7 @@ export default function AddSite( { className }: AddSiteProps ) {
 					variant="outlined"
 					className={ className }
 					onClick={ openModal }
-					disabled={ isSiteAdding }
+					disabled={ isAnySiteProcessing }
 				>
 					{ __( 'Add site' ) }
 				</Button>
@@ -210,14 +220,14 @@ export default function AddSite( { className }: AddSiteProps ) {
 							doesPathContainWordPress={ doesPathContainWordPress }
 						>
 							<div className="flex flex-row justify-end gap-x-5 mt-6">
-								<Button onClick={ closeModal } disabled={ isSiteAdding } variant="tertiary">
+								<Button onClick={ closeModal } disabled={ isAnySiteProcessing } variant="tertiary">
 									{ __( 'Cancel' ) }
 								</Button>
 								<Button
 									type="submit"
 									variant="primary"
-									isBusy={ isSiteAdding }
-									disabled={ isSiteAdding || !! error || ! siteName?.trim() }
+									isBusy={ isAnySiteProcessing }
+									disabled={ isAnySiteProcessing || !! error || ! siteName?.trim() }
 								>
 									{ __( 'Add site' ) }
 								</Button>
@@ -229,7 +239,7 @@ export default function AddSite( { className }: AddSiteProps ) {
 					variant="outlined"
 					className={ className }
 					onClick={ openModal }
-					disabled={ isSiteAdding }
+					disabled={ isAnySiteProcessing }
 				>
 					{ __( 'Add site' ) }
 				</Button>

--- a/src/components/add-site.tsx
+++ b/src/components/add-site.tsx
@@ -50,9 +50,7 @@ export default function AddSite( { className }: AddSiteProps ) {
 	const { importState } = useImportExport();
 
 	const isAnySiteProcessing = data.some(
-		( site ) =>
-			site.isAddingSite ||
-			( importState[ site.id ]?.progress < 100 && importState[ site.id ]?.isNewSite )
+		( site ) => site.isAddingSite || importState[ site.id ]?.isNewSite
 	);
 
 	const siteAddedMessage = sprintf(

--- a/src/components/add-site.tsx
+++ b/src/components/add-site.tsx
@@ -167,19 +167,10 @@ export default function AddSite( { className }: AddSiteProps ) {
 								fileError={ fileError }
 							>
 								<div className="flex flex-row justify-end gap-x-5 mt-6">
-									<Button
-										onClick={ closeModal }
-										disabled={ isAnySiteProcessing }
-										variant="tertiary"
-									>
+									<Button onClick={ closeModal } variant="tertiary">
 										{ __( 'Cancel' ) }
 									</Button>
-									<Button
-										type="submit"
-										variant="primary"
-										isBusy={ isAnySiteProcessing }
-										disabled={ isAnySiteProcessing || !! error || ! siteName?.trim() }
-									>
+									<Button type="submit" variant="primary">
 										{ __( 'Add site' ) }
 									</Button>
 								</div>
@@ -218,15 +209,10 @@ export default function AddSite( { className }: AddSiteProps ) {
 							doesPathContainWordPress={ doesPathContainWordPress }
 						>
 							<div className="flex flex-row justify-end gap-x-5 mt-6">
-								<Button onClick={ closeModal } disabled={ isAnySiteProcessing } variant="tertiary">
+								<Button onClick={ closeModal } variant="tertiary">
 									{ __( 'Cancel' ) }
 								</Button>
-								<Button
-									type="submit"
-									variant="primary"
-									isBusy={ isAnySiteProcessing }
-									disabled={ isAnySiteProcessing || !! error || ! siteName?.trim() }
-								>
+								<Button type="submit" variant="primary">
 									{ __( 'Add site' ) }
 								</Button>
 							</div>

--- a/src/components/add-site.tsx
+++ b/src/components/add-site.tsx
@@ -170,7 +170,11 @@ export default function AddSite( { className }: AddSiteProps ) {
 									<Button onClick={ closeModal } variant="tertiary">
 										{ __( 'Cancel' ) }
 									</Button>
-									<Button type="submit" variant="primary">
+									<Button
+										type="submit"
+										variant="primary"
+										disabled={ !! error || ! siteName?.trim() }
+									>
 										{ __( 'Add site' ) }
 									</Button>
 								</div>
@@ -212,7 +216,7 @@ export default function AddSite( { className }: AddSiteProps ) {
 								<Button onClick={ closeModal } variant="tertiary">
 									{ __( 'Cancel' ) }
 								</Button>
-								<Button type="submit" variant="primary">
+								<Button type="submit" variant="primary" disabled={ !! error || ! siteName?.trim() }>
 									{ __( 'Add site' ) }
 								</Button>
 							</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/8547

## Proposed Changes

This PR ensures that the `Add site` button is blocked until the new site that is created with import finishes importing.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
* Run `nvm use && npm install && STUDIO_IMPORT_EXPORT=true npm run start` to start Studio.
* Click on the `Add site` in the sidebar 
* Select an import file to import 
* Start the process of importing
* Confirm that the button is blocked while the import is running
* Confirm that the notification that the import was finished appears at the same time as `Add site` button gets enabled 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
