### PR TITLE
Export site to .zip archive by default

### DIFF
--- a/src/hooks/use-import-export.tsx
+++ b/src/hooks/use-import-export.tsx
@@ -293,7 +293,7 @@ export const ImportExportProvider = ( { children }: { children: React.ReactNode 
 			const fileName = generateBackupFilename( selectedSite.name );
 			const path = await getIpcApi().showSaveAsDialog( {
 				title: __( 'Save backup file' ),
-				defaultPath: `${ fileName }.tar.gz`,
+				defaultPath: `${ fileName }.zip`,
 				filters: [
 					{
 						name: 'Compressed Backup Files',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/8759

## Proposed Changes

- Change the default extension of the site export to `.zip` instead of `.tar.gz`

![CleanShot 2024-08-16 at 19 23 27@2x](https://github.com/user-attachments/assets/6b12903f-2eaa-4613-8d1e-44873654d8fd)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- `STUDIO_IMPORT_EXPORT=true npm start`
- Try to export the entire site and observe that the file dialog suggests a filename with the .zip extension.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
