### PR TITLE
Add .cursor folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,4 @@ test-results
 
 # Editor config files
 .cursorrules
+.cursor/


### PR DESCRIPTION
Ignoring the .cursor folder for now allows us to experiment with the latest rule-related changes:
[Cursor AI Rules Documentation](https://docs.cursor.com/context/rules-for-ai)