### PR TITLE
Ensure we exit the php process after running the WP cli command

### DIFF
--- a/vendor/wp-now/src/execute-wp-cli.ts
+++ b/vendor/wp-now/src/execute-wp-cli.ts
@@ -93,5 +93,7 @@ export async function executeWPCli( projectPath: string, args: string[] ): Promi
 	} catch (error) {
 		const stderr = php.readFileAsText(stderrPath).replace('PHP.run() output was: #!/usr/bin/env php', '').trim();
 		return { stdout: '', stderr: stderr, exitCode: 1 };
+	} finally {
+		php.exit();
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/8799

## Proposed Changes

- Exit the PHP process that runs the wp cli command to prevent accumulating processes. This will ensure we free up the memory right after the command has executed and returned its output.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run on windows and try to import a jetpack backup multiple times (10 times in a row on the same site). 
- Verify that all of those times it worked without any issue.
- To be 100% sure, also try to do the same without this fix.
- While testing, keep an eye on the task manager (processes) and watch for Studio (or Electron if you're not using the executable). With this fix, the memory usage of all Studio processes should be fairly stable. Without this fix, you should see the memory go up rapidly after each import.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
