### PR TITLE
Studio: Add connected site ID to the `create-new-site-from-zip` request

### DIFF
--- a/src/hooks/tests/use-archive-site.test.ts
+++ b/src/hooks/tests/use-archive-site.test.ts
@@ -1,0 +1,92 @@
+import { renderHook, act } from '@testing-library/react';
+import { getIpcApi } from '../../lib/get-ipc-api';
+import { useSyncSites } from '../sync-sites';
+import { useArchiveSite } from '../use-archive-site';
+import { useAuth } from '../use-auth';
+import { useSiteDetails } from '../use-site-details';
+
+jest.mock( '../use-auth' );
+jest.mock( '../sync-sites' );
+jest.mock( '../use-site-details' );
+jest.mock( '../../lib/get-ipc-api' );
+
+describe( 'useArchiveSite', () => {
+	const LOCAL_SITE_ID = '1658e275-3e68-4aff-a016-2dbf9c5de3db';
+	const mockPost = jest.fn();
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+
+		mockPost.mockImplementation( () => Promise.resolve( {} ) );
+
+		( useAuth as jest.Mock ).mockImplementation( () => ( {
+			client: { req: { post: mockPost } },
+		} ) );
+
+		( useSiteDetails as jest.Mock ).mockImplementation( () => ( {
+			uploadingSites: {},
+			setUploadingSites: jest.fn(),
+		} ) );
+
+		( getIpcApi as jest.Mock ).mockImplementation( () => ( {
+			archiveSite: () =>
+				Promise.resolve( {
+					archivePath: '/tmp/test.zip',
+					archiveSizeInBytes: 1000,
+				} ),
+			getFileContent: () => Promise.resolve( new Uint8Array() ),
+			removeTemporalFile: () => Promise.resolve(),
+			showErrorMessageBox: () => {},
+			getWpVersion: () => Promise.resolve( '6.7.1' ),
+		} ) );
+	} );
+
+	it( 'should include connected_site_id in form data when a production WPCOM site exists', async () => {
+		( useSyncSites as jest.Mock ).mockImplementation( () => ( {
+			connectedSites: [
+				{
+					id: 240383639,
+					localSiteId: LOCAL_SITE_ID,
+					name: 'Test Production Site',
+					url: 'https://test-site1987.wpcomstaging.com',
+					isStaging: false,
+					stagingSiteIds: [ 240567528 ],
+					syncSupport: 'already-connected',
+					lastPullTimestamp: null,
+					lastPushTimestamp: null,
+				},
+				{
+					id: 240567528,
+					localSiteId: LOCAL_SITE_ID,
+					name: 'Test Staging Site',
+					url: 'https://staging-9582-test-site1987.wpcomstaging.com',
+					isStaging: true,
+					stagingSiteIds: [],
+					syncSupport: 'already-connected',
+					lastPullTimestamp: null,
+					lastPushTimestamp: null,
+				},
+			],
+		} ) );
+
+		const { result } = renderHook( () => useArchiveSite() );
+		await act( () => result.current.archiveSite( LOCAL_SITE_ID ) );
+
+		const formData = mockPost.mock.calls[ 0 ][ 0 ].formData;
+		expect( formData ).toContainEqual( [ 'connected_site_id', 240383639 ] );
+	} );
+
+	it( 'should not include connected_site_id in form data when no WPCOM sites are connected', async () => {
+		( useSyncSites as jest.Mock ).mockImplementation( () => ( {
+			connectedSites: [],
+		} ) );
+
+		const { result } = renderHook( () => useArchiveSite() );
+		await act( () => result.current.archiveSite( LOCAL_SITE_ID ) );
+
+		const formData = mockPost.mock.calls[ 0 ][ 0 ].formData;
+		expect(
+			formData.find( ( [ key ]: [ string, number ] ) => key === 'connected_site_id' )
+		).toBeUndefined();
+	} );
+} );

--- a/src/hooks/tests/use-archive-site.test.ts
+++ b/src/hooks/tests/use-archive-site.test.ts
@@ -41,7 +41,7 @@ describe( 'useArchiveSite', () => {
 		} ) );
 	} );
 
-	it( 'should include connected_site_id in form data when a production WPCOM site exists', async () => {
+	it( 'should include connected_site_id in form data when a production WPCOM site is connected', async () => {
 		( useSyncSites as jest.Mock ).mockImplementation( () => ( {
 			connectedSites: [
 				{
@@ -76,7 +76,7 @@ describe( 'useArchiveSite', () => {
 		expect( formData ).toContainEqual( [ 'connected_site_id', 240383639 ] );
 	} );
 
-	it( 'should not include connected_site_id in form data when no WPCOM sites are connected', async () => {
+	it( 'should not include connected_site_id in form data when no WPCOM site is connected', async () => {
 		( useSyncSites as jest.Mock ).mockImplementation( () => ( {
 			connectedSites: [],
 		} ) );

--- a/src/hooks/use-archive-site.ts
+++ b/src/hooks/use-archive-site.ts
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useMemo } from 'react';
 import { DEMO_SITE_SIZE_LIMIT_BYTES, DEMO_SITE_SIZE_LIMIT_GB } from '../constants';
 import { getIpcApi } from '../lib/get-ipc-api';
 import { isWpcomNetworkError } from '../lib/is-wpcom-network-error';
+import { useSyncSites } from './sync-sites';
 import { useArchiveErrorMessages } from './use-archive-error-messages';
 import { useAuth } from './use-auth';
 import { useSiteDetails } from './use-site-details';
@@ -19,6 +20,7 @@ export function useArchiveSite() {
 	);
 	const { client } = useAuth();
 	const { __ } = useI18n();
+	const { connectedSites } = useSyncSites();
 
 	useEffect( () => {
 		if ( ! client ) {
@@ -115,6 +117,11 @@ export function useArchiveSite() {
 					formData.push( [ 'wordpress_version', wordpressVersion ] );
 				}
 
+				const connectedProductionSite = connectedSites.find( ( site ) => ! site.isStaging );
+				if ( connectedProductionSite ) {
+					formData.push( [ 'connected_site_id', String( connectedProductionSite.id ) ] );
+				}
+
 				try {
 					const response: {
 						atomic_site_id: number;
@@ -165,7 +172,15 @@ export function useArchiveSite() {
 				}
 			}
 		},
-		[ __, addSnapshot, client, errorMessages, fetchSnapshotUsage, setUploadingSites ]
+		[
+			__,
+			addSnapshot,
+			client,
+			errorMessages,
+			fetchSnapshotUsage,
+			setUploadingSites,
+			connectedSites,
+		]
 	);
 	const isAnySiteArchiving = useMemo( () => {
 		const isAnySiteUploading = Object.values( uploadingSites ).some( ( uploading ) => uploading );

--- a/src/hooks/use-archive-site.ts
+++ b/src/hooks/use-archive-site.ts
@@ -111,7 +111,7 @@ export function useArchiveSite() {
 					}
 				);
 
-				const formData = [ [ 'import', file ] ];
+				const formData: Array< [ string, string | number | File ] > = [ [ 'import', file ] ];
 				const wordpressVersion = await getIpcApi().getWpVersion( siteId );
 				if ( wordpressVersion.length >= 3 ) {
 					formData.push( [ 'wordpress_version', wordpressVersion ] );
@@ -119,7 +119,7 @@ export function useArchiveSite() {
 
 				const connectedProductionSite = connectedSites.find( ( site ) => ! site.isStaging );
 				if ( connectedProductionSite ) {
-					formData.push( [ 'connected_site_id', String( connectedProductionSite.id ) ] );
+					formData.push( [ 'connected_site_id', connectedProductionSite.id ] );
 				}
 
 				try {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Related to https://github.com/Automattic/dotcom-forge/issues/10243#issuecomment-2609523395.

## Proposed Changes

- if there's a WordPress.com production site connected to local Studio site, add its ID to the `create-new-site-from-zip request`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Please follow the testing instructions in 170864-ghe-Automattic/wpcom.
2. Newly introduced test should pass (`npm test src/hooks/tests/use-archive-site.test.ts`).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?