### PR TITLE
Settings: add section with database path and general connection instructions

### DIFF
--- a/src/components/content-tab-settings.tsx
+++ b/src/components/content-tab-settings.tsx
@@ -177,19 +177,19 @@ export function ContentTabSettings( { selectedSite }: ContentTabSettingsProps ) 
 					<SettingsRow label={ __( 'Local path' ) }>
 						<CopyTextButton
 							text={ pathToDatabase }
-							label={ __( 'Copy local path to clipboard' ) }
+							label={ __( 'Copy local database path to clipboard' ) }
 							copyConfirmation={ __( 'Copied!' ) }
 						>
 							<span className="line-clamp-1 break-all">{ pathToDatabase }</span>
 						</CopyTextButton>
 					</SettingsRow>
-					<SettingsRow label={ __( 'File system' ) }>
+					<SettingsRow label={ __( 'Local folder' ) }>
 						<div className="flex items-center">
 							<Button
 								variant="link"
 								onClick={ () => getIpcApi().showItemInFolder( pathToDatabase ) }
 							>
-								{ __( 'Open' ) }
+								{ __( 'Open in file system' ) }
 							</Button>
 							<ArrowIcon />
 						</div>

--- a/src/components/content-tab-settings.tsx
+++ b/src/components/content-tab-settings.tsx
@@ -1,11 +1,13 @@
 import { DropdownMenu, MenuGroup, Button } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
 import { moreVertical } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { PropsWithChildren } from 'react';
 import { ArrowIcon } from 'src/components/arrow-icon';
 import { CopyTextButton } from 'src/components/copy-text-button';
 import DeleteSite from 'src/components/delete-site';
-import { LOCAL_SQLITE_DATABASE_PATH } from 'src/constants';
+import { LOCAL_SQLITE_DATABASE_PATH, LOCAL_SQLITE_DATABASE_FILENAME } from 'src/constants';
 import { useGetWpVersion } from 'src/hooks/use-get-wp-version';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 import { decodePassword } from 'src/lib/passwords';
@@ -169,9 +171,36 @@ export function ContentTabSettings( { selectedSite }: ContentTabSettingsProps ) 
 					</tr>
 					<SettingsRow>
 						<div className="ltr:pr-8 rtl:pl-8">
-							{ __(
-								'Your WordPress site is connected to a local SQLite database. To view and manage your database, create backups, restore from backups, and more, you can open the local database file in an external SQLite-compatible database tool.'
-							) }
+							<p className="mb-2">
+								{ __(
+									'Your WordPress site is connected to a local SQLite database. To view and manage your database, create backups, restore from backups, and more, you can open the local database file in an external SQLite-compatible database tool.'
+								) }
+							</p>
+							<p className="mb-2">
+								{ createInterpolateElement(
+									sprintf(
+										// translators: %s is the local database file name.
+										__(
+											'Once you have installed an external SQLite-compatible database tool, open the local database and click on <span>%s</span>.'
+										),
+										LOCAL_SQLITE_DATABASE_FILENAME
+									),
+									{
+										span: <span className="italic text-a8c-gray-50 inline-block" />,
+									}
+								) }
+							</p>
+						</div>
+					</SettingsRow>
+					<SettingsRow label={ __( 'Local file' ) }>
+						<div className="flex items-center">
+							<Button
+								variant="link"
+								onClick={ () => getIpcApi().showItemInFolder( pathToDatabase ) }
+							>
+								{ __( 'Open local database' ) }
+							</Button>
+							<ArrowIcon />
 						</div>
 					</SettingsRow>
 					<SettingsRow label={ __( 'Local path' ) }>
@@ -182,17 +211,6 @@ export function ContentTabSettings( { selectedSite }: ContentTabSettingsProps ) 
 						>
 							<span className="line-clamp-1 break-all">{ pathToDatabase }</span>
 						</CopyTextButton>
-					</SettingsRow>
-					<SettingsRow label={ __( 'Local folder' ) }>
-						<div className="flex items-center">
-							<Button
-								variant="link"
-								onClick={ () => getIpcApi().showItemInFolder( pathToDatabase ) }
-							>
-								{ __( 'Open in file system' ) }
-							</Button>
-							<ArrowIcon />
-						</div>
 					</SettingsRow>
 				</tbody>
 			</table>

--- a/src/components/content-tab-settings.tsx
+++ b/src/components/content-tab-settings.tsx
@@ -2,8 +2,10 @@ import { DropdownMenu, MenuGroup, Button } from '@wordpress/components';
 import { moreVertical } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { PropsWithChildren } from 'react';
+import { ArrowIcon } from 'src/components/arrow-icon';
 import { CopyTextButton } from 'src/components/copy-text-button';
 import DeleteSite from 'src/components/delete-site';
+import { LOCAL_SQLITE_DATABASE_PATH } from 'src/constants';
 import { useGetWpVersion } from 'src/hooks/use-get-wp-version';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 import { decodePassword } from 'src/lib/passwords';
@@ -13,13 +15,22 @@ interface ContentTabSettingsProps {
 	selectedSite: SiteDetails;
 }
 
-function SettingsRow( { children, label }: PropsWithChildren< { label: string } > ) {
+function SettingsRow( {
+	children,
+	label,
+}: PropsWithChildren< {
+	label?: string;
+} > ) {
 	return (
 		<tr className="align-top">
-			<th className="text-nowrap text-a8c-gray-50 pb-4 ltr:pr-6 rtl:pl-6 ltr:text-left rtl:text-right font-normal">
-				{ label }
-			</th>
-			<td className="pb-4">{ children }</td>
+			{ label && (
+				<th className="text-nowrap text-a8c-gray-50 pb-4 ltr:pr-6 rtl:pl-6 ltr:text-left rtl:text-right font-normal">
+					{ label }
+				</th>
+			) }
+			<td className="pb-4" colSpan={ ! label ? 2 : undefined }>
+				{ children }
+			</td>
 		</tr>
 	);
 }
@@ -35,6 +46,7 @@ export function ContentTabSettings( { selectedSite }: ContentTabSettingsProps ) 
 		? `${ selectedSite.customDomain }`
 		: `localhost:${ selectedSite.port }`;
 	const protocol = selectedSite.customDomain && selectedSite.enableHttps ? 'https' : 'http';
+	const pathToDatabase = `${ selectedSite.path }${ LOCAL_SQLITE_DATABASE_PATH }`;
 	return (
 		<div className="p-8 ltr:pr-0 rtl:pl-0">
 			<div className="flex justify-between items-center mb-4">
@@ -149,6 +161,38 @@ export function ContentTabSettings( { selectedSite }: ContentTabSettingsProps ) 
 						>
 							{ `${ domain }/wp-admin` }
 						</CopyTextButton>
+					</SettingsRow>
+					<tr>
+						<th colSpan={ 2 } className="pb-4 ltr:text-left rtl:text-right">
+							<h3 className="text-black text-sm font-semibold mt-4">{ __( 'Database' ) }</h3>
+						</th>
+					</tr>
+					<SettingsRow>
+						<div className="ltr:pr-8 rtl:pl-8">
+							{ __(
+								'Your WordPress site is connected to a local SQLite database. To view and manage your database, create backups, restore from backups, and more, you can open the local database file in an external SQLite-compatible database tool.'
+							) }
+						</div>
+					</SettingsRow>
+					<SettingsRow label={ __( 'Local path' ) }>
+						<CopyTextButton
+							text={ pathToDatabase }
+							label={ __( 'Copy local path to clipboard' ) }
+							copyConfirmation={ __( 'Copied!' ) }
+						>
+							<span className="line-clamp-1 break-all">{ pathToDatabase }</span>
+						</CopyTextButton>
+					</SettingsRow>
+					<SettingsRow label={ __( 'File system' ) }>
+						<div className="flex items-center">
+							<Button
+								variant="link"
+								onClick={ () => getIpcApi().showItemInFolder( pathToDatabase ) }
+							>
+								{ __( 'Open' ) }
+							</Button>
+							<ArrowIcon />
+						</div>
 					</SettingsRow>
 				</tbody>
 			</table>

--- a/src/components/tests/content-tab-settings.test.tsx
+++ b/src/components/tests/content-tab-settings.test.tsx
@@ -300,7 +300,7 @@ describe( 'ContentTabSettings', () => {
 		it( 'opens the file system when the button is clicked', async () => {
 			const user = userEvent.setup();
 			renderWithProvider( <ContentTabSettings selectedSite={ selectedSite } /> );
-			const openButton = screen.getByRole( 'button', { name: 'Open in file system' } );
+			const openButton = screen.getByRole( 'button', { name: 'Open local database' } );
 			expect( openButton ).toBeVisible();
 			await user.click( openButton );
 			expect( showItemInFolder ).toHaveBeenCalled();

--- a/src/components/tests/content-tab-settings.test.tsx
+++ b/src/components/tests/content-tab-settings.test.tsx
@@ -3,6 +3,7 @@ import { fireEvent, render, screen, within } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import { Provider } from 'react-redux';
 import { ContentTabSettings } from 'src/components/content-tab-settings';
+import { LOCAL_SQLITE_DATABASE_PATH } from 'src/constants';
 import { useGetWpVersion } from 'src/hooks/use-get-wp-version';
 import { useOffline } from 'src/hooks/use-offline';
 import { useSiteDetails } from 'src/hooks/use-site-details';
@@ -43,6 +44,7 @@ describe( 'ContentTabSettings', () => {
 	const copyText = jest.fn();
 	const openLocalPath = jest.fn();
 	const generateProposedSitePath = jest.fn();
+	const showItemInFolder = jest.fn();
 	const getAllCustomDomains = jest.fn().mockResolvedValue( [] );
 
 	beforeEach( () => {
@@ -53,6 +55,7 @@ describe( 'ContentTabSettings', () => {
 			openLocalPath,
 			generateProposedSitePath,
 			getAllCustomDomains,
+			showItemInFolder,
 		} );
 
 		( useSnapshots as jest.Mock ).mockReturnValue( {
@@ -272,6 +275,35 @@ describe( 'ContentTabSettings', () => {
 				<ContentTabSettings selectedSite={ { ...selectedSite, phpVersion: '8.2' } } />
 			);
 			expect( screen.getByText( '8.2' ) ).toBeVisible();
+		} );
+	} );
+	describe( 'Database', () => {
+		it( 'copies the local database path to the clipboard', async () => {
+			const user = userEvent.setup();
+			const selectedSiteRunning: SiteDetails = {
+				...selectedSite,
+				path: '/path/to/site',
+			};
+			renderWithProvider( <ContentTabSettings selectedSite={ selectedSiteRunning } /> );
+
+			const databasePathButton = screen.getByRole( 'button', {
+				name: 'Copy local database path to clipboard',
+			} );
+			expect( databasePathButton ).toBeVisible();
+			await user.click( databasePathButton );
+			expect( copyText ).toHaveBeenCalledTimes( 1 );
+			expect( copyText ).toHaveBeenCalledWith(
+				`${ selectedSiteRunning.path }${ LOCAL_SQLITE_DATABASE_PATH }`
+			);
+		} );
+
+		it( 'opens the file system when the button is clicked', async () => {
+			const user = userEvent.setup();
+			renderWithProvider( <ContentTabSettings selectedSite={ selectedSite } /> );
+			const openButton = screen.getByRole( 'button', { name: 'Open in file system' } );
+			expect( openButton ).toBeVisible();
+			await user.click( openButton );
+			expect( showItemInFolder ).toHaveBeenCalled();
 		} );
 	} );
 } );

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -62,5 +62,6 @@ export const WP_CLI_IMPORT_EXPORT_RESPONSE_TIMEOUT =
 
 // SQLite
 export const SQLITE_DATABASE_INTEGRATION_VERSION = 'v2.1.19-alpha';
-export const LOCAL_SQLITE_DATABASE_PATH = '/wp-content/database/.ht.sqlite';
+export const LOCAL_SQLITE_DATABASE_FILENAME = '.ht.sqlite';
+export const LOCAL_SQLITE_DATABASE_PATH = `/wp-content/database/${ LOCAL_SQLITE_DATABASE_FILENAME }`;
 export const SQLITE_DATABASE_INTEGRATION_RELEASE_URL = `https://github.com/Automattic/sqlite-database-integration/archive/refs/tags/${ SQLITE_DATABASE_INTEGRATION_VERSION }.zip`;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -62,5 +62,5 @@ export const WP_CLI_IMPORT_EXPORT_RESPONSE_TIMEOUT =
 
 // SQLite
 export const SQLITE_DATABASE_INTEGRATION_VERSION = 'v2.1.19-alpha';
-
+export const LOCAL_SQLITE_DATABASE_PATH = '/wp-content/database/.ht.sqlite';
 export const SQLITE_DATABASE_INTEGRATION_RELEASE_URL = `https://github.com/Automattic/sqlite-database-integration/archive/refs/tags/${ SQLITE_DATABASE_INTEGRATION_VERSION }.zip`;


### PR DESCRIPTION
## Related issues

Temporary fix for https://github.com/Automattic/studio/issues/1033

## Proposed Changes

This PR adds a database section to the setting for users who wish to use a third-party application to manage the local SQLite database.

Such apps might include:

- https://sqlitebrowser.org/
- https://dbeaver.io/
- https://www.beekeeperstudio.io/

These apps are free. I've tested with all of them. Some are better than others. 

Changes:

- exposes the path to the local SQLite file in the settings tabs.
- adds a link to open the file in the local file system
- updates `<SettingsRow />` to conditionally render labels and adjust layout to accommodate new content
- adds basic tests

<img width="1079" alt="Screenshot 2025-03-31 at 3 49 22 pm" src="https://github.com/user-attachments/assets/bc904158-292c-4add-989a-c84efff99919" />

I've deliberately left out references to specific apps for fear of being accused of promotion. All the ones I tested will associate themselves with and open `*.db` and `*.sqlite` file.


> [!NOTE]
> This PR doesn't preclude bundling an browser-based app with Studio, only provides details for the sake of user choice.

## Testing Instructions

1. Fire up this branch
2. Open the settings tab in Studio
3. Ensure that the open in file system link works
4. Ensure that the copy link works

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
