### PR TITLE
Fix error when parsing an invalid command with shell-quote

### DIFF
--- a/src/hooks/use-is-valid-wp-cli-inline.ts
+++ b/src/hooks/use-is-valid-wp-cli-inline.ts
@@ -4,17 +4,24 @@ const PLACEHOLDER_CHAR_BEGIN = [ '<', '[', '{', '(' ];
 const UNSUPPORTED_COMMANDS = [ 'db', 'server', 'shell' ];
 
 export function useIsValidWpCliInline( command: string ) {
-	const wpCliArgs = parse( command )
-		.map( ( arg ) => {
-			if ( typeof arg === 'string' || arg instanceof String ) {
-				return arg;
-			} else if ( 'op' in arg ) {
-				return arg.op;
-			} else {
-				return false;
-			}
-		} )
-		.filter( Boolean ) as string[];
+	let wpCliArgs: string[] = [];
+
+	try {
+		wpCliArgs = parse( command )
+			.map( ( arg ) => {
+				if ( typeof arg === 'string' || arg instanceof String ) {
+					return arg;
+				} else if ( 'op' in arg ) {
+					return arg.op;
+				} else {
+					return false;
+				}
+			} )
+			.filter( Boolean ) as string[];
+	} catch ( error ) {
+		return false;
+	}
+
 	const wpCommandCount = wpCliArgs.filter( ( arg ) => arg === 'wp' ).length;
 	const containsPath = wpCliArgs.some( ( arg ) => /path/i.test( arg ) || arg.startsWith( '/' ) );
 	const containsPlaceholderArgs = wpCliArgs.some( ( arg ) =>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Fixes: https://github.com/Automattic/dotcom-forge/issues/9280

## Proposed Changes

- It wraps shell-quote parse to avoid returning an error in useIsValidWpCliInline

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run `npm start`
- Go to the assistant
- Click in `How do I create a store`
- Observe the message is sent and the response rendered
- You can go to trunk and observe the error when trying to render the same response.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
