### PR TITLE
Studio: Fix alignment in the Local path and Import a backup fields on the add site form

### DIFF
--- a/src/components/site-form.tsx
+++ b/src/components/site-form.tsx
@@ -302,7 +302,8 @@ export const SiteForm = ( {
 									>
 										<label
 											className={ cx(
-												'flex flex-col gap-1.5 leading-4 p-2',
+												'flex flex-col gap-1.5 leading-4',
+												isAdvancedSettingsVisible ? 'py-2' : 'p-2',
 												! isAdvancedSettingsVisible && 'hidden'
 											) }
 										>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/8719

## Proposed Changes

This PR fixes left and right padding on the `Local path` field so that it looks aligned with other fields on the `Add site` form.

**Before**

<img width="638" alt="Screenshot 2024-08-15 at 9 23 54 AM" src="https://github.com/user-attachments/assets/d735ebea-a31e-4c3b-a1b3-371b282b384e">

**After**

<img width="498" alt="Screenshot 2024-08-15 at 11 55 23 AM" src="https://github.com/user-attachments/assets/45e12ca4-a48e-4826-8f8b-ab29b776c511">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
* Start the app with `STUDIO_IMPORT_EXPORT=true npm start`
* Click on the `Add site` button in the sidebar
* Click on `Advanced settings` in the modal
* Confirm that the `Local path` is aligned with other fields on Add site form

**Testing onboarding screen**

* Delete all sites
* Observe the onboarding screen appear
* Click on `Advanced settings`
* Confirm that the `Local path` is aligned with other fields on Add site form

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
