### PR TITLE
Experiment using localizeUrl from i18n utils 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@automattic/generate-password": "^0.1.0",
+				"@automattic/i18n-utils": "^1.2.3",
 				"@formatjs/intl-locale": "^3.4.5",
 				"@formatjs/intl-localematcher": "^0.5.4",
 				"@php-wasm/node": "^0.9.44",
@@ -248,6 +249,19 @@
 				}
 			]
 		},
+		"node_modules/@automattic/calypso-config": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@automattic/calypso-config/-/calypso-config-1.2.0.tgz",
+			"integrity": "sha512-7NE5oVOEyQ4KRz1VNnPIHgW+mcwxnkcs/+Cymba7OA7SYKARiTg3ETGlZGX19S0F7gjYZMq+IeLHeAZSrNjz/Q=="
+		},
+		"node_modules/@automattic/calypso-url": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@automattic/calypso-url/-/calypso-url-1.1.0.tgz",
+			"integrity": "sha512-oA6pzfrp538gq5JEjE0ARDjvR8Efhw+jrK15TJPjAq5Q+vhPSJhH8sYKEsMAoYZV3d5nnyUcmI5Evge+yq4zeg==",
+			"dependencies": {
+				"photon": "^4.0.0"
+			}
+		},
 		"node_modules/@automattic/color-studio": {
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/@automattic/color-studio/-/color-studio-2.5.0.tgz",
@@ -258,6 +272,183 @@
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/@automattic/generate-password/-/generate-password-0.1.0.tgz",
 			"integrity": "sha512-NrqlnKZ7uwanHagVu9E1LC2YCC2X6rhXZMmyknoIXjHl0m4wHRTlj8t3MKDfiFk/Qg61LNTs4IiLO5AFHSExlQ=="
+		},
+		"node_modules/@automattic/i18n-utils": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@automattic/i18n-utils/-/i18n-utils-1.2.3.tgz",
+			"integrity": "sha512-zvZlazUoEasLATrta3ljfxu2uaZWgHRNKWf56KKBlrPiIxNQvx9D7YyN2MhiV27e/PuAhB0gI4ghqp3gzurKmA==",
+			"dependencies": {
+				"@automattic/calypso-config": "^1.0.0-alpha.0",
+				"@automattic/calypso-url": "^1.1.0",
+				"@automattic/languages": "^1.0.0",
+				"@wordpress/compose": "^7.2.0",
+				"@wordpress/i18n": "^5.2.0",
+				"react": "^18.2.0",
+				"tslib": "^2.3.0"
+			}
+		},
+		"node_modules/@automattic/i18n-utils/node_modules/@wordpress/compose": {
+			"version": "7.17.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.17.0.tgz",
+			"integrity": "sha512-jn5uCw08HHLfOpIDp0pKBDZh1oZiMwjiK3c3IZdZo6eoWZjpOr3ecsMa4RBl/4HbqnUoeFDD6Lj83IEKPuzHQg==",
+			"dependencies": {
+				"@babel/runtime": "7.25.7",
+				"@types/mousetrap": "^1.6.8",
+				"@wordpress/deprecated": "^4.17.0",
+				"@wordpress/dom": "^4.17.0",
+				"@wordpress/element": "^6.17.0",
+				"@wordpress/is-shallow-equal": "^5.17.0",
+				"@wordpress/keycodes": "^4.17.0",
+				"@wordpress/priority-queue": "^3.17.0",
+				"@wordpress/undo-manager": "^1.17.0",
+				"change-case": "^4.1.2",
+				"clipboard": "^2.0.11",
+				"mousetrap": "^1.6.5",
+				"use-memo-one": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
+			}
+		},
+		"node_modules/@automattic/i18n-utils/node_modules/@wordpress/deprecated": {
+			"version": "4.17.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.17.0.tgz",
+			"integrity": "sha512-7IlFpQ6tNkUbOuuxm6kBCR2R6C9Etlzojgh0ykJ/OmwgRMrosH/m6/zAmaA15oRYpd6dvO7ozJN+ArPz7LSOiQ==",
+			"dependencies": {
+				"@babel/runtime": "7.25.7",
+				"@wordpress/hooks": "^4.17.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@automattic/i18n-utils/node_modules/@wordpress/dom": {
+			"version": "4.17.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.17.0.tgz",
+			"integrity": "sha512-raAeub1L/a2yHd9rwCGs67yDSUsafcpERi9rJCeHiaBE/+h7gZn7Li+Pya+DMk7tGxoIHNpPuGVTAyVhQbjWdQ==",
+			"dependencies": {
+				"@babel/runtime": "7.25.7",
+				"@wordpress/deprecated": "^4.17.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@automattic/i18n-utils/node_modules/@wordpress/element": {
+			"version": "6.17.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.17.0.tgz",
+			"integrity": "sha512-mRLFDPmZiI3+POi/iUGoof/9fQi4YTJ/RAuIUipr7yG7l4SwOoQy4eSJy6QTyqtJxZ+/7qA+b/+Ek15UzFst5Q==",
+			"dependencies": {
+				"@babel/runtime": "7.25.7",
+				"@types/react": "^18.2.79",
+				"@types/react-dom": "^18.2.25",
+				"@wordpress/escape-html": "^3.17.0",
+				"change-case": "^4.1.2",
+				"is-plain-object": "^5.0.0",
+				"react": "^18.3.0",
+				"react-dom": "^18.3.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@automattic/i18n-utils/node_modules/@wordpress/hooks": {
+			"version": "4.17.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.17.0.tgz",
+			"integrity": "sha512-LGOHGuwCXCevuzaFpM2sgyPZxf3H7tWaSKzlvDzx2kmwiWIrFug/yebywv4Cxsl82I5DfZkDpxXRpqTxXrC0Nw==",
+			"dependencies": {
+				"@babel/runtime": "7.25.7"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@automattic/i18n-utils/node_modules/@wordpress/i18n": {
+			"version": "5.17.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-5.17.0.tgz",
+			"integrity": "sha512-aAsYls8sTTSEimsvjxBl9mCYbZYD3BddHVpuHgbBxzC+2SZE+JYJ+IpcwEghC712qo0jEkG8Vdzhqae1PL6vCQ==",
+			"dependencies": {
+				"@babel/runtime": "7.25.7",
+				"@wordpress/hooks": "^4.17.0",
+				"gettext-parser": "^1.3.1",
+				"memize": "^2.1.0",
+				"sprintf-js": "^1.1.1",
+				"tannin": "^1.2.0"
+			},
+			"bin": {
+				"pot-to-php": "tools/pot-to-php.js"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@automattic/i18n-utils/node_modules/@wordpress/is-shallow-equal": {
+			"version": "5.17.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.17.0.tgz",
+			"integrity": "sha512-PRykD6MgDkptKsKwETjNHiQUVtaegXkREX6UetN1iL6u+2la4XC/naDHByq7TL+Cg4snyR+PlNdw45Y4dgMf5w==",
+			"dependencies": {
+				"@babel/runtime": "7.25.7"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@automattic/i18n-utils/node_modules/@wordpress/keycodes": {
+			"version": "4.17.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.17.0.tgz",
+			"integrity": "sha512-6aZ28uoCmzjXONpRVtDPjevkw834fhIRBnn2KQdzENMnPiQCNbiG71mPNxkTw1yRHRRT5ptHvOe49ztWm9KMcA==",
+			"dependencies": {
+				"@babel/runtime": "7.25.7",
+				"@wordpress/i18n": "^5.17.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@automattic/i18n-utils/node_modules/@wordpress/priority-queue": {
+			"version": "3.17.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.17.0.tgz",
+			"integrity": "sha512-WzQHNx6wjgbxhuaKErjIRLSL9E9La8slsAXRTQPmkgvKqa11Rh4RYl2FLUh8tABK3xo5HzaHCplkZSm2q5wlbg==",
+			"dependencies": {
+				"@babel/runtime": "7.25.7",
+				"requestidlecallback": "^0.3.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@automattic/i18n-utils/node_modules/@wordpress/undo-manager": {
+			"version": "1.17.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.17.0.tgz",
+			"integrity": "sha512-inSOCUneGMmFq3jRTB9uIws/+6VWpz0zvY2IPW/vjWbz7Gg1YbJ+lmbbgtJCoiJ7Ei00b4sagvzI00TNUXe9mg==",
+			"dependencies": {
+				"@babel/runtime": "7.25.7",
+				"@wordpress/is-shallow-equal": "^5.17.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@automattic/languages": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@automattic/languages/-/languages-1.0.0.tgz",
+			"integrity": "sha512-froTyDbTmLitHkvY9WLCpFdjUo6moOLkDKw63J2fLiB2gBApy2thkBV+LRx4Z0kIF5iXVkQF4yYOPYkT9Sr13Q==",
+			"dependencies": {
+				"tslib": "^2.3.0"
+			}
 		},
 		"node_modules/@automattic/wp-babel-makepot": {
 			"version": "1.2.0",
@@ -6007,6 +6198,11 @@
 			"integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
 			"dev": true
 		},
+		"node_modules/@types/seed-random": {
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/@types/seed-random/-/seed-random-2.2.4.tgz",
+			"integrity": "sha512-M4wSiHb23w6oRFo69SrjWiYMXocfhRyzX5kuGkAJmLrYJDD//8zmhsY+9t6t87RLYhyIcE4h3feYwqOFdaslHw=="
+		},
 		"node_modules/@types/semver": {
 			"version": "7.5.8",
 			"resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
@@ -7133,9 +7329,9 @@
 			}
 		},
 		"node_modules/@wordpress/escape-html": {
-			"version": "3.10.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.10.0.tgz",
-			"integrity": "sha512-3glY3MhXEHlPP0/hrS3vkRmAOHtutvoHGhkr8vnva6TLg4CsAeo42nYbuFJ+ukVMWdCtmV+28UjOeiYtG/fZOA==",
+			"version": "3.17.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.17.0.tgz",
+			"integrity": "sha512-yOfJwgmrtIXQDwX6zTC0L7ymYBXz3K3hlW0nDdtYy+bCw5z0gbrEOnBotOD6YdXlejAgnaAH+K1VSf0xxG5uGA==",
 			"dependencies": {
 				"@babel/runtime": "7.25.7"
 			},
@@ -10776,6 +10972,17 @@
 			},
 			"engines": {
 				"node": ">=0.8"
+			}
+		},
+		"node_modules/crc32": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/crc32/-/crc32-0.2.2.tgz",
+			"integrity": "sha512-PFZEGbDUeoNbL2GHIEpJRQGheXReDody/9axKTxhXtQqIL443wnNigtVZO9iuCIMPApKZRv7k2xr8euXHqNxQQ==",
+			"bin": {
+				"crc32": "bin/runner.js"
+			},
+			"engines": {
+				"node": ">= 0.4.0"
 			}
 		},
 		"node_modules/crc32-stream": {
@@ -20447,6 +20654,18 @@
 			"resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
 			"integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="
 		},
+		"node_modules/photon": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/photon/-/photon-4.1.1.tgz",
+			"integrity": "sha512-YPsf1/tpjc8IjaOmDOLOY3fe4ajvLjsYY6Vlwn4SsoeI9U022u+U0skzB/Tk6jX6rtmNpoc6wj72de0oB267JQ==",
+			"dependencies": {
+				"@types/seed-random": "^2.2.1",
+				"crc32": "^0.2.2",
+				"debug": "^4.3.3",
+				"seed-random": "^2.2.0",
+				"tslib": "^2.3.0"
+			}
+		},
 		"node_modules/picocolors": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -22180,6 +22399,11 @@
 				"type": "opencollective",
 				"url": "https://opencollective.com/webpack"
 			}
+		},
+		"node_modules/seed-random": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/seed-random/-/seed-random-2.2.0.tgz",
+			"integrity": "sha512-34EQV6AAHQGhoc0tn/96a9Fsi6v2xdqe/dMUwljGRaFOzR3EgRmECvD0O8vi8X+/uQ50LGHfkNu/Eue5TPKZkQ=="
 		},
 		"node_modules/select": {
 			"version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
 	},
 	"dependencies": {
 		"@automattic/generate-password": "^0.1.0",
+		"@automattic/i18n-utils": "^1.2.3",
 		"@formatjs/intl-locale": "^3.4.5",
 		"@formatjs/intl-localematcher": "^0.5.4",
 		"@php-wasm/node": "^0.9.44",

--- a/src/components/content-tab-import-export.tsx
+++ b/src/components/content-tab-import-export.tsx
@@ -1,3 +1,4 @@
+import { localizeUrl } from '@automattic/i18n-utils';
 import { speak } from '@wordpress/a11y';
 import { Notice } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
@@ -232,7 +233,9 @@ const ImportSite = ( {
 						button: (
 							<Button
 								variant="link"
-								onClick={ () => getIpcApi().openURL( STUDIO_DOCS_URL_IMPORT_EXPORT ) }
+								onClick={ () =>
+									getIpcApi().openURL( localizeUrl( STUDIO_DOCS_URL_IMPORT_EXPORT, 'es' ) )
+								}
 							/>
 						),
 					}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Related to https://github.com/Automattic/dotcom-forge/issues/10048

## Proposed Changes

- I tried using `localizeUrl` from  `@automattic/i18n-utils`, but I couldn't make it work as it tries to 
- I also found that it's not exactly what we need since Studio docs are only available in English and Spanish.

I'm creating this PR just to document my exploration.



<details>
    <summary>Error returned:</summary>
<code>
studio on  trunk [$+] via  v20.15.1 via 💎 v2.6.10 took 23s 
❯ npm start

> studio@1.3.3 start
> electron-forge start

✔ Checking your system
✔ Locating application
✔ Loading configuration
✔ Preparing native dependencies: 1 / 1 [0.3s]
✔ Running generateAssets hook
❯ Running preStart hook
  ❯ [plugin-webpack] Preparing webpack bundles
    ✔ Compiling main process code [4s]
    ✖ Launching dev servers for renderer process code
      › Compilation errors in the preload: group_0:
        asset main_window/preload.js 238 KiB [emitted] (name: main_window) 1 related asset
        runtime modules 29.4 KiB 14 modules
        modules by path ./node_modules/ 165 KiB
        modules by path ./node_modules/webpack-dev-server/client/ 71.8 KiB 16 modules
        modules by path ./node_modules/webpack/hot/*.js 5.17 KiB
        ./node_modules/webpack/hot/dev-server.js 1.94 KiB [built] [code generated]
        + 3 modules
        modules by path ./node_modules/html-entities/lib/*.js 81.8 KiB
        ./node_modules/html-entities/lib/index.js 7.91 KiB [built] [code generated]
        ./node_modules/html-entities/lib/named-references.js 73 KiB [built] [code generated]
        + 2 modules
        ./node_modules/@sentry/electron/preload/index.js 2.06 KiB [built] [code generated]
        ./node_modules/ansi-html-community/index.js 4.16 KiB [built] [code generated]
        ./src/preload.ts 7.19 KiB [built] [code generated]
        external "electron" 42 bytes [built] [code generated]
        external "events" 42 bytes [built] [code generated]
        group_0 (webpack 5.94.0) compiled successfully in 2342 ms
        group_0:
        assets by path main_window/ 17.8 MiB
        asset main_window/index.js 17.8 MiB [emitted] (name: main_window) 1 related asset
        asset main_window/index.html 327 bytes [emitted]
        assets by info 1.11 MiB [immutable]
        asset 8476d11ddab2043938ed.wasm 1.06 MiB [emitted] [immutable] [from:
        node_modules/@rive-app/canvas/rive.wasm] (auxiliary name: main_window)
        asset a33f17d2656a6f583a3d.riv 52.9 KiB [emitted] [immutable] [from: assets/ai-icon.riv]
        (auxiliary name: main_window)
        asset main_window.css 169 KiB [emitted] (name: main_window) 1 related asset
        Entrypoint main_window 18 MiB (16.5 MiB) = main_window.css 169 KiB main_window/index.js 17.8 MiB 4
        auxiliary assets
        orphan modules 2.42 MiB (javascript) 13.4 KiB (runtime) [orphan] 1170 modules
        runtime modules 31.3 KiB 19 modules
        modules by path ./node_modules/ 12.7 MiB (javascript) 103 KiB (css/mini-extract) 1.06 MiB (asset)
        javascript modules 11.9 MiB 2830 modules
        json modules 785 KiB 2 modules
        + 2 modules
        modules by path ./src/ 1.19 MiB (javascript) 66 KiB (css/mini-extract)
        javascript modules 579 KiB 137 modules
        json modules 634 KiB 19 modules
        css
        ./node_modules/css-loader/dist/cjs.js!./node_modules/postcss-loader/dist/cjs.js!./src/index.css 66
        KiB [built] [code generated]
        modules by path ./assets/ 2.34 KiB (javascript) 52.9 KiB (asset)
        ./assets/titlebar-icon.svg 2.3 KiB [built] [code generated]
        ./assets/ai-icon.riv 42 bytes (javascript) 52.9 KiB (asset) [built] [code generated]
        ./vendor/wp-now/src/constants.ts 1.65 KiB [built] [code generated]
        ./util.inspect (ignored) 15 bytes [built] [code generated]
        ERROR in ./node_modules/@automattic/calypso-config/src/index.js 1:13-30
        Module not found: Error: Can't resolve 'path' in '/Users/macbookpro/Documents/projects-m3.nosync/s
        tudio/node_modules/@automattic/calypso-config/src'
        BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
        This is no longer the case. Verify if you need this module and configure a polyfill for it.
        If you want to include a polyfill, you need to:
        - add a fallback 'resolve.fallback: { "path": require.resolve("path-browserify") }'
        - install 'path-browserify'
        If you don't want to include a polyfill, you can use an empty module like this:
        resolve.fallback: { "path": false }
        @ ./node_modules/@automattic/i18n-utils/dist/esm/utils.js 1:0-48 29:22-28 190:11-17
        @ ./node_modules/@automattic/i18n-utils/dist/esm/index.js 5:0-24 5:0-24
        @ ./src/components/content-tab-import-export.tsx 17:21-54
        @ ./src/components/site-content-tabs.tsx 11:36-87
        @ ./src/components/app.tsx 12:28-71
        @ ./src/components/root.tsx 8:30-59
        @ ./src/renderer.ts 71:31-61
        ERROR in ./node_modules/@automattic/calypso-config/src/parser.js 4:11-26
        Module not found: Error: Can't resolve 'fs' in '/Users/macbookpro/Documents/projects-m3.nosync/stu
        dio/node_modules/@automattic/calypso-config/src'
        @ ./node_modules/@automattic/calypso-config/src/index.js 11:14-35
        @ ./node_modules/@automattic/i18n-utils/dist/esm/utils.js 1:0-48 29:22-28 190:11-17
        @ ./node_modules/@automattic/i18n-utils/dist/esm/index.js 5:0-24 5:0-24
        @ ./src/components/content-tab-import-export.tsx 17:21-54
        @ ./src/components/site-content-tabs.tsx 11:36-87
        @ ./src/components/app.tsx 12:28-71
        @ ./src/components/root.tsx 8:30-59
        @ ./src/renderer.ts 71:31-61
        ERROR in ./node_modules/@automattic/calypso-config/src/parser.js 5:8-25
        Module not found: Error: Can't resolve 'path' in '/Users/macbookpro/Documents/projects-m3.nosync/s
        tudio/node_modules/@automattic/calypso-config/src'
        BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
        This is no longer the case. Verify if you need this module and configure a polyfill for it.
        If you want to include a polyfill, you need to:
        - add a fallback 'resolve.fallback: { "path": require.resolve("path-browserify") }'
        - install 'path-browserify'
        If you don't want to include a polyfill, you can use an empty module like this:
        resolve.fallback: { "path": false }
        @ ./node_modules/@automattic/calypso-config/src/index.js 11:14-35
        @ ./node_modules/@automattic/i18n-utils/dist/esm/utils.js 1:0-48 29:22-28 190:11-17
        @ ./node_modules/@automattic/i18n-utils/dist/esm/index.js 5:0-24 5:0-24
        @ ./src/components/content-tab-import-export.tsx 17:21-54
        @ ./src/components/site-content-tabs.tsx 11:36-87
        @ ./src/components/app.tsx 12:28-71
        @ ./src/components/root.tsx 8:30-59
        @ ./src/renderer.ts 71:31-61
        3 errors have detailed information that is not shown.
        Use 'stats.errorDetails: true' resp. '--stats-error-details' to show it.
        group_0 (webpack 5.94.0) compiled with 3 errors in 7668 ms

Sentry release version: studio@1.3.3
Sentry environment: production
Building the HTML entry file ...
<i> [ForkTsCheckerWebpackPlugin] Type-checking in progress...
<i> [ForkTsCheckerWebpackPlugin] No errors found.

An unhandled rejection has occurred inside Forge:
Error: Compilation errors in the preload: group_0:
  asset main_window/preload.js 238 KiB [emitted] (name: main_window) 1 related asset
  runtime modules 29.4 KiB 14 modules
  modules by path ./node_modules/ 165 KiB
    modules by path ./node_modules/webpack-dev-server/client/ 71.8 KiB 16 modules
    modules by path ./node_modules/webpack/hot/*.js 5.17 KiB
      ./node_modules/webpack/hot/dev-server.js 1.94 KiB [built] [code generated]
      + 3 modules
    modules by path ./node_modules/html-entities/lib/*.js 81.8 KiB
      ./node_modules/html-entities/lib/index.js 7.91 KiB [built] [code generated]
      ./node_modules/html-entities/lib/named-references.js 73 KiB [built] [code generated]
      + 2 modules
    ./node_modules/@sentry/electron/preload/index.js 2.06 KiB [built] [code generated]
    ./node_modules/ansi-html-community/index.js 4.16 KiB [built] [code generated]
  ./src/preload.ts 7.19 KiB [built] [code generated]
  external "electron" 42 bytes [built] [code generated]
  external "events" 42 bytes [built] [code generated]
  group_0 (webpack 5.94.0) compiled successfully in 2342 ms

group_0:
  assets by path main_window/ 17.8 MiB
    asset main_window/index.js 17.8 MiB [emitted] (name: main_window) 1 related asset
    asset main_window/index.html 327 bytes [emitted]
  assets by info 1.11 MiB [immutable]
    asset 8476d11ddab2043938ed.wasm 1.06 MiB [emitted] [immutable] [from: node_modules/@rive-app/canvas/rive.wasm] (auxiliary name: main_window)
    asset a33f17d2656a6f583a3d.riv 52.9 KiB [emitted] [immutable] [from: assets/ai-icon.riv] (auxiliary name: main_window)
  asset main_window.css 169 KiB [emitted] (name: main_window) 1 related asset
  Entrypoint main_window 18 MiB (16.5 MiB) = main_window.css 169 KiB main_window/index.js 17.8 MiB 4 auxiliary assets
  orphan modules 2.42 MiB (javascript) 13.4 KiB (runtime) [orphan] 1170 modules
  runtime modules 31.3 KiB 19 modules
  modules by path ./node_modules/ 12.7 MiB (javascript) 103 KiB (css/mini-extract) 1.06 MiB (asset)
    javascript modules 11.9 MiB 2830 modules
    json modules 785 KiB 2 modules
    + 2 modules
  modules by path ./src/ 1.19 MiB (javascript) 66 KiB (css/mini-extract)
    javascript modules 579 KiB 137 modules
    json modules 634 KiB 19 modules
    css ./node_modules/css-loader/dist/cjs.js!./node_modules/postcss-loader/dist/cjs.js!./src/index.css 66 KiB [built] [code generated]
  modules by path ./assets/ 2.34 KiB (javascript) 52.9 KiB (asset)
    ./assets/titlebar-icon.svg 2.3 KiB [built] [code generated]
    ./assets/ai-icon.riv 42 bytes (javascript) 52.9 KiB (asset) [built] [code generated]
  ./vendor/wp-now/src/constants.ts 1.65 KiB [built] [code generated]
  ./util.inspect (ignored) 15 bytes [built] [code generated]

  ERROR in ./node_modules/@automattic/calypso-config/src/index.js 1:13-30
  Module not found: Error: Can't resolve 'path' in '/Users/macbookpro/Documents/projects-m3.nosync/studio/node_modules/@automattic/calypso-config/src'

  BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
  This is no longer the case. Verify if you need this module and configure a polyfill for it.

  If you want to include a polyfill, you need to:
        - add a fallback 'resolve.fallback: { "path": require.resolve("path-browserify") }'
        - install 'path-browserify'
  If you don't want to include a polyfill, you can use an empty module like this:
        resolve.fallback: { "path": false }
   @ ./node_modules/@automattic/i18n-utils/dist/esm/utils.js 1:0-48 29:22-28 190:11-17
   @ ./node_modules/@automattic/i18n-utils/dist/esm/index.js 5:0-24 5:0-24
   @ ./src/components/content-tab-import-export.tsx 17:21-54
   @ ./src/components/site-content-tabs.tsx 11:36-87
   @ ./src/components/app.tsx 12:28-71
   @ ./src/components/root.tsx 8:30-59
   @ ./src/renderer.ts 71:31-61

  ERROR in ./node_modules/@automattic/calypso-config/src/parser.js 4:11-26
  Module not found: Error: Can't resolve 'fs' in '/Users/macbookpro/Documents/projects-m3.nosync/studio/node_modules/@automattic/calypso-config/src'
   @ ./node_modules/@automattic/calypso-config/src/index.js 11:14-35
   @ ./node_modules/@automattic/i18n-utils/dist/esm/utils.js 1:0-48 29:22-28 190:11-17
   @ ./node_modules/@automattic/i18n-utils/dist/esm/index.js 5:0-24 5:0-24
   @ ./src/components/content-tab-import-export.tsx 17:21-54
   @ ./src/components/site-content-tabs.tsx 11:36-87
   @ ./src/components/app.tsx 12:28-71
   @ ./src/components/root.tsx 8:30-59
   @ ./src/renderer.ts 71:31-61

  ERROR in ./node_modules/@automattic/calypso-config/src/parser.js 5:8-25
  Module not found: Error: Can't resolve 'path' in '/Users/macbookpro/Documents/projects-m3.nosync/studio/node_modules/@automattic/calypso-config/src'

  BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
  This is no longer the case. Verify if you need this module and configure a polyfill for it.

  If you want to include a polyfill, you need to:
        - add a fallback 'resolve.fallback: { "path": require.resolve("path-browserify") }'
        - install 'path-browserify'
  If you don't want to include a polyfill, you can use an empty module like this:
        resolve.fallback: { "path": false }
   @ ./node_modules/@automattic/calypso-config/src/index.js 11:14-35
   @ ./node_modules/@automattic/i18n-utils/dist/esm/utils.js 1:0-48 29:22-28 190:11-17
   @ ./node_modules/@automattic/i18n-utils/dist/esm/index.js 5:0-24 5:0-24
   @ ./src/components/content-tab-import-export.tsx 17:21-54
   @ ./src/components/site-content-tabs.tsx 11:36-87
   @ ./src/components/app.tsx 12:28-71
   @ ./src/components/root.tsx 8:30-59
   @ ./src/renderer.ts 71:31-61

  3 errors have detailed information that is not shown.
  Use 'stats.errorDetails: true' resp. '--stats-error-details' to show it.

  group_0 (webpack 5.94.0) compiled with 3 errors in 7668 ms
at /Users/macbookpro/Documents/projects-m3.nosync/studio/node_modules/@electron-forge/plugin-webpack/src/WebpackPlugin.ts:562:27
    at Hook.eval (eval at create (/Users/macbookpro/Documents/projects-m3.nosync/studio/node_modules/tapable/lib/HookCodeFactory.js:19:10), <anonymous>:7:1)
    at Hook.CALL_DELEGATE [as _call] (/Users/macbookpro/Documents/projects-m3.nosync/studio/node_modules/tapable/lib/Hook.js:14:14)
    at /Users/macbookpro/Documents/projects-m3.nosync/studio/node_modules/webpack/lib/MultiCompiler.js:102:22
    at Hook.eval [as callAsync] (eval at create (/Users/macbookpro/Documents/projects-m3.nosync/studio/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:29:1)
    at Hook.CALL_ASYNC_DELEGATE [as _callAsync] (/Users/macbookpro/Documents/projects-m3.nosync/studio/node_modules/tapable/lib/Hook.js:18:14)
    at Watching._done (/Users/macbookpro/Documents/projects-m3.nosync/studio/node_modules/webpack/lib/Watching.js:314:28)
    at /Users/macbookpro/Documents/projects-m3.nosync/studio/node_modules/webpack/lib/Watching.js:229:21
    at Compiler.emitRecords (/Users/macbookpro/Documents/projects-m3.nosync/studio/node_modules/webpack/lib/Compiler.js:1044:4)
    at /Users/macbookpro/Documents/projects-m3.nosync/studio/node_modules/webpack/lib/Watching.js:205:22
    at /Users/macbookpro/Documents/projects-m3.nosync/studio/node_modules/webpack/lib/Compiler.js:1007:14
    at Hook.eval [as callAsync] (eval at create (/Users/macbookpro/Documents/projects-m3.nosync/studio/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:6:1)
    at Hook.CALL_ASYNC_DELEGATE [as _callAsync] (/Users/macbookpro/Documents/projects-m3.nosync/studio/node_modules/tapable/lib/Hook.js:18:14)
    at /Users/macbookpro/Documents/projects-m3.nosync/studio/node_modules/webpack/lib/Compiler.js:1004:27
    at /Users/macbookpro/Documents/projects-m3.nosync/studio/node_modules/neo-async/async.js:2818:7
    at done (/Users/macbookpro/Documents/projects-m3.nosync/studio/node_modules/neo-async/async.js:3522:9)
</code>
</details>


I've tried to fix it by installing `path-browserify` and setting this configuration in webpack, without luck:

<img width="518" alt="Screenshot 2025-02-09 at 09 38 36" src="https://github.com/user-attachments/assets/e90ff590-4c53-44a3-b891-e5708185edae" />
<img width="798" alt="Screenshot 2025-02-09 at 09 38 31" src="https://github.com/user-attachments/assets/3937b7d6-a13e-45fe-a96b-44f4ee1e1077" />

