### PR TITLE
Studio: Add STUDIO_WHATS_NEW_SECTION feature flag

### DIFF
--- a/src/hooks/use-feature-flags.tsx
+++ b/src/hooks/use-feature-flags.tsx
@@ -11,15 +11,18 @@ const featureFlagsSchema = z
 		terminal_wp_cli_enabled: z.boolean().optional(),
 		quick_deploys_enabled: z.boolean().optional(),
 		wp_versions_enabled: z.boolean().optional(),
+		whats_new_section_enabled: z.boolean().optional(),
 	} )
 	.catch( ( _ ) => ( {} ) );
 
 export interface FeatureFlagsContextType {
 	terminalWpCliEnabled: boolean;
+	whatsNewSectionEnabled: boolean;
 }
 
 export const FeatureFlagsContext = createContext< FeatureFlagsContextType >( {
 	terminalWpCliEnabled: false,
+	whatsNewSectionEnabled: false,
 } );
 
 interface FeatureFlagsProviderProps {
@@ -28,8 +31,10 @@ interface FeatureFlagsProviderProps {
 
 export const FeatureFlagsProvider: React.FC< FeatureFlagsProviderProps > = ( { children } ) => {
 	const terminalWpCliEnabledFromGlobals = getAppGlobals().terminalWpCliEnabled;
+	const whatsNewSectionEnabledFromGlobals = getAppGlobals().whatsNewSectionEnabled;
 	const [ featureFlags, setFeatureFlags ] = useState< FeatureFlagsContextType >( {
 		terminalWpCliEnabled: terminalWpCliEnabledFromGlobals,
+		whatsNewSectionEnabled: whatsNewSectionEnabledFromGlobals,
 	} );
 	const { isAuthenticated, client } = useAuth();
 
@@ -51,6 +56,8 @@ export const FeatureFlagsProvider: React.FC< FeatureFlagsProviderProps > = ( { c
 				setFeatureFlags( {
 					terminalWpCliEnabled:
 						Boolean( flags.terminal_wp_cli_enabled ) || terminalWpCliEnabledFromGlobals,
+					whatsNewSectionEnabled:
+						Boolean( flags.whats_new_section_enabled ) || whatsNewSectionEnabledFromGlobals,
 				} );
 			} catch ( error ) {
 				Sentry.captureException( error );
@@ -61,7 +68,12 @@ export const FeatureFlagsProvider: React.FC< FeatureFlagsProviderProps > = ( { c
 		return () => {
 			cancel = true;
 		};
-	}, [ isAuthenticated, client, terminalWpCliEnabledFromGlobals ] );
+	}, [
+		isAuthenticated,
+		client,
+		terminalWpCliEnabledFromGlobals,
+		whatsNewSectionEnabledFromGlobals,
+	] );
 
 	return (
 		<FeatureFlagsContext.Provider value={ featureFlags }>{ children }</FeatureFlagsContext.Provider>

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -770,6 +770,7 @@ export async function getAppGlobals( _event: IpcMainInvokeEvent ): Promise< AppG
 		appName: app.name,
 		arm64Translation: app.runningUnderARM64Translation,
 		terminalWpCliEnabled: process.env.STUDIO_TERMINAL_WP_CLI === 'true',
+		whatsNewSectionEnabled: process.env.STUDIO_WHATS_NEW_SECTION_ENABLED === 'true',
 	};
 }
 

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -770,7 +770,7 @@ export async function getAppGlobals( _event: IpcMainInvokeEvent ): Promise< AppG
 		appName: app.name,
 		arm64Translation: app.runningUnderARM64Translation,
 		terminalWpCliEnabled: process.env.STUDIO_TERMINAL_WP_CLI === 'true',
-		whatsNewSectionEnabled: process.env.STUDIO_WHATS_NEW_SECTION_ENABLED === 'true',
+		whatsNewSectionEnabled: process.env.STUDIO_WHATS_NEW_SECTION === 'true',
 	};
 }
 

--- a/src/ipc-types.d.ts
+++ b/src/ipc-types.d.ts
@@ -85,6 +85,7 @@ interface AppGlobals {
 	appName: string;
 	arm64Translation: boolean;
 	terminalWpCliEnabled: boolean;
+	whatsNewSectionEnabled: boolean;
 }
 
 // Our IPC objects will be attached to the `window` global


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

STU-220-linear-issue

## Proposed Changes

This PR adds `STUDIO_WHATS_NEW_SECTION` feature flag to Studio. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run STUDIO_WHATS_NEW_SECTION=true npm start
* Add a console log in:

```diff --git a/src/hooks/use-feature-flags.tsx b/src/hooks/use-feature-flags.tsx
index 7bdd3ddd..7023d81a 100644
--- a/src/hooks/use-feature-flags.tsx
+++ b/src/hooks/use-feature-flags.tsx
@@ -67,7 +67,7 @@ export const FeatureFlagsProvider: React.FC< FeatureFlagsProviderProps > = ( { c
 			cancel = true;
 		};
 	}, [ isAuthenticated, client, terminalWpCliEnabledFromGlobals, wpVersionsEnabledFromGlobals ] );
-
+	console.log( 'featureFlags', featureFlags );
 	return (
 		<FeatureFlagsContext.Provider value={ featureFlags }>{ children }</FeatureFlagsContext.Provider>
 	);
```

* Open the chrome dev tools
* Observe that the feature flag `whatsNewSectionEnabled` is set to `true`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?