### PR TITLE
Fix: Topbar icons display padding in macOS fullscreen

### DIFF
--- a/src/__mocks__/electron.ts
+++ b/src/__mocks__/electron.ts
@@ -42,6 +42,18 @@ BrowserWindow.fromWebContents = jest.fn( () => ( {
 BrowserWindow.getAllWindows = jest.fn( () => [] );
 BrowserWindow.getFocusedWindow = jest.fn();
 
+const eventHandlers: { [ key: string ]: Array< ( ...args: any[] ) => void > } = {};
+BrowserWindow.prototype.on = jest.fn( ( event: string, handler: ( ...args: any[] ) => void ) => {
+	if ( ! eventHandlers[ event ] ) {
+		eventHandlers[ event ] = [];
+	}
+	eventHandlers[ event ].push( handler );
+} );
+BrowserWindow.prototype.emit = jest.fn( ( event: string, ...args: any[] ) => {
+	const handlers = eventHandlers[ event ] || [];
+	handlers.forEach( ( handler ) => handler( ...args ) );
+} );
+
 export const Menu = {
 	buildFromTemplate: jest.fn(),
 	setApplicationMenu: jest.fn(),

--- a/src/components/mac-titlebar.tsx
+++ b/src/components/mac-titlebar.tsx
@@ -1,3 +1,4 @@
+import { useFullscreen } from '../hooks/use-fullscreen';
 import { cx } from '../lib/cx';
 import { isWindowFrameRtl } from '../lib/is-window-frame-rtl';
 
@@ -8,15 +9,20 @@ export default function MacTitlebar( {
 	className?: string;
 	children?: React.ReactNode;
 } ) {
+	const isFullscreen = useFullscreen();
+	const isRtl = isWindowFrameRtl();
+
 	return (
 		<div
 			className={ cx(
-				// Leave space for window controls depending on which side they are on
-				// Take into account the "chrome" padding, the position of which depends on the language direction
-				isWindowFrameRtl() &&
+				'transition-[padding] duration-700 ease-in-out',
+				! isFullscreen &&
+					isRtl &&
 					'ltr:pr-window-controls-width-excl-chrome-mac ltr:pl-chrome rtl:pr-window-controls-width-mac rtl:-ml-chrome',
-				! isWindowFrameRtl() &&
+				! isFullscreen &&
+					! isRtl &&
 					'ltr:pl-window-controls-width-mac rtl:pl-window-controls-width-excl-chrome-mac rtl:pr-chrome',
+				isFullscreen && 'ltr:pl-4 rtl:pr-4',
 				className
 			) }
 		>

--- a/src/components/mac-titlebar.tsx
+++ b/src/components/mac-titlebar.tsx
@@ -15,7 +15,7 @@ export default function MacTitlebar( {
 	return (
 		<div
 			className={ cx(
-				'transition-[padding] duration-700 ease-in-out',
+				'transition-[padding] duration-500 ease-in-out',
 				! isFullscreen &&
 					isRtl &&
 					'ltr:pr-window-controls-width-excl-chrome-mac ltr:pl-chrome rtl:pr-window-controls-width-mac rtl:-ml-chrome',

--- a/src/components/tests/mac-titlebar.test.tsx
+++ b/src/components/tests/mac-titlebar.test.tsx
@@ -1,0 +1,80 @@
+import { render } from '@testing-library/react';
+import { useFullscreen } from '../../hooks/use-fullscreen';
+import { isWindowFrameRtl } from '../../lib/is-window-frame-rtl';
+import MacTitlebar from '../mac-titlebar';
+
+jest.mock( '../../hooks/use-fullscreen' );
+jest.mock( '../../lib/is-window-frame-rtl' );
+
+const FULLSCREEN_CLASSES = {
+	ltr: 'ltr:pl-4',
+	rtl: 'rtl:pr-4',
+} as const;
+
+const NON_FULLSCREEN_CLASSES = {
+	ltr: {
+		normal: 'ltr:pl-window-controls-width-mac',
+		chrome: 'rtl:pl-window-controls-width-excl-chrome-mac rtl:pr-chrome',
+	},
+	rtl: {
+		normal:
+			'ltr:pr-window-controls-width-excl-chrome-mac ltr:pl-chrome rtl:pr-window-controls-width-mac rtl:-ml-chrome',
+	},
+} as const;
+
+describe( 'MacTitlebar', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		( useFullscreen as jest.Mock ).mockReturnValue( false );
+		( isWindowFrameRtl as jest.Mock ).mockReturnValue( false );
+	} );
+
+	it( 'should render with correct padding in non-fullscreen LTR mode', () => {
+		( useFullscreen as jest.Mock ).mockReturnValue( false );
+		( isWindowFrameRtl as jest.Mock ).mockReturnValue( false );
+
+		const { container } = render( <MacTitlebar /> );
+		const titlebar = container.firstChild;
+
+		expect( titlebar ).toHaveClass( NON_FULLSCREEN_CLASSES.ltr.normal );
+		expect( titlebar ).toHaveClass( NON_FULLSCREEN_CLASSES.ltr.chrome );
+		expect( titlebar ).not.toHaveClass( FULLSCREEN_CLASSES.ltr );
+		expect( titlebar ).not.toHaveClass( FULLSCREEN_CLASSES.rtl );
+	} );
+
+	it( 'should render with correct padding in non-fullscreen RTL mode', () => {
+		( useFullscreen as jest.Mock ).mockReturnValue( false );
+		( isWindowFrameRtl as jest.Mock ).mockReturnValue( true );
+
+		const { container } = render( <MacTitlebar /> );
+		const titlebar = container.firstChild;
+
+		expect( titlebar ).toHaveClass( NON_FULLSCREEN_CLASSES.rtl.normal );
+		expect( titlebar ).not.toHaveClass( FULLSCREEN_CLASSES.ltr );
+		expect( titlebar ).not.toHaveClass( FULLSCREEN_CLASSES.rtl );
+	} );
+
+	it( 'should render with minimal padding in fullscreen mode', () => {
+		( useFullscreen as jest.Mock ).mockReturnValue( true );
+
+		const { container } = render( <MacTitlebar /> );
+		const titlebar = container.firstChild;
+
+		expect( titlebar ).toHaveClass( FULLSCREEN_CLASSES.ltr );
+		expect( titlebar ).toHaveClass( FULLSCREEN_CLASSES.rtl );
+		expect( titlebar ).not.toHaveClass( NON_FULLSCREEN_CLASSES.ltr.normal );
+		expect( titlebar ).not.toHaveClass( NON_FULLSCREEN_CLASSES.rtl.normal );
+	} );
+
+	it( 'should render children', () => {
+		const { getByText } = render( <MacTitlebar>Test Content</MacTitlebar> );
+		expect( getByText( 'Test Content' ) ).toBeInTheDocument();
+	} );
+
+	it( 'should apply additional className if provided', () => {
+		const { container } = render( <MacTitlebar className="custom-class" /> );
+		const titlebar = container.firstChild;
+
+		expect( titlebar ).toHaveClass( 'custom-class' );
+	} );
+} );

--- a/src/hooks/tests/use-fullscreen.test.ts
+++ b/src/hooks/tests/use-fullscreen.test.ts
@@ -1,0 +1,78 @@
+import { renderHook } from '@testing-library/react';
+import { act } from 'react';
+import { getIpcApi } from '../../lib/get-ipc-api';
+import { useFullscreen } from '../use-fullscreen';
+import { useIpcListener } from '../use-ipc-listener';
+
+jest.mock( '../../lib/get-ipc-api' );
+jest.mock( '../use-ipc-listener' );
+
+const mockIpcApi = {
+	isFullscreen: jest.fn(),
+};
+
+( getIpcApi as jest.Mock ).mockReturnValue( mockIpcApi );
+
+describe( 'useFullscreen', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'should initialize with false and update when isFullscreen resolves', async () => {
+		mockIpcApi.isFullscreen.mockResolvedValue( true );
+		const { result } = renderHook( () => useFullscreen() );
+
+		expect( result.current ).toBe( false );
+
+		await act( async () => {
+			await Promise.resolve();
+		} );
+
+		expect( result.current ).toBe( true );
+	} );
+
+	it( 'should update state when receiving window-fullscreen-change event', async () => {
+		mockIpcApi.isFullscreen.mockResolvedValue( false );
+		let eventHandler: ( _: unknown, fullscreen: boolean ) => void = () => undefined;
+		( useIpcListener as jest.Mock ).mockImplementation( ( _channel, handler ) => {
+			eventHandler = handler;
+		} );
+
+		const { result } = renderHook( () => useFullscreen() );
+
+		await act( async () => {
+			await Promise.resolve();
+		} );
+
+		await act( async () => {
+			eventHandler( null, true );
+		} );
+
+		expect( result.current ).toBe( true );
+
+		await act( async () => {
+			eventHandler( null, false );
+		} );
+
+		expect( result.current ).toBe( false );
+	} );
+
+	it( 'should not update state if component is unmounted', async () => {
+		let eventHandler: ( _: unknown, fullscreen: boolean ) => void = () => undefined;
+		( useIpcListener as jest.Mock ).mockImplementation( ( _channel, handler ) => {
+			eventHandler = handler;
+		} );
+
+		const { result, unmount } = renderHook( () => useFullscreen() );
+
+		expect( result.current ).toBe( false );
+
+		unmount();
+
+		await act( async () => {
+			eventHandler( null, true );
+		} );
+
+		expect( result.current ).toBe( false );
+	} );
+} );

--- a/src/hooks/tests/use-fullscreen.test.ts
+++ b/src/hooks/tests/use-fullscreen.test.ts
@@ -1,4 +1,4 @@
-import { renderHook } from '@testing-library/react';
+import { renderHook, waitFor } from '@testing-library/react';
 import { act } from 'react';
 import { getIpcApi } from '../../lib/get-ipc-api';
 import { useFullscreen } from '../use-fullscreen';
@@ -24,8 +24,8 @@ describe( 'useFullscreen', () => {
 
 		expect( result.current ).toBe( false );
 
-		await act( async () => {
-			await Promise.resolve();
+		await waitFor( () => {
+			expect( mockIpcApi.isFullscreen ).toHaveBeenCalledTimes( 1 );
 		} );
 
 		expect( result.current ).toBe( true );
@@ -40,8 +40,8 @@ describe( 'useFullscreen', () => {
 
 		const { result } = renderHook( () => useFullscreen() );
 
-		await act( async () => {
-			await Promise.resolve();
+		await waitFor( () => {
+			expect( mockIpcApi.isFullscreen ).toHaveBeenCalledTimes( 1 );
 		} );
 
 		await act( async () => {

--- a/src/hooks/use-fullscreen.ts
+++ b/src/hooks/use-fullscreen.ts
@@ -1,0 +1,27 @@
+import { useState, useEffect } from 'react';
+import { getIpcApi } from '../lib/get-ipc-api';
+import { useIpcListener } from './use-ipc-listener';
+
+export function useFullscreen() {
+	const [ isFullscreen, setIsFullscreen ] = useState( false );
+
+	useEffect( () => {
+		let mounted = true;
+		getIpcApi()
+			.isFullscreen()
+			.then( ( fullscreen ) => {
+				if ( mounted ) {
+					setIsFullscreen( fullscreen );
+				}
+			} );
+		return () => {
+			mounted = false;
+		};
+	}, [] );
+
+	useIpcListener( 'window-fullscreen-change', ( _, fullscreen: boolean ) => {
+		setIsFullscreen( fullscreen );
+	} );
+
+	return isFullscreen;
+}

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -40,6 +40,7 @@ import { sortSites } from './lib/sort-sites';
 import { installSqliteIntegration, keepSqliteIntegrationUpdated } from './lib/sqlite-versions';
 import * as windowsHelpers from './lib/windows-helpers';
 import { getLogsFilePath, writeLogToFile, type LogLevel } from './logging';
+import { withMainWindow } from './main-window';
 import { popupMenu, setupMenu } from './menu';
 import { SiteServer, createSiteWorkingDirectory } from './site-server';
 import { DEFAULT_SITE_PATH, getResourcesPath, getSiteThumbnailPath } from './storage/paths';
@@ -1091,4 +1092,12 @@ export async function getFileContent( event: IpcMainInvokeEvent, filePath: strin
 	}
 
 	return fs.readFileSync( filePath );
+}
+
+export async function isFullscreen( _event: IpcMainInvokeEvent ): Promise< boolean > {
+	let isFullscreen = false;
+	withMainWindow( ( window ) => {
+		isFullscreen = window.isFullScreen();
+	} );
+	return isFullscreen;
 }

--- a/src/main-window.ts
+++ b/src/main-window.ts
@@ -102,6 +102,14 @@ export function createMainWindow(): BrowserWindow {
 		mainWindow = null;
 	} );
 
+	mainWindow.on( 'enter-full-screen', () => {
+		mainWindow?.webContents.send( 'window-fullscreen-change', true );
+	} );
+
+	mainWindow.on( 'leave-full-screen', () => {
+		mainWindow?.webContents.send( 'window-fullscreen-change', false );
+	} );
+
 	return mainWindow;
 }
 

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -104,6 +104,7 @@ const api: IpcApi = {
 	clearSyncOperation: ( id: string ) => ipcRenderer.invoke( 'clearSyncOperation', id ),
 	getPathForFile: webUtils.getPathForFile,
 	getFileContent: ( filePath: string ) => ipcRenderer.invoke( 'getFileContent', filePath ),
+	isFullscreen: () => ipcRenderer.invoke( 'isFullscreen' ),
 };
 
 contextBridge.exposeInMainWorld( 'ipcApi', api );
@@ -119,6 +120,7 @@ const allowedChannels = [
 	'theme-details-updating',
 	'on-import',
 	'on-export',
+	'window-fullscreen-change',
 ] as const;
 
 contextBridge.exposeInMainWorld( 'ipcListener', {

--- a/src/tests/main-window.test.ts
+++ b/src/tests/main-window.test.ts
@@ -84,3 +84,35 @@ describe( 'withMainWindow', () => {
 		expect( callback ).toHaveBeenCalledWith( expect.any( BrowserWindow ) );
 	} );
 } );
+
+describe( 'fullscreen events', () => {
+	let createdWindow: BrowserWindow;
+
+	beforeEach( () => {
+		createdWindow = createMainWindow();
+	} );
+
+	afterEach( () => {
+		__resetMainWindow();
+	} );
+
+	it( 'sends fullscreen-change event when entering fullscreen', () => {
+		const mockSend = jest.fn();
+		createdWindow.webContents.send = mockSend;
+
+		// Simulate entering fullscreen
+		createdWindow.emit( 'enter-full-screen' );
+
+		expect( mockSend ).toHaveBeenCalledWith( 'window-fullscreen-change', true );
+	} );
+
+	it( 'sends fullscreen-change event when leaving fullscreen', () => {
+		const mockSend = jest.fn();
+		createdWindow.webContents.send = mockSend;
+
+		// Simulate leaving fullscreen
+		createdWindow.emit( 'leave-full-screen' );
+
+		expect( mockSend ).toHaveBeenCalledWith( 'window-fullscreen-change', false );
+	} );
+} );


### PR DESCRIPTION
## Related issues

- Fixes https://github.com/Automattic/dotcom-forge/issues/9264

## Proposed Changes

- Added smooth transitions for window controls positioning when entering/exiting full-screen mode
- Implemented native full-screen state detection through Electron's IPC
- Added proper event handling for full-screen state changes in the main window

## Testing Instructions
1. Launch the application
2. Verify window topbar controls are properly positioned based on system language direction
3. Enter full-screen mode (⌘+Control+F or green window button)
   - Verify smooth transition of window topbar controls
   - Confirm correct padding in full-screen mode
4. Exit full-screen mode
   - Verify smooth transition back to windowed mode
   - Confirm window topbar controls return to correct position
5. Repeat tests with both LTR and RTL language settings

### Expected Behavior
- Window topbar controls should smoothly transition when entering/exiting full-screen
- Padding should adjust correctly based on window state and language direction
- No visual glitches or jumps during transitions
- Consistent behavior in both LTR and RTL

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
