### PR TITLE
Allow opening relative paths returned by the assistant in the user's IDE

### DIFF
--- a/src/components/assistant-code-block.tsx
+++ b/src/components/assistant-code-block.tsx
@@ -5,7 +5,6 @@ import { useCallback, useEffect, useState } from 'react';
 import { ExtraProps } from 'react-markdown';
 import stripAnsi from 'strip-ansi';
 import { Message as MessageType } from '../hooks/use-assistant';
-import { useCheckInstalledApps } from '../hooks/use-check-installed-apps';
 import { useExecuteWPCLI } from '../hooks/use-execute-cli';
 import { useIsValidWpCliInline } from '../hooks/use-is-valid-wp-cli-inline';
 import { cx } from '../lib/cx';
@@ -97,20 +96,14 @@ function FileBlock( props: ContextProps & CodeBlockProps ) {
 	const { children, className, node, blocks, updateMessage, siteId, messageId, ...htmlAttributes } =
 		props;
 	const content = String( children ).trim();
-	const installedApps = useCheckInstalledApps();
 	const [ filePath, setFilePath ] = useState( '' );
 
 	const openFileInIDE = useCallback( () => {
-		if ( ! filePath ) {
+		if ( ! siteId || ! filePath ) {
 			return;
 		}
-		const { vscode, phpstorm } = installedApps;
-		if ( vscode ) {
-			getIpcApi().openURL( `vscode://file/${ filePath }?windowId=_blank` );
-		} else if ( phpstorm ) {
-			getIpcApi().openURL( `phpstorm://open?file=${ filePath }` );
-		}
-	}, [ installedApps, filePath ] );
+		getIpcApi().openFileInIDE( content, siteId );
+	}, [ siteId, filePath, content ] );
 
 	useEffect( () => {
 		if ( ! siteId || ! content ) {

--- a/src/components/assistant-code-block.tsx
+++ b/src/components/assistant-code-block.tsx
@@ -128,7 +128,7 @@ function FileBlock( props: ContextProps & CodeBlockProps ) {
 	return (
 		<code
 			{ ...htmlAttributes }
-			className={ cx( className, filePath && 'cursor-pointer !text-a8c-blueberry' ) }
+			className={ cx( className, filePath && 'file-block' ) }
 			onClick={ openFileInIDE }
 		>
 			{ children }

--- a/src/components/assistant-code-block.tsx
+++ b/src/components/assistant-code-block.tsx
@@ -143,7 +143,6 @@ function CodeBlock( props: ContextProps & CodeBlockProps ) {
 	const { node, blocks, updateMessage, siteId, messageId, ...htmlAttributes } = props;
 
 	const isFilePath = ( content: string ) => {
-		const wpPaths = [ 'wp-content', 'wp-includes', 'wp-admin' ];
 		const fileExtensions = [
 			'.js',
 			'.css',
@@ -164,10 +163,7 @@ function CodeBlock( props: ContextProps & CodeBlockProps ) {
 			'.env',
 			'.sql',
 		];
-		return (
-			wpPaths.some( ( path ) => content.startsWith( path ) || content.startsWith( '/' + path ) ) ||
-			fileExtensions.some( ( ext ) => content.toLowerCase().endsWith( ext ) )
-		);
+		return fileExtensions.some( ( ext ) => content.toLowerCase().endsWith( ext ) );
 	};
 
 	const inferContentType = () => {

--- a/src/components/assistant-code-block.tsx
+++ b/src/components/assistant-code-block.tsx
@@ -1,5 +1,6 @@
 import { Spinner } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { Icon, edit } from '@wordpress/icons';
 import { useCallback, useEffect, useState } from 'react';
 import { ExtraProps } from 'react-markdown';
 import stripAnsi from 'strip-ansi';
@@ -131,6 +132,7 @@ function FileBlock( props: ContextProps & CodeBlockProps ) {
 			onClick={ openFileInIDE }
 		>
 			{ children }
+			{ filePath && <Icon icon={ edit } className="rtl:scale-x-[-1]" size={ 16 } /> }
 		</code>
 	);
 }

--- a/src/components/tests/assistant-code-block.test.tsx
+++ b/src/components/tests/assistant-code-block.test.tsx
@@ -197,9 +197,7 @@ describe( 'createCodeComponent', () => {
 
 			await waitFor( () => {
 				expect( screen.getByText( 'wp-content/plugins/hello.php' ) ).toBeVisible();
-				expect( screen.getByText( 'wp-content/plugins/hello.php' ) ).toHaveClass(
-					'cursor-pointer'
-				);
+				expect( screen.getByText( 'wp-content/plugins/hello.php' ) ).toHaveClass( 'file-block' );
 			} );
 
 			fireEvent.click( screen.getByText( 'wp-content/plugins/hello.php' ) );
@@ -219,7 +217,7 @@ describe( 'createCodeComponent', () => {
 
 			await waitFor( () => {
 				expect( screen.getByText( 'wp-content/debug.log' ) ).toBeVisible();
-				expect( screen.getByText( 'wp-content/debug.log' ) ).not.toHaveClass( 'cursor-pointer' );
+				expect( screen.getByText( 'wp-content/debug.log' ) ).not.toHaveClass( 'file-block' );
 			} );
 
 			fireEvent.click( screen.getByText( 'wp-content/debug.log' ) );

--- a/src/index.css
+++ b/src/index.css
@@ -146,6 +146,20 @@ blockquote {
 	border-radius: 2px;
 }
 
+.assistant-markdown code.file-block {
+	color: theme( 'colors.a8c-blueberry' );
+	fill: theme( 'colors.a8c-blueberry' );
+	display: inline-flex;
+	align-items: center;
+	padding: 0 0 0 3px;
+	cursor: pointer;
+}
+
+.assistant-markdown code.file-block:hover {
+	color: theme( 'colors.a8c-blueberry-70' );
+	fill: theme( 'colors.a8c-blueberry-70' );
+}
+
 .assistant-markdown pre {
 	background-color: theme( 'colors.a8c-gray.90' );
 	border-radius: 5px;

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -739,3 +739,21 @@ export function toggleMinWindowWidth( event: IpcMainInvokeEvent, isSidebarVisibl
 	);
 	parentWindow.setSize( newWidth, currentHeight, true );
 }
+
+/**
+ * Returns the absolute path of a file in the site's directory.
+ * Returns null if the file does not exist.
+ */
+export async function getAbsolutePathFromSite(
+	_event: IpcMainInvokeEvent,
+	siteId: string,
+	relativePath: string
+): Promise< string | null > {
+	const server = SiteServer.get( siteId );
+	if ( ! server ) {
+		throw new Error( 'Site not found.' );
+	}
+
+	const path = nodePath.join( server.details.path, relativePath );
+	return ( await pathExists( path ) ) ? path : null;
+}

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -757,3 +757,32 @@ export async function getAbsolutePathFromSite(
 	const path = nodePath.join( server.details.path, relativePath );
 	return ( await pathExists( path ) ) ? path : null;
 }
+
+/**
+ * Opens a file in the IDE with the site context.
+ */
+export async function openFileInIDE(
+	_event: IpcMainInvokeEvent,
+	relativePath: string,
+	siteId: string
+) {
+	const server = SiteServer.get( siteId );
+	if ( ! server ) {
+		throw new Error( 'Site not found.' );
+	}
+
+	const path = await getAbsolutePathFromSite( _event, siteId, relativePath );
+	if ( ! path ) {
+		return;
+	}
+
+	if ( isInstalled( 'vscode' ) ) {
+		// Open site first to ensure the file is opened within the site context
+		await shell.openExternal( `vscode://file/${ server.details.path }?windowId=_blank` );
+		await shell.openExternal( `vscode://file/${ path }` );
+	} else if ( isInstalled( 'phpstorm' ) ) {
+		// Open site first to ensure the file is opened within the site context
+		await shell.openExternal( `phpstorm://open?file=${ server.details.path }` );
+		await shell.openExternal( `phpstorm://open?file=${ path }` );
+	}
+}

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -782,7 +782,6 @@ export async function openFileInIDE(
 		await shell.openExternal( `vscode://file/${ path }` );
 	} else if ( isInstalled( 'phpstorm' ) ) {
 		// Open site first to ensure the file is opened within the site context
-		await shell.openExternal( `phpstorm://open?file=${ server.details.path }` );
 		await shell.openExternal( `phpstorm://open?file=${ path }` );
 	}
 }

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -72,6 +72,8 @@ const api: IpcApi = {
 	resetDefaultLocaleData: () => ipcRenderer.invoke( 'resetDefaultLocaleData' ),
 	toggleMinWindowWidth: ( isSidebarVisible: boolean ) =>
 		ipcRenderer.invoke( 'toggleMinWindowWidth', isSidebarVisible ),
+	getAbsolutePathFromSite: ( siteId: string, relativePath: string ) =>
+		ipcRenderer.invoke( 'getAbsolutePathFromSite', siteId, relativePath ),
 };
 
 contextBridge.exposeInMainWorld( 'ipcApi', api );

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -74,6 +74,8 @@ const api: IpcApi = {
 		ipcRenderer.invoke( 'toggleMinWindowWidth', isSidebarVisible ),
 	getAbsolutePathFromSite: ( siteId: string, relativePath: string ) =>
 		ipcRenderer.invoke( 'getAbsolutePathFromSite', siteId, relativePath ),
+	openFileInIDE: ( relativePath: string, siteId: string ) =>
+		ipcRenderer.invoke( 'openFileInIDE', relativePath, siteId ),
 };
 
 contextBridge.exposeInMainWorld( 'ipcApi', api );

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -126,7 +126,11 @@ for ( const [ key, value ] of Object.entries( palette.colors ) ) {
 	}
 	a8cToTailwindColors[ colorName ][ shade ] = value;
 }
-a8cToTailwindColors[ `${ PREFIX }-blueberry` ] = '#3858E9';
+
+// This colors are in the palette but not included because the color name contains more than one word.
+// Reference: https://github.com/Automattic/color-studio/blob/55218ffdaecc770cd697639071f1d2083f744f66/dist/colors.json#L123-L187
+a8cToTailwindColors[ `${ PREFIX }-blueberry` ] = '#3858E9'; // WordPress Blue
+a8cToTailwindColors[ `${ PREFIX }-blueberry-70` ] = '#1d35b4'; // WordPress Blue 70
 
 module.exports = {
 	content: [ './src/**/*.{html,ejs,js,jsx,ts,tsx}' ],


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to 8984-gh-Automattic/dotcom-forge.

## Proposed Changes

- Expand `CodeBlock` component by adding logic to infer the content type to render. There are two options:
  1. `language`: When the content contains code of a specific programming language. This will render the component `LanguageBlock` which might display actions like running the code.
  2. `file`: When the content represents a potential file path. This will render the component `File` that might allow opening the file in an IDE if the file exists.
  3. Other content: This will be rendered without any extra UI.
- Add unit tests to cover the new functionality.

![image](https://github.com/user-attachments/assets/2b409251-7e97-458c-8eff-505c7ebecfb1)

![image](https://github.com/user-attachments/assets/9120eca5-2789-4f54-a48e-8b8efff46015)


> [!IMPORTANT]
> I'm using the color `a8c-blueberry` when the file can be opened. However, there might be contrast issues depending on the code format that comes in the response. @matt-west I'd appreciate if you could take a look and share thoughts/feedback on this. Thanks 🙇 ! **UPDATE:** This has been solved in https://github.com/Automattic/studio/pull/549/commits/764e2865c2e45037130aa9f4603736d54292824f.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

> [!NOTE]
> I experienced performance issues when having several Assistant messages and typing in the input field. This will be addressed in a separate PR.

- Run the app with the command `npm start`.
- Log in to WPCOM with a A8C account.
- Navigate to the Assistant tab.
- Submit a prompt that will produce a response with references to files (e.g. `How can I enable debug logs in the site?`).
- Observe that the Assistant's response contains file path references.
- Observe that some of the file path references can be clicked (only the ones associated with existing files in the site).
- Click on one that references a file.
- Observe that the file is opened in an installed IDE (VSCode or PHPStorm).
- Click on one that references a directory.
- Observe that the directory is opened in the Finder/File Explorer.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
