### PR TITLE
Update SQLite database integration plugin to v2.1.17-alpha.1

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -61,6 +61,6 @@ export const WP_CLI_IMPORT_EXPORT_RESPONSE_TIMEOUT =
 	WP_CLI_IMPORT_EXPORT_RESPONSE_TIMEOUT_IN_HRS * 60 * 60 * 1000; // 6hr
 
 // SQLite
-export const SQLITE_DATABASE_INTEGRATION_VERSION = 'v2.1.19-alpha';
+export const SQLITE_DATABASE_INTEGRATION_VERSION = 'v2.1.17-alpha.1';
 
 export const SQLITE_DATABASE_INTEGRATION_RELEASE_URL = `https://github.com/Automattic/sqlite-database-integration/archive/refs/tags/${ SQLITE_DATABASE_INTEGRATION_VERSION }.zip`;

--- a/src/lib/sqlite-versions.ts
+++ b/src/lib/sqlite-versions.ts
@@ -37,8 +37,12 @@ export async function updateLatestSqliteVersion() {
  * @returns True if the SQLite integration is outdated.
  */
 export async function isSqliteInstallationOutdated( sitePath: string ): Promise< boolean > {
-	const serverFilesVersion = semver.coerce( SQLITE_DATABASE_INTEGRATION_VERSION );
-	const siteVersion = semver.coerce( await getSqliteVersionFromInstallation( sitePath ) );
+	const serverFilesVersion = semver.coerce( SQLITE_DATABASE_INTEGRATION_VERSION, {
+		includePrerelease: true,
+	} );
+	const siteVersion = semver.coerce( await getSqliteVersionFromInstallation( sitePath ), {
+		includePrerelease: true,
+	} );
 
 	if ( ! siteVersion ) {
 		return true;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Required to fix Jetpack backups in 1.3.9-beta2

## Proposed Changes

- Set SQLite database integration plugin to v2.1.17-alpha.1
- Allow `isSqliteInstallationOutdated` to compare prereleases 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Create a site with Production Studio or ensure that the site you are using has the v2.1.17-alpha version (or older) of the  SQLite database integration plugin
- Run `npm run postinstall`
- Ensure that your local version of the SQLite database integration plugin is v2.1.17-alpha.1
- Start Studio
- Confirm that your sites are now using SQLite database integration plugin v2.1.17-alpha.1
- Try importing a Jetpack backup and confirm it works

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
