### PR TITLE
Auto-start previously running sites on application launch

### DIFF
--- a/src/hooks/tests/use-site-details.test.tsx
+++ b/src/hooks/tests/use-site-details.test.tsx
@@ -1,0 +1,93 @@
+/**
+ * @jest-environment jsdom
+ */
+// To run tests, execute `npm run test -- src/hooks/tests/use-site-details.test.ts` from the root directory
+import { renderHook, waitFor } from '@testing-library/react';
+import { ReactNode } from 'react';
+import { SiteDetailsProvider, useSiteDetails } from 'src/hooks/use-site-details';
+import { getIpcApi } from 'src/lib/get-ipc-api';
+
+jest.mock( 'src/lib/get-ipc-api' );
+
+const mockSites = [
+	{
+		id: 'site-1',
+		name: 'Site 1',
+		path: '/path/to/site1',
+		port: 1234,
+		phpVersion: '8.0',
+		running: false,
+		autoStart: true,
+		themeDetails: undefined,
+	},
+	{
+		id: 'site-2',
+		name: 'Site 2',
+		path: '/path/to/site2',
+		port: 1235,
+		phpVersion: '8.0',
+		running: false,
+		autoStart: false,
+		themeDetails: undefined,
+	},
+	{
+		id: 'site-3',
+		name: 'Site 3',
+		path: '/path/to/site3',
+		port: 1236,
+		phpVersion: '8.0',
+		running: false,
+		autoStart: true,
+		themeDetails: undefined,
+	},
+];
+
+const wrapper = ( { children }: { children: ReactNode } ) => (
+	<SiteDetailsProvider>{ children }</SiteDetailsProvider>
+);
+
+describe( 'useSiteDetails', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		( getIpcApi as jest.Mock ).mockReturnValue( {
+			getSiteDetails: jest.fn().mockResolvedValue( mockSites ),
+			startServer: jest.fn().mockResolvedValue( undefined ),
+		} );
+	} );
+
+	describe( 'autoStart functionality', () => {
+		it( 'should auto-start sites with autoStart flag set to true', async () => {
+			const { result } = renderHook( () => useSiteDetails(), { wrapper } );
+
+			await waitFor( () => {
+				expect( result.current.loadingSites ).toBe( false );
+			} );
+
+			// Verify that startServer was called for the sites with autoStart: true
+			expect( getIpcApi().startServer ).toHaveBeenCalledWith( 'site-1' );
+			expect( getIpcApi().startServer ).not.toHaveBeenCalledWith( 'site-2' );
+			expect( getIpcApi().startServer ).toHaveBeenCalledWith( 'site-3' );
+		} );
+
+		it( 'should not auto-start sites if autoStart flag is false', async () => {
+			( getIpcApi as jest.Mock ).mockReturnValue( {
+				getSiteDetails: jest.fn().mockResolvedValue(
+					mockSites.map( ( site ) => ( {
+						...site,
+						autoStart: false,
+					} ) )
+				),
+				startServer: jest.fn().mockResolvedValue( undefined ),
+			} );
+
+			const { result } = renderHook( () => useSiteDetails(), { wrapper } );
+
+			await waitFor( () => {
+				expect( result.current.loadingSites ).toBe( false );
+			} );
+
+			// Verify that startServer was not called for any site
+			expect( getIpcApi().startServer ).not.toHaveBeenCalled();
+		} );
+	} );
+} );

--- a/src/hooks/use-site-details.tsx
+++ b/src/hooks/use-site-details.tsx
@@ -160,23 +160,6 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 		} ) );
 	}, [] );
 
-	useEffect( () => {
-		let cancel = false;
-		setLoadingSites( true );
-		getIpcApi()
-			.getSiteDetails()
-			.then( ( data ) => {
-				if ( ! cancel ) {
-					setData( data );
-					setLoadingSites( false );
-				}
-			} );
-
-		return () => {
-			cancel = true;
-		};
-	}, [] );
-
 	const onDeleteSite = useCallback(
 		async ( id: string, removeLocal: boolean ) => {
 			const newSites = await deleteSite( id, removeLocal );
@@ -337,6 +320,35 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 		},
 		[ toggleLoadingServerForSite ]
 	);
+
+	const autoStartSites = useCallback(
+		( sites: SiteDetails[] ) => {
+			for ( const site of sites ) {
+				if ( site.wasRunning ) {
+					startServer( site.id );
+				}
+			}
+		},
+		[ startServer ]
+	);
+
+	useEffect( () => {
+		let cancel = false;
+		setLoadingSites( true );
+		getIpcApi()
+			.getSiteDetails()
+			.then( async ( data ) => {
+				if ( ! cancel ) {
+					setData( data );
+					setLoadingSites( false );
+					autoStartSites( data );
+				}
+			} );
+
+		return () => {
+			cancel = true;
+		};
+	}, [ autoStartSites ] );
 
 	const stopServer = useCallback(
 		async ( id: string ) => {

--- a/src/hooks/use-site-details.tsx
+++ b/src/hooks/use-site-details.tsx
@@ -324,7 +324,7 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 	const autoStartSites = useCallback(
 		( sites: SiteDetails[] ) => {
 			for ( const site of sites ) {
-				if ( site.wasRunning ) {
+				if ( site.autoStart ) {
 					startServer( site.id );
 				}
 			}

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -445,6 +445,7 @@ export async function stopServer(
 	}
 
 	await server.stop();
+	await updateSite( event, server.details );
 	return server.details;
 }
 

--- a/src/ipc-types.d.ts
+++ b/src/ipc-types.d.ts
@@ -34,6 +34,7 @@ interface StoppedSiteDetails {
 		supportsMenus: boolean;
 	};
 	isAddingSite?: boolean;
+	wasRunning?: boolean;
 }
 
 interface StartedSiteDetails extends StoppedSiteDetails {
@@ -81,6 +82,15 @@ type IpcApi = {
 	 * for more details.
 	 */
 	getPathForFile: ( file: File ) => string;
+	getSiteDetails: () => Promise< SiteDetails[] >;
+	getUserData: () => Promise< PersistedUserData >;
+	createSite: (
+		path: string,
+		siteName?: string,
+		wpVersion?: string,
+		customDomain?: string,
+		enableHttps?: boolean
+	) => Promise< SiteDetails[] >;
 };
 
 interface AppGlobals {

--- a/src/ipc-types.d.ts
+++ b/src/ipc-types.d.ts
@@ -82,15 +82,6 @@ type IpcApi = {
 	 * for more details.
 	 */
 	getPathForFile: ( file: File ) => string;
-	getSiteDetails: () => Promise< SiteDetails[] >;
-	getUserData: () => Promise< PersistedUserData >;
-	createSite: (
-		path: string,
-		siteName?: string,
-		wpVersion?: string,
-		customDomain?: string,
-		enableHttps?: boolean
-	) => Promise< SiteDetails[] >;
 };
 
 interface AppGlobals {

--- a/src/ipc-types.d.ts
+++ b/src/ipc-types.d.ts
@@ -34,7 +34,7 @@ interface StoppedSiteDetails {
 		supportsMenus: boolean;
 	};
 	isAddingSite?: boolean;
-	wasRunning?: boolean;
+	autoStart?: boolean;
 }
 
 interface StartedSiteDetails extends StoppedSiteDetails {

--- a/src/site-server.ts
+++ b/src/site-server.ts
@@ -246,7 +246,7 @@ export class SiteServer {
 			return;
 		}
 
-		const { running, url, ...rest } = this.details;
+		const { running, autoStart, url, ...rest } = this.details;
 		this.details = { running: false, autoStart: false, ...rest };
 	}
 

--- a/src/site-server.ts
+++ b/src/site-server.ts
@@ -178,6 +178,7 @@ export class SiteServer {
 			port: this.server.options.port,
 			phpVersion: this.server.options.phpVersion ?? DEFAULT_PHP_VERSION,
 			running: true,
+			wasRunning: true,
 			themeDetails,
 		};
 	}
@@ -246,7 +247,7 @@ export class SiteServer {
 		}
 
 		const { running, url, ...rest } = this.details;
-		this.details = { running: false, ...rest };
+		this.details = { running: false, wasRunning: false, ...rest };
 	}
 
 	async updateCachedThumbnail() {

--- a/src/site-server.ts
+++ b/src/site-server.ts
@@ -178,7 +178,7 @@ export class SiteServer {
 			port: this.server.options.port,
 			phpVersion: this.server.options.phpVersion ?? DEFAULT_PHP_VERSION,
 			running: true,
-			wasRunning: true,
+			autoStart: true,
 			themeDetails,
 		};
 	}
@@ -247,7 +247,7 @@ export class SiteServer {
 		}
 
 		const { running, url, ...rest } = this.details;
-		this.details = { running: false, wasRunning: false, ...rest };
+		this.details = { running: false, autoStart: false, ...rest };
 	}
 
 	async updateCachedThumbnail() {

--- a/src/storage/user-data.ts
+++ b/src/storage/user-data.ts
@@ -169,7 +169,7 @@ function fromDiskFormat( { version, sites, ...rest }: PersistedUserData ): UserD
 			.map( ( { path, name, autoStart, ...restOfSite } ) => ( {
 				name: name || nodePath.basename( path ),
 				path,
-				running: false, // Sites start as not running, they will be auto-started if needed
+				running: false,
 				autoStart: autoStart || false,
 				...restOfSite,
 			} ) ),

--- a/src/storage/user-data.ts
+++ b/src/storage/user-data.ts
@@ -130,6 +130,7 @@ function toDiskFormat( { sites, ...rest }: UserData ): PersistedUserData {
 				themeDetails,
 				customDomain,
 				enableHttps,
+				wasRunning,
 			} ) => {
 				// No object spreading allowed. TypeScript's structural typing is too permissive and
 				// will permit us to persist properties that aren't in the type definition.
@@ -143,6 +144,7 @@ function toDiskFormat( { sites, ...rest }: UserData ): PersistedUserData {
 					phpVersion,
 					customDomain,
 					enableHttps,
+					wasRunning,
 					themeDetails: {
 						name: themeDetails?.name || '',
 						path: themeDetails?.path || '',
@@ -164,10 +166,11 @@ function fromDiskFormat( { version, sites, ...rest }: PersistedUserData ): UserD
 	return {
 		sites: sites
 			.filter( ( site ) => fs.existsSync( site.path ) ) // Remove sites the user has deleted from disk
-			.map( ( { path, name, ...restOfSite } ) => ( {
+			.map( ( { path, name, wasRunning, ...restOfSite } ) => ( {
 				name: name || nodePath.basename( path ),
 				path,
-				running: false,
+				running: false, // Sites start as not running, they will be auto-started if needed
+				wasRunning: wasRunning || false,
 				...restOfSite,
 			} ) ),
 		...rest,

--- a/src/storage/user-data.ts
+++ b/src/storage/user-data.ts
@@ -130,7 +130,7 @@ function toDiskFormat( { sites, ...rest }: UserData ): PersistedUserData {
 				themeDetails,
 				customDomain,
 				enableHttps,
-				wasRunning,
+				autoStart,
 			} ) => {
 				// No object spreading allowed. TypeScript's structural typing is too permissive and
 				// will permit us to persist properties that aren't in the type definition.
@@ -144,7 +144,7 @@ function toDiskFormat( { sites, ...rest }: UserData ): PersistedUserData {
 					phpVersion,
 					customDomain,
 					enableHttps,
-					wasRunning,
+					autoStart,
 					themeDetails: {
 						name: themeDetails?.name || '',
 						path: themeDetails?.path || '',
@@ -166,11 +166,11 @@ function fromDiskFormat( { version, sites, ...rest }: PersistedUserData ): UserD
 	return {
 		sites: sites
 			.filter( ( site ) => fs.existsSync( site.path ) ) // Remove sites the user has deleted from disk
-			.map( ( { path, name, wasRunning, ...restOfSite } ) => ( {
+			.map( ( { path, name, autoStart, ...restOfSite } ) => ( {
 				name: name || nodePath.basename( path ),
 				path,
 				running: false, // Sites start as not running, they will be auto-started if needed
-				wasRunning: wasRunning || false,
+				autoStart: autoStart || false,
 				...restOfSite,
 			} ) ),
 		...rest,


### PR DESCRIPTION
## Related issues

- Fixes STU-321

## Proposed Changes

- Added persistence of site running states across application restarts by saving `autoStart` site property into appData to track site were already running
- Implemented automatic startup of previously running sites when application launches
- Modified site server management to properly track and restore running states

## Testing Instructions

- Run `npm start`
- Create a new site and make sure it starts
- Close the application completely
- Reopen the application
- Verify the previously running site automatically starts up
- Create a second site and stop it
- Close and reopen the application
- Confirm only the first site auto-starts while the second remains stopped
- Stop the first site and restart the application
- Verify it remains stopped, demonstrating the state is properly tracked



https://github.com/user-attachments/assets/b94d931f-234a-4efe-98f0-be207bf7c024



## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?