### PR TITLE
Use grid layout for connected sites list in Sync tab

### DIFF
--- a/src/components/sync-connected-sites.tsx
+++ b/src/components/sync-connected-sites.tsx
@@ -203,7 +203,7 @@ const SyncConnectedSitesList = ( { selectedSite }: SyncConnectedSitesListProps )
 	const { isKeyPulling, isKeyPushing, isKeyFinished, isKeyFailed } = useSyncStatesProgressInfo();
 
 	return (
-		<div className="grid grid-cols-[fit-content_1fr_fit-content]">
+		<div className="grid grid-cols-[max-content_1fr_max-content]">
 			{ connectedSites.map( ( connectedSite ) => {
 				const sitePullState = getPullState( selectedSite.id, connectedSite.id );
 				const isPulling = sitePullState && isKeyPulling( sitePullState.status.key );

--- a/src/components/sync-connected-sites.tsx
+++ b/src/components/sync-connected-sites.tsx
@@ -213,7 +213,7 @@ const SyncConnectedSitesSection = ( {
 							key={ connectedSite.id }
 							className="flex items-center gap-2 min-h-14 border-b border-a8c-gray-0 px-8"
 						>
-							<div className="flex items-left min-w-20 me-6 shrink-0">
+							<div className="flex items-left min-w-[100px] me-4 shrink-0">
 								{ connectedSite.isStaging ? (
 									<Badge>{ __( 'Staging' ) }</Badge>
 								) : (
@@ -222,7 +222,7 @@ const SyncConnectedSitesSection = ( {
 							</div>
 							<Button
 								variant="link"
-								className="!text-a8c-gray-70 hover:!text-a8c-blueberry max-w-[100%]"
+								className="!text-a8c-gray-70 hover:!text-a8c-blueberry max-w-full overflow-hidden"
 								onClick={ () => {
 									getIpcApi().openURL( connectedSite.url );
 								} }

--- a/src/components/sync-connected-sites.tsx
+++ b/src/components/sync-connected-sites.tsx
@@ -30,35 +30,25 @@ interface ConnectedSiteSection {
 	connectedSites: SyncSite[];
 }
 
-const SyncConnectedSitesSection = ( {
-	section,
-	disconnectSite,
+const SyncConnectedSiteControls = ( {
+	connectedSite,
 	selectedSite,
-	openSitesSyncSelector,
 }: {
-	section: ConnectedSiteSection;
-	disconnectSite: ( id: number ) => void;
+	connectedSite: SyncSite;
 	selectedSite: SiteDetails;
-	openSitesSyncSelector: OpenSitesSyncSelector;
 } ) => {
 	const { __ } = useI18n();
-	const getDocsLink = useDocsLink();
+	const isOffline = useOffline();
 	const {
 		pullSite,
-		clearPullState,
-		getPullState,
 		isAnySitePulling,
 		isAnySitePushing,
 		pushSite,
-		getPushState,
-		clearPushState,
 		isSiteIdPulling,
 		isSiteIdPushing,
 		getLastSyncTimeText,
 		connectedSites,
 	} = useSyncSites();
-	const { isKeyPulling, isKeyPushing, isKeyFinished, isKeyFailed } = useSyncStatesProgressInfo();
-	const isOffline = useOffline();
 	const isAnyConnectedSiteSyncing = connectedSites.some(
 		( site ) =>
 			isSiteIdPulling( selectedSite.id, site.id ) || isSiteIdPushing( selectedSite.id, site.id )
@@ -86,6 +76,246 @@ const SyncConnectedSitesSection = ( {
 		message: __( 'Overwrite Studio site' ),
 		confirmButtonLabel: __( 'Pull' ),
 	} );
+	const handlePushSite = async ( connectedSite: SyncSite ) => {
+		if ( connectedSite.isStaging ) {
+			showPushStagingConfirmation( () => {
+				pushSite( connectedSite, selectedSite );
+			} );
+		} else {
+			showPushProductionConfirmation( () => {
+				pushSite( connectedSite, selectedSite );
+			} );
+		}
+	};
+
+	return (
+		<Tooltip
+			disabled={ ! isOffline }
+			icon={ offlineIcon }
+			text={ __( 'Pulling or pushing a site requires an internet connection.' ) }
+			placement="top-start"
+		>
+			<div className="flex gap-2 whitespace-nowrap h-5">
+				{ isAnySiteSyncing ? (
+					<Tooltip
+						text={
+							isAnyConnectedSiteSyncing
+								? __(
+										'This Studio site is syncing. Please wait for the sync to finish before you pull it.'
+								  )
+								: __(
+										'Another Studio site is syncing. Please wait for the sync to finish before you pull this site.'
+								  )
+						}
+						placement="top-start"
+					>
+						<Button variant="link" disabled={ true }>
+							<Icon icon={ cloudDownload } />
+							{ __( 'Pull' ) }
+						</Button>
+					</Tooltip>
+				) : (
+					<DynamicTooltip
+						getTooltipText={ () => getLastSyncTimeText( connectedSite.lastPullTimestamp, 'pull' ) }
+						placement="top-start"
+						disabled={ isOffline }
+					>
+						<Button
+							variant="link"
+							className={ cx(
+								! isOffline &&
+									! isAnySitePulling &&
+									! isAnySitePushing &&
+									'!text-black hover:!text-a8c-blueberry'
+							) }
+							onClick={ () => {
+								const detail = connectedSite.isStaging
+									? __(
+											"Pulling will replace your Studio site's files and database with a copy from your staging site."
+									  )
+									: __(
+											"Pulling will replace your Studio site's files and database with a copy from your production site."
+									  );
+								showPullConfirmation( () => pullSite( connectedSite, selectedSite ), {
+									detail,
+								} );
+							} }
+							disabled={ isAnySiteSyncing || isOffline }
+						>
+							<Icon icon={ cloudDownload } />
+							{ __( 'Pull' ) }
+						</Button>
+					</DynamicTooltip>
+				) }
+				{ isAnySiteSyncing ? (
+					<Tooltip
+						text={
+							isAnyConnectedSiteSyncing
+								? __(
+										'This Studio site is syncing. Please wait for the sync to finish before you push it.'
+								  )
+								: __(
+										'Another Studio site is syncing. Please wait for the sync to finish before you push this site.'
+								  )
+						}
+						placement="top-start"
+					>
+						<Button variant="link" disabled={ true }>
+							<Icon icon={ cloudUpload } />
+							{ __( 'Push' ) }
+						</Button>
+					</Tooltip>
+				) : (
+					<DynamicTooltip
+						getTooltipText={ () => getLastSyncTimeText( connectedSite.lastPushTimestamp, 'push' ) }
+						placement="top-start"
+						disabled={ isOffline }
+					>
+						<Button
+							variant="link"
+							className={ cx(
+								! isOffline &&
+									! isAnySitePulling &&
+									! isAnySitePushing &&
+									'!text-black hover:!text-a8c-blueberry'
+							) }
+							onClick={ () => handlePushSite( connectedSite ) }
+							disabled={ isAnySiteSyncing || isOffline }
+						>
+							<Icon icon={ cloudUpload } />
+							{ __( 'Push' ) }
+						</Button>
+					</DynamicTooltip>
+				) }
+			</div>
+		</Tooltip>
+	);
+};
+
+type SyncConnectedSitesListProps = {
+	selectedSite: SiteDetails;
+};
+
+const SyncConnectedSitesList = ( { selectedSite }: SyncConnectedSitesListProps ) => {
+	const { __ } = useI18n();
+	const { clearPullState, getPullState, getPushState, clearPushState, connectedSites } =
+		useSyncSites();
+	const { isKeyPulling, isKeyPushing, isKeyFinished, isKeyFailed } = useSyncStatesProgressInfo();
+
+	return (
+		<div className="grid grid-cols-[min-content_1fr_min-content]">
+			{ connectedSites.map( ( connectedSite ) => {
+				const sitePullState = getPullState( selectedSite.id, connectedSite.id );
+				const isPulling = sitePullState && isKeyPulling( sitePullState.status.key );
+				const isPullError = sitePullState && isKeyFailed( sitePullState.status.key );
+				const hasPullFinished = sitePullState && isKeyFinished( sitePullState.status.key );
+
+				const pushState = getPushState( selectedSite.id, connectedSite.id );
+				const isPushing = pushState && isKeyPushing( pushState.status.key );
+				const isPushError = pushState && isKeyFailed( pushState.status.key );
+				const hasPushFinished = pushState && isKeyFinished( pushState.status.key );
+
+				return (
+					<div
+						className="col-span-3 grid grid-cols-subgrid min-h-14 px-8 gap-4 justify-items-start items-center border-b border-a8c-gray-0"
+						key={ connectedSite.id }
+					>
+						<div className="shrink-0">
+							{ connectedSite.isStaging ? (
+								<Badge>{ __( 'Staging' ) }</Badge>
+							) : (
+								<Badge className="bg-a8c-green-5 text-a8c-green-80">{ __( 'Production' ) }</Badge>
+							) }
+						</div>
+						<Button
+							variant="link"
+							className="!text-a8c-gray-70 hover:!text-a8c-blueberry max-w-full overflow-hidden"
+							onClick={ () => {
+								getIpcApi().openURL( connectedSite.url );
+							} }
+						>
+							<span className="truncate">{ connectedSite.url }</span> <ArrowIcon />
+						</Button>
+						<div className="flex gap-2 ms-auto shrink-0">
+							{ isPulling && (
+								<div className="flex flex-col gap-2 min-w-44">
+									<div className="a8c-body-small">{ sitePullState.status.message }</div>
+									<ProgressBar value={ sitePullState.status.progress } maxValue={ 100 } />
+								</div>
+							) }
+							{ isPullError && (
+								<SyncPullPushClear
+									onClick={ () => clearPullState( selectedSite.id, connectedSite.id ) }
+									isError
+								>
+									{ __( 'Error pulling changes' ) }
+								</SyncPullPushClear>
+							) }
+							{ isPushError && (
+								<SyncPullPushClear
+									onClick={ () => clearPushState( selectedSite.id, connectedSite.id ) }
+									isError
+								>
+									{ __( 'Error pushing changes' ) }
+								</SyncPullPushClear>
+							) }
+							{ hasPullFinished && (
+								<SyncPullPushClear
+									onClick={ () => clearPullState( selectedSite.id, connectedSite.id ) }
+								>
+									{ __( 'Pull complete' ) }
+								</SyncPullPushClear>
+							) }
+							{ pushState?.status && isPushing && (
+								<div className="flex flex-col gap-2 min-w-44">
+									<div className="a8c-body-small">{ pushState.status.message }</div>
+									<ProgressBar value={ pushState.status.progress } maxValue={ 100 } />
+								</div>
+							) }
+
+							{ pushState?.status && hasPushFinished && (
+								<SyncPullPushClear
+									onClick={ () => clearPushState( selectedSite.id, connectedSite.id ) }
+								>
+									{ pushState.status.message }
+								</SyncPullPushClear>
+							) }
+							{ ! isPulling &&
+								! hasPullFinished &&
+								! isPullError &&
+								! isPushError &&
+								! isPushing &&
+								! hasPushFinished && (
+									<SyncConnectedSiteControls
+										connectedSite={ connectedSite }
+										selectedSite={ selectedSite }
+									/>
+								) }
+						</div>
+					</div>
+				);
+			} ) }
+		</div>
+	);
+};
+
+type SyncConnectedSiteSectionProps = {
+	section: ConnectedSiteSection;
+	disconnectSite: ( id: number ) => void;
+	selectedSite: SiteDetails;
+	openSitesSyncSelector: OpenSitesSyncSelector;
+};
+
+const SyncConnectedSiteSection = ( {
+	section,
+	disconnectSite,
+	selectedSite,
+	openSitesSyncSelector,
+}: SyncConnectedSiteSectionProps ) => {
+	const { __ } = useI18n();
+	const getDocsLink = useDocsLink();
+	const { clearPullState, isSiteIdPulling, isSiteIdPushing } = useSyncSites();
+	const isOffline = useOffline();
 
 	const handleDisconnectSite = async () => {
 		const dontShowDisconnectWarning = localStorage.getItem( 'dontShowDisconnectWarning' );
@@ -118,18 +348,6 @@ const SyncConnectedSitesSection = ( {
 			}
 		} else {
 			disconnectSite( section.id );
-		}
-	};
-
-	const handlePushSite = async ( connectedSite: SyncSite ) => {
-		if ( connectedSite.isStaging ) {
-			showPushStagingConfirmation( () => {
-				pushSite( connectedSite, selectedSite );
-			} );
-		} else {
-			showPushProductionConfirmation( () => {
-				pushSite( connectedSite, selectedSite );
-			} );
 		}
 	};
 
@@ -196,199 +414,7 @@ const SyncConnectedSitesSection = ( {
 				</div>
 			) }
 
-			{ ! hasConnectionErrors &&
-				section.connectedSites.map( ( connectedSite ) => {
-					const sitePullState = getPullState( selectedSite.id, connectedSite.id );
-					const isPulling = sitePullState && isKeyPulling( sitePullState.status.key );
-					const isPullError = sitePullState && isKeyFailed( sitePullState.status.key );
-					const hasPullFinished = sitePullState && isKeyFinished( sitePullState.status.key );
-
-					const pushState = getPushState( selectedSite.id, connectedSite.id );
-					const isPushing = pushState && isKeyPushing( pushState.status.key );
-					const isPushError = pushState && isKeyFailed( pushState.status.key );
-					const hasPushFinished = pushState && isKeyFinished( pushState.status.key );
-
-					return (
-						<div
-							key={ connectedSite.id }
-							className="flex items-center gap-2 min-h-14 border-b border-a8c-gray-0 px-8"
-						>
-							<div className="flex items-left min-w-[100px] me-4 shrink-0">
-								{ connectedSite.isStaging ? (
-									<Badge>{ __( 'Staging' ) }</Badge>
-								) : (
-									<Badge className="bg-a8c-green-5 text-a8c-green-80">{ __( 'Production' ) }</Badge>
-								) }
-							</div>
-							<Button
-								variant="link"
-								className="!text-a8c-gray-70 hover:!text-a8c-blueberry max-w-full overflow-hidden"
-								onClick={ () => {
-									getIpcApi().openURL( connectedSite.url );
-								} }
-							>
-								<span className="truncate">{ connectedSite.url }</span> <ArrowIcon />
-							</Button>
-							<div className="flex gap-2 ps-4 ms-auto shrink-0">
-								{ isPulling && (
-									<div className="flex flex-col gap-2 min-w-44">
-										<div className="a8c-body-small">{ sitePullState.status.message }</div>
-										<ProgressBar value={ sitePullState.status.progress } maxValue={ 100 } />
-									</div>
-								) }
-								{ isPullError && (
-									<SyncPullPushClear
-										onClick={ () => clearPullState( selectedSite.id, connectedSite.id ) }
-										isError
-									>
-										{ __( 'Error pulling changes' ) }
-									</SyncPullPushClear>
-								) }
-								{ isPushError && (
-									<SyncPullPushClear
-										onClick={ () => clearPushState( selectedSite.id, connectedSite.id ) }
-										isError
-									>
-										{ __( 'Error pushing changes' ) }
-									</SyncPullPushClear>
-								) }
-								{ hasPullFinished && (
-									<SyncPullPushClear
-										onClick={ () => clearPullState( selectedSite.id, connectedSite.id ) }
-									>
-										{ __( 'Pull complete' ) }
-									</SyncPullPushClear>
-								) }
-								{ pushState?.status && isPushing && (
-									<div className="flex flex-col gap-2 min-w-44">
-										<div className="a8c-body-small">{ pushState.status.message }</div>
-										<ProgressBar value={ pushState.status.progress } maxValue={ 100 } />
-									</div>
-								) }
-
-								{ pushState?.status && hasPushFinished && (
-									<SyncPullPushClear
-										onClick={ () => clearPushState( selectedSite.id, connectedSite.id ) }
-									>
-										{ pushState.status.message }
-									</SyncPullPushClear>
-								) }
-								{ ! isPulling &&
-									! hasPullFinished &&
-									! isPullError &&
-									! isPushError &&
-									! isPushing &&
-									! hasPushFinished && (
-										<Tooltip
-											disabled={ ! isOffline }
-											icon={ offlineIcon }
-											text={ __( 'Pulling or pushing a site requires an internet connection.' ) }
-											placement="top-start"
-										>
-											<div className="flex gap-2 ps-4 ms-auto shrink-0 h-5">
-												{ isAnySiteSyncing ? (
-													<Tooltip
-														text={
-															isAnyConnectedSiteSyncing
-																? __(
-																		'This Studio site is syncing. Please wait for the sync to finish before you pull it.'
-																  )
-																: __(
-																		'Another Studio site is syncing. Please wait for the sync to finish before you pull this site.'
-																  )
-														}
-														placement="top-start"
-													>
-														<Button variant="link" disabled={ true }>
-															<Icon icon={ cloudDownload } />
-															{ __( 'Pull' ) }
-														</Button>
-													</Tooltip>
-												) : (
-													<DynamicTooltip
-														getTooltipText={ () =>
-															getLastSyncTimeText( connectedSite.lastPullTimestamp, 'pull' )
-														}
-														placement="top-start"
-														disabled={ isOffline }
-													>
-														<Button
-															variant="link"
-															className={ cx(
-																! isOffline &&
-																	! isAnySitePulling &&
-																	! isAnySitePushing &&
-																	'!text-black hover:!text-a8c-blueberry'
-															) }
-															onClick={ () => {
-																const detail = connectedSite.isStaging
-																	? __(
-																			"Pulling will replace your Studio site's files and database with a copy from your staging site."
-																	  )
-																	: __(
-																			"Pulling will replace your Studio site's files and database with a copy from your production site."
-																	  );
-																showPullConfirmation(
-																	() => pullSite( connectedSite, selectedSite ),
-																	{ detail }
-																);
-															} }
-															disabled={ isAnySiteSyncing || isOffline }
-														>
-															<Icon icon={ cloudDownload } />
-															{ __( 'Pull' ) }
-														</Button>
-													</DynamicTooltip>
-												) }
-												{ isAnySiteSyncing ? (
-													<Tooltip
-														text={
-															isAnyConnectedSiteSyncing
-																? __(
-																		'This Studio site is syncing. Please wait for the sync to finish before you push it.'
-																  )
-																: __(
-																		'Another Studio site is syncing. Please wait for the sync to finish before you push this site.'
-																  )
-														}
-														placement="top-start"
-													>
-														<Button variant="link" disabled={ true }>
-															<Icon icon={ cloudUpload } />
-															{ __( 'Push' ) }
-														</Button>
-													</Tooltip>
-												) : (
-													<DynamicTooltip
-														getTooltipText={ () =>
-															getLastSyncTimeText( connectedSite.lastPushTimestamp, 'push' )
-														}
-														placement="top-start"
-														disabled={ isOffline }
-													>
-														<Button
-															variant="link"
-															className={ cx(
-																! isOffline &&
-																	! isAnySitePulling &&
-																	! isAnySitePushing &&
-																	'!text-black hover:!text-a8c-blueberry'
-															) }
-															onClick={ () => handlePushSite( connectedSite ) }
-															disabled={ isAnySiteSyncing || isOffline }
-														>
-															<Icon icon={ cloudUpload } />
-															{ __( 'Push' ) }
-														</Button>
-													</DynamicTooltip>
-												) }
-											</div>
-										</Tooltip>
-									) }
-							</div>
-						</div>
-					);
-				} ) }
+			{ ! hasConnectionErrors && <SyncConnectedSitesList selectedSite={ selectedSite } /> }
 		</div>
 	);
 };
@@ -441,7 +467,7 @@ export function SyncConnectedSites( {
 	return (
 		<div className="flex flex-col flex-1 pt-8 overflow-y-auto">
 			{ siteSections.map( ( section ) => (
-				<SyncConnectedSitesSection
+				<SyncConnectedSiteSection
 					key={ section.id }
 					section={ section }
 					selectedSite={ selectedSite }

--- a/src/components/sync-connected-sites.tsx
+++ b/src/components/sync-connected-sites.tsx
@@ -95,7 +95,7 @@ const SyncConnectedSiteControls = ( {
 			text={ __( 'Pulling or pushing a site requires an internet connection.' ) }
 			placement="top-start"
 		>
-			<div className="flex gap-2 whitespace-nowrap h-5">
+			<div className="flex gap-2 h-5">
 				{ isAnySiteSyncing ? (
 					<Tooltip
 						text={
@@ -203,7 +203,7 @@ const SyncConnectedSitesList = ( { selectedSite }: SyncConnectedSitesListProps )
 	const { isKeyPulling, isKeyPushing, isKeyFinished, isKeyFailed } = useSyncStatesProgressInfo();
 
 	return (
-		<div className="grid grid-cols-[min-content_1fr_min-content]">
+		<div className="grid grid-cols-[fit-content_1fr_fit-content]">
 			{ connectedSites.map( ( connectedSite ) => {
 				const sitePullState = getPullState( selectedSite.id, connectedSite.id );
 				const isPulling = sitePullState && isKeyPulling( sitePullState.status.key );
@@ -227,6 +227,7 @@ const SyncConnectedSitesList = ( { selectedSite }: SyncConnectedSitesListProps )
 								<Badge className="bg-a8c-green-5 text-a8c-green-80">{ __( 'Production' ) }</Badge>
 							) }
 						</div>
+
 						<Button
 							variant="link"
 							className="!text-a8c-gray-70 hover:!text-a8c-blueberry max-w-full overflow-hidden"
@@ -236,7 +237,8 @@ const SyncConnectedSitesList = ( { selectedSite }: SyncConnectedSitesListProps )
 						>
 							<span className="truncate">{ connectedSite.url }</span> <ArrowIcon />
 						</Button>
-						<div className="flex gap-2 ms-auto shrink-0">
+
+						<div className="flex shrink-0 justify-self-end">
 							{ isPulling && (
 								<div className="flex flex-col gap-2 min-w-44">
 									<div className="a8c-body-small">{ sitePullState.status.message }</div>

--- a/src/components/sync-pull-push-clear.tsx
+++ b/src/components/sync-pull-push-clear.tsx
@@ -17,7 +17,7 @@ export function SyncPullPushClear( {
 	return (
 		<div
 			className={ cx(
-				'flex gap-4 ps-4 ms-auto items-center shrink-0',
+				'flex gap-4 items-center',
 				isError ? 'text-a8c-red-50' : 'text-a8c-green-50'
 			) }
 		>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/dotcom-forge/issues/10605

## Proposed Changes

- Use CSS grid (and subgrid) to lay out the list of connected sites in the sync tab. The benefit of this approach over using a static `min-width` for the leftmost column (where the Production/Staging sticker lives) is that the column width is now dynamically controlled by the length of the translations.
  - Subgrid is useful because it allows the `max-content` width of the leftmost column to "propagate" out of each connected site list item. Not easy to explain in text, but it works great.
- Since `SyncConnectedSitesSection` previously contained very deep indentation, I also took this opportunity to split up that component into three ones: `SyncConnectedSiteSection`, `SyncConnectedSitesList`, and `SyncConnectedSiteControls`. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Have a connected site
2. Ensure that the layout looks good in a wide viewport and in a narrow viewport
3. Pull a site
4. Ensure that the layout looks good in a wide viewport and in a narrow viewport
5. After the pull operation finishes, ensure that the layout looks good in a wide viewport and in a narrow viewport
6. Switch the app language to German and repeat

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
