### PR TITLE
Insert remote users when connecting site

### DIFF
--- a/src/hooks/sync-sites/use-site-sync-management.ts
+++ b/src/hooks/sync-sites/use-site-sync-management.ts
@@ -4,6 +4,27 @@ import { useAuth } from '../use-auth';
 import { SyncSite, useFetchWpComSites } from '../use-fetch-wpcom-sites';
 import { useSiteDetails } from '../use-site-details';
 
+type UserEndpointUser = {
+	ID: number;
+	URL: string;
+	avatar_URL: string;
+	email: string;
+	first_name: string;
+	last_name: string;
+	linked_user_ID: number;
+	linked_user_info: Record< string, string >;
+	login: string;
+	name: string;
+	nice_name: string;
+	profile_URL: string;
+	roles: string[];
+};
+
+type UserEndpointResponse = {
+	found: number;
+	users: UserEndpointUser[];
+};
+
 /**
  * Generate updated site data to be stored in `appdata-v1.json` in three steps:
  *   1. Update the list of `connectedSites` with fresh data (name, URL, etc)
@@ -106,7 +127,7 @@ export const useSiteSyncManagement = ( {
 	connectedSites: SyncSite[];
 	setConnectedSites: React.Dispatch< React.SetStateAction< SyncSite[] > >;
 } ) => {
-	const { isAuthenticated } = useAuth();
+	const { client, isAuthenticated } = useAuth();
 	const { syncSites, isFetching, isInitialized, refetchSites } = useFetchWpComSites(
 		connectedSites.map( ( { id } ) => id )
 	);
@@ -183,11 +204,24 @@ export const useSiteSyncManagement = ( {
 			if ( ! localSiteIdToConnect ) {
 				return;
 			}
+
+			if ( ! client?.req ) {
+				return;
+			}
+
 			try {
 				const stagingSites = site.stagingSiteIds.flatMap(
 					( id ) => syncSites.find( ( s ) => s.id === id ) ?? []
 				);
 				const sitesToConnect = [ site, ...stagingSites ];
+
+				const usersResponse = await client.req.get< UserEndpointResponse >(
+					`/sites/${ site.id }/users`
+				);
+
+				console.log( usersResponse );
+
+				// TODO: Insert users into DB
 
 				const newConnectedSites = await getIpcApi().connectWpcomSites( [
 					{
@@ -195,6 +229,7 @@ export const useSiteSyncManagement = ( {
 						localSiteId: localSiteIdToConnect,
 					},
 				] );
+
 				if ( localSiteIdToConnect === localSiteId ) {
 					setConnectedSites( newConnectedSites );
 				}
@@ -203,7 +238,7 @@ export const useSiteSyncManagement = ( {
 				throw error;
 			}
 		},
-		[ localSiteId, syncSites, setConnectedSites ]
+		[ client?.req, localSiteId, syncSites, setConnectedSites ]
 	);
 
 	const disconnectSite = useCallback(


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Related to https://github.com/Automattic/dotcom-forge/issues/9994

## Proposed Changes

This PR is a very early draft of how we could insert users into the local Studio site when connecting a WordPress.com site. The `/sites/:site_id/users` API endpoint returns all the data we need, which is good. However, I can think of a few conceptual issues with inserting the remote users when connecting a site (and not, for example, when exporting):
1. A local site can be connected to multiple WordPress.com sites, which could cause ID collisions in the `wp_users` table locally.
2. Users only connect WordPress.com sites **once**. If new users are invited on the remote site, Studio won't pick up those users.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Open the `Sync` tab
2. Connect a new site
3. The users on the remote site will be logged to the console

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
