### PR TITLE
Studio: The "Add site" action doesn't work if there is no site

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -2,11 +2,13 @@ import {
 	__experimentalVStack as VStack,
 	__experimentalHStack as HStack,
 } from '@wordpress/components';
+import { useEffect } from 'react';
 import { useLocalizationSupport } from '../hooks/use-localization-support';
 import { useOnboarding } from '../hooks/use-onboarding';
 import { useSidebarVisibility } from '../hooks/use-sidebar-visibility';
 import { isWindows } from '../lib/app-globals';
 import { cx } from '../lib/cx';
+import { getIpcApi } from '../lib/get-ipc-api';
 import MainSidebar from './main-sidebar';
 import Onboarding from './onboarding';
 import { SiteContentTabs } from './site-content-tabs';
@@ -18,6 +20,10 @@ export default function App() {
 	useLocalizationSupport();
 	const { needsOnboarding } = useOnboarding();
 	const { isSidebarVisible, toggleSidebar } = useSidebarVisibility();
+
+	useEffect( () => {
+		getIpcApi().setupAppMenu( { needsOnboarding } );
+	}, [ needsOnboarding ] );
 
 	return (
 		<>

--- a/src/components/onboarding.tsx
+++ b/src/components/onboarding.tsx
@@ -6,10 +6,6 @@ import { FormEvent, useCallback, useEffect, useState } from 'react';
 import { ACCEPTED_IMPORT_FILE_TYPES } from '../constants';
 import { useAddSite } from '../hooks/use-add-site';
 import { useDragAndDropFile } from '../hooks/use-drag-and-drop-file';
-import { useImportExport } from '../hooks/use-import-export';
-import { useIpcListener } from '../hooks/use-ipc-listener';
-import { useOnboarding } from '../hooks/use-onboarding';
-import { useSiteDetails } from '../hooks/use-site-details';
 import { generateSiteName } from '../lib/generate-site-name';
 import { getIpcApi } from '../lib/get-ipc-api';
 import Button from './button';
@@ -39,7 +35,6 @@ const GradientBox = () => {
 
 export default function Onboarding() {
 	const { __ } = useI18n();
-	const { needsOnboarding } = useOnboarding();
 	const {
 		setSiteName,
 		setProposedSitePath,
@@ -57,12 +52,6 @@ export default function Onboarding() {
 		fileForImport,
 	} = useAddSite();
 	const [ fileError, setFileError ] = useState( '' );
-	const { importState } = useImportExport();
-	const { data } = useSiteDetails();
-
-	const isAnySiteProcessing = data.some(
-		( site ) => site.isAddingSite || importState[ site.id ]?.isNewSite
-	);
 
 	const siteAddedMessage = sprintf(
 		// translators: %s is the site name.
@@ -101,21 +90,24 @@ export default function Onboarding() {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [] );
 
-	const onAddSite = useCallback( async () => {
-		// Prompt the user to enable optimizations on Windows
-		try {
-			await getIpcApi().promptWindowsSpeedUpSites( { skipIfAlreadyPrompted: true } );
-		} catch ( error ) {
-			console.error( error );
-		}
+	const handleSubmit = useCallback(
+		async ( event: FormEvent ) => {
+			event.preventDefault();
+			try {
+				await getIpcApi().promptWindowsSpeedUpSites( { skipIfAlreadyPrompted: true } );
+			} catch ( error ) {
+				console.error( error );
+			}
 
-		try {
-			await handleAddSiteClick();
-			speak( siteAddedMessage );
-		} catch {
-			// No need to handle error here, it's already handled in handleAddSiteClick
-		}
-	}, [ handleAddSiteClick, siteAddedMessage ] );
+			try {
+				await handleAddSiteClick();
+				speak( siteAddedMessage );
+			} catch {
+				// No need to handle error here, it's already handled in handleAddSiteClick
+			}
+		},
+		[ handleAddSiteClick, siteAddedMessage ]
+	);
 
 	const handleImportFile = useCallback(
 		async ( file: File ) => {
@@ -124,13 +116,6 @@ export default function Onboarding() {
 		},
 		[ setFileForImport ]
 	);
-
-	useIpcListener( 'add-site', () => {
-		if ( isAnySiteProcessing || ! needsOnboarding ) {
-			return;
-		}
-		onAddSite();
-	} );
 
 	return (
 		<div className="flex flex-row flex-grow" data-testid="onboarding">
@@ -154,10 +139,7 @@ export default function Onboarding() {
 							onSelectPath={ handlePathSelectorClick }
 							error={ error }
 							doesPathContainWordPress={ doesPathContainWordPress }
-							onSubmit={ async ( event: FormEvent ) => {
-								event.preventDefault();
-								await onAddSite();
-							} }
+							onSubmit={ handleSubmit }
 							fileForImport={ fileForImport }
 							setFileForImport={ setFileForImport }
 							onFileSelected={ handleImportFile }

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -717,8 +717,8 @@ export async function showNotification(
 	new Notification( options ).show();
 }
 
-export function setupAppMenu( _event: IpcMainInvokeEvent ) {
-	setupMenu();
+export function setupAppMenu( _event: IpcMainInvokeEvent, config: { needsOnboarding: boolean } ) {
+	setupMenu( config );
 }
 
 export function popupAppMenu( _event: IpcMainInvokeEvent ) {

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -13,13 +13,13 @@ import { promptWindowsSpeedUpSites } from './lib/windows-helpers';
 import { withMainWindow } from './main-window';
 import { isUpdateReadyToInstall, manualCheckForUpdates } from './updates';
 
-export function setupMenu() {
+export function setupMenu( config: { needsOnboarding: boolean } ) {
 	withMainWindow( ( mainWindow ) => {
 		if ( ! mainWindow && process.platform !== 'darwin' ) {
 			Menu.setApplicationMenu( null );
 			return;
 		}
-		const menu = getAppMenu( mainWindow );
+		const menu = getAppMenu( mainWindow, config );
 		if ( process.platform === 'darwin' ) {
 			Menu.setApplicationMenu( menu );
 			return;
@@ -44,7 +44,10 @@ export function popupMenu() {
 	} );
 }
 
-function getAppMenu( mainWindow: BrowserWindow | null ) {
+function getAppMenu(
+	mainWindow: BrowserWindow | null,
+	{ needsOnboarding = false }: { needsOnboarding?: boolean } = {}
+) {
 	const crashTestMenuItems: MenuItemConstructorOptions[] = [
 		{
 			label: __( 'Test Hard Crash (dev only)' ),
@@ -119,6 +122,7 @@ function getAppMenu( mainWindow: BrowserWindow | null ) {
 							window.webContents.send( 'add-site' );
 						} );
 					},
+					enabled: ! needsOnboarding,
 				},
 				...( process.platform === 'win32'
 					? []

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -66,7 +66,8 @@ const api: IpcApi = {
 	// Use .send instead of .invoke because logging is fire-and-forget
 	logRendererMessage: ( level: LogLevel, ...args: any[] ) =>
 		ipcRenderer.send( 'logRendererMessage', level, ...args ),
-	setupAppMenu: () => ipcRenderer.invoke( 'setupAppMenu' ),
+	setupAppMenu: ( config: { needsOnboarding: boolean } ) =>
+		ipcRenderer.invoke( 'setupAppMenu', config ),
 	popupAppMenu: () => ipcRenderer.invoke( 'popupAppMenu' ),
 	promptWindowsSpeedUpSites: ( ...args: Parameters< typeof promptWindowsSpeedUpSites > ) =>
 		ipcRenderer.invoke( 'promptWindowsSpeedUpSites', ...args ),


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Closes https://github.com/Automattic/studio/issues/377

## Proposed Changes

This PR does the following:

* when the user has no sites, is on onboarding screen and they click on `File > Add site` in the topbar menu, the menu option is disabled
* when the user has some sites and they click on `File > Add site` in the topbar menu, that menu option is enabled ,and they can open the modal for adding a site

It addresses the current issue when the `File > Add site` looks enabled when the user has no sites and is on onboarding screen but clicking on it does nothing.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
* Start the app with `nvm use && npm install && npm start`
* Delete all sites and ensure that you see the onboarding screen
* Click on `File > Add site` option in the topbar menu
* Observe that that menu is disabled
* Create a site through onboarding screen so that you have at least one site
* Click on `File > Add site` option in the topbar menu
* Observe that `Add site` menu item is enabled
* Confirm that you can click it and it opens the modal to add a new site

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
