### PR TITLE
Check for prerelease versions when copying the bundled SQLite plugin

### DIFF
--- a/src/setup-wp-server-files.ts
+++ b/src/setup-wp-server-files.ts
@@ -51,7 +51,10 @@ async function copyBundledLatestWPVersion() {
 async function copyBundledSqlite() {
 	const bundledSqlitePath = path.join( getResourcesPath(), 'wp-files', SQLITE_FILENAME );
 	const bundledSqliteVersion = semver.coerce(
-		await getSqliteVersionFromInstallation( bundledSqlitePath )
+		await getSqliteVersionFromInstallation( bundledSqlitePath ),
+		{
+			includePrerelease: true,
+		}
 	);
 	if ( ! bundledSqliteVersion ) {
 		return;
@@ -59,7 +62,10 @@ async function copyBundledSqlite() {
 	const installedSqlitePath = getSqlitePath();
 	const isSqliteInstalled = await fs.pathExists( installedSqlitePath );
 	const installedSqliteVersion = semver.coerce(
-		await getSqliteVersionFromInstallation( installedSqlitePath )
+		await getSqliteVersionFromInstallation( installedSqlitePath ),
+		{
+			includePrerelease: true,
+		}
 	);
 	const isBundledVersionNewer =
 		installedSqliteVersion && semver.gt( bundledSqliteVersion, installedSqliteVersion );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Proposed Changes

- Check for prerelease versions when copying the bundled SQLite plugin

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run `npm run postinstall` to ensure your local `wp-files` have the latest version of the SQLite plugin `2.1.17-alpha.1`
- Open `/Users/bero/Library/Application Support/Studio/server-files/sqlite-database-integration/load.php`
- Change the SQLite plugin version to `2.1.17-alpha`
- Start Studio
- Confirm that the version of the SQLite plugin in `/Users/bero/Library/Application Support/Studio/server-files/sqlite-database-integration/load.php` is now `2.1.17-alpha.1`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
