### PR TITLE
Add an 'Open in Terminal' button to the code block

### DIFF
--- a/src/components/assistant-code-block.tsx
+++ b/src/components/assistant-code-block.tsx
@@ -73,7 +73,7 @@ const LanguageBlock = ( props: ContextProps & CodeBlockProps ) => {
 					iconSize={ 16 }
 					onCopied={ async () => {
 						await getIpcApi().showNotification( {
-							title: __( 'Command copied to the clipboard' ),
+							title: __( 'Copied to the clipboard' ),
 						} );
 					} }
 				></CopyTextButton>

--- a/src/components/assistant-code-block.tsx
+++ b/src/components/assistant-code-block.tsx
@@ -73,17 +73,14 @@ const LanguageBlock = ( props: ContextProps & CodeBlockProps ) => {
 					iconSize={ 16 }
 				></CopyTextButton>
 				{ [ 'language-sh', 'language-bash' ].includes( props.className || '' ) && selectedSite && (
-					<CopyTextButton
+					<Button
 						icon={ preformatted }
-						text={ content }
-						label={ __( 'Copy and open terminal' ) }
-						copyConfirmation={ __( 'Copied to clipboard' ) }
-						showText={ true }
 						variant="outlined"
-						className="h-auto mr-2 !px-2.5 py-0.5 !p-[6px] font-sans select-none"
+						className="h-auto mr-2 !px-2.5 py-0.5 font-sans select-none"
 						iconSize={ 16 }
-						onCopied={ async () => {
+						onClick={ async () => {
 							try {
+								await getIpcApi().copyText( content );
 								await getIpcApi().openTerminalAtPath( selectedSite.path, {
 									wpCliEnabled: terminalWpCliEnabled,
 								} );
@@ -91,7 +88,9 @@ const LanguageBlock = ( props: ContextProps & CodeBlockProps ) => {
 								console.error( error );
 							}
 						} }
-					></CopyTextButton>
+					>
+						{ __( 'Open in terminal' ) }
+					</Button>
 				) }
 				{ isValidWpCliCommand && (
 					<Button

--- a/src/components/assistant-code-block.tsx
+++ b/src/components/assistant-code-block.tsx
@@ -75,25 +75,27 @@ const LanguageBlock = ( props: ContextProps & CodeBlockProps ) => {
 					className="h-auto mr-2 !px-2.5 py-0.5 !p-[6px] font-sans select-none"
 					iconSize={ 16 }
 				></CopyTextButton>
-				<CopyTextButton
-					icon={ preformatted }
-					text={ content }
-					label={ __( 'Copy and open terminal' ) }
-					copyConfirmation={ __( 'Copied to clipboard' ) }
-					showText={ true }
-					variant="outlined"
-					className="h-auto mr-2 !px-2.5 py-0.5 !p-[6px] font-sans select-none"
-					iconSize={ 16 }
-					onCopied={ async () => {
-						try {
-							await getIpcApi().openTerminalAtPath( selectedSite.path, {
-								wpCliEnabled: terminalWpCliEnabled,
-							} );
-						} catch ( error ) {
-							console.error( error );
-						}
-					} }
-				></CopyTextButton>
+				{ 'language-sh' === props.className && (
+					<CopyTextButton
+						icon={ preformatted }
+						text={ content }
+						label={ __( 'Copy and open terminal' ) }
+						copyConfirmation={ __( 'Copied to clipboard' ) }
+						showText={ true }
+						variant="outlined"
+						className="h-auto mr-2 !px-2.5 py-0.5 !p-[6px] font-sans select-none"
+						iconSize={ 16 }
+						onCopied={ async () => {
+							try {
+								await getIpcApi().openTerminalAtPath( selectedSite.path, {
+									wpCliEnabled: terminalWpCliEnabled,
+								} );
+							} catch ( error ) {
+								console.error( error );
+							}
+						} }
+					></CopyTextButton>
+				) }
 				{ isValidWpCliCommand && (
 					<Button
 						icon={ <ExecuteIcon /> }

--- a/src/components/assistant-code-block.tsx
+++ b/src/components/assistant-code-block.tsx
@@ -54,9 +54,6 @@ const LanguageBlock = ( props: ContextProps & CodeBlockProps ) => {
 
 	const { terminalWpCliEnabled } = useFeatureFlags();
 	const { selectedSite } = useSiteDetails();
-	if ( ! selectedSite ) {
-		return null;
-	}
 
 	return (
 		<>
@@ -75,7 +72,7 @@ const LanguageBlock = ( props: ContextProps & CodeBlockProps ) => {
 					className="h-auto mr-2 !px-2.5 py-0.5 !p-[6px] font-sans select-none"
 					iconSize={ 16 }
 				></CopyTextButton>
-				{ [ 'language-sh', 'language-bash' ].includes( props.className || '' ) && (
+				{ [ 'language-sh', 'language-bash' ].includes( props.className || '' ) && selectedSite && (
 					<CopyTextButton
 						icon={ preformatted }
 						text={ content }

--- a/src/components/assistant-code-block.tsx
+++ b/src/components/assistant-code-block.tsx
@@ -71,6 +71,11 @@ const LanguageBlock = ( props: ContextProps & CodeBlockProps ) => {
 					variant="outlined"
 					className="h-auto mr-2 !px-2.5 py-0.5 !p-[6px] font-sans select-none"
 					iconSize={ 16 }
+					onCopied={ async () => {
+						await getIpcApi().showNotification( {
+							title: __( 'Command copied to the clipboard' ),
+						} );
+					} }
 				></CopyTextButton>
 				{ [ 'language-sh', 'language-bash' ].includes( props.className || '' ) && selectedSite && (
 					<Button
@@ -83,6 +88,9 @@ const LanguageBlock = ( props: ContextProps & CodeBlockProps ) => {
 								await getIpcApi().copyText( content );
 								await getIpcApi().openTerminalAtPath( selectedSite.path, {
 									wpCliEnabled: terminalWpCliEnabled,
+								} );
+								await getIpcApi().showNotification( {
+									title: __( 'Command copied to the clipboard' ),
 								} );
 							} catch ( error ) {
 								console.error( error );

--- a/src/components/assistant-code-block.tsx
+++ b/src/components/assistant-code-block.tsx
@@ -75,7 +75,7 @@ const LanguageBlock = ( props: ContextProps & CodeBlockProps ) => {
 					className="h-auto mr-2 !px-2.5 py-0.5 !p-[6px] font-sans select-none"
 					iconSize={ 16 }
 				></CopyTextButton>
-				{ 'language-sh' === props.className && (
+				{ [ 'language-sh', 'language-bash' ].includes( props.className || '' ) && (
 					<CopyTextButton
 						icon={ preformatted }
 						text={ content }

--- a/src/components/copy-text-button.tsx
+++ b/src/components/copy-text-button.tsx
@@ -15,6 +15,8 @@ interface CopyTextButtonProps {
 	showText?: boolean;
 	variant?: 'primary' | 'secondary' | 'tertiary' | 'outlined' | 'link' | 'icon';
 	iconSize?: number;
+	onCopied?: () => void;
+	icon?: React.JSX.Element;
 }
 
 export function CopyTextButton( {
@@ -27,6 +29,8 @@ export function CopyTextButton( {
 	showText = false,
 	variant = 'link',
 	iconSize = 13,
+	onCopied,
+	icon = copy,
 }: CopyTextButtonProps ) {
 	const { __ } = useI18n();
 	const [ showCopied, setShowCopied ] = useState( false );
@@ -34,12 +38,13 @@ export function CopyTextButton( {
 
 	const onClick = useCallback( () => {
 		getIpcApi().copyText( text );
+		onCopied?.();
 		setShowCopied( true );
 		if ( timeoutId ) {
 			clearTimeout( timeoutId );
 		}
 		setTimeoutId( setTimeout( () => setShowCopied( false ), timeoutConfirmation ) );
-	}, [ text, timeoutConfirmation, timeoutId ] );
+	}, [ onCopied, text, timeoutConfirmation, timeoutId ] );
 
 	return (
 		<Button
@@ -53,8 +58,8 @@ export function CopyTextButton( {
 			variant={ variant }
 		>
 			{ children }
-			<Icon className="ml-1 mr-1" fill="currentColor" size={ iconSize } icon={ copy } />{ ' ' }
-			{ showText && ! showCopied && <span>{ __( 'Copy' ) }</span> }{ ' ' }
+			<Icon className="ml-1 mr-1" fill="currentColor" size={ iconSize } icon={ icon } />{ ' ' }
+			{ showText && ! showCopied && <span>{ label }</span> }{ ' ' }
 			{ showCopied && (
 				<span role="alert" aria-atomic="true" className="ml-1">
 					{ copyConfirmation }

--- a/src/components/tests/assistant-code-block.test.tsx
+++ b/src/components/tests/assistant-code-block.test.tsx
@@ -170,6 +170,7 @@ describe( 'createCodeComponent', () => {
 			const mockCopyText = jest.fn();
 			( getIpcApi as jest.Mock ).mockReturnValue( {
 				copyText: mockCopyText,
+				showNotification: jest.fn(),
 			} );
 			render( <CodeBlock className="language-bash" children="wp --version" /> );
 
@@ -209,6 +210,7 @@ describe( 'createCodeComponent', () => {
 					.fn()
 					.mockResolvedValue( 'site-path/wp-content/plugins/hello.php' ),
 				openFileInIDE: jest.fn(),
+				showNotification: jest.fn(),
 			} );
 
 			const CodeBlock = createCodeComponent( contextProps );

--- a/src/components/tests/assistant-code-block.test.tsx
+++ b/src/components/tests/assistant-code-block.test.tsx
@@ -1,4 +1,5 @@
 import { act, render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { useSiteDetails } from '../../hooks/use-site-details';
 import { getIpcApi } from '../../lib/get-ipc-api';
 import createCodeComponent from '../assistant-code-block';
 
@@ -9,6 +10,22 @@ jest.mock( '../../hooks/use-check-installed-apps', () => ( {
 		phpstorm: false,
 	} ),
 } ) );
+jest.mock( '../../hooks/use-site-details' );
+
+const selectedSite: SiteDetails = {
+	id: 'site-id-1',
+	name: 'Test Site',
+	running: false,
+	path: '/test-site',
+	phpVersion: '8.0',
+	adminPassword: btoa( 'test-password' ),
+};
+
+( useSiteDetails as jest.Mock ).mockReturnValue( {
+	data: [ selectedSite ],
+	loadingSites: false,
+	selectedSite: selectedSite,
+} );
 
 describe( 'createCodeComponent', () => {
 	const contextProps = {

--- a/src/components/tests/assistant-code-block.test.tsx
+++ b/src/components/tests/assistant-code-block.test.tsx
@@ -301,17 +301,24 @@ describe( 'createCodeComponent', () => {
 		} );
 
 		it( 'should copy the code content to the clipboard and open terminal', async () => {
+			( getIpcApi as jest.Mock ).mockReturnValue( {
+				copyText: jest.fn(),
+				openTerminalAtPath: jest.fn(),
+				showNotification: jest.fn(),
+			} );
 			render( <CodeBlock className="language-bash" children="wp plugin list" /> );
 
 			fireEvent.click( screen.getByText( 'Open in terminal' ) );
 
-			expect( getIpcApi().copyText ).toHaveBeenCalledWith( 'wp plugin list' );
-			expect( getIpcApi().openTerminalAtPath ).toHaveBeenCalledWith(
-				selectedSite.path,
-				expect.any( Object )
-			);
-			expect( getIpcApi().showNotification ).toHaveBeenCalledWith( {
-				title: 'Command copied to the clipboard',
+			await waitFor( () => {
+				expect( getIpcApi().copyText ).toHaveBeenCalledWith( 'wp plugin list' );
+				expect( getIpcApi().openTerminalAtPath ).toHaveBeenCalledWith(
+					selectedSite.path,
+					expect.any( Object )
+				);
+				expect( getIpcApi().showNotification ).toHaveBeenCalledWith( {
+					title: 'Command copied to the clipboard',
+				} );
 			} );
 		} );
 	} );

--- a/src/components/tests/assistant-code-block.test.tsx
+++ b/src/components/tests/assistant-code-block.test.tsx
@@ -291,13 +291,13 @@ describe( 'createCodeComponent', () => {
 		it( 'should be visible for bash code blocks', () => {
 			render( <CodeBlock className="language-bash" children="wp plugin list" /> );
 
-			expect( screen.getByText( 'Copy and open terminal' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Copy and open terminal' ) ).toBeVisible();
 		} );
 
 		it( 'should be visible for sh code blocks', () => {
 			render( <CodeBlock className="language-sh" children="wp plugin list" /> );
 
-			expect( screen.getByText( 'Copy and open terminal' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Copy and open terminal' ) ).toBeVisible();
 		} );
 
 		it( 'should copy the code content to the clipboard and open terminal', async () => {

--- a/src/components/tests/assistant-code-block.test.tsx
+++ b/src/components/tests/assistant-code-block.test.tsx
@@ -281,35 +281,38 @@ describe( 'createCodeComponent', () => {
 		} );
 	} );
 
-	describe( 'when the "copy and open terminal" button is clicked', () => {
+	describe( 'when the "open in terminal" button is clicked', () => {
 		it( 'should not be visible for non-bash code blocks', () => {
 			render( <CodeBlock className="language-php" children="<?php echo 'Hello'; ?>" /> );
 
-			expect( screen.queryByText( 'Copy and open terminal' ) ).not.toBeInTheDocument();
+			expect( screen.queryByText( 'Open in terminal' ) ).not.toBeInTheDocument();
 		} );
 
 		it( 'should be visible for bash code blocks', () => {
 			render( <CodeBlock className="language-bash" children="wp plugin list" /> );
 
-			expect( screen.getByText( 'Copy and open terminal' ) ).toBeVisible();
+			expect( screen.getByText( 'Open in terminal' ) ).toBeVisible();
 		} );
 
 		it( 'should be visible for sh code blocks', () => {
 			render( <CodeBlock className="language-sh" children="wp plugin list" /> );
 
-			expect( screen.getByText( 'Copy and open terminal' ) ).toBeVisible();
+			expect( screen.getByText( 'Open in terminal' ) ).toBeVisible();
 		} );
 
 		it( 'should copy the code content to the clipboard and open terminal', async () => {
 			render( <CodeBlock className="language-bash" children="wp plugin list" /> );
 
-			fireEvent.click( screen.getByText( 'Copy and open terminal' ) );
+			fireEvent.click( screen.getByText( 'Open in terminal' ) );
 
 			expect( getIpcApi().copyText ).toHaveBeenCalledWith( 'wp plugin list' );
 			expect( getIpcApi().openTerminalAtPath ).toHaveBeenCalledWith(
 				selectedSite.path,
 				expect.any( Object )
 			);
+			expect( getIpcApi().showNotification ).toHaveBeenCalledWith( {
+				title: 'Command copied to the clipboard',
+			} );
 		} );
 	} );
 } );

--- a/src/components/tests/assistant-code-block.test.tsx
+++ b/src/components/tests/assistant-code-block.test.tsx
@@ -301,19 +301,12 @@ describe( 'createCodeComponent', () => {
 		} );
 
 		it( 'should copy the code content to the clipboard and open terminal', async () => {
-			const mockCopyText = jest.fn();
-			const mockOpenTerminalAtPath = jest.fn();
-			( getIpcApi as jest.Mock ).mockReturnValue( {
-				copyText: mockCopyText,
-				openTerminalAtPath: mockOpenTerminalAtPath,
-			} );
-
 			render( <CodeBlock className="language-bash" children="wp plugin list" /> );
 
 			fireEvent.click( screen.getByText( 'Copy and open terminal' ) );
 
-			expect( mockCopyText ).toHaveBeenCalledWith( 'wp plugin list' );
-			expect( mockOpenTerminalAtPath ).toHaveBeenCalledWith(
+			expect( getIpcApi().copyText ).toHaveBeenCalledWith( 'wp plugin list' );
+			expect( getIpcApi().openTerminalAtPath ).toHaveBeenCalledWith(
 				selectedSite.path,
 				expect.any( Object )
 			);

--- a/src/components/tests/assistant-code-block.test.tsx
+++ b/src/components/tests/assistant-code-block.test.tsx
@@ -280,4 +280,43 @@ describe( 'createCodeComponent', () => {
 			expect( getIpcApi().openLocalPath ).not.toHaveBeenCalled();
 		} );
 	} );
+
+	describe( 'when the "copy and open terminal" button is clicked', () => {
+		it( 'should not be visible for non-bash code blocks', () => {
+			render( <CodeBlock className="language-php" children="<?php echo 'Hello'; ?>" /> );
+
+			expect( screen.queryByText( 'Copy and open terminal' ) ).not.toBeInTheDocument();
+		} );
+
+		it( 'should be visible for bash code blocks', () => {
+			render( <CodeBlock className="language-bash" children="wp plugin list" /> );
+
+			expect( screen.getByText( 'Copy and open terminal' ) ).toBeInTheDocument();
+		} );
+
+		it( 'should be visible for sh code blocks', () => {
+			render( <CodeBlock className="language-sh" children="wp plugin list" /> );
+
+			expect( screen.getByText( 'Copy and open terminal' ) ).toBeInTheDocument();
+		} );
+
+		it( 'should copy the code content to the clipboard and open terminal', async () => {
+			const mockCopyText = jest.fn();
+			const mockOpenTerminalAtPath = jest.fn();
+			( getIpcApi as jest.Mock ).mockReturnValue( {
+				copyText: mockCopyText,
+				openTerminalAtPath: mockOpenTerminalAtPath,
+			} );
+
+			render( <CodeBlock className="language-bash" children="wp plugin list" /> );
+
+			fireEvent.click( screen.getByText( 'Copy and open terminal' ) );
+
+			expect( mockCopyText ).toHaveBeenCalledWith( 'wp plugin list' );
+			expect( mockOpenTerminalAtPath ).toHaveBeenCalledWith(
+				selectedSite.path,
+				expect.any( Object )
+			);
+		} );
+	} );
 } );

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -672,16 +672,7 @@ export function openTerminalAtPath(
 				if not application "Terminal" is running then launch
 				do script "${ wpCliEnabled ? loadWpCliCommand : '' } cd ${ targetPath } && clear"
 				activate
-			end tell
-
-			delay 0.5 -- Small delay to ensure the terminal is ready
-
-			tell application "System Events"
-				tell process "Terminal"
-					keystroke "v" using command down -- Simulate Cmd+V to paste the clipboard
-				end tell
-			end tell
-			`;
+			end tell`;
 			command = `osascript -e '${ script }'`;
 		} else if ( platform === 'linux' ) {
 			// Linux

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -665,18 +665,24 @@ export function openTerminalAtPath(
 			}
 		} else if ( platform === 'darwin' ) {
 			// macOS
-			if ( wpCliEnabled ) {
-				const script = `
+			const loadWpCliCommand =
+				'clear && export PATH=\\"${ cliPath }\\":$PATH && export STUDIO_APP_PATH=\\"${ appPath }\\" &&';
+			const script = `
 			tell application "Terminal"
 				if not application "Terminal" is running then launch
-				do script "clear && export PATH=\\"${ cliPath }\\":$PATH && export STUDIO_APP_PATH=\\"${ appPath }\\" && cd ${ targetPath }"
+				do script "${ wpCliEnabled ? loadWpCliCommand : '' } cd ${ targetPath } && clear"
 				activate
 			end tell
+
+			delay 0.5 -- Small delay to ensure the terminal is ready
+
+			tell application "System Events"
+				tell process "Terminal"
+					keystroke "v" using command down -- Simulate Cmd+V to paste the clipboard
+				end tell
+			end tell
 			`;
-				command = `osascript -e '${ script }'`;
-			} else {
-				command = `open -a Terminal "${ targetPath }"`;
-			}
+			command = `osascript -e '${ script }'`;
 		} else if ( platform === 'linux' ) {
 			// Linux
 			if ( wpCliEnabled ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

- Closes https://github.com/Automattic/dotcom-forge/issues/9222

## Proposed Changes

- Add button to copy and open terminal
- The button only is displayed if the code block language is `sh`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run `npm start` or run `npm run make` to try the preferences settings mentioned below.
- Ask the assistant to return a wp-cli command
- Observe a new button
- Click on it
- Observe that it opens the terminal and you can paste the command

- Check that the copy button also works as expected in the code block and settings tab



https://github.com/user-attachments/assets/eca7c115-9ab9-4345-bb43-9a45e3d43847





## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?