### PR TITLE
Enable feature flag to display previews tab for CfT

### DIFF
--- a/src/hooks/use-feature-flags.tsx
+++ b/src/hooks/use-feature-flags.tsx
@@ -54,8 +54,7 @@ export const FeatureFlagsProvider: React.FC< FeatureFlagsProviderProps > = ( { c
 				setFeatureFlags( {
 					terminalWpCliEnabled:
 						Boolean( flags.terminal_wp_cli_enabled ) || terminalWpCliEnabledFromGlobals,
-					quickDeploysEnabled:
-						Boolean( flags.quick_deploys_enabled ) || quickDeploysEnabledFromGlobals,
+					quickDeploysEnabled: true,
 				} );
 			} catch ( error ) {
 				Sentry.captureException( error );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Related to https://github.com/Automattic/dotcom-forge/issues/10281

## Proposed Changes

- Enable the feature flag to create a beta to share with 
- I'm not removing feature flag, since it's likely that we'll create a release next Monday that won't include the previews tab.
- Removing the feature flag from the codebase will be handled on https://github.com/Automattic/dotcom-forge/issues/10431

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run `npm start`
- Observe the Previews tab

<img width="1012" alt="Screenshot 2025-02-10 at 19 09 52" src="https://github.com/user-attachments/assets/1cb973c5-5d6f-451c-bb33-fb1c9ffdc279" />



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
