### PR TITLE
Activate Jetpack plugin when pushing site

### DIFF
--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -567,6 +567,7 @@ export async function exportSiteToPush( event: IpcMainInvokeEvent, id: string ) 
 		includes: { database: true, uploads: true, plugins: true, themes: true },
 		phpVersion: site.details.phpVersion,
 		splitDatabaseDumpByTable: true,
+		targetHost: 'wpcom',
 	};
 	// eslint-disable-next-line @typescript-eslint/no-empty-function
 	const onEvent = () => {};

--- a/src/lib/import-export/export/exporters/default-exporter.ts
+++ b/src/lib/import-export/export/exporters/default-exporter.ts
@@ -23,6 +23,7 @@ export class DefaultExporter extends EventEmitter implements Exporter {
 	private backup: BackupContents;
 	private readonly options: ExportOptions;
 	private siteFiles: string[];
+	private originalActivePlugins?: string[] = undefined;
 
 	constructor( options: ExportOptions ) {
 		super();
@@ -81,6 +82,7 @@ export class DefaultExporter extends EventEmitter implements Exporter {
 		this.archive.pipe( output );
 
 		try {
+			await this.activateJetpackIfNeeded();
 			this.addWpConfig();
 			this.addWpContent();
 			await this.addDatabase();
@@ -90,6 +92,7 @@ export class DefaultExporter extends EventEmitter implements Exporter {
 			this.emit( ExportEvents.BACKUP_CREATE_COMPLETE );
 			await archiveClosedPromise;
 			this.emit( ExportEvents.EXPORT_COMPLETE );
+			await this.deactivateJetpackIfNeeded();
 		} catch ( error ) {
 			this.archive.abort();
 			this.emit( ExportEvents.EXPORT_ERROR );
@@ -296,5 +299,54 @@ export class DefaultExporter extends EventEmitter implements Exporter {
 		}
 
 		return JSON.parse( stdout );
+	}
+
+	private async activateJetpackIfNeeded() {
+		if ( this.options.targetHost !== 'wpcom' ) {
+			return;
+		}
+
+		const server = SiteServer.get( this.options.site.id );
+
+		if ( ! server ) {
+			return;
+		}
+
+		const { stderr: getOptionStderr, stdout: getOptionStdout } = await server.executeWpCliCommand(
+			`option get active_plugins --format=json`
+		);
+
+		if ( getOptionStderr ) {
+			console.error( `Could not get active_plugins option: ${ getOptionStderr }` );
+			return;
+		}
+
+		const activePlugins = JSON.parse( getOptionStdout.trim() );
+		const jetpackSlug = 'jetpack/jetpack.php';
+
+		if ( Array.isArray( activePlugins ) && ! activePlugins.includes( jetpackSlug ) ) {
+			this.originalActivePlugins = activePlugins;
+			activePlugins.push( jetpackSlug );
+
+			await server.executeWpCliCommand(
+				`option set active_plugins '${ JSON.stringify( activePlugins ) }' --format=json`
+			);
+		}
+	}
+
+	private async deactivateJetpackIfNeeded() {
+		if ( this.options.targetHost !== 'wpcom' || ! this.originalActivePlugins ) {
+			return;
+		}
+
+		const server = SiteServer.get( this.options.site.id );
+
+		if ( ! server ) {
+			return;
+		}
+
+		await server.executeWpCliCommand(
+			`option set active_plugins '${ JSON.stringify( this.originalActivePlugins ) }' --format=json`
+		);
 	}
 }

--- a/src/lib/import-export/export/exporters/default-exporter.ts
+++ b/src/lib/import-export/export/exporters/default-exporter.ts
@@ -325,7 +325,7 @@ export class DefaultExporter extends EventEmitter implements Exporter {
 		const jetpackSlug = 'jetpack/jetpack.php';
 
 		if ( Array.isArray( activePlugins ) && ! activePlugins.includes( jetpackSlug ) ) {
-			this.originalActivePlugins = activePlugins;
+			this.originalActivePlugins = structuredClone( activePlugins );
 			activePlugins.push( jetpackSlug );
 
 			await server.executeWpCliCommand(

--- a/src/lib/import-export/export/types.ts
+++ b/src/lib/import-export/export/types.ts
@@ -7,6 +7,7 @@ export interface ExportOptions {
 	includes: { [ index in ExportOptionsIncludes ]: boolean };
 	phpVersion: string;
 	splitDatabaseDumpByTable?: boolean;
+	targetHost?: 'wpcom';
 }
 
 export type ExportOptionsIncludes = BackupContentsCategory | 'database';

--- a/src/lib/php-get-theme-details.ts
+++ b/src/lib/php-get-theme-details.ts
@@ -10,18 +10,18 @@ export async function phpGetThemeDetails(
 
 	let themeDetails = null;
 	const themeDetailsPhp = `<?php
-    require_once('${ server.php.documentRoot }/wp-load.php');
-    $theme = wp_get_theme();
-    echo json_encode([
-        'name' => $theme->get('Name'),
-        'uri' => $theme->get('ThemeURI'),
-        'path' => $theme->get_stylesheet_directory(),
-        'slug' => $theme->get_stylesheet(),
+	require_once('${ server.php.documentRoot }/wp-load.php');
+	$theme = wp_get_theme();
+	echo json_encode([
+		'name' => $theme->get('Name'),
+		'uri' => $theme->get('ThemeURI'),
+		'path' => $theme->get_stylesheet_directory(),
+		'slug' => $theme->get_stylesheet(),
 		'isBlockTheme' => $theme->is_block_theme(),
 		'supportsWidgets' => current_theme_supports('widgets'),
 		'supportsMenus' => get_registered_nav_menus() || current_theme_supports('menus'),
-    ]);
-    `;
+	]);
+	`;
 	try {
 		themeDetails = await server.runPhp( {
 			code: themeDetailsPhp,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Related to https://github.com/Automattic/dotcom-forge/issues/9994

## Proposed Changes

Include `jetpack/jetpack.php` in the `active_plugins` row in `wp_options` when pushing a site to WordPress.com.

This helps make the experience of pushing a "clean website" (i.e., one that wasn't previously pulled from WordPress.com) manageable. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Have a clean Studio website connected to a WordPress.com website
2. Open your Terminal and `cd` into the site directory
3. Have `wp-cli` installed locally
4. Run `wp option get active_plugins --format=json`
5. Make note of the output
6. Push the Studio website
7. Wait for the process to finish
8. Log in to `/wp-admin` on your WordPress.com website (username `admin`, password can be found in the Settings tab in Studio)
9. Ensure that you see a Jetpack sidebar item
10. Go back to your terminal
11. Run `wp option get active_plugins --format=json`
12. Ensure that the output matches what you saw the first time (i.e., that Jetpack isn't included among the active plugins on the local site)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
