### PR TITLE
Adjust sorting of WordPress versions dropdown

### DIFF
--- a/src/components/add-site.tsx
+++ b/src/components/add-site.tsx
@@ -68,16 +68,15 @@ export default function AddSite( { className }: AddSiteProps ) {
 		siteName
 	);
 
-	const wpVersions = useRootSelector(
-		wordpressVersionsSelectors.selectWordPressVersionsWithLatest
+	const latestStableVersion = useRootSelector(
+		wordpressVersionsSelectors.selectLatestStableVersion
 	);
 
 	const initializeForm = useCallback( async () => {
 		const siteName = await generateSiteName( sites );
 		const { path, name, isWordPress } = await getIpcApi().generateProposedSitePath( siteName );
-		const latestVersion = wpVersions.find( ( version ) => ! version.isBeta );
-		if ( latestVersion ) {
-			setWpVersion( latestVersion.value );
+		if ( latestStableVersion ) {
+			setWpVersion( latestStableVersion.value );
 		}
 		setNameSuggested( true );
 		setSiteName( name );
@@ -92,8 +91,8 @@ export default function AddSite( { className }: AddSiteProps ) {
 		setSitePath,
 		setError,
 		setDoesPathContainWordPress,
-		wpVersions,
 		setWpVersion,
+		latestStableVersion,
 	] );
 
 	useEffect( () => {

--- a/src/components/add-site.tsx
+++ b/src/components/add-site.tsx
@@ -14,6 +14,8 @@ import { useImportExport } from 'src/hooks/use-import-export';
 import { useIpcListener } from 'src/hooks/use-ipc-listener';
 import { generateSiteName } from 'src/lib/generate-site-name';
 import { getIpcApi } from 'src/lib/get-ipc-api';
+import { useRootSelector } from 'src/stores';
+import { wordpressVersionsSelectors } from 'src/stores/wordpress-versions-slice';
 import { DEFAULT_PHP_VERSION, DEFAULT_WORDPRESS_VERSION } from 'vendor/wp-now/src/constants';
 
 interface AddSiteProps {
@@ -66,9 +68,17 @@ export default function AddSite( { className }: AddSiteProps ) {
 		siteName
 	);
 
+	const wpVersions = useRootSelector(
+		wordpressVersionsSelectors.selectWordPressVersionsWithLatest
+	);
+
 	const initializeForm = useCallback( async () => {
 		const siteName = await generateSiteName( sites );
 		const { path, name, isWordPress } = await getIpcApi().generateProposedSitePath( siteName );
+		const latestVersion = wpVersions.find( ( version ) => ! version.isBeta );
+		if ( latestVersion ) {
+			setWpVersion( latestVersion.value );
+		}
 		setNameSuggested( true );
 		setSiteName( name );
 		setProposedSitePath( path );
@@ -82,6 +92,8 @@ export default function AddSite( { className }: AddSiteProps ) {
 		setSitePath,
 		setError,
 		setDoesPathContainWordPress,
+		wpVersions,
+		setWpVersion,
 	] );
 
 	useEffect( () => {

--- a/src/components/onboarding.tsx
+++ b/src/components/onboarding.tsx
@@ -87,16 +87,15 @@ export default function Onboarding() {
 		},
 	} );
 
-	const wpVersions = useRootSelector(
-		wordpressVersionsSelectors.selectWordPressVersionsWithLatest
+	const latestStableVersion = useRootSelector(
+		wordpressVersionsSelectors.selectLatestStableVersion
 	);
 
 	useEffect( () => {
-		const latestVersion = wpVersions.find( ( version ) => ! version.isBeta );
-		if ( latestVersion ) {
-			setWpVersion( latestVersion.value );
+		if ( latestStableVersion ) {
+			setWpVersion( latestStableVersion.value );
 		}
-	}, [ wpVersions, setWpVersion ] );
+	}, [ latestStableVersion, setWpVersion ] );
 
 	useEffect( () => {
 		const run = async () => {

--- a/src/components/onboarding.tsx
+++ b/src/components/onboarding.tsx
@@ -11,6 +11,8 @@ import { useAddSite } from 'src/hooks/use-add-site';
 import { useDragAndDropFile } from 'src/hooks/use-drag-and-drop-file';
 import { generateSiteName } from 'src/lib/generate-site-name';
 import { getIpcApi } from 'src/lib/get-ipc-api';
+import { useRootSelector } from 'src/stores';
+import { wordpressVersionsSelectors } from 'src/stores/wordpress-versions-slice';
 
 const GradientBox = () => {
 	const { __ } = useI18n();
@@ -84,6 +86,17 @@ export default function Onboarding() {
 			}
 		},
 	} );
+
+	const wpVersions = useRootSelector(
+		wordpressVersionsSelectors.selectWordPressVersionsWithLatest
+	);
+
+	useEffect( () => {
+		const latestVersion = wpVersions.find( ( version ) => ! version.isBeta );
+		if ( latestVersion ) {
+			setWpVersion( latestVersion.value );
+		}
+	}, [ wpVersions, setWpVersion ] );
 
 	useEffect( () => {
 		const run = async () => {

--- a/src/components/tests/add-site.test.tsx
+++ b/src/components/tests/add-site.test.tsx
@@ -11,16 +11,17 @@ jest.mock( 'src/stores', () => {
 	return {
 		useAppDispatch: jest.fn().mockReturnValue( mockDispatch ),
 		useRootSelector: jest.fn().mockImplementation( ( selector ) => {
-			if (
-				typeof selector === 'object' &&
-				selector !== null &&
-				'name' in selector &&
-				selector.name === 'selectWordPressVersionsWithLatest'
-			) {
+			if ( ! ( typeof selector === 'object' && selector !== null ) ) {
+				return { status: 'succeeded' };
+			}
+			if ( 'name' in selector && selector.name === 'selectWordPressVersionsWithLatest' ) {
 				return [
 					{ isBeta: false, label: '6.4', value: '6.4.3' },
 					{ isBeta: false, label: '6.3', value: '6.3.3' },
 				];
+			}
+			if ( 'name' in selector && selector.name === 'selectLatestStableVersion' ) {
+				return { isBeta: false, label: '6.4', value: '6.4.3' };
 			}
 			return { status: 'succeeded' };
 		} ),
@@ -30,6 +31,7 @@ jest.mock( 'src/stores', () => {
 jest.mock( 'src/stores/wordpress-versions-slice', () => ( {
 	wordpressVersionsSelectors: {
 		selectWordPressVersionsWithLatest: { name: 'selectWordPressVersionsWithLatest' },
+		selectLatestStableVersion: { name: 'selectLatestStableVersion' },
 	},
 	wordpressVersionsThunks: {
 		fetchWordPressVersions: jest.fn(),
@@ -270,7 +272,7 @@ describe( 'AddSite', () => {
 		).toBeVisible();
 	} );
 
-	it( 'should display WordPress version dropdown when feature flag is enabled', async () => {
+	it( 'should display WordPress version dropdown', async () => {
 		const user = userEvent.setup();
 		mockGenerateProposedSitePath.mockResolvedValue( {
 			path: '/default_path/my-wordpress-website',

--- a/src/components/tests/main-sidebar.test.tsx
+++ b/src/components/tests/main-sidebar.test.tsx
@@ -1,9 +1,11 @@
 import { render, act, screen } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
+import { Provider } from 'react-redux';
 import MainSidebar from 'src/components/main-sidebar';
 import { SyncSitesProvider } from 'src/hooks/sync-sites';
 import { useAuth } from 'src/hooks/use-auth';
 import { ContentTabsProvider } from 'src/hooks/use-content-tabs';
+import { store } from 'src/stores';
 
 jest.mock( 'src/hooks/use-auth' );
 
@@ -59,9 +61,11 @@ jest.mock( 'src/hooks/use-site-details', () => ( {
 
 const renderWithProvider = ( children: React.ReactElement ) => {
 	return render(
-		<ContentTabsProvider>
-			<SyncSitesProvider>{ children }</SyncSitesProvider>
-		</ContentTabsProvider>
+		<Provider store={ store }>
+			<ContentTabsProvider>
+				<SyncSitesProvider>{ children }</SyncSitesProvider>
+			</ContentTabsProvider>
+		</Provider>
 	);
 };
 

--- a/src/modules/site-settings/edit-site-details.tsx
+++ b/src/modules/site-settings/edit-site-details.tsx
@@ -1,6 +1,7 @@
 import { SelectControl } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
 import { FormEvent, useCallback, useState } from 'react';
+import semver from 'semver';
 import stripAnsi from 'strip-ansi';
 import Button from 'src/components/button';
 import { ErrorInformation } from 'src/components/error-information';
@@ -52,8 +53,25 @@ export default function EditSiteDetails( { currentWpVersion, onSave }: EditSiteD
 		label: version.label,
 		value: version.value,
 	} ) );
+
 	if ( ! wordpressVersionOptions.some( ( version ) => version.value === currentWpVersion ) ) {
-		wordpressVersionOptions.push( { label: currentWpVersion, value: currentWpVersion } );
+		const customVersion = { label: currentWpVersion, value: currentWpVersion };
+		// find the index of the version that is less than the current version
+		const insertIndex = wordpressVersionOptions.findIndex( ( compareVersion ) => {
+			const currentVer = semver.coerce( currentWpVersion );
+			const compareVer = semver.coerce( compareVersion.value );
+			if ( ! currentVer || ! compareVer ) {
+				return false;
+			}
+			return semver.lt( compareVer, currentVer );
+		} );
+		// if the current version is less than all the versions in the list, add it to the end
+		if ( insertIndex === -1 ) {
+			wordpressVersionOptions.push( customVersion );
+		} else {
+			// otherwise, insert it at the found index
+			wordpressVersionOptions.splice( insertIndex, 0, customVersion );
+		}
 	}
 
 	const resetFormState = useCallback( () => {

--- a/src/modules/site-settings/edit-site-details.tsx
+++ b/src/modules/site-settings/edit-site-details.tsx
@@ -1,7 +1,6 @@
 import { SelectControl } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
 import { FormEvent, useCallback, useState } from 'react';
-import semver from 'semver';
 import stripAnsi from 'strip-ansi';
 import Button from 'src/components/button';
 import { ErrorInformation } from 'src/components/error-information';
@@ -21,6 +20,7 @@ import {
 	ALLOWED_PHP_VERSIONS,
 	AllowedPHPVersion,
 } from 'vendor/wp-now/src/constants';
+import { addWpVersionToList } from './lib/wordpress-versions';
 
 type EditSiteDetailsProps = {
 	currentWpVersion: string;
@@ -55,23 +55,7 @@ export default function EditSiteDetails( { currentWpVersion, onSave }: EditSiteD
 	} ) );
 
 	if ( ! wordpressVersionOptions.some( ( version ) => version.value === currentWpVersion ) ) {
-		const customVersion = { label: currentWpVersion, value: currentWpVersion };
-		// find the index of the version that is less than the current version
-		const insertIndex = wordpressVersionOptions.findIndex( ( compareVersion ) => {
-			const currentVer = semver.coerce( currentWpVersion );
-			const compareVer = semver.coerce( compareVersion.value );
-			if ( ! currentVer || ! compareVer ) {
-				return false;
-			}
-			return semver.lt( compareVer, currentVer );
-		} );
-		// if the current version is less than all the versions in the list, add it to the end
-		if ( insertIndex === -1 ) {
-			wordpressVersionOptions.push( customVersion );
-		} else {
-			// otherwise, insert it at the found index
-			wordpressVersionOptions.splice( insertIndex, 0, customVersion );
-		}
+		addWpVersionToList( currentWpVersion, wordpressVersionOptions );
 	}
 
 	const resetFormState = useCallback( () => {

--- a/src/modules/site-settings/lib/wordpress-versions.ts
+++ b/src/modules/site-settings/lib/wordpress-versions.ts
@@ -1,0 +1,30 @@
+import semver from 'semver';
+
+export const addWpVersionToList = (
+	version: string,
+	options: Array< { label: string; value: string } >
+) => {
+	const customVersion = { label: version, value: version };
+	const currentVer = semver.coerce( version );
+
+	// Being extra cautious here, if the version is not valid, we add it to the end of the list.
+	if ( ! currentVer ) {
+		options.push( customVersion );
+		return;
+	}
+
+	// Find the index to insert the new version according to the semver version, newest first.
+	const indexToInsert = options.findIndex( ( compareVersion ) => {
+		const compareVer = semver.coerce( compareVersion.value );
+		if ( ! compareVer ) {
+			return false;
+		}
+		return semver.gt( currentVer, compareVer );
+	} );
+
+	if ( indexToInsert === -1 ) {
+		options.push( customVersion );
+	} else {
+		options.splice( indexToInsert, 0, customVersion );
+	}
+};

--- a/src/modules/site-settings/lib/wordpress-versions.ts
+++ b/src/modules/site-settings/lib/wordpress-versions.ts
@@ -13,8 +13,7 @@ export const addWpVersionToList = (
 		return;
 	}
 
-	// Find the index to insert the new version according to the semver version, newest first.
-	const indexToInsert = options.findIndex( ( compareVersion ) => {
+	const firstOlderVersionIndex = options.findIndex( ( compareVersion ) => {
 		const compareVer = semver.coerce( compareVersion.value );
 		if ( ! compareVer ) {
 			return false;
@@ -22,9 +21,9 @@ export const addWpVersionToList = (
 		return semver.gt( currentVer, compareVer );
 	} );
 
-	if ( indexToInsert === -1 ) {
+	if ( firstOlderVersionIndex === -1 ) {
 		options.push( customVersion );
 	} else {
-		options.splice( indexToInsert, 0, customVersion );
+		options.splice( firstOlderVersionIndex, 0, customVersion );
 	}
 };

--- a/src/modules/site-settings/tests/wordpress-versions.test.ts
+++ b/src/modules/site-settings/tests/wordpress-versions.test.ts
@@ -1,0 +1,115 @@
+import { addWpVersionToList } from 'src/modules/site-settings/lib/wordpress-versions';
+
+describe( 'addWpVersionToList', () => {
+	it( 'should add version to empty list', () => {
+		const options: Array< { label: string; value: string } > = [];
+		addWpVersionToList( '6.4.2', options );
+		expect( options ).toEqual( [ { label: '6.4.2', value: '6.4.2' } ] );
+	} );
+
+	it( 'should add version at the top when it is newer than all existing versions', () => {
+		const options = [
+			{ label: '6.4.1', value: '6.4.1' },
+			{ label: '6.4.0', value: '6.4.0' },
+		];
+		addWpVersionToList( '6.4.3', options );
+		expect( options ).toEqual( [
+			{ label: '6.4.3', value: '6.4.3' },
+			{ label: '6.4.1', value: '6.4.1' },
+			{ label: '6.4.0', value: '6.4.0' },
+		] );
+	} );
+
+	it( 'should add version at the end when it is older than all existing versions', () => {
+		const options = [
+			{ label: '6.4.2', value: '6.4.2' },
+			{ label: '6.4.1', value: '6.4.1' },
+		];
+		addWpVersionToList( '6.4.0', options );
+		expect( options ).toEqual( [
+			{ label: '6.4.2', value: '6.4.2' },
+			{ label: '6.4.1', value: '6.4.1' },
+			{ label: '6.4.0', value: '6.4.0' },
+		] );
+	} );
+
+	it( 'should add version in the middle when it is between existing versions', () => {
+		const options = [
+			{ label: '6.4.2', value: '6.4.2' },
+			{ label: '6.4.0', value: '6.4.0' },
+		];
+		addWpVersionToList( '6.4.1', options );
+		expect( options ).toEqual( [
+			{ label: '6.4.2', value: '6.4.2' },
+			{ label: '6.4.1', value: '6.4.1' },
+			{ label: '6.4.0', value: '6.4.0' },
+		] );
+	} );
+
+	it( 'should handle non-semver versions by adding them at the end', () => {
+		const options = [
+			{ label: '6.4.2', value: '6.4.2' },
+			{ label: '6.4.0', value: '6.4.0' },
+		];
+		addWpVersionToList( 'nightly', options );
+		expect( options ).toEqual( [
+			{ label: '6.4.2', value: '6.4.2' },
+			{ label: '6.4.0', value: '6.4.0' },
+			{ label: 'nightly', value: 'nightly' },
+		] );
+	} );
+
+	it( 'should handle mixed semver and non-semver versions', () => {
+		const options = [
+			{ label: 'nightly', value: 'nightly' },
+			{ label: '6.4.0', value: '6.4.0' },
+		];
+		addWpVersionToList( '6.4.1', options );
+		expect( options ).toEqual( [
+			{ label: 'nightly', value: 'nightly' },
+			{ label: '6.4.1', value: '6.4.1' },
+			{ label: '6.4.0', value: '6.4.0' },
+		] );
+	} );
+
+	it( 'should handle beta versions correctly', () => {
+		const options = [
+			{ label: '6.4.2', value: '6.4.2' },
+			{ label: '6.4.0', value: '6.4.0' },
+		];
+		addWpVersionToList( '6.4.1-beta2', options );
+		expect( options ).toEqual( [
+			{ label: '6.4.2', value: '6.4.2' },
+			{ label: '6.4.1-beta2', value: '6.4.1-beta2' },
+			{ label: '6.4.0', value: '6.4.0' },
+		] );
+	} );
+
+	it( 'should handle RC versions correctly', () => {
+		const options = [
+			{ label: '6.4.2', value: '6.4.2' },
+			{ label: '6.4.0', value: '6.4.0' },
+		];
+		addWpVersionToList( '6.4.1-RC1', options );
+		expect( options ).toEqual( [
+			{ label: '6.4.2', value: '6.4.2' },
+			{ label: '6.4.1-RC1', value: '6.4.1-RC1' },
+			{ label: '6.4.0', value: '6.4.0' },
+		] );
+	} );
+
+	it( 'should handle multiple pre-release versions', () => {
+		const options = [
+			{ label: '6.4.2', value: '6.4.2' },
+			{ label: '6.4.1-beta2', value: '6.4.1-beta2' },
+			{ label: '6.4.0', value: '6.4.0' },
+		];
+		addWpVersionToList( '6.4.1-beta1', options );
+		expect( options ).toEqual( [
+			{ label: '6.4.2', value: '6.4.2' },
+			{ label: '6.4.1-beta2', value: '6.4.1-beta2' },
+			{ label: '6.4.1-beta1', value: '6.4.1-beta1' },
+			{ label: '6.4.0', value: '6.4.0' },
+		] );
+	} );
+} );

--- a/src/stores/wordpress-versions-slice.ts
+++ b/src/stores/wordpress-versions-slice.ts
@@ -112,10 +112,10 @@ const wordpressVersionsSlice = createSlice( {
 	selectors: {
 		selectWordPressVersions: ( state ) => state.versions,
 		selectWordPressVersionsWithLatest: ( state ) => {
-			let foundLatest = false;
+			let foundLatestStable = false;
 			return state.versions.map( ( version ) => {
-				if ( ! foundLatest && ! version.isBeta ) {
-					foundLatest = true;
+				if ( ! foundLatestStable && ! version.isBeta ) {
+					foundLatestStable = true;
 					return {
 						...version,
 						label: `${ version.label } (${ __( 'latest' ) })`,
@@ -123,6 +123,9 @@ const wordpressVersionsSlice = createSlice( {
 				}
 				return version;
 			} );
+		},
+		selectLatestStableVersion: ( state ) => {
+			return state.versions.find( ( version ) => ! version.isBeta );
 		},
 	},
 } );

--- a/src/stores/wordpress-versions-slice.ts
+++ b/src/stores/wordpress-versions-slice.ts
@@ -112,19 +112,17 @@ const wordpressVersionsSlice = createSlice( {
 	selectors: {
 		selectWordPressVersions: ( state ) => state.versions,
 		selectWordPressVersionsWithLatest: ( state ) => {
-			const latestNonBeta = state.versions.find( ( version ) => ! version.isBeta );
-			if ( ! latestNonBeta ) {
-				return state.versions;
-			}
-			const otherVersions = state.versions.filter( ( version ) => version !== latestNonBeta );
-			return [
-				{
-					isBeta: false,
-					label: `${ latestNonBeta.label } (${ __( 'latest' ) })`,
-					value: latestNonBeta.value,
-				},
-				...otherVersions,
-			];
+			let foundLatest = false;
+			return state.versions.map( ( version ) => {
+				if ( ! foundLatest && ! version.isBeta ) {
+					foundLatest = true;
+					return {
+						...version,
+						label: `${ version.label } (${ __( 'latest' ) })`,
+					};
+				}
+				return version;
+			} );
 		},
 	},
 } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/dotcom-forge/issues/10621
- Fixes https://github.com/Automattic/dotcom-forge/issues/10601

## Proposed Changes

- Adjust the order or the wordpress versions, to preserve the semver order, instead of listing `latest` on top
- Ensure the latest version is selected by default on add site modal
- Improve version ordering logic when handling custom/non-listed WordPress versions
  - Use `semver.coerce()` to properly compare versions that aren't in the official version list
  - Ensure custom versions are inserted in the correct position based on semver comparison

| Onboarding - Default | Onboarding - Dropdown | Add Site - Default | Add Site - Dropdown | Edit Site - Default | Edit Site - Dropdown |
|--------|--------|--------|--------|--------|--------|
| ![image](https://github.com/user-attachments/assets/6b1b9725-2c57-45ec-be41-29f4405cb913) | ![image](https://github.com/user-attachments/assets/640be4d9-898c-4802-bb0a-369adcc89ffe) | ![image](https://github.com/user-attachments/assets/96f71311-9c9e-42a2-b98a-4aaaecd2be82) | ![image](https://github.com/user-attachments/assets/920a7dc4-40f4-4db4-9a16-69d1a6903914) | ![image](https://github.com/user-attachments/assets/7fe78748-9ca3-4cdb-8307-52605b64ab2e) | ![image](https://github.com/user-attachments/assets/fefdf0e2-7397-4eaa-87b4-c3108862bd30) | 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Start the onboarding flow (delete all sites)
- Confirm the default WordPress version selected value is the latest version
- Confirm the order from the WordPress version dropdown is correct
- Adding a site should result in a site with the selected WordPress version
- Try for multiple versions and without selecting a version from the dropdown to ensure the values are correctly set
- Repeat the process for Add Site workflow
- Check Edit site in Settings
- Confirm the site WordPress version is the version selected in the Edit site modal
- Confirm the order of the WordPress version dropdown

Additional Testing for Custom Versions:
- Install a WordPress version that isn't in the default version list (e.g. 5.8)
- Verify that the custom version appears in the correct position in the version dropdown based on semver ordering
- Test with both older and newer versions to ensure proper ordering in all cases

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
