### PR TITLE
Build the CLI with `mode: production` in the Webpack config

### DIFF
--- a/cli/lib/appdata.ts
+++ b/cli/lib/appdata.ts
@@ -114,8 +114,7 @@ export async function getAuthToken(): Promise< NonNullable< UserData[ 'authToken
 		return authToken;
 	} catch ( error ) {
 		throw new LoggerError(
-			__( 'Authentication required. Please run the Studio app and log in to WordPress.com first.' ),
-			error
+			__( 'Authentication required. Please run the Studio app and log in to WordPress.com first.' )
 		);
 	}
 }

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -132,7 +132,7 @@ const config: ForgeConfig = {
 			}
 
 			console.log( 'Building CLI ...' );
-			const compiler = webpack( cliConfig );
+			const compiler = webpack( { ...cliConfig, mode: 'production' } );
 
 			await new Promise< void >( ( resolve, reject ) => {
 				compiler.run( ( error ) => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-396

## Proposed Changes

When building the CLI as part of the electron-forge packaging flow, we should use the `mode: production` Webpack config option (see [docs](https://webpack.js.org/configuration/mode/)) to ensure that `process.env.NODE_ENV` is interpolated to the correct value.

This fixes an issue where `Would have bumped stat…` is printed by the CLI in production environments.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Download a dev build from Buildkite
2. Explore the package contents and open `Contents/Resources/cli/main.js`
3. Find the `bumpStat` function
4. Ensure it doesn't contain a `console.info( 'Would have bumped stat…` call

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
