### PR TITLE
More type declarations for WPCOM Requests module

### DIFF
--- a/src/custom-package-definitions.d.ts
+++ b/src/custom-package-definitions.d.ts
@@ -47,12 +47,40 @@ declare module 'wpcom' {
 	class Request {
 		/* eslint-disable @typescript-eslint/no-explicit-any */
 		get< TResponse = any >( params: object | string, query?: object ): Promise< TResponse >;
+		get< TResponse = any >(
+			params: object | string,
+			callback?: ( error: Error, data: TResponse, headers: Record< string, string > ) => void
+		);
+		get< TResponse = any >(
+			params: object | string,
+			query?: object,
+			callback?: ( error: Error, data: TResponse, headers: Record< string, string > ) => void
+		);
+		post< TResponse = any >(
+			params: object | string,
+			callback?: ( error: Error, data: TResponse, headers: Record< string, string > ) => void
+		);
 		post< TResponse = any >(
 			params: object | string,
 			query?: object,
 			body?: object
 		): Promise< TResponse >;
+		post< TResponse = any >(
+			params: object | string,
+			query?: object,
+			body?: object,
+			callback?: ( error: Error, data: TResponse, headers: Record< string, string > ) => void
+		);
 		del< TResponse = any >( params: object | string, query?: object ): Promise< TResponse >;
+		del< TResponse = any >(
+			params: object | string,
+			query?: object,
+			callback?: ( error: Error, data: TResponse, headers: Record< string, string > ) => void
+		);
+		del< TResponse = any >(
+			params: object | string,
+			callback?: ( error: Error, data: TResponse, headers: Record< string, string > ) => void
+		);
 		/* eslint-enable @typescript-eslint/no-explicit-any */
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/dotcom-forge/issues/10211

## Proposed Changes

Working on https://github.com/Automattic/dotcom-forge/issues/9575, I realized that the type declarations I added for `wpcom.req` in https://github.com/Automattic/studio/issues/608 are incomplete and don't cover the way we use `wpcom.req.post` in the `fetchAssistant` function in the `useAssistantApi` hook (by passing a callback).

This PR adds a (hopefully) exhaustive list of signatures for the `wpcom.req.get`, `wpcom.req.post` and `wpcom.req.del` methods.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

I've verified these changes by looking at these two files:
- https://github.com/Automattic/wp-calypso/blob/a072a5ab2b030f59f6c4332e23f8add02ad699d1/packages/wpcom.js/src/lib/util/request.js 
- https://github.com/Automattic/wp-calypso/blob/a072a5ab2b030f59f6c4332e23f8add02ad699d1/packages/wpcom.js/src/lib/util/send-request.js

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
