### PR TITLE
Studio: Ensure the  `Disconnect` button is disabled only when the particular site is syncing

### DIFF
--- a/src/components/sync-connected-sites.tsx
+++ b/src/components/sync-connected-sites.tsx
@@ -132,10 +132,14 @@ const SyncConnectedSitesSection = ( {
 
 	const mainSite = section.connectedSites.find( ( item ) => ! item.isStaging );
 	const hasConnectionErrors = mainSite?.syncSupport !== 'already-connected';
-	const sitePullState = getPullState( selectedSite.id, section.id );
-	const isPulling = sitePullState && isKeyPulling( sitePullState.status.key );
-	const sitePushState = getPushState( selectedSite.id, section.id );
-	const isPushing = sitePushState.isInProgress;
+	const isAnySectionSitePulling = section.connectedSites.some( ( site ) => {
+		const sitePullState = getPullState( selectedSite.id, site.id );
+		return sitePullState && isKeyPulling( sitePullState.status.key );
+	} );
+	const isAnySectionSitePushing = section.connectedSites.some( ( site ) => {
+		const sitePushState = getPushState( selectedSite.id, site.id );
+		return sitePushState?.isInProgress;
+	} );
 
 	return (
 		<div key={ section.id } className="flex flex-col gap-2 mb-6">
@@ -148,7 +152,7 @@ const SyncConnectedSitesSection = ( {
 					variant="link"
 					className="!ml-auto !text-a8c-gray-70 hover:!text-a8c-red-50 "
 					onClick={ handleDisconnectSite }
-					disabled={ isPulling || isPushing }
+					disabled={ isAnySectionSitePulling || isAnySectionSitePushing }
 				>
 					{ __( 'Disconnect' ) }
 				</Button>

--- a/src/components/sync-connected-sites.tsx
+++ b/src/components/sync-connected-sites.tsx
@@ -132,6 +132,10 @@ const SyncConnectedSitesSection = ( {
 
 	const mainSite = section.connectedSites.find( ( item ) => ! item.isStaging );
 	const hasConnectionErrors = mainSite?.syncSupport !== 'already-connected';
+	const sitePullState = getPullState( selectedSite.id, section.id );
+	const isPulling = sitePullState && isKeyPulling( sitePullState.status.key );
+	const sitePushState = getPushState( selectedSite.id, section.id );
+	const isPushing = sitePushState.isInProgress;
 
 	return (
 		<div key={ section.id } className="flex flex-col gap-2 mb-6">
@@ -144,7 +148,7 @@ const SyncConnectedSitesSection = ( {
 					variant="link"
 					className="!ml-auto !text-a8c-gray-70 hover:!text-a8c-red-50 "
 					onClick={ handleDisconnectSite }
-					disabled={ isAnySitePulling || isAnySitePushing }
+					disabled={ isPulling || isPushing }
 				>
 					{ __( 'Disconnect' ) }
 				</Button>

--- a/src/components/sync-connected-sites.tsx
+++ b/src/components/sync-connected-sites.tsx
@@ -132,11 +132,11 @@ const SyncConnectedSitesSection = ( {
 
 	const mainSite = section.connectedSites.find( ( item ) => ! item.isStaging );
 	const hasConnectionErrors = mainSite?.syncSupport !== 'already-connected';
-	const isAnySectionSitePulling = section.connectedSites.some( ( site ) => {
+	const isPulling = section.connectedSites.some( ( site ) => {
 		const sitePullState = getPullState( selectedSite.id, site.id );
 		return sitePullState && isKeyPulling( sitePullState.status.key );
 	} );
-	const isAnySectionSitePushing = section.connectedSites.some( ( site ) => {
+	const isPushing = section.connectedSites.some( ( site ) => {
 		const sitePushState = getPushState( selectedSite.id, site.id );
 		return sitePushState?.isInProgress;
 	} );
@@ -152,7 +152,7 @@ const SyncConnectedSitesSection = ( {
 					variant="link"
 					className="!ml-auto !text-a8c-gray-70 hover:!text-a8c-red-50 "
 					onClick={ handleDisconnectSite }
-					disabled={ isAnySectionSitePulling || isAnySectionSitePushing }
+					disabled={ isPulling || isPushing }
 				>
 					{ __( 'Disconnect' ) }
 				</Button>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Resolves https://github.com/Automattic/dotcom-forge/issues/9993. 

## Proposed Changes

- Ensure the  `Disconnect` button is disabled only when the particular site is syncing

![Markup on 2024-11-28 at 15:57:35](https://github.com/user-attachments/assets/bbadbc0f-e961-4385-9378-8b4b08b2acd1)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR and build the app with `STUDIO_SITE_SYNC=true npm start`.
2. Connect one of your local sites with multiple WPCOM sites.
3. Initiate pull or push operation and while it is in progress, try to disconnect one of the other connected WPCOM sites.
4. It should work correctly.
5. It should not be possible to disconnect the site that is syncing.
6. The above behavior should work the same when syncing staging sites as well.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
