### PR TITLE
Ensure all strings are updated when switching language

### DIFF
--- a/src/hooks/use-i18n-data.tsx
+++ b/src/hooks/use-i18n-data.tsx
@@ -27,8 +27,15 @@ export const I18nDataProvider = ( { children }: { children: React.ReactNode } ) 
 		// Update default I18n data to reflect language change when using
 		// I18n functions from `@wordpress/i18n` package.
 		// Note we need to update this in both the renderer and main processes.
-		defaultI18n.setLocaleData( translations );
-		getIpcApi().setDefaultLocaleData( translations );
+		if ( translations ) {
+			defaultI18n.setLocaleData( translations );
+			getIpcApi().setDefaultLocaleData( translations );
+		} else {
+			// In case we don't find translations, we reset the locale data to
+			// fallback to the default translations.
+			defaultI18n.resetLocaleData();
+			getIpcApi().resetDefaultLocaleData();
+		}
 		// App menu is reloaded to ensure the items show the translated strings.
 		getIpcApi().setupAppMenu();
 	}, [] );

--- a/src/hooks/use-i18n-data.tsx
+++ b/src/hooks/use-i18n-data.tsx
@@ -26,7 +26,9 @@ export const I18nDataProvider = ( { children }: { children: React.ReactNode } ) 
 		setI18n( newI18n );
 		// Update default I18n data to reflect language change when using
 		// I18n functions from `@wordpress/i18n` package.
+		// Note we need to update this in both the renderer and main processes.
 		defaultI18n.setLocaleData( translations );
+		getIpcApi().setDefaultLocaleData( translations );
 	}, [] );
 
 	useEffect( () => {

--- a/src/hooks/use-i18n-data.tsx
+++ b/src/hooks/use-i18n-data.tsx
@@ -29,6 +29,8 @@ export const I18nDataProvider = ( { children }: { children: React.ReactNode } ) 
 		// Note we need to update this in both the renderer and main processes.
 		defaultI18n.setLocaleData( translations );
 		getIpcApi().setDefaultLocaleData( translations );
+		// App menu is reloaded to ensure the items show the translated strings.
+		getIpcApi().setupAppMenu();
 	}, [] );
 
 	useEffect( () => {

--- a/src/hooks/use-i18n-data.tsx
+++ b/src/hooks/use-i18n-data.tsx
@@ -33,7 +33,6 @@ export const I18nDataProvider = ( { children }: { children: React.ReactNode } ) 
 		} else {
 			// In case we don't find translations, we reset the locale data to
 			// fallback to the default translations.
-			defaultI18n.resetLocaleData();
 			getIpcApi().resetDefaultLocaleData();
 		}
 		// App menu is reloaded to ensure the items show the translated strings.

--- a/src/hooks/use-i18n-data.tsx
+++ b/src/hooks/use-i18n-data.tsx
@@ -1,4 +1,4 @@
-import { createI18n, I18n } from '@wordpress/i18n';
+import { createI18n, I18n, defaultI18n } from '@wordpress/i18n';
 import { I18nProvider } from '@wordpress/react-i18n';
 import { createContext, useContext, useEffect, useMemo, useState, useCallback } from 'react';
 import { getIpcApi } from '../lib/get-ipc-api';
@@ -21,8 +21,12 @@ export const I18nDataProvider = ( { children }: { children: React.ReactNode } ) 
 	const [ locale, setLocale ] = useState< SupportedLocale >( 'en' );
 
 	const initI18n = useCallback( async ( localeKey: SupportedLocale ) => {
-		const newI18n = createI18n( getLocaleData( localeKey )?.messages );
+		const translations = getLocaleData( localeKey )?.messages;
+		const newI18n = createI18n( translations );
 		setI18n( newI18n );
+		// Update default I18n data to reflect language change when using
+		// I18n functions from `@wordpress/i18n` package.
+		defaultI18n.setLocaleData( translations );
 	}, [] );
 
 	useEffect( () => {

--- a/src/hooks/use-i18n-data.tsx
+++ b/src/hooks/use-i18n-data.tsx
@@ -33,6 +33,7 @@ export const I18nDataProvider = ( { children }: { children: React.ReactNode } ) 
 		} else {
 			// In case we don't find translations, we reset the locale data to
 			// fallback to the default translations.
+			defaultI18n.resetLocaleData();
 			getIpcApi().resetDefaultLocaleData();
 		}
 		// App menu is reloaded to ensure the items show the translated strings.

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -722,3 +722,7 @@ export async function promptWindowsSpeedUpSites(
 export function setDefaultLocaleData( _event: IpcMainInvokeEvent, locale?: LocaleData ) {
 	defaultI18n.setLocaleData( locale );
 }
+
+export function resetDefaultLocaleData( _event: IpcMainInvokeEvent ) {
+	defaultI18n.resetLocaleData();
+}

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -36,7 +36,7 @@ import { sortSites } from './lib/sort-sites';
 import { installSqliteIntegration, keepSqliteIntegrationUpdated } from './lib/sqlite-versions';
 import * as windowsHelpers from './lib/windows-helpers';
 import { writeLogToFile, type LogLevel } from './logging';
-import { popupMenu } from './menu';
+import { popupMenu, setupMenu } from './menu';
 import { SiteServer, createSiteWorkingDirectory } from './site-server';
 import { DEFAULT_SITE_PATH, getResourcesPath, getSiteThumbnailPath } from './storage/paths';
 import { loadUserData, saveUserData } from './storage/user-data';
@@ -702,6 +702,10 @@ export async function showNotification(
 	options: Electron.NotificationConstructorOptions
 ) {
 	new Notification( options ).show();
+}
+
+export function setupAppMenu( _event: IpcMainInvokeEvent ) {
+	setupMenu();
 }
 
 export function popupAppMenu( _event: IpcMainInvokeEvent ) {

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -13,6 +13,7 @@ import {
 import fs from 'fs';
 import nodePath from 'path';
 import * as Sentry from '@sentry/electron/main';
+import { LocaleData, defaultI18n } from '@wordpress/i18n';
 import archiver from 'archiver';
 import { DEFAULT_PHP_VERSION } from '../vendor/wp-now/src/constants';
 import { SIZE_LIMIT_BYTES } from './constants';
@@ -712,4 +713,8 @@ export async function promptWindowsSpeedUpSites(
 	{ skipIfAlreadyPrompted }: { skipIfAlreadyPrompted: boolean }
 ) {
 	await windowsHelpers.promptWindowsSpeedUpSites( { skipIfAlreadyPrompted } );
+}
+
+export function setDefaultLocaleData( _event: IpcMainInvokeEvent, locale?: LocaleData ) {
+	defaultI18n.setLocaleData( locale );
 }

--- a/src/main-window.ts
+++ b/src/main-window.ts
@@ -4,7 +4,7 @@ import { MAIN_MIN_HEIGHT, MAIN_MIN_WIDTH, WINDOWS_TITLEBAR_HEIGHT } from './cons
 import { isEmptyDir } from './lib/fs-utils';
 import { portFinder } from './lib/port-finder';
 import { keepSqliteIntegrationUpdated } from './lib/sqlite-versions';
-import { setupMenu } from './menu';
+import { removeMenu } from './menu';
 import { UserData } from './storage/storage-types';
 import { loadUserData, saveUserData } from './storage/user-data';
 
@@ -91,10 +91,9 @@ export function createMainWindow(): BrowserWindow {
 	} );
 
 	mainWindow.on( 'closed', () => {
-		setupMenu( null );
+		removeMenu();
 		mainWindow = null;
 	} );
-	setupMenu( mainWindow );
 
 	return mainWindow;
 }

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -13,21 +13,27 @@ import { promptWindowsSpeedUpSites } from './lib/windows-helpers';
 import { withMainWindow } from './main-window';
 import { isUpdateReadyToInstall, manualCheckForUpdates } from './updates';
 
-export function setupMenu( mainWindow: BrowserWindow | null ) {
-	if ( ! mainWindow && process.platform !== 'darwin' ) {
+export function setupMenu() {
+	withMainWindow( ( mainWindow ) => {
+		if ( ! mainWindow && process.platform !== 'darwin' ) {
+			Menu.setApplicationMenu( null );
+			return;
+		}
+		const menu = getAppMenu( mainWindow );
+		if ( process.platform === 'darwin' ) {
+			Menu.setApplicationMenu( menu );
+			return;
+		}
+		// Make menu accessible in development for non-macOS platforms
+		if ( process.env.NODE_ENV === 'development' ) {
+			mainWindow?.setMenu( menu );
+			return;
+		}
 		Menu.setApplicationMenu( null );
-		return;
-	}
-	const menu = getAppMenu( mainWindow );
-	if ( process.platform === 'darwin' ) {
-		Menu.setApplicationMenu( menu );
-		return;
-	}
-	// Make menu accessible in development for non-macOS platforms
-	if ( process.env.NODE_ENV === 'development' ) {
-		mainWindow?.setMenu( menu );
-		return;
-	}
+	} );
+}
+
+export function removeMenu() {
 	Menu.setApplicationMenu( null );
 }
 

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -3,6 +3,7 @@
 
 import '@sentry/electron/preload';
 import { SaveDialogOptions, contextBridge, ipcRenderer } from 'electron';
+import { LocaleData } from '@wordpress/i18n';
 import { ExportOptions } from './lib/import-export/export/types';
 import { BackupArchiveInfo } from './lib/import-export/import/types';
 import { promptWindowsSpeedUpSites } from './lib/windows-helpers';
@@ -65,6 +66,8 @@ const api: IpcApi = {
 	popupAppMenu: () => ipcRenderer.invoke( 'popupAppMenu' ),
 	promptWindowsSpeedUpSites: ( ...args: Parameters< typeof promptWindowsSpeedUpSites > ) =>
 		ipcRenderer.invoke( 'promptWindowsSpeedUpSites', ...args ),
+	setDefaultLocaleData: ( locale?: LocaleData ) =>
+		ipcRenderer.invoke( 'setDefaultLocaleData', locale ),
 };
 
 contextBridge.exposeInMainWorld( 'ipcApi', api );

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -69,6 +69,7 @@ const api: IpcApi = {
 		ipcRenderer.invoke( 'promptWindowsSpeedUpSites', ...args ),
 	setDefaultLocaleData: ( locale?: LocaleData ) =>
 		ipcRenderer.invoke( 'setDefaultLocaleData', locale ),
+	resetDefaultLocaleData: () => ipcRenderer.invoke( 'resetDefaultLocaleData' ),
 };
 
 contextBridge.exposeInMainWorld( 'ipcApi', api );

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -63,6 +63,7 @@ const api: IpcApi = {
 	// Use .send instead of .invoke because logging is fire-and-forget
 	logRendererMessage: ( level: LogLevel, ...args: any[] ) =>
 		ipcRenderer.send( 'logRendererMessage', level, ...args ),
+	setupAppMenu: () => ipcRenderer.invoke( 'setupAppMenu' ),
 	popupAppMenu: () => ipcRenderer.invoke( 'popupAppMenu' ),
 	promptWindowsSpeedUpSites: ( ...args: Parameters< typeof promptWindowsSpeedUpSites > ) =>
 		ipcRenderer.invoke( 'promptWindowsSpeedUpSites', ...args ),


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to https://github.com/Automattic/studio/pull/476#issuecomment-2325968838.

## Proposed Changes

- Update the default I18n locale data when switching languages. Note we need to do this for both renderer and main processes.
- Delegate app menu setup to `useI18nData` hook. This way the menu items will reflect the proper translations when opening the app and switching languages.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

> [!WARNING]
> - Some of the menu items are not translated because they are added by the OS based on the OS language set.
> - The string `Language` in the Settings popup is not translated because it's not included yet in the translation files.

- Open app settings.
- Change the language.
- Observe that all strings are translated to the selected language, including the app menu.
- Re-open the app.
- Observe that all strings are translated to the previously selected language, including the app menu.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
