### PR TITLE
Update scroll logic in Assistant tab

### DIFF
--- a/src/components/chat-message.tsx
+++ b/src/components/chat-message.tsx
@@ -1,4 +1,5 @@
 import { __ } from '@wordpress/i18n';
+import { forwardRef } from 'react';
 import Markdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { Message } from '../hooks/use-assistant';
@@ -60,61 +61,57 @@ export const MarkDownWithCode = ( {
 		</Markdown>
 	</div>
 );
-
-export const ChatMessage = ( {
-	id,
-	message,
-	className,
-	siteId,
-	updateMessage,
-	children,
-	isUnauthenticated,
-}: ChatMessageProps ) => {
-	return (
-		<div
-			className={ cx(
-				'flex mt-4',
-				isUnauthenticated || message.role !== 'user'
-					? 'justify-start ltr:md:mr-24 rtl:md:ml-24'
-					: 'justify-end ltr:md:ml-24 rtl:md:mr-24',
-				className
-			) }
-		>
-			<div
-				id={ id }
-				role="group"
-				data-testid="chat-message"
-				aria-labelledby={ id }
-				className={ cx(
-					'inline-block p-3 rounded border overflow-x-auto select-text',
-					isUnauthenticated ? 'lg:max-w-[90%]' : 'lg:max-w-[70%]',
-					message.failedMessage
-						? 'border-[#FACFD2] bg-[#F7EBEC]'
-						: message.role === 'user'
-						? 'bg-white'
-						: 'bg-white/45',
-					! message.failedMessage && 'border-gray-300'
-				) }
-			>
-				<div className="relative">
-					<span className="sr-only">
-						{ message.role === 'user' ? __( 'Your message' ) : __( 'Studio Assistant' ) },
-					</span>
+export const ChatMessage = forwardRef< HTMLDivElement, ChatMessageProps >(
+	( { id, message, className, siteId, updateMessage, children, isUnauthenticated }, ref ) => {
+		return (
+			<>
+				<div ref={ ref } className="h-4" />
+				<div
+					className={ cx(
+						'flex',
+						isUnauthenticated || message.role !== 'user'
+							? 'justify-start ltr:md:mr-24 rtl:md:ml-24'
+							: 'justify-end ltr:md:ml-24 rtl:md:mr-24',
+						className
+					) }
+				>
+					<div
+						id={ id }
+						role="group"
+						data-testid="chat-message"
+						aria-labelledby={ id }
+						className={ cx(
+							'inline-block p-3 rounded border overflow-x-auto select-text',
+							isUnauthenticated ? 'lg:max-w-[90%]' : 'lg:max-w-[70%]',
+							message.failedMessage
+								? 'border-[#FACFD2] bg-[#F7EBEC]'
+								: message.role === 'user'
+								? 'bg-white'
+								: 'bg-white/45',
+							! message.failedMessage && 'border-gray-300'
+						) }
+					>
+						<div className="relative">
+							<span className="sr-only">
+								{ message.role === 'user' ? __( 'Your message' ) : __( 'Studio Assistant' ) },
+							</span>
+						</div>
+						{ typeof children === 'string' ? (
+							<>
+								<MarkDownWithCode
+									message={ message }
+									updateMessage={ updateMessage }
+									siteId={ siteId }
+									content={ children }
+								/>
+								{ message.feedbackReceived && <FeedbackThanks /> }
+							</>
+						) : (
+							children
+						) }
+					</div>
 				</div>
-				{ typeof children === 'string' ? (
-					<>
-						<MarkDownWithCode
-							message={ message }
-							updateMessage={ updateMessage }
-							siteId={ siteId }
-							content={ children }
-						/>
-						{ message.feedbackReceived && <FeedbackThanks /> }
-					</>
-				) : (
-					children
-				) }
-			</div>
-		</div>
-	);
-};
+			</>
+		);
+	}
+);

--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -149,9 +149,7 @@ export const AuthenticatedView = memo(
 			let timer: NodeJS.Timeout;
 			// Scroll to the end of the messages when the tab is opened or site ID changes
 			if ( previousMessagesLength.current === 0 || previousSiteId.current !== siteId ) {
-				timer = setTimeout( () => {
-					endOfMessagesRef.current?.scrollIntoView( { behavior: 'instant' } );
-				}, 100 );
+				endOfMessagesRef.current?.scrollIntoView( { behavior: 'instant' } );
 			}
 			// Scroll when a new message is added
 			else if ( messages?.length > previousMessagesLength.current || showLastMessage ) {

--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -153,7 +153,7 @@ export const AuthenticatedView = memo(
 			}
 			// Scroll when a new message is added
 			else if ( messages?.length > previousMessagesLength.current || showLastMessage ) {
-				// Scroll to the beginning of last message recieved from the assistant
+				// Scroll to the beginning of last message received from the assistant
 				if ( showLastMessage ) {
 					timer = setTimeout( () => {
 						if ( lastMessageRef.current ) {

--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -138,6 +138,7 @@ export const AuthenticatedView = memo(
 			messages[ messages.length - 1 ]?.role === 'assistant' ? messages.slice( 0, -1 ) : messages;
 		const showLastMessage = showThinking || messages[ messages.length - 1 ]?.role === 'assistant';
 		const previousMessagesLength = useRef( messages?.length );
+		const previousSiteId = useRef( siteId );
 
 		useEffect( () => {
 			if ( ! messages?.length ) {
@@ -145,11 +146,11 @@ export const AuthenticatedView = memo(
 			}
 
 			let timer: NodeJS.Timeout;
-			// Scroll to the end of the messages when the tab is opened
-			if ( previousMessagesLength.current === 0 ) {
-				if ( endOfMessagesRef.current ) {
-					endOfMessagesRef.current.scrollIntoView( { behavior: 'instant' } );
-				}
+			// Scroll to the end of the messages when the tab is opened or site ID changes
+			if ( previousMessagesLength.current === 0 || previousSiteId.current !== siteId ) {
+				setTimeout( () => {
+					endOfMessagesRef.current?.scrollIntoView( { behavior: 'instant' } );
+				}, 100 );
 			}
 			// Scroll when a new message is added
 			else if ( messages?.length > previousMessagesLength.current || showLastMessage ) {
@@ -170,9 +171,10 @@ export const AuthenticatedView = memo(
 			}
 
 			previousMessagesLength.current = messages?.length;
+			previousSiteId.current = siteId;
 
 			return () => clearTimeout( timer );
-		}, [ messages?.length, showLastMessage ] );
+		}, [ messages?.length, showLastMessage, siteId ] );
 
 		useEffect( () => {
 			let timer: NodeJS.Timeout;

--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -142,12 +142,13 @@ export const AuthenticatedView = memo(
 
 		useEffect( () => {
 			if ( ! messages?.length ) {
+				previousSiteId.current = siteId;
 				return;
 			}
 
 			let timer: NodeJS.Timeout;
 			// Scroll to the end of the messages when the tab is opened or site ID changes
-			if ( previousSiteId.current !== siteId ) {
+			if ( previousMessagesLength.current === 0 || previousSiteId.current !== siteId ) {
 				timer = setTimeout( () => {
 					endOfMessagesRef.current?.scrollIntoView( { behavior: 'instant' } );
 				}, 100 );

--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -147,8 +147,8 @@ export const AuthenticatedView = memo(
 
 			let timer: NodeJS.Timeout;
 			// Scroll to the end of the messages when the tab is opened or site ID changes
-			if ( previousMessagesLength.current === 0 || previousSiteId.current !== siteId ) {
-				setTimeout( () => {
+			if ( previousSiteId.current !== siteId ) {
+				timer = setTimeout( () => {
 					endOfMessagesRef.current?.scrollIntoView( { behavior: 'instant' } );
 				}, 100 );
 			}
@@ -164,9 +164,7 @@ export const AuthenticatedView = memo(
 				}
 				// For user messages, scroll to the end of the messages
 				else {
-					if ( endOfMessagesRef.current ) {
-						endOfMessagesRef.current.scrollIntoView( { behavior: 'smooth' } );
-					}
+					endOfMessagesRef.current?.scrollIntoView( { behavior: 'smooth' } );
 				}
 			}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to 9224-gh-Automattic/dotcom-forge.

## Proposed Changes

- Add a separator element on top of chat messages. This will have two purposes, one is to separate messages (we were previously doing this by adding a margin at the top). The other is to use it as the anchor when scrolling to a message.
- The side effect that triggered the scroll has been updated to cover the following cases:
  - **When the assistant tab is navigated:** Scroll to the bottom.
  - **When a new message is added by the user:** Scroll to the bottom.
  - **When a new message is added by the assistant:** Scroll to the beginning of the message.


https://github.com/user-attachments/assets/265351e6-ae21-49f8-b37a-5e787e60b0d9



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run the app with the command `npm start`.
- Log in to WPCOM with an account that has the Assistant feature enabled.
- Navigate to the Assistant tab.
- Submit a prompt. Ideally, the prompt should produce a long response to test the scroll functionality.
- Observe that the content is scrolled to the bottom when the message is added.
- Observe that the content is scrolled to the bottom when the thinking message is added (the one with `...`).
- Wait until the Assistant responds.
- Observe that the content is scrolled to the beginning of the message responded by the Assistant.
- Navigate to the Overview tab and back again to the Assistant tab.
- Observe the content starts with the scroll at the bottom.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
