### PR TITLE
Studio: Fix all demo sites are marked as updating when one is updated

### DIFF
--- a/src/components/content-tab-snapshots.tsx
+++ b/src/components/content-tab-snapshots.tsx
@@ -59,6 +59,7 @@ function SnapshotRow( {
 	const isUploading = isUploadingSiteId( selectedSite.id );
 	const { updateDemoSite, isDemoSiteUpdating } = useUpdateDemoSite();
 	const errorMessages = useArchiveErrorMessages();
+	const isSiteDemoUpdating = isDemoSiteUpdating( snapshot.localSiteId );
 
 	const isOffline = useOffline();
 	const updateDemoSiteOfflineMessage = __(
@@ -70,7 +71,7 @@ function SnapshotRow( {
 	const userBlockedMessage = errorMessages.rest_site_creation_blocked;
 
 	const { progress, setProgress } = useProgressTimer( {
-		paused: ! isDemoSiteUpdating,
+		paused: ! isSiteDemoUpdating,
 		initialProgress: 5,
 		interval: 1500,
 		maxValue: 95,
@@ -81,10 +82,10 @@ function SnapshotRow( {
 	}, [ fetchSnapshotUsage ] );
 
 	useEffect( () => {
-		if ( isDemoSiteUpdating ) {
+		if ( isSiteDemoUpdating ) {
 			setProgress( 80 );
 		}
-	}, [ isDemoSiteUpdating, setProgress ] );
+	}, [ isSiteDemoUpdating, setProgress ] );
 
 	if ( isDeleting ) {
 		return <SnapshotRowLoading>{ __( 'Deleting demo site…' ) }</SnapshotRowLoading>;
@@ -199,7 +200,7 @@ function SnapshotRow( {
 				{ sprintf( __( 'Expires in %s' ), countDown ) }
 			</div>
 			<div className="mt-4 flex gap-4">
-				{ isDemoSiteUpdating ? (
+				{ isSiteDemoUpdating ? (
 					<div className="w-[300px]">
 						<ProgressBar value={ progress } maxValue={ 100 } />
 						<div className="text-a8c-gray-70 a8c-body mt-4">

--- a/src/components/tests/content-tab-snapshots.test.tsx
+++ b/src/components/tests/content-tab-snapshots.test.tsx
@@ -16,9 +16,10 @@ jest.mock( '../../hooks/use-offline' );
 
 jest.mock( '../../hooks/use-update-demo-site' );
 const updateDemoSiteMock = jest.fn();
+const isDemoSiteUpdating = jest.fn();
 ( useUpdateDemoSite as jest.Mock ).mockReturnValue( {
 	updateDemoSite: updateDemoSiteMock,
-	isDemoSiteUpdating: false,
+	isDemoSiteUpdating: isDemoSiteUpdating,
 } );
 
 const archiveSite = jest.fn();

--- a/src/hooks/tests/use-update-demo-site.test.tsx
+++ b/src/hooks/tests/use-update-demo-site.test.tsx
@@ -96,7 +96,7 @@ describe( 'useUpdateDemoSite', () => {
 		} );
 
 		// Assert that 'isDemoSiteUpdating' is set back to false
-		expect( result.current.isDemoSiteUpdating ).toBe( false );
+		expect( result.current.isDemoSiteUpdating( mockLocalSite.id ) ).toBe( false );
 
 		// Assert that demo site is updated with a new expiration date
 		expect( updateSnapshotMock ).toHaveBeenCalledWith(
@@ -125,7 +125,7 @@ describe( 'useUpdateDemoSite', () => {
 		);
 
 		// Assert that 'isDemoSiteUpdating' is set back to false
-		expect( result.current.isDemoSiteUpdating ).toBe( false );
+		expect( result.current.isDemoSiteUpdating( mockLocalSite.id ) ).toBe( false );
 	} );
 
 	afterEach( () => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/8797

## Proposed Changes

This PR ensures that when there is one demo site that is updating, all other demo sites are not marked as updating and the button `Update demo site` remains available.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
* Start the app with `nvm use && npm install && npm start`
* Create at least two local sites
* Create two demo sites
* Under the `Share` tab for a demo site A, click on `Update demo site` button
* Navigate to the `Share` tab of a demo site B
* Observe that the site B is not marked as updating while site A is updating 
* Observe that the loading bar is not present on site B and is present on site A

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
