### PR TITLE
Preview Sites: Avoid removing snapshots when switching between users

### DIFF
--- a/src/components/content-tab-previews.tsx
+++ b/src/components/content-tab-previews.tsx
@@ -164,13 +164,15 @@ function NoPreviews( { selectedSite }: React.ComponentProps< typeof EmptyGeneric
 export function ContentTabPreviews( { selectedSite }: ContentTabPreviewsProps ) {
 	const { __ } = useI18n();
 	const { snapshots, snapshotCreationBlocked } = useSnapshots();
-	const { isAuthenticated } = useAuth();
+	const { isAuthenticated, user } = useAuth();
 	const { archiveSite, isUploadingSiteId } = useArchiveSite();
 	const { isOverLimit } = useSiteSize( selectedSite.id );
 	const { isDemoSiteUpdating } = useUpdateDemoSite();
 	const isUploading = isUploadingSiteId( selectedSite.id );
 	const snapshotsOnSite = snapshots.filter(
-		( snapshot ) => snapshot.localSiteId === selectedSite.id
+		( snapshot ) =>
+			snapshot.localSiteId === selectedSite.id &&
+			( ! snapshot.userId || snapshot.userId === user?.id?.toString() )
 	);
 	const isSnapshotLoading = snapshotsOnSite.some( ( snapshot ) => snapshot.isLoading );
 	const isAnyPreviewUpdating = snapshots.some( ( snapshot ) =>

--- a/src/components/content-tab-previews.tsx
+++ b/src/components/content-tab-previews.tsx
@@ -170,9 +170,7 @@ export function ContentTabPreviews( { selectedSite }: ContentTabPreviewsProps ) 
 	const { isDemoSiteUpdating } = useUpdateDemoSite();
 	const isUploading = isUploadingSiteId( selectedSite.id );
 	const snapshotsOnSite = snapshots.filter(
-		( snapshot ) =>
-			snapshot.localSiteId === selectedSite.id &&
-			( ! snapshot.userId || snapshot.userId === user?.id )
+		( snapshot ) => snapshot.localSiteId === selectedSite.id && snapshot.userId === user?.id
 	);
 	const isSnapshotLoading = snapshotsOnSite.some( ( snapshot ) => snapshot.isLoading );
 	const isAnyPreviewUpdating = snapshots.some( ( snapshot ) =>

--- a/src/components/content-tab-previews.tsx
+++ b/src/components/content-tab-previews.tsx
@@ -172,7 +172,7 @@ export function ContentTabPreviews( { selectedSite }: ContentTabPreviewsProps ) 
 	const snapshotsOnSite = snapshots.filter(
 		( snapshot ) =>
 			snapshot.localSiteId === selectedSite.id &&
-			( ! snapshot.userId || snapshot.userId === user?.id?.toString() )
+			( ! snapshot.userId || snapshot.userId === user?.id )
 	);
 	const isSnapshotLoading = snapshotsOnSite.some( ( snapshot ) => snapshot.isLoading );
 	const isAnyPreviewUpdating = snapshots.some( ( snapshot ) =>

--- a/src/hooks/tests/use-archive-site.test.ts
+++ b/src/hooks/tests/use-archive-site.test.ts
@@ -21,6 +21,7 @@ describe( 'useArchiveSite', () => {
 
 		( useAuth as jest.Mock ).mockImplementation( () => ( {
 			client: { req: { post: mockPost } },
+			user: { id: 123 },
 		} ) );
 
 		( useSiteDetails as jest.Mock ).mockImplementation( () => ( {

--- a/src/hooks/use-archive-site.ts
+++ b/src/hooks/use-archive-site.ts
@@ -80,8 +80,14 @@ export function useArchiveSite() {
 	const errorMessages = useArchiveErrorMessages();
 	const archiveSite = useCallback(
 		async ( siteId: string ) => {
-			if ( ! client || ! user ) {
+			if ( ! client || ! user?.id ) {
 				// No-op if logged out
+				getIpcApi().showErrorMessageBox( {
+					title: __( 'Failed to archive site' ),
+					message: sprintf(
+						__( 'There was an authentication error. Please reauthenticate and try again.' )
+					),
+				} );
 				return;
 			}
 
@@ -164,7 +170,7 @@ export function useArchiveSite() {
 							nextSequence
 						),
 						sequence: nextSequence,
-						userId: user.id ?? undefined,
+						userId: user.id,
 					} );
 				} catch ( error ) {
 					if ( isWpcomNetworkError( error ) ) {

--- a/src/hooks/use-archive-site.ts
+++ b/src/hooks/use-archive-site.ts
@@ -69,7 +69,7 @@ export function useArchiveSite() {
 		userId: number | null
 	): number => {
 		const siteSnapshots = snapshots.filter(
-			( s ) => s.localSiteId === siteId && ( ! s.userId || s.userId === userId )
+			( s ) => s.localSiteId === siteId && s.userId === userId
 		);
 		const existingSequences = siteSnapshots
 			.map( ( s ) => s.sequence ?? 0 )

--- a/src/hooks/use-archive-site.ts
+++ b/src/hooks/use-archive-site.ts
@@ -158,7 +158,7 @@ export function useArchiveSite() {
 							nextSequence
 						),
 						sequence: nextSequence,
-						userId: user.id?.toString(),
+						userId: user.id,
 					} );
 				} catch ( error ) {
 					if ( isWpcomNetworkError( error ) ) {

--- a/src/hooks/use-archive-site.ts
+++ b/src/hooks/use-archive-site.ts
@@ -18,7 +18,7 @@ export function useArchiveSite() {
 		( localSiteId: string ) => uploadingSites[ localSiteId ] || false,
 		[ uploadingSites ]
 	);
-	const { client } = useAuth();
+	const { client, user } = useAuth();
 	const { __ } = useI18n();
 	const { connectedSites } = useSyncSites();
 
@@ -74,7 +74,7 @@ export function useArchiveSite() {
 	const errorMessages = useArchiveErrorMessages();
 	const archiveSite = useCallback(
 		async ( siteId: string ) => {
-			if ( ! client ) {
+			if ( ! client || ! user ) {
 				// No-op if logged out
 				return;
 			}
@@ -158,6 +158,7 @@ export function useArchiveSite() {
 							nextSequence
 						),
 						sequence: nextSequence,
+						userId: user.id?.toString(),
 					} );
 				} catch ( error ) {
 					if ( isWpcomNetworkError( error ) ) {
@@ -194,6 +195,7 @@ export function useArchiveSite() {
 			__,
 			addSnapshot,
 			client,
+			user,
 			errorMessages,
 			fetchSnapshotUsage,
 			setUploadingSites,

--- a/src/hooks/use-archive-site.ts
+++ b/src/hooks/use-archive-site.ts
@@ -158,7 +158,7 @@ export function useArchiveSite() {
 							nextSequence
 						),
 						sequence: nextSequence,
-						userId: user.id,
+						userId: user.id ?? undefined,
 					} );
 				} catch ( error ) {
 					if ( isWpcomNetworkError( error ) ) {

--- a/src/hooks/use-archive-site.ts
+++ b/src/hooks/use-archive-site.ts
@@ -63,8 +63,14 @@ export function useArchiveSite() {
 		};
 	}, [ client, snapshots, updateSnapshot ] );
 
-	const getNextSequenceNumber = ( siteId: string, snapshots: Array< Snapshot > ): number => {
-		const siteSnapshots = snapshots.filter( ( s ) => s.localSiteId === siteId );
+	const getNextSequenceNumber = (
+		siteId: string,
+		snapshots: Array< Snapshot >,
+		userId: number | null
+	): number => {
+		const siteSnapshots = snapshots.filter(
+			( s ) => s.localSiteId === siteId && ( ! s.userId || s.userId === userId )
+		);
 		const existingSequences = siteSnapshots
 			.map( ( s ) => s.sequence ?? 0 )
 			.filter( ( n ) => ! isNaN( n ) );
@@ -143,7 +149,7 @@ export function useArchiveSite() {
 						formData,
 					} );
 
-					const nextSequence = getNextSequenceNumber( siteId, snapshots );
+					const nextSequence = getNextSequenceNumber( siteId, snapshots, user.id );
 
 					addSnapshot( {
 						url: response.domain_name,

--- a/src/hooks/use-snapshots.tsx
+++ b/src/hooks/use-snapshots.tsx
@@ -27,7 +27,6 @@ interface SnapshotContextType {
 		displayAlert?: boolean
 	) => Promise< void >;
 	deleteAllSnapshots: ( snapshots: Pick< Snapshot, 'atomicSiteId' >[] ) => Promise< void >;
-	clearFloatingSnapshots: ( allSnapshots: Pick< Snapshot, 'atomicSiteId' >[] ) => void;
 	isLoading: boolean;
 	loadingDeletingAllSnapshots: boolean;
 	loadingServerSnapshots: boolean;
@@ -70,7 +69,6 @@ export const SnapshotContext = createContext< SnapshotContextType >( {
 	fetchAllSnapshots: async () => [],
 	deleteSnapshot: async () => undefined,
 	deleteAllSnapshots: async () => undefined,
-	clearFloatingSnapshots: () => undefined,
 	isLoading: false,
 	loadingDeletingAllSnapshots: false,
 	loadingServerSnapshots: false,
@@ -178,19 +176,6 @@ export const SnapshotProvider: React.FC< { children: ReactNode } > = ( { childre
 			newSnapshots[ index ] = { ...snapshots[ index ], ...snapshot };
 			return newSnapshots;
 		} );
-	}, [] );
-
-	const clearFloatingSnapshots = useCallback( function clearFloatingSnapshots(
-		allSnapshots: Pick< Snapshot, 'atomicSiteId' >[]
-	) {
-		const siteIds = allSnapshots.map( ( snapshot ) => snapshot.atomicSiteId );
-		if ( ! siteIds.length ) {
-			setSnapshots( [] );
-			return;
-		}
-		setSnapshots( ( snapshots ) =>
-			snapshots.filter( ( snapshot ) => siteIds.includes( snapshot.atomicSiteId ) )
-		);
 	}, [] );
 
 	const fetchAllSnapshots = useCallback( async () => {
@@ -332,7 +317,6 @@ export const SnapshotProvider: React.FC< { children: ReactNode } > = ( { childre
 			fetchAllSnapshots,
 			deleteSnapshot,
 			deleteAllSnapshots,
-			clearFloatingSnapshots,
 			isLoading,
 			loadingDeletingAllSnapshots,
 			loadingServerSnapshots,
@@ -352,7 +336,6 @@ export const SnapshotProvider: React.FC< { children: ReactNode } > = ( { childre
 			fetchAllSnapshots,
 			deleteSnapshot,
 			deleteAllSnapshots,
-			clearFloatingSnapshots,
 			isLoading,
 			loadingDeletingAllSnapshots,
 			loadingServerSnapshots,

--- a/src/hooks/use-snapshots.tsx
+++ b/src/hooks/use-snapshots.tsx
@@ -193,12 +193,6 @@ export const SnapshotProvider: React.FC< { children: ReactNode } > = ( { childre
 		);
 	}, [] );
 
-	useEffect( () => {
-		if ( initiated && ! loadingServerSnapshots && allSnapshots ) {
-			clearFloatingSnapshots( allSnapshots );
-		}
-	}, [ allSnapshots, clearFloatingSnapshots, initiated, loadingServerSnapshots ] );
-
 	const fetchAllSnapshots = useCallback( async () => {
 		if ( ! client?.req || isOffline || ! initiated ) {
 			return null;

--- a/src/ipc-types.d.ts
+++ b/src/ipc-types.d.ts
@@ -49,6 +49,7 @@ interface Snapshot {
 	isDeleting?: boolean;
 	name?: string;
 	sequence?: number;
+	userId?: string;
 }
 
 type InstalledApps = {

--- a/src/ipc-types.d.ts
+++ b/src/ipc-types.d.ts
@@ -49,7 +49,7 @@ interface Snapshot {
 	isDeleting?: boolean;
 	name?: string;
 	sequence?: number;
-	userId?: string;
+	userId?: number;
 }
 
 type InstalledApps = {

--- a/src/storage/user-data.ts
+++ b/src/storage/user-data.ts
@@ -4,6 +4,7 @@ import nodePath from 'path';
 import { SupportedPHPVersion, SupportedPHPVersions } from '@php-wasm/universal';
 import * as Sentry from '@sentry/electron/main';
 import * as atomically from 'atomically';
+import { getIpcApi } from 'src/lib/get-ipc-api';
 import { isErrnoException } from 'src/lib/is-errno-exception';
 import { sanitizeUnstructuredData, sanitizeUserpath } from 'src/lib/sanitize-for-logging';
 import { sortSites } from 'src/lib/sort-sites';
@@ -55,6 +56,18 @@ export async function loadUserData(): Promise< UserData > {
 		try {
 			const parsed = JSON.parse( asString );
 			const data = fromDiskFormat( parsed );
+
+			const userId = data.authToken?.id;
+
+			if ( userId && data.snapshots ) {
+				data.snapshots = data.snapshots.map( ( snapshot ) => {
+					if ( ! snapshot.userId ) {
+						return { ...snapshot, userId };
+					}
+					return snapshot;
+				} );
+			}
+
 			sortSites( data.sites );
 			populatePhpVersion( data.sites );
 			return data;

--- a/src/storage/user-data.ts
+++ b/src/storage/user-data.ts
@@ -47,6 +47,19 @@ function populatePhpVersion( sites: SiteDetails[] ) {
 	} );
 }
 
+function populateSnapshotUserIds( data: UserData ): void {
+	const userId = data.authToken?.id;
+
+	if ( userId && data.snapshots ) {
+		data.snapshots = data.snapshots.map( ( snapshot ) => {
+			if ( ! snapshot.userId ) {
+				return { ...snapshot, userId };
+			}
+			return snapshot;
+		} );
+	}
+}
+
 export async function loadUserData(): Promise< UserData > {
 	migrateUserDataOldName();
 	const filePath = getUserDataFilePath();
@@ -57,17 +70,7 @@ export async function loadUserData(): Promise< UserData > {
 			const parsed = JSON.parse( asString );
 			const data = fromDiskFormat( parsed );
 
-			const userId = data.authToken?.id;
-
-			if ( userId && data.snapshots ) {
-				data.snapshots = data.snapshots.map( ( snapshot ) => {
-					if ( ! snapshot.userId ) {
-						return { ...snapshot, userId };
-					}
-					return snapshot;
-				} );
-			}
-
+			populateSnapshotUserIds( data );
 			sortSites( data.sites );
 			populatePhpVersion( data.sites );
 			return data;

--- a/src/storage/user-data.ts
+++ b/src/storage/user-data.ts
@@ -4,7 +4,6 @@ import nodePath from 'path';
 import { SupportedPHPVersion, SupportedPHPVersions } from '@php-wasm/universal';
 import * as Sentry from '@sentry/electron/main';
 import * as atomically from 'atomically';
-import { getIpcApi } from 'src/lib/get-ipc-api';
 import { isErrnoException } from 'src/lib/is-errno-exception';
 import { sanitizeUnstructuredData, sanitizeUserpath } from 'src/lib/sanitize-for-logging';
 import { sortSites } from 'src/lib/sort-sites';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/dotcom-forge/issues/7516.

## Proposed Changes

- add `userId` to the snapshot object as the new preview site is created
- automatically add current `userId` to all snapshots that are missing when `appdata` is getting loaded
- add filter that will ensure only snapshots linked with the logged-in user get loaded on the Previews tab 
- remove `clearFloatingSnapshots` that is no longer needed

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

To test the changes in this PR, we will need two WPCOM accounts.

1. While logged-in to one of your WPCOM account in Studio, review your current preview sites.
2. Create a new preview site.
3. Take a look into `appdata-v1.json`. The newly created preview site should have a new `userId` value that equals to your WPCOM user ID:

![Markup on 2025-02-14 at 11:26:59](https://github.com/user-attachments/assets/db9dec9b-176c-4816-ab96-9d6452630eaa)

4. Log out from your WPCOM account in Studio and log in to your another WPCOM account.
5. When you review the existing preview sites in Studio, the preview site that you created in the step 2 **should not** load in the Preview tab of the related local site.
6. Create another preview site while still logged-in to your second WPCOM account.
7. Take a look into `appdata-v1.json`. The newly created preview site should have a new `userId` value - but this time it should equal to your second WPCOM user ID (that you are currently logged into).
8. Log out from your second WPCOM account in Studio and log in to your first WPCOM account.
9. When you review the existing preview sites in Studio, you should see the preview site that you have created in the step 2. The preview site that you created with your second account in the step 6 **should not** load in the Preview tab of the related local site.
10. If you manually remove `userId` value from any of your existing preview sites in the `appdata-v1.json`, the value should get added automatically on the next `appdata-v1.json` load, e.g. when you restart the app. The userId of a currently-logged-in user will be used.
11. You can try other cases / variations as well.

The snapshot sequence number should be calculated for each user and site separately.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
