### PR TITLE
Ensure sites are always stopped

### DIFF
--- a/src/lib/site-server-process.ts
+++ b/src/lib/site-server-process.ts
@@ -66,8 +66,11 @@ export default class SiteServerProcess {
 	async stop() {
 		const message = 'stop-server';
 		const messageId = this.sendMessage( message );
-		await this.waitForResponse( message, messageId );
-		await this.#killProcess();
+		try {
+			await this.waitForResponse( message, messageId, 5_000 );
+		} finally {
+			await this.#killProcess();
+		}
 	}
 
 	async runPhp( data: PHPRunOptions ): Promise< string > {

--- a/src/site-server.ts
+++ b/src/site-server.ts
@@ -128,7 +128,11 @@ export class SiteServer {
 
 	async stop() {
 		console.log( 'Stopping server with ID', this.details.id );
-		await this.server?.stop();
+		try {
+			await this.server?.stop();
+		} catch ( error ) {
+			console.error( error );
+		}
 		this.server = undefined;
 
 		if ( ! this.details.running ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to https://github.com//issues/9018-gh-Automattic/dotcom-forge.

## Proposed Changes

- Ensure the server process is killed independently of the result of the stop message sent to the process. Ideally, we kill the process when the server stops gracefully, but we'll force this if the set timeout is reached.
- Change the timeout of the server stop message from 2 minutes to 5 seconds. The 2-minute timeout is the default value we use for all server messages. My rationale for this change is that this value seems reasonable for starting the site or requests, but a server should be stopped sooner.
- Catch any errors produced during the server stop. We'll log the error internally but there won't be any notification to the user. I thought to report the error to Sentry, but since it won't have any context due to being a timeout, I felt it would end up generating noise instead of being helpful.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run the app with the command `npm start`.
- Create a site.
- Open the site's folder.
- Create a file with the name `test.php` at root with the following content. It will make the request to run indefinitely.
```php
<?php
while (true) {
    sleep(1);
}
```
- Start the site.
- Navigate to `http://localhost:<PORT>/test.php`.
- Observe that the page gets in an indefinite loading state.
- Stop the site.
- Observe the site is stopped after 5 seconds.
- Observe an error message is logged to the console.

| Before _(timeout has been set to 5 seconds for testing)_ | After |
|--------|--------|
| <video src=https://github.com/user-attachments/assets/678f62ea-6132-4427-96d3-b6fb12bfed61> | <video src=https://github.com/user-attachments/assets/22ae6e82-4704-4683-a023-5b26d5ad933b> | 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
