### PR TITLE
Studio: Automatically start site after import

### DIFF
--- a/src/hooks/tests/use-import-export.test.tsx
+++ b/src/hooks/tests/use-import-export.test.tsx
@@ -36,6 +36,7 @@ beforeEach( () => {
 	} );
 	( useSiteDetails as jest.Mock ).mockReturnValue( {
 		updateSite: jest.fn(),
+		startServer: jest.fn(),
 		stopServer: jest.fn(),
 	} );
 } );

--- a/src/hooks/tests/use-import-export.test.tsx
+++ b/src/hooks/tests/use-import-export.test.tsx
@@ -220,6 +220,8 @@ describe( 'useImportExport hook', () => {
 				body: 'Import completed',
 			} )
 		);
+		expect( useSiteDetails().startServer ).toHaveBeenCalledTimes( 1 );
+		expect( useSiteDetails().startServer ).toHaveBeenCalledWith( SITE_ID );
 	} );
 
 	it( 'shows error message when import fails', async () => {

--- a/src/hooks/use-import-export.tsx
+++ b/src/hooks/use-import-export.tsx
@@ -126,9 +126,7 @@ export const ImportExportProvider = ( { children }: { children: React.ReactNode 
 			} catch ( error ) {
 				await handleImportError( error );
 			} finally {
-				if ( wasSiteRunning ) {
-					await startServer( selectedSite.id );
-				}
+				await startServer( selectedSite.id );
 			}
 		},
 		[ importState, startServer, stopServer, updateSite ]


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/dotcom-forge/issues/9824.

## Proposed Changes

- automatically start site after import

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR and build the app with `npm start`.
2. Navigate to the _Import / Export_ tab and create an export.
3. Make some visible changes to the site's homepage (e.g. change the site title or some colors).
4. Stop the site.
5. Navigate to the _Import / Export_ tab again and upload a previously-exported site to initiate the import.
6. Once the import finishes, the site should start automatically.
7. If you go to the _Overview_ tab, the site thumbnail should be updated to match the originally-exported site (without the customizations).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
