### PR TITLE
Studio: Update styling of backup and local path fields

### DIFF
--- a/src/components/site-form.tsx
+++ b/src/components/site-form.tsx
@@ -97,10 +97,7 @@ function FormPathInputComponent( {
 					// eslint-disable-next-line @typescript-eslint/no-empty-function
 					onChange={ () => {} }
 				/>
-				<div
-					aria-hidden="true"
-					className="local-path-icon flex items-center py-[9px] px-2.5 border border-l-[#949494] border-t-0 border-r-0 border-b-0"
-				>
+				<div aria-hidden="true" className="local-path-icon flex items-center py-[9px] px-2.5">
 					<FolderIcon className="text-[#3C434A]" />
 				</div>
 			</button>
@@ -168,16 +165,17 @@ function FormImportComponent( {
 						onChange={ () => {} }
 					/>
 					{ ! fileName && (
-						<div
-							aria-hidden="true"
-							className="local-path-icon flex items-center py-[12px] px-2.5 border border-l-[#949494] border-t-0 border-r-0 border-b-0"
-						>
+						<div aria-hidden="true" className="local-path-icon flex items-center py-[12px] px-2.5">
 							<FolderIcon className="text-[#3C434A]" />
 						</div>
 					) }
 				</button>
 				{ fileName && (
-					<Button variant="icon" onClick={ handleIconClick }>
+					<Button
+						variant="icon"
+						onClick={ handleIconClick }
+						className="[&.components-button]:focus-visible:text-a8c-red-50 [&.components-button]:hover:text-a8c-red-50"
+					>
 						<div
 							aria-hidden="true"
 							className="flex items-center py-[10px] px-2.5 rounded-tr-sm rounded-br-sm border border-[#949494] border-l-0"

--- a/src/components/site-form.tsx
+++ b/src/components/site-form.tsx
@@ -42,13 +42,13 @@ const SiteFormError = ( { error, tipMessage = '', className = '' }: SiteFormErro
 				role="alert"
 				aria-atomic="true"
 				className={ cx(
-					'flex items-start gap-1',
-					error ? 'text-red-500' : 'text-a8c-gray-70',
+					'flex items-start gap-1 text-xs',
+					error ? 'text-red-500' : 'text-a8c-gray-50',
 					className
 				) }
 			>
 				<Icon
-					className={ cx( 'shrink-0 basis-4', error ? 'fill-red-500' : '' ) }
+					className={ cx( 'shrink-0 basis-4', error ? 'fill-red-500' : 'fill-a8c-gray-50' ) }
 					icon={ error ? warning : tip }
 					width={ 16 }
 					height={ 16 }
@@ -67,7 +67,7 @@ function FormPathInputComponent( {
 }: FormPathInputComponentProps ) {
 	const { __ } = useI18n();
 	return (
-		<div className="flex flex-col">
+		<div className="flex flex-col gap-2">
 			<button
 				aria-invalid={ !! error }
 				/**

--- a/src/components/site-form.tsx
+++ b/src/components/site-form.tsx
@@ -171,11 +171,7 @@ function FormImportComponent( {
 					) }
 				</button>
 				{ fileName && (
-					<Button
-						variant="icon"
-						onClick={ handleIconClick }
-						className="[&.components-button]:focus-visible:text-a8c-red-50 [&.components-button]:hover:text-a8c-red-50"
-					>
+					<Button variant="icon" onClick={ handleIconClick } isDestructive={ true }>
 						<div
 							aria-hidden="true"
 							className="flex items-center py-[10px] px-2.5 rounded-tr-sm rounded-br-sm border border-[#949494] border-l-0"


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Fixes #619
Fixes #618
Fixes #617 

## Proposed Changes

- Removes the left border from the icons in the backup and local path inputs.
- Trash icon that’s displayed when the backup field has been filled now uses the destructive styles.
- Updates styling for hint show when the selected local path already contains a WordPress site.

| Before | After |
|--------|--------|
| <img width="474" alt="Screenshot 2024-10-24 at 16 06 13" src="https://github.com/user-attachments/assets/94d8fbe2-5b97-4451-8056-1560e2081106"> | <img width="474" alt="Screenshot 2024-10-24 at 16 17 08" src="https://github.com/user-attachments/assets/fc096767-7355-424f-b04d-4d8488ddf7a7"> |
| <img width="474" alt="Screenshot 2024-10-24 at 16 02 00" src="https://github.com/user-attachments/assets/39181a4b-9b57-477d-8196-991a6ba2773b"> | <img width="474" alt="Screenshot 2024-10-24 at 16 01 39" src="https://github.com/user-attachments/assets/7d2ca4a3-b022-4c00-a079-ba4fb1f858f9"> | 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Open Studio
- Add new site
- Fill the backup field with a .zip file. Note that the trash icon is now red.
- Set the local path to an existing Wordpress site. Note that the hint is correctly styled.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
