### PR TITLE
Unify Import labels and mention another supported formats

### DIFF
--- a/src/components/content-tab-import-export.tsx
+++ b/src/components/content-tab-import-export.tsx
@@ -226,7 +226,7 @@ const ImportSite = ( {
 			<div className="text-a8c-gray-70 a8c-body mb-4">
 				{ createInterpolateElement(
 					__(
-						'Import a Jetpack backup, another full-site backup, or a .sql database file. <button>Learn more</button>'
+						'Import a Jetpack backup, a full-site backup in another format, or a .sql database file. <button>Learn more</button>'
 					),
 					{
 						button: (

--- a/src/components/content-tab-import-export.tsx
+++ b/src/components/content-tab-import-export.tsx
@@ -225,7 +225,9 @@ const ImportSite = ( {
 			<div className="a8c-subtitle-small mb-1">{ __( 'Import' ) }</div>
 			<div className="text-a8c-gray-70 a8c-body mb-4">
 				{ createInterpolateElement(
-					__( 'Import a Jetpack backup or a .sql database file. <button>Learn more</button>' ),
+					__(
+						'Import a Jetpack backup, another full-site backup, or a .sql database file. <button>Learn more</button>'
+					),
 					{
 						button: (
 							<Button

--- a/src/components/site-form.tsx
+++ b/src/components/site-form.tsx
@@ -260,7 +260,7 @@ export const SiteForm = ( {
 							<span className="text-a8c-gray-50 text-xs">
 								{ createInterpolateElement(
 									__(
-										'Import a Jetpack backup or another full-site backup format. <button>Learn more</button>'
+										'Import a Jetpack backup or a full-site backup in another format. <button>Learn more</button>'
 									),
 									{
 										button: (

--- a/src/components/site-form.tsx
+++ b/src/components/site-form.tsx
@@ -259,7 +259,9 @@ export const SiteForm = ( {
 							</label>
 							<span className="text-a8c-gray-50 text-xs">
 								{ createInterpolateElement(
-									__( 'Jetpack and WordPress backups supported. <button>Learn more</button>' ),
+									__(
+										'Import a Jetpack backup or another full-site backup format. <button>Learn more</button>'
+									),
 									{
 										button: (
 											<Button


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/studio/issues/783

## Proposed Changes

The import field label currently reads `Jetpack and WordPress backups supported` and seems confusing.

I propose to unify the wording used in labels in the 'Add site' form and 'Import / Export' tabs and mention that other formats than Jetback backup are supported.

<img width="1032" alt="Screenshot 2025-01-08 at 09 00 08" src="https://github.com/user-attachments/assets/74492ed3-ff6e-48d6-b956-329fd5c78927" />

<img width="515" alt="Screenshot 2025-01-08 at 08 59 55" src="https://github.com/user-attachments/assets/4dea9b61-e9d6-4489-894c-8b75f738053d" />


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Open 'Add site' form and confirm that the import label is clear
2. Add the site
3. Open 'Import / Export' tab and confirm that the import label is clear

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
