### PR TITLE
Update demo sites to open link in browser instead of copying the link

### DIFF
--- a/src/components/content-tab-snapshots.tsx
+++ b/src/components/content-tab-snapshots.tsx
@@ -15,9 +15,9 @@ import { useSnapshots } from '../hooks/use-snapshots';
 import { useUpdateDemoSite } from '../hooks/use-update-demo-site';
 import { cx } from '../lib/cx';
 import { getIpcApi } from '../lib/get-ipc-api';
+import { ArrowIcon } from './arrow-icon';
 import { Badge } from './badge';
 import Button from './button';
-import { CopyTextButton } from './copy-text-button';
 import offlineIcon from './offline-icon';
 import ProgressBar from './progress-bar';
 import { ScreenshotDemoSite } from './screenshot-demo-site';
@@ -189,13 +189,16 @@ function SnapshotRow( {
 				</div>
 				<Badge>{ __( 'Demo site' ) }</Badge>
 			</div>
-			<CopyTextButton
-				text={ urlWithHTTPS }
-				label={ `${ urlWithHTTPS }, ${ __( 'Copy site url to clipboard' ) }` }
-				copyConfirmation={ __( 'Copied!' ) }
+			<Button
+				variant="link"
+				className="!text-a8c-gray-70 hover:!text-a8c-blueberry max-w-[100%]"
+				onClick={ () => {
+					getIpcApi().openURL( urlWithHTTPS );
+				} }
 			>
-				{ urlWithHTTPS }
-			</CopyTextButton>
+				<span className="truncate">{ urlWithHTTPS }</span>
+				<ArrowIcon />
+			</Button>
 			<div className="mt-2 text-a8c-gray-70 whitespace-nowrap overflow-hidden truncate flex-1">
 				{ sprintf( __( 'Expires in %s' ), countDown ) }
 			</div>

--- a/src/components/tests/content-tab-snapshots.test.tsx
+++ b/src/components/tests/content-tab-snapshots.test.tsx
@@ -30,9 +30,10 @@ const archiveSite = jest.fn();
 jest.mock( '../../hooks/use-archive-site' );
 
 const mockShowMessageBox = jest.fn();
+const mockOpenURL = jest.fn();
 jest.mock( '../../lib/get-ipc-api', () => ( {
 	getIpcApi: () => ( {
-		openURL: jest.fn(),
+		openURL: mockOpenURL,
 		generateProposedSitePath: jest.fn(),
 		showMessageBox: mockShowMessageBox,
 	} ),
@@ -431,6 +432,30 @@ describe( 'ContentTabSnapshots', () => {
 		await waitFor( () => {
 			expect( clearSnapshotsButton ).not.toBeInTheDocument();
 		} );
+	} );
+
+	test( 'clicking the demo site URL opens the browser', async () => {
+		const user = userEvent.setup();
+		( useSnapshots as jest.Mock ).mockReturnValue( {
+			snapshots: [
+				{
+					url: 'fake-site.fake',
+					atomicSiteId: 150,
+					localSiteId: 'site-id-1',
+					date: new Date().getTime(),
+					deleted: false,
+				},
+			],
+			fetchSnapshotUsage: jest.fn(),
+		} );
+
+		render( <ContentTabSnapshots selectedSite={ selectedSite } /> );
+
+		const urlButton = screen.getByRole( 'button', { name: 'https://fake-site.fake ↗' } );
+		expect( urlButton ).toBeVisible();
+		await user.click( urlButton );
+
+		expect( mockOpenURL ).toHaveBeenCalledWith( 'https://fake-site.fake' );
 	} );
 } );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/dotcom-forge/issues/10196

## Proposed Changes

- Replace link in demo sites to open the browser instead of copy the link.
- Add tests to check the link opens the browser with the correct link

It follows the same style as Sync links but without tooltip.

https://github.com/Automattic/studio/blob/81760938fd3b6dff83fc13ab1e5921565d369353/src/components/sync-connected-sites.tsx#L225-L235

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run `npm start``
- Click on Share tab
- Create a new demo site
- Observe the demo site link opens the browser instead of copying it
- Tests should pass


| Before | After |
|--------|--------|
|  <img width="1012" alt="Screenshot 2025-01-08 at 20 42 16" src="https://github.com/user-attachments/assets/beb9332a-3307-4b84-b1dd-d44b23ab4f16" /> | <img width="1012" alt="Screenshot 2025-01-08 at 20 42 08" src="https://github.com/user-attachments/assets/2725f41a-bba2-44cd-9560-91ceafa46cb8" /> |



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
