### PR TITLE
Remove unit test `should have the latest wp-cli version installed`

### DIFF
--- a/src/tests/execute-wp-cli.test.ts
+++ b/src/tests/execute-wp-cli.test.ts
@@ -6,10 +6,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import { executeWPCli } from '../../vendor/wp-now/src/execute-wp-cli';
-import {
-	getWPCliVersionFromInstallation,
-	isWPCliInstallationOutdated,
-} from '../lib/wpcli-versions';
+import { getWPCliVersionFromInstallation } from '../lib/wpcli-versions';
 
 jest.unmock( 'fs-extra' );
 
@@ -53,10 +50,5 @@ describe( 'executeWPCli', () => {
 	it( 'should return the correct version of WP-CLI', async () => {
 		const result = await getWPCliVersionFromInstallation();
 		expect( result ).toMatch( /v\d+\.\d+\.\d+/ ); // Example: v2.10.0
-	} );
-
-	it( 'should have the latest wp-cli version installed', async () => {
-		const isOutdated = await isWPCliInstallationOutdated();
-		expect( isOutdated ).toBe( false );
 	} );
 } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to p1723119209295819-slack-C04GESRBWKW.

## Proposed Changes

- Ideally, unit tests shouldn't depend on external data, so I decided to remove the test case `should have the latest wp-cli version installed`. Besides, the test case is not testing the app's functionality but the project installation setup.


cc @kozer as author of https://github.com/Automattic/studio/pull/199/files#diff-664e14333153ac7d8ce1c7aee42a3dac5fce156f5317fb05bfe12c14f48c60e4R49-R52

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Observe that all CI jobs succeed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?