### PR TITLE
Site Overview: Check installed editors before setting default state for editor

### DIFF
--- a/src/components/content-tab-overview.tsx
+++ b/src/components/content-tab-overview.tsx
@@ -26,7 +26,7 @@ import { cx } from 'src/lib/cx';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 import { useEditorData } from 'src/modules/user-settings/hooks/use-editor-data';
 import { useTerminalData } from 'src/modules/user-settings/hooks/use-terminal-data';
-import { supportedEditorConfig } from 'src/modules/user-settings/lib/editor';
+import { SupportedEditor, supportedEditorConfig } from 'src/modules/user-settings/lib/editor';
 import { supportedTerminalNames } from 'src/modules/user-settings/lib/terminal';
 
 interface ContentTabOverviewProps {
@@ -170,7 +170,7 @@ function ShortcutsSection( { selectedSite }: Pick< ContentTabOverviewProps, 'sel
 		},
 	];
 
-	const editorConfig = supportedEditorConfig[ editor ];
+	const editorConfig = editor ? supportedEditorConfig[ editor as SupportedEditor ] : false;
 	if ( editorConfig ) {
 		buttonsArray.push( {
 			label: editorConfig.label,

--- a/src/components/tests/content-tab-overview-shortcuts-section.test.tsx
+++ b/src/components/tests/content-tab-overview-shortcuts-section.test.tsx
@@ -1,7 +1,6 @@
 // To run tests, execute `npm run test -- src/components/tests/content-tab-overview-shortcuts-section.test.tsx` from the root directory
 import { fireEvent, render, waitFor } from '@testing-library/react';
 import { ContentTabOverview } from 'src/components/content-tab-overview';
-import { useCheckInstalledApps } from 'src/hooks/use-check-installed-apps';
 import { useFeatureFlags } from 'src/hooks/use-feature-flags';
 import { useThemeDetails } from 'src/hooks/use-theme-details';
 import { getIpcApi } from 'src/lib/get-ipc-api';
@@ -38,12 +37,6 @@ describe( 'ShortcutsSection', () => {
 	} );
 
 	it( 'opens site in VS Code when the user select VS Code and clicked the button', async () => {
-		// Mock the `useCheckInstalledApps` hook to simulate VS Code being installed
-		( useCheckInstalledApps as jest.Mock ).mockReturnValue( {
-			vscode: true,
-			phpstorm: false,
-		} );
-
 		// Mock the IPC API
 		const openURLMock = jest.fn();
 		mockGetIpcApi.mockReturnValue( {
@@ -51,6 +44,10 @@ describe( 'ShortcutsSection', () => {
 			getUserEditor: jest.fn().mockResolvedValue( 'vscode' ),
 			getUserTerminal: jest.fn().mockResolvedValue( 'terminal' ),
 			getInstalledTerminals: jest.fn().mockResolvedValue( [ 'terminal' ] ),
+			getInstalledApps: jest.fn().mockResolvedValue( {
+				vscode: true,
+				phpstorm: false,
+			} ),
 		} );
 
 		const { getByLabelText } = render( <ContentTabOverview selectedSite={ selectedSite } /> );
@@ -63,12 +60,6 @@ describe( 'ShortcutsSection', () => {
 	} );
 
 	it( 'opens site in PhpStorm when PhpStorm is installed and the button is clicked, only available on MacOS', async () => {
-		// Mock the `useCheckInstalledApps` hook to simulate PhpStorm being installed
-		( useCheckInstalledApps as jest.Mock ).mockReturnValue( {
-			vscode: false,
-			phpstorm: true,
-		} );
-
 		// Mock the IPC API
 		const openURLMock = jest.fn();
 		mockGetIpcApi.mockReturnValue( {
@@ -76,6 +67,10 @@ describe( 'ShortcutsSection', () => {
 			getUserEditor: jest.fn().mockResolvedValue( 'phpstorm' ), // User prefers PhpStorm
 			getUserTerminal: jest.fn().mockResolvedValue( 'terminal' ),
 			getInstalledTerminals: jest.fn().mockResolvedValue( [ 'terminal' ] ),
+			getInstalledApps: jest.fn().mockResolvedValue( {
+				vscode: false,
+				phpstorm: true,
+			} ),
 		} );
 
 		const { getByLabelText } = render( <ContentTabOverview selectedSite={ selectedSite } /> );
@@ -89,12 +84,6 @@ describe( 'ShortcutsSection', () => {
 		);
 	} );
 	it( 'opens terminal when terminal is available and the button is clicked', async () => {
-		// Mock the `useCheckInstalledApps` hook to simulate terminal being available
-		( useCheckInstalledApps as jest.Mock ).mockReturnValue( {
-			vscode: false,
-			phpstorm: false,
-		} );
-
 		// Mock the IPC API
 		const openTerminalAtPathMock = jest.fn();
 		mockGetIpcApi.mockReturnValue( {
@@ -102,6 +91,10 @@ describe( 'ShortcutsSection', () => {
 			getUserEditor: jest.fn().mockResolvedValue( null ),
 			getUserTerminal: jest.fn().mockResolvedValue( 'terminal' ),
 			getInstalledTerminals: jest.fn().mockResolvedValue( [ 'terminal' ] ),
+			getInstalledApps: jest.fn().mockResolvedValue( {
+				vscode: false,
+				phpstorm: false,
+			} ),
 		} );
 
 		const { getByLabelText } = render( <ContentTabOverview selectedSite={ selectedSite } /> );
@@ -119,11 +112,6 @@ describe( 'ShortcutsSection', () => {
 	} );
 
 	it( 'opens terminal with wp-cli integration if feature flag is enabled', async () => {
-		// Mock the `useCheckInstalledApps` hook to simulate terminal being available
-		( useCheckInstalledApps as jest.Mock ).mockReturnValue( {
-			vscode: false,
-			phpstorm: false,
-		} );
 		( useFeatureFlags as jest.Mock ).mockReturnValue( {
 			terminalWpCliEnabled: true,
 		} );
@@ -151,18 +139,39 @@ describe( 'ShortcutsSection', () => {
 	} );
 
 	it( 'does not show editor buttons when no editors are installed', async () => {
-		// Mock the `useCheckInstalledApps` hook to simulate no editors installed
-		( useCheckInstalledApps as jest.Mock ).mockReturnValue( {
-			vscode: false,
-			phpstorm: false,
-		} );
-
 		// Mock the IPC API
 		mockGetIpcApi.mockReturnValue( {
 			openLocalPath: jest.fn(),
 			getUserEditor: jest.fn().mockResolvedValue( null ),
 			getUserTerminal: jest.fn().mockResolvedValue( null ),
 			getInstalledTerminals: jest.fn().mockResolvedValue( [] ),
+			getInstalledApps: jest.fn().mockResolvedValue( {
+				vscode: false,
+				phpstorm: false,
+			} ),
+		} );
+
+		const { queryByLabelText, findByLabelText } = render(
+			<ContentTabOverview selectedSite={ selectedSite } />
+		);
+
+		await findByLabelText( 'Terminal' );
+
+		expect( queryByLabelText( 'VS Code' ) ).toBeNull();
+		expect( queryByLabelText( 'PhpStorm' ) ).toBeNull();
+	} );
+
+	it( 'shows VS Code editor button when VS Code and phpStorm both editors are installed', async () => {
+		// Mock the IPC API
+		mockGetIpcApi.mockReturnValue( {
+			openLocalPath: jest.fn(),
+			getUserEditor: jest.fn().mockResolvedValue( null ),
+			getUserTerminal: jest.fn().mockResolvedValue( null ),
+			getInstalledTerminals: jest.fn().mockResolvedValue( [] ),
+			getInstalledApps: jest.fn().mockResolvedValue( {
+				vscode: true,
+				phpstorm: true,
+			} ),
 		} );
 
 		const { queryByLabelText, findByLabelText } = render(
@@ -172,6 +181,54 @@ describe( 'ShortcutsSection', () => {
 		await findByLabelText( 'Terminal' );
 		await findByLabelText( 'VS Code' );
 
+		expect( queryByLabelText( 'PhpStorm' ) ).toBeNull();
+	} );
+
+	it( 'shows phpStorm editor button when VS Code is not installed but phpStorm is', async () => {
+		// Mock the IPC API
+		mockGetIpcApi.mockReturnValue( {
+			openLocalPath: jest.fn(),
+			getUserEditor: jest.fn().mockResolvedValue( null ),
+			getUserTerminal: jest.fn().mockResolvedValue( null ),
+			getInstalledTerminals: jest.fn().mockResolvedValue( [] ),
+			getInstalledApps: jest.fn().mockResolvedValue( {
+				vscode: false,
+				phpstorm: true,
+			} ),
+		} );
+
+		const { queryByLabelText, findByLabelText } = render(
+			<ContentTabOverview selectedSite={ selectedSite } />
+		);
+
+		await findByLabelText( 'Terminal' );
+		await findByLabelText( 'PhpStorm' );
+
+		expect( queryByLabelText( 'VS Code' ) ).toBeNull();
+	} );
+
+	it( 'shows users preffered editor', async () => {
+		// Mock the IPC API
+		mockGetIpcApi.mockReturnValue( {
+			openLocalPath: jest.fn(),
+			getUserEditor: jest.fn().mockResolvedValue( 'cursor' ),
+			getUserTerminal: jest.fn().mockResolvedValue( null ),
+			getInstalledTerminals: jest.fn().mockResolvedValue( [] ),
+			getInstalledApps: jest.fn().mockResolvedValue( {
+				vscode: true,
+				phpstorm: true,
+				cursor: true,
+			} ),
+		} );
+
+		const { queryByLabelText, findByLabelText } = render(
+			<ContentTabOverview selectedSite={ selectedSite } />
+		);
+
+		await findByLabelText( 'Terminal' );
+		await findByLabelText( 'Cursor' );
+
+		expect( queryByLabelText( 'VS Code' ) ).toBeNull();
 		expect( queryByLabelText( 'PhpStorm' ) ).toBeNull();
 	} );
 } );

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -28,7 +28,6 @@ export const WPCOM_PROFILE_URL = 'https://wordpress.com/me';
 export const LOCAL_STORAGE_CHAT_MESSAGES_KEY = 'ai_chat_messages';
 export const LOCAL_STORAGE_CHAT_API_IDS_KEY = 'ai_chat_ids';
 export const DEFAULT_TERMINAL = 'terminal';
-export const DEFAULT_EDITOR = 'vscode';
 
 //Import file constants
 

--- a/src/modules/user-settings/components/editor-picker.tsx
+++ b/src/modules/user-settings/components/editor-picker.tsx
@@ -47,6 +47,7 @@ export const EditorPicker = ( { value, onChange }: EditorPickerProps ) => {
 				__nextHasNoMarginBottom
 				__next40pxDefaultSize
 			>
+				{ value === '' && <option value={ '' }>{ __( 'Select' ) }</option> }
 				{ installedEditors.map( ( [ editorKey, editorConfig ] ) => (
 					<option key={ editorKey } value={ editorKey }>
 						{ editorConfig.label }

--- a/src/modules/user-settings/components/editor-picker.tsx
+++ b/src/modules/user-settings/components/editor-picker.tsx
@@ -6,7 +6,7 @@ import { SupportedEditor, supportedEditorConfig } from 'src/modules/user-setting
 import { SettingsFormField } from './settings-form-field';
 
 interface EditorPickerProps {
-	value: SupportedEditor;
+	value: SupportedEditor | string;
 	onChange: ( value: SupportedEditor ) => void;
 }
 

--- a/src/modules/user-settings/hooks/use-editor-data.ts
+++ b/src/modules/user-settings/hooks/use-editor-data.ts
@@ -1,18 +1,33 @@
 import { useState, useEffect } from 'react';
-import { DEFAULT_EDITOR } from 'src/constants';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 import { SupportedEditor } from 'src/modules/user-settings/lib/editor';
 
 export function useEditorData() {
-	const [ editor, setEditor ] = useState< SupportedEditor >( DEFAULT_EDITOR );
-	const [ savedEditorValue, setSavedEditorValue ] = useState< SupportedEditor >( DEFAULT_EDITOR );
+	const [ editor, setEditor ] = useState< SupportedEditor | string >( '' );
+	const [ savedEditorValue, setSavedEditorValue ] = useState< SupportedEditor | string >( '' );
 
 	const getSavedEditor = async () => {
 		try {
 			const savedEditor = await getIpcApi().getUserEditor();
-			return savedEditor || DEFAULT_EDITOR;
+			// Respect user preference if it is set
+			if ( savedEditor ) {
+				return savedEditor;
+			}
+
+			// If no user preference is set, check for installed editors
+			// and set the default to the first one found
+			// This is a fallback to ensure we keep existing behavior
+			const installedEditors = await getIpcApi().getInstalledApps();
+			if ( installedEditors.vscode ) {
+				return 'vscode';
+			}
+			if ( installedEditors.phpstorm ) {
+				return 'phpstorm';
+			}
+
+			return '';
 		} catch ( error ) {
-			return DEFAULT_EDITOR;
+			return '';
 		}
 	};
 
@@ -25,12 +40,12 @@ export function useEditorData() {
 		void loadSavedEditor();
 	}, [] );
 
-	const handleEditorChange = ( newEditor: SupportedEditor ) => {
+	const handleEditorChange = ( newEditor: SupportedEditor | string ) => {
 		setEditor( newEditor );
 	};
 
 	const saveEditorPreference = async () => {
-		await getIpcApi().saveUserEditor( editor );
+		await getIpcApi().saveUserEditor( editor as SupportedEditor );
 	};
 
 	const resetEditor = () => {

--- a/src/modules/user-settings/hooks/use-editor-data.ts
+++ b/src/modules/user-settings/hooks/use-editor-data.ts
@@ -20,8 +20,7 @@ export function useEditorData() {
 			const installedEditors = await getIpcApi().getInstalledApps();
 			if ( installedEditors.vscode ) {
 				return 'vscode';
-			}
-			if ( installedEditors.phpstorm ) {
+			} else if ( installedEditors.phpstorm ) {
 				return 'phpstorm';
 			}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-409

## Proposed Changes

- Check installed apps before setting the default editor. If VS Code is installed, use it as the editor; otherwise, look for phpStorm if it is installed. If neither is available, set an empty string. 
- Introduce some more tests
- Remove default editor constant

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Refer: https://github.com/Automattic/studio/pull/1271

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
