### PR TITLE
Proof-of-concept: Calling `/me/sites` API endpoint

### DIFF
--- a/src/components/top-bar.tsx
+++ b/src/components/top-bar.tsx
@@ -1,5 +1,6 @@
 import { __, sprintf } from '@wordpress/i18n';
 import { Icon, help, drawerLeft } from '@wordpress/icons';
+import { useEffect } from 'react';
 import { STUDIO_DOCS_URL } from '../constants';
 import { useAuth } from '../hooks/use-auth';
 import { useOffline } from '../hooks/use-offline';
@@ -48,7 +49,23 @@ function OfflineIndicator() {
 }
 
 function Authentication() {
-	const { isAuthenticated, user } = useAuth();
+	const { isAuthenticated, client, user } = useAuth();
+
+	useEffect( () => {
+		if ( ! isAuthenticated ) {
+			return;
+		}
+
+		client?.req
+			.get( {
+				apiNamespace: 'rest/v1.2',
+				path: `/me/sites`,
+			} )
+			.then( ( res ) => {
+				console.log( res );
+			} );
+	} );
+
 	if ( isAuthenticated ) {
 		return (
 			<Button

--- a/src/components/top-bar.tsx
+++ b/src/components/top-bar.tsx
@@ -57,10 +57,17 @@ function Authentication() {
 		}
 
 		client?.req
-			.get( {
-				apiNamespace: 'rest/v1.2',
-				path: `/me/sites`,
-			} )
+			.get(
+				{
+					apiNamespace: 'rest/v1.2',
+					path: `/me/sites`,
+				},
+				{
+					fields:
+						'name,ID,plan,is_wpcom_staging_site,is_wpcom_atomic,wpcom_staging_blog_ids,options',
+					options: 'created_at',
+				}
+			)
 			.then( ( res ) => {
 				console.log( res );
 			} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/9345

## Proposed Changes

A simple illustration of how to use the `WPCOM` client provided by the `useAuth` hook to retrieve sites from the `public-api.wordpress.com/rest/v1.2/me/sites` API endpoint.

## Testing Instructions

Not intended to be landed