### PR TITLE
Switch to yauzl for unzipping files without loading everything into memory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,13 +19,11 @@
 				"@rive-app/react-canvas": "^4.12.0",
 				"@sentry/electron": "^4.24.0",
 				"@sentry/webpack-plugin": "^2.16.1",
-				"@types/adm-zip": "^0.5.5",
 				"@wordpress/compose": "^6.27.0",
 				"@wordpress/i18n": "^4.50.0",
 				"@wordpress/icons": "^10.10.0",
 				"@wp-playground/blueprints": "^0.9.44",
 				"@wp-playground/wordpress": "^0.9.44",
-				"adm-zip": "^0.5.14",
 				"archiver": "^6.0.1",
 				"atomically": "^2.0.3",
 				"compressible": "2.0.18",
@@ -49,7 +47,8 @@
 				"unzipper": "0.10.11",
 				"url-loader": "^4.1.1",
 				"wpcom": "^5.4.2",
-				"yargs": "17.7.2"
+				"yargs": "17.7.2",
+				"yauzl": "^3.2.0"
 			},
 			"devDependencies": {
 				"@automattic/color-studio": "^2.5.0",
@@ -75,6 +74,7 @@
 				"@types/react-dom": "^18.2.17",
 				"@types/semver": "^7.5.8",
 				"@types/shell-quote": "^1.7.5",
+				"@types/yauzl": "^2.10.3",
 				"@typescript-eslint/eslint-plugin": "^8.21.0",
 				"@typescript-eslint/parser": "^8.21.0",
 				"@vercel/webpack-asset-relocator-loader": "1.7.3",
@@ -5505,14 +5505,6 @@
 			"integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
 			"dev": true
 		},
-		"node_modules/@types/adm-zip": {
-			"version": "0.5.5",
-			"resolved": "https://registry.npmjs.org/@types/adm-zip/-/adm-zip-0.5.5.tgz",
-			"integrity": "sha512-YCGstVMjc4LTY5uK9/obvxBya93axZOVOyf2GSUulADzmLhYE45u2nAssCs/fWBs1Ifq5Vat75JTPwd5XZoPJw==",
-			"dependencies": {
-				"@types/node": "*"
-			}
-		},
 		"node_modules/@types/appdmg": {
 			"version": "0.5.5",
 			"resolved": "https://registry.npmjs.org/@types/appdmg/-/appdmg-0.5.5.tgz",
@@ -6086,7 +6078,6 @@
 			"resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
 			"integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
 			"dev": true,
-			"optional": true,
 			"dependencies": {
 				"@types/node": "*"
 			}
@@ -7895,14 +7886,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.4.0"
-			}
-		},
-		"node_modules/adm-zip": {
-			"version": "0.5.14",
-			"resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.14.tgz",
-			"integrity": "sha512-DnyqqifT4Jrcvb8USYjp6FHtBpEIz1mnXu6pTRHZ0RL69LbQYiO+0lDFg5+OKA7U29oWSs3a/i8fhn8ZcceIWg==",
-			"engines": {
-				"node": ">=12.0"
 			}
 		},
 		"node_modules/agent-base": {
@@ -13363,6 +13346,16 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/extract-zip/node_modules/yauzl": {
+			"version": "2.10.0",
+			"resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+			"integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+			"dev": true,
+			"dependencies": {
+				"buffer-crc32": "~0.2.3",
+				"fd-slicer": "~1.1.0"
 			}
 		},
 		"node_modules/fast-deep-equal": {
@@ -20388,8 +20381,7 @@
 		"node_modules/pend": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-			"integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-			"dev": true
+			"integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="
 		},
 		"node_modules/picocolors": {
 			"version": "1.1.1",
@@ -25614,13 +25606,15 @@
 			}
 		},
 		"node_modules/yauzl": {
-			"version": "2.10.0",
-			"resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-			"integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
-			"dev": true,
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.2.0.tgz",
+			"integrity": "sha512-Ow9nuGZE+qp1u4JIPvg+uCiUr7xGQWdff7JQSk5VGYTAZMDe2q8lxJ10ygv10qmSj031Ty/6FNJpLO4o1Sgc+w==",
 			"dependencies": {
 				"buffer-crc32": "~0.2.3",
-				"fd-slicer": "~1.1.0"
+				"pend": "~1.2.0"
+			},
+			"engines": {
+				"node": ">=12"
 			}
 		},
 		"node_modules/yn": {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
 		"@types/react-dom": "^18.2.17",
 		"@types/semver": "^7.5.8",
 		"@types/shell-quote": "^1.7.5",
+		"@types/yauzl": "^2.10.3",
 		"@typescript-eslint/eslint-plugin": "^8.21.0",
 		"@typescript-eslint/parser": "^8.21.0",
 		"@vercel/webpack-asset-relocator-loader": "1.7.3",
@@ -110,13 +111,11 @@
 		"@rive-app/react-canvas": "^4.12.0",
 		"@sentry/electron": "^4.24.0",
 		"@sentry/webpack-plugin": "^2.16.1",
-		"@types/adm-zip": "^0.5.5",
 		"@wordpress/compose": "^6.27.0",
 		"@wordpress/i18n": "^4.50.0",
 		"@wordpress/icons": "^10.10.0",
 		"@wp-playground/blueprints": "^0.9.44",
 		"@wp-playground/wordpress": "^0.9.44",
-		"adm-zip": "^0.5.14",
 		"archiver": "^6.0.1",
 		"atomically": "^2.0.3",
 		"compressible": "2.0.18",
@@ -140,7 +139,8 @@
 		"unzipper": "0.10.11",
 		"url-loader": "^4.1.1",
 		"wpcom": "^5.4.2",
-		"yargs": "17.7.2"
+		"yargs": "17.7.2",
+		"yauzl": "^3.2.0"
 	},
 	"optionalDependencies": {
 		"appdmg": "^0.6.6"

--- a/src/lib/import-export/import/handlers/backup-handler-zip.ts
+++ b/src/lib/import-export/import/handlers/backup-handler-zip.ts
@@ -1,9 +1,9 @@
 import { EventEmitter } from 'events';
-import * as fs from 'fs';
-import * as path from 'path';
+import fs from 'fs';
+import path from 'path';
 import { promisify } from 'util';
-import * as fse from 'fs-extra';
-import * as yauzl from 'yauzl';
+import fse from 'fs-extra';
+import yauzl from 'yauzl';
 import { ImportEvents } from '../events';
 import { BackupArchiveInfo, BackupExtractProgressEventData } from '../types';
 import { BackupHandler, isFileAllowed } from './backup-handler-factory';

--- a/src/lib/import-export/import/handlers/backup-handler-zip.ts
+++ b/src/lib/import-export/import/handlers/backup-handler-zip.ts
@@ -1,41 +1,92 @@
 import { EventEmitter } from 'events';
-import AdmZip from 'adm-zip';
+import * as fs from 'fs';
+import * as path from 'path';
+import { promisify } from 'util';
+import * as fse from 'fs-extra';
+import * as yauzl from 'yauzl';
 import { ImportEvents } from '../events';
 import { BackupArchiveInfo, BackupExtractProgressEventData } from '../types';
 import { BackupHandler, isFileAllowed } from './backup-handler-factory';
 
+const openZip = promisify< string, yauzl.Options, yauzl.ZipFile >( yauzl.open );
+
 export class BackupHandlerZip extends EventEmitter implements BackupHandler {
 	async listFiles( backup: BackupArchiveInfo ): Promise< string[] > {
-		const zip = new AdmZip( backup.path );
-		return zip
-			.getEntries()
-			.map( ( entry ) => {
-				if ( entry.entryName.startsWith( '/' ) ) {
-					return entry.entryName.slice( 1 );
+		const zipFile = await openZip( backup.path, { lazyEntries: true } );
+		const fileNames: string[] = [];
+
+		return new Promise( ( resolve, reject ) => {
+			zipFile.on( 'entry', ( entry ) => {
+				if ( isFileAllowed( entry.fileName ) ) {
+					fileNames.push( entry.fileName );
 				}
-				return entry.entryName;
-			} )
-			.filter( isFileAllowed );
+				zipFile.readEntry();
+			} );
+
+			zipFile.on( 'end', () => {
+				resolve( fileNames );
+			} );
+
+			zipFile.on( 'error', reject );
+			zipFile.readEntry();
+		} );
 	}
 
 	async extractFiles( file: BackupArchiveInfo, extractionDirectory: string ): Promise< void > {
+		const zipFile = await openZip( file.path, { lazyEntries: true } );
+		const totalSize = fs.statSync( file.path ).size;
+		let processedSize = 0;
+
 		this.emit( ImportEvents.BACKUP_EXTRACT_START );
+
 		return new Promise( ( resolve, reject ) => {
-			this.emit( ImportEvents.BACKUP_EXTRACT_PROGRESS, {
-				progress: 0,
-			} as BackupExtractProgressEventData );
-			const zip = new AdmZip( file.path );
-			zip.extractAllToAsync( extractionDirectory, true, undefined, ( error?: Error ) => {
-				if ( error ) {
-					this.emit( ImportEvents.BACKUP_EXTRACT_ERROR, { error } );
-					reject( error );
+			zipFile.on( 'entry', async ( entry ) => {
+				if ( ! isFileAllowed( entry.fileName ) ) {
+					zipFile.readEntry();
+					return;
 				}
-				this.emit( ImportEvents.BACKUP_EXTRACT_PROGRESS, {
-					progress: 1,
-				} as BackupExtractProgressEventData );
+
+				const fullPath = path.join( extractionDirectory, entry.fileName );
+				await fse.ensureDir( path.dirname( fullPath ) );
+
+				if ( entry.fileName.endsWith( '/' ) ) {
+					zipFile.readEntry();
+					return;
+				}
+
+				zipFile.openReadStream( entry, ( err, readStream ) => {
+					if ( err ) {
+						reject( err );
+						return;
+					}
+
+					const writeStream = fs.createWriteStream( fullPath );
+					readStream.on( 'data', ( chunk ) => {
+						processedSize += chunk.length;
+						this.emit( ImportEvents.BACKUP_EXTRACT_PROGRESS, {
+							progress: processedSize / totalSize,
+						} as BackupExtractProgressEventData );
+					} );
+
+					writeStream.on( 'finish', () => {
+						zipFile.readEntry();
+					} );
+
+					readStream.pipe( writeStream );
+				} );
+			} );
+
+			zipFile.on( 'end', () => {
 				this.emit( ImportEvents.BACKUP_EXTRACT_COMPLETE );
 				resolve();
 			} );
+
+			zipFile.on( 'error', ( error ) => {
+				this.emit( ImportEvents.BACKUP_EXTRACT_ERROR, { error } );
+				reject( error );
+			} );
+
+			zipFile.readEntry();
 		} );
 	}
 }

--- a/src/lib/import-export/import/handlers/backup-handler-zip.ts
+++ b/src/lib/import-export/import/handlers/backup-handler-zip.ts
@@ -55,26 +55,21 @@ export class BackupHandlerZip extends EventEmitter implements BackupHandler {
 					return;
 				}
 
-				zipFile.openReadStream( entry, ( err, readStream ) => {
-					if ( err ) {
-						reject( err );
-						return;
-					}
+				const readStream = await openReadStream( entry );
+				const writeStream = fs.createWriteStream( fullPath );
 
-					const writeStream = fs.createWriteStream( fullPath );
-					readStream.on( 'data', ( chunk ) => {
-						processedSize += chunk.length;
-						this.emit( ImportEvents.BACKUP_EXTRACT_PROGRESS, {
-							progress: processedSize / totalSize,
-						} as BackupExtractProgressEventData );
-					} );
-
-					writeStream.on( 'finish', () => {
-						zipFile.readEntry();
-					} );
-
-					readStream.pipe( writeStream );
+				readStream.on( 'data', ( chunk ) => {
+					processedSize += chunk.length;
+					this.emit( ImportEvents.BACKUP_EXTRACT_PROGRESS, {
+						progress: processedSize / totalSize,
+					} as BackupExtractProgressEventData );
 				} );
+
+				writeStream.on( 'finish', () => {
+					zipFile.readEntry();
+				} );
+
+				readStream.pipe( writeStream );
 			} );
 
 			zipFile.on( 'end', () => {

--- a/src/lib/import-export/import/handlers/backup-handler-zip.ts
+++ b/src/lib/import-export/import/handlers/backup-handler-zip.ts
@@ -34,6 +34,7 @@ export class BackupHandlerZip extends EventEmitter implements BackupHandler {
 
 	async extractFiles( file: BackupArchiveInfo, extractionDirectory: string ): Promise< void > {
 		const zipFile = await openZip( file.path, { lazyEntries: true } );
+		const openReadStream = promisify( zipFile.openReadStream.bind( zipFile ) );
 		const totalSize = fs.statSync( file.path ).size;
 		let processedSize = 0;
 


### PR DESCRIPTION
## Related issues

- Fixes #800

## Proposed Changes

- Remove `adm-zip` lib in favor of `yauzl` which is more mature & adheres to spec tightly
- Read zip file without loading it all into memory 

## Testing Instructions

- Import a 2GB+ back up file. I tested with a 8.93GB file.

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?
