### PR TITLE
Updated command signatures for CLI

### DIFF
--- a/cli/commands/preview/create.ts
+++ b/cli/commands/preview/create.ts
@@ -65,19 +65,10 @@ export async function runCommand(
 
 export const registerCommand = ( yargs: StudioArgv ) => {
 	return yargs.command( {
-		command: 'create [folder]',
-		describe: __(
-			'Create a preview site from the specified folder (defaults to current directory)'
-		),
-		builder: ( yargs ) => {
-			return yargs.positional( 'folder', {
-				type: 'string',
-				default: process.cwd(),
-				description: __( 'The folder to create a preview site from' ),
-			} );
-		},
+		command: 'create',
+		describe: __( 'Create a preview site' ),
 		handler: async ( argv ) => {
-			await runCommand( argv.folder, argv.outputFormat );
+			await runCommand( argv.path, argv.outputFormat );
 		},
 	} );
 };

--- a/cli/commands/preview/delete.ts
+++ b/cli/commands/preview/delete.ts
@@ -44,10 +44,10 @@ export const registerCommand = ( yargs: Argv< GlobalOptions > ) => {
 	return yargs.command( {
 		command: 'delete <host>',
 		describe: __( 'Delete a preview site' ),
-		builder: ( yargs: Argv< GlobalOptions > ) => {
+		builder: ( yargs ) => {
 			return yargs.positional( 'host', {
 				type: 'string',
-				description: __( 'The hostname of the preview site to delete' ),
+				description: __( 'Hostname of the preview site to delete' ),
 				demandOption: true,
 			} );
 		},

--- a/cli/commands/preview/list.ts
+++ b/cli/commands/preview/list.ts
@@ -56,24 +56,18 @@ export async function runCommand(
 
 export const registerCommand = ( yargs: StudioArgv ) => {
 	return yargs.command( {
-		command: 'list [folder]',
-		describe: __( 'List preview sites for the specified folder (defaults to current directory)' ),
+		command: 'list',
+		describe: __( 'List preview sites' ),
 		builder: ( yargs ) => {
-			return yargs
-				.positional( 'folder', {
-					type: 'string',
-					default: process.cwd(),
-					description: __( 'The folder to list preview sites for' ),
-				} )
-				.option( 'format', {
-					type: 'string',
-					choices: [ 'table', 'json' ],
-					default: 'table',
-					description: __( 'Output format' ),
-				} );
+			return yargs.option( 'format', {
+				type: 'string',
+				choices: [ 'table', 'json' ],
+				default: 'table',
+				description: __( 'Output format' ),
+			} );
 		},
 		handler: async ( argv ) => {
-			await runCommand( argv.folder, argv.format as 'table' | 'json', argv.outputFormat );
+			await runCommand( argv.path, argv.format as 'table' | 'json', argv.outputFormat );
 		},
 	} );
 };

--- a/cli/commands/preview/update.ts
+++ b/cli/commands/preview/update.ts
@@ -72,25 +72,18 @@ export async function runCommand(
 
 export const registerCommand = ( yargs: Argv< GlobalOptions > ) => {
 	return yargs.command( {
-		command: 'update [folder]',
-		describe: __( 'Update preview site for the specified folder (defaults to current directory)' ),
-		builder: ( yargs: Argv< GlobalOptions > ) => {
-			return yargs
-				.positional( 'folder', {
-					type: 'string',
-					default: process.cwd(),
-					description: __( 'The folder to update the preview site from' ),
-				} )
-				.option( 'host', {
-					alias: 'H',
-					type: 'string',
-					demandOption: true,
-					description: __( 'Host of the preview site to update' ),
-				} );
+		command: 'update <host>',
+		describe: __( 'Update preview site' ),
+		builder: ( yargs ) => {
+			return yargs.positional( 'host', {
+				type: 'string',
+				description: __( 'Hostname of the preview site to update' ),
+				demandOption: true,
+			} );
 		},
 		handler: async ( argv ) => {
 			const normalizedHost = normalizeHostname( argv.host );
-			await runCommand( argv.folder, normalizedHost, argv.outputFormat );
+			await runCommand( argv.path, normalizedHost, argv.outputFormat );
 		},
 	} );
 };

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import { __ } from '@wordpress/i18n';
 import { StatsGroup, StatsMetric } from 'common/types/stats';
 import yargs from 'yargs';
@@ -31,6 +32,13 @@ async function main() {
 		.option( 'avoid-telemetry', {
 			type: 'boolean',
 			hidden: true,
+		} )
+		.option( 'path', {
+			type: 'string',
+			default: process.cwd(),
+			defaultDescription: __( 'Current directory' ),
+			description: __( 'Path to the WordPress files' ),
+			coerce: ( value ) => path.resolve( process.cwd(), value ),
 		} )
 		.middleware( async ( argv ) => {
 			if ( ! argv.avoidTelemetry ) {

--- a/cli/types.ts
+++ b/cli/types.ts
@@ -4,6 +4,7 @@ export type OutputFormat = undefined | 'json';
 
 export interface GlobalOptions {
 	outputFormat?: OutputFormat;
+	path: string;
 }
 
 export type StudioArgv = Argv< GlobalOptions >;

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -1317,7 +1317,7 @@ export async function createSnapshot(
 	siteFolder: string
 ): Promise< { operationId: crypto.UUID } > {
 	const parentWindow = BrowserWindow.fromWebContents( event.sender );
-	return executePreviewCliCommand( [ 'preview', 'create', siteFolder ], parentWindow );
+	return executePreviewCliCommand( [ 'preview', 'create', '--path', siteFolder ], parentWindow );
 }
 
 export async function updateSnapshot(
@@ -1327,7 +1327,7 @@ export async function updateSnapshot(
 ): Promise< { operationId: crypto.UUID } > {
 	const parentWindow = BrowserWindow.fromWebContents( event.sender );
 	return executePreviewCliCommand(
-		[ 'preview', 'update', siteFolder, '-h', hostname ],
+		[ 'preview', 'update', '--path', siteFolder, hostname ],
 		parentWindow
 	);
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-419
- Fixes STU-418

## Proposed Changes

- Change the folder/path option from a positional to a `--path` option. This harmonises the `studio preview update` and `studio preview delete` command signatures, and aligns with the WP-CLI convention.
- Resolve potentially relative paths before passing them to the command handler.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Run `npm run cli:build`
2. Run `node dist/cli/main.js preview list --path PATH` where `PATH` is an **absolute** path to a Studio site with preview sites
3. Ensure that the preview sites are logged as expected
4. Run `node dist/cli/main.js preview list --path PATH` where `PATH` is an **relative** path to a Studio site with preview sites
5. Ensure that the preview sites are logged as expected
6. `cd` into the aforementioned `PATH` and run `node PATH_TO_MAIN_JS`
7. Ensure that the preview sites are logged as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
