### PR TITLE
Update message when WASM returns an error and allow user to restart the server

### DIFF
--- a/src/hooks/use-site-details.tsx
+++ b/src/hooks/use-site-details.tsx
@@ -278,7 +278,6 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 			try {
 				updatedSite = await getIpcApi().startServer( id );
 			} catch ( error ) {
-				Sentry.captureException( error );
 				getIpcApi().showErrorMessageBox( {
 					title: __( 'Failed to start the site server' ),
 					message: __(

--- a/src/hooks/use-site-details.tsx
+++ b/src/hooks/use-site-details.tsx
@@ -279,19 +279,24 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 				updatedSite = await getIpcApi().startServer( id );
 			} catch ( error ) {
 				Sentry.captureException( error );
+				let message = __(
+					"Please verify your site's local path directory contains the standard WordPress installation files and try again. If this problem persists, please contact support."
+				);
+				let errorToDisplay = error;
 				if (
 					error instanceof Error &&
 					error.message.includes( '"unreachable" WASM instruction executed' )
 				) {
-					error.message =
-						'Please try disabling plugins and themes that might be causing the issue.';
+					errorToDisplay = null;
+					message =
+						message +
+						'\n\n' +
+						__( 'Please try disabling plugins and themes that might be causing the issue.' );
 				}
 				getIpcApi().showErrorMessageBox( {
 					title: __( 'Failed to start the site server' ),
-					message: __(
-						"Please verify your site's local path directory contains the standard WordPress installation files and try again. If this problem persists, please contact support."
-					),
-					error,
+					message,
+					error: errorToDisplay,
 				} );
 				getIpcApi().stopServer( id );
 			}

--- a/src/hooks/use-site-details.tsx
+++ b/src/hooks/use-site-details.tsx
@@ -279,21 +279,12 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 				updatedSite = await getIpcApi().startServer( id );
 			} catch ( error ) {
 				Sentry.captureException( error );
-				let errorToDisplay = error;
-				if (
-					error instanceof Error &&
-					error.message.includes( '"unreachable" WASM instruction executed' )
-				) {
-					errorToDisplay = new Error(
-						__( 'Please try disabling plugins and themes that might be causing the issue.' )
-					);
-				}
 				getIpcApi().showErrorMessageBox( {
 					title: __( 'Failed to start the site server' ),
 					message: __(
 						"Please verify your site's local path directory contains the standard WordPress installation files and try again. If this problem persists, please contact support."
 					),
-					error: errorToDisplay,
+					error,
 				} );
 				await getIpcApi().stopServer( id );
 			}

--- a/src/hooks/use-site-details.tsx
+++ b/src/hooks/use-site-details.tsx
@@ -279,23 +279,20 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 				updatedSite = await getIpcApi().startServer( id );
 			} catch ( error ) {
 				Sentry.captureException( error );
-				let message = __(
-					"Please verify your site's local path directory contains the standard WordPress installation files and try again. If this problem persists, please contact support."
-				);
 				let errorToDisplay = error;
 				if (
 					error instanceof Error &&
 					error.message.includes( '"unreachable" WASM instruction executed' )
 				) {
-					errorToDisplay = null;
-					message =
-						message +
-						'\n\n' +
-						__( 'Please try disabling plugins and themes that might be causing the issue.' );
+					errorToDisplay = new Error(
+						__( 'Please try disabling plugins and themes that might be causing the issue.' )
+					);
 				}
 				getIpcApi().showErrorMessageBox( {
 					title: __( 'Failed to start the site server' ),
-					message,
+					message: __(
+						"Please verify your site's local path directory contains the standard WordPress installation files and try again. If this problem persists, please contact support."
+					),
 					error: errorToDisplay,
 				} );
 				await getIpcApi().stopServer( id );

--- a/src/hooks/use-site-details.tsx
+++ b/src/hooks/use-site-details.tsx
@@ -279,6 +279,13 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 				updatedSite = await getIpcApi().startServer( id );
 			} catch ( error ) {
 				Sentry.captureException( error );
+				if (
+					error instanceof Error &&
+					error.message.includes( '"unreachable" WASM instruction executed' )
+				) {
+					error.message =
+						'Please try disabling plugins and themes that might be causing the issue.';
+				}
 				getIpcApi().showErrorMessageBox( {
 					title: __( 'Failed to start the site server' ),
 					message: __(

--- a/src/hooks/use-site-details.tsx
+++ b/src/hooks/use-site-details.tsx
@@ -298,7 +298,7 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 					message,
 					error: errorToDisplay,
 				} );
-				getIpcApi().stopServer( id );
+				await getIpcApi().stopServer( id );
 			}
 
 			if ( updatedSite ) {

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -388,7 +388,17 @@ export async function startServer(
 	await keepSqliteIntegrationUpdated( server.details.path );
 
 	const parentWindow = BrowserWindow.fromWebContents( event.sender );
-	await server.start();
+	try {
+		await server.start();
+	} catch ( error ) {
+		if (
+			error instanceof Error &&
+			error.message.includes( '"unreachable" WASM instruction executed' )
+		) {
+			throw new Error( 'Please try disabling plugins and themes that might be causing the issue.' );
+		}
+		throw error;
+	}
 	if ( parentWindow && ! parentWindow.isDestroyed() && ! event.sender.isDestroyed() ) {
 		parentWindow.webContents.send( 'theme-details-changed', id, server.details.themeDetails );
 	}

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -391,6 +391,7 @@ export async function startServer(
 	try {
 		await server.start();
 	} catch ( error ) {
+		Sentry.captureException( error );
 		if (
 			error instanceof Error &&
 			error.message.includes( '"unreachable" WASM instruction executed' )

--- a/src/lib/site-server-process.ts
+++ b/src/lib/site-server-process.ts
@@ -18,6 +18,7 @@ export default class SiteServerProcess {
 	process?: UtilityProcess;
 	php?: { documentRoot: string };
 	url: string;
+	exitCode: number | null = null;
 
 	constructor( options: WPNowOptions ) {
 		this.options = options;
@@ -42,6 +43,7 @@ export default class SiteServerProcess {
 				}
 			};
 			const exitListener = ( code: number ) => {
+				this.exitCode = code;
 				if ( code !== 0 ) {
 					reject( new Error( `Site server process exited with code ${ code } upon starting` ) );
 				}
@@ -147,7 +149,15 @@ export default class SiteServerProcess {
 				}
 				resolve();
 			} );
-			process.kill();
+
+			const killResult = process.kill();
+			if ( ! killResult ) {
+				reject(
+					new Error(
+						`Failed to kill server process. Child server process exited with code: ${ this.exitCode }`
+					)
+				);
+			}
 		} ).catch( ( error ) => {
 			Sentry.captureException( error );
 		} );

--- a/src/lib/site-server-process.ts
+++ b/src/lib/site-server-process.ts
@@ -137,8 +137,8 @@ export default class SiteServerProcess {
 
 	async #killProcess(): Promise< void > {
 		const process = this.process;
-		if ( ! process ) {
-			throw Error( 'Server process is not running' );
+		if ( ! process || this.exitCode !== null ) {
+			throw Error( 'Server process is not running. Exit code: ' + this.exitCode );
 		}
 
 		return new Promise< void >( ( resolve, reject ) => {
@@ -150,14 +150,7 @@ export default class SiteServerProcess {
 				resolve();
 			} );
 
-			const killResult = process.kill();
-			if ( ! killResult ) {
-				reject(
-					new Error(
-						`Failed to kill server process. Child server process exited with code: ${ this.exitCode }`
-					)
-				);
-			}
+			process.kill();
 		} ).catch( ( error ) => {
 			Sentry.captureException( error );
 		} );

--- a/src/lib/site-server-process.ts
+++ b/src/lib/site-server-process.ts
@@ -149,7 +149,6 @@ export default class SiteServerProcess {
 				}
 				resolve();
 			} );
-
 			process.kill();
 		} ).catch( ( error ) => {
 			Sentry.captureException( error );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/dotcom-forge/issues/10037

## Proposed Changes

- Reject promise when the server dies when starting a server, so it can be started again by the user. 
- Change the message displayed to the user when we get the `"unreachable" WASM instruction executed`

Before this PR, when a site crashed, it got unresponsive, and users couldn't re-try starting it again.
The reason is that the server child process failed and didn't resolve or rejected a promise when stopping the site, which let the main thread waiting for messages. This was fixed on : https://github.com/Automattic/studio/commit/a4afa3402b3b5ca805eea36a53908153bdea3c9b

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Download a backup with a plugin that fails already activated. There is an example in the issue.
- Run `npm start`
- Create a blank site
- Go to the import tab
- Drag and drop the backup file
- Wait until the import succeeds
- Observe the site tries starting
- Observe a popup error saying : "[...] Please try disabling plugins and themes that might be causing the issue."
- Close the popup, wait a couple of seconds
- Click on start again
- Observe the same popup


## Before

<img width="1012" alt="Screenshot 2024-12-19 at 16 07 03" src="https://github.com/user-attachments/assets/6d7fe1e8-8493-46f9-9aa4-bf72fd551198" />

## After


<img width="1032" alt="Screenshot 2024-12-20 at 12 16 40" src="https://github.com/user-attachments/assets/9cc049a1-6cf0-4c3b-8495-44ce176de02d" />



![WEFING.gif](https://github.com/user-attachments/assets/9d2cda5e-8413-4d85-b0b5-7e6e9d0520b3)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?