### PR TITLE
Issue Templates: update bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -26,49 +26,17 @@ body:
     attributes:
       label: Steps to reproduce
       placeholder: |
+        E.g., What happened, and what did you expect to happen? Add images,
+        GIFs, and videos if you have them on hand.
+
         1. Start the Studio app.
         2. Click on 'Add site'.
         3. ...
-    validations:
-      required: true
-  - type: textarea
-    id: expected
-    attributes:
-      label: What you expected to happen
-      placeholder: |
-        e.g. The new site form shows up.
-    validations:
-      required: true
-  - type: textarea
-    id: actual
-    attributes:
-      label: What actually happened
-      placeholder: |
-        e.g. Clicking the 'Add site' button does nothing.
-    validations:
-      required: true
-  - type: dropdown
-    id: users-affected
-    attributes:
-      label: Impact
-      description: Approximately how many users are impacted?
-      options:
-        - One
-        - Some (< 50%)
-        - Most (> 50%)
-        - All
-    validations:
-      required: true
-  - type: dropdown
-    id: workarounds
-    attributes:
-      label: Available workarounds?
-      options:
-        - No and the app is unusable
-        - No but the app is still usable
-        - Yes, difficult to implement
-        - Yes, easy to implement
-        - There is no user impact
+
+        Add any information that may be relevant, such as:
+          - Browser/Platform
+          - Theme
+          - Logs/Errors
     validations:
       required: true
 
@@ -77,9 +45,65 @@ body:
       value: |
         <br>
 
+        ## Impact
+        Please help us understand more about the impact of this issue to help determine next steps.
+        If you are unsure about anything, please use your judgment to make an educated guess.
+  - type: dropdown
+    id: impact
+    attributes:
+      label: Site owner impact
+      description: Approximately what percentage of the total users of the platform are impacted? Unsure? Please provide your most educated guess!
+      options:
+        - Less than 20% of all
+        - Between 20% and 60% of all
+        - More than 60% of all
+    validations:
+      required: true
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      description: What is the severity of this issue? Please take a look at the descriptions below for further context.<br>
+        <br> - **Critical:** Prevents core functionality or has severe impact on the website/platform.
+        <br> - **Major:** Significantly impairs important features or has notable impact on the website/platform.
+        <br> - **Moderate:** Affects non-critical features or has limited impact on the website/platform.
+        <br> - **Minor:** Causes inconvenience or has minimal impact on functionality.
+      options:
+        - Critical
+        - Major
+        - Moderate
+        - Minor
+    validations:
+      required: true
+  - type: dropdown
+    id: additional-impact
+    attributes:
+      label: What other impact(s) does this issue have?
+      description: You may select more than one
+      options:
+        - Platform revenue
+        - Agency or developer revenue
+        - Individual site owner revenue
+        - No revenue impact
+      multiple: true
+
+  - type: markdown
+    attributes:
+      value: |
+        <br>
+
         ## Optional Information
 
-        The following section is optional.
+  - type: textarea
+    id: workaround
+    attributes:
+      label: If a workaround is available, please outline it here.
+      placeholder: |
+        Provide details of the specific steps to take that resolve the issue, e.g.:
+          - Open "Setting X".
+          - Toggle "Option Y".
+          - Click "Button Z".
+
   - type: dropdown
     id: site-type
     attributes:
@@ -90,11 +114,4 @@ body:
         - Mac Intel
         - Windows
       multiple: true
-  - type: textarea
-    id: logs
-    attributes:
-      label: Logs or notes
-      placeholder: |
-        Add any information that may be relevant, such as:
-          - Browser/Platform
-          - Logs/Errors
+


### PR DESCRIPTION
## Related issues

- Related PR: https://github.com/Automattic/wp-calypso/pull/97049/
- pfVjQF-su-p2

## Proposed Changes

We're updating our priority matrix, and consequently need to update the information we collect in our issues, so our GitHub action can automatically assign priority.
This also consolidates the steps to reproduce into one field instead of 3, to make things simpler for reporters.

## Testing Instructions

Open the bug issue template here on GitHub and check the preview ; the impact assessment section should match the one introduced in Calypso, in https://github.com/Automattic/wp-calypso/pull/97049/

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?
