### PR TITLE
Remove hello wp-now default index php that should be virtualized

### DIFF
--- a/vendor/wp-now/src/wp-now.ts
+++ b/vendor/wp-now/src/wp-now.ts
@@ -135,7 +135,7 @@ export default async function startWPNow(
 			await prepareWordPress( php, options );
 			return runtimeId;
 		},
-		maxRequests: 400,
+		maxRequests: 10,
 	} );
 
 	return {
@@ -166,7 +166,6 @@ async function getPHPInstance(
 async function prepareDocumentRoot( php: PHP, options: WPNowOptions ) {
 	php.mkdir( options.documentRoot );
 	php.chdir( options.documentRoot );
-	php.writeFile( `${ options.documentRoot }/index.php`, `<?php echo 'Hello wp-now!';` );
 	php.writeFile(
 		path.posix.join( PLAYGROUND_INTERNAL_SHARED_FOLDER, 'ca-bundle.crt' ),
 		rootCertificates.join( '\n' )


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Related https://github.com/Automattic/dotcom-forge/issues/10569

## Proposed Changes

- Remove unnecessary default wp-now index.php that was virtualized in the past
- It doesn't fix the issue of `rotatePHPRuntime` , but at least doesn't modify user's file.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Test start and stop sites
- Observe Studio sites work as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
