### PR TITLE
Add new rename modal

### DIFF
--- a/src/modules/preview-site/components/preview-action-buttons-menu.tsx
+++ b/src/modules/preview-site/components/preview-action-buttons-menu.tsx
@@ -2,25 +2,37 @@ import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { moreVertical } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
+import { useState } from 'react';
+import Button from 'src/components/button';
+import Modal from 'src/components/modal';
 import offlineIcon from 'src/components/offline-icon';
-import { Tooltip } from 'src/components/tooltip';
+import { Tooltip, TooltipProps } from 'src/components/tooltip';
 import { useConfirmationDialog } from 'src/hooks/use-confirmation-dialog';
 import { useOffline } from 'src/hooks/use-offline';
 import { useSnapshots } from 'src/hooks/use-snapshots';
 import { useUpdateDemoSite } from 'src/hooks/use-update-demo-site';
+import { RenamePreviewModal } from './rename-preview-modal';
+
 interface PreviewActionButtonsMenuProps {
 	snapshot: Snapshot;
 	selectedSite: SiteDetails;
+	disabledUpdate?: boolean;
+	updateButtonTooltipContent?: Partial< TooltipProps & { text?: string } >;
+	showUpdateTooltip?: boolean;
 }
 
 export function PreviewActionButtonsMenu( {
 	snapshot,
 	selectedSite,
+	disabledUpdate,
+	updateButtonTooltipContent = {},
+	showUpdateTooltip = false,
 }: PreviewActionButtonsMenuProps ) {
 	const { __ } = useI18n();
-	const { deleteSnapshot } = useSnapshots();
+	const { deleteSnapshot, updateSnapshot } = useSnapshots();
 	const { updateDemoSite } = useUpdateDemoSite();
 	const isOffline = useOffline();
+	const [ showRenameModal, setShowRenameModal ] = useState( false );
 
 	const showUpdatePreviewConfirmation = useConfirmationDialog( {
 		localStorageKey: 'dontShowUpdateWarning',
@@ -52,52 +64,74 @@ export function PreviewActionButtonsMenu( {
 		} );
 	};
 
+	const handleRename = ( newName: string ) => {
+		updateSnapshot( {
+			...snapshot,
+			name: newName,
+		} );
+		setShowRenameModal( false );
+	};
+
 	return (
-		<DropdownMenu
-			icon={ moreVertical }
-			label={ __( 'Preview actions' ) }
-			className="p-1 flex items-center"
-		>
-			{ ( { onClose }: { onClose: () => void } ) => (
-				<MenuGroup className="w-40 overflow-hidden">
-					<MenuItem>
-						<span>{ __( 'Rename' ) }</span>
-					</MenuItem>
-					<MenuItem
-						disabled={ isOffline }
-						onClick={ () => {
-							handleUpdatePreviewSite();
-							onClose();
-						} }
-					>
-						<Tooltip
-							disabled={ ! isOffline }
-							text={ __( 'Updating a preview site requires an internet connection.' ) }
-							icon={ offlineIcon }
-							placement="top-start"
+		<>
+			<DropdownMenu
+				icon={ moreVertical }
+				label={ __( 'Preview actions' ) }
+				className="p-1 flex items-center"
+			>
+				{ ( { onClose }: { onClose: () => void } ) => (
+					<MenuGroup className="w-40 overflow-hidden">
+						<MenuItem
+							onClick={ () => {
+								setShowRenameModal( true );
+								onClose();
+							} }
 						>
-							<span>{ __( 'Update' ) }</span>
-						</Tooltip>
-					</MenuItem>
-					<MenuItem
-						isDestructive
-						disabled={ isOffline }
-						onClick={ () => {
-							handleDeletePreviewSite();
-							onClose();
-						} }
-					>
-						<Tooltip
-							disabled={ ! isOffline }
-							text={ __( 'Deleting a preview site requires an internet connection.' ) }
-							icon={ offlineIcon }
-							placement="top-start"
+							<span>{ __( 'Rename' ) }</span>
+						</MenuItem>
+						<MenuItem
+							onClick={ () => {
+								handleUpdatePreviewSite();
+								onClose();
+							} }
+							disabled={ disabledUpdate }
 						>
-							<span>{ __( 'Delete' ) }</span>
-						</Tooltip>
-					</MenuItem>
-				</MenuGroup>
+							<Tooltip
+								disabled={ ! showUpdateTooltip }
+								placement="top-start"
+								{ ...updateButtonTooltipContent }
+							>
+								<span>{ __( 'Update' ) }</span>
+							</Tooltip>
+						</MenuItem>
+						<MenuItem
+							isDestructive
+							disabled={ isOffline }
+							onClick={ () => {
+								handleDeletePreviewSite();
+								onClose();
+							} }
+						>
+							<Tooltip
+								disabled={ ! isOffline }
+								text={ __( 'Deleting a preview site requires an internet connection.' ) }
+								icon={ offlineIcon }
+								placement="top-start"
+							>
+								<span>{ __( 'Delete' ) }</span>
+							</Tooltip>
+						</MenuItem>
+					</MenuGroup>
+				) }
+			</DropdownMenu>
+
+			{ showRenameModal && (
+				<RenamePreviewModal
+					initialName={ snapshot.name || selectedSite.name }
+					onRename={ handleRename }
+					onClose={ () => setShowRenameModal( false ) }
+				/>
 			) }
-		</DropdownMenu>
+		</>
 	);
 }

--- a/src/modules/preview-site/components/preview-action-buttons-menu.tsx
+++ b/src/modules/preview-site/components/preview-action-buttons-menu.tsx
@@ -3,8 +3,6 @@ import { __ } from '@wordpress/i18n';
 import { moreVertical } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { useState } from 'react';
-import Button from 'src/components/button';
-import Modal from 'src/components/modal';
 import offlineIcon from 'src/components/offline-icon';
 import { Tooltip, TooltipProps } from 'src/components/tooltip';
 import { useConfirmationDialog } from 'src/hooks/use-confirmation-dialog';

--- a/src/modules/preview-site/components/rename-preview-modal.tsx
+++ b/src/modules/preview-site/components/rename-preview-modal.tsx
@@ -33,6 +33,7 @@ export function RenamePreviewModal( { initialName, onRename, onClose }: RenamePr
 							autoFocus
 							onChange={ setNewName }
 							value={ newName }
+							maxLength={ 50 }
 						></TextControlComponent>
 					</label>
 					<div className="flex justify-end gap-3 mt-4">

--- a/src/modules/preview-site/components/rename-preview-modal.tsx
+++ b/src/modules/preview-site/components/rename-preview-modal.tsx
@@ -1,0 +1,50 @@
+import { __ } from '@wordpress/i18n';
+import { useState } from 'react';
+import Button from 'src/components/button';
+import Modal from 'src/components/modal';
+
+interface RenamePreviewModalProps {
+	initialName: string;
+	onRename: ( newName: string ) => void;
+	onClose: () => void;
+}
+
+export function RenamePreviewModal( { initialName, onRename, onClose }: RenamePreviewModalProps ) {
+	const [ newName, setNewName ] = useState( initialName );
+
+	const handleRename = () => {
+		if ( ! newName.trim() ) return;
+		onRename( newName.trim() );
+	};
+
+	return (
+		<Modal title={ __( 'Rename preview link' ) } onRequestClose={ onClose } isDismissible>
+			<form onSubmit={ handleRename }>
+				<div className="flex flex-col gap-4">
+					<label className="flex flex-col gap-1.5">
+						<span className="font-semibold">{ __( 'Name' ) }</span>
+						<input
+							type="text"
+							value={ newName }
+							onChange={ ( e ) => setNewName( e.target.value ) }
+							className="border rounded px-3 py-2"
+							autoFocus
+						/>
+					</label>
+					<div className="flex justify-end gap-3 mt-4">
+						<Button variant="tertiary" onClick={ onClose }>
+							{ __( 'Cancel' ) }
+						</Button>
+						<Button
+							variant="primary"
+							onClick={ handleRename }
+							disabled={ ! newName.trim() || newName.trim() === initialName }
+						>
+							{ __( 'Save' ) }
+						</Button>
+					</div>
+				</div>
+			</form>
+		</Modal>
+	);
+}

--- a/src/modules/preview-site/components/rename-preview-modal.tsx
+++ b/src/modules/preview-site/components/rename-preview-modal.tsx
@@ -18,7 +18,12 @@ export function RenamePreviewModal( { initialName, onRename, onClose }: RenamePr
 	};
 
 	return (
-		<Modal title={ __( 'Rename preview link' ) } onRequestClose={ onClose } isDismissible>
+		<Modal
+			title={ __( 'Rename preview link' ) }
+			size="medium"
+			onRequestClose={ onClose }
+			isDismissible
+		>
 			<form onSubmit={ handleRename }>
 				<div className="flex flex-col gap-4">
 					<label className="flex flex-col gap-1.5">

--- a/src/modules/preview-site/components/rename-preview-modal.tsx
+++ b/src/modules/preview-site/components/rename-preview-modal.tsx
@@ -2,6 +2,7 @@ import { __ } from '@wordpress/i18n';
 import { useState } from 'react';
 import Button from 'src/components/button';
 import Modal from 'src/components/modal';
+import TextControlComponent from 'src/components/text-control';
 
 interface RenamePreviewModalProps {
 	initialName: string;
@@ -26,15 +27,13 @@ export function RenamePreviewModal( { initialName, onRename, onClose }: RenamePr
 		>
 			<form onSubmit={ handleRename }>
 				<div className="flex flex-col gap-4">
-					<label className="flex flex-col gap-1.5">
+					<label className="flex flex-col gap-1.5 leading-4 mb-6">
 						<span className="font-semibold">{ __( 'Name' ) }</span>
-						<input
-							type="text"
-							value={ newName }
-							onChange={ ( e ) => setNewName( e.target.value ) }
-							className="border rounded px-3 py-2"
+						<TextControlComponent
 							autoFocus
-						/>
+							onChange={ setNewName }
+							value={ newName }
+						></TextControlComponent>
 					</label>
 					<div className="flex justify-end gap-3 mt-4">
 						<Button variant="tertiary" onClick={ onClose }>

--- a/src/modules/preview-site/components/tests/preview-action-buttons-menu.test.tsx
+++ b/src/modules/preview-site/components/tests/preview-action-buttons-menu.test.tsx
@@ -1,0 +1,112 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useSnapshots } from 'src/hooks/use-snapshots';
+import { PreviewActionButtonsMenu } from '../preview-action-buttons-menu';
+
+jest.mock( 'src/hooks/use-snapshots', () => ( {
+	useSnapshots: jest.fn().mockReturnValue( {
+		deleteSnapshot: jest.fn(),
+		updateSnapshot: jest.fn(),
+	} ),
+} ) );
+
+describe( 'PreviewActionButtonsMenu Rename', () => {
+	const mockSnapshot = {
+		atomicSiteId: 123,
+		localSiteId: '456',
+		url: 'test.com',
+		date: 123456789,
+		name: 'Test Preview',
+		sequence: 1,
+	};
+
+	const mockSelectedSite: StoppedSiteDetails = {
+		id: '456',
+		name: 'Test Site',
+		path: '/test/path',
+		phpVersion: '8.0',
+		running: false,
+	};
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'opens rename modal when rename menu item is clicked', async () => {
+		const user = userEvent.setup();
+		render(
+			<PreviewActionButtonsMenu snapshot={ mockSnapshot } selectedSite={ mockSelectedSite } />
+		);
+
+		await user.click( screen.getByLabelText( 'Preview actions' ) );
+		await user.click( screen.getByText( 'Rename' ) );
+
+		expect( screen.getByRole( 'heading', { name: 'Rename preview link' } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'textbox', { name: 'Name' } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: 'Save' } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: 'Cancel' } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: 'Close' } ) ).toBeInTheDocument();
+	} );
+
+	it( 'clicks update without modifying the existing name', async () => {
+		const user = userEvent.setup();
+		render(
+			<PreviewActionButtonsMenu snapshot={ mockSnapshot } selectedSite={ mockSelectedSite } />
+		);
+
+		await user.click( screen.getByLabelText( 'Preview actions' ) );
+		await user.click( screen.getByText( 'Rename' ) );
+		await user.click( screen.getByText( 'Save' ) );
+
+		expect( screen.getByRole( 'button', { name: 'Save' } ) ).toBeDisabled();
+		expect( useSnapshots().updateSnapshot ).not.toHaveBeenCalled();
+	} );
+
+	it( 'calls updateSnapshot with new name when rename is confirmed', async () => {
+		const user = userEvent.setup();
+		render(
+			<PreviewActionButtonsMenu snapshot={ mockSnapshot } selectedSite={ mockSelectedSite } />
+		);
+		await user.click( screen.getByLabelText( 'Preview actions' ) );
+		await user.click( screen.getByText( 'Rename' ) );
+		await user.clear( screen.getByRole( 'textbox', { name: 'Name' } ) );
+		await user.type( screen.getByRole( 'textbox', { name: 'Name' } ), 'New Cool Name' );
+		await user.click( screen.getByText( 'Save' ) );
+
+		expect( useSnapshots().updateSnapshot ).toHaveBeenCalledWith( {
+			...mockSnapshot,
+			name: 'New Cool Name',
+		} );
+	} );
+
+	it( 'closes rename modal without updating when cancelled', async () => {
+		const user = userEvent.setup();
+		render(
+			<PreviewActionButtonsMenu snapshot={ mockSnapshot } selectedSite={ mockSelectedSite } />
+		);
+
+		await user.click( screen.getByLabelText( 'Preview actions' ) );
+		await user.click( screen.getByText( 'Rename' ) );
+		await user.click( screen.getByRole( 'button', { name: 'Cancel' } ) );
+
+		expect(
+			screen.queryByRole( 'heading', { name: 'Rename preview link' } )
+		).not.toBeInTheDocument();
+		expect( useSnapshots().updateSnapshot ).not.toHaveBeenCalled();
+	} );
+
+	it( 'closes rename modal without updating when closed', async () => {
+		const user = userEvent.setup();
+		render(
+			<PreviewActionButtonsMenu snapshot={ mockSnapshot } selectedSite={ mockSelectedSite } />
+		);
+
+		await user.click( screen.getByLabelText( 'Preview actions' ) );
+		await user.click( screen.getByText( 'Rename' ) );
+		await user.click( screen.getByRole( 'button', { name: 'Close' } ) );
+
+		expect(
+			screen.queryByRole( 'heading', { name: 'Rename preview link' } )
+		).not.toBeInTheDocument();
+		expect( useSnapshots().updateSnapshot ).not.toHaveBeenCalled();
+	} );
+} );

--- a/src/modules/preview-site/components/tests/rename-preview-modal.test.tsx
+++ b/src/modules/preview-site/components/tests/rename-preview-modal.test.tsx
@@ -1,0 +1,116 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { RenamePreviewModal } from '../rename-preview-modal';
+
+describe( 'RenamePreviewModal', () => {
+	const mockOnRename = jest.fn();
+	const mockOnClose = jest.fn();
+	const initialName = 'Initial Preview Name';
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'renders with initial name in input', () => {
+		render(
+			<RenamePreviewModal
+				initialName={ initialName }
+				onRename={ mockOnRename }
+				onClose={ mockOnClose }
+			/>
+		);
+
+		expect( screen.getByRole( 'textbox' ) ).toHaveValue( initialName );
+		expect( screen.getByRole( 'button', { name: 'Save' } ) ).toBeDisabled();
+	} );
+
+	it( 'calls onClose when cancel button is clicked', async () => {
+		const user = userEvent.setup();
+		render(
+			<RenamePreviewModal
+				initialName={ initialName }
+				onRename={ mockOnRename }
+				onClose={ mockOnClose }
+			/>
+		);
+
+		await user.click( screen.getByRole( 'button', { name: 'Cancel' } ) );
+		expect( mockOnClose ).toHaveBeenCalledTimes( 1 );
+		expect( mockOnRename ).not.toHaveBeenCalled();
+	} );
+
+	it( 'enables save button when name is changed', async () => {
+		const user = userEvent.setup();
+		render(
+			<RenamePreviewModal
+				initialName={ initialName }
+				onRename={ mockOnRename }
+				onClose={ mockOnClose }
+			/>
+		);
+
+		const saveButton = screen.getByRole( 'button', { name: 'Save' } );
+		expect( saveButton ).toBeDisabled();
+
+		const input = screen.getByRole( 'textbox' );
+		await user.clear( input );
+		await user.type( input, 'New Preview Name' );
+
+		expect( saveButton ).toBeEnabled();
+	} );
+
+	it( 'calls onRename with trimmed name when save button is clicked', async () => {
+		const user = userEvent.setup();
+		render(
+			<RenamePreviewModal
+				initialName={ initialName }
+				onRename={ mockOnRename }
+				onClose={ mockOnClose }
+			/>
+		);
+
+		const input = screen.getByRole( 'textbox' );
+		await user.clear( input );
+		await user.type( input, '  New Preview Name  ' );
+
+		await user.click( screen.getByRole( 'button', { name: 'Save' } ) );
+		expect( mockOnRename ).toHaveBeenCalledWith( 'New Preview Name' );
+	} );
+
+	it( 'keeps save button disabled when input is empty or whitespace', async () => {
+		const user = userEvent.setup();
+		render(
+			<RenamePreviewModal
+				initialName={ initialName }
+				onRename={ mockOnRename }
+				onClose={ mockOnClose }
+			/>
+		);
+
+		const saveButton = screen.getByRole( 'button', { name: 'Save' } );
+		const input = screen.getByRole( 'textbox' );
+
+		await user.clear( input );
+		expect( saveButton ).toBeDisabled();
+
+		await user.type( input, '   ' );
+		expect( saveButton ).toBeDisabled();
+	} );
+
+	it( 'calls onRename when form is submitted when pressing Enter', async () => {
+		const user = userEvent.setup();
+		render(
+			<RenamePreviewModal
+				initialName={ initialName }
+				onRename={ mockOnRename }
+				onClose={ mockOnClose }
+			/>
+		);
+
+		const input = screen.getByRole( 'textbox' );
+		await user.clear( input );
+		await user.type( input, 'New Preview Name{Enter}' );
+
+		expect( mockOnRename ).toHaveBeenCalledWith( 'New Preview Name' );
+	} );
+} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/dotcom-forge/issues/10353


<img width="1032" alt="Screenshot 2025-02-07 at 15 07 30" src="https://github.com/user-attachments/assets/54ba6c2c-4283-4052-a0b4-217d647a3ce8" />

<img width="1032" alt="Screenshot 2025-02-07 at 15 12 11" src="https://github.com/user-attachments/assets/71997f05-e431-4e17-98b8-6e8d23249bdc" />


## Proposed Changes

- Add  modal to rename preview names and save them in appData

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run `STUDIO_QUICK_DEPLOYS=true npm start`
- Go to the previews tab
- Create a new one if you don't have any
- Click on the action menu on the right
- Change the preview name
- Observe the changes is reflected in the UI and also in appData

https://github.com/user-attachments/assets/fc457d38-acdf-40cd-bd60-ca0a19a3c519

In the video the input appears with yellow border, that's fixed on https://github.com/Automattic/studio/pull/905/commits/1fac7bd8b79fecc06699528a5d7a33d37fc39244



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
