### PR TITLE
Performance Metrics: Log the results in codevitals

### DIFF
--- a/.github/workflows/metrics-comparison.yml
+++ b/.github/workflows/metrics-comparison.yml
@@ -48,7 +48,7 @@ jobs:
 
       # Log performance metrics to CodeVitals when running on trunk
       - name: Log performance metrics to CodeVitals
-        #if: github.event_name == 'push' && github.ref == 'refs/heads/trunk' && !cancelled()
+        if: github.event_name == 'push' && github.ref == 'refs/heads/trunk' && !cancelled()
         run: |
           COMMITTED_AT=$(git show -s $GITHUB_SHA --format="%cI")
           npm ci && cd scripts/compare-perf && npm run log-to-codevitals -- $CODEVITALS_AUTH_TOKEN trunk $GITHUB_SHA c27db920b93947786da17271b859e90c6d64eaac $COMMITTED_AT

--- a/.github/workflows/metrics-comparison.yml
+++ b/.github/workflows/metrics-comparison.yml
@@ -21,6 +21,7 @@ jobs:
       ARTIFACTS_PATH: ${{ github.workspace }}/artifacts
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       FORCE_COLOR: '1'
+      CODEVITALS_AUTH_TOKEN: ${{ secrets.CODEVITALS_AUTH_TOKEN }}
 
     steps:
       - uses: actions/checkout@v4
@@ -44,6 +45,12 @@ jobs:
         # It is used as a base comparison point to avoid fluctuation in the performance metrics.
         run: |
           cd scripts/compare-perf && npm ci && npm run compare -- perf $GITHUB_SHA 0840137210db6f627f7dc1d8cab79ed497e699a6 --tests-branch $GITHUB_SHA
+
+      # Log performance metrics to CodeVitals when running on trunk
+      - name: Log performance metrics to CodeVitals
+        #if: github.event_name == 'push' && github.ref == 'refs/heads/trunk' && !cancelled()
+        run: |
+          cd scripts/compare-perf && npm run log-to-codevitals
 
       - name: Archive performance results
         if: ${{ !cancelled() }}

--- a/.github/workflows/metrics-comparison.yml
+++ b/.github/workflows/metrics-comparison.yml
@@ -35,22 +35,23 @@ jobs:
 
       - name: Compare performance with trunk
         if: github.event_name == 'pull_request'
-        run: cd scripts/compare-perf && npm ci && npm run compare -- perf $GITHUB_SHA bfff98655ec7b3b8d0580dd1610121dec529b59f --tests-branch $GITHUB_SHA
+        run: cd scripts/compare-perf && npm ci && npm run compare -- perf $GITHUB_SHA trunk --tests-branch $GITHUB_SHA
 
       - name: Compare performance with base branch
         if: github.event_name == 'push'
         # The base hash used here need to be a commit that is compatible with the current performance tests.
-        # The current one is 0840137210db6f627f7dc1d8cab79ed497e699a6
+        # The current one is c27db920b93947786da17271b859e90c6d64eaac
         # it needs to be updated every time it becomes unsupported by the current performance tests.
         # It is used as a base comparison point to avoid fluctuation in the performance metrics.
         run: |
-          cd scripts/compare-perf && npm ci && npm run compare -- perf $GITHUB_SHA 0840137210db6f627f7dc1d8cab79ed497e699a6 --tests-branch $GITHUB_SHA
+          cd scripts/compare-perf && npm ci && npm run compare -- perf $GITHUB_SHA c27db920b93947786da17271b859e90c6d64eaac --tests-branch $GITHUB_SHA
 
       # Log performance metrics to CodeVitals when running on trunk
       - name: Log performance metrics to CodeVitals
         #if: github.event_name == 'push' && github.ref == 'refs/heads/trunk' && !cancelled()
         run: |
-          npm ci && cd scripts/compare-perf && npm run log-to-codevitals
+          COMMITTED_AT=$(git show -s $GITHUB_SHA --format="%cI")
+          npm ci && cd scripts/compare-perf && npm run log-to-codevitals -- $CODEVITALS_AUTH_TOKEN trunk $GITHUB_SHA c27db920b93947786da17271b859e90c6d64eaac $COMMITTED_AT
 
       - name: Archive performance results
         if: ${{ !cancelled() }}

--- a/.github/workflows/metrics-comparison.yml
+++ b/.github/workflows/metrics-comparison.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Log performance metrics to CodeVitals
         #if: github.event_name == 'push' && github.ref == 'refs/heads/trunk' && !cancelled()
         run: |
-          cd scripts/compare-perf && npm run log-to-codevitals
+          npm ci && cd scripts/compare-perf && npm run log-to-codevitals
 
       - name: Archive performance results
         if: ${{ !cancelled() }}

--- a/metrics/README.md
+++ b/metrics/README.md
@@ -15,6 +15,7 @@ npm run test:metrics
 ```
 
 This will:
+
 1. Package the application (to ensure testing against the production build)
 2. Run the performance tests using Playwright
 3. Generate a performance reports in `artifacts/performance-metrics.json` at the project root and output the results to the console
@@ -35,9 +36,21 @@ cd scripts/compare-perf && npm run compare -- perf <commit1> <commit2>
 ```
 
 This tool is useful for:
+
 - Testing performance impact of code changes
 - Identifying performance regressions
 - Benchmarking improvements in new features
+
+## CodeVitals Integration
+
+Performance metrics from the `trunk` branch are automatically sent to [CodeVitals](https://codevitals.dev/) for tracking and visualization. This helps in tracking performance trends over time and detecting regressions.
+
+The metrics are sent when:
+
+1. A workflow runs on the `trunk` branch
+2. The `CODEVITALS_AUTH_TOKEN` secret is available in the GitHub repository
+
+Note that the job sends the metrics for the current command and a reference commit as well. This allows CodeVitals to compare the performance metrics between the two commits and normalize the current commit's values to avoid the CI fluctuations.
 
 ## Understanding the Results
 
@@ -45,8 +58,8 @@ The `performance-metrics.json` output file contains a summary of the results, ex
 
 ```json
 {
-  "siteCreation": 6150,
-  "siteStartup": 3946
+	"siteCreation": 6150,
+	"siteStartup": 3946
 }
 ```
 

--- a/scripts/compare-perf/log-to-codevitals.ts
+++ b/scripts/compare-perf/log-to-codevitals.ts
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+import fs from 'fs';
+import https from 'https';
+import path from 'path';
+const [ token, branch, hash, baseHash, timestamp ] = process.argv.slice( 2 );
+
+const resultsFiles = [
+	{
+		file: 'site-startup.summary.json',
+		metricsPrefix: '',
+	},
+];
+
+const performanceResults = resultsFiles.map( ( { file } ) =>
+	JSON.parse(
+		fs.readFileSync( path.join( process.env.ARTIFACTS_PATH ?? 'artifacts', file ), 'utf8' )
+	)
+);
+
+const data = new TextEncoder().encode(
+	JSON.stringify( {
+		branch,
+		hash,
+		baseHash,
+		timestamp,
+		metrics: resultsFiles.reduce( ( result, { metricsPrefix }, index ) => {
+			return {
+				...result,
+				...Object.fromEntries(
+					Object.entries( performanceResults[ index ][ hash ] ?? {} ).map( ( [ key, value ] ) => [
+						metricsPrefix + key,
+						value,
+					] )
+				),
+			};
+		}, {} ),
+		baseMetrics: resultsFiles.reduce( ( result, { metricsPrefix }, index ) => {
+			return {
+				...result,
+				...Object.fromEntries(
+					Object.entries( performanceResults[ index ][ baseHash ] ?? {} ).map(
+						( [ key, value ] ) => [ metricsPrefix + key, value ]
+					)
+				),
+			};
+		}, {} ),
+	} )
+);
+
+const options = {
+	hostname: 'www.codevitals.run',
+	port: 443,
+	path: '/api/log?token=' + token,
+	method: 'POST',
+	headers: {
+		'Content-Type': 'application/json',
+		'Content-Length': data.length,
+	},
+};
+
+const req = https.request( options, ( res ) => {
+	console.log( `statusCode: ${ res.statusCode }` );
+
+	res.on( 'data', ( d ) => {
+		process.stdout.write( d );
+	} );
+} );
+
+req.on( 'error', ( error ) => {
+	console.error( error );
+} );
+
+req.write( data );
+req.end();

--- a/scripts/compare-perf/package.json
+++ b/scripts/compare-perf/package.json
@@ -7,7 +7,8 @@
 	"license": "GPLv2",
 	"repository": "Automattic/studio",
 	"scripts": {
-		"compare": "ts-node index.ts"
+		"compare": "ts-node index.ts",
+		"log-to-codevitals": "ts-node log-to-codevitals.ts"
 	},
 	"dependencies": {
 		"chalk": "^4.1.2",


### PR DESCRIPTION
## Related issues

Fixes DOTCOM-671-linear-issue

## Changes proposed in this Pull Request:

**Big Picture** My goal is to bring metrics tracking and performance dashboard to the tools Studio use daily to avoid performance regressions and work on performance improvements similarly to the [Gutenberg project](https://www.codevitals.run/project/gutenberg) for instance.

Implementing this require three complementary steps:

 1- First step is to have some test runner (e2e test here) that we can launch to compute the metrics.
 2- Second step is to be able to use the same test runner in two separate branches as part of the same CI job. The reason for this is that CI runners capacities are unstable and we can't rely on the absolute numbers. We have to compute relative numbers and compare each commit with a given "base commit".
 3- Third step is to send these values (base branch and commit) to the dashboard (codevitals) to log it and produce the graphs.

The current PR implements the last step. 

### How to test the changes in this Pull Request:

http://codevitals.run/project/studio