### PR TITLE
Include original error message in error message box 

### DIFF
--- a/src/components/assistant-anchor.tsx
+++ b/src/components/assistant-anchor.tsx
@@ -35,11 +35,10 @@ export default function Anchor( props: JSX.IntrinsicElements[ 'a' ] & ExtraProps
 				try {
 					await getIpcApi().openURL( href );
 				} catch ( error ) {
-					getIpcApi().showMessageBox( {
-						type: 'error',
-						message: __( 'Failed to open link' ),
-						detail: __( 'We were unable to open the link. Please try again.' ),
-						buttons: [ __( 'OK' ) ],
+					getIpcApi().showErrorMessageBox( {
+						title: __( 'Failed to open link' ),
+						message: __( 'We were unable to open the link. Please try again.' ),
+						error,
 					} );
 					Sentry.captureException( error );
 				}

--- a/src/components/delete-site.tsx
+++ b/src/components/delete-site.tsx
@@ -51,19 +51,17 @@ const DeleteSite = () => {
 			try {
 				await deleteSite( selectedSite.id, checkboxChecked );
 			} catch ( error ) {
-				await showErrorMessageBox( error, trimmedSiteTitle );
+				await getIpcApi().showErrorMessageBox( {
+					title: __( 'Deletion failed' ),
+					message: sprintf(
+						__( "We couldn't delete the site '%s'. Please try again" ),
+						trimmedSiteTitle
+					),
+					error,
+				} );
 				Sentry.captureException( error );
 			}
 		}
-	};
-
-	const showErrorMessageBox = async ( error: unknown, siteTitle: string ) => {
-		getIpcApi().showMessageBox( {
-			type: 'warning',
-			message: __( 'Deletion failed' ),
-			detail: sprintf( __( "We couldn't delete the site '%s'. Please try again" ), siteTitle ),
-			buttons: [ __( 'OK' ) ],
-		} );
 	};
 
 	const getTrimmedSiteTitle = ( name: string ) =>

--- a/src/components/tests/assistant-anchor.test.tsx
+++ b/src/components/tests/assistant-anchor.test.tsx
@@ -15,7 +15,7 @@ describe( 'Anchor', () => {
 		( useSiteDetails as jest.Mock ).mockReturnValue( {} );
 		( getIpcApi as jest.Mock ).mockReturnValue( {
 			openURL: jest.fn( () => Promise.resolve() ),
-			showMessageBox: jest.fn(),
+			showErrorMessageBox: jest.fn(),
 		} );
 	} );
 
@@ -79,9 +79,10 @@ describe( 'Anchor', () => {
 	} );
 
 	it( 'should gracefully handle link open failures', async () => {
+		const error = new Error( 'Failed to open link' );
 		( getIpcApi as jest.Mock ).mockReturnValue( {
-			openURL: jest.fn( () => Promise.reject( new Error( 'Failed to open link' ) ) ),
-			showMessageBox: jest.fn(),
+			openURL: jest.fn( () => Promise.reject( error ) ),
+			showErrorMessageBox: jest.fn(),
 		} );
 		render( <Anchor href="https://example.com" children="Example link" /> );
 
@@ -90,11 +91,10 @@ describe( 'Anchor', () => {
 		// Await asynchronous openURL execution
 		await new Promise( process.nextTick );
 
-		expect( getIpcApi().showMessageBox ).toHaveBeenCalledWith( {
-			type: 'error',
-			message: 'Failed to open link',
-			detail: 'We were unable to open the link. Please try again.',
-			buttons: [ 'OK' ],
+		expect( getIpcApi().showErrorMessageBox ).toHaveBeenCalledWith( {
+			title: 'Failed to open link',
+			message: 'We were unable to open the link. Please try again.',
+			error,
 		} );
 		expect( Sentry.captureException ).toHaveBeenCalled();
 	} );

--- a/src/components/tests/header.test.tsx
+++ b/src/components/tests/header.test.tsx
@@ -23,7 +23,7 @@ function mockGetIpcApi( mocks: Record< string, jest.Mock > ) {
 		getSnapshots: jest.fn( () => Promise.resolve( [] ) ),
 		saveSnapshotsToStorage: jest.fn( () => Promise.resolve() ),
 		startServer: jest.fn( () => Promise.resolve( { running: true } ) ),
-		showMessageBox: jest.fn(),
+		showErrorMessageBox: jest.fn(),
 		...mocks,
 	} );
 }
@@ -54,9 +54,10 @@ describe( 'Header', () => {
 	describe( 'when starting a server fails', () => {
 		it( 'should display an error message', async () => {
 			const user = userEvent.setup();
+			const error = new Error( 'Failed to start the server' );
 			mockGetIpcApi( {
 				startServer: jest.fn( () => {
-					throw new Error( 'Failed to start the server' );
+					throw error;
 				} ),
 				stopServer: jest.fn( () => Promise.resolve( { running: false } ) ),
 			} );
@@ -72,12 +73,12 @@ describe( 'Header', () => {
 
 			expect( mockedGetIpcApi().startServer ).toHaveBeenCalledTimes( 1 );
 			expect( screen.getByText( 'Start' ) ).toBeVisible();
-			expect( mockedGetIpcApi().showMessageBox ).toHaveBeenCalledTimes( 1 );
-			expect( mockedGetIpcApi().showMessageBox ).toHaveBeenCalledWith( {
-				type: 'error',
-				message: 'Failed to start the site server',
-				detail:
+			expect( mockedGetIpcApi().showErrorMessageBox ).toHaveBeenCalledTimes( 1 );
+			expect( mockedGetIpcApi().showErrorMessageBox ).toHaveBeenCalledWith( {
+				title: 'Failed to start the site server',
+				message:
 					"Please verify your site's local path directory contains the standard WordPress installation files and try again. If this problem persists, please contact support.",
+				error,
 			} );
 		} );
 	} );

--- a/src/hooks/tests/use-import-export.test.tsx
+++ b/src/hooks/tests/use-import-export.test.tsx
@@ -29,7 +29,7 @@ beforeEach( () => {
 	jest.clearAllMocks();
 	( getIpcApi as jest.Mock ).mockReturnValue( {
 		showSaveAsDialog: jest.fn(),
-		showMessageBox: jest.fn().mockResolvedValue( { response: 0, checkboxChecked: false } ),
+		showErrorMessageBox: jest.fn(),
 		showNotification: jest.fn(),
 		exportSite: jest.fn().mockReturnValue( true ),
 		importSite: jest.fn().mockReturnValue( selectedSite ),
@@ -84,9 +84,12 @@ describe( 'useImportExport hook', () => {
 			},
 			SITE_ID
 		);
-		expect( getIpcApi().showMessageBox ).toHaveBeenCalledWith(
-			expect.objectContaining( { type: 'error', message: 'Failed exporting site' } )
-		);
+		expect( getIpcApi().showErrorMessageBox ).toHaveBeenCalledWith( {
+			title: 'Failed exporting site',
+			message:
+				'An error occurred while exporting the site. If this problem persists, please contact support.',
+			error: 'error',
+		} );
 	} );
 
 	it( 'exports database', async () => {
@@ -233,9 +236,12 @@ describe( 'useImportExport hook', () => {
 				path: 'backup.zip',
 			},
 		} );
-		expect( getIpcApi().showMessageBox ).toHaveBeenCalledWith(
-			expect.objectContaining( { type: 'error', message: 'Failed importing site' } )
-		);
+		expect( getIpcApi().showErrorMessageBox ).toHaveBeenCalledWith( {
+			title: 'Failed importing site',
+			message:
+				'An error occurred while importing the site. Verify the file is a valid Jetpack backup, Local, Playground or .sql database file and try again. If this problem persists, please contact support.',
+			error: 'error',
+		} );
 	} );
 
 	it( 'does not import if another import is running', async () => {

--- a/src/hooks/tests/use-update-demo-site.test.tsx
+++ b/src/hooks/tests/use-update-demo-site.test.tsx
@@ -11,7 +11,7 @@ jest.mock( '../../hooks/use-auth' );
 jest.mock( '../../lib/get-ipc-api', () => ( {
 	getIpcApi: jest.fn().mockReturnValue( {
 		archiveSite: jest.fn().mockResolvedValue( { zipContent: new Blob( [ 'zipContent' ] ) } ),
-		showMessageBox: jest.fn().mockResolvedValue( { response: 1 } ), // Assuming '1' is the cancel button
+		showErrorMessageBox: jest.fn().mockResolvedValue( { response: 1 } ), // Assuming '1' is the cancel button
 		getWpVersion: jest.fn().mockResolvedValue( '6.5' ),
 	} ),
 } ) );
@@ -108,7 +108,8 @@ describe( 'useUpdateDemoSite', () => {
 	} );
 
 	it( 'when an update fails, ensure an alert is triggered', async () => {
-		clientReqPost.mockRejectedValue( new Error( 'Update failed' ) );
+		const error = new Error( 'Update failed' );
+		clientReqPost.mockRejectedValue( error );
 
 		const { result } = renderHook( () => useUpdateDemoSite(), { wrapper } );
 
@@ -118,11 +119,11 @@ describe( 'useUpdateDemoSite', () => {
 		} );
 
 		// Assert that an alert is displayed to inform users of the failure
-		expect( getIpcApi().showMessageBox ).toHaveBeenCalledWith(
-			expect.objectContaining( {
-				type: 'warning',
-			} )
-		);
+		expect( getIpcApi().showErrorMessageBox ).toHaveBeenCalledWith( {
+			title: 'Update failed',
+			message: "We couldn't update the Test Site demo site. Please try again.",
+			error,
+		} );
 
 		// Assert that 'isDemoSiteUpdating' is set back to false
 		expect( result.current.isDemoSiteUpdating( mockLocalSite.id ) ).toBe( false );

--- a/src/hooks/use-import-export.tsx
+++ b/src/hooks/use-import-export.tsx
@@ -90,14 +90,13 @@ export const ImportExportProvider = ( { children }: { children: React.ReactNode 
 			} ) );
 
 			const wasSiteRunning = selectedSite.running;
-			const handleImportError = async () => {
-				await getIpcApi().showMessageBox( {
-					type: 'error',
-					message: __( 'Failed importing site' ),
-					detail: __(
+			const handleImportError = async ( error?: unknown ) => {
+				await getIpcApi().showErrorMessageBox( {
+					title: __( 'Failed importing site' ),
+					message: __(
 						'An error occurred while importing the site. Verify the file is a valid Jetpack backup, Local, Playground or .sql database file and try again. If this problem persists, please contact support.'
 					),
-					buttons: [ __( 'OK' ) ],
+					error,
 				} );
 				setImportState( ( { [ selectedSite.id ]: currentProgress, ...rest } ) => ( {
 					...rest,
@@ -130,7 +129,7 @@ export const ImportExportProvider = ( { children }: { children: React.ReactNode 
 					} );
 				}
 			} catch ( error ) {
-				await handleImportError();
+				await handleImportError( error );
 			} finally {
 				if ( wasSiteRunning ) {
 					startServer( selectedSite.id );
@@ -251,14 +250,13 @@ export const ImportExportProvider = ( { children }: { children: React.ReactNode 
 				[ selectedSite.id ]: INITIAL_EXPORT_STATE,
 			} ) );
 
-			const handleExportError = async () =>
-				getIpcApi().showMessageBox( {
-					type: 'error',
-					message: __( 'Failed exporting site' ),
-					detail: __(
+			const handleExportError = async ( error?: unknown ) =>
+				getIpcApi().showErrorMessageBox( {
+					title: __( 'Failed exporting site' ),
+					message: __(
 						'An error occurred while exporting the site. If this problem persists, please contact support.'
 					),
-					buttons: [ __( 'OK' ) ],
+					error,
 				} );
 
 			try {
@@ -278,7 +276,7 @@ export const ImportExportProvider = ( { children }: { children: React.ReactNode 
 				return options.backupFile;
 			} catch ( error ) {
 				Sentry.captureException( error );
-				await handleExportError();
+				await handleExportError( error );
 			} finally {
 				setExportState( ( { [ selectedSite.id ]: currentProgress, ...rest } ) => ( {
 					...rest,

--- a/src/hooks/use-site-details.tsx
+++ b/src/hooks/use-site-details.tsx
@@ -101,8 +101,6 @@ function useDeleteSite() {
 				const newSites = await getIpcApi().deleteSite( siteId, removeLocal );
 				await allSiteRemovePromises;
 				return newSites;
-			} catch ( error ) {
-				throw new Error( 'Failed to delete local files' );
 			} finally {
 				setIsLoading( ( loading ) => ( { ...loading, [ siteId ]: false } ) );
 			}

--- a/src/hooks/use-site-details.tsx
+++ b/src/hooks/use-site-details.tsx
@@ -172,15 +172,14 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 			callback?: ( site: SiteDetails | void ) => Promise< void >
 		) => {
 			// Function to handle error messages and cleanup
-			const showError = () => {
+			const showError = ( error?: unknown ) => {
 				console.error( 'Failed to create site' );
-				getIpcApi().showMessageBox( {
-					type: 'error',
-					message: __( 'Failed to create site' ),
-					detail: __(
+				getIpcApi().showErrorMessageBox( {
+					title: __( 'Failed to create site' ),
+					message: __(
 						'An error occurred while creating the site. Verify your selected local path is an empty directory or an existing WordPress folder and try again. If this problem persists, please contact support.'
 					),
-					buttons: [ __( 'OK' ) ],
+					error,
 				} );
 
 				// Remove the temporary site immediately, but with a minor delay to ensure state updates properly
@@ -240,7 +239,7 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 
 				return newSite;
 			} catch ( error ) {
-				showError();
+				showError( error );
 			}
 		},
 		[ setSelectedSiteId ]
@@ -260,12 +259,12 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 				updatedSite = await getIpcApi().startServer( id );
 			} catch ( error ) {
 				Sentry.captureException( error );
-				getIpcApi().showMessageBox( {
-					type: 'error',
-					message: __( 'Failed to start the site server' ),
-					detail: __(
+				getIpcApi().showErrorMessageBox( {
+					title: __( 'Failed to start the site server' ),
+					message: __(
 						"Please verify your site's local path directory contains the standard WordPress installation files and try again. If this problem persists, please contact support."
 					),
+					error,
 				} );
 				getIpcApi().stopServer( id );
 			}

--- a/src/hooks/use-update-demo-site.tsx
+++ b/src/hooks/use-update-demo-site.tsx
@@ -34,22 +34,22 @@ export const DemoSiteUpdateProvider: React.FC< DemoSiteUpdateProviderProps > = (
 			}
 			setUpdatingSites( ( prev ) => new Set( prev ).add( localSite.id ) );
 
-			const { zipContent } = await getIpcApi().archiveSite( localSite.id );
-			const file = new File( [ zipContent ], 'loca-env-site-1.zip', {
-				type: 'application/zip',
-			} );
-
-			const formData = [
-				[ 'site_id', snapshot.atomicSiteId ],
-				[ 'import', file ],
-			];
-
-			const wordpressVersion = await getIpcApi().getWpVersion( localSite.id );
-			if ( wordpressVersion.length >= 3 ) {
-				formData.push( [ 'wordpress_version', wordpressVersion ] );
-			}
-
 			try {
+				const { zipContent } = await getIpcApi().archiveSite( localSite.id );
+				const file = new File( [ zipContent ], 'loca-env-site-1.zip', {
+					type: 'application/zip',
+				} );
+
+				const formData = [
+					[ 'site_id', snapshot.atomicSiteId ],
+					[ 'import', file ],
+				];
+
+				const wordpressVersion = await getIpcApi().getWpVersion( localSite.id );
+				if ( wordpressVersion.length >= 3 ) {
+					formData.push( [ 'wordpress_version', wordpressVersion ] );
+				}
+
 				const response = await client.req.post( {
 					path: '/jurassic-ninja/update-site-from-zip',
 					apiNamespace: 'wpcom/v2',
@@ -65,14 +65,13 @@ export const DemoSiteUpdateProvider: React.FC< DemoSiteUpdateProviderProps > = (
 				} );
 				return response;
 			} catch ( error ) {
-				getIpcApi().showMessageBox( {
-					type: 'warning',
-					message: __( 'Update failed' ),
-					detail: sprintf(
+				getIpcApi().showErrorMessageBox( {
+					title: __( 'Update failed' ),
+					message: sprintf(
 						__( "We couldn't update the %s demo site. Please try again" ),
 						localSite.name
 					),
-					buttons: [ __( 'OK' ) ],
+					error,
 				} );
 				Sentry.captureException( error );
 			} finally {

--- a/src/hooks/use-update-demo-site.tsx
+++ b/src/hooks/use-update-demo-site.tsx
@@ -68,7 +68,7 @@ export const DemoSiteUpdateProvider: React.FC< DemoSiteUpdateProviderProps > = (
 				getIpcApi().showErrorMessageBox( {
 					title: __( 'Update failed' ),
 					message: sprintf(
-						__( "We couldn't update the %s demo site. Please try again" ),
+						__( "We couldn't update the %s demo site. Please try again." ),
 						localSite.name
 					),
 					error,

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -13,7 +13,7 @@ import {
 import fs from 'fs';
 import nodePath from 'path';
 import * as Sentry from '@sentry/electron/main';
-import { LocaleData, defaultI18n } from '@wordpress/i18n';
+import { __, LocaleData, defaultI18n } from '@wordpress/i18n';
 import archiver from 'archiver';
 import { DEFAULT_PHP_VERSION } from '../vendor/wp-now/src/constants';
 import { MAIN_MIN_WIDTH, SIDEBAR_WIDTH, SIZE_LIMIT_BYTES } from './constants';
@@ -705,6 +705,23 @@ export async function showMessageBox(
 		return dialog.showMessageBox( parentWindow, options );
 	}
 	return dialog.showMessageBox( options );
+}
+
+export async function showErrorMessageBox(
+	event: IpcMainInvokeEvent,
+	{ title, message, error }: { title: string; message: string; error?: unknown }
+) {
+	// Remove prepended error message added by IPC handler
+	const filteredError = ( error as Error )?.message?.replace(
+		/Error invoking remote method '\w+': Error:/g,
+		''
+	);
+	await showMessageBox( event, {
+		type: 'error',
+		message: title,
+		detail: error ? `${ message }\n\nError:\n\n${ filteredError }` : message,
+		buttons: [ __( 'OK' ) ],
+	} );
 }
 
 export async function showNotification(

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -719,7 +719,7 @@ export async function showErrorMessageBox(
 	await showMessageBox( event, {
 		type: 'error',
 		message: title,
-		detail: error ? `${ message }\n\nError:\n\n${ filteredError }` : message,
+		detail: error ? `${ message }\n\nError: ${ filteredError }` : message,
 		buttons: [ __( 'OK' ) ],
 	} );
 }

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -61,6 +61,8 @@ const api: IpcApi = {
 		ipcRenderer.invoke( 'openTerminalAtPath', targetPath, extraParams ),
 	showMessageBox: ( options: Electron.MessageBoxOptions ) =>
 		ipcRenderer.invoke( 'showMessageBox', options ),
+	showErrorMessageBox: ( options: { title: string; message: string; error?: unknown } ) =>
+		ipcRenderer.invoke( 'showErrorMessageBox', options ),
 	showNotification: ( options: Electron.NotificationConstructorOptions ) =>
 		ipcRenderer.invoke( 'showNotification', options ),
 	// Use .send instead of .invoke because logging is fire-and-forget


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to 9309-gh-Automattic/dotcom-forge.

## Proposed Changes

- Add an IPC handler to display the error message box. It removes the potential prepended error message when the exception comes from an IPC handler.
- Update different areas of the app that were displaying an error message box and use the new IPC handler.
- Handle exceptions produced when archiving a site and display the error message.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Preparation:**

- Apply the following patch:
```patch
diff --git forkSrcPrefix/src/ipc-handlers.ts forkDstPrefix/src/ipc-handlers.ts
index c1bd18ff8803404bf6b687455fcf01f8cd2dd057..4e47690ff63cc8009891b3cc2ae9974517cba0c9 100644
--- forkSrcPrefix/src/ipc-handlers.ts
+++ forkDstPrefix/src/ipc-handlers.ts
@@ -111,6 +111,7 @@ export async function importSite(
 				parentWindow.webContents.send( 'on-import', data, id );
 			}
 		};
+		// throw new Error( 'Error Test - importSite' );
 		const result = await importBackup( backupFile, site.details, onEvent, defaultImporterOptions );
 		if ( ! result ) {
 			return;
@@ -170,6 +171,8 @@ export async function createSite(
 
 	const server = SiteServer.create( details );
 
+	// throw new Error( `Error Test - createSite` );
+
 	if ( isWordPressDirectory( path ) ) {
 		// If the directory contains a WordPress installation, and user wants to force SQLite
 		// integration, let's rename the wp-config.php file to allow WP Now to create a new one
@@ -225,6 +228,8 @@ export async function startServer(
 		return null;
 	}
 
+	// throw new Error( `Error Test - startServer` );
+
 	await keepSqliteIntegrationUpdated( server.details.path );
 
 	const parentWindow = BrowserWindow.fromWebContents( event.sender );
@@ -372,6 +377,7 @@ export async function archiveSite( event: IpcMainInvokeEvent, id: string ) {
 	}
 	const sitePath = site.details.path;
 	const zipPath = `${ TEMP_DIR }site_${ id }.zip`;
+	// throw new Error( 'Error Test - archiveSite' );
 	await zipWordPressDirectory( {
 		source: sitePath,
 		zipPath,
@@ -401,6 +407,8 @@ export async function deleteSite( event: IpcMainInvokeEvent, id: string, deleteF
 	if ( ! server ) {
 		throw new Error( 'Site not found.' );
 	}
+	// throw new Error( 'Error Test - deleteSite' );
+
 	const userData = await loadUserData();
 	await server.delete();
 	try {
@@ -458,6 +466,7 @@ export async function exportSite(
 				parentWindow.webContents.send( 'on-export', data, siteId );
 			}
 		};
+		// throw new Error( 'Error Test - exportSite' );
 		return await exportBackup( options, onEvent );
 	} catch ( e ) {
 		Sentry.captureException( e );
@@ -501,6 +510,7 @@ export async function openSiteURL(
 }
 
 export async function openURL( event: IpcMainInvokeEvent, url: string ) {
+	// throw new Error( 'Error Test - openURL' );
 	return shell.openExternal( url );
 }
 

```

### Create site

- Uncomment the error throw statement in `ipc-handlers.ts` file related to creating a site.
- Create a site.
- Observe that the error message box is displayed and includes the error message of the exception.

### Start site

- Uncomment the error throw statement in `ipc-handlers.ts` file related to starting a site.
- Start a site.
- Observe that the error message box is displayed and includes the error message of the exception.

### Delete site

- Uncomment the error throw statement in `ipc-handlers.ts` file related to deleting a site.
- Delete a site.
- Observe that the error message box is displayed and includes the error message of the exception.

### Opening link from Assistant

- Uncomment the error throw statement in `ipc-handlers.ts` file related to opening an URL.
- Log in to WPCOM with a user that has access to the Assistant feature.
- Navigate to the Assistant tab.
- Submit a prompt that will display a link (e.g. `How can I access the plugins list?`).
- Wait for the response and try to open a link.
- Observe that the error message box is displayed and includes the error message of the exception.

### Add demo site

- Uncomment the error throw statement in `ipc-handlers.ts` file related to archiving a site.
- Navigate to the Share tab
- Add a demo site.
- Observe that the error message box is displayed and includes the error message of the exception.

### Update demo site

- Uncomment the error throw statement in `ipc-handlers.ts` file related to archiving a site.
- Navigate to the Share tab
- Add a demo site if needed.
- Update the demo site.
- Observe that the error message box is displayed and includes the error message of the exception.

### Import site

- Uncomment the error throw statement in `ipc-handlers.ts` file related to importing a site.
- Navigate to the Import/Export tab.
- Import a site.
- Observe that the error message box is displayed and includes the error message of the exception.

### Export site

- Uncomment the error throw statement in `ipc-handlers.ts` file related to exporting a site.
- Navigate to the Import/Export tab.
- Export a site.
- Observe that the error message box is displayed and includes the error message of the exception.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
