### PR TITLE
Studio: Display popover with last push and pull time

### DIFF
--- a/src/components/sync-connected-sites.tsx
+++ b/src/components/sync-connected-sites.tsx
@@ -54,7 +54,7 @@ const SyncConnectedSitesSection = ( {
 		clearPushState,
 	} = useSyncSites();
 	const { isKeyPulling, isKeyFinished, isKeyFailed } = useSyncStatesProgressInfo();
-	const { updateTimestamp, getLastSyncTime, clearTimestamps } = usePullPushTimestamps();
+	const { updateTimestamp, getLastSyncTimeWithType, clearTimestamps } = usePullPushTimestamps();
 	const showPushStagingConfirmation = useConfirmationDialog( {
 		localStorageKey: 'dontShowPushConfirmation',
 		message: __( 'Overwrite Staging site' ),
@@ -259,7 +259,11 @@ const SyncConnectedSitesSection = ( {
 									! pushState.hasFinished && (
 										<div className="flex gap-2 pl-4 ml-auto shrink-0 h-5">
 											<Tooltip
-												text={ getLastSyncTime( selectedSite.id, connectedSite.id, 'pull' ) }
+												text={ getLastSyncTimeWithType(
+													selectedSite.id,
+													connectedSite.id,
+													'pull'
+												) }
 											>
 												<Button
 													variant="link"
@@ -289,7 +293,11 @@ const SyncConnectedSitesSection = ( {
 												</Button>
 											</Tooltip>
 											<Tooltip
-												text={ getLastSyncTime( selectedSite.id, connectedSite.id, 'push' ) }
+												text={ getLastSyncTimeWithType(
+													selectedSite.id,
+													connectedSite.id,
+													'push'
+												) }
 											>
 												<Button
 													variant="link"

--- a/src/components/sync-connected-sites.tsx
+++ b/src/components/sync-connected-sites.tsx
@@ -9,7 +9,6 @@ import { useSyncSites } from '../hooks/sync-sites';
 import { useConfirmationDialog } from '../hooks/use-confirmation-dialog';
 import { SyncSite } from '../hooks/use-fetch-wpcom-sites';
 import { useOffline } from '../hooks/use-offline';
-import { usePullPushTimestamps } from '../hooks/use-pull-push-timestamps';
 import { useSyncStatesProgressInfo } from '../hooks/use-sync-states-progress-info';
 import { cx } from '../lib/cx';
 import { getIpcApi } from '../lib/get-ipc-api';
@@ -52,9 +51,11 @@ const SyncConnectedSitesSection = ( {
 		pushSite,
 		getPushState,
 		clearPushState,
+		updateTimestamp,
+		getLastSyncTimeWithType,
+		clearTimestamps,
 	} = useSyncSites();
 	const { isKeyPulling, isKeyFinished, isKeyFailed } = useSyncStatesProgressInfo();
-	const { updateTimestamp, getLastSyncTimeWithType, clearTimestamps } = usePullPushTimestamps();
 	const showPushStagingConfirmation = useConfirmationDialog( {
 		localStorageKey: 'dontShowPushConfirmation',
 		message: __( 'Overwrite Staging site' ),

--- a/src/components/sync-connected-sites.tsx
+++ b/src/components/sync-connected-sites.tsx
@@ -184,6 +184,18 @@ const SyncConnectedSitesSection = ( {
 
 					const pushState = getPushState( selectedSite.id, connectedSite.id );
 					const isPushError = pushState.isError;
+
+					const pullTimestamp = getLastSyncTimeWithType(
+						selectedSite.id,
+						connectedSite.id,
+						'pull'
+					);
+					const pushTimestamp = getLastSyncTimeWithType(
+						selectedSite.id,
+						connectedSite.id,
+						'push'
+					);
+
 					return (
 						<div
 							key={ connectedSite.id }
@@ -259,13 +271,36 @@ const SyncConnectedSitesSection = ( {
 									! pushState.isInProgress &&
 									! pushState.hasFinished && (
 										<div className="flex gap-2 pl-4 ml-auto shrink-0 h-5">
-											<Tooltip
-												text={ getLastSyncTimeWithType(
-													selectedSite.id,
-													connectedSite.id,
-													'pull'
-												) }
-											>
+											{ pullTimestamp ? (
+												<Tooltip text={ pullTimestamp }>
+													<Button
+														variant="link"
+														className="!text-black hover:!text-a8c-blueberry"
+														onClick={ () => {
+															const detail = connectedSite.isStaging
+																? __(
+																		"Pulling will replace your Studio site's files and database with a copy from your staging site."
+																  )
+																: __(
+																		"Pulling will replace your Studio site's files and database with a copy from your production site."
+																  );
+															showPullConfirmation(
+																() => {
+																	updateTimestamp( selectedSite.id, connectedSite.id, 'pull' );
+																	pullSite( connectedSite, selectedSite );
+																},
+																{
+																	detail,
+																}
+															);
+														} }
+														disabled={ isAnySitePulling || isAnySitePushing }
+													>
+														<Icon icon={ cloudDownload } />
+														{ __( 'Pull' ) }
+													</Button>
+												</Tooltip>
+											) : (
 												<Button
 													variant="link"
 													className="!text-black hover:!text-a8c-blueberry"
@@ -292,14 +327,20 @@ const SyncConnectedSitesSection = ( {
 													<Icon icon={ cloudDownload } />
 													{ __( 'Pull' ) }
 												</Button>
-											</Tooltip>
-											<Tooltip
-												text={ getLastSyncTimeWithType(
-													selectedSite.id,
-													connectedSite.id,
-													'push'
-												) }
-											>
+											) }
+											{ pushTimestamp ? (
+												<Tooltip text={ pushTimestamp }>
+													<Button
+														variant="link"
+														className="!text-black hover:!text-a8c-blueberry"
+														onClick={ () => handlePushSite( connectedSite ) }
+														disabled={ isAnySitePulling || isAnySitePushing }
+													>
+														<Icon icon={ cloudUpload } />
+														{ __( 'Push' ) }
+													</Button>
+												</Tooltip>
+											) : (
 												<Button
 													variant="link"
 													className="!text-black hover:!text-a8c-blueberry"
@@ -309,7 +350,7 @@ const SyncConnectedSitesSection = ( {
 													<Icon icon={ cloudUpload } />
 													{ __( 'Push' ) }
 												</Button>
-											</Tooltip>
+											) }
 										</div>
 									) }
 							</div>

--- a/src/components/sync-connected-sites.tsx
+++ b/src/components/sync-connected-sites.tsx
@@ -9,6 +9,7 @@ import { useSyncSites } from '../hooks/sync-sites';
 import { useConfirmationDialog } from '../hooks/use-confirmation-dialog';
 import { SyncSite } from '../hooks/use-fetch-wpcom-sites';
 import { useOffline } from '../hooks/use-offline';
+import { usePullPushTimestamps } from '../hooks/use-pull-push-timestamps';
 import { useSyncStatesProgressInfo } from '../hooks/use-sync-states-progress-info';
 import { cx } from '../lib/cx';
 import { getIpcApi } from '../lib/get-ipc-api';
@@ -53,6 +54,7 @@ const SyncConnectedSitesSection = ( {
 		clearPushState,
 	} = useSyncSites();
 	const { isKeyPulling, isKeyFinished, isKeyFailed } = useSyncStatesProgressInfo();
+	const { updateTimestamp, getLastSyncTime, clearTimestamps } = usePullPushTimestamps();
 	const showPushStagingConfirmation = useConfirmationDialog( {
 		localStorageKey: 'dontShowPushConfirmation',
 		message: __( 'Overwrite Staging site' ),
@@ -101,6 +103,7 @@ const SyncConnectedSitesSection = ( {
 					localStorage.setItem( 'dontShowDisconnectWarning', 'true' );
 				}
 				disconnectSite( section.id );
+				clearTimestamps( selectedSite.id, section.id );
 				section.connectedSites.forEach( ( connectedSite ) => {
 					clearPullState( selectedSite.id, connectedSite.id );
 				} );
@@ -112,9 +115,15 @@ const SyncConnectedSitesSection = ( {
 
 	const handlePushSite = async ( connectedSite: SyncSite ) => {
 		if ( connectedSite.isStaging ) {
-			showPushStagingConfirmation( () => pushSite( connectedSite, selectedSite ) );
+			showPushStagingConfirmation( () => {
+				updateTimestamp( selectedSite.id, connectedSite.id, 'push' );
+				pushSite( connectedSite, selectedSite );
+			} );
 		} else {
-			showPushProductionConfirmation( () => pushSite( connectedSite, selectedSite ) );
+			showPushProductionConfirmation( () => {
+				updateTimestamp( selectedSite.id, connectedSite.id, 'push' );
+				pushSite( connectedSite, selectedSite );
+			} );
 		}
 	};
 
@@ -249,35 +258,49 @@ const SyncConnectedSitesSection = ( {
 									! pushState.isInProgress &&
 									! pushState.hasFinished && (
 										<div className="flex gap-2 pl-4 ml-auto shrink-0 h-5">
-											<Button
-												variant="link"
-												className="!text-black hover:!text-a8c-blueberry"
-												onClick={ () => {
-													const detail = connectedSite.isStaging
-														? __(
-																"Pulling will replace your Studio site's files and database with a copy from your staging site."
-														  )
-														: __(
-																"Pulling will replace your Studio site's files and database with a copy from your production site."
-														  );
-													showPullConfirmation( () => pullSite( connectedSite, selectedSite ), {
-														detail,
-													} );
-												} }
-												disabled={ isAnySitePulling || isAnySitePushing }
+											<Tooltip
+												text={ getLastSyncTime( selectedSite.id, connectedSite.id, 'pull' ) }
 											>
-												<Icon icon={ cloudDownload } />
-												{ __( 'Pull' ) }
-											</Button>
-											<Button
-												variant="link"
-												className="!text-black hover:!text-a8c-blueberry"
-												onClick={ () => handlePushSite( connectedSite ) }
-												disabled={ isAnySitePulling || isAnySitePushing }
+												<Button
+													variant="link"
+													className="!text-black hover:!text-a8c-blueberry"
+													onClick={ () => {
+														const detail = connectedSite.isStaging
+															? __(
+																	"Pulling will replace your Studio site's files and database with a copy from your staging site."
+															  )
+															: __(
+																	"Pulling will replace your Studio site's files and database with a copy from your production site."
+															  );
+														showPullConfirmation(
+															() => {
+																updateTimestamp( selectedSite.id, connectedSite.id, 'pull' );
+																pullSite( connectedSite, selectedSite );
+															},
+															{
+																detail,
+															}
+														);
+													} }
+													disabled={ isAnySitePulling || isAnySitePushing }
+												>
+													<Icon icon={ cloudDownload } />
+													{ __( 'Pull' ) }
+												</Button>
+											</Tooltip>
+											<Tooltip
+												text={ getLastSyncTime( selectedSite.id, connectedSite.id, 'push' ) }
 											>
-												<Icon icon={ cloudUpload } />
-												{ __( 'Push' ) }
-											</Button>
+												<Button
+													variant="link"
+													className="!text-black hover:!text-a8c-blueberry"
+													onClick={ () => handlePushSite( connectedSite ) }
+													disabled={ isAnySitePulling || isAnySitePushing }
+												>
+													<Icon icon={ cloudUpload } />
+													{ __( 'Push' ) }
+												</Button>
+											</Tooltip>
 										</div>
 									) }
 							</div>

--- a/src/components/tests/content-tab-sync.test.tsx
+++ b/src/components/tests/content-tab-sync.test.tsx
@@ -51,6 +51,9 @@ describe( 'ContentTabSync', () => {
 			getPullState: jest.fn(),
 			getPushState: jest.fn().mockReturnValue( defaultPushState ),
 			refetchSites: jest.fn(),
+			updateTimestamp: jest.fn(),
+			getLastSyncTimeWithType: jest.fn().mockReturnValue( undefined ),
+			clearTimestamps: jest.fn(),
 		} );
 	} );
 
@@ -121,6 +124,9 @@ describe( 'ContentTabSync', () => {
 			getPullState: jest.fn(),
 			getPushState: jest.fn().mockReturnValue( defaultPushState ),
 			refetchSites: jest.fn(),
+			updateTimestamp: jest.fn(),
+			getLastSyncTimeWithType: jest.fn().mockReturnValue( undefined ),
+			clearTimestamps: jest.fn(),
 		} );
 		renderWithProvider( <ContentTabSync selectedSite={ selectedSite } /> );
 
@@ -150,6 +156,9 @@ describe( 'ContentTabSync', () => {
 			getPullState: jest.fn(),
 			getPushState: jest.fn().mockReturnValue( defaultPushState ),
 			refetchSites: jest.fn(),
+			updateTimestamp: jest.fn(),
+			getLastSyncTimeWithType: jest.fn().mockReturnValue( undefined ),
+			clearTimestamps: jest.fn(),
 		} );
 		renderWithProvider( <ContentTabSync selectedSite={ selectedSite } /> );
 
@@ -188,6 +197,9 @@ describe( 'ContentTabSync', () => {
 			getPullState: jest.fn(),
 			getPushState: jest.fn().mockReturnValue( defaultPushState ),
 			refetchSites: jest.fn(),
+			updateTimestamp: jest.fn(),
+			getLastSyncTimeWithType: jest.fn().mockReturnValue( undefined ),
+			clearTimestamps: jest.fn(),
 		} );
 		renderWithProvider( <ContentTabSync selectedSite={ selectedSite } /> );
 

--- a/src/components/tests/content-tab-sync.test.tsx
+++ b/src/components/tests/content-tab-sync.test.tsx
@@ -52,7 +52,7 @@ describe( 'ContentTabSync', () => {
 			getPushState: jest.fn().mockReturnValue( defaultPushState ),
 			refetchSites: jest.fn(),
 			updateTimestamp: jest.fn(),
-			getLastSyncTimeWithType: jest.fn().mockReturnValue( 'You never pulled this site' ),
+			getLastSyncTimeWithType: jest.fn().mockReturnValue( 'You have not pulled this site yet' ),
 			clearTimeout: jest.fn(),
 		} );
 	} );
@@ -125,7 +125,7 @@ describe( 'ContentTabSync', () => {
 			getPushState: jest.fn().mockReturnValue( defaultPushState ),
 			refetchSites: jest.fn(),
 			updateTimestamp: jest.fn(),
-			getLastSyncTimeWithType: jest.fn().mockReturnValue( 'You never pulled this site' ),
+			getLastSyncTimeWithType: jest.fn().mockReturnValue( 'You have not pulled this site yet' ),
 			clearTimeout: jest.fn(),
 		} );
 		renderWithProvider( <ContentTabSync selectedSite={ selectedSite } /> );
@@ -157,7 +157,7 @@ describe( 'ContentTabSync', () => {
 			getPushState: jest.fn().mockReturnValue( defaultPushState ),
 			refetchSites: jest.fn(),
 			updateTimestamp: jest.fn(),
-			getLastSyncTimeWithType: jest.fn().mockReturnValue( 'You never pulled this site' ),
+			getLastSyncTimeWithType: jest.fn().mockReturnValue( 'You have not pulled this site yet' ),
 			clearTimeout: jest.fn(),
 		} );
 		renderWithProvider( <ContentTabSync selectedSite={ selectedSite } /> );
@@ -198,7 +198,7 @@ describe( 'ContentTabSync', () => {
 			getPushState: jest.fn().mockReturnValue( defaultPushState ),
 			refetchSites: jest.fn(),
 			updateTimestamp: jest.fn(),
-			getLastSyncTimeWithType: jest.fn().mockReturnValue( 'You never pulled this site' ),
+			getLastSyncTimeWithType: jest.fn().mockReturnValue( 'You have not pulled this site yet' ),
 			clearTimeout: jest.fn(),
 		} );
 		renderWithProvider( <ContentTabSync selectedSite={ selectedSite } /> );

--- a/src/components/tests/content-tab-sync.test.tsx
+++ b/src/components/tests/content-tab-sync.test.tsx
@@ -51,6 +51,9 @@ describe( 'ContentTabSync', () => {
 			getPullState: jest.fn(),
 			getPushState: jest.fn().mockReturnValue( defaultPushState ),
 			refetchSites: jest.fn(),
+			updateTimestamp: jest.fn(),
+			getLastSyncTimeWithType: jest.fn().mockReturnValue( 'You never pulled this site' ),
+			clearTimeout: jest.fn(),
 		} );
 	} );
 
@@ -121,6 +124,9 @@ describe( 'ContentTabSync', () => {
 			getPullState: jest.fn(),
 			getPushState: jest.fn().mockReturnValue( defaultPushState ),
 			refetchSites: jest.fn(),
+			updateTimestamp: jest.fn(),
+			getLastSyncTimeWithType: jest.fn().mockReturnValue( 'You never pulled this site' ),
+			clearTimeout: jest.fn(),
 		} );
 		renderWithProvider( <ContentTabSync selectedSite={ selectedSite } /> );
 
@@ -150,6 +156,9 @@ describe( 'ContentTabSync', () => {
 			getPullState: jest.fn(),
 			getPushState: jest.fn().mockReturnValue( defaultPushState ),
 			refetchSites: jest.fn(),
+			updateTimestamp: jest.fn(),
+			getLastSyncTimeWithType: jest.fn().mockReturnValue( 'You never pulled this site' ),
+			clearTimeout: jest.fn(),
 		} );
 		renderWithProvider( <ContentTabSync selectedSite={ selectedSite } /> );
 
@@ -188,6 +197,9 @@ describe( 'ContentTabSync', () => {
 			getPullState: jest.fn(),
 			getPushState: jest.fn().mockReturnValue( defaultPushState ),
 			refetchSites: jest.fn(),
+			updateTimestamp: jest.fn(),
+			getLastSyncTimeWithType: jest.fn().mockReturnValue( 'You never pulled this site' ),
+			clearTimeout: jest.fn(),
 		} );
 		renderWithProvider( <ContentTabSync selectedSite={ selectedSite } /> );
 

--- a/src/hooks/sync-sites/sync-sites-context.tsx
+++ b/src/hooks/sync-sites/sync-sites-context.tsx
@@ -1,12 +1,14 @@
 import React, { createContext, useContext, useState } from 'react';
 import { SyncSite } from '../use-fetch-wpcom-sites';
+import { usePullPushTimestamps } from '../use-pull-push-timestamps';
 import { useSiteSyncManagement } from './use-site-sync-management';
 import { useSyncPull } from './use-sync-pull';
 import { useSyncPush } from './use-sync-push';
 
 type SyncSitesContextType = ReturnType< typeof useSyncPull > &
 	ReturnType< typeof useSyncPush > &
-	ReturnType< typeof useSiteSyncManagement >;
+	ReturnType< typeof useSiteSyncManagement > &
+	ReturnType< typeof usePullPushTimestamps >;
 
 const SyncSitesContext = createContext< SyncSitesContextType | undefined >( undefined );
 
@@ -31,6 +33,8 @@ export function SyncSitesProvider( { children }: { children: React.ReactNode } )
 	const { loadConnectedSites, connectSite, disconnectSite, syncSites, isFetching, refetchSites } =
 		useSiteSyncManagement( { connectedSites, setConnectedSites } );
 
+	const { updateTimestamp, getLastSyncTimeWithType, clearTimestamps } = usePullPushTimestamps();
+
 	return (
 		<SyncSitesContext.Provider
 			value={ {
@@ -53,6 +57,9 @@ export function SyncSitesProvider( { children }: { children: React.ReactNode } )
 				isAnySitePushing,
 				isSiteIdPushing,
 				clearPushState,
+				updateTimestamp,
+				getLastSyncTimeWithType,
+				clearTimestamps,
 			} }
 		>
 			{ children }

--- a/src/hooks/use-pull-push-timestamps.ts
+++ b/src/hooks/use-pull-push-timestamps.ts
@@ -41,7 +41,7 @@ export function usePullPushTimestamps() {
 		[ getStoredTimestamps ]
 	);
 
-	const getLastSyncTime = useCallback(
+	const getLastSyncTimeWithType = useCallback(
 		( localSiteId: string, connectedSiteId: number, type: 'pull' | 'push' ): string => {
 			const timestamps = getStoredTimestamps();
 			const localSiteTimestamps = timestamps[ localSiteId ] || {};
@@ -49,10 +49,12 @@ export function usePullPushTimestamps() {
 			const timestamp = type === 'pull' ? siteTimestamps.lastPull : siteTimestamps.lastPush;
 
 			if ( ! timestamp ) {
-				return __( 'Never synced' );
+				return type === 'pull' ? __( 'Never pulled' ) : __( 'Never pushed' );
 			}
 
-			return `${ __( 'Last synced' ) } ${ formatDistanceToNow( timestamp ) } ${ __( 'ago' ) }`;
+			return type === 'pull'
+				? __( 'Last pull %s ago', formatDistanceToNow( timestamp ) )
+				: __( 'Last push %s ago', formatDistanceToNow( timestamp ) );
 		},
 		[ getStoredTimestamps ]
 	);
@@ -77,7 +79,7 @@ export function usePullPushTimestamps() {
 
 	return {
 		updateTimestamp,
-		getLastSyncTime,
+		getLastSyncTimeWithType,
 		clearTimestamps,
 	};
 }

--- a/src/hooks/use-pull-push-timestamps.ts
+++ b/src/hooks/use-pull-push-timestamps.ts
@@ -50,13 +50,13 @@ export function usePullPushTimestamps() {
 	);
 
 	const getLastSyncTimeWithType = useCallback(
-		( localSiteId: string, connectedSiteId: number, type: 'pull' | 'push' ): string => {
+		( localSiteId: string, connectedSiteId: number, type: 'pull' | 'push' ): string | undefined => {
 			const localSiteTimestamps = timestamps[ localSiteId ] || {};
 			const siteTimestamps = localSiteTimestamps[ connectedSiteId ] || {};
 			const timestamp = siteTimestamps[ type ];
 
 			if ( ! timestamp ) {
-				return type === 'pull' ? __( 'Never pulled' ) : __( 'Never pushed' );
+				return undefined;
 			}
 
 			return sprintf(

--- a/src/hooks/use-pull-push-timestamps.ts
+++ b/src/hooks/use-pull-push-timestamps.ts
@@ -1,4 +1,4 @@
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { formatDistanceToNow } from 'date-fns';
 import { useCallback } from 'react';
 
@@ -53,8 +53,8 @@ export function usePullPushTimestamps() {
 			}
 
 			return type === 'pull'
-				? __( 'Last pull %s ago', formatDistanceToNow( timestamp ) )
-				: __( 'Last push %s ago', formatDistanceToNow( timestamp ) );
+				? sprintf( __( 'Last pull %s ago' ), formatDistanceToNow( timestamp ) )
+				: sprintf( __( 'Last push %s ago' ), formatDistanceToNow( timestamp ) );
 		},
 		[ getStoredTimestamps ]
 	);

--- a/src/hooks/use-pull-push-timestamps.ts
+++ b/src/hooks/use-pull-push-timestamps.ts
@@ -1,20 +1,20 @@
 import { __, sprintf } from '@wordpress/i18n';
 import { formatDistanceToNow } from 'date-fns';
-import { useCallback } from 'react';
+import { useCallback, useState, useEffect } from 'react';
 
 const SYNC_TIMESTAMPS_STORAGE_KEY = 'wp-studio-sync-timestamps';
 
 interface SyncTimestamps {
 	[ localSiteId: string ]: {
 		[ connectedSiteId: number ]: {
-			lastPull?: number;
-			lastPush?: number;
+			pull?: number;
+			push?: number;
 		};
 	};
 }
 
 export function usePullPushTimestamps() {
-	const getStoredTimestamps = useCallback( (): SyncTimestamps => {
+	const [ timestamps, setTimestamps ] = useState< SyncTimestamps >( () => {
 		try {
 			const stored = localStorage.getItem( SYNC_TIMESTAMPS_STORAGE_KEY );
 			return stored ? JSON.parse( stored ) : {};
@@ -22,60 +22,63 @@ export function usePullPushTimestamps() {
 			console.error( 'Failed to parse sync timestamps:', e );
 			return {};
 		}
-	}, [] );
+	} );
+
+	useEffect( () => {
+		try {
+			localStorage.setItem( SYNC_TIMESTAMPS_STORAGE_KEY, JSON.stringify( timestamps ) );
+		} catch ( e ) {
+			console.error( 'Failed to save sync timestamps:', e );
+		}
+	}, [ timestamps ] );
 
 	const updateTimestamp = useCallback(
 		( localSiteId: string, connectedSiteId: number, type: 'pull' | 'push' ) => {
-			try {
-				const timestamps = getStoredTimestamps();
-				timestamps[ localSiteId ] = timestamps[ localSiteId ] || {};
-				timestamps[ localSiteId ][ connectedSiteId ] = {
-					...timestamps[ localSiteId ][ connectedSiteId ],
-					[ type === 'pull' ? 'lastPull' : 'lastPush' ]: Date.now(),
-				};
-				localStorage.setItem( SYNC_TIMESTAMPS_STORAGE_KEY, JSON.stringify( timestamps ) );
-			} catch ( e ) {
-				console.error( 'Failed to update sync timestamp:', e );
-			}
+			setTimestamps( ( prev ) => {
+				const newTimestamps = { ...prev };
+				if ( ! newTimestamps[ localSiteId ] ) {
+					newTimestamps[ localSiteId ] = {};
+				}
+				if ( ! newTimestamps[ localSiteId ][ connectedSiteId ] ) {
+					newTimestamps[ localSiteId ][ connectedSiteId ] = {};
+				}
+				newTimestamps[ localSiteId ][ connectedSiteId ][ type ] = Date.now();
+				return newTimestamps;
+			} );
 		},
-		[ getStoredTimestamps ]
+		[]
 	);
 
 	const getLastSyncTimeWithType = useCallback(
 		( localSiteId: string, connectedSiteId: number, type: 'pull' | 'push' ): string => {
-			const timestamps = getStoredTimestamps();
 			const localSiteTimestamps = timestamps[ localSiteId ] || {};
 			const siteTimestamps = localSiteTimestamps[ connectedSiteId ] || {};
-			const timestamp = type === 'pull' ? siteTimestamps.lastPull : siteTimestamps.lastPush;
+			const timestamp = siteTimestamps[ type ];
 
 			if ( ! timestamp ) {
 				return type === 'pull' ? __( 'Never pulled' ) : __( 'Never pushed' );
 			}
 
-			return type === 'pull'
-				? sprintf( __( 'Last pull %s ago' ), formatDistanceToNow( timestamp ) )
-				: sprintf( __( 'Last push %s ago' ), formatDistanceToNow( timestamp ) );
+			return sprintf(
+				type === 'pull' ? __( 'Last pull %s ago' ) : __( 'Last push %s ago' ),
+				formatDistanceToNow( timestamp )
+			);
 		},
-		[ getStoredTimestamps ]
+		[ timestamps ]
 	);
 
-	const clearTimestamps = useCallback(
-		( localSiteId: string, connectedSiteId: number ) => {
-			try {
-				const timestamps = getStoredTimestamps();
-				if ( timestamps[ localSiteId ] ) {
-					delete timestamps[ localSiteId ][ connectedSiteId ];
-					if ( Object.keys( timestamps[ localSiteId ] ).length === 0 ) {
-						delete timestamps[ localSiteId ];
-					}
-					localStorage.setItem( SYNC_TIMESTAMPS_STORAGE_KEY, JSON.stringify( timestamps ) );
+	const clearTimestamps = useCallback( ( localSiteId: string, connectedSiteId: number ) => {
+		setTimestamps( ( prev ) => {
+			const newTimestamps = { ...prev };
+			if ( newTimestamps[ localSiteId ] ) {
+				delete newTimestamps[ localSiteId ][ connectedSiteId ];
+				if ( Object.keys( newTimestamps[ localSiteId ] ).length === 0 ) {
+					delete newTimestamps[ localSiteId ];
 				}
-			} catch ( e ) {
-				console.error( 'Failed to clear sync timestamps:', e );
 			}
-		},
-		[ getStoredTimestamps ]
-	);
+			return newTimestamps;
+		} );
+	}, [] );
 
 	return {
 		updateTimestamp,

--- a/src/hooks/use-pull-push-timestamps.ts
+++ b/src/hooks/use-pull-push-timestamps.ts
@@ -1,0 +1,83 @@
+import { __ } from '@wordpress/i18n';
+import { formatDistanceToNow } from 'date-fns';
+import { useCallback } from 'react';
+
+const SYNC_TIMESTAMPS_STORAGE_KEY = 'wp-studio-sync-timestamps';
+
+interface SyncTimestamps {
+	[ localSiteId: string ]: {
+		[ connectedSiteId: number ]: {
+			lastPull?: number;
+			lastPush?: number;
+		};
+	};
+}
+
+export function usePullPushTimestamps() {
+	const getStoredTimestamps = useCallback( (): SyncTimestamps => {
+		try {
+			const stored = localStorage.getItem( SYNC_TIMESTAMPS_STORAGE_KEY );
+			return stored ? JSON.parse( stored ) : {};
+		} catch ( e ) {
+			console.error( 'Failed to parse sync timestamps:', e );
+			return {};
+		}
+	}, [] );
+
+	const updateTimestamp = useCallback(
+		( localSiteId: string, connectedSiteId: number, type: 'pull' | 'push' ) => {
+			try {
+				const timestamps = getStoredTimestamps();
+				timestamps[ localSiteId ] = timestamps[ localSiteId ] || {};
+				timestamps[ localSiteId ][ connectedSiteId ] = {
+					...timestamps[ localSiteId ][ connectedSiteId ],
+					[ type === 'pull' ? 'lastPull' : 'lastPush' ]: Date.now(),
+				};
+				localStorage.setItem( SYNC_TIMESTAMPS_STORAGE_KEY, JSON.stringify( timestamps ) );
+			} catch ( e ) {
+				console.error( 'Failed to update sync timestamp:', e );
+			}
+		},
+		[ getStoredTimestamps ]
+	);
+
+	const getLastSyncTime = useCallback(
+		( localSiteId: string, connectedSiteId: number, type: 'pull' | 'push' ): string => {
+			const timestamps = getStoredTimestamps();
+			const localSiteTimestamps = timestamps[ localSiteId ] || {};
+			const siteTimestamps = localSiteTimestamps[ connectedSiteId ] || {};
+			const timestamp = type === 'pull' ? siteTimestamps.lastPull : siteTimestamps.lastPush;
+
+			if ( ! timestamp ) {
+				return __( 'Never synced' );
+			}
+
+			return `${ __( 'Last synced' ) } ${ formatDistanceToNow( timestamp ) } ${ __( 'ago' ) }`;
+		},
+		[ getStoredTimestamps ]
+	);
+
+	const clearTimestamps = useCallback(
+		( localSiteId: string, connectedSiteId: number ) => {
+			try {
+				const timestamps = getStoredTimestamps();
+				if ( timestamps[ localSiteId ] ) {
+					delete timestamps[ localSiteId ][ connectedSiteId ];
+					if ( Object.keys( timestamps[ localSiteId ] ).length === 0 ) {
+						delete timestamps[ localSiteId ];
+					}
+					localStorage.setItem( SYNC_TIMESTAMPS_STORAGE_KEY, JSON.stringify( timestamps ) );
+				}
+			} catch ( e ) {
+				console.error( 'Failed to clear sync timestamps:', e );
+			}
+		},
+		[ getStoredTimestamps ]
+	);
+
+	return {
+		updateTimestamp,
+		getLastSyncTime,
+		clearTimestamps,
+	};
+}

--- a/src/hooks/use-pull-push-timestamps.ts
+++ b/src/hooks/use-pull-push-timestamps.ts
@@ -7,8 +7,8 @@ const SYNC_TIMESTAMPS_STORAGE_KEY = 'wp-studio-sync-timestamps';
 interface SyncTimestamps {
 	[ localSiteId: string ]: {
 		[ connectedSiteId: number ]: {
-			lastPull?: number;
-			lastPush?: number;
+			pull?: number;
+			push?: number;
 		};
 	};
 }
@@ -29,10 +29,9 @@ export function usePullPushTimestamps() {
 			try {
 				const timestamps = getStoredTimestamps();
 				timestamps[ localSiteId ] = timestamps[ localSiteId ] || {};
-				timestamps[ localSiteId ][ connectedSiteId ] = {
-					...timestamps[ localSiteId ][ connectedSiteId ],
-					[ type === 'pull' ? 'lastPull' : 'lastPush' ]: Date.now(),
-				};
+				timestamps[ localSiteId ][ connectedSiteId ] =
+					timestamps[ localSiteId ][ connectedSiteId ] || {};
+				timestamps[ localSiteId ][ connectedSiteId ][ type ] = Date.now();
 				localStorage.setItem( SYNC_TIMESTAMPS_STORAGE_KEY, JSON.stringify( timestamps ) );
 			} catch ( e ) {
 				console.error( 'Failed to update sync timestamp:', e );
@@ -46,15 +45,16 @@ export function usePullPushTimestamps() {
 			const timestamps = getStoredTimestamps();
 			const localSiteTimestamps = timestamps[ localSiteId ] || {};
 			const siteTimestamps = localSiteTimestamps[ connectedSiteId ] || {};
-			const timestamp = type === 'pull' ? siteTimestamps.lastPull : siteTimestamps.lastPush;
+			const timestamp = siteTimestamps[ type ];
 
 			if ( ! timestamp ) {
 				return type === 'pull' ? __( 'Never pulled' ) : __( 'Never pushed' );
 			}
 
-			return type === 'pull'
-				? sprintf( __( 'Last pull %s ago' ), formatDistanceToNow( timestamp ) )
-				: sprintf( __( 'Last push %s ago' ), formatDistanceToNow( timestamp ) );
+			return sprintf(
+				type === 'pull' ? __( 'Last pull %s ago' ) : __( 'Last push %s ago' ),
+				formatDistanceToNow( timestamp )
+			);
 		},
 		[ getStoredTimestamps ]
 	);

--- a/src/hooks/use-pull-push-timestamps.ts
+++ b/src/hooks/use-pull-push-timestamps.ts
@@ -1,6 +1,6 @@
 import { __, sprintf } from '@wordpress/i18n';
 import { formatDistanceToNow } from 'date-fns';
-import { useCallback } from 'react';
+import { useCallback, useState, useEffect } from 'react';
 
 const SYNC_TIMESTAMPS_STORAGE_KEY = 'wp-studio-sync-timestamps';
 
@@ -14,7 +14,7 @@ interface SyncTimestamps {
 }
 
 export function usePullPushTimestamps() {
-	const getStoredTimestamps = useCallback( (): SyncTimestamps => {
+	const [ timestamps, setTimestamps ] = useState< SyncTimestamps >( () => {
 		try {
 			const stored = localStorage.getItem( SYNC_TIMESTAMPS_STORAGE_KEY );
 			return stored ? JSON.parse( stored ) : {};
@@ -22,27 +22,35 @@ export function usePullPushTimestamps() {
 			console.error( 'Failed to parse sync timestamps:', e );
 			return {};
 		}
-	}, [] );
+	} );
+
+	useEffect( () => {
+		try {
+			localStorage.setItem( SYNC_TIMESTAMPS_STORAGE_KEY, JSON.stringify( timestamps ) );
+		} catch ( e ) {
+			console.error( 'Failed to save sync timestamps:', e );
+		}
+	}, [ timestamps ] );
 
 	const updateTimestamp = useCallback(
 		( localSiteId: string, connectedSiteId: number, type: 'pull' | 'push' ) => {
-			try {
-				const timestamps = getStoredTimestamps();
-				timestamps[ localSiteId ] = timestamps[ localSiteId ] || {};
-				timestamps[ localSiteId ][ connectedSiteId ] =
-					timestamps[ localSiteId ][ connectedSiteId ] || {};
-				timestamps[ localSiteId ][ connectedSiteId ][ type ] = Date.now();
-				localStorage.setItem( SYNC_TIMESTAMPS_STORAGE_KEY, JSON.stringify( timestamps ) );
-			} catch ( e ) {
-				console.error( 'Failed to update sync timestamp:', e );
-			}
+			setTimestamps( ( prev ) => {
+				const newTimestamps = { ...prev };
+				if ( ! newTimestamps[ localSiteId ] ) {
+					newTimestamps[ localSiteId ] = {};
+				}
+				if ( ! newTimestamps[ localSiteId ][ connectedSiteId ] ) {
+					newTimestamps[ localSiteId ][ connectedSiteId ] = {};
+				}
+				newTimestamps[ localSiteId ][ connectedSiteId ][ type ] = Date.now();
+				return newTimestamps;
+			} );
 		},
-		[ getStoredTimestamps ]
+		[]
 	);
 
 	const getLastSyncTimeWithType = useCallback(
 		( localSiteId: string, connectedSiteId: number, type: 'pull' | 'push' ): string => {
-			const timestamps = getStoredTimestamps();
 			const localSiteTimestamps = timestamps[ localSiteId ] || {};
 			const siteTimestamps = localSiteTimestamps[ connectedSiteId ] || {};
 			const timestamp = siteTimestamps[ type ];
@@ -56,26 +64,21 @@ export function usePullPushTimestamps() {
 				formatDistanceToNow( timestamp )
 			);
 		},
-		[ getStoredTimestamps ]
+		[ timestamps ]
 	);
 
-	const clearTimestamps = useCallback(
-		( localSiteId: string, connectedSiteId: number ) => {
-			try {
-				const timestamps = getStoredTimestamps();
-				if ( timestamps[ localSiteId ] ) {
-					delete timestamps[ localSiteId ][ connectedSiteId ];
-					if ( Object.keys( timestamps[ localSiteId ] ).length === 0 ) {
-						delete timestamps[ localSiteId ];
-					}
-					localStorage.setItem( SYNC_TIMESTAMPS_STORAGE_KEY, JSON.stringify( timestamps ) );
+	const clearTimestamps = useCallback( ( localSiteId: string, connectedSiteId: number ) => {
+		setTimestamps( ( prev ) => {
+			const newTimestamps = { ...prev };
+			if ( newTimestamps[ localSiteId ] ) {
+				delete newTimestamps[ localSiteId ][ connectedSiteId ];
+				if ( Object.keys( newTimestamps[ localSiteId ] ).length === 0 ) {
+					delete newTimestamps[ localSiteId ];
 				}
-			} catch ( e ) {
-				console.error( 'Failed to clear sync timestamps:', e );
 			}
-		},
-		[ getStoredTimestamps ]
-	);
+			return newTimestamps;
+		} );
+	}, [] );
 
 	return {
 		updateTimestamp,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

Closes https://github.com/Automattic/dotcom-forge/issues/9360

## Proposed Changes

This PR adds the tooltip with the last pull and push time to the `Pull` and `Push` buttons. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
* Start  Studio with `STUDIO_SITE_SYNC=true npm start`
* Navigate to the `Sync` tab on Studio site A
* Click on `Connect site` and connect a WP.com site
* Navigate to the `Sync` tab on Studio site B
* Click on `Connect site` and connect the same WP.com site
* Hover over the `Pull` and `Push` buttons and confirm that you can see the `Never pushed` or `Never pulled` text
* Start the pull process on Studio site A
* Confirm that once the push finishes, you can see the text `Last pull {x} minutes ago`
* Switch to the Studio site B and confirm that the tooltip says `Never pulled` for that same WP.com site 
* Try switching tabs or sites and confirm that the state persists

<img width="1270" alt="Screenshot 2024-11-22 at 1 37 04 PM" src="https://github.com/user-attachments/assets/dff133ee-b8cb-4206-9d46-0a58f60efdc1">

<img width="1297" alt="Screenshot 2024-11-22 at 1 36 53 PM" src="https://github.com/user-attachments/assets/7223c78e-d964-4ddc-9c63-bdb05ab51f44">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
