### PR TITLE
Fix handling PHP version from Jetpack backup meta file

### DIFF
--- a/src/lib/import-export/import/importers/importer.ts
+++ b/src/lib/import-export/import/importers/importer.ts
@@ -4,6 +4,7 @@ import fs, { createReadStream, createWriteStream } from 'fs';
 import fsPromises from 'fs/promises';
 import path from 'path';
 import { createInterface } from 'readline';
+import { SupportedPHPVersionsList } from '@php-wasm/universal';
 import { lstat, move } from 'fs-extra';
 import semver from 'semver';
 import { generateBackupFilename } from 'src/lib/import-export/export/generate-backup-filename';
@@ -13,6 +14,7 @@ import { serializePlugins } from 'src/lib/serialize-plugins';
 import { updateSiteUrlToLocal } from 'src/lib/updateSiteUrlToLocal';
 import { SiteServer } from 'src/site-server';
 import { DEFAULT_PHP_VERSION } from 'vendor/wp-now/src/constants';
+
 export interface ImporterResult extends Omit< BackupContents, 'metaFile' > {
 	meta?: MetaFileData;
 }
@@ -204,6 +206,20 @@ abstract class BaseBackupImporter extends BaseImporter {
 		}
 		this.emit( ImportEvents.IMPORT_WP_CONTENT_COMPLETE );
 	}
+
+	protected parsePhpVersion( version: string | undefined ): string {
+		if ( ! version ) {
+			return DEFAULT_PHP_VERSION;
+		}
+		const phpVersion = semver.coerce( version );
+		if ( ! phpVersion ) {
+			return DEFAULT_PHP_VERSION;
+		}
+
+		const parsedVersion = `${ phpVersion.major }.${ phpVersion.minor }`;
+
+		return SupportedPHPVersionsList.includes( parsedVersion ) ? parsedVersion : DEFAULT_PHP_VERSION;
+	}
 }
 
 export class JetpackImporter extends BaseBackupImporter {
@@ -215,7 +231,11 @@ export class JetpackImporter extends BaseBackupImporter {
 		this.emit( ImportEvents.IMPORT_META_START );
 		try {
 			const metaContent = await fsPromises.readFile( metaFilePath, 'utf-8' );
-			return JSON.parse( metaContent );
+			const meta = JSON.parse( metaContent );
+			return {
+				phpVersion: this.parsePhpVersion( meta?.phpVersion ),
+				wordpressVersion: meta?.wordpressVersion || '',
+			};
 		} catch ( e ) {
 			return;
 		} finally {
@@ -234,11 +254,8 @@ export class LocalImporter extends BaseBackupImporter {
 		try {
 			const metaContent = await fsPromises.readFile( metaFilePath, 'utf-8' );
 			const meta = JSON.parse( metaContent );
-			const phpVersion = semver.coerce( meta?.services?.php?.version );
 			return {
-				phpVersion: phpVersion
-					? `${ phpVersion.major }.${ phpVersion.minor }`
-					: DEFAULT_PHP_VERSION,
+				phpVersion: this.parsePhpVersion( meta?.services?.php?.version ),
 				wordpressVersion: '',
 			};
 		} catch ( e ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/dotcom-forge/issues/10577

## Proposed Changes

Recently, Jetpack Backup files started including correct `meta.json`. It looks like Studio doesn't validate the PHP version correctly, so user who imports such site gets an error.

I propose to add PHP version detection support for Jetpack backups. When importing a Jetpack backup, Studio will now properly detect and use the PHP version from the backup's `meta.json` file, falling back to the default PHP version if the detected version is not supported.

### Changes
- Added PHP version parsing to JetpackImporter
- Refactored PHP version parsing into a shared method
- Added validation against supported PHP versions
- Updated meta file parsing to match Jetpack backup format

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create a Jetpack backup from a site running PHP 8.1
2. Import the backup into Studio
3. Verify that:
   - The site is created with PHP 8.1
   - If you import a backup with an unsupported PHP version (e.g., 8.5), it falls back to the default version
   - The WordPress version is correctly detected from the backup

You can find a sample meta.json structure in a Jetpack backup:

```
{
"wordpressVersion": "6.7.2",
"phpVersion": "8.1.31",
"siteUrl": "http://example.com",
"plugins": [...],
"themes": [...]
}
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
