### PR TITLE
Handle zip imports regression

### DIFF
--- a/src/hooks/tests/use-import-export.test.tsx
+++ b/src/hooks/tests/use-import-export.test.tsx
@@ -226,7 +226,7 @@ describe( 'useImportExport hook', () => {
 	} );
 
 	it( 'shows error message when import fails with absolute path error', async () => {
-		( getIpcApi().importSite as jest.Mock ).mockRejectedValue( new Error( 'absolute path error' ) );
+		( getIpcApi().importSite as jest.Mock ).mockRejectedValue( new Error( 'Error: absolute path: /' ) );
 
 		const { result } = renderHook( () => useImportExport(), { wrapper } );
 		const file = { path: 'backup.zip', type: 'application/zip' };
@@ -243,7 +243,7 @@ describe( 'useImportExport hook', () => {
 		expect( getIpcApi().showErrorMessageBox ).toHaveBeenCalledWith( {
 			title: 'Failed importing site',
 			message:
-				'The ZIP archive is incorrect. Try to unpack and pack it again. If this problem persists, please contact support.',
+				'The ZIP archive is invalid. Try to unpack and pack it again. If this problem persists, please contact support.',
 		} );
 	} );
 

--- a/src/hooks/tests/use-import-export.test.tsx
+++ b/src/hooks/tests/use-import-export.test.tsx
@@ -225,8 +225,30 @@ describe( 'useImportExport hook', () => {
 		expect( useSiteDetails().startServer ).toHaveBeenCalledWith( SITE_ID );
 	} );
 
-	it( 'shows error message when import fails', async () => {
-		( getIpcApi().importSite as jest.Mock ).mockRejectedValue( 'error' );
+	it( 'shows error message when import fails with absolute path error', async () => {
+		( getIpcApi().importSite as jest.Mock ).mockRejectedValue( new Error( 'absolute path error' ) );
+
+		const { result } = renderHook( () => useImportExport(), { wrapper } );
+		const file = { path: 'backup.zip', type: 'application/zip' };
+		await act( () => result.current.importFile( file, selectedSite ) );
+
+		expect( result.current.exportState ).toEqual( {} );
+		expect( getIpcApi().importSite ).toHaveBeenCalledWith( {
+			id: SITE_ID,
+			backupFile: {
+				type: 'application/zip',
+				path: 'backup.zip',
+			},
+		} );
+		expect( getIpcApi().showErrorMessageBox ).toHaveBeenCalledWith( {
+			title: 'Failed importing site',
+			message:
+				'The ZIP archive is incorrect. Try to unpack and pack it again. If this problem persists, please contact support.',
+		} );
+	} );
+
+	it( 'shows error message when import fails with other error', async () => {
+		( getIpcApi().importSite as jest.Mock ).mockRejectedValue( new Error( 'generic error' ) );
 
 		const { result } = renderHook( () => useImportExport(), { wrapper } );
 		const file = { path: 'backup.zip', type: 'application/zip' };
@@ -244,7 +266,7 @@ describe( 'useImportExport hook', () => {
 			title: 'Failed importing site',
 			message:
 				'An error occurred while importing the site. Verify the file is a valid Jetpack backup, Local, Playground, .wpress or .sql database file and try again. If this problem persists, please contact support.',
-			error: 'error',
+			error: new Error( 'generic error' ),
 			showOpenLogs: true,
 		} );
 	} );

--- a/src/hooks/tests/use-import-export.test.tsx
+++ b/src/hooks/tests/use-import-export.test.tsx
@@ -226,7 +226,9 @@ describe( 'useImportExport hook', () => {
 	} );
 
 	it( 'shows error message when import fails with absolute path error', async () => {
-		( getIpcApi().importSite as jest.Mock ).mockRejectedValue( new Error( 'Error: absolute path: /' ) );
+		( getIpcApi().importSite as jest.Mock ).mockRejectedValue(
+			new Error( 'Error: absolute path: /' )
+		);
 
 		const { result } = renderHook( () => useImportExport(), { wrapper } );
 		const file = { path: 'backup.zip', type: 'application/zip' };

--- a/src/hooks/use-import-export.tsx
+++ b/src/hooks/use-import-export.tsx
@@ -85,7 +85,7 @@ export const ImportExportProvider = ( { children }: { children: React.ReactNode 
 			} ) );
 
 			const handleImportError = async ( error: unknown ) => {
-				if ( error instanceof Error && error.message.includes( 'absolute path' ) ) {
+				if ( error instanceof Error && error.message.includes( 'Error: absolute path: /' ) ) {
 					await getIpcApi().showErrorMessageBox( {
 						title: __( 'Failed importing site' ),
 						message: __(

--- a/src/hooks/use-import-export.tsx
+++ b/src/hooks/use-import-export.tsx
@@ -89,7 +89,7 @@ export const ImportExportProvider = ( { children }: { children: React.ReactNode 
 					await getIpcApi().showErrorMessageBox( {
 						title: __( 'Failed importing site' ),
 						message: __(
-							'The ZIP archive is incorrect. Try to unpack and pack it again. If this problem persists, please contact support.'
+							'The ZIP archive is invalid. Try to unpack and pack it again. If this problem persists, please contact support.'
 						),
 					} );
 				} else {

--- a/src/hooks/use-import-export.tsx
+++ b/src/hooks/use-import-export.tsx
@@ -84,15 +84,24 @@ export const ImportExportProvider = ( { children }: { children: React.ReactNode 
 				},
 			} ) );
 
-			const handleImportError = async ( error?: unknown ) => {
-				await getIpcApi().showErrorMessageBox( {
-					title: __( 'Failed importing site' ),
-					message: __(
-						'An error occurred while importing the site. Verify the file is a valid Jetpack backup, Local, Playground, .wpress or .sql database file and try again. If this problem persists, please contact support.'
-					),
-					error,
-					showOpenLogs: true,
-				} );
+			const handleImportError = async ( error: unknown ) => {
+				if ( error instanceof Error && error.message.includes( 'absolute path' ) ) {
+					await getIpcApi().showErrorMessageBox( {
+						title: __( 'Failed importing site' ),
+						message: __(
+							'The ZIP archive is incorrect. Try to unpack and pack it again. If this problem persists, please contact support.'
+						),
+					} );
+				} else {
+					await getIpcApi().showErrorMessageBox( {
+						title: __( 'Failed importing site' ),
+						message: __(
+							'An error occurred while importing the site. Verify the file is a valid Jetpack backup, Local, Playground, .wpress or .sql database file and try again. If this problem persists, please contact support.'
+						),
+						error,
+						showOpenLogs: true,
+					} );
+				}
 				setImportState( ( { [ selectedSite.id ]: currentProgress, ...rest } ) => ( {
 					...rest,
 				} ) );
@@ -111,11 +120,6 @@ export const ImportExportProvider = ( { children }: { children: React.ReactNode 
 					id: selectedSite.id,
 					backupFile,
 				} );
-
-				if ( ! importedSite ) {
-					await handleImportError();
-					return;
-				}
 
 				await updateSite( importedSite );
 

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -103,7 +103,7 @@ export async function getInstalledApps( _event: IpcMainInvokeEvent ): Promise< I
 export async function importSite(
 	event: IpcMainInvokeEvent,
 	{ id, backupFile }: { id: string; backupFile: BackupArchiveInfo }
-): Promise< SiteDetails | undefined > {
+): Promise< SiteDetails > {
 	const site = SiteServer.get( id );
 	if ( ! site ) {
 		throw new Error( 'Site not found.' );
@@ -116,9 +116,6 @@ export async function importSite(
 			}
 		};
 		const result = await importBackup( backupFile, site.details, onEvent, defaultImporterOptions );
-		if ( ! result ) {
-			return;
-		}
 		if ( result?.meta?.phpVersion ) {
 			site.details.phpVersion = result.meta.phpVersion;
 		}

--- a/src/lib/import-export/import/import-manager.ts
+++ b/src/lib/import-export/import/import-manager.ts
@@ -50,22 +50,23 @@ export async function importBackup(
 	site: SiteDetails,
 	onEvent: ( data: ImportExportEventData ) => void,
 	options: ImporterOption[]
-): Promise< ImporterResult | undefined > {
+): Promise< ImporterResult > {
+	const backupHandler = BackupHandlerFactory.create( backupFile );
+	if ( ! backupHandler ) {
+		throw new Error( 'No suitable backup handler found for the provided backup file' );
+	}
+
+	const fileList = await backupHandler.listFiles( backupFile );
+	const importer = selectImporter( fileList, '', onEvent, options );
+
+	if ( ! importer ) {
+		throw new Error( 'No suitable importer found for the provided backup contents' );
+	}
+
 	const extractionDirectory = await fsPromises.mkdtemp( path.join( os.tmpdir(), 'studio_backup' ) );
 	let removeBackupListeners;
 	let removeImportListeners;
 	try {
-		const backupHandler = BackupHandlerFactory.create( backupFile );
-		if ( ! backupHandler ) {
-			return;
-		}
-		const fileList = await backupHandler.listFiles( backupFile );
-		const importer = selectImporter( fileList, extractionDirectory, onEvent, options );
-
-		if ( ! importer ) {
-			return;
-		}
-
 		removeBackupListeners = handleEvents( backupHandler, onEvent, BackupExtractEvents );
 		removeImportListeners = handleEvents( importer, onEvent, ImporterEvents );
 		await backupHandler.extractFiles( backupFile, extractionDirectory );

--- a/src/lib/import-export/tests/import/import-manager.test.ts
+++ b/src/lib/import-export/tests/import/import-manager.test.ts
@@ -126,7 +126,7 @@ describe( 'importManager', () => {
 			} );
 		} );
 
-		it( 'should return false if no suitable importer is found', async () => {
+		it( 'should throw error if no suitable importer is found', async () => {
 			const mockValidator: Validator = {
 				canHandle: jest.fn().mockReturnValue( false ),
 				parseBackupContents: jest.fn(),
@@ -137,18 +137,28 @@ describe( 'importManager', () => {
 			};
 			( BackupHandlerFactory.create as jest.Mock ).mockReturnValue( mockBackupHandler );
 
-			const result = await importBackup( mockFile, mockSite, jest.fn(), [
-				{
-					validator: mockValidator,
-					importer: jest.fn(),
-				},
-			] );
+			await expect(
+				importBackup( mockFile, mockSite, jest.fn(), [
+					{
+						validator: mockValidator,
+						importer: jest.fn(),
+					},
+				] )
+			).rejects.toThrow( 'No suitable importer found for the provided backup contents' );
 
-			expect( result ).toBeFalsy();
-			expect( fsPromises.mkdtemp ).toHaveBeenCalledWith( '/tmp/studio_backup' );
-			expect( fsPromises.rm ).toHaveBeenCalledWith( mockExtractDir, {
-				recursive: true,
-			} );
+			expect( fsPromises.mkdtemp ).not.toHaveBeenCalled();
+			expect( fsPromises.rm ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should throw error if no suitable backup handler is found', async () => {
+			( BackupHandlerFactory.create as jest.Mock ).mockReturnValue( null );
+
+			await expect( importBackup( mockFile, mockSite, jest.fn(), [] ) ).rejects.toThrow(
+				'No suitable backup handler found for the provided backup file'
+			);
+
+			expect( fsPromises.mkdtemp ).not.toHaveBeenCalled();
+			expect( fsPromises.rm ).not.toHaveBeenCalled();
 		} );
 	} );
 } );

--- a/src/tests/ipc-handlers.test.ts
+++ b/src/tests/ipc-handlers.test.ts
@@ -194,38 +194,4 @@ describe( 'importSite', () => {
 
 		expect( Sentry.captureException ).toHaveBeenCalledWith( mockError );
 	} );
-
-	it( 'should send import events to renderer process', async () => {
-		const mockSite = {
-			details: {
-				id: 'test-site',
-			},
-		};
-		const mockParentWindow = {
-			webContents: {
-				send: jest.fn(),
-			},
-			isDestroyed: () => false,
-		};
-		( SiteServer.get as jest.Mock ).mockReturnValue( mockSite );
-		( BrowserWindow.fromWebContents as jest.Mock ).mockReturnValue( mockParentWindow );
-
-		await importSite( mockIpcMainInvokeEvent, {
-			id: 'test-site',
-			backupFile: mockBackupFile,
-		} );
-
-		// Get the onEvent callback that was passed to importBackup
-		const onEvent = ( importBackup as jest.Mock ).mock.calls[ 0 ][ 2 ];
-		const mockEventData = { status: 'importing' };
-
-		// Simulate an import event
-		onEvent( mockEventData );
-
-		expect( mockParentWindow.webContents.send ).toHaveBeenCalledWith(
-			'on-import',
-			mockEventData,
-			'test-site'
-		);
-	} );
 } );

--- a/src/tests/ipc-handlers.test.ts
+++ b/src/tests/ipc-handlers.test.ts
@@ -5,13 +5,13 @@ import { shell, IpcMainInvokeEvent, BrowserWindow } from 'electron';
 import fs from 'fs';
 import { normalize } from 'path';
 import * as Sentry from '@sentry/electron/main';
+import { BackupArchiveInfo } from 'src/lib/import-export/import/types';
 import { createSite, startServer, isFullscreen, importSite } from '../ipc-handlers';
 import { isEmptyDir, pathExists } from '../lib/fs-utils';
 import { importBackup, defaultImporterOptions } from '../lib/import-export/import/import-manager';
 import { keepSqliteIntegrationUpdated } from '../lib/sqlite-versions';
 import { getMainWindow } from '../main-window';
 import { SiteServer, createSiteWorkingDirectory } from '../site-server';
-import { BackupArchiveInfo } from 'src/lib/import-export/import/types';
 
 jest.mock( 'fs' );
 jest.mock( 'fs-extra' );

--- a/src/tests/ipc-handlers.test.ts
+++ b/src/tests/ipc-handlers.test.ts
@@ -1,7 +1,7 @@
 /**
  * @jest-environment node
  */
-import { shell, IpcMainInvokeEvent, BrowserWindow } from 'electron';
+import { shell, IpcMainInvokeEvent } from 'electron';
 import fs from 'fs';
 import { normalize } from 'path';
 import * as Sentry from '@sentry/electron/main';

--- a/src/tests/ipc-handlers.test.ts
+++ b/src/tests/ipc-handlers.test.ts
@@ -1,14 +1,17 @@
 /**
  * @jest-environment node
  */
-import { shell, IpcMainInvokeEvent } from 'electron';
+import { shell, IpcMainInvokeEvent, BrowserWindow } from 'electron';
 import fs from 'fs';
 import { normalize } from 'path';
-import { createSite, startServer, isFullscreen } from '../ipc-handlers';
+import * as Sentry from '@sentry/electron/main';
+import { createSite, startServer, isFullscreen, importSite } from '../ipc-handlers';
 import { isEmptyDir, pathExists } from '../lib/fs-utils';
+import { importBackup, defaultImporterOptions } from '../lib/import-export/import/import-manager';
 import { keepSqliteIntegrationUpdated } from '../lib/sqlite-versions';
 import { getMainWindow } from '../main-window';
 import { SiteServer, createSiteWorkingDirectory } from '../site-server';
+import { BackupArchiveInfo } from 'src/lib/import-export/import/types';
 
 jest.mock( 'fs' );
 jest.mock( 'fs-extra' );
@@ -17,6 +20,8 @@ jest.mock( '../site-server' );
 jest.mock( '../lib/sqlite-versions' );
 jest.mock( '../../vendor/wp-now/src/download' );
 jest.mock( '../main-window' );
+jest.mock( '@sentry/electron/main' );
+jest.mock( '../lib/import-export/import/import-manager' );
 
 ( SiteServer.create as jest.Mock ).mockImplementation( ( details ) => ( {
 	start: jest.fn(),
@@ -116,5 +121,111 @@ describe( 'isFullscreen', () => {
 		const result = await isFullscreen( mockIpcMainInvokeEvent );
 
 		expect( result ).toBe( true );
+	} );
+} );
+
+describe( 'importSite', () => {
+	const mockBackupFile: BackupArchiveInfo = {
+		path: '/path/to/backup.zip',
+		type: 'doo',
+	};
+
+	beforeEach( () => {
+		( importBackup as jest.Mock ).mockReset();
+	} );
+
+	it( 'should throw error if site is not found', async () => {
+		( SiteServer.get as jest.Mock ).mockReturnValue( null );
+
+		await expect(
+			importSite( mockIpcMainInvokeEvent, {
+				id: 'non-existent-id',
+				backupFile: mockBackupFile,
+			} )
+		).rejects.toThrow( 'Site not found.' );
+	} );
+
+	it( 'should import backup successfully', async () => {
+		const mockSite = {
+			details: {
+				id: 'test-site',
+				phpVersion: '8.0',
+			},
+			updateSiteDetails: jest.fn(),
+		};
+		( SiteServer.get as jest.Mock ).mockReturnValue( mockSite );
+		( importBackup as jest.Mock ).mockResolvedValue( {
+			meta: {
+				phpVersion: '8.2',
+			},
+		} );
+
+		const result = await importSite( mockIpcMainInvokeEvent, {
+			id: 'test-site',
+			backupFile: mockBackupFile,
+		} );
+
+		expect( importBackup ).toHaveBeenCalledWith(
+			mockBackupFile,
+			mockSite.details,
+			expect.any( Function ),
+			defaultImporterOptions
+		);
+		expect( mockSite.details.phpVersion ).toBe( '8.2' );
+		expect( result ).toBe( mockSite.details );
+	} );
+
+	it( 'should capture exception in Sentry when import fails', async () => {
+		const mockError = new Error( 'Import failed' );
+		const mockSite = {
+			details: {
+				id: 'test-site',
+			},
+		};
+		( SiteServer.get as jest.Mock ).mockReturnValue( mockSite );
+		( importBackup as jest.Mock ).mockRejectedValue( mockError );
+
+		await expect(
+			importSite( mockIpcMainInvokeEvent, {
+				id: 'test-site',
+				backupFile: mockBackupFile,
+			} )
+		).rejects.toThrow( 'Import failed' );
+
+		expect( Sentry.captureException ).toHaveBeenCalledWith( mockError );
+	} );
+
+	it( 'should send import events to renderer process', async () => {
+		const mockSite = {
+			details: {
+				id: 'test-site',
+			},
+		};
+		const mockParentWindow = {
+			webContents: {
+				send: jest.fn(),
+			},
+			isDestroyed: () => false,
+		};
+		( SiteServer.get as jest.Mock ).mockReturnValue( mockSite );
+		( BrowserWindow.fromWebContents as jest.Mock ).mockReturnValue( mockParentWindow );
+
+		await importSite( mockIpcMainInvokeEvent, {
+			id: 'test-site',
+			backupFile: mockBackupFile,
+		} );
+
+		// Get the onEvent callback that was passed to importBackup
+		const onEvent = ( importBackup as jest.Mock ).mock.calls[ 0 ][ 2 ];
+		const mockEventData = { status: 'importing' };
+
+		// Simulate an import event
+		onEvent( mockEventData );
+
+		expect( mockParentWindow.webContents.send ).toHaveBeenCalledWith(
+			'on-import',
+			mockEventData,
+			'test-site'
+		);
 	} );
 } );


### PR DESCRIPTION
## Related issues

- Fixes https://github.com/Automattic/dotcom-forge/issues/10369

## Proposed Changes

- Show a specific error to the user about this issue, and suggesting them to re-package the zip archive
- Change `importBackup()` and `importSite()` to not return undefined and just throw

| Before | After |
|--------|--------|
| <img width="300" alt="Screenshot 2025-02-03 at 19 52 33" src="https://github.com/user-attachments/assets/8693ba74-79b3-43e5-bbe7-92e7ef46161a" /> | <img width="296" alt="Screenshot 2025-02-03 at 19 51 26" src="https://github.com/user-attachments/assets/ca56554d-abf3-4729-af27-27abb07c0c00" /> |


## Testing Instructions

- Try importing a zip file which has absolute paths in it
- Before: Error would show as in the linked issue
- After: Specific error shown

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?
