### PR TITLE
Site updates: Regenerate domain certificate when the domain is changed

### DIFF
--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -27,7 +27,6 @@ import { download } from 'src/lib/download';
 import { isEmptyDir, pathExists, isWordPressDirectory, sanitizeFolderName } from 'src/lib/fs-utils';
 import { getImageData } from 'src/lib/get-image-data';
 import { getSyncBackupTempPath } from 'src/lib/get-sync-backup-temp-path';
-import { addDomainToHosts, updateDomainInHosts } from 'src/lib/hosts-file';
 import { exportBackup } from 'src/lib/import-export/export/export-manager';
 import { ExportOptions } from 'src/lib/import-export/export/types';
 import { ImportExportEventData } from 'src/lib/import-export/handle-events';
@@ -42,7 +41,6 @@ import * as oauthClient from 'src/lib/oauth';
 import { createPassword } from 'src/lib/passwords';
 import { phpGetThemeDetails } from 'src/lib/php-get-theme-details';
 import { portFinder } from 'src/lib/port-finder';
-import { startProxyServer } from 'src/lib/proxy-server';
 import { shellOpenExternalWrapper } from 'src/lib/shell-open-external-wrapper';
 import { sortSites } from 'src/lib/sort-sites';
 import { installSqliteIntegration, keepSqliteIntegrationUpdated } from 'src/lib/sqlite-versions';
@@ -55,10 +53,7 @@ import { SiteServer, createSiteWorkingDirectory } from 'src/site-server';
 import { DEFAULT_SITE_PATH, getResourcesPath, getSiteThumbnailPath } from 'src/storage/paths';
 import { loadUserData, saveUserData } from 'src/storage/user-data';
 import { DEFAULT_PHP_VERSION } from 'vendor/wp-now/src/constants';
-import {
-	generateSiteCertificate,
-	openCertificate as openCertificateDialog,
-} from './lib/certificate-manager';
+import { openCertificate as openCertificateDialog } from './lib/certificate-manager';
 import type { SyncSite } from 'src/hooks/use-fetch-wpcom-sites/types';
 import type { WpCliResult } from 'src/lib/wp-cli-process';
 
@@ -227,10 +222,6 @@ export async function updateSite(
 	updatedSite: SiteDetails
 ): Promise< SiteDetails[] > {
 	const userData = await loadUserData();
-
-	const existingSite = userData.sites.find( ( site ) => site.id === updatedSite.id );
-	const oldDomain = existingSite?.customDomain;
-	const newDomain = updatedSite.customDomain;
 	const updatedSites = userData.sites.map( ( site ) =>
 		site.id === updatedSite.id ? updatedSite : site
 	);
@@ -238,15 +229,7 @@ export async function updateSite(
 
 	const server = SiteServer.get( updatedSite.id );
 	if ( server ) {
-		server.updateSiteDetails( updatedSite );
-
-		// Handle domain changes and url changes (updates hosts and database)
-		if ( oldDomain !== newDomain ) {
-			updateDomainInHosts( oldDomain, newDomain, server.details.port );
-		}
-		if ( ( oldDomain && ! newDomain ) || updatedSite.enableHttps !== existingSite?.enableHttps ) {
-			await updateSiteUrlToLocal( updatedSite.id );
-		}
+		await server.updateSiteDetails( updatedSite );
 	}
 	await saveUserData( userData );
 	return mergeSiteDetailsWithRunningDetails( userData.sites );
@@ -417,26 +400,6 @@ export async function startServer(
 	}
 
 	await keepSqliteIntegrationUpdated( server.details.path );
-
-	// Handle custom domain if necessary
-	if ( server.details.customDomain ) {
-		await addDomainToHosts( server.details.customDomain, server.details.port );
-		// Generate certificates for HTTPS sites *before* the server starts
-		// This ensures the certs are ready when the proxy server needs them
-		if ( server.details.enableHttps ) {
-			console.log(
-				`Generating certificates for ${ server.details.customDomain } during server start`
-			);
-
-			const { cert, key } = await generateSiteCertificate( server.details.customDomain );
-			server.details = {
-				...server.details,
-				tlsKey: key,
-				tlsCert: cert,
-			};
-		}
-		await startProxyServer();
-	}
 
 	const parentWindow = BrowserWindow.fromWebContents( event.sender );
 	try {

--- a/src/lib/certificate-manager.ts
+++ b/src/lib/certificate-manager.ts
@@ -262,3 +262,28 @@ export async function generateSiteCertificate(
 		throw error;
 	}
 }
+
+/**
+ * Delete the certificate files for a specific domain
+ */
+export function deleteSiteCertificate( domain: string ): boolean {
+	try {
+		const siteCertPath = path.join( CERT_DIRECTORY, 'domains', `${ domain }.crt` );
+		const siteKeyPath = path.join( CERT_DIRECTORY, 'domains', `${ domain }.key` );
+		let deletedFiles = false;
+		if ( fs.existsSync( siteCertPath ) ) {
+			fs.unlinkSync( siteCertPath );
+			deletedFiles = true;
+		}
+		if ( fs.existsSync( siteKeyPath ) ) {
+			fs.unlinkSync( siteKeyPath );
+			deletedFiles = true;
+		}
+
+		return deletedFiles;
+	} catch ( error ) {
+		Sentry.captureException( error );
+		console.error( `Failed to delete certificate for ${ domain }:`, error );
+		return false;
+	}
+}

--- a/src/lib/import-export/tests/import/import-manager.test.ts
+++ b/src/lib/import-export/tests/import/import-manager.test.ts
@@ -8,6 +8,9 @@ import { Importer } from 'src/lib/import-export/import/importers/importer';
 import { BackupContents, BackupArchiveInfo } from 'src/lib/import-export/import/types';
 import { Validator } from 'src/lib/import-export/import/validators/validator';
 
+jest.mock( 'src/storage/paths', () => ( {
+	getUserDataCertificatesPath: jest.fn().mockReturnValue( '/tmp/certificates' ),
+} ) );
 jest.mock( 'src/lib/import-export/import/handlers/backup-handler-factory' );
 jest.mock( 'fs/promises' );
 jest.mock( 'os' );

--- a/src/site-server.ts
+++ b/src/site-server.ts
@@ -3,8 +3,9 @@ import nodePath from 'path';
 import * as Sentry from '@sentry/electron/main';
 import fsExtra from 'fs-extra';
 import { parse } from 'shell-quote';
+import { deleteSiteCertificate, generateSiteCertificate } from 'src/lib/certificate-manager';
 import { pathExists, recursiveCopyDirectory, isEmptyDir } from 'src/lib/fs-utils';
-import { removeDomainFromHosts } from 'src/lib/hosts-file';
+import { addDomainToHosts, removeDomainFromHosts, updateDomainInHosts } from 'src/lib/hosts-file';
 import { decodePassword } from 'src/lib/passwords';
 import { phpGetThemeDetails } from 'src/lib/php-get-theme-details';
 import { portFinder } from 'src/lib/port-finder';
@@ -18,6 +19,8 @@ import { getWpNowConfig } from 'vendor/wp-now/src';
 import { WPNowMode } from 'vendor/wp-now/src/config';
 import { DEFAULT_PHP_VERSION, SQLITE_FILENAME } from 'vendor/wp-now/src/constants';
 import { getWordPressVersionPath, downloadWordPress } from 'vendor/wp-now/src/download';
+import { startProxyServer } from './lib/proxy-server';
+import { updateSiteUrlToLocal } from './lib/update-site-url-to-local';
 
 const servers = new Map< string, SiteServer >();
 const deletedServers: string[] = [];
@@ -102,6 +105,13 @@ export class SiteServer {
 			}
 		}
 
+		if ( this.details.customDomain && this.details.enableHttps ) {
+			const certificateDeleted = deleteSiteCertificate( this.details.customDomain ?? '' );
+			if ( certificateDeleted ) {
+				console.log( `Certificates for ${ this.details.customDomain } have been deleted` );
+			}
+		}
+
 		await this.stop();
 		await this.wpCliExecutor?.stop();
 		deletedServers.push( this.details.id );
@@ -112,6 +122,26 @@ export class SiteServer {
 	async start() {
 		if ( this.details.running || this.server ) {
 			return;
+		}
+
+		// Handle custom domain if necessary
+		if ( this.details.customDomain ) {
+			await addDomainToHosts( this.details.customDomain, this.details.port );
+			// Generate certificates for HTTPS sites *before* the server starts
+			// This ensures the certs are ready when the proxy server needs them
+			if ( this.details.enableHttps ) {
+				console.log(
+					`Generating certificates for ${ this.details.customDomain } during server start`
+				);
+
+				const { cert, key } = await generateSiteCertificate( this.details.customDomain );
+				this.details = {
+					...this.details,
+					tlsKey: key,
+					tlsCert: cert,
+				};
+			}
+			await startProxyServer();
 		}
 
 		const options = await getWpNowConfig( {
@@ -151,7 +181,12 @@ export class SiteServer {
 		};
 	}
 
-	updateSiteDetails( site: SiteDetails ) {
+	async updateSiteDetails( site: SiteDetails ) {
+		const oldDomain = this.details.customDomain;
+		const newDomain = site.customDomain;
+		const oldEnableHttps = this.details.enableHttps;
+		const newEnableHttps = site.enableHttps;
+
 		this.details = {
 			...this.details,
 			name: site.name,
@@ -165,6 +200,34 @@ export class SiteServer {
 		if ( this.server && this.details.running ) {
 			this.details.url = getAbsoluteUrl( this.details );
 			this.server.url = this.details.url;
+		}
+
+		// Handle domain changes and url changes (updates hosts and database)
+		if ( oldDomain !== newDomain ) {
+			updateDomainInHosts( oldDomain, newDomain, this.details.port );
+		}
+		if ( ( oldDomain && ! newDomain ) || oldEnableHttps !== newEnableHttps ) {
+			await updateSiteUrlToLocal( this.details.id );
+		}
+
+		if (
+			oldDomain &&
+			oldEnableHttps &&
+			( oldDomain !== newDomain || oldEnableHttps !== newEnableHttps )
+		) {
+			deleteSiteCertificate( oldDomain );
+		}
+		if (
+			newDomain &&
+			newEnableHttps &&
+			( oldDomain !== newDomain || oldEnableHttps !== newEnableHttps )
+		) {
+			const { cert, key } = await generateSiteCertificate( newDomain );
+			this.details = {
+				...this.details,
+				tlsKey: key,
+				tlsCert: cert,
+			};
 		}
 	}
 


### PR DESCRIPTION
Related STU-19-linear-issue

## Proposed Changes

This PR fixes a couple small bugs and makes a small related refactoring:

- Bug 1: When changing the custom domain name for a given site with HTTPs enabled, the certificate is regenerated properly for that site.
- Bug 2: Avoid lingering certificates when sites are removed.
- Refactoring: The logic to updates hosts file and certificates was sometimes implemented in ipc-handlers and sometimes in the server class, this moves all the logic to the server class.

## Testing Instructions

- Create a site
- Run the server
- Change custom domain
- Enable/disable HTTPs
- Rename the custom domain

On each step, the site should function properly (assuming the root certificate is trusted)
- Also removing the site, removes the certificate from the file system.
