### PR TITLE
Studio: Build windows and mac artifact only on trunk branch

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -125,7 +125,7 @@ steps:
         notify:
           - github_commit_status:
               context: All Mac Dev Builds
-    if: build.tag !~ /^v[0-9]+/
+    if: build.branch == 'trunk' && build.tag !~ /^v[0-9]+/
 
   - label: 🔨 Windows Dev Build
     key: dev-windows
@@ -143,7 +143,7 @@ steps:
     env:
       IS_DEV_BUILD: true
     plugins: [$CI_TOOLKIT_PLUGIN, $NVM_PLUGIN]
-    if: build.tag !~ /^v[0-9]+/
+    if: build.branch == 'trunk' && build.tag !~ /^v[0-9]+/
     notify:
       - github_commit_status:
           context: Windows Dev Build


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Proposed Changes

- Skip Mac and Windows builds when PR is created. 

## Why changes are being made

- The Mac and Windows builds run on every PR. I think this is not useful in any case. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Make sure that while creating this PR, the Windows and Mac build pipelines are not triggered. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
