### PR TITLE
Ensure that staging sites display a `Staging` sticker from the moment they are created

### DIFF
--- a/src/hooks/sync-sites/use-listen-deep-link-connection.ts
+++ b/src/hooks/sync-sites/use-listen-deep-link-connection.ts
@@ -30,7 +30,8 @@ export function useListenDeepLinkConnection( {
 				}
 				const newConnectedSite = transformSingleSiteResponse(
 					newConnectedSiteResponse,
-					'already-connected'
+					'already-connected',
+					false
 				);
 				await connectSite( newConnectedSite, studioSiteId );
 				if ( selectedTab !== 'sync' ) {

--- a/src/hooks/tests/reconcile-connected-sites.test.ts
+++ b/src/hooks/tests/reconcile-connected-sites.test.ts
@@ -2,7 +2,7 @@ import { reconcileConnectedSites } from '../use-fetch-wpcom-sites/reconcile-conn
 import type { SyncSite } from '../use-fetch-wpcom-sites/types';
 
 describe( 'reconcileConnectedSites', () => {
-	test( 'should update name, url, syncSupport properties', () => {
+	test( 'should update relevant properties', () => {
 		const connectedSites: SyncSite[] = [
 			{
 				id: 1,
@@ -16,12 +16,12 @@ describe( 'reconcileConnectedSites', () => {
 				lastPushTimestamp: null,
 			},
 		];
-		const originalSitesFromWpCom: SyncSite[] = [
+		const freshWpComSites: SyncSite[] = [
 			{
 				id: 1,
 				stagingSiteIds: [],
 				localSiteId: 'local-site-id',
-				isStaging: false,
+				isStaging: true,
 				name: 'site1-updated',
 				url: 'site1-updated.com',
 				syncSupport: 'unsupported',
@@ -29,8 +29,8 @@ describe( 'reconcileConnectedSites', () => {
 				lastPushTimestamp: null,
 			},
 		];
-		const result = reconcileConnectedSites( connectedSites, originalSitesFromWpCom );
-		expect( result.updatedConnectedSites ).toEqual( [ originalSitesFromWpCom[ 0 ] ] );
+		const result = reconcileConnectedSites( connectedSites, freshWpComSites );
+		expect( result.updatedConnectedSites ).toEqual( [ freshWpComSites[ 0 ] ] );
 	} );
 
 	test( 'should add staging site, if it was added in wordpress.com', () => {
@@ -47,7 +47,7 @@ describe( 'reconcileConnectedSites', () => {
 				lastPushTimestamp: null,
 			},
 		];
-		const originalSitesFromWpCom: SyncSite[] = [
+		const freshWpComSites: SyncSite[] = [
 			{
 				id: 1,
 				stagingSiteIds: [ 2 ],
@@ -71,10 +71,10 @@ describe( 'reconcileConnectedSites', () => {
 				lastPushTimestamp: null,
 			},
 		];
-		const result = reconcileConnectedSites( connectedSites, originalSitesFromWpCom );
+		const result = reconcileConnectedSites( connectedSites, freshWpComSites );
 		expect( result.stagingSitesToAdd ).toEqual( [
 			{
-				...originalSitesFromWpCom[ 1 ],
+				...freshWpComSites[ 1 ],
 				syncSupport: 'already-connected',
 			},
 		] );
@@ -106,7 +106,7 @@ describe( 'reconcileConnectedSites', () => {
 				lastPushTimestamp: null,
 			},
 		];
-		const originalSitesFromWpCom: SyncSite[] = [
+		const freshWpComSites: SyncSite[] = [
 			{
 				id: 1,
 				stagingSiteIds: [],
@@ -119,7 +119,7 @@ describe( 'reconcileConnectedSites', () => {
 				lastPushTimestamp: null,
 			},
 		];
-		const result = reconcileConnectedSites( connectedSites, originalSitesFromWpCom );
+		const result = reconcileConnectedSites( connectedSites, freshWpComSites );
 		expect( result.stagingSitesToDelete ).toEqual( [ { id: 2, localSiteId: 'local-site-id' } ] );
 		expect( result.stagingSitesToAdd ).toEqual( [] );
 	} );
@@ -149,7 +149,7 @@ describe( 'reconcileConnectedSites', () => {
 				lastPushTimestamp: null,
 			},
 		];
-		const originalSitesFromWpCom: SyncSite[] = [
+		const freshWpComSites: SyncSite[] = [
 			{
 				id: 1,
 				stagingSiteIds: [ 3 ],
@@ -173,11 +173,11 @@ describe( 'reconcileConnectedSites', () => {
 				lastPushTimestamp: null,
 			},
 		];
-		const result = reconcileConnectedSites( connectedSites, originalSitesFromWpCom );
+		const result = reconcileConnectedSites( connectedSites, freshWpComSites );
 		expect( result.stagingSitesToDelete ).toEqual( [ { id: 2, localSiteId: 'local-site-id' } ] );
 		expect( result.stagingSitesToAdd ).toEqual( [
 			{
-				...originalSitesFromWpCom[ 1 ],
+				...freshWpComSites[ 1 ],
 				syncSupport: 'already-connected',
 			},
 		] );
@@ -208,7 +208,7 @@ describe( 'reconcileConnectedSites', () => {
 				lastPushTimestamp: null,
 			},
 		];
-		const originalSitesFromWpCom: SyncSite[] = [
+		const freshWpComSites: SyncSite[] = [
 			{
 				id: 1,
 				stagingSiteIds: [ 2 ],
@@ -232,7 +232,7 @@ describe( 'reconcileConnectedSites', () => {
 				lastPushTimestamp: null,
 			},
 		];
-		const result = reconcileConnectedSites( connectedSites, originalSitesFromWpCom );
+		const result = reconcileConnectedSites( connectedSites, freshWpComSites );
 		expect( result.stagingSitesToDelete ).toEqual( [] );
 		expect( result.stagingSitesToAdd ).toEqual( [] );
 	} );
@@ -262,7 +262,7 @@ describe( 'reconcileConnectedSites', () => {
 				lastPushTimestamp: null,
 			},
 		];
-		const originalSitesFromWpCom: SyncSite[] = [
+		const freshWpComSites: SyncSite[] = [
 			{
 				id: 1,
 				stagingSiteIds: [ 2 ],
@@ -308,25 +308,25 @@ describe( 'reconcileConnectedSites', () => {
 				lastPushTimestamp: null,
 			},
 		];
-		const result = reconcileConnectedSites( connectedSites, originalSitesFromWpCom );
+		const result = reconcileConnectedSites( connectedSites, freshWpComSites );
 		expect( result.stagingSitesToAdd ).toEqual( [
 			{
-				...originalSitesFromWpCom[ 2 ],
+				...freshWpComSites[ 2 ],
 				syncSupport: 'already-connected',
 			},
 			{
-				...originalSitesFromWpCom[ 3 ],
+				...freshWpComSites[ 3 ],
 				syncSupport: 'already-connected',
 			},
 		] );
 		expect( result.stagingSitesToDelete ).toEqual( [] );
 		expect( result.updatedConnectedSites ).toEqual( [
 			{
-				...originalSitesFromWpCom[ 0 ],
+				...freshWpComSites[ 0 ],
 				syncSupport: 'already-connected',
 			},
 			{
-				...originalSitesFromWpCom[ 1 ],
+				...freshWpComSites[ 1 ],
 				syncSupport: 'already-connected',
 			},
 		] );
@@ -378,7 +378,7 @@ describe( 'reconcileConnectedSites', () => {
 				lastPushTimestamp: null,
 			},
 		];
-		const originalSitesFromWpCom: SyncSite[] = [
+		const freshWpComSites: SyncSite[] = [
 			{
 				id: 1,
 				stagingSiteIds: [],
@@ -402,14 +402,14 @@ describe( 'reconcileConnectedSites', () => {
 				lastPushTimestamp: null,
 			},
 		];
-		const result = reconcileConnectedSites( connectedSites, originalSitesFromWpCom );
+		const result = reconcileConnectedSites( connectedSites, freshWpComSites );
 		expect( result.updatedConnectedSites ).toEqual( [
 			{
-				...originalSitesFromWpCom[ 0 ],
+				...freshWpComSites[ 0 ],
 				syncSupport: 'already-connected',
 			},
 			{
-				...originalSitesFromWpCom[ 1 ],
+				...freshWpComSites[ 1 ],
 				syncSupport: 'already-connected',
 			},
 			{

--- a/src/hooks/use-fetch-wpcom-sites/index.tsx
+++ b/src/hooks/use-fetch-wpcom-sites/index.tsx
@@ -9,7 +9,6 @@ import type { SyncSite, SyncSupport } from './types';
 type SitesEndpointSite = {
 	ID: number;
 	is_wpcom_atomic: boolean;
-	is_wpcom_staging_site: boolean;
 	name: string;
 	URL: string;
 	jetpack?: boolean;
@@ -67,14 +66,15 @@ function getSyncSupport( site: SitesEndpointSite, connectedSiteIds: number[] ): 
 
 export function transformSingleSiteResponse(
 	site: SitesEndpointSite,
-	syncSupport: SyncSupport
+	syncSupport: SyncSupport,
+	isStaging: boolean
 ): SyncSite {
 	return {
 		id: site.ID,
 		localSiteId: '',
 		name: site.name,
 		url: site.URL,
-		isStaging: site.is_wpcom_staging_site,
+		isStaging,
 		stagingSiteIds: site.options?.wpcom_staging_blog_ids ?? [],
 		syncSupport,
 		lastPullTimestamp: null,
@@ -82,7 +82,7 @@ export function transformSingleSiteResponse(
 	};
 }
 
-function transformSiteResponse(
+function transformSitesResponse(
 	sites: SitesEndpointSite[],
 	connectedSiteIds: number[]
 ): SyncSite[] {
@@ -91,7 +91,12 @@ function transformSiteResponse(
 			return acc;
 		}
 
-		acc.push( transformSingleSiteResponse( site, getSyncSupport( site, connectedSiteIds ) ) );
+		const syncSupport = getSyncSupport( site, connectedSiteIds );
+		// The API returns the wrong value for the `is_wpcom_staging_site` prop while staging sites
+		// are being created. Hence the check in other sites' `wpcom_staging_blog_ids` arrays.
+		const isStaging = sites.some( ( s ) => s.options?.wpcom_staging_blog_ids?.includes( site.ID ) );
+
+		acc.push( transformSingleSiteResponse( site, syncSupport, isStaging ) );
 
 		return acc;
 	}, [] );
@@ -132,15 +137,14 @@ export const useFetchWpComSites = ( connectedSiteIdsOnlyForSelectedSite: number[
 					path: `/me/sites`,
 				},
 				{
-					fields:
-						'name,ID,URL,plan,is_wpcom_staging_site,is_wpcom_atomic,options,jetpack,is_deleted',
+					fields: 'name,ID,URL,plan,is_wpcom_atomic,options,jetpack,is_deleted',
 					filter: 'atomic,wpcom',
 					options: 'created_at,wpcom_staging_blog_ids',
 					site_activity: 'active',
 				}
 			);
 
-			const syncSites = transformSiteResponse(
+			const syncSites = transformSitesResponse(
 				response.sites,
 				allConnectedSites.map( ( { id } ) => id )
 			);
@@ -186,7 +190,7 @@ export const useFetchWpComSites = ( connectedSiteIdsOnlyForSelectedSite: number[
 	}, [ fetchSites ] );
 
 	const syncSitesWithSyncSupportForSelectedSite = useMemo(
-		() => transformSiteResponse( rawSyncSites, memoizedConnectedSiteIds ),
+		() => transformSitesResponse( rawSyncSites, memoizedConnectedSiteIds ),
 		[ rawSyncSites, memoizedConnectedSiteIds ]
 	);
 

--- a/src/hooks/use-fetch-wpcom-sites/reconcile-connected-sites.tsx
+++ b/src/hooks/use-fetch-wpcom-sites/reconcile-connected-sites.tsx
@@ -36,6 +36,7 @@ export const reconcileConnectedSites = (
 			url: site.url,
 			syncSupport: site.syncSupport,
 			stagingSiteIds: site.stagingSiteIds,
+			isStaging: site.isStaging,
 		};
 	}, [] );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/dotcom-forge/issues/10308

## Proposed Changes

As reported in https://github.com/Automattic/dotcom-forge/issues/10308, newly created staging sites display a `Production` sticker in the Sync tab. This happens because the `/sites` API endpoint returns the wrong value for the `is_wpcom_staging_site` prop until the site setup is completed. The problem was also made worse by the `reconcileConnectedSites` function not refreshing the value for `isStaging`.

This PR changes the logic in `transformSitesResponse` so we look at the `wpcom_staging_blog_ids` arrays of other sites to determine if the given site is a staging site. This data appears to be stable from the moment a new staging site is created. For good measure, I've also updated `reconcileConnectedSites` to refresh the `isStaging` value.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Log in to WordPress.com in Studio
2. Connect a Studio site to a WordPress.com site
3. If the site already has a staging site, delete it
4. Go to `wordpress.com/sites` and create a new staging site for the site in question
5. Open Studio again and periodically switch between the `Share` and `Sync` tabs (this triggers a new fetch from the `/sites` API endpoint)
6. Ensure that when the staging site appears in the Sync tab, the sticker to the left says `Staging` (see screenshot below for clarification)

<img width="922" alt="Screenshot 2025-02-05 at 15 49 06" src="https://github.com/user-attachments/assets/efb1ac1f-e1f7-4ab3-9949-c7b380e3b43a" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
