### PR TITLE
Studio: Remove "Create new site" button from the Sync tab for no connections

### DIFF
--- a/src/components/content-tab-sync.tsx
+++ b/src/components/content-tab-sync.tsx
@@ -52,27 +52,6 @@ function SiteSyncDescription( { children }: PropsWithChildren ) {
 	);
 }
 
-function CreateConnectSite( {
-	openSitesSyncSelector,
-}: {
-	className?: string;
-	openSitesSyncSelector: () => void;
-} ) {
-	const { __ } = useI18n();
-
-	return (
-		<div className="mt-8">
-			<div className="flex gap-4">
-				<ConnectButton
-					variant="primary"
-					connectSite={ openSitesSyncSelector }
-					disableConnectButtonStyle={ true }
-				/>
-			</div>
-		</div>
-	);
-}
-
 function NoAuthSyncTab() {
 	const isOffline = useOffline();
 	const { __ } = useI18n();
@@ -175,7 +154,13 @@ export function ContentTabSync( { selectedSite }: { selectedSite: SiteDetails } 
 				/>
 			) : (
 				<SiteSyncDescription>
-					<CreateConnectSite openSitesSyncSelector={ () => setIsSyncSitesSelectorOpen( true ) } />
+					<div className="mt-8">
+						<ConnectButton
+							variant="primary"
+							connectSite={ () => setIsSyncSitesSelectorOpen( true ) }
+							disableConnectButtonStyle={ true }
+						/>
+					</div>
 				</SiteSyncDescription>
 			) }
 

--- a/src/components/content-tab-sync.tsx
+++ b/src/components/content-tab-sync.tsx
@@ -8,7 +8,7 @@ import { useOffline } from '../hooks/use-offline';
 import { getIpcApi } from '../lib/get-ipc-api';
 import { ArrowIcon } from './arrow-icon';
 import Button from './button';
-import { ConnectButton, CreateButton } from './connect-create-buttons';
+import { ConnectButton } from './connect-create-buttons';
 import offlineIcon from './offline-icon';
 import { SyncConnectedSites } from './sync-connected-sites';
 import { SyncSitesModalSelector } from './sync-sites-modal-selector';
@@ -54,11 +54,9 @@ function SiteSyncDescription( { children }: PropsWithChildren ) {
 
 function CreateConnectSite( {
 	openSitesSyncSelector,
-	selectedSite,
 }: {
 	className?: string;
 	openSitesSyncSelector: () => void;
-	selectedSite: SiteDetails;
 } ) {
 	const { __ } = useI18n();
 
@@ -70,7 +68,6 @@ function CreateConnectSite( {
 					connectSite={ openSitesSyncSelector }
 					disableConnectButtonStyle={ true }
 				/>
-				<CreateButton variant="secondary" selectedSite={ selectedSite } />
 			</div>
 		</div>
 	);
@@ -178,10 +175,7 @@ export function ContentTabSync( { selectedSite }: { selectedSite: SiteDetails } 
 				/>
 			) : (
 				<SiteSyncDescription>
-					<CreateConnectSite
-						openSitesSyncSelector={ () => setIsSyncSitesSelectorOpen( true ) }
-						selectedSite={ selectedSite }
-					/>
+					<CreateConnectSite openSitesSyncSelector={ () => setIsSyncSitesSelectorOpen( true ) } />
 				</SiteSyncDescription>
 			) }
 

--- a/src/components/tests/content-tab-sync.test.tsx
+++ b/src/components/tests/content-tab-sync.test.tsx
@@ -87,19 +87,6 @@ describe( 'ContentTabSync', () => {
 		expect( getIpcApi().openURL ).toHaveBeenCalled();
 	} );
 
-	it( 'displays create new site button to authenticated user', () => {
-		( useAuth as jest.Mock ).mockReturnValue( { isAuthenticated: true, authenticate: jest.fn() } );
-		renderWithProvider( <ContentTabSync selectedSite={ selectedSite } /> );
-		const createSiteButton = screen.getByRole( 'button', { name: /Create new site/i } );
-		fireEvent.click( createSiteButton );
-
-		expect( screen.getByText( 'Sync with' ) ).toBeInTheDocument();
-		expect( createSiteButton ).toBeInTheDocument();
-		expect( getIpcApi().openURL ).toHaveBeenCalledWith(
-			'https://wordpress.com/setup/new-hosted-site?ref=studio&section=studio-sync&studioSiteId=site-id'
-		);
-	} );
-
 	it( 'displays connect site button to authenticated user', () => {
 		( useAuth as jest.Mock ).mockReturnValue( { isAuthenticated: true, authenticate: jest.fn() } );
 		renderWithProvider( <ContentTabSync selectedSite={ selectedSite } /> );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

Closes https://github.com/Automattic/dotcom-forge/issues/10197

## Proposed Changes

This PR removes the `Create a new site` button when there are no sites connected on the `Sync` tab:

<img width="664" alt="Screenshot 2025-01-03 at 10 48 44 AM" src="https://github.com/user-attachments/assets/184706b6-c49f-4b85-9bb5-0a263b4b2eeb" />

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
* Start the app with `npm install && npm start`
* Navigate to the `Sync` tab
* Make sure that you have no sites connected
* Observe that the button to create a site is not present in that view and that you can only see the `Connect site` button

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
