### PR TITLE
Start site after pulling a site

### DIFF
--- a/src/hooks/sync-sites/use-sync-pull.ts
+++ b/src/hooks/sync-sites/use-sync-pull.ts
@@ -6,6 +6,7 @@ import { getIpcApi } from '../../lib/get-ipc-api';
 import { useAuth } from '../use-auth';
 import { SyncSite } from '../use-fetch-wpcom-sites';
 import { useImportExport } from '../use-import-export';
+import { useSiteDetails } from '../use-site-details';
 import { useSyncStatesProgressInfo, PullStateProgressInfo } from '../use-sync-states-progress-info';
 
 export type SyncBackupState = {
@@ -28,6 +29,7 @@ export function useSyncPull( {
 	const { client } = useAuth();
 	const { importFile, clearImportState } = useImportExport();
 	const { pullStatesProgressInfo, isKeyPulling } = useSyncStatesProgressInfo();
+	const { startServer } = useSiteDetails();
 
 	const updatePullState = useCallback(
 		( selectedSiteId: string, remoteSiteId: number, state: Partial< SyncBackupState > ) => {
@@ -128,6 +130,8 @@ export function useSyncPull( {
 
 			await getIpcApi().removeSyncBackup( remoteSiteId );
 
+			await startServer( selectedSite.id );
+
 			clearImportState( selectedSite.id );
 
 			getIpcApi().showNotification( {
@@ -148,6 +152,7 @@ export function useSyncPull( {
 			pullStatesProgressInfo.downloading,
 			pullStatesProgressInfo.finished,
 			pullStatesProgressInfo.importing,
+			startServer,
 			updatePullState,
 		]
 	);

--- a/src/hooks/use-import-export.tsx
+++ b/src/hooks/use-import-export.tsx
@@ -127,7 +127,7 @@ export const ImportExportProvider = ( { children }: { children: React.ReactNode 
 				await handleImportError( error );
 			} finally {
 				if ( wasSiteRunning ) {
-					startServer( selectedSite.id );
+					await startServer( selectedSite.id );
 				}
 			}
 		},


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/dotcom-forge/issues/9823

## Proposed Changes

- Start a site after pulling a site

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run `STUDIO_SITE_SYNC=true npm start`
- Click on the Sync tab
- Connect a site
- Stop your site
- Click on pull
- Wait until the process finishes
- Observe your site has started successfully


https://github.com/user-attachments/assets/e00be8af-846b-4217-8ac7-6c1c20b14dc4



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?