### PR TITLE
Fix Studio launch after recent mac install script was added

### DIFF
--- a/src/modules/cli/lib/install-macos.ts
+++ b/src/modules/cli/lib/install-macos.ts
@@ -1,7 +1,7 @@
 import { dialog } from 'electron';
 import { mkdir, readlink, symlink, unlink } from 'node:fs/promises';
 import path from 'node:path';
-import * as Sentry from '@sentry/electron';
+import * as Sentry from '@sentry/electron/main';
 import { __ } from '@wordpress/i18n';
 import { sudoExec } from 'src/lib/sudo-exec';
 import { getMainWindow } from 'src/main-window';


### PR DESCRIPTION
## Related issues

Related PR #1132

## Proposed Changes

- A small typo in the related PR above meant that Studio stopped launching entirely. you can see it in the failed e2e tests on the linked PR or you can try launching Studio locally in trunk. This PR should fix it.

## Testing Instructions

- Just launch Studio locally, it should launch without errors.