### PR TITLE
Enable React Devtools

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -85,6 +85,7 @@
 				"css-loader": "^6.0.0",
 				"ejs": "^3.1.10",
 				"electron": "29.1.0",
+				"electron-devtools-installer": "^3.2.0",
 				"electron-playwright-helpers": "^1.7.0",
 				"eslint": "^8.0.1",
 				"eslint-config-prettier": "^9.1.0",
@@ -11075,6 +11076,18 @@
 				"node": ">= 12.20.55"
 			}
 		},
+		"node_modules/electron-devtools-installer": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/electron-devtools-installer/-/electron-devtools-installer-3.2.0.tgz",
+			"integrity": "sha512-t3UczsYugm4OAbqvdImMCImIMVdFzJAHgbwHpkl5jmfu1izVgUcP/mnrPqJIpEeCK1uZGpt+yHgWEN+9EwoYhQ==",
+			"dev": true,
+			"dependencies": {
+				"rimraf": "^3.0.2",
+				"semver": "^7.2.1",
+				"tslib": "^2.1.0",
+				"unzip-crx-3": "^0.2.0"
+			}
+		},
 		"node_modules/electron-installer-common": {
 			"version": "0.10.3",
 			"resolved": "https://registry.npmjs.org/electron-installer-common/-/electron-installer-common-0.10.3.tgz",
@@ -14089,6 +14102,12 @@
 				"node": ">=6.9.0"
 			}
 		},
+		"node_modules/immediate": {
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+			"integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+			"dev": true
+		},
 		"node_modules/import-fresh": {
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -16067,6 +16086,48 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/jszip": {
+			"version": "3.10.1",
+			"resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+			"integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+			"dev": true,
+			"dependencies": {
+				"lie": "~3.3.0",
+				"pako": "~1.0.2",
+				"readable-stream": "~2.3.6",
+				"setimmediate": "^1.0.5"
+			}
+		},
+		"node_modules/jszip/node_modules/isarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+			"dev": true
+		},
+		"node_modules/jszip/node_modules/readable-stream": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+			"integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+			"dev": true,
+			"dependencies": {
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.3",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~2.0.0",
+				"safe-buffer": "~5.1.1",
+				"string_decoder": "~1.1.1",
+				"util-deprecate": "~1.0.1"
+			}
+		},
+		"node_modules/jszip/node_modules/string_decoder": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+			"dev": true,
+			"dependencies": {
+				"safe-buffer": "~5.1.0"
+			}
+		},
 		"node_modules/junk": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/junk/-/junk-3.1.0.tgz",
@@ -16180,6 +16241,15 @@
 			},
 			"engines": {
 				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/lie": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+			"integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+			"dev": true,
+			"dependencies": {
+				"immediate": "~3.0.5"
 			}
 		},
 		"node_modules/lilconfig": {
@@ -18519,6 +18589,12 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.0.tgz",
 			"integrity": "sha512-dATvCeZN/8wQsGywez1mzHtTlP22H8OEfPrVMLNr4/eGa+ijtLn/6M5f0dY8UKNrC2O9UCU6SSoG3qRKnt7STw=="
+		},
+		"node_modules/pako": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+			"integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+			"dev": true
 		},
 		"node_modules/param-case": {
 			"version": "3.0.4",
@@ -22632,6 +22708,29 @@
 				"webpack-virtual-modules": "^0.5.0"
 			}
 		},
+		"node_modules/unzip-crx-3": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/unzip-crx-3/-/unzip-crx-3-0.2.0.tgz",
+			"integrity": "sha512-0+JiUq/z7faJ6oifVB5nSwt589v1KCduqIJupNVDoWSXZtWDmjDGO3RAEOvwJ07w90aoXoP4enKsR7ecMrJtWQ==",
+			"dev": true,
+			"dependencies": {
+				"jszip": "^3.1.0",
+				"mkdirp": "^0.5.1",
+				"yaku": "^0.16.6"
+			}
+		},
+		"node_modules/unzip-crx-3/node_modules/mkdirp": {
+			"version": "0.5.6",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+			"integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+			"dev": true,
+			"dependencies": {
+				"minimist": "^1.2.6"
+			},
+			"bin": {
+				"mkdirp": "bin/cmd.js"
+			}
+		},
 		"node_modules/unzipper": {
 			"version": "0.10.11",
 			"resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.10.11.tgz",
@@ -23639,6 +23738,12 @@
 			"engines": {
 				"node": ">=10"
 			}
+		},
+		"node_modules/yaku": {
+			"version": "0.16.7",
+			"resolved": "https://registry.npmjs.org/yaku/-/yaku-0.16.7.tgz",
+			"integrity": "sha512-Syu3IB3rZvKvYk7yTiyl1bo/jiEFaaStrgv1V2TIJTqYPStSMQVO8EQjg/z+DRzLq/4LIIharNT3iH1hylEIRw==",
+			"dev": true
 		},
 		"node_modules/yallist": {
 			"version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
 		"css-loader": "^6.0.0",
 		"ejs": "^3.1.10",
 		"electron": "29.1.0",
+		"electron-devtools-installer": "^3.2.0",
 		"electron-playwright-helpers": "^1.7.0",
 		"eslint": "^8.0.1",
 		"eslint-config-prettier": "^9.1.0",

--- a/src/main-window.ts
+++ b/src/main-window.ts
@@ -1,4 +1,5 @@
 import { BrowserWindow, type BrowserWindowConstructorOptions } from 'electron';
+import installExtension, { REACT_DEVELOPER_TOOLS } from 'electron-devtools-installer';
 import { moveDatabasesInSitu } from '../vendor/wp-now/src';
 import {
 	DEFAULT_WIDTH,
@@ -24,6 +25,7 @@ let mainWindow: BrowserWindow | null;
 function setupDevTools( mainWindow: BrowserWindow | null, devToolsOpen?: boolean ) {
 	if ( devToolsOpen || ( process.env.NODE_ENV === 'development' && devToolsOpen === undefined ) ) {
 		mainWindow?.webContents.openDevTools();
+		installExtension( REACT_DEVELOPER_TOOLS );
 	}
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Proposed Changes

- Install React Devtools to enable inspecting components and profiling the performance of the app.

<img width="1245" alt="Captura de pantalla 2024-09-23 a las 13 57 30" src="https://github.com/user-attachments/assets/23252044-242b-406f-beca-4558c3941021">


> [!NOTE]
> The React Devtools don't show up when starting the app due to a known bug (https://github.com/MarshallOfSound/electron-devtools-installer/issues/244). They appear when making a change in the code (i.e. when hot-reloading is triggered) or by reloading manually the window.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Start the app with the command `npm start`.
- Observe the Devtools window is shown.
- Focus on the Studio app and reload the window with `Command-R` or menu item `View->Reload`.
- Observe the React Components and Profile tabs show up in the Devtools.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
