### PR TITLE
Studio: Switch order of buttons on the connected sites screen

### DIFF
--- a/src/components/content-tab-sync.tsx
+++ b/src/components/content-tab-sync.tsx
@@ -68,8 +68,7 @@ function CreateConnectSite( {
 				<Tooltip disabled={ ! isOffline } text={ offlineMessageConnect }>
 					<Button
 						aria-disabled={ isOffline }
-						variant="secondary"
-						className={ cx( ! isOffline && '!text-a8c-blueberry !shadow-a8c-blueberry' ) }
+						variant="primary"
 						onClick={ () => {
 							if ( isOffline ) {
 								return;
@@ -83,7 +82,8 @@ function CreateConnectSite( {
 				<Tooltip disabled={ ! isOffline } text={ offlineMessageCreate }>
 					<Button
 						aria-disabled={ isOffline }
-						variant="primary"
+						className={ cx( ! isOffline && '!text-a8c-blueberry !shadow-a8c-blueberry' ) }
+						variant="secondary"
 						onClick={ async () => {
 							if ( isOffline ) {
 								return;

--- a/src/components/content-tab-sync.tsx
+++ b/src/components/content-tab-sync.tsx
@@ -65,21 +65,6 @@ function CreateConnectSite( {
 	return (
 		<div className="mt-8">
 			<div className="flex gap-4">
-				<Tooltip disabled={ ! isOffline } text={ offlineMessageCreate }>
-					<Button
-						aria-disabled={ isOffline }
-						variant="primary"
-						onClick={ async () => {
-							if ( isOffline ) {
-								return;
-							}
-							await getIpcApi().openURL( 'https://wordpress.com/start/new-site' );
-						} }
-					>
-						{ __( 'Create new site' ) }
-						<ArrowIcon />
-					</Button>
-				</Tooltip>
 				<Tooltip disabled={ ! isOffline } text={ offlineMessageConnect }>
 					<Button
 						aria-disabled={ isOffline }
@@ -93,6 +78,21 @@ function CreateConnectSite( {
 						} }
 					>
 						{ __( 'Connect site' ) }
+					</Button>
+				</Tooltip>
+				<Tooltip disabled={ ! isOffline } text={ offlineMessageCreate }>
+					<Button
+						aria-disabled={ isOffline }
+						variant="primary"
+						onClick={ async () => {
+							if ( isOffline ) {
+								return;
+							}
+							await getIpcApi().openURL( 'https://wordpress.com/start/new-site' );
+						} }
+					>
+						{ __( 'Create new site' ) }
+						<ArrowIcon />
 					</Button>
 				</Tooltip>
 			</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/9486

## Proposed Changes

This PR switches the order of the `Connect site` and `Create new site` on the `Sync` tab when the user has no connected sites. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
* Start the app with `STUDIO_SITE_SYNC=true npm start`
* Navigate to the `Sync` tab
* Confirm that you can see the following design e.g. `Connect site` button first and `Create new site` button second:

<img width="618" alt="Screenshot 2024-10-24 at 10 40 19 AM" src="https://github.com/user-attachments/assets/a5708d40-7bc3-4675-a9a0-e70874a62afa">

**Before these changes**:

<img width="632" alt="Screenshot 2024-10-24 at 10 46 35 AM" src="https://github.com/user-attachments/assets/66fbd86b-a2c1-4da4-944e-bdb524d18308">

Design was introduced in this comment: p9Jlb4-ewp-p2#comment-13926
## Pre-merge 
Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?