### PR TITLE
Studio: Increase timeout in wp-cli-process and terminate database import on timeout

### DIFF
--- a/src/lib/wp-cli-process.ts
+++ b/src/lib/wp-cli-process.ts
@@ -121,12 +121,13 @@ export default class WpCliProcess {
 				resolve( data );
 			};
 
-			const timeoutHandler = () => {
-				// Kill the process on timeout
-				this.#killProcess().catch( ( error ) => {
+			const timeoutHandler = async () => {
+				try {
+					await this.#killProcess();
+				} catch ( error ) {
 					console.error( 'Failed to kill process after timeout:', error );
 					Sentry.captureException( error );
-				} );
+				}
 				process.removeListener( 'message', handler );
 				reject( new Error( `Request for message ${ originalMessage } timed out` ) );
 			};

--- a/src/lib/wp-cli-process.ts
+++ b/src/lib/wp-cli-process.ts
@@ -11,7 +11,7 @@ export type MessageName = 'execute';
 export type WpCliResult = ReturnType< typeof executeWPCli >;
 export type MessageCanceled = { error: Error; canceled: boolean };
 
-const DEFAULT_RESPONSE_TIMEOUT = 120000;
+const DEFAULT_RESPONSE_TIMEOUT = 180 * 1000;
 
 export default class WpCliProcess {
 	lastMessageId = 0;

--- a/src/lib/wp-cli-process.ts
+++ b/src/lib/wp-cli-process.ts
@@ -11,7 +11,7 @@ export type MessageName = 'execute';
 export type WpCliResult = ReturnType< typeof executeWPCli >;
 export type MessageCanceled = { error: Error; canceled: boolean };
 
-const DEFAULT_RESPONSE_TIMEOUT = 180000;
+const DEFAULT_RESPONSE_TIMEOUT = 180 * 1000;
 
 export default class WpCliProcess {
 	lastMessageId = 0;

--- a/src/lib/wp-cli-process.ts
+++ b/src/lib/wp-cli-process.ts
@@ -11,7 +11,7 @@ export type MessageName = 'execute';
 export type WpCliResult = ReturnType< typeof executeWPCli >;
 export type MessageCanceled = { error: Error; canceled: boolean };
 
-const DEFAULT_RESPONSE_TIMEOUT = 180 * 1000;
+const DEFAULT_RESPONSE_TIMEOUT = 120000;
 
 export default class WpCliProcess {
 	lastMessageId = 0;
@@ -122,8 +122,13 @@ export default class WpCliProcess {
 			};
 
 			const timeoutHandler = () => {
-				reject( new Error( `Request for message ${ originalMessage } timed out` ) );
+				// Kill the process on timeout
+				this.#killProcess().catch( ( error ) => {
+					console.error( 'Failed to kill process after timeout:', error );
+					Sentry.captureException( error );
+				} );
 				process.removeListener( 'message', handler );
+				reject( new Error( `Request for message ${ originalMessage } timed out` ) );
 			};
 			const timeoutId = setTimeout( timeoutHandler, timeout );
 			const cancelHandler = () => {

--- a/src/lib/wp-cli-process.ts
+++ b/src/lib/wp-cli-process.ts
@@ -122,12 +122,7 @@ export default class WpCliProcess {
 			};
 
 			const timeoutHandler = async () => {
-				try {
-					await this.#killProcess();
-				} catch ( error ) {
-					console.error( 'Failed to kill process after timeout:', error );
-					Sentry.captureException( error );
-				}
+				await this.#killProcess();
 				process.removeListener( 'message', handler );
 				reject( new Error( `Request for message ${ originalMessage } timed out` ) );
 			};

--- a/src/lib/wp-cli-process.ts
+++ b/src/lib/wp-cli-process.ts
@@ -11,7 +11,7 @@ export type MessageName = 'execute';
 export type WpCliResult = ReturnType< typeof executeWPCli >;
 export type MessageCanceled = { error: Error; canceled: boolean };
 
-const DEFAULT_RESPONSE_TIMEOUT = 120000;
+const DEFAULT_RESPONSE_TIMEOUT = 240000;
 
 export default class WpCliProcess {
 	lastMessageId = 0;

--- a/src/lib/wp-cli-process.ts
+++ b/src/lib/wp-cli-process.ts
@@ -11,7 +11,7 @@ export type MessageName = 'execute';
 export type WpCliResult = ReturnType< typeof executeWPCli >;
 export type MessageCanceled = { error: Error; canceled: boolean };
 
-const DEFAULT_RESPONSE_TIMEOUT = 240000;
+const DEFAULT_RESPONSE_TIMEOUT = 180000;
 
 export default class WpCliProcess {
 	lastMessageId = 0;

--- a/src/lib/wp-cli-process.ts
+++ b/src/lib/wp-cli-process.ts
@@ -11,7 +11,7 @@ export type MessageName = 'execute';
 export type WpCliResult = ReturnType< typeof executeWPCli >;
 export type MessageCanceled = { error: Error; canceled: boolean };
 
-const DEFAULT_RESPONSE_TIMEOUT = 180 * 1000;
+const DEFAULT_RESPONSE_TIMEOUT = 300 * 1000;
 
 export default class WpCliProcess {
 	lastMessageId = 0;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

Closes https://github.com/Automattic/dotcom-forge/issues/10032

## Proposed Changes

This PR increases the timeout for the `wp-cli-process` so that the database import does not fail for larger sites.

Some related details:

* While testing the backup from https://github.com/Automattic/dotcom-forge/issues/10032 , I noticed that the error is specifically related to executing wp-cli commands: `Warning during import of /var/folders/bj/1qgxs1qd6_z20tw9llkw842h0000gn/T/studio_backupsJr1QS/sql/wp_aiowps_events.sql: error when executing wp-cli command`. 
* After inspecting the error more and comparing other .sql files from the `wp_aiowps_` that have the same configuration, I noticed that `wp_aiowps_events.sql` is substantially larger.
* I suggest increasing the timeout in `wp-cli-process` so that the larger .sql files get processed without failing. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**To test the fix for importing larger .sql files**

* Download the backup for the site reported in CfT: https://mc.a8c.com/rewind/debugger.php?site=220627588# (you can produce the backup by clicking on `Create backup link` and download it after)
* Pull the changes from this branch
* Run `npm install && npm start`
* Open the Studio app
* Navigate to the Import / Export tab 
* Drop the backup into the Import field
* Wait for the import to finish
* Confirm the import finishes successfully
* You can also repeat the same steps on trunk and confirm that the database import fails

**To test the fix for terminating database import process when it fails**:

* Download the backup for the site reported in CfT: https://mc.a8c.com/rewind/debugger.php?site=220627588# (you can produce the backup by clicking on `Create backup link` and download it after)
* Pull the changes from this branch
* Set this [timeout to a shorter period of time](https://github.com/Automattic/studio/blob/196681da0903ae93bc9b04e548b86178e9d1808d/src/lib/wp-cli-process.ts#L14) e.g. 1 minute so that you do not have to wait for a long time for the import failure
*  Run `npm install && npm start`
* Open the Studio app
* Navigate to the Import / Export tab 
* Open `Activity Monitor` app on macOS
* Observe low CPU usage by Studio under the `CPU` tab (see screenshot for reference of what to look for):

![Screenshot 2024-12-16 at 11 29 17 AM](https://github.com/user-attachments/assets/cba635ef-fe7a-4d55-b4b9-3198c6128d32)

* Drop the backup into the Import field to start the import
* Observe that the CPU usage rises drastically
* Wait for the import to fail and click on `OK` once you see the error
* Check the `Activity Monitor` and confirm that CPU usage is dropped back down to initial state before import (approximately) 
* This will confirm that the import process is stopped and not running any further

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
