### PR TITLE
Update existing snapshots appdata entry when preview site is updated

### DIFF
--- a/cli/commands/preview/create.ts
+++ b/cli/commands/preview/create.ts
@@ -4,7 +4,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { uploadArchive, waitForSiteReady } from 'cli/lib/api';
 import { getAuthToken } from 'cli/lib/appdata';
 import { createArchive, cleanup } from 'cli/lib/archive';
-import { addPreviewSiteToAppdata } from 'cli/lib/snapshots';
+import { upsertPreviewSiteInAppdata } from 'cli/lib/snapshots';
 import { validateSiteFolder } from 'cli/lib/validation';
 import { Logger, LoggerError } from 'cli/logger';
 import { RegisterCommand, OutputFormat } from 'cli/types';
@@ -45,7 +45,7 @@ async function runCommand( siteFolder: string, outputFormat?: OutputFormat ): Pr
 		);
 
 		logger.reportStart( LoggerAction.APPDATA, __( 'Saving preview site to Studio...' ) );
-		await addPreviewSiteToAppdata( uploadResponse.site_url, uploadResponse.site_id, siteFolder );
+		await upsertPreviewSiteInAppdata( siteFolder, uploadResponse.site_id, uploadResponse.site_url );
 		logger.reportSuccess( __( 'Preview site saved to Studio' ) );
 	} catch ( error ) {
 		if ( error instanceof LoggerError ) {

--- a/cli/commands/preview/tests/create.test.ts
+++ b/cli/commands/preview/tests/create.test.ts
@@ -4,7 +4,7 @@ import { Command } from 'commander';
 import { uploadArchive, waitForSiteReady } from 'cli/lib/api';
 import { getAuthToken } from 'cli/lib/appdata';
 import { createArchive, cleanup } from 'cli/lib/archive';
-import { addPreviewSiteToAppdata } from 'cli/lib/snapshots';
+import { upsertPreviewSiteInAppdata } from 'cli/lib/snapshots';
 import { validateSiteFolder } from 'cli/lib/validation';
 import { Logger, LoggerError } from 'cli/logger';
 
@@ -21,7 +21,7 @@ describe( 'Preview Create Command', () => {
 	const mockDate = 1234567890;
 	const mockArchivePath = path.join( os.tmpdir(), `${ mockBasename }-${ mockDate }.zip` );
 	const mockSiteUrl = 'test-preview.example.com';
-	const mockSiteId = 12345;
+	const mockAtomicSiteId = 12345;
 	const mockAuthToken = { accessToken: 'mock-auth-token', id: 123 };
 	const mockArchiver = {
 		on: jest.fn(),
@@ -58,10 +58,10 @@ describe( 'Preview Create Command', () => {
 		( cleanup as jest.Mock ).mockImplementation( () => {} );
 		( uploadArchive as jest.Mock ).mockResolvedValue( {
 			site_url: mockSiteUrl,
-			site_id: mockSiteId,
+			site_id: mockAtomicSiteId,
 		} );
 		( waitForSiteReady as jest.Mock ).mockResolvedValue( true );
-		( addPreviewSiteToAppdata as jest.Mock ).mockResolvedValue( undefined );
+		( upsertPreviewSiteInAppdata as jest.Mock ).mockResolvedValue( undefined );
 	} );
 
 	afterEach( () => {
@@ -92,7 +92,7 @@ describe( 'Preview Create Command', () => {
 		] );
 		expect( mockLogger.reportSuccess.mock.calls[ 2 ] ).toEqual( [ 'Archive uploaded' ] );
 
-		expect( waitForSiteReady ).toHaveBeenCalledWith( mockSiteId, mockAuthToken.accessToken );
+		expect( waitForSiteReady ).toHaveBeenCalledWith( mockAtomicSiteId, mockAuthToken.accessToken );
 		expect( mockLogger.reportStart.mock.calls[ 3 ] ).toEqual( [
 			'ready',
 			'Creating preview site...',
@@ -101,7 +101,11 @@ describe( 'Preview Create Command', () => {
 			`Preview site available at: https://${ mockSiteUrl }`,
 		] );
 
-		expect( addPreviewSiteToAppdata ).toHaveBeenCalledWith( mockSiteUrl, mockSiteId, mockFolder );
+		expect( upsertPreviewSiteInAppdata ).toHaveBeenCalledWith(
+			mockFolder,
+			mockAtomicSiteId,
+			mockSiteUrl
+		);
 		expect( mockLogger.reportStart.mock.calls[ 4 ] ).toEqual( [
 			'appdata',
 			'Saving preview site to Studio...',
@@ -200,12 +204,12 @@ describe( 'Preview Create Command', () => {
 
 		expect( mockLogger.reportError ).toHaveBeenCalled();
 		expect( mockLogger.reportError ).toHaveBeenCalledWith( expect.any( LoggerError ) );
-		expect( addPreviewSiteToAppdata ).not.toHaveBeenCalled();
+		expect( upsertPreviewSiteInAppdata ).not.toHaveBeenCalled();
 	} );
 
 	it( 'should handle appdata errors', async () => {
 		const errorMessage = 'Failed to save to appdata';
-		( addPreviewSiteToAppdata as jest.Mock ).mockImplementation( () => {
+		( upsertPreviewSiteInAppdata as jest.Mock ).mockImplementation( () => {
 			throw new LoggerError( errorMessage );
 		} );
 

--- a/cli/commands/preview/tests/list.test.ts
+++ b/cli/commands/preview/tests/list.test.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import { Command } from 'commander';
-import { readAppdata, Snapshot, getSiteIdFromFolder, getAuthToken } from 'cli/lib/appdata';
+import { readAppdata, Snapshot, getSiteFromFolder, getAuthToken } from 'cli/lib/appdata';
 import { validateSiteFolder } from 'cli/lib/validation';
 import { Logger } from 'cli/logger';
 
@@ -24,6 +24,11 @@ describe( 'Preview List Command', () => {
 			userId: 123,
 		},
 	];
+	const mockSite = {
+		id: '456',
+		name: 'Test Site',
+		path: '/test/site',
+	};
 	let program: Command;
 	let mockLogger: {
 		reportStart: jest.Mock;
@@ -36,7 +41,7 @@ describe( 'Preview List Command', () => {
 		( readAppdata as jest.Mock ).mockResolvedValue( { snapshots: mockSnapshots } );
 		( getAuthToken as jest.Mock ).mockResolvedValue( mockAuthToken );
 		( validateSiteFolder as jest.Mock ).mockReturnValue( true );
-		( getSiteIdFromFolder as jest.Mock ).mockResolvedValue( mockSnapshots[ 0 ].localSiteId );
+		( getSiteFromFolder as jest.Mock ).mockResolvedValue( mockSite );
 
 		jest.clearAllMocks();
 		jest.spyOn( Date, 'now' ).mockReturnValue( mockDate );

--- a/cli/commands/preview/tests/update.test.ts
+++ b/cli/commands/preview/tests/update.test.ts
@@ -4,7 +4,7 @@ import { Command } from 'commander';
 import { uploadArchive, waitForSiteReady } from 'cli/lib/api';
 import { getAuthToken } from 'cli/lib/appdata';
 import { createArchive } from 'cli/lib/archive';
-import { addPreviewSiteToAppdata, getSnapshotsFromAppdata } from 'cli/lib/snapshots';
+import { upsertPreviewSiteInAppdata, getSnapshotsFromAppdata } from 'cli/lib/snapshots';
 import { validateSiteFolder } from 'cli/lib/validation';
 import { Logger, LoggerError } from 'cli/logger';
 
@@ -63,7 +63,7 @@ describe( 'Preview Update Command', () => {
 			site_id: mockAtomicSiteId,
 		} );
 		( waitForSiteReady as jest.Mock ).mockResolvedValue( true );
-		( addPreviewSiteToAppdata as jest.Mock ).mockResolvedValue( undefined );
+		( upsertPreviewSiteInAppdata as jest.Mock ).mockResolvedValue( undefined );
 	} );
 
 	afterEach( () => {
@@ -107,10 +107,10 @@ describe( 'Preview Update Command', () => {
 			`Preview site available at: https://${ mockSiteUrl }`,
 		] );
 
-		expect( addPreviewSiteToAppdata ).toHaveBeenCalledWith(
-			mockSiteUrl,
+		expect( upsertPreviewSiteInAppdata ).toHaveBeenCalledWith(
+			mockFolder,
 			mockAtomicSiteId,
-			mockFolder
+			mockSiteUrl
 		);
 		expect( mockLogger.reportStart.mock.calls[ 4 ] ).toEqual( [
 			'appdata',
@@ -221,12 +221,12 @@ describe( 'Preview Update Command', () => {
 
 		expect( mockLogger.reportError ).toHaveBeenCalled();
 		expect( mockLogger.reportError ).toHaveBeenCalledWith( expect.any( LoggerError ) );
-		expect( addPreviewSiteToAppdata ).not.toHaveBeenCalled();
+		expect( upsertPreviewSiteInAppdata ).not.toHaveBeenCalled();
 	} );
 
 	it( 'should handle appdata errors', async () => {
 		const errorMessage = 'Failed to save to appdata';
-		( addPreviewSiteToAppdata as jest.Mock ).mockImplementation( () => {
+		( upsertPreviewSiteInAppdata as jest.Mock ).mockImplementation( () => {
 			throw new LoggerError( errorMessage );
 		} );
 

--- a/cli/commands/preview/update.ts
+++ b/cli/commands/preview/update.ts
@@ -4,7 +4,7 @@ import { __, _n, sprintf } from '@wordpress/i18n';
 import { uploadArchive, waitForSiteReady } from 'cli/lib/api';
 import { getAuthToken } from 'cli/lib/appdata';
 import { cleanup, createArchive } from 'cli/lib/archive';
-import { addPreviewSiteToAppdata, getSnapshotsFromAppdata } from 'cli/lib/snapshots';
+import { upsertPreviewSiteInAppdata, getSnapshotsFromAppdata } from 'cli/lib/snapshots';
 import { normalizeHostname } from 'cli/lib/utils';
 import { validateSiteFolder } from 'cli/lib/validation';
 import { Logger, LoggerError } from 'cli/logger';
@@ -59,7 +59,7 @@ async function runCommand(
 		);
 
 		logger.reportStart( LoggerAction.APPDATA, __( 'Saving preview site to Studio...' ) );
-		await addPreviewSiteToAppdata( uploadResponse.site_url, uploadResponse.site_id, siteFolder );
+		await upsertPreviewSiteInAppdata( siteFolder, uploadResponse.site_id, uploadResponse.site_url );
 		logger.reportSuccess( __( 'Preview site saved to Studio' ) );
 	} catch ( error ) {
 		if ( error instanceof LoggerError ) {

--- a/cli/lib/appdata.ts
+++ b/cli/lib/appdata.ts
@@ -11,7 +11,7 @@ export const snapshotSchema = z.object( {
 	atomicSiteId: z.number(),
 	localSiteId: z.string(),
 	date: z.number(),
-	name: z.string().optional(),
+	name: z.string(),
 	userId: z.number().optional(),
 } );
 
@@ -19,14 +19,14 @@ const siteSchema = z
 	.object( {
 		id: z.string(),
 		path: z.string(),
-		name: z.string().optional(),
+		name: z.string(),
 	} )
 	.passthrough();
 
 const userDataSchema = z
 	.object( {
-		snapshots: z.array( snapshotSchema ).optional(),
 		sites: z.array( siteSchema ).optional(),
+		snapshots: z.array( snapshotSchema ).optional(),
 		locale: z.string().optional(),
 		authToken: z
 			.object( {
@@ -129,7 +129,9 @@ export async function getAuthToken(): Promise< NonNullable< UserData[ 'authToken
 	}
 }
 
-export async function getSiteIdFromFolder( siteFolder: string ): Promise< string > {
+export async function getSiteFromFolder(
+	siteFolder: string
+): Promise< z.infer< typeof siteSchema > > {
 	const userData = await readAppdata();
 	const sites = userData.sites ?? [];
 	const site = sites.find( ( site ) => site.path === siteFolder );
@@ -138,5 +140,5 @@ export async function getSiteIdFromFolder( siteFolder: string ): Promise< string
 		throw new LoggerError( __( 'The specified folder is not added to Studio.' ) );
 	}
 
-	return site.id;
+	return site;
 }

--- a/cli/lib/snapshots.ts
+++ b/cli/lib/snapshots.ts
@@ -1,11 +1,4 @@
-import { z } from 'zod';
-import {
-	getSiteIdFromFolder,
-	readAppdata,
-	saveAppdata,
-	snapshotSchema,
-	Snapshot,
-} from 'cli/lib/appdata';
+import { getSiteFromFolder, readAppdata, saveAppdata, Snapshot } from 'cli/lib/appdata';
 import { LoggerError } from 'cli/logger';
 
 export async function getSnapshotsFromAppdata(
@@ -17,25 +10,23 @@ export async function getSnapshotsFromAppdata(
 	snapshots = snapshots.filter( ( snapshot ) => snapshot.userId === userId );
 
 	if ( siteFolder ) {
-		const siteId = await getSiteIdFromFolder( siteFolder );
-		snapshots = snapshots.filter( ( snapshot ) => snapshot.localSiteId === siteId );
+		const site = await getSiteFromFolder( siteFolder );
+		snapshots = snapshots.filter( ( snapshot ) => snapshot.localSiteId === site.id );
 	}
 
 	return snapshots;
 }
 
-export async function addPreviewSiteToAppdata(
-	previewUrl: string,
+// Insert or update a snapshot entry (matching on atomicSiteId) in the appdata file.
+export async function upsertPreviewSiteInAppdata(
+	siteFolder: string,
 	atomicSiteId: number,
-	siteFolder: string
-): Promise< void > {
+	previewUrl: string
+): Promise< Snapshot > {
 	try {
 		const userData = await readAppdata();
-		const site = userData.sites?.find( ( s ) => s.path === siteFolder );
-		if ( ! site ) {
-			return;
-		}
-		const snapshot: z.infer< typeof snapshotSchema > = {
+		const site = await getSiteFromFolder( siteFolder );
+		const snapshot: Snapshot = {
 			url: previewUrl,
 			atomicSiteId,
 			localSiteId: site.id,
@@ -48,8 +39,19 @@ export async function addPreviewSiteToAppdata(
 		if ( ! userData.snapshots ) {
 			userData.snapshots = [];
 		}
-		userData.snapshots.push( snapshot );
+
+		const existingSnapshotIndex = userData.snapshots.findIndex(
+			( s ) => s.atomicSiteId === atomicSiteId
+		);
+
+		if ( existingSnapshotIndex > -1 ) {
+			userData.snapshots.splice( existingSnapshotIndex, 1, snapshot );
+		} else {
+			userData.snapshots.push( snapshot );
+		}
+
 		await saveAppdata( userData );
+		return snapshot;
 	} catch ( error ) {
 		throw new LoggerError(
 			`Failed to add preview site to appdata: ${

--- a/cli/lib/tests/appdata.test.ts
+++ b/cli/lib/tests/appdata.test.ts
@@ -38,6 +38,7 @@ describe( 'Appdata Module', () => {
 					{
 						url: 'example.com',
 						atomicSiteId: 123,
+						name: 'Example site',
 						localSiteId: 'site1',
 						date: 1234567,
 					},

--- a/cli/lib/tests/snapshots.test.ts
+++ b/cli/lib/tests/snapshots.test.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import {
-	addPreviewSiteToAppdata,
+	upsertPreviewSiteInAppdata,
 	getSnapshotsFromAppdata,
 	deleteSnapshotFromAppdata,
 } from 'cli/lib/snapshots';
@@ -16,7 +16,7 @@ describe( 'Snapshots Module', () => {
 	const mockHomeDir = '/mock/home';
 	const mockSiteFolderName = 'folder';
 	const mockSiteUrl = 'test-preview.example.com';
-	const mockSiteId = 12345;
+	const mockAtomicSiteId = 12345;
 	const mockSiteFolder = '/test/folder';
 	const mockUserId = 9876;
 
@@ -33,10 +33,9 @@ describe( 'Snapshots Module', () => {
 		( fs.writeFileSync as jest.Mock ).mockImplementation( () => undefined );
 	} );
 
-	describe( 'addPreviewSiteToAppdata', () => {
+	describe( 'upsertPreviewSiteInAppdata', () => {
 		it( 'should add a new preview site to appdata', async () => {
 			const mockSiteId = 'abc123';
-			const mockAtomicSiteId = 123;
 			const mockUserData = {
 				version: 1,
 				sites: [
@@ -51,7 +50,7 @@ describe( 'Snapshots Module', () => {
 
 			( fs.readFileSync as jest.Mock ).mockReturnValue( JSON.stringify( mockUserData ) );
 
-			await addPreviewSiteToAppdata( mockSiteUrl, mockAtomicSiteId, mockSiteFolder );
+			await upsertPreviewSiteInAppdata( mockSiteFolder, mockAtomicSiteId, mockSiteUrl );
 
 			expect( fs.writeFileSync ).toHaveBeenCalled();
 			const savedData = JSON.parse( ( fs.writeFileSync as jest.Mock ).mock.calls[ 0 ][ 1 ] );
@@ -68,10 +67,10 @@ describe( 'Snapshots Module', () => {
 
 		it( 'should append to existing snapshots', async () => {
 			const mockSiteId = 'abc123';
-			const mockAtomicSiteId = 123;
 			const existingSnapshot = {
 				url: 'existing.com',
 				atomicSiteId: mockAtomicSiteId,
+				name: 'Existing',
 				localSiteId: 'existing',
 				date: 1000000,
 			};
@@ -90,7 +89,7 @@ describe( 'Snapshots Module', () => {
 
 			( fs.readFileSync as jest.Mock ).mockReturnValue( JSON.stringify( mockUserData ) );
 
-			await addPreviewSiteToAppdata( mockSiteUrl, mockAtomicSiteId, mockSiteFolder );
+			await upsertPreviewSiteInAppdata( mockSiteFolder, mockAtomicSiteId + 1, mockSiteUrl );
 
 			expect( fs.writeFileSync ).toHaveBeenCalled();
 			const savedData = JSON.parse( ( fs.writeFileSync as jest.Mock ).mock.calls[ 0 ][ 1 ] );
@@ -99,7 +98,7 @@ describe( 'Snapshots Module', () => {
 			expect( savedData.snapshots[ 0 ] ).toEqual( existingSnapshot );
 			expect( savedData.snapshots[ 1 ] ).toEqual( {
 				url: mockSiteUrl,
-				atomicSiteId: mockAtomicSiteId,
+				atomicSiteId: mockAtomicSiteId + 1,
 				localSiteId: mockSiteId,
 				date: 1234567890,
 				name: 'Test Site',
@@ -108,7 +107,6 @@ describe( 'Snapshots Module', () => {
 
 		it( 'should add userId from authToken if available', async () => {
 			const mockSiteId = 'abc123';
-			const mockAtomicSiteId = 123;
 			const mockUserData = {
 				version: 1,
 				sites: [
@@ -127,7 +125,7 @@ describe( 'Snapshots Module', () => {
 
 			( fs.readFileSync as jest.Mock ).mockReturnValue( JSON.stringify( mockUserData ) );
 
-			await addPreviewSiteToAppdata( mockSiteUrl, mockAtomicSiteId, mockSiteFolder );
+			await upsertPreviewSiteInAppdata( mockSiteFolder, mockAtomicSiteId, mockSiteUrl );
 
 			expect( fs.writeFileSync ).toHaveBeenCalled();
 			const savedData = JSON.parse( ( fs.writeFileSync as jest.Mock ).mock.calls[ 0 ][ 1 ] );
@@ -135,7 +133,7 @@ describe( 'Snapshots Module', () => {
 			expect( savedData.snapshots[ 0 ].userId ).toBe( mockUserId );
 		} );
 
-		it( 'should return without error if no matching site is found', async () => {
+		it( 'should throw an error if no matching site is found', async () => {
 			const mockUserData = {
 				version: 1,
 				sites: [
@@ -150,7 +148,9 @@ describe( 'Snapshots Module', () => {
 
 			( fs.readFileSync as jest.Mock ).mockReturnValue( JSON.stringify( mockUserData ) );
 
-			await addPreviewSiteToAppdata( mockSiteUrl, mockSiteId, mockSiteFolder );
+			await expect(
+				upsertPreviewSiteInAppdata( mockSiteFolder, mockAtomicSiteId, mockSiteUrl )
+			).rejects.toThrow( LoggerError );
 
 			expect( fs.writeFileSync ).not.toHaveBeenCalled();
 		} );
@@ -159,8 +159,47 @@ describe( 'Snapshots Module', () => {
 			( fs.existsSync as jest.Mock ).mockReturnValueOnce( false );
 
 			await expect(
-				addPreviewSiteToAppdata( mockSiteUrl, mockSiteId, mockSiteFolder )
+				upsertPreviewSiteInAppdata( mockSiteFolder, mockAtomicSiteId, mockSiteUrl )
 			).rejects.toThrow( LoggerError );
+		} );
+
+		it( 'should update existing snapshot with matching atomicSiteId', async () => {
+			const mockSiteId = 'abc123';
+			const mockUserData = {
+				version: 1,
+				sites: [
+					{
+						id: mockSiteId,
+						path: mockSiteFolder,
+						name: 'Test Site',
+					},
+				],
+				snapshots: [
+					{
+						url: 'old-url.com',
+						atomicSiteId: mockAtomicSiteId,
+						localSiteId: mockSiteId,
+						date: 1000000,
+						name: 'Test Site',
+					},
+				],
+			};
+
+			( fs.readFileSync as jest.Mock ).mockReturnValue( JSON.stringify( mockUserData ) );
+
+			await upsertPreviewSiteInAppdata( mockSiteFolder, mockAtomicSiteId, 'hello.wp.build' );
+
+			expect( fs.writeFileSync ).toHaveBeenCalled();
+			const savedData = JSON.parse( ( fs.writeFileSync as jest.Mock ).mock.calls[ 0 ][ 1 ] );
+
+			expect( savedData.snapshots ).toHaveLength( 1 );
+			expect( savedData.snapshots[ 0 ] ).toEqual( {
+				url: 'hello.wp.build',
+				atomicSiteId: mockAtomicSiteId,
+				localSiteId: mockSiteId,
+				date: 1234567890,
+				name: 'Test Site',
+			} );
 		} );
 	} );
 
@@ -169,8 +208,22 @@ describe( 'Snapshots Module', () => {
 			const mockUserData = {
 				version: 1,
 				snapshots: [
-					{ userId: 9876, url: 'test1.com', atomicSiteId: 1, localSiteId: 'site1', date: 1000 },
-					{ userId: 1234, url: 'test2.com', atomicSiteId: 2, localSiteId: 'site2', date: 2000 },
+					{
+						userId: 9876,
+						url: 'test1.com',
+						name: 'Site 1',
+						atomicSiteId: 1,
+						localSiteId: 'site1',
+						date: 1000,
+					},
+					{
+						userId: 1234,
+						url: 'test2.com',
+						name: 'Site 2',
+						atomicSiteId: 2,
+						localSiteId: 'site2',
+						date: 2000,
+					},
 				],
 			};
 
@@ -186,8 +239,22 @@ describe( 'Snapshots Module', () => {
 			const mockUserData = {
 				version: 1,
 				snapshots: [
-					{ userId: 9876, url: 'test1.com', atomicSiteId: 1, localSiteId: 'site1', date: 1000 },
-					{ userId: 9876, url: 'test2.com', atomicSiteId: 2, localSiteId: 'site2', date: 2000 },
+					{
+						userId: 9876,
+						url: 'test1.com',
+						name: 'Site 1',
+						atomicSiteId: 1,
+						localSiteId: 'site1',
+						date: 1000,
+					},
+					{
+						userId: 9876,
+						url: 'test2.com',
+						name: 'Site 2',
+						atomicSiteId: 2,
+						localSiteId: 'site2',
+						date: 2000,
+					},
 				],
 				sites: [ { id: 'site1', path: mockSiteFolder, name: 'Test Site' } ],
 			};
@@ -219,8 +286,8 @@ describe( 'Snapshots Module', () => {
 			const mockUserData = {
 				version: 1,
 				snapshots: [
-					{ url: 'test1.com', atomicSiteId: 1, localSiteId: 'site1', date: 1000 },
-					{ url: 'test2.com', atomicSiteId: 2, localSiteId: 'site2', date: 2000 },
+					{ url: 'test1.com', name: 'Site 1', atomicSiteId: 1, localSiteId: 'site1', date: 1000 },
+					{ url: 'test2.com', name: 'Site 2', atomicSiteId: 2, localSiteId: 'site2', date: 2000 },
 				],
 			};
 
@@ -237,7 +304,15 @@ describe( 'Snapshots Module', () => {
 		it( 'should not modify snapshots if url not found', async () => {
 			const mockUserData = {
 				version: 1,
-				snapshots: [ { url: 'test1.com', atomicSiteId: 1, localSiteId: 'site1', date: 1000 } ],
+				snapshots: [
+					{
+						url: 'test1.com',
+						atomicSiteId: 1,
+						name: 'Site',
+						localSiteId: 'site1',
+						date: 1000,
+					},
+				],
 			};
 
 			( fs.readFileSync as jest.Mock ).mockReturnValue( JSON.stringify( mockUserData ) );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-373

## Proposed Changes

Previously, the `preview update` command would insert a duplicate `snapshots` entry in the appdata when it finished. This PR makes it so the existing entry is updated instead. 

Because https://github.com/Automattic/studio/pull/1201 also touches a lot of the same files (the `upsertPreviewSiteInAppdata` function specifically), I checked out the changes from that branch, too. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Have an existing preview site
2. Open the appdata file in your code editor
3. Run `npm run cli:build`
4. Run `node dist/cli/main.js preview update PATH_TO_SITE -h PREVIEW_SITE_HOSTNAME`
5. Ensure that there are no duplicates in the `snapshots` array in the appdata file and that the `date` prop was updated

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
