### PR TITLE
Assistant: Prevent scrollbars from loading in the "Thinking" message

### DIFF
--- a/src/components/assistant-thinking.tsx
+++ b/src/components/assistant-thinking.tsx
@@ -4,7 +4,7 @@ export function MessageThinking() {
 	return (
 		<div
 			aria-label={ __( 'Thinking…' ) }
-			className="flex justify-center items-center gap-1 p-0.5 min-h-5"
+			className="flex justify-center items-center gap-1 p-0.5 h-5 overflow-hidden"
 		>
 			<div
 				className="animate-pulse h-1.5 w-1.5 bg-a8c-blueberry rounded-full"

--- a/src/components/assistant-thinking.tsx
+++ b/src/components/assistant-thinking.tsx
@@ -4,7 +4,7 @@ export function MessageThinking() {
 	return (
 		<div
 			aria-label={ __( 'Thinking…' ) }
-			className="flex justify-center items-center gap-1 p-0.5 h-5 overflow-hidden"
+			className="flex justify-center items-center gap-1 p-0.5 min-h-5 overflow-hidden"
 		>
 			<div
 				className="animate-pulse h-1.5 w-1.5 bg-a8c-blueberry rounded-full"

--- a/src/components/assistant-thinking.tsx
+++ b/src/components/assistant-thinking.tsx
@@ -4,7 +4,7 @@ export function MessageThinking() {
 	return (
 		<div
 			aria-label={ __( 'Thinking…' ) }
-			className="flex justify-center items-center gap-1 p-0.5 min-h-5 overflow-hidden"
+			className="flex justify-center items-center gap-1 p-0.5 min-h-5"
 		>
 			<div
 				className="animate-pulse h-1.5 w-1.5 bg-a8c-blueberry rounded-full"

--- a/src/components/chat-message.tsx
+++ b/src/components/chat-message.tsx
@@ -68,7 +68,7 @@ export const ChatMessage = forwardRef< HTMLDivElement, ChatMessageProps >(
 						data-testid="chat-message"
 						aria-labelledby={ id }
 						className={ cx(
-							'inline-block p-3 rounded border overflow-x-auto select-text',
+							'inline-block p-3 rounded border overflow-x-auto overflow-y-hidden select-text',
 							isUnauthenticated ? 'lg:max-w-[90%]' : 'lg:max-w-[70%]',
 							message.failedMessage
 								? 'border-[#FACFD2] bg-[#F7EBEC]'


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/dotcom-forge/issues/10376.

## Proposed Changes

- prevent scrollbar from displaying in the Assistant's "Thinking" message

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. With the current `trunk`, try to reproduce the issue reported in https://github.com/Automattic/dotcom-forge/issues/10376.
2. Check out this PR branch and try to reproduce the issue again. It should not be possible.

(I have trouble reproducing the issue in the first place myself)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
