### PR TITLE
Restore the Assistant chat input per site

### DIFF
--- a/src/components/ai-clear-history-reminder.tsx
+++ b/src/components/ai-clear-history-reminder.tsx
@@ -8,10 +8,10 @@ import Button from './button';
 
 function AIClearHistoryReminder( {
 	lastMessage,
-	clearInput,
+	clearConversation,
 }: {
 	lastMessage?: MessageType;
-	clearInput: () => void;
+	clearConversation: () => void;
 } ) {
 	const [ showReminder, setShowReminder ] = useState( false );
 	const timeoutId = useRef< NodeJS.Timeout >();
@@ -54,7 +54,7 @@ function AIClearHistoryReminder( {
 
 	const onClearHistory = useCallback( async () => {
 		if ( localStorage.getItem( 'dontShowClearMessagesWarning' ) === 'true' ) {
-			clearInput();
+			clearConversation();
 			return;
 		}
 
@@ -73,9 +73,9 @@ function AIClearHistoryReminder( {
 				localStorage.setItem( 'dontShowClearMessagesWarning', 'true' );
 			}
 
-			clearInput();
+			clearConversation();
 		}
-	}, [ clearInput ] );
+	}, [ clearConversation ] );
 
 	if ( ! showReminder ) {
 		return null;

--- a/src/components/ai-input.tsx
+++ b/src/components/ai-input.tsx
@@ -12,7 +12,7 @@ interface AIInputProps {
 	setInput: ( input: string ) => void;
 	handleSend: () => void;
 	handleKeyDown: ( e: React.KeyboardEvent< HTMLTextAreaElement > ) => void;
-	clearInput: () => void;
+	clearConversation: () => void;
 	isAssistantThinking: boolean;
 }
 
@@ -25,7 +25,7 @@ const UnforwardedAIInput = (
 		setInput,
 		handleSend,
 		handleKeyDown,
-		clearInput,
+		clearConversation,
 		isAssistantThinking,
 	}: AIInputProps,
 	inputRef: React.RefObject< HTMLTextAreaElement > | React.RefCallback< HTMLTextAreaElement > | null
@@ -139,7 +139,7 @@ const UnforwardedAIInput = (
 
 	const handleClearConversation = async () => {
 		if ( localStorage.getItem( 'dontShowClearMessagesWarning' ) === 'true' ) {
-			clearInput();
+			clearConversation();
 			return;
 		}
 
@@ -158,7 +158,7 @@ const UnforwardedAIInput = (
 				localStorage.setItem( 'dontShowClearMessagesWarning', 'true' );
 			}
 
-			clearInput();
+			clearConversation();
 		}
 	};
 

--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -12,6 +12,7 @@ import { useAssistant, Message as MessageType } from '../hooks/use-assistant';
 import { useAssistantApi } from '../hooks/use-assistant-api';
 import { useAuth } from '../hooks/use-auth';
 import { useChatContext } from '../hooks/use-chat-context';
+import { useChatInputContext } from '../hooks/use-chat-input';
 import { useOffline } from '../hooks/use-offline';
 import { usePromptUsage } from '../hooks/use-prompt-usage';
 import { useWelcomeMessages } from '../hooks/use-welcome-messages';
@@ -33,10 +34,10 @@ interface ContentTabAssistantProps {
 }
 
 const ErrorNotice = ( {
-	handleSend,
+	submitPrompt,
 	messageContent,
 }: {
-	handleSend: ( messageToSend?: string, isRetry?: boolean ) => void;
+	submitPrompt: ( messageToSend: string, isRetry?: boolean ) => void;
 	messageContent: string;
 } ) => {
 	const { __ } = useI18n();
@@ -49,7 +50,7 @@ const ErrorNotice = ( {
 					a: (
 						<Button
 							variant="link"
-							onClick={ () => handleSend( messageContent, true ) }
+							onClick={ () => submitPrompt( messageContent, true ) }
 							className="text-xs !ml-1"
 						/>
 					),
@@ -108,7 +109,7 @@ interface AuthenticatedViewProps {
 	isAssistantThinking: boolean;
 	updateMessage: OnUpdateMessageType;
 	siteId: string;
-	handleSend: ( messageToSend?: string, isRetry?: boolean ) => void;
+	submitPrompt: ( messageToSend: string, isRetry?: boolean ) => void;
 	markMessageAsFeedbackReceived: ReturnType<
 		typeof useAssistant
 	>[ 'markMessageAsFeedbackReceived' ];
@@ -120,7 +121,7 @@ export const AuthenticatedView = memo(
 		isAssistantThinking,
 		updateMessage,
 		siteId,
-		handleSend,
+		submitPrompt,
 		markMessageAsFeedbackReceived,
 	}: AuthenticatedViewProps ) => {
 		const endOfMessagesRef = useRef< HTMLDivElement >( null );
@@ -167,11 +168,11 @@ export const AuthenticatedView = memo(
 						{ message.content }
 					</ChatMessage>
 					{ message.failedMessage && (
-						<ErrorNotice handleSend={ handleSend } messageContent={ message.content } />
+						<ErrorNotice submitPrompt={ submitPrompt } messageContent={ message.content } />
 					) }
 				</>
 			),
-			[ handleSend, siteId, updateMessage ]
+			[ submitPrompt, siteId, updateMessage ]
 		);
 
 		const RenderLastMessage = useCallback(
@@ -335,15 +336,29 @@ export function ContentTabAssistant( { selectedSite }: ContentTabAssistantProps 
 	const { userCanSendMessage } = usePromptUsage();
 	const { fetchAssistant, isLoading: isAssistantThinking } = useAssistantApi( selectedSite.id );
 	const { messages: welcomeMessages, examplePrompts } = useWelcomeMessages();
-	const [ input, setInput ] = useState< string >( '' );
+	const { getChatInput, saveChatInput } = useChatInputContext();
+	const [ currentInput, setCurrentInput ] = useState( '' );
 	const isOffline = useOffline();
 	const { __ } = useI18n();
 	const lastMessage = messages.length === 0 ? undefined : messages[ messages.length - 1 ];
 	const hasFailedMessage = messages.some( ( msg ) => msg.failedMessage );
 
-	const handleSend = useCallback(
-		async ( messageToSend?: string, isRetry?: boolean ) => {
-			const chatMessage = messageToSend || inputRef.current?.value;
+	// Restore prompt input when site changes
+	useEffect( () => {
+		setCurrentInput( getChatInput( selectedSite.id ) );
+	}, [ selectedSite.id, getChatInput ] );
+
+	// Save prompt input when it changes
+	const setInput = useCallback(
+		( input: string ) => {
+			saveChatInput( input, selectedSite.id );
+			setCurrentInput( input );
+		},
+		[ selectedSite.id, saveChatInput ]
+	);
+
+	const submitPrompt = useCallback(
+		async ( chatMessage: string, isRetry?: boolean ) => {
 			if ( ! chatMessage ) {
 				return;
 			}
@@ -387,8 +402,22 @@ export function ContentTabAssistant( { selectedSite }: ContentTabAssistantProps 
 				}
 			}
 		},
-		[ addMessage, chatId, currentSiteChatContext, fetchAssistant, markMessageAsFailed, messages ]
+		[
+			addMessage,
+			chatId,
+			currentSiteChatContext,
+			fetchAssistant,
+			markMessageAsFailed,
+			messages,
+			setInput,
+		]
 	);
+
+	// Submit prompt input when the user clicks the send button
+	const handleSend = useCallback( () => {
+		submitPrompt( inputRef.current?.value ?? '' );
+		setInput( '' );
+	}, [ submitPrompt, setInput ] );
 
 	const handleKeyDown = ( e: React.KeyboardEvent< HTMLTextAreaElement > ) => {
 		if ( e.key === 'Enter' ) {
@@ -430,7 +459,7 @@ export function ContentTabAssistant( { selectedSite }: ContentTabAssistantProps 
 						<>
 							<WelcomeComponent
 								onExampleClick={ ( prompt ) => {
-									handleSend( prompt );
+									submitPrompt( prompt );
 									inputRef.current?.focus();
 								} }
 								showExamplePrompts={ messages.length === 0 }
@@ -446,7 +475,7 @@ export function ContentTabAssistant( { selectedSite }: ContentTabAssistantProps 
 									updateMessage={ updateMessage }
 									markMessageAsFeedbackReceived={ markMessageAsFeedbackReceived }
 									siteId={ selectedSite.id }
-									handleSend={ handleSend }
+									submitPrompt={ submitPrompt }
 								/>
 							}
 						</>
@@ -462,7 +491,7 @@ export function ContentTabAssistant( { selectedSite }: ContentTabAssistantProps 
 					<AIInput
 						ref={ inputRef }
 						disabled={ disabled }
-						input={ input }
+						input={ currentInput }
 						setInput={ setInput }
 						handleSend={ handleSend }
 						handleKeyDown={ handleKeyDown }

--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -396,7 +396,7 @@ export function ContentTabAssistant( { selectedSite }: ContentTabAssistantProps 
 		}
 	};
 
-	const clearInput = () => {
+	const clearConversation = () => {
 		setInput( '' );
 		clearMessages();
 	};
@@ -408,7 +408,9 @@ export function ContentTabAssistant( { selectedSite }: ContentTabAssistantProps 
 		} else if ( isAuthenticated && ! userCanSendMessage ) {
 			return <UsageLimitReached />;
 		} else if ( isAuthenticated ) {
-			return <ClearHistoryReminder lastMessage={ lastMessage } clearInput={ clearInput } />;
+			return (
+				<ClearHistoryReminder lastMessage={ lastMessage } clearConversation={ clearConversation } />
+			);
 		}
 	};
 
@@ -464,7 +466,7 @@ export function ContentTabAssistant( { selectedSite }: ContentTabAssistantProps 
 						setInput={ setInput }
 						handleSend={ handleSend }
 						handleKeyDown={ handleKeyDown }
-						clearInput={ clearInput }
+						clearConversation={ clearConversation }
 						isAssistantThinking={ isAssistantThinking }
 					/>
 					<div data-testid="guidelines-link" className="text-a8c-gray-50 self-end py-2">

--- a/src/components/root.tsx
+++ b/src/components/root.tsx
@@ -1,4 +1,5 @@
 import { ChatProvider } from '../hooks/use-chat-context';
+import { ChatInputProvider } from '../hooks/use-chat-input';
 import { InstalledAppsProvider } from '../hooks/use-check-installed-apps';
 import { FeatureFlagsProvider } from '../hooks/use-feature-flags';
 import { I18nDataProvider } from '../hooks/use-i18n-data';
@@ -30,7 +31,9 @@ const Root = () => {
 												<PromptUsageProvider>
 													<ChatProvider>
 														<ImportExportProvider>
-															<App />
+															<ChatInputProvider>
+																<App />
+															</ChatInputProvider>
 														</ImportExportProvider>
 													</ChatProvider>
 												</PromptUsageProvider>

--- a/src/components/tests/ai-clear-history-reminder.test.tsx
+++ b/src/components/tests/ai-clear-history-reminder.test.tsx
@@ -6,13 +6,13 @@ import type { Message } from '../../hooks/use-assistant';
 jest.mock( '../../lib/get-ipc-api' );
 
 describe( 'AIClearHistoryReminder', () => {
-	let clearInput: jest.Mock;
+	let clearConversation: jest.Mock;
 	const MOCKED_TIME = 1718882159928;
 	const TWO_HOURS_DIFF = 2 * 60 * 60 * 1000;
 
 	beforeEach( () => {
 		window.HTMLElement.prototype.scrollIntoView = jest.fn();
-		clearInput = jest.fn();
+		clearConversation = jest.fn();
 		jest.clearAllMocks();
 		jest.useFakeTimers();
 		jest.setSystemTime( MOCKED_TIME );
@@ -29,7 +29,9 @@ describe( 'AIClearHistoryReminder', () => {
 			content: '',
 			role: 'assistant',
 		};
-		render( <AIClearHistoryReminder lastMessage={ message } clearInput={ clearInput } /> );
+		render(
+			<AIClearHistoryReminder lastMessage={ message } clearConversation={ clearConversation } />
+		);
 
 		expect( screen.getByText( /This conversation is over two hours old./ ) ).toBeVisible();
 	} );
@@ -44,13 +46,15 @@ describe( 'AIClearHistoryReminder', () => {
 			content: '',
 			role: 'assistant',
 		};
-		render( <AIClearHistoryReminder lastMessage={ message } clearInput={ clearInput } /> );
+		render(
+			<AIClearHistoryReminder lastMessage={ message } clearConversation={ clearConversation } />
+		);
 
 		fireEvent.click( screen.getByText( /Clear the history/ ) );
 
 		await waitFor( () => {
 			expect( getIpcApi().showMessageBox ).toHaveBeenCalledTimes( 1 );
-			expect( clearInput ).toHaveBeenCalledTimes( 1 );
+			expect( clearConversation ).toHaveBeenCalledTimes( 1 );
 		} );
 	} );
 
@@ -65,11 +69,13 @@ describe( 'AIClearHistoryReminder', () => {
 			content: '',
 			role: 'assistant',
 		};
-		render( <AIClearHistoryReminder lastMessage={ message } clearInput={ clearInput } /> );
+		render(
+			<AIClearHistoryReminder lastMessage={ message } clearConversation={ clearConversation } />
+		);
 
 		fireEvent.click( screen.getByText( /Clear the history/ ) );
 
 		expect( getIpcApi().showMessageBox ).not.toHaveBeenCalled();
-		expect( clearInput ).toHaveBeenCalledTimes( 1 );
+		expect( clearConversation ).toHaveBeenCalledTimes( 1 );
 	} );
 } );

--- a/src/components/tests/ai-input.test.tsx
+++ b/src/components/tests/ai-input.test.tsx
@@ -15,7 +15,7 @@ describe( 'AIInput Component', () => {
 	let handleSend: jest.Mock;
 	let handleKeyDown: jest.Mock;
 	let setInput: jest.Mock;
-	let clearInput: jest.Mock;
+	let clearConverstaion: jest.Mock;
 
 	const defaultProps = {
 		disabled: false,
@@ -23,7 +23,7 @@ describe( 'AIInput Component', () => {
 		setInput: jest.fn(),
 		handleSend: jest.fn(),
 		handleKeyDown: jest.fn(),
-		clearInput: jest.fn(),
+		clearConverstaion: jest.fn(),
 		isAssistantThinking: false,
 	};
 
@@ -34,7 +34,7 @@ describe( 'AIInput Component', () => {
 		handleSend = jest.fn();
 		handleKeyDown = jest.fn();
 		setInput = jest.fn();
-		clearInput = jest.fn();
+		clearConverstaion = jest.fn();
 		const inputRef = React.createRef< HTMLTextAreaElement >();
 
 		jest.clearAllMocks();
@@ -47,7 +47,7 @@ describe( 'AIInput Component', () => {
 				setInput={ setInput }
 				handleSend={ handleSend }
 				handleKeyDown={ handleKeyDown }
-				clearInput={ clearInput }
+				clearConversation={ clearConverstaion }
 				isAssistantThinking={ defaultProps.isAssistantThinking }
 			/>
 		);
@@ -101,7 +101,7 @@ describe( 'AIInput Component', () => {
 
 		await waitFor( () => {
 			expect( mockShowMessageBox ).toHaveBeenCalled();
-			expect( clearInput ).toHaveBeenCalled();
+			expect( clearConverstaion ).toHaveBeenCalled();
 		} );
 	} );
 
@@ -118,6 +118,6 @@ describe( 'AIInput Component', () => {
 		fireEvent.click( clearConversationButton );
 
 		expect( mockShowMessageBox ).not.toHaveBeenCalled();
-		expect( clearInput ).toHaveBeenCalled();
+		expect( clearConverstaion ).toHaveBeenCalled();
 	} );
 } );

--- a/src/hooks/tests/use-chat-input.test.tsx
+++ b/src/hooks/tests/use-chat-input.test.tsx
@@ -6,7 +6,7 @@ const wrapper = ( { children }: { children: ReactNode } ) => (
 	<ChatInputProvider>{ children }</ChatInputProvider>
 );
 
-describe( 'useChatInput jook', () => {
+describe( 'useChatInput hook', () => {
 	it( 'should provide default values', () => {
 		const { result } = renderHook( () => useChatInputContext(), { wrapper } );
 

--- a/src/hooks/tests/use-chat-input.test.tsx
+++ b/src/hooks/tests/use-chat-input.test.tsx
@@ -1,0 +1,37 @@
+import { renderHook, act } from '@testing-library/react';
+import { ReactNode } from 'react';
+import { ChatInputProvider, useChatInputContext } from '../use-chat-input';
+
+const wrapper = ( { children }: { children: ReactNode } ) => (
+	<ChatInputProvider>{ children }</ChatInputProvider>
+);
+
+describe( 'useChatInput jook', () => {
+	it( 'should provide default values', () => {
+		const { result } = renderHook( () => useChatInputContext(), { wrapper } );
+
+		expect( result.current.getChatInput( 'site-1' ) ).toBe( '' );
+	} );
+
+	it( 'should save and retrieve chat input', () => {
+		const { result } = renderHook( () => useChatInputContext(), { wrapper } );
+
+		act( () => {
+			result.current.saveChatInput( 'Hello, world!', 'site-1' );
+		} );
+
+		expect( result.current.getChatInput( 'site-1' ) ).toBe( 'Hello, world!' );
+	} );
+
+	it( 'should update chat input for different sites', () => {
+		const { result } = renderHook( () => useChatInputContext(), { wrapper } );
+
+		act( () => {
+			result.current.saveChatInput( 'Hello, site-1!', 'site-1' );
+			result.current.saveChatInput( 'Hello, site-2!', 'site-2' );
+		} );
+
+		expect( result.current.getChatInput( 'site-1' ) ).toBe( 'Hello, site-1!' );
+		expect( result.current.getChatInput( 'site-2' ) ).toBe( 'Hello, site-2!' );
+	} );
+} );

--- a/src/hooks/use-chat-input.tsx
+++ b/src/hooks/use-chat-input.tsx
@@ -1,0 +1,46 @@
+import React, { createContext, useContext, useMemo, useRef, useCallback, ReactNode } from 'react';
+
+export interface ChatInputContextType {
+	getChatInput: ( siteId: string ) => string;
+	saveChatInput: ( input: string, siteId: string ) => void;
+}
+
+interface ChatInputProviderProps {
+	children: ReactNode;
+}
+
+const ChatInputContext = createContext< ChatInputContextType >( {
+	getChatInput: () => '',
+	saveChatInput: () => {
+		// NOOP
+	},
+} );
+
+export const ChatInputProvider: React.FC< ChatInputProviderProps > = ( { children } ) => {
+	const inputBySite = useRef< Record< string, string > >( {} );
+
+	const getChatInput = useCallback( ( siteId: string ) => {
+		return inputBySite.current[ siteId ] ?? '';
+	}, [] );
+
+	const saveChatInput = useCallback( ( input: string, siteId: string ) => {
+		inputBySite.current[ siteId ] = input;
+	}, [] );
+
+	const contextValue = useMemo( () => {
+		return {
+			getChatInput,
+			saveChatInput,
+		};
+	}, [ getChatInput, saveChatInput ] );
+
+	return <ChatInputContext.Provider value={ contextValue }>{ children }</ChatInputContext.Provider>;
+};
+
+export const useChatInputContext = (): ChatInputContextType => {
+	const context = useContext( ChatInputContext );
+	if ( ! context ) {
+		throw new Error( 'useChatInputContext must be used within a ChatInputProvider' );
+	}
+	return context;
+};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to 9208-gh-Automattic/dotcom-forge.

## Proposed Changes

- Add a React context to persist the chat input of each site in memory. 
- Update the logic of Assistant input to save/restore the chat input when navigating to other sites. As well as restore the input when navigating to the Assistant tab.
- Add unit test to cover the case solved by the PR.
- _Bonus:_ Rename `clearInput` handlers/functions to `clearConversation`, which I feel is more accurate for the logic.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run the app with the command `npm start`.
- Log in to WPCOM with an account that has access to the Assistant feature (e.g. A8C account).
- Select a site (Site A).
- Navigate to the Assistant tab.
- Observe the chat input is empty.
- Type a prompt but don't submit it.
- Navigate to another tab (e.g. Overview tab).
- Navigate back to the Assistant tab.
- Observe the previously typed prompt remains in the chat input.
- Select another site (Site B).
- Observe the chat input is empty.
- Type a prompt but don't submit it.
- Select Site A.
- Observe the prompt typed for that site is in the chat input.
- Select Site B.
- Observe the prompt typed for that site is in the chat input.
- Clear the conversation.
- Observe the chat input is empty.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
