### PR TITLE
Fix hardcoded wp-cli execution paths

### DIFF
--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -666,8 +666,7 @@ export function openTerminalAtPath(
 			}
 		} else if ( platform === 'darwin' ) {
 			// macOS
-			const loadWpCliCommand =
-				'clear && export PATH=\\"${ cliPath }\\":$PATH && export STUDIO_APP_PATH=\\"${ appPath }\\" &&';
+			const loadWpCliCommand = `clear && export PATH=\\"${ cliPath }\\":$PATH && export STUDIO_APP_PATH=\\"${ appPath }\\" &&`;
 			const script = `
 			tell application "Terminal"
 				if not application "Terminal" is running then launch


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to p1729153254575689-slack-C06DRMD6VPZ

## Proposed Changes

- Fix wp-cli execution from terminal on Mac when the feature is enabled

In dev mode, when running `npm start`, wp-cli in wasm  is loaded correctly in the terminal, because it takes the path of the dev Electron + the path of the project and it considers that as a single command. It seems it didn't work before either. It was introduced on https://github.com/Automattic/studio/pull/268
If we consider something important, we can create an issue to tackle it separately.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run `npm run make && STUDIO_TERMINAL_WP_CLI=true open out/Studio-darwin-arm64/Studio.app/Contents/MacOS/Studio`
- Observe Studio opens correctly
- Click on "terminal" in the overview page
- Run `wp --version`
- Observe it returns `WP-CLI 2.11.0`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?