### PR TITLE
Update font used in preview sites table header

### DIFF
--- a/src/modules/preview-site/components/preview-sites-table-header.tsx
+++ b/src/modules/preview-site/components/preview-sites-table-header.tsx
@@ -5,7 +5,7 @@ export function PreviewSitesTableHeader() {
 	const { __ } = useI18n();
 	return (
 		<div className="border-b border-a8c-gray-5">
-			<div className="flex items-center h-12 px-8 text-gray-900 text-xs uppercase">
+			<div className="flex items-center h-12 px-8 a8c-label uppercase">
 				<div className="w-[51%]">{ __( 'Preview site' ) }</div>
 				<div className="flex ltr:ml-auto rtl:mr-auto">
 					<div className="w-[150px] flex items-center pl-4">{ __( 'Updated' ) }</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes p1740145607798129/1740142244.756879-slack-C06DRMD6VPZ

## Proposed Changes

- Use font size 11, font weight 500 for preview sites table header

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run npm start
- Go to Previews tab
- Create a preview site
- Observe the font used in the tables is the correct one, same as the design

**BEFORE**

<img width="1051" alt="01-before" src="https://github.com/user-attachments/assets/e556a3ea-3e3a-4863-9dc6-ec26d04780a9" />


**AFTER**

<img width="1051" alt="02-after" src="https://github.com/user-attachments/assets/fbdf31b8-90e0-47a9-be9e-e95ce4019b13" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?