### PR TITLE
[Tooling] Update Buildkite Plugins

### DIFF
--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -5,8 +5,8 @@
 
 # The ~> modifier is not currently used, but we check for it just in case
 XCODE_VERSION=$(sed -E -n 's/^(~> )?(.*)/xcode-\2/p' .xcode-version)
-CI_TOOLKIT_VERSION='5.0.0'
-NVM_PLUGIN_VERSION='0.4.0'
+CI_TOOLKIT_VERSION='5.1.2'
+NVM_PLUGIN_VERSION='0.6.0'
 
 export IMAGE_ID="$XCODE_VERSION"
 export CI_TOOLKIT_PLUGIN="automattic/a8c-ci-toolkit#$CI_TOOLKIT_VERSION"


### PR DESCRIPTION
Updating the repo's Buildkite plugins, mainly to get the fix of an [nvm plugin issue](https://github.com/Automattic/nvm-buildkite-plugin/pull/23) that causes CI machines to eventually run out of space.