### PR TITLE
Add menu item to make the Studio to float on top of other windows

### DIFF
--- a/src/menu.ts
+++ b/src/menu.ts
@@ -154,9 +154,10 @@ function getAppMenu( mainWindow: BrowserWindow | null ) {
 				{
 					label: __( 'Float on Top of All Other Windows' ),
 					type: 'checkbox',
-					click: ( menuItem, browserWindow ) => {
+					checked: mainWindow?.isAlwaysOnTop(),
+					click: ( _menuItem, browserWindow ) => {
 						if ( browserWindow ) {
-							browserWindow.setAlwaysOnTop( menuItem.checked, 'floating' );
+							browserWindow.setAlwaysOnTop( ! browserWindow.isAlwaysOnTop(), 'floating' );
 						}
 					},
 				},

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -150,6 +150,16 @@ function getAppMenu( mainWindow: BrowserWindow | null ) {
 				{ role: 'zoomOut' },
 				{ type: 'separator' },
 				{ role: 'togglefullscreen' },
+				{ type: 'separator' },
+				{
+					label: __( 'Float on Top of All Other Windows' ),
+					type: 'checkbox',
+					click: ( menuItem, browserWindow ) => {
+						if ( browserWindow ) {
+							browserWindow.setAlwaysOnTop( menuItem.checked, 'floating' );
+						}
+					},
+				},
 			],
 		},
 		...( process.platform === 'win32'


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

- Closes https://github.com/Automattic/dotcom-forge/issues/8985

## Proposed Changes

- Added a new menu item to make the Studio App floating over the rest of windows, to make easier to interact with the assistant and the window site.
- This option is not saved as a user preference and it's set as the default false (non floating) after Studio restarts, this respects how QuickTime works.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run `npm start`
- Click on View in the the top menu
- Observe the new menu item "Float on Top of All Other Windows"
- Click on the menu item
- Observe the Studio window floats over all other screens
- Click again in the menu item "Float on Top of All Other Windows" to deselect it
- Observe the Studio window does not float, and other windows can be on top of it

https://github.com/user-attachments/assets/a502b71b-ae8a-43e9-9367-56ad8d6b3337



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?