### PR TITLE
Reset component state when switching sites

### DIFF
--- a/src/components/site-content-tabs.tsx
+++ b/src/components/site-content-tabs.tsx
@@ -41,7 +41,7 @@ export function SiteContentTabs() {
 				orientation="horizontal"
 				onSelect={ ( tabName ) => setSelectedTab( tabName as TabName ) }
 				initialTabName={ selectedTab }
-				key={ selectedTab }
+				key={ selectedTab + selectedSite.id }
 			>
 				{ ( { name } ) => (
 					<div
@@ -58,13 +58,7 @@ export function SiteContentTabs() {
 						{ name === 'previews' && <ContentTabPreviews selectedSite={ selectedSite } /> }
 						{ name === 'sync' && <ContentTabSync selectedSite={ selectedSite } /> }
 						{ name === 'settings' && <ContentTabSettings selectedSite={ selectedSite } /> }
-						{ name === 'assistant' && (
-							<ContentTabAssistant
-								// TODO: Remove this key once https://github.com/Automattic/dotcom-forge/issues/10219 is fixed
-								key={ selectedTab + selectedSite.id }
-								selectedSite={ selectedSite }
-							/>
-						) }
+						{ name === 'assistant' && <ContentTabAssistant selectedSite={ selectedSite } /> }
 						{ name === 'import-export' && <ContentTabImportExport selectedSite={ selectedSite } /> }
 					</div>
 				) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-180

## Proposed Changes

In https://github.com/Automattic/studio/pull/775, we worked on an issue caused by React state not resetting when selecting another site in Studio. This happens because the `key` prop passed to `TabPanel` references only the active tab and not the selected site. 

@katinthehatsite raised another issue in https://github.com/Automattic/studio/pull/1242#issuecomment-2823510545 that I suspect is related to the same thing. 

This PR fixes the problem by including the selected site ID in the `key` prop passed to `TabPanel`.

See [the React docs](https://react.dev/learn/preserving-and-resetting-state#option-2-resetting-state-with-a-key) for more details on resetting state with a `key` prop. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Ideally, @katinthehatsite would retry the same steps as in https://github.com/Automattic/studio/pull/1242#issuecomment-2823510545 and ensure that it works as expected now. 

For other testers, do a light smoke test of the Sync tab, the Previews tab, the Import/Export tab, and the Settings tab. While this should be a low-risk change, it also has far-reaching effects on state handling.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
