### PR TITLE
Add a feature flag for Pressable sync feature

### DIFF
--- a/src/hooks/use-feature-flags.tsx
+++ b/src/hooks/use-feature-flags.tsx
@@ -9,15 +9,18 @@ import { getAppGlobals } from 'src/lib/app-globals';
 const featureFlagsSchema = z
 	.object( {
 		terminal_wp_cli_enabled: z.boolean().optional(),
+		pressable_sync_enabled: z.boolean().optional(),
 	} )
 	.catch( ( _ ) => ( {} ) );
 
 export interface FeatureFlagsContextType {
 	terminalWpCliEnabled: boolean;
+	pressableSyncEnabled: boolean;
 }
 
 export const FeatureFlagsContext = createContext< FeatureFlagsContextType >( {
 	terminalWpCliEnabled: false,
+	pressableSyncEnabled: false,
 } );
 
 interface FeatureFlagsProviderProps {
@@ -26,8 +29,10 @@ interface FeatureFlagsProviderProps {
 
 export const FeatureFlagsProvider: React.FC< FeatureFlagsProviderProps > = ( { children } ) => {
 	const terminalWpCliEnabledFromGlobals = getAppGlobals().terminalWpCliEnabled;
+	const pressableSyncEnabledFromGlobals = getAppGlobals().pressableSyncEnabled;
 	const [ featureFlags, setFeatureFlags ] = useState< FeatureFlagsContextType >( {
 		terminalWpCliEnabled: terminalWpCliEnabledFromGlobals,
+		pressableSyncEnabled: pressableSyncEnabledFromGlobals,
 	} );
 	const { isAuthenticated, client } = useAuth();
 
@@ -49,6 +54,8 @@ export const FeatureFlagsProvider: React.FC< FeatureFlagsProviderProps > = ( { c
 				setFeatureFlags( {
 					terminalWpCliEnabled:
 						Boolean( flags.terminal_wp_cli_enabled ) || terminalWpCliEnabledFromGlobals,
+					pressableSyncEnabled:
+						Boolean( flags.pressable_sync_enabled ) || pressableSyncEnabledFromGlobals,
 				} );
 			} catch ( error ) {
 				Sentry.captureException( error );
@@ -59,7 +66,12 @@ export const FeatureFlagsProvider: React.FC< FeatureFlagsProviderProps > = ( { c
 		return () => {
 			cancel = true;
 		};
-	}, [ isAuthenticated, client, terminalWpCliEnabledFromGlobals ] );
+	}, [
+		isAuthenticated,
+		client,
+		terminalWpCliEnabledFromGlobals,
+		pressableSyncEnabledFromGlobals,
+	] );
 
 	return (
 		<FeatureFlagsContext.Provider value={ featureFlags }>{ children }</FeatureFlagsContext.Provider>

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -784,6 +784,7 @@ export async function getAppGlobals( _event: IpcMainInvokeEvent ): Promise< AppG
 		appName: app.name,
 		appVersion: app.getVersion(),
 		arm64Translation: app.runningUnderARM64Translation,
+		pressableSyncEnabled: process.env.STUDIO_PRESSABLE_SYNC === 'true',
 		terminalWpCliEnabled: process.env.STUDIO_TERMINAL_WP_CLI === 'true',
 	};
 }

--- a/src/ipc-types.d.ts
+++ b/src/ipc-types.d.ts
@@ -89,6 +89,7 @@ interface AppGlobals {
 	appName: string;
 	appVersion: string;
 	arm64Translation: boolean;
+	pressableSyncEnabled: boolean;
 	terminalWpCliEnabled: boolean;
 }
 


### PR DESCRIPTION
## Related issues

- Fixes STU-358

## Proposed Changes
- Added a new feature flag `pressableSyncEnabled` for the Pressable sync feature

## Testing Instructions
- Apply this diff:
```
diff --git a/src/components/content-tab-overview.tsx b/src/components/content-tab-overview.tsx
index 8bcdcd62..be9a8a27 100644
--- a/src/components/content-tab-overview.tsx
+++ b/src/components/content-tab-overview.tsx
@@ -137,7 +137,8 @@ function CustomizeSection( {
 }
 
 function ShortcutsSection( { selectedSite }: Pick< ContentTabOverviewProps, 'selectedSite' > ) {
-	const { terminalWpCliEnabled } = useFeatureFlags();
+	const { terminalWpCliEnabled, pressableSyncEnabled } = useFeatureFlags();
+	console.log( 'pressableSyncEnabled', pressableSyncEnabled );
 	const installedApps = useCheckInstalledApps();
 	const buttonsArray: ButtonsSectionProps[ 'buttonsArray' ] = [
 		{

```
- Run `STUDIO_PRESSABLE_SYNC=true npm start`
- Open the chrome dev tools
- Verify that the feature flag is correctly loaded and displayed in the console
- Test with both with and without the feature flag to ensure the flag works as expected

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?