### PR TITLE
Fix regression with login button in Assistant tab

### DIFF
--- a/src/components/auth-provider.tsx
+++ b/src/components/auth-provider.tsx
@@ -94,19 +94,19 @@ const AuthProvider: React.FC< AuthProviderProps > = ( { children } ) => {
 		run();
 	}, [ locale ] );
 
-	return (
-		<AuthContext.Provider
-			value={ {
-				client,
-				isAuthenticated,
-				authenticate,
-				logout,
-				user,
-			} }
-		>
-			{ children }
-		</AuthContext.Provider>
+	// Memoize the context value to avoid unnecessary renders
+	const contextValue: AuthContextType = useMemo(
+		() => ( {
+			client,
+			isAuthenticated,
+			authenticate,
+			logout,
+			user,
+		} ),
+		[ client, isAuthenticated, authenticate, logout, user ]
 	);
+
+	return <AuthContext.Provider value={ contextValue }>{ children }</AuthContext.Provider>;
 };
 
 function createWpcomClient( token?: string, locale?: string ): WPCOM {

--- a/src/components/auth-provider.tsx
+++ b/src/components/auth-provider.tsx
@@ -1,5 +1,5 @@
 import * as Sentry from '@sentry/electron/renderer';
-import { createContext, useState, useEffect, useMemo, useCallback, ReactNode } from 'react';
+import { createContext, useState, useEffect, useCallback, ReactNode, useMemo } from 'react';
 import WPCOM from 'wpcom';
 import { useI18nData } from '../hooks/use-i18n-data';
 import { useIpcListener } from '../hooks/use-ipc-listener';
@@ -37,7 +37,8 @@ const AuthProvider: React.FC< AuthProviderProps > = ( { children } ) => {
 	const [ user, setUser ] = useState< AuthContextType[ 'user' ] >( undefined );
 	const { locale } = useI18nData();
 
-	const authenticate = getIpcApi().authenticate;
+	const authenticate = useCallback( () => getIpcApi().authenticate(), [] );
+
 	useIpcListener( 'auth-updated', ( _event, { token, error } ) => {
 		if ( error ) {
 			Sentry.captureException( error );
@@ -93,19 +94,19 @@ const AuthProvider: React.FC< AuthProviderProps > = ( { children } ) => {
 		run();
 	}, [ locale ] );
 
-	// Memoize the context value to avoid unnecessary renders
-	const contextValue: AuthContextType = useMemo(
-		() => ( {
-			client,
-			isAuthenticated,
-			authenticate,
-			logout,
-			user,
-		} ),
-		[ client, isAuthenticated, authenticate, logout, user ]
+	return (
+		<AuthContext.Provider
+			value={ {
+				client,
+				isAuthenticated,
+				authenticate,
+				logout,
+				user,
+			} }
+		>
+			{ children }
+		</AuthContext.Provider>
 	);
-
-	return <AuthContext.Provider value={ contextValue }>{ children }</AuthContext.Provider>;
 };
 
 function createWpcomClient( token?: string, locale?: string ): WPCOM {

--- a/src/components/auth-provider.tsx
+++ b/src/components/auth-provider.tsx
@@ -1,5 +1,5 @@
 import * as Sentry from '@sentry/electron/renderer';
-import { createContext, useState, useEffect, useCallback, ReactNode, useMemo } from 'react';
+import { createContext, useState, useEffect, useMemo, useCallback, ReactNode } from 'react';
 import WPCOM from 'wpcom';
 import { useI18nData } from '../hooks/use-i18n-data';
 import { useIpcListener } from '../hooks/use-ipc-listener';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

p1738328591013149/1738232370.842149-slack-C04GESRBWKW

## Proposed Changes

The `Log in to WordPress.com` button in `UnauthenticatedView` in the Assistant tab currently throws an error when clicked. Judging by the error message ("an object could not be cloned"), I assume it's related to my changes in https://github.com/Automattic/studio/pull/826. This PR fixes the problem.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Be logged out
2. Go to the Assistant tab
3. Ensure that the login process works as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?