### PR TITLE
Enable quickDeploysEnabled feature flag from first render

### DIFF
--- a/src/hooks/use-feature-flags.tsx
+++ b/src/hooks/use-feature-flags.tsx
@@ -20,7 +20,7 @@ export interface FeatureFlagsContextType {
 
 export const FeatureFlagsContext = createContext< FeatureFlagsContextType >( {
 	terminalWpCliEnabled: false,
-	quickDeploysEnabled: false,
+	quickDeploysEnabled: true,
 } );
 
 interface FeatureFlagsProviderProps {
@@ -32,7 +32,7 @@ export const FeatureFlagsProvider: React.FC< FeatureFlagsProviderProps > = ( { c
 	const quickDeploysEnabledFromGlobals = getAppGlobals().quickDeploysEnabled;
 	const [ featureFlags, setFeatureFlags ] = useState< FeatureFlagsContextType >( {
 		terminalWpCliEnabled: terminalWpCliEnabledFromGlobals,
-		quickDeploysEnabled: quickDeploysEnabledFromGlobals,
+		quickDeploysEnabled: true,
 	} );
 	const { isAuthenticated, client } = useAuth();
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Related to https://github.com/Automattic/studio/pull/914

## Proposed Changes

- Enable the feature flag from first render

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run `npm start`
- Observe the previews tab from first render.


**Before**

https://github.com/user-attachments/assets/2d30db83-0466-43b8-be74-b0a71688cb91




## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
