### PR TITLE
Preview Sites: Add default name with sequence number when a site is created

### DIFF
--- a/src/hooks/use-archive-site.ts
+++ b/src/hooks/use-archive-site.ts
@@ -12,7 +12,7 @@ import { useSiteDetails } from './use-site-details';
 import { SnapshotStatus, SnapshotStatusResponse, useSnapshots } from './use-snapshots';
 
 export function useArchiveSite() {
-	const { uploadingSites, setUploadingSites } = useSiteDetails();
+	const { uploadingSites, setUploadingSites, selectedSite } = useSiteDetails();
 	const { snapshots, addSnapshot, updateSnapshot, fetchSnapshotUsage } = useSnapshots();
 	const isUploadingSiteId = useCallback(
 		( localSiteId: string ) => uploadingSites[ localSiteId ] || false,
@@ -62,6 +62,14 @@ export function useArchiveSite() {
 			clearInterval( intervalId );
 		};
 	}, [ client, snapshots, updateSnapshot ] );
+
+	const getNextSequenceNumber = ( siteId: string, snapshots: Array< Snapshot > ): number => {
+		const siteSnapshots = snapshots.filter( ( s ) => s.localSiteId === siteId );
+		const existingSequences = siteSnapshots
+			.map( ( s ) => s.sequence ?? 0 )
+			.filter( ( n ) => ! isNaN( n ) );
+		return existingSequences.length > 0 ? Math.max( ...existingSequences ) + 1 : 1;
+	};
 
 	const errorMessages = useArchiveErrorMessages();
 	const archiveSite = useCallback(
@@ -134,12 +142,17 @@ export function useArchiveSite() {
 						apiNamespace: 'wpcom/v2',
 						formData,
 					} );
+
+					const nextSequence = getNextSequenceNumber( siteId, snapshots );
+
 					addSnapshot( {
 						url: response.domain_name,
 						atomicSiteId: response.atomic_site_id,
 						localSiteId: siteId,
 						date: new Date().getTime(),
 						isLoading: true,
+						name: `${ selectedSite?.name } ${ __( 'Preview' ) } ${ nextSequence }`,
+						sequence: nextSequence,
 					} );
 				} catch ( error ) {
 					if ( isWpcomNetworkError( error ) ) {
@@ -180,6 +193,8 @@ export function useArchiveSite() {
 			fetchSnapshotUsage,
 			setUploadingSites,
 			connectedSites,
+			selectedSite,
+			snapshots,
 		]
 	);
 	const isAnySiteArchiving = useMemo( () => {

--- a/src/hooks/use-archive-site.ts
+++ b/src/hooks/use-archive-site.ts
@@ -151,7 +151,12 @@ export function useArchiveSite() {
 						localSiteId: siteId,
 						date: new Date().getTime(),
 						isLoading: true,
-						name: `${ selectedSite?.name } ${ __( 'Preview' ) } ${ nextSequence }`,
+						name: sprintf(
+							/* translators: 1: Site name 2: Sequence number  (e.g. "My Site Name Preview 1") */
+							__( '%1$s Preview %2$d' ),
+							selectedSite?.name,
+							nextSequence
+						),
 						sequence: nextSequence,
 					} );
 				} catch ( error ) {

--- a/src/ipc-types.d.ts
+++ b/src/ipc-types.d.ts
@@ -47,6 +47,8 @@ interface Snapshot {
 	date: number;
 	isLoading?: boolean;
 	isDeleting?: boolean;
+	name?: string;
+	sequence?: number;
 }
 
 type InstalledApps = {

--- a/src/modules/preview-site/components/preview-site-row.tsx
+++ b/src/modules/preview-site/components/preview-site-row.tsx
@@ -84,7 +84,7 @@ export function PreviewSiteRow( { snapshot, selectedSite }: PreviewSiteRowProps 
 				<div className="w-[51%]">
 					<div className="flex items-center">
 						<div className="text-[13px] leading-5 line-clamp-1 break-all">
-							{ selectedSite.name }
+							{ snapshot.name || selectedSite.name }
 						</div>
 					</div>
 					<Button

--- a/src/modules/preview-site/components/preview-site-row.tsx
+++ b/src/modules/preview-site/components/preview-site-row.tsx
@@ -84,7 +84,8 @@ export function PreviewSiteRow( { snapshot, selectedSite }: PreviewSiteRowProps 
 				<div className="w-[51%]">
 					<div className="flex items-center">
 						<div className="text-[13px] leading-5 line-clamp-1 break-all">
-							{ snapshot.name || selectedSite.name }
+							{ /* translators: %s: Site name (e.g. "My Site Preview") */ }
+							{ snapshot.name || sprintf( __( '%s Preview' ), selectedSite.name ) }
 						</div>
 					</div>
 					<Button


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Resolves https://github.com/Automattic/dotcom-forge/issues/10367.
- Related to https://github.com/Automattic/dotcom-forge/issues/10353.

## Proposed Changes

- add two new key-value pairs to the snapshots array in `appdata-v1.json`:
  - `name` (string)
  - `sequence` (number)
- set a default name for each newly-created Preview site in the following form: `{Local site name} + Preview + {sequence number}`
- display the default Preview site name in the list of Preview sites (if it is available); otherwise, display the local site name

![Markup on 2025-02-03 at 13:11:05](https://github.com/user-attachments/assets/76d070ce-1b6d-46f5-b0b5-62a21e21e27b)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Before applying this PR, build the Studio app with the current `trunk` using `STUDIO_QUICK_DEPLOYS=true npm start`.
2. Create at least one Preview site.
3. Check out this PR's branch and build the Studio app (again with `STUDIO_QUICK_DEPLOYS=true npm start`).
4. Create a couple more Preview sites.
5. The Preview site that was created on `trunk` should display on the Previews tab with the local site name.
6. Newly created Preview sites should have default names in the following form: `{Local site name} + Preview + {sequence number}`.
7. Try deleting / creating new Preview sites (even on other local sites) and make sure the default names are generated correctly.
8. Content of the `snapshots` array in the `appdata-v1.json` file should be correct.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
