### PR TITLE
Mount filesystems again when rotating PHP runtime instance

### DIFF
--- a/vendor/wp-now/src/wp-now.ts
+++ b/vendor/wp-now/src/wp-now.ts
@@ -155,7 +155,7 @@ function prepareDocumentRoot( php: PHP, options: WPNowOptions ) {
 	)
 }
 
-async function prepareWordPress( php: PHP, options: WPNowOptions 	) {
+async function prepareWordPress( php: PHP, options: WPNowOptions ) {
 	switch (options.mode) {
 		case WPNowMode.WP_CONTENT:
 			await runWpContentMode(php, options);

--- a/vendor/wp-now/src/wp-now.ts
+++ b/vendor/wp-now/src/wp-now.ts
@@ -41,14 +41,13 @@ export default async function startWPNow(
 	const requestHandler = new PHPRequestHandler({
 		phpFactory: async ({ isPrimary, requestHandler:reqHandler }) => {
 			const { php } = await getPHPInstance( options, isPrimary, reqHandler );
-			// CHeck if we need this?
-			// if(!isPrimary) {
-			// 	proxyFileSystem(await requestHandler.getPrimaryPhp(), php, [
-			// 		'/tmp',
-			// 		requestHandler.documentRoot,
-			// 		'/internal/shared',
-			// 	]);
-			// }
+			if(!isPrimary) {
+				proxyFileSystem(await requestHandler.getPrimaryPhp(), php, [
+					'/tmp',
+					requestHandler.documentRoot,
+					'/internal/shared',
+				]);
+			}
 			if( reqHandler ) {
 				php.requestHandler = reqHandler
 			}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Fixes #516

## Proposed Changes

When rotating an instance, the callback used by the rotation logic should prepare the filesystem and mount the required directories again as they are not retained. Only MEMFS mounts are carried over to the fresh instance but we are using NODEFS for most mounts.

To achieve this, i extracted some logic out of the huge main function `startWPNow` to make it reusable when creating the first instance AND during the rotation.

Not all logic needs to be executed again. We only care about the mounts and PHP settings.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Create a site
- Run `ab -n 500 http://localhost:<port>/`
- Wait for the 500 requests to run and ensure there are no failing requests
- Keep an eye on the console where you ran `npm start` when request 400 has been reached, you should see a log output telling you the PHP instance is being rotated.
- Observe that you can navigate the WordPress site and WP-admin without issues

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
