### PR TITLE
Error handling improvements in `phpGetThemeDetails`

### DIFF
--- a/src/hooks/use-theme-details.tsx
+++ b/src/hooks/use-theme-details.tsx
@@ -77,7 +77,7 @@ export const ThemeDetailsProvider: React.FC< ThemeDetailsProviderProps > = ( { c
 		if ( ! selectedSite?.id || selectedSite.running === false ) {
 			return;
 		}
-		await getIpcApi()?.getThemeDetails?.( selectedSite.id );
+		await getIpcApi().getThemeDetails( selectedSite.id );
 	} );
 
 	useEffect( () => {
@@ -89,7 +89,7 @@ export const ThemeDetailsProvider: React.FC< ThemeDetailsProviderProps > = ( { c
 			for ( const site of sites ) {
 				if ( site.themeDetails ) {
 					newThemeDetails[ site.id ] = { ...site.themeDetails };
-					const thumbnailData = await getIpcApi()?.getThumbnailData?.( site.id );
+					const thumbnailData = await getIpcApi().getThumbnailData( site.id );
 					newThumbnailData[ site.id ] = thumbnailData ?? undefined;
 				}
 			}

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -826,14 +826,17 @@ export async function showItemInFolder( _event: IpcMainInvokeEvent, path: string
 	shell.showItemInFolder( path );
 }
 
-export async function getThemeDetails( event: IpcMainInvokeEvent, id: string ) {
+export async function getThemeDetails(
+	event: IpcMainInvokeEvent,
+	id: string
+): Promise< StartedSiteDetails[ 'themeDetails' ] > {
 	const server = SiteServer.get( id );
 	if ( ! server ) {
 		throw new Error( 'Site not found.' );
 	}
 
 	if ( ! server.details.running || ! server.server ) {
-		return null;
+		return undefined;
 	}
 	const themeDetails = await phpGetThemeDetails( server.server );
 

--- a/src/lib/php-get-theme-details.ts
+++ b/src/lib/php-get-theme-details.ts
@@ -1,5 +1,14 @@
-import * as Sentry from '@sentry/electron/main';
+import { z } from 'zod';
 import SiteServerProcess from 'src/lib/site-server-process';
+
+export const themeDetailsSchema = z.object( {
+	name: z.string().catch( '' ),
+	path: z.string(),
+	slug: z.string(),
+	isBlockTheme: z.boolean(),
+	supportsWidgets: z.boolean(),
+	supportsMenus: z.boolean(),
+} );
 
 export async function phpGetThemeDetails(
 	server: SiteServerProcess
@@ -8,13 +17,11 @@ export async function phpGetThemeDetails(
 		throw Error( 'PHP is not instantiated' );
 	}
 
-	let themeDetails = null;
 	const themeDetailsPhp = `<?php
 	require_once('${ server.php.documentRoot }/wp-load.php');
 	$theme = wp_get_theme();
 	echo json_encode([
 		'name' => $theme->get('Name'),
-		'uri' => $theme->get('ThemeURI'),
 		'path' => $theme->get_stylesheet_directory(),
 		'slug' => $theme->get_stylesheet(),
 		'isBlockTheme' => $theme->is_block_theme(),
@@ -22,16 +29,14 @@ export async function phpGetThemeDetails(
 		'supportsMenus' => get_registered_nav_menus() || current_theme_supports('menus'),
 	]);
 	`;
+
 	try {
-		themeDetails = await server.runPhp( {
+		const themeDetailsRaw = await server.runPhp( {
 			code: themeDetailsPhp,
 		} );
-		themeDetails = JSON.parse( themeDetails );
+		const themeDetailsParsed = JSON.parse( themeDetailsRaw );
+		return themeDetailsSchema.parse( themeDetailsParsed );
 	} catch ( error ) {
-		Sentry.captureException( error, {
-			extra: { themeDetails },
-		} );
-		themeDetails = null;
+		return undefined;
 	}
-	return themeDetails;
 }

--- a/src/lib/php-get-theme-details.ts
+++ b/src/lib/php-get-theme-details.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import SiteServerProcess from 'src/lib/site-server-process';
 
-export const themeDetailsSchema = z.object( {
+const themeDetailsSchema = z.object( {
 	name: z.string().catch( '' ),
 	path: z.string(),
 	slug: z.string(),


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/dotcom-forge/issues/10646
- Fixes https://github.com/Automattic/dotcom-forge/issues/7291

## Proposed Changes

- Stop sending exceptions thrown in `phpGetThemeDetails` to Sentry. These exceptions indicate more general errors with the PHP-WASM environments and don't tell us anything useful.
- Parse the PHP output with zod to ensure we conform to the expected schema.

> [!IMPORTANT]  
> This PR should also fix some of the Sentry issues connected with https://github.com/Automattic/dotcom-forge/issues/7291. The underlying cause of timeout errors varies depending on the message name (`start-server`, `stop-server`, or `run-php`). `run-php` indicates an error in `phpGetThemeDetails` and it'll be fixed by this PR (by simply not reporting those errors to Sentry anymore). 
>
> Not reporting to Sentry may seem like a non-solution, but I believe it's viable because the fact that PHP execution fails is not always within our control (it could be due to PHP-WASM problems, or issues with the WP installation, etc). We also recently improved the logic for killing unresponsive processes in https://github.com/Automattic/studio/pull/1067.
> 
> https://github.com/Automattic/dotcom-forge/issues/7291 has grouped several timeout errors, and the ones related to `start-server` messages will not be affected by this PR. I will create new GitHub issues for tracking those.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Have a Studio site
2. Open the `appdata-v1.json` file in your editor
3. Go to wp-admin and change the theme
4. Ensure that the `themeDetails` value for your site was updated correctly in `appdata-v1.json`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
