### PR TITLE
Import WP content before database

### DIFF
--- a/src/lib/import-export/import/importers/importer.ts
+++ b/src/lib/import-export/import/importers/importer.ts
@@ -121,8 +121,8 @@ abstract class BaseBackupImporter extends BaseImporter {
 			await this.moveExistingDatabaseToTrash( dbPath );
 			await this.createEmptyDatabase( dbPath );
 			await this.importWpConfig( rootPath );
-			await this.importDatabase( rootPath, siteId, this.backup.sqlFiles );
 			await this.importWpContent( rootPath );
+			await this.importDatabase( rootPath, siteId, this.backup.sqlFiles );
 			let meta: MetaFileData | undefined;
 			if ( this.backup.metaFile ) {
 				meta = await this.parseMetaFile();


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Fixes: https://github.com/Automattic/dotcom-forge/issues/8703

## Proposed Changes

- Import WordPress content before the database to avoid potential conflicts. We experienced issues when the imported database referenced themes that were copied afterward.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Imports Jetpack backup

- Run the app with the command: `STUDIO_IMPORT_EXPORT=true npm start`.
- Click on Add site.
- Drag and drop a Jetpack backup file.
- Click on Add site to create the site.
- Wait until the creation finishes.
- Observe the site is created with the content from the Jetpack backup.

### Replaces previous import with new backup

- Run the app with the command: `STUDIO_IMPORT_EXPORT=true npm start`.
- Click on Add site.
- Drag and drop a backup file generated from the Local app.
- Click on Add site to create the site.
- Wait until the creation finishes.
- Observe the site is created with the content from the backup.
- Navigate to the Import/Export tab.
- Import a Jetpack backup.
- Wait until the import finishes.
- Observe the site now has the content from the Jetpack backup.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?