### PR TITLE
What's New Section: Add tests for app version API and version comparison functionality

### DIFF
--- a/src/stores/tests/app-version-api.test.ts
+++ b/src/stores/tests/app-version-api.test.ts
@@ -1,6 +1,6 @@
 import { configureStore } from '@reduxjs/toolkit';
 import { getIpcApi } from 'src/lib/get-ipc-api';
-import { appVersionApi, selectIsNewVersion } from '../app-version-api';
+import { appVersionApi, selectIsNewVersion } from 'src/stores/app-version-api';
 
 jest.mock( 'src/lib/get-ipc-api', () => ( {
 	getIpcApi: jest.fn(),

--- a/src/stores/tests/app-version-api.test.ts
+++ b/src/stores/tests/app-version-api.test.ts
@@ -1,0 +1,136 @@
+import { configureStore } from '@reduxjs/toolkit';
+import { getIpcApi } from 'src/lib/get-ipc-api';
+import { appVersionApi, selectIsNewVersion } from '../app-version-api';
+
+jest.mock( 'src/lib/get-ipc-api', () => ( {
+	getIpcApi: jest.fn(),
+} ) );
+
+const mockIpcApi = {
+	getLastSeenVersion: jest.fn(),
+	saveLastSeenVersion: jest.fn(),
+};
+
+( getIpcApi as jest.Mock ).mockReturnValue( mockIpcApi );
+
+const createTestStore = () => {
+	return configureStore( {
+		reducer: {
+			[ appVersionApi.reducerPath ]: appVersionApi.reducer,
+		},
+		middleware: ( getDefaultMiddleware ) =>
+			getDefaultMiddleware().concat( appVersionApi.middleware ),
+	} );
+};
+
+describe( 'App Version API', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	describe( 'getLastSeenVersion', () => {
+		it( 'should fetch the last seen version', async () => {
+			mockIpcApi.getLastSeenVersion.mockResolvedValueOnce( '1.2.0' );
+
+			const store = createTestStore();
+			const result = await store.dispatch(
+				appVersionApi.endpoints.getLastSeenVersion.initiate( undefined )
+			);
+
+			expect( mockIpcApi.getLastSeenVersion ).toHaveBeenCalledTimes( 1 );
+
+			expect( result.data ).toBe( '1.2.0' );
+		} );
+	} );
+
+	describe( 'saveLastSeenVersion', () => {
+		it( 'should save the last seen version', async () => {
+			mockIpcApi.saveLastSeenVersion.mockResolvedValueOnce( undefined );
+
+			const versionToSave = '1.3.0';
+			const store = createTestStore();
+			const result = await store.dispatch(
+				appVersionApi.endpoints.saveLastSeenVersion.initiate( versionToSave )
+			);
+
+			expect( mockIpcApi.saveLastSeenVersion ).toHaveBeenCalledTimes( 1 );
+			expect( mockIpcApi.saveLastSeenVersion ).toHaveBeenCalledWith( versionToSave );
+
+			expect( result.data ).toBe( versionToSave );
+		} );
+	} );
+
+	describe( 'selectIsNewVersion', () => {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const createMockQueryResult = ( data: string | undefined ): any => ( {
+			data,
+			isLoading: false,
+			isSuccess: true,
+			isError: false,
+			error: undefined,
+		} );
+
+		it( 'should return true for a new major version', () => {
+			const lastSeenVersion = '1.2.0';
+			const currentVersion = '2.0.0';
+
+			const result = selectIsNewVersion( createMockQueryResult( lastSeenVersion ), currentVersion );
+
+			expect( result ).toBe( true );
+		} );
+
+		it( 'should return true for a new minor version', () => {
+			const lastSeenVersion = '1.2.0';
+			const currentVersion = '1.3.0';
+
+			const result = selectIsNewVersion( createMockQueryResult( lastSeenVersion ), currentVersion );
+
+			expect( result ).toBe( true );
+		} );
+
+		it( 'should return false for the same version', () => {
+			const lastSeenVersion = '1.2.0';
+			const currentVersion = '1.2.0';
+
+			const result = selectIsNewVersion( createMockQueryResult( lastSeenVersion ), currentVersion );
+
+			expect( result ).toBe( false );
+		} );
+
+		it( 'should return false for a new patch version', () => {
+			const lastSeenVersion = '1.2.0';
+			const currentVersion = '1.2.1';
+
+			const result = selectIsNewVersion( createMockQueryResult( lastSeenVersion ), currentVersion );
+
+			expect( result ).toBe( false );
+		} );
+
+		it( 'should return false for prerelease versions', () => {
+			const lastSeenVersion = '1.2.0';
+			const currentVersion = '1.3.0-beta1';
+
+			const result = selectIsNewVersion( createMockQueryResult( lastSeenVersion ), currentVersion );
+
+			expect( result ).toBe( false );
+		} );
+
+		it( 'should return true for undefined lastSeenVersion', () => {
+			const lastSeenVersion = undefined;
+			const currentVersion = '1.2.0';
+
+			const result = selectIsNewVersion( createMockQueryResult( lastSeenVersion ), currentVersion );
+
+			expect( result ).toBe( true );
+		} );
+
+		it( 'should return false for invalid version formats', () => {
+			const lastSeenVersion = 'invalid';
+			const currentVersion = 'also-invalid';
+
+			const result = selectIsNewVersion( createMockQueryResult( lastSeenVersion ), currentVersion );
+
+			expect( result ).toBe( false );
+		} );
+	} );
+} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Resolves STU-334-linear-issue

## Proposed Changes

- add tests for app version API and version comparison functionality

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Please review the proposed tests.
2. Newly-introduced tests should pass (`npm test src/stores/tests/app-version-api.test.ts`).
3. All tests should pass (`npm run test`).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?