### PR TITLE
Studio: Disable import when export is in progress

### DIFF
--- a/src/components/content-tab-import-export.tsx
+++ b/src/components/content-tab-import-export.tsx
@@ -79,16 +79,19 @@ const InitialImportButton = ( {
 	children,
 	isInitial,
 	openFileSelector,
+	disabled,
 }: {
 	children: React.ReactNode;
 	isInitial: boolean;
 	openFileSelector: () => void;
+	disabled?: boolean;
 } ) =>
 	isInitial ? (
 		<Button
 			variant="icon"
 			className="w-full [&>div.border-zinc-300]:hover:border-a8c-blueberry"
 			onClick={ openFileSelector }
+			disabled={ disabled }
 		>
 			{ children }
 		</Button>
@@ -99,8 +102,11 @@ const InitialImportButton = ( {
 const ImportSite = ( props: { selectedSite: SiteDetails } ) => {
 	const { __ } = useI18n();
 	const { startServer, loadingServer } = useSiteDetails();
-	const { importState, importFile, clearImportState } = useImportExport();
+	const { importState, importFile, clearImportState, exportState } = useImportExport();
 	const { [ props.selectedSite.id ]: currentProgress } = importState;
+	const isSiteExporting =
+		exportState[ props.selectedSite?.id ] && exportState[ props.selectedSite?.id ].progress < 100;
+
 	const importConfirmation = useConfirmationDialog( {
 		message: sprintf( __( 'Overwrite %s?' ), props.selectedSite.name ),
 		checkboxLabel: __( "Don't ask again" ),
@@ -168,7 +174,11 @@ const ImportSite = ( props: { selectedSite: SiteDetails } ) => {
 				) }
 			</div>
 			<div ref={ dropRef } className="w-full">
-				<InitialImportButton isInitial={ isInitial } openFileSelector={ openFileSelector }>
+				<InitialImportButton
+					isInitial={ isInitial }
+					openFileSelector={ openFileSelector }
+					disabled={ isSiteExporting }
+				>
 					<div
 						className={ cx(
 							'h-48 w-full rounded-sm border border-zinc-300 flex-col justify-center items-center inline-flex',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/8547

## Proposed Changes

This PR disables drag and drop area for importing a site when there is an export in progress.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
* Run `nvm use && npm install && STUDIO_IMPORT_EXPORT=true npm run start` to start Studio.
* Create a new site
* Navigate to `Import/Export` tab
* Click on `Export entire site`
* Start the export process
* Observe that while the export is running the import area is disabled and you can't start import on a given site
* Observe that once the export is finished, the import area becomes available

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
