### PR TITLE
Validate `authToken` from user data file before returning it

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,8 @@
 				"url-loader": "^4.1.1",
 				"wpcom": "^5.4.2",
 				"yargs": "17.7.2",
-				"yauzl": "^3.2.0"
+				"yauzl": "^3.2.0",
+				"zod": "^3.24.1"
 			},
 			"devDependencies": {
 				"@automattic/color-studio": "^2.5.0",
@@ -25753,6 +25754,15 @@
 			},
 			"engines": {
 				"node": ">= 12.0.0"
+			}
+		},
+		"node_modules/zod": {
+			"version": "3.24.1",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-3.24.1.tgz",
+			"integrity": "sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
 			}
 		},
 		"node_modules/zwitch": {

--- a/package.json
+++ b/package.json
@@ -142,7 +142,8 @@
 		"url-loader": "^4.1.1",
 		"wpcom": "^5.4.2",
 		"yargs": "17.7.2",
-		"yauzl": "^3.2.0"
+		"yauzl": "^3.2.0",
+		"zod": "^3.24.1"
 	},
 	"optionalDependencies": {
 		"appdmg": "^0.6.6"

--- a/src/components/auth-provider.tsx
+++ b/src/components/auth-provider.tsx
@@ -1,4 +1,5 @@
 import * as Sentry from '@sentry/electron/renderer';
+import { useI18n } from '@wordpress/react-i18n';
 import { createContext, useState, useEffect, useMemo, useCallback, ReactNode } from 'react';
 import WPCOM from 'wpcom';
 import { useI18nData } from '../hooks/use-i18n-data';
@@ -36,14 +37,19 @@ const AuthProvider: React.FC< AuthProviderProps > = ( { children } ) => {
 	const [ client, setClient ] = useState< WPCOM | undefined >( undefined );
 	const [ user, setUser ] = useState< AuthContextType[ 'user' ] >( undefined );
 	const { locale } = useI18nData();
+	const { __ } = useI18n();
 
 	const authenticate = useCallback( () => getIpcApi().authenticate(), [] );
 
 	useIpcListener( 'auth-updated', ( _event, { token, error } ) => {
 		if ( error ) {
-			Sentry.captureException( error );
+			getIpcApi().showErrorMessageBox( {
+				title: __( 'Authentication error' ),
+				message: __( 'Please try again.' ),
+			} );
 			return;
 		}
+
 		setIsAuthenticated( true );
 		setClient( createWpcomClient( token.accessToken, locale ) );
 		setUser( {

--- a/src/components/auth-provider.tsx
+++ b/src/components/auth-provider.tsx
@@ -46,13 +46,11 @@ const AuthProvider: React.FC< AuthProviderProps > = ( { children } ) => {
 		}
 		setIsAuthenticated( true );
 		setClient( createWpcomClient( token.accessToken, locale ) );
-		if ( token.id || token.email || token.displayName ) {
-			setUser( {
-				id: token.id,
-				email: token.email,
-				displayName: token.displayName || '',
-			} );
-		}
+		setUser( {
+			id: token.id,
+			email: token.email,
+			displayName: token.displayName || '',
+		} );
 	} );
 
 	const logout = useCallback( async () => {

--- a/src/components/auth-provider.tsx
+++ b/src/components/auth-provider.tsx
@@ -47,8 +47,8 @@ const AuthProvider: React.FC< AuthProviderProps > = ( { children } ) => {
 		setClient( createWpcomClient( token.accessToken, locale ) );
 		if ( token.id || token.email || token.displayName ) {
 			setUser( {
-				id: token.id || null,
-				email: token.email || '',
+				id: token.id,
+				email: token.email,
 				displayName: token.displayName || '',
 			} );
 		}
@@ -69,22 +69,20 @@ const AuthProvider: React.FC< AuthProviderProps > = ( { children } ) => {
 	useEffect( () => {
 		async function run() {
 			try {
-				const isAuthenticated = await getIpcApi().isAuthenticated();
-				setIsAuthenticated( isAuthenticated );
-				if ( isAuthenticated ) {
-					const token = await getIpcApi().getAuthenticationToken();
-					if ( ! token ) {
-						return;
-					}
-					setClient( createWpcomClient( token.accessToken, locale ) );
-					if ( token.id || token.email || token.displayName ) {
-						setUser( {
-							id: token.id || null,
-							email: token.email || '',
-							displayName: token.displayName || '',
-						} );
-					}
+				const token = await getIpcApi().getAuthenticationToken();
+
+				if ( ! token ) {
+					setIsAuthenticated( false );
+					return;
 				}
+
+				setIsAuthenticated( true );
+				setClient( createWpcomClient( token.accessToken, locale ) );
+				setUser( {
+					id: token.id,
+					email: token.email,
+					displayName: token.displayName || '',
+				} );
 			} catch ( err ) {
 				console.error( err );
 				Sentry.captureException( err );

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,7 @@ import {
 	executeCLICommand,
 } from './lib/cli';
 import { getUserLocaleWithFallback } from './lib/locale-node';
-import { onOpenUrlCallback, setUpAuthCallbackHandler } from './lib/oauth';
+import { onOpenUrlCallback } from './lib/oauth';
 import { setupLogging } from './logging';
 import { createMainWindow, getMainWindow } from './main-window';
 import {
@@ -75,8 +75,6 @@ async function appBoot() {
 	Menu.setApplicationMenu( null );
 
 	setupCustomProtocolHandler();
-
-	setUpAuthCallbackHandler();
 
 	setupLogging();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,7 @@ import {
 	executeCLICommand,
 } from './lib/cli';
 import { getUserLocaleWithFallback } from './lib/locale-node';
-import { handleAuthCallback, setUpAuthCallbackHandler } from './lib/oauth';
+import { onOpenUrlCallback, setUpAuthCallbackHandler } from './lib/oauth';
 import { setupLogging } from './logging';
 import { createMainWindow, getMainWindow } from './main-window';
 import {
@@ -68,29 +68,6 @@ if ( gotTheLock && ! isInInstaller ) {
 		app.quit();
 	}
 }
-
-const onOpenUrlCallback = async ( url: string ) => {
-	const urlObject = new URL( url );
-	const { host, hash, searchParams } = urlObject;
-	if ( host === 'auth' ) {
-		handleAuthCallback( hash ).then( ( authResult ) => {
-			if ( authResult instanceof Error ) {
-				ipcMain.emit( 'auth-callback', null, { error: authResult } );
-			} else {
-				ipcMain.emit( 'auth-callback', null, { token: authResult } );
-			}
-		} );
-	}
-
-	if ( host === 'sync-connect-site' ) {
-		const remoteSiteId = parseInt( searchParams.get( 'remoteSiteId' ) ?? '' );
-		const studioSiteId = searchParams.get( 'studioSiteId' );
-		if ( remoteSiteId && studioSiteId ) {
-			const mainWindow = await getMainWindow();
-			mainWindow.webContents.send( 'sync-connect-site', { remoteSiteId, studioSiteId } );
-		}
-	}
-};
 
 async function appBoot() {
 	app.setName( packageJson.productName );

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -17,6 +17,7 @@ import nodePath from 'path';
 import * as Sentry from '@sentry/electron/main';
 import { __, LocaleData, defaultI18n } from '@wordpress/i18n';
 import archiver from 'archiver';
+import { StoredToken } from 'src/lib/oauth';
 import { DEFAULT_PHP_VERSION } from '../vendor/wp-now/src/constants';
 import { MAIN_MIN_WIDTH, SIDEBAR_WIDTH } from './constants';
 import { ACTIVE_SYNC_OPERATIONS } from './lib/active-sync-operations';
@@ -651,7 +652,7 @@ export function authenticate( _event: IpcMainInvokeEvent ) {
 
 export async function getAuthenticationToken(
 	_event: IpcMainInvokeEvent
-): Promise< oauthClient.StoredToken | null > {
+): Promise< StoredToken | null > {
 	return oauthClient.getAuthenticationToken();
 }
 

--- a/src/lib/oauth.ts
+++ b/src/lib/oauth.ts
@@ -21,19 +21,18 @@ export type StoredToken = z.infer< typeof authTokenSchema >;
 async function getToken(): Promise< StoredToken | null > {
 	try {
 		const userData = await loadUserData();
-		const parsed = authTokenSchema.parse( userData.authToken );
-		return parsed;
+		return authTokenSchema.parse( userData.authToken );
 	} catch ( error ) {
 		return null;
 	}
 }
 
-async function storeToken( tokens: StoredToken ) {
+async function storeToken( token: StoredToken ) {
 	try {
 		const userData = await loadUserData();
 		await saveUserData( {
 			...userData,
-			authToken: tokens,
+			authToken: token,
 		} );
 	} catch ( error ) {
 		console.error( 'Failed to store token', error );

--- a/src/lib/oauth.ts
+++ b/src/lib/oauth.ts
@@ -1,4 +1,3 @@
-import { ipcMain } from 'electron';
 import * as Sentry from '@sentry/electron/main';
 import wpcom from 'wpcom';
 import { z } from 'zod';
@@ -56,10 +55,7 @@ export async function clearAuthenticationToken() {
 export async function getAuthenticationToken(): Promise< StoredToken | null > {
 	// Check if tokens already exist and are valid
 	const existingToken = await getToken();
-	if (
-		existingToken?.accessToken &&
-		new Date().getTime() < ( existingToken?.expirationTime ?? 0 )
-	) {
+	if ( existingToken && new Date().getTime() < existingToken.expirationTime ) {
 		return existingToken;
 	}
 	return null;
@@ -70,20 +66,20 @@ export async function isAuthenticated(): Promise< boolean > {
 	return !! token;
 }
 
-export async function handleAuthCallback( hash: string ): Promise< Error | StoredToken > {
+async function handleAuthCallback( hash: string ): Promise< StoredToken > {
 	const params = new URLSearchParams( hash.substring( 1 ) );
 	const error = params.get( 'error' );
 
 	if ( error ) {
 		// Close the browser if code found or error
-		return new Error( error );
+		throw new Error( error );
 	}
 
 	const accessToken = params.get( 'access_token' ) ?? '';
 	const expiresIn = parseInt( params.get( 'expires_in' ) ?? '0' );
 
 	if ( isNaN( expiresIn ) || expiresIn === 0 || ! accessToken ) {
-		return new Error( 'Error while getting token' );
+		throw new Error( 'Error while getting token' );
 	}
 
 	try {
@@ -116,16 +112,16 @@ export async function onOpenUrlCallback( url: string ) {
 	const { host, hash, searchParams } = urlObject;
 
 	if ( host === 'auth' ) {
-		handleAuthCallback( hash ).then( ( authResult ) => {
-			if ( authResult instanceof Error ) {
-				ipcMain.emit( 'auth-callback', null, { error: authResult } );
-			} else {
-				ipcMain.emit( 'auth-callback', null, { token: authResult } );
-			}
-		} );
-	}
-
-	if ( host === 'sync-connect-site' ) {
+		try {
+			const authResult = await handleAuthCallback( hash );
+			const mainWindow = await getMainWindow();
+			await storeToken( authResult );
+			mainWindow.webContents.send( 'auth-updated', { token: authResult } );
+		} catch ( error ) {
+			const mainWindow = await getMainWindow();
+			mainWindow.webContents.send( 'auth-updated', { error } );
+		}
+	} else if ( host === 'sync-connect-site' ) {
 		const remoteSiteId = parseInt( searchParams.get( 'remoteSiteId' ) ?? '' );
 		const studioSiteId = searchParams.get( 'studioSiteId' );
 		if ( remoteSiteId && studioSiteId ) {
@@ -133,16 +129,4 @@ export async function onOpenUrlCallback( url: string ) {
 			mainWindow.webContents.send( 'sync-connect-site', { remoteSiteId, studioSiteId } );
 		}
 	}
-}
-
-export function setUpAuthCallbackHandler() {
-	ipcMain.on( 'auth-callback', async ( _event, { token, error } ) => {
-		const mainWindow = await getMainWindow();
-		if ( error ) {
-			mainWindow.webContents.send( 'auth-updated', { error } );
-		} else {
-			await storeToken( token );
-			mainWindow.webContents.send( 'auth-updated', { token } );
-		}
-	} );
 }

--- a/src/lib/oauth.ts
+++ b/src/lib/oauth.ts
@@ -81,21 +81,16 @@ async function handleAuthCallback( hash: string ): Promise< StoredToken > {
 		throw new Error( 'Error while getting token' );
 	}
 
-	try {
-		const response = await new wpcom( accessToken ).req.get( '/me?fields=ID,email,display_name' );
+	const response = await new wpcom( accessToken ).req.get( '/me?fields=ID,email,display_name' );
 
-		return authTokenSchema.parse( {
-			expiresIn,
-			expirationTime: new Date().getTime() + expiresIn * 1000,
-			accessToken,
-			id: response.ID,
-			email: response.email,
-			displayName: response.display_name,
-		} );
-	} catch ( error ) {
-		Sentry.captureException( error );
-		throw error;
-	}
+	return authTokenSchema.parse( {
+		expiresIn,
+		expirationTime: new Date().getTime() + expiresIn * 1000,
+		accessToken,
+		id: response.ID,
+		email: response.email,
+		displayName: response.display_name,
+	} );
 }
 
 export function authenticate(): void {
@@ -117,6 +112,7 @@ export async function onOpenUrlCallback( url: string ) {
 			await storeToken( authResult );
 			mainWindow.webContents.send( 'auth-updated', { token: authResult } );
 		} catch ( error ) {
+			Sentry.captureException( error );
 			const mainWindow = await getMainWindow();
 			mainWindow.webContents.send( 'auth-updated', { error } );
 		}

--- a/src/lib/oauth.ts
+++ b/src/lib/oauth.ts
@@ -1,26 +1,29 @@
 import { ipcMain } from 'electron';
 import * as Sentry from '@sentry/electron/main';
 import wpcom from 'wpcom';
+import { z } from 'zod';
 import { PROTOCOL_PREFIX, WP_AUTHORIZE_ENDPOINT, CLIENT_ID, SCOPES } from '../constants';
 import { shellOpenExternalWrapper } from '../lib/shell-open-external-wrapper';
 import { getMainWindow } from '../main-window';
 import { loadUserData, saveUserData } from '../storage/user-data';
 
-export interface StoredToken {
-	accessToken?: string;
-	expiresIn?: number;
-	expirationTime?: number;
-	id?: number;
-	email?: string;
-	displayName?: string;
-}
 const REDIRECT_URI = `${ PROTOCOL_PREFIX }://auth`;
-const TOKEN_KEY = 'authToken';
+const authTokenSchema = z.object( {
+	accessToken: z.string(),
+	expiresIn: z.number(),
+	expirationTime: z.number(),
+	id: z.number(),
+	email: z.string(),
+	displayName: z.string().optional(),
+} );
+
+export type StoredToken = z.infer< typeof authTokenSchema >;
 
 async function getToken(): Promise< StoredToken | null > {
 	try {
 		const userData = await loadUserData();
-		return userData[ TOKEN_KEY ] ?? null;
+		const parsed = authTokenSchema.parse( userData.authToken );
+		return parsed;
 	} catch ( error ) {
 		return null;
 	}
@@ -31,7 +34,7 @@ async function storeToken( tokens: StoredToken ) {
 		const userData = await loadUserData();
 		await saveUserData( {
 			...userData,
-			[ TOKEN_KEY ]: tokens,
+			authToken: tokens,
 		} );
 	} catch ( error ) {
 		console.error( 'Failed to store token', error );
@@ -43,7 +46,7 @@ export async function clearAuthenticationToken() {
 		const userData = await loadUserData();
 		await saveUserData( {
 			...userData,
-			[ TOKEN_KEY ]: undefined,
+			authToken: undefined,
 		} );
 	} catch ( error ) {
 		return;
@@ -70,29 +73,34 @@ export async function isAuthenticated(): Promise< boolean > {
 export async function handleAuthCallback( hash: string ): Promise< Error | StoredToken > {
 	const params = new URLSearchParams( hash.substring( 1 ) );
 	const error = params.get( 'error' );
+
 	if ( error ) {
 		// Close the browser if code found or error
 		return new Error( error );
 	}
+
 	const accessToken = params.get( 'access_token' ) ?? '';
 	const expiresIn = parseInt( params.get( 'expires_in' ) ?? '0' );
+
 	if ( isNaN( expiresIn ) || expiresIn === 0 || ! accessToken ) {
 		return new Error( 'Error while getting token' );
 	}
-	let response: { ID?: number; email?: string; display_name?: string } = {};
+
 	try {
-		response = await new wpcom( accessToken ).req.get( '/me?fields=ID,email,display_name' );
+		const response = await new wpcom( accessToken ).req.get( '/me?fields=ID,email,display_name' );
+
+		return authTokenSchema.parse( {
+			expiresIn,
+			expirationTime: new Date().getTime() + expiresIn * 1000,
+			accessToken,
+			id: response.ID,
+			email: response.email,
+			displayName: response.display_name,
+		} );
 	} catch ( error ) {
 		Sentry.captureException( error );
+		throw error;
 	}
-	return {
-		expiresIn,
-		expirationTime: new Date().getTime() + expiresIn * 1000,
-		accessToken,
-		id: response.ID,
-		email: response.email,
-		displayName: response.display_name,
-	};
 }
 
 export function authenticate(): void {
@@ -101,6 +109,30 @@ export function authenticate(): void {
 	) }&scope=${ encodeURIComponent( SCOPES ) }`;
 
 	shellOpenExternalWrapper( authUrl );
+}
+
+export async function onOpenUrlCallback( url: string ) {
+	const urlObject = new URL( url );
+	const { host, hash, searchParams } = urlObject;
+
+	if ( host === 'auth' ) {
+		handleAuthCallback( hash ).then( ( authResult ) => {
+			if ( authResult instanceof Error ) {
+				ipcMain.emit( 'auth-callback', null, { error: authResult } );
+			} else {
+				ipcMain.emit( 'auth-callback', null, { token: authResult } );
+			}
+		} );
+	}
+
+	if ( host === 'sync-connect-site' ) {
+		const remoteSiteId = parseInt( searchParams.get( 'remoteSiteId' ) ?? '' );
+		const studioSiteId = searchParams.get( 'studioSiteId' );
+		if ( remoteSiteId && studioSiteId ) {
+			const mainWindow = await getMainWindow();
+			mainWindow.webContents.send( 'sync-connect-site', { remoteSiteId, studioSiteId } );
+		}
+	}
 }
 
 export function setUpAuthCallbackHandler() {

--- a/src/lib/tests/oauth.test.ts
+++ b/src/lib/tests/oauth.test.ts
@@ -1,48 +1,162 @@
 /**
  * @jest-environment node
  */
-import { ipcMain } from 'electron';
-import fs from 'fs';
-import { normalize } from 'path';
+import wpcom from 'wpcom';
 import { getMainWindow } from '../../main-window';
 import { loadUserData, saveUserData } from '../../storage/user-data';
-import { setUpAuthCallbackHandler } from '../oauth';
+import { getAuthenticationToken, onOpenUrlCallback } from '../oauth';
 
-jest.mock( 'fs' );
 jest.mock( '../../main-window' );
 jest.mock( '../../storage/user-data' );
+jest.mock( 'wpcom' );
 
-const mockUserData = {
-	sites: [],
-};
-( fs as MockedFs ).__setFileContents(
-	normalize( '/path/to/app/appData/App Name/appdata-v1.json' ),
-	JSON.stringify( mockUserData )
-);
+describe( 'getAuthenticationToken', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
 
-describe( 'setUpAuthCallbackHandler', () => {
-	it( 'should set up auth callback handler', async () => {
-		let authCallback: ( ...args: any[] ) => void = jest.fn();
-		( ipcMain.on as jest.Mock ).mockImplementationOnce( ( event, callback ) => {
-			if ( event === 'auth-callback' ) {
-				authCallback = callback;
-			}
+	it( 'should return valid token', async () => {
+		const validToken = {
+			accessToken: 'valid-token',
+			expiresIn: 3600,
+			expirationTime: new Date().getTime() + 3600 * 1000,
+			id: 123,
+			email: 'user@example.com',
+			displayName: 'Test User',
+		};
+		( loadUserData as jest.Mock ).mockResolvedValue( { authToken: validToken } );
+
+		const result = await getAuthenticationToken();
+		expect( result ).toEqual( validToken );
+	} );
+
+	it( 'should return null for expired token', async () => {
+		const expiredToken = {
+			accessToken: 'expired-token',
+			expiresIn: 3600,
+			expirationTime: new Date().getTime() - 1000, // Past time
+			id: 123,
+			email: 'user@example.com',
+			displayName: 'Test User',
+		};
+		( loadUserData as jest.Mock ).mockResolvedValue( { authToken: expiredToken } );
+
+		const result = await getAuthenticationToken();
+		expect( result ).toBeNull();
+	} );
+
+	it( 'should return null for malformed token data', async () => {
+		const malformedToken = {
+			accessToken: 'token',
+			// Missing required fields
+		};
+		( loadUserData as jest.Mock ).mockResolvedValue( { authToken: malformedToken } );
+
+		const result = await getAuthenticationToken();
+		expect( result ).toBeNull();
+	} );
+
+	it( 'should return null when no token exists', async () => {
+		( loadUserData as jest.Mock ).mockResolvedValue( {} );
+
+		const result = await getAuthenticationToken();
+		expect( result ).toBeNull();
+	} );
+} );
+
+describe( 'onOpenUrlCallback', () => {
+	const mockSend = jest.fn();
+	const mockMainWindow = {
+		webContents: {
+			send: mockSend,
+		},
+	};
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+		( getMainWindow as jest.Mock ).mockResolvedValue( mockMainWindow );
+		( loadUserData as jest.Mock ).mockResolvedValue( {} );
+		( saveUserData as jest.Mock ).mockResolvedValue( undefined );
+	} );
+
+	describe( 'auth callback', () => {
+		it( 'should handle successful authentication', async () => {
+			const mockWpcomGet = jest.fn().mockResolvedValue( {
+				ID: 123,
+				email: 'user@example.com',
+				display_name: 'Test User',
+			} );
+			( wpcom as jest.Mock ).mockReturnValue( {
+				req: { get: mockWpcomGet },
+			} );
+
+			const url = 'studio://auth#access_token=mock-token&expires_in=3600';
+			await onOpenUrlCallback( url );
+
+			expect( mockSend ).toHaveBeenCalledWith( 'auth-updated', {
+				token: expect.objectContaining( {
+					accessToken: 'mock-token',
+					expiresIn: 3600,
+					id: 123,
+					email: 'user@example.com',
+					displayName: 'Test User',
+				} ),
+			} );
+			expect( saveUserData ).toHaveBeenCalled();
 		} );
-		const mockSend = jest.fn();
-		( getMainWindow as jest.Mock ).mockResolvedValue( {
-			webContents: {
-				send: mockSend,
-			},
+
+		it( 'should handle authentication error from WordPress.com', async () => {
+			const url = 'studio://auth#error=access_denied';
+			await onOpenUrlCallback( url );
+
+			expect( mockSend ).toHaveBeenCalledWith( 'auth-updated', {
+				error: new Error( 'access_denied' ),
+			} );
+			expect( saveUserData ).not.toHaveBeenCalled();
 		} );
-		( loadUserData as jest.Mock ).mockResolvedValueOnce( {} );
-		( saveUserData as jest.Mock ).mockResolvedValueOnce( {} );
 
-		setUpAuthCallbackHandler();
-		const mockToken = { email: 'mock-email' };
-		authCallback( null, { token: mockToken, error: null } );
-		// Wait for the mocked promises to resolve
-		await new Promise( process.nextTick );
+		it( 'should handle invalid token response', async () => {
+			const url = 'studio://auth#access_token=mock-token&expires_in=invalid';
+			await onOpenUrlCallback( url );
 
-		expect( mockSend ).toHaveBeenCalledWith( 'auth-updated', { token: mockToken } );
+			expect( mockSend ).toHaveBeenCalledWith( 'auth-updated', {
+				error: expect.any( Error ),
+			} );
+			expect( saveUserData ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should handle wpcom API error', async () => {
+			const mockWpcomGet = jest.fn().mockRejectedValue( new Error( 'API Error' ) );
+			( wpcom as jest.Mock ).mockReturnValue( {
+				req: { get: mockWpcomGet },
+			} );
+
+			const url = 'studio://auth#access_token=mock-token&expires_in=3600';
+			await onOpenUrlCallback( url );
+
+			expect( mockSend ).toHaveBeenCalledWith( 'auth-updated', {
+				error: expect.any( Error ),
+			} );
+			expect( saveUserData ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'sync-connect-site callback', () => {
+		it( 'should handle sync connect site callback', async () => {
+			const url = 'studio://sync-connect-site?remoteSiteId=123&studioSiteId=local-site';
+			await onOpenUrlCallback( url );
+
+			expect( mockSend ).toHaveBeenCalledWith( 'sync-connect-site', {
+				remoteSiteId: 123,
+				studioSiteId: 'local-site',
+			} );
+		} );
+
+		it( 'should not send sync connect site event if parameters are missing', async () => {
+			const url = 'studio://sync-connect-site?remoteSiteId=123';
+			await onOpenUrlCallback( url );
+
+			expect( mockSend ).not.toHaveBeenCalled();
+		} );
 	} );
 } );

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -26,43 +26,23 @@ const mockUserData = {
 );
 ( fs as MockedFs ).__setFileContents( normalize( '/path/to/app/temp/com.wordpress.studio/' ), '' );
 
-function mockElectron(
-	{
-		appEvents,
-		appMocks,
-		electronMocks,
-	}: {
-		appEvents: string[];
-		electronMocks?: Partial< typeof import('electron') >;
-		appMocks?: Partial< typeof import('electron').app >;
-	} = {
-		appEvents: [],
-	}
-) {
-	const mockedEvents = appEvents.reduce< Record< string, ( ...args: any[] ) => Promise< void > > >(
-		( accum, event ) => {
-			// eslint-disable-next-line @typescript-eslint/no-empty-function
-			return { ...accum, [ event ]: async () => {} };
-		},
-		{}
-	);
+function mockElectron() {
+	const mockedEvents: Record< string, ( ...args: any[] ) => Promise< void > > = {};
+
 	jest.doMock( 'electron', () => {
 		const electron = jest.genMockFromModule( 'electron' ) as typeof import('electron');
+
 		return {
 			...electron,
-			...electronMocks,
 			app: {
 				...electron.app,
-				...appMocks,
 				on: jest.fn( ( event, callback ) => {
-					const mockedEventName = Object.keys( mockedEvents ).find( ( key ) => key === event );
-					if ( mockedEventName ) {
-						mockedEvents[ mockedEventName ] = callback;
-					}
+					mockedEvents[ event ] = callback;
 				} ),
 			},
 		};
 	} );
+
 	return { mockedEvents };
 }
 
@@ -80,35 +60,17 @@ it( 'should handle authentication deep links', () => {
 	jest.isolateModules( async () => {
 		const originalProcessPlatform = process.platform;
 		Object.defineProperty( process, 'platform', { value: 'darwin' } );
-		const mockIpcMainEmit = jest.fn();
-		const electron = jest.genMockFromModule( 'electron' ) as typeof import('electron');
-		const { mockedEvents } = mockElectron( {
-			appEvents: [ 'open-url' ],
-			electronMocks: {
-				ipcMain: {
-					...electron.ipcMain,
-					emit: mockIpcMainEmit,
-				},
-			},
-		} );
-		const mockAuthResult = { email: 'mock-email', displayName: 'mock-display-name' };
-		const mockResolvedValue = Promise.resolve( mockAuthResult );
-		const mockHandleAuthCallback = jest.fn( () => mockResolvedValue );
-		jest.doMock( '../lib/oauth', () => ( {
-			setUpAuthCallbackHandler: jest.fn(),
-			handleAuthCallback: mockHandleAuthCallback,
-		} ) );
+
+		const { mockedEvents } = mockElectron();
+		const mockOnOpenUrlCallback = jest.fn();
+		jest.doMock( '../lib/oauth', () => ( { onOpenUrlCallback: mockOnOpenUrlCallback } ) );
+
 		require( '../index' );
 		const { 'open-url': openUrl } = mockedEvents;
 
-		const mockHash = '#access_token=1234&expires_in=1';
-		openUrl( {}, `wpcom-local-dev://auth${ mockHash }` );
-		await mockResolvedValue;
-
-		expect( mockHandleAuthCallback ).toHaveBeenCalledWith( mockHash );
-		expect( mockIpcMainEmit ).toHaveBeenCalledWith( 'auth-callback', null, {
-			token: mockAuthResult,
-		} );
+		const testUrl = 'wpcom-local-dev://auth#test-hash';
+		await openUrl( {}, testUrl );
+		expect( mockOnOpenUrlCallback ).toHaveBeenCalledWith( testUrl );
 
 		Object.defineProperty( process, 'platform', { value: originalProcessPlatform } );
 	} );
@@ -116,42 +78,36 @@ it( 'should handle authentication deep links', () => {
 
 it( 'should setup server files before creating main window', async () => {
 	await jest.isolateModulesAsync( async () => {
-		const { mockedEvents } = mockElectron( { appEvents: [ 'ready' ] } );
-		require( '../index' );
-		const { ready } = mockedEvents;
-
-		// Add a mock function to check that `setupWPServerFiles` is resolved before
-		// creating the main window.
-		const resolveFn = jest.fn();
-		( setupWPServerFiles as jest.Mock ).mockImplementation( async () => {
-			await new Promise( process.nextTick );
-			resolveFn();
+		const { mockedEvents } = mockElectron();
+		const setupSpy = jest.fn();
+		( setupWPServerFiles as jest.Mock ).mockImplementation( () => {
+			setupSpy();
+			return Promise.resolve();
 		} );
 
-		await ready();
+		require( '../index' );
+		await mockedEvents.ready();
 
-		expect( resolveFn ).toHaveBeenCalled();
-		const setupWPServerFilesResolvedOrder = resolveFn.mock.invocationCallOrder[ 0 ];
-		const createMainWindowOrder = ( createMainWindow as jest.Mock ).mock.invocationCallOrder[ 0 ];
-
-		expect( setupWPServerFilesResolvedOrder ).toBeLessThan( createMainWindowOrder );
+		expect( setupSpy ).toHaveBeenCalled();
+		expect( setupSpy.mock.invocationCallOrder[ 0 ] ).toBeLessThan(
+			( createMainWindow as jest.Mock ).mock.invocationCallOrder[ 0 ]
+		);
 	} );
 } );
 
-it( 'should wait app initialization before creating main window via activate event', async () => {
+it( 'should wait for app initialization before handling window events', async () => {
 	await jest.isolateModulesAsync( async () => {
-		const { mockedEvents } = mockElectron( { appEvents: [ 'ready', 'activate' ] } );
-
+		const { mockedEvents } = mockElectron();
 		require( '../index' );
-		const { ready, activate } = mockedEvents;
 
-		await activate();
-		expect( createMainWindow as jest.Mock ).not.toHaveBeenCalled();
+		// Before ready
+		await mockedEvents.activate();
+		expect( createMainWindow ).not.toHaveBeenCalled();
 
-		await ready();
-
-		await activate();
-		expect( createMainWindow as jest.Mock ).toHaveBeenCalled();
+		// After ready
+		await mockedEvents.ready();
+		await mockedEvents.activate();
+		expect( createMainWindow ).toHaveBeenCalled();
 	} );
 } );
 
@@ -162,7 +118,7 @@ it( 'should wait app initialization before creating main window via second-insta
 			isMinimized: jest.fn( () => false ),
 		} );
 
-		const { mockedEvents } = mockElectron( { appEvents: [ 'ready', 'second-instance' ] } );
+		const { mockedEvents } = mockElectron();
 
 		// The "second-instance" event is only invoked on Windows/Linux platforms.
 		// Therefore, we ensure the initialization is performed on one of those


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/dotcom-forge/issues/10215
- Fixes https://github.com/Automattic/dotcom-forge/issues/10258

## Proposed Changes

In https://github.com/Automattic/dotcom-forge/issues/10215, we observed that the `authToken` object in the `appdata-v1.json` file sometimes misses the `id` prop. Even if the TS type previously designated this prop as optional, that's not actually how the code works—we need the WordPress.com user ID for several features that interact with the WP.com APIs.

In this PR, I've addressed this problem by:

1. Adding [zod](https://zod.dev/) as a dependency (a validation library with incredibly good TS support that's successfully being used on Tumblr)
2. Adding a zod schema for the `authToken` object in the user data file. Most properties are _not_ optional.
3. Making `getToken` in `src/lib/oauth.ts` return null if the zod validation fails.

Moreover, I took the opportunity to move the `onOpenUrlCallback` function from `src/index.ts` to `src/lib/oauth.ts`. Given it deals exclusively with OAuth-related logic, it makes more sense for it to live there. I also inlined the logic from `setUpAuthCallbackHandler` into `onOpenUrlCallback`, reducing the number of events being passed around.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Be logged out
2. Log in
3. Ensure that the Assistant works as expected
4. Ensure that connecting sites in the Sync tab works as expected
5. Ensure that the Share tab works as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
