### PR TITLE
Mount mu-plugin polyfills to the Playground filesystem

### DIFF
--- a/vendor/wp-now/src/config.ts
+++ b/vendor/wp-now/src/config.ts
@@ -19,6 +19,7 @@ export interface CliOptions {
 	reset?: boolean;
 	adminPassword?: string;
 	siteTitle?: string;
+	mode?: WPNowMode;
 }
 
 export const enum WPNowMode {
@@ -30,6 +31,7 @@ export const enum WPNowMode {
 	WP_CONTENT = 'wp-content',
 	PLAYGROUND = 'playground',
 	AUTO = 'auto',
+	CLI = 'cli',
 }
 
 export interface WPNowOptions {
@@ -111,6 +113,7 @@ export default async function getWpNowConfig( args: CliOptions ): Promise< WPNow
 		wordPressVersion: args.wp as string,
 		port,
 		reset: args.reset as boolean,
+		mode: args.mode as WPNowMode,
 	};
 
 	const options: WPNowOptions = {} as WPNowOptions;

--- a/vendor/wp-now/src/constants.ts
+++ b/vendor/wp-now/src/constants.ts
@@ -1,4 +1,19 @@
 /**
+ * Playground internal shared folder.
+ */
+export const PLAYGROUND_INTERNAL_SHARED_FOLDER = '/internal/shared';
+
+/**
+ * Playground internal mu-plugins folder.
+ */
+export const PLAYGROUND_INTERNAL_MU_PLUGINS_FOLDER = '/internal/shared/mu-plugins';
+
+/**
+ * Playground internal preload path.
+ */
+export const PLAYGROUND_INTERNAL_PRELOAD_PATH = '/internal/shared/preload';
+
+/**
  * The file name for the SQLite plugin name.
  */
 export const SQLITE_FILENAME = 'sqlite-database-integration';
@@ -7,6 +22,11 @@ export const SQLITE_FILENAME = 'sqlite-database-integration';
  * The URL for downloading the "SQLite database integration" WordPress Plugin.
  */
 export const SQLITE_URL = 'https://downloads.wordpress.org/plugin/sqlite-database-integration.zip';
+
+/**
+ * The folder for the SQLite plugin.
+ */
+export const SQLITE_PLUGIN_FOLDER = '/internal/shared/mu-plugins/sqlite-database-integration';
 
 /**
  * The default starting port for running the WP Now server.

--- a/vendor/wp-now/src/download.ts
+++ b/vendor/wp-now/src/download.ts
@@ -1,15 +1,14 @@
-import followRedirects, { FollowResponse } from 'follow-redirects';
-import fs from 'fs-extra';
-import { HttpProxyAgent, HttpsProxyAgent } from 'hpagent';
 import { IncomingMessage } from 'http';
 import os from 'os';
 import path from 'path';
+import followRedirects, { FollowResponse } from 'follow-redirects';
+import fs from 'fs-extra';
+import { HttpProxyAgent, HttpsProxyAgent } from 'hpagent';
 import unzipper from 'unzipper';
 import { DEFAULT_WORDPRESS_VERSION, SQLITE_FILENAME, SQLITE_URL, WP_CLI_URL } from './constants';
 import getSqlitePath from './get-sqlite-path';
 import getWordpressVersionsPath from './get-wordpress-versions-path';
 import getWpCliPath from './get-wp-cli-path';
-import getWpNowPath from './get-wp-now-path';
 import { output } from './output';
 import { isValidWordPressVersion } from './wp-playground-wordpress';
 
@@ -231,151 +230,29 @@ export async function downloadSQLiteCommand( downloadUrl: string, targetPath: st
 		overwrite: true,
 	} );
 }
-
-export async function downloadMuPlugins( customMuPluginsPath = '' ) {
-	const muPluginsPath = customMuPluginsPath || path.join( getWpNowPath(), 'mu-plugins' );
-	fs.ensureDirSync( muPluginsPath );
-
-	fs.removeSync( path.join( muPluginsPath, '0-allow-wp-org.php' ) );
-
-	fs.writeFile(
-		path.join( muPluginsPath, '0-allowed-redirect-hosts.php' ),
-		`<?php
-	// Needed because gethostbyname( <host> ) returns
-	// a private network IP address for some reason.
-	add_filter( 'allowed_redirect_hosts', function( $hosts ) {
-		$redirect_hosts = array(
-			'wordpress.org',
-			'api.wordpress.org',
-			'downloads.wordpress.org',
-			'themes.svn.wordpress.org',
-			'fonts.gstatic.com',
-		);
-		return array_merge( $hosts, $redirect_hosts );
-	} );
-	add_filter('http_request_host_is_external', '__return_true', 20, 3 );
-	`
-	);
-
-	fs.writeFile(
-		path.join( muPluginsPath, '0-dns-functions.php' ),
-		`<?php
-		// Polyfill for DNS functions/features which are not currently supported by @php-wasm/node.
-		// See https://github.com/WordPress/wordpress-playground/issues/1042
-		// These specific features are polyfilled so the Jetpack plugin loads correctly, but others should be added as needed.
-		if ( ! function_exists( 'dns_get_record' ) ) {
-			function dns_get_record() {
-				return array();
-			}
-		}
-		if ( ! defined( 'DNS_NS' ) ) {
-			define( 'DNS_NS', 2 );
-		}`
-	);
-
-	fs.writeFile(
-		path.join( muPluginsPath, '0-thumbnails.php' ),
-		`<?php
-		// Facilitates the taking of screenshots to be used as thumbnails.
-		if ( isset( $_GET['studio-hide-adminbar'] ) ) {
-			add_filter( 'show_admin_bar', '__return_false' );
-		}
-		`
-	);
-
-	fs.writeFile(
-		path.join( muPluginsPath, '0-sqlite.php' ),
-		`<?php
-		if ( file_exists( WP_CONTENT_DIR . "/db.php" ) && file_exists( __DIR__ . "/${ SQLITE_FILENAME }/load.php" ) ) {
-			require_once __DIR__ . "/${ SQLITE_FILENAME }/load.php";
-		}`
-	);
-
-	fs.writeFile(
-		path.join( muPluginsPath, '0-32bit-integer-warnings.php' ),
-		`<?php
-/**
- * This is a temporary workaround to hide the 32bit integer warnings that
- * appear when using various time related function, such as strtotime and mktime.
- * Examples of the warnings that are displayed:
- * Warning: mktime(): Epoch doesn't fit in a PHP integer in <file>
- * Warning: strtotime(): Epoch doesn't fit in a PHP integer in <file>
- */
-set_error_handler(function($severity, $message, $file, $line) {
-  if (strpos($message, "fit in a PHP integer") !== false) {
-      return;
-  }
-  return false;
-});
-`
-	);
-
-	fs.writeFile(
-		path.join( muPluginsPath, '0-check-theme-availability.php' ),
-		`<?php
-	function check_current_theme_availability() {
-			// Get the current theme's directory
-			$current_theme = wp_get_theme();
-			$theme_dir = get_theme_root() . '/' . $current_theme->stylesheet;
-
-			if (!is_dir($theme_dir)) {
-					$all_themes = wp_get_themes();
-					$available_themes = [];
-
-					foreach ($all_themes as $theme_slug => $theme_obj) {
-							if ($theme_slug != $current_theme->get_stylesheet()) {
-									$available_themes[$theme_slug] = $theme_obj;
-							}
-					}
-
-					if (!empty($available_themes)) {
-							$new_theme_slug = array_keys($available_themes)[0];
-							switch_theme($new_theme_slug);
-					}
-			}
-	}
-	add_action('after_setup_theme', 'check_current_theme_availability');
-`
-	);
-
-	fs.writeFile(
-		path.join( muPluginsPath, '0-permalinks.php' ),
-		`<?php
-			// Support permalinks without "index.php"
-			add_filter( 'got_url_rewrite', '__return_true' );
-	`
-	);
-
-	fs.writeFile(
-		path.join( muPluginsPath, '0-deactivate-jetpack-modules.php' ),
-		`<?php
-			// Disable Jetpack Protect 2FA for local auto-login purpose
-			add_action( 'jetpack_active_modules', 'jetpack_deactivate_modules' );
-			function jetpack_deactivate_modules( $active ) {
-				if ( ( $index = array_search('protect', $active, true) ) !== false ) {
-					unset( $active[ $index ] );
-				}
-				return $active;
-			}
-	`
-	);
-
-	fs.writeFile(
-		path.join( muPluginsPath, '0-wp-config-constants-polyfill.php' ),
-		`<?php
-		// Define database constants if not already defined. It fixes the error
-		// for imported sites that don't have those defined e.g. WP Cloud and
-		// include plugins which try to access those directly e.g. Mailpoet
-		if (!defined('DB_NAME')) define('DB_NAME', 'database_name_here');
-		if (!defined('DB_USER')) define('DB_USER', 'username_here');
-		if (!defined('DB_PASSWORD')) define('DB_PASSWORD', 'password_here');
-		if (!defined('DB_HOST')) define('DB_HOST', 'localhost');
-		if (!defined('DB_CHARSET')) define('DB_CHARSET', 'utf8');
-		if (!defined('DB_COLLATE')) define('DB_COLLATE', '');
-		`
-	);
-}
-
 export function getWordPressVersionPath( wpVersion: string ) {
 	return path.join( getWordpressVersionsPath(), wpVersion );
+}
+
+/**
+ * This function removes the internal mu-plugins that WP-now used to store.
+ *
+ * WP-now used to store some internal mu-plugins in the site's mu-plugins directory.
+ * This prevented users from using the mu-plugins directory for their own plugins,
+ * so we now mount the mu-plugins directory to the shared mu-plugins directory.
+ *
+ * @param projectPath The path to the project directory.
+ */
+export async function removeDownloadedMuPlugins( projectPath: string ) {
+	const wpContentPath = path.join( projectPath, 'wp-content' );
+	const muPluginsPath = path.join( wpContentPath, 'mu-plugins' );
+	fs.removeSync( path.join( muPluginsPath, '0-32bit-integer-warnings.php' ) );
+	fs.removeSync( path.join( muPluginsPath, '0-allowed-redirect-hosts.php' ) );
+	fs.removeSync( path.join( muPluginsPath, '0-check-theme-availability.php' ) );
+	fs.removeSync( path.join( muPluginsPath, '0-deactivate-jetpack-modules.php' ) );
+	fs.removeSync( path.join( muPluginsPath, '0-dns-functions.php' ) );
+	fs.removeSync( path.join( muPluginsPath, '0-permalinks.php' ) );
+	fs.removeSync( path.join( muPluginsPath, '0-wp-config-constants-polyfill.php' ) );
+	fs.removeSync( path.join( muPluginsPath, '0-sqlite.php' ) );
+	fs.removeSync( path.join( muPluginsPath, '0-thumbnails.php' ) );
 }

--- a/vendor/wp-now/src/download.ts
+++ b/vendor/wp-now/src/download.ts
@@ -239,7 +239,7 @@ export function getWordPressVersionPath( wpVersion: string ) {
  *
  * WP-now used to store some internal mu-plugins in the site's mu-plugins directory.
  * This prevented users from using the mu-plugins directory for their own plugins,
- * so we now mount the mu-plugins directory to the shared mu-plugins directory.
+ * so Studio now mounts the mu-plugins directory to the shared mu-plugins directory.
  *
  * @param projectPath The path to the project directory.
  */


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Related https://github.com/Automattic/dotcom-forge/issues/9235

To complete #9235 we also need to mount the SQLite plugin to the Playground FS instead of adding it to the site folder. 

## Proposed Changes

- Mount mu-plugin polyfills to the Playground FS instead of adding them to the site's mu-plugins folder.
- Remove mu-plugin polyfills from the site folder when the server starts.
- Add a CLI mode to `prepareWordPress`, so all Playground modes can be configured from one place to avoid code duplication.
- Add constants for internal imports.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Start the production version of Studio
- Create a new site
- Confirm that the site has polyfills inside the mu-plugins folder (e.g. 0-32bit-integer-warnings.php)
- Close Studio
- Checkout this branch
- Open the dev version of Studio
- Start the site you previously created
- Confirm that the site works
- Confirm that the site doesn't have polyfills inside the mu-plugins folder (e.g. 0-32bit-integer-warnings.php)
- Create a new site 
- Confirm that it works

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
