### PR TITLE
Fix port replacement on creating new site from backup

### DIFF
--- a/src/components/tests/assistant-code-block.test.tsx
+++ b/src/components/tests/assistant-code-block.test.tsx
@@ -25,6 +25,7 @@ const selectedSite: SiteDetails = {
 	path: '/test-site',
 	phpVersion: '8.0',
 	adminPassword: btoa( 'test-password' ),
+	port: 9999,
 };
 
 ( useSiteDetails as jest.Mock ).mockReturnValue( {

--- a/src/components/tests/content-tab-import-export.test.tsx
+++ b/src/components/tests/content-tab-import-export.test.tsx
@@ -19,6 +19,7 @@ const selectedSite: SiteDetails = {
 	path: '/test-site',
 	phpVersion: '8.0',
 	adminPassword: btoa( 'test-password' ),
+	port: 9999,
 };
 
 beforeEach( () => {

--- a/src/hooks/tests/use-import-export.test.tsx
+++ b/src/hooks/tests/use-import-export.test.tsx
@@ -19,6 +19,7 @@ const selectedSite: SiteDetails = {
 	path: '/test-site',
 	phpVersion: '8.0',
 	adminPassword: btoa( 'test-password' ),
+	port: 9999,
 };
 
 const wrapper = ( { children }: { children: React.ReactNode } ) => (

--- a/src/hooks/tests/use-update-demo-site.test.tsx
+++ b/src/hooks/tests/use-update-demo-site.test.tsx
@@ -49,6 +49,7 @@ describe( 'useUpdateDemoSite', () => {
 		phpVersion: '8.0',
 		id: '54321',
 		path: '/path/to/site',
+		port: 9999,
 	};
 	const clientReqPost = jest.fn().mockResolvedValue( {
 		data: 'success',
@@ -160,6 +161,7 @@ describe( 'useUpdateDemoSite', () => {
 			phpVersion: '8.0',
 			id: '09876',
 			path: '/path/to/site2',
+			port: 9999,
 		};
 
 		// Mock different response times for each site

--- a/src/hooks/use-add-site.ts
+++ b/src/hooks/use-add-site.ts
@@ -67,6 +67,9 @@ export function useAddSite() {
 							isNewSite: true,
 						} );
 						clearImportState( newSite.id );
+					} else {
+						// when we import file we start the server automatically, so doesn't make sense to run it again, to avoid unexpected behaviour
+						await startServer( newSite.id );
 					}
 
 					getIpcApi().showNotification( {

--- a/src/hooks/use-add-site.ts
+++ b/src/hooks/use-add-site.ts
@@ -68,7 +68,7 @@ export function useAddSite() {
 						} );
 						clearImportState( newSite.id );
 					}
-					await startServer( newSite.id );
+
 					getIpcApi().showNotification( {
 						title: newSite.name,
 						body: __( 'Your new site is up and running' ),

--- a/src/hooks/use-site-details.tsx
+++ b/src/hooks/use-site-details.tsx
@@ -218,7 +218,7 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 						id: tempSiteId,
 						name: siteName || path,
 						path,
-						port: 9999, // Set a temporary port
+						port: -1, // Set a temporary port
 						running: false,
 						isAddingSite: true,
 						phpVersion: '',

--- a/src/hooks/use-site-details.tsx
+++ b/src/hooks/use-site-details.tsx
@@ -218,6 +218,7 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 						id: tempSiteId,
 						name: siteName || path,
 						path,
+						port: 9999, // Set a temporary port
 						running: false,
 						isAddingSite: true,
 						phpVersion: '',

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -51,6 +51,7 @@ import { loadUserData, saveUserData } from 'src/storage/user-data';
 import { DEFAULT_PHP_VERSION } from 'vendor/wp-now/src/constants';
 import type { SyncSite } from 'src/hooks/use-fetch-wpcom-sites/types';
 import type { WpCliResult } from 'src/lib/wp-cli-process';
+import { portFinder } from 'src/lib/port-finder';
 
 const TEMP_DIR = nodePath.join( app.getPath( 'temp' ), 'com.wordpress.studio' ) + nodePath.sep;
 if ( ! fs.existsSync( TEMP_DIR ) ) {
@@ -161,11 +162,14 @@ export async function createSite(
 		}
 	}
 
+	const port = await portFinder.getOpenPort();
+
 	const details = {
 		id: crypto.randomUUID(),
 		name: siteName || nodePath.basename( path ),
 		path,
 		adminPassword: createPassword(),
+		port,
 		running: false,
 		phpVersion: DEFAULT_PHP_VERSION,
 	} as const;

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -38,6 +38,7 @@ import { StoredToken } from 'src/lib/oauth';
 import * as oauthClient from 'src/lib/oauth';
 import { createPassword } from 'src/lib/passwords';
 import { phpGetThemeDetails } from 'src/lib/php-get-theme-details';
+import { portFinder } from 'src/lib/port-finder';
 import { shellOpenExternalWrapper } from 'src/lib/shell-open-external-wrapper';
 import { sortSites } from 'src/lib/sort-sites';
 import { installSqliteIntegration, keepSqliteIntegrationUpdated } from 'src/lib/sqlite-versions';
@@ -51,7 +52,6 @@ import { loadUserData, saveUserData } from 'src/storage/user-data';
 import { DEFAULT_PHP_VERSION } from 'vendor/wp-now/src/constants';
 import type { SyncSite } from 'src/hooks/use-fetch-wpcom-sites/types';
 import type { WpCliResult } from 'src/lib/wp-cli-process';
-import { portFinder } from 'src/lib/port-finder';
 
 const TEMP_DIR = nodePath.join( app.getPath( 'temp' ), 'com.wordpress.studio' ) + nodePath.sep;
 if ( ! fs.existsSync( TEMP_DIR ) ) {

--- a/src/ipc-types.d.ts
+++ b/src/ipc-types.d.ts
@@ -17,7 +17,7 @@ interface StoppedSiteDetails {
 	id: string;
 	name: string;
 	path: string;
-	port?: number;
+	port: number;
 	phpVersion: string;
 	adminPassword?: string;
 	themeDetails?: {

--- a/src/lib/import-export/import/importers/importer.ts
+++ b/src/lib/import-export/import/importers/importer.ts
@@ -95,14 +95,12 @@ abstract class BaseImporter extends EventEmitter implements Importer {
 		}
 
 		const studioUrl = `http://localhost:${ server.details.port }`;
-		console.log( 'server.details', server.details );
 		const oldUrl = currentSiteUrl.trim();
 		const urlWithoutProtocol = oldUrl.replace( /^https?:\/\//, '' );
 
 		const oldUrlVariants = [ `http://${ urlWithoutProtocol }`, `https://${ urlWithoutProtocol }` ];
 
 		for ( const urlToReplace of oldUrlVariants ) {
-			console.info( `Replacing URL: ${ urlToReplace } -> ${ studioUrl }` );
 			const { stderr, exitCode } = await server.executeWpCliCommand(
 				`search-replace '${ urlToReplace }' '${ studioUrl }'`,
 				{ skipPluginsAndThemes: true }

--- a/src/lib/import-export/import/importers/importer.ts
+++ b/src/lib/import-export/import/importers/importer.ts
@@ -89,19 +89,20 @@ abstract class BaseImporter extends EventEmitter implements Importer {
 		const { stdout: currentSiteUrl } = await server.executeWpCliCommand( `option get siteurl`, {
 			skipPluginsAndThemes: true,
 		} );
-
 		if ( ! currentSiteUrl ) {
 			console.error( 'Failed to fetch site URL after import' );
 			return;
 		}
 
 		const studioUrl = `http://localhost:${ server.details.port }`;
+		console.log( 'server.details', server.details );
 		const oldUrl = currentSiteUrl.trim();
 		const urlWithoutProtocol = oldUrl.replace( /^https?:\/\//, '' );
 
 		const oldUrlVariants = [ `http://${ urlWithoutProtocol }`, `https://${ urlWithoutProtocol }` ];
 
 		for ( const urlToReplace of oldUrlVariants ) {
+			console.info( `Replacing URL: ${ urlToReplace } -> ${ studioUrl }` );
 			const { stderr, exitCode } = await server.executeWpCliCommand(
 				`search-replace '${ urlToReplace }' '${ studioUrl }'`,
 				{ skipPluginsAndThemes: true }

--- a/src/lib/import-export/import/importers/importer.ts
+++ b/src/lib/import-export/import/importers/importer.ts
@@ -89,6 +89,7 @@ abstract class BaseImporter extends EventEmitter implements Importer {
 		const { stdout: currentSiteUrl } = await server.executeWpCliCommand( `option get siteurl`, {
 			skipPluginsAndThemes: true,
 		} );
+
 		if ( ! currentSiteUrl ) {
 			console.error( 'Failed to fetch site URL after import' );
 			return;

--- a/src/lib/import-export/tests/export/exporters/default-exporter.test.ts
+++ b/src/lib/import-export/tests/export/exporters/default-exporter.test.ts
@@ -147,7 +147,7 @@ platformTestSuite( 'DefaultExporter', ( { normalize } ) => {
 				id: '123',
 				name: '123',
 				path: normalize( '/path/to/site' ),
-				port: 8881,
+				port: 9999,
 				phpVersion: '7.4',
 			},
 			backupFile: normalize( '/path/to/backup.tar.gz' ),

--- a/src/lib/import-export/tests/export/exporters/default-exporter.test.ts
+++ b/src/lib/import-export/tests/export/exporters/default-exporter.test.ts
@@ -147,6 +147,7 @@ platformTestSuite( 'DefaultExporter', ( { normalize } ) => {
 				id: '123',
 				name: '123',
 				path: normalize( '/path/to/site' ),
+				port: 8881,
 				phpVersion: '7.4',
 			},
 			backupFile: normalize( '/path/to/backup.tar.gz' ),

--- a/src/lib/import-export/tests/export/exporters/sql-exporter.test.ts
+++ b/src/lib/import-export/tests/export/exporters/sql-exporter.test.ts
@@ -23,6 +23,7 @@ platformTestSuite( 'SqlExporter', ( { normalize } ) => {
 				id: '123',
 				name: '123',
 				path: '/path/to/site',
+				port: 9999,
 				phpVersion: '7.4',
 			},
 			backupFile: normalize( '/path/to/backup.sql' ),

--- a/src/lib/import-export/tests/import/import-manager.test.ts
+++ b/src/lib/import-export/tests/import/import-manager.test.ts
@@ -77,6 +77,7 @@ describe( 'importManager', () => {
 			id: '123',
 			name: 'Site Name',
 			path: '/path/to/site',
+			port: 9999,
 			phpVersion: '7.4',
 			running: false,
 		};

--- a/src/modules/preview-site/components/tests/preview-action-buttons-menu.test.tsx
+++ b/src/modules/preview-site/components/tests/preview-action-buttons-menu.test.tsx
@@ -25,6 +25,7 @@ describe( 'PreviewActionButtonsMenu Rename', () => {
 		name: 'Test Site',
 		path: '/test/path',
 		phpVersion: '8.0',
+		port: 9999,
 		running: false,
 	};
 	beforeEach( () => {

--- a/src/modules/preview-site/components/tests/preview-site-row.test.tsx
+++ b/src/modules/preview-site/components/tests/preview-site-row.test.tsx
@@ -37,6 +37,7 @@ describe( 'PreviewSiteRow', () => {
 		name: 'Test',
 		path: '/test/path',
 		phpVersion: '8.2',
+		port: 9999,
 		running: false,
 	};
 

--- a/src/site-server.ts
+++ b/src/site-server.ts
@@ -78,16 +78,15 @@ export class SiteServer {
 		if ( this.details.running || this.server ) {
 			return;
 		}
-		const port = await portFinder.getOpenPort( this.details.port );
-		portFinder.addUnavailablePort( this.details.port );
+
 		const options = await getWpNowConfig( {
 			path: this.details.path,
-			port,
+			port: this.details.port,
 			adminPassword: decodePassword( this.details.adminPassword ?? '' ),
 			siteTitle: this.details.name,
 			php: this.details.phpVersion,
 		} );
-		const absoluteUrl = `http://localhost:${ port }`;
+		const absoluteUrl = `http://localhost:${ this.details.port }`;
 		options.absoluteUrl = absoluteUrl;
 		options.siteLanguage = await getPreferredSiteLanguage( options.wordPressVersion );
 

--- a/src/tests/ipc-handlers.test.ts
+++ b/src/tests/ipc-handlers.test.ts
@@ -9,6 +9,7 @@ import { createSite, startServer, isFullscreen, importSite } from 'src/ipc-handl
 import { isEmptyDir, pathExists } from 'src/lib/fs-utils';
 import { importBackup, defaultImporterOptions } from 'src/lib/import-export/import/import-manager';
 import { BackupArchiveInfo } from 'src/lib/import-export/import/types';
+import { portFinder } from 'src/lib/port-finder';
 import { keepSqliteIntegrationUpdated } from 'src/lib/sqlite-versions';
 import { getMainWindow } from 'src/main-window';
 import { SiteServer, createSiteWorkingDirectory } from 'src/site-server';
@@ -56,6 +57,7 @@ describe( 'createSite', () => {
 	it( 'should create a site', async () => {
 		( isEmptyDir as jest.Mock ).mockResolvedValueOnce( true );
 		( pathExists as jest.Mock ).mockResolvedValueOnce( true );
+		( portFinder.getOpenPort as jest.Mock ).mockResolvedValueOnce( 8881 );
 
 		const [ site ] = await createSite( mockIpcMainInvokeEvent, '/test', 'Test' );
 
@@ -65,6 +67,7 @@ describe( 'createSite', () => {
 			name: 'Test',
 			path: '/test',
 			phpVersion: '8.2',
+			port: 8881,
 			running: false,
 		} );
 	} );

--- a/src/tests/ipc-handlers.test.ts
+++ b/src/tests/ipc-handlers.test.ts
@@ -9,7 +9,6 @@ import { createSite, startServer, isFullscreen, importSite } from 'src/ipc-handl
 import { isEmptyDir, pathExists } from 'src/lib/fs-utils';
 import { importBackup, defaultImporterOptions } from 'src/lib/import-export/import/import-manager';
 import { BackupArchiveInfo } from 'src/lib/import-export/import/types';
-import { portFinder } from 'src/lib/port-finder';
 import { keepSqliteIntegrationUpdated } from 'src/lib/sqlite-versions';
 import { getMainWindow } from 'src/main-window';
 import { SiteServer, createSiteWorkingDirectory } from 'src/site-server';
@@ -23,6 +22,12 @@ jest.mock( 'vendor/wp-now/src/download' );
 jest.mock( 'src/main-window' );
 jest.mock( '@sentry/electron/main' );
 jest.mock( 'src/lib/import-export/import/import-manager' );
+
+jest.mock( 'src/lib/port-finder', () => ( {
+	portFinder: {
+		getOpenPort: jest.fn().mockResolvedValue( 9999 ),
+	},
+} ) );
 
 ( SiteServer.create as jest.Mock ).mockImplementation( ( details ) => ( {
 	start: jest.fn(),
@@ -57,7 +62,6 @@ describe( 'createSite', () => {
 	it( 'should create a site', async () => {
 		( isEmptyDir as jest.Mock ).mockResolvedValueOnce( true );
 		( pathExists as jest.Mock ).mockResolvedValueOnce( true );
-		( portFinder.getOpenPort as jest.Mock ).mockResolvedValueOnce( 9999 );
 
 		const [ site ] = await createSite( mockIpcMainInvokeEvent, '/test', 'Test' );
 

--- a/src/tests/ipc-handlers.test.ts
+++ b/src/tests/ipc-handlers.test.ts
@@ -57,7 +57,7 @@ describe( 'createSite', () => {
 	it( 'should create a site', async () => {
 		( isEmptyDir as jest.Mock ).mockResolvedValueOnce( true );
 		( pathExists as jest.Mock ).mockResolvedValueOnce( true );
-		( portFinder.getOpenPort as jest.Mock ).mockResolvedValueOnce( 8881 );
+		( portFinder.getOpenPort as jest.Mock ).mockResolvedValueOnce( 9999 );
 
 		const [ site ] = await createSite( mockIpcMainInvokeEvent, '/test', 'Test' );
 
@@ -67,7 +67,7 @@ describe( 'createSite', () => {
 			name: 'Test',
 			path: '/test',
 			phpVersion: '8.2',
-			port: 8881,
+			port: 9999,
 			running: false,
 		} );
 	} );


### PR DESCRIPTION
## Related issues

- Fixes https://github.com/Automattic/studio/issues/939

## Proposed Changes

If we create a new site with the help of backup archive, then it works under the hood as - we create a new website and then import backup to created website. During importing, we need to replace website URL with local URL (e.g. localhost:8001), but we set up port only during running a website, so it ends up with `localhost:undefined`.
With proposed changes in this PR we are chisong port for website during creation of it, instead of during first running.

## Testing Instructions
Apply the next diff:
```
diff --git a/src/lib/import-export/import/importers/importer.ts b/src/lib/import-export/import/importers/importer.ts
index b82ec5d..f7a0ff0 100644
--- a/src/lib/import-export/import/importers/importer.ts
+++ b/src/lib/import-export/import/importers/importer.ts
@@ -102,6 +102,7 @@ abstract class BaseImporter extends EventEmitter implements Importer {
                const oldUrlVariants = [ `http://${ urlWithoutProtocol }`, `https://${ urlWithoutProtocol }` ];
 
                for ( const urlToReplace of oldUrlVariants ) {
+                       console.info( `Replacing URL: ${ urlToReplace } -> ${ studioUrl }` );
                        const { stderr, exitCode } = await server.executeWpCliCommand(
                                `search-replace '${ urlToReplace }' '${ studioUrl }'`,
                                { skipPluginsAndThemes: true }

```

1. Open Studio
2. Create a new website with teh help of backup
3. Assert that in terminal logs (from the diff above) you see a correct port, instead of `undefined`