### PR TITLE
Studio: Allow to start the import when there is already a process in progress from onClick

### DIFF
--- a/src/components/content-tab-import-export.tsx
+++ b/src/components/content-tab-import-export.tsx
@@ -191,8 +191,8 @@ const ImportSite = ( {
 			return;
 		}
 		importConfirmation( async () => {
-			await importFile( file, selectedSite );
 			clearImportFileInput();
+			await importFile( file, selectedSite );
 		} );
 	};
 	const openSite = async () => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

Closes https://github.com/Automattic/dotcom-forge/issues/9759

## Proposed Changes

This PR ensures that multiple import processes can be started at the same time from the `Import / Export` tab for different sites. It is currently possible with the drag and drop functionality but not with file selector. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
* Start the app with `npm start`
* Navigate to the `Import/Export` tab on Studio site A
* Start the import process with file selector e.g. by clicking to select a file (and not drag and drop)
* Switch to the `Import/Export` tab on Studio site B
* Start the import process with file selector e.g. by clicking to select a file (and not drag and drop)
* Confirm the second import starts

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
