### PR TITLE
What's New Section: Fix modal display logic

### DIFF
--- a/src/stores/app-version-api.ts
+++ b/src/stores/app-version-api.ts
@@ -52,9 +52,10 @@ export const selectIsNewVersion = createSelector(
 	( lastSeenVersion, currentVersion ) => {
 		const forceNewVersion = false;
 
-		if ( forceNewVersion && currentVersion !== lastSeenVersion ) {
-			return true;
+		if ( currentVersion === lastSeenVersion ) {
+			return false;
 		}
+
 		if ( ! currentVersion || ! lastSeenVersion ) {
 			return !! currentVersion && lastSeenVersion !== currentVersion;
 		}
@@ -79,7 +80,9 @@ export const selectIsNewVersion = createSelector(
 			}
 
 			return (
-				lastSeenParts.major !== currentParts.major || lastSeenParts.minor !== currentParts.minor
+				lastSeenParts.major !== currentParts.major ||
+				lastSeenParts.minor !== currentParts.minor ||
+				forceNewVersion
 			);
 		} catch ( error ) {
 			console.error( 'Error comparing versions:', error );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

While working on https://github.com/Automattic/studio/pull/1178 I observed a smaller issue with our modal opening logic. If `forceNewVersion` was `true` it ignored other checks (e.g. prerelease beta version check).

## Proposed Changes

- ensure `forceNewVersion` overrides the `selectIsNewVersion` output after all other conditions are evaluated

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the branch PR and build the app with `npm start`.
2. The modal should work as expected.
3. All tests should pass (`npm test src/stores/tests/app-version-api.test.ts` and `npm run test`).
4. Change the `forceNewVersion` to `true` in `src/stores/app-version-api.ts`.
5. Run `npm test src/stores/tests/app-version-api.test.ts`  again. One test should fail - `should return false for a new patch version`.
6. Additionally, we could also consider the going through the testing instructions in https://github.com/Automattic/studio/pull/1133.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
