### PR TITLE
Studio: Add tests for connecting and disconnecting sites

### DIFF
--- a/src/hooks/tests/use-site-sync-management.test.ts
+++ b/src/hooks/tests/use-site-sync-management.test.ts
@@ -1,5 +1,4 @@
-import { renderHook, act } from '@testing-library/react';
-import { getIpcApi } from '../../lib/get-ipc-api';
+import { renderHook, waitFor } from '@testing-library/react';
 import { useAuth } from '../use-auth';
 import { useFetchWpComSites } from '../use-fetch-wpcom-sites';
 import { useSiteDetails } from '../use-site-details';
@@ -8,23 +7,30 @@ import { useSiteSyncManagement } from '../use-site-sync-management';
 jest.mock( '../use-auth' );
 jest.mock( '../use-site-details' );
 jest.mock( '../use-fetch-wpcom-sites' );
-jest.mock( '../../lib/get-ipc-api' );
-
+jest.mock( '../../lib/get-ipc-api', () => ( {
+	getIpcApi: () => ( {
+		getConnectedWpcomSites: jest.fn().mockResolvedValue( mockConnectedWpcomSites ),
+		connectWpcomSite: jest
+			.fn()
+			.mockResolvedValue( [ ...mockConnectedWpcomSites, { id: 6, stagingSiteIds: [] } ] ),
+		disconnectWpcomSite: jest.fn().mockResolvedValue( mockConnectedWpcomSites.slice( 1 ) ),
+	} ),
+} ) );
 export const mockConnectedWpcomSites = [
 	{
-		id: 229386460,
+		id: 6,
 		localSiteId: '788a7e0c-62d2-427e-8b1a-e6d5ac84b61c',
-		name: 'Site Nice',
-		url: 'https://codesnippets.wpcomstaging.com',
+		name: 'My simple business site',
+		url: 'https://developer.wordpress.com/studio/',
 		isStaging: false,
-		stagingSiteIds: [ 238312390 ],
+		stagingSiteIds: [ 7 ],
 		syncSupport: 'syncable',
 	},
 	{
-		id: 238312390,
+		id: 7,
 		localSiteId: '788a7e0c-62d2-427e-8b1a-e6d5ac84b61c',
-		name: '',
-		url: 'https://staging-codesnippets9.wpcomstaging.com',
+		name: 'Staging: My simple business site',
+		url: 'https://developer-staging.wordpress.com/studio/',
 		isStaging: true,
 		stagingSiteIds: [],
 		syncSupport: 'syncable',
@@ -36,3 +42,56 @@ export const ConnectedSitesStore = {
 		'99440446': mockConnectedWpcomSites,
 	},
 };
+
+const mockSyncSites = [
+	{
+		id: 6,
+		name: 'My simple business site',
+		url: 'https://developer.wordpress.com/studio/',
+		isStaging: false,
+		stagingSiteIds: [ 7 ],
+		syncSupport: 'syncable',
+	},
+	{
+		id: 7,
+		name: 'Staging: My simple business site',
+		url: 'https://developer-staging.wordpress.com/studio/',
+		isStaging: true,
+		stagingSiteIds: [],
+		syncSupport: 'syncable',
+	},
+];
+
+describe( 'useSiteSyncManagement', () => {
+	beforeEach( () => {
+		( useAuth as jest.Mock ).mockReturnValue( { isAuthenticated: true } );
+		( useSiteDetails as jest.Mock ).mockReturnValue( {
+			selectedSite: { id: '788a7e0c-62d2-427e-8b1a-e6d5ac84b61c' },
+		} );
+		( useFetchWpComSites as jest.Mock ).mockReturnValue( {
+			syncSites: mockSyncSites,
+			isFetching: false,
+		} );
+	} );
+
+	afterEach( () => {
+		jest.resetAllMocks();
+	} );
+
+	it( 'loads connected sites on mount when authenticated', async () => {
+		const { result } = renderHook( () => useSiteSyncManagement() );
+
+		await waitFor( () => {
+			expect( result.current.connectedSites ).toEqual( mockConnectedWpcomSites );
+		} );
+	} );
+
+	it( 'does not load connected sites when not authenticated', async () => {
+		( useAuth as jest.Mock ).mockReturnValue( { isAuthenticated: false } );
+		const { result } = renderHook( () => useSiteSyncManagement() );
+
+		await waitFor( () => {
+			expect( result.current.connectedSites ).toEqual( [] );
+		} );
+	} );
+} );

--- a/src/hooks/tests/use-site-sync-management.test.ts
+++ b/src/hooks/tests/use-site-sync-management.test.ts
@@ -29,12 +29,6 @@ const mockConnectedWpcomSites = [
 	},
 ];
 
-export const ConnectedSitesStore = {
-	connectedWpcomSites: {
-		'99440446': mockConnectedWpcomSites,
-	},
-};
-
 const mockSyncSites = [
 	{
 		id: 8,

--- a/src/hooks/tests/use-site-sync-management.test.ts
+++ b/src/hooks/tests/use-site-sync-management.test.ts
@@ -1,0 +1,38 @@
+import { renderHook, act } from '@testing-library/react';
+import { getIpcApi } from '../../lib/get-ipc-api';
+import { useAuth } from '../use-auth';
+import { useFetchWpComSites } from '../use-fetch-wpcom-sites';
+import { useSiteDetails } from '../use-site-details';
+import { useSiteSyncManagement } from '../use-site-sync-management';
+
+jest.mock( '../use-auth' );
+jest.mock( '../use-site-details' );
+jest.mock( '../use-fetch-wpcom-sites' );
+jest.mock( '../../lib/get-ipc-api' );
+
+export const mockConnectedWpcomSites = [
+	{
+		id: 229386460,
+		localSiteId: '788a7e0c-62d2-427e-8b1a-e6d5ac84b61c',
+		name: 'Site Nice',
+		url: 'https://codesnippets.wpcomstaging.com',
+		isStaging: false,
+		stagingSiteIds: [ 238312390 ],
+		syncSupport: 'syncable',
+	},
+	{
+		id: 238312390,
+		localSiteId: '788a7e0c-62d2-427e-8b1a-e6d5ac84b61c',
+		name: '',
+		url: 'https://staging-codesnippets9.wpcomstaging.com',
+		isStaging: true,
+		stagingSiteIds: [],
+		syncSupport: 'syncable',
+	},
+];
+
+export const ConnectedSitesStore = {
+	connectedWpcomSites: {
+		'99440446': mockConnectedWpcomSites,
+	},
+};

--- a/src/hooks/tests/use-site-sync-management.test.ts
+++ b/src/hooks/tests/use-site-sync-management.test.ts
@@ -7,15 +7,7 @@ import { useSiteSyncManagement } from '../use-site-sync-management';
 jest.mock( '../use-auth' );
 jest.mock( '../use-site-details' );
 jest.mock( '../use-fetch-wpcom-sites' );
-jest.mock( '../../lib/get-ipc-api', () => ( {
-	getIpcApi: () => ( {
-		getConnectedWpcomSites: jest.fn().mockResolvedValue( mockConnectedWpcomSites ),
-		connectWpcomSite: jest
-			.fn()
-			.mockResolvedValue( [ ...mockConnectedWpcomSites, { id: 6, stagingSiteIds: [] } ] ),
-		disconnectWpcomSite: jest.fn().mockResolvedValue( mockConnectedWpcomSites.slice( 1 ) ),
-	} ),
-} ) );
+
 export const mockConnectedWpcomSites = [
 	{
 		id: 6,
@@ -45,22 +37,36 @@ export const ConnectedSitesStore = {
 
 const mockSyncSites = [
 	{
-		id: 6,
-		name: 'My simple business site',
-		url: 'https://developer.wordpress.com/studio/',
+		id: 8,
+		localSiteId: '',
+		name: 'My simple store',
+		url: 'https://developer.wordpress.com/studio/store',
 		isStaging: false,
-		stagingSiteIds: [ 7 ],
+		stagingSiteIds: [ 9 ],
 		syncSupport: 'syncable',
 	},
 	{
-		id: 7,
-		name: 'Staging: My simple business site',
-		url: 'https://developer-staging.wordpress.com/studio/',
+		id: 9,
+		localSiteId: '',
+		name: 'Staging: My simple test store',
+		url: 'https://developer-staging.wordpress.com/studio/test-store',
 		isStaging: true,
 		stagingSiteIds: [],
 		syncSupport: 'syncable',
 	},
 ];
+
+const connectWpcomSiteMock = jest
+	.fn()
+	.mockResolvedValue( [ ...mockConnectedWpcomSites, { id: 6, stagingSiteIds: [] } ] );
+
+jest.mock( '../../lib/get-ipc-api', () => ( {
+	getIpcApi: () => ( {
+		getConnectedWpcomSites: jest.fn().mockResolvedValue( mockConnectedWpcomSites ),
+		connectWpcomSite: connectWpcomSiteMock,
+		disconnectWpcomSite: jest.fn().mockResolvedValue( mockConnectedWpcomSites.slice( 1 ) ),
+	} ),
+} ) );
 
 describe( 'useSiteSyncManagement', () => {
 	beforeEach( () => {
@@ -92,6 +98,25 @@ describe( 'useSiteSyncManagement', () => {
 
 		await waitFor( () => {
 			expect( result.current.connectedSites ).toEqual( [] );
+		} );
+	} );
+
+	it( 'connects a site and its staging sites successfully', async () => {
+		const { result } = renderHook( () => useSiteSyncManagement() );
+		const siteToConnect = mockSyncSites[ 0 ];
+
+		await waitFor( async () => {
+			await result.current.connectSite( {
+				...siteToConnect,
+				syncSupport: 'syncable',
+			} );
+		} );
+
+		await waitFor( () => {
+			expect( connectWpcomSiteMock ).toHaveBeenCalledWith(
+				[ siteToConnect, mockSyncSites[ 1 ] ],
+				'788a7e0c-62d2-427e-8b1a-e6d5ac84b61c'
+			);
 		} );
 	} );
 } );

--- a/src/hooks/tests/use-site-sync-management.test.ts
+++ b/src/hooks/tests/use-site-sync-management.test.ts
@@ -8,7 +8,7 @@ jest.mock( '../use-auth' );
 jest.mock( '../use-site-details' );
 jest.mock( '../use-fetch-wpcom-sites' );
 
-export const mockConnectedWpcomSites = [
+const mockConnectedWpcomSites = [
 	{
 		id: 6,
 		localSiteId: '788a7e0c-62d2-427e-8b1a-e6d5ac84b61c',

--- a/src/hooks/tests/use-site-sync-management.test.ts
+++ b/src/hooks/tests/use-site-sync-management.test.ts
@@ -56,6 +56,7 @@ const mockSyncSites = [
 	},
 ];
 
+const disconnectWpcomSiteMock = jest.fn().mockResolvedValue( [] );
 const connectWpcomSiteMock = jest
 	.fn()
 	.mockResolvedValue( [ ...mockConnectedWpcomSites, { id: 6, stagingSiteIds: [] } ] );
@@ -64,7 +65,7 @@ jest.mock( '../../lib/get-ipc-api', () => ( {
 	getIpcApi: () => ( {
 		getConnectedWpcomSites: jest.fn().mockResolvedValue( mockConnectedWpcomSites ),
 		connectWpcomSite: connectWpcomSiteMock,
-		disconnectWpcomSite: jest.fn().mockResolvedValue( mockConnectedWpcomSites.slice( 1 ) ),
+		disconnectWpcomSite: disconnectWpcomSiteMock,
 	} ),
 } ) );
 
@@ -118,5 +119,24 @@ describe( 'useSiteSyncManagement', () => {
 				'788a7e0c-62d2-427e-8b1a-e6d5ac84b61c'
 			);
 		} );
+	} );
+
+	it( 'disconnects a site and its staging sites successfully', async () => {
+		const { result } = renderHook( () => useSiteSyncManagement() );
+		const siteToDisconnect = mockConnectedWpcomSites[ 0 ];
+
+		await waitFor( () => {
+			expect( result.current.connectedSites ).toBeDefined();
+			expect( result.current.connectedSites ).toEqual( mockConnectedWpcomSites );
+		} );
+
+		await waitFor( async () => {
+			await result.current.disconnectSite( siteToDisconnect.id );
+		} );
+
+		expect( disconnectWpcomSiteMock ).toHaveBeenCalledWith(
+			[ siteToDisconnect.id, ...siteToDisconnect.stagingSiteIds ],
+			'788a7e0c-62d2-427e-8b1a-e6d5ac84b61c'
+		);
 	} );
 } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/9515

## Proposed Changes

This PR adds tests to `use-site-sync-management` hook. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Observe that the tests below are passing

Alternatively:

* Pull the changes from this branch
* Run `nvm use && npm install && npm run test` (or another version manager that you have installed if you are not using `nvm`)
* Confirm that the tests are passing


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
