### PR TITLE
Show logs button when Studio ask to contact support

### DIFF
--- a/src/hooks/sync-sites/use-sync-push.ts
+++ b/src/hooks/sync-sites/use-sync-push.ts
@@ -111,11 +111,12 @@ export function useSyncPush( {
 					message:
 						response.error === 'Import timed out'
 							? __(
-									"A timeout error occurred while pushing the site, likely due to its large size. Please try reducing the site's content or files and try again. If the problem persists, contact support."
+									"A timeout error occurred while pushing the site, likely due to its large size. Please try reducing the site's content or files and try again. If this problem persists, please contact support."
 							  )
 							: __(
 									'An error occurred while pushing the site. If this problem persists, please contact support.'
 							  ),
+					showOpenLogs: true,
 				} );
 			}
 			// Update state in any case to keep polling push state
@@ -179,6 +180,7 @@ export function useSyncPush( {
 						'An error occurred while pushing the site. If this problem persists, please contact support.'
 					),
 					error,
+					showOpenLogs: true,
 				} );
 				return;
 			}

--- a/src/hooks/tests/use-import-export.test.tsx
+++ b/src/hooks/tests/use-import-export.test.tsx
@@ -90,6 +90,7 @@ describe( 'useImportExport hook', () => {
 			message:
 				'An error occurred while exporting the site. If this problem persists, please contact support.',
 			error: 'error',
+			showOpenLogs: true,
 		} );
 	} );
 
@@ -244,6 +245,7 @@ describe( 'useImportExport hook', () => {
 			message:
 				'An error occurred while importing the site. Verify the file is a valid Jetpack backup, Local, Playground, .wpress or .sql database file and try again. If this problem persists, please contact support.',
 			error: 'error',
+			showOpenLogs: true,
 		} );
 	} );
 

--- a/src/hooks/use-import-export.tsx
+++ b/src/hooks/use-import-export.tsx
@@ -91,6 +91,7 @@ export const ImportExportProvider = ( { children }: { children: React.ReactNode 
 						'An error occurred while importing the site. Verify the file is a valid Jetpack backup, Local, Playground, .wpress or .sql database file and try again. If this problem persists, please contact support.'
 					),
 					error,
+					showOpenLogs: true,
 				} );
 				setImportState( ( { [ selectedSite.id ]: currentProgress, ...rest } ) => ( {
 					...rest,
@@ -252,6 +253,7 @@ export const ImportExportProvider = ( { children }: { children: React.ReactNode 
 						'An error occurred while exporting the site. If this problem persists, please contact support.'
 					),
 					error,
+					showOpenLogs: true,
 				} );
 
 			try {

--- a/src/hooks/use-site-details.tsx
+++ b/src/hooks/use-site-details.tsx
@@ -200,6 +200,7 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 						'An error occurred while creating the site. Verify your selected local path is an empty directory or an existing WordPress folder and try again. If this problem persists, please contact support.'
 					),
 					error,
+					showOpenLogs: true,
 				} );
 
 				// Remove the temporary site immediately, but with a minor delay to ensure state updates properly


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/dotcom-forge/issues/10143

## Proposed Changes

I propose to display a button that allows users to open Studio logs for error messages that ask to contact support.

![Screenshot 2025-01-02 at 15 06 22](https://github.com/user-attachments/assets/6f5a659a-2241-4898-a91a-64d808e56ebe)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create a Studio site
2. Connect the site to the WordPress.com site
3. Open the site in the editor and add `die('test')` in the `wp-config.php`
4. Push the site in Sync tab or Export entire site in the Import / Export tab
5. Confirm that dialog displays clear error and allows to open log file automatically

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
