### PR TITLE
Studio: Display a progress if the assistant answer takes longer

### DIFF
--- a/src/components/ai-input.tsx
+++ b/src/components/ai-input.tsx
@@ -146,13 +146,13 @@ const UnforwardedAIInput = (
 			thinkingTimeout.current.push(
 				setTimeout( () => {
 					setThinkingDuration( 'long' );
-				}, 5000 )
+				}, 6000 )
 			);
 
 			thinkingTimeout.current.push(
 				setTimeout( () => {
 					setThinkingDuration( 'veryLong' );
-				}, 8000 )
+				}, 10000 )
 			);
 		} else {
 			thinkingTimeout.current.forEach( clearTimeout );
@@ -170,13 +170,13 @@ const UnforwardedAIInput = (
 		if ( isAssistantThinking ) {
 			switch ( thinkingDuration ) {
 				case 'veryLong':
-					return __( 'Stick with me...' );
+					return __( 'Stick with me…' );
 				case 'long':
-					return __( 'This is taking a little longer than I thought...' );
+					return __( 'This is taking a little longer than I thought…' );
 				case 'medium':
-					return __( 'Still working on it...' );
+					return __( 'Still working on it…' );
 				default:
-					return __( 'Thinking about that...' );
+					return __( 'Thinking about that…' );
 			}
 		}
 		return __( 'What would you like to learn?' );

--- a/src/components/ai-input.tsx
+++ b/src/components/ai-input.tsx
@@ -136,6 +136,10 @@ const UnforwardedAIInput = (
 	};
 
 	useEffect( () => {
+		function clearThinkingTimeouts() {
+			thinkingTimeout.current.forEach( clearTimeout );
+			thinkingTimeout.current = [];
+		}
 		if ( isAssistantThinking ) {
 			thinkingTimeout.current.push(
 				setTimeout( () => {
@@ -155,14 +159,12 @@ const UnforwardedAIInput = (
 				}, 10000 )
 			);
 		} else {
-			thinkingTimeout.current.forEach( clearTimeout );
-			thinkingTimeout.current = [];
+			clearThinkingTimeouts();
 			setThinkingDuration( 'short' );
 		}
 
 		return () => {
-			thinkingTimeout.current.forEach( clearTimeout );
-			thinkingTimeout.current = [];
+			clearThinkingTimeouts();
 		};
 	}, [ isAssistantThinking ] );
 

--- a/src/components/tests/content-tab-assistant.test.tsx
+++ b/src/components/tests/content-tab-assistant.test.tsx
@@ -292,7 +292,7 @@ describe( 'ContentTabAssistant', () => {
 		expect( samplePrompt ).toBeVisible();
 		fireEvent.click( samplePrompt );
 
-		textInput = screen.getByPlaceholderText( 'Thinking about that...' );
+		textInput = screen.getByPlaceholderText( 'Thinking about that…' );
 		expect( textInput ).toHaveFocus();
 	} );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->
Closes: https://github.com/Automattic/dotcom-forge/issues/9223

## Proposed Changes

This PR ensures that the user sees progress updates when the assistant is taking some time to think.

https://github.com/user-attachments/assets/08db9ddc-dd37-4cd7-8f14-65c8e497dfec

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
* Start the app with `nvm use && npm install && npm start`
* Ensure that you are logged-in with your Automattic account
* Navigate to the Assistant tab
* Open the developer tools
* Open the Network tab
* Type a message and send it / or use one of the prompts
* Quickly pause the network requests in the Network tab (you can see an example in the video shared above)
* Observe that the assistant progress messages are changing as the time passes by

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
