### PR TITLE
Change loading state label to 'Loading' to cover both start and stop

### DIFF
--- a/src/components/action-button.tsx
+++ b/src/components/action-button.tsx
@@ -114,7 +114,7 @@ export const ActionButton = ( {
 			};
 			break;
 		case 'loading':
-			buttonLabel = __( 'Loading…' );
+			buttonLabel = isRunning ? __( 'Stopping…' ) : __( 'Starting…' );
 			buttonProps = {
 				// `aria-disabled` used rather than `disabled` to prevent losing button
 				// focus while the button's asynchronous action is pending.

--- a/src/components/action-button.tsx
+++ b/src/components/action-button.tsx
@@ -114,7 +114,7 @@ export const ActionButton = ( {
 			};
 			break;
 		case 'loading':
-			buttonLabel = __( 'Starting…' );
+			buttonLabel = __( 'Loading…' );
 			buttonProps = {
 				// `aria-disabled` used rather than `disabled` to prevent losing button
 				// focus while the button's asynchronous action is pending.


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9292

## Proposed Changes

I propose to change the loading state label from 'Starting' to 'Loading' to cover both start and stop.

I considered splitting the 'loading' status into 'starting' and 'stopping', so we could display different labels each time, but it would make the code more complex and wouldn't provide value to the user, especially since stopping is quick in most cases.

I thought about using 'Processing', too, but 'Loading' seems clearer in this case.

![Screenshot 2024-10-03 at 15 25 44](https://github.com/user-attachments/assets/3c956837-e1e9-4841-bc6b-b91a654593c6)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Start and stop site
2. Confirm that new label shows 'Loading...'

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
