### PR TITLE
Add site to Studio when creating preview from CLI

### DIFF
--- a/cli/lib/appdata.ts
+++ b/cli/lib/appdata.ts
@@ -1,3 +1,4 @@
+import crypto from 'crypto';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
@@ -16,8 +17,16 @@ const siteSchema = z
 	} )
 	.passthrough();
 
+const newSiteSchema = z
+	.object( {
+		id: z.string(),
+		path: z.string(),
+	} )
+	.passthrough();
+
 const userDataSchema = z
 	.object( {
+		newSites: z.array( newSiteSchema ).optional(),
 		sites: z.array( siteSchema ).optional(),
 		snapshots: z.array( snapshotSchema ).optional(),
 		locale: z.string().optional(),
@@ -128,14 +137,24 @@ export async function getAuthToken(): Promise< NonNullable< UserData[ 'authToken
 
 export async function getSiteByFolder(
 	siteFolder: string
-): Promise< z.infer< typeof siteSchema > > {
+): Promise< z.infer< typeof siteSchema > | null > {
 	const userData = await readAppdata();
 	const sites = userData.sites ?? [];
 	const site = sites.find( ( site ) => site.path === siteFolder );
 
 	if ( ! site ) {
-		throw new LoggerError( __( 'The specified folder is not added to Studio.' ) );
+		return null;
 	}
 
 	return site;
+}
+
+export function getNewSiteAppData( siteFolder: string ): z.infer< typeof siteSchema > {
+	const newSite = {
+		id: crypto.randomUUID(),
+		path: siteFolder,
+		name: path.basename( siteFolder ),
+	};
+
+	return newSite;
 }

--- a/cli/lib/appdata.ts
+++ b/cli/lib/appdata.ts
@@ -17,16 +17,9 @@ const siteSchema = z
 	} )
 	.passthrough();
 
-const newSiteSchema = z
-	.object( {
-		id: z.string(),
-		path: z.string(),
-	} )
-	.passthrough();
-
 const userDataSchema = z
 	.object( {
-		newSites: z.array( newSiteSchema ).optional(),
+		newSites: z.array( siteSchema ).optional(),
 		sites: z.array( siteSchema ).optional(),
 		snapshots: z.array( snapshotSchema ).optional(),
 		locale: z.string().optional(),
@@ -137,19 +130,19 @@ export async function getAuthToken(): Promise< NonNullable< UserData[ 'authToken
 
 export async function getSiteByFolder(
 	siteFolder: string
-): Promise< z.infer< typeof siteSchema > | null > {
+): Promise< z.infer< typeof siteSchema > > {
 	const userData = await readAppdata();
 	const sites = userData.sites ?? [];
 	const site = sites.find( ( site ) => site.path === siteFolder );
 
 	if ( ! site ) {
-		return null;
+		throw new LoggerError( __( 'The specified folder is not added to Studio.' ) );
 	}
 
 	return site;
 }
 
-export function getNewSiteAppData( siteFolder: string ): z.infer< typeof siteSchema > {
+export function getNewSitePartial( siteFolder: string ): z.infer< typeof siteSchema > {
 	const newSite = {
 		id: crypto.randomUUID(),
 		path: siteFolder,

--- a/cli/lib/snapshots.ts
+++ b/cli/lib/snapshots.ts
@@ -1,6 +1,12 @@
 import { __, sprintf } from '@wordpress/i18n';
 import { Snapshot } from 'common/types/snapshot';
-import { getAuthToken, getSiteByFolder, readAppdata, saveAppdata } from 'cli/lib/appdata';
+import {
+	getAuthToken,
+	getNewSiteAppData,
+	getSiteByFolder,
+	readAppdata,
+	saveAppdata,
+} from 'cli/lib/appdata';
 import { LoggerError } from 'cli/logger';
 
 export async function getSnapshotsFromAppdata(
@@ -13,6 +19,9 @@ export async function getSnapshotsFromAppdata(
 
 	if ( siteFolder ) {
 		const site = await getSiteByFolder( siteFolder );
+		if ( ! site ) {
+			throw new LoggerError( __( 'Site not found in appdata' ) );
+		}
 		snapshots = snapshots.filter( ( snapshot ) => snapshot.localSiteId === site.id );
 	}
 
@@ -57,7 +66,15 @@ export async function saveSnapshotToAppdata(
 ): Promise< Snapshot > {
 	const userData = await readAppdata();
 	const authToken = await getAuthToken();
-	const site = await getSiteByFolder( siteFolder );
+	let site = await getSiteByFolder( siteFolder );
+
+	if ( ! site ) {
+		site = getNewSiteAppData( siteFolder );
+		if ( ! userData.newSites ) {
+			userData.newSites = [];
+		}
+		userData.newSites.push( site );
+	}
 
 	if ( ! userData.snapshots ) {
 		userData.snapshots = [];

--- a/cli/lib/snapshots.ts
+++ b/cli/lib/snapshots.ts
@@ -2,7 +2,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { Snapshot } from 'common/types/snapshot';
 import {
 	getAuthToken,
-	getNewSiteAppData,
+	getNewSitePartial,
 	getSiteByFolder,
 	readAppdata,
 	saveAppdata,
@@ -19,9 +19,6 @@ export async function getSnapshotsFromAppdata(
 
 	if ( siteFolder ) {
 		const site = await getSiteByFolder( siteFolder );
-		if ( ! site ) {
-			throw new LoggerError( __( 'Site not found in appdata' ) );
-		}
 		snapshots = snapshots.filter( ( snapshot ) => snapshot.localSiteId === site.id );
 	}
 
@@ -66,10 +63,14 @@ export async function saveSnapshotToAppdata(
 ): Promise< Snapshot > {
 	const userData = await readAppdata();
 	const authToken = await getAuthToken();
-	let site = await getSiteByFolder( siteFolder );
-
-	if ( ! site ) {
-		site = getNewSiteAppData( siteFolder );
+	let site;
+	try {
+		site = await getSiteByFolder( siteFolder );
+	} catch ( error ) {
+		if ( ! ( error instanceof LoggerError ) ) {
+			throw error;
+		}
+		site = getNewSitePartial( siteFolder );
 		if ( ! userData.newSites ) {
 			userData.newSites = [];
 		}

--- a/cli/lib/tests/appdata.test.ts
+++ b/cli/lib/tests/appdata.test.ts
@@ -1,11 +1,14 @@
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import { readAppdata, saveAppdata, getAuthToken } from 'cli/lib/appdata';
+import { readAppdata, saveAppdata, getAuthToken, getNewSitePartial } from 'cli/lib/appdata';
 
 jest.mock( 'fs' );
 jest.mock( 'os' );
 jest.mock( 'path' );
+jest.mock( 'crypto', () => ( {
+	randomUUID: jest.fn().mockReturnValue( 'mock-uuid-1234' ),
+} ) );
 
 describe( 'Appdata Module', () => {
 	const mockHomeDir = '/mock/home';
@@ -156,6 +159,23 @@ describe( 'Appdata Module', () => {
 			);
 
 			await expect( getAuthToken() ).rejects.toThrow( 'Authentication required' );
+		} );
+	} );
+
+	describe( 'getNewSitePartial', () => {
+		it( 'should create a new site object with random UUID', () => {
+			const folderPath = '/test/site/path';
+			const baseName = 'sitename';
+
+			( path.basename as jest.Mock ).mockReturnValueOnce( baseName );
+
+			const result = getNewSitePartial( folderPath );
+
+			expect( result ).toEqual( {
+				id: 'mock-uuid-1234',
+				path: folderPath,
+				name: baseName,
+			} );
 		} );
 	} );
 } );

--- a/cli/lib/tests/snapshots.test.ts
+++ b/cli/lib/tests/snapshots.test.ts
@@ -12,6 +12,9 @@ import { LoggerError } from 'cli/logger';
 jest.mock( 'fs' );
 jest.mock( 'os' );
 jest.mock( 'path' );
+jest.mock( 'crypto', () => ( {
+	randomUUID: jest.fn().mockReturnValue( 'mock-uuid-1234' ),
+} ) );
 
 describe( 'Snapshots Module', () => {
 	const mockHomeDir = '/mock/home';
@@ -120,7 +123,7 @@ describe( 'Snapshots Module', () => {
 			} );
 		} );
 
-		it( 'should throw an error if no matching site is found', async () => {
+		it( 'should create a new site if no matching site is found', async () => {
 			const mockUserData = {
 				version: 1,
 				sites: [
@@ -131,15 +134,78 @@ describe( 'Snapshots Module', () => {
 					},
 				],
 				snapshots: [],
+				authToken: {
+					id: mockUserId,
+					accessToken: 'mock-token',
+				},
 			};
 
 			( fs.readFileSync as jest.Mock ).mockReturnValue( JSON.stringify( mockUserData ) );
+			( path.basename as jest.Mock ).mockReturnValueOnce( mockSiteFolderName );
 
-			await expect(
-				saveSnapshotToAppdata( mockSiteFolder, mockAtomicSiteId, mockSiteUrl )
-			).rejects.toThrow( LoggerError );
+			await saveSnapshotToAppdata( mockSiteFolder, mockAtomicSiteId, mockSiteUrl );
 
-			expect( fs.writeFileSync ).not.toHaveBeenCalled();
+			expect( fs.writeFileSync ).toHaveBeenCalled();
+			const savedData = JSON.parse( ( fs.writeFileSync as jest.Mock ).mock.calls[ 0 ][ 1 ] );
+
+			// Check that a new site was created
+			expect( savedData.newSites ).toHaveLength( 1 );
+			expect( savedData.newSites[ 0 ] ).toEqual( {
+				id: 'mock-uuid-1234',
+				path: mockSiteFolder,
+				name: mockSiteFolderName,
+			} );
+
+			// Check that a snapshot was created for the new site
+			expect( savedData.snapshots ).toHaveLength( 1 );
+			expect( savedData.snapshots[ 0 ] ).toEqual( {
+				url: mockSiteUrl,
+				atomicSiteId: mockAtomicSiteId,
+				localSiteId: 'mock-uuid-1234',
+				date: 1234567890,
+				name: `${ mockSiteFolderName } Preview 1`,
+				userId: mockUserId,
+				sequence: 1,
+			} );
+		} );
+
+		it( 'should append to newSites array if it already exists', async () => {
+			const existingNewSite = {
+				id: 'existing-new-site',
+				path: '/existing/path',
+				name: 'Existing New Site',
+			};
+
+			const mockUserData = {
+				version: 1,
+				sites: [],
+				newSites: [ existingNewSite ],
+				snapshots: [],
+				authToken: {
+					id: mockUserId,
+					accessToken: 'mock-token',
+				},
+			};
+
+			( fs.readFileSync as jest.Mock ).mockReturnValue( JSON.stringify( mockUserData ) );
+			( path.basename as jest.Mock ).mockReturnValueOnce( mockSiteFolderName );
+
+			await saveSnapshotToAppdata( mockSiteFolder, mockAtomicSiteId, mockSiteUrl );
+
+			expect( fs.writeFileSync ).toHaveBeenCalled();
+			const savedData = JSON.parse( ( fs.writeFileSync as jest.Mock ).mock.calls[ 0 ][ 1 ] );
+
+			// Check that the new site was added to existing newSites array
+			expect( savedData.newSites ).toHaveLength( 2 );
+			expect( savedData.newSites[ 0 ] ).toEqual( existingNewSite );
+			expect( savedData.newSites[ 1 ] ).toEqual( {
+				id: 'mock-uuid-1234',
+				path: mockSiteFolder,
+				name: mockSiteFolderName,
+			} );
+
+			// Check that a snapshot was created for the new site
+			expect( savedData.snapshots ).toHaveLength( 1 );
 		} );
 
 		it( 'should handle errors correctly', async () => {
@@ -148,6 +214,34 @@ describe( 'Snapshots Module', () => {
 			await expect(
 				saveSnapshotToAppdata( mockSiteFolder, mockAtomicSiteId, mockSiteUrl )
 			).rejects.toThrow( LoggerError );
+		} );
+
+		it( 'should only create a new site when getSiteByFolder throws a LoggerError', async () => {
+			const mockUserData = {
+				version: 1,
+				sites: [],
+				snapshots: [],
+				authToken: {
+					id: mockUserId,
+					accessToken: 'mock-token',
+				},
+			};
+
+			( fs.readFileSync as jest.Mock ).mockReturnValue( JSON.stringify( mockUserData ) );
+
+			// Mock fs.existsSync to throw a different error first, then a LoggerError
+			const fsExistsSyncMock = fs.existsSync as jest.Mock;
+			fsExistsSyncMock
+				.mockImplementationOnce( () => {
+					throw new Error( 'Some other error' );
+				} )
+				.mockReturnValueOnce( true );
+
+			await expect(
+				saveSnapshotToAppdata( mockSiteFolder, mockAtomicSiteId, mockSiteUrl )
+			).rejects.toThrow( 'Some other error' );
+
+			expect( fs.writeFileSync ).not.toHaveBeenCalled();
 		} );
 	} );
 

--- a/src/components/tests/header.test.tsx
+++ b/src/components/tests/header.test.tsx
@@ -10,6 +10,15 @@ import { store } from 'src/stores';
 
 jest.mock( 'src/lib/get-ipc-api' );
 
+beforeAll( () => {
+	Object.defineProperty( window, 'ipcListener', {
+		value: {
+			subscribe: jest.fn().mockReturnValue( () => {} ),
+		},
+		writable: true,
+	} );
+} );
+
 const mockedGetIpcApi = getIpcApi as jest.Mock;
 const mockedSites = [
 	{

--- a/src/hooks/tests/use-site-details.test.tsx
+++ b/src/hooks/tests/use-site-details.test.tsx
@@ -51,6 +51,15 @@ const wrapper = ( { children }: { children: ReactNode } ) => (
 );
 
 describe( 'useSiteDetails', () => {
+	beforeAll( () => {
+		Object.defineProperty( window, 'ipcListener', {
+			value: {
+				subscribe: jest.fn().mockReturnValue( () => {} ),
+			},
+			writable: true,
+		} );
+	} );
+
 	beforeEach( () => {
 		jest.clearAllMocks();
 		( getIpcApi as jest.Mock ).mockReturnValue( {

--- a/src/hooks/use-site-details.tsx
+++ b/src/hooks/use-site-details.tsx
@@ -1,4 +1,5 @@
 import { __ } from '@wordpress/i18n';
+import fastDeepEqual from 'fast-deep-equal';
 import {
 	ReactNode,
 	createContext,
@@ -340,6 +341,19 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 		},
 		[ startServer ]
 	);
+
+	useEffect( () => {
+		const unsubscribe = window.ipcListener.subscribe( 'user-data-updated', async ( _, payload ) => {
+			if ( ! fastDeepEqual( payload.newSites, payload.sites ) ) {
+				const updatedSites = await getIpcApi().getSiteDetails();
+				setData( updatedSites );
+			}
+		} );
+
+		return () => {
+			unsubscribe();
+		};
+	}, [] );
 
 	useEffect( () => {
 		let cancel = false;

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -150,7 +150,8 @@ export async function createSite(
 	siteName?: string,
 	wpVersion?: string,
 	customDomain?: string,
-	enableHttps?: boolean
+	enableHttps?: boolean,
+	siteId?: string
 ): Promise< SiteDetails[] > {
 	const userData = await loadUserData();
 	const forceSetupSqlite = false;
@@ -184,7 +185,7 @@ export async function createSite(
 	const port = await portFinder.getOpenPort();
 
 	const details = {
-		id: crypto.randomUUID(),
+		id: siteId || crypto.randomUUID(),
 		name: siteName || nodePath.basename( path ),
 		path,
 		adminPassword: createPassword(),
@@ -1337,4 +1338,22 @@ export async function deleteSnapshot(
 ): Promise< { operationId: crypto.UUID } > {
 	const parentWindow = BrowserWindow.fromWebContents( event.sender );
 	return executePreviewCliCommand( [ 'preview', 'delete', hostname ], parentWindow );
+}
+
+export async function handleNewSite( event: IpcMainInvokeEvent, newSite: NewSiteDetails ) {
+	await createSite(
+		event,
+		newSite.path,
+		undefined, // siteName - Let Studio generate a name
+		undefined,
+		undefined,
+		undefined,
+		newSite.id
+	);
+
+	const userData = await loadUserData();
+	await saveUserData( {
+		...userData,
+		newSites: userData.newSites?.filter( ( s ) => s.id !== newSite.id ),
+	} );
 }

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -1341,15 +1341,7 @@ export async function deleteSnapshot(
 }
 
 export async function handleNewSite( event: IpcMainInvokeEvent, newSite: NewSiteDetails ) {
-	await createSite(
-		event,
-		newSite.path,
-		undefined, // siteName - Let Studio generate a name
-		undefined,
-		undefined,
-		undefined,
-		newSite.id
-	);
+	await createSite( event, newSite.path, undefined, undefined, undefined, undefined, newSite.id );
 
 	const userData = await loadUserData();
 	await saveUserData( {

--- a/src/ipc-types.d.ts
+++ b/src/ipc-types.d.ts
@@ -45,6 +45,12 @@ interface StartedSiteDetails extends StoppedSiteDetails {
 
 type SiteDetails = StartedSiteDetails | StoppedSiteDetails;
 
+type NewSiteDetails = {
+	id: string;
+	path: string;
+	name: string;
+};
+
 type InstalledApps = {
 	vscode: boolean;
 	phpstorm: boolean;

--- a/src/ipc-types.d.ts
+++ b/src/ipc-types.d.ts
@@ -45,11 +45,7 @@ interface StartedSiteDetails extends StoppedSiteDetails {
 
 type SiteDetails = StartedSiteDetails | StoppedSiteDetails;
 
-type NewSiteDetails = {
-	id: string;
-	path: string;
-	name: string;
-};
+type NewSiteDetails = Pick< SiteDetails, 'id' | 'path' | 'name' >;
 
 type InstalledApps = {
 	vscode: boolean;

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -115,6 +115,7 @@ const api: IpcApi = {
 	getInstalledTerminals: () => ipcRendererInvoke( 'getInstalledTerminals' ),
 	getUserEditor: () => ipcRendererInvoke( 'getUserEditor' ),
 	saveUserEditor: ( editor ) => ipcRendererInvoke( 'saveUserEditor', editor ),
+	handleNewSite: ( newSite ) => ipcRendererInvoke( 'handleNewSite', newSite ),
 };
 
 contextBridge.exposeInMainWorld( 'ipcApi', api );

--- a/src/storage/storage-types.ts
+++ b/src/storage/storage-types.ts
@@ -21,6 +21,7 @@ export interface UserData {
 	lastSeenVersion?: string;
 	supportedTerminal?: SupportedTerminal;
 	preferredEditor?: SupportedEditor;
+	newSites?: NewSiteDetails[];
 }
 
 export interface PersistedUserData extends Omit< UserData, 'sites' > {

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -4,6 +4,7 @@ import { LOCAL_STORAGE_CHAT_API_IDS_KEY, LOCAL_STORAGE_CHAT_MESSAGES_KEY } from 
 import { getIpcApi } from 'src/lib/get-ipc-api';
 import { appVersionApi } from 'src/stores/app-version-api';
 import { reducer as chatReducer } from 'src/stores/chat-slice';
+import { reducer as newSitesReducer } from 'src/stores/new-sites-slice';
 import { reducer as snapshotReducer } from 'src/stores/snapshot-slice';
 import { wpcomApi } from 'src/stores/wpcom-api';
 import { wordpressVersionsApi } from './wordpress-versions-api';
@@ -11,6 +12,7 @@ import { wordpressVersionsApi } from './wordpress-versions-api';
 export type RootState = {
 	appVersionApi: ReturnType< typeof appVersionApi.reducer >;
 	chat: ReturnType< typeof chatReducer >;
+	newSites: ReturnType< typeof newSitesReducer >;
 	snapshot: ReturnType< typeof snapshotReducer >;
 	wordpressVersionsApi: ReturnType< typeof wordpressVersionsApi.reducer >;
 	wpcomApi: ReturnType< typeof wpcomApi.reducer >;
@@ -63,6 +65,7 @@ listenerMiddleware.startListening( {
 export const rootReducer = combineReducers( {
 	appVersionApi: appVersionApi.reducer,
 	chat: chatReducer,
+	newSites: newSitesReducer,
 	snapshot: snapshotReducer,
 	wordpressVersionsApi: wordpressVersionsApi.reducer,
 	wpcomApi: wpcomApi.reducer,

--- a/src/stores/new-sites-slice.ts
+++ b/src/stores/new-sites-slice.ts
@@ -52,7 +52,7 @@ window.ipcListener.subscribe( 'user-data-updated', ( _, payload ) => {
 	const newSites = payload.newSites;
 
 	if ( ! state.newSites.isProcessing && newSites ) {
-		store.dispatch( handleNewSite( newSites ) );
+		void store.dispatch( handleNewSite( newSites ) );
 	}
 } );
 

--- a/src/stores/new-sites-slice.ts
+++ b/src/stores/new-sites-slice.ts
@@ -1,6 +1,6 @@
-import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { createAsyncThunk, createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { getIpcApi } from 'src/lib/get-ipc-api';
-import { RootState, store } from 'src/stores/index';
+import { store } from 'src/stores/index';
 
 interface NewSitesState {
 	isProcessing: boolean;
@@ -18,30 +18,41 @@ const newSitesSlice = createSlice( {
 			state.isProcessing = action.payload;
 		},
 	},
+	extraReducers: ( builder ) => {
+		builder
+			.addCase( handleNewSite.pending, ( state ) => {
+				state.isProcessing = true;
+			} )
+			.addCase( handleNewSite.fulfilled, ( state ) => {
+				state.isProcessing = false;
+			} )
+			.addCase( handleNewSite.rejected, ( state ) => {
+				state.isProcessing = false;
+			} );
+	},
+} );
+
+const handleNewSite = createAsyncThunk( 'newSites/handleNewSite', ( sites: NewSiteDetails[] ) => {
+	return Promise.all(
+		sites.map( async ( site ) => {
+			try {
+				await getIpcApi().handleNewSite( site );
+			} catch ( error ) {
+				console.error(
+					`[New Sites Slice] Failed to create site for folder: ${ site.path }`,
+					error
+				);
+			}
+		} )
+	);
 } );
 
 window.ipcListener.subscribe( 'user-data-updated', ( _, payload ) => {
-	const state = store.getState() as RootState & { newSites?: NewSitesState };
-
+	const state = store.getState();
 	const newSites = payload.newSites;
 
-	if ( ! state.newSites?.isProcessing && newSites && newSites.length > 0 ) {
-		store.dispatch( newSitesSlice.actions.setIsProcessing( true ) );
-
-		Promise.all(
-			newSites.map( async ( site: NewSiteDetails ) => {
-				try {
-					await getIpcApi().handleNewSite( site );
-				} catch ( error ) {
-					console.error(
-						`[New Sites Slice] Failed to create site for folder: ${ site.path }`,
-						error
-					);
-				}
-			} )
-		).finally( () => {
-			store.dispatch( newSitesSlice.actions.setIsProcessing( false ) );
-		} );
+	if ( ! state.newSites.isProcessing && newSites ) {
+		store.dispatch( handleNewSite( newSites ) );
 	}
 } );
 

--- a/src/stores/new-sites-slice.ts
+++ b/src/stores/new-sites-slice.ts
@@ -25,13 +25,13 @@ const newSitesSlice = createSlice( {
 	},
 } );
 
-export const { addProcessingSites, removeProcessingSites } = newSitesSlice.actions;
+export const newSitesActions = newSitesSlice.actions;
 
 const handleNewSite = createAsyncThunk(
 	'newSites/handleNewSite',
 	async ( sites: NewSiteDetails[], { dispatch } ) => {
 		const siteIds = sites.map( ( site ) => site.id );
-		dispatch( addProcessingSites( siteIds ) );
+		dispatch( newSitesActions.addProcessingSites( siteIds ) );
 
 		try {
 			await Promise.all(
@@ -47,7 +47,7 @@ const handleNewSite = createAsyncThunk(
 				} )
 			);
 		} finally {
-			dispatch( removeProcessingSites( siteIds ) );
+			dispatch( newSitesActions.removeProcessingSites( siteIds ) );
 		}
 	}
 );

--- a/src/stores/new-sites-slice.ts
+++ b/src/stores/new-sites-slice.ts
@@ -3,56 +3,67 @@ import { getIpcApi } from 'src/lib/get-ipc-api';
 import { store } from 'src/stores/index';
 
 interface NewSitesState {
-	isProcessing: boolean;
+	processingSiteIds: string[];
 }
 
 const initialState: NewSitesState = {
-	isProcessing: false,
+	processingSiteIds: [],
 };
 
 const newSitesSlice = createSlice( {
 	name: 'newSites',
 	initialState,
 	reducers: {
-		setIsProcessing: ( state, action: PayloadAction< boolean > ) => {
-			state.isProcessing = action.payload;
+		addProcessingSites: ( state, action: PayloadAction< string[] > ) => {
+			state.processingSiteIds = [ ...new Set( [ ...state.processingSiteIds, ...action.payload ] ) ];
 		},
-	},
-	extraReducers: ( builder ) => {
-		builder
-			.addCase( handleNewSite.pending, ( state ) => {
-				state.isProcessing = true;
-			} )
-			.addCase( handleNewSite.fulfilled, ( state ) => {
-				state.isProcessing = false;
-			} )
-			.addCase( handleNewSite.rejected, ( state ) => {
-				state.isProcessing = false;
-			} );
+		removeProcessingSites: ( state, action: PayloadAction< string[] > ) => {
+			state.processingSiteIds = state.processingSiteIds.filter(
+				( id ) => ! action.payload.includes( id )
+			);
+		},
 	},
 } );
 
-const handleNewSite = createAsyncThunk( 'newSites/handleNewSite', ( sites: NewSiteDetails[] ) => {
-	return Promise.all(
-		sites.map( async ( site ) => {
-			try {
-				await getIpcApi().handleNewSite( site );
-			} catch ( error ) {
-				console.error(
-					`[New Sites Slice] Failed to create site for folder: ${ site.path }`,
-					error
-				);
-			}
-		} )
-	);
-} );
+export const { addProcessingSites, removeProcessingSites } = newSitesSlice.actions;
+
+const handleNewSite = createAsyncThunk(
+	'newSites/handleNewSite',
+	async ( sites: NewSiteDetails[], { dispatch } ) => {
+		const siteIds = sites.map( ( site ) => site.id );
+		dispatch( addProcessingSites( siteIds ) );
+
+		try {
+			await Promise.all(
+				sites.map( async ( site ) => {
+					try {
+						await getIpcApi().handleNewSite( site );
+					} catch ( error ) {
+						console.error(
+							`[New Sites Slice] Failed to create site for folder: ${ site.path }`,
+							error
+						);
+					}
+				} )
+			);
+		} finally {
+			dispatch( removeProcessingSites( siteIds ) );
+		}
+	}
+);
 
 window.ipcListener.subscribe( 'user-data-updated', ( _, payload ) => {
 	const state = store.getState();
 	const newSites = payload.newSites;
 
-	if ( ! state.newSites.isProcessing && newSites ) {
-		void store.dispatch( handleNewSite( newSites ) );
+	if ( newSites?.length ) {
+		const sitesToProcess = newSites.filter(
+			( site ) => ! state.newSites.processingSiteIds.includes( site.id )
+		);
+
+		if ( sitesToProcess.length ) {
+			void store.dispatch( handleNewSite( sitesToProcess ) );
+		}
 	}
 } );
 

--- a/src/stores/new-sites-slice.ts
+++ b/src/stores/new-sites-slice.ts
@@ -1,0 +1,48 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { getIpcApi } from 'src/lib/get-ipc-api';
+import { RootState, store } from 'src/stores/index';
+
+interface NewSitesState {
+	isProcessing: boolean;
+}
+
+const initialState: NewSitesState = {
+	isProcessing: false,
+};
+
+const newSitesSlice = createSlice( {
+	name: 'newSites',
+	initialState,
+	reducers: {
+		setIsProcessing: ( state, action: PayloadAction< boolean > ) => {
+			state.isProcessing = action.payload;
+		},
+	},
+} );
+
+window.ipcListener.subscribe( 'user-data-updated', ( _, payload ) => {
+	const state = store.getState() as RootState & { newSites?: NewSitesState };
+
+	const newSites = payload.newSites;
+
+	if ( ! state.newSites?.isProcessing && newSites && newSites.length > 0 ) {
+		store.dispatch( newSitesSlice.actions.setIsProcessing( true ) );
+
+		Promise.all(
+			newSites.map( async ( site: NewSiteDetails ) => {
+				try {
+					await getIpcApi().handleNewSite( site );
+				} catch ( error ) {
+					console.error(
+						`[New Sites Slice] Failed to create site for folder: ${ site.path }`,
+						error
+					);
+				}
+			} )
+		).finally( () => {
+			store.dispatch( newSitesSlice.actions.setIsProcessing( false ) );
+		} );
+	}
+} );
+
+export const { reducer } = newSitesSlice;

--- a/src/stores/tests/new-sites-slice.test.ts
+++ b/src/stores/tests/new-sites-slice.test.ts
@@ -1,0 +1,53 @@
+import { reducer } from 'src/stores/new-sites-slice';
+
+// Mock ipcListener
+window.ipcListener = {
+	subscribe: jest.fn(),
+};
+
+// Mock getIpcApi
+jest.mock( 'src/lib/get-ipc-api', () => ( {
+	getIpcApi: jest.fn().mockReturnValue( {
+		handleNewSite: jest.fn().mockResolvedValue( undefined ),
+	} ),
+} ) );
+
+describe( 'newSitesSlice', () => {
+	describe( 'reducers', () => {
+		it( 'should set isProcessing when setIsProcessing action is dispatched', () => {
+			const initialState = { isProcessing: false };
+
+			const action = { type: 'newSites/setIsProcessing', payload: true };
+			const nextState = reducer( initialState, action );
+
+			expect( nextState.isProcessing ).toBe( true );
+		} );
+
+		it( 'should set isProcessing to true when handleNewSite.pending is dispatched', () => {
+			const initialState = { isProcessing: false };
+
+			const action = { type: 'newSites/handleNewSite/pending' };
+			const nextState = reducer( initialState, action );
+
+			expect( nextState.isProcessing ).toBe( true );
+		} );
+
+		it( 'should set isProcessing to false when handleNewSite.fulfilled is dispatched', () => {
+			const initialState = { isProcessing: true };
+
+			const action = { type: 'newSites/handleNewSite/fulfilled' };
+			const nextState = reducer( initialState, action );
+
+			expect( nextState.isProcessing ).toBe( false );
+		} );
+
+		it( 'should set isProcessing to false when handleNewSite.rejected is dispatched', () => {
+			const initialState = { isProcessing: true };
+
+			const action = { type: 'newSites/handleNewSite/rejected' };
+			const nextState = reducer( initialState, action );
+
+			expect( nextState.isProcessing ).toBe( false );
+		} );
+	} );
+} );

--- a/src/stores/tests/new-sites-slice.test.ts
+++ b/src/stores/tests/new-sites-slice.test.ts
@@ -14,40 +14,52 @@ jest.mock( 'src/lib/get-ipc-api', () => ( {
 
 describe( 'newSitesSlice', () => {
 	describe( 'reducers', () => {
-		it( 'should set isProcessing when setIsProcessing action is dispatched', () => {
-			const initialState = { isProcessing: false };
+		it( 'should add site IDs to processingSiteIds when addProcessingSites is dispatched', () => {
+			const initialState = { processingSiteIds: [] };
 
-			const action = { type: 'newSites/setIsProcessing', payload: true };
+			const action = {
+				type: 'newSites/addProcessingSites',
+				payload: [ 'site-1', 'site-2' ],
+			};
 			const nextState = reducer( initialState, action );
 
-			expect( nextState.isProcessing ).toBe( true );
+			expect( nextState.processingSiteIds ).toEqual( [ 'site-1', 'site-2' ] );
 		} );
 
-		it( 'should set isProcessing to true when handleNewSite.pending is dispatched', () => {
-			const initialState = { isProcessing: false };
+		it( 'should deduplicate site IDs when adding to processingSiteIds', () => {
+			const initialState = { processingSiteIds: [ 'site-1', 'site-3' ] };
 
-			const action = { type: 'newSites/handleNewSite/pending' };
+			const action = {
+				type: 'newSites/addProcessingSites',
+				payload: [ 'site-1', 'site-2' ],
+			};
 			const nextState = reducer( initialState, action );
 
-			expect( nextState.isProcessing ).toBe( true );
+			expect( nextState.processingSiteIds ).toEqual( [ 'site-1', 'site-3', 'site-2' ] );
 		} );
 
-		it( 'should set isProcessing to false when handleNewSite.fulfilled is dispatched', () => {
-			const initialState = { isProcessing: true };
+		it( 'should remove site IDs from processingSiteIds when removeProcessingSites is dispatched', () => {
+			const initialState = { processingSiteIds: [ 'site-1', 'site-2', 'site-3' ] };
 
-			const action = { type: 'newSites/handleNewSite/fulfilled' };
+			const action = {
+				type: 'newSites/removeProcessingSites',
+				payload: [ 'site-1', 'site-3' ],
+			};
 			const nextState = reducer( initialState, action );
 
-			expect( nextState.isProcessing ).toBe( false );
+			expect( nextState.processingSiteIds ).toEqual( [ 'site-2' ] );
 		} );
 
-		it( 'should set isProcessing to false when handleNewSite.rejected is dispatched', () => {
-			const initialState = { isProcessing: true };
+		it( 'should handle removing site IDs that do not exist in processingSiteIds', () => {
+			const initialState = { processingSiteIds: [ 'site-1', 'site-2' ] };
 
-			const action = { type: 'newSites/handleNewSite/rejected' };
+			const action = {
+				type: 'newSites/removeProcessingSites',
+				payload: [ 'site-3', 'site-4' ],
+			};
 			const nextState = reducer( initialState, action );
 
-			expect( nextState.isProcessing ).toBe( false );
+			expect( nextState.processingSiteIds ).toEqual( [ 'site-1', 'site-2' ] );
 		} );
 	} );
 } );

--- a/src/stores/tests/new-sites-slice.test.ts
+++ b/src/stores/tests/new-sites-slice.test.ts
@@ -1,4 +1,4 @@
-import { reducer } from 'src/stores/new-sites-slice';
+import { newSitesActions, reducer } from 'src/stores/new-sites-slice';
 
 // Mock ipcListener
 window.ipcListener = {
@@ -17,10 +17,7 @@ describe( 'newSitesSlice', () => {
 		it( 'should add site IDs to processingSiteIds when addProcessingSites is dispatched', () => {
 			const initialState = { processingSiteIds: [] };
 
-			const action = {
-				type: 'newSites/addProcessingSites',
-				payload: [ 'site-1', 'site-2' ],
-			};
+			const action = newSitesActions.addProcessingSites( [ 'site-1', 'site-2' ] );
 			const nextState = reducer( initialState, action );
 
 			expect( nextState.processingSiteIds ).toEqual( [ 'site-1', 'site-2' ] );
@@ -29,10 +26,7 @@ describe( 'newSitesSlice', () => {
 		it( 'should deduplicate site IDs when adding to processingSiteIds', () => {
 			const initialState = { processingSiteIds: [ 'site-1', 'site-3' ] };
 
-			const action = {
-				type: 'newSites/addProcessingSites',
-				payload: [ 'site-1', 'site-2' ],
-			};
+			const action = newSitesActions.addProcessingSites( [ 'site-1', 'site-2' ] );
 			const nextState = reducer( initialState, action );
 
 			expect( nextState.processingSiteIds ).toEqual( [ 'site-1', 'site-3', 'site-2' ] );
@@ -41,10 +35,7 @@ describe( 'newSitesSlice', () => {
 		it( 'should remove site IDs from processingSiteIds when removeProcessingSites is dispatched', () => {
 			const initialState = { processingSiteIds: [ 'site-1', 'site-2', 'site-3' ] };
 
-			const action = {
-				type: 'newSites/removeProcessingSites',
-				payload: [ 'site-1', 'site-3' ],
-			};
+			const action = newSitesActions.removeProcessingSites( [ 'site-1', 'site-3' ] );
 			const nextState = reducer( initialState, action );
 
 			expect( nextState.processingSiteIds ).toEqual( [ 'site-2' ] );
@@ -53,10 +44,7 @@ describe( 'newSitesSlice', () => {
 		it( 'should handle removing site IDs that do not exist in processingSiteIds', () => {
 			const initialState = { processingSiteIds: [ 'site-1', 'site-2' ] };
 
-			const action = {
-				type: 'newSites/removeProcessingSites',
-				payload: [ 'site-3', 'site-4' ],
-			};
+			const action = newSitesActions.removeProcessingSites( [ 'site-3', 'site-4' ] );
 			const nextState = reducer( initialState, action );
 
 			expect( nextState.processingSiteIds ).toEqual( [ 'site-1', 'site-2' ] );

--- a/src/tests/ipc-handlers.test.ts
+++ b/src/tests/ipc-handlers.test.ts
@@ -62,7 +62,7 @@ afterEach( () => {
 } );
 
 describe( 'createSite', () => {
-	it( 'should create a site', async () => {
+	it( 'should create a site with generated ID when siteId is not provided', async () => {
 		( isEmptyDir as jest.Mock ).mockResolvedValueOnce( true );
 		( pathExists as jest.Mock ).mockResolvedValueOnce( true );
 
@@ -71,6 +71,35 @@ describe( 'createSite', () => {
 		expect( site ).toEqual( {
 			adminPassword: expect.any( String ),
 			id: expect.any( String ),
+			name: 'Test',
+			path: '/test',
+			phpVersion: '8.2',
+			port: 9999,
+			running: false,
+			customDomain: undefined,
+			enableHttps: undefined,
+			isWpAutoUpdating: false,
+		} );
+	} );
+
+	it( 'should create a site with provided siteId', async () => {
+		( isEmptyDir as jest.Mock ).mockResolvedValueOnce( true );
+		( pathExists as jest.Mock ).mockResolvedValueOnce( true );
+
+		const customSiteId = 'custom-site-id-123';
+		const [ site ] = await createSite(
+			mockIpcMainInvokeEvent,
+			'/test',
+			'Test',
+			'6.4',
+			undefined,
+			undefined,
+			customSiteId
+		);
+
+		expect( site ).toEqual( {
+			adminPassword: expect.any( String ),
+			id: customSiteId,
 			name: 'Test',
 			path: '/test',
 			phpVersion: '8.2',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-395

## Proposed Changes

- Added `newSites` field to user data schema to track sites pending creation
- Implemented handling for the case when a preview is created for a site that doesn't exist in Studio
- Created a Redux slice to manage new site processing
- Added IPC handlers and listeners to automatically create sites when detected
- Updated relevant tests to cover new functionality


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run `npm run start` and create a new site in Studio
- Go to settings, copy the path of the site and delete it from Studio with the option to keep files in the system
- Run `npm run cli:build`
- Run `node dist/cli/main.js preview create <STUDIO SITE FOLDER>`
- Wait for preview creation success
- Go back to Studio
- There should be a new site, with the name = pathname
- That site should have the newly created preview

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
