### PR TITLE
STU-22: Add custom local domain support for WordPress sites

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
 				"follow-redirects": "1.15.6",
 				"fs-extra": "11.1.1",
 				"hpagent": "1.2.0",
+				"http-proxy": "^1.18.1",
 				"node-fetch": "^2.7.0",
 				"react-markdown": "^9.0.1",
 				"react-redux": "^9.2.0",
@@ -14350,8 +14351,7 @@
 		"node_modules/eventemitter3": {
 			"version": "4.0.7",
 			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-			"integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
-			"dev": true
+			"integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
 		},
 		"node_modules/events": {
 			"version": "3.3.0",
@@ -16273,7 +16273,6 @@
 			"version": "1.18.1",
 			"resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
 			"integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
-			"dev": true,
 			"dependencies": {
 				"eventemitter3": "^4.0.0",
 				"follow-redirects": "^1.0.0",
@@ -23277,8 +23276,7 @@
 		"node_modules/requires-port": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-			"integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
-			"dev": true
+			"integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
 		},
 		"node_modules/reselect": {
 			"version": "5.1.1",
@@ -24770,7 +24768,9 @@
 		"node_modules/sudo-prompt": {
 			"version": "9.2.1",
 			"resolved": "https://registry.npmjs.org/sudo-prompt/-/sudo-prompt-9.2.1.tgz",
-			"integrity": "sha512-Mu7R0g4ig9TUuGSxJavny5Rv0egCEtpZRNMrZaYS1vxkiIxGiGUwoezU3LazIQ+KE04hTrTfNPgxU5gzi7F5Pw=="
+			"integrity": "sha512-Mu7R0g4ig9TUuGSxJavny5Rv0egCEtpZRNMrZaYS1vxkiIxGiGUwoezU3LazIQ+KE04hTrTfNPgxU5gzi7F5Pw==",
+			"deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+			"license": "MIT"
 		},
 		"node_modules/sumchecker": {
 			"version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -132,6 +132,7 @@
 		"follow-redirects": "1.15.6",
 		"fs-extra": "11.1.1",
 		"hpagent": "1.2.0",
+		"http-proxy": "^1.18.1",
 		"node-fetch": "^2.7.0",
 		"react-markdown": "^9.0.1",
 		"react-redux": "^9.2.0",

--- a/src/components/add-site.tsx
+++ b/src/components/add-site.tsx
@@ -209,7 +209,11 @@ export default function AddSite( { className }: AddSiteProps ) {
 								<Button onClick={ closeModal } variant="tertiary">
 									{ __( 'Cancel' ) }
 								</Button>
-								<Button type="submit" variant="primary" disabled={ !! error || ! siteName?.trim() }>
+								<Button
+									type="submit"
+									variant="primary"
+									disabled={ !! error || !! customDomainError || ! siteName?.trim() }
+								>
 									{ __( 'Add site' ) }
 								</Button>
 							</div>

--- a/src/components/add-site.tsx
+++ b/src/components/add-site.tsx
@@ -49,6 +49,12 @@ export default function AddSite( { className }: AddSiteProps ) {
 		fileForImport,
 		setFileForImport,
 		sites,
+		useCustomDomain,
+		setUseCustomDomain,
+		customDomain,
+		setCustomDomain,
+		customDomainError,
+		setCustomDomainError,
 	} = useAddSite();
 	const { importState } = useImportExport();
 
@@ -101,6 +107,9 @@ export default function AddSite( { className }: AddSiteProps ) {
 			setWpVersion( DEFAULT_WORDPRESS_VERSION );
 			setPhpVersion( DEFAULT_PHP_VERSION as SupportedPHPVersion );
 		}
+		setUseCustomDomain( false );
+		setCustomDomain( '' );
+		setCustomDomainError( '' );
 	}, [
 		setSitePath,
 		setDoesPathContainWordPress,
@@ -108,6 +117,9 @@ export default function AddSite( { className }: AddSiteProps ) {
 		setPhpVersion,
 		setWpVersion,
 		wpVersionsEnabled,
+		setUseCustomDomain,
+		setCustomDomain,
+		setCustomDomainError,
 	] );
 
 	const handleSubmit = useCallback(
@@ -187,6 +199,11 @@ export default function AddSite( { className }: AddSiteProps ) {
 							onFileSelected={ handleImportFile }
 							fileError={ fileError }
 							allowVersionsChange
+							useCustomDomain={ useCustomDomain }
+							setUseCustomDomain={ setUseCustomDomain }
+							customDomain={ customDomain }
+							setCustomDomain={ setCustomDomain }
+							customDomainError={ customDomainError }
 						>
 							<div className="flex flex-row justify-end gap-x-5 mt-6">
 								<Button onClick={ closeModal } variant="tertiary">

--- a/src/components/add-site.tsx
+++ b/src/components/add-site.tsx
@@ -108,7 +108,7 @@ export default function AddSite( { className }: AddSiteProps ) {
 			setPhpVersion( DEFAULT_PHP_VERSION as SupportedPHPVersion );
 		}
 		setUseCustomDomain( false );
-		setCustomDomain( '' );
+		setCustomDomain( null );
 		setCustomDomainError( '' );
 	}, [
 		setSitePath,

--- a/src/components/content-tab-settings.tsx
+++ b/src/components/content-tab-settings.tsx
@@ -56,26 +56,22 @@ export function ContentTabSettings( { selectedSite }: ContentTabSettingsProps ) 
 						</div>
 					</SettingsRow>
 					<SettingsRow label={ __( 'Local URL' ) }>
-						<div className="flex">
-							<CopyTextButton
-								text={ `http://${ domain }` }
-								label={ `${ domain }, ${ __( 'Copy site url to clipboard' ) }` }
-								copyConfirmation={ __( 'Copied!' ) }
-							>
-								{ domain }
-							</CopyTextButton>
-						</div>
+						<CopyTextButton
+							text={ `http://${ domain }` }
+							label={ `${ domain }, ${ __( 'Copy site url to clipboard' ) }` }
+							copyConfirmation={ __( 'Copied!' ) }
+						>
+							{ domain }
+						</CopyTextButton>
 					</SettingsRow>
 					<SettingsRow label={ __( 'Local path' ) }>
-						<div className="flex">
-							<CopyTextButton
-								text={ selectedSite.path }
-								label={ __( 'Copy local path to clipboard' ) }
-								copyConfirmation={ __( 'Copied!' ) }
-							>
-								<span className="line-clamp-1 break-all">{ selectedSite.path }</span>
-							</CopyTextButton>
-						</div>
+						<CopyTextButton
+							text={ selectedSite.path }
+							label={ __( 'Copy local path to clipboard' ) }
+							copyConfirmation={ __( 'Copied!' ) }
+						>
+							<span className="line-clamp-1 break-all">{ selectedSite.path }</span>
+						</CopyTextButton>
 					</SettingsRow>
 					<SettingsRow label={ __( 'WP Version' ) }>{ wpVersion }</SettingsRow>
 					<SettingsRow label={ __( 'PHP Version' ) }>

--- a/src/components/content-tab-settings.tsx
+++ b/src/components/content-tab-settings.tsx
@@ -32,10 +32,9 @@ export function ContentTabSettings( { selectedSite }: ContentTabSettingsProps ) 
 	const storedPassword = decodePassword( selectedSite.adminPassword ?? '' );
 	const password = storedPassword === '' ? 'password' : storedPassword;
 	const [ wpVersion, refreshWpVersion ] = useGetWpVersion( selectedSite );
-	const domain =
-		selectedSite.useCustomDomain && selectedSite.customDomain
-			? `${ selectedSite.customDomain }`
-			: `localhost:${ selectedSite.port }`;
+	const domain = selectedSite.customDomain
+		? `${ selectedSite.customDomain }`
+		: `localhost:${ selectedSite.port }`;
 	return (
 		<div className="p-8">
 			<table className="mb-2 m-w-full" cellPadding={ 0 } cellSpacing={ 0 }>

--- a/src/components/content-tab-settings.tsx
+++ b/src/components/content-tab-settings.tsx
@@ -32,6 +32,10 @@ export function ContentTabSettings( { selectedSite }: ContentTabSettingsProps ) 
 	const storedPassword = decodePassword( selectedSite.adminPassword ?? '' );
 	const password = storedPassword === '' ? 'password' : storedPassword;
 	const [ wpVersion, refreshWpVersion ] = useGetWpVersion( selectedSite );
+	const domain =
+		selectedSite.useCustomDomain && selectedSite.customDomain
+			? `${ selectedSite.customDomain }`
+			: `localhost:${ selectedSite.port }`;
 	return (
 		<div className="p-8">
 			<table className="mb-2 m-w-full" cellPadding={ 0 } cellSpacing={ 0 }>
@@ -53,13 +57,15 @@ export function ContentTabSettings( { selectedSite }: ContentTabSettingsProps ) 
 						</div>
 					</SettingsRow>
 					<SettingsRow label={ __( 'Local URL' ) }>
-						<CopyTextButton
-							text={ `http://localhost:${ selectedSite.port }` }
-							label={ `localhost:${ selectedSite.port }, ${ __( 'Copy site url to clipboard' ) }` }
-							copyConfirmation={ __( 'Copied!' ) }
-						>
-							{ `localhost:${ selectedSite.port }` }
-						</CopyTextButton>
+						<div className="flex">
+							<CopyTextButton
+								text={ `http://${ domain }` }
+								label={ `${ domain }, ${ __( 'Copy site url to clipboard' ) }` }
+								copyConfirmation={ __( 'Copied!' ) }
+							>
+								{ domain }
+							</CopyTextButton>
+						</div>
 					</SettingsRow>
 					<SettingsRow label={ __( 'Local path' ) }>
 						<div className="flex">
@@ -105,13 +111,11 @@ export function ContentTabSettings( { selectedSite }: ContentTabSettingsProps ) 
 					</SettingsRow>
 					<SettingsRow label={ __( 'Admin URL' ) }>
 						<CopyTextButton
-							text={ `http://localhost:${ selectedSite.port }/wp-admin` }
-							label={ `localhost:${ selectedSite.port }/wp-admin, ${ __(
-								'Copy wp-admin url to clipboard'
-							) }` }
+							text={ `http://${ domain }/wp-admin` }
+							label={ `${ domain }/wp-admin, ${ __( 'Copy wp-admin url to clipboard' ) }` }
 							copyConfirmation={ __( 'Copied!' ) }
 						>
-							{ `localhost:${ selectedSite.port }/wp-admin` }
+							{ `${ domain }/wp-admin` }
 						</CopyTextButton>
 					</SettingsRow>
 				</tbody>

--- a/src/components/onboarding.tsx
+++ b/src/components/onboarding.tsx
@@ -54,6 +54,12 @@ export default function Onboarding() {
 		fileForImport,
 		phpVersion,
 		wpVersion,
+		useCustomDomain,
+		setUseCustomDomain,
+		customDomain,
+		setCustomDomain,
+		customDomainError,
+		setCustomDomainError,
 	} = useAddSite();
 	const [ fileError, setFileError ] = useState( '' );
 
@@ -88,6 +94,9 @@ export default function Onboarding() {
 			setSitePath( '' );
 			setError( '' );
 			setDoesPathContainWordPress( isWordPress );
+			setUseCustomDomain( false );
+			setCustomDomain( '' );
+			setCustomDomainError( '' );
 		};
 		run();
 		// eslint-disable-next-line react-hooks/exhaustive-deps
@@ -155,6 +164,11 @@ export default function Onboarding() {
 							setPhpVersion={ setPhpVersion }
 							wpVersion={ wpVersion }
 							setWpVersion={ setWpVersion }
+							useCustomDomain={ useCustomDomain }
+							setUseCustomDomain={ setUseCustomDomain }
+							customDomain={ customDomain }
+							setCustomDomain={ setCustomDomain }
+							customDomainError={ customDomainError }
 						>
 							<div className="flex flex-row gap-x-5 mt-6 justify-end">
 								<Button type="submit" variant="primary">

--- a/src/components/onboarding.tsx
+++ b/src/components/onboarding.tsx
@@ -95,7 +95,7 @@ export default function Onboarding() {
 			setError( '' );
 			setDoesPathContainWordPress( isWordPress );
 			setUseCustomDomain( false );
-			setCustomDomain( '' );
+			setCustomDomain( null );
 			setCustomDomainError( '' );
 		};
 		run();

--- a/src/components/site-form.tsx
+++ b/src/components/site-form.tsx
@@ -12,6 +12,7 @@ import { ACCEPTED_IMPORT_FILE_TYPES } from 'src/constants';
 import { useDocsLink } from 'src/hooks/use-docs-link';
 import { useFeatureFlags } from 'src/hooks/use-feature-flags';
 import { cx } from 'src/lib/cx';
+import { generateCustomDomainFromSiteName } from 'src/lib/generate-custom-domain';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 import { useAppDispatch, useRootSelector } from 'src/stores';
 import {
@@ -85,20 +86,6 @@ interface SiteFormWithoutVersionsProps extends SiteFormBaseProps {
 }
 
 type SiteFormProps = SiteFormWithVersionsProps | SiteFormWithoutVersionsProps;
-
-/**
- * Generates a suitable domain name from site name
- */
-const generateDomainFromSiteName = ( siteName: string ): string => {
-	// Convert the site name to lowercase and replace spaces with hyphens
-	const domainBase = siteName
-		.toLowerCase()
-		.replace( /[^a-z0-9-]/g, '-' ) // Replace non-alphanumeric chars with hyphens
-		.replace( /-+/g, '-' ) // Replace multiple hyphens with single hyphen
-		.replace( /^-|-$/g, '' ); // Remove hyphens from start and end
-
-	return `${ domainBase }.wp.local`;
-};
 
 const SiteFormError = ( { error, tipMessage = '', className = '' }: SiteFormErrorProps ) => {
 	return (
@@ -318,6 +305,7 @@ export const SiteForm = ( {
 	} else {
 		chevronIcon = chevronRight;
 	}
+	const generatedDomainName = generateCustomDomainFromSiteName( siteName );
 
 	return (
 		<form className={ className } onSubmit={ onSubmit }>
@@ -332,10 +320,7 @@ export const SiteForm = ( {
 							type="checkbox"
 							id="use-custom-domain"
 							checked={ useCustomDomain }
-							onChange={ ( e ) => {
-								setUseCustomDomain( e.target.checked );
-								setCustomDomain( generateDomainFromSiteName( siteName ) );
-							} }
+							onChange={ ( e ) => setUseCustomDomain( e.target.checked ) }
 						/>
 						<label htmlFor="use-custom-domain">{ __( 'Use custom domain' ) }</label>
 						<span className="text-a8c-gray-50 text-xs ml-2">
@@ -353,7 +338,7 @@ export const SiteForm = ( {
 							id="custom-domain"
 							value={ customDomain ?? '' }
 							onChange={ setCustomDomain }
-							placeholder="my-site.wp.local"
+							placeholder={ generatedDomainName }
 						/>
 						{ customDomainError && (
 							<div className="text-red-500 text-xs">{ customDomainError }</div>

--- a/src/components/site-form.tsx
+++ b/src/components/site-form.tsx
@@ -314,47 +314,7 @@ export const SiteForm = ( {
 					<span className="font-semibold">{ __( 'Site name' ) }</span>
 					<TextControlComponent onChange={ setSiteName } value={ siteName }></TextControlComponent>
 				</label>
-				{ setUseCustomDomain && setCustomDomain && (
-					<div className="flex items-center gap-2 mb-6">
-						<input
-							type="checkbox"
-							id="use-custom-domain"
-							checked={ useCustomDomain }
-							onChange={ ( e ) => setUseCustomDomain( e.target.checked ) }
-						/>
-						<label htmlFor="use-custom-domain">{ __( 'Use custom domain' ) }</label>
-						<span className="text-a8c-gray-50 text-xs ml-2">
-							{ __( 'This will require your password to authorize changes to the hosts file.' ) }
-						</span>
-					</div>
-				) }
 
-				{ useCustomDomain && setCustomDomain && (
-					<div className="flex flex-col gap-2 mb-6">
-						<label htmlFor="custom-domain" className="font-semibold">
-							{ __( 'Domain name' ) }
-						</label>
-						<TextControlComponent
-							id="custom-domain"
-							value={ customDomain ?? '' }
-							onChange={ setCustomDomain }
-							placeholder={ generatedDomainName }
-						/>
-						{ customDomainError && (
-							<div className="text-red-500 text-xs">{ customDomainError }</div>
-						) }
-						<div className="text-a8c-gray-50 text-xs">
-							{ __(
-								'You will be prompted for administrator permission to modify your system hosts file.'
-							) }
-						</div>
-						<div className="text-a8c-gray-50 text-xs mt-1">
-							{ __(
-								'Note: You will need administrator privileges to enable direct domain access.'
-							) }
-						</div>
-					</div>
-				) }
 				{ setFileForImport && (
 					<>
 						<div className="flex flex-col gap-1.5 leading-4 mb-6">
@@ -414,7 +374,7 @@ export const SiteForm = ( {
 								</div>
 								<div
 									className={ cx(
-										'transition-all duration-500 ease-in-out overflow-hidden',
+										'transition-all duration-500 ease-in-out overflow-hidden flex flex-col gap-2',
 										isAdvancedSettingsVisible ? 'max-h-96 opacity-100' : 'max-h-0 opacity-0'
 									) }
 								>
@@ -482,6 +442,62 @@ export const SiteForm = ( {
 											</div>
 										) }
 									</div>
+
+									{ setUseCustomDomain && setCustomDomain && (
+										<div
+											className={ cx(
+												'flex items-center gap-2',
+												isAdvancedSettingsVisible ? 'py-2' : 'p-2',
+												! isAdvancedSettingsVisible && 'hidden'
+											) }
+										>
+											<input
+												type="checkbox"
+												id="use-custom-domain"
+												checked={ useCustomDomain }
+												onChange={ ( e ) => setUseCustomDomain( e.target.checked ) }
+											/>
+											<label htmlFor="use-custom-domain">{ __( 'Use custom domain' ) }</label>
+											<span className="text-a8c-gray-50 text-xs ml-2">
+												{ __(
+													'This will require your password to authorize changes to the hosts file.'
+												) }
+											</span>
+										</div>
+									) }
+
+									{ useCustomDomain && setCustomDomain && (
+										<div
+											className={ cx(
+												'flex flex-col gap-2',
+												isAdvancedSettingsVisible ? 'py-2' : 'p-2',
+												! isAdvancedSettingsVisible && 'hidden'
+											) }
+										>
+											<label htmlFor="custom-domain" className="font-semibold">
+												{ __( 'Domain name' ) }
+											</label>
+											<TextControlComponent
+												id="custom-domain"
+												value={ customDomain ?? '' }
+												onChange={ setCustomDomain }
+												placeholder={ generatedDomainName }
+											/>
+											{ customDomainError && (
+												<div className="text-red-500 text-xs">{ customDomainError }</div>
+											) }
+											<div className="text-a8c-gray-50 text-xs">
+												{ __(
+													'You will be prompted for administrator permission to modify your system hosts file.'
+												) }
+											</div>
+											<div className="text-a8c-gray-50 text-xs mt-1">
+												{ __(
+													'Note: You will need administrator privileges to enable direct domain access.'
+												) }
+											</div>
+										</div>
+									) }
 								</div>
 							</>
 						) }

--- a/src/components/site-form.tsx
+++ b/src/components/site-form.tsx
@@ -365,10 +365,12 @@ export const SiteForm = ( {
 											{ __( 'Advanced settings' ) }
 										</div>
 									</Button>
-									{ error && (
+									{ ( error || customDomainError ) && (
 										<span className="text-red-500 text-[13px] leading-[16px] ml-2 flex items-center">
 											<Icon icon={ warning } size={ 16 } className="mr-1 fill-red-500" />
-											{ __( '1 error found' ) }
+											{ error && customDomainError
+												? __( '2 errors found' )
+												: __( '1 error found' ) }
 										</span>
 									) }
 								</div>
@@ -483,9 +485,7 @@ export const SiteForm = ( {
 												onChange={ setCustomDomain }
 												placeholder={ generatedDomainName }
 											/>
-											{ customDomainError && (
-												<div className="text-red-500 text-xs">{ customDomainError }</div>
-											) }
+											{ customDomainError && <SiteFormError error={ customDomainError } /> }
 											<div className="text-a8c-gray-50 text-xs">
 												{ __(
 													'You will be prompted for administrator permission to modify your system hosts file.'

--- a/src/components/site-form.tsx
+++ b/src/components/site-form.tsx
@@ -58,6 +58,11 @@ interface SiteFormBaseProps {
 	setFileForImport?: ( file: File | null ) => void;
 	onFileSelected?: ( file: File ) => void;
 	fileError?: string;
+	useCustomDomain?: boolean;
+	setUseCustomDomain?: ( use: boolean ) => void;
+	customDomain?: string;
+	setCustomDomain?: ( domain: string ) => void;
+	customDomainError?: string;
 }
 
 // TODO: Add all this props to the SiteForm component once we have the versions selects in edit site page.
@@ -80,6 +85,20 @@ interface SiteFormWithoutVersionsProps extends SiteFormBaseProps {
 }
 
 type SiteFormProps = SiteFormWithVersionsProps | SiteFormWithoutVersionsProps;
+
+/**
+ * Generates a suitable domain name from site name
+ */
+const generateDomainFromSiteName = ( siteName: string ): string => {
+	// Convert the site name to lowercase and replace spaces with hyphens
+	const domainBase = siteName
+		.toLowerCase()
+		.replace( /[^a-z0-9-]/g, '-' ) // Replace non-alphanumeric chars with hyphens
+		.replace( /-+/g, '-' ) // Replace multiple hyphens with single hyphen
+		.replace( /^-|-$/g, '' ); // Remove hyphens from start and end
+
+	return `${ domainBase }.wp.local`;
+};
 
 const SiteFormError = ( { error, tipMessage = '', className = '' }: SiteFormErrorProps ) => {
 	return (
@@ -263,6 +282,11 @@ export const SiteForm = ( {
 	onFileSelected,
 	fileError,
 	allowVersionsChange = false,
+	useCustomDomain,
+	setUseCustomDomain,
+	customDomain,
+	setCustomDomain,
+	customDomainError,
 }: SiteFormProps ) => {
 	const { __, isRTL } = useI18n();
 	const getDocsLink = useDocsLink();
@@ -302,6 +326,47 @@ export const SiteForm = ( {
 					<span className="font-semibold">{ __( 'Site name' ) }</span>
 					<TextControlComponent onChange={ setSiteName } value={ siteName }></TextControlComponent>
 				</label>
+				{ setUseCustomDomain && setCustomDomain && (
+					<div className="flex items-center gap-2 mb-6">
+						<input
+							type="checkbox"
+							id="use-custom-domain"
+							checked={ useCustomDomain }
+							onChange={ ( e ) => {
+								setUseCustomDomain( e.target.checked );
+								setCustomDomain( generateDomainFromSiteName( siteName ) );
+							} }
+						/>
+						<label htmlFor="use-custom-domain">{ __( 'Use custom domain' ) }</label>
+					</div>
+				) }
+
+				{ useCustomDomain && setCustomDomain && (
+					<div className="flex flex-col gap-2 mb-6">
+						<label htmlFor="custom-domain" className="font-semibold">
+							{ __( 'Domain name' ) }
+						</label>
+						<TextControlComponent
+							id="custom-domain"
+							value={ customDomain ?? '' }
+							onChange={ setCustomDomain }
+							placeholder="my-site.wp.local"
+						/>
+						{ customDomainError && (
+							<div className="text-red-500 text-xs">{ customDomainError }</div>
+						) }
+						<div className="text-a8c-gray-50 text-xs">
+							{ __(
+								'You will be prompted for administrator permission to modify your system hosts file.'
+							) }
+						</div>
+						<div className="text-a8c-gray-50 text-xs mt-1">
+							{ __(
+								'Note: You will need administrator privileges to enable direct domain access.'
+							) }
+						</div>
+					</div>
+				) }
 				{ setFileForImport && (
 					<>
 						<div className="flex flex-col gap-1.5 leading-4 mb-6">

--- a/src/components/site-form.tsx
+++ b/src/components/site-form.tsx
@@ -443,16 +443,9 @@ export const SiteForm = ( {
 												</div>
 											</div>
 										) }
-									</div>
 
-									{ setUseCustomDomain && setCustomDomain && (
-										<div
-											className={ cx(
-												isAdvancedSettingsVisible ? 'py-2' : 'p-2',
-												! isAdvancedSettingsVisible && 'hidden'
-											) }
-										>
-											<div className="flex items-center gap-2">
+										{ setUseCustomDomain && setCustomDomain && (
+											<div className="flex items-center gap-2 mt-4">
 												<input
 													type="checkbox"
 													id="use-custom-domain"
@@ -461,33 +454,28 @@ export const SiteForm = ( {
 												/>
 												<label htmlFor="use-custom-domain">{ __( 'Use custom domain' ) }</label>
 											</div>
-											<div className="text-a8c-gray-50 text-xs pt-2">
-												{ __(
-													'This will require your password to authorize changes to the hosts file.'
-												) }
-											</div>
-										</div>
-									) }
+										) }
 
-									{ useCustomDomain && setCustomDomain && (
-										<div
-											className={ cx(
-												'flex flex-col gap-2',
-												isAdvancedSettingsVisible ? 'py-2' : 'p-2',
-												! isAdvancedSettingsVisible && 'hidden'
-											) }
-										>
-											<label htmlFor="custom-domain" className="font-semibold">
-												{ __( 'Domain name' ) }
-											</label>
-											<TextControlComponent
-												id="custom-domain"
-												value={ customDomain !== null ? customDomain : generatedDomainName }
-												onChange={ setCustomDomain }
-											/>
-											{ customDomainError && <SiteFormError error={ customDomainError } /> }
-										</div>
-									) }
+										{ useCustomDomain && setCustomDomain && (
+											<div className="flex flex-col gap-2 mt-4">
+												<label htmlFor="custom-domain" className="font-semibold">
+													{ __( 'Domain name' ) }
+												</label>
+												<TextControlComponent
+													id="custom-domain"
+													value={ customDomain !== null ? customDomain : generatedDomainName }
+													onChange={ setCustomDomain }
+												/>
+												{ customDomainError && <SiteFormError error={ customDomainError } /> }
+											</div>
+										) }
+
+										{ setUseCustomDomain && setCustomDomain && (
+											<div className="text-a8c-gray-50 text-xs mt-2">
+												{ __( 'Your system password will be required to set up the domain.' ) }
+											</div>
+										) }
+									</div>
 								</div>
 							</>
 						) }

--- a/src/components/site-form.tsx
+++ b/src/components/site-form.tsx
@@ -338,6 +338,9 @@ export const SiteForm = ( {
 							} }
 						/>
 						<label htmlFor="use-custom-domain">{ __( 'Use custom domain' ) }</label>
+						<span className="text-a8c-gray-50 text-xs ml-2">
+							{ __( 'This will require your password to authorize changes to the hosts file.' ) }
+						</span>
 					</div>
 				) }
 

--- a/src/components/site-form.tsx
+++ b/src/components/site-form.tsx
@@ -61,7 +61,7 @@ interface SiteFormBaseProps {
 	fileError?: string;
 	useCustomDomain?: boolean;
 	setUseCustomDomain?: ( use: boolean ) => void;
-	customDomain?: string;
+	customDomain?: string | null;
 	setCustomDomain?: ( domain: string ) => void;
 	customDomainError?: string;
 }
@@ -271,7 +271,7 @@ export const SiteForm = ( {
 	allowVersionsChange = false,
 	useCustomDomain,
 	setUseCustomDomain,
-	customDomain,
+	customDomain = null,
 	setCustomDomain,
 	customDomainError,
 }: SiteFormProps ) => {
@@ -482,9 +482,8 @@ export const SiteForm = ( {
 											</label>
 											<TextControlComponent
 												id="custom-domain"
-												value={ customDomain ?? '' }
+												value={ customDomain !== null ? customDomain : generatedDomainName }
 												onChange={ setCustomDomain }
-												placeholder={ generatedDomainName }
 											/>
 											{ customDomainError && <SiteFormError error={ customDomainError } /> }
 										</div>

--- a/src/components/site-form.tsx
+++ b/src/components/site-form.tsx
@@ -448,23 +448,24 @@ export const SiteForm = ( {
 									{ setUseCustomDomain && setCustomDomain && (
 										<div
 											className={ cx(
-												'flex items-center gap-2',
 												isAdvancedSettingsVisible ? 'py-2' : 'p-2',
 												! isAdvancedSettingsVisible && 'hidden'
 											) }
 										>
-											<input
-												type="checkbox"
-												id="use-custom-domain"
-												checked={ useCustomDomain }
-												onChange={ ( e ) => setUseCustomDomain( e.target.checked ) }
-											/>
-											<label htmlFor="use-custom-domain">{ __( 'Use custom domain' ) }</label>
-											<span className="text-a8c-gray-50 text-xs ml-2">
+											<div className="flex items-center gap-2">
+												<input
+													type="checkbox"
+													id="use-custom-domain"
+													checked={ useCustomDomain }
+													onChange={ ( e ) => setUseCustomDomain( e.target.checked ) }
+												/>
+												<label htmlFor="use-custom-domain">{ __( 'Use custom domain' ) }</label>
+											</div>
+											<div className="text-a8c-gray-50 text-xs pt-2">
 												{ __(
 													'This will require your password to authorize changes to the hosts file.'
 												) }
-											</span>
+											</div>
 										</div>
 									) }
 
@@ -486,11 +487,6 @@ export const SiteForm = ( {
 												placeholder={ generatedDomainName }
 											/>
 											{ customDomainError && <SiteFormError error={ customDomainError } /> }
-											<div className="text-a8c-gray-50 text-xs">
-												{ __(
-													'You will be prompted for administrator permission to modify your system hosts file.'
-												) }
-											</div>
 										</div>
 									) }
 								</div>

--- a/src/components/site-form.tsx
+++ b/src/components/site-form.tsx
@@ -491,11 +491,6 @@ export const SiteForm = ( {
 													'You will be prompted for administrator permission to modify your system hosts file.'
 												) }
 											</div>
-											<div className="text-a8c-gray-50 text-xs mt-1">
-												{ __(
-													'Note: You will need administrator privileges to enable direct domain access.'
-												) }
-											</div>
 										</div>
 									) }
 								</div>

--- a/src/components/tests/add-site.test.tsx
+++ b/src/components/tests/add-site.test.tsx
@@ -131,6 +131,8 @@ describe( 'AddSite', () => {
 				'test',
 				'My WordPress Website',
 				expect.any( String ),
+				false,
+				'',
 				expect.any( Function )
 			);
 		} );

--- a/src/components/tests/add-site.test.tsx
+++ b/src/components/tests/add-site.test.tsx
@@ -131,8 +131,7 @@ describe( 'AddSite', () => {
 				'test',
 				'My WordPress Website',
 				expect.any( String ),
-				false,
-				'',
+				undefined,
 				expect.any( Function )
 			);
 		} );

--- a/src/components/tests/add-site.test.tsx
+++ b/src/components/tests/add-site.test.tsx
@@ -307,6 +307,7 @@ describe( 'AddSite', () => {
 				'test',
 				'My WordPress Website',
 				'6.3.3',
+				undefined,
 				expect.any( Function )
 			);
 		} );

--- a/src/components/tests/onboarding.test.tsx
+++ b/src/components/tests/onboarding.test.tsx
@@ -99,6 +99,12 @@ describe( 'Onboarding Component', () => {
 			handleSubmit: jest.fn( () => {
 				mockCreateSite( '/path/to/my/site', 'My Site', DEFAULT_WORDPRESS_VERSION );
 			} ),
+			setUseCustomDomain: jest.fn(),
+			useCustomDomain: false,
+			customDomain: '',
+			setCustomDomain: jest.fn(),
+			setCustomDomainError: jest.fn(),
+			customDomainError: '',
 		} );
 	} );
 

--- a/src/components/tests/onboarding.test.tsx
+++ b/src/components/tests/onboarding.test.tsx
@@ -181,6 +181,12 @@ describe( 'Onboarding Component', () => {
 			setFileForImport: jest.fn(),
 			fileForImport: null,
 			isAdvancedSettingsVisible: true,
+			setUseCustomDomain: jest.fn(),
+			useCustomDomain: false,
+			customDomain: '',
+			setCustomDomain: jest.fn(),
+			setCustomDomainError: jest.fn(),
+			customDomainError: '',
 		} );
 
 		render( <Onboarding /> );
@@ -262,6 +268,12 @@ describe( 'Onboarding Component', () => {
 			setFileForImport: jest.fn(),
 			fileForImport: null,
 			isAdvancedSettingsVisible: true,
+			setUseCustomDomain: jest.fn(),
+			useCustomDomain: false,
+			customDomain: '',
+			setCustomDomain: jest.fn(),
+			setCustomDomainError: jest.fn(),
+			customDomainError: '',
 		} );
 
 		render( <Onboarding /> );
@@ -324,6 +336,12 @@ describe( 'Onboarding Component', () => {
 			fileForImport: null,
 			isAdvancedSettingsVisible: true,
 			handleSubmit: jest.fn(),
+			setUseCustomDomain: jest.fn(),
+			useCustomDomain: false,
+			customDomain: '',
+			setCustomDomain: jest.fn(),
+			setCustomDomainError: jest.fn(),
+			customDomainError: '',
 		} );
 
 		render( <Onboarding /> );

--- a/src/hooks/tests/use-add-site.test.tsx
+++ b/src/hooks/tests/use-add-site.test.tsx
@@ -106,6 +106,7 @@ describe( 'useAddSite', () => {
 			'/test/path',
 			'',
 			'6.1.7',
+			undefined,
 			expect.any( Function )
 		);
 	} );
@@ -119,7 +120,7 @@ describe( 'useAddSite', () => {
 			phpVersion: '8.2',
 		};
 
-		mockCreateSite.mockImplementation( ( path, name, wpVersion, callback ) => {
+		mockCreateSite.mockImplementation( ( path, name, wpVersion, customDomain, callback ) => {
 			callback( newSite );
 			return Promise.resolve();
 		} );
@@ -151,7 +152,7 @@ describe( 'useAddSite', () => {
 			phpVersion: '8.2',
 		};
 
-		mockCreateSite.mockImplementation( ( path, name, version, callback ) => {
+		mockCreateSite.mockImplementation( ( path, name, version, customDomain, callback ) => {
 			callback( {
 				...newSite,
 				wpVersion: version,
@@ -211,6 +212,7 @@ describe( 'useAddSite', () => {
 			'/test/path',
 			'',
 			DEFAULT_WORDPRESS_VERSION,
+			undefined,
 			expect.any( Function )
 		);
 	} );

--- a/src/hooks/use-add-site.ts
+++ b/src/hooks/use-add-site.ts
@@ -25,7 +25,7 @@ export function useAddSite() {
 	);
 	const [ wpVersion, setWpVersion ] = useState( DEFAULT_WORDPRESS_VERSION );
 	const [ useCustomDomain, setUseCustomDomain ] = useState( false );
-	const [ customDomain, setCustomDomain ] = useState( '' );
+	const [ customDomain, setCustomDomain ] = useState< string | null >( null );
 	const [ customDomainError, setCustomDomainError ] = useState( '' );
 
 	const siteWithPathAlreadyExists = useCallback(
@@ -44,6 +44,8 @@ export function useAddSite() {
 				setCustomDomainError( __( 'Please enter a valid domain name' ) );
 			} else if ( useCustomDomain && value && value.length > 253 ) {
 				setCustomDomainError( __( 'The domain name is too long' ) );
+			} else if ( useCustomDomain && value === '' ) {
+				setCustomDomainError( __( 'The domain name is required' ) );
 			} else {
 				setCustomDomainError( '' );
 			}
@@ -85,8 +87,7 @@ export function useAddSite() {
 	const handleAddSiteClick = useCallback( async () => {
 		try {
 			const path = sitePath ? sitePath : proposedSitePath;
-
-			let usedCustomDomain = useCustomDomain ? customDomain : undefined;
+			let usedCustomDomain = useCustomDomain && customDomain ? customDomain : undefined;
 			if ( useCustomDomain && ! customDomain ) {
 				usedCustomDomain = generateCustomDomainFromSiteName( siteName ?? '' );
 			}

--- a/src/hooks/use-add-site.ts
+++ b/src/hooks/use-add-site.ts
@@ -39,9 +39,11 @@ export function useAddSite() {
 		( value: string ) => {
 			setCustomDomain( value );
 			// Validate custom domain if enabled
-			const domainPattern = /^[a-zA-Z0-9][a-zA-Z0-9-]{0,61}[a-zA-Z0-9](?:\.[a-zA-Z]{2,})+$/;
+			const domainPattern = /^[a-z0-9][a-z0-9-]{0,61}[a-z0-9](?:\.[a-z]{2,})+$/i;
 			if ( useCustomDomain && value && ! domainPattern.test( value ) ) {
 				setCustomDomainError( __( 'Please enter a valid domain name' ) );
+			} else if ( useCustomDomain && value && value.length > 253 ) {
+				setCustomDomainError( __( 'The domain name is too long' ) );
 			} else {
 				setCustomDomainError( '' );
 			}

--- a/src/hooks/use-add-site.ts
+++ b/src/hooks/use-add-site.ts
@@ -39,7 +39,8 @@ export function useAddSite() {
 		( value: string | null ) => {
 			setCustomDomain( value );
 			// Validate custom domain if enabled
-			const domainPattern = /^[\p{L}\p{N}][\p{L}\p{N}-]{0,61}[\p{L}\p{N}](?:\.[\p{L}\p{N}-]{2,})+$/u;
+			const domainPattern =
+				/^[\p{L}\p{N}][\p{L}\p{N}-]{0,61}[\p{L}\p{N}](?:\.[\p{L}\p{N}-]{2,})+$/u;
 			if ( useCustomDomain && value && ! domainPattern.test( value ) ) {
 				setCustomDomainError( __( 'Please enter a valid domain name' ) );
 			} else if ( useCustomDomain && value && value.length > 253 ) {

--- a/src/hooks/use-add-site.ts
+++ b/src/hooks/use-add-site.ts
@@ -5,6 +5,7 @@ import { useCallback, useMemo, useState } from 'react';
 import { useFeatureFlags } from 'src/hooks/use-feature-flags';
 import { useImportExport } from 'src/hooks/use-import-export';
 import { useSiteDetails } from 'src/hooks/use-site-details';
+import { generateCustomDomainFromSiteName } from 'src/lib/generate-custom-domain';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 import { DEFAULT_PHP_VERSION, DEFAULT_WORDPRESS_VERSION } from 'vendor/wp-now/src/constants';
 
@@ -68,26 +69,24 @@ export function useAddSite() {
 	const handleAddSiteClick = useCallback( async () => {
 		try {
 			// Validate custom domain if enabled
-			if ( useCustomDomain ) {
-				if ( ! customDomain.trim() ) {
-					setCustomDomainError( __( 'Custom domain cannot be empty' ) );
-					return;
-				}
-
-				const domainPattern = /^[a-zA-Z0-9][a-zA-Z0-9-]{0,61}[a-zA-Z0-9](?:\.[a-zA-Z]{2,})+$/;
-				if ( ! domainPattern.test( customDomain ) ) {
-					setCustomDomainError( __( 'Please enter a valid domain name' ) );
-					return;
-				}
+			const domainPattern = /^[a-zA-Z0-9][a-zA-Z0-9-]{0,61}[a-zA-Z0-9](?:\.[a-zA-Z]{2,})+$/;
+			if ( useCustomDomain && customDomain && ! domainPattern.test( customDomain ) ) {
+				setCustomDomainError( __( 'Please enter a valid domain name' ) );
+				return;
 			}
 
 			const path = sitePath ? sitePath : proposedSitePath;
+
+			let usedCustomDomain = customDomain;
+			if ( useCustomDomain && ! customDomain ) {
+				usedCustomDomain = generateCustomDomainFromSiteName( siteName ?? '' );
+			}
 			await createSite(
 				path,
 				siteName ?? '',
 				wpVersionsEnabled ? wpVersion : DEFAULT_WORDPRESS_VERSION,
 				useCustomDomain,
-				customDomain,
+				usedCustomDomain,
 				async ( newSite ) => {
 					if ( newSite ) {
 						let updatedSite = { ...newSite };

--- a/src/hooks/use-add-site.ts
+++ b/src/hooks/use-add-site.ts
@@ -23,6 +23,9 @@ export function useAddSite() {
 		DEFAULT_PHP_VERSION as SupportedPHPVersion
 	);
 	const [ wpVersion, setWpVersion ] = useState( DEFAULT_WORDPRESS_VERSION );
+	const [ useCustomDomain, setUseCustomDomain ] = useState( false );
+	const [ customDomain, setCustomDomain ] = useState( '' );
+	const [ customDomainError, setCustomDomainError ] = useState( '' );
 
 	const siteWithPathAlreadyExists = useCallback(
 		( path: string ) => {
@@ -64,11 +67,27 @@ export function useAddSite() {
 
 	const handleAddSiteClick = useCallback( async () => {
 		try {
+			// Validate custom domain if enabled
+			if ( useCustomDomain ) {
+				if ( ! customDomain.trim() ) {
+					setCustomDomainError( __( 'Custom domain cannot be empty' ) );
+					return;
+				}
+
+				const domainPattern = /^[a-zA-Z0-9][a-zA-Z0-9-]{0,61}[a-zA-Z0-9](?:\.[a-zA-Z]{2,})+$/;
+				if ( ! domainPattern.test( customDomain ) ) {
+					setCustomDomainError( __( 'Please enter a valid domain name' ) );
+					return;
+				}
+			}
+
 			const path = sitePath ? sitePath : proposedSitePath;
 			await createSite(
 				path,
 				siteName ?? '',
 				wpVersionsEnabled ? wpVersion : DEFAULT_WORDPRESS_VERSION,
+				useCustomDomain,
+				customDomain,
 				async ( newSite ) => {
 					if ( newSite ) {
 						let updatedSite = { ...newSite };
@@ -125,6 +144,8 @@ export function useAddSite() {
 		wpVersion,
 		phpVersion,
 		wpVersionsEnabled,
+		customDomain,
+		useCustomDomain,
 	] );
 
 	const handleSiteNameChange = useCallback(
@@ -194,6 +215,12 @@ export function useAddSite() {
 			setPhpVersion,
 			wpVersion,
 			setWpVersion,
+			useCustomDomain,
+			setUseCustomDomain,
+			customDomain,
+			setCustomDomain,
+			customDomainError,
+			setCustomDomainError,
 		};
 	}, [
 		__,
@@ -211,5 +238,11 @@ export function useAddSite() {
 		fileForImport,
 		phpVersion,
 		wpVersion,
+		useCustomDomain,
+		setUseCustomDomain,
+		customDomain,
+		setCustomDomain,
+		customDomainError,
+		setCustomDomainError,
 	] );
 }

--- a/src/hooks/use-add-site.ts
+++ b/src/hooks/use-add-site.ts
@@ -40,7 +40,7 @@ export function useAddSite() {
 			setCustomDomain( value );
 			// Validate custom domain if enabled
 			const domainPattern =
-				/^[\p{L}\p{N}][\p{L}\p{N}-]{0,61}[\p{L}\p{N}](?:\.[\p{L}\p{N}-]{2,})+$/u;
+				/^(?!-)[\p{L}\p{N}][\p{L}\p{N}-]{0,61}[\p{L}\p{N}](?<!-)(?:\.(?!-)[\p{L}\p{N}-]{1,61}[\p{L}\p{N}](?<!-))+$/u;
 			if ( useCustomDomain && value && ! domainPattern.test( value ) ) {
 				setCustomDomainError( __( 'Please enter a valid domain name' ) );
 			} else if ( useCustomDomain && value && value.length > 253 ) {

--- a/src/hooks/use-add-site.ts
+++ b/src/hooks/use-add-site.ts
@@ -36,10 +36,10 @@ export function useAddSite() {
 	);
 
 	const handleCustomDomainChange = useCallback(
-		( value: string ) => {
+		( value: string | null ) => {
 			setCustomDomain( value );
 			// Validate custom domain if enabled
-			const domainPattern = /^[a-z0-9][a-z0-9-]{0,61}[a-z0-9](?:\.[a-z]{2,})+$/i;
+			const domainPattern = /^[\p{L}\p{N}][\p{L}\p{N}-]{0,61}[\p{L}\p{N}](?:\.[\p{L}\p{N}-]{2,})+$/u;
 			if ( useCustomDomain && value && ! domainPattern.test( value ) ) {
 				setCustomDomainError( __( 'Please enter a valid domain name' ) );
 			} else if ( useCustomDomain && value && value.length > 253 ) {

--- a/src/hooks/use-add-site.ts
+++ b/src/hooks/use-add-site.ts
@@ -86,7 +86,7 @@ export function useAddSite() {
 		try {
 			const path = sitePath ? sitePath : proposedSitePath;
 
-			let usedCustomDomain = customDomain;
+			let usedCustomDomain = useCustomDomain ? customDomain : undefined;
 			if ( useCustomDomain && ! customDomain ) {
 				usedCustomDomain = generateCustomDomainFromSiteName( siteName ?? '' );
 			}
@@ -94,7 +94,6 @@ export function useAddSite() {
 				path,
 				siteName ?? '',
 				wpVersionsEnabled ? wpVersion : DEFAULT_WORDPRESS_VERSION,
-				useCustomDomain,
 				usedCustomDomain,
 				async ( newSite ) => {
 					if ( newSite ) {

--- a/src/hooks/use-add-site.ts
+++ b/src/hooks/use-add-site.ts
@@ -35,6 +35,20 @@ export function useAddSite() {
 		[ sites ]
 	);
 
+	const handleCustomDomainChange = useCallback(
+		( value: string ) => {
+			setCustomDomain( value );
+			// Validate custom domain if enabled
+			const domainPattern = /^[a-zA-Z0-9][a-zA-Z0-9-]{0,61}[a-zA-Z0-9](?:\.[a-zA-Z]{2,})+$/;
+			if ( useCustomDomain && value && ! domainPattern.test( value ) ) {
+				setCustomDomainError( __( 'Please enter a valid domain name' ) );
+			} else {
+				setCustomDomainError( '' );
+			}
+		},
+		[ __, useCustomDomain, setCustomDomain, setCustomDomainError ]
+	);
+
 	const handlePathSelectorClick = useCallback( async () => {
 		const response = await getIpcApi().showOpenFolderDialog(
 			__( 'Choose folder for site' ),
@@ -68,13 +82,6 @@ export function useAddSite() {
 
 	const handleAddSiteClick = useCallback( async () => {
 		try {
-			// Validate custom domain if enabled
-			const domainPattern = /^[a-zA-Z0-9][a-zA-Z0-9-]{0,61}[a-zA-Z0-9](?:\.[a-zA-Z]{2,})+$/;
-			if ( useCustomDomain && customDomain && ! domainPattern.test( customDomain ) ) {
-				setCustomDomainError( __( 'Please enter a valid domain name' ) );
-				return;
-			}
-
 			const path = sitePath ? sitePath : proposedSitePath;
 
 			let usedCustomDomain = customDomain;
@@ -217,7 +224,7 @@ export function useAddSite() {
 			useCustomDomain,
 			setUseCustomDomain,
 			customDomain,
-			setCustomDomain,
+			setCustomDomain: handleCustomDomainChange,
 			customDomainError,
 			setCustomDomainError,
 		};
@@ -240,7 +247,7 @@ export function useAddSite() {
 		useCustomDomain,
 		setUseCustomDomain,
 		customDomain,
-		setCustomDomain,
+		handleCustomDomainChange,
 		customDomainError,
 		setCustomDomainError,
 	] );

--- a/src/hooks/use-site-details.tsx
+++ b/src/hooks/use-site-details.tsx
@@ -21,7 +21,6 @@ interface SiteDetailsContext {
 		path: string,
 		siteName?: string,
 		wpVersion?: string,
-		useCustomDomain?: boolean,
 		customDomain?: string,
 		callback?: ( site: SiteDetails | void ) => Promise< void >
 	) => Promise< SiteDetails | void >;
@@ -194,7 +193,6 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 			path: string,
 			siteName?: string,
 			wpVersion?: string,
-			useCustomDomain?: boolean,
 			customDomain?: string,
 			callback?: ( site: SiteDetails | void ) => Promise< void >
 		) => {
@@ -236,13 +234,7 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 			setSelectedSiteId( tempSiteId ); // Set the temporary ID as the selected site
 
 			try {
-				const data = await getIpcApi().createSite(
-					path,
-					siteName,
-					wpVersion,
-					useCustomDomain,
-					customDomain
-				);
+				const data = await getIpcApi().createSite( path, siteName, wpVersion, customDomain );
 				const newSite = data.find( ( site ) => site.path === path );
 				if ( ! newSite ) {
 					showError();

--- a/src/hooks/use-site-details.tsx
+++ b/src/hooks/use-site-details.tsx
@@ -21,6 +21,8 @@ interface SiteDetailsContext {
 		path: string,
 		siteName?: string,
 		wpVersion?: string,
+		useCustomDomain?: boolean,
+		customDomain?: string,
 		callback?: ( site: SiteDetails | void ) => Promise< void >
 	) => Promise< SiteDetails | void >;
 	startServer: ( id: string ) => Promise< void >;
@@ -192,6 +194,8 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 			path: string,
 			siteName?: string,
 			wpVersion?: string,
+			useCustomDomain?: boolean,
+			customDomain?: string,
 			callback?: ( site: SiteDetails | void ) => Promise< void >
 		) => {
 			// Function to handle error messages and cleanup
@@ -232,7 +236,13 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 			setSelectedSiteId( tempSiteId ); // Set the temporary ID as the selected site
 
 			try {
-				const data = await getIpcApi().createSite( path, siteName, wpVersion );
+				const data = await getIpcApi().createSite(
+					path,
+					siteName,
+					wpVersion,
+					useCustomDomain,
+					customDomain
+				);
 				const newSite = data.find( ( site ) => site.path === path );
 				if ( ! newSite ) {
 					showError();

--- a/src/index.ts
+++ b/src/index.ts
@@ -320,7 +320,7 @@ async function appBoot() {
 		const clickedButtonIndex = dialog.showMessageBoxSync( {
 			message: __( 'Sync in progress' ),
 			detail: __(
-				"There's a sync operation in progress. Quitting the app will abort that operation. Are you sure you want to quit?"
+				'There’s a sync operation in progress. Quitting the app will abort that operation. Are you sure you want to quit?'
 			),
 			buttons: [ __( 'Yes, quit the app' ), __( 'No, take me back' ) ],
 			cancelId: CANCEL_BUTTON_INDEX,

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ import {
 } from 'src/lib/cli';
 import { getUserLocaleWithFallback } from 'src/lib/locale-node';
 import { onOpenUrlCallback } from 'src/lib/oauth';
+import { startProxyServer, stopProxyServer } from 'src/lib/proxy-server';
 import { getSentryReleaseInfo } from 'src/lib/sentry-release';
 import { setupLogging } from 'src/logging';
 import { createMainWindow, getMainWindow } from 'src/main-window';
@@ -197,6 +198,20 @@ async function appBoot() {
 		console.log( `System locale: ${ app.getSystemLocale() }` );
 		console.log( `Used language: ${ locale }` );
 
+		// Start the proxy server for custom domains
+		try {
+			const proxyStarted = await startProxyServer();
+			if ( proxyStarted ) {
+				console.log( 'Custom domain proxy server started successfully' );
+			} else {
+				console.warn(
+					'Failed to start custom domain proxy server - custom domains will require port numbers'
+				);
+			}
+		} catch ( error ) {
+			console.error( 'Error starting proxy server:', error );
+		}
+
 		// By default Electron automatically approves all permissions requests (e.g. notifications, webcam)
 		// We'll opt-in to permissions we specifically need instead.
 		session.defaultSession.setPermissionRequestHandler( ( webContents, permission, callback ) => {
@@ -305,7 +320,7 @@ async function appBoot() {
 		const clickedButtonIndex = dialog.showMessageBoxSync( {
 			message: __( 'Sync in progress' ),
 			detail: __(
-				'There’s a sync operation in progress. Quitting the app will abort that operation. Are you sure you want to quit?'
+				"There's a sync operation in progress. Quitting the app will abort that operation. Are you sure you want to quit?"
 			),
 			buttons: [ __( 'Yes, quit the app' ), __( 'No, take me back' ) ],
 			cancelId: CANCEL_BUTTON_INDEX,
@@ -320,6 +335,7 @@ async function appBoot() {
 
 	app.on( 'quit', () => {
 		stopAllServersOnQuit();
+		stopProxyServer().catch( ( error ) => console.error( 'Error stopping proxy server:', error ) );
 	} );
 
 	app.on( 'activate', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -198,20 +198,6 @@ async function appBoot() {
 		console.log( `System locale: ${ app.getSystemLocale() }` );
 		console.log( `Used language: ${ locale }` );
 
-		// Start the proxy server for custom domains
-		try {
-			const proxyStarted = await startProxyServer();
-			if ( proxyStarted ) {
-				console.log( 'Custom domain proxy server started successfully' );
-			} else {
-				console.warn(
-					'Failed to start custom domain proxy server - custom domains will require port numbers'
-				);
-			}
-		} catch ( error ) {
-			console.error( 'Error starting proxy server:', error );
-		}
-
 		// By default Electron automatically approves all permissions requests (e.g. notifications, webcam)
 		// We'll opt-in to permissions we specifically need instead.
 		session.defaultSession.setPermissionRequestHandler( ( webContents, permission, callback ) => {
@@ -278,6 +264,20 @@ async function appBoot() {
 		Sentry.setUser( { id: userData.sentryUserId } );
 
 		createMainWindow();
+
+		// Start the proxy server for custom domains
+		try {
+			const proxyStarted = await startProxyServer();
+			if ( proxyStarted ) {
+				console.log( 'Custom domain proxy server started successfully' );
+			} else {
+				console.warn(
+					'Failed to start custom domain proxy server - custom domains will require port numbers'
+				);
+			}
+		} catch ( error ) {
+			console.error( 'Error starting proxy server:', error );
+		}
 
 		// Handle CLI commands
 		listenCLICommands();

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -135,7 +135,6 @@ export async function createSite(
 	path: string,
 	siteName?: string,
 	wpVersion?: string,
-	useCustomDomain?: boolean,
 	customDomain?: string
 ): Promise< SiteDetails[] > {
 	const userData = await loadUserData();
@@ -178,7 +177,6 @@ export async function createSite(
 		running: false,
 		phpVersion: DEFAULT_PHP_VERSION,
 		customDomain: customDomain,
-		useCustomDomain: Boolean( useCustomDomain ),
 	} as const;
 
 	const server = SiteServer.create( details );
@@ -396,7 +394,7 @@ export async function startServer(
 	await keepSqliteIntegrationUpdated( server.details.path );
 
 	// Handle custom domain if necessary
-	if ( server.details.useCustomDomain && server.details.customDomain ) {
+	if ( server.details.customDomain ) {
 		await addDomainToHosts( server.details.customDomain, server.details.port );
 		console.log(
 			`Domain ${ server.details.customDomain } added to hosts file for port ${ server.details.port }`

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -397,15 +397,10 @@ export async function startServer(
 
 	// Handle custom domain if necessary
 	if ( server.details.useCustomDomain && server.details.customDomain ) {
-		try {
-			await addDomainToHosts( server.details.customDomain, server.details.port );
-			console.log(
-				`Domain ${ server.details.customDomain } added to hosts file for port ${ server.details.port }`
-			);
-		} catch ( error ) {
-			console.error( 'Failed to setup custom domain:', error );
-			// Continue even if custom domain setup fails - the site will still work with localhost:PORT
-		}
+		await addDomainToHosts( server.details.customDomain, server.details.port );
+		console.log(
+			`Domain ${ server.details.customDomain } added to hosts file for port ${ server.details.port }`
+		);
 	}
 
 	const parentWindow = BrowserWindow.fromWebContents( event.sender );

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -25,6 +25,7 @@ import { download } from 'src/lib/download';
 import { isEmptyDir, pathExists, isWordPressDirectory, sanitizeFolderName } from 'src/lib/fs-utils';
 import { getImageData } from 'src/lib/get-image-data';
 import { getSyncBackupTempPath } from 'src/lib/get-sync-backup-temp-path';
+import { addDomainToHosts } from 'src/lib/hosts-file';
 import { exportBackup } from 'src/lib/import-export/export/export-manager';
 import { ExportOptions } from 'src/lib/import-export/export/types';
 import { ImportExportEventData } from 'src/lib/import-export/handle-events';
@@ -133,7 +134,9 @@ export async function createSite(
 	event: IpcMainInvokeEvent,
 	path: string,
 	siteName?: string,
-	wpVersion?: string
+	wpVersion?: string,
+	useCustomDomain?: boolean,
+	customDomain?: string
 ): Promise< SiteDetails[] > {
 	const userData = await loadUserData();
 	const forceSetupSqlite = false;
@@ -174,6 +177,8 @@ export async function createSite(
 		port,
 		running: false,
 		phpVersion: DEFAULT_PHP_VERSION,
+		customDomain: customDomain,
+		useCustomDomain: Boolean( useCustomDomain ),
 	} as const;
 
 	const server = SiteServer.create( details );
@@ -389,6 +394,19 @@ export async function startServer(
 	}
 
 	await keepSqliteIntegrationUpdated( server.details.path );
+
+	// Handle custom domain if necessary
+	if ( server.details.useCustomDomain && server.details.customDomain ) {
+		try {
+			await addDomainToHosts( server.details.customDomain, server.details.port );
+			console.log(
+				`Domain ${ server.details.customDomain } added to hosts file for port ${ server.details.port }`
+			);
+		} catch ( error ) {
+			console.error( 'Failed to setup custom domain:', error );
+			// Continue even if custom domain setup fails - the site will still work with localhost:PORT
+		}
+	}
 
 	const parentWindow = BrowserWindow.fromWebContents( event.sender );
 	try {

--- a/src/ipc-types.d.ts
+++ b/src/ipc-types.d.ts
@@ -20,6 +20,8 @@ interface StoppedSiteDetails {
 	port: number;
 	phpVersion: string;
 	wpVersion?: string;
+	customDomain?: string;
+	useCustomDomain?: boolean; // Set during site creation and can't be changed afterward
 	adminPassword?: string;
 	themeDetails?: {
 		name: string;

--- a/src/ipc-types.d.ts
+++ b/src/ipc-types.d.ts
@@ -21,7 +21,6 @@ interface StoppedSiteDetails {
 	phpVersion: string;
 	wpVersion?: string;
 	customDomain?: string;
-	useCustomDomain?: boolean; // Set during site creation and can't be changed afterward
 	adminPassword?: string;
 	themeDetails?: {
 		name: string;

--- a/src/lib/generate-custom-domain.ts
+++ b/src/lib/generate-custom-domain.ts
@@ -1,13 +1,10 @@
+import { sanitizeFolderName } from './generate-site-name';
+
 /**
  * Generates a suitable domain name from site name
  */
 export const generateCustomDomainFromSiteName = ( siteName: string ): string => {
-	// Convert the site name to lowercase and replace spaces with hyphens
-	const domainBase = siteName
-		.toLowerCase()
-		.replace( /[^a-z0-9-]/g, '-' ) // Replace non-alphanumeric chars with hyphens
-		.replace( /-+/g, '-' ) // Replace multiple hyphens with single hyphen
-		.replace( /^-|-$/g, '' ); // Remove hyphens from start and end
+	const domainBase = sanitizeFolderName( siteName );
 
 	return `${ domainBase }.wp.local`;
 };

--- a/src/lib/generate-custom-domain.ts
+++ b/src/lib/generate-custom-domain.ts
@@ -1,0 +1,13 @@
+/**
+ * Generates a suitable domain name from site name
+ */
+export const generateCustomDomainFromSiteName = ( siteName: string ): string => {
+	// Convert the site name to lowercase and replace spaces with hyphens
+	const domainBase = siteName
+		.toLowerCase()
+		.replace( /[^a-z0-9-]/g, '-' ) // Replace non-alphanumeric chars with hyphens
+		.replace( /-+/g, '-' ) // Replace multiple hyphens with single hyphen
+		.replace( /^-|-$/g, '' ); // Remove hyphens from start and end
+
+	return `${ domainBase }.wp.local`;
+};

--- a/src/lib/hosts-file.ts
+++ b/src/lib/hosts-file.ts
@@ -87,7 +87,7 @@ export const addDomainToHosts = async ( domain: string, port: number ): Promise<
 				return entries;
 			}
 
-			return [ ...entries, `127.0.0.1 ${ domain } # Port ${ port } (WordPress Studio)` ];
+			return [ ...entries, `127.0.0.1 ${ domain } # Port ${ port }` ];
 		} );
 
 		if ( newContent !== hostsContent ) {

--- a/src/lib/hosts-file.ts
+++ b/src/lib/hosts-file.ts
@@ -48,23 +48,12 @@ export const writeHostsFile = async ( content: string ): Promise< void > => {
 	const currentPlatform = platform();
 
 	try {
-		// On Windows and macOS, we need to use sudo to write to the hosts file
-		if ( currentPlatform === 'win32' || currentPlatform === 'darwin' ) {
-			const tempPath = '/tmp/wp-studio-hosts';
-			await writeFile( tempPath, content );
-			// @ts-expect-error promisify doesn't seem typed properly.
-			await sudoExec( `cat ${ tempPath } > ${ hostsPath }`, {
-				name: 'WordPress Studio',
-			} );
-		} else {
-			// For Linux, we also need sudo
-			const tempPath = '/tmp/wp-studio-hosts';
-			await writeFile( tempPath, content );
-			// @ts-expect-error promisify doesn't seem typed properly.
-			await sudoExec( `cat ${ tempPath } > ${ hostsPath }`, {
-				name: 'WordPress Studio',
-			} );
-		}
+		const tempPath = '/tmp/wp-studio-hosts';
+		await writeFile( tempPath, content );
+		// @ts-expect-error promisify doesn't seem typed properly.
+		await sudoExec( `cat ${ tempPath } > ${ hostsPath }`, {
+			name: 'WordPress Studio',
+		} );
 	} catch ( error ) {
 		console.error( 'Error writing hosts file:', error );
 		throw error;

--- a/src/lib/hosts-file.ts
+++ b/src/lib/hosts-file.ts
@@ -1,5 +1,6 @@
 import fs from 'fs';
-import { platform } from 'os';
+import { platform, tmpdir } from 'os';
+import path from 'path';
 import { promisify } from 'util';
 import sudo from 'sudo-prompt';
 
@@ -46,7 +47,7 @@ export const readHostsFile = async (): Promise< string > => {
 export const writeHostsFile = async ( content: string ): Promise< void > => {
 	const hostsPath = getHostsFilePath();
 	try {
-		const tempPath = '/tmp/wp-studio-hosts';
+		const tempPath = path.join( tmpdir(), 'wp-studio-hosts' );
 		await writeFile( tempPath, content );
 		// @ts-expect-error promisify doesn't seem typed properly.
 		await sudoExec( `cat ${ tempPath } > ${ hostsPath }`, {

--- a/src/lib/hosts-file.ts
+++ b/src/lib/hosts-file.ts
@@ -60,57 +60,35 @@ export const writeHostsFile = async ( content: string ): Promise< void > => {
 };
 
 /**
+ * Create a regular expression matching the hosts entry for a given domain:
+ *
+ * 	127.0.0.1 foo.wp.cloud # Port 8000 (WordPress Studio)
+ */
+function createHostsEntryPattern( domain: string ): RegExp {
+	return new RegExp( `127\\.0\\.0\\.1\\s+${ domain.replace( /\./g, '\\.' ) }(\\s|$)`, 'i' );
+}
+
+/**
  * Adds a domain to the hosts file pointing to 127.0.0.1
  */
 export const addDomainToHosts = async ( domain: string, port: number ): Promise< void > => {
 	try {
 		const hostsContent = await readHostsFile();
 
-		// Check if the domain is already in the hosts file
-		const domainRegex = new RegExp(
-			`^127\\.0\\.0\\.1\\s+${ domain.replace( /\./g, '\\.' ) }`,
-			'i'
-		);
-		if ( domainRegex.test( hostsContent ) ) {
-			return; // Domain already exists
+		const newContent = updateStudioBlock( hostsContent, ( entries ) => {
+			const pattern = createHostsEntryPattern( domain );
+
+			// No changes if domain already present
+			if ( entries.some( ( entry ) => entry.match( pattern ) ) ) {
+				return entries;
+			}
+
+			return [ ...entries, `127.0.0.1 ${ domain } # Port ${ port } (WordPress Studio)` ];
+		} );
+
+		if ( newContent !== hostsContent ) {
+			await writeHostsFile( newContent );
 		}
-
-		// Define markers for WordPress Studio block
-		const beginMarker = '# BEGIN WordPress Studio';
-		const endMarker = '# END WordPress Studio';
-
-		// Create the domain entry with port reference
-		const domainEntry = `127.0.0.1\t${ domain } # Port: ${ port }`;
-
-		// Check if WordPress Studio block already exists
-		// Use non-greedy matching to avoid capturing multiple blocks at once
-		const blockRegex = new RegExp( `(${ beginMarker })[\\s\\S]*?(${ endMarker })` );
-		const blockMatch = hostsContent.match( blockRegex );
-
-		let newContent;
-
-		if ( blockMatch ) {
-			// Extract existing entries between markers
-			const existingBlock = blockMatch[ 0 ];
-			const entries = existingBlock
-				.split( '\n' )
-				.filter( ( line ) => line !== beginMarker && line !== endMarker && line.trim() !== '' );
-
-			// Add new entry to entries
-			entries.push( domainEntry );
-
-			// Create updated block with entries
-			const updatedBlock = `${ beginMarker }\n${ entries.join( '\n' ) }\n${ endMarker }`;
-
-			// Replace old block with updated block
-			newContent = hostsContent.replace( blockRegex, updatedBlock );
-		} else {
-			// Create new block with the domain entry
-			const newBlock = `\n\n${ beginMarker }\n${ domainEntry }\n${ endMarker }\n`;
-			newContent = hostsContent + newBlock;
-		}
-
-		await writeHostsFile( newContent );
 	} catch ( error ) {
 		console.error( `Error adding domain ${ domain } to hosts file:`, error );
 		throw error;
@@ -124,48 +102,10 @@ export const removeDomainFromHosts = async ( domain: string ): Promise< void > =
 	try {
 		const hostsContent = await readHostsFile();
 
-		// Check if the domain is already in the hosts file
-		const domainRegex = new RegExp(
-			`^127\\.0\\.0\\.1\\s+${ domain.replace( /\./g, '\\.' ) }`,
-			'i'
+		const pattern = createHostsEntryPattern( domain );
+		const newContent = updateStudioBlock( hostsContent, ( entries ) =>
+			entries.filter( ( entry ) => ! entry.match( pattern ) )
 		);
-		if ( ! domainRegex.test( hostsContent ) ) {
-			return; // Domain doesn't exist
-		}
-
-		// All WordPress Studio entries will be grouped in a block
-		const beginMarker = '# BEGIN WordPress Studio';
-		const endMarker = '# END WordPress Studio';
-
-		// Find the Studio block, if any. For performance, avoid greedy
-		// searches; there should only be a small block anyway.
-		const blockRegex = new RegExp( `(${ beginMarker })[\\s\\S]*?(${ endMarker })` );
-		const blockMatch = hostsContent.match( blockRegex );
-
-		let newContent = hostsContent;
-
-		if ( blockMatch ) {
-			// Split into lines to remove domain entry
-			const block = blockMatch[ 0 ];
-			const lines = block.split( '\n' );
-			const remainingLines = lines.filter(
-				( line ) =>
-					line === beginMarker ||
-					line === endMarker ||
-					( line.trim() !== '' && ! domainRegex.test( line ) )
-			);
-
-			if ( remainingLines.length <= 2 ) {
-				// Only markers left, remove entire block
-				newContent = newContent.replace( block, '' );
-				// Clean up extra newlines
-				newContent = newContent.replace( /\n\n\n+/g, '\n\n' );
-			} else {
-				// Create updated block with remaining entries
-				const updatedBlock = remainingLines.join( '\n' );
-				newContent = newContent.replace( block, updatedBlock );
-			}
-		}
 
 		// Only write if content changed
 		if ( newContent !== hostsContent ) {
@@ -176,3 +116,56 @@ export const removeDomainFromHosts = async ( domain: string ): Promise< void > =
 		throw error;
 	}
 };
+
+/**
+ * Helper function for manipulating the "block" of entries in the hosts file
+ * pertaining to WordPres Studio.
+ *
+ * @param content - Content of the hosts file
+ * @param updateFn - Function to map/filter over hosts entries
+ */
+function updateStudioBlock( content: string, updateFn: ( entries: string[] ) => string[] ): string {
+	/**
+	 * Regular expression matching a block of entries demarcated as follows:
+	 *
+	 * 	# BEGIN WordPress Studio
+	 * 	127.0.0.1 foo.wp.cloud
+	 * 	127.0.0.1 bar.wp.cloud
+	 * 	# END WordPress Studio
+	 */
+	const STUDIO_BLOCK_PATTERN =
+		/(^|\n)(# BEGIN WordPress Studio)([\s\S]*?)\n(# END WordPress Studio)/;
+
+	const match = content.match( STUDIO_BLOCK_PATTERN );
+
+	// Edit the existing "block" of Studio entries
+	if ( match ) {
+		const [ _, space, begin, block, end ] = match;
+
+		const before = content.slice( 0, match.index );
+		const after = content.slice( ( match.index ?? 0 ) + match[ 0 ].length );
+
+		const entries = block.split( '\n' ).filter( Boolean );
+		const newEntries = updateFn( entries );
+
+		// Remove whole block if empty
+		if ( ! newEntries.length ) {
+			return before + after;
+		}
+
+		const newLines = [ begin, ...newEntries, end ];
+		return before + space + newLines.join( '\n' ) + after;
+	}
+	// Append a new block to the hosts file
+	else {
+		const newEntries = updateFn( [] );
+		if ( newEntries.length ) {
+			return (
+				content +
+				[ '\n', '# BEGIN WordPress Studio', ...newEntries, '# END WordPress Studio' ].join( '\n' )
+			);
+		}
+	}
+
+	return content;
+}

--- a/src/lib/hosts-file.ts
+++ b/src/lib/hosts-file.ts
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import { domainToASCII } from 'node:url';
 import { platform, tmpdir } from 'os';
 import path from 'path';
 import { promisify } from 'util';
@@ -78,16 +79,17 @@ function createHostsEntryPattern( domain: string ): RegExp {
 export const addDomainToHosts = async ( domain: string, port: number ): Promise< void > => {
 	try {
 		const hostsContent = await readHostsFile();
+		const encodedDomain = domainToASCII( domain );
 
 		const newContent = updateStudioBlock( hostsContent, ( entries ) => {
-			const pattern = createHostsEntryPattern( domain );
+			const pattern = createHostsEntryPattern( encodedDomain );
 
 			// No changes if domain already present
 			if ( entries.some( ( entry ) => entry.match( pattern ) ) ) {
 				return entries;
 			}
 
-			return [ ...entries, `127.0.0.1 ${ domain } # Port ${ port }` ];
+			return [ ...entries, `127.0.0.1 ${ encodedDomain } # Port ${ port }` ];
 		} );
 
 		if ( newContent !== hostsContent ) {
@@ -105,8 +107,9 @@ export const addDomainToHosts = async ( domain: string, port: number ): Promise<
 export const removeDomainFromHosts = async ( domain: string ): Promise< void > => {
 	try {
 		const hostsContent = await readHostsFile();
+		const encodedDomain = domainToASCII( domain );
 
-		const pattern = createHostsEntryPattern( domain );
+		const pattern = createHostsEntryPattern( encodedDomain );
 		const newContent = updateStudioBlock( hostsContent, ( entries ) =>
 			entries.filter( ( entry ) => ! entry.match( pattern ) )
 		);

--- a/src/lib/hosts-file.ts
+++ b/src/lib/hosts-file.ts
@@ -1,0 +1,123 @@
+import fs from 'fs';
+import { platform } from 'os';
+import { promisify } from 'util';
+import sudo from 'sudo-prompt';
+
+const readFile = promisify( fs.readFile );
+const writeFile = promisify( fs.writeFile );
+const sudoExec = promisify( sudo.exec );
+
+// Host file paths for different operating systems
+const HOST_FILES: Record< string, string > = {
+	win32: 'C:\\Windows\\System32\\drivers\\etc\\hosts',
+	darwin: '/etc/hosts',
+	linux: '/etc/hosts',
+};
+
+// Get the appropriate hosts file path for the current platform
+const getHostsFilePath = (): string => {
+	const currentPlatform = platform();
+	const hostsPath = HOST_FILES[ currentPlatform ];
+
+	if ( ! hostsPath ) {
+		throw new Error( `Unsupported platform: ${ currentPlatform }` );
+	}
+
+	return hostsPath;
+};
+
+/**
+ * Reads the hosts file content
+ */
+export const readHostsFile = async (): Promise< string > => {
+	try {
+		const hostsPath = getHostsFilePath();
+		const content = await readFile( hostsPath, 'utf8' );
+		return content;
+	} catch ( error ) {
+		console.error( 'Error reading hosts file:', error );
+		throw error;
+	}
+};
+
+/**
+ * Writes content to the hosts file (requires elevated permissions)
+ */
+export const writeHostsFile = async ( content: string ): Promise< void > => {
+	const hostsPath = getHostsFilePath();
+	const currentPlatform = platform();
+
+	try {
+		// On Windows and macOS, we need to use sudo to write to the hosts file
+		if ( currentPlatform === 'win32' || currentPlatform === 'darwin' ) {
+			const tempPath = '/tmp/wp-studio-hosts';
+			await writeFile( tempPath, content );
+			// @ts-expect-error promisify doesn't seem typed properly.
+			await sudoExec( `cat ${ tempPath } > ${ hostsPath }`, {
+				name: 'WordPress Studio',
+			} );
+		} else {
+			// For Linux, we also need sudo
+			const tempPath = '/tmp/wp-studio-hosts';
+			await writeFile( tempPath, content );
+			// @ts-expect-error promisify doesn't seem typed properly.
+			await sudoExec( `cat ${ tempPath } > ${ hostsPath }`, {
+				name: 'WordPress Studio',
+			} );
+		}
+	} catch ( error ) {
+		console.error( 'Error writing hosts file:', error );
+		throw error;
+	}
+};
+
+/**
+ * Adds a domain to the hosts file pointing to 127.0.0.1
+ */
+export const addDomainToHosts = async ( domain: string, port: number ): Promise< void > => {
+	try {
+		const hostsContent = await readHostsFile();
+
+		// Check if the domain is already in the hosts file
+		const domainRegex = new RegExp( `127\\.0\\.0\\.1\\s+${ domain.replace( /\./g, '\\.' ) }`, 'i' );
+		if ( domainRegex.test( hostsContent ) ) {
+			return; // Domain already exists
+		}
+
+		// Add the domain entry with comment showing the port for reference
+		const newEntry = `\n# Added by WordPress Studio (Port: ${ port })\n127.0.0.1\t${ domain }`;
+		const newContent = hostsContent + newEntry;
+
+		await writeHostsFile( newContent );
+	} catch ( error ) {
+		console.error( `Error adding domain ${ domain } to hosts file:`, error );
+		throw error;
+	}
+};
+
+/**
+ * Removes a domain from the hosts file
+ */
+export const removeDomainFromHosts = async ( domain: string ): Promise< void > => {
+	try {
+		const hostsContent = await readHostsFile();
+
+		// Remove the domain entry and the comment line
+		// Match both formats of comments (with and without port)
+		const pattern = new RegExp(
+			`\\n# Added by WordPress Studio(?: \\(Port: \\d+\\))?\\n127\\.0\\.0\\.1\\s+${ domain.replace(
+				/\./g,
+				'\\.'
+			) }`,
+			'i'
+		);
+		const newContent = hostsContent.replace( pattern, '' );
+
+		if ( newContent !== hostsContent ) {
+			await writeHostsFile( newContent );
+		}
+	} catch ( error ) {
+		console.error( `Error removing domain ${ domain } from hosts file:`, error );
+		throw error;
+	}
+};

--- a/src/lib/hosts-file.ts
+++ b/src/lib/hosts-file.ts
@@ -45,8 +45,6 @@ export const readHostsFile = async (): Promise< string > => {
  */
 export const writeHostsFile = async ( content: string ): Promise< void > => {
 	const hostsPath = getHostsFilePath();
-	const currentPlatform = platform();
-
 	try {
 		const tempPath = '/tmp/wp-studio-hosts';
 		await writeFile( tempPath, content );

--- a/src/lib/hosts-file.ts
+++ b/src/lib/hosts-file.ts
@@ -66,14 +66,48 @@ export const addDomainToHosts = async ( domain: string, port: number ): Promise<
 		const hostsContent = await readHostsFile();
 
 		// Check if the domain is already in the hosts file
-		const domainRegex = new RegExp( `127\\.0\\.0\\.1\\s+${ domain.replace( /\./g, '\\.' ) }`, 'i' );
+		const domainRegex = new RegExp(
+			`^127\\.0\\.0\\.1\\s+${ domain.replace( /\./g, '\\.' ) }`,
+			'i'
+		);
 		if ( domainRegex.test( hostsContent ) ) {
 			return; // Domain already exists
 		}
 
-		// Add the domain entry with comment showing the port for reference
-		const newEntry = `\n# Added by WordPress Studio (Port: ${ port })\n127.0.0.1\t${ domain }`;
-		const newContent = hostsContent + newEntry;
+		// Define markers for WordPress Studio block
+		const beginMarker = '# BEGIN WordPress Studio';
+		const endMarker = '# END WordPress Studio';
+
+		// Create the domain entry with port reference
+		const domainEntry = `127.0.0.1\t${ domain } # Port: ${ port }`;
+
+		// Check if WordPress Studio block already exists
+		// Use non-greedy matching to avoid capturing multiple blocks at once
+		const blockRegex = new RegExp( `(${ beginMarker })[\\s\\S]*?(${ endMarker })` );
+		const blockMatch = hostsContent.match( blockRegex );
+
+		let newContent;
+
+		if ( blockMatch ) {
+			// Extract existing entries between markers
+			const existingBlock = blockMatch[ 0 ];
+			const entries = existingBlock
+				.split( '\n' )
+				.filter( ( line ) => line !== beginMarker && line !== endMarker && line.trim() !== '' );
+
+			// Add new entry to entries
+			entries.push( domainEntry );
+
+			// Create updated block with entries
+			const updatedBlock = `${ beginMarker }\n${ entries.join( '\n' ) }\n${ endMarker }`;
+
+			// Replace old block with updated block
+			newContent = hostsContent.replace( blockRegex, updatedBlock );
+		} else {
+			// Create new block with the domain entry
+			const newBlock = `\n\n${ beginMarker }\n${ domainEntry }\n${ endMarker }\n`;
+			newContent = hostsContent + newBlock;
+		}
 
 		await writeHostsFile( newContent );
 	} catch ( error ) {
@@ -89,17 +123,50 @@ export const removeDomainFromHosts = async ( domain: string ): Promise< void > =
 	try {
 		const hostsContent = await readHostsFile();
 
-		// Remove the domain entry and the comment line
-		// Match both formats of comments (with and without port)
-		const pattern = new RegExp(
-			`\\n# Added by WordPress Studio(?: \\(Port: \\d+\\))?\\n127\\.0\\.0\\.1\\s+${ domain.replace(
-				/\./g,
-				'\\.'
-			) }`,
+		// Check if the domain is already in the hosts file
+		const domainRegex = new RegExp(
+			`^127\\.0\\.0\\.1\\s+${ domain.replace( /\./g, '\\.' ) }`,
 			'i'
 		);
-		const newContent = hostsContent.replace( pattern, '' );
+		if ( ! domainRegex.test( hostsContent ) ) {
+			return; // Domain doesn't exist
+		}
 
+		// All WordPress Studio entries will be grouped in a block
+		const beginMarker = '# BEGIN WordPress Studio';
+		const endMarker = '# END WordPress Studio';
+
+		// Find the Studio block, if any. For performance, avoid greedy
+		// searches; there should only be a small block anyway.
+		const blockRegex = new RegExp( `(${ beginMarker })[\\s\\S]*?(${ endMarker })` );
+		const blockMatch = hostsContent.match( blockRegex );
+
+		let newContent = hostsContent;
+
+		if ( blockMatch ) {
+			// Split into lines to remove domain entry
+			const block = blockMatch[ 0 ];
+			const lines = block.split( '\n' );
+			const remainingLines = lines.filter(
+				( line ) =>
+					line === beginMarker ||
+					line === endMarker ||
+					( line.trim() !== '' && ! domainRegex.test( line ) )
+			);
+
+			if ( remainingLines.length <= 2 ) {
+				// Only markers left, remove entire block
+				newContent = newContent.replace( block, '' );
+				// Clean up extra newlines
+				newContent = newContent.replace( /\n\n\n+/g, '\n\n' );
+			} else {
+				// Create updated block with remaining entries
+				const updatedBlock = remainingLines.join( '\n' );
+				newContent = newContent.replace( block, updatedBlock );
+			}
+		}
+
+		// Only write if content changed
 		if ( newContent !== hostsContent ) {
 			await writeHostsFile( newContent );
 		}

--- a/src/lib/hosts-file.ts
+++ b/src/lib/hosts-file.ts
@@ -3,6 +3,7 @@ import { domainToASCII } from 'node:url';
 import { platform, tmpdir } from 'os';
 import path from 'path';
 import { promisify } from 'util';
+import * as Sentry from '@sentry/electron/main';
 import sudo from 'sudo-prompt';
 
 const readFile = promisify( fs.readFile );
@@ -96,6 +97,7 @@ export const addDomainToHosts = async ( domain: string, port: number ): Promise<
 			await writeHostsFile( newContent );
 		}
 	} catch ( error ) {
+		Sentry.captureException( error );
 		console.error( `Error adding domain ${ domain } to hosts file:`, error );
 		throw error;
 	}
@@ -119,6 +121,7 @@ export const removeDomainFromHosts = async ( domain: string ): Promise< void > =
 			await writeHostsFile( newContent );
 		}
 	} catch ( error ) {
+		Sentry.captureException( error );
 		console.error( `Error removing domain ${ domain } from hosts file:`, error );
 		throw error;
 	}

--- a/src/lib/hosts-file.ts
+++ b/src/lib/hosts-file.ts
@@ -68,7 +68,7 @@ export const writeHostsFile = async ( content: string ): Promise< void > => {
 /**
  * Create a regular expression matching the hosts entry for a given domain:
  *
- * 	127.0.0.1 foo.wp.cloud # Port 8000 (WordPress Studio)
+ * 	127.0.0.1 foo.wp.cloud # Port 8000
  */
 function createHostsEntryPattern( domain: string ): RegExp {
 	return new RegExp( `127\\.0\\.0\\.1\\s+${ domain.replace( /\./g, '\\.' ) }(\\s|$)`, 'i' );

--- a/src/lib/hosts-file.ts
+++ b/src/lib/hosts-file.ts
@@ -10,7 +10,7 @@ const sudoExec = promisify( sudo.exec );
 
 // Host file paths for different operating systems
 const HOST_FILES: Record< string, string > = {
-	win32: 'C:\\Windows\\System32\\drivers\\etc\\hosts',
+	win32: path.resolve( process.env.SystemRoot ?? 'C:\\Windows', 'System32\\drivers\\etc\\hosts' ),
 	darwin: '/etc/hosts',
 	linux: '/etc/hosts',
 };

--- a/src/lib/hosts-file.ts
+++ b/src/lib/hosts-file.ts
@@ -49,8 +49,12 @@ export const writeHostsFile = async ( content: string ): Promise< void > => {
 	try {
 		const tempPath = path.join( tmpdir(), 'wp-studio-hosts' );
 		await writeFile( tempPath, content );
+		const command =
+			platform() === 'win32'
+				? `type ${ tempPath } > ${ hostsPath }`
+				: `cat ${ tempPath } > ${ hostsPath }`;
 		// @ts-expect-error promisify doesn't seem typed properly.
-		await sudoExec( `cat ${ tempPath } > ${ hostsPath }`, {
+		await sudoExec( command, {
 			name: 'WordPress Studio',
 		} );
 	} catch ( error ) {

--- a/src/lib/proxy-server.ts
+++ b/src/lib/proxy-server.ts
@@ -52,7 +52,7 @@ async function startDomainProxy(): Promise< boolean > {
 		const proxy = httpProxy.createProxyServer();
 
 		proxy.on( 'error', ( err, req, res ) => {
-			if ( res && 'writeHead' in res ) {
+			if ( res && res instanceof http.ServerResponse ) {
 				res.writeHead( 500 );
 				res.end( 'Proxy error: ' + err.message );
 			}
@@ -79,7 +79,7 @@ async function startDomainProxy(): Promise< boolean > {
 
 			if ( ! site.running ) {
 				res.writeHead( 404 );
-				res.end( `The Studio site is currently stopped: ${ host }` );
+				res.end( `The Studio site is currently stopped: ${ site.name }` );
 				return;
 			}
 

--- a/src/lib/proxy-server.ts
+++ b/src/lib/proxy-server.ts
@@ -36,12 +36,12 @@ export async function startProxyServer(): Promise< boolean > {
 
 	try {
 		// First, try starting on a privileged port directly (might work if app has permissions)
-		const result = await startProxyDirectly();
+		const result = await startDomainProxy();
 		if ( result ) {
 			return true;
 		}
 
-		// If direct start fails, attempt with sudo/admin privileges
+		// If direct start fails and we're not skipping elevation, attempt with sudo/admin privileges
 		return await startProxyWithElevation();
 	} catch ( error ) {
 		console.error( 'Failed to start proxy server:', error );
@@ -51,8 +51,9 @@ export async function startProxyServer(): Promise< boolean > {
 
 /**
  * Attempts to start the proxy server directly (without privilege elevation)
+ * @param {number} port - The port to listen on (defaults to 80)
  */
-async function startProxyDirectly(): Promise< boolean > {
+async function startDomainProxy( port: number = 80 ): Promise< boolean > {
 	try {
 		// Create proxy with additional options to preserve host header
 		const proxy = httpProxy.createProxyServer();
@@ -98,20 +99,20 @@ async function startProxyDirectly(): Promise< boolean > {
 
 		await new Promise< void >( ( resolve, reject ) => {
 			proxyServer!
-				.listen( 80, () => {
-					console.log( 'Proxy server started on port 80' );
+				.listen( port, () => {
+					console.log( `Proxy server started on port ${ port }` );
 					isProxyRunning = true;
 					resolve();
 				} )
 				.on( 'error', ( err ) => {
-					console.error( 'Error starting proxy server on port 80:', err );
+					console.error( `Error starting proxy server on port ${ port }:`, err );
 					reject( err );
 				} );
 		} );
 
 		return true;
 	} catch ( error ) {
-		console.error( 'Failed to start proxy server directly:', error );
+		console.error( `Failed to start proxy server directly:`, error );
 		return false;
 	}
 }
@@ -122,23 +123,38 @@ async function startProxyDirectly(): Promise< boolean > {
 async function startProxyWithElevation(): Promise< boolean > {
 	const currentPlatform = platform();
 
-	// We need to create a separate script that can be run with elevated privileges
 	try {
 		console.log( 'Attempting to start proxy server with elevated privileges' );
 
-		// For now, this is a simplified implementation
-		// In a full solution, we would need a more sophisticated approach for each platform
-		const command =
-			currentPlatform === 'win32'
-				? 'netsh interface portproxy add v4tov4 listenport=80 listenaddress=127.0.0.1 connectport=8880 connectaddress=127.0.0.1'
-				: 'sudo -p "Enter password to start proxy server: " node -e "require(\'http\').createServer((req, res) => { res.end(\'hello\') }).listen(80)"';
+		if ( currentPlatform === 'win32' ) {
+			// For Windows: First start the actual proxy on a non-privileged port (8880)
+			const proxyStarted = await startDomainProxy( 8880 );
+			if ( ! proxyStarted ) {
+				console.error( 'Failed to start proxy server on port 8880' );
+				return false;
+			}
 
-		// @ts-expect-error promisify doesn't seem typed properly.
-		await sudoExec( command, { name: 'WordPress Studio Proxy' } );
+			// Then use netsh to forward from privileged port 80 to our proxy on 8880
+			const command =
+				'netsh interface portproxy add v4tov4 listenport=80 listenaddress=127.0.0.1 connectport=8880 connectaddress=127.0.0.1';
 
-		// If we get here, assume the proxy was started successfully
-		isProxyRunning = true;
-		return true;
+			try {
+				// @ts-expect-error promisify doesn't seem typed properly.
+				await sudoExec( command, { name: 'WordPress Studio Proxy' } );
+				console.log( 'Successfully set up port forwarding from port 80 to 8880' );
+				return true;
+			} catch ( error ) {
+				console.error( 'Failed to set up port forwarding:', error );
+				// Even though port forwarding failed, we still have a working proxy on 8880
+				return proxyStarted;
+			}
+		} else {
+			// For Mac/Linux: Use sudo to run a command that starts a proxy directly on port 80
+			// This is a more complex solution that would require a proper script
+			// For now, we'll just return false and let the app fall back to non-privileged ports
+			console.log( 'Elevated privileges for Mac/Linux not fully implemented yet' );
+			return false;
+		}
 	} catch ( error ) {
 		console.error( 'Failed to start proxy with elevated privileges:', error );
 		return false;

--- a/src/lib/proxy-server.ts
+++ b/src/lib/proxy-server.ts
@@ -125,35 +125,36 @@ async function startProxyWithElevation(): Promise< boolean > {
 
 	try {
 		console.log( 'Attempting to start proxy server with elevated privileges' );
-
-		if ( currentPlatform === 'win32' ) {
-			// For Windows: First start the actual proxy on a non-privileged port (8880)
-			const proxyStarted = await startDomainProxy( 8880 );
-			if ( ! proxyStarted ) {
-				console.error( 'Failed to start proxy server on port 8880' );
-				return false;
-			}
-
-			// Then use netsh to forward from privileged port 80 to our proxy on 8880
-			const command =
-				'netsh interface portproxy add v4tov4 listenport=80 listenaddress=127.0.0.1 connectport=8880 connectaddress=127.0.0.1';
-
-			try {
-				// @ts-expect-error promisify doesn't seem typed properly.
-				await sudoExec( command, { name: 'WordPress Studio Proxy' } );
-				console.log( 'Successfully set up port forwarding from port 80 to 8880' );
-				return true;
-			} catch ( error ) {
-				console.error( 'Failed to set up port forwarding:', error );
-				// Even though port forwarding failed, we still have a working proxy on 8880
-				return proxyStarted;
-			}
-		} else {
-			// For Mac/Linux: Use sudo to run a command that starts a proxy directly on port 80
-			// This is a more complex solution that would require a proper script
-			// For now, we'll just return false and let the app fall back to non-privileged ports
-			console.log( 'Elevated privileges for Mac/Linux not fully implemented yet' );
+		// First start the actual proxy on a non-privileged port (8880)
+		const proxyStarted = await startDomainProxy( 8880 );
+		if ( ! proxyStarted ) {
+			console.error( 'Failed to start proxy server on port 8880' );
 			return false;
+		}
+
+		// Then use netsh or iptables to forward from privileged port 80 to our proxy on 8880
+		const elevatedProxyCommands: Record< string, string > = {
+			win32:
+				'netsh interface portproxy add v4tov4 listenport=80 listenaddress=127.0.0.1 connectport=8880 connectaddress=127.0.0.1',
+			darwin:
+				'echo "rdr pass inet proto tcp from any to any port 80 -> 127.0.0.1 port 8880" | sudo pfctl -ef -',
+			linux: 'iptables -t nat -A PREROUTING -p tcp --dport 80 -j REDIRECT --to-port 8880',
+		};
+		const command = elevatedProxyCommands[ currentPlatform ];
+		if ( ! command ) {
+			console.error( 'Elevated privileges not supported on this platform' );
+			return false;
+		}
+
+		try {
+			// @ts-expect-error promisify doesn't seem typed properly.
+			await sudoExec( command, { name: 'WordPress Studio Proxy' } );
+			console.log( 'Successfully set up port forwarding from port 80 to 8880' );
+			return true;
+		} catch ( error ) {
+			console.error( 'Failed to set up port forwarding:', error );
+			// Even though port forwarding failed, we still have a working proxy on 8880
+			return proxyStarted;
 		}
 	} catch ( error ) {
 		console.error( 'Failed to start proxy with elevated privileges:', error );

--- a/src/lib/proxy-server.ts
+++ b/src/lib/proxy-server.ts
@@ -8,14 +8,14 @@ let isProxyRunning = false;
 /**
  * Gets the port number for a given domain by looking it up in user data
  */
-async function getPortForDomain( domain: string ): Promise< number | null > {
+async function getSiteByHost( domain: string ): Promise< SiteDetails | null > {
 	try {
 		const userData = await loadUserData();
 		// Find the site with the matching custom domain
 		const site = userData.sites.find(
 			( site ) => site.useCustomDomain && site.customDomain === domain
 		);
-		return site ? site.port : null;
+		return site ? site : null;
 	} catch ( error ) {
 		console.error( 'Error looking up domain in user data:', error );
 		return null;
@@ -63,17 +63,23 @@ async function startDomainProxy(): Promise< boolean > {
 				return;
 			}
 
-			const port = await getPortForDomain( host );
-			if ( ! port ) {
+			const site = await getSiteByHost( host );
+			if ( ! site ) {
 				console.log( `Domain not found: ${ host }` );
 				res.writeHead( 404 );
 				res.end( `Domain not found: ${ host }` );
 				return;
 			}
 
+			if ( ! site.running ) {
+				res.writeHead( 404 );
+				res.end( `The Studio site is currently stopped: ${ host }` );
+				return;
+			}
+
 			// Forward the request with the original host preserved
 			proxy.web( req, res, {
-				target: `http://localhost:${ port }`,
+				target: `http://localhost:${ site.port }`,
 				xfwd: true, // Pass along x-forwarded headers
 			} );
 		} );

--- a/src/lib/proxy-server.ts
+++ b/src/lib/proxy-server.ts
@@ -46,7 +46,6 @@ async function startDomainProxy(): Promise< boolean > {
 		const proxy = httpProxy.createProxyServer();
 
 		proxy.on( 'error', ( err, req, res ) => {
-			console.error( 'Proxy error:', err );
 			if ( res && 'writeHead' in res ) {
 				res.writeHead( 500 );
 				res.end( 'Proxy error: ' + err.message );

--- a/src/lib/proxy-server.ts
+++ b/src/lib/proxy-server.ts
@@ -1,18 +1,24 @@
 import http from 'http';
 import httpProxy from 'http-proxy';
+import { SiteServer } from 'src/site-server';
 import { loadUserData } from 'src/storage/user-data';
 
 let proxyServer: http.Server | null = null;
 let isProxyRunning = false;
 
 /**
- * Gets the port number for a given domain by looking it up in user data
+ * Gets the site details for a given domain by looking it up in user data and SiteServer
  */
 async function getSiteByHost( domain: string ): Promise< SiteDetails | null > {
 	try {
 		const userData = await loadUserData();
 		const site = userData.sites.find( ( site ) => site.customDomain === domain );
-		return site ? site : null;
+		if ( site ) {
+			const server = SiteServer.get( site.id );
+			return server ? server.details : null;
+		}
+
+		return null;
 	} catch ( error ) {
 		console.error( 'Error looking up domain in user data:', error );
 		return null;

--- a/src/lib/proxy-server.ts
+++ b/src/lib/proxy-server.ts
@@ -1,5 +1,6 @@
 import http from 'http';
 import { domainToASCII } from 'node:url';
+import * as Sentry from '@sentry/electron/main';
 import httpProxy from 'http-proxy';
 import { SiteServer } from 'src/site-server';
 import { loadUserData } from 'src/storage/user-data';
@@ -105,6 +106,7 @@ async function startDomainProxy(): Promise< boolean > {
 
 		return true;
 	} catch ( error ) {
+		Sentry.captureException( error );
 		console.error( `Failed to start proxy server directly:`, error );
 		return false;
 	}

--- a/src/lib/proxy-server.ts
+++ b/src/lib/proxy-server.ts
@@ -1,6 +1,8 @@
+import { dialog } from 'electron';
 import http from 'http';
 import { domainToASCII } from 'node:url';
 import * as Sentry from '@sentry/electron/main';
+import { __ } from '@wordpress/i18n';
 import httpProxy from 'http-proxy';
 import { SiteServer } from 'src/site-server';
 import { loadUserData } from 'src/storage/user-data';
@@ -30,24 +32,11 @@ async function getSiteByHost( domain: string ): Promise< SiteDetails | null > {
 }
 
 /**
- * Attempts to start the proxy server on port 80
- * This requires admin/root privileges
+ * Starts the proxy server for sites with custom domains
  */
 export async function startProxyServer(): Promise< boolean > {
 	if ( isProxyRunning ) return true;
 
-	try {
-		return await startDomainProxy();
-	} catch ( error ) {
-		console.error( 'Failed to start proxy server:', error );
-		return false;
-	}
-}
-
-/**
- * Starts the proxy server for sites with custom domains
- */
-async function startDomainProxy(): Promise< boolean > {
 	try {
 		// Create proxy with additional options to preserve host header
 		const proxy = httpProxy.createProxyServer();
@@ -99,6 +88,7 @@ async function startDomainProxy(): Promise< boolean > {
 					resolve();
 				} )
 				.on( 'error', ( err ) => {
+					console.log( err );
 					console.error( `Error starting proxy server on port 80:`, err );
 					reject( err );
 				} );
@@ -106,6 +96,18 @@ async function startDomainProxy(): Promise< boolean > {
 
 		return true;
 	} catch ( error ) {
+		if ( error instanceof Error && 'code' in error && error.code === 'EADDRINUSE' ) {
+			dialog.showMessageBox( {
+				type: 'error',
+				message: __( 'Failed to start custom domain proxy server' ),
+				detail: __(
+					'Another server is already running on port 80. For custom domains to work, please stop that server and then restart Studio.'
+				),
+				buttons: [ __( 'OK' ) ],
+			} );
+			return false;
+		}
+
 		Sentry.captureException( error );
 		console.error( `Failed to start proxy server directly:`, error );
 		return false;

--- a/src/lib/proxy-server.ts
+++ b/src/lib/proxy-server.ts
@@ -11,10 +11,7 @@ let isProxyRunning = false;
 async function getSiteByHost( domain: string ): Promise< SiteDetails | null > {
 	try {
 		const userData = await loadUserData();
-		// Find the site with the matching custom domain
-		const site = userData.sites.find(
-			( site ) => site.useCustomDomain && site.customDomain === domain
-		);
+		const site = userData.sites.find( ( site ) => site.customDomain === domain );
 		return site ? site : null;
 	} catch ( error ) {
 		console.error( 'Error looking up domain in user data:', error );

--- a/src/lib/proxy-server.ts
+++ b/src/lib/proxy-server.ts
@@ -1,11 +1,6 @@
 import http from 'http';
-import { platform } from 'os';
-import { promisify } from 'util';
 import httpProxy from 'http-proxy';
-import sudo from 'sudo-prompt';
 import { loadUserData } from 'src/storage/user-data';
-
-const sudoExec = promisify( sudo.exec );
 
 let proxyServer: http.Server | null = null;
 let isProxyRunning = false;
@@ -35,14 +30,7 @@ export async function startProxyServer(): Promise< boolean > {
 	if ( isProxyRunning ) return true;
 
 	try {
-		// First, try starting on a privileged port directly (might work if app has permissions)
-		const result = await startDomainProxy();
-		if ( result ) {
-			return true;
-		}
-
-		// If direct start fails and we're not skipping elevation, attempt with sudo/admin privileges
-		return await startProxyWithElevation();
+		return await startDomainProxy();
 	} catch ( error ) {
 		console.error( 'Failed to start proxy server:', error );
 		return false;
@@ -51,9 +39,8 @@ export async function startProxyServer(): Promise< boolean > {
 
 /**
  * Attempts to start the proxy server directly (without privilege elevation)
- * @param {number} port - The port to listen on (defaults to 80)
  */
-async function startDomainProxy( port: number = 80 ): Promise< boolean > {
+async function startDomainProxy(): Promise< boolean > {
 	try {
 		// Create proxy with additional options to preserve host header
 		const proxy = httpProxy.createProxyServer();
@@ -94,13 +81,13 @@ async function startDomainProxy( port: number = 80 ): Promise< boolean > {
 
 		await new Promise< void >( ( resolve, reject ) => {
 			proxyServer!
-				.listen( port, () => {
-					console.log( `Proxy server started on port ${ port }` );
+				.listen( 80, () => {
+					console.log( `Proxy server started on port 80` );
 					isProxyRunning = true;
 					resolve();
 				} )
 				.on( 'error', ( err ) => {
-					console.error( `Error starting proxy server on port ${ port }:`, err );
+					console.error( `Error starting proxy server on port 80:`, err );
 					reject( err );
 				} );
 		} );
@@ -108,51 +95,6 @@ async function startDomainProxy( port: number = 80 ): Promise< boolean > {
 		return true;
 	} catch ( error ) {
 		console.error( `Failed to start proxy server directly:`, error );
-		return false;
-	}
-}
-
-/**
- * Attempts to start the proxy server with elevated privileges
- */
-async function startProxyWithElevation(): Promise< boolean > {
-	const currentPlatform = platform();
-
-	try {
-		console.log( 'Attempting to start proxy server with elevated privileges' );
-		// First start the actual proxy on a non-privileged port (8880)
-		const proxyStarted = await startDomainProxy( 8880 );
-		if ( ! proxyStarted ) {
-			console.error( 'Failed to start proxy server on port 8880' );
-			return false;
-		}
-
-		// Then use netsh or iptables to forward from privileged port 80 to our proxy on 8880
-		const elevatedProxyCommands: Record< string, string > = {
-			win32:
-				'netsh interface portproxy add v4tov4 listenport=80 listenaddress=127.0.0.1 connectport=8880 connectaddress=127.0.0.1',
-			darwin:
-				'echo "rdr pass inet proto tcp from any to any port 80 -> 127.0.0.1 port 8880" | sudo pfctl -ef -',
-			linux: 'iptables -t nat -A PREROUTING -p tcp --dport 80 -j REDIRECT --to-port 8880',
-		};
-		const command = elevatedProxyCommands[ currentPlatform ];
-		if ( ! command ) {
-			console.error( 'Elevated privileges not supported on this platform' );
-			return false;
-		}
-
-		try {
-			// @ts-expect-error promisify doesn't seem typed properly.
-			await sudoExec( command, { name: 'WordPress Studio Proxy' } );
-			console.log( 'Successfully set up port forwarding from port 80 to 8880' );
-			return true;
-		} catch ( error ) {
-			console.error( 'Failed to set up port forwarding:', error );
-			// Even though port forwarding failed, we still have a working proxy on 8880
-			return proxyStarted;
-		}
-	} catch ( error ) {
-		console.error( 'Failed to start proxy with elevated privileges:', error );
 		return false;
 	}
 }

--- a/src/lib/proxy-server.ts
+++ b/src/lib/proxy-server.ts
@@ -69,9 +69,6 @@ async function startDomainProxy( port: number = 80 ): Promise< boolean > {
 		proxyServer = http.createServer( async ( req, res ) => {
 			const host = req.headers.host?.split( ':' )[ 0 ]; // Remove port if present
 
-			// Log incoming request information for debugging
-			console.log( `Received request with host header: ${ host }` );
-
 			// Look up the port directly from user data
 			if ( ! host ) {
 				console.log( 'No host header found' );
@@ -87,8 +84,6 @@ async function startDomainProxy( port: number = 80 ): Promise< boolean > {
 				res.end( `Domain not found: ${ host }` );
 				return;
 			}
-
-			console.log( `Proxying request for ${ host } to port ${ port }` );
 
 			// Forward the request with the original host preserved
 			proxy.web( req, res, {

--- a/src/lib/proxy-server.ts
+++ b/src/lib/proxy-server.ts
@@ -38,7 +38,7 @@ export async function startProxyServer(): Promise< boolean > {
 }
 
 /**
- * Attempts to start the proxy server directly (without privilege elevation)
+ * Starts the proxy server for sites with custom domains
  */
 async function startDomainProxy(): Promise< boolean > {
 	try {

--- a/src/lib/proxy-server.ts
+++ b/src/lib/proxy-server.ts
@@ -1,4 +1,5 @@
 import http from 'http';
+import { domainToASCII } from 'node:url';
 import httpProxy from 'http-proxy';
 import { SiteServer } from 'src/site-server';
 import { loadUserData } from 'src/storage/user-data';
@@ -12,7 +13,9 @@ let isProxyRunning = false;
 async function getSiteByHost( domain: string ): Promise< SiteDetails | null > {
 	try {
 		const userData = await loadUserData();
-		const site = userData.sites.find( ( site ) => site.customDomain === domain );
+		const site = userData.sites.find(
+			( site ) => domainToASCII( site.customDomain ?? '' ) === domainToASCII( domain )
+		);
 		if ( site ) {
 			const server = SiteServer.get( site.id );
 			return server ? server.details : null;

--- a/src/lib/proxy-server.ts
+++ b/src/lib/proxy-server.ts
@@ -1,0 +1,173 @@
+import http from 'http';
+import { platform } from 'os';
+import { promisify } from 'util';
+import httpProxy from 'http-proxy';
+import sudo from 'sudo-prompt';
+import { loadUserData } from 'src/storage/user-data';
+
+const sudoExec = promisify( sudo.exec );
+
+let proxyServer: http.Server | null = null;
+let isProxyRunning = false;
+
+/**
+ * Gets the port number for a given domain by looking it up in user data
+ */
+async function getPortForDomain( domain: string ): Promise< number | null > {
+	try {
+		const userData = await loadUserData();
+		// Find the site with the matching custom domain
+		const site = userData.sites.find(
+			( site ) => site.useCustomDomain && site.customDomain === domain
+		);
+		return site ? site.port : null;
+	} catch ( error ) {
+		console.error( 'Error looking up domain in user data:', error );
+		return null;
+	}
+}
+
+/**
+ * Attempts to start the proxy server on port 80
+ * This requires admin/root privileges
+ */
+export async function startProxyServer(): Promise< boolean > {
+	if ( isProxyRunning ) return true;
+
+	try {
+		// First, try starting on a privileged port directly (might work if app has permissions)
+		const result = await startProxyDirectly();
+		if ( result ) {
+			return true;
+		}
+
+		// If direct start fails, attempt with sudo/admin privileges
+		return await startProxyWithElevation();
+	} catch ( error ) {
+		console.error( 'Failed to start proxy server:', error );
+		return false;
+	}
+}
+
+/**
+ * Attempts to start the proxy server directly (without privilege elevation)
+ */
+async function startProxyDirectly(): Promise< boolean > {
+	try {
+		// Create proxy with additional options to preserve host header
+		const proxy = httpProxy.createProxyServer();
+
+		proxy.on( 'error', ( err, req, res ) => {
+			console.error( 'Proxy error:', err );
+			if ( res && 'writeHead' in res ) {
+				res.writeHead( 500 );
+				res.end( 'Proxy error: ' + err.message );
+			}
+		} );
+
+		proxyServer = http.createServer( async ( req, res ) => {
+			const host = req.headers.host?.split( ':' )[ 0 ]; // Remove port if present
+
+			// Log incoming request information for debugging
+			console.log( `Received request with host header: ${ host }` );
+
+			// Look up the port directly from user data
+			if ( ! host ) {
+				console.log( 'No host header found' );
+				res.writeHead( 404 );
+				res.end( 'No host header found' );
+				return;
+			}
+
+			const port = await getPortForDomain( host );
+			if ( ! port ) {
+				console.log( `Domain not found: ${ host }` );
+				res.writeHead( 404 );
+				res.end( `Domain not found: ${ host }` );
+				return;
+			}
+
+			console.log( `Proxying request for ${ host } to port ${ port }` );
+
+			// Forward the request with the original host preserved
+			proxy.web( req, res, {
+				target: `http://localhost:${ port }`,
+				xfwd: true, // Pass along x-forwarded headers
+			} );
+		} );
+
+		await new Promise< void >( ( resolve, reject ) => {
+			proxyServer!
+				.listen( 80, () => {
+					console.log( 'Proxy server started on port 80' );
+					isProxyRunning = true;
+					resolve();
+				} )
+				.on( 'error', ( err ) => {
+					console.error( 'Error starting proxy server on port 80:', err );
+					reject( err );
+				} );
+		} );
+
+		return true;
+	} catch ( error ) {
+		console.error( 'Failed to start proxy server directly:', error );
+		return false;
+	}
+}
+
+/**
+ * Attempts to start the proxy server with elevated privileges
+ */
+async function startProxyWithElevation(): Promise< boolean > {
+	const currentPlatform = platform();
+
+	// We need to create a separate script that can be run with elevated privileges
+	try {
+		console.log( 'Attempting to start proxy server with elevated privileges' );
+
+		// For now, this is a simplified implementation
+		// In a full solution, we would need a more sophisticated approach for each platform
+		const command =
+			currentPlatform === 'win32'
+				? 'netsh interface portproxy add v4tov4 listenport=80 listenaddress=127.0.0.1 connectport=8880 connectaddress=127.0.0.1'
+				: 'sudo -p "Enter password to start proxy server: " node -e "require(\'http\').createServer((req, res) => { res.end(\'hello\') }).listen(80)"';
+
+		// @ts-expect-error promisify doesn't seem typed properly.
+		await sudoExec( command, { name: 'WordPress Studio Proxy' } );
+
+		// If we get here, assume the proxy was started successfully
+		isProxyRunning = true;
+		return true;
+	} catch ( error ) {
+		console.error( 'Failed to start proxy with elevated privileges:', error );
+		return false;
+	}
+}
+
+/**
+ * Stop the proxy server
+ */
+export function stopProxyServer(): Promise< void > {
+	return new Promise( ( resolve ) => {
+		if ( ! proxyServer ) {
+			isProxyRunning = false;
+			resolve();
+			return;
+		}
+
+		proxyServer.close( () => {
+			proxyServer = null;
+			isProxyRunning = false;
+			console.log( 'Proxy server stopped' );
+			resolve();
+		} );
+	} );
+}
+
+/**
+ * Check if the proxy server is running
+ */
+export function isProxyServerRunning(): boolean {
+	return isProxyRunning;
+}

--- a/src/lib/tests/hosts-file.test.ts
+++ b/src/lib/tests/hosts-file.test.ts
@@ -70,6 +70,33 @@ describe( 'hosts-file', () => {
 			);
 		} );
 
+		it( 'should add a new domain with special characters', async () => {
+			readFileCallbackMock.mockResolvedValueOnce( sampleHostsContent );
+
+			await addDomainToHosts( 'münchen.local', 8002 );
+
+			expect( readFile ).toHaveBeenCalled();
+			expect( writeFile ).toHaveBeenCalled();
+
+			const newContent = ( writeFile as unknown as jest.Mock ).mock.calls[ 0 ][ 1 ];
+
+			expect( newContent ).toEqual(
+				`127.0.0.1 localhost
+::1 localhost
+
+# Some comment
+
+# BEGIN WordPress Studio
+127.0.0.1 foo.wp.cloud # Port 8000
+127.0.0.1 bar.wp.cloud # Port 8001
+127.0.0.1 xn--mnchen-3ya.local # Port 8002
+# END WordPress Studio
+
+# Other entries
+192.168.1.1 router`
+			);
+		} );
+
 		it( 'should not add duplicate domains', async () => {
 			readFileCallbackMock.mockResolvedValueOnce( sampleHostsContent );
 			await addDomainToHosts( 'foo.wp.cloud', 8000 );

--- a/src/lib/tests/hosts-file.test.ts
+++ b/src/lib/tests/hosts-file.test.ts
@@ -1,0 +1,167 @@
+import { readFile, writeFile } from 'fs';
+import { addDomainToHosts, removeDomainFromHosts } from '../hosts-file';
+
+const readFileCallbackMock = jest.fn();
+
+jest.mock( 'fs', () => ( {
+	readFile: jest.fn( ( path, encoding, callback ) => {
+		callback( null, readFileCallbackMock() );
+	} ),
+	writeFile: jest.fn( ( path, data, callback ) => {
+		callback( null );
+	} ),
+} ) );
+
+jest.mock( 'sudo-prompt', () => {
+	return {
+		exec: jest.fn( ( command, options, callback ) => {
+			callback( null, 'Mocked output' );
+		} ),
+	};
+} );
+
+jest.spyOn( console, 'error' ).mockImplementation( () => {} );
+
+describe( 'hosts-file', () => {
+	// Sample hosts file content for testing
+	const sampleHostsContent = `127.0.0.1 localhost
+::1 localhost
+
+# Some comment
+
+# BEGIN WordPress Studio
+127.0.0.1 foo.wp.cloud # Port 8000 (WordPress Studio)
+127.0.0.1 bar.wp.cloud # Port 8001 (WordPress Studio)
+# END WordPress Studio
+
+# Other entries
+192.168.1.1 router`;
+
+	// Setup before each test
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	describe( 'addDomainToHosts', () => {
+		it( 'should add a new domain to the hosts file', async () => {
+			readFileCallbackMock.mockResolvedValueOnce( sampleHostsContent );
+
+			await addDomainToHosts( 'new-domain.wp.cloud', 8002 );
+
+			expect( readFile ).toHaveBeenCalled();
+			expect( writeFile ).toHaveBeenCalled();
+
+			const newContent = ( writeFile as unknown as jest.Mock ).mock.calls[ 0 ][ 1 ];
+
+			expect( newContent ).toEqual(
+				`127.0.0.1 localhost
+::1 localhost
+
+# Some comment
+
+# BEGIN WordPress Studio
+127.0.0.1 foo.wp.cloud # Port 8000 (WordPress Studio)
+127.0.0.1 bar.wp.cloud # Port 8001 (WordPress Studio)
+127.0.0.1 new-domain.wp.cloud # Port 8002 (WordPress Studio)
+# END WordPress Studio
+
+# Other entries
+192.168.1.1 router`
+			);
+		} );
+
+		it( 'should not add duplicate domains', async () => {
+			readFileCallbackMock.mockResolvedValueOnce( sampleHostsContent );
+			await addDomainToHosts( 'foo.wp.cloud', 8000 );
+			expect( readFile ).toHaveBeenCalled();
+			expect( writeFile ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should create a new WordPress Studio block if none exists', async () => {
+			// Content without a WordPress Studio block
+			const contentWithoutBlock = `127.0.0.1 localhost
+::1 localhost
+
+# Some other entries
+192.168.1.1 router`;
+
+			readFileCallbackMock.mockResolvedValueOnce( contentWithoutBlock );
+
+			await addDomainToHosts( 'new-domain.wp.cloud', 8002 );
+
+			expect( writeFile ).toHaveBeenCalled();
+
+			const newContent = ( writeFile as unknown as jest.Mock ).mock.calls[ 0 ][ 1 ];
+			expect( newContent ).toEqual( `127.0.0.1 localhost
+::1 localhost
+
+# Some other entries
+192.168.1.1 router
+
+# BEGIN WordPress Studio
+127.0.0.1 new-domain.wp.cloud # Port 8002 (WordPress Studio)
+# END WordPress Studio` );
+		} );
+
+		it( 'should handle errors when reading the hosts file', async () => {
+			readFileCallbackMock.mockRejectedValueOnce( new Error( 'Failed to read file' ) );
+
+			await expect( addDomainToHosts( 'new-domain.wp.cloud', 8002 ) ).rejects.toThrow(
+				'Failed to read file'
+			);
+
+			expect( readFile ).toHaveBeenCalled();
+			expect( writeFile ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'removeDomainFromHosts', () => {
+		it( 'should remove an existing domain from the hosts file', async () => {
+			readFileCallbackMock.mockResolvedValueOnce( sampleHostsContent );
+
+			await removeDomainFromHosts( 'foo.wp.cloud' );
+
+			expect( readFile ).toHaveBeenCalled();
+			expect( writeFile ).toHaveBeenCalled();
+
+			const newContent = ( writeFile as unknown as jest.Mock ).mock.calls[ 0 ][ 1 ];
+
+			expect( newContent ).not.toContain( '127.0.0.1 foo.wp.cloud' );
+			expect( newContent ).toContain( '127.0.0.1 bar.wp.cloud' );
+		} );
+
+		it( 'should not modify the hosts file if domain not found', async () => {
+			readFileCallbackMock.mockResolvedValueOnce( sampleHostsContent );
+
+			await removeDomainFromHosts( 'nonexistent.wp.cloud' );
+
+			expect( readFile ).toHaveBeenCalled();
+			expect( writeFile ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should remove the entire WordPress Studio block if all domains are removed', async () => {
+			const contentWithSingleDomain = `127.0.0.1 localhost
+::1 localhost
+
+# BEGIN WordPress Studio
+127.0.0.1 foo.wp.cloud # Port 8000 (WordPress Studio)
+# END WordPress Studio`;
+
+			readFileCallbackMock.mockResolvedValueOnce( contentWithSingleDomain );
+
+			await removeDomainFromHosts( 'foo.wp.cloud' );
+
+			expect( writeFile ).toHaveBeenCalled();
+
+			const newContent = ( writeFile as unknown as jest.Mock ).mock.calls[ 0 ][ 1 ];
+
+			expect( newContent.trim() ).toEqual( '127.0.0.1 localhost\n::1 localhost' );
+		} );
+
+		it( 'should handle errors when reading the hosts file', async () => {
+			readFileCallbackMock.mockRejectedValueOnce( new Error( 'Read error' ) );
+
+			await expect( removeDomainFromHosts( 'test.wp.cloud' ) ).rejects.toThrow( 'Read error' );
+		} );
+	} );
+} );

--- a/src/lib/tests/hosts-file.test.ts
+++ b/src/lib/tests/hosts-file.test.ts
@@ -30,8 +30,8 @@ describe( 'hosts-file', () => {
 # Some comment
 
 # BEGIN WordPress Studio
-127.0.0.1 foo.wp.cloud # Port 8000 (WordPress Studio)
-127.0.0.1 bar.wp.cloud # Port 8001 (WordPress Studio)
+127.0.0.1 foo.wp.cloud # Port 8000
+127.0.0.1 bar.wp.cloud # Port 8001
 # END WordPress Studio
 
 # Other entries
@@ -60,9 +60,9 @@ describe( 'hosts-file', () => {
 # Some comment
 
 # BEGIN WordPress Studio
-127.0.0.1 foo.wp.cloud # Port 8000 (WordPress Studio)
-127.0.0.1 bar.wp.cloud # Port 8001 (WordPress Studio)
-127.0.0.1 new-domain.wp.cloud # Port 8002 (WordPress Studio)
+127.0.0.1 foo.wp.cloud # Port 8000
+127.0.0.1 bar.wp.cloud # Port 8001
+127.0.0.1 new-domain.wp.cloud # Port 8002
 # END WordPress Studio
 
 # Other entries
@@ -99,7 +99,7 @@ describe( 'hosts-file', () => {
 192.168.1.1 router
 
 # BEGIN WordPress Studio
-127.0.0.1 new-domain.wp.cloud # Port 8002 (WordPress Studio)
+127.0.0.1 new-domain.wp.cloud # Port 8002
 # END WordPress Studio` );
 		} );
 
@@ -144,7 +144,7 @@ describe( 'hosts-file', () => {
 ::1 localhost
 
 # BEGIN WordPress Studio
-127.0.0.1 foo.wp.cloud # Port 8000 (WordPress Studio)
+127.0.0.1 foo.wp.cloud # Port 8000
 # END WordPress Studio`;
 
 			readFileCallbackMock.mockResolvedValueOnce( contentWithSingleDomain );

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -23,13 +23,8 @@ const api: IpcApi = {
 	exportSiteToPush: ( id: string ) => ipcRenderer.invoke( 'exportSiteToPush', id ),
 	deleteSite: ( id: string, deleteFiles?: boolean ) =>
 		ipcRenderer.invoke( 'deleteSite', id, deleteFiles ),
-	createSite: (
-		path: string,
-		name?: string,
-		wpVersion?: string,
-		useCustomDomain?: boolean,
-		customDomain?: string
-	) => ipcRenderer.invoke( 'createSite', path, name, wpVersion, useCustomDomain, customDomain ),
+	createSite: ( path: string, name?: string, wpVersion?: string, customDomain?: string ) =>
+		ipcRenderer.invoke( 'createSite', path, name, wpVersion, customDomain ),
 	updateSite: ( updatedSite: SiteDetails ) => ipcRenderer.invoke( 'updateSite', updatedSite ),
 	connectWpcomSites: ( ...args ) => ipcRenderer.invoke( 'connectWpcomSites', ...args ),
 	disconnectWpcomSites: ( ...args ) => ipcRenderer.invoke( 'disconnectWpcomSites', ...args ),

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -23,8 +23,13 @@ const api: IpcApi = {
 	exportSiteToPush: ( id: string ) => ipcRenderer.invoke( 'exportSiteToPush', id ),
 	deleteSite: ( id: string, deleteFiles?: boolean ) =>
 		ipcRenderer.invoke( 'deleteSite', id, deleteFiles ),
-	createSite: ( path: string, name?: string, wpVersion?: string ) =>
-		ipcRenderer.invoke( 'createSite', path, name, wpVersion ),
+	createSite: (
+		path: string,
+		name?: string,
+		wpVersion?: string,
+		useCustomDomain?: boolean,
+		customDomain?: string
+	) => ipcRenderer.invoke( 'createSite', path, name, wpVersion, useCustomDomain, customDomain ),
 	updateSite: ( updatedSite: SiteDetails ) => ipcRenderer.invoke( 'updateSite', updatedSite ),
 	connectWpcomSites: ( ...args ) => ipcRenderer.invoke( 'connectWpcomSites', ...args ),
 	disconnectWpcomSites: ( ...args ) => ipcRenderer.invoke( 'disconnectWpcomSites', ...args ),

--- a/src/site-server.ts
+++ b/src/site-server.ts
@@ -4,6 +4,7 @@ import * as Sentry from '@sentry/electron/main';
 import fsExtra from 'fs-extra';
 import { parse } from 'shell-quote';
 import { pathExists, recursiveCopyDirectory, isEmptyDir } from 'src/lib/fs-utils';
+import { removeDomainFromHosts } from 'src/lib/hosts-file';
 import { decodePassword } from 'src/lib/passwords';
 import { phpGetThemeDetails } from 'src/lib/php-get-theme-details';
 import { portFinder } from 'src/lib/port-finder';
@@ -81,6 +82,17 @@ export class SiteServer {
 		if ( fs.existsSync( thumbnailPath ) ) {
 			await fs.promises.unlink( thumbnailPath );
 		}
+
+		// If we're using a custom domain, clean up the hosts file and unregister from proxy
+		if ( this.details.useCustomDomain && this.details.customDomain ) {
+			try {
+				await removeDomainFromHosts( this.details.customDomain );
+				console.log( `Domain ${ this.details.customDomain } unregistered from proxy server` );
+			} catch ( error ) {
+				console.error( 'Failed to clean up custom domain:', error );
+			}
+		}
+
 		await this.stop();
 		await this.wpCliExecutor?.stop();
 		deletedServers.push( this.details.id );
@@ -100,7 +112,16 @@ export class SiteServer {
 			siteTitle: this.details.name,
 			php: this.details.phpVersion,
 		} );
-		const absoluteUrl = `http://localhost:${ this.details.port }`;
+		// Determine the URL to use - either custom domain or localhost with port
+		let absoluteUrl;
+		if ( this.details.useCustomDomain && this.details.customDomain ) {
+			absoluteUrl = `http://${ this.details.customDomain }`;
+			// For custom domains, we still need to handle hosts file management elsewhere
+			// This happens in the ipc-handlers.ts file when starting the server
+		} else {
+			absoluteUrl = `http://localhost:${ this.details.port }`;
+		}
+
 		options.absoluteUrl = absoluteUrl;
 		options.siteLanguage = await getPreferredSiteLanguage( options.wordPressVersion );
 
@@ -131,12 +152,18 @@ export class SiteServer {
 	}
 
 	updateSiteDetails( site: SiteDetails ) {
+		// We no longer modify custom domain settings after site creation,
+		// so we preserve the existing custom domain settings and only update other fields
 		this.details = {
 			...this.details,
 			name: site.name,
 			path: site.path,
 			phpVersion: site.phpVersion,
 			wpVersion: site.wpVersion,
+			// These two fields are preserved from the original site details
+			// since we don't allow changing custom domain settings after creation
+			customDomain: this.details.customDomain,
+			useCustomDomain: this.details.useCustomDomain,
 		};
 	}
 

--- a/src/site-server.ts
+++ b/src/site-server.ts
@@ -84,7 +84,7 @@ export class SiteServer {
 		}
 
 		// If we're using a custom domain, clean up the hosts file and unregister from proxy
-		if ( this.details.useCustomDomain && this.details.customDomain ) {
+		if ( this.details.customDomain ) {
 			try {
 				await removeDomainFromHosts( this.details.customDomain );
 				console.log( `Domain ${ this.details.customDomain } unregistered from proxy server` );
@@ -114,7 +114,7 @@ export class SiteServer {
 		} );
 		// Determine the URL to use - either custom domain or localhost with port
 		let absoluteUrl;
-		if ( this.details.useCustomDomain && this.details.customDomain ) {
+		if ( this.details.customDomain ) {
 			absoluteUrl = `http://${ this.details.customDomain }`;
 			// For custom domains, we still need to handle hosts file management elsewhere
 			// This happens in the ipc-handlers.ts file when starting the server
@@ -160,10 +160,7 @@ export class SiteServer {
 			path: site.path,
 			phpVersion: site.phpVersion,
 			wpVersion: site.wpVersion,
-			// These two fields are preserved from the original site details
-			// since we don't allow changing custom domain settings after creation
 			customDomain: this.details.customDomain,
-			useCustomDomain: this.details.useCustomDomain,
 		};
 	}
 

--- a/src/storage/user-data.ts
+++ b/src/storage/user-data.ts
@@ -119,29 +119,43 @@ export async function saveUserData( data: UserData ): Promise< void > {
 function toDiskFormat( { sites, ...rest }: UserData ): PersistedUserData {
 	return {
 		version: 1,
-		sites: sites.map( ( { id, path, adminPassword, port, phpVersion, name, themeDetails } ) => {
-			// No object spreading allowed. TypeScript's structural typing is too permissive and
-			// will permit us to persist properties that aren't in the type definition.
-			// Add each property explicitly instead.
-			const persistedSiteDetails: PersistedUserData[ 'sites' ][ number ] = {
+		sites: sites.map(
+			( {
 				id,
-				name,
 				path,
 				adminPassword,
 				port,
 				phpVersion,
-				themeDetails: {
-					name: themeDetails?.name || '',
-					path: themeDetails?.path || '',
-					slug: themeDetails?.slug || '',
-					isBlockTheme: themeDetails?.isBlockTheme || false,
-					supportsWidgets: themeDetails?.supportsWidgets || false,
-					supportsMenus: themeDetails?.supportsMenus || false,
-				},
-			};
+				name,
+				themeDetails,
+				customDomain,
+				useCustomDomain,
+			} ) => {
+				// No object spreading allowed. TypeScript's structural typing is too permissive and
+				// will permit us to persist properties that aren't in the type definition.
+				// Add each property explicitly instead.
+				const persistedSiteDetails: PersistedUserData[ 'sites' ][ number ] = {
+					id,
+					name,
+					path,
+					adminPassword,
+					port,
+					phpVersion,
+					customDomain,
+					useCustomDomain,
+					themeDetails: {
+						name: themeDetails?.name || '',
+						path: themeDetails?.path || '',
+						slug: themeDetails?.slug || '',
+						isBlockTheme: themeDetails?.isBlockTheme || false,
+						supportsWidgets: themeDetails?.supportsWidgets || false,
+						supportsMenus: themeDetails?.supportsMenus || false,
+					},
+				};
 
-			return persistedSiteDetails;
-		} ),
+				return persistedSiteDetails;
+			}
+		),
 		...rest,
 	};
 }

--- a/src/storage/user-data.ts
+++ b/src/storage/user-data.ts
@@ -120,17 +120,7 @@ function toDiskFormat( { sites, ...rest }: UserData ): PersistedUserData {
 	return {
 		version: 1,
 		sites: sites.map(
-			( {
-				id,
-				path,
-				adminPassword,
-				port,
-				phpVersion,
-				name,
-				themeDetails,
-				customDomain,
-				useCustomDomain,
-			} ) => {
+			( { id, path, adminPassword, port, phpVersion, name, themeDetails, customDomain } ) => {
 				// No object spreading allowed. TypeScript's structural typing is too permissive and
 				// will permit us to persist properties that aren't in the type definition.
 				// Add each property explicitly instead.
@@ -142,7 +132,6 @@ function toDiskFormat( { sites, ...rest }: UserData ): PersistedUserData {
 					port,
 					phpVersion,
 					customDomain,
-					useCustomDomain,
 					themeDetails: {
 						name: themeDetails?.name || '',
 						path: themeDetails?.path || '',

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -106,6 +106,8 @@ describe( 'App initialization', () => {
 			expect( setupSpy.mock.invocationCallOrder[ 0 ] ).toBeLessThan(
 				( createMainWindow as jest.Mock ).mock.invocationCallOrder[ 0 ]
 			);
+
+			await mockedEvents.quit();
 		} );
 	} );
 
@@ -122,6 +124,8 @@ describe( 'App initialization', () => {
 			await mockedEvents.ready();
 			await mockedEvents.activate();
 			expect( createMainWindow ).toHaveBeenCalled();
+
+			await mockedEvents.quit();
 		} );
 	} );
 
@@ -153,6 +157,8 @@ describe( 'App initialization', () => {
 			expect( getMainWindow as jest.Mock ).toHaveBeenCalled();
 
 			Object.defineProperty( process, 'platform', { value: originalProcessPlatform } );
+
+			await mockedEvents.quit();
 		} );
 	} );
 } );

--- a/src/tests/ipc-handlers.test.ts
+++ b/src/tests/ipc-handlers.test.ts
@@ -74,7 +74,6 @@ describe( 'createSite', () => {
 			port: 9999,
 			running: false,
 			customDomain: undefined,
-			useCustomDomain: false,
 		} );
 	} );
 

--- a/src/tests/ipc-handlers.test.ts
+++ b/src/tests/ipc-handlers.test.ts
@@ -73,6 +73,8 @@ describe( 'createSite', () => {
 			phpVersion: '8.2',
 			port: 9999,
 			running: false,
+			customDomain: undefined,
+			useCustomDomain: false,
 		} );
 	} );
 


### PR DESCRIPTION
## Related issues

- Fixes #215

## Summary            …

- Implemented custom domain support for WordPress sites using a proxy server
- Added UI for setting custom domains when creating sites
- Integrated with system hosts file for local domain resolution
- The user chooses a custom domain on site creation (editing an existing site is harder because it would require updates to the WP database).

## Implementation details

- Created a proxy server that listens on port 80 and forwards requests to the appropriate local site. This means that if 80 is already used, custom domains won't work (there's no way around this)
- Added domain management in hosts file to resolve custom domains to localhost
- Updated site details to store and display custom domain information
- Modified URL display in settings to show custom domain when enabled
- Added validation for custom domain format

## Test plan

- Create a new site with custom domain enabled
- Verify the domain is added to hosts file (requires admin permission)
- Visit the site using the custom domain (without port)
- Verify admin and frontend URLs work properly
- Delete the site and verify domain is removed from hosts file

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?

**Important note** This PR has been created for a huge part using AI. My main purpose with this PR was to learn both Studio's code base and learn AI while implementing a useful feature.

<img width="534" alt="Screenshot 2025-03-02 at 2 20 18 PM" src="https://github.com/user-attachments/assets/e8983c09-1ec4-491c-b6a3-22535dd31777" />
