### PR TITLE
Update import/export URL for in-app links

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -17,7 +17,7 @@ export const ABOUT_WINDOW_HEIGHT = 350;
 export const AI_GUIDELINES_URL = 'https://automattic.com/ai-guidelines/';
 export const STUDIO_DOCS_URL = `https://developer.wordpress.com/docs/developer-tools/studio/`;
 export const STUDIO_DOCS_URL_IMPORT_EXPORT =
-	'https://developer.wordpress.com/docs/developer-tools/studio/#import-export';
+	'https://developer.wordpress.com/docs/developer-tools/studio/import-export';
 export const BUG_REPORT_URL =
 	'https://github.com/Automattic/studio/issues/new?assignees=&labels=Needs+triage%2C%5BType%5D+Bug&projects=&template=bug_report.yml';
 export const FEATURE_REQUEST_URL =


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/10200

## Proposed Changes

- This updates the const `STUDIO_DOCS_URL_IMPORT_EXPORT` with the new documentation URL for the import/export feature: https://developer.wordpress.com/docs/developer-tools/studio/import-export

## Testing Instructions

- In-app link clicks on the `Add a site` modal and on the `Import / Export` site tab should be updated to https://developer.wordpress.com/docs/developer-tools/studio/import-export
