### PR TITLE
Wire up void IPC handlers using `ipcMain.on`

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -64,3 +64,19 @@ export const WP_CLI_IMPORT_EXPORT_RESPONSE_TIMEOUT =
 export const SQLITE_DATABASE_INTEGRATION_VERSION = 'v2.1.17-alpha.1';
 
 export const SQLITE_DATABASE_INTEGRATION_RELEASE_URL = `https://github.com/Automattic/sqlite-database-integration/archive/refs/tags/${ SQLITE_DATABASE_INTEGRATION_VERSION }.zip`;
+
+// IPC handlers that don't return anything (i.e. that are called with `ipcRenderer.send`)
+export const IPC_VOID_HANDLERS = < const >[
+	'addSyncOperation',
+	'clearSyncOperation',
+	'logRendererMessage',
+	'openCertificate',
+	'openFileInIDE',
+	'openLocalPath',
+	'openSiteURL',
+	'openURL',
+	'popupAppMenu',
+	'showErrorMessageBox',
+	'showItemInFolder',
+	'showNotification',
+];

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ import path from 'path';
 import * as Sentry from '@sentry/electron/main';
 import { __ } from '@wordpress/i18n';
 import { StatsGroup } from 'common/types/stats';
-import { PROTOCOL_PREFIX } from 'src/constants';
+import { PROTOCOL_PREFIX, IPC_VOID_HANDLERS } from 'src/constants';
 import * as ipcHandlers from 'src/ipc-handlers';
 import { hasActiveSyncOperations } from 'src/lib/active-sync-operations';
 import { bumpAggregatedUniqueStat, bumpStat } from 'src/lib/bump-stats';
@@ -148,29 +148,27 @@ async function appBoot() {
 	}
 
 	function setupIpc() {
-		for ( const [ key, handler ] of Object.entries( ipcHandlers ) ) {
-			if ( typeof handler === 'function' && key !== 'logRendererMessage' ) {
-				ipcMain.handle( key, function ( event, ...args ) {
+		const ipcHandlerEntries = Object.entries( ipcHandlers ) as [
+			keyof typeof ipcHandlers,
+			( ...args: unknown[] ) => unknown,
+		][];
+
+		for ( const [ key, handler ] of ipcHandlerEntries ) {
+			if ( IPC_VOID_HANDLERS.find( ( handler ) => handler === key ) ) {
+				ipcMain.on( key, function ( event, ...args: unknown[] ) {
 					try {
 						validateIpcSender( event );
-
-						// Invoke the handler. Param types have already been type checked by code in ipc-types.d.ts,
-						// so we can safetly ignore the handler function's param types here.
-						return ( handler as any )( event, ...args ); // eslint-disable-line @typescript-eslint/no-explicit-any
+						handler( event, ...args );
 					} catch ( error ) {
 						console.error( error );
 						throw error;
 					}
 				} );
-			}
-
-			// logRendererMessage is handled specially because it uses the (hopefully more efficient)
-			// fire-and-forget .send method instead of .invoke
-			if ( typeof handler === 'function' && key === 'logRendererMessage' ) {
-				ipcMain.on( key, function ( event, level, ...args ) {
+			} else {
+				ipcMain.handle( key, function ( event, ...args: unknown[] ) {
 					try {
 						validateIpcSender( event );
-						( handler as typeof ipcHandlers.logRendererMessage )( event, level as never, ...args );
+						return handler( event, ...args );
 					} catch ( error ) {
 						console.error( error );
 						throw error;

--- a/src/ipc-types.d.ts
+++ b/src/ipc-types.d.ts
@@ -65,19 +65,7 @@ type ToPromise< T > = T extends Promise< unknown > ? T : Promise< T >;
 type IpcHandlers = typeof import('./ipc-handlers');
 
 // Define which handlers use `ipcRenderer.send` instead of `ipcRenderer.invoke` in `src/preload.ts`
-type NonInvokeHandlers =
-	| 'addSyncOperation'
-	| 'clearSyncOperation'
-	| 'logRendererMessage'
-	| 'openCertificate'
-	| 'openFileInIDE'
-	| 'openLocalPath'
-	| 'openSiteURL'
-	| 'openURL'
-	| 'popupAppMenu'
-	| 'showErrorMessageBox'
-	| 'showItemInFolder'
-	| 'showNotification';
+type IpcVoidHandlers = ( typeof import('./constants') )[ 'IPC_VOID_HANDLERS' ][ number ];
 
 // IpcApi functions have the same signatures as the functions in ipc-handlers.ts, except
 // with the first parameter removed.
@@ -89,7 +77,7 @@ type IpcApi = {
 	// of a utility function.
 	[ K in keyof IpcHandlers ]: (
 		...args: WithoutIpcEvent< Parameters< IpcHandlers[ K ] > >
-	) => K extends NonInvokeHandlers ? undefined : ToPromise< ReturnType< IpcHandlers[ K ] > >;
+	) => K extends IpcVoidHandlers ? undefined : ToPromise< ReturnType< IpcHandlers[ K ] > >;
 } & {
 	// `webUtils.getPathForFile` is available only inside preload script, that's why this one
 	// function is exception and need to be defined here manually. See

--- a/src/ipc-types.d.ts
+++ b/src/ipc-types.d.ts
@@ -71,8 +71,8 @@ type IpcVoidHandlers = ( typeof import('./constants') )[ 'IPC_VOID_HANDLERS' ][ 
 // with the first parameter removed.
 type IpcApi = {
 	// `void` is satisfied by `Promise<any>`, which means that if a method in the
-	// `NonInvokeHandlers` list returns an `ipcRenderer.invoke` call, it wouldn't raise a type
-	// error. We use `undefined` instead because we want to be intentional about using
+	// `IpcVoidHandlers` list returns an `ipcRenderer.invoke` call, it wouldn't raise a type
+	// error. We use `undefined` instead because we need to be intentional about using
 	// `ipcRenderer.invoke` vs `ipcRenderer.send`. We make this work in `preload.ts` with the help
 	// of a utility function.
 	[ K in keyof IpcHandlers ]: (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes a regression from https://github.com/Automattic/studio/pull/1086

## Proposed Changes

- Use a constant to define the list of void IPC handlers instead of a type. 
- Derive the `IpcApi` directly from this constant. 
- Use this list to determine which channels should use `ipcMain.on` and `ipcMain.handle` respectively in the `setupIpc` function in `src/index.ts`. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Start Studio
2. Ensure that you can open any URL (a site homepage, for example)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
