### PR TITLE
Studio: Clear out Site Health critical issue

### DIFF
--- a/vendor/wp-now/src/wp-now.ts
+++ b/vendor/wp-now/src/wp-now.ts
@@ -414,9 +414,13 @@ async function initWordPress(
 		WP_HOME: siteUrl,
 		WP_SITEURL: siteUrl,
 	};
-	if ( wordPressVersion !== 'user-defined' ) {
+
+	output.log(`WordPress version detected: ${wordPressVersion}`);
+
+	if ( wordPressVersion !== 'user-provided' ) {
 		wpConfigConsts[ 'WP_AUTO_UPDATE_CORE' ] = wordPressVersion === 'latest';
 	}
+
 	await defineWpConfigConsts( php, {
 		consts: wpConfigConsts,
 		method: 'define-before-run',

--- a/vendor/wp-now/src/wp-now.ts
+++ b/vendor/wp-now/src/wp-now.ts
@@ -415,12 +415,9 @@ async function initWordPress(
 		WP_SITEURL: siteUrl,
 	};
 
-	output.log(`WordPress version detected: ${wordPressVersion}`);
-
 	if ( wordPressVersion !== 'user-provided' ) {
 		wpConfigConsts[ 'WP_AUTO_UPDATE_CORE' ] = wordPressVersion === 'latest';
 	}
-
 	await defineWpConfigConsts( php, {
 		consts: wpConfigConsts,
 		method: 'define-before-run',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/6652 

## Proposed Changes

This PR ensures that the `WP_AUTO_UPDATE_CORE` is not set to `false` when the WordPress version is `user-provided`. As a result, the critical issue present under `Tools > Site Health` is not present on a newly created Studio site anymore.

<img width="1238" alt="Screenshot 2024-09-26 at 1 31 48 PM" src="https://github.com/user-attachments/assets/6d4ce7f6-52c9-4e29-8af0-2047b14cb890">

## Testing Instructions

* Pull the changes from this branch
* Start the app with `nvm use && npm install && npm start`
* Create a new site in Studio through `Add site` form
* Navigate to the wp-admin of that site
* Navigate to `Tools > Site Health`
* Wait for a couple of minutes
* Confirm that there are no critical issues detected
* You can also compare these changes to trunk to confirm that the issue is present on trunk but not with this fix

Notes:

* The reason why `WP_AUTO_UPDATE_CORE` is set to `false` is because we are passing `user-provided` instead of `user-defined`  on this line: https://github.com/Automattic/studio/blob/dc061f3a49570cbeaf8def95df8763a2d6fbca00/vendor/wp-now/src/wp-now.ts#L266 
* I am not completely sure though if it is a typo or something that is intended. After discussing this with @jeroenpf , we decided that it would be reasonable to change it

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
