### PR TITLE
Make capabilities property optional for sites response

### DIFF
--- a/src/hooks/use-fetch-wpcom-sites/index.tsx
+++ b/src/hooks/use-fetch-wpcom-sites/index.tsx
@@ -22,7 +22,7 @@ export const sitesEndpointSiteSchema = z.object( {
 		.optional(),
 	capabilities: z.object( {
 		manage_options: z.boolean(),
-	} ),
+	} ).optional(),
 	plan: z
 		.object( {
 			expired: z.boolean(),
@@ -60,7 +60,7 @@ function getSyncSupport( site: SitesEndpointSite, connectedSiteIds: number[] ): 
 	if ( site.is_deleted ) {
 		return 'deleted';
 	}
-	if ( ! site.capabilities.manage_options ) {
+	if ( ! site.capabilities?.manage_options ) {
 		return 'missing-permissions';
 	}
 	if ( isJetpackSite( site ) && ! hasSupportedPlan( site ) ) {

--- a/src/hooks/use-fetch-wpcom-sites/index.tsx
+++ b/src/hooks/use-fetch-wpcom-sites/index.tsx
@@ -20,9 +20,11 @@ export const sitesEndpointSiteSchema = z.object( {
 			wpcom_staging_blog_ids: z.array( z.number() ),
 		} )
 		.optional(),
-	capabilities: z.object( {
-		manage_options: z.boolean(),
-	} ).optional(),
+	capabilities: z
+		.object( {
+			manage_options: z.boolean(),
+		} )
+		.optional(),
 	plan: z
 		.object( {
 			expired: z.boolean(),


### PR DESCRIPTION


## Proposed Changes
Deleted websites don't have `capabilities` property, so we should make it optional.
<img width="1252" alt="Screenshot 2025-03-14 at 15 29 27" src="https://github.com/user-attachments/assets/9c98645d-f392-4222-b9b9-2fda879a5ab5" />

ATM it prints a lot of console.logs which even block UI.


https://github.com/user-attachments/assets/6f223115-3c58-47bc-acce-a4bc104f82ca


## Testing Instructions
1. Create website on wordpress.com
2. Deleted it, so that you see it on wordpress.com/stes page as `Deleted`
3. Open Studio and create a site
4. Open Sync tab and asser that you don't see these console.logs<br /> <img width="1392" alt="Screenshot 2025-03-14 at 15 32 28" src="https://github.com/user-attachments/assets/0254e9a2-bed5-4169-b6e1-fc81b31853b4" />
