### PR TITLE
fix(sync): align arrows of site url and add tooltip

### DIFF
--- a/src/components/sync-connected-sites.tsx
+++ b/src/components/sync-connected-sites.tsx
@@ -125,7 +125,7 @@ export function SyncConnectedSites( {
 
 								<Button
 									variant="link"
-									className="!text-a8c-gray-70 hover:!text-a8c-blueberry"
+									className="!text-a8c-gray-70 hover:!text-a8c-blueberry inline-block break-all"
 									onClick={ () => {
 										getIpcApi().openURL( connectedSite.url );
 									} }

--- a/src/components/sync-connected-sites.tsx
+++ b/src/components/sync-connected-sites.tsx
@@ -8,8 +8,8 @@ import { getIpcApi } from '../lib/get-ipc-api';
 import { ArrowIcon } from './arrow-icon';
 import { Badge } from './badge';
 import Button from './button';
-import { WordPressLogoCircle } from './wordpress-logo-circle';
 import Tooltip from './tooltip';
+import { WordPressLogoCircle } from './wordpress-logo-circle';
 
 interface ConnectedSiteSection {
 	id: number;
@@ -124,10 +124,10 @@ export function SyncConnectedSites( {
 									) }
 								</div>
 
-								<Tooltip text={ connectedSite.url }>
+								<Tooltip text={ connectedSite.url } className="overflow-hidden">
 									<Button
 										variant="link"
-										className="!text-a8c-gray-70 hover:!text-a8c-blueberry truncate"
+										className="!text-a8c-gray-70 hover:!text-a8c-blueberry max-w-[100%]"
 										onClick={ () => {
 											getIpcApi().openURL( connectedSite.url );
 										} }

--- a/src/components/sync-connected-sites.tsx
+++ b/src/components/sync-connected-sites.tsx
@@ -9,6 +9,7 @@ import { ArrowIcon } from './arrow-icon';
 import { Badge } from './badge';
 import Button from './button';
 import { WordPressLogoCircle } from './wordpress-logo-circle';
+import Tooltip from './tooltip';
 
 interface ConnectedSiteSection {
 	id: number;
@@ -123,16 +124,17 @@ export function SyncConnectedSites( {
 									) }
 								</div>
 
-								<Button
-									variant="link"
-									className="!text-a8c-gray-70 hover:!text-a8c-blueberry truncate"
-									onClick={ () => {
-										getIpcApi().openURL( connectedSite.url );
-									} }
-									title={ connectedSite.url }
-								>
-									<span className="truncate">{ connectedSite.url }</span> <ArrowIcon />
-								</Button>
+								<Tooltip text={ connectedSite.url }>
+									<Button
+										variant="link"
+										className="!text-a8c-gray-70 hover:!text-a8c-blueberry truncate"
+										onClick={ () => {
+											getIpcApi().openURL( connectedSite.url );
+										} }
+									>
+										<span className="truncate">{ connectedSite.url }</span> <ArrowIcon />
+									</Button>
+								</Tooltip>
 								<div className="flex gap-2 pl-4 ml-auto shrink-0">
 									<Button variant="link" className="!text-black hover:!text-a8c-blueberry">
 										<Icon icon={ cloudDownload } />

--- a/src/components/tooltip.tsx
+++ b/src/components/tooltip.tsx
@@ -52,7 +52,7 @@ const Tooltip = ( {
 				>
 					<div className="flex flex-row justify-center items-center max-w-60 gap-2 rounded py-2 px-2.5 bg-[#101517] text-white animate-[fade_0.5s_ease-in-out_1]">
 						{ icon && <Icon className="fill-white shrink-0 m-[2px] " size={ 16 } icon={ icon } /> }
-						<p className="text-left text-xs">{ text }</p>
+						<p className="text-left text-xs break-words overflow-hidden">{ text }</p>
 					</div>
 				</Popover>
 			) }


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/9510

## Proposed Changes
We should keep arrows always at the end of the URL, even if it's very long
<img width="616" alt="Screenshot 2024-10-30 at 13 00 37" src="https://github.com/user-attachments/assets/cc621bec-5a66-4e63-a5b1-5b7f52e45937">

## Testing Instructions
1. Run STUDIO_SITE_SYNC=true npm start
2. Select any site -> Click on Sync tab -> click on Connect site button -> Select a site -> Click on "Connect' button
3. You should see the next<br /><img width="879" alt="Screenshot 2024-10-30 at 13 03 12" src="https://github.com/user-attachments/assets/de8ab4da-4b37-4aed-bc7d-ffda7d19fd1b">
4. Duplicate the URL a few times to make it long
5. Assert that that the arrow is located at the end of the URl and the URL is rendered as a few lines
<table>
<tr>
<td>BEFORE
<td>AFTER
</tr>
<tr>
<td><img width="882" alt="Screenshot 2024-10-30 at 13 05 33" src="https://github.com/user-attachments/assets/1f8ba7e8-022c-4fbe-901b-c0806169a939">
<td><img width="882" alt="Screenshot 2024-10-30 at 13 04 59" src="https://github.com/user-attachments/assets/ae09ab99-a5fe-4e47-84a7-672f6783fd04">
</tr>
</table>
