### PR TITLE
Studio: Add  state for when the preview site was just updated

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,6 +6,7 @@ export const SCREENSHOT_WIDTH = 1040;
 export const SCREENSHOT_HEIGHT = 1248;
 export const LIMIT_OF_ZIP_SITES_PER_USER = 10;
 export const LIMIT_OF_PROMPTS_PER_USER = 200;
+export const UPDATED_MESSAGE_DURATION_MS = 60000; // 1 minute
 export const DEMO_SITE_SIZE_LIMIT_GB = 2;
 export const DEMO_SITE_SIZE_LIMIT_BYTES = DEMO_SITE_SIZE_LIMIT_GB * 1024 * 1024 * 1024; // 2GB
 export const SYNC_PUSH_SIZE_LIMIT_GB = 2;

--- a/src/modules/preview-site/components/preview-site-row.tsx
+++ b/src/modules/preview-site/components/preview-site-row.tsx
@@ -5,6 +5,7 @@ import { useI18n } from '@wordpress/react-i18n';
 import { useEffect, useState, useRef } from 'react';
 import { ArrowIcon } from 'src/components/arrow-icon';
 import Button from 'src/components/button';
+import { UPDATED_MESSAGE_DURATION_MS } from 'src/constants';
 import { useExpirationDate } from 'src/hooks/use-expiration-date';
 import { useFormatLocalizedTimestamps } from 'src/hooks/use-format-localized-timestamps';
 import { useSnapshots } from 'src/hooks/use-snapshots';
@@ -30,25 +31,23 @@ export function PreviewSiteRow( { snapshot, selectedSite }: PreviewSiteRowProps 
 	const wasUpdating = useRef( false );
 
 	useEffect( () => {
-		let timeoutId: NodeJS.Timeout;
-
 		if ( isPreviewSiteUpdating ) {
 			wasUpdating.current = true;
 			setShowUpdatedMessage( false );
-		} else if ( wasUpdating.current ) {
-			setShowUpdatedMessage( true );
-			wasUpdating.current = false;
-
-			timeoutId = setTimeout( () => {
-				setShowUpdatedMessage( false );
-			}, 60000 );
+			return;
 		}
 
-		return () => {
-			if ( timeoutId ) {
-				clearTimeout( timeoutId );
-			}
-		};
+		if ( ! wasUpdating.current ) {
+			return;
+		}
+		wasUpdating.current = false;
+		setShowUpdatedMessage( true );
+
+		const timeoutId = setTimeout( () => {
+			setShowUpdatedMessage( false );
+		}, UPDATED_MESSAGE_DURATION_MS );
+
+		return () => clearTimeout( timeoutId );
 	}, [ isPreviewSiteUpdating ] );
 
 	const getLastUpdateTimeText = () => {

--- a/src/modules/preview-site/components/preview-site-row.tsx
+++ b/src/modules/preview-site/components/preview-site-row.tsx
@@ -1,7 +1,8 @@
 import { Spinner } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
+import { Icon, published } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
-import { useEffect } from 'react';
+import { useEffect, useState, useRef } from 'react';
 import { ArrowIcon } from 'src/components/arrow-icon';
 import Button from 'src/components/button';
 import { useExpirationDate } from 'src/hooks/use-expiration-date';
@@ -25,11 +26,45 @@ export function PreviewSiteRow( { snapshot, selectedSite }: PreviewSiteRowProps 
 	const { isDemoSiteUpdating } = useUpdateDemoSite();
 	const isPreviewSiteUpdating = isDemoSiteUpdating( snapshot.atomicSiteId );
 	const { formatRelativeTime } = useFormatLocalizedTimestamps();
+	const [ showUpdatedMessage, setShowUpdatedMessage ] = useState( false );
+	const wasUpdating = useRef( false );
+
+	useEffect( () => {
+		let timeoutId: NodeJS.Timeout;
+
+		if ( isPreviewSiteUpdating ) {
+			wasUpdating.current = true;
+			setShowUpdatedMessage( false );
+		} else if ( wasUpdating.current ) {
+			setShowUpdatedMessage( true );
+			wasUpdating.current = false;
+
+			timeoutId = setTimeout( () => {
+				setShowUpdatedMessage( false );
+			}, 60000 );
+		}
+
+		return () => {
+			if ( timeoutId ) {
+				clearTimeout( timeoutId );
+			}
+		};
+	}, [ isPreviewSiteUpdating ] );
 
 	const getLastUpdateTimeText = () => {
 		if ( ! date ) {
 			return '-';
 		}
+
+		if ( showUpdatedMessage ) {
+			return (
+				<div className="flex items-center">
+					<Icon icon={ published } className="!mt-0 mr-1 fill-a8c-green-50" />
+					<span className="text-a8c-green-50">{ __( 'Updated' ) }</span>
+				</div>
+			);
+		}
+
 		const timeDistance = formatRelativeTime( new Date( date ).toISOString() );
 		return sprintf( __( '%s ago' ), timeDistance );
 	};

--- a/src/modules/preview-site/components/preview-site-row.tsx
+++ b/src/modules/preview-site/components/preview-site-row.tsx
@@ -102,7 +102,7 @@ export function PreviewSiteRow( { snapshot, selectedSite }: PreviewSiteRowProps 
 				<div className="flex ml-auto">
 					<div className="w-[110px] text-[#757575] flex items-center pl-4">
 						{ isPreviewSiteUpdating ? (
-							<div className="flex items-center">
+							<div className="flex items-center text-gray-900">
 								<Spinner className="!mt-0 !mx-2" />
 								{ __( 'Updating' ) }
 							</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

Related to: https://github.com/Automattic/dotcom-forge/issues/10352

## Proposed Changes

This PR implements the remaining pieces of the update functionality for the preview sites:

* Adds `Updated` state when the site was updated. This state displays for about 1 minute before showing the relative time. If the user switches tabs, the state is reset and also displays a relative time.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
* Start the app with `STUDIO_QUICK_DEPLOYS=true npm start`
* Navigate to the `Previews` tab
* Create at least one preview site 
* From the actions menu, click on the `Update` button
* While the site is updating, observe the spinner with the `Updating` text (the color of the text should be the same as the color of the table header and not light gray)
* Once the update is finished, observe the checkmark with the words `Updated`
* Wait for one minute
* Observe that the displays changes to the relative time (unless you switch between tabs or sites - in that case, the display will change right away. I left it like this intentionally as I am not sure the `Updated` state needs to persist)
* Try to create a new site
* Observe that it does not display `Updated` state and that it is not present on the initial load

<img width="874" alt="Screenshot 2025-01-31 at 11 27 59 AM" src="https://github.com/user-attachments/assets/57fd1211-8471-4919-89a0-36ce674274e0" />

<img width="619" alt="Screenshot 2025-01-31 at 11 28 23 AM" src="https://github.com/user-attachments/assets/fe502675-0b0c-4416-8cec-c713c1f89194" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
