### PR TITLE
Studio: Ensure RTL screen looks good on settings

### DIFF
--- a/src/components/content-tab-settings.tsx
+++ b/src/components/content-tab-settings.tsx
@@ -34,7 +34,7 @@ export function ContentTabSettings( { selectedSite }: ContentTabSettingsProps ) 
 		? `${ selectedSite.customDomain }`
 		: `localhost:${ selectedSite.port }`;
 	return (
-		<div className="p-8 pr-0">
+		<div className="p-8 ltr:pr-0 rtl:pl-0">
 			<div className="flex justify-between items-center mb-4">
 				<h3 role="heading" className="text-black text-sm font-semibold">
 					{ __( 'Site details' ) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/dotcom-forge/issues/10624

## Proposed Changes

This PR ensures that RTL screen looks correct on the `Settings` tab:

| Before | After |
|---------|---------|
| <img src="https://github.com/user-attachments/assets/ba3c9279-f6b4-4691-a7d2-c62587a88e01" width="300"/> | <img src="https://github.com/user-attachments/assets/379a965c-ad2b-44e2-9a63-6c1360bc0107" width="300"/> |


## Testing Instructions

* Pull the changes from this branch
* Start the app with `npm start`
* Navigate to the `Settings` tab
* Switch the language of the app to RTL e.g. Arabic
* Ensure that the screen does not look cut off 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
