### PR TITLE
Update Sync Tab UI to Include Pressable Sites

### DIFF
--- a/src/components/content-tab-sync.tsx
+++ b/src/components/content-tab-sync.tsx
@@ -13,12 +13,13 @@ import { WordPressShortLogo } from 'src/components/wordpress-short-logo';
 import { CLIENT_ID, PROTOCOL_PREFIX, SCOPES, WP_AUTHORIZE_ENDPOINT } from 'src/constants';
 import { useSyncSites } from 'src/hooks/sync-sites';
 import { useAuth } from 'src/hooks/use-auth';
+import { useFeatureFlags } from 'src/hooks/use-feature-flags';
 import { useOffline } from 'src/hooks/use-offline';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 import type { SyncSite } from 'src/hooks/use-fetch-wpcom-sites/types';
-
 function SiteSyncDescription( { children }: PropsWithChildren ) {
 	const { __ } = useI18n();
+	const { pressableSyncEnabled } = useFeatureFlags();
 	return (
 		<div className="flex justify-between max-w-3xl gap-4">
 			<div className="flex flex-col p-8">
@@ -27,9 +28,13 @@ function SiteSyncDescription( { children }: PropsWithChildren ) {
 					<WordPressShortLogo className="ms-2 h-5" />
 				</div>
 				<div className="max-w-[40ch] text-a8c-gray-70 a8c-body">
-					{ __(
-						'Connect any Jetpack-activated site, including your WordPress.com or Pressable sites, or create a new one. Then, share your work with the world.'
-					) }
+					{ pressableSyncEnabled
+						? __(
+								'Connect your existing WordPress.com or Jetpack-activated Pressable sites, or create a new one. Then, share your work with the world.'
+						  )
+						: __(
+								'Connect an existing WordPress.com site, or create a new one and share your site with the world.'
+						  ) }
 				</div>
 				<div className="mt-6">
 					{ [

--- a/src/components/content-tab-sync.tsx
+++ b/src/components/content-tab-sync.tsx
@@ -28,7 +28,7 @@ function SiteSyncDescription( { children }: PropsWithChildren ) {
 				</div>
 				<div className="max-w-[40ch] text-a8c-gray-70 a8c-body">
 					{ __(
-						'Connect an existing WordPress.com site, or create a new one and share your site with the world.'
+						'Connect any Jetpack-activated site, including your WordPress.com or Pressable sites, or create a new one. Then, share your work with the world.'
 					) }
 				</div>
 				<div className="mt-6">


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Resolves STU-349

## Proposed Changes

- Updated sync tab UI text to explicitly mention Pressable sites

Figma link RToz6tIuQ7nlZrikBte4GU-fi-7835_3430

|Before | After|
|-------|------|
|  ![CleanShot 2025-04-23 at 11 56 43@2x](https://github.com/user-attachments/assets/5d21c0a8-ae1b-4580-934b-777843694d43)|    ![CleanShot 2025-04-23 at 11 57 44@2x](https://github.com/user-attachments/assets/a1f02d01-44ab-4490-a2b7-149592fd523f)|

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Apply this branch
- Run `STUDIO_PRESSABLE_SYNC=true npm start` 
- Using a site without _synced_ sites, check that the text in the `Sync` tab corresponds with the Figma designs. Link here RToz6tIuQ7nlZrikBte4GU-fi-7835_3430
- Check that the text looks fine for different sizes of the screen
- Run Studio again without the feature flag: `npm start`
- Using a site without _synced_ sites, check that the text in the `Sync` tab corresponds to the `Before` screenshot

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?