### PR TITLE
Assistant: Fix `<ol>` and `<ul>` markdown styling RTL styling

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -211,14 +211,14 @@ blockquote {
 
 .assistant-markdown ol {
 	list-style-type: decimal;
-	margin: 0 0 1rem;
-	padding-left: 1.5rem;
+	margin-block-end: 1rem;
+	padding-inline-start: 1.5rem;
 }
 
 .assistant-markdown ul {
 	list-style-type: disc;
-	margin: 0 0 1rem;
-	padding-left: 1.5rem;
+	margin-block-end: 1rem;
+	padding-inline-start: 1.5rem;
 }
 
 .assistant-markdown li {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/dotcom-forge/issues/10176.

## Proposed Changes

- fix `<ol>` and `<ul>` markdown styling in Assistant when RTL locale is set 

| Before | After |
|--------|--------|
| ![Markup on 2025-02-26 at 12:46:32](https://github.com/user-attachments/assets/90432039-dcb2-4b0b-a100-20b79b361731) | ![Markup on 2025-02-26 at 12:45:20](https://github.com/user-attachments/assets/4bc9e26f-a2a8-4e19-8ada-0675fdc90d9a) | 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR branch and build it with `npm start`.
2. Head over to the Assistant tab and ask it a question that will produce content that will include ordered and unordered list. You can ask the Assistant AI something like: "Please answer me with random text by using markdown. Do not use the code block, use actual markdown.".
3. The formatting should look good.
4. Switch to any RTL locale and review the formatting again. There should be no issues.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
