### PR TITLE
User Settings: Add Shell selector dropdown to the Preferences tab

### DIFF
--- a/src/components/terminal-picker.tsx
+++ b/src/components/terminal-picker.tsx
@@ -1,0 +1,57 @@
+import { SelectControl } from '@wordpress/components';
+import { useI18n } from '@wordpress/react-i18n';
+import { useEffect, useState } from 'react';
+import { SupportedTerminal, supportedTerminalNames } from 'src/lib/terminal';
+
+interface TerminalPickerProps {
+	value: SupportedTerminal;
+	onChange: ( value: SupportedTerminal ) => void;
+}
+
+export const TerminalPicker = ( { value, onChange }: TerminalPickerProps ) => {
+	const { __ } = useI18n();
+	const [ installedTerminals, setInstalledTerminals ] = useState< {
+		iterm: boolean | null;
+		terminal: boolean | null;
+	} >( {
+		iterm: null,
+		terminal: null,
+	} );
+
+	useEffect( () => {
+		const fetchInstalledTerminals = async () => {
+			try {
+				const terminals = { iterm: true, terminal: true }; // TODO:: Fetch installed terminals from the API
+				setInstalledTerminals( terminals );
+			} catch ( error ) {
+				console.error( 'Failed to fetch installed terminals:', error );
+			}
+		};
+
+		fetchInstalledTerminals();
+	}, [] );
+
+	const options = Object.entries( supportedTerminalNames ).map( ( [ terminal, label ] ) => {
+		const terminalKey = terminal as SupportedTerminal;
+		const isInstalled = installedTerminals[ terminalKey as keyof typeof installedTerminals ];
+
+		return {
+			value: terminalKey,
+			label,
+			disabled: ! isInstalled,
+		};
+	} );
+
+	return (
+		<div className="flex gap-5 flex-col">
+			<h2 className="a8c-subtitle-small">{ __( 'Shell' ) }</h2>
+			<SelectControl
+				value={ value }
+				onChange={ onChange }
+				options={ options }
+				__nextHasNoMarginBottom
+				className="mb-2"
+			/>
+		</div>
+	);
+};

--- a/src/components/tests/terminal-picker.tsx
+++ b/src/components/tests/terminal-picker.tsx
@@ -1,0 +1,26 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { TerminalPicker } from 'src/components/terminal-picker';
+
+describe( 'TerminalPicker', () => {
+	const mockOnChange = jest.fn();
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'renders correctly with initial props', () => {
+		render( <TerminalPicker value="terminal" onChange={ mockOnChange } /> );
+
+		expect( screen.getByText( 'Shell' ) ).toBeVisible();
+		expect( screen.getByRole( 'combobox' ) ).toBeVisible();
+	} );
+
+	it( 'calls onChange when selecting a different terminal', async () => {
+		render( <TerminalPicker value="terminal" onChange={ mockOnChange } /> );
+
+		const select = screen.getByRole( 'combobox' );
+		fireEvent.change( select, { target: { value: 'iterm' } } );
+
+		expect( mockOnChange ).toHaveBeenCalledWith( 'iterm', expect.anything() );
+	} );
+} );

--- a/src/components/tests/user-settings.test.tsx
+++ b/src/components/tests/user-settings.test.tsx
@@ -87,6 +87,7 @@ describe( 'UserSettings', () => {
 			fireEvent.click( screen.getByText( 'Preferences' ) );
 			expect( screen.getByText( 'Preferences' ) ).toHaveAttribute( 'aria-selected', 'true' );
 			expect( screen.getByText( 'Language' ) ).toBeVisible();
+			expect( screen.getByText( 'Shell' ) ).toBeVisible();
 
 			// Switch to Usage tab
 			fireEvent.click( screen.getByText( 'Usage' ) );

--- a/src/components/user-settings.tsx
+++ b/src/components/user-settings.tsx
@@ -22,8 +22,10 @@ import { useIpcListener } from 'src/hooks/use-ipc-listener';
 import { useOffline } from 'src/hooks/use-offline';
 import { usePromptUsage } from 'src/hooks/use-prompt-usage';
 import { useSnapshots } from 'src/hooks/use-snapshots';
+import { useTerminalData } from 'src/hooks/use-terminal-data';
 import { cx } from 'src/lib/cx';
 import { getIpcApi } from 'src/lib/get-ipc-api';
+import { TerminalPicker } from './terminal-picker';
 
 const UserInfo = ( {
 	user,
@@ -227,24 +229,35 @@ const PreferencesTab = ( { onClose }: { onClose: () => void } ) => {
 	const { editor, handleEditorChange, saveEditorPreference, resetEditor, hasEditorChanges } =
 		useEditorData();
 
+	const {
+		terminal,
+		handleTerminalChange,
+		saveTerminalPreference,
+		resetTerminal,
+		hasTerminalChanges,
+	} = useTerminalData();
+
 	const savePreferences = async () => {
 		setSavedLocale( locale );
 		await saveEditorPreference();
+		await saveTerminalPreference();
 		onClose();
 	};
 
 	const cancelChanges = () => {
 		setLocale( savedLocale );
 		resetEditor();
+		resetTerminal();
 		onClose();
 	};
 
-	const hasChanges = locale !== savedLocale || hasEditorChanges;
+	const hasChanges = locale !== savedLocale || hasEditorChanges || hasTerminalChanges;
 
 	return (
 		<>
 			<LanguagePicker value={ locale } onChange={ setLocale } />
 			<EditorPicker value={ editor } onChange={ handleEditorChange } />
+			<TerminalPicker value={ terminal } onChange={ handleTerminalChange } />
 			<div className="mt-auto pt-6 flex justify-end gap-3">
 				<Button variant="tertiary" onClick={ cancelChanges }>
 					{ __( 'Cancel' ) }

--- a/src/hooks/use-terminal-data.ts
+++ b/src/hooks/use-terminal-data.ts
@@ -1,0 +1,50 @@
+import { useState, useEffect } from 'react';
+import { SupportedTerminal, DEFAULT_TERMINAL } from 'src/lib/terminal';
+
+/**
+ * Hook to manage terminal preferences
+ */
+export function useTerminalData() {
+	const [ terminal, setTerminal ] = useState< SupportedTerminal >( DEFAULT_TERMINAL );
+	const [ savedTerminalValue, setSavedTerminalValue ] =
+		useState< SupportedTerminal >( DEFAULT_TERMINAL );
+
+	const getSavedTerminal = async () => {
+		// TODO::Get the actual terminal from the IPC API
+		return DEFAULT_TERMINAL;
+	};
+
+	// Load the saved terminal value
+	useEffect( () => {
+		const loadSavedTerminal = async () => {
+			const terminal = await getSavedTerminal();
+			setSavedTerminalValue( terminal );
+			setTerminal( terminal );
+		};
+		loadSavedTerminal();
+	}, [] );
+
+	const handleTerminalChange = ( newTerminal: SupportedTerminal ) => {
+		setTerminal( newTerminal );
+	};
+
+	const saveTerminalPreference = async () => {
+		//TODO:: Save the terminal preference to the IPC API
+		alert( terminal );
+	};
+
+	const resetTerminal = () => {
+		setTerminal( savedTerminalValue );
+	};
+
+	const hasTerminalChanges = terminal !== savedTerminalValue;
+
+	return {
+		terminal,
+		savedTerminalValue,
+		handleTerminalChange,
+		saveTerminalPreference,
+		resetTerminal,
+		hasTerminalChanges,
+	};
+}

--- a/src/lib/terminal.ts
+++ b/src/lib/terminal.ts
@@ -1,0 +1,8 @@
+export type SupportedTerminal = 'terminal' | 'iterm';
+
+export const supportedTerminalNames: Record< SupportedTerminal, string > = {
+	terminal: 'Terminal',
+	iterm: 'iTerm',
+};
+
+export const DEFAULT_TERMINAL: SupportedTerminal = 'terminal';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-360

## Proposed Changes

- Add terminal shell selector dropdown on preferences tab
- This PR does not handle:
     - Saving preference is app data.
     - Looking for actually installed terminals
     - Disable dropdown when none of the supported terminal is found.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Check out this branch
- Run `STUDIO_PREFERRED_EDITOR=true npm start`
- Open settings
- Goto Preference Tab
- Make sure the terminal dropdown is visible
- Change the value and notice that the `Save` button is enabled. 
- You will be alerted with saved value when clicked on `Save`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
