### PR TITLE
Studio: Add periods to push and pull tooltip

### DIFF
--- a/src/components/tests/content-tab-sync.test.tsx
+++ b/src/components/tests/content-tab-sync.test.tsx
@@ -52,7 +52,7 @@ describe( 'ContentTabSync', () => {
 			getPushState: jest.fn().mockReturnValue( defaultPushState ),
 			refetchSites: jest.fn(),
 			updateTimestamp: jest.fn(),
-			getLastSyncTimeWithType: jest.fn().mockReturnValue( 'You have not pulled this site yet' ),
+			getLastSyncTimeWithType: jest.fn().mockReturnValue( 'You have not pulled this site yet.' ),
 			clearTimeout: jest.fn(),
 		} );
 	} );
@@ -127,7 +127,7 @@ describe( 'ContentTabSync', () => {
 			getPushState: jest.fn().mockReturnValue( defaultPushState ),
 			refetchSites: jest.fn(),
 			updateTimestamp: jest.fn(),
-			getLastSyncTimeWithType: jest.fn().mockReturnValue( 'You have not pulled this site yet' ),
+			getLastSyncTimeWithType: jest.fn().mockReturnValue( 'You have not pulled this site yet.' ),
 			clearTimeout: jest.fn(),
 		} );
 		renderWithProvider( <ContentTabSync selectedSite={ selectedSite } /> );
@@ -159,7 +159,7 @@ describe( 'ContentTabSync', () => {
 			getPushState: jest.fn().mockReturnValue( defaultPushState ),
 			refetchSites: jest.fn(),
 			updateTimestamp: jest.fn(),
-			getLastSyncTimeWithType: jest.fn().mockReturnValue( 'You have not pulled this site yet' ),
+			getLastSyncTimeWithType: jest.fn().mockReturnValue( 'You have not pulled this site yet.' ),
 			clearTimeout: jest.fn(),
 		} );
 		renderWithProvider( <ContentTabSync selectedSite={ selectedSite } /> );
@@ -200,7 +200,7 @@ describe( 'ContentTabSync', () => {
 			getPushState: jest.fn().mockReturnValue( defaultPushState ),
 			refetchSites: jest.fn(),
 			updateTimestamp: jest.fn(),
-			getLastSyncTimeWithType: jest.fn().mockReturnValue( 'You have not pulled this site yet' ),
+			getLastSyncTimeWithType: jest.fn().mockReturnValue( 'You have not pulled this site yet.' ),
 			clearTimeout: jest.fn(),
 		} );
 		renderWithProvider( <ContentTabSync selectedSite={ selectedSite } /> );

--- a/src/hooks/use-pull-push-timestamps.ts
+++ b/src/hooks/use-pull-push-timestamps.ts
@@ -57,12 +57,14 @@ export function usePullPushTimestamps() {
 
 			if ( ! timestamp ) {
 				return type === 'pull'
-					? __( 'You have not pulled this site yet' )
-					: __( 'You have not pushed this site yet' );
+					? __( 'You have not pulled this site yet.' )
+					: __( 'You have not pushed this site yet.' );
 			}
 
 			return sprintf(
-				type === 'pull' ? __( 'You pulled this site %s ago' ) : __( 'You pushed this site %s ago' ),
+				type === 'pull'
+					? __( 'You pulled this site %s ago.' )
+					: __( 'You pushed this site %s ago.' ),
 				formatDistanceToNow( timestamp )
 			);
 		},


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

Related to this comment: https://github.com/Automattic/studio/pull/693#pullrequestreview-2458178569

## Proposed Changes

Let's add periods at the end of the push and pull tooltip so that we are consistent with other parts of the UI.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
* Start  Studio with `STUDIO_SITE_SYNC=true npm start`
* Navigate to the `Sync` tab on Studio site A
* Click on `Connect site` and connect a WP.com site
* Navigate to the `Sync` tab on Studio site B
* Click on `Connect site` and connect the same WP.com site
* Hover over the `Pull` and `Push` buttons and confirm that you can see the `You have not pushed this site yet.` or `You have not pulled this site yet.` text
---
* Alternatively, just looks through the changes and confirm the sentences look good

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
