### PR TITLE
Studio: Set max-width on export progress bar

### DIFF
--- a/src/components/content-tab-import-export.tsx
+++ b/src/components/content-tab-import-export.tsx
@@ -43,7 +43,7 @@ export const ExportSite = ( { selectedSite }: { selectedSite: SiteDetails } ) =>
 				</p>
 			</div>
 			{ currentProgress ? (
-				<div className="flex flex-col gap-4">
+				<div className="flex flex-col gap-4 max-w-[300px]">
 					<ProgressBar value={ currentProgress.progress } maxValue={ 100 } />
 					<div className="text-a8c-gray-70 a8c-body">{ currentProgress.statusMessage }</div>
 				</div>

--- a/src/components/progress-bar.tsx
+++ b/src/components/progress-bar.tsx
@@ -12,7 +12,7 @@ const ProgressBar = ( {
 	const fillPercentage = Math.max( 0, Math.min( 100, ( value / maxValue ) * 100 ) );
 
 	return (
-		<div className="w-full flex h-1 self-stretch rounded-[4.5px] bg-a8c-gray-5">
+		<div className="w-full flex h-0.5 self-stretch rounded-[4.5px] bg-a8c-gray-5">
 			<div
 				role="progressbar"
 				aria-valuenow={ fillPercentage }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Fixes #622 

## Proposed Changes

- Set max-width on progress bar in Import/Export tab.
- Correct the height of progress bars to 2px.

| Before | After |
|--------|--------|
| <img width="1012" alt="Screenshot 2024-10-24 at 15 05 40" src="https://github.com/user-attachments/assets/7362ec78-bb00-4467-b433-4c1de10c576a"> | <img width="1012" alt="Screenshot 2024-10-24 at 15 06 05" src="https://github.com/user-attachments/assets/ee6506ec-b6ce-4757-848e-c6d45c2ce1be"> | 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Open Studio
- Click the Import / Export tab
- Export entire site
- Export database

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
