### PR TITLE
change placement of topbar elements tooltip to bottom-start

### DIFF
--- a/src/components/top-bar.tsx
+++ b/src/components/top-bar.tsx
@@ -14,10 +14,16 @@ interface TopBarProps {
 	onToggleSidebar: () => void;
 }
 
+const DEFAULT_TOOLTIP_PLACEMENT = 'bottom-start';
+
 function ToggleSidebar( { onToggleSidebar }: TopBarProps ) {
 	return (
 		<div className="app-no-drag-region">
-			<Tooltip text={ __( 'Toggle sidebar' ) } className="h-6">
+			<Tooltip
+				text={ __( 'Toggle sidebar' ) }
+				className="h-6"
+				placement={ DEFAULT_TOOLTIP_PLACEMENT }
+			>
 				<Button onClick={ onToggleSidebar } variant="icon" aria-label={ __( 'Toggle sidebar' ) }>
 					<Icon className="text-white" icon={ drawerLeft } size={ 24 } />
 				</Button>
@@ -44,6 +50,7 @@ function OfflineIndicator() {
 						</span>
 					}
 					className="h-6"
+					placement={ DEFAULT_TOOLTIP_PLACEMENT }
 				>
 					<Button
 						aria-label={ __( 'Offline indicator' ) }


### PR DESCRIPTION
## Related issues

- Fixes https://github.com/Automattic/dotcom-forge/issues/9896

## Proposed Changes

- Added a default tooltip placement constant (`DEFAULT_TOOLTIP_PLACEMENT`) set to 'bottom-start'
- Standardized tooltip placement across the top bar components:
  - Applied consistent placement to the sidebar toggle tooltip
  - Applied consistent placement to the offline indicator tooltip

## Testing Instructions

1. Launch the application
2. Test in LTR languages:
   - Hover over the sidebar toggle button in the top bar
     - Verify the tooltip appears from the bottom-start position
   - Toggle offline mode and hover over the offline indicator
     - Verify the tooltip appears from the bottom-start position

3. Test in RTL languages:
   - Switch the application language to an RTL language (e.g., Arabic, Hebrew)
   - Verify tooltip placement remains correct for:
     - Sidebar toggle button
     - Offline indicator
   - Ensure tooltips don't overlap with other UI elements
   - Confirm tooltips respect the RTL text direction

4. General checks:
   - Ensure tooltips remain visible and don't get cut off by screen edges
   - Verify consistent behavior across different screen sizes

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?