### PR TITLE
Regenerate media thumbnails when importing any WordPress backup

### DIFF
--- a/src/hooks/tests/use-import-export.test.tsx
+++ b/src/hooks/tests/use-import-export.test.tsx
@@ -337,7 +337,7 @@ describe( 'useImportExport hook', () => {
 		expect( result.current.importState ).toEqual( {
 			[ SITE_ID ]: {
 				statusMessage: 'Importing WordPress content…',
-				progress: 95,
+				progress: 90,
 				isNewSite: false,
 			},
 		} );

--- a/src/hooks/tests/use-import-export.test.tsx
+++ b/src/hooks/tests/use-import-export.test.tsx
@@ -342,6 +342,15 @@ describe( 'useImportExport hook', () => {
 			},
 		} );
 
+		emitImportEvent( SITE_ID, ImportEvents.IMPORT_MEDIA_REGENERATE_START );
+		expect( result.current.importState ).toEqual( {
+			[ SITE_ID ]: {
+				statusMessage: 'Regenerating media…',
+				progress: 95,
+				isNewSite: false,
+			},
+		} );
+
 		emitImportEvent( SITE_ID, ImportEvents.IMPORT_COMPLETE );
 		expect( result.current.importState ).toEqual( {
 			[ SITE_ID ]: {

--- a/src/hooks/use-import-export.tsx
+++ b/src/hooks/use-import-export.tsx
@@ -211,6 +211,16 @@ export const ImportExportProvider = ( { children }: { children: React.ReactNode 
 					...rest,
 					[ siteId ]: {
 						...currentProgress,
+						progress: 90,
+					},
+				} ) );
+				break;
+			case ImporterEvents.IMPORT_MEDIA_REGENERATE_START:
+				setImportState( ( { [ siteId ]: currentProgress, ...rest } ) => ( {
+					...rest,
+					[ siteId ]: {
+						...currentProgress,
+						statusMessage: __( 'Regenerating media…' ),
 						progress: 95,
 					},
 				} ) );

--- a/src/lib/import-export/import/events.ts
+++ b/src/lib/import-export/import/events.ts
@@ -19,6 +19,8 @@ export const ImporterEvents = {
 	IMPORT_WP_CONTENT_COMPLETE: 'import_wp_content_complete',
 	IMPORT_META_START: 'import_meta',
 	IMPORT_META_COMPLETE: 'import_meta_complete',
+	IMPORT_MEDIA_REGENERATE_START: 'import_media_regenerate_start',
+	IMPORT_MEDIA_REGENERATE_COMPLETE: 'import_media_regenerate_complete',
 	IMPORT_COMPLETE: 'import_complete',
 	IMPORT_ERROR: 'import_error',
 } as const;

--- a/src/lib/import-export/import/importers/importer.ts
+++ b/src/lib/import-export/import/importers/importer.ts
@@ -204,10 +204,14 @@ abstract class BaseBackupImporter extends BaseImporter {
 	}
 
 	protected async importWpConfig( rootPath: string ): Promise< void > {
-		if ( ! this.backup.wpConfig ) {
-			return;
+		const wpConfigPath = path.join( rootPath, 'wp-config.php' );
+		const wpConfigSamplePath = path.join( rootPath, 'wp-config-sample.php' );
+
+		if ( this.backup.wpConfig ) {
+			await fsPromises.copyFile( this.backup.wpConfig, wpConfigPath );
+		} else if ( ! fs.existsSync( wpConfigPath ) && fs.existsSync( wpConfigSamplePath ) ) {
+			await fsPromises.copyFile( wpConfigSamplePath, wpConfigPath );
 		}
-		await fsPromises.copyFile( this.backup.wpConfig, `${ rootPath }/wp-config.php` );
 	}
 
 	protected async importWpContent( rootPath: string ): Promise< void > {

--- a/src/lib/import-export/import/importers/importer.ts
+++ b/src/lib/import-export/import/importers/importer.ts
@@ -246,7 +246,9 @@ export class JetpackImporter extends BaseBackupImporter {
 		if ( ! server ) {
 			throw new Error( 'Site not found.' );
 		}
+		this.emit( ImportEvents.IMPORT_MEDIA_REGENERATE_START );
 		await server.executeWpCliCommand( 'media regenerate --yes' );
+		this.emit( ImportEvents.IMPORT_MEDIA_REGENERATE_COMPLETE );
 	}
 }
 

--- a/src/lib/import-export/tests/import/importer/default-importer.test.ts
+++ b/src/lib/import-export/tests/import/importer/default-importer.test.ts
@@ -116,5 +116,13 @@ describe( 'JetpackImporter', () => {
 			expect( fs.copyFile ).toHaveBeenCalledTimes( 4 );
 			expect( fs.readFile ).toHaveBeenCalledWith( '/tmp/extracted/studio.json', 'utf-8' );
 		} );
+
+		it( 'should regenerate media after import', async () => {
+			const importer = new JetpackImporter( mockBackupContents );
+			await importer.import( mockStudioSitePath, mockStudioSiteId );
+
+			const siteServer = SiteServer.get( mockStudioSiteId );
+			expect( siteServer?.executeWpCliCommand ).toHaveBeenCalledWith( 'media regenerate --yes' );
+		} );
 	} );
 } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

- Solves https://github.com/Automattic/dotcom-forge/issues/8758

## Proposed Changes

- It runs `wp media regenerate --yes` WP-CLI commands after importing a Jetpack, Local, Playground or .wpress backup, fixing the thumbnails in ``
- There is a new import step for Jetpack sites that say `Regenerating media…`
- Add tests for the new step

If we observe other backups do not include the thumbnails, we can execute the same command for other backup types.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Download a Jetpack backup or .wpress from an atomic site with images. You can use the activity log for that.
- Run `npm start`
- Import that backup into a new site (Add new site button) or existing site (Import/Export tab)
- Observe there is a new last step says `Regenerating media…`
- Start the site and go to wp-admin
- Navigate to media
- Observe all the thumbnails are correctly visible

https://github.com/user-attachments/assets/6d682b50-8858-4a67-bb26-b6d19df4327f


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
