### PR TITLE
Make sure the width of the main container still the same when collapsed

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,6 @@
 export const DEFAULT_WIDTH = 900;
 export const MAIN_MIN_HEIGHT = 600;
-export const SIDEBAR_WIDTH = 268;
+export const SIDEBAR_WIDTH = 208;
 export const MAIN_MIN_WIDTH = DEFAULT_WIDTH - SIDEBAR_WIDTH + 20;
 export const SCREENSHOT_WIDTH = 1040;
 export const SCREENSHOT_HEIGHT = 1248;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/dotcom-forge/issues/10461

## Proposed Changes

- Update SIDEBAR_WIDTH constant from 268px to 208px in window size calculations
   - 208px is more in line with the tailwind class we use for the sidebar `basis-52`
   - This constant is used specifically for `toggleMinWindowWidth`
   - This change does not affect the actual sidebar visual width, only the window size constraints

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run Studio locally
- Check size of the main container
- Toggle the sidebar
- Confirm the size stays the same

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
