### PR TITLE
Support absolute import paths in Jest

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -19,6 +19,8 @@ module.exports = {
 	transformIgnorePatterns: [ 'node_modules/(?!(@php-wasm|@wp-playground)/)' ],
 	moduleNameMapper: {
 		'^(\\.{1,2}/.*)\\.js$': '$1',
+		'^src/(.*)$': '<rootDir>/src/$1',
+		'^vendor/(.*)$': '<rootDir>/vendor/$1',
 	},
 	testEnvironment: 'jsdom',
 	globals: {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Follow-up to https://github.com/Automattic/studio/pull/825

## Proposed Changes

In https://github.com/Automattic/studio/pull/825, I added support for absolute imports starting with `src/` or `vendor/`. Turns out we need to add this to Jest's config, too. This PR fixes that.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Change one of the relative import paths in `src/components/content-tab-assistant.tsx` to be absolute
2. Run `npm run test src/components/tests/content-tab-assistant.test.tsx`
3. Ensure that the tests pass

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
