### PR TITLE
Use `path.posix.join` for relevant paths

### DIFF
--- a/vendor/wp-now/src/execute-wp-cli.ts
+++ b/vendor/wp-now/src/execute-wp-cli.ts
@@ -97,14 +97,14 @@ export async function executeWPCli(
 			$_SERVER['argv'][0] = '${ wpCliPath }';
 
 			require( '${ wpCliPath }' );`,
-		[ path.join( PLAYGROUND_INTERNAL_SHARED_FOLDER, 'ca-bundle.crt' ) ]:
+		[ path.posix.join( PLAYGROUND_INTERNAL_SHARED_FOLDER, 'ca-bundle.crt' ) ]:
 			rootCertificates.join( '\n' ),
 	};
 
 	await writeFiles( php, '/', createFiles );
 
 	await setPhpIniEntries( php, {
-		'openssl.cafile': path.join( PLAYGROUND_INTERNAL_SHARED_FOLDER, 'ca-bundle.crt' ),
+		'openssl.cafile': path.posix.join( PLAYGROUND_INTERNAL_SHARED_FOLDER, 'ca-bundle.crt' ),
 	} );
 	try {
 		php.mkdir( sqliteCommandPath );

--- a/vendor/wp-now/src/wp-now.ts
+++ b/vendor/wp-now/src/wp-now.ts
@@ -156,7 +156,7 @@ async function getPHPInstance(
 		memory_limit: '256M',
 		disable_functions: '',
 		allow_url_fopen: '1',
-		'openssl.cafile': path.join( PLAYGROUND_INTERNAL_SHARED_FOLDER, 'ca-bundle.crt' ),
+		'openssl.cafile': path.posix.join( PLAYGROUND_INTERNAL_SHARED_FOLDER, 'ca-bundle.crt' ),
 	} );
 
 	return { php, runtimeId: id };
@@ -167,7 +167,7 @@ async function prepareDocumentRoot( php: PHP, options: WPNowOptions ) {
 	php.chdir( options.documentRoot );
 	php.writeFile( `${ options.documentRoot }/index.php`, `<?php echo 'Hello wp-now!';` );
 	php.writeFile(
-		path.join( PLAYGROUND_INTERNAL_SHARED_FOLDER, 'ca-bundle.crt' ),
+		path.posix.join( PLAYGROUND_INTERNAL_SHARED_FOLDER, 'ca-bundle.crt' ),
 		rootCertificates.join( '\n' )
 	);
 }
@@ -472,7 +472,7 @@ async function mountInternalMuPlugins( php: PHP ) {
 	php.mkdir( PLAYGROUND_INTERNAL_MU_PLUGINS_FOLDER );
 
 	php.writeFile(
-		path.join( PLAYGROUND_INTERNAL_MU_PLUGINS_FOLDER, '0-allowed-redirect-hosts.php' ),
+		path.posix.join( PLAYGROUND_INTERNAL_MU_PLUGINS_FOLDER, '0-allowed-redirect-hosts.php' ),
 		`<?php
 	// Needed because gethostbyname( <host> ) returns
 	// a private network IP address for some reason.
@@ -491,7 +491,7 @@ async function mountInternalMuPlugins( php: PHP ) {
 	);
 
 	php.writeFile(
-		path.join( PLAYGROUND_INTERNAL_MU_PLUGINS_FOLDER, '0-thumbnails.php' ),
+		path.posix.join( PLAYGROUND_INTERNAL_MU_PLUGINS_FOLDER, '0-thumbnails.php' ),
 		`<?php
 		// Facilitates the taking of screenshots to be used as thumbnails.
 		if ( isset( $_GET['studio-hide-adminbar'] ) ) {
@@ -501,7 +501,7 @@ async function mountInternalMuPlugins( php: PHP ) {
 	);
 
 	php.writeFile(
-		path.join( PLAYGROUND_INTERNAL_MU_PLUGINS_FOLDER, '0-32bit-integer-warnings.php' ),
+		path.posix.join( PLAYGROUND_INTERNAL_MU_PLUGINS_FOLDER, '0-32bit-integer-warnings.php' ),
 		`<?php
 /**
  * This is a temporary workaround to hide the 32bit integer warnings that
@@ -520,7 +520,7 @@ set_error_handler(function($severity, $message, $file, $line) {
 	);
 
 	php.writeFile(
-		path.join( PLAYGROUND_INTERNAL_MU_PLUGINS_FOLDER, '0-check-theme-availability.php' ),
+		path.posix.join( PLAYGROUND_INTERNAL_MU_PLUGINS_FOLDER, '0-check-theme-availability.php' ),
 		`<?php
 	function check_current_theme_availability() {
 			// Get the current theme's directory
@@ -548,7 +548,7 @@ set_error_handler(function($severity, $message, $file, $line) {
 	);
 
 	php.writeFile(
-		path.join( PLAYGROUND_INTERNAL_MU_PLUGINS_FOLDER, '0-permalinks.php' ),
+		path.posix.join( PLAYGROUND_INTERNAL_MU_PLUGINS_FOLDER, '0-permalinks.php' ),
 		`<?php
 			// Support permalinks without "index.php"
 			add_filter( 'got_url_rewrite', '__return_true' );
@@ -556,7 +556,7 @@ set_error_handler(function($severity, $message, $file, $line) {
 	);
 
 	php.writeFile(
-		path.join( PLAYGROUND_INTERNAL_MU_PLUGINS_FOLDER, '0-sqlite-command.php' ),
+		path.posix.join( PLAYGROUND_INTERNAL_MU_PLUGINS_FOLDER, '0-sqlite-command.php' ),
 		`<?php
 			add_filter( 'sqlite_command_sqlite_plugin_directories', function( $directories ) {
 				$directories[] = ${ phpVar( SQLITE_PLUGIN_FOLDER ) };
@@ -566,7 +566,7 @@ set_error_handler(function($severity, $message, $file, $line) {
 	);
 
 	php.writeFile(
-		path.join( PLAYGROUND_INTERNAL_MU_PLUGINS_FOLDER, '0-deactivate-jetpack-modules.php' ),
+		path.posix.join( PLAYGROUND_INTERNAL_MU_PLUGINS_FOLDER, '0-deactivate-jetpack-modules.php' ),
 		`<?php
 			// Disable Jetpack Protect 2FA for local auto-login purpose
 			add_action( 'jetpack_active_modules', 'jetpack_deactivate_modules' );
@@ -580,7 +580,7 @@ set_error_handler(function($severity, $message, $file, $line) {
 	);
 
 	php.writeFile(
-		path.join( PLAYGROUND_INTERNAL_MU_PLUGINS_FOLDER, '0-wp-config-constants-polyfill.php' ),
+		path.posix.join( PLAYGROUND_INTERNAL_MU_PLUGINS_FOLDER, '0-wp-config-constants-polyfill.php' ),
 		`<?php
 		// Define database constants if not already defined. It fixes the error
 		// for imported sites that don't have those defined e.g. WP Cloud and
@@ -718,7 +718,7 @@ export async function moveDatabasesInSitu( projectPath: string ) {
  */
 function applyOverrideUmaskWorkaround( php: PHP ) {
 	php.writeFile(
-		path.join( PLAYGROUND_INTERNAL_PRELOAD_PATH, 'override-umask-workaround.php' ),
+		path.posix.join( PLAYGROUND_INTERNAL_PRELOAD_PATH, 'override-umask-workaround.php' ),
 		'<?php umask(0022);'
 	);
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/dotcom-forge/issues/10389

## Proposed Changes

This PR fixes a regression from https://github.com/Automattic/studio/pull/845. In that PR, we moved all mu-plugins but the SQLite one to be mounted in Playground's internal mu-plugins directory to give back more control to users over the regular mu-plugins directory.

The problem is that we use `path.join` for the paths passed to `php.writeFile`. The `php.writeFile` seems to expect Unix-style paths, but `path.join` is platform-aware, meaning we get Windows-style paths on Windows.

This PR fixes that problem by using `path.posix.join` instead.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Ensure that starting a server works as expected on Windows

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
