### PR TITLE
Update user-facing CLI preview copy

### DIFF
--- a/cli/commands/preview/list.ts
+++ b/cli/commands/preview/list.ts
@@ -20,16 +20,16 @@ async function runCommand( siteFolder: string, outputFormat?: OutputFormat ): Pr
 		const token = await getAuthToken();
 		logger.reportSuccess( __( 'Validation successful' ) );
 
-		logger.reportStart( LoggerAction.LOAD, __( 'Loading snapshots...' ) );
+		logger.reportStart( LoggerAction.LOAD, __( 'Loading previews...' ) );
 		const snapshots = await getSnapshotsFromAppdata( token.id, siteFolder );
 
 		if ( snapshots.length === 0 ) {
-			logger.reportSuccess( __( 'No snapshots found' ) );
+			logger.reportSuccess( __( 'No previews found' ) );
 			return;
 		}
 
 		logger.reportSuccess(
-			sprintf( _n( 'Found %d snapshot', 'Found %d snapshots', snapshots.length ), snapshots.length )
+			sprintf( _n( 'Found %d preview', 'Found %d previews', snapshots.length ), snapshots.length )
 		);
 
 		const table = getSnapshotCliTable( snapshots );
@@ -38,7 +38,7 @@ async function runCommand( siteFolder: string, outputFormat?: OutputFormat ): Pr
 		if ( error instanceof LoggerError ) {
 			logger.reportError( error );
 		} else {
-			const loggerError = new LoggerError( __( 'Failed to load snapshots' ), error );
+			const loggerError = new LoggerError( __( 'Failed to load previews' ), error );
 			logger.reportError( loggerError );
 		}
 	}

--- a/cli/commands/preview/tests/list.test.ts
+++ b/cli/commands/preview/tests/list.test.ts
@@ -1,11 +1,7 @@
 import path from 'path';
 import { Command } from 'commander';
-<<<<<<< HEAD
 import { Snapshot } from 'common/types/snapshot';
-import { readAppdata, getSiteFromFolder, getAuthToken } from 'cli/lib/appdata';
-=======
-import { readAppdata, Snapshot, getSiteFromAppData, getAuthToken } from 'cli/lib/appdata';
->>>>>>> 8fdad0ce (chore: naming and export)
+import { readAppdata, getSiteByFolder, getAuthToken } from 'cli/lib/appdata';
 import { validateSiteFolder } from 'cli/lib/validation';
 import { Logger } from 'cli/logger';
 
@@ -45,7 +41,7 @@ describe( 'Preview List Command', () => {
 		( readAppdata as jest.Mock ).mockResolvedValue( { snapshots: mockSnapshots } );
 		( getAuthToken as jest.Mock ).mockResolvedValue( mockAuthToken );
 		( validateSiteFolder as jest.Mock ).mockReturnValue( true );
-		( getSiteFromAppData as jest.Mock ).mockResolvedValue( mockSite );
+		( getSiteByFolder as jest.Mock ).mockResolvedValue( mockSite );
 
 		jest.clearAllMocks();
 		jest.spyOn( Date, 'now' ).mockReturnValue( mockDate );

--- a/cli/commands/preview/tests/list.test.ts
+++ b/cli/commands/preview/tests/list.test.ts
@@ -1,7 +1,11 @@
 import path from 'path';
 import { Command } from 'commander';
+<<<<<<< HEAD
 import { Snapshot } from 'common/types/snapshot';
 import { readAppdata, getSiteFromFolder, getAuthToken } from 'cli/lib/appdata';
+=======
+import { readAppdata, Snapshot, getSiteFromAppData, getAuthToken } from 'cli/lib/appdata';
+>>>>>>> 8fdad0ce (chore: naming and export)
 import { validateSiteFolder } from 'cli/lib/validation';
 import { Logger } from 'cli/logger';
 
@@ -41,7 +45,7 @@ describe( 'Preview List Command', () => {
 		( readAppdata as jest.Mock ).mockResolvedValue( { snapshots: mockSnapshots } );
 		( getAuthToken as jest.Mock ).mockResolvedValue( mockAuthToken );
 		( validateSiteFolder as jest.Mock ).mockReturnValue( true );
-		( getSiteFromFolder as jest.Mock ).mockResolvedValue( mockSite );
+		( getSiteFromAppData as jest.Mock ).mockResolvedValue( mockSite );
 
 		jest.clearAllMocks();
 		jest.spyOn( Date, 'now' ).mockReturnValue( mockDate );

--- a/cli/commands/preview/tests/list.test.ts
+++ b/cli/commands/preview/tests/list.test.ts
@@ -65,8 +65,8 @@ describe( 'Preview List Command', () => {
 
 		expect( mockLogger.reportStart ).toHaveBeenCalledWith( 'validate', 'Validating...' );
 		expect( mockLogger.reportSuccess ).toHaveBeenCalledWith( 'Validation successful' );
-		expect( mockLogger.reportStart ).toHaveBeenCalledWith( 'load', 'Loading snapshots...' );
-		expect( mockLogger.reportSuccess ).toHaveBeenCalledWith( 'Found 1 snapshot' );
+		expect( mockLogger.reportStart ).toHaveBeenCalledWith( 'load', 'Loading previews...' );
+		expect( mockLogger.reportSuccess ).toHaveBeenCalledWith( 'Found 1 preview' );
 	} );
 
 	it( 'should handle validation errors', async () => {
@@ -88,6 +88,6 @@ describe( 'Preview List Command', () => {
 
 		await program.parseAsync( [ 'node', 'studio', 'list', '/test/path' ] );
 
-		expect( mockLogger.reportSuccess ).toHaveBeenCalledWith( 'No snapshots found' );
+		expect( mockLogger.reportSuccess ).toHaveBeenCalledWith( 'No previews found' );
 	} );
 } );

--- a/cli/lib/appdata.ts
+++ b/cli/lib/appdata.ts
@@ -120,7 +120,7 @@ export async function getAuthToken(): Promise< NonNullable< UserData[ 'authToken
 	}
 }
 
-export async function getSiteFromAppData(
+export async function getSiteByFolder(
 	siteFolder: string
 ): Promise< z.infer< typeof siteSchema > > {
 	const userData = await readAppdata();

--- a/cli/lib/appdata.ts
+++ b/cli/lib/appdata.ts
@@ -120,7 +120,7 @@ export async function getAuthToken(): Promise< NonNullable< UserData[ 'authToken
 	}
 }
 
-export async function getSiteFromFolder(
+export async function getSiteFromAppData(
 	siteFolder: string
 ): Promise< z.infer< typeof siteSchema > > {
 	const userData = await readAppdata();

--- a/cli/lib/snapshots.ts
+++ b/cli/lib/snapshots.ts
@@ -1,5 +1,5 @@
 import { Snapshot } from 'common/types/snapshot';
-import { getSiteFromAppData, readAppdata, saveAppdata } from 'cli/lib/appdata';
+import { getSiteByFolder, readAppdata, saveAppdata } from 'cli/lib/appdata';
 import { LoggerError } from 'cli/logger';
 export async function getSnapshotsFromAppdata(
 	userId: number,
@@ -10,7 +10,7 @@ export async function getSnapshotsFromAppdata(
 	snapshots = snapshots.filter( ( snapshot ) => snapshot.userId === userId );
 
 	if ( siteFolder ) {
-		const site = await getSiteFromAppData( siteFolder );
+		const site = await getSiteByFolder( siteFolder );
 		snapshots = snapshots.filter( ( snapshot ) => snapshot.localSiteId === site.id );
 	}
 
@@ -25,7 +25,7 @@ export async function upsertPreviewSiteInAppdata(
 ): Promise< Snapshot > {
 	try {
 		const userData = await readAppdata();
-		const site = await getSiteFromAppData( siteFolder );
+		const site = await getSiteByFolder( siteFolder );
 		const snapshot: Snapshot = {
 			url: previewUrl,
 			atomicSiteId,

--- a/cli/lib/snapshots.ts
+++ b/cli/lib/snapshots.ts
@@ -1,5 +1,5 @@
 import { Snapshot } from 'common/types/snapshot';
-import { getSiteFromFolder, readAppdata, saveAppdata } from 'cli/lib/appdata';
+import { getSiteFromAppData, readAppdata, saveAppdata } from 'cli/lib/appdata';
 import { LoggerError } from 'cli/logger';
 export async function getSnapshotsFromAppdata(
 	userId: number,
@@ -10,7 +10,7 @@ export async function getSnapshotsFromAppdata(
 	snapshots = snapshots.filter( ( snapshot ) => snapshot.userId === userId );
 
 	if ( siteFolder ) {
-		const site = await getSiteFromFolder( siteFolder );
+		const site = await getSiteFromAppData( siteFolder );
 		snapshots = snapshots.filter( ( snapshot ) => snapshot.localSiteId === site.id );
 	}
 
@@ -25,7 +25,7 @@ export async function upsertPreviewSiteInAppdata(
 ): Promise< Snapshot > {
 	try {
 		const userData = await readAppdata();
-		const site = await getSiteFromFolder( siteFolder );
+		const site = await getSiteFromAppData( siteFolder );
 		const snapshot: Snapshot = {
 			url: previewUrl,
 			atomicSiteId,

--- a/src/hooks/use-snapshots.tsx
+++ b/src/hooks/use-snapshots.tsx
@@ -45,12 +45,12 @@ interface SnapshotContextType {
 	stopCreationProgress: () => void;
 }
 
-export enum SnapshotStatus {
+enum SnapshotStatus {
 	Deleted = '1',
 	Active = '2',
 }
 
-export interface SnapshotStatusResponse {
+interface SnapshotStatusResponse {
 	is_deleted: string;
 	domain_name: string;
 	atomic_site_id: string;


### PR DESCRIPTION
## Proposed Changes
In Studio UI we use "preview" instead of "snapshot", also CLI command is called "preview", so this PR renames output

<img width="196" alt="Screenshot 2025-04-17 at 13 18 07" src="https://github.com/user-attachments/assets/b2f9a265-d5c2-47c8-be26-d4cf0f09cd9f" />
<img width="854" alt="Screenshot 2025-04-17 at 13 18 15" src="https://github.com/user-attachments/assets/663b2daf-1ca5-43fd-a1b4-c6ef894dc948" />

## Testing Instructions

Visual review shoudl suffice