### PR TITLE
Fix export on Windows

### DIFF
--- a/src/lib/import-export/export/exporters/default-exporter.ts
+++ b/src/lib/import-export/export/exporters/default-exporter.ts
@@ -47,8 +47,8 @@ export class DefaultExporter extends EventEmitter implements Exporter {
 		}
 
 		const requiredPaths = [
-			{ path: 'wp-content', isDir: true },
-			{ path: 'wp-includes', isDir: true },
+			{ path: [ 'wp-content' ], isDir: true },
+			{ path: [ 'wp-includes' ], isDir: true },
 			{ path: 'wp-load.php', isDir: false },
 			{ path: 'wp-config.php', isDir: false },
 		];
@@ -58,8 +58,11 @@ export class DefaultExporter extends EventEmitter implements Exporter {
 		return requiredPaths.every( ( requiredPath ) =>
 			this.siteFiles.some( ( file ) => {
 				const relativePath = path.relative( this.options.site.path, file );
+				const relativePathItems = relativePath.split( path.sep );
 				return requiredPath.isDir
-					? relativePath.startsWith( requiredPath.path )
+					? ( requiredPath.path as string[] ).every(
+							( path, index ) => path === relativePathItems[ index ]
+					  )
 					: relativePath === requiredPath.path;
 			} )
 		);
@@ -208,13 +211,26 @@ export class DefaultExporter extends EventEmitter implements Exporter {
 		const siteFiles = await this.getSiteFiles();
 		siteFiles.forEach( ( file ) => {
 			const relativePath = path.relative( options.site.path, file );
+			const relativePathItems = relativePath.split( path.sep );
 			if ( path.basename( file ) === 'wp-config.php' ) {
 				backupContents.wpConfigFile = file;
-			} else if ( relativePath.startsWith( 'wp-content/uploads/' ) && options.includes.uploads ) {
+			} else if (
+				relativePathItems[ 0 ] === 'wp-content' &&
+				relativePathItems[ 1 ] === 'uploads' &&
+				options.includes.uploads
+			) {
 				backupContents.wpContent.uploads.push( file );
-			} else if ( relativePath.startsWith( 'wp-content/plugins/' ) && options.includes.plugins ) {
+			} else if (
+				relativePathItems[ 0 ] === 'wp-content' &&
+				relativePathItems[ 1 ] === 'plugins' &&
+				options.includes.plugins
+			) {
 				backupContents.wpContent.plugins.push( file );
-			} else if ( relativePath.startsWith( 'wp-content/themes/' ) && options.includes.themes ) {
+			} else if (
+				relativePathItems[ 0 ] === 'wp-content' &&
+				relativePathItems[ 1 ] === 'themes' &&
+				options.includes.themes
+			) {
 				backupContents.wpContent.themes.push( file );
 			}
 		} );

--- a/src/lib/import-export/export/exporters/default-exporter.ts
+++ b/src/lib/import-export/export/exporters/default-exporter.ts
@@ -213,16 +213,14 @@ export class DefaultExporter extends EventEmitter implements Exporter {
 			const relativePath = path.relative( options.site.path, file );
 			const relativePathItems = relativePath.split( path.sep );
 			const [ wpContent, category ] = relativePathItems;
-			const contentCategory = category as BackupContentsCategory;
 
 			if ( path.basename( file ) === 'wp-config.php' ) {
 				backupContents.wpConfigFile = file;
 			} else if (
 				wpContent === 'wp-content' &&
-				options.includes[ contentCategory ] &&
-				( contentCategory as string ) !== 'database'
+				( category === 'uploads' || category === 'plugins' || category === 'themes' )
 			) {
-				backupContents.wpContent[ contentCategory ].push( file );
+				backupContents.wpContent[ category ].push( file );
 			}
 		} );
 

--- a/src/lib/import-export/export/exporters/default-exporter.ts
+++ b/src/lib/import-export/export/exporters/default-exporter.ts
@@ -212,26 +212,17 @@ export class DefaultExporter extends EventEmitter implements Exporter {
 		siteFiles.forEach( ( file ) => {
 			const relativePath = path.relative( options.site.path, file );
 			const relativePathItems = relativePath.split( path.sep );
+			const [ wpContent, category ] = relativePathItems;
+			const contentCategory = category as BackupContentsCategory;
+
 			if ( path.basename( file ) === 'wp-config.php' ) {
 				backupContents.wpConfigFile = file;
 			} else if (
-				relativePathItems[ 0 ] === 'wp-content' &&
-				relativePathItems[ 1 ] === 'uploads' &&
-				options.includes.uploads
+				wpContent === 'wp-content' &&
+				options.includes[ contentCategory ] &&
+				( contentCategory as string ) !== 'database'
 			) {
-				backupContents.wpContent.uploads.push( file );
-			} else if (
-				relativePathItems[ 0 ] === 'wp-content' &&
-				relativePathItems[ 1 ] === 'plugins' &&
-				options.includes.plugins
-			) {
-				backupContents.wpContent.plugins.push( file );
-			} else if (
-				relativePathItems[ 0 ] === 'wp-content' &&
-				relativePathItems[ 1 ] === 'themes' &&
-				options.includes.themes
-			) {
-				backupContents.wpContent.themes.push( file );
+				backupContents.wpContent[ contentCategory ].push( file );
 			}
 		} );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to 8636-gh-Automattic/dotcom-forge.

## Proposed Changes

- Make all path calculations in export logic platform-agnostic. This implies using the platform path separator and splitting the path by items.

> [!NOTE]
> I haven't updated the import logic as paths are in Unix format. This is because the Tar/Zip libraries provide the file paths in this format.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run the app on Windows with the following command: `$env:STUDIO_IMPORT_EXPORT='true'; npm start`.
- Select a site.
- Navigate to the Import/Export tab.
- Click on Export entire site and export the site.
- Observe the file is generated and contains all expected files:
    - `sql` folder with SQL file.
    - `studio.json` file
    - `wp-config.php` file
    - `wp-content/plugins` folder with plugin folders.
    - `wp-content/themes` folder with theme folders.
    - `wp-content/uploads` folder with upload folders.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
