### PR TITLE
Preview Sites: Fix truncating of site names and URLs

### DIFF
--- a/src/modules/preview-site/components/preview-site-row.tsx
+++ b/src/modules/preview-site/components/preview-site-row.tsx
@@ -92,7 +92,7 @@ export function PreviewSiteRow( {
 	return (
 		<div className="self-stretch flex-col">
 			<div className="flex items-center px-8 py-6">
-				<div className="w-[51%]">
+				<div className="w-[51%] overflow-hidden ltr:pr-4 rtl:pl-4">
 					<div className="flex items-center">
 						<div
 							className={ cx(
@@ -104,12 +104,12 @@ export function PreviewSiteRow( {
 							{ snapshot.name || sprintf( __( '%s Preview' ), selectedSite.name ) }
 						</div>
 					</div>
-					<Tooltip text={ urlWithHTTPS } disabled={ isExpired }>
+					<Tooltip text={ urlWithHTTPS } disabled={ isExpired } className="overflow-hidden">
 						<Button
 							variant="link"
 							disabled={ isExpired }
 							className={ cx(
-								'!text-a8c-gray-700 max-w-[250px]',
+								'!text-a8c-gray-700 max-w-[100%]',
 								isExpired ? 'pointer-events-none' : 'hover:!text-a8c-blueberry'
 							) }
 							onClick={ () => getIpcApi().openURL( urlWithHTTPS ) }

--- a/src/modules/preview-site/components/preview-site-row.tsx
+++ b/src/modules/preview-site/components/preview-site-row.tsx
@@ -92,7 +92,7 @@ export function PreviewSiteRow( {
 	return (
 		<div className="self-stretch flex-col">
 			<div className="flex items-center px-8 py-6">
-				<div className="w-[51%] overflow-hidden ltr:pr-4 rtl:pl-4">
+				<div className="w-[51%] overflow-hidden pe-4">
 					<div className="flex items-center">
 						<div
 							className={ cx(
@@ -109,7 +109,7 @@ export function PreviewSiteRow( {
 							variant="link"
 							disabled={ isExpired }
 							className={ cx(
-								'!text-a8c-gray-700 max-w-[100%]',
+								'!text-a8c-gray-700 max-w-full',
 								isExpired ? 'pointer-events-none' : 'hover:!text-a8c-blueberry'
 							) }
 							onClick={ () => getIpcApi().openURL( urlWithHTTPS ) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/dotcom-forge/issues/10487.

## Proposed Changes

- fix styling on the Previews tab to ensure the preview site names and URLs get truncated correctly

https://github.com/user-attachments/assets/f989a953-4d5b-47c1-a84e-7b72ed1242e9

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR branch and build the app with `npm start`.
2. Head over to the Preview sites tab and create some preview sites (if you don't have any).
3. If the preview site names and URLs are not long enough, manually change the strings through the browser console.
4. Try to change the size of the app window.
5. Long site names and URLs should get truncated correctly. If you maximize the app window, the string shouldn't get truncated.
6. The above should work well when RTL locale is set.   

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
