### PR TITLE
Use site's PHP version when running WP-CLI commands

### DIFF
--- a/src/lib/wp-cli-process-child.ts
+++ b/src/lib/wp-cli-process-child.ts
@@ -19,11 +19,15 @@ const handlers: Handlers = {
 };
 
 async function execute( data: unknown ) {
-	const { projectPath, args } = data as { projectPath: string; args: string[] };
+	const { projectPath, args, phpVersion } = data as {
+		projectPath: string;
+		args: string[];
+		phpVersion: string;
+	};
 	if ( ! projectPath || ! args ) {
 		throw Error( 'Command execution needs project path and arguments' );
 	}
-	return await executeWPCli( projectPath, args );
+	return await executeWPCli( projectPath, args, { phpVersion } );
 }
 
 function createHandler< T >( handler: ( data: unknown ) => T ) {

--- a/src/lib/wp-cli-process.ts
+++ b/src/lib/wp-cli-process.ts
@@ -52,9 +52,16 @@ export default class WpCliProcess {
 		} );
 	}
 
-	async execute( args: string[] ): Promise< WpCliResult > {
+	async execute(
+		args: string[],
+		{ phpVersion }: { phpVersion?: string } = {}
+	): Promise< WpCliResult > {
 		const message = 'execute';
-		const messageId = this.sendMessage( message, { projectPath: this.projectPath, args } );
+		const messageId = this.sendMessage( message, {
+			projectPath: this.projectPath,
+			args,
+			phpVersion,
+		} );
 		return await this.waitForResponse( message, messageId );
 	}
 

--- a/src/site-server.ts
+++ b/src/site-server.ts
@@ -166,6 +166,7 @@ export class SiteServer {
 
 	async executeWpCliCommand( args: string ): Promise< WpCliResult > {
 		const projectPath = this.details.path;
+		const phpVersion = this.details.phpVersion;
 
 		if ( ! this.wpCliExecutor ) {
 			this.wpCliExecutor = new WpCliProcess( projectPath );
@@ -183,7 +184,7 @@ export class SiteServer {
 		}
 
 		try {
-			return await this.wpCliExecutor.execute( wpCliArgs as string[] );
+			return await this.wpCliExecutor.execute( wpCliArgs as string[], { phpVersion } );
 		} catch ( error ) {
 			if ( ( error as MessageCanceled )?.canceled ) {
 				return { stdout: '', stderr: 'wp-cli command canceled', exitCode: 1 };

--- a/vendor/wp-now/src/execute-wp-cli.ts
+++ b/vendor/wp-now/src/execute-wp-cli.ts
@@ -14,10 +14,14 @@ const isWindows = process.platform === 'win32';
 /**
  * This is an unstable API. Multiple wp-cli commands may not work due to a current limitation on php-wasm and pthreads.
  */
-export async function executeWPCli( projectPath: string, args: string[] ): Promise<{ stdout: string; stderr: string; exitCode: number; }> {
+export async function executeWPCli(
+	projectPath: string,
+	args: string[],
+	{ phpVersion }: { phpVersion?: string } = {}
+): Promise< { stdout: string; stderr: string; exitCode: number } > {
 	await downloadWpCli();
 	let options = await getWpNowConfig({
-		php: DEFAULT_PHP_VERSION,
+		php: phpVersion || DEFAULT_PHP_VERSION,
 		wp: DEFAULT_WORDPRESS_VERSION,
 		path: projectPath,
 	});


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to https://github.com/Automattic/studio/issues/468.

## Proposed Changes

- Pass the site's PHP version when executing a WP-CLI command.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Download the following test plugin: [test-plugin.zip](https://github.com/user-attachments/files/16928988/test-plugin.zip)
- Start the app with the command `npm start`.
- Create a site.
- Navigate to WP-Admin.
- Navigate to the Plugins page.
- Install the test plugin.
- Activate the test plugin.
- Observe the site throws an error. This is due to the plugin using a deprecated function [`create_function `](https://www.php.net/manual/en/function.create-function.php) which was removed in PHP version 8.
- Change the PHP version to `7.4` in the Settings tab of the app.
- Try to activate the test plugin again.
- Observe no errors are thrown.
- Switch to another app and back again to the Studio app. This will trigger WP-CLI commands to fetch the installed plugins and themes of the running site.
- Observe no errors are thrown in the app logs.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
