### PR TITLE
Add studio.json when exporting full site

### DIFF
--- a/src/hooks/tests/use-import-export.tsx
+++ b/src/hooks/tests/use-import-export.tsx
@@ -48,6 +48,7 @@ describe( 'useImportExport hook', () => {
 				site: selectedSite,
 				backupFile: '/path/to/exported-site.tar.gz',
 				includes: { database: true, uploads: true, plugins: true, themes: true },
+				phpVersion: '8.0',
 			},
 			SITE_ID
 		);
@@ -73,6 +74,7 @@ describe( 'useImportExport hook', () => {
 				site: selectedSite,
 				backupFile: '/path/to/exported-site.tar.gz',
 				includes: { database: true, uploads: true, plugins: true, themes: true },
+				phpVersion: '8.0',
 			},
 			SITE_ID
 		);
@@ -94,6 +96,7 @@ describe( 'useImportExport hook', () => {
 				site: selectedSite,
 				backupFile: '/path/to/exported-database.sql',
 				includes: { database: true, uploads: false, plugins: false, themes: false },
+				phpVersion: '8.0',
 			},
 			SITE_ID
 		);

--- a/src/hooks/use-import-export.tsx
+++ b/src/hooks/use-import-export.tsx
@@ -274,6 +274,7 @@ export const ImportExportProvider = ( { children }: { children: React.ReactNode 
 					plugins: true,
 					themes: true,
 				},
+				phpVersion: selectedSite.phpVersion,
 			};
 			return exportSite( selectedSite, options );
 		},
@@ -305,6 +306,7 @@ export const ImportExportProvider = ( { children }: { children: React.ReactNode 
 					plugins: false,
 					themes: false,
 				},
+				phpVersion: selectedSite.phpVersion,
 			};
 			return exportSite( selectedSite, options );
 		},

--- a/src/lib/import-export/export/types.ts
+++ b/src/lib/import-export/export/types.ts
@@ -5,6 +5,7 @@ export interface ExportOptions {
 	site: SiteDetails;
 	backupFile: string;
 	includes: { [ index in ExportOptionsIncludes ]: boolean };
+	phpVersion: string;
 }
 
 export type ExportOptionsIncludes = BackupContentsCategory | 'database';

--- a/src/lib/import-export/tests/export/exporters/default-exporter.test.ts
+++ b/src/lib/import-export/tests/export/exporters/default-exporter.test.ts
@@ -129,8 +129,6 @@ describe( 'DefaultExporter', () => {
 		await exporter.export();
 
 		expect( archiver ).toHaveBeenCalledWith( 'tar', { gzip: true, gzipOptions: { level: 9 } } );
-		expect( getWordPressVersionFromInstallation ).toHaveBeenCalledTimes( 1 );
-		expect( getWordPressVersionFromInstallation ).toHaveBeenCalledWith( '/path/to/site' );
 	} );
 
 	it( 'should create a zip archive when the backup file ends with .zip', async () => {
@@ -138,8 +136,6 @@ describe( 'DefaultExporter', () => {
 		await exporter.export();
 
 		expect( archiver ).toHaveBeenCalledWith( 'zip', { gzip: false, gzipOptions: undefined } );
-		expect( getWordPressVersionFromInstallation ).toHaveBeenCalledTimes( 1 );
-		expect( getWordPressVersionFromInstallation ).toHaveBeenCalledWith( '/path/to/site' );
 	} );
 
 	it( 'should add wp-config.php to the archive', async () => {
@@ -159,8 +155,17 @@ describe( 'DefaultExporter', () => {
 		expect( mockArchiver.file ).toHaveBeenCalledWith( '/path/to/site/wp-config.php', {
 			name: 'wp-config.php',
 		} );
+	} );
+
+	it( 'should add studio.json to the archive', async () => {
+		const exporter = new DefaultExporter( mockOptions );
+		await exporter.export();
+
 		expect( getWordPressVersionFromInstallation ).toHaveBeenCalledTimes( 1 );
 		expect( getWordPressVersionFromInstallation ).toHaveBeenCalledWith( '/path/to/site' );
+		expect( mockArchiver.file ).toHaveBeenCalledWith( '/tmp/studio_export_123/studio.json', {
+			name: 'studio.json',
+		} );
 	} );
 
 	it( 'should add wp-content files to the archive', async () => {
@@ -195,8 +200,6 @@ describe( 'DefaultExporter', () => {
 			'/path/to/site/wp-content/themes/theme1/index.php',
 			{ name: 'wp-content/themes/theme1/index.php' }
 		);
-		expect( getWordPressVersionFromInstallation ).toHaveBeenCalledTimes( 1 );
-		expect( getWordPressVersionFromInstallation ).toHaveBeenCalledWith( '/path/to/site' );
 	} );
 
 	it( 'should add a database file to the archive when database is included', async () => {
@@ -230,8 +233,6 @@ describe( 'DefaultExporter', () => {
 		await exporter.export();
 
 		expect( mockArchiver.finalize ).toHaveBeenCalled();
-		expect( getWordPressVersionFromInstallation ).toHaveBeenCalledTimes( 1 );
-		expect( getWordPressVersionFromInstallation ).toHaveBeenCalledWith( '/path/to/site' );
 	} );
 
 	it( 'should cleanup temporary files when database is included', async () => {

--- a/src/lib/import-export/tests/export/exporters/sql-exporter.test.ts
+++ b/src/lib/import-export/tests/export/exporters/sql-exporter.test.ts
@@ -31,6 +31,7 @@ describe( 'SqlExporter', () => {
 				themes: false,
 				database: true,
 			},
+			phpVersion: '7.4',
 		};
 
 		// Reset all mock implementations


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

- Related to
  - https://github.com/Automattic/dotcom-forge/issues/8362
  - https://github.com/Automattic/studio/pull/407

## Proposed Changes

- Include the `studio.json` file when exporting full site

The logic to load and set the PHP version from `studio.json` will be handled separately on https://github.com/Automattic/studio/pull/407 after the rest of PRs that refactor the import get merged.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run `STUDIO_IMPORT_EXPORT=true npm start`
- In any Studio site, click on Import/Export
- Click on Export entire site
- Unzip the file
- Observe a new file studio.json that contains the correct PHP and WordPress versions of your site


https://github.com/user-attachments/assets/06a200a6-f35e-4057-9741-742edbd910ea



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?