### PR TITLE
Studio: Add optgroup for uninstalled terminals

### DIFF
--- a/src/modules/user-settings/components/terminal-picker.tsx
+++ b/src/modules/user-settings/components/terminal-picker.tsx
@@ -16,26 +16,37 @@ export const TerminalPicker = ( {
 }: TerminalPickerProps ) => {
 	const { __ } = useI18n();
 
-	const options = Object.entries( supportedTerminalNames ).map( ( [ terminal, label ] ) => {
-		const terminalKey = terminal as SupportedTerminal;
-		const isAvailable = availableTerminals.includes( terminalKey );
+	const availableTerminalEntries = Object.entries( supportedTerminalNames ).filter(
+		( [ terminal ] ) => availableTerminals.includes( terminal as SupportedTerminal )
+	);
 
-		return {
-			value: terminalKey,
-			label,
-			disabled: ! isAvailable,
-		};
-	} );
+	const unavailableTerminalEntries = Object.entries( supportedTerminalNames ).filter(
+		( [ terminal ] ) => ! availableTerminals.includes( terminal as SupportedTerminal )
+	);
 
 	return (
 		<SettingsFormField label={ __( 'Shell' ) }>
 			<SelectControl
 				value={ value }
-				onChange={ onChange }
-				options={ options }
+				onChange={ ( newValue ) => onChange( newValue as SupportedTerminal ) }
 				__nextHasNoMarginBottom
 				__next40pxDefaultSize
-			/>
+			>
+				{ availableTerminalEntries.map( ( [ terminal, label ] ) => (
+					<option key={ terminal } value={ terminal }>
+						{ label }
+					</option>
+				) ) }
+				{ unavailableTerminalEntries.length > 0 && (
+					<optgroup label={ __( 'Not installed' ) }>
+						{ unavailableTerminalEntries.map( ( [ terminal, label ] ) => (
+							<option key={ terminal } value={ terminal } disabled>
+								{ label }
+							</option>
+						) ) }
+					</optgroup>
+				) }
+			</SelectControl>
 		</SettingsFormField>
 	);
 };

--- a/src/modules/user-settings/components/tests/terminal-picker.test.tsx
+++ b/src/modules/user-settings/components/tests/terminal-picker.test.tsx
@@ -21,6 +21,6 @@ describe( 'TerminalPicker', () => {
 		const select = screen.getByRole( 'combobox' );
 		fireEvent.change( select, { target: { value: 'iterm' } } );
 
-		expect( mockOnChange ).toHaveBeenCalledWith( 'iterm', expect.anything() );
+		expect( mockOnChange ).toHaveBeenCalledWith( 'iterm' );
 	} );
 } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

Fixes STU-406

## Proposed Changes

This PR adds optgroup for uninstalled terminals picker to be consistent with the uninstalled editors picker:

<img width="1108" alt="Screenshot 2025-04-25 at 3 05 00 PM" src="https://github.com/user-attachments/assets/385f7715-e4b6-407f-887a-3ebeacbe0ea6" />

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
* Ensure that you don't have one of the supported terminal apps in your Applications folder
* Start the app with `STUDIO_PREFERRED_EDITOR=true npm start`
* Click on the `User Settings` in the top right corner
* Click on the terminal selector 
* Confirm that you can see optgroup with uninstalled terminals as indicated on the screenshot

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
