### PR TITLE
Address dev builds on beta tags

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -158,6 +158,7 @@ steps:
       export IS_DEV_BUILD=true
 
       echo "--- :node: Generating Release Manifest"
+      node ./scripts/prepare-dev-build-version.mjs
       node ./scripts/generate-releases-manifest.mjs
 
       echo "--- :fastlane: Distributing Dev Builds"

--- a/docs/versioning-and-updates.md
+++ b/docs/versioning-and-updates.md
@@ -9,8 +9,8 @@ Studio uses [semver](https://semver.org/)-style version numbers.
 ## “Dev Builds” and “Release Builds”
 
 A **dev build** is any version of the app built from `trunk` using CI. It has
-version numbers that look like `0.1.0-dev.e7c8583`, where the suffix is the
-changeset it was built from.
+version numbers that look like `0.1.0-devX`, where the suffix is the
+number of commits since the last release tag.
 
 A **release build** is version of the app built from a specific changeset that
 was chosen by a member of the team by applying a tag to the changeset. It has

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -114,19 +114,6 @@ def aws_upload_to_s3(bucket:, key:, file:, if_exists:, auto_prefix: false, dry_r
   )
 end
 
-def get_commit_count
-  # Get the most recent release tag (excluding pre-release tags)
-  tags = `git tag --sort=-v:refname`.strip.split("\n")
-  latest_tag = tags.find { |tag| !tag.include?('-') } rescue ''
-  
-  # Get commit count since the last tag
-  if latest_tag.empty?
-    `git rev-list --count HEAD`.strip.to_i
-  else
-    `git rev-list #{latest_tag}..HEAD --count`.strip.to_i
-  end
-end
-
 def distribute_builds(
   commit_hash: last_git_commit[:abbreviated_commit_hash],
   build_number: get_required_env('BUILDKITE_BUILD_NUMBER'),
@@ -135,8 +122,7 @@ def distribute_builds(
   UI.message("Running in #{DRY_RUN ? 'DRY RUN' : 'NORMAL'} mode")
   # If we are distributing a build without a tag, i.e. a development build, we also want to update the latest build reference for distribution.
   update_latest = release_tag.nil?
-  commit_count = get_commit_count
-  suffix = release_tag.nil? ? "v#{PACKAGE_VERSION}-dev#{commit_count}" : release_tag
+  suffix = release_tag.nil? ? "v#{PACKAGE_VERSION}" : release_tag
   filename_root = 'studio'
   bucket_folder = 'studio'
 

--- a/scripts/generate-releases-manifest.mjs
+++ b/scripts/generate-releases-manifest.mjs
@@ -140,22 +140,22 @@ if ( isDevBuild ) {
 	releasesData[ 'dev' ][ 'darwin' ] = releasesData[ 'dev' ][ 'darwin' ] ?? {};
 	releasesData[ 'dev' ][ 'darwin' ][ 'universal' ] = {
 		sha: currentCommit,
-		url: `${ cdnURL }/${ baseName }-darwin-universal-v${ version }-dev${ commitCount }.app.zip`,
+		url: `${ cdnURL }/${ baseName }-darwin-universal-v${ version }.app.zip`,
 	};
 	releasesData[ 'dev' ][ 'darwin' ][ 'x64' ] = {
 		sha: currentCommit,
-		url: `${ cdnURL }/${ baseName }-darwin-x64-v${ version }-dev${ commitCount }.app.zip`,
+		url: `${ cdnURL }/${ baseName }-darwin-x64-v${ version }.app.zip`,
 	};
 	releasesData[ 'dev' ][ 'darwin' ][ 'arm64' ] = {
 		sha: currentCommit,
-		url: `${ cdnURL }/${ baseName }-darwin-arm64-v${ version }-dev${ commitCount }.app.zip`,
+		url: `${ cdnURL }/${ baseName }-darwin-arm64-v${ version }.app.zip`,
 	};
 
 	// Windows
 	const windowsReleaseInfo = await getWindowsReleaseInfo();
 	releasesData[ 'dev' ][ 'win32' ] = {
 		sha: windowsReleaseInfo.sha1,
-		url: `${ cdnURL }/${ baseName }-win32-v${ version }-dev${ commitCount }-full.nupkg`,
+		url: `${ cdnURL }/${ baseName }-win32-v${ version }-full.nupkg`,
 		size: windowsReleaseInfo.size,
 	};
 

--- a/scripts/prepare-dev-build-version.mjs
+++ b/scripts/prepare-dev-build-version.mjs
@@ -3,6 +3,7 @@
 import fs from 'fs/promises';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import semver from 'semver';
 import { getLatestTag, getCommitCount } from './lib/git-utils.mjs';
 
 const __dirname = path.dirname( fileURLToPath( import.meta.url ) );
@@ -22,7 +23,14 @@ const packageJsonPath = path.resolve( __dirname, '../package.json' );
 const packageJsonText = await fs.readFile( packageJsonPath, 'utf-8' );
 const packageJson = JSON.parse( packageJsonText );
 
-const devVersion = `${ packageJson.version.split( '-' )[ 0 ] }-dev${ commitCount }`;
+// Parse the version using semver to get just the core version numbers
+const parsedVersion = semver.parse( packageJson.version );
+if ( ! parsedVersion ) {
+	throw new Error( `Invalid version in package.json: ${ packageJson.version }` );
+}
+
+// Create dev version using just the core version numbers (major.minor.patch)
+const devVersion = `${ parsedVersion.major }.${ parsedVersion.minor }.${ parsedVersion.patch }-dev${ commitCount }`;
 
 packageJson.version = devVersion;
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Proposed Changes

- Make prepare-dev-build-version.mjs the single source of truth for dev version formatting
- Remove version manipulation logic from generate-releases-manifest.mjs
- Remove version manipulation logic from Fastfile
- Add proper semver parsing to ensure consistent version formatting
- Update pipeline to run prepare-dev-build-version.mjs before generating release manifest

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Build a dev version from a regular version (e.g. 1.3.2)
```bash
  # Before: Results in 1.3.2-dev42
  # After: Results in 1.3.2-dev42
```
- Build a dev version from a beta version (e.g. 1.3.2-beta1)
```
  # Before: Results in 1.3.2-beta1-dev42 (problematic for Squirrel.Windows)
  # After: Results in 1.3.2-dev42
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
