### PR TITLE
Studio: Hide tooltip if the provided text is not available

### DIFF
--- a/src/components/tooltip.tsx
+++ b/src/components/tooltip.tsx
@@ -1,5 +1,5 @@
 import { Icon, Popover } from '@wordpress/components';
-import { PropsWithChildren, useState } from 'react';
+import { PropsWithChildren, useState, useEffect } from 'react';
 
 export interface TooltipProps
 	extends Pick< React.ComponentProps< typeof Popover >, 'placement' | 'className' > {
@@ -31,6 +31,12 @@ const Tooltip = ( {
 	if ( ! children ) {
 		return null;
 	}
+
+	useEffect( () => {
+		if ( ! text ) {
+			hidePopover();
+		}
+	}, [ text ] );
 
 	return (
 		<div

--- a/src/components/tooltip.tsx
+++ b/src/components/tooltip.tsx
@@ -28,15 +28,15 @@ const Tooltip = ( {
 		setIsPopoverVisible( false );
 	};
 
+	useEffect( () => {
+		if ( ! text && isPopoverVisible ) {
+			setIsPopoverVisible( false );
+		}
+	}, [ text, isPopoverVisible ] );
+
 	if ( ! children ) {
 		return null;
 	}
-
-	useEffect( () => {
-		if ( ! text ) {
-			hidePopover();
-		}
-	}, [ text ] );
 
 	return (
 		<div


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/dotcom-forge/issues/10087.

## Proposed Changes

- hide tooltip if the provided text is not available

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR branch and build the app with `npm start`.
2. Wait for https://github.com/Automattic/studio/pull/717 to be merged.
3. Initiate a sync of one of the connected sites and head over to the _Import / Export_ tab.
4. Hover over the "Drag file" or export button to see the tooltip. Keep the cursor there.
5. As soon as the syncing finishes, the tooltip should disappear automatically.
6. Review other existing Studio app tooltips. There should be no regression.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
