### PR TITLE
Fix layout shift caused by scrollbar

### DIFF
--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -410,7 +410,7 @@ export function ContentTabAssistant( { selectedSite }: ContentTabAssistantProps 
 	const disabled = isOffline || ! isAuthenticated || ! userCanSendMessage || hasFailedMessage;
 
 	return (
-		<div className="relative min-h-full flex flex-col bg-gray-50" ref={ wrapperRef }>
+		<div className="relative min-h-full flex flex-col" ref={ wrapperRef }>
 			<div
 				data-testid="assistant-chat"
 				className={ cx(

--- a/src/components/site-content-tabs.tsx
+++ b/src/components/site-content-tabs.tsx
@@ -45,12 +45,7 @@ export function SiteContentTabs() {
 					key={ selectedTab }
 				>
 					{ ( { name } ) => (
-						<div
-							className="h-full overflow-y-auto"
-							style={ {
-								scrollbarGutter: 'stable',
-							} }
-						>
+						<div className="h-full">
 							{ name === 'overview' && <ContentTabOverview selectedSite={ selectedSite } /> }
 							{ name === 'share' && <ContentTabSnapshots selectedSite={ selectedSite } /> }
 							{ name === 'previews' && <ContentTabPreviews selectedSite={ selectedSite } /> }

--- a/src/components/site-content-tabs.tsx
+++ b/src/components/site-content-tabs.tsx
@@ -45,7 +45,9 @@ export function SiteContentTabs() {
 					key={ selectedTab }
 				>
 					{ ( { name } ) => (
-						<div className="h-full">
+						<div className="h-full overflow-y-auto" style={ {
+							scrollbarGutter: 'stable',
+						} }>
 							{ name === 'overview' && <ContentTabOverview selectedSite={ selectedSite } /> }
 							{ name === 'share' && <ContentTabSnapshots selectedSite={ selectedSite } /> }
 							{ name === 'previews' && <ContentTabPreviews selectedSite={ selectedSite } /> }

--- a/src/components/site-content-tabs.tsx
+++ b/src/components/site-content-tabs.tsx
@@ -45,9 +45,12 @@ export function SiteContentTabs() {
 					key={ selectedTab }
 				>
 					{ ( { name } ) => (
-						<div className="h-full overflow-y-auto" style={ {
-							scrollbarGutter: 'stable',
-						} }>
+						<div
+							className="h-full overflow-y-auto"
+							style={ {
+								scrollbarGutter: 'stable',
+							} }
+						>
 							{ name === 'overview' && <ContentTabOverview selectedSite={ selectedSite } /> }
 							{ name === 'share' && <ContentTabSnapshots selectedSite={ selectedSite } /> }
 							{ name === 'previews' && <ContentTabPreviews selectedSite={ selectedSite } /> }

--- a/src/components/site-content-tabs.tsx
+++ b/src/components/site-content-tabs.tsx
@@ -13,6 +13,7 @@ import { TabName, useContentTabs } from 'src/hooks/use-content-tabs';
 import { useImportExport } from 'src/hooks/use-import-export';
 import { useSiteDetails } from 'src/hooks/use-site-details';
 import { WelcomeMessagesProvider } from 'src/hooks/use-welcome-messages';
+import { cx } from 'src/lib/cx';
 
 export function SiteContentTabs() {
 	const { selectedSite } = useSiteDetails();
@@ -45,7 +46,16 @@ export function SiteContentTabs() {
 					key={ selectedTab }
 				>
 					{ ( { name } ) => (
-						<div className="h-full">
+						<div
+							className={ cx(
+								'h-full overflow-y-auto',
+								selectedTab === 'assistant' && 'bg-gray-50'
+							) }
+							style={ {
+								scrollbarWidth: 'thin',
+								scrollbarGutter: 'stable',
+							} }
+						>
 							{ name === 'overview' && <ContentTabOverview selectedSite={ selectedSite } /> }
 							{ name === 'share' && <ContentTabSnapshots selectedSite={ selectedSite } /> }
 							{ name === 'previews' && <ContentTabPreviews selectedSite={ selectedSite } /> }

--- a/src/index.css
+++ b/src/index.css
@@ -36,9 +36,7 @@ blockquote {
 /* Tabs */
 .components-tab-panel__tab-content {
 	flex: 1;
-	overflow: auto;
-	scrollbar-width: thin;
-	scrollbar-gutter: stable;
+	overflow: hidden;
 }
 
 .components-tab-panel__tabs {

--- a/src/index.css
+++ b/src/index.css
@@ -38,6 +38,7 @@ blockquote {
 	flex: 1;
 	overflow: auto;
 	scrollbar-width: thin;
+	scrollbar-gutter: stable;
 }
 
 .components-tab-panel__tabs {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/dotcom-forge/issues/10254

## Proposed Changes

- I propose explicitly defining `overflow` as `auto` and then setting the `scrollbar-gutter` to `stable` to ensure that the scrollbar appearing for main content doesn't cause a layout shift, which can now be observed in the Assistant tab.

<img width="309" alt="Image" src="https://github.com/user-attachments/assets/b3e41c0e-0022-41d1-bc1b-298c2977917c" />

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Open the Assistant tab
2. Run prompt observing bottom UI and confirm it doesn't move to the left when scrollbar appears
3. Clear discussion and confirm bottom UI width doesn't change
4. Switch between two sites, one with empty Assistant tab and another one with discussion, and confirm there is no visible layout shift in the bottom UI area
5. Test other tabs for any regressions

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
