### PR TITLE
Studio: Fix `SearchControl` margin bottom styles to ensure compatibility with the new component version

### DIFF
--- a/src/components/sync-sites-modal-selector.tsx
+++ b/src/components/sync-sites-modal-selector.tsx
@@ -110,7 +110,7 @@ function SearchSites( {
 	return (
 		<div className="flex flex-col px-8 pb-6 border-b border-a8c-gray-5">
 			<SearchControl
-				className="w-full mt-0.5"
+				className="w-full mt-0.5 mb-2"
 				placeholder={ __( 'Search sites' ) }
 				onChange={ ( value ) => {
 					setSearchQuery( value );

--- a/src/components/sync-sites-modal-selector.tsx
+++ b/src/components/sync-sites-modal-selector.tsx
@@ -117,6 +117,7 @@ function SearchSites( {
 				} }
 				value={ searchQuery }
 				autoFocus
+				__nextHasNoMarginBottom={ true }
 			/>
 			<p className="a8c-helper-text text-gray-500">
 				{ __( 'Syncing is supported for sites on the Business plan or above.' ) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/dotcom-forge/issues/9652.

## Proposed Changes

- add `__nextHasNoMarginBottom={ true }` prop that removes margin bottom built into the `SearchControl` component
- add margin bottom back using the `className` prop

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR and build the app with `STUDIO_SITE_SYNC=true npm start`.
2. Open browser inspector.
3. Navigate to the _Sync_ tab of a particular site and click on the `Connect site` button.
4. There should be no `Bottom margin styles for wp.components.SearchControl is deprecated since version 6.7 [...]` warning displayed in the console (as described in the related issue: https://github.com/Automattic/dotcom-forge/issues/9652).
5. There should still be a margin bottom separating the `SearchControl` component from the `Syncing is supported for sites on the Business plan or above.` text below. 

![Markup on 2024-11-27 at 10:40:11](https://github.com/user-attachments/assets/21f4a6ae-deee-47fc-8379-4d81f85de680)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
