### PR TITLE
Fix Sync "Connect a WordPress.com site" modal tabbing and styling

### DIFF
--- a/src/components/sync-sites-modal-selector.tsx
+++ b/src/components/sync-sites-modal-selector.tsx
@@ -213,7 +213,7 @@ function SiteItem( {
 				onClick();
 			} }
 		>
-			<div className="flex flex-col gap-0.5 min-w-0">
+			<div className="flex flex-col gap-0.5 min-w-0 items-start">
 				<div className={ cx( 'a8c-body truncate', ! isSyncable && 'text-a8c-gray-30' ) }>
 					{ site.name }
 				</div>

--- a/src/components/sync-sites-modal-selector.tsx
+++ b/src/components/sync-sites-modal-selector.tsx
@@ -156,7 +156,7 @@ function ListSites( {
 	const sortedSites = getSortedSites( syncSites );
 
 	return (
-		<div className="flex flex-col overflow-y-auto h-full">
+		<div className="flex flex-col overflow-y-auto h-full pt-px">
 			{ sortedSites.map( ( site ) => (
 				<SiteItem
 					key={ site.id }
@@ -193,10 +193,12 @@ function SiteItem( {
 	return (
 		<div
 			className={ cx(
-				'flex py-3 px-8 items-center border-b border-a8c-gray-0 justify-between gap-4',
-				isSelected && 'bg-a8c-blueberry text-white',
+				'flex py-3 px-8 items-center border-b justify-between gap-4',
+				isSelected && 'bg-a8c-blueberry text-white border-a8c-blueberry',
+				! isSelected && 'border-a8c-gray-0',
 				! isSelected && isSyncable && 'hover:bg-a8c-blueberry-5',
-				isSyncable && 'focus:outline-none focus:ring-1 focus:ring-a8c-blueberry'
+				isSyncable &&
+					'focus:outline-none focus:ring-1 focus:ring-a8c-blueberry focus:relative focus:z-10'
 			) }
 			role={ isSyncable ? 'button' : undefined }
 			tabIndex={ isSyncable ? 0 : -1 }

--- a/src/components/sync-sites-modal-selector.tsx
+++ b/src/components/sync-sites-modal-selector.tsx
@@ -301,12 +301,11 @@ function Footer( {
 	const { __ } = useI18n();
 
 	return (
-		<div className="flex px-8 py-4 border-t border-a8c-gray-5 justify-between">
+		<div className="flex px-8 py-4 border-t border-a8c-gray-5 justify-between items-center">
 			<CreateButton
-				variant="secondary"
+				variant="link"
 				selectedSite={ selectedSite }
 				text={ __( 'Create a new WordPress.com site' ) }
-				className="!shadow-none !px-0"
 			/>
 			<div className="flex gap-4">
 				<Button variant="link" onClick={ onRequestClose }>

--- a/src/components/sync-sites-modal-selector.tsx
+++ b/src/components/sync-sites-modal-selector.tsx
@@ -195,9 +195,17 @@ function SiteItem( {
 			className={ cx(
 				'flex py-3 px-8 items-center border-b border-a8c-gray-0 justify-between gap-4',
 				isSelected && 'bg-a8c-blueberry text-white',
-				! isSelected && isSyncable && 'hover:bg-a8c-blueberry-5'
+				! isSelected && isSyncable && 'hover:bg-a8c-blueberry-5',
+				isSyncable && 'focus:outline-none focus:ring-1 focus:ring-a8c-blueberry'
 			) }
 			role={ isSyncable ? 'button' : undefined }
+			tabIndex={ isSyncable ? 0 : -1 }
+			onKeyDown={ ( e: React.KeyboardEvent ) => {
+				if ( e.code === 'Space' && isSyncable ) {
+					e.preventDefault();
+					onClick();
+				}
+			} }
 			onClick={ () => {
 				if ( ! isSyncable ) {
 					return;
@@ -218,6 +226,13 @@ function SiteItem( {
 							: '!text-a8c-gray-30 hover:!text-a8c-gray-30'
 					) }
 					onClick={ () => getIpcApi().openURL( site.url ) }
+					onKeyDown={ ( e: React.KeyboardEvent ) => {
+						if ( e.code === 'Space' ) {
+							e.preventDefault();
+							e.stopPropagation();
+							getIpcApi().openURL( site.url );
+						}
+					} }
 				>
 					{ site.url.replace( /^https?:\/\//, '' ) }
 					<ArrowIcon />

--- a/src/components/sync-sites-modal-selector.tsx
+++ b/src/components/sync-sites-modal-selector.tsx
@@ -213,7 +213,7 @@ function SiteItem( {
 				onClick();
 			} }
 		>
-			<div className="flex flex-col gap-0.5 overflow-hidden">
+			<div className="flex flex-col gap-0.5 min-w-0">
 				<div className={ cx( 'a8c-body truncate', ! isSyncable && 'text-a8c-gray-30' ) }>
 					{ site.name }
 				</div>
@@ -234,7 +234,7 @@ function SiteItem( {
 						}
 					} }
 				>
-					{ site.url.replace( /^https?:\/\//, '' ) }
+					<div className="truncate">{ site.url.replace( /^https?:\/\//, '' ) }</div>
 					<ArrowIcon />
 				</Button>
 			</div>

--- a/src/components/sync-sites-modal-selector.tsx
+++ b/src/components/sync-sites-modal-selector.tsx
@@ -216,7 +216,7 @@ function SiteItem( {
 			} }
 		>
 			<div className="flex flex-col gap-0.5 min-w-0 items-start">
-				<div className={ cx( 'a8c-body truncate', ! isSyncable && 'text-a8c-gray-30' ) }>
+				<div className={ cx( 'a8c-body truncate w-full', ! isSyncable && 'text-a8c-gray-30' ) }>
 					{ site.name }
 				</div>
 				<Button

--- a/src/components/sync-sites-modal-selector.tsx
+++ b/src/components/sync-sites-modal-selector.tsx
@@ -222,7 +222,7 @@ function SiteItem( {
 				<Button
 					variant="link"
 					className={ cx(
-						'a8c-body-small truncate !p-0',
+						'a8c-body-small truncate !p-0 w-full justify-start',
 						isSelected
 							? '!text-inherit hover:!text-inherit'
 							: '!text-a8c-gray-30 hover:!text-a8c-gray-30'

--- a/src/components/sync-sites-modal-selector.tsx
+++ b/src/components/sync-sites-modal-selector.tsx
@@ -203,7 +203,7 @@ function SiteItem( {
 			role={ isSyncable ? 'button' : undefined }
 			tabIndex={ isSyncable ? 0 : -1 }
 			onKeyDown={ ( e: React.KeyboardEvent ) => {
-				if ( e.code === 'Space' && isSyncable ) {
+				if ( ( e.code === 'Space' || e.code === 'Enter' ) && isSyncable ) {
 					e.preventDefault();
 					onClick();
 				}
@@ -229,7 +229,7 @@ function SiteItem( {
 					) }
 					onClick={ () => getIpcApi().openURL( site.url ) }
 					onKeyDown={ ( e: React.KeyboardEvent ) => {
-						if ( e.code === 'Space' ) {
+						if ( e.code === 'Space' || e.code === 'Enter' ) {
 							e.preventDefault();
 							e.stopPropagation();
 							getIpcApi().openURL( site.url );

--- a/src/components/sync-sites-modal-selector.tsx
+++ b/src/components/sync-sites-modal-selector.tsx
@@ -215,14 +215,14 @@ function SiteItem( {
 				onClick();
 			} }
 		>
-			<div className="flex flex-col gap-0.5 min-w-0 items-start">
-				<div className={ cx( 'a8c-body truncate w-full', ! isSyncable && 'text-a8c-gray-30' ) }>
+			<div className="flex flex-col gap-0.5 min-w-0">
+				<div className={ cx( 'a8c-body truncate', ! isSyncable && 'text-a8c-gray-30' ) }>
 					{ site.name }
 				</div>
 				<Button
 					variant="link"
 					className={ cx(
-						'a8c-body-small truncate !p-0 w-full justify-start',
+						'a8c-body-small truncate !p-0 w-full !justify-start',
 						isSelected
 							? '!text-inherit hover:!text-inherit'
 							: '!text-a8c-gray-30 hover:!text-a8c-gray-30'

--- a/src/components/sync-sites-modal-selector.tsx
+++ b/src/components/sync-sites-modal-selector.tsx
@@ -15,6 +15,11 @@ import type { SyncSite } from 'src/hooks/use-fetch-wpcom-sites/types';
 
 const SearchControl = process.env.NODE_ENV === 'test' ? () => null : SearchControlWp;
 
+const focusConnectButton = () => {
+	const connectButton = document.querySelector( 'button#connect-button' ) as HTMLButtonElement;
+	connectButton?.focus();
+};
+
 export function SyncSitesModalSelector( {
 	isLoading,
 	onRequestClose,
@@ -206,6 +211,7 @@ function SiteItem( {
 				if ( ( e.code === 'Space' || e.code === 'Enter' ) && isSyncable ) {
 					e.preventDefault();
 					onClick();
+					focusConnectButton();
 				}
 			} }
 			onClick={ () => {
@@ -317,6 +323,12 @@ function Footer( {
 } ) {
 	const { __ } = useI18n();
 
+	useEffect( () => {
+		if ( ! disabled ) {
+			focusConnectButton();
+		}
+	}, [ disabled ] );
+
 	return (
 		<div className="flex px-8 py-4 border-t border-a8c-gray-5 justify-between items-center">
 			<CreateButton
@@ -328,7 +340,7 @@ function Footer( {
 				<Button variant="link" onClick={ onRequestClose }>
 					{ __( 'Cancel' ) }
 				</Button>
-				<Button variant="primary" disabled={ disabled } onClick={ onConnect }>
+				<Button id="connect-button" variant="primary" disabled={ disabled } onClick={ onConnect }>
 					{ __( 'Connect' ) }
 				</Button>
 			</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

Fixes https://github.com/Automattic/dotcom-forge/issues/10580.

## Proposed Changes

- add outline to site items, allowing to select each one by pressing Spacebar

![Markup on 2025-03-17 at 18:02:58](https://github.com/user-attachments/assets/3382777b-d19b-4c40-91be-88c9a3d9fbef)

- fix outline of sites' address

| Before | After |
|--------|--------|
| ![Markup on 2025-03-18 at 11:36:16](https://github.com/user-attachments/assets/72a58e14-cecc-43e5-a22e-f748bde17bc2) | ![Markup on 2025-03-18 at 11:37:10](https://github.com/user-attachments/assets/4def25e0-6431-482c-a697-d076f0b5e990) | 

- add outline of `Create a new WordPress.com site` button in the modal footer

![Markup on 2025-03-17 at 18:06:36](https://github.com/user-attachments/assets/ad8b2994-951e-47a5-845a-56d953c6121a)

- fix alignment of site's URL

| Before | After |
|--------|--------|
| ![Markup on 2025-03-18 at 11:30:27](https://github.com/user-attachments/assets/fe9309fa-a925-4089-9cea-5b3c0cc2e2d1) | ![Markup on 2025-03-17 at 17:42:06](https://github.com/user-attachments/assets/7b0d32c9-1391-4db5-8bdd-8a7664a22d06) | 

- fix site address truncating (when they are too long)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the branch PR and build the app with `npm start`.
2. Head over to the Sync tab of a local site that does not have any WPCOM site connected yet.
3. Tab through the app elements until you reach the `Connect site` button. Open it with pressing Spacebar.
4. Tab through the elements in the modal. It should be possible to select each site item, but also its URL.
5. If you press Spacebar while the site URL is selected, it should open in a new browser tab / window.
6. If you press Spacebar while the whole site item is selected, it should select it.
7. It should be possible to tab through (and open) the `Enable hosting site features` and `Upgrade plan` links as well (on particular sites).
8. When you tab to the bottom of the list of sites and hit Tab more, it should be possible to select the `Create a new WordPress.com site` and pressing Spacebar should open it in the new browser tab / window. 
9. You may manually make a site name and site URL longer and observe it gets truncated correctly.
10. You may also test the tabbing using VoiceOver. It should work correctly.
11. The site list should work well in RTL locale as well.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
