### PR TITLE
Revert SQLite database integration plugin to v2.1.18-alpha and allow downgrading the plugin

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,6 +9,9 @@
 				"runtimeExecutable": "${workspaceFolder}/node_modules/@electron-forge/cli/script/vscode.cmd"
 			},
 			"cwd": "${workspaceFolder}",
+			"env": {
+				"NODE_ENV": "development"
+			},
 			"console": "integratedTerminal"
 		},
 		{

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -61,6 +61,6 @@ export const WP_CLI_IMPORT_EXPORT_RESPONSE_TIMEOUT =
 	WP_CLI_IMPORT_EXPORT_RESPONSE_TIMEOUT_IN_HRS * 60 * 60 * 1000; // 6hr
 
 // SQLite
-export const SQLITE_DATABASE_INTEGRATION_VERSION = 'v2.1.19-alpha';
+export const SQLITE_DATABASE_INTEGRATION_VERSION = 'v2.1.18-alpha';
 
 export const SQLITE_DATABASE_INTEGRATION_RELEASE_URL = `https://github.com/Automattic/sqlite-database-integration/archive/refs/tags/${ SQLITE_DATABASE_INTEGRATION_VERSION }.zip`;

--- a/src/lib/sqlite-versions.ts
+++ b/src/lib/sqlite-versions.ts
@@ -32,6 +32,9 @@ export async function updateLatestSqliteVersion() {
  * Checks if the SQLite integration version installed in a site is outdated compared to the version
  * installed locally in the server files.
  *
+ * A version is outdated if the installed version doesn't match the Studio version of the SQLite database
+ * integration plugin and it can be either greater or lower version.
+ *
  * @param sitePath Path of the site.
  *
  * @returns True if the SQLite integration is outdated.
@@ -48,7 +51,7 @@ export async function isSqliteInstallationOutdated( sitePath: string ): Promise<
 		return false;
 	}
 
-	return semver.lt( siteVersion, serverFilesVersion );
+	return ! semver.eq( siteVersion, serverFilesVersion );
 }
 
 export async function getSqliteVersionFromInstallation(

--- a/src/storage/paths.ts
+++ b/src/storage/paths.ts
@@ -1,11 +1,20 @@
 import { app } from 'electron';
 import path from 'path';
+import { pathExistsSync } from 'fs-extra';
 
 export function getUserDataFilePath(): string {
 	return path.join( getAppDataPath(), getAppName(), 'appdata-v1.json' );
 }
 
 export function getServerFilesPath(): string {
+	const localServerFilesPath = path.join( __dirname, '..', '..', 'wp-files' );
+	/**
+	 * Locally, we might have a newer version of the server files in the project folder
+	 * so we can test the app with the latest version of the server files.
+	 */
+	if ( process.env.NODE_ENV === 'development' && pathExistsSync( localServerFilesPath ) ) {
+		return localServerFilesPath;
+	}
 	return path.join( getAppDataPath(), getAppName(), 'server-files' );
 }
 

--- a/src/storage/paths.ts
+++ b/src/storage/paths.ts
@@ -12,7 +12,11 @@ export function getServerFilesPath(): string {
 	 * Locally, we might have a newer version of the server files in the project folder
 	 * so we can test the app with the latest version of the server files.
 	 */
-	if ( process.env.NODE_ENV === 'development' && pathExistsSync( localServerFilesPath ) ) {
+	if (
+		process.env.NODE_ENV === 'development' &&
+		pathExistsSync( localServerFilesPath ) &&
+		! process.env.CI
+	) {
 		return localServerFilesPath;
 	}
 	return path.join( getAppDataPath(), getAppName(), 'server-files' );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Required to fix Jetpack backups in 1.3.9-beta2

## Proposed Changes

- Revert SQLite database integration plugin to v2.1.18-alpha
- Allow downgrading the SQLite database integration plugin
- If available use wp-files from the project folder instead of wp-files locally
- VScode debugger launches Studio in development mode

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run `npm run postinstall`
- Ensure that your local version of the SQLite database integration plugin is v2.1.18-alpha
- Start Studio
- Confirm that your sites are now using SQLite database integration plugin v2.1.18-alpha
- Try importing a Jetpack backup and confirm it works

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
