### PR TITLE
Limit the site server child process memory to 128MB

### DIFF
--- a/src/lib/site-server-process-child.ts
+++ b/src/lib/site-server-process-child.ts
@@ -17,6 +17,9 @@ if ( process.env.STUDIO_APP_LOGS_PATH ) {
 }
 
 const options = JSON.parse( process.argv[ 2 ] ) as WPNowOptions;
+console.log( 'Process memory limit:', process.argv, process.execArgv );
+console.log( 'Heap limits:', require( 'v8' ).getHeapStatistics() );
+
 let server: WPNowServer;
 
 const handlers: Handlers = {

--- a/src/lib/site-server-process.ts
+++ b/src/lib/site-server-process.ts
@@ -50,6 +50,7 @@ export default class SiteServerProcess {
 				}
 			};
 
+			const ramSize = 128;
 			this.process = utilityProcess
 				.fork( SITE_SERVER_PROCESS_MODULE_PATH, [ JSON.stringify( this.options ) ], {
 					serviceName: 'studio-site-server',
@@ -60,6 +61,9 @@ export default class SiteServerProcess {
 						STUDIO_APP_DATA_PATH: app.getPath( 'appData' ),
 						STUDIO_APP_LOGS_PATH: app.getPath( 'logs' ),
 					},
+					execArgv: [
+						`--js-flags="--max-old-space-size=${ ramSize } --max-heap-size=${ ramSize }"`,
+					],
 				} )
 				.on( 'spawn', spawnListener )
 				.on( 'exit', exitListener );


### PR DESCRIPTION
🚧 WIP I'm using this PR create Windows builds and test how limiting the amount of memory affects Studio performence.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Proposed Changes

- Limit the amount of memory used by WP-now to 128MB

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- CI

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
