### PR TITLE
Remove unused wasSiteRunning var on import flow

### DIFF
--- a/src/hooks/use-import-export.tsx
+++ b/src/hooks/use-import-export.tsx
@@ -84,7 +84,6 @@ export const ImportExportProvider = ( { children }: { children: React.ReactNode 
 				},
 			} ) );
 
-			const wasSiteRunning = selectedSite.running;
 			const handleImportError = async ( error?: unknown ) => {
 				await getIpcApi().showErrorMessageBox( {
 					title: __( 'Failed importing site' ),


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Related to https://github.com/Automattic/studio/pull/678

## Proposed Changes

- Remove unused var we overlooked when creating https://github.com/Automattic/studio/pull/678

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- See testing instructions on https://github.com/Automattic/studio/pull/678
- Run `npm run lint` observe it finishes without errors nor warnings

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
