### PR TITLE
Add confirmation dialog before pull

### DIFF
--- a/src/components/sync-connected-sites.tsx
+++ b/src/components/sync-connected-sites.tsx
@@ -4,6 +4,7 @@ import { cloudUpload, cloudDownload } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { useMemo } from 'react';
 import { useSyncSites } from '../hooks/sync-sites';
+import { useConfirmationDialog } from '../hooks/use-confirmation-dialog';
 import { SyncSite } from '../hooks/use-fetch-wpcom-sites';
 import { useSyncStatesProgressInfo } from '../hooks/use-sync-states-progress-info';
 import { getIpcApi } from '../lib/get-ipc-api';
@@ -70,6 +71,15 @@ export function SyncConnectedSites( {
 
 		return siteSections;
 	}, [ connectedSites ] );
+
+	const showPullConfirmation = useConfirmationDialog( {
+		localStorageKey: 'dontShowPullConfirmation',
+		message: __( 'Overwrite Studio site' ),
+		detail: __(
+			"Pulling will replace your Studio site's files and database with a copy from your staging site."
+		),
+		confirmButtonLabel: __( 'Pull' ),
+	} );
 
 	const handleDisconnectSite = async ( sectionId: number, sectionName?: string ) => {
 		const dontShowDisconnectWarning = localStorage.getItem( 'dontShowDisconnectWarning' );
@@ -198,7 +208,7 @@ export function SyncConnectedSites( {
 													variant="link"
 													className="!text-black hover:!text-a8c-blueberry"
 													onClick={ () => {
-														pullSite( connectedSite, selectedSite );
+														showPullConfirmation( () => pullSite( connectedSite, selectedSite ) );
 													} }
 													disabled={ isAnySitePulling }
 												>

--- a/src/components/sync-connected-sites.tsx
+++ b/src/components/sync-connected-sites.tsx
@@ -75,9 +75,6 @@ export function SyncConnectedSites( {
 	const showPullConfirmation = useConfirmationDialog( {
 		localStorageKey: 'dontShowPullConfirmation',
 		message: __( 'Overwrite Studio site' ),
-		detail: __(
-			"Pulling will replace your Studio site's files and database with a copy from your staging site."
-		),
 		confirmButtonLabel: __( 'Pull' ),
 	} );
 
@@ -208,7 +205,16 @@ export function SyncConnectedSites( {
 													variant="link"
 													className="!text-black hover:!text-a8c-blueberry"
 													onClick={ () => {
-														showPullConfirmation( () => pullSite( connectedSite, selectedSite ) );
+														const detail = connectedSite.isStaging
+															? __(
+																	"Pulling will replace your Studio site's files and database with a copy from your staging site."
+															  )
+															: __(
+																	"Pulling will replace your Studio site's files and database with a copy from your production site."
+															  );
+														showPullConfirmation( () => pullSite( connectedSite, selectedSite ), {
+															detail,
+														} );
 													} }
 													disabled={ isAnySitePulling }
 												>

--- a/src/hooks/use-confirmation-dialog.ts
+++ b/src/hooks/use-confirmation-dialog.ts
@@ -4,7 +4,7 @@ import { getIpcApi } from '../lib/get-ipc-api';
 interface ConfirmationDialogOptions {
 	message: string;
 	detail?: string;
-	checkboxLabel: string;
+	checkboxLabel?: string;
 	confirmButtonLabel: string;
 	cancelButtonLabel?: string;
 	localStorageKey: string;
@@ -15,7 +15,7 @@ export function useConfirmationDialog( options: ConfirmationDialogOptions ) {
 	const {
 		message,
 		detail,
-		checkboxLabel,
+		checkboxLabel = __( "Don't ask again" ),
 		confirmButtonLabel,
 		cancelButtonLabel = __( 'Cancel' ),
 		localStorageKey,

--- a/src/hooks/use-confirmation-dialog.ts
+++ b/src/hooks/use-confirmation-dialog.ts
@@ -21,7 +21,7 @@ export function useConfirmationDialog( options: ConfirmationDialogOptions ) {
 		localStorageKey,
 	} = options;
 
-	return async ( onConfirm: () => void ) => {
+	return async ( onConfirm: () => void, { detail: detailOverride }: { detail?: string } = {} ) => {
 		if ( localStorage.getItem( localStorageKey ) === 'true' ) {
 			onConfirm();
 			return;
@@ -31,7 +31,7 @@ export function useConfirmationDialog( options: ConfirmationDialogOptions ) {
 		const CANCEL_BUTTON_INDEX = 1;
 		const { response, checkboxChecked } = await getIpcApi().showMessageBox( {
 			message,
-			detail,
+			detail: detailOverride ?? detail,
 			checkboxLabel,
 			buttons: [ confirmButtonLabel, cancelButtonLabel ],
 			cancelId: CANCEL_BUTTON_INDEX,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/dotcom-forge/issues/9822

## Proposed Changes

- Add confirmation dialog before pull, using `useConfirmationDialog` hook.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run `STUDIO_SITE_SYNC=true npm start`
- Click on the Sync tab
- Connect a site
- Click on pull
- Observe the new dialog


<img width="1032" alt="Screenshot 2024-11-15 at 11 01 45" src="https://github.com/user-attachments/assets/38402103-fc94-4c4f-a56e-6bcc90ac0201">




## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?