### PR TITLE
Studio: Improve wording for when preview site is being created

### DIFF
--- a/src/hooks/use-archive-site.ts
+++ b/src/hooks/use-archive-site.ts
@@ -216,14 +216,23 @@ export function useArchiveSite() {
 			snapshots,
 		]
 	);
-	const isAnySiteArchiving = useMemo( () => {
-		const isAnySiteUploading = Object.values( uploadingSites ).some( ( uploading ) => uploading );
-		return isAnySiteUploading || snapshots.some( ( snapshot ) => snapshot.isLoading );
-	}, [ snapshots, uploadingSites ] );
+
+	const { isAnySiteArchiving, archivingSiteId } = useMemo( () => {
+		const uploadingSiteId = Object.keys( uploadingSites ).find(
+			( siteId ) => uploadingSites[ siteId ]
+		);
+		const loadingSnapshot = snapshots.find( ( snapshot ) => snapshot.isLoading );
+
+		return {
+			isAnySiteArchiving: !! uploadingSiteId || !! loadingSnapshot,
+			archivingSiteId: uploadingSiteId || loadingSnapshot?.localSiteId || null,
+		};
+	}, [ uploadingSites, snapshots ] );
 
 	return {
 		archiveSite,
 		isUploadingSiteId,
 		isAnySiteArchiving,
+		archivingSiteId,
 	};
 }

--- a/src/modules/preview-site/components/create-preview-button.tsx
+++ b/src/modules/preview-site/components/create-preview-button.tsx
@@ -37,7 +37,7 @@ export function CreatePreviewButton( { onClick, selectedSite }: CreatePreviewBut
 		isOverLimit;
 
 	const currentSiteArchivingMessage = __(
-		"This site's preview is being created. Please wait for it to finish before creating another."
+		'A preview of this siteis being created. Please wait for it to finish before creating another.'
 	);
 	const otherSiteArchivingMessage = __(
 		'A different preview site is being created. Please wait for it to finish before creating another.'

--- a/src/modules/preview-site/components/create-preview-button.tsx
+++ b/src/modules/preview-site/components/create-preview-button.tsx
@@ -17,13 +17,16 @@ interface CreatePreviewButtonProps {
 
 export function CreatePreviewButton( { onClick, selectedSite }: CreatePreviewButtonProps ) {
 	const { __, _n } = useI18n();
-	const { isAnySiteArchiving } = useArchiveSite();
+	const { isAnySiteArchiving, archivingSiteId } = useArchiveSite();
 	const { activeSnapshotCount, snapshotQuota, isLoadingSnapshotUsage, snapshotCreationBlocked } =
 		useSnapshots();
 	const isLimitUsed = activeSnapshotCount >= snapshotQuota;
 	const { isOverLimit } = useSiteSize( selectedSite.id );
 	const isOffline = useOffline();
 	const errorMessages = useArchiveErrorMessages();
+
+	const isCurrentSiteArchiving = archivingSiteId === selectedSite.id;
+	const isOtherSiteArchiving = isAnySiteArchiving && ! isCurrentSiteArchiving;
 
 	const isDisabled =
 		isAnySiteArchiving ||
@@ -33,7 +36,10 @@ export function CreatePreviewButton( { onClick, selectedSite }: CreatePreviewBut
 		snapshotCreationBlocked ||
 		isOverLimit;
 
-	const siteArchivingMessage = __(
+	const currentSiteArchivingMessage = __(
+		"This site's preview is being created. Please wait for it to finish before creating another."
+	);
+	const otherSiteArchivingMessage = __(
 		'A different preview site is being created. Please wait for it to finish before creating another.'
 	);
 	const allotmentConsumptionMessage = sprintf(
@@ -60,8 +66,10 @@ export function CreatePreviewButton( { onClick, selectedSite }: CreatePreviewBut
 		};
 	} else if ( isLimitUsed ) {
 		tooltipContent = { text: allotmentConsumptionMessage };
-	} else if ( isAnySiteArchiving ) {
-		tooltipContent = { text: siteArchivingMessage };
+	} else if ( isCurrentSiteArchiving ) {
+		tooltipContent = { text: currentSiteArchivingMessage };
+	} else if ( isOtherSiteArchiving ) {
+		tooltipContent = { text: otherSiteArchivingMessage };
 	} else if ( snapshotCreationBlocked ) {
 		tooltipContent = { text: errorMessages.rest_site_creation_blocked };
 	} else if ( isOverLimit ) {

--- a/src/modules/preview-site/components/create-preview-button.tsx
+++ b/src/modules/preview-site/components/create-preview-button.tsx
@@ -37,7 +37,7 @@ export function CreatePreviewButton( { onClick, selectedSite }: CreatePreviewBut
 		isOverLimit;
 
 	const currentSiteArchivingMessage = __(
-		'A preview of this siteis being created. Please wait for it to finish before creating another.'
+		'A preview of this site is being created. Please wait for it to finish before creating another.'
 	);
 	const otherSiteArchivingMessage = __(
 		'A different preview site is being created. Please wait for it to finish before creating another.'


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

Closes https://github.com/Automattic/dotcom-forge/issues/10453

## Proposed Changes

This PR adjusts the wording for the message when a preview site is being created. When a preview site is being created for a specific local site A, the wording on the `Create new site` button on that site A should say `This site's preview is being created. Please wait for it to finish before creating another`.  

<img width="905" alt="Screenshot 2025-02-19 at 4 44 26 PM" src="https://github.com/user-attachments/assets/cffc3f5b-1ab0-4499-8a4d-6f39dfbddd62" />

The wording on any other local Studio site on the disabled button should remain as before: `A different preview site is being created. Please wait for it to finish before creating another.`

<img width="925" alt="Screenshot 2025-02-19 at 4 44 32 PM" src="https://github.com/user-attachments/assets/8c9ba63e-5b0a-44cb-a0fc-5bedc8c6a95f" />


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
* Start the app with `npm start`
* Navigate to the `Previews` tab on Studio site A
* Click on `Create preview site` 
* Observe that you see the message `This site's preview is being created. Please wait for it to finish before creating another` when you hover over the disabled `Create preview site` while the preview is being created
* Switch to Studio site B
* Observe that you see the message `A different preview site is being created. Please wait for it to finish before creating another.` when you hover over the disabled `Create preview site` while the preview is being created

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
