### PR TITLE
Add/refactor settings tab layout

### DIFF
--- a/e2e/page-objects/settings-tab.ts
+++ b/e2e/page-objects/settings-tab.ts
@@ -23,7 +23,13 @@ export default class SettingsTab {
 	}
 
 	get deleteButton() {
-		return this.locator.getByRole( 'button', { name: 'Delete site' } );
+		// The delete button is a menu item rendered at the root level of the document,
+		// so we need to search for it using page.locator instead of locator.locator.
+		return this.page.getByRole( 'menuitem', { name: 'Delete site' } );
+	}
+
+	get optionsMenu() {
+		return this.locator.getByRole( 'button', { name: 'More options' } );
 	}
 
 	async copyWPAdminUrlToClipboard( electronApp: ElectronApplication ) {
@@ -37,6 +43,7 @@ export default class SettingsTab {
 	}
 
 	async openDeleteSiteModal() {
+		await this.optionsMenu.click();
 		await this.deleteButton.click();
 	}
 }

--- a/src/components/content-tab-settings.tsx
+++ b/src/components/content-tab-settings.tsx
@@ -36,7 +36,9 @@ export function ContentTabSettings( { selectedSite }: ContentTabSettingsProps ) 
 	return (
 		<div className="p-8">
 			<div className="flex justify-between items-center mb-4">
-				<h3 className="text-black text-sm font-semibold">{ __( 'Site details' ) }</h3>
+				<h3 role="heading" className="text-black text-sm font-semibold">
+					{ __( 'Site details' ) }
+				</h3>
 				<div className="flex items-center">
 					<EditSiteDetails currentWpVersion={ wpVersion } onSave={ refreshWpVersion } />
 					<DropdownMenu

--- a/src/components/content-tab-settings.tsx
+++ b/src/components/content-tab-settings.tsx
@@ -1,3 +1,5 @@
+import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
+import { moreVertical } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { PropsWithChildren } from 'react';
 import { CopyTextButton } from 'src/components/copy-text-button';
@@ -35,7 +37,31 @@ export function ContentTabSettings( { selectedSite }: ContentTabSettingsProps ) 
 		<div className="p-8">
 			<div className="flex justify-between items-center mb-4">
 				<h3 className="text-black text-sm font-semibold">{ __( 'Site details' ) }</h3>
-				<EditSiteDetails currentWpVersion={ wpVersion } onSave={ refreshWpVersion } />
+				<div className="flex items-center">
+					<EditSiteDetails currentWpVersion={ wpVersion } onSave={ refreshWpVersion } />
+					<DropdownMenu
+						icon={ moreVertical }
+						label={ __( 'More options' ) }
+						className="p-1 flex items-center"
+					>
+						{ ( { onClose }: { onClose: () => void } ) => (
+							<MenuGroup>
+								<MenuItem
+									onClick={ () => {
+										onClose();
+										const deleteButton = document.querySelector( '[data-wp-c16t="true"]' );
+										if ( deleteButton instanceof HTMLElement ) {
+											deleteButton.click();
+										}
+									} }
+									isDestructive
+								>
+									{ __( 'Delete site' ) }
+								</MenuItem>
+							</MenuGroup>
+						) }
+					</DropdownMenu>
+				</div>
 			</div>
 			<table className="mb-2 m-w-full" cellPadding={ 0 } cellSpacing={ 0 }>
 				<tbody>

--- a/src/components/content-tab-settings.tsx
+++ b/src/components/content-tab-settings.tsx
@@ -1,4 +1,4 @@
-import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
+import { DropdownMenu, MenuGroup } from '@wordpress/components';
 import { moreVertical } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { PropsWithChildren } from 'react';
@@ -46,18 +46,7 @@ export function ContentTabSettings( { selectedSite }: ContentTabSettingsProps ) 
 					>
 						{ ( { onClose }: { onClose: () => void } ) => (
 							<MenuGroup>
-								<MenuItem
-									onClick={ () => {
-										onClose();
-										const deleteButton = document.querySelector( '[data-wp-c16t="true"]' );
-										if ( deleteButton instanceof HTMLElement ) {
-											deleteButton.click();
-										}
-									} }
-									isDestructive
-								>
-									{ __( 'Delete site' ) }
-								</MenuItem>
+								<DeleteSite onClose={ onClose } />
 							</MenuGroup>
 						) }
 					</DropdownMenu>
@@ -129,7 +118,6 @@ export function ContentTabSettings( { selectedSite }: ContentTabSettingsProps ) 
 					</SettingsRow>
 				</tbody>
 			</table>
-			<DeleteSite />
 		</div>
 	);
 }

--- a/src/components/content-tab-settings.tsx
+++ b/src/components/content-tab-settings.tsx
@@ -34,7 +34,7 @@ export function ContentTabSettings( { selectedSite }: ContentTabSettingsProps ) 
 		? `${ selectedSite.customDomain }`
 		: `localhost:${ selectedSite.port }`;
 	return (
-		<div className="p-8">
+		<div className="p-8 pr-0">
 			<div className="flex justify-between items-center mb-4">
 				<h3 role="heading" className="text-black text-sm font-semibold">
 					{ __( 'Site details' ) }

--- a/src/components/content-tab-settings.tsx
+++ b/src/components/content-tab-settings.tsx
@@ -33,16 +33,12 @@ export function ContentTabSettings( { selectedSite }: ContentTabSettingsProps ) 
 		: `localhost:${ selectedSite.port }`;
 	return (
 		<div className="p-8">
+			<div className="flex justify-between items-center mb-4">
+				<h3 className="text-black text-sm font-semibold">{ __( 'Site details' ) }</h3>
+				<EditSiteDetails currentWpVersion={ wpVersion } onSave={ refreshWpVersion } />
+			</div>
 			<table className="mb-2 m-w-full" cellPadding={ 0 } cellSpacing={ 0 }>
 				<tbody>
-					<tr>
-						<th colSpan={ 2 } className="pb-4 ltr:text-left rtl:text-right">
-							<h3 className="text-black text-sm font-semibold">
-								{ __( 'Site details' ) }
-								<EditSiteDetails currentWpVersion={ wpVersion } onSave={ refreshWpVersion } />
-							</h3>
-						</th>
-					</tr>
 					<SettingsRow label={ __( 'Site name' ) }>
 						<div className="flex">
 							<span className="line-clamp-1 break-all">{ selectedSite.name }</span>

--- a/src/components/delete-site.tsx
+++ b/src/components/delete-site.tsx
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/electron/renderer';
+import { MenuItem } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
-import Button from 'src/components/button';
 import offlineIcon from 'src/components/offline-icon';
 import { Tooltip } from 'src/components/tooltip';
 import { useOffline } from 'src/hooks/use-offline';
@@ -11,10 +11,14 @@ import { getIpcApi } from 'src/lib/get-ipc-api';
 
 const MAX_LENGTH_SITE_TITLE = 35;
 
-const DeleteSite = () => {
+type DeleteSiteProps = {
+	onClose: () => void;
+};
+
+const DeleteSite = ( { onClose }: DeleteSiteProps ) => {
 	const { __ } = useI18n();
 	const { selectedSite, deleteSite, isDeleting } = useSiteDetails();
-	const isOffline = useOffline();
+	const isOffline = true; // useOffline();
 
 	const offlineMessage = __(
 		'This site has active preview sites that cannot be deleted without an internet connection.'
@@ -77,21 +81,21 @@ const DeleteSite = () => {
 			disabled={ ! ( isOffline && snapshotsOnSite.length > 0 ) }
 			icon={ offlineIcon }
 			text={ offlineMessage }
+			placement="top-start"
 		>
-			<Button
-				aria-description={ isOffline && snapshotsOnSite.length > 0 ? offlineMessage : '' }
-				aria-disabled={ isSiteDeletionDisabled }
+			<MenuItem
 				onClick={ () => {
 					if ( isSiteDeletionDisabled ) {
 						return;
 					}
+					onClose();
 					handleDeleteSite();
 				} }
-				variant="link"
 				isDestructive
+				disabled={ isSiteDeletionDisabled }
 			>
 				{ __( 'Delete site' ) }
-			</Button>
+			</MenuItem>
 		</Tooltip>
 	);
 };

--- a/src/components/delete-site.tsx
+++ b/src/components/delete-site.tsx
@@ -81,7 +81,7 @@ const DeleteSite = ( { onClose }: DeleteSiteProps ) => {
 			disabled={ ! ( isOffline && snapshotsOnSite.length > 0 ) }
 			icon={ offlineIcon }
 			text={ offlineMessage }
-			placement="top-start"
+			placement="left"
 		>
 			<MenuItem
 				aria-disabled={ isSiteDeletionDisabled }

--- a/src/components/delete-site.tsx
+++ b/src/components/delete-site.tsx
@@ -84,6 +84,8 @@ const DeleteSite = ( { onClose }: DeleteSiteProps ) => {
 			placement="top-start"
 		>
 			<MenuItem
+				aria-disabled={ isSiteDeletionDisabled }
+				aria-description={ isOffline && snapshotsOnSite.length > 0 ? offlineMessage : '' }
 				onClick={ () => {
 					if ( isSiteDeletionDisabled ) {
 						return;

--- a/src/components/delete-site.tsx
+++ b/src/components/delete-site.tsx
@@ -18,7 +18,7 @@ type DeleteSiteProps = {
 const DeleteSite = ( { onClose }: DeleteSiteProps ) => {
 	const { __ } = useI18n();
 	const { selectedSite, deleteSite, isDeleting } = useSiteDetails();
-	const isOffline = true; // useOffline();
+	const isOffline = useOffline();
 
 	const offlineMessage = __(
 		'This site has active preview sites that cannot be deleted without an internet connection.'

--- a/src/components/tests/content-tab-settings.test.tsx
+++ b/src/components/tests/content-tab-settings.test.tsx
@@ -65,7 +65,7 @@ describe( 'ContentTabSettings', () => {
 	test( 'renders site details correctly', () => {
 		renderWithProvider( <ContentTabSettings selectedSite={ selectedSite } /> );
 
-		expect( screen.getByRole( 'heading', { name: 'Site details Edit' } ) ).toBeVisible();
+		expect( screen.getByRole( 'heading', { name: 'Site details' } ) ).toBeVisible();
 		expect( screen.getByText( 'Test Site' ) ).toBeVisible();
 		expect(
 			screen.getByRole( 'button', { name: 'localhost:8881, Copy site url to clipboard' } )
@@ -143,7 +143,9 @@ describe( 'ContentTabSettings', () => {
 			isDeleting: false,
 		} );
 		renderWithProvider( <ContentTabSettings selectedSite={ selectedSite } /> );
-		const deleteSiteButton = await screen.findByRole( 'button', { name: 'Delete site' } );
+		const dropdownButton = screen.getByRole( 'button', { name: 'More options' } );
+		await userEvent.click( dropdownButton );
+		const deleteSiteButton = screen.getByRole( 'menuitem', { name: 'Delete site' } );
 		expect( deleteSiteButton ).toHaveAttribute( 'aria-disabled', 'true' );
 		fireEvent.mouseOver( deleteSiteButton );
 		expect(

--- a/src/modules/site-settings/edit-site-details.tsx
+++ b/src/modules/site-settings/edit-site-details.tsx
@@ -226,7 +226,7 @@ export default function EditSiteDetails( { currentWpVersion, onSave }: EditSiteD
 			) }
 			<Button
 				disabled={ ! selectedSite }
-				className="!mx-4 shrink-0"
+				className="shrink-0"
 				onClick={ () => {
 					setShowModal( true );
 					resetFormState();

--- a/src/modules/site-settings/edit-site-details.tsx
+++ b/src/modules/site-settings/edit-site-details.tsx
@@ -232,9 +232,9 @@ export default function EditSiteDetails( { currentWpVersion, onSave }: EditSiteD
 					resetFormState();
 				} }
 				label={ __( 'Edit site' ) }
-				variant="link"
+				variant="secondary"
 			>
-				{ __( 'Edit' ) }
+				{ __( 'Edit site' ) }
 			</Button>
 		</>
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/dotcom-forge/issues/10618

## Proposed Changes

- Moved "Edit" button to the right side and adjust its layout
- Create a new dropdown menu
- Moved the "Delete site" button into a dropdown menu in the site details section
- Updated the `DeleteSite` component to work as a menu item
- Updated tests to reflect the new dropdown menu

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Open the site settings tab
- Verify the "More options" dropdown menu is present in the top right
- Click the dropdown menu to open it
- Verify the "Delete site" option is present in the dropdown
- Test the delete functionality:
  - When offline with preview sites: Delete should be disabled with appropriate tooltip
  - When online or no preview sites: Delete should be enabled
- Verify the Edit site button styling is consistent with the design
- Run `npm run test` to ensure all tests pass

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
