### PR TITLE
Fix gradient color on onboarding for Spanish

### DIFF
--- a/src/components/onboarding.tsx
+++ b/src/components/onboarding.tsx
@@ -20,7 +20,7 @@ const GradientBox = () => {
 			className="gap-1 flex flex-col font-normal text-[42px] leading-[42px] text-white"
 		>
 			<div className="flex flex-col gap-1 relative self-stretch">
-				<div className="absolute inset-0 bg-gradient-to-b from-[#3858E9] to-[#3858E9]/60"></div>
+				<div className="absolute inset-0 bg-gradient-to-b from-[#3858E9] to-[#3858E9]/60 bottom-[-4px]"></div>
 				<p>{ __( 'Imagine' ) }</p>
 				<p>{ __( 'Create' ) }</p>
 				<p>{ __( 'Design' ) }</p>

--- a/src/components/onboarding.tsx
+++ b/src/components/onboarding.tsx
@@ -17,10 +17,10 @@ const GradientBox = () => {
 	return (
 		<div
 			aria-label={ __( 'Imagine, Create, Design, Code, Build' ) }
-			className="gap-1 flex flex-col font-normal text-[42px] leading-[42px] text-white"
+			className="gap-0 flex flex-col font-normal text-[42px] leading-[42px] text-white"
 		>
-			<div className="flex flex-col gap-1 relative self-stretch">
-				<div className="absolute inset-0 bg-gradient-to-b from-[#3858E9] to-[#3858E9]/60 bottom-[-4px]"></div>
+			<div className="flex flex-col gap-1 relative self-stretch pb-1">
+				<div className="absolute inset-0 bg-gradient-to-b from-[#3858E9] to-[#3858E9]/60"></div>
 				<p>{ __( 'Imagine' ) }</p>
 				<p>{ __( 'Create' ) }</p>
 				<p>{ __( 'Design' ) }</p>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes pdtkmj-3a1-p2#comment-5977

## Proposed Changes

- Fix gradient color for onboarding screen on Spanish

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Start Studio and change the language to Spanish
- Start Studio with no sites
- Observe the gradient covers all the words
- Try in different languages and observe the gradient looks good.

| Before | After |
|--------|--------|
|<img width="945" alt="Screenshot 2024-12-04 at 15 08 38" src="https://github.com/user-attachments/assets/9e9120ad-5866-4478-ae88-dd21b062e4fd">| <img width="989" alt="Screenshot 2024-12-04 at 15 08 28" src="https://github.com/user-attachments/assets/878e14d8-394c-4e44-8026-4d0a57fea64f"> |



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?