### PR TITLE
Always pass Electron window to `dialog.showMessageBox`

### DIFF
--- a/src/lib/shell-open-external-wrapper.ts
+++ b/src/lib/shell-open-external-wrapper.ts
@@ -1,6 +1,7 @@
 import { shell, dialog } from 'electron';
 import * as Sentry from '@sentry/electron/main';
 import { __ } from '@wordpress/i18n';
+import { getMainWindow } from 'src/main-window';
 
 // Determines if an error should be muted (not reported to Sentry) based on known "application not
 // found" error codes.
@@ -38,7 +39,8 @@ export const shellOpenExternalWrapper = async ( url: string ) => {
 			);
 		}
 
-		dialog.showMessageBox( {
+		const mainWindow = await getMainWindow();
+		dialog.showMessageBox( mainWindow, {
 			type: 'error',
 			message: title,
 			detail: message,

--- a/src/lib/windows-helpers.ts
+++ b/src/lib/windows-helpers.ts
@@ -2,6 +2,7 @@ import { app, dialog } from 'electron';
 import path from 'path';
 import sudo from '@vscode/sudo-prompt';
 import { __ } from '@wordpress/i18n';
+import { getMainWindow } from 'src/main-window';
 import { loadUserData, saveUserData } from 'src/storage/user-data';
 
 export async function promptWindowsSpeedUpSites( {
@@ -23,7 +24,8 @@ export async function promptWindowsSpeedUpSites( {
 
 	const buttons = [ AUTOMATIC_UPDATE, NOT_INTERESTED ];
 
-	const { response } = await dialog.showMessageBox( {
+	const mainWindow = await getMainWindow();
+	const { response } = await dialog.showMessageBox( mainWindow, {
 		type: 'question',
 		buttons,
 		title: __( 'Want to speed up site creation?' ),
@@ -43,7 +45,8 @@ export async function promptWindowsSpeedUpSites( {
 			try {
 				await excludeProcessInWindowsDefender();
 			} catch ( _error ) {
-				await dialog.showMessageBox( {
+				const mainWindow = await getMainWindow();
+				await dialog.showMessageBox( mainWindow, {
 					type: 'error',
 					title: __( 'Something went wrong' ),
 					message: __(

--- a/src/updates.ts
+++ b/src/updates.ts
@@ -2,7 +2,8 @@ import { app, autoUpdater, dialog } from 'electron';
 import * as Sentry from '@sentry/electron/main';
 import { sprintf, __ } from '@wordpress/i18n';
 import { AUTO_UPDATE_INTERVAL_MS } from 'src/constants';
-import { isDevRelease } from './lib/version-utils';
+import { isDevRelease } from 'src/lib/version-utils';
+import { getMainWindow } from 'src/main-window';
 
 type UpdpaterState =
 	| 'init'
@@ -152,7 +153,8 @@ function queueUpdateCheck() {
 
 async function showUpdateAvailableNotice() {
 	showManualCheckDialogs = false;
-	await dialog.showMessageBox( {
+	const mainWindow = await getMainWindow();
+	await dialog.showMessageBox( mainWindow, {
 		type: 'info',
 		buttons: [ __( 'OK' ) ],
 		title: __( 'New Version Available' ),
@@ -162,7 +164,8 @@ async function showUpdateAvailableNotice() {
 
 async function showUpdateUnavailableNotice() {
 	showManualCheckDialogs = false;
-	await dialog.showMessageBox( {
+	const mainWindow = await getMainWindow();
+	await dialog.showMessageBox( mainWindow, {
 		type: 'info',
 		buttons: [ __( 'OK' ) ],
 		title: __( 'Application Update' ),
@@ -171,7 +174,8 @@ async function showUpdateUnavailableNotice() {
 }
 
 async function showUpdateReadyToInstallNotice() {
-	const { response } = await dialog.showMessageBox( {
+	const mainWindow = await getMainWindow();
+	const { response } = await dialog.showMessageBox( mainWindow, {
 		type: 'info',
 		buttons: [ __( 'Restart' ), __( 'Later' ) ],
 		title: __( 'Application Update' ),
@@ -194,7 +198,7 @@ function isAppRunningFromDMG(): boolean {
 	return appPath.startsWith( '/Volumes/' ) || appPath.startsWith( '/private/var/folders' );
 }
 
-function showReadOnlyVolumeError( err: Error ) {
+async function showReadOnlyVolumeError( err: Error ) {
 	let detailMessage = '';
 	let detailPath = '';
 	if ( isAppRunningFromDMG() ) {
@@ -221,7 +225,8 @@ function showReadOnlyVolumeError( err: Error ) {
 		console.error( err );
 	}
 
-	dialog.showMessageBox( {
+	const mainWindow = await getMainWindow();
+	await dialog.showMessageBox( mainWindow, {
 		type: 'warning',
 		buttons: [ __( 'OK' ) ],
 		message: __( 'Error updating Studio' ),


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/dotcom-forge/issues/10627

## Proposed Changes

As identified in https://github.com/Automattic/studio/pull/1068, there's a difference between the modals rendered by the app when a `BrowserWindow` instance is passed to `dialog.showMessageBox` and not. 

I've only observed benefits with the window-attached modals (they look better on Mac and allow the main window to continue rendering in the background).

We already render all message boxes displayed with the IPC `showMessageBox` function this way. This PR changes all other `dialog.showMessageBox` calls to take a `BrowserWindow` instance as the first argument, giving us a consistent style across the app.

| Before | After |
| - | - |
| <img width="901" alt="Screenshot 2025-03-17 at 12 28 08" src="https://github.com/user-attachments/assets/22fd6b15-7a90-41fb-81ad-19ea6626be76" /> | <img width="1012" alt="Screenshot 2025-03-17 at 12 27 12" src="https://github.com/user-attachments/assets/de27b47e-42d9-4715-8782-ffca100e5b6d" /> |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Open the application menu and click `Check for updates`
2. Ensure that the modal renders according to the `After` screenshot in the PR description

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
