### PR TITLE
Associate preview sites with existing pending sites

### DIFF
--- a/cli/lib/appdata.ts
+++ b/cli/lib/appdata.ts
@@ -138,7 +138,8 @@ export async function getSiteByFolder(
 ): Promise< z.infer< typeof siteSchema > > {
 	const userData = await readAppdata();
 	const sites = userData.sites ?? [];
-	const site = sites.find( ( site ) => site.path === siteFolder );
+	const newSites = userData.newSites ?? [];
+	const site = [ ...sites, ...newSites ].find( ( site ) => site.path === siteFolder );
 
 	if ( ! site ) {
 		throw new LoggerError( __( 'The specified folder is not added to Studio.' ) );

--- a/cli/lib/tests/appdata.test.ts
+++ b/cli/lib/tests/appdata.test.ts
@@ -190,7 +190,7 @@ describe( 'Appdata Module', () => {
 		it( 'should find a site in sites', async () => {
 			const folderPath = '/test/site/path';
 			const site = { id: 'site-1', path: folderPath, name: 'Site 1' };
-			( fs.readFileSync as jest.Mock ).mockReturnValueOnce(
+			( readFile as jest.Mock ).mockReturnValueOnce(
 				JSON.stringify( { version: 1, sites: [ site ], newSites: [], snapshots: [] } )
 			);
 			const result = await getSiteByFolder( folderPath );
@@ -200,7 +200,7 @@ describe( 'Appdata Module', () => {
 		it( 'should find a site in newSites', async () => {
 			const folderPath = '/test/newsite/path';
 			const newSite = { id: 'site-2', path: folderPath, name: 'New Site' };
-			( fs.readFileSync as jest.Mock ).mockReturnValueOnce(
+			( readFile as jest.Mock ).mockReturnValueOnce(
 				JSON.stringify( { version: 1, sites: [], newSites: [ newSite ], snapshots: [] } )
 			);
 			const result = await getSiteByFolder( folderPath );
@@ -209,7 +209,7 @@ describe( 'Appdata Module', () => {
 
 		it( 'should throw if site is not found in either sites or newSites', async () => {
 			const folderPath = '/not/found/path';
-			( fs.readFileSync as jest.Mock ).mockReturnValueOnce(
+			( readFile as jest.Mock ).mockReturnValueOnce(
 				JSON.stringify( { version: 1, sites: [], newSites: [], snapshots: [] } )
 			);
 			await expect( getSiteByFolder( folderPath ) ).rejects.toThrow(

--- a/cli/lib/tests/appdata.test.ts
+++ b/cli/lib/tests/appdata.test.ts
@@ -2,7 +2,13 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import { readFile, writeFile } from 'atomically';
-import { readAppdata, saveAppdata, getAuthToken, getNewSitePartial } from 'cli/lib/appdata';
+import {
+	readAppdata,
+	saveAppdata,
+	getAuthToken,
+	getNewSitePartial,
+	getSiteByFolder,
+} from 'cli/lib/appdata';
 
 jest.mock( 'fs' );
 jest.mock( 'os' );
@@ -181,8 +187,6 @@ describe( 'Appdata Module', () => {
 	} );
 
 	describe( 'getSiteByFolder', () => {
-		const getSiteByFolder = require( '../appdata' ).getSiteByFolder;
-
 		it( 'should find a site in sites', async () => {
 			const folderPath = '/test/site/path';
 			const site = { id: 'site-1', path: folderPath, name: 'Site 1' };

--- a/cli/lib/tests/appdata.test.ts
+++ b/cli/lib/tests/appdata.test.ts
@@ -179,4 +179,38 @@ describe( 'Appdata Module', () => {
 			} );
 		} );
 	} );
+
+	describe( 'getSiteByFolder', () => {
+		const getSiteByFolder = require( '../appdata' ).getSiteByFolder;
+
+		it( 'should find a site in sites', async () => {
+			const folderPath = '/test/site/path';
+			const site = { id: 'site-1', path: folderPath, name: 'Site 1' };
+			( fs.readFileSync as jest.Mock ).mockReturnValueOnce(
+				JSON.stringify( { version: 1, sites: [ site ], newSites: [], snapshots: [] } )
+			);
+			const result = await getSiteByFolder( folderPath );
+			expect( result ).toEqual( site );
+		} );
+
+		it( 'should find a site in newSites', async () => {
+			const folderPath = '/test/newsite/path';
+			const newSite = { id: 'site-2', path: folderPath, name: 'New Site' };
+			( fs.readFileSync as jest.Mock ).mockReturnValueOnce(
+				JSON.stringify( { version: 1, sites: [], newSites: [ newSite ], snapshots: [] } )
+			);
+			const result = await getSiteByFolder( folderPath );
+			expect( result ).toEqual( newSite );
+		} );
+
+		it( 'should throw if site is not found in either sites or newSites', async () => {
+			const folderPath = '/not/found/path';
+			( fs.readFileSync as jest.Mock ).mockReturnValueOnce(
+				JSON.stringify( { version: 1, sites: [], newSites: [], snapshots: [] } )
+			);
+			await expect( getSiteByFolder( folderPath ) ).rejects.toThrow(
+				'The specified folder is not added to Studio.'
+			);
+		} );
+	} );
 } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-423

## Proposed Changes

- Associates preview sites with existing pending sites when creating or updating previews.
- Ensures that when a preview site is created or updated, it is correctly linked to any existing pending site records, improving data consistency and user experience.
- Updates logic in the preview site creation and update flows to check for and associate with pending sites.
- Adds or updates tests to cover the new association logic.

| CLI | Studio |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/838d3be0-32d7-4ca0-9449-fd6b4567b79a) | ![image](https://github.com/user-attachments/assets/9dd8545f-c42a-4306-b07a-85f7cfcb4254) | 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run `npm run cli:build` and make sure Studio isn't running
- On a WordPress folder, not added on Studio run:
- `preview list <FOLDER>` and validate the error
- `preview create <FOLDER>` and wait for the success
- `preview list <FOLDER>` and confirm the preview site shows up
- `preview create <FOLDER>` and wait for the success
- `preview list <FOLDER>` and confirm both preview sites show up
- Run `npm run start`
- Confirm the new site is added to Studio and both preview sites created are displayed correctly in the UI

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
