### PR TITLE
Fetch real API data in sync modal

### DIFF
--- a/src/components/content-tab-sync.tsx
+++ b/src/components/content-tab-sync.tsx
@@ -164,7 +164,7 @@ function NoAuthSyncTab() {
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function ContentTabSync( { selectedSite }: { selectedSite: SiteDetails } ) {
 	const { __ } = useI18n();
-	const { syncSites, connectedSites, setConnectedSites } = useSyncSites();
+	const { syncSites, connectedSites, setConnectedSites, isFetching } = useSyncSites();
 	const [ isSyncSitesSelectorOpen, setIsSyncSitesSelectorOpen ] = useState( false );
 	const { isAuthenticated } = useAuth();
 	if ( ! isAuthenticated ) {
@@ -210,6 +210,7 @@ export function ContentTabSync( { selectedSite }: { selectedSite: SiteDetails } 
 
 			{ isSyncSitesSelectorOpen && (
 				<SyncSitesModalSelector
+					isLoading={ isFetching }
 					onRequestClose={ () => setIsSyncSitesSelectorOpen( false ) }
 					syncSites={ syncSites }
 					onConnect={ ( siteId ) => {

--- a/src/components/sync-sites-modal-selector.tsx
+++ b/src/components/sync-sites-modal-selector.tsx
@@ -13,10 +13,12 @@ import { WordPressShortLogo } from './wordpress-short-logo';
 const SearchControl = process.env.NODE_ENV === 'test' ? () => null : SearchControlWp;
 
 export function SyncSitesModalSelector( {
+	isLoading,
 	onRequestClose,
 	onConnect,
 	syncSites,
 }: {
+	isLoading?: boolean;
 	onRequestClose: () => void;
 	syncSites: SyncSite[];
 	onConnect: ( siteId: number ) => void;
@@ -27,6 +29,8 @@ export function SyncSitesModalSelector( {
 	const filteredSites = syncSites.filter( ( site ) =>
 		site.name.toLowerCase().includes( searchQuery.toLowerCase() )
 	);
+	const isEmpty = filteredSites.length === 0;
+
 	return (
 		<Modal
 			className="w-3/5 min-w-[550px] h-full max-h-[84vh] [&>div]:!p-0"
@@ -35,13 +39,19 @@ export function SyncSitesModalSelector( {
 		>
 			<SearchSites searchQuery={ searchQuery } setSearchQuery={ setSearchQuery } />
 			<div className="h-[calc(84vh-230px)]">
-				{ filteredSites.length === 0 ? (
+				{ isLoading && (
+					<div className="flex justify-center items-center h-full">{ __( 'Loading sites' ) }</div>
+				) }
+
+				{ ! isLoading && isEmpty && (
 					<div className="flex justify-center items-center h-full">
 						{ searchQuery
 							? sprintf( __( 'No sites found for "%s"' ), searchQuery )
 							: __( 'No sites found' ) }
 					</div>
-				) : (
+				) }
+
+				{ ! isLoading && ! isEmpty && (
 					<ListSites
 						syncSites={ filteredSites }
 						selectedSiteId={ selectedSiteId }
@@ -148,7 +158,7 @@ function SiteItem( {
 			<div className="flex flex-col gap-0.5 pr-4">
 				<div className={ cx( 'a8c-body', ! isSyncable && 'text-a8c-gray-30' ) }>{ site.name }</div>
 				<div className={ cx( 'a8c-body-small text-a8c-gray-30', isSelected && 'text-white' ) }>
-					{ site.url }
+					{ site.url.replace( /^https?:\/\//, '' ) }
 				</div>
 			</div>
 			{ isSyncable && (
@@ -203,8 +213,8 @@ function Footer( {
 				className="flex items-center mb-1"
 				onClick={ () => getIpcApi().openURL( 'https://wordpress.com/hosting/' ) }
 			>
-				<div className="a8c-subtitle text-black">{ __( 'Powered by' ) }</div>
-				<WordPressShortLogo className="ml-2 h-5" />
+				<div className="a8c-subtitle-small text-black">{ __( 'Powered by' ) }</div>
+				<WordPressShortLogo className="h-4.5" />
 			</Button>
 			<div className="flex gap-4">
 				<Button variant="link" onClick={ onRequestClose }>

--- a/src/components/sync-sites-modal-selector.tsx
+++ b/src/components/sync-sites-modal-selector.tsx
@@ -40,7 +40,7 @@ export function SyncSitesModalSelector( {
 			<SearchSites searchQuery={ searchQuery } setSearchQuery={ setSearchQuery } />
 			<div className="h-[calc(84vh-230px)]">
 				{ isLoading && (
-					<div className="flex justify-center items-center h-full">{ __( 'Loading sites' ) }</div>
+					<div className="flex justify-center items-center h-full">{ __( 'Loading sites…' ) }</div>
 				) }
 
 				{ ! isLoading && isEmpty && (

--- a/src/custom-package-definitions.d.ts
+++ b/src/custom-package-definitions.d.ts
@@ -46,9 +46,13 @@ declare module '@timfish/forge-externals-plugin' {
 declare module 'wpcom' {
 	class Request {
 		/* eslint-disable @typescript-eslint/no-explicit-any */
-		get( params: object | string, query?: object ): Promise< any >;
-		post( params: object | string, query?: object, body?: object ): Promise< any >;
-		del( params: object | string, query?: object ): Promise< any >;
+		get< TResponse = any >( params: object | string, query?: object ): Promise< TResponse >;
+		post< TResponse = any >(
+			params: object | string,
+			query?: object,
+			body?: object
+		): Promise< TResponse >;
+		del< TResponse = any >( params: object | string, query?: object ): Promise< TResponse >;
 		/* eslint-enable @typescript-eslint/no-explicit-any */
 	}
 

--- a/src/hooks/use-sync-sites.ts
+++ b/src/hooks/use-sync-sites.ts
@@ -1,82 +1,111 @@
-import { useState, useEffect } from 'react';
+import * as Sentry from '@sentry/electron/renderer';
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { useAuth } from './use-auth';
+import { useOffline } from './use-offline';
 
 export type SyncSupport = 'unsupported' | 'syncable' | 'needs-transfer' | 'already-connected';
 
-export interface SyncSite {
+export type SyncSite = {
 	id: number;
 	name: string;
 	url: string;
 	isStaging: boolean;
 	stagingSiteIds: number[];
 	syncSupport: SyncSupport;
+};
+
+type Site = {
+	ID: number;
+	is_wpcom_atomic: boolean;
+	is_wpcom_staging_site: boolean;
+	name: string;
+	URL: string;
+	options: {
+		created_at: string;
+		wpcom_staging_blog_ids: number[];
+	};
+	plan: {
+		expired: boolean;
+		features: {
+			active: string[];
+			available: Record< string, string[] >;
+		};
+		is_free: boolean;
+		product_id: number;
+		product_name_short: string;
+		product_slug: string;
+		user_is_owner: boolean;
+	};
+};
+
+type SitesEndpointResponse = {
+	sites: Site[];
+};
+
+function getSyncSupport( site: Site ): SyncSupport {
+	if ( site.plan.product_id !== 1008 ) {
+		return 'unsupported';
+	}
+	if ( ! site.is_wpcom_atomic ) {
+		return 'needs-transfer';
+	}
+	return 'syncable';
 }
 
-const FAKE_SITES: SyncSite[] = [
-	{
-		id: 1,
-		name: 'My First Site',
-		url: 'https://developer.wordpress.com',
-		isStaging: false,
-		stagingSiteIds: [],
-		syncSupport: 'syncable',
-	},
-	{
-		id: 2,
-		name: 'My Blog',
-		url: 'https://developer.wordpress.com',
-		isStaging: false,
-		stagingSiteIds: [],
-		syncSupport: 'unsupported',
-	},
-	{
-		id: 3,
-		name: 'My Project',
-		url: 'https://developer.wordpress.com',
-		isStaging: false,
-		stagingSiteIds: [ 4 ],
-		syncSupport: 'syncable',
-	},
-	{
-		id: 4,
-		name: 'My Project',
-		url: 'https:/developer.wordpress.com/studio/',
-		isStaging: true,
-		stagingSiteIds: [],
-		syncSupport: 'syncable',
-	},
-	{
-		id: 5,
-		name: 'My Project Site with a suuuuuuper long long long name that should appear in multiple lines with a nice padding on the side, so it keeps being readable',
-		url: 'https:/developer.wordpress.com/studio/',
-		isStaging: false,
-		stagingSiteIds: [],
-		syncSupport: 'syncable',
-	},
-	{
-		id: 6,
-		name: 'My simple business site that needs a transfer',
-		url: 'https:/developer.wordpress.com/studio/',
-		isStaging: false,
-		stagingSiteIds: [],
-		syncSupport: 'needs-transfer',
-	},
-	...Array.from( { length: 10 }, ( _, index ) => ( {
-		id: index + 7,
-		name: `My Pro site ${ index + 7 }`,
-		url: `https://developer.wordpress.com/`,
-		isStaging: false,
-		stagingSiteIds: [],
-		syncSupport: 'syncable' as SyncSupport,
-	} ) ),
-];
+function transformSiteResponse( sites: Site[] ): SyncSite[] {
+	return sites.map( ( site ) => {
+		return {
+			id: site.ID,
+			name: site.name,
+			url: site.URL,
+			isStaging: site.is_wpcom_staging_site,
+			stagingSiteIds: site.options.wpcom_staging_blog_ids,
+			syncSupport: getSyncSupport( site ),
+		};
+	} );
+}
 
 export function useSyncSites() {
 	const [ syncSites, setSyncSites ] = useState< SyncSite[] >( [] );
 	const [ connectedSites, setConnectedSites ] = useState< SyncSite[] >( [] );
+	const { isAuthenticated, client } = useAuth();
+	const isFetchingSites = useRef( false );
+	const isOffline = useOffline();
+
+	const fetchSites = useCallback( async () => {
+		if ( ! client?.req || isFetchingSites.current || ! isAuthenticated || isOffline ) {
+			return;
+		}
+
+		isFetchingSites.current = true;
+
+		try {
+			const response = await client.req.get< SitesEndpointResponse >(
+				{
+					apiNamespace: 'rest/v1.2',
+					path: `/me/sites`,
+				},
+				{
+					fields: 'name,ID,URL,plan,is_wpcom_staging_site,is_wpcom_atomic,options',
+					filter: 'atomic,wpcom',
+					options: 'created_at,wpcom_staging_blog_ids',
+				}
+			);
+
+			if ( response ) {
+				setSyncSites( transformSiteResponse( response.sites ) );
+			}
+		} catch ( error ) {
+			Sentry.captureException( error );
+			console.error( error );
+		} finally {
+			isFetchingSites.current = false;
+		}
+	}, [ client?.req, isAuthenticated, isOffline ] );
 
 	useEffect( () => {
-		setSyncSites( FAKE_SITES );
-	}, [] );
+		fetchSites();
+	}, [ fetchSites, isOffline ] );
 
 	const isSiteAlreadyConnected = ( siteId: number ) =>
 		connectedSites.some( ( site ) => site.id === siteId );
@@ -88,5 +117,6 @@ export function useSyncSites() {
 		} ) ),
 		connectedSites,
 		setConnectedSites,
+		isFetching: isFetchingSites.current,
 	};
 }

--- a/src/hooks/use-sync-sites.ts
+++ b/src/hooks/use-sync-sites.ts
@@ -8,7 +8,7 @@ const COMMERCE_PLAN_ID = 1011;
 
 type SyncSupport = 'unsupported' | 'syncable' | 'needs-transfer' | 'already-connected';
 
-type SyncSite = {
+export type SyncSite = {
 	id: number;
 	name: string;
 	url: string;

--- a/src/hooks/use-sync-sites.ts
+++ b/src/hooks/use-sync-sites.ts
@@ -3,9 +3,6 @@ import { useState, useEffect, useRef } from 'react';
 import { useAuth } from './use-auth';
 import { useOffline } from './use-offline';
 
-const BUSINESS_PLAN_ID = 1008;
-const COMMERCE_PLAN_ID = 1011;
-
 type SyncSupport = 'unsupported' | 'syncable' | 'needs-transfer' | 'already-connected';
 
 export type SyncSite = {
@@ -45,11 +42,13 @@ type SitesEndpointResponse = {
 	sites: SitesEndpointSite[];
 };
 
+const STUDIO_SYNC_FEATURE_NAME = 'studio-sync';
+
 function getSyncSupport( site: SitesEndpointSite, connectedSiteIds: number[] ): SyncSupport {
 	if ( connectedSiteIds.some( ( id ) => id === site.ID ) ) {
 		return 'already-connected';
 	}
-	if ( site.plan.product_id !== BUSINESS_PLAN_ID && site.plan.product_id !== COMMERCE_PLAN_ID ) {
+	if ( ! site.plan.features.active.includes( STUDIO_SYNC_FEATURE_NAME ) ) {
 		return 'unsupported';
 	}
 	if ( ! site.is_wpcom_atomic ) {

--- a/src/hooks/use-sync-sites.ts
+++ b/src/hooks/use-sync-sites.ts
@@ -14,7 +14,7 @@ export type SyncSite = {
 	syncSupport: SyncSupport;
 };
 
-type Site = {
+type SitesEndpointSite = {
 	ID: number;
 	is_wpcom_atomic: boolean;
 	is_wpcom_staging_site: boolean;
@@ -39,14 +39,14 @@ type Site = {
 };
 
 type SitesEndpointResponse = {
-	sites: Site[];
+	sites: SitesEndpointSite[];
 };
 
-function getSyncSupport( site: Site, connectedSiteIds: number[] ): SyncSupport {
+function getSyncSupport( site: SitesEndpointSite, connectedSiteIds: number[] ): SyncSupport {
 	if ( connectedSiteIds.some( ( id ) => id === site.ID ) ) {
 		return 'already-connected';
 	}
-	if ( site.plan.product_id !== 1008 ) {
+	if ( site.plan.product_id !== 1008 && site.plan.product_id !== 1011 ) {
 		return 'unsupported';
 	}
 	if ( ! site.is_wpcom_atomic ) {
@@ -55,7 +55,10 @@ function getSyncSupport( site: Site, connectedSiteIds: number[] ): SyncSupport {
 	return 'syncable';
 }
 
-function transformSiteResponse( sites: Site[], connectedSiteIds: number[] ): SyncSite[] {
+function transformSiteResponse(
+	sites: SitesEndpointSite[],
+	connectedSiteIds: number[]
+): SyncSite[] {
 	return sites.map( ( site ) => {
 		return {
 			id: site.ID,
@@ -112,7 +115,7 @@ export function useSyncSites() {
 	}, [ client?.req, connectedSites, isAuthenticated, isOffline ] );
 
 	return {
-		syncSites: syncSites,
+		syncSites,
 		connectedSites,
 		setConnectedSites,
 		isFetching: isFetchingSites.current,

--- a/src/hooks/use-sync-sites.ts
+++ b/src/hooks/use-sync-sites.ts
@@ -3,9 +3,12 @@ import { useState, useEffect, useRef } from 'react';
 import { useAuth } from './use-auth';
 import { useOffline } from './use-offline';
 
-export type SyncSupport = 'unsupported' | 'syncable' | 'needs-transfer' | 'already-connected';
+const BUSINESS_PLAN_ID = 1008;
+const COMMERCE_PLAN_ID = 1011;
 
-export type SyncSite = {
+type SyncSupport = 'unsupported' | 'syncable' | 'needs-transfer' | 'already-connected';
+
+type SyncSite = {
 	id: number;
 	name: string;
 	url: string;
@@ -46,7 +49,7 @@ function getSyncSupport( site: SitesEndpointSite, connectedSiteIds: number[] ): 
 	if ( connectedSiteIds.some( ( id ) => id === site.ID ) ) {
 		return 'already-connected';
 	}
-	if ( site.plan.product_id !== 1008 && site.plan.product_id !== 1011 ) {
+	if ( site.plan.product_id !== BUSINESS_PLAN_ID && site.plan.product_id !== COMMERCE_PLAN_ID ) {
 		return 'unsupported';
 	}
 	if ( ! site.is_wpcom_atomic ) {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -168,6 +168,9 @@ module.exports = {
 			screens: {
 				sd: `${ MAIN_MIN_WIDTH }px`,
 			},
+			height: {
+				4.5: '1.125rem',
+			},
 		},
 	},
 	plugins: [


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/9465

## Proposed Changes

Follow-up to https://github.com/Automattic/studio/pull/601. Implements an actual API call in `useSyncSites`, along with some minor visual tweaks.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run `STUDIO_SITE_SYNC=true npm start`
- Click on Sync tab
- Click on Connect site
- Observe a modal opens with the list of your sites
- Try searching and observe the sites filter correctly

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
