### PR TITLE
Override default `umask` in PHP

### DIFF
--- a/vendor/wp-now/src/wp-now.ts
+++ b/vendor/wp-now/src/wp-now.ts
@@ -115,6 +115,8 @@ export default async function startWPNow(
 
 	// Setup internal plugins needed for Playground
 	await setupPlatformLevelMuPlugins( php );
+	// Add custom plugins needed for Studio sites
+	addDefaultUmaskPlugin( php, options.documentRoot );
 
 	rotatePHPRuntime( {
 		php,
@@ -569,4 +571,16 @@ export async function moveDatabasesInSitu( projectPath: string ) {
 		fs.copySync( path.join( getSqlitePath(), 'db.copy' ), dbPhpPath );
 		fs.rmSync( wpContentPath, { recursive: true, force: true } );
 	}
+}
+
+function addDefaultUmaskPlugin( php: PHP, documentRoot: string ) {
+	php.writeFile(
+		'/internal/shared/mu-plugins/override-default-umask.php',
+		`<?php
+function set_default_umask()
+{
+    umask(0022);
+}
+add_action('init', 'set_default_umask', -9999);`
+	);
 }

--- a/vendor/wp-now/src/wp-now.ts
+++ b/vendor/wp-now/src/wp-now.ts
@@ -8,7 +8,11 @@ import {
 	rotatePHPRuntime,
 	setPhpIniEntries,
 } from '@php-wasm/universal';
-import { wordPressRewriteRules, getFileNotFoundActionForWordPress } from '@wp-playground/wordpress';
+import {
+	wordPressRewriteRules,
+	getFileNotFoundActionForWordPress,
+	setupPlatformLevelMuPlugins,
+} from '@wp-playground/wordpress';
 import path from 'path';
 import { SQLITE_FILENAME } from './constants';
 import { rootCertificates } from 'tls';
@@ -108,6 +112,9 @@ export default async function startWPNow(
 	if ( isFirstTimeProject && [ WPNowMode.PLUGIN, WPNowMode.THEME ].includes( options.mode ) ) {
 		await activatePluginOrTheme( php, options );
 	}
+
+	// Setup internal plugins needed for Playground
+	await setupPlatformLevelMuPlugins( php );
 
 	rotatePHPRuntime( {
 		php,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to 8816-gh-Automattic/dotcom-forge.

## Proposed Changes

- The original issue needs to be fixed in Emscripten. There's already [a PR](https://github.com/emscripten-core/emscripten/pull/22589) to address it but it will take time until the changes will be incorporated in the app, as we'll need to wait for new Emscripten and Playground versions.
- ~~In the meantime, we'll create an internal plugin that will override the default `umask` value. Note that this plugin is located in a special folder managed by Playground for platform-level-specific plugins.~~
- As a temporary workaround, we'll override the default `umask` value by pretending a PHP file using the `auto_prepend_file` PHP directive.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Create files with test file

- Run the app with the command `npm start`.
- Create a new site or select one already created.
- Create the file `test.php`, at the root level on the site, with the following content:
```php
<?php
// Create file with default umask
$filename = "example-default-umask.txt";
$current_umask = umask();
    echo sprintf("Current umask: %04o<br>", $current_umask);
    $content = 'This is the content of the file.';
if (file_exists($filename)) {
    unlink($filename);
}
if (file_put_contents($filename, $content) !== false) {
    echo "File '$filename' created successfully.<br>";
} else {
    echo "Error creating file '$filename'.<br>";
}
chmod($filename, 0777 - umask());
```
- Start the site.
- Navigate to the PHP file: `http://localhost:<PORT>/test.php`.
- Observe the `umask` value shown on the page is `0022`.
- Navigate to the site folder.
- Observe that the permissions of the file are `rwxr-xr-x` (Full access to owner, and only READ and EXECUTE permissions to group and others).

### Addresses https://github.com/Automattic/studio/issues/269

- Start the app with command `npm start`.
- Create a new site.
- Change the PHP version to 8.2.
- Click on the Terminal button.
- In the terminal:
  - Run `cd wp-content/themes`.
  - Run `git clone https://github.com/DevArge/sage-vite.git`.
  - Run `cd sage-vite`.
  - Run `yarn install && composer install && yarn build`.
- Back in the Studio app, start the site.
- Navigate to WP-Admin dashboard.
- Navigate to Appearance -> Themes.
- Activate the Sage Vite theme.
- Observe that no errors are thrown and the site is working as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
