### PR TITLE
Sync: Add tests for `getSyncSupport`

### DIFF
--- a/src/hooks/tests/get-sync-support.test.ts
+++ b/src/hooks/tests/get-sync-support.test.ts
@@ -1,0 +1,95 @@
+import { getSyncSupport } from 'src/hooks/use-fetch-wpcom-sites';
+
+// Mocks for site shapes
+const baseSite = {
+	ID: 1,
+	is_wpcom_atomic: false,
+	name: 'Test Site',
+	URL: 'https://test.com',
+	jetpack: false,
+	is_deleted: false,
+	hosting_provider_guess: undefined,
+	options: { created_at: '2020-01-01', wpcom_staging_blog_ids: [] },
+	capabilities: { manage_options: true },
+	plan: {
+		expired: false,
+		features: { active: [ 'studio-sync' ] },
+		is_free: true,
+		product_id: 1,
+		product_name_short: 'Free',
+		product_slug: 'free-plan',
+		user_is_owner: true,
+	},
+};
+
+describe( 'getSyncSupport', () => {
+	it( 'returns "deleted" if site is deleted', () => {
+		const site = { ...baseSite, is_deleted: true };
+		expect( getSyncSupport( site, [] ) ).toBe( 'deleted' );
+	} );
+
+	it( 'returns "missing-permissions" if manage_options is false', () => {
+		const site = { ...baseSite, capabilities: { manage_options: false } };
+		expect( getSyncSupport( site, [] ) ).toBe( 'missing-permissions' );
+	} );
+
+	it( 'returns "unsupported" if site is Jetpack', () => {
+		const site = {
+			...baseSite,
+			jetpack: true,
+			is_wpcom_atomic: false,
+			hosting_provider_guess: undefined,
+		};
+		expect( getSyncSupport( site, [] ) ).toBe( 'unsupported' );
+	} );
+
+	it( 'returns "needs-upgrade" if plan is not supported and the site is not Pressable', () => {
+		const site = {
+			...baseSite,
+			plan: {
+				expired: false,
+				features: { active: [] },
+				is_free: true,
+				product_id: 1,
+				product_name_short: 'Free',
+				product_slug: 'free-plan',
+				user_is_owner: true,
+			},
+			hosting_provider_guess: undefined,
+		};
+		expect( getSyncSupport( site, [] ) ).toBe( 'needs-upgrade' );
+	} );
+
+	it( 'returns "needs-transfer" if site not Atomic, Jetpack, nor Pressable', () => {
+		const site = {
+			...baseSite,
+			plan: {
+				expired: false,
+				features: { active: [ 'studio-sync' ] },
+				is_free: false,
+				product_id: 1,
+				product_name_short: 'Premium',
+				product_slug: 'premium-plan',
+				user_is_owner: true,
+			},
+			is_wpcom_atomic: false,
+			jetpack: false,
+		};
+		expect( getSyncSupport( site, [] ) ).toBe( 'needs-transfer' );
+	} );
+
+	it( 'returns "already-connected" if site ID is in connectedSiteIds', () => {
+		const site = { ...baseSite, ID: 42, is_wpcom_atomic: true };
+		expect( getSyncSupport( site, [ 42 ] ) ).toBe( 'already-connected' );
+	} );
+
+	it( 'returns "syncable" for Atomic site', () => {
+		const site = { ...baseSite, is_wpcom_atomic: true };
+		expect( getSyncSupport( site, [] ) ).toBe( 'syncable' );
+	} );
+
+	it( 'returns "syncable" for Pressable site', () => {
+		const site = { ...baseSite, hosting_provider_guess: 'pressable' };
+		expect( getSyncSupport( site, [] ) ).toBe( 'syncable' );
+	} );
+} );

--- a/src/hooks/use-fetch-wpcom-sites/index.tsx
+++ b/src/hooks/use-fetch-wpcom-sites/index.tsx
@@ -72,7 +72,7 @@ function needsTransfer( site: SitesEndpointSite ): boolean {
 	return ! isJetpackSite( site ) && ! isPressableSite( site ) && ! isAtomicSite( site );
 }
 
-function getSyncSupport( site: SitesEndpointSite, connectedSiteIds: number[] ): SyncSupport {
+export function getSyncSupport( site: SitesEndpointSite, connectedSiteIds: number[] ): SyncSupport {
 	if ( site.is_deleted ) {
 		return 'deleted';
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Resolves STU-380-linear-issue

## Proposed Changes

- adds tests for the `getSyncSupport`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Review the proposed tests.
2. Both `npx jest src/hooks/tests/get-sync-support.test.ts` and `npm run test` should pass.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?