### PR TITLE
Update useUpdateDemoSite tests to mention preview sites instead of demo sites

### DIFF
--- a/src/hooks/tests/use-update-demo-site.test.tsx
+++ b/src/hooks/tests/use-update-demo-site.test.tsx
@@ -121,7 +121,7 @@ describe( 'useUpdateDemoSite', () => {
 		// Assert that success notification is shown
 		expect( getIpcApi().showNotification ).toHaveBeenCalledWith( {
 			title: 'Update Successful',
-			body: "Demo site for 'Test Site' has been updated.",
+			body: "Preview site for 'Test Site' has been updated.",
 		} );
 	} );
 
@@ -139,7 +139,7 @@ describe( 'useUpdateDemoSite', () => {
 		// Assert that an alert is displayed to inform users of the failure
 		expect( getIpcApi().showErrorMessageBox ).toHaveBeenCalledWith( {
 			title: 'Update failed',
-			message: "We couldn't update the Test Site demo site. Please try again.",
+			message: "We couldn't update the Test Site preview site. Please try again.",
 			error,
 		} );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Related to:
  -  https://github.com/Automattic/studio/pull/929
  - https://github.com/Automattic/dotcom-forge/issues/10446

## Proposed Changes

- Update strings to mention preview sites and pass tests

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run `npm run test`
- Observe the tests pass

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
