### PR TITLE
chore: improve breadcrumbs in Sentry with providing more info

### DIFF
--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -35,58 +35,59 @@ import Root from './components/root';
 import { getIpcApi } from './lib/get-ipc-api';
 import './index.css';
 
+// Enhances Sentry breadcrumbs messages by extracting meaningful information from DOM elements
+const getExtraSentryBreadcrumbs = ( targetElement: HTMLElement ) => {
+	// Check for custom data-sentry attribute first, which is used for elements
+	// that need explicit tracking identification
+	const sentryData = targetElement.getAttribute( 'data-sentry' );
+	if ( sentryData ) {
+		return `[data-sentry="${ sentryData }"]`;
+	}
+
+	// Skip adding extra context if aria-label is present, as it already provides
+	// sufficient identification for both tracking and accessibility
+	if ( targetElement.getAttribute( 'aria-label' ) ) {
+		return '';
+	}
+
+	// Fall back to the element's text content if available
+	const textContent = targetElement.textContent?.trim() || targetElement.innerText?.trim();
+	if ( textContent ) {
+		return `[text-content="${ textContent }"]`;
+	}
+
+	// If no identifying information is found on the target element,
+	// traverse up the DOM tree looking for identifiable parent elements.
+	// This helps with SVG icons or other elements wrapped in interactive parents.
+	let element = targetElement.parentElement;
+	while ( element ) {
+		const ariaLabel = element.getAttribute( 'aria-label' );
+		const sentryData = element.getAttribute( 'data-sentry' );
+		const textContent = element.textContent?.trim() || element.innerText?.trim();
+		if ( ariaLabel ) {
+			return `[parent-aria-label="${ ariaLabel }"]`;
+		}
+		if ( sentryData ) {
+			return `[parent-data-sentry="${ sentryData }"]`;
+		}
+		if ( textContent ) {
+			return `[parent-text-content="${ textContent }"]`;
+		}
+		element = element.parentElement;
+	}
+
+	return '';
+};
+
 Sentry.init(
 	{
 		debug: true,
 		beforeBreadcrumb( breadcrumb, hint ) {
-			if ( breadcrumb.category === 'ui.click' ) {
-				const targetElement = hint?.event?.target;
+			const targetElement = hint?.event?.target;
 
-				if ( targetElement ) {
-					// improve breadcrumb message, since sometimes we don't have any valuable information in the clicked element
-					const getExtraInformation = () => {
-						// if some clicked element doesn't have any valuable information, we can use data-sentry attribute to identify it
-						// but if button doesn't have textContent or any other information, prefer to always add area-label, since it's useful for screen-readers.
-						// data-sentry should be used only in edge-cases
-						const sentryData = targetElement.getAttribute( 'data-sentry' );
-						if ( sentryData ) {
-							return `[data-sentry="${ sentryData }"]`;
-						}
-
-						// area-label is added by default to message, so we don't need to add it again or any extra information, typically it's enough information to identify the element
-						if ( targetElement.getAttribute( 'aria-label' ) ) {
-							return '';
-						}
-
-						const textContent =
-							targetElement.textContent?.trim() || targetElement.innerText?.trim();
-						if ( textContent ) {
-							return `[text-content="${ textContent }"]`;
-						}
-
-						// Last resort, for example in cases when click happened on svg which doesn't have any information, but area-label or data-sentry or textContent is located in parent <a> or <button> tag
-						let element = targetElement.parentElement;
-						while ( element ) {
-							const ariaLabel = element.getAttribute( 'aria-label' );
-							const sentryData = element.getAttribute( 'data-sentry' );
-							const textContent = element.textContent?.trim() || element.innerText?.trim();
-							if ( ariaLabel ) {
-								return `[parent-aria-label="${ ariaLabel }"]`;
-							}
-							if ( sentryData ) {
-								return `[parent-data-sentry="${ sentryData }"]`;
-							}
-							if ( textContent ) {
-								return `[parent-text-content="${ textContent }"]`;
-							}
-							element = element.parentElement;
-						}
-
-						return '';
-					};
-
-					breadcrumb.message = ( breadcrumb.message || '' ) + getExtraInformation();
-				}
+			if ( breadcrumb.category === 'ui.click' && targetElement ) {
+				breadcrumb.message =
+					( breadcrumb.message || '' ) + getExtraSentryBreadcrumbs( targetElement );
 			}
 
 			return breadcrumb;

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -35,7 +35,65 @@ import Root from './components/root';
 import { getIpcApi } from './lib/get-ipc-api';
 import './index.css';
 
-Sentry.init( { debug: true }, reactInit );
+Sentry.init(
+	{
+		debug: true,
+		beforeBreadcrumb( breadcrumb, hint ) {
+			if ( breadcrumb.category === 'ui.click' ) {
+				const targetElement = hint?.event?.target;
+
+				if ( targetElement ) {
+					// improve breadcrumb message, since sometimes we don't have any valuable information in the clicked element
+					const getExtraInformation = () => {
+						// if some clicked element doesn't have any valuable information, we can use data-sentry attribute to identify it
+						// but if button doesn't have textContent or any other information, prefer to always add area-label, since it's useful for screen-readers.
+						// data-sentry should be used only in edge-cases
+						const sentryData = targetElement.getAttribute( 'data-sentry' );
+						if ( sentryData ) {
+							return `[data-sentry="${ sentryData }"]`;
+						}
+
+						// area-label is added by default to message, so we don't need to add it again or any extra information, typically it's enough information to identify the element
+						if ( targetElement.getAttribute( 'aria-label' ) ) {
+							return '';
+						}
+
+						const textContent =
+							targetElement.textContent?.trim() || targetElement.innerText?.trim();
+						if ( textContent ) {
+							return `[text-content="${ textContent }"]`;
+						}
+
+						// Last resort, for example in cases when click happened on svg which doesn't have any information, but area-label or data-sentry or textContent is located in parent <a> or <button> tag
+						let element = targetElement.parentElement;
+						while ( element ) {
+							const ariaLabel = element.getAttribute( 'aria-label' );
+							const sentryData = element.getAttribute( 'data-sentry' );
+							const textContent = element.textContent?.trim() || element.innerText?.trim();
+							if ( ariaLabel ) {
+								return `[parent-aria-label="${ ariaLabel }"]`;
+							}
+							if ( sentryData ) {
+								return `[parent-data-sentry="${ sentryData }"]`;
+							}
+							if ( textContent ) {
+								return `[parent-text-content="${ textContent }"]`;
+							}
+							element = element.parentElement;
+						}
+
+						return '';
+					};
+
+					breadcrumb.message = ( breadcrumb.message || '' ) + getExtraInformation();
+				}
+			}
+
+			return breadcrumb;
+		},
+	},
+	reactInit
+);
 
 const makeLogger =
 	( level: 'info' | 'warn' | 'erro', originalLogger: typeof console.log ) =>


### PR DESCRIPTION
## Related issues

- Fixes https://github.com/Automattic/dotcom-forge/issues/10276

## Proposed Changes
Sometimes in Sentry breadcrumbs it's not possible to understand which exactly element was clicked, either due to no selectors on element or tailwind classes which are not unique so easy to mix up buttons. Example:

<img width="708" alt="Screenshot 2025-01-30 at 17 12 08" src="https://github.com/user-attachments/assets/06eb5278-0528-4df2-b647-9ad7e490c4d5" />
<img width="696" alt="Screenshot 2025-01-30 at 17 13 11" src="https://github.com/user-attachments/assets/c99ea4b0-490a-46fb-a697-a492c170f690" />

Check out what is the result of the proposed changes. I think, as a first option for the nearest release is a good start and maybe in the future we will improve it, in the next releases.


## Testing Instructions
1. Apply the next diff:
```
diff --git a/src/index.ts b/src/index.ts
index 4545504..9ca2251 100644
--- a/src/index.ts
+++ b/src/index.ts
@@ -41,7 +41,7 @@ if ( ! isCLI() && ! process.env.IS_DEV_BUILD ) {
        Sentry.init( {
                dsn: 'https://97693275b2716fb95048c6d12f4318cf@o248881.ingest.sentry.io/4506612776501248',
                debug: true,
-               enabled: process.env.NODE_ENV !== 'development' && process.env.NODE_ENV !== 'test',
+               enabled: process.env.NODE_ENV !== 'test',
                release: `${ app.getVersion() ? app.getVersion() : COMMIT_HASH }-${ getPlatformName() }`,
        } );
 }
diff --git a/src/lib/shell-open-external-wrapper.ts b/src/lib/shell-open-external-wrapper.ts
index 53916ef..f4cd525 100644
--- a/src/lib/shell-open-external-wrapper.ts
+++ b/src/lib/shell-open-external-wrapper.ts
@@ -12,37 +12,5 @@ const shouldMute = ( error: Error ) => {
 // while only reporting specific errors to Sentry. Some common "application not found"
 // errors are muted to avoid unnecessary error reporting.
 export const shellOpenExternalWrapper = async ( url: string ) => {
-       try {
-               await shell.openExternal( url );
-       } catch ( error ) {
-               if ( error instanceof Error && ! shouldMute( error ) ) {
-                       Sentry.captureException( error );
-               }
-
-               let title = '';
-               let message = '';
-               if ( url.startsWith( 'vscode://file/' ) ) {
-                       title = __( 'Failed to open VS Code' );
-                       message = __(
-                               'Studio is unable to open VS Code. Please ensure it is functioning correctly.'
-                       );
-               } else if ( url.startsWith( 'phpstorm://open?file=' ) ) {
-                       title = __( 'Failed to open PHP Storm' );
-                       message = __(
-                               'Studio is unable to open PHPStorm. Please ensure it is functioning correctly.'
-                       );
-               } else {
-                       title = __( 'Failed to open browser' );
-                       message = __(
-                               'Studio is unable to open your default browser. Please ensure it is functioning correctly.'
-                       );
-               }
-
-               dialog.showMessageBox( {
-                       type: 'error',
-                       message: title,
-                       detail: message,
-                       buttons: [ __( 'OK' ) ],
-               } );
-       }
+       throw new Error( 'test' );
 };
diff --git a/src/renderer.ts b/src/renderer.ts
index 896ec80..1324072 100644
--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -84,8 +84,9 @@ Sentry.init(
 
                                                return '';
                                        };
-
+                                       console.log( 'before:', breadcrumb.message );
                                        breadcrumb.message = ( breadcrumb.message || '' ) + getExtraInformation();
+                                       console.log( 'after:', breadcrumb.message );
                                }
                        }
```
2. Run Studio
3. Open dev-tools -> Console
4. Test the next buttons, but as many you test as better, since maybe you will find some cases not handled with proposed changes.
  4.1  <img width="262" alt="Screenshot 2025-01-30 at 17 15 23" src="https://github.com/user-attachments/assets/164e22cc-3173-4c74-8b33-ee2d0415f02d" /><br /><img width="360" alt="Screenshot 2025-01-30 at 17 19 30" src="https://github.com/user-attachments/assets/9f80d6e6-50d1-4b14-9901-1b6abd082123" />
  4.2 <img width="800" alt="Screenshot 2025-01-30 at 17 16 49" src="https://github.com/user-attachments/assets/cb7ebfdd-3a3c-4f77-8182-05d9e331e7af" /><br ><img width="1080" alt="Screenshot 2025-01-30 at 17 18 45" src="https://github.com/user-attachments/assets/00a7b89d-fdcf-41e3-ac17-22cd801ec5a7" />
  4.3 Not big benefit but easier to understand at a glance:<br/><img width="726" alt="Screenshot 2025-01-30 at 17 21 55" src="https://github.com/user-attachments/assets/9f912c81-b8b6-4e5b-95b8-e3d75134fe37" /><br /><img width="1045" alt="Screenshot 2025-01-30 at 17 21 22" src="https://github.com/user-attachments/assets/64210d16-4620-49b3-bd70-48b4a24706bb" />
  4.4 Not perfect, but still very helpful:<br/><img width="409" alt="Screenshot 2025-01-30 at 17 25 24" src="https://github.com/user-attachments/assets/d56dc147-f2be-4f08-8241-a4dbbe3b1dfc" /><br /><img width="1065" alt="Screenshot 2025-01-30 at 17 26 15" src="https://github.com/user-attachments/assets/866f2a0d-24d7-4587-9b99-28762e6e8bae" />
  4.5 <img width="767" alt="Screenshot 2025-01-30 at 17 28 14" src="https://github.com/user-attachments/assets/38fe1794-9fd6-481a-882b-5b447a8f0c7c" /><br /><img width="507" alt="Screenshot 2025-01-30 at 17 28 40" src="https://github.com/user-attachments/assets/f42bfb19-618e-47cf-a58d-fd63fd6a4bcd" />
  4.6 Test as much as possible

