### PR TITLE
Add support to use iTerm as the terminal application if installed

### DIFF
--- a/src/components/content-tab-overview.tsx
+++ b/src/components/content-tab-overview.tsx
@@ -177,6 +177,24 @@ function ShortcutsSection( { selectedSite }: Pick< ContentTabOverviewProps, 'sel
 			},
 		} );
 	}
+	if ( installedApps.iterm ) {
+		buttonsArray.push( {
+			// translators: "iTerm" is the brand name for a terminal app and does not need to be translated
+			label: __( 'iTerm' ),
+			className: 'text-nowrap',
+			icon: preformatted,
+			onClick: async () => {
+				try {
+					await getIpcApi().openItermAtPath( selectedSite.path, {
+						wpCliEnabled: terminalWpCliEnabled,
+					} );
+				} catch ( error ) {
+					Sentry.captureException( error );
+					alert( __( 'Could not open iTerm.' ) );
+				}
+			},
+		} );
+	}
 	buttonsArray.push( {
 		label: __( 'Terminal' ),
 		className: 'text-nowrap',

--- a/src/hooks/use-check-installed-apps.tsx
+++ b/src/hooks/use-check-installed-apps.tsx
@@ -4,6 +4,7 @@ import { getIpcApi } from 'src/lib/get-ipc-api';
 const initState = {
 	vscode: false,
 	phpstorm: false,
+	iterm: false,
 };
 const checkInstalledAppsContext = createContext< InstalledApps >( initState );
 

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -102,6 +102,7 @@ export async function getInstalledApps( _event: IpcMainInvokeEvent ): Promise< I
 	return {
 		vscode: isInstalled( 'vscode' ),
 		phpstorm: isInstalled( 'phpstorm' ),
+		iterm: isInstalled( 'iterm' ),
 	};
 }
 
@@ -934,6 +935,40 @@ END` );
 		console.error( 'Unsupported platform:', platform );
 		return;
 	}
+}
+
+export function openItermAtPath(
+	_event: IpcMainInvokeEvent,
+	targetPath: string,
+	{ wpCliEnabled }: { wpCliEnabled?: boolean } = {}
+) {
+	const cliPath = nodePath.join( getResourcesPath(), 'bin' );
+
+	const exePath = app.getPath( 'exe' );
+	const appDirectory = app.getAppPath();
+	const appPath = ! app.isPackaged ? `${ exePath } ${ appDirectory }` : exePath;
+
+	const initScriptSteps = [];
+
+	if ( wpCliEnabled ) {
+		initScriptSteps.push(
+			`export PATH=\\"${ cliPath }\\":$PATH`,
+			`export STUDIO_APP_PATH=\\"${ appPath }\\"`
+		);
+	}
+
+	const escapedPath = targetPath.replace( /"/g, '\\"' );
+	initScriptSteps.push( `cd \\"${ escapedPath }\\"`, 'clear' );
+
+	return promiseExec( `osascript << END
+activate application "iTerm"
+tell application "iTerm"
+	 set newWindow to (create window with default profile)
+    tell current session of newWindow
+        write text "${ initScriptSteps.join( ';' ) }"
+    end tell
+end tell
+END` );
 }
 
 export async function showMessageBox(

--- a/src/ipc-types.d.ts
+++ b/src/ipc-types.d.ts
@@ -54,6 +54,7 @@ interface Snapshot {
 type InstalledApps = {
 	vscode: boolean | null;
 	phpstorm: boolean | null;
+	iterm: boolean | null;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/lib/is-installed.ts
+++ b/src/lib/is-installed.ts
@@ -8,16 +8,19 @@ if ( process.platform === 'darwin' ) {
 	appPaths = {
 		vscode: '/Applications/Visual Studio Code.app',
 		phpstorm: '/Applications/PhpStorm.app',
+		iterm: '/Applications/iTerm.app',
 	};
 } else if ( process.platform === 'linux' ) {
 	appPaths = {
 		vscode: '/usr/bin/code',
 		phpstorm: '/usr/bin/phpstorm',
+		iterm: '', // Disable iTerm for Linux
 	};
 } else if ( process.platform === 'win32' ) {
 	appPaths = {
 		vscode: path.join( app.getPath( 'appData' ), 'Code' ),
 		phpstorm: '', // Disable phpStorm for Windows
+		iterm: '', // Disable iTerm for Windows
 	};
 }
 

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -77,6 +77,8 @@ const api: IpcApi = {
 		ipcRenderer.invoke( 'saveOnboarding', onboardingCompleted ),
 	openTerminalAtPath: ( targetPath: string, extraParams: { wpCliEnabled?: boolean } = {} ) =>
 		ipcRenderer.invoke( 'openTerminalAtPath', targetPath, extraParams ),
+	openItermAtPath: ( targetPath: string, extraParams: { wpCliEnabled?: boolean } = {} ) =>
+		ipcRenderer.invoke( 'openItermAtPath', targetPath, extraParams ),
 	showMessageBox: ( options: Electron.MessageBoxOptions ) =>
 		ipcRenderer.invoke( 'showMessageBox', options ),
 	showErrorMessageBox: ( options: { title: string; message: string; error?: unknown } ) =>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->
## Proposed Changes

This PR attempts to allow the user to use the iTerm application if installed. iTerm is very popular and allowing developers to use their preferred tools is a big DevEx win.

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
If iTerm is installed, a new iTerm button will display that will open iTerm and `cd` to the correct location.

| Before | After |
|--------|--------|
| ![before](https://github.com/user-attachments/assets/592639ca-0cc8-4cd1-b4f1-a769cdee8dd0) |  ![after](https://github.com/user-attachments/assets/8668bb31-6f0f-40ee-b183-197849bf6362)|


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
