### PR TITLE
Studio: Handle Add Site top bar menu item in onboarding screen

### DIFF
--- a/src/components/onboarding.tsx
+++ b/src/components/onboarding.tsx
@@ -101,12 +101,7 @@ export default function Onboarding() {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [] );
 
-	const preventEventAndHandleSubmit = async ( event: FormEvent ) => {
-		event.preventDefault();
-		await handleSubmit();
-	};
-
-	const handleSubmit = useCallback( async () => {
+	const onAddSite = useCallback( async () => {
 		// Prompt the user to enable optimizations on Windows
 		try {
 			await getIpcApi().promptWindowsSpeedUpSites( { skipIfAlreadyPrompted: true } );
@@ -134,7 +129,7 @@ export default function Onboarding() {
 		if ( isAnySiteProcessing || ! needsOnboarding ) {
 			return;
 		}
-		handleSubmit();
+		onAddSite();
 	} );
 
 	return (
@@ -159,7 +154,10 @@ export default function Onboarding() {
 							onSelectPath={ handlePathSelectorClick }
 							error={ error }
 							doesPathContainWordPress={ doesPathContainWordPress }
-							onSubmit={ preventEventAndHandleSubmit }
+							onSubmit={ async ( event: FormEvent ) => {
+								event.preventDefault();
+								await onAddSite();
+							} }
 							fileForImport={ fileForImport }
 							setFileForImport={ setFileForImport }
 							onFileSelected={ handleImportFile }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Closes https://github.com/Automattic/studio/issues/377

## Proposed Changes

This PR changes the behaviour of the `Add site` menu item in the top bar menu when the user is presented with the onboarding screen. Instead of doing nothing, the menu item now triggers the site creation.

## Testing Instructions

* Pull the changes from this branch
* Start the app with `npm start`
* Delete all local sites to be presented with the onboarding screen
* Once on onboarding screen, click on `Add Site..` in the top bar menu
* Observe that it creates a new site and you are presented with the loading screen
* Observe that once the site is created and you try to click on `Add Site...`, it opens a modal with add site form

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
