### PR TITLE
Studio: Add a Sync tab accessible behind the feature flag 

### DIFF
--- a/src/hooks/tests/use-chat-context.test.tsx
+++ b/src/hooks/tests/use-chat-context.test.tsx
@@ -75,6 +75,7 @@ beforeEach( () => {
 		arm64Translation: false,
 		assistantEnabled: false,
 		terminalWpCliEnabled: false,
+		siteSyncEnabled: false,
 	} );
 	setupWpCliResult( { themes: [], plugins: [] } );
 } );

--- a/src/hooks/use-content-tabs.ts
+++ b/src/hooks/use-content-tabs.ts
@@ -15,34 +15,34 @@ export function useContentTabs() {
 				title: __( 'Overview' ),
 			},
 			{
-				order: 3,
+				order: 2,
+				name: 'share',
+				title: __( 'Share' ),
+			},
+			{
+				order: 4,
 				name: 'import-export',
 				title: __( 'Import / Export' ),
 			},
 			{
-				order: 4,
+				order: 5,
 				name: 'settings',
 				title: __( 'Settings' ),
 			},
 		];
 
+		// Add Sync tab as third if siteSyncEnabled is true
 		if ( siteSyncEnabled ) {
 			tabs.push( {
-				order: 2,
+				order: 3,
 				name: 'sync',
 				title: __( 'Sync' ),
-			} );
-		} else {
-			tabs.push( {
-				order: 2,
-				name: 'share',
-				title: __( 'Share' ),
 			} );
 		}
 
 		if ( assistantEnabled ) {
 			tabs.push( {
-				order: 5,
+				order: 6,
 				name: 'assistant',
 				title: __( 'Assistant' ),
 				className:
@@ -50,6 +50,7 @@ export function useContentTabs() {
 			} );
 		}
 
+		// Sort tabs by order value to ensure correct ordering
 		return tabs.sort( ( a, b ) => a.order - b.order );
 	}, [ __, assistantEnabled, siteSyncEnabled ] );
 }

--- a/src/hooks/use-content-tabs.ts
+++ b/src/hooks/use-content-tabs.ts
@@ -5,7 +5,7 @@ import { useFeatureFlags } from './use-feature-flags';
 
 export function useContentTabs() {
 	const { __ } = useI18n();
-	const { assistantEnabled } = useFeatureFlags();
+	const { assistantEnabled, siteSyncEnabled } = useFeatureFlags();
 
 	return useMemo( () => {
 		const tabs: React.ComponentProps< typeof TabPanel >[ 'tabs' ] = [
@@ -13,11 +13,6 @@ export function useContentTabs() {
 				order: 1,
 				name: 'overview',
 				title: __( 'Overview' ),
-			},
-			{
-				order: 2,
-				name: 'share',
-				title: __( 'Share' ),
 			},
 			{
 				order: 3,
@@ -31,6 +26,20 @@ export function useContentTabs() {
 			},
 		];
 
+		if ( siteSyncEnabled ) {
+			tabs.push( {
+				order: 2,
+				name: 'sync',
+				title: __( 'Sync' ),
+			} );
+		} else {
+			tabs.push( {
+				order: 2,
+				name: 'share',
+				title: __( 'Share' ),
+			} );
+		}
+
 		if ( assistantEnabled ) {
 			tabs.push( {
 				order: 5,
@@ -42,5 +51,5 @@ export function useContentTabs() {
 		}
 
 		return tabs.sort( ( a, b ) => a.order - b.order );
-	}, [ __, assistantEnabled ] );
+	}, [ __, assistantEnabled, siteSyncEnabled ] );
 }

--- a/src/hooks/use-content-tabs.ts
+++ b/src/hooks/use-content-tabs.ts
@@ -49,7 +49,6 @@ export function useContentTabs() {
 			} );
 		}
 
-		// Sort tabs by order value to ensure correct ordering
 		return tabs.sort( ( a, b ) => a.order - b.order );
 	}, [ __, assistantEnabled, siteSyncEnabled ] );
 }

--- a/src/hooks/use-content-tabs.ts
+++ b/src/hooks/use-content-tabs.ts
@@ -31,7 +31,6 @@ export function useContentTabs() {
 			},
 		];
 
-		// Add Sync tab as third if siteSyncEnabled is true
 		if ( siteSyncEnabled ) {
 			tabs.push( {
 				order: 3,

--- a/src/hooks/use-content-tabs.ts
+++ b/src/hooks/use-content-tabs.ts
@@ -15,7 +15,7 @@ export function useContentTabs() {
 				title: __( 'Overview' ),
 			},
 			{
-				order: 2,
+				order: 3,
 				name: 'share',
 				title: __( 'Share' ),
 			},
@@ -33,7 +33,7 @@ export function useContentTabs() {
 
 		if ( siteSyncEnabled ) {
 			tabs.push( {
-				order: 3,
+				order: 2,
 				name: 'sync',
 				title: __( 'Sync' ),
 			} );

--- a/src/hooks/use-feature-flags.tsx
+++ b/src/hooks/use-feature-flags.tsx
@@ -5,11 +5,13 @@ import { useAuth } from './use-auth';
 export interface FeatureFlagsContextType {
 	assistantEnabled: boolean;
 	terminalWpCliEnabled: boolean;
+	siteSyncEnabled: boolean;
 }
 
 export const FeatureFlagsContext = createContext< FeatureFlagsContextType >( {
 	assistantEnabled: false,
 	terminalWpCliEnabled: false,
+	siteSyncEnabled: false,
 } );
 
 interface FeatureFlagsProviderProps {
@@ -19,9 +21,11 @@ interface FeatureFlagsProviderProps {
 export const FeatureFlagsProvider: React.FC< FeatureFlagsProviderProps > = ( { children } ) => {
 	const assistantEnabledFromGlobals = getAppGlobals().assistantEnabled;
 	const terminalWpCliEnabledFromGlobals = getAppGlobals().terminalWpCliEnabled;
+	const siteSyncEnabledFromGlobals = getAppGlobals().siteSyncEnabled;
 	const [ featureFlags, setFeatureFlags ] = useState< FeatureFlagsContextType >( {
 		assistantEnabled: assistantEnabledFromGlobals,
 		terminalWpCliEnabled: terminalWpCliEnabledFromGlobals,
+		siteSyncEnabled: siteSyncEnabledFromGlobals,
 	} );
 	const { isAuthenticated, client } = useAuth();
 
@@ -44,6 +48,7 @@ export const FeatureFlagsProvider: React.FC< FeatureFlagsProviderProps > = ( { c
 						Boolean( flags?.[ 'assistant_enabled' ] ) || assistantEnabledFromGlobals,
 					terminalWpCliEnabled:
 						Boolean( flags?.[ 'terminal_wp_cli_enabled' ] ) || terminalWpCliEnabledFromGlobals,
+					siteSyncEnabled: Boolean( flags?.[ 'site_sync_enabled' ] ) || siteSyncEnabledFromGlobals,
 				} );
 			} catch ( error ) {
 				console.error( error );
@@ -53,7 +58,13 @@ export const FeatureFlagsProvider: React.FC< FeatureFlagsProviderProps > = ( { c
 		return () => {
 			cancel = true;
 		};
-	}, [ isAuthenticated, client, assistantEnabledFromGlobals, terminalWpCliEnabledFromGlobals ] );
+	}, [
+		isAuthenticated,
+		client,
+		assistantEnabledFromGlobals,
+		terminalWpCliEnabledFromGlobals,
+		siteSyncEnabledFromGlobals,
+	] );
 
 	return (
 		<FeatureFlagsContext.Provider value={ featureFlags }>{ children }</FeatureFlagsContext.Provider>

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -515,6 +515,7 @@ export async function getAppGlobals( _event: IpcMainInvokeEvent ): Promise< AppG
 		arm64Translation: app.runningUnderARM64Translation,
 		assistantEnabled: process.env.STUDIO_AI === 'true',
 		terminalWpCliEnabled: process.env.STUDIO_TERMINAL_WP_CLI === 'true',
+		siteSyncEnabled: process.env.STUDIO_SITE_SYNC === 'true',
 	};
 }
 

--- a/src/ipc-types.d.ts
+++ b/src/ipc-types.d.ts
@@ -73,6 +73,7 @@ interface AppGlobals {
 	arm64Translation: boolean;
 	assistantEnabled: boolean;
 	terminalWpCliEnabled: boolean;
+	siteSyncEnabled: boolean;
 }
 
 interface IpcListener {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/9349

## Proposed Changes

This PR adds a `Sync` tab that is hidden behind the feature flag `STUDIO_SITE_SYNC`. 

<img width="859" alt="Screenshot 2024-10-10 at 3 06 23 PM" src="https://github.com/user-attachments/assets/bdac867a-e638-4fe9-8a34-3e3c59d22e80">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
* Run `nvm use && npm install`
* Run `STUDIO_SITE_SYNC=true npm start` to start Studio with the new feature flag
* Confirm that the second tab that you see is called `Sync` and that it is empty at the moment
* Kill the app
* Run `nvm use && npm install && npm start`
* Confirm that you can still see the `Share` tab when the app is not started with the feature flag and that the `Sync` tab is not present

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
