### PR TITLE
Studio: Include `showDomainStep` in the `Create new site` button URL

### DIFF
--- a/src/components/connect-create-buttons.tsx
+++ b/src/components/connect-create-buttons.tsx
@@ -68,7 +68,7 @@ export const CreateButton = ( {
 			<Button
 				onClick={ () => {
 					getIpcApi().openURL(
-						`https://wordpress.com/setup/new-hosted-site?ref=studio&section=studio-sync&studioSiteId=${ selectedSite.id }`
+						`https://wordpress.com/setup/new-hosted-site?ref=studio&section=studio-sync&showDomainStep&studioSiteId=${ selectedSite.id }`
 					);
 				} }
 				variant={ variant }

--- a/src/components/tests/content-tab-sync.test.tsx
+++ b/src/components/tests/content-tab-sync.test.tsx
@@ -96,7 +96,7 @@ describe( 'ContentTabSync', () => {
 		expect( screen.getByText( 'Sync with' ) ).toBeInTheDocument();
 		expect( createSiteButton ).toBeInTheDocument();
 		expect( getIpcApi().openURL ).toHaveBeenCalledWith(
-			'https://wordpress.com/setup/new-hosted-site?ref=studio&section=studio-sync&studioSiteId=site-id'
+			'https://wordpress.com/setup/new-hosted-site?ref=studio&section=studio-sync&showDomainStep&studioSiteId=site-id'
 		);
 	} );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Resolves https://github.com/Automattic/dotcom-forge/issues/10069.

## Proposed Changes

- include `showDomainStep` in the `Create new site` button URL

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR and build the app with `npm start`.
2. Navigate to a local site that hasn't been connected to a WPCOM site.
3. Open the `Sync` tab and click on the `Create new site` button.
4. The browser window should open the `Choose a domain` step and should let you follow through the WPCOM site creation flow without any issues.

ℹ️ Please note there is a couple of existing styling issues on the `Choose a domain` step in Calypso which I am planning to look at next week.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
