### PR TITLE
Rename `populateSnapshotUserIds` to `legacyPopulateSnapshotUserIds`

### DIFF
--- a/src/storage/user-data.ts
+++ b/src/storage/user-data.ts
@@ -46,7 +46,7 @@ function populatePhpVersion( sites: SiteDetails[] ) {
 	} );
 }
 
-function populateSnapshotUserIds( data: UserData ): void {
+function legacyPopulateSnapshotUserIds( data: UserData ): void {
 	const userId = data.authToken?.id;
 
 	if ( userId && data.snapshots ) {
@@ -69,7 +69,9 @@ export async function loadUserData(): Promise< UserData > {
 			const parsed = JSON.parse( asString );
 			const data = fromDiskFormat( parsed );
 
-			populateSnapshotUserIds( data );
+			// Temporarily populate old snapshots with userId of authenticated user.
+			// See PR #937 for more context.
+			legacyPopulateSnapshotUserIds( data );
 			sortSites( data.sites );
 			populatePhpVersion( data.sites );
 			return data;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Resolves https://github.com/Automattic/dotcom-forge/issues/10484.

## Proposed Changes

- rename `populateSnapshotUserIds` to `legacyPopulateSnapshotUserIds`
- add context

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- code review should be sufficient

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
