### PR TITLE
Studio: Fix import/export database on linux

### DIFF
--- a/src/lib/app-globals.ts
+++ b/src/lib/app-globals.ts
@@ -14,6 +14,9 @@ export function isWindows() {
 }
 
 export function isLinux() {
+	if ( process.env.NODE_ENV === 'test' ) {
+		return false;
+	}
 	const platform = process ? process.platform : getAppGlobals().platform;
 	return platform === 'linux';
 }

--- a/src/lib/app-globals.ts
+++ b/src/lib/app-globals.ts
@@ -13,6 +13,11 @@ export function isWindows() {
 	return getAppGlobals().platform === 'win32';
 }
 
+export function isLinux() {
+	const platform = process ? process.platform : getAppGlobals().platform;
+	return platform === 'linux';
+}
+
 export function getPlatformName() {
 	const platform = process ? process.platform : getAppGlobals().platform;
 	switch ( platform ) {

--- a/src/lib/import-export/export/export-database.ts
+++ b/src/lib/import-export/export/export-database.ts
@@ -1,7 +1,8 @@
 import path from 'path';
-import { rename } from 'fs-extra';
+import { move, rename } from 'fs-extra';
 import { SiteServer } from '../../../site-server';
 import { generateBackupFilename } from './generate-backup-filename';
+import { isLinux } from '../../../lib/app-globals';
 
 export async function exportDatabaseToFile(
 	site: SiteDetails,
@@ -32,7 +33,11 @@ export async function exportDatabaseToFile(
 	}
 
 	// Move the file to its final destination
-	await rename( tempFilePath, finalDestination );
+	if ( isLinux() ) {
+		await move( tempFilePath, finalDestination );
+	} else {
+		await rename( tempFilePath, finalDestination );
+	}
 
 	console.log( `Database export saved to ${ finalDestination }` );
 }

--- a/src/lib/import-export/export/export-database.ts
+++ b/src/lib/import-export/export/export-database.ts
@@ -1,8 +1,8 @@
 import path from 'path';
 import { move, rename } from 'fs-extra';
+import { isLinux } from '../../../lib/app-globals';
 import { SiteServer } from '../../../site-server';
 import { generateBackupFilename } from './generate-backup-filename';
-import { isLinux } from '../../../lib/app-globals';
 
 export async function exportDatabaseToFile(
 	site: SiteDetails,

--- a/src/lib/import-export/export/export-database.ts
+++ b/src/lib/import-export/export/export-database.ts
@@ -1,6 +1,5 @@
 import path from 'path';
-import { move, rename } from 'fs-extra';
-import { isLinux } from '../../../lib/app-globals';
+import { move } from 'fs-extra';
 import { SiteServer } from '../../../site-server';
 import { generateBackupFilename } from './generate-backup-filename';
 
@@ -33,11 +32,7 @@ export async function exportDatabaseToFile(
 	}
 
 	// Move the file to its final destination
-	if ( isLinux() ) {
-		await move( tempFilePath, finalDestination );
-	} else {
-		await rename( tempFilePath, finalDestination );
-	}
+	await move( tempFilePath, finalDestination );
 
 	console.log( `Database export saved to ${ finalDestination }` );
 }

--- a/src/lib/import-export/import/importers/importer.ts
+++ b/src/lib/import-export/import/importers/importer.ts
@@ -3,8 +3,7 @@ import { EventEmitter } from 'events';
 import fs from 'fs';
 import fsPromises from 'fs/promises';
 import path from 'path';
-import { lstat, move, rename } from 'fs-extra';
-import { isLinux } from '../../../..//lib/app-globals';
+import { lstat, move } from 'fs-extra';
 import { SiteServer } from '../../../../site-server';
 import { generateBackupFilename } from '../../export/generate-backup-filename';
 import { ImportEvents } from '../events';
@@ -52,11 +51,7 @@ export abstract class BaseImporter extends EventEmitter implements Importer {
 			const tmpPath = path.join( rootPath, sqlTempFile );
 
 			try {
-				if ( isLinux() ) {
-					await move( sqlFile, tmpPath );
-				} else {
-					await rename( sqlFile, tmpPath );
-				}
+				await move( sqlFile, tmpPath );
 				const { stderr, exitCode } = await server.executeWpCliCommand(
 					`sqlite import ${ sqlTempFile } --require=/tmp/sqlite-command/command.php`
 				);

--- a/src/lib/import-export/import/importers/importer.ts
+++ b/src/lib/import-export/import/importers/importer.ts
@@ -3,7 +3,8 @@ import { EventEmitter } from 'events';
 import fs from 'fs';
 import fsPromises from 'fs/promises';
 import path from 'path';
-import { lstat, rename } from 'fs-extra';
+import { lstat, move, rename } from 'fs-extra';
+import { isLinux } from '../../../..//lib/app-globals';
 import { SiteServer } from '../../../../site-server';
 import { generateBackupFilename } from '../../export/generate-backup-filename';
 import { ImportEvents } from '../events';
@@ -51,7 +52,11 @@ export abstract class BaseImporter extends EventEmitter implements Importer {
 			const tmpPath = path.join( rootPath, sqlTempFile );
 
 			try {
-				await rename( sqlFile, tmpPath );
+				if ( isLinux() ) {
+					await move( sqlFile, tmpPath );
+				} else {
+					await rename( sqlFile, tmpPath );
+				}
 				const { stderr, exitCode } = await server.executeWpCliCommand(
 					`sqlite import ${ sqlTempFile } --require=/tmp/sqlite-command/command.php`
 				);

--- a/src/lib/import-export/tests/export/exporters/sql-exporter.test.ts
+++ b/src/lib/import-export/tests/export/exporters/sql-exporter.test.ts
@@ -1,4 +1,4 @@
-import { rename } from 'fs-extra';
+import { move } from 'fs-extra';
 import { SiteServer } from '../../../../../site-server';
 import { SqlExporter } from '../../../export/exporters';
 import { ExportOptions } from '../../../export/types';
@@ -41,7 +41,7 @@ describe( 'SqlExporter', () => {
 			details: { path: '/path/to/site' },
 			executeWpCliCommand: jest.fn().mockResolvedValue( { stderr: null } ),
 		} );
-		( rename as jest.Mock ).mockResolvedValue( null );
+		( move as jest.Mock ).mockResolvedValue( null );
 
 		jest.useFakeTimers();
 		jest.setSystemTime( new Date( '2024-08-01T12:00:00Z' ) );
@@ -62,9 +62,9 @@ describe( 'SqlExporter', () => {
 		);
 	} );
 
-	it( 'should call rename on the temporary file', async () => {
+	it( 'should call move on the temporary file', async () => {
 		await exporter.export();
-		expect( rename ).toHaveBeenCalledWith(
+		expect( move ).toHaveBeenCalledWith(
 			'/path/to/site/studio-backup-db-export-2024-08-01-12-00-00.sql',
 			mockOptions.backupFile
 		);

--- a/src/lib/import-export/tests/import/importer/default-importer.test.ts
+++ b/src/lib/import-export/tests/import/importer/default-importer.test.ts
@@ -1,6 +1,6 @@
 // To run tests, execute `npm run test -- src/lib/import-export/tests/import/importer/jetpack-importer.test.ts`
 import * as fs from 'fs/promises';
-import { lstat, rename } from 'fs-extra';
+import { lstat, move } from 'fs-extra';
 import { SiteServer } from '../../../../../site-server';
 import { JetpackImporter, SQLImporter } from '../../../import/importers';
 import { BackupContents } from '../../../import/types';
@@ -32,8 +32,8 @@ describe( 'JetpackImporter', () => {
 			executeWpCliCommand: jest.fn().mockReturnValue( { stderr: null } ),
 		} );
 
-		// mock rename
-		( rename as jest.Mock ).mockResolvedValue( null );
+		// mock move
+		( move as jest.Mock ).mockResolvedValue( null );
 
 		jest.useFakeTimers();
 		jest.setSystemTime( new Date( '2024-08-01T12:00:00Z' ) );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/8627

## Proposed Changes

Import/export database not working on linux, because we use `rename`. This PR fixes that.

## Testing Instructions
1. Create a new site on linux
2. Export full site and database.
3. Ensure export works
4. Import the backups to another site.
5. Ensure import works
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
