### PR TITLE
Override `umask` value using a preload file loaded by Playground

### DIFF
--- a/vendor/wp-now/src/wp-now.ts
+++ b/vendor/wp-now/src/wp-now.ts
@@ -67,7 +67,7 @@ export default async function startWPNow(
 
 	const php = await requestHandler.getPrimaryPhp();
 
-	await applyOverrideUmaskWorkaround( php );
+	applyOverrideUmaskWorkaround( php );
 
 	prepareDocumentRoot( php, options );
 
@@ -571,18 +571,11 @@ export async function moveDatabasesInSitu( projectPath: string ) {
  * The default `umask` set by Emscripten is 0777 which is too restrictive. This has been updated
  * in https://github.com/emscripten-core/emscripten/pull/22589 but is not available in the stable
  * version of Emscripten yet. In the meantime, we'll apply a workaround by setting the umask via
- * `auto_prepend_file` PHP directive.
+ * a preload file that will be executed before running any PHP file.
  *
  * Once the Emscripten update is available, a new version of Playground is released using the
  * updated Emscripten, and the Playground dependency is updated in the app, this workaround can be removed.
  */
-async function applyOverrideUmaskWorkaround( php: PHP ) {
-	const iniEntries = await getPhpIniEntries( php );
-	await setPhpIniEntries( php, {
-		...iniEntries,
-		auto_prepend_file: '/internal/shared/studio/auto-prepend-file.php',
-	} );
-
-	php.mkdir( '/internal/shared/studio' );
-	php.writeFile( '/internal/shared/studio/auto-prepend-file.php', '<?php umask(0022);' );
+function applyOverrideUmaskWorkaround( php: PHP ) {
+	php.writeFile( '/internal/shared/preload/override-umask-workaround.php', '<?php umask(0022);' );
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to p1727269932269989-slack-C04GESRBWKW and https://github.com/Automattic/studio/pull/555.

## Proposed Changes

- To override the `umask` value, in https://github.com/Automattic/studio/pull/555 we were prepending a file using the `auto_prepend_file` PHP directive. However, [this is already used by Playground to define constants](https://github.com/WordPress/wordpress-playground/blob/f35c60cd0b514ec071cc74aa77e03eeb3e4b7978/packages/php-wasm/universal/src/lib/php.ts#L243-L262). As an alternative to the directive, Playground allows preloading PHP files if they are located in the path `/internal/shared/preload`.
- Update the workaround introduced in https://github.com/Automattic/studio/pull/555 to write the file in `/internal/shared/preload`.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Ensure `umask` value is overriden

- Run the app with the command `npm start`.
- Create a new site or select one already created.
- Create the file `test.php`, at the root level on the site, with the following content:
```php
<?php
// Create file with default umask
$filename = "example-default-umask.txt";
$current_umask = umask();
    echo sprintf("Current umask: %04o<br>", $current_umask);
    $content = 'This is the content of the file.';
if (file_exists($filename)) {
    unlink($filename);
}
if (file_put_contents($filename, $content) !== false) {
    echo "File '$filename' created successfully.<br>";
} else {
    echo "Error creating file '$filename'.<br>";
}
chmod($filename, 0777 - umask());
```
- Start the site.
- Navigate to the PHP file: `http://localhost:<PORT>/test.php`.
- Observe the `umask` value shown on the page is `0022`.
- Navigate to the site folder.
- Observe that the permissions of the file are `rwxr-xr-x` (Full access to owner, and only READ and EXECUTE permissions to group and others).

### Start a site created with a backup succeeds

- Run the app with the command `npm start`.
- Click on Add site.
- Drop a backup file.
- Create the site.
- Observe the import process succeeds.
- Start the site.
- Navigate to the homepage.
- Observe the site loads successfully.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?