### PR TITLE
Studio: Add STUDIO_PREFERRED_EDITOR feature flag

### DIFF
--- a/src/hooks/use-feature-flags.tsx
+++ b/src/hooks/use-feature-flags.tsx
@@ -9,15 +9,18 @@ import { getAppGlobals } from 'src/lib/app-globals';
 const featureFlagsSchema = z
 	.object( {
 		terminal_wp_cli_enabled: z.boolean().optional(),
+		preferred_editor: z.boolean().optional(),
 	} )
 	.catch( ( _ ) => ( {} ) );
 
 export interface FeatureFlagsContextType {
 	terminalWpCliEnabled: boolean;
+	preferredEditor: boolean;
 }
 
 export const FeatureFlagsContext = createContext< FeatureFlagsContextType >( {
 	terminalWpCliEnabled: false,
+	preferredEditor: false,
 } );
 
 interface FeatureFlagsProviderProps {
@@ -26,8 +29,10 @@ interface FeatureFlagsProviderProps {
 
 export const FeatureFlagsProvider: React.FC< FeatureFlagsProviderProps > = ( { children } ) => {
 	const terminalWpCliEnabledFromGlobals = getAppGlobals().terminalWpCliEnabled;
+	const preferredEditorFromGlobals = getAppGlobals().preferredEditor;
 	const [ featureFlags, setFeatureFlags ] = useState< FeatureFlagsContextType >( {
 		terminalWpCliEnabled: terminalWpCliEnabledFromGlobals,
+		preferredEditor: preferredEditorFromGlobals,
 	} );
 	const { isAuthenticated, client } = useAuth();
 
@@ -49,6 +54,7 @@ export const FeatureFlagsProvider: React.FC< FeatureFlagsProviderProps > = ( { c
 				setFeatureFlags( {
 					terminalWpCliEnabled:
 						Boolean( flags.terminal_wp_cli_enabled ) || terminalWpCliEnabledFromGlobals,
+					preferredEditor: Boolean( flags.preferred_editor ) || preferredEditorFromGlobals,
 				} );
 			} catch ( error ) {
 				Sentry.captureException( error );
@@ -59,7 +65,7 @@ export const FeatureFlagsProvider: React.FC< FeatureFlagsProviderProps > = ( { c
 		return () => {
 			cancel = true;
 		};
-	}, [ isAuthenticated, client, terminalWpCliEnabledFromGlobals ] );
+	}, [ isAuthenticated, client, terminalWpCliEnabledFromGlobals, preferredEditorFromGlobals ] );
 
 	return (
 		<FeatureFlagsContext.Provider value={ featureFlags }>{ children }</FeatureFlagsContext.Provider>

--- a/src/hooks/use-feature-flags.tsx
+++ b/src/hooks/use-feature-flags.tsx
@@ -34,7 +34,6 @@ export const FeatureFlagsProvider: React.FC< FeatureFlagsProviderProps > = ( { c
 	const terminalWpCliEnabledFromGlobals = getAppGlobals().terminalWpCliEnabled;
 	const preferredEditorFromGlobals = getAppGlobals().preferredEditor;
 	const pressableSyncEnabledFromGlobals = getAppGlobals().pressableSyncEnabled;
-
 	const [ featureFlags, setFeatureFlags ] = useState< FeatureFlagsContextType >( {
 		terminalWpCliEnabled: terminalWpCliEnabledFromGlobals,
 		preferredEditor: preferredEditorFromGlobals,

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -785,6 +785,7 @@ export async function getAppGlobals( _event: IpcMainInvokeEvent ): Promise< AppG
 		appVersion: app.getVersion(),
 		arm64Translation: app.runningUnderARM64Translation,
 		terminalWpCliEnabled: process.env.STUDIO_TERMINAL_WP_CLI === 'true',
+		preferredEditor: process.env.STUDIO_PREFERRED_EDITOR === 'true',
 	};
 }
 

--- a/src/ipc-types.d.ts
+++ b/src/ipc-types.d.ts
@@ -90,6 +90,7 @@ interface AppGlobals {
 	appVersion: string;
 	arm64Translation: boolean;
 	terminalWpCliEnabled: boolean;
+	preferredEditor: boolean;
 }
 
 // Our IPC objects will be attached to the `window` global


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

STU-356

## Proposed Changes

This PR adds `STUDIO_PREFERRED_EDITOR` feature flag so that the work related to the Preferred Studio code and terminal applications can be shipped behind it.

## Testing Instructions

* Run STUDIO_PREFERRED_EDITOR=true npm start
* Add a console log in:

```diff --git a/src/hooks/use-feature-flags.tsx b/src/hooks/use-feature-flags.tsx
index 7bdd3ddd..7023d81a 100644
--- a/src/hooks/use-feature-flags.tsx
+++ b/src/hooks/use-feature-flags.tsx
@@ -67,7 +67,7 @@ export const FeatureFlagsProvider: React.FC< FeatureFlagsProviderProps > = ( { c
 			cancel = true;
 		};
 	}, [ isAuthenticated, client, terminalWpCliEnabledFromGlobals, wpVersionsEnabledFromGlobals ] );
-
+	console.log( 'featureFlags', featureFlags );
 	return (
 		<FeatureFlagsContext.Provider value={ featureFlags }>{ children }</FeatureFlagsContext.Provider>
 	);
```

* Open the Chrome dev tools
* Observe that the feature flag `preferredEditor` is set to `true`


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
