### PR TITLE
Add back `0-dns-functions.php` mu-plugin

### DIFF
--- a/vendor/wp-now/src/wp-now.ts
+++ b/vendor/wp-now/src/wp-now.ts
@@ -550,14 +550,9 @@ set_error_handler(function($severity, $message, $file, $line) {
 	php.writeFile(
 		path.join( PLAYGROUND_INTERNAL_MU_PLUGINS_FOLDER, '0-dns-functions.php' ),
 		`<?php
-		// Polyfill for DNS functions/features which are not currently supported by @php-wasm/node.
+		// Polyfill for DNS features which are not currently supported by @php-wasm/node.
 		// See https://github.com/WordPress/wordpress-playground/issues/1042
 		// These specific features are polyfilled so the Jetpack plugin loads correctly, but others should be added as needed.
-		if ( ! function_exists( 'dns_get_record' ) ) {
-			function dns_get_record() {
-				return array();
-			}
-		}
 		if ( ! defined( 'DNS_NS' ) ) {
 			define( 'DNS_NS', 2 );
 		}

--- a/vendor/wp-now/src/wp-now.ts
+++ b/vendor/wp-now/src/wp-now.ts
@@ -544,7 +544,24 @@ set_error_handler(function($severity, $message, $file, $line) {
 			}
 	}
 	add_action('after_setup_theme', 'check_current_theme_availability');
-`
+	`
+	);
+
+	php.writeFile(
+		path.join( PLAYGROUND_INTERNAL_MU_PLUGINS_FOLDER, '0-dns-functions.php' ),
+		`<?php
+		// Polyfill for DNS functions/features which are not currently supported by @php-wasm/node.
+		// See https://github.com/WordPress/wordpress-playground/issues/1042
+		// These specific features are polyfilled so the Jetpack plugin loads correctly, but others should be added as needed.
+		if ( ! function_exists( 'dns_get_record' ) ) {
+			function dns_get_record() {
+				return array();
+			}
+		}
+		if ( ! defined( 'DNS_NS' ) ) {
+			define( 'DNS_NS', 2 );
+		}
+	`
 	);
 
 	php.writeFile(


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/dotcom-forge/issues/10394

## Proposed Changes

Fixes a regression from https://github.com/Automattic/studio/pull/845 where the `0-dns-functions.php` mu-plugin disappeared. This plugin was introduced in https://github.com/Automattic/dotcom-forge/issues/99 and fixed an issue where Jetpack throws a fatal error in Studio because PHP-WASM doesn't define the `dns_get_record` function and the `DNS_NS` constant.

Excluding this plugin might have been intentional by @bgrgicak since I see that https://github.com/WordPress/wordpress-playground/pull/1067 added polyfills for DNS functions directly in Playground. However, we still need the `DNS_NS` constant…

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Import a Jetpack backup (pulling a site in the Sync tab also works)
2. Ensure that you can access wp-admin of the site

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
