### PR TITLE
Assorted CLI tweaks

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -18,9 +18,6 @@ async function main() {
 		.usage( __( 'Studio by WordPress.com CLI' ) )
 		.locale( locale )
 		.version( version )
-		.middleware( () =>
-			bumpAggregatedUniqueStat( StatsGroup.STUDIO_CLI_USAGE_UNIQUE, StatsMetric.SUCCESS, 'weekly' )
-		)
 		.option( 'output-format', {
 			type: 'string',
 			hidden: true,
@@ -30,6 +27,19 @@ async function main() {
 				}
 				return value;
 			},
+		} )
+		.option( 'avoid-telemetry', {
+			type: 'boolean',
+			hidden: true,
+		} )
+		.middleware( async ( argv ) => {
+			if ( ! argv.avoidTelemetry ) {
+				await bumpAggregatedUniqueStat(
+					StatsGroup.STUDIO_CLI_USAGE_UNIQUE,
+					StatsMetric.SUCCESS,
+					'weekly'
+				);
+			}
 		} )
 		.command( 'preview', __( 'Manage preview sites' ), ( previewYargs ) => {
 			registerCreateCommand( previewYargs );

--- a/src/modules/cli/lib/execute-command.ts
+++ b/src/modules/cli/lib/execute-command.ts
@@ -1,8 +1,7 @@
 import { fork } from 'node:child_process';
 import EventEmitter from 'node:events';
-import path from 'node:path';
 import * as Sentry from '@sentry/electron/main';
-import { getResourcesPath } from 'src/storage/paths';
+import { getCliPath } from 'src/storage/paths';
 
 type CliCommandEventMap = {
 	data: { data: unknown };
@@ -45,12 +44,9 @@ function* parseOutput( data: Buffer ): Generator< unknown, void, unknown > {
 }
 
 export function executeCliCommand( args: string[] ): CliCommandEventEmitter {
-	const cliPath =
-		process.env.NODE_ENV === 'development'
-			? path.join( getResourcesPath(), 'dist', 'cli', 'main.js' )
-			: path.join( getResourcesPath(), 'cli', 'main.js' );
+	const cliPath = getCliPath();
 	// Using Electron's utilityProcess.fork API gave us issues with the child process never exiting
-	const child = fork( cliPath, [ ...args, '--output-format', 'json' ], {
+	const child = fork( cliPath, [ ...args, '--output-format', 'json', '--avoid-telemetry' ], {
 		stdio: 'pipe',
 	} );
 	const eventEmitter = new CliCommandEventEmitter();

--- a/src/modules/user-settings/components/tests/user-settings.test.tsx
+++ b/src/modules/user-settings/components/tests/user-settings.test.tsx
@@ -65,22 +65,6 @@ describe( 'UserSettings', () => {
 		} );
 	} );
 
-	it( 'calls refetchSnapshotUsage when modal is opened', async () => {
-		const refetchMock = jest.fn();
-		( useGetSnapshotUsage as jest.Mock ).mockReturnValue( {
-			data: { siteCount: 2, siteLimit: 10, siteCreationBlocked: false },
-			isLoading: false,
-			refetch: refetchMock,
-		} );
-		( useAuth as jest.Mock ).mockReturnValue( { isAuthenticated: true } );
-		( useFeatureFlags as jest.Mock ).mockReturnValue( {
-			preferredEditor: false,
-		} );
-
-		renderWithProvider( <UserSettings /> );
-		expect( refetchMock ).toHaveBeenCalledTimes( 1 );
-	} );
-
 	it( 'logs in when not authenticated', async () => {
 		const authenticate = jest.fn();
 		( useAuth as jest.Mock ).mockReturnValue( { isAuthenticated: false, authenticate } );

--- a/src/modules/user-settings/components/user-settings.tsx
+++ b/src/modules/user-settings/components/user-settings.tsx
@@ -34,11 +34,7 @@ export default function UserSettings() {
 		snapshotSelectors.selectSnapshotsByUser( state, user?.id ?? 0 )
 	);
 	const snapshotQuota = useRootSelector( ( state ) => state.snapshot.snapshotQuota );
-	const {
-		data: snapshotUsage,
-		isLoading: isLoadingSnapshotUsage,
-		refetch: refetchSnapshotUsage,
-	} = useGetSnapshotUsage();
+	const { data: snapshotUsage, isLoading: isLoadingSnapshotUsage } = useGetSnapshotUsage();
 	const definitiveSnapshotCount = snapshotUsage?.siteCount ?? snapshotsByUser?.length ?? 0;
 
 	const [ needsToOpenUserSettings, setNeedsToOpenUserSettings ] = useState( false );
@@ -71,12 +67,6 @@ export default function UserSettings() {
 			await dispatch( snapshotThunks.deleteAllSnapshotsForUser( { userId: user?.id ?? 0 } ) );
 		}
 	}, [ __, dispatch, user?.id ] );
-
-	useEffect( () => {
-		if ( needsToOpenUserSettings ) {
-			refetchSnapshotUsage();
-		}
-	}, [ snapshotsByUser.length, needsToOpenUserSettings, refetchSnapshotUsage ] );
 
 	if ( ! preferredEditor ) {
 		return (

--- a/src/storage/paths.ts
+++ b/src/storage/paths.ts
@@ -38,6 +38,12 @@ export function getResourcesPath(): string {
 	return path.join( exePath, 'resources' );
 }
 
+export function getCliPath(): string {
+	return process.env.NODE_ENV === 'development'
+		? path.join( getResourcesPath(), 'dist', 'cli', 'main.js' )
+		: path.join( getResourcesPath(), 'cli', 'main.js' );
+}
+
 function inChildProcess() {
 	return process.env.STUDIO_IN_CHILD_PROCESS === 'true';
 }

--- a/src/stores/snapshot-slice.ts
+++ b/src/stores/snapshot-slice.ts
@@ -141,10 +141,8 @@ const snapshotSlice = createSlice( {
 			);
 		},
 		setSnapshots: ( state, action: PayloadAction< Snapshot[] > ) => {
-			if ( ! fastDeepEqual( state.snapshots, action.payload ) ) {
-				state.snapshots = action.payload;
-				state.isInitialSnapshotsLoaded = true;
-			}
+			state.snapshots = action.payload;
+			state.isInitialSnapshotsLoaded = true;
 		},
 		updateOperation: (
 			state,
@@ -293,7 +291,17 @@ const selectSnapshotsBySiteAndUser = createSelector(
 );
 
 window.ipcListener.subscribe( 'user-data-updated', ( _, payload ) => {
-	store.dispatch( snapshotSlice.actions.setSnapshots( payload.snapshots ) );
+	const state = store.getState();
+	const snapshots = payload.snapshots;
+
+	if ( ! fastDeepEqual( state.snapshot.snapshots, snapshots ) ) {
+		store.dispatch( snapshotSlice.actions.setSnapshots( snapshots ) );
+
+		// Wait for changes to take effect on the back-end before invalidating the query
+		setTimeout( () => {
+			store.dispatch( wpcomApi.util.invalidateTags( [ 'SnapshotUsage' ] ) );
+		}, 8000 );
+	}
 } );
 
 function getCreateProgress( action: PreviewCommandLoggerAction ): [ string, number ] {
@@ -475,11 +483,6 @@ window.ipcListener.subscribe( 'snapshot-success', ( event, payload ) => {
 			} );
 		}
 	}
-
-	// Wait for changes to take effect on the back-end before invalidating the cache.
-	setTimeout( () => {
-		store.dispatch( wpcomApi.util.invalidateTags( [ 'SnapshotUsage' ] ) );
-	}, 8000 );
 } );
 
 export const snapshotActions = snapshotSlice.actions;

--- a/src/stores/snapshot-slice.ts
+++ b/src/stores/snapshot-slice.ts
@@ -297,6 +297,13 @@ window.ipcListener.subscribe( 'user-data-updated', ( _, payload ) => {
 	if ( ! fastDeepEqual( state.snapshot.snapshots, snapshots ) ) {
 		store.dispatch( snapshotSlice.actions.setSnapshots( snapshots ) );
 
+		// Optimistically update the snapshot usage count
+		store.dispatch(
+			wpcomApi.util.updateQueryData( 'getSnapshotUsage', undefined, ( data ) => {
+				data.siteCount = snapshots.length;
+			} )
+		);
+
 		// Wait for changes to take effect on the back-end before invalidating the query
 		setTimeout( () => {
 			store.dispatch( wpcomApi.util.invalidateTags( [ 'SnapshotUsage' ] ) );
@@ -449,12 +456,6 @@ window.ipcListener.subscribe( 'snapshot-success', ( event, payload ) => {
 	}
 
 	if ( operation.type === 'create' ) {
-		store.dispatch(
-			wpcomApi.util.updateQueryData( 'getSnapshotUsage', undefined, ( data ) => {
-				data.siteCount += 1;
-			} )
-		);
-
 		getIpcApi().showNotification( {
 			title: operation.snapshotName,
 			body: sprintf( __( "Preview site '%s' has been created." ), operation.snapshotUrl ),
@@ -465,12 +466,6 @@ window.ipcListener.subscribe( 'snapshot-success', ( event, payload ) => {
 			body: sprintf( __( "Preview site '%s' has been updated." ), operation.snapshotUrl ),
 		} );
 	} else if ( operation.type === 'delete' ) {
-		store.dispatch(
-			wpcomApi.util.updateQueryData( 'getSnapshotUsage', undefined, ( data ) => {
-				data.siteCount -= 1;
-			} )
-		);
-
 		if ( ! bulkOperation ) {
 			getIpcApi().showNotification( {
 				title: operation.snapshotName,

--- a/src/stores/snapshot-slice.ts
+++ b/src/stores/snapshot-slice.ts
@@ -298,9 +298,10 @@ window.ipcListener.subscribe( 'user-data-updated', ( _, payload ) => {
 		store.dispatch( snapshotSlice.actions.setSnapshots( snapshots ) );
 
 		// Optimistically update the snapshot usage count
+		const countDiff = snapshots.length - state.snapshot.snapshots.length;
 		store.dispatch(
 			wpcomApi.util.updateQueryData( 'getSnapshotUsage', undefined, ( data ) => {
-				data.siteCount = snapshots.length;
+				data.siteCount += countDiff;
 			} )
 		);
 

--- a/src/stores/snapshot-slice.ts
+++ b/src/stores/snapshot-slice.ts
@@ -98,9 +98,9 @@ const deleteSnapshot = createAsyncThunk(
 
 async function deleteMultipleSnapshots(
 	snapshots: Snapshot[]
-): Promise< [ string, crypto.UUID ][] > {
+): Promise< [ url: string, operationId: crypto.UUID ][] > {
 	return await Promise.all(
-		snapshots.map( async ( snapshot ): Promise< [ string, crypto.UUID ] > => {
+		snapshots.map( async ( snapshot ) => {
 			const { operationId } = await getIpcApi().deleteSnapshot( snapshot.url );
 			return [ snapshot.url, operationId ];
 		} )


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes #

## Proposed Changes

- Type tweak in `src/stores/snapshot-slice.ts`
- Added a standalone `getCliPath` function
- Removed refetch call for `useGetSnapshotUsage` query in `UserSettings` (see https://github.com/Automattic/studio/pull/1244#discussion_r2057697355)
- Added `--avoid-telemetry` option to CLI for when CLI is initiated internally from Studio

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Code review should suffice

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
