### PR TITLE
Add selector that prepends the `latest` wp version as first choice

### DIFF
--- a/src/stores/tests/wordpress-versions-slice.test.ts
+++ b/src/stores/tests/wordpress-versions-slice.test.ts
@@ -277,5 +277,34 @@ describe( 'wordpress-versions-slice', () => {
 				{ value: '6.5.0-beta1', isBeta: true, label: '6.5.0-beta1' },
 			] );
 		} );
+
+		it( 'should select WordPress versions with latest', async () => {
+			( global.fetch as jest.Mock ).mockResolvedValueOnce( {
+				ok: true,
+				json: jest.fn().mockResolvedValueOnce( {
+					offers: [
+						{ version: '6.1.0', response: 'autoupdate' },
+						{ version: '6.2.0', response: 'autoupdate' },
+						{ version: '6.3.0', response: 'autoupdate' },
+						{ version: '6.4.0', response: 'autoupdate' },
+						{ version: '6.5.0-beta1', response: 'autoupdate' },
+					],
+				} ),
+			} );
+
+			await store.dispatch( fetchWordPressVersions() );
+
+			const state = store.getState();
+			const versions = wordpressVersionsSelectors.selectWordPressVersionsWithLatest( state );
+
+			expect( versions ).toEqual( [
+				{ value: 'latest', isBeta: false, label: 'Latest' },
+				{ value: '6.1.0', isBeta: false, label: '6.1' },
+				{ value: '6.2.0', isBeta: false, label: '6.2' },
+				{ value: '6.3.0', isBeta: false, label: '6.3' },
+				{ value: '6.4.0', isBeta: false, label: '6.4' },
+				{ value: '6.5.0-beta1', isBeta: true, label: '6.5.0-beta1' },
+			] );
+		} );
 	} );
 } );

--- a/src/stores/wordpress-versions-slice.ts
+++ b/src/stores/wordpress-versions-slice.ts
@@ -1,5 +1,6 @@
 import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
 import * as Sentry from '@sentry/electron/renderer';
+import { __ } from '@wordpress/i18n';
 import { z, ZodError } from 'zod';
 
 const MINIMUM_WORDPRESS_VERSION = '5.9.9';
@@ -110,6 +111,14 @@ const wordpressVersionsSlice = createSlice( {
 	},
 	selectors: {
 		selectWordPressVersions: ( state ) => state.versions,
+		selectWordPressVersionsWithLatest: ( state ) => [
+			{
+				isBeta: false,
+				label: __( 'Latest' ),
+				value: 'latest',
+			},
+			...state.versions,
+		],
 	},
 } );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Related to https://github.com/Automattic/studio/pull/989#pullrequestreview-2661071749

## Proposed Changes

- Create a wordpress version slice selector that preprends `latest` version to the list.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Apply this diff
```diff
diff --git a/src/modules/site-settings/edit-site-details.tsx b/src/modules/site-settings/edit-site-details.tsx
index 122b5021..c3e6b85d 100644
--- a/src/modules/site-settings/edit-site-details.tsx
+++ b/src/modules/site-settings/edit-site-details.tsx
@@ -22,7 +22,9 @@ export default function EditSiteDetails() {
 	);
 	const [ selectedWpVersion, setSelectedWpVersion ] = useState( 'latest' );
 
-	const wordpressVersions = useRootSelector( wordpressVersionsSelectors.selectWordPressVersions );
+	const wordpressVersions = useRootSelector(
+		wordpressVersionsSelectors.selectWordPressVersionsWithLatest
+	);
 
 	useEffect( () => {
 		if ( selectedSite && showModal ) {

```
- Run `STUDIO_WP_VERSIONS=true npm start`
- Go to settings tab
- Click on edit
- Observe the list of versions start with `Latest` instead of the current `-beta`

<img width="1012" alt="Screenshot 2025-03-05 at 14 18 19" src="https://github.com/user-attachments/assets/e6a3da59-157b-4351-b8cc-45ec0839f9c3" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
