### PR TITLE
Assistant: Fix scroll glitch on initial render

### DIFF
--- a/src/components/ai-clear-history-reminder.tsx
+++ b/src/components/ai-clear-history-reminder.tsx
@@ -9,7 +9,7 @@ import Button from './button';
 function shouldShowReminder( lastMessage?: MessageType ) {
 	return (
 		lastMessage?.role === 'assistant' &&
-		Date.now() - lastMessage?.createdAt > CLEAR_HISTORY_REMINDER_TIME
+		Date.now() - ( lastMessage?.createdAt ?? 0 ) > CLEAR_HISTORY_REMINDER_TIME
 	);
 }
 

--- a/src/components/ai-clear-history-reminder.tsx
+++ b/src/components/ai-clear-history-reminder.tsx
@@ -6,6 +6,13 @@ import { Message as MessageType } from '../hooks/use-assistant';
 import { getIpcApi } from '../lib/get-ipc-api';
 import Button from './button';
 
+function shouldShowReminder( lastMessage?: MessageType ) {
+	return (
+		lastMessage?.role === 'assistant' &&
+		Date.now() - lastMessage?.createdAt > CLEAR_HISTORY_REMINDER_TIME
+	);
+}
+
 function AIClearHistoryReminder( {
 	lastMessage,
 	clearConversation,
@@ -13,36 +20,22 @@ function AIClearHistoryReminder( {
 	lastMessage?: MessageType;
 	clearConversation: () => void;
 } ) {
-	const [ showReminder, setShowReminder ] = useState( false );
-	const timeoutId = useRef< NodeJS.Timeout >();
-	const currentMessage = useRef< number >();
+	const [ showReminder, setShowReminder ] = useState( shouldShowReminder( lastMessage ) );
 	const elementRef = useRef< HTMLDivElement >( null );
 
 	useEffect( () => {
-		if ( ! lastMessage || lastMessage.role === 'user' ) {
-			clearTimeout( timeoutId.current );
-			setShowReminder( false );
-			return;
-		}
+		let timeoutId: NodeJS.Timeout;
+		const nextValue = shouldShowReminder( lastMessage );
+		setShowReminder( nextValue );
 
-		if ( lastMessage.id === currentMessage.current ) {
-			return;
-		}
-
-		const messageTime = Date.now() - lastMessage?.createdAt;
-		const timeToRemind = CLEAR_HISTORY_REMINDER_TIME - messageTime;
-		if ( timeToRemind > 0 ) {
-			clearTimeout( timeoutId.current );
-			setShowReminder( false );
-			timeoutId.current = setTimeout( () => {
+		if ( nextValue && lastMessage ) {
+			timeoutId = setTimeout( () => {
 				setShowReminder( true );
-			}, timeToRemind );
-		} else {
-			setShowReminder( true );
+			}, Date.now() - lastMessage.createdAt );
 		}
 
 		return () => {
-			clearTimeout( timeoutId.current );
+			clearTimeout( timeoutId );
 		};
 	}, [ lastMessage ] );
 

--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -112,6 +112,7 @@ interface AuthenticatedViewProps {
 	markMessageAsFeedbackReceived: ReturnType<
 		typeof useAssistant
 	>[ 'markMessageAsFeedbackReceived' ];
+	wrapperRef: React.RefObject< HTMLDivElement >;
 }
 
 const AuthenticatedView = memo(
@@ -122,8 +123,8 @@ const AuthenticatedView = memo(
 		siteId,
 		submitPrompt,
 		markMessageAsFeedbackReceived,
+		wrapperRef,
 	}: AuthenticatedViewProps ) => {
-		const endOfMessagesRef = useRef< HTMLDivElement >( null );
 		const lastMessageRef = useRef< HTMLDivElement >( null );
 		const [ showThinking, setShowThinking ] = useState( isAssistantThinking );
 		const lastMessage = useMemo(
@@ -151,7 +152,7 @@ const AuthenticatedView = memo(
 			let timer: NodeJS.Timeout;
 			// Scroll to the end of the messages when the tab is opened or site ID changes
 			if ( isInitialRenderRef.current ) {
-				endOfMessagesRef.current?.scrollIntoView( { behavior: 'instant' } );
+				wrapperRef.current?.scrollIntoView( { block: 'end', behavior: 'instant' } );
 				isInitialRenderRef.current = false;
 			}
 			// Scroll when a new message is added
@@ -166,7 +167,7 @@ const AuthenticatedView = memo(
 				}
 				// For user messages, scroll to the end of the messages
 				else {
-					endOfMessagesRef.current?.scrollIntoView( { behavior: 'smooth' } );
+					wrapperRef.current?.scrollIntoView( { block: 'end', behavior: 'smooth' } );
 				}
 			}
 
@@ -300,7 +301,6 @@ const AuthenticatedView = memo(
 						</div>
 					</RenderLastMessage>
 				) }
-				<div ref={ endOfMessagesRef } />
 			</>
 		);
 	}
@@ -351,6 +351,7 @@ const UnauthenticatedView = ( { onAuthenticate }: { onAuthenticate: () => void }
 
 export function ContentTabAssistant( { selectedSite }: ContentTabAssistantProps ) {
 	const inputRef = useRef< HTMLTextAreaElement >( null );
+	const wrapperRef = useRef< HTMLDivElement >( null );
 	const chatContext = useChatContext();
 	const { isAuthenticated, authenticate, user } = useAuth();
 	const instanceId = user?.id ? `${ user.id }_${ selectedSite.id }` : selectedSite.id;
@@ -467,7 +468,7 @@ export function ContentTabAssistant( { selectedSite }: ContentTabAssistantProps 
 	const disabled = isOffline || ! isAuthenticated || ! userCanSendMessage || hasFailedMessage;
 
 	return (
-		<div className="relative min-h-full flex flex-col bg-gray-50">
+		<div className="relative min-h-full flex flex-col bg-gray-50" ref={ wrapperRef }>
 			<div
 				data-testid="assistant-chat"
 				className={ cx(
@@ -497,6 +498,7 @@ export function ContentTabAssistant( { selectedSite }: ContentTabAssistantProps 
 								markMessageAsFeedbackReceived={ markMessageAsFeedbackReceived }
 								siteId={ selectedSite.id }
 								submitPrompt={ submitPrompt }
+								wrapperRef={ wrapperRef }
 							/>
 						</>
 					) : (

--- a/src/components/tests/ai-clear-history-reminder.test.tsx
+++ b/src/components/tests/ai-clear-history-reminder.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { CLEAR_HISTORY_REMINDER_TIME } from '../../constants';
 import { getIpcApi } from '../../lib/get-ipc-api';
 import AIClearHistoryReminder from '../ai-clear-history-reminder';
 import type { Message } from '../../hooks/use-assistant';
@@ -7,15 +8,15 @@ jest.mock( '../../lib/get-ipc-api' );
 
 describe( 'AIClearHistoryReminder', () => {
 	let clearConversation: jest.Mock;
-	const MOCKED_TIME = 1718882159928;
-	const TWO_HOURS_DIFF = 2 * 60 * 60 * 1000;
+	const MOCKED_CURRENT_TIME = 1718882159928;
+	const OLD_MESSAGE_TIME = MOCKED_CURRENT_TIME - CLEAR_HISTORY_REMINDER_TIME - 1;
 
 	beforeEach( () => {
 		window.HTMLElement.prototype.scrollIntoView = jest.fn();
 		clearConversation = jest.fn();
 		jest.clearAllMocks();
 		jest.useFakeTimers();
-		jest.setSystemTime( MOCKED_TIME );
+		jest.setSystemTime( MOCKED_CURRENT_TIME );
 	} );
 
 	afterEach( () => {
@@ -25,7 +26,7 @@ describe( 'AIClearHistoryReminder', () => {
 	it( 'should display a reminder when the conversation is stale', () => {
 		const message: Message = {
 			id: 0,
-			createdAt: MOCKED_TIME - TWO_HOURS_DIFF,
+			createdAt: OLD_MESSAGE_TIME,
 			content: '',
 			role: 'assistant',
 		};
@@ -42,7 +43,7 @@ describe( 'AIClearHistoryReminder', () => {
 		} );
 		const message: Message = {
 			id: 0,
-			createdAt: MOCKED_TIME - TWO_HOURS_DIFF,
+			createdAt: OLD_MESSAGE_TIME,
 			content: '',
 			role: 'assistant',
 		};
@@ -65,7 +66,7 @@ describe( 'AIClearHistoryReminder', () => {
 		} );
 		const message: Message = {
 			id: 0,
-			createdAt: MOCKED_TIME - TWO_HOURS_DIFF,
+			createdAt: OLD_MESSAGE_TIME,
 			content: '',
 			role: 'assistant',
 		};

--- a/src/components/tests/content-tab-assistant.test.tsx
+++ b/src/components/tests/content-tab-assistant.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
+import { CLEAR_HISTORY_REMINDER_TIME } from '../../constants';
 import { useAuth } from '../../hooks/use-auth';
 import { ChatProvider } from '../../hooks/use-chat-context';
 import { useGetWpVersion } from '../../hooks/use-get-wp-version';
@@ -338,10 +339,10 @@ describe( 'ContentTabAssistant', () => {
 	} );
 
 	test( 'clears history via reminder when last message is two hours old', async () => {
-		const MOCKED_TIME = 1718882159928;
-		const TWO_HOURS_DIFF = 2 * 60 * 60 * 1000;
+		const MOCKED_CURRENT_TIME = 1718882159928;
+		const OLD_MESSAGE_TIME = MOCKED_CURRENT_TIME - CLEAR_HISTORY_REMINDER_TIME - 1;
 		jest.useFakeTimers();
-		jest.setSystemTime( MOCKED_TIME );
+		jest.setSystemTime( MOCKED_CURRENT_TIME );
 
 		const storageKey = 'ai_chat_messages';
 		localStorage.setItem(
@@ -353,7 +354,7 @@ describe( 'ContentTabAssistant', () => {
 						id: 1,
 						content: 'Initial message 2',
 						role: 'assistant',
-						createdAt: MOCKED_TIME - TWO_HOURS_DIFF,
+						createdAt: OLD_MESSAGE_TIME,
 					},
 				],
 			} )


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/dotcom-forge/issues/9281

## Proposed Changes

As described in https://github.com/Automattic/dotcom-forge/issues/9281, there are currently some glitches in how the viewport scrolls when the Assistant tab is opened. This PR fixes those by changing `endOfMessagesRef` into a ref on the topmost wrapper in the Assistant tab and by computing whether `AIClearHistoryReminder` should be displayed instantly instead of doing it in a `useEffect` callback.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Have two or more Studio sites
2. Have an Assistant conversation where the last message is older than 2 hours
3. Switch back and forth between the Assistant and Settings tabs and ensure that the viewport scroll starts at the very bottom every time the Assistant tab is opened
4. Switch between two sites and ensure that the scroll behaves well in this scenario, too

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
