### PR TITLE
Pass extractionDirectory to select importer

### DIFF
--- a/src/lib/import-export/import/import-manager.ts
+++ b/src/lib/import-export/import/import-manager.ts
@@ -56,14 +56,14 @@ export async function importBackup(
 		throw new Error( 'No suitable backup handler found for the provided backup file' );
 	}
 
+	const extractionDirectory = await fsPromises.mkdtemp( path.join( os.tmpdir(), 'studio_backup' ) );
 	const fileList = await backupHandler.listFiles( backupFile );
-	const importer = selectImporter( fileList, '', onEvent, options );
+	const importer = selectImporter( fileList, extractionDirectory, onEvent, options );
 
 	if ( ! importer ) {
 		throw new Error( 'No suitable importer found for the provided backup contents' );
 	}
 
-	const extractionDirectory = await fsPromises.mkdtemp( path.join( os.tmpdir(), 'studio_backup' ) );
 	let removeBackupListeners;
 	let removeImportListeners;
 	try {

--- a/src/lib/import-export/tests/import/import-manager.test.ts
+++ b/src/lib/import-export/tests/import/import-manager.test.ts
@@ -146,7 +146,7 @@ describe( 'importManager', () => {
 				] )
 			).rejects.toThrow( 'No suitable importer found for the provided backup contents' );
 
-			expect( fsPromises.mkdtemp ).not.toHaveBeenCalled();
+			expect( fsPromises.mkdtemp ).toHaveBeenCalled();
 			expect( fsPromises.rm ).not.toHaveBeenCalled();
 		} );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes p1738682918275369/1738681657.150269-slack-C04GESRBWKW

## Proposed Changes

- Fix imports. A regression added on https://github.com/Automattic/studio/pull/874 where we passed an empty string as extraction directory.

Hat tip to @fredrikekelund for finding the error.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run `npm start`
- Try to import any backup, like a Jetpack backup or pull a site in Mac or Windows
- Observe the import works fine


**Before**
<img width="1012" alt="Screenshot 2025-02-04 at 15 45 25" src="https://github.com/user-attachments/assets/7adbe6d3-f7d9-47f0-a032-9f25519e9c5d" />



**After**
<img width="1012" alt="Screenshot 2025-02-04 at 15 50 01" src="https://github.com/user-attachments/assets/e1cc4ad7-b3a9-4a65-a428-607e001db36e" />



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?