### PR TITLE
STU-417: Disallow updating expired preview sites on the CLI

### DIFF
--- a/cli/commands/preview/tests/update.test.ts
+++ b/cli/commands/preview/tests/update.test.ts
@@ -1,5 +1,6 @@
 import os from 'os';
 import path from 'path';
+import { DEMO_SITE_EXPIRATION_DAYS } from 'common/constants';
 import { uploadArchive, waitForSiteReady } from 'cli/lib/api';
 import { getAuthToken } from 'cli/lib/appdata';
 import { createArchive, cleanup } from 'cli/lib/archive';
@@ -223,5 +224,18 @@ describe( 'Preview Update Command', () => {
 		await runCommand( mockFolder, mockSiteUrl );
 
 		expect( cleanup ).toHaveBeenCalledWith( mockArchivePath );
+	} );
+
+	it( 'should not allow updating an expired preview site', async () => {
+		const { runCommand } = await import( '../update' );
+		const expiredDate = mockDate - ( DEMO_SITE_EXPIRATION_DAYS + 1 ) * 24 * 60 * 60 * 1000;
+		const expiredSnapshot = { ...mockSnapshot, date: expiredDate };
+		( getSnapshotsFromAppdata as jest.Mock ).mockResolvedValue( [ expiredSnapshot ] );
+
+		await runCommand( mockFolder, mockSiteUrl );
+
+		expect( mockLogger.reportError ).toHaveBeenCalled();
+		expect( mockLogger.reportError ).toHaveBeenCalledWith( expect.any( LoggerError ) );
+		expect( createArchive ).not.toHaveBeenCalled();
 	} );
 } );

--- a/cli/commands/preview/update.ts
+++ b/cli/commands/preview/update.ts
@@ -1,7 +1,9 @@
 import os from 'node:os';
 import path from 'node:path';
 import { __, _n, sprintf } from '@wordpress/i18n';
+import { DEMO_SITE_EXPIRATION_DAYS } from 'common/constants';
 import { PreviewCommandLoggerAction as LoggerAction } from 'common/logger-actions';
+import { addDays } from 'date-fns';
 import { Argv } from 'yargs';
 import { uploadArchive, waitForSiteReady } from 'cli/lib/api';
 import { getAuthToken } from 'cli/lib/appdata';
@@ -32,6 +34,13 @@ export async function runCommand(
 		if ( ! snapshotToUpdate ) {
 			throw new LoggerError( 'Preview site not found' );
 		}
+
+		const now = new Date();
+		const endDate = addDays( snapshotToUpdate.date, DEMO_SITE_EXPIRATION_DAYS );
+		if ( endDate < now ) {
+			throw new LoggerError( __( 'Cannot update an expired preview site.' ) );
+		}
+
 		logger.reportSuccess( __( 'Validation successful' ) );
 
 		logger.reportStart( LoggerAction.ARCHIVE, __( 'Creating archive...' ) );

--- a/cli/lib/snapshots.ts
+++ b/cli/lib/snapshots.ts
@@ -1,7 +1,7 @@
 import { __, sprintf } from '@wordpress/i18n';
 // eslint-disable-next-line import/no-named-as-default
 import Table from 'cli-table3';
-import { HOUR_MS, DAY_MS } from 'common/constants';
+import { HOUR_MS, DAY_MS, DEMO_SITE_EXPIRATION_DAYS } from 'common/constants';
 import { Snapshot } from 'common/types/snapshot';
 import {
 	addDays,
@@ -127,9 +127,8 @@ export async function deleteSnapshotFromAppdata( snapshotUrl: string ): Promise<
 }
 
 function formatDurationUntilExpiry( lastUpdatedAt: number ) {
-	const MAX_AGE_IN_DAYS = 7;
 	const now = new Date();
-	const endDate = addDays( lastUpdatedAt, MAX_AGE_IN_DAYS );
+	const endDate = addDays( lastUpdatedAt, DEMO_SITE_EXPIRATION_DAYS );
 	const difference = endDate.getTime() - now.getTime();
 	let format: DurationUnit[] = [ 'days', 'hours' ];
 

--- a/common/constants.ts
+++ b/common/constants.ts
@@ -1,5 +1,6 @@
 export const DEMO_SITE_SIZE_LIMIT_GB = 2;
 export const DEMO_SITE_SIZE_LIMIT_BYTES = DEMO_SITE_SIZE_LIMIT_GB * 1024 * 1024 * 1024; // 2GB
+export const DEMO_SITE_EXPIRATION_DAYS = 7;
 export const HOUR_MS = 1000 * 60 * 60;
 export const DAY_MS = HOUR_MS * 24;
 

--- a/src/hooks/use-expiration-date.ts
+++ b/src/hooks/use-expiration-date.ts
@@ -1,6 +1,6 @@
 import { useI18n } from '@wordpress/react-i18n';
 import { intervalToDuration, formatDuration, addDays, DurationUnit, addHours } from 'date-fns';
-import { HOUR_MS, DAY_MS } from 'common/constants';
+import { HOUR_MS, DAY_MS, DEMO_SITE_EXPIRATION_DAYS } from 'common/constants';
 import { SupportedLocale } from 'common/lib/locale';
 import { useI18nData } from 'src/hooks/use-i18n-data';
 import { formatDistance } from 'src/lib/date';
@@ -34,9 +34,8 @@ function formatStringDate(
 export function useExpirationDate( snapshotDate: number ) {
 	const { __ } = useI18n();
 	const { locale } = useI18nData();
-	const MAX_DAYS = 7;
 	const now = new Date();
-	const endDate = addDays( snapshotDate, MAX_DAYS );
+	const endDate = addDays( snapshotDate, DEMO_SITE_EXPIRATION_DAYS );
 	const difference = endDate.getTime() - now.getTime();
 	let isExpired = false;
 	let format: DurationUnit[] = [ 'days', 'hours' ];


### PR DESCRIPTION
## Related issues

- Fixes STU-417

## Proposed Changes

- Disallow updating expired preview sites via the CLI.
- Extract preview site expiration days to a shared constant (DEMO_SITE_EXPIRATION_DAYS) in common/constants.ts.
- Use the shared constant in all expiration logic (CLI, frontend, and tests).
- Add a CLI test to ensure updating an expired preview site is not allowed.

![image](https://github.com/user-attachments/assets/612a296c-2258-4818-968c-75488bcf45ba)

## Testing Instructions

- Run `npm run cli:build`
- Attempt to update a preview site that is expired (older than 7 days). The CLI should report an error and not proceed.
- Attempt to update a non-expired preview site. The update should proceed as normal.
- Run the CLI tests and ensure all pass, including the new test for expired preview site updates.

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?
