### PR TITLE
Disable ESLint rule `import/no-named-as-default-member`

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -32,9 +32,10 @@
 			{
 				"args": "after-used",
 				"argsIgnorePattern": "^_",
+				"caughtErrors": "none",
+				"ignoreRestSiblings": true,
 				"vars": "all",
-				"varsIgnorePattern": "^_",
-				"ignoreRestSiblings": true
+				"varsIgnorePattern": "^_"
 			}
 		],
 		"import/no-named-as-default-member": "off",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -37,6 +37,7 @@
 				"ignoreRestSiblings": true
 			}
 		],
+		"import/no-named-as-default-member": "off",
 		"import/order": [
 			"error",
 			{


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

–

## Proposed Changes

As I mentioned in https://github.com/Automattic/studio/pull/835#discussion_r1928772419, it's my fault that ESLint's `import/no-named-as-default-member` rule is enabled (happened in https://github.com/Automattic/studio/pull/825), and this is currently generating a lot of linter noise.

Aside from the noisy linter warnings, I don't see a good reason for enabling this rule in our case. I think it's overly strict (see [docs](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-named-as-default-member.md)). 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Code review should suffice. Check the linter output if you want to, we should now have 31 warnings instead of 111.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
