### PR TITLE
Studio Logs: Could not open log file on Studio when error occurred on Windows

### DIFF
--- a/src/logging.ts
+++ b/src/logging.ts
@@ -1,6 +1,7 @@
 import { app } from 'electron';
 import path from 'path';
 import * as FileStreamRotator from 'file-stream-rotator';
+import { platform } from 'os';
 
 let logStream: ReturnType< typeof FileStreamRotator.getStream > | null = null;
 let currentLogFile = '';
@@ -25,6 +26,8 @@ export function setupLogging( {
 		app.setAppLogsPath();
 	}
 
+	const isWindows = platform() === 'win32';
+	
 	logStream = FileStreamRotator.getStream( {
 		filename: path.join( logDir, 'studio-%DATE%' ),
 		date_format: 'YYYYMMDD',
@@ -33,12 +36,18 @@ export function setupLogging( {
 		max_logs: '10',
 		audit_file: path.join( logDir, 'log-rotator.json' ),
 		extension: '.log',
-		create_symlink: true,
+		create_symlink: !isWindows, // Only create symlinks on non-Windows platforms
 		audit_hash_type: 'sha256',
 		verbose: true, // file-stream-rotator itself will log to console too
 	} );
 
-	currentLogFile = path.join( logDir, 'current.log' );
+	// On Windows, we'll use the most recent log file as the current log file
+	if (isWindows) {
+		const today = new Date().toISOString().split('T')[0].replace(/-/g, '');
+		currentLogFile = path.join(logDir, `studio-${today}.0.log`);
+	} else {
+		currentLogFile = path.join(logDir, 'current.log');
+	}
 
 	const makeLogger =
 		( level: LogLevel, originalLogger: typeof console.log ) =>

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -1,7 +1,7 @@
 import { app } from 'electron';
+import { platform } from 'os';
 import path from 'path';
 import * as FileStreamRotator from 'file-stream-rotator';
-import { platform } from 'os';
 
 let logStream: ReturnType< typeof FileStreamRotator.getStream > | null = null;
 let currentLogFile = '';

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -27,7 +27,7 @@ export function setupLogging( {
 	}
 
 	const isWindows = platform() === 'win32';
-	
+
 	logStream = FileStreamRotator.getStream( {
 		filename: path.join( logDir, 'studio-%DATE%' ),
 		date_format: 'YYYYMMDD',
@@ -36,17 +36,17 @@ export function setupLogging( {
 		max_logs: '10',
 		audit_file: path.join( logDir, 'log-rotator.json' ),
 		extension: '.log',
-		create_symlink: !isWindows, // Only create symlinks on non-Windows platforms
+		create_symlink: ! isWindows, // Only create symlinks on non-Windows platforms
 		audit_hash_type: 'sha256',
 		verbose: true, // file-stream-rotator itself will log to console too
 	} );
 
 	// On Windows, we'll use the most recent log file as the current log file
-	if (isWindows) {
-		const today = new Date().toISOString().split('T')[0].replace(/-/g, '');
-		currentLogFile = path.join(logDir, `studio-${today}.0.log`);
+	if ( isWindows ) {
+		const today = new Date().toISOString().split( 'T' )[ 0 ].replace( /-/g, '' );
+		currentLogFile = path.join( logDir, `studio-${ today }.0.log` );
 	} else {
-		currentLogFile = path.join(logDir, 'current.log');
+		currentLogFile = path.join( logDir, 'current.log' );
 	}
 
 	const makeLogger =


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-102

## Proposed Changes

- Do not try to create symlink for logger file on windows

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- TBA

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
