### PR TITLE
Studio: Change the position of the create preview button

### DIFF
--- a/src/components/content-tab-previews.tsx
+++ b/src/components/content-tab-previews.tsx
@@ -197,31 +197,29 @@ export function ContentTabPreviews( { selectedSite }: ContentTabPreviewsProps ) 
 	return (
 		<div className="relative min-h-full flex flex-col">
 			<div className="w-full flex flex-col flex-1">
-				<div className="flex-1">
-					<PreviewSitesTableHeader />
-					<div className="[&>*:not(:last-child)]:border-b [&>*]:border-a8c-gray-5">
-						{ ( isUploading || isSnapshotLoading ) && (
-							<ProgressRow text={ __( 'Creating preview site' ) } />
-						) }
-						{ snapshotsOnSite
-							.filter( ( snapshot ) => ! snapshot.isLoading )
-							.map( ( snapshot ) => (
-								<PreviewSiteRow
-									snapshot={ snapshot }
-									selectedSite={ selectedSite }
-									disabledUpdate={ isUpdateDisabled }
-									updateButtonTooltipContent={ tooltipContent }
-									showUpdateTooltip={ isOverLimit }
-									key={ snapshot.atomicSiteId }
-								/>
-							) ) }
+				<PreviewSitesTableHeader />
+				<div className="[&>*:not(:last-child)]:border-b [&>*]:border-a8c-gray-5">
+					{ ( isUploading || isSnapshotLoading ) && (
+						<ProgressRow text={ __( 'Creating preview site' ) } />
+					) }
+					{ [ snapshotsOnSite[ 0 ] ]
+						.filter( ( snapshot ) => ! snapshot.isLoading )
+						.map( ( snapshot ) => (
+							<PreviewSiteRow
+								snapshot={ snapshot }
+								selectedSite={ selectedSite }
+								disabledUpdate={ isUpdateDisabled }
+								updateButtonTooltipContent={ tooltipContent }
+								showUpdateTooltip={ isOverLimit }
+								key={ snapshot.atomicSiteId }
+							/>
+						) ) }
+					<div className="sticky bottom-0 bg-white/[0.8] backdrop-blur-sm w-full px-8 py-6 mt-auto">
+						<CreatePreviewButton
+							onClick={ () => archiveSite( selectedSite.id ) }
+							selectedSite={ selectedSite }
+						/>
 					</div>
-				</div>
-				<div className="sticky bottom-0 bg-white/[0.8] backdrop-blur-sm w-full px-8 py-6 mt-auto">
-					<CreatePreviewButton
-						onClick={ () => archiveSite( selectedSite.id ) }
-						selectedSite={ selectedSite }
-					/>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/dotcom-forge/issues/10422#issuecomment-2650592828

## Proposed Changes

- We move the button below the table to avoid bad "align" positions between the add site and create preview buttons
- The button gets sticky at the bottom when the table grows enough.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run `npm start`
- Go to the Previews tab
- Create a preview site, observe the button below the table
- Create two or three more sites  and observe the button sticky at the bottom.

**Before**

![image](https://github.com/user-attachments/assets/3a09d438-1dcc-4e2d-8705-b91484dc789c)


**After**

![image](https://github.com/user-attachments/assets/12c45786-66bc-4a0f-be92-4be3227e6a6e)

![image](https://github.com/user-attachments/assets/6aac6604-84ac-4195-a977-e6c8d08bba16)




## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
