### PR TITLE
Assistant: Ensure the last message does not animate on tab switch

### DIFF
--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -120,7 +120,6 @@ const AuthenticatedView = memo(
 		submitPrompt,
 		wrapperRef,
 	}: AuthenticatedViewProps ) => {
-		const isInitialRenderRef = useRef( true );
 		const lastMessageRef = useRef< HTMLDivElement >( null );
 		const [ showThinking, setShowThinking ] = useState( isAssistantThinking );
 		const lastMessage = useMemo(
@@ -134,6 +133,7 @@ const AuthenticatedView = memo(
 			messages[ messages.length - 1 ]?.role === 'assistant' ? messages.slice( 0, -1 ) : messages;
 		const showLastMessage = lastMessage?.role === 'assistant';
 		const previousMessagesLength = useRef( messages.length );
+		const isInitialRenderRef = useRef( true );
 
 		// This effect may run twice when the component is mounted, which makes the viewport scroll
 		// to the wrong position. This happens because the app runs in React strict mode, meaning

--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -123,7 +123,6 @@ const AuthenticatedView = memo(
 		const isInitialRenderRef = useRef( true );
 		const lastMessageRef = useRef< HTMLDivElement >( null );
 		const [ showThinking, setShowThinking ] = useState( isAssistantThinking );
-
 		const lastMessage = useMemo(
 			() =>
 				showThinking

--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -123,7 +123,6 @@ const AuthenticatedView = memo(
 		const isInitialRenderRef = useRef( true );
 		const lastMessageRef = useRef< HTMLDivElement >( null );
 		const [ showThinking, setShowThinking ] = useState( isAssistantThinking );
-		const [ shouldAnimate, setShouldAnimate ] = useState( ! isInitialRenderRef.current );
 
 		const lastMessage = useMemo(
 			() =>
@@ -144,10 +143,6 @@ const AuthenticatedView = memo(
 		useEffect( () => {
 			if ( ! messages.length ) {
 				return;
-			}
-
-			if ( ! isInitialRenderRef.current ) {
-				setShouldAnimate( true );
 			}
 
 			let timer: NodeJS.Timeout;
@@ -209,12 +204,12 @@ const AuthenticatedView = memo(
 		const RenderLastMessage = useCallback(
 			( { message, children }: { message: MessageType; children: React.ReactNode } ) => {
 				const thinkingAnimation = {
-					initial: shouldAnimate ? { opacity: 0, y: 20 } : { opacity: 1, y: 0 },
+					initial: { opacity: 1, y: 20 },
 					animate: { opacity: 1, y: 0 },
 					exit: { opacity: 0, y: -20 },
 				};
 				const messageAnimation = {
-					initial: shouldAnimate ? { opacity: 0, y: 20 } : { opacity: 1, y: 0 },
+					initial: { opacity: 0, y: 20 },
 					animate: { opacity: 1, y: 0 },
 				};
 
@@ -230,12 +225,11 @@ const AuthenticatedView = memo(
 							{ showThinking ? (
 								<motion.div
 									key="thinking"
-									initial="initial"
+									initial={ isInitialRenderRef.current ? 'animate' : 'initial' }
 									animate="animate"
 									exit="exit"
 									variants={ thinkingAnimation }
 									transition={ { duration: 0.3 } }
-									onAnimationComplete={ () => setShouldAnimate( false ) }
 								>
 									<MessageThinking />
 								</motion.div>
@@ -244,9 +238,8 @@ const AuthenticatedView = memo(
 									key="content"
 									variants={ messageAnimation }
 									transition={ { duration: 0.3 } }
-									initial="initial"
+									initial={ isInitialRenderRef.current ? 'animate' : 'initial' }
 									animate="animate"
-									onAnimationComplete={ () => setShouldAnimate( false ) }
 								>
 									<MarkDownWithCode
 										message={ message }
@@ -261,7 +254,7 @@ const AuthenticatedView = memo(
 					</ChatMessage>
 				);
 			},
-			[ showThinking, siteId, instanceId, shouldAnimate, setShouldAnimate ]
+			[ showThinking, siteId, instanceId ]
 		);
 
 		if ( messages.length === 0 ) {

--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -132,7 +132,6 @@ const AuthenticatedView = memo(
 					: messages[ messages.length - 1 ],
 			[ messages, showThinking ]
 		);
-
 		const messagesToRender =
 			messages[ messages.length - 1 ]?.role === 'assistant' ? messages.slice( 0, -1 ) : messages;
 		const showLastMessage = lastMessage?.role === 'assistant';

--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -203,7 +203,7 @@ const AuthenticatedView = memo(
 		const RenderLastMessage = useCallback(
 			( { message, children }: { message: MessageType; children: React.ReactNode } ) => {
 				const thinkingAnimation = {
-					initial: { opacity: 1, y: 20 },
+					initial: { opacity: 0, y: 20 },
 					animate: { opacity: 1, y: 0 },
 					exit: { opacity: 0, y: -20 },
 				};

--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -209,7 +209,7 @@ const AuthenticatedView = memo(
 		const RenderLastMessage = useCallback(
 			( { message, children }: { message: MessageType; children: React.ReactNode } ) => {
 				const thinkingAnimation = {
-					initial: { opacity: 0, y: 20 },
+					initial: shouldAnimate ? { opacity: 0, y: 20 } : { opacity: 1, y: 0 },
 					animate: { opacity: 1, y: 0 },
 					exit: { opacity: 0, y: -20 },
 				};
@@ -235,6 +235,7 @@ const AuthenticatedView = memo(
 									exit="exit"
 									variants={ thinkingAnimation }
 									transition={ { duration: 0.3 } }
+									onAnimationComplete={ () => setShouldAnimate( false ) }
 								>
 									<MessageThinking />
 								</motion.div>

--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -122,6 +122,9 @@ const AuthenticatedView = memo(
 	}: AuthenticatedViewProps ) => {
 		const lastMessageRef = useRef< HTMLDivElement >( null );
 		const [ showThinking, setShowThinking ] = useState( isAssistantThinking );
+		const [ lastSeenMessageId, setLastSeenMessageId ] = useState< number | null >( null );
+		const [ shouldAnimate, setShouldAnimate ] = useState( false );
+
 		const lastMessage = useMemo(
 			() =>
 				showThinking
@@ -129,6 +132,14 @@ const AuthenticatedView = memo(
 					: messages[ messages.length - 1 ],
 			[ messages, showThinking ]
 		);
+
+		useEffect( () => {
+			if ( lastMessage?.id !== lastSeenMessageId ) {
+				setLastSeenMessageId( lastMessage?.id ?? null );
+				setShouldAnimate( true );
+			}
+		}, [ lastMessage, lastSeenMessageId ] );
+
 		const messagesToRender =
 			messages[ messages.length - 1 ]?.role === 'assistant' ? messages.slice( 0, -1 ) : messages;
 		const showLastMessage = lastMessage?.role === 'assistant';
@@ -208,7 +219,7 @@ const AuthenticatedView = memo(
 					exit: { opacity: 0, y: -20 },
 				};
 				const messageAnimation = {
-					initial: { opacity: 0, y: 20 },
+					initial: shouldAnimate ? { opacity: 0, y: 20 } : { opacity: 1, y: 0 },
 					animate: { opacity: 1, y: 0 },
 				};
 
@@ -239,6 +250,7 @@ const AuthenticatedView = memo(
 									transition={ { duration: 0.3 } }
 									initial="initial"
 									animate="animate"
+									onAnimationComplete={ () => setShouldAnimate( false ) }
 								>
 									<MarkDownWithCode
 										message={ message }
@@ -253,7 +265,7 @@ const AuthenticatedView = memo(
 					</ChatMessage>
 				);
 			},
-			[ showThinking, siteId, instanceId ]
+			[ showThinking, siteId, instanceId, shouldAnimate, setShouldAnimate ]
 		);
 
 		if ( messages.length === 0 ) {

--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -120,10 +120,10 @@ const AuthenticatedView = memo(
 		submitPrompt,
 		wrapperRef,
 	}: AuthenticatedViewProps ) => {
+		const isInitialRenderRef = useRef( true );
 		const lastMessageRef = useRef< HTMLDivElement >( null );
 		const [ showThinking, setShowThinking ] = useState( isAssistantThinking );
-		const [ lastSeenMessageId, setLastSeenMessageId ] = useState< number | null >( null );
-		const [ shouldAnimate, setShouldAnimate ] = useState( false );
+		const [ shouldAnimate, setShouldAnimate ] = useState( ! isInitialRenderRef.current );
 
 		const lastMessage = useMemo(
 			() =>
@@ -133,18 +133,10 @@ const AuthenticatedView = memo(
 			[ messages, showThinking ]
 		);
 
-		useEffect( () => {
-			if ( lastMessage?.id !== lastSeenMessageId ) {
-				setLastSeenMessageId( lastMessage?.id ?? null );
-				setShouldAnimate( true );
-			}
-		}, [ lastMessage, lastSeenMessageId ] );
-
 		const messagesToRender =
 			messages[ messages.length - 1 ]?.role === 'assistant' ? messages.slice( 0, -1 ) : messages;
 		const showLastMessage = lastMessage?.role === 'assistant';
 		const previousMessagesLength = useRef( messages.length );
-		const isInitialRenderRef = useRef( true );
 
 		// This effect may run twice when the component is mounted, which makes the viewport scroll
 		// to the wrong position. This happens because the app runs in React strict mode, meaning
@@ -153,6 +145,10 @@ const AuthenticatedView = memo(
 		useEffect( () => {
 			if ( ! messages.length ) {
 				return;
+			}
+
+			if ( ! isInitialRenderRef.current ) {
+				setShouldAnimate( true );
 			}
 
 			let timer: NodeJS.Timeout;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/dotcom-forge/issues/10256.

## Proposed Changes

- ensure the last AI Assistant message is animated only when it arrives, not when a tab is switched

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Build the app with `npm install && npm run make` and test the changes on the build app outputted in the `/out` directory. Context: https://github.com/Automattic/studio/pull/978#issuecomment-2690157542.
2. Head over to the Assistant tab and try to reproduce the issue reported in https://github.com/Automattic/dotcom-forge/issues/10256. It should not be possible:
  - when a new message arrives, it should still animate
  - when you switch to a different tab and back, the last message should not animate 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
