### PR TITLE
SSL Support: Hide all HTTPS help messages when the certificate is trusted

### DIFF
--- a/src/components/content-tab-settings.tsx
+++ b/src/components/content-tab-settings.tsx
@@ -4,6 +4,7 @@ import { useI18n } from '@wordpress/react-i18n';
 import { PropsWithChildren } from 'react';
 import { CopyTextButton } from 'src/components/copy-text-button';
 import DeleteSite from 'src/components/delete-site';
+import { useCertificateTrust } from 'src/hooks/use-certificate-trust';
 import { useGetWpVersion } from 'src/hooks/use-get-wp-version';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 import { decodePassword } from 'src/lib/passwords';
@@ -26,6 +27,7 @@ function SettingsRow( { children, label }: PropsWithChildren< { label: string } 
 
 export function ContentTabSettings( { selectedSite }: ContentTabSettingsProps ) {
 	const { __ } = useI18n();
+	const isCertificateTrusted = useCertificateTrust();
 	const username = 'admin';
 	// Empty strings account for legacy sites lacking a stored password.
 	const storedPassword = decodePassword( selectedSite.adminPassword ?? '' );
@@ -75,13 +77,13 @@ export function ContentTabSettings( { selectedSite }: ContentTabSettingsProps ) 
 					<SettingsRow label={ __( 'HTTPS' ) }>
 						<div>
 							<span>{ selectedSite.enableHttps ? __( 'Enabled' ) : __( 'Disabled' ) }</span>{ ' ' }
-							{ selectedSite.enableHttps && (
+							{ ! isCertificateTrusted && selectedSite.enableHttps && (
 								<Button variant="link" onClick={ () => getIpcApi().openCertificate() }>
 									{ __( 'Trust Certificate' ) }
 								</Button>
 							) }
 						</div>
-						{ selectedSite.enableHttps && (
+						{ ! isCertificateTrusted && selectedSite.enableHttps && (
 							<div className="mt-1 max-w-96">
 								<span className="text-a8c-gray-50 mt-1">
 									{ __(

--- a/src/components/site-form.tsx
+++ b/src/components/site-form.tsx
@@ -13,7 +13,6 @@ import { ACCEPTED_IMPORT_FILE_TYPES } from 'src/constants';
 import { useCertificateTrust } from 'src/hooks/use-certificate-trust';
 import { useI18nData } from 'src/hooks/use-i18n-data';
 import { useOffline } from 'src/hooks/use-offline';
-import { isWindows } from 'src/lib/app-globals';
 import { cx } from 'src/lib/cx';
 import { generateCustomDomainFromSiteName } from 'src/lib/domains';
 import { getIpcApi } from 'src/lib/get-ipc-api';
@@ -468,27 +467,24 @@ export const SiteForm = ( {
 											</div>
 										) }
 
-										{ ! isCertificateTrusted &&
-											! isWindows() &&
-											useCustomDomain &&
-											setEnableHttps && (
-												<div className="text-a8c-gray-50 text-xs mt-2">
-													{ __(
-														'You need to manually add the Studio root certificate authority to your keychain and trust it to enable HTTPS.'
-													) }{ ' ' }
-													<Button
-														variant="link"
-														onClick={ () => {
-															getIpcApi().openURL(
-																'https://developer.wordpress.com/docs/developer-tools/studio/ssl-in-studio/'
-															);
-														} }
-													>
-														{ __( 'Learn how' ) }
-														<span aria-label={ __( '(opens in a web browser)' ) }>&#8599;</span>
-													</Button>
-												</div>
-											) }
+										{ ! isCertificateTrusted && useCustomDomain && setEnableHttps && (
+											<div className="text-a8c-gray-50 text-xs mt-2">
+												{ __(
+													'You need to manually add the Studio root certificate authority to your keychain and trust it to enable HTTPS.'
+												) }{ ' ' }
+												<Button
+													variant="link"
+													onClick={ () => {
+														getIpcApi().openURL(
+															'https://developer.wordpress.com/docs/developer-tools/studio/ssl-in-studio/'
+														);
+													} }
+												>
+													{ __( 'Learn how' ) }
+													<span aria-label={ __( '(opens in a web browser)' ) }>&#8599;</span>
+												</Button>
+											</div>
+										) }
 									</div>
 								</div>
 							</>

--- a/src/components/site-form.tsx
+++ b/src/components/site-form.tsx
@@ -4,16 +4,18 @@ import { __, sprintf, _n } from '@wordpress/i18n';
 import { tip, warning, trash, chevronRight, chevronDown, chevronLeft } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { FormEvent, useRef, useState } from 'react';
+import { useDocsLink } from 'src/hooks/use-docs-link';
 import Button from 'src/components/button';
 import FolderIcon from 'src/components/folder-icon';
 import TextControlComponent from 'src/components/text-control';
 import { WPVersionSelector } from 'src/components/wp-version-selector';
 import { ACCEPTED_IMPORT_FILE_TYPES } from 'src/constants';
+import { useCertificateTrust } from 'src/hooks/use-certificate-trust';
 import { useI18nData } from 'src/hooks/use-i18n-data';
+import { useOffline } from 'src/hooks/use-offline';
 import { isWindows } from 'src/lib/app-globals';
 import { cx } from 'src/lib/cx';
 import { generateCustomDomainFromSiteName } from 'src/lib/domains';
-import { getDocsLink } from 'src/lib/get-docs-link';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 import {
 	DEFAULT_WORDPRESS_VERSION,
@@ -265,12 +267,21 @@ export const SiteForm = ( {
 }: SiteFormProps ) => {
 	const { __, isRTL } = useI18n();
 	const { locale } = useI18nData();
+	const getDocsLink = useDocsLink();
+	const isOffline = useOffline();
+	const isCertificateTrusted = useCertificateTrust();
 
 	const shouldShowCustomDomainError = useCustomDomain && customDomainError;
 	const errorCount = [ error, shouldShowCustomDomainError ].filter( Boolean ).length;
 
 	const [ isAdvancedSettingsVisible, setAdvancedSettingsVisible ] = useState( false );
-
+	/*
+	useEffect( () => {
+		if ( useCustomDomain && enableHttps && ! isCertificateTrusted && ! isWindows() ) {
+			getIpcApi().openCertificate();
+		}
+	}, [ useCustomDomain, enableHttps, isCertificateTrusted ] );
+*/
 	const handleAdvancedSettingsClick = () => {
 		setAdvancedSettingsVisible( ! isAdvancedSettingsVisible );
 	};
@@ -463,24 +474,27 @@ export const SiteForm = ( {
 											</div>
 										) }
 
-										{ ! isWindows() && useCustomDomain && setEnableHttps && (
-											<div className="text-a8c-gray-50 text-xs mt-2">
-												{ __(
-													'You need to manually add the Studio root certificate authority to your keychain and trust it to enable HTTPS.'
-												) }{ ' ' }
-												<Button
-													variant="link"
-													onClick={ () => {
-														getIpcApi().openURL(
-															'https://developer.wordpress.com/docs/developer-tools/studio/ssl-in-studio/'
-														);
-													} }
-												>
-													{ __( 'Learn how' ) }
-													<span aria-label={ __( '(opens in a web browser)' ) }>&#8599;</span>
-												</Button>
-											</div>
-										) }
+										{ ! isCertificateTrusted &&
+											! isWindows() &&
+											useCustomDomain &&
+											setEnableHttps && (
+												<div className="text-a8c-gray-50 text-xs mt-2">
+													{ __(
+														'You need to manually add the Studio root certificate authority to your keychain and trust it to enable HTTPS.'
+													) }{ ' ' }
+													<Button
+														variant="link"
+														onClick={ () => {
+															getIpcApi().openURL(
+																'https://developer.wordpress.com/docs/developer-tools/studio/ssl-in-studio/'
+															);
+														} }
+													>
+														{ __( 'Learn how' ) }
+														<span aria-label={ __( '(opens in a web browser)' ) }>&#8599;</span>
+													</Button>
+												</div>
+											) }
 									</div>
 								</div>
 							</>

--- a/src/components/site-form.tsx
+++ b/src/components/site-form.tsx
@@ -3,7 +3,7 @@ import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf, _n } from '@wordpress/i18n';
 import { tip, warning, trash, chevronRight, chevronDown, chevronLeft } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
-import { FormEvent, useRef, useState } from 'react';
+import { FormEvent, useRef, useState, useEffect } from 'react';
 import Button from 'src/components/button';
 import FolderIcon from 'src/components/folder-icon';
 import TextControlComponent from 'src/components/text-control';
@@ -266,6 +266,13 @@ export const SiteForm = ( {
 	const { __, isRTL } = useI18n();
 	const { locale } = useI18nData();
 	const isCertificateTrusted = useCertificateTrust();
+
+	// If the custom domain is enabled and the root certificate is trusted, enable HTTPS
+	useEffect( () => {
+		if ( useCustomDomain && isCertificateTrusted && setEnableHttps ) {
+			setEnableHttps( true );
+		}
+	}, [ useCustomDomain, isCertificateTrusted, setEnableHttps ] );
 
 	const shouldShowCustomDomainError = useCustomDomain && customDomainError;
 	const errorCount = [ error, shouldShowCustomDomainError ].filter( Boolean ).length;

--- a/src/components/site-form.tsx
+++ b/src/components/site-form.tsx
@@ -275,13 +275,7 @@ export const SiteForm = ( {
 	const errorCount = [ error, shouldShowCustomDomainError ].filter( Boolean ).length;
 
 	const [ isAdvancedSettingsVisible, setAdvancedSettingsVisible ] = useState( false );
-	/*
-	useEffect( () => {
-		if ( useCustomDomain && enableHttps && ! isCertificateTrusted && ! isWindows() ) {
-			getIpcApi().openCertificate();
-		}
-	}, [ useCustomDomain, enableHttps, isCertificateTrusted ] );
-*/
+
 	const handleAdvancedSettingsClick = () => {
 		setAdvancedSettingsVisible( ! isAdvancedSettingsVisible );
 	};

--- a/src/components/site-form.tsx
+++ b/src/components/site-form.tsx
@@ -11,7 +11,6 @@ import { WPVersionSelector } from 'src/components/wp-version-selector';
 import { ACCEPTED_IMPORT_FILE_TYPES } from 'src/constants';
 import { useCertificateTrust } from 'src/hooks/use-certificate-trust';
 import { useI18nData } from 'src/hooks/use-i18n-data';
-import { useOffline } from 'src/hooks/use-offline';
 import { cx } from 'src/lib/cx';
 import { generateCustomDomainFromSiteName } from 'src/lib/domains';
 import { getDocsLink } from 'src/lib/get-docs-link';
@@ -266,7 +265,6 @@ export const SiteForm = ( {
 }: SiteFormProps ) => {
 	const { __, isRTL } = useI18n();
 	const { locale } = useI18nData();
-	const isOffline = useOffline();
 	const isCertificateTrusted = useCertificateTrust();
 
 	const shouldShowCustomDomainError = useCustomDomain && customDomainError;

--- a/src/components/site-form.tsx
+++ b/src/components/site-form.tsx
@@ -4,7 +4,6 @@ import { __, sprintf, _n } from '@wordpress/i18n';
 import { tip, warning, trash, chevronRight, chevronDown, chevronLeft } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { FormEvent, useRef, useState } from 'react';
-import { useDocsLink } from 'src/hooks/use-docs-link';
 import Button from 'src/components/button';
 import FolderIcon from 'src/components/folder-icon';
 import TextControlComponent from 'src/components/text-control';
@@ -15,6 +14,7 @@ import { useI18nData } from 'src/hooks/use-i18n-data';
 import { useOffline } from 'src/hooks/use-offline';
 import { cx } from 'src/lib/cx';
 import { generateCustomDomainFromSiteName } from 'src/lib/domains';
+import { getDocsLink } from 'src/lib/get-docs-link';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 import {
 	DEFAULT_WORDPRESS_VERSION,
@@ -266,7 +266,6 @@ export const SiteForm = ( {
 }: SiteFormProps ) => {
 	const { __, isRTL } = useI18n();
 	const { locale } = useI18nData();
-	const getDocsLink = useDocsLink();
 	const isOffline = useOffline();
 	const isCertificateTrusted = useCertificateTrust();
 

--- a/src/components/tests/add-site.test.tsx
+++ b/src/components/tests/add-site.test.tsx
@@ -45,6 +45,7 @@ jest.mock( 'src/lib/get-ipc-api', () => ( {
 	__esModule: true,
 	default: jest.fn(),
 	getIpcApi: () => ( {
+		isCATrusted: jest.fn( () => Promise.resolve( true ) ),
 		showOpenFolderDialog: mockShowOpenFolderDialog,
 		generateProposedSitePath: mockGenerateProposedSitePath,
 		getAllCustomDomains: mockGetAllCustomDomains,

--- a/src/components/tests/content-tab-settings.test.tsx
+++ b/src/components/tests/content-tab-settings.test.tsx
@@ -85,6 +85,7 @@ describe( 'ContentTabSettings', () => {
 			openLocalPath,
 			generateProposedSitePath,
 			getAllCustomDomains,
+			isCATrusted: jest.fn( () => Promise.resolve( true ) ),
 		} );
 
 		store.dispatch( testActions.resetState() );

--- a/src/components/tests/onboarding.test.tsx
+++ b/src/components/tests/onboarding.test.tsx
@@ -53,6 +53,7 @@ jest.mock( 'src/lib/get-ipc-api', () => ( {
 		} ),
 		promptWindowsSpeedUpSites: jest.fn(),
 		openURL: jest.fn(),
+		isCATrusted: jest.fn( () => Promise.resolve( true ) ),
 	} ),
 } ) );
 

--- a/src/hooks/use-certificate-trust.ts
+++ b/src/hooks/use-certificate-trust.ts
@@ -1,0 +1,33 @@
+import { useEffect, useState } from 'react';
+import { getIpcApi } from 'src/lib/get-ipc-api';
+
+/**
+ * Custom hook that checks if the Studio CA certificate is trusted on the system
+ * @returns A boolean indicating if the certificate is trusted
+ */
+export function useCertificateTrust(): boolean {
+	const [ isTrusted, setIsTrusted ] = useState< boolean >( false );
+
+	useEffect( () => {
+		let isMounted = true;
+
+		const checkCertificateTrust = async () => {
+			try {
+				const trusted = await getIpcApi().isCATrusted();
+				if ( isMounted ) {
+					setIsTrusted( trusted );
+				}
+			} catch ( error ) {
+				console.error( 'Error checking certificate trust status:', error );
+			}
+		};
+
+		checkCertificateTrust();
+
+		return () => {
+			isMounted = false;
+		};
+	}, [] );
+
+	return isTrusted;
+}

--- a/src/hooks/use-certificate-trust.ts
+++ b/src/hooks/use-certificate-trust.ts
@@ -1,4 +1,5 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useWindowListener } from 'src/hooks/use-window-listener';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 
 /**
@@ -6,28 +7,28 @@ import { getIpcApi } from 'src/lib/get-ipc-api';
  * @returns A boolean indicating if the certificate is trusted
  */
 export function useCertificateTrust(): boolean {
+	const isMounted = useRef( true );
 	const [ isTrusted, setIsTrusted ] = useState< boolean >( false );
 
-	useEffect( () => {
-		let isMounted = true;
-
-		const checkCertificateTrust = async () => {
-			try {
-				const trusted = await getIpcApi().isCATrusted();
-				if ( isMounted ) {
+	const checkCertificateTrust = useCallback( () => {
+		getIpcApi()
+			.isCATrusted()
+			.then( ( trusted ) => {
+				if ( isMounted.current ) {
 					setIsTrusted( trusted );
 				}
-			} catch ( error ) {
-				console.error( 'Error checking certificate trust status:', error );
-			}
-		};
+			} );
+	}, [ setIsTrusted ] );
 
+	useWindowListener( 'focus', checkCertificateTrust );
+
+	useEffect( () => {
+		isMounted.current = true;
 		checkCertificateTrust();
-
 		return () => {
-			isMounted = false;
+			isMounted.current = false;
 		};
-	}, [] );
+	}, [ checkCertificateTrust ] );
 
 	return isTrusted;
 }

--- a/src/hooks/use-certificate-trust.ts
+++ b/src/hooks/use-certificate-trust.ts
@@ -11,6 +11,11 @@ export function useCertificateTrust(): boolean {
 	const [ isTrusted, setIsTrusted ] = useState< boolean >( false );
 
 	const checkCertificateTrust = useCallback( () => {
+		// If the certificate is already trusted, don't check it again
+		if ( isTrusted ) {
+			return;
+		}
+
 		getIpcApi()
 			.isCATrusted()
 			.then( ( trusted ) => {

--- a/src/hooks/use-certificate-trust.ts
+++ b/src/hooks/use-certificate-trust.ts
@@ -22,8 +22,11 @@ export function useCertificateTrust(): boolean {
 				if ( isMounted.current ) {
 					setIsTrusted( trusted );
 				}
+			} )
+			.catch( ( error ) => {
+				console.error( 'Failed to check certificate trust:', error );
 			} );
-	}, [ setIsTrusted ] );
+	}, [ setIsTrusted, isTrusted ] );
 
 	useWindowListener( 'focus', checkCertificateTrust );
 

--- a/src/hooks/use-certificate-trust.ts
+++ b/src/hooks/use-certificate-trust.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useWindowListener } from 'src/hooks/use-window-listener';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 
@@ -7,7 +7,6 @@ import { getIpcApi } from 'src/lib/get-ipc-api';
  * @returns A boolean indicating if the certificate is trusted
  */
 export function useCertificateTrust(): boolean {
-	const isMounted = useRef( true );
 	const [ isTrusted, setIsTrusted ] = useState< boolean >( false );
 
 	const checkCertificateTrust = useCallback( () => {
@@ -19,23 +18,17 @@ export function useCertificateTrust(): boolean {
 		getIpcApi()
 			.isCATrusted()
 			.then( ( trusted ) => {
-				if ( isMounted.current ) {
-					setIsTrusted( trusted );
-				}
+				setIsTrusted( trusted );
 			} )
 			.catch( ( error ) => {
 				console.error( 'Failed to check certificate trust:', error );
 			} );
-	}, [ setIsTrusted, isTrusted ] );
+	}, [ isTrusted ] );
 
 	useWindowListener( 'focus', checkCertificateTrust );
 
 	useEffect( () => {
-		isMounted.current = true;
 		checkCertificateTrust();
-		return () => {
-			isMounted.current = false;
-		};
 	}, [ checkCertificateTrust ] );
 
 	return isTrusted;

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -27,7 +27,6 @@ import { sendIpcEventToRenderer, sendIpcEventToRendererWithWindow } from 'src/ip
 import { ACTIVE_SYNC_OPERATIONS } from 'src/lib/active-sync-operations';
 import { bumpStat } from 'src/lib/bump-stats';
 import { getImporterMetric } from 'src/lib/bump-stats/lib';
-import { openCertificate as openCertificateDialog } from 'src/lib/certificate-manager';
 import { download } from 'src/lib/download';
 import { isEmptyDir, pathExists, sanitizeFolderName } from 'src/lib/fs-utils';
 import { getImageData } from 'src/lib/get-image-data';
@@ -55,12 +54,16 @@ import { getLogsFilePath, writeLogToFile, type LogLevel } from 'src/logging';
 import { getMainWindow } from 'src/main-window';
 import { popupMenu, setupMenu } from 'src/menu';
 import { executePreviewCliCommand } from 'src/modules/cli/lib/execute-preview-command';
+import { SupportedEditor } from 'src/modules/user-settings/lib/editor';
+import { SupportedTerminal } from 'src/modules/user-settings/lib/terminal';
 import { SiteServer, createSiteWorkingDirectory } from 'src/site-server';
 import { DEFAULT_SITE_PATH, getResourcesPath, getSiteThumbnailPath } from 'src/storage/paths';
 import { loadUserData, saveUserData } from 'src/storage/user-data';
 import { DEFAULT_PHP_VERSION, DEFAULT_WORDPRESS_VERSION } from 'vendor/wp-now/src/constants';
-import { SupportedEditor } from './modules/user-settings/lib/editor';
-import { SupportedTerminal } from './modules/user-settings/lib/terminal';
+import {
+	openCertificate as openCertificateDialog,
+	isRootCATrusted,
+} from './lib/certificate-manager';
 import type { SyncSite } from 'src/hooks/use-fetch-wpcom-sites/types';
 import type { WpCliResult } from 'src/lib/wp-cli-process';
 
@@ -1260,7 +1263,11 @@ export function openCertificate( _event: IpcMainInvokeEvent ) {
 	return openCertificateDialog();
 }
 
-export function getFileContent( event: IpcMainInvokeEvent, filePath: string ) {
+export async function isCATrusted( _event: IpcMainInvokeEvent ): Promise< boolean > {
+	return isRootCATrusted();
+}
+
+export async function getFileContent( event: IpcMainInvokeEvent, filePath: string ) {
 	if ( ! fs.existsSync( filePath ) ) {
 		throw new Error( `File not found: ${ filePath }` );
 	}

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -27,6 +27,10 @@ import { sendIpcEventToRenderer, sendIpcEventToRendererWithWindow } from 'src/ip
 import { ACTIVE_SYNC_OPERATIONS } from 'src/lib/active-sync-operations';
 import { bumpStat } from 'src/lib/bump-stats';
 import { getImporterMetric } from 'src/lib/bump-stats/lib';
+import {
+	openCertificate as openCertificateDialog,
+	isRootCATrusted,
+} from 'src/lib/certificate-manager';
 import { download } from 'src/lib/download';
 import { isEmptyDir, pathExists, sanitizeFolderName } from 'src/lib/fs-utils';
 import { getImageData } from 'src/lib/get-image-data';
@@ -60,10 +64,6 @@ import { SiteServer, createSiteWorkingDirectory } from 'src/site-server';
 import { DEFAULT_SITE_PATH, getResourcesPath, getSiteThumbnailPath } from 'src/storage/paths';
 import { loadUserData, saveUserData } from 'src/storage/user-data';
 import { DEFAULT_PHP_VERSION, DEFAULT_WORDPRESS_VERSION } from 'vendor/wp-now/src/constants';
-import {
-	openCertificate as openCertificateDialog,
-	isRootCATrusted,
-} from './lib/certificate-manager';
 import type { SyncSite } from 'src/hooks/use-fetch-wpcom-sites/types';
 import type { WpCliResult } from 'src/lib/wp-cli-process';
 

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -1263,7 +1263,7 @@ export function openCertificate( _event: IpcMainInvokeEvent ) {
 	return openCertificateDialog();
 }
 
-export async function isCATrusted( _event: IpcMainInvokeEvent ): Promise< boolean > {
+export async function isCATrusted(): Promise< boolean > {
 	return isRootCATrusted();
 }
 

--- a/src/lib/certificate-manager.ts
+++ b/src/lib/certificate-manager.ts
@@ -181,15 +181,7 @@ export async function isRootCATrusted(): Promise< boolean > {
 		}
 	} else if ( process.platform === 'darwin' ) {
 		try {
-			await execFilePromise( 'security', [
-				'verify-cert',
-				'-c',
-				CA_CERT_PATH,
-				'-p',
-				'ssl',
-				'-s',
-				CA_NAME,
-			] );
+			await execFilePromise( 'security', [ 'verify-cert', '-r', CA_CERT_PATH, '-p', 'ssl' ] );
 
 			return true;
 		} catch ( error ) {

--- a/src/lib/certificate-manager.ts
+++ b/src/lib/certificate-manager.ts
@@ -163,20 +163,31 @@ export async function isRootCATrusted(): Promise< boolean > {
 
 	if ( process.platform === 'win32' ) {
 		try {
-			const { stdout } = await execFilePromise( 'certutil', [ '-store', 'ROOT', CA_NAME ] );
-			return stdout.includes( CA_NAME );
+			await execFilePromise( 'certutil', [
+				'-verify',
+				'-urlfetch',
+				'-purpose',
+				'sslserver',
+				CA_CERT_PATH,
+			] );
+
+			return true;
 		} catch ( error ) {
 			return false;
 		}
 	} else if ( process.platform === 'darwin' ) {
 		try {
-			const { stdout } = await execFilePromise( 'security', [
-				'find-certificate',
+			await execFilePromise( 'security', [
+				'verify-cert',
 				'-c',
-				CA_NAME,
+				CA_CERT_PATH,
 				'-p',
+				'ssl',
+				'-s',
+				CA_NAME,
 			] );
-			return stdout.trim().length > 0;
+
+			return true;
 		} catch ( error ) {
 			return false;
 		}

--- a/src/lib/certificate-manager.ts
+++ b/src/lib/certificate-manager.ts
@@ -161,15 +161,14 @@ export async function isRootCATrusted(): Promise< boolean > {
 		return false;
 	}
 
-	const platform = process.platform;
-	if ( platform === 'win32' ) {
+	if ( process.platform === 'win32' ) {
 		try {
 			const { stdout } = await execFilePromise( 'certutil', [ '-store', 'ROOT', CA_NAME ] );
 			return stdout.includes( CA_NAME );
 		} catch ( error ) {
 			return false;
 		}
-	} else if ( platform === 'darwin' ) {
+	} else if ( process.platform === 'darwin' ) {
 		try {
 			const { stdout } = await execFilePromise( 'security', [
 				'find-certificate',

--- a/src/lib/certificate-manager.ts
+++ b/src/lib/certificate-manager.ts
@@ -167,8 +167,6 @@ export async function isRootCATrusted(): Promise< boolean > {
 			const { stdout } = await execFilePromise( 'certutil', [
 				'-verify',
 				'-urlfetch',
-				'-purpose',
-				'sslserver',
 				CA_CERT_PATH,
 			] );
 

--- a/src/lib/certificate-manager.ts
+++ b/src/lib/certificate-manager.ts
@@ -1,11 +1,15 @@
 import { shell } from 'electron';
+import { execFile } from 'node:child_process';
 import crypto from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
+import { promisify } from 'node:util';
 import * as Sentry from '@sentry/electron/main';
 import sudo from '@vscode/sudo-prompt';
 import forge from 'node-forge';
 import { getUserDataCertificatesPath } from 'src/storage/paths';
+
+const execFilePromise = promisify( execFile );
 
 /**
  * Generate name constraints in conformance with
@@ -149,10 +153,50 @@ export async function openCertificate() {
 }
 
 /**
+ * Checks if the root CA certificate is already trusted by the system
+ * @returns A promise that resolves to true if the certificate is trusted, false otherwise
+ */
+export async function isRootCATrusted(): Promise< boolean > {
+	if ( ! fs.existsSync( CA_CERT_PATH ) ) {
+		return false;
+	}
+
+	const platform = process.platform;
+	if ( platform === 'win32' ) {
+		try {
+			const { stdout } = await execFilePromise( 'certutil', [ '-store', 'ROOT', CA_NAME ] );
+			return stdout.includes( CA_NAME );
+		} catch ( error ) {
+			return false;
+		}
+	} else if ( platform === 'darwin' ) {
+		try {
+			const { stdout } = await execFilePromise( 'security', [
+				'find-certificate',
+				'-c',
+				CA_NAME,
+				'-p',
+			] );
+			return stdout.trim().length > 0;
+		} catch ( error ) {
+			return false;
+		}
+	}
+
+	return false;
+}
+
+/**
  * Trust the root CA certificate in the system trust store
  */
 async function trustRootCA(): Promise< void > {
 	try {
+		// If certificate is already trusted, no need to re-trust it
+		if ( await isRootCATrusted() ) {
+			console.log( 'Root CA is already trusted in the system store' );
+			return;
+		}
+
 		const platform = process.platform;
 		if ( platform === 'win32' ) {
 			// Windows - Use certutil
@@ -172,7 +216,7 @@ async function trustRootCA(): Promise< void > {
 				);
 			} );
 		} else {
-			console.error( 'Unsupported platform for certificate trust:', platform );
+			console.error( 'Unsupported platform for automatic certificate trust:', platform );
 		}
 	} catch ( error ) {
 		Sentry.captureException( error );

--- a/src/lib/certificate-manager.ts
+++ b/src/lib/certificate-manager.ts
@@ -164,11 +164,7 @@ export async function isRootCATrusted(): Promise< boolean > {
 	if ( process.platform === 'win32' ) {
 		try {
 			// Execute certutil with more specific validation
-			const { stdout } = await execFilePromise( 'certutil', [
-				'-verify',
-				'-urlfetch',
-				CA_CERT_PATH,
-			] );
+			const { stdout } = await execFilePromise( 'certutil', [ '-verify', CA_CERT_PATH ] );
 
 			const hasValidPolicies =
 				stdout.includes( 'Verified Application Policies:' ) &&

--- a/src/lib/certificate-manager.ts
+++ b/src/lib/certificate-manager.ts
@@ -163,7 +163,8 @@ export async function isRootCATrusted(): Promise< boolean > {
 
 	if ( process.platform === 'win32' ) {
 		try {
-			await execFilePromise( 'certutil', [
+			// Execute certutil with more specific validation
+			const { stdout } = await execFilePromise( 'certutil', [
 				'-verify',
 				'-urlfetch',
 				'-purpose',
@@ -171,7 +172,12 @@ export async function isRootCATrusted(): Promise< boolean > {
 				CA_CERT_PATH,
 			] );
 
-			return true;
+			const hasValidPolicies =
+				stdout.includes( 'Verified Application Policies:' ) &&
+				stdout.includes( 'Server Authentication' );
+
+			// Only consider the certificate trusted if it has the Server Authentication policy.
+			return hasValidPolicies;
 		} catch ( error ) {
 			return false;
 		}

--- a/src/modules/site-settings/edit-site-details.tsx
+++ b/src/modules/site-settings/edit-site-details.tsx
@@ -99,8 +99,8 @@ export default function EditSiteDetails( { currentWpVersion, onSave }: EditSiteD
 		setCustomDomain( selectedSite.customDomain ?? null );
 		setCustomDomainError( '' );
 		setErrorUpdatingWpVersion( null );
-		setEnableHttps( selectedSite.enableHttps ?? isCertificateTrusted );
-	}, [ selectedSite, getEffectiveWpVersion, isCertificateTrusted ] );
+		setEnableHttps( selectedSite.enableHttps ?? false );
+	}, [ selectedSite, getEffectiveWpVersion ] );
 
 	const onSiteEdit = async ( event: FormEvent ) => {
 		event.preventDefault();
@@ -156,7 +156,7 @@ export default function EditSiteDetails( { currentWpVersion, onSave }: EditSiteD
 				phpVersion: selectedPhpVersion,
 				isWpAutoUpdating: selectedWpVersion === DEFAULT_WORDPRESS_VERSION,
 				customDomain: usedCustomDomain,
-				enableHttps: !! usedCustomDomain && ( isCertificateTrusted || enableHttps ),
+				enableHttps: !! usedCustomDomain && enableHttps,
 			} );
 
 			if ( needsRestart ) {

--- a/src/modules/site-settings/edit-site-details.tsx
+++ b/src/modules/site-settings/edit-site-details.tsx
@@ -7,6 +7,8 @@ import { ErrorInformation } from 'src/components/error-information';
 import Modal from 'src/components/modal';
 import TextControlComponent from 'src/components/text-control';
 import { WPVersionSelector } from 'src/components/wp-version-selector';
+import { useCertificateTrust } from 'src/hooks/use-certificate-trust';
+import { useOffline } from 'src/hooks/use-offline';
 import { useSiteDetails } from 'src/hooks/use-site-details';
 import { isWindows } from 'src/lib/app-globals';
 import { cx } from 'src/lib/cx';
@@ -33,6 +35,9 @@ export default function EditSiteDetails( { currentWpVersion, onSave }: EditSiteD
 	const [ isEditingSite, setIsEditingSite ] = useState( false );
 	const [ needsRestart, setNeedsRestart ] = useState( false );
 
+	const isOffline = useOffline();
+	const isCertificateTrusted = useCertificateTrust();
+	const offlineMessage = __( 'Changing WordPress version requires an internet connection.' );
 	const closeModal = useCallback( () => {
 		if ( isEditingSite ) {
 			return;
@@ -98,8 +103,8 @@ export default function EditSiteDetails( { currentWpVersion, onSave }: EditSiteD
 		setCustomDomain( selectedSite.customDomain ?? null );
 		setCustomDomainError( '' );
 		setErrorUpdatingWpVersion( null );
-		setEnableHttps( selectedSite.enableHttps ?? false );
-	}, [ selectedSite, getEffectiveWpVersion ] );
+		setEnableHttps( selectedSite.enableHttps ?? isCertificateTrusted );
+	}, [ selectedSite, getEffectiveWpVersion, isCertificateTrusted ] );
 
 	const onSiteEdit = async ( event: FormEvent ) => {
 		event.preventDefault();
@@ -155,7 +160,7 @@ export default function EditSiteDetails( { currentWpVersion, onSave }: EditSiteD
 				phpVersion: selectedPhpVersion,
 				isWpAutoUpdating: selectedWpVersion === DEFAULT_WORDPRESS_VERSION,
 				customDomain: usedCustomDomain,
-				enableHttps: !! usedCustomDomain && enableHttps,
+				enableHttps: !! usedCustomDomain && ( isCertificateTrusted || enableHttps ),
 			} );
 
 			if ( needsRestart ) {
@@ -291,7 +296,7 @@ export default function EditSiteDetails( { currentWpVersion, onSave }: EditSiteD
 									</div>
 								) }
 
-								{ ! isWindows() && useCustomDomain && (
+								{ ! isCertificateTrusted && ! isWindows() && useCustomDomain && (
 									<div className="text-a8c-gray-50 text-xs mt-2">
 										{ __(
 											'You need to manually add the Studio certificate authority to your keychain and trust it.'

--- a/src/modules/site-settings/edit-site-details.tsx
+++ b/src/modules/site-settings/edit-site-details.tsx
@@ -8,7 +8,6 @@ import Modal from 'src/components/modal';
 import TextControlComponent from 'src/components/text-control';
 import { WPVersionSelector } from 'src/components/wp-version-selector';
 import { useCertificateTrust } from 'src/hooks/use-certificate-trust';
-import { useOffline } from 'src/hooks/use-offline';
 import { useSiteDetails } from 'src/hooks/use-site-details';
 import { cx } from 'src/lib/cx';
 import { generateCustomDomainFromSiteName, getDomainNameValidationError } from 'src/lib/domains';
@@ -34,9 +33,7 @@ export default function EditSiteDetails( { currentWpVersion, onSave }: EditSiteD
 	const [ isEditingSite, setIsEditingSite ] = useState( false );
 	const [ needsRestart, setNeedsRestart ] = useState( false );
 
-	const isOffline = useOffline();
 	const isCertificateTrusted = useCertificateTrust();
-	const offlineMessage = __( 'Changing WordPress version requires an internet connection.' );
 	const closeModal = useCallback( () => {
 		if ( isEditingSite ) {
 			return;

--- a/src/modules/site-settings/edit-site-details.tsx
+++ b/src/modules/site-settings/edit-site-details.tsx
@@ -10,7 +10,6 @@ import { WPVersionSelector } from 'src/components/wp-version-selector';
 import { useCertificateTrust } from 'src/hooks/use-certificate-trust';
 import { useOffline } from 'src/hooks/use-offline';
 import { useSiteDetails } from 'src/hooks/use-site-details';
-import { isWindows } from 'src/lib/app-globals';
 import { cx } from 'src/lib/cx';
 import { generateCustomDomainFromSiteName, getDomainNameValidationError } from 'src/lib/domains';
 import { getIpcApi } from 'src/lib/get-ipc-api';
@@ -296,7 +295,7 @@ export default function EditSiteDetails( { currentWpVersion, onSave }: EditSiteD
 									</div>
 								) }
 
-								{ ! isCertificateTrusted && ! isWindows() && useCustomDomain && (
+								{ ! isCertificateTrusted && useCustomDomain && (
 									<div className="text-a8c-gray-50 text-xs mt-2">
 										{ __(
 											'You need to manually add the Studio certificate authority to your keychain and trust it.'

--- a/src/modules/site-settings/tests/edit-site-details.test.tsx
+++ b/src/modules/site-settings/tests/edit-site-details.test.tsx
@@ -36,6 +36,7 @@ jest.mock( 'src/lib/get-ipc-api', () => ( {
 		executeWPCLiInline: mockExecuteWPCLiInline,
 		showErrorMessageBox: mockShowErrorMessageBox,
 		getAllCustomDomains: mockGetAllCustomDomains,
+		isCATrusted: jest.fn( () => Promise.resolve( true ) ),
 	} ),
 } ) );
 

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -53,6 +53,7 @@ const api: IpcApi = {
 	openURL: ( url ) => ipcRendererSend( 'openURL', url ),
 	showOpenFolderDialog: ( title, defaultDialogPath ) =>
 		ipcRendererInvoke( 'showOpenFolderDialog', title, defaultDialogPath ),
+	isCATrusted: () => ipcRenderer.invoke( 'isCATrusted' ),
 	showSaveAsDialog: ( options ) => ipcRendererInvoke( 'showSaveAsDialog', options ),
 	saveUserLocale: ( locale ) => ipcRendererInvoke( 'saveUserLocale', locale ),
 	getSentryUserId: () => ipcRendererInvoke( 'getSentryUserId' ),


### PR DESCRIPTION
## Related issues

- Fixes #1109
- Fixes STU-255-linear-issue

## Proposed Changes

- Implements a function to check whether the CA certificate is trusted.
- Hide all the SSL help texts when the CA certificate is trusted.
- Auto enable https when the custom domain is enabled and the root certificate is trusted

## Testing Instructions

- Create an SSL site
- If your CA certificate is not trusted, you should see help text on the creation form and on the settings tab

![CleanShot 2025-05-01 at 14 59 59@2x](https://github.com/user-attachments/assets/eb317159-3f11-4eaa-9954-4e27bf128691)

- If your CA certificate is trusted, you should not see either of these.