### PR TITLE
Render unsupported sites at the end of the list

### DIFF
--- a/src/components/sync-sites-modal-selector.tsx
+++ b/src/components/sync-sites-modal-selector.tsx
@@ -102,26 +102,15 @@ function SearchSites( {
 
 // render unsupported sites at the bottom of the list
 const getSortedSites = ( sites: SyncSite[] ) => {
+	const order: Record< SyncSite[ 'syncSupport' ], number > = {
+		syncable: 1,
+		'already-connected': 1,
+		'needs-transfer': 2,
+		unsupported: 3,
+	};
+
 	return [ ...sites ].sort( ( a, b ) => {
-		if ( a.syncSupport === 'unsupported' && b.syncSupport === 'unsupported' ) {
-			return 0;
-		}
-		if ( a.syncSupport === 'unsupported' ) {
-			return 1;
-		}
-		if ( b.syncSupport === 'unsupported' ) {
-			return -1;
-		}
-		if ( a.syncSupport === 'needs-transfer' && b.syncSupport === 'needs-transfer' ) {
-			return 0;
-		}
-		if ( a.syncSupport === 'needs-transfer' ) {
-			return 1;
-		}
-		if ( b.syncSupport === 'needs-transfer' ) {
-			return -1;
-		}
-		return 0;
+		return ( order[ a.syncSupport ] || 1 ) - ( order[ b.syncSupport ] || 1 );
 	} );
 };
 

--- a/src/components/sync-sites-modal-selector.tsx
+++ b/src/components/sync-sites-modal-selector.tsx
@@ -100,7 +100,6 @@ function SearchSites( {
 	);
 }
 
-// render unsupported sites at the bottom of the list
 const getSortedSites = ( sites: SyncSite[] ) => {
 	const order: Record< SyncSite[ 'syncSupport' ], number > = {
 		syncable: 1,

--- a/src/components/sync-sites-modal-selector.tsx
+++ b/src/components/sync-sites-modal-selector.tsx
@@ -100,25 +100,13 @@ function SearchSites( {
 	);
 }
 
-// we are rendering in the next order: syncable / already-connected, needs-transfer, unsupported
+// render unsupported sites at the bottom of the list
 const getSortedSites = ( sites: SyncSite[] ) => {
 	return [ ...sites ].sort( ( a, b ) => {
-		if ( a.syncSupport === 'unsupported' && b.syncSupport === 'unsupported' ) {
-			return 0;
-		}
-		if ( a.syncSupport === 'unsupported' ) {
+		if ( a.syncSupport === 'unsupported' && b.syncSupport !== 'unsupported' ) {
 			return 1;
 		}
-		if ( b.syncSupport === 'unsupported' ) {
-			return -1;
-		}
-		if ( a.syncSupport === 'needs-transfer' && b.syncSupport === 'needs-transfer' ) {
-			return 0;
-		}
-		if ( a.syncSupport === 'needs-transfer' ) {
-			return 1;
-		}
-		if ( b.syncSupport === 'needs-transfer' ) {
+		if ( a.syncSupport !== 'unsupported' && b.syncSupport === 'unsupported' ) {
 			return -1;
 		}
 		return 0;

--- a/src/components/sync-sites-modal-selector.tsx
+++ b/src/components/sync-sites-modal-selector.tsx
@@ -109,9 +109,7 @@ const getSortedSites = ( sites: SyncSite[] ) => {
 		unsupported: 3,
 	};
 
-	return [ ...sites ].sort( ( a, b ) => {
-		return ( order[ a.syncSupport ] || 1 ) - ( order[ b.syncSupport ] || 1 );
-	} );
+	return [ ...sites ].sort( ( a, b ) => order[ a.syncSupport ] - order[ b.syncSupport ] );
 };
 
 function ListSites( {

--- a/src/components/sync-sites-modal-selector.tsx
+++ b/src/components/sync-sites-modal-selector.tsx
@@ -103,10 +103,22 @@ function SearchSites( {
 // render unsupported sites at the bottom of the list
 const getSortedSites = ( sites: SyncSite[] ) => {
 	return [ ...sites ].sort( ( a, b ) => {
-		if ( a.syncSupport === 'unsupported' && b.syncSupport !== 'unsupported' ) {
+		if ( a.syncSupport === 'unsupported' && b.syncSupport === 'unsupported' ) {
+			return 0;
+		}
+		if ( a.syncSupport === 'unsupported' ) {
 			return 1;
 		}
-		if ( a.syncSupport !== 'unsupported' && b.syncSupport === 'unsupported' ) {
+		if ( b.syncSupport === 'unsupported' ) {
+			return -1;
+		}
+		if ( a.syncSupport === 'needs-transfer' && b.syncSupport === 'needs-transfer' ) {
+			return 0;
+		}
+		if ( a.syncSupport === 'needs-transfer' ) {
+			return 1;
+		}
+		if ( b.syncSupport === 'needs-transfer' ) {
 			return -1;
 		}
 		return 0;

--- a/src/components/sync-sites-modal-selector.tsx
+++ b/src/components/sync-sites-modal-selector.tsx
@@ -100,6 +100,31 @@ function SearchSites( {
 	);
 }
 
+// we are rendering in the next order: syncable / already-connected, needs-transfer, unsupported
+const getSortedSites = ( sites: SyncSite[] ) => {
+	return [ ...sites ].sort( ( a, b ) => {
+		if ( a.syncSupport === 'unsupported' && b.syncSupport === 'unsupported' ) {
+			return 0;
+		}
+		if ( a.syncSupport === 'unsupported' ) {
+			return 1;
+		}
+		if ( b.syncSupport === 'unsupported' ) {
+			return -1;
+		}
+		if ( a.syncSupport === 'needs-transfer' && b.syncSupport === 'needs-transfer' ) {
+			return 0;
+		}
+		if ( a.syncSupport === 'needs-transfer' ) {
+			return 1;
+		}
+		if ( b.syncSupport === 'needs-transfer' ) {
+			return -1;
+		}
+		return 0;
+	} );
+};
+
 function ListSites( {
 	syncSites,
 	selectedSiteId,
@@ -109,9 +134,11 @@ function ListSites( {
 	selectedSiteId: null | number;
 	onSelectSite: ( id: number ) => void;
 } ) {
+	const sortedSites = getSortedSites( syncSites );
+
 	return (
 		<div className="flex flex-col overflow-y-auto h-full">
-			{ syncSites.map( ( site ) => (
+			{ sortedSites.map( ( site ) => (
 				<SiteItem
 					key={ site.id }
 					site={ site }

--- a/src/components/sync-sites-modal-selector.tsx
+++ b/src/components/sync-sites-modal-selector.tsx
@@ -103,9 +103,9 @@ function SearchSites( {
 const getSortedSites = ( sites: SyncSite[] ) => {
 	const order: Record< SyncSite[ 'syncSupport' ], number > = {
 		syncable: 1,
-		'already-connected': 1,
-		'needs-transfer': 2,
-		unsupported: 3,
+		'already-connected': 2,
+		'needs-transfer': 3,
+		unsupported: 4,
 	};
 
 	return [ ...sites ].sort( ( a, b ) => order[ a.syncSupport ] - order[ b.syncSupport ] );

--- a/src/hooks/use-fetch-wpcom-sites.tsx
+++ b/src/hooks/use-fetch-wpcom-sites.tsx
@@ -21,11 +21,11 @@ type SitesEndpointSite = {
 	is_wpcom_staging_site: boolean;
 	name: string;
 	URL: string;
-	options: {
+	options?: {
 		created_at: string;
 		wpcom_staging_blog_ids: number[];
 	};
-	plan: {
+	plan?: {
 		expired: boolean;
 		features: {
 			active: string[];
@@ -49,7 +49,7 @@ function getSyncSupport( site: SitesEndpointSite, connectedSiteIds: number[] ): 
 	if ( connectedSiteIds.some( ( id ) => id === site.ID ) ) {
 		return 'already-connected';
 	}
-	if ( ! site.plan.features.active.includes( STUDIO_SYNC_FEATURE_NAME ) ) {
+	if ( ! site.plan || ! site.plan.features.active.includes( STUDIO_SYNC_FEATURE_NAME ) ) {
 		return 'unsupported';
 	}
 	if ( ! site.is_wpcom_atomic ) {
@@ -69,7 +69,7 @@ function transformSiteResponse(
 			name: site.name,
 			url: site.URL,
 			isStaging: site.is_wpcom_staging_site,
-			stagingSiteIds: site.options.wpcom_staging_blog_ids,
+			stagingSiteIds: site.options?.wpcom_staging_blog_ids ?? [],
 			syncSupport: getSyncSupport( site, connectedSiteIds ),
 		};
 	} );
@@ -99,6 +99,7 @@ export const useFetchWpComSites = ( connectedSites: SyncSite[] ) => {
 					fields: 'name,ID,URL,plan,is_wpcom_staging_site,is_wpcom_atomic,options',
 					filter: 'atomic,wpcom',
 					options: 'created_at,wpcom_staging_blog_ids',
+					site_visibility: 'visible',
 				}
 			)
 			.then( ( response ) => {


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/9487

## Proposed Changes
With this PR we are rendering `Unsupported` sites at the end of the list.

## Testing Instructions
1. Purchase a few sites on wordpress.com
2. Deleted at least one of them
3. Run `STUDIO_SITE_SYNC=true npm start`
4. select any site -> Click on `Sync` tab -> click on `Connect site` button
5. Assert that you see `Unsupported` sites at the end of the list <br /> <img width="754" alt="Screenshot 2024-10-30 at 12 36 38" src="https://github.com/user-attachments/assets/0a8a994b-2be9-41fa-936b-b717e3197716">
