### PR TITLE
Studio: Can't select a new backup after deleting a backup from import a backup field

### DIFF
--- a/src/components/site-form.tsx
+++ b/src/components/site-form.tsx
@@ -130,6 +130,9 @@ function FormImportComponent( {
 		event.stopPropagation();
 		if ( onClear ) {
 			onClear();
+			if ( inputFileRef.current ) {
+				inputFileRef.current.value = '';
+			}
 		}
 	};
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/8718
## Proposed Changes

This PR resets the file input field for the `Import backup` field when the file selection is cleared.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
* Start the app with `STUDIO_IMPORT_EXPORT=true npm start`
* Click on the `Add site` button in the sidebar
* Add a file for the `Import backup` field
* Observe that the field gets populated
* Click on the trash icon to clear the field
* Try adding a file again
* Observe that the file gets successfully populated again

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
