### PR TITLE
Performance metrics: Add a CI job to compare the performance of PR branches with trunk

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -13,6 +13,7 @@ steps:
     key: lint
     command: |
       .buildkite/commands/install-node-dependencies.sh
+      cd scripts/compare-perf && npm install && cd -
       echo '--- :eslint: Lint'
       npm run lint
     plugins: [$CI_TOOLKIT_PLUGIN, $NVM_PLUGIN]

--- a/.github/workflows/metrics-comparison.yml
+++ b/.github/workflows/metrics-comparison.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Compare performance with trunk
         if: github.event_name == 'pull_request'
-        run: cd scripts/compare-perf && npm install && npm run compare perf $GITHUB_SHA trunk --tests-branch $GITHUB_SHA
+        run: cd scripts/compare-perf && npm install && npm run compare -- perf $GITHUB_SHA trunk --tests-branch $GITHUB_SHA
 
       - name: Compare performance with base branch
         if: github.event_name == 'push'

--- a/.github/workflows/metrics-comparison.yml
+++ b/.github/workflows/metrics-comparison.yml
@@ -39,11 +39,11 @@ jobs:
       - name: Compare performance with base branch
         if: github.event_name == 'push'
         # The base hash used here need to be a commit that is compatible with the current performance tests.
-        # The current one is c954cc2228eab819118ab6e84e22dd0223faacfe
+        # The current one is 0840137210db6f627f7dc1d8cab79ed497e699a6
         # it needs to be updated every time it becomes unsupported by the current performance tests.
         # It is used as a base comparison point to avoid fluctuation in the performance metrics.
         run: |
-          cd scripts/compare-perf && npm ci && npm run compare -- perf $GITHUB_SHA c954cc2228eab819118ab6e84e22dd0223faacfe --tests-branch $GITHUB_SHA
+          cd scripts/compare-perf && npm ci && npm run compare -- perf $GITHUB_SHA 0840137210db6f627f7dc1d8cab79ed497e699a6 --tests-branch $GITHUB_SHA
 
       - name: Archive performance results
         if: ${{ !cancelled() }}

--- a/.github/workflows/metrics-comparison.yml
+++ b/.github/workflows/metrics-comparison.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Compare performance with trunk
         if: github.event_name == 'pull_request'
-        run: cd scripts/compare-perf && npm ci && npm run compare -- perf $GITHUB_SHA trunk --tests-branch $GITHUB_SHA
+        run: cd scripts/compare-perf && npm ci && npm run compare -- perf $GITHUB_SHA bfff98655ec7b3b8d0580dd1610121dec529b59f --tests-branch $GITHUB_SHA
 
       - name: Compare performance with base branch
         if: github.event_name == 'push'

--- a/.github/workflows/metrics-comparison.yml
+++ b/.github/workflows/metrics-comparison.yml
@@ -1,0 +1,50 @@
+name: Performance Metrics Comparison
+
+on:
+  pull_request:
+  push:
+    branches: [trunk]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  metrics:
+    name: Run metrics tests
+    runs-on: macos-13
+    permissions:
+      contents: read
+    env:
+      ARTIFACTS_PATH: ${{ github.workspace }}/artifacts
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Compare performance with trunk
+        if: github.event_name == 'pull_request'
+        run: cd scripts/compare-perf && npm install && npm run compare perf $GITHUB_SHA trunk --tests-branch $GITHUB_SHA
+
+      - name: Compare performance with base branch
+        if: github.event_name == 'push'
+        # The base hash used here need to be a commit that is compatible with the current performance tests.
+        # The current one is c954cc2228eab819118ab6e84e22dd0223faacfe 
+        # it needs to be updated every time it becomes unsupported by the current performance tests.
+        # It is used as a base comparison point to avoid fluctuation in the performance metrics.
+        run: |
+            cd scripts/compare-perf && npm install && npm run compare perf $GITHUB_SHA c954cc2228eab819118ab6e84e22dd0223faacfe --tests-branch $GITHUB_SHA
+      - name: Archive performance results
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+            name: performance-results
+            path: ${{ env.WP_ARTIFACTS_PATH }}/*.performance-results*.json

--- a/.github/workflows/metrics-comparison.yml
+++ b/.github/workflows/metrics-comparison.yml
@@ -41,7 +41,7 @@ jobs:
         # it needs to be updated every time it becomes unsupported by the current performance tests.
         # It is used as a base comparison point to avoid fluctuation in the performance metrics.
         run: |
-            cd scripts/compare-perf && npm install && npm run compare perf $GITHUB_SHA c954cc2228eab819118ab6e84e22dd0223faacfe --tests-branch $GITHUB_SHA
+            cd scripts/compare-perf && npm install && npm run compare -- perf $GITHUB_SHA c954cc2228eab819118ab6e84e22dd0223faacfe --tests-branch $GITHUB_SHA
       - name: Archive performance results
         if: success()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/metrics-comparison.yml
+++ b/.github/workflows/metrics-comparison.yml
@@ -19,12 +19,14 @@ jobs:
       contents: read
     env:
       ARTIFACTS_PATH: ${{ github.workspace }}/artifacts
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      FORCE_COLOR: '1'
 
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -32,19 +34,20 @@ jobs:
 
       - name: Compare performance with trunk
         if: github.event_name == 'pull_request'
-        run: cd scripts/compare-perf && npm install && npm run compare -- perf $GITHUB_SHA trunk --tests-branch $GITHUB_SHA
+        run: cd scripts/compare-perf && npm ci && npm run compare -- perf $GITHUB_SHA trunk --tests-branch $GITHUB_SHA
 
       - name: Compare performance with base branch
         if: github.event_name == 'push'
         # The base hash used here need to be a commit that is compatible with the current performance tests.
-        # The current one is c954cc2228eab819118ab6e84e22dd0223faacfe 
+        # The current one is c954cc2228eab819118ab6e84e22dd0223faacfe
         # it needs to be updated every time it becomes unsupported by the current performance tests.
         # It is used as a base comparison point to avoid fluctuation in the performance metrics.
         run: |
-            cd scripts/compare-perf && npm install && npm run compare -- perf $GITHUB_SHA c954cc2228eab819118ab6e84e22dd0223faacfe --tests-branch $GITHUB_SHA
+          cd scripts/compare-perf && npm ci && npm run compare -- perf $GITHUB_SHA c954cc2228eab819118ab6e84e22dd0223faacfe --tests-branch $GITHUB_SHA
+
       - name: Archive performance results
-        if: success()
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
-            name: performance-results
-            path: ${{ env.WP_ARTIFACTS_PATH }}/*.performance-results*.json
+          name: performance-results
+          path: ${{ env.ARTIFACTS_PATH }}

--- a/e2e/e2e-helpers.ts
+++ b/e2e/e2e-helpers.ts
@@ -44,6 +44,7 @@ export class E2ESession {
 				E2E_APP_DATA_PATH: this.appDataPath,
 				E2E_HOME_PATH: this.homePath,
 			},
+			recordVideo: { dir: tmpdir() },
 			timeout: 60_000,
 		} );
 		this.mainWindow = await this.electronApp.firstWindow( { timeout: 60_000 } );

--- a/metrics/README.md
+++ b/metrics/README.md
@@ -7,10 +7,10 @@ This directory contains tools for measuring and tracking performance metrics in 
 To run the performance tests:
 
 ```bash
-// Package the application first
+# Package the application first
 npm run package
 
-// Run the performance tests
+# Run the performance tests
 npm run test:metrics
 ```
 
@@ -23,7 +23,21 @@ This will:
 
 The performance tests simulate key user workflows and measure the time they take to complete. Currently, we measure:
 
-- Site creation and startup time: How long it takes to create a new WordPress site and have it running
+- **siteCreation**: How long it takes to create a new WordPress site and have it running
+- **siteStartup**: How long it takes to restart an existing site
+
+## Comparing Performance Between Commits
+
+You can compare performance metrics between different commits or branches:
+
+```bash
+npm run test:metrics:compare <commit1> <commit2>
+```
+
+This tool is useful for:
+- Testing performance impact of code changes
+- Identifying performance regressions
+- Benchmarking improvements in new features
 
 ## Understanding the Results
 
@@ -35,3 +49,5 @@ The `performance-metrics.json` output file contains a summary of the results, ex
   "siteStartup": 3946
 }
 ```
+
+All measurements are in milliseconds (ms), and lower values indicate better performance.

--- a/metrics/README.md
+++ b/metrics/README.md
@@ -31,7 +31,7 @@ The performance tests simulate key user workflows and measure the time they take
 You can compare performance metrics between different commits or branches:
 
 ```bash
-npm run test:metrics:compare <commit1> <commit2>
+cd scripts/compare-perf && npm run compare -- perf <commit1> <commit2>
 ```
 
 This tool is useful for:

--- a/metrics/performance-reporter.ts
+++ b/metrics/performance-reporter.ts
@@ -4,6 +4,10 @@ import type { Reporter, FullResult, TestCase, TestResult } from '@playwright/tes
 
 export type PerformanceResults = Record< string, number >;
 
+if ( ! process.env.ARTIFACTS_PATH ) {
+	throw new Error( 'ARTIFACTS_PATH is not set' );
+}
+
 class PerformanceReporter implements Reporter {
 	private results: Record< string, PerformanceResults >;
 
@@ -21,16 +25,17 @@ class PerformanceReporter implements Reporter {
 				throw new Error( 'Empty results attachment' );
 			}
 
-			const testSuite = path.basename( test.location.file, '.test.js' );
+			const testSuite = path.basename( test.location.file, '.test.ts' );
 			const resultsId = process.env.RESULTS_ID || testSuite;
 			const resultsPath = process.env.ARTIFACTS_PATH as string;
 			const resultsBody = attachment.body.toString();
+			const resultsFileSuffix = process.env.RESULTS_FILE_SUFFIX || '.results.json';
 			const results = JSON.parse( resultsBody );
 
 			if ( ! existsSync( resultsPath ) ) {
 				mkdirSync( resultsPath, { recursive: true } );
 			}
-			writeFileSync( path.join( resultsPath, `${ resultsId }-results.json` ), resultsBody );
+			writeFileSync( path.join( resultsPath, resultsId + resultsFileSuffix ), resultsBody );
 
 			this.results[ testSuite ] = results;
 		}

--- a/metrics/playwright.metrics.config.ts
+++ b/metrics/playwright.metrics.config.ts
@@ -20,9 +20,9 @@ export default defineConfig( {
 		actionTimeout: 120_000, // 2 minutes.
 		headless: true,
 		// Enable only for debugging.
-		trace: 'off',
-		screenshot: 'off',
-		video: 'off',
+		trace: 'on',
+		screenshot: 'on',
+		video: 'on',
 	},
 	expect: {
 		timeout: 120_000, // 2 minutes.

--- a/metrics/playwright.metrics.config.ts
+++ b/metrics/playwright.metrics.config.ts
@@ -2,13 +2,29 @@ import path from 'path';
 import { defineConfig } from '@playwright/test';
 import baseConfig from '../playwright.config';
 
-process.env.ARTIFACTS_PATH ??= path.join( process.cwd(), 'artifacts' );
+process.env.ARTIFACTS_PATH ??= path.join( __dirname, 'artifacts' );
 
 export default defineConfig( {
 	...baseConfig,
 	testDir: './tests',
-	testMatch: /.*\.test\.ts/,
-	reporter: process.env.CI
-		? './performance-reporter.ts'
-		: [ [ 'list' ], [ './performance-reporter.ts' ] ],
+	testMatch: '*.test.ts',
+	reporter: [ [ 'list' ], [ './performance-reporter.ts' ] ],
+	outputDir: path.join( process.env.ARTIFACTS_PATH, 'test-results' ),
+	forbidOnly: !! process.env.CI,
+	fullyParallel: false,
+	retries: 0,
+	timeout: parseInt( process.env.TIMEOUT || '', 10 ) || 600_000, // Defaults to 10 minutes.
+	reportSlowTests: null,
+	use: {
+		...baseConfig.use,
+		actionTimeout: 120_000, // 2 minutes.
+		headless: true,
+		// Enable only for debugging.
+		trace: 'off',
+		screenshot: 'off',
+		video: 'off',
+	},
+	expect: {
+		timeout: 120_000, // 2 minutes.
+	},
 } );

--- a/metrics/tests/site-startup.test.ts
+++ b/metrics/tests/site-startup.test.ts
@@ -1,3 +1,4 @@
+import path from 'path';
 import { test, expect } from '@playwright/test';
 import { E2ESession } from '../../e2e/e2e-helpers';
 import MainSidebar from '../../e2e/page-objects/main-sidebar';
@@ -33,6 +34,18 @@ test.describe( 'Startup Metrics', () => {
 		} );
 
 		await session.cleanup();
+
+		const video = session.mainWindow.video();
+
+		if ( video ) {
+			await video.saveAs(
+				path.join(
+					process.env.ARTIFACTS_PATH ?? '',
+					'test-results',
+					'video-' + Date.now() + '.webm'
+				)
+			);
+		}
 	} );
 
 	test( 'measure site creation and startup performance', async () => {
@@ -51,7 +64,20 @@ test.describe( 'Startup Metrics', () => {
 			const startTime = Date.now();
 			await modal.addSiteButton.click();
 			siteContent = new SiteContent( session.mainWindow, siteName );
-			await expect( siteContent.runningButton ).toBeAttached( { timeout: 240_000 } );
+
+			try {
+				await expect( siteContent.runningButton ).toBeAttached();
+			} finally {
+				// Capture a screenshot.
+				await session.mainWindow.screenshot( {
+					path: path.join(
+						process.env.ARTIFACTS_PATH ?? '',
+						'test-results',
+						'screenshot-' + Date.now() + '.png'
+					),
+				} );
+			}
+
 			const endTime = Date.now();
 			const duration = endTime - startTime;
 			results.siteCreation = [ duration ];

--- a/metrics/tests/site-startup.test.ts
+++ b/metrics/tests/site-startup.test.ts
@@ -51,7 +51,7 @@ test.describe( 'Startup Metrics', () => {
 			const startTime = Date.now();
 			await modal.addSiteButton.click();
 			siteContent = new SiteContent( session.mainWindow, siteName );
-			await expect( siteContent.runningButton ).toBeAttached();
+			await expect( siteContent.runningButton ).toBeAttached( { timeout: 240_000 } );
 			const endTime = Date.now();
 			const duration = endTime - startTime;
 			results.siteCreation = [ duration ];

--- a/metrics/tests/site-startup.test.ts
+++ b/metrics/tests/site-startup.test.ts
@@ -15,9 +15,6 @@ test.describe( 'Startup Metrics', () => {
 		await session.launch();
 
 		// Complete onboarding before tests
-		const onboarding = new Onboarding( session.mainWindow );
-		await expect( onboarding.heading ).toBeVisible();
-		await onboarding.continueButton.click();
 	} );
 
 	// eslint-disable-next-line no-empty-pattern
@@ -49,20 +46,14 @@ test.describe( 'Startup Metrics', () => {
 	} );
 
 	test( 'measure site creation and startup performance', async () => {
-		let modal;
 		let siteContent;
-
-		// Create a new site first (without timing)
-		await test.step( 'Create a new site', async () => {
-			const sidebar = new MainSidebar( session.mainWindow );
-			modal = await sidebar.openAddSiteModal();
-			await modal.siteNameInput.fill( siteName );
-		} );
 
 		// Measure site creation time (includes initial startup time)
 		await test.step( 'Measure site creation time', async () => {
+			const onboarding = new Onboarding( session.mainWindow );
+			await expect( onboarding.heading ).toBeVisible();
 			const startTime = Date.now();
-			await modal.addSiteButton.click();
+			await onboarding.continueButton.click();
 			siteContent = new SiteContent( session.mainWindow, siteName );
 
 			try {

--- a/metrics/tests/site-startup.test.ts
+++ b/metrics/tests/site-startup.test.ts
@@ -22,9 +22,11 @@ test.describe( 'Startup Metrics', () => {
 	// eslint-disable-next-line no-empty-pattern
 	test.afterAll( async ( {}, testInfo ) => {
 		const medians = {};
+
 		Object.keys( results ).map( ( metric ) => {
 			medians[ metric ] = median( results[ metric ] );
 		} );
+
 		await testInfo.attach( 'results', {
 			body: JSON.stringify( medians, null, 2 ),
 			contentType: 'application/json',
@@ -34,53 +36,63 @@ test.describe( 'Startup Metrics', () => {
 	} );
 
 	test( 'measure site creation and startup performance', async () => {
+		let modal;
+		let siteContent;
+
 		// Create a new site first (without timing)
-		const sidebar = new MainSidebar( session.mainWindow );
-		const modal = await sidebar.openAddSiteModal();
-		await modal.siteNameInput.fill( siteName );
+		await test.step( 'Create a new site', async () => {
+			const sidebar = new MainSidebar( session.mainWindow );
+			modal = await sidebar.openAddSiteModal();
+			await modal.siteNameInput.fill( siteName );
+		} );
 
 		// Measure site creation time (includes initial startup time)
-		const startTime = Date.now();
-		await modal.addSiteButton.click();
-		const siteContent = new SiteContent( session.mainWindow, siteName );
-		await expect( siteContent.runningButton ).toBeAttached( { timeout: 60_000 } );
-		const endTime = Date.now();
-		const duration = endTime - startTime;
-		results.siteCreation = [ duration ];
+		await test.step( 'Measure site creation time', async () => {
+			const startTime = Date.now();
+			await modal.addSiteButton.click();
+			siteContent = new SiteContent( session.mainWindow, siteName );
+			await expect( siteContent.runningButton ).toBeAttached();
+			const endTime = Date.now();
+			const duration = endTime - startTime;
+			results.siteCreation = [ duration ];
+		} );
 
 		results.siteStartup = [];
 		// Measure server stop/start 5 times
 		for ( let i = 0; i < 5; i++ ) {
-			console.log( `Run ${ i + 1 }/5: Stopping and starting site` );
-			// Stop the site by clicking the Running button
-			await siteContent.runningButton.click();
-			const startButton = siteContent.locator.getByRole( 'button', { name: 'Start' } );
-			await expect( startButton ).toBeAttached( { timeout: 30_000 } );
+			await test.step( `Run ${ i + 1 }/5: Stopping and starting site`, async () => {
+				// Stop the site by clicking the Running button
+				await siteContent.runningButton.click();
+				const startButton = siteContent.locator.getByRole( 'button', { name: 'Start' } );
+				await expect( startButton ).toBeAttached();
 
-			// Start timer
-			const startTime = Date.now();
-			await startButton.click();
-			// Wait for site to be running
-			await expect( siteContent.runningButton ).toBeAttached( { timeout: 60_000 } );
-			const endTime = Date.now();
-			const duration = endTime - startTime;
+				// Start timer
+				const startTime = Date.now();
+				await startButton.click();
+				// Wait for site to be running
+				await expect( siteContent.runningButton ).toBeAttached();
+				const endTime = Date.now();
+				const duration = endTime - startTime;
 
-			// Log performance data for this run
-			console.log( `Run ${ i + 1 }/5: Restart took ${ duration }ms` );
-			results.siteStartup.push( duration );
+				// Log performance data for this run
+				console.log( `Run ${ i + 1 }/5: Restart took ${ duration }ms` );
+				results.siteStartup.push( duration );
 
-			// Wait a moment before next cycle
-			await session.mainWindow.waitForTimeout( 100 );
+				// Wait a moment before next cycle
+				await session.mainWindow.waitForTimeout( 100 );
+			} );
 		}
 
 		// Delete the site after test
-		const settingsTab = await siteContent.navigateToTab( 'Settings' );
-		await session.electronApp.evaluate( ( { dialog } ) => {
-			dialog.showMessageBox = async () => {
-				return { response: 0, checkboxChecked: true };
-			};
+		await test.step( 'Delete the site', async () => {
+			const settingsTab = await siteContent.navigateToTab( 'Settings' );
+			await session.electronApp.evaluate( ( { dialog } ) => {
+				dialog.showMessageBox = async () => {
+					return { response: 0, checkboxChecked: true };
+				};
+			} );
+			await settingsTab.openDeleteSiteModal();
+			await session.mainWindow.waitForTimeout( 200 ); // Wait for deletion
 		} );
-		await settingsTab.openDeleteSiteModal();
-		await session.mainWindow.waitForTimeout( 200 ); // Wait for deletion
 	} );
 } );

--- a/metrics/tests/site-startup.test.ts
+++ b/metrics/tests/site-startup.test.ts
@@ -1,7 +1,6 @@
 import path from 'path';
 import { test, expect } from '@playwright/test';
 import { E2ESession } from '../../e2e/e2e-helpers';
-import MainSidebar from '../../e2e/page-objects/main-sidebar';
 import Onboarding from '../../e2e/page-objects/onboarding';
 import SiteContent from '../../e2e/page-objects/site-content';
 import { median } from '../utils';
@@ -55,20 +54,7 @@ test.describe( 'Startup Metrics', () => {
 			const startTime = Date.now();
 			await onboarding.continueButton.click();
 			siteContent = new SiteContent( session.mainWindow, siteName );
-
-			try {
-				await expect( siteContent.runningButton ).toBeAttached();
-			} finally {
-				// Capture a screenshot.
-				await session.mainWindow.screenshot( {
-					path: path.join(
-						process.env.ARTIFACTS_PATH ?? '',
-						'test-results',
-						'screenshot-' + Date.now() + '.png'
-					),
-				} );
-			}
-
+			await expect( siteContent.runningButton ).toBeAttached();
 			const endTime = Date.now();
 			const duration = endTime - startTime;
 			results.siteCreation = [ duration ];

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
 		"test": "cross-env NODE_OPTIONS='--no-deprecation' jest",
 		"test:watch": "cross-env NODE_OPTIONS='--no-deprecation' jest --watch",
 		"e2e": "npx playwright install && npx playwright test",
-		"test:metrics": "npx playwright install && npx playwright test --config=./metrics/playwright.metrics.config.ts",
+		"test:metrics": "npx playwright test --config=./metrics/playwright.metrics.config.ts",
 		"make-pot": "wp-babel-makepot \"./src/**/*.{js,jsx,ts,tsx}\" --ignore \"**/*.d.ts\" --base \"./src\" --dir \"./out/pots\" --output \"./out/pots/bundle-strings.pot\""
 	},
 	"devDependencies": {

--- a/scripts/compare-perf/config.ts
+++ b/scripts/compare-perf/config.ts
@@ -1,9 +1,17 @@
+import path from 'path';
+
+const metricsPath = path.resolve( __dirname, '../../metrics' );
+
 const config = {
 	gitRepositoryURL: 'https://github.com/Automattic/studio.git',
-	setupTestRunner: 'npm install',
-	setupCommand: 'npm install && IS_DEV_BUILD=true npm run package',
-	testsPath: '/metrics/tests',
+	setupTestRunner: 'npm ci && npx playwright install chromium',
 	testCommand: 'npm run test:metrics',
+	setupCommand: 'npm ci && IS_DEV_BUILD=true npm run package',
+	testsPath: 'metrics/tests',
+	testFileSuffix: '.test.ts',
+	artifactsPath: path.join( metricsPath, 'artifacts' ),
+	resultsFileSuffix: '.results.json',
+	summaryFileSuffix: '.summary.json',
 };
 
 export default config;

--- a/scripts/compare-perf/config.ts
+++ b/scripts/compare-perf/config.ts
@@ -1,0 +1,9 @@
+const config = {
+	gitRepositoryURL: 'https://github.com/Automattic/studio.git',
+	setupTestRunner: 'npm install',
+	setupCommand: 'npm install && IS_DEV_BUILD=true npm run package',
+	testsPath: '/metrics/tests',
+	testCommand: 'npm run test:metrics',
+};
+
+export default config;

--- a/scripts/compare-perf/config.ts
+++ b/scripts/compare-perf/config.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 
 const metricsPath = path.resolve( __dirname, '../../metrics' );
+const artifactsPath = process.env.ARTIFACTS_PATH ?? path.join( metricsPath, 'artifacts' );
 
 const config = {
 	gitRepositoryURL: 'https://github.com/Automattic/studio.git',
@@ -9,7 +10,7 @@ const config = {
 	setupCommand: 'npm ci && IS_DEV_BUILD=true npm run package',
 	testsPath: 'metrics/tests',
 	testFileSuffix: '.test.ts',
-	artifactsPath: path.join( metricsPath, 'artifacts' ),
+	artifactsPath,
 	resultsFileSuffix: '.results.json',
 	summaryFileSuffix: '.summary.json',
 };

--- a/scripts/compare-perf/index.ts
+++ b/scripts/compare-perf/index.ts
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+
+import { Command } from 'commander';
+import { runPerformanceTests } from './performance';
+
+const program = new Command();
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+const catchException = ( command: Function ) => {
+	return async ( ...args: unknown[] ) => {
+		try {
+			await command( ...args );
+		} catch ( error ) {
+			console.error( error );
+			process.exitCode = 1;
+		}
+	};
+};
+
+program
+	.command( 'compare-performance [branches...]' )
+	.alias( 'perf' )
+	.option( '-c, --ci', 'Run in CI (non interactive)' )
+	.option(
+		'--rounds <count>',
+		'Run each test suite this many times for each branch; results are summarized, default = 1'
+	)
+	.option( '--tests-branch <branch>', "Use this branch's performance test files" )
+	.description( 'Runs performance tests on two separate branches and outputs the result' )
+	.action( catchException( runPerformanceTests ) );
+
+program.parse( process.argv );

--- a/scripts/compare-perf/package-lock.json
+++ b/scripts/compare-perf/package-lock.json
@@ -1,0 +1,899 @@
+{
+	"name": "compare-perf",
+	"version": "0.0.1",
+	"lockfileVersion": 3,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "compare-perf",
+			"version": "0.0.1",
+			"license": "GPLv2",
+			"dependencies": {
+				"chalk": "^4.1.2",
+				"commander": "^13.1.0",
+				"inquirer": "^12.5.0",
+				"simple-git": "^3.27.0",
+				"ts-node": "^10.9.2"
+			}
+		},
+		"node_modules/@cspotcode/source-map-support": {
+			"version": "0.8.1",
+			"resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+			"integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/trace-mapping": "0.3.9"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@inquirer/checkbox": {
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.1.4.tgz",
+			"integrity": "sha512-d30576EZdApjAMceijXA5jDzRQHT/MygbC+J8I7EqA6f/FRpYxlRtRJbHF8gHeWYeSdOuTEJqonn7QLB1ELezA==",
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/core": "^10.1.9",
+				"@inquirer/figures": "^1.0.11",
+				"@inquirer/type": "^3.0.5",
+				"ansi-escapes": "^4.3.2",
+				"yoctocolors-cjs": "^2.1.2"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/confirm": {
+			"version": "5.1.8",
+			"resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.8.tgz",
+			"integrity": "sha512-dNLWCYZvXDjO3rnQfk2iuJNL4Ivwz/T2+C3+WnNfJKsNGSuOs3wAo2F6e0p946gtSAk31nZMfW+MRmYaplPKsg==",
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/core": "^10.1.9",
+				"@inquirer/type": "^3.0.5"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/core": {
+			"version": "10.1.9",
+			"resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.9.tgz",
+			"integrity": "sha512-sXhVB8n20NYkUBfDYgizGHlpRVaCRjtuzNZA6xpALIUbkgfd2Hjz+DfEN6+h1BRnuxw0/P4jCIMjMsEOAMwAJw==",
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/figures": "^1.0.11",
+				"@inquirer/type": "^3.0.5",
+				"ansi-escapes": "^4.3.2",
+				"cli-width": "^4.1.0",
+				"mute-stream": "^2.0.0",
+				"signal-exit": "^4.1.0",
+				"wrap-ansi": "^6.2.0",
+				"yoctocolors-cjs": "^2.1.2"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/editor": {
+			"version": "4.2.9",
+			"resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.9.tgz",
+			"integrity": "sha512-8HjOppAxO7O4wV1ETUlJFg6NDjp/W2NP5FB9ZPAcinAlNT4ZIWOLe2pUVwmmPRSV0NMdI5r/+lflN55AwZOKSw==",
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/core": "^10.1.9",
+				"@inquirer/type": "^3.0.5",
+				"external-editor": "^3.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/expand": {
+			"version": "4.0.11",
+			"resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.11.tgz",
+			"integrity": "sha512-OZSUW4hFMW2TYvX/Sv+NnOZgO8CHT2TU1roUCUIF2T+wfw60XFRRp9MRUPCT06cRnKL+aemt2YmTWwt7rOrNEA==",
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/core": "^10.1.9",
+				"@inquirer/type": "^3.0.5",
+				"yoctocolors-cjs": "^2.1.2"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/figures": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.11.tgz",
+			"integrity": "sha512-eOg92lvrn/aRUqbxRyvpEWnrvRuTYRifixHkYVpJiygTgVSBIHDqLh0SrMQXkafvULg3ck11V7xvR+zcgvpHFw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@inquirer/input": {
+			"version": "4.1.8",
+			"resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.1.8.tgz",
+			"integrity": "sha512-WXJI16oOZ3/LiENCAxe8joniNp8MQxF6Wi5V+EBbVA0ZIOpFcL4I9e7f7cXse0HJeIPCWO8Lcgnk98juItCi7Q==",
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/core": "^10.1.9",
+				"@inquirer/type": "^3.0.5"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/number": {
+			"version": "3.0.11",
+			"resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.11.tgz",
+			"integrity": "sha512-pQK68CsKOgwvU2eA53AG/4npRTH2pvs/pZ2bFvzpBhrznh8Mcwt19c+nMO7LHRr3Vreu1KPhNBF3vQAKrjIulw==",
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/core": "^10.1.9",
+				"@inquirer/type": "^3.0.5"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/password": {
+			"version": "4.0.11",
+			"resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.11.tgz",
+			"integrity": "sha512-dH6zLdv+HEv1nBs96Case6eppkRggMe8LoOTl30+Gq5Wf27AO/vHFgStTVz4aoevLdNXqwE23++IXGw4eiOXTg==",
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/core": "^10.1.9",
+				"@inquirer/type": "^3.0.5",
+				"ansi-escapes": "^4.3.2"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/prompts": {
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.4.0.tgz",
+			"integrity": "sha512-EZiJidQOT4O5PYtqnu1JbF0clv36oW2CviR66c7ma4LsupmmQlUwmdReGKRp456OWPWMz3PdrPiYg3aCk3op2w==",
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/checkbox": "^4.1.4",
+				"@inquirer/confirm": "^5.1.8",
+				"@inquirer/editor": "^4.2.9",
+				"@inquirer/expand": "^4.0.11",
+				"@inquirer/input": "^4.1.8",
+				"@inquirer/number": "^3.0.11",
+				"@inquirer/password": "^4.0.11",
+				"@inquirer/rawlist": "^4.0.11",
+				"@inquirer/search": "^3.0.11",
+				"@inquirer/select": "^4.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/rawlist": {
+			"version": "4.0.11",
+			"resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.0.11.tgz",
+			"integrity": "sha512-uAYtTx0IF/PqUAvsRrF3xvnxJV516wmR6YVONOmCWJbbt87HcDHLfL9wmBQFbNJRv5kCjdYKrZcavDkH3sVJPg==",
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/core": "^10.1.9",
+				"@inquirer/type": "^3.0.5",
+				"yoctocolors-cjs": "^2.1.2"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/search": {
+			"version": "3.0.11",
+			"resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.0.11.tgz",
+			"integrity": "sha512-9CWQT0ikYcg6Ls3TOa7jljsD7PgjcsYEM0bYE+Gkz+uoW9u8eaJCRHJKkucpRE5+xKtaaDbrND+nPDoxzjYyew==",
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/core": "^10.1.9",
+				"@inquirer/figures": "^1.0.11",
+				"@inquirer/type": "^3.0.5",
+				"yoctocolors-cjs": "^2.1.2"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/select": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.1.0.tgz",
+			"integrity": "sha512-z0a2fmgTSRN+YBuiK1ROfJ2Nvrpij5lVN3gPDkQGhavdvIVGHGW29LwYZfM/j42Ai2hUghTI/uoBuTbrJk42bA==",
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/core": "^10.1.9",
+				"@inquirer/figures": "^1.0.11",
+				"@inquirer/type": "^3.0.5",
+				"ansi-escapes": "^4.3.2",
+				"yoctocolors-cjs": "^2.1.2"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/type": {
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.5.tgz",
+			"integrity": "sha512-ZJpeIYYueOz/i/ONzrfof8g89kNdO2hjGuvULROo3O8rlB2CRtSseE5KeirnyE4t/thAn/EwvS/vuQeJCn+NZg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@jridgewell/resolve-uri": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+			"integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@jridgewell/sourcemap-codec": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+			"integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+			"license": "MIT"
+		},
+		"node_modules/@jridgewell/trace-mapping": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+			"integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/resolve-uri": "^3.0.3",
+				"@jridgewell/sourcemap-codec": "^1.4.10"
+			}
+		},
+		"node_modules/@kwsites/file-exists": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
+			"integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.1.1"
+			}
+		},
+		"node_modules/@kwsites/promise-deferred": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
+			"integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==",
+			"license": "MIT"
+		},
+		"node_modules/@tsconfig/node10": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+			"integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+			"license": "MIT"
+		},
+		"node_modules/@tsconfig/node12": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+			"integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+			"license": "MIT"
+		},
+		"node_modules/@tsconfig/node14": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+			"integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+			"license": "MIT"
+		},
+		"node_modules/@tsconfig/node16": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+			"integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+			"license": "MIT"
+		},
+		"node_modules/@types/node": {
+			"version": "22.13.13",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.13.tgz",
+			"integrity": "sha512-ClsL5nMwKaBRwPcCvH8E7+nU4GxHVx1axNvMZTFHMEfNI7oahimt26P5zjVCRrjiIWj6YFXfE1v3dEp94wLcGQ==",
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"undici-types": "~6.20.0"
+			}
+		},
+		"node_modules/acorn": {
+			"version": "8.14.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
+			"integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
+			"license": "MIT",
+			"bin": {
+				"acorn": "bin/acorn"
+			},
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/acorn-walk": {
+			"version": "8.3.4",
+			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+			"integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+			"license": "MIT",
+			"dependencies": {
+				"acorn": "^8.11.0"
+			},
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/ansi-escapes": {
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+			"integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+			"license": "MIT",
+			"dependencies": {
+				"type-fest": "^0.21.3"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"license": "MIT",
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/arg": {
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+			"integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+			"license": "MIT"
+		},
+		"node_modules/chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/chardet": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+			"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+			"license": "MIT"
+		},
+		"node_modules/cli-width": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+			"integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+			"license": "ISC",
+			"engines": {
+				"node": ">= 12"
+			}
+		},
+		"node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"license": "MIT",
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"license": "MIT"
+		},
+		"node_modules/commander": {
+			"version": "13.1.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+			"integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/create-require": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+			"integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+			"license": "MIT"
+		},
+		"node_modules/debug": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+			"integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+			"license": "MIT",
+			"dependencies": {
+				"ms": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/diff": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+			"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.3.1"
+			}
+		},
+		"node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"license": "MIT"
+		},
+		"node_modules/external-editor": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+			"integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+			"license": "MIT",
+			"dependencies": {
+				"chardet": "^0.7.0",
+				"iconv-lite": "^0.4.24",
+				"tmp": "^0.0.33"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/iconv-lite": {
+			"version": "0.4.24",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+			"license": "MIT",
+			"dependencies": {
+				"safer-buffer": ">= 2.1.2 < 3"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/inquirer": {
+			"version": "12.5.0",
+			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-12.5.0.tgz",
+			"integrity": "sha512-aiBBq5aKF1k87MTxXDylLfwpRwToShiHrSv4EmB07EYyLgmnjEz5B3rn0aGw1X3JA/64Ngf2T54oGwc+BCsPIQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/core": "^10.1.9",
+				"@inquirer/prompts": "^7.4.0",
+				"@inquirer/type": "^3.0.5",
+				"ansi-escapes": "^4.3.2",
+				"mute-stream": "^2.0.0",
+				"run-async": "^3.0.0",
+				"rxjs": "^7.8.2"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/is-fullwidth-code-point": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/make-error": {
+			"version": "1.3.6",
+			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+			"integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+			"license": "ISC"
+		},
+		"node_modules/ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"license": "MIT"
+		},
+		"node_modules/mute-stream": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
+			"integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
+			"license": "ISC",
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
+		"node_modules/os-tmpdir": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+			"integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/run-async": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/run-async/-/run-async-3.0.0.tgz",
+			"integrity": "sha512-540WwVDOMxA6dN6We19EcT9sc3hkXPw5mzRNGM3FkdN/vtE9NFvj5lFAPNwUDmJjXidm3v7TC1cTE7t17Ulm1Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.12.0"
+			}
+		},
+		"node_modules/rxjs": {
+			"version": "7.8.2",
+			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+			"integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.1.0"
+			}
+		},
+		"node_modules/safer-buffer": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+			"license": "MIT"
+		},
+		"node_modules/signal-exit": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/simple-git": {
+			"version": "3.27.0",
+			"resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.27.0.tgz",
+			"integrity": "sha512-ivHoFS9Yi9GY49ogc6/YAi3Fl9ROnF4VyubNylgCkA+RVqLaKWnDSzXOVzya8csELIaWaYNutsEuAhZrtOjozA==",
+			"license": "MIT",
+			"dependencies": {
+				"@kwsites/file-exists": "^1.1.1",
+				"@kwsites/promise-deferred": "^1.1.1",
+				"debug": "^4.3.5"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/steveukx/git-js?sponsor=1"
+			}
+		},
+		"node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"license": "MIT",
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/tmp": {
+			"version": "0.0.33",
+			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+			"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+			"license": "MIT",
+			"dependencies": {
+				"os-tmpdir": "~1.0.2"
+			},
+			"engines": {
+				"node": ">=0.6.0"
+			}
+		},
+		"node_modules/ts-node": {
+			"version": "10.9.2",
+			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+			"integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@cspotcode/source-map-support": "^0.8.0",
+				"@tsconfig/node10": "^1.0.7",
+				"@tsconfig/node12": "^1.0.7",
+				"@tsconfig/node14": "^1.0.0",
+				"@tsconfig/node16": "^1.0.2",
+				"acorn": "^8.4.1",
+				"acorn-walk": "^8.1.1",
+				"arg": "^4.1.0",
+				"create-require": "^1.1.0",
+				"diff": "^4.0.1",
+				"make-error": "^1.1.1",
+				"v8-compile-cache-lib": "^3.0.1",
+				"yn": "3.1.1"
+			},
+			"bin": {
+				"ts-node": "dist/bin.js",
+				"ts-node-cwd": "dist/bin-cwd.js",
+				"ts-node-esm": "dist/bin-esm.js",
+				"ts-node-script": "dist/bin-script.js",
+				"ts-node-transpile-only": "dist/bin-transpile.js",
+				"ts-script": "dist/bin-script-deprecated.js"
+			},
+			"peerDependencies": {
+				"@swc/core": ">=1.2.50",
+				"@swc/wasm": ">=1.2.50",
+				"@types/node": "*",
+				"typescript": ">=2.7"
+			},
+			"peerDependenciesMeta": {
+				"@swc/core": {
+					"optional": true
+				},
+				"@swc/wasm": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"license": "0BSD"
+		},
+		"node_modules/type-fest": {
+			"version": "0.21.3",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+			"integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+			"license": "(MIT OR CC0-1.0)",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/typescript": {
+			"version": "5.8.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
+			"integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
+			"license": "Apache-2.0",
+			"peer": true,
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=14.17"
+			}
+		},
+		"node_modules/undici-types": {
+			"version": "6.20.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+			"integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/v8-compile-cache-lib": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+			"integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+			"license": "MIT"
+		},
+		"node_modules/wrap-ansi": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+			"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/yn": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+			"integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/yoctocolors-cjs": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.2.tgz",
+			"integrity": "sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		}
+	}
+}

--- a/scripts/compare-perf/package.json
+++ b/scripts/compare-perf/package.json
@@ -1,0 +1,19 @@
+{
+	"name": "compare-perf",
+	"version": "0.0.1",
+	"description": "A tool to compare performance accross tow branches in Studio Monorepo.",
+	"author": "Automattic",
+	"homepage": "https://github.com/Automattic/studio",
+	"license": "GPLv2",
+	"repository": "Automattic/studio",
+	"scripts": {
+		"compare": "ts-node index.ts"
+	},
+	"dependencies": {
+		"chalk": "^4.1.2",
+		"commander": "^13.1.0",
+		"inquirer": "^12.5.0",
+		"simple-git": "^3.27.0",
+		"ts-node": "^10.9.2"
+	}
+}

--- a/scripts/compare-perf/performance.ts
+++ b/scripts/compare-perf/performance.ts
@@ -14,9 +14,6 @@ const formats = {
 	success: chalk.bold.green,
 };
 
-const ARTIFACTS_PATH = process.env.ARTIFACTS_PATH || path.join( process.cwd(), 'artifacts' );
-const RESULTS_FILE_SUFFIX = 'results.json';
-
 interface PerformanceCommandOptions {
 	/**
 	 * Run on CI.
@@ -99,7 +96,8 @@ async function runTestSuite(
 	// Run the test suite
 	await runShellScript( `${ config.testCommand } ${ testSuite }`, testRunnerDir, {
 		...process.env,
-		ARTIFACTS_PATH: ARTIFACTS_PATH,
+		ARTIFACTS_PATH: config.artifactsPath,
+		RESULTS_FILE_SUFFIX: config.resultsFileSuffix,
 		RESULTS_ID: runKey,
 	} );
 }
@@ -115,7 +113,7 @@ export async function runPerformanceTests(
 	options: PerformanceCommandOptions
 ) {
 	const runningInCI = !! process.env.CI || !! options.ci;
-	const TEST_ROUNDS = options.rounds || 1;
+	const testRounds = options.rounds || 1;
 
 	// The default value doesn't work because commander provides an array.
 	if ( branches.length === 0 ) {
@@ -190,7 +188,9 @@ export async function runPerformanceTests(
 
 	logAtIndent( 2, 'Installing dependencies and building' );
 
-	await runShellScript( config.setupTestRunner, testRunnerDir );
+	await runShellScript( config.setupTestRunner, testRunnerDir, {
+		GITHUB_TOKEN: process.env.GITHUB_TOKEN,
+	} );
 
 	logAtIndent( 1, 'Setting up test environments' );
 
@@ -216,7 +216,9 @@ export async function runPerformanceTests(
 		await simpleGit( buildDir ).raw( 'checkout', branch );
 
 		logAtIndent( 3, 'Installing dependencies and building' );
-		await runShellScript( config.setupCommand, buildDir );
+		await runShellScript( config.setupCommand, buildDir, {
+			GITHUB_TOKEN: process.env.GITHUB_TOKEN,
+		} );
 	}
 
 	logAtIndent( 0, 'Looking for test files' );
@@ -224,24 +226,25 @@ export async function runPerformanceTests(
 	const testSuites = getFilesFromDir( path.join( testRunnerDir, config.testsPath ) ).map(
 		( file: string ) => {
 			logAtIndent( 1, 'Found:', formats.success( file ) );
-			return path.basename( file, '.test.ts' );
+			return path.basename( file, config.testFileSuffix );
 		}
 	);
 
 	logAtIndent( 0, 'Running tests' );
 
 	for ( const testSuite of testSuites ) {
-		for ( let i = 1; i <= TEST_ROUNDS; i++ ) {
+		for ( let i = 1; i <= testRounds; i++ ) {
 			logAtIndent(
 				1,
 				// prettier-ignore
-				`Suite: ${ formats.success( testSuite ) } (round ${ i } of ${ TEST_ROUNDS })`
+				`Suite: ${ formats.success( testSuite ) } (round ${ i } of ${ testRounds })`
 			);
 
 			for ( const branch of branches ) {
 				logAtIndent( 2, 'Branch:', formats.success( branch ) );
 				const sanitizedBranchName = sanitizeBranchName( branch );
 				const runKey = `${ testSuite }_${ sanitizedBranchName }_round-${ i }`;
+
 				logAtIndent( 3, 'Running tests' );
 				await runTestSuite(
 					testSuite,
@@ -255,9 +258,10 @@ export async function runPerformanceTests(
 
 	logAtIndent( 0, 'Calculating results' );
 
-	const resultFiles = getFilesFromDir( ARTIFACTS_PATH ).filter( ( file: string ) =>
-		file.endsWith( RESULTS_FILE_SUFFIX )
+	const resultFiles = getFilesFromDir( config.artifactsPath ).filter( ( file: string ) =>
+		file.endsWith( config.resultsFileSuffix )
 	);
+
 	/** @type {Record<string,Record<string, Record<string, number>>>} */
 	const results: Record< string, Record< string, Record< string, number > > > = {};
 
@@ -291,7 +295,10 @@ export async function runPerformanceTests(
 				}
 			}
 		}
-		const calculatedResultsPath = path.join( ARTIFACTS_PATH, testSuite + RESULTS_FILE_SUFFIX );
+		const calculatedResultsPath = path.join(
+			config.artifactsPath,
+			testSuite + config.summaryFileSuffix
+		);
 
 		logAtIndent( 2, 'Saving curated results to:', formats.success( calculatedResultsPath ) );
 		fs.writeFileSync( calculatedResultsPath, JSON.stringify( results[ testSuite ], null, 2 ) );

--- a/scripts/compare-perf/performance.ts
+++ b/scripts/compare-perf/performance.ts
@@ -1,0 +1,318 @@
+/* eslint-disable no-console */
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import chalk from 'chalk';
+import { simpleGit } from 'simple-git';
+import config from './config';
+import { runShellScript, readJSONFile, askForConfirmation, getFilesFromDir } from './utils';
+
+const formats = {
+	title: chalk.bold,
+	error: chalk.bold.red,
+	warning: chalk.bold.hex( '#FFA500' ),
+	success: chalk.bold.green,
+};
+
+const ARTIFACTS_PATH = process.env.ARTIFACTS_PATH || path.join( process.cwd(), 'artifacts' );
+const RESULTS_FILE_SUFFIX = 'results.json';
+
+interface PerformanceCommandOptions {
+	/**
+	 * Run on CI.
+	 */
+	ci?: boolean;
+	/**
+	 * Run each test suite this many times for each branch.
+	 */
+	rounds?: number;
+	/**
+	 * The branch whose performance test files will be used for testing.
+	 */
+	testsBranch?: string;
+}
+
+/**
+ * A logging helper for printing steps and their substeps.
+ *
+ * @param indent Value to indent the log.
+ * @param msg    Message to log.
+ * @paramargs   Rest of the arguments to pass to console.log.
+ */
+function logAtIndent( indent: number, msg: string, ...args: string[] ) {
+	const prefix = indent === 0 ? '▶ ' : '> ';
+	const newline = indent === 0 ? '\n' : '';
+	return console.log( newline + '    '.repeat( indent ) + prefix + msg, ...args );
+}
+
+/**
+ * Sanitizes branch name to be used in a path or a filename.
+ *
+ * @param branch
+ *
+ * @return Sanitized branch name.
+ */
+function sanitizeBranchName( branch: string ): string {
+	return branch.replace( /[^a-zA-Z0-9-]/g, '-' );
+}
+
+/**
+ * Computes the median number from an array numbers.
+ *
+ * @param array
+ *
+ * @return Median value or undefined if array empty.
+ */
+function median( array: number[] ): number | undefined {
+	if ( ! array || ! array.length ) return undefined;
+
+	const numbers = [ ...array ].sort( ( a, b ) => a - b );
+	const middleIndex = Math.floor( numbers.length / 2 );
+
+	if ( numbers.length % 2 === 0 ) {
+		return ( numbers[ middleIndex - 1 ] + numbers[ middleIndex ] ) / 2;
+	}
+	return numbers[ middleIndex ];
+}
+
+/**
+ * Runs the performance tests on the current branch.
+ *
+ * @param testSuite     Name of the tests set.
+ * @param testRunnerDir Path to the performance tests' clone.
+ * @param runKey        Unique identifier for the test run.
+ * @param branchDir     Path to the branch's clone.
+ */
+async function runTestSuite(
+	testSuite: string,
+	testRunnerDir: string,
+	runKey: string,
+	branchDir: string
+) {
+	const outDir = path.join( branchDir, 'out' );
+	const testRunnerOutDir = path.join( testRunnerDir, 'out' );
+	if ( fs.existsSync( testRunnerOutDir ) ) {
+		fs.rmSync( testRunnerOutDir, { recursive: true } );
+	}
+	fs.symlinkSync( outDir, testRunnerOutDir, 'dir' );
+
+	// Run the test suite
+	await runShellScript( `${ config.testCommand } ${ testSuite }`, testRunnerDir, {
+		...process.env,
+		ARTIFACTS_PATH: ARTIFACTS_PATH,
+		RESULTS_ID: runKey,
+	} );
+}
+
+/**
+ * Runs the performances tests on an array of branches and output the result.
+ *
+ * @param branches Branches to compare
+ * @param options  Command options.
+ */
+export async function runPerformanceTests(
+	branches: string[],
+	options: PerformanceCommandOptions
+) {
+	const runningInCI = !! process.env.CI || !! options.ci;
+	const TEST_ROUNDS = options.rounds || 1;
+
+	// The default value doesn't work because commander provides an array.
+	if ( branches.length === 0 ) {
+		branches = [ 'trunk' ];
+	}
+
+	console.log( formats.title( '\n💃 Performance Tests 🕺' ) );
+	console.log(
+		'\nWelcome! This tool runs the performance tests on multiple branches and displays a comparison table.'
+	);
+
+	if ( ! runningInCI ) {
+		await askForConfirmation( 'Ready to go? ' );
+	}
+
+	logAtIndent( 0, 'Setting up' );
+
+	/**
+	 * @type {string[]} git refs against which to run tests;
+	 *                  could be commit SHA, branch name, tag, etc...
+	 */
+	if ( branches.length < 2 ) {
+		//	throw new Error( `Need at least two git refs to run` );
+	}
+
+	const baseDir = path.join( os.tmpdir(), 'studio-performance-tests' );
+
+	if ( fs.existsSync( baseDir ) ) {
+		logAtIndent( 1, 'Removing existing files' );
+		fs.rmSync( baseDir, { recursive: true } );
+	}
+
+	logAtIndent( 1, 'Creating base directory:', formats.success( baseDir ) );
+	fs.mkdirSync( baseDir );
+
+	logAtIndent( 1, 'Setting up repository' );
+	const sourceDir = path.join( baseDir, 'source' );
+
+	logAtIndent( 2, 'Creating directory:', formats.success( sourceDir ) );
+	fs.mkdirSync( sourceDir );
+
+	const sourceGit = simpleGit( sourceDir );
+	logAtIndent( 2, 'Initializing:', formats.success( config.gitRepositoryURL ) );
+	await sourceGit.raw( 'init' ).raw( 'remote', 'add', 'origin', config.gitRepositoryURL );
+
+	for ( const [ i, branch ] of branches.entries() ) {
+		logAtIndent(
+			2,
+			`Fetching environment branch (${ i + 1 } of ${ branches.length }):`,
+			formats.success( branch )
+		);
+		await sourceGit.raw( 'fetch', '--depth=1', 'origin', branch );
+	}
+
+	const testRunnerBranch = options.testsBranch || branches[ 0 ];
+	if ( options.testsBranch && ! branches.includes( options.testsBranch ) ) {
+		logAtIndent( 2, 'Fetching test runner branch:', formats.success( options.testsBranch ) );
+		await sourceGit.raw( 'fetch', '--depth=1', 'origin', options.testsBranch );
+	} else {
+		logAtIndent( 2, 'Using test runner branch:', formats.success( testRunnerBranch ) );
+	}
+
+	logAtIndent( 1, 'Setting up test runner' );
+
+	const testRunnerDir = path.join( baseDir + '/tests' );
+
+	logAtIndent( 2, 'Copying source to:', formats.success( testRunnerDir ) );
+	await runShellScript( `cp -R  ${ sourceDir } ${ testRunnerDir }` );
+
+	logAtIndent( 2, 'Checking out branch:', formats.success( testRunnerBranch ) );
+	await simpleGit( testRunnerDir ).raw( 'checkout', testRunnerBranch );
+
+	logAtIndent( 2, 'Installing dependencies and building' );
+
+	await runShellScript( config.setupTestRunner, testRunnerDir );
+
+	logAtIndent( 1, 'Setting up test environments' );
+
+	const envsDir = path.join( baseDir, 'environments' );
+	logAtIndent( 2, 'Creating parent directory:', formats.success( envsDir ) );
+	fs.mkdirSync( envsDir );
+
+	const branchDirs: Record< string, string > = {};
+	for ( const branch of branches ) {
+		logAtIndent( 2, 'Branch:', formats.success( branch ) );
+		const sanitizedBranchName = sanitizeBranchName( branch );
+		const envDir = path.join( envsDir, sanitizedBranchName );
+
+		logAtIndent( 3, 'Creating directory:', formats.success( envDir ) );
+		fs.mkdirSync( envDir );
+		branchDirs[ branch ] = envDir;
+		const buildDir = path.join( envDir, 'app' );
+
+		logAtIndent( 3, 'Copying source to:', formats.success( buildDir ) );
+		await runShellScript( `cp -R ${ sourceDir } ${ buildDir }` );
+
+		logAtIndent( 3, 'Checking out:', formats.success( branch ) );
+		await simpleGit( buildDir ).raw( 'checkout', branch );
+
+		logAtIndent( 3, 'Installing dependencies and building' );
+		await runShellScript( config.setupCommand, buildDir );
+	}
+
+	logAtIndent( 0, 'Looking for test files' );
+
+	const testSuites = getFilesFromDir( path.join( testRunnerDir, config.testsPath ) ).map(
+		( file: string ) => {
+			logAtIndent( 1, 'Found:', formats.success( file ) );
+			return path.basename( file, '.test.ts' );
+		}
+	);
+
+	logAtIndent( 0, 'Running tests' );
+
+	for ( const testSuite of testSuites ) {
+		for ( let i = 1; i <= TEST_ROUNDS; i++ ) {
+			logAtIndent(
+				1,
+				// prettier-ignore
+				`Suite: ${ formats.success( testSuite ) } (round ${ i } of ${ TEST_ROUNDS })`
+			);
+
+			for ( const branch of branches ) {
+				logAtIndent( 2, 'Branch:', formats.success( branch ) );
+				const sanitizedBranchName = sanitizeBranchName( branch );
+				const runKey = `${ testSuite }_${ sanitizedBranchName }_round-${ i }`;
+				logAtIndent( 3, 'Running tests' );
+				await runTestSuite(
+					testSuite,
+					testRunnerDir,
+					runKey,
+					path.join( branchDirs[ branch ], 'app' )
+				);
+			}
+		}
+	}
+
+	logAtIndent( 0, 'Calculating results' );
+
+	const resultFiles = getFilesFromDir( ARTIFACTS_PATH ).filter( ( file: string ) =>
+		file.endsWith( RESULTS_FILE_SUFFIX )
+	);
+	/** @type {Record<string,Record<string, Record<string, number>>>} */
+	const results: Record< string, Record< string, Record< string, number > > > = {};
+
+	// Calculate medians from all rounds.
+	for ( const testSuite of testSuites ) {
+		logAtIndent( 1, 'Test suite:', formats.success( testSuite ) );
+
+		results[ testSuite ] = {};
+		for ( const branch of branches ) {
+			const sanitizedBranchName = sanitizeBranchName( branch );
+			const resultsRounds = resultFiles
+				.filter( ( file: string ) =>
+					file.includes( `${ testSuite }_${ sanitizedBranchName }_round-` )
+				)
+				.map( ( file: string ) => {
+					logAtIndent( 2, 'Reading from:', formats.success( file ) );
+					return readJSONFile( file );
+				} );
+
+			const metrics = Object.keys( resultsRounds[ 0 ] );
+			results[ testSuite ][ branch ] = {};
+
+			for ( const metric of metrics ) {
+				const values = resultsRounds
+					.map( ( round: Record< string, number > ) => round[ metric ] )
+					.filter( ( value: number ) => typeof value === 'number' );
+
+				const value = median( values );
+				if ( value !== undefined ) {
+					results[ testSuite ][ branch ][ metric ] = value;
+				}
+			}
+		}
+		const calculatedResultsPath = path.join( ARTIFACTS_PATH, testSuite + RESULTS_FILE_SUFFIX );
+
+		logAtIndent( 2, 'Saving curated results to:', formats.success( calculatedResultsPath ) );
+		fs.writeFileSync( calculatedResultsPath, JSON.stringify( results[ testSuite ], null, 2 ) );
+	}
+
+	logAtIndent( 0, 'Printing results' );
+
+	for ( const testSuite of testSuites ) {
+		logAtIndent( 0, formats.success( testSuite ) );
+
+		// Invert the results so we can display them in a table.
+		/** @type {Record<string, Record<string, string>>} */
+		const invertedResult: Record< string, Record< string, string > > = {};
+		for ( const [ branch, metrics ] of Object.entries( results[ testSuite ] ) ) {
+			for ( const [ metric, value ] of Object.entries( metrics ) ) {
+				invertedResult[ metric ] = invertedResult[ metric ] || {};
+				invertedResult[ metric ][ branch ] = `${ value } ms`;
+			}
+		}
+
+		// Print the results.
+		console.table( invertedResult );
+	}
+}

--- a/scripts/compare-perf/performance.ts
+++ b/scripts/compare-perf/performance.ts
@@ -138,7 +138,7 @@ export async function runPerformanceTests(
 	 *                  could be commit SHA, branch name, tag, etc...
 	 */
 	if ( branches.length < 2 ) {
-		//	throw new Error( `Need at least two git refs to run` );
+		throw new Error( `Need at least two git refs to run` );
 	}
 
 	const baseDir = path.join( os.tmpdir(), 'studio-performance-tests' );

--- a/scripts/compare-perf/utils.ts
+++ b/scripts/compare-perf/utils.ts
@@ -1,0 +1,96 @@
+/* eslint-disable no-console */
+import childProcess from 'child_process';
+import fs from 'fs';
+import path from 'path';
+import chalk from 'chalk';
+import inquirer from 'inquirer';
+
+/**
+ * Utility to run a child script
+ *
+ * @param script Script to run.
+ * @param cwd    Working directory.
+ * @param env    Additional environment variables to pass to the script.
+ */
+export function runShellScript( script: string, cwd?: string, env: NodeJS.ProcessEnv = {} ) {
+	return new Promise( ( resolve, reject ) => {
+		childProcess.exec(
+			script,
+			{
+				cwd,
+				env: {
+					NO_CHECKS: 'true',
+					PATH: process.env.PATH,
+					HOME: process.env.HOME,
+					USER: process.env.USER,
+					...env,
+				},
+			},
+			function ( error, stdout, stderr ) {
+				if ( error ) {
+					console.log( stdout ); // Sometimes the error message is thrown via stdout.
+					console.log( stderr );
+					reject( error );
+				} else {
+					resolve( true );
+				}
+			}
+		);
+	} );
+}
+
+/**
+ * Small utility used to read an uncached version of a JSON file
+ *
+ * @param fileName
+ */
+export function readJSONFile( fileName: string ) {
+	const data = fs.readFileSync( fileName, 'utf8' );
+	return JSON.parse( data );
+}
+
+/**
+ * Asks the user for a confirmation to continue or abort otherwise.
+ *
+ * @param message      Confirmation message.
+ * @param isDefault    Default reply.
+ * @param abortMessage Abort message.
+ */
+export async function askForConfirmation(
+	message: string,
+	isDefault: boolean = true,
+	abortMessage: string = 'Aborting.'
+) {
+	const { isReady } = await inquirer.prompt( [
+		{
+			type: 'confirm',
+			name: 'isReady',
+			default: isDefault,
+			message,
+		},
+	] );
+
+	if ( ! isReady ) {
+		console.log( chalk.bold.red( '\n' + abortMessage ) );
+		process.exit( 1 );
+	}
+}
+
+/**
+ * Scans the given directory and returns an array of file paths.
+ *
+ * @param dir The path to the directory to scan.
+ *
+ * @return An array of file paths.
+ */
+export function getFilesFromDir( dir: string ): string[] {
+	if ( ! fs.existsSync( dir ) ) {
+		console.log( 'Directory does not exist: ', dir );
+		return [];
+	}
+
+	return fs
+		.readdirSync( dir, { withFileTypes: true } )
+		.filter( ( dirent ) => dirent.isFile() )
+		.map( ( dirent ) => path.join( dir, dirent.name ) );
+}

--- a/src/lib/sqlite-command-release.ts
+++ b/src/lib/sqlite-command-release.ts
@@ -7,8 +7,27 @@ export interface GithubRelease {
 }
 
 export async function getLatestSQLiteCommandRelease(): Promise< GithubRelease > {
-	const response = await fetch(
-		`https://api.github.com/repos/automattic/wp-cli-sqlite-command/releases/latest`
-	);
-	return ( await response.json() ) as GithubRelease;
+	const url = 'https://api.github.com/repos/automattic/wp-cli-sqlite-command/releases/latest';
+
+	const headers: HeadersInit = {
+		Accept: 'application/vnd.github.v3+json',
+		'User-Agent': 'wp-now-cli',
+	};
+
+	// GitHub API has rate limits:
+	// - 60 requests/hour for unauthenticated requests
+	// - 5,000 requests/hour with token authentication
+	// In CI environments, the IP-based rate limit is shared across runners,
+	// so we authenticate with GITHUB_TOKEN when available.
+	if ( process.env.GITHUB_TOKEN ) {
+		headers.Authorization = `token ${ process.env.GITHUB_TOKEN }`;
+	}
+
+	const response = await fetch( url, { headers } );
+
+	if ( ! response.ok ) {
+		throw new Error( `GitHub API request failed: ${ response.status } ${ response.statusText }` );
+	}
+
+	return await response.json();
 }


### PR DESCRIPTION
## Related issues

Fixes DOTCOM-670-linear-issue

## Changes proposed in this Pull Request:

**Big Picture** My goal is to bring metrics tracking and performance dashboard to the tools Studio use daily to avoid performance regressions and work on performance improvements similarly to the [Gutenberg project](https://www.codevitals.run/project/gutenberg) for instance.

Implementing this require three complementary steps:

 1- First step is to have some test runner (e2e test here) that we can launch to compute the metrics.
 2- Second step is to be able to use the same test runner in two separate branches as part of the same CI job. The reason for this is that CI runners capacities are unstable and we can't rely on the absolute numbers. We have to compute relative numbers and compare each commit with a given "base commit".
 3- Third step is to send these values (base branch and commit) to the dashboard (codevitals) to log it and produce the graphs.

The first step is being implemented in https://github.com/Automattic/studio/pull/1119
The current PR implements the second step. 

So it adds a "compare-perf" tool that was copied and adapted from the Woo and Gutenberg repository. It's almost a generic tool. the only specific things at the moment is the `config.js` file and some specifics about switching apps to use for the e2e test depending on the branch we're running. 

The PR also adds a "metrics" workflow to CI. The workflow runs for each PR and compare its metrics with trunk. And it also runs on trunk for each commit and compares the commit with a "fixed" point of comparison (this is going to be used later to track the number on a graph like [here](http://codevitals.run)) 

### How to test the changes in this Pull Request:

You can run the perf tool locally like so (give random commits or tags to compare, the first commit must include the perf tests though as it's going to be used to run the tests)

```
cd tools/compare-perf
pnpm test perf 1485688ecf2e4746306879d938f5099493ab3d4b  trunk
```

you'll get something close to the following results:

<img width="1193" alt="Screenshot 2025-03-25 at 1 19 30 PM" src="https://github.com/user-attachments/assets/944d3325-2c9c-42e8-95c5-d7ecb78c9689" />

Also, we can check the results of the "metrics" workflow on the PR as well.
