### PR TITLE
Add the Tailwind utility class interpolate-size-allow-keywords to improve site form animation

### DIFF
--- a/src/components/site-form.tsx
+++ b/src/components/site-form.tsx
@@ -369,8 +369,8 @@ export const SiteForm = ( {
 								</div>
 								<div
 									className={ cx(
-										'transition-all duration-500 ease-in-out overflow-hidden flex flex-col gap-2',
-										isAdvancedSettingsVisible ? 'max-h-[450px] opacity-100' : 'max-h-0 opacity-0'
+										'transition-all duration-500 ease-in-out overflow-hidden flex flex-col gap-2 interpolate-size-allow-keywords',
+										isAdvancedSettingsVisible ? 'h-auto opacity-100' : 'h-0 opacity-0'
 									) }
 								>
 									<div className={ cx( 'flex flex-col gap-1.5 leading-4 py-2' ) }>

--- a/src/index.css
+++ b/src/index.css
@@ -3,6 +3,12 @@
 @tailwind utilities;
 @import '@wordpress/components/build-style/style.css';
 
+@layer utilities {
+	.interpolate-size-allow-keywords {
+		interpolate-size: allow-keywords;
+	}
+}
+
 body {
 	font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- https://github.com/Automattic/studio/pull/1078#discussion_r2005174984

## Proposed Changes

- Add new Tailwind utility class `interpolate-size-allow-keywords` to use height auto in animations https://developer.mozilla.org/en-US/docs/Web/CSS/interpolate-size

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run `npm start`
- Click on Add Site
- Expand and collapse the "Advance settings"
- Observe the animation runs smoothly


https://github.com/user-attachments/assets/a31d823c-f4e7-4f3c-ae3e-98c9af39c6a4



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
