### PR TITLE
Translate the tooltip for the close button on the modal

### DIFF
--- a/src/components/modal.tsx
+++ b/src/components/modal.tsx
@@ -1,10 +1,13 @@
 import { Modal as WPModal } from '@wordpress/components';
+import { useI18n } from '@wordpress/react-i18n';
 import { cx } from '../lib/cx';
 import type { ComponentProps } from 'react';
 
 export default function Modal( { className, ...rest }: ComponentProps< typeof WPModal > ) {
+	const { __ } = useI18n();
 	return (
 		<WPModal
+			closeButtonLabel={ __( 'Close' ) }
 			className={ cx( 'select-none [&_h1]:!text-xl [&_h1]:!font-normal outline-0', className ) }
 			{ ...rest }
 		/>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

- Related to https://github.com/Automattic/studio/pull/452#pullrequestreview-2230614288 , testing the Ukrainian language I've observed we don't translate the label of the close button.

## Proposed Changes

- Translates the tooltip of the close button in the modals

<img width="1012" alt="Screenshot 2024-08-12 at 19 21 54" src="https://github.com/user-attachments/assets/de2ea990-95ba-48e2-92e8-cba2f71bf5a1">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Change the language of your computer or in `src/lib/locale.ts`
```diff
diff --git a/src/lib/locale.ts b/src/lib/locale.ts
index 4e17d62..354e96d 100644
--- a/src/lib/locale.ts
+++ b/src/lib/locale.ts
@@ -32,6 +32,7 @@ export function getSupportedLocale(): string {
        // `app.getLocale` returns the current application locale, acquired using
        // Chromium's `l10n_util` library. This value is utilized to determine
        // the best fit for supported locales.
+       return 'es';
        return match( [ app.getLocale() ], supportedLocales, DEFAULT_LOCALE );
 }
 
```
- Add the translation: `,"Close":["Cerrar"]` to the selected language file, for example: `src/translations/studio-es.jed.json`
- Run `npm start`
- Click on your profile image or add site button to open a modal
- Move the mouse hover the X button to close the modal
- Wait a second and observe the tooltip is translated. (You need to add the translation to your language , for example `src/translations/studio-es.jed.json`)


https://github.com/user-attachments/assets/68aba5c1-ac78-4276-bc4c-7a1ba7fdb5f2



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?