### PR TITLE
Run Lint and Unit Tests on mac agent

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -8,6 +8,8 @@ env:
 
 steps:
   - label: Lint
+    agents:
+      queue: mac
     key: lint
     command: |
       .buildkite/commands/install-node-dependencies.sh
@@ -19,6 +21,8 @@ steps:
           context: Lint
 
   - label: Unit Tests
+    agents:
+      queue: mac
     key: unit_tests
     command: |
       .buildkite/commands/install-node-dependencies.sh


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- N/A

## Proposed Changes

- For some reason, the default agent stopped working today. I'm trying to run Lint and Unit Tests on the mac agent to fix recent build issues. For Lint, it doesn't matter where it runs, and Unit Tests should run on mac as there is separate build step for Windows Unit Tests.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- N/A

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
