### PR TITLE
Feat: Adds shorcut for Cursor on shortcut section

### DIFF
--- a/src/components/content-tab-overview.tsx
+++ b/src/components/content-tab-overview.tsx
@@ -176,6 +176,17 @@ function ShortcutsSection( { selectedSite }: Pick< ContentTabOverviewProps, 'sel
 				getIpcApi().openURL( `phpstorm://open?file=${ selectedSite.path }` );
 			},
 		} );
+	} else if ( installedApps.cursor ) {
+		buttonsArray.push( {
+			label:
+				// translators: "Cursor" is the brand name for an IDE and does not need to be translated
+				__( 'Cursor' ),
+			className: 'text-nowrap',
+			icon: code,
+			onClick: () => {
+				getIpcApi().openURL( `cursor://file/${ selectedSite.path }?windowId=_blank` );
+			},
+		} );
 	}
 	buttonsArray.push( {
 		label: __( 'Terminal' ),

--- a/src/components/tests/content-tab-overview-shortcuts-section.test.tsx
+++ b/src/components/tests/content-tab-overview-shortcuts-section.test.tsx
@@ -42,6 +42,7 @@ describe( 'ShortcutsSection', () => {
 		( useCheckInstalledApps as jest.Mock ).mockReturnValue( {
 			vscode: true,
 			phpstorm: false,
+			cursor: false,
 		} );
 
 		// Mock the IPC API
@@ -64,6 +65,7 @@ describe( 'ShortcutsSection', () => {
 		( useCheckInstalledApps as jest.Mock ).mockReturnValue( {
 			vscode: true,
 			phpstorm: true,
+			cursor: false,
 		} );
 
 		// Mock the IPC API
@@ -87,6 +89,7 @@ describe( 'ShortcutsSection', () => {
 		( useCheckInstalledApps as jest.Mock ).mockReturnValue( {
 			vscode: false,
 			phpstorm: true,
+			cursor: false,
 		} );
 
 		// Mock the IPC API
@@ -110,6 +113,7 @@ describe( 'ShortcutsSection', () => {
 			terminal: true,
 			vscode: false,
 			phpstorm: false,
+			cursor: false,
 		} );
 
 		// Mock the IPC API
@@ -139,6 +143,7 @@ describe( 'ShortcutsSection', () => {
 			terminal: true,
 			vscode: false,
 			phpstorm: false,
+			cursor: false,
 		} );
 		( useFeatureFlags as jest.Mock ).mockReturnValue( {
 			terminalWpCliEnabled: true,

--- a/src/components/tests/content-tab-overview-shortcuts-section.test.tsx
+++ b/src/components/tests/content-tab-overview-shortcuts-section.test.tsx
@@ -60,7 +60,7 @@ describe( 'ShortcutsSection', () => {
 			expect( openURLMock ).toHaveBeenCalledWith( expect.stringContaining( 'vscode://' ) )
 		);
 	} );
-	it( 'opens site in VS Code when VS Code and PhpStorm are both installed', async () => {
+	it( 'opens site in VS Code when VS Code, PhpStorm and Cursor are installed', async () => {
 		// Mock the `useCheckInstalledApps` hook to simulate VS Code being installed
 		( useCheckInstalledApps as jest.Mock ).mockReturnValue( {
 			vscode: true,
@@ -169,4 +169,28 @@ describe( 'ShortcutsSection', () => {
 			} );
 		} );
 	} );
+} );
+
+it( 'opens site in Cursor when Cursor is installed and the button is clicked, only available on MacOS', async () => {
+	// Mock the `useCheckInstalledApps` hook to simulate Cursor being installed
+	( useCheckInstalledApps as jest.Mock ).mockReturnValue( {
+		vscode: false,
+		phpstorm: false,
+		cursor: true,
+	} );
+
+	// Mock the IPC API
+	const openURLMock = jest.fn();
+	mockGetIpcApi.mockReturnValue( {
+		openURL: openURLMock,
+	} );
+
+	const { getByText } = render( <ContentTabOverview selectedSite={ selectedSite } /> );
+
+	const cursorButton = getByText( 'Cursor' );
+	fireEvent.click( cursorButton );
+
+	await waitFor( () =>
+		expect( openURLMock ).toHaveBeenCalledWith( expect.stringContaining( 'cursor://' ) )
+	);
 } );

--- a/src/hooks/use-check-installed-apps.tsx
+++ b/src/hooks/use-check-installed-apps.tsx
@@ -4,6 +4,7 @@ import { getIpcApi } from 'src/lib/get-ipc-api';
 const initState = {
 	vscode: false,
 	phpstorm: false,
+	cursor: false,
 };
 const checkInstalledAppsContext = createContext< InstalledApps >( initState );
 

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -1064,7 +1064,8 @@ export async function openFileInIDE(
 		await shell.openExternal( `phpstorm://open?file=${ path }` );
 	} else if ( isInstalled( 'cursor' ) ) {
 		// Open site first to ensure the file is opened within the site context
-		await shell.openExternal( `cursor://open?file=${ path }` );
+		await shell.openExternal( `cursor://file/${ server.details.path }?windowId=_blank` );
+		await shell.openExternal( `cursor://file/${ path }` );
 	}
 }
 

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -100,6 +100,7 @@ export async function getInstalledApps( _event: IpcMainInvokeEvent ): Promise< I
 	return {
 		vscode: isInstalled( 'vscode' ),
 		phpstorm: isInstalled( 'phpstorm' ),
+		cursor: isInstalled( 'cursor' ),
 	};
 }
 
@@ -1061,6 +1062,9 @@ export async function openFileInIDE(
 	} else if ( isInstalled( 'phpstorm' ) ) {
 		// Open site first to ensure the file is opened within the site context
 		await shell.openExternal( `phpstorm://open?file=${ path }` );
+	} else if ( isInstalled( 'cursor' ) ) {
+		// Open site first to ensure the file is opened within the site context
+		await shell.openExternal( `cursor://open?file=${ path }` );
 	}
 }
 

--- a/src/ipc-types.d.ts
+++ b/src/ipc-types.d.ts
@@ -54,6 +54,7 @@ interface Snapshot {
 type InstalledApps = {
 	vscode: boolean | null;
 	phpstorm: boolean | null;
+	cursor: boolean | null;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/lib/is-installed.ts
+++ b/src/lib/is-installed.ts
@@ -14,13 +14,13 @@ if ( process.platform === 'darwin' ) {
 	appPaths = {
 		vscode: '/usr/bin/code',
 		phpstorm: '/usr/bin/phpstorm',
-		cursor: '', //disable for linux
+		cursor: '', // Disable Cursor for Linux
 	};
 } else if ( process.platform === 'win32' ) {
 	appPaths = {
 		vscode: path.join( app.getPath( 'appData' ), 'Code' ),
 		phpstorm: '', // Disable phpStorm for Windows
-		cursor: '', // Disable cursor for Windows
+		cursor: '', // Disable Cursor for Windows
 	};
 }
 

--- a/src/lib/is-installed.ts
+++ b/src/lib/is-installed.ts
@@ -8,16 +8,19 @@ if ( process.platform === 'darwin' ) {
 	appPaths = {
 		vscode: '/Applications/Visual Studio Code.app',
 		phpstorm: '/Applications/PhpStorm.app',
+		cursor: '/Applications/Cursor.app',
 	};
 } else if ( process.platform === 'linux' ) {
 	appPaths = {
 		vscode: '/usr/bin/code',
 		phpstorm: '/usr/bin/phpstorm',
+		cursor: '', //disable for linux
 	};
 } else if ( process.platform === 'win32' ) {
 	appPaths = {
 		vscode: path.join( app.getPath( 'appData' ), 'Code' ),
 		phpstorm: '', // Disable phpStorm for Windows
+		cursor: '', // Disable cursor for Windows
 	};
 }
 

--- a/src/lib/shell-open-external-wrapper.ts
+++ b/src/lib/shell-open-external-wrapper.ts
@@ -31,7 +31,7 @@ export const shellOpenExternalWrapper = async ( url: string ) => {
 			message = __(
 				'Studio is unable to open PHPStorm. Please ensure it is functioning correctly.'
 			);
-		} else if ( url.startsWith( 'cursor://open?file=' ) ) {
+		} else if ( url.startsWith( 'cursor://file/' ) ) {
 			title = __( 'Failed to open Cursor' );
 			message = __( 'Studio is unable to open Cursor. Please ensure it is functioning correctly.' );
 		} else {

--- a/src/lib/shell-open-external-wrapper.ts
+++ b/src/lib/shell-open-external-wrapper.ts
@@ -31,6 +31,9 @@ export const shellOpenExternalWrapper = async ( url: string ) => {
 			message = __(
 				'Studio is unable to open PHPStorm. Please ensure it is functioning correctly.'
 			);
+		} else if ( url.startsWith( 'cursor://open?file=' ) ) {
+			title = __( 'Failed to open Cursor' );
+			message = __( 'Studio is unable to open Cursor. Please ensure it is functioning correctly.' );
 		} else {
 			title = __( 'Failed to open browser' );
 			message = __(


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Implements #938 

## Proposed Changes

- This PR proposes changes needed to add `Cursor` button on Shortcut Section. By clicking on Cursor button will open the WordPress installation folder on Cursor Code Editor. Cursor is rapidly growing Code Editor which is being loved by WordPress Developers. By priority is the last option after VS Code and Php Storm. 

## Testing Instructions

1. Remove both VS Code and Php Storm if installed
2. Install Cursor
3. Run Studio to see Cursor button
4. Clicking on it will open the project on Cursor

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
### Before 
<img width="1012" alt="before" src="https://github.com/user-attachments/assets/1cd709e4-f8bc-4a0f-a6db-5f583bc9e8aa" />

### After
<img width="1012" alt="after" src="https://github.com/user-attachments/assets/634f67f2-ce2c-412c-b800-5f3fe323f0cc" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
