### PR TITLE
Start proxy during site start and improve error wording

### DIFF
--- a/src/hooks/use-site-details.tsx
+++ b/src/hooks/use-site-details.tsx
@@ -287,7 +287,9 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 			} catch ( error ) {
 				if (
 					error instanceof Error &&
-					error.message.includes( 'Studio failed to start the proxy server' )
+					error.message.includes(
+						'Studio failed to start the proxy server because port 80 is already in use'
+					)
 				) {
 					getIpcApi().showErrorMessageBox( {
 						title: __( 'Studio failed to initialize custom domains' ),

--- a/src/hooks/use-site-details.tsx
+++ b/src/hooks/use-site-details.tsx
@@ -285,14 +285,27 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 			try {
 				updatedSite = await getIpcApi().startServer( id );
 			} catch ( error ) {
-				getIpcApi().showErrorMessageBox( {
-					title: __( 'Failed to start the site server' ),
-					message: __(
-						"Please verify your site's local path directory contains the standard WordPress installation files and try again. If this problem persists, please contact support."
-					),
-					error,
-					showOpenLogs: true,
-				} );
+				if (
+					error instanceof Error &&
+					error.message.includes( 'Studio failed to start the proxy server' )
+				) {
+					getIpcApi().showErrorMessageBox( {
+						title: __( 'Studio failed to initialize custom domains' ),
+						message: __(
+							'Studio needs to use port 80, but it’s already in use by another app. Close any local development apps and restart Studio.'
+						),
+						showOpenLogs: false,
+					} );
+				} else {
+					getIpcApi().showErrorMessageBox( {
+						title: __( 'Failed to start the site server' ),
+						message: __(
+							"Please verify your site's local path directory contains the standard WordPress installation files and try again. If this problem persists, please contact support."
+						),
+						error,
+						showOpenLogs: true,
+					} );
+				}
 				await getIpcApi().stopServer( id );
 			}
 

--- a/src/hooks/use-site-details.tsx
+++ b/src/hooks/use-site-details.tsx
@@ -288,7 +288,7 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 				if (
 					error instanceof Error &&
 					error.message.includes(
-						'Studio failed to start the proxy server because port 80 is already in use'
+						'Studio failed to start the proxy server because port 80 is already in use.'
 					)
 				) {
 					getIpcApi().showErrorMessageBox( {
@@ -297,6 +297,17 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 							'Studio needs to use port 80 to enable custom domains, but it’s already in use by another app. Close any local development apps and restart Studio.'
 						),
 						showOpenLogs: false,
+					} );
+				} else if (
+					error instanceof Error &&
+					error.message.includes( 'Studio failed to start the proxy server.' )
+				) {
+					getIpcApi().showErrorMessageBox( {
+						title: __( 'Studio failed to initialize custom domains' ),
+						message: __(
+							'Please restart Studio and try again. If this problem persists, please contact support.'
+						),
+						showOpenLogs: true,
 					} );
 				} else {
 					getIpcApi().showErrorMessageBox( {

--- a/src/hooks/use-site-details.tsx
+++ b/src/hooks/use-site-details.tsx
@@ -292,7 +292,7 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 					getIpcApi().showErrorMessageBox( {
 						title: __( 'Studio failed to initialize custom domains' ),
 						message: __(
-							'Studio needs to use port 80, but it’s already in use by another app. Close any local development apps and restart Studio.'
+							'Studio needs to use port 80 to enable custom domains, but it’s already in use by another app. Close any local development apps and restart Studio.'
 						),
 						showOpenLogs: false,
 					} );

--- a/src/hooks/use-site-details.tsx
+++ b/src/hooks/use-site-details.tsx
@@ -285,12 +285,7 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 			try {
 				updatedSite = await getIpcApi().startServer( id );
 			} catch ( error ) {
-				if (
-					error instanceof Error &&
-					error.message.includes(
-						'Studio failed to start the proxy server because port 80 is already in use.'
-					)
-				) {
+				if ( error instanceof Error && error.message.includes( 'PROXY_ERROR_PORT_80_IN_USE' ) ) {
 					getIpcApi().showErrorMessageBox( {
 						title: __( 'Studio failed to initialize custom domains' ),
 						message: __(
@@ -300,7 +295,7 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 					} );
 				} else if (
 					error instanceof Error &&
-					error.message.includes( 'Studio failed to start the proxy server.' )
+					error.message.includes( 'PROXY_ERROR_START_FAILED' )
 				) {
 					getIpcApi().showErrorMessageBox( {
 						title: __( 'Studio failed to initialize custom domains' ),

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,7 @@ import {
 } from 'src/lib/cli';
 import { getUserLocaleWithFallback } from 'src/lib/locale-node';
 import { onOpenUrlCallback } from 'src/lib/oauth';
-import { startProxyServer, stopProxyServer } from 'src/lib/proxy-server';
+import { stopProxyServer } from 'src/lib/proxy-server';
 import { getSentryReleaseInfo } from 'src/lib/sentry-release';
 import { setupLogging } from 'src/logging';
 import { createMainWindow, getMainWindow } from 'src/main-window';
@@ -265,20 +265,6 @@ async function appBoot() {
 		Sentry.setUser( { id: userData.sentryUserId } );
 
 		createMainWindow();
-
-		// Start the proxy server for custom domains
-		try {
-			const proxyStarted = await startProxyServer();
-			if ( proxyStarted ) {
-				console.log( 'Custom domain proxy server started successfully' );
-			} else {
-				console.warn(
-					'Failed to start custom domain proxy server - custom domains will require port numbers'
-				);
-			}
-		} catch ( error ) {
-			console.error( 'Error starting proxy server:', error );
-		}
 
 		// Handle CLI commands
 		listenCLICommands();

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -403,9 +403,6 @@ export async function startServer(
 	// Handle custom domain if necessary
 	if ( server.details.customDomain ) {
 		await addDomainToHosts( server.details.customDomain, server.details.port );
-		console.log(
-			`Domain ${ server.details.customDomain } added to hosts file for port ${ server.details.port }`
-		);
 
 		const proxyStarted = await startProxyServer();
 		if ( ! proxyStarted ) {

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -403,13 +403,7 @@ export async function startServer(
 	// Handle custom domain if necessary
 	if ( server.details.customDomain ) {
 		await addDomainToHosts( server.details.customDomain, server.details.port );
-
-		const proxyStarted = await startProxyServer();
-		if ( ! proxyStarted ) {
-			console.warn(
-				'Failed to start custom domain proxy server - custom domains will require port numbers'
-			);
-		}
+		await startProxyServer();
 	}
 
 	const parentWindow = BrowserWindow.fromWebContents( event.sender );

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -407,17 +407,11 @@ export async function startServer(
 			`Domain ${ server.details.customDomain } added to hosts file for port ${ server.details.port }`
 		);
 
-		try {
-			const proxyStarted = await startProxyServer();
-			if ( ! proxyStarted ) {
-				console.warn(
-					'Failed to start custom domain proxy server - custom domains will require port numbers'
-				);
-			}
-			console.log( 'Custom domain proxy server started successfully' );
-		} catch ( error ) {
-			console.error( 'Error starting proxy server:', error );
-			throw error;
+		const proxyStarted = await startProxyServer();
+		if ( ! proxyStarted ) {
+			console.warn(
+				'Failed to start custom domain proxy server - custom domains will require port numbers'
+			);
 		}
 	}
 

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -42,6 +42,7 @@ import * as oauthClient from 'src/lib/oauth';
 import { createPassword } from 'src/lib/passwords';
 import { phpGetThemeDetails } from 'src/lib/php-get-theme-details';
 import { portFinder } from 'src/lib/port-finder';
+import { startProxyServer } from 'src/lib/proxy-server';
 import { shellOpenExternalWrapper } from 'src/lib/shell-open-external-wrapper';
 import { sortSites } from 'src/lib/sort-sites';
 import { installSqliteIntegration, keepSqliteIntegrationUpdated } from 'src/lib/sqlite-versions';
@@ -405,6 +406,19 @@ export async function startServer(
 		console.log(
 			`Domain ${ server.details.customDomain } added to hosts file for port ${ server.details.port }`
 		);
+
+		try {
+			const proxyStarted = await startProxyServer();
+			if ( ! proxyStarted ) {
+				console.warn(
+					'Failed to start custom domain proxy server - custom domains will require port numbers'
+				);
+			}
+			console.log( 'Custom domain proxy server started successfully' );
+		} catch ( error ) {
+			console.error( 'Error starting proxy server:', error );
+			throw error;
+		}
 	}
 
 	const parentWindow = BrowserWindow.fromWebContents( event.sender );

--- a/src/lib/hosts-file.ts
+++ b/src/lib/hosts-file.ts
@@ -95,6 +95,7 @@ export const addDomainToHosts = async ( domain: string, port: number ): Promise<
 
 		if ( newContent !== hostsContent ) {
 			await writeHostsFile( newContent );
+			console.log( `Domain ${ domain } added to hosts file for port ${ port }` );
 		}
 	} catch ( error ) {
 		Sentry.captureException( error );

--- a/src/lib/proxy-server.ts
+++ b/src/lib/proxy-server.ts
@@ -1,4 +1,3 @@
-import { dialog } from 'electron';
 import http from 'http';
 import { createConnection } from 'node:net';
 import { domainToASCII } from 'node:url';
@@ -6,7 +5,6 @@ import * as Sentry from '@sentry/electron/main';
 import { __ } from '@wordpress/i18n';
 import httpProxy from 'http-proxy';
 import { isErrnoException } from 'src/lib/is-errno-exception';
-import { getMainWindow } from 'src/main-window';
 import { SiteServer } from 'src/site-server';
 import { loadUserData } from 'src/storage/user-data';
 
@@ -117,8 +115,7 @@ export async function startProxyServer(): Promise< boolean > {
 					resolve();
 				} )
 				.on( 'error', ( err ) => {
-					console.log( err );
-					console.error( `Error starting proxy server on port 80:`, err );
+					console.error( `Error starting proxy server on port 80` );
 					reject( err );
 				} );
 		} );
@@ -129,16 +126,7 @@ export async function startProxyServer(): Promise< boolean > {
 			( isErrnoException( error ) && error.code === 'EADDRINUSE' ) ||
 			( error instanceof Error && error.message === 'EADDRINUSE' )
 		) {
-			const mainWindow = await getMainWindow();
-			dialog.showMessageBox( mainWindow, {
-				type: 'error',
-				message: __( 'Studio failed to initialize custom domains' ),
-				detail: __(
-					'Studio needs to use port 80, but it’s already in use by another app. Close any local development apps and restart Studio.'
-				),
-				buttons: [ __( 'OK' ) ],
-			} );
-			return false;
+			throw new Error( 'Studio failed to start the proxy server' );
 		}
 
 		Sentry.captureException( error );

--- a/src/lib/proxy-server.ts
+++ b/src/lib/proxy-server.ts
@@ -132,7 +132,7 @@ export async function startProxyServer(): Promise< boolean > {
 			const mainWindow = await getMainWindow();
 			dialog.showMessageBox( mainWindow, {
 				type: 'error',
-				message: __( 'Studio failed to start a proxy server' ),
+				message: __( 'Studio failed to initialize custom domains' ),
 				detail: __(
 					'Studio needs to use port 80, but it’s already in use by another app. Close any local development apps and restart Studio.'
 				),

--- a/src/lib/proxy-server.ts
+++ b/src/lib/proxy-server.ts
@@ -126,13 +126,14 @@ export async function startProxyServer(): Promise< boolean > {
 			( error instanceof Error && error.message === 'EADDRINUSE' )
 		) {
 			throw new Error(
-				'Studio failed to start the proxy server because port 80 is already in use'
+				'Studio failed to start the proxy server because port 80 is already in use.'
 			);
 		}
 
 		Sentry.captureException( error );
-		console.error( `Failed to start proxy server directly:`, error );
-		return false;
+		console.error( `Failed to start proxy server:`, error );
+
+		throw new Error( 'Studio failed to start the proxy server.' );
 	}
 }
 

--- a/src/lib/proxy-server.ts
+++ b/src/lib/proxy-server.ts
@@ -2,7 +2,6 @@ import http from 'http';
 import { createConnection } from 'node:net';
 import { domainToASCII } from 'node:url';
 import * as Sentry from '@sentry/electron/main';
-import { __ } from '@wordpress/i18n';
 import httpProxy from 'http-proxy';
 import { isErrnoException } from 'src/lib/is-errno-exception';
 import { SiteServer } from 'src/site-server';

--- a/src/lib/proxy-server.ts
+++ b/src/lib/proxy-server.ts
@@ -132,7 +132,7 @@ export async function startProxyServer(): Promise< boolean > {
 			const mainWindow = await getMainWindow();
 			dialog.showMessageBox( mainWindow, {
 				type: 'error',
-				message: __( 'Custom domain set up failed' ),
+				message: __( 'Studio failed to start a proxy server' ),
 				detail: __(
 					'Studio needs to use port 80, but it’s already in use by another app. Close any local development apps and restart Studio.'
 				),

--- a/src/lib/proxy-server.ts
+++ b/src/lib/proxy-server.ts
@@ -125,15 +125,13 @@ export async function startProxyServer(): Promise< boolean > {
 			( isErrnoException( error ) && error.code === 'EADDRINUSE' ) ||
 			( error instanceof Error && error.message === 'EADDRINUSE' )
 		) {
-			throw new Error(
-				'Studio failed to start the proxy server because port 80 is already in use.'
-			);
+			throw new Error( 'PROXY_ERROR_PORT_80_IN_USE' );
 		}
 
 		Sentry.captureException( error );
 		console.error( `Failed to start proxy server:`, error );
 
-		throw new Error( 'Studio failed to start the proxy server.' );
+		throw new Error( 'PROXY_ERROR_START_FAILED' );
 	}
 }
 

--- a/src/lib/proxy-server.ts
+++ b/src/lib/proxy-server.ts
@@ -125,7 +125,9 @@ export async function startProxyServer(): Promise< boolean > {
 			( isErrnoException( error ) && error.code === 'EADDRINUSE' ) ||
 			( error instanceof Error && error.message === 'EADDRINUSE' )
 		) {
-			throw new Error( 'Studio failed to start the proxy server' );
+			throw new Error(
+				'Studio failed to start the proxy server because port 80 is already in use'
+			);
 		}
 
 		Sentry.captureException( error );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/dotcom-forge/issues/10644

## Proposed Changes

A "Custom domain set up failed" error is displayed immediately after user starts Studio, even if the user doesn't use a custom domain. I propose to improve Proxy error wording to be more informative about what happened:

<img width="1012" alt="Screenshot 2025-03-18 at 16 19 17" src="https://github.com/user-attachments/assets/06641fb4-14b0-4a82-af26-b00377df15b1" />

Also, I delay starting the proxy until the user tries to start a site that uses custom domains, so users who have port 80 busy and start Studio won't see error immediately.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Start a local web server app, e.g., Local
2. Start Studio
3. Confirm there is no error about custom domains displayed
4. Start a site that doesn't use custom domains
5. Confirm there is no error about custom domains displayed
4. Start a site that uses custom domains
7. Confirm that the error message is displayed and that the new wording is clear
8. Close Studio and other web server that uses 80 port
9. Repeat above steps and confirm there is no error message and that site is accessible using custom domain 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
