### PR TITLE
More permissive zod schema when fetching sites

### DIFF
--- a/src/hooks/use-fetch-wpcom-sites/index.tsx
+++ b/src/hooks/use-fetch-wpcom-sites/index.tsx
@@ -14,25 +14,29 @@ export const sitesEndpointSiteSchema = z.object( {
 	URL: z.string(),
 	jetpack: z.boolean().optional(),
 	is_deleted: z.boolean(),
-	options: z.object( {
-		created_at: z.string(),
-		wpcom_staging_blog_ids: z.array( z.number() ),
-	} ),
+	options: z
+		.object( {
+			created_at: z.string(),
+			wpcom_staging_blog_ids: z.array( z.number() ),
+		} )
+		.optional(),
 	capabilities: z.object( {
 		manage_options: z.boolean(),
 	} ),
-	plan: z.object( {
-		expired: z.boolean(),
-		features: z.object( {
-			active: z.array( z.string() ),
-			available: z.record( z.string(), z.array( z.string() ) ).optional(),
-		} ),
-		is_free: z.boolean(),
-		product_id: z.number(),
-		product_name_short: z.string(),
-		product_slug: z.string(),
-		user_is_owner: z.boolean(),
-	} ),
+	plan: z
+		.object( {
+			expired: z.boolean(),
+			features: z.object( {
+				active: z.array( z.string() ),
+				available: z.record( z.string(), z.array( z.string() ) ).optional(),
+			} ),
+			is_free: z.boolean(),
+			product_id: z.number(),
+			product_name_short: z.string(),
+			product_slug: z.string(),
+			user_is_owner: z.boolean(),
+		} )
+		.optional(),
 } );
 
 type SitesEndpointSite = z.infer< typeof sitesEndpointSiteSchema >;
@@ -49,7 +53,7 @@ function isJetpackSite( site: SitesEndpointSite ): boolean {
 }
 
 function hasSupportedPlan( site: SitesEndpointSite ): boolean {
-	return site.plan.features.active.includes( STUDIO_SYNC_FEATURE_NAME );
+	return site.plan?.features.active.includes( STUDIO_SYNC_FEATURE_NAME ) ?? false;
 }
 
 function getSyncSupport( site: SitesEndpointSite, connectedSiteIds: number[] ): SyncSupport {
@@ -98,13 +102,13 @@ export function transformSitesResponse( sites: unknown[], connectedSiteIds: numb
 			const site = sitesEndpointSiteSchema.parse( rawSite );
 			return [ ...acc, site ];
 		} catch ( error ) {
-			Sentry.captureException( error );
+			console.error( error );
 			return acc;
 		}
 	}, [] );
 
 	const allStagingSiteIds = validatedSites.flatMap( ( site ) => {
-		return site.options.wpcom_staging_blog_ids;
+		return site.options?.wpcom_staging_blog_ids ?? [];
 	} );
 
 	return validatedSites

--- a/src/hooks/use-fetch-wpcom-sites/index.tsx
+++ b/src/hooks/use-fetch-wpcom-sites/index.tsx
@@ -102,7 +102,7 @@ export function transformSitesResponse( sites: unknown[], connectedSiteIds: numb
 			const site = sitesEndpointSiteSchema.parse( rawSite );
 			return [ ...acc, site ];
 		} catch ( error ) {
-			console.error( error );
+			Sentry.captureException( error );
 			return acc;
 		}
 	}, [] );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/dotcom-forge/issues/10511

## Proposed Changes

The Sentry error shows that more than one key didn't pass the schema validation, but it only shows the name of the first one, `options` (the rest is truncated). This PR makes the `options` and `plan` objects optional. So, I'm assuming that `plan` could also be undefined.

I initially suspected this might happen for third-party Jetpack-connected site, but I couldn't reproduce it for sites like that, or for any other type of site.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Code review should suffice

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
