### PR TITLE
Site Overview: setup default state for editor and terminal

### DIFF
--- a/src/components/content-tab-overview.tsx
+++ b/src/components/content-tab-overview.tsx
@@ -26,7 +26,7 @@ import { cx } from 'src/lib/cx';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 import { useEditorData } from 'src/modules/user-settings/hooks/use-editor-data';
 import { useTerminalData } from 'src/modules/user-settings/hooks/use-terminal-data';
-import { SupportedEditor, supportedEditorConfig } from 'src/modules/user-settings/lib/editor';
+import { supportedEditorConfig } from 'src/modules/user-settings/lib/editor';
 import { supportedTerminalNames } from 'src/modules/user-settings/lib/terminal';
 
 interface ContentTabOverviewProps {
@@ -170,7 +170,7 @@ function ShortcutsSection( { selectedSite }: Pick< ContentTabOverviewProps, 'sel
 		},
 	];
 
-	const editorConfig = editor ? supportedEditorConfig[ editor as SupportedEditor ] : false;
+	const editorConfig = editor ? supportedEditorConfig[ editor ] : false;
 	if ( editorConfig ) {
 		buttonsArray.push( {
 			label: editorConfig.label,

--- a/src/components/content-tab-overview.tsx
+++ b/src/components/content-tab-overview.tsx
@@ -14,19 +14,20 @@ import {
 	widget,
 } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect } from 'react';
 import { ArrowIcon } from 'src/components/arrow-icon';
 import { ButtonsSection, ButtonsSectionProps } from 'src/components/buttons-section';
-import { useCheckInstalledApps } from 'src/hooks/use-check-installed-apps';
+import { useEditorData } from 'src/hooks/use-editor-data';
 import { useFeatureFlags } from 'src/hooks/use-feature-flags';
 import { useIpcListener } from 'src/hooks/use-ipc-listener';
 import { useSiteDetails } from 'src/hooks/use-site-details';
+import { useTerminalData } from 'src/hooks/use-terminal-data';
 import { useThemeDetails } from 'src/hooks/use-theme-details';
 import { isMac } from 'src/lib/app-globals';
 import { cx } from 'src/lib/cx';
 import { getIpcApi } from 'src/lib/get-ipc-api';
-import { supportedEditorConfig } from 'src/modules/user-settings/lib/editor';
-import { supportedTerminalNames, DEFAULT_TERMINAL } from 'src/modules/user-settings/lib/terminal';
+import { SupportedEditor, supportedEditorConfig } from 'src/modules/user-settings/lib/editor';
+import { SupportedTerminal, supportedTerminalNames } from 'src/modules/user-settings/lib/terminal';
 
 interface ContentTabOverviewProps {
 	selectedSite: SiteDetails;
@@ -141,34 +142,28 @@ function CustomizeSection( {
 
 function ShortcutsSection( { selectedSite }: Pick< ContentTabOverviewProps, 'selectedSite' > ) {
 	const { terminalWpCliEnabled } = useFeatureFlags();
-	const installedApps = useCheckInstalledApps();
-	const [ terminalName, setTerminalName ] = useState( supportedTerminalNames[ DEFAULT_TERMINAL ] );
-	const [ editorName, setEditorName ] = useState( '' );
+	const { terminal, getSavedTerminal } = useTerminalData();
+	const { editor, getSavedEditor } = useEditorData();
+	const [ terminalName, setTerminalName ] = useState( supportedTerminalNames[ terminal ] );
+	const [ editorName, setEditorName ] = useState( editor );
 
-	const updateTerminalName = useCallback( async () => {
-		const terminal = await getIpcApi().getUserTerminal();
-		setTerminalName( supportedTerminalNames[ terminal ] );
-	}, [ setTerminalName ] );
+	const handleEditorChange = ( newEditor: SupportedEditor ) => {
+		setEditorName( newEditor );
+	};
 
-	const updateEditorName = useCallback( async () => {
-		const editor = await getIpcApi().getUserEditor();
-
-		if ( editor && installedApps[ editor as keyof typeof installedApps ] ) {
-			setEditorName( editor );
-		} else {
-			setEditorName( '' );
-		}
-	}, [ setEditorName, installedApps ] );
-
-	useIpcListener( 'user-preference-changed', () => {
-		void updateTerminalName();
-		void updateEditorName();
-	} );
+	const handleTerminalChange = ( newTerminal: SupportedTerminal ) => {
+		setTerminalName( supportedTerminalNames[ newTerminal ] );
+	};
 
 	useEffect( () => {
-		void updateTerminalName();
-		void updateEditorName();
-	}, [ updateTerminalName, updateEditorName ] );
+		handleEditorChange( editor );
+		handleTerminalChange( terminal );
+	}, [ editor, terminal ] );
+
+	useIpcListener( 'user-preference-changed', async () => {
+		handleEditorChange( await getSavedEditor() );
+		handleTerminalChange( await getSavedTerminal() );
+	} );
 
 	const buttonsArray: ButtonsSectionProps[ 'buttonsArray' ] = [
 		{

--- a/src/components/content-tab-overview.tsx
+++ b/src/components/content-tab-overview.tsx
@@ -147,22 +147,22 @@ function ShortcutsSection( { selectedSite }: Pick< ContentTabOverviewProps, 'sel
 	const [ terminalName, setTerminalName ] = useState( supportedTerminalNames[ terminal ] );
 	const [ editorName, setEditorName ] = useState( editor );
 
-	const handleEditorChange = ( newEditor: SupportedEditor ) => {
+	const updateEditorName = ( newEditor: SupportedEditor ) => {
 		setEditorName( newEditor );
 	};
 
-	const handleTerminalChange = ( newTerminal: SupportedTerminal ) => {
+	const updateTerminalName = ( newTerminal: SupportedTerminal ) => {
 		setTerminalName( supportedTerminalNames[ newTerminal ] );
 	};
 
 	useEffect( () => {
-		handleEditorChange( editor );
-		handleTerminalChange( terminal );
+		updateEditorName( editor );
+		updateTerminalName( terminal );
 	}, [ editor, terminal ] );
 
 	useIpcListener( 'user-preference-changed', async () => {
-		handleEditorChange( await getSavedEditor() );
-		handleTerminalChange( await getSavedTerminal() );
+		updateEditorName( await getSavedEditor() );
+		updateTerminalName( await getSavedTerminal() );
 	} );
 
 	const buttonsArray: ButtonsSectionProps[ 'buttonsArray' ] = [

--- a/src/components/content-tab-overview.tsx
+++ b/src/components/content-tab-overview.tsx
@@ -26,8 +26,8 @@ import { useThemeDetails } from 'src/hooks/use-theme-details';
 import { isMac } from 'src/lib/app-globals';
 import { cx } from 'src/lib/cx';
 import { getIpcApi } from 'src/lib/get-ipc-api';
-import { SupportedEditor, supportedEditorConfig } from 'src/modules/user-settings/lib/editor';
-import { SupportedTerminal, supportedTerminalNames } from 'src/modules/user-settings/lib/terminal';
+import { supportedEditorConfig } from 'src/modules/user-settings/lib/editor';
+import { supportedTerminalNames } from 'src/modules/user-settings/lib/terminal';
 
 interface ContentTabOverviewProps {
 	selectedSite: SiteDetails;

--- a/src/components/content-tab-overview.tsx
+++ b/src/components/content-tab-overview.tsx
@@ -17,15 +17,15 @@ import { useI18n } from '@wordpress/react-i18n';
 import { useState, useEffect } from 'react';
 import { ArrowIcon } from 'src/components/arrow-icon';
 import { ButtonsSection, ButtonsSectionProps } from 'src/components/buttons-section';
-import { useEditorData } from 'src/hooks/use-editor-data';
 import { useFeatureFlags } from 'src/hooks/use-feature-flags';
 import { useIpcListener } from 'src/hooks/use-ipc-listener';
 import { useSiteDetails } from 'src/hooks/use-site-details';
-import { useTerminalData } from 'src/hooks/use-terminal-data';
 import { useThemeDetails } from 'src/hooks/use-theme-details';
 import { isMac } from 'src/lib/app-globals';
 import { cx } from 'src/lib/cx';
 import { getIpcApi } from 'src/lib/get-ipc-api';
+import { useEditorData } from 'src/modules/user-settings/hooks/use-editor-data';
+import { useTerminalData } from 'src/modules/user-settings/hooks/use-terminal-data';
 import { supportedEditorConfig } from 'src/modules/user-settings/lib/editor';
 import { supportedTerminalNames } from 'src/modules/user-settings/lib/terminal';
 

--- a/src/components/content-tab-overview.tsx
+++ b/src/components/content-tab-overview.tsx
@@ -142,27 +142,17 @@ function CustomizeSection( {
 
 function ShortcutsSection( { selectedSite }: Pick< ContentTabOverviewProps, 'selectedSite' > ) {
 	const { terminalWpCliEnabled } = useFeatureFlags();
-	const { terminal, getSavedTerminal } = useTerminalData();
-	const { editor, getSavedEditor } = useEditorData();
-	const [ terminalName, setTerminalName ] = useState( supportedTerminalNames[ terminal ] );
-	const [ editorName, setEditorName ] = useState( editor );
-
-	const updateEditorName = ( newEditor: SupportedEditor ) => {
-		setEditorName( newEditor );
-	};
-
-	const updateTerminalName = ( newTerminal: SupportedTerminal ) => {
-		setTerminalName( supportedTerminalNames[ newTerminal ] );
-	};
+	const { terminal, handleTerminalChange, getSavedTerminal } = useTerminalData();
+	const { editor, handleEditorChange, getSavedEditor } = useEditorData();
 
 	useEffect( () => {
-		updateEditorName( editor );
-		updateTerminalName( terminal );
-	}, [ editor, terminal ] );
+		handleEditorChange( editor );
+		handleTerminalChange( terminal );
+	}, [ editor, handleEditorChange, handleTerminalChange, terminal ] );
 
 	useIpcListener( 'user-preference-changed', async () => {
-		updateEditorName( await getSavedEditor() );
-		updateTerminalName( await getSavedTerminal() );
+		handleEditorChange( await getSavedEditor() );
+		handleTerminalChange( await getSavedTerminal() );
 	} );
 
 	const buttonsArray: ButtonsSectionProps[ 'buttonsArray' ] = [
@@ -180,19 +170,19 @@ function ShortcutsSection( { selectedSite }: Pick< ContentTabOverviewProps, 'sel
 		},
 	];
 
-	if ( editorName ) {
-		const editor = supportedEditorConfig[ editorName as keyof typeof supportedEditorConfig ];
-		if ( editor ) {
-			buttonsArray.push( {
-				label: editor.label,
-				className: 'text-nowrap',
-				icon: code,
-				onClick: () => {
-					getIpcApi().openURL( editor.url( selectedSite.path ) );
-				},
-			} );
-		}
+	const editorConfig = supportedEditorConfig[ editor ];
+	if ( editorConfig ) {
+		buttonsArray.push( {
+			label: editorConfig.label,
+			className: 'text-nowrap',
+			icon: code,
+			onClick: () => {
+				getIpcApi().openURL( editorConfig.url( selectedSite.path ) );
+			},
+		} );
 	}
+
+	const terminalName = supportedTerminalNames[ terminal ];
 	buttonsArray.push( {
 		label: terminalName,
 		className: 'text-nowrap',

--- a/src/components/content-tab-overview.tsx
+++ b/src/components/content-tab-overview.tsx
@@ -26,7 +26,7 @@ import { cx } from 'src/lib/cx';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 import { useEditorData } from 'src/modules/user-settings/hooks/use-editor-data';
 import { useTerminalData } from 'src/modules/user-settings/hooks/use-terminal-data';
-import { supportedEditorConfig } from 'src/modules/user-settings/lib/editor';
+import { SupportedEditor, supportedEditorConfig } from 'src/modules/user-settings/lib/editor';
 import { supportedTerminalNames } from 'src/modules/user-settings/lib/terminal';
 
 interface ContentTabOverviewProps {
@@ -170,7 +170,7 @@ function ShortcutsSection( { selectedSite }: Pick< ContentTabOverviewProps, 'sel
 		},
 	];
 
-	const editorConfig = supportedEditorConfig[ editor ];
+	const editorConfig = editor ? supportedEditorConfig[ editor as SupportedEditor ] : false;
 	if ( editorConfig ) {
 		buttonsArray.push( {
 			label: editorConfig.label,

--- a/src/components/tests/content-tab-overview-shortcuts-section.test.tsx
+++ b/src/components/tests/content-tab-overview-shortcuts-section.test.tsx
@@ -50,6 +50,7 @@ describe( 'ShortcutsSection', () => {
 			openURL: openURLMock,
 			getUserEditor: jest.fn().mockResolvedValue( 'vscode' ),
 			getUserTerminal: jest.fn().mockResolvedValue( 'terminal' ),
+			getInstalledTerminals: jest.fn().mockResolvedValue( [ 'terminal' ] ),
 		} );
 
 		const { getByLabelText } = render( <ContentTabOverview selectedSite={ selectedSite } /> );
@@ -74,6 +75,7 @@ describe( 'ShortcutsSection', () => {
 			openURL: openURLMock,
 			getUserEditor: jest.fn().mockResolvedValue( 'phpstorm' ), // User prefers PhpStorm
 			getUserTerminal: jest.fn().mockResolvedValue( 'terminal' ),
+			getInstalledTerminals: jest.fn().mockResolvedValue( [ 'terminal' ] ),
 		} );
 
 		const { getByLabelText } = render( <ContentTabOverview selectedSite={ selectedSite } /> );
@@ -99,6 +101,7 @@ describe( 'ShortcutsSection', () => {
 			openTerminalAtPath: openTerminalAtPathMock,
 			getUserEditor: jest.fn().mockResolvedValue( null ),
 			getUserTerminal: jest.fn().mockResolvedValue( 'terminal' ),
+			getInstalledTerminals: jest.fn().mockResolvedValue( [ 'terminal' ] ),
 		} );
 
 		const { getByLabelText } = render( <ContentTabOverview selectedSite={ selectedSite } /> );
@@ -131,6 +134,7 @@ describe( 'ShortcutsSection', () => {
 			openTerminalAtPath: openTerminalAtPathMock,
 			getUserEditor: jest.fn().mockResolvedValue( null ),
 			getUserTerminal: jest.fn().mockResolvedValue( 'terminal' ),
+			getInstalledTerminals: jest.fn().mockResolvedValue( [ 'terminal' ] ),
 		} );
 
 		const { getByLabelText } = render( <ContentTabOverview selectedSite={ selectedSite } /> );
@@ -157,7 +161,8 @@ describe( 'ShortcutsSection', () => {
 		mockGetIpcApi.mockReturnValue( {
 			openLocalPath: jest.fn(),
 			getUserEditor: jest.fn().mockResolvedValue( null ),
-			getUserTerminal: jest.fn().mockResolvedValue( 'terminal' ),
+			getUserTerminal: jest.fn().mockResolvedValue( null ),
+			getInstalledTerminals: jest.fn().mockResolvedValue( [] ),
 		} );
 
 		const { queryByLabelText, findByLabelText } = render(
@@ -165,7 +170,8 @@ describe( 'ShortcutsSection', () => {
 		);
 
 		await findByLabelText( 'Terminal' );
-		expect( queryByLabelText( 'VS Code' ) ).toBeNull();
+		await findByLabelText( 'VS Code' );
+
 		expect( queryByLabelText( 'PhpStorm' ) ).toBeNull();
 	} );
 } );

--- a/src/components/tests/content-tab-overview-shortcuts-section.test.tsx
+++ b/src/components/tests/content-tab-overview-shortcuts-section.test.tsx
@@ -1,7 +1,6 @@
 // To run tests, execute `npm run test -- src/components/tests/content-tab-overview-shortcuts-section.test.tsx` from the root directory
 import { fireEvent, render, waitFor } from '@testing-library/react';
 import { ContentTabOverview } from 'src/components/content-tab-overview';
-import { useCheckInstalledApps } from 'src/hooks/use-check-installed-apps';
 import { useFeatureFlags } from 'src/hooks/use-feature-flags';
 import { useThemeDetails } from 'src/hooks/use-theme-details';
 import { getIpcApi } from 'src/lib/get-ipc-api';
@@ -38,12 +37,6 @@ describe( 'ShortcutsSection', () => {
 	} );
 
 	it( 'opens site in VS Code when the user select VS Code and clicked the button', async () => {
-		// Mock the `useCheckInstalledApps` hook to simulate VS Code being installed
-		( useCheckInstalledApps as jest.Mock ).mockReturnValue( {
-			vscode: true,
-			phpstorm: false,
-		} );
-
 		// Mock the IPC API
 		const openURLMock = jest.fn();
 		mockGetIpcApi.mockReturnValue( {
@@ -51,6 +44,10 @@ describe( 'ShortcutsSection', () => {
 			getUserEditor: jest.fn().mockResolvedValue( 'vscode' ),
 			getUserTerminal: jest.fn().mockResolvedValue( 'terminal' ),
 			getInstalledTerminals: jest.fn().mockResolvedValue( [ 'terminal' ] ),
+			getInstalledApps: jest.fn().mockResolvedValue( {
+				vscode: true,
+				phpstorm: false,
+			} ),
 		} );
 
 		const { getByLabelText } = render( <ContentTabOverview selectedSite={ selectedSite } /> );
@@ -63,12 +60,6 @@ describe( 'ShortcutsSection', () => {
 	} );
 
 	it( 'opens site in PhpStorm when PhpStorm is installed and the button is clicked, only available on MacOS', async () => {
-		// Mock the `useCheckInstalledApps` hook to simulate PhpStorm being installed
-		( useCheckInstalledApps as jest.Mock ).mockReturnValue( {
-			vscode: false,
-			phpstorm: true,
-		} );
-
 		// Mock the IPC API
 		const openURLMock = jest.fn();
 		mockGetIpcApi.mockReturnValue( {
@@ -76,6 +67,10 @@ describe( 'ShortcutsSection', () => {
 			getUserEditor: jest.fn().mockResolvedValue( 'phpstorm' ), // User prefers PhpStorm
 			getUserTerminal: jest.fn().mockResolvedValue( 'terminal' ),
 			getInstalledTerminals: jest.fn().mockResolvedValue( [ 'terminal' ] ),
+			getInstalledApps: jest.fn().mockResolvedValue( {
+				vscode: false,
+				phpstorm: true,
+			} ),
 		} );
 
 		const { getByLabelText } = render( <ContentTabOverview selectedSite={ selectedSite } /> );
@@ -89,12 +84,6 @@ describe( 'ShortcutsSection', () => {
 		);
 	} );
 	it( 'opens terminal when terminal is available and the button is clicked', async () => {
-		// Mock the `useCheckInstalledApps` hook to simulate terminal being available
-		( useCheckInstalledApps as jest.Mock ).mockReturnValue( {
-			vscode: false,
-			phpstorm: false,
-		} );
-
 		// Mock the IPC API
 		const openTerminalAtPathMock = jest.fn();
 		mockGetIpcApi.mockReturnValue( {
@@ -102,6 +91,10 @@ describe( 'ShortcutsSection', () => {
 			getUserEditor: jest.fn().mockResolvedValue( null ),
 			getUserTerminal: jest.fn().mockResolvedValue( 'terminal' ),
 			getInstalledTerminals: jest.fn().mockResolvedValue( [ 'terminal' ] ),
+			getInstalledApps: jest.fn().mockResolvedValue( {
+				vscode: false,
+				phpstorm: false,
+			} ),
 		} );
 
 		const { getByLabelText } = render( <ContentTabOverview selectedSite={ selectedSite } /> );
@@ -119,11 +112,6 @@ describe( 'ShortcutsSection', () => {
 	} );
 
 	it( 'opens terminal with wp-cli integration if feature flag is enabled', async () => {
-		// Mock the `useCheckInstalledApps` hook to simulate terminal being available
-		( useCheckInstalledApps as jest.Mock ).mockReturnValue( {
-			vscode: false,
-			phpstorm: false,
-		} );
 		( useFeatureFlags as jest.Mock ).mockReturnValue( {
 			terminalWpCliEnabled: true,
 		} );
@@ -151,18 +139,39 @@ describe( 'ShortcutsSection', () => {
 	} );
 
 	it( 'does not show editor buttons when no editors are installed', async () => {
-		// Mock the `useCheckInstalledApps` hook to simulate no editors installed
-		( useCheckInstalledApps as jest.Mock ).mockReturnValue( {
-			vscode: false,
-			phpstorm: false,
-		} );
-
 		// Mock the IPC API
 		mockGetIpcApi.mockReturnValue( {
 			openLocalPath: jest.fn(),
 			getUserEditor: jest.fn().mockResolvedValue( null ),
 			getUserTerminal: jest.fn().mockResolvedValue( null ),
 			getInstalledTerminals: jest.fn().mockResolvedValue( [] ),
+			getInstalledApps: jest.fn().mockResolvedValue( {
+				vscode: false,
+				phpstorm: false,
+			} ),
+		} );
+
+		const { queryByLabelText, findByLabelText } = render(
+			<ContentTabOverview selectedSite={ selectedSite } />
+		);
+
+		await findByLabelText( 'Terminal' );
+
+		expect( queryByLabelText( 'VS Code' ) ).toBeNull();
+		expect( queryByLabelText( 'PhpStorm' ) ).toBeNull();
+	} );
+
+	it( 'shows VS Code editor button when VS Code and phpStorm both editors are installed', async () => {
+		// Mock the IPC API
+		mockGetIpcApi.mockReturnValue( {
+			openLocalPath: jest.fn(),
+			getUserEditor: jest.fn().mockResolvedValue( null ),
+			getUserTerminal: jest.fn().mockResolvedValue( null ),
+			getInstalledTerminals: jest.fn().mockResolvedValue( [] ),
+			getInstalledApps: jest.fn().mockResolvedValue( {
+				vscode: true,
+				phpstorm: true,
+			} ),
 		} );
 
 		const { queryByLabelText, findByLabelText } = render(
@@ -172,6 +181,54 @@ describe( 'ShortcutsSection', () => {
 		await findByLabelText( 'Terminal' );
 		await findByLabelText( 'VS Code' );
 
+		expect( queryByLabelText( 'PhpStorm' ) ).toBeNull();
+	} );
+
+	it( 'shows phpStorm editor button when VS Code is not installed but phpStorm is', async () => {
+		// Mock the IPC API
+		mockGetIpcApi.mockReturnValue( {
+			openLocalPath: jest.fn(),
+			getUserEditor: jest.fn().mockResolvedValue( null ),
+			getUserTerminal: jest.fn().mockResolvedValue( null ),
+			getInstalledTerminals: jest.fn().mockResolvedValue( [] ),
+			getInstalledApps: jest.fn().mockResolvedValue( {
+				vscode: false,
+				phpstorm: true,
+			} ),
+		} );
+
+		const { queryByLabelText, findByLabelText } = render(
+			<ContentTabOverview selectedSite={ selectedSite } />
+		);
+
+		await findByLabelText( 'Terminal' );
+		await findByLabelText( 'PhpStorm' );
+
+		expect( queryByLabelText( 'VS Code' ) ).toBeNull();
+	} );
+
+	it( 'shows users preffered editor', async () => {
+		// Mock the IPC API
+		mockGetIpcApi.mockReturnValue( {
+			openLocalPath: jest.fn(),
+			getUserEditor: jest.fn().mockResolvedValue( 'cursor' ),
+			getUserTerminal: jest.fn().mockResolvedValue( null ),
+			getInstalledTerminals: jest.fn().mockResolvedValue( [] ),
+			getInstalledApps: jest.fn().mockResolvedValue( {
+				vscode: true,
+				phpstorm: true,
+				cursor: true,
+			} ),
+		} );
+
+		const { queryByLabelText, findByLabelText } = render(
+			<ContentTabOverview selectedSite={ selectedSite } />
+		);
+
+		await findByLabelText( 'Terminal' );
+		await findByLabelText( 'Cursor' );
+
+		expect( queryByLabelText( 'VS Code' ) ).toBeNull();
 		expect( queryByLabelText( 'PhpStorm' ) ).toBeNull();
 	} );
 } );

--- a/src/components/tests/content-tab-overview-shortcuts-section.test.tsx
+++ b/src/components/tests/content-tab-overview-shortcuts-section.test.tsx
@@ -207,7 +207,7 @@ describe( 'ShortcutsSection', () => {
 		expect( queryByLabelText( 'VS Code' ) ).toBeNull();
 	} );
 
-	it( 'shows users preffered editor', async () => {
+	it( 'shows users preferred editor', async () => {
 		// Mock the IPC API
 		mockGetIpcApi.mockReturnValue( {
 			openLocalPath: jest.fn(),

--- a/src/components/tests/site-content-tabs.test.tsx
+++ b/src/components/tests/site-content-tabs.test.tsx
@@ -77,7 +77,6 @@ describe( 'SiteContentTabs', () => {
 		expect( screen.queryByRole( 'tab', { name: 'Assistant', selected: false } ) ).toBeVisible();
 		expect( screen.queryByRole( 'tab', { name: 'Backup', selected: false } ) ).toBeNull();
 	} );
-
 	it( 'should render a "No Site" screen if selected site is absent', async () => {
 		( useSiteDetails as jest.Mock ).mockReturnValue( {
 			undefined,

--- a/src/components/tests/site-content-tabs.test.tsx
+++ b/src/components/tests/site-content-tabs.test.tsx
@@ -77,6 +77,7 @@ describe( 'SiteContentTabs', () => {
 		expect( screen.queryByRole( 'tab', { name: 'Assistant', selected: false } ) ).toBeVisible();
 		expect( screen.queryByRole( 'tab', { name: 'Backup', selected: false } ) ).toBeNull();
 	} );
+
 	it( 'should render a "No Site" screen if selected site is absent', async () => {
 		( useSiteDetails as jest.Mock ).mockReturnValue( {
 			undefined,

--- a/src/components/tests/site-content-tabs.test.tsx
+++ b/src/components/tests/site-content-tabs.test.tsx
@@ -31,6 +31,7 @@ jest.mock( 'src/lib/get-ipc-api', () => ( {
 		updateConnectedWpcomSites: jest.fn(),
 		getUserTerminal: jest.fn().mockResolvedValue( 'terminal' ),
 		getUserEditor: jest.fn().mockResolvedValue( 'vscode' ),
+		getInstalledTerminals: jest.fn().mockResolvedValue( [] ),
 	} ),
 } ) );
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -28,6 +28,7 @@ export const WPCOM_PROFILE_URL = 'https://wordpress.com/me';
 export const LOCAL_STORAGE_CHAT_MESSAGES_KEY = 'ai_chat_messages';
 export const LOCAL_STORAGE_CHAT_API_IDS_KEY = 'ai_chat_ids';
 export const DEFAULT_TERMINAL = 'terminal';
+export const DEFAULT_EDITOR = 'vscode';
 
 //Import file constants
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -27,6 +27,7 @@ export const FEATURE_REQUEST_URL =
 export const WPCOM_PROFILE_URL = 'https://wordpress.com/me';
 export const LOCAL_STORAGE_CHAT_MESSAGES_KEY = 'ai_chat_messages';
 export const LOCAL_STORAGE_CHAT_API_IDS_KEY = 'ai_chat_ids';
+export const DEFAULT_TERMINAL = 'terminal';
 
 //Import file constants
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -28,7 +28,6 @@ export const WPCOM_PROFILE_URL = 'https://wordpress.com/me';
 export const LOCAL_STORAGE_CHAT_MESSAGES_KEY = 'ai_chat_messages';
 export const LOCAL_STORAGE_CHAT_API_IDS_KEY = 'ai_chat_ids';
 export const DEFAULT_TERMINAL = 'terminal';
-export const DEFAULT_EDITOR = 'vscode';
 
 //Import file constants
 

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -1269,12 +1269,12 @@ export async function checkSyncBackupSize(
 
 export async function saveUserTerminal(
 	_event: IpcMainInvokeEvent,
-	supportedTerminal: SupportedTerminal
+	preferredTerminal: SupportedTerminal
 ) {
 	const userData = await loadUserData();
 	await saveUserData( {
 		...userData,
-		supportedTerminal: supportedTerminal,
+		preferredTerminal: preferredTerminal,
 	} );
 
 	// Notify renderer processes that the terminal preference has changed
@@ -1283,7 +1283,7 @@ export async function saveUserTerminal(
 
 export async function getUserTerminal( _event: IpcMainInvokeEvent ): Promise< SupportedTerminal > {
 	const userData = await loadUserData();
-	return userData.supportedTerminal || DEFAULT_TERMINAL;
+	return userData.preferredTerminal as SupportedTerminal;
 }
 
 export async function isFullscreen( _event: IpcMainInvokeEvent ): Promise< boolean > {

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -22,7 +22,7 @@ import { SupportedLocale } from 'common/lib/locale';
 import { getAuthenticationUrl } from 'common/lib/oauth';
 import { Snapshot } from 'common/types/snapshot';
 import { StatsGroup, StatsMetric } from 'common/types/stats';
-import { ARCHIVER_OPTIONS, MAIN_MIN_WIDTH, SIDEBAR_WIDTH } from 'src/constants';
+import { ARCHIVER_OPTIONS, DEFAULT_TERMINAL, MAIN_MIN_WIDTH, SIDEBAR_WIDTH } from 'src/constants';
 import { sendIpcEventToRenderer, sendIpcEventToRendererWithWindow } from 'src/ipc-utils';
 import { ACTIVE_SYNC_OPERATIONS } from 'src/lib/active-sync-operations';
 import { bumpStat } from 'src/lib/bump-stats';
@@ -1283,7 +1283,7 @@ export async function saveUserTerminal(
 
 export async function getUserTerminal( _event: IpcMainInvokeEvent ): Promise< SupportedTerminal > {
 	const userData = await loadUserData();
-	return userData.preferredTerminal as SupportedTerminal;
+	return ( userData.preferredTerminal || DEFAULT_TERMINAL ) as SupportedTerminal;
 }
 
 export async function isFullscreen( _event: IpcMainInvokeEvent ): Promise< boolean > {

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -987,13 +987,13 @@ export async function openTerminalAtPath(
 		initScriptSteps.push( `cd \\"${ escapedPath }\\"`, 'clear' );
 
 		const userData = await loadUserData();
-		const preferredTerminal = userData.supportedTerminal || 'terminal';
+		const preferredTerminal = userData.preferredEditor || 'terminal';
 
 		if ( preferredTerminal === ( 'warp' as SupportedTerminal ) ) {
 			return promiseExec( `open -a Warp "${ targetPath }"` );
 		} else if ( preferredTerminal === ( 'ghostty' as SupportedTerminal ) ) {
 			return promiseExec( `open -a Ghostty "${ targetPath }"` );
-		} else if ( preferredTerminal === 'iterm' ) {
+		} else if ( preferredTerminal === ( 'iterm' as SupportedTerminal ) ) {
 			return promiseExec( `osascript << END
 tell application "iTerm"
     activate
@@ -1013,7 +1013,7 @@ END` );
 		}
 	} else if ( platform === 'win32' ) {
 		const userData = await loadUserData();
-		const preferredTerminal = userData.supportedTerminal;
+		const preferredTerminal = userData.preferredTerminal;
 		const defaultShell = process.env.ComSpec || 'cmd.exe';
 		const env = wpCliEnabled
 			? { PATH: `${ cliPath };${ process.env.PATH }`, STUDIO_APP_PATH: appPath }

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -987,7 +987,7 @@ export async function openTerminalAtPath(
 		initScriptSteps.push( `cd \\"${ escapedPath }\\"`, 'clear' );
 
 		const userData = await loadUserData();
-		const preferredTerminal = userData.preferredEditor || 'terminal';
+		const preferredTerminal = userData.preferredTerminal || 'terminal';
 
 		if ( preferredTerminal === ( 'warp' as SupportedTerminal ) ) {
 			return promiseExec( `open -a Warp "${ targetPath }"` );

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -556,9 +556,11 @@ export async function getUserLocale( _event: IpcMainInvokeEvent ): Promise< Supp
 	return getUserLocaleWithFallback();
 }
 
-export async function getUserEditor( _event: IpcMainInvokeEvent ): Promise< SupportedEditor > {
+export async function getUserEditor(
+	_event: IpcMainInvokeEvent
+): Promise< SupportedEditor | undefined > {
 	const userData = await loadUserData();
-	return userData.preferredEditor as SupportedEditor;
+	return userData.preferredEditor;
 }
 
 export function showUserSettings( event: IpcMainInvokeEvent ) {

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -60,7 +60,7 @@ import { DEFAULT_SITE_PATH, getResourcesPath, getSiteThumbnailPath } from 'src/s
 import { loadUserData, saveUserData } from 'src/storage/user-data';
 import { DEFAULT_PHP_VERSION, DEFAULT_WORDPRESS_VERSION } from 'vendor/wp-now/src/constants';
 import { SupportedEditor } from './modules/user-settings/lib/editor';
-import { SupportedTerminal, DEFAULT_TERMINAL } from './modules/user-settings/lib/terminal';
+import { SupportedTerminal } from './modules/user-settings/lib/terminal';
 import type { SyncSite } from 'src/hooks/use-fetch-wpcom-sites/types';
 import type { WpCliResult } from 'src/lib/wp-cli-process';
 

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -987,13 +987,13 @@ export async function openTerminalAtPath(
 		initScriptSteps.push( `cd \\"${ escapedPath }\\"`, 'clear' );
 
 		const userData = await loadUserData();
-		const preferredTerminal = userData.preferredTerminal || 'terminal';
+		const preferredTerminal = ( userData.preferredTerminal || 'terminal' ) as SupportedTerminal;
 
-		if ( preferredTerminal === ( 'warp' as SupportedTerminal ) ) {
+		if ( preferredTerminal === 'warp' ) {
 			return promiseExec( `open -a Warp "${ targetPath }"` );
-		} else if ( preferredTerminal === ( 'ghostty' as SupportedTerminal ) ) {
+		} else if ( preferredTerminal === 'ghostty' ) {
 			return promiseExec( `open -a Ghostty "${ targetPath }"` );
-		} else if ( preferredTerminal === ( 'iterm' as SupportedTerminal ) ) {
+		} else if ( preferredTerminal === 'iterm' ) {
 			return promiseExec( `osascript << END
 tell application "iTerm"
     activate

--- a/src/modules/user-settings/components/editor-picker.tsx
+++ b/src/modules/user-settings/components/editor-picker.tsx
@@ -6,8 +6,8 @@ import { SupportedEditor, supportedEditorConfig } from 'src/modules/user-setting
 import { SettingsFormField } from './settings-form-field';
 
 interface EditorPickerProps {
-	value: SupportedEditor | string;
-	onChange: ( value: SupportedEditor ) => void;
+	value: SupportedEditor | undefined;
+	onChange: ( value: SupportedEditor | undefined ) => void;
 }
 
 export const EditorPicker = ( { value, onChange }: EditorPickerProps ) => {
@@ -47,7 +47,7 @@ export const EditorPicker = ( { value, onChange }: EditorPickerProps ) => {
 				__nextHasNoMarginBottom
 				__next40pxDefaultSize
 			>
-				{ value === '' && <option value={ '' }>{ __( 'Select' ) }</option> }
+				{ ! value && <option value={ '' }>{ __( 'Select' ) }</option> }
 				{ installedEditors.map( ( [ editorKey, editorConfig ] ) => (
 					<option key={ editorKey } value={ editorKey }>
 						{ editorConfig.label }

--- a/src/modules/user-settings/components/editor-picker.tsx
+++ b/src/modules/user-settings/components/editor-picker.tsx
@@ -6,7 +6,7 @@ import { SupportedEditor, supportedEditorConfig } from 'src/modules/user-setting
 import { SettingsFormField } from './settings-form-field';
 
 interface EditorPickerProps {
-	value: SupportedEditor;
+	value: SupportedEditor | string;
 	onChange: ( value: SupportedEditor ) => void;
 }
 
@@ -47,6 +47,7 @@ export const EditorPicker = ( { value, onChange }: EditorPickerProps ) => {
 				__nextHasNoMarginBottom
 				__next40pxDefaultSize
 			>
+				{ value === '' && <option value={ '' }>{ __( 'Select' ) }</option> }
 				{ installedEditors.map( ( [ editorKey, editorConfig ] ) => (
 					<option key={ editorKey } value={ editorKey }>
 						{ editorConfig.label }

--- a/src/modules/user-settings/components/preferences-tab.tsx
+++ b/src/modules/user-settings/components/preferences-tab.tsx
@@ -13,12 +13,15 @@ export const PreferencesTab = ( { onClose }: { onClose: () => void } ) => {
 	const { locale: savedLocale, setLocale: setSavedLocale } = useI18nData();
 	const [ locale, setLocale ] = useState( savedLocale );
 
-	const { editor, handleEditorChange, saveEditorPreference, resetEditor } = useEditorData();
+	const { editor, handleEditorChange, saveEditorPreference, resetEditor, hasEditorChanges } =
+		useEditorData();
+
 	const {
 		terminal,
 		handleTerminalChange,
 		saveTerminalPreference,
 		resetTerminal,
+		hasTerminalChanges,
 		availableTerminals,
 	} = useTerminalData();
 
@@ -36,6 +39,8 @@ export const PreferencesTab = ( { onClose }: { onClose: () => void } ) => {
 		onClose();
 	};
 
+	const hasChanges = locale !== savedLocale || hasEditorChanges || hasTerminalChanges;
+
 	return (
 		<>
 			<LanguagePicker value={ locale } onChange={ setLocale } />
@@ -49,7 +54,7 @@ export const PreferencesTab = ( { onClose }: { onClose: () => void } ) => {
 				<Button variant="tertiary" onClick={ cancelChanges }>
 					{ __( 'Cancel' ) }
 				</Button>
-				<Button variant="primary" onClick={ savePreferences }>
+				<Button variant="primary" onClick={ savePreferences } disabled={ ! hasChanges }>
 					{ __( 'Save' ) }
 				</Button>
 			</div>

--- a/src/modules/user-settings/components/preferences-tab.tsx
+++ b/src/modules/user-settings/components/preferences-tab.tsx
@@ -13,8 +13,7 @@ export const PreferencesTab = ( { onClose }: { onClose: () => void } ) => {
 	const { locale: savedLocale, setLocale: setSavedLocale } = useI18nData();
 	const [ locale, setLocale ] = useState( savedLocale );
 
-	const { editor, handleEditorChange, saveEditorPreference, resetEditor } =
-		useEditorData();
+	const { editor, handleEditorChange, saveEditorPreference, resetEditor } = useEditorData();
 	const {
 		terminal,
 		handleTerminalChange,

--- a/src/modules/user-settings/components/preferences-tab.tsx
+++ b/src/modules/user-settings/components/preferences-tab.tsx
@@ -13,14 +13,13 @@ export const PreferencesTab = ( { onClose }: { onClose: () => void } ) => {
 	const { locale: savedLocale, setLocale: setSavedLocale } = useI18nData();
 	const [ locale, setLocale ] = useState( savedLocale );
 
-	const { editor, handleEditorChange, saveEditorPreference, resetEditor, hasEditorChanges } =
+	const { editor, handleEditorChange, saveEditorPreference, resetEditor } =
 		useEditorData();
 	const {
 		terminal,
 		handleTerminalChange,
 		saveTerminalPreference,
 		resetTerminal,
-		hasTerminalChanges,
 		availableTerminals,
 	} = useTerminalData();
 
@@ -38,8 +37,6 @@ export const PreferencesTab = ( { onClose }: { onClose: () => void } ) => {
 		onClose();
 	};
 
-	const hasChanges = locale !== savedLocale || hasEditorChanges || hasTerminalChanges;
-
 	return (
 		<>
 			<LanguagePicker value={ locale } onChange={ setLocale } />
@@ -53,7 +50,7 @@ export const PreferencesTab = ( { onClose }: { onClose: () => void } ) => {
 				<Button variant="tertiary" onClick={ cancelChanges }>
 					{ __( 'Cancel' ) }
 				</Button>
-				<Button variant="primary" onClick={ savePreferences } disabled={ ! hasChanges }>
+				<Button variant="primary" onClick={ savePreferences }>
 					{ __( 'Save' ) }
 				</Button>
 			</div>

--- a/src/modules/user-settings/hooks/use-editor-data.ts
+++ b/src/modules/user-settings/hooks/use-editor-data.ts
@@ -1,17 +1,17 @@
 import { useState, useEffect } from 'react';
 import { getIpcApi } from 'src/lib/get-ipc-api';
-import { SupportedEditor } from 'src/modules/user-settings/lib/editor';
+import { DEFAULT_EDITOR, SupportedEditor } from 'src/modules/user-settings/lib/editor';
 
 export function useEditorData() {
-	const [ editor, setEditor ] = useState< SupportedEditor >( 'vscode' );
-	const [ savedEditorValue, setSavedEditorValue ] = useState< SupportedEditor >( 'vscode' );
+	const [ editor, setEditor ] = useState< SupportedEditor >( DEFAULT_EDITOR );
+	const [ savedEditorValue, setSavedEditorValue ] = useState< SupportedEditor >( DEFAULT_EDITOR );
 
 	const getSavedEditor = async () => {
 		try {
 			const savedEditor = await getIpcApi().getUserEditor();
-			return savedEditor;
+			return savedEditor || DEFAULT_EDITOR;
 		} catch ( error ) {
-			return 'vscode';
+			return DEFAULT_EDITOR;
 		}
 	};
 
@@ -45,5 +45,6 @@ export function useEditorData() {
 		saveEditorPreference,
 		resetEditor,
 		hasEditorChanges,
+		getSavedEditor
 	};
 }

--- a/src/modules/user-settings/hooks/use-editor-data.ts
+++ b/src/modules/user-settings/hooks/use-editor-data.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
+import { DEFAULT_EDITOR } from 'src/constants';
 import { getIpcApi } from 'src/lib/get-ipc-api';
-import { DEFAULT_EDITOR, SupportedEditor } from 'src/modules/user-settings/lib/editor';
+import { SupportedEditor } from 'src/modules/user-settings/lib/editor';
 
 export function useEditorData() {
 	const [ editor, setEditor ] = useState< SupportedEditor >( DEFAULT_EDITOR );

--- a/src/modules/user-settings/hooks/use-editor-data.ts
+++ b/src/modules/user-settings/hooks/use-editor-data.ts
@@ -3,8 +3,8 @@ import { getIpcApi } from 'src/lib/get-ipc-api';
 import { SupportedEditor } from 'src/modules/user-settings/lib/editor';
 
 export function useEditorData() {
-	const [ editor, setEditor ] = useState< SupportedEditor | string >( '' );
-	const [ savedEditorValue, setSavedEditorValue ] = useState< SupportedEditor | string >( '' );
+	const [ editor, setEditor ] = useState< SupportedEditor | undefined >();
+	const [ savedEditorValue, setSavedEditorValue ] = useState< SupportedEditor | undefined >();
 
 	const getSavedEditor = async () => {
 		try {
@@ -24,9 +24,9 @@ export function useEditorData() {
 				return 'phpstorm';
 			}
 
-			return '';
+			return undefined;
 		} catch ( error ) {
-			return '';
+			return undefined;
 		}
 	};
 
@@ -39,12 +39,14 @@ export function useEditorData() {
 		void loadSavedEditor();
 	}, [] );
 
-	const handleEditorChange = ( newEditor: SupportedEditor | string ) => {
+	const handleEditorChange = ( newEditor: SupportedEditor | undefined ) => {
 		setEditor( newEditor );
 	};
 
 	const saveEditorPreference = async () => {
-		await getIpcApi().saveUserEditor( editor as SupportedEditor );
+		if ( editor ) {
+			await getIpcApi().saveUserEditor( editor );
+		}
 	};
 
 	const resetEditor = () => {

--- a/src/modules/user-settings/hooks/use-editor-data.ts
+++ b/src/modules/user-settings/hooks/use-editor-data.ts
@@ -1,18 +1,32 @@
 import { useState, useEffect } from 'react';
-import { DEFAULT_EDITOR } from 'src/constants';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 import { SupportedEditor } from 'src/modules/user-settings/lib/editor';
 
 export function useEditorData() {
-	const [ editor, setEditor ] = useState< SupportedEditor >( DEFAULT_EDITOR );
-	const [ savedEditorValue, setSavedEditorValue ] = useState< SupportedEditor >( DEFAULT_EDITOR );
+	const [ editor, setEditor ] = useState< SupportedEditor | string >( '' );
+	const [ savedEditorValue, setSavedEditorValue ] = useState< SupportedEditor | string >( '' );
 
 	const getSavedEditor = async () => {
 		try {
 			const savedEditor = await getIpcApi().getUserEditor();
-			return savedEditor || DEFAULT_EDITOR;
+			// Respect user preference if it is set
+			if ( savedEditor ) {
+				return savedEditor;
+			}
+
+			// If no user preference is set, check for installed editors
+			// and set the default to the first one found
+			// This is a fallback to ensure we keep existing behavior
+			const installedEditors = await getIpcApi().getInstalledApps();
+			if ( installedEditors.vscode ) {
+				return 'vscode';
+			} else if ( installedEditors.phpstorm ) {
+				return 'phpstorm';
+			}
+
+			return '';
 		} catch ( error ) {
-			return DEFAULT_EDITOR;
+			return '';
 		}
 	};
 
@@ -25,12 +39,12 @@ export function useEditorData() {
 		void loadSavedEditor();
 	}, [] );
 
-	const handleEditorChange = ( newEditor: SupportedEditor ) => {
+	const handleEditorChange = ( newEditor: SupportedEditor | string ) => {
 		setEditor( newEditor );
 	};
 
 	const saveEditorPreference = async () => {
-		await getIpcApi().saveUserEditor( editor );
+		await getIpcApi().saveUserEditor( editor as SupportedEditor );
 	};
 
 	const resetEditor = () => {

--- a/src/modules/user-settings/hooks/use-editor-data.ts
+++ b/src/modules/user-settings/hooks/use-editor-data.ts
@@ -45,6 +45,6 @@ export function useEditorData() {
 		saveEditorPreference,
 		resetEditor,
 		hasEditorChanges,
-		getSavedEditor
+		getSavedEditor,
 	};
 }

--- a/src/modules/user-settings/hooks/use-terminal-data.ts
+++ b/src/modules/user-settings/hooks/use-terminal-data.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
+import { DEFAULT_TERMINAL } from 'src/constants';
 import { getIpcApi } from 'src/lib/get-ipc-api';
-import { SupportedTerminal, DEFAULT_TERMINAL } from 'src/modules/user-settings/lib/terminal';
+import { SupportedTerminal } from 'src/modules/user-settings/lib/terminal';
 
 /**
  * Hook to manage terminal preferences

--- a/src/modules/user-settings/hooks/use-terminal-data.ts
+++ b/src/modules/user-settings/hooks/use-terminal-data.ts
@@ -69,6 +69,6 @@ export function useTerminalData() {
 		saveTerminalPreference,
 		resetTerminal,
 		hasTerminalChanges,
-		getSavedTerminal
+		getSavedTerminal,
 	};
 }

--- a/src/modules/user-settings/hooks/use-terminal-data.ts
+++ b/src/modules/user-settings/hooks/use-terminal-data.ts
@@ -69,5 +69,6 @@ export function useTerminalData() {
 		saveTerminalPreference,
 		resetTerminal,
 		hasTerminalChanges,
+		getSavedTerminal
 	};
 }

--- a/src/modules/user-settings/lib/editor.ts
+++ b/src/modules/user-settings/lib/editor.ts
@@ -2,6 +2,8 @@ import { __ } from '@wordpress/i18n';
 
 export type SupportedEditor = 'vscode' | 'phpstorm' | 'cursor' | 'windsurf' | 'webstorm';
 
+export const DEFAULT_EDITOR = 'vscode';
+
 export type SupportedEditorConfig = {
 	label: string;
 	url: ( path: string ) => string;

--- a/src/modules/user-settings/lib/editor.ts
+++ b/src/modules/user-settings/lib/editor.ts
@@ -2,8 +2,6 @@ import { __ } from '@wordpress/i18n';
 
 export type SupportedEditor = 'vscode' | 'phpstorm' | 'cursor' | 'windsurf' | 'webstorm';
 
-export const DEFAULT_EDITOR = 'vscode';
-
 export type SupportedEditorConfig = {
 	label: string;
 	url: ( path: string ) => string;

--- a/src/modules/user-settings/lib/terminal.ts
+++ b/src/modules/user-settings/lib/terminal.ts
@@ -11,5 +11,3 @@ export const supportedTerminalNames: Record< SupportedTerminal, string > = {
 	// translators: "Ghostty" is the brand name for a terminal app and does not need to be translated
 	ghostty: __( 'Ghostty' ),
 };
-
-export const DEFAULT_TERMINAL: SupportedTerminal = 'terminal';

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -109,8 +109,8 @@ const api: IpcApi = {
 	getFileContent: ( filePath ) => ipcRendererInvoke( 'getFileContent', filePath ),
 	isFullscreen: () => ipcRendererInvoke( 'isFullscreen' ),
 	getAllCustomDomains: () => ipcRendererInvoke( 'getAllCustomDomains' ),
-	saveUserTerminal: ( supportedTerminal ) =>
-		ipcRendererInvoke( 'saveUserTerminal', supportedTerminal ),
+	saveUserTerminal: ( preferredTerminal ) =>
+		ipcRendererInvoke( 'saveUserTerminal', preferredTerminal ),
 	getUserTerminal: () => ipcRendererInvoke( 'getUserTerminal' ),
 	getInstalledTerminals: () => ipcRendererInvoke( 'getInstalledTerminals' ),
 	getUserEditor: () => ipcRendererInvoke( 'getUserEditor' ),

--- a/src/storage/storage-types.ts
+++ b/src/storage/storage-types.ts
@@ -19,7 +19,7 @@ export interface UserData {
 	connectedWpcomSites?: { [ userId: number ]: SyncSite[] };
 	sentryUserId?: string;
 	lastSeenVersion?: string;
-	supportedTerminal?: SupportedTerminal;
+	preferredTerminal?: SupportedTerminal;
 	preferredEditor?: SupportedEditor;
 	newSites?: NewSiteDetails[];
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-409

## Proposed Changes

- Use data provider hooks to populate the default editor and terminal on the overview screen. 
- Remove duplicate implementation for getting preferred editor and terminal. 
- Revert saved terminal to `preferredTerminal`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Check out this branch
- Remove preferred editor and terminal from appdata-v1.json. (/Users/[USERNAME]/Library/Application Support/Studio/appdata-v1.json)
- Run `npm start`
- Visit the site overview and see that the `VS Code` and `Terminal` buttons are visible.

![CleanShot 2025-04-25 at 19 08 09@2x](https://github.com/user-attachments/assets/68ba7675-9a34-4fe8-9fa5-a10406b5a758)

- Terminate `npm start`. 
- Run `STUDIO_PREFERRED_EDITOR=true npm start`. 
- Check site overview for `VS Code` and `Terminal` buttons. 
- Update preferred editor or terminal in settings. 
- Ensure overview updates with the correct editor or terminal after saving settings. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?