### PR TITLE
Edit WordPress version in site details modal

### DIFF
--- a/src/components/content-tab-settings.tsx
+++ b/src/components/content-tab-settings.tsx
@@ -31,7 +31,7 @@ export function ContentTabSettings( { selectedSite }: ContentTabSettingsProps ) 
 	// Empty strings account for legacy sites lacking a stored password.
 	const storedPassword = decodePassword( selectedSite.adminPassword ?? '' );
 	const password = storedPassword === '' ? 'password' : storedPassword;
-	const wpVersion = useGetWpVersion( selectedSite );
+	const [ wpVersion, refreshWpVersion ] = useGetWpVersion( selectedSite );
 	return (
 		<div className="p-8">
 			<table className="mb-2 m-w-full" cellPadding={ 0 } cellSpacing={ 0 }>
@@ -40,7 +40,9 @@ export function ContentTabSettings( { selectedSite }: ContentTabSettingsProps ) 
 						<th colSpan={ 2 } className="pb-4 ltr:text-left rtl:text-right">
 							<h3 className="text-black text-sm font-semibold">
 								{ __( 'Site details' ) }
-								{ wpVersionsEnabled && <EditSiteDetails currentWpVersion={ wpVersion } /> }
+								{ wpVersionsEnabled && (
+									<EditSiteDetails currentWpVersion={ wpVersion } onSave={ refreshWpVersion } />
+								) }
 							</h3>
 						</th>
 					</tr>

--- a/src/components/content-tab-settings.tsx
+++ b/src/components/content-tab-settings.tsx
@@ -40,7 +40,7 @@ export function ContentTabSettings( { selectedSite }: ContentTabSettingsProps ) 
 						<th colSpan={ 2 } className="pb-4 ltr:text-left rtl:text-right">
 							<h3 className="text-black text-sm font-semibold">
 								{ __( 'Site details' ) }
-								{ wpVersionsEnabled && <EditSiteDetails /> }
+								{ wpVersionsEnabled && <EditSiteDetails currentWpVersion={ wpVersion } /> }
 							</h3>
 						</th>
 					</tr>

--- a/src/components/error-information.tsx
+++ b/src/components/error-information.tsx
@@ -1,0 +1,16 @@
+import { cx } from 'src/lib/cx';
+import { ErrorIcon } from './error-icon';
+
+type ErrorInformationProps = {
+	children: React.ReactNode;
+	className?: string;
+};
+
+export function ErrorInformation( { children, className }: ErrorInformationProps ) {
+	return (
+		<div className={ cx( 'flex items-center gap-1 text-xs text-red-500', className ) }>
+			<ErrorIcon />
+			{ children }
+		</div>
+	);
+}

--- a/src/components/tests/content-tab-assistant.test.tsx
+++ b/src/components/tests/content-tab-assistant.test.tsx
@@ -117,7 +117,7 @@ describe( 'ContentTabAssistant', () => {
 			showMessageBox: jest.fn().mockResolvedValue( { response: 0, checkboxChecked: false } ),
 			executeWPCLiInline: jest.fn().mockResolvedValue( { stdout: '', stderr: 'Error' } ),
 		} );
-		( useGetWpVersion as jest.Mock ).mockReturnValue( '6.4.3' );
+		( useGetWpVersion as jest.Mock ).mockReturnValue( [ '6.4.3', jest.fn() ] );
 	} );
 
 	it( 'renders placeholder text input', () => {

--- a/src/components/tests/content-tab-settings.test.tsx
+++ b/src/components/tests/content-tab-settings.test.tsx
@@ -29,7 +29,7 @@ describe( 'ContentTabSettings', () => {
 	const generateProposedSitePath = jest.fn();
 	beforeEach( () => {
 		jest.clearAllMocks();
-		( useGetWpVersion as jest.Mock ).mockReturnValue( '7.7.7' );
+		( useGetWpVersion as jest.Mock ).mockReturnValue( [ '7.7.7', jest.fn() ] );
 		( getIpcApi as jest.Mock ).mockReturnValue( {
 			copyText,
 			openLocalPath,

--- a/src/components/text-control.tsx
+++ b/src/components/text-control.tsx
@@ -12,6 +12,8 @@ const TextControlComponent = ( props: TextControlProps ) => {
 			__nextHasNoMarginBottom={ true }
 			className={ cx(
 				'[&_input]:!px-4 [&_input]:!py-3 [&_input]:!rounded-sm [&_input]:!self-stretch [&_input]:!align-center [&_input]:!gap-1 [&_input]:!flex',
+				props.disabled &&
+					'[&_input]:!bg-a8c-gray-100 [&_input]:!text-a8c-gray-600 [&_input]:!border-a8c-gray-400',
 				props.className
 			) }
 		/>

--- a/src/hooks/use-get-wp-version.ts
+++ b/src/hooks/use-get-wp-version.ts
@@ -1,10 +1,13 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 
 export function useGetWpVersion( site: SiteDetails ) {
 	const [ wpVersion, setWpVersion ] = useState( '-' );
-	useEffect( () => {
+	const refreshWpVersion = useCallback( () => {
 		getIpcApi().getWpVersion( site.id ).then( setWpVersion );
-	}, [ site.id, site.running ] );
-	return wpVersion;
+	}, [ site.id ] );
+	useEffect( () => {
+		refreshWpVersion();
+	}, [ site.running, refreshWpVersion ] );
+	return [ wpVersion, refreshWpVersion ] as const;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -272,3 +272,7 @@ blockquote {
 .error-message {
 	color: #D63638;
 }
+
+.error-select-control .components-input-control__backdrop {
+	border-color: theme( 'colors.red.500' )!important;
+}

--- a/src/modules/site-settings/edit-site-details.tsx
+++ b/src/modules/site-settings/edit-site-details.tsx
@@ -22,7 +22,7 @@ type EditSiteDetailsProps = {
 export default function EditSiteDetails( { currentWpVersion, onSave }: EditSiteDetailsProps ) {
 	const { __ } = useI18n();
 	const { updateSite, selectedSite, stopServer, startServer } = useSiteDetails();
-	const [ changeWpError, setChangeWpError ] = useState( '' );
+	const [ isChangeWpError, setIsChangeWpError ] = useState( '' );
 	const [ showModal, setShowModal ] = useState( false );
 	const [ isEditingSite, setIsEditingSite ] = useState( false );
 	const closeModal = useCallback( () => {
@@ -52,7 +52,7 @@ export default function EditSiteDetails( { currentWpVersion, onSave }: EditSiteD
 		setSiteName( selectedSite.name );
 		setSelectedPhpVersion( selectedSite.phpVersion as SupportedPHPVersion );
 		setSelectedWpVersion( currentWpVersion );
-		setChangeWpError( '' );
+		setIsChangeWpError( '' );
 	}, [ currentWpVersion, selectedSite ] );
 
 	const onSiteEdit = async ( event: FormEvent ) => {
@@ -61,7 +61,7 @@ export default function EditSiteDetails( { currentWpVersion, onSave }: EditSiteD
 			return;
 		}
 		setIsEditingSite( true );
-		setChangeWpError( '' );
+		setIsChangeWpError( '' );
 		try {
 			const running = selectedSite.running;
 
@@ -85,7 +85,7 @@ export default function EditSiteDetails( { currentWpVersion, onSave }: EditSiteD
 				} catch ( wpError ) {
 					console.error( 'Error changing WordPress version:', wpError );
 					const errorMessage = stripAnsi( ( wpError as Error )?.message );
-					setChangeWpError( __( 'Error changing WordPress version' ) );
+					setIsChangeWpError( __( 'Error changing WordPress version' ) );
 					getIpcApi().showErrorMessageBox( {
 						title: __( 'Error changing WordPress version' ),
 						message: errorMessage,
@@ -109,7 +109,7 @@ export default function EditSiteDetails( { currentWpVersion, onSave }: EditSiteD
 			closeModal();
 			resetFormState();
 		} catch ( e ) {
-			setChangeWpError( ( e as Error )?.message );
+			setIsChangeWpError( ( e as Error )?.message );
 		}
 		setIsEditingSite( false );
 	};
@@ -157,7 +157,7 @@ export default function EditSiteDetails( { currentWpVersion, onSave }: EditSiteD
 								<label className="flex flex-1 flex-col gap-1.5 leading-4">
 									<span className="font-semibold">{ __( 'WordPress version' ) }</span>
 									<SelectControl
-										className={ cx( changeWpError && 'error-select-control' ) }
+										className={ cx( isChangeWpError && 'error-select-control' ) }
 										disabled={ isEditingSite }
 										value={ selectedWpVersion }
 										options={ wordpressVersionOptions }
@@ -168,8 +168,8 @@ export default function EditSiteDetails( { currentWpVersion, onSave }: EditSiteD
 							</div>
 						</div>
 
-						{ changeWpError && (
-							<ErrorInformation className="mt-4">{ changeWpError }</ErrorInformation>
+						{ isChangeWpError && (
+							<ErrorInformation className="mt-4">{ isChangeWpError }</ErrorInformation>
 						) }
 
 						<div className="flex flex-row justify-end gap-x-5 mt-6">

--- a/src/modules/site-settings/edit-site-details.tsx
+++ b/src/modules/site-settings/edit-site-details.tsx
@@ -153,6 +153,7 @@ export default function EditSiteDetails( { currentWpVersion, onSave }: EditSiteD
 								<label className="flex flex-1 flex-col gap-1.5 leading-4">
 									<span className="font-semibold">{ __( 'WordPress version' ) }</span>
 									<SelectControl
+										className={ cx( changeWpError && 'error-select-control' ) }
 										disabled={ isEditingSite }
 										value={ selectedWpVersion }
 										options={ wordpressVersionOptions }

--- a/src/modules/site-settings/edit-site-details.tsx
+++ b/src/modules/site-settings/edit-site-details.tsx
@@ -1,7 +1,7 @@
 import { SupportedPHPVersion, SupportedPHPVersions } from '@php-wasm/universal';
 import { SelectControl } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
-import { FormEvent, useCallback, useEffect, useState } from 'react';
+import { FormEvent, useCallback, useState } from 'react';
 import Button from 'src/components/button';
 import Modal from 'src/components/modal';
 import TextControlComponent from 'src/components/text-control';
@@ -30,22 +30,15 @@ export default function EditSiteDetails( { currentWpVersion }: { currentWpVersio
 	const [ selectedWpVersion, setSelectedWpVersion ] = useState( currentWpVersion );
 	const wordpressVersions = useRootSelector( wordpressVersionsSelectors.selectWordPressVersions );
 
-	const resetLocalState = useCallback( () => {
+	const resetFormState = useCallback( () => {
 		if ( ! selectedSite ) {
 			return;
 		}
-
 		setSiteName( selectedSite.name );
 		setSelectedPhpVersion( selectedSite.phpVersion as SupportedPHPVersion );
 		setSelectedWpVersion( currentWpVersion );
 		setEditSiteError( '' );
 	}, [ currentWpVersion, selectedSite ] );
-
-	useEffect( () => {
-		if ( showModal ) {
-			resetLocalState();
-		}
-	}, [ showModal, resetLocalState ] );
 
 	const onSiteEdit = useCallback(
 		async ( event: FormEvent ) => {
@@ -93,7 +86,7 @@ export default function EditSiteDetails( { currentWpVersion }: { currentWpVersio
 				}
 
 				closeModal();
-				resetLocalState();
+				resetFormState();
 			} catch ( e ) {
 				setEditSiteError( ( e as Error )?.message );
 			}
@@ -107,7 +100,7 @@ export default function EditSiteDetails( { currentWpVersion }: { currentWpVersio
 			updateSite,
 			siteName,
 			closeModal,
-			resetLocalState,
+			resetFormState,
 			stopServer,
 			__,
 			startServer,
@@ -192,6 +185,7 @@ export default function EditSiteDetails( { currentWpVersion }: { currentWpVersio
 				className="!mx-4 shrink-0"
 				onClick={ () => {
 					setShowModal( true );
+					resetFormState();
 				} }
 				label={ __( 'Edit site' ) }
 				variant="link"

--- a/src/modules/site-settings/edit-site-details.tsx
+++ b/src/modules/site-settings/edit-site-details.tsx
@@ -122,6 +122,7 @@ export default function EditSiteDetails( { currentWpVersion }: { currentWpVersio
 							<label className="flex flex-col gap-1.5 leading-4">
 								<span className="font-semibold">{ __( 'Site name' ) }</span>
 								<TextControlComponent
+									disabled={ isEditingSite }
 									onChange={ setSiteName }
 									value={ siteName }
 								></TextControlComponent>
@@ -131,6 +132,7 @@ export default function EditSiteDetails( { currentWpVersion }: { currentWpVersio
 								<label className="flex flex-1 flex-col gap-1.5 leading-4">
 									<span className="font-semibold">{ __( 'PHP version' ) }</span>
 									<SelectControl
+										disabled={ isEditingSite }
 										value={ selectedPhpVersion }
 										options={ SupportedPHPVersions.map( ( version ) => ( {
 											label: version,
@@ -144,6 +146,7 @@ export default function EditSiteDetails( { currentWpVersion }: { currentWpVersio
 								<label className="flex flex-1 flex-col gap-1.5 leading-4">
 									<span className="font-semibold">{ __( 'WordPress version' ) }</span>
 									<SelectControl
+										disabled={ isEditingSite }
 										value={ selectedWpVersion }
 										options={ wordpressVersions.map( ( { label, value } ) => ( {
 											label,

--- a/src/modules/site-settings/edit-site-details.tsx
+++ b/src/modules/site-settings/edit-site-details.tsx
@@ -123,6 +123,10 @@ export default function EditSiteDetails( { currentWpVersion, onSave }: EditSiteD
 					isDismissible
 					focusOnMount="firstContentElement"
 					onRequestClose={ closeModal }
+					className={ cx(
+						isEditingSite &&
+							'[&_[aria-label="Close"]_svg]:opacity-50 [&_[aria-label="Close"]]:cursor-not-allowed'
+					) }
 				>
 					<form onSubmit={ onSiteEdit }>
 						<div className="flex flex-col gap-6">

--- a/src/modules/site-settings/edit-site-details.tsx
+++ b/src/modules/site-settings/edit-site-details.tsx
@@ -6,58 +6,93 @@ import Button from 'src/components/button';
 import Modal from 'src/components/modal';
 import TextControlComponent from 'src/components/text-control';
 import { useSiteDetails } from 'src/hooks/use-site-details';
+import { getIpcApi } from 'src/lib/get-ipc-api';
 import { useRootSelector } from 'src/stores';
 import { wordpressVersionsSelectors } from 'src/stores/wordpress-versions-slice';
 import { DEFAULT_PHP_VERSION } from 'vendor/wp-now/src/constants';
 
-export default function EditSiteDetails() {
+export default function EditSiteDetails( { currentWpVersion }: { currentWpVersion: string } ) {
 	const { __ } = useI18n();
 	const { updateSite, selectedSite, stopServer, startServer } = useSiteDetails();
 	const [ editSiteError, setEditSiteError ] = useState( '' );
 	const [ showModal, setShowModal ] = useState( false );
 	const [ isEditingSite, setIsEditingSite ] = useState( false );
+	const closeModal = useCallback( () => {
+		if ( isEditingSite ) {
+			return;
+		}
+		setShowModal( false );
+	}, [ isEditingSite ] );
 	const [ siteName, setSiteName ] = useState( selectedSite?.name ?? '' );
 	const [ selectedPhpVersion, setSelectedPhpVersion ] = useState< SupportedPHPVersion >(
 		( selectedSite?.phpVersion as SupportedPHPVersion ) ?? DEFAULT_PHP_VERSION
 	);
-	const [ selectedWpVersion, setSelectedWpVersion ] = useState( 'latest' );
-
+	const [ selectedWpVersion, setSelectedWpVersion ] = useState( currentWpVersion );
 	const wordpressVersions = useRootSelector( wordpressVersionsSelectors.selectWordPressVersions );
 
-	useEffect( () => {
-		if ( selectedSite && showModal ) {
-			setSiteName( selectedSite.name );
-			setSelectedPhpVersion( selectedSite.phpVersion as SupportedPHPVersion );
-		}
-	}, [ selectedSite, showModal ] );
-
 	const resetLocalState = useCallback( () => {
-		setShowModal( false );
-		setSiteName( '' );
-		setSelectedPhpVersion( DEFAULT_PHP_VERSION );
-		setSelectedWpVersion( 'latest' );
+		if ( ! selectedSite ) {
+			return;
+		}
+
+		setSiteName( selectedSite.name );
+		setSelectedPhpVersion( selectedSite.phpVersion as SupportedPHPVersion );
+		setSelectedWpVersion( currentWpVersion );
 		setEditSiteError( '' );
-	}, [] );
+	}, [ currentWpVersion, selectedSite ] );
+
+	useEffect( () => {
+		if ( showModal ) {
+			resetLocalState();
+		}
+	}, [ showModal, resetLocalState ] );
 
 	const onSiteEdit = useCallback(
 		async ( event: FormEvent ) => {
 			event.preventDefault();
-			if ( ! selectedSite ) {
+			if ( ! selectedSite?.id ) {
 				return;
 			}
 			setIsEditingSite( true );
 			try {
 				const running = selectedSite.running;
+
+				const hasWpVersionChanged = selectedWpVersion !== currentWpVersion;
+				const hasPhpVersionChanged = selectedPhpVersion !== selectedSite.phpVersion;
+				const needsRestart = running && ( hasWpVersionChanged || hasPhpVersionChanged );
+				if ( needsRestart ) {
+					await stopServer( selectedSite.id );
+				}
+
+				if ( hasWpVersionChanged ) {
+					try {
+						await getIpcApi().executeWPCLiInline( {
+							siteId: selectedSite.id,
+							args: `core update --version=${ selectedWpVersion } --force`,
+							skipPluginsAndThemes: false,
+						} );
+					} catch ( wpError ) {
+						console.error( 'Error updating WordPress version:', wpError );
+						setEditSiteError( ( wpError as Error )?.message );
+						getIpcApi().showErrorMessageBox( {
+							title: __( 'Error updating WordPress version' ),
+							message: ( wpError as Error )?.message,
+						} );
+						return;
+					}
+				}
+
 				await updateSite( {
 					...selectedSite,
 					name: siteName,
 					phpVersion: selectedPhpVersion,
 				} );
-				if ( running && selectedSite.phpVersion !== selectedPhpVersion ) {
-					await stopServer( selectedSite.id );
+
+				if ( needsRestart ) {
 					await startServer( selectedSite.id );
 				}
-				setShowModal( false );
+
+				closeModal();
 				resetLocalState();
 			} catch ( e ) {
 				setEditSiteError( ( e as Error )?.message );
@@ -65,13 +100,17 @@ export default function EditSiteDetails() {
 			setIsEditingSite( false );
 		},
 		[
-			updateSite,
 			selectedSite,
-			siteName,
+			selectedWpVersion,
+			currentWpVersion,
 			selectedPhpVersion,
+			updateSite,
+			siteName,
+			closeModal,
 			resetLocalState,
-			startServer,
 			stopServer,
+			__,
+			startServer,
 		]
 	);
 
@@ -83,7 +122,7 @@ export default function EditSiteDetails() {
 					title={ __( 'Edit site' ) }
 					isDismissible
 					focusOnMount="firstContentElement"
-					onRequestClose={ resetLocalState }
+					onRequestClose={ closeModal }
 				>
 					<form onSubmit={ onSiteEdit }>
 						<div className="flex flex-col gap-6">
@@ -113,8 +152,11 @@ export default function EditSiteDetails() {
 									<span className="font-semibold">{ __( 'WordPress version' ) }</span>
 									<SelectControl
 										value={ selectedWpVersion }
-										options={ wordpressVersions }
-										onChange={ ( version ) => setSelectedWpVersion( version ) }
+										options={ wordpressVersions.map( ( { label, value } ) => ( {
+											label,
+											value,
+										} ) ) }
+										onChange={ setSelectedWpVersion }
 										__next40pxDefaultSize
 									/>
 								</label>
@@ -122,7 +164,7 @@ export default function EditSiteDetails() {
 						</div>
 
 						<div className="flex flex-row justify-end gap-x-5 mt-6">
-							<Button onClick={ resetLocalState } disabled={ isEditingSite } variant="tertiary">
+							<Button onClick={ closeModal } disabled={ isEditingSite } variant="tertiary">
 								{ __( 'Cancel' ) }
 							</Button>
 							<Button
@@ -133,7 +175,8 @@ export default function EditSiteDetails() {
 									isEditingSite ||
 										! selectedSite ||
 										( selectedSite?.name === siteName &&
-											selectedSite?.phpVersion === selectedPhpVersion ) ||
+											selectedSite?.phpVersion === selectedPhpVersion &&
+											currentWpVersion === selectedWpVersion ) ||
 										! siteName.trim() ||
 										editSiteError
 								) }

--- a/src/modules/site-settings/edit-site-details.tsx
+++ b/src/modules/site-settings/edit-site-details.tsx
@@ -4,9 +4,11 @@ import { useI18n } from '@wordpress/react-i18n';
 import { FormEvent, useCallback, useState } from 'react';
 import stripAnsi from 'strip-ansi';
 import Button from 'src/components/button';
+import { ErrorInformation } from 'src/components/error-information';
 import Modal from 'src/components/modal';
 import TextControlComponent from 'src/components/text-control';
 import { useSiteDetails } from 'src/hooks/use-site-details';
+import { cx } from 'src/lib/cx';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 import { useRootSelector } from 'src/stores';
 import { wordpressVersionsSelectors } from 'src/stores/wordpress-versions-slice';
@@ -20,7 +22,7 @@ type EditSiteDetailsProps = {
 export default function EditSiteDetails( { currentWpVersion, onSave }: EditSiteDetailsProps ) {
 	const { __ } = useI18n();
 	const { updateSite, selectedSite, stopServer, startServer } = useSiteDetails();
-	const [ editSiteError, setEditSiteError ] = useState( '' );
+	const [ changeWpError, setChangeWpError ] = useState( '' );
 	const [ showModal, setShowModal ] = useState( false );
 	const [ isEditingSite, setIsEditingSite ] = useState( false );
 	const closeModal = useCallback( () => {
@@ -50,7 +52,7 @@ export default function EditSiteDetails( { currentWpVersion, onSave }: EditSiteD
 		setSiteName( selectedSite.name );
 		setSelectedPhpVersion( selectedSite.phpVersion as SupportedPHPVersion );
 		setSelectedWpVersion( currentWpVersion );
-		setEditSiteError( '' );
+		setChangeWpError( '' );
 	}, [ currentWpVersion, selectedSite ] );
 
 	const onSiteEdit = async ( event: FormEvent ) => {
@@ -59,7 +61,7 @@ export default function EditSiteDetails( { currentWpVersion, onSave }: EditSiteD
 			return;
 		}
 		setIsEditingSite( true );
-		setEditSiteError( '' );
+		setChangeWpError( '' );
 		try {
 			const running = selectedSite.running;
 
@@ -83,7 +85,7 @@ export default function EditSiteDetails( { currentWpVersion, onSave }: EditSiteD
 				} catch ( wpError ) {
 					console.error( 'Error changing WordPress version:', wpError );
 					const errorMessage = stripAnsi( ( wpError as Error )?.message );
-					setEditSiteError( __( 'Error changing WordPress version' ) );
+					setChangeWpError( __( 'Error changing WordPress version' ) );
 					getIpcApi().showErrorMessageBox( {
 						title: __( 'Error changing WordPress version' ),
 						message: errorMessage,
@@ -107,7 +109,7 @@ export default function EditSiteDetails( { currentWpVersion, onSave }: EditSiteD
 			closeModal();
 			resetFormState();
 		} catch ( e ) {
-			setEditSiteError( ( e as Error )?.message );
+			setChangeWpError( ( e as Error )?.message );
 		}
 		setIsEditingSite( false );
 	};
@@ -161,7 +163,9 @@ export default function EditSiteDetails( { currentWpVersion, onSave }: EditSiteD
 							</div>
 						</div>
 
-						{ editSiteError && <div className="mt-4 text-red-500">{ editSiteError }</div> }
+						{ changeWpError && (
+							<ErrorInformation className="mt-4">{ changeWpError }</ErrorInformation>
+						) }
 
 						<div className="flex flex-row justify-end gap-x-5 mt-6">
 							<Button onClick={ closeModal } disabled={ isEditingSite } variant="tertiary">

--- a/src/modules/site-settings/edit-site-details.tsx
+++ b/src/modules/site-settings/edit-site-details.tsx
@@ -12,7 +12,12 @@ import { useRootSelector } from 'src/stores';
 import { wordpressVersionsSelectors } from 'src/stores/wordpress-versions-slice';
 import { DEFAULT_PHP_VERSION } from 'vendor/wp-now/src/constants';
 
-export default function EditSiteDetails( { currentWpVersion }: { currentWpVersion: string } ) {
+type EditSiteDetailsProps = {
+	currentWpVersion: string;
+	onSave: () => void;
+};
+
+export default function EditSiteDetails( { currentWpVersion, onSave }: EditSiteDetailsProps ) {
 	const { __ } = useI18n();
 	const { updateSite, selectedSite, stopServer, startServer } = useSiteDetails();
 	const [ editSiteError, setEditSiteError ] = useState( '' );
@@ -48,79 +53,64 @@ export default function EditSiteDetails( { currentWpVersion }: { currentWpVersio
 		setEditSiteError( '' );
 	}, [ currentWpVersion, selectedSite ] );
 
-	const onSiteEdit = useCallback(
-		async ( event: FormEvent ) => {
-			event.preventDefault();
-			if ( ! selectedSite?.id ) {
-				return;
+	const onSiteEdit = async ( event: FormEvent ) => {
+		event.preventDefault();
+		if ( ! selectedSite?.id ) {
+			return;
+		}
+		setIsEditingSite( true );
+		setEditSiteError( '' );
+		try {
+			const running = selectedSite.running;
+
+			const hasWpVersionChanged = selectedWpVersion !== currentWpVersion;
+			const hasPhpVersionChanged = selectedPhpVersion !== selectedSite.phpVersion;
+			const needsRestart = running && ( hasWpVersionChanged || hasPhpVersionChanged );
+			if ( needsRestart ) {
+				await stopServer( selectedSite.id );
 			}
-			setIsEditingSite( true );
-			setEditSiteError( '' );
-			try {
-				const running = selectedSite.running;
 
-				const hasWpVersionChanged = selectedWpVersion !== currentWpVersion;
-				const hasPhpVersionChanged = selectedPhpVersion !== selectedSite.phpVersion;
-				const needsRestart = running && ( hasWpVersionChanged || hasPhpVersionChanged );
-				if ( needsRestart ) {
-					await stopServer( selectedSite.id );
-				}
-
-				if ( hasWpVersionChanged ) {
-					try {
-						const result = await getIpcApi().executeWPCLiInline( {
-							siteId: selectedSite.id,
-							args: `core update --version=${ selectedWpVersion } --force`,
-							skipPluginsAndThemes: true,
-						} );
-						if ( result.exitCode !== 0 ) {
-							throw new Error( result.stderr );
-						}
-					} catch ( wpError ) {
-						console.error( 'Error updating WordPress version:', wpError );
-						const errorMessage = stripAnsi( ( wpError as Error )?.message );
-						setEditSiteError( __( 'Error updating WordPress version' ) );
-						getIpcApi().showErrorMessageBox( {
-							title: __( 'Error updating WordPress version' ),
-							message: errorMessage,
-						} );
-						setSelectedWpVersion( currentWpVersion );
-						setIsEditingSite( false );
-						return;
+			if ( hasWpVersionChanged ) {
+				try {
+					const result = await getIpcApi().executeWPCLiInline( {
+						siteId: selectedSite.id,
+						args: `core update --version=${ selectedWpVersion } --force`,
+						skipPluginsAndThemes: true,
+					} );
+					if ( result.exitCode !== 0 ) {
+						throw new Error( result.stderr );
 					}
+				} catch ( wpError ) {
+					console.error( 'Error updating WordPress version:', wpError );
+					const errorMessage = stripAnsi( ( wpError as Error )?.message );
+					setEditSiteError( __( 'Error updating WordPress version' ) );
+					getIpcApi().showErrorMessageBox( {
+						title: __( 'Error updating WordPress version' ),
+						message: errorMessage,
+					} );
+					setSelectedWpVersion( currentWpVersion );
+					setIsEditingSite( false );
+					return;
 				}
-
-				await updateSite( {
-					...selectedSite,
-					name: siteName,
-					phpVersion: selectedPhpVersion,
-				} );
-
-				if ( needsRestart ) {
-					await startServer( selectedSite.id );
-				}
-
-				closeModal();
-				resetFormState();
-			} catch ( e ) {
-				setEditSiteError( ( e as Error )?.message );
 			}
-			setIsEditingSite( false );
-		},
-		[
-			selectedSite,
-			selectedWpVersion,
-			currentWpVersion,
-			selectedPhpVersion,
-			updateSite,
-			siteName,
-			closeModal,
-			resetFormState,
-			stopServer,
-			__,
-			startServer,
-		]
-	);
+
+			await updateSite( {
+				...selectedSite,
+				name: siteName,
+				phpVersion: selectedPhpVersion,
+			} );
+
+			if ( needsRestart ) {
+				await startServer( selectedSite.id );
+			}
+			onSave();
+			closeModal();
+			resetFormState();
+		} catch ( e ) {
+			setEditSiteError( ( e as Error )?.message );
+		}
+		setIsEditingSite( false );
+	};
 
 	return (
 		<>

--- a/src/modules/site-settings/edit-site-details.tsx
+++ b/src/modules/site-settings/edit-site-details.tsx
@@ -29,6 +29,13 @@ export default function EditSiteDetails( { currentWpVersion }: { currentWpVersio
 	);
 	const [ selectedWpVersion, setSelectedWpVersion ] = useState( currentWpVersion );
 	const wordpressVersions = useRootSelector( wordpressVersionsSelectors.selectWordPressVersions );
+	const wordpressVersionOptions = wordpressVersions.map( ( version ) => ( {
+		label: version.label,
+		value: version.value,
+	} ) );
+	if ( ! wordpressVersionOptions.some( ( version ) => version.value === currentWpVersion ) ) {
+		wordpressVersionOptions.push( { label: currentWpVersion, value: currentWpVersion } );
+	}
 
 	const resetFormState = useCallback( () => {
 		if ( ! selectedSite ) {
@@ -148,10 +155,7 @@ export default function EditSiteDetails( { currentWpVersion }: { currentWpVersio
 									<SelectControl
 										disabled={ isEditingSite }
 										value={ selectedWpVersion }
-										options={ wordpressVersions.map( ( { label, value } ) => ( {
-											label,
-											value,
-										} ) ) }
+										options={ wordpressVersionOptions }
 										onChange={ setSelectedWpVersion }
 										__next40pxDefaultSize
 									/>

--- a/src/modules/site-settings/edit-site-details.tsx
+++ b/src/modules/site-settings/edit-site-details.tsx
@@ -81,11 +81,11 @@ export default function EditSiteDetails( { currentWpVersion, onSave }: EditSiteD
 						throw new Error( result.stderr );
 					}
 				} catch ( wpError ) {
-					console.error( 'Error updating WordPress version:', wpError );
+					console.error( 'Error changing WordPress version:', wpError );
 					const errorMessage = stripAnsi( ( wpError as Error )?.message );
-					setEditSiteError( __( 'Error updating WordPress version' ) );
+					setEditSiteError( __( 'Error changing WordPress version' ) );
 					getIpcApi().showErrorMessageBox( {
-						title: __( 'Error updating WordPress version' ),
+						title: __( 'Error changing WordPress version' ),
 						message: errorMessage,
 					} );
 					setSelectedWpVersion( currentWpVersion );

--- a/src/modules/site-settings/edit-site-details.tsx
+++ b/src/modules/site-settings/edit-site-details.tsx
@@ -2,6 +2,7 @@ import { SupportedPHPVersion, SupportedPHPVersions } from '@php-wasm/universal';
 import { SelectControl } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
 import { FormEvent, useCallback, useState } from 'react';
+import stripAnsi from 'strip-ansi';
 import Button from 'src/components/button';
 import Modal from 'src/components/modal';
 import TextControlComponent from 'src/components/text-control';
@@ -54,6 +55,7 @@ export default function EditSiteDetails( { currentWpVersion }: { currentWpVersio
 				return;
 			}
 			setIsEditingSite( true );
+			setEditSiteError( '' );
 			try {
 				const running = selectedSite.running;
 
@@ -66,18 +68,24 @@ export default function EditSiteDetails( { currentWpVersion }: { currentWpVersio
 
 				if ( hasWpVersionChanged ) {
 					try {
-						await getIpcApi().executeWPCLiInline( {
+						const result = await getIpcApi().executeWPCLiInline( {
 							siteId: selectedSite.id,
 							args: `core update --version=${ selectedWpVersion } --force`,
 							skipPluginsAndThemes: true,
 						} );
+						if ( result.exitCode !== 0 ) {
+							throw new Error( result.stderr );
+						}
 					} catch ( wpError ) {
 						console.error( 'Error updating WordPress version:', wpError );
-						setEditSiteError( ( wpError as Error )?.message );
+						const errorMessage = stripAnsi( ( wpError as Error )?.message );
+						setEditSiteError( __( 'Error updating WordPress version' ) );
 						getIpcApi().showErrorMessageBox( {
 							title: __( 'Error updating WordPress version' ),
-							message: ( wpError as Error )?.message,
+							message: errorMessage,
 						} );
+						setSelectedWpVersion( currentWpVersion );
+						setIsEditingSite( false );
 						return;
 					}
 				}
@@ -163,6 +171,8 @@ export default function EditSiteDetails( { currentWpVersion }: { currentWpVersio
 							</div>
 						</div>
 
+						{ editSiteError && <div className="mt-4 text-red-500">{ editSiteError }</div> }
+
 						<div className="flex flex-row justify-end gap-x-5 mt-6">
 							<Button onClick={ closeModal } disabled={ isEditingSite } variant="tertiary">
 								{ __( 'Cancel' ) }
@@ -177,8 +187,7 @@ export default function EditSiteDetails( { currentWpVersion }: { currentWpVersio
 										( selectedSite?.name === siteName &&
 											selectedSite?.phpVersion === selectedPhpVersion &&
 											currentWpVersion === selectedWpVersion ) ||
-										! siteName.trim() ||
-										editSiteError
+										! siteName.trim()
 								) }
 							>
 								{ isEditingSite ? __( 'Saving…' ) : __( 'Save' ) }

--- a/src/modules/site-settings/edit-site-details.tsx
+++ b/src/modules/site-settings/edit-site-details.tsx
@@ -69,7 +69,7 @@ export default function EditSiteDetails( { currentWpVersion }: { currentWpVersio
 						await getIpcApi().executeWPCLiInline( {
 							siteId: selectedSite.id,
 							args: `core update --version=${ selectedWpVersion } --force`,
-							skipPluginsAndThemes: false,
+							skipPluginsAndThemes: true,
 						} );
 					} catch ( wpError ) {
 						console.error( 'Error updating WordPress version:', wpError );

--- a/src/modules/site-settings/edit-site-details.tsx
+++ b/src/modules/site-settings/edit-site-details.tsx
@@ -139,7 +139,7 @@ export default function EditSiteDetails( { currentWpVersion, onSave }: EditSiteD
 								></TextControlComponent>
 							</label>
 
-							<div className="flex flex-row gap-x-6">
+							<div className="flex flex-row gap-x-6 pb-2">
 								<label className="flex flex-1 flex-col gap-1.5 leading-4">
 									<span className="font-semibold">{ __( 'PHP version' ) }</span>
 									<SelectControl
@@ -151,6 +151,7 @@ export default function EditSiteDetails( { currentWpVersion, onSave }: EditSiteD
 										} ) ) }
 										onChange={ ( version ) => setSelectedPhpVersion( version ) }
 										__next40pxDefaultSize
+										__nextHasNoMarginBottom
 									/>
 								</label>
 
@@ -163,6 +164,7 @@ export default function EditSiteDetails( { currentWpVersion, onSave }: EditSiteD
 										options={ wordpressVersionOptions }
 										onChange={ setSelectedWpVersion }
 										__next40pxDefaultSize
+										__nextHasNoMarginBottom
 									/>
 								</label>
 							</div>

--- a/src/modules/site-settings/tests/edit-site-details.test.tsx
+++ b/src/modules/site-settings/tests/edit-site-details.test.tsx
@@ -1,0 +1,269 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import EditSiteDetails from 'src/modules/site-settings/edit-site-details';
+
+// Mock the hooks and dependencies
+const mockUpdateSite = jest.fn();
+const mockStopServer = jest.fn();
+const mockStartServer = jest.fn();
+const mockExecuteWPCLiInline = jest.fn();
+const mockShowErrorMessageBox = jest.fn();
+
+jest.mock( 'src/hooks/use-site-details', () => ( {
+	useSiteDetails: () => ( {
+		selectedSite: {
+			id: 'site-123',
+			name: 'Test Site',
+			phpVersion: '8.0',
+			running: true,
+		},
+		updateSite: mockUpdateSite,
+		stopServer: mockStopServer,
+		startServer: mockStartServer,
+	} ),
+} ) );
+
+jest.mock( 'src/lib/get-ipc-api', () => ( {
+	getIpcApi: () => ( {
+		executeWPCLiInline: mockExecuteWPCLiInline,
+		showErrorMessageBox: mockShowErrorMessageBox,
+	} ),
+} ) );
+
+jest.mock( '@wordpress/react-i18n', () => ( {
+	useI18n: () => ( {
+		__: ( text: string ) => text,
+	} ),
+} ) );
+
+jest.mock( 'src/stores', () => ( {
+	useRootSelector: jest.fn().mockImplementation( () => {
+		// Mock the WordPress versions selector
+		return [
+			{ label: '6.4', value: '6.4' },
+			{ label: '6.3', value: '6.3' },
+			{ label: '6.2', value: '6.2' },
+		];
+	} ),
+} ) );
+
+describe( 'EditSiteDetails', () => {
+	const defaultProps = {
+		currentWpVersion: '6.3',
+		onSave: jest.fn(),
+	};
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockExecuteWPCLiInline.mockResolvedValue( { exitCode: 0 } );
+	} );
+
+	it( 'should render the edit button', () => {
+		render( <EditSiteDetails { ...defaultProps } /> );
+		expect( screen.getByRole( 'button', { name: 'Edit site' } ) ).toBeInTheDocument();
+	} );
+
+	it( 'should open the modal when edit button is clicked', async () => {
+		render( <EditSiteDetails { ...defaultProps } /> );
+		const user = userEvent.setup();
+
+		await user.click( screen.getByRole( 'button', { name: 'Edit site' } ) );
+
+		expect( screen.getByRole( 'dialog' ) ).toBeInTheDocument();
+		expect( screen.getByLabelText( 'Site name' ) ).toHaveValue( 'Test Site' );
+		expect( screen.getByLabelText( 'PHP version' ) ).toHaveValue( '8.0' );
+		expect( screen.getByLabelText( 'WordPress version' ) ).toHaveValue( '6.3' );
+	} );
+
+	it( 'should close the modal when cancel button is clicked', async () => {
+		render( <EditSiteDetails { ...defaultProps } /> );
+		const user = userEvent.setup();
+
+		await user.click( screen.getByRole( 'button', { name: 'Edit site' } ) );
+		await user.click( screen.getByRole( 'button', { name: 'Cancel' } ) );
+
+		expect( screen.queryByRole( 'dialog' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'should disable the save button when no changes are made', async () => {
+		render( <EditSiteDetails { ...defaultProps } /> );
+		const user = userEvent.setup();
+
+		await user.click( screen.getByRole( 'button', { name: 'Edit site' } ) );
+
+		expect( screen.getByRole( 'button', { name: 'Save' } ) ).toBeDisabled();
+	} );
+
+	it( 'should enable the save button when site name is changed', async () => {
+		render( <EditSiteDetails { ...defaultProps } /> );
+		const user = userEvent.setup();
+
+		await user.click( screen.getByRole( 'button', { name: 'Edit site' } ) );
+
+		const siteNameInput = screen.getByLabelText( 'Site name' );
+		await user.clear( siteNameInput );
+		await user.type( siteNameInput, 'New Site Name' );
+
+		expect( screen.getByRole( 'button', { name: 'Save' } ) ).toBeEnabled();
+	} );
+
+	it( 'should enable the save button when PHP version is changed', async () => {
+		render( <EditSiteDetails { ...defaultProps } /> );
+		const user = userEvent.setup();
+
+		await user.click( screen.getByRole( 'button', { name: 'Edit site' } ) );
+
+		const phpVersionSelect = screen.getByLabelText( 'PHP version' );
+		await user.selectOptions( phpVersionSelect, '8.2' );
+
+		expect( screen.getByRole( 'button', { name: 'Save' } ) ).toBeEnabled();
+	} );
+
+	it( 'should enable the save button when WordPress version is changed', async () => {
+		render( <EditSiteDetails { ...defaultProps } /> );
+		const user = userEvent.setup();
+
+		await user.click( screen.getByRole( 'button', { name: 'Edit site' } ) );
+
+		const wpVersionSelect = screen.getByLabelText( 'WordPress version' );
+		await user.selectOptions( wpVersionSelect, '6.4' );
+
+		expect( screen.getByRole( 'button', { name: 'Save' } ) ).toBeEnabled();
+	} );
+
+	it( 'should disable the save button when site name is empty', async () => {
+		render( <EditSiteDetails { ...defaultProps } /> );
+		const user = userEvent.setup();
+
+		await user.click( screen.getByRole( 'button', { name: 'Edit site' } ) );
+
+		const siteNameInput = screen.getByLabelText( 'Site name' );
+		await user.clear( siteNameInput );
+
+		expect( screen.getByRole( 'button', { name: 'Save' } ) ).toBeDisabled();
+	} );
+
+	it( 'should update site when save button is clicked with changed site name', async () => {
+		render( <EditSiteDetails { ...defaultProps } /> );
+		const user = userEvent.setup();
+
+		await user.click( screen.getByRole( 'button', { name: 'Edit site' } ) );
+
+		const siteNameInput = screen.getByLabelText( 'Site name' );
+		await user.clear( siteNameInput );
+		await user.type( siteNameInput, 'New Site Name' );
+
+		await user.click( screen.getByRole( 'button', { name: 'Save' } ) );
+
+		expect( mockUpdateSite ).toHaveBeenCalledWith( {
+			id: 'site-123',
+			name: 'New Site Name',
+			phpVersion: '8.0',
+			running: true,
+		} );
+		expect( defaultProps.onSave ).toHaveBeenCalled();
+	} );
+
+	it( 'should update site and restart server when PHP version is changed', async () => {
+		render( <EditSiteDetails { ...defaultProps } /> );
+		const user = userEvent.setup();
+
+		await user.click( screen.getByRole( 'button', { name: 'Edit site' } ) );
+
+		const phpVersionSelect = screen.getByLabelText( 'PHP version' );
+		await user.selectOptions( phpVersionSelect, '8.2' );
+
+		await user.click( screen.getByRole( 'button', { name: 'Save' } ) );
+
+		expect( mockStopServer ).toHaveBeenCalledWith( 'site-123' );
+		expect( mockUpdateSite ).toHaveBeenCalledWith( {
+			id: 'site-123',
+			name: 'Test Site',
+			phpVersion: '8.2',
+			running: true,
+		} );
+		expect( mockStartServer ).toHaveBeenCalledWith( 'site-123' );
+		expect( defaultProps.onSave ).toHaveBeenCalled();
+	} );
+
+	it( 'should update WordPress version when changed', async () => {
+		render( <EditSiteDetails { ...defaultProps } /> );
+		const user = userEvent.setup();
+
+		await user.click( screen.getByRole( 'button', { name: 'Edit site' } ) );
+
+		const wpVersionSelect = screen.getByLabelText( 'WordPress version' );
+		await user.selectOptions( wpVersionSelect, '6.4' );
+
+		await user.click( screen.getByRole( 'button', { name: 'Save' } ) );
+
+		expect( mockStopServer ).toHaveBeenCalledWith( 'site-123' );
+		expect( mockExecuteWPCLiInline ).toHaveBeenCalledWith( {
+			siteId: 'site-123',
+			args: 'core update --version=6.4 --force',
+			skipPluginsAndThemes: true,
+		} );
+		expect( mockUpdateSite ).toHaveBeenCalledWith( {
+			id: 'site-123',
+			name: 'Test Site',
+			phpVersion: '8.0',
+			running: true,
+		} );
+		expect( mockStartServer ).toHaveBeenCalledWith( 'site-123' );
+		expect( defaultProps.onSave ).toHaveBeenCalled();
+	} );
+
+	it( 'should show error when WordPress version update fails', async () => {
+		mockExecuteWPCLiInline.mockResolvedValue( { exitCode: 1, stderr: 'Update failed' } );
+
+		render( <EditSiteDetails { ...defaultProps } /> );
+		const user = userEvent.setup();
+
+		await user.click( screen.getByRole( 'button', { name: 'Edit site' } ) );
+
+		const wpVersionSelect = screen.getByLabelText( 'WordPress version' );
+		await user.selectOptions( wpVersionSelect, '6.4' );
+
+		await user.click( screen.getByRole( 'button', { name: 'Save' } ) );
+
+		await waitFor( () => {
+			expect( mockShowErrorMessageBox ).toHaveBeenCalledWith( {
+				title: 'Error changing WordPress version',
+				message: 'Update failed',
+			} );
+		} );
+
+		expect( screen.getByText( 'Error changing WordPress version' ) ).toBeInTheDocument();
+	} );
+
+	it( 'should disable form controls when site is being edited', async () => {
+		// Mock the updateSite to delay completion
+		mockUpdateSite.mockImplementation(
+			() => new Promise( ( resolve ) => setTimeout( resolve, 100 ) )
+		);
+
+		render( <EditSiteDetails { ...defaultProps } /> );
+		const user = userEvent.setup();
+
+		await user.click( screen.getByRole( 'button', { name: 'Edit site' } ) );
+
+		const siteNameInput = screen.getByLabelText( 'Site name' );
+		await user.clear( siteNameInput );
+		await user.type( siteNameInput, 'New Site Name' );
+
+		const saveButton = screen.getByRole( 'button', { name: 'Save' } );
+		await user.click( saveButton );
+
+		// Check that controls are disabled during save
+		expect( screen.getByRole( 'button', { name: 'Saving…' } ) ).toBeInTheDocument();
+		expect( screen.getByLabelText( 'Site name' ) ).toBeDisabled();
+		expect( screen.getByLabelText( 'PHP version' ) ).toBeDisabled();
+		expect( screen.getByLabelText( 'WordPress version' ) ).toBeDisabled();
+		expect( screen.getByRole( 'button', { name: 'Cancel' } ) ).toBeDisabled();
+
+		// Wait for the update to complete
+		await waitFor( () => {
+			expect( mockUpdateSite ).toHaveBeenCalled();
+		} );
+	} );
+} );

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -133,6 +133,9 @@ a8cToTailwindColors[ `${ PREFIX }-blueberry-5` ] = '#F7F8FE'; // WordPress Blue 
 a8cToTailwindColors[ `${ PREFIX }-blueberry` ] = '#3858E9'; // WordPress Blue
 a8cToTailwindColors[ `${ PREFIX }-blueberry-70` ] = '#1d35b4'; // WordPress Blue 70
 a8cToTailwindColors[ `${ PREFIX }-gray-700` ] = '#757575'; // Gray 700
+a8cToTailwindColors[ `${ PREFIX }-gray-400` ] = '#CCC'; // Gray 400
+a8cToTailwindColors[ `${ PREFIX }-gray-600` ] = '#949494'; // Gray 600
+a8cToTailwindColors[ `${ PREFIX }-gray-100` ] = '#f0f0f0'; // Gray 100
 
 module.exports = {
 	content: [ './src/**/*.{html,ejs,js,jsx,ts,tsx}' ],


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/dotcom-forge/issues/10536

## Proposed Changes

- Add the ability to change WordPress version in the settings modal

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run

**Change WordPress version**

- Run `STUDIO_WP_VERSIONS=true npm start`
- Go to settings tab
- Click Edit, next to Site Details
- Select a different WordPress version
- Save
- Wait ~1 minute
- Start the site if it was not started before
- Open wp-admin
- Observe the WordPress version installed is what you selected before.
- Repeat with beta versions, downgrading, upgrading and confirm it works as expected.

**Change name and PHP version**

- Confirm editing the name and PHP version are working as expected.

https://github.com/user-attachments/assets/3855c96c-0e14-49cc-a5c1-24a60676c8ee

**Error message**

We display an error message when the wp version update fails. An easy way to reproduce is updating a beta in a WP site in "Spanish": https://github.com/Automattic/dotcom-forge/issues/10568

- Change your languages to Spanish or other language
- Select your a beta version 
- Save
- Observe the alert and error message. The error message says: `Failed download`
- Change the WP version to a valid version
- Confirm it works as expected, and the error message disappears when you click save.


https://github.com/user-attachments/assets/176c0f98-fca7-41fa-9913-7fb8bbd77b65


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
