### PR TITLE
add version to dev builds file names

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -25,12 +25,9 @@ APPLE_BUNDLE_IDENTIFIER = 'com.automattic.studio'
 APPLE_API_KEY_PATH = File.join(SECRETS_FOLDER, 'app_store_connect_fastlane_api_key.json')
 
 CDN_URL = 'https://cdn.a8c-ci.services'
+CLOUDFRONT_DISTRIBUTION_ID = 'EF4A01YASGPY5'
 
-# Use this instead of getting values from ENV directly
-# It will throw an error if the requested value is missing
 def get_required_env(key)
-  return 'dry-run' if DRY_RUN && (key == 'BUILDKITE_BUILD_NUMBER' || key == 'BUILDKITE_TAG' || key == 'SLACK_WEBHOOK')
-  
   UI.user_error!("Environment variable `#{key}` is not set.") unless ENV.key?(key)
   ENV.fetch(key)
 end
@@ -77,27 +74,27 @@ end
 
 desc 'Ship release build'
 lane :distribute_release_build do |_options|
+  next if DRY_RUN
+  
   release_tag = get_required_env('BUILDKITE_TAG')
   builds = distribute_builds(release_tag:)
 
-  unless DRY_RUN
-    slack(
-      username: 'CI Bot',
-      icon_url: 'https://octodex.github.com/images/jenktocat.jpg',
-      message: ":tada: #{release_tag} is now available! :tada:",
-      channel: '#dotcom-studio',
-      success: true,
-      slack_url: get_required_env('SLACK_WEBHOOK'),
-      payload: {
-        ':studio-app-icon-mac: Release available for': builds.each_value.map { |b| "[#{b[:name]}](#{b[:cdn_url]})" }.join(', ')
-      },
-      default_payloads: []
-    )
-  end
+  slack(
+    username: 'CI Bot',
+    icon_url: 'https://octodex.github.com/images/jenktocat.jpg',
+    message: ":tada: #{release_tag} is now available! :tada:",
+    channel: '#dotcom-studio',
+    success: true,
+    slack_url: get_required_env('SLACK_WEBHOOK'),
+    payload: {
+      ':studio-app-icon-mac: Release available for': builds.each_value.map { |b| "[#{b[:name]}](#{b[:cdn_url]})" }.join(', ')
+    },
+    default_payloads: []
+  )
 end
 
-def upload_to_s3_with_dry_run(bucket:, key:, file:, if_exists:, auto_prefix:)
-  if DRY_RUN
+def upload_to_s3(bucket:, key:, file:, if_exists:, auto_prefix: false, dry_run: DRY_RUN)
+  if dry_run
     UI.message("[DRY RUN] Would upload file: #{file}")
     UI.message("           to S3 bucket: #{bucket}")
     UI.message("           with key: #{key}")
@@ -105,25 +102,34 @@ def upload_to_s3_with_dry_run(bucket:, key:, file:, if_exists:, auto_prefix:)
     return true
   end
 
-  upload_to_s3(
-    bucket: bucket,
-    key: key,
-    file: file,
-    if_exists: if_exists,
-    auto_prefix: auto_prefix
+  aws_s3_upload(
+    bucket:,
+    key:,
+    file:,
+    if_exists:,
+    auto_prefix:
   )
 end
 
-def clear_cloudfront_cache_with_dry_run(paths:, commit_hash:)
-  if DRY_RUN
+def clear_cloudfront_cache(paths:, commit_hash:, dry_run: DRY_RUN)
+  if dry_run
     UI.message("[DRY RUN] Would invalidate CloudFront cache:")
-    UI.message("           Distribution: EF4A01YASGPY5")
+    UI.message("           Distribution: #{CLOUDFRONT_DISTRIBUTION_ID}")
     UI.message("           Paths: #{paths.join(', ')}")
     UI.message("           Commit hash: #{commit_hash}")
     return true
   end
 
-  clear_cloudfront_cache(paths: paths, commit_hash: commit_hash)
+  Aws::CloudFront::Client.new.create_invalidation(
+    distribution_id: CLOUDFRONT_DISTRIBUTION_ID,
+    invalidation_batch: {
+      paths: {
+        quantity: paths.length,
+        items: paths
+      },
+      caller_reference: commit_hash
+    }
+  )
 end
 
 def distribute_builds(
@@ -204,7 +210,7 @@ def distribute_builds(
   bucket_name = 'a8c-apps-public-artifacts'
 
   builds.each_value do |build|
-    upload_to_s3_with_dry_run(
+    upload_to_s3(
       bucket: bucket_name,
       key: "#{bucket_folder}/#{build[:filename]}",
       file: build[:binary_path],
@@ -214,7 +220,7 @@ def distribute_builds(
   end
 
   manifest_name = 'releases.json'
-  upload_to_s3_with_dry_run(
+  upload_to_s3(
     bucket: bucket_name,
     key: "#{bucket_folder}/#{manifest_name}",
     file: File.join(BUILDS_FOLDER, manifest_name),
@@ -231,7 +237,7 @@ def distribute_builds(
       filename = assemble_filename.call(build, 'latest')
       key = "#{bucket_folder}/#{filename}"
 
-      upload_to_s3_with_dry_run(
+      upload_to_s3(
         bucket: bucket_name,
         key: key,
         file: build[:binary_path],
@@ -243,7 +249,7 @@ def distribute_builds(
     end
   end
 
-  clear_cloudfront_cache_with_dry_run(
+  clear_cloudfront_cache(
     paths: cache_paths_to_clear,
     commit_hash: "#{commit_hash}-#{build_number}"
   )
@@ -258,17 +264,4 @@ def distribute_builds(
 
   # Return the builds data so callers can use them for further processing or messaging.
   builds
-end
-
-def clear_cloudfront_cache(paths:, commit_hash:)
-  Aws::CloudFront::Client.new.create_invalidation(
-    distribution_id: 'EF4A01YASGPY5',
-    invalidation_batch: {
-      paths: {
-        quantity: paths.length,
-        items: paths
-      },
-      caller_reference: commit_hash
-    }
-  )
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -3,6 +3,7 @@
 fastlane_require 'digest'
 fastlane_require 'zip'
 fastlane_require 'aws-sdk-cloudfront'
+fastlane_require 'json'
 
 UI.user_error!('Please run fastlane via `bundle exec`') unless FastlaneCore::Helper.bundler?
 
@@ -12,6 +13,9 @@ UI.user_error!('Please run fastlane via `bundle exec`') unless FastlaneCore::Hel
 PROJECT_ROOT_FOLDER = File.dirname(File.expand_path(__dir__))
 SECRETS_FOLDER = File.join(Dir.home, '.configure', 'studio', 'secrets')
 BUILDS_FOLDER = File.join(PROJECT_ROOT_FOLDER, 'out')
+
+# Read version from package.json
+PACKAGE_VERSION = JSON.parse(File.read(File.join(PROJECT_ROOT_FOLDER, 'package.json')))['version']
 
 APPLE_TEAM_ID = 'PZYM8XX95Q'
 APPLE_BUNDLE_IDENTIFIER = 'com.automattic.studio'
@@ -92,7 +96,7 @@ def distribute_builds(
 )
   # If we are distributing a build without a tag, i.e. a development build, we also want to update the latest build reference for distribution.
   update_latest = release_tag.nil?
-  suffix = release_tag.nil? ? commit_hash : release_tag
+  suffix = release_tag.nil? ? "v#{PACKAGE_VERSION}-#{commit_hash}" : release_tag
   filename_root = 'studio'
   bucket_folder = 'studio'
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -27,6 +27,8 @@ APPLE_API_KEY_PATH = File.join(SECRETS_FOLDER, 'app_store_connect_fastlane_api_k
 CDN_URL = 'https://cdn.a8c-ci.services'
 CLOUDFRONT_DISTRIBUTION_ID = 'EF4A01YASGPY5'
 
+# Use this instead of getting values from ENV directly
+# It will throw an error if the requested value is missing
 def get_required_env(key)
   UI.user_error!("Environment variable `#{key}` is not set.") unless ENV.key?(key)
   ENV.fetch(key)
@@ -108,27 +110,6 @@ def upload_to_s3(bucket:, key:, file:, if_exists:, auto_prefix: false, dry_run: 
     file:,
     if_exists:,
     auto_prefix:
-  )
-end
-
-def clear_cloudfront_cache(paths:, commit_hash:, dry_run: DRY_RUN)
-  if dry_run
-    UI.message("[DRY RUN] Would invalidate CloudFront cache:")
-    UI.message("           Distribution: #{CLOUDFRONT_DISTRIBUTION_ID}")
-    UI.message("           Paths: #{paths.join(', ')}")
-    UI.message("           Commit hash: #{commit_hash}")
-    return true
-  end
-
-  Aws::CloudFront::Client.new.create_invalidation(
-    distribution_id: CLOUDFRONT_DISTRIBUTION_ID,
-    invalidation_batch: {
-      paths: {
-        quantity: paths.length,
-        items: paths
-      },
-      caller_reference: commit_hash
-    }
   )
 end
 
@@ -239,7 +220,7 @@ def distribute_builds(
 
       upload_to_s3(
         bucket: bucket_name,
-        key: key,
+        key:,
         file: build[:binary_path],
         if_exists: :replace,
         auto_prefix: false
@@ -249,6 +230,9 @@ def distribute_builds(
     end
   end
 
+  # Because we distribute via Cloudfront, we need to invalidate the manifest
+  # and the latest build (<if building for release) after each upload, otherwise
+  # it'll be stale.
   clear_cloudfront_cache(
     paths: cache_paths_to_clear,
     commit_hash: "#{commit_hash}-#{build_number}"
@@ -264,4 +248,25 @@ def distribute_builds(
 
   # Return the builds data so callers can use them for further processing or messaging.
   builds
+end
+
+def clear_cloudfront_cache(paths:, commit_hash:, dry_run: DRY_RUN)
+  if dry_run
+    UI.message("[DRY RUN] Would invalidate CloudFront cache:")
+    UI.message("           Distribution: #{CLOUDFRONT_DISTRIBUTION_ID}")
+    UI.message("           Paths: #{paths.join(', ')}")
+    UI.message("           Commit hash: #{commit_hash}")
+    return true
+  end
+
+  Aws::CloudFront::Client.new.create_invalidation(
+    distribution_id: CLOUDFRONT_DISTRIBUTION_ID,
+    invalidation_batch: {
+      paths: {
+        quantity: paths.length,
+        items: paths
+      },
+      caller_reference: commit_hash
+    }
+  )
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -14,6 +14,9 @@ PROJECT_ROOT_FOLDER = File.dirname(File.expand_path(__dir__))
 SECRETS_FOLDER = File.join(Dir.home, '.configure', 'studio', 'secrets')
 BUILDS_FOLDER = File.join(PROJECT_ROOT_FOLDER, 'out')
 
+# Enable dry run mode through environment variable
+DRY_RUN = ENV['DRY_RUN'] == 'true'
+
 # Read version from package.json
 PACKAGE_VERSION = JSON.parse(File.read(File.join(PROJECT_ROOT_FOLDER, 'package.json')))['version']
 
@@ -26,6 +29,8 @@ CDN_URL = 'https://cdn.a8c-ci.services'
 # Use this instead of getting values from ENV directly
 # It will throw an error if the requested value is missing
 def get_required_env(key)
+  return 'dry-run' if DRY_RUN && (key == 'BUILDKITE_BUILD_NUMBER' || key == 'BUILDKITE_TAG' || key == 'SLACK_WEBHOOK')
+  
   UI.user_error!("Environment variable `#{key}` is not set.") unless ENV.key?(key)
   ENV.fetch(key)
 end
@@ -75,18 +80,50 @@ lane :distribute_release_build do |_options|
   release_tag = get_required_env('BUILDKITE_TAG')
   builds = distribute_builds(release_tag:)
 
-  slack(
-    username: 'CI Bot',
-    icon_url: 'https://octodex.github.com/images/jenktocat.jpg',
-    message: ":tada: #{release_tag} is now available! :tada:",
-    channel: '#dotcom-studio',
-    success: true,
-    slack_url: get_required_env('SLACK_WEBHOOK'),
-    payload: {
-      ':studio-app-icon-mac: Release available for': builds.each_value.map { |b| "[#{b[:name]}](#{b[:cdn_url]})" }.join(', ')
-    },
-    default_payloads: []
+  unless DRY_RUN
+    slack(
+      username: 'CI Bot',
+      icon_url: 'https://octodex.github.com/images/jenktocat.jpg',
+      message: ":tada: #{release_tag} is now available! :tada:",
+      channel: '#dotcom-studio',
+      success: true,
+      slack_url: get_required_env('SLACK_WEBHOOK'),
+      payload: {
+        ':studio-app-icon-mac: Release available for': builds.each_value.map { |b| "[#{b[:name]}](#{b[:cdn_url]})" }.join(', ')
+      },
+      default_payloads: []
+    )
+  end
+end
+
+def upload_to_s3_with_dry_run(bucket:, key:, file:, if_exists:, auto_prefix:)
+  if DRY_RUN
+    UI.message("[DRY RUN] Would upload file: #{file}")
+    UI.message("           to S3 bucket: #{bucket}")
+    UI.message("           with key: #{key}")
+    UI.message("           if_exists: #{if_exists}")
+    return true
+  end
+
+  upload_to_s3(
+    bucket: bucket,
+    key: key,
+    file: file,
+    if_exists: if_exists,
+    auto_prefix: auto_prefix
   )
+end
+
+def clear_cloudfront_cache_with_dry_run(paths:, commit_hash:)
+  if DRY_RUN
+    UI.message("[DRY RUN] Would invalidate CloudFront cache:")
+    UI.message("           Distribution: EF4A01YASGPY5")
+    UI.message("           Paths: #{paths.join(', ')}")
+    UI.message("           Commit hash: #{commit_hash}")
+    return true
+  end
+
+  clear_cloudfront_cache(paths: paths, commit_hash: commit_hash)
 end
 
 def distribute_builds(
@@ -94,6 +131,7 @@ def distribute_builds(
   build_number: get_required_env('BUILDKITE_BUILD_NUMBER'),
   release_tag: nil
 )
+  UI.message("Running in #{DRY_RUN ? 'DRY RUN' : 'NORMAL'} mode")
   # If we are distributing a build without a tag, i.e. a development build, we also want to update the latest build reference for distribution.
   update_latest = release_tag.nil?
   suffix = release_tag.nil? ? "v#{PACKAGE_VERSION}-#{commit_hash}" : release_tag
@@ -166,7 +204,7 @@ def distribute_builds(
   bucket_name = 'a8c-apps-public-artifacts'
 
   builds.each_value do |build|
-    upload_to_s3(
+    upload_to_s3_with_dry_run(
       bucket: bucket_name,
       key: "#{bucket_folder}/#{build[:filename]}",
       file: build[:binary_path],
@@ -176,7 +214,7 @@ def distribute_builds(
   end
 
   manifest_name = 'releases.json'
-  upload_to_s3(
+  upload_to_s3_with_dry_run(
     bucket: bucket_name,
     key: "#{bucket_folder}/#{manifest_name}",
     file: File.join(BUILDS_FOLDER, manifest_name),
@@ -193,9 +231,9 @@ def distribute_builds(
       filename = assemble_filename.call(build, 'latest')
       key = "#{bucket_folder}/#{filename}"
 
-      upload_to_s3(
+      upload_to_s3_with_dry_run(
         bucket: bucket_name,
-        key:,
+        key: key,
         file: build[:binary_path],
         if_exists: :replace,
         auto_prefix: false
@@ -205,19 +243,18 @@ def distribute_builds(
     end
   end
 
-  # Because we distribute via Cloudfront, we need to invalidate the manifest
-  # and the latest build (if building for release) after each upload, otherwise
-  # it'll be stale.
-  clear_cloudfront_cache(
+  clear_cloudfront_cache_with_dry_run(
     paths: cache_paths_to_clear,
     commit_hash: "#{commit_hash}-#{build_number}"
   )
 
-  buildkite_annotate(
-    context: 'cdn-link',
-    style: 'info',
-    message: "🔗 Build available for #{builds.each_value.map { |build| "[#{build[:name]}](#{build[:cdn_url]})" }.join(', ')}"
-  )
+  unless DRY_RUN
+    buildkite_annotate(
+      context: 'cdn-link',
+      style: 'info',
+      message: "🔗 Build available for #{builds.each_value.map { |build| "[#{build[:name]}](#{build[:cdn_url]})" }.join(', ')}"
+    )
+  end
 
   # Return the builds data so callers can use them for further processing or messaging.
   builds

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -231,7 +231,7 @@ def distribute_builds(
   end
 
   # Because we distribute via Cloudfront, we need to invalidate the manifest
-  # and the latest build (<if building for release) after each upload, otherwise
+  # and the latest build (if building for release) after each upload, otherwise
   # it'll be stale.
   clear_cloudfront_cache(
     paths: cache_paths_to_clear,

--- a/scripts/generate-releases-manifest.mjs
+++ b/scripts/generate-releases-manifest.mjs
@@ -136,22 +136,22 @@ if ( isDevBuild ) {
 	releasesData[ 'dev' ][ 'darwin' ] = releasesData[ 'dev' ][ 'darwin' ] ?? {};
 	releasesData[ 'dev' ][ 'darwin' ][ 'universal' ] = {
 		sha: currentCommit,
-		url: `${ cdnURL }/${ baseName }-darwin-universal-${ currentCommit }.app.zip`,
+		url: `${ cdnURL }/${ baseName }-darwin-universal-v${ version }-${ currentCommit }.app.zip`,
 	};
 	releasesData[ 'dev' ][ 'darwin' ][ 'x64' ] = {
 		sha: currentCommit,
-		url: `${ cdnURL }/${ baseName }-darwin-x64-${ currentCommit }.app.zip`,
+		url: `${ cdnURL }/${ baseName }-darwin-x64-v${ version }-${ currentCommit }.app.zip`,
 	};
 	releasesData[ 'dev' ][ 'darwin' ][ 'arm64' ] = {
 		sha: currentCommit,
-		url: `${ cdnURL }/${ baseName }-darwin-arm64-${ currentCommit }.app.zip`,
+		url: `${ cdnURL }/${ baseName }-darwin-arm64-v${ version }-${ currentCommit }.app.zip`,
 	};
 
 	// Windows
 	const windowsReleaseInfo = await getWindowsReleaseInfo();
 	releasesData[ 'dev' ][ 'win32' ] = {
 		sha: windowsReleaseInfo.sha1,
-		url: `${ cdnURL }/${ baseName }-win32-${ currentCommit }-full.nupkg`,
+		url: `${ cdnURL }/${ baseName }-win32-v${ version }-${ currentCommit }-full.nupkg`,
 		size: windowsReleaseInfo.size,
 	};
 


### PR DESCRIPTION
## Related issues

- Fixes https://github.com/Automattic/dotcom-forge/issues/7439

## Proposed Changes

- Added version information to development build filenames
- Modified the release manifest generation to include version numbers in URLs
- Updated build naming convention to include semantic version (e.g., v1.2.3-commit_hash)
- Added dry run mode to safely test distribution changes
- Skip external service calls (Slack, Buildkite, S3, Cloudfront) in dry run mode

## Testing Instructions

Note: You need to have all the builds in the `out` folder.

<details>
<summary>expected folder structure</summary>

```bash
out/
├── Studio-darwin-universal/
│   └── Studio.app.zip
├── Studio-darwin-universal.dmg
├── Studio-darwin-x64/
│   └── Studio.app.zip
├── Studio-darwin-x64.dmg
├── Studio-darwin-arm64/
│   └── Studio.app.zip
├── Studio-darwin-arm64.dmg
├── make/
│   └── squirrel.windows/
│       └── x64/
│           ├── studio-setup.exe
└──         └── studio-update.nupkg
```

</details>

1. Test dev build distribution (dry run):

```bash
DRY_RUN=true BUILDKITE_BUILD_NUMBER=test-build bundle exec fastlane distribute_dev_build
```
2. Check the output and confirm files have the expected format

<details>
<summary>Example dry run output</summary>

```bash
[16:02:53]: Running in DRY RUN mode
[16:02:53]: [DRY RUN] Would upload file: Studio-darwin-universal/Studio.app.zip
[16:02:53]: to S3 bucket: a8c-apps-public-artifacts
[16:02:53]: with key: studio/studio-darwin-universal-v1.3.2-0ba91bc.app.zip
[16:02:53]: if_exists: fail
[16:02:53]: [DRY RUN] Would upload file: Studio-darwin-universal.dmg
[16:02:53]: to S3 bucket: a8c-apps-public-artifacts
[16:02:53]: with key: studio/studio-darwin-universal-v1.3.2-0ba91bc.dmg
[16:02:53]: if_exists: fail
[16:02:53]: [DRY RUN] Would upload file: Studio-darwin-x64/Studio.app.zip
[16:02:53]: to S3 bucket: a8c-apps-public-artifacts
[16:02:53]: with key: studio/studio-darwin-x64-v1.3.2-0ba91bc.app.zip
[16:02:53]: if_exists: fail
[16:02:53]: [DRY RUN] Would upload file: Studio-darwin-arm64/Studio.app.zip
[16:02:53]: to S3 bucket: a8c-apps-public-artifacts
[16:02:53]: with key: studio/studio-darwin-arm64-v1.3.2-0ba91bc.app.zip
[16:02:53]: if_exists: fail
[16:02:53]: [DRY RUN] Would upload file: studio-setup.exe
[16:02:53]: to S3 bucket: a8c-apps-public-artifacts
[16:02:53]: with key: studio/studio-win32-v1.3.2-0ba91bc.exe
[16:02:53]: if_exists: fail
[16:02:53]: [DRY RUN] Would upload file: studio-update.nupkg
[16:02:53]: to S3 bucket: a8c-apps-public-artifacts
[16:02:53]: with key: studio/studio-win32-v1.3.2-0ba91bc-full.nupkg
[16:02:53]: if_exists: fail
[16:02:53]: [DRY RUN] Would upload file: releases.json
[16:02:53]: to S3 bucket: a8c-apps-public-artifacts
[16:02:53]: with key: studio/releases.json
[16:02:53]: if_exists: replace
[16:02:53]: [DRY RUN] Would invalidate CloudFront cache:
[16:02:53]: Distribution: EF4A01YASGPY5
[16:02:53]: Paths: /studio/releases.json
[16:02:53]: Commit hash: 0ba91bc-dry-run
```

</details>

3. Run the releases manifest script to check if the dev builds have the right name.

```bash
IS_DEV_BUILD=true node scripts/generate-releases-manifest.mjs
grep -A 20 '"dev"' out/releases.json
```

<details>
<summary>Example releases manifest output</summary>

```json
"dev": {
    "darwin": {
      "universal": {
        "sha": "0ba91bc",
        "url": "https://cdn.a8c-ci.services/studio/studio-darwin-universal-v1.3.2-0ba91bc.app.zip"
      },
      "x64": {
        "sha": "0ba91bc",
        "url": "https://cdn.a8c-ci.services/studio/studio-darwin-x64-v1.3.2-0ba91bc.app.zip"
      },
      "arm64": {
        "sha": "0ba91bc",
        "url": "https://cdn.a8c-ci.services/studio/studio-darwin-arm64-v1.3.2-0ba91bc.app.zip"
      }
    },
    "win32": {
      "sha": "2B249D838747BBC5FF07454961CC4DCF4C05DA4A",
      "url": "https://cdn.a8c-ci.services/studio/studio-win32-v1.3.2-0ba91bc-full.nupkg",
      "size": "199236843"
    }
  },
 ```

</details>

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?
