### PR TITLE
Display sidebar spinner during export

### DIFF
--- a/src/components/site-menu.tsx
+++ b/src/components/site-menu.tsx
@@ -110,11 +110,12 @@ function ButtonToRun( { running, id, name }: Pick< SiteDetails, 'running' | 'id'
 function SiteItem( { site }: { site: SiteDetails } ) {
 	const { selectedSite, setSelectedSiteId } = useSiteDetails();
 	const isSelected = site === selectedSite;
-	const { isSiteImporting } = useImportExport();
+	const { isSiteImporting, isSiteExporting } = useImportExport();
 	const { isSiteIdPulling } = useSyncSites();
 	const isImporting = isSiteImporting( site.id );
+	const isExporting = isSiteExporting( site.id );
 	const isPulling = isSiteIdPulling( site.id );
-	const showSpinner = site.isAddingSite || isImporting || isPulling;
+	const showSpinner = site.isAddingSite || isImporting || isPulling || isExporting;
 
 	let tooltipText;
 	if ( site.isAddingSite ) {

--- a/src/hooks/tests/use-import-export.test.tsx
+++ b/src/hooks/tests/use-import-export.test.tsx
@@ -211,7 +211,7 @@ describe( 'useImportExport hook', () => {
 		expect( result.current.exportState ).toEqual( {
 			[ SITE_ID ]: {
 				statusMessage: 'Backing up files...',
-				progress: 100,
+				progress: 95,
 			},
 		} );
 

--- a/src/hooks/use-import-export.tsx
+++ b/src/hooks/use-import-export.tsx
@@ -42,6 +42,7 @@ interface ImportExportContext {
 	) => Promise< void >;
 	clearImportState: ( siteId: string ) => void;
 	isSiteImporting: ( siteId: string ) => boolean;
+	isSiteExporting: ( siteId: string ) => boolean;
 	exportState: ExportProgressState;
 	exportFullSite: ( selectedSite: SiteDetails ) => Promise< string | undefined >;
 	exportDatabase: ( selectedSite: SiteDetails ) => Promise< string | undefined >;
@@ -52,6 +53,7 @@ const ImportExportContext = createContext< ImportExportContext >( {
 	importFile: async () => undefined,
 	clearImportState: () => undefined,
 	isSiteImporting: () => false,
+	isSiteExporting: () => false,
 	exportState: {},
 	exportFullSite: async () => undefined,
 	exportDatabase: async () => undefined,
@@ -301,6 +303,11 @@ export const ImportExportProvider = ( { children }: { children: React.ReactNode 
 		[ exportState ]
 	);
 
+	const isSiteExporting = useCallback(
+		( siteId: string ) => !! exportState[ siteId ] && exportState[ siteId ].progress < 100,
+		[ exportState ]
+	);
+
 	const exportFullSite = useCallback(
 		async ( selectedSite: SiteDetails ): Promise< string | undefined > => {
 			const fileName = generateBackupFilename( selectedSite.name );
@@ -421,7 +428,7 @@ export const ImportExportProvider = ( { children }: { children: React.ReactNode 
 					[ siteId ]: {
 						...currentProgress,
 						statusMessage: __( 'Backing up files...' ),
-						progress: Math.min( 100, 20 + entriesProgress * 80 ), // Backup creation takes progress from 20% to 100%
+						progress: Math.min( 95, 20 + entriesProgress * 80 ), // Backup creation takes progress from 20% to 95%
 					},
 				} ) );
 				break;
@@ -454,6 +461,7 @@ export const ImportExportProvider = ( { children }: { children: React.ReactNode 
 			importFile,
 			clearImportState,
 			isSiteImporting,
+			isSiteExporting,
 			exportState,
 			exportFullSite,
 			exportDatabase,
@@ -463,6 +471,7 @@ export const ImportExportProvider = ( { children }: { children: React.ReactNode 
 			importFile,
 			clearImportState,
 			isSiteImporting,
+			isSiteExporting,
 			exportState,
 			exportFullSite,
 			exportDatabase,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/dotcom-forge/issues/10572

## Proposed Changes

- Display a spinner in the main sidebar when exporting a site (to match the behavior when importing a site).

<img width="1012" alt="Screenshot 2025-03-14 at 16 40 54" src="https://github.com/user-attachments/assets/6b89519d-8b70-463e-85f1-31a31807c446" />


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Have a Studio site
2. Go to the Import/Export tab and export the entire site
3. Ensure that a spinner is displayed in the sidebar until the operation is complete
4. Export just the database
5. Ensure that a spinner is displayed in the sidebar until the operation is complete

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
