### PR TITLE
Exclude deleted sites from sync dialog

### DIFF
--- a/src/hooks/use-fetch-wpcom-sites.tsx
+++ b/src/hooks/use-fetch-wpcom-sites.tsx
@@ -21,11 +21,11 @@ type SitesEndpointSite = {
 	is_wpcom_staging_site: boolean;
 	name: string;
 	URL: string;
-	options: {
+	options?: {
 		created_at: string;
 		wpcom_staging_blog_ids: number[];
 	};
-	plan: {
+	plan?: {
 		expired: boolean;
 		features: {
 			active: string[];
@@ -49,7 +49,7 @@ function getSyncSupport( site: SitesEndpointSite, connectedSiteIds: number[] ): 
 	if ( connectedSiteIds.some( ( id ) => id === site.ID ) ) {
 		return 'already-connected';
 	}
-	if ( ! site.plan.features.active.includes( STUDIO_SYNC_FEATURE_NAME ) ) {
+	if ( ! site.plan || ! site.plan.features.active.includes( STUDIO_SYNC_FEATURE_NAME ) ) {
 		return 'unsupported';
 	}
 	if ( ! site.is_wpcom_atomic ) {
@@ -69,7 +69,7 @@ function transformSiteResponse(
 			name: site.name,
 			url: site.URL,
 			isStaging: site.is_wpcom_staging_site,
-			stagingSiteIds: site.options.wpcom_staging_blog_ids,
+			stagingSiteIds: site.options?.wpcom_staging_blog_ids ?? [],
 			syncSupport: getSyncSupport( site, connectedSiteIds ),
 		};
 	} );
@@ -99,6 +99,7 @@ export const useFetchWpComSites = ( connectedSites: SyncSite[] ) => {
 					fields: 'name,ID,URL,plan,is_wpcom_staging_site,is_wpcom_atomic,options',
 					filter: 'atomic,wpcom',
 					options: 'created_at,wpcom_staging_blog_ids',
+					site_visibility: 'visible',
 				}
 			)
 			.then( ( response ) => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/9550

## Proposed Changes

- Pass a `site_visibility=visible` param to the `/me/sites` API endpoint to exclude deleted sites, preventing a crash in the client
- For good measure, don't assume that `options` and `plan` are always defined on site objects in the response.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Delete a WordPress.com website
2. Start Studio with `STUDIO_SITE_SYNC=true npm start`
3. Go to the **Sync** tab and click **Connect site**
4. Ensure that the dialog displays a list of site and that the site you recently deleted is not included
