### PR TITLE
Defer reading the archive content after our max size checks

### DIFF
--- a/src/hooks/use-archive-site.ts
+++ b/src/hooks/use-archive-site.ts
@@ -81,14 +81,15 @@ export function useArchiveSite() {
 			try {
 				const { archivePath, archiveSizeInBytes } = await getIpcApi().archiveSite( siteId, 'zip' );
 				if ( archiveSizeInBytes > DEMO_SITE_SIZE_LIMIT_BYTES ) {
-					alert(
-						sprintf(
+					getIpcApi().showErrorMessageBox( {
+						title: __( 'Adding demo site failed' ),
+						message: sprintf(
 							__(
 								'The site exceeds the maximum size of %dGB. Please remove some files and try again.'
 							),
 							DEMO_SITE_SIZE_LIMIT_GB
-						)
-					);
+						),
+					} );
 					setUploadingSites( ( _uploadingSites ) => ( { ..._uploadingSites, [ siteId ]: false } ) );
 					getIpcApi().removeTemporalFile( archivePath );
 					return;

--- a/src/hooks/use-archive-site.ts
+++ b/src/hooks/use-archive-site.ts
@@ -79,10 +79,7 @@ export function useArchiveSite() {
 			}
 
 			try {
-				const { archiveContent, archivePath, archiveSizeInBytes } = await getIpcApi().archiveSite(
-					siteId,
-					'zip'
-				);
+				const { archivePath, archiveSizeInBytes } = await getIpcApi().archiveSite( siteId, 'zip' );
 				if ( archiveSizeInBytes > DEMO_SITE_SIZE_LIMIT_BYTES ) {
 					alert(
 						sprintf(
@@ -97,9 +94,13 @@ export function useArchiveSite() {
 					return;
 				}
 
-				const file = new File( [ archiveContent ], 'loca-env-site-1.zip', {
-					type: 'application/zip',
-				} );
+				const file = new File(
+					[ await getIpcApi().getFileContent( archivePath ) ],
+					'loca-env-site-1.zip',
+					{
+						type: 'application/zip',
+					}
+				);
 
 				const formData = [ [ 'import', file ] ];
 				const wordpressVersion = await getIpcApi().getWpVersion( siteId );

--- a/src/hooks/use-update-demo-site.tsx
+++ b/src/hooks/use-update-demo-site.tsx
@@ -42,14 +42,15 @@ export const DemoSiteUpdateProvider: React.FC< DemoSiteUpdateProviderProps > = (
 				);
 
 				if ( archiveSizeInBytes > DEMO_SITE_SIZE_LIMIT_BYTES ) {
-					alert(
-						sprintf(
+					getIpcApi().showErrorMessageBox( {
+						title: __( 'Updating demo site failed' ),
+						message: sprintf(
 							__(
 								'The site exceeds the maximum size of %dGB. Please remove some files and try again.'
 							),
 							DEMO_SITE_SIZE_LIMIT_GB
-						)
-					);
+						),
+					} );
 
 					setUpdatingSites( ( prev ) => {
 						const newSet = new Set( prev );

--- a/src/hooks/use-update-demo-site.tsx
+++ b/src/hooks/use-update-demo-site.tsx
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/electron/renderer';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import { useCallback, useState, createContext, useContext, useMemo, ReactNode } from 'react';
+import { DEMO_SITE_SIZE_LIMIT_BYTES, DEMO_SITE_SIZE_LIMIT_GB } from '../constants';
 import { getIpcApi } from '../lib/get-ipc-api';
 import { useAuth } from './use-auth';
 import { useSnapshots } from './use-snapshots';
@@ -35,10 +36,37 @@ export const DemoSiteUpdateProvider: React.FC< DemoSiteUpdateProviderProps > = (
 			setUpdatingSites( ( prev ) => new Set( prev ).add( localSite.id ) );
 
 			try {
-				const { archiveContent } = await getIpcApi().archiveSite( localSite.id, 'zip' );
-				const file = new File( [ archiveContent ], 'loca-env-site-1.zip', {
-					type: 'application/zip',
-				} );
+				const { archivePath, archiveSizeInBytes } = await getIpcApi().archiveSite(
+					localSite.id,
+					'zip'
+				);
+
+				if ( archiveSizeInBytes > DEMO_SITE_SIZE_LIMIT_BYTES ) {
+					alert(
+						sprintf(
+							__(
+								'The site exceeds the maximum size of %dGB. Please remove some files and try again.'
+							),
+							DEMO_SITE_SIZE_LIMIT_GB
+						)
+					);
+
+					setUpdatingSites( ( prev ) => {
+						const newSet = new Set( prev );
+						newSet.delete( localSite.id );
+						return newSet;
+					} );
+					getIpcApi().removeTemporalFile( archivePath );
+					return;
+				}
+
+				const file = new File(
+					[ await getIpcApi().getFileContent( archivePath ) ],
+					'loca-env-site-1.zip',
+					{
+						type: 'application/zip',
+					}
+				);
 
 				const formData = [
 					[ 'site_id', snapshot.atomicSiteId ],

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -1084,3 +1084,11 @@ export function addSyncOperation( event: IpcMainInvokeEvent, id: string ) {
 export function clearSyncOperation( event: IpcMainInvokeEvent, id: string ) {
 	ACTIVE_SYNC_OPERATIONS.delete( id );
 }
+
+export async function getFileContent( event: IpcMainInvokeEvent, filePath: string ) {
+	if ( ! fs.existsSync( filePath ) ) {
+		throw new Error( `File not found: ${ filePath }` );
+	}
+
+	return fs.readFileSync( filePath );
+}

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -566,8 +566,7 @@ export async function archiveSite( event: IpcMainInvokeEvent, id: string, format
 		format,
 	} );
 	const stats = fs.statSync( archivePath );
-	const archiveContent = fs.readFileSync( archivePath );
-	return { archivePath, archiveContent, archiveSizeInBytes: stats.size };
+	return { archivePath, archiveSizeInBytes: stats.size };
 }
 
 export async function exportSiteToPush( event: IpcMainInvokeEvent, id: string ) {

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -103,6 +103,7 @@ const api: IpcApi = {
 	addSyncOperation: ( id: string ) => ipcRenderer.invoke( 'addSyncOperation', id ),
 	clearSyncOperation: ( id: string ) => ipcRenderer.invoke( 'clearSyncOperation', id ),
 	getPathForFile: webUtils.getPathForFile,
+	getFileContent: ( filePath: string ) => ipcRenderer.invoke( 'getFileContent', filePath ),
 };
 
 contextBridge.exposeInMainWorld( 'ipcApi', api );


### PR DESCRIPTION
- Fixes https://github.com/Automattic/dotcom-forge/issues/9174

## Proposed Changes

Previously, we were reading the file inside of `archiveSite()` which prevented us from getting to our user-friendly error-msg alert since reading a large file resulted in `RangeError [ERR_FS_FILE_TOO_LARGE]` error.

In this PR, I have changed `archiveSite()` to just stick to its responsibility of creating the archive file and not try to read it. For reading, new method on ipc-handler has been defined, which is only invoked once we have checked the archive size is within the max limits defined by us.

## Testing Instructions

- Try uploading a site more than 2GB and we get our alert instead of generic error.

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?
