### PR TITLE
Studio: Display error message on push timeout

### DIFF
--- a/src/hooks/sync-sites/use-sync-push.ts
+++ b/src/hooks/sync-sites/use-sync-push.ts
@@ -88,6 +88,7 @@ export function useSyncPush( {
 			const response = await client.req.get< {
 				status: 'finished' | 'failed' | 'initial_backup_started' | 'archive_import_started';
 				success: boolean;
+				error?: string;
 			} >( {
 				path: `/sites/${ remoteSiteId }/studio-app/sync/import`,
 				apiNamespace: 'wpcom/v2',
@@ -105,6 +106,17 @@ export function useSyncPush( {
 				} );
 			} else if ( response.success && response.status === 'failed' ) {
 				status = pushStatesProgressInfo.failed;
+				getIpcApi().showErrorMessageBox( {
+					title: sprintf( __( 'Error pushing to %s' ), syncPushState.selectedSite.name ),
+					message:
+						response.error === 'Import timed out'
+							? __(
+									'A timeout error occurred while pushing the site. If this problem persists, please contact support.'
+							  )
+							: __(
+									'An error occurred while pushing the site. If this problem persists, please contact support.'
+							  ),
+				} );
 			}
 			// Update state in any case to keep polling push state
 			updatePushState( syncPushState.selectedSite.id, syncPushState.remoteSiteId, {

--- a/src/hooks/sync-sites/use-sync-push.ts
+++ b/src/hooks/sync-sites/use-sync-push.ts
@@ -111,7 +111,7 @@ export function useSyncPush( {
 					message:
 						response.error === 'Import timed out'
 							? __(
-									'A timeout error occurred while pushing the site. If this problem persists, please contact support.'
+									"A timeout error occurred while pushing the site, likely due to its large size. Please try reducing the site's content or files and try again. If the problem persists, contact support."
 							  )
 							: __(
 									'An error occurred while pushing the site. If this problem persists, please contact support.'


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

Closes: https://github.com/Automattic/dotcom-forge/issues/10073

## Proposed Changes

This PR displays an error in Studio UI when the push operation fails due to timeout:

![Screenshot 2024-12-18 at 11 47 24 AM](https://github.com/user-attachments/assets/6d25fd7c-6022-4994-b4b3-e23ac1051de8)

## Testing Instructions

* Pull changes from this branch
* Start Studio with `npm start`
* Reduce the timeout on your sandbox [on this in line to:](https://github.a8c.com/Automattic/wpcom/blob/8b0e94608abb2a887d6cc2f48ddaa84dcf5d6c2d/wp-content/mu-plugins/site-studio/class.site-studio-import-manager.php#L38)

```
private const IMPORT_TIMEOUT= 6 * HOUR_IN_SECONDS
```

I used something like this:

```
private const IMPORT_TIMEOUT = MINUTE_IN_SECONDS / 2;
```

* Sandbox the `studio_site_import_process` by adding the following code to your 0-sandox.php file:

```
add_filter( 'sandbox_async_job', function( $sandboxed, $type ) {
	return $type === 'studio_site_import_process';
}, 10, 2 );
```
* In another terminal window, start the watcher with: `php async-jobs/watcher.php`
* Sandbox the public API
* In Studio, navigate to `Sync` tab
* Start push operation on one of the connected sites
* Wait for the timeout to occur
* Observe that you see the warning informing you about the timeout error and that the push fails

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
