### PR TITLE
Studio: Handle duplicate SQL files in tar.gz archives

### DIFF
--- a/src/lib/import-export/import/handlers/backup-handler-tar-gz.ts
+++ b/src/lib/import-export/import/handlers/backup-handler-tar-gz.ts
@@ -9,7 +9,6 @@ import { BackupHandler, isFileAllowed } from './backup-handler-factory';
 export class BackupHandlerTarGz extends EventEmitter implements BackupHandler {
 	async listFiles( backup: BackupArchiveInfo ): Promise< string[] > {
 		const filesSet = new Set< string >();
-
 		await tar.t( {
 			file: backup.path,
 			onReadEntry: ( entry ) => {

--- a/src/lib/import-export/import/handlers/backup-handler-tar-gz.ts
+++ b/src/lib/import-export/import/handlers/backup-handler-tar-gz.ts
@@ -8,7 +8,8 @@ import { BackupHandler, isFileAllowed } from './backup-handler-factory';
 
 export class BackupHandlerTarGz extends EventEmitter implements BackupHandler {
 	async listFiles( backup: BackupArchiveInfo ): Promise< string[] > {
-		const files: string[] = [];
+		const filesSet = new Set< string >();
+
 		await tar.t( {
 			file: backup.path,
 			onReadEntry: ( entry ) => {
@@ -17,11 +18,11 @@ export class BackupHandlerTarGz extends EventEmitter implements BackupHandler {
 					if ( entry.path.startsWith( '/' ) ) {
 						path = path.slice( 1 );
 					}
-					files.push( path );
+					filesSet.add( path );
 				}
 			},
 		} );
-		return files;
+		return Array.from( filesSet );
 	}
 
 	async extractFiles( file: BackupArchiveInfo, extractionDirectory: string ): Promise< void > {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/dotcom-forge/issues/9029

## Proposed Changes

When importing `tar.gz` archives that contain duplicate SQL files, we will now ensure each file is processed only once by using a Set for deduplication. During extraction, tar's natural behavior will use the last occurrence of each file.

Details can be found in the following comment: https://github.com/Automattic/dotcom-forge/issues/9029#issuecomment-2578098289.

- ensure array returned by `listFiles` does not include any file path duplicates

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Try to reproduce the https://github.com/Automattic/dotcom-forge/issues/9029 issue:
2. Head over to the Import tab and try to import the following tar.gz archive: https://drive.google.com/file/d/1XgU0NZFUeuCLXnT9Zr-CAbArQpAkDQIh/view?usp=drive_link.
3. The process should finish correctly and the imported site should work as expected.
4. There should be no regressions when importing any other files (e.g. zip exports).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
