### PR TITLE
Studio: Bubble up path validation error

### DIFF
--- a/src/components/site-form.tsx
+++ b/src/components/site-form.tsx
@@ -289,7 +289,7 @@ export const SiteForm = ( {
 						{ onSelectPath && (
 							<>
 								<div className="flex flex-row items-center mb-0">
-									<Button className={ 'pl-0' } onClick={ handleAdvancedSettingsClick }>
+									<Button className="pl-0" onClick={ handleAdvancedSettingsClick }>
 										<Icon
 											size={ 24 }
 											icon={ chevronIcon }

--- a/src/components/site-form.tsx
+++ b/src/components/site-form.tsx
@@ -304,6 +304,12 @@ export const SiteForm = ( {
 											{ __( 'Advanced settings' ) }
 										</div>
 									</Button>
+									{ error && (
+										<span className="text-red-500 text-[13px] leading-[16px] ml-2 flex items-center">
+											<Icon icon={ warning } size={ 16 } className="mr-1 fill-red-500" />
+											{ __( '1 error found' ) }
+										</span>
+									) }
 								</div>
 								<div
 									className={ cx(

--- a/src/components/site-form.tsx
+++ b/src/components/site-form.tsx
@@ -289,9 +289,18 @@ export const SiteForm = ( {
 						{ onSelectPath && (
 							<>
 								<div className="flex flex-row items-center mb-0">
-									<Button className="pl-0" onClick={ handleAdvancedSettingsClick }>
-										<Icon size={ 24 } icon={ chevronIcon } />
-										<div className="text-[13px] leading-[16px] ml-2">
+									<Button className={ 'pl-0' } onClick={ handleAdvancedSettingsClick }>
+										<Icon
+											size={ 24 }
+											icon={ chevronIcon }
+											className={ error ? 'text-red-500' : '' }
+										/>
+										<div
+											className={ cx(
+												'text-[13px] leading-[16px] ml-2',
+												error ? 'text-red-500' : ''
+											) }
+										>
 											{ __( 'Advanced settings' ) }
 										</div>
 									</Button>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/9069

## Proposed Changes

This PR adds a new error indication to the add site form for the case when:
* there is an error related to the `Local path` address 
* AND the `Advanced settings` tab is closed

<img width="570" alt="Screenshot 2024-09-26 at 2 00 48 PM" src="https://github.com/user-attachments/assets/881baa3f-0861-41b1-9c2f-bbcda1631b13">

<img width="577" alt="Screenshot 2024-09-26 at 2 01 04 PM" src="https://github.com/user-attachments/assets/991002a7-d4f3-41b9-bf7d-00bb083987f0">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
* Start the app with `nvm use && npm install && npm start`
* Create a site with the name `My WordPress Site` in Studio
* Try creating a second site with the same name  `My WordPress Site` 
* Observe that you can see the text `1 error found` and the `Advanced settings` text goes red
* Open the Advanced settings and see the full error
* Change the site name to something else
* Observe that the error goes away and the `Advanced settings` text goes back to the usual color

RToz6tIuQ7nlZrikBte4GU-fi-3748_312092

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?