### PR TITLE
What's New Section: Fetch `lastSeenVersion` at the `App` component instead of the store

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -18,7 +18,7 @@ import { isWindows } from 'src/lib/app-globals';
 import { cx } from 'src/lib/cx';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 import { WhatsNewModal, useWhatsNew } from 'src/modules/whats-new';
-import { initializeStore } from 'src/stores';
+import { initializeAppVersionData } from 'src/stores';
 
 export default function App() {
 	useLocalizationSupport();
@@ -32,7 +32,7 @@ export default function App() {
 	}, [ needsOnboarding, whatsNewSectionEnabled ] );
 
 	useEffect( () => {
-		initializeStore();
+		initializeAppVersionData();
 	}, [] );
 
 	return (

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -18,6 +18,7 @@ import { isWindows } from 'src/lib/app-globals';
 import { cx } from 'src/lib/cx';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 import { WhatsNewModal, useWhatsNew } from 'src/modules/whats-new';
+import { initializeStore } from 'src/stores';
 
 export default function App() {
 	useLocalizationSupport();
@@ -29,6 +30,10 @@ export default function App() {
 	useEffect( () => {
 		getIpcApi().setupAppMenu( { needsOnboarding, whatsNewSectionEnabled } );
 	}, [ needsOnboarding, whatsNewSectionEnabled ] );
+
+	useEffect( () => {
+		initializeStore();
+	}, [] );
 
 	return (
 		<>

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -59,7 +59,9 @@ export const store = configureStore( {
 			.concat( wpcomApi.middleware ),
 } );
 
-store.dispatch( appVersionThunks.fetchLastSeenVersion() );
+export const initializeStore = () => {
+	store.dispatch( appVersionThunks.fetchLastSeenVersion() );
+};
 
 export type AppDispatch = typeof store.dispatch;
 

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -59,7 +59,7 @@ export const store = configureStore( {
 			.concat( wpcomApi.middleware ),
 } );
 
-export const initializeStore = () => {
+export const initializeAppVersionData = () => {
 	store.dispatch( appVersionThunks.fetchLastSeenVersion() );
 };
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-308-linear-issue.

## Proposed Changes

- fetch `lastSeenVersion` at the `App` component instead of the store

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR branch and build the app with `STUDIO_WHATS_NEW_SECTION=true npm start`.
2. Head over to your `appdata-v1.json` and make sure there's no `lastSeenVersion` value stored in it.
3. The `What's New` modal should work as expected, i.e.: it should open on app start.
4. If you run `npm test`, there should be no errors similar to what has Fredrik encountered: https://github.com/Automattic/studio/pull/1110#issuecomment-2754740221.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?