### PR TITLE
Studio: Solve console warnings on user-settings tests

### DIFF
--- a/src/components/tests/user-settings.test.tsx
+++ b/src/components/tests/user-settings.test.tsx
@@ -16,6 +16,7 @@ jest.mock( 'src/lib/get-ipc-api', () => ( {
 			terminal: true,
 			iterm: false,
 		} ),
+		getInstalledApps: jest.fn().mockResolvedValue( [ 'vscode', 'phpstorm' ] ),
 	} ),
 } ) );
 

--- a/src/components/tests/user-settings.test.tsx
+++ b/src/components/tests/user-settings.test.tsx
@@ -1,4 +1,4 @@
-// To run tests, execute `npm run test -- src/components/user-settings.test.tsx` from the root directory
+// To run tests, execute `npm run test -- src/components/tests/user-settings.test.tsx` from the root directory
 import { fireEvent, render, screen } from '@testing-library/react';
 import UserSettings from 'src/components/user-settings';
 import { useAuth } from 'src/hooks/use-auth';

--- a/src/components/tests/user-settings.test.tsx
+++ b/src/components/tests/user-settings.test.tsx
@@ -1,5 +1,5 @@
 // To run tests, execute `npm run test -- src/components/tests/user-settings.test.tsx` from the root directory
-import { fireEvent, render, screen, act, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import UserSettings from 'src/components/user-settings';
 import { useAuth } from 'src/hooks/use-auth';
 import { useFeatureFlags } from 'src/hooks/use-feature-flags';

--- a/src/components/tests/user-settings.test.tsx
+++ b/src/components/tests/user-settings.test.tsx
@@ -1,5 +1,5 @@
 // To run tests, execute `npm run test -- src/components/tests/user-settings.test.tsx` from the root directory
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, act, waitFor } from '@testing-library/react';
 import UserSettings from 'src/components/user-settings';
 import { useAuth } from 'src/hooks/use-auth';
 import { useFeatureFlags } from 'src/hooks/use-feature-flags';
@@ -94,13 +94,17 @@ describe( 'UserSettings', () => {
 
 			// Switch to Preferences tab
 			fireEvent.click( screen.getByText( 'Preferences' ) );
-			expect( screen.getByText( 'Preferences' ) ).toHaveAttribute( 'aria-selected', 'true' );
+			await waitFor( () => {
+				expect( screen.getByText( 'Preferences' ) ).toHaveAttribute( 'aria-selected', 'true' );
+			} );
 			expect( screen.getByText( 'Language' ) ).toBeVisible();
 			expect( screen.getByText( 'Shell' ) ).toBeVisible();
 
 			// Switch to Usage tab
 			fireEvent.click( screen.getByText( 'Usage' ) );
-			expect( screen.getByText( 'Usage' ) ).toHaveAttribute( 'aria-selected', 'true' );
+			await waitFor( () => {
+				expect( screen.getByText( 'Usage' ) ).toHaveAttribute( 'aria-selected', 'true' );
+			} );
 			expect( screen.getByText( 'Preview sites' ) ).toBeVisible();
 			expect( screen.getByText( 'AI assistant' ) ).toBeVisible();
 		} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-376

## Proposed Changes

This PR ensures that the tests for `user-settings.test.tsx` do not throw console warnings `When testing, code that causes React state updates should be wrapped into act(...):`.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
* Run `npm run test -- src/components/tests/user-settings.test.tsx`
* Confirm the tests are passing
* Confirm there are no React warnings `When testing, code that causes React state updates should be wrapped into act(...):`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
