### PR TITLE
Sync modal enhancements

### DIFF
--- a/src/components/sync-connected-sites.tsx
+++ b/src/components/sync-connected-sites.tsx
@@ -113,7 +113,7 @@ export function SyncConnectedSites( {
 								key={ connectedSite.id }
 								className="flex items-center gap-2 py-2.5 border-b border-a8c-gray-0 px-8"
 							>
-								<div className="flex items-left min-w-20 mr-6">
+								<div className="flex items-left min-w-20 mr-6 shrink-0">
 									{ connectedSite.isStaging ? (
 										<Badge>{ __( 'Staging' ) }</Badge>
 									) : (
@@ -125,14 +125,14 @@ export function SyncConnectedSites( {
 
 								<Button
 									variant="link"
-									className="!text-a8c-gray-70 hover:!text-a8c-blueberry"
+									className="!text-a8c-gray-70 hover:!text-a8c-blueberry truncate"
 									onClick={ () => {
 										getIpcApi().openURL( connectedSite.url );
 									} }
 								>
-									{ connectedSite.url } <ArrowIcon />
+									<span className="truncate">{ connectedSite.url }</span> <ArrowIcon />
 								</Button>
-								<div className="flex gap-2 pl-4 ml-auto">
+								<div className="flex gap-2 pl-4 ml-auto shrink-0">
 									<Button variant="link" className="!text-black hover:!text-a8c-blueberry">
 										<Icon icon={ cloudDownload } />
 										{ __( 'Pull' ) }

--- a/src/components/sync-sites-modal-selector.tsx
+++ b/src/components/sync-sites-modal-selector.tsx
@@ -38,7 +38,7 @@ export function SyncSitesModalSelector( {
 			title={ __( 'Connect a WordPress.com site' ) }
 		>
 			<SearchSites searchQuery={ searchQuery } setSearchQuery={ setSearchQuery } />
-			<div className="h-[calc(84vh-230px)]">
+			<div className="h-[calc(84vh-232px)]">
 				{ isLoading && (
 					<div className="flex justify-center items-center h-full">{ __( 'Loading sites…' ) }</div>
 				) }
@@ -85,7 +85,7 @@ function SearchSites( {
 	return (
 		<div className="flex flex-col px-8 pb-6 border-b border-a8c-gray-5">
 			<SearchControl
-				className="w-full"
+				className="w-full mt-0.5"
 				placeholder={ __( 'Search sites' ) }
 				onChange={ ( value ) => {
 					setSearchQuery( value );

--- a/src/components/sync-sites-modal-selector.tsx
+++ b/src/components/sync-sites-modal-selector.tsx
@@ -143,7 +143,7 @@ function SiteItem( {
 	return (
 		<div
 			className={ cx(
-				'flex py-3 px-8 items-center border-b border-a8c-gray-0 justify-between',
+				'flex py-3 px-8 items-center border-b border-a8c-gray-0 justify-between gap-4',
 				isSelected && 'bg-a8c-blueberry text-white',
 				! isSelected && isSyncable && 'hover:bg-a8c-blueberry-5'
 			) }
@@ -155,7 +155,7 @@ function SiteItem( {
 				onClick();
 			} }
 		>
-			<div className="flex flex-col gap-0.5 pr-4 max-w-[78%]">
+			<div className="flex flex-col gap-0.5 overflow-hidden">
 				<div className={ cx( 'a8c-body truncate', ! isSyncable && 'text-a8c-gray-30' ) }>
 					{ site.name }
 				</div>
@@ -186,13 +186,15 @@ function SiteItem( {
 				</div>
 			) }
 			{ isAlreadyConnected && (
-				<div className="a8c-body-small text-a8c-gray-30">{ __( 'Already connected' ) }</div>
+				<div className="a8c-body-small text-a8c-gray-30 shrink-0">
+					{ __( 'Already connected' ) }
+				</div>
 			) }
 			{ isUnsupported && (
-				<div className="a8c-body-small text-a8c-gray-30"> { __( 'Unsupported plan' ) }</div>
+				<div className="a8c-body-small text-a8c-gray-30 shrink-0">{ __( 'Unsupported plan' ) }</div>
 			) }
 			{ isNeedsTransfer && (
-				<div className="a8c-body-small text-a8c-gray-30">
+				<div className="a8c-body-small text-a8c-gray-30 shrink-0">
 					{ __( 'Please enable hosting features' ) }
 				</div>
 			) }

--- a/src/components/sync-sites-modal-selector.tsx
+++ b/src/components/sync-sites-modal-selector.tsx
@@ -155,9 +155,13 @@ function SiteItem( {
 				onClick();
 			} }
 		>
-			<div className="flex flex-col gap-0.5 pr-4">
-				<div className={ cx( 'a8c-body', ! isSyncable && 'text-a8c-gray-30' ) }>{ site.name }</div>
-				<div className={ cx( 'a8c-body-small text-a8c-gray-30', isSelected && 'text-white' ) }>
+			<div className="flex flex-col gap-0.5 pr-4 max-w-[78%]">
+				<div className={ cx( 'a8c-body truncate', ! isSyncable && 'text-a8c-gray-30' ) }>
+					{ site.name }
+				</div>
+				<div
+					className={ cx( 'a8c-body-small text-a8c-gray-30 truncate', isSelected && 'text-white' ) }
+				>
 					{ site.url.replace( /^https?:\/\//, '' ) }
 				</div>
 			</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

- Closes https://github.com/Automattic/dotcom-forge/issues/9466

## Proposed Changes

- Fix Search input border top
- Fix long URLs inside the modal and connected sites

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run `STUDIO_SITE_SYNC=true npm start`
- Click on the Sync tab
- Click on connect a site
- Click on the search input
- Observe the blue border top displays correctly
- Observe long urls are correctly end in ellipsis in the modal and connected sites

**Focus border**

<img width="1015" alt="Screenshot 2024-10-29 at 22 10 20" src="https://github.com/user-attachments/assets/bdc4db4f-72ae-4402-b7a3-651c05f6502c">

**Long URLs or names inside the modal**

<img width="897" alt="Screenshot 2024-10-29 at 20 43 47" src="https://github.com/user-attachments/assets/06531f5e-e4b0-4ed8-a7aa-fa04253f21dd">

**Long URLs or names in connected sites**

![url-long-sync-connected](https://github.com/user-attachments/assets/e0ac8b9c-2331-431d-84d2-85b4c7e88cf7)



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
