### PR TITLE
Improve site name suggestions to ensure both name and path uniqueness

### DIFF
--- a/src/components/add-site.tsx
+++ b/src/components/add-site.tsx
@@ -11,7 +11,6 @@ import { useAddSite } from 'src/hooks/use-add-site';
 import { useDragAndDropFile } from 'src/hooks/use-drag-and-drop-file';
 import { useImportExport } from 'src/hooks/use-import-export';
 import { useIpcListener } from 'src/hooks/use-ipc-listener';
-import { useSiteDetails } from 'src/hooks/use-site-details';
 import { generateSiteName } from 'src/lib/generate-site-name';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 
@@ -24,8 +23,6 @@ export default function AddSite( { className }: AddSiteProps ) {
 	const [ showModal, setShowModal ] = useState( false );
 	const [ nameSuggested, setNameSuggested ] = useState( false );
 	const [ fileError, setFileError ] = useState( '' );
-
-	const { data } = useSiteDetails();
 
 	const {
 		handleAddSiteClick,
@@ -40,14 +37,14 @@ export default function AddSite( { className }: AddSiteProps ) {
 		setDoesPathContainWordPress,
 		handleSiteNameChange,
 		handlePathSelectorClick,
-		usedSiteNames,
 		loadingSites,
 		fileForImport,
 		setFileForImport,
+		sites,
 	} = useAddSite();
 	const { importState } = useImportExport();
 
-	const isAnySiteProcessing = data.some(
+	const isAnySiteProcessing = sites.some(
 		( site ) => site.isAddingSite || importState[ site.id ]?.isNewSite
 	);
 
@@ -59,7 +56,7 @@ export default function AddSite( { className }: AddSiteProps ) {
 
 	const initializeForm = useCallback( async () => {
 		const { name, path, isWordPress } =
-			( await getIpcApi().generateProposedSitePath( generateSiteName( usedSiteNames ) ) ) || {};
+			( await getIpcApi().generateProposedSitePath( generateSiteName( sites ) ) ) || {};
 		setNameSuggested( true );
 		setSiteName( name );
 		setProposedSitePath( path );
@@ -67,7 +64,7 @@ export default function AddSite( { className }: AddSiteProps ) {
 		setError( '' );
 		setDoesPathContainWordPress( isWordPress );
 	}, [
-		usedSiteNames,
+		sites,
 		setSiteName,
 		setProposedSitePath,
 		setSitePath,

--- a/src/hooks/use-add-site.ts
+++ b/src/hooks/use-add-site.ts
@@ -16,8 +16,6 @@ export function useAddSite() {
 	const [ doesPathContainWordPress, setDoesPathContainWordPress ] = useState( false );
 	const [ fileForImport, setFileForImport ] = useState< File | null >( null );
 
-	const usedSiteNames = sites.map( ( site ) => site.name );
-
 	const siteWithPathAlreadyExists = useCallback(
 		( path: string ) => {
 			return sites.some( ( site ) => site.path.toLowerCase() === path.toLowerCase() );
@@ -152,7 +150,7 @@ export function useAddSite() {
 			setSitePath,
 			setError,
 			setDoesPathContainWordPress,
-			usedSiteNames,
+			sites,
 			loadingSites,
 			fileForImport,
 			setFileForImport,
@@ -168,7 +166,7 @@ export function useAddSite() {
 		siteName,
 		sitePath,
 		proposedSitePath,
-		usedSiteNames,
+		sites,
 		loadingSites,
 		fileForImport,
 	] );

--- a/src/lib/generate-site-name.ts
+++ b/src/lib/generate-site-name.ts
@@ -1,6 +1,6 @@
 import { __ } from '@wordpress/i18n';
 
-export function generateSiteName( usedSiteNames: string[] ): string {
+export function generateSiteName( usedSites: SiteDetails[] ): string {
 	const siteNames = [
 		__( 'My Bold Website' ),
 		__( 'My Bright Website' ),
@@ -26,20 +26,41 @@ export function generateSiteName( usedSiteNames: string[] ): string {
 
 	const defaultName = __( 'My WordPress Website' );
 
-	if ( ! usedSiteNames.includes( defaultName ) ) {
+	// Helper function to check if a name's path would be unique
+	const isPathUnique = ( name: string ): boolean => {
+		const sanitizedPath = sanitizeFolderName( name );
+		return ! usedSites.some( ( site ) => site.path.toLowerCase().endsWith( '/' + sanitizedPath ) );
+	};
+
+	// Helper function to check if a name is unique
+	const isNameUnique = ( name: string ): boolean => {
+		return ! usedSites.some( ( site ) => site.name === name );
+	};
+
+	// Try default name first
+	if ( isNameUnique( defaultName ) && isPathUnique( defaultName ) ) {
 		return defaultName;
 	}
 
-	const availableNames = siteNames.filter( ( name ) => ! usedSiteNames.includes( name ) );
+	// Try names from the predefined list
+	const availableNames = siteNames.filter(
+		( name ) => isNameUnique( name ) && isPathUnique( name )
+	);
+
 	if ( availableNames.length > 0 ) {
 		return availableNames[ Math.floor( Math.random() * availableNames.length ) ];
 	}
 
+	// If all else fails, append numbers to the default name until we find a unique combination
 	let siteNumber = 2;
-	while ( usedSiteNames.includes( `${ defaultName } ${ siteNumber }` ) ) {
+	let candidateName = `${ defaultName } ${ siteNumber }`;
+
+	while ( ! isNameUnique( candidateName ) || ! isPathUnique( candidateName ) ) {
 		siteNumber++;
+		candidateName = `${ defaultName } ${ siteNumber }`;
 	}
-	return `${ defaultName } ${ siteNumber }`;
+
+	return candidateName;
 }
 
 export const sanitizeFolderName = ( filename: string ) => {

--- a/src/lib/generate-site-name.ts
+++ b/src/lib/generate-site-name.ts
@@ -26,23 +26,19 @@ export function generateSiteName( usedSites: SiteDetails[] ): string {
 
 	const defaultName = __( 'My WordPress Website' );
 
-	// Helper function to check if a name's path would be unique
 	const isPathUnique = ( name: string ): boolean => {
 		const sanitizedPath = sanitizeFolderName( name );
 		return ! usedSites.some( ( site ) => site.path.toLowerCase().endsWith( '/' + sanitizedPath ) );
 	};
 
-	// Helper function to check if a name is unique
 	const isNameUnique = ( name: string ): boolean => {
 		return ! usedSites.some( ( site ) => site.name === name );
 	};
 
-	// Try default name first
 	if ( isNameUnique( defaultName ) && isPathUnique( defaultName ) ) {
 		return defaultName;
 	}
 
-	// Try names from the predefined list
 	const availableNames = siteNames.filter(
 		( name ) => isNameUnique( name ) && isPathUnique( name )
 	);
@@ -51,7 +47,6 @@ export function generateSiteName( usedSites: SiteDetails[] ): string {
 		return availableNames[ Math.floor( Math.random() * availableNames.length ) ];
 	}
 
-	// If all else fails, append numbers to the default name until we find a unique combination
 	let siteNumber = 2;
 	let candidateName = `${ defaultName } ${ siteNumber }`;
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/dotcom-forge/issues/10503

## Proposed Changes

- Modified site name generation to ensure both name and path uniqueness
- Simplified code by using sites directly from useAddSite
- Improved type safety with proper SiteDetails type usage

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Happy path
- Create a new site using the default name
- Create another site.
Expected results: Site name is suggested without conflicting name or path

2. Previous error case
- Create a new site using the default name
- Rename the site in "Settings"
- Create a new site
Expected results: Site name is suggested without conflicting name or path

3. Suggested name limit
- Create a new site using the default name
- Create more sites until all suggestions are used (you can comment some names [here](https://github.com/Automattic/studio/blob/trunk/src/lib/generate-site-name.ts#L4) to speed up the process)
- Create another site.
Expected results: Site name is suggested, using the default name plus an incremental value, without conflicting name or path

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
