### PR TITLE
Export SQLite tables into different files

### DIFF
--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -507,11 +507,12 @@ export async function exportSiteToPush( event: IpcMainInvokeEvent, id: string ) 
 	}
 	const extension = 'tar.gz';
 	const archivePath = `${ TEMP_DIR }site_${ id }.${ extension }`;
-	const exportOptions = {
+	const exportOptions: ExportOptions = {
 		site: site.details,
 		backupFile: archivePath,
 		includes: { database: true, uploads: true, plugins: true, themes: true },
 		phpVersion: site.details.phpVersion,
+		splitDatabaseDumpByTable: true,
 	};
 	// eslint-disable-next-line @typescript-eslint/no-empty-function
 	const onEvent = () => {};

--- a/src/lib/import-export/export/export-database.ts
+++ b/src/lib/import-export/export/export-database.ts
@@ -60,7 +60,7 @@ export async function exportDatabaseToMultipleFiles(
 	const tmpFiles: string[] = [];
 
 	for ( const table of tables ) {
-		const fileName = `${ generateBackupFilename( table ) }.sql`;
+		const fileName = `${ table }.sql`;
 
 		// Execute the command to export directly to a temporary file in the project directory
 		const { stderr, exitCode } = await server.executeWpCliCommand(

--- a/src/lib/import-export/export/export-database.ts
+++ b/src/lib/import-export/export/export-database.ts
@@ -35,3 +35,48 @@ export async function exportDatabaseToFile(
 
 	console.log( `Database export saved to ${ finalDestination }` );
 }
+
+export async function exportDatabaseToMultipleFiles(
+	site: SiteDetails,
+	finalDestination: string
+): Promise< void > {
+	const server = SiteServer.get( site.id );
+
+	if ( ! server ) {
+		throw new Error( 'Site not found.' );
+	}
+
+	const tablesResult = await server.executeWpCliCommand(
+		`sqlite tables --format=csv --require=/tmp/sqlite-command/command.php`
+	);
+	if ( tablesResult.stderr ) {
+		throw new Error( `Database export failed: ${ tablesResult.stderr }` );
+	}
+	if ( tablesResult.exitCode ) {
+		throw new Error( 'Database export failed' );
+	}
+	const tables = tablesResult.stdout.split( ',' );
+
+	for ( const table of tables ) {
+		// Generate a temporary file name in the project directory
+		const tempFileName = `${ generateBackupFilename( table ) }.sql`;
+		const tempFilePath = path.join( site.path, tempFileName );
+		// Execute the command to export directly to the temp file
+		const { stderr, exitCode } = await server.executeWpCliCommand(
+			`sqlite export ${ tempFilePath } --tables=${ table } --require=/tmp/sqlite-command/command.php`
+		);
+
+		if ( stderr ) {
+			throw new Error( `Database export failed: ${ stderr }` );
+		}
+
+		if ( exitCode ) {
+			throw new Error( 'Database export failed' );
+		}
+
+		// Move the file to its final destination
+		await move( tempFilePath, finalDestination );
+	}
+
+	console.log( `Database export saved to ${ finalDestination }` );
+}

--- a/src/lib/import-export/export/export-database.ts
+++ b/src/lib/import-export/export/export-database.ts
@@ -15,7 +15,6 @@ export async function exportDatabaseToFile(
 
 	// Generate a temporary file name in the project directory
 	const tempFileName = `${ generateBackupFilename( 'db-export' ) }.sql`;
-	const tempFilePath = path.join( site.path, tempFileName );
 
 	// Execute the command to export directly to the temp file
 	const { stderr, exitCode } = await server.executeWpCliCommand(
@@ -31,6 +30,7 @@ export async function exportDatabaseToFile(
 	}
 
 	// Move the file to its final destination
+	const tempFilePath = path.join( site.path, tempFileName );
 	await move( tempFilePath, finalDestination );
 
 	console.log( `Database export saved to ${ finalDestination }` );
@@ -38,8 +38,8 @@ export async function exportDatabaseToFile(
 
 export async function exportDatabaseToMultipleFiles(
 	site: SiteDetails,
-	finalDestination: string
-): Promise< void > {
+	finalDestinationDir: string
+): Promise< string[] > {
 	const server = SiteServer.get( site.id );
 
 	if ( ! server ) {
@@ -57,13 +57,14 @@ export async function exportDatabaseToMultipleFiles(
 	}
 	const tables = tablesResult.stdout.split( ',' );
 
+	const tmpFiles: string[] = [];
+
 	for ( const table of tables ) {
-		// Generate a temporary file name in the project directory
-		const tempFileName = `${ generateBackupFilename( table ) }.sql`;
-		const tempFilePath = path.join( site.path, tempFileName );
-		// Execute the command to export directly to the temp file
+		const fileName = `${ generateBackupFilename( table ) }.sql`;
+
+		// Execute the command to export directly to a temporary file in the project directory
 		const { stderr, exitCode } = await server.executeWpCliCommand(
-			`sqlite export ${ tempFilePath } --tables=${ table } --require=/tmp/sqlite-command/command.php`
+			`sqlite export ${ fileName } --tables=${ table } --require=/tmp/sqlite-command/command.php`
 		);
 
 		if ( stderr ) {
@@ -75,8 +76,14 @@ export async function exportDatabaseToMultipleFiles(
 		}
 
 		// Move the file to its final destination
+		const tempFilePath = path.join( site.path, fileName );
+		const finalDestination = path.join( finalDestinationDir, fileName );
 		await move( tempFilePath, finalDestination );
+
+		tmpFiles.push( finalDestination );
 	}
 
-	console.log( `Database export saved to ${ finalDestination }` );
+	console.log( `Database export saved to ${ finalDestinationDir }` );
+
+	return tmpFiles;
 }

--- a/src/lib/import-export/export/exporters/default-exporter.ts
+++ b/src/lib/import-export/export/exporters/default-exporter.ts
@@ -8,7 +8,6 @@ import { getWordPressVersionFromInstallation } from '../../../../lib/wp-versions
 import { SiteServer } from '../../../../site-server';
 import { ExportEvents } from '../events';
 import { exportDatabaseToMultipleFiles } from '../export-database';
-import { generateBackupFilename } from '../generate-backup-filename';
 import {
 	ExportOptions,
 	BackupContents,
@@ -163,11 +162,9 @@ export class DefaultExporter extends EventEmitter implements Exporter {
 		if ( this.options.includes.database ) {
 			this.emit( ExportEvents.DATABASE_EXPORT_START );
 			const tmpFolder = await fsPromises.mkdtemp( path.join( os.tmpdir(), 'studio_export' ) );
-			const fileName = `${ generateBackupFilename( 'db-export' ) }.sql`;
-			const sqlDumpPath = path.join( tmpFolder, fileName );
-			await exportDatabaseToMultipleFiles( this.options.site, sqlDumpPath );
-			this.archive.file( sqlDumpPath, { name: `sql/${ fileName }` } );
-			this.backup.sqlFiles.push( sqlDumpPath );
+			const sqlFiles = await exportDatabaseToMultipleFiles( this.options.site, tmpFolder );
+			this.archive.directory( tmpFolder, 'sql' );
+			this.backup.sqlFiles.push( ...sqlFiles );
 			this.emit( ExportEvents.DATABASE_EXPORT_COMPLETE );
 		}
 	}

--- a/src/lib/import-export/export/exporters/default-exporter.ts
+++ b/src/lib/import-export/export/exporters/default-exporter.ts
@@ -169,7 +169,9 @@ export class DefaultExporter extends EventEmitter implements Exporter {
 
 		if ( this.options.splitDatabaseDumpByTable ) {
 			const sqlFiles = await exportDatabaseToMultipleFiles( this.options.site, tmpFolder );
-			this.archive.directory( tmpFolder, 'sql' );
+			sqlFiles.forEach( ( file ) =>
+				this.archive.file( file, { name: `sql/${ path.basename( file ) }` } )
+			);
 			this.backup.sqlFiles.push( ...sqlFiles );
 		} else {
 			const fileName = `${ generateBackupFilename( 'db-export' ) }.sql`;

--- a/src/lib/import-export/export/exporters/default-exporter.ts
+++ b/src/lib/import-export/export/exporters/default-exporter.ts
@@ -7,7 +7,8 @@ import archiver from 'archiver';
 import { getWordPressVersionFromInstallation } from '../../../../lib/wp-versions';
 import { SiteServer } from '../../../../site-server';
 import { ExportEvents } from '../events';
-import { exportDatabaseToMultipleFiles } from '../export-database';
+import { exportDatabaseToFile, exportDatabaseToMultipleFiles } from '../export-database';
+import { generateBackupFilename } from '../generate-backup-filename';
 import {
 	ExportOptions,
 	BackupContents,
@@ -159,14 +160,26 @@ export class DefaultExporter extends EventEmitter implements Exporter {
 	}
 
 	private async addDatabase(): Promise< void > {
-		if ( this.options.includes.database ) {
-			this.emit( ExportEvents.DATABASE_EXPORT_START );
-			const tmpFolder = await fsPromises.mkdtemp( path.join( os.tmpdir(), 'studio_export' ) );
+		if ( ! this.options.includes.database ) {
+			return;
+		}
+
+		this.emit( ExportEvents.DATABASE_EXPORT_START );
+		const tmpFolder = await fsPromises.mkdtemp( path.join( os.tmpdir(), 'studio_export' ) );
+
+		if ( this.options.splitDatabaseDumpByTable ) {
 			const sqlFiles = await exportDatabaseToMultipleFiles( this.options.site, tmpFolder );
 			this.archive.directory( tmpFolder, 'sql' );
 			this.backup.sqlFiles.push( ...sqlFiles );
-			this.emit( ExportEvents.DATABASE_EXPORT_COMPLETE );
+		} else {
+			const fileName = `${ generateBackupFilename( 'db-export' ) }.sql`;
+			const sqlDumpPath = path.join( tmpFolder, fileName );
+			await exportDatabaseToFile( this.options.site, sqlDumpPath );
+			this.archive.file( sqlDumpPath, { name: `sql/${ fileName }` } );
+			this.backup.sqlFiles.push( sqlDumpPath );
 		}
+
+		this.emit( ExportEvents.DATABASE_EXPORT_COMPLETE );
 	}
 
 	private async cleanupTempFiles(): Promise< void > {

--- a/src/lib/import-export/export/exporters/default-exporter.ts
+++ b/src/lib/import-export/export/exporters/default-exporter.ts
@@ -7,7 +7,7 @@ import archiver from 'archiver';
 import { getWordPressVersionFromInstallation } from '../../../../lib/wp-versions';
 import { SiteServer } from '../../../../site-server';
 import { ExportEvents } from '../events';
-import { exportDatabaseToFile } from '../export-database';
+import { exportDatabaseToMultipleFiles } from '../export-database';
 import { generateBackupFilename } from '../generate-backup-filename';
 import {
 	ExportOptions,
@@ -165,7 +165,7 @@ export class DefaultExporter extends EventEmitter implements Exporter {
 			const tmpFolder = await fsPromises.mkdtemp( path.join( os.tmpdir(), 'studio_export' ) );
 			const fileName = `${ generateBackupFilename( 'db-export' ) }.sql`;
 			const sqlDumpPath = path.join( tmpFolder, fileName );
-			await exportDatabaseToFile( this.options.site, sqlDumpPath );
+			await exportDatabaseToMultipleFiles( this.options.site, sqlDumpPath );
 			this.archive.file( sqlDumpPath, { name: `sql/${ fileName }` } );
 			this.backup.sqlFiles.push( sqlDumpPath );
 			this.emit( ExportEvents.DATABASE_EXPORT_COMPLETE );

--- a/src/lib/import-export/export/types.ts
+++ b/src/lib/import-export/export/types.ts
@@ -6,6 +6,7 @@ export interface ExportOptions {
 	backupFile: string;
 	includes: { [ index in ExportOptionsIncludes ]: boolean };
 	phpVersion: string;
+	splitDatabaseDumpByTable?: boolean;
 }
 
 export type ExportOptionsIncludes = BackupContentsCategory | 'database';

--- a/src/lib/import-export/tests/export/exporters/default-exporter.test.ts
+++ b/src/lib/import-export/tests/export/exporters/default-exporter.test.ts
@@ -58,6 +58,22 @@ describe( 'DefaultExporter', () => {
 		{ path: '/path/to/site', name: 'wp-load.php', isFile: () => true },
 	];
 
+	const defaultTableNames = [
+		'wp_commentmeta',
+		'wp_comments',
+		'wp_links',
+		'wp_options',
+		'wp_postmeta',
+		'wp_posts',
+		'wp_term_relationships',
+		'wp_term_taxonomy',
+		'wp_termmeta',
+		'wp_terms',
+		'wp_usermeta',
+		'wp_users',
+	];
+
+
 	( fsPromises.readdir as jest.Mock ).mockResolvedValue( mockFiles );
 	( getWordPressVersionFromInstallation as jest.Mock ).mockResolvedValue( '6.6.1' );
 
@@ -102,6 +118,8 @@ describe( 'DefaultExporter', () => {
 						return { stdout: '[{"name":"akismet","status":"active","version":"5.3.3"}]' };
 					case /theme list/.test( command ):
 						return { stdout: '[{"name":"twentytwentyfour","status":"active","version":"1.0"}]' };
+					case /tables/.test( command ):
+						return { stdout: defaultTableNames.join( ',' ) };
 					default:
 						return { stderr: null };
 				}
@@ -237,6 +255,34 @@ describe( 'DefaultExporter', () => {
 				name: 'sql/studio-backup-db-export-2023-07-31-12-00-00.sql',
 			}
 		);
+	} );
+
+	it( 'should add a multiple SQL dumps to the archive when `splitDatabaseDumpByTable` is true', async () => {
+		const options = {
+			...mockOptions,
+			includes: {
+				plugins: false,
+				uploads: false,
+				themes: false,
+				database: true,
+			},
+			splitDatabaseDumpByTable: true,
+		};
+		( fsPromises.mkdtemp as jest.Mock ).mockResolvedValue( '/tmp/studio_export_123' );
+
+		const exporter = new DefaultExporter( options );
+		await exporter.export();
+
+		expect( mockArchiver.file ).toHaveBeenNthCalledWith( 1, '/path/to/site/wp-config.php', {
+			name: 'wp-config.php',
+		} );
+
+		for ( const tableName of defaultTableNames ) {
+			expect( mockArchiver.file ).toHaveBeenCalledWith(
+				`/tmp/studio_export_123/${ tableName }.sql`,
+				{ name: `sql/${ tableName }.sql` }
+			);
+		}
 	} );
 
 	it( 'should finalize the archive', async () => {

--- a/src/lib/import-export/tests/export/exporters/default-exporter.test.ts
+++ b/src/lib/import-export/tests/export/exporters/default-exporter.test.ts
@@ -73,7 +73,6 @@ describe( 'DefaultExporter', () => {
 		'wp_users',
 	];
 
-
 	( fsPromises.readdir as jest.Mock ).mockResolvedValue( mockFiles );
 	( getWordPressVersionFromInstallation as jest.Mock ).mockResolvedValue( '6.6.1' );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/dotcom-forge/issues/9932

## Proposed Changes

When exporting the site for a sync push operation, use separate files for each database table. For other export mechanisms, keep the previous behavior.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Clone https://github.com/Automattic/wp-cli-sqlite-command/pull/5 locally
2. Run `composer install --no-dev` in the `wp-cli-sqlite-command` repo
3. Replace `wp-files/sqlite-command` in the Studio repo with a symlink to your local `wp-cli-sqlite-command` repo
4. Apply 3658f-pb and 36594-pb to the Studio repo
5. Run `npm start`
6. Click on Import/Export tab
7. Click on "Export entire site"
8. Observe a zip is created
9. Unzip it
10. Ensure that the `sql` folder contains a single file for each database table

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?