### PR TITLE
Studio: Update `demo sites` to `preview sites` in Settings

### DIFF
--- a/src/components/tests/user-settings.test.tsx
+++ b/src/components/tests/user-settings.test.tsx
@@ -1,6 +1,7 @@
 // To run tests, execute `npm run test -- src/components/user-settings.test.tsx` from the root directory
 import { fireEvent, render, screen } from '@testing-library/react';
 import { useAuth } from '../../hooks/use-auth';
+import { useFeatureFlags } from '../../hooks/use-feature-flags';
 import { useIpcListener } from '../../hooks/use-ipc-listener';
 import { useOffline } from '../../hooks/use-offline';
 import UserSettings from '../user-settings';
@@ -15,6 +16,8 @@ afterEach( () => {
 
 describe( 'UserSettings', () => {
 	beforeEach( () => {
+		( useFeatureFlags as jest.Mock ).mockReturnValue( { quickDeploysEnabled: false } );
+
 		// Triggers IPC listener to show modal
 		( useIpcListener as jest.Mock ).mockImplementationOnce( ( listener, callback ) => {
 			if ( listener === 'user-settings' ) {

--- a/src/components/user-settings.tsx
+++ b/src/components/user-settings.tsx
@@ -256,7 +256,7 @@ export default function UserSettings() {
 			await deleteAllSnapshots( allSnapshots );
 			setDeletedAllSnapshots( true );
 		}
-	}, [ allSnapshots, quickDeploysEnabled, __, deleteAllSnapshots ] );
+	}, [ allSnapshots, deleteAllSnapshots, __, quickDeploysEnabled ] );
 
 	return (
 		<>

--- a/src/components/user-settings.tsx
+++ b/src/components/user-settings.tsx
@@ -5,6 +5,7 @@ import { useI18n } from '@wordpress/react-i18n';
 import { useCallback, useState, useEffect } from 'react';
 import { WPCOM_PROFILE_URL } from '../constants';
 import { useAuth } from '../hooks/use-auth';
+import { useFeatureFlags } from '../hooks/use-feature-flags';
 import { useIpcListener } from '../hooks/use-ipc-listener';
 import { useOffline } from '../hooks/use-offline';
 import { usePromptUsage } from '../hooks/use-prompt-usage';
@@ -64,7 +65,7 @@ const SnapshotInfo = ( {
 	isDeleting?: boolean;
 } ) => {
 	const { __ } = useI18n();
-
+	const { quickDeploysEnabled } = useFeatureFlags();
 	const { snapshotCreationBlocked } = useSnapshots();
 	const menuItemStyles = cx(
 		'[&_span]:min-w-0 [&_span]:p-[1px]',
@@ -72,14 +73,20 @@ const SnapshotInfo = ( {
 			'[&.components-button:disabled]:cursor-not-allowed [&.components-button]:aria-disabled:cursor-not-allowed'
 	);
 	const isOffline = useOffline();
-	const offlineMessage = __( 'Deleting demo sites requires an internet connection.' );
+	const offlineMessage = quickDeploysEnabled
+		? __( 'Deleting preview sites requires an internet connection.' )
+		: __( 'Deleting demo sites requires an internet connection.' );
 	return (
 		<div className={ cx( 'flex flex-col', ! snapshotCreationBlocked && 'gap-3' ) }>
-			<h2 className="a8c-label-semibold">{ __( 'Demo sites' ) }</h2>
+			<h2 className="a8c-label-semibold">
+				{ quickDeploysEnabled ? __( 'Preview sites' ) : __( 'Demo sites' ) }
+			</h2>
 			<div className="flex gap-3 flex-row items-center w-full">
 				{ snapshotCreationBlocked ? (
 					<div className="text-a8c-gray-70">
-						{ __( 'Demo sites are not available for your account.' ) }
+						{ quickDeploysEnabled
+							? __( 'Preview sites are not available for your account.' )
+							: __( 'Demo sites are not available for your account.' ) }
 					</div>
 				) : (
 					<>
@@ -88,7 +95,13 @@ const SnapshotInfo = ( {
 								<div className="flex flex-row items-center text-right">
 									{ isDeleting && <Spinner className="!mt-0 !mx-2" /> }
 									<span className="text-a8c-gray-70">
-										{ sprintf( __( '%1s of %2s active demo sites' ), siteCount, siteLimit ) }
+										{ sprintf(
+											quickDeploysEnabled
+												? __( '%1s of %2s active preview sites' )
+												: __( '%1s of %2s active demo sites' ),
+											siteCount,
+											siteLimit
+										) }
 									</span>
 								</div>
 							</div>
@@ -134,7 +147,9 @@ const SnapshotInfo = ( {
 													onClose();
 												} }
 											>
-												{ __( 'Delete all demo sites' ) }
+												{ quickDeploysEnabled
+													? __( 'Delete all preview sites' )
+													: __( 'Delete all demo sites' ) }
 											</MenuItem>
 										</Tooltip>
 									</MenuGroup>
@@ -175,6 +190,7 @@ function PromptInfo() {
 }
 
 export default function UserSettings() {
+	const { quickDeploysEnabled } = useFeatureFlags();
 	const { __ } = useI18n();
 	const [ deletedAllSnapshots, setDeletedAllSnapshots ] = useState( false );
 	const { isAuthenticated, authenticate, logout, user } = useAuth();
@@ -205,10 +221,12 @@ export default function UserSettings() {
 			setDeletedAllSnapshots( false );
 			getIpcApi().showNotification( {
 				title: __( 'Delete Successful' ),
-				body: __( 'All demo sites have been deleted.' ),
+				body: quickDeploysEnabled
+					? __( 'All preview sites have been deleted.' )
+					: __( 'All demo sites have been deleted.' ),
 			} );
 		}
-	}, [ __, loadingDeletingAllSnapshots, deletedAllSnapshots ] );
+	}, [ __, loadingDeletingAllSnapshots, deletedAllSnapshots, quickDeploysEnabled ] );
 
 	const onRemoveSnapshots = useCallback( async () => {
 		if ( ! allSnapshots || allSnapshots.length === 0 ) {
@@ -220,10 +238,16 @@ export default function UserSettings() {
 
 		const { response } = await getIpcApi().showMessageBox( {
 			type: 'warning',
-			message: __( 'Delete all demo sites' ),
-			detail: __(
-				'All demo sites that exist for your WordPress.com account, along with all posts, pages, comments, and media, will be lost.'
-			),
+			message: quickDeploysEnabled
+				? __( 'Delete all preview sites' )
+				: __( 'Delete all demo sites' ),
+			detail: quickDeploysEnabled
+				? __(
+						'All preview sites that exist for your WordPress.com account, along with all posts, pages, comments, and media, will be lost.'
+				  )
+				: __(
+						'All demo sites that exist for your WordPress.com account, along with all posts, pages, comments, and media, will be lost.'
+				  ),
 			buttons: [ __( 'Cancel' ), __( 'Delete all' ) ],
 			cancelId: CANCEL_BUTTON_INDEX,
 		} );
@@ -232,7 +256,7 @@ export default function UserSettings() {
 			await deleteAllSnapshots( allSnapshots );
 			setDeletedAllSnapshots( true );
 		}
-	}, [ allSnapshots, deleteAllSnapshots, __ ] );
+	}, [ allSnapshots, quickDeploysEnabled, __, deleteAllSnapshots ] );
 
 	return (
 		<>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Resolves https://github.com/Automattic/dotcom-forge/issues/10351.

## Proposed Changes

- update of occurrences of `demo site` to `preview site` on in Settings (when the `quickDeploysEnabled` feature flag is enabled)

| Settings | Confirmation modal |
|--------|--------|
| ![Markup on 2025-01-29 at 17:38:03](https://github.com/user-attachments/assets/da3ac74e-c06e-40d8-bf0e-8d9596059333) | ![Markup on 2025-01-29 at 17:38:39](https://github.com/user-attachments/assets/9f659c63-3b8d-4541-b71c-9f1ccbecbfb5) | 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the branch PR and build the app with `STUDIO_QUICK_DEPLOYS=true npm start`.
2. Navigate to the Settings section. All occurrences of the `demo site` should be replaced by `preview site` - as can be seen in the screenshots above.
3. Now build the app with `npm start`.
4. Navigate to the Settings section. The current `demo site` copy should be displayed everywhere.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
