### PR TITLE
Remove regenerate media step after import

### DIFF
--- a/src/hooks/tests/use-import-export.test.tsx
+++ b/src/hooks/tests/use-import-export.test.tsx
@@ -342,15 +342,6 @@ describe( 'useImportExport hook', () => {
 			},
 		} );
 
-		emitImportEvent( SITE_ID, ImportEvents.IMPORT_MEDIA_REGENERATE_START );
-		expect( result.current.importState ).toEqual( {
-			[ SITE_ID ]: {
-				statusMessage: 'Regenerating media…',
-				progress: 95,
-				isNewSite: false,
-			},
-		} );
-
 		emitImportEvent( SITE_ID, ImportEvents.IMPORT_COMPLETE );
 		expect( result.current.importState ).toEqual( {
 			[ SITE_ID ]: {

--- a/src/hooks/use-import-export.tsx
+++ b/src/hooks/use-import-export.tsx
@@ -210,16 +210,6 @@ export const ImportExportProvider = ( { children }: { children: React.ReactNode 
 					},
 				} ) );
 				break;
-			case ImporterEvents.IMPORT_MEDIA_REGENERATE_START:
-				setImportState( ( { [ siteId ]: currentProgress, ...rest } ) => ( {
-					...rest,
-					[ siteId ]: {
-						...currentProgress,
-						statusMessage: __( 'Regenerating media…' ),
-						progress: 95,
-					},
-				} ) );
-				break;
 			case ImporterEvents.IMPORT_COMPLETE:
 				setImportState( ( { [ siteId ]: currentProgress, ...rest } ) => ( {
 					...rest,

--- a/src/lib/import-export/import/events.ts
+++ b/src/lib/import-export/import/events.ts
@@ -19,8 +19,6 @@ export const ImporterEvents = {
 	IMPORT_WP_CONTENT_COMPLETE: 'import_wp_content_complete',
 	IMPORT_META_START: 'import_meta',
 	IMPORT_META_COMPLETE: 'import_meta_complete',
-	IMPORT_MEDIA_REGENERATE_START: 'import_media_regenerate_start',
-	IMPORT_MEDIA_REGENERATE_COMPLETE: 'import_media_regenerate_complete',
 	IMPORT_COMPLETE: 'import_complete',
 	IMPORT_ERROR: 'import_error',
 } as const;

--- a/src/lib/import-export/import/importers/importer.ts
+++ b/src/lib/import-export/import/importers/importer.ts
@@ -137,7 +137,6 @@ abstract class BaseBackupImporter extends BaseImporter {
 				this.meta = await this.parseMetaFile();
 			}
 			await this.importDatabase( rootPath, siteId, this.backup.sqlFiles );
-			await this.regenerateMedia( siteId );
 
 			this.emit( ImportEvents.IMPORT_COMPLETE );
 			return {
@@ -155,19 +154,6 @@ abstract class BaseBackupImporter extends BaseImporter {
 	}
 
 	protected abstract parseMetaFile(): Promise< MetaFileData | undefined >;
-
-	protected async regenerateMedia( siteId: string ): Promise< void > {
-		const server = SiteServer.get( siteId );
-		if ( ! server ) {
-			throw new Error( 'Site not found.' );
-		}
-		this.emit( ImportEvents.IMPORT_MEDIA_REGENERATE_START );
-		const { stderr } = await server.executeWpCliCommand( 'media regenerate --yes' );
-		if ( stderr ) {
-			console.error( 'Error during media regeneration:', stderr );
-		}
-		this.emit( ImportEvents.IMPORT_MEDIA_REGENERATE_COMPLETE );
-	}
 
 	protected async createEmptyDatabase( dbPath: string ): Promise< void > {
 		await fsPromises.writeFile( dbPath, '' );

--- a/src/lib/import-export/tests/import/importer/default-importer.test.ts
+++ b/src/lib/import-export/tests/import/importer/default-importer.test.ts
@@ -116,13 +116,5 @@ describe( 'JetpackImporter', () => {
 			expect( fs.copyFile ).toHaveBeenCalledTimes( 4 );
 			expect( fs.readFile ).toHaveBeenCalledWith( '/tmp/extracted/meta.json', 'utf-8' );
 		} );
-
-		it( 'should regenerate media after import', async () => {
-			const importer = new JetpackImporter( mockBackupContents );
-			await importer.import( mockStudioSitePath, mockStudioSiteId );
-
-			const siteServer = SiteServer.get( mockStudioSiteId );
-			expect( siteServer?.executeWpCliCommand ).toHaveBeenCalledWith( 'media regenerate --yes' );
-		} );
 	} );
 } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

- Closes https://github.com/Automattic/dotcom-forge/issues/9559
- Reverts https://github.com/Automattic/studio/pull/592

## Proposed Changes

- Let's not regenerate media thumbnails as part of the import flow. Users can ask the assistant to run it if they need to.
- We'll document it in the FAQs

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Download a .wpress or Jetpack backup
- Run `npm start`
- Create a site and select your backup
- Observe the import succeeds and it doesn't display the "regenerate" media step.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
