### PR TITLE
change release naming for Sentry

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -39,7 +39,7 @@ import { setupUpdates } from './updates';
 if ( ! isCLI() && ! process.env.IS_DEV_BUILD ) {
 	const version = app.getVersion();
 	const [ baseVersionWithBeta ] = version.split( '-dev.' );
-	const isDevBuild = version.includes( '-dev.' );
+	const isDevBuild = version.includes( '-dev.' ) || process.env.NODE_ENV !== 'development';
 	const sentryRelease = `studio@${ baseVersionWithBeta }`;
 
 	Sentry.init( {

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,11 +37,17 @@ import { loadUserData, saveUserData } from './storage/user-data'; // eslint-disa
 import { setupUpdates } from './updates';
 
 if ( ! isCLI() && ! process.env.IS_DEV_BUILD ) {
+	const version = app.getVersion();
+	const baseVersion = version.split( '-' )[ 0 ]; // Get the version without the dev suffix
+	const isDevBuild = version.includes( '-dev.' );
+	const sentryRelease = `studio@${ baseVersion }`;
+
 	Sentry.init( {
 		dsn: 'https://97693275b2716fb95048c6d12f4318cf@o248881.ingest.sentry.io/4506612776501248',
 		debug: true,
 		enabled: process.env.NODE_ENV !== 'development' && process.env.NODE_ENV !== 'test',
-		release: `studio@${ app.getVersion() }`,
+		release: sentryRelease,
+		environment: isDevBuild ? 'development' : 'production',
 	} );
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,9 +38,9 @@ import { setupUpdates } from './updates';
 
 if ( ! isCLI() && ! process.env.IS_DEV_BUILD ) {
 	const version = app.getVersion();
-	const baseVersion = version.split( '-' )[ 0 ]; // Get the version without the dev suffix
+	const [ baseVersionWithBeta ] = version.split( '-dev.' );
 	const isDevBuild = version.includes( '-dev.' );
-	const sentryRelease = `studio@${ baseVersion }`;
+	const sentryRelease = `studio@${ baseVersionWithBeta }`;
 
 	Sentry.init( {
 		dsn: 'https://97693275b2716fb95048c6d12f4318cf@o248881.ingest.sentry.io/4506612776501248',

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ import {
 } from './lib/cli';
 import { getUserLocaleWithFallback } from './lib/locale-node';
 import { handleAuthCallback, setUpAuthCallbackHandler } from './lib/oauth';
+import { getSentryReleaseInfo } from './lib/sentry-release';
 import { setupLogging } from './logging';
 import { createMainWindow, getMainWindow } from './main-window';
 import {
@@ -37,17 +38,14 @@ import { loadUserData, saveUserData } from './storage/user-data'; // eslint-disa
 import { setupUpdates } from './updates';
 
 if ( ! isCLI() && ! process.env.IS_DEV_BUILD ) {
-	const version = app.getVersion();
-	const [ baseVersionWithBeta ] = version.split( '-dev.' );
-	const isDevBuild = version.includes( '-dev.' ) || process.env.NODE_ENV === 'development';
-	const sentryRelease = `studio@${ baseVersionWithBeta }`;
+	const { release, environment } = getSentryReleaseInfo( app.getVersion() );
 
 	Sentry.init( {
 		dsn: 'https://97693275b2716fb95048c6d12f4318cf@o248881.ingest.sentry.io/4506612776501248',
 		debug: true,
 		enabled: process.env.NODE_ENV !== 'development' && process.env.NODE_ENV !== 'test',
-		release: sentryRelease,
-		environment: isDevBuild ? 'development' : 'production',
+		release,
+		environment,
 	} );
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,7 +39,7 @@ import { setupUpdates } from './updates';
 if ( ! isCLI() && ! process.env.IS_DEV_BUILD ) {
 	const version = app.getVersion();
 	const [ baseVersionWithBeta ] = version.split( '-dev.' );
-	const isDevBuild = version.includes( '-dev.' ) || process.env.NODE_ENV !== 'development';
+	const isDevBuild = version.includes( '-dev.' ) || process.env.NODE_ENV === 'development';
 	const sentryRelease = `studio@${ baseVersionWithBeta }`;
 
 	Sentry.init( {

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,6 @@ import packageJson from '../package.json';
 import { PROTOCOL_PREFIX } from './constants';
 import * as ipcHandlers from './ipc-handlers';
 import { hasActiveSyncOperations } from './lib/active-sync-operations';
-import { getPlatformName } from './lib/app-globals';
 import { bumpAggregatedUniqueStat, bumpStat } from './lib/bump-stats';
 import {
 	listenCLICommands,
@@ -42,7 +41,7 @@ if ( ! isCLI() && ! process.env.IS_DEV_BUILD ) {
 		dsn: 'https://97693275b2716fb95048c6d12f4318cf@o248881.ingest.sentry.io/4506612776501248',
 		debug: true,
 		enabled: process.env.NODE_ENV !== 'development' && process.env.NODE_ENV !== 'test',
-		release: `${ app.getVersion() ? app.getVersion() : COMMIT_HASH }-${ getPlatformName() }`,
+		release: `studio@${ app.getVersion() }`,
 	} );
 }
 

--- a/src/lib/app-globals.ts
+++ b/src/lib/app-globals.ts
@@ -20,17 +20,3 @@ export function isLinux() {
 	const platform = process ? process.platform : getAppGlobals().platform;
 	return platform === 'linux';
 }
-
-export function getPlatformName() {
-	const platform = process ? process.platform : getAppGlobals().platform;
-	switch ( platform ) {
-		case 'darwin':
-			return 'macos';
-		case 'win32':
-			return 'windows';
-		case 'linux':
-			return 'linux';
-		default:
-			return 'other';
-	}
-}

--- a/src/lib/sentry-release.ts
+++ b/src/lib/sentry-release.ts
@@ -1,0 +1,17 @@
+/**
+ * Get the Sentry release information based on the version
+ * @param version The version string from package.json or app.getVersion()
+ */
+export function getSentryReleaseInfo( version: string ) {
+	const [ baseVersionWithBeta ] = version.split( '-dev.' );
+	const isDevEnvironment =
+		version.includes( '-dev.' ) ||
+		!! process.env.IS_DEV_BUILD ||
+		process.env.NODE_ENV === 'development';
+	const sentryRelease = `studio@${ baseVersionWithBeta }`;
+
+	return {
+		release: sentryRelease,
+		environment: isDevEnvironment ? 'development' : 'production',
+	};
+}

--- a/webpack.plugins.ts
+++ b/webpack.plugins.ts
@@ -3,11 +3,10 @@ import type IForkTsCheckerWebpackPlugin from 'fork-ts-checker-webpack-plugin';
 import type { WebpackPluginInstance } from 'webpack';
 const ForkTsCheckerWebpackPlugin: typeof IForkTsCheckerWebpackPlugin = require( 'fork-ts-checker-webpack-plugin' );
 
-// For dev builds, we want to use a consistent release name
 const version = process.env.npm_package_version || '';
-const baseVersion = version.split( '-' )[ 0 ]; // Get the version without the dev suffix
+const [ baseVersionWithBeta ] = version.split( '-dev.' );
 const isDevBuild = version.includes( '-dev.' ) || process.env.IS_DEV_BUILD;
-const sentryRelease = `studio@${ baseVersion }`;
+const sentryRelease = `studio@${ baseVersionWithBeta }`;
 console.log( 'Sentry release version would be:', sentryRelease );
 console.log( 'Sentry environment would be:', isDevBuild ? 'development' : 'production' );
 

--- a/webpack.plugins.ts
+++ b/webpack.plugins.ts
@@ -1,15 +1,13 @@
 import { sentryWebpackPlugin } from '@sentry/webpack-plugin';
+import { getSentryReleaseInfo } from './src/lib/sentry-release';
 import type IForkTsCheckerWebpackPlugin from 'fork-ts-checker-webpack-plugin';
 import type { WebpackPluginInstance } from 'webpack';
 const ForkTsCheckerWebpackPlugin: typeof IForkTsCheckerWebpackPlugin = require( 'fork-ts-checker-webpack-plugin' );
 
 const version = process.env.npm_package_version || '';
-const [ baseVersionWithBeta ] = version.split( '-dev.' );
-const isDevBuild =
-	version.includes( '-dev.' ) || process.env.IS_DEV_BUILD || process.env.NODE_ENV === 'development';
-const sentryRelease = `studio@${ baseVersionWithBeta }`;
-console.log( 'Sentry release version would be:', sentryRelease );
-console.log( 'Sentry environment would be:', isDevBuild ? 'development' : 'production' );
+const { release: sentryRelease, environment } = getSentryReleaseInfo( version );
+console.log( 'Sentry release version:', sentryRelease );
+console.log( 'Sentry environment:', environment );
 
 export const plugins: WebpackPluginInstance[] = [
 	new ForkTsCheckerWebpackPlugin( {
@@ -21,7 +19,7 @@ export const plugins: WebpackPluginInstance[] = [
 		},
 	} ),
 	// Sentry must be the last plugin
-	! isDevBuild &&
+	environment !== 'development' &&
 		!! process.env.SENTRY_AUTH_TOKEN &&
 		sentryWebpackPlugin( {
 			authToken: process.env.SENTRY_AUTH_TOKEN,

--- a/webpack.plugins.ts
+++ b/webpack.plugins.ts
@@ -3,6 +3,9 @@ import type IForkTsCheckerWebpackPlugin from 'fork-ts-checker-webpack-plugin';
 import type { WebpackPluginInstance } from 'webpack';
 const ForkTsCheckerWebpackPlugin: typeof IForkTsCheckerWebpackPlugin = require( 'fork-ts-checker-webpack-plugin' );
 
+const sentryRelease = `studio@${ process.env.npm_package_version }`;
+console.log( 'Sentry release version would be:', sentryRelease );
+
 export const plugins: WebpackPluginInstance[] = [
 	new ForkTsCheckerWebpackPlugin( {
 		logger: 'webpack-infrastructure',
@@ -19,5 +22,8 @@ export const plugins: WebpackPluginInstance[] = [
 			authToken: process.env.SENTRY_AUTH_TOKEN,
 			org: 'a8c',
 			project: 'studio',
+			release: {
+				name: sentryRelease,
+			},
 		} ),
 ];

--- a/webpack.plugins.ts
+++ b/webpack.plugins.ts
@@ -3,8 +3,13 @@ import type IForkTsCheckerWebpackPlugin from 'fork-ts-checker-webpack-plugin';
 import type { WebpackPluginInstance } from 'webpack';
 const ForkTsCheckerWebpackPlugin: typeof IForkTsCheckerWebpackPlugin = require( 'fork-ts-checker-webpack-plugin' );
 
-const sentryRelease = `studio@${ process.env.npm_package_version }`;
+// For dev builds, we want to use a consistent release name
+const version = process.env.npm_package_version || '';
+const baseVersion = version.split( '-' )[ 0 ]; // Get the version without the dev suffix
+const isDevBuild = version.includes( '-dev.' ) || process.env.IS_DEV_BUILD;
+const sentryRelease = `studio@${ baseVersion }`;
 console.log( 'Sentry release version would be:', sentryRelease );
+console.log( 'Sentry environment would be:', isDevBuild ? 'development' : 'production' );
 
 export const plugins: WebpackPluginInstance[] = [
 	new ForkTsCheckerWebpackPlugin( {
@@ -16,7 +21,7 @@ export const plugins: WebpackPluginInstance[] = [
 		},
 	} ),
 	// Sentry must be the last plugin
-	! process.env.IS_DEV_BUILD &&
+	! isDevBuild &&
 		!! process.env.SENTRY_AUTH_TOKEN &&
 		sentryWebpackPlugin( {
 			authToken: process.env.SENTRY_AUTH_TOKEN,

--- a/webpack.plugins.ts
+++ b/webpack.plugins.ts
@@ -5,7 +5,8 @@ const ForkTsCheckerWebpackPlugin: typeof IForkTsCheckerWebpackPlugin = require( 
 
 const version = process.env.npm_package_version || '';
 const [ baseVersionWithBeta ] = version.split( '-dev.' );
-const isDevBuild = version.includes( '-dev.' ) || process.env.IS_DEV_BUILD;
+const isDevBuild =
+	version.includes( '-dev.' ) || process.env.IS_DEV_BUILD || process.env.NODE_ENV === 'development';
 const sentryRelease = `studio@${ baseVersionWithBeta }`;
 console.log( 'Sentry release version would be:', sentryRelease );
 console.log( 'Sentry environment would be:', isDevBuild ? 'development' : 'production' );


### PR DESCRIPTION
## Related issues

- Related to https://github.com/Automattic/dotcom-forge/issues/10345

## Proposed Changes

1. Changed Sentry release naming format:
   - New format: `studio@1.3.3` (consistent across all platforms)
   - Removed platform-specific suffixes (no more `-macos`, `-windows`)
   - Uses base version without commit hash

2. Added environment-based error tracking:
   - Development builds report to `development` environment
   - Release builds report to `production` environment
   - Allows tracking issues in dev builds while keeping them separate from production

3. Improved webpack integration:
   - Source maps are uploaded with the same release name format
   - Added logging to show what release name and environment would be used
   - Fixed dev build detection by checking both version suffix and `IS_DEV_BUILD` flag

4. Code cleanup:
   - Removed unused `getPlatformName()` function
   - Consolidated version parsing logic
   - Added explanatory comments

## Testing Instructions

1. Build the app in development mode:
   - Run `npm run dev`
   - Check console logs for:
     ```
     Sentry release version would be: studio@1.3.3
     Sentry environment would be: development
     ```

2. Build the app in production mode:
   - Run a production build
   - Check console logs for:
     ```
     Sentry release version would be: studio@1.3.3
     Sentry environment would be: production
     ```

3. Test error reporting:
   - Trigger an error in both dev and production builds
   - Verify in Sentry that:
     - Errors are grouped under the correct release (e.g., `studio@1.3.3`)
     - Dev build errors show up in the `development` environment
     - Production build errors show up in the `production` environment
     - Source maps work correctly in both environments

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?