### PR TITLE
Studio: Add rotation to welcome messages

### DIFF
--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -307,7 +307,7 @@ export function ContentTabAssistant( { selectedSite }: ContentTabAssistantProps 
 	const { userCanSendMessage } = usePromptUsage();
 	const { fetchAssistant, isLoading: isAssistantThinking } = useAssistantApi( selectedSite.id );
 	const { messages: welcomeMessages } = useWelcomeMessages();
-	const { randomizedPrompts } = useRotateWelcomeMessages();
+	const { randomizedPrompts } = useRotateWelcomeMessages( selectedSite.id );
 	const [ input, setInput ] = useState< string >( '' );
 	const isOffline = useOffline();
 	const { __ } = useI18n();

--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -14,7 +14,7 @@ import { useAuth } from '../hooks/use-auth';
 import { useChatContext } from '../hooks/use-chat-context';
 import { useOffline } from '../hooks/use-offline';
 import { usePromptUsage } from '../hooks/use-prompt-usage';
-import { useRotateWelcomeMessages } from '../hooks/use-rotate-promp-messages';
+import { useRotatePromptMessages } from '../hooks/use-rotate-promp-messages';
 import { useWelcomeMessages } from '../hooks/use-welcome-messages';
 import { cx } from '../lib/cx';
 import { getIpcApi } from '../lib/get-ipc-api';
@@ -307,7 +307,7 @@ export function ContentTabAssistant( { selectedSite }: ContentTabAssistantProps 
 	const { userCanSendMessage } = usePromptUsage();
 	const { fetchAssistant, isLoading: isAssistantThinking } = useAssistantApi( selectedSite.id );
 	const { messages: welcomeMessages } = useWelcomeMessages();
-	const { randomizedPrompts } = useRotateWelcomeMessages( selectedSite.id );
+	const { randomizedPrompts } = useRotatePromptMessages( selectedSite.id );
 	const [ input, setInput ] = useState< string >( '' );
 	const isOffline = useOffline();
 	const { __ } = useI18n();

--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -14,6 +14,7 @@ import { useAuth } from '../hooks/use-auth';
 import { useChatContext } from '../hooks/use-chat-context';
 import { useOffline } from '../hooks/use-offline';
 import { usePromptUsage } from '../hooks/use-prompt-usage';
+import { useRotateWelcomeMessages } from '../hooks/use-rotate-promp-messages';
 import { useWelcomeMessages } from '../hooks/use-welcome-messages';
 import { cx } from '../lib/cx';
 import { getIpcApi } from '../lib/get-ipc-api';
@@ -305,12 +306,15 @@ export function ContentTabAssistant( { selectedSite }: ContentTabAssistantProps 
 		useAssistant( user?.id ? `${ user.id }_${ selectedSite.id }` : selectedSite.id );
 	const { userCanSendMessage } = usePromptUsage();
 	const { fetchAssistant, isLoading: isAssistantThinking } = useAssistantApi( selectedSite.id );
-	const { messages: welcomeMessages, examplePrompts } = useWelcomeMessages();
+	const { messages: welcomeMessages } = useWelcomeMessages();
+	const { randomizedPrompts } = useRotateWelcomeMessages();
 	const [ input, setInput ] = useState< string >( '' );
 	const isOffline = useOffline();
 	const { __ } = useI18n();
 	const lastMessage = messages.length === 0 ? undefined : messages[ messages.length - 1 ];
 	const hasFailedMessage = messages.some( ( msg ) => msg.failedMessage );
+
+	console.log( randomizedPrompts );
 
 	const handleSend = async ( messageToSend?: string, isRetry?: boolean ) => {
 		const chatMessage = messageToSend || input;
@@ -394,7 +398,7 @@ export function ContentTabAssistant( { selectedSite }: ContentTabAssistantProps 
 								} }
 								showExamplePrompts={ messages.length === 0 }
 								messages={ welcomeMessages }
-								examplePrompts={ examplePrompts }
+								examplePrompts={ randomizedPrompts }
 								disabled={ disabled }
 							/>
 							<AuthenticatedView

--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -314,8 +314,6 @@ export function ContentTabAssistant( { selectedSite }: ContentTabAssistantProps 
 	const lastMessage = messages.length === 0 ? undefined : messages[ messages.length - 1 ];
 	const hasFailedMessage = messages.some( ( msg ) => msg.failedMessage );
 
-	console.log( randomizedPrompts );
-
 	const handleSend = async ( messageToSend?: string, isRetry?: boolean ) => {
 		const chatMessage = messageToSend || input;
 		let messageId;

--- a/src/hooks/use-rotate-promp-messages.ts
+++ b/src/hooks/use-rotate-promp-messages.ts
@@ -1,14 +1,14 @@
 import { useMemo } from 'react';
 import { useWelcomeMessages } from '../hooks/use-welcome-messages';
 
-export function useRotateWelcomeMessages() {
+export function useRotateWelcomeMessages( siteId: string ) {
 	const { examplePrompts } = useWelcomeMessages();
 
 	//Limit to 3 and shuffle initial prompts
 	const randomizedPrompts = useMemo( () => {
 		const shuffled = [ ...examplePrompts ].sort( () => 0.5 - Math.random() );
 		return shuffled.slice( 0, 3 );
-	}, [ examplePrompts ] );
+	}, [ examplePrompts, siteId ] );
 
 	return { randomizedPrompts };
 }

--- a/src/hooks/use-rotate-promp-messages.ts
+++ b/src/hooks/use-rotate-promp-messages.ts
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 import { useWelcomeMessages } from '../hooks/use-welcome-messages';
 
-export function useRotateWelcomeMessages( siteId: string ) {
+export function useRotatePromptMessages( siteId: string ) {
 	const { examplePrompts } = useWelcomeMessages();
 
 	//Limit to 3 and shuffle initial prompts

--- a/src/hooks/use-rotate-promp-messages.ts
+++ b/src/hooks/use-rotate-promp-messages.ts
@@ -1,0 +1,14 @@
+import { useMemo } from 'react';
+import { useWelcomeMessages } from '../hooks/use-welcome-messages';
+
+export function useRotateWelcomeMessages() {
+	const { examplePrompts } = useWelcomeMessages();
+
+	//Limit to 3 and shuffle initial prompts
+	const randomizedPrompts = useMemo( () => {
+		const shuffled = [ ...examplePrompts ].sort( () => 0.5 - Math.random() );
+		return shuffled.slice( 0, 3 );
+	}, [ examplePrompts ] );
+
+	return { randomizedPrompts };
+}

--- a/src/hooks/use-rotate-promp-messages.ts
+++ b/src/hooks/use-rotate-promp-messages.ts
@@ -8,6 +8,7 @@ export function useRotateWelcomeMessages( siteId: string ) {
 	const randomizedPrompts = useMemo( () => {
 		const shuffled = [ ...examplePrompts ].sort( () => 0.5 - Math.random() );
 		return shuffled.slice( 0, 3 );
+		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ examplePrompts, siteId ] );
 
 	return { randomizedPrompts };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Closes: https://github.com/Automattic/dotcom-forge/issues/8981

## Proposed Changes

This PR adds a rotation for example prompts so that every time you access the Assistant tab, you will get a new selection of prompts that come from the backend.

## Testing Instructions

* Apply this diff to your sandbox: D160843-code
* Sandbox the public API
* Pull the changes from this branch
* Start the app with `nvm use && npm install && npm start`
* Create a site
* Navigate to the Assistant tab
* Observe the two welcome messages and three example prompts
* Switch to the `Settings` tab
* Navigate back to the `Assistant` tab
* Observe the new set of three example prompts 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?