### PR TITLE
Remove internal mu-plugins during prepareWordPress

### DIFF
--- a/vendor/wp-now/src/wp-now.ts
+++ b/vendor/wp-now/src/wp-now.ts
@@ -105,8 +105,6 @@ export default async function startWPNow(
 
 	const isFirstTimeProject = ! fs.existsSync( options.wpContentPath );
 
-	await removeDownloadedMuPlugins( options.projectPath );
-
 	await prepareWordPress( php, options );
 
 	if ( options.blueprintObject ) {
@@ -175,6 +173,13 @@ async function prepareDocumentRoot( php: PHP, options: WPNowOptions ) {
 }
 
 export async function prepareWordPress( php: PHP, options: WPNowOptions ) {
+	/**
+	 * Studio used to store internal mu-plugins in the site's mu-plugins folder.
+	 * Internal mu-plugins are now mounted into Playground's internal mu-plugins folder,
+	 * so we need to remove the mu-plugins from the site's mu-plugins folder.
+	 */
+	await removeDownloadedMuPlugins( options.projectPath );
+
 	switch ( options.mode ) {
 		case WPNowMode.WP_CONTENT:
 			await runWpContentMode( php, options );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->


## Proposed Changes

- Remove internal mu-plugins during `prepareWordPress` to ensure it runs both during the server setup and CLI command runs.

## Testing Instructions

### Setup an outdated site with internal mu-plugins

- Start the production version of Studio
- Create a new site
- Confirm that the site has internal mu-plugins in the site's mu-plugins folder (e.g. `0-permalinks.php`)
- Close Studio

### Confirm that CLI runs don't return errors

- Checkout this branch
- Start Studio
- Click on the site with outdated mu-plugins, but don't start the server
- Click on Assistant
- Confirm that there are no errors in Studio logs (on trunk there would be a 500 response from Playground)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
