### PR TITLE
Studio: Fix text formatting on Preview and Sync tabs when the user is logged out

### DIFF
--- a/src/components/content-tab-previews.tsx
+++ b/src/components/content-tab-previews.tsx
@@ -115,31 +115,28 @@ function NoAuth( { selectedSite }: React.ComponentProps< typeof EmptyGeneric > )
 					text={ offlineMessage }
 					placement="bottom-start"
 				>
-					{ createInterpolateElement(
-						__(
-							'A WordPress.com account is required to create preview sites. <a>Create a free account</a>'
-						),
-						{
-							a: (
-								<Button
-									aria-description={ isOffline ? offlineMessage : '' }
-									aria-disabled={ isOffline }
-									className="!p-0 text-a8c-blueberry hover:opacity-80 h-auto"
-									onClick={ () => {
-										if ( isOffline ) {
-											return;
-										}
-										const baseURL = 'https://wordpress.com/log-in/link';
-										const authURL = encodeURIComponent(
-											`${ WP_AUTHORIZE_ENDPOINT }?response_type=token&client_id=${ CLIENT_ID }&redirect_uri=${ PROTOCOL_PREFIX }%3A%2F%2Fauth&scope=${ SCOPES }&from-calypso=1`
-										);
-										const finalURL = `${ baseURL }?redirect_to=${ authURL }&client_id=${ CLIENT_ID }`;
-										getIpcApi().openURL( finalURL );
-									} }
-								/>
-							),
-						}
-					) }
+					<span>
+						{ __( 'A WordPress.com account is required to create preview sites.' ) }{ ' ' }
+						<Button
+							aria-description={ isOffline ? offlineMessage : '' }
+							aria-disabled={ isOffline }
+							className="!p-0 text-a8c-blueberry hover:opacity-80 h-auto inline-flex items-center"
+							onClick={ () => {
+								if ( isOffline ) {
+									return;
+								}
+								const baseURL = 'https://wordpress.com/log-in/link';
+								const authURL = encodeURIComponent(
+									`${ WP_AUTHORIZE_ENDPOINT }?response_type=token&client_id=${ CLIENT_ID }&redirect_uri=${ PROTOCOL_PREFIX }%3A%2F%2Fauth&scope=${ SCOPES }&from-calypso=1`
+								);
+								const finalURL = `${ baseURL }?redirect_to=${ authURL }&client_id=${ CLIENT_ID }`;
+								getIpcApi().openURL( finalURL );
+							} }
+						>
+							{ __( 'Create a free account' ) }
+							<ArrowIcon />
+						</Button>
+					</span>
 				</Tooltip>
 			</div>
 		</EmptyGeneric>

--- a/src/components/content-tab-sync.tsx
+++ b/src/components/content-tab-sync.tsx
@@ -85,26 +85,28 @@ function NoAuthSyncTab() {
 					text={ offlineMessage }
 					placement="bottom-start"
 				>
-					{ __( 'New to WordPress.com?' ) }{ ' ' }
-					<Button
-						aria-description={ isOffline ? offlineMessage : '' }
-						aria-disabled={ isOffline }
-						className="!p-0 text-a8c-blueberry hover:opacity-80 h-auto inline-flex items-center"
-						onClick={ () => {
-							if ( isOffline ) {
-								return;
-							}
-							const baseURL = 'https://wordpress.com/log-in/link';
-							const authURL = encodeURIComponent(
-								`${ WP_AUTHORIZE_ENDPOINT }?response_type=token&client_id=${ CLIENT_ID }&redirect_uri=${ PROTOCOL_PREFIX }%3A%2F%2Fauth&scope=${ SCOPES }&from-calypso=1`
-							);
-							const finalURL = `${ baseURL }?redirect_to=${ authURL }&client_id=${ CLIENT_ID }`;
-							getIpcApi().openURL( finalURL );
-						} }
-					>
-						{ __( 'Create a free account' ) }
-						<ArrowIcon />
-					</Button>
+					<span>
+						{ __( 'New to WordPress.com?' ) }{ ' ' }
+						<Button
+							aria-description={ isOffline ? offlineMessage : '' }
+							aria-disabled={ isOffline }
+							className="!p-0 text-a8c-blueberry hover:opacity-80 h-auto inline-flex items-center"
+							onClick={ () => {
+								if ( isOffline ) {
+									return;
+								}
+								const baseURL = 'https://wordpress.com/log-in/link';
+								const authURL = encodeURIComponent(
+									`${ WP_AUTHORIZE_ENDPOINT }?response_type=token&client_id=${ CLIENT_ID }&redirect_uri=${ PROTOCOL_PREFIX }%3A%2F%2Fauth&scope=${ SCOPES }&from-calypso=1`
+								);
+								const finalURL = `${ baseURL }?redirect_to=${ authURL }&client_id=${ CLIENT_ID }`;
+								getIpcApi().openURL( finalURL );
+							} }
+						>
+							{ __( 'Create a free account' ) }
+							<ArrowIcon />
+						</Button>
+					</span>
 				</Tooltip>
 			</div>
 		</SiteSyncDescription>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- fixes https://github.com/Automattic/dotcom-forge/issues/10516
- related discussion: p1740153536076449/1740142244.756879-slack-C06DRMD6VPZ

## Proposed Changes

- fix text formatting on the `Sync` and `Previews` tab pages when the user is logged out:

| Before | After |
|--------|--------|
| ![Markup on 2025-02-21 at 17:01:07](https://github.com/user-attachments/assets/b87b8173-ccf4-4ae9-b57f-6953157cdbc6) | ![Markup on 2025-02-21 at 17:00:34](https://github.com/user-attachments/assets/7c801c9b-0bd9-4fa4-ae6f-d879b90494de) |
| ![Markup on 2025-02-21 at 17:01:20](https://github.com/user-attachments/assets/ddd333da-738b-44f5-acd1-8883c17b7f39) | ![Markup on 2025-02-21 at 17:00:46](https://github.com/user-attachments/assets/fbb59c98-d8e8-4c38-8c68-edccebeee4b4) | 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR branch and build the app with `npm start`.
2. Ensure you are not logged in to your WPCOM account in Studio.
3. Head over to the `Sync` and `Previews` tab when there are no synced sites connected / no preview sites created.
4. The formatting of the bottom text should be correct and the clicking the link should work correctly as well. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?