### PR TITLE
Studio: Fix the error when Studio cannot update thumbnail for a stopped server

### DIFF
--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -344,14 +344,12 @@ export async function startServer(
 	}
 
 	if ( server.details.running ) {
-		server
-			.updateCachedThumbnail()
-			.then( () => {
-				sendThumbnailChangedEvent( event, id );
-			} )
-			.catch( ( error ) => {
-				console.error( `Failed to update thumbnail for server ${ id }:`, error );
-			} );
+		try {
+			await server.updateCachedThumbnail();
+			sendThumbnailChangedEvent( event, id );
+		} catch ( error ) {
+			console.error( `Failed to update thumbnail for server ${ id }:`, error );
+		}
 	}
 
 	console.log( 'Server started', server.details );

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -342,7 +342,17 @@ export async function startServer(
 	if ( parentWindow && ! parentWindow.isDestroyed() && ! event.sender.isDestroyed() ) {
 		parentWindow.webContents.send( 'theme-details-changed', id, server.details.themeDetails );
 	}
-	server.updateCachedThumbnail().then( () => sendThumbnailChangedEvent( event, id ) );
+
+	if ( server.details.running ) {
+		server
+			.updateCachedThumbnail()
+			.then( () => {
+				sendThumbnailChangedEvent( event, id );
+			} )
+			.catch( ( error ) => {
+				console.error( `Failed to update thumbnail for server ${ id }:`, error );
+			} );
+	}
 
 	console.log( 'Server started', server.details );
 	await updateSite( event, server.details );

--- a/src/site-server.ts
+++ b/src/site-server.ts
@@ -146,7 +146,8 @@ export class SiteServer {
 
 	async updateCachedThumbnail() {
 		if ( ! this.details.running ) {
-			throw new Error( 'Cannot update thumbnail for a stopped server' );
+			console.warn( `Thumbnail update skipped: server ${ this.details.id } is not running.` );
+			return;
 		}
 
 		const captureUrl = new URL( '/?studio-hide-adminbar', this.details.url );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

Closes https://github.com/Automattic/dotcom-forge/issues/9701

## Proposed Changes

This PR ensures that we do not attempt to update a thumbnail when the server is stopped and we skip this step. It will also clean up the Sentry logs for `Studio cannot update thumbnail for a stopped server`.

From digging in https://github.com/Automattic/dotcom-forge/issues/9701 , I discovered that the issue usually happens in relation to the `Out of memory` error related to PHP WASM in the `startServer` process and mostly on Windows machines. This can be confirmed by checking Sentry logs ([there are some linked in this comment](https://github.com/Automattic/dotcom-forge/issues/9701#issuecomment-2473643204)). It seems that the scenario where this error happens works like this:

* The server starts and `running` is set to `true`
* The process proceeds with the update of the thumbnail
* In the process of attempting the thumbnail, the server crashes and running is set to `false`
* The thumbnail update fails and throws the error `Studio cannot update thumbnail for a stopped server` logged in Sentry

I propose the following:

* Adding a check if the server is running right before attempting to call `updateCachedThumbnail`.  In that case, if the server is not running, it won’t even attempt the `updateCachedThumbnail call`, saving processing time and avoiding unnecessary logging. 
* Additionally, even though `updateCachedThumbnail` has its own safety checks, ensuring the precondition here makes the calling code more robust and explicitly documents that the thumbnail should not be updated if the server is not running. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

There is no easy way to test this. I tried triggering this error on macOs and was not able to. For now, start Studio with `npm start` and confirm that the thumbnail still gets updated correctly when you start and stop a site:

* Pull the changes from this branch
* Start Studio with `npm start`
* Start a local Studio site and confirm that the thumbnail looks good
* Open wp-admin of the local Studio site and Studio side by side
* Change a theme on a local Studio site in wp-admin and super quickly stop the server in Studio before the thumbnail has a chance to update
* Start the site and confirm the thumbnail updates

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
