### PR TITLE
Studio: Remove ability to dismiss the warning when pushing to a production site

### DIFF
--- a/src/components/sync-connected-sites.tsx
+++ b/src/components/sync-connected-sites.tsx
@@ -63,7 +63,6 @@ const SyncConnectedSiteControls = ( {
 		confirmButtonLabel: __( 'Push' ),
 	} );
 	const showPushProductionConfirmation = useConfirmationDialog( {
-		localStorageKey: 'dontShowPushConfirmation',
 		message: __( 'Overwrite Production site' ),
 		detail: __(
 			'Pushing will replace the existing files and database with a copy from your local site.\n\n The production site will be backed-up before any changes are applied.'


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

Closes STU-322

## Proposed Changes

This PR allows ensures that the user can not dismiss the warning to not show again when they are trying to push to a production site. It should be possible though to dismiss the warning when pushing to a staging site. 

| **Before** | **After** |
|---------|---------|
| <img src="https://github.com/user-attachments/assets/424097a2-8b01-49ca-8972-e5c8cc197f33" width="300"/> | <img src="https://github.com/user-attachments/assets/ee5a68c0-f96b-4d76-9bea-81b90b345e4d" width="300"/> |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

_You might also need to clear your local storage in the Application tab in the Chrome dev tools if you previously dismissed this warning to test the changes on this branch._

* Pull the changes from this branch
* Start the app with `npm start`
* Navigate to the `Sync` tab 
* Ensure that you have a WP.com site connected that has both production and staging sites
* Click on `Push` by a production site
* Observe that the warning about your site being overwritten can not be dismissed
* Click on `Push` by a staging site
* Observe that you can dismiss the warning to not show again

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
