### PR TITLE
Studio: Start server after site is created and imported

### DIFF
--- a/e2e/page-objects/site-content.ts
+++ b/e2e/page-objects/site-content.ts
@@ -16,6 +16,10 @@ export default class SiteContent {
 		return this.locator.getByRole( 'heading', { name: this.siteName } );
 	}
 
+	get runningButton() {
+		return this.locator.getByRole( 'button', { name: 'Running' } );
+	}
+
 	get frontendButton() {
 		// Original: No longer works.
 		//

--- a/e2e/sites.test.ts
+++ b/e2e/sites.test.ts
@@ -42,7 +42,7 @@ test.describe( 'Servers', () => {
 
 		// Check the site is running
 		const siteContent = new SiteContent( session.mainWindow, siteName );
-		await expect( siteContent.siteNameHeading ).toBeAttached( { timeout: 30_000 } );
+		await expect( siteContent.runningButton ).toBeAttached( { timeout: 30_000 } );
 		expect( await siteContent.siteNameHeading ).toHaveText( siteName );
 
 		// Check a WordPress site has been created

--- a/src/hooks/use-add-site.ts
+++ b/src/hooks/use-add-site.ts
@@ -7,7 +7,7 @@ import { useSiteDetails } from './use-site-details';
 
 export function useAddSite() {
 	const { __ } = useI18n();
-	const { createSite, data: sites, loadingSites } = useSiteDetails();
+	const { createSite, data: sites, loadingSites, startServer } = useSiteDetails();
 	const { importFile, clearImportState } = useImportExport();
 	const [ error, setError ] = useState( '' );
 	const [ siteName, setSiteName ] = useState< string | null >( null );
@@ -64,6 +64,7 @@ export function useAddSite() {
 					} );
 					clearImportState( newSite.id );
 				}
+				await startServer( newSite.id );
 				getIpcApi().showNotification( {
 					title: newSite.name,
 					body: __( 'Your new site is up and running' ),
@@ -81,6 +82,7 @@ export function useAddSite() {
 		proposedSitePath,
 		siteName,
 		sitePath,
+		startServer,
 	] );
 
 	const handleSiteNameChange = useCallback(

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -222,15 +222,6 @@ export async function createSite(
 	if ( parentWindow && ! parentWindow.isDestroyed() && ! event.sender.isDestroyed() ) {
 		parentWindow.webContents.send( 'theme-details-updating', details.id );
 	}
-	await server.start();
-	if ( parentWindow && ! parentWindow.isDestroyed() && ! event.sender.isDestroyed() ) {
-		parentWindow.webContents.send(
-			'theme-details-changed',
-			details.id,
-			server.details.themeDetails
-		);
-	}
-	server.updateCachedThumbnail().then( () => sendThumbnailChangedEvent( event, details.id ) );
 
 	userData.sites.push( server.details );
 	sortSites( userData.sites );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/8547


## Proposed Changes

This PR ensures that the site is started only after the import is finished.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
* Run `nvm use && npm install && STUDIO_IMPORT_EXPORT=true npm run start` to start Studio.
* Click on `Add site` in the sidebar and add an import file
* Start adding the site
* Observe that after the import is completed, the site is started and you can log into WP-Admin without being asked to log in
* Observe that the site thumbnail is immediately updated when the import is finished to a new theme

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
