### PR TITLE
Studio: Translate Studio Assistant Welcome messages

### DIFF
--- a/src/hooks/use-welcome-messages.tsx
+++ b/src/hooks/use-welcome-messages.tsx
@@ -8,7 +8,6 @@ import {
 	useCallback,
 	useContext,
 } from 'react';
-import { getAppGlobals } from '../lib/app-globals';
 import { useAuth } from './use-auth';
 import { useOffline } from './use-offline';
 import { useWindowListener } from './use-window-listener';
@@ -31,7 +30,6 @@ const WelcomeMessagesContext = createContext< WelcomeMessagesContext >( {
 export const WelcomeMessagesProvider = ( { children }: { children: React.ReactNode } ) => {
 	const { client } = useAuth();
 	const isOffline = useOffline();
-	const locale = getAppGlobals().locale;
 	const [ messages, setMessages ] = useState< string[] >( [] );
 	const [ examplePrompts, setExamplePrompts ] = useState< string[] >( [] );
 	const isFetchingMessages = useRef( false );
@@ -43,7 +41,7 @@ export const WelcomeMessagesProvider = ( { children }: { children: React.ReactNo
 		isFetchingMessages.current = true;
 		try {
 			const response = await client.req.get( {
-				path: `/studio-app/ai-assistant/welcome?locale=${ encodeURIComponent( locale ) }`,
+				path: '/studio-app/ai-assistant/welcome',
 				apiNamespace: 'wpcom/v2',
 			} );
 			const data = response as WelcomeMessageResponse;
@@ -57,7 +55,7 @@ export const WelcomeMessagesProvider = ( { children }: { children: React.ReactNo
 		} finally {
 			isFetchingMessages.current = false;
 		}
-	}, [ client, isOffline, locale ] );
+	}, [ client, isOffline ] );
 
 	useEffect( () => {
 		fetchMessages();

--- a/src/hooks/use-welcome-messages.tsx
+++ b/src/hooks/use-welcome-messages.tsx
@@ -43,11 +43,9 @@ export const WelcomeMessagesProvider = ( { children }: { children: React.ReactNo
 		isFetchingMessages.current = true;
 		try {
 			const response = await client.req.get( {
-				path: '/studio-app/ai-assistant/welcome',
+				path: `/studio-app/ai-assistant/welcome?locale=${ encodeURIComponent( locale ) }`,
 				apiNamespace: 'wpcom/v2',
-				params: { locale },
 			} );
-
 			const data = response as WelcomeMessageResponse;
 			if ( data ) {
 				setMessages( data.messages );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/8279

## Proposed Changes

This PR ensures that the welcome messages for which we have translated the strings in GlotPress are translated in Studio Assistant:

<img width="672" alt="Zrzut ekranu 2024-08-20 o 10 41 39 AM" src="https://github.com/user-attachments/assets/8bbb75b4-ba87-49fc-8c9b-937bb6b17c4c">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply the following diff to your sandbox: D158963-code
* Sandbox the public API
* Pull the changes from this branch
* Switch the language to one of the supported languages e.g. Polish would be a good example as it has all the strings for welcome messages translated
* Start the app with `npm start`
* Navigate to the `Assistant` tab
* Confirm that the welcome messages are translated

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?