### PR TITLE
Add missing translation function call for validation tip

### DIFF
--- a/src/components/site-form.tsx
+++ b/src/components/site-form.tsx
@@ -104,7 +104,9 @@ function FormPathInputComponent( {
 			<SiteFormError
 				error={ error }
 				tipMessage={
-					doesPathContainWordPress ? __( 'The existing WordPress site at this path will be added.' ) : ''
+					doesPathContainWordPress
+						? __( 'The existing WordPress site at this path will be added.' )
+						: ''
 				}
 			/>
 		</div>

--- a/src/components/site-form.tsx
+++ b/src/components/site-form.tsx
@@ -104,7 +104,7 @@ function FormPathInputComponent( {
 			<SiteFormError
 				error={ error }
 				tipMessage={
-					doesPathContainWordPress ? 'The existing WordPress site at this path will be added.' : ''
+					doesPathContainWordPress ? __( 'The existing WordPress site at this path will be added.' ) : ''
 				}
 			/>
 		</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/dotcom-forge/issues/10232

## Proposed Changes

- I propose adding a missing translation call for the tip displayed when a user chooses the existing WordPress directory.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Ensure that the phrase is translated into your language by editing a file in `src/translations`
2. Start Studio and change language
3. Open the 'Add site' form
4. Open 'Advanced settings'
5. Open the directory selector
6. Choose the directory that includes WordPress installation but is not used by any other Studio site
7. Confirm that the tip displayed below the field is translated

<img width="481" alt="Screenshot 2025-01-22 at 15 11 27" src="https://github.com/user-attachments/assets/2ffc5b9c-5bc9-4157-8fdc-fa97905c5087" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
