### PR TITLE
Capture JSON parsing errors in `chat-slice.ts`

### DIFF
--- a/src/stores/chat-slice.ts
+++ b/src/stores/chat-slice.ts
@@ -121,6 +121,7 @@ const fetchAssistant = createAsyncThunk(
 				},
 				( error, data, headers ) => {
 					if ( error ) {
+						Sentry.captureException( error );
 						return reject( error );
 					}
 					return resolve( { data, headers } );
@@ -191,6 +192,17 @@ const getInitialState = (): ChatState => {
 	const storedMessages = localStorage.getItem( LOCAL_STORAGE_CHAT_MESSAGES_KEY );
 	const storedChatIds = localStorage.getItem( LOCAL_STORAGE_CHAT_API_IDS_KEY );
 
+	let parsedStoredMessages: ChatState[ 'messagesDict' ] = {};
+	let parsedStoredChatIds: ChatState[ 'chatApiIdDict' ] = {};
+
+	try {
+		parsedStoredMessages = storedMessages ? JSON.parse( storedMessages ) : {};
+		parsedStoredChatIds = storedChatIds ? JSON.parse( storedChatIds ) : {};
+	} catch ( error ) {
+		Sentry.captureException( error );
+		console.error( error );
+	}
+
 	return {
 		currentURL: '',
 		pluginListDict: {},
@@ -203,8 +215,8 @@ const getInitialState = (): ChatState => {
 		os: window.appGlobals?.platform || '',
 		availableEditors: [],
 		siteName: '',
-		messagesDict: storedMessages ? JSON.parse( storedMessages ) : {},
-		chatApiIdDict: storedChatIds ? JSON.parse( storedChatIds ) : {},
+		messagesDict: parsedStoredMessages,
+		chatApiIdDict: parsedStoredChatIds,
 		chatInputBySite: {},
 		isLoadingDict: {},
 		promptUsageDict: {},

--- a/src/stores/tests/chat-slice.test.ts
+++ b/src/stores/tests/chat-slice.test.ts
@@ -218,6 +218,23 @@ describe( 'chat-slice', () => {
 			);
 			expect( storedChatIds[ instanceId ] ).toBe( 'chatcmpl-123' );
 		} );
+
+		it( 'should handle invalid JSON in localStorage gracefully', () => {
+			const consoleErrorSpy = jest.spyOn( console, 'error' );
+
+			localStorage.setItem( LOCAL_STORAGE_CHAT_MESSAGES_KEY, 'invalid json' );
+			localStorage.setItem( LOCAL_STORAGE_CHAT_API_IDS_KEY, '{also invalid}' );
+
+			jest.isolateModules( () => {
+				const { store } = require( 'src/stores' );
+
+				const state = store.getState();
+				expect( state.chat.messagesDict ).toEqual( {} );
+				expect( state.chat.chatApiIdDict ).toEqual( {} );
+			} );
+
+			expect( consoleErrorSpy ).toHaveBeenCalledTimes( 1 );
+		} );
 	} );
 
 	describe( 'updateMessage', () => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Follow-up to #786 

## Proposed Changes

`chat-slice.ts` queries localStorage for existing Assistant conversations and chat API IDs when the app starts. That data is stored as JSON. Previously, we didn't have any error handling for the JSON parsing. This PR fixes that.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Code review should suffice

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
