### PR TITLE
Try to stop server if site initialization failed

### DIFF
--- a/src/components/tests/header.test.tsx
+++ b/src/components/tests/header.test.tsx
@@ -58,6 +58,7 @@ describe( 'Header', () => {
 				startServer: jest.fn( () => {
 					throw new Error( 'Failed to start the server' );
 				} ),
+				stopServer: jest.fn( () => Promise.resolve( { running: false } ) ),
 			} );
 			render(
 				<SiteDetailsProvider>

--- a/src/hooks/use-site-details.tsx
+++ b/src/hooks/use-site-details.tsx
@@ -267,6 +267,7 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 						"Please verify your site's local path directory contains the standard WordPress installation files and try again. If this problem persists, please contact support."
 					),
 				} );
+				getIpcApi().stopServer( id );
 			}
 
 			if ( updatedSite ) {

--- a/src/lib/site-server-process-child.ts
+++ b/src/lib/site-server-process-child.ts
@@ -35,7 +35,7 @@ async function start() {
 }
 
 async function stop() {
-	await server.stopServer();
+	await server?.stopServer();
 }
 
 async function runPhp( data: unknown ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to https://github.com/Automattic/studio/pull/561#issuecomment-2376626678 and https://github.com/Automattic/dotcom-forge/issues/9257.

## Proposed Changes

- This PR doesn't fix 9257-gh-Automattic/dotcom-forge, but handles the case when there's an error during the site initialization and ensures the site can be started again. For instance, it addresses the following case:
  - Have a broken symlink inside the site's folder.
  - Start a site and get a failure.
  - Remove the broken symlink.
  - Start a site will work.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run the app with `npm start`.
- Create a site and stop it.
- Click on the Terminal button.
- Run the command `ln -s unknown broken-symlink` to create a broken symlink.
- Start the site.
- Observe an error message is displayed.
- Remove the symlink.
- Start the site again.
- Observe the site starts and works as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
