### PR TITLE
Add custom GitHub commit status to Buildkite steps using matrix

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -70,8 +70,9 @@ steps:
     matrix:
       - mac
       #- windows
-    # No notify node because we cannot interpolate the matrix value in the context string
-    # See https://github.com/Automattic/studio/pull/614#discussion_r1821669523
+    notify:
+      - github_commit_status:
+          context: All E2E Tests
 
   - group: 📦 Build for Mac
     key: dev-mac
@@ -110,7 +111,6 @@ steps:
 
           echo "--- 📃 Notarizing Binary"
           bundle exec fastlane notarize_binary
-
         plugins: *common_plugins
         artifact_paths:
           - out/**/*.app.zip
@@ -119,9 +119,10 @@ steps:
           - universal
           - x64
           - arm64
+        notify:
+          - github_commit_status:
+              context: All Mac Dev Builds
     if: build.tag !~ /^v[0-9]+/
-    # No notify node because we cannot interpolate the matrix value in the context string
-    # See https://github.com/Automattic/studio/pull/614#discussion_r1821669523
 
   - label: 🔨 Windows Dev Build
     key: dev-windows
@@ -208,7 +209,6 @@ steps:
 
           echo "--- 📃 Notarizing Binary"
           bundle exec fastlane notarize_binary
-
         plugins: *common_plugins
         artifact_paths:
           - out/**/*.app.zip
@@ -217,8 +217,9 @@ steps:
           - universal
           - x64
           - arm64
-        # No notify node because we cannot interpolate the matrix value in the context string
-        # See https://github.com/Automattic/studio/pull/614#discussion_r1821669523
+        notify:
+          - github_commit_status:
+              context: All Mac Release Builds
     if: build.tag =~ /^v[0-9]+/
 
   - label: 🔨 Windows Release Build


### PR DESCRIPTION
## Proposed Changes

Add custom commit status notification from Buildkite to GitHub for the steps using a build matrix.
That is:

- E2E tests
- Mac dev builds
- Mac release builds

The name for the commit status reflect that the reporting occurs when _all_ the steps have completed.

See also:

- https://github.com/Automattic/studio/pull/614#discussion_r1821669523
- https://forum.buildkite.community/t/support-matrix-interpolation-in-github-commit-status-context/4004

## Testing Instructions

Verify the new commit statuses are in this PR's checks view.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors? — N.A.