### PR TITLE
Studio: Display error when push fails & trigger `updatePushState` when site is too large to be pushed

### DIFF
--- a/src/components/sync-connected-sites.tsx
+++ b/src/components/sync-connected-sites.tsx
@@ -169,10 +169,11 @@ const SyncConnectedSitesSection = ( {
 				section.connectedSites.map( ( connectedSite ) => {
 					const sitePullState = getPullState( selectedSite.id, connectedSite.id );
 					const isPulling = sitePullState && isKeyPulling( sitePullState.status.key );
-					const isError = sitePullState && isKeyFailed( sitePullState.status.key );
+					const isPullError = sitePullState && isKeyFailed( sitePullState.status.key );
 					const hasPullFinished = sitePullState && isKeyFinished( sitePullState.status.key );
 
 					const pushState = getPushState( selectedSite.id, connectedSite.id );
+					const isPushError = pushState.isError;
 					return (
 						<div
 							key={ connectedSite.id }
@@ -204,12 +205,20 @@ const SyncConnectedSitesSection = ( {
 										<ProgressBar value={ sitePullState.status.progress } maxValue={ 100 } />
 									</div>
 								) }
-								{ isError && (
+								{ isPullError && (
 									<SyncPullPushClear
 										onClick={ () => clearPullState( selectedSite.id, connectedSite.id ) }
 										isError
 									>
 										{ __( 'Error pulling changes' ) }
+									</SyncPullPushClear>
+								) }
+								{ isPushError && (
+									<SyncPullPushClear
+										onClick={ () => clearPushState( selectedSite.id, connectedSite.id ) }
+										isError
+									>
+										{ __( 'Error pushing changes' ) }
 									</SyncPullPushClear>
 								) }
 								{ hasPullFinished && (
@@ -235,9 +244,9 @@ const SyncConnectedSitesSection = ( {
 								) }
 								{ ! isPulling &&
 									! hasPullFinished &&
-									! isError &&
+									! isPullError &&
+									! isPushError &&
 									! pushState.isInProgress &&
-									! pushState.isError &&
 									! pushState.hasFinished && (
 										<div className="flex gap-2 pl-4 ml-auto shrink-0 h-5">
 											<Button

--- a/src/hooks/sync-sites/use-sync-push.ts
+++ b/src/hooks/sync-sites/use-sync-push.ts
@@ -92,6 +92,9 @@ export function useSyncPush( {
 				'tar'
 			);
 			if ( archiveSizeInBytes > SYNC_PUSH_SIZE_LIMIT_BYTES ) {
+				updatePushState( selectedSite.id, remoteSiteId, {
+					status: pushStatesProgressInfo.failed,
+				} );
 				getIpcApi().showErrorMessageBox( {
 					title: sprintf( __( 'Error pushing to %s' ), connectedSite.name ),
 					message: __(


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/dotcom-forge/issues/9917.

## Proposed Changes

- display `Error pushing changes` when there's an error during the pushing process
- ensure  `updatePushState` is triggered when the site is too large to be pushed (this then allows the error message to be displayed)

![Markup on 2024-11-22 at 10:07:48](https://github.com/user-attachments/assets/ed2ca91b-90be-4f0c-a65a-de42c5ce21d1)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR and build the app with `STUDIO_SITE_SYNC=true npm start`.
2. Simulate an issue with the pushing process. For instance, you could make one of these three changes in `src/hooks/sync-sites/use-sync-push.ts`:

```diff
diff --git a/src/hooks/sync-sites/use-sync-push.ts b/src/hooks/sync-sites/use-sync-push.ts
index 7684f2e..88caf38 100644
--- a/src/hooks/sync-sites/use-sync-push.ts
+++ b/src/hooks/sync-sites/use-sync-push.ts
@@ -56,7 +56,7 @@ export function useSyncPush( {
 						? __( 'Staging has been updated' )
 						: __( 'Production has been updated' ),
 				} );
-			} else if ( response.success && response.status === 'failed' ) {
+			} else if ( true || ( response.success && response.status === 'failed' ) ) {
 				status = pushStatesProgressInfo.failed;
 			}
 			// Update state in any case to keep polling push state
@@ -91,7 +91,7 @@ export function useSyncPush( {
 				selectedSite.id,
 				'tar'
 			);
-			if ( archiveSizeInBytes > SYNC_PUSH_SIZE_LIMIT_BYTES ) {
+			if ( true || archiveSizeInBytes > SYNC_PUSH_SIZE_LIMIT_BYTES ) {
 				updatePushState( selectedSite.id, remoteSiteId, {
 					status: pushStatesProgressInfo.failed,
 				} );
@@ -118,7 +118,7 @@ export function useSyncPush( {
 					apiNamespace: 'wpcom/v2',
 					formData,
 				} );
-				if ( response.success ) {
+				if ( false && response.success ) {
 					updatePushState( selectedSite.id, remoteSiteId, {
 						status: pushStatesProgressInfo.importing,
 					} );

```

3. Navigate to the _Sync_ tab and make sure there's at least one site connected.
4. Click the `Push` button.
5. Once the process fails, there should be a `Error pushing changes` message displayed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
