### PR TITLE
Fix deleting paths before the import to support directories

### DIFF
--- a/src/lib/import-export/import/importers/importer.ts
+++ b/src/lib/import-export/import/importers/importer.ts
@@ -68,7 +68,7 @@ abstract class BaseImporter extends EventEmitter implements Importer {
 					throw new Error( 'Database import failed' );
 				}
 			} finally {
-				await this.safelyDeleteFile( tmpPath );
+				await this.safelyDeletePath( tmpPath );
 			}
 		}
 
@@ -112,11 +112,11 @@ abstract class BaseImporter extends EventEmitter implements Importer {
 		}
 	}
 
-	protected async safelyDeleteFile( filePath: string ): Promise< void > {
+	protected async safelyDeletePath( path: string ): Promise< void > {
 		try {
-			await fsPromises.unlink( filePath );
+			await fsPromises.rm( path, { recursive: true, force: true } );
 		} catch ( error ) {
-			console.error( `Failed to safely delete file ${ filePath }:`, error );
+			console.error( `Failed to safely delete path ${ path }:`, error );
 		}
 	}
 }
@@ -182,7 +182,7 @@ abstract class BaseBackupImporter extends BaseImporter {
 				if ( contentToKeep.includes( content ) ) {
 					continue;
 				}
-				await this.safelyDeleteFile( contentPath );
+				await this.safelyDeletePath( contentPath );
 			}
 		} catch {
 			return;

--- a/src/lib/import-export/tests/import/importer/default-importer.test.ts
+++ b/src/lib/import-export/tests/import/importer/default-importer.test.ts
@@ -86,8 +86,14 @@ describe( 'JetpackImporter', () => {
 			} );
 
 			const expectedUnlinkPath = '/path/to/studio/site/studio-backup-sql-2024-08-01-12-00-00.sql';
-			expect( fs.unlink ).toHaveBeenNthCalledWith( 1, expectedUnlinkPath );
-			expect( fs.unlink ).toHaveBeenNthCalledWith( 2, expectedUnlinkPath );
+			expect( fs.rm ).toHaveBeenNthCalledWith( 1, expectedUnlinkPath, {
+				force: true,
+				recursive: true,
+			} );
+			expect( fs.rm ).toHaveBeenNthCalledWith( 2, expectedUnlinkPath, {
+				force: true,
+				recursive: true,
+			} );
 		} );
 
 		it( 'should handle missing meta file', async () => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/dotcom-forge/issues/9220

## Proposed Changes

I propose fixing deleting paths before the import to ensure default plugins and themes are deleted before we import the site content.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Import sites from different formats (Jetpack Backup, Playground ZIP file, .wpress file, Local export)
2. Confirm that default set of plugins themes that are included in clean WordPress are not visible on imported site if they were not included in the site being imported

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
