### PR TITLE
Studio: Fix spacing in top bar

### DIFF
--- a/src/components/top-bar.tsx
+++ b/src/components/top-bar.tsx
@@ -109,7 +109,7 @@ export default function TopBar( { onToggleSidebar }: TopBarProps ) {
 				<OfflineIndicator />
 			</div>
 
-			<div className="app-no-drag-region flex items-center space-x-1.5">
+			<div className="app-no-drag-region flex items-center space-x-1.5 rtl:space-x-reverse">
 				<Authentication />
 				<Button onClick={ openDocs } aria-label={ __( 'Get help' ) } variant="icon">
 					<Icon className="text-white" size={ 24 } icon={ help } />

--- a/src/components/top-bar.tsx
+++ b/src/components/top-bar.tsx
@@ -88,7 +88,7 @@ function Authentication() {
 			onClick={ () => getIpcApi().showUserSettings() }
 			aria-label={ __( 'Open settings to log in' ) }
 			tooltipText={ __( 'Open settings to log in' ) }
-			className="flex gap-x-2 justify-between w-full text-white rounded !px-0 !py-0 h-auto active:!text-white hover:!text-white hover:underline items-center"
+			className="flex gap-x-2 justify-between w-full text-white rounded !px-2 !py-0 h-auto active:!text-white hover:!text-white hover:underline items-center"
 		>
 			<WordPressLogo />
 
@@ -109,7 +109,7 @@ export default function TopBar( { onToggleSidebar }: TopBarProps ) {
 				<OfflineIndicator />
 			</div>
 
-			<div className="app-no-drag-region flex items-center space-x-4">
+			<div className="app-no-drag-region flex items-center space-x-1.5">
 				<Authentication />
 				<Button onClick={ openDocs } aria-label={ __( 'Get help' ) } variant="icon">
 					<Icon className="text-white" size={ 24 } icon={ help } />


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

Fixes https://github.com/Automattic/dotcom-forge/issues/10177

## Proposed Changes

- Fixed spacing between the user menu and the help icon in the top bar.

| Logged out | Logged in |
|--------|--------|
| <img width="314" alt="Screenshot 2025-01-06 at 12 09 57" src="https://github.com/user-attachments/assets/7c28f296-1ac5-43b9-9de7-562be3eccbd2" /> | <img width="314" alt="Screenshot 2025-01-06 at 12 10 07" src="https://github.com/user-attachments/assets/308c3214-b1c9-41bb-8ba6-9804419cfcda" /> | 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Open Studio
- Check spacing when logged out
- Log in to WordPress.com account
- Check spacing when logged in

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
