### PR TITLE
chore: allow sending errors to Sentry from dev env

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -41,7 +41,7 @@ if ( ! isCLI() && ! process.env.IS_DEV_BUILD ) {
 	Sentry.init( {
 		dsn: 'https://97693275b2716fb95048c6d12f4318cf@o248881.ingest.sentry.io/4506612776501248',
 		debug: true,
-		enabled: process.env.NODE_ENV !== 'development' && process.env.NODE_ENV !== 'test',
+		enabled: process.env.NODE_ENV !== 'test',
 		release: `${ app.getVersion() ? app.getVersion() : COMMIT_HASH }-${ getPlatformName() }`,
 	} );
 }


### PR DESCRIPTION
## Proposed Changes
I spent some time figuring out - why we have `development` logs in Sentry, but I don't see mine.
It's kinda edge case (since now I know 😄), but as for me, would be useful to allow sending errors by default, w/o the necessity to turn it on manually in code every time.

## Testing Instructions

Visual review should suffice