### PR TITLE
Studio: Remove unncessary CSS

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -291,10 +291,6 @@ blockquote {
 	background: white;
 }
 
-.components-button.components-guide__finish-button {
-	height: 40px;
-}
-
 .components-button.components-guide__back-button {
 	outline: none;
 	border: 1px solid theme( 'colors.a8c-blueberry' );


### PR DESCRIPTION
## Proposed Changes

Since we upgraded wordpress/components dependency in https://github.com/Automattic/studio/pull/1195 , this fix is no longer needed and the `Done` button should be set to 40px height automatically. 

## Testing Instructions

* Pull the changes from this branch
* Start the app with `npm start`
* Click on `Help > What's new` button
* Navigate to the last page of the `Guide` component
* Confirm that the `Done` button is set to 40px (feel free to compare to the look on trunk as it should remain the same)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
