### PR TITLE
Update edit site details wp error style

### DIFF
--- a/src/modules/site-settings/edit-site-details.tsx
+++ b/src/modules/site-settings/edit-site-details.tsx
@@ -85,7 +85,7 @@ export default function EditSiteDetails( { currentWpVersion, onSave }: EditSiteD
 				} catch ( wpError ) {
 					console.error( 'Error changing WordPress version:', wpError );
 					const errorMessage = stripAnsi( ( wpError as Error )?.message );
-					setIsChangeWpError( __( 'Error changing WordPress version' ) );
+					setIsChangeWpError( __( 'Error changing WordPress version.' ) );
 					getIpcApi().showErrorMessageBox( {
 						title: __( 'Error changing WordPress version' ),
 						message: errorMessage,
@@ -129,8 +129,8 @@ export default function EditSiteDetails( { currentWpVersion, onSave }: EditSiteD
 					) }
 				>
 					<form onSubmit={ onSiteEdit }>
-						<div className="flex flex-col gap-6">
-							<label className="flex flex-col gap-1.5 leading-4">
+						<div className="flex flex-col">
+							<label className="flex flex-col gap-1.5 leading-4 mb-6">
 								<span className="font-semibold">{ __( 'Site name' ) }</span>
 								<TextControlComponent
 									disabled={ isEditingSite }
@@ -139,7 +139,7 @@ export default function EditSiteDetails( { currentWpVersion, onSave }: EditSiteD
 								></TextControlComponent>
 							</label>
 
-							<div className="flex flex-row gap-x-6 pb-2">
+							<div className="flex flex-row gap-x-6">
 								<label className="flex flex-1 flex-col gap-1.5 leading-4">
 									<span className="font-semibold">{ __( 'PHP version' ) }</span>
 									<SelectControl
@@ -168,13 +168,12 @@ export default function EditSiteDetails( { currentWpVersion, onSave }: EditSiteD
 									/>
 								</label>
 							</div>
+							{ isChangeWpError && (
+								<ErrorInformation className="mt-2">{ isChangeWpError }</ErrorInformation>
+							) }
 						</div>
 
-						{ isChangeWpError && (
-							<ErrorInformation className="mt-4">{ isChangeWpError }</ErrorInformation>
-						) }
-
-						<div className="flex flex-row justify-end gap-x-5 mt-6">
+						<div className="flex flex-row justify-end gap-x-5 mt-8">
 							<Button onClick={ closeModal } disabled={ isEditingSite } variant="tertiary">
 								{ __( 'Cancel' ) }
 							</Button>

--- a/src/modules/site-settings/tests/edit-site-details.test.tsx
+++ b/src/modules/site-settings/tests/edit-site-details.test.tsx
@@ -233,7 +233,7 @@ describe( 'EditSiteDetails', () => {
 			} );
 		} );
 
-		expect( screen.getByText( 'Error changing WordPress version' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Error changing WordPress version.' ) ).toBeInTheDocument();
 	} );
 
 	it( 'should disable form controls when site is being edited', async () => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Related https://github.com/Automattic/dotcom-forge/issues/10579#issuecomment-2706042660

## Proposed Changes

- Update WP update error styles

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Apply this diff
```diff
diff --git a/src/modules/site-settings/edit-site-details.tsx b/src/modules/site-settings/edit-site-details.tsx
index 568503ee..0e21c21e 100644
--- a/src/modules/site-settings/edit-site-details.tsx
+++ b/src/modules/site-settings/edit-site-details.tsx
@@ -52,7 +52,7 @@ export default function EditSiteDetails( { currentWpVersion, onSave }: EditSiteD
 		setSiteName( selectedSite.name );
 		setSelectedPhpVersion( selectedSite.phpVersion as SupportedPHPVersion );
 		setSelectedWpVersion( currentWpVersion );
-		setIsChangeWpError( '' );
+		setIsChangeWpError( 'Error changing WordPress version.' );
 	}, [ currentWpVersion, selectedSite ] );
 
 	const onSiteEdit = async ( event: FormEvent ) => {
```
- Access settings tab
- Click on edit
- Observe the error

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
