### PR TITLE
Sync: Filter out a8c sites from the sync sites listing

### DIFF
--- a/src/hooks/use-fetch-wpcom-sites/index.tsx
+++ b/src/hooks/use-fetch-wpcom-sites/index.tsx
@@ -16,6 +16,7 @@ export const sitesEndpointSiteSchema = z.object( {
 	jetpack: z.boolean().optional(),
 	is_deleted: z.boolean(),
 	hosting_provider_guess: z.string().optional(),
+	site_owner: z.number().optional(),
 	options: z
 		.object( {
 			created_at: z.string(),
@@ -51,6 +52,7 @@ export const sitesEndpointResponseSchema = z.object( {
 } );
 
 const STUDIO_SYNC_FEATURE_NAME = 'studio-sync';
+const A8C_SITE_OWNER_ID = 26957695;
 
 function isPressableSite( site: SitesEndpointSite ): boolean {
 	return site.hosting_provider_guess === 'pressable';
@@ -128,6 +130,7 @@ export function transformSitesResponse( sites: unknown[], connectedSiteIds: numb
 	} );
 
 	return validatedSites
+		.filter( ( site ) => site.site_owner !== A8C_SITE_OWNER_ID )
 		.filter( ( site ) => ! site.is_deleted || connectedSiteIds.some( ( id ) => id === site.ID ) )
 		.map( ( site ) => {
 			// The API returns the wrong value for the `is_wpcom_staging_site` prop while staging sites
@@ -169,7 +172,8 @@ export const useFetchWpComSites = ( connectedSiteIdsOnlyForSelectedSite: number[
 		try {
 			const allConnectedSites = await getIpcApi().getConnectedWpcomSites();
 
-			const baseFields = 'name,ID,URL,plan,capabilities,is_wpcom_atomic,options,jetpack,is_deleted';
+			const baseFields =
+				'name,ID,URL,plan,capabilities,is_wpcom_atomic,options,jetpack,is_deleted,site_owner';
 			const fields = pressableSyncEnabled ? `${ baseFields },hosting_provider_guess` : baseFields;
 
 			const response = await client.req.get(


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Resolves STU-390-linear-issue

## Proposed Changes

- filter out sites owned by a8c

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR branch and build the app with `npm start`.
2. Head over to the Sync tab of any local site and click on the `Connect site` button.
3. Observe that the list of sites in the modal does not include any a8c sites.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?