### PR TITLE
Pressable Sync: Mark Pressable sites as syncable

### DIFF
--- a/src/hooks/use-fetch-wpcom-sites/index.tsx
+++ b/src/hooks/use-fetch-wpcom-sites/index.tsx
@@ -65,12 +65,7 @@ function hasSupportedPlan( site: SitesEndpointSite ): boolean {
 }
 
 function isJetpackSite( site: SitesEndpointSite ): boolean {
-	return (
-		!! site.jetpack &&
-		! isAtomicSite( site ) &&
-		! isPressableSite( site ) &&
-		! hasSupportedPlan( site )
-	);
+	return !! site.jetpack && ! isAtomicSite( site ) && ! isPressableSite( site );
 }
 
 function needsTransfer( site: SitesEndpointSite ): boolean {

--- a/src/hooks/use-fetch-wpcom-sites/index.tsx
+++ b/src/hooks/use-fetch-wpcom-sites/index.tsx
@@ -52,35 +52,49 @@ export const sitesEndpointResponseSchema = z.object( {
 
 const STUDIO_SYNC_FEATURE_NAME = 'studio-sync';
 
-function isJetpackSite( site: SitesEndpointSite ): boolean {
-	return !! site.jetpack && ! site.is_wpcom_atomic;
+function isPressableSite( site: SitesEndpointSite ): boolean {
+	return site.hosting_provider_guess === 'pressable';
+}
+
+function isAtomicSite( site: SitesEndpointSite ): boolean {
+	return site.is_wpcom_atomic;
 }
 
 function hasSupportedPlan( site: SitesEndpointSite ): boolean {
-	return site.plan?.features.active.includes( STUDIO_SYNC_FEATURE_NAME ) ?? false;
+	return (
+		( isPressableSite( site ) ||
+			site.plan?.features.active.includes( STUDIO_SYNC_FEATURE_NAME ) ) ??
+		false
+	);
 }
 
-function getSyncSupport(
-	site: SitesEndpointSite,
-	connectedSiteIds: number[],
-	pressableSyncEnabled: boolean
-): SyncSupport {
+function isJetpackSite( site: SitesEndpointSite ): boolean {
+	return (
+		!! site.jetpack &&
+		! isAtomicSite( site ) &&
+		! isPressableSite( site ) &&
+		! hasSupportedPlan( site )
+	);
+}
+
+function needsTransfer( site: SitesEndpointSite ): boolean {
+	return ! isJetpackSite( site ) && ! isPressableSite( site ) && ! isAtomicSite( site );
+}
+
+function getSyncSupport( site: SitesEndpointSite, connectedSiteIds: number[] ): SyncSupport {
 	if ( site.is_deleted ) {
 		return 'deleted';
 	}
 	if ( ! site.capabilities?.manage_options ) {
 		return 'missing-permissions';
 	}
-	if ( pressableSyncEnabled && site.hosting_provider_guess === 'pressable' ) {
-		return 'syncable';
-	}
-	if ( isJetpackSite( site ) && ! hasSupportedPlan( site ) ) {
+	if ( isJetpackSite( site ) ) {
 		return 'jetpack-site';
 	}
 	if ( ! hasSupportedPlan( site ) ) {
 		return 'unsupported';
 	}
-	if ( ! site.is_wpcom_atomic ) {
+	if ( needsTransfer( site ) ) {
 		return 'needs-transfer';
 	}
 	if ( connectedSiteIds.some( ( id ) => id === site.ID ) ) {
@@ -107,11 +121,7 @@ export function transformSingleSiteResponse(
 	};
 }
 
-export function transformSitesResponse(
-	sites: unknown[],
-	connectedSiteIds: number[],
-	pressableSyncEnabled: boolean
-): SyncSite[] {
+export function transformSitesResponse( sites: unknown[], connectedSiteIds: number[] ): SyncSite[] {
 	const validatedSites = sites.reduce< SitesEndpointSite[] >( ( acc, rawSite ) => {
 		try {
 			const site = sitesEndpointSiteSchema.parse( rawSite );
@@ -132,7 +142,7 @@ export function transformSitesResponse(
 			// The API returns the wrong value for the `is_wpcom_staging_site` prop while staging sites
 			// are being created. Hence the check in other sites' `wpcom_staging_blog_ids` arrays.
 			const isStaging = allStagingSiteIds.includes( site.ID );
-			const syncSupport = getSyncSupport( site, connectedSiteIds, pressableSyncEnabled );
+			const syncSupport = getSyncSupport( site, connectedSiteIds );
 
 			return transformSingleSiteResponse( site, syncSupport, isStaging );
 		} );
@@ -168,14 +178,16 @@ export const useFetchWpComSites = ( connectedSiteIdsOnlyForSelectedSite: number[
 		try {
 			const allConnectedSites = await getIpcApi().getConnectedWpcomSites();
 
+			const baseFields = 'name,ID,URL,plan,capabilities,is_wpcom_atomic,options,jetpack,is_deleted';
+			const fields = pressableSyncEnabled ? `${ baseFields },hosting_provider_guess` : baseFields;
+
 			const response = await client.req.get(
 				{
 					apiNamespace: 'rest/v1.2',
 					path: `/me/sites`,
 				},
 				{
-					fields:
-						'name,ID,URL,plan,capabilities,is_wpcom_atomic,options,jetpack,is_deleted,hosting_provider_guess',
+					fields,
 					filter: 'atomic,wpcom',
 					options: 'created_at,wpcom_staging_blog_ids',
 					site_activity: 'active',
@@ -185,8 +197,7 @@ export const useFetchWpComSites = ( connectedSiteIdsOnlyForSelectedSite: number[
 			const parsedResponse = sitesEndpointResponseSchema.parse( response );
 			const syncSites = transformSitesResponse(
 				parsedResponse.sites,
-				allConnectedSites.map( ( { id } ) => id ),
-				pressableSyncEnabled
+				allConnectedSites.map( ( { id } ) => id )
 			);
 
 			// whenever array of syncSites changes, we need to update connectedSites to keep them updated with wordpress.com
@@ -230,8 +241,8 @@ export const useFetchWpComSites = ( connectedSiteIdsOnlyForSelectedSite: number[
 	}, [ fetchSites ] );
 
 	const syncSitesWithSyncSupportForSelectedSite = useMemo(
-		() => transformSitesResponse( rawSyncSites, memoizedConnectedSiteIds, pressableSyncEnabled ),
-		[ rawSyncSites, memoizedConnectedSiteIds, pressableSyncEnabled ]
+		() => transformSitesResponse( rawSyncSites, memoizedConnectedSiteIds ),
+		[ rawSyncSites, memoizedConnectedSiteIds ]
 	);
 
 	return {

--- a/src/hooks/use-fetch-wpcom-sites/index.tsx
+++ b/src/hooks/use-fetch-wpcom-sites/index.tsx
@@ -61,11 +61,7 @@ function isAtomicSite( site: SitesEndpointSite ): boolean {
 }
 
 function hasSupportedPlan( site: SitesEndpointSite ): boolean {
-	return (
-		( isPressableSite( site ) ||
-			site.plan?.features.active.includes( STUDIO_SYNC_FEATURE_NAME ) ) ??
-		false
-	);
+	return site.plan?.features.active.includes( STUDIO_SYNC_FEATURE_NAME ) ?? false;
 }
 
 function isJetpackSite( site: SitesEndpointSite ): boolean {
@@ -91,7 +87,7 @@ function getSyncSupport( site: SitesEndpointSite, connectedSiteIds: number[] ): 
 	if ( isJetpackSite( site ) ) {
 		return 'jetpack-site';
 	}
-	if ( ! hasSupportedPlan( site ) ) {
+	if ( ! hasSupportedPlan( site ) && ! isPressableSite( site ) ) {
 		return 'unsupported';
 	}
 	if ( needsTransfer( site ) ) {

--- a/src/hooks/use-fetch-wpcom-sites/index.tsx
+++ b/src/hooks/use-fetch-wpcom-sites/index.tsx
@@ -164,7 +164,8 @@ export const useFetchWpComSites = ( connectedSiteIdsOnlyForSelectedSite: number[
 					path: `/me/sites`,
 				},
 				{
-					fields: 'name,ID,URL,plan,capabilities,is_wpcom_atomic,options,jetpack,is_deleted',
+					fields:
+						'name,ID,URL,plan,capabilities,is_wpcom_atomic,options,jetpack,is_deleted,hosting_provider_guess',
 					filter: 'atomic,wpcom',
 					options: 'created_at,wpcom_staging_blog_ids',
 					site_activity: 'active',

--- a/src/hooks/use-fetch-wpcom-sites/index.tsx
+++ b/src/hooks/use-fetch-wpcom-sites/index.tsx
@@ -14,6 +14,7 @@ export const sitesEndpointSiteSchema = z.object( {
 	URL: z.string(),
 	jetpack: z.boolean().optional(),
 	is_deleted: z.boolean(),
+	hosting_provider_guess: z.string().optional(),
 	options: z
 		.object( {
 			created_at: z.string(),
@@ -64,6 +65,9 @@ function getSyncSupport( site: SitesEndpointSite, connectedSiteIds: number[] ): 
 	}
 	if ( ! site.capabilities?.manage_options ) {
 		return 'missing-permissions';
+	}
+	if ( site.hosting_provider_guess === 'pressable' ) {
+		return 'syncable';
 	}
 	if ( isJetpackSite( site ) && ! hasSupportedPlan( site ) ) {
 		return 'jetpack-site';

--- a/src/hooks/use-fetch-wpcom-sites/index.tsx
+++ b/src/hooks/use-fetch-wpcom-sites/index.tsx
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/electron/renderer';
 import { useState, useEffect, useRef, useMemo, useCallback } from 'react';
 import { z } from 'zod';
 import { useAuth } from 'src/hooks/use-auth';
+import { useFeatureFlags } from 'src/hooks/use-feature-flags';
 import { reconcileConnectedSites } from 'src/hooks/use-fetch-wpcom-sites/reconcile-connected-sites';
 import { useOffline } from 'src/hooks/use-offline';
 import { getIpcApi } from 'src/lib/get-ipc-api';
@@ -59,14 +60,18 @@ function hasSupportedPlan( site: SitesEndpointSite ): boolean {
 	return site.plan?.features.active.includes( STUDIO_SYNC_FEATURE_NAME ) ?? false;
 }
 
-function getSyncSupport( site: SitesEndpointSite, connectedSiteIds: number[] ): SyncSupport {
+function getSyncSupport(
+	site: SitesEndpointSite,
+	connectedSiteIds: number[],
+	pressableSyncEnabled: boolean
+): SyncSupport {
 	if ( site.is_deleted ) {
 		return 'deleted';
 	}
 	if ( ! site.capabilities?.manage_options ) {
 		return 'missing-permissions';
 	}
-	if ( site.hosting_provider_guess === 'pressable' ) {
+	if ( pressableSyncEnabled && site.hosting_provider_guess === 'pressable' ) {
 		return 'syncable';
 	}
 	if ( isJetpackSite( site ) && ! hasSupportedPlan( site ) ) {
@@ -102,7 +107,11 @@ export function transformSingleSiteResponse(
 	};
 }
 
-export function transformSitesResponse( sites: unknown[], connectedSiteIds: number[] ): SyncSite[] {
+export function transformSitesResponse(
+	sites: unknown[],
+	connectedSiteIds: number[],
+	pressableSyncEnabled: boolean
+): SyncSite[] {
 	const validatedSites = sites.reduce< SitesEndpointSite[] >( ( acc, rawSite ) => {
 		try {
 			const site = sitesEndpointSiteSchema.parse( rawSite );
@@ -123,7 +132,7 @@ export function transformSitesResponse( sites: unknown[], connectedSiteIds: numb
 			// The API returns the wrong value for the `is_wpcom_staging_site` prop while staging sites
 			// are being created. Hence the check in other sites' `wpcom_staging_blog_ids` arrays.
 			const isStaging = allStagingSiteIds.includes( site.ID );
-			const syncSupport = getSyncSupport( site, connectedSiteIds );
+			const syncSupport = getSyncSupport( site, connectedSiteIds, pressableSyncEnabled );
 
 			return transformSingleSiteResponse( site, syncSupport, isStaging );
 		} );
@@ -136,6 +145,7 @@ export const useFetchWpComSites = ( connectedSiteIdsOnlyForSelectedSite: number[
 	const { isAuthenticated, client } = useAuth();
 	const isFetchingSites = useRef( false );
 	const isOffline = useOffline();
+	const { pressableSyncEnabled } = useFeatureFlags();
 
 	const joinedConnectedSiteIds = connectedSiteIdsOnlyForSelectedSite.join( ',' );
 	// we need this trick to avoid unnecessary re-renders,
@@ -175,7 +185,8 @@ export const useFetchWpComSites = ( connectedSiteIdsOnlyForSelectedSite: number[
 			const parsedResponse = sitesEndpointResponseSchema.parse( response );
 			const syncSites = transformSitesResponse(
 				parsedResponse.sites,
-				allConnectedSites.map( ( { id } ) => id )
+				allConnectedSites.map( ( { id } ) => id ),
+				pressableSyncEnabled
 			);
 
 			// whenever array of syncSites changes, we need to update connectedSites to keep them updated with wordpress.com
@@ -212,15 +223,15 @@ export const useFetchWpComSites = ( connectedSiteIdsOnlyForSelectedSite: number[
 		} finally {
 			isFetchingSites.current = false;
 		}
-	}, [ client?.req, isAuthenticated, isOffline ] );
+	}, [ client?.req, isAuthenticated, isOffline, pressableSyncEnabled ] );
 
 	useEffect( () => {
 		fetchSites();
 	}, [ fetchSites ] );
 
 	const syncSitesWithSyncSupportForSelectedSite = useMemo(
-		() => transformSitesResponse( rawSyncSites, memoizedConnectedSiteIds ),
-		[ rawSyncSites, memoizedConnectedSiteIds ]
+		() => transformSitesResponse( rawSyncSites, memoizedConnectedSiteIds, pressableSyncEnabled ),
+		[ rawSyncSites, memoizedConnectedSiteIds, pressableSyncEnabled ]
 	);
 
 	return {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Resolves STU-343-linear-issue

## Proposed Changes

- get `hosting_provider_guess` value from the `me/sites/` endpoint (behind the `pressableSyncEnabled` feature flag)
- mark all Pressable sites as `syncable`
- refactor logic that marks site as syncable

| Before | After |
|--------|--------|
| ![Markup on 2025-04-16 at 17:47:30](https://github.com/user-attachments/assets/1f83691a-556e-4e51-906c-a1b6fd92eadc) | ![Markup on 2025-04-16 at 17:46:16](https://github.com/user-attachments/assets/ca874662-dd87-4542-a783-d4f6caab0ea7) | 

> [!NOTE]
> The presence of the `Production` badge is a matter of discussion: STU-320-linear-issue#comment-de01edcd. Regardless, we can tackle it in a separate PR.

> [!NOTE]
> Once this PR is merged, I am planning to follow up with https://github.com/Automattic/studio/pull/1229 where I would like to clean up site sync states. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create a couple of test Pressable sites on https://pressable.com and connect them to your WordPress.com account which you are using in Studio as well.
2. Check out the PR branch and build the app with `STUDIO_PRESSABLE_SYNC=true npm start`.
3. Head over to the Sync tab on any local Studio site and click on the `Connect site` button.
4. Search for your Pressable sites. It should be possible to connect any of them to your local Studio site.
5. If you build the app with `npm start` only, it shouldn't be possible to connect those same Pressable sites. Everything else should work normally.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?