### PR TITLE
Use WP Zip URL on wp core update to support betas in different locales

### DIFF
--- a/src/lib/get-wordpress-version-url.ts
+++ b/src/lib/get-wordpress-version-url.ts
@@ -1,0 +1,11 @@
+import { DEFAULT_WORDPRESS_VERSION } from 'vendor/wp-now/src/constants';
+import { isValidWordPressVersion } from 'vendor/wp-now/src/wp-playground-wordpress/is-valid-wordpress-version';
+
+export function getWordPressVersionUrl( version = DEFAULT_WORDPRESS_VERSION ) {
+	if ( ! isValidWordPressVersion( version ) ) {
+		throw new Error(
+			'Unrecognized WordPress version. Please use "latest" or numeric versions such as "6.2", "6.0.1", "6.2-beta1", or "6.2-RC1"'
+		);
+	}
+	return `https://wordpress.org/wordpress-${ version }.zip`;
+}

--- a/src/modules/site-settings/edit-site-details.tsx
+++ b/src/modules/site-settings/edit-site-details.tsx
@@ -10,6 +10,7 @@ import TextControlComponent from 'src/components/text-control';
 import { useSiteDetails } from 'src/hooks/use-site-details';
 import { cx } from 'src/lib/cx';
 import { getIpcApi } from 'src/lib/get-ipc-api';
+import { getWordPressVersionUrl } from 'src/lib/get-wordpress-version-url';
 import { useRootSelector } from 'src/stores';
 import { wordpressVersionsSelectors } from 'src/stores/wordpress-versions-slice';
 import { DEFAULT_PHP_VERSION } from 'vendor/wp-now/src/constants';
@@ -74,9 +75,10 @@ export default function EditSiteDetails( { currentWpVersion, onSave }: EditSiteD
 
 			if ( hasWpVersionChanged ) {
 				try {
+					const zipUrl = getWordPressVersionUrl( selectedWpVersion );
 					const result = await getIpcApi().executeWPCLiInline( {
 						siteId: selectedSite.id,
-						args: `core update --version=${ selectedWpVersion } --force`,
+						args: `core update ${ zipUrl } --force`,
 						skipPluginsAndThemes: true,
 					} );
 					if ( result.exitCode !== 0 ) {

--- a/src/modules/site-settings/tests/edit-site-details.test.tsx
+++ b/src/modules/site-settings/tests/edit-site-details.test.tsx
@@ -40,6 +40,7 @@ jest.mock( 'src/stores', () => ( {
 	useRootSelector: jest.fn().mockImplementation( () => {
 		// Mock the WordPress versions selector
 		return [
+			{ label: '6.8-beta1', value: '6.8-beta1' },
 			{ label: '6.4', value: '6.4' },
 			{ label: '6.3', value: '6.3' },
 			{ label: '6.2', value: '6.2' },
@@ -200,7 +201,7 @@ describe( 'EditSiteDetails', () => {
 		expect( mockStopServer ).toHaveBeenCalledWith( 'site-123' );
 		expect( mockExecuteWPCLiInline ).toHaveBeenCalledWith( {
 			siteId: 'site-123',
-			args: 'core update --version=6.4 --force',
+			args: 'core update https://wordpress.org/wordpress-6.4.zip --force',
 			skipPluginsAndThemes: true,
 		} );
 		expect( mockUpdateSite ).toHaveBeenCalledWith( {
@@ -211,6 +212,24 @@ describe( 'EditSiteDetails', () => {
 		} );
 		expect( mockStartServer ).toHaveBeenCalledWith( 'site-123' );
 		expect( defaultProps.onSave ).toHaveBeenCalled();
+	} );
+
+	it( 'should update WordPress version when changed to beta', async () => {
+		render( <EditSiteDetails { ...defaultProps } /> );
+		const user = userEvent.setup();
+
+		await user.click( screen.getByRole( 'button', { name: 'Edit site' } ) );
+
+		const wpVersionSelect = screen.getByLabelText( 'WordPress version' );
+		await user.selectOptions( wpVersionSelect, '6.8-beta1' );
+
+		await user.click( screen.getByRole( 'button', { name: 'Save' } ) );
+
+		expect( mockExecuteWPCLiInline ).toHaveBeenCalledWith( {
+			siteId: 'site-123',
+			args: 'core update https://wordpress.org/wordpress-6.8-beta1.zip --force',
+			skipPluginsAndThemes: true,
+		} );
 	} );
 
 	it( 'should show error when WordPress version update fails', async () => {

--- a/vendor/wp-now/src/download.ts
+++ b/vendor/wp-now/src/download.ts
@@ -4,14 +4,13 @@ import path from 'path';
 import followRedirects, { FollowResponse } from 'follow-redirects';
 import fs from 'fs-extra';
 import { HttpProxyAgent, HttpsProxyAgent } from 'hpagent';
+import { getWordPressVersionUrl } from 'src/lib/get-wordpress-version-url';
 import unzipper from 'unzipper';
 import { DEFAULT_WORDPRESS_VERSION, SQLITE_FILENAME, SQLITE_URL, WP_CLI_URL } from './constants';
 import getSqlitePath from './get-sqlite-path';
 import getWordpressVersionsPath from './get-wordpress-versions-path';
 import getWpCliPath from './get-wp-cli-path';
 import { output } from './output';
-import { isValidWordPressVersion } from './wp-playground-wordpress';
-
 function httpsGet( url: string, callback: ( res: IncomingMessage & FollowResponse ) => void ) {
 	const proxy =
 		process.env.https_proxy ||
@@ -28,15 +27,6 @@ function httpsGet( url: string, callback: ( res: IncomingMessage & FollowRespons
 	}
 
 	https.get( url, { agent }, callback );
-}
-
-function getWordPressVersionUrl( version = DEFAULT_WORDPRESS_VERSION ) {
-	if ( ! isValidWordPressVersion( version ) ) {
-		throw new Error(
-			'Unrecognized WordPress version. Please use "latest" or numeric versions such as "6.2", "6.0.1", "6.2-beta1", or "6.2-RC1"'
-		);
-	}
-	return `https://wordpress.org/wordpress-${ version }.zip`;
 }
 
 interface DownloadFileAndUnzipResult {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/dotcom-forge/issues/10568#issuecomment-2706076404

## Proposed Changes

- wp-cli seems to have a bug building the URL of WP beta versions. I suggest using our custom function that is already working on site creation. That way we'll use the same URL for creating a new site or updating the WP version of an existing site.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run `npm start`
- Change your locale in the top bar settings to any locale different to English, let's say "Spanish".
- Create a site
- That site should be in "Spanish"
- Go to the settings tab
- Click Edit
- Change the WP version to 6.8-beta1
- Observe the site is updated correctly
- Start the site if necessary
- Got to wp-admin
- Observe the site is running 6.8-beta1 and it's in "Spanish"

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
