### PR TITLE
Auto-start site when user opens it in header or overview

### DIFF
--- a/src/components/content-tab-overview.tsx
+++ b/src/components/content-tab-overview.tsx
@@ -19,6 +19,7 @@ import { ArrowIcon } from 'src/components/arrow-icon';
 import { ButtonsSection, ButtonsSectionProps } from 'src/components/buttons-section';
 import { useCheckInstalledApps } from 'src/hooks/use-check-installed-apps';
 import { useFeatureFlags } from 'src/hooks/use-feature-flags';
+import { useSiteDetails } from 'src/hooks/use-site-details';
 import { useThemeDetails } from 'src/hooks/use-theme-details';
 import { isMac } from 'src/lib/app-globals';
 import { cx } from 'src/lib/cx';
@@ -197,6 +198,7 @@ function ShortcutsSection( { selectedSite }: Pick< ContentTabOverviewProps, 'sel
 export function ContentTabOverview( { selectedSite }: ContentTabOverviewProps ) {
 	const [ isThumbnailError, setIsThumbnailError ] = useState( false );
 	const { __ } = useI18n();
+	const { startServer } = useSiteDetails();
 	const {
 		selectedThemeDetails: themeDetails,
 		selectedThumbnail: thumbnailData,
@@ -206,7 +208,6 @@ export function ContentTabOverview( { selectedSite }: ContentTabOverviewProps ) 
 	} = useThemeDetails();
 
 	const loading = loadingThemeDetails || loadingThumbnails || initialLoading;
-	const siteRunning = selectedSite.running;
 
 	const thumbnailImage = (
 		<img
@@ -227,7 +228,7 @@ export function ContentTabOverview( { selectedSite }: ContentTabOverviewProps ) 
 						'w-full min-h-40 max-h-64 rounded-sm border border-a8c-gray-5 bg-a8c-gray-0 mb-2 flex justify-center',
 						loading && `h-64 ${ skeletonBg }`,
 						isThumbnailError && 'border-none',
-						! loading && siteRunning && 'hover:border-a8c-blueberry duration-300'
+						! loading && 'hover:border-a8c-blueberry duration-300'
 					) }
 				>
 					{ isThumbnailError && ! loading && (
@@ -235,11 +236,16 @@ export function ContentTabOverview( { selectedSite }: ContentTabOverviewProps ) 
 							{ __( 'Preview unavailable' ) }
 						</div>
 					) }
-					{ ! loading && siteRunning && (
+					{ ! loading && (
 						<button
 							aria-label={ __( 'Open site' ) }
 							className={ 'relative group focus-visible:outline-a8c-blueberry' }
-							onClick={ () => getIpcApi().openSiteURL( selectedSite.id, '', { autoLogin: false } ) }
+							onClick={ async () => {
+								if ( ! selectedSite.running ) {
+									await startServer( selectedSite.id );
+								}
+								getIpcApi().openSiteURL( selectedSite.id, '', { autoLogin: false } );
+							} }
 						>
 							<div
 								className={
@@ -252,7 +258,6 @@ export function ContentTabOverview( { selectedSite }: ContentTabOverviewProps ) 
 							{ thumbnailImage }
 						</button>
 					) }
-					{ ! loading && ! siteRunning && thumbnailImage }
 				</div>
 				<div className="flex justify-between items-center w-full">
 					{ loading && <div className={ `w-[100px] min-h-4 ${ skeletonBg }` }></div> }

--- a/src/components/content-tab-overview.tsx
+++ b/src/components/content-tab-overview.tsx
@@ -198,7 +198,7 @@ function ShortcutsSection( { selectedSite }: Pick< ContentTabOverviewProps, 'sel
 export function ContentTabOverview( { selectedSite }: ContentTabOverviewProps ) {
 	const [ isThumbnailError, setIsThumbnailError ] = useState( false );
 	const { __ } = useI18n();
-	const { startServer } = useSiteDetails();
+	const { startServer, loadingServer } = useSiteDetails();
 	const {
 		selectedThemeDetails: themeDetails,
 		selectedThumbnail: thumbnailData,
@@ -208,6 +208,16 @@ export function ContentTabOverview( { selectedSite }: ContentTabOverviewProps ) 
 	} = useThemeDetails();
 
 	const loading = loadingThemeDetails || loadingThumbnails || initialLoading;
+	const isServerLoading = loadingServer[ selectedSite.id ];
+
+	const handleThumbnailClick = async () => {
+		if ( isServerLoading ) return;
+
+		if ( ! selectedSite.running ) {
+			await startServer( selectedSite.id );
+		}
+		getIpcApi().openSiteURL( selectedSite.id, '', { autoLogin: false } );
+	};
 
 	const thumbnailImage = (
 		<img
@@ -239,13 +249,12 @@ export function ContentTabOverview( { selectedSite }: ContentTabOverviewProps ) 
 					{ ! loading && (
 						<button
 							aria-label={ __( 'Open site' ) }
-							className={ 'relative group focus-visible:outline-a8c-blueberry' }
-							onClick={ async () => {
-								if ( ! selectedSite.running ) {
-									await startServer( selectedSite.id );
-								}
-								getIpcApi().openSiteURL( selectedSite.id, '', { autoLogin: false } );
-							} }
+							className={ cx(
+								'relative group focus-visible:outline-a8c-blueberry',
+								isServerLoading && 'cursor-not-allowed'
+							) }
+							onClick={ handleThumbnailClick }
+							disabled={ isServerLoading }
 						>
 							<div
 								className={

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -8,6 +8,26 @@ import { getIpcApi } from 'src/lib/get-ipc-api';
 export default function Header() {
 	const { __ } = useI18n();
 	const { selectedSite: site, startServer, stopServer, loadingServer } = useSiteDetails();
+	const isLoading = site?.id ? loadingServer[ site.id ] : false;
+
+	const handleWpAdminClick = async () => {
+		if ( ! site || isLoading ) return;
+
+		if ( ! site.running ) {
+			await startServer( site.id );
+		}
+		getIpcApi().openSiteURL( site.id, '/wp-admin' );
+	};
+
+	const handleOpenSiteClick = async () => {
+		if ( ! site || isLoading ) return;
+
+		if ( ! site.running ) {
+			await startServer( site.id );
+		}
+		getIpcApi().openSiteURL( site.id, '', { autoLogin: false } );
+	};
+
 	return (
 		<div
 			data-testid="site-content-header"
@@ -21,26 +41,18 @@ export default function Header() {
 					<div className="flex mt-1 gap-x-4">
 						<Button
 							className="[&.is-link]:text-a8c-gray-70 [&.is-link]:hover:text-a8c-blueberry !px-0 h-0 leading-4"
-							onClick={ async () => {
-								if ( ! site.running ) {
-									await startServer( site.id );
-								}
-								getIpcApi().openSiteURL( site.id, '/wp-admin' );
-							} }
+							onClick={ handleWpAdminClick }
 							variant="link"
+							disabled={ isLoading }
 						>
 							{ __( 'WP admin' ) }
 							<ArrowIcon />
 						</Button>
 						<Button
 							className="[&.is-link]:text-a8c-gray-70 [&.is-link]:hover:text-a8c-blueberry !px-0 h-0 leading-4"
-							onClick={ async () => {
-								if ( ! site.running ) {
-									await startServer( site.id );
-								}
-								getIpcApi().openSiteURL( site.id, '', { autoLogin: false } );
-							} }
+							onClick={ handleOpenSiteClick }
 							variant="link"
+							disabled={ isLoading }
 						>
 							{
 								// translators: "Open site" refers to the action, like "to open site"
@@ -53,7 +65,7 @@ export default function Header() {
 			) }
 			<SiteManagementActions
 				onStart={ startServer }
-				loading={ site?.id ? loadingServer[ site.id ] : false }
+				loading={ isLoading }
 				onStop={ stopServer }
 				selectedSite={ site }
 			/>

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -20,18 +20,26 @@ export default function Header() {
 					</h1>
 					<div className="flex mt-1 gap-x-4">
 						<Button
-							disabled={ ! site.running }
 							className="[&.is-link]:text-a8c-gray-70 [&.is-link]:hover:text-a8c-blueberry !px-0 h-0 leading-4"
-							onClick={ () => getIpcApi().openSiteURL( site.id, '/wp-admin' ) }
+							onClick={ async () => {
+								if ( ! site.running ) {
+									await startServer( site.id );
+								}
+								getIpcApi().openSiteURL( site.id, '/wp-admin' );
+							} }
 							variant="link"
 						>
 							{ __( 'WP admin' ) }
 							<ArrowIcon />
 						</Button>
 						<Button
-							disabled={ ! site.running }
 							className="[&.is-link]:text-a8c-gray-70 [&.is-link]:hover:text-a8c-blueberry !px-0 h-0 leading-4"
-							onClick={ () => getIpcApi().openSiteURL( site.id, '', { autoLogin: false } ) }
+							onClick={ async () => {
+								if ( ! site.running ) {
+									await startServer( site.id );
+								}
+								getIpcApi().openSiteURL( site.id, '', { autoLogin: false } );
+							} }
 							variant="link"
 						>
 							{


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Related to https://github.com/Automattic/dotcom-forge/issues/9139

## Proposed Changes

- I propose to automatically start the site when a user opens it in the header using 'WP admin' or 'Open site' links or screenshot in the Overview tab.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Ensure site is stopped
2. Click 'WP admin', 'Open site' and screenshot
3. Confirm each action starts and site and opens it

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
