### PR TITLE
Move constant to fix translations

### DIFF
--- a/src/lib/generate-site-name.ts
+++ b/src/lib/generate-site-name.ts
@@ -1,29 +1,28 @@
 import { __ } from '@wordpress/i18n';
 
-const siteNames = [
-	__( 'My Bold Website' ),
-	__( 'My Bright Website' ),
-	__( 'My Blissful Website' ),
-	__( 'My Calm Website' ),
-	__( 'My Cool Website' ),
-	__( 'My Dreamy Website' ),
-	__( 'My Elite Website' ),
-	__( 'My Fresh Website' ),
-	__( 'My Glowing Website' ),
-	__( 'My Happy Website' ),
-	__( 'My Joyful Website' ),
-	__( 'My Noble Website' ),
-	__( 'My Pure Website' ),
-	__( 'My Peak Website' ),
-	__( 'My Prime Website' ),
-	__( 'My Serene Website' ),
-	__( 'My Shiny Website' ),
-	__( 'My Sparkly Website' ),
-	__( 'My Swift Website' ),
-	__( 'My True Website' ),
-];
-
 export function generateSiteName( usedSiteNames: string[] ): string {
+	const siteNames = [
+		__( 'My Bold Website' ),
+		__( 'My Bright Website' ),
+		__( 'My Blissful Website' ),
+		__( 'My Calm Website' ),
+		__( 'My Cool Website' ),
+		__( 'My Dreamy Website' ),
+		__( 'My Elite Website' ),
+		__( 'My Fresh Website' ),
+		__( 'My Glowing Website' ),
+		__( 'My Happy Website' ),
+		__( 'My Joyful Website' ),
+		__( 'My Noble Website' ),
+		__( 'My Pure Website' ),
+		__( 'My Peak Website' ),
+		__( 'My Prime Website' ),
+		__( 'My Serene Website' ),
+		__( 'My Shiny Website' ),
+		__( 'My Sparkly Website' ),
+		__( 'My Swift Website' ),
+		__( 'My True Website' ),
+	];
 	let proposedName = __( 'My WordPress Website' );
 	let tryCount = 0;
 

--- a/src/lib/generate-site-name.ts
+++ b/src/lib/generate-site-name.ts
@@ -43,11 +43,12 @@ export const sanitizeFolderName = ( filename: string ) => {
 	const JAPANESE_HIRAGANA = '\\u3040-\\u309F';
 	const JAPANESE_KATAKANA = '\\u30A0-\\u30FF';
 	const KOREAN_HANGUL = '\\uAC00-\\uD7AF';
+	const KOREAN_JAMO = '\\u1100-\\u11FF'; // Hangul syllables are decomposed to Jamo letters
 	const NUMBERS = '0-9';
 	const WHITELISTED_SYMBOLS = '_\\- '; // Allow underscore, hyphen, and space
 
 	const ALLOWED_CHARS = new RegExp(
-		`[^${ LATIN }${ NUMBERS }${ CYRILLIC }${ ARABIC }${ HEBREW }${ CHINESE }${ JAPANESE_HIRAGANA }${ JAPANESE_KATAKANA }${ KOREAN_HANGUL }${ WHITELISTED_SYMBOLS }]`,
+		`[^${ LATIN }${ NUMBERS }${ CYRILLIC }${ ARABIC }${ HEBREW }${ CHINESE }${ JAPANESE_HIRAGANA }${ JAPANESE_KATAKANA }${ KOREAN_HANGUL }${ KOREAN_JAMO }${ WHITELISTED_SYMBOLS }]`,
 		'gi'
 	);
 

--- a/src/lib/generate-site-name.ts
+++ b/src/lib/generate-site-name.ts
@@ -57,7 +57,7 @@ export const sanitizeFolderName = ( filename: string ) => {
 		.normalize( 'NFKD' )
 		.replace( /[\u0300-\u036f]/g, '' ) // Remove diacritics
 		.toLowerCase()
-		.replace( ALLOWED_CHARS, '')
+		.replace( ALLOWED_CHARS, '' )
 		.trim()
 		.replace( /\s+/g, '-' ) // Replace spaces with hyphens
 		.replace( /-+/g, '-' ); // Replace multiple hyphens with a single one

--- a/src/lib/generate-site-name.ts
+++ b/src/lib/generate-site-name.ts
@@ -35,14 +35,30 @@ export function generateSiteName( usedSiteNames: string[] ): string {
 }
 
 export const sanitizeFolderName = ( filename: string ) => {
+	const LATIN = 'a-z';
+	const CYRILLIC = 'а-яё';
+	const ARABIC = '\\u0600-\\u06FF';
+	const HEBREW = '\\u0590-\\u05FF';
+	const CHINESE = '\\u4e00-\\u9fa5';
+	const JAPANESE_HIRAGANA = '\\u3040-\\u309F';
+	const JAPANESE_KATAKANA = '\\u30A0-\\u30FF';
+	const KOREAN_HANGUL = '\\uAC00-\\uD7AF';
+	const NUMBERS = '0-9';
+	const WHITELISTED_SYMBOLS = '_\\- '; // Allow underscore, hyphen, and space
+
+	const ALLOWED_CHARS = new RegExp(
+		`[^${ LATIN }${ NUMBERS }${ CYRILLIC }${ ARABIC }${ HEBREW }${ CHINESE }${ JAPANESE_HIRAGANA }${ JAPANESE_KATAKANA }${ KOREAN_HANGUL }${ WHITELISTED_SYMBOLS }]`,
+		'gi'
+	);
+
 	return String( filename )
-		.replace( /ł/g, 'l' )
-		.replace( /Ł/g, 'L' )
+		.replace( /ł/g, 'l' ) // Polish ł to l
+		.replace( /Ł/g, 'L' ) // Polish Ł to L
 		.normalize( 'NFKD' )
-		.replace( /[\u0300-\u036f]/g, '' )
+		.replace( /[\u0300-\u036f]/g, '' ) // Remove diacritics
 		.toLowerCase()
-		.replace( /[^a-z0-9 -]/g, '' )
+		.replace( ALLOWED_CHARS, '')
 		.trim()
-		.replace( /\s+/g, '-' )
-		.replace( /-+/g, '-' );
+		.replace( /\s+/g, '-' ) // Replace spaces with hyphens
+		.replace( /-+/g, '-' ); // Replace multiple hyphens with a single one
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to https://github.com/Automattic/studio/issues/416 and https://github.com/Automattic/dotcom-forge/issues/8648

## Proposed Changes

I propose to move constants to function to ensure phrases are translated after translations are loaded.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Switch language to other than English
2. Add the first site, and confirm that 'My WordPress Website' gets translated
3. Add another site and confirm that generated name is translated

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
