### PR TITLE
Studio: Ensure wp-config constants are defined after import

### DIFF
--- a/src/lib/import-export/import/importers/importer.ts
+++ b/src/lib/import-export/import/importers/importer.ts
@@ -200,58 +200,32 @@ abstract class BaseBackupImporter extends BaseImporter {
 
 		// First ensure we have a wp-config.php file
 		if ( this.backup.wpConfig ) {
-			await fsPromises.copyFile( this.backup.wpConfig, wpConfigPath );
+			try {
+				await fsPromises.copyFile( this.backup.wpConfig, wpConfigPath );
+			} catch ( error ) {
+				// If copying fails, fall back to sample config
+				if ( fs.existsSync( wpConfigSamplePath ) ) {
+					await fsPromises.copyFile( wpConfigSamplePath, wpConfigPath );
+				}
+			}
 		} else if ( ! fs.existsSync( wpConfigPath ) && fs.existsSync( wpConfigSamplePath ) ) {
 			await fsPromises.copyFile( wpConfigSamplePath, wpConfigPath );
 		}
 
-		// Read the current config content
+		const polyfill =
+			'<?php\n' +
+			'// Polyfill for missing database constants\n' +
+			"if (!defined('DB_HOST')) define('DB_HOST', 'localhost');\n" +
+			"if (!defined('DB_NAME')) define('DB_NAME', 'wordpress');\n" +
+			"if (!defined('DB_USER')) define('DB_USER', 'root');\n" +
+			"if (!defined('DB_PASSWORD')) define('DB_PASSWORD', '');\n" +
+			'?>\n';
+
 		const configContent = await readFile( wpConfigPath, 'utf8' );
 
-		// Check for missing constants
-		const requiredConstants = [ 'DB_HOST', 'DB_NAME', 'DB_USER', 'DB_PASSWORD' ];
-		const missingConstants: { [ key: string ]: string } = {};
-
-		for ( const constant of requiredConstants ) {
-			if (
-				! configContent.includes( `define('${ constant }'` ) &&
-				! configContent.includes( `define("${ constant }"` )
-			) {
-				// If constant is missing, add it to our list with a default value
-				missingConstants[ constant ] = this.getDefaultDbValue( constant );
-			}
-		}
-
-		// If we found missing constants, add them to the config
-		if ( Object.keys( missingConstants ).length > 0 ) {
-			// Create the constants definition block
-			const constantsBlock = Object.entries( missingConstants )
-				.map( ( [ constant, value ] ) => `define('${ constant }', '${ value }');` )
-				.join( '\n' );
-
-			// Find a good place to insert the constants (after the comment block if it exists)
-			const newContent = configContent.replace(
-				/\/\*\*[\s\S]*?\*\/\s*/,
-				( match ) => `${ match }\n${ constantsBlock }\n`
-			);
-
-			// Write the updated config back to the file
-			await writeFile( wpConfigPath, newContent );
-		}
-	}
-
-	private getDefaultDbValue( constant: string ): string {
-		switch ( constant ) {
-			case 'DB_HOST':
-				return 'localhost';
-			case 'DB_NAME':
-				return 'wordpress';
-			case 'DB_USER':
-				return 'root';
-			case 'DB_PASSWORD':
-				return '';
-			default:
-				return '';
+		// Only add polyfill if it's not already present
+		if ( ! configContent.includes( 'Polyfill for missing database constants' ) ) {
+			await writeFile( wpConfigPath, polyfill + configContent );
 		}
 	}
 

--- a/src/lib/import-export/import/importers/importer.ts
+++ b/src/lib/import-export/import/importers/importer.ts
@@ -198,7 +198,6 @@ abstract class BaseBackupImporter extends BaseImporter {
 		const wpConfigPath = path.join( rootPath, 'wp-config.php' );
 		const wpConfigSamplePath = path.join( rootPath, 'wp-config-sample.php' );
 
-		// First ensure we have a wp-config.php file
 		if ( this.backup.wpConfig ) {
 			try {
 				await fsPromises.copyFile( this.backup.wpConfig, wpConfigPath );
@@ -212,21 +211,18 @@ abstract class BaseBackupImporter extends BaseImporter {
 			await fsPromises.copyFile( wpConfigSamplePath, wpConfigPath );
 		}
 
+		const configContent = await readFile( wpConfigPath, 'utf8' );
 		const polyfill =
 			'<?php\n' +
-			'// Polyfill for missing database constants\n' +
+			"if (!defined('DB_NAME')) define('DB_NAME', 'database_name_here');\n" +
+			"if (!defined('DB_USER')) define('DB_USER', 'username_here');\n" +
+			"if (!defined('DB_PASSWORD')) define('DB_PASSWORD', 'password_here');\n" +
 			"if (!defined('DB_HOST')) define('DB_HOST', 'localhost');\n" +
-			"if (!defined('DB_NAME')) define('DB_NAME', 'wordpress');\n" +
-			"if (!defined('DB_USER')) define('DB_USER', 'root');\n" +
-			"if (!defined('DB_PASSWORD')) define('DB_PASSWORD', '');\n" +
+			"if (!defined('DB_CHARSET')) define('DB_CHARSET', 'utf8');\n" +
+			"if (!defined('DB_COLLATE')) define('DB_COLLATE', '');\n" +
 			'?>\n';
 
-		const configContent = await readFile( wpConfigPath, 'utf8' );
-
-		// Only add polyfill if it's not already present
-		if ( ! configContent.includes( 'Polyfill for missing database constants' ) ) {
-			await writeFile( wpConfigPath, polyfill + configContent );
-		}
+		await writeFile( wpConfigPath, polyfill + configContent );
 	}
 
 	protected async importWpContent( rootPath: string ): Promise< void > {

--- a/src/lib/import-export/import/importers/importer.ts
+++ b/src/lib/import-export/import/importers/importer.ts
@@ -1,7 +1,7 @@
 import { shell } from 'electron';
 import { EventEmitter } from 'events';
 import fs, { createReadStream, createWriteStream } from 'fs';
-import fsPromises from 'fs/promises';
+import fsPromises, { readFile, writeFile } from 'fs/promises';
 import path from 'path';
 import { createInterface } from 'readline';
 import { lstat, move } from 'fs-extra';
@@ -198,10 +198,60 @@ abstract class BaseBackupImporter extends BaseImporter {
 		const wpConfigPath = path.join( rootPath, 'wp-config.php' );
 		const wpConfigSamplePath = path.join( rootPath, 'wp-config-sample.php' );
 
+		// First ensure we have a wp-config.php file
 		if ( this.backup.wpConfig ) {
 			await fsPromises.copyFile( this.backup.wpConfig, wpConfigPath );
 		} else if ( ! fs.existsSync( wpConfigPath ) && fs.existsSync( wpConfigSamplePath ) ) {
 			await fsPromises.copyFile( wpConfigSamplePath, wpConfigPath );
+		}
+
+		// Read the current config content
+		const configContent = await readFile( wpConfigPath, 'utf8' );
+
+		// Check for missing constants
+		const requiredConstants = [ 'DB_HOST', 'DB_NAME', 'DB_USER', 'DB_PASSWORD' ];
+		const missingConstants: { [ key: string ]: string } = {};
+
+		for ( const constant of requiredConstants ) {
+			if (
+				! configContent.includes( `define('${ constant }'` ) &&
+				! configContent.includes( `define("${ constant }"` )
+			) {
+				// If constant is missing, add it to our list with a default value
+				missingConstants[ constant ] = this.getDefaultDbValue( constant );
+			}
+		}
+
+		// If we found missing constants, add them to the config
+		if ( Object.keys( missingConstants ).length > 0 ) {
+			// Create the constants definition block
+			const constantsBlock = Object.entries( missingConstants )
+				.map( ( [ constant, value ] ) => `define('${ constant }', '${ value }');` )
+				.join( '\n' );
+
+			// Find a good place to insert the constants (after the comment block if it exists)
+			const newContent = configContent.replace(
+				/\/\*\*[\s\S]*?\*\/\s*/,
+				( match ) => `${ match }\n${ constantsBlock }\n`
+			);
+
+			// Write the updated config back to the file
+			await writeFile( wpConfigPath, newContent );
+		}
+	}
+
+	private getDefaultDbValue( constant: string ): string {
+		switch ( constant ) {
+			case 'DB_HOST':
+				return 'localhost';
+			case 'DB_NAME':
+				return 'wordpress';
+			case 'DB_USER':
+				return 'root';
+			case 'DB_PASSWORD':
+				return '';
+			default:
+				return '';
 		}
 	}
 

--- a/src/lib/import-export/import/importers/importer.ts
+++ b/src/lib/import-export/import/importers/importer.ts
@@ -200,14 +200,7 @@ abstract class BaseBackupImporter extends BaseImporter {
 
 		// First ensure we have a wp-config.php file
 		if ( this.backup.wpConfig ) {
-			try {
-				await fsPromises.copyFile( this.backup.wpConfig, wpConfigPath );
-			} catch ( error ) {
-				// If copying fails, fall back to sample config
-				if ( fs.existsSync( wpConfigSamplePath ) ) {
-					await fsPromises.copyFile( wpConfigSamplePath, wpConfigPath );
-				}
-			}
+			await fsPromises.copyFile( this.backup.wpConfig, wpConfigPath );
 		} else if ( ! fs.existsSync( wpConfigPath ) && fs.existsSync( wpConfigSamplePath ) ) {
 			await fsPromises.copyFile( wpConfigSamplePath, wpConfigPath );
 		}

--- a/src/lib/import-export/import/importers/importer.ts
+++ b/src/lib/import-export/import/importers/importer.ts
@@ -198,6 +198,7 @@ abstract class BaseBackupImporter extends BaseImporter {
 		const wpConfigPath = path.join( rootPath, 'wp-config.php' );
 		const wpConfigSamplePath = path.join( rootPath, 'wp-config-sample.php' );
 
+		// First ensure we have a wp-config.php file
 		if ( this.backup.wpConfig ) {
 			try {
 				await fsPromises.copyFile( this.backup.wpConfig, wpConfigPath );
@@ -212,17 +213,22 @@ abstract class BaseBackupImporter extends BaseImporter {
 		}
 
 		const configContent = await readFile( wpConfigPath, 'utf8' );
-		const polyfill =
-			'<?php\n' +
-			"if (!defined('DB_NAME')) define('DB_NAME', 'database_name_here');\n" +
-			"if (!defined('DB_USER')) define('DB_USER', 'username_here');\n" +
-			"if (!defined('DB_PASSWORD')) define('DB_PASSWORD', 'password_here');\n" +
-			"if (!defined('DB_HOST')) define('DB_HOST', 'localhost');\n" +
-			"if (!defined('DB_CHARSET')) define('DB_CHARSET', 'utf8');\n" +
-			"if (!defined('DB_COLLATE')) define('DB_COLLATE', '');\n" +
-			'?>\n';
 
-		await writeFile( wpConfigPath, polyfill + configContent );
+		// Add a unique marker comment to identify our polyfill
+		if ( ! configContent.includes( '/* WP_POLYFILL_MARKER */' ) ) {
+			const polyfill =
+				'<?php\n' +
+				'/* WP_POLYFILL_MARKER */\n' +
+				"if (!defined('DB_NAME')) define('DB_NAME', 'database_name_here');\n" +
+				"if (!defined('DB_USER')) define('DB_USER', 'username_here');\n" +
+				"if (!defined('DB_PASSWORD')) define('DB_PASSWORD', 'password_here');\n" +
+				"if (!defined('DB_HOST')) define('DB_HOST', 'localhost');\n" +
+				"if (!defined('DB_CHARSET')) define('DB_CHARSET', 'utf8');\n" +
+				"if (!defined('DB_COLLATE')) define('DB_COLLATE', '');\n" +
+				'?>\n';
+
+			await writeFile( wpConfigPath, polyfill + configContent );
+		}
 	}
 
 	protected async importWpContent( rootPath: string ): Promise< void > {

--- a/src/lib/import-export/tests/import/importer/default-importer.test.ts
+++ b/src/lib/import-export/tests/import/importer/default-importer.test.ts
@@ -107,7 +107,7 @@ describe( 'JetpackImporter', () => {
 
 			expect( fs.mkdir ).toHaveBeenCalled();
 			expect( fs.copyFile ).toHaveBeenCalledTimes( 4 );
-			expect( fs.readFile ).not.toHaveBeenCalled();
+			expect( fs.readFile ).toHaveBeenCalledTimes( 1 );
 		} );
 
 		it( 'should handle JSON parse error in meta file', async () => {

--- a/src/lib/import-export/tests/import/importer/local-importer.test.ts
+++ b/src/lib/import-export/tests/import/importer/local-importer.test.ts
@@ -86,7 +86,7 @@ describe( 'localImporter', () => {
 
 			expect( fs.mkdir ).toHaveBeenCalled();
 			expect( fs.copyFile ).toHaveBeenCalledTimes( 4 );
-			expect( fs.readFile ).not.toHaveBeenCalled();
+			expect( fs.readFile ).toHaveBeenCalledTimes( 1 );
 		} );
 
 		it( 'should handle JSON parse error in meta file', async () => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

Closes https://github.com/Automattic/dotcom-forge/issues/10148

## Proposed Changes

This PR adds polyfill for database constants in case they are not defined in the `wp-config.php` file when it is being imported. This ensures that the database constants are defined when the site is started.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
* Download a backup from this site: https://mc.a8c.com/rewind/debugger.php?site=138657400
* Navigate to Import/Export tab in Studio
* Drop this backup to import it into a site
* Observe that the import succeeds and the site starts successfully

Alternatively, you can export a Studio site, edit `wp-config.php` file and remove the constants such as `DB_HOST` etc. from that file. You can then attempt to import it and confirm that the import succeeds and that the site starts successfully. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
