### PR TITLE
Studio: Display correct status for self-hosted Jetpack sites

### DIFF
--- a/src/components/sync-sites-modal-selector.tsx
+++ b/src/components/sync-sites-modal-selector.tsx
@@ -131,6 +131,7 @@ const getSortedSites = ( sites: SyncSite[] ) => {
 		'already-connected': 2,
 		'needs-transfer': 3,
 		unsupported: 4,
+		'jetpack-site': 5,
 	};
 
 	return [ ...sites ].sort( ( a, b ) => order[ a.syncSupport ] - order[ b.syncSupport ] );
@@ -178,6 +179,7 @@ function SiteItem( {
 	const isSyncable = site.syncSupport === 'syncable';
 	const isNeedsTransfer = site.syncSupport === 'needs-transfer';
 	const isUnsupported = site.syncSupport === 'unsupported';
+	const isJetpackSite = site.syncSupport === 'jetpack-site';
 	return (
 		<div
 			className={ cx(
@@ -249,6 +251,9 @@ function SiteItem( {
 						{ __( 'Enable hosting features ↗' ) }
 					</Button>
 				</div>
+			) }
+			{ isJetpackSite && (
+				<div className="a8c-body-small text-a8c-gray-30 shrink-0">{ __( 'Unsupported site' ) }</div>
 			) }
 		</div>
 	);

--- a/src/hooks/use-fetch-wpcom-sites.tsx
+++ b/src/hooks/use-fetch-wpcom-sites.tsx
@@ -3,7 +3,12 @@ import { useState, useEffect, useRef, useMemo, useCallback } from 'react';
 import { useAuth } from './use-auth';
 import { useOffline } from './use-offline';
 
-type SyncSupport = 'unsupported' | 'syncable' | 'needs-transfer' | 'already-connected';
+type SyncSupport =
+	| 'unsupported'
+	| 'syncable'
+	| 'needs-transfer'
+	| 'already-connected'
+	| 'jetpack-site';
 
 export type SyncSite = {
 	id: number;
@@ -21,9 +26,11 @@ type SitesEndpointSite = {
 	is_wpcom_staging_site: boolean;
 	name: string;
 	URL: string;
+	jetpack?: boolean;
 	options?: {
 		created_at: string;
 		wpcom_staging_blog_ids: number[];
+		jetpack_connection_active_plugins?: string[];
 	};
 	plan?: {
 		expired: boolean;
@@ -45,8 +52,22 @@ type SitesEndpointResponse = {
 
 const STUDIO_SYNC_FEATURE_NAME = 'studio-sync';
 
+function isJetpackSite( site: SitesEndpointSite ): boolean {
+	const hasJetpack = site.jetpack && ! site.is_wpcom_atomic;
+	const hasJetpackPlugins =
+		site.options?.jetpack_connection_active_plugins?.length && ! site.is_wpcom_atomic;
+	return !! hasJetpack || !! hasJetpackPlugins;
+}
+
+function hasSupportedPlan( site: SitesEndpointSite ): boolean {
+	return !! site.plan && site.plan.features.active.includes( STUDIO_SYNC_FEATURE_NAME );
+}
+
 function getSyncSupport( site: SitesEndpointSite, connectedSiteIds: number[] ): SyncSupport {
-	if ( ! site.plan || ! site.plan.features.active.includes( STUDIO_SYNC_FEATURE_NAME ) ) {
+	if ( isJetpackSite( site ) && ! hasSupportedPlan( site ) ) {
+		return 'jetpack-site';
+	}
+	if ( ! hasSupportedPlan( site ) ) {
 		return 'unsupported';
 	}
 	if ( ! site.is_wpcom_atomic ) {
@@ -106,9 +127,9 @@ export const useFetchWpComSites = ( connectedSiteIds: number[] ) => {
 					path: `/me/sites`,
 				},
 				{
-					fields: 'name,ID,URL,plan,is_wpcom_staging_site,is_wpcom_atomic,options',
+					fields: 'name,ID,URL,plan,is_wpcom_staging_site,is_wpcom_atomic,options,jetpack',
 					filter: 'atomic,wpcom',
-					options: 'created_at,wpcom_staging_blog_ids',
+					options: 'created_at,wpcom_staging_blog_ids,jetpack_connection_active_plugins',
 					site_visibility: 'visible',
 				}
 			)

--- a/src/hooks/use-fetch-wpcom-sites.tsx
+++ b/src/hooks/use-fetch-wpcom-sites.tsx
@@ -53,10 +53,7 @@ type SitesEndpointResponse = {
 const STUDIO_SYNC_FEATURE_NAME = 'studio-sync';
 
 function isJetpackSite( site: SitesEndpointSite ): boolean {
-	const hasJetpack = site.jetpack && ! site.is_wpcom_atomic;
-	const hasJetpackPlugins =
-		site.options?.jetpack_connection_active_plugins?.length && ! site.is_wpcom_atomic;
-	return !! hasJetpack || !! hasJetpackPlugins;
+	return !! site.jetpack && ! site.is_wpcom_atomic;
 }
 
 function hasSupportedPlan( site: SitesEndpointSite ): boolean {

--- a/src/hooks/use-fetch-wpcom-sites.tsx
+++ b/src/hooks/use-fetch-wpcom-sites.tsx
@@ -30,7 +30,6 @@ type SitesEndpointSite = {
 	options?: {
 		created_at: string;
 		wpcom_staging_blog_ids: number[];
-		jetpack_connection_active_plugins?: string[];
 	};
 	plan?: {
 		expired: boolean;
@@ -126,7 +125,7 @@ export const useFetchWpComSites = ( connectedSiteIds: number[] ) => {
 				{
 					fields: 'name,ID,URL,plan,is_wpcom_staging_site,is_wpcom_atomic,options,jetpack',
 					filter: 'atomic,wpcom',
-					options: 'created_at,wpcom_staging_blog_ids,jetpack_connection_active_plugins',
+					options: 'created_at,wpcom_staging_blog_ids',
 					site_visibility: 'visible',
 				}
 			)


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

Closes https://github.com/Automattic/dotcom-forge/issues/9912

## Proposed Changes

This PR adds a label `Unsupported site` to self-hosted Jetpack sites connected to Studio.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Before testing the PR, you will need to ensure that you have a self-hosted site. One way to do it is to create it on Pressable and connect to WP.com via Jetpack. Another option would be to use a Jurassic Ninja site:

* Pull the changes from this branch
* Start Studio with `STUDIO_SITE_SYNC=true npm start`
* Navigate to the `Sync` tab
* Click on the `Connect site` button to open the modal
* Search for your self-hosted site
* Confirm that you see `Unsupported site` instead of CTA by that site:

<img width="941" alt="Screenshot 2024-11-22 at 12 01 46 PM" src="https://github.com/user-attachments/assets/6a55e2d5-a041-4dc4-8873-6b239febd14e">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
