### PR TITLE
Remove `common_plugins` YAML anchor in favor of explicit list

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,9 +1,3 @@
-# Nodes with values to reuse in the pipeline.
-common_params:
-  plugins: &common_plugins
-    - $CI_TOOLKIT_PLUGIN
-    - $NVM_PLUGIN
-
 # IMAGE_ID is an env var that only macOS agents need.
 # Defining it at the root level propagates it too all agents, which can seem unnecessary but is a the same time convenient and DRY.
 env:
@@ -16,7 +10,7 @@ steps:
       .buildkite/commands/install-node-dependencies.sh
       echo '--- :eslint: Lint'
       npm run lint
-    plugins: *common_plugins
+    plugins: [$CI_TOOLKIT_PLUGIN, $NVM_PLUGIN]
     notify:
       - github_commit_status:
           context: Lint
@@ -27,7 +21,7 @@ steps:
       .buildkite/commands/install-node-dependencies.sh
       echo '--- :npm: Run Unit Tests'
       npm run test
-    plugins: *common_plugins
+    plugins: [$CI_TOOLKIT_PLUGIN, $NVM_PLUGIN]
     notify:
       - github_commit_status:
           context: Unit Tests
@@ -39,7 +33,7 @@ steps:
       npm run test
     agents:
       queue: windows
-    plugins: *common_plugins
+    plugins: [$CI_TOOLKIT_PLUGIN, $NVM_PLUGIN]
     notify:
       - github_commit_status:
           context: Windows Unit Tests
@@ -60,7 +54,7 @@ steps:
       npm run e2e
     artifact_paths:
       - test-results/**/*.zip
-    plugins: *common_plugins
+    plugins: [$CI_TOOLKIT_PLUGIN, $NVM_PLUGIN]
     agents:
       queue: "{{matrix}}"
     env:
@@ -112,7 +106,7 @@ steps:
 
           echo "--- 📃 Notarizing Binary"
           bundle exec fastlane notarize_binary
-        plugins: *common_plugins
+        plugins: [$CI_TOOLKIT_PLUGIN, $NVM_PLUGIN]
         artifact_paths:
           - out/**/*.app.zip
           - out/*.dmg
@@ -175,7 +169,7 @@ steps:
     depends_on:
       - step: dev-mac
       - step: dev-windows
-    plugins: *common_plugins
+    plugins: [$CI_TOOLKIT_PLUGIN, $NVM_PLUGIN]
     if: build.branch == 'trunk' && build.tag !~ /^v[0-9]+/
     notify:
       - github_commit_status:
@@ -217,7 +211,7 @@ steps:
 
           echo "--- 📃 Notarizing Binary"
           bundle exec fastlane notarize_binary
-        plugins: *common_plugins
+        plugins: [$CI_TOOLKIT_PLUGIN, $NVM_PLUGIN]
         artifact_paths:
           - out/**/*.app.zip
           - out/*.dmg
@@ -277,7 +271,7 @@ steps:
     depends_on:
       - step: release-mac
       - step: release-windows
-    plugins: *common_plugins
+    plugins: [$CI_TOOLKIT_PLUGIN, $NVM_PLUGIN]
     if: build.tag =~ /^v[0-9]+/
     notify:
       - github_commit_status:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,3 +1,6 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
+---
+
 # IMAGE_ID is an env var that only macOS agents need.
 # Defining it at the root level propagates it too all agents, which can seem unnecessary but is a the same time convenient and DRY.
 env:


### PR DESCRIPTION
## Proposed Changes

Remove the `common_plugins` YAML anchor previously used to DRY the plugins list in favor of explicitly listing each plugin a step needs.

The shared node was a remnant of the time where we didn't have the infrastructure to define plugins as environment variables that the pipeline can read (e.g. `$CI_TOOLKIT_PLUGIN`). Back then, DRYing in that way simplified bumping a plugin's version. But now that the plugins definition can be DRYed in the `shared-pipeline-var` file, we no longer need the shared plugins node.

Notice that I haven't added `NVM_PLUGIN` to the Windows build steps because the build script they use from the current CI toolkit version runs the Node.js setup. That will change soon, with the `nvm` plugin being the recommended way to set up Node.js in Windows, too. At that point, I'll add `NVM_PLUGIN` to those steps, too.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- If CI is green, then the change was successful

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors? — N.A.
