### PR TITLE
Studio: Improve position of Advanced Settings chevron for rtl languages

### DIFF
--- a/src/components/site-form.tsx
+++ b/src/components/site-form.tsx
@@ -239,6 +239,16 @@ export const SiteForm = ( {
 		setAdvancedSettingsVisible( ! isAdvancedSettingsVisible );
 	};
 
+	let chevronIcon;
+
+	if ( isAdvancedSettingsVisible ) {
+		chevronIcon = chevronDown;
+	} else if ( isRTL() ) {
+		chevronIcon = chevronLeft;
+	} else {
+		chevronIcon = chevronRight;
+	}
+
 	return (
 		<form className={ className } onSubmit={ onSubmit }>
 			<div className="flex flex-col">
@@ -280,16 +290,7 @@ export const SiteForm = ( {
 							<>
 								<div className="flex flex-row items-center mb-0">
 									<Button className="pl-0" onClick={ handleAdvancedSettingsClick }>
-										<Icon
-											size={ 24 }
-											icon={
-												isAdvancedSettingsVisible
-													? chevronDown
-													: isRTL()
-													? chevronLeft
-													: chevronRight
-											}
-										/>
+										<Icon size={ 24 } icon={ chevronIcon } />
 										<div className="text-[13px] leading-[16px] ml-2">
 											{ __( 'Advanced settings' ) }
 										</div>

--- a/src/components/site-form.tsx
+++ b/src/components/site-form.tsx
@@ -1,7 +1,7 @@
 import { Icon } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { tip, warning, trash, chevronRight, chevronDown } from '@wordpress/icons';
+import { tip, warning, trash, chevronRight, chevronDown, chevronLeft } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { FormEvent, useRef, useState } from 'react';
 import { STUDIO_DOCS_URL_IMPORT_EXPORT } from '../constants';
@@ -231,7 +231,7 @@ export const SiteForm = ( {
 	onFileSelected?: ( file: File ) => void;
 	fileError?: string;
 } ) => {
-	const { __ } = useI18n();
+	const { __, isRTL } = useI18n();
 
 	const [ isAdvancedSettingsVisible, setAdvancedSettingsVisible ] = useState( false );
 
@@ -282,7 +282,13 @@ export const SiteForm = ( {
 									<Button className="pl-0" onClick={ handleAdvancedSettingsClick }>
 										<Icon
 											size={ 24 }
-											icon={ isAdvancedSettingsVisible ? chevronDown : chevronRight }
+											icon={
+												isAdvancedSettingsVisible
+													? chevronDown
+													: isRTL()
+													? chevronLeft
+													: chevronRight
+											}
 										/>
 										<div className="text-[13px] leading-[16px] ml-2">
 											{ __( 'Advanced settings' ) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/8793

## Proposed Changes

This PR changes the orientation for the `Advanced settings` chevron to left instead of right for RTL languages.

**Before**

<img width="489" alt="Screenshot 2024-08-19 at 1 59 29 PM" src="https://github.com/user-attachments/assets/da6c8fe2-2fe1-4398-8daa-674b3472ab77">

**After**

<img width="457" alt="‏لقطة الشاشة ٢٠٢٤-٠٨-١٩ في ١ ٥٤ ١٢ م ١" src="https://github.com/user-attachments/assets/cdef0e87-928c-49a7-8a3c-25094d372f09">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
* Switch the language on your OS to RTL e.g. Arabic
* Start the app with `npm start`
* Click on `Add site` in the sidebar
* Confirm that the chevron by `Advanced settings` is pointing left and not right
* Close the app
* Switch the language on your OS to English
* Start the app with `npm start`
* Click on `Add site` in the sidebar
* Confirm that the chevron by `Advanced settings` is pointing right

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
