### PR TITLE
Fix background site form file selectors 

### DIFF
--- a/src/components/site-form.tsx
+++ b/src/components/site-form.tsx
@@ -138,7 +138,7 @@ function FormPathInputComponent( {
 			>
 				<TextControlComponent
 					aria-hidden="true"
-					disabled={ true }
+					tabIndex={ -1 }
 					className="[&_.components-text-control\_\_input]:bg-transparent [&_.components-text-control\_\_input]:border-none [&_input]:pointer-events-none w-full"
 					value={ value }
 					// eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -206,7 +206,7 @@ function FormImportComponent( {
 				>
 					<TextControlComponent
 						aria-hidden="true"
-						disabled={ true }
+						tabIndex={ -1 }
 						placeholder={ placeholder }
 						className="flex-grow [&_.components-text-control\_\_input]:bg-transparent [&_.components-text-control\_\_input]:border-none [&_input]:pointer-events-none [&_.components-text-control\_\_input]:text-sm w-full [&_.components-text-control\_\_input]:truncate"
 						value={ fileName }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/dotcom-forge/issues/10579

## Proposed Changes

- Let's use a default style for all TextControl disabled components
- Avoid keyboard focus on a "fake" text input with tabIndex instead of disabled

We could consider removing the text controls in favor of a regular Div with custom styles, but then it might diverge in the future after updating `@wordpress/components`.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run `npm start``
- Press `cmd+n`
- Observe the input files have a white background
- Use the tab to change the focus between the elements
- Observe the "fake" text input is not focused


https://github.com/user-attachments/assets/2d999c71-2b75-4dcd-9d20-fe1eff9f0679


<img width="1012" alt="Screenshot 2025-03-07 at 12 25 21" src="https://github.com/user-attachments/assets/b817e2bd-927f-4680-8147-9531187db675" />
<img width="1012" alt="Screenshot 2025-03-07 at 12 24 41" src="https://github.com/user-attachments/assets/1a40c3b8-257e-48a5-8aec-18f36469fc0c" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
