### PR TITLE
Fix optimistic updates for preview site counter

### DIFF
--- a/src/ipc-utils.ts
+++ b/src/ipc-utils.ts
@@ -22,6 +22,7 @@ export interface IpcEvents {
 	'on-export': [ ImportExportEventData, string ];
 	'on-import': [ ImportExportEventData, string ];
 	'snapshot-error': [ { operationId: crypto.UUID; data: SnapshotEventData } ];
+	'snapshot-fatal-error': [ { operationId: crypto.UUID; data: { message: string } } ];
 	'snapshot-output': [ { operationId: crypto.UUID; data: SnapshotEventData } ];
 	'snapshot-key-value': [ { operationId: crypto.UUID; data: SnapshotKeyValueEventData } ];
 	'snapshot-success': [ { operationId: crypto.UUID } ];

--- a/src/modules/cli/lib/execute-command.ts
+++ b/src/modules/cli/lib/execute-command.ts
@@ -4,6 +4,30 @@ import path from 'node:path';
 import * as Sentry from '@sentry/electron/main';
 import { getResourcesPath } from 'src/storage/paths';
 
+type CliCommandEventMap = {
+	data: { data: unknown };
+	error: { error: unknown };
+	'fatal-error': { error: Error };
+	success: void;
+	failure: void;
+};
+
+class CliCommandEventEmitter extends EventEmitter {
+	on< K extends keyof CliCommandEventMap >(
+		event: K,
+		listener: ( payload: CliCommandEventMap[ K ] ) => void
+	): this {
+		return super.on( event, listener );
+	}
+
+	emit< K extends keyof CliCommandEventMap >(
+		event: K,
+		payload?: CliCommandEventMap[ K ]
+	): boolean {
+		return super.emit( event, payload );
+	}
+}
+
 function* parseOutput( data: Buffer ): Generator< unknown, void, unknown > {
 	const output = data.toString( 'utf8' );
 
@@ -20,7 +44,7 @@ function* parseOutput( data: Buffer ): Generator< unknown, void, unknown > {
 	}
 }
 
-export function executeCliCommand( args: string[] ) {
+export function executeCliCommand( args: string[] ): CliCommandEventEmitter {
 	const cliPath =
 		process.env.NODE_ENV === 'development'
 			? path.join( getResourcesPath(), 'dist', 'cli', 'main.js' )
@@ -29,32 +53,32 @@ export function executeCliCommand( args: string[] ) {
 	const child = fork( cliPath, [ ...args, '--output-format', 'json' ], {
 		stdio: 'pipe',
 	} );
-	const eventEmitter = new EventEmitter();
+	const eventEmitter = new CliCommandEventEmitter();
 
 	child.stdout?.on( 'data', ( data: Buffer ) => {
 		for ( const parsed of parseOutput( data ) ) {
-			eventEmitter.emit( 'data', parsed );
+			eventEmitter.emit( 'data', { data: parsed } );
 		}
 	} );
 
 	child.stderr?.on( 'data', ( data: Buffer ) => {
 		for ( const parsed of parseOutput( data ) ) {
 			Sentry.captureException( parsed );
-			eventEmitter.emit( 'error', parsed );
+			eventEmitter.emit( 'error', { error: parsed } );
 		}
 	} );
 
 	child.on( 'error', ( error ) => {
 		console.error( 'Child process error:', error );
 		Sentry.captureException( error );
-		eventEmitter.emit( 'error', error );
+		eventEmitter.emit( 'fatal-error', { error } );
 	} );
 
 	child.on( 'exit', ( code: number | null ) => {
 		if ( code === 0 ) {
 			eventEmitter.emit( 'success' );
 		} else {
-			eventEmitter.emit( 'error', { code, message: `Process exited with code ${ code }` } );
+			eventEmitter.emit( 'failure' );
 		}
 	} );
 

--- a/src/modules/cli/lib/execute-preview-command.ts
+++ b/src/modules/cli/lib/execute-preview-command.ts
@@ -38,7 +38,7 @@ export async function executePreviewCliCommand(
 	const operationId = crypto.randomUUID();
 	const cliEventEmitter = executeCliCommand( args );
 
-	cliEventEmitter.on( 'data', ( data: unknown ) => {
+	cliEventEmitter.on( 'data', ( { data } ) => {
 		const parsed = parseSnapshotEventData( data, createSnapshotStdoutSchema );
 
 		if ( ! parsed ) {
@@ -58,8 +58,8 @@ export async function executePreviewCliCommand(
 		}
 	} );
 
-	cliEventEmitter.on( 'error', ( data: unknown ) => {
-		const parsed = parseSnapshotEventData( data, snapshotEventSchema );
+	cliEventEmitter.on( 'error', ( { error } ) => {
+		const parsed = parseSnapshotEventData( error, snapshotEventSchema );
 
 		if ( parsed ) {
 			sendIpcEventToRendererWithWindow( parentWindow, 'snapshot-error', {
@@ -67,6 +67,13 @@ export async function executePreviewCliCommand(
 				data: parsed,
 			} );
 		}
+	} );
+
+	cliEventEmitter.on( 'fatal-error', ( { error } ) => {
+		sendIpcEventToRendererWithWindow( parentWindow, 'snapshot-fatal-error', {
+			operationId,
+			data: { message: error.message },
+		} );
 	} );
 
 	cliEventEmitter.on( 'success', () => {

--- a/src/modules/preview-site/components/preview-site-row.tsx
+++ b/src/modules/preview-site/components/preview-site-row.tsx
@@ -42,14 +42,16 @@ export function PreviewSiteRow( {
 	const deleteOperation = useRootSelector( ( state ) =>
 		snapshotSelectors.selectDeleteOperationForSnapshot( state, snapshot.url )
 	);
-	const isPreviewSiteUpdating = updateOperation?.status === 'pending';
-	const hasError = updateOperation?.status === 'rejected';
 	const { formatRelativeTime } = useFormatLocalizedTimestamps();
 	const [ showUpdatedMessage, setShowUpdatedMessage ] = useState( false );
 	const wasUpdating = useRef( false );
 
 	useEffect( () => {
-		if ( isPreviewSiteUpdating ) {
+		if ( ! updateOperation ) {
+			return;
+		}
+
+		if ( updateOperation.status === 'pending' ) {
 			wasUpdating.current = true;
 			setShowUpdatedMessage( false );
 			return;
@@ -60,7 +62,7 @@ export function PreviewSiteRow( {
 		}
 		wasUpdating.current = false;
 
-		if ( ! hasError ) {
+		if ( updateOperation.status === 'fulfilled' ) {
 			setShowUpdatedMessage( true );
 		}
 
@@ -69,7 +71,7 @@ export function PreviewSiteRow( {
 		}, UPDATED_MESSAGE_DURATION_MS );
 
 		return () => clearTimeout( timeoutId );
-	}, [ hasError, isPreviewSiteUpdating ] );
+	}, [ updateOperation ] );
 
 	const getLastUpdateTimeText = () => {
 		if ( ! date ) {
@@ -85,7 +87,7 @@ export function PreviewSiteRow( {
 			);
 		}
 
-		if ( hasError ) {
+		if ( updateOperation?.status === 'rejected' ) {
 			return (
 				<div className="flex items-center">
 					<Icon icon={ warning } className="!mt-0 mr-1 fill-a8c-red-50" />
@@ -100,7 +102,7 @@ export function PreviewSiteRow( {
 
 	const urlWithHTTPS = `https://${ url }`;
 
-	if ( deleteOperation ) {
+	if ( deleteOperation?.status === 'pending' ) {
 		return <DeleteProgressRow />;
 	}
 
@@ -136,7 +138,7 @@ export function PreviewSiteRow( {
 				</div>
 				<div className="flex ltr:ml-auto rtl:mr-auto">
 					<div className="w-[150px] text-a8c-gray-700 flex items-center pl-4">
-						{ isPreviewSiteUpdating ? (
+						{ updateOperation?.status === 'pending' ? (
 							<div className="flex items-center text-gray-900">
 								<Spinner className="!mt-0 !mx-2" />
 								{ __( 'Updating' ) }

--- a/src/modules/user-settings/components/user-settings.tsx
+++ b/src/modules/user-settings/components/user-settings.tsx
@@ -27,7 +27,9 @@ export default function UserSettings() {
 	const { preferredEditor } = useFeatureFlags();
 	const { locale: savedLocale, setLocale: setSavedLocale } = useI18nData();
 
-	const [ isDeletingAllSnapshots, setIsDeletingAllSnapshots ] = useState( false );
+	const activeBulkOperationForUser = useRootSelector( ( state ) =>
+		snapshotSelectors.selectActiveBulkOperationForUser( state, user?.id ?? 0 )
+	);
 	const snapshotsByUser = useRootSelector( ( state ) =>
 		snapshotSelectors.selectSnapshotsByUser( state, user?.id ?? 0 )
 	);
@@ -62,9 +64,7 @@ export default function UserSettings() {
 		} );
 
 		if ( response === DELETE_BUTTON_INDEX ) {
-			setIsDeletingAllSnapshots( true );
 			await dispatch( snapshotThunks.deleteAllSnapshotsForUser( { userId: user?.id ?? 0 } ) );
-			setIsDeletingAllSnapshots( false );
 		}
 	}, [ __, dispatch, user?.id ] );
 
@@ -87,10 +87,10 @@ export default function UserSettings() {
 								<div className="flex flex-col gap-6">
 									<LanguagePicker value={ savedLocale } onChange={ setSavedLocale } />
 									<SnapshotInfo
-										isDeleting={ isDeletingAllSnapshots }
+										isDeleting={ !! activeBulkOperationForUser }
 										isDisabled={
 											definitiveSnapshotCount === 0 ||
-											isDeletingAllSnapshots ||
+											!! activeBulkOperationForUser ||
 											isLoadingSnapshotUsage ||
 											isOffline
 										}
@@ -153,7 +153,7 @@ export default function UserSettings() {
 								{ name === 'preferences' && <PreferencesTab onClose={ resetLocalState } /> }
 								{ name === 'usage' && isAuthenticated && (
 									<UsageTab
-										loadingDeletingAllSnapshots={ isDeletingAllSnapshots }
+										loadingDeletingAllSnapshots={ !! activeBulkOperationForUser }
 										activeSnapshotCount={ definitiveSnapshotCount }
 										isLoadingSnapshotUsage={ isLoadingSnapshotUsage }
 										allSnapshots={ snapshotsByUser }

--- a/src/stores/snapshot-slice.ts
+++ b/src/stores/snapshot-slice.ts
@@ -391,6 +391,11 @@ window.ipcListener.subscribe( 'snapshot-error', ( event, payload ) => {
 			title: __( 'Updating preview site failed' ),
 			message: payload.data.message,
 		} );
+	} else if ( operation.type === 'delete' ) {
+		getIpcApi().showErrorMessageBox( {
+			title: __( 'Deleting preview site failed' ),
+			message: payload.data.message,
+		} );
 	}
 
 	store.dispatch(

--- a/src/stores/snapshot-slice.ts
+++ b/src/stores/snapshot-slice.ts
@@ -38,9 +38,11 @@ type DeleteOperation = BaseOperation & {
 	type: 'delete';
 };
 
-type BulkOperation = BaseOperation & {
+type BulkOperation = Omit< BaseOperation, 'progress' > & {
 	operationIds: crypto.UUID[];
+	siteId?: string;
 	type: 'bulk';
+	userId?: number;
 };
 
 export type SnapshotOperation = CreateOperation | UpdateOperation | DeleteOperation | BulkOperation;
@@ -200,13 +202,20 @@ const snapshotSlice = createSlice( {
 			.addMatcher(
 				isAnyOf( deleteAllSnapshotsForSite.fulfilled, deleteAllSnapshotsForUser.fulfilled ),
 				( state, action ) => {
-					state.operations[ action.payload.bulkOperationId ] = {
+					const bulkOperation: BulkOperation = {
 						error: null,
 						operationIds: action.payload.operations.map( ( [ _, operationId ] ) => operationId ),
-						progress: 0,
 						status: 'pending',
 						type: 'bulk',
 					};
+
+					if ( 'siteId' in action.meta.arg ) {
+						bulkOperation.siteId = action.meta.arg.siteId;
+					} else if ( 'userId' in action.meta.arg ) {
+						bulkOperation.userId = action.meta.arg.userId;
+					}
+
+					state.operations[ action.payload.bulkOperationId ] = bulkOperation;
 
 					action.payload.operations.forEach( ( [ url, operationId ] ) => {
 						state.operations[ operationId ] = {
@@ -221,6 +230,11 @@ const snapshotSlice = createSlice( {
 			);
 	},
 	selectors: {
+		selectActiveBulkOperationForUser: ( state, userId: number ): BulkOperation | undefined =>
+			Object.values( state.operations ).find(
+				( operation ): operation is BulkOperation =>
+					operation.status === 'pending' && operation.type === 'bulk' && operation.userId === userId
+			),
 		selectActiveCreateOperationForSite: ( state, siteId: string ): CreateOperation | undefined =>
 			Object.values( state.operations ).find(
 				( operation ): operation is CreateOperation =>

--- a/src/stores/snapshot-slice.ts
+++ b/src/stores/snapshot-slice.ts
@@ -375,35 +375,43 @@ window.ipcListener.subscribe( 'snapshot-key-value', ( event, payload ) => {
 	);
 } );
 
-window.ipcListener.subscribe( 'snapshot-error', ( event, payload ) => {
-	const operation = getOperation( payload.operationId );
-	if ( ! operation ) {
+function errorEventHandler( operationId: crypto.UUID, message: string ) {
+	const operation = getOperation( operationId );
+	if ( ! operation || operation.status !== 'pending' ) {
 		return;
 	}
 
 	if ( operation.type === 'create' ) {
 		getIpcApi().showErrorMessageBox( {
 			title: __( 'Adding preview site failed' ),
-			message: payload.data.message,
+			message: message,
 		} );
 	} else if ( operation.type === 'update' ) {
 		getIpcApi().showErrorMessageBox( {
 			title: __( 'Updating preview site failed' ),
-			message: payload.data.message,
+			message: message,
 		} );
 	} else if ( operation.type === 'delete' ) {
 		getIpcApi().showErrorMessageBox( {
 			title: __( 'Deleting preview site failed' ),
-			message: payload.data.message,
+			message: message,
 		} );
 	}
 
 	store.dispatch(
 		snapshotActions.updateOperation( {
-			operationId: payload.operationId,
-			operation: { status: 'rejected', error: payload.data.message },
+			operationId: operationId,
+			operation: { status: 'rejected', error: message },
 		} )
 	);
+}
+
+window.ipcListener.subscribe( 'snapshot-error', ( event, payload ) => {
+	errorEventHandler( payload.operationId, payload.data.message );
+} );
+
+window.ipcListener.subscribe( 'snapshot-fatal-error', ( event, payload ) => {
+	errorEventHandler( payload.operationId, payload.data.message );
 } );
 
 window.ipcListener.subscribe( 'snapshot-success', ( event, payload ) => {

--- a/src/stores/snapshot-slice.ts
+++ b/src/stores/snapshot-slice.ts
@@ -415,28 +415,28 @@ window.ipcListener.subscribe( 'snapshot-success', ( event, payload ) => {
 	}
 
 	if ( operation.type === 'create' ) {
-		getIpcApi().showNotification( {
-			title: operation.snapshotName,
-			body: sprintf( __( "Preview site '%s' has been created." ), operation.snapshotUrl ),
-		} );
-
 		store.dispatch(
 			wpcomApi.util.updateQueryData( 'getSnapshotUsage', undefined, ( data ) => {
 				data.siteCount += 1;
 			} )
 		);
+
+		getIpcApi().showNotification( {
+			title: operation.snapshotName,
+			body: sprintf( __( "Preview site '%s' has been created." ), operation.snapshotUrl ),
+		} );
 	} else if ( operation.type === 'update' ) {
 		getIpcApi().showNotification( {
 			title: operation.snapshotName,
 			body: sprintf( __( "Preview site '%s' has been updated." ), operation.snapshotUrl ),
 		} );
-
+	} else if ( operation.type === 'delete' ) {
 		store.dispatch(
 			wpcomApi.util.updateQueryData( 'getSnapshotUsage', undefined, ( data ) => {
 				data.siteCount -= 1;
 			} )
 		);
-	} else if ( operation.type === 'delete' ) {
+
 		if ( ! bulkOperation ) {
 			getIpcApi().showNotification( {
 				title: operation.snapshotName,

--- a/src/stores/snapshot-slice.ts
+++ b/src/stores/snapshot-slice.ts
@@ -50,7 +50,6 @@ export type SnapshotOperation = CreateOperation | UpdateOperation | DeleteOperat
 type SnapshotState = {
 	isLoaded: boolean;
 	operations: Record< crypto.UUID, SnapshotOperation >;
-	snapshotProgress: number;
 	snapshots: Snapshot[];
 	snapshotQuota: number;
 };
@@ -59,7 +58,6 @@ const getInitialState = (): SnapshotState => {
 	return {
 		isLoaded: false,
 		operations: {},
-		snapshotProgress: 0,
 		snapshots: [],
 		snapshotQuota: LIMIT_OF_ZIP_SITES_PER_USER,
 	};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Related to https://github.com/Automattic/studio/pull/1230

## Proposed Changes

I made a mistake in cab51208c8d8e4099d15ccf70ef7b1b0c63605b2 where the optimistic decrement update was triggered for `update` operations rather than `delete` operations. This PR fixes that. 

I also took the opportunity to improve the loading state of the "delete all preview sites" action. Previously, the loading spinner would display very briefly. Now, it's displayed until all delete operations have completed.

Lastly, I fixed an issue where the delete site progress would continue displaying after the operation was completed. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Have at least three preview sites
2. Delete one of them and quickly open the settings modal
3. Ensure that the preview site counter decrements quickly after the operation finishes
4. Open the three-dot menu next to the preview site counter and click `Delete all preview sites`
5. Ensure that the loading spinner displays continuously until all preview sites have been successfully deleted (at which point you'll get a notification)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
