### PR TITLE
Improve the alignment of the "More options" dropdown

### DIFF
--- a/src/components/content-tab-settings.tsx
+++ b/src/components/content-tab-settings.tsx
@@ -36,17 +36,17 @@ export function ContentTabSettings( { selectedSite }: ContentTabSettingsProps ) 
 		: `localhost:${ selectedSite.port }`;
 	const protocol = selectedSite.customDomain && selectedSite.enableHttps ? 'https' : 'http';
 	return (
-		<div className="p-8 ltr:pr-0 rtl:pl-0">
+		<div className="p-8 ltr:pr-4 rtl:pl-4">
 			<div className="flex justify-between items-center mb-4">
 				<h3 role="heading" className="text-black text-sm font-semibold">
 					{ __( 'Site details' ) }
 				</h3>
-				<div className="flex items-center">
+				<div className="flex items-center gap-1">
 					<EditSiteDetails currentWpVersion={ wpVersion } onSave={ refreshWpVersion } />
 					<DropdownMenu
 						icon={ moreVertical }
 						label={ __( 'More options' ) }
-						className="p-1 flex items-center"
+						className="flex items-center"
 					>
 						{ ( { onClose }: { onClose: () => void } ) => (
 							<MenuGroup>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Proposed Changes

- This is a minor update that better aligns the"More options" dropdown on the site Settings tab.

| Before | After | 
|-|-|
|<img width="239" alt="image" src="https://github.com/user-attachments/assets/3ae09348-b8cb-4b1d-9056-f5bbdbc5a402" />|<img width="239" alt="image" src="https://github.com/user-attachments/assets/ed3618cb-a98a-488c-9129-b308e38cabd6" />|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
