### PR TITLE
Update Import and Export Learn more to the final one

### DIFF
--- a/src/components/content-tab-import-export.tsx
+++ b/src/components/content-tab-import-export.tsx
@@ -168,7 +168,10 @@ const ImportSite = ( props: { selectedSite: SiteDetails } ) => {
 					__( 'Import a Jetpack backup or a .sql database file. <button>Learn more</button>' ),
 					{
 						button: (
-							<Button variant="link" onClick={ () => getIpcApi().openURL( STUDIO_DOCS_URL_IMPORT_EXPORT ) } />
+							<Button
+								variant="link"
+								onClick={ () => getIpcApi().openURL( STUDIO_DOCS_URL_IMPORT_EXPORT ) }
+							/>
 						),
 					}
 				) }

--- a/src/components/content-tab-import-export.tsx
+++ b/src/components/content-tab-import-export.tsx
@@ -4,7 +4,7 @@ import { sprintf, __ } from '@wordpress/i18n';
 import { Icon, download } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { useRef } from 'react';
-import { STUDIO_DOCS_URL } from '../constants';
+import { STUDIO_DOCS_URL_IMPORT_EXPORT } from '../constants';
 import { useConfirmationDialog } from '../hooks/use-confirmation-dialog';
 import { useDragAndDropFile } from '../hooks/use-drag-and-drop-file';
 import { useImportExport } from '../hooks/use-import-export';
@@ -168,7 +168,7 @@ const ImportSite = ( props: { selectedSite: SiteDetails } ) => {
 					__( 'Import a Jetpack backup or a .sql database file. <button>Learn more</button>' ),
 					{
 						button: (
-							<Button variant="link" onClick={ () => getIpcApi().openURL( STUDIO_DOCS_URL ) } />
+							<Button variant="link" onClick={ () => getIpcApi().openURL( STUDIO_DOCS_URL_IMPORT_EXPORT ) } />
 						),
 					}
 				) }

--- a/src/components/site-form.tsx
+++ b/src/components/site-form.tsx
@@ -4,7 +4,7 @@ import { __ } from '@wordpress/i18n';
 import { tip, warning, trash, chevronRight, chevronDown } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { FormEvent, useRef, useState } from 'react';
-import { STUDIO_DOCS_URL } from '../constants';
+import { STUDIO_DOCS_URL_IMPORT_EXPORT } from '../constants';
 import { useFeatureFlags } from '../hooks/use-feature-flags';
 import { cx } from '../lib/cx';
 import { getIpcApi } from '../lib/get-ipc-api';
@@ -264,7 +264,7 @@ export const SiteForm = ( {
 												<Button
 													variant="link"
 													className="text-xs"
-													onClick={ () => getIpcApi().openURL( STUDIO_DOCS_URL ) }
+													onClick={ () => getIpcApi().openURL( STUDIO_DOCS_URL_IMPORT_EXPORT ) }
 												/>
 											),
 										}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -11,6 +11,8 @@ export const ABOUT_WINDOW_WIDTH = 284;
 export const ABOUT_WINDOW_HEIGHT = 350;
 export const AI_GUIDELINES_URL = 'https://automattic.com/ai-guidelines/';
 export const STUDIO_DOCS_URL = `https://developer.wordpress.com/docs/developer-tools/studio/`;
+export const STUDIO_DOCS_URL_IMPORT_EXPORT =
+	'https://developer.wordpress.com/docs/developer-tools/studio/#import-export';
 export const BUG_REPORT_URL =
 	'https://github.com/Automattic/studio/issues/new?assignees=&labels=Needs+triage%2C%5BType%5D+Bug&projects=&template=bug_report.yml';
 export const FEATURE_REQUEST_URL =


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/8512

## Proposed Changes

I propose to change the Import and Export 'Learn more' link to point to the URL we've reserved for the new feature docs.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Confirm that 'Learn more' link in the Import and Export UI points to the new URL.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
