### PR TITLE
Add missing tooltips and fix `Tooltip` component styling

### DIFF
--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -1,7 +1,9 @@
+import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import { ArrowIcon } from 'src/components/arrow-icon';
 import Button from 'src/components/button';
 import { SiteManagementActions } from 'src/components/site-management-actions';
+import { Tooltip } from 'src/components/tooltip';
 import { useSiteDetails } from 'src/hooks/use-site-details';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 
@@ -19,27 +21,55 @@ export default function Header() {
 						{ site ? site.name : null }
 					</h1>
 					<div className="flex mt-1 gap-x-4">
-						<Button
-							disabled={ ! site.running }
-							className="[&.is-link]:text-a8c-gray-70 [&.is-link]:hover:text-a8c-blueberry !px-0 h-0 leading-4"
-							onClick={ () => getIpcApi().openSiteURL( site.id, '/wp-admin' ) }
-							variant="link"
-						>
-							{ __( 'WP admin' ) }
-							<ArrowIcon />
-						</Button>
-						<Button
-							disabled={ ! site.running }
-							className="[&.is-link]:text-a8c-gray-70 [&.is-link]:hover:text-a8c-blueberry !px-0 h-0 leading-4"
-							onClick={ () => getIpcApi().openSiteURL( site.id, '', { autoLogin: false } ) }
-							variant="link"
-						>
-							{
-								// translators: "Open site" refers to the action, like "to open site"
-								__( 'Open site' )
+						<Tooltip
+							text={
+								site.running
+									? sprintf(
+											/* translators: wpAdminUrl is the site's WP admin URL */
+											__( 'Open %(wpAdminUrl)s' ),
+											{ wpAdminUrl: `${ site.url }/wp-admin` }
+									  )
+									: undefined
 							}
-							<ArrowIcon />
-						</Button>
+							disabled={ ! site.running }
+							placement="top-start"
+						>
+							<Button
+								disabled={ ! site.running }
+								className="[&.is-link]:text-a8c-gray-70 [&.is-link]:hover:text-a8c-blueberry !px-0 h-0 leading-4"
+								onClick={ () => getIpcApi().openSiteURL( site.id, '/wp-admin' ) }
+								variant="link"
+							>
+								{ __( 'WP admin' ) }
+								<ArrowIcon />
+							</Button>
+						</Tooltip>
+						<Tooltip
+							text={
+								site.running
+									? sprintf(
+											/* translators: siteUrl is the site URL */
+											__( 'Open %(siteUrl)s' ),
+											{ siteUrl: site.url }
+									  )
+									: undefined
+							}
+							disabled={ ! site.running }
+							placement="top-start"
+						>
+							<Button
+								disabled={ ! site.running }
+								className="[&.is-link]:text-a8c-gray-70 [&.is-link]:hover:text-a8c-blueberry !px-0 h-0 leading-4"
+								onClick={ () => getIpcApi().openSiteURL( site.id, '', { autoLogin: false } ) }
+								variant="link"
+							>
+								{
+									// translators: "Open site" refers to the action, like "to open site"
+									__( 'Open site' )
+								}
+								<ArrowIcon />
+							</Button>
+						</Tooltip>
 					</div>
 				</div>
 			) }

--- a/src/components/tooltip.tsx
+++ b/src/components/tooltip.tsx
@@ -40,7 +40,7 @@ const Tooltip = ( {
 
 	return (
 		<div
-			className={ className ?? 'inline-block' }
+			className={ className ?? 'inline-flex items-center h-fit' }
 			onFocus={ showPopover }
 			onBlur={ hidePopover }
 			onMouseOut={ hidePopover }

--- a/src/components/top-bar.tsx
+++ b/src/components/top-bar.tsx
@@ -113,9 +113,11 @@ export default function TopBar( { onToggleSidebar }: TopBarProps ) {
 
 			<div className="app-no-drag-region flex items-center space-x-1.5 rtl:space-x-reverse">
 				<Authentication />
-				<Button onClick={ openDocs } aria-label={ __( 'Get help' ) } variant="icon">
-					<Icon className="text-white" size={ 24 } icon={ help } />
-				</Button>
+				<Tooltip text={ __( 'Get help' ) } placement="bottom-start">
+					<Button onClick={ openDocs } aria-label={ __( 'Get help' ) } variant="icon">
+						<Icon className="text-white" size={ 24 } icon={ help } />
+					</Button>
+				</Tooltip>
 			</div>
 		</div>
 	);

--- a/src/components/user-settings.tsx
+++ b/src/components/user-settings.tsx
@@ -32,13 +32,15 @@ const UserInfo = ( {
 	return (
 		<div className="flex w-full gap-5">
 			<div className="flex w-full items-center gap-3">
-				<Button
-					onClick={ () => getIpcApi().openURL( WPCOM_PROFILE_URL ) }
-					aria-label={ __( 'Edit profile' ) }
-					variant="icon"
-				>
-					<Gravatar detailedDefaultImage size={ 32 } isBlack />
-				</Button>
+				<Tooltip text={ __( 'Edit profile' ) } placement="bottom">
+					<Button
+						onClick={ () => getIpcApi().openURL( WPCOM_PROFILE_URL ) }
+						aria-label={ __( 'Edit profile' ) }
+						variant="icon"
+					>
+						<Gravatar detailedDefaultImage size={ 32 } isBlack />
+					</Button>
+				</Tooltip>
 				<div className="flex flex-col">
 					<span className="overflow-ellipsis">{ user?.displayName }</span>
 					<span className="text-a8c-gray-700 text-[10px] leading-[10px]">{ user?.email }</span>

--- a/src/modules/preview-site/components/preview-site-row.tsx
+++ b/src/modules/preview-site/components/preview-site-row.tsx
@@ -104,20 +104,22 @@ export function PreviewSiteRow( {
 							{ snapshot.name || sprintf( __( '%s Preview' ), selectedSite.name ) }
 						</div>
 					</div>
-					<Button
-						variant="link"
-						disabled={ isExpired }
-						className={ cx(
-							'!text-a8c-gray-700 max-w-[250px]',
-							isExpired ? 'pointer-events-none' : 'hover:!text-a8c-blueberry'
-						) }
-						onClick={ () => getIpcApi().openURL( urlWithHTTPS ) }
-					>
-						<span className={ cx( 'truncate', isExpired && 'line-through text-a8c-gray-700' ) }>
-							{ urlWithHTTPS }
-						</span>
-						{ ! isExpired && <ArrowIcon /> }
-					</Button>
+					<Tooltip text={ urlWithHTTPS } disabled={ isExpired }>
+						<Button
+							variant="link"
+							disabled={ isExpired }
+							className={ cx(
+								'!text-a8c-gray-700 max-w-[250px]',
+								isExpired ? 'pointer-events-none' : 'hover:!text-a8c-blueberry'
+							) }
+							onClick={ () => getIpcApi().openURL( urlWithHTTPS ) }
+						>
+							<span className={ cx( 'truncate', isExpired && 'line-through text-a8c-gray-700' ) }>
+								{ urlWithHTTPS }
+							</span>
+							{ ! isExpired && <ArrowIcon /> }
+						</Button>
+					</Tooltip>
 				</div>
 				<div className="flex ml-auto">
 					<div className="w-[150px] text-a8c-gray-700 flex items-center pl-4">


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- fixes https://github.com/Automattic/dotcom-forge/issues/10464
- fixes https://github.com/Automattic/dotcom-forge/issues/9841

## Proposed Changes

- fix `Tooltip` component styling which:
  - removes unexpected stripe at the bottom of the local site preview (site screenshot) when the site is running
  - allows us to add missing tooltips as described in https://github.com/Automattic/dotcom-forge/issues/9841

**Fixed stripe at the bottom of the local site preview:**

| Before | After |
|--------|--------|
| ![Markup on 2025-02-14 at 16:43:36](https://github.com/user-attachments/assets/d86dbf9e-9d51-455e-a609-46f82046affc) | ![Markup on 2025-02-14 at 16:42:35](https://github.com/user-attachments/assets/e3767695-8bb6-4c55-9126-e1e41f0ba50d) | 

**Newly-introduced tooltips:**

| WP Admin link | Site link | Get help | Edit profile | Preview site link |
|--------|--------|--------|--------|--------|
| ![Markup on 2025-02-14 at 16:46:10](https://github.com/user-attachments/assets/eb0b49fa-cb29-4019-86c4-470e357ba02b) | ![Markup on 2025-02-14 at 16:46:36](https://github.com/user-attachments/assets/aee02914-1ff5-4910-b97d-1eacbac3f617) | ![Markup on 2025-02-14 at 16:47:17](https://github.com/user-attachments/assets/97be87d2-148a-4e52-a8ed-6d91758c479e) | ![Markup on 2025-02-14 at 16:47:43](https://github.com/user-attachments/assets/6b9fc665-178d-4ad5-9b18-df39d6961b97) | ![Markup on 2025-02-17 at 11:03:35](https://github.com/user-attachments/assets/0cd8160d-566e-489b-ae68-14ce3af0507b) | 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR branch and build the app with `npm start`.
2. While on the _Overview_ tab, start and stop a site to observe whether there's no unexpected stripe below the local site screenshot.
3. Review all new and existing tooltip tooltips throughout the app. There should be no issues.
4. All tooltips should work well in RTL and also when the app sidebar is closed. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
