### PR TITLE
Account for custom domain in meta.json export

### DIFF
--- a/src/lib/get-site-url.ts
+++ b/src/lib/get-site-url.ts
@@ -1,0 +1,3 @@
+export function getSiteUrl( site: SiteDetails ) {
+	return site.customDomain ? `http://${ site.customDomain }` : `http://localhost:${ site.port }`;
+}

--- a/src/lib/import-export/export/exporters/default-exporter.ts
+++ b/src/lib/import-export/export/exporters/default-exporter.ts
@@ -5,6 +5,7 @@ import os from 'os';
 import path from 'path';
 import archiver from 'archiver';
 import { ARCHIVER_OPTIONS } from 'src/constants';
+import { getSiteUrl } from 'src/lib/get-site-url';
 import { ExportEvents } from 'src/lib/import-export/export/events';
 import {
 	exportDatabaseToFile,
@@ -273,7 +274,7 @@ export class DefaultExporter extends EventEmitter implements Exporter {
 	private async createStudioJsonFile(): Promise< string > {
 		const wpVersion = await getWordPressVersionFromInstallation( this.options.site.path );
 		const studioJson: StudioJson = {
-			siteUrl: `http://localhost:${ this.options.site.port }`,
+			siteUrl: getSiteUrl( this.options.site ),
 			phpVersion: this.options.phpVersion,
 			wordpressVersion: wpVersion ? wpVersion : '',
 			plugins: [],

--- a/src/lib/tests/get-site-url.test.ts
+++ b/src/lib/tests/get-site-url.test.ts
@@ -1,0 +1,22 @@
+import { getSiteUrl } from 'src/lib/get-site-url';
+
+describe( 'getSiteUrl', () => {
+	it( 'should return custom domain URL when customDomain is provided', () => {
+		const site: SiteDetails = {
+			customDomain: 'example.wp.local',
+			port: 8080,
+		} as SiteDetails;
+
+		const result = getSiteUrl( site );
+		expect( result ).toBe( 'http://example.wp.local' );
+	} );
+
+	it( 'should return localhost URL when no custom domain is provided', () => {
+		const site: SiteDetails = {
+			port: 8080,
+		} as SiteDetails;
+
+		const result = getSiteUrl( site );
+		expect( result ).toBe( 'http://localhost:8080' );
+	} );
+} );

--- a/src/lib/updateSiteUrlToLocal.ts
+++ b/src/lib/updateSiteUrlToLocal.ts
@@ -1,3 +1,4 @@
+import { getSiteUrl } from 'src/lib/get-site-url';
 import { SiteServer } from 'src/site-server';
 
 export const updateSiteUrlToLocal = async ( siteId: string ) => {
@@ -15,9 +16,7 @@ export const updateSiteUrlToLocal = async ( siteId: string ) => {
 		return;
 	}
 
-	const studioUrl = server.details.customDomain
-		? `http://${ server.details.customDomain }`
-		: `http://localhost:${ server.details.port }`;
+	const studioUrl = getSiteUrl( server.details );
 	const oldUrl = currentSiteUrl.trim();
 	const urlWithoutProtocol = oldUrl.replace( /^https?:\/\//, '' );
 

--- a/src/lib/updateSiteUrlToLocal.ts
+++ b/src/lib/updateSiteUrlToLocal.ts
@@ -15,7 +15,9 @@ export const updateSiteUrlToLocal = async ( siteId: string ) => {
 		return;
 	}
 
-	const studioUrl = `http://localhost:${ server.details.port }`;
+	const studioUrl = server.details.customDomain
+		? `http://${ server.details.customDomain }`
+		: `http://localhost:${ server.details.port }`;
 	const oldUrl = currentSiteUrl.trim();
 	const urlWithoutProtocol = oldUrl.replace( /^https?:\/\//, '' );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/dotcom-forge/issues/10587

## Proposed Changes

Account for custom domain in `DefaultExporter` when creating the `meta.json` file included in the exported archive.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Have a Studio site with a custom domain
2. Export the entire site
3. Unpack the exported ZIP and open `meta.json`
4. Ensure that the `siteUrl` field contains the custom domain URL

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
