### PR TITLE
Improve error message when port 80 is already in use

### DIFF
--- a/src/lib/proxy-server.ts
+++ b/src/lib/proxy-server.ts
@@ -4,6 +4,7 @@ import { domainToASCII } from 'node:url';
 import * as Sentry from '@sentry/electron/main';
 import { __ } from '@wordpress/i18n';
 import httpProxy from 'http-proxy';
+import { getMainWindow } from 'src/main-window';
 import { SiteServer } from 'src/site-server';
 import { loadUserData } from 'src/storage/user-data';
 
@@ -97,16 +98,15 @@ export async function startProxyServer(): Promise< boolean > {
 		return true;
 	} catch ( error ) {
 		if ( error instanceof Error && 'code' in error && error.code === 'EADDRINUSE' ) {
-			setTimeout( () => {
-				dialog.showMessageBox( {
-					type: 'error',
-					message: __( 'Custom domain set up failed' ),
-					detail: __(
-						'Studio needs to use port 80, but it’s already in use by another app. Close any local development apps and restart Studio.'
-					),
-					buttons: [ __( 'OK' ) ],
-				} );
-			}, 2000 );
+			const mainWindow = await getMainWindow();
+			dialog.showMessageBox( mainWindow, {
+				type: 'error',
+				message: __( 'Custom domain set up failed' ),
+				detail: __(
+					'Studio needs to use port 80, but it’s already in use by another app. Close any local development apps and restart Studio.'
+				),
+				buttons: [ __( 'OK' ) ],
+			} );
 			return false;
 		}
 

--- a/src/lib/proxy-server.ts
+++ b/src/lib/proxy-server.ts
@@ -97,14 +97,16 @@ export async function startProxyServer(): Promise< boolean > {
 		return true;
 	} catch ( error ) {
 		if ( error instanceof Error && 'code' in error && error.code === 'EADDRINUSE' ) {
-			dialog.showMessageBox( {
-				type: 'error',
-				message: __( 'Failed to start custom domain proxy server' ),
-				detail: __(
-					'Another server is already running on port 80. For custom domains to work, please stop that server and then restart Studio.'
-				),
-				buttons: [ __( 'OK' ) ],
-			} );
+			setTimeout( () => {
+				dialog.showMessageBox( {
+					type: 'error',
+					message: __( 'Failed to start custom domain proxy server' ),
+					detail: __(
+						'Another server is already running on port 80. For custom domains to work, please stop that server and then restart Studio.'
+					),
+					buttons: [ __( 'OK' ) ],
+				} );
+			}, 2000 );
 			return false;
 		}
 

--- a/src/lib/proxy-server.ts
+++ b/src/lib/proxy-server.ts
@@ -102,7 +102,7 @@ export async function startProxyServer(): Promise< boolean > {
 					type: 'error',
 					message: __( 'Custom domain set up failed' ),
 					detail: __(
-						'Studio needs to use port 80, but it’s in use by another app. Close any local development apps and restart Studio.'
+						'Studio needs to use port 80, but it’s already in use by another app. Close any local development apps and restart Studio.'
 					),
 					buttons: [ __( 'OK' ) ],
 				} );

--- a/src/lib/proxy-server.ts
+++ b/src/lib/proxy-server.ts
@@ -100,9 +100,9 @@ export async function startProxyServer(): Promise< boolean > {
 			setTimeout( () => {
 				dialog.showMessageBox( {
 					type: 'error',
-					message: __( 'Failed to start custom domain proxy server' ),
+					message: __( 'Custom domain set up failed' ),
 					detail: __(
-						'Another server is already running on port 80. For custom domains to work, please stop that server and then restart Studio.'
+						'Studio needs to use port 80, but it’s in use by another app. Close any local development apps and restart Studio.'
 					),
 					buttons: [ __( 'OK' ) ],
 				} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Resolves https://github.com/Automattic/dotcom-forge/issues/10583. 

## Proposed Changes

- delay error message and update its copy

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Start a WordPress site with custom domain through the Local app: https://localwp.com/
2. Check out the PR branch and build the app with `npm start`. 
3. The error message should load with updated copy only after complete Studio app interface load.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
