### PR TITLE
Studio: Add constant to force modal in select versions

### DIFF
--- a/src/modules/whats-new/config/whats-new-config.ts
+++ b/src/modules/whats-new/config/whats-new-config.ts
@@ -1,0 +1,25 @@
+/**
+ * Configuration for the What's New feature
+ * 
+ * This file contains settings that control when the What's New modal appears.
+ * Add version numbers to the forceWhatsNewVersions array to make the modal
+ * appear for those specific versions, even if they're just patch updates.
+ */
+
+/**
+ * List of versions that should always show the What's New modal,
+ * regardless of the normal version comparison logic.
+ */
+export const forceWhatsNewVersions = [
+	'1.3.9-beta1', // Example: Important security patch
+];
+
+/**
+ * Determines if the What's New modal should be forced for a specific version
+ *
+ * @param version The current application version
+ * @returns True if the modal should be forced for this version
+ */
+export const shouldForceWhatsNew = ( version: string ): boolean => {
+	return forceWhatsNewVersions.includes( version );
+}; 

--- a/src/modules/whats-new/config/whats-new-config.ts
+++ b/src/modules/whats-new/config/whats-new-config.ts
@@ -1,6 +1,6 @@
 /**
  * Configuration for the What's New feature
- * 
+ *
  * This file contains settings that control when the What's New modal appears.
  * Add version numbers to the forceWhatsNewVersions array to make the modal
  * appear for those specific versions, even if they're just patch updates.
@@ -10,9 +10,7 @@
  * List of versions that should always show the What's New modal,
  * regardless of the normal version comparison logic.
  */
-export const forceWhatsNewVersions = [
-	'1.3.9-beta1', // Example: Important security patch
-];
+export const forceWhatsNewVersions: string[] = [];
 
 /**
  * Determines if the What's New modal should be forced for a specific version
@@ -22,4 +20,4 @@ export const forceWhatsNewVersions = [
  */
 export const shouldForceWhatsNew = ( version: string ): boolean => {
 	return forceWhatsNewVersions.includes( version );
-}; 
+};

--- a/src/modules/whats-new/hooks/use-last-seen-version.tsx
+++ b/src/modules/whats-new/hooks/use-last-seen-version.tsx
@@ -6,6 +6,7 @@ interface UseLastSeenVersion {
 	lastSeenVersion: string | undefined;
 	isNewVersion: boolean;
 	updateLastSeenVersion: () => Promise< void >;
+	currentVersion: string | undefined;
 }
 
 export function useLastSeenVersion(): UseLastSeenVersion {
@@ -25,5 +26,6 @@ export function useLastSeenVersion(): UseLastSeenVersion {
 		lastSeenVersion,
 		isNewVersion,
 		updateLastSeenVersion,
+		currentVersion,
 	};
 }

--- a/src/modules/whats-new/hooks/use-whats-new.tsx
+++ b/src/modules/whats-new/hooks/use-whats-new.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useIpcListener } from 'src/hooks/use-ipc-listener';
 import { useOnboarding } from 'src/hooks/use-onboarding';
+import { shouldForceWhatsNew } from 'src/modules/whats-new/config/whats-new-config';
 import { useLastSeenVersion } from 'src/modules/whats-new/hooks/use-last-seen-version';
 
 interface UseWhatsNew {
@@ -11,22 +12,33 @@ interface UseWhatsNew {
 export function useWhatsNew(): UseWhatsNew {
 	const [ showWhatsNew, setShowWhatsNew ] = useState( true );
 	const [ manuallyTriggered, setManuallyTriggered ] = useState( false );
+	const [ forcedModalSeen, setForcedModalSeen ] = useState( false );
 	const { needsOnboarding } = useOnboarding();
-	const { isNewVersion, updateLastSeenVersion } = useLastSeenVersion();
+	const { isNewVersion, updateLastSeenVersion, currentVersion, lastSeenVersion } =
+		useLastSeenVersion();
+
+	const shouldForceForVersion = currentVersion
+		? shouldForceWhatsNew( currentVersion ) && lastSeenVersion !== currentVersion
+		: false;
+	const forceWhatsNew = shouldForceForVersion && ! forcedModalSeen;
 
 	useIpcListener( 'show-whats-new', () => {
 		setManuallyTriggered( true );
 		setShowWhatsNew( true );
+		setForcedModalSeen( false );
 	} );
 
 	const closeWhatsNew = async () => {
 		setShowWhatsNew( false );
 		setManuallyTriggered( false );
+		setForcedModalSeen( true );
 		await updateLastSeenVersion();
 	};
 
 	return {
-		showWhatsNew: ( manuallyTriggered || ( showWhatsNew && isNewVersion ) ) && ! needsOnboarding,
+		showWhatsNew:
+			( manuallyTriggered || ( showWhatsNew && isNewVersion ) || forceWhatsNew ) &&
+			! needsOnboarding,
 		closeWhatsNew,
 	};
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

STU-271

## Proposed Changes

This PR adds a config file which allows you to control the `What's new modal` display for specific versions of Studio besides minor and major. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes of this branch
* Apply this diff

```diff --git a/src/modules/whats-new/config/whats-new-config.ts b/src/modules/whats-new/config/whats-new-config.ts
index 3a0e0384..42f41e60 100644
--- a/src/modules/whats-new/config/whats-new-config.ts
+++ b/src/modules/whats-new/config/whats-new-config.ts
@@ -11,7 +11,7 @@
  * regardless of the normal version comparison logic.
  */
 export const forceWhatsNewVersions = [
-       '1.3.9-beta1', // Example: Important security patch
+       '1.3.9-beta2', // Example: Important security patch
 ];
```
* Open package.json and change the app version to `1.3.9-beta2`
* Run `npm install`
* Start the app with `STUDIO_WHATS_NEW_SECTION=true npm start`
* Confirm that you can see the modal appearing automatically when the app starts
* Close the modal
* Type `rs` in the terminal where you have Studio open
* Confirm that once the app restarts, you do not see the modal again 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
