### PR TITLE
[WIP] (need to add AI Assistant support) Add Cursor to available code editors

### DIFF
--- a/src/components/content-tab-overview.tsx
+++ b/src/components/content-tab-overview.tsx
@@ -153,8 +153,16 @@ function ShortcutsSection( { selectedSite }: Pick< ContentTabOverviewProps, 'sel
 			},
 		},
 	];
-	if ( installedApps.vscode ) {
-		// Use VS Code as a default even if none of the editors are installed
+	if ( installedApps.cursor ) {
+		buttonsArray.push( {
+			label: 'Cursor',
+			className: 'text-nowrap',
+			icon: code,
+			onClick: () => {
+				getIpcApi().openURL( `cursor://file/${ selectedSite.path }` );
+			},
+		} );
+	} else if ( installedApps.vscode ) {
 		buttonsArray.push( {
 			label:
 				// translators: "VS Code" is the brand name for an IDE and does not need to be translated

--- a/src/hooks/use-check-installed-apps.tsx
+++ b/src/hooks/use-check-installed-apps.tsx
@@ -4,6 +4,7 @@ import { getIpcApi } from 'src/lib/get-ipc-api';
 const initState = {
 	vscode: false,
 	phpstorm: false,
+	cursor: false,
 };
 const checkInstalledAppsContext = createContext< InstalledApps >( initState );
 

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -100,6 +100,7 @@ export async function getInstalledApps( _event: IpcMainInvokeEvent ): Promise< I
 	return {
 		vscode: isInstalled( 'vscode' ),
 		phpstorm: isInstalled( 'phpstorm' ),
+		cursor: isInstalled( 'cursor' ),
 	};
 }
 

--- a/src/ipc-types.d.ts
+++ b/src/ipc-types.d.ts
@@ -52,8 +52,9 @@ interface Snapshot {
 }
 
 type InstalledApps = {
-	vscode: boolean | null;
-	phpstorm: boolean | null;
+	vscode: boolean;
+	phpstorm: boolean;
+	cursor: boolean;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/lib/is-installed.ts
+++ b/src/lib/is-installed.ts
@@ -8,16 +8,19 @@ if ( process.platform === 'darwin' ) {
 	appPaths = {
 		vscode: '/Applications/Visual Studio Code.app',
 		phpstorm: '/Applications/PhpStorm.app',
+		cursor: '/Applications/Cursor.app',
 	};
 } else if ( process.platform === 'linux' ) {
 	appPaths = {
 		vscode: '/usr/bin/code',
 		phpstorm: '/usr/bin/phpstorm',
+		cursor: '/usr/bin/cursor',
 	};
 } else if ( process.platform === 'win32' ) {
 	appPaths = {
 		vscode: path.join( app.getPath( 'appData' ), 'Code' ),
 		phpstorm: '', // Disable phpStorm for Windows
+		cursor: path.join( app.getPath( 'appData' ), 'Cursor' ),
 	};
 }
 


### PR DESCRIPTION
## Proposed Changes

Since some people are moving from VS Code to Cursor, I think it's important to add the button to open code from Studio. This PR is domign it and I put the condition before VS Code, since if user has Cursor the most likely it's preferable option.

## Testing Instructions
1. Install Cursor on Windows and MacOS (If you have Linux, it would be awesome, since I tested only with MacOS and Windows)
2. Open Studio and select any site
3. Assert that you see Cursor button and click on it opens the editor <br /><img width="510" alt="Screenshot 2025-02-14 at 15 14 13" src="https://github.com/user-attachments/assets/d6e0ce73-d8aa-43c2-8c61-ceed14b39f90" />
