### PR TITLE
Add mu-plugin that disables Jetpack Protect on the fly to enable auto-login

### DIFF
--- a/vendor/wp-now/src/download.ts
+++ b/vendor/wp-now/src/download.ts
@@ -345,6 +345,20 @@ set_error_handler(function($severity, $message, $file, $line) {
 			add_filter( 'got_url_rewrite', '__return_true' );
 	`
 	);
+
+	fs.writeFile(
+		path.join( muPluginsPath, '0-deactivate-jetpack-modules.php' ),
+		`<?php
+			// Disable Jetpack Protect 2FA for local auto-login purpose
+			add_action( 'jetpack_active_modules', 'jetpack_deactivate_modules' );
+			function jetpack_deactivate_modules( $active ) {
+				if ( ( $index = array_search('protect', $active, true) ) !== false ) {
+					unset( $active[ $index ] );
+				}
+				return $active;
+			}
+	`
+	);
 }
 
 export function getWordPressVersionPath( wpVersion: string ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/dotcom-forge/issues/9751

## Proposed Changes

I propose adding an mu-plugin that deactivates Jetpack Protect on the fly to avoid showing math questions in the login form. 

Before the change, it prevented users from using "WP Admin" auto-login on local sites that have Jetpack installed. When users used "WP Admin", it showed the login form with the math question:

<img width="503" alt="Screenshot 2024-11-13 at 13 45 10" src="https://github.com/user-attachments/assets/239aa827-748e-44f7-b3c1-cf30311154b9">

The expected behavior is to get the user automatically logged in to WP Admin, regardless of whether Jetpack is installed.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Export a site that includes the Jetpack plugin, for example:
- from Activity Log for WoA site
- from Local dev env after installing the Jetpack plugin there
2. Import the site to Studio
3. Open the "WP Admin" link in Studio
4. Confirm that you were logged to WP Admin automatically

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
