### PR TITLE
Studio: Add left border to the Import backup field

### DIFF
--- a/src/components/site-form.tsx
+++ b/src/components/site-form.tsx
@@ -168,7 +168,7 @@ function FormImportComponent( {
 					{ ! fileName && (
 						<div
 							aria-hidden="true"
-							className="local-path-icon flex items-center py-[9px] px-2.5 border border-l-0 border-t-0 border-r-0 border-b-0"
+							className="local-path-icon flex items-center py-[12px] px-2.5 border border-l-[#949494] border-t-0 border-r-0 border-b-0"
 						>
 							<FolderIcon className="text-[#3C434A]" />
 						</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/8722

## Proposed Changes

This PR adds a left border to the folder icon in the `Import backup` field so that it is consistent with the design of the `Local path` field.

**Before**

<img width="472" alt="Screenshot 2024-08-15 at 12 52 06 PM" src="https://github.com/user-attachments/assets/592b5604-18e0-4f03-ad98-ef6c0b378c86">

**After**

<img width="487" alt="Screenshot 2024-08-15 at 12 48 58 PM" src="https://github.com/user-attachments/assets/8777ee36-677a-4baf-a9c7-3bcdb3aa5da4">

## Testing Instructions

* Pull the changes from this branch
* Start the app with `STUDIO_IMPORT_EXPORT=true npm start`
* Click on the `Add site` button in the sidebar
* Confirm that you can see the left border by the folder icon in the `Import backup` field

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
