### PR TITLE
Studio: Ensure that buttons in the footer are the same size

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -289,8 +289,13 @@ blockquote {
 	left: 0;
 	right: 0;
 	background: white;
-  }
-  
-  .components-button.components-guide__finish-button {
-	  height: 40px;
-  }
+}
+
+.components-button.components-guide__finish-button {
+	height: 40px;
+}
+
+.components-button.components-guide__back-button {
+	outline: none;
+	border: 1px solid theme( 'colors.a8c-blueberry' );
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

Closes STU-325

## Proposed Changes

This PR ensures that the `Previous` and `Next` / `Done` buttons have the same height in the `What's new` modal. 

Previously, the buttons did use the same height but the `Previous` button had an outline added to it which added 2 extra pixels (1 to the top and 1 to the bottom) and made it look slightly bigger. I propose to remove the outline and use border instead to make sure it is included in the box model and is not added on the top of the button. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
* Start the app with `STUDIO_WHATS_NEW_SECTION=true npm start`
* Click on `Help > What's New` in the top bar
* Once the modal is open, navigate to the second page
* Confirm that `Previous` and `Next` buttons look visually the same

Sidenote: I tried with Tailwind but it was not going anywhere so I decided to use CSS directly. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
