### PR TITLE
Studio: User settings modal throws console warnings for deprecated prop

### DIFF
--- a/src/components/language-picker.tsx
+++ b/src/components/language-picker.tsx
@@ -16,7 +16,7 @@ export const LanguagePicker = () => {
 					value: locale as SupportedLocale,
 					label,
 				} ) ) }
-				__nextHasNoMarginBottom={ true }
+				__nextHasNoMarginBottom
 				className="mb-2"
 			/>
 		</div>

--- a/src/components/language-picker.tsx
+++ b/src/components/language-picker.tsx
@@ -16,6 +16,8 @@ export const LanguagePicker = () => {
 					value: locale as SupportedLocale,
 					label,
 				} ) ) }
+				__nextHasNoMarginBottom={ true }
+				className="mb-2"
 			/>
 		</div>
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

Closes https://github.com/Automattic/dotcom-forge/issues/10136

## Proposed Changes

This PR passes `__nextHasNoMarginBottom` prop as true for `SelectControl` and adds back the margin as a classname. This ensures that there are no React warnings in the console.

## Testing Instructions

* Pull the changes from this branch
* Start Studio app with `npm start`
* Click on the user profile picture in the top right corner
* Open developer tools
* Confirm that there is no warnings in the console
* Confirm that User Settings modals looks the same as before

**Before**

![Screenshot 2024-12-13 at 2 12 30 PM](https://github.com/user-attachments/assets/2e42ef2d-7a36-43b7-bb52-02bbc8cc2eed)

**After**

![Screenshot 2024-12-13 at 2 13 45 PM](https://github.com/user-attachments/assets/c716ad36-613e-4cc5-ad42-ac13fc4f9f8b)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
