### PR TITLE
Studio: Add failed state when the preview site fails to update

### DIFF
--- a/src/components/content-tab-previews.tsx
+++ b/src/components/content-tab-previews.tsx
@@ -170,8 +170,8 @@ export function ContentTabPreviews( { selectedSite }: ContentTabPreviewsProps ) 
 		( snapshot ) => snapshot.localSiteId === selectedSite.id && snapshot.userId === user?.id
 	);
 	const isSnapshotLoading = snapshotsOnSite.some( ( snapshot ) => snapshot.isLoading );
-	const isAnyPreviewUpdating = snapshots.some( ( snapshot ) =>
-		isDemoSiteUpdating( snapshot.atomicSiteId )
+	const isAnyPreviewUpdating = snapshots.some(
+		( snapshot ) => isDemoSiteUpdating( snapshot.atomicSiteId ).isUpdating
 	);
 	const isOffline = useOffline();
 

--- a/src/components/content-tab-previews.tsx
+++ b/src/components/content-tab-previews.tsx
@@ -170,8 +170,8 @@ export function ContentTabPreviews( { selectedSite }: ContentTabPreviewsProps ) 
 		( snapshot ) => snapshot.localSiteId === selectedSite.id && snapshot.userId === user?.id
 	);
 	const isSnapshotLoading = snapshotsOnSite.some( ( snapshot ) => snapshot.isLoading );
-	const isAnyPreviewUpdating = snapshots.some(
-		( snapshot ) => isDemoSiteUpdating( snapshot.atomicSiteId ).isUpdating
+	const isAnyPreviewUpdating = snapshots.some( ( snapshot ) =>
+		isDemoSiteUpdating( snapshot.atomicSiteId )
 	);
 	const isOffline = useOffline();
 

--- a/src/hooks/use-update-demo-site.tsx
+++ b/src/hooks/use-update-demo-site.tsx
@@ -37,7 +37,6 @@ export const DemoSiteUpdateProvider: React.FC< DemoSiteUpdateProviderProps > = (
 			setUpdatingSites( ( prev ) => new Set( prev ).add( snapshot.atomicSiteId ) );
 
 			let archivePath = '';
-
 			try {
 				const { archivePath: tempArchivePath, archiveSizeInBytes } = await getIpcApi().archiveSite(
 					localSite.id,

--- a/src/hooks/use-update-demo-site.tsx
+++ b/src/hooks/use-update-demo-site.tsx
@@ -37,6 +37,12 @@ export const DemoSiteUpdateProvider: React.FC< DemoSiteUpdateProviderProps > = (
 				return;
 			}
 			setUpdatingSites( ( prev ) => new Set( prev ).add( snapshot.atomicSiteId ) );
+			// Clear any previous error state when starting a new update
+			setErrorSites( ( prev ) => {
+				const next = new Set( prev );
+				next.delete( snapshot.atomicSiteId );
+				return next;
+			} );
 
 			let archivePath = '';
 			try {

--- a/src/hooks/use-update-demo-site.tsx
+++ b/src/hooks/use-update-demo-site.tsx
@@ -2,7 +2,11 @@ import * as Sentry from '@sentry/electron/renderer';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import { useCallback, useState, createContext, useContext, useMemo, ReactNode } from 'react';
-import { DEMO_SITE_SIZE_LIMIT_BYTES, DEMO_SITE_SIZE_LIMIT_GB } from 'src/constants';
+import {
+	DEMO_SITE_SIZE_LIMIT_BYTES,
+	DEMO_SITE_SIZE_LIMIT_GB,
+	UPDATED_MESSAGE_DURATION_MS,
+} from 'src/constants';
 import { useAuth } from 'src/hooks/use-auth';
 import { useSnapshots } from 'src/hooks/use-snapshots';
 import { getIpcApi } from 'src/lib/get-ipc-api';
@@ -37,12 +41,6 @@ export const DemoSiteUpdateProvider: React.FC< DemoSiteUpdateProviderProps > = (
 				return;
 			}
 			setUpdatingSites( ( prev ) => new Set( prev ).add( snapshot.atomicSiteId ) );
-			// Clear any previous error state when starting a new update
-			setErrorSites( ( prev ) => {
-				const next = new Set( prev );
-				next.delete( snapshot.atomicSiteId );
-				return next;
-			} );
 
 			let archivePath = '';
 			try {
@@ -106,6 +104,13 @@ export const DemoSiteUpdateProvider: React.FC< DemoSiteUpdateProviderProps > = (
 				return response;
 			} catch ( error ) {
 				setErrorSites( ( prev ) => new Set( prev ).add( snapshot.atomicSiteId ) );
+				setTimeout( () => {
+					setErrorSites( ( prev ) => {
+						const next = new Set( prev );
+						next.delete( snapshot.atomicSiteId );
+						return next;
+					} );
+				}, UPDATED_MESSAGE_DURATION_MS );
 				getIpcApi().showErrorMessageBox( {
 					title: __( 'Update failed' ),
 					message: sprintf(

--- a/src/hooks/use-update-demo-site.tsx
+++ b/src/hooks/use-update-demo-site.tsx
@@ -83,9 +83,6 @@ export const DemoSiteUpdateProvider: React.FC< DemoSiteUpdateProviderProps > = (
 					formData.push( [ 'wordpress_version', wordpressVersion ] );
 				}
 
-				// Temporary: Simulate a failure for testing
-				throw new Error( 'Artificial error for testing' );
-
 				const response = await client.req.post( {
 					path: '/jurassic-ninja/update-site-from-zip',
 					apiNamespace: 'wpcom/v2',

--- a/src/hooks/use-update-demo-site.tsx
+++ b/src/hooks/use-update-demo-site.tsx
@@ -9,12 +9,12 @@ import { getIpcApi } from 'src/lib/get-ipc-api';
 
 interface DemoSiteUpdateContextType {
 	updateDemoSite: ( snapshot: Snapshot, localSite: SiteDetails ) => Promise< void >;
-	isDemoSiteUpdating: ( atomicSiteId: number ) => boolean;
+	isDemoSiteUpdating: ( atomicSiteId: number ) => { isUpdating: boolean; hasError: boolean };
 }
 
 const DemoSiteUpdateContext = createContext< DemoSiteUpdateContextType >( {
 	updateDemoSite: async () => undefined,
-	isDemoSiteUpdating: () => false,
+	isDemoSiteUpdating: () => ( { isUpdating: false, hasError: false } ),
 } );
 
 interface DemoSiteUpdateProviderProps {
@@ -25,6 +25,7 @@ export const DemoSiteUpdateProvider: React.FC< DemoSiteUpdateProviderProps > = (
 	const { client } = useAuth();
 	const { __ } = useI18n();
 	const [ updatingSites, setUpdatingSites ] = useState< Set< number > >( new Set() );
+	const [ errorSites, setErrorSites ] = useState< Set< number > >( new Set() );
 	const { updateSnapshot } = useSnapshots();
 
 	const updateDemoSite = useCallback(
@@ -36,6 +37,7 @@ export const DemoSiteUpdateProvider: React.FC< DemoSiteUpdateProviderProps > = (
 			setUpdatingSites( ( prev ) => new Set( prev ).add( snapshot.atomicSiteId ) );
 
 			let archivePath = '';
+
 			try {
 				const { archivePath: tempArchivePath, archiveSizeInBytes } = await getIpcApi().archiveSite(
 					localSite.id,
@@ -81,6 +83,9 @@ export const DemoSiteUpdateProvider: React.FC< DemoSiteUpdateProviderProps > = (
 					formData.push( [ 'wordpress_version', wordpressVersion ] );
 				}
 
+				// Temporary: Simulate a failure for testing
+				throw new Error( 'Artificial error for testing' );
+
 				const response = await client.req.post( {
 					path: '/jurassic-ninja/update-site-from-zip',
 					apiNamespace: 'wpcom/v2',
@@ -96,6 +101,7 @@ export const DemoSiteUpdateProvider: React.FC< DemoSiteUpdateProviderProps > = (
 				} );
 				return response;
 			} catch ( error ) {
+				setErrorSites( ( prev ) => new Set( prev ).add( snapshot.atomicSiteId ) );
 				getIpcApi().showErrorMessageBox( {
 					title: __( 'Update failed' ),
 					message: sprintf(
@@ -120,10 +126,11 @@ export const DemoSiteUpdateProvider: React.FC< DemoSiteUpdateProviderProps > = (
 	);
 
 	const isDemoSiteUpdating = useCallback(
-		( atomicSiteId: number ) => {
-			return updatingSites.has( atomicSiteId );
-		},
-		[ updatingSites ]
+		( atomicSiteId: number ) => ( {
+			isUpdating: updatingSites.has( atomicSiteId ),
+			hasError: errorSites.has( atomicSiteId ),
+		} ),
+		[ updatingSites, errorSites ]
 	);
 
 	const contextValue = useMemo(

--- a/src/hooks/use-update-demo-site.tsx
+++ b/src/hooks/use-update-demo-site.tsx
@@ -9,12 +9,14 @@ import { getIpcApi } from 'src/lib/get-ipc-api';
 
 interface DemoSiteUpdateContextType {
 	updateDemoSite: ( snapshot: Snapshot, localSite: SiteDetails ) => Promise< void >;
-	isDemoSiteUpdating: ( atomicSiteId: number ) => { isUpdating: boolean; hasError: boolean };
+	isDemoSiteUpdating: ( atomicSiteId: number ) => boolean;
+	hasDemoSiteError: ( atomicSiteId: number ) => boolean;
 }
 
 const DemoSiteUpdateContext = createContext< DemoSiteUpdateContextType >( {
 	updateDemoSite: async () => undefined,
-	isDemoSiteUpdating: () => ( { isUpdating: false, hasError: false } ),
+	isDemoSiteUpdating: () => false,
+	hasDemoSiteError: () => false,
 } );
 
 interface DemoSiteUpdateProviderProps {
@@ -122,19 +124,22 @@ export const DemoSiteUpdateProvider: React.FC< DemoSiteUpdateProviderProps > = (
 	);
 
 	const isDemoSiteUpdating = useCallback(
-		( atomicSiteId: number ) => ( {
-			isUpdating: updatingSites.has( atomicSiteId ),
-			hasError: errorSites.has( atomicSiteId ),
-		} ),
-		[ updatingSites, errorSites ]
+		( atomicSiteId: number ) => updatingSites.has( atomicSiteId ),
+		[ updatingSites ]
+	);
+
+	const hasDemoSiteError = useCallback(
+		( atomicSiteId: number ) => errorSites.has( atomicSiteId ),
+		[ errorSites ]
 	);
 
 	const contextValue = useMemo(
 		() => ( {
 			updateDemoSite,
 			isDemoSiteUpdating,
+			hasDemoSiteError,
 		} ),
-		[ updateDemoSite, isDemoSiteUpdating ]
+		[ updateDemoSite, isDemoSiteUpdating, hasDemoSiteError ]
 	);
 
 	return (

--- a/src/hooks/use-update-demo-site.tsx
+++ b/src/hooks/use-update-demo-site.tsx
@@ -2,11 +2,7 @@ import * as Sentry from '@sentry/electron/renderer';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import { useCallback, useState, createContext, useContext, useMemo, ReactNode } from 'react';
-import {
-	DEMO_SITE_SIZE_LIMIT_BYTES,
-	DEMO_SITE_SIZE_LIMIT_GB,
-	UPDATED_MESSAGE_DURATION_MS,
-} from 'src/constants';
+import { DEMO_SITE_SIZE_LIMIT_BYTES, DEMO_SITE_SIZE_LIMIT_GB } from 'src/constants';
 import { useAuth } from 'src/hooks/use-auth';
 import { useSnapshots } from 'src/hooks/use-snapshots';
 import { getIpcApi } from 'src/lib/get-ipc-api';
@@ -41,6 +37,14 @@ export const DemoSiteUpdateProvider: React.FC< DemoSiteUpdateProviderProps > = (
 				return;
 			}
 			setUpdatingSites( ( prev ) => new Set( prev ).add( snapshot.atomicSiteId ) );
+			// Clear error when user retries
+			if ( errorSites.has( snapshot.atomicSiteId ) ) {
+				setErrorSites( ( prev ) => {
+					const next = new Set( prev );
+					next.delete( snapshot.atomicSiteId );
+					return next;
+				} );
+			}
 
 			let archivePath = '';
 			try {
@@ -104,13 +108,6 @@ export const DemoSiteUpdateProvider: React.FC< DemoSiteUpdateProviderProps > = (
 				return response;
 			} catch ( error ) {
 				setErrorSites( ( prev ) => new Set( prev ).add( snapshot.atomicSiteId ) );
-				setTimeout( () => {
-					setErrorSites( ( prev ) => {
-						const next = new Set( prev );
-						next.delete( snapshot.atomicSiteId );
-						return next;
-					} );
-				}, UPDATED_MESSAGE_DURATION_MS );
 				getIpcApi().showErrorMessageBox( {
 					title: __( 'Update failed' ),
 					message: sprintf(
@@ -131,7 +128,7 @@ export const DemoSiteUpdateProvider: React.FC< DemoSiteUpdateProviderProps > = (
 				}
 			}
 		},
-		[ __, client, updateSnapshot ]
+		[ __, client, errorSites, updateSnapshot ]
 	);
 
 	const isDemoSiteUpdating = useCallback(

--- a/src/modules/preview-site/components/preview-site-row.tsx
+++ b/src/modules/preview-site/components/preview-site-row.tsx
@@ -35,15 +35,16 @@ export function PreviewSiteRow( {
 	const { url, date, isDeleting } = snapshot;
 	const { countDown, expireDateString, isExpired } = useExpirationDate( date );
 	const { fetchSnapshotUsage, removeSnapshot } = useSnapshots();
-	const { isDemoSiteUpdating } = useUpdateDemoSite();
-	const { isUpdating, hasError } = isDemoSiteUpdating( snapshot.atomicSiteId );
+	const { isDemoSiteUpdating, hasDemoSiteError } = useUpdateDemoSite();
+	const isPreviewSiteUpdating = isDemoSiteUpdating( snapshot.atomicSiteId );
+	const hasError = hasDemoSiteError( snapshot.atomicSiteId );
 	const { formatRelativeTime } = useFormatLocalizedTimestamps();
 	const [ showUpdatedMessage, setShowUpdatedMessage ] = useState( false );
 	const [ showFailedMessage, setShowFailedMessage ] = useState( false );
 	const wasUpdating = useRef( false );
 
 	useEffect( () => {
-		if ( isUpdating ) {
+		if ( isPreviewSiteUpdating ) {
 			wasUpdating.current = true;
 			setShowUpdatedMessage( false );
 			setShowFailedMessage( false );
@@ -67,7 +68,7 @@ export function PreviewSiteRow( {
 		}, UPDATED_MESSAGE_DURATION_MS );
 
 		return () => clearTimeout( timeoutId );
-	}, [ hasError, isUpdating ] );
+	}, [ hasError, isPreviewSiteUpdating ] );
 
 	const getLastUpdateTimeText = () => {
 		if ( ! date ) {
@@ -140,7 +141,7 @@ export function PreviewSiteRow( {
 				</div>
 				<div className="flex ltr:ml-auto rtl:mr-auto">
 					<div className="w-[150px] text-a8c-gray-700 flex items-center pl-4">
-						{ isUpdating ? (
+						{ isPreviewSiteUpdating ? (
 							<div className="flex items-center text-gray-900">
 								<Spinner className="!mt-0 !mx-2" />
 								{ __( 'Updating' ) }

--- a/src/modules/preview-site/components/preview-site-row.tsx
+++ b/src/modules/preview-site/components/preview-site-row.tsx
@@ -40,14 +40,12 @@ export function PreviewSiteRow( {
 	const hasError = hasDemoSiteError( snapshot.atomicSiteId );
 	const { formatRelativeTime } = useFormatLocalizedTimestamps();
 	const [ showUpdatedMessage, setShowUpdatedMessage ] = useState( false );
-	const [ showFailedMessage, setShowFailedMessage ] = useState( false );
 	const wasUpdating = useRef( false );
 
 	useEffect( () => {
 		if ( isPreviewSiteUpdating ) {
 			wasUpdating.current = true;
 			setShowUpdatedMessage( false );
-			setShowFailedMessage( false );
 			return;
 		}
 
@@ -56,15 +54,12 @@ export function PreviewSiteRow( {
 		}
 		wasUpdating.current = false;
 
-		if ( hasError ) {
-			setShowFailedMessage( true );
-		} else {
+		if ( ! hasError ) {
 			setShowUpdatedMessage( true );
 		}
 
 		const timeoutId = setTimeout( () => {
 			setShowUpdatedMessage( false );
-			setShowFailedMessage( false );
 		}, UPDATED_MESSAGE_DURATION_MS );
 
 		return () => clearTimeout( timeoutId );
@@ -84,7 +79,7 @@ export function PreviewSiteRow( {
 			);
 		}
 
-		if ( showFailedMessage ) {
+		if ( hasError ) {
 			return (
 				<div className="flex items-center">
 					<Icon icon={ warning } className="!mt-0 mr-1 fill-a8c-red-50" />

--- a/src/modules/preview-site/components/preview-site-row.tsx
+++ b/src/modules/preview-site/components/preview-site-row.tsx
@@ -1,6 +1,6 @@
 import { Spinner } from '@wordpress/components';
 import { sprintf } from '@wordpress/i18n';
-import { Icon, published } from '@wordpress/icons';
+import { Icon, published, warning } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { useEffect, useState, useRef } from 'react';
 import { ArrowIcon } from 'src/components/arrow-icon';
@@ -36,15 +36,17 @@ export function PreviewSiteRow( {
 	const { countDown, expireDateString, isExpired } = useExpirationDate( date );
 	const { fetchSnapshotUsage, removeSnapshot } = useSnapshots();
 	const { isDemoSiteUpdating } = useUpdateDemoSite();
-	const isPreviewSiteUpdating = isDemoSiteUpdating( snapshot.atomicSiteId );
+	const { isUpdating, hasError } = isDemoSiteUpdating( snapshot.atomicSiteId );
 	const { formatRelativeTime } = useFormatLocalizedTimestamps();
 	const [ showUpdatedMessage, setShowUpdatedMessage ] = useState( false );
+	const [ showFailedMessage, setShowFailedMessage ] = useState( false );
 	const wasUpdating = useRef( false );
 
 	useEffect( () => {
-		if ( isPreviewSiteUpdating ) {
+		if ( isUpdating ) {
 			wasUpdating.current = true;
 			setShowUpdatedMessage( false );
+			setShowFailedMessage( false );
 			return;
 		}
 
@@ -52,14 +54,20 @@ export function PreviewSiteRow( {
 			return;
 		}
 		wasUpdating.current = false;
-		setShowUpdatedMessage( true );
+
+		if ( hasError ) {
+			setShowFailedMessage( true );
+		} else {
+			setShowUpdatedMessage( true );
+		}
 
 		const timeoutId = setTimeout( () => {
 			setShowUpdatedMessage( false );
+			setShowFailedMessage( false );
 		}, UPDATED_MESSAGE_DURATION_MS );
 
 		return () => clearTimeout( timeoutId );
-	}, [ isPreviewSiteUpdating ] );
+	}, [ hasError, isUpdating ] );
 
 	const getLastUpdateTimeText = () => {
 		if ( ! date ) {
@@ -71,6 +79,15 @@ export function PreviewSiteRow( {
 				<div className="flex items-center">
 					<Icon icon={ published } className="!mt-0 mr-1 fill-a8c-green-50" />
 					<span className="text-a8c-green-50">{ __( 'Updated' ) }</span>
+				</div>
+			);
+		}
+
+		if ( showFailedMessage ) {
+			return (
+				<div className="flex items-center">
+					<Icon icon={ warning } className="!mt-0 mr-1 fill-a8c-red-50" />
+					<span className="text-a8c-red-50">{ __( 'Failed' ) }</span>
 				</div>
 			);
 		}
@@ -123,7 +140,7 @@ export function PreviewSiteRow( {
 				</div>
 				<div className="flex ltr:ml-auto rtl:mr-auto">
 					<div className="w-[150px] text-a8c-gray-700 flex items-center pl-4">
-						{ isPreviewSiteUpdating ? (
+						{ isUpdating ? (
 							<div className="flex items-center text-gray-900">
 								<Spinner className="!mt-0 !mx-2" />
 								{ __( 'Updating' ) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

Closes https://github.com/Automattic/dotcom-forge/issues/10384

## Proposed Changes

This PR adds a failed state for when an update to a preview site fails due to an error. Currently it displays the `Updated` state / wording even when update fails due to an error:

<img width="1095" alt="Screenshot 2025-02-25 at 1 28 28 PM" src="https://github.com/user-attachments/assets/cb6e66b0-a904-4343-8b86-6e272c10239e" />

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
* Make sure you have at least one preview site created
* Apply the following diff to simulate an error during update process:

```diff --git a/src/hooks/use-update-demo-site.tsx b/src/hooks/use-update-demo-site.tsx
index f55a9d1a..11d5f61e 100644
--- a/src/hooks/use-update-demo-site.tsx
+++ b/src/hooks/use-update-demo-site.tsx
@@ -83,6 +83,9 @@ export const DemoSiteUpdateProvider: React.FC< DemoSiteUpdateProviderProps > = (
                                        formData.push( [ 'wordpress_version', wordpressVersion ] );
                                }
 
+                               // Temporary: Simulate a failure for testing
+                               throw new Error( 'Artificial error for testing' );
+
                                const response = await client.req.post( {
                                        path: '/jurassic-ninja/update-site-from-zip',
                                        apiNamespace: 'wpcom/v2',
```
* Click on the `Update` button by a preview site in the preview actions menu
* Observe that when the error is triggered, you can see the failed state highlighted on the screenshot above
* Observe that the failed state gets removed after either 1 minute or when you switch tabs and come back
* Observe that the update time gets set back to what it was before the update was triggered 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
