### PR TITLE
Update arrow icons to follow same pattern

### DIFF
--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -4,11 +4,12 @@ import {
 } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { Icon, external } from '@wordpress/icons';
+import { Icon } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import React, { useState, useEffect, useRef, memo, useCallback, useMemo } from 'react';
 import ClearHistoryReminder from 'src/components/ai-clear-history-reminder';
 import { AIInput } from 'src/components/ai-input';
+import { ArrowIcon } from 'src/components/arrow-icon';
 import { MessageThinking } from 'src/components/assistant-thinking';
 import Button from 'src/components/button';
 import { ChatMessage, MarkDownWithCode } from 'src/components/chat-message';
@@ -320,7 +321,7 @@ const UnauthenticatedView = ( { onAuthenticate }: { onAuthenticate: () => void }
 		</div>
 		<Button variant="primary" onClick={ onAuthenticate }>
 			{ __( 'Log in to WordPress.com' ) }
-			<Icon className="ltr:ml-1 rtl:mr-1 rtl:scale-x-[-1]" icon={ external } size={ 21 } />
+			<ArrowIcon />
 		</Button>
 	</ChatMessage>
 );

--- a/src/components/content-tab-overview.tsx
+++ b/src/components/content-tab-overview.tsx
@@ -17,6 +17,7 @@ import {
 } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { useState } from 'react';
+import { ArrowIcon } from 'src/components/arrow-icon';
 import { ButtonsSection, ButtonsSectionProps } from 'src/components/buttons-section';
 import { Tooltip } from 'src/components/tooltip';
 import { useCheckInstalledApps } from 'src/hooks/use-check-installed-apps';
@@ -259,11 +260,7 @@ export function ContentTabOverview( { selectedSite }: ContentTabOverviewProps ) 
 									}
 								>
 									{ __( 'Open site' ) }
-									<Icon
-										icon={ external }
-										className="ltr:ml-0.5 rtl:mr-0.5 rtl:scale-x-[-1] fill-a8c-blueberry"
-										size={ 14 }
-									/>
+									<ArrowIcon />
 								</div>
 								{ thumbnailImage }
 							</button>

--- a/src/components/content-tab-previews.tsx
+++ b/src/components/content-tab-previews.tsx
@@ -1,8 +1,9 @@
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import { check, external, Icon } from '@wordpress/icons';
+import { check, Icon } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { PropsWithChildren } from 'react';
+import { ArrowIcon } from 'src/components/arrow-icon';
 import Button from 'src/components/button';
 import offlineIcon from 'src/components/offline-icon';
 import { ScreenshotDemoSite } from 'src/components/screenshot-demo-site';
@@ -103,7 +104,7 @@ function NoAuth( { selectedSite }: React.ComponentProps< typeof EmptyGeneric > )
 						} }
 					>
 						{ __( 'Log in to WordPress.com' ) }
-						<Icon className="ltr:ml-1 rtl:mr-1 rtl:scale-x-[-1]" icon={ external } size={ 21 } />
+						<ArrowIcon />
 					</Button>
 				</Tooltip>
 			</div>

--- a/src/components/content-tab-snapshots.tsx
+++ b/src/components/content-tab-snapshots.tsx
@@ -1,7 +1,7 @@
 import { Spinner } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import { Icon, check, external } from '@wordpress/icons';
+import { Icon, check } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { PropsWithChildren, useEffect } from 'react';
 import { ArrowIcon } from 'src/components/arrow-icon';
@@ -376,7 +376,7 @@ function NoAuth( { selectedSite }: React.ComponentProps< typeof EmptyGeneric > )
 						} }
 					>
 						{ __( 'Log in to WordPress.com' ) }
-						<Icon className="ltr:ml-1 rtl:mr-1 rtl:scale-x-[-1]" icon={ external } size={ 21 } />
+						<ArrowIcon />
 					</Button>
 				</Tooltip>
 			</div>

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -1,5 +1,5 @@
-import { Icon, external } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
+import { ArrowIcon } from 'src/components/arrow-icon';
 import Button from 'src/components/button';
 import { SiteManagementActions } from 'src/components/site-management-actions';
 import { useSiteDetails } from 'src/hooks/use-site-details';
@@ -26,11 +26,7 @@ export default function Header() {
 							variant="link"
 						>
 							{ __( 'WP admin' ) }
-							<Icon
-								icon={ external }
-								className="ltr:ml-0.5 rtl:mr-0.5 rtl:scale-x-[-1]"
-								size={ 14 }
-							/>
+							<ArrowIcon />
 						</Button>
 						<Button
 							disabled={ ! site.running }
@@ -42,11 +38,7 @@ export default function Header() {
 								// translators: "Open site" refers to the action, like "to open site"
 								__( 'Open site' )
 							}
-							<Icon
-								className="ltr:ml-0.5 rtl:mr-0.5 rtl:scale-x-[-1]"
-								icon={ external }
-								size={ 14 }
-							/>
+							<ArrowIcon />
 						</Button>
 					</div>
 				</div>

--- a/src/components/tests/content-tab-assistant.test.tsx
+++ b/src/components/tests/content-tab-assistant.test.tsx
@@ -205,11 +205,11 @@ describe( 'ContentTabAssistant', () => {
 		render( <ContextWrapper selectedSite={ runningSite } /> );
 
 		await waitFor( () => {
-			const loginButton = screen.getByRole( 'button', { name: 'Log in to WordPress.com' } );
+			const loginButton = screen.getByRole( 'button', { name: 'Log in to WordPress.com ↗' } );
 			expect( loginButton ).toBeInTheDocument();
 		} );
 
-		const loginButton = screen.getByRole( 'button', { name: 'Log in to WordPress.com' } );
+		const loginButton = screen.getByRole( 'button', { name: 'Log in to WordPress.com ↗' } );
 		fireEvent.click( loginButton );
 		expect( authenticate ).toHaveBeenCalledTimes( 1 );
 	} );

--- a/src/components/tests/content-tab-snapshots.test.tsx
+++ b/src/components/tests/content-tab-snapshots.test.tsx
@@ -70,7 +70,7 @@ describe( 'ContentTabSnapshots', () => {
 		( useOffline as jest.Mock ).mockReturnValue( false );
 
 		render( <ContentTabSnapshots selectedSite={ selectedSite } /> );
-		const loginButton = screen.getByRole( 'button', { name: 'Log in to WordPress.com' } );
+		const loginButton = screen.getByRole( 'button', { name: 'Log in to WordPress.com ↗' } );
 		expect( loginButton ).toBeVisible();
 		await user.click( loginButton );
 		expect( authenticate ).toHaveBeenCalledTimes( 1 );
@@ -378,7 +378,7 @@ describe( 'ContentTabSnapshots', () => {
 		( useAuth as jest.Mock ).mockReturnValue( { isAuthenticated: false } );
 		render( <ContentTabSnapshots selectedSite={ selectedSite } /> );
 
-		const loginButton = screen.getByRole( 'button', { name: 'Log in to WordPress.com' } );
+		const loginButton = screen.getByRole( 'button', { name: 'Log in to WordPress.com ↗' } );
 		expect( loginButton ).toHaveAttribute( 'aria-disabled', 'true' );
 		fireEvent.mouseOver( loginButton );
 		expect(


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/dotcom-forge/issues/10438

## Proposed Changes

- Let's use the same arrow to identify external links ↗

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run `npm start`
- Make sure your are logged out in Studio
- Navigate to the follow screens and confirm the icon is correct
- Search for `icon={ external }` and observe there are zero occurrences

### Header main buttons

| Before | After |
|--------|--------|
|  <img width="1012" alt="header-after" src="https://github.com/user-attachments/assets/d48d73ab-f8d8-4539-bd83-ee00fedcffbe" /> | <img width="1012" alt="header-before" src="https://github.com/user-attachments/assets/b08fcdd1-2e7e-49d2-a98f-d78d07cb375b" /> |

### Overview

| Before | After |
|--------|--------|
|  <img width="1012" alt="overview-before" src="https://github.com/user-attachments/assets/199e110e-ae63-43f5-a13d-82ef18124a69" /> | <img width="1012" alt="overview-after" src="https://github.com/user-attachments/assets/af80ccee-6c83-474a-af09-4c29ef5b187b" /> |



### Previews

| Before | After |
|--------|--------|
|  <img width="1012" alt="previews-before" src="https://github.com/user-attachments/assets/017693a3-8a3a-40aa-8b3b-47dc75b002d2" /> | <img width="1012" alt="previews-after" src="https://github.com/user-attachments/assets/ffb61817-2e03-41e8-9db2-3c814444c57d" /> |



### Assistant

| Before | After |
|--------|--------|
|  <img width="1012" alt="assistant-before" src="https://github.com/user-attachments/assets/f506cd4f-5d14-4c01-846f-ce547e5c8f31" /> | <img width="1012" alt="assistant-after" src="https://github.com/user-attachments/assets/8fae9e2b-1480-46fb-bc76-ea5d4e037e87" /> |



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
