### PR TITLE
Apply formatting to `vendor/wp-now` files

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,1 @@
 src/translations
-
-# wp-now
-vendor/wp-now

--- a/vendor/wp-now/.prettierignore
+++ b/vendor/wp-now/.prettierignore
@@ -1,3 +1,0 @@
-# NOTE: This file is only needed to prevent formatting when using PhpStorm.
-# Ignore patterns should be set in root's `.prettierignore` file.
-*

--- a/vendor/wp-now/public/with-node-version.js
+++ b/vendor/wp-now/public/with-node-version.js
@@ -6,7 +6,7 @@ import fs from 'fs';
 // Set the minimum required/supported version of node here.
 
 // Check if `--blueprint=` is passed in proccess.argv
-const hasBlueprint = process.argv.some((arg) => arg.startsWith('--blueprint='));
+const hasBlueprint = process.argv.some( ( arg ) => arg.startsWith( '--blueprint=' ) );
 
 const minimum = {
 	// `--blueprint=` requires node v20
@@ -17,38 +17,38 @@ const minimum = {
 
 // Matches "v18.14.2", as an example.
 const versionPattern = /^v(\d+)\.(\d+)\.(\d+)$/;
-const [major, minor, patch] = versionPattern.exec(process.version).slice(1, 4);
+const [ major, minor, patch ] = versionPattern.exec( process.version ).slice( 1, 4 );
 
-function meetsMinimumVersion(minimum, [major, minor, patch]) {
-	if (major > minimum.major) {
+function meetsMinimumVersion( minimum, [ major, minor, patch ] ) {
+	if ( major > minimum.major ) {
 		return true;
 	}
 
-	if (major < minimum.major) {
+	if ( major < minimum.major ) {
 		return false;
 	}
 
-	if (minor > minimum.minor) {
+	if ( minor > minimum.minor ) {
 		return true;
 	}
 
-	if (minor < minimum.minor) {
+	if ( minor < minimum.minor ) {
 		return false;
 	}
 
 	return patch >= minimum.patch;
 }
 
-if (!meetsMinimumVersion(minimum, [major, minor, patch])) {
+if ( ! meetsMinimumVersion( minimum, [ major, minor, patch ] ) ) {
 	const extra = hasBlueprint ? ' when --blueprint=<file> is used' : '';
 	console.error(
-		`This script is requires node version v${minimum.major}.${minimum.minor}.${minimum.patch} or above${extra}; found ${process.version}`
+		`This script is requires node version v${ minimum.major }.${ minimum.minor }.${ minimum.patch } or above${ extra }; found ${ process.version }`
 	);
-	process.exit(1);
+	process.exit( 1 );
 }
 
 // Launch the wp-now process and pipe output through this wrappers streams.
-const dir = path.dirname(fs.realpathSync(process.argv[1]));
-child_process.spawn('node', [dir + '/cli.js', ...process.argv.slice(2)], {
-	stdio: ['inherit', 'inherit', 'inherit'],
-});
+const dir = path.dirname( fs.realpathSync( process.argv[ 1 ] ) );
+child_process.spawn( 'node', [ dir + '/cli.js', ...process.argv.slice( 2 ) ], {
+	stdio: [ 'inherit', 'inherit', 'inherit' ],
+} );

--- a/vendor/wp-now/src/add-trailing-slash.ts
+++ b/vendor/wp-now/src/add-trailing-slash.ts
@@ -3,13 +3,13 @@
  * @param path - The path to add a trailing slash to. E.g. '/wp-admin'
  * @returns  - Returns a middleware function that may redirect adding a trailing slash to the given path. E.g. '/wp-admin/'
  */
-export function addTrailingSlash(path) {
-	return (req, res, next) => {
-		const urlParts = req.url.split('?');
-		const url = urlParts[0];
-		const queryString = req.url.substr(url.length);
-		if (url === path) {
-			res.redirect(301, `${path}/${queryString}`);
+export function addTrailingSlash( path ) {
+	return ( req, res, next ) => {
+		const urlParts = req.url.split( '?' );
+		const url = urlParts[ 0 ];
+		const queryString = req.url.substr( url.length );
+		if ( url === path ) {
+			res.redirect( 301, `${ path }/${ queryString }` );
 		} else {
 			next();
 		}

--- a/vendor/wp-now/src/config.ts
+++ b/vendor/wp-now/src/config.ts
@@ -1,7 +1,4 @@
-import {
-	SupportedPHPVersion,
-	SupportedPHPVersionsList,
-} from '@php-wasm/universal';
+import { SupportedPHPVersion, SupportedPHPVersionsList } from '@php-wasm/universal';
 import crypto from 'crypto';
 import fs from 'fs-extra';
 import path from 'path';
@@ -80,39 +77,32 @@ let absoluteUrlFromBlueprint = '';
 
 async function getAbsoluteURL() {
 	const port = await portFinder.getOpenPort();
-	if (isGitHubCodespace) {
-		return getCodeSpaceURL(port);
+	if ( isGitHubCodespace ) {
+		return getCodeSpaceURL( port );
 	}
 
-	if (absoluteUrlFromBlueprint) {
+	if ( absoluteUrlFromBlueprint ) {
 		return absoluteUrlFromBlueprint;
 	}
 
 	const url = 'http://localhost';
-	if (port === 80) {
+	if ( port === 80 ) {
 		return url;
 	}
-	return `${url}:${port}`;
+	return `${ url }:${ port }`;
 }
 
-function getWpContentHomePath(projectPath: string, mode: string) {
-	const basename = path.basename(projectPath);
-	const directoryHash = crypto
-		.createHash('sha1')
-		.update(projectPath)
-		.digest('hex');
+function getWpContentHomePath( projectPath: string, mode: string ) {
+	const basename = path.basename( projectPath );
+	const directoryHash = crypto.createHash( 'sha1' ).update( projectPath ).digest( 'hex' );
 	const projectDirectory =
-		mode === WPNowMode.PLAYGROUND
-			? 'playground'
-			: `${basename}-${directoryHash}`;
-	return path.join(getWpNowPath(), 'wp-content', projectDirectory);
+		mode === WPNowMode.PLAYGROUND ? 'playground' : `${ basename }-${ directoryHash }`;
+	return path.join( getWpNowPath(), 'wp-content', projectDirectory );
 }
 
-export default async function getWpNowConfig(
-	args: CliOptions
-): Promise<WPNowOptions> {
-	if (args.port) {
-		portFinder.setPort(args.port);
+export default async function getWpNowConfig( args: CliOptions ): Promise< WPNowOptions > {
+	if ( args.port ) {
+		portFinder.setPort( args.port );
 	}
 	const port = await portFinder.getOpenPort();
 	const optionsFromCli: WPNowOptions = {
@@ -125,81 +115,68 @@ export default async function getWpNowConfig(
 
 	const options: WPNowOptions = {} as WPNowOptions;
 
-	[optionsFromCli, DEFAULT_OPTIONS].forEach((config) => {
-		for (const key in config) {
-			if (!options[key]) {
-				options[key] = config[key];
+	[ optionsFromCli, DEFAULT_OPTIONS ].forEach( ( config ) => {
+		for ( const key in config ) {
+			if ( ! options[ key ] ) {
+				options[ key ] = config[ key ];
 			}
 		}
-	});
+	} );
 
-	if (!options.mode || options.mode === 'auto') {
-		options.mode = inferMode(options.projectPath);
+	if ( ! options.mode || options.mode === 'auto' ) {
+		options.mode = inferMode( options.projectPath );
 	}
-	if (!options.wpContentPath) {
-		options.wpContentPath = getWpContentHomePath(
-			options.projectPath,
-			options.mode
-		);
+	if ( ! options.wpContentPath ) {
+		options.wpContentPath = getWpContentHomePath( options.projectPath, options.mode );
 	}
-	if (!options.absoluteUrl) {
+	if ( ! options.absoluteUrl ) {
 		options.absoluteUrl = await getAbsoluteURL();
 	}
-	if (!isValidWordPressVersion(options.wordPressVersion)) {
+	if ( ! isValidWordPressVersion( options.wordPressVersion ) ) {
 		throw new Error(
 			'Unrecognized WordPress version. Please use "latest" or numeric versions such as "6.2", "6.0.1", "6.2-beta1", or "6.2-RC1"'
 		);
 	}
-	if (
-		options.phpVersion &&
-		!SupportedPHPVersionsList.includes(options.phpVersion)
-	) {
+	if ( options.phpVersion && ! SupportedPHPVersionsList.includes( options.phpVersion ) ) {
 		throw new Error(
 			`Unsupported PHP version: ${
 				options.phpVersion
-			}. Supported versions: ${SupportedPHPVersionsList.join(', ')}`
+			}. Supported versions: ${ SupportedPHPVersionsList.join( ', ' ) }`
 		);
 	}
-	if (args.blueprint) {
-		const blueprintPath = path.resolve(args.blueprint);
-		if (!fs.existsSync(blueprintPath)) {
-			throw new Error(`Blueprint file not found: ${blueprintPath}`);
+	if ( args.blueprint ) {
+		const blueprintPath = path.resolve( args.blueprint );
+		if ( ! fs.existsSync( blueprintPath ) ) {
+			throw new Error( `Blueprint file not found: ${ blueprintPath }` );
 		}
-		const blueprintObject = JSON.parse(
-			fs.readFileSync(blueprintPath, 'utf8')
-		);
+		const blueprintObject = JSON.parse( fs.readFileSync( blueprintPath, 'utf8' ) );
 
 		options.blueprintObject = blueprintObject;
-		const siteUrl = extractSiteUrlFromBlueprint(blueprintObject);
-		if (siteUrl) {
+		const siteUrl = extractSiteUrlFromBlueprint( blueprintObject );
+		if ( siteUrl ) {
 			options.absoluteUrl = siteUrl;
 			absoluteUrlFromBlueprint = siteUrl;
 		}
 	}
-	if (args.adminPassword) {
+	if ( args.adminPassword ) {
 		options.adminPassword = args.adminPassword;
 	}
-	if (args.siteTitle) {
+	if ( args.siteTitle ) {
 		options.siteTitle = args.siteTitle;
 	}
 	return options;
 }
 
-function extractSiteUrlFromBlueprint(
-	blueprintObject: Blueprint
-): string | false {
-	for (const step of blueprintObject.steps) {
-		if (typeof step !== 'object') {
+function extractSiteUrlFromBlueprint( blueprintObject: Blueprint ): string | false {
+	for ( const step of blueprintObject.steps ) {
+		if ( typeof step !== 'object' ) {
 			return false;
 		}
 
-		if (step.step === 'defineSiteUrl') {
-			return `${step.siteUrl}`;
-		} else if (
-			step.step === 'defineWpConfigConsts' &&
-			step.consts.WP_SITEURL
-		) {
-			return `${step.consts.WP_SITEURL}`;
+		if ( step.step === 'defineSiteUrl' ) {
+			return `${ step.siteUrl }`;
+		} else if ( step.step === 'defineWpConfigConsts' && step.consts.WP_SITEURL ) {
+			return `${ step.consts.WP_SITEURL }`;
 		}
 	}
 	return false;

--- a/vendor/wp-now/src/constants.ts
+++ b/vendor/wp-now/src/constants.ts
@@ -6,8 +6,7 @@ export const SQLITE_FILENAME = 'sqlite-database-integration';
 /**
  * The URL for downloading the "SQLite database integration" WordPress Plugin.
  */
-export const SQLITE_URL =
-	'https://downloads.wordpress.org/plugin/sqlite-database-integration.zip';
+export const SQLITE_URL = 'https://downloads.wordpress.org/plugin/sqlite-database-integration.zip';
 
 /**
  * The default starting port for running the WP Now server.

--- a/vendor/wp-now/src/download.ts
+++ b/vendor/wp-now/src/download.ts
@@ -13,7 +13,7 @@ import getWpNowPath from './get-wp-now-path';
 import { output } from './output';
 import { isValidWordPressVersion } from './wp-playground-wordpress';
 
-function httpsGet(url: string, callback: (res: IncomingMessage & FollowResponse) => void) {
+function httpsGet( url: string, callback: ( res: IncomingMessage & FollowResponse ) => void ) {
 	const proxy =
 		process.env.https_proxy ||
 		process.env.HTTPS_PROXY ||
@@ -22,23 +22,22 @@ function httpsGet(url: string, callback: (res: IncomingMessage & FollowResponse)
 
 	let agent: HttpsProxyAgent | HttpProxyAgent | undefined;
 
-	if (proxy) {
-		const urlParts = new URL(url);
-		const Agent =
-			urlParts.protocol === 'https:' ? HttpsProxyAgent : HttpProxyAgent;
-		agent = new Agent({ proxy });
+	if ( proxy ) {
+		const urlParts = new URL( url );
+		const Agent = urlParts.protocol === 'https:' ? HttpsProxyAgent : HttpProxyAgent;
+		agent = new Agent( { proxy } );
 	}
 
-	https.get(url, { agent }, callback);
+	https.get( url, { agent }, callback );
 }
 
-function getWordPressVersionUrl(version = DEFAULT_WORDPRESS_VERSION) {
-	if (!isValidWordPressVersion(version)) {
+function getWordPressVersionUrl( version = DEFAULT_WORDPRESS_VERSION ) {
+	if ( ! isValidWordPressVersion( version ) ) {
 		throw new Error(
 			'Unrecognized WordPress version. Please use "latest" or numeric versions such as "6.2", "6.0.1", "6.2-beta1", or "6.2-RC1"'
 		);
 	}
-	return `https://wordpress.org/wordpress-${version}.zip`;
+	return `https://wordpress.org/wordpress-${ version }.zip`;
 }
 
 interface DownloadFileAndUnzipResult {
@@ -48,170 +47,167 @@ interface DownloadFileAndUnzipResult {
 
 const { https } = followRedirects;
 
-async function downloadFile({
+async function downloadFile( {
 	url,
 	destinationFilePath,
 	itemName,
 	overwrite = false,
-}): Promise<DownloadFileAndUnzipResult> {
+} ): Promise< DownloadFileAndUnzipResult > {
 	let statusCode = 0;
 	try {
-		if (fs.existsSync(destinationFilePath) && !overwrite ) {
+		if ( fs.existsSync( destinationFilePath ) && ! overwrite ) {
 			return { downloaded: false, statusCode: 0 };
 		}
-		fs.ensureDirSync(path.dirname(destinationFilePath));
-		const response = await new Promise<IncomingMessage>((resolve) =>
-			httpsGet(url, (response) => resolve(response))
+		fs.ensureDirSync( path.dirname( destinationFilePath ) );
+		const response = await new Promise< IncomingMessage >( ( resolve ) =>
+			httpsGet( url, ( response ) => resolve( response ) )
 		);
 		statusCode = response.statusCode;
-		if (response.statusCode !== 200) {
-			throw new Error(
-				`Failed to download file (Status code ${response.statusCode}).`
-			);
+		if ( response.statusCode !== 200 ) {
+			throw new Error( `Failed to download file (Status code ${ response.statusCode }).` );
 		}
-		await new Promise<void>((resolve, reject) => {
-			fs.ensureFileSync(destinationFilePath);
-			const file = fs.createWriteStream(destinationFilePath);
-			response.pipe(file);
-			file.on('finish', () => {
+		await new Promise< void >( ( resolve, reject ) => {
+			fs.ensureFileSync( destinationFilePath );
+			const file = fs.createWriteStream( destinationFilePath );
+			response.pipe( file );
+			file.on( 'finish', () => {
 				file.close();
 				resolve();
-			});
-			file.on('error', (error) => {
+			} );
+			file.on( 'error', ( error ) => {
 				file.close();
-				reject(error);
-			});
-		});
-		output?.log(`Downloaded ${itemName} to ${destinationFilePath}`);
+				reject( error );
+			} );
+		} );
+		output?.log( `Downloaded ${ itemName } to ${ destinationFilePath }` );
 		return { downloaded: true, statusCode };
-	} catch (error) {
-		output?.error(`Error downloading file ${itemName}`, error);
+	} catch ( error ) {
+		output?.error( `Error downloading file ${ itemName }`, error );
 		return { downloaded: false, statusCode };
 	}
 }
 
 export async function downloadWpCli( overwrite = false ) {
-	return downloadFile({
+	return downloadFile( {
 		url: WP_CLI_URL,
 		destinationFilePath: getWpCliPath(),
 		itemName: 'wp-cli',
 		overwrite,
-	});
+	} );
 }
 
-async function downloadFileAndUnzip({
+async function downloadFileAndUnzip( {
 	url,
 	destinationFolder,
 	checkFinalPath,
 	itemName,
 	overwrite = false,
-}): Promise<DownloadFileAndUnzipResult> {
-	if (!overwrite && fs.existsSync(checkFinalPath)) {
-		output?.log(`${itemName} folder already exists. Skipping download.`);
+} ): Promise< DownloadFileAndUnzipResult > {
+	if ( ! overwrite && fs.existsSync( checkFinalPath ) ) {
+		output?.log( `${ itemName } folder already exists. Skipping download.` );
 		return { downloaded: false, statusCode: 0 };
 	}
 
 	let statusCode = 0;
 
 	try {
-		await fs.ensureDir(path.dirname(destinationFolder));
+		await fs.ensureDir( path.dirname( destinationFolder ) );
 
-		output?.log(`Downloading ${itemName}...`);
-		const response = await new Promise<IncomingMessage>((resolve) =>
-			httpsGet(url, (response) => resolve(response))
+		output?.log( `Downloading ${ itemName }...` );
+		const response = await new Promise< IncomingMessage >( ( resolve ) =>
+			httpsGet( url, ( response ) => resolve( response ) )
 		);
 		statusCode = response.statusCode;
 
-		if (response.statusCode !== 200) {
-			throw new Error(
-				`Failed to download file (Status code ${response.statusCode}).`
-			);
+		if ( response.statusCode !== 200 ) {
+			throw new Error( `Failed to download file (Status code ${ response.statusCode }).` );
 		}
 
-		const entryPromises: Promise<unknown>[] = [];
+		const entryPromises: Promise< unknown >[] = [];
 
 		/**
 		 * Using Parse because Extract is broken:
 		 * https://github.com/WordPress/wordpress-playground/issues/248
 		 */
 		await response
-			.pipe(unzipper.Parse())
-			.on('entry', (entry) => {
-				const filePath = path.join(destinationFolder, entry.path);
+			.pipe( unzipper.Parse() )
+			.on( 'entry', ( entry ) => {
+				const filePath = path.join( destinationFolder, entry.path );
 				/*
 				 * Use the sync version to ensure entry is piped to
 				 * a write stream before moving on to the next entry.
 				 */
-				fs.ensureDirSync(path.dirname(filePath));
+				fs.ensureDirSync( path.dirname( filePath ) );
 
-				if (entry.type === 'Directory') {
-					entryPromises.push(entry.autodrain().promise());
+				if ( entry.type === 'Directory' ) {
+					entryPromises.push( entry.autodrain().promise() );
 				} else {
-					const promise = new Promise((resolve, reject) => {
-						entry.pipe(fs.createWriteStream(filePath))
-							.on('close', resolve)
-							.on('error', reject);
-					});
-					entryPromises.push(promise);
+					const promise = new Promise( ( resolve, reject ) => {
+						entry
+							.pipe( fs.createWriteStream( filePath ) )
+							.on( 'close', resolve )
+							.on( 'error', reject );
+					} );
+					entryPromises.push( promise );
 				}
-			})
+			} )
 			.promise();
 
 		// Wait until all entries have been extracted before continuing
-		await Promise.all(entryPromises);
+		await Promise.all( entryPromises );
 
 		return { downloaded: true, statusCode };
-	} catch (err) {
-		output?.error(`Error downloading or unzipping ${itemName}:`, err);
+	} catch ( err ) {
+		output?.error( `Error downloading or unzipping ${ itemName }:`, err );
 	}
 	return { downloaded: false, statusCode };
 }
 
 export async function downloadWordPress(
 	wordPressVersion = DEFAULT_WORDPRESS_VERSION,
-	{overwrite}: {overwrite: boolean} = {overwrite: false}
+	{ overwrite }: { overwrite: boolean } = { overwrite: false }
 ) {
-	const finalFolder = getWordPressVersionPath(wordPressVersion);
+	const finalFolder = getWordPressVersionPath( wordPressVersion );
 	const tempFolder = os.tmpdir();
-	const { downloaded, statusCode } = await downloadFileAndUnzip({
-		url: getWordPressVersionUrl(wordPressVersion),
+	const { downloaded, statusCode } = await downloadFileAndUnzip( {
+		url: getWordPressVersionUrl( wordPressVersion ),
 		destinationFolder: tempFolder,
 		checkFinalPath: finalFolder,
-		itemName: `WordPress ${wordPressVersion}`,
+		itemName: `WordPress ${ wordPressVersion }`,
 		overwrite,
-	});
-	if (downloaded) {
-		await fs.ensureDir(path.dirname(finalFolder));
-		await fs.move(path.join(tempFolder, 'wordpress'), finalFolder, {
+	} );
+	if ( downloaded ) {
+		await fs.ensureDir( path.dirname( finalFolder ) );
+		await fs.move( path.join( tempFolder, 'wordpress' ), finalFolder, {
 			overwrite: true,
-		});
-	} else if (404 === statusCode) {
+		} );
+	} else if ( 404 === statusCode ) {
 		output?.log(
-			`WordPress ${wordPressVersion} not found. Check https://wordpress.org/download/releases/ for available versions.`
+			`WordPress ${ wordPressVersion } not found. Check https://wordpress.org/download/releases/ for available versions.`
 		);
 	}
 }
 
 export async function downloadSqliteIntegrationPlugin(
-	{overwrite}: {overwrite: boolean} = {overwrite: false}
+	{ overwrite }: { overwrite: boolean } = { overwrite: false }
 ) {
 	const finalFolder = getSqlitePath();
-	const tempFolder = path.join(os.tmpdir(), SQLITE_FILENAME);
-	const { downloaded, statusCode } = await downloadFileAndUnzip({
+	const tempFolder = path.join( os.tmpdir(), SQLITE_FILENAME );
+	const { downloaded, statusCode } = await downloadFileAndUnzip( {
 		url: SQLITE_URL,
 		destinationFolder: tempFolder,
 		checkFinalPath: finalFolder,
 		itemName: 'SQLite',
 		overwrite,
-	});
-	if (downloaded) {
-		const nestedFolder = path.join(tempFolder, SQLITE_FILENAME);
-		await fs.ensureDir(path.dirname(finalFolder));
-		await fs.move(nestedFolder, finalFolder, {
+	} );
+	if ( downloaded ) {
+		const nestedFolder = path.join( tempFolder, SQLITE_FILENAME );
+		await fs.ensureDir( path.dirname( finalFolder ) );
+		await fs.move( nestedFolder, finalFolder, {
 			overwrite: true,
-		});
-	} else if(0 !== statusCode) {
-		throw Error('An error ocurred when download SQLite' );
+		} );
+	} else if ( 0 !== statusCode ) {
+		throw Error( 'An error ocurred when download SQLite' );
 	}
 }
 
@@ -225,25 +221,25 @@ export async function downloadSQLiteCommand( downloadUrl: string, targetPath: st
 		overwrite: true,
 	} );
 
-	if (!downloaded) {
-		throw new Error(`Failed to download SQLite CLI command. Status code: ${statusCode}`);
+	if ( ! downloaded ) {
+		throw new Error( `Failed to download SQLite CLI command. Status code: ${ statusCode }` );
 	}
 
-	await fs.ensureDir(path.dirname(targetPath));
+	await fs.ensureDir( path.dirname( targetPath ) );
 
-	await fs.move(path.join( tempFolder ), targetPath, {
+	await fs.move( path.join( tempFolder ), targetPath, {
 		overwrite: true,
-	});
+	} );
 }
 
-export async function downloadMuPlugins(customMuPluginsPath = '') {
-	const muPluginsPath = customMuPluginsPath || path.join(getWpNowPath(), 'mu-plugins');
-	fs.ensureDirSync(muPluginsPath);
+export async function downloadMuPlugins( customMuPluginsPath = '' ) {
+	const muPluginsPath = customMuPluginsPath || path.join( getWpNowPath(), 'mu-plugins' );
+	fs.ensureDirSync( muPluginsPath );
 
-	fs.removeSync(path.join(muPluginsPath, '0-allow-wp-org.php') );
+	fs.removeSync( path.join( muPluginsPath, '0-allow-wp-org.php' ) );
 
 	fs.writeFile(
-		path.join(muPluginsPath, '0-allowed-redirect-hosts.php'),
+		path.join( muPluginsPath, '0-allowed-redirect-hosts.php' ),
 		`<?php
 	// Needed because gethostbyname( <host> ) returns
 	// a private network IP address for some reason.
@@ -262,7 +258,7 @@ export async function downloadMuPlugins(customMuPluginsPath = '') {
 	);
 
 	fs.writeFile(
-		path.join(muPluginsPath, '0-dns-functions.php'),
+		path.join( muPluginsPath, '0-dns-functions.php' ),
 		`<?php
 		// Polyfill for DNS functions/features which are not currently supported by @php-wasm/node.
 		// See https://github.com/WordPress/wordpress-playground/issues/1042
@@ -278,25 +274,25 @@ export async function downloadMuPlugins(customMuPluginsPath = '') {
 	);
 
 	fs.writeFile(
-		path.join(muPluginsPath, '0-thumbnails.php'),
+		path.join( muPluginsPath, '0-thumbnails.php' ),
 		`<?php
 		// Facilitates the taking of screenshots to be used as thumbnails.
 		if ( isset( $_GET['studio-hide-adminbar'] ) ) {
 			add_filter( 'show_admin_bar', '__return_false' );
 		}
 		`
-	)
+	);
 
 	fs.writeFile(
-		path.join(muPluginsPath, '0-sqlite.php'),
+		path.join( muPluginsPath, '0-sqlite.php' ),
 		`<?php
-		if ( file_exists( WP_CONTENT_DIR . "/db.php" ) && file_exists( __DIR__ . "/${SQLITE_FILENAME}/load.php" ) ) {
-			require_once __DIR__ . "/${SQLITE_FILENAME}/load.php";
+		if ( file_exists( WP_CONTENT_DIR . "/db.php" ) && file_exists( __DIR__ . "/${ SQLITE_FILENAME }/load.php" ) ) {
+			require_once __DIR__ . "/${ SQLITE_FILENAME }/load.php";
 		}`
 	);
 
 	fs.writeFile(
-		path.join(muPluginsPath, '0-32bit-integer-warnings.php'),
+		path.join( muPluginsPath, '0-32bit-integer-warnings.php' ),
 		`<?php
 /**
  * This is a temporary workaround to hide the 32bit integer warnings that
@@ -311,10 +307,11 @@ set_error_handler(function($severity, $message, $file, $line) {
   }
   return false;
 });
-`);
+`
+	);
 
 	fs.writeFile(
-		path.join(muPluginsPath, '0-check-theme-availability.php'),
+		path.join( muPluginsPath, '0-check-theme-availability.php' ),
 		`<?php
 	function check_current_theme_availability() {
 			// Get the current theme's directory
@@ -338,16 +335,18 @@ set_error_handler(function($severity, $message, $file, $line) {
 			}
 	}
 	add_action('after_setup_theme', 'check_current_theme_availability');
-`);
+`
+	);
 
 	fs.writeFile(
-		path.join(muPluginsPath, '0-permalinks.php'),
+		path.join( muPluginsPath, '0-permalinks.php' ),
 		`<?php
 			// Support permalinks without "index.php"
 			add_filter( 'got_url_rewrite', '__return_true' );
-	`);
+	`
+	);
 }
 
-export function getWordPressVersionPath(wpVersion: string) {
-	return path.join(getWordpressVersionsPath(), wpVersion);
+export function getWordPressVersionPath( wpVersion: string ) {
+	return path.join( getWordpressVersionsPath(), wpVersion );
 }

--- a/vendor/wp-now/src/execute-php.ts
+++ b/vendor/wp-now/src/execute-php.ts
@@ -13,37 +13,28 @@ import fs from 'fs-extra';
  * the exit name and status (0 for success).
  * @throws - Throws an error if the first element in phpArgs is not the string 'php'.
  */
-export async function executePHP(
-	phpArgs: string[],
-	options: WPNowOptions = {}
-) {
-	if (phpArgs[0] !== 'php') {
-		throw new Error(
-			'The first argument to executePHP must be the string "php".'
-		);
+export async function executePHP( phpArgs: string[], options: WPNowOptions = {} ) {
+	if ( phpArgs[ 0 ] !== 'php' ) {
+		throw new Error( 'The first argument to executePHP must be the string "php".' );
 	}
 	disableOutput();
-	const { phpInstances, options: wpNowOptions } = await startWPNow({
+	const { phpInstances, options: wpNowOptions } = await startWPNow( {
 		...options,
 		numberOfPhpInstances: 2,
-	});
-	const [, php] = phpInstances;
+	} );
+	const [ , php ] = phpInstances;
 
 	try {
-		if (!path.isAbsolute(phpArgs[1])) {
-			const maybePhpFile = path.join(
-				wpNowOptions.projectPath,
-				phpArgs[1]
-			);
-			if (fs.existsSync(maybePhpFile)) {
-				phpArgs[1] = maybePhpFile;
+		if ( ! path.isAbsolute( phpArgs[ 1 ] ) ) {
+			const maybePhpFile = path.join( wpNowOptions.projectPath, phpArgs[ 1 ] );
+			if ( fs.existsSync( maybePhpFile ) ) {
+				phpArgs[ 1 ] = maybePhpFile;
 			}
 		}
-		await php.cli(phpArgs);
-	} catch (resultOrError) {
-		const success =
-			resultOrError.name === 'ExitStatus' && resultOrError.status === 0;
-		if (!success) {
+		await php.cli( phpArgs );
+	} catch ( resultOrError ) {
+		const success = resultOrError.name === 'ExitStatus' && resultOrError.status === 0;
+		if ( ! success ) {
 			throw resultOrError;
 		}
 	}

--- a/vendor/wp-now/src/execute-wp-cli.ts
+++ b/vendor/wp-now/src/execute-wp-cli.ts
@@ -6,7 +6,13 @@ import { DEFAULT_PHP_VERSION, DEFAULT_WORDPRESS_VERSION } from './constants';
 import { phpVar } from '@php-wasm/util';
 import { createNodeFsMountHandler, loadNodeRuntime } from '@php-wasm/node';
 import { getSqliteCommandPath } from '../../../src/lib/sqlite-command-versions';
-import { PHP, MountHandler, writeFiles, setPhpIniEntries, loadPHPRuntime } from '@php-wasm/universal';
+import {
+	PHP,
+	MountHandler,
+	writeFiles,
+	setPhpIniEntries,
+	loadPHPRuntime,
+} from '@php-wasm/universal';
 import { readFileSync } from 'fs';
 
 const isWindows = process.platform === 'win32';
@@ -20,30 +26,33 @@ export async function executeWPCli(
 	{ phpVersion }: { phpVersion?: string } = {}
 ): Promise< { stdout: string; stderr: string; exitCode: number } > {
 	await downloadWpCli();
-	let options = await getWpNowConfig({
+	let options = await getWpNowConfig( {
 		php: phpVersion || DEFAULT_PHP_VERSION,
 		wp: DEFAULT_WORDPRESS_VERSION,
 		path: projectPath,
-	});
+	} );
 
-	const id =  await loadNodeRuntime(options.phpVersion);
-	const php = new PHP(id);
-	php.mkdir(options.documentRoot);
-	await php.mount(options.documentRoot, createNodeFsMountHandler(projectPath) as unknown as MountHandler);
+	const id = await loadNodeRuntime( options.phpVersion );
+	const php = new PHP( id );
+	php.mkdir( options.documentRoot );
+	await php.mount(
+		options.documentRoot,
+		createNodeFsMountHandler( projectPath ) as unknown as MountHandler
+	);
 
 	//Set the SAPI name to cli before running the script
-	await php.setSapiName('cli');
+	await php.setSapiName( 'cli' );
 
-	php.mkdir('/tmp');
+	php.mkdir( '/tmp' );
 
 	const wpCliPath = '/tmp/wp-cli.phar';
 	const stderrPath = '/tmp/stderr';
 	const sqliteCommandPath = '/tmp/sqlite-command';
-	const runCliPath =  '/tmp/run-cli.php';
+	const runCliPath = '/tmp/run-cli.php';
 	const createFiles = {
-			[wpCliPath]: readFileSync(getWpCliPath()),
-			[stderrPath]: '',
-			[runCliPath]: `<?php
+		[ wpCliPath ]: readFileSync( getWpCliPath() ),
+		[ stderrPath ]: '',
+		[ runCliPath ]: `<?php
 			// Set up the environment to emulate a shell script
 			// call.
 
@@ -55,19 +64,19 @@ export async function executeWPCli(
 			// When running PHP on Playground, the value of constant PHP_OS is set to Linux.
 			// This implies that platform-specific logic won't work as expected. To solve this,
 			// we use an environment variable to ensure WP-CLI runs the Windows-specific logic.
-			putenv( 'WP_CLI_TEST_IS_WINDOWS=${isWindows ? 1 : 0}' );
+			putenv( 'WP_CLI_TEST_IS_WINDOWS=${ isWindows ? 1 : 0 }' );
 
 			// Set the argv global.
 			$GLOBALS['argv'] = array_merge([
-				"${wpCliPath}",
-				"--path=${options.documentRoot}"
-			], ${phpVar(args)});
+				"${ wpCliPath }",
+				"--path=${ options.documentRoot }"
+			], ${ phpVar( args ) });
 
 			// Provide stdin, stdout, stderr streams outside of
 			// the CLI SAPI.
 			define('STDIN', fopen('php://stdin', 'rb'));
 			define('STDOUT', fopen('php://stdout', 'wb'));
-			define('STDERR', fopen('${stderrPath}', 'wb'));
+			define('STDERR', fopen('${ stderrPath }', 'wb'));
 			
 			// Force disabling WordPress debugging mode to avoid parsing issues of WP-CLI command result
 			define('WP_DEBUG', false);
@@ -77,35 +86,48 @@ export async function executeWPCli(
 			// WP-CLI uses this argument for checking updates. Seems it's not defined by Playground
 			// when running a script, so we explicitly set it.
 			// Reference: https://github.com/wp-cli/wp-cli/blob/main/php/WP_CLI/Runner.php#L1889
-			$_SERVER['argv'][0] = '${wpCliPath}';
+			$_SERVER['argv'][0] = '${ wpCliPath }';
 
-			require( '${wpCliPath}' );`,
-			['/internal/shared/ca-bundle.crt']: rootCertificates.join('\n')
-	}
+			require( '${ wpCliPath }' );`,
+		[ '/internal/shared/ca-bundle.crt' ]: rootCertificates.join( '\n' ),
+	};
 
-	await writeFiles(php, '/', createFiles);
+	await writeFiles( php, '/', createFiles );
 
-	await setPhpIniEntries(php, {
-		'openssl.cafile': '/internal/shared/ca-bundle.crt'
-	});
-	try{
-		php.mkdir(sqliteCommandPath);
-		await php.mount(sqliteCommandPath, createNodeFsMountHandler(getSqliteCommandPath()) as unknown as MountHandler)
-	}catch(e){
-		console.log(e)
+	await setPhpIniEntries( php, {
+		'openssl.cafile': '/internal/shared/ca-bundle.crt',
+	} );
+	try {
+		php.mkdir( sqliteCommandPath );
+		await php.mount(
+			sqliteCommandPath,
+			createNodeFsMountHandler( getSqliteCommandPath() ) as unknown as MountHandler
+		);
+	} catch ( e ) {
+		console.log( e );
 	}
 
 	try {
-		php.chdir(options.documentRoot);
-		const result = await php.run({
+		php.chdir( options.documentRoot );
+		const result = await php.run( {
 			scriptPath: runCliPath,
-		});
-		const stderr = php.readFileAsText(stderrPath).replace('PHP.run() output was: #!/usr/bin/env php', '').trim();
-		return { stdout: result.text.replace('#!/usr/bin/env php', '').trim(), stderr, exitCode: result.exitCode };
-	} catch (error) {
-		const stderr = php.readFileAsText(stderrPath).replace('PHP.run() output was: #!/usr/bin/env php', '').trim();
+		} );
+		const stderr = php
+			.readFileAsText( stderrPath )
+			.replace( 'PHP.run() output was: #!/usr/bin/env php', '' )
+			.trim();
+		return {
+			stdout: result.text.replace( '#!/usr/bin/env php', '' ).trim(),
+			stderr,
+			exitCode: result.exitCode,
+		};
+	} catch ( error ) {
+		const stderr = php
+			.readFileAsText( stderrPath )
+			.replace( 'PHP.run() output was: #!/usr/bin/env php', '' )
+			.trim();
 		return { stdout: '', stderr: stderr, exitCode: 1 };
 	} finally {
-		php.exit()
+		php.exit();
 	}
 }

--- a/vendor/wp-now/src/get-sqlite-path.ts
+++ b/vendor/wp-now/src/get-sqlite-path.ts
@@ -6,5 +6,5 @@ import { SQLITE_FILENAME } from './constants';
  * The full path to the "SQLite database integration" folder.
  */
 export default function getSqlitePath() {
-	return path.join(getWpNowPath(), `${SQLITE_FILENAME}`);
+	return path.join( getWpNowPath(), `${ SQLITE_FILENAME }` );
 }

--- a/vendor/wp-now/src/get-wordpress-versions-path.ts
+++ b/vendor/wp-now/src/get-wordpress-versions-path.ts
@@ -5,5 +5,5 @@ import getWpNowPath from './get-wp-now-path';
  * The path where WordPress zip files will be unzipped and stored within the WP Now folder.
  */
 export default function getWordpressVersionsPath() {
-	return path.join(getWpNowPath(), 'wordpress-versions');
+	return path.join( getWpNowPath(), 'wordpress-versions' );
 }

--- a/vendor/wp-now/src/get-wp-cli-path.ts
+++ b/vendor/wp-now/src/get-wp-cli-path.ts
@@ -6,8 +6,8 @@ import { getServerFilesPath } from '../../../src/storage/paths';
  * The path for wp-cli phar file within the WP Now folder.
  */
 export default function getWpCliPath() {
-	if (process.env.NODE_ENV !== 'test') {
-		return path.join(getServerFilesPath(), 'wp-cli.phar');
+	if ( process.env.NODE_ENV !== 'test' ) {
+		return path.join( getServerFilesPath(), 'wp-cli.phar' );
 	}
-	return path.join(getWpCliTmpPath(), 'wp-cli.phar');
+	return path.join( getWpCliTmpPath(), 'wp-cli.phar' );
 }

--- a/vendor/wp-now/src/get-wp-cli-tmp-path.ts
+++ b/vendor/wp-now/src/get-wp-cli-tmp-path.ts
@@ -7,5 +7,5 @@ import os from 'os';
 export default function getWpCliTmpPath() {
 	const tmpDirectory = os.tmpdir();
 
-	return path.join(tmpDirectory, `wp-now-tests-wp-cli-hidden-folder`);
+	return path.join( tmpDirectory, `wp-now-tests-wp-cli-hidden-folder` );
 }

--- a/vendor/wp-now/src/get-wp-now-path.ts
+++ b/vendor/wp-now/src/get-wp-now-path.ts
@@ -2,8 +2,8 @@ import getWpNowTmpPath from './get-wp-now-tmp-path';
 import { getServerFilesPath } from '../../../src/storage/paths';
 
 export default function getWpNowPath() {
-	if (process.env.NODE_ENV !== 'test') {
-		return getServerFilesPath()
+	if ( process.env.NODE_ENV !== 'test' ) {
+		return getServerFilesPath();
 	}
 
 	return getWpNowTmpPath();

--- a/vendor/wp-now/src/get-wp-now-tmp-path.ts
+++ b/vendor/wp-now/src/get-wp-now-tmp-path.ts
@@ -7,5 +7,5 @@ import os from 'os';
 export default function getWpNowTmpPath() {
 	const tmpDirectory = os.tmpdir();
 
-	return path.join(tmpDirectory, `wp-now-tests-hidden-folder`);
+	return path.join( tmpDirectory, `wp-now-tests-hidden-folder` );
 }

--- a/vendor/wp-now/src/github-codespaces.ts
+++ b/vendor/wp-now/src/github-codespaces.ts
@@ -2,14 +2,13 @@
  * True if the current environment is a GitHub Codespace
  */
 export const isGitHubCodespace = Boolean(
-	process.env.CODESPACE_NAME &&
-		process.env.GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN
+	process.env.CODESPACE_NAME && process.env.GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN
 );
 
 /*
  * Returns the URL in the current GitHub Codespace
  * e.g: https://sejas-fluffy-space-eureka-wrj7r95qhvq4x-8881.preview.app.github.dev
  */
-export function getCodeSpaceURL(port: number): string {
-	return `https://${process.env.CODESPACE_NAME}-${port}.${process.env.GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN}`;
+export function getCodeSpaceURL( port: number ): string {
+	return `https://${ process.env.CODESPACE_NAME }-${ port }.${ process.env.GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN }`;
 }

--- a/vendor/wp-now/src/main.ts
+++ b/vendor/wp-now/src/main.ts
@@ -2,11 +2,11 @@ import { runCli } from './run-cli';
 
 const requiredMajorVersion = 18;
 
-const currentNodeVersion = parseInt(process.versions?.node?.split('.')?.[0]);
+const currentNodeVersion = parseInt( process.versions?.node?.split( '.' )?.[ 0 ] );
 
-if (currentNodeVersion < requiredMajorVersion) {
+if ( currentNodeVersion < requiredMajorVersion ) {
 	console.warn(
-		`You are running Node.js version ${currentNodeVersion}, but this application recommends at least Node.js ${requiredMajorVersion} and isn't guaranteed to work on lower versions. Please upgrade your Node.js version.`
+		`You are running Node.js version ${ currentNodeVersion }, but this application recommends at least Node.js ${ requiredMajorVersion } and isn't guaranteed to work on lower versions. Please upgrade your Node.js version.`
 	);
 }
 

--- a/vendor/wp-now/src/port-finder.ts
+++ b/vendor/wp-now/src/port-finder.ts
@@ -9,7 +9,7 @@ class PortFinder {
 	private constructor() {}
 
 	public static getInstance(): PortFinder {
-		if (!PortFinder.#instance) {
+		if ( ! PortFinder.#instance ) {
 			PortFinder.#instance = new PortFinder();
 		}
 		return PortFinder.#instance;
@@ -19,19 +19,19 @@ class PortFinder {
 		return this.#searchPort++;
 	}
 
-	#isPortFree(): Promise<boolean> {
-		return new Promise((resolve) => {
+	#isPortFree(): Promise< boolean > {
+		return new Promise( ( resolve ) => {
 			const server = http.createServer();
 
 			server
-				.listen(this.#searchPort, () => {
+				.listen( this.#searchPort, () => {
 					server.close();
-					resolve(true);
-				})
-				.on('error', () => {
-					resolve(false);
-				});
-		});
+					resolve( true );
+				} )
+				.on( 'error', () => {
+					resolve( false );
+				} );
+		} );
 	}
 
 	/**
@@ -39,11 +39,11 @@ class PortFinder {
 	 *
 	 * @returns {Promise<number>} A promise that resolves to the open port number.
 	 */
-	public async getOpenPort(): Promise<number> {
-		if (this.#openPort) {
+	public async getOpenPort(): Promise< number > {
+		if ( this.#openPort ) {
 			return this.#openPort;
 		}
-		while (!(await this.#isPortFree())) {
+		while ( ! ( await this.#isPortFree() ) ) {
 			this.#incrementPort();
 		}
 
@@ -51,7 +51,7 @@ class PortFinder {
 		return this.#openPort;
 	}
 
-	public setPort(port: number): void {
+	public setPort( port: number ): void {
 		this.#openPort = port;
 	}
 }

--- a/vendor/wp-now/src/run-cli.ts
+++ b/vendor/wp-now/src/run-cli.ts
@@ -9,102 +9,98 @@ import { executePHP } from './execute-php';
 import { output } from './output';
 import { isGitHubCodespace } from './github-codespaces';
 
-function startSpinner(message: string) {
-	process.stdout.write(`${message}...\n`);
+function startSpinner( message: string ) {
+	process.stdout.write( `${ message }...\n` );
 	return {
-		succeed: (text: string) => {
-			output?.log(`${text}`);
+		succeed: ( text: string ) => {
+			output?.log( `${ text }` );
 		},
-		fail: (text: string) => {
-			output?.error(`${text}`);
+		fail: ( text: string ) => {
+			output?.error( `${ text }` );
 		},
 	};
 }
 
-function commonParameters(yargs) {
+function commonParameters( yargs ) {
 	return yargs
-		.option('path', {
-			describe:
-				'Path to the PHP or WordPress project. Defaults to the current working directory.',
+		.option( 'path', {
+			describe: 'Path to the PHP or WordPress project. Defaults to the current working directory.',
 			type: 'string',
-		})
-		.option('php', {
+		} )
+		.option( 'php', {
 			describe: 'PHP version to use.',
 			type: 'string',
-		});
+		} );
 }
 
 export async function runCli() {
-	return yargs(hideBin(process.argv))
-		.scriptName('wp-now')
-		.usage('$0 <cmd> [args]')
-		.check(async (argv) => {
+	return yargs( hideBin( process.argv ) )
+		.scriptName( 'wp-now' )
+		.usage( '$0 <cmd> [args]' )
+		.check( async ( argv ) => {
 			const config: CliOptions = {
 				php: argv.php as SupportedPHPVersion,
 				path: argv.path as string,
 			};
-			if (argv._[0] !== 'php') {
+			if ( argv._[ 0 ] !== 'php' ) {
 				config.wp = argv.wp as string;
 				config.port = argv.port as number;
 			}
 			try {
-				await getWpNowConfig(config);
-			} catch (error) {
+				await getWpNowConfig( config );
+			} catch ( error ) {
 				return error.message;
 			}
 			return true;
-		})
+		} )
 		.command(
 			'start',
 			'Start the server',
-			(yargs) => {
-				commonParameters(yargs);
-				yargs.option('wp', {
+			( yargs ) => {
+				commonParameters( yargs );
+				yargs.option( 'wp', {
 					describe: "WordPress version to use: e.g. '--wp=6.2'",
 					type: 'string',
-				});
-				yargs.option('port', {
+				} );
+				yargs.option( 'port', {
 					describe: 'Server port',
 					type: 'number',
-				});
-				yargs.option('blueprint', {
+				} );
+				yargs.option( 'blueprint', {
 					describe: 'Path to a blueprint file to be executed',
 					type: 'string',
-				});
-				yargs.option('reset', {
-					describe:
-						'Create a new project environment, destroying the old project environment.',
+				} );
+				yargs.option( 'reset', {
+					describe: 'Create a new project environment, destroying the old project environment.',
 					type: 'boolean',
-				});
-				yargs.option('inspect', {
+				} );
+				yargs.option( 'inspect', {
 					describe: 'Use Node debugging client.',
 					type: 'number',
-				});
-				yargs.option('inspect-brk', {
-					describe:
-						'Use Node debugging client. Break immediately on script execution start.',
+				} );
+				yargs.option( 'inspect-brk', {
+					describe: 'Use Node debugging client. Break immediately on script execution start.',
 					type: 'number',
-				});
-				yargs.option('trace-exit', {
+				} );
+				yargs.option( 'trace-exit', {
 					describe:
 						'Prints a stack trace whenever an environment is exited proactively, i.e. invoking process.exit().',
 					type: 'number',
-				});
-				yargs.option('trace-uncaught', {
+				} );
+				yargs.option( 'trace-uncaught', {
 					describe:
 						'Print stack traces for uncaught exceptions; usually, the stack trace associated with the creation of an Error is printed, whereas this makes Node.js also print the stack trace associated with throwing the value (which does not need to be an Error instance).',
 					type: 'number',
-				});
-				yargs.option('trace-warnings', {
-					describe:
-						'Print stack traces for process warnings (including deprecations).',
+				} );
+				yargs.option( 'trace-warnings', {
+					describe: 'Print stack traces for process warnings (including deprecations).',
 					type: 'number',
-				});
+				} );
 			},
-			async (argv) => {
-				const spinner = startSpinner('Starting the server...');
+			async ( argv ) => {
+				const spinner = startSpinner( 'Starting the server...' );
 				try {
-					const options = await getWpNowConfig({
+					const options = await getWpNowConfig( {
 						path: argv.path as string,
 						php: argv.php as SupportedPHPVersion,
 						wp: argv.wp as string,
@@ -113,76 +109,70 @@ export async function runCli() {
 						reset: argv.reset as boolean,
 						adminPassword: argv.adminPassword as string,
 						siteTitle: argv.siteTitle as string,
-					});
-					portFinder.setPort(options.port as number);
-					const { url } = await startServer(options);
-					openInDefaultBrowser(url);
-				} catch (error) {
-					output?.error(error);
-					spinner.fail(
-						`Failed to start the server: ${
-							(error as Error).message
-						}`
-					);
+					} );
+					portFinder.setPort( options.port as number );
+					const { url } = await startServer( options );
+					openInDefaultBrowser( url );
+				} catch ( error ) {
+					output?.error( error );
+					spinner.fail( `Failed to start the server: ${ ( error as Error ).message }` );
 				}
 			}
 		)
 		.command(
 			'php [..args]',
 			'Run the php command passing the arguments to php cli',
-			(yargs) => {
-				commonParameters(yargs);
-				yargs.strict(false);
+			( yargs ) => {
+				commonParameters( yargs );
+				yargs.strict( false );
 			},
-			async (argv) => {
+			async ( argv ) => {
 				try {
 					// 0: node, 1: wp-now, 2: php, ...args
-					const args = process.argv.slice(2);
-					const options = await getWpNowConfig({
+					const args = process.argv.slice( 2 );
+					const options = await getWpNowConfig( {
 						path: argv.path as string,
 						php: argv.php as SupportedPHPVersion,
-					});
-					const phpArgs = args.includes('--')
-						? (argv._ as string[])
-						: args;
+					} );
+					const phpArgs = args.includes( '--' ) ? ( argv._ as string[] ) : args;
 					// 0: php, ...args
-					await executePHP(phpArgs, options);
-					process.exit(0);
-				} catch (error) {
-					console.error(error);
-					process.exit(error.status || -1);
+					await executePHP( phpArgs, options );
+					process.exit( 0 );
+				} catch ( error ) {
+					console.error( error );
+					process.exit( error.status || -1 );
 				}
 			}
 		)
-		.demandCommand(1, 'You must provide a valid command')
+		.demandCommand( 1, 'You must provide a valid command' )
 		.help()
-		.alias('h', 'help')
+		.alias( 'h', 'help' )
 		.strict().argv;
 }
 
-function openInDefaultBrowser(url: string) {
-	if (isGitHubCodespace) {
+function openInDefaultBrowser( url: string ) {
+	if ( isGitHubCodespace ) {
 		return;
 	}
 	let cmd: string, args: string[] | SpawnOptionsWithoutStdio;
-	switch (process.platform) {
+	switch ( process.platform ) {
 		case 'darwin':
 			cmd = 'open';
-			args = [url];
+			args = [ url ];
 			break;
 		case 'linux':
 			cmd = 'xdg-open';
-			args = [url];
+			args = [ url ];
 			break;
 		case 'win32':
 			cmd = 'cmd';
-			args = ['/c', `start ${url}`];
+			args = [ '/c', `start ${ url }` ];
 			break;
 		default:
-			output?.log(`Platform '${process.platform}' not supported`);
+			output?.log( `Platform '${ process.platform }' not supported` );
 			return;
 	}
-	spawn(cmd, args).on('error', function (err) {
-		console.error(err.message);
-	});
+	spawn( cmd, args ).on( 'error', function ( err ) {
+		console.error( err.message );
+	} );
 }

--- a/vendor/wp-now/src/tests/add-trailing-slash.spec.ts
+++ b/vendor/wp-now/src/tests/add-trailing-slash.spec.ts
@@ -1,34 +1,34 @@
 import { addTrailingSlash } from '../add-trailing-slash';
 
-describe('add trailing slash middleware', () => {
-	const middlewareTrailingSlash = addTrailingSlash('/wp-admin');
+describe( 'add trailing slash middleware', () => {
+	const middlewareTrailingSlash = addTrailingSlash( '/wp-admin' );
 	let res, next;
 
-	beforeEach(() => {
+	beforeEach( () => {
 		res = {
 			redirect: vi.fn(),
 		};
 		next = vi.fn();
-	});
+	} );
 
-	test('adds a trailing slash to the given path', () => {
+	test( 'adds a trailing slash to the given path', () => {
 		const req = { url: '/wp-admin' };
-		middlewareTrailingSlash(req, res, next);
-		expect(res.redirect).toHaveBeenCalledWith(301, '/wp-admin/');
-		expect(next).not.toHaveBeenCalled();
-	});
+		middlewareTrailingSlash( req, res, next );
+		expect( res.redirect ).toHaveBeenCalledWith( 301, '/wp-admin/' );
+		expect( next ).not.toHaveBeenCalled();
+	} );
 
-	test('adds a trailing slash to the given path with parameters', () => {
+	test( 'adds a trailing slash to the given path with parameters', () => {
 		const req = { url: '/wp-admin?foo=bar' };
-		middlewareTrailingSlash(req, res, next);
-		expect(res.redirect).toHaveBeenCalledWith(301, '/wp-admin/?foo=bar');
-		expect(next).not.toHaveBeenCalled();
-	});
+		middlewareTrailingSlash( req, res, next );
+		expect( res.redirect ).toHaveBeenCalledWith( 301, '/wp-admin/?foo=bar' );
+		expect( next ).not.toHaveBeenCalled();
+	} );
 
-	test('does not add a trailing slash to the given path', () => {
+	test( 'does not add a trailing slash to the given path', () => {
 		const req = { url: '/wp-admin/' };
-		middlewareTrailingSlash(req, res, next);
-		expect(res.redirect).not.toHaveBeenCalled();
-		expect(next).toHaveBeenCalled();
-	});
-});
+		middlewareTrailingSlash( req, res, next );
+		expect( res.redirect ).not.toHaveBeenCalled();
+		expect( next ).toHaveBeenCalled();
+	} );
+} );

--- a/vendor/wp-now/src/tests/execute-php.spec.ts
+++ b/vendor/wp-now/src/tests/execute-php.spec.ts
@@ -2,83 +2,72 @@ import path from 'path';
 import { executePHP } from '../execute-php';
 import getWpNowConfig from '../config';
 
-const exampleDir = path.join(__dirname, 'execute-php');
+const exampleDir = path.join( __dirname, 'execute-php' );
 
-describe('validate php execution', () => {
+describe( 'validate php execution', () => {
 	let output = '';
-	beforeEach(() => {
-		vi.spyOn(console, 'log').mockImplementation((newLine: string) => {
-			output += `${newLine}`;
-		});
-	});
+	beforeEach( () => {
+		vi.spyOn( console, 'log' ).mockImplementation( ( newLine: string ) => {
+			output += `${ newLine }`;
+		} );
+	} );
 
-	afterEach(() => {
+	afterEach( () => {
 		output = '';
 		vi.restoreAllMocks();
-	});
-	test('php file execution in index mode', async () => {
-		const options = await getWpNowConfig({
+	} );
+	test( 'php file execution in index mode', async () => {
+		const options = await getWpNowConfig( {
 			path: exampleDir,
-		});
-		await executePHP(
-			['php', path.join(exampleDir, 'hello-world.php')],
-			options
-		);
+		} );
+		await executePHP( [ 'php', path.join( exampleDir, 'hello-world.php' ) ], options );
 
-		expect(output).toMatch(/Hello World!/);
-	});
-	test('php file execution for each PHP Version', async () => {
-		const options = await getWpNowConfig({
+		expect( output ).toMatch( /Hello World!/ );
+	} );
+	test( 'php file execution for each PHP Version', async () => {
+		const options = await getWpNowConfig( {
 			path: exampleDir,
-		});
-		await executePHP(['php', path.join(exampleDir, 'php-version.php')], {
+		} );
+		await executePHP( [ 'php', path.join( exampleDir, 'php-version.php' ) ], {
 			...options,
 			phpVersion: '7.4',
-		});
-		expect(output.substring(0, 16)).toBe('PHP Version: 7.4');
+		} );
+		expect( output.substring( 0, 16 ) ).toBe( 'PHP Version: 7.4' );
 
 		output = '';
-		await executePHP(['php', path.join(exampleDir, 'php-version.php')], {
+		await executePHP( [ 'php', path.join( exampleDir, 'php-version.php' ) ], {
 			...options,
 			phpVersion: '8.0',
-		});
-		expect(output.substring(0, 16)).toBe('PHP Version: 8.0');
+		} );
+		expect( output.substring( 0, 16 ) ).toBe( 'PHP Version: 8.0' );
 
 		output = '';
-		await executePHP(['php', path.join(exampleDir, 'php-version.php')], {
+		await executePHP( [ 'php', path.join( exampleDir, 'php-version.php' ) ], {
 			...options,
 			phpVersion: '8.2',
-		});
-		expect(output.substring(0, 16)).toBe('PHP Version: 8.2');
-	});
-	test('php file execution with non absolute path', async () => {
-		const options = await getWpNowConfig({
+		} );
+		expect( output.substring( 0, 16 ) ).toBe( 'PHP Version: 8.2' );
+	} );
+	test( 'php file execution with non absolute path', async () => {
+		const options = await getWpNowConfig( {
 			path: exampleDir,
-		});
-		await executePHP(['php', 'hello-world.php'], options);
+		} );
+		await executePHP( [ 'php', 'hello-world.php' ], options );
 
-		expect(output).toMatch(/Hello World!/);
-	});
+		expect( output ).toMatch( /Hello World!/ );
+	} );
 
-	test('php throws an error if the first element is not the string "php"', async () => {
-		const options = await getWpNowConfig({
+	test( 'php throws an error if the first element is not the string "php"', async () => {
+		const options = await getWpNowConfig( {
 			path: exampleDir,
-		});
+		} );
 		try {
-			await executePHP(
-				[
-					'word-different-to-php',
-					path.join(exampleDir, 'php-version.php'),
-				],
-				{
-					...options,
-					phpVersion: '7.4',
-				}
-			);
-		} catch (error) {
-			expect(error.message).toBe(
-				'The first argument to executePHP must be the string "php".'
-			);
+			await executePHP( [ 'word-different-to-php', path.join( exampleDir, 'php-version.php' ) ], {
+				...options,
+				phpVersion: '7.4',
+			} );
+		} catch ( error ) {
+			expect( error.message ).toBe( 'The first argument to executePHP must be the string "php".' );
 		}
-	});
-});
+	} );
+} );

--- a/vendor/wp-now/src/tests/github-codespaces.spec.ts
+++ b/vendor/wp-now/src/tests/github-codespaces.spec.ts
@@ -1,35 +1,32 @@
 import getWpNowConfig from '../config';
 import * as codespaces from '../github-codespaces';
 
-describe('Test GitHub Codespaces', () => {
+describe( 'Test GitHub Codespaces', () => {
 	let processEnv;
-	beforeAll(() => {
+	beforeAll( () => {
 		processEnv = process.env;
 		process.env = {};
-	});
+	} );
 
-	afterAll(() => {
+	afterAll( () => {
 		process.env = processEnv;
-	});
+	} );
 
-	test('getAbsoluteURL returns the localhost URL', async () => {
-		vi.spyOn(codespaces, 'isGitHubCodespace', 'get').mockReturnValue(false);
-		const options = await getWpNowConfig({ port: 7777 });
+	test( 'getAbsoluteURL returns the localhost URL', async () => {
+		vi.spyOn( codespaces, 'isGitHubCodespace', 'get' ).mockReturnValue( false );
+		const options = await getWpNowConfig( { port: 7777 } );
 
-		expect(options.absoluteUrl).toBe('http://localhost:7777');
+		expect( options.absoluteUrl ).toBe( 'http://localhost:7777' );
 		vi.resetAllMocks();
-	});
+	} );
 
-	test('getAbsoluteURL returns the codespace URL', async () => {
-		vi.spyOn(codespaces, 'isGitHubCodespace', 'get').mockReturnValue(true);
+	test( 'getAbsoluteURL returns the codespace URL', async () => {
+		vi.spyOn( codespaces, 'isGitHubCodespace', 'get' ).mockReturnValue( true );
 		process.env.CODESPACE_NAME = 'my-codespace-name';
-		process.env.GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN =
-			'preview.app.github.dev';
-		const options = await getWpNowConfig({ port: 7777 });
+		process.env.GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN = 'preview.app.github.dev';
+		const options = await getWpNowConfig( { port: 7777 } );
 
-		expect(options.absoluteUrl).toBe(
-			'https://my-codespace-name-7777.preview.app.github.dev'
-		);
+		expect( options.absoluteUrl ).toBe( 'https://my-codespace-name-7777.preview.app.github.dev' );
 		vi.resetAllMocks();
-	});
-});
+	} );
+} );

--- a/vendor/wp-now/src/tests/wp-now.spec.ts
+++ b/vendor/wp-now/src/tests/wp-now.spec.ts
@@ -10,11 +10,7 @@ import {
 	isWordPressDirectory,
 	isWordPressDevelopDirectory,
 } from '../wp-playground-wordpress';
-import {
-	downloadSqliteIntegrationPlugin,
-	downloadWpCli,
-	downloadWordPress,
-} from '../download';
+import { downloadSqliteIntegrationPlugin, downloadWpCli, downloadWordPress } from '../download';
 import os from 'os';
 import crypto from 'crypto';
 import getWpNowTmpPath from '../get-wp-now-tmp-path';
@@ -24,28 +20,28 @@ import { runCli } from '../run-cli';
 
 const exampleDir = __dirname + '/mode-examples';
 
-async function downloadWithTimer(name, fn) {
-	console.log(`Downloading ${name}...`);
-	console.time(name);
+async function downloadWithTimer( name, fn ) {
+	console.log( `Downloading ${ name }...` );
+	console.time( name );
 	await fn();
-	console.log(`${name} downloaded.`);
-	console.timeEnd(name);
+	console.log( `${ name } downloaded.` );
+	console.timeEnd( name );
 }
 
 // Options
-test('getWpNowConfig with default options', async () => {
+test( 'getWpNowConfig with default options', async () => {
 	const projectDirectory = exampleDir + '/index';
 	const rawOptions: CliOptions = {
 		path: projectDirectory,
 	};
-	const options = await getWpNowConfig(rawOptions);
+	const options = await getWpNowConfig( rawOptions );
 
-	expect(options.phpVersion).toBe('8.0');
-	expect(options.wordPressVersion).toBe('latest');
-	expect(options.documentRoot).toBe('/var/www/html');
-	expect(options.mode).toBe(WPNowMode.INDEX);
-	expect(options.projectPath).toBe(projectDirectory);
-});
+	expect( options.phpVersion ).toBe( '8.0' );
+	expect( options.wordPressVersion ).toBe( 'latest' );
+	expect( options.documentRoot ).toBe( '/var/www/html' );
+	expect( options.mode ).toBe( WPNowMode.INDEX );
+	expect( options.projectPath ).toBe( projectDirectory );
+} );
 
 //TODO: Add it back when all options are supported as cli arguments
 // test('parseOptions with custom options', async () => {
@@ -68,174 +64,171 @@ test('getWpNowConfig with default options', async () => {
 // 	expect(options.absoluteUrl).toBe('http://localhost:8080');
 // });
 
-test('getWpNowConfig with unsupported PHP version', async () => {
+test( 'getWpNowConfig with unsupported PHP version', async () => {
 	const rawOptions: CliOptions = {
 		php: '5.4' as any,
 	};
-	await expect(getWpNowConfig(rawOptions)).rejects.toThrowError(
+	await expect( getWpNowConfig( rawOptions ) ).rejects.toThrowError(
 		'Unsupported PHP version: 5.4.'
 	);
-});
+} );
 
 // Plugin mode
-test('isPluginDirectory detects a WordPress plugin and infer PLUGIN mode.', () => {
+test( 'isPluginDirectory detects a WordPress plugin and infer PLUGIN mode.', () => {
 	const projectPath = exampleDir + '/plugin';
-	expect(isPluginDirectory(projectPath)).toBe(true);
-	expect(inferMode(projectPath)).toBe(WPNowMode.PLUGIN);
-});
+	expect( isPluginDirectory( projectPath ) ).toBe( true );
+	expect( inferMode( projectPath ) ).toBe( WPNowMode.PLUGIN );
+} );
 
-test('isPluginDirectory detects a WordPress plugin in case-insensitive way and infer PLUGIN mode.', () => {
+test( 'isPluginDirectory detects a WordPress plugin in case-insensitive way and infer PLUGIN mode.', () => {
 	const projectPath = exampleDir + '/plugin-case-insensitive';
-	expect(isPluginDirectory(projectPath)).toBe(true);
-	expect(inferMode(projectPath)).toBe(WPNowMode.PLUGIN);
-});
+	expect( isPluginDirectory( projectPath ) ).toBe( true );
+	expect( inferMode( projectPath ) ).toBe( WPNowMode.PLUGIN );
+} );
 
-test('isPluginDirectory returns false for non-plugin directory', () => {
+test( 'isPluginDirectory returns false for non-plugin directory', () => {
 	const projectPath = exampleDir + '/not-plugin';
-	expect(isPluginDirectory(projectPath)).toBe(false);
-	expect(inferMode(projectPath)).toBe(WPNowMode.PLAYGROUND);
-});
+	expect( isPluginDirectory( projectPath ) ).toBe( false );
+	expect( inferMode( projectPath ) ).toBe( WPNowMode.PLAYGROUND );
+} );
 
 // Theme mode
-test('isThemeDirectory detects a WordPress theme and infer THEME mode', () => {
+test( 'isThemeDirectory detects a WordPress theme and infer THEME mode', () => {
 	const projectPath = exampleDir + '/theme';
-	expect(isThemeDirectory(projectPath)).toBe(true);
-	expect(inferMode(projectPath)).toBe(WPNowMode.THEME);
-});
+	expect( isThemeDirectory( projectPath ) ).toBe( true );
+	expect( inferMode( projectPath ) ).toBe( WPNowMode.THEME );
+} );
 
-test('getThemeTemplate detects if a WordPress theme has a parent template.', () => {
+test( 'getThemeTemplate detects if a WordPress theme has a parent template.', () => {
 	const projectPath = exampleDir + '/child-theme/child';
-	expect(getThemeTemplate(projectPath)).toBe('parent');
-	expect(inferMode(projectPath)).toBe(WPNowMode.THEME);
-});
+	expect( getThemeTemplate( projectPath ) ).toBe( 'parent' );
+	expect( inferMode( projectPath ) ).toBe( WPNowMode.THEME );
+} );
 
-test('getThemeTemplate returns falsy value for themes without parent', () => {
+test( 'getThemeTemplate returns falsy value for themes without parent', () => {
 	const projectPath = exampleDir + '/theme';
-	expect(getThemeTemplate(projectPath)).toBe(undefined);
-	expect(inferMode(projectPath)).toBe(WPNowMode.THEME);
-});
+	expect( getThemeTemplate( projectPath ) ).toBe( undefined );
+	expect( inferMode( projectPath ) ).toBe( WPNowMode.THEME );
+} );
 
-test('isThemeDirectory returns false for non-theme directory', () => {
+test( 'isThemeDirectory returns false for non-theme directory', () => {
 	const projectPath = exampleDir + '/not-theme';
-	expect(isThemeDirectory(projectPath)).toBe(false);
-	expect(inferMode(projectPath)).toBe(WPNowMode.PLAYGROUND);
-});
+	expect( isThemeDirectory( projectPath ) ).toBe( false );
+	expect( inferMode( projectPath ) ).toBe( WPNowMode.PLAYGROUND );
+} );
 
-test('isThemeDirectory returns false for a directory with style.css but without Theme Name', () => {
+test( 'isThemeDirectory returns false for a directory with style.css but without Theme Name', () => {
 	const projectPath = exampleDir + '/not-theme';
 
-	expect(isThemeDirectory(projectPath)).toBe(false);
-	expect(inferMode(projectPath)).toBe(WPNowMode.PLAYGROUND);
-});
+	expect( isThemeDirectory( projectPath ) ).toBe( false );
+	expect( inferMode( projectPath ) ).toBe( WPNowMode.PLAYGROUND );
+} );
 
 // WP_CONTENT mode
-test('isWpContentDirectory detects a WordPress wp-content directory and infer WP_CONTENT mode', () => {
+test( 'isWpContentDirectory detects a WordPress wp-content directory and infer WP_CONTENT mode', () => {
 	const projectPath = exampleDir + '/wp-content';
-	expect(isWpContentDirectory(projectPath)).toBe(true);
-	expect(isWordPressDirectory(projectPath)).toBe(false);
-	expect(inferMode(projectPath)).toBe(WPNowMode.WP_CONTENT);
-});
+	expect( isWpContentDirectory( projectPath ) ).toBe( true );
+	expect( isWordPressDirectory( projectPath ) ).toBe( false );
+	expect( inferMode( projectPath ) ).toBe( WPNowMode.WP_CONTENT );
+} );
 
-test('isWpContentDirectory returns false for wp-content parent directory', () => {
+test( 'isWpContentDirectory returns false for wp-content parent directory', () => {
 	const projectPath = exampleDir + '/index';
-	expect(isWpContentDirectory(projectPath)).toBe(false);
-	expect(isWordPressDirectory(projectPath)).toBe(false);
-	expect(inferMode(projectPath)).toBe(WPNowMode.INDEX);
-});
+	expect( isWpContentDirectory( projectPath ) ).toBe( false );
+	expect( isWordPressDirectory( projectPath ) ).toBe( false );
+	expect( inferMode( projectPath ) ).toBe( WPNowMode.INDEX );
+} );
 
-test('isWpContentDirectory returns true for a directory with only themes directory', () => {
+test( 'isWpContentDirectory returns true for a directory with only themes directory', () => {
 	const projectPath = exampleDir + '/wp-content-only-themes';
-	expect(isWpContentDirectory(projectPath)).toBe(true);
-	expect(isWordPressDirectory(projectPath)).toBe(false);
-	expect(inferMode(projectPath)).toBe(WPNowMode.WP_CONTENT);
-});
+	expect( isWpContentDirectory( projectPath ) ).toBe( true );
+	expect( isWordPressDirectory( projectPath ) ).toBe( false );
+	expect( inferMode( projectPath ) ).toBe( WPNowMode.WP_CONTENT );
+} );
 
-test('isWpContentDirectory returns true for a directory with only mu-plugins directory', () => {
+test( 'isWpContentDirectory returns true for a directory with only mu-plugins directory', () => {
 	const projectPath = exampleDir + '/wp-content-only-mu-plugins';
-	expect(isWpContentDirectory(projectPath)).toBe(true);
-	expect(isWordPressDirectory(projectPath)).toBe(false);
-	expect(inferMode(projectPath)).toBe(WPNowMode.WP_CONTENT);
-});
+	expect( isWpContentDirectory( projectPath ) ).toBe( true );
+	expect( isWordPressDirectory( projectPath ) ).toBe( false );
+	expect( inferMode( projectPath ) ).toBe( WPNowMode.WP_CONTENT );
+} );
 
 // WordPress mode
-test('isWordPressDirectory detects a WordPress directory and WORDPRESS mode', () => {
+test( 'isWordPressDirectory detects a WordPress directory and WORDPRESS mode', () => {
 	const projectPath = exampleDir + '/wordpress';
 
-	expect(isWordPressDirectory(projectPath)).toBe(true);
-	expect(inferMode(projectPath)).toBe(WPNowMode.WORDPRESS);
-});
+	expect( isWordPressDirectory( projectPath ) ).toBe( true );
+	expect( inferMode( projectPath ) ).toBe( WPNowMode.WORDPRESS );
+} );
 
-test('isWordPressDirectory returns false for non-WordPress directory', () => {
+test( 'isWordPressDirectory returns false for non-WordPress directory', () => {
 	const projectPath = exampleDir + '/nothing';
 
-	expect(isWordPressDirectory(projectPath)).toBe(false);
-	expect(inferMode(projectPath)).toBe(WPNowMode.PLAYGROUND);
-});
+	expect( isWordPressDirectory( projectPath ) ).toBe( false );
+	expect( inferMode( projectPath ) ).toBe( WPNowMode.PLAYGROUND );
+} );
 
 // WordPress developer mode
-test('isWordPressDevelopDirectory detects a WordPress-develop directory and WORDPRESS_DEVELOP mode', () => {
+test( 'isWordPressDevelopDirectory detects a WordPress-develop directory and WORDPRESS_DEVELOP mode', () => {
 	const projectPath = exampleDir + '/wordpress-develop';
 
-	expect(isWordPressDevelopDirectory(projectPath)).toBe(true);
-	expect(inferMode(projectPath)).toBe(WPNowMode.WORDPRESS_DEVELOP);
-});
+	expect( isWordPressDevelopDirectory( projectPath ) ).toBe( true );
+	expect( inferMode( projectPath ) ).toBe( WPNowMode.WORDPRESS_DEVELOP );
+} );
 
-test('isWordPressDevelopDirectory returns false for non-WordPress-develop directory', () => {
+test( 'isWordPressDevelopDirectory returns false for non-WordPress-develop directory', () => {
 	const projectPath = exampleDir + '/nothing';
 
-	expect(isWordPressDevelopDirectory(projectPath)).toBe(false);
-	expect(inferMode(projectPath)).toBe(WPNowMode.PLAYGROUND);
-});
+	expect( isWordPressDevelopDirectory( projectPath ) ).toBe( false );
+	expect( inferMode( projectPath ) ).toBe( WPNowMode.PLAYGROUND );
+} );
 
-test('isWordPressDevelopDirectory returns false for incomplete WordPress-develop directory', () => {
+test( 'isWordPressDevelopDirectory returns false for incomplete WordPress-develop directory', () => {
 	const projectPath = exampleDir + '/not-wordpress-develop';
 
-	expect(isWordPressDevelopDirectory(projectPath)).toBe(false);
-	expect(inferMode(projectPath)).toBe(WPNowMode.PLAYGROUND);
-});
+	expect( isWordPressDevelopDirectory( projectPath ) ).toBe( false );
+	expect( inferMode( projectPath ) ).toBe( WPNowMode.PLAYGROUND );
+} );
 
-describe('Test starting different modes', () => {
+describe( 'Test starting different modes', () => {
 	let tmpExampleDirectory;
 
 	/**
 	 * Download an initial copy of WordPress
 	 */
-	beforeAll(async () => {
-		fs.rmSync(getWpNowTmpPath(), { recursive: true, force: true });
-		await Promise.all([
-			downloadWithTimer('wordpress', downloadWordPress),
-			downloadWithTimer('sqlite', downloadSqliteIntegrationPlugin),
-		]);
-	});
+	beforeAll( async () => {
+		fs.rmSync( getWpNowTmpPath(), { recursive: true, force: true } );
+		await Promise.all( [
+			downloadWithTimer( 'wordpress', downloadWordPress ),
+			downloadWithTimer( 'sqlite', downloadSqliteIntegrationPlugin ),
+		] );
+	} );
 
 	/**
 	 * Copy example directory to a temporary directory
 	 */
-	beforeEach(() => {
+	beforeEach( () => {
 		const tmpDirectory = os.tmpdir();
-		const directoryHash = crypto.randomBytes(20).toString('hex');
+		const directoryHash = crypto.randomBytes( 20 ).toString( 'hex' );
 
-		tmpExampleDirectory = path.join(
-			tmpDirectory,
-			`wp-now-tests-examples-${directoryHash}`
-		);
-		fs.ensureDirSync(tmpExampleDirectory);
-		fs.copySync(exampleDir, tmpExampleDirectory);
-	});
+		tmpExampleDirectory = path.join( tmpDirectory, `wp-now-tests-examples-${ directoryHash }` );
+		fs.ensureDirSync( tmpExampleDirectory );
+		fs.copySync( exampleDir, tmpExampleDirectory );
+	} );
 
 	/**
 	 * Remove temporary directory
 	 */
-	afterEach(() => {
-		fs.rmSync(tmpExampleDirectory, { recursive: true, force: true });
-	});
+	afterEach( () => {
+		fs.rmSync( tmpExampleDirectory, { recursive: true, force: true } );
+	} );
 
 	/**
 	 * Remove wp-now hidden directory from temporary directory.
 	 */
-	afterAll(() => {
-		fs.rmSync(getWpNowTmpPath(), { recursive: true, force: true });
-	});
+	afterAll( () => {
+		fs.rmSync( getWpNowTmpPath(), { recursive: true, force: true } );
+	} );
 
 	/**
 	 * Expect that all provided mount point paths are empty directories which are result of file system mounts.
@@ -243,25 +236,25 @@ describe('Test starting different modes', () => {
 	 * @param mountPaths List of mount point paths that should exist on file system.
 	 * @param projectPath Project path.
 	 */
-	const expectEmptyMountPoints = (mountPaths, projectPath) => {
-		mountPaths.map((relativePath) => {
-			const fullPath = path.join(projectPath, relativePath);
+	const expectEmptyMountPoints = ( mountPaths, projectPath ) => {
+		mountPaths.map( ( relativePath ) => {
+			const fullPath = path.join( projectPath, relativePath );
 
-			expect({
+			expect( {
 				path: fullPath,
-				exists: fs.existsSync(fullPath),
-			}).toStrictEqual({ path: fullPath, exists: true });
+				exists: fs.existsSync( fullPath ),
+			} ).toStrictEqual( { path: fullPath, exists: true } );
 
-			expect({
+			expect( {
 				path: fullPath,
-				content: fs.readdirSync(fullPath),
-			}).toStrictEqual({ path: fullPath, content: [] });
+				content: fs.readdirSync( fullPath ),
+			} ).toStrictEqual( { path: fullPath, content: [] } );
 
-			expect({
+			expect( {
 				path: fullPath,
-				isDirectory: fs.lstatSync(fullPath).isDirectory(),
-			}).toStrictEqual({ path: fullPath, isDirectory: true });
-		});
+				isDirectory: fs.lstatSync( fullPath ).isDirectory(),
+			} ).toStrictEqual( { path: fullPath, isDirectory: true } );
+		} );
 	};
 
 	/**
@@ -270,14 +263,14 @@ describe('Test starting different modes', () => {
 	 * @param forbiddenFiles List of files that should not exist on file system.
 	 * @param projectPath Project path.
 	 */
-	const expectForbiddenProjectFiles = (forbiddenFiles, projectPath) => {
-		forbiddenFiles.map((relativePath) => {
-			const fullPath = path.join(projectPath, relativePath);
-			expect({
+	const expectForbiddenProjectFiles = ( forbiddenFiles, projectPath ) => {
+		forbiddenFiles.map( ( relativePath ) => {
+			const fullPath = path.join( projectPath, relativePath );
+			expect( {
 				path: fullPath,
-				exists: fs.existsSync(fullPath),
-			}).toStrictEqual({ path: fullPath, exists: false });
-		});
+				exists: fs.existsSync( fullPath ),
+			} ).toStrictEqual( { path: fullPath, exists: false } );
+		} );
 	};
 
 	/**
@@ -287,56 +280,56 @@ describe('Test starting different modes', () => {
 	 * @param documentRoot Document root of the PHP server.
 	 * @param php NodePHP instance.
 	 */
-	const expectRequiredRootFiles = (requiredFiles, documentRoot, php) => {
-		requiredFiles.map((relativePath) => {
-			const fullPath = path.join(documentRoot, relativePath);
-			expect({
+	const expectRequiredRootFiles = ( requiredFiles, documentRoot, php ) => {
+		requiredFiles.map( ( relativePath ) => {
+			const fullPath = path.join( documentRoot, relativePath );
+			expect( {
 				path: fullPath,
-				exists: php.fileExists(fullPath),
-			}).toStrictEqual({ path: fullPath, exists: true });
-		});
+				exists: php.fileExists( fullPath ),
+			} ).toStrictEqual( { path: fullPath, exists: true } );
+		} );
 	};
 
 	/**
 	 * Test that startWPNow in "index", "plugin", "theme", and "playground" modes doesn't change anything in the project directory.
 	 */
-	test.each([
-		['index', ['index.php']],
-		['plugin', ['sample-plugin.php']],
-		['theme', ['style.css']],
-		['playground', ['my-file.txt']],
-	])('startWPNow starts %s mode', async (mode, expectedDirectories) => {
-		const projectPath = path.join(tmpExampleDirectory, mode);
+	test.each( [
+		[ 'index', [ 'index.php' ] ],
+		[ 'plugin', [ 'sample-plugin.php' ] ],
+		[ 'theme', [ 'style.css' ] ],
+		[ 'playground', [ 'my-file.txt' ] ],
+	] )( 'startWPNow starts %s mode', async ( mode, expectedDirectories ) => {
+		const projectPath = path.join( tmpExampleDirectory, mode );
 
 		const rawOptions: CliOptions = {
 			path: projectPath,
 		};
 
-		const options = await getWpNowConfig(rawOptions);
+		const options = await getWpNowConfig( rawOptions );
 
-		await startWPNow(options);
+		await startWPNow( options );
 
-		const forbiddenPaths = ['wp-config.php'];
+		const forbiddenPaths = [ 'wp-config.php' ];
 
-		expectForbiddenProjectFiles(forbiddenPaths, projectPath);
+		expectForbiddenProjectFiles( forbiddenPaths, projectPath );
 
-		expect(fs.readdirSync(projectPath)).toEqual(expectedDirectories);
-	});
+		expect( fs.readdirSync( projectPath ) ).toEqual( expectedDirectories );
+	} );
 
 	/**
 	 * Test that startWPNow in "wp-content" mode mounts required files and directories, and
 	 * that required files exist for PHP.
 	 */
-	test('startWPNow starts wp-content mode', async () => {
-		const projectPath = path.join(tmpExampleDirectory, 'wp-content');
+	test( 'startWPNow starts wp-content mode', async () => {
+		const projectPath = path.join( tmpExampleDirectory, 'wp-content' );
 
 		const rawOptions: CliOptions = {
 			path: projectPath,
 		};
 
-		const options = await getWpNowConfig(rawOptions);
+		const options = await getWpNowConfig( rawOptions );
 
-		const { php, options: wpNowOptions } = await startWPNow(options);
+		const { php, options: wpNowOptions } = await startWPNow( options );
 
 		const mountPointPaths = [
 			'database',
@@ -345,33 +338,30 @@ describe('Test starting different modes', () => {
 			'plugins/sqlite-database-integration',
 		];
 
-		expectEmptyMountPoints(mountPointPaths, projectPath);
+		expectEmptyMountPoints( mountPointPaths, projectPath );
 
-		const forbiddenPaths = ['wp-config.php'];
+		const forbiddenPaths = [ 'wp-config.php' ];
 
-		expectForbiddenProjectFiles(forbiddenPaths, projectPath);
+		expectForbiddenProjectFiles( forbiddenPaths, projectPath );
 
-		const requiredFiles = [
-			'wp-content/db.php',
-			'wp-content/mu-plugins/0-allow-wp-org.php',
-		];
+		const requiredFiles = [ 'wp-content/db.php', 'wp-content/mu-plugins/0-allow-wp-org.php' ];
 
-		expectRequiredRootFiles(requiredFiles, wpNowOptions.documentRoot, php);
-	});
+		expectRequiredRootFiles( requiredFiles, wpNowOptions.documentRoot, php );
+	} );
 
 	/**
 	 * Test that startWPNow in "wordpress" mode without existing wp-config.php file mounts
 	 * required files and directories, and that required files exist for PHP.
 	 */
-	test('startWPNow starts wordpress mode', async () => {
-		const projectPath = path.join(tmpExampleDirectory, 'wordpress');
+	test( 'startWPNow starts wordpress mode', async () => {
+		const projectPath = path.join( tmpExampleDirectory, 'wordpress' );
 
 		const rawOptions: CliOptions = {
 			path: projectPath,
 		};
-		const options = await getWpNowConfig(rawOptions);
+		const options = await getWpNowConfig( rawOptions );
 
-		const { php, options: wpNowOptions } = await startWPNow(options);
+		const { php, options: wpNowOptions } = await startWPNow( options );
 
 		const mountPointPaths = [
 			'wp-content/database',
@@ -380,7 +370,7 @@ describe('Test starting different modes', () => {
 			'wp-content/plugins/sqlite-database-integration',
 		];
 
-		expectEmptyMountPoints(mountPointPaths, projectPath);
+		expectEmptyMountPoints( mountPointPaths, projectPath );
 
 		const requiredFiles = [
 			'wp-content/db.php',
@@ -388,29 +378,26 @@ describe('Test starting different modes', () => {
 			'wp-config.php',
 		];
 
-		expectRequiredRootFiles(requiredFiles, wpNowOptions.documentRoot, php);
-	});
+		expectRequiredRootFiles( requiredFiles, wpNowOptions.documentRoot, php );
+	} );
 
 	/**
 	 * Test that startWPNow in "wordpress" mode with existing wp-config.php file mounts
 	 * required files and directories, and that required files exist for PHP.
 	 */
-	test('startWPNow starts wordpress mode with existing wp-config', async () => {
-		const projectPath = path.join(
-			tmpExampleDirectory,
-			'wordpress-with-config'
-		);
+	test( 'startWPNow starts wordpress mode with existing wp-config', async () => {
+		const projectPath = path.join( tmpExampleDirectory, 'wordpress-with-config' );
 
 		const rawOptions: CliOptions = {
 			path: projectPath,
 		};
-		const options = await getWpNowConfig(rawOptions);
+		const options = await getWpNowConfig( rawOptions );
 
-		const { php, options: wpNowOptions } = await startWPNow(options);
+		const { php, options: wpNowOptions } = await startWPNow( options );
 
-		const mountPointPaths = ['wp-content/mu-plugins'];
+		const mountPointPaths = [ 'wp-content/mu-plugins' ];
 
-		expectEmptyMountPoints(mountPointPaths, projectPath);
+		expectEmptyMountPoints( mountPointPaths, projectPath );
 
 		const forbiddenPaths = [
 			'wp-content/database',
@@ -418,58 +405,53 @@ describe('Test starting different modes', () => {
 			'wp-content/plugins/sqlite-database-integration',
 		];
 
-		expectForbiddenProjectFiles(forbiddenPaths, projectPath);
+		expectForbiddenProjectFiles( forbiddenPaths, projectPath );
 
-		const requiredFiles = [
-			'wp-content/mu-plugins/0-allow-wp-org.php',
-			'wp-config.php',
-		];
+		const requiredFiles = [ 'wp-content/mu-plugins/0-allow-wp-org.php', 'wp-config.php' ];
 
-		expectRequiredRootFiles(requiredFiles, wpNowOptions.documentRoot, php);
-	});
+		expectRequiredRootFiles( requiredFiles, wpNowOptions.documentRoot, php );
+	} );
 
 	/**
 	 * Test that startWPNow in "plugin" mode auto installs the plugin.
 	 */
-	test('startWPNow auto installs the plugin', async () => {
-		const projectPath = path.join(tmpExampleDirectory, 'plugin');
-		const options = await getWpNowConfig({ path: projectPath });
-		const { php } = await startWPNow(options);
+	test( 'startWPNow auto installs the plugin', async () => {
+		const projectPath = path.join( tmpExampleDirectory, 'plugin' );
+		const options = await getWpNowConfig( { path: projectPath } );
+		const { php } = await startWPNow( options );
 		const codeIsPluginActivePhp = `<?php
-    require_once('${php.documentRoot}/wp-load.php');
-    require_once('${php.documentRoot}/wp-admin/includes/plugin.php');
+    require_once('${ php.documentRoot }/wp-load.php');
+    require_once('${ php.documentRoot }/wp-admin/includes/plugin.php');
 
     if (is_plugin_active('plugin/sample-plugin.php')) {
       echo 'plugin/sample-plugin.php is active';
     }
     `;
-		const isPluginActive = await php.run({
+		const isPluginActive = await php.run( {
 			code: codeIsPluginActivePhp,
-		});
+		} );
 
-		expect(isPluginActive.text).toContain(
-			'plugin/sample-plugin.php is active'
-		);
-	});
+		expect( isPluginActive.text ).toContain( 'plugin/sample-plugin.php is active' );
+	} );
 
 	/**
 	 * Test that startWPNow in "plugin" mode does not auto install the plugin the second time.
 	 */
-	test('startWPNow auto installs the plugin', async () => {
-		const projectPath = path.join(tmpExampleDirectory, 'plugin');
-		const options = await getWpNowConfig({ path: projectPath });
-		const { php } = await startWPNow(options);
+	test( 'startWPNow auto installs the plugin', async () => {
+		const projectPath = path.join( tmpExampleDirectory, 'plugin' );
+		const options = await getWpNowConfig( { path: projectPath } );
+		const { php } = await startWPNow( options );
 		const deactivatePluginPhp = `<?php
-    require_once('${php.documentRoot}/wp-load.php');
-    require_once('${php.documentRoot}/wp-admin/includes/plugin.php');
+    require_once('${ php.documentRoot }/wp-load.php');
+    require_once('${ php.documentRoot }/wp-admin/includes/plugin.php');
     deactivate_plugins('plugin/sample-plugin.php');
     `;
-		await php.run({ code: deactivatePluginPhp });
+		await php.run( { code: deactivatePluginPhp } );
 		// Run startWPNow a second time.
-		const { php: phpSecondTime } = await startWPNow(options);
+		const { php: phpSecondTime } = await startWPNow( options );
 		const codeIsPluginActivePhp = `<?php
-    require_once('${php.documentRoot}/wp-load.php');
-    require_once('${php.documentRoot}/wp-admin/includes/plugin.php');
+    require_once('${ php.documentRoot }/wp-load.php');
+    require_once('${ php.documentRoot }/wp-admin/includes/plugin.php');
 
     if (is_plugin_active('plugin/sample-plugin.php')) {
       echo 'plugin/sample-plugin.php is active';
@@ -477,46 +459,46 @@ describe('Test starting different modes', () => {
       echo 'plugin not active';
     }
     `;
-		const isPluginActive = await phpSecondTime.run({
+		const isPluginActive = await phpSecondTime.run( {
 			code: codeIsPluginActivePhp,
-		});
+		} );
 
-		expect(isPluginActive.text).toContain('plugin not active');
-	});
+		expect( isPluginActive.text ).toContain( 'plugin not active' );
+	} );
 
 	/**
 	 * Test that startWPNow in "theme" mode auto activates the theme.
 	 */
-	test('startWPNow auto installs the theme', async () => {
-		const projectPath = path.join(tmpExampleDirectory, 'theme');
-		const options = await getWpNowConfig({ path: projectPath });
-		const { php } = await startWPNow(options);
+	test( 'startWPNow auto installs the theme', async () => {
+		const projectPath = path.join( tmpExampleDirectory, 'theme' );
+		const options = await getWpNowConfig( { path: projectPath } );
+		const { php } = await startWPNow( options );
 		const codeActiveThemeNamePhp = `<?php
-    require_once('${php.documentRoot}/wp-load.php');
+    require_once('${ php.documentRoot }/wp-load.php');
     echo wp_get_theme()->get('Name');
     `;
-		const themeName = await php.run({
+		const themeName = await php.run( {
 			code: codeActiveThemeNamePhp,
-		});
+		} );
 
-		expect(themeName.text).toContain('Yolo Theme');
-	});
+		expect( themeName.text ).toContain( 'Yolo Theme' );
+	} );
 
 	/**
 	 * Test that startWPNow in "theme" mode auto activates the theme.
 	 */
-	test('startWPNow auto installs mounts child and parent theme.', async () => {
-		const projectPath = path.join(tmpExampleDirectory, 'child-theme/child');
-		const options = await getWpNowConfig({ path: projectPath });
-		const { php } = await startWPNow(options);
+	test( 'startWPNow auto installs mounts child and parent theme.', async () => {
+		const projectPath = path.join( tmpExampleDirectory, 'child-theme/child' );
+		const options = await getWpNowConfig( { path: projectPath } );
+		const { php } = await startWPNow( options );
 
 		const childThemePhp = `<?php
-		require_once('${php.documentRoot}/wp-load.php');
+		require_once('${ php.documentRoot }/wp-load.php');
 		echo wp_get_theme()->get('Name');
 		`;
 
 		const parentThemePhp = `<?php
-		    require_once('${php.documentRoot}/wp-load.php');
+		    require_once('${ php.documentRoot }/wp-load.php');
 			$theme = wp_get_theme( 'parent' );
 			if ( $theme->exists() ) {
 				echo $theme->get('Name');
@@ -525,338 +507,282 @@ describe('Test starting different modes', () => {
 			}
 		`;
 
-		const childThemeName = await php.run({
+		const childThemeName = await php.run( {
 			code: childThemePhp,
-		});
-		const parentThemeName = await php.run({
+		} );
+		const parentThemeName = await php.run( {
 			code: parentThemePhp,
-		});
+		} );
 
-		expect(childThemeName.text).toContain('Child Theme');
-		expect(parentThemeName.text).toContain('Parent Theme');
-	});
+		expect( childThemeName.text ).toContain( 'Child Theme' );
+		expect( parentThemeName.text ).toContain( 'Parent Theme' );
+	} );
 
 	/**
 	 * Test that startWPNow in "theme" mode auto activates the theme.
 	 */
-	test('startWPNow auto handles child theme with missing parent.', async () => {
-		const projectPath = path.join(
-			tmpExampleDirectory,
-			'child-theme-missing-parent/child'
-		);
-		const options = await getWpNowConfig({ path: projectPath });
-		const { php } = await startWPNow(options);
+	test( 'startWPNow auto handles child theme with missing parent.', async () => {
+		const projectPath = path.join( tmpExampleDirectory, 'child-theme-missing-parent/child' );
+		const options = await getWpNowConfig( { path: projectPath } );
+		const { php } = await startWPNow( options );
 
 		const childThemePhp = `<?php
-		require_once('${php.documentRoot}/wp-load.php');
+		require_once('${ php.documentRoot }/wp-load.php');
 		echo wp_get_theme()->get('Name');
 		`;
 
-		const childThemeName = await php.run({
+		const childThemeName = await php.run( {
 			code: childThemePhp,
-		});
+		} );
 
-		expect(childThemeName.text).toContain('Child Theme');
-	});
+		expect( childThemeName.text ).toContain( 'Child Theme' );
+	} );
 
 	/**
 	 * Test that startWPNow in "theme" mode does not auto activate the theme the second time.
 	 */
-	test('startWPNow auto installs the theme', async () => {
-		const projectPath = path.join(tmpExampleDirectory, 'theme');
-		const options = await getWpNowConfig({ path: projectPath });
-		const { php } = await startWPNow(options);
+	test( 'startWPNow auto installs the theme', async () => {
+		const projectPath = path.join( tmpExampleDirectory, 'theme' );
+		const options = await getWpNowConfig( { path: projectPath } );
+		const { php } = await startWPNow( options );
 		const switchThemePhp = `<?php
-    require_once('${php.documentRoot}/wp-load.php');
+    require_once('${ php.documentRoot }/wp-load.php');
     switch_theme('twentytwentythree');
     `;
-		await php.run({ code: switchThemePhp });
+		await php.run( { code: switchThemePhp } );
 		// Run startWPNow a second time.
-		const { php: phpSecondTime } = await startWPNow(options);
+		const { php: phpSecondTime } = await startWPNow( options );
 		const codeActiveThemeNamePhp = `<?php
-    require_once('${php.documentRoot}/wp-load.php');
+    require_once('${ php.documentRoot }/wp-load.php');
     echo wp_get_theme()->get('Name');
     `;
-		const themeName = await phpSecondTime.run({
+		const themeName = await phpSecondTime.run( {
 			code: codeActiveThemeNamePhp,
-		});
+		} );
 
-		expect(themeName.text).toContain('Twenty Twenty-Three');
-	});
+		expect( themeName.text ).toContain( 'Twenty Twenty-Three' );
+	} );
 
 	/*
 	 * Test that startWPNow doesn't leave dirty files.
 	 *
 	 * @see https://github.com/WordPress/playground-tools/issues/32
 	 */
-	test.skip('startWPNow does not leave dirty folders and files', async () => {
-		const projectPath = path.join(tmpExampleDirectory, 'wordpress');
-		const options = await getWpNowConfig({ path: projectPath });
-		await startWPNow(options);
+	test.skip( 'startWPNow does not leave dirty folders and files', async () => {
+		const projectPath = path.join( tmpExampleDirectory, 'wordpress' );
+		const options = await getWpNowConfig( { path: projectPath } );
+		await startWPNow( options );
+		expect(
+			fs.existsSync( path.join( projectPath, 'wp-content', 'mu-plugins', '0-allow-wp-org.php' ) )
+		).toBe( false );
+		expect( fs.existsSync( path.join( projectPath, 'wp-content', 'database' ) ) ).toBe( false );
 		expect(
 			fs.existsSync(
-				path.join(
-					projectPath,
-					'wp-content',
-					'mu-plugins',
-					'0-allow-wp-org.php'
-				)
+				path.join( projectPath, 'wp-content', 'plugins', 'sqlite-database-integration' )
 			)
-		).toBe(false);
-		expect(
-			fs.existsSync(path.join(projectPath, 'wp-content', 'database'))
-		).toBe(false);
-		expect(
-			fs.existsSync(
-				path.join(
-					projectPath,
-					'wp-content',
-					'plugins',
-					'sqlite-database-integration'
-				)
-			)
-		).toBe(false);
-		expect(
-			fs.existsSync(path.join(projectPath, 'wp-content', 'db.php'))
-		).toBe(false);
-	});
+		).toBe( false );
+		expect( fs.existsSync( path.join( projectPath, 'wp-content', 'db.php' ) ) ).toBe( false );
+	} );
 
 	/**
 	 * Test PHP integration test executing runCli.
 	 */
-	describe('validate php comand arguments passed through yargs', () => {
-		const phpExampleDir = path.join(__dirname, 'execute-php');
+	describe( 'validate php comand arguments passed through yargs', () => {
+		const phpExampleDir = path.join( __dirname, 'execute-php' );
 		const argv = process.argv;
 		let output = '';
 		let processExitMock;
-		beforeEach(() => {
-			vi.spyOn(console, 'log').mockImplementation((newLine: string) => {
-				output += `${newLine}\n`;
-			});
-			processExitMock = vi
-				.spyOn(process, 'exit')
-				.mockImplementation(() => null);
-		});
+		beforeEach( () => {
+			vi.spyOn( console, 'log' ).mockImplementation( ( newLine: string ) => {
+				output += `${ newLine }\n`;
+			} );
+			processExitMock = vi.spyOn( process, 'exit' ).mockImplementation( () => null );
+		} );
 
-		afterEach(() => {
+		afterEach( () => {
 			output = '';
 			process.argv = argv;
 			vi.resetAllMocks();
-		});
+		} );
 
-		test('php should receive the correct yargs arguments', async () => {
-			process.argv = ['node', 'wp-now', 'php', '--', '--version'];
+		test( 'php should receive the correct yargs arguments', async () => {
+			process.argv = [ 'node', 'wp-now', 'php', '--', '--version' ];
 			await runCli();
-			expect(output).toMatch(/PHP 8\.0(.*)\(cli\)/i);
-			expect(processExitMock).toHaveBeenCalledWith(0);
-		});
+			expect( output ).toMatch( /PHP 8\.0(.*)\(cli\)/i );
+			expect( processExitMock ).toHaveBeenCalledWith( 0 );
+		} );
 
-		test('wp-now should change the php version', async () => {
-			process.argv = [
-				'node',
-				'wp-now',
-				'php',
-				'--php=7.4',
-				'--',
-				'--version',
-			];
+		test( 'wp-now should change the php version', async () => {
+			process.argv = [ 'node', 'wp-now', 'php', '--php=7.4', '--', '--version' ];
 			await runCli();
-			expect(output).toMatch(/PHP 7\.4(.*)\(cli\)/i);
-			expect(processExitMock).toHaveBeenCalledWith(0);
-		});
+			expect( output ).toMatch( /PHP 7\.4(.*)\(cli\)/i );
+			expect( processExitMock ).toHaveBeenCalledWith( 0 );
+		} );
 
-		test('php should execute a file', async () => {
-			const filePath = path.join(phpExampleDir, 'php-version.php');
-			process.argv = ['node', 'wp-now', 'php', filePath];
+		test( 'php should execute a file', async () => {
+			const filePath = path.join( phpExampleDir, 'php-version.php' );
+			process.argv = [ 'node', 'wp-now', 'php', filePath ];
 			await runCli();
-			expect(output).toMatch(/8\.0/i);
-			expect(processExitMock).toHaveBeenCalledWith(0);
-		});
+			expect( output ).toMatch( /8\.0/i );
+			expect( processExitMock ).toHaveBeenCalledWith( 0 );
+		} );
 
-		test('php should execute a file and change php version', async () => {
-			const filePath = path.join(phpExampleDir, 'php-version.php');
-			process.argv = [
-				'node',
-				'wp-now',
-				'php',
-				'--php=7.4',
-				'--',
-				filePath,
-			];
+		test( 'php should execute a file and change php version', async () => {
+			const filePath = path.join( phpExampleDir, 'php-version.php' );
+			process.argv = [ 'node', 'wp-now', 'php', '--php=7.4', '--', filePath ];
 			await runCli();
-			expect(output).toMatch(/7\.4/i);
-			expect(processExitMock).toHaveBeenCalledWith(0);
-		});
-	});
+			expect( output ).toMatch( /7\.4/i );
+			expect( processExitMock ).toHaveBeenCalledWith( 0 );
+		} );
+	} );
 
 	/**
 	 * Test startServer.
 	 */
-	describe('startServer', () => {
+	describe( 'startServer', () => {
 		let stopServer, options;
 
-		beforeEach(async () => {
-			const projectPath = path.join(
-				tmpExampleDirectory,
-				'theme-with-assets'
-			);
-			const config = await getWpNowConfig({ path: projectPath });
-			const server = await startServer(config);
+		beforeEach( async () => {
+			const projectPath = path.join( tmpExampleDirectory, 'theme-with-assets' );
+			const config = await getWpNowConfig( { path: projectPath } );
+			const server = await startServer( config );
 			stopServer = server.stopServer;
 			options = server.options;
-		});
+		} );
 
-		afterEach(async () => {
+		afterEach( async () => {
 			options = null;
 			await stopServer();
-		});
+		} );
 
 		/**
 		 * Test that startServer compresses the text files correctly.
 		 */
-		test.each([
-			['html', ''],
-			['css', '/wp-content/themes/theme-with-assets/style.css'],
-			[
-				'javascript',
-				'/wp-content/themes/theme-with-assets/javascript.js',
-			],
-		])('startServer compresses the %s file', async (_, file) => {
-			const req = await fetch(`${options.absoluteUrl}${file}`);
-			expect(req.headers.get('content-encoding')).toBe('gzip');
-		});
+		test.each( [
+			[ 'html', '' ],
+			[ 'css', '/wp-content/themes/theme-with-assets/style.css' ],
+			[ 'javascript', '/wp-content/themes/theme-with-assets/javascript.js' ],
+		] )( 'startServer compresses the %s file', async ( _, file ) => {
+			const req = await fetch( `${ options.absoluteUrl }${ file }` );
+			expect( req.headers.get( 'content-encoding' ) ).toBe( 'gzip' );
+		} );
 
 		/**
 		 * Test that startServer doesn't compress non text files.
 		 */
-		test.each([
-			['png', '/wp-content/themes/theme-with-assets/image.png'],
-			['jpg', '/wp-content/themes/theme-with-assets/image.jpg'],
-		])("startServer doesn't compress the %s file", async (_, file) => {
-			const req = await fetch(`${options.absoluteUrl}${file}`);
-			expect(req.headers.get('content-encoding')).toBe(null);
-		});
-	});
+		test.each( [
+			[ 'png', '/wp-content/themes/theme-with-assets/image.png' ],
+			[ 'jpg', '/wp-content/themes/theme-with-assets/image.jpg' ],
+		] )( "startServer doesn't compress the %s file", async ( _, file ) => {
+			const req = await fetch( `${ options.absoluteUrl }${ file }` );
+			expect( req.headers.get( 'content-encoding' ) ).toBe( null );
+		} );
+	} );
 
 	/**
 	 * Test blueprints execution.
 	 */
-	describe('blueprints', () => {
-		const blueprintExamplesPath = path.join(__dirname, 'blueprints');
+	describe( 'blueprints', () => {
+		const blueprintExamplesPath = path.join( __dirname, 'blueprints' );
 
-		afterEach(() => {
+		afterEach( () => {
 			// Clean the custom url from the SQLite database
-			fs.rmSync(
-				path.join(getWpNowTmpPath(), 'wp-content', 'playground'),
-				{ recursive: true }
-			);
-		});
+			fs.rmSync( path.join( getWpNowTmpPath(), 'wp-content', 'playground' ), { recursive: true } );
+		} );
 
-		test('setting wp-config variable WP_DEBUG_LOG through blueprint', async () => {
-			const options = await getWpNowConfig({
-				blueprint: path.join(blueprintExamplesPath, 'wp-debug.json'),
-			});
-			const { php, stopServer } = await startServer(options);
-			php.writeFile(
-				`${php.documentRoot}/print-constants.php`,
-				`<?php echo WP_DEBUG_LOG;`
-			);
-			const result = await php.requestHandler.request({
+		test( 'setting wp-config variable WP_DEBUG_LOG through blueprint', async () => {
+			const options = await getWpNowConfig( {
+				blueprint: path.join( blueprintExamplesPath, 'wp-debug.json' ),
+			} );
+			const { php, stopServer } = await startServer( options );
+			php.writeFile( `${ php.documentRoot }/print-constants.php`, `<?php echo WP_DEBUG_LOG;` );
+			const result = await php.requestHandler.request( {
 				method: 'GET',
 				url: '/print-constants.php',
-			});
-			expect(result.text).toMatch(
-				'/var/www/html/wp-content/themes/fake/example.log'
-			);
+			} );
+			expect( result.text ).toMatch( '/var/www/html/wp-content/themes/fake/example.log' );
 			await stopServer();
-		});
+		} );
 
-		test('setting wp-config variable WP_SITEURL through blueprint', async () => {
-			const options = await getWpNowConfig({
-				blueprint: path.join(blueprintExamplesPath, 'wp-config.json'),
-			});
-			const { php, stopServer } = await startServer(options);
-			expect(options.absoluteUrl).toBe('http://127.0.0.1');
+		test( 'setting wp-config variable WP_SITEURL through blueprint', async () => {
+			const options = await getWpNowConfig( {
+				blueprint: path.join( blueprintExamplesPath, 'wp-config.json' ),
+			} );
+			const { php, stopServer } = await startServer( options );
+			expect( options.absoluteUrl ).toBe( 'http://127.0.0.1' );
 
-			php.writeFile(
-				`${php.documentRoot}/print-constants.php`,
-				`<?php echo WP_SITEURL;`
-			);
-			const result = await php.requestHandler.request({
+			php.writeFile( `${ php.documentRoot }/print-constants.php`, `<?php echo WP_SITEURL;` );
+			const result = await php.requestHandler.request( {
 				method: 'GET',
 				url: '/print-constants.php',
-			});
-			expect(result.text).toMatch('http://127.0.0.1');
+			} );
+			expect( result.text ).toMatch( 'http://127.0.0.1' );
 			await stopServer();
-		});
-	});
+		} );
+	} );
 
-	describe('reset', () => {
+	describe( 'reset', () => {
 		let removeSyncSpy;
-		beforeAll(() => {
-			removeSyncSpy = vi
-				.spyOn(fs, 'removeSync')
-				.mockImplementation(() => {});
-		});
+		beforeAll( () => {
+			removeSyncSpy = vi.spyOn( fs, 'removeSync' ).mockImplementation( () => {} );
+		} );
 
-		afterAll(() => {
+		afterAll( () => {
 			removeSyncSpy.mockRestore();
-		});
+		} );
 
-		test('creates a new environment, destroying the old environment', async () => {
+		test( 'creates a new environment, destroying the old environment', async () => {
 			const mode = 'theme';
-			const projectPath = path.join(tmpExampleDirectory, mode);
+			const projectPath = path.join( tmpExampleDirectory, mode );
 			const rawOptions: CliOptions = {
 				path: projectPath,
 				reset: true,
 			};
-			const options = await getWpNowConfig(rawOptions);
-			await startWPNow(options);
+			const options = await getWpNowConfig( rawOptions );
+			await startWPNow( options );
 			const wpContentPathRegExp = new RegExp(
-				`${getWpNowTmpPath()}\\/wp-content\\/${mode}-[\\w\\d]+`
+				`${ getWpNowTmpPath() }\\/wp-content\\/${ mode }-[\\w\\d]+`
 			);
 
-			expect(removeSyncSpy).toHaveBeenCalledWith(
-				expect.stringMatching(wpContentPathRegExp)
-			);
-		});
-	});
-});
+			expect( removeSyncSpy ).toHaveBeenCalledWith( expect.stringMatching( wpContentPathRegExp ) );
+		} );
+	} );
+} );
 
 /**
  * Test wp-cli command.
  */
-describe('wp-cli command', () => {
+describe( 'wp-cli command', () => {
 	let consoleSpy;
 	let output = '';
 
-	beforeEach(() => {
-		function onStdout(outputLine: string) {
+	beforeEach( () => {
+		function onStdout( outputLine: string ) {
 			output += outputLine;
 		}
-		consoleSpy = vi.spyOn(console, 'log');
-		consoleSpy.mockImplementation(onStdout);
-	});
+		consoleSpy = vi.spyOn( console, 'log' );
+		consoleSpy.mockImplementation( onStdout );
+	} );
 
-	afterEach(() => {
+	afterEach( () => {
 		output = '';
 		consoleSpy.mockRestore();
-	});
+	} );
 
-	beforeAll(async () => {
-		await downloadWithTimer('wp-cli', downloadWpCli);
-	});
+	beforeAll( async () => {
+		await downloadWithTimer( 'wp-cli', downloadWpCli );
+	} );
 
-	afterAll(() => {
-		fs.removeSync(getWpCliTmpPath());
-	});
+	afterAll( () => {
+		fs.removeSync( getWpCliTmpPath() );
+	} );
 
 	/**
 	 * Test wp-cli displays the version.
 	 * We don't need the WordPress context for this test.
 	 */
-	test('wp-cli displays the version', async () => {
-		await executeWPCli(['cli', 'version']);
-		expect(output).toMatch(/WP-CLI (\d\.?)+/i);
-	});
-});
+	test( 'wp-cli displays the version', async () => {
+		await executeWPCli( [ 'cli', 'version' ] );
+		expect( output ).toMatch( /WP-CLI (\d\.?)+/i );
+	} );
+} );

--- a/vendor/wp-now/src/wp-playground-wordpress/get-plugin-file.ts
+++ b/vendor/wp-now/src/wp-playground-wordpress/get-plugin-file.ts
@@ -8,12 +8,12 @@ import { readFileHead } from './read-file-head';
  * @param files The files to sort.
  * @returns The sorted files.
  */
-function heuristicSort(files: string[], projectPath: string) {
-	const heuristicsBestGuess = `${basename(projectPath)}.php`;
-	const heuristicsBestGuessIndex = files.indexOf(heuristicsBestGuess);
-	if (heuristicsBestGuessIndex !== -1) {
-		files.splice(heuristicsBestGuessIndex, 1);
-		files.unshift(heuristicsBestGuess);
+function heuristicSort( files: string[], projectPath: string ) {
+	const heuristicsBestGuess = `${ basename( projectPath ) }.php`;
+	const heuristicsBestGuessIndex = files.indexOf( heuristicsBestGuess );
+	if ( heuristicsBestGuessIndex !== -1 ) {
+		files.splice( heuristicsBestGuessIndex, 1 );
+		files.unshift( heuristicsBestGuess );
 	}
 	return files;
 }
@@ -23,15 +23,14 @@ function heuristicSort(files: string[], projectPath: string) {
  * @param projectPath The path to the plugin.
  * @returns Path to the plugin file relative to the plugins directory.
  */
-export function getPluginFile(projectPath: string) {
-	const files = heuristicSort(fs.readdirSync(projectPath), projectPath);
-	for (const file of files) {
-		if (file.endsWith('.php')) {
-			const fileContent = readFileHead(path.join(projectPath, file));
-			const pluginNameRegex =
-				/^(?:[ \t]*<\?php)?[ \t/*#@]*Plugin Name:(.*)$/im;
-			if (pluginNameRegex.test(fileContent)) {
-				return path.join(path.basename(projectPath), file);
+export function getPluginFile( projectPath: string ) {
+	const files = heuristicSort( fs.readdirSync( projectPath ), projectPath );
+	for ( const file of files ) {
+		if ( file.endsWith( '.php' ) ) {
+			const fileContent = readFileHead( path.join( projectPath, file ) );
+			const pluginNameRegex = /^(?:[ \t]*<\?php)?[ \t/*#@]*Plugin Name:(.*)$/im;
+			if ( pluginNameRegex.test( fileContent ) ) {
+				return path.join( path.basename( projectPath ), file );
 			}
 		}
 	}

--- a/vendor/wp-now/src/wp-playground-wordpress/has-index-file.ts
+++ b/vendor/wp-now/src/wp-playground-wordpress/has-index-file.ts
@@ -7,6 +7,6 @@ import path from 'path';
  * @param projectPath The path to the project to check.
  * @returns A boolean value indicating whether the project has an index.php file.
  */
-export function hasIndexFile(projectPath: string): Boolean {
-	return fs.existsSync(path.join(projectPath, 'index.php'));
+export function hasIndexFile( projectPath: string ): Boolean {
+	return fs.existsSync( path.join( projectPath, 'index.php' ) );
 }

--- a/vendor/wp-now/src/wp-playground-wordpress/is-plugin-directory.ts
+++ b/vendor/wp-now/src/wp-playground-wordpress/is-plugin-directory.ts
@@ -6,7 +6,7 @@ import { getPluginFile } from './get-plugin-file';
  * @param projectPath The path to the project to check.
  * @returns A boolean value indicating whether the project is a WordPress plugin.
  */
-export function isPluginDirectory(projectPath: string): Boolean {
-	const pluginFile = getPluginFile(projectPath);
+export function isPluginDirectory( projectPath: string ): Boolean {
+	const pluginFile = getPluginFile( projectPath );
 	return pluginFile !== null;
 }

--- a/vendor/wp-now/src/wp-playground-wordpress/is-theme-directory.ts
+++ b/vendor/wp-now/src/wp-playground-wordpress/is-theme-directory.ts
@@ -8,12 +8,12 @@ import { readFileHead } from './read-file-head';
  * @param projectPath The path to the project to check.
  * @returns A boolean value indicating whether the project is a WordPress theme directory.
  */
-export function isThemeDirectory(projectPath: string): Boolean {
-	const styleCSSExists = fs.existsSync(path.join(projectPath, 'style.css'));
-	if (!styleCSSExists) {
+export function isThemeDirectory( projectPath: string ): Boolean {
+	const styleCSSExists = fs.existsSync( path.join( projectPath, 'style.css' ) );
+	if ( ! styleCSSExists ) {
 		return false;
 	}
-	const styleCSS = readFileHead(path.join(projectPath, 'style.css'));
+	const styleCSS = readFileHead( path.join( projectPath, 'style.css' ) );
 	const themeNameRegex = /^(?:[ \t]*<\?php)?[ \t/*#@]*Theme Name:(.*)$/im;
-	return themeNameRegex.test(styleCSS);
+	return themeNameRegex.test( styleCSS );
 }

--- a/vendor/wp-now/src/wp-playground-wordpress/is-valid-wordpress-version.ts
+++ b/vendor/wp-now/src/wp-playground-wordpress/is-valid-wordpress-version.ts
@@ -12,8 +12,8 @@
  * @param version The version string to check.
  * @returns A boolean value indicating whether the version string is a valid WordPress version.
  */
-export function isValidWordPressVersion(version: string): boolean {
+export function isValidWordPressVersion( version: string ): boolean {
 	const versionPattern =
 		/^latest$|^(?:(\d+)\.(\d+)(?:\.(\d+))?)((?:-beta(?:\d+)?)|(?:-RC(?:\d+)?))?$/;
-	return versionPattern.test(version);
+	return versionPattern.test( version );
 }

--- a/vendor/wp-now/src/wp-playground-wordpress/is-wordpress-develop-directory.ts
+++ b/vendor/wp-now/src/wp-playground-wordpress/is-wordpress-develop-directory.ts
@@ -7,7 +7,7 @@ import path from 'path';
  * @param projectPath The path to the project to check.
  * @returns Is it a WordPress-develop directory?
  */
-export function isWordPressDevelopDirectory(projectPath: string): boolean {
+export function isWordPressDevelopDirectory( projectPath: string ): boolean {
 	const requiredFiles = [
 		'src',
 		'src/wp-content',
@@ -19,7 +19,5 @@ export function isWordPressDevelopDirectory(projectPath: string): boolean {
 		'build/wp-load.php',
 	];
 
-	return requiredFiles.every((file) =>
-		fs.existsSync(path.join(projectPath, file))
-	);
+	return requiredFiles.every( ( file ) => fs.existsSync( path.join( projectPath, file ) ) );
 }

--- a/vendor/wp-now/src/wp-playground-wordpress/is-wordpress-directory.ts
+++ b/vendor/wp-now/src/wp-playground-wordpress/is-wordpress-directory.ts
@@ -7,10 +7,10 @@ import path from 'path';
  * @param projectPath The path to the project to check.
  * @returns Is it a WordPress directory?
  */
-export function isWordPressDirectory(projectPath: string): Boolean {
+export function isWordPressDirectory( projectPath: string ): Boolean {
 	return (
-		fs.existsSync(path.join(projectPath, 'wp-content')) &&
-		fs.existsSync(path.join(projectPath, 'wp-includes')) &&
-		fs.existsSync(path.join(projectPath, 'wp-load.php'))
+		fs.existsSync( path.join( projectPath, 'wp-content' ) ) &&
+		fs.existsSync( path.join( projectPath, 'wp-includes' ) ) &&
+		fs.existsSync( path.join( projectPath, 'wp-load.php' ) )
 	);
 }

--- a/vendor/wp-now/src/wp-playground-wordpress/is-wp-content-directory.ts
+++ b/vendor/wp-now/src/wp-playground-wordpress/is-wp-content-directory.ts
@@ -7,11 +7,11 @@ import path from 'path';
  * @param projectPath The path to the project to check.
  * @returns A boolean value indicating whether the project is a WordPress wp-content directory.
  */
-export function isWpContentDirectory(projectPath: string): Boolean {
-	const muPluginsExists = fs.existsSync(path.join(projectPath, 'mu-plugins'));
-	const pluginsExists = fs.existsSync(path.join(projectPath, 'plugins'));
-	const themesExists = fs.existsSync(path.join(projectPath, 'themes'));
-	if (muPluginsExists || pluginsExists || themesExists) {
+export function isWpContentDirectory( projectPath: string ): Boolean {
+	const muPluginsExists = fs.existsSync( path.join( projectPath, 'mu-plugins' ) );
+	const pluginsExists = fs.existsSync( path.join( projectPath, 'plugins' ) );
+	const themesExists = fs.existsSync( path.join( projectPath, 'themes' ) );
+	if ( muPluginsExists || pluginsExists || themesExists ) {
 		return true;
 	}
 	return false;

--- a/vendor/wp-now/src/wp-playground-wordpress/read-file-head.ts
+++ b/vendor/wp-now/src/wp-playground-wordpress/read-file-head.ts
@@ -7,11 +7,11 @@ import fs from 'fs-extra';
  * @returns The first `length` bytes of the file as string.
  * @see https://developer.wordpress.org/reference/functions/get_file_data/
  */
-export function readFileHead(filePath: string, length = 8192) {
-	const buffer = Buffer.alloc(length);
-	const fd = fs.openSync(filePath, 'r');
-	fs.readSync(fd, buffer, 0, buffer.length, 0);
-	const fileContentBuffer = buffer.toString('utf8');
-	fs.closeSync(fd);
+export function readFileHead( filePath: string, length = 8192 ) {
+	const buffer = Buffer.alloc( length );
+	const fd = fs.openSync( filePath, 'r' );
+	fs.readSync( fd, buffer, 0, buffer.length, 0 );
+	const fileContentBuffer = buffer.toString( 'utf8' );
+	fs.closeSync( fd );
 	return fileContentBuffer.toString();
 }

--- a/vendor/wp-now/src/wp-playground-wordpress/tests/get-plugin-file.spec.ts
+++ b/vendor/wp-now/src/wp-playground-wordpress/tests/get-plugin-file.spec.ts
@@ -1,26 +1,20 @@
 import path from 'path';
 import { getPluginFile } from '../get-plugin-file';
 
-const modesPath = path.resolve(__dirname, '..', '..', 'tests', 'mode-examples');
+const modesPath = path.resolve( __dirname, '..', '..', 'tests', 'mode-examples' );
 
-describe('getPluginFile', () => {
-	it('should return the path to the plugin file if it exists', () => {
-		const pluginFilePath = getPluginFile(path.join(modesPath, 'plugin'));
-		expect(pluginFilePath).toEqual(
-			path.join('plugin', 'sample-plugin.php')
-		);
-	});
+describe( 'getPluginFile', () => {
+	it( 'should return the path to the plugin file if it exists', () => {
+		const pluginFilePath = getPluginFile( path.join( modesPath, 'plugin' ) );
+		expect( pluginFilePath ).toEqual( path.join( 'plugin', 'sample-plugin.php' ) );
+	} );
 
-	it('should return null if no plugin file is found', () => {
-		const pluginFilePath = getPluginFile(
-			path.join(modesPath, 'not-plugin')
-		);
-		expect(pluginFilePath).toBeNull();
-	});
+	it( 'should return null if no plugin file is found', () => {
+		const pluginFilePath = getPluginFile( path.join( modesPath, 'not-plugin' ) );
+		expect( pluginFilePath ).toBeNull();
+	} );
 
-	it('should handle non-existing directories', () => {
-		expect(() =>
-			getPluginFile(path.resolve('non-existing'))
-		).toThrowError();
-	});
-});
+	it( 'should handle non-existing directories', () => {
+		expect( () => getPluginFile( path.resolve( 'non-existing' ) ) ).toThrowError();
+	} );
+} );

--- a/vendor/wp-now/src/wp-playground-wordpress/tests/is-valid-wordpress-version.test.ts
+++ b/vendor/wp-now/src/wp-playground-wordpress/tests/is-valid-wordpress-version.test.ts
@@ -3,15 +3,15 @@
  */
 import { isValidWordPressVersion } from '../is-valid-wordpress-version';
 
-test('isValidWordPressVersion', () => {
+test( 'isValidWordPressVersion', () => {
 	// Accepted versions
 	// Check https://wordpress.org/download/releases/
-	expect(isValidWordPressVersion('latest')).toBe(true);
-	expect(isValidWordPressVersion('6.2')).toBe(true);
-	expect(isValidWordPressVersion('6.0.1')).toBe(true);
-	expect(isValidWordPressVersion('6.2-beta1')).toBe(true);
-	expect(isValidWordPressVersion('6.2-RC1')).toBe(true);
+	expect( isValidWordPressVersion( 'latest' ) ).toBe( true );
+	expect( isValidWordPressVersion( '6.2' ) ).toBe( true );
+	expect( isValidWordPressVersion( '6.0.1' ) ).toBe( true );
+	expect( isValidWordPressVersion( '6.2-beta1' ) ).toBe( true );
+	expect( isValidWordPressVersion( '6.2-RC1' ) ).toBe( true );
 	// Rejected versions
-	expect(isValidWordPressVersion('v6.2')).toBe(false);
-	expect(isValidWordPressVersion('6.2-rc1')).toBe(false);
-});
+	expect( isValidWordPressVersion( 'v6.2' ) ).toBe( false );
+	expect( isValidWordPressVersion( '6.2-rc1' ) ).toBe( false );
+} );

--- a/vendor/wp-now/vite.config.ts
+++ b/vendor/wp-now/vite.config.ts
@@ -8,14 +8,14 @@ import { defineConfig } from 'vite';
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import { viteTsConfigPaths } from '../vite-ts-config-paths';
 
-export default defineConfig(() => {
+export default defineConfig( () => {
 	return {
 		cacheDir: '../../node_modules/.vite/wp-now',
 
 		plugins: [
-			viteTsConfigPaths({
+			viteTsConfigPaths( {
 				root: '../../',
-			}),
+			} ),
 		],
 
 		test: {
@@ -24,7 +24,7 @@ export default defineConfig(() => {
 				dir: '../../node_modules/.vitest',
 			},
 			environment: 'jsdom',
-			include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+			include: [ 'src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}' ],
 		},
 	};
-});
+} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to https://github.com/Automattic/studio/pull/510#discussion_r1764625483 and https://github.com/Automattic/local-environment/pull/198#discussion_r1540910017.

## Proposed Changes

`wp-now` files were ignored in Prettier until we made a decision on what formatting to use (they are formatted with [this configuration](https://github.com/WordPress/playground-tools/blob/trunk/.prettierrc)). My proposal is to use the [same Prettier configuration we have in the project](https://github.com/Automattic/studio/blob/trunk/.prettierrc). However, this implies updating most of the files.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- This PR only re-formats the files so it shouldn't produce any change in the logic. Hence, we don't need to test anything specifically, we could simply run a short smoke test.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
