### PR TITLE
Studio: Add config constants to mu-plugins

### DIFF
--- a/vendor/wp-now/src/download.ts
+++ b/vendor/wp-now/src/download.ts
@@ -359,6 +359,19 @@ set_error_handler(function($severity, $message, $file, $line) {
 			}
 	`
 	);
+
+	fs.writeFile(
+		path.join( muPluginsPath, '0-wp-config-constants-polyfill.php' ),
+		`<?php
+		/* WP_POLYFILL_MARKER */
+		if (!defined('DB_NAME')) define('DB_NAME', 'database_name_here');
+		if (!defined('DB_USER')) define('DB_USER', 'username_here');
+		if (!defined('DB_PASSWORD')) define('DB_PASSWORD', 'password_here');
+		if (!defined('DB_HOST')) define('DB_HOST', 'localhost');
+		if (!defined('DB_CHARSET')) define('DB_CHARSET', 'utf8');
+		if (!defined('DB_COLLATE')) define('DB_COLLATE', '');
+		`
+	);
 }
 
 export function getWordPressVersionPath( wpVersion: string ) {

--- a/vendor/wp-now/src/download.ts
+++ b/vendor/wp-now/src/download.ts
@@ -363,7 +363,9 @@ set_error_handler(function($severity, $message, $file, $line) {
 	fs.writeFile(
 		path.join( muPluginsPath, '0-wp-config-constants-polyfill.php' ),
 		`<?php
-		/* WP_POLYFILL_MARKER */
+		// Define database constants if not already defined. It fixes the error
+		// for imported sites that don't have those defined e.g. WP Cloud and
+		// include plugins which try to access those directly e.g. Mailpoet
 		if (!defined('DB_NAME')) define('DB_NAME', 'database_name_here');
 		if (!defined('DB_USER')) define('DB_USER', 'username_here');
 		if (!defined('DB_PASSWORD')) define('DB_PASSWORD', 'password_here');


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

Closes https://github.com/Automattic/dotcom-forge/issues/10148

## Proposed Changes

This PR adds polyfill to `mu-plugins` for database constants in case they are not defined in the `wp-config.php` file when it is being imported. This ensures that the database constants are defined at all times.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
* Download a backup from this site: https://mc.a8c.com/rewind/debugger.php?site=138657400
* Navigate to Import/Export tab in Studio
* Drop this backup to import it into a site
* Observe that the import succeeds and the site starts successfully
* Navigate to `wp-admin/plugins.php?plugin_status=mustuse` and confirm that the `0-wp-config-constants-polyfill.php` plugin is present there 

Alternatively, you can export a Studio site, edit `wp-config.php` file and remove the constants such as `DB_HOST` etc. from that file. You can then attempt to import it and confirm that the import succeeds and that the site starts successfully. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
