### PR TITLE
Sync: Remove unexpected horizontal scrollbar on the tab when the user is logged out

### DIFF
--- a/src/components/content-tab-sync.tsx
+++ b/src/components/content-tab-sync.tsx
@@ -78,7 +78,7 @@ function NoAuthSyncTab() {
 					</Button>
 				</Tooltip>
 			</div>
-			<div className="mt-3 max-w-[40ch] text-a8c-gray-70 a8c-body">
+			<div className="mt-3 text-a8c-gray-70 a8c-body">
 				<Tooltip
 					disabled={ ! isOffline }
 					icon={ offlineIcon }

--- a/src/components/content-tab-sync.tsx
+++ b/src/components/content-tab-sync.tsx
@@ -78,7 +78,7 @@ function NoAuthSyncTab() {
 					</Button>
 				</Tooltip>
 			</div>
-			<div className="mt-3 w-[40ch] text-a8c-gray-70 a8c-body">
+			<div className="mt-3 max-w-[40ch] text-a8c-gray-70 a8c-body">
 				<Tooltip
 					disabled={ ! isOffline }
 					icon={ offlineIcon }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/dotcom-forge/issues/10522.

## Proposed Changes

- use `max-width` instead of `width` for the "New to WordPress.com?" section on the Sync tab

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Try to reproduce the https://github.com/Automattic/dotcom-forge/issues/10522 issue.
2. Check out the PR branch and build the app with `npm start`.
3. Try to reproduce the issue again. It should not be possible.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
