### PR TITLE
Studio: Fix `Toggle sidebar` tooltip

### DIFF
--- a/src/components/top-bar.tsx
+++ b/src/components/top-bar.tsx
@@ -14,6 +14,18 @@ interface TopBarProps {
 	onToggleSidebar: () => void;
 }
 
+function ToggleSidebar( { onToggleSidebar }: TopBarProps ) {
+	return (
+		<div className="app-no-drag-region">
+			<Tooltip text={ __( 'Toggle sidebar' ) } className="h-6">
+				<Button onClick={ onToggleSidebar } variant="icon" aria-label={ __( 'Toggle sidebar' ) }>
+					<Icon className="text-white" icon={ drawerLeft } size={ 24 } />
+				</Button>
+			</Tooltip>
+		</div>
+	);
+}
+
 function OfflineIndicator() {
 	const isOffline = useOffline();
 	const offlineMessage = [
@@ -86,16 +98,7 @@ export default function TopBar( { onToggleSidebar }: TopBarProps ) {
 	return (
 		<div className="flex justify-between items-center text-white px-2 pb-2 pt-1.5">
 			<div className="flex items-center space-x-1.5">
-				<Button
-					className="app-no-drag-region"
-					onClick={ onToggleSidebar }
-					variant="icon"
-					aria-label={ __( 'Toggle sidebar' ) }
-					tooltipText={ __( 'Toggle sidebar' ) }
-				>
-					<Icon className="text-white" icon={ drawerLeft } size={ 24 } />
-				</Button>
-
+				<ToggleSidebar onToggleSidebar={ onToggleSidebar } />
 				<OfflineIndicator />
 			</div>
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/studio/issues/668.

## Proposed Changes

- replace current tooltip implementation (that relies on `tooltipText` prop) with wrapper `Tooltip` component
- extract out "Toggle sidebar" button into its own component

| Before (small vertical misalignment can be observed) | After |
|--------|--------|
| ![Markup on 2024-11-18 at 12:40:18](https://github.com/user-attachments/assets/b3482c75-a9d8-4913-af4b-f5c3d283a9e1) | ![Markup on 2024-11-18 at 12:39:38](https://github.com/user-attachments/assets/a68f5978-46ee-43d9-8a7f-e19f8b8beb9f) | 

Related PR: https://github.com/Automattic/studio/pull/648.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR and build the app.
2. Disconnect from the internet (e.g. by switching off your wifi).
3. Review the `Toggle sidebar` and `Offline` status icons, hover over them with mouse and confirm they are aligned correctly.
4. The `Toggle sidebar` tooltip should render correctly regardless whether the sidebar is open or closed.
5. If you enable VoiceOver - or other accessibility / assistive technology, the `Toggle sidebar` button label should be read just once.
6. There should be no regressions.

Instructions on how to enable / disable VoiceOver: https://support.apple.com/guide/voiceover/turn-voiceover-on-or-off-vo2682/mac. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
