### PR TITLE
Add EADDRINUSE error on Windows when port 80 is already in use

### DIFF
--- a/src/lib/proxy-server.ts
+++ b/src/lib/proxy-server.ts
@@ -83,24 +83,31 @@ export async function startProxyServer(): Promise< boolean > {
 		} );
 
 		// On Windows, we need to check if the port is in use before we can listen on it
-		await new Promise< void >( ( resolve, reject ) => {
-			const tester = createConnection( { port: 80 }, () => {
-				// If we can connect, port is in use
-				tester.end();
-				const error = new Error( 'Port 80 is in use' ) as NodeJS.ErrnoException;
-				error.code = 'EADDRINUSE';
-				reject( error );
-			} );
+		if ( process.platform === 'win32' ) {
+			await new Promise< void >( ( resolve, reject ) => {
+				const tester = createConnection( { port: 80 }, () => {
+					// If we can connect, port is in use
+					tester.end();
+					const error = new Error( 'Port 80 is in use' ) as NodeJS.ErrnoException;
+					error.code = 'EADDRINUSE';
+					reject( error );
+				} );
 
-			tester.on( 'error', ( err: NodeJS.ErrnoException ) => {
-				if ( err.code === 'ECONNREFUSED' ) {
-					// Port is available
-					resolve();
-				} else {
-					reject( err );
-				}
+				tester.setTimeout( 1000, () => {
+					tester.destroy();
+					reject( new Error( 'Port check timed out' ) );
+				} );
+
+				tester.on( 'error', ( err: NodeJS.ErrnoException ) => {
+					if ( err.code === 'ECONNREFUSED' ) {
+						// Port is available
+						resolve();
+					} else {
+						reject( err );
+					}
+				} );
 			} );
-		} );
+		}
 
 		await new Promise< void >( ( resolve, reject ) => {
 			proxyServer!

--- a/src/lib/proxy-server.ts
+++ b/src/lib/proxy-server.ts
@@ -1,5 +1,6 @@
 import { dialog } from 'electron';
 import http from 'http';
+import { createConnection } from 'node:net';
 import { domainToASCII } from 'node:url';
 import * as Sentry from '@sentry/electron/main';
 import { __ } from '@wordpress/i18n';
@@ -81,6 +82,26 @@ export async function startProxyServer(): Promise< boolean > {
 			} );
 		} );
 
+		// On Windows, we need to check if the port is in use before we can listen on it
+		await new Promise< void >( ( resolve, reject ) => {
+			const tester = createConnection( { port: 80 }, () => {
+				// If we can connect, port is in use
+				tester.end();
+				const error = new Error( 'Port 80 is in use' ) as NodeJS.ErrnoException;
+				error.code = 'EADDRINUSE';
+				reject( error );
+			} );
+
+			tester.on( 'error', ( err: NodeJS.ErrnoException ) => {
+				if ( err.code === 'ECONNREFUSED' ) {
+					// Port is available
+					resolve();
+				} else {
+					reject( err );
+				}
+			} );
+		} );
+
 		await new Promise< void >( ( resolve, reject ) => {
 			proxyServer!
 				.listen( 80, () => {
@@ -97,12 +118,7 @@ export async function startProxyServer(): Promise< boolean > {
 
 		return true;
 	} catch ( error ) {
-		const errorCodes = [ 'EADDRINUSE', 'WSAEADDRINUSE' ];
-		if (
-			error instanceof Error &&
-			'code' in error &&
-			errorCodes.includes( error.code as string )
-		) {
+		if ( error instanceof Error && 'code' in error && error.code === 'EADDRINUSE' ) {
 			const mainWindow = await getMainWindow();
 			dialog.showMessageBox( mainWindow, {
 				type: 'error',

--- a/src/lib/proxy-server.ts
+++ b/src/lib/proxy-server.ts
@@ -126,7 +126,7 @@ export async function startProxyServer(): Promise< boolean > {
 		return true;
 	} catch ( error ) {
 		if (
-			( error instanceof Error && isErrnoException( error ) && error.code === 'EADDRINUSE' ) ||
+			( isErrnoException( error ) && error.code === 'EADDRINUSE' ) ||
 			( error instanceof Error && error.message === 'EADDRINUSE' )
 		) {
 			const mainWindow = await getMainWindow();

--- a/src/lib/proxy-server.ts
+++ b/src/lib/proxy-server.ts
@@ -97,7 +97,12 @@ export async function startProxyServer(): Promise< boolean > {
 
 		return true;
 	} catch ( error ) {
-		if ( error instanceof Error && 'code' in error && error.code === 'EADDRINUSE' ) {
+		const errorCodes = [ 'EADDRINUSE', 'WSAEADDRINUSE' ];
+		if (
+			error instanceof Error &&
+			'code' in error &&
+			errorCodes.includes( error.code as string )
+		) {
 			const mainWindow = await getMainWindow();
 			dialog.showMessageBox( mainWindow, {
 				type: 'error',

--- a/src/lib/proxy-server.ts
+++ b/src/lib/proxy-server.ts
@@ -5,6 +5,7 @@ import { domainToASCII } from 'node:url';
 import * as Sentry from '@sentry/electron/main';
 import { __ } from '@wordpress/i18n';
 import httpProxy from 'http-proxy';
+import { isErrnoException } from 'src/lib/is-errno-exception';
 import { getMainWindow } from 'src/main-window';
 import { SiteServer } from 'src/site-server';
 import { loadUserData } from 'src/storage/user-data';
@@ -82,24 +83,23 @@ export async function startProxyServer(): Promise< boolean > {
 			} );
 		} );
 
-		// On Windows, we need to check if the port is in use before we can listen on it
+		// On Windows, node doesn't throw an error if port 80 is busy, so we use the net module to explicitly check
+		// if it's possible to establish a TCP connection to that port (meaning it's busy)
 		if ( process.platform === 'win32' ) {
 			await new Promise< void >( ( resolve, reject ) => {
 				const tester = createConnection( { port: 80 }, () => {
 					// If we can connect, port is in use
 					tester.end();
-					const error = new Error( 'Port 80 is in use' ) as NodeJS.ErrnoException;
-					error.code = 'EADDRINUSE';
-					reject( error );
+					reject( new Error( 'EADDRINUSE' ) );
 				} );
 
 				tester.setTimeout( 1000, () => {
 					tester.destroy();
-					reject( new Error( 'Port check timed out' ) );
+					reject( new Error( 'EADDRINUSE' ) );
 				} );
 
-				tester.on( 'error', ( err: NodeJS.ErrnoException ) => {
-					if ( err.code === 'ECONNREFUSED' ) {
+				tester.on( 'error', ( err ) => {
+					if ( isErrnoException( err ) && err.code === 'ECONNREFUSED' ) {
 						// Port is available
 						resolve();
 					} else {
@@ -125,7 +125,10 @@ export async function startProxyServer(): Promise< boolean > {
 
 		return true;
 	} catch ( error ) {
-		if ( error instanceof Error && 'code' in error && error.code === 'EADDRINUSE' ) {
+		if (
+			( error instanceof Error && isErrnoException( error ) && error.code === 'EADDRINUSE' ) ||
+			( error instanceof Error && error.message === 'EADDRINUSE' )
+		) {
 			const mainWindow = await getMainWindow();
 			dialog.showMessageBox( mainWindow, {
 				type: 'error',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/dotcom-forge/issues/10626

## Proposed Changes

- Added Windows-specific port availability check before starting the proxy server
- Implemented a port tester using createConnection from node:net to verify if port 80 is available
- Added timeout handling (1 second) for the port check, I opted to be safe and assume that if the host is unreachable we won't be able to start a new server on that port, so an error is shown to the user.

**Note**: I couldn't understand why Windows doesn't catch the error when we create the server.
That would be the ideal scenario, but this solution should achieve the same result at a marginal cost, of doing an extra request to assert port availability.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Port already in use
- Test on a Windows machine where port 80 is already in use by another application (e.g., Local with a custom domain site)
- The application should properly detect that the port is in use and handle the error

2. Port available
- Test on a Windows machine where port 80 is available
- The proxy server should start successfully
- Create and start a site with a custom domain and validate it works

3. macOS
- Test both scenarios above in macOS and confirm the same behavior

4. Tester timeout
- Adjust to code to simulate timeout scenarios. Examples:
    - unreachable host - by doing `const tester = createConnection( { port: 80, host: '240.0.0.0' }, () => { ...`
    - smaller tester timeout - `tester.setTimeout( 1, () => {`
- Both tests should result in the warning.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
