### PR TITLE
Studio: Fix alignment on the Share tab for header for rtl languages

### DIFF
--- a/src/components/content-tab-snapshots.tsx
+++ b/src/components/content-tab-snapshots.tsx
@@ -273,7 +273,7 @@ function EmptyGeneric( {
 		<div className="p-8 flex justify-between max-w-3xl gap-4">
 			<div className="flex flex-col">
 				<div className="a8c-subtitle mb-1">{ __( 'Share a demo site' ) }</div>
-				<div className="w-[40ch] text-a8c-gray-70 a8c-body pr-2">
+				<div className="w-[40ch] text-a8c-gray-70 a8c-body">
 					{ createInterpolateElement(
 						__(
 							'Get feedback from anyone, anywhere with a free demo site powered by <a>WordPress.com</a>.'
@@ -299,7 +299,8 @@ function EmptyGeneric( {
 						__( 'Demo sites are deleted 7 days after the last update.' ),
 					].map( ( text ) => (
 						<div key={ text } className="text-a8c-gray-70 a8c-body flex items-center">
-							<Icon className="fill-a8c-blueberry mr-2 shrink-0" icon={ check } /> { text }
+							<Icon className="fill-a8c-blueberry ltr:mr-2 rtl:ml-2 shrink-0" icon={ check } />{ ' ' }
+							{ text }
 						</div>
 					) ) }
 				</div>

--- a/src/components/content-tab-snapshots.tsx
+++ b/src/components/content-tab-snapshots.tsx
@@ -299,7 +299,7 @@ function EmptyGeneric( {
 						__( 'Demo sites are deleted 7 days after the last update.' ),
 					].map( ( text ) => (
 						<div key={ text } className="text-a8c-gray-70 a8c-body flex items-center">
-							<Icon className="fill-a8c-blueberry ltr:mr-2 rtl:ml-2 shrink-0" icon={ check } />{ ' ' }
+							<Icon className="fill-a8c-blueberry ltr:mr-2 rtl:ml-2 shrink-0" icon={ check } />
 							{ text }
 						</div>
 					) ) }

--- a/src/components/content-tab-sync.tsx
+++ b/src/components/content-tab-sync.tsx
@@ -26,7 +26,7 @@ function SiteSyncDescription( { children }: PropsWithChildren ) {
 					<div className="a8c-subtitle">{ __( 'Sync with' ) }</div>
 					<WordPressShortLogo className="ml-2 h-5" />
 				</div>
-				<div className="max-w-[40ch] text-a8c-gray-70 a8c-body pr-2">
+				<div className="max-w-[40ch] text-a8c-gray-70 a8c-body">
 					{ __(
 						'Connect an existing WordPress.com site, or create a new one and share your site with the world.'
 					) }
@@ -38,7 +38,8 @@ function SiteSyncDescription( { children }: PropsWithChildren ) {
 						__( 'Sync database and file changes.' ),
 					].map( ( text ) => (
 						<div key={ text } className="text-a8c-gray-70 a8c-body flex items-center">
-							<Icon className="fill-a8c-blueberry mr-2 shrink-0" icon={ check } /> { text }
+							<Icon className="fill-a8c-blueberry ltr:mr-2 rtl:ml-2 shrink-0" icon={ check } />{ ' ' }
+							{ text }
 						</div>
 					) ) }
 				</div>

--- a/src/components/content-tab-sync.tsx
+++ b/src/components/content-tab-sync.tsx
@@ -38,7 +38,7 @@ function SiteSyncDescription( { children }: PropsWithChildren ) {
 						__( 'Sync database and file changes.' ),
 					].map( ( text ) => (
 						<div key={ text } className="text-a8c-gray-70 a8c-body flex items-center">
-							<Icon className="fill-a8c-blueberry ltr:mr-2 rtl:ml-2 shrink-0" icon={ check } />{ ' ' }
+							<Icon className="fill-a8c-blueberry ltr:mr-2 rtl:ml-2 shrink-0" icon={ check } />
 							{ text }
 						</div>
 					) ) }

--- a/src/components/content-tab-sync.tsx
+++ b/src/components/content-tab-sync.tsx
@@ -24,7 +24,7 @@ function SiteSyncDescription( { children }: PropsWithChildren ) {
 			<div className="flex flex-col p-8">
 				<div className="flex items-center mb-1">
 					<div className="a8c-subtitle">{ __( 'Sync with' ) }</div>
-					<WordPressShortLogo className="ml-2 h-5" />
+					<WordPressShortLogo className="ltr:ml-2 rtl:mr-2 h-5" />
 				</div>
 				<div className="max-w-[40ch] text-a8c-gray-70 a8c-body">
 					{ __(


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

Closes https://github.com/Automattic/dotcom-forge/issues/9942

## Proposed Changes

This PR fixes some inconsistencies in styling on the `Share and `Sync` tabs for rtl languages:

* On the `Sync` tab, there was no space between the WordPress.com logo and the wording for rtl
* On both `Share` and `Sync` tabs the wording there was extra right padding and margin for both checkmarks and the text. 

| Before | After |
|--------|--------|
<img width="403" alt="Screenshot 2024-11-26 at 11 50 34 AM" src="https://github.com/user-attachments/assets/81ec9f6f-fe49-497e-94f4-28254b012997"> | <img width="398" alt="Screenshot 2024-11-26 at 11 50 57 AM" src="https://github.com/user-attachments/assets/bf67f7df-492b-4e21-bc2d-39e8deb7bcbb">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
* Start the app with `STUDIO_SITE_SYNC=true npm start` 
* Switch the language in Studio to rtl language e.g. Arabic or Hebrew
* Navigate to the Sync tab (ensure that you check the view when there are no sites connected)
* Confirm that there is space between `Sync` text and WordPress.com logo
* Confirm that the text and checkmarks look aligned
* Switch to the `Share` tab
* Confirm that the text and checkmarks look aligned

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
