### PR TITLE
Studio: Refactor windows port checker to use `portFinder` helpers

### DIFF
--- a/src/hooks/use-site-details.tsx
+++ b/src/hooks/use-site-details.tsx
@@ -281,7 +281,7 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 					getIpcApi().showErrorMessageBox( {
 						title: __( 'Studio failed to initialize custom domains' ),
 						message: __(
-							'Studio needs to use port 80 and 443 to enable custom domains and SSL, but one of both of these ports are already in use by another app. Close any local development apps and restart Studio.'
+							'Studio needs to use port 80 and 443 to enable custom domains and SSL, but one of these ports are already in use by another app. Close any local development apps and restart Studio.'
 						),
 						showOpenLogs: false,
 					} );

--- a/src/lib/proxy-server.ts
+++ b/src/lib/proxy-server.ts
@@ -102,15 +102,11 @@ async function handleProxyRequest(
  * On Windows, node doesn't throw an error if port is busy, so we use portFinder to check
  * if the port is available.
  */
-export async function checkPortInWindows( port: number ): Promise< boolean > {
-	if ( process.platform !== 'win32' ) {
-		return true;
-	}
-
+export async function checkIfPortIsFree( port: number ): Promise< boolean > {
 	const portAvailable = await portFinder.isPortAvailable( port );
 
 	if ( ! portAvailable ) {
-		throw new Error( 'EADDRINUSE' );
+		throw new Error( 'PROXY_ERROR_PORT_IN_USE' );
 	}
 
 	return portAvailable;
@@ -124,7 +120,7 @@ export async function startProxyServer(): Promise< boolean > {
 	try {
 		// Start HTTP server if not already running
 		if ( ! isHttpProxyRunning ) {
-			await checkPortInWindows( 80 );
+			await checkIfPortIsFree( 80 );
 			httpProxyServer = http.createServer( ( req, res ) => handleProxyRequest( req, res, false ) );
 			await new Promise< void >( ( resolve, reject ) => {
 				httpProxyServer!
@@ -142,7 +138,7 @@ export async function startProxyServer(): Promise< boolean > {
 
 		// Start HTTPS server if not already running
 		if ( ! isHttpsProxyRunning ) {
-			await checkPortInWindows( 443 );
+			await checkIfPortIsFree( 443 );
 			const defaultOptions: https.ServerOptions = {
 				SNICallback: async ( servername, cb ) => {
 					try {
@@ -195,10 +191,7 @@ export async function startProxyServer(): Promise< boolean > {
 
 		return true;
 	} catch ( error ) {
-		if (
-			( isErrnoException( error ) && error.code === 'EADDRINUSE' ) ||
-			( error instanceof Error && error.message === 'EADDRINUSE' )
-		) {
+		if ( error instanceof Error && error.message === 'PROXY_ERROR_PORT_IN_USE' ) {
 			throw new Error( 'PROXY_ERROR_PORT_IN_USE' );
 		}
 

--- a/src/lib/proxy-server.ts
+++ b/src/lib/proxy-server.ts
@@ -192,7 +192,7 @@ export async function startProxyServer(): Promise< boolean > {
 		return true;
 	} catch ( error ) {
 		if ( error instanceof Error && error.message === 'PROXY_ERROR_PORT_IN_USE' ) {
-			throw new Error( 'PROXY_ERROR_PORT_IN_USE' );
+			throw error;
 		}
 
 		Sentry.captureException( error );

--- a/src/lib/proxy-server.ts
+++ b/src/lib/proxy-server.ts
@@ -100,7 +100,7 @@ async function handleProxyRequest(
 
 /**
  * On Windows, node doesn't throw an error if port is busy, so we use portFinder to check
- * if the port is available.
+ * if the port is available. If not, we throw an error to indicate that the port is in use.
  */
 export async function checkPortInWindows( port: number ): Promise< boolean > {
 	if ( process.platform !== 'win32' ) {

--- a/src/lib/proxy-server.ts
+++ b/src/lib/proxy-server.ts
@@ -4,7 +4,6 @@ import { createSecureContext } from 'node:tls';
 import { domainToASCII } from 'node:url';
 import * as Sentry from '@sentry/electron/main';
 import httpProxy from 'http-proxy';
-import { isErrnoException } from 'src/lib/is-errno-exception';
 import { portFinder } from 'src/lib/port-finder';
 import { SiteServer } from 'src/site-server';
 import { loadUserData } from 'src/storage/user-data';

--- a/src/lib/proxy-server.ts
+++ b/src/lib/proxy-server.ts
@@ -1,6 +1,5 @@
 import http from 'http';
 import https from 'https';
-import { createConnection } from 'node:net';
 import { createSecureContext } from 'node:tls';
 import { domainToASCII } from 'node:url';
 import * as Sentry from '@sentry/electron/main';
@@ -8,6 +7,7 @@ import httpProxy from 'http-proxy';
 import { isErrnoException } from 'src/lib/is-errno-exception';
 import { SiteServer } from 'src/site-server';
 import { loadUserData } from 'src/storage/user-data';
+import { portFinder } from 'src/lib/port-finder';
 
 let httpProxyServer: http.Server | null = null;
 let httpsProxyServer: https.Server | null = null;
@@ -99,35 +99,25 @@ async function handleProxyRequest(
 }
 
 /**
- * On Windows, node doesn't throw an error if port is busy, so we use the net module to explicitly check
- * if it's possible to establish a TCP connection to that port (meaning it's busy).
+ * On Windows, node doesn't throw an error if port is busy, so we use portFinder to check
+ * if the port is available.
  */
 export async function checkPortInWindows( port: number ): Promise< boolean > {
 	if ( process.platform !== 'win32' ) {
 		return true;
 	}
 
-	return await new Promise< boolean >( ( resolve, reject ) => {
-		const tester = createConnection( { port }, () => {
-			// If we can connect, port is in use
-			tester.end();
-			reject( new Error( 'EADDRINUSE' ) );
-		} );
+	try {
+		const portAvailable = await portFinder.isPortAvailable( port );
 
-		tester.setTimeout( 1000, () => {
-			tester.destroy();
-			reject( new Error( 'EADDRINUSE' ) );
-		} );
+		if ( ! portAvailable ) {
+			throw new Error( 'EADDRINUSE' );
+		}
 
-		tester.on( 'error', ( err ) => {
-			if ( isErrnoException( err ) && err.code === 'ECONNREFUSED' ) {
-				// Port is available
-				resolve( true );
-			} else {
-				reject( err );
-			}
-		} );
-	} );
+		return true;
+	} catch ( error ) {
+		throw error;
+	}
 }
 
 /**

--- a/src/lib/proxy-server.ts
+++ b/src/lib/proxy-server.ts
@@ -100,7 +100,7 @@ async function handleProxyRequest(
 
 /**
  * On Windows, node doesn't throw an error if port is busy, so we use portFinder to check
- * if the port is available. If not, we throw an error to indicate that the port is in use.
+ * if the port is available.
  */
 export async function checkPortInWindows( port: number ): Promise< boolean > {
 	if ( process.platform !== 'win32' ) {

--- a/src/lib/proxy-server.ts
+++ b/src/lib/proxy-server.ts
@@ -113,7 +113,7 @@ export async function checkPortInWindows( port: number ): Promise< boolean > {
 		throw new Error( 'EADDRINUSE' );
 	}
 
-	return true;
+	return portAvailable;
 }
 
 /**

--- a/src/lib/proxy-server.ts
+++ b/src/lib/proxy-server.ts
@@ -5,9 +5,9 @@ import { domainToASCII } from 'node:url';
 import * as Sentry from '@sentry/electron/main';
 import httpProxy from 'http-proxy';
 import { isErrnoException } from 'src/lib/is-errno-exception';
+import { portFinder } from 'src/lib/port-finder';
 import { SiteServer } from 'src/site-server';
 import { loadUserData } from 'src/storage/user-data';
-import { portFinder } from 'src/lib/port-finder';
 
 let httpProxyServer: http.Server | null = null;
 let httpsProxyServer: https.Server | null = null;

--- a/src/lib/proxy-server.ts
+++ b/src/lib/proxy-server.ts
@@ -107,17 +107,13 @@ export async function checkPortInWindows( port: number ): Promise< boolean > {
 		return true;
 	}
 
-	try {
-		const portAvailable = await portFinder.isPortAvailable( port );
+	const portAvailable = await portFinder.isPortAvailable( port );
 
-		if ( ! portAvailable ) {
-			throw new Error( 'EADDRINUSE' );
-		}
-
-		return true;
-	} catch ( error ) {
-		throw error;
+	if ( ! portAvailable ) {
+		throw new Error( 'EADDRINUSE' );
 	}
+
+	return true;
 }
 
 /**


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-103

> [!NOTE]
> We also have checkPortInWindows in src/lib/proxy-server.ts. There's an obvious difference in that the checkPortInWindows function only runs on Windows, but I still wonder if we shouldn't refactor that function and PortFinder::isPortFree to share the same underlying logic.
> - https://github.com/Automattic/studio/pull/1236#issuecomment-2826996329 

## Proposed Changes

- Refactor Windows port checker to use `portFinder` helpers

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the branch on a Windows machine.
2. Open a new terminal tab and run:
   ```bash
   php -S localhost:80
   ```
3. In another terminal tab, start Studio by running:
   ```bash
   npm start
   ```
4. Confirm that you receive an alert indicating the port is busy (similar to the screenshots provided).

![CleanShot 2025-04-27 at 18 44 30@2x](https://github.com/user-attachments/assets/1aef4a39-2682-41d1-bee7-15f3f701df75)

![CleanShot 2025-04-27 at 18 46 30@2x](https://github.com/user-attachments/assets/a4a4f51a-d82f-4ccd-bb81-171489b0287a)

5. Stop Studio (`Ctrl+C` in the terminal).
6. Cancel the PHP server process (`Ctrl+C` in the other terminal).
7. Wait a few seconds to ensure both processes have fully stopped.
8. Start Studio again by running:
   ```bash
   npm start
   ```
9. Confirm that this time, you **do not** receive any alert about the port being busy.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
