### PR TITLE
Set the default locale when the language picker changes

### DIFF
--- a/src/hooks/use-i18n-data.tsx
+++ b/src/hooks/use-i18n-data.tsx
@@ -1,4 +1,4 @@
-import { createI18n, I18n } from '@wordpress/i18n';
+import { createI18n, defaultI18n, I18n } from '@wordpress/i18n';
 import { I18nProvider } from '@wordpress/react-i18n';
 import { createContext, useContext, useEffect, useMemo, useState, useCallback } from 'react';
 import { getIpcApi } from '../lib/get-ipc-api';
@@ -22,6 +22,7 @@ export const I18nDataProvider = ( { children }: { children: React.ReactNode } ) 
 
 	const initI18n = useCallback( async ( localeKey: SupportedLocale ) => {
 		const newI18n = createI18n( getLocaleData( localeKey )?.messages );
+		defaultI18n.setLocaleData( getLocaleData( localeKey )?.messages );
 		setI18n( newI18n );
 	}, [] );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to https://github.com/Automattic/studio/pull/502#pullrequestreview-2276754994

## Proposed Changes

- Update the default locale to ensure all the strings are translated.

I've tried removing the i18n hook in favor of using only the default, but then the other half of translations are not correctly translated.

<img width="1012" alt="Screenshot 2024-09-03 at 10 05 03" src="https://github.com/user-attachments/assets/7cc01ca8-b5a5-41c4-9501-1115ed32a3c2">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Change the locale in the settings and observe all the strings are translated.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
