### PR TITLE
Studio: Can't drag and drop zip files on Windows

### DIFF
--- a/src/components/add-site.tsx
+++ b/src/components/add-site.tsx
@@ -120,7 +120,11 @@ export default function AddSite( { className }: AddSiteProps ) {
 
 	const { dropRef, isDraggingOver } = useDragAndDropFile< HTMLDivElement >( {
 		onFileDrop: ( file: File ) => {
-			if ( ACCEPTED_IMPORT_FILE_TYPES.includes( file.type ) ) {
+			const isAccepted = ACCEPTED_IMPORT_FILE_TYPES.some( ( ext ) =>
+				file.name.toLowerCase().endsWith( ext )
+			);
+
+			if ( isAccepted ) {
 				setFileForImport( file );
 				setFileError( '' );
 			} else {

--- a/src/components/site-form.tsx
+++ b/src/components/site-form.tsx
@@ -192,7 +192,7 @@ function FormImportComponent( {
 					className="hidden"
 					type="file"
 					data-testid="backup-file"
-					accept=".zip,.sql,.tar,.gz"
+					accept=".zip,.tar,.gz"
 					onChange={ handleFileChange }
 				/>
 			</div>

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -22,12 +22,7 @@ export const WPCOM_PROFILE_URL = `https://wordpress.com/me`;
 
 //Import file constants
 
-export const ACCEPTED_IMPORT_FILE_TYPES = [
-	'application/zip',
-	'application/x-gzip',
-	'application/sql',
-	'application/x-tar',
-];
+export const ACCEPTED_IMPORT_FILE_TYPES = [ '.zip', '.gz', '.gzip', '.sql', '.tar', '.tar.gz' ];
 
 // OAuth constants
 export const CLIENT_ID = '95109';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -22,7 +22,7 @@ export const WPCOM_PROFILE_URL = `https://wordpress.com/me`;
 
 //Import file constants
 
-export const ACCEPTED_IMPORT_FILE_TYPES = [ '.zip', '.gz', '.gzip', '.sql', '.tar', '.tar.gz' ];
+export const ACCEPTED_IMPORT_FILE_TYPES = [ '.zip', '.gz', '.gzip', '.tar', '.tar.gz' ];
 
 // OAuth constants
 export const CLIENT_ID = '95109';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/8798

## Proposed Changes

This PR changes `ACCEPTED_FILE_TYPES` from MIME types to file extensions so that they are easily recognized on Windows.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

This testing must be done on Windows:

* Pull the changes from this branch
* Start the app with `npm start`
* Alternatively: Download a build from Buildkite
* Click on `Add site` in the left sidebar
* Try dragging and dropping `.zip` file into the site form
* Check if the file gets accepted
* Try uploading an invalid file such as `jpg` 
* Confirm that the file does not get uploaded

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
