### PR TITLE
Skip user data when exporting for push purposes

### DIFF
--- a/src/lib/import-export/export/export-database.ts
+++ b/src/lib/import-export/export/export-database.ts
@@ -60,6 +60,11 @@ export async function exportDatabaseToMultipleFiles(
 	const tmpFiles: string[] = [];
 
 	for ( const table of tables ) {
+		if ( table === 'wp_users' || table === 'wp_usermeta' ) {
+			// Skip the wp_users and wp_usermeta tables as they are not needed
+			continue;
+		}
+
 		const fileName = `${ table }.sql`;
 
 		// Execute the command to export directly to a temporary file in the project directory

--- a/src/lib/import-export/tests/export/exporters/default-exporter.test.ts
+++ b/src/lib/import-export/tests/export/exporters/default-exporter.test.ts
@@ -69,8 +69,6 @@ describe( 'DefaultExporter', () => {
 		'wp_term_taxonomy',
 		'wp_termmeta',
 		'wp_terms',
-		'wp_usermeta',
-		'wp_users',
 	];
 
 	( fsPromises.readdir as jest.Mock ).mockResolvedValue( mockFiles );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/dotcom-forge/issues/9994

## Proposed Changes

I propose to skip the `wp_users` and `wp_usermeta` tables from the archive prepared for Jetpack Backup restore. That way, VaultPress will preserve the original tables, so the Jetpack connection will be intact.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create a site with a Business plan
2. Create a staging site
3. Create a new site in Studio
4. Open Sync tab
5. Connect a site to a staging site
6. Push the site
7. Open the staging site at /wp-admin and confirm connection to WPcom is healthy - ensure that you see a Jetpack sidebar item.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
