### PR TITLE
Studio: Fix Sync tab sites list misalignment

### DIFF
--- a/src/components/sync-connected-sites.tsx
+++ b/src/components/sync-connected-sites.tsx
@@ -213,7 +213,7 @@ const SyncConnectedSitesSection = ( {
 							key={ connectedSite.id }
 							className="flex items-center gap-2 min-h-14 border-b border-a8c-gray-0 px-8"
 						>
-							<div className="flex items-left min-w-20 me-6 shrink-0">
+							<div className="flex items-left min-w-[100px] me-4 shrink-0">
 								{ connectedSite.isStaging ? (
 									<Badge>{ __( 'Staging' ) }</Badge>
 								) : (
@@ -222,7 +222,7 @@ const SyncConnectedSitesSection = ( {
 							</div>
 							<Button
 								variant="link"
-								className="!text-a8c-gray-70 hover:!text-a8c-blueberry max-w-[100%]"
+								className="!text-a8c-gray-70 hover:!text-a8c-blueberry max-w-full overflow-hidden"
 								onClick={ () => {
 									getIpcApi().openURL( connectedSite.url );
 								} }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/dotcom-forge/issues/10605.

## Proposed Changes

- fix Sync sites list alignment

| Before | After |
|--------|--------|
| ![Markup on 2025-03-11 at 12:17:38](https://github.com/user-attachments/assets/e85e89fe-8bd0-445b-808e-a6a658ae49df) | ![Markup on 2025-03-11 at 12:25:10](https://github.com/user-attachments/assets/7a32ecab-3d1a-443c-b40a-bfd8765377a3) | 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR branch and build the app with `npm start`.
2. Head over to the Sync tab and connect to a WPCOM site that also has a staging site.
3. Review the alignment of both sites on the list.
4. Switch through different locales and window sizes. The alignment should be correct.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
