### PR TITLE
Studio: Fix spacing around user avatar in settings modal

### DIFF
--- a/src/components/user-settings.tsx
+++ b/src/components/user-settings.tsx
@@ -260,14 +260,14 @@ export default function UserSettings() {
 									</Button>
 								</Tooltip>
 							</div>
-							<div className="border border-[#F0F0F0] w-full"></div>
+							<div className="border-t border-[#F0F0F0] w-full"></div>
 							<LanguagePicker />
 						</div>
 					) }
 					{ isAuthenticated && (
 						<div className="gap-6 flex flex-col">
 							<UserInfo onLogout={ logout } user={ user } />
-							<div className="border border-[#F0F0F0] w-full"></div>
+							<div className="border-t border-[#F0F0F0] w-full"></div>
 							<div className="flex flex-col gap-6">
 								<LanguagePicker />
 								<SnapshotInfo

--- a/src/components/user-settings.tsx
+++ b/src/components/user-settings.tsx
@@ -31,11 +31,11 @@ const UserInfo = ( {
 	const { __ } = useI18n();
 	return (
 		<div className="flex w-full gap-5">
-			<div className="flex w-full items-center gap-[15px]">
+			<div className="flex w-full items-center gap-3">
 				<Button
 					onClick={ () => getIpcApi().openURL( WPCOM_PROFILE_URL ) }
 					aria-label={ __( 'Profile link' ) }
-					className="py-0 px-0"
+					variant="icon"
 				>
 					<Gravatar detailedDefaultImage size={ 32 } isBlack />
 				</Button>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Fixes #621 

## Proposed Changes

- Update spacing around user avatar in the settings modal
- Dry-by fix to border width

| Before | After |
|--------|--------|
| <img width="307" alt="Screenshot 2024-10-24 at 15 31 21" src="https://github.com/user-attachments/assets/a6dfb911-2d94-459d-9168-7f72b0d01e6b"> | <img width="307" alt="Screenshot 2024-10-24 at 15 40 35" src="https://github.com/user-attachments/assets/a3517995-4c52-4c31-b415-a3bba6e98671"> | 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Open Studio
- Log in to WordPress.com
- Open settings modal

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
