### PR TITLE
Studio: Handle offline mode for preview site

### DIFF
--- a/src/modules/preview-site/components/preview-action-buttons-menu.tsx
+++ b/src/modules/preview-site/components/preview-action-buttons-menu.tsx
@@ -2,11 +2,12 @@ import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { moreVertical } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
+import offlineIcon from 'src/components/offline-icon';
+import { Tooltip } from 'src/components/tooltip';
 import { useConfirmationDialog } from 'src/hooks/use-confirmation-dialog';
 import { useOffline } from 'src/hooks/use-offline';
 import { useSnapshots } from 'src/hooks/use-snapshots';
 import { useUpdateDemoSite } from 'src/hooks/use-update-demo-site';
-
 interface PreviewActionButtonsMenuProps {
 	snapshot: Snapshot;
 	selectedSite: SiteDetails;
@@ -69,7 +70,14 @@ export function PreviewActionButtonsMenu( {
 							onClose();
 						} }
 					>
-						<span>{ __( 'Update' ) }</span>
+						<Tooltip
+							disabled={ ! isOffline }
+							text={ __( 'Updating a preview site requires an internet connection.' ) }
+							icon={ offlineIcon }
+							placement="top-start"
+						>
+							<span>{ __( 'Update' ) }</span>
+						</Tooltip>
 					</MenuItem>
 					<MenuItem
 						isDestructive
@@ -79,7 +87,14 @@ export function PreviewActionButtonsMenu( {
 							onClose();
 						} }
 					>
-						<span>{ __( 'Delete' ) }</span>
+						<Tooltip
+							disabled={ ! isOffline }
+							text={ __( 'Deleting a preview site requires an internet connection.' ) }
+							icon={ offlineIcon }
+							placement="top-start"
+						>
+							<span>{ __( 'Delete' ) }</span>
+						</Tooltip>
 					</MenuItem>
 				</MenuGroup>
 			) }

--- a/src/modules/preview-site/components/preview-action-buttons-menu.tsx
+++ b/src/modules/preview-site/components/preview-action-buttons-menu.tsx
@@ -3,6 +3,7 @@ import { __ } from '@wordpress/i18n';
 import { moreVertical } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { useConfirmationDialog } from 'src/hooks/use-confirmation-dialog';
+import { useOffline } from 'src/hooks/use-offline';
 import { useSnapshots } from 'src/hooks/use-snapshots';
 import { useUpdateDemoSite } from 'src/hooks/use-update-demo-site';
 
@@ -18,6 +19,7 @@ export function PreviewActionButtonsMenu( {
 	const { __ } = useI18n();
 	const { deleteSnapshot } = useSnapshots();
 	const { updateDemoSite } = useUpdateDemoSite();
+	const isOffline = useOffline();
 
 	const showUpdatePreviewConfirmation = useConfirmationDialog( {
 		localStorageKey: 'dontShowUpdateWarning',
@@ -61,6 +63,7 @@ export function PreviewActionButtonsMenu( {
 						<span>{ __( 'Rename' ) }</span>
 					</MenuItem>
 					<MenuItem
+						disabled={ isOffline }
 						onClick={ () => {
 							handleUpdatePreviewSite();
 							onClose();
@@ -70,6 +73,7 @@ export function PreviewActionButtonsMenu( {
 					</MenuItem>
 					<MenuItem
 						isDestructive
+						disabled={ isOffline }
 						onClick={ () => {
 							handleDeletePreviewSite();
 							onClose();


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

**Closes**: https://github.com/Automattic/dotcom-forge/issues/10357

## Proposed Changes

This PR handles the offline mode for the preview site. When the user is offline, the `Update`, `Delete` and `Create preview site` buttons are disabled and there is a tooltip over them indicating that they are in the offline mode. 
## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
* Start the app with `STUDIO_QUICK_DEPLOYS=true npm start`
* Create a preview site
* Navigate to the `Previews` tab
* Cut off your internet or your WiFi connection
* Observe that `Create preview site` link is disabled and that you see a tooltip over the button informing you that you are offline
* Go to the `Actions` menu and click on three ellipsis
* Observe that `Update` and `Delete` buttons are disabled
* Hover over the buttons and observe the tooltip present that explains that you are offline:

<img width="584" alt="Screenshot 2025-01-31 at 3 10 34 PM" src="https://github.com/user-attachments/assets/b333a3b2-1271-459e-b8f2-2c48114eb6f9" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
