### PR TITLE
Fix incorrectly handled variable in translatable text

### DIFF
--- a/src/components/content-tab-previews.tsx
+++ b/src/components/content-tab-previews.tsx
@@ -1,5 +1,5 @@
 import { createInterpolateElement } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { check, external, Icon } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { PropsWithChildren } from 'react';
@@ -47,7 +47,7 @@ function EmptyGeneric( {
 				</div>
 				<div className="mt-6">
 					{ [
-						__( `Create up to ${ LIMIT_OF_ZIP_SITES_PER_USER } preview sites for free.` ),
+						sprintf( __( 'Create up to %d preview sites for free.' ), LIMIT_OF_ZIP_SITES_PER_USER ),
 						__( 'Preview sites expire 7 days after the last update.' ),
 						createInterpolateElement( __( 'Powered by <a> WordPress.com</a>.' ), {
 							a: (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- N/A

## Proposed Changes

- I propose to fix incorrectly handled variable in translatable text.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Start Studio:
```
STUDIO_QUICK_DEPLOYS=true npm start
```
2. Confirm that the variable in new Previews tab still works fine

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
