### PR TITLE
Memorize WP version selectors and fix bottom margin styles

### DIFF
--- a/src/components/site-form.tsx
+++ b/src/components/site-form.tsx
@@ -409,6 +409,7 @@ export const SiteForm = ( {
 													} ) ) }
 													onChange={ setPhpVersion as ( value: string ) => void }
 													__next40pxDefaultSize
+													__nextHasNoMarginBottom
 												/>
 											</div>
 											<div className="flex flex-col gap-1.5 leading-4">
@@ -439,8 +440,9 @@ export const SiteForm = ( {
 																  ]
 														}
 														onChange={ setWpVersion }
-														__next40pxDefaultSize
 														disabled={ isOffline }
+														__next40pxDefaultSize
+														__nextHasNoMarginBottom
 													/>
 												</Tooltip>
 											</div>

--- a/src/stores/wordpress-versions-slice.ts
+++ b/src/stores/wordpress-versions-slice.ts
@@ -1,4 +1,4 @@
-import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
+import { createSlice, createAsyncThunk, createSelector } from '@reduxjs/toolkit';
 import * as Sentry from '@sentry/electron/renderer';
 import { __ } from '@wordpress/i18n';
 import { z, ZodError } from 'zod';
@@ -111,22 +111,27 @@ const wordpressVersionsSlice = createSlice( {
 	},
 	selectors: {
 		selectWordPressVersions: ( state ) => state.versions,
-		selectWordPressVersionsWithLatest: ( state ) => {
-			let foundLatestStable = false;
-			return state.versions.map( ( version ) => {
-				if ( ! foundLatestStable && ! version.isBeta ) {
-					foundLatestStable = true;
-					return {
-						...version,
-						label: `${ version.label } (${ __( 'latest' ) })`,
-					};
-				}
-				return version;
-			} );
-		},
-		selectLatestStableVersion: ( state ) => {
-			return state.versions.find( ( version ) => ! version.isBeta );
-		},
+		selectWordPressVersionsWithLatest: createSelector(
+			[ ( state ) => state.versions ],
+			( versions: WordPressVersion[] ) => {
+				let foundLatestStable = false;
+				return versions.map( ( version: WordPressVersion ) => {
+					if ( ! foundLatestStable && ! version.isBeta ) {
+						foundLatestStable = true;
+						return {
+							...version,
+							label: `${ version.label } (${ __( 'latest' ) })`,
+						};
+					}
+					return version;
+				} );
+			}
+		),
+		selectLatestStableVersion: createSelector(
+			[ ( state ) => state.versions ],
+			( versions: WordPressVersion[] ) =>
+				versions.find( ( version: WordPressVersion ) => ! version.isBeta )
+		),
 	},
 } );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/dotcom-forge/issues/10650.

## Proposed Changes

While working on Studio today I noticed the following console warnings:

![Markup on 2025-03-18 at 18:38:37](https://github.com/user-attachments/assets/0a24c98c-8890-42ff-95a4-c1c48743f07b)

![Markup on 2025-03-18 at 18:46:40](https://github.com/user-attachments/assets/726e02bf-dd16-4192-9e68-bcd5869d7d5c)

The goal of this PR is fix them.

- memorize `selectWordPressVersionsWithLatest` and `selectLatestStableVersion` selectors
- add `__nextHasNoMarginBottom` to `SelectControl` elements

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR branch and build the app with `npm start`.
2. Trigger any UI that relies on the above selectors and `SelectControl` with the console open, e.g.:
  - click on `Add site` in the sidebar
  - click on the `Settings` tab of a particular site
3. There should be no warnings visible.
4. The WP versions' listing and selection / update should still work as expected. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
