### PR TITLE
Studio: Remove redundant useEffect on user-settings

### DIFF
--- a/src/modules/user-settings/components/user-settings.tsx
+++ b/src/modules/user-settings/components/user-settings.tsx
@@ -1,6 +1,6 @@
 import { TabPanel } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 import Modal from 'src/components/modal';
 import { useAuth } from 'src/hooks/use-auth';
 import { useFeatureFlags } from 'src/hooks/use-feature-flags';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

N/A

## Proposed Changes

While working on unrelated issue, I noticed that we have unused import in the `user-settings.tsx` file. I propose to clean it up with this PR. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Look through the code and confirm that the changes look good:

<img width="1041" alt="Screenshot 2025-04-25 at 2 01 31 PM" src="https://github.com/user-attachments/assets/077b67f0-4a4f-40ae-bdba-00a1b0eb89cd" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
