### PR TITLE
Fix performance tests

### DIFF
--- a/.github/workflows/metrics-comparison.yml
+++ b/.github/workflows/metrics-comparison.yml
@@ -40,18 +40,18 @@ jobs:
       - name: Compare performance with base branch
         if: github.event_name == 'push'
         # The base hash used here need to be a commit that is compatible with the current performance tests.
-        # The current one is c27db920b93947786da17271b859e90c6d64eaac
+        # The current one is d1f49275f3e08fb675d5685855c2243b6cd183de
         # it needs to be updated every time it becomes unsupported by the current performance tests.
         # It is used as a base comparison point to avoid fluctuation in the performance metrics.
         run: |
-          cd scripts/compare-perf && npm ci && npm run compare -- perf $GITHUB_SHA c27db920b93947786da17271b859e90c6d64eaac --tests-branch $GITHUB_SHA
+          cd scripts/compare-perf && npm ci && npm run compare -- perf $GITHUB_SHA d1f49275f3e08fb675d5685855c2243b6cd183de --tests-branch $GITHUB_SHA
 
       # Log performance metrics to CodeVitals when running on trunk
       - name: Log performance metrics to CodeVitals
         if: github.event_name == 'push' && github.ref == 'refs/heads/trunk' && !cancelled()
         run: |
           COMMITTED_AT=$(git show -s $GITHUB_SHA --format="%cI")
-          npm ci && cd scripts/compare-perf && npm run log-to-codevitals -- $CODEVITALS_AUTH_TOKEN trunk $GITHUB_SHA c27db920b93947786da17271b859e90c6d64eaac $COMMITTED_AT
+          npm ci && cd scripts/compare-perf && npm run log-to-codevitals -- $CODEVITALS_AUTH_TOKEN trunk $GITHUB_SHA d1f49275f3e08fb675d5685855c2243b6cd183de $COMMITTED_AT
 
       - name: Archive performance results
         if: ${{ !cancelled() }}


### PR DESCRIPTION
Running the performance test on the old reference commit is broken now, because we removed the SQLite version that was used. This means we have to update the hash commit.