### PR TITLE
Preserve index.php in wp-content during import

### DIFF
--- a/src/lib/import-export/import/importers/importer.ts
+++ b/src/lib/import-export/import/importers/importer.ts
@@ -149,6 +149,7 @@ abstract class BaseBackupImporter extends BaseImporter {
 				/^mu-plugins(\/|\\)sqlite-database-integration(\/|\\)?.*/, // Match sqlite-database-integration dir and contents
 				/^database(\/|\\)?.*/, // Match database dir and all contents
 				/^db\.php$/, // Exact match for db.php
+				/^index\.php$/, // Exact match for index.php
 			];
 
 			const contents = await fsPromises.readdir( wpContentDir, { recursive: true } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/studio/issues/1047

## Proposed Changes

I propose to add `index.php` to the protected files list during site import. Previously, the `moveExistingWpContentToTrash` method was removing `index.php` from the `wp-content` directory, which is a required WordPress file. The fix ensures this file is preserved alongside other critical files like `db.php` and the `mu-plugins` directory.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create a new WordPress site in Studio
2. Verify that `wp-content/index.php` exists in the new site
3. Export this site as a backup file
4. Create another new WordPress site in Studio
5. Import the backup file into the second site
6. Verify that `wp-content/index.php` still exists after the import
7. The site should work normally without any file-related errors

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
