### PR TITLE
Change link to new-hosted-site flow for new sync sites

### DIFF
--- a/src/components/connect-create-buttons.tsx
+++ b/src/components/connect-create-buttons.tsx
@@ -54,7 +54,7 @@ export const ConnectCreateButtons = ( {
 				<Button
 					onClick={ () => {
 						getIpcApi().openURL(
-							`https://wordpress.com/setup/new-hosted-site?ref=studio&section=studio-sync&showDomainStep&studioSiteId=${ selectedSite.id }`
+							`https://wordpress.com/setup/new-hosted-site?ref=studio&section=studio-sync&studioSiteId=${ selectedSite.id }`
 						);
 					} }
 					variant={ createButtonVariant }

--- a/src/components/connect-create-buttons.tsx
+++ b/src/components/connect-create-buttons.tsx
@@ -1,4 +1,5 @@
 import { __ } from '@wordpress/i18n';
+import { useSiteDetails } from '../hooks/use-site-details';
 import { cx } from '../lib/cx';
 import { getIpcApi } from '../lib/get-ipc-api';
 import { ArrowIcon } from './arrow-icon';
@@ -21,6 +22,10 @@ export const ConnectCreateButtons = ( {
 	connectButtonVariant,
 	disableConnectButtonStyle,
 }: ConnectCreateButtonsProps ) => {
+	const { selectedSite } = useSiteDetails();
+	if ( ! selectedSite ) {
+		return null;
+	}
 	return (
 		<>
 			<Tooltip
@@ -51,7 +56,9 @@ export const ConnectCreateButtons = ( {
 			>
 				<Button
 					onClick={ () => {
-						getIpcApi().openURL( 'https://wordpress.com/start/new-site' );
+						getIpcApi().openURL(
+							`https://wordpress.com/setup/new-hosted-site?ref=studio&section=studio-sync&studio-site-id=${ selectedSite.id }`
+						);
 					} }
 					variant={ createButtonVariant }
 					className={ cx( ! isOffline && '!text-a8c-blueberry !shadow-a8c-blueberry' ) }

--- a/src/components/connect-create-buttons.tsx
+++ b/src/components/connect-create-buttons.tsx
@@ -1,5 +1,4 @@
 import { __ } from '@wordpress/i18n';
-import { useSiteDetails } from '../hooks/use-site-details';
 import { cx } from '../lib/cx';
 import { getIpcApi } from '../lib/get-ipc-api';
 import { ArrowIcon } from './arrow-icon';
@@ -13,6 +12,7 @@ interface ConnectCreateButtonsProps {
 	connectButtonVariant: ButtonVariant;
 	createButtonVariant: ButtonVariant;
 	disableConnectButtonStyle?: boolean;
+	selectedSite: SiteDetails;
 }
 
 export const ConnectCreateButtons = ( {
@@ -21,11 +21,8 @@ export const ConnectCreateButtons = ( {
 	createButtonVariant,
 	connectButtonVariant,
 	disableConnectButtonStyle,
+	selectedSite,
 }: ConnectCreateButtonsProps ) => {
-	const { selectedSite } = useSiteDetails();
-	if ( ! selectedSite ) {
-		return null;
-	}
 	return (
 		<>
 			<Tooltip

--- a/src/components/connect-create-buttons.tsx
+++ b/src/components/connect-create-buttons.tsx
@@ -54,7 +54,7 @@ export const ConnectCreateButtons = ( {
 				<Button
 					onClick={ () => {
 						getIpcApi().openURL(
-							`https://wordpress.com/setup/new-hosted-site?ref=studio&section=studio-sync&showDomainStep&studio-site-id=${ selectedSite.id }`
+							`https://wordpress.com/setup/new-hosted-site?ref=studio&section=studio-sync&showDomainStep&studioSiteId=${ selectedSite.id }`
 						);
 					} }
 					variant={ createButtonVariant }

--- a/src/components/connect-create-buttons.tsx
+++ b/src/components/connect-create-buttons.tsx
@@ -54,7 +54,7 @@ export const ConnectCreateButtons = ( {
 				<Button
 					onClick={ () => {
 						getIpcApi().openURL(
-							`https://wordpress.com/setup/new-hosted-site?ref=studio&section=studio-sync&studio-site-id=${ selectedSite.id }`
+							`https://wordpress.com/setup/new-hosted-site?ref=studio&section=studio-sync&showDomainStep&studio-site-id=${ selectedSite.id }`
 						);
 					} }
 					variant={ createButtonVariant }

--- a/src/components/content-tab-sync.tsx
+++ b/src/components/content-tab-sync.tsx
@@ -53,9 +53,11 @@ function SiteSyncDescription( { children }: PropsWithChildren ) {
 
 function CreateConnectSite( {
 	openSitesSyncSelector,
+	selectedSite,
 }: {
 	className?: string;
 	openSitesSyncSelector: () => void;
+	selectedSite: SiteDetails;
 } ) {
 	const { __ } = useI18n();
 	const isOffline = useOffline();
@@ -69,6 +71,7 @@ function CreateConnectSite( {
 					connectButtonVariant="primary"
 					createButtonVariant="secondary"
 					disableConnectButtonStyle={ true }
+					selectedSite={ selectedSite }
 				/>
 			</div>
 		</div>
@@ -177,7 +180,10 @@ export function ContentTabSync( { selectedSite }: { selectedSite: SiteDetails } 
 				/>
 			) : (
 				<SiteSyncDescription>
-					<CreateConnectSite openSitesSyncSelector={ () => setIsSyncSitesSelectorOpen( true ) } />
+					<CreateConnectSite
+						openSitesSyncSelector={ () => setIsSyncSitesSelectorOpen( true ) }
+						selectedSite={ selectedSite }
+					/>
 				</SiteSyncDescription>
 			) }
 

--- a/src/components/sync-connected-sites.tsx
+++ b/src/components/sync-connected-sites.tsx
@@ -355,6 +355,7 @@ export function SyncConnectedSites( {
 					isOffline={ isOffline }
 					connectButtonVariant="secondary"
 					createButtonVariant="secondary"
+					selectedSite={ selectedSite }
 				/>
 			</div>
 		</div>

--- a/src/components/tests/content-tab-sync.test.tsx
+++ b/src/components/tests/content-tab-sync.test.tsx
@@ -83,7 +83,9 @@ describe( 'ContentTabSync', () => {
 
 		expect( screen.getByText( 'Sync with' ) ).toBeInTheDocument();
 		expect( createSiteButton ).toBeInTheDocument();
-		expect( getIpcApi().openURL ).toHaveBeenCalledWith( 'https://wordpress.com/start/new-site' );
+		expect( getIpcApi().openURL ).toHaveBeenCalledWith(
+			'https://wordpress.com/setup/new-hosted-site?ref=studio&section=studio-sync&studio-site-id=site-id'
+		);
 	} );
 
 	it( 'displays connect site button to authenticated user', () => {

--- a/src/components/tests/content-tab-sync.test.tsx
+++ b/src/components/tests/content-tab-sync.test.tsx
@@ -84,7 +84,7 @@ describe( 'ContentTabSync', () => {
 		expect( screen.getByText( 'Sync with' ) ).toBeInTheDocument();
 		expect( createSiteButton ).toBeInTheDocument();
 		expect( getIpcApi().openURL ).toHaveBeenCalledWith(
-			'https://wordpress.com/setup/new-hosted-site?ref=studio&section=studio-sync&showDomainStep&studioSiteId=site-id'
+			'https://wordpress.com/setup/new-hosted-site?ref=studio&section=studio-sync&studioSiteId=site-id'
 		);
 	} );
 

--- a/src/components/tests/content-tab-sync.test.tsx
+++ b/src/components/tests/content-tab-sync.test.tsx
@@ -84,7 +84,7 @@ describe( 'ContentTabSync', () => {
 		expect( screen.getByText( 'Sync with' ) ).toBeInTheDocument();
 		expect( createSiteButton ).toBeInTheDocument();
 		expect( getIpcApi().openURL ).toHaveBeenCalledWith(
-			'https://wordpress.com/setup/new-hosted-site?ref=studio&section=studio-sync&showDomainStep&studio-site-id=site-id'
+			'https://wordpress.com/setup/new-hosted-site?ref=studio&section=studio-sync&showDomainStep&studioSiteId=site-id'
 		);
 	} );
 

--- a/src/components/tests/content-tab-sync.test.tsx
+++ b/src/components/tests/content-tab-sync.test.tsx
@@ -84,7 +84,7 @@ describe( 'ContentTabSync', () => {
 		expect( screen.getByText( 'Sync with' ) ).toBeInTheDocument();
 		expect( createSiteButton ).toBeInTheDocument();
 		expect( getIpcApi().openURL ).toHaveBeenCalledWith(
-			'https://wordpress.com/setup/new-hosted-site?ref=studio&section=studio-sync&studio-site-id=site-id'
+			'https://wordpress.com/setup/new-hosted-site?ref=studio&section=studio-sync&showDomainStep&studio-site-id=site-id'
 		);
 	} );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Related to https://github.com/Automattic/dotcom-forge/issues/9359

## Proposed Changes

- Open `new-hosted-site` which creates a new site and moves it to atomic by default
- Pass the current siteId as a param so we can save it in the flow
- Add ref "studio" to track it

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

There will be an wpcalypso PR that you can use for testing.
The following steps will work on production even without that PR.

- Run `STUDIO_SITE_SYNC=true npm start`
- Click on the Sync tab
- Click on "Create new site ↗"
- Observe the plan selector opens with only the business and ecommerce plans
- Observe the URL contains the param `studio-site-id`
- Continue the flow and purchase a site
- Observe you've created a new site that is atomic

<img width="1723" alt="Screenshot 2024-11-22 at 19 38 49" src="https://github.com/user-attachments/assets/bf107f21-6147-4b02-9f6b-465b5e5ab317">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
