### PR TITLE
Create sites using user preferred language instead of systems locale

### DIFF
--- a/src/lib/locale-node.ts
+++ b/src/lib/locale-node.ts
@@ -11,9 +11,13 @@ export function getSupportedLocale() {
 }
 
 export async function getUserLocaleWithFallback() {
-	const { locale } = await loadUserData();
-	if ( ! locale || ! isSupportedLocale( locale ) ) {
+	try {
+		const { locale } = await loadUserData();
+		if ( ! locale || ! isSupportedLocale( locale ) ) {
+			return getSupportedLocale();
+		}
+		return locale;
+	} catch ( error ) {
 		return getSupportedLocale();
 	}
-	return locale;
 }

--- a/src/lib/site-language.ts
+++ b/src/lib/site-language.ts
@@ -4,7 +4,7 @@ import { match } from '@formatjs/intl-localematcher';
 import fs from 'fs-extra';
 import { getResourcesPath } from '../storage/paths';
 import { DEFAULT_LOCALE } from './locale';
-import { getSupportedLocale } from './locale-node';
+import { getUserLocaleWithFallback } from './locale-node';
 
 interface TranslationsData {
 	translations: Translation[];
@@ -94,7 +94,8 @@ export async function getPreferredSiteLanguage( wpVersion = 'latest' ) {
 		// Filter special locales
 		.filter( ( item ) => SKIP_LOCALE_TAGS.every( ( tagToSkip ) => ! item.endsWith( tagToSkip ) ) );
 
-	return match( [ getSupportedLocale() ], availableLanguages, DEFAULT_LOCALE )
+	const preferredLanguage = await getUserLocaleWithFallback();
+	return match( [ preferredLanguage ], availableLanguages, DEFAULT_LOCALE )
 		.split( '-' )
 		.join( '_' );
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

- Related to https://github.com/Automattic/dotcom-forge/issues/9070

## Proposed Changes

- Use user's locale to create new WordPress sites

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Start the app by running `npm start`
- Create a site
- Observe the WordPress site is the same as your current Studio UI
- Press `cmd+.` to open the settings modal
- Change the locale to another language
- Create a site
- Observe the new site uses your chosen locale


https://github.com/user-attachments/assets/0e7e6b0d-4d11-4d95-849e-ce5606b01996



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?