### PR TITLE
Provide more specific errors for incorrect Local path during creating a site

### DIFF
--- a/src/hooks/use-add-site.ts
+++ b/src/hooks/use-add-site.ts
@@ -125,7 +125,7 @@ export function useAddSite() {
 		if ( siteWithPathAlreadyExists( sitePath ? sitePath : proposedSitePath ) ) {
 			if ( sitePath ) {
 				errorPathIsNotAvailable = __(
-					'This directory is already connected to another site in Studio.'
+					'The directory is already associated with another Studio site. Please choose a different custom local path.'
 				);
 			} else {
 				errorPathIsNotAvailable = __(

--- a/src/hooks/use-add-site.ts
+++ b/src/hooks/use-add-site.ts
@@ -129,7 +129,7 @@ export function useAddSite() {
 				);
 			} else {
 				errorPathIsNotAvailable = __(
-					'The directory is already associated with another site. Please choose a different "Site name" or adjust the "Local path".'
+					'The directory is already associated with another Studio site. Please choose a different site name or a custom local path.'
 				);
 			}
 		}

--- a/src/hooks/use-add-site.ts
+++ b/src/hooks/use-add-site.ts
@@ -20,7 +20,7 @@ export function useAddSite() {
 
 	const siteWithPathAlreadyExists = useCallback(
 		( path: string ) => {
-			return sites.some( ( site ) => site.path === path );
+			return sites.some( ( site ) => site.path.toLowerCase() === path.toLowerCase() );
 		},
 		[ sites ]
 	);

--- a/src/hooks/use-add-site.ts
+++ b/src/hooks/use-add-site.ts
@@ -120,16 +120,25 @@ export function useAddSite() {
 		[ __, sitePath, siteWithPathAlreadyExists ]
 	);
 
-	return useMemo(
-		() => ( {
+	return useMemo( () => {
+		let errorPathIsNotAvailable;
+		if ( siteWithPathAlreadyExists( sitePath ? sitePath : proposedSitePath ) ) {
+			if ( sitePath ) {
+				errorPathIsNotAvailable = __(
+					'This directory is already connected to another site in Studio.'
+				);
+			} else {
+				errorPathIsNotAvailable = __(
+					'The directory is already associated with another site. Please choose a different "Site name" or adjust the "Local path".'
+				);
+			}
+		}
+
+		return {
 			handleAddSiteClick,
 			handlePathSelectorClick,
 			handleSiteNameChange,
-			error: siteWithPathAlreadyExists( sitePath ? sitePath : proposedSitePath )
-				? __(
-						'Another site already exists at this path. Please select an empty directory to create a site.'
-				  )
-				: error,
+			error: errorPathIsNotAvailable || error,
 			sitePath: sitePath ? sitePath : proposedSitePath,
 			siteName,
 			doesPathContainWordPress,
@@ -144,21 +153,21 @@ export function useAddSite() {
 			loadingSites,
 			fileForImport,
 			setFileForImport,
-		} ),
-		[
-			__,
-			doesPathContainWordPress,
-			error,
-			handleAddSiteClick,
-			handlePathSelectorClick,
-			siteWithPathAlreadyExists,
-			handleSiteNameChange,
-			siteName,
-			sitePath,
-			proposedSitePath,
-			usedSiteNames,
-			loadingSites,
-			fileForImport,
-		]
-	);
+		};
+	}, [
+		__,
+		doesPathContainWordPress,
+		error,
+		handleAddSiteClick,
+		handlePathSelectorClick,
+		siteWithPathAlreadyExists,
+		handleSiteNameChange,
+		siteName,
+		sitePath,
+		proposedSitePath,
+		usedSiteNames,
+		loadingSites,
+		fileForImport,
+	]
+);
 }

--- a/src/hooks/use-add-site.ts
+++ b/src/hooks/use-add-site.ts
@@ -168,6 +168,5 @@ export function useAddSite() {
 		usedSiteNames,
 		loadingSites,
 		fileForImport,
-	]
-);
+	] );
 }

--- a/src/lib/generate-site-name.ts
+++ b/src/lib/generate-site-name.ts
@@ -3,25 +3,6 @@ import { __ } from '@wordpress/i18n';
 export function generateSiteName( usedSiteNames: string[] ): string {
 	const siteNames = [
 		__( 'My Bold Website' ),
-		__( 'My Bright Website' ),
-		__( 'My Blissful Website' ),
-		__( 'My Calm Website' ),
-		__( 'My Cool Website' ),
-		__( 'My Dreamy Website' ),
-		__( 'My Elite Website' ),
-		__( 'My Fresh Website' ),
-		__( 'My Glowing Website' ),
-		__( 'My Happy Website' ),
-		__( 'My Joyful Website' ),
-		__( 'My Noble Website' ),
-		__( 'My Pure Website' ),
-		__( 'My Peak Website' ),
-		__( 'My Prime Website' ),
-		__( 'My Serene Website' ),
-		__( 'My Shiny Website' ),
-		__( 'My Sparkly Website' ),
-		__( 'My Swift Website' ),
-		__( 'My True Website' ),
 	];
 	let proposedName = __( 'My WordPress Website' );
 	let tryCount = 0;

--- a/src/lib/generate-site-name.ts
+++ b/src/lib/generate-site-name.ts
@@ -3,6 +3,25 @@ import { __ } from '@wordpress/i18n';
 export function generateSiteName( usedSiteNames: string[] ): string {
 	const siteNames = [
 		__( 'My Bold Website' ),
+		__( 'My Bright Website' ),
+		__( 'My Blissful Website' ),
+		__( 'My Calm Website' ),
+		__( 'My Cool Website' ),
+		__( 'My Dreamy Website' ),
+		__( 'My Elite Website' ),
+		__( 'My Fresh Website' ),
+		__( 'My Glowing Website' ),
+		__( 'My Happy Website' ),
+		__( 'My Joyful Website' ),
+		__( 'My Noble Website' ),
+		__( 'My Pure Website' ),
+		__( 'My Peak Website' ),
+		__( 'My Prime Website' ),
+		__( 'My Serene Website' ),
+		__( 'My Shiny Website' ),
+		__( 'My Sparkly Website' ),
+		__( 'My Swift Website' ),
+		__( 'My True Website' ),
 	];
 	let proposedName = __( 'My WordPress Website' );
 	let tryCount = 0;


### PR DESCRIPTION
## Related issues

- Fixes https://github.com/Automattic/dotcom-forge/issues/10392


## Testing Instructions
### "Site name" change
1. Click on "Add site" button in the left bottom corner
2. Provide "test" as site name and create site
3. Click on "Add site" again
4. Provide "test" as site name again
5. I didn't think about the fact that we create directory based on the site name, so for me it was confusing seeing some error and I didn't get what happened at a glance. I think that such error will be more specific to show the error and at the same time explain that site name and path are connected, so the user should either chose another site name or keep it but manually select directory name for this site.

<table>
<tr>
<td>BEFORE
<td>AFTER
</tr>
<tr>
<td><img width="470" alt="Screenshot 2025-02-06 at 15 03 58" src="https://github.com/user-attachments/assets/70fa8e32-6ecc-4df4-9d66-b23af05f9305" />
<td><img width="590" alt="Screenshot 2025-02-06 at 14 26 28" src="https://github.com/user-attachments/assets/526c4d93-296d-47ae-85a2-7dc789c2b138" />
</tr>
</table>


### Adding new site with existing folder
1. Create a site in Studio
2. Click on "Add site"
3. Try to create a new site with the folder which is already connected to another site in Studio
4. I think, showing the next error, would be:
  4.1 more specific - menthion that the directory is already connected specifically tosome site in Studio
  4.2 concise - user selected some directory to connect to Studio, we don't know was their intention to create new site or add some existing WP folder, so saying "*empty* directory to *create* site" looks confusing if they wonted to add existed WP site.

<table>
<tr>
<td>BEFORE
<td>AFTER
</tr>
<tr>
<td><img width="467" alt="Screenshot 2025-02-06 at 15 07 24" src="https://github.com/user-attachments/assets/ebc12476-fafc-4512-aefa-146abbe48cfe" />
<td><img width="471" alt="Screenshot 2025-02-06 at 15 08 31" src="https://github.com/user-attachments/assets/844906f9-8173-4175-8791-90fbf636efad" />
</tr>
</table>