### PR TITLE
fix: More suggestions button communicates focus

### DIFF
--- a/src/components/welcome-message-prompt.tsx
+++ b/src/components/welcome-message-prompt.tsx
@@ -127,7 +127,7 @@ const WelcomeComponent = React.forwardRef< HTMLDivElement, WelcomeComponentProps
 											<div className="mt-2 ml-2">
 												<Button
 													variant="secondary"
-													className="!text-a8c-gray-50 !shadow-none"
+													className="!text-a8c-gray-50 [&:not(:focus)]:shadow-none"
 													onClick={ handleShowMore }
 												>
 													{ __( 'More suggestions' ) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Proposed Changes

Reinstate focus styles for the "More suggestions" button.

The previous use of `!important` to remove the default "ring" styles meant
that all other "ring" styles—including focus styles—were forcibly
removed. The lack of focus styles prevents users from understanding when
the element is currently focused, which is particularly important for
users relying upon keyboard navigation.

| Default | Hover | Focus |
| - | - | - |
| <img width="1012" alt="default" src="https://github.com/user-attachments/assets/7ee27408-7789-4ea1-8632-3b028616f349"> | <img width="1012" alt="focus" src="https://github.com/user-attachments/assets/4a5dba87-13a1-4736-ace0-333628724388"> | <img width="1012" alt="hover" src="https://github.com/user-attachments/assets/985d5be1-ceec-4265-936a-df24febd9851"> |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Launch Studio.
1. If not logged in to a WordPress.com account, log in.
1. If no sites exist, add one.
1. Navigate to the _Assistant_ tab.
1. Verify the "More suggestions" button does not have a gray "ring" style around
   the button.
1. Press the keyboard <kbd>Tab</kbd> button until the "More suggestions" button
   is focused.
1. Verify the button communicates its focus in the form a blue "ring" style.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
