### PR TITLE
Improve formatting of the latest version and add it to edit site form

### DIFF
--- a/src/modules/site-settings/edit-site-details.tsx
+++ b/src/modules/site-settings/edit-site-details.tsx
@@ -45,7 +45,9 @@ export default function EditSiteDetails( { currentWpVersion, onSave }: EditSiteD
 		( selectedSite?.phpVersion as AllowedPHPVersion ) ?? DEFAULT_PHP_VERSION
 	);
 	const [ selectedWpVersion, setSelectedWpVersion ] = useState( currentWpVersion );
-	const wordpressVersions = useRootSelector( wordpressVersionsSelectors.selectWordPressVersions );
+	const wordpressVersions = useRootSelector(
+		wordpressVersionsSelectors.selectWordPressVersionsWithLatest
+	);
 	const wordpressVersionOptions = wordpressVersions.map( ( version ) => ( {
 		label: version.label,
 		value: version.value,

--- a/src/stores/tests/wordpress-versions-slice.test.ts
+++ b/src/stores/tests/wordpress-versions-slice.test.ts
@@ -298,8 +298,7 @@ describe( 'wordpress-versions-slice', () => {
 			const versions = wordpressVersionsSelectors.selectWordPressVersionsWithLatest( state );
 
 			expect( versions ).toEqual( [
-				{ value: 'latest', isBeta: false, label: 'Latest' },
-				{ value: '6.1.0', isBeta: false, label: '6.1' },
+				{ value: '6.1.0', isBeta: false, label: '6.1 (latest)' },
 				{ value: '6.2.0', isBeta: false, label: '6.2' },
 				{ value: '6.3.0', isBeta: false, label: '6.3' },
 				{ value: '6.4.0', isBeta: false, label: '6.4' },

--- a/src/stores/wordpress-versions-slice.ts
+++ b/src/stores/wordpress-versions-slice.ts
@@ -111,14 +111,21 @@ const wordpressVersionsSlice = createSlice( {
 	},
 	selectors: {
 		selectWordPressVersions: ( state ) => state.versions,
-		selectWordPressVersionsWithLatest: ( state ) => [
-			{
-				isBeta: false,
-				label: __( 'Latest' ),
-				value: 'latest',
-			},
-			...state.versions,
-		],
+		selectWordPressVersionsWithLatest: ( state ) => {
+			const latestNonBeta = state.versions.find( ( version ) => ! version.isBeta );
+			const otherVersions = state.versions.filter( ( version ) => version !== latestNonBeta );
+			if ( ! latestNonBeta ) {
+				return otherVersions;
+			}
+			return [
+				{
+					isBeta: false,
+					label: `${ latestNonBeta.label } (${ __( 'latest' ) })`,
+					value: latestNonBeta.value,
+				},
+				...otherVersions,
+			];
+		},
 	},
 } );
 

--- a/src/stores/wordpress-versions-slice.ts
+++ b/src/stores/wordpress-versions-slice.ts
@@ -113,10 +113,10 @@ const wordpressVersionsSlice = createSlice( {
 		selectWordPressVersions: ( state ) => state.versions,
 		selectWordPressVersionsWithLatest: ( state ) => {
 			const latestNonBeta = state.versions.find( ( version ) => ! version.isBeta );
-			const otherVersions = state.versions.filter( ( version ) => version !== latestNonBeta );
 			if ( ! latestNonBeta ) {
-				return otherVersions;
+				return state.versions;
 			}
+			const otherVersions = state.versions.filter( ( version ) => version !== latestNonBeta );
 			return [
 				{
 					isBeta: false,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/dotcom-forge/issues/10601

## Proposed Changes

- Removes hardcoded "Latest" WordPress version option
- Implements dynamic "Latest" version based on most recent non-beta version
- Updates WordPress versions selector to use the new dynamic latest version approach

Example on Add Site form:
![image](https://github.com/user-attachments/assets/f3b2c2a6-53fc-4fff-824b-0e31145a0634)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- For Onboarding, Add Site and Edit Site workflows check that the wordpress version selector has the options according to the changes mentioned above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
