### PR TITLE
Improve test hygiene and remove `Loaded user data…` and `Saved user data…` logging calls

### DIFF
--- a/src/components/edit-php-version.tsx
+++ b/src/components/edit-php-version.tsx
@@ -74,6 +74,7 @@ export default function EditPhpVersion() {
 									value: version,
 								} ) ) }
 								onChange={ ( version ) => setSelectedPhpVersion( version ) }
+								__nextHasNoMarginBottom
 							/>
 						</label>
 						<div className="flex flex-row justify-end gap-x-5 mt-6">

--- a/src/lib/import-export/tests/export/exporters/default-exporter.test.ts
+++ b/src/lib/import-export/tests/export/exporters/default-exporter.test.ts
@@ -56,6 +56,19 @@ const defaultTableNames = [
 	'wp_terms',
 ];
 
+// Silence `console.log`, `console.warn`, and `console.error` output
+beforeAll( () => {
+	jest.spyOn( console, 'log' ).mockImplementation( () => {} );
+	jest.spyOn( console, 'warn' ).mockImplementation( () => {} );
+	jest.spyOn( console, 'error' ).mockImplementation( () => {} );
+} );
+
+afterAll( () => {
+	jest.spyOn( console, 'log' ).mockRestore();
+	jest.spyOn( console, 'warn' ).mockRestore();
+	jest.spyOn( console, 'error' ).mockRestore();
+} );
+
 platformTestSuite( 'DefaultExporter', ( { normalize } ) => {
 	let exporter: DefaultExporter;
 	let mockBackup: BackupContents;

--- a/src/lib/tests/bump-stats.test.ts
+++ b/src/lib/tests/bump-stats.test.ts
@@ -30,6 +30,12 @@ function mockCurrentTime( timestamp: number ) {
 }
 
 describe( 'bumpStat', () => {
+	let logger: jest.SpyInstance;
+
+	beforeEach( () => {
+		logger = jest.spyOn( console, 'info' ).mockImplementation( () => {} );
+	} );
+
 	test( 'record stat with GET request to b.gif', async () => {
 		const nock = mockBumpStatRequest( 'usage', 'launch' );
 
@@ -40,7 +46,6 @@ describe( 'bumpStat', () => {
 
 	test( "don't record stat in e2e tests", () => {
 		process.env.E2E = 'true';
-		const logger = jest.spyOn( console, 'info' );
 
 		bumpStat( 'usage', 'launch' );
 
@@ -49,7 +54,6 @@ describe( 'bumpStat', () => {
 
 	test( "don't record stat in development mode", () => {
 		process.env.NODE_ENV = 'development';
-		const logger = jest.spyOn( console, 'info' );
 
 		bumpStat( 'usage', 'launch' );
 
@@ -58,7 +62,6 @@ describe( 'bumpStat', () => {
 
 	test( 'record stat in development mode if override arg is used', async () => {
 		process.env.NODE_ENV = 'development';
-		const logger = jest.spyOn( console, 'info' );
 		const nock = mockBumpStatRequest( 'usage', 'launch' );
 
 		bumpStat( 'usage', 'launch', true );

--- a/src/lib/tests/site-language.test.ts
+++ b/src/lib/tests/site-language.test.ts
@@ -5,6 +5,10 @@ import { app } from 'electron';
 import { getPreferredSiteLanguage } from 'src/lib/site-language';
 
 jest.unmock( 'fs-extra' );
+
+// `getPreferredSiteLanguage` uses `getUserLocaleWithFallback`, which calls `loadUserData` to
+// get the user's locale. This mock ensures that `loadUserData` returns an empty object, which
+// simulates a user with no locale preference.
 jest.mock( 'src/storage/user-data', () => ( {
 	loadUserData: jest.fn().mockResolvedValue( { locale: undefined } ),
 } ) );

--- a/src/lib/tests/site-language.test.ts
+++ b/src/lib/tests/site-language.test.ts
@@ -5,6 +5,9 @@ import { app } from 'electron';
 import { getPreferredSiteLanguage } from 'src/lib/site-language';
 
 jest.unmock( 'fs-extra' );
+jest.mock( 'src/storage/user-data', () => ( {
+	loadUserData: jest.fn().mockResolvedValue( { locale: undefined } ),
+} ) );
 
 const originalFetch = global.fetch;
 

--- a/src/storage/user-data.ts
+++ b/src/storage/user-data.ts
@@ -57,7 +57,6 @@ export async function loadUserData(): Promise< UserData > {
 			const data = fromDiskFormat( parsed );
 			sortSites( data.sites );
 			populatePhpVersion( data.sites );
-			console.log( `Loaded user data from ${ sanitizeUserpath( filePath ) }` );
 			return data;
 		} catch ( err ) {
 			// Awkward double try-catch needed to have access to the file contents
@@ -98,7 +97,6 @@ export async function saveUserData( data: UserData ): Promise< void > {
 			await fs.promises.writeFile( filePath, asString, 'utf-8' );
 		}
 	}
-	console.log( `Saved user data to ${ sanitizeUserpath( filePath ) }` );
 }
 
 function toDiskFormat( { sites, ...rest }: UserData ): PersistedUserData {

--- a/src/stores/tests/chat-slice.test.ts
+++ b/src/stores/tests/chat-slice.test.ts
@@ -243,7 +243,10 @@ describe( 'chat-slice', () => {
 			} );
 
 			expect( consoleErrorSpy ).toHaveBeenCalledTimes( 1 );
-			consoleErrorSpy.mockRestore();
+		} );
+
+		afterEach( () => {
+			jest.restoreAllMocks();
 		} );
 	} );
 

--- a/src/stores/tests/chat-slice.test.ts
+++ b/src/stores/tests/chat-slice.test.ts
@@ -228,7 +228,8 @@ describe( 'chat-slice', () => {
 		} );
 
 		it( 'should handle invalid JSON in localStorage gracefully', () => {
-			const consoleErrorSpy = jest.spyOn( console, 'error' );
+			// Silence `console.error` output
+			const consoleErrorSpy = jest.spyOn( console, 'error' ).mockImplementation( () => {} );
 
 			localStorage.setItem( LOCAL_STORAGE_CHAT_MESSAGES_KEY, 'invalid json' );
 			localStorage.setItem( LOCAL_STORAGE_CHAT_API_IDS_KEY, '{also invalid}' );
@@ -242,6 +243,7 @@ describe( 'chat-slice', () => {
 			} );
 
 			expect( consoleErrorSpy ).toHaveBeenCalledTimes( 1 );
+			consoleErrorSpy.mockRestore();
 		} );
 	} );
 

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -46,98 +46,113 @@ function mockElectron() {
 	return { mockedEvents };
 }
 
+// Silence `console.log`, `console.warn`, and `console.error` output
+beforeAll( () => {
+	jest.spyOn( console, 'log' ).mockImplementation( () => {} );
+	jest.spyOn( console, 'warn' ).mockImplementation( () => {} );
+	jest.spyOn( console, 'error' ).mockImplementation( () => {} );
+} );
+
+afterAll( () => {
+	jest.spyOn( console, 'log' ).mockRestore();
+	jest.spyOn( console, 'warn' ).mockRestore();
+	jest.spyOn( console, 'error' ).mockRestore();
+} );
+
 afterEach( () => {
 	jest.clearAllMocks();
 } );
 
-it( 'should boot successfully', () => {
-	jest.isolateModules( () => {
-		expect( () => require( '../index' ) ).not.toThrow();
-	} );
-} );
-
-it( 'should handle authentication deep links', () => {
-	jest.isolateModules( async () => {
-		const originalProcessPlatform = process.platform;
-		Object.defineProperty( process, 'platform', { value: 'darwin' } );
-
-		const { mockedEvents } = mockElectron();
-		const mockOnOpenUrlCallback = jest.fn();
-		jest.doMock( '../lib/oauth', () => ( { onOpenUrlCallback: mockOnOpenUrlCallback } ) );
-
-		require( '../index' );
-		const { 'open-url': openUrl } = mockedEvents;
-
-		const testUrl = 'wpcom-local-dev://auth#test-hash';
-		await openUrl( {}, testUrl );
-		expect( mockOnOpenUrlCallback ).toHaveBeenCalledWith( testUrl );
-
-		Object.defineProperty( process, 'platform', { value: originalProcessPlatform } );
-	} );
-} );
-
-it( 'should setup server files before creating main window', async () => {
-	await jest.isolateModulesAsync( async () => {
-		const { mockedEvents } = mockElectron();
-		const setupSpy = jest.fn();
-		( setupWPServerFiles as jest.Mock ).mockImplementation( () => {
-			setupSpy();
-			return Promise.resolve();
+describe( 'App initialization', () => {
+	it( 'should boot successfully', () => {
+		jest.isolateModules( () => {
+			expect( () => require( '../index' ) ).not.toThrow();
 		} );
-
-		require( '../index' );
-		await mockedEvents.ready();
-
-		expect( setupSpy ).toHaveBeenCalled();
-		expect( setupSpy.mock.invocationCallOrder[ 0 ] ).toBeLessThan(
-			( createMainWindow as jest.Mock ).mock.invocationCallOrder[ 0 ]
-		);
 	} );
-} );
 
-it( 'should wait for app initialization before handling window events', async () => {
-	await jest.isolateModulesAsync( async () => {
-		const { mockedEvents } = mockElectron();
-		require( '../index' );
+	it( 'should handle authentication deep links', () => {
+		jest.isolateModules( async () => {
+			const originalProcessPlatform = process.platform;
+			Object.defineProperty( process, 'platform', { value: 'darwin' } );
 
-		// Before ready
-		await mockedEvents.activate();
-		expect( createMainWindow ).not.toHaveBeenCalled();
+			const { mockedEvents } = mockElectron();
+			const mockOnOpenUrlCallback = jest.fn();
+			jest.doMock( '../lib/oauth', () => ( { onOpenUrlCallback: mockOnOpenUrlCallback } ) );
 
-		// After ready
-		await mockedEvents.ready();
-		await mockedEvents.activate();
-		expect( createMainWindow ).toHaveBeenCalled();
-	} );
-} );
+			require( '../index' );
+			const { 'open-url': openUrl } = mockedEvents;
 
-it( 'should wait app initialization before creating main window via second-instance event', async () => {
-	await jest.isolateModulesAsync( async () => {
-		( getMainWindow as jest.Mock ).mockResolvedValue( {
-			focus: jest.fn(),
-			isMinimized: jest.fn( () => false ),
+			const testUrl = 'wpcom-local-dev://auth#test-hash';
+			await openUrl( {}, testUrl );
+			expect( mockOnOpenUrlCallback ).toHaveBeenCalledWith( testUrl );
+
+			Object.defineProperty( process, 'platform', { value: originalProcessPlatform } );
 		} );
+	} );
 
-		const { mockedEvents } = mockElectron();
+	it( 'should setup server files before creating main window', async () => {
+		await jest.isolateModulesAsync( async () => {
+			const { mockedEvents } = mockElectron();
+			const setupSpy = jest.fn();
+			( setupWPServerFiles as jest.Mock ).mockImplementation( () => {
+				setupSpy();
+				return Promise.resolve();
+			} );
 
-		// The "second-instance" event is only invoked on Windows/Linux platforms.
-		// Therefore, we ensure the initialization is performed on one of those
-		// platforms.
-		const originalProcessPlatform = process.platform;
-		Object.defineProperty( process, 'platform', { value: 'win32' } );
+			require( '../index' );
+			await mockedEvents.ready();
 
-		require( '../index' );
-		const { ready, 'second-instance': secondInstance } = mockedEvents;
+			expect( setupSpy ).toHaveBeenCalled();
+			expect( setupSpy.mock.invocationCallOrder[ 0 ] ).toBeLessThan(
+				( createMainWindow as jest.Mock ).mock.invocationCallOrder[ 0 ]
+			);
+		} );
+	} );
 
-		await secondInstance();
-		// "getMainWindow" creates the main window if it doesn't exist
-		expect( getMainWindow as jest.Mock ).not.toHaveBeenCalled();
+	it( 'should wait for app initialization before handling window events', async () => {
+		await jest.isolateModulesAsync( async () => {
+			const { mockedEvents } = mockElectron();
+			require( '../index' );
 
-		await ready();
+			// Before ready
+			await mockedEvents.activate();
+			expect( createMainWindow ).not.toHaveBeenCalled();
 
-		await secondInstance();
-		expect( getMainWindow as jest.Mock ).toHaveBeenCalled();
+			// After ready
+			await mockedEvents.ready();
+			await mockedEvents.activate();
+			expect( createMainWindow ).toHaveBeenCalled();
+		} );
+	} );
 
-		Object.defineProperty( process, 'platform', { value: originalProcessPlatform } );
+	it( 'should wait app initialization before creating main window via second-instance event', async () => {
+		await jest.isolateModulesAsync( async () => {
+			( getMainWindow as jest.Mock ).mockResolvedValue( {
+				focus: jest.fn(),
+				isMinimized: jest.fn( () => false ),
+			} );
+
+			const { mockedEvents } = mockElectron();
+
+			// The "second-instance" event is only invoked on Windows/Linux platforms.
+			// Therefore, we ensure the initialization is performed on one of those
+			// platforms.
+			const originalProcessPlatform = process.platform;
+			Object.defineProperty( process, 'platform', { value: 'win32' } );
+
+			require( '../index' );
+			const { ready, 'second-instance': secondInstance } = mockedEvents;
+
+			await secondInstance();
+			// "getMainWindow" creates the main window if it doesn't exist
+			expect( getMainWindow as jest.Mock ).not.toHaveBeenCalled();
+
+			await ready();
+
+			await secondInstance();
+			expect( getMainWindow as jest.Mock ).toHaveBeenCalled();
+
+			Object.defineProperty( process, 'platform', { value: originalProcessPlatform } );
+		} );
 	} );
 } );

--- a/src/tests/main-window.test.ts
+++ b/src/tests/main-window.test.ts
@@ -4,9 +4,11 @@
 import { BrowserWindow } from 'electron';
 import fs from 'fs';
 import { normalize } from 'path';
+import { sendIpcEventToRendererWithWindow } from 'src/ipc-utils';
 import { createMainWindow, getMainWindow, __resetMainWindow } from 'src/main-window';
 
 jest.mock( 'fs' );
+jest.mock( 'src/ipc-utils' );
 
 const mockUserData = {
 	sites: [],
@@ -63,7 +65,7 @@ describe( 'getMainWindow', () => {
 		// eslint-disable-next-line @typescript-eslint/no-empty-function
 		let didFinishLoad: ( ...args: any[] ) => void = () => {};
 		( createdWindow.isDestroyed as jest.Mock ).mockReturnValueOnce( true );
-		( BrowserWindow.prototype.webContents.on as jest.Mock ).mockImplementation(
+		( BrowserWindow.prototype.webContents.on as jest.Mock ).mockImplementationOnce(
 			( _event, callback ) => {
 				didFinishLoad = callback;
 			}
@@ -89,22 +91,24 @@ describe( 'fullscreen events', () => {
 	} );
 
 	it( 'sends fullscreen-change event when entering fullscreen', () => {
-		const mockSend = jest.fn();
-		createdWindow.webContents.send = mockSend;
-
 		// Simulate entering fullscreen
 		createdWindow.emit( 'enter-full-screen' );
 
-		expect( mockSend ).toHaveBeenCalledWith( 'window-fullscreen-change', true );
+		expect( sendIpcEventToRendererWithWindow ).toHaveBeenCalledWith(
+			createdWindow,
+			'window-fullscreen-change',
+			true
+		);
 	} );
 
 	it( 'sends fullscreen-change event when leaving fullscreen', () => {
-		const mockSend = jest.fn();
-		createdWindow.webContents.send = mockSend;
-
 		// Simulate leaving fullscreen
 		createdWindow.emit( 'leave-full-screen' );
 
-		expect( mockSend ).toHaveBeenCalledWith( 'window-fullscreen-change', false );
+		expect( sendIpcEventToRendererWithWindow ).toHaveBeenCalledWith(
+			createdWindow,
+			'window-fullscreen-change',
+			false
+		);
 	} );
 } );

--- a/src/tests/site-server.test.ts
+++ b/src/tests/site-server.test.ts
@@ -7,6 +7,10 @@ import { getWpNowConfig } from 'vendor/wp-now/src';
 // Electron's Node.js environment provides `bota`/`atob`, but Jests' does not
 jest.mock( 'src/lib/passwords' );
 
+jest.mock( 'src/lib/site-language', () => ( {
+	getPreferredSiteLanguage: jest.fn().mockResolvedValue( 'en' ),
+} ) );
+
 // `download` and `config` are private APIs that must be mocked individually
 jest.mock( 'vendor/wp-now/src/download' );
 jest.mock( 'vendor/wp-now/src/config' );

--- a/src/tests/site-server.test.ts
+++ b/src/tests/site-server.test.ts
@@ -7,6 +7,7 @@ import { getWpNowConfig } from 'vendor/wp-now/src';
 // Electron's Node.js environment provides `bota`/`atob`, but Jests' does not
 jest.mock( 'src/lib/passwords' );
 
+// `SiteServer::start` uses `getPreferredSiteLanguage` to set the site language
 jest.mock( 'src/lib/site-language', () => ( {
 	getPreferredSiteLanguage: jest.fn().mockResolvedValue( 'en' ),
 } ) );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Related to https://github.com/Automattic/dotcom-forge/issues/10437

## Proposed Changes

This PR does not fix the flaky tests described in https://github.com/Automattic/dotcom-forge/issues/10437, but it addresses a few issues with our tests that I discovered along the way:

- Silence `console` output from noisy tests
- Add relevant mocks to fix warnings
- Added the `__nextHasNoMarginBottom` prop to the `SelectControl` component in `src/components/edit-php-version.tsx` to silence a console warning
- Removed `Loaded user data…` and `Saved user data…` logging calls (see p1739268087313499-slack-C04GESRBWKW)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

CI should pass

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?