### PR TITLE
fix px on site form advanced settings

### DIFF
--- a/src/components/site-form.tsx
+++ b/src/components/site-form.tsx
@@ -385,7 +385,7 @@ export const SiteForm = ( {
 										isAdvancedSettingsVisible ? 'max-h-96 opacity-100' : 'max-h-0 opacity-0'
 									) }
 								>
-									<div className={ cx( 'flex flex-col gap-1.5 leading-4 p-2' ) }>
+									<div className={ cx( 'flex flex-col gap-1.5 leading-4 py-2' ) }>
 										<label onClick={ onSelectPath } className="font-semibold">
 											{ __( 'Local path' ) }
 										</label>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/dotcom-forge/issues/10582

## Proposed Changes

- Fix padding for the advance settings fields in site form

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Pull the changes from this branch
- Start Studio with STUDIO_WP_VERSIONS=true npm start
- Click on Add site button in the sidebar
- In the modal, click on Advanced settings
- Confirm that all the input fields are aligned

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
