### PR TITLE
Studio: Add STUDIO_WP_VERSIONS feature flag

### DIFF
--- a/src/hooks/use-feature-flags.tsx
+++ b/src/hooks/use-feature-flags.tsx
@@ -10,15 +10,18 @@ const featureFlagsSchema = z
 	.object( {
 		terminal_wp_cli_enabled: z.boolean().optional(),
 		quick_deploys_enabled: z.boolean().optional(),
+		wp_versions_enabled: z.boolean().optional(),
 	} )
 	.catch( ( _ ) => ( {} ) );
 
 export interface FeatureFlagsContextType {
 	terminalWpCliEnabled: boolean;
+	wpVersionsEnabled: boolean;
 }
 
 export const FeatureFlagsContext = createContext< FeatureFlagsContextType >( {
 	terminalWpCliEnabled: false,
+	wpVersionsEnabled: false,
 } );
 
 interface FeatureFlagsProviderProps {
@@ -27,8 +30,10 @@ interface FeatureFlagsProviderProps {
 
 export const FeatureFlagsProvider: React.FC< FeatureFlagsProviderProps > = ( { children } ) => {
 	const terminalWpCliEnabledFromGlobals = getAppGlobals().terminalWpCliEnabled;
+	const wpVersionsEnabledFromGlobals = getAppGlobals().wpVersionsEnabled;
 	const [ featureFlags, setFeatureFlags ] = useState< FeatureFlagsContextType >( {
 		terminalWpCliEnabled: terminalWpCliEnabledFromGlobals,
+		wpVersionsEnabled: wpVersionsEnabledFromGlobals,
 	} );
 	const { isAuthenticated, client } = useAuth();
 
@@ -50,6 +55,7 @@ export const FeatureFlagsProvider: React.FC< FeatureFlagsProviderProps > = ( { c
 				setFeatureFlags( {
 					terminalWpCliEnabled:
 						Boolean( flags.terminal_wp_cli_enabled ) || terminalWpCliEnabledFromGlobals,
+					wpVersionsEnabled: Boolean( flags.wp_versions_enabled ) || wpVersionsEnabledFromGlobals,
 				} );
 			} catch ( error ) {
 				Sentry.captureException( error );
@@ -60,7 +66,7 @@ export const FeatureFlagsProvider: React.FC< FeatureFlagsProviderProps > = ( { c
 		return () => {
 			cancel = true;
 		};
-	}, [ isAuthenticated, client, terminalWpCliEnabledFromGlobals ] );
+	}, [ isAuthenticated, client, terminalWpCliEnabledFromGlobals, wpVersionsEnabledFromGlobals ] );
 
 	return (
 		<FeatureFlagsContext.Provider value={ featureFlags }>{ children }</FeatureFlagsContext.Provider>

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -732,6 +732,7 @@ export async function getAppGlobals( _event: IpcMainInvokeEvent ): Promise< AppG
 		appName: app.name,
 		arm64Translation: app.runningUnderARM64Translation,
 		terminalWpCliEnabled: process.env.STUDIO_TERMINAL_WP_CLI === 'true',
+		wpVersionsEnabled: process.env.STUDIO_WP_VERSIONS === 'true',
 	};
 }
 

--- a/src/ipc-types.d.ts
+++ b/src/ipc-types.d.ts
@@ -83,6 +83,7 @@ interface AppGlobals {
 	appName: string;
 	arm64Translation: boolean;
 	terminalWpCliEnabled: boolean;
+	wpVersionsEnabled: boolean;
 }
 
 // Our IPC objects will be attached to the `window` global


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/dotcom-forge/issues/10525

## Proposed Changes

- Add STUDIO_WP_VERSIONS feature flag

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run `STUDIO_WP_VERSIONS=true npm start`
- Add a console log in https://github.com/Automattic/studio/blob/e3ee2beffe4b112bd11a15e873901ff72964ba26/src/hooks/use-feature-flags.tsx#L70 `console.log( 'featureFlags', featureFlags );`
```diff
diff --git a/src/hooks/use-feature-flags.tsx b/src/hooks/use-feature-flags.tsx
index 7bdd3ddd..7023d81a 100644
--- a/src/hooks/use-feature-flags.tsx
+++ b/src/hooks/use-feature-flags.tsx
@@ -67,7 +67,7 @@ export const FeatureFlagsProvider: React.FC< FeatureFlagsProviderProps > = ( { c
 			cancel = true;
 		};
 	}, [ isAuthenticated, client, terminalWpCliEnabledFromGlobals, wpVersionsEnabledFromGlobals ] );
-
+	console.log( 'featureFlags', featureFlags );
 	return (
 		<FeatureFlagsContext.Provider value={ featureFlags }>{ children }</FeatureFlagsContext.Provider>
 	);

```
- Open the chrome dev tools
- Observe the feature flag `wpVersionsEnabled: true`

<img width="1012" alt="Screenshot 2025-02-26 at 13 07 27" src="https://github.com/user-attachments/assets/a9edebdb-201f-4b50-ab4e-5a26e2c38bde" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
