### PR TITLE
Ensure sites are stopped during import

### DIFF
--- a/src/components/action-button.tsx
+++ b/src/components/action-button.tsx
@@ -5,7 +5,7 @@ import { useEffect, useRef, useState } from 'react';
 import { cx } from '../lib/cx';
 import Button, { ButtonProps } from './button';
 
-type ActionButtonState = 'idle' | 'loading' | 'stop' | 'running';
+type ActionButtonState = 'idle' | 'loading' | 'stop' | 'running' | 'importing';
 
 interface ActionButtonProps {
 	isRunning: boolean;
@@ -14,6 +14,7 @@ interface ActionButtonProps {
 	className?: string;
 	buttonClassName?: string;
 	iconSize?: number;
+	isImporting?: boolean;
 }
 
 const MIN_WIDTH = 96;
@@ -49,6 +50,7 @@ export const ActionButton = ( {
 	className,
 	buttonClassName,
 	iconSize = 10,
+	isImporting = false,
 }: ActionButtonProps ) => {
 	const { __ } = useI18n();
 	const [ isUserHighlighting, setIsUserHighlighting ] = useState( false );
@@ -57,7 +59,9 @@ export const ActionButton = ( {
 	const minSize = useRef( { width: MIN_WIDTH, height: 0 } );
 
 	let state: ActionButtonState = 'idle';
-	if ( isLoading ) {
+	if ( isImporting ) {
+		state = 'importing';
+	} else if ( isLoading ) {
 		state = 'loading';
 	} else if ( isRunning ) {
 		if ( isUserHighlighting ) {
@@ -83,7 +87,7 @@ export const ActionButton = ( {
 	}, [ sizes ] );
 
 	const handleOnClick = () => {
-		if ( isLoading ) {
+		if ( isLoading || isImporting ) {
 			return;
 		}
 		onClick();
@@ -137,6 +141,15 @@ export const ActionButton = ( {
 				className: cx( defaultButtonClassName, '!text-a8c-green-50' ),
 			};
 			break;
+		case 'importing':
+			buttonLabel = __( 'Importing…' );
+			buttonProps = {
+				// `aria-disabled` used rather than `disabled` to prevent losing button
+				// focus while the button's asynchronous action is pending.
+				'aria-disabled': true,
+				icon: undefined,
+				className: defaultButtonClassName,
+			};
 	}
 
 	return (

--- a/src/components/site-management-actions.tsx
+++ b/src/components/site-management-actions.tsx
@@ -1,4 +1,7 @@
+import { __ } from '@wordpress/i18n';
+import { useImportExport } from '../hooks/use-import-export';
 import { ActionButton } from './action-button';
+import Tooltip from './tooltip';
 
 export interface SiteManagementActionProps {
 	onStop: ( id: string ) => Promise< void >;
@@ -13,13 +16,28 @@ export const SiteManagementActions = ( {
 	loading,
 	selectedSite,
 }: SiteManagementActionProps ) => {
-	return selectedSite ? (
-		<ActionButton
-			isRunning={ selectedSite.running }
-			isLoading={ loading }
-			onClick={ () => {
-				selectedSite.running ? onStop( selectedSite.id ) : onStart( selectedSite.id );
-			} }
-		/>
-	) : null;
+	const { isSiteImporting } = useImportExport();
+
+	if ( ! selectedSite ) {
+		return null;
+	}
+
+	const isImporting = isSiteImporting( selectedSite.id );
+
+	return (
+		<Tooltip
+			disabled={ ! isImporting }
+			text={ __( 'Starting and stopping a site is disabled during import.' ) }
+			placement="left"
+		>
+			<ActionButton
+				isRunning={ selectedSite.running }
+				isLoading={ loading }
+				onClick={ () => {
+					selectedSite.running ? onStop( selectedSite.id ) : onStart( selectedSite.id );
+				} }
+				isImporting={ isImporting }
+			/>
+		</Tooltip>
+	);
 };

--- a/src/components/site-management-actions.tsx
+++ b/src/components/site-management-actions.tsx
@@ -27,7 +27,7 @@ export const SiteManagementActions = ( {
 	return (
 		<Tooltip
 			disabled={ ! isImporting }
-			text={ __( 'Starting and stopping a site is disabled during import.' ) }
+			text={ __( 'A site can't be stopped or started during import.' ) }
 			placement="left"
 		>
 			<ActionButton

--- a/src/components/site-management-actions.tsx
+++ b/src/components/site-management-actions.tsx
@@ -27,7 +27,7 @@ export const SiteManagementActions = ( {
 	return (
 		<Tooltip
 			disabled={ ! isImporting }
-			text={ __( 'A site can't be stopped or started during import.' ) }
+			text={ __( "A site can't be stopped or started during import." ) }
 			placement="left"
 		>
 			<ActionButton

--- a/src/components/site-menu.tsx
+++ b/src/components/site-menu.tsx
@@ -2,6 +2,7 @@ import { speak } from '@wordpress/a11y';
 import { Spinner } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { useEffect } from 'react';
+import { useImportExport } from '../hooks/use-import-export';
 import { useSiteDetails } from '../hooks/use-site-details';
 import { isMac } from '../lib/app-globals';
 import { cx } from '../lib/cx';
@@ -97,7 +98,9 @@ function ButtonToRun( { running, id, name }: Pick< SiteDetails, 'running' | 'id'
 }
 function SiteItem( { site }: { site: SiteDetails } ) {
 	const { selectedSite, setSelectedSiteId } = useSiteDetails();
+	const { isSiteImporting } = useImportExport();
 	const isSelected = site === selectedSite;
+	const isImporting = isSiteImporting( site.id );
 	return (
 		<li
 			className={ cx(
@@ -114,7 +117,7 @@ function SiteItem( { site }: { site: SiteDetails } ) {
 			>
 				{ site.name }
 			</button>
-			{ site.isAddingSite ? (
+			{ site.isAddingSite || isImporting ? (
 				<Spinner className="!w-2.5 !h-2.5 !top-[6px] !mr-2 [&>circle]:stroke-a8c-gray-70" />
 			) : (
 				<ButtonToRun { ...site } />

--- a/src/hooks/use-import-export.tsx
+++ b/src/hooks/use-import-export.tsx
@@ -41,6 +41,7 @@ interface ImportExportContext {
 		options?: { showImportNotification?: boolean; isNewSite?: boolean }
 	) => Promise< void >;
 	clearImportState: ( siteId: string ) => void;
+	isSiteImporting: ( siteId: string ) => boolean;
 	exportState: ExportProgressState;
 	exportFullSite: ( selectedSite: SiteDetails ) => Promise< string | undefined >;
 	exportDatabase: ( selectedSite: SiteDetails ) => Promise< string | undefined >;
@@ -59,6 +60,7 @@ const ImportExportContext = createContext< ImportExportContext >( {
 	importState: {},
 	importFile: async () => undefined,
 	clearImportState: () => undefined,
+	isSiteImporting: () => false,
 	exportState: {},
 	exportFullSite: async () => undefined,
 	exportDatabase: async () => undefined,
@@ -130,6 +132,11 @@ export const ImportExportProvider = ( { children }: { children: React.ReactNode 
 			...rest,
 		} ) );
 	}, [] );
+
+	const isSiteImporting = useCallback(
+		( siteId: string ) => !! importState[ siteId ] && importState[ siteId ].progress < 100,
+		[ importState ]
+	);
 
 	useIpcListener( 'on-import', ( _, { event, data }: ImportExportEventData, siteId: string ) => {
 		if ( ! siteId ) {
@@ -399,11 +406,20 @@ export const ImportExportProvider = ( { children }: { children: React.ReactNode 
 			importState,
 			importFile,
 			clearImportState,
+			isSiteImporting,
 			exportState,
 			exportFullSite,
 			exportDatabase,
 		} ),
-		[ importState, importFile, clearImportState, exportState, exportFullSite, exportDatabase ]
+		[
+			importState,
+			importFile,
+			clearImportState,
+			isSiteImporting,
+			exportState,
+			exportFullSite,
+			exportDatabase,
+		]
 	);
 
 	return (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to 8608-gh-Automattic/dotcom-forge and 8610-gh-Automattic/dotcom-forge.

## Proposed Changes

- Stop the site before initiating the import process. If the site was running before the import, it will be restarted when the process finishes.
- Add `isSiteImporting` function to `useImportExport` hook to facilitate checking when a site is being imported.
- Disable site actions (start/stop the site) during the import.


https://github.com/user-attachments/assets/1f144e1f-1ea0-4dad-a541-104ee198c11d



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Site is stopped and restarted during the import

- Run the app with the command `STUDIO_IMPORT_EXPORT=true npm start`.
- Create a new site.
- Navigate to the Import/Export tab.
- Observe that the site is running.
- Import a Jetpack backup exported from an Atomic site.
- Observe the site stopped.
- Wait until the import finishes.
- Observe the site is running again.
- Navigate to the site and observe the import was applied successfully.

### Site is stopped during the import

- Run the app with the command `STUDIO_IMPORT_EXPORT=true npm start`.
- Select a site.
- Navigate to the Import/Export tab.
- Stop the site if needed.
- Observe that the site is stopped.
- Import a Jetpack backup exported from an Atomic site.
- Observe the site remains stopped.
- Wait until the import finishes.
- Observe the site remains stopped and start the site.
- Navigate to the site and observe the import was applied successfully.

### Site can't be started during the import

- Run the app with the command `STUDIO_IMPORT_EXPORT=true npm start`.
- Select a site.
- Navigate to the Import/Export tab.
- Import a Jetpack backup exported from an Atomic site.
- During the import process:
    - Observe that the Start button is disabled and displays a tooltip when hovering.
    - Observe in the sidebar that the selected site shows a spinner during the import.
- Wait until the import finishes.
- Observe that the Start button is active again.
- Observe in the sidebar that the selected site no longer shows a spinner.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
