### PR TITLE
Improvements to site thumbnail generation

### DIFF
--- a/src/screenshot-window.ts
+++ b/src/screenshot-window.ts
@@ -30,7 +30,7 @@ export function createScreenshotWindow( captureUrl: string ) {
 		await window.loadURL( captureUrl );
 		await responseStatusCodePromise;
 		await window.webContents.insertCSS( `
-			body {
+			body, html {
 				overflow: hidden;
 				height: 100vh;
 			}
@@ -39,7 +39,7 @@ export function createScreenshotWindow( captureUrl: string ) {
 			}
 		` );
 
-		await new Promise( ( resolve ) => setTimeout( resolve, 500 ) );
+		await new Promise( ( resolve ) => setTimeout( resolve, 2000 ) );
 		return window.webContents.capturePage();
 	};
 

--- a/src/screenshot-window.ts
+++ b/src/screenshot-window.ts
@@ -12,14 +12,23 @@ export function createScreenshotWindow( captureUrl: string ) {
 		webPreferences: { session: newSession },
 	} );
 
-	const finishedLoading = new Promise< void >( ( resolve ) => {
-		window.webContents.on( 'did-finish-load', () => resolve() );
+	const responseStatusCodePromise = new Promise< void >( ( resolve, reject ) => {
+		newSession.webRequest.onCompleted( ( details ) => {
+			if ( details.resourceType !== 'mainFrame' ) {
+				return;
+			}
+
+			if ( details.statusCode < 200 || details.statusCode >= 400 ) {
+				reject( new Error( `Page returned status code: ${ details.statusCode }` ) );
+			} else {
+				resolve();
+			}
+		} );
 	} );
 
-	window.loadURL( captureUrl );
-
 	const waitForCapture = async () => {
-		await finishedLoading;
+		await window.loadURL( captureUrl );
+		await responseStatusCodePromise;
 		await window.webContents.insertCSS( `
 			body {
 				overflow: hidden;

--- a/src/screenshot-window.ts
+++ b/src/screenshot-window.ts
@@ -39,7 +39,10 @@ export function createScreenshotWindow( captureUrl: string ) {
 			}
 		` );
 
-		await new Promise( ( resolve ) => setTimeout( resolve, 2000 ) );
+		// Oftentimes, web pages need a bit more time for images to load and layouts to settle
+		const LOAD_TIMEOUT = process.platform === 'win32' ? 2000 : 500;
+		await new Promise( ( resolve ) => setTimeout( resolve, LOAD_TIMEOUT ) );
+
 		return window.webContents.capturePage();
 	};
 

--- a/src/site-server.ts
+++ b/src/site-server.ts
@@ -199,9 +199,9 @@ export class SiteServer {
 			.mkdir( outDir, { recursive: true } )
 			.then( waitForCapture )
 			.then( ( image ) => fs.promises.writeFile( outPath, image.toPNG() ) )
-			.catch( ( error ) => {
-				fs.promises.unlink( outPath );
+			.catch( async ( error ) => {
 				Sentry.captureException( error );
+				await fs.promises.unlink( outPath );
 			} )
 			.finally( () => window.destroy() );
 	}

--- a/src/site-server.ts
+++ b/src/site-server.ts
@@ -199,7 +199,10 @@ export class SiteServer {
 			.mkdir( outDir, { recursive: true } )
 			.then( waitForCapture )
 			.then( ( image ) => fs.promises.writeFile( outPath, image.toPNG() ) )
-			.catch( Sentry.captureException )
+			.catch( ( error ) => {
+				fs.promises.unlink( outPath );
+				Sentry.captureException( error );
+			} )
 			.finally( () => window.destroy() );
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/dotcom-forge/issues/10560

## Proposed Changes

- Despite my best efforts, I couldn't come up with a better solution for the Windows thumbnail bug than simply increasing the hard-coded timeout in `waitForCapture`. 
- I also changed the logic so a new thumbnail is not generated (and the old one is removed) when the home page responds with an HTTP error status code. This can happen if port 80 is already busy, for example. 

**QUESTION:** I'm open to suggestions for which behavior to implement when the site home page returns an error. I think generating a thumbnail makes for weird behavior, but maybe it's better to leave the old thumbnail in place, I'm not sure… 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Ping me on Slack to get a site backup for reproducing this error
2. On Windows, create a Studio site from that backup
3. Stop and start the site a few times
4. Ensure that the site thumbnail appears correctly with each restart
5. Quit Studio
6. Have Local installed and start a site with a custom domain 
7. Start Studio
8. Start the Studio site
9. Ensure that the site thumbnail displays `No preview available`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
