### PR TITLE
Allow theme and plugin list generation to fail gracefully

### DIFF
--- a/src/lib/import-export/export/exporters/default-exporter.ts
+++ b/src/lib/import-export/export/exporters/default-exporter.ts
@@ -261,6 +261,7 @@ export class DefaultExporter extends EventEmitter implements Exporter {
 
 		if ( stderr ) {
 			console.error( `Could not get information about plugins: ${ stderr }` );
+			return [];
 		}
 
 		return JSON.parse( stdout );
@@ -279,6 +280,7 @@ export class DefaultExporter extends EventEmitter implements Exporter {
 
 		if ( stderr ) {
 			console.error( `Could not get information about themes: ${ stderr }` );
+			return [];
 		}
 
 		return JSON.parse( stdout );

--- a/src/lib/import-export/tests/export/exporters/default-exporter.test.ts
+++ b/src/lib/import-export/tests/export/exporters/default-exporter.test.ts
@@ -279,4 +279,26 @@ describe( 'DefaultExporter', () => {
 		const canHandle = await exporter.canHandle();
 		expect( canHandle ).toBe( false );
 	} );
+
+	it( 'should not fail when can not get plugin or theme details', async () => {
+		( SiteServer.get as jest.Mock ).mockReturnValue( {
+			details: { path: '/path/to/site' },
+			executeWpCliCommand: jest.fn( function ( command: string ) {
+				switch ( true ) {
+					case /plugin list/.test( command ):
+					case /theme list/.test( command ):
+						return { stdout: '<a><br/>some html</ap>', stderr: 'Error' };
+					default:
+						return { stderr: null };
+				}
+			} ),
+		} );
+
+		const exporter = new DefaultExporter( mockOptions );
+		await exporter.export();
+
+		expect( mockArchiver.file ).toHaveBeenCalledWith( '/tmp/studio_export_123/meta.json', {
+			name: 'meta.json',
+		} );
+	} );
 } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/dotcom-forge/issues/9582

## Proposed Changes

I propose to return an empty array when Studio gets an error from WP CLI when it tries to get a list of plugins or themes for export purposes.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Export site from Studio
2. Open package
3. Locate and open `meta.json` file
4. Confirm that file includes list of themes and plugins
5. Confirm that regression test passes

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
