### PR TITLE
Fix notification wording to skip the part about the start

### DIFF
--- a/src/hooks/use-add-site.ts
+++ b/src/hooks/use-add-site.ts
@@ -130,14 +130,19 @@ export function useAddSite() {
 							isNewSite: true,
 						} );
 						clearImportState( newSite.id );
+
+						getIpcApi().showNotification( {
+							title: newSite.name,
+							body: __( 'Your new site was imported' ),
+						} );
 					} else {
+						getIpcApi().showNotification( {
+							title: newSite.name,
+							body: __( 'Your new site was created' ),
+						} );
+
 						await startServer( newSite.id );
 					}
-
-					getIpcApi().showNotification( {
-						title: newSite.name,
-						body: __( 'Your new site is up and running' ),
-					} );
 				}
 			);
 		} catch ( e ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/studio/issues/1095

## Proposed Changes

Currently, when a user creates or imports a site that fails to be started, there is a system notification saying the site is "up and running". The purpose of that notification was to let the user that the site was created or imported in case they changed focus to another app.

I propose to keep things simple and fix the notification wording to:
- skip the part saying if the site was started or not. If it wasn't started, there would be an error dialog shown when user focused the Studio again.
- differentiate the notification for site created and imported

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Apply a code that throws an error during site start, e.g.:

```
diff --git a/src/site-server.ts b/src/site-server.ts
index ed5dc66a..9920d195 100644
--- a/src/site-server.ts
+++ b/src/site-server.ts
@@ -166,6 +166,10 @@ export class SiteServer {
                this.server = new SiteServerProcess( options );
                await this.server.start();
 
+               throw new Error(
+                       `Test throwing error.`
+               );
+
                if ( this.server.options.port === undefined ) {
                        throw new Error( 'Server started with no port' );
                }

```

2. Add a new site, and move focus to another app
3. Confirm notification was displayed
4. Go back to the Studio and confirm the error dialog
5. Repeat 2-4 by using import file

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
