### PR TITLE
Export: Exclude `node_modules` and `.git` paths from site export

### DIFF
--- a/src/lib/import-export/export/exporters/default-exporter.ts
+++ b/src/lib/import-export/export/exporters/default-exporter.ts
@@ -38,7 +38,6 @@ export class DefaultExporter extends EventEmitter implements Exporter {
 		'wp-content/mu-plugins/0-wp-config-constants-polyfill.php',
 		'wp-content/mu-plugins/0-sqlite.php',
 		'wp-content/mu-plugins/0-thumbnails.php',
-		'wp-content/plugins/node_modules/',
 	];
 
 	constructor( options: ExportOptions ) {

--- a/src/lib/import-export/export/exporters/default-exporter.ts
+++ b/src/lib/import-export/export/exporters/default-exporter.ts
@@ -229,12 +229,11 @@ export class DefaultExporter extends EventEmitter implements Exporter {
 				relativePath.startsWith( path.normalize( pathToExclude ) )
 			);
 
-			// Check for node_modules within any plugin directory
-			const isPluginNodeModules =
-				relativePath.startsWith( 'wp-content/plugins/' ) &&
-				relativePath.includes( '/node_modules/' );
+			// Check for node_modules and .git directories anywhere
+			const isNodeModulesDirectory = relativePath.includes( 'node_modules' );
+			const isGitDirectory = relativePath.includes( '.git' );
 
-			if ( isExcluded || isPluginNodeModules ) {
+			if ( isExcluded || isNodeModulesDirectory || isGitDirectory ) {
 				return files;
 			}
 			if ( directoryContent.isFile() ) {

--- a/src/lib/import-export/export/exporters/default-exporter.ts
+++ b/src/lib/import-export/export/exporters/default-exporter.ts
@@ -38,6 +38,7 @@ export class DefaultExporter extends EventEmitter implements Exporter {
 		'wp-content/mu-plugins/0-wp-config-constants-polyfill.php',
 		'wp-content/mu-plugins/0-sqlite.php',
 		'wp-content/mu-plugins/0-thumbnails.php',
+		'wp-content/plugins/node_modules/',
 	];
 
 	constructor( options: ExportOptions ) {
@@ -223,10 +224,18 @@ export class DefaultExporter extends EventEmitter implements Exporter {
 		return directoryContents.reduce< string[] >( ( files: string[], directoryContent ) => {
 			const filePath = path.join( directoryContent.path, directoryContent.name );
 			const relativePath = path.relative( this.options.site.path, filePath );
+
+			// Check for exact path exclusions
 			const isExcluded = this.pathsToExclude.some( ( pathToExclude ) =>
 				relativePath.startsWith( path.normalize( pathToExclude ) )
 			);
-			if ( isExcluded ) {
+
+			// Check for node_modules within any plugin directory
+			const isPluginNodeModules =
+				relativePath.startsWith( 'wp-content/plugins/' ) &&
+				relativePath.includes( '/node_modules/' );
+
+			if ( isExcluded || isPluginNodeModules ) {
 				return files;
 			}
 			if ( directoryContent.isFile() ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Resolves STU-205-linear-issue

## Proposed Changes

- exclude `node_modules` and `.git` paths from site export

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR branch and build the app with `npm start`.
2. Open one of your local sites in Finder / Terminal and create a bunch of directories with `.git` and `node_modules` with some random files in them.
3. Add these directories to `/wp-content/plugins`, `/wp-content/themes`, etc. ...
4. Head over to the Import / Export tab and export the site.
5. Extract the export and review the directories. There should be no `.git` or `node_modules` directories present.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?