### PR TITLE
Studio: Fix offline mode on push and pull buttons

### DIFF
--- a/src/components/sync-connected-sites.tsx
+++ b/src/components/sync-connected-sites.tsx
@@ -18,6 +18,7 @@ import Button from './button';
 import { ConnectCreateButtons } from './connect-create-buttons';
 import { OpenSitesSyncSelector } from './content-tab-sync';
 import { CircleRedCrossIcon } from './icons/circle-red-cross';
+import offlineIcon from './offline-icon';
 import ProgressBar from './progress-bar';
 import { SyncPullPushClear } from './sync-pull-push-clear';
 import Tooltip from './tooltip';
@@ -53,6 +54,7 @@ const SyncConnectedSitesSection = ( {
 		clearPushState,
 	} = useSyncSites();
 	const { isKeyPulling, isKeyFinished, isKeyFailed } = useSyncStatesProgressInfo();
+	const isOffline = useOffline();
 	const showPushStagingConfirmation = useConfirmationDialog( {
 		localStorageKey: 'dontShowPushConfirmation',
 		message: __( 'Overwrite Staging site' ),
@@ -248,37 +250,44 @@ const SyncConnectedSitesSection = ( {
 									! isPushError &&
 									! pushState.isInProgress &&
 									! pushState.hasFinished && (
-										<div className="flex gap-2 pl-4 ml-auto shrink-0 h-5">
-											<Button
-												variant="link"
-												className="!text-black hover:!text-a8c-blueberry"
-												onClick={ () => {
-													const detail = connectedSite.isStaging
-														? __(
-																"Pulling will replace your Studio site's files and database with a copy from your staging site."
-														  )
-														: __(
-																"Pulling will replace your Studio site's files and database with a copy from your production site."
-														  );
-													showPullConfirmation( () => pullSite( connectedSite, selectedSite ), {
-														detail,
-													} );
-												} }
-												disabled={ isAnySitePulling || isAnySitePushing }
-											>
-												<Icon icon={ cloudDownload } />
-												{ __( 'Pull' ) }
-											</Button>
-											<Button
-												variant="link"
-												className="!text-black hover:!text-a8c-blueberry"
-												onClick={ () => handlePushSite( connectedSite ) }
-												disabled={ isAnySitePulling || isAnySitePushing }
-											>
-												<Icon icon={ cloudUpload } />
-												{ __( 'Push' ) }
-											</Button>
-										</div>
+										<Tooltip
+											disabled={ ! isOffline }
+											icon={ offlineIcon }
+											text={ __( 'Pulling or pushing a site requires an internet connection.' ) }
+											placement="top-start"
+										>
+											<div className="flex gap-2 pl-4 ml-auto shrink-0 h-5">
+												<Button
+													variant="link"
+													className={ cx( ! isOffline && '!text-black hover:!text-a8c-blueberry' ) }
+													onClick={ () => {
+														const detail = connectedSite.isStaging
+															? __(
+																	"Pulling will replace your Studio site's files and database with a copy from your staging site."
+															  )
+															: __(
+																	"Pulling will replace your Studio site's files and database with a copy from your production site."
+															  );
+														showPullConfirmation( () => pullSite( connectedSite, selectedSite ), {
+															detail,
+														} );
+													} }
+													disabled={ isAnySitePulling || isAnySitePushing || isOffline }
+												>
+													<Icon icon={ cloudDownload } />
+													{ __( 'Pull' ) }
+												</Button>
+												<Button
+													variant="link"
+													className={ cx( ! isOffline && '!text-black hover:!text-a8c-blueberry' ) }
+													onClick={ () => handlePushSite( connectedSite ) }
+													disabled={ isAnySitePulling || isAnySitePushing || isOffline }
+												>
+													<Icon icon={ cloudUpload } />
+													{ __( 'Push' ) }
+												</Button>
+											</div>
+										</Tooltip>
 									) }
 							</div>
 						</div>

--- a/src/components/sync-connected-sites.tsx
+++ b/src/components/sync-connected-sites.tsx
@@ -274,6 +274,7 @@ const SyncConnectedSitesSection = ( {
 														'pull'
 													) }
 													placement="top-start"
+													disabled={ isOffline }
 												>
 													<Button
 														variant="link"
@@ -305,6 +306,7 @@ const SyncConnectedSitesSection = ( {
 														'push'
 													) }
 													placement="top-start"
+													disabled={ isOffline }
 												>
 													<Button
 														variant="link"


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

Closes https://github.com/Automattic/dotcom-forge/issues/9939

## Proposed Changes

This PR adds back the offline mode to `Pull` and `Push` buttons (it was initially added in https://github.com/Automattic/dotcom-forge/issues/9808 but unintentionally removed in https://github.com/Automattic/dotcom-forge/issues/9939 ).


<img width="1155" alt="Screenshot 2024-11-25 at 12 03 44 PM" src="https://github.com/user-attachments/assets/1a534eef-e088-4a69-9866-fa7f1d48b0a4">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
* Start Studio app with `STUDIO_SITE_SYNC=true npm start`
* Navigate to the Sync tab that has some sites connected
* Disable your internet connection (in my case, it was enough to disconnect from WiFi)
* Confirm that when you hover over `Pull` or `Push` buttons, they are disabled and you can see a tooltip with information

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
