### PR TITLE
fix isBeta error on site form

### DIFF
--- a/src/components/site-form.tsx
+++ b/src/components/site-form.tsx
@@ -414,7 +414,10 @@ export const SiteForm = ( {
 														value={ wpVersion }
 														options={
 															wpVersions.length > 0
-																? wpVersions
+																? wpVersions.map( ( { label, value } ) => ( {
+																		label,
+																		value,
+																  } ) )
 																: [
 																		{
 																			label: DEFAULT_WORDPRESS_VERSION,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/dotcom-forge/issues/10578

## Proposed Changes

- Modified the WordPress version options mapping in SiteForm component to only include label and value properties when passing options to SelectControl

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Start Studio with the feature flag STUDIO_WP_VERSIONS=true npm start
- Navigate to the Site Settings tab
- Click on Edit by Site details
- Open developer tools
- Confirm there are no errors in the console log


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
