### PR TITLE
Use `env` node for all `IS_DEV_BUILD` CI assignments

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -54,7 +54,6 @@ steps:
     command: |
       # call with bash explicitly because we run this on Windows, too
       bash .buildkite/commands/install-node-dependencies.sh
-      export IS_DEV_BUILD=true
       echo '--- :package: Package app for testing'
       npm run package
       echo '--- :playwright: Run End To End Tests'
@@ -67,6 +66,7 @@ steps:
     env:
       # See https://playwright.dev/docs/ci#debugging-browser-launches
       DEBUG: "pw:browser"
+      IS_DEV_BUILD: true
     matrix:
       - mac
       #- windows
@@ -86,8 +86,6 @@ steps:
           .buildkite/commands/install-node-dependencies.sh
 
           node ./scripts/prepare-dev-build-version.mjs
-
-          export IS_DEV_BUILD=true
 
           echo "--- :node: Building Binary"
           npm run make:macos-{{matrix}}
@@ -113,6 +111,8 @@ steps:
 
           echo "--- 📃 Notarizing Binary"
           bundle exec fastlane notarize_binary
+        env:
+          IS_DEV_BUILD: true
         plugins: [$CI_TOOLKIT_PLUGIN, $NVM_PLUGIN]
         artifact_paths:
           - out/**/*.app.zip
@@ -158,8 +158,6 @@ steps:
 
       .buildkite/commands/install-node-dependencies.sh
 
-      export IS_DEV_BUILD=true
-
       echo "--- :node: Generating Release Manifest"
       node ./scripts/prepare-dev-build-version.mjs
       node ./scripts/generate-releases-manifest.mjs
@@ -167,6 +165,8 @@ steps:
       echo "--- :fastlane: Distributing Dev Builds"
       install_gems
       bundle exec fastlane distribute_dev_build
+    env:
+      IS_DEV_BUILD: true
     artifact_paths:
       - out/releases.json
     agents:


### PR DESCRIPTION

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Builds on to of #998

## Proposed Changes

Always use `env: IS_DEV_BUILD: true` in CI to set the `IS_DEV_BUILD` env var.

In https://github.com/Automattic/studio/pull/998#discussion_r1978739613 I got confirmation that it's okay to use this approach for the env var setting.

Given it's already in use, because it would not work otherwise, in the Windows steps, this commit updates all the other steps so we have a consistent setup.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

-

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors? – N.A.
