### PR TITLE
[DRAFT] CLI architecture proposal

### DIFF
--- a/cli/base.ts
+++ b/cli/base.ts
@@ -1,0 +1,26 @@
+export type OutputFormat = undefined | 'json';
+
+export abstract class BaseCommand {
+	protected readonly STATUSES: Record< string, string >;
+	protected readonly outputFormat: OutputFormat;
+
+	constructor( outputFormat: OutputFormat ) {
+		this.outputFormat = outputFormat;
+	}
+
+	protected reportProgress( status: keyof typeof this.STATUSES ) {
+		if ( this.outputFormat === 'json' ) {
+			console.log( JSON.stringify( { status } ) );
+		} else {
+			console.log( status );
+		}
+	}
+
+	protected reportError( error: string ) {
+		if ( this.outputFormat === 'json' ) {
+			console.error( JSON.stringify( { error } ) );
+		} else {
+			console.error( error );
+		}
+	}
+}

--- a/cli/go.ts
+++ b/cli/go.ts
@@ -1,0 +1,72 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import archiver from 'archiver';
+import fetch from 'node-fetch';
+import { BaseCommand, OutputFormat } from './base';
+
+export class StudioGo extends BaseCommand {
+	private folder: string;
+	private archivePath: string;
+
+	protected readonly STATUSES = {
+		ARCHIVE_CREATED: 'ARCHIVE_CREATED',
+		ARCHIVE_UPLOADED: 'ARCHIVE_UPLOADED',
+		ARCHIVE_DELETED: 'ARCHIVE_DELETED',
+	};
+
+	constructor( folder: string, outputFormat: OutputFormat ) {
+		super( outputFormat );
+		this.folder = folder;
+		this.archivePath = path.join( os.tmpdir(), `${ this.folder }.zip` );
+	}
+
+	async run() {
+		await this.archiveFolder();
+		await this.uploadArchive();
+		await this.cleanup();
+		return true;
+	}
+
+	async archiveFolder() {
+		return new Promise( ( resolve, reject ) => {
+			const output = fs.createWriteStream( this.archivePath );
+
+			const archive = archiver( 'zip', {
+				zlib: { level: 9 },
+			} );
+
+			output.on( 'close', () => {
+				this.reportProgress( this.STATUSES.ARCHIVE_CREATED );
+				resolve( archive );
+			} );
+
+			archive.on( 'error', ( err: Error ) => {
+				this.reportError( err.message );
+				reject( err );
+			} );
+
+			archive.pipe( output );
+			archive.directory( `${ this.folder }/wp-content`, 'wp-content' );
+			archive.file( `${ this.folder }/wp-config.php`, { name: 'wp-config.php' } );
+
+			archive.finalize();
+		} );
+	}
+
+	async uploadArchive() {
+		const response = await fetch(
+			'https://public-api.wordpress.com/rest/v1.1/jurassic-ninja/create-new-site-from-zip',
+			{
+				method: 'POST',
+				body: fs.createReadStream( this.archivePath ),
+			}
+		);
+		this.reportProgress( this.STATUSES.ARCHIVE_UPLOADED );
+		return response.json();
+	}
+
+	async cleanup() {
+		fs.unlinkSync( this.archivePath );
+	}
+}

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+
+import path from 'path';
+import { Command } from 'commander';
+import lockfile from 'lockfile';
+import { version } from '../package.json';
+import { StudioGo } from './go';
+
+const program = new Command();
+
+program.name( 'studio' ).description( 'WordPress.com Studio CLI' ).version( version );
+
+program
+	.command( 'go [folder]' )
+	.description(
+		'Start a new WordPress environment in the specified folder (defaults to current directory)'
+	)
+	.option(
+		'--output-format [format]',
+		'Specify a non-standard output format',
+		( value: string ) => {
+			if ( value !== 'json' ) {
+				throw new Error( 'The only custom output format supported is "json"' );
+			}
+			return value;
+		}
+	)
+	.action( async ( folder: string = process.cwd(), options: { outputFormat?: 'json' } ) => {
+		lockfile.lockSync( path.join( folder, '.studio-lock' ), {
+			stale: 1000 * 60 * 5,
+		} );
+
+		const studioGo = new StudioGo( folder, options.outputFormat );
+		await studioGo.run();
+	} );
+
+program.parse( process.argv );

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
 				"@wp-playground/wordpress": "https://wpcomplaygroundpackages.wpcomstaging.com/packages/v1.0.27/@wp-playground-wordpress-1.0.27.tar.gz",
 				"archiver": "^6.0.1",
 				"atomically": "^2.0.3",
+				"commander": "^13.1.0",
 				"compressible": "2.0.18",
 				"compression": "1.7.4",
 				"cross-port-killer": "^1.4.0",
@@ -39,6 +40,7 @@
 				"fs-extra": "11.1.1",
 				"hpagent": "1.2.0",
 				"http-proxy": "^1.18.1",
+				"lockfile": "^1.0.4",
 				"node-fetch": "^2.7.0",
 				"react-markdown": "^9.0.1",
 				"react-redux": "^9.2.0",
@@ -54,6 +56,9 @@
 				"yargs": "17.7.2",
 				"yauzl": "^3.2.0",
 				"zod": "^3.24.1"
+			},
+			"bin": {
+				"studio": "dist/cli/studio-cli.js"
 			},
 			"devDependencies": {
 				"@automattic/color-studio": "^2.5.0",
@@ -124,6 +129,7 @@
 				"ts-node": "^10.0.0",
 				"typescript": "~5.3.2",
 				"web-streams-polyfill": "^4.0.0",
+				"webpack-cli": "^6.0.1",
 				"webpack-dev-middleware": "5.3.4"
 			},
 			"optionalDependencies": {
@@ -353,6 +359,16 @@
 			},
 			"peerDependencies": {
 				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/cli/node_modules/commander": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+			"integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 6"
 			}
 		},
 		"node_modules/@babel/cli/node_modules/make-dir": {
@@ -2318,6 +2334,16 @@
 				"@jridgewell/sourcemap-codec": "^1.4.10"
 			}
 		},
+		"node_modules/@discoveryjs/json-ext": {
+			"version": "0.6.3",
+			"resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.6.3.tgz",
+			"integrity": "sha512-4B4OijXeVNOPZlYA2oEwWOTkzyltLao+xbotHQeqN++Rv27Y6s818+n2Qkp8q+Fxhn0t/5lA5X1Mxktud8eayQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.17.0"
+			}
+		},
 		"node_modules/@electron-forge/cli": {
 			"version": "7.6.0",
 			"resolved": "https://registry.npmjs.org/@electron-forge/cli/-/cli-7.6.0.tgz",
@@ -2352,6 +2378,16 @@
 			},
 			"engines": {
 				"node": ">= 16.4.0"
+			}
+		},
+		"node_modules/@electron-forge/cli/node_modules/commander": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+			"integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 6"
 			}
 		},
 		"node_modules/@electron-forge/cli/node_modules/fs-extra": {
@@ -7495,6 +7531,53 @@
 				"@xtuc/long": "4.2.2"
 			}
 		},
+		"node_modules/@webpack-cli/configtest": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-3.0.1.tgz",
+			"integrity": "sha512-u8d0pJ5YFgneF/GuvEiDA61Tf1VDomHHYMjv/wc9XzYj7nopltpG96nXN5dJRstxZhcNpV1g+nT6CydO7pHbjA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.12.0"
+			},
+			"peerDependencies": {
+				"webpack": "^5.82.0",
+				"webpack-cli": "6.x.x"
+			}
+		},
+		"node_modules/@webpack-cli/info": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-3.0.1.tgz",
+			"integrity": "sha512-coEmDzc2u/ffMvuW9aCjoRzNSPDl/XLuhPdlFRpT9tZHmJ/039az33CE7uH+8s0uL1j5ZNtfdv0HkfaKRBGJsQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.12.0"
+			},
+			"peerDependencies": {
+				"webpack": "^5.82.0",
+				"webpack-cli": "6.x.x"
+			}
+		},
+		"node_modules/@webpack-cli/serve": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-3.0.1.tgz",
+			"integrity": "sha512-sbgw03xQaCLiT6gcY/6u3qBDn01CWw/nbaXl3gTdTFuJJ75Gffv3E3DBpgvY2fkkrdS1fpjaXNOmJlnbtKauKg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.12.0"
+			},
+			"peerDependencies": {
+				"webpack": "^5.82.0",
+				"webpack-cli": "6.x.x"
+			},
+			"peerDependenciesMeta": {
+				"webpack-dev-server": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/@wordpress/a11y": {
 			"version": "4.7.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.7.0.tgz",
@@ -11741,12 +11824,12 @@
 			}
 		},
 		"node_modules/commander": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
-			"integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
-			"dev": true,
+			"version": "13.1.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+			"integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+			"license": "MIT",
 			"engines": {
-				"node": ">= 6"
+				"node": ">=18"
 			}
 		},
 		"node_modules/compare-version": {
@@ -13650,6 +13733,19 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/envinfo": {
+			"version": "7.14.0",
+			"resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.14.0.tgz",
+			"integrity": "sha512-CO40UI41xDQzhLB1hWyqUKgFhs250pNcGbyGKe1l/e4FSaI/+YE4IMG76GDt0In67WLPACIITC+sOi08x4wIvg==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"envinfo": "dist/cli.js"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/equivalent-key-map": {
 			"version": "0.2.2",
 			"resolved": "https://registry.npmjs.org/equivalent-key-map/-/equivalent-key-map-0.2.2.tgz",
@@ -14787,6 +14883,16 @@
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
 			"integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
 			"dev": true
+		},
+		"node_modules/fastest-levenshtein": {
+			"version": "1.0.16",
+			"resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
+			"integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4.9.1"
+			}
 		},
 		"node_modules/fastq": {
 			"version": "1.16.0",
@@ -19168,6 +19274,15 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/lockfile": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.4.tgz",
+			"integrity": "sha512-cvbTwETRfsFh4nHsL1eGWapU1XFi5Ot9E85sWAwia7Y7EgB7vfqcZhTKZ+l7hCGxSPoushMv5GKhT5PdLv03WA==",
+			"license": "ISC",
+			"dependencies": {
+				"signal-exit": "^3.0.2"
 			}
 		},
 		"node_modules/lodash": {
@@ -24719,6 +24834,16 @@
 				"balanced-match": "^1.0.0"
 			}
 		},
+		"node_modules/sucrase/node_modules/commander": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+			"integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 6"
+			}
+		},
 		"node_modules/sucrase/node_modules/glob": {
 			"version": "10.3.10",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz",
@@ -26457,6 +26582,74 @@
 				"webpack-cli": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/webpack-cli": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-6.0.1.tgz",
+			"integrity": "sha512-MfwFQ6SfwinsUVi0rNJm7rHZ31GyTcpVE5pgVA3hwFRb7COD4TzjUUwhGWKfO50+xdc2MQPuEBBJoqIMGt3JDw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@discoveryjs/json-ext": "^0.6.1",
+				"@webpack-cli/configtest": "^3.0.1",
+				"@webpack-cli/info": "^3.0.1",
+				"@webpack-cli/serve": "^3.0.1",
+				"colorette": "^2.0.14",
+				"commander": "^12.1.0",
+				"cross-spawn": "^7.0.3",
+				"envinfo": "^7.14.0",
+				"fastest-levenshtein": "^1.0.12",
+				"import-local": "^3.0.2",
+				"interpret": "^3.1.1",
+				"rechoir": "^0.8.0",
+				"webpack-merge": "^6.0.1"
+			},
+			"bin": {
+				"webpack-cli": "bin/cli.js"
+			},
+			"engines": {
+				"node": ">=18.12.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/webpack"
+			},
+			"peerDependencies": {
+				"webpack": "^5.82.0"
+			},
+			"peerDependenciesMeta": {
+				"webpack-bundle-analyzer": {
+					"optional": true
+				},
+				"webpack-dev-server": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/webpack-cli/node_modules/commander": {
+			"version": "12.1.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+			"integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/webpack-cli/node_modules/webpack-merge": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-6.0.1.tgz",
+			"integrity": "sha512-hXXvrjtx2PLYx4qruKl+kyRSLc52V+cCvMxRjmKwoA+CBbbF5GfIBtR6kCvl0fYGqTUPKB+1ktVmTHqMOzgCBg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"clone-deep": "^4.0.1",
+				"flat": "^5.0.2",
+				"wildcard": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=18.0.0"
 			}
 		},
 		"node_modules/webpack-dev-middleware": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
 		"test": "cross-env NODE_OPTIONS='--no-deprecation' jest",
 		"test:watch": "cross-env NODE_OPTIONS='--no-deprecation' jest --watch",
 		"e2e": "npx playwright install && npx playwright test",
-		"make-pot": "wp-babel-makepot \"./src/**/*.{js,jsx,ts,tsx}\" --ignore \"**/*.d.ts\" --base \"./src\" --dir \"./out/pots\" --output \"./out/pots/bundle-strings.pot\""
+		"make-pot": "wp-babel-makepot \"./src/**/*.{js,jsx,ts,tsx}\" --ignore \"**/*.d.ts\" --base \"./src\" --dir \"./out/pots\" --output \"./out/pots/bundle-strings.pot\"",
+		"build:cli": "webpack --config webpack.cli.config.ts"
 	},
 	"devDependencies": {
 		"@automattic/color-studio": "^2.5.0",
@@ -101,6 +102,7 @@
 		"ts-node": "^10.0.0",
 		"typescript": "~5.3.2",
 		"web-streams-polyfill": "^4.0.0",
+		"webpack-cli": "^6.0.1",
 		"webpack-dev-middleware": "5.3.4"
 	},
 	"dependencies": {
@@ -121,6 +123,7 @@
 		"@wp-playground/wordpress": "https://wpcomplaygroundpackages.wpcomstaging.com/packages/v1.0.27/@wp-playground-wordpress-1.0.27.tar.gz",
 		"archiver": "^6.0.1",
 		"atomically": "^2.0.3",
+		"commander": "^13.1.0",
 		"compressible": "2.0.18",
 		"compression": "1.7.4",
 		"cross-port-killer": "^1.4.0",
@@ -133,6 +136,7 @@
 		"fs-extra": "11.1.1",
 		"hpagent": "1.2.0",
 		"http-proxy": "^1.18.1",
+		"lockfile": "^1.0.4",
 		"node-fetch": "^2.7.0",
 		"react-markdown": "^9.0.1",
 		"react-redux": "^9.2.0",

--- a/src/commands/base.ts
+++ b/src/commands/base.ts
@@ -1,0 +1,51 @@
+import { spawn, ChildProcess } from 'child_process';
+import eventEmitter from 'events';
+
+export abstract class BaseCommand extends eventEmitter {
+	protected abstract onError( error: null | string ): void;
+	protected abstract onOutput( output: string ): void;
+	protected abstract onSuccess(): void;
+	protected abstract run(): void;
+
+	protected parseOutput( data: Buffer ): string | null {
+		try {
+			const output = data.toString();
+			const json = JSON.parse( output );
+			return json.output;
+		} catch ( error ) {
+			return null;
+		}
+	}
+
+	protected runCommand( args: string[] ): ChildProcess {
+		const process = spawn( 'studio', [ ...args, '--output-format', 'json' ] );
+
+		process.stdout.on( 'data', ( data: Buffer ) => {
+			const output = this.parseOutput( data );
+			if ( output ) {
+				this.onOutput( output );
+			}
+		} );
+
+		process.stderr.on( 'data', ( data: Buffer ) => {
+			const error = this.parseOutput( data );
+			if ( error ) {
+				this.onError( error );
+			}
+		} );
+
+		process.on( 'error', ( error: Error ) => {
+			this.onError( error.message );
+		} );
+
+		process.on( 'close', ( code: number | null ) => {
+			if ( code === 0 ) {
+				this.onSuccess();
+			} else {
+				this.onError( null );
+			}
+		} );
+
+		return process;
+	}
+}

--- a/src/commands/preview.ts
+++ b/src/commands/preview.ts
@@ -1,0 +1,26 @@
+import { BaseCommand } from './base';
+
+export class PreviewCommand extends BaseCommand {
+	private siteFolder: string;
+
+	constructor( siteFolder: string ) {
+		super();
+		this.siteFolder = siteFolder;
+	}
+
+	public run(): void {
+		this.runCommand( [ 'go', this.siteFolder ] );
+	}
+
+	protected onError( error: null | string ): void {
+		this.emit( 'error', error );
+	}
+
+	protected onOutput( output: string ): void {
+		this.emit( 'output', output );
+	}
+
+	protected onSuccess(): void {
+		this.emit( 'success' );
+	}
+}

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -17,6 +17,7 @@ import nodePath from 'path';
 import * as Sentry from '@sentry/electron/main';
 import { __, LocaleData, defaultI18n } from '@wordpress/i18n';
 import archiver from 'archiver';
+import { PreviewCommand } from 'src/commands/preview';
 import { ARCHIVER_OPTIONS, MAIN_MIN_WIDTH, SIDEBAR_WIDTH } from 'src/constants';
 import { sendIpcEventToRendererWithWindow } from 'src/ipc-utils';
 import { ACTIVE_SYNC_OPERATIONS } from 'src/lib/active-sync-operations';
@@ -1195,4 +1196,36 @@ export async function checkSyncBackupSize(
 export async function isFullscreen( _event: IpcMainInvokeEvent ): Promise< boolean > {
 	const window = await getMainWindow();
 	return window.isFullScreen();
+}
+
+export async function createPreviewSite(
+	event: IpcMainInvokeEvent,
+	site: SiteDetails
+): Promise< void > {
+	const parentWindow = BrowserWindow.fromWebContents( event.sender );
+	const previewCommand = new PreviewCommand( site.path );
+
+	previewCommand.on( 'error', ( error: string | null ) => {
+		if ( error ) {
+			sendIpcEventToRendererWithWindow( parentWindow, 'preview-error', {
+				siteId: site.id,
+				error,
+			} );
+		}
+	} );
+
+	previewCommand.on( 'output', ( output: string ) => {
+		sendIpcEventToRendererWithWindow( parentWindow, 'preview-output', {
+			siteId: site.id,
+			output,
+		} );
+	} );
+
+	previewCommand.on( 'success', () => {
+		sendIpcEventToRendererWithWindow( parentWindow, 'preview-success', {
+			siteId: site.id,
+		} );
+	} );
+
+	previewCommand.run();
 }

--- a/src/ipc-utils.ts
+++ b/src/ipc-utils.ts
@@ -8,6 +8,9 @@ export interface IpcEvents {
 	'auth-updated': [ { token: StoredToken } | { error: unknown } ];
 	'on-export': [ ImportExportEventData, string ];
 	'on-import': [ ImportExportEventData, string ];
+	'preview-error': [ { siteId: string; error: string } ];
+	'preview-output': [ { siteId: string; output: string } ];
+	'preview-success': [ { siteId: string } ];
 	'sync-connect-site': [ { remoteSiteId: number; studioSiteId: string } ];
 	'test-render-failure': [ void ];
 	'theme-details-changed': [ { id: string; details: StartedSiteDetails[ 'themeDetails' ] } ];

--- a/src/stores/preview-slice.ts
+++ b/src/stores/preview-slice.ts
@@ -1,0 +1,92 @@
+import { createSlice, createAsyncThunk, PayloadAction } from '@reduxjs/toolkit';
+import { getIpcApi } from 'src/lib/get-ipc-api';
+
+export const createPreviewSite = createAsyncThunk(
+	'preview/createPreviewSite',
+	async ( site: SiteDetails, { rejectWithValue } ) => {
+		try {
+			await getIpcApi().createPreviewSite( site );
+		} catch ( error ) {
+			return rejectWithValue(
+				error instanceof Error ? error.message : 'Failed to create preview site'
+			);
+		}
+	}
+);
+
+window.ipcListener.subscribe( 'preview-output', ( _evt, { siteId, output } ) => {
+	previewSlice.actions.previewSiteProgress( { siteId, output } );
+} );
+
+window.ipcListener.subscribe( 'preview-success', ( _evt, { siteId } ) => {
+	previewSlice.actions.previewSiteSuccess( { siteId } );
+} );
+
+window.ipcListener.subscribe( 'preview-error', ( _evt, { siteId, error } ) => {
+	previewSlice.actions.previewSiteError( { siteId, error } );
+} );
+
+type PreviewSite = {
+	id: string;
+	status: 'creating' | 'ready' | 'error';
+};
+
+type PreviewSitesState = {
+	sites: PreviewSite[];
+};
+
+const initialState: PreviewSitesState = {
+	sites: [],
+};
+
+const previewSlice = createSlice( {
+	name: 'preview',
+	initialState,
+	reducers: {
+		previewSiteSuccess: ( state, action: PayloadAction< { siteId: PreviewSite[ 'id' ] } > ) => {
+			for ( const site of state.sites ) {
+				if ( site.id === action.payload.siteId ) {
+					site.status = 'ready';
+				}
+			}
+		},
+		previewSiteProgress: (
+			state,
+			action: PayloadAction< { siteId: PreviewSite[ 'id' ]; output: string } >
+		) => {
+			for ( const site of state.sites ) {
+				if ( site.id === action.payload.siteId ) {
+					site.status = 'creating';
+				}
+			}
+		},
+		previewSiteError: (
+			state,
+			action: PayloadAction< { siteId: PreviewSite[ 'id' ]; error: string } >
+		) => {
+			for ( const site of state.sites ) {
+				if ( site.id === action.payload.siteId ) {
+					site.status = 'error';
+				}
+			}
+		},
+	},
+	extraReducers: ( builder ) => {
+		builder
+			.addCase( createPreviewSite.pending, ( state, action ) => {
+				state.sites.push( {
+					id: action.meta.arg.id,
+					status: 'creating',
+				} );
+			} )
+			.addCase( createPreviewSite.rejected, ( state, action ) => {
+				for ( const site of state.sites ) {
+					if ( site.id === action.meta.arg.id ) {
+						site.status = 'error';
+					}
+				}
+			} );
+	},
+} );
+
+export default previewSlice.reducer;

--- a/webpack.cli.config.ts
+++ b/webpack.cli.config.ts
@@ -1,0 +1,28 @@
+import path from 'path';
+import { type Configuration } from 'webpack';
+import { rules } from './webpack.rules';
+
+const config: Configuration = {
+	target: 'node',
+	entry: './cli/index.ts',
+	output: {
+		filename: 'studio-cli.js',
+		path: path.resolve( __dirname, 'dist/cli' ),
+	},
+	mode: 'production',
+	devtool: 'source-map',
+	module: {
+		rules,
+	},
+	resolve: {
+		extensions: [ '.js', '.ts', '.json' ],
+		alias: {
+			src: path.resolve( __dirname, 'src/' ),
+		},
+	},
+	optimization: {
+		minimize: false, // Better for Node.js CLI tools
+	},
+};
+
+export default config; 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Proposed Changes

🚨 **THIS IS A DRAFT.** PLEASE DO NOT ENGAGE IN DISCUSSION HERE BEFORE TALKING TO ME ON SLACK. 🚨

- Adds a `cli` folder at the repo root with code that builds to a single JS file to be executed by node.
- Adds a Webpack config for that folder.
- Adds an optional `output-format` option to make the CLI output JSON-formatted.
- Implements a simple lockfile mechanism for the CLI.
- Adds logic for creating preview sites in the CLI.
- Adds a `studio go` command for triggering that logic.
- Adds an IPC back-end handler for triggering preview site creation from Studio.
- Adds IPC events to communicate preview site creation status to Studio front-end.
- Adds a Redux slice where preview site state can be stored in Studio front-end.

