### PR TITLE
Add a 'Local path' field label and a doc link

### DIFF
--- a/src/components/site-form.tsx
+++ b/src/components/site-form.tsx
@@ -319,40 +319,40 @@ export const SiteForm = ( {
 											: 'max-h-0 opacity-0 mb-0'
 									) }
 								>
-									<label
+									<div
 										className={ cx(
 											'flex flex-col gap-1.5 leading-4',
 											isAdvancedSettingsVisible ? 'py-2' : 'p-2',
 											! isAdvancedSettingsVisible && 'hidden'
 										) }
 									>
-										<span onClick={ onSelectPath } className="font-semibold">
+										<label onClick={ onSelectPath } className="font-semibold">
 											{ __( 'Local path' ) }
-										</span>
-									</label>
-									<span className="text-a8c-gray-50 text-xs">
-										{ createInterpolateElement(
-											__(
-												'Select an empty directory or a directory with an existing WordPress site. <button>Learn more</button>'
-											),
-											{
-												button: (
-													<Button
-														variant="link"
-														className="text-xs"
-														onClick={ () => getIpcApi().openURL( STUDIO_DOCS_URL_SITES ) }
-													/>
+										</label>
+										<span className="text-a8c-gray-50 text-xs">
+											{ createInterpolateElement(
+												__(
+													'Select an empty directory or a directory with an existing WordPress site. <button>Learn more</button>'
 												),
-											}
-										) }
-									</span>
-									<FormPathInputComponent
-										isDisabled={ isPathInputDisabled }
-										doesPathContainWordPress={ doesPathContainWordPress }
-										error={ error }
-										value={ sitePath }
-										onClick={ onSelectPath }
-									/>
+												{
+													button: (
+														<Button
+															variant="link"
+															className="text-xs"
+															onClick={ () => getIpcApi().openURL( STUDIO_DOCS_URL_SITES ) }
+														/>
+													),
+												}
+											) }
+										</span>
+										<FormPathInputComponent
+											isDisabled={ isPathInputDisabled }
+											doesPathContainWordPress={ doesPathContainWordPress }
+											error={ error }
+											value={ sitePath }
+											onClick={ onSelectPath }
+										/>
+									</div>
 								</div>
 							</>
 						) }

--- a/src/components/site-form.tsx
+++ b/src/components/site-form.tsx
@@ -4,7 +4,11 @@ import { __ } from '@wordpress/i18n';
 import { tip, warning, trash, chevronRight, chevronDown, chevronLeft } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { FormEvent, useRef, useState } from 'react';
-import { ACCEPTED_IMPORT_FILE_TYPES, STUDIO_DOCS_URL_IMPORT_EXPORT } from '../constants';
+import {
+	ACCEPTED_IMPORT_FILE_TYPES,
+	STUDIO_DOCS_URL_IMPORT_EXPORT,
+	STUDIO_DOCS_URL_SITES,
+} from '../constants';
 import { cx } from '../lib/cx';
 import { getIpcApi } from '../lib/get-ipc-api';
 import Button from './button';
@@ -325,14 +329,30 @@ export const SiteForm = ( {
 										<span onClick={ onSelectPath } className="font-semibold">
 											{ __( 'Local path' ) }
 										</span>
-										<FormPathInputComponent
-											isDisabled={ isPathInputDisabled }
-											doesPathContainWordPress={ doesPathContainWordPress }
-											error={ error }
-											value={ sitePath }
-											onClick={ onSelectPath }
-										/>
 									</label>
+									<span className="text-a8c-gray-50 text-xs">
+										{ createInterpolateElement(
+											__(
+												'Select an empty directory or a directory with an existing WordPress site. <button>Learn more</button>'
+											),
+											{
+												button: (
+													<Button
+														variant="link"
+														className="text-xs"
+														onClick={ () => getIpcApi().openURL( STUDIO_DOCS_URL_SITES ) }
+													/>
+												),
+											}
+										) }
+									</span>
+									<FormPathInputComponent
+										isDisabled={ isPathInputDisabled }
+										doesPathContainWordPress={ doesPathContainWordPress }
+										error={ error }
+										value={ sitePath }
+										onClick={ onSelectPath }
+									/>
 								</div>
 							</>
 						) }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -18,6 +18,8 @@ export const AI_GUIDELINES_URL = 'https://automattic.com/ai-guidelines/';
 export const STUDIO_DOCS_URL = `https://developer.wordpress.com/docs/developer-tools/studio/`;
 export const STUDIO_DOCS_URL_IMPORT_EXPORT =
 	'https://developer.wordpress.com/docs/developer-tools/studio/import-export';
+export const STUDIO_DOCS_URL_SITES =
+	'https://developer.wordpress.com/docs/developer-tools/studio/sites/';
 export const BUG_REPORT_URL =
 	'https://github.com/Automattic/studio/issues/new?assignees=&labels=Needs+triage%2C%5BType%5D+Bug&projects=&template=bug_report.yml';
 export const FEATURE_REQUEST_URL =


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/dotcom-forge/issues/10270

## Proposed Changes

I propose to add a 'Local path' field label to explain accepted directory formats. I also propose adding a 'Learn more' link pointing to the documentation page, which explains this better.

<img width="1012" alt="Screenshot 2025-01-22 at 11 26 27" src="https://github.com/user-attachments/assets/b1191d9b-9f09-4a63-9dc0-5047da39f647" />

<img width="1012" alt="Screenshot 2025-01-22 at 11 17 10" src="https://github.com/user-attachments/assets/53e21efb-5185-49e1-a01b-face2dda08ad" />

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check if the 'Add site' form still works fine and allows selecting a local path
2. Validate the same in the Onboarding form
3. Validate if message is clear enough

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
