### PR TITLE
Add Local backup format importer

### DIFF
--- a/src/lib/import-export/import/import-manager.ts
+++ b/src/lib/import-export/import/import-manager.ts
@@ -4,7 +4,7 @@ import path from 'path';
 import { ImportExportEventData, handleEvents } from '../handle-events';
 import { BackupExtractEvents, ImporterEvents, ValidatorEvents } from './events';
 import { BackupHandlerFactory } from './handlers/backup-handler-factory';
-import { Importer, ImporterResult, JetpackImporter, SQLImporter } from './importers/importer';
+import {Importer, ImporterResult, JetpackImporter, LocalImporter, SQLImporter} from './importers/importer';
 import { BackupArchiveInfo, NewImporter } from './types';
 import { JetpackValidator, SqlValidator, LocalValidator } from './validators';
 import { Validator } from './validators/validator';
@@ -65,6 +65,6 @@ export async function importBackup(
 
 export const defaultImporterOptions: ImporterOption[] = [
 	{ validator: new JetpackValidator(), importer: JetpackImporter },
-	{ validator: new LocalValidator(), importer: JetpackImporter },
+	{ validator: new LocalValidator(), importer: LocalImporter },
 	{ validator: new SqlValidator(), importer: SQLImporter },
 ];

--- a/src/lib/import-export/import/import-manager.ts
+++ b/src/lib/import-export/import/import-manager.ts
@@ -4,7 +4,13 @@ import path from 'path';
 import { ImportExportEventData, handleEvents } from '../handle-events';
 import { BackupExtractEvents, ImporterEvents, ValidatorEvents } from './events';
 import { BackupHandlerFactory } from './handlers/backup-handler-factory';
-import { Importer, ImporterResult, JetpackImporter, LocalImporter, SQLImporter } from './importers/importer';
+import {
+	Importer,
+	ImporterResult,
+	JetpackImporter,
+	LocalImporter,
+	SQLImporter,
+} from './importers/importer';
 import { BackupArchiveInfo, NewImporter } from './types';
 import { JetpackValidator, SqlValidator, LocalValidator } from './validators';
 import { Validator } from './validators/validator';

--- a/src/lib/import-export/import/import-manager.ts
+++ b/src/lib/import-export/import/import-manager.ts
@@ -6,7 +6,7 @@ import { BackupExtractEvents, ImporterEvents, ValidatorEvents } from './events';
 import { BackupHandlerFactory } from './handlers/backup-handler-factory';
 import { Importer, ImporterResult, JetpackImporter, SQLImporter } from './importers/importer';
 import { BackupArchiveInfo, NewImporter } from './types';
-import { JetpackValidator, SqlValidator } from './validators';
+import { JetpackValidator, SqlValidator, LocalValidator } from './validators';
 import { Validator } from './validators/validator';
 
 export interface ImporterOption {
@@ -65,5 +65,6 @@ export async function importBackup(
 
 export const defaultImporterOptions: ImporterOption[] = [
 	{ validator: new JetpackValidator(), importer: JetpackImporter },
+	{ validator: new LocalValidator(), importer: JetpackImporter },
 	{ validator: new SqlValidator(), importer: SQLImporter },
 ];

--- a/src/lib/import-export/import/import-manager.ts
+++ b/src/lib/import-export/import/import-manager.ts
@@ -4,7 +4,7 @@ import path from 'path';
 import { ImportExportEventData, handleEvents } from '../handle-events';
 import { BackupExtractEvents, ImporterEvents, ValidatorEvents } from './events';
 import { BackupHandlerFactory } from './handlers/backup-handler-factory';
-import {Importer, ImporterResult, JetpackImporter, LocalImporter, SQLImporter} from './importers/importer';
+import { Importer, ImporterResult, JetpackImporter, LocalImporter, SQLImporter } from './importers/importer';
 import { BackupArchiveInfo, NewImporter } from './types';
 import { JetpackValidator, SqlValidator, LocalValidator } from './validators';
 import { Validator } from './validators/validator';

--- a/src/lib/import-export/import/importers/importer.ts
+++ b/src/lib/import-export/import/importers/importer.ts
@@ -102,6 +102,7 @@ abstract class BaseBackupImporter extends BaseImporter {
 				extractionDirectory: this.backup.extractionDirectory,
 				sqlFiles: this.backup.sqlFiles,
 				wpContent: this.backup.wpContent,
+				wpContentDirectory: this.backup.wpContentDirectory,
 				meta,
 			};
 		} catch ( error ) {
@@ -127,7 +128,8 @@ abstract class BaseBackupImporter extends BaseImporter {
 		this.emit( ImportEvents.IMPORT_WP_CONTENT_START );
 		const extractionDirectory = this.backup.extractionDirectory;
 		const wpContent = this.backup.wpContent;
-		const wpContentDir = path.join( rootPath, 'wp-content' );
+		const wpContentSourceDir = this.backup.wpContentDirectory;
+		const wpContentDestDir = path.join( rootPath, 'wp-content' );
 		for ( const files of Object.values( wpContent ) ) {
 			for ( const file of files ) {
 				const stats = await lstat( file );
@@ -135,8 +137,11 @@ abstract class BaseBackupImporter extends BaseImporter {
 				if ( stats.isDirectory() ) {
 					continue;
 				}
-				const relativePath = path.relative( path.join( extractionDirectory, 'wp-content' ), file );
-				const destPath = path.join( wpContentDir, relativePath );
+				const relativePath = path.relative(
+					path.join( extractionDirectory, wpContentSourceDir ),
+					file
+				);
+				const destPath = path.join( wpContentDestDir, relativePath );
 				await fsPromises.mkdir( path.dirname( destPath ), { recursive: true } );
 				await fsPromises.copyFile( file, destPath );
 			}
@@ -200,6 +205,7 @@ export class SQLImporter extends BaseImporter {
 				extractionDirectory: this.backup.extractionDirectory,
 				sqlFiles: this.backup.sqlFiles,
 				wpContent: this.backup.wpContent,
+				wpContentDirectory: this.backup.wpContentDirectory,
 			};
 		} catch ( error ) {
 			this.emit( ImportEvents.IMPORT_ERROR, error );

--- a/src/lib/import-export/import/importers/importer.ts
+++ b/src/lib/import-export/import/importers/importer.ts
@@ -90,6 +90,7 @@ export abstract class BaseBackupImporter extends BaseImporter implements Importe
 			if ( this.backup.metaFile ) {
 				meta = await this.parseMetaFile();
 			}
+
 			this.emit( ImportEvents.IMPORT_COMPLETE );
 			return {
 				extractionDirectory: this.backup.extractionDirectory,

--- a/src/lib/import-export/import/importers/importer.ts
+++ b/src/lib/import-export/import/importers/importer.ts
@@ -24,7 +24,11 @@ abstract class BaseImporter extends EventEmitter implements Importer {
 
 	abstract import( rootPath: string, siteId: string ): Promise< ImporterResult >;
 
-	async importDatabase( rootPath: string, siteId: string, sqlFiles: string[] ): Promise< void > {
+	protected async importDatabase(
+		rootPath: string,
+		siteId: string,
+		sqlFiles: string[]
+	): Promise< void > {
 		if ( ! sqlFiles.length ) {
 			return;
 		}

--- a/src/lib/import-export/import/importers/importer.ts
+++ b/src/lib/import-export/import/importers/importer.ts
@@ -78,7 +78,7 @@ abstract class BaseImporter extends EventEmitter implements Importer {
 	}
 }
 
-export abstract class BaseBackupImporter extends BaseImporter {
+abstract class BaseBackupImporter extends BaseImporter {
 	async import( rootPath: string, siteId: string ): Promise< ImporterResult > {
 		this.emit( ImportEvents.IMPORT_START );
 

--- a/src/lib/import-export/import/importers/importer.ts
+++ b/src/lib/import-export/import/importers/importer.ts
@@ -23,12 +23,80 @@ abstract class BaseImporter extends EventEmitter implements Importer {
 	}
 
 	abstract import( rootPath: string, siteId: string ): Promise< ImporterResult >;
+}
 
-	protected async importDatabase(
-		rootPath: string,
-		siteId: string,
-		sqlFiles: string[]
-	): Promise< void > {
+export abstract class BaseBackupImporter extends BaseImporter implements Importer {
+	async import( rootPath: string, siteId: string ): Promise< ImporterResult > {
+		this.emit( ImportEvents.IMPORT_START );
+
+		try {
+			const databaseDir = path.join( rootPath, 'wp-content', 'database' );
+			const dbPath = path.join( databaseDir, '.ht.sqlite' );
+			const dbImporter = new DatabaseImporter();
+
+			await this.moveExistingDatabaseToTrash( dbPath );
+			await this.createEmptyDatabase( dbPath );
+			await dbImporter.importDatabase( rootPath, siteId, this.backup.sqlFiles );
+			await this.importWpContent( rootPath );
+			let meta: MetaFileData | undefined;
+			if ( this.backup.metaFile ) {
+				meta = await this.parseMetaFile();
+			}
+
+			this.emit( ImportEvents.IMPORT_COMPLETE );
+			return {
+				extractionDirectory: this.backup.extractionDirectory,
+				sqlFiles: this.backup.sqlFiles,
+				wpContent: this.backup.wpContent,
+				meta,
+			};
+		} catch ( error ) {
+			this.emit( ImportEvents.IMPORT_ERROR, error );
+			throw error;
+		}
+	}
+
+	protected abstract parseMetaFile(): Promise< MetaFileData | undefined >;
+
+	protected async createEmptyDatabase( dbPath: string ): Promise< void > {
+		await fsPromises.writeFile( dbPath, '' );
+	}
+
+	protected async moveExistingDatabaseToTrash( dbPath: string ): Promise< void > {
+		if ( ! fs.existsSync( dbPath ) ) {
+			return;
+		}
+		await shell.trashItem( dbPath );
+	}
+
+	protected async importWpContent( rootPath: string ): Promise< void > {
+		this.emit( ImportEvents.IMPORT_WP_CONTENT_START );
+		const extractionDirectory = this.backup.extractionDirectory;
+		const wpContent = this.backup.wpContent;
+		const wpContentDir = path.join( rootPath, 'wp-content' );
+		for ( const files of Object.values( wpContent ) ) {
+			for ( const file of files ) {
+				const stats = await lstat( file );
+				// Skip if it's a directory
+				if ( stats.isDirectory() ) {
+					continue;
+				}
+				const relativePath = path.relative( path.join( extractionDirectory, 'wp-content' ), file );
+				const destPath = path.join( wpContentDir, relativePath );
+				await fsPromises.mkdir( path.dirname( destPath ), { recursive: true } );
+				await fsPromises.copyFile( file, destPath );
+			}
+		}
+		this.emit( ImportEvents.IMPORT_WP_CONTENT_COMPLETE );
+	}
+}
+
+export class DatabaseImporter extends EventEmitter {
+	constructor() {
+		super();
+	}
+
+	async importDatabase( rootPath: string, siteId: string, sqlFiles: string[] ): Promise< void > {
 		if ( ! sqlFiles.length ) {
 			return;
 		}
@@ -78,68 +146,25 @@ abstract class BaseImporter extends EventEmitter implements Importer {
 	}
 }
 
-export class JetpackImporter extends BaseImporter {
-	async import( rootPath: string, siteId: string ): Promise< ImporterResult > {
-		this.emit( ImportEvents.IMPORT_START );
-
-		try {
-			const databaseDir = path.join( rootPath, 'wp-content', 'database' );
-			const dbPath = path.join( databaseDir, '.ht.sqlite' );
-
-			await this.moveExistingDatabaseToTrash( dbPath );
-			await this.createEmptyDatabase( dbPath );
-			await this.importDatabase( rootPath, siteId, this.backup.sqlFiles );
-			await this.importWpContent( rootPath );
-			let meta: MetaFileData | undefined;
-			if ( this.backup.metaFile ) {
-				meta = await this.parseMetaFile();
-			}
-
-			this.emit( ImportEvents.IMPORT_COMPLETE );
-			return {
-				extractionDirectory: this.backup.extractionDirectory,
-				sqlFiles: this.backup.sqlFiles,
-				wpContent: this.backup.wpContent,
-				meta,
-			};
-		} catch ( error ) {
-			this.emit( ImportEvents.IMPORT_ERROR, error );
-			throw error;
-		}
-	}
-
-	protected async createEmptyDatabase( dbPath: string ): Promise< void > {
-		await fsPromises.writeFile( dbPath, '' );
-	}
-
-	protected async moveExistingDatabaseToTrash( dbPath: string ): Promise< void > {
-		if ( ! fs.existsSync( dbPath ) ) {
+export class JetpackImporter extends BaseBackupImporter {
+	protected async parseMetaFile(): Promise< MetaFileData | undefined > {
+		const metaFilePath = this.backup.metaFile;
+		if ( ! metaFilePath ) {
 			return;
 		}
-		await shell.trashItem( dbPath );
-	}
-
-	protected async importWpContent( rootPath: string ): Promise< void > {
-		this.emit( ImportEvents.IMPORT_WP_CONTENT_START );
-		const extractionDirectory = this.backup.extractionDirectory;
-		const wpContent = this.backup.wpContent;
-		const wpContentDir = path.join( rootPath, 'wp-content' );
-		for ( const files of Object.values( wpContent ) ) {
-			for ( const file of files ) {
-				const stats = await lstat( file );
-				// Skip if it's a directory
-				if ( stats.isDirectory() ) {
-					continue;
-				}
-				const relativePath = path.relative( path.join( extractionDirectory, 'wp-content' ), file );
-				const destPath = path.join( wpContentDir, relativePath );
-				await fsPromises.mkdir( path.dirname( destPath ), { recursive: true } );
-				await fsPromises.copyFile( file, destPath );
-			}
+		this.emit( ImportEvents.IMPORT_META_START );
+		try {
+			const metaContent = await fsPromises.readFile( metaFilePath, 'utf-8' );
+			return JSON.parse( metaContent );
+		} catch ( e ) {
+			return;
+		} finally {
+			this.emit( ImportEvents.IMPORT_META_COMPLETE );
 		}
-		this.emit( ImportEvents.IMPORT_WP_CONTENT_COMPLETE );
 	}
+}
 
+export class LocalImporter extends BaseBackupImporter {
 	protected async parseMetaFile(): Promise< MetaFileData | undefined > {
 		const metaFilePath = this.backup.metaFile;
 		if ( ! metaFilePath ) {
@@ -158,11 +183,16 @@ export class JetpackImporter extends BaseImporter {
 }
 
 export class SQLImporter extends BaseImporter {
+	constructor( protected backup: BackupContents ) {
+		super( backup );
+	}
+
 	async import( rootPath: string, siteId: string ): Promise< ImporterResult > {
+		const dbImporter = new DatabaseImporter();
 		this.emit( ImportEvents.IMPORT_START );
 
 		try {
-			await this.importDatabase( rootPath, siteId, this.backup.sqlFiles );
+			await dbImporter.importDatabase( rootPath, siteId, this.backup.sqlFiles );
 
 			this.emit( ImportEvents.IMPORT_COMPLETE );
 			return {

--- a/src/lib/import-export/import/importers/importer.ts
+++ b/src/lib/import-export/import/importers/importer.ts
@@ -185,10 +185,6 @@ export class LocalImporter extends BaseBackupImporter {
 }
 
 export class SQLImporter extends BaseImporter {
-	constructor( protected backup: BackupContents ) {
-		super( backup );
-	}
-
 	async import( rootPath: string, siteId: string ): Promise< ImporterResult > {
 		this.emit( ImportEvents.IMPORT_START );
 

--- a/src/lib/import-export/import/importers/importer.ts
+++ b/src/lib/import-export/import/importers/importer.ts
@@ -4,6 +4,8 @@ import fs from 'fs';
 import fsPromises from 'fs/promises';
 import path from 'path';
 import { lstat, rename } from 'fs-extra';
+import semver from 'semver';
+import { DEFAULT_PHP_VERSION } from '../../../../../vendor/wp-now/src/constants';
 import { SiteServer } from '../../../../site-server';
 import { generateBackupFilename } from '../../export/generate-backup-filename';
 import { ImportEvents } from '../events';
@@ -171,9 +173,11 @@ export class LocalImporter extends BaseBackupImporter {
 		try {
 			const metaContent = await fsPromises.readFile( metaFilePath, 'utf-8' );
 			const meta = JSON.parse( metaContent );
-			const phpVersion = meta?.services?.php?.version;
+			const phpVersion = semver.coerce( meta?.services?.php?.version );
 			return {
-				phpVersion: phpVersion.split( '.' ).slice( 0, 2 ).join( '.' ) ?? '8.1',
+				phpVersion: phpVersion
+					? `${ phpVersion.major }.${ phpVersion.minor }`
+					: DEFAULT_PHP_VERSION,
 				wordpressVersion: '',
 			};
 		} catch ( e ) {

--- a/src/lib/import-export/import/importers/importer.ts
+++ b/src/lib/import-export/import/importers/importer.ts
@@ -78,7 +78,7 @@ abstract class BaseImporter extends EventEmitter implements Importer {
 	}
 }
 
-export abstract class BaseBackupImporter extends BaseImporter implements Importer {
+export abstract class BaseBackupImporter extends BaseImporter {
 	async import( rootPath: string, siteId: string ): Promise< ImporterResult > {
 		this.emit( ImportEvents.IMPORT_START );
 

--- a/src/lib/import-export/import/importers/importer.ts
+++ b/src/lib/import-export/import/importers/importer.ts
@@ -42,7 +42,6 @@ export abstract class BaseBackupImporter extends BaseImporter implements Importe
 			if ( this.backup.metaFile ) {
 				meta = await this.parseMetaFile();
 			}
-
 			this.emit( ImportEvents.IMPORT_COMPLETE );
 			return {
 				extractionDirectory: this.backup.extractionDirectory,
@@ -173,7 +172,12 @@ export class LocalImporter extends BaseBackupImporter {
 		this.emit( ImportEvents.IMPORT_META_START );
 		try {
 			const metaContent = await fsPromises.readFile( metaFilePath, 'utf-8' );
-			return JSON.parse( metaContent );
+			const meta = JSON.parse( metaContent );
+			const phpVersion = meta?.services?.php?.version;
+			return {
+				phpVersion: phpVersion.split( '.' ).slice( 0, 2 ).join( '.' ) ?? '8.1',
+				wordpressVersion: '',
+			};
 		} catch ( e ) {
 			return;
 		} finally {

--- a/src/lib/import-export/import/types.ts
+++ b/src/lib/import-export/import/types.ts
@@ -15,6 +15,7 @@ export interface BackupContents {
 	extractionDirectory: string;
 	sqlFiles: string[];
 	wpContent: WpContent;
+	wpContentDirectory: string;
 	metaFile?: string;
 }
 

--- a/src/lib/import-export/import/validators/index.ts
+++ b/src/lib/import-export/import/validators/index.ts
@@ -1,3 +1,4 @@
 export * from './validator';
 export * from './sql-validator';
 export * from './jetpack-validator';
+export * from './local-validator';

--- a/src/lib/import-export/import/validators/jetpack-validator.ts
+++ b/src/lib/import-export/import/validators/jetpack-validator.ts
@@ -23,6 +23,7 @@ export class JetpackValidator extends EventEmitter implements Validator {
 				plugins: [],
 				themes: [],
 			},
+			wpContentDirectory: 'wp-content',
 		};
 		/* File rules:
 		 * - Ignore wp-config.php

--- a/src/lib/import-export/import/validators/local-validator.ts
+++ b/src/lib/import-export/import/validators/local-validator.ts
@@ -28,6 +28,7 @@ export class LocalValidator extends EventEmitter implements Validator {
 				plugins: [],
 				themes: [],
 			},
+			wpContentDirectory: 'app/public/wp-content',
 		};
 		/* File rules:
 		 * - Ignore wp-config.php

--- a/src/lib/import-export/import/validators/local-validator.ts
+++ b/src/lib/import-export/import/validators/local-validator.ts
@@ -1,0 +1,64 @@
+import { EventEmitter } from 'events';
+import path from 'path';
+import { ImportEvents } from '../events';
+import { BackupContents } from '../types';
+import { Validator } from './validator';
+
+export class LocalValidator extends EventEmitter implements Validator {
+	canHandle( fileList: string[] ): boolean {
+		const requiredDirs = [
+			'app/sql',
+			'app/public/wp-content/uploads',
+			'app/public/wp-content/plugins',
+			'app/public/wp-content/themes',
+		];
+		return (
+			requiredDirs.some( ( dir ) => fileList.some( ( file ) => file.startsWith( dir + '/' ) ) ) &&
+			fileList.some( ( file ) => file.startsWith( 'app/sql/' ) && file.endsWith( '.sql' ) )
+		);
+	}
+
+	parseBackupContents( fileList: string[], extractionDirectory: string ): BackupContents {
+		this.emit( ImportEvents.IMPORT_VALIDATION_START );
+		const extractedBackup: BackupContents = {
+			extractionDirectory: extractionDirectory,
+			sqlFiles: [],
+			wpContent: {
+				uploads: [],
+				plugins: [],
+				themes: [],
+			},
+		};
+		/* File rules:
+		 * - Ignore wp-config.php
+		 * - Accept .zip
+		 * - Do not reject the archive that includes core WP files, and ignore those instead.
+		 * - Support optional meta file, local-site.json, that stores desired PHP and WP versions.
+		 * */
+
+		for ( const file of fileList ) {
+			// Ignore wp-config.php
+			if ( file === 'app/public/wp-config.php' ) continue;
+
+			const fullPath = path.join( extractionDirectory, file );
+
+			if ( file.startsWith( 'app/sql/' ) && file.endsWith( '.sql' ) ) {
+				extractedBackup.sqlFiles.push( fullPath );
+			} else if ( file.startsWith( 'app/public/wp-content/uploads/' ) ) {
+				extractedBackup.wpContent.uploads.push( fullPath );
+			} else if ( file.startsWith( 'app/public/wp-content/plugins/' ) ) {
+				extractedBackup.wpContent.plugins.push( fullPath );
+			} else if ( file.startsWith( 'app/public/wp-content/themes/' ) ) {
+				extractedBackup.wpContent.themes.push( fullPath );
+			} else if ( file === 'local-site.json' ) {
+				extractedBackup.metaFile = fullPath;
+			}
+		}
+		extractedBackup.sqlFiles.sort( ( a: string, b: string ) =>
+			path.basename( a ).localeCompare( path.basename( b ) )
+		);
+
+		this.emit( ImportEvents.IMPORT_VALIDATION_COMPLETE );
+		return extractedBackup;
+	}
+}

--- a/src/lib/import-export/import/validators/sql-validator.ts
+++ b/src/lib/import-export/import/validators/sql-validator.ts
@@ -19,6 +19,7 @@ export class SqlValidator extends EventEmitter implements Validator {
 				plugins: [],
 				themes: [],
 			},
+			wpContentDirectory: '',
 		};
 
 		for ( const file of fileList ) {

--- a/src/lib/import-export/tests/import/importer/default-importer.test.ts
+++ b/src/lib/import-export/tests/import/importer/default-importer.test.ts
@@ -18,6 +18,7 @@ describe( 'JetpackImporter', () => {
 			plugins: [ '/tmp/extracted/wp-content/plugins/jetpack/jetpack.php' ],
 			themes: [ '/tmp/extracted/wp-content/themes/twentytwentyone/style.css' ],
 		},
+		wpContentDirectory: 'wp-content',
 		metaFile: '/tmp/extracted/studio.json',
 	};
 

--- a/src/lib/import-export/tests/import/importer/default-importer.test.ts
+++ b/src/lib/import-export/tests/import/importer/default-importer.test.ts
@@ -44,7 +44,7 @@ describe( 'JetpackImporter', () => {
 		} );
 	} );
 
-	afterAll( () => {
+	afterEach( () => {
 		jest.useRealTimers();
 	} );
 

--- a/src/lib/import-export/tests/import/importer/local-importer.test.ts
+++ b/src/lib/import-export/tests/import/importer/local-importer.test.ts
@@ -44,7 +44,7 @@ describe( 'localImporter', () => {
 		} );
 	} );
 
-	afterAll( () => {
+	afterEach( () => {
 		jest.useRealTimers();
 	} );
 

--- a/src/lib/import-export/tests/import/importer/local-importer.test.ts
+++ b/src/lib/import-export/tests/import/importer/local-importer.test.ts
@@ -1,0 +1,103 @@
+// To run tests, execute `npm run test -- src/lib/import-export/tests/import/importer/local-importer.test.ts`
+import * as fs from 'fs/promises';
+import { lstat, rename } from 'fs-extra';
+import { SiteServer } from '../../../../../site-server';
+import { LocalImporter } from '../../../import/importers';
+import { BackupContents } from '../../../import/types';
+
+jest.mock( 'fs/promises' );
+jest.mock( '../../../../../site-server' );
+jest.mock( 'fs-extra' );
+
+describe( 'localImporter', () => {
+	const mockBackupContents: BackupContents = {
+		extractionDirectory: '/tmp/extracted',
+		sqlFiles: [ '/tmp/extracted/app/sql/local.sql', '/tmp/extracted/app/sql/local.sql' ],
+		wpContent: {
+			uploads: [ '/tmp/extracted/app/public/wp-content/uploads/2023/image.jpg' ],
+			plugins: [ '/tmp/extracted/app/public/wp-content/plugins/jetpack/jetpack.php' ],
+			themes: [ '/tmp/extracted/app/public/wp-content/themes/twentytwentyone/style.css' ],
+		},
+		metaFile: '/tmp/extracted/local-site.json',
+	};
+
+	const mockStudioSitePath = '/path/to/studio/site';
+	const mockStudioSiteId = '123';
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+
+		( SiteServer.get as jest.Mock ).mockReturnValue( {
+			details: { path: '/path/to/site' },
+			executeWpCliCommand: jest.fn().mockReturnValue( { stderr: null } ),
+		} );
+
+		// mock rename
+		( rename as jest.Mock ).mockResolvedValue( null );
+
+		jest.useFakeTimers();
+		jest.setSystemTime( new Date( '2024-08-01T12:00:00Z' ) );
+
+		( lstat as jest.Mock ).mockResolvedValue( {
+			isDirectory: jest.fn().mockReturnValue( false ),
+		} );
+	} );
+
+	afterAll( () => {
+		jest.useRealTimers();
+	} );
+
+	describe( 'import', () => {
+		it( 'should copy wp-content files and read meta file', async () => {
+			const importer = new LocalImporter( mockBackupContents );
+			( fs.mkdir as jest.Mock ).mockResolvedValue( undefined );
+			( fs.copyFile as jest.Mock ).mockResolvedValue( undefined );
+			( fs.readFile as jest.Mock ).mockResolvedValue(
+				JSON.stringify( {
+					services: {
+						php: {
+							version: '8.2.23',
+						},
+					},
+				} )
+			);
+
+			const result = await importer.import( mockStudioSitePath, mockStudioSiteId );
+
+			expect( result?.meta?.phpVersion ).toBe( '8.2' );
+
+			expect( fs.mkdir ).toHaveBeenCalled();
+			expect( fs.copyFile ).toHaveBeenCalledTimes( 3 ); // One for each wp-content file
+			expect( fs.readFile ).toHaveBeenCalledWith( '/tmp/extracted/local-site.json', 'utf-8' );
+		} );
+
+		it( 'should handle missing meta file', async () => {
+			const importer = new LocalImporter( { ...mockBackupContents, metaFile: undefined } );
+			( fs.mkdir as jest.Mock ).mockResolvedValue( undefined );
+			( fs.copyFile as jest.Mock ).mockResolvedValue( undefined );
+
+			const result = await importer.import( mockStudioSitePath, mockStudioSiteId );
+
+			expect( result?.meta?.phpVersion ).toBe( undefined );
+
+			expect( fs.mkdir ).toHaveBeenCalled();
+			expect( fs.copyFile ).toHaveBeenCalledTimes( 3 );
+			expect( fs.readFile ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should handle JSON parse error in meta file', async () => {
+			const importer = new LocalImporter( mockBackupContents );
+			( fs.mkdir as jest.Mock ).mockResolvedValue( undefined );
+			( fs.copyFile as jest.Mock ).mockResolvedValue( undefined );
+			( fs.readFile as jest.Mock ).mockResolvedValue( 'Invalid JSON' );
+
+			await expect(
+				importer.import( mockStudioSitePath, mockStudioSiteId )
+			).resolves.not.toThrow();
+
+			expect( fs.mkdir ).toHaveBeenCalled();
+			expect( fs.copyFile ).toHaveBeenCalledTimes( 3 );
+			expect( fs.readFile ).toHaveBeenCalledWith( '/tmp/extracted/local-site.json', 'utf-8' );
+		} );
+	} );
+} );

--- a/src/lib/import-export/tests/import/importer/local-importer.test.ts
+++ b/src/lib/import-export/tests/import/importer/local-importer.test.ts
@@ -18,6 +18,7 @@ describe( 'localImporter', () => {
 			plugins: [ '/tmp/extracted/app/public/wp-content/plugins/jetpack/jetpack.php' ],
 			themes: [ '/tmp/extracted/app/public/wp-content/themes/twentytwentyone/style.css' ],
 		},
+		wpContentDirectory: 'app/public/wp-content',
 		metaFile: '/tmp/extracted/local-site.json',
 	};
 

--- a/src/lib/import-export/tests/import/validators/jetpack-validator.test.ts
+++ b/src/lib/import-export/tests/import/validators/jetpack-validator.test.ts
@@ -54,6 +54,7 @@ describe( 'JetpackValidator', () => {
 					plugins: [ '/tmp/extracted/wp-content/plugins/jetpack/jetpack.php' ],
 					themes: [ '/tmp/extracted/wp-content/themes/twentytwentyone/style.css' ],
 				},
+				wpContentDirectory: 'wp-content',
 				metaFile: '/tmp/extracted/studio.json',
 			} );
 		} );
@@ -81,6 +82,7 @@ describe( 'JetpackValidator', () => {
 					plugins: [ '/tmp/extracted/wp-content/plugins/jetpack/jetpack.php' ],
 					themes: [ '/tmp/extracted/wp-content/themes/twentytwentyone/style.css' ],
 				},
+				wpContentDirectory: 'wp-content',
 				metaFile: '/tmp/extracted/studio.json',
 			} );
 		} );

--- a/src/lib/import-export/tests/import/validators/local-validator.test.ts
+++ b/src/lib/import-export/tests/import/validators/local-validator.test.ts
@@ -7,7 +7,7 @@ describe( 'LocalValidator', () => {
 	describe( 'canHandle', () => {
 		it( 'should return true for valid Local backup structure', () => {
 			const fileList = [
-				'app/sql/wp_options.sql',
+				'app/sql/local.sql',
 				'app/public/wp-content/uploads/2023/image.jpg',
 				'app/public/wp-content/plugins/jetpack/jetpack.php',
 				'app/public/wp-content/themes/twentytwentyone/style.css',
@@ -17,7 +17,7 @@ describe( 'LocalValidator', () => {
 
 		it( 'should not fail if core files exists.', () => {
 			const fileList = [
-				'app/sql/wp_options.sql',
+				'app/sql/local.sql',
 				'app/public/wp-admin/wp-admin.php',
 				'app/public/wp-admin/about.php',
 				'app/public/wp-includes/test.php',
@@ -37,7 +37,7 @@ describe( 'LocalValidator', () => {
 	describe( 'parseBackupContents', () => {
 		it( 'should correctly parse backup contents', () => {
 			const fileList = [
-				'app/sql/wp_options.sql',
+				'app/sql/local.sql',
 				'app/public/wp-content/uploads/2023/image.jpg',
 				'app/public/wp-content/plugins/jetpack/jetpack.php',
 				'app/public/wp-content/themes/twentytwentyone/style.css',
@@ -48,7 +48,7 @@ describe( 'LocalValidator', () => {
 
 			expect( result ).toEqual( {
 				extractionDirectory,
-				sqlFiles: [ '/tmp/extracted/app/sql/wp_options.sql' ],
+				sqlFiles: [ '/tmp/extracted/app/sql/local.sql' ],
 				wpContent: {
 					uploads: [ '/tmp/extracted/app/public/wp-content/uploads/2023/image.jpg' ],
 					plugins: [ '/tmp/extracted/app/public/wp-content/plugins/jetpack/jetpack.php' ],
@@ -60,7 +60,7 @@ describe( 'LocalValidator', () => {
 
 		it( 'should ignore files that not needed', () => {
 			const fileList = [
-				'app/sql/wp_options.sql',
+				'app/sql/local.sql',
 				'app/public/wp-admin/wp-admin.php',
 				'app/public/wp-admin/about.php',
 				'app/public/wp-includes/test.php',
@@ -75,7 +75,7 @@ describe( 'LocalValidator', () => {
 
 			expect( result ).toEqual( {
 				extractionDirectory,
-				sqlFiles: [ '/tmp/extracted/app/sql/wp_options.sql' ],
+				sqlFiles: [ '/tmp/extracted/app/sql/local.sql' ],
 				wpContent: {
 					uploads: [ '/tmp/extracted/app/public/wp-content/uploads/2023/image.jpg' ],
 					plugins: [ '/tmp/extracted/app/public/wp-content/plugins/jetpack/jetpack.php' ],

--- a/src/lib/import-export/tests/import/validators/local-validator.test.ts
+++ b/src/lib/import-export/tests/import/validators/local-validator.test.ts
@@ -1,0 +1,88 @@
+// To run tests, execute `npm run test -- src/lib/import-export/tests/import/validators/local-validator.test.ts`
+import { LocalValidator } from '../../../import/validators/local-validator';
+
+describe( 'LocalValidator', () => {
+	const validator = new LocalValidator();
+
+	describe( 'canHandle', () => {
+		it( 'should return true for valid Local backup structure', () => {
+			const fileList = [
+				'app/sql/wp_options.sql',
+				'app/public/wp-content/uploads/2023/image.jpg',
+				'app/public/wp-content/plugins/jetpack/jetpack.php',
+				'app/public/wp-content/themes/twentytwentyone/style.css',
+			];
+			expect( validator.canHandle( fileList ) ).toBe( true );
+		} );
+
+		it( 'should not fail if core files exists.', () => {
+			const fileList = [
+				'app/sql/wp_options.sql',
+				'app/public/wp-admin/wp-admin.php',
+				'app/public/wp-admin/about.php',
+				'app/public/wp-includes/test.php',
+				'app/public/wp-content/uploads/2023/image.jpg',
+				'app/public/wp-content/plugins/jetpack/jetpack.php',
+				'app/public/wp-content/themes/twentytwentyone/style.css',
+			];
+			expect( validator.canHandle( fileList ) ).toBe( true );
+		} );
+
+		it( 'should return false for invalid backup structure', () => {
+			const fileList = [ 'random.txt', 'another-file.js' ];
+			expect( validator.canHandle( fileList ) ).toBe( false );
+		} );
+	} );
+
+	describe( 'parseBackupContents', () => {
+		it( 'should correctly parse backup contents', () => {
+			const fileList = [
+				'app/sql/wp_options.sql',
+				'app/public/wp-content/uploads/2023/image.jpg',
+				'app/public/wp-content/plugins/jetpack/jetpack.php',
+				'app/public/wp-content/themes/twentytwentyone/style.css',
+				'local-site.json',
+			];
+			const extractionDirectory = '/tmp/extracted';
+			const result = validator.parseBackupContents( fileList, extractionDirectory );
+
+			expect( result ).toEqual( {
+				extractionDirectory,
+				sqlFiles: [ '/tmp/extracted/app/sql/wp_options.sql' ],
+				wpContent: {
+					uploads: [ '/tmp/extracted/app/public/wp-content/uploads/2023/image.jpg' ],
+					plugins: [ '/tmp/extracted/app/public/wp-content/plugins/jetpack/jetpack.php' ],
+					themes: [ '/tmp/extracted/app/public/wp-content/themes/twentytwentyone/style.css' ],
+				},
+				metaFile: '/tmp/extracted/local-site.json',
+			} );
+		} );
+
+		it( 'should ignore files that not needed', () => {
+			const fileList = [
+				'app/sql/wp_options.sql',
+				'app/public/wp-admin/wp-admin.php',
+				'app/public/wp-admin/about.php',
+				'app/public/wp-includes/test.php',
+				'app/public/wp-content/wp-config.php',
+				'app/public/wp-content/uploads/2023/image.jpg',
+				'app/public/wp-content/plugins/jetpack/jetpack.php',
+				'app/public/wp-content/themes/twentytwentyone/style.css',
+				'local-site.json',
+			];
+			const extractionDirectory = '/tmp/extracted';
+			const result = validator.parseBackupContents( fileList, extractionDirectory );
+
+			expect( result ).toEqual( {
+				extractionDirectory,
+				sqlFiles: [ '/tmp/extracted/app/sql/wp_options.sql' ],
+				wpContent: {
+					uploads: [ '/tmp/extracted/app/public/wp-content/uploads/2023/image.jpg' ],
+					plugins: [ '/tmp/extracted/app/public/wp-content/plugins/jetpack/jetpack.php' ],
+					themes: [ '/tmp/extracted/app/public/wp-content/themes/twentytwentyone/style.css' ],
+				},
+				metaFile: '/tmp/extracted/local-site.json',
+			} );
+		} );
+	} );
+} );

--- a/src/lib/import-export/tests/import/validators/local-validator.test.ts
+++ b/src/lib/import-export/tests/import/validators/local-validator.test.ts
@@ -54,6 +54,7 @@ describe( 'LocalValidator', () => {
 					plugins: [ '/tmp/extracted/app/public/wp-content/plugins/jetpack/jetpack.php' ],
 					themes: [ '/tmp/extracted/app/public/wp-content/themes/twentytwentyone/style.css' ],
 				},
+				wpContentDirectory: 'app/public/wp-content',
 				metaFile: '/tmp/extracted/local-site.json',
 			} );
 		} );
@@ -81,6 +82,7 @@ describe( 'LocalValidator', () => {
 					plugins: [ '/tmp/extracted/app/public/wp-content/plugins/jetpack/jetpack.php' ],
 					themes: [ '/tmp/extracted/app/public/wp-content/themes/twentytwentyone/style.css' ],
 				},
+				wpContentDirectory: 'app/public/wp-content',
 				metaFile: '/tmp/extracted/local-site.json',
 			} );
 		} );

--- a/src/lib/import-export/tests/import/validators/sql-validator.test.ts
+++ b/src/lib/import-export/tests/import/validators/sql-validator.test.ts
@@ -40,6 +40,7 @@ describe( 'SqlValidator', () => {
 					plugins: [],
 					themes: [],
 				},
+				wpContentDirectory: '',
 			} );
 		} );
 	} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/8164

## Proposed Changes

I propose to add support importing site backup exported from the Local app.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create a site in the Local
2. Install custom theme, activate it, upload media, install the plugin, add post etc.
3. Export site from Local
4. Import site to Studio

Confirm that the site looks in the same way as in Local.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
