### PR TITLE
Fix replacing site url in DB after pulling site

### DIFF
--- a/src/lib/updateSiteUrlToLocal.ts
+++ b/src/lib/updateSiteUrlToLocal.ts
@@ -19,7 +19,16 @@ export const updateSiteUrlToLocal = async ( siteId: string ) => {
 	const oldUrl = currentSiteUrl.trim();
 	const urlWithoutProtocol = oldUrl.replace( /^https?:\/\//, '' );
 
-	const oldUrlVariants = [ `http://${ urlWithoutProtocol }`, `https://${ urlWithoutProtocol }` ];
+	const oldUrlVariants = [
+		`http://${ urlWithoutProtocol }`,
+		`https://${ urlWithoutProtocol }`,
+		// e.g. "posterUrl" for videos uses encoded URLs
+		`http%3A%2F%2F${ urlWithoutProtocol }`,
+		`https%3A%2F%2F${ urlWithoutProtocol }`,
+		// e.g. Elementor plugin uses escaped URLs
+		String.raw`http:\/\/${ urlWithoutProtocol }`,
+		String.raw`https:\/\/${ urlWithoutProtocol }`,
+	];
 
 	for ( const urlToReplace of oldUrlVariants ) {
 		const { stderr, exitCode } = await server.executeWpCliCommand(


### PR DESCRIPTION
## Related issues

- Fixes https://github.com/Automattic/dotcom-forge/issues/10428

## Proposed Changes
When user pull or puh a site to/from Studio - all links should reflect the actual domain, all of them should be `localhost:<port>` if it was pulling to Studio or actual domain on dotcom if it was pushing.
This PR handles improving pulling process. We had it before, but I found not covered cases, so this PR fixes them
Regarding pushing - we don't handle it at all. I was thinking about it end ended up that it's better to do it in VaultPress side (details - p1740755830254999-slack-C07Q6R5HW3T).

Examples of issues covered in this PR:
<img width="825" alt="Screenshot 2025-02-28 at 15 05 15" src="https://github.com/user-attachments/assets/307d6473-789d-440c-84cb-8f59051a2382" />
<img width="973" alt="Screenshot 2025-02-28 at 15 07 47" src="https://github.com/user-attachments/assets/f6a34f20-54f3-411b-8419-57e7fb6a8fb5" />


## Testing Instructions
1. Create a site in wp.com
2. Create a post with video and add poster to this video
3. Install Elementor plugin
4. Create a post with the help of Elementor, add video and poster to it
5. Open Studio -> Create a new site -> Pull site from wp.com, created in the 1-st step of this instructions
6. Open local site
7. Assert that posters mentioned on screenshots in "Proposed Changes" have the correct localhost domain