### PR TITLE
Fix metrics job errors

### DIFF
--- a/.github/workflows/metrics-comparison.yml
+++ b/.github/workflows/metrics-comparison.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Compare performance with trunk
         if: github.event_name == 'pull_request'
-        run: cd scripts/compare-perf && npm install && npm run compare -- perf $GITHUB_SHA trunk --tests-branch $GITHUB_SHA
+        run: cd scripts/compare-perf && npm ci && npm run compare -- perf $GITHUB_SHA trunk --tests-branch $GITHUB_SHA
 
       - name: Compare performance with base branch
         if: github.event_name == 'push'
@@ -42,7 +42,7 @@ jobs:
         # it needs to be updated every time it becomes unsupported by the current performance tests.
         # It is used as a base comparison point to avoid fluctuation in the performance metrics.
         run: |
-          cd scripts/compare-perf && npm install && npm run compare -- perf $GITHUB_SHA c954cc2228eab819118ab6e84e22dd0223faacfe --tests-branch $GITHUB_SHA
+          cd scripts/compare-perf && npm ci && npm run compare -- perf $GITHUB_SHA c954cc2228eab819118ab6e84e22dd0223faacfe --tests-branch $GITHUB_SHA
       - name: Archive performance results
         if: success()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/metrics-comparison.yml
+++ b/.github/workflows/metrics-comparison.yml
@@ -49,3 +49,11 @@ jobs:
         with:
           name: performance-results
           path: ${{ env.WP_ARTIFACTS_PATH }}/*.performance-results*.json
+
+      - name: Archive debug artifacts (screenshots, HTML snapshots)
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        if: failure()
+        with:
+          name: failures-artifacts
+          path: ${{ env.WP_ARTIFACTS_PATH }}
+          if-no-files-found: ignore

--- a/.github/workflows/metrics-comparison.yml
+++ b/.github/workflows/metrics-comparison.yml
@@ -48,12 +48,12 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: performance-results
-          path: ${{ env.WP_ARTIFACTS_PATH }}/*.performance-results*.json
+          path: ${{ env.ARTIFACTS_PATH }}/*.performance-results*.json
 
       - name: Archive debug artifacts (screenshots, HTML snapshots)
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         if: failure()
         with:
           name: failures-artifacts
-          path: ${{ env.WP_ARTIFACTS_PATH }}
+          path: ${{ env.ARTIFACTS_PATH }}
           if-no-files-found: ignore

--- a/.github/workflows/metrics-comparison.yml
+++ b/.github/workflows/metrics-comparison.yml
@@ -19,12 +19,13 @@ jobs:
       contents: read
     env:
       ARTIFACTS_PATH: ${{ github.workspace }}/artifacts
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -37,14 +38,14 @@ jobs:
       - name: Compare performance with base branch
         if: github.event_name == 'push'
         # The base hash used here need to be a commit that is compatible with the current performance tests.
-        # The current one is c954cc2228eab819118ab6e84e22dd0223faacfe 
+        # The current one is c954cc2228eab819118ab6e84e22dd0223faacfe
         # it needs to be updated every time it becomes unsupported by the current performance tests.
         # It is used as a base comparison point to avoid fluctuation in the performance metrics.
         run: |
-            cd scripts/compare-perf && npm install && npm run compare -- perf $GITHUB_SHA c954cc2228eab819118ab6e84e22dd0223faacfe --tests-branch $GITHUB_SHA
+          cd scripts/compare-perf && npm install && npm run compare -- perf $GITHUB_SHA c954cc2228eab819118ab6e84e22dd0223faacfe --tests-branch $GITHUB_SHA
       - name: Archive performance results
         if: success()
         uses: actions/upload-artifact@v4
         with:
-            name: performance-results
-            path: ${{ env.WP_ARTIFACTS_PATH }}/*.performance-results*.json
+          name: performance-results
+          path: ${{ env.WP_ARTIFACTS_PATH }}/*.performance-results*.json

--- a/.github/workflows/metrics-comparison.yml
+++ b/.github/workflows/metrics-comparison.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Compare performance with trunk
         if: github.event_name == 'pull_request'
-        run: cd scripts/compare-perf && npm ci && npm run compare -- perf $GITHUB_SHA trunk --tests-branch $GITHUB_SHA
+        run: cd scripts/compare-perf && npm ci && npm run compare -- perf $GITHUB_SHA $GITHUB_SHA --tests-branch $GITHUB_SHA
 
       - name: Compare performance with base branch
         if: github.event_name == 'push'
@@ -42,7 +42,7 @@ jobs:
         # it needs to be updated every time it becomes unsupported by the current performance tests.
         # It is used as a base comparison point to avoid fluctuation in the performance metrics.
         run: |
-          cd scripts/compare-perf && npm ci && npm run compare -- perf $GITHUB_SHA c954cc2228eab819118ab6e84e22dd0223faacfe --tests-branch $GITHUB_SHA
+          cd scripts/compare-perf && npm ci && npm run compare -- perf $GITHUB_SHA $GITHUB_SHA --tests-branch $GITHUB_SHA
       - name: Archive performance results
         if: success()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/metrics-comparison.yml
+++ b/.github/workflows/metrics-comparison.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Compare performance with trunk
         if: github.event_name == 'pull_request'
-        run: cd scripts/compare-perf && npm ci && npm run compare -- perf $GITHUB_SHA b966f334fc38f0f8d57cecea3ef190b2721dc2db --tests-branch $GITHUB_SHA
+        run: cd scripts/compare-perf && npm ci && npm run compare -- perf $GITHUB_SHA trunk --tests-branch $GITHUB_SHA
 
       - name: Compare performance with base branch
         if: github.event_name == 'push'
@@ -43,7 +43,8 @@ jobs:
         # it needs to be updated every time it becomes unsupported by the current performance tests.
         # It is used as a base comparison point to avoid fluctuation in the performance metrics.
         run: |
-          cd scripts/compare-perf && npm ci && npm run compare -- perf $GITHUB_SHA b966f334fc38f0f8d57cecea3ef190b2721dc2db --tests-branch $GITHUB_SHA
+          cd scripts/compare-perf && npm ci && npm run compare -- perf $GITHUB_SHA c954cc2228eab819118ab6e84e22dd0223faacfe --tests-branch $GITHUB_SHA
+
       - name: Archive performance results
         if: success()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/metrics-comparison.yml
+++ b/.github/workflows/metrics-comparison.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Compare performance with trunk
         if: github.event_name == 'pull_request'
-        run: cd scripts/compare-perf && npm ci && npm run compare -- perf $GITHUB_SHA $GITHUB_SHA --tests-branch $GITHUB_SHA
+        run: cd scripts/compare-perf && npm ci && npm run compare -- perf $GITHUB_SHA b966f334fc38f0f8d57cecea3ef190b2721dc2db --tests-branch $GITHUB_SHA
 
       - name: Compare performance with base branch
         if: github.event_name == 'push'
@@ -42,7 +42,7 @@ jobs:
         # it needs to be updated every time it becomes unsupported by the current performance tests.
         # It is used as a base comparison point to avoid fluctuation in the performance metrics.
         run: |
-          cd scripts/compare-perf && npm ci && npm run compare -- perf $GITHUB_SHA $GITHUB_SHA --tests-branch $GITHUB_SHA
+          cd scripts/compare-perf && npm ci && npm run compare -- perf $GITHUB_SHA b966f334fc38f0f8d57cecea3ef190b2721dc2db --tests-branch $GITHUB_SHA
       - name: Archive performance results
         if: success()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/metrics-comparison.yml
+++ b/.github/workflows/metrics-comparison.yml
@@ -20,6 +20,7 @@ jobs:
     env:
       ARTIFACTS_PATH: ${{ github.workspace }}/artifacts
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      FORCE_COLOR: '1'
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/metrics-comparison.yml
+++ b/.github/workflows/metrics-comparison.yml
@@ -46,16 +46,8 @@ jobs:
           cd scripts/compare-perf && npm ci && npm run compare -- perf $GITHUB_SHA c954cc2228eab819118ab6e84e22dd0223faacfe --tests-branch $GITHUB_SHA
 
       - name: Archive performance results
-        if: success()
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
           name: performance-results
-          path: ${{ env.ARTIFACTS_PATH }}/*.performance-results*.json
-
-      - name: Archive debug artifacts (screenshots, HTML snapshots)
-        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
-        if: failure()
-        with:
-          name: failures-artifacts
           path: ${{ env.ARTIFACTS_PATH }}
-          if-no-files-found: ignore

--- a/metrics/performance-reporter.ts
+++ b/metrics/performance-reporter.ts
@@ -4,6 +4,10 @@ import type { Reporter, FullResult, TestCase, TestResult } from '@playwright/tes
 
 export type PerformanceResults = Record< string, number >;
 
+if ( ! process.env.ARTIFACTS_PATH ) {
+	throw new Error( 'ARTIFACTS_PATH is not set' );
+}
+
 class PerformanceReporter implements Reporter {
 	private results: Record< string, PerformanceResults >;
 
@@ -21,16 +25,17 @@ class PerformanceReporter implements Reporter {
 				throw new Error( 'Empty results attachment' );
 			}
 
-			const testSuite = path.basename( test.location.file, '.test.js' );
+			const testSuite = path.basename( test.location.file, '.test.ts' );
 			const resultsId = process.env.RESULTS_ID || testSuite;
 			const resultsPath = process.env.ARTIFACTS_PATH as string;
 			const resultsBody = attachment.body.toString();
+			const resultsFileSuffix = process.env.RESULTS_FILE_SUFFIX || '.results.json';
 			const results = JSON.parse( resultsBody );
 
 			if ( ! existsSync( resultsPath ) ) {
 				mkdirSync( resultsPath, { recursive: true } );
 			}
-			writeFileSync( path.join( resultsPath, `${ resultsId }-results.json` ), resultsBody );
+			writeFileSync( path.join( resultsPath, resultsId + resultsFileSuffix ), resultsBody );
 
 			this.results[ testSuite ] = results;
 		}

--- a/metrics/playwright.metrics.config.ts
+++ b/metrics/playwright.metrics.config.ts
@@ -8,7 +8,5 @@ export default defineConfig( {
 	...baseConfig,
 	testDir: './tests',
 	testMatch: /.*\.test\.ts/,
-	reporter: process.env.CI
-		? './performance-reporter.ts'
-		: [ [ 'list' ], [ './performance-reporter.ts' ] ],
+	reporter: [ [ 'list' ], [ './performance-reporter.ts' ] ],
 } );

--- a/metrics/playwright.metrics.config.ts
+++ b/metrics/playwright.metrics.config.ts
@@ -9,4 +9,11 @@ export default defineConfig( {
 	testDir: './tests',
 	testMatch: /.*\.test\.ts/,
 	reporter: [ [ 'list' ], [ './performance-reporter.ts' ] ],
+	outputDir: path.join( process.env.ARTIFACTS_PATH, 'test-results' ),
+	use: {
+		headless: true,
+		trace: 'on',
+		screenshot: 'on',
+		video: 'on',
+	},
 } );

--- a/metrics/playwright.metrics.config.ts
+++ b/metrics/playwright.metrics.config.ts
@@ -16,4 +16,5 @@ export default defineConfig( {
 		screenshot: 'on',
 		video: 'on',
 	},
+	timeout: 120_000,
 } );

--- a/metrics/playwright.metrics.config.ts
+++ b/metrics/playwright.metrics.config.ts
@@ -2,19 +2,29 @@ import path from 'path';
 import { defineConfig } from '@playwright/test';
 import baseConfig from '../playwright.config';
 
-process.env.ARTIFACTS_PATH ??= path.join( process.cwd(), 'artifacts' );
+process.env.ARTIFACTS_PATH ??= path.join( __dirname, 'artifacts' );
 
 export default defineConfig( {
 	...baseConfig,
 	testDir: './tests',
-	testMatch: /.*\.test\.ts/,
+	testMatch: '*.test.ts',
 	reporter: [ [ 'list' ], [ './performance-reporter.ts' ] ],
 	outputDir: path.join( process.env.ARTIFACTS_PATH, 'test-results' ),
+	forbidOnly: !! process.env.CI,
+	fullyParallel: false,
+	retries: 0,
+	timeout: parseInt( process.env.TIMEOUT || '', 10 ) || 600_000, // Defaults to 10 minutes.
+	reportSlowTests: null,
 	use: {
+		...baseConfig.use,
+		actionTimeout: 120_000, // 2 minutes.
 		headless: true,
-		trace: 'on',
-		screenshot: 'on',
-		video: 'on',
+		// Enable only for debugging.
+		trace: 'off',
+		screenshot: 'off',
+		video: 'off',
 	},
-	timeout: 120_000,
+	expect: {
+		timeout: 120_000, // 2 minutes.
+	},
 } );

--- a/metrics/tests/site-startup.test.ts
+++ b/metrics/tests/site-startup.test.ts
@@ -22,9 +22,11 @@ test.describe( 'Startup Metrics', () => {
 	// eslint-disable-next-line no-empty-pattern
 	test.afterAll( async ( {}, testInfo ) => {
 		const medians = {};
+
 		Object.keys( results ).map( ( metric ) => {
 			medians[ metric ] = median( results[ metric ] );
 		} );
+
 		await testInfo.attach( 'results', {
 			body: JSON.stringify( medians, null, 2 ),
 			contentType: 'application/json',
@@ -34,53 +36,63 @@ test.describe( 'Startup Metrics', () => {
 	} );
 
 	test( 'measure site creation and startup performance', async () => {
+		let modal;
+		let siteContent;
+
 		// Create a new site first (without timing)
-		const sidebar = new MainSidebar( session.mainWindow );
-		const modal = await sidebar.openAddSiteModal();
-		await modal.siteNameInput.fill( siteName );
+		await test.step( 'Create a new site', async () => {
+			const sidebar = new MainSidebar( session.mainWindow );
+			modal = await sidebar.openAddSiteModal();
+			await modal.siteNameInput.fill( siteName );
+		} );
 
 		// Measure site creation time (includes initial startup time)
-		const startTime = Date.now();
-		await modal.addSiteButton.click();
-		const siteContent = new SiteContent( session.mainWindow, siteName );
-		await expect( siteContent.runningButton ).toBeAttached( { timeout: 60_000 } );
-		const endTime = Date.now();
-		const duration = endTime - startTime;
-		results.siteCreation = [ duration ];
+		await test.step( 'Measure site creation time', async () => {
+			const startTime = Date.now();
+			await modal.addSiteButton.click();
+			siteContent = new SiteContent( session.mainWindow, siteName );
+			await expect( siteContent.runningButton ).toBeAttached();
+			const endTime = Date.now();
+			const duration = endTime - startTime;
+			results.siteCreation = [ duration ];
+		} );
 
 		results.siteStartup = [];
 		// Measure server stop/start 5 times
 		for ( let i = 0; i < 5; i++ ) {
-			console.log( `Run ${ i + 1 }/5: Stopping and starting site` );
-			// Stop the site by clicking the Running button
-			await siteContent.runningButton.click();
-			const startButton = siteContent.locator.getByRole( 'button', { name: 'Start' } );
-			await expect( startButton ).toBeAttached( { timeout: 30_000 } );
+			await test.step( `Run ${ i + 1 }/5: Stopping and starting site`, async () => {
+				// Stop the site by clicking the Running button
+				await siteContent.runningButton.click();
+				const startButton = siteContent.locator.getByRole( 'button', { name: 'Start' } );
+				await expect( startButton ).toBeAttached();
 
-			// Start timer
-			const startTime = Date.now();
-			await startButton.click();
-			// Wait for site to be running
-			await expect( siteContent.runningButton ).toBeAttached( { timeout: 120_000 } );
-			const endTime = Date.now();
-			const duration = endTime - startTime;
+				// Start timer
+				const startTime = Date.now();
+				await startButton.click();
+				// Wait for site to be running
+				await expect( siteContent.runningButton ).toBeAttached();
+				const endTime = Date.now();
+				const duration = endTime - startTime;
 
-			// Log performance data for this run
-			console.log( `Run ${ i + 1 }/5: Restart took ${ duration }ms` );
-			results.siteStartup.push( duration );
+				// Log performance data for this run
+				console.log( `Run ${ i + 1 }/5: Restart took ${ duration }ms` );
+				results.siteStartup.push( duration );
 
-			// Wait a moment before next cycle
-			await session.mainWindow.waitForTimeout( 100 );
+				// Wait a moment before next cycle
+				await session.mainWindow.waitForTimeout( 100 );
+			} );
 		}
 
 		// Delete the site after test
-		const settingsTab = await siteContent.navigateToTab( 'Settings' );
-		await session.electronApp.evaluate( ( { dialog } ) => {
-			dialog.showMessageBox = async () => {
-				return { response: 0, checkboxChecked: true };
-			};
+		await test.step( 'Delete the site', async () => {
+			const settingsTab = await siteContent.navigateToTab( 'Settings' );
+			await session.electronApp.evaluate( ( { dialog } ) => {
+				dialog.showMessageBox = async () => {
+					return { response: 0, checkboxChecked: true };
+				};
+			} );
+			await settingsTab.openDeleteSiteModal();
+			await session.mainWindow.waitForTimeout( 200 ); // Wait for deletion
 		} );
-		await settingsTab.openDeleteSiteModal();
-		await session.mainWindow.waitForTimeout( 200 ); // Wait for deletion
 	} );
 } );

--- a/metrics/tests/site-startup.test.ts
+++ b/metrics/tests/site-startup.test.ts
@@ -61,7 +61,7 @@ test.describe( 'Startup Metrics', () => {
 			const startTime = Date.now();
 			await startButton.click();
 			// Wait for site to be running
-			await expect( siteContent.runningButton ).toBeAttached( { timeout: 60_000 } );
+			await expect( siteContent.runningButton ).toBeAttached( { timeout: 120_000 } );
 			const endTime = Date.now();
 			const duration = endTime - startTime;
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
 		"test": "cross-env NODE_OPTIONS='--no-deprecation' jest",
 		"test:watch": "cross-env NODE_OPTIONS='--no-deprecation' jest --watch",
 		"e2e": "npx playwright install && npx playwright test",
-		"test:metrics": "npx playwright install chromium && npx playwright test --config=./metrics/playwright.metrics.config.ts",
+		"test:metrics": "npx playwright test --config=./metrics/playwright.metrics.config.ts",
 		"make-pot": "wp-babel-makepot \"./src/**/*.{js,jsx,ts,tsx}\" --ignore \"**/*.d.ts\" --base \"./src\" --dir \"./out/pots\" --output \"./out/pots/bundle-strings.pot\""
 	},
 	"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
 		"test": "cross-env NODE_OPTIONS='--no-deprecation' jest",
 		"test:watch": "cross-env NODE_OPTIONS='--no-deprecation' jest --watch",
 		"e2e": "npx playwright install && npx playwright test",
-		"test:metrics": "npx playwright install && npx playwright test --config=./metrics/playwright.metrics.config.ts",
+		"test:metrics": "npx playwright install chromium && npx playwright test --config=./metrics/playwright.metrics.config.ts",
 		"make-pot": "wp-babel-makepot \"./src/**/*.{js,jsx,ts,tsx}\" --ignore \"**/*.d.ts\" --base \"./src\" --dir \"./out/pots\" --output \"./out/pots/bundle-strings.pot\""
 	},
 	"devDependencies": {

--- a/scripts/compare-perf/config.ts
+++ b/scripts/compare-perf/config.ts
@@ -1,8 +1,7 @@
 const config = {
 	gitRepositoryURL: 'https://github.com/Automattic/studio.git',
-	setupTestRunner: 'npm ci --unsafe-perm --no-audit --no-progress',
-	setupCommand:
-		'npm ci --unsafe-perm --no-audit --no-progress && IS_DEV_BUILD=true npm run package',
+	setupTestRunner: 'npm ci',
+	setupCommand: 'npm ci && IS_DEV_BUILD=true npm run package',
 	testsPath: '/metrics/tests',
 	testCommand: 'npm run test:metrics',
 };

--- a/scripts/compare-perf/config.ts
+++ b/scripts/compare-perf/config.ts
@@ -1,6 +1,6 @@
 const config = {
 	gitRepositoryURL: 'https://github.com/Automattic/studio.git',
-	setupTestRunner: 'npm ci',
+	setupTestRunner: 'npm ci && npx playwright install chromium',
 	setupCommand: 'npm ci && IS_DEV_BUILD=true npm run package',
 	testsPath: '/metrics/tests',
 	testCommand: 'npm run test:metrics',

--- a/scripts/compare-perf/config.ts
+++ b/scripts/compare-perf/config.ts
@@ -1,7 +1,7 @@
 const config = {
 	gitRepositoryURL: 'https://github.com/Automattic/studio.git',
 	setupTestRunner: 'npm install',
-	setupCommand: 'npm install && IS_DEV_BUILD=true npm run package',
+	setupCommand: 'npm install && IS_DEV_BUILD=true npm run package && npm run make',
 	testsPath: '/metrics/tests',
 	testCommand: 'npm run test:metrics',
 };

--- a/scripts/compare-perf/config.ts
+++ b/scripts/compare-perf/config.ts
@@ -1,7 +1,8 @@
 const config = {
 	gitRepositoryURL: 'https://github.com/Automattic/studio.git',
-	setupTestRunner: 'npm install',
-	setupCommand: 'npm install && IS_DEV_BUILD=true npm run package && npm run make',
+	setupTestRunner: 'npm ci --unsafe-perm --no-audit --no-progress',
+	setupCommand:
+		'npm ci --unsafe-perm --no-audit --no-progress && IS_DEV_BUILD=true npm run package',
 	testsPath: '/metrics/tests',
 	testCommand: 'npm run test:metrics',
 };

--- a/scripts/compare-perf/config.ts
+++ b/scripts/compare-perf/config.ts
@@ -1,6 +1,6 @@
 const config = {
 	gitRepositoryURL: 'https://github.com/Automattic/studio.git',
-	setupTestRunner: 'npm ci && npx playwright install chromium',
+	setupTestRunner: 'npm ci',
 	setupCommand: 'npm ci && IS_DEV_BUILD=true npm run package',
 	testsPath: '/metrics/tests',
 	testCommand: 'npm run test:metrics',

--- a/scripts/compare-perf/config.ts
+++ b/scripts/compare-perf/config.ts
@@ -1,9 +1,17 @@
+import path from 'path';
+
+const metricsPath = path.resolve( __dirname, '../../metrics' );
+
 const config = {
 	gitRepositoryURL: 'https://github.com/Automattic/studio.git',
 	setupTestRunner: 'npm ci && npx playwright install chromium',
-	setupCommand: 'npm ci && IS_DEV_BUILD=true npm run package',
-	testsPath: '/metrics/tests',
 	testCommand: 'npm run test:metrics',
+	setupCommand: 'npm ci && IS_DEV_BUILD=true npm run package',
+	testsPath: 'metrics/tests',
+	testFileSuffix: '.test.ts',
+	artifactsPath: path.join( metricsPath, 'artifacts' ),
+	resultsFileSuffix: '.results.json',
+	summaryFileSuffix: '.summary.json',
 };
 
 export default config;

--- a/scripts/compare-perf/performance.ts
+++ b/scripts/compare-perf/performance.ts
@@ -190,7 +190,9 @@ export async function runPerformanceTests(
 
 	logAtIndent( 2, 'Installing dependencies and building' );
 
-	await runShellScript( config.setupTestRunner, testRunnerDir );
+	await runShellScript( config.setupTestRunner, testRunnerDir, {
+		GITHUB_TOKEN: process.env.GITHUB_TOKEN,
+	} );
 
 	logAtIndent( 1, 'Setting up test environments' );
 
@@ -216,7 +218,9 @@ export async function runPerformanceTests(
 		await simpleGit( buildDir ).raw( 'checkout', branch );
 
 		logAtIndent( 3, 'Installing dependencies and building' );
-		await runShellScript( config.setupCommand, buildDir );
+		await runShellScript( config.setupCommand, buildDir, {
+			GITHUB_TOKEN: process.env.GITHUB_TOKEN,
+		} );
 	}
 
 	logAtIndent( 0, 'Looking for test files' );

--- a/scripts/compare-perf/performance.ts
+++ b/scripts/compare-perf/performance.ts
@@ -15,7 +15,7 @@ const formats = {
 };
 
 const ARTIFACTS_PATH = process.env.ARTIFACTS_PATH || path.join( process.cwd(), 'artifacts' );
-const RESULTS_FILE_SUFFIX = 'results.json';
+const RESULTS_FILE_SUFFIX = '.performance-results.json';
 
 interface PerformanceCommandOptions {
 	/**

--- a/scripts/compare-perf/performance.ts
+++ b/scripts/compare-perf/performance.ts
@@ -99,7 +99,7 @@ async function runTestSuite(
 	// Run the test suite
 	await runShellScript( `${ config.testCommand } ${ testSuite }`, testRunnerDir, {
 		...process.env,
-		ARTIFACTS_PATH: ARTIFACTS_PATH,
+		ARTIFACTS_PATH,
 		RESULTS_ID: runKey,
 	} );
 }

--- a/scripts/compare-perf/performance.ts
+++ b/scripts/compare-perf/performance.ts
@@ -14,9 +14,6 @@ const formats = {
 	success: chalk.bold.green,
 };
 
-const ARTIFACTS_PATH = process.env.ARTIFACTS_PATH || path.join( process.cwd(), 'artifacts' );
-const RESULTS_FILE_SUFFIX = '.performance-results.json';
-
 interface PerformanceCommandOptions {
 	/**
 	 * Run on CI.
@@ -99,7 +96,8 @@ async function runTestSuite(
 	// Run the test suite
 	await runShellScript( `${ config.testCommand } ${ testSuite }`, testRunnerDir, {
 		...process.env,
-		ARTIFACTS_PATH,
+		ARTIFACTS_PATH: config.artifactsPath,
+		RESULTS_FILE_SUFFIX: config.resultsFileSuffix,
 		RESULTS_ID: runKey,
 	} );
 }
@@ -115,7 +113,7 @@ export async function runPerformanceTests(
 	options: PerformanceCommandOptions
 ) {
 	const runningInCI = !! process.env.CI || !! options.ci;
-	const TEST_ROUNDS = options.rounds || 1;
+	const testRounds = options.rounds || 1;
 
 	// The default value doesn't work because commander provides an array.
 	if ( branches.length === 0 ) {
@@ -228,24 +226,25 @@ export async function runPerformanceTests(
 	const testSuites = getFilesFromDir( path.join( testRunnerDir, config.testsPath ) ).map(
 		( file: string ) => {
 			logAtIndent( 1, 'Found:', formats.success( file ) );
-			return path.basename( file, '.test.ts' );
+			return path.basename( file, config.testFileSuffix );
 		}
 	);
 
 	logAtIndent( 0, 'Running tests' );
 
 	for ( const testSuite of testSuites ) {
-		for ( let i = 1; i <= TEST_ROUNDS; i++ ) {
+		for ( let i = 1; i <= testRounds; i++ ) {
 			logAtIndent(
 				1,
 				// prettier-ignore
-				`Suite: ${ formats.success( testSuite ) } (round ${ i } of ${ TEST_ROUNDS })`
+				`Suite: ${ formats.success( testSuite ) } (round ${ i } of ${ testRounds })`
 			);
 
 			for ( const branch of branches ) {
 				logAtIndent( 2, 'Branch:', formats.success( branch ) );
 				const sanitizedBranchName = sanitizeBranchName( branch );
 				const runKey = `${ testSuite }_${ sanitizedBranchName }_round-${ i }`;
+
 				logAtIndent( 3, 'Running tests' );
 				await runTestSuite(
 					testSuite,
@@ -259,9 +258,10 @@ export async function runPerformanceTests(
 
 	logAtIndent( 0, 'Calculating results' );
 
-	const resultFiles = getFilesFromDir( ARTIFACTS_PATH ).filter( ( file: string ) =>
-		file.endsWith( RESULTS_FILE_SUFFIX )
+	const resultFiles = getFilesFromDir( config.artifactsPath ).filter( ( file: string ) =>
+		file.endsWith( config.resultsFileSuffix )
 	);
+
 	/** @type {Record<string,Record<string, Record<string, number>>>} */
 	const results: Record< string, Record< string, Record< string, number > > > = {};
 
@@ -295,7 +295,10 @@ export async function runPerformanceTests(
 				}
 			}
 		}
-		const calculatedResultsPath = path.join( ARTIFACTS_PATH, testSuite + RESULTS_FILE_SUFFIX );
+		const calculatedResultsPath = path.join(
+			config.artifactsPath,
+			testSuite + config.summaryFileSuffix
+		);
 
 		logAtIndent( 2, 'Saving curated results to:', formats.success( calculatedResultsPath ) );
 		fs.writeFileSync( calculatedResultsPath, JSON.stringify( results[ testSuite ], null, 2 ) );

--- a/src/lib/sqlite-command-release.ts
+++ b/src/lib/sqlite-command-release.ts
@@ -10,7 +10,17 @@ export async function getLatestSQLiteCommandRelease(): Promise< GithubRelease > 
 	const url = 'https://api.github.com/repos/automattic/wp-cli-sqlite-command/releases/latest';
 	console.log( '[sqlite-command] Fetching from:', url );
 
-	const response = await fetch( url );
+	const headers: HeadersInit = {
+		Accept: 'application/vnd.github.v3+json',
+		'User-Agent': 'wp-now-cli',
+	};
+
+	if ( process.env.GITHUB_TOKEN ) {
+		console.log( '[sqlite-command] GITHUB_TOKEN available' );
+		headers.Authorization = `token ${ process.env.GITHUB_TOKEN }`;
+	}
+
+	const response = await fetch( url, { headers } );
 	console.log( '[sqlite-command] Response status:', response.status );
 
 	if ( ! response.ok ) {

--- a/src/lib/sqlite-command-release.ts
+++ b/src/lib/sqlite-command-release.ts
@@ -18,6 +18,8 @@ export async function getLatestSQLiteCommandRelease(): Promise< GithubRelease > 
 	if ( process.env.GITHUB_TOKEN ) {
 		console.log( '[sqlite-command] GITHUB_TOKEN available' );
 		headers.Authorization = `token ${ process.env.GITHUB_TOKEN }`;
+	} else {
+		console.log( '[sqlite-command] GITHUB_TOKEN not available' );
 	}
 
 	const response = await fetch( url, { headers } );

--- a/src/lib/sqlite-command-release.ts
+++ b/src/lib/sqlite-command-release.ts
@@ -8,7 +8,6 @@ export interface GithubRelease {
 
 export async function getLatestSQLiteCommandRelease(): Promise< GithubRelease > {
 	const url = 'https://api.github.com/repos/automattic/wp-cli-sqlite-command/releases/latest';
-	console.log( '[sqlite-command] Fetching from:', url );
 
 	const headers: HeadersInit = {
 		Accept: 'application/vnd.github.v3+json',
@@ -16,25 +15,14 @@ export async function getLatestSQLiteCommandRelease(): Promise< GithubRelease > 
 	};
 
 	if ( process.env.GITHUB_TOKEN ) {
-		console.log( '[sqlite-command] GITHUB_TOKEN available' );
 		headers.Authorization = `token ${ process.env.GITHUB_TOKEN }`;
 	}
 
 	const response = await fetch( url, { headers } );
-	console.log( '[sqlite-command] Response status:', response.status );
 
 	if ( ! response.ok ) {
-		const text = await response.text();
-		console.log( '[sqlite-command] Error response:', text );
 		throw new Error( `GitHub API request failed: ${ response.status } ${ response.statusText }` );
 	}
 
-	const data = await response.json();
-	console.log( '[sqlite-command] Release data:', {
-		tag_name: data.tag_name,
-		assets: data.assets?.length,
-		download_url: data.assets?.[ 0 ]?.browser_download_url,
-	} );
-
-	return data;
+	return await response.json();
 }

--- a/src/lib/sqlite-command-release.ts
+++ b/src/lib/sqlite-command-release.ts
@@ -7,8 +7,24 @@ export interface GithubRelease {
 }
 
 export async function getLatestSQLiteCommandRelease(): Promise< GithubRelease > {
-	const response = await fetch(
-		`https://api.github.com/repos/automattic/wp-cli-sqlite-command/releases/latest`
-	);
-	return ( await response.json() ) as GithubRelease;
+	const url = 'https://api.github.com/repos/automattic/wp-cli-sqlite-command/releases/latest';
+	console.log( '[sqlite-command] Fetching from:', url );
+
+	const response = await fetch( url );
+	console.log( '[sqlite-command] Response status:', response.status );
+
+	if ( ! response.ok ) {
+		const text = await response.text();
+		console.log( '[sqlite-command] Error response:', text );
+		throw new Error( `GitHub API request failed: ${ response.status } ${ response.statusText }` );
+	}
+
+	const data = await response.json();
+	console.log( '[sqlite-command] Release data:', {
+		tag_name: data.tag_name,
+		assets: data.assets?.length,
+		download_url: data.assets?.[ 0 ]?.browser_download_url,
+	} );
+
+	return data;
 }

--- a/src/lib/sqlite-command-release.ts
+++ b/src/lib/sqlite-command-release.ts
@@ -8,6 +8,7 @@ export interface GithubRelease {
 
 export async function getLatestSQLiteCommandRelease(): Promise< GithubRelease > {
 	const url = 'https://api.github.com/repos/automattic/wp-cli-sqlite-command/releases/latest';
+	console.log( '[sqlite-command] Fetching from:', url );
 
 	const headers: HeadersInit = {
 		Accept: 'application/vnd.github.v3+json',
@@ -15,14 +16,25 @@ export async function getLatestSQLiteCommandRelease(): Promise< GithubRelease > 
 	};
 
 	if ( process.env.GITHUB_TOKEN ) {
+		console.log( '[sqlite-command] GITHUB_TOKEN available' );
 		headers.Authorization = `token ${ process.env.GITHUB_TOKEN }`;
 	}
 
 	const response = await fetch( url, { headers } );
+	console.log( '[sqlite-command] Response status:', response.status );
 
 	if ( ! response.ok ) {
+		const text = await response.text();
+		console.log( '[sqlite-command] Error response:', text );
 		throw new Error( `GitHub API request failed: ${ response.status } ${ response.statusText }` );
 	}
 
-	return await response.json();
+	const data = await response.json();
+	console.log( '[sqlite-command] Release data:', {
+		tag_name: data.tag_name,
+		assets: data.assets?.length,
+		download_url: data.assets?.[ 0 ]?.browser_download_url,
+	} );
+
+	return data;
 }

--- a/src/lib/sqlite-command-release.ts
+++ b/src/lib/sqlite-command-release.ts
@@ -8,35 +8,26 @@ export interface GithubRelease {
 
 export async function getLatestSQLiteCommandRelease(): Promise< GithubRelease > {
 	const url = 'https://api.github.com/repos/automattic/wp-cli-sqlite-command/releases/latest';
-	console.log( '[sqlite-command] Fetching from:', url );
 
 	const headers: HeadersInit = {
 		Accept: 'application/vnd.github.v3+json',
 		'User-Agent': 'wp-now-cli',
 	};
 
+	// GitHub API has rate limits:
+	// - 60 requests/hour for unauthenticated requests
+	// - 5,000 requests/hour with token authentication
+	// In CI environments, the IP-based rate limit is shared across runners,
+	// so we authenticate with GITHUB_TOKEN when available.
 	if ( process.env.GITHUB_TOKEN ) {
-		console.log( '[sqlite-command] GITHUB_TOKEN available' );
 		headers.Authorization = `token ${ process.env.GITHUB_TOKEN }`;
-	} else {
-		console.log( '[sqlite-command] GITHUB_TOKEN not available' );
 	}
 
 	const response = await fetch( url, { headers } );
-	console.log( '[sqlite-command] Response status:', response.status );
 
 	if ( ! response.ok ) {
-		const text = await response.text();
-		console.log( '[sqlite-command] Error response:', text );
 		throw new Error( `GitHub API request failed: ${ response.status } ${ response.statusText }` );
 	}
 
-	const data = await response.json();
-	console.log( '[sqlite-command] Release data:', {
-		tag_name: data.tag_name,
-		assets: data.assets?.length,
-		download_url: data.assets?.[ 0 ]?.browser_download_url,
-	} );
-
-	return data;
+	return await response.json();
 }


### PR DESCRIPTION
Checking CI errors from https://github.com/Automattic/studio/pull/1123

This PR:
- Fixes npm install error caused by GH API rate limiting when downloading SQLiteCommand release.
- Fixes test error due to insufficient total timeout.
- Fixes errors due to results file name mismatch.
- Uses `tests.step` instead of logs in tests for clarity.
- Add color to CI logs for clarity.
- Uses `npm ci` instead of `npm install` for stability.
- Saves time by limiting browser install to chromium only since the rest is not needed.
- Adds a few more small tweaks :)

cc: @youknowriad 