### PR TITLE
Studio: Remove connected sites after local site deletion

### DIFF
--- a/e2e/sites.test.ts
+++ b/e2e/sites.test.ts
@@ -94,7 +94,7 @@ test.describe( 'Servers', () => {
 		} );
 		await settingsTab.openDeleteSiteModal();
 
-		await session.mainWindow.waitForTimeout( 300 ); // Short pause for site to delete.
+		await session.mainWindow.waitForTimeout( 200 ); // Short pause for site to delete.
 
 		expect( await pathExists( path.join( session.homePath, 'Studio', siteName ) ) ).toBe( false );
 		const sidebar = new MainSidebar( session.mainWindow );

--- a/e2e/sites.test.ts
+++ b/e2e/sites.test.ts
@@ -94,7 +94,7 @@ test.describe( 'Servers', () => {
 		} );
 		await settingsTab.openDeleteSiteModal();
 
-		await session.mainWindow.waitForTimeout( 200 ); // Short pause for site to delete.
+		await session.mainWindow.waitForTimeout( 300 ); // Short pause for site to delete.
 
 		expect( await pathExists( path.join( session.homePath, 'Studio', siteName ) ) ).toBe( false );
 		const sidebar = new MainSidebar( session.mainWindow );

--- a/src/hooks/use-site-details.tsx
+++ b/src/hooks/use-site-details.tsx
@@ -99,13 +99,21 @@ function useDeleteSite() {
 			try {
 				setIsLoading( ( loading ) => ( { ...loading, [ siteId ]: true } ) );
 
-				// Find related connected sites and remove them before deletetion
-				const connectedSites = await getIpcApi().getConnectedWpcomSites( siteId );
-				const connectedSiteIds = connectedSites.map( ( site ) => site.id );
-				await getIpcApi().disconnectWpcomSite( connectedSiteIds, siteId );
-
 				const newSites = await getIpcApi().deleteSite( siteId, removeLocal );
 				await allSiteRemovePromises;
+
+				// After site is deleted successfully, clean up wpcom connections
+				try {
+					const connectedSites = await getIpcApi().getConnectedWpcomSites( siteId );
+					const connectedSiteIds = connectedSites.map( ( site ) => site.id );
+					if ( connectedSiteIds.length > 0 ) {
+						await getIpcApi().disconnectWpcomSite( connectedSiteIds, siteId );
+					}
+				} catch ( error ) {
+					// If disconnection fails, log but don't fail the deletion
+					console.error( 'Failed to disconnect wpcom sites:', error );
+				}
+
 				return newSites;
 			} catch ( error ) {
 				console.error( 'Error during site deletion:', error );

--- a/src/hooks/use-site-details.tsx
+++ b/src/hooks/use-site-details.tsx
@@ -87,11 +87,11 @@ function useDeleteSite() {
 
 	const deleteSite = useCallback(
 		async ( siteId: string, removeLocal: boolean ): Promise< SiteDetails[] | undefined > => {
-			const siteSnapshots = snapshots.filter( ( snapshot ) => snapshot.localSiteId === siteId );
-
 			if ( ! siteId ) {
 				return;
 			}
+
+			const siteSnapshots = snapshots.filter( ( snapshot ) => snapshot.localSiteId === siteId );
 			const allSiteRemovePromises = Promise.allSettled(
 				siteSnapshots.map( ( snapshot ) => deleteSnapshot( snapshot, removeLocal ) )
 			);
@@ -104,13 +104,12 @@ function useDeleteSite() {
 				const connectedSiteIds = connectedSites.map( ( site ) => site.id );
 				await getIpcApi().disconnectWpcomSite( connectedSiteIds, siteId );
 
-				// Then delete the site and its snapshots
 				const newSites = await getIpcApi().deleteSite( siteId, removeLocal );
 				await allSiteRemovePromises;
 				return newSites;
 			} catch ( error ) {
 				console.error( 'Error during site deletion:', error );
-				throw error; // Rethrow to handle in the component
+				throw error;
 			} finally {
 				setIsLoading( ( loading ) => ( { ...loading, [ siteId ]: false } ) );
 			}

--- a/src/hooks/use-site-details.tsx
+++ b/src/hooks/use-site-details.tsx
@@ -98,9 +98,19 @@ function useDeleteSite() {
 
 			try {
 				setIsLoading( ( loading ) => ( { ...loading, [ siteId ]: true } ) );
+
+				// Find related connected sites and remove them before deletetion
+				const connectedSites = await getIpcApi().getConnectedWpcomSites( siteId );
+				const connectedSiteIds = connectedSites.map( ( site ) => site.id );
+				await getIpcApi().disconnectWpcomSite( connectedSiteIds, siteId );
+
+				// Then delete the site and its snapshots
 				const newSites = await getIpcApi().deleteSite( siteId, removeLocal );
 				await allSiteRemovePromises;
 				return newSites;
+			} catch ( error ) {
+				console.error( 'Error during site deletion:', error );
+				throw error; // Rethrow to handle in the component
 			} finally {
 				setIsLoading( ( loading ) => ( { ...loading, [ siteId ]: false } ) );
 			}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/9548

## Proposed Changes

This PR ensures that we clean up the connected WP.com sites from `appdata-v1.json` when we delete a Studio site. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
* Pull the changes from this branch
* Start Studio app with `STUDIO_SITE_SYNC=true npm start`
* Create a Studio site by clicking on `Add site` in the sidebar
* Navigate to the `Sync` tab
* Click on `Connect site`
* Connect a site (either with or without a staging site)
* Open `/Users/{yourUser}/Library/Application Support/Studio/appdata-v1.json` on your machine (make sure to replace `yourUser` with your actual user)
* Confirm that you can see the connected site / sites in the `connectedWpcomSites` object present
* In Studio, navigate to the `Settings` tab for the local site
* Click on `Delete site` and proceed with deletion\
* Open `/Users/{yourUser}/Library/Application Support/Studio/appdata-v1.json`
* Observe that `connectedWpcomSites` object does not contain connected sites anymore

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
