### PR TITLE
Studio: Add chat rating feedback feature

### DIFF
--- a/src/components/chat-message.tsx
+++ b/src/components/chat-message.tsx
@@ -101,12 +101,19 @@ export const ChatMessage = ( {
 					</span>
 				</div>
 				{ typeof children === 'string' ? (
-					<MarkDownWithCode
-						message={ message }
-						updateMessage={ updateMessage }
-						siteId={ siteId }
-						content={ children }
-					/>
+					<>
+						<MarkDownWithCode
+							message={ message }
+							updateMessage={ updateMessage }
+							siteId={ siteId }
+							content={ children }
+						/>
+						{ message.feedbackReceived && (
+							<div className="text-a8c-gray-70 italic text-xs flex justify-end">
+								{ __( 'Thanks for the feedback!' ) }
+							</div>
+						) }
+					</>
 				) : (
 					children
 				) }

--- a/src/components/chat-message.tsx
+++ b/src/components/chat-message.tsx
@@ -21,6 +21,7 @@ export interface ChatMessageProps {
 	) => void;
 	isUnauthenticated?: boolean;
 	failedMessage?: boolean;
+	feedbackReceived?: boolean;
 }
 
 export const MarkDownWithCode = ( {
@@ -104,7 +105,7 @@ export const ChatMessage = ( {
 						message={ message }
 						updateMessage={ updateMessage }
 						siteId={ siteId }
-						content={ message.content }
+						content={ children }
 					/>
 				) : (
 					children

--- a/src/components/chat-message.tsx
+++ b/src/components/chat-message.tsx
@@ -21,7 +21,6 @@ export interface ChatMessageProps {
 	) => void;
 	isUnauthenticated?: boolean;
 	failedMessage?: boolean;
-	feedbackReceived?: boolean;
 }
 
 export const MarkDownWithCode = ( {
@@ -105,7 +104,7 @@ export const ChatMessage = ( {
 						message={ message }
 						updateMessage={ updateMessage }
 						siteId={ siteId }
-						content={ children }
+						content={ message.content }
 					/>
 				) : (
 					children

--- a/src/components/chat-message.tsx
+++ b/src/components/chat-message.tsx
@@ -21,6 +21,7 @@ export interface ChatMessageProps {
 	) => void;
 	isUnauthenticated?: boolean;
 	failedMessage?: boolean;
+	feedbackReceived?: boolean;
 }
 
 export const MarkDownWithCode = ( {

--- a/src/components/chat-message.tsx
+++ b/src/components/chat-message.tsx
@@ -5,6 +5,7 @@ import { Message } from '../hooks/use-assistant';
 import { cx } from '../lib/cx';
 import Anchor from './assistant-anchor';
 import createCodeComponent from './assistant-code-block';
+import { FeedbackThanks } from './chat-rating';
 
 export interface ChatMessageProps {
 	children: React.ReactNode;
@@ -108,11 +109,7 @@ export const ChatMessage = ( {
 							siteId={ siteId }
 							content={ children }
 						/>
-						{ message.feedbackReceived && (
-							<div className="text-a8c-gray-70 italic text-xs flex justify-end">
-								{ __( 'Thanks for the feedback!' ) }
-							</div>
-						) }
+						{ message.feedbackReceived && <FeedbackThanks /> }
 					</>
 				) : (
 					children

--- a/src/components/chat-rating.tsx
+++ b/src/components/chat-rating.tsx
@@ -5,6 +5,7 @@ import Button from './button';
 
 interface ChatRatingProps {
 	messageId: number;
+	messageApiId: number;
 	chatId: string;
 	feedbackReceived: boolean;
 	markMessageAsFeedbackReceived: ( id: number ) => void;
@@ -13,6 +14,7 @@ interface ChatRatingProps {
 
 export const ChatRating = ( {
 	messageId,
+	messageApiId,
 	markMessageAsFeedbackReceived,
 	feedbackReceived,
 	chatId,
@@ -21,11 +23,13 @@ export const ChatRating = ( {
 
 	const handleRatingClick = async ( feedback: number ) => {
 		markMessageAsFeedbackReceived( messageId );
+		console.log( 'from chatRating', messageApiId );
+		console.log( 'messageId', messageId );
 
 		try {
 			await sendFeedback( {
 				chatId,
-				messageId,
+				messageId: messageApiId,
 				ratingValue: feedback,
 			} );
 		} catch ( error ) {

--- a/src/components/chat-rating.tsx
+++ b/src/components/chat-rating.tsx
@@ -12,6 +12,14 @@ interface ChatRatingProps {
 	className?: string;
 }
 
+export const FeedbackThanks = () => {
+	return (
+		<div className="text-a8c-gray-70 italic text-xs flex justify-end">
+			{ __( 'Thanks for the feedback!' ) }
+		</div>
+	);
+};
+
 export const ChatRating = ( {
 	messageId,
 	messageApiId,

--- a/src/components/chat-rating.tsx
+++ b/src/components/chat-rating.tsx
@@ -1,5 +1,6 @@
 import { __ } from '@wordpress/i18n';
 import { thumbsUp, thumbsDown, Icon } from '@wordpress/icons';
+import { useState } from 'react';
 import { useAssistant } from '../hooks/use-assistant';
 import Button from './button';
 
@@ -13,33 +14,43 @@ export const ChatRating = ( { messageId, instanceId }: ChatRatingProps ) => {
 	// Pass the instanceId to the useAssistant hook
 	const { markMessageAsFeedbackReceived } = useAssistant( instanceId );
 
-	const handleRatingClick = ( feedbackReceived: boolean ) => {
-		markMessageAsFeedbackReceived( messageId, feedbackReceived );
-		console.log( feedbackReceived );
+	// State to track if feedback has been received
+	const [ feedbackReceived, setFeedbackReceived ] = useState( false );
+
+	const handleRatingClick = ( feedback: boolean ) => {
+		markMessageAsFeedbackReceived( messageId, feedback );
+		setFeedbackReceived( true ); // Update state to indicate feedback is received
+		console.log( feedback );
 		console.log( messageId );
 	};
 
 	return (
 		<div className="flex flex-col mt-4 items-start gap-3">
-			<div className="flex items-center gap-3">
-				<span className="text-a8c-gray-70 text-xs">{ __( 'Was this helpful?' ) }</span>
-				<Button
-					variant="icon"
-					className="text-a8c-green-50 flex items-center gap-1"
-					onClick={ () => handleRatingClick( true ) }
-				>
-					<Icon size={ 18 } icon={ thumbsUp } />
-					<span className="text-xs">{ __( 'Yes' ) }</span>
-				</Button>
-				<Button
-					variant="icon"
-					className="text-a8c-red-50 flex items-center gap-1"
-					onClick={ () => handleRatingClick( false ) }
-				>
-					<Icon size={ 18 } icon={ thumbsDown } />
-					<span className="text-xs">{ __( 'No' ) }</span>
-				</Button>
-			</div>
+			{ feedbackReceived ? (
+				<div className="text-a8c-gray-70 italic text-xs flex justify-end">
+					{ __( 'Thanks for the feedback!' ) }
+				</div>
+			) : (
+				<div className="flex items-center gap-3">
+					<span className="text-a8c-gray-70 text-xs">{ __( 'Was this helpful?' ) }</span>
+					<Button
+						variant="icon"
+						className="text-a8c-green-50 flex items-center gap-1"
+						onClick={ () => handleRatingClick( true ) }
+					>
+						<Icon size={ 18 } icon={ thumbsUp } />
+						<span className="text-xs">{ __( 'Yes' ) }</span>
+					</Button>
+					<Button
+						variant="icon"
+						className="text-a8c-red-50 flex items-center gap-1"
+						onClick={ () => handleRatingClick( false ) }
+					>
+						<Icon size={ 18 } icon={ thumbsDown } />
+						<span className="text-xs">{ __( 'No' ) }</span>
+					</Button>
+				</div>
+			) }
 		</div>
 	);
 };

--- a/src/components/chat-rating.tsx
+++ b/src/components/chat-rating.tsx
@@ -1,7 +1,8 @@
 import { __ } from '@wordpress/i18n';
 import { thumbsUp, thumbsDown, Icon } from '@wordpress/icons';
 import { useState } from 'react';
-import { useAssistant, chatMessagesStoreKey } from '../hooks/use-assistant';
+import { CHAT_MESSAGES_STORE_KEY } from '../constants';
+import { useAssistant } from '../hooks/use-assistant';
 import Button from './button';
 
 interface ChatRatingProps {
@@ -13,9 +14,8 @@ interface ChatRatingProps {
 export const ChatRating = ( { messageId, instanceId }: ChatRatingProps ) => {
 	// Pass the instanceId to the useAssistant hook
 	const { markMessageAsFeedbackReceived } = useAssistant( instanceId );
-	// Read feedback state from localStorage
 	const [ feedbackReceived, setFeedbackReceived ] = useState( () => {
-		const storedMessages = localStorage.getItem( chatMessagesStoreKey );
+		const storedMessages = localStorage.getItem( CHAT_MESSAGES_STORE_KEY );
 		if ( storedMessages ) {
 			const messagesDict = JSON.parse( storedMessages );
 			const messages = messagesDict[ instanceId ] || [];

--- a/src/components/chat-rating.tsx
+++ b/src/components/chat-rating.tsx
@@ -1,36 +1,21 @@
 import { __ } from '@wordpress/i18n';
 import { thumbsUp, thumbsDown, Icon } from '@wordpress/icons';
-import { useState } from 'react';
-import { CHAT_MESSAGES_STORE_KEY } from '../constants';
-import { useAssistant } from '../hooks/use-assistant';
 import Button from './button';
 
 interface ChatRatingProps {
 	messageId: number;
-	instanceId: string;
+	feedbackReceived: boolean;
+	markMessageAsFeedbackReceived: ( id: number ) => void;
 	className?: string;
 }
 
-export const ChatRating = ( { messageId, instanceId }: ChatRatingProps ) => {
-	// Pass the instanceId to the useAssistant hook
-	const { markMessageAsFeedbackReceived } = useAssistant( instanceId );
-	const [ feedbackReceived, setFeedbackReceived ] = useState( () => {
-		const storedMessages = localStorage.getItem( CHAT_MESSAGES_STORE_KEY );
-		if ( storedMessages ) {
-			const messagesDict = JSON.parse( storedMessages );
-			const messages = messagesDict[ instanceId ] || [];
-			const message = messages.find( ( m ) => m.id === messageId );
-			return message ? message.feedbackReceived : false;
-		}
-		return false;
-	} );
-
-	// const [ feedbackReceived, setFeedbackReceived ] = useState( false );
-
-	const handleRatingClick = ( feedback: boolean ) => {
-		markMessageAsFeedbackReceived( messageId, feedback );
-		setFeedbackReceived( true ); // Update state to indicate feedback is received
-		localStorage.setItem( `feedback_${ messageId }`, 'true' );
+export const ChatRating = ( {
+	messageId,
+	markMessageAsFeedbackReceived,
+	feedbackReceived,
+}: ChatRatingProps ) => {
+	const handleRatingClick = ( feedback: number ) => {
+		markMessageAsFeedbackReceived( messageId );
 		console.log( feedback );
 		console.log( 'messageId', messageId );
 	};
@@ -47,7 +32,7 @@ export const ChatRating = ( { messageId, instanceId }: ChatRatingProps ) => {
 					<Button
 						variant="icon"
 						className="text-a8c-green-50 flex items-center gap-1"
-						onClick={ () => handleRatingClick( true ) }
+						onClick={ () => handleRatingClick( 1 ) }
 					>
 						<Icon size={ 18 } icon={ thumbsUp } />
 						<span className="text-xs">{ __( 'Yes' ) }</span>
@@ -55,7 +40,7 @@ export const ChatRating = ( { messageId, instanceId }: ChatRatingProps ) => {
 					<Button
 						variant="icon"
 						className="text-a8c-red-50 flex items-center gap-1"
-						onClick={ () => handleRatingClick( true ) }
+						onClick={ () => handleRatingClick( 0 ) }
 					>
 						<Icon size={ 18 } icon={ thumbsDown } />
 						<span className="text-xs">{ __( 'No' ) }</span>

--- a/src/components/chat-rating.tsx
+++ b/src/components/chat-rating.tsx
@@ -25,12 +25,14 @@ export const ChatRating = ( { messageId, instanceId }: ChatRatingProps ) => {
 		return false;
 	} );
 
+	// const [ feedbackReceived, setFeedbackReceived ] = useState( false );
+
 	const handleRatingClick = ( feedback: boolean ) => {
 		markMessageAsFeedbackReceived( messageId, feedback );
 		setFeedbackReceived( true ); // Update state to indicate feedback is received
 		localStorage.setItem( `feedback_${ messageId }`, 'true' );
 		console.log( feedback );
-		console.log( messageId );
+		console.log( 'messageId', messageId );
 	};
 
 	return (

--- a/src/components/chat-rating.tsx
+++ b/src/components/chat-rating.tsx
@@ -54,7 +54,7 @@ export const ChatRating = ( {
 					<span className="text-a8c-gray-70 text-xs">{ __( 'Was this helpful?' ) }</span>
 					<Button
 						variant="icon"
-						className="text-a8c-green-50 flex items-center gap-1"
+						className="text-a8c-green-50 hover:!text-a8c-green-50 flex items-center gap-1"
 						onClick={ () => handleRatingClick( 1 ) }
 					>
 						<Icon size={ 18 } icon={ thumbsUp } />
@@ -62,7 +62,7 @@ export const ChatRating = ( {
 					</Button>
 					<Button
 						variant="icon"
-						className="text-a8c-red-50 flex items-center gap-1"
+						className="text-a8c-red-50 hover:!text-a8c-red-50 flex items-center gap-1"
 						onClick={ () => handleRatingClick( 0 ) }
 					>
 						<Icon size={ 18 } icon={ thumbsDown } />

--- a/src/components/chat-rating.tsx
+++ b/src/components/chat-rating.tsx
@@ -55,7 +55,7 @@ export const ChatRating = ( { messageId, instanceId }: ChatRatingProps ) => {
 					<Button
 						variant="icon"
 						className="text-a8c-red-50 flex items-center gap-1"
-						onClick={ () => handleRatingClick( false ) }
+						onClick={ () => handleRatingClick( true ) }
 					>
 						<Icon size={ 18 } icon={ thumbsDown } />
 						<span className="text-xs">{ __( 'No' ) }</span>

--- a/src/components/chat-rating.tsx
+++ b/src/components/chat-rating.tsx
@@ -1,9 +1,11 @@
 import { __ } from '@wordpress/i18n';
 import { thumbsUp, thumbsDown, Icon } from '@wordpress/icons';
+import { useSendFeedback } from '../hooks/use-send-feedback';
 import Button from './button';
 
 interface ChatRatingProps {
 	messageId: number;
+	chatId: string;
 	feedbackReceived: boolean;
 	markMessageAsFeedbackReceived: ( id: number ) => void;
 	className?: string;
@@ -13,11 +15,22 @@ export const ChatRating = ( {
 	messageId,
 	markMessageAsFeedbackReceived,
 	feedbackReceived,
+	chatId,
 }: ChatRatingProps ) => {
-	const handleRatingClick = ( feedback: number ) => {
+	const sendFeedback = useSendFeedback();
+
+	const handleRatingClick = async ( feedback: number ) => {
 		markMessageAsFeedbackReceived( messageId );
-		console.log( feedback );
-		console.log( 'messageId', messageId );
+
+		try {
+			await sendFeedback( {
+				chatId,
+				messageId,
+				ratingValue: feedback,
+			} );
+		} catch ( error ) {
+			console.error( 'Failed to submit feedback:', error );
+		}
 	};
 
 	return (

--- a/src/components/chat-rating.tsx
+++ b/src/components/chat-rating.tsx
@@ -1,19 +1,40 @@
 import { __ } from '@wordpress/i18n';
 import { thumbsUp, thumbsDown, Icon } from '@wordpress/icons';
+import { useState } from 'react';
 import Button from './button';
 
 export const ChatRating = () => {
+	const [ feedbackReceived, setFeedbackReceived ] = useState( false );
+
+	const handleRatingClick = () => {
+		setFeedbackReceived( true );
+	};
+
 	return (
-		<div className="flex mt-4 items-center gap-3">
-			<span className="text-a8c-gray-70 text-xs">{ __( 'Was this helpful?' ) }</span>
-			<Button variant="icon" className="text-a8c-green-50 flex items-center gap-1">
-				<Icon size={ 18 } icon={ thumbsUp } />
-				<span className="text-xs">{ __( 'Yes' ) }</span>
-			</Button>
-			<Button variant="icon" className="text-a8c-red-50 flex items-center gap-1">
-				<Icon size={ 18 } icon={ thumbsDown } />
-				<span className="text-xs">{ __( 'No' ) }</span>
-			</Button>
+		<div className="flex flex-col mt-4 items-start gap-3">
+			{ ! feedbackReceived ? (
+				<div className="flex items-center gap-3">
+					<span className="text-a8c-gray-70 text-xs">{ __( 'Was this helpful?' ) }</span>
+					<Button
+						variant="icon"
+						className="text-a8c-green-50 flex items-center gap-1"
+						onClick={ handleRatingClick }
+					>
+						<Icon size={ 18 } icon={ thumbsUp } />
+						<span className="text-xs">{ __( 'Yes' ) }</span>
+					</Button>
+					<Button
+						variant="icon"
+						className="text-a8c-red-50 flex items-center gap-1"
+						onClick={ handleRatingClick }
+					>
+						<Icon size={ 18 } icon={ thumbsDown } />
+						<span className="text-xs">{ __( 'No' ) }</span>
+					</Button>
+				</div>
+			) : (
+				<div className="text-a8c-gray-70 text-xs italic">{ __( 'Thanks for the feedback!' ) }</div>
+			) }
 		</div>
 	);
 };

--- a/src/components/chat-rating.tsx
+++ b/src/components/chat-rating.tsx
@@ -1,0 +1,19 @@
+import { __ } from '@wordpress/i18n';
+import { thumbsUp, thumbsDown, Icon } from '@wordpress/icons';
+import Button from './button';
+
+export const ChatRating = () => {
+	return (
+		<div className="flex mt-4 items-center gap-3">
+			<span className="text-a8c-gray-70 text-xs">{ __( 'Was this helpful?' ) }</span>
+			<Button variant="icon" className="text-a8c-green-50 flex items-center gap-1">
+				<Icon size={ 18 } icon={ thumbsUp } />
+				<span className="text-xs">{ __( 'Yes' ) }</span>
+			</Button>
+			<Button variant="icon" className="text-a8c-red-50 flex items-center gap-1">
+				<Icon size={ 18 } icon={ thumbsDown } />
+				<span className="text-xs">{ __( 'No' ) }</span>
+			</Button>
+		</div>
+	);
+};

--- a/src/components/chat-rating.tsx
+++ b/src/components/chat-rating.tsx
@@ -1,7 +1,7 @@
 import { __ } from '@wordpress/i18n';
 import { thumbsUp, thumbsDown, Icon } from '@wordpress/icons';
 import { useState } from 'react';
-import { useAssistant } from '../hooks/use-assistant';
+import { useAssistant, chatMessagesStoreKey } from '../hooks/use-assistant';
 import Button from './button';
 
 interface ChatRatingProps {
@@ -13,13 +13,22 @@ interface ChatRatingProps {
 export const ChatRating = ( { messageId, instanceId }: ChatRatingProps ) => {
 	// Pass the instanceId to the useAssistant hook
 	const { markMessageAsFeedbackReceived } = useAssistant( instanceId );
-
-	// State to track if feedback has been received
-	const [ feedbackReceived, setFeedbackReceived ] = useState( false );
+	// Read feedback state from localStorage
+	const [ feedbackReceived, setFeedbackReceived ] = useState( () => {
+		const storedMessages = localStorage.getItem( chatMessagesStoreKey );
+		if ( storedMessages ) {
+			const messagesDict = JSON.parse( storedMessages );
+			const messages = messagesDict[ instanceId ] || [];
+			const message = messages.find( ( m ) => m.id === messageId );
+			return message ? message.feedbackReceived : false;
+		}
+		return false;
+	} );
 
 	const handleRatingClick = ( feedback: boolean ) => {
 		markMessageAsFeedbackReceived( messageId, feedback );
 		setFeedbackReceived( true ); // Update state to indicate feedback is received
+		localStorage.setItem( `feedback_${ messageId }`, 'true' );
 		console.log( feedback );
 		console.log( messageId );
 	};

--- a/src/components/chat-rating.tsx
+++ b/src/components/chat-rating.tsx
@@ -23,8 +23,6 @@ export const ChatRating = ( {
 
 	const handleRatingClick = async ( feedback: number ) => {
 		markMessageAsFeedbackReceived( messageId );
-		console.log( 'from chatRating', messageApiId );
-		console.log( 'messageId', messageId );
 
 		try {
 			await sendFeedback( {

--- a/src/components/chat-rating.tsx
+++ b/src/components/chat-rating.tsx
@@ -1,75 +1,57 @@
 import { __ } from '@wordpress/i18n';
 import { thumbsUp, thumbsDown, Icon } from '@wordpress/icons';
-import { useSendFeedback } from '../hooks/use-send-feedback';
+import { useAssistant } from '../hooks/use-assistant';
 import Button from './button';
 
 interface ChatRatingProps {
-	messageId: number;
 	messageApiId: number;
-	chatId: string;
 	feedbackReceived: boolean;
-	markMessageAsFeedbackReceived: ( id: number ) => void;
+	markMessageAsFeedbackReceived: ReturnType<
+		typeof useAssistant
+	>[ 'markMessageAsFeedbackReceived' ];
 	className?: string;
 }
 
 export const FeedbackThanks = () => {
 	return (
-		<div className="text-a8c-gray-70 italic text-xs flex justify-end">
+		<div className="text-a8c-gray-70 italic text-xs flex justify-end mt-4">
 			{ __( 'Thanks for the feedback!' ) }
 		</div>
 	);
 };
 
 export const ChatRating = ( {
-	messageId,
 	messageApiId,
 	markMessageAsFeedbackReceived,
 	feedbackReceived,
-	chatId,
 }: ChatRatingProps ) => {
-	const sendFeedback = useSendFeedback();
-
 	const handleRatingClick = async ( feedback: number ) => {
-		markMessageAsFeedbackReceived( messageId );
-
-		try {
-			await sendFeedback( {
-				chatId,
-				messageId: messageApiId,
-				ratingValue: feedback,
-			} );
-		} catch ( error ) {
-			console.error( 'Failed to submit feedback:', error );
-		}
+		markMessageAsFeedbackReceived( messageApiId, feedback );
 	};
 
-	return (
+	return feedbackReceived ? (
+		<FeedbackThanks />
+	) : (
 		<div className="flex flex-col mt-4 items-start gap-3">
-			{ feedbackReceived ? (
-				<div className="text-a8c-gray-70 italic text-xs flex justify-end">
-					{ __( 'Thanks for the feedback!' ) }
-				</div>
-			) : (
-				<div className="flex items-center gap-3">
-					<span className="text-a8c-gray-70 text-xs">{ __( 'Was this helpful?' ) }</span>
-					<Button
-						variant="icon"
-						className="text-a8c-green-50 hover:!text-a8c-green-50 flex items-center gap-1"
-						onClick={ () => handleRatingClick( 1 ) }
-					>
-						<Icon size={ 18 } icon={ thumbsUp } />
-						<span className="text-xs">{ __( 'Yes' ) }</span>
-					</Button>
-					<Button
-						variant="icon"
-						className="text-a8c-red-50 hover:!text-a8c-red-50 flex items-center gap-1"
-						onClick={ () => handleRatingClick( 0 ) }
-					>
-						<Icon size={ 18 } icon={ thumbsDown } />
-						<span className="text-xs">{ __( 'No' ) }</span>
-					</Button>
-				</div>
-			) }
+			<div className="flex items-center gap-3">
+				<span className="text-a8c-gray-70 text-xs">{ __( 'Was this helpful?' ) }</span>
+				<Button
+					variant="icon"
+					className="text-a8c-green-50 hover:!text-a8c-green-50 flex items-center gap-1"
+					onClick={ () => handleRatingClick( 1 ) }
+				>
+					<Icon size={ 18 } icon={ thumbsUp } />
+					<span className="text-xs">{ __( 'Yes' ) }</span>
+				</Button>
+				<Button
+					variant="icon"
+					className="text-a8c-red-50 hover:!text-a8c-red-50 flex items-center gap-1"
+					onClick={ () => handleRatingClick( 0 ) }
+				>
+					<Icon size={ 18 } icon={ thumbsDown } />
+					<span className="text-xs">{ __( 'No' ) }</span>
+				</Button>
+			</div>
 		</div>
 	);
 };

--- a/src/components/chat-rating.tsx
+++ b/src/components/chat-rating.tsx
@@ -1,40 +1,45 @@
 import { __ } from '@wordpress/i18n';
 import { thumbsUp, thumbsDown, Icon } from '@wordpress/icons';
-import { useState } from 'react';
+import { useAssistant } from '../hooks/use-assistant';
 import Button from './button';
 
-export const ChatRating = () => {
-	const [ feedbackReceived, setFeedbackReceived ] = useState( false );
+interface ChatRatingProps {
+	messageId: number;
+	instanceId: string;
+	className?: string;
+}
 
-	const handleRatingClick = () => {
-		setFeedbackReceived( true );
+export const ChatRating = ( { messageId, instanceId }: ChatRatingProps ) => {
+	// Pass the instanceId to the useAssistant hook
+	const { markMessageAsFeedbackReceived } = useAssistant( instanceId );
+
+	const handleRatingClick = ( feedbackReceived: boolean ) => {
+		markMessageAsFeedbackReceived( messageId, feedbackReceived );
+		console.log( feedbackReceived );
+		console.log( messageId );
 	};
 
 	return (
 		<div className="flex flex-col mt-4 items-start gap-3">
-			{ ! feedbackReceived ? (
-				<div className="flex items-center gap-3">
-					<span className="text-a8c-gray-70 text-xs">{ __( 'Was this helpful?' ) }</span>
-					<Button
-						variant="icon"
-						className="text-a8c-green-50 flex items-center gap-1"
-						onClick={ handleRatingClick }
-					>
-						<Icon size={ 18 } icon={ thumbsUp } />
-						<span className="text-xs">{ __( 'Yes' ) }</span>
-					</Button>
-					<Button
-						variant="icon"
-						className="text-a8c-red-50 flex items-center gap-1"
-						onClick={ handleRatingClick }
-					>
-						<Icon size={ 18 } icon={ thumbsDown } />
-						<span className="text-xs">{ __( 'No' ) }</span>
-					</Button>
-				</div>
-			) : (
-				<div className="text-a8c-gray-70 text-xs italic">{ __( 'Thanks for the feedback!' ) }</div>
-			) }
+			<div className="flex items-center gap-3">
+				<span className="text-a8c-gray-70 text-xs">{ __( 'Was this helpful?' ) }</span>
+				<Button
+					variant="icon"
+					className="text-a8c-green-50 flex items-center gap-1"
+					onClick={ () => handleRatingClick( true ) }
+				>
+					<Icon size={ 18 } icon={ thumbsUp } />
+					<span className="text-xs">{ __( 'Yes' ) }</span>
+				</Button>
+				<Button
+					variant="icon"
+					className="text-a8c-red-50 flex items-center gap-1"
+					onClick={ () => handleRatingClick( false ) }
+				>
+					<Icon size={ 18 } icon={ thumbsDown } />
+					<span className="text-xs">{ __( 'No' ) }</span>
+				</Button>
+			</div>
 		</div>
 	);
 };

--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -201,7 +201,6 @@ export const AuthenticatedView = memo(
 					animate: { opacity: 1, y: 0 },
 				};
 
-				console.log( 'from lastMessage', messageApiId );
 				return (
 					<>
 						<ChatMessage

--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -235,7 +235,11 @@ export const AuthenticatedView = memo(
 										/>
 										<div className="flex justify-end">
 											{ ! message.feedbackReceived && (
-												<ChatRating messageId={ message.id } instanceId={ instanceId } />
+												<ChatRating
+													//messageId={ `message-chat-${ message.id }` }
+													messageId={ message.id }
+													instanceId={ instanceId }
+												/>
 											) }
 											{ message.feedbackReceived && (
 												<div className="text-a8c-gray-70 italic text-xs flex justify-end">

--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -226,7 +226,9 @@ export const AuthenticatedView = memo(
 											updateMessage={ updateMessage }
 											content={ message.content }
 										/>
-										<ChatRating />
+										<div className="flex justify-end">
+											<ChatRating />
+										</div>
 									</motion.div>
 								) }
 							</AnimatePresence>

--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -109,6 +109,7 @@ interface AuthenticatedViewProps {
 	isAssistantThinking: boolean;
 	updateMessage: OnUpdateMessageType;
 	siteId: string;
+	chatId: string;
 	handleSend: ( messageToSend?: string, isRetry?: boolean ) => void;
 	markMessageAsFeedbackReceived: ( id: number ) => void;
 }
@@ -119,6 +120,7 @@ export const AuthenticatedView = memo(
 		isAssistantThinking,
 		updateMessage,
 		siteId,
+		chatId,
 		handleSend,
 		markMessageAsFeedbackReceived,
 	}: AuthenticatedViewProps ) => {
@@ -231,6 +233,7 @@ export const AuthenticatedView = memo(
 										<div className="flex justify-end">
 											{ !! message.id && ! message.feedbackReceived && (
 												<ChatRating
+													chatId={ chatId }
 													messageId={ message.id }
 													markMessageAsFeedbackReceived={ markMessageAsFeedbackReceived }
 													feedbackReceived={ !! message?.feedbackReceived }
@@ -249,7 +252,7 @@ export const AuthenticatedView = memo(
 					</>
 				);
 			},
-			[ markMessageAsFeedbackReceived ]
+			[ chatId, markMessageAsFeedbackReceived ]
 		);
 
 		if ( messages.length === 0 ) {
@@ -429,8 +432,8 @@ export function ContentTabAssistant( { selectedSite }: ContentTabAssistantProps 
 								updateMessage={ updateMessage }
 								markMessageAsFeedbackReceived={ markMessageAsFeedbackReceived }
 								siteId={ selectedSite.id }
+								chatId={ chatId }
 								handleSend={ handleSend }
-								instanceId={ instanceId }
 							/>
 						</>
 					) : (

--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -229,7 +229,7 @@ export const AuthenticatedView = memo(
 											content={ message.content }
 										/>
 										<div className="flex justify-end">
-											{ message.id && ! message.feedbackReceived && (
+											{ !! message.id && ! message.feedbackReceived && (
 												<ChatRating
 													messageId={ message.id }
 													markMessageAsFeedbackReceived={ markMessageAsFeedbackReceived }

--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -23,7 +23,7 @@ import { AIInput } from './ai-input';
 import { MessageThinking } from './assistant-thinking';
 import Button from './button';
 import { ChatMessage, MarkDownWithCode } from './chat-message';
-import { ChatRating } from './chat-rating';
+import { ChatRating, FeedbackThanks } from './chat-rating';
 import offlineIcon from './offline-icon';
 import WelcomeComponent from './welcome-message-prompt';
 
@@ -245,11 +245,7 @@ export const AuthenticatedView = memo(
 													feedbackReceived={ !! message?.feedbackReceived }
 												/>
 											) }
-											{ message.feedbackReceived && (
-												<div className="text-a8c-gray-70 italic text-xs flex justify-end">
-													{ __( 'Thanks for the feedback!' ) }
-												</div>
-											) }
+											{ message.feedbackReceived && <FeedbackThanks /> }
 										</div>
 									</motion.div>
 								) }

--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -164,11 +164,6 @@ export const AuthenticatedView = memo(
 						updateMessage={ updateMessage }
 					>
 						{ message.content }
-						{ message.feedbackReceived && (
-							<div className="text-a8c-gray-70 italic text-xs flex justify-end">
-								{ __( 'Thanks for the feedback!' ) }
-							</div>
-						) }
 					</ChatMessage>
 					{ message.failedMessage && (
 						<ErrorNotice handleSend={ handleSend } messageContent={ message.content } />

--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -235,11 +235,7 @@ export const AuthenticatedView = memo(
 										/>
 										<div className="flex justify-end">
 											{ ! message.feedbackReceived && (
-												<ChatRating
-													//messageId={ `message-chat-${ message.id }` }
-													messageId={ message.id }
-													instanceId={ instanceId }
-												/>
+												<ChatRating messageId={ message.id } instanceId={ instanceId } />
 											) }
 											{ message.feedbackReceived && (
 												<div className="text-a8c-gray-70 italic text-xs flex justify-end">

--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -23,6 +23,7 @@ import { AIInput } from './ai-input';
 import { MessageThinking } from './assistant-thinking';
 import Button from './button';
 import { ChatMessage, MarkDownWithCode } from './chat-message';
+import { ChatRating } from './chat-rating';
 import offlineIcon from './offline-icon';
 import WelcomeComponent from './welcome-message-prompt';
 
@@ -225,6 +226,7 @@ export const AuthenticatedView = memo(
 											updateMessage={ updateMessage }
 											content={ message.content }
 										/>
+										<ChatRating />
 									</motion.div>
 								) }
 							</AnimatePresence>

--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -110,6 +110,7 @@ interface AuthenticatedViewProps {
 	updateMessage: OnUpdateMessageType;
 	siteId: string;
 	handleSend: ( messageToSend?: string, isRetry?: boolean ) => void;
+	instanceId: string;
 }
 
 export const AuthenticatedView = memo(
@@ -119,6 +120,7 @@ export const AuthenticatedView = memo(
 		updateMessage,
 		siteId,
 		handleSend,
+		instanceId,
 	}: AuthenticatedViewProps ) => {
 		const endOfMessagesRef = useRef< HTMLDivElement >( null );
 		const [ showThinking, setShowThinking ] = useState( false );
@@ -162,6 +164,11 @@ export const AuthenticatedView = memo(
 						updateMessage={ updateMessage }
 					>
 						{ message.content }
+						{ message.feedbackReceived && (
+							<div className="text-a8c-gray-70 italic text-xs flex justify-end">
+								{ __( 'Thanks for the feedback!' ) }
+							</div>
+						) }
 					</ChatMessage>
 					{ message.failedMessage && (
 						<ErrorNotice handleSend={ handleSend } messageContent={ message.content } />
@@ -227,7 +234,14 @@ export const AuthenticatedView = memo(
 											content={ message.content }
 										/>
 										<div className="flex justify-end">
-											<ChatRating />
+											{ ! message.feedbackReceived && (
+												<ChatRating messageId={ message.id } instanceId={ instanceId } />
+											) }
+											{ message.feedbackReceived && (
+												<div className="text-a8c-gray-70 italic text-xs flex justify-end">
+													{ __( 'Thanks for the feedback!' ) }
+												</div>
+											) }
 										</div>
 									</motion.div>
 								) }
@@ -306,8 +320,9 @@ export function ContentTabAssistant( { selectedSite }: ContentTabAssistantProps 
 	const inputRef = useRef< HTMLTextAreaElement >( null );
 	const currentSiteChatContext = useChatContext();
 	const { isAuthenticated, authenticate, user } = useAuth();
+	const instanceId = user?.id ? `${ user.id }_${ selectedSite.id }` : selectedSite.id;
 	const { messages, addMessage, clearMessages, updateMessage, markMessageAsFailed, chatId } =
-		useAssistant( user?.id ? `${ user.id }_${ selectedSite.id }` : selectedSite.id );
+		useAssistant( instanceId );
 	const { userCanSendMessage } = usePromptUsage();
 	const { fetchAssistant, isLoading: isAssistantThinking } = useAssistantApi( selectedSite.id );
 	const { messages: welcomeMessages } = useWelcomeMessages();
@@ -409,6 +424,7 @@ export function ContentTabAssistant( { selectedSite }: ContentTabAssistantProps 
 								updateMessage={ updateMessage }
 								siteId={ selectedSite.id }
 								handleSend={ handleSend }
+								instanceId={ instanceId }
 							/>
 						</>
 					) : (

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -19,6 +19,7 @@ export const BUG_REPORT_URL =
 export const FEATURE_REQUEST_URL =
 	'https://github.com/Automattic/studio/issues/new?assignees=&labels=%5BType%5D+Feature+Request&projects=&template=feature_request.yml&title=Feature+Request%3A';
 export const WPCOM_PROFILE_URL = `https://wordpress.com/me`;
+export const CHAT_MESSAGES_STORE_KEY = 'ai_chat_messages';
 
 //Import file constants
 

--- a/src/hooks/tests/use-assistant.test.ts
+++ b/src/hooks/tests/use-assistant.test.ts
@@ -44,11 +44,29 @@ describe( 'useAssistant', () => {
 		} );
 
 		expect( result.current.messages ).toEqual( [
-			{ content: 'Hello', role: 'user', id: 0, createdAt: MOCKED_TIME },
+			{
+				chatId: undefined,
+				content: 'Hello',
+				role: 'user',
+				id: 0,
+				createdAt: MOCKED_TIME,
+				feedbackReceived: false,
+				messageApiId: undefined,
+			},
 		] );
 		expect( localStorage.getItem( `ai_chat_messages` ) ).toEqual(
 			JSON.stringify( {
-				[ selectedSiteId ]: [ { content: 'Hello', role: 'user', id: 0, createdAt: MOCKED_TIME } ],
+				[ selectedSiteId ]: [
+					{
+						chatId: undefined,
+						content: 'Hello',
+						role: 'user',
+						id: 0,
+						createdAt: MOCKED_TIME,
+						feedbackReceived: false,
+						messageApiId: undefined,
+					},
+				],
 			} )
 		);
 	} );

--- a/src/hooks/use-assistant-api.ts
+++ b/src/hooks/use-assistant-api.ts
@@ -74,7 +74,6 @@ export function useAssistantApi( selectedSiteId: string ) {
 
 			const message = response?.choices?.[ 0 ]?.message?.content;
 			const messageApiId = response?.choices?.[ 0 ]?.message?.id;
-			console.log( messageApiId );
 
 			updatePromptUsage( {
 				maxQuota: headers[ 'x-quota-max' ] || '',

--- a/src/hooks/use-assistant-api.ts
+++ b/src/hooks/use-assistant-api.ts
@@ -45,7 +45,7 @@ export function useAssistantApi( selectedSiteId: string ) {
 			let headers;
 			try {
 				const { data, response_headers } = await new Promise< {
-					data: { choices: { message: { content: string } }[]; id: string };
+					data: { choices: { message: { content: string; id: number } }[]; id: string };
 					response_headers: Record< string, string >;
 				} >( ( resolve, reject ) => {
 					client.req.post(
@@ -56,7 +56,7 @@ export function useAssistantApi( selectedSiteId: string ) {
 						},
 						(
 							error: Error,
-							data: { choices: { message: { content: string } }[]; id: string },
+							data: { choices: { message: { content: string; id: number } }[]; id: string },
 							headers: Record< string, string >
 						) => {
 							if ( error ) {
@@ -71,12 +71,17 @@ export function useAssistantApi( selectedSiteId: string ) {
 			} finally {
 				setIsLoading( ( prev ) => ( { ...prev, [ selectedSiteId ]: false } ) );
 			}
+
 			const message = response?.choices?.[ 0 ]?.message?.content;
+			const messageApiId = response?.choices?.[ 0 ]?.message?.id;
+			console.log( messageApiId );
+
 			updatePromptUsage( {
 				maxQuota: headers[ 'x-quota-max' ] || '',
 				remainingQuota: headers[ 'x-quota-remaining' ] || '',
 			} );
-			return { message, chatId: response?.id };
+
+			return { message, messageApiId, chatId: response?.id };
 		},
 		[ client, selectedSiteId, updatePromptUsage ]
 	);

--- a/src/hooks/use-assistant.ts
+++ b/src/hooks/use-assistant.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { CHAT_MESSAGES_STORE_KEY } from '../constants';
 
 export type Message = {

--- a/src/hooks/use-assistant.ts
+++ b/src/hooks/use-assistant.ts
@@ -56,7 +56,14 @@ export const useAssistant = ( instanceId: string ) => {
 				const prevMessages = prevDict[ instanceId ] || [];
 				const updatedMessages = [
 					...prevMessages,
-					{ content, role, id: newMessageId, chatId, createdAt: Date.now() },
+					{
+						content,
+						role,
+						id: newMessageId,
+						chatId,
+						createdAt: Date.now(),
+						feedbackReceived: false,
+					},
 				];
 				const newDict = { ...prevDict, [ instanceId ]: updatedMessages };
 				localStorage.setItem( CHAT_MESSAGES_STORE_KEY, JSON.stringify( newDict ) );
@@ -132,16 +139,13 @@ export const useAssistant = ( instanceId: string ) => {
 				const prevMessages = prevDict[ instanceId ] || [];
 
 				console.log( 'prevMessages: ', prevMessages );
-
-				// Add logging to debug
 				console.log( 'Clicked message id: ', id );
-				prevMessages.forEach( ( message ) => {
-					console.log( 'Message being checked id: ', message.id );
-				} );
 
 				const updatedMessages = prevMessages.map( ( message ) => {
-					if ( message.id !== id ) return message;
-					return { ...message, feedbackReceived };
+					if ( message.id === id ) {
+						return { ...message, feedbackReceived };
+					}
+					return message;
 				} );
 
 				console.log( 'updatedMessages: ', updatedMessages );

--- a/src/hooks/use-assistant.ts
+++ b/src/hooks/use-assistant.ts
@@ -130,12 +130,19 @@ export const useAssistant = ( instanceId: string ) => {
 		( id: number, feedbackReceived: boolean ) => {
 			setMessagesDict( ( prevDict ) => {
 				const prevMessages = prevDict[ instanceId ] || [];
+
+				// Add logging to debug
+				console.log( 'Clicked message id: ', id );
+				prevMessages.forEach( ( message ) => {
+					console.log( 'Message being checked id: ', message.id );
+				} );
+
 				const updatedMessages = prevMessages.map( ( message ) => {
 					if ( message.id !== id ) return message;
 					return { ...message, feedbackReceived };
 				} );
+
 				const newDict = { ...prevDict, [ instanceId ]: updatedMessages };
-				console.log( updatedMessages );
 				localStorage.setItem( chatMessagesStoreKey, JSON.stringify( newDict ) );
 				return newDict;
 			} );

--- a/src/hooks/use-assistant.ts
+++ b/src/hooks/use-assistant.ts
@@ -134,7 +134,7 @@ export const useAssistant = ( instanceId: string ) => {
 	);
 
 	const markMessageAsFeedbackReceived = useCallback(
-		( id: number, feedbackReceived: boolean ) => {
+		( id: number ) => {
 			setMessagesDict( ( prevDict ) => {
 				const prevMessages = prevDict[ instanceId ] || [];
 
@@ -143,7 +143,7 @@ export const useAssistant = ( instanceId: string ) => {
 
 				const updatedMessages = prevMessages.map( ( message ) => {
 					if ( message.id === id ) {
-						return { ...message, feedbackReceived };
+						return { ...message, feedbackReceived: true };
 					}
 					return message;
 				} );
@@ -153,7 +153,6 @@ export const useAssistant = ( instanceId: string ) => {
 				const newDict = { ...prevDict, [ instanceId ]: updatedMessages };
 				localStorage.setItem( CHAT_MESSAGES_STORE_KEY, JSON.stringify( newDict ) );
 
-				console.log( 'newDict: ', newDict );
 				return newDict;
 			} );
 		},
@@ -175,25 +174,15 @@ export const useAssistant = ( instanceId: string ) => {
 		nextMessageIdRef.current[ instanceId ] = 0;
 	}, [ instanceId ] );
 
-	return useMemo(
-		() => ( {
-			messages: messagesDict[ instanceId ] || [],
-			addMessage,
-			updateMessage,
-			clearMessages,
-			chatId: chatIdDict[ instanceId ],
-			markMessageAsFailed,
-			markMessageAsFeedbackReceived,
-		} ),
-		[
-			messagesDict,
-			instanceId,
-			addMessage,
-			updateMessage,
-			clearMessages,
-			chatIdDict,
-			markMessageAsFailed,
-			markMessageAsFeedbackReceived,
-		]
-	);
+	console.log( 'returning messages -->', messagesDict[ instanceId ] );
+
+	return {
+		messages: messagesDict[ instanceId ] || [],
+		addMessage,
+		updateMessage,
+		clearMessages,
+		chatId: chatIdDict[ instanceId ],
+		markMessageAsFailed,
+		markMessageAsFeedbackReceived,
+	};
 };

--- a/src/hooks/use-assistant.ts
+++ b/src/hooks/use-assistant.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import { CHAT_MESSAGES_STORE_KEY } from '../constants';
 
 export type Message = {
 	id?: number;
@@ -20,7 +21,6 @@ export type MessageDict = { [ key: string ]: Message[] };
 export type ChatIdDict = { [ key: string ]: string | undefined };
 
 const chatIdStoreKey = 'ai_chat_ids';
-const chatMessagesStoreKey = 'ai_chat_messages';
 
 export const useAssistant = ( instanceId: string ) => {
 	const [ messagesDict, setMessagesDict ] = useState< MessageDict >( {} );
@@ -32,7 +32,7 @@ export const useAssistant = ( instanceId: string ) => {
 	} );
 
 	useEffect( () => {
-		const storedMessages = localStorage.getItem( chatMessagesStoreKey );
+		const storedMessages = localStorage.getItem( CHAT_MESSAGES_STORE_KEY );
 		const storedChatIds = localStorage.getItem( chatIdStoreKey );
 
 		if ( storedMessages ) {
@@ -59,7 +59,7 @@ export const useAssistant = ( instanceId: string ) => {
 					{ content, role, id: newMessageId, chatId, createdAt: Date.now() },
 				];
 				const newDict = { ...prevDict, [ instanceId ]: updatedMessages };
-				localStorage.setItem( chatMessagesStoreKey, JSON.stringify( newDict ) );
+				localStorage.setItem( CHAT_MESSAGES_STORE_KEY, JSON.stringify( newDict ) );
 				return newDict;
 			} );
 
@@ -103,7 +103,7 @@ export const useAssistant = ( instanceId: string ) => {
 					return { ...message, blocks: updatedBlocks };
 				} );
 				const newDict = { ...prevDict, [ instanceId ]: updatedMessages };
-				localStorage.setItem( chatMessagesStoreKey, JSON.stringify( newDict ) );
+				localStorage.setItem( CHAT_MESSAGES_STORE_KEY, JSON.stringify( newDict ) );
 				return newDict;
 			} );
 		},
@@ -119,7 +119,7 @@ export const useAssistant = ( instanceId: string ) => {
 					return { ...message, failedMessage };
 				} );
 				const newDict = { ...prevDict, [ instanceId ]: updatedMessages };
-				localStorage.setItem( chatMessagesStoreKey, JSON.stringify( newDict ) );
+				localStorage.setItem( CHAT_MESSAGES_STORE_KEY, JSON.stringify( newDict ) );
 				return newDict;
 			} );
 		},
@@ -130,6 +130,8 @@ export const useAssistant = ( instanceId: string ) => {
 		( id: number, feedbackReceived: boolean ) => {
 			setMessagesDict( ( prevDict ) => {
 				const prevMessages = prevDict[ instanceId ] || [];
+
+				console.log( 'prevMessages: ', prevMessages );
 
 				// Add logging to debug
 				console.log( 'Clicked message id: ', id );
@@ -142,8 +144,12 @@ export const useAssistant = ( instanceId: string ) => {
 					return { ...message, feedbackReceived };
 				} );
 
+				console.log( 'updatedMessages: ', updatedMessages );
+
 				const newDict = { ...prevDict, [ instanceId ]: updatedMessages };
-				localStorage.setItem( chatMessagesStoreKey, JSON.stringify( newDict ) );
+				localStorage.setItem( CHAT_MESSAGES_STORE_KEY, JSON.stringify( newDict ) );
+
+				console.log( 'newDict: ', newDict );
 				return newDict;
 			} );
 		},
@@ -153,7 +159,7 @@ export const useAssistant = ( instanceId: string ) => {
 	const clearMessages = useCallback( () => {
 		setMessagesDict( ( prevDict ) => {
 			const { [ instanceId ]: _, ...rest } = prevDict;
-			localStorage.setItem( chatMessagesStoreKey, JSON.stringify( rest ) );
+			localStorage.setItem( CHAT_MESSAGES_STORE_KEY, JSON.stringify( rest ) );
 			return rest;
 		} );
 

--- a/src/hooks/use-assistant.ts
+++ b/src/hooks/use-assistant.ts
@@ -13,6 +13,7 @@ export type Message = {
 	}[];
 	createdAt: number; // Unix timestamp
 	failedMessage?: boolean;
+	feedbackReceived?: boolean;
 };
 
 export type MessageDict = { [ key: string ]: Message[] };
@@ -125,6 +126,23 @@ export const useAssistant = ( instanceId: string ) => {
 		[ instanceId ]
 	);
 
+	const markMessageAsFeedbackReceived = useCallback(
+		( id: number, feedbackReceived: boolean ) => {
+			setMessagesDict( ( prevDict ) => {
+				const prevMessages = prevDict[ instanceId ] || [];
+				const updatedMessages = prevMessages.map( ( message ) => {
+					if ( message.id !== id ) return message;
+					return { ...message, feedbackReceived };
+				} );
+				const newDict = { ...prevDict, [ instanceId ]: updatedMessages };
+				console.log( updatedMessages );
+				localStorage.setItem( chatMessagesStoreKey, JSON.stringify( newDict ) );
+				return newDict;
+			} );
+		},
+		[ instanceId ]
+	);
+
 	const clearMessages = useCallback( () => {
 		setMessagesDict( ( prevDict ) => {
 			const { [ instanceId ]: _, ...rest } = prevDict;
@@ -148,6 +166,7 @@ export const useAssistant = ( instanceId: string ) => {
 			clearMessages,
 			chatId: chatIdDict[ instanceId ],
 			markMessageAsFailed,
+			markMessageAsFeedbackReceived,
 		} ),
 		[
 			messagesDict,
@@ -157,6 +176,7 @@ export const useAssistant = ( instanceId: string ) => {
 			clearMessages,
 			chatIdDict,
 			markMessageAsFailed,
+			markMessageAsFeedbackReceived,
 		]
 	);
 };

--- a/src/hooks/use-assistant.ts
+++ b/src/hooks/use-assistant.ts
@@ -174,8 +174,6 @@ export const useAssistant = ( instanceId: string ) => {
 		nextMessageIdRef.current[ instanceId ] = 0;
 	}, [ instanceId ] );
 
-	console.log( 'returning messages -->', messagesDict[ instanceId ] );
-
 	return {
 		messages: messagesDict[ instanceId ] || [],
 		addMessage,

--- a/src/hooks/use-send-feedback.ts
+++ b/src/hooks/use-send-feedback.ts
@@ -1,0 +1,34 @@
+import * as Sentry from '@sentry/electron/renderer';
+import { useAuth } from './use-auth';
+
+interface SendFeedbackParams {
+	messageId: number;
+	chatId: string;
+	ratingValue: number;
+}
+
+export const useSendFeedback = () => {
+	const { client } = useAuth();
+	const studioBotId = 'wpcom-studio-chat';
+
+	const sendFeedback = async ( { chatId, messageId, ratingValue }: SendFeedbackParams ) => {
+		if ( ! client?.req ) {
+			return;
+		}
+
+		try {
+			await client.req.post( {
+				path: `/odie/chat/${ studioBotId }/${ chatId }/${ messageId }/feedback`,
+				apiNamespace: 'wpcom/v2',
+				body: {
+					rating_value: ratingValue,
+				},
+			} );
+		} catch ( error ) {
+			Sentry.captureException( error );
+			console.error( error );
+		}
+	};
+
+	return sendFeedback;
+};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

- Closes https://github.com/Automattic/dotcom-forge/issues/8980

## Proposed Changes

This PR adds a rating system to the chat assistant so that the user can leave feedback. Initial view:

<img width="807" alt="Screenshot 2024-09-12 at 11 26 24 AM" src="https://github.com/user-attachments/assets/958f1234-927c-4841-b028-1d990713fb53">

After the feedback has been left:

<img width="1163" alt="Screenshot 2024-09-12 at 11 26 53 AM" src="https://github.com/user-attachments/assets/b147842f-b445-4cb8-bf2c-1bc107fa0495">

`Thanks for the feedback` notice should persist once you click it on a specific message.

## Testing Instructions

* Apply D161215-code if not yet deployed
* Pull the changes from this branch
* Start the app with `nvm use && npm install && npm start`
* Navigate to the Assistant tab
* Send a message and wait for assistant response
* Once the message is sent, observe the rating to appear
* Open the `Network` tab in the browser console
* Click on either positive or negative rating
* Observe `Thanks for the feedback` notice
* Onserve in the Network tab that API request succeeds (look for `feedback`):

<img width="1421" alt="Screenshot 2024-09-12 at 11 31 10 AM" src="https://github.com/user-attachments/assets/7baefb68-7ca8-4fc5-9d60-8235c539bdb4">

* Note down the `chatId` parameter:

<img width="1227" alt="Screenshot 2024-09-12 at 11 32 24 AM" src="https://github.com/user-attachments/assets/ad23c894-217f-4f7e-a3ca-b638299e47ac">

* Open the developer console on: https://developer.wordpress.com/docs/api/console/
* Query the following endpoint `wpcom/v2/`, `GET`, `/odie/chat/wpcom-studio-chat/${chatId}` (use chatId that you noted down earlier)

<img width="1335" alt="Screenshot 2024-09-12 at 11 34 30 AM" src="https://github.com/user-attachments/assets/6cb14478-7c55-436e-a0b5-288485e72895">

* Look for the message that you rated and confirm the rating is present (you can find it by the messageId from the API request):

<img width="1325" alt="Screenshot 2024-09-12 at 11 36 04 AM" src="https://github.com/user-attachments/assets/d3ec9288-629e-47dd-9458-47f4e9a42385">

* Try sending a couple of other messages and rating them
* Confirm that `Thanks for the feedback` notice persists

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?