### PR TITLE
Studio: Visual adjustments to Sync tab footer

### DIFF
--- a/src/components/sync-connected-sites.tsx
+++ b/src/components/sync-connected-sites.tsx
@@ -400,7 +400,7 @@ export function SyncConnectedSites( {
 				) ) }
 			</div>
 
-			<div className="flex mt-auto gap-4 py-5 px-8 border-t border-a8c-gray-5 flex-shrink-0">
+			<div className="flex mt-auto gap-4 pt-4 pb-5 px-8 border-t border-a8c-gray-5 flex-shrink-0">
 				<ConnectCreateButtons
 					connectSite={ openSitesSyncSelector }
 					isOffline={ isOffline }

--- a/src/components/sync-connected-sites.tsx
+++ b/src/components/sync-connected-sites.tsx
@@ -400,7 +400,7 @@ export function SyncConnectedSites( {
 				) ) }
 			</div>
 
-			<div className="flex mt-auto gap-4 pt-4 pb-5 px-8 border-t border-a8c-gray-5 flex-shrink-0">
+			<div className="flex mt-auto gap-4 pt-5 pb-4 px-8 border-t border-a8c-gray-5 flex-shrink-0">
 				<ConnectCreateButtons
 					connectSite={ openSitesSyncSelector }
 					isOffline={ isOffline }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

Closes https://github.com/Automattic/dotcom-forge/issues/9997

## Proposed Changes

This PR aligns the buttons `Connect site` and `Create new site` and the line above them with the `Add site` button on the `Sync` tab in Studio.

**Before**

<img width="1343" alt="Screenshot 2024-12-03 at 9 25 31 AM" src="https://github.com/user-attachments/assets/7f1ecf17-1832-430a-86a9-b757d78b4d72"> 

**After**

<img width="1346" alt="Screenshot 2024-12-03 at 9 24 29 AM" src="https://github.com/user-attachments/assets/2015da76-dc0b-48a8-91af-820067c903d8">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
* Start Studio with `STUDIO_SITE_SYNC=true npm start`
* Navigate to the `Sync` tab
* Make sure that at least one site is connected there
* Observe that `Create a new site` and `Connect site` at the bottom are aligned with the `Add site` button in the sidebar
* Observe that the line above these buttons is aligned with the line in the sidebar (to me personally, it looks like the line is slightly higher but I measured the x-axis and it is actually aligned 😅 )

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
