### PR TITLE
Change studio.json to meta.json

### DIFF
--- a/src/hooks/tests/use-import-export.test.tsx
+++ b/src/hooks/tests/use-import-export.test.tsx
@@ -361,7 +361,7 @@ describe( 'useImportExport hook', () => {
 		} );
 	} );
 
-	it( 'imports site with given studio.json PHP version', async () => {
+	it( 'imports site with given meta.json PHP version', async () => {
 		const importedSite = { ...selectedSite, phpVersion: '7.4' };
 		( getIpcApi().importSite as jest.Mock ).mockResolvedValue( importedSite );
 

--- a/src/lib/import-export/export/exporters/default-exporter.ts
+++ b/src/lib/import-export/export/exporters/default-exporter.ts
@@ -83,7 +83,7 @@ export class DefaultExporter extends EventEmitter implements Exporter {
 			this.addWpContent();
 			await this.addDatabase();
 			const studioJsonPath = await this.createStudioJsonFile();
-			this.archive.file( studioJsonPath, { name: 'studio.json' } );
+			this.archive.file( studioJsonPath, { name: 'meta.json' } );
 			await this.archive.finalize();
 			this.emit( ExportEvents.BACKUP_CREATE_COMPLETE );
 			await archiveClosedPromise;
@@ -236,7 +236,7 @@ export class DefaultExporter extends EventEmitter implements Exporter {
 			studioJson.wordpressVersion = wpVersion;
 		}
 		const tempDir = await fsPromises.mkdtemp( path.join( os.tmpdir(), 'studio-export-' ) );
-		const studioJsonPath = path.join( tempDir, 'studio.json' );
+		const studioJsonPath = path.join( tempDir, 'meta.json' );
 		await fsPromises.writeFile( studioJsonPath, JSON.stringify( studioJson, null, 2 ) );
 		return studioJsonPath;
 	}

--- a/src/lib/import-export/export/exporters/default-exporter.ts
+++ b/src/lib/import-export/export/exporters/default-exporter.ts
@@ -14,6 +14,7 @@ import {
 	Exporter,
 	BackupCreateProgressEventData,
 	BackupContentsCategory,
+	StudioJson,
 } from '../types';
 
 export class DefaultExporter extends EventEmitter implements Exporter {
@@ -229,12 +230,14 @@ export class DefaultExporter extends EventEmitter implements Exporter {
 
 	private async createStudioJsonFile(): Promise< string > {
 		const wpVersion = await getWordPressVersionFromInstallation( this.options.site.path );
-		const studioJson: { phpVersion: string; wordpressVersion?: string } = {
+		const studioJson: StudioJson = {
+			siteUrl: `http://localhost:${ this.options.site.port }`,
 			phpVersion: this.options.phpVersion,
 		};
 		if ( wpVersion ) {
 			studioJson.wordpressVersion = wpVersion;
 		}
+
 		const tempDir = await fsPromises.mkdtemp( path.join( os.tmpdir(), 'studio-export-' ) );
 		const studioJsonPath = path.join( tempDir, 'meta.json' );
 		await fsPromises.writeFile( studioJsonPath, JSON.stringify( studioJson, null, 2 ) );

--- a/src/lib/import-export/export/types.ts
+++ b/src/lib/import-export/export/types.ts
@@ -34,4 +34,12 @@ export interface StudioJson {
 	phpVersion: string;
 	wordpressVersion?: string;
 	siteUrl: string;
+	plugins: StudioJsonPluginOrTheme[];
+	themes: StudioJsonPluginOrTheme[];
+}
+
+export interface StudioJsonPluginOrTheme {
+	name: string;
+	status: 'active' | 'inactive';
+	version: string;
 }

--- a/src/lib/import-export/export/types.ts
+++ b/src/lib/import-export/export/types.ts
@@ -29,3 +29,9 @@ export interface BackupCreateProgressEventData {
 }
 
 export type NewExporter = new ( options: ExportOptions ) => Exporter;
+
+export interface StudioJson {
+	phpVersion: string;
+	wordpressVersion?: string;
+	siteUrl: string;
+}

--- a/src/lib/import-export/import/validators/jetpack-validator.ts
+++ b/src/lib/import-export/import/validators/jetpack-validator.ts
@@ -29,7 +29,7 @@ export class JetpackValidator extends EventEmitter implements Validator {
 		/* File rules:
 		 * - Accept .zip in addition to tar.gz ( Handled by backup handler )
 		 * - Do not reject the archive that includes core WP files in addition to files and directories required by Jetpack format, and ignore those instead.
-		 * - Support optional meta file, e.g., studio.json, that stores desired PHP and WP versions.
+		 * - Support optional meta file, e.g., meta.json, that stores desired PHP and WP versions.
 		 * */
 
 		for ( const file of fileList ) {
@@ -47,7 +47,7 @@ export class JetpackValidator extends EventEmitter implements Validator {
 				extractedBackup.wpContent.plugins.push( fullPath );
 			} else if ( file.startsWith( 'wp-content/themes/' ) ) {
 				extractedBackup.wpContent.themes.push( fullPath );
-			} else if ( file === 'studio.json' ) {
+			} else if ( file === 'studio.json' || file === 'meta.json' ) {
 				extractedBackup.metaFile = fullPath;
 			}
 		}

--- a/src/lib/import-export/tests/export/exporters/default-exporter.test.ts
+++ b/src/lib/import-export/tests/export/exporters/default-exporter.test.ts
@@ -157,14 +157,14 @@ describe( 'DefaultExporter', () => {
 		} );
 	} );
 
-	it( 'should add studio.json to the archive', async () => {
+	it( 'should add meta.json to the archive', async () => {
 		const exporter = new DefaultExporter( mockOptions );
 		await exporter.export();
 
 		expect( getWordPressVersionFromInstallation ).toHaveBeenCalledTimes( 1 );
 		expect( getWordPressVersionFromInstallation ).toHaveBeenCalledWith( '/path/to/site' );
-		expect( mockArchiver.file ).toHaveBeenCalledWith( '/tmp/studio_export_123/studio.json', {
-			name: 'studio.json',
+		expect( mockArchiver.file ).toHaveBeenCalledWith( '/tmp/studio_export_123/meta.json', {
+			name: 'meta.json',
 		} );
 	} );
 

--- a/src/lib/import-export/tests/export/exporters/default-exporter.test.ts
+++ b/src/lib/import-export/tests/export/exporters/default-exporter.test.ts
@@ -93,9 +93,19 @@ describe( 'DefaultExporter', () => {
 
 		// Reset all mock implementations
 		jest.clearAllMocks();
+
 		( SiteServer.get as jest.Mock ).mockReturnValue( {
 			details: { path: '/path/to/site' },
-			executeWpCliCommand: jest.fn().mockResolvedValue( { stderr: null } ),
+			executeWpCliCommand: jest.fn( function ( command: string ) {
+				switch ( true ) {
+					case /plugin list/.test( command ):
+						return { stdout: '[{"name":"akismet","status":"active","version":"5.3.3"}]' };
+					case /theme list/.test( command ):
+						return { stdout: '[{"name":"twentytwentyfour","status":"active","version":"1.0"}]' };
+					default:
+						return { stderr: null };
+				}
+			} ),
 		} );
 
 		mockArchiver = createMockArchiver();

--- a/src/lib/import-export/tests/import/importer/default-importer.test.ts
+++ b/src/lib/import-export/tests/import/importer/default-importer.test.ts
@@ -20,7 +20,7 @@ describe( 'JetpackImporter', () => {
 			themes: [ '/tmp/extracted/wp-content/themes/twentytwentyone/style.css' ],
 		},
 		wpContentDirectory: 'wp-content',
-		metaFile: '/tmp/extracted/studio.json',
+		metaFile: '/tmp/extracted/meta.json',
 	};
 
 	const mockStudioSitePath = '/path/to/studio/site';
@@ -67,7 +67,7 @@ describe( 'JetpackImporter', () => {
 
 			expect( fs.mkdir ).toHaveBeenCalled();
 			expect( fs.copyFile ).toHaveBeenCalledTimes( 4 ); // One for each wp-content file + wp-config
-			expect( fs.readFile ).toHaveBeenCalledWith( '/tmp/extracted/studio.json', 'utf-8' );
+			expect( fs.readFile ).toHaveBeenCalledWith( '/tmp/extracted/meta.json', 'utf-8' );
 		} );
 
 		it( 'should handle sql files and call wp sqlite import cli command', async () => {
@@ -114,7 +114,7 @@ describe( 'JetpackImporter', () => {
 
 			expect( fs.mkdir ).toHaveBeenCalled();
 			expect( fs.copyFile ).toHaveBeenCalledTimes( 4 );
-			expect( fs.readFile ).toHaveBeenCalledWith( '/tmp/extracted/studio.json', 'utf-8' );
+			expect( fs.readFile ).toHaveBeenCalledWith( '/tmp/extracted/meta.json', 'utf-8' );
 		} );
 
 		it( 'should regenerate media after import', async () => {

--- a/src/lib/import-export/tests/import/validators/jetpack-validator.test.ts
+++ b/src/lib/import-export/tests/import/validators/jetpack-validator.test.ts
@@ -41,7 +41,7 @@ describe( 'JetpackValidator', () => {
 				'wp-content/uploads/2023/image.jpg',
 				'wp-content/plugins/jetpack/jetpack.php',
 				'wp-content/themes/twentytwentyone/style.css',
-				'studio.json',
+				'meta.json',
 			];
 			const extractionDirectory = '/tmp/extracted';
 			const result = validator.parseBackupContents( fileList, extractionDirectory );
@@ -56,7 +56,7 @@ describe( 'JetpackValidator', () => {
 					themes: [ '/tmp/extracted/wp-content/themes/twentytwentyone/style.css' ],
 				},
 				wpContentDirectory: 'wp-content',
-				metaFile: '/tmp/extracted/studio.json',
+				metaFile: '/tmp/extracted/meta.json',
 			} );
 		} );
 
@@ -72,7 +72,7 @@ describe( 'JetpackValidator', () => {
 				'wp-content/uploads/2023/image.jpg',
 				'wp-content/plugins/jetpack/jetpack.php',
 				'wp-content/themes/twentytwentyone/style.css',
-				'studio.json',
+				'meta.json',
 			];
 			const extractionDirectory = '/tmp/extracted';
 			const result = validator.parseBackupContents( fileList, extractionDirectory );
@@ -87,7 +87,7 @@ describe( 'JetpackValidator', () => {
 					themes: [ '/tmp/extracted/wp-content/themes/twentytwentyone/style.css' ],
 				},
 				wpContentDirectory: 'wp-content',
-				metaFile: '/tmp/extracted/studio.json',
+				metaFile: '/tmp/extracted/meta.json',
 			} );
 		} );
 	} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Resolves https://github.com/Automattic/dotcom-forge/issues/9351

## Proposed Changes

I propose to change the default meta file name to `meta.json` and format to the following one:

```
{
  "siteUrl": "http://localhost:8889",
  "phpVersion": "8.1",
  "wordpressVersion": "6.6.2",
  "plugins": [
    {
      "name": "akismet",
      "status": "active",
      "version": "5.3.3"
    },
    {
      "name": "google-authenticator",
      "status": "active",
      "version": "0.54"
    },
    {
      "name": "jetpack",
      "status": "active",
      "version": "13.9.1"
    },
    {
      "name": "wp-postviews",
      "status": "inactive",
      "version": "1.77"
    }
  ],
  "themes": [
    {
      "name": "arrakkis",
      "status": "active",
      "version": "1.2.8"
    },
    {
      "name": "ubergrid",
      "status": "inactive",
      "version": "1.2.8"
    }
  ]
}
```

The data there will allow other systems like VaultPress to import the site easily.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Export

1. Add a new site
2. Install some themes on a site
3. Install some plugins on a site
4. Change PHP version to non-default one
5. Export the entire site
6. Open the export package and ensure that `meta.json` file exists and has the correct content

### Import

1. Add a new site
2. Import the previously exported site to the new site
3. Confirm non-default PHP version was set based on the version from `meta.json` file
4. Optionally, test importing older backups that include `studio.json` file

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
