### PR TITLE
Update SQLite database integration plugin to v2.1.19-alpha

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -61,6 +61,6 @@ export const WP_CLI_IMPORT_EXPORT_RESPONSE_TIMEOUT =
 	WP_CLI_IMPORT_EXPORT_RESPONSE_TIMEOUT_IN_HRS * 60 * 60 * 1000; // 6hr
 
 // SQLite
-export const SQLITE_DATABASE_INTEGRATION_VERSION = 'v2.1.17-alpha';
+export const SQLITE_DATABASE_INTEGRATION_VERSION = 'v2.1.18-alpha';
 
 export const SQLITE_DATABASE_INTEGRATION_RELEASE_URL = `https://github.com/Automattic/sqlite-database-integration/archive/refs/tags/${ SQLITE_DATABASE_INTEGRATION_VERSION }.zip`;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -61,6 +61,6 @@ export const WP_CLI_IMPORT_EXPORT_RESPONSE_TIMEOUT =
 	WP_CLI_IMPORT_EXPORT_RESPONSE_TIMEOUT_IN_HRS * 60 * 60 * 1000; // 6hr
 
 // SQLite
-export const SQLITE_DATABASE_INTEGRATION_VERSION = 'v2.1.18-alpha';
+export const SQLITE_DATABASE_INTEGRATION_VERSION = 'v2.1.19-alpha';
 
 export const SQLITE_DATABASE_INTEGRATION_RELEASE_URL = `https://github.com/Automattic/sqlite-database-integration/archive/refs/tags/${ SQLITE_DATABASE_INTEGRATION_VERSION }.zip`;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes #1124

## Proposed Changes

- Update the SQLite database integration plugin to version 2.1.19-alpha

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Create a new site in Production Studio (or on trunk)
- Note the SQLite database integration plugin version for that site
- Checkout this branch
- Run `npm run postinstall`
- Start the site in Studio
- Confirm that the SQLite database integration plugin version was updated to 2.1.19-alpha and that the site runs

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
