### PR TITLE
Studio: Set tooltip to be wider 

### DIFF
--- a/src/components/tooltip.tsx
+++ b/src/components/tooltip.tsx
@@ -56,9 +56,9 @@ const Tooltip = ( {
 					animate={ false }
 					placement={ placement }
 				>
-					<div className="flex flex-row justify-center items-center max-w-60 gap-2 rounded py-2 px-2.5 bg-[#101517] text-white animate-[fade_0.5s_ease-in-out_1]">
-						{ icon && <Icon className="fill-white shrink-0 m-[2px] " size={ 16 } icon={ icon } /> }
-						<p className="text-left text-xs break-words overflow-hidden">{ text }</p>
+					<div className="inline-flex items-center gap-2 max-w-80 rounded py-2 px-2.5 bg-[#101517] text-white animate-[fade_0.5s_ease-in-out_1]">
+						{ icon && <Icon className="fill-white shrink-0" size={ 16 } icon={ icon } /> }
+						<span className="text-left text-xs">{ text }</span>
 					</div>
 				</Popover>
 			) }

--- a/src/components/tooltip.tsx
+++ b/src/components/tooltip.tsx
@@ -58,7 +58,7 @@ const Tooltip = ( {
 				>
 					<div className="inline-flex items-center gap-2 max-w-80 rounded py-2 px-2.5 bg-[#101517] text-white animate-[fade_0.5s_ease-in-out_1]">
 						{ icon && <Icon className="fill-white shrink-0  m-[2px]" size={ 16 } icon={ icon } /> }
-						<span className="text-left text-x break-words overflow-hidden">{ text }</span>
+						<span className="text-left text-xs break-words overflow-hidden">{ text }</span>
 					</div>
 				</Popover>
 			) }

--- a/src/components/tooltip.tsx
+++ b/src/components/tooltip.tsx
@@ -57,8 +57,8 @@ const Tooltip = ( {
 					placement={ placement }
 				>
 					<div className="inline-flex items-center gap-2 max-w-80 rounded py-2 px-2.5 bg-[#101517] text-white animate-[fade_0.5s_ease-in-out_1]">
-						{ icon && <Icon className="fill-white shrink-0" size={ 16 } icon={ icon } /> }
-						<span className="text-left text-xs">{ text }</span>
+						{ icon && <Icon className="fill-white shrink-0  m-[2px]" size={ 16 } icon={ icon } /> }
+						<span className="text-left text-x break-words overflow-hidden">{ text }</span>
 					</div>
 				</Popover>
 			) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

Closes: https://github.com/Automattic/dotcom-forge/issues/10317

## Proposed Changes

This PR increases the `max-width` on the tooltip to 320px so that the tooltips with longer text spans over less lines:

<img width="628" alt="Screenshot 2025-01-24 at 2 26 24 PM" src="https://github.com/user-attachments/assets/b6ad5528-241a-4bda-be36-7e5f436d8336" />

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
* Create a new site in Studio
* Open the uploads directory in the Terminal with `cd /path/to/wp-content/uploads`
* Create `dummy.zip` there
* Run `dd if=/dev/urandom bs=1M count=2560 | zip -0 dummy.zip` - to increase the size of the site 
* Navigate to the `Share` tab for that site in Studio
* Hover over `Add demo site` button
* Confirm that you see the tooltip that you see there spans about three or four lines
* Double-check that other tooltips e.g. offline mode tooltip look good

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
