### PR TITLE
Studio: Check if port is open before starting servers

### DIFF
--- a/src/hooks/use-site-details.tsx
+++ b/src/hooks/use-site-details.tsx
@@ -302,7 +302,7 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 						message: __(
 							`The site server failed to start because the port is already in use. Please close any local development apps that may be using port ${ port } and try again.`
 						),
-						showOpenLogs: true,
+						showOpenLogs: false,
 					} );
 				} else {
 					getIpcApi().showErrorMessageBox( {

--- a/src/hooks/use-site-details.tsx
+++ b/src/hooks/use-site-details.tsx
@@ -295,6 +295,15 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 						),
 						showOpenLogs: true,
 					} );
+				} else if ( error instanceof Error && error.message.includes( 'ERROR_PORT_IN_USE' ) ) {
+					const port = error.message.match( /\d+/ );
+					getIpcApi().showErrorMessageBox( {
+						title: __( 'Failed to start the site server' ),
+						message: __(
+							`The site server failed to start because the port is already in use. Please close any local development apps that may be using port ${ port } and try again.`
+						),
+						showOpenLogs: true,
+					} );
 				} else {
 					getIpcApi().showErrorMessageBox( {
 						title: __( 'Failed to start the site server' ),

--- a/src/lib/port-finder.ts
+++ b/src/lib/port-finder.ts
@@ -1,4 +1,5 @@
 import http from 'http';
+import net from 'net';
 import killPort from 'cross-port-killer';
 
 const DEFAULT_PORT = 8881;
@@ -26,16 +27,28 @@ class PortFinder {
 
 	#isPortFree(): Promise< boolean > {
 		return new Promise( ( resolve ) => {
-			const server = http.createServer();
+			// First try to connect to the port
+			const socket = new net.Socket();
+			socket.on( 'error', () => {
+				// If we can't connect, try to bind to the port
+				const server = http.createServer();
+				server
+					.listen( this.#searchPort, () => {
+						server.close();
+						setTimeout( () => {
+							resolve( true );
+						}, 50 ); // Add a small delay to ensure port is released
+					} )
+					.on( 'error', () => {
+						resolve( false );
+					} );
+			} );
 
-			server
-				.listen( this.#searchPort, () => {
-					server.close();
-					resolve( true );
-				} )
-				.on( 'error', () => {
-					resolve( false );
-				} );
+			// Try to connect to the port
+			socket.connect( this.#searchPort, 'localhost', () => {
+				socket.destroy();
+				resolve( false );
+			} );
 		} );
 	}
 
@@ -92,6 +105,20 @@ class PortFinder {
 					this.#openPort = DEFAULT_PORT;
 				} );
 		}
+	}
+
+	/**
+	 * Checks if a specific port is available.
+	 *
+	 * @param {number} port - The port number to check.
+	 * @returns {Promise<boolean>} A promise that resolves to true if the port is available, false otherwise.
+	 **/
+	public async isPortAvailable( port: number ): Promise< boolean > {
+		const localPort = this.#searchPort;
+		this.#searchPort = port;
+		const result = await this.#isPortFree();
+		this.#searchPort = localPort;
+		return result;
 	}
 }
 

--- a/src/lib/port-finder.ts
+++ b/src/lib/port-finder.ts
@@ -25,7 +25,7 @@ class PortFinder {
 		return ++this.#searchPort;
 	}
 
-	#isPortFree(): Promise< boolean > {
+	#isPortFree( portToCheck: number ): Promise< boolean > {
 		return new Promise( ( resolve ) => {
 			// First try to connect to the port
 			const socket = new net.Socket();
@@ -33,7 +33,7 @@ class PortFinder {
 				// If we can't connect, try to bind to the port
 				const server = http.createServer();
 				server
-					.listen( this.#searchPort, () => {
+					.listen( portToCheck, () => {
 						server.close();
 						setTimeout( () => {
 							resolve( true );
@@ -45,7 +45,7 @@ class PortFinder {
 			} );
 
 			// Try to connect to the port
-			socket.connect( this.#searchPort, 'localhost', () => {
+			socket.connect( portToCheck, 'localhost', () => {
 				socket.destroy();
 				resolve( false );
 			} );
@@ -59,14 +59,15 @@ class PortFinder {
 	 */
 	public async getOpenPort( portToStart?: number ): Promise< number > {
 		this.#searchPort = portToStart ? portToStart : this.#openPort ?? DEFAULT_PORT;
-		if ( portToStart && ( await this.#isPortFree() ) ) {
+
+		if ( portToStart && ( await this.#isPortFree( this.#searchPort ) ) ) {
 			const port = this.#searchPort;
 			this.#openPort = this.#incrementPort();
 			return port;
 		}
 		let isPortUnavailable = this.#unavailablePorts?.includes( this.#searchPort );
 
-		while ( isPortUnavailable || ! ( await this.#isPortFree() ) ) {
+		while ( isPortUnavailable || ! ( await this.#isPortFree( this.#searchPort ) ) ) {
 			this.#incrementPort();
 			isPortUnavailable = this.#unavailablePorts?.includes( this.#searchPort );
 		}
@@ -110,15 +111,11 @@ class PortFinder {
 	/**
 	 * Checks if a specific port is available.
 	 *
-	 * @param {number} port - The port number to check.
+	 * @param {number} portToCheck - The port number to check.
 	 * @returns {Promise<boolean>} A promise that resolves to true if the port is available, false otherwise.
 	 **/
-	public async isPortAvailable( port: number ): Promise< boolean > {
-		const localPort = this.#searchPort;
-		this.#searchPort = port;
-		const result = await this.#isPortFree();
-		this.#searchPort = localPort;
-		return result;
+	public async isPortAvailable( portToCheck: number ): Promise< boolean > {
+		return await this.#isPortFree( portToCheck );
 	}
 }
 

--- a/src/site-server.ts
+++ b/src/site-server.ts
@@ -162,6 +162,13 @@ export class SiteServer {
 			);
 		}
 
+		const isPortAvailable = await portFinder.isPortAvailable( this.details.port );
+		if ( ! isPortAvailable ) {
+			throw new Error(
+				`Port ${ this.details.port } is not available. error code: ERROR_PORT_IN_USE`
+			);
+		}
+
 		console.log( `Starting server for '${ this.details.name }'` );
 		this.server = new SiteServerProcess( options );
 		await this.server.start();


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-103

## Proposed Changes

- Added port availability checking before starting servers
- Improved error handling for busy ports

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Check out this branch and run `npm start`
- Start the server for your site and confirm that the server starts normally. 
- Note the port number. e.g. 8881 and stop the server. 
- Open a new terminal and run `php -S localhost:{PORT_NUMBER}`. e.g. `php -S localhost:8881`
- Come back to the studio and try to start the server. It should show the following alert:

![CleanShot 2025-04-22 at 10 24 46@2x](https://github.com/user-attachments/assets/6ee5ed21-8530-4504-961b-622db08f90ab)

- Confirm that the site running status returns to normal and shows the `Start` button. 
- Go back to the terminal where you started `php -S localhost:8881`, press cmd + c to terminate the server. This would free up port 8881. 
- Come back to the studio and start the server.
- Confirm the site server started without any problem, and you can browse your test site. 

### Bonus Test
- Open your `appdata-v1.json` (cat "~/Library/Application Support/Studio/appdata-v1.json")
- Look at the `sites` key, note down the highest occupied port number. For example, in my case it's `8883`. 
- Add 1 to that port number. So becomes `8884`
- Open a new terminal session and run `php -S localhost:8884`
- Come back to the studio and add a new site. 
- Check the port number for the new site; it should be 8885. When creating the site, port 8884 was busy, so Studio skipped it and chose the next available port. If 8885 is also busy, the port finder will increment by 1 to find the next available port. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
