### PR TITLE
Load translations for CLI

### DIFF
--- a/cli/commands/preview/create.ts
+++ b/cli/commands/preview/create.ts
@@ -1,6 +1,6 @@
 import os from 'os';
 import path from 'path';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { uploadArchive, waitForSiteReady } from 'cli/lib/api';
 import { getAuthToken } from 'cli/lib/appdata';
 import { createArchive, cleanup } from 'cli/lib/archive';
@@ -25,26 +25,28 @@ async function runCommand( siteFolder: string, outputFormat?: OutputFormat ): Pr
 	const logger = new Logger< LoggerAction >( outputFormat );
 
 	try {
-		logger.reportStart( LoggerAction.VALIDATE, 'Validating...' );
+		logger.reportStart( LoggerAction.VALIDATE, __( 'Validating...' ) );
 		validateSiteFolder( siteFolder );
 		const token = await getAuthToken();
-		logger.reportSuccess( 'Validation successful' );
+		logger.reportSuccess( __( 'Validation successful' ) );
 
-		logger.reportStart( LoggerAction.ARCHIVE, 'Creating archive...' );
+		logger.reportStart( LoggerAction.ARCHIVE, __( 'Creating archive...' ) );
 		await createArchive( siteFolder, archivePath );
-		logger.reportSuccess( 'Archive created' );
+		logger.reportSuccess( __( 'Archive created' ) );
 
-		logger.reportStart( LoggerAction.UPLOAD, 'Uploading archive...' );
+		logger.reportStart( LoggerAction.UPLOAD, __( 'Uploading archive...' ) );
 		const uploadResponse = await uploadArchive( archivePath, token.accessToken );
-		logger.reportSuccess( 'Archive uploaded' );
+		logger.reportSuccess( __( 'Archive uploaded' ) );
 
-		logger.reportStart( LoggerAction.READY, 'Creating preview site...' );
+		logger.reportStart( LoggerAction.READY, __( 'Creating preview site...' ) );
 		await waitForSiteReady( uploadResponse.site_id, token.accessToken );
-		logger.reportSuccess( `Preview site available at: https://${ uploadResponse.site_url }` );
+		logger.reportSuccess(
+			sprintf( __( 'Preview site available at: %s' ), `https://${ uploadResponse.site_url }` )
+		);
 
-		logger.reportStart( LoggerAction.APPDATA, 'Saving preview site to Studio...' );
+		logger.reportStart( LoggerAction.APPDATA, __( 'Saving preview site to Studio...' ) );
 		await addPreviewSiteToAppdata( uploadResponse.site_url, uploadResponse.site_id, siteFolder );
-		logger.reportSuccess( 'Preview site saved to Studio' );
+		logger.reportSuccess( __( 'Preview site saved to Studio' ) );
 	} catch ( error ) {
 		if ( error instanceof LoggerError ) {
 			logger.reportError( error );
@@ -61,7 +63,7 @@ export const registerCommand: RegisterCommand = ( program ) => {
 	program
 		.command( 'go [folder]' )
 		.description(
-			'Create a preview site from the specified folder (defaults to current directory)'
+			__( 'Create a preview site from the specified folder (defaults to current directory)' )
 		)
 		.action( async ( siteFolder: string = process.cwd() ) => {
 			const options = program.opts();

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -1,3 +1,4 @@
+import { __ } from '@wordpress/i18n';
 import { Command, Option } from 'commander';
 import { registerCommand as registerPreviewCreateCommand } from 'cli/commands/preview/create';
 import { registerCommand as registerPreviewDeleteCommand } from 'cli/commands/preview/delete';
@@ -9,20 +10,20 @@ const program = new Command();
 
 program
 	.name( 'studio' )
-	.description( 'Studio by WordPress.com CLI' )
+	.description( __( 'Studio by WordPress.com CLI' ) )
 	.version( version )
 	.addOption(
-		new Option( '--output-format [format]', 'Specify a non-standard output format' )
+		new Option( '--output-format [format]', __( 'Specify a non-standard output format' ) )
 			.argParser( ( value: string ) => {
 				if ( value !== 'json' ) {
-					throw new Error( 'The only custom output format supported is "json"' );
+					throw new Error( __( 'The only custom output format supported is "json"' ) );
 				}
 				return value;
 			} )
 			.hideHelp()
 	);
 
-const previewCommand = program.command( 'preview' ).description( 'Manage preview sites' );
+const previewCommand = program.command( 'preview' ).description( __( 'Manage preview sites' ) );
 
 registerPreviewCreateCommand( program );
 registerPreviewListCommand( previewCommand );

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -4,30 +4,37 @@ import { registerCommand as registerPreviewCreateCommand } from 'cli/commands/pr
 import { registerCommand as registerPreviewDeleteCommand } from 'cli/commands/preview/delete';
 import { registerCommand as registerPreviewListCommand } from 'cli/commands/preview/list';
 import { registerCommand as registerPreviewUpdateCommand } from 'cli/commands/preview/update';
+import { loadTranslations } from 'cli/lib/i18n';
 import { version } from 'cli/package.json';
 
-const program = new Command();
+async function main() {
+	await loadTranslations();
 
-program
-	.name( 'studio' )
-	.description( __( 'Studio by WordPress.com CLI' ) )
-	.version( version )
-	.addOption(
-		new Option( '--output-format [format]', __( 'Specify a non-standard output format' ) )
-			.argParser( ( value: string ) => {
-				if ( value !== 'json' ) {
-					throw new Error( __( 'The only custom output format supported is "json"' ) );
-				}
-				return value;
-			} )
-			.hideHelp()
-	);
+	const program = new Command();
 
-const previewCommand = program.command( 'preview' ).description( __( 'Manage preview sites' ) );
+	program
+		.name( 'studio' )
+		.description( __( 'Studio by WordPress.com CLI' ) )
+		.version( version )
+		.addOption(
+			new Option( '--output-format [format]', __( 'Specify a non-standard output format' ) )
+				.argParser( ( value: string ) => {
+					if ( value !== 'json' ) {
+						throw new Error( __( 'The only custom output format supported is "json"' ) );
+					}
+					return value;
+				} )
+				.hideHelp()
+		);
 
-registerPreviewCreateCommand( program );
-registerPreviewListCommand( previewCommand );
-registerPreviewDeleteCommand( previewCommand );
-registerPreviewUpdateCommand( previewCommand );
+	const previewCommand = program.command( 'preview' ).description( __( 'Manage preview sites' ) );
 
-program.parse( process.argv );
+	registerPreviewCreateCommand( program );
+	registerPreviewListCommand( previewCommand );
+	registerPreviewDeleteCommand( previewCommand );
+	registerPreviewUpdateCommand( previewCommand );
+
+	program.parse( process.argv );
+}
+
+main();

--- a/cli/lib/api.ts
+++ b/cli/lib/api.ts
@@ -11,13 +11,13 @@ export enum SnapshotStatus {
 }
 
 const createSiteResponseSchema = z.object( {
-	domain_name: z.string().min( 1, 'Domain name is required' ),
-	atomic_site_id: z.coerce.number().int().positive( 'Site ID must be a positive integer' ),
+	domain_name: z.string().min( 1, __( 'Domain name is required' ) ),
+	atomic_site_id: z.coerce.number().int().positive( __( 'Site ID must be a positive integer' ) ),
 } );
 
 const statusResponseSchema = z.object( {
 	status: z.enum( [ SnapshotStatus.Pending, SnapshotStatus.Processing, SnapshotStatus.Active ], {
-		errorMap: () => ( { message: 'Invalid site status' } ),
+		errorMap: () => ( { message: __( 'Invalid site status' ) } ),
 	} ),
 	domain_name: z.string(),
 	atomic_site_id: z.number().int().positive(),
@@ -108,7 +108,7 @@ export async function waitForSiteReady( siteId: number, token: string ): Promise
 	}
 
 	throw new LoggerError(
-		'Failed to create preview site: site did not become ready within timeout'
+		__( 'Failed to create preview site: site did not become ready within timeout' )
 	);
 }
 

--- a/cli/lib/appdata.ts
+++ b/cli/lib/appdata.ts
@@ -26,6 +26,7 @@ const userDataSchema = z
 	.object( {
 		snapshots: z.array( snapshotSchema ).optional(),
 		sites: z.array( siteSchema ).optional(),
+		locale: z.string().optional(),
 		authToken: z
 			.object( {
 				accessToken: z.string().min( 1, __( 'Access token cannot be empty' ) ),

--- a/cli/lib/appdata.ts
+++ b/cli/lib/appdata.ts
@@ -28,7 +28,7 @@ const userDataSchema = z
 		sites: z.array( siteSchema ).optional(),
 		authToken: z
 			.object( {
-				accessToken: z.string().min( 1, 'Access token cannot be empty' ),
+				accessToken: z.string().min( 1, __( 'Access token cannot be empty' ) ),
 				id: z.number(),
 			} )
 			.passthrough()

--- a/cli/lib/i18n.ts
+++ b/cli/lib/i18n.ts
@@ -1,0 +1,33 @@
+import { defaultI18n } from '@wordpress/i18n';
+import { SupportedLocale, getLocaleData, DEFAULT_LOCALE, isSupportedLocale } from 'src/lib/locale';
+import { readAppdata } from 'cli/lib/appdata';
+
+async function getLocaleFromAppdata(): Promise< SupportedLocale | undefined > {
+	try {
+		const appdata = await readAppdata();
+		return isSupportedLocale( appdata.locale ) ? appdata.locale : undefined;
+	} catch ( error ) {
+		console.error( 'Error reading appdata', error );
+		return undefined;
+	}
+}
+
+function getLocaleFromEnvironment(): SupportedLocale | undefined {
+	const envLocale =
+		process.env.LANG || process.env.LANGUAGE || process.env.LC_ALL || process.env.LC_MESSAGES || '';
+	const locale = envLocale.split( /[._]/ )[ 0 ].toLowerCase();
+	return isSupportedLocale( locale ) ? locale : undefined;
+}
+
+export async function loadTranslations() {
+	const appdataLocale = await getLocaleFromAppdata();
+	const envLocale = getLocaleFromEnvironment();
+	const locale = appdataLocale || envLocale || DEFAULT_LOCALE;
+	const translations = getLocaleData( locale )?.messages;
+
+	if ( translations ) {
+		defaultI18n.setLocaleData( translations );
+	} else {
+		defaultI18n.resetLocaleData();
+	}
+}

--- a/cli/lib/output.ts
+++ b/cli/lib/output.ts
@@ -1,3 +1,4 @@
+import { __ } from '@wordpress/i18n';
 // eslint-disable-next-line import/no-named-as-default
 import Table from 'cli-table3';
 import {
@@ -46,7 +47,7 @@ function formatDurationUntilExpiry( lastUpdatedAt: number ) {
 
 export function getSnapshotCliTable( snapshots: Snapshot[] ) {
 	const table = new Table( {
-		head: [ 'URL', 'Site Name', 'Updated', 'Expires in' ],
+		head: [ __( 'URL' ), __( 'Site Name' ), __( 'Updated' ), __( 'Expires in' ) ],
 		style: {
 			head: [],
 			border: [],

--- a/cli/lib/output.ts
+++ b/cli/lib/output.ts
@@ -30,7 +30,7 @@ function formatDurationUntilExpiry( lastUpdatedAt: number ) {
 	}
 
 	if ( endDate < now ) {
-		return 'Expired';
+		return __( 'Expired' );
 	}
 
 	return formatDuration(

--- a/src/lib/locale.ts
+++ b/src/lib/locale.ts
@@ -37,6 +37,9 @@ export function getLocaleData( locale: string ) {
 	return null;
 }
 
-export function isSupportedLocale( locale: string ): locale is SupportedLocale {
+export function isSupportedLocale( locale: string | undefined ): locale is SupportedLocale {
+	if ( ! locale ) {
+		return false;
+	}
 	return supportedLocales.includes( locale as SupportedLocale );
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-335

## Proposed Changes

- Added `__()` wrappers around all relevant remaining strings
- Added a `loadTranslations` function called on startup that loads translations based on the preference from Studio or based on environment configuration.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Open Studio and change the language preference to something other than English (ideally something you can read)
2. Open the corresponding JSON file in `src/translations`
3. Add the following message at the end: `"Studio by WordPress.com CLI":["YOUR TRANSLATION"]`
4. Run `npm run cli:watch`
5. Run `node dist/cli/main.js`
6. Ensure that the second row of the help text is translated according to what you added to the JSON file

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
