### PR TITLE
Studio: Fix missing dependency of `getErrorFromResponse` in `use-sync-push`

### DIFF
--- a/src/hooks/sync-sites/use-sync-push.ts
+++ b/src/hooks/sync-sites/use-sync-push.ts
@@ -99,18 +99,21 @@ export function useSyncPush( {
 		]
 	);
 
-	const getErrorFromResponse = ( error: unknown ): string => {
-		if (
-			typeof error === 'object' &&
-			error !== null &&
-			'error' in error &&
-			typeof ( error as { error: unknown } ).error === 'string'
-		) {
-			return ( error as { error: string } ).error;
-		}
+	const getErrorFromResponse = useCallback(
+		( error: unknown ): string => {
+			if (
+				typeof error === 'object' &&
+				error !== null &&
+				'error' in error &&
+				typeof ( error as { error: unknown } ).error === 'string'
+			) {
+				return ( error as { error: string } ).error;
+			}
 
-		return __( 'Studio was unable to connect to WordPress.com. Please try again.' );
-	};
+			return __( 'Studio was unable to connect to WordPress.com. Please try again.' );
+		},
+		[ __ ]
+	);
 
 	const pushSite = useCallback(
 		async ( connectedSite: SyncSite, selectedSite: SiteDetails ) => {
@@ -175,7 +178,7 @@ export function useSyncPush( {
 				await getIpcApi().removeTemporalFile( archivePath );
 			}
 		},
-		[ __, client, pushStatesProgressInfo, updatePushState ]
+		[ __, client, pushStatesProgressInfo, updatePushState, getErrorFromResponse ]
 	);
 
 	useEffect( () => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/dotcom-forge/issues/10120#issuecomment-2539048757.

## Proposed Changes

- wrap `getErrorFromResponse` in `useCallback`
- add `getErrorFromResponse` to the dependency array of `pushSite`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out this PR and build the app with `npm start`.
2. Navigate to the Sync tab and make sure you have a WPCOM site **with its staging site** connected.
3. While at the staging site settings tab of the WPCOM site (`https://wordpress.com/staging-site/{site-slug}`), initiate a sync from staging to production.
4. Head back to the Sync tab in Studio and try to initiate a push operation.
5. After some time, a dialog with relevant error message should display.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
