### PR TITLE
Fix open logs on Windows by using real path

### DIFF
--- a/src/logging.ts
+++ b/src/logging.ts
@@ -1,5 +1,4 @@
 import { app } from 'electron';
-import fs from 'fs';
 import path from 'path';
 import * as FileStreamRotator from 'file-stream-rotator';
 
@@ -108,5 +107,5 @@ export function getLogsFilePath(): string {
 	if ( ! currentLogFile ) {
 		throw new Error( 'Logging system not initialized' );
 	}
-	return fs.realpathSync( currentLogFile );
+	return currentLogFile;
 }

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -38,7 +38,7 @@ export function setupLogging( {
 		verbose: true, // file-stream-rotator itself will log to console too
 	} );
 
-	logStream.on( 'open', ( logFile: string ) => {
+	logStream?.on( 'open', ( logFile: string ) => {
 		currentLogFile = logFile;
 	} );
 

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -1,4 +1,5 @@
 import { app } from 'electron';
+import fs from 'fs';
 import path from 'path';
 import * as FileStreamRotator from 'file-stream-rotator';
 
@@ -107,5 +108,5 @@ export function getLogsFilePath(): string {
 	if ( ! currentLogFile ) {
 		throw new Error( 'Logging system not initialized' );
 	}
-	return currentLogFile;
+	return fs.realpathSync( currentLogFile );
 }

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -38,7 +38,7 @@ export function setupLogging( {
 		verbose: true, // file-stream-rotator itself will log to console too
 	} );
 
-	logStream.on( 'open', ( logFile ) => {
+	logStream.on( 'open', ( logFile: string ) => {
 		currentLogFile = logFile;
 	} );
 

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -33,12 +33,14 @@ export function setupLogging( {
 		max_logs: '10',
 		audit_file: path.join( logDir, 'log-rotator.json' ),
 		extension: '.log',
-		create_symlink: true,
+		create_symlink: false,
 		audit_hash_type: 'sha256',
 		verbose: true, // file-stream-rotator itself will log to console too
 	} );
 
-	currentLogFile = path.join( logDir, 'current.log' );
+	logStream.on( 'open', ( logFile ) => {
+		currentLogFile = logFile;
+	} );
 
 	const makeLogger =
 		( level: LogLevel, originalLogger: typeof console.log ) =>


### PR DESCRIPTION
## Related issues

- Fixes STU-102

## Proposed Changes
- Avoid using Symlink for current log file.
- Return the real path to logFile even after rotations.
- Keep parity between OS.

## Testing Instructions
- Run `npm start`
- Go to Import / Export tab
- Try importing this broken zip file [empty.txt.zip](https://github.com/user-attachments/files/19855192/empty.txt.zip)
- Observe the alert and click on Open logs
- Observe the correct log file opens correctly
- Test on Mac and Windows

To test if it works after a few rotations I applied this diff and repeated the test instructions a couple of times:

```diff
diff --git a/src/logging.ts b/src/logging.ts
index 7cc49e66..d0827ad5 100644
--- a/src/logging.ts
+++ b/src/logging.ts
@@ -109,5 +109,6 @@ export function getLogsFilePath(): string {
 	if ( ! currentLogFile ) {
 		throw new Error( 'Logging system not initialized' );
 	}
+	logStream?.rotate( true );
 	return currentLogFile;
 }
```

https://github.com/user-attachments/assets/03ebe6c9-254a-4d13-ab1f-6e3246e7f7e5



## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?