### PR TITLE
Keep SQLite command up-to-date with bundled version

### DIFF
--- a/src/lib/sqlite-command-versions.ts
+++ b/src/lib/sqlite-command-versions.ts
@@ -14,6 +14,8 @@ interface DistributionCheckResult {
 	error?: string;
 }
 
+const VERSION_FILENAME = 'version';
+
 /**
  * The path for wp-cli phar file within the WP Now folder.
  */
@@ -57,11 +59,10 @@ async function checkForUpdate(): Promise< DistributionCheckResult > {
 	let currentVersion: string | null = null;
 	let distributionExists = false;
 	const distributionPath = getSqliteCommandPath();
-	const versionFilePath = path.join( distributionPath, 'version' );
 
 	if ( await fs.pathExists( distributionPath ) ) {
 		distributionExists = true;
-		currentVersion = await getCurrentSQLiteCommandVersion( versionFilePath );
+		currentVersion = await getSQLiteCommandVersion( distributionPath );
 	}
 
 	try {
@@ -88,9 +89,11 @@ async function checkForUpdate(): Promise< DistributionCheckResult > {
 	}
 }
 
-async function getCurrentSQLiteCommandVersion( versionFilePath: string ) {
+export async function getSQLiteCommandVersion( distributionPath: string ) {
 	try {
-		return ( await fs.readFile( versionFilePath, 'utf8' ) ).trim().replace( 'v', '' );
+		return ( await fs.readFile( path.join( distributionPath, VERSION_FILENAME ), 'utf8' ) )
+			.trim()
+			.replace( 'v', '' );
 	} catch ( _error ) {
 		return null;
 	}

--- a/src/lib/sqlite-command-versions.ts
+++ b/src/lib/sqlite-command-versions.ts
@@ -48,7 +48,6 @@ export async function updateLatestSQLiteCommandVersion() {
 	}
 
 	try {
-		console.log( `Downloading SQLite Command ${ distributionCheck.latestVersion }...` );
 		await downloadSQLiteCommand( distributionCheck.downloadUrl, getSqliteCommandPath() );
 	} catch ( error ) {
 		console.error( `Failed to download SQLite Command: ${ error }` );

--- a/src/setup-wp-server-files.ts
+++ b/src/setup-wp-server-files.ts
@@ -66,19 +66,14 @@ async function copyBundledWPCLI() {
 
 async function copyBundledSQLiteCommand() {
 	const bundledSqliteCommandPath = path.join( getResourcesPath(), 'wp-files', 'sqlite-command' );
-	const bundledSqliteCommandVersion = semver.coerce(
-		await getSQLiteCommandVersion( bundledSqliteCommandPath )
-	);
-
+	const bundledSqliteCommandVersion = await getSQLiteCommandVersion( bundledSqliteCommandPath );
 	if ( ! bundledSqliteCommandVersion ) {
 		return;
 	}
 	const installedSqliteCommandPath = getSqliteCommandPath();
 	const isSqliteCommandInstalled = await fs.pathExists( installedSqliteCommandPath );
 
-	const installedSqliteCommandVersion = semver.coerce(
-		await getSQLiteCommandVersion( installedSqliteCommandPath )
-	);
+	const installedSqliteCommandVersion = await getSQLiteCommandVersion( installedSqliteCommandPath );
 	const isBundledVersionNewer =
 		installedSqliteCommandVersion &&
 		semver.gt( bundledSqliteCommandVersion, installedSqliteCommandVersion );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to 8602-gh-Automattic/dotcom-forge.

## Proposed Changes

- The SQLite command bundled in the app will update the local one (located in server files) if it's newer.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

> [!WARNING]
> The instructions are meant to be executed on the macOS platform. If you use another, some of the commands might need to be adjusted.

- Download [wp-cli-sqlite-command-v1.0.3.zip](https://github.com/user-attachments/files/16529048/wp-cli-sqlite-command-v1.0.3.zip) and unzip it in Dowloads folder.
- Download [wp-cli-sqlite-command-v1.0.2.zip](https://github.com/user-attachments/files/16529049/wp-cli-sqlite-command-v1.0.2.zip) and unzip it in Dowloads folder.
- Run the following command to change version of SQLite command:
```
# Bundled version will be 1.0.3
rm -rf ./wp-files/sqlite-command && \
cp -r $HOME/Downloads/wp-cli-sqlite-command-v1.0.3 ./wp-files/sqlite-command && \
# Server files version will be 1.0.2
rm -rf $HOME/Library/Application\ Support/Studio/server-files/sqlite-command && \
cp -r $HOME/Downloads/wp-cli-sqlite-command-v1.0.2 $HOME/Library/Application\ Support/Studio/server-files/sqlite-command
```
- Apply the following patch to avoid updating SQLite command from remote origin:
```patch
diff --git forkSrcPrefix/src/setup-wp-server-files.ts forkDstPrefix/src/setup-wp-server-files.ts
index 7304292fd3953433f858b80acda805cbcb7baacd..4385fff684a9d56d9a6a310a04763740908c6fa7 100644
--- forkSrcPrefix/src/setup-wp-server-files.ts
+++ forkDstPrefix/src/setup-wp-server-files.ts
@@ -99,5 +99,5 @@ export async function updateWPServerFiles() {
 	await updateLatestWordPressVersion();
 	await updateLatestSqliteVersion();
 	await updateLatestWPCliVersion();
-	await updateLatestSQLiteCommandVersion();
+	// await updateLatestSQLiteCommandVersion();
 }

```
- Run the app with the command `npm start`.
- Observe the entry "Copying bundled SQLite command version 1.0.3..." in the logs.
- Open the file located in `<APP_DATA_PATH>/Studio/server-files/sqlite-command/version` (e.g. in macOS the location is `$HOME/Library/Application\ Support/Studio/server-files/sqlite-command/version`).
- Observe that the SQLite version in server files has been updated with the bundled version (`1.0.3`).
- Remove the patch shared above.
- Run the app again with the command `npm start`.
- Observe the entry "Downloading SQLite Command..." in the logs.
- Open the file located in `<APP_DATA_PATH>/Studio/server-files/sqlite-command/version` (e.g. in macOS the location is `$HOME/Library/Application\ Support/Studio/server-files/sqlite-command/version`).
- Observe that the SQLite version in server files has been updated with latest one (`1.0.4`).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
