### PR TITLE
Add stats for PHP and WP versions

### DIFF
--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -21,7 +21,13 @@ import { ARCHIVER_OPTIONS, MAIN_MIN_WIDTH, SIDEBAR_WIDTH } from 'src/constants';
 import { sendIpcEventToRendererWithWindow } from 'src/ipc-utils';
 import { ACTIVE_SYNC_OPERATIONS } from 'src/lib/active-sync-operations';
 import { bumpStat } from 'src/lib/bump-stats';
-import { getImporterMetric, StatsGroup, StatsMetric } from 'src/lib/bump-stats/types';
+import {
+	getImporterMetric,
+	StatsGroup,
+	StatsMetric,
+	getWordPressVersionMetric,
+	getPHPVersionMetric,
+} from 'src/lib/bump-stats/types';
 import { calculateDirectorySize } from 'src/lib/calculate-directory-size';
 import { download } from 'src/lib/download';
 import { isEmptyDir, pathExists, isWordPressDirectory, sanitizeFolderName } from 'src/lib/fs-utils';
@@ -54,6 +60,7 @@ import { SiteServer, createSiteWorkingDirectory } from 'src/site-server';
 import { DEFAULT_SITE_PATH, getResourcesPath, getSiteThumbnailPath } from 'src/storage/paths';
 import { loadUserData, saveUserData } from 'src/storage/user-data';
 import { DEFAULT_PHP_VERSION } from 'vendor/wp-now/src/constants';
+import { getWordPressVersionUrl } from './lib/get-wordpress-version-url';
 import type { SyncSite } from 'src/hooks/use-fetch-wpcom-sites/types';
 import type { WpCliResult } from 'src/lib/wp-cli-process';
 
@@ -205,6 +212,13 @@ export async function createSite(
 		}
 	}
 
+	if ( details.phpVersion ) {
+		bumpStat( StatsGroup.STUDIO_SITE_VERSIONS, getPHPVersionMetric( details.phpVersion ) );
+	}
+	if ( wpVersion ) {
+		bumpStat( StatsGroup.STUDIO_SITE_VERSIONS, getWordPressVersionMetric( wpVersion ) );
+	}
+
 	const parentWindow = BrowserWindow.fromWebContents( event.sender );
 	sendIpcEventToRendererWithWindow( parentWindow, 'theme-details-updating', { id: details.id } );
 
@@ -226,9 +240,15 @@ export async function updateSite(
 	userData.sites = updatedSites;
 
 	const server = SiteServer.get( updatedSite.id );
+	const hasPHPVersionChanged = server?.details.phpVersion !== updatedSite.phpVersion;
 	if ( server ) {
 		server.updateSiteDetails( updatedSite );
 	}
+
+	if ( hasPHPVersionChanged ) {
+		bumpStat( StatsGroup.STUDIO_SITE_VERSIONS, getPHPVersionMetric( updatedSite.phpVersion ) );
+	}
+
 	await saveUserData( userData );
 	return mergeSiteDetailsWithRunningDetails( userData.sites );
 }
@@ -899,6 +919,40 @@ export async function executeWPCLiInline(
 	return server.executeWpCliCommand( args, {
 		skipPluginsAndThemes,
 	} );
+}
+
+export async function changeWordPressVersion(
+	_event: IpcMainInvokeEvent,
+	{
+		siteId,
+		wpVersion,
+	}: {
+		siteId: string;
+		wpVersion: string;
+	}
+): Promise< WpCliResult > {
+	if ( SiteServer.isDeleted( siteId ) ) {
+		return {
+			stdout: '',
+			stderr: `Cannot change WordPress version on deleted site ${ siteId }`,
+			exitCode: 1,
+		};
+	}
+
+	const server = SiteServer.get( siteId );
+	if ( ! server ) {
+		throw new Error( 'Site not found.' );
+	}
+	const zipUrl = getWordPressVersionUrl( wpVersion );
+	const result = await server.executeWpCliCommand( `core update ${ zipUrl } --force`, {
+		skipPluginsAndThemes: true,
+	} );
+
+	if ( result.exitCode === 0 ) {
+		bumpStat( StatsGroup.STUDIO_SITE_VERSIONS, getWordPressVersionMetric( wpVersion ) );
+	}
+
+	return result;
 }
 
 export async function getThumbnailData( _event: IpcMainInvokeEvent, id: string ) {

--- a/src/lib/bump-stats/types.ts
+++ b/src/lib/bump-stats/types.ts
@@ -12,6 +12,7 @@ export enum StatsGroup {
 	STUDIO_APP_LAUNCH_UNIQUE = 'local-environment-launch-uniques',
 	STUDIO_IMPORT = 'studio-app-import',
 	STUDIO_EXPORT = 'studio-app-export',
+	STUDIO_SITE_VERSIONS = 'studio-site-versions',
 }
 
 export enum StatsMetric {
@@ -32,6 +33,9 @@ export enum StatsMetric {
 	PLAYGROUND_IMPORTER = 'PlaygroundImporter',
 	WPRESS_IMPORTER = 'WpressImporter',
 	UNKNOWN_IMPORTER = 'UnknownImporter',
+	// WordPress and PHP versions
+	WP_VERSION_PREFIX = 'wp-version-',
+	PHP_VERSION_PREFIX = 'php-version-',
 }
 
 export type AggregateInterval = 'daily' | 'weekly' | 'monthly';
@@ -64,4 +68,14 @@ export function getImporterMetric( importer?: string ): StatsMetric {
 		default:
 			return StatsMetric.UNKNOWN_IMPORTER;
 	}
+}
+
+export function getWordPressVersionMetric( version: string ): StatsMetric {
+	const sanitizedVersion = version.replace( /\./g, '-' ).toLowerCase();
+	return `${ StatsMetric.WP_VERSION_PREFIX }${ sanitizedVersion }` as unknown as StatsMetric;
+}
+
+export function getPHPVersionMetric( version: string ): StatsMetric {
+	const sanitizedVersion = version.replace( /\./g, '-' ).toLowerCase();
+	return `${ StatsMetric.PHP_VERSION_PREFIX }${ sanitizedVersion }` as unknown as StatsMetric;
 }

--- a/src/lib/tests/bump-stats.test.ts
+++ b/src/lib/tests/bump-stats.test.ts
@@ -1,7 +1,12 @@
 import { waitFor } from '@testing-library/react';
 import nock from 'nock';
 import { bumpAggregatedUniqueStat, bumpStat } from 'src/lib/bump-stats';
-import { StatsGroup, StatsMetric } from 'src/lib/bump-stats/types';
+import {
+	StatsGroup,
+	StatsMetric,
+	getWordPressVersionMetric,
+	getPHPVersionMetric,
+} from 'src/lib/bump-stats/types';
 import { loadUserData, saveUserData } from 'src/storage/user-data';
 
 jest.mock( 'src/storage/user-data' );
@@ -143,4 +148,24 @@ describe( 'bumpAggregatedUniqueStat', () => {
 			expect( saveUserData ).not.toHaveBeenCalled();
 		} );
 	}
+} );
+
+describe( 'getWordPressVersionMetric', () => {
+	test( 'should convert WordPress version to a valid metric', () => {
+		expect( getWordPressVersionMetric( '6.4' ) ).toEqual( `${ StatsMetric.WP_VERSION_PREFIX }6-4` );
+		expect( getWordPressVersionMetric( '6.4.1' ) ).toEqual(
+			`${ StatsMetric.WP_VERSION_PREFIX }6-4-1`
+		);
+		expect( getWordPressVersionMetric( 'latest' ) ).toEqual(
+			`${ StatsMetric.WP_VERSION_PREFIX }latest`
+		);
+	} );
+} );
+
+describe( 'getPHPVersionMetric', () => {
+	test( 'should convert PHP version to a valid metric', () => {
+		expect( getPHPVersionMetric( '8.2' ) ).toEqual( `${ StatsMetric.PHP_VERSION_PREFIX }8-2` );
+		expect( getPHPVersionMetric( '8.0' ) ).toEqual( `${ StatsMetric.PHP_VERSION_PREFIX }8-0` );
+		expect( getPHPVersionMetric( '7.4' ) ).toEqual( `${ StatsMetric.PHP_VERSION_PREFIX }7-4` );
+	} );
 } );

--- a/src/modules/site-settings/edit-site-details.tsx
+++ b/src/modules/site-settings/edit-site-details.tsx
@@ -12,7 +12,6 @@ import { useOffline } from 'src/hooks/use-offline';
 import { useSiteDetails } from 'src/hooks/use-site-details';
 import { cx } from 'src/lib/cx';
 import { getIpcApi } from 'src/lib/get-ipc-api';
-import { getWordPressVersionUrl } from 'src/lib/get-wordpress-version-url';
 import { useRootSelector } from 'src/stores';
 import { wordpressVersionsSelectors } from 'src/stores/wordpress-versions-slice';
 import {
@@ -83,12 +82,11 @@ export default function EditSiteDetails( { currentWpVersion, onSave }: EditSiteD
 
 			if ( hasWpVersionChanged ) {
 				try {
-					const zipUrl = getWordPressVersionUrl( selectedWpVersion );
-					const result = await getIpcApi().executeWPCLiInline( {
+					const result = await getIpcApi().changeWordPressVersion( {
 						siteId: selectedSite.id,
-						args: `core update ${ zipUrl } --force`,
-						skipPluginsAndThemes: true,
+						wpVersion: selectedWpVersion,
 					} );
+
 					if ( result.exitCode !== 0 ) {
 						throw new Error( result.stderr );
 					}

--- a/src/modules/site-settings/tests/edit-site-details.test.tsx
+++ b/src/modules/site-settings/tests/edit-site-details.test.tsx
@@ -7,7 +7,7 @@ import EditSiteDetails from 'src/modules/site-settings/edit-site-details';
 const mockUpdateSite = jest.fn();
 const mockStopServer = jest.fn();
 const mockStartServer = jest.fn();
-const mockExecuteWPCLiInline = jest.fn();
+const mockChangeWordPressVersion = jest.fn();
 const mockShowErrorMessageBox = jest.fn();
 
 jest.mock( 'src/hooks/use-site-details', () => ( {
@@ -26,7 +26,7 @@ jest.mock( 'src/hooks/use-site-details', () => ( {
 
 jest.mock( 'src/lib/get-ipc-api', () => ( {
 	getIpcApi: () => ( {
-		executeWPCLiInline: mockExecuteWPCLiInline,
+		changeWordPressVersion: mockChangeWordPressVersion,
 		showErrorMessageBox: mockShowErrorMessageBox,
 	} ),
 } ) );
@@ -61,7 +61,7 @@ describe( 'EditSiteDetails', () => {
 
 	beforeEach( () => {
 		jest.clearAllMocks();
-		mockExecuteWPCLiInline.mockResolvedValue( { exitCode: 0 } );
+		mockChangeWordPressVersion.mockResolvedValue( { exitCode: 0 } );
 	} );
 
 	it( 'should render the edit button', () => {
@@ -204,10 +204,9 @@ describe( 'EditSiteDetails', () => {
 		await user.click( screen.getByRole( 'button', { name: 'Save' } ) );
 
 		expect( mockStopServer ).toHaveBeenCalledWith( 'site-123' );
-		expect( mockExecuteWPCLiInline ).toHaveBeenCalledWith( {
+		expect( mockChangeWordPressVersion ).toHaveBeenCalledWith( {
 			siteId: 'site-123',
-			args: 'core update https://wordpress.org/wordpress-6.4.zip --force',
-			skipPluginsAndThemes: true,
+			wpVersion: '6.4',
 		} );
 		expect( mockUpdateSite ).toHaveBeenCalledWith( {
 			id: 'site-123',
@@ -230,15 +229,14 @@ describe( 'EditSiteDetails', () => {
 
 		await user.click( screen.getByRole( 'button', { name: 'Save' } ) );
 
-		expect( mockExecuteWPCLiInline ).toHaveBeenCalledWith( {
+		expect( mockChangeWordPressVersion ).toHaveBeenCalledWith( {
 			siteId: 'site-123',
-			args: 'core update https://wordpress.org/wordpress-6.8-beta1.zip --force',
-			skipPluginsAndThemes: true,
+			wpVersion: '6.8-beta1',
 		} );
 	} );
 
 	it( 'should show error when WordPress version update fails', async () => {
-		mockExecuteWPCLiInline.mockResolvedValue( { exitCode: 1, stderr: 'Update failed' } );
+		mockChangeWordPressVersion.mockResolvedValue( { exitCode: 1, stderr: 'Update failed' } );
 
 		render( <EditSiteDetails { ...defaultProps } /> );
 		const user = userEvent.setup();

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -117,6 +117,8 @@ const api: IpcApi = {
 	getPathForFile: webUtils.getPathForFile,
 	getFileContent: ( filePath: string ) => ipcRenderer.invoke( 'getFileContent', filePath ),
 	isFullscreen: () => ipcRenderer.invoke( 'isFullscreen' ),
+	changeWordPressVersion: ( { siteId, wpVersion }: { siteId: string; wpVersion: string } ) =>
+		ipcRenderer.invoke( 'changeWordPressVersion', { siteId, wpVersion } ),
 };
 
 contextBridge.exposeInMainWorld( 'ipcApi', api );

--- a/src/tests/ipc-handlers.test.ts
+++ b/src/tests/ipc-handlers.test.ts
@@ -5,10 +5,23 @@ import { shell, IpcMainInvokeEvent } from 'electron';
 import fs from 'fs';
 import { normalize } from 'path';
 import * as Sentry from '@sentry/electron/main';
-import { createSite, startServer, isFullscreen, importSite } from 'src/ipc-handlers';
+import {
+	createSite,
+	startServer,
+	isFullscreen,
+	importSite,
+	updateSite,
+	changeWordPressVersion,
+} from 'src/ipc-handlers';
 import { bumpStat } from 'src/lib/bump-stats';
-import { StatsGroup, StatsMetric } from 'src/lib/bump-stats/types';
+import {
+	StatsGroup,
+	StatsMetric,
+	getWordPressVersionMetric,
+	getPHPVersionMetric,
+} from 'src/lib/bump-stats/types';
 import { isEmptyDir, pathExists } from 'src/lib/fs-utils';
+import { getWordPressVersionUrl } from 'src/lib/get-wordpress-version-url';
 import { importBackup, defaultImporterOptions } from 'src/lib/import-export/import/import-manager';
 import { BackupArchiveInfo } from 'src/lib/import-export/import/types';
 import { keepSqliteIntegrationUpdated } from 'src/lib/sqlite-versions';
@@ -25,6 +38,7 @@ jest.mock( 'src/main-window' );
 jest.mock( '@sentry/electron/main' );
 jest.mock( 'src/lib/import-export/import/import-manager' );
 jest.mock( 'src/lib/bump-stats' );
+jest.mock( 'src/lib/get-wordpress-version-url' );
 
 jest.mock( 'src/lib/port-finder', () => ( {
 	portFinder: {
@@ -40,7 +54,7 @@ jest.mock( 'src/lib/port-finder', () => ( {
 } ) );
 ( createSiteWorkingDirectory as jest.Mock ).mockResolvedValue( true );
 
-const mockUserData = {
+const mockUserData: { sites: SiteDetails[] } = {
 	sites: [],
 };
 ( fs as MockedFs ).__setFileContents(
@@ -78,6 +92,15 @@ describe( 'createSite', () => {
 			running: false,
 			customDomain: undefined,
 		} );
+
+		expect( bumpStat ).toHaveBeenCalledWith(
+			StatsGroup.STUDIO_SITE_VERSIONS,
+			getPHPVersionMetric( '8.2' )
+		);
+		expect( bumpStat ).toHaveBeenCalledWith(
+			StatsGroup.STUDIO_SITE_VERSIONS,
+			getWordPressVersionMetric( '6.4' )
+		);
 	} );
 
 	describe( 'when the site path started as an empty directory', () => {
@@ -93,6 +116,170 @@ describe( 'createSite', () => {
 				expect( shell.trashItem ).toHaveBeenCalledWith( '/test' );
 			} );
 		} );
+	} );
+} );
+
+describe( 'updateSite', () => {
+	it( 'should update a site and bump stats when PHP version changes', async () => {
+		const existingSite = {
+			id: 'test-site-id',
+			name: 'Test Site',
+			path: '/test',
+			phpVersion: '8.0',
+			port: 9999,
+			running: false,
+		};
+
+		const updatedSite = {
+			...existingSite,
+			phpVersion: '8.2',
+		};
+
+		mockUserData.sites = [ existingSite as unknown as SiteDetails ];
+
+		( SiteServer.get as jest.Mock ).mockReturnValue( {
+			details: existingSite,
+			updateSiteDetails: jest.fn(),
+		} );
+
+		await updateSite( mockIpcMainInvokeEvent, updatedSite as unknown as SiteDetails );
+
+		// Verify that stats are bumped for PHP version change
+		expect( bumpStat ).toHaveBeenCalledWith(
+			StatsGroup.STUDIO_SITE_VERSIONS,
+			getPHPVersionMetric( '8.2' )
+		);
+	} );
+
+	it( 'should not bump stats when PHP version does not change', async () => {
+		const existingSite = {
+			id: 'test-site-id',
+			name: 'Test Site',
+			path: '/test',
+			phpVersion: '8.2',
+			port: 9999,
+			running: false,
+		};
+
+		const updatedSite = {
+			...existingSite,
+			name: 'Updated Test Site',
+		};
+
+		mockUserData.sites = [ existingSite ] as unknown as SiteDetails[];
+
+		( SiteServer.get as jest.Mock ).mockReturnValue( {
+			details: existingSite,
+			updateSiteDetails: jest.fn(),
+		} );
+
+		await updateSite( mockIpcMainInvokeEvent, updatedSite as unknown as SiteDetails );
+
+		// Verify that stats are not bumped
+		expect( bumpStat ).not.toHaveBeenCalled();
+	} );
+} );
+
+describe( 'changeWordPressVersion', () => {
+	it( 'should change WordPress version and bump stats on success', async () => {
+		const siteId = 'test-site-id';
+		const wpVersion = '6.4';
+		const zipUrl = 'https://wordpress.org/wordpress-6.4.zip';
+
+		( getWordPressVersionUrl as jest.Mock ).mockReturnValue( zipUrl );
+
+		const mockServer = {
+			executeWpCliCommand: jest.fn().mockResolvedValue( {
+				stdout: 'WordPress updated successfully',
+				stderr: '',
+				exitCode: 0,
+			} ),
+		};
+
+		( SiteServer.get as jest.Mock ).mockReturnValue( mockServer );
+		( SiteServer.isDeleted as jest.Mock ).mockReturnValue( false );
+
+		const result = await changeWordPressVersion( mockIpcMainInvokeEvent, { siteId, wpVersion } );
+
+		expect( mockServer.executeWpCliCommand ).toHaveBeenCalledWith(
+			`core update ${ zipUrl } --force`,
+			{ skipPluginsAndThemes: true }
+		);
+
+		expect( result ).toEqual( {
+			stdout: 'WordPress updated successfully',
+			stderr: '',
+			exitCode: 0,
+		} );
+
+		// Verify that stats are bumped for WordPress version
+		expect( bumpStat ).toHaveBeenCalledWith(
+			StatsGroup.STUDIO_SITE_VERSIONS,
+			getWordPressVersionMetric( wpVersion )
+		);
+	} );
+
+	it( 'should not bump stats when WordPress update fails', async () => {
+		const siteId = 'test-site-id';
+		const wpVersion = '6.4';
+		const zipUrl = 'https://wordpress.org/wordpress-6.4.zip';
+
+		( getWordPressVersionUrl as jest.Mock ).mockReturnValue( zipUrl );
+
+		const mockServer = {
+			executeWpCliCommand: jest.fn().mockResolvedValue( {
+				stdout: '',
+				stderr: 'Error updating WordPress',
+				exitCode: 1,
+			} ),
+		};
+
+		( SiteServer.get as jest.Mock ).mockReturnValue( mockServer );
+		( SiteServer.isDeleted as jest.Mock ).mockReturnValue( false );
+
+		const result = await changeWordPressVersion( mockIpcMainInvokeEvent, { siteId, wpVersion } );
+
+		expect( result ).toEqual( {
+			stdout: '',
+			stderr: 'Error updating WordPress',
+			exitCode: 1,
+		} );
+
+		// Verify that stats are not bumped
+		expect( bumpStat ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should return error when site is deleted', async () => {
+		const siteId = 'deleted-site-id';
+		const wpVersion = '6.4';
+
+		( SiteServer.isDeleted as jest.Mock ).mockReturnValue( true );
+
+		const result = await changeWordPressVersion( mockIpcMainInvokeEvent, { siteId, wpVersion } );
+
+		expect( result ).toEqual( {
+			stdout: '',
+			stderr: `Cannot change WordPress version on deleted site ${ siteId }`,
+			exitCode: 1,
+		} );
+
+		// Verify that stats are not bumped
+		expect( bumpStat ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should throw error when site is not found', async () => {
+		const siteId = 'non-existent-site-id';
+		const wpVersion = '6.4';
+
+		( SiteServer.isDeleted as jest.Mock ).mockReturnValue( false );
+		( SiteServer.get as jest.Mock ).mockReturnValue( null );
+
+		await expect(
+			changeWordPressVersion( mockIpcMainInvokeEvent, { siteId, wpVersion } )
+		).rejects.toThrow( 'Site not found.' );
+
+		// Verify that stats are not bumped
+		expect( bumpStat ).not.toHaveBeenCalled();
 	} );
 } );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/dotcom-forge/issues/10534

## Proposed Changes

- Added tracking for WordPress and PHP versions used in sites
- Created new changeWordPressVersion IPC handler to centralize WordPress version changes
- Added utility functions to convert WordPress and PHP versions to metrics for stats tracking
- Added version tracking when creating sites, updating PHP versions, and changing WordPress versions
- Added tests for the new functionality

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Create a new site and verify that WordPress and PHP version stats are tracked
- Change the PHP version of an existing site and verify that stats are tracked
- Change the WordPress version of an existing site and verify that stats are tracked
- Run the test suite to verify that all tests pass

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
