### PR TITLE
fix dev version on release

### DIFF
--- a/scripts/prepare-dev-build-version.mjs
+++ b/scripts/prepare-dev-build-version.mjs
@@ -11,7 +11,7 @@ const __dirname = path.dirname( fileURLToPath( import.meta.url ) );
 const latestTag = getLatestTag();
 const commitCount = getCommitCount( latestTag );
 
-if ( ! commitCount ) {
+if ( ! commitCount && commitCount !== 0 ) {
 	// Are you trying to dev on the build scripts outside of CI?
 	// You will need to define the GITHUB_SHA or BUILDKITE_COMMIT environment
 	// variable before running build scripts. e.g.


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- I noticed the build was failing on the release, for example: https://buildkite.com/automattic/studio/builds/4620#019560dd-3ab4-4bdd-9c7b-935cc6c4f21e

## Proposed Changes

- Fix condition in scripts/prepare-dev-build-version.mjs to properly handle when commit count is 0

## Testing Instructions

- Hard code the return value for `getCommitCount` to 0 (or any other value)
- Run the prepare dev version command 
```bash
node ./scripts/prepare-dev-build-version.mjs
```
- The version in package.json should be like `-dev0`

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

-

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
