### PR TITLE
User Settings: Add explicit `Save` and `Cancel` buttons to Preferences tab

### DIFF
--- a/src/components/language-picker.tsx
+++ b/src/components/language-picker.tsx
@@ -1,17 +1,20 @@
 import { SelectControl } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
-import { useI18nData } from 'src/hooks/use-i18n-data';
 import { SupportedLocale, supportedLocaleNames } from 'src/lib/locale';
 
-export const LanguagePicker = () => {
+interface LanguagePickerProps {
+	value: SupportedLocale;
+	onChange: ( value: SupportedLocale ) => void;
+}
+
+export const LanguagePicker = ( { value, onChange }: LanguagePickerProps ) => {
 	const { __ } = useI18n();
-	const { locale, setLocale } = useI18nData();
 	return (
 		<div className="flex gap-5 flex-col">
 			<h2 className="a8c-subtitle-small">{ __( 'Language' ) }</h2>
 			<SelectControl
-				value={ locale || 'en' }
-				onChange={ ( value ) => setLocale( value as SupportedLocale ) }
+				value={ value || 'en' }
+				onChange={ onChange }
 				options={ Object.entries( supportedLocaleNames ).map( ( [ locale, label ] ) => ( {
 					value: locale as SupportedLocale,
 					label,

--- a/src/components/user-settings.tsx
+++ b/src/components/user-settings.tsx
@@ -344,8 +344,13 @@ export default function UserSettings() {
 					isDismissible
 					onRequestClose={ resetLocalState }
 					size="medium"
-					// `[&_[role='document']]:px-0` removes padding from modal content
-					className="min-h-[350px] [&_[role='document']]:px-0"
+					className={ cx(
+						'min-h-[350px]',
+						// Remove padding so that the Tabs are flush with the header
+						'[&_[role="document"]]:px-0',
+						// The modal header is 72px tall but we want to remove 8px from the top
+						'[&_[role="document"]]:mt-[64px]'
+					) }
 				>
 					<TabPanel className="w-full" tabs={ tabs } orientation="horizontal">
 						{ ( { name } ) => (

--- a/src/components/user-settings.tsx
+++ b/src/components/user-settings.tsx
@@ -20,7 +20,6 @@ import { usePromptUsage } from 'src/hooks/use-prompt-usage';
 import { useSnapshots } from 'src/hooks/use-snapshots';
 import { cx } from 'src/lib/cx';
 import { getIpcApi } from 'src/lib/get-ipc-api';
-import { SupportedLocale } from 'src/lib/locale';
 
 const UserInfo = ( {
 	user,
@@ -282,9 +281,11 @@ export default function UserSettings() {
 		const hasChanges = locale !== savedLocale;
 
 		return (
-			<div className="flex flex-col gap-6">
+			<>
 				<LanguagePicker value={ locale } onChange={ setLocale } />
-				<div className="flex justify-end gap-3 mt-4">
+
+				{ /* Add future preferences here */ }
+				<div className="mt-auto pt-6 flex justify-end gap-3">
 					<Button variant="tertiary" onClick={ cancelChanges } disabled={ ! hasChanges }>
 						{ __( 'Cancel' ) }
 					</Button>
@@ -292,7 +293,7 @@ export default function UserSettings() {
 						{ __( 'Save' ) }
 					</Button>
 				</div>
-			</div>
+			</>
 		);
 	};
 
@@ -346,20 +347,16 @@ export default function UserSettings() {
 					// `[&_[role='document']]:px-0` removes padding from modal content
 					className="min-h-[350px] [&_[role='document']]:px-0"
 				>
-					<div className="flex flex-col gap-6">
-						<TabPanel className="w-full" tabs={ tabs } orientation="horizontal">
-							{ ( { name } ) => (
-								<div className="mt-6 px-8">
-									<div className="flex flex-col gap-6">
-										{ name === 'account' &&
-											( isAuthenticated ? <AccountTab /> : <NonAuthenticatedAccountTab /> ) }
-										{ name === 'preferences' && <PreferencesTab /> }
-										{ name === 'usage' && isAuthenticated && <UsageTab /> }
-									</div>
-								</div>
-							) }
-						</TabPanel>
-					</div>
+					<TabPanel className="w-full" tabs={ tabs } orientation="horizontal">
+						{ ( { name } ) => (
+							<div className="mt-6 px-8 flex flex-col gap-6">
+								{ name === 'account' &&
+									( isAuthenticated ? <AccountTab /> : <NonAuthenticatedAccountTab /> ) }
+								{ name === 'preferences' && <PreferencesTab /> }
+								{ name === 'usage' && isAuthenticated && <UsageTab /> }
+							</div>
+						) }
+					</TabPanel>
 				</Modal>
 			) }
 		</>

--- a/src/components/user-settings.tsx
+++ b/src/components/user-settings.tsx
@@ -13,12 +13,14 @@ import { Tooltip } from 'src/components/tooltip';
 import { WordPressLogo } from 'src/components/wordpress-logo';
 import { WPCOM_PROFILE_URL } from 'src/constants';
 import { useAuth } from 'src/hooks/use-auth';
+import { useI18nData } from 'src/hooks/use-i18n-data';
 import { useIpcListener } from 'src/hooks/use-ipc-listener';
 import { useOffline } from 'src/hooks/use-offline';
 import { usePromptUsage } from 'src/hooks/use-prompt-usage';
 import { useSnapshots } from 'src/hooks/use-snapshots';
 import { cx } from 'src/lib/cx';
 import { getIpcApi } from 'src/lib/get-ipc-api';
+import { SupportedLocale } from 'src/lib/locale';
 
 const UserInfo = ( {
 	user,
@@ -260,7 +262,39 @@ export default function UserSettings() {
 
 	const AccountTab = () => <UserInfo onLogout={ logout } user={ user } />;
 
-	const PreferencesTab = () => <LanguagePicker />;
+	const PreferencesTab = () => {
+		const { __ } = useI18n();
+		const { locale: savedLocale, setLocale: setSavedLocale } = useI18nData();
+
+		const [ locale, setLocale ] = useState( savedLocale );
+
+		// Save all pending preferences
+		const savePreferences = () => {
+			// Apply each preference
+			setSavedLocale( locale );
+		};
+
+		// Reset pending changes
+		const cancelChanges = () => {
+			setLocale( savedLocale );
+		};
+
+		const hasChanges = locale !== savedLocale;
+
+		return (
+			<div className="flex flex-col gap-6">
+				<LanguagePicker value={ locale } onChange={ setLocale } />
+				<div className="flex justify-end gap-3 mt-4">
+					<Button variant="tertiary" onClick={ cancelChanges } disabled={ ! hasChanges }>
+						{ __( 'Cancel' ) }
+					</Button>
+					<Button variant="primary" onClick={ savePreferences } disabled={ ! hasChanges }>
+						{ __( 'Save' ) }
+					</Button>
+				</div>
+			</div>
+		);
+	};
 
 	const UsageTab = () => (
 		<>


### PR DESCRIPTION
## Related issues

This PR builds on top of https://github.com/Automattic/studio/pull/1075 (note the merge base).

- Related to https://github.com/Automattic/studio/issues/63

## Proposed Changes

- Add `Save` & `Cancel` buttons to `Preferences` tab in User Settings

<img width="501" alt="Screenshot 2025-04-02 at 16 00 20" src="https://github.com/user-attachments/assets/13b08332-15a6-4657-a6b4-1b36aca2c8ee" />

## Testing Instructions

- Open User Settings > `Preferences`
- Try to change the language to something else
- Ensure that the Cancel button works to reset the language 
- Try to change the language again
- Ensure that `Save` confirms changing the language

## Pre-merge Checklist


- [ ] Have you checked for TypeScript, React or other console errors?
