### PR TITLE
Studio: Update error handling when push fails on local site export 

### DIFF
--- a/src/hooks/sync-sites/use-sync-push.ts
+++ b/src/hooks/sync-sites/use-sync-push.ts
@@ -125,8 +125,23 @@ export function useSyncPush( {
 				isStaging: connectedSite.isStaging,
 			} );
 
-			const { archiveContent, archivePath, archiveSizeInBytes } =
-				await getIpcApi().exportSiteToPush( selectedSite.id );
+			let archiveContent, archivePath, archiveSizeInBytes;
+
+			try {
+				const result = await getIpcApi().exportSiteToPush( selectedSite.id );
+				( { archiveContent, archivePath, archiveSizeInBytes } = result );
+			} catch ( error ) {
+				Sentry.captureException( error );
+				updatePushState( selectedSite.id, remoteSiteId, {
+					status: pushStatesProgressInfo.failed,
+				} );
+				getIpcApi().showErrorMessageBox( {
+					title: sprintf( __( 'Error exporting site to %s' ), connectedSite.name ),
+					message: __( 'Studio was unable to export the site.' ),
+				} );
+				return;
+			}
+
 			if ( archiveSizeInBytes > SYNC_PUSH_SIZE_LIMIT_BYTES ) {
 				updatePushState( selectedSite.id, remoteSiteId, {
 					status: pushStatesProgressInfo.failed,

--- a/src/hooks/use-chat-context.tsx
+++ b/src/hooks/use-chat-context.tsx
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/electron/renderer';
 import React, {
 	createContext,
 	useContext,
@@ -53,6 +54,9 @@ const parseWpCliOutput = ( stdout: string, defaultValue: string[] ): string[] =>
 		return data?.map( ( item: { name: string } ) => item.name ) || [];
 	} catch ( error ) {
 		console.error( error, stdout );
+		Sentry.captureException( error, {
+			extra: { stdout },
+		} );
 	}
 	return defaultValue;
 };

--- a/src/hooks/use-chat-context.tsx
+++ b/src/hooks/use-chat-context.tsx
@@ -52,7 +52,7 @@ const parseWpCliOutput = ( stdout: string, defaultValue: string[] ): string[] =>
 		const data = JSON.parse( stdout );
 		return data?.map( ( item: { name: string } ) => item.name ) || [];
 	} catch ( error ) {
-		console.error( error );
+		console.error( error, stdout );
 	}
 	return defaultValue;
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/dotcom-forge/issues/10097.
- Related https://github.com/Automattic/dotcom-forge/issues/8961.

## Proposed Changes

- If the push operation fails during the site export
  - catch the error and display error message
  - update push state to `failed`
- output `stdout` string in the console if it triggers an error on `JSON.parse`
- catch the error in Sentry as well (details: https://github.com/Automattic/dotcom-forge/issues/8961#issuecomment-2538806558)

| error message | failed state | console error |
|--------|--------|--------|
| ![Markup on 2024-12-10 at 12:39:20](https://github.com/user-attachments/assets/650542ed-df7e-4576-8cf0-a3b7ebef4b8c) | ![Markup on 2024-12-10 at 12:41:12](https://github.com/user-attachments/assets/a5759dde-ca99-4a30-8005-d6bd9354eec4) | ![Markup on 2024-12-10 at 12:41:47](https://github.com/user-attachments/assets/58093dc3-2a21-48e8-bab1-eb819d4fe58c) | 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Before checking out the PR branch, try to reproduce the issue by following the steps in https://github.com/Automattic/dotcom-forge/issues/10097.
2. Check out the PR and build the app with `npm start`.
3. Try to follow the steps to reproduce the issue again.
4. Custom error should load in a window.
5. Once you click the `OK` button, the operation should be in the failed state with the `Error pushing changes` message displayed by the connected site address.
6. If you review the browser console, you should see `stdout` string outputted as well.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
