### PR TITLE
Generate always available name for a new website

### DIFF
--- a/src/lib/generate-site-name.ts
+++ b/src/lib/generate-site-name.ts
@@ -35,7 +35,7 @@ export function generateSiteName( usedSiteNames: string[] ): string {
 		return availableNames[ Math.floor( Math.random() * availableNames.length ) ];
 	}
 
-	let siteNumber = 1;
+	let siteNumber = 2;
 	while ( usedSiteNames.includes( `${ defaultName } ${ siteNumber }` ) ) {
 		siteNumber++;
 	}

--- a/src/lib/generate-site-name.ts
+++ b/src/lib/generate-site-name.ts
@@ -46,7 +46,7 @@ export const sanitizeFolderName = ( filename: string ) => {
 	const LATIN = 'a-z';
 	const CYRILLIC = 'а-яё';
 	const ARABIC = '\\u0600-\\u06FF';
-	const HEREW = '\\u0590-\\u05FF';
+	const HEBREW = '\\u0590-\\u05FF';
 	const CHINESE = '\\u4e00-\\u9fa5';
 	const JAPANESE_HIRAGANA = '\\u3040-\\u309F';
 	const JAPANESE_KATAKANA = '\\u30A0-\\u30FF';

--- a/src/lib/generate-site-name.ts
+++ b/src/lib/generate-site-name.ts
@@ -23,22 +23,30 @@ export function generateSiteName( usedSiteNames: string[] ): string {
 		__( 'My Swift Website' ),
 		__( 'My True Website' ),
 	];
-	let proposedName = __( 'My WordPress Website' );
-	let tryCount = 0;
 
-	while ( usedSiteNames.includes( proposedName ) && tryCount < siteNames.length ) {
-		tryCount++;
-		proposedName = siteNames[ Math.floor( Math.random() * siteNames.length ) ];
+	const defaultName = __( 'My WordPress Website' );
+	if ( ! usedSiteNames.includes( defaultName ) ) {
+		return defaultName;
 	}
 
-	return proposedName;
+	const availableNames = siteNames.filter( ( name ) => ! usedSiteNames.includes( name ) );
+	if ( availableNames.length > 0 ) {
+		return availableNames[ Math.floor( Math.random() * availableNames.length ) ];
+	}
+
+	const randomName = siteNames[ Math.floor( Math.random() * siteNames.length ) ];
+	let postfix = 1;
+	while ( usedSiteNames.includes( `${ randomName } ${ postfix }` ) ) {
+		postfix++;
+	}
+	return `${ randomName } ${ postfix }`;
 }
 
 export const sanitizeFolderName = ( filename: string ) => {
 	const LATIN = 'a-z';
 	const CYRILLIC = 'а-яё';
 	const ARABIC = '\\u0600-\\u06FF';
-	const HEBREW = '\\u0590-\\u05FF';
+	const HEREW = '\\u0590-\\u05FF';
 	const CHINESE = '\\u4e00-\\u9fa5';
 	const JAPANESE_HIRAGANA = '\\u3040-\\u309F';
 	const JAPANESE_KATAKANA = '\\u30A0-\\u30FF';

--- a/src/lib/generate-site-name.ts
+++ b/src/lib/generate-site-name.ts
@@ -25,6 +25,7 @@ export function generateSiteName( usedSiteNames: string[] ): string {
 	];
 
 	const defaultName = __( 'My WordPress Website' );
+
 	if ( ! usedSiteNames.includes( defaultName ) ) {
 		return defaultName;
 	}
@@ -34,12 +35,11 @@ export function generateSiteName( usedSiteNames: string[] ): string {
 		return availableNames[ Math.floor( Math.random() * availableNames.length ) ];
 	}
 
-	const randomName = siteNames[ Math.floor( Math.random() * siteNames.length ) ];
-	let postfix = 1;
-	while ( usedSiteNames.includes( `${ randomName } ${ postfix }` ) ) {
-		postfix++;
+	let siteNumber = 1;
+	while ( usedSiteNames.includes( `${ defaultName } ${ siteNumber }` ) ) {
+		siteNumber++;
 	}
-	return `${ randomName } ${ postfix }`;
+	return `${ defaultName } ${ siteNumber }`;
 }
 
 export const sanitizeFolderName = ( filename: string ) => {


### PR DESCRIPTION
## Proposed Changes
When you run out of available names, there is very weird result: after clicking "Add site" button we immediately see the next:
<img width="515" alt="Screenshot 2025-02-06 at 12 08 34" src="https://github.com/user-attachments/assets/d52a619e-9858-45d2-8e35-70a1a4b6780d" />
<img width="457" alt="Screenshot 2025-02-06 at 12 09 25" src="https://github.com/user-attachments/assets/36cafa0e-3fb7-463e-afc9-0d86539a952b" />

With this PR, the generation of names is always successful (we add numeric postfix), so users don't need to do extra actions and spend time to figure out "what is going on" .

## Testing Instructions
Apply the next diff:

```
diff --git a/src/lib/generate-site-name.ts b/src/lib/generate-site-name.ts
index 3052a2f..ae3e6ad 100644
--- a/src/lib/generate-site-name.ts
+++ b/src/lib/generate-site-name.ts
@@ -4,24 +4,6 @@ export function generateSiteName( usedSiteNames: string[] ): string {
        const siteNames = [
                __( 'My Bold Website' ),
                __( 'My Bright Website' ),
-               __( 'My Blissful Website' ),
-               __( 'My Calm Website' ),
-               __( 'My Cool Website' ),
-               __( 'My Dreamy Website' ),
-               __( 'My Elite Website' ),
-               __( 'My Fresh Website' ),
-               __( 'My Glowing Website' ),
-               __( 'My Happy Website' ),
-               __( 'My Joyful Website' ),
-               __( 'My Noble Website' ),
-               __( 'My Pure Website' ),
-               __( 'My Peak Website' ),
-               __( 'My Prime Website' ),
-               __( 'My Serene Website' ),
-               __( 'My Shiny Website' ),
-               __( 'My Sparkly Website' ),
-               __( 'My Swift Website' ),
-               __( 'My True Website' ),
        ];
 
        const defaultName = __( 'My WordPress Website' );
```

1. Remove all websites
2. Assert that default website has name `My WordPress Website` and create it
3. "Add new" website and assert that it has random name between `My Bold Website` and `My Bright Website`
4. Add one more website and assert that it has the second name which left from previous step
5. Add new website and assert that we have numeric postfix and further generations increase postfix correctly for random name