### PR TITLE
Studio: Solve console errors for getWpContentSize

### DIFF
--- a/src/components/tests/content-tab-snapshots.test.tsx
+++ b/src/components/tests/content-tab-snapshots.test.tsx
@@ -5,6 +5,7 @@ import { LIMIT_OF_ZIP_SITES_PER_USER } from '../../constants';
 import { useArchiveSite } from '../../hooks/use-archive-site';
 import { useAuth } from '../../hooks/use-auth';
 import { useOffline } from '../../hooks/use-offline';
+import { useSiteSize } from '../../hooks/use-site-size';
 import { useSnapshots } from '../../hooks/use-snapshots';
 import { useUpdateDemoSite } from '../../hooks/use-update-demo-site';
 import { ContentTabSnapshots } from '../content-tab-snapshots';
@@ -13,7 +14,7 @@ const authenticate = jest.fn();
 jest.mock( '../../hooks/use-auth' );
 jest.mock( '../../hooks/use-snapshots' );
 jest.mock( '../../hooks/use-offline' );
-
+jest.mock( '../../hooks/use-site-size' );
 jest.mock( '../../hooks/use-update-demo-site' );
 const updateDemoSiteMock = jest.fn();
 const isDemoSiteUpdating = jest.fn();
@@ -47,6 +48,10 @@ const selectedSite = {
 	phpVersion: '8.0',
 	adminPassword: btoa( 'test-password' ),
 };
+
+( useSiteSize as jest.Mock ).mockReturnValue( {
+	isOverLimit: false,
+} );
 
 afterEach( () => {
 	jest.clearAllMocks();


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

Closes https://github.com/Automattic/dotcom-forge/issues/10378

## Proposed Changes

This PR adds a missing mock for the `useSiteSize` hook to make sure that there are no console errors when the unit tests are running. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
* Run `npm run test`
* Confirm that you do not see the following console error:  `Error checking site size: TypeError: (0 , get_ipc_api_1.getIpcApi)(...).getWpContentSize is not a function`
* Switch to trunk
* Run `npm run test`
* Observe that you see the error being present

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
