### PR TITLE
Studio: make sure the search and replace database work properly in all images

### DIFF
--- a/src/lib/import-export/import/importers/importer.ts
+++ b/src/lib/import-export/import/importers/importer.ts
@@ -102,7 +102,7 @@ abstract class BaseImporter extends EventEmitter implements Importer {
 
 		for ( const urlToReplace of [ oldUrlHttps, oldUrlHttp ] ) {
 			const { stderr, exitCode } = await server.executeWpCliCommand(
-				`search-replace '${ urlToReplace }' '${ studioUrl }' wp_posts wp_postmeta wp_options`,
+				`search-replace '${ urlToReplace }' '${ studioUrl }'`,
 				{ skipPluginsAndThemes: true }
 			);
 

--- a/src/lib/import-export/import/importers/importer.ts
+++ b/src/lib/import-export/import/importers/importer.ts
@@ -71,7 +71,7 @@ abstract class BaseImporter extends EventEmitter implements Importer {
 				await this.safelyDeletePath( tmpPath );
 			}
 		}
-		await this.replaceOldUrl( siteId );
+		await this.replaceSiteUrl( siteId );
 
 		this.emit( ImportEvents.IMPORT_DATABASE_COMPLETE );
 	}
@@ -91,44 +91,7 @@ abstract class BaseImporter extends EventEmitter implements Importer {
 		} );
 
 		if ( ! currentSiteUrl ) {
-			console.error( 'Failed to fetch site URL' );
-			return;
-		}
-
-		const studioUrl = `http://localhost:${ server.details.port }`;
-
-		const { stderr, exitCode } = await server.executeWpCliCommand(
-			`search-replace '${ currentSiteUrl.trim() }' '${ studioUrl.trim() }'`,
-			{
-				skipPluginsAndThemes: true,
-			}
-		);
-
-		if ( stderr ) {
-			console.error(
-				`Warning during replacing siteUrl ${ currentSiteUrl } -> ${ studioUrl }: ${ stderr }`
-			);
-		}
-
-		if ( exitCode ) {
-			console.error(
-				`Error during replacing siteUrl ${ currentSiteUrl } -> ${ studioUrl }, Exit Code: ${ exitCode }`
-			);
-		}
-	}
-
-	protected async replaceOldUrl( siteId: string ) {
-		const server = SiteServer.get( siteId );
-		if ( ! server ) {
-			throw new Error( 'Site not found.' );
-		}
-
-		const { stdout: currentSiteUrl } = await server.executeWpCliCommand( `option get siteurl`, {
-			skipPluginsAndThemes: true,
-		} );
-
-		if ( ! currentSiteUrl ) {
-			console.error( 'Failed to fetch site URL' );
+			console.error( 'Failed to fetch site URL after import' );
 			return;
 		}
 
@@ -141,12 +104,12 @@ abstract class BaseImporter extends EventEmitter implements Importer {
 		console.log( `Studio URL: ${ studioUrl }` );
 		console.log( `Original URLs to replace: ${ oldUrlHttp }, ${ oldUrlHttps }` );
 
-		// Replace both HTTP and HTTPS versions
+		// Replace all URLs including site URL in one go
 		for ( const urlToReplace of [ oldUrlHttps, oldUrlHttp ] ) {
 			console.log( `\nReplacing: ${ urlToReplace } → ${ studioUrl }` );
 
 			const { stdout, stderr, exitCode } = await server.executeWpCliCommand(
-				`search-replace '${ urlToReplace }' '${ studioUrl }' --all-tables --precise --include-columns=guid,post_content,post_excerpt,post_content_filtered,meta_value --report`,
+				`search-replace '${ urlToReplace }' '${ studioUrl }' wp_posts wp_postmeta wp_options --precise --report --report-changed-only`,
 				{ skipPluginsAndThemes: true }
 			);
 
@@ -164,6 +127,12 @@ abstract class BaseImporter extends EventEmitter implements Importer {
 				);
 			}
 		}
+
+		// Verify the final site URL
+		const { stdout: finalSiteUrl } = await server.executeWpCliCommand( `option get siteurl`, {
+			skipPluginsAndThemes: true,
+		} );
+		console.log( '\nFinal site URL:', finalSiteUrl?.trim() );
 
 		console.log( '\nURL replacement completed' );
 	}
@@ -346,8 +315,6 @@ export class PlaygroundImporter extends BaseBackupImporter {
 				overwrite: true,
 			} );
 		}
-
-		await this.replaceOldUrl( siteId );
 		await this.replaceSiteUrl( siteId );
 
 		this.emit( ImportEvents.IMPORT_DATABASE_COMPLETE );

--- a/src/lib/import-export/import/importers/importer.ts
+++ b/src/lib/import-export/import/importers/importer.ts
@@ -71,8 +71,8 @@ abstract class BaseImporter extends EventEmitter implements Importer {
 				await this.safelyDeletePath( tmpPath );
 			}
 		}
-		await this.replaceSiteUrl( siteId );
 
+		await this.replaceSiteUrl( siteId );
 		this.emit( ImportEvents.IMPORT_DATABASE_COMPLETE );
 	}
 

--- a/src/lib/import-export/import/importers/importer.ts
+++ b/src/lib/import-export/import/importers/importer.ts
@@ -97,10 +97,11 @@ abstract class BaseImporter extends EventEmitter implements Importer {
 
 		const studioUrl = `http://localhost:${ server.details.port }`;
 		const oldUrl = currentSiteUrl.trim();
-		const oldUrlHttps = oldUrl.replace( 'http://', 'https://' );
-		const oldUrlHttp = oldUrl.replace( 'https://', 'http://' );
+		const urlWithoutProtocol = oldUrl.replace( /^https?:\/\//, '' );
 
-		for ( const urlToReplace of [ oldUrlHttps, oldUrlHttp ] ) {
+		const oldUrlVariants = [ `http://${ urlWithoutProtocol }`, `https://${ urlWithoutProtocol }` ];
+
+		for ( const urlToReplace of oldUrlVariants ) {
 			const { stderr, exitCode } = await server.executeWpCliCommand(
 				`search-replace '${ urlToReplace }' '${ studioUrl }'`,
 				{ skipPluginsAndThemes: true }

--- a/src/lib/import-export/import/importers/importer.ts
+++ b/src/lib/import-export/import/importers/importer.ts
@@ -100,11 +100,6 @@ abstract class BaseImporter extends EventEmitter implements Importer {
 		const oldUrlHttps = oldUrl.replace( 'http://', 'https://' );
 		const oldUrlHttp = oldUrl.replace( 'https://', 'http://' );
 
-		console.log( 'Starting URL replacement:' );
-		console.log( `Studio URL: ${ studioUrl }` );
-		console.log( `Original URLs to replace: ${ oldUrlHttp }, ${ oldUrlHttps }` );
-
-		// Replace all URLs including site URL in one go
 		for ( const urlToReplace of [ oldUrlHttps, oldUrlHttp ] ) {
 			const { stderr, exitCode } = await server.executeWpCliCommand(
 				`search-replace '${ urlToReplace }' '${ studioUrl }' wp_posts wp_postmeta wp_options`,

--- a/src/lib/import-export/import/importers/importer.ts
+++ b/src/lib/import-export/import/importers/importer.ts
@@ -71,8 +71,8 @@ abstract class BaseImporter extends EventEmitter implements Importer {
 				await this.safelyDeletePath( tmpPath );
 			}
 		}
+		await this.replaceOldUrl( siteId );
 
-		await this.replaceSiteUrl( siteId );
 		this.emit( ImportEvents.IMPORT_DATABASE_COMPLETE );
 	}
 
@@ -91,7 +91,7 @@ abstract class BaseImporter extends EventEmitter implements Importer {
 		} );
 
 		if ( ! currentSiteUrl ) {
-			console.error( 'Failed to fetch site URL after import' );
+			console.error( 'Failed to fetch site URL' );
 			return;
 		}
 
@@ -115,6 +115,57 @@ abstract class BaseImporter extends EventEmitter implements Importer {
 				`Error during replacing siteUrl ${ currentSiteUrl } -> ${ studioUrl }, Exit Code: ${ exitCode }`
 			);
 		}
+	}
+
+	protected async replaceOldUrl( siteId: string ) {
+		const server = SiteServer.get( siteId );
+		if ( ! server ) {
+			throw new Error( 'Site not found.' );
+		}
+
+		const { stdout: currentSiteUrl } = await server.executeWpCliCommand( `option get siteurl`, {
+			skipPluginsAndThemes: true,
+		} );
+
+		if ( ! currentSiteUrl ) {
+			console.error( 'Failed to fetch site URL' );
+			return;
+		}
+
+		const studioUrl = `http://localhost:${ server.details.port }`;
+		const oldUrl = currentSiteUrl.trim();
+		const oldUrlHttps = oldUrl.replace( 'http://', 'https://' );
+		const oldUrlHttp = oldUrl.replace( 'https://', 'http://' );
+
+		console.log( 'Starting URL replacement:' );
+		console.log( `Studio URL: ${ studioUrl }` );
+		console.log( `Original URLs to replace: ${ oldUrlHttp }, ${ oldUrlHttps }` );
+
+		// Replace both HTTP and HTTPS versions
+		for ( const urlToReplace of [ oldUrlHttps, oldUrlHttp ] ) {
+			console.log( `\nReplacing: ${ urlToReplace } → ${ studioUrl }` );
+
+			const { stdout, stderr, exitCode } = await server.executeWpCliCommand(
+				`search-replace '${ urlToReplace }' '${ studioUrl }' --all-tables --precise --include-columns=guid,post_content,post_excerpt,post_content_filtered,meta_value --report`,
+				{ skipPluginsAndThemes: true }
+			);
+
+			if ( stdout ) {
+				console.log( 'Replacement results:', stdout );
+			}
+
+			if ( stderr ) {
+				console.error( `Warning during replacing URLs (${ urlToReplace }): ${ stderr }` );
+			}
+
+			if ( exitCode ) {
+				console.error(
+					`Error during replacing URLs (${ urlToReplace }), Exit Code: ${ exitCode }`
+				);
+			}
+		}
+
+		console.log( '\nURL replacement completed' );
 	}
 
 	protected async safelyDeletePath( path: string ): Promise< void > {
@@ -295,6 +346,8 @@ export class PlaygroundImporter extends BaseBackupImporter {
 				overwrite: true,
 			} );
 		}
+
+		await this.replaceOldUrl( siteId );
 		await this.replaceSiteUrl( siteId );
 
 		this.emit( ImportEvents.IMPORT_DATABASE_COMPLETE );

--- a/src/lib/import-export/import/importers/importer.ts
+++ b/src/lib/import-export/import/importers/importer.ts
@@ -106,16 +106,10 @@ abstract class BaseImporter extends EventEmitter implements Importer {
 
 		// Replace all URLs including site URL in one go
 		for ( const urlToReplace of [ oldUrlHttps, oldUrlHttp ] ) {
-			console.log( `\nReplacing: ${ urlToReplace } → ${ studioUrl }` );
-
-			const { stdout, stderr, exitCode } = await server.executeWpCliCommand(
-				`search-replace '${ urlToReplace }' '${ studioUrl }' wp_posts wp_postmeta wp_options --precise --report --report-changed-only`,
+			const { stderr, exitCode } = await server.executeWpCliCommand(
+				`search-replace '${ urlToReplace }' '${ studioUrl }' wp_posts wp_postmeta wp_options`,
 				{ skipPluginsAndThemes: true }
 			);
-
-			if ( stdout ) {
-				console.log( 'Replacement results:', stdout );
-			}
 
 			if ( stderr ) {
 				console.error( `Warning during replacing URLs (${ urlToReplace }): ${ stderr }` );
@@ -127,14 +121,6 @@ abstract class BaseImporter extends EventEmitter implements Importer {
 				);
 			}
 		}
-
-		// Verify the final site URL
-		const { stdout: finalSiteUrl } = await server.executeWpCliCommand( `option get siteurl`, {
-			skipPluginsAndThemes: true,
-		} );
-		console.log( '\nFinal site URL:', finalSiteUrl?.trim() );
-
-		console.log( '\nURL replacement completed' );
 	}
 
 	protected async safelyDeletePath( path: string ): Promise< void > {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

Closes https://github.com/Automattic/dotcom-forge/issues/10060

## Proposed Changes

This PR runs the search and replace for images on local sites after the import is finished to ensure that the URLs are updated to the URLs of the local site. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create an Atomic site on WP.com and add an image to one of the posts
* Pull the changes from this branch
* Start Studio with `npm install && npm start`
* Navigate to the `Sync` tab
* Connect the WP.com site on which you created the post with the image
* Pull the WP.com site
* Once the pull is finished, navigate to the local site
* Navigate to the post with the image
* Inspect the image source and confirm that the URL is changed to localhost

![Screenshot 2024-12-30 at 12 03 33 PM](https://github.com/user-attachments/assets/a8d27230-ede0-4d1d-b52d-c936b3738211)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
