### PR TITLE
Suggested edits for #700

### DIFF
--- a/src/hooks/sync-sites/use-site-sync-management.ts
+++ b/src/hooks/sync-sites/use-site-sync-management.ts
@@ -4,81 +4,98 @@ import { useAuth } from '../use-auth';
 import { SyncSite, useFetchWpComSites } from '../use-fetch-wpcom-sites';
 import { useSiteDetails } from '../use-site-details';
 
-type UpToDateConnectedSitesReturn = {
-	updatedConnectedSites: SyncSite[];
-	toAdd: SyncSite[];
-	toDelete: { id: number; localSiteId: string }[];
-};
-
-export const upToDateConnectedSites = (
+/**
+ * Generate updated site data to be stored in `appdata-v1.json` in three steps:
+ *   1. Update the list of `connectedSites` with fresh data (name, URL, etc)
+ *   2. Find any staging sites that have been added to an already connected site
+ *   3. Find any connected staging sites that have been deleted on WordPress.com
+ *
+ * We treat staging sites differently from production sites because users can't connect staging
+ * sites separately from production sites (they're always connected together). So, while deleted
+ * production sites are still rendered in the UI (with a "deleted" notice), we need to automatically
+ * keep the list of staging sites up-to-date, which is where `stagingSitesToAdd` and
+ * `stagingSitesToDelete` comes in.
+ */
+export const getUpdatedConnectedSites = (
 	connectedSites: SyncSite[],
-	originalSitesFromWpCom: SyncSite[]
-): UpToDateConnectedSitesReturn => {
-	const updatedConnectedSites = connectedSites.reduce( ( acc: SyncSite[], connectedSite ) => {
-		const site = originalSitesFromWpCom.find( ( site ) => site.id === connectedSite.id );
+	freshWpComSites: SyncSite[]
+): {
+	updatedConnectedSites: SyncSite[];
+	stagingSitesToAdd: SyncSite[];
+	stagingSitesToDelete: { id: number; localSiteId: string }[];
+} => {
+	const updatedConnectedSites = connectedSites.map( ( connectedSite ): SyncSite => {
+		const site = freshWpComSites.find( ( site ) => site.id === connectedSite.id );
 
 		if ( ! site ) {
-			acc.push( {
+			return {
 				...connectedSite,
 				syncSupport: 'deleted',
-			} );
-		} else {
-			acc.push( {
-				...connectedSite,
-				name: site.name,
-				url: site.url,
-				syncSupport: site.syncSupport,
-				stagingSiteIds: site.stagingSiteIds,
-			} );
+			};
 		}
 
-		return acc;
+		return {
+			...connectedSite,
+			name: site.name,
+			url: site.url,
+			syncSupport: site.syncSupport,
+			stagingSiteIds: site.stagingSiteIds,
+		};
 	}, [] );
 
-	const { toAdd, toDelete } = connectedSites.reduce(
-		( acc: Omit< UpToDateConnectedSitesReturn, 'updatedConnectedSites' >, prevSiteState ) => {
-			const newSiteState = updatedConnectedSites.find( ( site ) => site.id === prevSiteState.id );
+	const stagingSitesToAdd = connectedSites.flatMap( ( connectedSite ) => {
+		const updatedConnectedSite = updatedConnectedSites.find(
+			( site ) => site.id === connectedSite.id
+		);
 
-			if ( ! prevSiteState.stagingSiteIds.length && ! newSiteState?.stagingSiteIds.length ) {
-				return acc;
+		if ( ! updatedConnectedSite?.stagingSiteIds.length ) {
+			return [];
+		}
+
+		const addedStagingSiteIds = updatedConnectedSite.stagingSiteIds.filter(
+			( id ) => ! connectedSite.stagingSiteIds.includes( id )
+		);
+
+		return addedStagingSiteIds.flatMap( ( id ): SyncSite[] => {
+			const freshSite = freshWpComSites.find( ( site ) => site.id === id );
+
+			if ( ! freshSite ) {
+				return [];
 			}
 
-			const toAdd =
-				newSiteState?.stagingSiteIds
-					.filter( ( id ) => ! prevSiteState.stagingSiteIds.includes( id ) )
-					.reduce( ( acc: SyncSite[], id ) => {
-						const site = originalSitesFromWpCom.find( ( site ) => site.id === id );
+			return [
+				{
+					...freshSite,
+					localSiteId: connectedSite.localSiteId,
+					syncSupport: 'already-connected',
+				},
+			];
+		}, [] );
+	} );
 
-						if ( site ) {
-							acc.push( {
-								...site,
-								localSiteId: prevSiteState.localSiteId,
-								syncSupport: 'already-connected',
-							} );
-						}
+	const stagingSitesToDelete = connectedSites.flatMap( ( connectedSite ) => {
+		const updatedConnectedSite = updatedConnectedSites.find(
+			( site ) => site.id === connectedSite.id
+		);
 
-						return acc;
-					}, [] ) || [];
+		if ( ! connectedSite?.stagingSiteIds.length ) {
+			return [];
+		}
 
-			const toDelete = prevSiteState.stagingSiteIds
-				.filter( ( id ) => ! newSiteState?.stagingSiteIds.includes( id ) )
-				.map( ( id ) => ( {
+		return connectedSite.stagingSiteIds
+			.filter( ( id ) => ! updatedConnectedSite?.stagingSiteIds.includes( id ) )
+			.map( ( id ) => {
+				return {
 					id,
-					localSiteId: prevSiteState.localSiteId,
-				} ) );
-
-			acc.toAdd.push( ...toAdd );
-			acc.toDelete.push( ...toDelete );
-
-			return acc;
-		},
-		{ toAdd: [], toDelete: [] }
-	);
+					localSiteId: connectedSite.localSiteId,
+				};
+			} );
+	} );
 
 	return {
 		updatedConnectedSites,
-		toAdd,
-		toDelete,
+		stagingSitesToAdd,
+		stagingSitesToDelete,
 	};
 };
 
@@ -126,15 +143,13 @@ export const useSiteSyncManagement = ( {
 		getIpcApi()
 			.getConnectedWpcomSites()
 			.then( async ( allConnectedSites ) => {
-				const { updatedConnectedSites, toAdd, toDelete } = upToDateConnectedSites(
-					allConnectedSites,
-					syncSites
-				);
+				const { updatedConnectedSites, stagingSitesToAdd, stagingSitesToDelete } =
+					getUpdatedConnectedSites( allConnectedSites, syncSites );
 
 				await getIpcApi().updateConnectedWpcomSites( updatedConnectedSites );
 
-				if ( toDelete.length ) {
-					const data = toDelete.map( ( { id, localSiteId } ) => ( {
+				if ( stagingSitesToDelete.length ) {
+					const data = stagingSitesToDelete.map( ( { id, localSiteId } ) => ( {
 						siteIds: [ id ],
 						localSiteId,
 					} ) );
@@ -142,8 +157,8 @@ export const useSiteSyncManagement = ( {
 					await getIpcApi().disconnectWpcomSite( data );
 				}
 
-				if ( toAdd.length ) {
-					const data = toAdd.map( ( site ) => ( {
+				if ( stagingSitesToAdd.length ) {
+					const data = stagingSitesToAdd.map( ( site ) => ( {
 						sites: [ site ],
 						localSiteId: site.localSiteId,
 					} ) );

--- a/src/hooks/tests/up-to-date-connected-sites.test.ts
+++ b/src/hooks/tests/up-to-date-connected-sites.test.ts
@@ -1,4 +1,4 @@
-import { upToDateConnectedSites } from '../sync-sites/use-site-sync-management';
+import { getUpdatedConnectedSites } from '../sync-sites/use-site-sync-management';
 import { SyncSite } from '../use-fetch-wpcom-sites';
 
 describe( 'upToDateConnectedSites', () => {
@@ -25,7 +25,7 @@ describe( 'upToDateConnectedSites', () => {
 				syncSupport: 'unsupported',
 			},
 		];
-		const result = upToDateConnectedSites( connectedSites, originalSitesFromWpCom );
+		const result = getUpdatedConnectedSites( connectedSites, originalSitesFromWpCom );
 		expect( result.updatedConnectedSites ).toEqual( [ originalSitesFromWpCom[ 0 ] ] );
 	} );
 
@@ -61,14 +61,14 @@ describe( 'upToDateConnectedSites', () => {
 				syncSupport: 'syncable',
 			},
 		];
-		const result = upToDateConnectedSites( connectedSites, originalSitesFromWpCom );
-		expect( result.toAdd ).toEqual( [
+		const result = getUpdatedConnectedSites( connectedSites, originalSitesFromWpCom );
+		expect( result.stagingSitesToAdd ).toEqual( [
 			{
 				...originalSitesFromWpCom[ 1 ],
 				syncSupport: 'already-connected',
 			},
 		] );
-		expect( result.toDelete ).toEqual( [] );
+		expect( result.stagingSitesToDelete ).toEqual( [] );
 	} );
 
 	test( 'should delete staging site, if it was removed in wordpress.com', () => {
@@ -103,9 +103,9 @@ describe( 'upToDateConnectedSites', () => {
 				syncSupport: 'already-connected',
 			},
 		];
-		const result = upToDateConnectedSites( connectedSites, originalSitesFromWpCom );
-		expect( result.toDelete ).toEqual( [ { id: 2, localSiteId: 'local-site-id' } ] );
-		expect( result.toAdd ).toEqual( [] );
+		const result = getUpdatedConnectedSites( connectedSites, originalSitesFromWpCom );
+		expect( result.stagingSitesToDelete ).toEqual( [ { id: 2, localSiteId: 'local-site-id' } ] );
+		expect( result.stagingSitesToAdd ).toEqual( [] );
 	} );
 
 	test( 'should add new staging site and delete the old one, if staging site was recreated in wordpress.com', () => {
@@ -149,9 +149,9 @@ describe( 'upToDateConnectedSites', () => {
 				syncSupport: 'syncable',
 			},
 		];
-		const result = upToDateConnectedSites( connectedSites, originalSitesFromWpCom );
-		expect( result.toDelete ).toEqual( [ { id: 2, localSiteId: 'local-site-id' } ] );
-		expect( result.toAdd ).toEqual( [
+		const result = getUpdatedConnectedSites( connectedSites, originalSitesFromWpCom );
+		expect( result.stagingSitesToDelete ).toEqual( [ { id: 2, localSiteId: 'local-site-id' } ] );
+		expect( result.stagingSitesToAdd ).toEqual( [
 			{
 				...originalSitesFromWpCom[ 1 ],
 				syncSupport: 'already-connected',
@@ -200,9 +200,9 @@ describe( 'upToDateConnectedSites', () => {
 				syncSupport: 'already-connected',
 			},
 		];
-		const result = upToDateConnectedSites( connectedSites, originalSitesFromWpCom );
-		expect( result.toDelete ).toEqual( [] );
-		expect( result.toAdd ).toEqual( [] );
+		const result = getUpdatedConnectedSites( connectedSites, originalSitesFromWpCom );
+		expect( result.stagingSitesToDelete ).toEqual( [] );
+		expect( result.stagingSitesToAdd ).toEqual( [] );
 	} );
 
 	test( 'should add staging site, if original site was initially connected to two different local sites, but initially w/o staging site', () => {
@@ -264,8 +264,8 @@ describe( 'upToDateConnectedSites', () => {
 				syncSupport: 'syncable',
 			},
 		];
-		const result = upToDateConnectedSites( connectedSites, originalSitesFromWpCom );
-		expect( result.toAdd ).toEqual( [
+		const result = getUpdatedConnectedSites( connectedSites, originalSitesFromWpCom );
+		expect( result.stagingSitesToAdd ).toEqual( [
 			{
 				...originalSitesFromWpCom[ 2 ],
 				syncSupport: 'already-connected',
@@ -275,7 +275,7 @@ describe( 'upToDateConnectedSites', () => {
 				syncSupport: 'already-connected',
 			},
 		] );
-		expect( result.toDelete ).toEqual( [] );
+		expect( result.stagingSitesToDelete ).toEqual( [] );
 		expect( result.updatedConnectedSites ).toEqual( [
 			{
 				...originalSitesFromWpCom[ 0 ],
@@ -346,7 +346,7 @@ describe( 'upToDateConnectedSites', () => {
 				syncSupport: 'already-connected',
 			},
 		];
-		const result = upToDateConnectedSites( connectedSites, originalSitesFromWpCom );
+		const result = getUpdatedConnectedSites( connectedSites, originalSitesFromWpCom );
 		expect( result.updatedConnectedSites ).toEqual( [
 			{
 				...originalSitesFromWpCom[ 0 ],
@@ -365,7 +365,7 @@ describe( 'upToDateConnectedSites', () => {
 				syncSupport: 'deleted',
 			},
 		] );
-		expect( result.toDelete ).toEqual( [
+		expect( result.stagingSitesToDelete ).toEqual( [
 			{
 				id: 2,
 				localSiteId: 'local-site-id-1',
@@ -375,6 +375,6 @@ describe( 'upToDateConnectedSites', () => {
 				localSiteId: 'local-site-id-2',
 			},
 		] );
-		expect( result.toAdd ).toEqual( [] );
+		expect( result.stagingSitesToAdd ).toEqual( [] );
 	} );
 } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

Suggested edits for #700

## Proposed Changes

- Rename `upToDateConnectedSites` to `getUpdatedConnectedSites`.
- Generate `updatedConnectedSites`, `stagingSitesToAdd`, and `stagingSitesToDelete` by mapping directly over `connectedSites` instead of generating those arrays in multiple steps. Helps simplify the code.
- Rename some variables for greater consistency.
- Add a docblock comment to `getUpdatedConnectedSites` to help explain what it does.
- More use of `map` and `flatMap` instead of `reduce`. This isn't critical, but I think it helps simplify the code.
