### PR TITLE
Limit arm translation modal to mac

### DIFF
--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -83,7 +83,11 @@ getIpcApi()
 		window.appGlobals = appGlobals;
 
 		// Show warning if running an ARM64 translator
-		if ( appGlobals.arm64Translation && ! localStorage.getItem( 'dontShowARM64Warning' ) ) {
+		if (
+			appGlobals.platform === 'darwin' &&
+			appGlobals.arm64Translation &&
+			! localStorage.getItem( 'dontShowARM64Warning' )
+		) {
 			const showARM64MessageBox = async () => {
 				const { response, checkboxChecked } = await getIpcApi().showMessageBox( {
 					type: 'warning',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/dotcom-forge/issues/9846

## Proposed Changes

- Let's limit the ARM translation modal to be shown only on MacOS. Currently, we were receiving this alert on some Windows Machines. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- If you have a Win machine with ARM chip, run `npm start` and observe there is no alert
- If you have a M1,2,3 Mac, download the x64 build from the CI of this PR and observe the prompt appears.

<img width="1012" alt="Screenshot 2024-11-19 at 01 45 58" src="https://github.com/user-attachments/assets/af8162a2-a3e8-4fb8-86ee-554aa51e139d">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
