### PR TITLE
Display confirmation when quitting while active push/pull

### DIFF
--- a/src/hooks/sync-sites/use-pull-push-states.ts
+++ b/src/hooks/sync-sites/use-pull-push-states.ts
@@ -1,5 +1,8 @@
 import { useCallback } from 'react';
 
+export const generateStateId = ( selectedSiteId: string, remoteSiteId: number ) =>
+	`${ selectedSiteId }-${ remoteSiteId }`;
+
 export function usePullPushStates< T >(
 	states: Record< string, T >,
 	setStates: React.Dispatch< React.SetStateAction< Record< string, T > > >
@@ -8,8 +11,8 @@ export function usePullPushStates< T >(
 		( selectedSiteId: string, remoteSiteId: number, state: Partial< T > ) => {
 			setStates( ( prevStates ) => ( {
 				...prevStates,
-				[ `${ selectedSiteId }-${ remoteSiteId }` ]: {
-					...prevStates[ `${ selectedSiteId }-${ remoteSiteId }` ],
+				[ generateStateId( selectedSiteId, remoteSiteId ) ]: {
+					...prevStates[ generateStateId( selectedSiteId, remoteSiteId ) ],
 					...state,
 				},
 			} ) );
@@ -19,7 +22,7 @@ export function usePullPushStates< T >(
 
 	const getState = useCallback(
 		( selectedSiteId: string, remoteSiteId: number ): T | undefined => {
-			return states[ `${ selectedSiteId }-${ remoteSiteId }` ];
+			return states[ generateStateId( selectedSiteId, remoteSiteId ) ];
 		},
 		[ states ]
 	);
@@ -28,7 +31,7 @@ export function usePullPushStates< T >(
 		( selectedSiteId: string, remoteSiteId: number ) => {
 			setStates( ( prevStates ) => {
 				const newStates = { ...prevStates };
-				delete newStates[ `${ selectedSiteId }-${ remoteSiteId }` ];
+				delete newStates[ generateStateId( selectedSiteId, remoteSiteId ) ];
 				return newStates;
 			} );
 		},

--- a/src/hooks/sync-sites/use-sync-pull.ts
+++ b/src/hooks/sync-sites/use-sync-pull.ts
@@ -8,7 +8,7 @@ import { SyncSite } from '../use-fetch-wpcom-sites';
 import { useImportExport } from '../use-import-export';
 import { useSiteDetails } from '../use-site-details';
 import { useSyncStatesProgressInfo, PullStateProgressInfo } from '../use-sync-states-progress-info';
-import { usePullPushStates } from './use-pull-push-states';
+import { generateStateId, usePullPushStates } from './use-pull-push-states';
 
 export type SyncBackupState = {
 	remoteSiteId: number;
@@ -29,12 +29,35 @@ export function useSyncPull( {
 	const { __ } = useI18n();
 	const { client } = useAuth();
 	const { importFile, clearImportState } = useImportExport();
-	const { pullStatesProgressInfo, isKeyPulling } = useSyncStatesProgressInfo();
+	const { pullStatesProgressInfo, isKeyPulling, isKeyFinished, isKeyFailed } =
+		useSyncStatesProgressInfo();
 	const {
-		updateState: updatePullState,
+		updateState,
 		getState: getPullState,
-		clearState: clearPullState,
+		clearState,
 	} = usePullPushStates< SyncBackupState >( pullStates, setPullStates );
+
+	const updatePullState: typeof updateState = useCallback(
+		( selectedSiteId, remoteSiteId, state ) => {
+			updateState( selectedSiteId, remoteSiteId, state );
+			const statusKey = state.status?.key;
+
+			if ( isKeyFailed( statusKey ) || isKeyFinished( statusKey ) ) {
+				getIpcApi().clearPushPullOperation( generateStateId( selectedSiteId, remoteSiteId ) );
+			} else {
+				getIpcApi().addPushPullOperation( generateStateId( selectedSiteId, remoteSiteId ) );
+			}
+		},
+		[ isKeyFailed, isKeyFinished, updateState ]
+	);
+
+	const clearPullState: typeof clearState = useCallback(
+		( selectedSiteId, remoteSiteId ) => {
+			clearState( selectedSiteId, remoteSiteId );
+			getIpcApi().clearPushPullOperation( generateStateId( selectedSiteId, remoteSiteId ) );
+		},
+		[ clearState ]
+	);
 
 	const { startServer } = useSiteDetails();
 

--- a/src/hooks/sync-sites/use-sync-pull.ts
+++ b/src/hooks/sync-sites/use-sync-pull.ts
@@ -43,9 +43,9 @@ export function useSyncPull( {
 			const statusKey = state.status?.key;
 
 			if ( isKeyFailed( statusKey ) || isKeyFinished( statusKey ) ) {
-				getIpcApi().clearPushPullOperation( generateStateId( selectedSiteId, remoteSiteId ) );
+				getIpcApi().clearSyncOperation( generateStateId( selectedSiteId, remoteSiteId ) );
 			} else {
-				getIpcApi().addPushPullOperation( generateStateId( selectedSiteId, remoteSiteId ) );
+				getIpcApi().addSyncOperation( generateStateId( selectedSiteId, remoteSiteId ) );
 			}
 		},
 		[ isKeyFailed, isKeyFinished, updateState ]
@@ -54,7 +54,7 @@ export function useSyncPull( {
 	const clearPullState: typeof clearState = useCallback(
 		( selectedSiteId, remoteSiteId ) => {
 			clearState( selectedSiteId, remoteSiteId );
-			getIpcApi().clearPushPullOperation( generateStateId( selectedSiteId, remoteSiteId ) );
+			getIpcApi().clearSyncOperation( generateStateId( selectedSiteId, remoteSiteId ) );
 		},
 		[ clearState ]
 	);

--- a/src/hooks/sync-sites/use-sync-push.ts
+++ b/src/hooks/sync-sites/use-sync-push.ts
@@ -38,9 +38,9 @@ export function useSyncPush( {
 			const statusKey = state.status?.key;
 
 			if ( isKeyFailed( statusKey ) || isKeyFinished( statusKey ) ) {
-				getIpcApi().clearPushPullOperation( generateStateId( selectedSiteId, remoteSiteId ) );
+				getIpcApi().clearSyncOperation( generateStateId( selectedSiteId, remoteSiteId ) );
 			} else {
-				getIpcApi().addPushPullOperation( generateStateId( selectedSiteId, remoteSiteId ) );
+				getIpcApi().addSyncOperation( generateStateId( selectedSiteId, remoteSiteId ) );
 			}
 		},
 		[ isKeyFailed, isKeyFinished, updateState ]
@@ -49,7 +49,7 @@ export function useSyncPush( {
 	const clearPushState: typeof clearState = useCallback(
 		( selectedSiteId, remoteSiteId ) => {
 			clearState( selectedSiteId, remoteSiteId );
-			getIpcApi().clearPushPullOperation( generateStateId( selectedSiteId, remoteSiteId ) );
+			getIpcApi().clearSyncOperation( generateStateId( selectedSiteId, remoteSiteId ) );
 		},
 		[ clearState ]
 	);

--- a/src/hooks/sync-sites/use-sync-push.ts
+++ b/src/hooks/sync-sites/use-sync-push.ts
@@ -7,7 +7,7 @@ import { getIpcApi } from '../../lib/get-ipc-api';
 import { useAuth } from '../use-auth';
 import { SyncSite } from '../use-fetch-wpcom-sites';
 import { useSyncStatesProgressInfo, PushStateProgressInfo } from '../use-sync-states-progress-info';
-import { usePullPushStates } from './use-pull-push-states';
+import { generateStateId, usePullPushStates } from './use-pull-push-states';
 
 export type SyncPushState = {
 	remoteSiteId: number;
@@ -25,13 +25,34 @@ export function useSyncPush( {
 } ) {
 	const { __ } = useI18n();
 	const { client } = useAuth();
-	const {
-		updateState: updatePushState,
-		getState,
-		clearState: clearPushState,
-	} = usePullPushStates< SyncPushState >( pushStates, setPushStates );
+	const { updateState, getState, clearState } = usePullPushStates< SyncPushState >(
+		pushStates,
+		setPushStates
+	);
 	const { pushStatesProgressInfo, isKeyPushing, isKeyFinished, isKeyFailed } =
 		useSyncStatesProgressInfo();
+
+	const updatePushState: typeof updateState = useCallback(
+		( selectedSiteId, remoteSiteId, state ) => {
+			updateState( selectedSiteId, remoteSiteId, state );
+			const statusKey = state.status?.key;
+
+			if ( isKeyFailed( statusKey ) || isKeyFinished( statusKey ) ) {
+				getIpcApi().clearPushPullOperation( generateStateId( selectedSiteId, remoteSiteId ) );
+			} else {
+				getIpcApi().addPushPullOperation( generateStateId( selectedSiteId, remoteSiteId ) );
+			}
+		},
+		[ isKeyFailed, isKeyFinished, updateState ]
+	);
+
+	const clearPushState: typeof clearState = useCallback(
+		( selectedSiteId, remoteSiteId ) => {
+			clearState( selectedSiteId, remoteSiteId );
+			getIpcApi().clearPushPullOperation( generateStateId( selectedSiteId, remoteSiteId ) );
+		},
+		[ clearState ]
+	);
 
 	const getPushProgressInfo = useCallback(
 		async ( remoteSiteId: number, syncPushState: SyncPushState ) => {

--- a/src/hooks/use-sync-states-progress-info.ts
+++ b/src/hooks/use-sync-states-progress-info.ts
@@ -1,5 +1,5 @@
 import { useI18n } from '@wordpress/react-i18n';
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 
 export type PullStateProgressInfo = {
 	key: 'in-progress' | 'downloading' | 'importing' | 'finished' | 'failed';
@@ -99,17 +99,19 @@ export function useSyncStatesProgressInfo() {
 		return pushingStateKeys.includes( key );
 	};
 
-	const isKeyFinished = (
-		key: PullStateProgressInfo[ 'key' ] | PushStateProgressInfo[ 'key' ] | undefined
-	) => {
-		return key === 'finished';
-	};
+	const isKeyFinished = useCallback(
+		( key: PullStateProgressInfo[ 'key' ] | PushStateProgressInfo[ 'key' ] | undefined ) => {
+			return key === 'finished';
+		},
+		[]
+	);
 
-	const isKeyFailed = (
-		key: PullStateProgressInfo[ 'key' ] | PushStateProgressInfo[ 'key' ] | undefined
-	) => {
-		return key === 'failed';
-	};
+	const isKeyFailed = useCallback(
+		( key: PullStateProgressInfo[ 'key' ] | PushStateProgressInfo[ 'key' ] | undefined ) => {
+			return key === 'failed';
+		},
+		[]
+	);
 
 	return {
 		pullStatesProgressInfo,

--- a/src/hooks/use-window-listener.ts
+++ b/src/hooks/use-window-listener.ts
@@ -1,6 +1,9 @@
 import { useEffect } from 'react';
 
-export function useWindowListener( type: keyof WindowEventMap, callback: () => void ) {
+export function useWindowListener(
+	type: keyof WindowEventMap,
+	callback: Parameters< typeof window.addEventListener >[ 1 ]
+) {
 	useEffect( () => {
 		window.addEventListener( type, callback );
 		return () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import {
 	type IpcMainInvokeEvent,
 	globalShortcut,
 	Menu,
+	dialog,
 } from 'electron';
 import path from 'path';
 import * as Sentry from '@sentry/electron/main';
@@ -301,6 +302,30 @@ async function appBoot() {
 
 	app.on( 'will-quit', () => {
 		globalShortcut.unregisterAll();
+	} );
+
+	app.on( 'before-quit', ( event ) => {
+		if ( ! ipcHandlers.hasActivePushPullOperations() ) {
+			return;
+		}
+
+		const QUIT_APP_BUTTON_INDEX = 0;
+		const CANCEL_BUTTON_INDEX = 1;
+
+		const clickedButtonIndex = dialog.showMessageBoxSync( {
+			message: __( 'Pull or push operation in progress' ),
+			detail: __(
+				'There’s a pull or push operation in progress. Quitting the app will abort that operation. Are you sure?'
+			),
+			buttons: [ __( 'Yes, quit the app' ), __( 'No, take me back' ) ],
+			cancelId: CANCEL_BUTTON_INDEX,
+			defaultId: QUIT_APP_BUTTON_INDEX,
+			type: 'warning',
+		} );
+
+		if ( clickedButtonIndex === CANCEL_BUTTON_INDEX ) {
+			event.preventDefault();
+		}
 	} );
 
 	app.on( 'quit', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -315,7 +315,7 @@ async function appBoot() {
 		const clickedButtonIndex = dialog.showMessageBoxSync( {
 			message: __( 'Sync in progress' ),
 			detail: __(
-				'There’s a sync operation in progress. Quitting the app will abort that operation. Are you sure?'
+				'There’s a sync operation in progress. Quitting the app will abort that operation. Are you sure you want to quit?'
 			),
 			buttons: [ __( 'Yes, quit the app' ), __( 'No, take me back' ) ],
 			cancelId: CANCEL_BUTTON_INDEX,

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ import { __ } from '@wordpress/i18n';
 import packageJson from '../package.json';
 import { PROTOCOL_PREFIX } from './constants';
 import * as ipcHandlers from './ipc-handlers';
-import { hasActivePushPullOperations } from './lib/active-push-pull-operations';
+import { hasActiveSyncOperations } from './lib/active-sync-operations';
 import { getPlatformName } from './lib/app-globals';
 import { bumpAggregatedUniqueStat, bumpStat } from './lib/bump-stats';
 import {
@@ -306,7 +306,7 @@ async function appBoot() {
 	} );
 
 	app.on( 'before-quit', ( event ) => {
-		if ( ! hasActivePushPullOperations() ) {
+		if ( ! hasActiveSyncOperations() ) {
 			return;
 		}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -313,9 +313,9 @@ async function appBoot() {
 		const CANCEL_BUTTON_INDEX = 1;
 
 		const clickedButtonIndex = dialog.showMessageBoxSync( {
-			message: __( 'Pull or push operation in progress' ),
+			message: __( 'Sync in progress' ),
 			detail: __(
-				'There’s a pull or push operation in progress. Quitting the app will abort that operation. Are you sure?'
+				'There’s a sync operation in progress. Quitting the app will abort that operation. Are you sure?'
 			),
 			buttons: [ __( 'Yes, quit the app' ), __( 'No, take me back' ) ],
 			cancelId: CANCEL_BUTTON_INDEX,

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import { __ } from '@wordpress/i18n';
 import packageJson from '../package.json';
 import { PROTOCOL_PREFIX } from './constants';
 import * as ipcHandlers from './ipc-handlers';
+import { hasActivePushPullOperations } from './lib/active-push-pull-operations';
 import { getPlatformName } from './lib/app-globals';
 import { bumpAggregatedUniqueStat, bumpStat } from './lib/bump-stats';
 import {
@@ -305,7 +306,7 @@ async function appBoot() {
 	} );
 
 	app.on( 'before-quit', ( event ) => {
-		if ( ! ipcHandlers.hasActivePushPullOperations() ) {
+		if ( ! hasActivePushPullOperations() ) {
 			return;
 		}
 

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -19,7 +19,7 @@ import archiver from 'archiver';
 import { DEFAULT_PHP_VERSION } from '../vendor/wp-now/src/constants';
 import { MAIN_MIN_WIDTH, SIDEBAR_WIDTH } from './constants';
 import { SyncSite } from './hooks/use-fetch-wpcom-sites';
-import { ACTIVE_PUSH_PULL_OPERATIONS } from './lib/active-push-pull-operations';
+import { ACTIVE_SYNC_OPERATIONS } from './lib/active-sync-operations';
 import { download } from './lib/download';
 import { isEmptyDir, pathExists, isWordPressDirectory, sanitizeFolderName } from './lib/fs-utils';
 import { getImageData } from './lib/get-image-data';
@@ -1008,13 +1008,13 @@ export async function isImportExportSupported( _event: IpcMainInvokeEvent, siteI
 /**
  * Store the ID of a push/pull operation in a deduped set.
  */
-export function addPushPullOperation( event: IpcMainInvokeEvent, id: string ) {
-	ACTIVE_PUSH_PULL_OPERATIONS.add( id );
+export function addSyncOperation( event: IpcMainInvokeEvent, id: string ) {
+	ACTIVE_SYNC_OPERATIONS.add( id );
 }
 
 /**
  * Clear the ID of a push/pull operation.
  */
-export function clearPushPullOperation( event: IpcMainInvokeEvent, id: string ) {
-	ACTIVE_PUSH_PULL_OPERATIONS.delete( id );
+export function clearSyncOperation( event: IpcMainInvokeEvent, id: string ) {
+	ACTIVE_SYNC_OPERATIONS.delete( id );
 }

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -1003,3 +1003,28 @@ export async function isImportExportSupported( _event: IpcMainInvokeEvent, siteI
 	}
 	return site.hasSQLitePlugin();
 }
+
+const ACTIVE_PUSH_PULL_OPERATIONS = new Set();
+
+/**
+ * Store the ID of a push/pull operation in a deduped set.
+ */
+export function addPushPullOperation( event: IpcMainInvokeEvent, id: string ) {
+	ACTIVE_PUSH_PULL_OPERATIONS.add( id );
+}
+
+/**
+ * Clear the ID of a push/pull operation.
+ */
+export function clearPushPullOperation( event: IpcMainInvokeEvent, id: string ) {
+	ACTIVE_PUSH_PULL_OPERATIONS.delete( id );
+}
+
+/**
+ * Determine if the set of active push/pull operations has any members. Note that this function
+ * isn't exposed to the renderer process even if it lives in `ipc-handlers`, because it's only
+ * relevant to the main process.
+ */
+export function hasActivePushPullOperations(): boolean {
+	return ACTIVE_PUSH_PULL_OPERATIONS.size > 0;
+}

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -19,6 +19,7 @@ import archiver from 'archiver';
 import { DEFAULT_PHP_VERSION } from '../vendor/wp-now/src/constants';
 import { MAIN_MIN_WIDTH, SIDEBAR_WIDTH } from './constants';
 import { SyncSite } from './hooks/use-fetch-wpcom-sites';
+import { ACTIVE_PUSH_PULL_OPERATIONS } from './lib/active-push-pull-operations';
 import { download } from './lib/download';
 import { isEmptyDir, pathExists, isWordPressDirectory, sanitizeFolderName } from './lib/fs-utils';
 import { getImageData } from './lib/get-image-data';
@@ -1004,8 +1005,6 @@ export async function isImportExportSupported( _event: IpcMainInvokeEvent, siteI
 	return site.hasSQLitePlugin();
 }
 
-const ACTIVE_PUSH_PULL_OPERATIONS = new Set();
-
 /**
  * Store the ID of a push/pull operation in a deduped set.
  */
@@ -1018,13 +1017,4 @@ export function addPushPullOperation( event: IpcMainInvokeEvent, id: string ) {
  */
 export function clearPushPullOperation( event: IpcMainInvokeEvent, id: string ) {
 	ACTIVE_PUSH_PULL_OPERATIONS.delete( id );
-}
-
-/**
- * Determine if the set of active push/pull operations has any members. Note that this function
- * isn't exposed to the renderer process even if it lives in `ipc-handlers`, because it's only
- * relevant to the main process.
- */
-export function hasActivePushPullOperations(): boolean {
-	return ACTIVE_PUSH_PULL_OPERATIONS.size > 0;
 }

--- a/src/lib/active-push-pull-operations.ts
+++ b/src/lib/active-push-pull-operations.ts
@@ -1,0 +1,12 @@
+/**
+ * This set is used to store the IDs of active sync operations. It's used to determine if we should
+ * display a confirmation modal before quitting the app.
+ */
+export const ACTIVE_PUSH_PULL_OPERATIONS = new Set();
+
+/**
+ * Determine if the set of active push/pull operations has any members.
+ */
+export function hasActivePushPullOperations(): boolean {
+	return ACTIVE_PUSH_PULL_OPERATIONS.size > 0;
+}

--- a/src/lib/active-sync-operations.ts
+++ b/src/lib/active-sync-operations.ts
@@ -2,11 +2,11 @@
  * This set is used to store the IDs of active sync operations. It's used to determine if we should
  * display a confirmation modal before quitting the app.
  */
-export const ACTIVE_PUSH_PULL_OPERATIONS = new Set();
+export const ACTIVE_SYNC_OPERATIONS = new Set();
 
 /**
  * Determine if the set of active push/pull operations has any members.
  */
-export function hasActivePushPullOperations(): boolean {
-	return ACTIVE_PUSH_PULL_OPERATIONS.size > 0;
+export function hasActiveSyncOperations(): boolean {
+	return ACTIVE_SYNC_OPERATIONS.size > 0;
 }

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -96,8 +96,8 @@ const api: IpcApi = {
 		ipcRenderer.invoke( 'removeSyncBackup', remoteSiteId ),
 	getConnectedWpcomSites: ( localSiteId?: string ) =>
 		ipcRenderer.invoke( 'getConnectedWpcomSites', localSiteId ),
-	addPushPullOperation: ( id: string ) => ipcRenderer.invoke( 'addPushPullOperation', id ),
-	clearPushPullOperation: ( id: string ) => ipcRenderer.invoke( 'clearPushPullOperation', id ),
+	addSyncOperation: ( id: string ) => ipcRenderer.invoke( 'addSyncOperation', id ),
+	clearSyncOperation: ( id: string ) => ipcRenderer.invoke( 'clearSyncOperation', id ),
 };
 
 contextBridge.exposeInMainWorld( 'ipcApi', api );

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -9,7 +9,7 @@ import { BackupArchiveInfo } from './lib/import-export/import/types';
 import { promptWindowsSpeedUpSites } from './lib/windows-helpers';
 import type { LogLevel } from './logging';
 
-const api: Omit< IpcApi, 'hasActivePushPullOperations' > = {
+const api: IpcApi = {
 	archiveSite: ( id: string, format: 'zip' | 'tar' ) =>
 		ipcRenderer.invoke( 'archiveSite', id, format ),
 	exportSiteToPush: ( id: string ) => ipcRenderer.invoke( 'exportSiteToPush', id ),

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -9,7 +9,7 @@ import { BackupArchiveInfo } from './lib/import-export/import/types';
 import { promptWindowsSpeedUpSites } from './lib/windows-helpers';
 import type { LogLevel } from './logging';
 
-const api: IpcApi = {
+const api: Omit< IpcApi, 'hasActivePushPullOperations' > = {
 	archiveSite: ( id: string, format: 'zip' | 'tar' ) =>
 		ipcRenderer.invoke( 'archiveSite', id, format ),
 	exportSiteToPush: ( id: string ) => ipcRenderer.invoke( 'exportSiteToPush', id ),
@@ -96,6 +96,8 @@ const api: IpcApi = {
 		ipcRenderer.invoke( 'removeSyncBackup', remoteSiteId ),
 	getConnectedWpcomSites: ( localSiteId?: string ) =>
 		ipcRenderer.invoke( 'getConnectedWpcomSites', localSiteId ),
+	addPushPullOperation: ( id: string ) => ipcRenderer.invoke( 'addPushPullOperation', id ),
+	clearPushPullOperation: ( id: string ) => ipcRenderer.invoke( 'clearPushPullOperation', id ),
 };
 
 contextBridge.exposeInMainWorld( 'ipcApi', api );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- https://github.com/Automattic/dotcom-forge/issues/9907

## Proposed Changes

Because push/pull operations cannot always be resumed after restarting the app, this PR adds a confirmation modal displayed when users try to quit the app when there's a push/pull operation in progress. 

<img width="296" alt="Screenshot 2024-12-03 at 10 28 21" src="https://github.com/user-attachments/assets/231b28c1-414f-485c-baba-1db37f470d8d">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Open the `Sync` tab in Studio
2. Connect a site if you haven't already
3. Pull that site
4. Attempt to quit the app
5. Ensure that you see a confirmation modal like in the screenshot above
6. Click "No"
7. Ensure that the app doesn't close
8. Attempt to quit the app again
9. Click "Yes"
10. Ensure that the app closes
11. Repeat the process with a push operation
12. Start another pull operation and allow it to finish
13. Attempt to quit the app again
14. Ensure that no confirmation modal is displayed (because there's no active push/pull operation)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
