### PR TITLE
Attempt to fix osascript issue with launching Terminal

### DIFF
--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -908,15 +908,25 @@ export function openTerminalAtPath(
 			env: { ...process.env, ...env },
 		} );
 	} else if ( platform === 'darwin' ) {
-		const loadWpCliCommand = `clear && export PATH=\\"${ cliPath }\\":$PATH && export STUDIO_APP_PATH=\\"${ appPath }\\" &&`;
+		const initScriptSteps = [];
+
+		if ( wpCliEnabled ) {
+			initScriptSteps.push(
+				`export PATH=\\"${ cliPath }\\":$PATH`,
+				`export STUDIO_APP_PATH=\\"${ appPath }\\"`
+			);
+		}
+
+		const escapedPath = targetPath.replace( /"/g, '\\"' );
+		initScriptSteps.push( `cd \\"${ escapedPath }\\"`, 'clear' );
+
 		const osascript = `
 		tell application "Terminal"
-			if not application "Terminal" is running then launch
-			do script "${ wpCliEnabled ? loadWpCliCommand : '' } cd ${ targetPath } && clear"
+			do script "${ initScriptSteps.join( ' ; ' ) }"
 			activate
 		end tell`;
 
-		return promiseExec( `osascript -e '${ osascript }'` );
+		return promiseExec( `osascript << END '${ osascript }' END` );
 	} else if ( platform === 'linux' ) {
 		if ( wpCliEnabled ) {
 			return promiseExec(

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -923,7 +923,7 @@ export function openTerminalAtPath(
 		return promiseExec( `osascript << END
 activate application "Terminal"
 tell application "Terminal"
-	do script "${ initScriptSteps.join( '\n' ) }"
+	do script "${ initScriptSteps.join( ';' ) }"
 end tell
 END` );
 	} else if ( platform === 'linux' ) {

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -920,13 +920,12 @@ export function openTerminalAtPath(
 		const escapedPath = targetPath.replace( /"/g, '\\"' );
 		initScriptSteps.push( `cd \\"${ escapedPath }\\"`, 'clear' );
 
-		const osascript = `
-		tell application "Terminal"
-			do script "${ initScriptSteps.join( ' ; ' ) }"
-			activate
-		end tell`;
-
-		return promiseExec( `osascript << END '${ osascript }' END` );
+		return promiseExec( `osascript << END
+activate application "Terminal"
+tell application "Terminal"
+	do script "${ initScriptSteps.join( '\n' ) }"
+end tell
+END` );
 	} else if ( platform === 'linux' ) {
 		if ( wpCliEnabled ) {
 			return promiseExec(


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/dotcom-forge/issues/10416

## Proposed Changes

There are numerous reports in Sentry about `osascript` failing to run the command used to launch a Terminal from Studio. It's not clear why this happens, but in this PR, I've taken a few steps to make the script safer:

1. Escape the site folder path by wrapping it in quotes (would help if there's whitespace in the path)
2. Use `;` instead of `&&` to separate statements in the init script (proceed even if the previous step failed)
3. Use STDIN to pipe the script to `osascript` instead of passing it as an argument to `osascript -e`. Why? Because the manpage for `osascript` mentions that the `-e` argument technically only accepts single-line scripts:

```
     -e statement
           Enter one line of a script.  If -e is given, osascript will not look for a filename in the argument list.  Multiple -e options
           may be given to build up a multi-line script.  Because most scripts use characters that are special to many shell programs (for
           example, AppleScript uses single and double quote marks, “(”, “)”, and “*”), the statement will have to be correctly quoted and
           escaped to get it past the shell intact.
```

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Ensure that the `Open in… Terminal` button still works as expected on macOS

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
