### PR TITLE
Studio: Disable export when import is in progress

### DIFF
--- a/src/components/content-tab-import-export.tsx
+++ b/src/components/content-tab-import-export.tsx
@@ -22,7 +22,7 @@ interface ContentTabImportExportProps {
 export const ExportSite = ( { selectedSite }: { selectedSite: SiteDetails } ) => {
 	const { exportState, exportFullSite, exportDatabase, importState } = useImportExport();
 	const { [ selectedSite.id ]: currentProgress } = exportState;
-	const isSiteImporting = importState[ selectedSite?.id ]?.isNewSite;
+	const isSiteImporting = importState[ selectedSite.id ]?.progress < 100;
 	const siteNotReadyForExportMessage = __(
 		'This site is being imported. Please wait for the import to finish before you export it.'
 	);

--- a/src/components/content-tab-import-export.tsx
+++ b/src/components/content-tab-import-export.tsx
@@ -50,7 +50,11 @@ export const ExportSite = ( { selectedSite }: { selectedSite: SiteDetails } ) =>
 			) : (
 				<div className="flex flex-row gap-4">
 					<Tooltip text={ siteNotReadyForExportMessage } disabled={ ! isSiteImporting }>
-						<Button onClick={ () => handleExport( exportFullSite ) } variant="primary">
+						<Button
+							onClick={ () => handleExport( exportFullSite ) }
+							variant="primary"
+							disabled={ isSiteImporting }
+						>
 							{ __( 'Export entire site' ) }
 						</Button>
 					</Tooltip>
@@ -60,6 +64,7 @@ export const ExportSite = ( { selectedSite }: { selectedSite: SiteDetails } ) =>
 							type="submit"
 							variant="secondary"
 							className="!text-a8c-blueberry !shadow-a8c-blueberry"
+							disabled={ isSiteImporting }
 						>
 							{ __( 'Export database' ) }
 						</Button>

--- a/src/components/content-tab-import-export.tsx
+++ b/src/components/content-tab-import-export.tsx
@@ -63,7 +63,7 @@ export const ExportSite = ( { selectedSite }: { selectedSite: SiteDetails } ) =>
 							onClick={ () => handleExport( exportDatabase ) }
 							type="submit"
 							variant="secondary"
-							className="!text-a8c-blueberry !shadow-a8c-blueberry"
+							className={ cx( isSiteImporting ? '' : '!text-a8c-blueberry !shadow-a8c-blueberry' ) }
 							disabled={ isSiteImporting }
 						>
 							{ __( 'Export database' ) }

--- a/src/components/content-tab-import-export.tsx
+++ b/src/components/content-tab-import-export.tsx
@@ -13,14 +13,19 @@ import { cx } from '../lib/cx';
 import { getIpcApi } from '../lib/get-ipc-api';
 import Button from './button';
 import ProgressBar from './progress-bar';
+import Tooltip from './tooltip';
 
 interface ContentTabImportExportProps {
 	selectedSite: SiteDetails;
 }
 
 export const ExportSite = ( { selectedSite }: { selectedSite: SiteDetails } ) => {
-	const { exportState, exportFullSite, exportDatabase } = useImportExport();
+	const { exportState, exportFullSite, exportDatabase, importState } = useImportExport();
 	const { [ selectedSite.id ]: currentProgress } = exportState;
+	const isSiteImporting = importState[ selectedSite?.id ]?.isNewSite;
+	const siteNotReadyForExportMessage = __(
+		'This site is being imported. Please wait for the import to finish before you export it.'
+	);
 
 	const handleExport = async ( exportFunction: typeof exportFullSite | typeof exportDatabase ) => {
 		const exportPath = await exportFunction( selectedSite );
@@ -44,17 +49,21 @@ export const ExportSite = ( { selectedSite }: { selectedSite: SiteDetails } ) =>
 				</div>
 			) : (
 				<div className="flex flex-row gap-4">
-					<Button onClick={ () => handleExport( exportFullSite ) } variant="primary">
-						{ __( 'Export entire site' ) }
-					</Button>
-					<Button
-						onClick={ () => handleExport( exportDatabase ) }
-						type="submit"
-						variant="secondary"
-						className="!text-a8c-blueberry !shadow-a8c-blueberry"
-					>
-						{ __( 'Export database' ) }
-					</Button>
+					<Tooltip text={ siteNotReadyForExportMessage } disabled={ ! isSiteImporting }>
+						<Button onClick={ () => handleExport( exportFullSite ) } variant="primary">
+							{ __( 'Export entire site' ) }
+						</Button>
+					</Tooltip>
+					<Tooltip text={ siteNotReadyForExportMessage } disabled={ ! isSiteImporting }>
+						<Button
+							onClick={ () => handleExport( exportDatabase ) }
+							type="submit"
+							variant="secondary"
+							className="!text-a8c-blueberry !shadow-a8c-blueberry"
+						>
+							{ __( 'Export database' ) }
+						</Button>
+					</Tooltip>
 				</div>
 			) }
 		</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/8547

## Proposed Changes

This PR disables the `Export entire site` and `Export database` when site import is in progress.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
* Run `nvm use && npm install && STUDIO_IMPORT_EXPORT=true npm run start` to start Studio.
* Create a new site
* Navigate to `Import/Export` tab
* Select an import file to import
* Observe that `Export entire site` and `Export database` buttons are disabled and you can't click on them while the import is in progress
* Observe that you see the tooltip with a message when you hover over the buttons
* Try switching to another site and confirm that the export is enabled for a different site
* Confirm that when the import is finished, the buttons get enabled and the tooltip goes away

<img width="451" alt="Screenshot 2024-08-07 at 7 29 07 AM" src="https://github.com/user-attachments/assets/0d984c57-63c8-484b-996e-8ab27920de20">

- [ ] Have you checked for TypeScript, React or other console errors?
