### PR TITLE
Create redux slice to list WordPress versions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -219,12 +219,14 @@ async function appBoot() {
 				"style-src 'self' 'unsafe-inline'", // unsafe-inline used by tailwindcss in development, and also in production after the app rename
 				"script-src 'self' 'wasm-unsafe-eval'", // allow WebAssembly to compile and instantiate
 			];
-			const prodPolicies = [ "connect-src 'self' https://public-api.wordpress.com" ];
+			const prodPolicies = [
+				"connect-src 'self' https://public-api.wordpress.com https://api.wordpress.org",
+			];
 			const devPolicies = [
 				// Webpack uses eval in development, react-devtools uses localhost
 				"script-src 'self' 'unsafe-eval' 'unsafe-inline' data: http://localhost:*",
 				// react-devtools uses localhost
-				"connect-src 'self' https://public-api.wordpress.com ws://localhost:*",
+				"connect-src 'self' https://public-api.wordpress.com https://api.wordpress.org ws://localhost:*",
 			];
 			const policies = [
 				...basePolicies,

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -2,9 +2,11 @@ import { combineReducers, configureStore, createListenerMiddleware } from '@redu
 import { useDispatch, useSelector } from 'react-redux';
 import { LOCAL_STORAGE_CHAT_API_IDS_KEY, LOCAL_STORAGE_CHAT_MESSAGES_KEY } from 'src/constants';
 import { reducer as chatReducer } from 'src/stores/chat-slice';
+import { reducer as wordpressVersionsReducer } from './wordpress-versions-slice';
 
 export type RootState = {
 	chat: ReturnType< typeof chatReducer >;
+	wordpressVersions: ReturnType< typeof wordpressVersionsReducer >;
 };
 
 const listenerMiddleware = createListenerMiddleware< RootState >();
@@ -39,6 +41,7 @@ listenerMiddleware.startListening( {
 
 export const rootReducer = combineReducers( {
 	chat: chatReducer,
+	wordpressVersions: wordpressVersionsReducer,
 } );
 
 export const store = configureStore( {

--- a/src/stores/tests/wordpress-versions-slice.test.ts
+++ b/src/stores/tests/wordpress-versions-slice.test.ts
@@ -1,0 +1,182 @@
+import * as Sentry from '@sentry/electron/renderer';
+import { store } from 'src/stores';
+import { testActions, testReducer } from 'src/stores/tests/utils/test-reducer';
+import {
+	fetchWordPressVersions,
+	wordpressVersionsSelectors,
+} from 'src/stores/wordpress-versions-slice';
+
+// Mock fetch
+global.fetch = jest.fn();
+
+// Mock Sentry
+jest.mock( '@sentry/electron/renderer', () => ( {
+	captureException: jest.fn(),
+} ) );
+
+store.replaceReducer( testReducer );
+
+describe( 'wordpress-versions-slice', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		store.dispatch( testActions.resetState() );
+	} );
+
+	describe( 'fetchWordPressVersions', () => {
+		it( 'should update versions when API call is successful', async () => {
+			// Mock successful API response
+			( global.fetch as jest.Mock ).mockResolvedValueOnce( {
+				ok: true,
+				json: jest.fn().mockResolvedValueOnce( {
+					offers: [
+						{ version: '6.4.0', response: 'autoupdate' },
+						{ version: '6.5.0-beta1', response: 'autoupdate' },
+						{ version: '6.3.0', response: 'upgrade' }, // Should be filtered out
+					],
+				} ),
+			} );
+
+			const result = await store.dispatch( fetchWordPressVersions() );
+
+			expect( result.type ).toBe( 'wordpressVersions/fetchWordPressVersions/fulfilled' );
+			expect( result.payload ).toEqual( [
+				{ version: '6.4.0', isBeta: false },
+				{ version: '6.5.0-beta1', isBeta: true },
+			] );
+
+			const state = store.getState();
+			const versions = wordpressVersionsSelectors.selectWordPressVersions( state );
+
+			expect( versions ).toHaveLength( 2 );
+			expect( versions[ 0 ] ).toEqual( { version: '6.4.0', isBeta: false } );
+			expect( versions[ 1 ] ).toEqual( { version: '6.5.0-beta1', isBeta: true } );
+			expect( state.wordpressVersions.status ).toBe( 'succeeded' );
+			expect( state.wordpressVersions.error ).toBeNull();
+		} );
+
+		it( 'should handle API response with no autoupdate offers', async () => {
+			// Mock API response with no autoupdate offers
+			( global.fetch as jest.Mock ).mockResolvedValueOnce( {
+				ok: true,
+				json: jest.fn().mockResolvedValueOnce( {
+					offers: [
+						{ version: '6.3.0', response: 'upgrade' },
+						{ version: '6.2.0', response: 'upgrade' },
+					],
+				} ),
+			} );
+
+			const result = await store.dispatch( fetchWordPressVersions() );
+
+			expect( result.type ).toBe( 'wordpressVersions/fetchWordPressVersions/fulfilled' );
+			expect( result.payload ).toEqual( [] );
+
+			const state = store.getState();
+			const versions = wordpressVersionsSelectors.selectWordPressVersions( state );
+
+			expect( versions ).toHaveLength( 0 );
+			expect( state.wordpressVersions.status ).toBe( 'succeeded' );
+		} );
+
+		it( 'should handle non-OK API response', async () => {
+			// Mock failed API response
+			( global.fetch as jest.Mock ).mockResolvedValueOnce( {
+				ok: false,
+			} );
+
+			const result = await store.dispatch( fetchWordPressVersions() );
+
+			expect( result.type ).toBe( 'wordpressVersions/fetchWordPressVersions/rejected' );
+			expect( result.payload ).toEqual( undefined );
+
+			const state = store.getState();
+			expect( state.wordpressVersions.versions ).toHaveLength( 0 );
+			expect( state.wordpressVersions.status ).toBe( 'failed' );
+			expect( state.wordpressVersions.error ).toBe( 'Failed to fetch WordPress versions' );
+		} );
+
+		it( 'should handle API fetch error', async () => {
+			// Mock fetch throwing an error
+			( global.fetch as jest.Mock ).mockRejectedValueOnce( new Error( 'Network error' ) );
+
+			const result = await store.dispatch( fetchWordPressVersions() );
+
+			expect( result.type ).toBe( 'wordpressVersions/fetchWordPressVersions/rejected' );
+
+			const state = store.getState();
+			expect( state.wordpressVersions.versions ).toHaveLength( 0 );
+			expect( state.wordpressVersions.status ).toBe( 'failed' );
+			expect( state.wordpressVersions.error ).toBe( 'Network error' );
+		} );
+
+		it( 'should handle schema validation error', async () => {
+			// Mock API response with invalid schema
+			( global.fetch as jest.Mock ).mockResolvedValueOnce( {
+				ok: true,
+				json: jest.fn().mockResolvedValueOnce( {
+					// Missing 'offers' field
+					something_else: [],
+				} ),
+			} );
+
+			const result = await store.dispatch( fetchWordPressVersions() );
+
+			expect( result.type ).toBe( 'wordpressVersions/fetchWordPressVersions/rejected' );
+			expect( result.payload ).toEqual( undefined );
+			expect( Sentry.captureException ).toHaveBeenCalled();
+
+			const state = store.getState();
+			expect( state.wordpressVersions.versions ).toHaveLength( 0 );
+			expect( state.wordpressVersions.status ).toBe( 'failed' );
+			expect( state.wordpressVersions.error ).toContain( 'invalid_type' );
+		} );
+
+		it( 'should correctly identify beta and RC versions', async () => {
+			// Mock API response with beta and RC versions
+			( global.fetch as jest.Mock ).mockResolvedValueOnce( {
+				ok: true,
+				json: jest.fn().mockResolvedValueOnce( {
+					offers: [
+						{ version: '6.4.0', response: 'autoupdate' },
+						{ version: '6.5.0-beta1', response: 'autoupdate' },
+						{ version: '6.5.0-RC1', response: 'autoupdate' },
+					],
+				} ),
+			} );
+
+			await store.dispatch( fetchWordPressVersions() );
+
+			const state = store.getState();
+			const versions = wordpressVersionsSelectors.selectWordPressVersions( state );
+
+			expect( versions ).toHaveLength( 3 );
+			expect( versions[ 0 ] ).toEqual( { version: '6.4.0', isBeta: false } );
+			expect( versions[ 1 ] ).toEqual( { version: '6.5.0-beta1', isBeta: true } );
+			expect( versions[ 2 ] ).toEqual( { version: '6.5.0-RC1', isBeta: true } );
+		} );
+	} );
+
+	describe( 'selectors', () => {
+		it( 'should select WordPress versions', async () => {
+			// Setup state with versions
+			( global.fetch as jest.Mock ).mockResolvedValueOnce( {
+				ok: true,
+				json: jest.fn().mockResolvedValueOnce( {
+					offers: [
+						{ version: '6.4.0', response: 'autoupdate' },
+						{ version: '6.5.0-beta1', response: 'autoupdate' },
+					],
+				} ),
+			} );
+
+			await store.dispatch( fetchWordPressVersions() );
+
+			const state = store.getState();
+			const versions = wordpressVersionsSelectors.selectWordPressVersions( state );
+
+			expect( versions ).toHaveLength( 2 );
+			expect( versions[ 0 ].version ).toBe( '6.4.0' );
+			expect( versions[ 1 ].version ).toBe( '6.5.0-beta1' );
+		} );
+	} );
+} );

--- a/src/stores/tests/wordpress-versions-slice.test.ts
+++ b/src/stores/tests/wordpress-versions-slice.test.ts
@@ -21,7 +21,6 @@ describe( 'wordpress-versions-slice', () => {
 		jest.clearAllMocks();
 		store.dispatch( testActions.resetState() );
 	} );
-
 	describe( 'fetchWordPressVersions', () => {
 		it( 'should update versions when API call is successful', async () => {
 			// Mock successful API response
@@ -40,16 +39,20 @@ describe( 'wordpress-versions-slice', () => {
 
 			expect( result.type ).toBe( 'wordpressVersions/fetchWordPressVersions/fulfilled' );
 			expect( result.payload ).toEqual( [
-				{ version: '6.4.0', isBeta: false },
-				{ version: '6.5.0-beta1', isBeta: true },
+				{ version: '6.4.0', isBeta: false, name: '6.4' },
+				{ version: '6.5.0-beta1', isBeta: true, name: '6.5.0-beta1' },
 			] );
 
 			const state = store.getState();
 			const versions = wordpressVersionsSelectors.selectWordPressVersions( state );
 
 			expect( versions ).toHaveLength( 2 );
-			expect( versions[ 0 ] ).toEqual( { version: '6.4.0', isBeta: false } );
-			expect( versions[ 1 ] ).toEqual( { version: '6.5.0-beta1', isBeta: true } );
+			expect( versions[ 0 ] ).toEqual( { version: '6.4.0', isBeta: false, name: '6.4' } );
+			expect( versions[ 1 ] ).toEqual( {
+				version: '6.5.0-beta1',
+				isBeta: true,
+				name: '6.5.0-beta1',
+			} );
 			expect( state.wordpressVersions.status ).toBe( 'succeeded' );
 			expect( state.wordpressVersions.error ).toBeNull();
 		} );
@@ -131,7 +134,7 @@ describe( 'wordpress-versions-slice', () => {
 			expect( state.wordpressVersions.error ).toContain( 'invalid_type' );
 		} );
 
-		it( 'should correctly identify beta and RC versions', async () => {
+		it( 'should correctly identify beta and RC versions and use full version for name', async () => {
 			// Mock API response with beta and RC versions
 			( global.fetch as jest.Mock ).mockResolvedValueOnce( {
 				ok: true,
@@ -150,19 +153,48 @@ describe( 'wordpress-versions-slice', () => {
 			const versions = wordpressVersionsSelectors.selectWordPressVersions( state );
 
 			expect( versions ).toHaveLength( 3 );
-			expect( versions[ 0 ] ).toEqual( { version: '6.4.0', isBeta: false } );
-			expect( versions[ 1 ] ).toEqual( { version: '6.5.0-beta1', isBeta: true } );
-			expect( versions[ 2 ] ).toEqual( { version: '6.5.0-RC1', isBeta: true } );
+			expect( versions ).toEqual( [
+				{ version: '6.4.0', isBeta: false, name: '6.4' },
+				{ version: '6.5.0-beta1', isBeta: true, name: '6.5.0-beta1' },
+				{ version: '6.5.0-RC1', isBeta: true, name: '6.5.0-RC1' },
+			] );
+		} );
+
+		it( 'should handle unusual version formats', async () => {
+			// Mock API response with unusual version formats
+			( global.fetch as jest.Mock ).mockResolvedValueOnce( {
+				ok: true,
+				json: jest.fn().mockResolvedValueOnce( {
+					offers: [
+						{ version: '10.11.12', response: 'autoupdate' },
+						{ version: '6.5-dev', response: 'autoupdate' },
+					],
+				} ),
+			} );
+
+			await store.dispatch( fetchWordPressVersions() );
+
+			const state = store.getState();
+			const versions = wordpressVersionsSelectors.selectWordPressVersions( state );
+
+			expect( versions ).toHaveLength( 2 );
+			expect( versions ).toEqual( [
+				{ version: '10.11.12', isBeta: false, name: '10.11' },
+				{ version: '6.5-dev', isBeta: false, name: '6.5' },
+			] );
 		} );
 	} );
 
 	describe( 'selectors', () => {
-		it( 'should select WordPress versions', async () => {
+		it( 'should select WordPress versions with name property', async () => {
 			// Setup state with versions
 			( global.fetch as jest.Mock ).mockResolvedValueOnce( {
 				ok: true,
 				json: jest.fn().mockResolvedValueOnce( {
 					offers: [
+						{ version: '6.1.0', response: 'autoupdate' },
+						{ version: '6.2.0', response: 'autoupdate' },
+						{ version: '6.3.0', response: 'autoupdate' },
 						{ version: '6.4.0', response: 'autoupdate' },
 						{ version: '6.5.0-beta1', response: 'autoupdate' },
 					],
@@ -174,9 +206,14 @@ describe( 'wordpress-versions-slice', () => {
 			const state = store.getState();
 			const versions = wordpressVersionsSelectors.selectWordPressVersions( state );
 
-			expect( versions ).toHaveLength( 2 );
-			expect( versions[ 0 ].version ).toBe( '6.4.0' );
-			expect( versions[ 1 ].version ).toBe( '6.5.0-beta1' );
+			expect( versions ).toHaveLength( 5 );
+			expect( versions ).toEqual( [
+				{ version: '6.1.0', isBeta: false, name: '6.1' },
+				{ version: '6.2.0', isBeta: false, name: '6.2' },
+				{ version: '6.3.0', isBeta: false, name: '6.3' },
+				{ version: '6.4.0', isBeta: false, name: '6.4' },
+				{ version: '6.5.0-beta1', isBeta: true, name: '6.5.0-beta1' },
+			] );
 		} );
 	} );
 } );

--- a/src/stores/tests/wordpress-versions-slice.test.ts
+++ b/src/stores/tests/wordpress-versions-slice.test.ts
@@ -173,6 +173,50 @@ describe( 'wordpress-versions-slice', () => {
 				{ version: '6.5-dev', isBeta: false, name: '6.5' },
 			] );
 		} );
+
+		it( 'should handle multiple patch versions of the same minor', async () => {
+			( global.fetch as jest.Mock ).mockResolvedValueOnce( {
+				ok: true,
+				json: jest.fn().mockResolvedValueOnce( {
+					offers: [
+						{
+							response: 'upgrade',
+							version: '6.7.2',
+						},
+						{
+							response: 'autoupdate',
+							version: '6.7.2',
+						},
+						{
+							response: 'autoupdate',
+							version: '6.7.1',
+						},
+						{
+							response: 'autoupdate',
+							version: '6.6.2',
+						},
+						{
+							response: 'autoupdate',
+							version: '6.5.5',
+						},
+					],
+					translations: [],
+				} ),
+			} );
+
+			await store.dispatch( fetchWordPressVersions() );
+
+			const state = store.getState();
+			const versions = wordpressVersionsSelectors.selectWordPressVersions( state );
+
+			expect( versions ).toHaveLength( 4 );
+			expect( versions ).toEqual( [
+				{ version: '6.7.2', isBeta: false, name: '6.7.2' },
+				{ version: '6.7.1', isBeta: false, name: '6.7.1' },
+				{ version: '6.6.2', isBeta: false, name: '6.6' },
+				{ version: '6.5.5', isBeta: false, name: '6.5' },
+			] );
+		} );
 	} );
 
 	describe( 'selectors', () => {

--- a/src/stores/tests/wordpress-versions-slice.test.ts
+++ b/src/stores/tests/wordpress-versions-slice.test.ts
@@ -6,10 +6,7 @@ import {
 	wordpressVersionsSelectors,
 } from 'src/stores/wordpress-versions-slice';
 
-// Mock fetch
 global.fetch = jest.fn();
-
-// Mock Sentry
 jest.mock( '@sentry/electron/renderer', () => ( {
 	captureException: jest.fn(),
 } ) );
@@ -23,7 +20,6 @@ describe( 'wordpress-versions-slice', () => {
 	} );
 	describe( 'fetchWordPressVersions', () => {
 		it( 'should update versions when API call is successful', async () => {
-			// Mock successful API response
 			( global.fetch as jest.Mock ).mockResolvedValueOnce( {
 				ok: true,
 				json: jest.fn().mockResolvedValueOnce( {
@@ -58,7 +54,6 @@ describe( 'wordpress-versions-slice', () => {
 		} );
 
 		it( 'should handle API response with no autoupdate offers', async () => {
-			// Mock API response with no autoupdate offers
 			( global.fetch as jest.Mock ).mockResolvedValueOnce( {
 				ok: true,
 				json: jest.fn().mockResolvedValueOnce( {
@@ -82,7 +77,6 @@ describe( 'wordpress-versions-slice', () => {
 		} );
 
 		it( 'should handle non-OK API response', async () => {
-			// Mock failed API response
 			( global.fetch as jest.Mock ).mockResolvedValueOnce( {
 				ok: false,
 			} );
@@ -99,7 +93,6 @@ describe( 'wordpress-versions-slice', () => {
 		} );
 
 		it( 'should handle API fetch error', async () => {
-			// Mock fetch throwing an error
 			( global.fetch as jest.Mock ).mockRejectedValueOnce( new Error( 'Network error' ) );
 
 			const result = await store.dispatch( fetchWordPressVersions() );
@@ -113,11 +106,10 @@ describe( 'wordpress-versions-slice', () => {
 		} );
 
 		it( 'should handle schema validation error', async () => {
-			// Mock API response with invalid schema
 			( global.fetch as jest.Mock ).mockResolvedValueOnce( {
 				ok: true,
 				json: jest.fn().mockResolvedValueOnce( {
-					// Missing 'offers' field
+					// Missing 'offers' field to trigger schema validation error
 					something_else: [],
 				} ),
 			} );
@@ -135,7 +127,6 @@ describe( 'wordpress-versions-slice', () => {
 		} );
 
 		it( 'should correctly identify beta and RC versions and use full version for name', async () => {
-			// Mock API response with beta and RC versions
 			( global.fetch as jest.Mock ).mockResolvedValueOnce( {
 				ok: true,
 				json: jest.fn().mockResolvedValueOnce( {
@@ -161,7 +152,6 @@ describe( 'wordpress-versions-slice', () => {
 		} );
 
 		it( 'should handle unusual version formats', async () => {
-			// Mock API response with unusual version formats
 			( global.fetch as jest.Mock ).mockResolvedValueOnce( {
 				ok: true,
 				json: jest.fn().mockResolvedValueOnce( {
@@ -187,7 +177,6 @@ describe( 'wordpress-versions-slice', () => {
 
 	describe( 'selectors', () => {
 		it( 'should select WordPress versions with name property', async () => {
-			// Setup state with versions
 			( global.fetch as jest.Mock ).mockResolvedValueOnce( {
 				ok: true,
 				json: jest.fn().mockResolvedValueOnce( {

--- a/src/stores/wordpress-versions-slice.ts
+++ b/src/stores/wordpress-versions-slice.ts
@@ -52,14 +52,13 @@ export const fetchWordPressVersions = createAsyncThunk(
 			const rawData = await response.json();
 			const data = wordPressApiResponseSchema.parse( rawData );
 
-			const offers = data.offers
+			return data.offers
 				.filter( ( offer ) => offer.response === 'autoupdate' )
 				.map( ( offer ) => ( {
 					version: offer.version,
 					isBeta: offer.version.includes( 'beta' ) || offer.version.includes( 'RC' ),
 					name: extractVersionName( offer.version ),
 				} ) );
-			return offers;
 		} catch ( error ) {
 			if ( error instanceof ZodError ) {
 				Sentry.captureException( error );

--- a/src/stores/wordpress-versions-slice.ts
+++ b/src/stores/wordpress-versions-slice.ts
@@ -1,19 +1,21 @@
 import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
+import * as Sentry from '@sentry/electron/renderer';
+import { z, ZodError } from 'zod';
 
 const MINIMUM_WORDPRESS_VERSION = '5.9.9';
+
+const wordPressOfferSchema = z.object( {
+	version: z.string(),
+	response: z.enum( [ 'autoupdate', 'upgrade' ] ),
+} );
+
+const wordPressApiResponseSchema = z.object( {
+	offers: z.array( wordPressOfferSchema ),
+} );
 
 interface WordPressVersion {
 	version: string;
 	isBeta: boolean;
-}
-
-interface WordPressOffer {
-	version: string;
-	response: 'autoupdate' | 'upgrade';
-}
-
-interface WordPressApiResponse {
-	offers: WordPressOffer[];
 }
 
 interface WordPressVersionsState {
@@ -31,21 +33,29 @@ const initialState: WordPressVersionsState = {
 export const fetchWordPressVersions = createAsyncThunk(
 	'wordpressVersions/fetchWordPressVersions',
 	async () => {
-		const response = await fetch(
-			`https://api.wordpress.org/core/version-check/1.7/?channel=beta&version=${ MINIMUM_WORDPRESS_VERSION }`
-		);
-		if ( ! response.ok ) {
-			throw new Error( 'Failed to fetch WordPress versions' );
-		}
-		const data: WordPressApiResponse = await response.json();
+		try {
+			const response = await fetch(
+				`https://api.wordpress.org/core/version-check/1.7/?channel=beta&version=${ MINIMUM_WORDPRESS_VERSION }`
+			);
+			if ( ! response.ok ) {
+				throw new Error( 'Failed to fetch WordPress versions' );
+			}
+			const rawData = await response.json();
+			const data = wordPressApiResponseSchema.parse( rawData );
 
-		const offers = data.offers
-			.filter( ( offer ) => offer.response === 'autoupdate' )
-			.map( ( offer ) => ( {
-				version: offer.version,
-				isBeta: offer.version.includes( 'beta' ) || offer.version.includes( 'RC' ),
-			} ) );
-		return offers;
+			const offers = data.offers
+				.filter( ( offer ) => offer.response === 'autoupdate' )
+				.map( ( offer ) => ( {
+					version: offer.version,
+					isBeta: offer.version.includes( 'beta' ) || offer.version.includes( 'RC' ),
+				} ) );
+			return offers;
+		} catch ( error ) {
+			if ( error instanceof ZodError ) {
+				Sentry.captureException( error );
+			}
+			throw error;
+		}
 	}
 );
 
@@ -60,7 +70,9 @@ const wordpressVersionsSlice = createSlice( {
 			} )
 			.addCase( fetchWordPressVersions.fulfilled, ( state, action ) => {
 				state.status = 'succeeded';
-				state.versions = action.payload;
+				if ( action.payload.length > 0 ) {
+					state.versions = action.payload;
+				}
 			} )
 			.addCase( fetchWordPressVersions.rejected, ( state, action ) => {
 				state.status = 'failed';

--- a/src/stores/wordpress-versions-slice.ts
+++ b/src/stores/wordpress-versions-slice.ts
@@ -79,9 +79,8 @@ const wordpressVersionsSlice = createSlice( {
 			} )
 			.addCase( fetchWordPressVersions.fulfilled, ( state, action ) => {
 				state.status = 'succeeded';
-				if ( action.payload.length > 0 ) {
-					state.versions = action.payload;
-				}
+				state.versions = action.payload;
+				state.error = null;
 			} )
 			.addCase( fetchWordPressVersions.rejected, ( state, action ) => {
 				state.status = 'failed';

--- a/src/stores/wordpress-versions-slice.ts
+++ b/src/stores/wordpress-versions-slice.ts
@@ -1,0 +1,82 @@
+import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
+
+const MINIMUM_WORDPRESS_VERSION = '5.9.9';
+
+interface WordPressVersion {
+	version: string;
+	isBeta: boolean;
+}
+
+interface WordPressOffer {
+	version: string;
+	response: 'autoupdate' | 'upgrade';
+}
+
+interface WordPressApiResponse {
+	offers: WordPressOffer[];
+}
+
+interface WordPressVersionsState {
+	versions: WordPressVersion[];
+	status: 'idle' | 'loading' | 'succeeded' | 'failed';
+	error: string | null;
+}
+
+const initialState: WordPressVersionsState = {
+	versions: [],
+	status: 'idle',
+	error: null,
+};
+
+export const fetchWordPressVersions = createAsyncThunk(
+	'wordpressVersions/fetchWordPressVersions',
+	async () => {
+		const response = await fetch(
+			`https://api.wordpress.org/core/version-check/1.7/?channel=beta&version=${ MINIMUM_WORDPRESS_VERSION }`
+		);
+		if ( ! response.ok ) {
+			throw new Error( 'Failed to fetch WordPress versions' );
+		}
+		const data: WordPressApiResponse = await response.json();
+
+		const offers = data.offers
+			.filter( ( offer ) => offer.response === 'autoupdate' )
+			.map( ( offer ) => ( {
+				version: offer.version,
+				isBeta: offer.version.includes( 'beta' ) || offer.version.includes( 'RC' ),
+			} ) );
+		return offers;
+	}
+);
+
+const wordpressVersionsSlice = createSlice( {
+	name: 'wordpressVersions',
+	initialState,
+	reducers: {},
+	extraReducers: ( builder ) => {
+		builder
+			.addCase( fetchWordPressVersions.pending, ( state ) => {
+				state.status = 'loading';
+			} )
+			.addCase( fetchWordPressVersions.fulfilled, ( state, action ) => {
+				state.status = 'succeeded';
+				state.versions = action.payload;
+			} )
+			.addCase( fetchWordPressVersions.rejected, ( state, action ) => {
+				state.status = 'failed';
+				state.error =
+					action.error.message || 'Something went wrong when fetching the WordPress versions';
+			} );
+	},
+	selectors: {
+		selectWordPressVersions: ( state ) => state.versions,
+	},
+} );
+
+export const wordpressVersionsActions = wordpressVersionsSlice.actions;
+export const wordpressVersionsSelectors = wordpressVersionsSlice.selectors;
+export const wordpressVersionsThunks = {
+	fetchWordPressVersions,
+};
+
+export const reducer = wordpressVersionsSlice.reducer;

--- a/src/stores/wordpress-versions-slice.ts
+++ b/src/stores/wordpress-versions-slice.ts
@@ -32,18 +32,17 @@ export const fetchWordPressVersions = createAsyncThunk(
 			const data = wordPressApiResponseSchema.parse( rawData );
 
 			const shortNameOccurrences = new Map< string, number >();
-			const versionShortNames = data.offers
+			const offers = data.offers
 				.filter( ( offer ) => offer.response === 'autoupdate' )
-				.map( ( offer ) => {
-					const shortName = extractShortName( offer.version );
+				.map( ( { version } ) => {
+					const shortName = extractShortName( version );
 					shortNameOccurrences.set( shortName, ( shortNameOccurrences.get( shortName ) || 0 ) + 1 );
 					return {
-						version: offer.version,
+						version,
 						shortName,
 					};
 				} );
-
-			return versionShortNames.map( ( { version, shortName } ) => {
+			return offers.map( ( { version, shortName } ) => {
 				const isBeta = version.includes( 'beta' ) || version.includes( 'RC' );
 				const occurrences = shortNameOccurrences.get( shortName ) || 0;
 				return {

--- a/src/stores/wordpress-versions-slice.ts
+++ b/src/stores/wordpress-versions-slice.ts
@@ -16,6 +16,7 @@ const wordPressApiResponseSchema = z.object( {
 interface WordPressVersion {
 	version: string;
 	isBeta: boolean;
+	name: string;
 }
 
 interface WordPressVersionsState {
@@ -28,6 +29,14 @@ const initialState: WordPressVersionsState = {
 	versions: [],
 	status: 'idle',
 	error: null,
+};
+
+const extractVersionName = ( version: string ): string => {
+	if ( version.includes( 'beta' ) || version.includes( 'RC' ) ) {
+		return version;
+	}
+	const match = version.match( /^(\d+\.\d+)/ );
+	return match ? match[ 1 ] : version;
 };
 
 export const fetchWordPressVersions = createAsyncThunk(
@@ -48,6 +57,7 @@ export const fetchWordPressVersions = createAsyncThunk(
 				.map( ( offer ) => ( {
 					version: offer.version,
 					isBeta: offer.version.includes( 'beta' ) || offer.version.includes( 'RC' ),
+					name: extractVersionName( offer.version ),
 				} ) );
 			return offers;
 		} catch ( error ) {

--- a/src/stores/wordpress-versions-slice.ts
+++ b/src/stores/wordpress-versions-slice.ts
@@ -13,10 +13,7 @@ const wordPressApiResponseSchema = z.object( {
 	offers: z.array( wordPressOfferSchema ),
 } );
 
-const extractVersionName = ( version: string ): string => {
-	if ( version.includes( 'beta' ) || version.includes( 'RC' ) ) {
-		return version;
-	}
+const extractShortName = ( version: string ): string => {
 	const match = version.match( /^(\d+\.\d+)/ );
 	return match ? match[ 1 ] : version;
 };
@@ -34,13 +31,27 @@ export const fetchWordPressVersions = createAsyncThunk(
 			const rawData = await response.json();
 			const data = wordPressApiResponseSchema.parse( rawData );
 
-			return data.offers
+			const shortNameOccurrences = new Map< string, number >();
+			const versionShortNames = data.offers
 				.filter( ( offer ) => offer.response === 'autoupdate' )
-				.map( ( offer ) => ( {
-					version: offer.version,
-					isBeta: offer.version.includes( 'beta' ) || offer.version.includes( 'RC' ),
-					name: extractVersionName( offer.version ),
-				} ) );
+				.map( ( offer ) => {
+					const shortName = extractShortName( offer.version );
+					shortNameOccurrences.set( shortName, ( shortNameOccurrences.get( shortName ) || 0 ) + 1 );
+					return {
+						version: offer.version,
+						shortName,
+					};
+				} );
+
+			return versionShortNames.map( ( { version, shortName } ) => {
+				const isBeta = version.includes( 'beta' ) || version.includes( 'RC' );
+				const occurrences = shortNameOccurrences.get( shortName ) || 0;
+				return {
+					version,
+					isBeta,
+					name: occurrences > 1 || isBeta ? version : shortName,
+				};
+			} );
 		} catch ( error ) {
 			if ( error instanceof ZodError ) {
 				Sentry.captureException( error );

--- a/src/stores/wordpress-versions-slice.ts
+++ b/src/stores/wordpress-versions-slice.ts
@@ -13,24 +13,6 @@ const wordPressApiResponseSchema = z.object( {
 	offers: z.array( wordPressOfferSchema ),
 } );
 
-interface WordPressVersion {
-	version: string;
-	isBeta: boolean;
-	name: string;
-}
-
-interface WordPressVersionsState {
-	versions: WordPressVersion[];
-	status: 'idle' | 'loading' | 'succeeded' | 'failed';
-	error: string | null;
-}
-
-const initialState: WordPressVersionsState = {
-	versions: [],
-	status: 'idle',
-	error: null,
-};
-
 const extractVersionName = ( version: string ): string => {
 	if ( version.includes( 'beta' ) || version.includes( 'RC' ) ) {
 		return version;
@@ -67,6 +49,24 @@ export const fetchWordPressVersions = createAsyncThunk(
 		}
 	}
 );
+
+interface WordPressVersion {
+	version: string;
+	isBeta: boolean;
+	name: string;
+}
+
+interface WordPressVersionsState {
+	versions: WordPressVersion[];
+	status: 'idle' | 'loading' | 'succeeded' | 'failed';
+	error: string | null;
+}
+
+const initialState: WordPressVersionsState = {
+	versions: [],
+	status: 'idle',
+	error: null,
+};
 
 const wordpressVersionsSlice = createSlice( {
 	name: 'wordpressVersions',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/dotcom-forge/issues/10528

## Proposed Changes

- Add a WordPress slice to get the list of versions with shortnames

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Apply this diff. We could decide to load the information only once when the app starts.

```diff
diff --git a/src/components/content-tab-settings.tsx b/src/components/content-tab-settings.tsx
index 803b84d7..4bdc6d69 100644
--- a/src/components/content-tab-settings.tsx
+++ b/src/components/content-tab-settings.tsx
@@ -1,11 +1,16 @@
 import { useI18n } from '@wordpress/react-i18n';
-import { PropsWithChildren } from 'react';
+import { PropsWithChildren, useEffect } from 'react';
 import { CopyTextButton } from 'src/components/copy-text-button';
 import DeleteSite from 'src/components/delete-site';
 import EditPhpVersion from 'src/components/edit-php-version';
 import EditSite from 'src/components/edit-site';
 import { useGetWpVersion } from 'src/hooks/use-get-wp-version';
 import { decodePassword } from 'src/lib/passwords';
+import { useAppDispatch, useRootSelector } from 'src/stores';
+import {
+	wordpressVersionsThunks,
+	wordpressVersionsSelectors,
+} from 'src/stores/wordpress-versions-slice';
 
 interface ContentTabSettingsProps {
 	selectedSite: SiteDetails;
@@ -29,6 +34,12 @@ export function ContentTabSettings( { selectedSite }: ContentTabSettingsProps )
 	const storedPassword = decodePassword( selectedSite.adminPassword ?? '' );
 	const password = storedPassword === '' ? 'password' : storedPassword;
 	const wpVersion = useGetWpVersion( selectedSite );
+	const wordpressVersions = useRootSelector( wordpressVersionsSelectors.selectWordPressVersions );
+	const dispatch = useAppDispatch();
+	useEffect( () => {
+		dispatch( wordpressVersionsThunks.fetchWordPressVersions() );
+	}, [ dispatch ] );
+	console.log( wordpressVersions );
 	return (
 		<div className="p-8">
 			<table className="mb-2 m-w-full" cellPadding={ 0 } cellSpacing={ 0 }>

```
- Run `npm start`
- Go to the settings tab
- Open the chrome developer tools
- Observe the list of versions in the console

<img width="1131" alt="Screenshot 2025-02-27 at 16 23 25" src="https://github.com/user-attachments/assets/e096baac-5547-4797-ba83-79daa1793703" />


## Pre-merge Checklist


<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
