### PR TITLE
Pressable Sync: Add design doc

### DIFF
--- a/docs/design-docs/sync.md
+++ b/docs/design-docs/sync.md
@@ -55,6 +55,6 @@ It will run the import process to extract the backup file and save the data in t
 
 ### Push
 
-When the user clicks "Push," Studio will create a Jetpack backup of the local site. Studio sends a request to the WPcom API to start uploading the backup file, and then an active listener starts to wait until the restore process is complete.
+When the user clicks "Push," Studio will create a Jetpack backup of the local site. Studio sends a request to the WPcom API to start uploading the backup file, and then an active listener waits until the restore process is complete.
 
 The backend will send an email after the Push has finished.

--- a/docs/design-docs/sync.md
+++ b/docs/design-docs/sync.md
@@ -13,7 +13,7 @@ WordPress Studio Sync enables developers to pull a live site down for local deve
 - **Sync**: Replicating files and database content between a local machine and a remote site in any direction.
 - **Push**: Copying changes from a local machine to a remote (staging or production) site.
 - **Pull**: Copying changes from a remote site down to a local machine.
-- **Staging site**: A staging site is hosted on WordPress.com and is connected to the production site. It is used to test the sync feature and serves as the source of truth for this feature. WordPress.com staging sites can sync with production sites and vice versa.
+- **Staging site**: A staging site is hosted on WordPress.com and is connected to its production site. It is used to test the sync feature and serves as the source of truth for this feature. WordPress.com staging sites can sync with production sites and vice versa.
 - **Production site**: A production site is hosted on WordPress.com and is used to store the synced site. We consider all Pressable sites as production servers.
 - **Jetpack Backup**: A feature of WordPress.com that allows users to back up their sites and serves as the format used to share site data for the sync feature.
 - **Connection**: A connection is a relationship between a local machine and a remote site. That information lives in appData `connectedWpcomSites` array.

--- a/docs/design-docs/sync.md
+++ b/docs/design-docs/sync.md
@@ -1,0 +1,15 @@
+# Sync WordPress Studio Sites
+
+## About this doc
+
+This document outlines the design and implementation details for syncing WordPress Studio sites. It covers the high-level implementation, terminology, formats and data flow for this feature.
+
+## Context
+
+## Terminology
+
+## High level implementation
+
+### Backup format
+
+### Data Flow

--- a/docs/design-docs/sync.md
+++ b/docs/design-docs/sync.md
@@ -6,7 +6,7 @@ This design document describes the requirements, architecture, and data models f
 
 ## Context
 
-WordPress Studio Sync enables developers to pull a live site down for local development (including themes, plugins, media, and the database) and then push changes back up without manual exports or FTP. It supports both WordPress.com and Pressable sites with a Jetpack connection.
+WordPress Studio Sync enables developers to pull a live site down for local development (including themes, plugins, media, and the database) and then push changes back without manual exports or FTP. It supports both WordPress.com and Pressable sites with a Jetpack connection.
 
 ## Terminology
 

--- a/docs/design-docs/sync.md
+++ b/docs/design-docs/sync.md
@@ -57,4 +57,4 @@ It will run the import process to extract the backup file and save the data in t
 
 When the user clicks "Push," Studio will create a Jetpack backup of the local site. Studio sends a request to the WPcom API to start uploading the backup file, and then an active listener waits until the restore process is complete.
 
-The backend will send an email after the Push has finished.
+An email notification will be sent from the backend after the Push has finished.

--- a/docs/design-docs/sync.md
+++ b/docs/design-docs/sync.md
@@ -14,7 +14,7 @@ WordPress Studio Sync enables developers to pull a live site down for local deve
 - **Push**: Copying changes from a local machine to a remote (staging or production) site.
 - **Pull**: Copying changes from a remote site down to a local machine.
 - **Staging site**: A staging site is hosted on WordPress.com and is connected to its production site. It is used to test the sync feature and serves as the source of truth for this feature. WordPress.com staging sites can sync with production sites and vice versa.
-- **Production site**: A production site is hosted on WordPress.com and is used to store the synced site. We consider all Pressable sites as production servers.
+- **Production site**: A production site is hosted on WordPress.com and is used to store the synced site. We consider all Pressable sites as production sites.
 - **Jetpack Backup**: A feature of WordPress.com that allows users to back up their sites and serves as the format used to share site data for the sync feature.
 - **Connection**: A connection is a relationship between a local machine and a remote site. That information lives in appData `connectedWpcomSites` array.
 

--- a/docs/design-docs/sync.md
+++ b/docs/design-docs/sync.md
@@ -38,7 +38,7 @@ Compatible sites:
 - WPcom sites with a Business or eCommerce plan.
 - Pressable sites with a valid Jetpack connection.
 
-Only WPcom sites with a Business or eCommerce plan can be connected. If the site is Business but simple, we will ask the user to enable the Hosting Features. Additionally, Pressable sites with a valid Jetpack connection can also be connected to Studio.
+Only WPcom sites with a Business or eCommerce plan can be connected. If a site with the Business plan does not have hosting features enabled, we will ask the user to do so before using Studio sync feature. Additionally, Pressable sites with a valid Jetpack connection can also be connected to Studio.
 
 When a WPcom production site is connected, we will also connect the staging site automatically if it exists.
 For Pressable sites, we cannot identify if a site is a production or staging.

--- a/docs/design-docs/sync.md
+++ b/docs/design-docs/sync.md
@@ -40,7 +40,7 @@ Compatible sites:
 
 Only WPcom sites with a Business or eCommerce plan can be connected. If a site with the Business plan does not have hosting features enabled, we will ask the user to do so before using Studio sync feature. Additionally, Pressable sites with a valid Jetpack connection can also be connected to Studio.
 
-When a WPcom production site is connected, we will also connect the staging site automatically if it exists.
+When connecting the WPcom production site, we will also automatically connect its staging site, if one exists.
 For Pressable sites, we cannot identify if a site is a production or staging.
 
 Users can connect multiple sites to Studio independently of their hosting provider.
@@ -51,10 +51,10 @@ When the user clicks "Pull," we make a request to the WPcom API to start the Jet
 
 The studio will download the backup file and save it on the local machine in a temporary folder.
 
-It will run the import process to extract the backup file and save the data in the local database by executing the WP-CLI sqlite import command.
+It will run the import process to extract the backup file and save the data in the local database by executing the WP-CLI sqlite import command. The former site will be completely replaced by the new one.
 
 ### Push
 
-When the user clicks "Push," Studio will create a Jetpack backup of the local site. Studio sends a request to the WPcom API to start uploading the backup file, and then an active listener waits until the restore process is complete.
+When the user clicks "Push," Studio will create a Jetpack backup of the local site. Studio sends a request to the WPcom API to start uploading the backup file, and then an active listener waits until the restore process is complete. The former site will be completely replaced by the new one.
 
 An email notification will be sent from the backend after the Push has finished.

--- a/docs/design-docs/sync.md
+++ b/docs/design-docs/sync.md
@@ -2,11 +2,37 @@
 
 ## About this doc
 
-This document outlines the design and implementation details for syncing WordPress Studio sites. It covers the high-level implementation, terminology, formats and data flow for this feature.
+This design doc describes the requirements, architecture, and data models for the **Studio Sync** feature.
 
 ## Context
 
+WordPress Studio sync enables developers to pull a live site down for local development (themes, plugins, media, and database) and then push changes back up without manual exports or FTP. It supports both WordPress.com and Pressable sites with a Jetpack connection.
+
 ## Terminology
+
+### Sync
+
+Replicating files and database content between a local machine and a remote site in any direction.
+
+### Push
+
+Copying changes from a local machine to a remote (staging or production) site.
+
+### Pull
+
+Copying changes from a remote site down to a local machine.
+
+### Staging site
+
+A staging site is hosted on WordPress.com and is connected to the production site. It is used to test the sync feature and serves as the source of truth for this feature. WordPress.com staging sites can sync with production sites and vice versa.
+
+### Production site
+
+The production site is hosted on WordPress.com and is used to store the synced site. We consider all Pressable sites as production servers.
+
+### Jetpack Backup
+
+Jetpack Backup is a feature of WordPress.com that allows users to back up their sites and serves as the format used to share site data for the sync feature.
 
 ## High level implementation
 

--- a/docs/design-docs/sync.md
+++ b/docs/design-docs/sync.md
@@ -2,40 +2,59 @@
 
 ## About this doc
 
-This design doc describes the requirements, architecture, and data models for the **Studio Sync** feature.
+This design document describes the requirements, architecture, and data models for the **Studio Sync** feature.
 
 ## Context
 
-WordPress Studio sync enables developers to pull a live site down for local development (themes, plugins, media, and database) and then push changes back up without manual exports or FTP. It supports both WordPress.com and Pressable sites with a Jetpack connection.
+WordPress Studio Sync enables developers to pull a live site down for local development (including themes, plugins, media, and the database) and then push changes back up without manual exports or FTP. It supports both WordPress.com and Pressable sites with a Jetpack connection.
 
 ## Terminology
 
-### Sync
-
-Replicating files and database content between a local machine and a remote site in any direction.
-
-### Push
-
-Copying changes from a local machine to a remote (staging or production) site.
-
-### Pull
-
-Copying changes from a remote site down to a local machine.
-
-### Staging site
-
-A staging site is hosted on WordPress.com and is connected to the production site. It is used to test the sync feature and serves as the source of truth for this feature. WordPress.com staging sites can sync with production sites and vice versa.
-
-### Production site
-
-The production site is hosted on WordPress.com and is used to store the synced site. We consider all Pressable sites as production servers.
-
-### Jetpack Backup
-
-Jetpack Backup is a feature of WordPress.com that allows users to back up their sites and serves as the format used to share site data for the sync feature.
-
-## High level implementation
+- **Sync**: Replicating files and database content between a local machine and a remote site in any direction.
+- **Push**: Copying changes from a local machine to a remote (staging or production) site.
+- **Pull**: Copying changes from a remote site down to a local machine.
+- **Staging site**: A staging site is hosted on WordPress.com and is connected to the production site. It is used to test the sync feature and serves as the source of truth for this feature. WordPress.com staging sites can sync with production sites and vice versa.
+- **Production site**: A production site is hosted on WordPress.com and is used to store the synced site. We consider all Pressable sites as production servers.
+- **Jetpack Backup**: A feature of WordPress.com that allows users to back up their sites and serves as the format used to share site data for the sync feature.
+- **Connection**: A connection is a relationship between a local machine and a remote site. That information lives in appData `connectedWpcomSites` array.
 
 ### Backup format
 
-### Data Flow
+The backup format is a tar.gz file that contains the site data. It follows the format of the Jetpack Backup, which consists of:
+
+- wp-content folder
+- sql folder with a .sql file for each database table
+- wp-config.php file
+- meta.json file
+
+## High level implementation
+
+### Connection
+
+Users need to connect a remote site to their local Studio site. When users click on "Connect a Site," a modal will open to select the remote site. The list of sites is fetched from the WPcom API at /me/sites and will include all their simple, atomic, and Jetpack sites.
+
+Compatible sites:
+
+- WPcom sites with a Business or eCommerce plan.
+- Pressable sites with a valid Jetpack connection.
+
+Only WPcom sites with a Business or eCommerce plan can be connected. If the site is Business but simple, we will ask the user to enable the Hosting Features. Additionally, Pressable sites with a valid Jetpack connection can also be connected to Studio.
+
+When a WPcom production site is connected, we will also connect the staging site automatically if it exists.
+For Pressable sites, we cannot identify if a site is a production or staging.
+
+Users can connect multiple sites to Studio independently of their hosting provider.
+
+### Pull
+
+When the user clicks "Pull," we make a request to the WPcom API to start the Jetpack Backup process. We actively listen until the process is ready to download the backup file.
+
+The studio will download the backup file and save it on the local machine in a temporary folder.
+
+It will run the import process to extract the backup file and save the data in the local database by executing the WP-CLI sqlite import command.
+
+### Push
+
+When the user clicks "Push," Studio will create a Jetpack backup of the local site. Studio sends a request to the WPcom API to start uploading the backup file, and then an active listener starts to wait until the restore process is complete.
+
+The backend will send an email after the Push has finished.

--- a/docs/design-docs/sync.md
+++ b/docs/design-docs/sync.md
@@ -31,7 +31,7 @@ The backup format is a tar.gz file that contains the site data. It follows the f
 
 ### Connection
 
-Users need to connect a remote site to their local Studio site. When users click on "Connect a Site," a modal will open to select the remote site. The list of sites is fetched from the WPcom API at /me/sites and will include all their simple, atomic, and Jetpack sites.
+Users need to connect a remote site to their local Studio site. When users click on "Connect site," a modal will open to select the remote site. The list of sites is fetched from the WPcom API at /me/sites and will include all their simple, atomic, and Jetpack sites.
 
 Compatible sites:
 


### PR DESCRIPTION
## Related issues

- Fixes STU-384

## Proposed Changes
- Added a new design document `docs/design-docs/sync.md` describing the WordPress Studio site sync feature
- Document outlines implementation details, terminology, formats, and data flow
- Provides clear documentation for future development and maintenance

## Testing Instructions
- Navigate to [`docs/design-docs/sync.md`](https://github.com/Automattic/studio/blob/add/stu-384-studio-write-a-design-docs-describing-studio-sync-including/docs/design-docs/sync.md)
- Read it and verify that the document's structure and content are useful, correct and descriptive.

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?