### PR TITLE
Fix absolute imports in main process

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -46,17 +46,6 @@
 				},
 				"groups": [ "builtin", "external", "internal", "parent", "sibling", "index", "type" ]
 			}
-		],
-		"no-restricted-imports": [
-			"warn",
-			{
-				"patterns": [
-					{
-						"group": ["../*", "./*"],
-						"message": "Please use absolute imports instead of relative imports. Example: 'src/components/foo' instead of '../components/foo'"
-					}
-				]
-			}
 		]
 	},
 	"overrides": [

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -46,6 +46,17 @@
 				},
 				"groups": [ "builtin", "external", "internal", "parent", "sibling", "index", "type" ]
 			}
+		],
+		"no-restricted-imports": [
+			"warn",
+			{
+				"patterns": [
+					{
+						"group": ["../*", "./*"],
+						"message": "Please use absolute imports instead of relative imports. Example: 'src/components/foo' instead of '../components/foo'"
+					}
+				]
+			}
 		]
 	},
 	"overrides": [

--- a/webpack.main.config.ts
+++ b/webpack.main.config.ts
@@ -99,5 +99,9 @@ export const mainBaseConfig: Configuration = {
 	],
 	resolve: {
 		extensions: [ '.js', '.ts', '.jsx', '.tsx', '.css', '.json' ],
+		alias: {
+			src: path.resolve( __dirname, 'src/' ),
+			vendor: path.resolve( __dirname, 'vendor/' ),
+		},
 	},
 };


### PR DESCRIPTION
## Related issues

Following up on the work done in #825 (which introduced absolute imports), I discovered that absolute imports weren't working in the main process, despite TypeScript and ESLint not flagging any errors. This was because the webpack configuration for the main process was missing the necessary alias configuration.

## Proposed Changes

- Configured path resolution for `src` and `vendor` directories in webpack.main.config.ts

## Testing Instructions

1. Build and run the application in development mode:
   ```bash
   npm run start
   ```

2. Verify that absolute imports work in main process files:
   - Check that imports like `import { ... } from 'src/...'` work
   - Check that imports like `import { ... } from 'vendor/...'` work
   - For example, verify the import in `ipc-handlers.ts` works: `import { DEFAULT_PHP_VERSION } from 'vendor/wp-now/src/constants'`

3. Build the application for production:
   ```bash
   npm run make
   ```
   - Verify that the built application runs without any module resolution errors
   - Test the functionality that uses the absolute imports to ensure they work in production


## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
