### PR TITLE
Run SQLite import WP-CLI command with default PHP version

### DIFF
--- a/src/lib/import-export/import/importers/importer.ts
+++ b/src/lib/import-export/import/importers/importer.ts
@@ -50,7 +50,9 @@ abstract class BaseImporter extends EventEmitter implements Importer {
 			try {
 				await move( sqlFile, tmpPath );
 				const { stderr, exitCode } = await server.executeWpCliCommand(
-					`sqlite import ${ sqlTempFile } --require=/tmp/sqlite-command/command.php`
+					`sqlite import ${ sqlTempFile } --require=/tmp/sqlite-command/command.php`,
+					// SQLite plugin requires PHP 8+
+					{ targetPhpVersion: DEFAULT_PHP_VERSION }
 				);
 
 				if ( stderr ) {

--- a/src/lib/import-export/tests/import/importer/default-importer.test.ts
+++ b/src/lib/import-export/tests/import/importer/default-importer.test.ts
@@ -78,8 +78,12 @@ describe( 'JetpackImporter', () => {
 
 			const expectedCommand =
 				'sqlite import studio-backup-sql-2024-08-01-12-00-00.sql --require=/tmp/sqlite-command/command.php';
-			expect( siteServer?.executeWpCliCommand ).toHaveBeenNthCalledWith( 1, expectedCommand );
-			expect( siteServer?.executeWpCliCommand ).toHaveBeenNthCalledWith( 2, expectedCommand );
+			expect( siteServer?.executeWpCliCommand ).toHaveBeenNthCalledWith( 1, expectedCommand, {
+				targetPhpVersion: '8.1',
+			} );
+			expect( siteServer?.executeWpCliCommand ).toHaveBeenNthCalledWith( 2, expectedCommand, {
+				targetPhpVersion: '8.1',
+			} );
 
 			const expectedUnlinkPath = '/path/to/studio/site/studio-backup-sql-2024-08-01-12-00-00.sql';
 			expect( fs.unlink ).toHaveBeenNthCalledWith( 1, expectedUnlinkPath );

--- a/src/site-server.ts
+++ b/src/site-server.ts
@@ -164,9 +164,12 @@ export class SiteServer {
 			.finally( () => window.destroy() );
 	}
 
-	async executeWpCliCommand( args: string ): Promise< WpCliResult > {
+	async executeWpCliCommand(
+		args: string,
+		{ targetPhpVersion }: { targetPhpVersion?: string } = {}
+	): Promise< WpCliResult > {
 		const projectPath = this.details.path;
-		const phpVersion = this.details.phpVersion;
+		const phpVersion = targetPhpVersion ?? this.details.phpVersion;
 
 		if ( ! this.wpCliExecutor ) {
 			this.wpCliExecutor = new WpCliProcess( projectPath );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to https://github.com/Automattic/studio/issues/558.

## Proposed Changes

- Allow passing the PHP version to be used when running a WP-CLI command.
- Use default PHP version (`8.1`) when running `sqlite import` WP-CLI command. Using a PHP 8 version is required due to SQLite plugin (used in the WP-CLI command) using functions only supported in PHP 8+.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run the app with the command `npm start`.
- Create a site.
- Change the PHP version of the site to `7.4`.
- Navigate to the Import/Export tab.
- Import a full Jetpack backup file.
- Observe the import process succeeded.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
