### PR TITLE
Studio: Limit PHP versions from edit-site-form and add-site form

### DIFF
--- a/src/components/site-form.tsx
+++ b/src/components/site-form.tsx
@@ -1,4 +1,3 @@
-import { SupportedPHPVersion, SupportedPHPVersionsList } from '@php-wasm/universal';
 import { Icon, SelectControl } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -21,7 +20,9 @@ import {
 	wordpressVersionsSelectors,
 	wordpressVersionsThunks,
 } from 'src/stores/wordpress-versions-slice';
-import { DEFAULT_WORDPRESS_VERSION } from 'vendor/wp-now/src/constants';
+import { DEFAULT_WORDPRESS_VERSION, ALLOWED_PHP_VERSIONS } from 'vendor/wp-now/src/constants';
+
+type AllowedPHPVersion = ( typeof ALLOWED_PHP_VERSIONS )[ number ];
 
 interface FormPathInputComponentProps {
 	value: string;
@@ -67,8 +68,8 @@ interface SiteFormBaseProps {
 interface SiteFormWithVersionsProps extends SiteFormBaseProps {
 	// TODO: allowVersionsChange should be removed once we have the versions selects in edit site page.
 	allowVersionsChange: true;
-	phpVersion: SupportedPHPVersion;
-	setPhpVersion: ( version: SupportedPHPVersion ) => void;
+	phpVersion: AllowedPHPVersion;
+	setPhpVersion: ( version: AllowedPHPVersion ) => void;
 	wpVersion: string;
 	setWpVersion: ( version: string ) => void;
 }
@@ -406,12 +407,10 @@ export const SiteForm = ( {
 													<SelectControl
 														id="php-version-select"
 														value={ phpVersion }
-														options={ SupportedPHPVersionsList.map( ( version ) => {
-															return {
-																label: version,
-																value: version,
-															};
-														} ) }
+														options={ ALLOWED_PHP_VERSIONS.map( ( version ) => ( {
+															label: version,
+															value: version,
+														} ) ) }
 														onChange={ setPhpVersion as ( value: string ) => void }
 														__next40pxDefaultSize
 													/>

--- a/src/components/site-form.tsx
+++ b/src/components/site-form.tsx
@@ -20,9 +20,11 @@ import {
 	wordpressVersionsSelectors,
 	wordpressVersionsThunks,
 } from 'src/stores/wordpress-versions-slice';
-import { DEFAULT_WORDPRESS_VERSION, ALLOWED_PHP_VERSIONS } from 'vendor/wp-now/src/constants';
-
-type AllowedPHPVersion = ( typeof ALLOWED_PHP_VERSIONS )[ number ];
+import {
+	DEFAULT_WORDPRESS_VERSION,
+	ALLOWED_PHP_VERSIONS,
+	AllowedPHPVersion,
+} from 'vendor/wp-now/src/constants';
 
 interface FormPathInputComponentProps {
 	value: string;

--- a/src/hooks/use-add-site.ts
+++ b/src/hooks/use-add-site.ts
@@ -1,4 +1,3 @@
-import { SupportedPHPVersion } from '@php-wasm/universal';
 import * as Sentry from '@sentry/electron/renderer';
 import { useI18n } from '@wordpress/react-i18n';
 import { useCallback, useMemo, useState } from 'react';
@@ -6,7 +5,13 @@ import { useFeatureFlags } from 'src/hooks/use-feature-flags';
 import { useImportExport } from 'src/hooks/use-import-export';
 import { useSiteDetails } from 'src/hooks/use-site-details';
 import { getIpcApi } from 'src/lib/get-ipc-api';
-import { DEFAULT_PHP_VERSION, DEFAULT_WORDPRESS_VERSION } from 'vendor/wp-now/src/constants';
+import {
+	DEFAULT_PHP_VERSION,
+	DEFAULT_WORDPRESS_VERSION,
+	ALLOWED_PHP_VERSIONS,
+} from 'vendor/wp-now/src/constants';
+
+type AllowedPHPVersion = ( typeof ALLOWED_PHP_VERSIONS )[ number ];
 
 export function useAddSite() {
 	const { __ } = useI18n();
@@ -19,8 +24,8 @@ export function useAddSite() {
 	const [ proposedSitePath, setProposedSitePath ] = useState( '' );
 	const [ doesPathContainWordPress, setDoesPathContainWordPress ] = useState( false );
 	const [ fileForImport, setFileForImport ] = useState< File | null >( null );
-	const [ phpVersion, setPhpVersion ] = useState< SupportedPHPVersion >(
-		DEFAULT_PHP_VERSION as SupportedPHPVersion
+	const [ phpVersion, setPhpVersion ] = useState< AllowedPHPVersion >(
+		DEFAULT_PHP_VERSION as AllowedPHPVersion
 	);
 	const [ wpVersion, setWpVersion ] = useState( DEFAULT_WORDPRESS_VERSION );
 

--- a/src/hooks/use-add-site.ts
+++ b/src/hooks/use-add-site.ts
@@ -8,10 +8,8 @@ import { getIpcApi } from 'src/lib/get-ipc-api';
 import {
 	DEFAULT_PHP_VERSION,
 	DEFAULT_WORDPRESS_VERSION,
-	ALLOWED_PHP_VERSIONS,
+	AllowedPHPVersion,
 } from 'vendor/wp-now/src/constants';
-
-type AllowedPHPVersion = ( typeof ALLOWED_PHP_VERSIONS )[ number ];
 
 export function useAddSite() {
 	const { __ } = useI18n();

--- a/src/modules/site-settings/edit-site-details.tsx
+++ b/src/modules/site-settings/edit-site-details.tsx
@@ -15,9 +15,11 @@ import { getIpcApi } from 'src/lib/get-ipc-api';
 import { getWordPressVersionUrl } from 'src/lib/get-wordpress-version-url';
 import { useRootSelector } from 'src/stores';
 import { wordpressVersionsSelectors } from 'src/stores/wordpress-versions-slice';
-import { DEFAULT_PHP_VERSION, ALLOWED_PHP_VERSIONS } from 'vendor/wp-now/src/constants';
-
-type AllowedPHPVersion = ( typeof ALLOWED_PHP_VERSIONS )[ number ];
+import {
+	DEFAULT_PHP_VERSION,
+	ALLOWED_PHP_VERSIONS,
+	AllowedPHPVersion,
+} from 'vendor/wp-now/src/constants';
 
 type EditSiteDetailsProps = {
 	currentWpVersion: string;

--- a/src/modules/site-settings/edit-site-details.tsx
+++ b/src/modules/site-settings/edit-site-details.tsx
@@ -1,4 +1,3 @@
-import { SupportedPHPVersion, SupportedPHPVersions } from '@php-wasm/universal';
 import { SelectControl } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
 import { FormEvent, useCallback, useState } from 'react';
@@ -12,7 +11,9 @@ import { cx } from 'src/lib/cx';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 import { useRootSelector } from 'src/stores';
 import { wordpressVersionsSelectors } from 'src/stores/wordpress-versions-slice';
-import { DEFAULT_PHP_VERSION } from 'vendor/wp-now/src/constants';
+import { DEFAULT_PHP_VERSION, ALLOWED_PHP_VERSIONS } from 'vendor/wp-now/src/constants';
+
+type AllowedPHPVersion = ( typeof ALLOWED_PHP_VERSIONS )[ number ];
 
 type EditSiteDetailsProps = {
 	currentWpVersion: string;
@@ -32,8 +33,8 @@ export default function EditSiteDetails( { currentWpVersion, onSave }: EditSiteD
 		setShowModal( false );
 	}, [ isEditingSite ] );
 	const [ siteName, setSiteName ] = useState( selectedSite?.name ?? '' );
-	const [ selectedPhpVersion, setSelectedPhpVersion ] = useState< SupportedPHPVersion >(
-		( selectedSite?.phpVersion as SupportedPHPVersion ) ?? DEFAULT_PHP_VERSION
+	const [ selectedPhpVersion, setSelectedPhpVersion ] = useState< AllowedPHPVersion >(
+		( selectedSite?.phpVersion as AllowedPHPVersion ) ?? DEFAULT_PHP_VERSION
 	);
 	const [ selectedWpVersion, setSelectedWpVersion ] = useState( currentWpVersion );
 	const wordpressVersions = useRootSelector( wordpressVersionsSelectors.selectWordPressVersions );
@@ -50,7 +51,7 @@ export default function EditSiteDetails( { currentWpVersion, onSave }: EditSiteD
 			return;
 		}
 		setSiteName( selectedSite.name );
-		setSelectedPhpVersion( selectedSite.phpVersion as SupportedPHPVersion );
+		setSelectedPhpVersion( selectedSite.phpVersion as AllowedPHPVersion );
 		setSelectedWpVersion( currentWpVersion );
 		setIsChangeWpError( '' );
 	}, [ currentWpVersion, selectedSite ] );
@@ -145,11 +146,11 @@ export default function EditSiteDetails( { currentWpVersion, onSave }: EditSiteD
 									<SelectControl
 										disabled={ isEditingSite }
 										value={ selectedPhpVersion }
-										options={ SupportedPHPVersions.map( ( version ) => ( {
+										options={ ALLOWED_PHP_VERSIONS.map( ( version ) => ( {
 											label: version,
 											value: version,
 										} ) ) }
-										onChange={ ( version ) => setSelectedPhpVersion( version ) }
+										onChange={ ( version: AllowedPHPVersion ) => setSelectedPhpVersion( version ) }
 										__next40pxDefaultSize
 										__nextHasNoMarginBottom
 									/>

--- a/vendor/wp-now/src/constants.ts
+++ b/vendor/wp-now/src/constants.ts
@@ -49,6 +49,11 @@ export const DEFAULT_PHP_VERSION = '8.2';
 export const ALLOWED_PHP_VERSIONS = [ '8.4', '8.3', '8.2', '8.1', '8.0', '7.4' ];
 
 /**
+ * The type for the allowed PHP versions.
+ */
+export type AllowedPHPVersion = ( typeof ALLOWED_PHP_VERSIONS )[ number ];
+
+/**
  * The default WordPress version to use when running the WP Now server.
  */
 export const DEFAULT_WORDPRESS_VERSION = 'latest';

--- a/vendor/wp-now/src/constants.ts
+++ b/vendor/wp-now/src/constants.ts
@@ -44,6 +44,11 @@ export const DEFAULT_PORT = 8881;
 export const DEFAULT_PHP_VERSION = '8.2';
 
 /**
+ * The allowed PHP versions that can be used
+ */
+export const ALLOWED_PHP_VERSIONS = [ '8.4', '8.3', '8.2', '8.1', '8.0', '7.4' ];
+
+/**
  * The default WordPress version to use when running the WP Now server.
  */
 export const DEFAULT_WORDPRESS_VERSION = 'latest';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

Related to: https://github.com/Automattic/dotcom-forge/issues/10546

## Proposed Changes

This PR proposes to remove some of the PHP versions that we allow to use. We have noticed that when PHP version on a site is below `7.4`, some of the export and push features do not work as expected and throw errors related to `wp server command requiring at least 7.4`.

To ensure that the exporting and pushing works as expected, I propose to remove PHP versions that are below that limit. 

Note: Alternatively, we can modify the error and mention to the user that they need to change their PHP version. However, since WP.com and many other hosts use at least PHP 8.1, I think we would be okay to remove versions below `7.4`.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
* Start Studio with `STUDIO_WP_VERSIONS=true npm start`
* Navigate to the `Settings` tab
* Click on `Edit` by `Site details`
* Confirm that you can not see any PHP versions below `7.4` in the PHP versions selector.
* Click on `Add site` button in the sidebar
* In the modal, click on `Advanced settings`
* Confirm that you can not select version lower than `7.4` in the modal

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
