### PR TITLE
Ensure Windows' application menu button is always visible by leaving space for window controls

### DIFF
--- a/src/components/windows-titlebar.tsx
+++ b/src/components/windows-titlebar.tsx
@@ -6,6 +6,15 @@ import { cx } from '../lib/cx';
 import { getIpcApi } from '../lib/get-ipc-api';
 import Button from './button';
 
+interface HasTextInfo {
+	textInfo: { direction: 'ltr' | 'rtl' };
+}
+
+// If this breaks in a future Electron version, we might need to change `textInfo` to `getTextInfo()`
+// See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/getTextInfo
+const isWindowFrameRtl =
+	'rtl' === ( new Intl.Locale( navigator.language ) as unknown as HasTextInfo ).textInfo.direction;
+
 export default function WindowsTitlebar( {
 	className,
 	children,
@@ -14,7 +23,20 @@ export default function WindowsTitlebar( {
 	children?: React.ReactNode;
 } ) {
 	return (
-		<HStack alignment="left" className={ cx( 'bg-chrome text-white', className ) } spacing="2">
+		<HStack
+			alignment="left"
+			className={ cx(
+				'bg-chrome text-white',
+				// Leave space for window controls depending on which side they are on
+				// Take into account the "chrome" padding, the position of which depends on the language direction
+				isWindowFrameRtl &&
+					'ltr:pl-window-controls-width-win rtl:pl-window-controls-width-excl-chrome-win',
+				! isWindowFrameRtl &&
+					'ltr:pr-window-controls-width-excl-chrome-win rtl:pr-window-controls-width-win',
+				className
+			) }
+			spacing="2"
+		>
 			<Button
 				variant="icon"
 				onClick={ () => {
@@ -29,7 +51,7 @@ export default function WindowsTitlebar( {
 				<img src={ appIcon } alt="" className="w-[16px] flex-shrink-0" />
 				<h1 className="text-xs">{ getAppGlobals().appName }</h1>
 			</div>
-			<div className="flex-1 pl-2 pr-32">{ children }</div>
+			<div className="flex-1 pl-2">{ children }</div>
 		</HStack>
 	);
 }

--- a/src/components/windows-titlebar.tsx
+++ b/src/components/windows-titlebar.tsx
@@ -51,7 +51,7 @@ export default function WindowsTitlebar( {
 				<img src={ appIcon } alt="" className="w-[16px] flex-shrink-0" />
 				<h1 className="text-xs">{ getAppGlobals().appName }</h1>
 			</div>
-			<div className="flex-1 pl-2">{ children }</div>
+			<div className="flex-1 ps-2">{ children }</div>
 		</HStack>
 	);
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -146,6 +146,8 @@ module.exports = {
 				sidebar: '6px',
 				'sidebar-mac': '10px',
 				'titlebar-win': `${ WINDOWS_TITLEBAR_HEIGHT }px`,
+				'window-controls-width-win': '138px',
+				'window-controls-width-excl-chrome-win': '128px', // Subtract 10px for the chrome
 			},
 			borderRadius: {
 				chrome: '5px',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to #541

Studio has a concept of what the active language is, however we don't tell Chromium about it. That means that while we might be rendering Arabic text in the UI, Chromium might still be using English under the hood. This means that the LTR browser window controls might obscure the React controls which think we're in RTL mode.

This PR adjusts logic so that all components are visible, even when our language at the Chromium language directions are mismatched. In a future task we should probably tell Chromium to use the same language the rest of the app uses. But in the mean time it's still important to handle the mismatch gracefully since [Chromium's language can't be changed without a restart](https://www.electronjs.org/docs/latest/api/command-line-switches#--lang), so there'll always be a period of time when we'll have to render the mismatched version of the app.

The mismatched version of the app is still a little less important though, so I didn't bother getting all the alignment perfectly right. For example in the screenshots below, notice that the left side of the help icon has too much padding when the language is RTL but the window is LTR.

## Proposed Changes

- Move the padding that leaves space for Windows' window controls up to the top-level of `<WindowsTitlebar>` so that the padding never appears in the middle of the component, always at the very left or very right
- Ensure the padding we leave for Windows' window controls is based on the _browser window's_ language, not the language used by `@wordpress/i18n` etc.
- Use a fixed pixel width for the window controls, rather than some number of `rem`
- Use [logical property](https://developer.mozilla.org/en-US/docs/Web/CSS/padding-inline-start) to define padding between `<WindowsTitlebar>` and `<TopBar>` so it automatically responds to language RTL changes

**RTL language in a RTL window**
![image](https://github.com/user-attachments/assets/f22bd16d-272a-4fb7-b325-07a9a8736792)

**LTR language in a RTL window**
![image](https://github.com/user-attachments/assets/248b632a-46ff-4043-a4b7-eee60e06917b)

**LTR language in a LTR window**
![image](https://github.com/user-attachments/assets/b4eee820-3927-4678-b6f0-9d2c12487e51)

**RTL language in a LTR window**
![image](https://github.com/user-attachments/assets/0f31421d-6a55-4988-9d69-07aa8afeef13)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Here's a quick way to change the browser window's language without having to reboot your OS into a different language: add `app.commandLine.appendSwitch( 'lang', 'ar' );` at the very top of `index.ts`, right after the `import` statements.

- Test a LTR language in a RTL window
- Test a LTR language in a LTR window
- Test a RTL language in a RTL window
- Test a RTL language in a LTR window
- Confirm app menu items still work as expected
- Confirm there are no changes for Mac

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
