### PR TITLE
Studio: Polish User Settings Modal design

### DIFF
--- a/src/modules/user-settings/components/editor-picker.tsx
+++ b/src/modules/user-settings/components/editor-picker.tsx
@@ -42,7 +42,7 @@ export const EditorPicker = ( { value, onChange }: EditorPickerProps ) => {
 
 	return (
 		<div className="flex gap-1.5 flex-col">
-			<h2 className="a8c-subtitle-small">{ __( 'Code editor' ) }</h2>
+			<label className="font-semibold">{ __( 'Code editor' ) }</label>
 			<SelectControl
 				value={ value }
 				onChange={ ( newValue ) => onChange( newValue as SupportedEditor ) }

--- a/src/modules/user-settings/components/editor-picker.tsx
+++ b/src/modules/user-settings/components/editor-picker.tsx
@@ -49,13 +49,11 @@ export const EditorPicker = ( { value, onChange }: EditorPickerProps ) => {
 				__nextHasNoMarginBottom
 				__next40pxDefaultSize
 			>
-				<optgroup label={ __( 'Installed' ) }>
-					{ installedEditors.map( ( [ editor, label ] ) => (
-						<option key={ editor } value={ editor }>
-							{ label }
-						</option>
-					) ) }
-				</optgroup>
+				{ installedEditors.map( ( [ editor, label ] ) => (
+					<option key={ editor } value={ editor }>
+						{ label }
+					</option>
+				) ) }
 				<optgroup label={ __( 'Not installed' ) }>
 					{ uninstalledEditors.map( ( [ editor, label ] ) => (
 						<option key={ editor } value={ editor } disabled>

--- a/src/modules/user-settings/components/editor-picker.tsx
+++ b/src/modules/user-settings/components/editor-picker.tsx
@@ -3,6 +3,7 @@ import { useI18n } from '@wordpress/react-i18n';
 import { useEffect, useState } from 'react';
 import { SupportedEditor, supportedEditorNames } from 'src/lib/editor';
 import { getIpcApi } from 'src/lib/get-ipc-api';
+import { SettingsFormField } from './settings-form-field';
 
 interface EditorPickerProps {
 	value: SupportedEditor;
@@ -41,8 +42,7 @@ export const EditorPicker = ( { value, onChange }: EditorPickerProps ) => {
 	);
 
 	return (
-		<div className="flex gap-1.5 flex-col">
-			<label className="font-semibold">{ __( 'Code editor' ) }</label>
+		<SettingsFormField label={ __( 'Code editor' ) }>
 			<SelectControl
 				value={ value }
 				onChange={ ( newValue ) => onChange( newValue as SupportedEditor ) }
@@ -64,6 +64,6 @@ export const EditorPicker = ( { value, onChange }: EditorPickerProps ) => {
 					) ) }
 				</optgroup>
 			</SelectControl>
-		</div>
+		</SettingsFormField>
 	);
 };

--- a/src/modules/user-settings/components/editor-picker.tsx
+++ b/src/modules/user-settings/components/editor-picker.tsx
@@ -41,13 +41,13 @@ export const EditorPicker = ( { value, onChange }: EditorPickerProps ) => {
 	);
 
 	return (
-		<div className="flex gap-5 flex-col">
-			<h2 className="a8c-subtitle-small">{ __( 'Code Editor' ) }</h2>
+		<div className="flex gap-1.5 flex-col">
+			<h2 className="a8c-subtitle-small">{ __( 'Code editor' ) }</h2>
 			<SelectControl
 				value={ value }
 				onChange={ ( newValue ) => onChange( newValue as SupportedEditor ) }
 				__nextHasNoMarginBottom
-				className="mb-2"
+				__next40pxDefaultSize
 			>
 				<optgroup label={ __( 'Installed' ) }>
 					{ installedEditors.map( ( [ editor, label ] ) => (

--- a/src/modules/user-settings/components/language-picker.tsx
+++ b/src/modules/user-settings/components/language-picker.tsx
@@ -11,7 +11,7 @@ export const LanguagePicker = ( { value, onChange }: LanguagePickerProps ) => {
 	const { __ } = useI18n();
 	return (
 		<div className="flex gap-1.5 flex-col">
-			<h2 className="a8c-subtitle-small">{ __( 'Language' ) }</h2>
+			<label className="font-semibold">{ __( 'Language' ) }</label>
 			<SelectControl
 				value={ value || 'en' }
 				onChange={ onChange }

--- a/src/modules/user-settings/components/language-picker.tsx
+++ b/src/modules/user-settings/components/language-picker.tsx
@@ -10,7 +10,7 @@ interface LanguagePickerProps {
 export const LanguagePicker = ( { value, onChange }: LanguagePickerProps ) => {
 	const { __ } = useI18n();
 	return (
-		<div className="flex gap-5 flex-col">
+		<div className="flex gap-1.5 flex-col">
 			<h2 className="a8c-subtitle-small">{ __( 'Language' ) }</h2>
 			<SelectControl
 				value={ value || 'en' }
@@ -20,7 +20,7 @@ export const LanguagePicker = ( { value, onChange }: LanguagePickerProps ) => {
 					label,
 				} ) ) }
 				__nextHasNoMarginBottom
-				className="mb-2"
+				__next40pxDefaultSize
 			/>
 		</div>
 	);

--- a/src/modules/user-settings/components/language-picker.tsx
+++ b/src/modules/user-settings/components/language-picker.tsx
@@ -1,6 +1,7 @@
 import { SelectControl } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
 import { SupportedLocale, supportedLocaleNames } from 'common/lib/locale';
+import { SettingsFormField } from './settings-form-field';
 
 interface LanguagePickerProps {
 	value: SupportedLocale;
@@ -10,8 +11,7 @@ interface LanguagePickerProps {
 export const LanguagePicker = ( { value, onChange }: LanguagePickerProps ) => {
 	const { __ } = useI18n();
 	return (
-		<div className="flex gap-1.5 flex-col">
-			<label className="font-semibold">{ __( 'Language' ) }</label>
+		<SettingsFormField label={ __( 'Language' ) }>
 			<SelectControl
 				value={ value || 'en' }
 				onChange={ onChange }
@@ -22,6 +22,6 @@ export const LanguagePicker = ( { value, onChange }: LanguagePickerProps ) => {
 				__nextHasNoMarginBottom
 				__next40pxDefaultSize
 			/>
-		</div>
+		</SettingsFormField>
 	);
 };

--- a/src/modules/user-settings/components/preferences-tab.tsx
+++ b/src/modules/user-settings/components/preferences-tab.tsx
@@ -49,7 +49,7 @@ export const PreferencesTab = ( { onClose }: { onClose: () => void } ) => {
 				onChange={ handleTerminalChange }
 				availableTerminals={ availableTerminals }
 			/>
-			<div className="mt-auto pt-6 flex justify-end gap-3">
+			<div className="mt-auto pt-2 flex justify-end gap-3">
 				<Button variant="tertiary" onClick={ cancelChanges }>
 					{ __( 'Cancel' ) }
 				</Button>

--- a/src/modules/user-settings/components/settings-form-field.tsx
+++ b/src/modules/user-settings/components/settings-form-field.tsx
@@ -1,0 +1,11 @@
+interface SettingsFormFieldProps {
+	label: string;
+	children: React.ReactNode;
+}
+
+export const SettingsFormField = ( { label, children }: SettingsFormFieldProps ) => (
+	<div className="flex gap-1.5 flex-col">
+		<label className="font-semibold">{ label }</label>
+		{ children }
+	</div>
+);

--- a/src/modules/user-settings/components/terminal-picker.tsx
+++ b/src/modules/user-settings/components/terminal-picker.tsx
@@ -1,6 +1,7 @@
 import { SelectControl } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
 import { SupportedTerminal, supportedTerminalNames } from 'src/lib/terminal';
+import { SettingsFormField } from './settings-form-field';
 
 interface TerminalPickerProps {
 	value: SupportedTerminal;
@@ -27,8 +28,7 @@ export const TerminalPicker = ( {
 	} );
 
 	return (
-		<div className="flex gap-1.5 flex-col">
-			<label className="font-semibold">{ __( 'Shell' ) }</label>
+		<SettingsFormField label={ __( 'Shell' ) }>
 			<SelectControl
 				value={ value }
 				onChange={ onChange }
@@ -36,6 +36,6 @@ export const TerminalPicker = ( {
 				__nextHasNoMarginBottom
 				__next40pxDefaultSize
 			/>
-		</div>
+		</SettingsFormField>
 	);
 };

--- a/src/modules/user-settings/components/terminal-picker.tsx
+++ b/src/modules/user-settings/components/terminal-picker.tsx
@@ -28,7 +28,7 @@ export const TerminalPicker = ( {
 
 	return (
 		<div className="flex gap-1.5 flex-col">
-			<h2 className="a8c-subtitle-small">{ __( 'Shell' ) }</h2>
+			<label className="font-semibold">{ __( 'Shell' ) }</label>
 			<SelectControl
 				value={ value }
 				onChange={ onChange }

--- a/src/modules/user-settings/components/terminal-picker.tsx
+++ b/src/modules/user-settings/components/terminal-picker.tsx
@@ -27,14 +27,14 @@ export const TerminalPicker = ( {
 	} );
 
 	return (
-		<div className="flex gap-5 flex-col">
+		<div className="flex gap-1.5 flex-col">
 			<h2 className="a8c-subtitle-small">{ __( 'Shell' ) }</h2>
 			<SelectControl
 				value={ value }
 				onChange={ onChange }
 				options={ options }
 				__nextHasNoMarginBottom
-				className="mb-2"
+				__next40pxDefaultSize
 			/>
 		</div>
 	);

--- a/src/modules/user-settings/components/user-settings.tsx
+++ b/src/modules/user-settings/components/user-settings.tsx
@@ -156,7 +156,7 @@ export default function UserSettings() {
 				>
 					<TabPanel className="w-full" tabs={ tabs } orientation="horizontal">
 						{ ( { name } ) => (
-							<div className="mt-6 px-8 flex flex-col gap-6">
+							<div className="mt-6 px-8 flex gap-4 flex-col">
 								{ name === 'account' &&
 									( isAuthenticated ? (
 										<AccountTab user={ user } logout={ logout } />

--- a/src/modules/user-settings/components/user-settings.tsx
+++ b/src/modules/user-settings/components/user-settings.tsx
@@ -148,11 +148,7 @@ export default function UserSettings() {
 					isDismissible
 					onRequestClose={ resetLocalState }
 					size="medium"
-					className={ cx(
-						'min-h-[350px]',
-						'[&_[role="document"]]:px-0',
-						'[&_[role="document"]]:mt-[64px]'
-					) }
+					className={ cx( 'min-h-[350px]', '[&_[role="document"]]:px-0' ) }
 				>
 					<TabPanel className="w-full" tabs={ tabs } orientation="horizontal">
 						{ ( { name } ) => (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-374

## Proposed Changes

- Update gaps between label and select control
- Update select components to use __next40pxDefaultSize to match with rest of the designs
- Update string case of "Code Editor" -> "Code editor". 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Check out this branch
- Run `STUDIO_PREFERRED_EDITOR=true npm start`
- Compare the rendered layout with the Figma designs added below. 

| Trunk | Branch | Figma |
|--------|--------|--------|
| ![CleanShot 2025-04-21 at 15 24 46@2x](https://github.com/user-attachments/assets/f51e462a-b71c-408c-a6a9-a7297a4f75d1) | ![CleanShot 2025-04-21 at 15 23 22@2x](https://github.com/user-attachments/assets/7b51a99a-1e0b-4120-83fe-ae42c9ba625c) | ![CleanShot 2025-04-21 at 15 27 40@2x](https://github.com/user-attachments/assets/a705a175-e599-4faa-86f0-0b633209d342) |


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
