### PR TITLE
Use platform-aware path separator in `WpressValidator`

### DIFF
--- a/src/lib/import-export/import/validators/wpress-validator.ts
+++ b/src/lib/import-export/import/validators/wpress-validator.ts
@@ -10,7 +10,7 @@ export class WpressValidator extends EventEmitter implements Validator {
 		const optionalDirs = [ 'uploads', 'plugins', 'themes' ];
 		return (
 			requiredFiles.every( ( file ) => fileList.includes( file ) ) &&
-			fileList.some( ( file ) => optionalDirs.some( ( dir ) => file.startsWith( dir + '/' ) ) )
+			optionalDirs.some( ( dir ) => fileList.some( ( file ) => file.startsWith( dir + path.sep ) ) )
 		);
 	}
 

--- a/src/lib/import-export/import/validators/wpress-validator.ts
+++ b/src/lib/import-export/import/validators/wpress-validator.ts
@@ -37,11 +37,11 @@ export class WpressValidator extends EventEmitter implements Validator {
 			const fullPath = path.join( extractionDirectory, file );
 			if ( file === 'database.sql' ) {
 				extractedBackup.sqlFiles.push( fullPath );
-			} else if ( file.startsWith( 'uploads/' ) ) {
+			} else if ( file.startsWith( 'uploads' + path.sep ) ) {
 				extractedBackup.wpContent.uploads.push( fullPath );
-			} else if ( file.startsWith( 'plugins/' ) ) {
+			} else if ( file.startsWith( 'plugins' + path.sep ) ) {
 				extractedBackup.wpContent.plugins.push( fullPath );
-			} else if ( file.startsWith( 'themes/' ) ) {
+			} else if ( file.startsWith( 'themes' + path.sep ) ) {
 				extractedBackup.wpContent.themes.push( fullPath );
 			} else if ( file === 'package.json' ) {
 				extractedBackup.metaFile = fullPath;

--- a/src/lib/import-export/tests/import/validators/wpress-validator.test.ts
+++ b/src/lib/import-export/tests/import/validators/wpress-validator.test.ts
@@ -6,24 +6,24 @@ describe( 'WpressValidator', () => {
 	let validator: WpressValidator;
 
 	const originalSep = path.sep;
+	const originalJoin = path.join;
 	const separators = [
 		{ name: 'Unix', separator: '/' },
 		{ name: 'Windows', separator: '\\' },
 	];
 
-	beforeEach( () => {
-		validator = new WpressValidator();
+	afterEach( () => {
+		// @ts-expect-error - Restore original path.sep
+		path.sep = originalSep;
+		path.join = originalJoin;
 	} );
 
 	describe.each( separators )( 'canHandle with $name separators', ( { separator } ) => {
 		beforeEach( () => {
+			validator = new WpressValidator();
 			// @ts-expect-error - Temporarily override path.sep
 			path.sep = separator;
-		} );
-
-		afterEach( () => {
-			// @ts-expect-error - Temporarily override path.sep
-			path.sep = originalSep;
+			path.join = jest.fn( ( ...segments ) => segments.join( separator ) );
 		} );
 
 		it( 'should return true for valid wpress file structure', () => {
@@ -63,13 +63,20 @@ describe( 'WpressValidator', () => {
 		} );
 	} );
 
-	describe( 'parseBackupContents', () => {
-		const extractionDirectory = '/path/to/extraction';
+	describe.each( separators )( 'parseBackupContents with $name separators', ( { separator } ) => {
+		beforeEach( () => {
+			validator = new WpressValidator();
+			// @ts-expect-error - Temporarily override path.sep
+			path.sep = separator;
+			path.join = jest.fn( ( ...segments ) => segments.join( separator ) );
+		} );
+
+		const extractionDirectory = [ 'path', 'to', 'extraction' ].join( separator );
 		const fileList = [
 			'database.sql',
-			'uploads/image.jpg',
-			'plugins/some-plugin/plugin.php',
-			'themes/some-theme/style.css',
+			[ 'uploads', 'image.jpg' ].join( separator ),
+			[ 'plugins', 'some-plugin', 'plugin.php' ].join( separator ),
+			[ 'themes', 'some-theme', 'style.css' ].join( separator ),
 			'package.json',
 		];
 
@@ -77,17 +84,19 @@ describe( 'WpressValidator', () => {
 			const result = validator.parseBackupContents( fileList, extractionDirectory );
 
 			expect( result.extractionDirectory ).toBe( extractionDirectory );
-			expect( result.sqlFiles ).toEqual( [ path.join( extractionDirectory, 'database.sql' ) ] );
+			expect( result.sqlFiles ).toEqual( [
+				[ extractionDirectory, 'database.sql' ].join( separator ),
+			] );
 			expect( result.wpContent.uploads ).toEqual( [
-				path.join( extractionDirectory, 'uploads/image.jpg' ),
+				[ extractionDirectory, 'uploads', 'image.jpg' ].join( separator ),
 			] );
 			expect( result.wpContent.plugins ).toEqual( [
-				path.join( extractionDirectory, 'plugins/some-plugin/plugin.php' ),
+				[ extractionDirectory, 'plugins', 'some-plugin', 'plugin.php' ].join( separator ),
 			] );
 			expect( result.wpContent.themes ).toEqual( [
-				path.join( extractionDirectory, 'themes/some-theme/style.css' ),
+				[ extractionDirectory, 'themes', 'some-theme', 'style.css' ].join( separator ),
 			] );
-			expect( result.metaFile ).toBe( path.join( extractionDirectory, 'package.json' ) );
+			expect( result.metaFile ).toBe( [ extractionDirectory, 'package.json' ].join( separator ) );
 		} );
 
 		it( 'should emit validation events', () => {

--- a/src/lib/import-export/tests/import/validators/wpress-validator.test.ts
+++ b/src/lib/import-export/tests/import/validators/wpress-validator.test.ts
@@ -5,18 +5,34 @@ import { WpressValidator } from '../../../import/validators/wpress-validator';
 describe( 'WpressValidator', () => {
 	let validator: WpressValidator;
 
+	const originalSep = path.sep;
+	const separators = [
+		{ name: 'Unix', separator: '/' },
+		{ name: 'Windows', separator: '\\' },
+	];
+
 	beforeEach( () => {
 		validator = new WpressValidator();
 	} );
 
-	describe( 'canHandle', () => {
+	describe.each( separators )( 'canHandle with $name separators', ( { separator } ) => {
+		beforeEach( () => {
+			// @ts-expect-error - Temporarily override path.sep
+			path.sep = separator;
+		} );
+
+		afterEach( () => {
+			// @ts-expect-error - Temporarily override path.sep
+			path.sep = originalSep;
+		} );
+
 		it( 'should return true for valid wpress file structure', () => {
 			const fileList = [
 				'database.sql',
 				'package.json',
-				'uploads/image.jpg',
-				'plugins/some-plugin/plugin.php',
-				'themes/some-theme/style.css',
+				[ 'uploads', 'image.jpg' ].join( separator ),
+				[ 'plugins', 'some-plugin', 'plugin.php' ].join( separator ),
+				[ 'themes', 'some-theme', 'style.css' ].join( separator ),
 			];
 			expect( validator.canHandle( fileList ) ).toBe( true );
 		} );
@@ -24,9 +40,9 @@ describe( 'WpressValidator', () => {
 		it( 'should return false if database.sql is missing', () => {
 			const fileList = [
 				'package.json',
-				'uploads/image.jpg',
-				'plugins/some-plugin/plugin.php',
-				'themes/some-theme/style.css',
+				[ 'uploads', 'image.jpg' ].join( separator ),
+				[ 'plugins', 'some-plugin', 'plugin.php' ].join( separator ),
+				[ 'themes', 'some-theme', 'style.css' ].join( separator ),
 			];
 			expect( validator.canHandle( fileList ) ).toBe( false );
 		} );
@@ -34,9 +50,9 @@ describe( 'WpressValidator', () => {
 		it( 'should return false if package.json is missing', () => {
 			const fileList = [
 				'database.sql',
-				'uploads/image.jpg',
-				'plugins/some-plugin/plugin.php',
-				'themes/some-theme/style.css',
+				[ 'uploads', 'image.jpg' ].join( separator ),
+				[ 'plugins', 'some-plugin', 'plugin.php' ].join( separator ),
+				[ 'themes', 'some-theme', 'style.css' ].join( separator ),
 			];
 			expect( validator.canHandle( fileList ) ).toBe( false );
 		} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/dotcom-forge/issues/9567

## Proposed Changes

`BackupHandlerWpress::listFiles` uses `path.join` when enumerating the files in a `.wpress` archive (All-in-One WP Migration format). This breaks `WpressValidator` on Windows because it assumes Unix style path separators in both `canHandle` and `parseBackupContents`.

This PR fixes the problem by replacing `'/'` with `path.sep` and by changing the unit tests to account for both Unix and Windows-style paths.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Import a `.wpress` archive on Windows
2. Ensure that the import completes successfully and the site works

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
