### PR TITLE
Avoid WP-CLI command failures due to PHP warnings

### DIFF
--- a/vendor/wp-now/src/execute-wp-cli.ts
+++ b/vendor/wp-now/src/execute-wp-cli.ts
@@ -66,6 +66,8 @@ export async function executeWPCli( projectPath: string, args: string[] ): Promi
 		define('STDOUT', fopen('php://stdout', 'wb'));
 		define('STDERR', fopen('${stderrPath}', 'wb'));
 		
+		// Force disabling WordPress debugging mode to avoid parsing issues of WP-CLI command result
+		define('WP_DEBUG', false);
 		// Filter out errors below ERROR level to avoid parsing issues of WP-CLI command result
 		error_reporting(E_ERROR);
 

--- a/vendor/wp-now/src/execute-wp-cli.ts
+++ b/vendor/wp-now/src/execute-wp-cli.ts
@@ -65,6 +65,9 @@ export async function executeWPCli( projectPath: string, args: string[] ): Promi
 		define('STDIN', fopen('php://stdin', 'rb'));
 		define('STDOUT', fopen('php://stdout', 'wb'));
 		define('STDERR', fopen('${stderrPath}', 'wb'));
+		
+		// Filter out errors below ERROR level to avoid parsing issues of WP-CLI command result
+		error_reporting(E_ERROR);
 
 		// WP-CLI uses this argument for checking updates. Seems it's not defined by Playground
 		// when running a script, so we explicitly set it.


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to 8701-gh-Automattic/dotcom-forge.

## Proposed Changes

- Set PHP error reporting to only render PHP errors of ERROR level when executing WP-CLI commands.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Run the app with the command `npm start`.
2. Create a site.
3. Wait until the site is created and running.
4. Edit the `wp-config.php` file of the site and add the following line:
`trigger_error("This is a warning!", E_USER_WARNING);`
5. Switch to the Studio app.
6. Observe that no error logs are in the console.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
