### PR TITLE
Keep custom path open if user selected one

### DIFF
--- a/src/components/tests/add-site.test.tsx
+++ b/src/components/tests/add-site.test.tsx
@@ -71,7 +71,7 @@ describe( 'AddSite', () => {
 		await user.click( screen.getByRole( 'button', { name: 'Advanced settings' } ) );
 		await user.click( screen.getByTestId( 'select-path-button' ) );
 
-		expect( mockShowOpenFolderDialog ).toHaveBeenCalledWith( 'Choose folder for site' );
+		expect( mockShowOpenFolderDialog ).toHaveBeenCalledWith( 'Choose folder for site', '' );
 		await user.click( screen.getByRole( 'button', { name: 'Add site' } ) );
 
 		await waitFor( () => {
@@ -104,7 +104,7 @@ describe( 'AddSite', () => {
 		await user.click( screen.getByRole( 'button', { name: 'Advanced settings' } ) );
 		await user.click( screen.getByTestId( 'select-path-button' ) );
 
-		expect( mockShowOpenFolderDialog ).toHaveBeenCalledWith( 'Choose folder for site' );
+		expect( mockShowOpenFolderDialog ).toHaveBeenCalledWith( 'Choose folder for site', '' );
 
 		await waitFor( () => {
 			expect( screen.getByRole( 'button', { name: 'Add site' } ) ).toBeDisabled();
@@ -136,7 +136,7 @@ describe( 'AddSite', () => {
 		await user.click( screen.getByRole( 'button', { name: 'Advanced settings' } ) );
 		await user.click( screen.getByTestId( 'select-path-button' ) );
 
-		expect( mockShowOpenFolderDialog ).toHaveBeenCalledWith( 'Choose folder for site' );
+		expect( mockShowOpenFolderDialog ).toHaveBeenCalledWith( 'Choose folder for site', '' );
 
 		await waitFor( () => {
 			expect( screen.getByRole( 'button', { name: 'Add site' } ) ).not.toBeDisabled();

--- a/src/hooks/use-add-site.ts
+++ b/src/hooks/use-add-site.ts
@@ -26,13 +26,17 @@ export function useAddSite() {
 	);
 
 	const handlePathSelectorClick = useCallback( async () => {
-		const response = await getIpcApi().showOpenFolderDialog( __( 'Choose folder for site' ) );
+		const response = await getIpcApi().showOpenFolderDialog(
+			__( 'Choose folder for site' ),
+			sitePath
+		);
 		if ( response?.path ) {
 			const { path, name, isEmpty, isWordPress } = response;
 			setDoesPathContainWordPress( false );
 			setError( '' );
 			const pathResetToDefaultSitePath =
 				path === proposedSitePath.substring( 0, proposedSitePath.lastIndexOf( '/' ) );
+
 			setSitePath( pathResetToDefaultSitePath ? '' : path );
 			if ( siteWithPathAlreadyExists( path ) ) {
 				return;
@@ -50,7 +54,7 @@ export function useAddSite() {
 				setSiteName( name ?? null );
 			}
 		}
-	}, [ __, siteWithPathAlreadyExists, siteName, proposedSitePath ] );
+	}, [ __, siteWithPathAlreadyExists, siteName, proposedSitePath, sitePath ] );
 
 	const handleAddSiteClick = useCallback( async () => {
 		try {

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -460,7 +460,8 @@ export async function showSaveAsDialog( event: IpcMainInvokeEvent, options: Save
 
 export async function showOpenFolderDialog(
 	event: IpcMainInvokeEvent,
-	title: string
+	title: string,
+	defaultDialogPath: string
 ): Promise< FolderDialogResponse | null > {
 	const parentWindow = BrowserWindow.fromWebContents( event.sender );
 	if ( ! parentWindow ) {
@@ -482,7 +483,7 @@ export async function showOpenFolderDialog(
 
 	const { canceled, filePaths } = await dialog.showOpenDialog( parentWindow, {
 		title,
-		defaultPath: DEFAULT_SITE_PATH,
+		defaultPath: defaultDialogPath !== '' ? defaultDialogPath : DEFAULT_SITE_PATH,
 		properties: [
 			'openDirectory',
 			'createDirectory', // allow user to create new directories; macOS only

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -40,7 +40,7 @@ const api: IpcApi = {
 		{ autoLogin = true }: { autoLogin?: boolean } = {}
 	) => ipcRenderer.invoke( 'openSiteURL', id, relativeURL, { autoLogin } ),
 	openURL: ( url: string ) => ipcRenderer.invoke( 'openURL', url ),
-	showOpenFolderDialog: ( title: string ) => ipcRenderer.invoke( 'showOpenFolderDialog', title ),
+	showOpenFolderDialog: ( title: string, defaultDialogPath: string ) => ipcRenderer.invoke( 'showOpenFolderDialog', title, defaultDialogPath ),
 	showSaveAsDialog: ( options: SaveDialogOptions ) =>
 		ipcRenderer.invoke( 'showSaveAsDialog', options ),
 	saveUserLocale: ( locale: string ) => ipcRenderer.invoke( 'saveUserLocale', locale ),

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -40,7 +40,8 @@ const api: IpcApi = {
 		{ autoLogin = true }: { autoLogin?: boolean } = {}
 	) => ipcRenderer.invoke( 'openSiteURL', id, relativeURL, { autoLogin } ),
 	openURL: ( url: string ) => ipcRenderer.invoke( 'openURL', url ),
-	showOpenFolderDialog: ( title: string, defaultDialogPath: string ) => ipcRenderer.invoke( 'showOpenFolderDialog', title, defaultDialogPath ),
+	showOpenFolderDialog: ( title: string, defaultDialogPath: string ) =>
+		ipcRenderer.invoke( 'showOpenFolderDialog', title, defaultDialogPath ),
 	showSaveAsDialog: ( options: SaveDialogOptions ) =>
 		ipcRenderer.invoke( 'showSaveAsDialog', options ),
 	saveUserLocale: ( locale: string ) => ipcRenderer.invoke( 'saveUserLocale', locale ),


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/studio/issues/779

## Proposed Changes

- I propose to change how a new site dialog form opens the directory dialog, to use the previously selected path if the user selected it already.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Start Studio
2. Click 'Add site'
3. In the form, open 'Advanced settings'
4. Select a directory different from the default path, existing or a new one
5. Open the directory picker again
6. Confirm that the opened directory is the local path you created/selected previously

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
