### PR TITLE
Site overview: Adjust additional code editors

### DIFF
--- a/src/components/content-tab-overview.tsx
+++ b/src/components/content-tab-overview.tsx
@@ -185,7 +185,7 @@ function ShortcutsSection( { selectedSite }: Pick< ContentTabOverviewProps, 'sel
 	];
 
 	if ( editorName ) {
-		const editor = supportedEditorConfig[ editorName ] ?? null;
+		const editor = supportedEditorConfig[ editorName as keyof typeof supportedEditorConfig ];
 		if ( editor ) {
 			buttonsArray.push( {
 				label: editor.label,

--- a/src/components/content-tab-overview.tsx
+++ b/src/components/content-tab-overview.tsx
@@ -24,6 +24,7 @@ import { useSiteDetails } from 'src/hooks/use-site-details';
 import { useThemeDetails } from 'src/hooks/use-theme-details';
 import { isMac } from 'src/lib/app-globals';
 import { cx } from 'src/lib/cx';
+import { supportedEditorConfig } from 'src/lib/editor';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 
 interface ContentTabOverviewProps {
@@ -150,12 +151,9 @@ function ShortcutsSection( { selectedSite }: Pick< ContentTabOverviewProps, 'sel
 
 	const updateEditorName = useCallback( async () => {
 		const editor = await getIpcApi().getUserEditor();
-		if ( editor === 'vscode' && installedApps.vscode ) {
-			// translators: "VS Code" is the brand name for an IDE and does not need to be translated
-			setEditorName( __( 'VS Code' ) );
-		} else if ( editor === 'phpstorm' && installedApps.phpstorm ) {
-			// translators: "PhpStorm" is the brand name for an IDE and does not need to be translated
-			setEditorName( __( 'PhpStorm' ) );
+
+		if ( editor && installedApps[ editor as keyof typeof installedApps ] ) {
+			setEditorName( editor );
 		} else {
 			setEditorName( '' );
 		}
@@ -187,18 +185,17 @@ function ShortcutsSection( { selectedSite }: Pick< ContentTabOverviewProps, 'sel
 	];
 
 	if ( editorName ) {
-		buttonsArray.push( {
-			label: editorName,
-			className: 'text-nowrap',
-			icon: code,
-			onClick: () => {
-				if ( editorName === __( 'VS Code' ) ) {
-					getIpcApi().openURL( `vscode://file/${ selectedSite.path }?windowId=_blank` );
-				} else if ( editorName === __( 'PhpStorm' ) ) {
-					getIpcApi().openURL( `phpstorm://open?file=${ selectedSite.path }` );
-				}
-			},
-		} );
+		const editor = supportedEditorConfig[ editorName ] ?? null;
+		if ( editor ) {
+			buttonsArray.push( {
+				label: editor.label,
+				className: 'text-nowrap',
+				icon: code,
+				onClick: () => {
+					getIpcApi().openURL( editor.url( selectedSite.path ) );
+				},
+			} );
+		}
 	}
 	buttonsArray.push( {
 		label: terminalName,

--- a/src/lib/editor.ts
+++ b/src/lib/editor.ts
@@ -1,3 +1,5 @@
+import { __ } from '@wordpress/i18n';
+
 export type SupportedEditor = 'vscode' | 'phpstorm' | 'cursor' | 'windsurf' | 'webstorm';
 
 export type SupportedEditorConfig = {
@@ -15,23 +17,28 @@ export const supportedEditorNames: Record< SupportedEditor, string > = {
 
 export const supportedEditorConfig: Record< SupportedEditor, SupportedEditorConfig > = {
 	vscode: {
-		label: 'VS Code',
+		// translators: "VS Code" is the brand name for an IDE and does not need to be translated
+		label: __( 'VS Code' ),
 		url: ( path: string ) => `vscode://file/${ path }?windowId=_blank`,
 	},
 	phpstorm: {
-		label: 'PhpStorm',
+		// translators: "PhpStorm" is the brand name for an IDE and does not need to be translated
+		label: __( 'PhpStorm' ),
 		url: ( path: string ) => `phpstorm://open?file=${ path }`,
 	},
 	webstorm: {
-		label: 'WebStorm',
+		// translators: "WebStorm" is the brand name for an IDE and does not need to be translated
+		label: __( 'WebStorm' ),
 		url: ( path: string ) => `webstorm://open?file=${ path }`,
 	},
 	windsurf: {
-		label: 'WindSurf',
+		// translators: "Windsurf" is the brand name for an IDE and does not need to be translated
+		label: __( 'WindSurf' ),
 		url: ( path: string ) => `windsurf://file/${ path }?windowId=_blank`,
 	},
 	cursor: {
-		label: 'Cursor',
+		// translators: "Cursor" is the brand name for an IDE and does not need to be translated
+		label: __( 'Cursor' ),
 		url: ( path: string ) => `cursor://file/${ path }?windowId=_blank`,
 	},
 };

--- a/src/lib/editor.ts
+++ b/src/lib/editor.ts
@@ -7,14 +7,6 @@ export type SupportedEditorConfig = {
 	url: ( path: string ) => string;
 };
 
-export const supportedEditorNames: Record< SupportedEditor, string > = {
-	vscode: 'Visual Studio Code',
-	phpstorm: 'PhpStorm',
-	cursor: 'Cursor',
-	windsurf: 'Windsurf',
-	webstorm: 'WebStorm',
-};
-
 export const supportedEditorConfig: Record< SupportedEditor, SupportedEditorConfig > = {
 	vscode: {
 		// translators: "VS Code" is the brand name for an IDE and does not need to be translated

--- a/src/lib/editor.ts
+++ b/src/lib/editor.ts
@@ -8,6 +8,11 @@ export type SupportedEditor =
 	| 'sublime'
 	| 'atom';
 
+export type SupportedEditorConfig = {
+	label: string;
+	url: ( path: string ) => string;
+};
+
 export const supportedEditorNames: Record< SupportedEditor, string > = {
 	vscode: 'Visual Studio Code',
 	phpstorm: 'PhpStorm',
@@ -17,4 +22,27 @@ export const supportedEditorNames: Record< SupportedEditor, string > = {
 	webstorm: 'WebStorm',
 	sublime: 'Sublime',
 	atom: 'Atom',
+};
+
+export const supportedEditorConfig: Record< string, SupportedEditorConfig > = {
+	vscode: {
+		label: 'VS Code',
+		url: ( path: string ) => `vscode://file/${ path }?windowId=_blank`,
+	},
+	phpstorm: {
+		label: 'PhpStorm',
+		url: ( path: string ) => `phpstorm://open?file=${ path }`,
+	},
+	webstorm: {
+		label: 'WebStorm',
+		url: ( path: string ) => `webstorm://open?file=${ path }`,
+	},
+	windsurf: {
+		label: 'WindSurf',
+		url: ( path: string ) => `windsurf://file/${ path }?windowId=_blank`,
+	},
+	cursor: {
+		label: 'Cursor',
+		url: ( path: string ) => `cursor://file/${ path }?windowId=_blank`,
+	},
 };

--- a/src/lib/editor.ts
+++ b/src/lib/editor.ts
@@ -1,12 +1,4 @@
-export type SupportedEditor =
-	| 'vscode'
-	| 'phpstorm'
-	| 'cursor'
-	| 'windsurf'
-	| 'nova'
-	| 'webstorm'
-	| 'sublime'
-	| 'atom';
+export type SupportedEditor = 'vscode' | 'phpstorm' | 'cursor' | 'windsurf' | 'webstorm';
 
 export type SupportedEditorConfig = {
 	label: string;
@@ -18,13 +10,10 @@ export const supportedEditorNames: Record< SupportedEditor, string > = {
 	phpstorm: 'PhpStorm',
 	cursor: 'Cursor',
 	windsurf: 'Windsurf',
-	nova: 'Nova',
 	webstorm: 'WebStorm',
-	sublime: 'Sublime',
-	atom: 'Atom',
 };
 
-export const supportedEditorConfig: Record< string, SupportedEditorConfig > = {
+export const supportedEditorConfig: Record< SupportedEditor, SupportedEditorConfig > = {
 	vscode: {
 		label: 'VS Code',
 		url: ( path: string ) => `vscode://file/${ path }?windowId=_blank`,

--- a/src/modules/user-settings/components/editor-picker.tsx
+++ b/src/modules/user-settings/components/editor-picker.tsx
@@ -1,7 +1,7 @@
 import { SelectControl } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
 import { useEffect, useState } from 'react';
-import { SupportedEditor, supportedEditorNames } from 'src/lib/editor';
+import { SupportedEditor, supportedEditorConfig } from 'src/lib/editor';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 import { SettingsFormField } from './settings-form-field';
 
@@ -33,11 +33,11 @@ export const EditorPicker = ( { value, onChange }: EditorPickerProps ) => {
 		fetchInstalledApps();
 	}, [] );
 
-	const installedEditors = Object.entries( supportedEditorNames ).filter(
+	const installedEditors = Object.entries( supportedEditorConfig ).filter(
 		( [ editor ] ) => installedApps[ editor as keyof typeof installedApps ]
 	);
 
-	const uninstalledEditors = Object.entries( supportedEditorNames ).filter(
+	const uninstalledEditors = Object.entries( supportedEditorConfig ).filter(
 		( [ editor ] ) => ! installedApps[ editor as keyof typeof installedApps ]
 	);
 
@@ -49,15 +49,15 @@ export const EditorPicker = ( { value, onChange }: EditorPickerProps ) => {
 				__nextHasNoMarginBottom
 				__next40pxDefaultSize
 			>
-				{ installedEditors.map( ( [ editor, label ] ) => (
-					<option key={ editor } value={ editor }>
-						{ label }
+				{ installedEditors.map( ( [ editorKey, editorConfig ] ) => (
+					<option key={ editorKey } value={ editorKey }>
+						{ editorConfig.label }
 					</option>
 				) ) }
 				<optgroup label={ __( 'Not installed' ) }>
-					{ uninstalledEditors.map( ( [ editor, label ] ) => (
-						<option key={ editor } value={ editor } disabled>
-							{ label }
+					{ uninstalledEditors.map( ( [ editorKey, editorConfig ] ) => (
+						<option key={ editorKey } value={ editorKey } disabled>
+							{ editorConfig.label }
 						</option>
 					) ) }
 				</optgroup>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-387.

## Proposed Changes

- Add config for handling additional editors on sites overview section.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Check out this branch
- Select PhpStorm or Cursor editor from preferences
- Make sure Open In... "YOUR SELECTED EDITOR" buttons appear
![CleanShot 2025-04-23 at 19 02 09@2x](https://github.com/user-attachments/assets/0027fb7d-1638-4240-ae0c-df1bbec20e88)
- Click on the button and make sure the editor opens with the site folder selected. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
