### PR TITLE
Sync: Clean up site sync statuses

### DIFF
--- a/src/components/sync-sites-modal-selector.tsx
+++ b/src/components/sync-sites-modal-selector.tsx
@@ -141,8 +141,8 @@ const getSortedSites = ( sites: SyncSite[] ) => {
 		deleted: 3,
 		'missing-permissions': 4,
 		'needs-transfer': 5,
-		unsupported: 6,
-		'jetpack-site': 7,
+		'needs-upgrade': 6,
+		unsupported: 7,
 	};
 
 	return [ ...sites ].sort( ( a, b ) => order[ a.syncSupport ] - order[ b.syncSupport ] );
@@ -190,9 +190,9 @@ function SiteItem( {
 	const isSyncable = site.syncSupport === 'syncable';
 	const isNeedsTransfer = site.syncSupport === 'needs-transfer';
 	const isMissingPermissions = site.syncSupport === 'missing-permissions';
-	const isUnsupported = site.syncSupport === 'unsupported';
+	const needsUpgrade = site.syncSupport === 'needs-upgrade';
 	const isDeleted = site.syncSupport === 'deleted';
-	const isJetpackSite = site.syncSupport === 'jetpack-site';
+	const isUnsupported = site.syncSupport === 'unsupported';
 
 	return (
 		<div
@@ -270,7 +270,7 @@ function SiteItem( {
 					{ __( 'Already connected' ) }
 				</div>
 			) }
-			{ isUnsupported && (
+			{ needsUpgrade && (
 				<div className="a8c-body-small text-a8c-gray-30 shrink-0 text-right">
 					<Button
 						variant="link"
@@ -302,7 +302,7 @@ function SiteItem( {
 					{ __( 'Deleted' ) }
 				</div>
 			) }
-			{ isJetpackSite && (
+			{ isUnsupported && (
 				<div className="a8c-body-small text-a8c-gray-30 shrink-0">{ __( 'Unsupported site' ) }</div>
 			) }
 		</div>

--- a/src/hooks/use-fetch-wpcom-sites/index.tsx
+++ b/src/hooks/use-fetch-wpcom-sites/index.tsx
@@ -61,11 +61,7 @@ function isAtomicSite( site: SitesEndpointSite ): boolean {
 }
 
 function hasSupportedPlan( site: SitesEndpointSite ): boolean {
-	return (
-		( isPressableSite( site ) ||
-			site.plan?.features.active.includes( STUDIO_SYNC_FEATURE_NAME ) ) ??
-		false
-	);
+	return site.plan?.features.active.includes( STUDIO_SYNC_FEATURE_NAME ) ?? false;
 }
 
 function isJetpackSite( site: SitesEndpointSite ): boolean {

--- a/src/hooks/use-fetch-wpcom-sites/index.tsx
+++ b/src/hooks/use-fetch-wpcom-sites/index.tsx
@@ -79,7 +79,14 @@ function getSyncSupport( site: SitesEndpointSite, connectedSiteIds: number[] ): 
 	if ( ! site.capabilities?.manage_options ) {
 		return 'missing-permissions';
 	}
+<<<<<<< HEAD
 	if ( isJetpackSite( site ) ) {
+=======
+	if ( site.hosting_provider_guess === 'pressable' ) {
+		return 'syncable';
+	}
+	if ( isJetpackSite( site ) && ! hasSupportedPlan( site ) ) {
+>>>>>>> e7139585 (Add hosting provider check for Pressable sites in wpcom site fetching logic)
 		return 'jetpack-site';
 	}
 	if ( ! hasSupportedPlan( site ) && ! isPressableSite( site ) ) {

--- a/src/hooks/use-fetch-wpcom-sites/index.tsx
+++ b/src/hooks/use-fetch-wpcom-sites/index.tsx
@@ -185,7 +185,12 @@ export const useFetchWpComSites = ( connectedSiteIdsOnlyForSelectedSite: number[
 					path: `/me/sites`,
 				},
 				{
+<<<<<<< HEAD
 					fields,
+=======
+					fields:
+						'name,ID,URL,plan,capabilities,is_wpcom_atomic,options,jetpack,is_deleted,hosting_provider_guess',
+>>>>>>> 3bb3891b (Add `hosting_provider_guess` field to wpcom sites API request)
 					filter: 'atomic,wpcom',
 					options: 'created_at,wpcom_staging_blog_ids',
 					site_activity: 'active',

--- a/src/hooks/use-fetch-wpcom-sites/index.tsx
+++ b/src/hooks/use-fetch-wpcom-sites/index.tsx
@@ -64,6 +64,7 @@ function hasSupportedPlan( site: SitesEndpointSite ): boolean {
 	return site.plan?.features.active.includes( STUDIO_SYNC_FEATURE_NAME ) ?? false;
 }
 
+<<<<<<< HEAD
 function isJetpackSite( site: SitesEndpointSite ): boolean {
 	return !! site.jetpack && ! isAtomicSite( site ) && ! isPressableSite( site );
 }
@@ -73,6 +74,13 @@ function needsTransfer( site: SitesEndpointSite ): boolean {
 }
 
 function getSyncSupport( site: SitesEndpointSite, connectedSiteIds: number[] ): SyncSupport {
+=======
+function getSyncSupport(
+	site: SitesEndpointSite,
+	connectedSiteIds: number[],
+	pressableSyncEnabled: boolean
+): SyncSupport {
+>>>>>>> 03badf57 (Add feature flag to control Pressable site sync support)
 	if ( site.is_deleted ) {
 		return 'deleted';
 	}
@@ -80,9 +88,13 @@ function getSyncSupport( site: SitesEndpointSite, connectedSiteIds: number[] ): 
 		return 'missing-permissions';
 	}
 <<<<<<< HEAD
+<<<<<<< HEAD
 	if ( isJetpackSite( site ) ) {
 =======
 	if ( site.hosting_provider_guess === 'pressable' ) {
+=======
+	if ( pressableSyncEnabled && site.hosting_provider_guess === 'pressable' ) {
+>>>>>>> 03badf57 (Add feature flag to control Pressable site sync support)
 		return 'syncable';
 	}
 	if ( isJetpackSite( site ) && ! hasSupportedPlan( site ) ) {
@@ -119,7 +131,11 @@ export function transformSingleSiteResponse(
 	};
 }
 
-export function transformSitesResponse( sites: unknown[], connectedSiteIds: number[] ): SyncSite[] {
+export function transformSitesResponse(
+	sites: unknown[],
+	connectedSiteIds: number[],
+	pressableSyncEnabled: boolean
+): SyncSite[] {
 	const validatedSites = sites.reduce< SitesEndpointSite[] >( ( acc, rawSite ) => {
 		try {
 			const site = sitesEndpointSiteSchema.parse( rawSite );
@@ -140,7 +156,7 @@ export function transformSitesResponse( sites: unknown[], connectedSiteIds: numb
 			// The API returns the wrong value for the `is_wpcom_staging_site` prop while staging sites
 			// are being created. Hence the check in other sites' `wpcom_staging_blog_ids` arrays.
 			const isStaging = allStagingSiteIds.includes( site.ID );
-			const syncSupport = getSyncSupport( site, connectedSiteIds );
+			const syncSupport = getSyncSupport( site, connectedSiteIds, pressableSyncEnabled );
 
 			return transformSingleSiteResponse( site, syncSupport, isStaging );
 		} );
@@ -200,7 +216,8 @@ export const useFetchWpComSites = ( connectedSiteIdsOnlyForSelectedSite: number[
 			const parsedResponse = sitesEndpointResponseSchema.parse( response );
 			const syncSites = transformSitesResponse(
 				parsedResponse.sites,
-				allConnectedSites.map( ( { id } ) => id )
+				allConnectedSites.map( ( { id } ) => id ),
+				pressableSyncEnabled
 			);
 
 			// whenever array of syncSites changes, we need to update connectedSites to keep them updated with wordpress.com
@@ -244,8 +261,8 @@ export const useFetchWpComSites = ( connectedSiteIdsOnlyForSelectedSite: number[
 	}, [ fetchSites ] );
 
 	const syncSitesWithSyncSupportForSelectedSite = useMemo(
-		() => transformSitesResponse( rawSyncSites, memoizedConnectedSiteIds ),
-		[ rawSyncSites, memoizedConnectedSiteIds ]
+		() => transformSitesResponse( rawSyncSites, memoizedConnectedSiteIds, pressableSyncEnabled ),
+		[ rawSyncSites, memoizedConnectedSiteIds, pressableSyncEnabled ]
 	);
 
 	return {

--- a/src/hooks/use-fetch-wpcom-sites/index.tsx
+++ b/src/hooks/use-fetch-wpcom-sites/index.tsx
@@ -61,10 +61,13 @@ function isAtomicSite( site: SitesEndpointSite ): boolean {
 }
 
 function hasSupportedPlan( site: SitesEndpointSite ): boolean {
-	return site.plan?.features.active.includes( STUDIO_SYNC_FEATURE_NAME ) ?? false;
+	return (
+		( isPressableSite( site ) ||
+			site.plan?.features.active.includes( STUDIO_SYNC_FEATURE_NAME ) ) ??
+		false
+	);
 }
 
-<<<<<<< HEAD
 function isJetpackSite( site: SitesEndpointSite ): boolean {
 	return !! site.jetpack && ! isAtomicSite( site ) && ! isPressableSite( site );
 }
@@ -74,31 +77,13 @@ function needsTransfer( site: SitesEndpointSite ): boolean {
 }
 
 function getSyncSupport( site: SitesEndpointSite, connectedSiteIds: number[] ): SyncSupport {
-=======
-function getSyncSupport(
-	site: SitesEndpointSite,
-	connectedSiteIds: number[],
-	pressableSyncEnabled: boolean
-): SyncSupport {
->>>>>>> 03badf57 (Add feature flag to control Pressable site sync support)
 	if ( site.is_deleted ) {
 		return 'deleted';
 	}
 	if ( ! site.capabilities?.manage_options ) {
 		return 'missing-permissions';
 	}
-<<<<<<< HEAD
-<<<<<<< HEAD
 	if ( isJetpackSite( site ) ) {
-=======
-	if ( site.hosting_provider_guess === 'pressable' ) {
-=======
-	if ( pressableSyncEnabled && site.hosting_provider_guess === 'pressable' ) {
->>>>>>> 03badf57 (Add feature flag to control Pressable site sync support)
-		return 'syncable';
-	}
-	if ( isJetpackSite( site ) && ! hasSupportedPlan( site ) ) {
->>>>>>> e7139585 (Add hosting provider check for Pressable sites in wpcom site fetching logic)
 		return 'jetpack-site';
 	}
 	if ( ! hasSupportedPlan( site ) && ! isPressableSite( site ) ) {
@@ -131,11 +116,7 @@ export function transformSingleSiteResponse(
 	};
 }
 
-export function transformSitesResponse(
-	sites: unknown[],
-	connectedSiteIds: number[],
-	pressableSyncEnabled: boolean
-): SyncSite[] {
+export function transformSitesResponse( sites: unknown[], connectedSiteIds: number[] ): SyncSite[] {
 	const validatedSites = sites.reduce< SitesEndpointSite[] >( ( acc, rawSite ) => {
 		try {
 			const site = sitesEndpointSiteSchema.parse( rawSite );
@@ -156,7 +137,7 @@ export function transformSitesResponse(
 			// The API returns the wrong value for the `is_wpcom_staging_site` prop while staging sites
 			// are being created. Hence the check in other sites' `wpcom_staging_blog_ids` arrays.
 			const isStaging = allStagingSiteIds.includes( site.ID );
-			const syncSupport = getSyncSupport( site, connectedSiteIds, pressableSyncEnabled );
+			const syncSupport = getSyncSupport( site, connectedSiteIds );
 
 			return transformSingleSiteResponse( site, syncSupport, isStaging );
 		} );
@@ -201,12 +182,7 @@ export const useFetchWpComSites = ( connectedSiteIdsOnlyForSelectedSite: number[
 					path: `/me/sites`,
 				},
 				{
-<<<<<<< HEAD
 					fields,
-=======
-					fields:
-						'name,ID,URL,plan,capabilities,is_wpcom_atomic,options,jetpack,is_deleted,hosting_provider_guess',
->>>>>>> 3bb3891b (Add `hosting_provider_guess` field to wpcom sites API request)
 					filter: 'atomic,wpcom',
 					options: 'created_at,wpcom_staging_blog_ids',
 					site_activity: 'active',
@@ -216,8 +192,7 @@ export const useFetchWpComSites = ( connectedSiteIdsOnlyForSelectedSite: number[
 			const parsedResponse = sitesEndpointResponseSchema.parse( response );
 			const syncSites = transformSitesResponse(
 				parsedResponse.sites,
-				allConnectedSites.map( ( { id } ) => id ),
-				pressableSyncEnabled
+				allConnectedSites.map( ( { id } ) => id )
 			);
 
 			// whenever array of syncSites changes, we need to update connectedSites to keep them updated with wordpress.com
@@ -261,8 +236,8 @@ export const useFetchWpComSites = ( connectedSiteIdsOnlyForSelectedSite: number[
 	}, [ fetchSites ] );
 
 	const syncSitesWithSyncSupportForSelectedSite = useMemo(
-		() => transformSitesResponse( rawSyncSites, memoizedConnectedSiteIds, pressableSyncEnabled ),
-		[ rawSyncSites, memoizedConnectedSiteIds, pressableSyncEnabled ]
+		() => transformSitesResponse( rawSyncSites, memoizedConnectedSiteIds ),
+		[ rawSyncSites, memoizedConnectedSiteIds ]
 	);
 
 	return {

--- a/src/hooks/use-fetch-wpcom-sites/index.tsx
+++ b/src/hooks/use-fetch-wpcom-sites/index.tsx
@@ -80,10 +80,10 @@ function getSyncSupport( site: SitesEndpointSite, connectedSiteIds: number[] ): 
 		return 'missing-permissions';
 	}
 	if ( isJetpackSite( site ) ) {
-		return 'jetpack-site';
+		return 'unsupported';
 	}
 	if ( ! hasSupportedPlan( site ) && ! isPressableSite( site ) ) {
-		return 'unsupported';
+		return 'needs-upgrade';
 	}
 	if ( needsTransfer( site ) ) {
 		return 'needs-transfer';

--- a/src/hooks/use-fetch-wpcom-sites/types.ts
+++ b/src/hooks/use-fetch-wpcom-sites/types.ts
@@ -3,7 +3,7 @@ export type SyncSupport =
 	| 'syncable'
 	| 'needs-transfer'
 	| 'already-connected'
-	| 'jetpack-site'
+	| 'needs-upgrade'
 	| 'deleted'
 	| 'missing-permissions';
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Related to https://github.com/Automattic/studio/pull/1212.

## Proposed Changes

While working on https://github.com/Automattic/studio/pull/1212 I noticed we could improve the sync statuses to make them less confusing and relevant to what they actually mean:

- replace `unsupported` sync status with `needs-upgrade`
- replace  `jetpack-site` sync status with `unsupported`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Ensure you have some Jurassic Ninja sites connected to your WordPress.com account which you are using in Studio as well.
2. Ensure you also have some Simple sites without a Business plan or higher.
3. Check out the PR branch and build the app with `npm start`.
4. Head over to the Sync tab on any local Studio site and click on the Connect site button.
5. Search for your Jurassic Ninja and Simple sites.
6. Jurassic Ninja sites should still be marked as "Unsupported site" and Simple site should still be marked as "Upgrade plan".

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
