### PR TITLE
Fix: Prevent server process from hanging during stop operation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,6 @@
 				"semver": "^7.6.0",
 				"shell-quote": "^1.8.1",
 				"strip-ansi": "^7.1.0",
-				"sudo-prompt": "^9.2.1",
 				"tar": "^7.4.0",
 				"unzipper": "0.10.11",
 				"url-loader": "^4.1.1",
@@ -24777,6 +24776,7 @@
 			"resolved": "https://registry.npmjs.org/sudo-prompt/-/sudo-prompt-9.2.1.tgz",
 			"integrity": "sha512-Mu7R0g4ig9TUuGSxJavny5Rv0egCEtpZRNMrZaYS1vxkiIxGiGUwoezU3LazIQ+KE04hTrTfNPgxU5gzi7F5Pw==",
 			"deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/sumchecker": {

--- a/src/lib/site-server-process.ts
+++ b/src/lib/site-server-process.ts
@@ -143,23 +143,17 @@ export default class SiteServerProcess {
 		}
 
 		return new Promise< void >( ( resolve, reject ) => {
-			let isResolved = false;
 			process.once( 'exit', ( code ) => {
-				if ( ! isResolved ) {
-					isResolved = true;
-					if ( code !== 0 ) {
-						reject( new Error( `Site server process exited with code ${ code } upon stopping` ) );
-					} else {
-						resolve();
-					}
+				if ( code !== 0 ) {
+					reject( new Error( `Site server process exited with code ${ code } upon stopping` ) );
+				} else {
+					resolve();
 				}
 			} );
-			// process.kill() returns false if we're not able to kill the process.
-			if ( ! process.kill() && ! isResolved ) {
+			if ( ! process.kill() ) {
 				if ( process.pid ) {
 					kill( process.pid, 'SIGKILL' );
 				} else {
-					isResolved = true;
 					resolve();
 				}
 			}

--- a/src/lib/site-server-process.ts
+++ b/src/lib/site-server-process.ts
@@ -1,4 +1,5 @@
 import { app, utilityProcess, UtilityProcess } from 'electron';
+import { kill } from 'process';
 import { PHPRunOptions } from '@php-wasm/universal';
 import * as Sentry from '@sentry/electron/renderer';
 import { WPNowOptions } from 'vendor/wp-now/src/config';
@@ -142,25 +143,19 @@ export default class SiteServerProcess {
 		}
 
 		return new Promise< void >( ( resolve, reject ) => {
-			const KILL_TIMEOUT = 5000;
 			let isResolved = false;
 
-			const forceKillTimeout = setTimeout( () => {
+			const forceKillTimeout = () => {
 				if ( isResolved ) return;
-
-				// Check if process and pid are still valid before attempting force kill
-				if ( process && process.pid ) {
-					require( 'process' ).kill( process.pid, 'SIGKILL' );
+				if ( process.pid ) {
+					kill( process.pid, 'SIGKILL' );
 				} else {
-					if ( ! isResolved ) {
-						isResolved = true;
-						resolve();
-					}
+					isResolved = true;
+					resolve();
 				}
-			}, KILL_TIMEOUT );
+			};
 
 			process.once( 'exit', ( code ) => {
-				clearTimeout( forceKillTimeout );
 				if ( ! isResolved ) {
 					isResolved = true;
 					if ( code !== 0 ) {
@@ -170,7 +165,9 @@ export default class SiteServerProcess {
 					}
 				}
 			} );
-			process.kill();
+			if ( ! process.kill() ) {
+				forceKillTimeout();
+			}
 		} ).catch( ( error ) => {
 			Sentry.captureException( error );
 		} );

--- a/src/lib/site-server-process.ts
+++ b/src/lib/site-server-process.ts
@@ -144,17 +144,6 @@ export default class SiteServerProcess {
 
 		return new Promise< void >( ( resolve, reject ) => {
 			let isResolved = false;
-
-			const forceKillTimeout = () => {
-				if ( isResolved ) return;
-				if ( process.pid ) {
-					kill( process.pid, 'SIGKILL' );
-				} else {
-					isResolved = true;
-					resolve();
-				}
-			};
-
 			process.once( 'exit', ( code ) => {
 				if ( ! isResolved ) {
 					isResolved = true;
@@ -165,8 +154,14 @@ export default class SiteServerProcess {
 					}
 				}
 			} );
-			if ( ! process.kill() ) {
-				forceKillTimeout();
+			// process.kill() returns false if we're not able to kill the process.
+			if ( ! process.kill() && ! isResolved ) {
+				if ( process.pid ) {
+					kill( process.pid, 'SIGKILL' );
+				} else {
+					isResolved = true;
+					resolve();
+				}
 			}
 		} ).catch( ( error ) => {
 			Sentry.captureException( error );

--- a/src/lib/site-server-process.ts
+++ b/src/lib/site-server-process.ts
@@ -142,12 +142,33 @@ export default class SiteServerProcess {
 		}
 
 		return new Promise< void >( ( resolve, reject ) => {
-			process.once( 'exit', ( code ) => {
-				if ( code !== 0 ) {
-					reject( new Error( `Site server process exited with code ${ code } upon stopping` ) );
-					return;
+			const KILL_TIMEOUT = 5000;
+			let isResolved = false;
+
+			const forceKillTimeout = setTimeout( () => {
+				if ( isResolved ) return;
+
+				// Check if process and pid are still valid before attempting force kill
+				if ( process && process.pid ) {
+					require( 'process' ).kill( process.pid, 'SIGKILL' );
+				} else {
+					if ( ! isResolved ) {
+						isResolved = true;
+						resolve();
+					}
 				}
-				resolve();
+			}, KILL_TIMEOUT );
+
+			process.once( 'exit', ( code ) => {
+				clearTimeout( forceKillTimeout );
+				if ( ! isResolved ) {
+					isResolved = true;
+					if ( code !== 0 ) {
+						reject( new Error( `Site server process exited with code ${ code } upon stopping` ) );
+					} else {
+						resolve();
+					}
+				}
 			} );
 			process.kill();
 		} ).catch( ( error ) => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes #985

## Proposed Changes

- Added isResolved flag to prevent multiple promise resolutions in the #killProcess method
- Added force kill with SIGKILL if graceful shutdown fails
- Improved process cleanup by clearing timeouts and handling process state properly

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Follow the steps mentioned in the issue
- Setup default WordPress site.
- Install Remote Data Blocks Plugin.
- Setup third party data ingestion via Google Sheets (https://github.com/Automattic/remote-data-blocks/blob/trunk/docs/tutorials/google-sheets.md).
- When the site eventually fails (This site can’t be reached - localhost refused to connect.). Attempt to stop the site.
- The site stops after the timeout timer runs out, instead of hanging.
- Confirm that there are no pending processes for that site

More details on reproducing the issue (thanks @ppolo99): p1741865890679379/1741864717.468099-slack-C04GESRBWKW

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?