### PR TITLE
Clear chat API ID when clearing Assistant convo

### DIFF
--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -392,6 +392,7 @@ export function ContentTabAssistant( { selectedSite }: ContentTabAssistantProps 
 	const clearConversation = () => {
 		dispatch( chatActions.setChatInput( { siteId: selectedSite.id, input: '' } ) );
 		dispatch( chatActions.setMessages( { instanceId, messages: [] } ) );
+		dispatch( chatActions.setChatApiId( { instanceId, chatApiId: undefined } ) );
 	};
 
 	// We should render only one notice at a time in the bottom area

--- a/src/stores/chat-slice.ts
+++ b/src/stores/chat-slice.ts
@@ -286,6 +286,13 @@ const chatSlice = createSlice( {
 			state.themeName = action.payload.name;
 			state.isBlockTheme = action.payload.isBlockTheme;
 		},
+		setChatApiId: (
+			state,
+			action: PayloadAction< { instanceId: string; chatApiId: number | undefined } >
+		) => {
+			const { instanceId, chatApiId } = action.payload;
+			state.chatApiIdDict[ instanceId ] = chatApiId;
+		},
 		setMessages: (
 			state,
 			action: PayloadAction< { instanceId: string; messages: Message[] } >


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/dotcom-forge/issues/10478

## Proposed Changes

Also clear the `chatApiIdDict[ instanceId ]` state when clearing an Assistant conversation. This is how it's supposed to work and was likely a regression caused by https://github.com/Automattic/studio/pull/826.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Open the Network tab in the dev tools
3. Continue an old Assistant chat or start a new one
4. Observe the `id` prop in the response from the `/studio-app/ai-assistant/chat` API endpoint
5. Clear the conversation
6. Send another message
7. Ensure that the `id` prop in the response from the `/studio-app/ai-assistant/chat` API endpoint is different than before

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
