### PR TITLE
Add exportSiteToPush function to upload a valid VaultPress backup

### DIFF
--- a/src/hooks/sync-sites/use-sync-push.ts
+++ b/src/hooks/sync-sites/use-sync-push.ts
@@ -87,10 +87,8 @@ export function useSyncPush( {
 				isStaging: connectedSite.isStaging,
 			} );
 
-			const { archiveContent, archivePath, archiveSizeInBytes } = await getIpcApi().archiveSite(
-				selectedSite.id,
-				'tar'
-			);
+			const { archiveContent, archivePath, archiveSizeInBytes } =
+				await getIpcApi().exportSiteToPush( selectedSite.id );
 			if ( archiveSizeInBytes > SYNC_PUSH_SIZE_LIMIT_BYTES ) {
 				updatePushState( selectedSite.id, remoteSiteId, {
 					status: pushStatesProgressInfo.failed,

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -500,6 +500,27 @@ export async function archiveSite( event: IpcMainInvokeEvent, id: string, format
 	return { archivePath, archiveContent, archiveSizeInBytes: stats.size };
 }
 
+export async function exportSiteToPush( event: IpcMainInvokeEvent, id: string ) {
+	const site = SiteServer.get( id );
+	if ( ! site ) {
+		throw new Error( 'Site not found.' );
+	}
+	const extension = 'tar.gz';
+	const archivePath = `${ TEMP_DIR }site_${ id }.${ extension }`;
+	const exportOptions = {
+		site: site.details,
+		backupFile: archivePath,
+		includes: { database: true, uploads: true, plugins: true, themes: true },
+		phpVersion: site.details.phpVersion,
+	};
+	// eslint-disable-next-line @typescript-eslint/no-empty-function
+	const onEvent = () => {};
+	await exportBackup( exportOptions, onEvent );
+	const stats = fs.statSync( archivePath );
+	const archiveContent = fs.readFileSync( archivePath );
+	return { archivePath, archiveContent, archiveSizeInBytes: stats.size };
+}
+
 export function removeTemporalFile( event: IpcMainInvokeEvent, path: string ) {
 	if ( ! path.includes( TEMP_DIR ) ) {
 		throw new Error( 'The given path is not a temporal file' );

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -13,6 +13,7 @@ import type { LogLevel } from './logging';
 const api: IpcApi = {
 	archiveSite: ( id: string, format: 'zip' | 'tar' ) =>
 		ipcRenderer.invoke( 'archiveSite', id, format ),
+	exportSiteToPush: ( id: string ) => ipcRenderer.invoke( 'exportSiteToPush', id ),
 	deleteSite: ( id: string, deleteFiles?: boolean ) =>
 		ipcRenderer.invoke( 'deleteSite', id, deleteFiles ),
 	createSite: ( path: string, name?: string ) => ipcRenderer.invoke( 'createSite', path, name ),


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/dotcom-forge/issues/9930
- Follow-up of: https://github.com/Automattic/studio/pull/662

## Proposed Changes

- Use export format with sql file and meta.json instead of archive format

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run `STUDIO_SITE_SYNC=true npm start`
- Click on the Sync tab
- Connect a site
- Click on Push
- Change tabs and sites, observe the process continues correctly
- Wait until the process finishes
- Observe your remote site has restored. In fact, the remote site would look the same as before, but it restored a previous backup of the same site.


<img width="935" alt="Screenshot 2024-11-22 at 13 36 51" src="https://github.com/user-attachments/assets/e3a55621-b6f4-48b6-8001-d293366bac50">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
