### PR TITLE
disable editing wp version when offline

### DIFF
--- a/src/components/site-form.tsx
+++ b/src/components/site-form.tsx
@@ -108,7 +108,6 @@ const SiteFormError = ( { error, tipMessage = '', className = '' }: SiteFormErro
 		)
 	);
 };
-
 function FormPathInputComponent( {
 	value,
 	onClick,
@@ -247,7 +246,6 @@ function FormImportComponent( {
 		</>
 	);
 }
-
 export const SiteForm = ( {
 	className,
 	children,

--- a/src/components/site-form.tsx
+++ b/src/components/site-form.tsx
@@ -7,10 +7,13 @@ import { useI18n } from '@wordpress/react-i18n';
 import { FormEvent, useEffect, useRef, useState } from 'react';
 import Button from 'src/components/button';
 import FolderIcon from 'src/components/folder-icon';
+import offlineIcon from 'src/components/offline-icon';
 import TextControlComponent from 'src/components/text-control';
+import { Tooltip } from 'src/components/tooltip';
 import { ACCEPTED_IMPORT_FILE_TYPES } from 'src/constants';
 import { useDocsLink } from 'src/hooks/use-docs-link';
 import { useFeatureFlags } from 'src/hooks/use-feature-flags';
+import { useOffline } from 'src/hooks/use-offline';
 import { cx } from 'src/lib/cx';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 import { useAppDispatch, useRootSelector } from 'src/stores';
@@ -105,6 +108,7 @@ const SiteFormError = ( { error, tipMessage = '', className = '' }: SiteFormErro
 		)
 	);
 };
+
 function FormPathInputComponent( {
 	value,
 	onClick,
@@ -243,6 +247,7 @@ function FormImportComponent( {
 		</>
 	);
 }
+
 export const SiteForm = ( {
 	className,
 	children,
@@ -268,6 +273,8 @@ export const SiteForm = ( {
 	const getDocsLink = useDocsLink();
 	const { wpVersionsEnabled } = useFeatureFlags();
 	const dispatch = useAppDispatch();
+	const isOffline = useOffline();
+	const offlineMessage = __( 'Changing WordPress version requires an internet connection.' );
 	const wpVersions = useRootSelector(
 		wordpressVersionsSelectors.selectWordPressVersionsWithLatest
 	);
@@ -395,8 +402,11 @@ export const SiteForm = ( {
 										{ wpVersionsEnabled && allowVersionsChange && (
 											<div className="grid grid-cols-2 gap-4 mt-4">
 												<div className="flex flex-col gap-1.5 leading-4">
-													<label className="font-semibold">{ __( 'PHP version' ) }</label>
+													<label className="font-semibold" htmlFor="php-version-select">
+														{ __( 'PHP version' ) }
+													</label>
 													<SelectControl
+														id="php-version-select"
 														value={ phpVersion }
 														options={ SupportedPHPVersionsList.map( ( version ) => {
 															return {
@@ -409,25 +419,37 @@ export const SiteForm = ( {
 													/>
 												</div>
 												<div className="flex flex-col gap-1.5 leading-4">
-													<label className="font-semibold">{ __( 'WordPress version' ) }</label>
-													<SelectControl
-														value={ wpVersion }
-														options={
-															wpVersions.length > 0
-																? wpVersions.map( ( { label, value } ) => ( {
-																		label,
-																		value,
-																  } ) )
-																: [
-																		{
-																			label: DEFAULT_WORDPRESS_VERSION,
-																			value: DEFAULT_WORDPRESS_VERSION,
-																		},
-																  ]
-														}
-														onChange={ setWpVersion }
-														__next40pxDefaultSize
-													/>
+													<label className="font-semibold" htmlFor="wp-version-select">
+														{ __( 'WordPress version' ) }
+													</label>
+													<Tooltip
+														disabled={ ! isOffline }
+														icon={ offlineIcon }
+														text={ offlineMessage }
+														placement="top-start"
+														className="flex flex-1 flex-col"
+													>
+														<SelectControl
+															id="wp-version-select"
+															value={ wpVersion }
+															options={
+																wpVersions.length > 0
+																	? wpVersions.map( ( { label, value } ) => ( {
+																			label,
+																			value,
+																	  } ) )
+																	: [
+																			{
+																				label: DEFAULT_WORDPRESS_VERSION,
+																				value: DEFAULT_WORDPRESS_VERSION,
+																			},
+																	  ]
+															}
+															onChange={ setWpVersion }
+															__next40pxDefaultSize
+															disabled={ isOffline }
+														/>
+													</Tooltip>
 												</div>
 											</div>
 										) }

--- a/src/components/tests/add-site.test.tsx
+++ b/src/components/tests/add-site.test.tsx
@@ -3,6 +3,7 @@ import { jest } from '@jest/globals';
 import { render, waitFor, screen } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import AddSite from 'src/components/add-site';
+import { useOffline } from 'src/hooks/use-offline';
 import { FolderDialogResponse } from 'src/ipc-handlers';
 
 jest.mock( 'src/hooks/use-feature-flags', () => ( {
@@ -58,6 +59,10 @@ jest.mock( 'src/hooks/use-site-details', () => ( {
 		createSite: mockCreateSite,
 		data: [],
 	} ),
+} ) );
+
+jest.mock( 'src/hooks/use-offline', () => ( {
+	useOffline: jest.fn().mockReturnValue( false ),
 } ) );
 
 beforeEach( () => {
@@ -347,5 +352,65 @@ describe( 'AddSite', () => {
 		await waitFor( () => {
 			expect( mockCreateSite ).toHaveBeenCalled();
 		} );
+	} );
+
+	it( 'should disable WordPress version field when offline', async () => {
+		( useOffline as jest.Mock ).mockReturnValue( true );
+
+		render( <AddSite /> );
+		const user = userEvent.setup();
+
+		await user.click( screen.getByRole( 'button', { name: 'Add site' } ) );
+		await user.click( screen.getByRole( 'button', { name: 'Advanced settings' } ) );
+
+		const wpVersionSelect = screen.getByLabelText( 'WordPress version' );
+		expect( wpVersionSelect ).toBeDisabled();
+	} );
+
+	it( 'should enable WordPress version field when online', async () => {
+		( useOffline as jest.Mock ).mockReturnValue( false );
+
+		render( <AddSite /> );
+		const user = userEvent.setup();
+
+		await user.click( screen.getByRole( 'button', { name: 'Add site' } ) );
+		await user.click( screen.getByRole( 'button', { name: 'Advanced settings' } ) );
+
+		const wpVersionSelect = screen.getByLabelText( 'WordPress version' );
+		expect( wpVersionSelect ).not.toBeDisabled();
+	} );
+
+	it( 'should show tooltip with offline message when hovering over disabled WordPress version field', async () => {
+		( useOffline as jest.Mock ).mockReturnValue( true );
+
+		render( <AddSite /> );
+		const user = userEvent.setup();
+
+		await user.click( screen.getByRole( 'button', { name: 'Add site' } ) );
+		await user.click( screen.getByRole( 'button', { name: 'Advanced settings' } ) );
+
+		const wpVersionSelect = screen.getByLabelText( 'WordPress version' );
+		await user.hover( wpVersionSelect );
+
+		expect(
+			screen.getByText( 'Changing WordPress version requires an internet connection.' )
+		).toBeInTheDocument();
+	} );
+
+	it( 'should not show tooltip when hovering over WordPress version field while online', async () => {
+		( useOffline as jest.Mock ).mockReturnValue( false );
+
+		render( <AddSite /> );
+		const user = userEvent.setup();
+
+		await user.click( screen.getByRole( 'button', { name: 'Add site' } ) );
+		await user.click( screen.getByRole( 'button', { name: 'Advanced settings' } ) );
+
+		const wpVersionSelect = screen.getByLabelText( 'WordPress version' );
+		await user.hover( wpVersionSelect );
+
+		expect(
+			screen.queryByText( 'Changing WordPress version requires an internet connection.' )
+		).not.toBeInTheDocument();
 	} );
 } );

--- a/src/components/tests/onboarding.test.tsx
+++ b/src/components/tests/onboarding.test.tsx
@@ -5,6 +5,7 @@ import { userEvent } from '@testing-library/user-event';
 import Onboarding from 'src/components/onboarding';
 import { useAddSite } from 'src/hooks/use-add-site';
 import { useFeatureFlags } from 'src/hooks/use-feature-flags';
+import { useOffline } from 'src/hooks/use-offline';
 import { useOnboarding } from 'src/hooks/use-onboarding';
 import { FolderDialogResponse } from 'src/ipc-handlers';
 import { useAppDispatch, useRootSelector } from 'src/stores';
@@ -28,6 +29,10 @@ jest.mock( 'src/stores', () => ( {
 
 jest.mock( 'src/lib/app-globals', () => ( {
 	isMac: () => true,
+} ) );
+
+jest.mock( 'src/hooks/use-offline', () => ( {
+	useOffline: jest.fn().mockReturnValue( false ),
 } ) );
 
 const mockGenerateProposedSitePath =
@@ -340,5 +345,63 @@ describe( 'Onboarding Component', () => {
 
 		expect( screen.queryByText( 'WordPress version' ) ).not.toBeInTheDocument();
 		expect( screen.queryByText( 'PHP version' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'should disable WordPress version field when offline', () => {
+		( useOffline as jest.Mock ).mockReturnValue( true );
+		( useFeatureFlags as jest.Mock ).mockReturnValue( {
+			wpVersionsEnabled: true,
+		} );
+
+		render( <Onboarding /> );
+
+		const wpVersionSelect = screen.getByLabelText( 'WordPress version' );
+		expect( wpVersionSelect ).toBeDisabled();
+	} );
+
+	it( 'should enable WordPress version field when online', () => {
+		( useOffline as jest.Mock ).mockReturnValue( false );
+		( useFeatureFlags as jest.Mock ).mockReturnValue( {
+			wpVersionsEnabled: true,
+		} );
+
+		render( <Onboarding /> );
+
+		const wpVersionSelect = screen.getByLabelText( 'WordPress version' );
+		expect( wpVersionSelect ).not.toBeDisabled();
+	} );
+
+	it( 'should show tooltip with offline message when hovering over disabled WordPress version field', async () => {
+		( useOffline as jest.Mock ).mockReturnValue( true );
+		( useFeatureFlags as jest.Mock ).mockReturnValue( {
+			wpVersionsEnabled: true,
+		} );
+
+		render( <Onboarding /> );
+		const user = userEvent.setup();
+
+		const wpVersionSelect = screen.getByLabelText( 'WordPress version' );
+		await user.hover( wpVersionSelect );
+
+		expect(
+			screen.getByText( 'Changing WordPress version requires an internet connection.' )
+		).toBeInTheDocument();
+	} );
+
+	it( 'should not show tooltip when hovering over WordPress version field while online', async () => {
+		( useOffline as jest.Mock ).mockReturnValue( false );
+		( useFeatureFlags as jest.Mock ).mockReturnValue( {
+			wpVersionsEnabled: true,
+		} );
+
+		render( <Onboarding /> );
+		const user = userEvent.setup();
+
+		const wpVersionSelect = screen.getByLabelText( 'WordPress version' );
+		await user.hover( wpVersionSelect );
+
+		expect(
+			screen.queryByText( 'Changing WordPress version requires an internet connection.' )
+		).not.toBeInTheDocument();
 	} );
 } );

--- a/src/modules/site-settings/edit-site-details.tsx
+++ b/src/modules/site-settings/edit-site-details.tsx
@@ -6,7 +6,10 @@ import stripAnsi from 'strip-ansi';
 import Button from 'src/components/button';
 import { ErrorInformation } from 'src/components/error-information';
 import Modal from 'src/components/modal';
+import offlineIcon from 'src/components/offline-icon';
 import TextControlComponent from 'src/components/text-control';
+import { Tooltip } from 'src/components/tooltip';
+import { useOffline } from 'src/hooks/use-offline';
 import { useSiteDetails } from 'src/hooks/use-site-details';
 import { cx } from 'src/lib/cx';
 import { getIpcApi } from 'src/lib/get-ipc-api';
@@ -25,6 +28,8 @@ export default function EditSiteDetails( { currentWpVersion, onSave }: EditSiteD
 	const [ isChangeWpError, setIsChangeWpError ] = useState( '' );
 	const [ showModal, setShowModal ] = useState( false );
 	const [ isEditingSite, setIsEditingSite ] = useState( false );
+	const isOffline = useOffline();
+	const offlineMessage = __( 'Changing WordPress version requires an internet connection.' );
 	const closeModal = useCallback( () => {
 		if ( isEditingSite ) {
 			return;
@@ -140,9 +145,13 @@ export default function EditSiteDetails( { currentWpVersion, onSave }: EditSiteD
 							</label>
 
 							<div className="flex flex-row gap-x-6">
-								<label className="flex flex-1 flex-col gap-1.5 leading-4">
+								<label
+									htmlFor="php-version-select"
+									className="flex flex-1 flex-col gap-1.5 leading-4"
+								>
 									<span className="font-semibold">{ __( 'PHP version' ) }</span>
 									<SelectControl
+										id="php-version-select"
 										disabled={ isEditingSite }
 										value={ selectedPhpVersion }
 										options={ SupportedPHPVersions.map( ( version ) => ( {
@@ -155,17 +164,29 @@ export default function EditSiteDetails( { currentWpVersion, onSave }: EditSiteD
 									/>
 								</label>
 
-								<label className="flex flex-1 flex-col gap-1.5 leading-4">
+								<label
+									htmlFor="wp-version-select"
+									className="flex flex-1 flex-col gap-1.5 leading-4"
+								>
 									<span className="font-semibold">{ __( 'WordPress version' ) }</span>
-									<SelectControl
-										className={ cx( isChangeWpError && 'error-select-control' ) }
-										disabled={ isEditingSite }
-										value={ selectedWpVersion }
-										options={ wordpressVersionOptions }
-										onChange={ setSelectedWpVersion }
-										__next40pxDefaultSize
-										__nextHasNoMarginBottom
-									/>
+									<Tooltip
+										disabled={ ! isOffline }
+										icon={ offlineIcon }
+										text={ offlineMessage }
+										placement="top-start"
+										className="flex flex-1 flex-col"
+									>
+										<SelectControl
+											id="wp-version-select"
+											className={ cx( isChangeWpError && 'error-select-control' ) }
+											disabled={ isEditingSite || isOffline }
+											value={ selectedWpVersion }
+											options={ wordpressVersionOptions }
+											onChange={ setSelectedWpVersion }
+											__next40pxDefaultSize
+											__nextHasNoMarginBottom
+										/>
+									</Tooltip>
 								</label>
 							</div>
 							{ isChangeWpError && (

--- a/src/modules/site-settings/tests/edit-site-details.test.tsx
+++ b/src/modules/site-settings/tests/edit-site-details.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
+import { useOffline } from 'src/hooks/use-offline';
 import EditSiteDetails from 'src/modules/site-settings/edit-site-details';
 
 // Mock the hooks and dependencies
@@ -45,6 +46,10 @@ jest.mock( 'src/stores', () => ( {
 			{ label: '6.2', value: '6.2' },
 		];
 	} ),
+} ) );
+
+jest.mock( 'src/hooks/use-offline', () => ( {
+	useOffline: jest.fn().mockReturnValue( false ),
 } ) );
 
 describe( 'EditSiteDetails', () => {
@@ -265,5 +270,61 @@ describe( 'EditSiteDetails', () => {
 		await waitFor( () => {
 			expect( mockUpdateSite ).toHaveBeenCalled();
 		} );
+	} );
+
+	it( 'should disable WordPress version field when offline', async () => {
+		( useOffline as jest.Mock ).mockReturnValue( true );
+
+		render( <EditSiteDetails { ...defaultProps } /> );
+		const user = userEvent.setup();
+
+		await user.click( screen.getByRole( 'button', { name: 'Edit site' } ) );
+
+		const wpVersionSelect = screen.getByLabelText( 'WordPress version' );
+		expect( wpVersionSelect ).toBeDisabled();
+	} );
+
+	it( 'should enable WordPress version field when online', async () => {
+		( useOffline as jest.Mock ).mockReturnValue( false );
+
+		render( <EditSiteDetails { ...defaultProps } /> );
+		const user = userEvent.setup();
+
+		await user.click( screen.getByRole( 'button', { name: 'Edit site' } ) );
+
+		const wpVersionSelect = screen.getByLabelText( 'WordPress version' );
+		expect( wpVersionSelect ).not.toBeDisabled();
+	} );
+
+	it( 'should show tooltip with offline message when hovering over disabled WordPress version field', async () => {
+		( useOffline as jest.Mock ).mockReturnValue( true );
+
+		render( <EditSiteDetails { ...defaultProps } /> );
+		const user = userEvent.setup();
+
+		await user.click( screen.getByRole( 'button', { name: 'Edit site' } ) );
+
+		const wpVersionSelect = screen.getByLabelText( 'WordPress version' );
+		await user.hover( wpVersionSelect );
+
+		expect(
+			screen.getByText( 'Changing WordPress version requires an internet connection.' )
+		).toBeInTheDocument();
+	} );
+
+	it( 'should not show tooltip when hovering over WordPress version field while online', async () => {
+		( useOffline as jest.Mock ).mockReturnValue( false );
+
+		render( <EditSiteDetails { ...defaultProps } /> );
+		const user = userEvent.setup();
+
+		await user.click( screen.getByRole( 'button', { name: 'Edit site' } ) );
+
+		const wpVersionSelect = screen.getByLabelText( 'WordPress version' );
+		await user.hover( wpVersionSelect );
+
+		expect(
+			screen.queryByText( 'Changing WordPress version requires an internet connection.' )
+		).not.toBeInTheDocument();
 	} );
 } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/dotcom-forge/issues/10542

## Proposed Changes

- Added offline state handling for WordPress version selection across the application
- Disabled WordPress version selection when offline in SiteForm, AddSite, and EditSiteDetails components
- Added tooltips to inform users when WordPress version changes require internet connection
- Added test coverage for offline scenarios
- Added proper accessibility attributes (htmlFor, id) to form controls

| Online | Offline |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/f64ff4f2-db26-4d33-b1e6-e5a1de35efc9) | ![image](https://github.com/user-attachments/assets/1ba75ec3-dba4-47e4-8d01-7250b595f317) | 
| ![image](https://github.com/user-attachments/assets/98f1d0ce-73a1-4c35-896f-10e71cd5ef80) | ![image](https://github.com/user-attachments/assets/ece9bcdb-b7b6-491a-82c7-d8a6e98978b9) | 
| ![image](https://github.com/user-attachments/assets/1dc0a668-769d-44a8-a23f-e75a7d83c10f) | ![image](https://github.com/user-attachments/assets/03649d5f-9de5-45a6-99b3-0e1d763be2a9) | 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Test offline behavior:
   - Disable internet connection (you can do it from dev tools, network throttling)
   - Open Add Site form
   - Verify WordPress version field is disabled
   - Hover over the field to see offline tooltip
   - Verify PHP version field remains enabled

2. Test online behavior:
   - Enable internet connection
   - Open Add Site form
   - Verify WordPress version field is enabled
   - Hover over the field to verify no tooltip appears

3. Test in different contexts:
   - Add Site form
   - Onboarding flow
   - Site settings edit form

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
