### PR TITLE
Studio: Fix spacing between the offline and toggle sidebar icons for RTL languages

### DIFF
--- a/src/components/top-bar.tsx
+++ b/src/components/top-bar.tsx
@@ -104,7 +104,7 @@ export default function TopBar( { onToggleSidebar }: TopBarProps ) {
 
 	return (
 		<div className="flex justify-between items-center text-white px-2 pb-2 pt-1.5">
-			<div className="flex items-center space-x-1.5">
+			<div className="flex items-center space-x-1.5 rtl:space-x-reverse">
 				<ToggleSidebar onToggleSidebar={ onToggleSidebar } />
 				<OfflineIndicator />
 			</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

Closes https://github.com/Automattic/dotcom-forge/issues/10167

## Proposed Changes

This PR adds spacing between the offline icon and toggle sidebar button in the topbar for rtl languages:

**Before**

![Screenshot 2024-12-20 at 3 41 18 PM](https://github.com/user-attachments/assets/100ec472-4235-4780-bf62-cbda4fe17f1e)

**After**

![Screenshot 2024-12-20 at 4 39 11 PM](https://github.com/user-attachments/assets/294645ab-8aaf-46b9-be1c-5f8d0932e3c3)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
* Start Studio with `npm start`
* Switch the app to RTL language e.g. Hebrew
* Turn off WiFi to display the offline icon
* Observe the spacing between the icons
* Switch back to LTR language
* Confirm that the spacing looks correct and remains unaffected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
