### PR TITLE
Move preview site location when updated from different local site

### DIFF
--- a/cli/commands/preview/tests/update.test.ts
+++ b/cli/commands/preview/tests/update.test.ts
@@ -65,6 +65,11 @@ describe( 'Preview Update Command', () => {
 		} );
 		( waitForSiteReady as jest.Mock ).mockResolvedValue( true );
 		( updateSnapshotInAppdata as jest.Mock ).mockResolvedValue( undefined );
+		( require( 'cli/lib/appdata' ).getSiteByFolder as jest.Mock ).mockResolvedValue( {
+			id: mockSnapshot.localSiteId,
+			path: mockFolder,
+			name: 'Test Site',
+		} );
 	} );
 
 	afterEach( () => {
@@ -240,5 +245,25 @@ describe( 'Preview Update Command', () => {
 		expect( mockLogger.reportError ).toHaveBeenCalled();
 		expect( mockLogger.reportError ).toHaveBeenCalledWith( expect.any( LoggerError ) );
 		expect( createArchive ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should throw error if folder does not match original site and no overwrite flag', async () => {
+		const { runCommand } = await import( '../update' );
+		jest
+			.spyOn( await import( 'cli/lib/appdata' ), 'getSiteByFolder' )
+			.mockResolvedValueOnce( { id: 'different-id', path: '/other/path', name: 'Other Site' } );
+		await runCommand( mockFolder, mockSiteUrl, undefined, false );
+		expect( mockLogger.reportError ).toHaveBeenCalledWith( expect.any( LoggerError ) );
+		expect( createArchive ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should allow update if overwrite flag is set even if folder does not match', async () => {
+		const { runCommand } = await import( '../update' );
+		jest
+			.spyOn( await import( 'cli/lib/appdata' ), 'getSiteByFolder' )
+			.mockResolvedValueOnce( { id: 'different-id', path: '/other/path', name: 'Other Site' } );
+		await runCommand( mockFolder, mockSiteUrl, undefined, true );
+		// Should proceed to createArchive
+		expect( createArchive ).toHaveBeenCalledWith( mockFolder, mockArchivePath );
 	} );
 } );

--- a/cli/commands/preview/tests/update.test.ts
+++ b/cli/commands/preview/tests/update.test.ts
@@ -252,7 +252,7 @@ describe( 'Preview Update Command', () => {
 		jest
 			.spyOn( await import( 'cli/lib/appdata' ), 'getSiteByFolder' )
 			.mockResolvedValueOnce( { id: 'different-id', path: '/other/path', name: 'Other Site' } );
-		await runCommand( mockFolder, mockSiteUrl, undefined, false );
+		await runCommand( mockFolder, mockSiteUrl, false );
 		expect( mockLogger.reportError ).toHaveBeenCalledWith( expect.any( LoggerError ) );
 		expect( createArchive ).not.toHaveBeenCalled();
 	} );
@@ -262,8 +262,7 @@ describe( 'Preview Update Command', () => {
 		jest
 			.spyOn( await import( 'cli/lib/appdata' ), 'getSiteByFolder' )
 			.mockResolvedValueOnce( { id: 'different-id', path: '/other/path', name: 'Other Site' } );
-		await runCommand( mockFolder, mockSiteUrl, undefined, true );
-		// Should proceed to createArchive
+		await runCommand( mockFolder, mockSiteUrl, true );
 		expect( createArchive ).toHaveBeenCalledWith( mockFolder, mockArchivePath );
 	} );
 } );

--- a/cli/commands/preview/tests/update.test.ts
+++ b/cli/commands/preview/tests/update.test.ts
@@ -2,7 +2,7 @@ import os from 'os';
 import path from 'path';
 import { DEMO_SITE_EXPIRATION_DAYS } from 'common/constants';
 import { uploadArchive, waitForSiteReady } from 'cli/lib/api';
-import { getAuthToken } from 'cli/lib/appdata';
+import { getAuthToken, getSiteByFolder } from 'cli/lib/appdata';
 import { createArchive, cleanup } from 'cli/lib/archive';
 import { updateSnapshotInAppdata, getSnapshotsFromAppdata } from 'cli/lib/snapshots';
 import { validateSiteFolder } from 'cli/lib/validation';
@@ -11,6 +11,7 @@ import { Logger, LoggerError } from 'cli/logger';
 jest.mock( 'cli/lib/appdata', () => ( {
 	getAppdataDirectory: jest.fn().mockReturnValue( '/test/appdata' ),
 	getAuthToken: jest.fn(),
+	getSiteByFolder: jest.fn(),
 } ) );
 jest.mock( 'cli/lib/validation' );
 jest.mock( 'cli/lib/archive' );
@@ -65,7 +66,7 @@ describe( 'Preview Update Command', () => {
 		} );
 		( waitForSiteReady as jest.Mock ).mockResolvedValue( true );
 		( updateSnapshotInAppdata as jest.Mock ).mockResolvedValue( undefined );
-		( require( 'cli/lib/appdata' ).getSiteByFolder as jest.Mock ).mockResolvedValue( {
+		( getSiteByFolder as jest.Mock ).mockResolvedValue( {
 			id: mockSnapshot.localSiteId,
 			path: mockFolder,
 			name: 'Test Site',

--- a/cli/commands/preview/tests/update.test.ts
+++ b/cli/commands/preview/tests/update.test.ts
@@ -4,7 +4,7 @@ import { DEMO_SITE_EXPIRATION_DAYS } from 'common/constants';
 import { uploadArchive, waitForSiteReady } from 'cli/lib/api';
 import { getAuthToken } from 'cli/lib/appdata';
 import { createArchive, cleanup } from 'cli/lib/archive';
-import { updateSnapshotDateInAppdata, getSnapshotsFromAppdata } from 'cli/lib/snapshots';
+import { updateSnapshotInAppdata, getSnapshotsFromAppdata } from 'cli/lib/snapshots';
 import { validateSiteFolder } from 'cli/lib/validation';
 import { Logger, LoggerError } from 'cli/logger';
 
@@ -64,7 +64,7 @@ describe( 'Preview Update Command', () => {
 			site_id: mockAtomicSiteId,
 		} );
 		( waitForSiteReady as jest.Mock ).mockResolvedValue( true );
-		( updateSnapshotDateInAppdata as jest.Mock ).mockResolvedValue( undefined );
+		( updateSnapshotInAppdata as jest.Mock ).mockResolvedValue( undefined );
 	} );
 
 	afterEach( () => {
@@ -106,7 +106,7 @@ describe( 'Preview Update Command', () => {
 			`Preview site available at: https://${ mockSiteUrl }`,
 		] );
 
-		expect( updateSnapshotDateInAppdata ).toHaveBeenCalledWith( mockAtomicSiteId );
+		expect( updateSnapshotInAppdata ).toHaveBeenCalledWith( mockAtomicSiteId, mockFolder );
 		expect( mockLogger.reportStart.mock.calls[ 4 ] ).toEqual( [
 			'appdata',
 			'Saving preview site to Studio...',
@@ -202,12 +202,12 @@ describe( 'Preview Update Command', () => {
 
 		expect( mockLogger.reportError ).toHaveBeenCalled();
 		expect( mockLogger.reportError ).toHaveBeenCalledWith( expect.any( LoggerError ) );
-		expect( updateSnapshotDateInAppdata ).not.toHaveBeenCalled();
+		expect( updateSnapshotInAppdata ).not.toHaveBeenCalled();
 	} );
 
 	it( 'should handle appdata errors', async () => {
 		const errorMessage = 'Failed to save to appdata';
-		( updateSnapshotDateInAppdata as jest.Mock ).mockImplementation( () => {
+		( updateSnapshotInAppdata as jest.Mock ).mockImplementation( () => {
 			throw new LoggerError( errorMessage );
 		} );
 

--- a/cli/commands/preview/tests/update.test.ts
+++ b/cli/commands/preview/tests/update.test.ts
@@ -79,7 +79,7 @@ describe( 'Preview Update Command', () => {
 
 	it( 'should complete the preview update process successfully', async () => {
 		const { runCommand } = await import( '../update' );
-		await runCommand( mockFolder, mockSiteUrl );
+		await runCommand( mockFolder, mockSiteUrl, false );
 
 		expect( validateSiteFolder ).toHaveBeenCalledWith( mockFolder );
 		expect( mockLogger.reportStart.mock.calls[ 0 ] ).toEqual( [ 'validate', 'Validating...' ] );
@@ -124,7 +124,7 @@ describe( 'Preview Update Command', () => {
 
 	it( 'should use current directory when no folder is specified', async () => {
 		const { runCommand } = await import( '../update' );
-		await runCommand( process.cwd(), mockSiteUrl );
+		await runCommand( process.cwd(), mockSiteUrl, false );
 
 		expect( validateSiteFolder ).toHaveBeenCalledWith( process.cwd() );
 	} );
@@ -136,7 +136,7 @@ describe( 'Preview Update Command', () => {
 		} );
 
 		const { runCommand } = await import( '../update' );
-		await runCommand( mockFolder, mockSiteUrl );
+		await runCommand( mockFolder, mockSiteUrl, false );
 
 		expect( mockLogger.reportError ).toHaveBeenCalled();
 		expect( mockLogger.reportError ).toHaveBeenCalledWith( expect.any( LoggerError ) );
@@ -151,7 +151,7 @@ describe( 'Preview Update Command', () => {
 		} );
 
 		const { runCommand } = await import( '../update' );
-		await runCommand( mockFolder, mockSiteUrl );
+		await runCommand( mockFolder, mockSiteUrl, false );
 
 		expect( mockLogger.reportError ).toHaveBeenCalled();
 		expect( mockLogger.reportError ).toHaveBeenCalledWith( expect.any( LoggerError ) );
@@ -162,7 +162,7 @@ describe( 'Preview Update Command', () => {
 		( getSnapshotsFromAppdata as jest.Mock ).mockResolvedValue( [] );
 
 		const { runCommand } = await import( '../update' );
-		await runCommand( mockFolder, mockSiteUrl );
+		await runCommand( mockFolder, mockSiteUrl, false );
 
 		expect( mockLogger.reportError ).toHaveBeenCalled();
 		expect( mockLogger.reportError ).toHaveBeenCalledWith( expect.any( LoggerError ) );
@@ -176,7 +176,7 @@ describe( 'Preview Update Command', () => {
 		} );
 
 		const { runCommand } = await import( '../update' );
-		await runCommand( mockFolder, mockSiteUrl );
+		await runCommand( mockFolder, mockSiteUrl, false );
 
 		expect( mockLogger.reportError ).toHaveBeenCalled();
 		expect( mockLogger.reportError ).toHaveBeenCalledWith( expect.any( LoggerError ) );
@@ -190,7 +190,7 @@ describe( 'Preview Update Command', () => {
 		} );
 
 		const { runCommand } = await import( '../update' );
-		await runCommand( mockFolder, mockSiteUrl );
+		await runCommand( mockFolder, mockSiteUrl, false );
 
 		expect( mockLogger.reportError ).toHaveBeenCalled();
 		expect( mockLogger.reportError ).toHaveBeenCalledWith( expect.any( LoggerError ) );
@@ -204,7 +204,7 @@ describe( 'Preview Update Command', () => {
 		} );
 
 		const { runCommand } = await import( '../update' );
-		await runCommand( mockFolder, mockSiteUrl );
+		await runCommand( mockFolder, mockSiteUrl, false );
 
 		expect( mockLogger.reportError ).toHaveBeenCalled();
 		expect( mockLogger.reportError ).toHaveBeenCalledWith( expect.any( LoggerError ) );
@@ -218,7 +218,7 @@ describe( 'Preview Update Command', () => {
 		} );
 
 		const { runCommand } = await import( '../update' );
-		await runCommand( mockFolder, mockSiteUrl );
+		await runCommand( mockFolder, mockSiteUrl, false );
 
 		expect( mockLogger.reportError ).toHaveBeenCalled();
 		expect( mockLogger.reportError ).toHaveBeenCalledWith( expect.any( LoggerError ) );
@@ -230,7 +230,7 @@ describe( 'Preview Update Command', () => {
 		} );
 
 		const { runCommand } = await import( '../update' );
-		await runCommand( mockFolder, mockSiteUrl );
+		await runCommand( mockFolder, mockSiteUrl, false );
 
 		expect( cleanup ).toHaveBeenCalledWith( mockArchivePath );
 	} );
@@ -241,7 +241,7 @@ describe( 'Preview Update Command', () => {
 		const expiredSnapshot = { ...mockSnapshot, date: expiredDate };
 		( getSnapshotsFromAppdata as jest.Mock ).mockResolvedValue( [ expiredSnapshot ] );
 
-		await runCommand( mockFolder, mockSiteUrl );
+		await runCommand( mockFolder, mockSiteUrl, false );
 
 		expect( mockLogger.reportError ).toHaveBeenCalled();
 		expect( mockLogger.reportError ).toHaveBeenCalledWith( expect.any( LoggerError ) );

--- a/cli/commands/preview/tests/update.test.ts
+++ b/cli/commands/preview/tests/update.test.ts
@@ -250,9 +250,11 @@ describe( 'Preview Update Command', () => {
 
 	it( 'should throw error if folder does not match original site and no overwrite flag', async () => {
 		const { runCommand } = await import( '../update' );
-		jest
-			.spyOn( await import( 'cli/lib/appdata' ), 'getSiteByFolder' )
-			.mockResolvedValueOnce( { id: 'different-id', path: '/other/path', name: 'Other Site' } );
+		( getSiteByFolder as jest.Mock ).mockResolvedValueOnce( {
+			id: 'different-id',
+			path: '/other/path',
+			name: 'Other Site',
+		} );
 		await runCommand( mockFolder, mockSiteUrl, false );
 		expect( mockLogger.reportError ).toHaveBeenCalledWith( expect.any( LoggerError ) );
 		expect( createArchive ).not.toHaveBeenCalled();
@@ -260,9 +262,11 @@ describe( 'Preview Update Command', () => {
 
 	it( 'should allow update if overwrite flag is set even if folder does not match', async () => {
 		const { runCommand } = await import( '../update' );
-		jest
-			.spyOn( await import( 'cli/lib/appdata' ), 'getSiteByFolder' )
-			.mockResolvedValueOnce( { id: 'different-id', path: '/other/path', name: 'Other Site' } );
+		( getSiteByFolder as jest.Mock ).mockResolvedValueOnce( {
+			id: 'different-id',
+			path: '/other/path',
+			name: 'Other Site',
+		} );
 		await runCommand( mockFolder, mockSiteUrl, true );
 		expect( createArchive ).toHaveBeenCalledWith( mockFolder, mockArchivePath );
 	} );

--- a/cli/commands/preview/update.ts
+++ b/cli/commands/preview/update.ts
@@ -7,7 +7,7 @@ import { addDays } from 'date-fns';
 import { uploadArchive, waitForSiteReady } from 'cli/lib/api';
 import { getAuthToken } from 'cli/lib/appdata';
 import { cleanup, createArchive } from 'cli/lib/archive';
-import { getSnapshotsFromAppdata, updateSnapshotDateInAppdata } from 'cli/lib/snapshots';
+import { getSnapshotsFromAppdata, updateSnapshotInAppdata } from 'cli/lib/snapshots';
 import { normalizeHostname } from 'cli/lib/utils';
 import { validateSiteFolder } from 'cli/lib/validation';
 import { Logger, LoggerError } from 'cli/logger';
@@ -57,7 +57,7 @@ export async function runCommand( siteFolder: string, host: string ): Promise< v
 		);
 
 		logger.reportStart( LoggerAction.APPDATA, __( 'Saving preview site to Studio...' ) );
-		const snapshot = await updateSnapshotDateInAppdata( uploadResponse.site_id );
+		const snapshot = await updateSnapshotInAppdata( uploadResponse.site_id, siteFolder );
 		logger.reportSuccess( __( 'Preview site saved to Studio' ) );
 
 		logger.reportKeyValuePair( 'name', snapshot.name );

--- a/cli/commands/preview/update.ts
+++ b/cli/commands/preview/update.ts
@@ -5,7 +5,7 @@ import { DEMO_SITE_EXPIRATION_DAYS } from 'common/constants';
 import { PreviewCommandLoggerAction as LoggerAction } from 'common/logger-actions';
 import { addDays } from 'date-fns';
 import { uploadArchive, waitForSiteReady } from 'cli/lib/api';
-import { getAuthToken } from 'cli/lib/appdata';
+import { getAuthToken, getSiteByFolder } from 'cli/lib/appdata';
 import { cleanup, createArchive } from 'cli/lib/archive';
 import { getSnapshotsFromAppdata, updateSnapshotInAppdata } from 'cli/lib/snapshots';
 import { normalizeHostname } from 'cli/lib/utils';
@@ -13,7 +13,11 @@ import { validateSiteFolder } from 'cli/lib/validation';
 import { Logger, LoggerError } from 'cli/logger';
 import { StudioArgv } from 'cli/types';
 
-export async function runCommand( siteFolder: string, host: string ): Promise< void > {
+export async function runCommand(
+	siteFolder: string,
+	host: string,
+	overwrite?: boolean
+): Promise< void > {
 	const archivePath = path.join(
 		os.tmpdir(),
 		`${ path.basename( siteFolder ) }-${ Date.now() }.zip`
@@ -25,9 +29,19 @@ export async function runCommand( siteFolder: string, host: string ): Promise< v
 		validateSiteFolder( siteFolder );
 		const token = await getAuthToken();
 		const snapshots = await getSnapshotsFromAppdata( token.id );
+		const { id: currentSiteId } = await getSiteByFolder( siteFolder );
+
 		const snapshotToUpdate = snapshots.find( ( s ) => s.url === host );
 		if ( ! snapshotToUpdate ) {
 			throw new LoggerError( 'Preview site not found' );
+		}
+
+		if ( snapshotToUpdate.localSiteId !== currentSiteId && ! overwrite ) {
+			throw new LoggerError(
+				__(
+					'The specified folder does not match the original site for this preview. If you want to overwrite, run the command with --overwrite.'
+				)
+			);
 		}
 
 		const now = new Date();
@@ -79,15 +93,22 @@ export const registerCommand = ( yargs: StudioArgv ) => {
 		command: 'update <host>',
 		describe: __( 'Update preview site' ),
 		builder: ( yargs ) => {
-			return yargs.positional( 'host', {
-				type: 'string',
-				description: __( 'Hostname of the preview site to update' ),
-				demandOption: true,
-			} );
+			return yargs
+				.positional( 'host', {
+					type: 'string',
+					description: __( 'Hostname of the preview site to update' ),
+					demandOption: true,
+				} )
+				.option( 'overwrite', {
+					alias: 'o',
+					type: 'boolean',
+					default: false,
+					description: __( 'Allow updating a preview site from a different folder' ),
+				} );
 		},
 		handler: async ( argv ) => {
 			const normalizedHost = normalizeHostname( argv.host );
-			await runCommand( argv.path, normalizedHost );
+			await runCommand( argv.path, normalizedHost, argv.overwrite );
 		},
 	} );
 };

--- a/cli/commands/preview/update.ts
+++ b/cli/commands/preview/update.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { DEMO_SITE_EXPIRATION_DAYS } from 'common/constants';
 import { PreviewCommandLoggerAction as LoggerAction } from 'common/logger-actions';
+import { Snapshot } from 'common/types/snapshot';
 import { addDays } from 'date-fns';
 import { uploadArchive, waitForSiteReady } from 'cli/lib/api';
 import { getAuthToken, getSiteByFolder } from 'cli/lib/appdata';
@@ -13,10 +14,38 @@ import { validateSiteFolder } from 'cli/lib/validation';
 import { Logger, LoggerError } from 'cli/logger';
 import { StudioArgv } from 'cli/types';
 
+function getSnapshotToUpdate(
+	snapshots: Snapshot[],
+	host: string,
+	currentSiteId: string,
+	overwrite: boolean
+) {
+	const snapshotToUpdate = snapshots.find( ( s ) => s.url === host );
+	if ( ! snapshotToUpdate ) {
+		throw new LoggerError( 'Preview site not found' );
+	}
+
+	if ( snapshotToUpdate.localSiteId !== currentSiteId && ! overwrite ) {
+		throw new LoggerError(
+			__(
+				'The specified folder does not match the original site for this preview. If you want to overwrite, run the command with --overwrite.'
+			)
+		);
+	}
+
+	const now = new Date();
+	const endDate = addDays( snapshotToUpdate.date, DEMO_SITE_EXPIRATION_DAYS );
+	if ( endDate < now ) {
+		throw new LoggerError( __( 'Cannot update an expired preview site.' ) );
+	}
+
+	return snapshotToUpdate;
+}
+
 export async function runCommand(
 	siteFolder: string,
 	host: string,
-	overwrite?: boolean
+	overwrite: boolean
 ): Promise< void > {
 	const archivePath = path.join(
 		os.tmpdir(),
@@ -31,18 +60,7 @@ export async function runCommand(
 		const snapshots = await getSnapshotsFromAppdata( token.id );
 		const { id: currentSiteId } = await getSiteByFolder( siteFolder );
 
-		const snapshotToUpdate = snapshots.find( ( s ) => s.url === host );
-		if ( ! snapshotToUpdate ) {
-			throw new LoggerError( 'Preview site not found' );
-		}
-
-		if ( snapshotToUpdate.localSiteId !== currentSiteId && ! overwrite ) {
-			throw new LoggerError(
-				__(
-					'The specified folder does not match the original site for this preview. If you want to overwrite, run the command with --overwrite.'
-				)
-			);
-		}
+		const snapshotToUpdate = getSnapshotToUpdate( snapshots, host, currentSiteId, overwrite );
 
 		const now = new Date();
 		const endDate = addDays( snapshotToUpdate.date, DEMO_SITE_EXPIRATION_DAYS );

--- a/cli/lib/appdata.ts
+++ b/cli/lib/appdata.ts
@@ -160,8 +160,7 @@ export function getNewSitePartial( siteFolder: string ): z.infer< typeof siteSch
 
 export async function getOrCreateSiteByFolder(
 	siteFolder: string
-): Promise< { site: ReturnType< typeof getNewSitePartial >; userData: UserData } > {
-	const userData = await readAppdata();
+): Promise< z.infer< typeof siteSchema > > {
 	let site;
 	try {
 		site = await getSiteByFolder( siteFolder );
@@ -169,6 +168,7 @@ export async function getOrCreateSiteByFolder(
 		if ( ! ( error instanceof LoggerError ) ) {
 			throw error;
 		}
+		const userData = await readAppdata();
 		site = getNewSitePartial( siteFolder );
 		if ( ! userData.newSites ) {
 			userData.newSites = [];
@@ -176,5 +176,5 @@ export async function getOrCreateSiteByFolder(
 		userData.newSites.push( site );
 		await saveAppdata( userData );
 	}
-	return { site, userData };
+	return site;
 }

--- a/cli/lib/appdata.ts
+++ b/cli/lib/appdata.ts
@@ -157,3 +157,24 @@ export function getNewSitePartial( siteFolder: string ): z.infer< typeof siteSch
 
 	return newSite;
 }
+
+export async function getOrCreateSiteByFolder(
+	siteFolder: string
+): Promise< { site: ReturnType< typeof getNewSitePartial >; userData: UserData } > {
+	const userData = await readAppdata();
+	let site;
+	try {
+		site = await getSiteByFolder( siteFolder );
+	} catch ( error ) {
+		if ( ! ( error instanceof LoggerError ) ) {
+			throw error;
+		}
+		site = getNewSitePartial( siteFolder );
+		if ( ! userData.newSites ) {
+			userData.newSites = [];
+		}
+		userData.newSites.push( site );
+		await saveAppdata( userData );
+	}
+	return { site, userData };
+}

--- a/cli/lib/snapshots.ts
+++ b/cli/lib/snapshots.ts
@@ -17,10 +17,10 @@ import lockfile from 'lockfile';
 import {
 	getAppdataDirectory,
 	getAuthToken,
-	getNewSitePartial,
 	getSiteByFolder,
 	readAppdata,
 	saveAppdata,
+	getOrCreateSiteByFolder,
 } from 'cli/lib/appdata';
 import { LoggerError } from 'cli/logger';
 
@@ -70,8 +70,11 @@ export async function getSnapshotsFromAppdata(
 	return snapshots;
 }
 
-export async function updateSnapshotDateInAppdata( atomicSiteId: number ): Promise< Snapshot > {
-	const userData = await readAppdata();
+export async function updateSnapshotInAppdata(
+	atomicSiteId: number,
+	siteFolder: string
+): Promise< Snapshot > {
+	const { site, userData } = await getOrCreateSiteByFolder( siteFolder );
 	if ( ! userData.snapshots ) {
 		userData.snapshots = [];
 	}
@@ -81,6 +84,7 @@ export async function updateSnapshotDateInAppdata( atomicSiteId: number ): Promi
 		throw new LoggerError( __( 'Failed to find existing preview site in appdata' ) );
 	}
 
+	snapshot.localSiteId = site.id;
 	snapshot.date = Date.now();
 	await saveAppdata( userData );
 
@@ -106,21 +110,8 @@ export async function saveSnapshotToAppdata(
 	atomicSiteId: number,
 	previewUrl: string
 ): Promise< Snapshot > {
-	const userData = await readAppdata();
+	const { site, userData } = await getOrCreateSiteByFolder( siteFolder );
 	const authToken = await getAuthToken();
-	let site;
-	try {
-		site = await getSiteByFolder( siteFolder );
-	} catch ( error ) {
-		if ( ! ( error instanceof LoggerError ) ) {
-			throw error;
-		}
-		site = getNewSitePartial( siteFolder );
-		if ( ! userData.newSites ) {
-			userData.newSites = [];
-		}
-		userData.newSites.push( site );
-	}
 
 	if ( ! userData.snapshots ) {
 		userData.snapshots = [];

--- a/cli/lib/snapshots.ts
+++ b/cli/lib/snapshots.ts
@@ -74,7 +74,8 @@ export async function updateSnapshotInAppdata(
 	atomicSiteId: number,
 	siteFolder: string
 ): Promise< Snapshot > {
-	const { site, userData } = await getOrCreateSiteByFolder( siteFolder );
+	const site = await getOrCreateSiteByFolder( siteFolder );
+	const userData = await readAppdata();
 	if ( ! userData.snapshots ) {
 		userData.snapshots = [];
 	}
@@ -110,7 +111,8 @@ export async function saveSnapshotToAppdata(
 	atomicSiteId: number,
 	previewUrl: string
 ): Promise< Snapshot > {
-	const { site, userData } = await getOrCreateSiteByFolder( siteFolder );
+	const site = await getOrCreateSiteByFolder( siteFolder );
+	const userData = await readAppdata();
 	const authToken = await getAuthToken();
 
 	if ( ! userData.snapshots ) {

--- a/cli/lib/tests/appdata.test.ts
+++ b/cli/lib/tests/appdata.test.ts
@@ -187,7 +187,22 @@ describe( 'Appdata Module', () => {
 	} );
 
 	describe( 'getOrCreateSiteByFolder', () => {
-		it( 'should return an existing site if present', async () => {
+		it( 'should return an existing site if present on sites', async () => {
+			const folderPath = '/existing/site/path';
+			const existingSite = {
+				id: 'existing-id',
+				path: folderPath,
+				name: 'existing-site',
+			};
+			( readFile as jest.Mock ).mockReturnValueOnce(
+				JSON.stringify( { sites: [ existingSite ], newSites: [], snapshots: [] } )
+			);
+			const site = await getOrCreateSiteByFolder( folderPath );
+			expect( site ).toEqual( existingSite );
+			expect( writeFile ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should return an existing site if present on newSites', async () => {
 			const folderPath = '/existing/site/path';
 			const existingSite = {
 				id: 'existing-id',
@@ -197,14 +212,9 @@ describe( 'Appdata Module', () => {
 			( readFile as jest.Mock ).mockReturnValueOnce(
 				JSON.stringify( { sites: [], newSites: [ existingSite ], snapshots: [] } )
 			);
-			const { site, userData } = await getOrCreateSiteByFolder( folderPath );
-			expect( site ).toEqual( {
-				id: 'mock-uuid-1234',
-				path: folderPath,
-				name: mockSiteFolderName,
-			} );
-			expect( userData.newSites ).toContainEqual( site );
-			expect( writeFile ).toHaveBeenCalled();
+			const site = await getOrCreateSiteByFolder( folderPath );
+			expect( site ).toEqual( existingSite );
+			expect( writeFile ).not.toHaveBeenCalled();
 		} );
 
 		it( 'should create and return a new site if not present', async () => {
@@ -212,13 +222,12 @@ describe( 'Appdata Module', () => {
 			( readFile as jest.Mock ).mockReturnValueOnce(
 				JSON.stringify( { sites: [], newSites: [], snapshots: [] } )
 			);
-			const { site, userData } = await getOrCreateSiteByFolder( folderPath );
+			const site = await getOrCreateSiteByFolder( folderPath );
 			expect( site ).toEqual( {
 				id: 'mock-uuid-1234',
 				path: folderPath,
 				name: mockSiteFolderName,
 			} );
-			expect( userData.newSites ).toContainEqual( site );
 			expect( writeFile ).toHaveBeenCalled();
 		} );
 	} );

--- a/cli/lib/tests/appdata.test.ts
+++ b/cli/lib/tests/appdata.test.ts
@@ -7,7 +7,7 @@ import {
 	saveAppdata,
 	getAuthToken,
 	getNewSitePartial,
-	getSiteByFolder,
+	getOrCreateSiteByFolder,
 } from 'cli/lib/appdata';
 
 jest.mock( 'fs' );
@@ -186,35 +186,40 @@ describe( 'Appdata Module', () => {
 		} );
 	} );
 
-	describe( 'getSiteByFolder', () => {
-		it( 'should find a site in sites', async () => {
-			const folderPath = '/test/site/path';
-			const site = { id: 'site-1', path: folderPath, name: 'Site 1' };
+	describe( 'getOrCreateSiteByFolder', () => {
+		it( 'should return an existing site if present', async () => {
+			const folderPath = '/existing/site/path';
+			const existingSite = {
+				id: 'existing-id',
+				path: folderPath,
+				name: 'existing-site',
+			};
 			( readFile as jest.Mock ).mockReturnValueOnce(
-				JSON.stringify( { version: 1, sites: [ site ], newSites: [], snapshots: [] } )
+				JSON.stringify( { sites: [], newSites: [ existingSite ], snapshots: [] } )
 			);
-			const result = await getSiteByFolder( folderPath );
-			expect( result ).toEqual( site );
+			const { site, userData } = await getOrCreateSiteByFolder( folderPath );
+			expect( site ).toEqual( {
+				id: 'mock-uuid-1234',
+				path: folderPath,
+				name: mockSiteFolderName,
+			} );
+			expect( userData.newSites ).toContainEqual( site );
+			expect( writeFile ).toHaveBeenCalled();
 		} );
 
-		it( 'should find a site in newSites', async () => {
-			const folderPath = '/test/newsite/path';
-			const newSite = { id: 'site-2', path: folderPath, name: 'New Site' };
+		it( 'should create and return a new site if not present', async () => {
+			const folderPath = '/new/site/path';
 			( readFile as jest.Mock ).mockReturnValueOnce(
-				JSON.stringify( { version: 1, sites: [], newSites: [ newSite ], snapshots: [] } )
+				JSON.stringify( { sites: [], newSites: [], snapshots: [] } )
 			);
-			const result = await getSiteByFolder( folderPath );
-			expect( result ).toEqual( newSite );
-		} );
-
-		it( 'should throw if site is not found in either sites or newSites', async () => {
-			const folderPath = '/not/found/path';
-			( readFile as jest.Mock ).mockReturnValueOnce(
-				JSON.stringify( { version: 1, sites: [], newSites: [], snapshots: [] } )
-			);
-			await expect( getSiteByFolder( folderPath ) ).rejects.toThrow(
-				'The specified folder is not added to Studio.'
-			);
+			const { site, userData } = await getOrCreateSiteByFolder( folderPath );
+			expect( site ).toEqual( {
+				id: 'mock-uuid-1234',
+				path: folderPath,
+				name: mockSiteFolderName,
+			} );
+			expect( userData.newSites ).toContainEqual( site );
+			expect( writeFile ).toHaveBeenCalled();
 		} );
 	} );
 } );

--- a/cli/lib/tests/snapshots.test.ts
+++ b/cli/lib/tests/snapshots.test.ts
@@ -281,6 +281,13 @@ describe( 'Snapshots Module', () => {
 						sequence: 1,
 					},
 				],
+				sites: [
+					{
+						id: mockSiteId,
+						path: mockSiteFolder,
+						name: 'Test Site',
+					},
+				],
 			};
 
 			( readFile as jest.Mock ).mockResolvedValue( JSON.stringify( mockUserData ) );

--- a/cli/lib/tests/snapshots.test.ts
+++ b/cli/lib/tests/snapshots.test.ts
@@ -151,12 +151,31 @@ describe( 'Snapshots Module', () => {
 				},
 			};
 
-			( readFile as jest.Mock ).mockResolvedValue( JSON.stringify( mockUserData ) );
+			let hasWrittenNewSite = false;
+			( readFile as jest.Mock ).mockImplementation( async () => {
+				if ( hasWrittenNewSite ) {
+					return JSON.stringify( {
+						...mockUserData,
+						newSites: [
+							{
+								id: 'mock-uuid-1234',
+								path: mockSiteFolder,
+								name: mockSiteFolderName,
+							},
+						],
+					} );
+				}
+				return JSON.stringify( mockUserData );
+			} );
+
+			( writeFile as jest.Mock ).mockImplementation( async () => {
+				hasWrittenNewSite = true;
+			} );
 			( path.basename as jest.Mock ).mockReturnValueOnce( mockSiteFolderName );
 
 			await saveSnapshotToAppdata( mockSiteFolder, mockAtomicSiteId, mockSiteUrl );
 
-			expect( writeFile ).toHaveBeenCalled();
+			expect( writeFile ).toHaveBeenCalledTimes( 2 );
 			const savedData = JSON.parse( ( writeFile as jest.Mock ).mock.calls[ 1 ][ 1 ] );
 
 			// Check that a new site was created
@@ -198,12 +217,32 @@ describe( 'Snapshots Module', () => {
 				},
 			};
 
-			( readFile as jest.Mock ).mockResolvedValue( JSON.stringify( mockUserData ) );
+			let hasWrittenNewSite = false;
+			( readFile as jest.Mock ).mockImplementation( async () => {
+				if ( hasWrittenNewSite ) {
+					return JSON.stringify( {
+						...mockUserData,
+						newSites: [
+							existingNewSite,
+							{
+								id: 'mock-uuid-1234',
+								path: mockSiteFolder,
+								name: mockSiteFolderName,
+							},
+						],
+					} );
+				}
+				return JSON.stringify( mockUserData );
+			} );
+
+			( writeFile as jest.Mock ).mockImplementation( async () => {
+				hasWrittenNewSite = true;
+			} );
 			( path.basename as jest.Mock ).mockReturnValueOnce( mockSiteFolderName );
 
 			await saveSnapshotToAppdata( mockSiteFolder, mockAtomicSiteId, mockSiteUrl );
 
-			expect( writeFile ).toHaveBeenCalled();
+			expect( writeFile ).toHaveBeenCalledTimes( 2 );
 			const savedData = JSON.parse( ( writeFile as jest.Mock ).mock.calls[ 1 ][ 1 ] );
 
 			// Check that the new site was added to existing newSites array

--- a/cli/lib/tests/snapshots.test.ts
+++ b/cli/lib/tests/snapshots.test.ts
@@ -6,7 +6,7 @@ import {
 	deleteSnapshotFromAppdata,
 	getSnapshotsFromAppdata,
 	saveSnapshotToAppdata,
-	updateSnapshotDateInAppdata,
+	updateSnapshotInAppdata,
 } from 'cli/lib/snapshots';
 import { LoggerError } from 'cli/logger';
 
@@ -157,7 +157,7 @@ describe( 'Snapshots Module', () => {
 			await saveSnapshotToAppdata( mockSiteFolder, mockAtomicSiteId, mockSiteUrl );
 
 			expect( writeFile ).toHaveBeenCalled();
-			const savedData = JSON.parse( ( writeFile as jest.Mock ).mock.calls[ 0 ][ 1 ] );
+			const savedData = JSON.parse( ( writeFile as jest.Mock ).mock.calls[ 1 ][ 1 ] );
 
 			// Check that a new site was created
 			expect( savedData.newSites ).toHaveLength( 1 );
@@ -204,7 +204,7 @@ describe( 'Snapshots Module', () => {
 			await saveSnapshotToAppdata( mockSiteFolder, mockAtomicSiteId, mockSiteUrl );
 
 			expect( writeFile ).toHaveBeenCalled();
-			const savedData = JSON.parse( ( writeFile as jest.Mock ).mock.calls[ 0 ][ 1 ] );
+			const savedData = JSON.parse( ( writeFile as jest.Mock ).mock.calls[ 1 ][ 1 ] );
 
 			// Check that the new site was added to existing newSites array
 			expect( savedData.newSites ).toHaveLength( 2 );
@@ -217,6 +217,15 @@ describe( 'Snapshots Module', () => {
 
 			// Check that a snapshot was created for the new site
 			expect( savedData.snapshots ).toHaveLength( 1 );
+			expect( savedData.snapshots[ 0 ] ).toEqual( {
+				url: mockSiteUrl,
+				atomicSiteId: mockAtomicSiteId,
+				localSiteId: 'mock-uuid-1234',
+				date: 1234567890,
+				name: `${ mockSiteFolderName } Preview 1`,
+				userId: mockUserId,
+				sequence: 1,
+			} );
 		} );
 
 		it( 'should handle errors correctly', async () => {
@@ -256,7 +265,7 @@ describe( 'Snapshots Module', () => {
 		} );
 	} );
 
-	describe( 'updateSnapshotDateInAppdata', () => {
+	describe( 'updateSnapshotInAppdata', () => {
 		it( 'should update the date of an existing snapshot', async () => {
 			const mockSiteId = 'abc123';
 			const mockUserData = {
@@ -276,13 +285,14 @@ describe( 'Snapshots Module', () => {
 
 			( readFile as jest.Mock ).mockResolvedValue( JSON.stringify( mockUserData ) );
 
-			const updatedSnapshot = await updateSnapshotDateInAppdata( mockAtomicSiteId );
+			const updatedSnapshot = await updateSnapshotInAppdata( mockAtomicSiteId, mockSiteFolder );
 
 			expect( writeFile ).toHaveBeenCalled();
 			const savedData = JSON.parse( ( writeFile as jest.Mock ).mock.calls[ 0 ][ 1 ] );
 
 			expect( savedData.snapshots[ 0 ].date ).toBe( 1234567890 );
 			expect( updatedSnapshot ).toEqual( savedData.snapshots[ 0 ] );
+			expect( updatedSnapshot.date ).toBe( 1234567890 );
 		} );
 
 		it( 'should throw an error if snapshot not found', async () => {
@@ -293,7 +303,7 @@ describe( 'Snapshots Module', () => {
 
 			( readFile as jest.Mock ).mockResolvedValue( JSON.stringify( mockUserData ) );
 
-			await expect( updateSnapshotDateInAppdata( mockAtomicSiteId ) ).rejects.toThrow(
+			await expect( updateSnapshotInAppdata( mockAtomicSiteId, mockSiteFolder ) ).rejects.toThrow(
 				LoggerError
 			);
 		} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-422

## Proposed Changes

- Ensures that when a preview site is updated from a different local site, the preview's location (local site association) is moved accordingly.
- Updates the logic in the preview update command and snapshot handling to reflect the new local site association when updating an existing preview from a different folder.
- Improves reliability and accuracy of preview site management when users update previews from different local site folders.
- Adds an `--overwrite` check for this use case

![image](https://github.com/user-attachments/assets/5d1cd3d9-4f0d-41f9-a1f6-2c4ae957c911)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run npm start
- Create a preview site for a local site (Site A).
- Update the preview site from a different local site (Site B) using the update CLI command without `--overwrite`
- Validate the error message
- Update the preview site from a different local site (Site B) using the update CLI command with `--overwrite`
- Verify that the preview site is now associated with Site B in the UI.
- Confirm that the preview site URL and data reflect the updated local site.
- Ensure no errors occur during the update process and that the preview is accessible.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
