### PR TITLE
Studio: Fix some styles for RTL language on previews tab

### DIFF
--- a/src/modules/preview-site/components/preview-site-row.tsx
+++ b/src/modules/preview-site/components/preview-site-row.tsx
@@ -119,7 +119,7 @@ export function PreviewSiteRow( {
 						{ ! isExpired && <ArrowIcon /> }
 					</Button>
 				</div>
-				<div className="flex ml-auto">
+				<div className="flex ltr:ml-auto rtl:mr-auto">
 					<div className="w-[150px] text-a8c-gray-700 flex items-center pl-4">
 						{ isPreviewSiteUpdating ? (
 							<div className="flex items-center text-gray-900">

--- a/src/modules/preview-site/components/preview-sites-table-header.tsx
+++ b/src/modules/preview-site/components/preview-sites-table-header.tsx
@@ -10,7 +10,7 @@ export function PreviewSitesTableHeader() {
 				<div className="flex ml-auto">
 					<div className="w-[150px] flex items-center pl-4">{ __( 'Updated' ) }</div>
 					<div className="w-[150px] pl-4">{ __( 'Expires' ) }</div>
-					<div className="w-[60px] text-right">{ __( 'Actions' ) }</div>
+					<div className="w-[60px] ltr:text-right rtl:text-left">{ __( 'Actions' ) }</div>
 				</div>
 			</div>
 		</div>

--- a/src/modules/preview-site/components/preview-sites-table-header.tsx
+++ b/src/modules/preview-site/components/preview-sites-table-header.tsx
@@ -7,7 +7,7 @@ export function PreviewSitesTableHeader() {
 		<div className="border-b border-a8c-gray-5">
 			<div className="flex items-center h-12 px-8 text-gray-900 text-xs uppercase">
 				<div className="w-[51%]">{ __( 'Preview site' ) }</div>
-				<div className="flex ml-auto">
+				<div className="flex ltr:ml-auto rtl:mr-auto">
 					<div className="w-[150px] flex items-center pl-4">{ __( 'Updated' ) }</div>
 					<div className="w-[150px] pl-4">{ __( 'Expires' ) }</div>
 					<div className="w-[60px] ltr:text-right rtl:text-left">{ __( 'Actions' ) }</div>

--- a/src/modules/preview-site/components/progress-row.tsx
+++ b/src/modules/preview-site/components/progress-row.tsx
@@ -23,9 +23,13 @@ export function ProgressRow( { text }: ProgressRowProps ) {
 						<ProgressBar value={ progress } maxValue={ 100 } />
 					</div>
 				</div>
-				<div className="flex ml-auto">
-					<div className="w-[150px] text-a8c-gray-700 flex items-center pl-4">{ '-' }</div>
-					<div className="w-[150px] text-a8c-gray-700 flex items-center pl-4">{ '-' }</div>
+				<div className="flex ltr:ml-auto rtl:mr-auto">
+					<div className="w-[150px] text-a8c-gray-700 flex items-center ltr:pl-4 rtl:pr-4">
+						{ '-' }
+					</div>
+					<div className="w-[150px] text-a8c-gray-700 flex items-center ltr:pl-4 rtl:pr-4">
+						{ '-' }
+					</div>
 					<div className="w-[60px] pr-2" />
 				</div>
 			</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

Closes https://github.com/Automattic/dotcom-forge/issues/10375

## Proposed Changes

This PR adjust styles for RLT languages on the `Previews` tab. 

**Before**

<img width="986" alt="Screenshot 2025-02-14 at 2 29 16 PM" src="https://github.com/user-attachments/assets/2c49b372-031e-4537-afd4-5dd4722511fb" />

**After**

<img width="998" alt="Screenshot 2025-02-14 at 2 39 54 PM" src="https://github.com/user-attachments/assets/4a7b1b48-c421-41a6-ab5f-efb65c947cf3" />

## Testing Instructions


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
* Switch the languages of the app from the User Settings modal to RTL language e.g. Hebrew 
* Navigate to the `Preview` tab
* Add a preview site and confirm the items look correctly aligned for the loading state, normal state or when the site is being deleted for RTL mode

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
