### PR TITLE
Update translation handling experience

### DIFF
--- a/src/components/site-form.tsx
+++ b/src/components/site-form.tsx
@@ -267,8 +267,7 @@ export const SiteForm = ( {
 	const dispatch = useAppDispatch();
 	const isOffline = useOffline();
 
-	const errorCount = error && customDomainError ? 2 : error || customDomainError ? 1 : 0;
-	const hasErrors = errorCount > 0;
+	const errorCount = [ error, customDomainError ].filter( Boolean ).length;
 
 	const offlineMessage = __( 'Changing WordPress version requires an internet connection.' );
 	const wpVersions = useRootSelector(
@@ -358,7 +357,7 @@ export const SiteForm = ( {
 											{ __( 'Advanced settings' ) }
 										</div>
 									</Button>
-									{ hasErrors && (
+									{ errorCount > 0 && (
 										<span className="text-red-500 text-[13px] leading-[16px] ml-2 flex items-center">
 											<Icon icon={ warning } size={ 16 } className="mr-1 fill-red-500" />
 											{ sprintf(

--- a/src/components/site-form.tsx
+++ b/src/components/site-form.tsx
@@ -372,7 +372,7 @@ export const SiteForm = ( {
 								<div
 									className={ cx(
 										'transition-all duration-500 ease-in-out overflow-hidden flex flex-col gap-2',
-										isAdvancedSettingsVisible ? 'max-h-96 opacity-100' : 'max-h-0 opacity-0'
+										isAdvancedSettingsVisible ? 'max-h-100 opacity-100' : 'max-h-0 opacity-0'
 									) }
 								>
 									<div className={ cx( 'flex flex-col gap-1.5 leading-4 py-2' ) }>

--- a/src/components/site-form.tsx
+++ b/src/components/site-form.tsx
@@ -370,8 +370,8 @@ export const SiteForm = ( {
 								</div>
 								<div
 									className={ cx(
-										'transition-all duration-500 ease-in-out overflow-hidden flex flex-col gap-2',
-										isAdvancedSettingsVisible ? 'max-h-[450px] opacity-100' : 'max-h-0 opacity-0'
+										'transition-all duration-500 ease-in-out overflow-hidden flex flex-col gap-2 interpolate-size-allow-keywords',
+										isAdvancedSettingsVisible ? 'h-auto opacity-100' : 'h-0 opacity-0'
 									) }
 								>
 									<div className={ cx( 'flex flex-col gap-1.5 leading-4 py-2' ) }>

--- a/src/components/site-form.tsx
+++ b/src/components/site-form.tsx
@@ -1,6 +1,6 @@
 import { Icon, SelectControl } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf, _n } from '@wordpress/i18n';
 import { tip, warning, trash, chevronRight, chevronDown, chevronLeft } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { FormEvent, useEffect, useRef, useState } from 'react';
@@ -266,6 +266,10 @@ export const SiteForm = ( {
 	const getDocsLink = useDocsLink();
 	const dispatch = useAppDispatch();
 	const isOffline = useOffline();
+
+	const errorCount = error && customDomainError ? 2 : error || customDomainError ? 1 : 0;
+	const hasErrors = errorCount > 0;
+
 	const offlineMessage = __( 'Changing WordPress version requires an internet connection.' );
 	const wpVersions = useRootSelector(
 		wordpressVersionsSelectors.selectWordPressVersionsWithLatest
@@ -354,12 +358,14 @@ export const SiteForm = ( {
 											{ __( 'Advanced settings' ) }
 										</div>
 									</Button>
-									{ ( error || shouldShowCustomDomainError ) && (
+									{ hasErrors && (
 										<span className="text-red-500 text-[13px] leading-[16px] ml-2 flex items-center">
 											<Icon icon={ warning } size={ 16 } className="mr-1 fill-red-500" />
-											{ error && shouldShowCustomDomainError
-												? __( '2 errors found' )
-												: __( '1 error found' ) }
+											{ sprintf(
+												/* translators: %d: number of errors found */
+												_n( '%d error found', '%d errors found', errorCount ),
+												errorCount
+											) }
 										</span>
 									) }
 								</div>

--- a/src/components/site-form.tsx
+++ b/src/components/site-form.tsx
@@ -371,7 +371,7 @@ export const SiteForm = ( {
 								<div
 									className={ cx(
 										'transition-all duration-500 ease-in-out overflow-hidden flex flex-col gap-2',
-										isAdvancedSettingsVisible ? 'max-h-100 opacity-100' : 'max-h-0 opacity-0'
+										isAdvancedSettingsVisible ? 'max-h-[450px] opacity-100' : 'max-h-0 opacity-0'
 									) }
 								>
 									<div className={ cx( 'flex flex-col gap-1.5 leading-4 py-2' ) }>

--- a/src/components/site-form.tsx
+++ b/src/components/site-form.tsx
@@ -267,7 +267,8 @@ export const SiteForm = ( {
 	const dispatch = useAppDispatch();
 	const isOffline = useOffline();
 
-	const errorCount = [ error, customDomainError ].filter( Boolean ).length;
+	const shouldShowCustomDomainError = useCustomDomain && customDomainError;
+	const errorCount = [ error, shouldShowCustomDomainError ].filter( Boolean ).length;
 
 	const offlineMessage = __( 'Changing WordPress version requires an internet connection.' );
 	const wpVersions = useRootSelector(
@@ -297,7 +298,6 @@ export const SiteForm = ( {
 		chevronIcon = chevronRight;
 	}
 	const generatedDomainName = generateCustomDomainFromSiteName( siteName );
-	const shouldShowCustomDomainError = customDomainError && useCustomDomain;
 
 	return (
 		<form className={ className } onSubmit={ onSubmit }>

--- a/src/index.css
+++ b/src/index.css
@@ -3,6 +3,12 @@
 @tailwind utilities;
 @import '@wordpress/components/build-style/style.css';
 
+@layer utilities {
+	.interpolate-size-allow-keywords {
+		interpolate-size: allow-keywords;
+	}
+}
+
 body {
 	font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
 }

--- a/src/modules/site-settings/edit-site-details.tsx
+++ b/src/modules/site-settings/edit-site-details.tsx
@@ -121,7 +121,7 @@ export default function EditSiteDetails( { currentWpVersion, onSave }: EditSiteD
 				} catch ( wpError ) {
 					console.error( 'Error changing WordPress version:', wpError );
 					const errorMessage = stripAnsi( ( wpError as Error )?.message );
-					setIsChangeWpError( __( 'Error changing WordPress version.' ) );
+					setIsChangeWpError( __( 'Error changing WordPress version' ) );
 					getIpcApi().showErrorMessageBox( {
 						title: __( 'Error changing WordPress version' ),
 						message: errorMessage,

--- a/src/modules/site-settings/edit-site-details.tsx
+++ b/src/modules/site-settings/edit-site-details.tsx
@@ -121,7 +121,6 @@ export default function EditSiteDetails( { currentWpVersion, onSave }: EditSiteD
 				} catch ( wpError ) {
 					console.error( 'Error changing WordPress version:', wpError );
 					const errorMessage = stripAnsi( ( wpError as Error )?.message );
-					setIsChangeWpError( __( 'Error changing WordPress version' ) );
 					getIpcApi().showErrorMessageBox( {
 						title: __( 'Error changing WordPress version' ),
 						message: errorMessage,

--- a/src/modules/site-settings/tests/edit-site-details.test.tsx
+++ b/src/modules/site-settings/tests/edit-site-details.test.tsx
@@ -256,8 +256,6 @@ describe( 'EditSiteDetails', () => {
 				message: 'Update failed',
 			} );
 		} );
-
-		expect( screen.getByText( 'Error changing WordPress version' ) ).toBeInTheDocument();
 	} );
 
 	it( 'should disable form controls when site is being edited', async () => {

--- a/src/modules/site-settings/tests/edit-site-details.test.tsx
+++ b/src/modules/site-settings/tests/edit-site-details.test.tsx
@@ -257,7 +257,7 @@ describe( 'EditSiteDetails', () => {
 			} );
 		} );
 
-		expect( screen.getByText( 'Error changing WordPress version.' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Error changing WordPress version' ) ).toBeInTheDocument();
 	} );
 
 	it( 'should disable form controls when site is being edited', async () => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues
- Fixes STU-79-linear-issue

## Proposed Changes

I propose to improve the translation UX:
- by merging two phrases that differ with a trailing dot
- by adding support for plurals

Also, while testing that, I noticed small bug which makes bottom part of the form invisible when there are two validation errors displayed.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Open a 'Add site' form
2. Trigger cases with one and two validation errors
3. Confirm validation works as expected
4. Confirm the custom domain info text is visible

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?