### PR TITLE
Update tooltips in the new Previews tab

### DIFF
--- a/src/components/sync-connected-sites.tsx
+++ b/src/components/sync-connected-sites.tsx
@@ -220,7 +220,7 @@ const SyncConnectedSitesSection = ( {
 									<Badge className="bg-a8c-green-5 text-a8c-green-80">{ __( 'Production' ) }</Badge>
 								) }
 							</div>
-							<Tooltip 
+							<Tooltip
 								text={ sprintf(
 									/* translators: %s: The URL of the connected site */
 									__( 'Open %s' ),

--- a/src/components/sync-connected-sites.tsx
+++ b/src/components/sync-connected-sites.tsx
@@ -220,8 +220,14 @@ const SyncConnectedSitesSection = ( {
 									<Badge className="bg-a8c-green-5 text-a8c-green-80">{ __( 'Production' ) }</Badge>
 								) }
 							</div>
-
-							<Tooltip text={ connectedSite.url } className="overflow-hidden">
+							<Tooltip 
+								text={ sprintf(
+									/* translators: %s: The URL of the connected site */
+									__( 'Open %s' ),
+									connectedSite.url
+								) }
+								className="overflow-hidden"
+							>
 								<Button
 									variant="link"
 									className="!text-a8c-gray-70 hover:!text-a8c-blueberry max-w-[100%]"

--- a/src/hooks/use-expiration-date.ts
+++ b/src/hooks/use-expiration-date.ts
@@ -65,6 +65,6 @@ export function useExpirationDate( snapshotDate: number ) {
 		isExpired,
 		countDown: isExpired ? __( 'Expired' ) : countDown,
 		expireDateString: formatStringDate( endDate.getTime(), locale, 'long' ),
-		dateString: formatStringDate( snapshotDate, locale ),
+		dateString: formatStringDate( snapshotDate, locale, 'long' ),
 	};
 }

--- a/src/modules/preview-site/components/preview-site-row.tsx
+++ b/src/modules/preview-site/components/preview-site-row.tsx
@@ -117,13 +117,13 @@ export function PreviewSiteRow( {
 							{ snapshot.name || sprintf( __( '%s Preview' ), selectedSite.name ) }
 						</div>
 					</div>
-					<Tooltip 
+					<Tooltip
 						text={ sprintf(
 							/* translators: %s: The preview site URL */
 							__( 'Open %s' ),
 							urlWithHTTPS
 						) }
-						disabled={ isExpired } 
+						disabled={ isExpired }
 						className="overflow-hidden"
 					>
 						<Button

--- a/src/modules/preview-site/components/preview-site-row.tsx
+++ b/src/modules/preview-site/components/preview-site-row.tsx
@@ -33,7 +33,7 @@ export function PreviewSiteRow( {
 }: PreviewSiteRowProps ) {
 	const { __ } = useI18n();
 	const { url, date, isDeleting } = snapshot;
-	const { countDown, expireDateString, isExpired } = useExpirationDate( date );
+	const { countDown, dateString, expireDateString, isExpired } = useExpirationDate( date );
 	const { fetchSnapshotUsage, removeSnapshot } = useSnapshots();
 	const { isDemoSiteUpdating, hasDemoSiteError } = useUpdateDemoSite();
 	const isPreviewSiteUpdating = isDemoSiteUpdating( snapshot.atomicSiteId );
@@ -117,22 +117,20 @@ export function PreviewSiteRow( {
 							{ snapshot.name || sprintf( __( '%s Preview' ), selectedSite.name ) }
 						</div>
 					</div>
-					<Tooltip text={ urlWithHTTPS } disabled={ isExpired } className="overflow-hidden">
-						<Button
-							variant="link"
-							disabled={ isExpired }
-							className={ cx(
-								'!text-a8c-gray-700 max-w-full',
-								isExpired ? 'pointer-events-none' : 'hover:!text-a8c-blueberry'
-							) }
-							onClick={ () => getIpcApi().openURL( urlWithHTTPS ) }
-						>
-							<span className={ cx( 'truncate', isExpired && 'line-through text-a8c-gray-700' ) }>
-								{ urlWithHTTPS }
-							</span>
-							{ ! isExpired && <ArrowIcon /> }
-						</Button>
-					</Tooltip>
+					<Button
+						variant="link"
+						disabled={ isExpired }
+						className={ cx(
+							'!text-a8c-gray-700 max-w-full',
+							isExpired ? 'pointer-events-none' : 'hover:!text-a8c-blueberry'
+						) }
+						onClick={ () => getIpcApi().openURL( urlWithHTTPS ) }
+					>
+						<span className={ cx( 'truncate', isExpired && 'line-through text-a8c-gray-700' ) }>
+							{ urlWithHTTPS }
+						</span>
+						{ ! isExpired && <ArrowIcon /> }
+					</Button>
 				</div>
 				<div className="flex ltr:ml-auto rtl:mr-auto">
 					<div className="w-[150px] text-a8c-gray-700 flex items-center pl-4">
@@ -142,7 +140,9 @@ export function PreviewSiteRow( {
 								{ __( 'Updating' ) }
 							</div>
 						) : (
-							getLastUpdateTimeText()
+							<Tooltip text={ dateString } disabled={ ! date }>
+								{ getLastUpdateTimeText() }
+							</Tooltip>
 						) }
 					</div>
 					<div className="flex items-center">

--- a/src/modules/preview-site/components/preview-site-row.tsx
+++ b/src/modules/preview-site/components/preview-site-row.tsx
@@ -117,20 +117,30 @@ export function PreviewSiteRow( {
 							{ snapshot.name || sprintf( __( '%s Preview' ), selectedSite.name ) }
 						</div>
 					</div>
-					<Button
-						variant="link"
-						disabled={ isExpired }
-						className={ cx(
-							'!text-a8c-gray-700 max-w-full',
-							isExpired ? 'pointer-events-none' : 'hover:!text-a8c-blueberry'
+					<Tooltip 
+						text={ sprintf(
+							/* translators: %s: The preview site URL */
+							__( 'Open %s' ),
+							urlWithHTTPS
 						) }
-						onClick={ () => getIpcApi().openURL( urlWithHTTPS ) }
+						disabled={ isExpired } 
+						className="overflow-hidden"
 					>
-						<span className={ cx( 'truncate', isExpired && 'line-through text-a8c-gray-700' ) }>
-							{ urlWithHTTPS }
-						</span>
-						{ ! isExpired && <ArrowIcon /> }
-					</Button>
+						<Button
+							variant="link"
+							disabled={ isExpired }
+							className={ cx(
+								'!text-a8c-gray-700 max-w-full',
+								isExpired ? 'pointer-events-none' : 'hover:!text-a8c-blueberry'
+							) }
+							onClick={ () => getIpcApi().openURL( urlWithHTTPS ) }
+						>
+							<span className={ cx( 'truncate', isExpired && 'line-through text-a8c-gray-700' ) }>
+								{ urlWithHTTPS }
+							</span>
+							{ ! isExpired && <ArrowIcon /> }
+						</Button>
+					</Tooltip>
 				</div>
 				<div className="flex ltr:ml-auto rtl:mr-auto">
 					<div className="w-[150px] text-a8c-gray-700 flex items-center pl-4">


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Proposed Changes

This PR contains a few minute updates to the tooltips used on the new Previews tab. 

- Remove the tooltip for the site URL. It provides no new information beyond the link that's already visible. 
- Add a date/time tooltip for the Updated value. This provides users with the exact date/time their preview was last updated.

## Testing Instructions

| Preview URL - Before |  Preview URL - After |
|-|-|
|<img width="341" alt="image" src="https://github.com/user-attachments/assets/710b0915-f8ee-44fb-a37c-c9ea6a78ffee" />|<img width="360" alt="image" src="https://github.com/user-attachments/assets/3217f493-db7d-4272-95dc-149bd86409a7" />|

| Updated - Before |  Updated - After |
|-|-|
|<img width="309" alt="image" src="https://github.com/user-attachments/assets/593c4250-96c3-400f-a7c9-d58253b47ba1" />|<img width="306" alt="image" src="https://github.com/user-attachments/assets/ea2de4ad-7f9f-456a-b0c6-e1ad5c882c23" />|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
