### PR TITLE
Fix some RTL styles

### DIFF
--- a/src/components/content-tab-sync.tsx
+++ b/src/components/content-tab-sync.tsx
@@ -24,7 +24,7 @@ function SiteSyncDescription( { children }: PropsWithChildren ) {
 			<div className="flex flex-col p-8">
 				<div className="flex items-center mb-1">
 					<div className="a8c-subtitle">{ __( 'Sync with' ) }</div>
-					<WordPressShortLogo className="ltr:ml-2 rtl:mr-2 h-5" />
+					<WordPressShortLogo className="ms-2 h-5" />
 				</div>
 				<div className="max-w-[40ch] text-a8c-gray-70 a8c-body">
 					{ __(
@@ -38,7 +38,7 @@ function SiteSyncDescription( { children }: PropsWithChildren ) {
 						__( 'Sync database and file changes.' ),
 					].map( ( text ) => (
 						<div key={ text } className="text-a8c-gray-70 a8c-body flex items-center">
-							<Icon className="fill-a8c-blueberry ltr:mr-2 rtl:ml-2 shrink-0" icon={ check } />
+							<Icon className="fill-a8c-blueberry me-2 shrink-0" icon={ check } />
 							{ text }
 						</div>
 					) ) }

--- a/src/components/content-tab-sync.tsx
+++ b/src/components/content-tab-sync.tsx
@@ -45,7 +45,7 @@ function SiteSyncDescription( { children }: PropsWithChildren ) {
 				</div>
 				{ children }
 			</div>
-			<div className="flex flex-col shrink-0 items-end p-4">
+			<div className="flex flex-col shrink-0 items-end p-4 rtl:order-first">
 				<SyncTabImage />
 			</div>
 		</div>

--- a/src/components/modal.tsx
+++ b/src/components/modal.tsx
@@ -8,7 +8,11 @@ export default function Modal( { className, ...rest }: ComponentProps< typeof WP
 	return (
 		<WPModal
 			closeButtonLabel={ __( 'Close' ) }
-			className={ cx( 'select-none [&_h1]:!text-xl [&_h1]:!font-normal outline-0', className ) }
+			className={ cx(
+				'select-none [&_h1]:!text-xl [&_h1]:!font-normal outline-0',
+				'[&_h1]:flex-1 [&_h1]:rtl:text-right',
+				className
+			) }
 			{ ...rest }
 		/>
 	);

--- a/src/components/modal.tsx
+++ b/src/components/modal.tsx
@@ -10,7 +10,7 @@ export default function Modal( { className, ...rest }: ComponentProps< typeof WP
 			closeButtonLabel={ __( 'Close' ) }
 			className={ cx(
 				'select-none [&_h1]:!text-xl [&_h1]:!font-normal outline-0',
-				'[&_h1]:flex-1 [&_h1]:rtl:text-right',
+				'[&_h1]:flex-1 [&_h1]:text-start',
 				className
 			) }
 			{ ...rest }

--- a/src/components/modal.tsx
+++ b/src/components/modal.tsx
@@ -11,6 +11,10 @@ export default function Modal( { className, ...rest }: ComponentProps< typeof WP
 			className={ cx(
 				'select-none [&_h1]:!text-xl [&_h1]:!font-normal outline-0',
 				'[&_h1]:flex-1 [&_h1]:text-start',
+				'[&_[role="document"]>div:first-child_button]:rtl:left-0',
+				'[&_[role="document"]>div:first-child_button]:rtl:right-2',
+				'[&_[role="document"]>div:first-child_button]:ltr:left-2',
+				'[&_[role="document"]>div:first-child_button]:ltr:right-0',
 				className
 			) }
 			{ ...rest }

--- a/src/components/sync-connected-sites.tsx
+++ b/src/components/sync-connected-sites.tsx
@@ -148,7 +148,7 @@ const SyncConnectedSitesSection = ( {
 				<div className={ cx( 'a8c-label-semibold', hasConnectionErrors && 'error-message' ) }>
 					{ section.name }
 				</div>
-				<div className="!ml-auto rtl:!mr-auto rtl:!ml-0">
+				<div className="ms-auto">
 					<Tooltip
 						text={ __(
 							'This site is syncing. Please wait for the sync to finish before you can disconnect it.'
@@ -190,7 +190,7 @@ const SyncConnectedSitesSection = ( {
 					<Button
 						onClick={ () => openSitesSyncSelector( { disconnectSiteId: section.id } ) }
 						variant="primary"
-						className="ml-auto rtl:mr-auto rtl:ml-0"
+						className="ms-auto"
 					>
 						{ __( 'Reconnect' ) }
 					</Button>
@@ -214,7 +214,7 @@ const SyncConnectedSitesSection = ( {
 							key={ connectedSite.id }
 							className="flex items-center gap-2 min-h-14 border-b border-a8c-gray-0 px-8"
 						>
-							<div className="flex items-left min-w-20 ltr:mr-6 rtl:ml-6 shrink-0">
+							<div className="flex items-left min-w-20 me-6 shrink-0">
 								{ connectedSite.isStaging ? (
 									<Badge>{ __( 'Staging' ) }</Badge>
 								) : (
@@ -233,7 +233,7 @@ const SyncConnectedSitesSection = ( {
 									<span className="truncate">{ connectedSite.url }</span> <ArrowIcon />
 								</Button>
 							</Tooltip>
-							<div className="flex gap-2 ltr:pl-4 rtl:pr-4 ml-auto rtl:mr-auto rtl:ml-0 shrink-0">
+							<div className="flex gap-2 ps-4 ms-auto shrink-0">
 								{ isPulling && (
 									<div className="flex flex-col gap-2 min-w-44">
 										<div className="a8c-body-small">{ sitePullState.status.message }</div>
@@ -289,7 +289,7 @@ const SyncConnectedSitesSection = ( {
 											text={ __( 'Pulling or pushing a site requires an internet connection.' ) }
 											placement="top-start"
 										>
-											<div className="flex gap-2 ltr:pl-4 rtl:pr-4 ml-auto rtl:mr-auto rtl:ml-0 shrink-0 h-5">
+											<div className="flex gap-2 ps-4 ms-auto shrink-0 h-5">
 												{ isAnySiteSyncing ? (
 													<Tooltip
 														text={

--- a/src/components/sync-connected-sites.tsx
+++ b/src/components/sync-connected-sites.tsx
@@ -148,7 +148,7 @@ const SyncConnectedSitesSection = ( {
 				<div className={ cx( 'a8c-label-semibold', hasConnectionErrors && 'error-message' ) }>
 					{ section.name }
 				</div>
-				<div className="!ml-auto">
+				<div className="!ml-auto rtl:!mr-auto rtl:!ml-0">
 					<Tooltip
 						text={ __(
 							'This site is syncing. Please wait for the sync to finish before you can disconnect it.'
@@ -190,7 +190,7 @@ const SyncConnectedSitesSection = ( {
 					<Button
 						onClick={ () => openSitesSyncSelector( { disconnectSiteId: section.id } ) }
 						variant="primary"
-						className="ml-auto"
+						className="ml-auto rtl:mr-auto rtl:ml-0"
 					>
 						{ __( 'Reconnect' ) }
 					</Button>
@@ -214,7 +214,7 @@ const SyncConnectedSitesSection = ( {
 							key={ connectedSite.id }
 							className="flex items-center gap-2 min-h-14 border-b border-a8c-gray-0 px-8"
 						>
-							<div className="flex items-left min-w-20 mr-6 shrink-0">
+							<div className="flex items-left min-w-20 ltr:mr-6 rtl:ml-6 shrink-0">
 								{ connectedSite.isStaging ? (
 									<Badge>{ __( 'Staging' ) }</Badge>
 								) : (
@@ -233,7 +233,7 @@ const SyncConnectedSitesSection = ( {
 									<span className="truncate">{ connectedSite.url }</span> <ArrowIcon />
 								</Button>
 							</Tooltip>
-							<div className="flex gap-2 pl-4 ml-auto shrink-0">
+							<div className="flex gap-2 ltr:pl-4 rtl:pr-4 ml-auto rtl:mr-auto rtl:ml-0 shrink-0">
 								{ isPulling && (
 									<div className="flex flex-col gap-2 min-w-44">
 										<div className="a8c-body-small">{ sitePullState.status.message }</div>
@@ -289,7 +289,7 @@ const SyncConnectedSitesSection = ( {
 											text={ __( 'Pulling or pushing a site requires an internet connection.' ) }
 											placement="top-start"
 										>
-											<div className="flex gap-2 pl-4 ml-auto shrink-0 h-5">
+											<div className="flex gap-2 ltr:pl-4 rtl:pr-4 ml-auto rtl:mr-auto rtl:ml-0 shrink-0 h-5">
 												{ isAnySiteSyncing ? (
 													<Tooltip
 														text={

--- a/src/components/sync-pull-push-clear.tsx
+++ b/src/components/sync-pull-push-clear.tsx
@@ -18,6 +18,7 @@ export function SyncPullPushClear( {
 		<div
 			className={ cx(
 				'flex gap-4 pl-4 ml-auto items-center shrink-0',
+				'rtl:pl-0',
 				isError ? 'text-a8c-red-50' : 'text-a8c-green-50'
 			) }
 		>

--- a/src/components/sync-pull-push-clear.tsx
+++ b/src/components/sync-pull-push-clear.tsx
@@ -17,8 +17,7 @@ export function SyncPullPushClear( {
 	return (
 		<div
 			className={ cx(
-				'flex gap-4 pl-4 ml-auto items-center shrink-0',
-				'rtl:pl-0',
+				'flex gap-4 ps-4 ms-auto items-center shrink-0',
 				isError ? 'text-a8c-red-50' : 'text-a8c-green-50'
 			) }
 		>
@@ -26,7 +25,7 @@ export function SyncPullPushClear( {
 				{ isError ? <ErrorIcon /> : <CheckIcon /> }
 				{ children }
 			</span>
-			<Button variant="link" className="ml-3" onClick={ onClick }>
+			<Button variant="link" className="ms-3" onClick={ onClick }>
 				{ __( 'Clear' ) }
 			</Button>
 		</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/dotcom-forge/issues/10374

## Proposed Changes

<details>
<summary> Modal title alignment</summary>

![image](https://github.com/user-attachments/assets/5840fc79-d87f-4dec-9660-370c1a8310ac)

</details>

<details>
<summary>Sync pull/push buttons</summary>

![image](https://github.com/user-attachments/assets/047a0c19-570c-423a-9a8a-765036ab9679)

</details>

<details>
<summary>Sync progress bar</summary>

![image](https://github.com/user-attachments/assets/e2dc3b41-63db-4b56-a6e1-f533bb5999c5)

</details>

<details>
<summary>Sync clear button</summary>

![image](https://github.com/user-attachments/assets/b29dce05-b07a-4e36-adbd-ff6e6c9671b7)

</details>

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Open studio and change the language to an RTL language
2. Check a modal title (user settings, create site, etc...)
3. Navigate to Sync tab
4. Check the icons alignment
5. Do a push/pull and check the progress bar layout
6. After the push/pull check the clear button layout

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
