### PR TITLE
Improve error handling for Studio updating process

### DIFF
--- a/src/updates.ts
+++ b/src/updates.ts
@@ -1,6 +1,6 @@
 import { app, autoUpdater, dialog } from 'electron';
 import * as Sentry from '@sentry/electron/main';
-import { __ } from '@wordpress/i18n';
+import { sprintf, __ } from '@wordpress/i18n';
 import { AUTO_UPDATE_INTERVAL_MS } from 'src/constants';
 
 type UpdpaterState =
@@ -71,15 +71,14 @@ export function setupUpdates() {
 		// Doesn't re-queue an update after an error.
 		updaterState = 'done';
 
-		if ( 'code' in err && err.code === 8 ) {
-			// Corresponds to error: "Cannot update while running on a read-only volume."
-			// This appears to occur when the app is launched from the ~/Downloads folder.
-			showInstallLocationErrorNotice();
-			console.log( err );
-		} else {
-			console.error( err );
-			Sentry.captureException( err );
+		const isReadOnlyVolumeError = 'code' in err && err.code === 8;
+		if ( isReadOnlyVolumeError ) {
+			handleReadOnlyVolumeError( err );
+			return;
 		}
+
+		console.error( err );
+		Sentry.captureException( err );
 	} );
 
 	autoUpdater.on( 'update-available', () => {
@@ -185,17 +184,65 @@ async function showUpdateReadyToInstallNotice() {
 	}
 }
 
-async function showInstallLocationErrorNotice() {
+async function showInstallLocationErrorNotice( message: string ) {
 	if ( process.platform === 'darwin' ) {
 		await dialog.showMessageBox( {
 			type: 'warning',
 			buttons: [ __( 'OK' ) ],
 			title: __( 'Could Not Update Studio' ),
 			message:
+				message ||
 				// Translators: "Applications" is the name of the folder apps are installed to on macOS
 				__(
 					'Studio can only update automatically from the Applications folder. Please move Studio to Applications and try again.'
 				),
 		} );
 	}
+}
+
+function isAppRunningFromDMG(): boolean {
+	if ( process.platform !== 'darwin' ) {
+		return false;
+	}
+
+	const appPath = app.getPath( 'exe' );
+	return appPath.startsWith( '/Volumes/' );
+}
+
+function handleReadOnlyVolumeError( err: Error ) {
+	if ( isAppRunningFromDMG() ) {
+		showInstallLocationErrorNotice(
+			sprintf(
+				__(
+					'Studio is currently running from a disk image at: %s\n\nPlease drag Studio to the Applications folder first, to enable automatic updates.'
+				),
+				app.getPath( 'exe' )
+			)
+		);
+		return;
+	}
+
+	if ( ! app.isInApplicationsFolder() ) {
+		showInstallLocationErrorNotice(
+			sprintf(
+				__(
+					'Studio is currently running from: %s\n\nPlease move Studio to the Applications folder to enable automatic updates.'
+				),
+				app.getPath( 'exe' )
+			)
+		);
+		return;
+	}
+
+	showInstallLocationErrorNotice(
+		sprintf(
+			__(
+				'Unable to update Studio at: %s\n\nPlease check if you have write permissions for this location.'
+			),
+			app.getPath( 'exe' )
+		)
+	);
+
+	console.error( err );
+	Sentry.captureException( err );
 }

--- a/src/updates.ts
+++ b/src/updates.ts
@@ -72,8 +72,8 @@ export function setupUpdates() {
 		updaterState = 'done';
 
 		const isReadOnlyVolumeError = 'code' in err && err.code === 8;
-		if ( isReadOnlyVolumeError ) {
-			handleReadOnlyVolumeError( err );
+		if ( isReadOnlyVolumeError && process.platform === 'darwin' ) {
+			showReadOnlyVolumeError( err );
 			return;
 		}
 
@@ -184,22 +184,6 @@ async function showUpdateReadyToInstallNotice() {
 	}
 }
 
-async function showInstallLocationErrorNotice( message: string ) {
-	if ( process.platform === 'darwin' ) {
-		await dialog.showMessageBox( {
-			type: 'warning',
-			buttons: [ __( 'OK' ) ],
-			title: __( 'Could Not Update Studio' ),
-			message:
-				message ||
-				// Translators: "Applications" is the name of the folder apps are installed to on macOS
-				__(
-					'Studio can only update automatically from the Applications folder. Please move Studio to Applications and try again.'
-				),
-		} );
-	}
-}
-
 function isAppRunningFromDMG(): boolean {
 	if ( process.platform !== 'darwin' ) {
 		return false;
@@ -209,40 +193,39 @@ function isAppRunningFromDMG(): boolean {
 	return appPath.startsWith( '/Volumes/' );
 }
 
-function handleReadOnlyVolumeError( err: Error ) {
+function showReadOnlyVolumeError( err: Error ) {
+	let message = '';
 	if ( isAppRunningFromDMG() ) {
-		showInstallLocationErrorNotice(
-			sprintf(
-				__(
-					'Studio is currently running from a disk image at: %s\n\nPlease drag Studio to the Applications folder first, to enable automatic updates.'
-				),
-				app.getPath( 'exe' )
-			)
-		);
-		return;
-	}
-
-	if ( ! app.isInApplicationsFolder() ) {
-		showInstallLocationErrorNotice(
-			sprintf(
-				__(
-					'Studio is currently running from: %s\n\nPlease move Studio to the Applications folder to enable automatic updates.'
-				),
-				app.getPath( 'exe' )
-			)
-		);
-		return;
-	}
-
-	showInstallLocationErrorNotice(
-		sprintf(
+		message = sprintf(
 			__(
-				'Unable to update Studio at: %s\n\nPlease check if you have write permissions for this location.'
+				'Studio can only update automatically from the Applications folder. Please move Studio to Applications and try again.\n\nStudio is running from a disk image at: %s'
 			),
 			app.getPath( 'exe' )
-		)
-	);
+		);
+	} else if ( ! app.isInApplicationsFolder() ) {
+		message = sprintf(
+			__(
+				'Studio can only update automatically from the Applications folder. Please move Studio to Applications and try again.\n\nStudio is running from: %s'
+			),
+			app.getPath( 'exe' )
+		);
+	} else {
+		message = sprintf(
+			__(
+				'Studio can only update from the writable Applications folder. Please check write permissions and try again.\n\nStudio is running from: %s'
+			),
+			app.getPath( 'exe' )
+		);
 
-	console.error( err );
-	Sentry.captureException( err );
+		// this case is not expected, so we want to capture it
+		Sentry.captureException( err );
+		console.error( err );
+	}
+
+	dialog.showMessageBox( {
+		type: 'warning',
+		buttons: [ __( 'OK' ) ],
+		title: __( 'Error updating Studio' ),
+		message,
+	} );
 }

--- a/src/updates.ts
+++ b/src/updates.ts
@@ -194,28 +194,26 @@ function isAppRunningFromDMG(): boolean {
 }
 
 function showReadOnlyVolumeError( err: Error ) {
-	let message = '';
+	let detailMessage = '';
+	let detailPath = '';
 	if ( isAppRunningFromDMG() ) {
-		message = sprintf(
-			__(
-				'Studio can only update automatically from the Applications folder. Please move Studio to Applications and try again.\n\nStudio is running from a disk image at: %s'
-			),
+		detailMessage = __(
+			'Studio can only update automatically from the Applications folder. Please move Studio to Applications and try again.'
+		);
+		detailPath = sprintf(
+			__( 'Studio is running from a disk image at: %s' ),
 			app.getPath( 'exe' )
 		);
 	} else if ( ! app.isInApplicationsFolder() ) {
-		message = sprintf(
-			__(
-				'Studio can only update automatically from the Applications folder. Please move Studio to Applications and try again.\n\nStudio is running from: %s'
-			),
-			app.getPath( 'exe' )
+		detailMessage = __(
+			'Studio can only update automatically from the Applications folder. Please move Studio to Applications and try again.'
 		);
+		detailPath = sprintf( __( 'Studio is running from: %s' ), app.getPath( 'exe' ) );
 	} else {
-		message = sprintf(
-			__(
-				'Studio can only update from the writable Applications folder. Please check write permissions and try again.\n\nStudio is running from: %s'
-			),
-			app.getPath( 'exe' )
+		detailMessage = __(
+			'Studio can only update from the writable Applications folder. Please check write permissions and try again.'
 		);
+		detailPath = sprintf( __( 'Studio is running from: %s' ), app.getPath( 'exe' ) );
 
 		// this case is not expected, so we want to capture it
 		Sentry.captureException( err );
@@ -225,7 +223,7 @@ function showReadOnlyVolumeError( err: Error ) {
 	dialog.showMessageBox( {
 		type: 'warning',
 		buttons: [ __( 'OK' ) ],
-		title: __( 'Error updating Studio' ),
-		message,
+		message: __( 'Error updating Studio' ),
+		detail: `${ detailMessage }\n\n${ detailPath }`,
 	} );
 }

--- a/src/updates.ts
+++ b/src/updates.ts
@@ -190,7 +190,7 @@ function isAppRunningFromDMG(): boolean {
 	}
 
 	const appPath = app.getPath( 'exe' );
-	return appPath.startsWith( '/Volumes/' );
+	return appPath.startsWith( '/Volumes/' ) || appPath.startsWith( '/private/var/folders' );
 }
 
 function showReadOnlyVolumeError( err: Error ) {


### PR DESCRIPTION
## Related issues

- Fixes https://github.com/Automattic/studio/issues/204

## Proposed Changes
I tried to reproduce the issue, I messed up file system and I managed to reproduce the error only from inside of DMG file.
But necessary to mention:
1. I have M1 (Intel in the issue). Also, ofc, bundles are different.
2. I have macOS Sequoia 15.2 (Sierra and latter versions [disallowed to update from non-Application folders](https://github.com/Squirrel/Squirrel.Mac/issues/182))
3. I am working with Studio 1.3.3 (1.0.3 in the issue, maybe it was related to old Electron or something like that)
Necessary to mention, that the error is thrown from [Squirrel.Mac](https://github.com/Squirrel/Squirrel.Mac/blob/0e5d146ba13101a1302d59ea6e6e0b3cace4ae38/Squirrel/SQRLUpdater.m#L226-L233), so such issue is not specific to Studio and can be reprodicable for many different apps, so we can do not more then improving error handling.

So after different testings, I can confirm that update process work totally correctly in Studio 1.3.3 and almost latest macOS Sequoia 15.2.
What we can do (my proposed changes) - show more specific errors when it's running from inside DMG file. Also show errors to move the app to Applications folder in case if somebody accidentally encounter such error (I haven't managed to see this error) and as a last resort - show default message to check folder permissions and additionally in this case we will send Sentry error, to have move info about it, if somebody one day catch it somehow.

If this PR is merged - we can close the issue and ask the issue creator to try to reproduce it with Studio 1.3.4. So that we can catch this error in Sentry. But my assumption is that something is wrong specifically with installing Studio for that user, since during research of the error, I saw cases in some people, when just reinstalling an app fixed the issue. So I think that installing 1.3.4, after removing their version will fix it.

## Testing Instructions
Apply the next diff:
```
diff --git a/src/updates.ts b/src/updates.ts
index 42f20a1..6a64de6 100644
--- a/src/updates.ts
+++ b/src/updates.ts
@@ -35,6 +35,7 @@ export function setupUpdates() {
        autoUpdater.setFeedURL( { url: url.toString() } );
 
        autoUpdater.on( 'checking-for-update', () => {
+               showReadOnlyVolumeError( new Error( 'Checking for update' ) );
                updaterState = 'checking-for-update';
        } );
```

* run `npm run make`

### Test running Studio from inside of DMG file
* Open `/out/make`
* Click on `Studio-1.3.3-arm64.dmg`
* Open Studio from dmg, instead of dragging the app to Apllications folder
* Assert that you see the next error (ignore the fact about seeing 2 errors, it's expected from our diff above)<br /><img width="262" alt="Screenshot 2025-02-12 at 16 17 32" src="https://github.com/user-attachments/assets/2521c4fb-fb75-47d1-9846-a9d4dbf200d2" />

### Test running Studio from Applications folder (It's literally unreal error, but it's exactly what encountered in [this issue](https://github.com/Automattic/studio/issues/204). My assumption that something is aliased/linked/etc, so with this error we will be sure, which path Studio sees)
* Open `/out/make`
* Click on `Studio-1.3.3-arm64.dmg`
* Drag to Applications folder
* Run it from there
* Assert that you see the error from diff above<br /><img width="261" alt="Screenshot 2025-02-12 at 16 22 03" src="https://github.com/user-attachments/assets/d99cd344-605e-4ae8-8cd5-9aa680716598" />

### Test running Studio outside of Applications folder
* Following previous test case, let's move Studio from Applications to Downloads (macOS Sequoia 15.2 allows to do it, unlike Sierra, so here will be used applied diff)
* Run it from Downloads
* Assert that you see the next error<br /><img width="261" alt="Screenshot 2025-02-12 at 16 26 17" src="https://github.com/user-attachments/assets/14102701-f94e-4640-afb7-ee38fa5091bd" />
