### PR TITLE
Studio: Output proper message on push error

### DIFF
--- a/src/hooks/sync-sites/use-sync-push.ts
+++ b/src/hooks/sync-sites/use-sync-push.ts
@@ -74,6 +74,23 @@ export function useSyncPush( {
 		]
 	);
 
+	const getErrorFromResponse = ( error: unknown ): string => {
+		const defaultErrorMessage = __(
+			'Studio was unable to connect to WordPress.com. Please try again.'
+		);
+
+		if (
+			typeof error === 'object' &&
+			error !== null &&
+			'error' in error &&
+			typeof ( error as { error: unknown } ).error === 'string'
+		) {
+			return ( error as { error: string } ).error;
+		}
+
+		return defaultErrorMessage;
+	};
+
 	const pushSite = useCallback(
 		async ( connectedSite: SyncSite, selectedSite: SiteDetails ) => {
 			if ( ! client ) {
@@ -129,10 +146,7 @@ export function useSyncPush( {
 				updatePushState( selectedSite.id, remoteSiteId, {
 					status: pushStatesProgressInfo.failed,
 				} );
-				let errorMessage = __( 'Studio was unable to connect to WordPress.com. Please try again.' );
-				if ( typeof error === 'object' && error !== null && 'error' in error ) {
-					errorMessage = ( error as { error: string } ).error || errorMessage;
-				}
+				const errorMessage = getErrorFromResponse( error );
 				getIpcApi().showErrorMessageBox( {
 					title: sprintf( __( 'Error pushing to %s' ), connectedSite.name ),
 					message: errorMessage,

--- a/src/hooks/sync-sites/use-sync-push.ts
+++ b/src/hooks/sync-sites/use-sync-push.ts
@@ -142,10 +142,9 @@ export function useSyncPush( {
 				updatePushState( selectedSite.id, remoteSiteId, {
 					status: pushStatesProgressInfo.failed,
 				} );
-				const errorMessage = getErrorFromResponse( error );
 				getIpcApi().showErrorMessageBox( {
 					title: sprintf( __( 'Error pushing to %s' ), connectedSite.name ),
-					message: errorMessage,
+					message: getErrorFromResponse( error ),
 				} );
 			} finally {
 				await getIpcApi().removeTemporalFile( archivePath );

--- a/src/hooks/sync-sites/use-sync-push.ts
+++ b/src/hooks/sync-sites/use-sync-push.ts
@@ -75,10 +75,6 @@ export function useSyncPush( {
 	);
 
 	const getErrorFromResponse = ( error: unknown ): string => {
-		const defaultErrorMessage = __(
-			'Studio was unable to connect to WordPress.com. Please try again.'
-		);
-
 		if (
 			typeof error === 'object' &&
 			error !== null &&
@@ -88,7 +84,7 @@ export function useSyncPush( {
 			return ( error as { error: string } ).error;
 		}
 
-		return defaultErrorMessage;
+		return __( 'Studio was unable to connect to WordPress.com. Please try again.' );
 	};
 
 	const pushSite = useCallback(

--- a/src/hooks/sync-sites/use-sync-push.ts
+++ b/src/hooks/sync-sites/use-sync-push.ts
@@ -129,9 +129,13 @@ export function useSyncPush( {
 				updatePushState( selectedSite.id, remoteSiteId, {
 					status: pushStatesProgressInfo.failed,
 				} );
+				let errorMessage = __( 'Studio was unable to connect to WordPress.com. Please try again.' );
+				if ( typeof error === 'object' && error !== null && 'error' in error ) {
+					errorMessage = ( error as { error: string } ).error || errorMessage;
+				}
 				getIpcApi().showErrorMessageBox( {
 					title: sprintf( __( 'Error pushing to %s' ), connectedSite.name ),
-					message: __( 'Studio was unable to connect to WordPress.com. Please try again.' ),
+					message: errorMessage,
 				} );
 			} finally {
 				await getIpcApi().removeTemporalFile( archivePath );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Related to https://github.com/Automattic/dotcom-forge/issues/10009.

## Proposed Changes

- output relevant message on push error

![Markup on 2024-12-02 at 15:43:13](https://github.com/user-attachments/assets/622c2fef-9de0-4c46-8cf7-2cde3a752941)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Apply the backend diff (D167588-code) to your sandbox and sandbox `public-api.wordpress.com`.
2. Check out this PR and build the app with `npm start`.
3. Navigate to the Sync tab and make sure you have a WPCOM site **with its staging site** connected.
4. While at the staging site settings tab (`https://wordpress.com/staging-site/{site-slug}`), initiate a sync from staging to production.
5. Head back to the Sync tab in Studio and try to initiate a push operation.
6. After some time, a dialog with relevant error message should display (as can be seen in the screenshot above).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?