### PR TITLE
Remove assistantEnabled feature flag

### DIFF
--- a/src/components/tests/site-content-tabs.test.tsx
+++ b/src/components/tests/site-content-tabs.test.tsx
@@ -61,7 +61,7 @@ describe( 'SiteContentTabs', () => {
 		expect( screen.queryByRole( 'tab', { name: 'Overview', selected: true } ) ).toBeVisible();
 		expect( screen.queryByRole( 'tab', { name: 'Share', selected: false } ) ).toBeVisible();
 		expect( screen.queryByRole( 'tab', { name: 'Settings', selected: false } ) ).toBeVisible();
-		expect( screen.queryByRole( 'tab', { name: 'Assistant', selected: false } ) ).toBeNull();
+		expect( screen.queryByRole( 'tab', { name: 'Assistant', selected: false } ) ).toBeVisible();
 		expect( screen.queryByRole( 'tab', { name: 'Backup', selected: false } ) ).toBeNull();
 	} );
 	it( 'should render a "No Site" screen if selected site is absent', async () => {
@@ -78,28 +78,6 @@ describe( 'SiteContentTabs', () => {
 		expect( screen.queryByRole( 'tab', { name: 'Publish' } ) ).toBeNull();
 		expect( screen.queryByRole( 'tab', { name: 'Export' } ) ).toBeNull();
 		expect( screen.getByText( 'Select a site to view details.' ) ).toBeVisible();
-	} );
-	it( 'should not render the Assistant tab if assistantEnabled is not enabled', async () => {
-		( useSiteDetails as jest.Mock ).mockReturnValue( {
-			selectedSite,
-			snapshots: [],
-			loadingServer: {},
-		} );
-		await act( async () => render( <SiteContentTabs /> ) );
-		expect( screen.queryByRole( 'tab', { name: 'Assistant' } ) ).toBeNull();
-	} );
-
-	it( 'should render the Assistant tab if assistantEnabled is enabled', async () => {
-		( useSiteDetails as jest.Mock ).mockReturnValue( {
-			selectedSite,
-			snapshots: [],
-			loadingServer: {},
-		} );
-		( useFeatureFlags as jest.Mock ).mockReturnValue( {
-			assistantEnabled: true,
-		} );
-		await act( async () => render( <SiteContentTabs /> ) );
-		expect( screen.queryByRole( 'tab', { name: 'Assistant' } ) ).toBeVisible();
 	} );
 
 	it( 'should render the Sync tab if siteSyncEnabled is enabled', async () => {

--- a/src/components/tests/site-content-tabs.test.tsx
+++ b/src/components/tests/site-content-tabs.test.tsx
@@ -29,9 +29,7 @@ jest.mock( '../../lib/app-globals', () => ( {
 	getAppGlobals: jest.fn().mockReturnValue( { locale: ' en' } ),
 } ) );
 
-( useFeatureFlags as jest.Mock ).mockReturnValue( {
-	assistantEnabled: false,
-} );
+( useFeatureFlags as jest.Mock ).mockReturnValue( {} );
 
 describe( 'SiteContentTabs', () => {
 	beforeEach( () => {

--- a/src/components/tests/user-settings.test.tsx
+++ b/src/components/tests/user-settings.test.tsx
@@ -1,7 +1,6 @@
 // To run tests, execute `npm run test -- src/components/user-settings.test.tsx` from the root directory
 import { fireEvent, render, screen } from '@testing-library/react';
 import { useAuth } from '../../hooks/use-auth';
-import { useFeatureFlags } from '../../hooks/use-feature-flags';
 import { useIpcListener } from '../../hooks/use-ipc-listener';
 import { useOffline } from '../../hooks/use-offline';
 import UserSettings from '../user-settings';
@@ -9,10 +8,6 @@ import UserSettings from '../user-settings';
 jest.mock( '../../hooks/use-feature-flags' );
 jest.mock( '../../hooks/use-auth' );
 jest.mock( '../../hooks/use-ipc-listener' );
-
-( useFeatureFlags as jest.Mock ).mockReturnValue( {
-	assistantEnabled: false,
-} );
 
 afterEach( () => {
 	jest.clearAllMocks();

--- a/src/components/user-settings.tsx
+++ b/src/components/user-settings.tsx
@@ -5,7 +5,6 @@ import { useI18n } from '@wordpress/react-i18n';
 import { useCallback, useState, useEffect } from 'react';
 import { LIMIT_OF_PROMPTS_PER_USER, WPCOM_PROFILE_URL } from '../constants';
 import { useAuth } from '../hooks/use-auth';
-import { useFeatureFlags } from '../hooks/use-feature-flags';
 import { useIpcListener } from '../hooks/use-ipc-listener';
 import { useOffline } from '../hooks/use-offline';
 import { usePromptUsage } from '../hooks/use-prompt-usage';
@@ -151,11 +150,7 @@ const SnapshotInfo = ( {
 function PromptInfo() {
 	const { __ } = useI18n();
 	const { promptCount = 0, promptLimit = LIMIT_OF_PROMPTS_PER_USER } = usePromptUsage();
-	const { assistantEnabled } = useFeatureFlags();
 
-	if ( ! assistantEnabled ) {
-		return null;
-	}
 	return (
 		<div className="flex gap-3 flex-col">
 			<h2 className="a8c-label-semibold">{ __( 'AI assistant' ) }</h2>

--- a/src/hooks/tests/use-chat-context.test.tsx
+++ b/src/hooks/tests/use-chat-context.test.tsx
@@ -73,7 +73,6 @@ beforeEach( () => {
 		platform: 'darwin',
 		appName: '',
 		arm64Translation: false,
-		assistantEnabled: false,
 		terminalWpCliEnabled: false,
 		siteSyncEnabled: false,
 	} );

--- a/src/hooks/tests/use-prompt-usage.test.ts
+++ b/src/hooks/tests/use-prompt-usage.test.ts
@@ -1,6 +1,5 @@
 import { renderHook, act, waitFor } from '@testing-library/react';
 import { useAuth } from '../use-auth';
-import { useFeatureFlags } from '../use-feature-flags';
 import { usePromptUsage, PromptUsageProvider } from '../use-prompt-usage';
 
 jest.mock( '../use-auth', () => ( {
@@ -20,7 +19,6 @@ describe( 'usePromptUsage hook', () => {
 
 	beforeEach( () => {
 		( useAuth as jest.Mock ).mockReturnValue( { client: null } );
-		( useFeatureFlags as jest.Mock ).mockReturnValue( { assistantEnabled: true } );
 		jest.useFakeTimers();
 		jest.setSystemTime( new Date( '2024-09-16' ) );
 	} );
@@ -94,15 +92,5 @@ describe( 'usePromptUsage hook', () => {
 			expect( result.current.userCanSendMessage ).toBe( false );
 			expect( result.current.daysUntilReset ).toBe( 15 );
 		} );
-	} );
-
-	it( 'should not fetch usage when assistant is disabled', async () => {
-		( useFeatureFlags as jest.Mock ).mockReturnValue( { assistantEnabled: false } );
-
-		renderHook( () => usePromptUsage(), {
-			wrapper: PromptUsageProvider,
-		} );
-
-		expect( mockClient.req.get ).not.toHaveBeenCalled();
 	} );
 } );

--- a/src/hooks/use-content-tabs.ts
+++ b/src/hooks/use-content-tabs.ts
@@ -5,7 +5,7 @@ import { useFeatureFlags } from './use-feature-flags';
 
 export function useContentTabs() {
 	const { __ } = useI18n();
-	const { assistantEnabled, siteSyncEnabled } = useFeatureFlags();
+	const { siteSyncEnabled } = useFeatureFlags();
 
 	return useMemo( () => {
 		const tabs: React.ComponentProps< typeof TabPanel >[ 'tabs' ] = [
@@ -39,16 +39,13 @@ export function useContentTabs() {
 			} );
 		}
 
-		if ( assistantEnabled ) {
-			tabs.push( {
-				order: 6,
-				name: 'assistant',
-				title: __( 'Assistant' ),
-				className:
-					'components-tab-panel__tabs--assistant ltr:pl-8 rtl:pr-8 ltr:ml-auto rtl:mr-auto',
-			} );
-		}
+		tabs.push( {
+			order: 6,
+			name: 'assistant',
+			title: __( 'Assistant' ),
+			className: 'components-tab-panel__tabs--assistant ltr:pl-8 rtl:pr-8 ltr:ml-auto rtl:mr-auto',
+		} );
 
 		return tabs.sort( ( a, b ) => a.order - b.order );
-	}, [ __, assistantEnabled, siteSyncEnabled ] );
+	}, [ __, siteSyncEnabled ] );
 }

--- a/src/hooks/use-feature-flags.tsx
+++ b/src/hooks/use-feature-flags.tsx
@@ -3,13 +3,11 @@ import { getAppGlobals } from '../lib/app-globals';
 import { useAuth } from './use-auth';
 
 export interface FeatureFlagsContextType {
-	assistantEnabled: boolean;
 	terminalWpCliEnabled: boolean;
 	siteSyncEnabled: boolean;
 }
 
 export const FeatureFlagsContext = createContext< FeatureFlagsContextType >( {
-	assistantEnabled: false,
 	terminalWpCliEnabled: false,
 	siteSyncEnabled: false,
 } );
@@ -19,11 +17,9 @@ interface FeatureFlagsProviderProps {
 }
 
 export const FeatureFlagsProvider: React.FC< FeatureFlagsProviderProps > = ( { children } ) => {
-	const assistantEnabledFromGlobals = getAppGlobals().assistantEnabled;
 	const terminalWpCliEnabledFromGlobals = getAppGlobals().terminalWpCliEnabled;
 	const siteSyncEnabledFromGlobals = getAppGlobals().siteSyncEnabled;
 	const [ featureFlags, setFeatureFlags ] = useState< FeatureFlagsContextType >( {
-		assistantEnabled: assistantEnabledFromGlobals,
 		terminalWpCliEnabled: terminalWpCliEnabledFromGlobals,
 		siteSyncEnabled: siteSyncEnabledFromGlobals,
 	} );
@@ -44,8 +40,6 @@ export const FeatureFlagsProvider: React.FC< FeatureFlagsProviderProps > = ( { c
 					return;
 				}
 				setFeatureFlags( {
-					assistantEnabled:
-						Boolean( flags?.[ 'assistant_enabled' ] ) || assistantEnabledFromGlobals,
 					terminalWpCliEnabled:
 						Boolean( flags?.[ 'terminal_wp_cli_enabled' ] ) || terminalWpCliEnabledFromGlobals,
 					siteSyncEnabled: Boolean( flags?.[ 'site_sync_enabled' ] ) || siteSyncEnabledFromGlobals,
@@ -58,13 +52,7 @@ export const FeatureFlagsProvider: React.FC< FeatureFlagsProviderProps > = ( { c
 		return () => {
 			cancel = true;
 		};
-	}, [
-		isAuthenticated,
-		client,
-		assistantEnabledFromGlobals,
-		terminalWpCliEnabledFromGlobals,
-		siteSyncEnabledFromGlobals,
-	] );
+	}, [ isAuthenticated, client, terminalWpCliEnabledFromGlobals, siteSyncEnabledFromGlobals ] );
 
 	return (
 		<FeatureFlagsContext.Provider value={ featureFlags }>{ children }</FeatureFlagsContext.Provider>

--- a/src/hooks/use-prompt-usage.tsx
+++ b/src/hooks/use-prompt-usage.tsx
@@ -2,7 +2,6 @@ import * as Sentry from '@sentry/electron/renderer';
 import { useState, useEffect, useCallback, useMemo, createContext, useContext } from 'react';
 import { LIMIT_OF_PROMPTS_PER_USER } from '../constants';
 import { useAuth } from './use-auth';
-import { useFeatureFlags } from './use-feature-flags';
 
 type PromptUsage = {
 	promptLimit: number;
@@ -42,7 +41,6 @@ const calculateDaysRemaining = ( quotaResetDate: string ): number => {
 
 export function PromptUsageProvider( { children }: PromptUsageProps ) {
 	const { Provider } = promptUsageContext;
-	const { assistantEnabled } = useFeatureFlags();
 
 	const [ promptLimit, setPromptLimit ] = useState( LIMIT_OF_PROMPTS_PER_USER );
 	const [ promptCount, setPromptCount ] = useState( 0 );
@@ -60,7 +58,7 @@ export function PromptUsageProvider( { children }: PromptUsageProps ) {
 	}, [] );
 
 	const fetchPromptUsage = useCallback( async () => {
-		if ( ! client?.req || ! assistantEnabled ) {
+		if ( ! client?.req ) {
 			return;
 		}
 		try {
@@ -77,7 +75,7 @@ export function PromptUsageProvider( { children }: PromptUsageProps ) {
 			Sentry.captureException( error );
 			console.error( error );
 		}
-	}, [ assistantEnabled, client, updatePromptUsage ] );
+	}, [ client, updatePromptUsage ] );
 
 	useEffect( () => {
 		if ( ! client ) {

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -513,7 +513,6 @@ export async function getAppGlobals( _event: IpcMainInvokeEvent ): Promise< AppG
 		platform: process.platform,
 		appName: app.name,
 		arm64Translation: app.runningUnderARM64Translation,
-		assistantEnabled: process.env.STUDIO_AI === 'true',
 		terminalWpCliEnabled: process.env.STUDIO_TERMINAL_WP_CLI === 'true',
 		siteSyncEnabled: process.env.STUDIO_SITE_SYNC === 'true',
 	};

--- a/src/ipc-types.d.ts
+++ b/src/ipc-types.d.ts
@@ -71,7 +71,6 @@ interface AppGlobals {
 	platform: NodeJS.Platform;
 	appName: string;
 	arm64Translation: boolean;
-	assistantEnabled: boolean;
 	terminalWpCliEnabled: boolean;
 	siteSyncEnabled: boolean;
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

- Solves https://github.com/Automattic/dotcom-forge/issues/9031

## Proposed Changes

- Let's remove the Assistant feature flag, so it will be available to all users in the next release.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Tests should pass
- Run `npm start`
- Make sure you are logged out
- Observe the Assistant tab
- Log in
- Send a message
- Observe the assistant answers the message

<img width="1012" alt="Screenshot 2024-10-23 at 14 57 38" src="https://github.com/user-attachments/assets/279ed959-1578-42fc-9017-68ae665f0c75">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
