### PR TITLE
Issue templates: add new issue type option

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,7 @@
 name: Bug Report
 description: Helps us improve our product!
 labels: [ 'Needs triage', '[Type] Bug' ]
+type: 'Bug'
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -2,6 +2,7 @@ name: Feature Request
 description: Suggest an idea for Studio!
 title: "Feature Request:"
 labels: ["[Type] Feature Request"]
+type: 'Enhancement'
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION


## Proposed Changes

This was added as an option as part of this set of changes to GitHub issues:
https://github.blog/changelog/2024-10-01-evolving-github-issues-public-preview/

Related post: pdWQjU-WT-p2

## Testing Instructions

Not much to test here, we'll need this PR to be merged to be able to see the results when we create a new issue. 

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
