### PR TITLE
Update urls in DB if site is being created from existing folder

### DIFF
--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -42,6 +42,7 @@ import { portFinder } from 'src/lib/port-finder';
 import { shellOpenExternalWrapper } from 'src/lib/shell-open-external-wrapper';
 import { sortSites } from 'src/lib/sort-sites';
 import { installSqliteIntegration, keepSqliteIntegrationUpdated } from 'src/lib/sqlite-versions';
+import { updateSiteUrlToLocal } from 'src/lib/updateSiteUrlToLocal';
 import * as windowsHelpers from 'src/lib/windows-helpers';
 import { getLogsFilePath, writeLogToFile, type LogLevel } from 'src/logging';
 import { getMainWindow } from 'src/main-window';
@@ -190,6 +191,10 @@ export async function createSite(
 		if ( ! ( await pathExists( nodePath.join( path, 'wp-config.php' ) ) ) ) {
 			await installSqliteIntegration( path );
 		}
+	}
+
+	if ( await pathExists( nodePath.join( path, 'wp-content/database/.ht.sqlite' ) ) ) {
+		await updateSiteUrlToLocal( details.id );
 	}
 
 	const parentWindow = BrowserWindow.fromWebContents( event.sender );

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -190,11 +190,9 @@ export async function createSite(
 
 		if ( ! ( await pathExists( nodePath.join( path, 'wp-config.php' ) ) ) ) {
 			await installSqliteIntegration( path );
+		} else {
+			await updateSiteUrlToLocal( details.id );
 		}
-	}
-
-	if ( await pathExists( nodePath.join( path, 'wp-content/database/.ht.sqlite' ) ) ) {
-		await updateSiteUrlToLocal( details.id );
 	}
 
 	const parentWindow = BrowserWindow.fromWebContents( event.sender );

--- a/src/ipc-types.d.ts
+++ b/src/ipc-types.d.ts
@@ -34,7 +34,6 @@ interface StoppedSiteDetails {
 interface StartedSiteDetails extends StoppedSiteDetails {
 	running: true;
 
-	port: number;
 	url: string;
 }
 

--- a/src/lib/import-export/import/importers/importer.ts
+++ b/src/lib/import-export/import/importers/importer.ts
@@ -10,9 +10,9 @@ import { generateBackupFilename } from 'src/lib/import-export/export/generate-ba
 import { ImportEvents } from 'src/lib/import-export/import/events';
 import { BackupContents, MetaFileData } from 'src/lib/import-export/import/types';
 import { serializePlugins } from 'src/lib/serialize-plugins';
+import { updateSiteUrlToLocal } from 'src/lib/updateSiteUrlToLocal';
 import { SiteServer } from 'src/site-server';
 import { DEFAULT_PHP_VERSION } from 'vendor/wp-now/src/constants';
-
 export interface ImporterResult extends Omit< BackupContents, 'metaFile' > {
 	meta?: MetaFileData;
 }
@@ -72,51 +72,12 @@ abstract class BaseImporter extends EventEmitter implements Importer {
 			}
 		}
 
-		await this.replaceSiteUrl( siteId );
+		await updateSiteUrlToLocal( siteId );
 		this.emit( ImportEvents.IMPORT_DATABASE_COMPLETE );
 	}
 
 	protected async prepareSqlFile( _tmpPath: string ): Promise< void > {
 		// This method can be overridden by subclasses to prepare the SQL file before import.
-	}
-
-	protected async replaceSiteUrl( siteId: string ) {
-		const server = SiteServer.get( siteId );
-		if ( ! server ) {
-			throw new Error( 'Site not found.' );
-		}
-
-		const { stdout: currentSiteUrl } = await server.executeWpCliCommand( `option get siteurl`, {
-			skipPluginsAndThemes: true,
-		} );
-
-		if ( ! currentSiteUrl ) {
-			console.error( 'Failed to fetch site URL after import' );
-			return;
-		}
-
-		const studioUrl = `http://localhost:${ server.details.port }`;
-		const oldUrl = currentSiteUrl.trim();
-		const urlWithoutProtocol = oldUrl.replace( /^https?:\/\//, '' );
-
-		const oldUrlVariants = [ `http://${ urlWithoutProtocol }`, `https://${ urlWithoutProtocol }` ];
-
-		for ( const urlToReplace of oldUrlVariants ) {
-			const { stderr, exitCode } = await server.executeWpCliCommand(
-				`search-replace '${ urlToReplace }' '${ studioUrl }'`,
-				{ skipPluginsAndThemes: true }
-			);
-
-			if ( stderr ) {
-				console.error( `Warning during replacing URLs (${ urlToReplace }): ${ stderr }` );
-			}
-
-			if ( exitCode ) {
-				console.error(
-					`Error during replacing URLs (${ urlToReplace }), Exit Code: ${ exitCode }`
-				);
-			}
-		}
 	}
 
 	protected async safelyDeletePath( path: string ): Promise< void > {
@@ -309,7 +270,7 @@ export class PlaygroundImporter extends BaseBackupImporter {
 				overwrite: true,
 			} );
 		}
-		await this.replaceSiteUrl( siteId );
+		await updateSiteUrlToLocal( siteId );
 
 		this.emit( ImportEvents.IMPORT_DATABASE_COMPLETE );
 	}

--- a/src/lib/updateSiteUrlToLocal.ts
+++ b/src/lib/updateSiteUrlToLocal.ts
@@ -1,0 +1,39 @@
+import { SiteServer } from 'src/site-server';
+
+export const updateSiteUrlToLocal = async ( siteId: string ) => {
+	const server = SiteServer.get( siteId );
+	if ( ! server ) {
+		throw new Error( 'Site not found.' );
+	}
+
+	const { stdout: currentSiteUrl } = await server.executeWpCliCommand( `option get siteurl`, {
+		skipPluginsAndThemes: true,
+	} );
+
+	if ( ! currentSiteUrl ) {
+		console.error( 'Failed to fetch site URL after import' );
+		return;
+	}
+
+	const studioUrl = `http://localhost:${ server.details.port }`;
+	const oldUrl = currentSiteUrl.trim();
+	const urlWithoutProtocol = oldUrl.replace( /^https?:\/\//, '' );
+
+	const oldUrlVariants = [ `http://${ urlWithoutProtocol }`, `https://${ urlWithoutProtocol }` ];
+
+	for ( const urlToReplace of oldUrlVariants ) {
+		const { stderr, exitCode } = await server.executeWpCliCommand(
+			// --skip-columns=guid Skip the guid column to avoid altering the GUIDs of your posts, which is a best practice.
+			`search-replace '${ urlToReplace }' '${ studioUrl }' --skip-columns=guid`,
+			{ skipPluginsAndThemes: true }
+		);
+
+		if ( stderr ) {
+			console.error( `Warning during replacing URLs (${ urlToReplace }): ${ stderr }` );
+		}
+
+		if ( exitCode ) {
+			console.error( `Error during replacing URLs (${ urlToReplace }), Exit Code: ${ exitCode }` );
+		}
+	}
+};

--- a/src/lib/updateSiteUrlToLocal.ts
+++ b/src/lib/updateSiteUrlToLocal.ts
@@ -23,7 +23,6 @@ export const updateSiteUrlToLocal = async ( siteId: string ) => {
 
 	for ( const urlToReplace of oldUrlVariants ) {
 		const { stderr, exitCode } = await server.executeWpCliCommand(
-			// --skip-columns=guid Skip the guid column to avoid altering the GUIDs of your posts, which is a best practice.
 			`search-replace '${ urlToReplace }' '${ studioUrl }' --skip-columns=guid`,
 			{ skipPluginsAndThemes: true }
 		);


### PR DESCRIPTION
## Related issues

- Fixes https://github.com/Automattic/dotcom-forge/issues/7075

## Proposed Changes
The initial issue was about broken URLs for images, but actually we have much bigger problems (Antonio was right [here](https://github.com/Automattic/dotcom-forge/issues/7075#issuecomment-2662715171)) - in 100% cases the website is completely broken. But this PR indeed fixes both - images and broken wp-admin.

<img width="1543" alt="Screenshot 2025-02-20 at 17 28 29" src="https://github.com/user-attachments/assets/5ff46280-f02d-4ed4-ad6d-50a9cb518f93" />

## Testing Instructions
1. We need to create a website with some big port, it will simplify testing
  1.1. Create a few websites (e.g. three)
  1.2 Open wp admin for the last one (let's assume that it has port 8883) and create a new post with adding some image there
  1.3 Remove the last one, but keep a folder on your laptop
  1.4 Remove other websites, together with folders, we don't need them anymore
2. So now we have folder with WP site, which saved port 8883 in URLs inside your DB (you can confirm it by opening `/wp-content/databases/.ht.sqlite` and check for example `wp-options` -> `home` || `siteurl`)
3. Create a new website, but provide this fodler as `Local path` in the creation dialog
4. Click on "WP Admin" link
5. Assert that wp admin looks good in browser, there are no error in console, connected to not available favicon, files etc
6. Assert that the image is available from 1.2 step
7. Additionally, you can check your DB (`wp_options`, `wp_users` and `wp_posts`)
