### PR TITLE
Sync: Replace `site_owner` with `is_a8c` field for filtering out A8C sites

### DIFF
--- a/src/hooks/use-fetch-wpcom-sites/index.tsx
+++ b/src/hooks/use-fetch-wpcom-sites/index.tsx
@@ -16,7 +16,7 @@ export const sitesEndpointSiteSchema = z.object( {
 	jetpack: z.boolean().optional(),
 	is_deleted: z.boolean(),
 	hosting_provider_guess: z.string().optional(),
-	site_owner: z.number().optional(),
+	is_a8c: z.boolean().optional(),
 	options: z
 		.object( {
 			created_at: z.string(),
@@ -130,7 +130,7 @@ export function transformSitesResponse( sites: unknown[], connectedSiteIds: numb
 	} );
 
 	return validatedSites
-		.filter( ( site ) => site.site_owner !== A8C_SITE_OWNER_ID )
+		.filter( ( site ) => ! site.is_a8c )
 		.filter( ( site ) => ! site.is_deleted || connectedSiteIds.some( ( id ) => id === site.ID ) )
 		.map( ( site ) => {
 			// The API returns the wrong value for the `is_wpcom_staging_site` prop while staging sites
@@ -173,7 +173,7 @@ export const useFetchWpComSites = ( connectedSiteIdsOnlyForSelectedSite: number[
 			const allConnectedSites = await getIpcApi().getConnectedWpcomSites();
 
 			const baseFields =
-				'name,ID,URL,plan,capabilities,is_wpcom_atomic,options,jetpack,is_deleted,site_owner';
+				'name,ID,URL,plan,capabilities,is_wpcom_atomic,options,jetpack,is_deleted,is_a8c';
 			const fields = pressableSyncEnabled ? `${ baseFields },hosting_provider_guess` : baseFields;
 
 			const response = await client.req.get(


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Related to STU-390-linear-issue

## Proposed Changes

- use `is_a8c` instead of `site_owner` field to filter out A8C sites

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. If 181408-ghe-Automattic/wpcom hasn't been merged and deployed yet, check out related branch and sandbox `public-api.wordpress.com`.
2. Check out the PR branch and build the app with `npm start`.
3. Head over to the Sync tab of any local site and click on the `Connect site` button.
4. Observe that the list of sites in the modal does not include any A8C sites.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?