### PR TITLE
Let user open Settings menu in offline mode

### DIFF
--- a/src/components/tests/topbar.test.tsx
+++ b/src/components/tests/topbar.test.tsx
@@ -24,13 +24,11 @@ describe( 'TopBar', () => {
 		jest.clearAllMocks();
 	} );
 	it( 'Test unauthenticated TopBar has the Log in button', async () => {
-		const user = userEvent.setup();
 		const authenticate = jest.fn();
 		( useAuth as jest.Mock ).mockReturnValue( { isAuthenticated: false, authenticate } );
 		await act( async () => render( <TopBar onToggleSidebar={ jest.fn() } /> ) );
+		expect( screen.queryByRole( 'button', { name: 'Account' } ) ).not.toBeInTheDocument();
 		expect( screen.getByRole( 'button', { name: 'Log in' } ) ).toBeVisible();
-		await user.click( screen.getByRole( 'button', { name: 'Log in' } ) );
-		expect( authenticate ).toHaveBeenCalledTimes( 1 );
 	} );
 
 	it( 'Test authenticated TopBar does not have the log in button and it has the settings and account buttons', async () => {
@@ -38,15 +36,6 @@ describe( 'TopBar', () => {
 		await act( async () => render( <TopBar onToggleSidebar={ jest.fn() } /> ) );
 		expect( screen.queryByRole( 'button', { name: 'Log in' } ) ).not.toBeInTheDocument();
 		expect( screen.getByRole( 'button', { name: 'Account' } ) ).toBeVisible();
-	} );
-	it( 'disables log in button when offline', async () => {
-		( useOffline as jest.Mock ).mockReturnValue( true );
-		( useAuth as jest.Mock ).mockReturnValue( { isAuthenticated: false } );
-		await act( async () => render( <TopBar onToggleSidebar={ jest.fn() } /> ) );
-		const loginButton = screen.getByRole( 'button', { name: 'Log in' } );
-		expect( loginButton ).toHaveAttribute( 'aria-disabled', 'true' );
-		fireEvent.mouseOver( loginButton );
-		expect( screen.getByRole( 'tooltip', { name: 'You’re currently offline.' } ) ).toBeVisible();
 	} );
 
 	it( 'shows offline indicator', async () => {

--- a/src/components/top-bar.tsx
+++ b/src/components/top-bar.tsx
@@ -48,9 +48,7 @@ function OfflineIndicator() {
 }
 
 function Authentication() {
-	const { isAuthenticated, authenticate, user } = useAuth();
-	const isOffline = useOffline();
-	const offlineMessage = __( 'You’re currently offline.' );
+	const { isAuthenticated, user } = useAuth();
 	if ( isAuthenticated ) {
 		return (
 			<Button
@@ -66,29 +64,15 @@ function Authentication() {
 	}
 
 	return (
-		<Tooltip
-			disabled={ ! isOffline }
-			icon={ offlineIcon }
-			text={ offlineMessage }
-			placement="right"
-			className="flex"
+		<Button
+			onClick={ () => getIpcApi().showUserSettings() }
+			aria-label={ __( 'Log in' ) }
+			className="flex gap-x-2 justify-between w-full text-white rounded !px-0 !py-1 h-auto active:!text-white hover:!text-white hover:underline items-end"
 		>
-			<Button
-				aria-description={ isOffline ? offlineMessage : '' }
-				aria-disabled={ isOffline }
-				className="flex gap-x-2 justify-between w-full text-white rounded !px-0 !py-1 h-auto active:!text-white hover:!text-white hover:underline items-end"
-				onClick={ () => {
-					if ( isOffline ) {
-						return;
-					}
-					authenticate();
-				} }
-			>
-				<WordPressLogo />
+			<WordPressLogo />
 
-				<div className="text-xs text-right">{ __( 'Log in' ) }</div>
-			</Button>
-		</Tooltip>
+			<div className="text-xs text-right">{ __( 'Log in' ) }</div>
+		</Button>
 	);
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9298

## Proposed Changes

Now, when the Settings menu allows selecting language, I propose letting users open it using the 'Log in' link in the top bar, making it consistent with behavior for a logged-in state.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Log in using the 'Log in' button in the top bar
2. Confirm that the top bar link changes state to 'Howdy [...]'
3. Turn off wifi to put Studio into offline mode
4. Confirm that log out action works
5. Confirm that the 'Log in' link opens the settings which allows changing language

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
