### PR TITLE
Studio: Move the create new WPcom site inside the modal 

### DIFF
--- a/src/components/connect-create-buttons.tsx
+++ b/src/components/connect-create-buttons.tsx
@@ -8,7 +8,7 @@ import offlineIcon from './offline-icon';
 import { Tooltip } from './tooltip';
 
 interface ConnectButtonProps {
-	connectButtonVariant: ButtonVariant;
+	variant: ButtonVariant;
 	connectSite?: () => void;
 	disableConnectButtonStyle?: boolean;
 	className?: string;
@@ -22,7 +22,7 @@ interface CreateButtonProps {
 }
 
 export const ConnectButton = ( {
-	connectButtonVariant,
+	variant,
 	connectSite,
 	disableConnectButtonStyle,
 	className,
@@ -39,7 +39,7 @@ export const ConnectButton = ( {
 				onClick={ connectSite }
 				disabled={ isOffline }
 				aria-disabled={ isOffline }
-				variant={ connectButtonVariant }
+				variant={ variant }
 				className={ cx(
 					! disableConnectButtonStyle && ! isOffline && '!text-a8c-blueberry !shadow-a8c-blueberry',
 					className

--- a/src/components/connect-create-buttons.tsx
+++ b/src/components/connect-create-buttons.tsx
@@ -8,9 +8,9 @@ import offlineIcon from './offline-icon';
 import { Tooltip } from './tooltip';
 
 interface ConnectCreateButtonsProps {
-	connectSite: () => void;
 	connectButtonVariant: ButtonVariant;
 	createButtonVariant: ButtonVariant;
+	connectSite?: () => void;
 	disableConnectButtonStyle?: boolean;
 	selectedSite: SiteDetails;
 	createButtonText?: string;

--- a/src/components/connect-create-buttons.tsx
+++ b/src/components/connect-create-buttons.tsx
@@ -15,9 +15,9 @@ interface ConnectButtonProps {
 }
 
 interface CreateButtonProps {
-	createButtonVariant: ButtonVariant;
+	variant: ButtonVariant;
 	selectedSite: SiteDetails;
-	createButtonText?: string;
+	text?: string;
 	className?: string;
 }
 
@@ -52,9 +52,9 @@ export const ConnectButton = ( {
 };
 
 export const CreateButton = ( {
-	createButtonVariant,
+	variant,
 	selectedSite,
-	createButtonText = __( 'Create new site' ),
+	text = __( 'Create new site' ),
 	className,
 }: CreateButtonProps ) => {
 	const isOffline = useOffline();
@@ -71,12 +71,12 @@ export const CreateButton = ( {
 						`https://wordpress.com/setup/new-hosted-site?ref=studio&section=studio-sync&studioSiteId=${ selectedSite.id }`
 					);
 				} }
-				variant={ createButtonVariant }
+				variant={ variant }
 				className={ cx( ! isOffline && '!text-a8c-blueberry !shadow-a8c-blueberry', className ) }
 				disabled={ isOffline }
 				aria-disabled={ isOffline }
 			>
-				{ createButtonText }
+				{ text }
 				<ArrowIcon />
 			</Button>
 		</Tooltip>

--- a/src/components/connect-create-buttons.tsx
+++ b/src/components/connect-create-buttons.tsx
@@ -1,4 +1,5 @@
 import { __ } from '@wordpress/i18n';
+import { useOffline } from '../hooks/use-offline';
 import { cx } from '../lib/cx';
 import { getIpcApi } from '../lib/get-ipc-api';
 import { ArrowIcon } from './arrow-icon';
@@ -8,7 +9,6 @@ import { Tooltip } from './tooltip';
 
 interface ConnectCreateButtonsProps {
 	connectSite: () => void;
-	isOffline: boolean;
 	connectButtonVariant: ButtonVariant;
 	createButtonVariant: ButtonVariant;
 	disableConnectButtonStyle?: boolean;
@@ -20,7 +20,6 @@ interface ConnectCreateButtonsProps {
 
 export const ConnectCreateButtons = ( {
 	connectSite,
-	isOffline,
 	createButtonVariant,
 	connectButtonVariant,
 	disableConnectButtonStyle,
@@ -29,6 +28,7 @@ export const ConnectCreateButtons = ( {
 	showConnectButton = true,
 	showCreateButton = true,
 }: ConnectCreateButtonsProps ) => {
+	const isOffline = useOffline();
 	return (
 		<>
 			{ showConnectButton && (

--- a/src/components/connect-create-buttons.tsx
+++ b/src/components/connect-create-buttons.tsx
@@ -14,6 +14,8 @@ interface ConnectCreateButtonsProps {
 	disableConnectButtonStyle?: boolean;
 	selectedSite: SiteDetails;
 	createButtonText?: string;
+	showConnectButton?: boolean;
+	showCreateButton?: boolean;
 }
 
 export const ConnectCreateButtons = ( {
@@ -24,50 +26,56 @@ export const ConnectCreateButtons = ( {
 	disableConnectButtonStyle,
 	selectedSite,
 	createButtonText = __( 'Create new site' ),
+	showConnectButton = true,
+	showCreateButton = true,
 }: ConnectCreateButtonsProps ) => {
 	return (
 		<>
-			<Tooltip
-				disabled={ ! isOffline }
-				text={ __( 'Connecting a site requires an internet connection.' ) }
-				icon={ offlineIcon }
-				placement="top-start"
-			>
-				<Button
-					onClick={ connectSite }
-					disabled={ isOffline }
-					aria-disabled={ isOffline }
-					variant={ connectButtonVariant }
-					className={ cx(
-						! disableConnectButtonStyle &&
-							! isOffline &&
-							'!text-a8c-blueberry !shadow-a8c-blueberry'
-					) }
+			{ showConnectButton && (
+				<Tooltip
+					disabled={ ! isOffline }
+					text={ __( 'Connecting a site requires an internet connection.' ) }
+					icon={ offlineIcon }
+					placement="top-start"
 				>
-					{ __( 'Connect site' ) }
-				</Button>
-			</Tooltip>
-			<Tooltip
-				disabled={ ! isOffline }
-				text={ __( 'Creating a site requires an internet connection.' ) }
-				icon={ offlineIcon }
-				placement="top-start"
-			>
-				<Button
-					onClick={ () => {
-						getIpcApi().openURL(
-							`https://wordpress.com/setup/new-hosted-site?ref=studio&section=studio-sync&studioSiteId=${ selectedSite.id }`
-						);
-					} }
-					variant={ createButtonVariant }
-					className={ cx( ! isOffline && '!text-a8c-blueberry !shadow-a8c-blueberry' ) }
-					disabled={ isOffline }
-					aria-disabled={ isOffline }
+					<Button
+						onClick={ connectSite }
+						disabled={ isOffline }
+						aria-disabled={ isOffline }
+						variant={ connectButtonVariant }
+						className={ cx(
+							! disableConnectButtonStyle &&
+								! isOffline &&
+								'!text-a8c-blueberry !shadow-a8c-blueberry'
+						) }
+					>
+						{ __( 'Connect site' ) }
+					</Button>
+				</Tooltip>
+			) }
+			{ showCreateButton && (
+				<Tooltip
+					disabled={ ! isOffline }
+					text={ __( 'Creating a site requires an internet connection.' ) }
+					icon={ offlineIcon }
+					placement="top-start"
 				>
-					{ createButtonText }
-					<ArrowIcon />
-				</Button>
-			</Tooltip>
+					<Button
+						onClick={ () => {
+							getIpcApi().openURL(
+								`https://wordpress.com/setup/new-hosted-site?ref=studio&section=studio-sync&studioSiteId=${ selectedSite.id }`
+							);
+						} }
+						variant={ createButtonVariant }
+						className={ cx( ! isOffline && '!text-a8c-blueberry !shadow-a8c-blueberry' ) }
+						disabled={ isOffline }
+						aria-disabled={ isOffline }
+					>
+						{ createButtonText }
+						<ArrowIcon />
+					</Button>
+				</Tooltip>
+			) }
 		</>
 	);
 };

--- a/src/components/connect-create-buttons.tsx
+++ b/src/components/connect-create-buttons.tsx
@@ -7,75 +7,73 @@ import Button, { ButtonVariant } from './button';
 import offlineIcon from './offline-icon';
 import { Tooltip } from './tooltip';
 
-interface ConnectCreateButtonsProps {
+interface ConnectButtonProps {
 	connectButtonVariant: ButtonVariant;
-	createButtonVariant: ButtonVariant;
 	connectSite?: () => void;
 	disableConnectButtonStyle?: boolean;
-	selectedSite: SiteDetails;
-	createButtonText?: string;
-	showConnectButton?: boolean;
-	showCreateButton?: boolean;
 }
 
-export const ConnectCreateButtons = ( {
-	connectSite,
-	createButtonVariant,
+interface CreateButtonProps {
+	createButtonVariant: ButtonVariant;
+	selectedSite: SiteDetails;
+	createButtonText?: string;
+}
+
+export const ConnectButton = ( {
 	connectButtonVariant,
+	connectSite,
 	disableConnectButtonStyle,
-	selectedSite,
-	createButtonText = __( 'Create new site' ),
-	showConnectButton = true,
-	showCreateButton = true,
-}: ConnectCreateButtonsProps ) => {
+}: ConnectButtonProps ) => {
 	const isOffline = useOffline();
 	return (
-		<>
-			{ showConnectButton && (
-				<Tooltip
-					disabled={ ! isOffline }
-					text={ __( 'Connecting a site requires an internet connection.' ) }
-					icon={ offlineIcon }
-					placement="top-start"
-				>
-					<Button
-						onClick={ connectSite }
-						disabled={ isOffline }
-						aria-disabled={ isOffline }
-						variant={ connectButtonVariant }
-						className={ cx(
-							! disableConnectButtonStyle &&
-								! isOffline &&
-								'!text-a8c-blueberry !shadow-a8c-blueberry'
-						) }
-					>
-						{ __( 'Connect site' ) }
-					</Button>
-				</Tooltip>
-			) }
-			{ showCreateButton && (
-				<Tooltip
-					disabled={ ! isOffline }
-					text={ __( 'Creating a site requires an internet connection.' ) }
-					icon={ offlineIcon }
-					placement="top-start"
-				>
-					<Button
-						onClick={ () => {
-							getIpcApi().openURL(
-								`https://wordpress.com/setup/new-hosted-site?ref=studio&section=studio-sync&studioSiteId=${ selectedSite.id }`
-							);
-						} }
-						variant={ createButtonVariant }
-						className={ cx( ! isOffline && '!text-a8c-blueberry !shadow-a8c-blueberry' ) }
-						disabled={ isOffline }
-						aria-disabled={ isOffline }
-					>
-						{ createButtonText }
-						<ArrowIcon />
-					</Button>
-				</Tooltip>
-			) }
-		</>
+		<Tooltip
+			disabled={ ! isOffline }
+			text={ __( 'Connecting a site requires an internet connection.' ) }
+			icon={ offlineIcon }
+			placement="top-start"
+		>
+			<Button
+				onClick={ connectSite }
+				disabled={ isOffline }
+				aria-disabled={ isOffline }
+				variant={ connectButtonVariant }
+				className={ cx(
+					! disableConnectButtonStyle && ! isOffline && '!text-a8c-blueberry !shadow-a8c-blueberry'
+				) }
+			>
+				{ __( 'Connect site' ) }
+			</Button>
+		</Tooltip>
+	);
+};
+
+export const CreateButton = ( {
+	createButtonVariant,
+	selectedSite,
+	createButtonText = __( 'Create new site' ),
+}: CreateButtonProps ) => {
+	const isOffline = useOffline();
+	return (
+		<Tooltip
+			disabled={ ! isOffline }
+			text={ __( 'Creating a site requires an internet connection.' ) }
+			icon={ offlineIcon }
+			placement="top-start"
+		>
+			<Button
+				onClick={ () => {
+					getIpcApi().openURL(
+						`https://wordpress.com/setup/new-hosted-site?ref=studio&section=studio-sync&studioSiteId=${ selectedSite.id }`
+					);
+				} }
+				variant={ createButtonVariant }
+				className={ cx( ! isOffline && '!text-a8c-blueberry !shadow-a8c-blueberry' ) }
+				disabled={ isOffline }
+				aria-disabled={ isOffline }
+			>
+				{ createButtonText }
+				<ArrowIcon />
+			</Button>
+		</Tooltip>
 	);
 };

--- a/src/components/connect-create-buttons.tsx
+++ b/src/components/connect-create-buttons.tsx
@@ -13,6 +13,7 @@ interface ConnectCreateButtonsProps {
 	createButtonVariant: ButtonVariant;
 	disableConnectButtonStyle?: boolean;
 	selectedSite: SiteDetails;
+	createButtonText?: string;
 }
 
 export const ConnectCreateButtons = ( {
@@ -22,6 +23,7 @@ export const ConnectCreateButtons = ( {
 	connectButtonVariant,
 	disableConnectButtonStyle,
 	selectedSite,
+	createButtonText = __( 'Create new site' ),
 }: ConnectCreateButtonsProps ) => {
 	return (
 		<>
@@ -62,7 +64,7 @@ export const ConnectCreateButtons = ( {
 					disabled={ isOffline }
 					aria-disabled={ isOffline }
 				>
-					{ __( 'Create new site' ) }
+					{ createButtonText }
 					<ArrowIcon />
 				</Button>
 			</Tooltip>

--- a/src/components/connect-create-buttons.tsx
+++ b/src/components/connect-create-buttons.tsx
@@ -11,18 +11,21 @@ interface ConnectButtonProps {
 	connectButtonVariant: ButtonVariant;
 	connectSite?: () => void;
 	disableConnectButtonStyle?: boolean;
+	className?: string;
 }
 
 interface CreateButtonProps {
 	createButtonVariant: ButtonVariant;
 	selectedSite: SiteDetails;
 	createButtonText?: string;
+	className?: string;
 }
 
 export const ConnectButton = ( {
 	connectButtonVariant,
 	connectSite,
 	disableConnectButtonStyle,
+	className,
 }: ConnectButtonProps ) => {
 	const isOffline = useOffline();
 	return (
@@ -38,7 +41,8 @@ export const ConnectButton = ( {
 				aria-disabled={ isOffline }
 				variant={ connectButtonVariant }
 				className={ cx(
-					! disableConnectButtonStyle && ! isOffline && '!text-a8c-blueberry !shadow-a8c-blueberry'
+					! disableConnectButtonStyle && ! isOffline && '!text-a8c-blueberry !shadow-a8c-blueberry',
+					className
 				) }
 			>
 				{ __( 'Connect site' ) }
@@ -51,6 +55,7 @@ export const CreateButton = ( {
 	createButtonVariant,
 	selectedSite,
 	createButtonText = __( 'Create new site' ),
+	className,
 }: CreateButtonProps ) => {
 	const isOffline = useOffline();
 	return (
@@ -67,7 +72,7 @@ export const CreateButton = ( {
 					);
 				} }
 				variant={ createButtonVariant }
-				className={ cx( ! isOffline && '!text-a8c-blueberry !shadow-a8c-blueberry' ) }
+				className={ cx( ! isOffline && '!text-a8c-blueberry !shadow-a8c-blueberry', className ) }
 				disabled={ isOffline }
 				aria-disabled={ isOffline }
 			>

--- a/src/components/content-tab-sync.tsx
+++ b/src/components/content-tab-sync.tsx
@@ -212,6 +212,7 @@ export function ContentTabSync( { selectedSite }: { selectedSite: SiteDetails } 
 						}
 						handleConnect( newConnectedSite );
 					} }
+					selectedSite={ selectedSite }
 				/>
 			) }
 		</div>

--- a/src/components/content-tab-sync.tsx
+++ b/src/components/content-tab-sync.tsx
@@ -66,7 +66,7 @@ function CreateConnectSite( {
 		<div className="mt-8">
 			<div className="flex gap-4">
 				<ConnectButton
-					connectButtonVariant="primary"
+					variant="primary"
 					connectSite={ openSitesSyncSelector }
 					disableConnectButtonStyle={ true }
 				/>

--- a/src/components/content-tab-sync.tsx
+++ b/src/components/content-tab-sync.tsx
@@ -9,7 +9,7 @@ import { useOffline } from '../hooks/use-offline';
 import { getIpcApi } from '../lib/get-ipc-api';
 import { ArrowIcon } from './arrow-icon';
 import Button from './button';
-import { ConnectCreateButtons } from './connect-create-buttons';
+import { ConnectButton, CreateButton } from './connect-create-buttons';
 import offlineIcon from './offline-icon';
 import { SyncConnectedSites } from './sync-connected-sites';
 import { SyncSitesModalSelector } from './sync-sites-modal-selector';
@@ -65,13 +65,12 @@ function CreateConnectSite( {
 	return (
 		<div className="mt-8">
 			<div className="flex gap-4">
-				<ConnectCreateButtons
-					connectSite={ openSitesSyncSelector }
+				<ConnectButton
 					connectButtonVariant="primary"
-					createButtonVariant="secondary"
+					connectSite={ openSitesSyncSelector }
 					disableConnectButtonStyle={ true }
-					selectedSite={ selectedSite }
 				/>
+				<CreateButton createButtonVariant="secondary" selectedSite={ selectedSite } />
 			</div>
 		</div>
 	);

--- a/src/components/content-tab-sync.tsx
+++ b/src/components/content-tab-sync.tsx
@@ -61,14 +61,12 @@ function CreateConnectSite( {
 	selectedSite: SiteDetails;
 } ) {
 	const { __ } = useI18n();
-	const isOffline = useOffline();
 
 	return (
 		<div className="mt-8">
 			<div className="flex gap-4">
 				<ConnectCreateButtons
 					connectSite={ openSitesSyncSelector }
-					isOffline={ isOffline }
 					connectButtonVariant="primary"
 					createButtonVariant="secondary"
 					disableConnectButtonStyle={ true }

--- a/src/components/content-tab-sync.tsx
+++ b/src/components/content-tab-sync.tsx
@@ -70,7 +70,7 @@ function CreateConnectSite( {
 					connectSite={ openSitesSyncSelector }
 					disableConnectButtonStyle={ true }
 				/>
-				<CreateButton createButtonVariant="secondary" selectedSite={ selectedSite } />
+				<CreateButton variant="secondary" selectedSite={ selectedSite } />
 			</div>
 		</div>
 	);

--- a/src/components/sync-connected-sites.tsx
+++ b/src/components/sync-connected-sites.tsx
@@ -458,7 +458,7 @@ export function SyncConnectedSites( {
 			</div>
 
 			<div className="flex mt-auto gap-4 pt-5 pb-4 px-8 border-t border-a8c-gray-5 flex-shrink-0">
-				<ConnectButton connectButtonVariant="secondary" connectSite={ openSitesSyncSelector } />
+				<ConnectButton variant="secondary" connectSite={ openSitesSyncSelector } />
 			</div>
 		</div>
 	);

--- a/src/components/sync-connected-sites.tsx
+++ b/src/components/sync-connected-sites.tsx
@@ -409,8 +409,6 @@ export function SyncConnectedSites( {
 	disconnectSite: ( id: number ) => void;
 	selectedSite: SiteDetails;
 } ) {
-	const isOffline = useOffline();
-
 	const siteSections: ConnectedSiteSection[] = useMemo( () => {
 		const siteSections: ConnectedSiteSection[] = [];
 		const processedSites = new Set< number >();
@@ -462,7 +460,6 @@ export function SyncConnectedSites( {
 			<div className="flex mt-auto gap-4 pt-5 pb-4 px-8 border-t border-a8c-gray-5 flex-shrink-0">
 				<ConnectCreateButtons
 					connectSite={ openSitesSyncSelector }
-					isOffline={ isOffline }
 					connectButtonVariant="secondary"
 					createButtonVariant="secondary"
 					selectedSite={ selectedSite }

--- a/src/components/sync-connected-sites.tsx
+++ b/src/components/sync-connected-sites.tsx
@@ -15,7 +15,7 @@ import { getIpcApi } from '../lib/get-ipc-api';
 import { ArrowIcon } from './arrow-icon';
 import { Badge } from './badge';
 import Button from './button';
-import { ConnectCreateButtons } from './connect-create-buttons';
+import { ConnectButton } from './connect-create-buttons';
 import { OpenSitesSyncSelector } from './content-tab-sync';
 import { CircleRedCrossIcon } from './icons/circle-red-cross';
 import offlineIcon from './offline-icon';
@@ -458,13 +458,7 @@ export function SyncConnectedSites( {
 			</div>
 
 			<div className="flex mt-auto gap-4 pt-5 pb-4 px-8 border-t border-a8c-gray-5 flex-shrink-0">
-				<ConnectCreateButtons
-					connectSite={ openSitesSyncSelector }
-					connectButtonVariant="secondary"
-					createButtonVariant="secondary"
-					selectedSite={ selectedSite }
-					showCreateButton={ false }
-				/>
+				<ConnectButton connectButtonVariant="secondary" connectSite={ openSitesSyncSelector } />
 			</div>
 		</div>
 	);

--- a/src/components/sync-connected-sites.tsx
+++ b/src/components/sync-connected-sites.tsx
@@ -466,6 +466,7 @@ export function SyncConnectedSites( {
 					connectButtonVariant="secondary"
 					createButtonVariant="secondary"
 					selectedSite={ selectedSite }
+					showCreateButton={ false }
 				/>
 			</div>
 		</div>

--- a/src/components/sync-sites-modal-selector.tsx
+++ b/src/components/sync-sites-modal-selector.tsx
@@ -8,6 +8,7 @@ import { cx } from '../lib/cx';
 import { getIpcApi } from '../lib/get-ipc-api';
 import { Badge } from './badge';
 import Button from './button';
+import { ConnectCreateButtons } from './connect-create-buttons';
 import Modal from './modal';
 import offlineIcon from './offline-icon';
 
@@ -19,12 +20,14 @@ export function SyncSitesModalSelector( {
 	onConnect,
 	syncSites,
 	onInitialRender,
+	selectedSite,
 }: {
 	isLoading?: boolean;
 	onRequestClose: () => void;
 	syncSites: SyncSite[];
 	onConnect: ( siteId: number ) => void;
 	onInitialRender?: () => void;
+	selectedSite: SiteDetails;
 } ) {
 	const { __ } = useI18n();
 	const [ selectedSiteId, setSelectedSiteId ] = useState< number | null >( null );
@@ -86,6 +89,7 @@ export function SyncSitesModalSelector( {
 						onRequestClose();
 					} }
 					disabled={ ! selectedSiteId }
+					selectedSite={ selectedSite }
 				/>
 
 				{ isOffline && (
@@ -271,14 +275,25 @@ function Footer( {
 	onRequestClose,
 	onConnect,
 	disabled,
+	selectedSite,
 }: {
 	onRequestClose: () => void;
 	onConnect: () => void;
 	disabled: boolean;
+	selectedSite: SiteDetails;
 } ) {
 	const { __ } = useI18n();
+	console.log( 'selectedSite', selectedSite );
+
 	return (
 		<div className="flex px-8 py-4 border-t border-a8c-gray-5 justify-between">
+			<ConnectCreateButtons
+				createButtonVariant="secondary"
+				connectButtonVariant="secondary"
+				showConnectButton={ false }
+				selectedSite={ selectedSite }
+				createButtonText={ __( 'Create new site' ) }
+			/>
 			<div className="flex gap-4">
 				<Button variant="link" onClick={ onRequestClose }>
 					{ __( 'Cancel' ) }

--- a/src/components/sync-sites-modal-selector.tsx
+++ b/src/components/sync-sites-modal-selector.tsx
@@ -283,7 +283,6 @@ function Footer( {
 	selectedSite: SiteDetails;
 } ) {
 	const { __ } = useI18n();
-	console.log( 'selectedSite', selectedSite );
 
 	return (
 		<div className="flex px-8 py-4 border-t border-a8c-gray-5 justify-between">

--- a/src/components/sync-sites-modal-selector.tsx
+++ b/src/components/sync-sites-modal-selector.tsx
@@ -287,9 +287,9 @@ function Footer( {
 	return (
 		<div className="flex px-8 py-4 border-t border-a8c-gray-5 justify-between">
 			<CreateButton
-				createButtonVariant="secondary"
+				variant="secondary"
 				selectedSite={ selectedSite }
-				createButtonText={ __( 'Create a new WordPress.com site' ) }
+				text={ __( 'Create a new WordPress.com site' ) }
 				className="!shadow-none !px-0"
 			/>
 			<div className="flex gap-4">

--- a/src/components/sync-sites-modal-selector.tsx
+++ b/src/components/sync-sites-modal-selector.tsx
@@ -10,7 +10,6 @@ import { Badge } from './badge';
 import Button from './button';
 import Modal from './modal';
 import offlineIcon from './offline-icon';
-import { WordPressShortLogo } from './wordpress-short-logo';
 
 const SearchControl = process.env.NODE_ENV === 'test' ? () => null : SearchControlWp;
 
@@ -280,14 +279,6 @@ function Footer( {
 	const { __ } = useI18n();
 	return (
 		<div className="flex px-8 py-4 border-t border-a8c-gray-5 justify-between">
-			<Button
-				variant="link"
-				className="flex items-center mb-1"
-				onClick={ () => getIpcApi().openURL( 'https://wordpress.com/hosting/' ) }
-			>
-				<div className="a8c-subtitle-small text-black">{ __( 'Powered by' ) }</div>
-				<WordPressShortLogo className="h-4.5" />
-			</Button>
 			<div className="flex gap-4">
 				<Button variant="link" onClick={ onRequestClose }>
 					{ __( 'Cancel' ) }

--- a/src/components/sync-sites-modal-selector.tsx
+++ b/src/components/sync-sites-modal-selector.tsx
@@ -8,7 +8,7 @@ import { cx } from '../lib/cx';
 import { getIpcApi } from '../lib/get-ipc-api';
 import { Badge } from './badge';
 import Button from './button';
-import { ConnectCreateButtons } from './connect-create-buttons';
+import { CreateButton } from './connect-create-buttons';
 import Modal from './modal';
 import offlineIcon from './offline-icon';
 
@@ -287,10 +287,8 @@ function Footer( {
 
 	return (
 		<div className="flex px-8 py-4 border-t border-a8c-gray-5 justify-between">
-			<ConnectCreateButtons
+			<CreateButton
 				createButtonVariant="secondary"
-				connectButtonVariant="secondary"
-				showConnectButton={ false }
 				selectedSite={ selectedSite }
 				createButtonText={ __( 'Create new site' ) }
 			/>

--- a/src/components/sync-sites-modal-selector.tsx
+++ b/src/components/sync-sites-modal-selector.tsx
@@ -290,7 +290,8 @@ function Footer( {
 			<CreateButton
 				createButtonVariant="secondary"
 				selectedSite={ selectedSite }
-				createButtonText={ __( 'Create new site' ) }
+				createButtonText={ __( 'Create a new WordPress.com site' ) }
+				className="!shadow-none !px-0"
 			/>
 			<div className="flex gap-4">
 				<Button variant="link" onClick={ onRequestClose }>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

Closes https://github.com/Automattic/dotcom-forge/issues/10081

## Proposed Changes

This PR moves the `Create a new WordPress.com site` button inside the modal to connect sites. Also, it removes `Create new site` button from the Sync tab:

**Modal before**:

<img width="691" alt="Screenshot 2024-12-12 at 1 06 01 PM" src="https://github.com/user-attachments/assets/dac2053d-c0d6-48f0-81c6-d5ae8b319ba2" />

**Modal after**:

<img width="689" alt="Screenshot 2024-12-12 at 1 00 33 PM" src="https://github.com/user-attachments/assets/2068398f-7421-4b94-8c3e-a7b38baf2dfc" />

**Sync tab before**:

<img width="931" alt="Screenshot 2024-12-12 at 1 05 55 PM" src="https://github.com/user-attachments/assets/c8c1f0dd-6c94-4751-b7ac-d94a18b0baf4" />

**Sync tab after**:

<img width="908" alt="Screenshot 2024-12-12 at 1 00 24 PM" src="https://github.com/user-attachments/assets/6aff4202-5013-49b5-a213-fb4e175346ae" />

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
* Start the app with `npm start`
* Navigate to the `Sync` app on a Studio site where there are no sites connect
* Ensure that `Create new site` and `Connect site` buttons remain unchanged
* Click on `Connect site` 
* Observe that the modal shows the button to `Create a new WP.com site` at the bottom in the footer
* Connect a WP.com site
* Observe that at the footer on the `Sync` tab you can see only `Connect site` button

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
