### PR TITLE
Demonstrate infinite fs watcher loop

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
 				"electron-squirrel-startup": "^1.0.0",
 				"electron2appx": "^2.1.2",
 				"express": "4.21.2",
+				"fast-deep-equal": "^3.1.3",
 				"file-stream-rotator": "^1.0.0",
 				"follow-redirects": "1.15.6",
 				"form-data": "^4.0.2",

--- a/package.json
+++ b/package.json
@@ -136,6 +136,7 @@
 		"electron-squirrel-startup": "^1.0.0",
 		"electron2appx": "^2.1.2",
 		"express": "4.21.2",
+		"fast-deep-equal": "^3.1.3",
 		"file-stream-rotator": "^1.0.0",
 		"follow-redirects": "1.15.6",
 		"form-data": "^4.0.2",

--- a/src/modules/preview-site/components/preview-action-buttons-menu.tsx
+++ b/src/modules/preview-site/components/preview-action-buttons-menu.tsx
@@ -72,6 +72,8 @@ export function PreviewActionButtonsMenu( {
 	};
 
 	const handleRename = ( newName: string ) => {
+		console.log( 'handleRename', newName );
+
 		dispatch(
 			snapshotActions.updateSnapshot( {
 				atomicSiteId: snapshot.atomicSiteId,

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -58,6 +58,7 @@ listenerMiddleware.startListening( {
 	},
 	effect( action, listenerApi ) {
 		const state = listenerApi.getState();
+		console.log( 'Saving snapshots to storage', state.snapshot.snapshots );
 		getIpcApi().saveSnapshotsToStorage( state.snapshot.snapshots );
 	},
 } );

--- a/src/stores/snapshot-slice.ts
+++ b/src/stores/snapshot-slice.ts
@@ -7,6 +7,7 @@ import {
 	PayloadAction,
 } from '@reduxjs/toolkit';
 import { __, sprintf } from '@wordpress/i18n';
+import fastDeepEqual from 'fast-deep-equal';
 import { PreviewCommandLoggerAction } from 'common/logger-actions';
 import { Snapshot } from 'common/types/snapshot';
 import { LIMIT_OF_ZIP_SITES_PER_USER } from 'src/constants';
@@ -141,8 +142,10 @@ const snapshotSlice = createSlice( {
 			);
 		},
 		setSnapshots: ( state, action: PayloadAction< Snapshot[] > ) => {
-			state.snapshots = action.payload;
-			state.isLoaded = true;
+			if ( ! fastDeepEqual( state.snapshots, action.payload ) ) {
+				state.snapshots = action.payload;
+				state.isLoaded = true;
+			}
 		},
 		updateOperation: (
 			state,

--- a/src/stores/snapshot-slice.ts
+++ b/src/stores/snapshot-slice.ts
@@ -78,7 +78,7 @@ const updateSnapshot = createAsyncThunk(
 		thunkAPI
 	) => {
 		const state = thunkAPI.getState() as RootState;
-		const found = state.userData.snapshots.find( ( snap ) => snap.atomicSiteId === atomicSiteId );
+		const found = state.snapshot.snapshots.find( ( snap ) => snap.atomicSiteId === atomicSiteId );
 		if ( ! found ) {
 			throw new Error( 'Snapshot not found' );
 		}
@@ -139,6 +139,10 @@ const snapshotSlice = createSlice( {
 			state.snapshots = state.snapshots.filter(
 				( snapshot ) => snapshot.atomicSiteId !== action.payload.atomicSiteId
 			);
+		},
+		setSnapshots: ( state, action: PayloadAction< Snapshot[] > ) => {
+			state.snapshots = action.payload;
+			state.isLoaded = true;
 		},
 		updateOperation: (
 			state,
@@ -259,7 +263,7 @@ const selectActiveOperationsForAnySite = createSelector(
 
 const selectSnapshotsBySite = createSelector(
 	[
-		( state: RootState ) => state.userData.snapshots,
+		( state: RootState ) => state.snapshot.snapshots,
 		( state: RootState, localSiteId: string ) => localSiteId,
 	],
 	( snapshots = [], localSiteId ) =>
@@ -268,7 +272,7 @@ const selectSnapshotsBySite = createSelector(
 
 const selectSnapshotsByUser = createSelector(
 	[
-		( state: RootState ) => state.userData.snapshots,
+		( state: RootState ) => state.snapshot.snapshots,
 		( state: RootState, userId: number ) => userId,
 	],
 	( snapshots = [], userId ) => snapshots.filter( ( snapshot ) => snapshot.userId === userId )
@@ -276,7 +280,7 @@ const selectSnapshotsByUser = createSelector(
 
 const selectSnapshotsBySiteAndUser = createSelector(
 	[
-		( state: RootState ) => state.userData.snapshots,
+		( state: RootState ) => state.snapshot.snapshots,
 		( state: RootState, localSiteId: string ) => localSiteId,
 		( state: RootState, localSiteId: string, userId: number ) => userId,
 	],
@@ -285,6 +289,11 @@ const selectSnapshotsBySiteAndUser = createSelector(
 			( snapshot ) => snapshot.localSiteId === localSiteId && snapshot.userId === userId
 		)
 );
+
+window.ipcListener.subscribe( 'user-data-updated', ( _, payload ) => {
+	console.log( 'user-data-updated', payload );
+	store.dispatch( snapshotSlice.actions.setSnapshots( payload.snapshots ) );
+} );
 
 function getCreateProgress( action: PreviewCommandLoggerAction ): [ string, number ] {
 	switch ( action ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Related to https://github.com/Automattic/studio/pull/1244

## Proposed Changes

- Demonstrate an issue with "infinite watcher loops" when Studio writes to the appdata file

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Rename a preview site
2. See how this causes an infinite loop of reads and writes

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
