### PR TITLE
Update WP CLI error handling

### DIFF
--- a/src/hooks/sync-sites/use-sync-push.ts
+++ b/src/hooks/sync-sites/use-sync-push.ts
@@ -139,8 +139,11 @@ export function useSyncPush( {
 					status: pushStatesProgressInfo.failed,
 				} );
 				getIpcApi().showErrorMessageBox( {
-					title: sprintf( __( 'Error exporting site to %s' ), connectedSite.name ),
-					message: __( 'Studio was unable to export the site.' ),
+					title: sprintf( __( 'Error pushing to %s' ), connectedSite.name ),
+					message: __(
+						'An error occurred while pushing the site. If this problem persists, please contact support.'
+					),
+					error,
 				} );
 				return;
 			}

--- a/src/hooks/use-chat-context.tsx
+++ b/src/hooks/use-chat-context.tsx
@@ -53,12 +53,8 @@ const parseWpCliOutput = ( stdout: string, defaultValue: string[] ): string[] =>
 		const data = JSON.parse( stdout );
 		return data?.map( ( item: { name: string } ) => item.name ) || [];
 	} catch ( error ) {
-		console.error( error, stdout );
-		Sentry.captureException( error, {
-			extra: { stdout },
-		} );
+		return defaultValue;
 	}
-	return defaultValue;
 };
 
 export const ChatProvider: React.FC< ChatProviderProps > = ( { children } ) => {

--- a/src/hooks/use-chat-context.tsx
+++ b/src/hooks/use-chat-context.tsx
@@ -53,8 +53,11 @@ const parseWpCliOutput = ( stdout: string, defaultValue: string[] ): string[] =>
 		const data = JSON.parse( stdout );
 		return data?.map( ( item: { name: string } ) => item.name ) || [];
 	} catch ( error ) {
-		return defaultValue;
+		Sentry.captureException( error, {
+			extra: { stdout },
+		} );
 	}
+	return defaultValue;
 };
 
 export const ChatProvider: React.FC< ChatProviderProps > = ( { children } ) => {

--- a/src/lib/import-export/export/export-database.ts
+++ b/src/lib/import-export/export/export-database.ts
@@ -47,7 +47,7 @@ export async function exportDatabaseToMultipleFiles(
 	}
 
 	const tablesResult = await server.executeWpCliCommand(
-		`sqlite tables --format=csv --require=/tmp/sqlite-command/command.php`
+		`sqlite tables --format=json --require=/tmp/sqlite-command/command.php`
 	);
 	if ( tablesResult.stderr ) {
 		throw new Error( `Database export failed: ${ tablesResult.stderr }` );
@@ -55,7 +55,17 @@ export async function exportDatabaseToMultipleFiles(
 	if ( tablesResult.exitCode ) {
 		throw new Error( 'Database export failed' );
 	}
-	const tables = tablesResult.stdout.split( ',' );
+
+	let tables;
+
+	try {
+		tables = JSON.parse( tablesResult.stdout );
+	} catch ( error ) {
+		console.error(
+			`Could not get list of database tables. The WP CLI output: ${ tablesResult.stdout }`
+		);
+		throw new Error( 'Could not get list of database tables to export.' );
+	}
 
 	const tmpFiles: string[] = [];
 

--- a/src/lib/import-export/export/exporters/default-exporter.ts
+++ b/src/lib/import-export/export/exporters/default-exporter.ts
@@ -273,13 +273,18 @@ export class DefaultExporter extends EventEmitter implements Exporter {
 
 		if ( stderr ) {
 			console.error( `Could not get information about plugins: ${ stderr }` );
-			return [];
+			throw new Error(
+				'Could not get information about installed plugins to create meta.json file.'
+			);
 		}
 
 		try {
 			return JSON.parse( stdout );
 		} catch ( error ) {
-			return [];
+			console.error( `Could not parse plugins list. The WP CLI output: ${ stdout }` );
+			throw new Error(
+				'Could not parse information about installed plugins to create meta.json file.'
+			);
 		}
 	}
 
@@ -296,13 +301,18 @@ export class DefaultExporter extends EventEmitter implements Exporter {
 
 		if ( stderr ) {
 			console.error( `Could not get information about themes: ${ stderr }` );
-			return [];
+			throw new Error(
+				'Could not get information about installed themes to create meta.json file.'
+			);
 		}
 
 		try {
 			return JSON.parse( stdout );
 		} catch ( error ) {
-			return [];
+			console.error( `Could not parse themes list. The WP CLI output: ${ stdout }` );
+			throw new Error(
+				'Could not parse information about installed themes to create meta.json file.'
+			);
 		}
 	}
 }

--- a/src/lib/import-export/export/exporters/default-exporter.ts
+++ b/src/lib/import-export/export/exporters/default-exporter.ts
@@ -276,7 +276,11 @@ export class DefaultExporter extends EventEmitter implements Exporter {
 			return [];
 		}
 
-		return JSON.parse( stdout );
+		try {
+			return JSON.parse( stdout );
+		} catch ( error ) {
+			return [];
+		}
 	}
 
 	private async getSiteThemes( site_id: string ) {
@@ -295,6 +299,10 @@ export class DefaultExporter extends EventEmitter implements Exporter {
 			return [];
 		}
 
-		return JSON.parse( stdout );
+		try {
+			return JSON.parse( stdout );
+		} catch ( error ) {
+			return [];
+		}
 	}
 }

--- a/src/lib/import-export/tests/export/exporters/default-exporter.test.ts
+++ b/src/lib/import-export/tests/export/exporters/default-exporter.test.ts
@@ -339,6 +339,8 @@ describe( 'DefaultExporter', () => {
 
 		const exporter = new DefaultExporter( mockOptions );
 
-		await expect( exporter.export() ).rejects.toThrow( 'Could not get information about installed plugins to create meta.json file.' );
+		await expect( exporter.export() ).rejects.toThrow(
+			'Could not get information about installed plugins to create meta.json file.'
+		);
 	} );
 } );

--- a/src/lib/import-export/tests/export/exporters/default-exporter.test.ts
+++ b/src/lib/import-export/tests/export/exporters/default-exporter.test.ts
@@ -116,7 +116,7 @@ describe( 'DefaultExporter', () => {
 					case /theme list/.test( command ):
 						return { stdout: '[{"name":"twentytwentyfour","status":"active","version":"1.0"}]' };
 					case /tables/.test( command ):
-						return { stdout: defaultTableNames.join( ',' ) };
+						return { stdout: JSON.stringify( defaultTableNames ) };
 					default:
 						return { stderr: null };
 				}
@@ -323,7 +323,7 @@ describe( 'DefaultExporter', () => {
 		expect( canHandle ).toBe( false );
 	} );
 
-	it( 'should not fail when can not get plugin or theme details', async () => {
+	it( 'should fail when can not get plugin or theme details', async () => {
 		( SiteServer.get as jest.Mock ).mockReturnValue( {
 			details: { path: '/path/to/site' },
 			executeWpCliCommand: jest.fn( function ( command: string ) {
@@ -338,10 +338,7 @@ describe( 'DefaultExporter', () => {
 		} );
 
 		const exporter = new DefaultExporter( mockOptions );
-		await exporter.export();
 
-		expect( mockArchiver.file ).toHaveBeenCalledWith( '/tmp/studio_export_123/meta.json', {
-			name: 'meta.json',
-		} );
+		await expect( exporter.export() ).rejects.toThrow( 'Could not get information about installed plugins to create meta.json file.' );
 	} );
 } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/dotcom-forge/issues/8961

## Proposed Changes

The Studio Assistant uses WP CLI to get the site's context data. When something is broken on the site's side, and the CLI command produces non-JSON output, the error is caught and logged to the browser console and Sentry. It's not helpful for the user as the user doesn't have access to the browser console log and a message itself isn't too useful. I propose to remove this logger line.

We might remove Sentry logging, as those are not really helpful, too:

https://a8c.sentry.io/issues/5243457569/?project=4506612776501248&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&statsPeriod=14d&stream_index=16

I also propose to better catch errors received from the WP CLI when Studio fetches theme and plugin lists for meta.json purposes, and mark the export or push as failed with a proper message.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

> [!WARNING]  
> The PR depends on https://github.com/Automattic/wp-cli-sqlite-command/pull/9

### Push

1. Create a new local Studio site.
2. Open site in Terminal
3. Install and activate the plugin:
```
wp plugin install slider-revolution-search-replace
wp plugin activate slider-revolution-search-replace
```
4. Connect the site to one of your testing WPCOM sites.
5. Initiate the push operation.
6. Confirm there is a dialog with descriptive error and push is marked as failed

### Export
1. Use the site from previous test
2. Navigate to Import / Export tab
3. Export entire site
4. Confirm there is a dialog with descriptive error

### Browser console error
1. Open Studio's browser console
2. Switch between sites and tabs
3. Confirm there is no error in the browser console

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
