### PR TITLE
Studio: Add feature flag for repurposing quick deploys

### DIFF
--- a/src/hooks/tests/use-chat-context.test.tsx
+++ b/src/hooks/tests/use-chat-context.test.tsx
@@ -74,6 +74,7 @@ beforeEach( () => {
 		appName: '',
 		arm64Translation: false,
 		terminalWpCliEnabled: false,
+		quickDeploysEnabled: false,
 	} );
 	setupWpCliResult( { themes: [], plugins: [] } );
 } );

--- a/src/hooks/use-feature-flags.tsx
+++ b/src/hooks/use-feature-flags.tsx
@@ -4,10 +4,12 @@ import { useAuth } from './use-auth';
 
 export interface FeatureFlagsContextType {
 	terminalWpCliEnabled: boolean;
+	quickDeploysEnabled: boolean;
 }
 
 export const FeatureFlagsContext = createContext< FeatureFlagsContextType >( {
 	terminalWpCliEnabled: false,
+	quickDeploysEnabled: false,
 } );
 
 interface FeatureFlagsProviderProps {
@@ -16,8 +18,10 @@ interface FeatureFlagsProviderProps {
 
 export const FeatureFlagsProvider: React.FC< FeatureFlagsProviderProps > = ( { children } ) => {
 	const terminalWpCliEnabledFromGlobals = getAppGlobals().terminalWpCliEnabled;
+	const quickDeploysEnabledFromGlobals = getAppGlobals().quickDeploysEnabled;
 	const [ featureFlags, setFeatureFlags ] = useState< FeatureFlagsContextType >( {
 		terminalWpCliEnabled: terminalWpCliEnabledFromGlobals,
+		quickDeploysEnabled: quickDeploysEnabledFromGlobals,
 	} );
 	const { isAuthenticated, client } = useAuth();
 
@@ -38,6 +42,8 @@ export const FeatureFlagsProvider: React.FC< FeatureFlagsProviderProps > = ( { c
 				setFeatureFlags( {
 					terminalWpCliEnabled:
 						Boolean( flags?.[ 'terminal_wp_cli_enabled' ] ) || terminalWpCliEnabledFromGlobals,
+					quickDeploysEnabled:
+						Boolean( flags?.[ 'quick_deploys_enabled' ] ) || quickDeploysEnabledFromGlobals,
 				} );
 			} catch ( error ) {
 				console.error( error );
@@ -47,7 +53,7 @@ export const FeatureFlagsProvider: React.FC< FeatureFlagsProviderProps > = ( { c
 		return () => {
 			cancel = true;
 		};
-	}, [ isAuthenticated, client, terminalWpCliEnabledFromGlobals ] );
+	}, [ isAuthenticated, client, terminalWpCliEnabledFromGlobals, quickDeploysEnabledFromGlobals ] );
 
 	return (
 		<FeatureFlagsContext.Provider value={ featureFlags }>{ children }</FeatureFlagsContext.Provider>

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -725,6 +725,7 @@ export async function getAppGlobals( _event: IpcMainInvokeEvent ): Promise< AppG
 		appName: app.name,
 		arm64Translation: app.runningUnderARM64Translation,
 		terminalWpCliEnabled: process.env.STUDIO_TERMINAL_WP_CLI === 'true',
+		quickDeploysEnabled: process.env.STUDIO_QUICK_DEPLOYS === 'true',
 	};
 }
 

--- a/src/ipc-types.d.ts
+++ b/src/ipc-types.d.ts
@@ -81,6 +81,7 @@ interface AppGlobals {
 	appName: string;
 	arm64Translation: boolean;
 	terminalWpCliEnabled: boolean;
+	quickDeploysEnabled: boolean;
 }
 
 interface IpcListener {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

Closes https://github.com/Automattic/dotcom-forge/issues/10268

## Proposed Changes

This PR adds `STUDIO_QUICK_DEPLOYS` feature flag to Studio. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
* Apply the following diff:

```diff diff --git a/src/hooks/use-content-tabs.tsx b/src/hooks/use-content-tabs.tsx
index 7142eb94..2c7caab8 100644
--- a/src/hooks/use-content-tabs.tsx
+++ b/src/hooks/use-content-tabs.tsx
@@ -3,14 +3,21 @@ import { useI18n } from '@wordpress/react-i18n';
 import { createContext, ReactNode, useContext, useMemo, useState } from 'react';
 import { useFeatureFlags } from './use-feature-flags';
 
-export type TabName = 'overview' | 'share' | 'sync' | 'settings' | 'assistant' | 'import-export';
+export type TabName =
+       | 'overview'
+       | 'share'
+       | 'sync'
+       | 'settings'
+       | 'assistant'
+       | 'import-export'
+       | 'deploys';
 type Tab = React.ComponentProps< typeof TabPanel >[ 'tabs' ][ number ] & {
        name: TabName;
 };
 
 function useTabs() {
        const { __ } = useI18n();
-
+       const { quickDeploysEnabled } = useFeatureFlags();
        return useMemo( () => {
                const tabs: Tab[] = [
                        {
@@ -47,8 +54,16 @@ function useTabs() {
                        className: 'components-tab-panel__tabs--assistant ltr:pl-8 rtl:pr-8 ltr:ml-auto rtl:mr-auto',
                } );
 
+               if ( quickDeploysEnabled ) {
+                       tabs.push( {
+                               order: 2,
+                               name: 'deploys',
+                               title: __( 'Deploys' ),
+                       } );
+               }
+
                return tabs.sort( ( a, b ) => a.order - b.order );
-       }, [ __ ] );
+       }, [ __, quickDeploysEnabled ] );
 }
 interface ContentTabsContextType {
        selectedTab: TabName;
```
* Start Studio with the following feature flag `STUDIO_QUICK_DEPLOYS=true npm start`
* Once Studio is started, observe the `Deploys` tab is present:

<img width="689" alt="Screenshot 2025-01-17 at 2 24 16 PM" src="https://github.com/user-attachments/assets/0372e8bf-b7ba-400c-a844-8c01b5f4f9bc" />
* Restart Studio without the feature flag: `npm start`
* Confirm that the `Deploys` tab is not visible

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
