### PR TITLE
Resolve relative symlink paths correctly

### DIFF
--- a/src/lib/symlink-manager.ts
+++ b/src/lib/symlink-manager.ts
@@ -210,6 +210,9 @@ export class SymlinkManager {
 			vfsTarget,
 			createNodeFsMountHandler( hostTarget )
 		);
+		// For some reason, we must access the target directory after mounting it, otherwise the
+		// mount will not work.
+		this.php.listFiles( vfsTarget );
 	}
 
 	/**

--- a/src/lib/symlink-manager.ts
+++ b/src/lib/symlink-manager.ts
@@ -139,10 +139,10 @@ export class SymlinkManager {
 	 * @param filename
 	 */
 	private async addSymlink( filename: string ) {
-		const fullPath = path.join( this.projectPath, filename );
-		let target: string;
+		const fullPath = path.resolve( this.projectPath, filename );
+		let hostTarget: string;
 		try {
-			target = await fs.realpath( fullPath );
+			hostTarget = await fs.realpath( fullPath );
 		} catch ( err ) {
 			if ( isErrnoException( err ) && err.code === 'ENOENT' ) {
 				console.error( `Symlink target does not exist: ${ fullPath }` );
@@ -152,7 +152,7 @@ export class SymlinkManager {
 			return;
 		}
 
-		const vfsPath = path.posix.join( this.documentRoot, filename );
+		const vfsPath = path.posix.resolve( this.documentRoot, filename );
 
 		// Double check to ensure the symlink exists
 		if ( ! this.php.fileExists( vfsPath ) ) {
@@ -160,10 +160,10 @@ export class SymlinkManager {
 		}
 
 		// Get the realpath of the symlink within the PHP runtime.
-		const vfsTarget = this.php.readlink( vfsPath );
+		const vfsTarget = path.posix.resolve( path.dirname( vfsPath ), this.php.readlink( vfsPath ) );
 		this.symlinks.set( filename, vfsTarget );
 
-		await this.mountTarget( vfsTarget, target );
+		await this.mountTarget( vfsTarget, hostTarget );
 	}
 
 	/**

--- a/src/lib/symlink-manager.ts
+++ b/src/lib/symlink-manager.ts
@@ -135,15 +135,6 @@ export class SymlinkManager {
 	}
 
 	/**
-	 * Check if a target path is inside the document root.
-	 * @param target
-	 * @returns
-	 */
-	private isTargetInsideDocumentRoot( target: string ) {
-		return path.posix.normalize( target ).startsWith( this.documentRoot );
-	}
-
-	/**
 	 * Add a symlink to the PHP runtime by mounting the target path.
 	 * @param filename
 	 */
@@ -170,11 +161,6 @@ export class SymlinkManager {
 
 		// Get the realpath of the symlink within the PHP runtime.
 		const vfsTarget = path.posix.resolve( path.dirname( vfsPath ), this.php.readlink( vfsPath ) );
-
-		// If the target is inside the document root, we don't need to mount it.
-		if ( this.isTargetInsideDocumentRoot( vfsTarget ) ) {
-			return;
-		}
 
 		this.symlinks.set( filename, vfsTarget );
 

--- a/src/lib/symlink-manager.ts
+++ b/src/lib/symlink-manager.ts
@@ -135,6 +135,15 @@ export class SymlinkManager {
 	}
 
 	/**
+	 * Check if a target path is inside the document root.
+	 * @param target
+	 * @returns
+	 */
+	private isTargetInsideDocumentRoot( target: string ) {
+		return path.posix.normalize( target ).startsWith( this.documentRoot );
+	}
+
+	/**
 	 * Add a symlink to the PHP runtime by mounting the target path.
 	 * @param filename
 	 */
@@ -161,6 +170,12 @@ export class SymlinkManager {
 
 		// Get the realpath of the symlink within the PHP runtime.
 		const vfsTarget = path.posix.resolve( path.dirname( vfsPath ), this.php.readlink( vfsPath ) );
+
+		// If the target is inside the document root, we don't need to mount it.
+		if ( this.isTargetInsideDocumentRoot( vfsTarget ) ) {
+			return;
+		}
+
 		this.symlinks.set( filename, vfsTarget );
 
 		await this.mountTarget( vfsTarget, hostTarget );

--- a/src/lib/tests/symlink-manager.test.ts
+++ b/src/lib/tests/symlink-manager.test.ts
@@ -37,6 +37,7 @@ describe( 'SymlinkManager', () => {
 			isDir: jest.fn(),
 			unlink: jest.fn(),
 			rmdir: jest.fn(),
+			listFiles: jest.fn(),
 			requestHandler: {
 				documentRoot: mockDocumentRoot,
 			},


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/studio/issues/1000 and https://github.com/Automattic/studio/issues/1006

## Proposed Changes

First, a quick recap of how `SymlinkManager` works. Symlinks are technically preserved when mounting the site directory in Playground's virtual file system. However, symlinks are in reality just a special type of file with a target path, and if the target path is outside the document root, it's not accessible in Playground's FS. This is where `SymlinkManager` comes in – it creates a directory inside Playground's FS at the target path and mounts the target path from the host filesystem there.

This PR specifically fixes an issue that was introduced when we recently upgraded our Playground dependencies (https://github.com/Automattic/studio/pull/959). After the upgrade, the `php.readlink` function started returning the correct value, which is the symlink's exact, unresolved target path (i.e. it suddenly returned relative paths sometimes).

This PR changes the `SymlinkManager::addSymlink` method to resolve the path returned from `php.readlink` relative to the directory where the symlink lives (i.e. how symlinks are normally handled). 

<del>I've also added a `SymlinkManager::isTargetInsideDocumentRoot` method that allows us to skip mounting symlink target paths that are already accessible inside the document root. Should make `SymlinkManager` more efficient.</del><ins>After working on fixing the failing tests, I realized that `SymlinkManager::mountTarget` already has this performance optimization in that it checks if the file or directory already exists in the Playground FS before attempting to mount it.</ins>

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

First, let's test the specific case that was reported to us:

1. Have a Studio site
2. Download [this plugin](https://github.com/juanma-wp/wp-data-layer-app-pages) and unpack it to `wp-content/plugins`
3. Run `npm install` inside the plugin directory
4. Start the Studio site and ensure that it doesn't encounter any errors

Secondly, let's test a typical symlink targeting a directory outside the document root:

1. Have a Studio site where Yoast SEO is not already installed
2. Download [Yoast SEO](https://wordpress.org/plugins/wordpress-seo) and extract it to `~/wordpress-seo`
3. In your site's `wp-content/plugins` directory, run `ln -s ~/wordpress-seo`
4. Start the Studio site
5. Navigate to `/wp-admin/plugins.php`
6. Ensure that the Yoast SEO plugin is available and that you can activate it without error

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
