### PR TITLE
Display only active sites on Studio Sync modal

### DIFF
--- a/src/hooks/use-fetch-wpcom-sites.tsx
+++ b/src/hooks/use-fetch-wpcom-sites.tsx
@@ -127,6 +127,7 @@ export const useFetchWpComSites = ( connectedSiteIds: number[] ) => {
 					filter: 'atomic,wpcom',
 					options: 'created_at,wpcom_staging_blog_ids',
 					site_visibility: 'visible',
+					site_activity: 'active',
 				}
 			)
 			.then( ( response ) => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Related to https://github.com/Automattic/dotcom-forge/issues/9912

## Proposed Changes

- When testing https://github.com/Automattic/studio/pull/682 I realized I was able to see all my past jurassic ninja, even some that do not appear on wp.com/sites
- In this PR I suggest applying filtering the sites to active.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run `STUDIO_SITE_SYNC=true npm start`
- Navigate to the sync tab
- Click on Connect site
- Search by `jurassic.ninja`
- Observe there are much less sites visible
- Observe your active sites are still displayed
- Observe the JN sites that appear if any, they have the correct CTA "unsupported site" instead of upgrade.

| Before | After |
|--------|--------|
|  <img width="1012" alt="Screenshot 2024-11-22 at 11 57 48" src="https://github.com/user-attachments/assets/57f80892-373e-4bbf-8a56-f69a85b735ef"> | <img width="1012" alt="Screenshot 2024-11-22 at 11 57 29" src="https://github.com/user-attachments/assets/ee3ae876-2868-410d-8fcc-450f74272b75"> |



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
