### PR TITLE
Fix editor detection on Windows

### DIFF
--- a/src/lib/is-installed.ts
+++ b/src/lib/is-installed.ts
@@ -27,14 +27,12 @@ function getLocalProgramsPath(): string {
 		return app.getPath( 'appData' );
 	}
 
-	// On Windows, we can get the Local\Programs folder by using LOCALAPPDATA
 	const localAppData = process.env.LOCALAPPDATA;
 	if ( localAppData ) {
-		return path.join( localAppData, 'Local', 'Programs' );
+		return path.win32.join( localAppData, 'Local', 'Programs' );
 	}
 
-	// Fallback to electron's appData path if environment variable is not available
-	return path.join( app.getPath( 'appData' ), 'Local', 'Programs' );
+	return path.win32.join( app.getPath( 'appData' ), 'Local', 'Programs' );
 }
 
 // Define installation paths for each IDE by platform

--- a/src/lib/is-installed.ts
+++ b/src/lib/is-installed.ts
@@ -82,7 +82,6 @@ const installationPaths: Record< string, PlatformPaths > = {
 	},
 };
 
-console.log( installationPaths );
 
 if ( process.platform === 'darwin' ) {
 	const systemApplications = '/Applications';

--- a/src/lib/is-installed.ts
+++ b/src/lib/is-installed.ts
@@ -29,9 +29,10 @@ function getLocalProgramsPath(): string {
 
 	const localAppData = process.env.LOCALAPPDATA;
 	if ( localAppData ) {
-		return path.win32.join( path.dirname(localAppData), 'Local', 'Programs' );
+		return path.win32.join( localAppData, 'Programs' );
 	}
 
+	// Fallback to electron's appData path if environment variable is not available
 	return path.win32.join( app.getPath( 'appData' ), 'Local', 'Programs' );
 }
 
@@ -80,6 +81,8 @@ const installationPaths: Record< string, PlatformPaths > = {
 		terminal: [],
 	},
 };
+
+console.log( installationPaths );
 
 if ( process.platform === 'darwin' ) {
 	const systemApplications = '/Applications';

--- a/src/lib/is-installed.ts
+++ b/src/lib/is-installed.ts
@@ -82,7 +82,6 @@ const installationPaths: Record< string, PlatformPaths > = {
 	},
 };
 
-
 if ( process.platform === 'darwin' ) {
 	const systemApplications = '/Applications';
 	const userApplications = path.join( app.getPath( 'home' ), 'Applications' );

--- a/src/lib/is-installed.ts
+++ b/src/lib/is-installed.ts
@@ -37,7 +37,6 @@ function getAppDataPath(): string {
 	return app.getPath( 'appData' );
 }
 
-console.log(getAppDataPath());
 // Define installation paths for each IDE by platform
 const installationPaths: Record< string, PlatformPaths > = {
 	darwin: {

--- a/src/lib/is-installed.ts
+++ b/src/lib/is-installed.ts
@@ -29,7 +29,7 @@ function getLocalProgramsPath(): string {
 
 	const localAppData = process.env.LOCALAPPDATA;
 	if ( localAppData ) {
-		return path.win32.join( localAppData, 'Local', 'Programs' );
+		return path.win32.join( path.dirname(localAppData), 'Local', 'Programs' );
 	}
 
 	return path.win32.join( app.getPath( 'appData' ), 'Local', 'Programs' );

--- a/src/lib/is-installed.ts
+++ b/src/lib/is-installed.ts
@@ -22,19 +22,19 @@ function getProgramFilesPath(): string {
 	return 'C:\\Program Files';
 }
 
-function getAppDataPath(): string {
+function getLocalProgramsPath(): string {
 	if ( process.platform !== 'win32' ) {
 		return app.getPath( 'appData' );
 	}
 
-	// On Windows, we can get the AppData folder by going up one directory from LOCALAPPDATA
+	// On Windows, we can get the Local\Programs folder by using LOCALAPPDATA
 	const localAppData = process.env.LOCALAPPDATA;
 	if ( localAppData ) {
-		return path.dirname( localAppData );
+		return path.join( localAppData, 'Local', 'Programs' );
 	}
 
 	// Fallback to electron's appData path if environment variable is not available
-	return app.getPath( 'appData' );
+	return path.join( app.getPath( 'appData' ), 'Local', 'Programs' );
 }
 
 // Define installation paths for each IDE by platform
@@ -60,23 +60,23 @@ const installationPaths: Record< string, PlatformPaths > = {
 	win32: {
 		vscode: [
 			path.win32.join( getProgramFilesPath(), 'Microsoft VS Code' ),
-			path.win32.join( getAppDataPath(), 'Local\\Programs\\Microsoft VS Code' ),
+			path.win32.join( getLocalProgramsPath(), 'Microsoft VS Code' ),
 		],
 		phpstorm: [
 			path.win32.join( getProgramFilesPath(), 'JetBrains\\PhpStorm' ),
-			path.win32.join( getAppDataPath(), 'Local\\Programs\\PhpStorm' ),
+			path.win32.join( getLocalProgramsPath(), 'PhpStorm' ),
 		],
 		cursor: [
 			path.win32.join( getProgramFilesPath(), 'Cursor' ),
-			path.win32.join( getAppDataPath(), 'Local\\Programs\\cursor' ),
+			path.win32.join( getLocalProgramsPath(), 'cursor' ),
 		],
 		windsurf: [
 			path.win32.join( getProgramFilesPath(), 'Windsurf' ),
-			path.win32.join( getAppDataPath(), 'Local\\Programs\\Windsurf' ),
+			path.win32.join( getLocalProgramsPath(), 'Windsurf' ),
 		],
 		webstorm: [
 			path.win32.join( getProgramFilesPath(), 'JetBrains\\WebStorm' ),
-			path.win32.join( getAppDataPath(), 'Local\\Programs\\WebStorm' ),
+			path.win32.join( getLocalProgramsPath(), 'WebStorm' ),
 		],
 		iterm: [],
 		terminal: [],

--- a/src/lib/is-installed.ts
+++ b/src/lib/is-installed.ts
@@ -61,15 +61,15 @@ const installationPaths: Record< string, PlatformPaths > = {
 	win32: {
 		vscode: [
 			path.win32.join( getProgramFilesPath(), 'Microsoft VS Code' ),
-			path.win32.join(getAppDataPath(), 'Local\\Programs\\Microsoft VS Code' ),
+			path.win32.join( getAppDataPath(), 'Local\\Programs\\Microsoft VS Code' ),
 		],
 		phpstorm: [
 			path.win32.join( getProgramFilesPath(), 'JetBrains\\PhpStorm' ),
-			path.win32.join( getAppDataPath(), 'Local\\Programs\\JetBrains\\PhpStorm' ),
+			path.win32.join( getAppDataPath(), 'Local\\Programs\\PhpStorm' ),
 		],
 		cursor: [
 			path.win32.join( getProgramFilesPath(), 'Cursor' ),
-			path.win32.join(getAppDataPath(), 'Local\\Programs\\cursor' ),
+			path.win32.join( getAppDataPath(), 'Local\\Programs\\cursor' ),
 		],
 		windsurf: [
 			path.win32.join( getProgramFilesPath(), 'Windsurf' ),
@@ -77,7 +77,7 @@ const installationPaths: Record< string, PlatformPaths > = {
 		],
 		webstorm: [
 			path.win32.join( getProgramFilesPath(), 'JetBrains\\WebStorm' ),
-			path.win32.join( getAppDataPath(), 'Local\\Programs\\JetBrains\\WebStorm' ),
+			path.win32.join( getAppDataPath(), 'Local\\Programs\\WebStorm' ),
 		],
 		iterm: [],
 		terminal: [],

--- a/src/lib/is-installed.ts
+++ b/src/lib/is-installed.ts
@@ -22,6 +22,22 @@ function getProgramFilesPath(): string {
 	return 'C:\\Program Files';
 }
 
+function getAppDataPath(): string {
+	if ( process.platform !== 'win32' ) {
+		return app.getPath( 'appData' );
+	}
+
+	// On Windows, we can get the AppData folder by going up one directory from LOCALAPPDATA
+	const localAppData = process.env.LOCALAPPDATA;
+	if ( localAppData ) {
+		return path.dirname( localAppData );
+	}
+
+	// Fallback to electron's appData path if environment variable is not available
+	return app.getPath( 'appData' );
+}
+
+console.log(getAppDataPath());
 // Define installation paths for each IDE by platform
 const installationPaths: Record< string, PlatformPaths > = {
 	darwin: {
@@ -45,23 +61,23 @@ const installationPaths: Record< string, PlatformPaths > = {
 	win32: {
 		vscode: [
 			path.win32.join( getProgramFilesPath(), 'Microsoft VS Code' ),
-			path.win32.join( app.getPath( 'appData' ), 'Local\\Programs\\Microsoft VS Code' ),
+			path.win32.join(getAppDataPath(), 'Local\\Programs\\Microsoft VS Code' ),
 		],
 		phpstorm: [
 			path.win32.join( getProgramFilesPath(), 'JetBrains\\PhpStorm' ),
-			path.win32.join( app.getPath( 'appData' ), 'JetBrains\\PhpStorm' ),
+			path.win32.join( getAppDataPath(), 'Local\\Programs\\JetBrains\\PhpStorm' ),
 		],
 		cursor: [
 			path.win32.join( getProgramFilesPath(), 'Cursor' ),
-			path.win32.join( app.getPath( 'appData' ), 'Local\\Programs\\Cursor' ),
+			path.win32.join(getAppDataPath(), 'Local\\Programs\\cursor' ),
 		],
 		windsurf: [
 			path.win32.join( getProgramFilesPath(), 'Windsurf' ),
-			path.win32.join( app.getPath( 'appData' ), 'Windsurf' ),
+			path.win32.join( getAppDataPath(), 'Local\\Programs\\Windsurf' ),
 		],
 		webstorm: [
 			path.win32.join( getProgramFilesPath(), 'JetBrains\\WebStorm' ),
-			path.win32.join( app.getPath( 'appData' ), 'JetBrains\\WebStorm' ),
+			path.win32.join( getAppDataPath(), 'Local\\Programs\\JetBrains\\WebStorm' ),
 		],
 		iterm: [],
 		terminal: [],

--- a/src/lib/tests/is-installed.test.ts
+++ b/src/lib/tests/is-installed.test.ts
@@ -76,6 +76,7 @@ describe( 'isInstalled', () => {
 		beforeEach( () => {
 			Object.defineProperty( process, 'platform', { value: 'win32' } );
 			process.env.ProgramFiles = 'D:\\Program Files';
+			process.env.LOCALAPPDATA = 'C:\\Users\\TestUser\\AppData';
 			// Re-import the module after setting the environment variable
 			jest.isolateModules( () => {
 				const module = require( '../is-installed' );
@@ -85,26 +86,27 @@ describe( 'isInstalled', () => {
 
 		it( 'detects VS Code installed in Program Files', () => {
 			mockPaths = [ 'D:\\Program Files\\Microsoft VS Code' ];
-
 			expect( isInstalled( 'vscode' ) ).toBe( true );
 		} );
 
-		it( 'detects VS Code installed in AppData', () => {
-			mockPaths = [ 'C:\\mock\\AppData\\Local\\Programs\\Microsoft VS Code' ];
+		it( 'detects VS Code installed in Local Programs', () => {
+			mockPaths = [ 'C:\\Users\\TestUser\\AppData\\Local\\Programs\\Microsoft VS Code' ];
 			expect( isInstalled( 'vscode' ) ).toBe( true );
 		} );
 
 		it( 'detects PhpStorm with version-specific folder', () => {
 			mockPaths = [ 'D:\\Program Files\\JetBrains', 'D:\\Program Files\\JetBrains\\PhpStorm' ];
-
 			( fs.readdirSync as jest.Mock ).mockReturnValue( [ 'PhpStorm 2023.1', 'WebStorm 2023.1' ] );
+			expect( isInstalled( 'phpstorm' ) ).toBe( true );
+		} );
 
+		it( 'detects PhpStorm in Local Programs', () => {
+			mockPaths = [ 'C:\\Users\\TestUser\\AppData\\Local\\Programs\\PhpStorm' ];
 			expect( isInstalled( 'phpstorm' ) ).toBe( true );
 		} );
 
 		it( 'falls back to default Program Files path when environment variable is not set', () => {
 			delete process.env.ProgramFiles;
-
 			// Re-import the module after setting the environment variable
 			jest.isolateModules( () => {
 				const module = require( '../is-installed' );
@@ -112,6 +114,18 @@ describe( 'isInstalled', () => {
 			} );
 
 			mockPaths = [ 'C:\\Program Files\\Microsoft VS Code' ];
+			expect( isInstalled( 'vscode' ) ).toBe( true );
+		} );
+
+		it( 'falls back to electron appData path when LOCALAPPDATA is not set', () => {
+			delete process.env.LOCALAPPDATA;
+			// Re-import the module after setting the environment variable
+			jest.isolateModules( () => {
+				const module = require( '../is-installed' );
+				isInstalled = module.isInstalled;
+			} );
+
+			mockPaths = [ 'C:\\mock\\AppData\\Local\\Programs\\Microsoft VS Code' ];
 			expect( isInstalled( 'vscode' ) ).toBe( true );
 		} );
 	} );

--- a/src/lib/tests/is-installed.test.ts
+++ b/src/lib/tests/is-installed.test.ts
@@ -34,7 +34,9 @@ describe( 'isInstalled', () => {
 				case 'home':
 					return '/mock/home/path';
 				case 'appData':
-					return process.platform === 'win32' ? 'C:\\mock\\AppData' : '/mock/home/path/.config';
+					return process.platform === 'win32'
+						? 'C:\\Users\\TestUser\\AppData\\Roaming'
+						: '/mock/home/path/.config';
 				default:
 					return '';
 			}
@@ -76,7 +78,7 @@ describe( 'isInstalled', () => {
 		beforeEach( () => {
 			Object.defineProperty( process, 'platform', { value: 'win32' } );
 			process.env.ProgramFiles = 'D:\\Program Files';
-			process.env.LOCALAPPDATA = 'C:\\Users\\TestUser\\AppData';
+			process.env.LOCALAPPDATA = 'C:\\Users\\TestUser\\AppData\\Local';
 			// Re-import the module after setting the environment variable
 			jest.isolateModules( () => {
 				const module = require( '../is-installed' );
@@ -125,7 +127,7 @@ describe( 'isInstalled', () => {
 				isInstalled = module.isInstalled;
 			} );
 
-			mockPaths = [ 'C:\\mock\\AppData\\Local\\Programs\\Microsoft VS Code' ];
+			mockPaths = [ 'C:\\Users\\TestUser\\AppData\\Roaming\\Local\\Programs\\Microsoft VS Code' ];
 			expect( isInstalled( 'vscode' ) ).toBe( true );
 		} );
 	} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes [STU-393 User Settings: fix Windows app detection](https://linear.app/a8c/issue/STU-393/user-settings-fix-windows-app-detection)

## Proposed Changes

- Get the AppData path using an env var
- Use the AppData Local path for detecting installed apps

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

#### Unit tests
- Run `npm test src/lib/tests/is-installed.test.ts` and `npm test`
![CleanShot 2025-04-23 at 15 24 37@2x](https://github.com/user-attachments/assets/5ef9b54c-4889-4adc-a5f1-f8fb74c1e965)

#### Manual tests
- Using Windows, start the app with `STUDIO_PREFERRED_EDITOR=true npm start`
- Open Preferences
- Check that the Editor picker correctly shows the list of editors.

Having installed all apps on a Windows x64 machine (Cursor doesn't have an official arm64 build):
![CleanShot 2025-04-23 at 15 25 38@2x](https://github.com/user-attachments/assets/dd97b3a5-cd48-4c20-a026-3c43153d74df)

#### Regressions

- Using Mac, check for any regressions

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
