### PR TITLE
macOS CLI script tweaks

### DIFF
--- a/bin/install-studio-cli.sh
+++ b/bin/install-studio-cli.sh
@@ -1,18 +1,18 @@
 #!/bin/sh
 
-# This script is used to install the Studio CLI on macOS. It creates a symlink at CLI_SYMLINK_SOURCE
-# (e.g. /usr/local/bin/studio) pointing to the packaged Studio CLI JS file at CLI_SYMLINK_TARGET.
+# This script is used to install the Studio CLI on macOS. It creates a symlink at CLI_SYMLINK_PATH
+# (e.g. /usr/local/bin/studio) pointing to the packaged Studio CLI JS file at CLI_SYMLINK_DESTINATION.
 
 # Exit if any command fails
 set -e
 
-if [ -z "$CLI_SYMLINK_SOURCE" ] || [ -z "$CLI_SYMLINK_TARGET" ]; then
-	echo "Error: CLI_SYMLINK_SOURCE and CLI_SYMLINK_TARGET environment variables must be set"
+if [ -z "$CLI_SYMLINK_PATH" ] || [ -z "$CLI_SYMLINK_DESTINATION" ]; then
+	echo >&2 "Error: CLI_SYMLINK_PATH and CLI_SYMLINK_DESTINATION environment variables must be set"
 	exit 1
 fi
 
-DIRECTORY_PATH=$(dirname "$CLI_SYMLINK_SOURCE")
+DIRECTORY_PATH=$(dirname "$CLI_SYMLINK_PATH")
 
-rm -f "$CLI_SYMLINK_SOURCE"
+rm -f "$CLI_SYMLINK_PATH"
 mkdir -p "$DIRECTORY_PATH"
-ln -s "$CLI_SYMLINK_TARGET" "$CLI_SYMLINK_SOURCE"
+ln -s "$CLI_SYMLINK_DESTINATION" "$CLI_SYMLINK_PATH"

--- a/bin/install-studio-cli.sh
+++ b/bin/install-studio-cli.sh
@@ -1,18 +1,18 @@
 #!/bin/sh
 
 # This script is used to install the Studio CLI on macOS. It creates a symlink at CLI_SYMLINK_PATH
-# (e.g. /usr/local/bin/studio) pointing to the packaged Studio CLI JS file at CLI_SYMLINK_DESTINATION.
+# (e.g. /usr/local/bin/studio) pointing to the packaged Studio CLI JS file at CLI_PACKAGED_PATH.
 
 # Exit if any command fails
 set -e
 
-if [ -z "$CLI_SYMLINK_PATH" ] || [ -z "$CLI_SYMLINK_DESTINATION" ]; then
-	echo >&2 "Error: CLI_SYMLINK_PATH and CLI_SYMLINK_DESTINATION environment variables must be set"
+if [ -z "$CLI_SYMLINK_PATH" ] || [ -z "$CLI_PACKAGED_PATH" ]; then
+	echo >&2 "Error: CLI_SYMLINK_PATH and CLI_PACKAGED_PATH environment variables must be set"
 	exit 1
 fi
 
-DIRECTORY_PATH=$(dirname "$CLI_SYMLINK_PATH")
+CLI_DIRECTORY_PATH=$(dirname "$CLI_SYMLINK_PATH")
 
-rm -f "$CLI_SYMLINK_PATH"
-mkdir -p "$DIRECTORY_PATH"
-ln -s "$CLI_SYMLINK_DESTINATION" "$CLI_SYMLINK_PATH"
+[ -h "$CLI_SYMLINK_PATH" ] && rm "$CLI_SYMLINK_PATH"
+mkdir -p "$CLI_DIRECTORY_PATH"
+ln -s "$CLI_PACKAGED_PATH" "$CLI_SYMLINK_PATH"

--- a/bin/studio-cli.sh
+++ b/bin/studio-cli.sh
@@ -1,16 +1,13 @@
 #!/bin/sh
 
-# The least terrible way to resolve a symlink to its real path.
-function realpath() {
-  /usr/bin/perl -e "use Cwd;print Cwd::abs_path(@ARGV[0])" "$0";
-}
-
 # This script is assumed to live in `/Applications/Studio.app/Contents/Resources/bin/studio-cli.sh`
-CONTENTS_DIR="$(command dirname "$(command dirname "$(command dirname "$(realpath "$0")")")")"
-BINARY_NAME="$(TERM=dumb command ls "$CONTENTS_DIR/MacOS/")"
-ELECTRON="$CONTENTS_DIR/MacOS/$BINARY_NAME"
-CLI="$CONTENTS_DIR/Resources/cli/main.js"
+CONTENTS_DIR=$(dirname "$(dirname "$(dirname "$(realpath "$0")")")")
+ELECTRON_EXECUTABLE="$CONTENTS_DIR/MacOS/Studio"
+CLI_SCRIPT="$CONTENTS_DIR/Resources/cli/main.js"
 
-ELECTRON_RUN_AS_NODE=1 "$ELECTRON" "$CLI" "$@"
+if ! [ -x "$ELECTRON_EXECUTABLE" ]; then
+	echo >&2 "'Studio' executable not found"
+	exit 1
+fi
 
-exit $? 
+ELECTRON_RUN_AS_NODE=1 exec "$ELECTRON_EXECUTABLE" "$CLI_SCRIPT" "$@"

--- a/src/modules/cli/lib/install-macos.ts
+++ b/src/modules/cli/lib/install-macos.ts
@@ -1,8 +1,8 @@
 import { dialog } from 'electron';
-import { mkdir, readlink, symlink, unlink } from 'node:fs/promises';
+import { mkdir, readlink, symlink, unlink, lstat } from 'node:fs/promises';
 import path from 'node:path';
 import * as Sentry from '@sentry/electron/main';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { sudoExec } from 'src/lib/sudo-exec';
 import { getMainWindow } from 'src/main-window';
 import { getResourcesPath } from 'src/storage/paths';
@@ -13,6 +13,11 @@ const cliSymlinkPath = '/usr/local/bin/studio';
 const binPath = path.join( getResourcesPath(), 'bin' );
 const cliPackagedPath = path.join( binPath, 'studio-cli.sh' );
 const installScriptPath = path.join( binPath, 'install-studio-cli.sh' );
+
+enum InstallError {
+	WrongPlatform = 'Studio CLI is only available on macOS',
+	FileAlreadyExists = 'Studio CLI symlink path already occupied by non-symlink',
+}
 
 export async function installCLIOnMacOSWithConfirmation() {
 	try {
@@ -27,13 +32,22 @@ export async function installCLIOnMacOSWithConfirmation() {
 		Sentry.captureException( error );
 		console.error( 'Failed to install CLI', error );
 
+		let message = __( 'Please ensure you grant Studio admin permissions when prompted.' );
+		if ( error instanceof Error && error.message === InstallError.FileAlreadyExists ) {
+			message = sprintf(
+				/* translators: 1: Installation path */
+				__(
+					'The installation path %1$s is already occupied by a file or directory. Please remove it and try again.'
+				),
+				cliSymlinkPath
+			);
+		}
+
 		const mainWindow = await getMainWindow();
 		await dialog.showMessageBox( mainWindow, {
 			type: 'error',
 			title: __( 'Failed to install CLI' ),
-			message: __(
-				'Please try again and ensure you grant Studio admin permissions when prompted.'
-			),
+			message,
 		} );
 	}
 }
@@ -42,11 +56,19 @@ export async function installCLIOnMacOSWithConfirmation() {
 // to the packaged Studio CLI JS file at `cliPackagedPath`.
 async function installCLI(): Promise< void > {
 	if ( process.platform !== 'darwin' ) {
-		return;
+		throw new Error( InstallError.WrongPlatform );
+	}
+
+	const fileType = await getFileType( cliSymlinkPath );
+
+	// Avoid overwriting an existing file if it's not a symlink.
+	if ( fileType === FileType.NonSymlink ) {
+		throw new Error( InstallError.FileAlreadyExists );
 	}
 
 	const currentSymlinkDestination = await getCurrentSymlinkDestination();
 
+	// The CLI is already installed.
 	if ( currentSymlinkDestination === cliPackagedPath ) {
 		return;
 	}
@@ -67,6 +89,21 @@ async function installCLI(): Promise< void > {
 				CLI_PACKAGED_PATH: cliPackagedPath,
 			},
 		} );
+	}
+}
+
+enum FileType {
+	NonExistent,
+	NonSymlink,
+	Symlink,
+}
+
+async function getFileType( filePath: string ): Promise< FileType > {
+	try {
+		const stats = await lstat( filePath );
+		return stats.isSymbolicLink() ? FileType.Symlink : FileType.NonSymlink;
+	} catch ( error ) {
+		return FileType.NonExistent;
 	}
 }
 

--- a/src/modules/cli/lib/install-macos.ts
+++ b/src/modules/cli/lib/install-macos.ts
@@ -8,10 +8,10 @@ import { getMainWindow } from 'src/main-window';
 import { getResourcesPath } from 'src/storage/paths';
 import packageJson from '../../../../package.json';
 
-const cliSymlinkSource = '/usr/local/bin/studio';
+const cliSymlinkPath = '/usr/local/bin/studio';
 
 const binPath = path.join( getResourcesPath(), 'bin' );
-const cliSymlinkTarget = path.join( binPath, 'studio-cli.sh' );
+const cliSymlinkDestination = path.join( binPath, 'studio-cli.sh' );
 const installScriptPath = path.join( binPath, 'install-studio-cli.sh' );
 
 export async function installCLIOnMacOSWithConfirmation() {
@@ -45,34 +45,34 @@ async function installCLI(): Promise< void > {
 		return;
 	}
 
-	const currentSymlinkTarget = await getCurrentSymlinkTarget();
+	const currentSymlinkDestination = await getCurrentSymlinkDestination();
 
-	if ( currentSymlinkTarget === cliSymlinkTarget ) {
+	if ( currentSymlinkDestination === cliSymlinkDestination ) {
 		return;
 	}
 
 	try {
-		const directoryPath = path.dirname( cliSymlinkSource );
+		const directoryPath = path.dirname( cliSymlinkPath );
 
-		await unlink( cliSymlinkSource );
+		await unlink( cliSymlinkPath );
 		await mkdir( directoryPath, { recursive: true } );
-		await symlink( cliSymlinkTarget, cliSymlinkSource );
+		await symlink( cliSymlinkDestination, cliSymlinkPath );
 	} catch ( e ) {
 		// `/usr/local/bin` is not typically writable by non-root users, so in most cases, we run
 		// this install script with admin privileges to create the symlink.
 		await sudoExec( `/bin/sh "${ installScriptPath }"`, {
 			name: packageJson.productName,
 			env: {
-				CLI_SYMLINK_SOURCE: cliSymlinkSource,
-				CLI_SYMLINK_TARGET: cliSymlinkTarget,
+				CLI_SYMLINK_PATH: cliSymlinkPath,
+				CLI_SYMLINK_DESTINATION: cliSymlinkDestination,
 			},
 		} );
 	}
 }
 
-async function getCurrentSymlinkTarget(): Promise< string | null > {
+async function getCurrentSymlinkDestination(): Promise< string | null > {
 	try {
-		return await readlink( cliSymlinkSource );
+		return await readlink( cliSymlinkPath );
 	} catch {
 		return null;
 	}

--- a/src/modules/cli/lib/install-macos.ts
+++ b/src/modules/cli/lib/install-macos.ts
@@ -17,6 +17,8 @@ const installScriptPath = path.join( binPath, 'install-studio-cli.sh' );
 enum InstallError {
 	WrongPlatform = 'Studio CLI is only available on macOS',
 	FileAlreadyExists = 'Studio CLI symlink path already occupied by non-symlink',
+	// Defined in @vscode/sudo-prompt
+	PermissionError = 'User did not grant permission.',
 }
 
 export async function installCLIOnMacOSWithConfirmation() {
@@ -32,15 +34,20 @@ export async function installCLIOnMacOSWithConfirmation() {
 		Sentry.captureException( error );
 		console.error( 'Failed to install CLI', error );
 
-		let message = __( 'Please ensure you grant Studio admin permissions when prompted.' );
-		if ( error instanceof Error && error.message === InstallError.FileAlreadyExists ) {
-			message = sprintf(
-				/* translators: 1: Installation path */
-				__(
-					'The installation path %1$s is already occupied by a file or directory. Please remove it and try again.'
-				),
-				cliSymlinkPath
-			);
+		let message = __( 'There was an unknown error. Please check the logs for more information.' );
+
+		if ( error instanceof Error ) {
+			if ( error.message === InstallError.FileAlreadyExists ) {
+				message = sprintf(
+					/* translators: 1: Installation path */
+					__(
+						'The installation path %1$s is already occupied by a file or directory. Please remove it and try again.'
+					),
+					cliSymlinkPath
+				);
+			} else if ( error.message === InstallError.PermissionError ) {
+				message = __( 'Please ensure you grant Studio admin permissions when prompted.' );
+			}
 		}
 
 		const mainWindow = await getMainWindow();

--- a/src/modules/cli/lib/install-macos.ts
+++ b/src/modules/cli/lib/install-macos.ts
@@ -15,12 +15,10 @@ const binPath = path.join( getResourcesPath(), 'bin' );
 const cliPackagedPath = path.join( binPath, 'studio-cli.sh' );
 const installScriptPath = path.join( binPath, 'install-studio-cli.sh' );
 
-enum InstallError {
-	WrongPlatform = 'Studio CLI is only available on macOS',
-	FileAlreadyExists = 'Studio CLI symlink path already occupied by non-symlink',
-	// Defined in @vscode/sudo-prompt
-	PermissionError = 'User did not grant permission.',
-}
+const ERROR_WRONG_PLATFORM = 'Studio CLI is only available on macOS';
+const ERROR_FILE_ALREADY_EXISTS = 'Studio CLI symlink path already occupied by non-symlink';
+// Defined in @vscode/sudo-prompt
+const ERROR_PERMISSION = 'User did not grant permission.';
 
 export async function installCLIOnMacOSWithConfirmation() {
 	try {
@@ -38,7 +36,7 @@ export async function installCLIOnMacOSWithConfirmation() {
 		let message = __( 'There was an unknown error. Please check the logs for more information.' );
 
 		if ( error instanceof Error ) {
-			if ( error.message === InstallError.FileAlreadyExists ) {
+			if ( error.message === ERROR_FILE_ALREADY_EXISTS ) {
 				message = sprintf(
 					/* translators: 1: Installation path */
 					__(
@@ -46,7 +44,7 @@ export async function installCLIOnMacOSWithConfirmation() {
 					),
 					cliSymlinkPath
 				);
-			} else if ( error.message === InstallError.PermissionError ) {
+			} else if ( error.message === ERROR_PERMISSION ) {
 				message = __( 'Please ensure you grant Studio admin permissions when prompted.' );
 			}
 		}
@@ -64,14 +62,14 @@ export async function installCLIOnMacOSWithConfirmation() {
 // to the packaged Studio CLI JS file at `cliPackagedPath`.
 async function installCLI(): Promise< void > {
 	if ( process.platform !== 'darwin' ) {
-		throw new Error( InstallError.WrongPlatform );
+		throw new Error( ERROR_WRONG_PLATFORM );
 	}
 
 	try {
 		const stats = await lstat( cliSymlinkPath );
 
 		if ( ! stats.isSymbolicLink() ) {
-			throw new Error( InstallError.FileAlreadyExists );
+			throw new Error( ERROR_FILE_ALREADY_EXISTS );
 		}
 	} catch ( error ) {
 		if ( isErrnoException( error ) && error.code === 'ENOENT' ) {

--- a/src/modules/cli/lib/install-macos.ts
+++ b/src/modules/cli/lib/install-macos.ts
@@ -11,7 +11,7 @@ import packageJson from '../../../../package.json';
 const cliSymlinkPath = '/usr/local/bin/studio';
 
 const binPath = path.join( getResourcesPath(), 'bin' );
-const cliSymlinkDestination = path.join( binPath, 'studio-cli.sh' );
+const cliPackagedPath = path.join( binPath, 'studio-cli.sh' );
 const installScriptPath = path.join( binPath, 'install-studio-cli.sh' );
 
 export async function installCLIOnMacOSWithConfirmation() {
@@ -38,8 +38,8 @@ export async function installCLIOnMacOSWithConfirmation() {
 	}
 }
 
-// This function installs the Studio CLI on macOS. It creates a symlink at `cliSymlinkSource`
-// pointing to the packaged Studio CLI JS file at `cliSymlinkTarget`.
+// This function installs the Studio CLI on macOS. It creates a symlink at `cliSymlinkPath` pointing
+// to the packaged Studio CLI JS file at `cliPackagedPath`.
 async function installCLI(): Promise< void > {
 	if ( process.platform !== 'darwin' ) {
 		return;
@@ -47,7 +47,7 @@ async function installCLI(): Promise< void > {
 
 	const currentSymlinkDestination = await getCurrentSymlinkDestination();
 
-	if ( currentSymlinkDestination === cliSymlinkDestination ) {
+	if ( currentSymlinkDestination === cliPackagedPath ) {
 		return;
 	}
 
@@ -56,7 +56,7 @@ async function installCLI(): Promise< void > {
 
 		await unlink( cliSymlinkPath );
 		await mkdir( directoryPath, { recursive: true } );
-		await symlink( cliSymlinkDestination, cliSymlinkPath );
+		await symlink( cliPackagedPath, cliSymlinkPath );
 	} catch ( e ) {
 		// `/usr/local/bin` is not typically writable by non-root users, so in most cases, we run
 		// this install script with admin privileges to create the symlink.
@@ -64,7 +64,7 @@ async function installCLI(): Promise< void > {
 			name: packageJson.productName,
 			env: {
 				CLI_SYMLINK_PATH: cliSymlinkPath,
-				CLI_SYMLINK_DESTINATION: cliSymlinkDestination,
+				CLI_PACKAGED_PATH: cliPackagedPath,
 			},
 		} );
 	}

--- a/src/modules/cli/lib/install-macos.ts
+++ b/src/modules/cli/lib/install-macos.ts
@@ -59,11 +59,14 @@ async function installCLI(): Promise< void > {
 		throw new Error( InstallError.WrongPlatform );
 	}
 
-	const fileType = await getFileType( cliSymlinkPath );
+	try {
+		const stats = await lstat( cliSymlinkPath );
 
-	// Avoid overwriting an existing file if it's not a symlink.
-	if ( fileType === FileType.NonSymlink ) {
-		throw new Error( InstallError.FileAlreadyExists );
+		if ( ! stats.isSymbolicLink() ) {
+			throw new Error( InstallError.FileAlreadyExists );
+		}
+	} catch ( error ) {
+		// File does not exist, do nothing
 	}
 
 	const currentSymlinkDestination = await getCurrentSymlinkDestination();
@@ -89,21 +92,6 @@ async function installCLI(): Promise< void > {
 				CLI_PACKAGED_PATH: cliPackagedPath,
 			},
 		} );
-	}
-}
-
-enum FileType {
-	NonExistent,
-	NonSymlink,
-	Symlink,
-}
-
-async function getFileType( filePath: string ): Promise< FileType > {
-	try {
-		const stats = await lstat( filePath );
-		return stats.isSymbolicLink() ? FileType.Symlink : FileType.NonSymlink;
-	} catch ( error ) {
-		return FileType.NonExistent;
 	}
 }
 

--- a/src/modules/cli/lib/install-macos.ts
+++ b/src/modules/cli/lib/install-macos.ts
@@ -3,6 +3,7 @@ import { mkdir, readlink, symlink, unlink, lstat } from 'node:fs/promises';
 import path from 'node:path';
 import * as Sentry from '@sentry/electron/main';
 import { __, sprintf } from '@wordpress/i18n';
+import { isErrnoException } from 'src/lib/is-errno-exception';
 import { sudoExec } from 'src/lib/sudo-exec';
 import { getMainWindow } from 'src/main-window';
 import { getResourcesPath } from 'src/storage/paths';
@@ -73,7 +74,11 @@ async function installCLI(): Promise< void > {
 			throw new Error( InstallError.FileAlreadyExists );
 		}
 	} catch ( error ) {
-		// File does not exist, do nothing
+		if ( isErrnoException( error ) && error.code === 'ENOENT' ) {
+			// File does not exist, which means we can proceed with the installation.
+		} else {
+			throw error;
+		}
 	}
 
 	const currentSymlinkDestination = await getCurrentSymlinkDestination();


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Follow-up to https://github.com/Automattic/studio/pull/1132 and https://github.com/Automattic/studio/pull/1111

## Proposed Changes

- In the POSIX `ln` utility documentation, the `source` and `target` terms refer to the opposite of what you'd expect (if you expect that "target" means link destination and "source" means symlink path). To avoid additional confusion, I've changed the terms to "symlink path" and "packaged path".
- As an additional safety measure, we now abort the installation if something other than a symlink already lives at `/usr/local/bin/studio`
- Tweaked the macOS CLI bootstrap script per @mcsf's recommendations in https://github.com/Automattic/studio/pull/1111.
  - Remove the use of `command` prefixes.
  - Use a static name for the Electron executable file.
  - Verify the existence of the Electron executable file.
  - Use `exec` to replace the shell process with the node process.

> [!TIP]
> An interesting piece of trivia is that the GNU `ln` utility [apparently](https://unix.stackexchange.com/a/616744/106354) uses the opposite meaning for "target".

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Same as https://github.com/Automattic/studio/pull/1132

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
