### PR TITLE
Update the label in the left sidebar when we have a single site running

### DIFF
--- a/src/components/running-sites.tsx
+++ b/src/components/running-sites.tsx
@@ -28,7 +28,7 @@ export function RunningSites() {
 						onClick={ stopAllRunningSites }
 						variant="link"
 					>
-						{ __( 'Stop all' ) }
+						{ runningSites.length === 1 ? __( 'Stop' ) : __( 'Stop all' ) }
 					</Button>
 				</div>
 			) }

--- a/src/components/tests/main-sidebar.test.tsx
+++ b/src/components/tests/main-sidebar.test.tsx
@@ -82,9 +82,16 @@ describe( 'MainSidebar Footer', () => {
 		expect( container.firstChild ).toHaveClass( 'test-class' );
 	} );
 
-	it( 'shows a "Stop All" button when there are running sites', async () => {
+	it( 'shows a "Stop" button when there is a running site', async () => {
+		await act( async () => renderWithProvider( <MainSidebar /> ) );
+		expect( screen.getByRole( 'button', { name: 'Stop' } ) ).toBeVisible();
+	} );
+
+	it( 'shows a "Stop All" button when there are multiple running sites', async () => {
+		site2.running = true;
 		await act( async () => renderWithProvider( <MainSidebar /> ) );
 		expect( screen.getByRole( 'button', { name: 'Stop all' } ) ).toBeVisible();
+		site2.running = false;
 	} );
 } );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes pdtkmj-3a1-p2#comment-5982

> could we update the Stop all link label to Stop when there is only one local site?

## Proposed Changes

- update the `Stop all` link label to `Stop` when there is only one site running

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run `npm start`
- Start one site
- Observe it says `Stop` in the left sidebar 
- Start a second site
- Observe it says `Stop all` in the left sidebar

| Before | After |
|--------|--------|
| <img width="1032" alt="Screenshot 2024-12-04 at 21 20 19" src="https://github.com/user-attachments/assets/ea186abb-5f0b-479e-a033-cef872b415e9"> | <img width="1032" alt="Screenshot 2024-12-04 at 21 19 32" src="https://github.com/user-attachments/assets/7825022b-dfe3-42b3-b0bb-b934047d4739"> |



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?