### PR TITLE
User capabilities returned from `/sites` endpoint determine sync support

### DIFF
--- a/src/components/sync-sites-modal-selector.tsx
+++ b/src/components/sync-sites-modal-selector.tsx
@@ -135,9 +135,10 @@ const getSortedSites = ( sites: SyncSite[] ) => {
 		syncable: 1,
 		'already-connected': 2,
 		deleted: 3,
-		'needs-transfer': 4,
-		unsupported: 5,
-		'jetpack-site': 6,
+		'missing-permissions': 4,
+		'needs-transfer': 5,
+		unsupported: 6,
+		'jetpack-site': 7,
 	};
 
 	return [ ...sites ].sort( ( a, b ) => order[ a.syncSupport ] - order[ b.syncSupport ] );
@@ -184,6 +185,7 @@ function SiteItem( {
 	const isAlreadyConnected = site.syncSupport === 'already-connected';
 	const isSyncable = site.syncSupport === 'syncable';
 	const isNeedsTransfer = site.syncSupport === 'needs-transfer';
+	const isMissingPermissions = site.syncSupport === 'missing-permissions';
 	const isUnsupported = site.syncSupport === 'unsupported';
 	const isDeleted = site.syncSupport === 'deleted';
 	const isJetpackSite = site.syncSupport === 'jetpack-site';
@@ -266,6 +268,11 @@ function SiteItem( {
 					>
 						{ __( 'Enable hosting features ↗' ) }
 					</Button>
+				</div>
+			) }
+			{ isMissingPermissions && (
+				<div className="a8c-body-small text-a8c-gray-30 shrink-0 text-right">
+					{ __( 'Missing permissions' ) }
 				</div>
 			) }
 			{ isDeleted && (

--- a/src/custom-package-definitions.d.ts
+++ b/src/custom-package-definitions.d.ts
@@ -46,38 +46,38 @@ declare module '@timfish/forge-externals-plugin' {
 declare module 'wpcom' {
 	class Request {
 		/* eslint-disable @typescript-eslint/no-explicit-any */
-		get< TResponse = any >( params: object | string, query?: object ): Promise< TResponse >;
-		get< TResponse = any >(
+		get< TResponse = unknown >( params: object | string, query?: object ): Promise< TResponse >;
+		get< TResponse = unknown >(
 			params: object | string,
 			callback?: ( error: Error, data: TResponse, headers: Record< string, string > ) => void
 		);
-		get< TResponse = any >(
+		get< TResponse = unknown >(
 			params: object | string,
 			query?: object,
 			callback?: ( error: Error, data: TResponse, headers: Record< string, string > ) => void
 		);
-		post< TResponse = any >(
+		post< TResponse = unknown >(
 			params: object | string,
 			callback?: ( error: Error, data: TResponse, headers: Record< string, string > ) => void
 		);
-		post< TResponse = any >(
+		post< TResponse = unknown >(
 			params: object | string,
 			query?: object,
 			body?: object
 		): Promise< TResponse >;
-		post< TResponse = any >(
+		post< TResponse = unknown >(
 			params: object | string,
 			query?: object,
 			body?: object,
 			callback?: ( error: Error, data: TResponse, headers: Record< string, string > ) => void
 		);
-		del< TResponse = any >( params: object | string, query?: object ): Promise< TResponse >;
-		del< TResponse = any >(
+		del< TResponse = unknown >( params: object | string, query?: object ): Promise< TResponse >;
+		del< TResponse = unknown >(
 			params: object | string,
 			query?: object,
 			callback?: ( error: Error, data: TResponse, headers: Record< string, string > ) => void
 		);
-		del< TResponse = any >(
+		del< TResponse = unknown >(
 			params: object | string,
 			callback?: ( error: Error, data: TResponse, headers: Record< string, string > ) => void
 		);

--- a/src/custom-package-definitions.d.ts
+++ b/src/custom-package-definitions.d.ts
@@ -46,38 +46,38 @@ declare module '@timfish/forge-externals-plugin' {
 declare module 'wpcom' {
 	class Request {
 		/* eslint-disable @typescript-eslint/no-explicit-any */
-		get< TResponse = unknown >( params: object | string, query?: object ): Promise< TResponse >;
-		get< TResponse = unknown >(
+		get< TResponse = any >( params: object | string, query?: object ): Promise< TResponse >;
+		get< TResponse = any >(
 			params: object | string,
 			callback?: ( error: Error, data: TResponse, headers: Record< string, string > ) => void
 		);
-		get< TResponse = unknown >(
+		get< TResponse = any >(
 			params: object | string,
 			query?: object,
 			callback?: ( error: Error, data: TResponse, headers: Record< string, string > ) => void
 		);
-		post< TResponse = unknown >(
+		post< TResponse = any >(
 			params: object | string,
 			callback?: ( error: Error, data: TResponse, headers: Record< string, string > ) => void
 		);
-		post< TResponse = unknown >(
+		post< TResponse = any >(
 			params: object | string,
 			query?: object,
 			body?: object
 		): Promise< TResponse >;
-		post< TResponse = unknown >(
+		post< TResponse = any >(
 			params: object | string,
 			query?: object,
 			body?: object,
 			callback?: ( error: Error, data: TResponse, headers: Record< string, string > ) => void
 		);
-		del< TResponse = unknown >( params: object | string, query?: object ): Promise< TResponse >;
-		del< TResponse = unknown >(
+		del< TResponse = any >( params: object | string, query?: object ): Promise< TResponse >;
+		del< TResponse = any >(
 			params: object | string,
 			query?: object,
 			callback?: ( error: Error, data: TResponse, headers: Record< string, string > ) => void
 		);
-		del< TResponse = unknown >(
+		del< TResponse = any >(
 			params: object | string,
 			callback?: ( error: Error, data: TResponse, headers: Record< string, string > ) => void
 		);

--- a/src/hooks/sync-sites/use-listen-deep-link-connection.ts
+++ b/src/hooks/sync-sites/use-listen-deep-link-connection.ts
@@ -1,6 +1,5 @@
 import { SyncSitesContextType } from 'src/hooks/sync-sites/sync-sites-context';
 import { useContentTabs } from 'src/hooks/use-content-tabs';
-import { transformSingleSiteResponse } from 'src/hooks/use-fetch-wpcom-sites';
 import { useIpcListener } from 'src/hooks/use-ipc-listener';
 import { useSiteDetails } from 'src/hooks/use-site-details';
 
@@ -22,16 +21,12 @@ export function useListenDeepLinkConnection( {
 		) => {
 			// Fetch latest sites from network before checking
 			const latestSites = await refetchSites();
-			const newConnectedSiteResponse = latestSites.find( ( site ) => site.ID === remoteSiteId );
-			if ( newConnectedSiteResponse ) {
+			const newConnectedSite = latestSites.find( ( site ) => site.id === remoteSiteId );
+			if ( newConnectedSite ) {
 				if ( selectedSite?.id && selectedSite.id !== studioSiteId ) {
 					// Select studio site that started the sync
 					setSelectedSiteId( studioSiteId );
 				}
-				const newConnectedSite = transformSingleSiteResponse(
-					newConnectedSiteResponse,
-					'already-connected'
-				);
 				await connectSite( newConnectedSite, studioSiteId );
 				if ( selectedTab !== 'sync' ) {
 					// Switch to sync tab

--- a/src/hooks/use-fetch-wpcom-sites/index.tsx
+++ b/src/hooks/use-fetch-wpcom-sites/index.tsx
@@ -92,7 +92,7 @@ export function transformSingleSiteResponse(
 	};
 }
 
-function transformSiteResponse( sites: unknown[], connectedSiteIds: number[] ): SyncSite[] {
+export function transformSiteResponse( sites: unknown[], connectedSiteIds: number[] ): SyncSite[] {
 	return sites
 		.map( ( rawSite ) => {
 			try {
@@ -108,10 +108,10 @@ function transformSiteResponse( sites: unknown[], connectedSiteIds: number[] ): 
 				return null;
 			}
 		} )
-		.filter( ( site ) => site !== null );
+		.filter( ( site ): site is SyncSite => site !== null );
 }
 
-export type FetchSites = () => Promise< unknown[] >;
+export type FetchSites = () => Promise< SyncSite[] >;
 
 export const useFetchWpComSites = ( connectedSiteIdsOnlyForSelectedSite: number[] ) => {
 	const [ rawSyncSites, setRawSyncSites ] = useState< unknown[] >( [] );
@@ -186,7 +186,7 @@ export const useFetchWpComSites = ( connectedSiteIdsOnlyForSelectedSite: number[
 
 			setRawSyncSites( parsedResponse.sites );
 
-			return parsedResponse.sites;
+			return syncSites;
 		} catch ( error ) {
 			Sentry.captureException( error );
 			console.error( error );

--- a/src/hooks/use-fetch-wpcom-sites/index.tsx
+++ b/src/hooks/use-fetch-wpcom-sites/index.tsx
@@ -49,7 +49,7 @@ function isJetpackSite( site: SitesEndpointSite ): boolean {
 }
 
 function hasSupportedPlan( site: SitesEndpointSite ): boolean {
-	return !! site.plan && site.plan.features.active.includes( STUDIO_SYNC_FEATURE_NAME );
+	return site.plan.features.active.includes( STUDIO_SYNC_FEATURE_NAME );
 }
 
 function getSyncSupport( site: SitesEndpointSite, connectedSiteIds: number[] ): SyncSupport {

--- a/src/hooks/use-fetch-wpcom-sites/index.tsx
+++ b/src/hooks/use-fetch-wpcom-sites/index.tsx
@@ -1,40 +1,47 @@
 import * as Sentry from '@sentry/electron/renderer';
 import { useState, useEffect, useRef, useMemo, useCallback } from 'react';
+import { z } from 'zod';
 import { useAuth } from 'src/hooks/use-auth';
 import { reconcileConnectedSites } from 'src/hooks/use-fetch-wpcom-sites/reconcile-connected-sites';
 import { useOffline } from 'src/hooks/use-offline';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 import type { SyncSite, SyncSupport } from 'src/hooks/use-fetch-wpcom-sites/types';
 
-type SitesEndpointSite = {
-	ID: number;
-	is_wpcom_atomic: boolean;
-	is_wpcom_staging_site: boolean;
-	name: string;
-	URL: string;
-	jetpack?: boolean;
-	options?: {
-		created_at: string;
-		wpcom_staging_blog_ids: number[];
-	};
-	plan?: {
-		expired: boolean;
-		features: {
-			active: string[];
-			available: Record< string, string[] >;
-		};
-		is_free: boolean;
-		product_id: number;
-		product_name_short: string;
-		product_slug: string;
-		user_is_owner: boolean;
-	};
-	is_deleted: boolean;
-};
+export const sitesEndpointSiteSchema = z.object( {
+	ID: z.number(),
+	is_wpcom_atomic: z.boolean(),
+	is_wpcom_staging_site: z.boolean(),
+	name: z.string(),
+	URL: z.string(),
+	jetpack: z.boolean().optional(),
+	is_deleted: z.boolean(),
+	options: z.object( {
+		created_at: z.string(),
+		wpcom_staging_blog_ids: z.array( z.number() ),
+	} ),
+	capabilities: z.object( {
+		manage_options: z.boolean(),
+	} ),
+	plan: z.object( {
+		expired: z.boolean(),
+		features: z.object( {
+			active: z.array( z.string() ),
+			available: z.record( z.string(), z.array( z.string() ) ).optional(),
+		} ),
+		is_free: z.boolean(),
+		product_id: z.number(),
+		product_name_short: z.string(),
+		product_slug: z.string(),
+		user_is_owner: z.boolean(),
+	} ),
+} );
 
-type SitesEndpointResponse = {
-	sites: SitesEndpointSite[];
-};
+type SitesEndpointSite = z.infer< typeof sitesEndpointSiteSchema >;
+
+// We use a permissive schema for the API response to fail gracefully if a single site is malformed
+export const sitesEndpointResponseSchema = z.object( {
+	sites: z.array( z.unknown() ),
+} );
 
 const STUDIO_SYNC_FEATURE_NAME = 'studio-sync';
 
@@ -49,6 +56,9 @@ function hasSupportedPlan( site: SitesEndpointSite ): boolean {
 function getSyncSupport( site: SitesEndpointSite, connectedSiteIds: number[] ): SyncSupport {
 	if ( site.is_deleted ) {
 		return 'deleted';
+	}
+	if ( ! site.capabilities.manage_options ) {
+		return 'missing-permissions';
 	}
 	if ( isJetpackSite( site ) && ! hasSupportedPlan( site ) ) {
 		return 'jetpack-site';
@@ -82,25 +92,29 @@ export function transformSingleSiteResponse(
 	};
 }
 
-function transformSiteResponse(
-	sites: SitesEndpointSite[],
-	connectedSiteIds: number[]
-): SyncSite[] {
-	return sites.reduce( ( acc: SyncSite[], site ) => {
-		if ( site.is_deleted && ! connectedSiteIds.some( ( id ) => id === site.ID ) ) {
-			return acc;
-		}
+function transformSiteResponse( sites: unknown[], connectedSiteIds: number[] ): SyncSite[] {
+	return sites
+		.map( ( rawSite ) => {
+			try {
+				const site = sitesEndpointSiteSchema.parse( rawSite );
 
-		acc.push( transformSingleSiteResponse( site, getSyncSupport( site, connectedSiteIds ) ) );
+				if ( site.is_deleted && ! connectedSiteIds.some( ( id ) => id === site.ID ) ) {
+					return null;
+				}
 
-		return acc;
-	}, [] );
+				return transformSingleSiteResponse( site, getSyncSupport( site, connectedSiteIds ) );
+			} catch ( error ) {
+				Sentry.captureException( error );
+				return null;
+			}
+		} )
+		.filter( ( site ) => site !== null );
 }
 
-export type FetchSites = () => Promise< SitesEndpointSite[] >;
+export type FetchSites = () => Promise< unknown[] >;
 
 export const useFetchWpComSites = ( connectedSiteIdsOnlyForSelectedSite: number[] ) => {
-	const [ rawSyncSites, setRawSyncSites ] = useState< SitesEndpointSite[] >( [] );
+	const [ rawSyncSites, setRawSyncSites ] = useState< unknown[] >( [] );
 	const { isAuthenticated, client } = useAuth();
 	const isFetchingSites = useRef( false );
 	const isOffline = useOffline();
@@ -126,22 +140,23 @@ export const useFetchWpComSites = ( connectedSiteIdsOnlyForSelectedSite: number[
 		try {
 			const allConnectedSites = await getIpcApi().getConnectedWpcomSites();
 
-			const response = await client.req.get< SitesEndpointResponse >(
+			const response = await client.req.get(
 				{
 					apiNamespace: 'rest/v1.2',
 					path: `/me/sites`,
 				},
 				{
 					fields:
-						'name,ID,URL,plan,is_wpcom_staging_site,is_wpcom_atomic,options,jetpack,is_deleted',
+						'name,ID,URL,plan,capabilities,is_wpcom_staging_site,is_wpcom_atomic,options,jetpack,is_deleted',
 					filter: 'atomic,wpcom',
 					options: 'created_at,wpcom_staging_blog_ids',
 					site_activity: 'active',
 				}
 			);
 
+			const parsedResponse = sitesEndpointResponseSchema.parse( response );
 			const syncSites = transformSiteResponse(
-				response.sites,
+				parsedResponse.sites,
 				allConnectedSites.map( ( { id } ) => id )
 			);
 
@@ -169,9 +184,9 @@ export const useFetchWpComSites = ( connectedSiteIdsOnlyForSelectedSite: number[
 				await getIpcApi().connectWpcomSites( data );
 			}
 
-			setRawSyncSites( response.sites );
+			setRawSyncSites( parsedResponse.sites );
 
-			return response.sites;
+			return parsedResponse.sites;
 		} catch ( error ) {
 			Sentry.captureException( error );
 			console.error( error );

--- a/src/hooks/use-fetch-wpcom-sites/index.tsx
+++ b/src/hooks/use-fetch-wpcom-sites/index.tsx
@@ -93,29 +93,31 @@ export function transformSingleSiteResponse(
 }
 
 export function transformSitesResponse( sites: unknown[], connectedSiteIds: number[] ): SyncSite[] {
-	return sites
+	const validatedSites = sites
 		.map( ( rawSite ) => {
 			try {
-				const site = sitesEndpointSiteSchema.parse( rawSite );
-
-				if ( site.is_deleted && ! connectedSiteIds.some( ( id ) => id === site.ID ) ) {
-					return null;
-				}
-
-				const syncSupport = getSyncSupport( site, connectedSiteIds );
-				// The API returns the wrong value for the `is_wpcom_staging_site` prop while staging sites
-				// are being created. Hence the check in other sites' `wpcom_staging_blog_ids` arrays.
-				const isStaging = sites.some(
-					( s ) => s.options?.wpcom_staging_blog_ids?.includes( site.ID )
-				);
-
-				return transformSingleSiteResponse( site, syncSupport, isStaging );
+				return sitesEndpointSiteSchema.parse( rawSite );
 			} catch ( error ) {
 				Sentry.captureException( error );
 				return null;
 			}
 		} )
-		.filter( ( site ): site is SyncSite => site !== null );
+		.filter( ( site ): site is SitesEndpointSite => site !== null );
+
+	const allStagingSiteIds = validatedSites.flatMap( ( site ) => {
+		return site.options.wpcom_staging_blog_ids;
+	} );
+
+	return validatedSites
+		.filter( ( site ) => ! site.is_deleted || connectedSiteIds.some( ( id ) => id === site.ID ) )
+		.map( ( site ) => {
+			// The API returns the wrong value for the `is_wpcom_staging_site` prop while staging sites
+			// are being created. Hence the check in other sites' `wpcom_staging_blog_ids` arrays.
+			const isStaging = allStagingSiteIds.includes( site.ID );
+			const syncSupport = getSyncSupport( site, connectedSiteIds );
+
+			return transformSingleSiteResponse( site, syncSupport, isStaging );
+		} );
 }
 
 export type FetchSites = () => Promise< SyncSite[] >;

--- a/src/hooks/use-fetch-wpcom-sites/index.tsx
+++ b/src/hooks/use-fetch-wpcom-sites/index.tsx
@@ -93,16 +93,15 @@ export function transformSingleSiteResponse(
 }
 
 export function transformSitesResponse( sites: unknown[], connectedSiteIds: number[] ): SyncSite[] {
-	const validatedSites = sites
-		.map( ( rawSite ) => {
-			try {
-				return sitesEndpointSiteSchema.parse( rawSite );
-			} catch ( error ) {
-				Sentry.captureException( error );
-				return null;
-			}
-		} )
-		.filter( ( site ): site is SitesEndpointSite => site !== null );
+	const validatedSites = sites.reduce< SitesEndpointSite[] >( ( acc, rawSite ) => {
+		try {
+			const site = sitesEndpointSiteSchema.parse( rawSite );
+			return [ ...acc, site ];
+		} catch ( error ) {
+			Sentry.captureException( error );
+			return acc;
+		}
+	}, [] );
 
 	const allStagingSiteIds = validatedSites.flatMap( ( site ) => {
 		return site.options.wpcom_staging_blog_ids;

--- a/src/hooks/use-fetch-wpcom-sites/types.ts
+++ b/src/hooks/use-fetch-wpcom-sites/types.ts
@@ -4,7 +4,8 @@ export type SyncSupport =
 	| 'needs-transfer'
 	| 'already-connected'
 	| 'jetpack-site'
-	| 'deleted';
+	| 'deleted'
+	| 'missing-permissions';
 
 export type SyncSite = {
 	id: number;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/dotcom-forge/issues/10257

## Proposed Changes

To be able to push a site to WordPress.com, users need the `manage_options` capability. Currently, we only look for this capability after users have initiated the push. This PR modifies our network request to the `/sites` API endpoint to return user capability data and then looks at that data to determine sync support. Hopefully, this will resolve https://github.com/Automattic/dotcom-forge/issues/10257 (it's possible that a broken Jetpack connection might still mess things up, though).

Moreover, I took the opportunity to add a [zod](https://zod.dev/) schema for the `/sites` response in `src/hooks/use-fetch-wpcom-sites/index.tsx`. Sites are parsed one-by-one, meaning we don't reject the entire response if a single site doesn't conform. Errors are reported to Sentry.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Be invited to a WordPress.com site where your user has a **lower role** than administrator
2. Open the `Connect site` modal in Studio
3. Ensure that you cannot connect the site in question and that the explanation says `Missing permissions`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
