### PR TITLE
Ensure Mac's titlebar padding always leaves space for the window controls

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -9,6 +9,7 @@ import { useSidebarVisibility } from '../hooks/use-sidebar-visibility';
 import { isWindows } from '../lib/app-globals';
 import { cx } from '../lib/cx';
 import { getIpcApi } from '../lib/get-ipc-api';
+import MacTitlebar from './mac-titlebar';
 import MainSidebar from './main-sidebar';
 import Onboarding from './onboarding';
 import { SiteContentTabs } from './site-content-tabs';
@@ -49,9 +50,9 @@ export default function App() {
 							<TopBar onToggleSidebar={ toggleSidebar } />
 						</WindowsTitlebar>
 					) : (
-						<div className="pl-20 flex-shrink-0">
+						<MacTitlebar className="flex-shrink-0">
 							<TopBar onToggleSidebar={ toggleSidebar } />
-						</div>
+						</MacTitlebar>
 					) }
 
 					<HStack spacing="0" alignment="left" className="flex-grow">

--- a/src/components/mac-titlebar.tsx
+++ b/src/components/mac-titlebar.tsx
@@ -1,0 +1,26 @@
+import { cx } from '../lib/cx';
+import { isWindowFrameRtl } from '../lib/is-window-frame-rtl';
+
+export default function MacTitlebar( {
+	className,
+	children,
+}: {
+	className?: string;
+	children?: React.ReactNode;
+} ) {
+	return (
+		<div
+			className={ cx(
+				// Leave space for window controls depending on which side they are on
+				// Take into account the "chrome" padding, the position of which depends on the language direction
+				isWindowFrameRtl() &&
+					'ltr:pr-window-controls-width-excl-chrome-mac ltr:pl-chrome rtl:pr-window-controls-width-mac rtl:-ml-chrome',
+				! isWindowFrameRtl() &&
+					'ltr:pl-window-controls-width-mac rtl:pl-window-controls-width-excl-chrome-mac rtl:pr-chrome',
+				className
+			) }
+		>
+			{ children }
+		</div>
+	);
+}

--- a/src/components/main-sidebar.tsx
+++ b/src/components/main-sidebar.tsx
@@ -24,7 +24,7 @@ export default function MainSidebar( { className }: MainSidebarProps ) {
 				<div
 					className={ cx(
 						'flex-1 overflow-y-auto sites-scrollbar app-no-drag-region',
-						isMac() ? 'ml-4' : 'ml-3'
+						isMac() ? 'ms-4' : 'ms-3'
 					) }
 				>
 					<SiteMenu />

--- a/src/components/site-menu.tsx
+++ b/src/components/site-menu.tsx
@@ -104,8 +104,8 @@ function SiteItem( { site }: { site: SiteDetails } ) {
 	return (
 		<li
 			className={ cx(
-				'flex flex-row min-w-[168px] h-8 hover:bg-[#ffffff0C] rounded transition-all ml-1',
-				isMac() ? 'mr-5' : 'mr-4',
+				'flex flex-row min-w-[168px] h-8 hover:bg-[#ffffff0C] rounded transition-all ms-1',
+				isMac() ? 'me-5' : 'me-4',
 				isSelected && 'bg-[#ffffff19] hover:bg-[#ffffff19]'
 			) }
 		>

--- a/src/components/windows-titlebar.tsx
+++ b/src/components/windows-titlebar.tsx
@@ -4,16 +4,8 @@ import appIcon from '../../assets/titlebar-icon.svg';
 import { getAppGlobals } from '../lib/app-globals';
 import { cx } from '../lib/cx';
 import { getIpcApi } from '../lib/get-ipc-api';
+import { isWindowFrameRtl } from '../lib/is-window-frame-rtl';
 import Button from './button';
-
-interface HasTextInfo {
-	textInfo: { direction: 'ltr' | 'rtl' };
-}
-
-// If this breaks in a future Electron version, we might need to change `textInfo` to `getTextInfo()`
-// See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/getTextInfo
-const isWindowFrameRtl =
-	'rtl' === ( new Intl.Locale( navigator.language ) as unknown as HasTextInfo ).textInfo.direction;
 
 export default function WindowsTitlebar( {
 	className,
@@ -29,9 +21,9 @@ export default function WindowsTitlebar( {
 				'bg-chrome text-white',
 				// Leave space for window controls depending on which side they are on
 				// Take into account the "chrome" padding, the position of which depends on the language direction
-				isWindowFrameRtl &&
+				isWindowFrameRtl() &&
 					'ltr:pl-window-controls-width-win rtl:pl-window-controls-width-excl-chrome-win',
-				! isWindowFrameRtl &&
+				! isWindowFrameRtl() &&
 					'ltr:pr-window-controls-width-excl-chrome-win rtl:pr-window-controls-width-win',
 				className
 			) }

--- a/src/lib/is-window-frame-rtl.ts
+++ b/src/lib/is-window-frame-rtl.ts
@@ -1,0 +1,21 @@
+interface HasTextInfo {
+	textInfo: { direction: 'ltr' | 'rtl' };
+}
+
+let cachedResult: boolean | null = null;
+
+/**
+ * Returns true when the window frame's language (not the language set in the app)
+ * is right-to-left.
+ */
+export function isWindowFrameRtl(): boolean {
+	if ( null === cachedResult ) {
+		// If `textInfo` is removed in a future version of Electron, we might need to change it to `getTextInfo()`
+		// See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/getTextInfo
+		cachedResult =
+			'rtl' ===
+			( new Intl.Locale( navigator.language ) as unknown as HasTextInfo ).textInfo.direction;
+	}
+
+	return cachedResult;
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -148,6 +148,8 @@ module.exports = {
 				'titlebar-win': `${ WINDOWS_TITLEBAR_HEIGHT }px`,
 				'window-controls-width-win': '138px',
 				'window-controls-width-excl-chrome-win': '128px', // Subtract 10px for the chrome
+				'window-controls-width-mac': '80px',
+				'window-controls-width-excl-chrome-mac': '70px', // Subtract 10px for the chrome
 			},
 			borderRadius: {
 				chrome: '5px',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to #541 and #596

This PR fixes the same issue as #596 except this time for Mac. Namely, the padding in the app's top bar needs to be aware of both the RTL mode of the language _and_ the RTL mode of the underlying browser window.

## Proposed Changes

- Refactor `isWindowFrameRtl` logic into utility module
- Create a `<MacTitlebar>` component that does the equivalent job of `<WindowsTitlebar>`
   - i.e. adjust padding to accommodate windows controls
   - Linux continues to the same topbar padding logic as Mac. No change here.
- Ensure the padding we leave for Mac window controls is based on the browser window's language, not the language used by `@wordpress/i18n` etc.
- Use a fixed pixel width for the window controls, rather than some number of `rem`
- Did some fix ups in the site's sidebar to use [logical properties](https://developer.mozilla.org/en-US/docs/Web/CSS/padding-inline-start), which can automatically deal with RTL switches.
   - I did a side-by-side comparison with `trunk` to confirm none of the padding sidebar padding has changed.

**RTL language in a RTL window**
![ar-rtlCleanShot 2024-10-16 at 21 08 07@2x](https://github.com/user-attachments/assets/d7fdd661-61be-4b8b-8cb4-c4559e4c8af0)

**LTR language in a RTL window**
![en-rtlCleanShot 2024-10-16 at 21 08 31@2x](https://github.com/user-attachments/assets/6486ec37-3c5d-4341-b71b-6c35413ab336)

**LTR language in a LTR window**
![CleanShot 2024-10-16 at 21 19 34@2x](https://github.com/user-attachments/assets/d953e391-d7a7-4ac8-85a8-1a2a2eda724b)


**RTL language in a LTR window**
![ar-ltrCleanShot 2024-10-16 at 21 06 52@2x](https://github.com/user-attachments/assets/40ce086d-979d-48b9-83ad-0d868d258852)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Here's a quick way to change the browser window's language without having to reboot your OS into a different language: add `app.commandLine.appendSwitch( 'lang', 'ar' );` at the very top of `index.ts`, right after the `import` statements.

- Test a LTR language in a RTL window
- Test a LTR language in a LTR window
- Test a RTL language in a RTL window
- Test a RTL language in a LTR window

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
