### PR TITLE
More safety checks around IPC communication

### DIFF
--- a/src/__mocks__/electron.ts
+++ b/src/__mocks__/electron.ts
@@ -32,10 +32,12 @@ BrowserWindow.prototype.on = jest.fn();
 BrowserWindow.prototype.webContents = {
 	on: jest.fn(),
 	send: jest.fn(),
+	isDestroyed: jest.fn( () => false ),
 };
 BrowserWindow.fromWebContents = jest.fn( () => ( {
 	isDestroyed: jest.fn( () => false ),
 	webContents: {
+		isDestroyed: jest.fn( () => false ),
 		send: jest.fn(),
 	},
 } ) );

--- a/src/index.ts
+++ b/src/index.ts
@@ -187,7 +187,7 @@ async function appBoot() {
 			} );
 		} else {
 			// Handle custom protocol links on Windows and Linux
-			app.on( 'second-instance', async ( _event, argv ): Promise< void > => {
+			app.on( 'second-instance', async ( _event, argv ) => {
 				if ( ! finishedInitialization ) {
 					return;
 				}
@@ -315,7 +315,7 @@ async function appBoot() {
 		const clickedButtonIndex = dialog.showMessageBoxSync( {
 			message: __( 'Sync in progress' ),
 			detail: __(
-				"There's a sync operation in progress. Quitting the app will abort that operation. Are you sure you want to quit?"
+				'There’s a sync operation in progress. Quitting the app will abort that operation. Are you sure you want to quit?'
 			),
 			buttons: [ __( 'Yes, quit the app' ), __( 'No, take me back' ) ],
 			cancelId: CANCEL_BUTTON_INDEX,

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,7 @@ import {
 import { getUserLocaleWithFallback } from './lib/locale-node';
 import { handleAuthCallback, setUpAuthCallbackHandler } from './lib/oauth';
 import { setupLogging } from './logging';
-import { createMainWindow, withMainWindow } from './main-window';
+import { createMainWindow, getMainWindow } from './main-window';
 import {
 	migrateFromWpNowFolder,
 	needsToMigrateFromWpNowFolder,
@@ -69,7 +69,7 @@ if ( gotTheLock && ! isInInstaller ) {
 	}
 }
 
-const onOpenUrlCallback = ( url: string ) => {
+const onOpenUrlCallback = async ( url: string ) => {
 	const urlObject = new URL( url );
 	const { host, hash, searchParams } = urlObject;
 	if ( host === 'auth' ) {
@@ -86,9 +86,8 @@ const onOpenUrlCallback = ( url: string ) => {
 		const remoteSiteId = parseInt( searchParams.get( 'remoteSiteId' ) ?? '' );
 		const studioSiteId = searchParams.get( 'studioSiteId' );
 		if ( remoteSiteId && studioSiteId ) {
-			withMainWindow( ( mainWindow ) => {
-				mainWindow.webContents.send( 'sync-connect-site', { remoteSiteId, studioSiteId } );
-			} );
+			const mainWindow = await getMainWindow();
+			mainWindow.webContents.send( 'sync-connect-site', { remoteSiteId, studioSiteId } );
 		}
 	}
 };
@@ -188,26 +187,23 @@ async function appBoot() {
 			} );
 		} else {
 			// Handle custom protocol links on Windows and Linux
-			app.on( 'second-instance', ( _event, argv ): void => {
+			app.on( 'second-instance', async ( _event, argv ): Promise< void > => {
 				if ( ! finishedInitialization ) {
 					return;
 				}
 
-				withMainWindow( ( mainWindow ) => {
-					// CLI commands are likely invoked from other apps, so we need to avoid changing app focus.
-					const isCLI = argv?.find( ( arg ) => arg.startsWith( '--cli=' ) );
-					if ( ! isCLI ) {
-						if ( mainWindow.isMinimized() ) mainWindow.restore();
-						mainWindow.focus();
-					}
+				const mainWindow = await getMainWindow();
+				// CLI commands are likely invoked from other apps, so we need to avoid changing app focus.
+				const isCLI = argv?.find( ( arg ) => arg.startsWith( '--cli=' ) );
+				if ( ! isCLI ) {
+					if ( mainWindow.isMinimized() ) mainWindow.restore();
+					mainWindow.focus();
+				}
 
-					const customProtocolParameter = argv?.find( ( arg ) =>
-						arg.startsWith( PROTOCOL_PREFIX )
-					);
-					if ( customProtocolParameter ) {
-						onOpenUrlCallback( customProtocolParameter );
-					}
-				} );
+				const customProtocolParameter = argv?.find( ( arg ) => arg.startsWith( PROTOCOL_PREFIX ) );
+				if ( customProtocolParameter ) {
+					await onOpenUrlCallback( customProtocolParameter );
+				}
 			} );
 		}
 	}
@@ -319,7 +315,7 @@ async function appBoot() {
 		const clickedButtonIndex = dialog.showMessageBoxSync( {
 			message: __( 'Sync in progress' ),
 			detail: __(
-				'There’s a sync operation in progress. Quitting the app will abort that operation. Are you sure you want to quit?'
+				"There's a sync operation in progress. Quitting the app will abort that operation. Are you sure you want to quit?"
 			),
 			buttons: [ __( 'Yes, quit the app' ), __( 'No, take me back' ) ],
 			cancelId: CANCEL_BUTTON_INDEX,

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -41,7 +41,7 @@ import { sortSites } from './lib/sort-sites';
 import { installSqliteIntegration, keepSqliteIntegrationUpdated } from './lib/sqlite-versions';
 import * as windowsHelpers from './lib/windows-helpers';
 import { getLogsFilePath, writeLogToFile, type LogLevel } from './logging';
-import { withMainWindow } from './main-window';
+import { getMainWindow } from './main-window';
 import { popupMenu, setupMenu } from './menu';
 import { SiteServer, createSiteWorkingDirectory } from './site-server';
 import { DEFAULT_SITE_PATH, getResourcesPath, getSiteThumbnailPath } from './storage/paths';
@@ -968,12 +968,15 @@ export async function showNotification(
 	new Notification( options ).show();
 }
 
-export function setupAppMenu( _event: IpcMainInvokeEvent, config: { needsOnboarding: boolean } ) {
-	setupMenu( config );
+export async function setupAppMenu(
+	_event: IpcMainInvokeEvent,
+	config: { needsOnboarding: boolean }
+) {
+	await setupMenu( config );
 }
 
-export function popupAppMenu( _event: IpcMainInvokeEvent ) {
-	popupMenu();
+export async function popupAppMenu( _event: IpcMainInvokeEvent ) {
+	await popupMenu();
 }
 
 export async function promptWindowsSpeedUpSites(
@@ -1106,9 +1109,6 @@ export async function getFileContent( event: IpcMainInvokeEvent, filePath: strin
 }
 
 export async function isFullscreen( _event: IpcMainInvokeEvent ): Promise< boolean > {
-	let isFullscreen = false;
-	withMainWindow( ( window ) => {
-		isFullscreen = window.isFullScreen();
-	} );
-	return isFullscreen;
+	const window = await getMainWindow();
+	return window.isFullScreen();
 }

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -520,6 +520,9 @@ export async function showUserSettings( event: IpcMainInvokeEvent ): Promise< vo
 	if ( ! parentWindow ) {
 		throw new Error( `No window found for sender of showUserSettings message: ${ event.frameId }` );
 	}
+	if ( parentWindow.isDestroyed() || event.sender.isDestroyed() ) {
+		return;
+	}
 	parentWindow.webContents.send( 'user-settings' );
 }
 

--- a/src/lib/oauth.ts
+++ b/src/lib/oauth.ts
@@ -2,7 +2,7 @@ import { ipcMain, shell } from 'electron';
 import * as Sentry from '@sentry/electron/main';
 import wpcom from 'wpcom';
 import { PROTOCOL_PREFIX, WP_AUTHORIZE_ENDPOINT, CLIENT_ID, SCOPES } from '../constants';
-import { withMainWindow } from '../main-window';
+import { getMainWindow } from '../main-window';
 import { loadUserData, saveUserData } from '../storage/user-data';
 
 export interface StoredToken {
@@ -102,15 +102,13 @@ export function authenticate(): void {
 }
 
 export function setUpAuthCallbackHandler() {
-	ipcMain.on( 'auth-callback', ( _event, { token, error } ) => {
-		withMainWindow( ( mainWindow ) => {
-			if ( error ) {
-				mainWindow.webContents.send( 'auth-updated', { error: error } );
-			} else {
-				storeToken( token ).then( () => {
-					mainWindow.webContents.send( 'auth-updated', { token } );
-				} );
-			}
-		} );
+	ipcMain.on( 'auth-callback', async ( _event, { token, error } ) => {
+		const mainWindow = await getMainWindow();
+		if ( error ) {
+			mainWindow.webContents.send( 'auth-updated', { error: error } );
+		} else {
+			await storeToken( token );
+			mainWindow.webContents.send( 'auth-updated', { token } );
+		}
 	} );
 }

--- a/src/lib/oauth.ts
+++ b/src/lib/oauth.ts
@@ -105,7 +105,7 @@ export function setUpAuthCallbackHandler() {
 	ipcMain.on( 'auth-callback', async ( _event, { token, error } ) => {
 		const mainWindow = await getMainWindow();
 		if ( error ) {
-			mainWindow.webContents.send( 'auth-updated', { error: error } );
+			mainWindow.webContents.send( 'auth-updated', { error } );
 		} else {
 			await storeToken( token );
 			mainWindow.webContents.send( 'auth-updated', { token } );

--- a/src/lib/tests/oauth.test.ts
+++ b/src/lib/tests/oauth.test.ts
@@ -3,7 +3,7 @@
  */
 import { ipcMain } from 'electron';
 import fs from 'fs';
-import { withMainWindow } from '../../main-window';
+import { getMainWindow } from '../../main-window';
 import { loadUserData, saveUserData } from '../../storage/user-data';
 import { setUpAuthCallbackHandler } from '../oauth';
 
@@ -28,12 +28,10 @@ describe( 'setUpAuthCallbackHandler', () => {
 			}
 		} );
 		const mockSend = jest.fn();
-		( withMainWindow as jest.Mock ).mockImplementationOnce( ( callback ) => {
-			callback( {
-				webContents: {
-					send: mockSend,
-				},
-			} );
+		( getMainWindow as jest.Mock ).mockResolvedValue( {
+			webContents: {
+				send: mockSend,
+			},
 		} );
 		( loadUserData as jest.Mock ).mockResolvedValueOnce( {} );
 		( saveUserData as jest.Mock ).mockResolvedValueOnce( {} );

--- a/src/main-window.ts
+++ b/src/main-window.ts
@@ -139,7 +139,7 @@ function getOSWindowOptions(): Partial< BrowserWindowConstructorOptions > {
 }
 
 export function withMainWindow( callback: ( window: BrowserWindow ) => void ): void {
-	if ( mainWindow && ! mainWindow.isDestroyed() ) {
+	if ( mainWindow && ! mainWindow.isDestroyed() && ! mainWindow.webContents.isDestroyed() ) {
 		callback( mainWindow );
 		return;
 	}
@@ -147,14 +147,18 @@ export function withMainWindow( callback: ( window: BrowserWindow ) => void ): v
 	const windows = BrowserWindow.getAllWindows();
 	if ( windows.length > 0 ) {
 		mainWindow = BrowserWindow.getFocusedWindow() || windows[ 0 ];
-		callback( mainWindow );
+		if ( ! mainWindow.webContents.isDestroyed() ) {
+			callback( mainWindow );
+		}
 		return;
 	}
 
 	const newWindow = createMainWindow();
 	mainWindow = newWindow;
 	newWindow.webContents.on( 'did-finish-load', () => {
-		callback( newWindow );
+		if ( ! newWindow.webContents.isDestroyed() ) {
+			callback( newWindow );
+		}
 	} );
 }
 

--- a/src/main-window.ts
+++ b/src/main-window.ts
@@ -138,27 +138,27 @@ function getOSWindowOptions(): Partial< BrowserWindowConstructorOptions > {
 	}
 }
 
-export function withMainWindow( callback: ( window: BrowserWindow ) => void ): void {
-	if ( mainWindow && ! mainWindow.isDestroyed() && ! mainWindow.webContents.isDestroyed() ) {
-		callback( mainWindow );
-		return;
-	}
-
-	const windows = BrowserWindow.getAllWindows();
-	if ( windows.length > 0 ) {
-		mainWindow = BrowserWindow.getFocusedWindow() || windows[ 0 ];
-		if ( ! mainWindow.webContents.isDestroyed() ) {
-			callback( mainWindow );
+export function getMainWindow(): Promise< BrowserWindow > {
+	return new Promise( ( resolve ) => {
+		if ( mainWindow && ! mainWindow.isDestroyed() && ! mainWindow.webContents.isDestroyed() ) {
+			resolve( mainWindow );
+			return;
 		}
-		return;
-	}
 
-	const newWindow = createMainWindow();
-	mainWindow = newWindow;
-	newWindow.webContents.on( 'did-finish-load', () => {
-		if ( ! newWindow.webContents.isDestroyed() ) {
-			callback( newWindow );
+		const windows = BrowserWindow.getAllWindows();
+		if ( windows.length > 0 ) {
+			mainWindow = BrowserWindow.getFocusedWindow() || windows[ 0 ];
+			if ( ! mainWindow.webContents.isDestroyed() ) {
+				resolve( mainWindow );
+			}
+			return;
 		}
+
+		const newWindow = createMainWindow();
+		mainWindow = newWindow;
+		newWindow.webContents.on( 'did-finish-load', () => {
+			resolve( newWindow );
+		} );
 	} );
 }
 

--- a/src/main-window.ts
+++ b/src/main-window.ts
@@ -138,8 +138,8 @@ function getOSWindowOptions(): Partial< BrowserWindowConstructorOptions > {
 	}
 }
 
-export function getMainWindow(): Promise< BrowserWindow > {
-	return new Promise( ( resolve ) => {
+export function getMainWindow() {
+	return new Promise< BrowserWindow >( ( resolve ) => {
 		if ( mainWindow && ! mainWindow.isDestroyed() && ! mainWindow.webContents.isDestroyed() ) {
 			resolve( mainWindow );
 			return;

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -10,38 +10,36 @@ import { __ } from '@wordpress/i18n';
 import { openAboutWindow } from './about-menu/open-about-menu';
 import { BUG_REPORT_URL, FEATURE_REQUEST_URL, STUDIO_DOCS_URL } from './constants';
 import { promptWindowsSpeedUpSites } from './lib/windows-helpers';
-import { withMainWindow } from './main-window';
+import { getMainWindow } from './main-window';
 import { isUpdateReadyToInstall, manualCheckForUpdates } from './updates';
 
-export function setupMenu( config: { needsOnboarding: boolean } ) {
-	withMainWindow( ( mainWindow ) => {
-		if ( ! mainWindow && process.platform !== 'darwin' ) {
-			Menu.setApplicationMenu( null );
-			return;
-		}
-		const menu = getAppMenu( mainWindow, config );
-		if ( process.platform === 'darwin' ) {
-			Menu.setApplicationMenu( menu );
-			return;
-		}
-		// Make menu accessible in development for non-macOS platforms
-		if ( process.env.NODE_ENV === 'development' ) {
-			mainWindow?.setMenu( menu );
-			return;
-		}
+export async function setupMenu( config: { needsOnboarding: boolean } ) {
+	const mainWindow = await getMainWindow();
+	if ( ! mainWindow && process.platform !== 'darwin' ) {
 		Menu.setApplicationMenu( null );
-	} );
+		return;
+	}
+	const menu = getAppMenu( mainWindow, config );
+	if ( process.platform === 'darwin' ) {
+		Menu.setApplicationMenu( menu );
+		return;
+	}
+	// Make menu accessible in development for non-macOS platforms
+	if ( process.env.NODE_ENV === 'development' ) {
+		mainWindow?.setMenu( menu );
+		return;
+	}
+	Menu.setApplicationMenu( null );
 }
 
 export function removeMenu() {
 	Menu.setApplicationMenu( null );
 }
 
-export function popupMenu() {
-	withMainWindow( ( window ) => {
-		const menu = getAppMenu( window );
-		menu.popup();
-	} );
+export async function popupMenu() {
+	const window = await getMainWindow();
+	const menu = getAppMenu( window );
+	menu.popup();
 }
 
 function getAppMenu(
@@ -57,10 +55,9 @@ function getAppMenu(
 		},
 		{
 			label: __( 'Test Render Failure (dev only)' ),
-			click: () => {
-				withMainWindow( ( window ) => {
-					window.webContents.send( 'test-render-failure' );
-				} );
+			click: async () => {
+				const window = await getMainWindow();
+				window.webContents.send( 'test-render-failure' );
 			},
 		},
 	];
@@ -93,10 +90,9 @@ function getAppMenu(
 				{
 					label: __( 'Settings…' ),
 					accelerator: 'CommandOrControl+,',
-					click: () => {
-						withMainWindow( ( window ) => {
-							window.webContents.send( 'user-settings' );
-						} );
+					click: async () => {
+						const window = await getMainWindow();
+						window.webContents.send( 'user-settings' );
 					},
 				},
 				{ type: 'separator' },
@@ -119,10 +115,9 @@ function getAppMenu(
 				{
 					label: __( 'Add Site…' ),
 					accelerator: 'CommandOrControl+N',
-					click: () => {
-						withMainWindow( ( window ) => {
-							window.webContents.send( 'add-site' );
-						} );
+					click: async () => {
+						const window = await getMainWindow();
+						window.webContents.send( 'add-site' );
 					},
 					enabled: ! needsOnboarding,
 				},

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -2,7 +2,7 @@
  * @jest-environment node
  */
 import fs from 'fs';
-import { createMainWindow, withMainWindow } from '../main-window';
+import { createMainWindow, getMainWindow } from '../main-window';
 import { setupWPServerFiles } from '../setup-wp-server-files';
 
 jest.mock( 'fs' );
@@ -156,6 +156,11 @@ it( 'should wait app initialization before creating main window via activate eve
 
 it( 'should wait app initialization before creating main window via second-instance event', async () => {
 	await jest.isolateModulesAsync( async () => {
+		( getMainWindow as jest.Mock ).mockResolvedValue( {
+			focus: jest.fn(),
+			isMinimized: jest.fn( () => false ),
+		} );
+
 		const { mockedEvents } = mockElectron( { appEvents: [ 'ready', 'second-instance' ] } );
 
 		// The "second-instance" event is only invoked on Windows/Linux platforms.
@@ -168,13 +173,13 @@ it( 'should wait app initialization before creating main window via second-insta
 		const { ready, 'second-instance': secondInstance } = mockedEvents;
 
 		await secondInstance();
-		// "withMainWindow" creates the main window if it doesn't exist
-		expect( withMainWindow as jest.Mock ).not.toHaveBeenCalled();
+		// "getMainWindow" creates the main window if it doesn't exist
+		expect( getMainWindow as jest.Mock ).not.toHaveBeenCalled();
 
 		await ready();
 
 		await secondInstance();
-		expect( withMainWindow as jest.Mock ).toHaveBeenCalled();
+		expect( getMainWindow as jest.Mock ).toHaveBeenCalled();
 
 		Object.defineProperty( process, 'platform', { value: originalProcessPlatform } );
 	} );

--- a/src/tests/ipc-handlers.test.ts
+++ b/src/tests/ipc-handlers.test.ts
@@ -6,7 +6,7 @@ import fs from 'fs';
 import { createSite, startServer, isFullscreen } from '../ipc-handlers';
 import { isEmptyDir, pathExists } from '../lib/fs-utils';
 import { keepSqliteIntegrationUpdated } from '../lib/sqlite-versions';
-import { withMainWindow } from '../main-window';
+import { getMainWindow } from '../main-window';
 import { SiteServer, createSiteWorkingDirectory } from '../site-server';
 
 jest.mock( 'fs' );
@@ -98,10 +98,8 @@ describe( 'startServer', () => {
 
 describe( 'isFullscreen', () => {
 	it( 'should return false when window is not in fullscreen', async () => {
-		( withMainWindow as jest.Mock ).mockImplementationOnce( ( callback ) => {
-			callback( {
-				isFullScreen: () => false,
-			} );
+		( getMainWindow as jest.Mock ).mockResolvedValue( {
+			isFullScreen: () => false,
 		} );
 
 		const result = await isFullscreen( mockIpcMainInvokeEvent );
@@ -110,10 +108,8 @@ describe( 'isFullscreen', () => {
 	} );
 
 	it( 'should return true when window is in fullscreen', async () => {
-		( withMainWindow as jest.Mock ).mockImplementationOnce( ( callback ) => {
-			callback( {
-				isFullScreen: () => true,
-			} );
+		( getMainWindow as jest.Mock ).mockResolvedValue( {
+			isFullScreen: () => true,
 		} );
 
 		const result = await isFullscreen( mockIpcMainInvokeEvent );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/dotcom-forge/issues/10346

## Proposed Changes

With the help of some AI debugging in Sentry, I determined that https://github.com/Automattic/dotcom-forge/issues/10346 seems to be happening because we send IPC messages to windows that have been destroyed. This PR adds some additional `isDestroyed` checks to mitigate that (see 0ae3042). 

I also took the opportunity to refactor `withMainWindow` into a function that returns a promise instead. There's really no reason for it to accept a callback, so this helps keep our code clean and simple.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Smoke test the app. Ensure that the About menu, the settings, and the fullscreen view work as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
