### PR TITLE
Cleanup tooltips across the app

### DIFF
--- a/src/components/content-tab-overview.tsx
+++ b/src/components/content-tab-overview.tsx
@@ -1,5 +1,5 @@
 import * as Sentry from '@sentry/electron/renderer';
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import {
 	archive,
 	code,
@@ -17,7 +17,6 @@ import { useI18n } from '@wordpress/react-i18n';
 import { useState } from 'react';
 import { ArrowIcon } from 'src/components/arrow-icon';
 import { ButtonsSection, ButtonsSectionProps } from 'src/components/buttons-section';
-import { Tooltip } from 'src/components/tooltip';
 import { useCheckInstalledApps } from 'src/hooks/use-check-installed-apps';
 import { useFeatureFlags } from 'src/hooks/use-feature-flags';
 import { useThemeDetails } from 'src/hooks/use-theme-details';
@@ -240,9 +239,7 @@ export function ContentTabOverview( { selectedSite }: ContentTabOverviewProps ) 
 						<button
 							aria-label={ __( 'Open site' ) }
 							className={ 'relative group focus-visible:outline-a8c-blueberry' }
-							onClick={ () =>
-								getIpcApi().openSiteURL( selectedSite.id, '', { autoLogin: false } )
-							}
+							onClick={ () => getIpcApi().openSiteURL( selectedSite.id, '', { autoLogin: false } ) }
 						>
 							<div
 								className={

--- a/src/components/content-tab-overview.tsx
+++ b/src/components/content-tab-overview.tsx
@@ -237,32 +237,23 @@ export function ContentTabOverview( { selectedSite }: ContentTabOverviewProps ) 
 						</div>
 					) }
 					{ ! loading && siteRunning && (
-						<Tooltip
-							text={ sprintf(
-								/* translators: siteUrl is the site URL */
-								__( 'Open %(siteUrl)s' ),
-								{ siteUrl: selectedSite.url }
-							) }
-							placement="top"
+						<button
+							aria-label={ __( 'Open site' ) }
+							className={ 'relative group focus-visible:outline-a8c-blueberry' }
+							onClick={ () =>
+								getIpcApi().openSiteURL( selectedSite.id, '', { autoLogin: false } )
+							}
 						>
-							<button
-								aria-label={ __( 'Open site' ) }
-								className={ 'relative group focus-visible:outline-a8c-blueberry' }
-								onClick={ () =>
-									getIpcApi().openSiteURL( selectedSite.id, '', { autoLogin: false } )
+							<div
+								className={
+									'opacity-0 group-hover:opacity-90 group-hover:bg-white group-focus:opacity-90 group-focus:bg-white duration-300 absolute size-full flex justify-center items-center bg-white text-a8c-blueberry'
 								}
 							>
-								<div
-									className={
-										'opacity-0 group-hover:opacity-90 group-hover:bg-white group-focus:opacity-90 group-focus:bg-white duration-300 absolute size-full flex justify-center items-center bg-white text-a8c-blueberry'
-									}
-								>
-									{ __( 'Open site' ) }
-									<ArrowIcon />
-								</div>
-								{ thumbnailImage }
-							</button>
-						</Tooltip>
+								{ __( 'Open site' ) }
+								<ArrowIcon />
+							</div>
+							{ thumbnailImage }
+						</button>
 					) }
 					{ ! loading && ! siteRunning && thumbnailImage }
 				</div>

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -21,55 +21,27 @@ export default function Header() {
 						{ site ? site.name : null }
 					</h1>
 					<div className="flex mt-1 gap-x-4">
-						<Tooltip
-							text={
-								site.running
-									? sprintf(
-											/* translators: wpAdminUrl is the site's WP admin URL */
-											__( 'Open %(wpAdminUrl)s' ),
-											{ wpAdminUrl: `${ site.url }/wp-admin` }
-									  )
-									: undefined
-							}
+						<Button
 							disabled={ ! site.running }
-							placement="top-start"
+							className="[&.is-link]:text-a8c-gray-70 [&.is-link]:hover:text-a8c-blueberry !px-0 h-0 leading-4"
+							onClick={ () => getIpcApi().openSiteURL( site.id, '/wp-admin' ) }
+							variant="link"
 						>
-							<Button
-								disabled={ ! site.running }
-								className="[&.is-link]:text-a8c-gray-70 [&.is-link]:hover:text-a8c-blueberry !px-0 h-0 leading-4"
-								onClick={ () => getIpcApi().openSiteURL( site.id, '/wp-admin' ) }
-								variant="link"
-							>
-								{ __( 'WP admin' ) }
-								<ArrowIcon />
-							</Button>
-						</Tooltip>
-						<Tooltip
-							text={
-								site.running
-									? sprintf(
-											/* translators: siteUrl is the site URL */
-											__( 'Open %(siteUrl)s' ),
-											{ siteUrl: site.url }
-									  )
-									: undefined
-							}
+							{ __( 'WP admin' ) }
+							<ArrowIcon />
+						</Button>
+						<Button
 							disabled={ ! site.running }
-							placement="top-start"
+							className="[&.is-link]:text-a8c-gray-70 [&.is-link]:hover:text-a8c-blueberry !px-0 h-0 leading-4"
+							onClick={ () => getIpcApi().openSiteURL( site.id, '', { autoLogin: false } ) }
+							variant="link"
 						>
-							<Button
-								disabled={ ! site.running }
-								className="[&.is-link]:text-a8c-gray-70 [&.is-link]:hover:text-a8c-blueberry !px-0 h-0 leading-4"
-								onClick={ () => getIpcApi().openSiteURL( site.id, '', { autoLogin: false } ) }
-								variant="link"
-							>
-								{
-									// translators: "Open site" refers to the action, like "to open site"
-									__( 'Open site' )
-								}
-								<ArrowIcon />
-							</Button>
-						</Tooltip>
+							{
+								// translators: "Open site" refers to the action, like "to open site"
+								__( 'Open site' )
+							}
+							<ArrowIcon />
+						</Button>
 					</div>
 				</div>
 			) }

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -1,9 +1,7 @@
-import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import { ArrowIcon } from 'src/components/arrow-icon';
 import Button from 'src/components/button';
 import { SiteManagementActions } from 'src/components/site-management-actions';
-import { Tooltip } from 'src/components/tooltip';
 import { useSiteDetails } from 'src/hooks/use-site-details';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 

--- a/src/components/sync-connected-sites.tsx
+++ b/src/components/sync-connected-sites.tsx
@@ -220,24 +220,15 @@ const SyncConnectedSitesSection = ( {
 									<Badge className="bg-a8c-green-5 text-a8c-green-80">{ __( 'Production' ) }</Badge>
 								) }
 							</div>
-							<Tooltip
-								text={ sprintf(
-									/* translators: %s: The URL of the connected site */
-									__( 'Open %s' ),
-									connectedSite.url
-								) }
-								className="overflow-hidden"
+							<Button
+								variant="link"
+								className="!text-a8c-gray-70 hover:!text-a8c-blueberry max-w-[100%]"
+								onClick={ () => {
+									getIpcApi().openURL( connectedSite.url );
+								} }
 							>
-								<Button
-									variant="link"
-									className="!text-a8c-gray-70 hover:!text-a8c-blueberry max-w-[100%]"
-									onClick={ () => {
-										getIpcApi().openURL( connectedSite.url );
-									} }
-								>
-									<span className="truncate">{ connectedSite.url }</span> <ArrowIcon />
-								</Button>
-							</Tooltip>
+								<span className="truncate">{ connectedSite.url }</span> <ArrowIcon />
+							</Button>
 							<div className="flex gap-2 ps-4 ms-auto shrink-0">
 								{ isPulling && (
 									<div className="flex flex-col gap-2 min-w-44">

--- a/src/components/top-bar.tsx
+++ b/src/components/top-bar.tsx
@@ -73,7 +73,6 @@ function Authentication() {
 			<Button
 				onClick={ () => getIpcApi().showUserSettings() }
 				aria-label={ __( 'Open settings' ) }
-				tooltipText={ __( 'Open settings' ) }
 				variant="icon"
 				className="text-white hover:!text-white !px-1 py-1 !h-6 gap-2"
 			>
@@ -87,7 +86,6 @@ function Authentication() {
 		<Button
 			onClick={ () => getIpcApi().showUserSettings() }
 			aria-label={ __( 'Open settings to log in' ) }
-			tooltipText={ __( 'Open settings to log in' ) }
 			className="flex gap-x-2 justify-between w-full text-white rounded !px-2 !py-0 h-auto active:!text-white hover:!text-white hover:underline items-center"
 		>
 			<WordPressLogo />

--- a/src/hooks/use-expiration-date.ts
+++ b/src/hooks/use-expiration-date.ts
@@ -19,7 +19,7 @@ function formatStringDate(
 			year: 'numeric',
 		},
 		long: {
-			day: '2-digit',
+			day: 'numeric',
 			month: 'short',
 			year: 'numeric',
 			hour: '2-digit',

--- a/src/modules/preview-site/components/preview-site-row.tsx
+++ b/src/modules/preview-site/components/preview-site-row.tsx
@@ -117,30 +117,20 @@ export function PreviewSiteRow( {
 							{ snapshot.name || sprintf( __( '%s Preview' ), selectedSite.name ) }
 						</div>
 					</div>
-					<Tooltip
-						text={ sprintf(
-							/* translators: %s: The preview site URL */
-							__( 'Open %s' ),
-							urlWithHTTPS
-						) }
+					<Button
+						variant="link"
 						disabled={ isExpired }
-						className="overflow-hidden"
+						className={ cx(
+							'!text-a8c-gray-700 max-w-full',
+							isExpired ? 'pointer-events-none' : 'hover:!text-a8c-blueberry'
+						) }
+						onClick={ () => getIpcApi().openURL( urlWithHTTPS ) }
 					>
-						<Button
-							variant="link"
-							disabled={ isExpired }
-							className={ cx(
-								'!text-a8c-gray-700 max-w-full',
-								isExpired ? 'pointer-events-none' : 'hover:!text-a8c-blueberry'
-							) }
-							onClick={ () => getIpcApi().openURL( urlWithHTTPS ) }
-						>
-							<span className={ cx( 'truncate', isExpired && 'line-through text-a8c-gray-700' ) }>
-								{ urlWithHTTPS }
-							</span>
-							{ ! isExpired && <ArrowIcon /> }
-						</Button>
-					</Tooltip>
+						<span className={ cx( 'truncate', isExpired && 'line-through text-a8c-gray-700' ) }>
+							{ urlWithHTTPS }
+						</span>
+						{ ! isExpired && <ArrowIcon /> }
+					</Button>
 				</div>
 				<div className="flex ltr:ml-auto rtl:mr-auto">
 					<div className="w-[150px] text-a8c-gray-700 flex items-center pl-4">


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes p1741367797915539-slack-C06DRMD6VPZ

## Proposed Changes

I propose to clean up tooltips:
- Remove "Open URL" tooltips on links that already show URL and have an arrow that indicates it opens a link
- Remove "Open URL" on buttons which already have descriptive texts
- Remove "Open Settings" on links that is descriptive
- Fix format date issue

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Test if tooltips are removed and elements still work correctly.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?