### PR TITLE
Console the Push Sync error to save it in Studio current.log

### DIFF
--- a/src/hooks/sync-sites/use-sync-push.ts
+++ b/src/hooks/sync-sites/use-sync-push.ts
@@ -134,6 +134,7 @@ export function useSyncPush( {
 				const result = await getIpcApi().exportSiteToPush( selectedSite.id );
 				( { archiveContent, archivePath, archiveSizeInBytes } = result );
 			} catch ( error ) {
+				console.error( error );
 				Sentry.captureException( error );
 				updatePushState( selectedSite.id, remoteSiteId, {
 					status: pushStatesProgressInfo.failed,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- follow-up https://github.com/Automattic/dotcom-forge/issues/10097#issuecomment-2545258085
- 

## Proposed Changes

- Output the push error in `~/Library/Logs/Studio/current.log`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Apply this diff to produce an error when push
```
diff --git a/src/hooks/sync-sites/use-sync-push.ts b/src/hooks/sync-sites/use-sync-push.ts
index 435870e..b0d825c 100644
--- a/src/hooks/sync-sites/use-sync-push.ts
+++ b/src/hooks/sync-sites/use-sync-push.ts
@@ -131,6 +131,7 @@ export function useSyncPush( {
                        let archiveContent, archivePath, archiveSizeInBytes;
 
                        try {
+                               throw new Error( 'Test error' );
                                const result = await getIpcApi().exportSiteToPush( selectedSite.id );
                                ( { archiveContent, archivePath, archiveSizeInBytes } = result );
                        } catch ( error ) {
```
- Open the console and run: `tail -f ~/Library/Logs/Studio/current.log`
- Run `STUDIO_SITE_SYNC=true npm start`
- Go to Sync tab and click on Push 
- Observe the error is logged in the `~/Library/Logs/Studio/current.log` file

Example:

```
> tail -f ~/Library/Logs/Studio/current.log
[2024-12-16T15:40:52.355Z][erro][ren1] Error: Test error
    at http://localhost:3456/main_window/index.js:275215:19
    at Generator.next (<anonymous>)
    at http://localhost:3456/main_window/index.js:275124:71
    at new Promise (<anonymous>)
    at __webpack_modules__../src/hooks/sync-sites/use-sync-push.ts.__awaiter (http://localhost:3456/main_window/index.js:275120:12)
    at http://localhost:3456/main_window/index.js:275202:80
    at http://localhost:3456/main_window/index.js:273702:17
    at http://localhost:3456/main_window/index.js:276405:13
    at Generator.next (<anonymous>)
    at fulfilled (http://localhost:3456/main_window/index.js:276373:58)
[2024-12-16T15:40:52.357Z][erro][main] Sentry Logger [error]: Transport disabled
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
