### PR TITLE
Studio: Use feature flag to force the modal

### DIFF
--- a/src/modules/whats-new/hooks/use-whats-new.tsx
+++ b/src/modules/whats-new/hooks/use-whats-new.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useFeatureFlags } from 'src/hooks/use-feature-flags';
 import { useIpcListener } from 'src/hooks/use-ipc-listener';
 import { useOnboarding } from 'src/hooks/use-onboarding';
 import { useLastSeenVersion } from 'src/modules/whats-new/hooks/use-last-seen-version';
@@ -11,8 +12,11 @@ interface UseWhatsNew {
 export function useWhatsNew(): UseWhatsNew {
 	const [ showWhatsNew, setShowWhatsNew ] = useState( true );
 	const [ manuallyTriggered, setManuallyTriggered ] = useState( false );
+	const [ featureFlagModalSeen, setFeatureFlagModalSeen ] = useState( false );
+
 	const { needsOnboarding } = useOnboarding();
 	const { isNewVersion, updateLastSeenVersion } = useLastSeenVersion();
+	const { whatsNewSectionEnabled } = useFeatureFlags();
 
 	useIpcListener( 'show-whats-new', () => {
 		setManuallyTriggered( true );
@@ -22,11 +26,22 @@ export function useWhatsNew(): UseWhatsNew {
 	const closeWhatsNew = async () => {
 		setShowWhatsNew( false );
 		setManuallyTriggered( false );
+
+		// If the modal was shown because of the feature flag, mark it as seen
+		if ( whatsNewSectionEnabled && ! manuallyTriggered && ! isNewVersion ) {
+			setFeatureFlagModalSeen( true );
+		}
+
 		await updateLastSeenVersion();
 	};
 
+	// Determine if we should show the modal based on the feature flag
+	const shouldForceWhatsNew = whatsNewSectionEnabled && ! featureFlagModalSeen;
+
 	return {
-		showWhatsNew: ( manuallyTriggered || ( showWhatsNew && isNewVersion ) ) && ! needsOnboarding,
+		showWhatsNew:
+			( manuallyTriggered || shouldForceWhatsNew || ( showWhatsNew && isNewVersion ) ) &&
+			! needsOnboarding,
 		closeWhatsNew,
 	};
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

STU-271

## Proposed Changes

This PR adds forces the modal for when `whatsNewSectionEnabled` feature flag is set to true to be able to force it with app versions that are not included for automatic triggering of the modal. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
* Apply the following diff:
```diff --git a/src/ipc-handlers.ts b/src/ipc-handlers.ts
index cc090c42..3324682f 100644
--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -784,7 +784,7 @@ export async function getAppGlobals( _event: IpcMainInvokeEvent ): Promise< AppG
                appVersion: app.getVersion(),
                arm64Translation: app.runningUnderARM64Translation,
                terminalWpCliEnabled: process.env.STUDIO_TERMINAL_WP_CLI === 'true',
-               whatsNewSectionEnabled: process.env.STUDIO_WHATS_NEW_SECTION === 'true',
+               whatsNewSectionEnabled: true,
        };
 }
```
* Start the app with `npm start`
* Confirm that you see the modal when the app starts
* Confirm that the modal closes correctly

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
