### PR TITLE
Fix flaky `useFullscreen` test

### DIFF
--- a/src/hooks/tests/use-fullscreen.test.ts
+++ b/src/hooks/tests/use-fullscreen.test.ts
@@ -25,10 +25,8 @@ describe( 'useFullscreen', () => {
 		expect( result.current ).toBe( false );
 
 		await waitFor( () => {
-			expect( mockIpcApi.isFullscreen ).toHaveBeenCalledTimes( 1 );
+			expect( result.current ).toBe( true );
 		} );
-
-		expect( result.current ).toBe( true );
 	} );
 
 	it( 'should update state when receiving window-fullscreen-change event', async () => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/dotcom-forge/issues/10437

## Proposed Changes

I'm still not sure why the first test in `src/hooks/tests/use-fullscreen.test.ts` occassionally fails, but this simple strategy of waiting for the result to have the right value (instead of waiting for the mock to be called) seems to be effective.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Code review should suffice

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
