### PR TITLE
Add support for IDE installed in user's home directory

### DIFF
--- a/src/lib/is-installed.ts
+++ b/src/lib/is-installed.ts
@@ -2,22 +2,32 @@ import { app } from 'electron';
 import fs from 'fs';
 import path from 'path';
 
-let appPaths: Record< keyof InstalledApps, string >;
+let appPaths: Record< keyof InstalledApps, string[] >;
 
 if ( process.platform === 'darwin' ) {
+	// Get both system and user Applications directories
+	const systemApplications = '/Applications';
+	const userApplications = path.join( app.getPath( 'home' ), 'Applications' );
+
 	appPaths = {
-		vscode: '/Applications/Visual Studio Code.app',
-		phpstorm: '/Applications/PhpStorm.app',
+		vscode: [
+			path.join( systemApplications, 'Visual Studio Code.app' ),
+			path.join( userApplications, 'Visual Studio Code.app' ),
+		],
+		phpstorm: [
+			path.join( systemApplications, 'PhpStorm.app' ),
+			path.join( userApplications, 'PhpStorm.app' ),
+		],
 	};
 } else if ( process.platform === 'linux' ) {
 	appPaths = {
-		vscode: '/usr/bin/code',
-		phpstorm: '/usr/bin/phpstorm',
+		vscode: [ '/usr/bin/code' ],
+		phpstorm: [ '/usr/bin/phpstorm' ],
 	};
 } else if ( process.platform === 'win32' ) {
 	appPaths = {
-		vscode: path.join( app.getPath( 'appData' ), 'Code' ),
-		phpstorm: '', // Disable phpStorm for Windows
+		vscode: [ path.join( app.getPath( 'appData' ), 'Code' ) ],
+		phpstorm: [ '' ], // Disable phpStorm for Windows
 	};
 }
 
@@ -25,5 +35,6 @@ export function isInstalled( key: keyof typeof appPaths ): boolean {
 	if ( ! appPaths[ key ] ) {
 		return false;
 	}
-	return fs.existsSync( appPaths[ key ] );
+	// Return true if any of the possible paths exist
+	return appPaths[ key ].some( ( path ) => path && fs.existsSync( path ) );
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/studio/issues/21 (STU-2)

## Proposed Changes

Currently, Studio only checks for VS Code and PHPStorm in the system-wide `/Applications` directory. This change adds support for detecting these apps in the user's `~/Applications` directory as well.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Install VS Code or PHPStorm in your user's Applications folder (`~/Applications`)
2. Verify that Studio detects the app in the user's Applications folder
3. Verify that Studio still detects apps in the system-wide `/Applications` folder
4. Verify that the detection still works on Windows

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
