### PR TITLE
Fix parsing of Assistant usage quota

### DIFF
--- a/src/components/welcome-message-prompt.tsx
+++ b/src/components/welcome-message-prompt.tsx
@@ -111,7 +111,7 @@ const WelcomeComponent = React.forwardRef< HTMLDivElement, WelcomeComponentProps
 					{ showExamplePrompts && (
 						<div className="flex-grow">
 							{ displayedPrompts.map( ( prompt, index ) => (
-								<div className="flex items-center">
+								<div key={ index } className="flex items-center">
 									<ExampleMessagePrompt
 										key={ index }
 										className="example-prompt"

--- a/src/hooks/tests/use-prompt-usage.test.ts
+++ b/src/hooks/tests/use-prompt-usage.test.ts
@@ -1,0 +1,108 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { useAuth } from '../use-auth';
+import { useFeatureFlags } from '../use-feature-flags';
+import { usePromptUsage, PromptUsageProvider } from '../use-prompt-usage';
+
+jest.mock( '../use-auth', () => ( {
+	useAuth: jest.fn(),
+} ) );
+
+jest.mock( '../use-feature-flags', () => ( {
+	useFeatureFlags: jest.fn(),
+} ) );
+
+describe( 'usePromptUsage hook', () => {
+	const mockClient = {
+		req: {
+			get: jest.fn().mockResolvedValue( {} ),
+		},
+	};
+
+	beforeEach( () => {
+		( useAuth as jest.Mock ).mockReturnValue( { client: null } );
+		( useFeatureFlags as jest.Mock ).mockReturnValue( { assistantEnabled: true } );
+		jest.useFakeTimers();
+		jest.setSystemTime( new Date( '2024-09-16' ) );
+	} );
+
+	afterEach( () => {
+		jest.useRealTimers();
+		jest.clearAllMocks();
+	} );
+
+	it( 'should initialize with default values', () => {
+		const { result } = renderHook( () => usePromptUsage(), {
+			wrapper: PromptUsageProvider,
+		} );
+
+		expect( result.current.promptLimit ).toBe( 200 );
+		expect( result.current.promptCount ).toBe( 0 );
+		expect( result.current.userCanSendMessage ).toBe( true );
+		expect( result.current.daysUntilReset ).toBe( NaN );
+	} );
+
+	it( 'should fetch prompt usage on mount', async () => {
+		( useAuth as jest.Mock ).mockReturnValue( { client: mockClient } );
+		mockClient.req.get.mockResolvedValue( {
+			max_quota: 250,
+			remaining_quota: 150,
+			quota_reset_date: '2024-10-01T00:00:00+00:00',
+		} );
+
+		const { result } = renderHook( () => usePromptUsage(), {
+			wrapper: PromptUsageProvider,
+		} );
+
+		await waitFor( () => {
+			expect( result.current.promptLimit ).toBe( 250 );
+			expect( result.current.promptCount ).toBe( 100 );
+			expect( result.current.userCanSendMessage ).toBe( true );
+			expect( result.current.daysUntilReset ).toBe( 15 );
+		} );
+	} );
+
+	it( 'should update prompt usage', async () => {
+		const { result } = renderHook( () => usePromptUsage(), {
+			wrapper: PromptUsageProvider,
+		} );
+
+		act( () => {
+			result.current.updatePromptUsage( { maxQuota: '300', remainingQuota: '50' } );
+		} );
+
+		expect( result.current.promptLimit ).toBe( 300 );
+		expect( result.current.promptCount ).toBe( 250 );
+		expect( result.current.userCanSendMessage ).toBe( true );
+		expect( result.current.daysUntilReset ).toBe( NaN );
+	} );
+
+	it.only( 'should not allow sending message when limit is reached', async () => {
+		( useAuth as jest.Mock ).mockReturnValue( { client: mockClient } );
+		mockClient.req.get.mockResolvedValue( {
+			max_quota: 100,
+			remaining_quota: 0,
+			quota_reset_date: '2024-10-01T00:00:00+00:00',
+		} );
+
+		const { result } = renderHook( () => usePromptUsage(), {
+			wrapper: PromptUsageProvider,
+		} );
+
+		await waitFor( () => {
+			expect( result.current.promptLimit ).toBe( 100 );
+			expect( result.current.promptCount ).toBe( 100 );
+			expect( result.current.userCanSendMessage ).toBe( false );
+			expect( result.current.daysUntilReset ).toBe( 15 );
+		} );
+	} );
+
+	it( 'should not fetch usage when assistant is disabled', async () => {
+		( useFeatureFlags as jest.Mock ).mockReturnValue( { assistantEnabled: false } );
+
+		renderHook( () => usePromptUsage(), {
+			wrapper: PromptUsageProvider,
+		} );
+
+		expect( mockClient.req.get ).not.toHaveBeenCalled();
+	} );
+} );

--- a/src/hooks/use-prompt-usage.tsx
+++ b/src/hooks/use-prompt-usage.tsx
@@ -69,8 +69,8 @@ export function PromptUsageProvider( { children }: PromptUsageProps ) {
 				apiNamespace: 'wpcom/v2',
 			} );
 			updatePromptUsage( {
-				maxQuota: response.max_quota || '',
-				remainingQuota: response.remaining_quota || '',
+				maxQuota: response.max_quota ?? '',
+				remainingQuota: response.remaining_quota ?? '',
 			} );
 			setQuotaResetDate( response.quota_reset_date || '' );
 		} catch ( error ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to p1726577612250489-slack-C04GESRBWKW.

## Proposed Changes

- The quota and remaining parameters received from `/studio-app/ai-assistant/quota` endpoint are integers. When the prompt limit is reached, the remaining value will be `0` which produces a false value in the parsing code. This has been updated to only fallback to an empty string when the value is not defined.
- Add unit tests to cover the functionality of the `usePromptUsage` hook.
- Fix a React error coming from rendering the extra example prompts.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Update manually the assistant quota usage for a WPCOM account (this can only be performed internally, more info in p1726581507875539/1726577612.250489-slack-C04GESRBWKW).
- Run the app with the command `npm start`.
- Log in with a WPCOM account.
- Open the settings modal.
- Observe the Assistant usage is 100%.
- Navigate to the Assistant tab.
- Observe there's a warning message notifying about the prompt limit reached.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?