### PR TITLE
Search by URL on connect sites modal

### DIFF
--- a/src/components/sync-sites-modal-selector.tsx
+++ b/src/components/sync-sites-modal-selector.tsx
@@ -26,9 +26,13 @@ export function SyncSitesModalSelector( {
 	const { __ } = useI18n();
 	const [ selectedSiteId, setSelectedSiteId ] = useState< number | null >( null );
 	const [ searchQuery, setSearchQuery ] = useState< string >( '' );
-	const filteredSites = syncSites.filter( ( site ) =>
-		site.name.toLowerCase().includes( searchQuery.toLowerCase() )
-	);
+	const filteredSites = syncSites.filter( ( site ) => {
+		const searchQueryLower = searchQuery.toLowerCase();
+		return (
+			site.name?.toLowerCase().includes( searchQueryLower ) ||
+			site.url?.toLowerCase().includes( searchQueryLower )
+		);
+	} );
 	const isEmpty = filteredSites.length === 0;
 
 	return (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

- Closes https://github.com/Automattic/dotcom-forge/issues/9562

## Proposed Changes

- Adds functionality to search sites by URL in the Connect Site Modal

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run `STUDIO_SITE_SYNC=true npm start`
- Click on the Sync tab
- Click on Connect a site
- Enter a string to search by URL, something like `wpcomstaging` can work
- Observe the returned list of sites is correct


https://github.com/user-attachments/assets/99fd8a34-7839-41b1-9a87-48126b0b9275



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?