### PR TITLE
Add info about missed appdmg to docs

### DIFF
--- a/docs/code-contributions.md
+++ b/docs/code-contributions.md
@@ -12,11 +12,14 @@ Before you can build and run the app, you need to install the following dependen
 
 Many project contributors rely upon [`nvm`](https://github.com/nvm-sh/nvm) and [Homebrew](https://brew.sh) to manage Node.js and Python installations respectively.
 
-If you manage packages with Homebrew you can do the following:
-
+If you manage packages with Homebrew you can do the following:<br />
 ```bash
 brew install python3 python-setuptools
 ```
+>[!TIP]
+>Note, if you have error `Error: Cannot find module 'appdmg'`, it means that you have installed `setuptools`<br />(added this line to simplify finding it by keywords).
+
+
 
 `nvm` commands referenced in the remaining documentation operate under the assumption that installed Node.js versions are managed with `nvm`. To use the correct Node.js version and install the project dependencies, run the following commands:
 

--- a/docs/code-contributions.md
+++ b/docs/code-contributions.md
@@ -17,8 +17,9 @@ If you manage packages with Homebrew you can do the following:
 ```bash
 brew install python3 python-setuptools
 ```
->[!TIP]
->Note, if you have error `Error: Cannot find module 'appdmg'`, it means that you haven't installed `setuptools`<br />(Added this line to simplify finding it by keywords).
+
+> [!TIP]
+> If you encounter the error `Error: Cannot find module 'appdmg'`, ensure that `setuptools` is installed in your environment.
 
 
 

--- a/docs/code-contributions.md
+++ b/docs/code-contributions.md
@@ -12,7 +12,7 @@ Before you can build and run the app, you need to install the following dependen
 
 Many project contributors rely upon [`nvm`](https://github.com/nvm-sh/nvm) and [Homebrew](https://brew.sh) to manage Node.js and Python installations respectively.
 
-If you manage packages with Homebrew you can do the following:<br />
+If you manage packages with Homebrew you can do the following:
 ```bash
 brew install python3 python-setuptools
 ```

--- a/docs/code-contributions.md
+++ b/docs/code-contributions.md
@@ -21,8 +21,6 @@ brew install python3 python-setuptools
 > [!TIP]
 > If you encounter the error `Error: Cannot find module 'appdmg'`, ensure that `setuptools` is installed in your environment.
 
-
-
 `nvm` commands referenced in the remaining documentation operate under the assumption that installed Node.js versions are managed with `nvm`. To use the correct Node.js version and install the project dependencies, run the following commands:
 
 ```bash

--- a/docs/code-contributions.md
+++ b/docs/code-contributions.md
@@ -18,7 +18,7 @@ If you manage packages with Homebrew you can do the following:
 brew install python3 python-setuptools
 ```
 >[!TIP]
->Note, if you have error `Error: Cannot find module 'appdmg'`, it means that you have installed `setuptools`<br />(Added this line to simplify finding it by keywords).
+>Note, if you have error `Error: Cannot find module 'appdmg'`, it means that you haven't installed `setuptools`<br />(Added this line to simplify finding it by keywords).
 
 
 

--- a/docs/code-contributions.md
+++ b/docs/code-contributions.md
@@ -13,11 +13,12 @@ Before you can build and run the app, you need to install the following dependen
 Many project contributors rely upon [`nvm`](https://github.com/nvm-sh/nvm) and [Homebrew](https://brew.sh) to manage Node.js and Python installations respectively.
 
 If you manage packages with Homebrew you can do the following:
+
 ```bash
 brew install python3 python-setuptools
 ```
 >[!TIP]
->Note, if you have error `Error: Cannot find module 'appdmg'`, it means that you have installed `setuptools`<br />(added this line to simplify finding it by keywords).
+>Note, if you have error `Error: Cannot find module 'appdmg'`, it means that you have installed `setuptools`<br />(Added this line to simplify finding it by keywords).
 
 
 

--- a/docs/code-contributions.md
+++ b/docs/code-contributions.md
@@ -18,9 +18,6 @@ If you manage packages with Homebrew you can do the following:
 brew install python3 python-setuptools
 ```
 
-> [!TIP]
-> If you encounter the error `Error: Cannot find module 'appdmg'`, ensure that `setuptools` is installed in your environment.
-
 `nvm` commands referenced in the remaining documentation operate under the assumption that installed Node.js versions are managed with `nvm`. To use the correct Node.js version and install the project dependencies, run the following commands:
 
 ```bash
@@ -38,6 +35,9 @@ npm start
 ```
 
 The app automatically launches with the Chromium developer tools opened by default. Changes to the "renderer" process code will automatically reload the app, changes to the main process code require a manual server restart or [typing `rs`](https://www.electronforge.io/cli#start) into the same terminal where the server was started.
+
+> [!TIP]
+> If you encounter `Error: Cannot find module 'appdmg'` error, ensure that `python-setuptools` are installed in your environment according to the previous steps.
 
 ### Project Structure
 


### PR DESCRIPTION
## Proposed Changes
I had the error `Error: Cannot find module 'appdmg'` locally. And it turned out that I didn't have `setuptools ` installed. I decided to add error message to docs, to simplify finding the solution in our docs. I think it will be useful in the future, if somebody forgets about it.

## Testing Instructions
Visual review