### PR TITLE
Studio: Display tooltip with the demo site last update time

### DIFF
--- a/src/components/content-tab-snapshots.tsx
+++ b/src/components/content-tab-snapshots.tsx
@@ -9,6 +9,7 @@ import { useArchiveErrorMessages } from '../hooks/use-archive-error-messages';
 import { useArchiveSite } from '../hooks/use-archive-site';
 import { useAuth } from '../hooks/use-auth';
 import { useExpirationDate } from '../hooks/use-expiration-date';
+import { useFormatLocalizedTimestamps } from '../hooks/use-format-localized-timestamps';
 import { useOffline } from '../hooks/use-offline';
 import { useProgressTimer } from '../hooks/use-progress-timer';
 import { useSnapshots } from '../hooks/use-snapshots';
@@ -21,7 +22,7 @@ import Button from './button';
 import offlineIcon from './offline-icon';
 import ProgressBar from './progress-bar';
 import { ScreenshotDemoSite } from './screenshot-demo-site';
-import { Tooltip, TooltipProps } from './tooltip';
+import { Tooltip, TooltipProps, DynamicTooltip } from './tooltip';
 
 interface ContentTabSnapshotsProps {
 	selectedSite: SiteDetails;
@@ -60,6 +61,7 @@ function SnapshotRow( {
 	const { updateDemoSite, isDemoSiteUpdating } = useUpdateDemoSite();
 	const errorMessages = useArchiveErrorMessages();
 	const isSiteDemoUpdating = isDemoSiteUpdating( snapshot.localSiteId );
+	const { formatRelativeTime } = useFormatLocalizedTimestamps();
 
 	const isOffline = useOffline();
 	const updateDemoSiteOfflineMessage = __(
@@ -68,6 +70,13 @@ function SnapshotRow( {
 	const deleteDemoSiteOfflineMessage = __(
 		'Deleting a demo site requires an internet connection.'
 	);
+	const getLastUpdateTimeText = () => {
+		if ( ! date ) {
+			return __( 'Never updated' );
+		}
+		const timeDistance = formatRelativeTime( new Date( date ).toISOString() );
+		return sprintf( __( 'Last updated %s ago.' ), timeDistance );
+	};
 	const userBlockedMessage = errorMessages.rest_site_creation_blocked;
 
 	const { progress, setProgress } = useProgressTimer( {
@@ -213,19 +222,25 @@ function SnapshotRow( {
 				) : (
 					<>
 						<Tooltip disabled={ ! isUpdateDisabled } { ...tooltipContent }>
-							<Button
-								aria-description={ tooltipContent?.text || '' }
-								aria-disabled={ isUpdateDisabled }
-								variant="primary"
-								onClick={ () => {
-									if ( isUpdateDisabled ) {
-										return;
-									}
-									handleUpdateDemoSite();
-								} }
+							<DynamicTooltip
+								getTooltipText={ getLastUpdateTimeText }
+								placement="top-start"
+								disabled={ isUpdateDisabled }
 							>
-								{ __( 'Update demo site' ) }
-							</Button>
+								<Button
+									aria-description={ tooltipContent?.text || '' }
+									aria-disabled={ isUpdateDisabled }
+									variant="primary"
+									onClick={ () => {
+										if ( isUpdateDisabled ) {
+											return;
+										}
+										handleUpdateDemoSite();
+									} }
+								>
+									{ __( 'Update demo site' ) }
+								</Button>
+							</DynamicTooltip>
 						</Tooltip>
 						<Tooltip
 							disabled={ ! isOffline }

--- a/src/components/content-tab-snapshots.tsx
+++ b/src/components/content-tab-snapshots.tsx
@@ -221,7 +221,7 @@ function SnapshotRow( {
 					</div>
 				) : (
 					<>
-						<Tooltip disabled={ ! isUpdateDisabled } { ...tooltipContent }>
+						<Tooltip disabled={ ! isUpdateDisabled } placement="top-start" { ...tooltipContent }>
 							<DynamicTooltip
 								getTooltipText={ getLastUpdateTimeText }
 								placement="top-start"
@@ -245,6 +245,7 @@ function SnapshotRow( {
 						<Tooltip
 							disabled={ ! isOffline }
 							icon={ offlineIcon }
+							placement="top-start"
 							text={ deleteDemoSiteOfflineMessage }
 						>
 							<Button

--- a/src/components/content-tab-snapshots.tsx
+++ b/src/components/content-tab-snapshots.tsx
@@ -224,7 +224,7 @@ function SnapshotRow( {
 						<Tooltip disabled={ ! isUpdateDisabled } placement="top-start" { ...tooltipContent }>
 							<DynamicTooltip
 								getTooltipText={ getLastUpdateTimeText }
-								placement="top-start"
+								placement="bottom-start"
 								disabled={ isUpdateDisabled }
 							>
 								<Button


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Resolves https://github.com/Automattic/dotcom-forge/issues/10207.

## Proposed Changes

- add tooltip with the demo site last update time to the `Update demo site` button
- update placement of "offline" tooltips displayed for `Update demo site` and `Delete demo site` buttons

![Markup on 2025-01-16 at 14:35:07](https://github.com/user-attachments/assets/f619925f-2104-41dc-ac9c-6da88c760587)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR branch and build the app with `npm start`.
2. While on an existing Studio site, head over to the Share tab and create a new demo site.
3. When you hover over the `Update demo site` button, a tooltip with information when the demo site was updated should show up.
4. If you click the button and confirm the update, the time displayed in the tooltip should reset.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
