### PR TITLE
Fix WP.org API zod schema

### DIFF
--- a/src/stores/tests/wordpress-versions-slice.test.ts
+++ b/src/stores/tests/wordpress-versions-slice.test.ts
@@ -126,6 +126,35 @@ describe( 'wordpress-versions-slice', () => {
 			expect( state.wordpressVersions.error ).toContain( 'invalid_type' );
 		} );
 
+		it( 'should gracefully handle schema validation errors for individual offers', async () => {
+			( global.fetch as jest.Mock ).mockResolvedValueOnce( {
+				ok: true,
+				json: jest.fn().mockResolvedValueOnce( {
+					offers: [
+						{ version: '6.4.0', response: 'autoupdate' },
+						{ version: '6.5.0-beta1', response: 'autoupdate' },
+						{ version: '6.5.0-RC1', response: 10 },
+					],
+				} ),
+			} );
+
+			const result = await store.dispatch( fetchWordPressVersions() );
+			expect( result.type ).toBe( 'wordpressVersions/fetchWordPressVersions/fulfilled' );
+
+			const state = store.getState();
+			const versions = wordpressVersionsSelectors.selectWordPressVersions( state );
+
+			expect( versions ).toHaveLength( 2 );
+			expect( versions[ 0 ] ).toEqual( { value: '6.4.0', isBeta: false, label: '6.4' } );
+			expect( versions[ 1 ] ).toEqual( {
+				value: '6.5.0-beta1',
+				isBeta: true,
+				label: '6.5.0-beta1',
+			} );
+			expect( state.wordpressVersions.status ).toBe( 'succeeded' );
+			expect( state.wordpressVersions.error ).toBeNull();
+		} );
+
 		it( 'should correctly identify beta and RC versions and use full version for name', async () => {
 			( global.fetch as jest.Mock ).mockResolvedValueOnce( {
 				ok: true,

--- a/src/stores/wordpress-versions-slice.ts
+++ b/src/stores/wordpress-versions-slice.ts
@@ -6,7 +6,7 @@ const MINIMUM_WORDPRESS_VERSION = '5.9.9';
 
 const wordPressOfferSchema = z.object( {
 	version: z.string(),
-	response: z.enum( [ 'autoupdate', 'upgrade' ] ),
+	response: z.enum( [ 'autoupdate', 'development', 'upgrade' ] ),
 } );
 
 const wordPressApiResponseSchema = z.object( {

--- a/src/stores/wordpress-versions-slice.ts
+++ b/src/stores/wordpress-versions-slice.ts
@@ -6,7 +6,7 @@ const MINIMUM_WORDPRESS_VERSION = '5.9.9';
 
 const wordPressOfferSchema = z.object( {
 	version: z.string(),
-	response: z.enum( [ 'autoupdate', 'development', 'upgrade' ] ),
+	response: z.string(),
 } );
 
 const wordPressApiResponseSchema = z.object( {

--- a/src/stores/wordpress-versions-slice.ts
+++ b/src/stores/wordpress-versions-slice.ts
@@ -35,9 +35,9 @@ export const fetchWordPressVersions = createAsyncThunk(
 
 			const shortNameOccurrences = new Map< string, number >();
 			const offers = data.offers
-				.map( ( o ) => {
+				.map( ( offer ) => {
 					try {
-						return wordPressOfferSchema.parse( o );
+						return wordPressOfferSchema.parse( offer );
 					} catch ( error ) {
 						return null;
 					}

--- a/src/stores/wordpress-versions-slice.ts
+++ b/src/stores/wordpress-versions-slice.ts
@@ -9,8 +9,10 @@ const wordPressOfferSchema = z.object( {
 	response: z.string(),
 } );
 
+type WordPressOffer = z.infer< typeof wordPressOfferSchema >;
+
 const wordPressApiResponseSchema = z.object( {
-	offers: z.array( wordPressOfferSchema ),
+	offers: z.array( z.any() ),
 } );
 
 const extractShortName = ( version: string ): string => {
@@ -33,7 +35,14 @@ export const fetchWordPressVersions = createAsyncThunk(
 
 			const shortNameOccurrences = new Map< string, number >();
 			const offers = data.offers
-				.filter( ( offer ) => offer.response === 'autoupdate' )
+				.map( ( o ) => {
+					try {
+						return wordPressOfferSchema.parse( o );
+					} catch ( error ) {
+						return null;
+					}
+				} )
+				.filter( ( offer ): offer is WordPressOffer => offer?.response === 'autoupdate' )
 				.map( ( { version } ) => {
 					const shortName = extractShortName( version );
 					shortNameOccurrences.set( shortName, ( shortNameOccurrences.get( shortName ) || 0 ) + 1 );
@@ -42,6 +51,7 @@ export const fetchWordPressVersions = createAsyncThunk(
 						shortName,
 					};
 				} );
+
 			return offers.map( ( { version, shortName } ) => {
 				const isBeta = version.includes( 'beta' ) || version.includes( 'RC' );
 				const occurrences = shortNameOccurrences.get( shortName ) || 0;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/dotcom-forge/issues/10564

## Proposed Changes

https://api.wordpress.org/core/version-check/1.7/?channel=beta&version now returns the string `development` in an `offers[].response` key. This PR changes the zod schema to be more permissive to avoid those validation errors. It also makes the parsing less sensitive by discarding individual array items that don't conform to the schema instead of discarding the entire response.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Code review should suffice

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
