### PR TITLE
Silence Jest warnings about punycode module deprecation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -87,6 +87,7 @@
 				"autoprefixer": "^10.4.16",
 				"babel-preset-env": "^1.7.0",
 				"copy-webpack-plugin": "^12.0.2",
+				"cross-env": "^7.0.3",
 				"css-loader": "^6.0.0",
 				"ejs": "^3.1.10",
 				"electron": "33.3.1",
@@ -10822,6 +10823,25 @@
 			"resolved": "https://registry.npmjs.org/cross-dirname/-/cross-dirname-0.1.0.tgz",
 			"integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
 			"dev": true
+		},
+		"node_modules/cross-env": {
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+			"integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"cross-spawn": "^7.0.1"
+			},
+			"bin": {
+				"cross-env": "src/bin/cross-env.js",
+				"cross-env-shell": "src/bin/cross-env-shell.js"
+			},
+			"engines": {
+				"node": ">=10.14",
+				"npm": ">=6",
+				"yarn": ">=1"
+			}
 		},
 		"node_modules/cross-port-killer": {
 			"version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
 		"publish": "electron-forge publish",
 		"lint": "eslint --ext .ts,.tsx,.js,.jsx,.mjs .",
 		"format": "prettier . --write",
-		"test": "NODE_OPTIONS='--no-deprecation' jest",
-		"test:watch": "NODE_OPTIONS='--no-deprecation' jest --watch",
+		"test": "cross-env NODE_OPTIONS='--no-deprecation' jest",
+		"test:watch": "cross-env NODE_OPTIONS='--no-deprecation' jest --watch",
 		"e2e": "npx playwright install && npx playwright test",
 		"make-pot": "wp-babel-makepot \"./src/**/*.{js,jsx,ts,tsx}\" --ignore \"**/*.d.ts\" --base \"./src\" --dir \"./out/pots\" --output \"./out/pots/bundle-strings.pot\""
 	},
@@ -66,6 +66,7 @@
 		"autoprefixer": "^10.4.16",
 		"babel-preset-env": "^1.7.0",
 		"copy-webpack-plugin": "^12.0.2",
+		"cross-env": "^7.0.3",
 		"css-loader": "^6.0.0",
 		"ejs": "^3.1.10",
 		"electron": "33.3.1",

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
 		"publish": "electron-forge publish",
 		"lint": "eslint --ext .ts,.tsx,.js,.jsx,.mjs .",
 		"format": "prettier . --write",
-		"test": "jest",
-		"test:watch": "jest --watch",
+		"test": "NODE_OPTIONS='--no-deprecation' jest",
+		"test:watch": "NODE_OPTIONS='--no-deprecation' jest --watch",
 		"e2e": "npx playwright install && npx playwright test",
 		"make-pot": "wp-babel-makepot \"./src/**/*.{js,jsx,ts,tsx}\" --ignore \"**/*.d.ts\" --base \"./src\" --dir \"./out/pots\" --output \"./out/pots/bundle-strings.pot\""
 	},


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/dotcom-forge/issues/10430

## Proposed Changes

Silence the `punycode` deprecation warnings printed in Node 22 when running `npm test` (see issue description for more details).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Run `npm test`
2. Ensure that no deprecation warnings about the punycode are printed

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
