### PR TITLE
Studio: Add missing `key` prop to `SyncConnectedSitesSection` in `SyncConnectedSites` render

### DIFF
--- a/src/components/sync-connected-sites.tsx
+++ b/src/components/sync-connected-sites.tsx
@@ -331,6 +331,7 @@ export function SyncConnectedSites( {
 			<div className="flex flex-col flex-1 pt-8 overflow-y-auto">
 				{ siteSections.map( ( section ) => (
 					<SyncConnectedSitesSection
+						key={ section.id }
 						section={ section }
 						selectedSite={ selectedSite }
 						disconnectSite={ disconnectSite }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/dotcom-forge/issues/9921.

## Proposed Changes

- add missing `key` prop to `SyncConnectedSitesSection` in `SyncConnectedSites` render

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR and build the app with `STUDIO_SITE_SYNC=true npm start`.
2. Navigate to the _Sync_ tab and make sure there's at least one site connected.
3. Open the browser inspector.
4. There should be no `Warning: Each child in a list should have a unique "key" prop.` present.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
