### PR TITLE
Update metrics readme to use correct codevitals link

### DIFF
--- a/metrics/README.md
+++ b/metrics/README.md
@@ -44,7 +44,7 @@ This tool is useful for:
 
 ## CodeVitals Integration
 
-Performance metrics from the `trunk` branch are automatically sent to [CodeVitals](https://codevitals.dev/) for tracking and visualization. This helps in tracking performance trends over time and detecting regressions.
+Performance metrics from the `trunk` branch are automatically sent to [CodeVitals](https://www.codevitals.run/project/studio/) for tracking and visualization. This helps in tracking performance trends over time and detecting regressions.
 
 The metrics are sent when:
 


### PR DESCRIPTION
Metric readme used an invalid codevitals link (ending with .dev instead of .run), this PR fixes that and links to studio dashboard directly.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
