### PR TITLE
Clean up archiver options handling

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -28,6 +28,17 @@ export const LOCAL_STORAGE_CHAT_API_IDS_KEY = 'ai_chat_ids';
 
 export const ACCEPTED_IMPORT_FILE_TYPES = [ '.zip', '.gz', '.gzip', '.tar', '.tar.gz', '.wpress' ];
 
+// Archiver options
+export const ARCHIVER_OPTIONS = {
+	zip: {
+		zlib: { level: 9 },
+	},
+	tar: {
+		gzip: true,
+		gzipOptions: { level: 9 },
+	},
+};
+
 // OAuth constants
 export const CLIENT_ID = '95109';
 export const PROTOCOL_PREFIX = 'wpcom-local-dev';

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -17,7 +17,7 @@ import nodePath from 'path';
 import * as Sentry from '@sentry/electron/main';
 import { __, LocaleData, defaultI18n } from '@wordpress/i18n';
 import archiver from 'archiver';
-import { MAIN_MIN_WIDTH, SIDEBAR_WIDTH } from 'src/constants';
+import { ARCHIVER_OPTIONS, MAIN_MIN_WIDTH, SIDEBAR_WIDTH } from 'src/constants';
 import { sendIpcEventToRendererWithWindow } from 'src/ipc-utils';
 import { ACTIVE_SYNC_OPERATIONS } from 'src/lib/active-sync-operations';
 import { calculateDirectorySize } from 'src/lib/calculate-directory-size';
@@ -535,9 +535,7 @@ function archiveWordPressDirectory( {
 } ) {
 	return new Promise( ( resolve, reject ) => {
 		const output = fs.createWriteStream( archivePath );
-		const archive = archiver( format, {
-			zlib: { level: 9 }, // Sets the compression level.
-		} );
+		const archive = archiver( format, ARCHIVER_OPTIONS[ format ] );
 
 		output.on( 'close', function () {
 			resolve( archive );

--- a/src/lib/import-export/export/exporters/default-exporter.ts
+++ b/src/lib/import-export/export/exporters/default-exporter.ts
@@ -4,6 +4,7 @@ import fsPromises from 'fs/promises';
 import os from 'os';
 import path from 'path';
 import archiver from 'archiver';
+import { ARCHIVER_OPTIONS } from 'src/constants';
 import { ExportEvents } from 'src/lib/import-export/export/events';
 import {
 	exportDatabaseToFile,
@@ -120,10 +121,8 @@ export class DefaultExporter extends EventEmitter implements Exporter {
 	private createArchive(): archiver.Archiver {
 		this.emit( ExportEvents.BACKUP_CREATE_START );
 		const isZip = this.options.backupFile.endsWith( '.zip' );
-		return archiver( isZip ? 'zip' : 'tar', {
-			gzip: ! isZip,
-			gzipOptions: isZip ? undefined : { level: 9 },
-		} );
+		const format = isZip ? 'zip' : 'tar';
+		return archiver( format, ARCHIVER_OPTIONS[ format ] );
 	}
 
 	private setupArchiveListeners( output: fs.WriteStream ): Promise< void > {

--- a/src/lib/import-export/tests/export/exporters/default-exporter.test.ts
+++ b/src/lib/import-export/tests/export/exporters/default-exporter.test.ts
@@ -217,7 +217,7 @@ platformTestSuite( 'DefaultExporter', ( { normalize } ) => {
 		mockOptions.backupFile = '/path/to/backup.zip';
 		await exporter.export();
 
-		expect( archiver ).toHaveBeenCalledWith( 'zip', { gzip: false, gzipOptions: undefined } );
+		expect( archiver ).toHaveBeenCalledWith( 'zip', { zlib: { level: 9 } } );
 	} );
 
 	it( 'should add wp-config.php to the archive', async () => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- https://github.com/Automattic/dotcom-forge/issues/9931

## Proposed Changes

- I propose to clean up archiver options handling to set and pass them explicitly for each format.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Export the site and confirm that the correct .zip is produced
- Push site and confirm the process works fine
- Optionally, comment out `unlink` call in `removeTemporalFile` and replace it with `console.log` to confirm file sizes

```
diff --git a/src/ipc-handlers.ts b/src/ipc-handlers.ts
index f84e155..3ef3e47 100644
--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -603,7 +603,8 @@ export function removeTemporalFile( event: IpcMainInvokeEvent, path: string ) {
                throw new Error( 'The given path is not a temporal file' );
        }
        try {
-               fs.unlinkSync( path );
+               console.log( path );
+               //fs.unlinkSync( path );
        } catch ( error ) {
                if ( isErrnoException( error ) && error.code === 'ENOENT' ) {
                        // Silently ignore if the temporal file doesn't exist

```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
