### PR TITLE
Mount symlinks when executing WP-cli commands

### DIFF
--- a/src/lib/symlink-manager.ts
+++ b/src/lib/symlink-manager.ts
@@ -34,18 +34,20 @@ export class SymlinkManager {
 	readonly projectPath: string;
 	private watcher?: AsyncIterable< FileChangeInfo< string > > | null;
 	private watcherAbortController?: AbortController | null;
+	readonly documentRoot: string;
 
 	/**
 	 * Create a new symlink manager.
 	 * @param php
 	 * @param projectPath
-	 *
+	 * @param documentRoot
 	 */
-	constructor( php: PHP, projectPath: string ) {
+	constructor( php: PHP, projectPath: string, documentRoot: string ) {
 		this.symlinks = new Map< string, string >();
 		this.mountedTargets = new Map< string, MountedTarget >();
 		this.php = php;
 		this.projectPath = projectPath;
+		this.documentRoot = documentRoot;
 	}
 
 	/**
@@ -150,11 +152,7 @@ export class SymlinkManager {
 			return;
 		}
 
-		if ( ! this.php.requestHandler ) {
-			throw new Error( 'Request handler is not set' );
-		}
-
-		const vfsPath = path.posix.join( this.php.requestHandler.documentRoot, filename );
+		const vfsPath = path.posix.join( this.documentRoot, filename );
 
 		// Double check to ensure the symlink exists
 		if ( ! this.php.fileExists( vfsPath ) ) {

--- a/src/lib/tests/symlink-manage.test.ts
+++ b/src/lib/tests/symlink-manage.test.ts
@@ -26,7 +26,7 @@ describe( 'SymlinkManager', () => {
 	let symlinkManager: SymlinkManager;
 	let mockPHP: jest.Mocked< PHP >;
 	const mockProjectPath = '/mock/project/path';
-
+	const mockDocumentRoot = '/mock/document/root';
 	beforeEach( () => {
 		mockPHP = {
 			fileExists: jest.fn().mockReturnValue( false ),
@@ -38,11 +38,11 @@ describe( 'SymlinkManager', () => {
 			unlink: jest.fn(),
 			rmdir: jest.fn(),
 			requestHandler: {
-				documentRoot: '/mock/document/root',
+				documentRoot: mockDocumentRoot,
 			},
 		} as unknown as jest.Mocked< PHP >;
 
-		symlinkManager = new SymlinkManager( mockPHP, mockProjectPath );
+		symlinkManager = new SymlinkManager( mockPHP, mockProjectPath, mockDocumentRoot );
 
 		jest.mock( 'path', () => ( {
 			...jest.requireActual( 'path' ),

--- a/src/lib/wpcli-versions.ts
+++ b/src/lib/wpcli-versions.ts
@@ -54,7 +54,12 @@ async function getLatestWPCliVersion() {
 }
 
 export const getWPCliVersionFromInstallation = async () => {
-	const { stdout } = await executeWPCli( '.', [ '--version' ] );
+	/**
+	 * This command is used to check the version of WP-CLI
+	 * which doesn't require mounting the project directory
+	 * so we are not passing the projectPath.
+	 */
+	const { stdout } = await executeWPCli( undefined, [ '--version' ] );
 	if ( stdout?.startsWith( 'WP-CLI ' ) ) {
 		const version = stdout.split( ' ' )[ 1 ];
 		if ( ! version ) {

--- a/src/lib/wpcli-versions.ts
+++ b/src/lib/wpcli-versions.ts
@@ -2,7 +2,7 @@ import fs from 'fs-extra';
 import semver from 'semver';
 import { downloadWpCli } from '../../vendor/wp-now/src/download';
 import { executeWPCli } from '../../vendor/wp-now/src/execute-wp-cli';
-import getWpCliPath from '../../vendor/wp-now/src/get-wp-cli-path';
+import getWpCliPath, { getWpCliFolderPath } from '../../vendor/wp-now/src/get-wp-cli-path';
 
 export async function updateLatestWPCliVersion() {
 	let shouldOverwrite = false;
@@ -54,12 +54,8 @@ async function getLatestWPCliVersion() {
 }
 
 export const getWPCliVersionFromInstallation = async () => {
-	/**
-	 * This command is used to check the version of WP-CLI
-	 * which doesn't require mounting the project directory
-	 * so we are not passing the projectPath.
-	 */
-	const { stdout } = await executeWPCli( undefined, [ '--version' ] );
+	const { stdout } = await executeWPCli( getWpCliFolderPath(), [ '--version' ] );
+
 	if ( stdout?.startsWith( 'WP-CLI ' ) ) {
 		const version = stdout.split( ' ' )[ 1 ];
 		if ( ! version ) {

--- a/src/lib/wpcli-versions.ts
+++ b/src/lib/wpcli-versions.ts
@@ -54,6 +54,10 @@ async function getLatestWPCliVersion() {
 }
 
 export const getWPCliVersionFromInstallation = async () => {
+	/**
+	 * Version checks don't require a project folder to be mounted for WP-cli
+	 * to execute a version check. 
+	 */
 	const { stdout } = await executeWPCli( getWpCliFolderPath(), [ '--version' ] );
 
 	if ( stdout?.startsWith( 'WP-CLI ' ) ) {

--- a/src/lib/wpcli-versions.ts
+++ b/src/lib/wpcli-versions.ts
@@ -56,7 +56,7 @@ async function getLatestWPCliVersion() {
 export const getWPCliVersionFromInstallation = async () => {
 	/**
 	 * Version checks don't require a project folder to be mounted for WP-cli
-	 * to execute a version check. 
+	 * to execute a version check.
 	 */
 	const { stdout } = await executeWPCli( getWpCliFolderPath(), [ '--version' ] );
 

--- a/src/tests/execute-wp-cli.test.ts
+++ b/src/tests/execute-wp-cli.test.ts
@@ -50,5 +50,5 @@ describe( 'executeWPCli', () => {
 	it( 'should return the correct version of WP-CLI', async () => {
 		const result = await getWPCliVersionFromInstallation();
 		expect( result ).toMatch( /v\d+\.\d+\.\d+/ ); // Example: v2.10.0
-	}, 30000 ); // The underlying WP-CLI version check can take more than 20 seconds in CI.
+	} );
 } );

--- a/src/tests/execute-wp-cli.test.ts
+++ b/src/tests/execute-wp-cli.test.ts
@@ -50,5 +50,5 @@ describe( 'executeWPCli', () => {
 	it( 'should return the correct version of WP-CLI', async () => {
 		const result = await getWPCliVersionFromInstallation();
 		expect( result ).toMatch( /v\d+\.\d+\.\d+/ ); // Example: v2.10.0
-	}, 10000 ); // The underlying WP-CLI version check can take up to 7 seconds.
+	}, 30000 ); // The underlying WP-CLI version check can take up to 7 seconds.
 } );

--- a/src/tests/execute-wp-cli.test.ts
+++ b/src/tests/execute-wp-cli.test.ts
@@ -50,5 +50,5 @@ describe( 'executeWPCli', () => {
 	it( 'should return the correct version of WP-CLI', async () => {
 		const result = await getWPCliVersionFromInstallation();
 		expect( result ).toMatch( /v\d+\.\d+\.\d+/ ); // Example: v2.10.0
-	}, 30000 ); // The underlying WP-CLI version check can take up to 7 seconds.
+	}, 30000 ); // The underlying WP-CLI version check can take more than 20 seconds in CI.
 } );

--- a/src/tests/execute-wp-cli.test.ts
+++ b/src/tests/execute-wp-cli.test.ts
@@ -50,5 +50,5 @@ describe( 'executeWPCli', () => {
 	it( 'should return the correct version of WP-CLI', async () => {
 		const result = await getWPCliVersionFromInstallation();
 		expect( result ).toMatch( /v\d+\.\d+\.\d+/ ); // Example: v2.10.0
-	} );
+	}, 10000 ); // The underlying WP-CLI version check can take up to 7 seconds.
 } );

--- a/vendor/wp-now/src/execute-wp-cli.ts
+++ b/vendor/wp-now/src/execute-wp-cli.ts
@@ -33,7 +33,7 @@ export async function executeWPCli(
 		options.documentRoot,
 		createNodeFsMountHandler( projectPath ) as unknown as MountHandler
 	);
-	await startSymlinkManager( php, projectPath );
+	await startSymlinkManager( php, options.projectPath );
 
 	//Set the SAPI name to cli before running the script
 	await php.setSapiName( 'cli' );

--- a/vendor/wp-now/src/execute-wp-cli.ts
+++ b/vendor/wp-now/src/execute-wp-cli.ts
@@ -9,6 +9,7 @@ import { getSqliteCommandPath } from '../../../src/lib/sqlite-command-versions';
 import { PHP, MountHandler, writeFiles, setPhpIniEntries } from '@php-wasm/universal';
 import { readFileSync } from 'fs';
 import { startSymlinkManager } from './wp-now';
+
 const isWindows = process.platform === 'win32';
 
 /**

--- a/vendor/wp-now/src/execute-wp-cli.ts
+++ b/vendor/wp-now/src/execute-wp-cli.ts
@@ -28,7 +28,6 @@ export async function executeWPCli(
 	let options = await getWpNowConfig( {
 		php: phpVersion || DEFAULT_PHP_VERSION,
 		wp: DEFAULT_WORDPRESS_VERSION,
-		path: projectPath || '.',
 	} );
 
 	const id = await loadNodeRuntime( options.phpVersion );
@@ -39,7 +38,7 @@ export async function executeWPCli(
 			options.documentRoot,
 			createNodeFsMountHandler( projectPath ) as unknown as MountHandler
 		);
-		await startSymlinkManager( php, options.projectPath, options.documentRoot );
+		await startSymlinkManager( php, projectPath, options.documentRoot );
 	}
 
 	//Set the SAPI name to cli before running the script

--- a/vendor/wp-now/src/execute-wp-cli.ts
+++ b/vendor/wp-now/src/execute-wp-cli.ts
@@ -13,9 +13,14 @@ const isWindows = process.platform === 'win32';
 
 /**
  * This is an unstable API. Multiple wp-cli commands may not work due to a current limitation on php-wasm and pthreads.
+ *
+ * @param projectPath - The path to the project. If undefined or a empty string is provided files won't be mounted.
+ * @param args - The arguments to pass to wp-cli.
+ * @param phpVersion - The PHP version to use.
+ * @returns The result of the wp-cli command.
  */
 export async function executeWPCli(
-	projectPath: string,
+	projectPath: string | undefined,
 	args: string[],
 	{ phpVersion }: { phpVersion?: string } = {}
 ): Promise< { stdout: string; stderr: string; exitCode: number } > {
@@ -23,17 +28,19 @@ export async function executeWPCli(
 	let options = await getWpNowConfig( {
 		php: phpVersion || DEFAULT_PHP_VERSION,
 		wp: DEFAULT_WORDPRESS_VERSION,
-		path: projectPath,
+		path: projectPath || '.',
 	} );
 
 	const id = await loadNodeRuntime( options.phpVersion );
 	const php = new PHP( id );
 	php.mkdir( options.documentRoot );
-	await php.mount(
-		options.documentRoot,
-		createNodeFsMountHandler( projectPath ) as unknown as MountHandler
-	);
-	await startSymlinkManager( php, options.projectPath, options.documentRoot );
+	if ( projectPath ) {
+		await php.mount(
+			options.documentRoot,
+			createNodeFsMountHandler( projectPath ) as unknown as MountHandler
+		);
+		await startSymlinkManager( php, options.projectPath, options.documentRoot );
+	}
 
 	//Set the SAPI name to cli before running the script
 	await php.setSapiName( 'cli' );

--- a/vendor/wp-now/src/execute-wp-cli.ts
+++ b/vendor/wp-now/src/execute-wp-cli.ts
@@ -33,7 +33,7 @@ export async function executeWPCli(
 		options.documentRoot,
 		createNodeFsMountHandler( projectPath ) as unknown as MountHandler
 	);
-	await startSymlinkManager( php, options.projectPath );
+	await startSymlinkManager( php, options.projectPath, options.documentRoot );
 
 	//Set the SAPI name to cli before running the script
 	await php.setSapiName( 'cli' );

--- a/vendor/wp-now/src/execute-wp-cli.ts
+++ b/vendor/wp-now/src/execute-wp-cli.ts
@@ -6,15 +6,9 @@ import { DEFAULT_PHP_VERSION, DEFAULT_WORDPRESS_VERSION } from './constants';
 import { phpVar } from '@php-wasm/util';
 import { createNodeFsMountHandler, loadNodeRuntime } from '@php-wasm/node';
 import { getSqliteCommandPath } from '../../../src/lib/sqlite-command-versions';
-import {
-	PHP,
-	MountHandler,
-	writeFiles,
-	setPhpIniEntries,
-	loadPHPRuntime,
-} from '@php-wasm/universal';
+import { PHP, MountHandler, writeFiles, setPhpIniEntries } from '@php-wasm/universal';
 import { readFileSync } from 'fs';
-
+import { startSymlinkManager } from './wp-now';
 const isWindows = process.platform === 'win32';
 
 /**
@@ -39,6 +33,7 @@ export async function executeWPCli(
 		options.documentRoot,
 		createNodeFsMountHandler( projectPath ) as unknown as MountHandler
 	);
+	await startSymlinkManager( php, projectPath );
 
 	//Set the SAPI name to cli before running the script
 	await php.setSapiName( 'cli' );
@@ -77,7 +72,7 @@ export async function executeWPCli(
 			define('STDIN', fopen('php://stdin', 'rb'));
 			define('STDOUT', fopen('php://stdout', 'wb'));
 			define('STDERR', fopen('${ stderrPath }', 'wb'));
-			
+
 			// Force disabling WordPress debugging mode to avoid parsing issues of WP-CLI command result
 			define('WP_DEBUG', false);
 			// Filter out errors below ERROR level to avoid parsing issues of WP-CLI command result

--- a/vendor/wp-now/src/execute-wp-cli.ts
+++ b/vendor/wp-now/src/execute-wp-cli.ts
@@ -14,13 +14,13 @@ const isWindows = process.platform === 'win32';
 /**
  * This is an unstable API. Multiple wp-cli commands may not work due to a current limitation on php-wasm and pthreads.
  *
- * @param projectPath - The path to the project. If undefined or a empty string is provided files won't be mounted.
+ * @param projectPath - The path to the project.
  * @param args - The arguments to pass to wp-cli.
  * @param phpVersion - The PHP version to use.
  * @returns The result of the wp-cli command.
  */
 export async function executeWPCli(
-	projectPath: string | undefined,
+	projectPath: string,
 	args: string[],
 	{ phpVersion }: { phpVersion?: string } = {}
 ): Promise< { stdout: string; stderr: string; exitCode: number } > {
@@ -28,18 +28,17 @@ export async function executeWPCli(
 	let options = await getWpNowConfig( {
 		php: phpVersion || DEFAULT_PHP_VERSION,
 		wp: DEFAULT_WORDPRESS_VERSION,
+		path: projectPath,
 	} );
 
 	const id = await loadNodeRuntime( options.phpVersion );
 	const php = new PHP( id );
 	php.mkdir( options.documentRoot );
-	if ( projectPath ) {
-		await php.mount(
-			options.documentRoot,
-			createNodeFsMountHandler( projectPath ) as unknown as MountHandler
-		);
-		await startSymlinkManager( php, projectPath, options.documentRoot );
-	}
+	await php.mount(
+		options.documentRoot,
+		createNodeFsMountHandler( projectPath ) as unknown as MountHandler
+	);
+	await startSymlinkManager( php, projectPath, options.documentRoot );
 
 	//Set the SAPI name to cli before running the script
 	await php.setSapiName( 'cli' );

--- a/vendor/wp-now/src/get-wp-cli-path.ts
+++ b/vendor/wp-now/src/get-wp-cli-path.ts
@@ -3,7 +3,7 @@ import getWpCliTmpPath from './get-wp-cli-tmp-path';
 import { getServerFilesPath } from '../../../src/storage/paths';
 
 /**
- * The path for wp-cli folder within the WP Now folder.
+ * The path to the wp-cli folder within the WP Now folder.
  */
 export function getWpCliFolderPath() {
 	if ( process.env.NODE_ENV !== 'test' ) {

--- a/vendor/wp-now/src/get-wp-cli-path.ts
+++ b/vendor/wp-now/src/get-wp-cli-path.ts
@@ -3,11 +3,18 @@ import getWpCliTmpPath from './get-wp-cli-tmp-path';
 import { getServerFilesPath } from '../../../src/storage/paths';
 
 /**
+ * The path for wp-cli folder within the WP Now folder.
+ */
+export function getWpCliFolderPath() {
+	if ( process.env.NODE_ENV !== 'test' ) {
+		return path.join( getServerFilesPath() );
+	}
+	return path.join( getWpCliTmpPath() );
+}
+
+/**
  * The path for wp-cli phar file within the WP Now folder.
  */
 export default function getWpCliPath() {
-	if ( process.env.NODE_ENV !== 'test' ) {
-		return path.join( getServerFilesPath(), 'wp-cli.phar' );
-	}
-	return path.join( getWpCliTmpPath(), 'wp-cli.phar' );
+	return path.join( getWpCliFolderPath(), 'wp-cli.phar' );
 }

--- a/vendor/wp-now/src/wp-now.ts
+++ b/vendor/wp-now/src/wp-now.ts
@@ -179,11 +179,7 @@ async function prepareWordPress( php: PHP, options: WPNowOptions ) {
 			break;
 	}
 
-	// Symlink manager is not yet supported on windows
-	// See: https://github.com/Automattic/studio/issues/548
-	if ( process.platform !== 'win32' ) {
-		await startSymlinkManager(php, options.projectPath);
-	}
+	await startSymlinkManager( php, options.projectPath );
 }
 
 /**
@@ -196,21 +192,28 @@ async function prepareWordPress( php: PHP, options: WPNowOptions ) {
  * @param php
  * @param projectPath
  */
-async function startSymlinkManager(php: PHP, projectPath: string) {
-	const symlinkManager = new SymlinkManager(php, projectPath);
+export async function startSymlinkManager( php: PHP, projectPath: string ) {
+	// Symlink manager is not yet supported on windows
+	// See: https://github.com/Automattic/studio/issues/548
+	if ( process.platform === 'win32' ) {
+		return;
+	}
+
+	const symlinkManager = new SymlinkManager( php, projectPath );
 	await symlinkManager.scanAndCreateSymlinks();
-	symlinkManager.startWatching()
-		.catch((err) => {
-			output?.error('Error while watching for file changes', err);
-		})
-		.finally(() => {
-			output?.log('Stopped watching for file changes');
-		});
+	symlinkManager
+		.startWatching()
+		.catch( ( err ) => {
+			output?.error( 'Error while watching for file changes', err );
+		} )
+		.finally( () => {
+			output?.log( 'Stopped watching for file changes' );
+		} );
 
 	// Ensure that we stop watching for file changes when the runtime is exiting
-	php.addEventListener('runtime.beforedestroy', () => {
+	php.addEventListener( 'runtime.beforedestroy', () => {
 		symlinkManager.stopWatching();
-	});
+	} );
 }
 
 async function runIndexMode( php: PHP, { documentRoot, projectPath }: WPNowOptions ) {

--- a/vendor/wp-now/src/wp-now.ts
+++ b/vendor/wp-now/src/wp-now.ts
@@ -179,7 +179,7 @@ async function prepareWordPress( php: PHP, options: WPNowOptions ) {
 			break;
 	}
 
-	await startSymlinkManager( php, options.projectPath );
+	await startSymlinkManager( php, options.projectPath, options.documentRoot );
 }
 
 /**
@@ -191,15 +191,16 @@ async function prepareWordPress( php: PHP, options: WPNowOptions ) {
  *
  * @param php
  * @param projectPath
+ * @param documentRoot
  */
-export async function startSymlinkManager( php: PHP, projectPath: string ) {
+export async function startSymlinkManager( php: PHP, projectPath: string, documentRoot: string ) {
 	// Symlink manager is not yet supported on windows
 	// See: https://github.com/Automattic/studio/issues/548
 	if ( process.platform === 'win32' ) {
 		return;
 	}
 
-	const symlinkManager = new SymlinkManager( php, projectPath );
+	const symlinkManager = new SymlinkManager( php, projectPath, documentRoot );
 	await symlinkManager.scanAndCreateSymlinks();
 	symlinkManager
 		.startWatching()


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes #20 

## Proposed Changes

This PR mounts symlinked project folders to the Playground filesystem when executing WP-cli commands in Studio.

Before this PR WP-cli executions would mount the project into the Playground filesystem without mounting symlinked folders.
The lack of symlinked folders would lead to issues like a symlinked theme or plugin getting deactivated during a CLI run.

When WP-cli starts it loads WordPress, which loads the current theme and activated plugins, while loading it performs a check to see if the theme and plugins are available. In the case of symlinked themes and plugins they weren't available in the filesystem during a CLI run, so WordPress deactivated them. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- symlink a local theme to a site running in Studio `ln -s THEME_PATH SITE_PATH`
- start the site and activate the theme
- reload Studio with `cmd+r` 
- stop and start the site
- click on a different site and click back on the site with a symlinked theme
- confirm that the symlinked theme is still active

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
