### PR TITLE
studio cli boostrap files

### DIFF
--- a/bin/studio-cli.bat
+++ b/bin/studio-cli.bat
@@ -2,6 +2,6 @@
 setlocal
 
 set ELECTRON_RUN_AS_NODE=1
-call "%~dp0..\..\..\Studio.exe" "%~dp0..\cli\index.js" %*
+call "%~dp0..\..\Studio.exe" "%~dp0..\cli\index.js" %*
 
 endlocal 

--- a/bin/studio-cli.bat
+++ b/bin/studio-cli.bat
@@ -1,0 +1,7 @@
+@echo off
+setlocal
+
+set ELECTRON_RUN_AS_NODE=1
+call "%~dp0..\..\..\Studio.exe" "%~dp0..\cli\index.js" %*
+
+endlocal 

--- a/bin/studio-cli.sh
+++ b/bin/studio-cli.sh
@@ -5,7 +5,7 @@ function realpath() {
   /usr/bin/perl -e "use Cwd;print Cwd::abs_path(@ARGV[0])" "$0";
 }
 
-CONTENTS="$(command dirname "$(command dirname "$(command dirname "$(command dirname "$(realpath "$0")")")")")"
+CONTENTS="$(command dirname "$(command dirname "$(command dirname "$(realpath "$0")")")")"
 BINARY_NAME="$(TERM=dumb command ls "$CONTENTS/MacOS/")"
 ELECTRON="$CONTENTS/MacOS/$BINARY_NAME"
 CLI="$CONTENTS/Resources/app/cli/index.js"

--- a/bin/studio-cli.sh
+++ b/bin/studio-cli.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# The least terrible way to resolve a symlink to its real path.
+function realpath() {
+  /usr/bin/perl -e "use Cwd;print Cwd::abs_path(@ARGV[0])" "$0";
+}
+
+CONTENTS="$(command dirname "$(command dirname "$(command dirname "$(command dirname "$(realpath "$0")")")")")"
+BINARY_NAME="$(TERM=dumb command ls "$CONTENTS/MacOS/")"
+ELECTRON="$CONTENTS/MacOS/$BINARY_NAME"
+CLI="$CONTENTS/Resources/app/cli/index.js"
+
+ELECTRON_RUN_AS_NODE=1 "$ELECTRON" "$CLI" "$@"
+
+exit $? 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-248-linear-issue

## Proposed Changes

- Added CLI bootstrap scripts for both Windows and Mac

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Prerequisites
1. Build and install the Studio app (we need this so the scripts exist in bin):
   ```bash
   npm run make
   ```

### Testing Steps

 1. First, create a test script at:
     -  `/Applications/Studio.app/Contents/Resources/cli-test.js` (Mac)
     - `C:\Users\<username>\AppData\Local\Programs\studio\app-1.3.8\resources` (Windows)
   ```javascript
   console.log('CLI Test');
   console.log('Arguments:', process.argv.slice(2));
   ```
2. Then modify the CLI scripts to point to the test file:

   **Mac** - Edit `/Applications/Studio.app/Contents/Resources/bin/studio-cli.sh`:
   ```bash
   # Change the CLI line to:
   CLI="$CONTENTS/Resources/cli-test.js"
   ```

   **Windows** - Edit `.\resources\bin\studio-cli.bat`:
   ```batch
   # Change the call line to:
   call "%~dp0..\cli-test.js" %*
   ```

 3. Then test with:
   ```bash
   # Mac - No arguments
   /Applications/Studio.app/Contents/Resources/bin/studio-cli.sh
   # Expected output:
   # CLI Test
   # Arguments: []

   # Mac - With arguments
   /Applications/Studio.app/Contents/Resources/bin/studio-cli.sh --test arg1 arg2
   # Expected output:
   # CLI Test
   # Arguments: [ '--test', 'arg1', 'arg2' ]

   # Windows - Similar tests using studio-cli.bat
   ```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?