### PR TITLE
Studio: Add playground importer

### DIFF
--- a/src/hooks/use-import-export.tsx
+++ b/src/hooks/use-import-export.tsx
@@ -95,7 +95,7 @@ export const ImportExportProvider = ( { children }: { children: React.ReactNode 
 					type: 'error',
 					message: __( 'Failed importing site' ),
 					detail: __(
-						'An error occurred while importing the site. Verify the file is a valid Jetpack backup or .sql database file and try again. If this problem persists, please contact support.'
+						'An error occurred while importing the site. Verify the file is a valid Jetpack backup, Local, Playground or .sql database file and try again. If this problem persists, please contact support.'
 					),
 					buttons: [ __( 'OK' ) ],
 				} );

--- a/src/lib/import-export/import/handlers/backup-handler-factory.ts
+++ b/src/lib/import-export/import/handlers/backup-handler-factory.ts
@@ -12,7 +12,7 @@ export interface BackupHandler extends Partial< EventEmitter > {
 const EXCLUDED_FILES_PATTERNS = [
 	/^__MACOSX\/.*/, // MacOS meta folder
 	/^\..*/, // Unix hidden files at root
-	/\/\..*/, // Unix hidden files at subfolders
+	/\/\.(?!.*\.sqlite$).*/, // Unix hidden files at subfolders, except .sqlite files
 ];
 
 export function isFileAllowed( filePath: string ) {

--- a/src/lib/import-export/import/handlers/backup-handler-tar-gz.ts
+++ b/src/lib/import-export/import/handlers/backup-handler-tar-gz.ts
@@ -11,7 +11,15 @@ export class BackupHandlerTarGz extends EventEmitter implements BackupHandler {
 		const files: string[] = [];
 		await tar.t( {
 			file: backup.path,
-			onReadEntry: ( entry ) => isFileAllowed( entry.path ) && files.push( entry.path ),
+			onReadEntry: ( entry ) => {
+				if ( isFileAllowed( entry.path ) ) {
+					let path = entry.path;
+					if ( entry.path.startsWith( '/' ) ) {
+						path = path.slice( 1 );
+					}
+					files.push( path );
+				}
+			},
 		} );
 		return files;
 	}

--- a/src/lib/import-export/import/handlers/backup-handler-zip.ts
+++ b/src/lib/import-export/import/handlers/backup-handler-zip.ts
@@ -9,7 +9,12 @@ export class BackupHandlerZip extends EventEmitter implements BackupHandler {
 		const zip = new AdmZip( backup.path );
 		return zip
 			.getEntries()
-			.map( ( entry ) => entry.entryName )
+			.map( ( entry ) => {
+				if ( entry.entryName.startsWith( '/' ) ) {
+					return entry.entryName.slice( 1 );
+				}
+				return entry.entryName;
+			} )
 			.filter( isFileAllowed );
 	}
 

--- a/src/lib/import-export/import/import-manager.ts
+++ b/src/lib/import-export/import/import-manager.ts
@@ -9,10 +9,11 @@ import {
 	ImporterResult,
 	JetpackImporter,
 	LocalImporter,
+	PlaygroundImporter,
 	SQLImporter,
 } from './importers/importer';
 import { BackupArchiveInfo, NewImporter } from './types';
-import { JetpackValidator, SqlValidator, LocalValidator } from './validators';
+import { JetpackValidator, SqlValidator, LocalValidator, PlaygroundValidator } from './validators';
 import { Validator } from './validators/validator';
 
 export interface ImporterOption {
@@ -73,4 +74,5 @@ export const defaultImporterOptions: ImporterOption[] = [
 	{ validator: new JetpackValidator(), importer: JetpackImporter },
 	{ validator: new LocalValidator(), importer: LocalImporter },
 	{ validator: new SqlValidator(), importer: SQLImporter },
+	{ validator: new PlaygroundValidator(), importer: PlaygroundImporter },
 ];

--- a/src/lib/import-export/import/importers/importer.ts
+++ b/src/lib/import-export/import/importers/importer.ts
@@ -69,7 +69,7 @@ abstract class BaseImporter extends EventEmitter implements Importer {
 		this.emit( ImportEvents.IMPORT_DATABASE_COMPLETE );
 	}
 
-	private async replaceSiteUrl( siteId: string ) {
+	protected async replaceSiteUrl( siteId: string ) {
 		const server = SiteServer.get( siteId );
 		if ( ! server ) {
 			throw new Error( 'Site not found.' );
@@ -229,6 +229,37 @@ export class LocalImporter extends BaseBackupImporter {
 		} finally {
 			this.emit( ImportEvents.IMPORT_META_COMPLETE );
 		}
+	}
+}
+
+export class PlaygroundImporter extends BaseBackupImporter {
+	protected async importDatabase(
+		rootPath: string,
+		siteId: string,
+		sqlFiles: string[]
+	): Promise< void > {
+		if ( ! sqlFiles.length ) {
+			return;
+		}
+		const server = SiteServer.get( siteId );
+		if ( ! server ) {
+			throw new Error( 'Site not found.' );
+		}
+
+		this.emit( ImportEvents.IMPORT_DATABASE_START );
+
+		for ( const sqlFile of sqlFiles ) {
+			await move( sqlFile, path.join( rootPath, 'wp-content', 'database', '.ht.sqlite' ), {
+				overwrite: true,
+			} );
+		}
+		await this.replaceSiteUrl( siteId );
+
+		this.emit( ImportEvents.IMPORT_DATABASE_COMPLETE );
+	}
+
+	protected async parseMetaFile(): Promise< MetaFileData | undefined > {
+		return undefined;
 	}
 }
 

--- a/src/lib/import-export/import/validators/index.ts
+++ b/src/lib/import-export/import/validators/index.ts
@@ -2,3 +2,4 @@ export * from './validator';
 export * from './sql-validator';
 export * from './jetpack-validator';
 export * from './local-validator';
+export * from './playground-validator';

--- a/src/lib/import-export/import/validators/playground-validator.ts
+++ b/src/lib/import-export/import/validators/playground-validator.ts
@@ -1,0 +1,63 @@
+import { EventEmitter } from 'events';
+import path from 'path';
+import { ImportEvents } from '../events';
+import { BackupContents } from '../types';
+import { Validator } from './validator';
+
+export class PlaygroundValidator extends EventEmitter implements Validator {
+	canHandle( fileList: string[] ): boolean {
+		const requiredDirs = [
+			'wp-content/database',
+			'wp-content/uploads',
+			'wp-content/plugins',
+			'wp-content/themes',
+		];
+		return (
+			requiredDirs.some( ( dir ) => fileList.some( ( file ) => file.startsWith( dir + '/' ) ) ) &&
+			fileList.some(
+				( file ) => file.startsWith( 'wp-content/database' ) && file.endsWith( '.ht.sqlite' )
+			)
+		);
+	}
+
+	parseBackupContents( fileList: string[], extractionDirectory: string ): BackupContents {
+		this.emit( ImportEvents.IMPORT_VALIDATION_START );
+		const extractedBackup: BackupContents = {
+			extractionDirectory: extractionDirectory,
+			sqlFiles: [],
+			wpConfig: '',
+			wpContent: {
+				uploads: [],
+				plugins: [],
+				themes: [],
+			},
+			wpContentDirectory: 'wp-content',
+		};
+
+		/* File rules:
+		 * - Accept .zip
+		 * - Do not reject the archive that includes core WP files, and ignore those instead.
+		 * - Support .ht.sqlite database files
+		 * */
+
+		for ( const file of fileList ) {
+			const fullPath = path.join( extractionDirectory, file );
+			if ( file === 'wp-config.php' ) {
+				extractedBackup.wpConfig = fullPath;
+				continue;
+			}
+
+			if ( file.startsWith( 'wp-content/database' ) && file.endsWith( '.ht.sqlite' ) ) {
+				extractedBackup.sqlFiles.push( fullPath );
+			} else if ( file.startsWith( 'wp-content/uploads/' ) ) {
+				extractedBackup.wpContent.uploads.push( fullPath );
+			} else if ( file.startsWith( 'wp-content/plugins/' ) ) {
+				extractedBackup.wpContent.plugins.push( fullPath );
+			} else if ( file.startsWith( 'wp-content/themes/' ) ) {
+				extractedBackup.wpContent.themes.push( fullPath );
+			}
+		}
+		this.emit( ImportEvents.IMPORT_VALIDATION_COMPLETE );
+		return extractedBackup;
+	}
+}

--- a/src/lib/import-export/tests/import/importer/default-importer.test.ts
+++ b/src/lib/import-export/tests/import/importer/default-importer.test.ts
@@ -50,7 +50,7 @@ describe( 'JetpackImporter', () => {
 	} );
 
 	describe( 'import', () => {
-		it( 'should copy wp-cofnig, wp-content files and read meta file', async () => {
+		it( 'should copy wp-config, wp-content files and read meta file', async () => {
 			const importer = new JetpackImporter( mockBackupContents );
 			( fs.mkdir as jest.Mock ).mockResolvedValue( undefined );
 			( fs.copyFile as jest.Mock ).mockResolvedValue( undefined );

--- a/src/lib/import-export/tests/import/importer/playground-importer.test.ts
+++ b/src/lib/import-export/tests/import/importer/playground-importer.test.ts
@@ -1,0 +1,86 @@
+// To run tests, execute `npm run test -- src/lib/import-export/tests/import/importer/local-importer.test.ts`
+import * as fs from 'fs/promises';
+import { lstat, move } from 'fs-extra';
+import { SiteServer } from '../../../../../site-server';
+import { PlaygroundImporter } from '../../../import/importers';
+import { BackupContents } from '../../../import/types';
+
+jest.mock( 'fs/promises' );
+jest.mock( '../../../../../site-server' );
+jest.mock( 'fs-extra' );
+
+describe( 'localImporter', () => {
+	const mockBackupContents: BackupContents = {
+		extractionDirectory: '/tmp/extracted',
+		sqlFiles: [ '/tmp/extracted/wp-content/database/.ht.sqlite' ],
+		wpConfig: 'wp-config.php',
+		wpContent: {
+			uploads: [ '/tmp/extracted/wp-content/uploads/2023/image.jpg' ],
+			plugins: [ '/tmp/extracted/wp-content/plugins/jetpack/jetpack.php' ],
+			themes: [ '/tmp/extracted/wp-content/themes/twentytwentyone/style.css' ],
+		},
+		wpContentDirectory: 'wp-content',
+	};
+
+	const mockStudioSitePath = '/path/to/studio/site';
+	const mockStudioSiteId = '123';
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+
+		( SiteServer.get as jest.Mock ).mockReturnValue( {
+			details: { path: '/path/to/site' },
+			executeWpCliCommand: jest.fn().mockReturnValue( { stderr: null } ),
+		} );
+
+		// mock rename
+		( move as jest.Mock ).mockResolvedValue( null );
+
+		jest.useFakeTimers();
+		jest.setSystemTime( new Date( '2024-08-01T12:00:00Z' ) );
+
+		( lstat as jest.Mock ).mockResolvedValue( {
+			isDirectory: jest.fn().mockReturnValue( false ),
+		} );
+	} );
+
+	afterEach( () => {
+		jest.useRealTimers();
+	} );
+
+	describe( 'import', () => {
+		it( 'should copy wp-config, wp-content files and read meta file', async () => {
+			const importer = new PlaygroundImporter( mockBackupContents );
+			( fs.mkdir as jest.Mock ).mockResolvedValue( undefined );
+			( fs.copyFile as jest.Mock ).mockResolvedValue( undefined );
+			( fs.readFile as jest.Mock ).mockResolvedValue(
+				JSON.stringify( {
+					phpVersion: '7.4',
+					wordpressVersion: '5.8',
+				} )
+			);
+
+			await importer.import( mockStudioSitePath, mockStudioSiteId );
+
+			expect( fs.mkdir ).toHaveBeenCalled();
+			expect( fs.copyFile ).toHaveBeenCalledTimes( 4 ); // One for each wp-content file + wp-config
+		} );
+
+		it( 'should handle sqlite,copies them in the correct folder, and rename the urls', async () => {
+			const importer = new PlaygroundImporter( mockBackupContents );
+			await importer.import( mockStudioSitePath, mockStudioSiteId );
+
+			const siteServer = SiteServer.get( mockStudioSiteId );
+
+			const expectedCommand = 'option get siteurl';
+			expect( siteServer?.executeWpCliCommand ).toHaveBeenNthCalledWith( 1, expectedCommand );
+
+			expect( move ).toHaveBeenNthCalledWith(
+				1,
+				'/tmp/extracted/wp-content/database/.ht.sqlite',
+				'/path/to/studio/site/wp-content/database/.ht.sqlite',
+				{ overwrite: true }
+			);
+		} );
+	} );
+} );

--- a/src/lib/import-export/tests/import/validators/playground-validator.ts
+++ b/src/lib/import-export/tests/import/validators/playground-validator.ts
@@ -1,0 +1,97 @@
+// To run tests, execute `npm run test -- src/lib/import-export/tests/import/validators/local-validator.test.ts`
+import { PlaygroundValidator } from '../../../import/validators/playground-validator';
+
+describe( 'PlaygroundValidator', () => {
+	const validator = new PlaygroundValidator();
+
+	describe( 'canHandle', () => {
+		it( 'should return true for valid Playground backup structure', () => {
+			const fileList = [
+				'wp-content/database/.ht.sqlite',
+				'wp-content/uploads/2023/image.jpg',
+				'wp-content/plugins/jetpack/jetpack.php',
+				'wp-content/themes/twentytwentyone/style.css',
+			];
+			expect( validator.canHandle( fileList ) ).toBe( true );
+		} );
+
+		it( 'should not fail if core files exists.', () => {
+			const fileList = [
+				'wp-content/database/.ht.sqlite',
+				'wp-admin/wp-admin.php',
+				'wp-admin/about.php',
+				'wp-includes/test.php',
+				'wp-content/uploads/2023/image.jpg',
+				'wp-content/plugins/jetpack/jetpack.php',
+				'wp-content/themes/twentytwentyone/style.css',
+			];
+			expect( validator.canHandle( fileList ) ).toBe( true );
+		} );
+
+		it( 'should return false for invalid backup structure', () => {
+			const fileList = [
+				'wp-admin/wp-admin.php',
+				'wp-admin/about.php',
+				'wp-includes/test.php',
+				'wp-content/uploads/2023/image.jpg',
+				'wp-content/plugins/jetpack/jetpack.php',
+				'wp-content/themes/twentytwentyone/style.css',
+				'random.txt',
+				'another-file.js',
+			];
+			expect( validator.canHandle( fileList ) ).toBe( false );
+		} );
+	} );
+
+	describe( 'parseBackupContents', () => {
+		it( 'should correctly parse backup contents', () => {
+			const fileList = [
+				'wp-content/database/.ht.sqlite',
+				'wp-content/uploads/2023/image.jpg',
+				'wp-content/plugins/jetpack/jetpack.php',
+				'wp-content/themes/twentytwentyone/style.css',
+			];
+			const extractionDirectory = '/tmp/extracted';
+			const result = validator.parseBackupContents( fileList, extractionDirectory );
+
+			expect( result ).toEqual( {
+				extractionDirectory,
+				sqlFiles: [ '/tmp/extracted/wp-content/database/.ht.sqlite' ],
+				wpConfig: '',
+				wpContent: {
+					uploads: [ '/tmp/extracted/wp-content/uploads/2023/image.jpg' ],
+					plugins: [ '/tmp/extracted/wp-content/plugins/jetpack/jetpack.php' ],
+					themes: [ '/tmp/extracted/wp-content/themes/twentytwentyone/style.css' ],
+				},
+				wpContentDirectory: 'wp-content',
+			} );
+		} );
+
+		it( 'should ignore files that not needed', () => {
+			const fileList = [
+				'wp-content/database/.ht.sqlite',
+				'wp-admin/wp-admin.php',
+				'wp-admin/about.php',
+				'wp-includes/test.php',
+				'wp-config.php',
+				'wp-content/uploads/2023/image.jpg',
+				'wp-content/plugins/jetpack/jetpack.php',
+				'wp-content/themes/twentytwentyone/style.css',
+			];
+			const extractionDirectory = '/tmp/extracted';
+			const result = validator.parseBackupContents( fileList, extractionDirectory );
+
+			expect( result ).toEqual( {
+				extractionDirectory,
+				sqlFiles: [ '/tmp/extracted/wp-content/database/.ht.sqlite' ],
+				wpConfig: '/tmp/extracted/wp-config.php',
+				wpContent: {
+					uploads: [ '/tmp/extracted/wp-content/uploads/2023/image.jpg' ],
+					plugins: [ '/tmp/extracted/wp-content/plugins/jetpack/jetpack.php' ],
+					themes: [ '/tmp/extracted/wp-content/themes/twentytwentyone/style.css' ],
+				},
+				wpContentDirectory: 'wp-content',
+			} );
+		} );
+	} );
+} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/8169

## Proposed Changes

This PR adds support for importing a site backup exported from Playground.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Create a site in the [Playground](https://playground.wordpress.net/)
- Install custom theme, activate it, upload media, install the plugin, add post etc.
- Export site from Playground
- Import site to Studio
- Confirm that the site looks in the same way as in Playground.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
