### PR TITLE
User Settings:  Close settings modal on save or cancel button click

### DIFF
--- a/src/components/user-settings.tsx
+++ b/src/components/user-settings.tsx
@@ -267,15 +267,21 @@ export default function UserSettings() {
 
 		const [ locale, setLocale ] = useState( savedLocale );
 
+		const closeTheModal = () => {
+			setNeedsToOpenUserSettings( false );
+		};
+
 		// Save all pending preferences
 		const savePreferences = () => {
 			// Apply each preference
 			setSavedLocale( locale );
+			closeTheModal();
 		};
 
 		// Reset pending changes
 		const cancelChanges = () => {
 			setLocale( savedLocale );
+			closeTheModal();
 		};
 
 		const hasChanges = locale !== savedLocale;
@@ -285,8 +291,8 @@ export default function UserSettings() {
 				<LanguagePicker value={ locale } onChange={ setLocale } />
 
 				{ /* Add future preferences here */ }
-				<div className="mt-auto pt-6 pb-2 flex justify-end gap-3">
-					<Button variant="tertiary" onClick={ cancelChanges } disabled={ ! hasChanges }>
+				<div className="mt-auto pt-6 flex justify-end gap-3">
+					<Button variant="tertiary" onClick={ cancelChanges }>
 						{ __( 'Cancel' ) }
 					</Button>
 					<Button variant="primary" onClick={ savePreferences } disabled={ ! hasChanges }>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

Fixes https://github.com/Automattic/studio/issues/63
Fixes [STU-317](https://linear.app/a8c/issue/STU-317/user-settings-add-separate-tabs-for-account-preferences-and-usage)

Related to: https://github.com/Automattic/studio/pull/1075#issuecomment-2803796455

## Proposed Changes

- Close settings modal on save or cancel button click
- Always allow cancel button to be clickable to close the modal.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Navigate to the User Settings.
- Verify that the 'Cancel' button is clickable in the Preferences tab and confirms that the modal closes.
- Ensure that the 'Save' button is disabled initially.
- Select a different language from the dropdown menu.
- The 'Save' button should now be clickable. Upon clicking, the modal should close. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
