### PR TITLE
fix fastfile s3 upload call

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -95,7 +95,7 @@ lane :distribute_release_build do |_options|
   )
 end
 
-def upload_to_s3(bucket:, key:, file:, if_exists:, auto_prefix: false, dry_run: DRY_RUN)
+def aws_upload_to_s3(bucket:, key:, file:, if_exists:, auto_prefix: false, dry_run: DRY_RUN)
   if dry_run
     UI.message("[DRY RUN] Would upload file: #{file}")
     UI.message("           to S3 bucket: #{bucket}")
@@ -104,7 +104,7 @@ def upload_to_s3(bucket:, key:, file:, if_exists:, auto_prefix: false, dry_run: 
     return true
   end
 
-  aws_s3_upload(
+  upload_to_s3(
     bucket:,
     key:,
     file:,
@@ -191,7 +191,7 @@ def distribute_builds(
   bucket_name = 'a8c-apps-public-artifacts'
 
   builds.each_value do |build|
-    upload_to_s3(
+    aws_upload_to_s3(
       bucket: bucket_name,
       key: "#{bucket_folder}/#{build[:filename]}",
       file: build[:binary_path],
@@ -201,7 +201,7 @@ def distribute_builds(
   end
 
   manifest_name = 'releases.json'
-  upload_to_s3(
+  aws_upload_to_s3(
     bucket: bucket_name,
     key: "#{bucket_folder}/#{manifest_name}",
     file: File.join(BUILDS_FOLDER, manifest_name),
@@ -218,7 +218,7 @@ def distribute_builds(
       filename = assemble_filename.call(build, 'latest')
       key = "#{bucket_folder}/#{filename}"
 
-      upload_to_s3(
+      aws_upload_to_s3(
         bucket: bucket_name,
         key:,
         file: build[:binary_path],


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- The dev builds are broken https://buildkite.com/automattic/studio/builds/4152#0194d5e4-3ffe-40f9-8700-af3822f65bc1

## Proposed Changes

- Fix the aws call
## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Dry run using
```bash
DRY_RUN=true BUILDKITE_BUILD_NUMBER=test-build bundle exec fastlane distribute_dev_build
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
