### PR TITLE
Fix Studio site crashing when rotatePHPRuntime was executed

### DIFF
--- a/vendor/wp-now/src/wp-now.ts
+++ b/vendor/wp-now/src/wp-now.ts
@@ -166,7 +166,6 @@ async function getPHPInstance(
 async function prepareDocumentRoot( php: PHP, options: WPNowOptions ) {
 	php.mkdir( options.documentRoot );
 	php.chdir( options.documentRoot );
-	php.writeFile( `${ options.documentRoot }/index.php`, `<?php echo 'Hello wp-now!';` );
 	php.writeFile(
 		path.posix.join( PLAYGROUND_INTERNAL_SHARED_FOLDER, 'ca-bundle.crt' ),
 		rootCertificates.join( '\n' )

--- a/vendor/wp-now/src/wp-now.ts
+++ b/vendor/wp-now/src/wp-now.ts
@@ -130,9 +130,7 @@ export default async function startWPNow(
 		cwd: requestHandler.documentRoot,
 		recreateRuntime: async () => {
 			output?.log( 'Recreating and rotating PHP runtime' );
-			const { php, runtimeId } = await getPHPInstance( options, true, requestHandler );
-			await prepareDocumentRoot( php, options );
-			await prepareWordPress( php, options );
+			const { runtimeId } = await getPHPInstance( options, true, requestHandler );
 			return runtimeId;
 		},
 		maxRequests: 400,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/dotcom-forge/issues/10569

## Proposed Changes

- Remove default Hello wp-now "virtual" index.php
- Avoids remounting directories, which prevents PHP runtime crashes during rotation.

Why?
It seems in the past the `rotatePHPRuntime` was starting a fresh Playground that needed mounting the directories, and that's not the case anymore.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Apply this diff to reduce the number of requests that produces a PHP runtime rotation.
```
diff --git a/vendor/wp-now/src/wp-now.ts b/vendor/wp-now/src/wp-now.ts
index b3e61cd1..0c0b3235 100644
--- a/vendor/wp-now/src/wp-now.ts
+++ b/vendor/wp-now/src/wp-now.ts
@@ -135,7 +135,7 @@ export default async function startWPNow(
 			await prepareWordPress( php, options );
 			return runtimeId;
 		},
-		maxRequests: 400,
+		maxRequests: 10,
 	} );
 
 	return {

```
- Run `npm start`
- Start a site
- Access wp-admin, index, and other pages/posts multiple times
- Observe the message `Recreating and rotating PHP runtime` every ~10 PHP requests.

I've also observed that the message `Stopped watching for file changes` but I confirm that the file changes are still working. I edited the main index.php and I saw the changes applied correctly in the browser.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
