### PR TITLE
Update default PHP version to 8.2

### DIFF
--- a/src/lib/import-export/tests/import/importer/default-importer.test.ts
+++ b/src/lib/import-export/tests/import/importer/default-importer.test.ts
@@ -79,11 +79,11 @@ describe( 'JetpackImporter', () => {
 			const expectedCommand =
 				'sqlite import studio-backup-sql-2024-08-01-12-00-00.sql --require=/tmp/sqlite-command/command.php';
 			expect( siteServer?.executeWpCliCommand ).toHaveBeenNthCalledWith( 1, expectedCommand, {
-				targetPhpVersion: '8.1',
+				targetPhpVersion: '8.2',
 				skipPluginsAndThemes: true,
 			} );
 			expect( siteServer?.executeWpCliCommand ).toHaveBeenNthCalledWith( 2, expectedCommand, {
-				targetPhpVersion: '8.1',
+				targetPhpVersion: '8.2',
 				skipPluginsAndThemes: true,
 			} );
 

--- a/src/tests/ipc-handlers.test.ts
+++ b/src/tests/ipc-handlers.test.ts
@@ -56,7 +56,7 @@ describe( 'createSite', () => {
 			id: expect.any( String ),
 			name: 'Test',
 			path: '/test',
-			phpVersion: '8.1',
+			phpVersion: '8.2',
 			running: false,
 		} );
 	} );

--- a/vendor/wp-now/src/constants.ts
+++ b/vendor/wp-now/src/constants.ts
@@ -16,7 +16,7 @@ export const DEFAULT_PORT = 8881;
 /**
  * The default PHP version to use when running the WP Now server.
  */
-export const DEFAULT_PHP_VERSION = '8.1';
+export const DEFAULT_PHP_VERSION = '8.2';
 
 /**
  * The default WordPress version to use when running the WP Now server.


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/dotcom-forge/issues/10194

## Proposed Changes

- I propose to update the default PHP version to 8.2. The 8.1 no longer gets security upgrades, so 8.2 should be considered as the minimum version that should be used for the WP site.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create a Studio site
2. Confirm it uses PHP 8.2 by default
3. Confirm site works e.g. WP Admin and frontend loads fine

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
