### PR TITLE
Use path.posix.join for 0-dns-functions.php

### DIFF
--- a/vendor/wp-now/src/wp-now.ts
+++ b/vendor/wp-now/src/wp-now.ts
@@ -548,7 +548,7 @@ set_error_handler(function($severity, $message, $file, $line) {
 	);
 
 	php.writeFile(
-		path.join( PLAYGROUND_INTERNAL_MU_PLUGINS_FOLDER, '0-dns-functions.php' ),
+		path.posix.join( PLAYGROUND_INTERNAL_MU_PLUGINS_FOLDER, '0-dns-functions.php' ),
 		`<?php
 		// Polyfill for DNS features which are not currently supported by @php-wasm/node.
 		// See https://github.com/WordPress/wordpress-playground/issues/1042


### PR DESCRIPTION
## Related issues

- Fixes p1738684909079949/1738681657.150269-slack-C04GESRBWKW

## Proposed Changes

The php.writeFile expects Unix-style paths, but path.join is platform-aware, meaning we get Windows-style paths on Windows.
This PR fixes that problem by using `path.posix.join` instead.



## Testing Instructions
Try to create new website on Windows, it should be successful now (before had error).
Also visual review should suffice, since we use `path.posix.join` in all other places for `php.writeFile`