### PR TITLE
Improve performance of Assistant tab

### DIFF
--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -343,7 +343,10 @@ export function ContentTabAssistant( { selectedSite }: ContentTabAssistantProps 
 
 	const handleSend = useCallback(
 		async ( messageToSend?: string, isRetry?: boolean ) => {
-			const chatMessage = messageToSend || input;
+			const chatMessage = messageToSend || inputRef.current?.value;
+			if ( ! chatMessage ) {
+				return;
+			}
 			let messageId;
 			if ( chatMessage.trim() ) {
 				if ( isRetry ) {
@@ -384,15 +387,7 @@ export function ContentTabAssistant( { selectedSite }: ContentTabAssistantProps 
 				}
 			}
 		},
-		[
-			addMessage,
-			chatId,
-			currentSiteChatContext,
-			fetchAssistant,
-			input,
-			markMessageAsFailed,
-			messages,
-		]
+		[ addMessage, chatId, currentSiteChatContext, fetchAssistant, markMessageAsFailed, messages ]
 	);
 
 	const handleKeyDown = ( e: React.KeyboardEvent< HTMLTextAreaElement > ) => {

--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -341,48 +341,59 @@ export function ContentTabAssistant( { selectedSite }: ContentTabAssistantProps 
 	const lastMessage = messages.length === 0 ? undefined : messages[ messages.length - 1 ];
 	const hasFailedMessage = messages.some( ( msg ) => msg.failedMessage );
 
-	const handleSend = async ( messageToSend?: string, isRetry?: boolean ) => {
-		const chatMessage = messageToSend || input;
-		let messageId;
-		if ( chatMessage.trim() ) {
-			if ( isRetry ) {
-				// If retrying, find the message ID with failedMessage flag
-				const failedMessage = messages.find(
-					( msg ) => msg.failedMessage && msg.content === chatMessage
-				);
-				if ( failedMessage ) {
-					messageId = failedMessage.id;
+	const handleSend = useCallback(
+		async ( messageToSend?: string, isRetry?: boolean ) => {
+			const chatMessage = messageToSend || input;
+			let messageId;
+			if ( chatMessage.trim() ) {
+				if ( isRetry ) {
+					// If retrying, find the message ID with failedMessage flag
+					const failedMessage = messages.find(
+						( msg ) => msg.failedMessage && msg.content === chatMessage
+					);
+					if ( failedMessage ) {
+						messageId = failedMessage.id;
+						if ( typeof messageId !== 'undefined' ) {
+							markMessageAsFailed( messageId, false );
+						}
+					}
+				} else {
+					messageId = addMessage( chatMessage, 'user', chatId ); // Get the new message ID
+					setInput( '' );
+				}
+				try {
+					const {
+						message,
+						chatId: fetchedChatId,
+						messageApiId,
+					} = await fetchAssistant(
+						chatId,
+						[
+							...messages,
+							{ id: messageId, content: chatMessage, role: 'user', createdAt: Date.now() },
+						],
+						currentSiteChatContext
+					);
+					if ( message ) {
+						addMessage( message, 'assistant', chatId ?? fetchedChatId, messageApiId );
+					}
+				} catch ( error ) {
 					if ( typeof messageId !== 'undefined' ) {
-						markMessageAsFailed( messageId, false );
+						markMessageAsFailed( messageId, true );
 					}
 				}
-			} else {
-				messageId = addMessage( chatMessage, 'user', chatId ); // Get the new message ID
-				setInput( '' );
 			}
-			try {
-				const {
-					message,
-					chatId: fetchedChatId,
-					messageApiId,
-				} = await fetchAssistant(
-					chatId,
-					[
-						...messages,
-						{ id: messageId, content: chatMessage, role: 'user', createdAt: Date.now() },
-					],
-					currentSiteChatContext
-				);
-				if ( message ) {
-					addMessage( message, 'assistant', chatId ?? fetchedChatId, messageApiId );
-				}
-			} catch ( error ) {
-				if ( typeof messageId !== 'undefined' ) {
-					markMessageAsFailed( messageId, true );
-				}
-			}
-		}
-	};
+		},
+		[
+			addMessage,
+			chatId,
+			currentSiteChatContext,
+			fetchAssistant,
+			input,
+			markMessageAsFailed,
+			messages,
+		]
+	);
 
 	const handleKeyDown = ( e: React.KeyboardEvent< HTMLTextAreaElement > ) => {
 		if ( e.key === 'Enter' ) {

--- a/src/hooks/use-assistant.ts
+++ b/src/hooks/use-assistant.ts
@@ -23,6 +23,7 @@ export type MessageDict = { [ key: string ]: Message[] };
 export type ChatIdDict = { [ key: string ]: string | undefined };
 
 const chatIdStoreKey = 'ai_chat_ids';
+const EMPTY_MESSAGES: Message[] = [];
 
 export const useAssistant = ( instanceId: string ) => {
 	const [ messagesDict, setMessagesDict ] = useState< MessageDict >( {} );
@@ -191,7 +192,7 @@ export const useAssistant = ( instanceId: string ) => {
 	}, [ instanceId ] );
 
 	return {
-		messages: messagesDict[ instanceId ] || [],
+		messages: messagesDict[ instanceId ] || EMPTY_MESSAGES,
 		addMessage,
 		updateMessage,
 		clearMessages,

--- a/src/hooks/use-send-feedback.ts
+++ b/src/hooks/use-send-feedback.ts
@@ -1,4 +1,5 @@
 import * as Sentry from '@sentry/electron/renderer';
+import { useCallback } from 'react';
 import { useAuth } from './use-auth';
 
 interface SendFeedbackParams {
@@ -11,24 +12,27 @@ export const useSendFeedback = () => {
 	const { client } = useAuth();
 	const studioBotId = 'wpcom-studio-chat';
 
-	const sendFeedback = async ( { chatId, messageId, ratingValue }: SendFeedbackParams ) => {
-		if ( ! client?.req ) {
-			return;
-		}
+	const sendFeedback = useCallback(
+		async ( { chatId, messageId, ratingValue }: SendFeedbackParams ) => {
+			if ( ! client?.req ) {
+				return;
+			}
 
-		try {
-			await client.req.post( {
-				path: `/odie/chat/${ studioBotId }/${ chatId }/${ messageId }/feedback`,
-				apiNamespace: 'wpcom/v2',
-				body: {
-					rating_value: ratingValue,
-				},
-			} );
-		} catch ( error ) {
-			Sentry.captureException( error );
-			console.error( error );
-		}
-	};
+			try {
+				await client.req.post( {
+					path: `/odie/chat/${ studioBotId }/${ chatId }/${ messageId }/feedback`,
+					apiNamespace: 'wpcom/v2',
+					body: {
+						rating_value: ratingValue,
+					},
+				} );
+			} catch ( error ) {
+				Sentry.captureException( error );
+				console.error( error );
+			}
+		},
+		[ client ]
+	);
 
 	return sendFeedback;
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to https://github.com/Automattic/studio/pull/549 (this issue was spotted while testing that PR) and https://github.com/Automattic/dotcom-forge/issues/9207.

## Proposed Changes

- While testing https://github.com/Automattic/studio/pull/549, I noticed that typing in the Assistant input field caused performance degradation. After debugging the code, I realized that it was caused by a high amount of re-renders of the Assistant tab. The component `AuthenticatedView` is already memorized to avoid re-renders, but still, I identified the following props to be the culprit of the re-renders:
    - [`handleSend`](https://github.com/Automattic/studio/blob/8e6816e2ba015c7013e681d63f9c359369df01eb/src/components/content-tab-assistant.tsx#L344-L385) (in `components/content-tab-assistant.tsx`)
    - [`markMessageAsFeedbackReceived`](https://github.com/Automattic/studio/blob/8e6816e2ba015c7013e681d63f9c359369df01eb/src/hooks/use-assistant.ts#L142-L176) (in `hooks/use-assistant.ts`)
- Memoize `handleSend` with `useCallback`.
- Rely on input ref to obtain the value to send in `handleSend` function, instead of the `input` state value. Otherwise, the function is re-generated when typing in the input field.
- `markMessageAsFeedbackReceived` is already memorized but it was being re-generated due to the function `sendFeedback` from the `useSendFeedback` hook. This functional has been memorized with `useCallback`.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Apply the following patch:
```patch
diff --git forkSrcPrefix/src/components/content-tab-assistant.tsx forkDstPrefix/src/components/content-tab-assistant.tsx
index b88c72b761daefb4994af61496e3de9bc3945e95..4789b236e88f4312bd3eca4a258b785d296405f1 100644
--- forkSrcPrefix/src/components/content-tab-assistant.tsx
+++ forkDstPrefix/src/components/content-tab-assistant.tsx
@@ -123,6 +123,7 @@ export const AuthenticatedView = memo(
 		handleSend,
 		markMessageAsFeedbackReceived,
 	}: AuthenticatedViewProps ) => {
+		console.log( 'rendering AuthenticatedView' );
 		const endOfMessagesRef = useRef< HTMLDivElement >( null );
 		const [ showThinking, setShowThinking ] = useState( false );
 		const lastMessage = useMemo(

```
- Run the app with the command `npm start`.
- Open the DevTools.
- Log in to WPCOM with an A8C account.
- Navigate to the Assitant tab.
- Focus on the input field.
- Type some letters.
- Observe that no extra logs are recorded when typing.
- Type quickly several words.
- Observe that the app slows down.
- Submit a request.
- Check the network request made to `wpcom/v2/studio-app/ai-assistant/chat`.
- Observe in the request payload that the `messages` field contains the full prompt.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
