### PR TITLE
Move CI lint step back to default (Linux) queue

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -9,7 +9,7 @@ env:
 steps:
   - label: Lint
     agents:
-      queue: mac
+      queue: default
     key: lint
     command: |
       .buildkite/commands/install-node-dependencies.sh

--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -6,7 +6,7 @@
 # The ~> modifier is not currently used, but we check for it just in case
 XCODE_VERSION=$(sed -E -n 's/^(~> )?(.*)/xcode-\2/p' .xcode-version)
 CI_TOOLKIT_VERSION='3.10.0'
-NVM_PLUGIN_VERSION='0.3.0'
+NVM_PLUGIN_VERSION='0.4.0'
 
 export IMAGE_ID="$XCODE_VERSION"
 export CI_TOOLKIT_PLUGIN="automattic/a8c-ci-toolkit#$CI_TOOLKIT_VERSION"

--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -5,7 +5,7 @@
 
 # The ~> modifier is not currently used, but we check for it just in case
 XCODE_VERSION=$(sed -E -n 's/^(~> )?(.*)/xcode-\2/p' .xcode-version)
-CI_TOOLKIT_VERSION='3.10.0'
+CI_TOOLKIT_VERSION='mokagio/fail-early-on-aws-missing-credentials'
 NVM_PLUGIN_VERSION='0.4.0'
 
 export IMAGE_ID="$XCODE_VERSION"


### PR DESCRIPTION

---

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

See internal discussion at p1740390251662719-slack-CC7L49W13

## Proposed Changes

Move the lint CI step back from the `mac` queue to the `default` queue. 

It was switched to the `mac` queue in https://github.com/Automattic/studio/pull/971 because of an issues with connecting to AWS in the `default` queue (Linux agents).

The AWS issue is yet to be addressed, but we have [a CI toolkit PR](https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/pull/162) that introduces a brute workaround: skip fetching the cache from AWS if you can't authenticate with AWS.

This way, at least we won't spam the `mac` queue, which is more expensive and should be used to run steps that legitimately need macOS.

The main reason for this is to have a working example of the changes in the plugin, https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/pull/162, I am okay with closing this if you'd rather have faster CI and stay on the `mac` queue. (Although I'd say that given we have other steps that run in considerably slower than the lint one, even if lint is not as fast as possible the time to complete feedback won't be affected, so... 🤷‍♂️ ⚖️ )

_We ought to measure it, but don't I think the $ difference would be that much._

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Refer to [green CI](https://buildkite.com/automattic/studio/builds/4496#01953b27-d490-412c-ae79-32d9cc2362ea):

![image](https://github.com/user-attachments/assets/0fa35269-0e04-4a36-905d-6311a4d28d29)

For reference, the lint step here ran ~45 seconds slower than [this random build](https://buildkite.com/automattic/studio/builds/4447#0195283c-c13f-4614-8383-c10f541f4604) from a few days ago before the AWS issue.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?