### PR TITLE
Sort sites numerically correct

### DIFF
--- a/src/lib/sort-sites.ts
+++ b/src/lib/sort-sites.ts
@@ -1,3 +1,3 @@
 export function sortSites( sites: SiteDetails[] ): SiteDetails[] {
-	return sites.sort( ( a, b ) => a.name.localeCompare( b.name ) );
+	return sites.sort( ( a, b ) => a.name.localeCompare( b.name, undefined, { numeric: true } ) );
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/dotcom-forge/issues/10468

## Proposed Changes

Pass the `numeric` option to `String.prototype.localeCompare` in `src/lib/sort-sites.ts` so that the following strings are sorted in the correct numeric order: `test1`, `test2`, and `test10`.

| Before | After |
| - | - |
| <img width="1012" alt="before" src="https://github.com/user-attachments/assets/6eb28f3a-d7e3-444e-8ae5-a7d097bbc881" /> | <img width="1012" alt="after" src="https://github.com/user-attachments/assets/d142e772-9d76-4c87-a69d-a20db51239be" /> |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Have three sites with names ending in `1`, `2`, and `10`
2. Ensure that they are sorted in the correct numerical order
3. Ensure that there are no regressions in sorting your other sites

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
