### PR TITLE
Studio: Add notification when the preview site is created

### DIFF
--- a/src/hooks/use-archive-site.ts
+++ b/src/hooks/use-archive-site.ts
@@ -49,7 +49,6 @@ export function useArchiveSite() {
 								isLoading: false,
 							} );
 
-							// Show notification only when site is actually ready
 							await getIpcApi().showNotification( {
 								title: __( 'Preview created' ),
 								body: snapshot.localSiteName

--- a/src/hooks/use-archive-site.ts
+++ b/src/hooks/use-archive-site.ts
@@ -32,6 +32,9 @@ export function useArchiveSite() {
 		if ( loadingSnapshots.length === 0 ) {
 			return;
 		}
+
+		let activeSnapshot: Snapshot | null = null;
+
 		const intervalId = setInterval( async () => {
 			for ( const snapshot of loadingSnapshots ) {
 				if ( snapshot.isLoading ) {
@@ -48,16 +51,7 @@ export function useArchiveSite() {
 								...snapshot,
 								isLoading: false,
 							} );
-
-							await getIpcApi().showNotification( {
-								title: __( 'Preview created' ),
-								body: snapshot.localSiteName
-									? sprintf(
-											__( "Preview site for '%s' has been created." ),
-											snapshot.localSiteName
-									  )
-									: __( 'Preview site has been created.' ),
-							} );
+							activeSnapshot = snapshot;
 						}
 					} catch ( error ) {
 						updateSnapshot( {
@@ -70,6 +64,18 @@ export function useArchiveSite() {
 		}, 3000 );
 		return () => {
 			clearInterval( intervalId );
+			if ( activeSnapshot ) {
+				console.log( 'Showing notification...' );
+				getIpcApi().showNotification( {
+					title: __( 'Preview created' ),
+					body: activeSnapshot.localSiteName
+						? sprintf(
+								__( "Preview site for '%s' has been created." ),
+								activeSnapshot.localSiteName
+						  )
+						: __( 'Preview site has been created.' ),
+				} );
+			}
 		};
 	}, [ __, client, snapshots, updateSnapshot ] );
 

--- a/src/hooks/use-archive-site.ts
+++ b/src/hooks/use-archive-site.ts
@@ -65,7 +65,6 @@ export function useArchiveSite() {
 		return () => {
 			clearInterval( intervalId );
 			if ( activeSnapshot ) {
-				console.log( 'Showing notification...' );
 				getIpcApi().showNotification( {
 					title: __( 'Preview created' ),
 					body: activeSnapshot.localSiteName

--- a/src/hooks/use-archive-site.ts
+++ b/src/hooks/use-archive-site.ts
@@ -1,19 +1,19 @@
 import * as Sentry from '@sentry/electron/renderer';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
-import { useCallback, useEffect, useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import { DEMO_SITE_SIZE_LIMIT_BYTES, DEMO_SITE_SIZE_LIMIT_GB } from 'src/constants';
 import { useSyncSites } from 'src/hooks/sync-sites';
 import { useArchiveErrorMessages } from 'src/hooks/use-archive-error-messages';
 import { useAuth } from 'src/hooks/use-auth';
 import { useSiteDetails } from 'src/hooks/use-site-details';
-import { SnapshotStatus, SnapshotStatusResponse, useSnapshots } from 'src/hooks/use-snapshots';
+import { useSnapshots } from 'src/hooks/use-snapshots';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 import { isWpcomNetworkError } from 'src/lib/is-wpcom-network-error';
 
 export function useArchiveSite() {
 	const { uploadingSites, setUploadingSites, selectedSite } = useSiteDetails();
-	const { snapshots, addSnapshot, updateSnapshot, fetchSnapshotUsage } = useSnapshots();
+	const { snapshots, addSnapshot, fetchSnapshotUsage } = useSnapshots();
 	const isUploadingSiteId = useCallback(
 		( localSiteId: string ) => uploadingSites[ localSiteId ] || false,
 		[ uploadingSites ]
@@ -21,52 +21,6 @@ export function useArchiveSite() {
 	const { client, user } = useAuth();
 	const { __ } = useI18n();
 	const { connectedSites } = useSyncSites();
-
-	useEffect( () => {
-		if ( ! client ) {
-			// Can't poll for snapshots if logged out
-			return;
-		}
-
-		const loadingSnapshots = snapshots.filter( ( snapshot ) => snapshot.isLoading );
-		if ( loadingSnapshots.length === 0 ) {
-			return;
-		}
-
-		const intervalId = setInterval( async () => {
-			for ( const snapshot of loadingSnapshots ) {
-				if ( snapshot.isLoading ) {
-					try {
-						const response: SnapshotStatusResponse = await client.req.get(
-							'/jurassic-ninja/status',
-							{
-								apiNamespace: 'wpcom/v2',
-								site_id: snapshot.atomicSiteId,
-							}
-						);
-						if ( response.status === SnapshotStatus.Active ) {
-							updateSnapshot( {
-								...snapshot,
-								isLoading: false,
-							} );
-							getIpcApi().showNotification( {
-								title: snapshot.name,
-								body: sprintf( __( "Preview site '%s' has been created." ), snapshot.url ),
-							} );
-						}
-					} catch ( error ) {
-						updateSnapshot( {
-							...snapshot,
-							isLoading: false,
-						} );
-					}
-				}
-			}
-		}, 3000 );
-		return () => {
-			clearInterval( intervalId );
-		};
-	}, [ __, client, snapshots, updateSnapshot ] );
 
 	const getNextSequenceNumber = (
 		siteId: string,

--- a/src/hooks/use-archive-site.ts
+++ b/src/hooks/use-archive-site.ts
@@ -48,6 +48,17 @@ export function useArchiveSite() {
 								...snapshot,
 								isLoading: false,
 							} );
+
+							// Show notification only when site is actually ready
+							await getIpcApi().showNotification( {
+								title: __( 'Preview created' ),
+								body: snapshot.localSiteName
+									? sprintf(
+											__( "Preview site for '%s' has been created." ),
+											snapshot.localSiteName
+									  )
+									: __( 'Preview site has been created.' ),
+							} );
 						}
 					} catch ( error ) {
 						updateSnapshot( {
@@ -61,7 +72,7 @@ export function useArchiveSite() {
 		return () => {
 			clearInterval( intervalId );
 		};
-	}, [ client, snapshots, updateSnapshot ] );
+	}, [ __, client, snapshots, updateSnapshot ] );
 
 	const getNextSequenceNumber = (
 		siteId: string,
@@ -171,6 +182,7 @@ export function useArchiveSite() {
 						),
 						sequence: nextSequence,
 						userId: user.id,
+						localSiteName: selectedSite?.name,
 					} );
 				} catch ( error ) {
 					if ( isWpcomNetworkError( error ) ) {

--- a/src/hooks/use-archive-site.ts
+++ b/src/hooks/use-archive-site.ts
@@ -66,13 +66,11 @@ export function useArchiveSite() {
 			clearInterval( intervalId );
 			if ( activeSnapshot ) {
 				getIpcApi().showNotification( {
-					title: __( 'Preview created' ),
-					body: activeSnapshot.localSiteName
-						? sprintf(
-								__( "Preview site for '%s' has been created." ),
-								activeSnapshot.localSiteName
-						  )
-						: __( 'Preview site has been created.' ),
+					title: activeSnapshot.localSiteName,
+					body: sprintf(
+						__( "Preview site for '%s' has been created." ),
+						activeSnapshot.localSiteName
+					),
 				} );
 			}
 		};

--- a/src/hooks/use-archive-site.ts
+++ b/src/hooks/use-archive-site.ts
@@ -66,11 +66,8 @@ export function useArchiveSite() {
 			clearInterval( intervalId );
 			if ( activeSnapshot ) {
 				getIpcApi().showNotification( {
-					title: activeSnapshot.localSiteName,
-					body: sprintf(
-						__( "Preview site for '%s' has been created." ),
-						activeSnapshot.localSiteName
-					),
+					title: activeSnapshot.name,
+					body: sprintf( __( "Preview site '%s' has been created." ), activeSnapshot.url ),
 				} );
 			}
 		};
@@ -184,7 +181,6 @@ export function useArchiveSite() {
 						),
 						sequence: nextSequence,
 						userId: user.id,
-						localSiteName: selectedSite?.name,
 					} );
 				} catch ( error ) {
 					if ( isWpcomNetworkError( error ) ) {

--- a/src/hooks/use-archive-site.ts
+++ b/src/hooks/use-archive-site.ts
@@ -33,8 +33,6 @@ export function useArchiveSite() {
 			return;
 		}
 
-		let activeSnapshot: Snapshot | null = null;
-
 		const intervalId = setInterval( async () => {
 			for ( const snapshot of loadingSnapshots ) {
 				if ( snapshot.isLoading ) {
@@ -51,7 +49,10 @@ export function useArchiveSite() {
 								...snapshot,
 								isLoading: false,
 							} );
-							activeSnapshot = snapshot;
+							getIpcApi().showNotification( {
+								title: snapshot.name,
+								body: sprintf( __( "Preview site '%s' has been created." ), snapshot.url ),
+							} );
 						}
 					} catch ( error ) {
 						updateSnapshot( {
@@ -64,12 +65,6 @@ export function useArchiveSite() {
 		}, 3000 );
 		return () => {
 			clearInterval( intervalId );
-			if ( activeSnapshot ) {
-				getIpcApi().showNotification( {
-					title: activeSnapshot.name,
-					body: sprintf( __( "Preview site '%s' has been created." ), activeSnapshot.url ),
-				} );
-			}
 		};
 	}, [ __, client, snapshots, updateSnapshot ] );
 

--- a/src/hooks/use-snapshots.tsx
+++ b/src/hooks/use-snapshots.tsx
@@ -1,4 +1,5 @@
 import * as Sentry from '@sentry/electron/renderer';
+import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import React, {
 	createContext,
@@ -306,6 +307,52 @@ export const SnapshotProvider: React.FC< { children: ReactNode } > = ( { childre
 		};
 		fetchStats();
 	}, [ client, fetchSnapshotUsage, initiated, snapshots.length ] );
+
+	useEffect( () => {
+		if ( ! client ) {
+			// Can't poll for snapshots if logged out
+			return;
+		}
+
+		const loadingSnapshots = snapshots.filter( ( snapshot ) => snapshot.isLoading );
+		if ( loadingSnapshots.length === 0 ) {
+			return;
+		}
+
+		const intervalId = setInterval( async () => {
+			for ( const snapshot of loadingSnapshots ) {
+				if ( snapshot.isLoading ) {
+					try {
+						const response: SnapshotStatusResponse = await client.req.get(
+							'/jurassic-ninja/status',
+							{
+								apiNamespace: 'wpcom/v2',
+								site_id: snapshot.atomicSiteId,
+							}
+						);
+						if ( response.status === SnapshotStatus.Active ) {
+							updateSnapshot( {
+								...snapshot,
+								isLoading: false,
+							} );
+							getIpcApi().showNotification( {
+								title: snapshot.name,
+								body: sprintf( __( "Preview site '%s' has been created." ), snapshot.url ),
+							} );
+						}
+					} catch ( error ) {
+						updateSnapshot( {
+							...snapshot,
+							isLoading: false,
+						} );
+					}
+				}
+			}
+		}, 3000 );
+		return () => {
+			clearInterval( intervalId );
+		};
+	}, [ __, client, snapshots, updateSnapshot ] );
 
 	const value: SnapshotContextType = useMemo(
 		() => ( {

--- a/src/ipc-types.d.ts
+++ b/src/ipc-types.d.ts
@@ -50,6 +50,7 @@ interface Snapshot {
 	name?: string;
 	sequence?: number;
 	userId?: number;
+	localSiteName?: string;
 }
 
 type InstalledApps = {

--- a/src/ipc-types.d.ts
+++ b/src/ipc-types.d.ts
@@ -50,7 +50,6 @@ interface Snapshot {
 	name?: string;
 	sequence?: number;
 	userId?: number;
-	localSiteName?: string;
 }
 
 type InstalledApps = {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

Closes https://github.com/Automattic/dotcom-forge/issues/10486

## Proposed Changes

This PR adds a notification when a new preview site has been successfully created:

<img width="368" alt="Screenshot 2025-02-20 at 9 52 45 AM" src="https://github.com/user-attachments/assets/b77fb2c4-3576-41b4-89ab-e38d49ec8645" />

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
* Start the app with `npm start`
* Navigate to the `Previews` tab
* Click on `Create preview site`
* Once the process is finished and the loading bar is not present anymore, observe that there is a notification about new site being created

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
