### PR TITLE
Studio: Remove connect site button when already exists a Sync connection

### DIFF
--- a/src/components/sync-connected-sites.tsx
+++ b/src/components/sync-connected-sites.tsx
@@ -444,22 +444,16 @@ export function SyncConnectedSites( {
 	}, [ connectedSites ] );
 
 	return (
-		<div className="flex flex-col h-full overflow-hidden">
-			<div className="flex flex-col flex-1 pt-8 overflow-y-auto">
-				{ siteSections.map( ( section ) => (
-					<SyncConnectedSitesSection
-						key={ section.id }
-						section={ section }
-						selectedSite={ selectedSite }
-						disconnectSite={ disconnectSite }
-						openSitesSyncSelector={ openSitesSyncSelector }
-					/>
-				) ) }
-			</div>
-
-			<div className="flex mt-auto gap-4 pt-5 pb-4 px-8 border-t border-a8c-gray-5 flex-shrink-0">
-				<ConnectButton variant="secondary" connectSite={ openSitesSyncSelector } />
-			</div>
+		<div className="flex flex-col flex-1 pt-8 overflow-y-auto">
+			{ siteSections.map( ( section ) => (
+				<SyncConnectedSitesSection
+					key={ section.id }
+					section={ section }
+					selectedSite={ selectedSite }
+					disconnectSite={ disconnectSite }
+					openSitesSyncSelector={ openSitesSyncSelector }
+				/>
+			) ) }
 		</div>
 	);
 }

--- a/src/components/sync-connected-sites.tsx
+++ b/src/components/sync-connected-sites.tsx
@@ -14,7 +14,6 @@ import { getIpcApi } from '../lib/get-ipc-api';
 import { ArrowIcon } from './arrow-icon';
 import { Badge } from './badge';
 import Button from './button';
-import { ConnectButton } from './connect-create-buttons';
 import { OpenSitesSyncSelector } from './content-tab-sync';
 import { CircleRedCrossIcon } from './icons/circle-red-cross';
 import offlineIcon from './offline-icon';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

Closes https://github.com/Automattic/dotcom-forge/issues/10158

## Proposed Changes

This PR removes the `Connect` button on the `Sync` screen when there is a connection already present. 

![Screenshot 2024-12-19 at 12 02 25 PM](https://github.com/user-attachments/assets/ba25e6b6-ef0f-40ef-87e7-132a6e677698)

## Testing Instructions

* Pull the changes from this branch
* Start Studio with `npm start`
* Navigate to a Studio site that has no sites connected
* Confirm that you can see `Connect site` button
* Connect a site
* Confirm that once a site is connected, there is no more `Connect site` button present on the `Sync` screen

Please note that this PR does not do any cleanup on the logic for connecting multiple sites to a local site. [As per this comment](https://github.com/Automattic/dotcom-forge/issues/10158#issuecomment-2552105836), we will create a separate logic to do this cleanup.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
