### PR TITLE
Update wp-babel-makepot to fix security issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -221,6 +221,7 @@
 			"resolved": "https://registry.npmjs.org/@automattic/babel-plugin-i18n-calypso/-/babel-plugin-i18n-calypso-1.2.0.tgz",
 			"integrity": "sha512-I3s8EpOUjKm65OpQRsRwElNx0bunBs1x/WDD4nUeLb/dFXx2gREQJcG2iIlvUmG/KsGZDEWg9qQ30c0G4x0VHw==",
 			"dev": true,
+			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"gettext-parser": "^4.0.3",
 				"lodash": "^4.17.15"
@@ -234,6 +235,7 @@
 			"resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-4.2.0.tgz",
 			"integrity": "sha512-aMgPyjC9W5Mz9tbFU8DcQ7GYMXoFWq633kaWGt4imlcpBWzDIWk7HY7nCSZTCJxyjRaLq9L/NEjMKkZ9gR630Q==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"content-type": "^1.0.4",
 				"encoding": "^0.1.13",
@@ -259,7 +261,8 @@
 					"type": "consulting",
 					"url": "https://feross.org/support"
 				}
-			]
+			],
+			"license": "MIT"
 		},
 		"node_modules/@automattic/color-studio": {
 			"version": "2.5.0",
@@ -277,6 +280,7 @@
 			"resolved": "https://registry.npmjs.org/@automattic/wp-babel-makepot/-/wp-babel-makepot-1.2.0.tgz",
 			"integrity": "sha512-AdYxKkuRKuyoS99XPTwUcWgzr1zvEDxnBCioyiKGe7eS6+/mx+BImkr4b2rxvTkCqyyDCoU8eBrpSxw+0f+CxA==",
 			"dev": true,
+			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@automattic/babel-plugin-i18n-calypso": "^1.2.0",
 				"@babel/cli": "^7.23.4",
@@ -299,6 +303,7 @@
 			"resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
 			"integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">= 6"
 			}
@@ -308,6 +313,7 @@
 			"resolved": "https://registry.npmjs.org/gettext-parser/-/gettext-parser-4.2.0.tgz",
 			"integrity": "sha512-aMgPyjC9W5Mz9tbFU8DcQ7GYMXoFWq633kaWGt4imlcpBWzDIWk7HY7nCSZTCJxyjRaLq9L/NEjMKkZ9gR630Q==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"content-type": "^1.0.4",
 				"encoding": "^0.1.13",
@@ -333,16 +339,18 @@
 					"type": "consulting",
 					"url": "https://feross.org/support"
 				}
-			]
+			],
+			"license": "MIT"
 		},
 		"node_modules/@babel/cli": {
-			"version": "7.23.9",
-			"resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.23.9.tgz",
-			"integrity": "sha512-vB1UXmGDNEhcf1jNAHKT9IlYk1R+hehVTLFlCLHBi8gfuHQGP6uRjgXVYU0EVlI/qwAWpstqkBdf2aez3/z/5Q==",
+			"version": "7.27.0",
+			"resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.27.0.tgz",
+			"integrity": "sha512-bZfxn8DRxwiVzDO5CEeV+7IqXeCkzI4yYnrQbpwjT76CUyossQc6RYE7n+xfm0/2k40lPaCpW0FhxYs7EBAetw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@jridgewell/trace-mapping": "^0.3.17",
-				"commander": "^4.0.1",
+				"@jridgewell/trace-mapping": "^0.3.25",
+				"commander": "^6.2.0",
 				"convert-source-map": "^2.0.0",
 				"fs-readdir-recursive": "^1.1.0",
 				"glob": "^7.2.0",
@@ -358,16 +366,16 @@
 			},
 			"optionalDependencies": {
 				"@nicolo-ribaudo/chokidar-2": "2.1.8-no-fsevents.3",
-				"chokidar": "^3.4.0"
+				"chokidar": "^3.6.0"
 			},
 			"peerDependencies": {
 				"@babel/core": "^7.0.0-0"
 			}
 		},
 		"node_modules/@babel/cli/node_modules/commander": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
-			"integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+			"version": "6.2.1",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+			"integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -379,6 +387,7 @@
 			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
 			"integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"pify": "^4.0.1",
 				"semver": "^5.6.0"
@@ -392,6 +401,7 @@
 			"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
 			"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=6"
 			}
@@ -401,6 +411,7 @@
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
 			"integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
 			"dev": true,
+			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver"
 			}
@@ -410,6 +421,7 @@
 			"resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
 			"integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=6"
 			}
@@ -429,9 +441,9 @@
 			}
 		},
 		"node_modules/@babel/compat-data": {
-			"version": "7.26.3",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.3.tgz",
-			"integrity": "sha512-nHIxvKPniQXpmQLb0vhY3VaFb3S0YrTAwpOWJZh1wn3oJPjJk9Asva204PsBdmAE8vpzfHudT8DB0scYvy9q0g==",
+			"version": "7.26.8",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.8.tgz",
+			"integrity": "sha512-oH5UPLMWR3L2wEFLnFJ1TZXqHufiTKAiLfqw5zkhS4dKXLJ10yVztfil/twG8EDTA4F/tvVNw9nOl4ZMslB8rQ==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
@@ -476,13 +488,13 @@
 			}
 		},
 		"node_modules/@babel/generator": {
-			"version": "7.26.3",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.3.tgz",
-			"integrity": "sha512-6FF/urZvD0sTeO7k6/B15pMLC4CHUv1426lzr3N01aHJTl046uCAh9LXW/fzeXXjPNCJ6iABW5XaWOsIZB93aQ==",
+			"version": "7.27.0",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.27.0.tgz",
+			"integrity": "sha512-VybsKvpiN1gU1sdMZIp7FcqphVVKEwcuj02x73uvcHE0PTihx1nlBcowYWhDwjpoAXRv43+gDzyggGnn1XZhVw==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/parser": "^7.26.3",
-				"@babel/types": "^7.26.3",
+				"@babel/parser": "^7.27.0",
+				"@babel/types": "^7.27.0",
 				"@jridgewell/gen-mapping": "^0.3.5",
 				"@jridgewell/trace-mapping": "^0.3.25",
 				"jsesc": "^3.0.2"
@@ -492,36 +504,25 @@
 			}
 		},
 		"node_modules/@babel/helper-annotate-as-pure": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.22.5.tgz",
-			"integrity": "sha512-LvBTxu8bQSQkcyKOU+a1btnNFQ1dMAd0R6PyW3arXes06F6QLWLIrd681bxRPIXlrMGR3XYnW9JyML7dP3qgxg==",
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.25.9.tgz",
+			"integrity": "sha512-gv7320KBUFJz1RnylIg5WWYPRXKZ884AGkYpgpWW02TH66Dl+HaC1t1CKd0z3R4b6hdYEcmrNZHUmfCP+1u3/g==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/types": "^7.22.5"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/helper-builder-binary-assignment-operator-visitor": {
-			"version": "7.22.15",
-			"resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.22.15.tgz",
-			"integrity": "sha512-QkBXwGgaoC2GtGZRoma6kv7Szfv06khvhFav67ZExau2RaXzy8MpHSMO2PNoP2XtmQphJQRHFfg77Bq731Yizw==",
-			"dev": true,
-			"dependencies": {
-				"@babel/types": "^7.22.15"
+				"@babel/types": "^7.25.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-compilation-targets": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.25.9.tgz",
-			"integrity": "sha512-j9Db8Suy6yV/VHa4qzrj9yZfZxhLWQdVnRlXxmKLYlhWUVB1sB2G5sxuWYXk/whHD9iW76PmNzxZ4UCnTQTVEQ==",
+			"version": "7.27.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.0.tgz",
+			"integrity": "sha512-LVk7fbXml0H2xH34dFzKQ7TDZ2G4/rVTOrq9V+icbbadjbVxxeFeDsNHv2SrZeWoA+6ZiTyWYWtScEIW07EAcA==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/compat-data": "^7.25.9",
+				"@babel/compat-data": "^7.26.8",
 				"@babel/helper-validator-option": "^7.25.9",
 				"browserslist": "^4.24.0",
 				"lru-cache": "^5.1.1",
@@ -540,19 +541,18 @@
 			}
 		},
 		"node_modules/@babel/helper-create-class-features-plugin": {
-			"version": "7.23.10",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.23.10.tgz",
-			"integrity": "sha512-2XpP2XhkXzgxecPNEEK8Vz8Asj9aRxt08oKOqtiZoqV2UGZ5T+EkyP9sXQ9nwMxBIG34a7jmasVqoMop7VdPUw==",
+			"version": "7.27.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.27.0.tgz",
+			"integrity": "sha512-vSGCvMecvFCd/BdpGlhpXYNhhC4ccxyvQWpbGL4CWbvfEoLFWUZuSuf7s9Aw70flgQF+6vptvgK2IfOnKlRmBg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-annotate-as-pure": "^7.22.5",
-				"@babel/helper-environment-visitor": "^7.22.20",
-				"@babel/helper-function-name": "^7.23.0",
-				"@babel/helper-member-expression-to-functions": "^7.23.0",
-				"@babel/helper-optimise-call-expression": "^7.22.5",
-				"@babel/helper-replace-supers": "^7.22.20",
-				"@babel/helper-skip-transparent-expression-wrappers": "^7.22.5",
-				"@babel/helper-split-export-declaration": "^7.22.6",
+				"@babel/helper-annotate-as-pure": "^7.25.9",
+				"@babel/helper-member-expression-to-functions": "^7.25.9",
+				"@babel/helper-optimise-call-expression": "^7.25.9",
+				"@babel/helper-replace-supers": "^7.26.5",
+				"@babel/helper-skip-transparent-expression-wrappers": "^7.25.9",
+				"@babel/traverse": "^7.27.0",
 				"semver": "^6.3.1"
 			},
 			"engines": {
@@ -567,18 +567,20 @@
 			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
 			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
 			"dev": true,
+			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver.js"
 			}
 		},
 		"node_modules/@babel/helper-create-regexp-features-plugin": {
-			"version": "7.22.15",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.22.15.tgz",
-			"integrity": "sha512-29FkPLFjn4TPEa3RE7GpW+qbE8tlsu3jntNYNfcGsc49LphF1PQIiD+vMZ1z1xVOKt+93khA9tc2JBs3kBjA7w==",
+			"version": "7.27.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.27.0.tgz",
+			"integrity": "sha512-fO8l08T76v48BhpNRW/nQ0MxfnSdoSKUJBMjubOAYffsVuGG5qOfMq7N6Es7UJvi7Y8goXXo07EfcHZXDPuELQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-annotate-as-pure": "^7.22.5",
-				"regexpu-core": "^5.3.1",
+				"@babel/helper-annotate-as-pure": "^7.25.9",
+				"regexpu-core": "^6.2.0",
 				"semver": "^6.3.1"
 			},
 			"engines": {
@@ -593,15 +595,17 @@
 			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
 			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
 			"dev": true,
+			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver.js"
 			}
 		},
 		"node_modules/@babel/helper-define-polyfill-provider": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.5.0.tgz",
-			"integrity": "sha512-NovQquuQLAQ5HuyjCz7WQP9MjRj7dx++yspwiyUiGl9ZyadHRSql1HZh5ogRd8W8w6YM6EQ/NTB8rgjLt5W65Q==",
+			"version": "0.6.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.4.tgz",
+			"integrity": "sha512-jljfR1rGnXXNWnmQg2K3+bvhkxB51Rl32QRaOTuwwjviGrHzIbSc8+x9CpraDtbT7mfyjXObULP4w/adunNwAw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@babel/helper-compilation-targets": "^7.22.6",
 				"@babel/helper-plugin-utils": "^7.22.5",
@@ -613,47 +617,15 @@
 				"@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
 			}
 		},
-		"node_modules/@babel/helper-environment-visitor": {
-			"version": "7.22.20",
-			"resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
-			"integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
-			"dev": true,
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/helper-function-name": {
-			"version": "7.23.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
-			"integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
-			"dev": true,
-			"dependencies": {
-				"@babel/template": "^7.22.15",
-				"@babel/types": "^7.23.0"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/helper-hoist-variables": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz",
-			"integrity": "sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==",
-			"dev": true,
-			"dependencies": {
-				"@babel/types": "^7.22.5"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
 		"node_modules/@babel/helper-member-expression-to-functions": {
-			"version": "7.23.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.23.0.tgz",
-			"integrity": "sha512-6gfrPwh7OuT6gZyJZvd6WbTfrqAo7vm4xCzAXOusKqq/vWdKXphTpj5klHKNmRUU6/QRGlBsyU9mAIPaWHlqJA==",
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.25.9.tgz",
+			"integrity": "sha512-wbfdZ9w5vk0C0oyHqAJbc62+vet5prjj01jjJ8sKn3j9h3MQQlflEdXYvuqRWjHnM12coDEqiC1IRCi0U/EKwQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/types": "^7.23.0"
+				"@babel/traverse": "^7.25.9",
+				"@babel/types": "^7.25.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -690,35 +662,38 @@
 			}
 		},
 		"node_modules/@babel/helper-optimise-call-expression": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.22.5.tgz",
-			"integrity": "sha512-HBwaojN0xFRx4yIvpwGqxiV2tUfl7401jlok564NgB9EHS1y6QT17FmKWm4ztqjeVdXLuC4fSvHc5ePpQjoTbw==",
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.25.9.tgz",
+			"integrity": "sha512-FIpuNaz5ow8VyrYcnXQTDRGvV6tTjkNtCK/RYNDXGSLlUD6cBuQTSw43CShGxjvfBTfcUA/r6UhUCbtYqkhcuQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/types": "^7.22.5"
+				"@babel/types": "^7.25.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-plugin-utils": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.22.5.tgz",
-			"integrity": "sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg==",
+			"version": "7.26.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.26.5.tgz",
+			"integrity": "sha512-RS+jZcRdZdRFzMyr+wcsaqOmld1/EqTghfaBGQQd/WnRdzdlvSZ//kF7U8VQTxf1ynZ4cjUcYgjVGx13ewNPMg==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-remap-async-to-generator": {
-			"version": "7.22.20",
-			"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.22.20.tgz",
-			"integrity": "sha512-pBGyV4uBqOns+0UvhsTO8qgl8hO89PmiDYv+/COyp1aeMcmfrfruz+/nCMFiYyFF/Knn0yfrC85ZzNFjembFTw==",
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.25.9.tgz",
+			"integrity": "sha512-IZtukuUeBbhgOcaW2s06OXTzVNJR0ybm4W5xC1opWFFJMZbwRj5LCk+ByYH7WdZPZTt8KnFwA8pvjN2yqcPlgw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-annotate-as-pure": "^7.22.5",
-				"@babel/helper-environment-visitor": "^7.22.20",
-				"@babel/helper-wrap-function": "^7.22.20"
+				"@babel/helper-annotate-as-pure": "^7.25.9",
+				"@babel/helper-wrap-function": "^7.25.9",
+				"@babel/traverse": "^7.25.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -728,14 +703,15 @@
 			}
 		},
 		"node_modules/@babel/helper-replace-supers": {
-			"version": "7.22.20",
-			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.22.20.tgz",
-			"integrity": "sha512-qsW0In3dbwQUbK8kejJ4R7IHVGwHJlV6lpG6UA7a9hSa2YEiAib+N1T2kr6PEeUT+Fl7najmSOS6SmAwCHK6Tw==",
+			"version": "7.26.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.26.5.tgz",
+			"integrity": "sha512-bJ6iIVdYX1YooY2X7w1q6VITt+LnUILtNk7zT78ykuwStx8BauCzxvFqFaHjOpW1bVnSUM1PN1f0p5P21wHxvg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-environment-visitor": "^7.22.20",
-				"@babel/helper-member-expression-to-functions": "^7.22.15",
-				"@babel/helper-optimise-call-expression": "^7.22.5"
+				"@babel/helper-member-expression-to-functions": "^7.25.9",
+				"@babel/helper-optimise-call-expression": "^7.25.9",
+				"@babel/traverse": "^7.26.5"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -744,37 +720,15 @@
 				"@babel/core": "^7.0.0"
 			}
 		},
-		"node_modules/@babel/helper-simple-access": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.22.5.tgz",
-			"integrity": "sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==",
-			"dev": true,
-			"dependencies": {
-				"@babel/types": "^7.22.5"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
 		"node_modules/@babel/helper-skip-transparent-expression-wrappers": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.22.5.tgz",
-			"integrity": "sha512-tK14r66JZKiC43p8Ki33yLBVJKlQDFoA8GYN67lWCDCqoL6EMMSuM9b+Iff2jHaM/RRFYl7K+iiru7hbRqNx8Q==",
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.25.9.tgz",
+			"integrity": "sha512-K4Du3BFa3gvyhzgPcntrkDgZzQaq6uozzcpGbOO1OEJaI+EJdqWIMTLgFgQf6lrfiDFo5FU+BxKepI9RmZqahA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/types": "^7.22.5"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/helper-split-export-declaration": {
-			"version": "7.22.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
-			"integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
-			"dev": true,
-			"dependencies": {
-				"@babel/types": "^7.22.5"
+				"@babel/traverse": "^7.25.9",
+				"@babel/types": "^7.25.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -808,14 +762,15 @@
 			}
 		},
 		"node_modules/@babel/helper-wrap-function": {
-			"version": "7.22.20",
-			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.22.20.tgz",
-			"integrity": "sha512-pms/UwkOpnQe/PDAEdV/d7dVCoBbB+R4FvYoHGZz+4VPcg7RtYy2KP7S2lbuWM6FCSgob5wshfGESbC/hzNXZw==",
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.25.9.tgz",
+			"integrity": "sha512-ETzz9UTjQSTmw39GboatdymDq4XIQbR8ySgVrylRhPOFpsd+JrKHIuF0de7GCWmem+T4uC5z7EZguod7Wj4A4g==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-function-name": "^7.22.5",
-				"@babel/template": "^7.22.15",
-				"@babel/types": "^7.22.19"
+				"@babel/template": "^7.25.9",
+				"@babel/traverse": "^7.25.9",
+				"@babel/types": "^7.25.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -835,12 +790,12 @@
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.26.3",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.3.tgz",
-			"integrity": "sha512-WJ/CvmY8Mea8iDXo6a7RK2wbmJITT5fN3BEkRuFlxVyNx8jOKIIhmC4fSkTcPcf8JyavbBwIe6OpiCOBXt/IcA==",
+			"version": "7.27.0",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.0.tgz",
+			"integrity": "sha512-iaepho73/2Pz7w2eMS0Q5f83+0RKI7i4xmiYeBmDzfRVbQtTOG7Ts0S4HzJVsTMGI9keU8rNfuZr8DKfSt7Yyg==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/types": "^7.26.3"
+				"@babel/types": "^7.27.0"
 			},
 			"bin": {
 				"parser": "bin/babel-parser.js"
@@ -849,13 +804,47 @@
 				"node": ">=6.0.0"
 			}
 		},
-		"node_modules/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.23.3.tgz",
-			"integrity": "sha512-iRkKcCqb7iGnq9+3G6rZ+Ciz5VywC4XNRHe57lKM+jOeYAoR0lVqdeeDRfh0tQcTfw/+vBhHn926FmQhLtlFLQ==",
+		"node_modules/@babel/plugin-bugfix-firefox-class-in-computed-class-key": {
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-7.25.9.tgz",
+			"integrity": "sha512-ZkRyVkThtxQ/J6nv3JFYv1RYY+JT5BvU0y3k5bWrmuG4woXypRa4PXmm9RhOwodRkYFWqC0C0cqcJ4OqR7kW+g==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.22.5"
+				"@babel/helper-plugin-utils": "^7.25.9",
+				"@babel/traverse": "^7.25.9"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0"
+			}
+		},
+		"node_modules/@babel/plugin-bugfix-safari-class-field-initializer-scope": {
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-class-field-initializer-scope/-/plugin-bugfix-safari-class-field-initializer-scope-7.25.9.tgz",
+			"integrity": "sha512-MrGRLZxLD/Zjj0gdU15dfs+HH/OXvnw/U4jJD8vpcP2CJQapPEv1IWwjc/qMg7ItBlPwSv1hRBbb7LeuANdcnw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.25.9"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0"
+			}
+		},
+		"node_modules/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.25.9.tgz",
+			"integrity": "sha512-2qUwwfAFpJLZqxd02YW9btUCZHl+RFvdDkNfZwaIJrvB8Tesjsk8pEQkTvGwZXLqXUx/2oyY3ySRhm6HOXuCug==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.25.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -865,14 +854,15 @@
 			}
 		},
 		"node_modules/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.23.3.tgz",
-			"integrity": "sha512-WwlxbfMNdVEpQjZmK5mhm7oSwD3dS6eU+Iwsi4Knl9wAletWem7kaRsGOG+8UEbRyqxY4SS5zvtfXwX+jMxUwQ==",
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.25.9.tgz",
+			"integrity": "sha512-6xWgLZTJXwilVjlnV7ospI3xi+sl8lN8rXXbBD6vYn3UYDlGsag8wrZkKcSI8G6KgqKP7vNFaDgeDnfAABq61g==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.22.5",
-				"@babel/helper-skip-transparent-expression-wrappers": "^7.22.5",
-				"@babel/plugin-transform-optional-chaining": "^7.23.3"
+				"@babel/helper-plugin-utils": "^7.25.9",
+				"@babel/helper-skip-transparent-expression-wrappers": "^7.25.9",
+				"@babel/plugin-transform-optional-chaining": "^7.25.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -882,13 +872,14 @@
 			}
 		},
 		"node_modules/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": {
-			"version": "7.23.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.23.7.tgz",
-			"integrity": "sha512-LlRT7HgaifEpQA1ZgLVOIJZZFVPWN5iReq/7/JixwBtwcoeVGDBD53ZV28rrsLYOZs1Y/EHhA8N/Z6aazHR8cw==",
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.25.9.tgz",
+			"integrity": "sha512-aLnMXYPnzwwqhYSCyXfKkIkYgJ8zv9RK+roo9DkTXz38ynIhd9XCbN08s3MGvqL2MYGVUGdRQLL/JqBIeJhJBg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-environment-visitor": "^7.22.20",
-				"@babel/helper-plugin-utils": "^7.22.5"
+				"@babel/helper-plugin-utils": "^7.25.9",
+				"@babel/traverse": "^7.25.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -898,14 +889,15 @@
 			}
 		},
 		"node_modules/@babel/plugin-proposal-decorators": {
-			"version": "7.23.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.23.9.tgz",
-			"integrity": "sha512-hJhBCb0+NnTWybvWq2WpbCYDOcflSbx0t+BYP65e5R9GVnukiDTi+on5bFkk4p7QGuv190H6KfNiV9Knf/3cZA==",
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.25.9.tgz",
+			"integrity": "sha512-smkNLL/O1ezy9Nhy4CNosc4Va+1wo5w4gzSZeLe6y6dM4mmHfYOCPolXQPHQxonZCF+ZyebxN9vqOolkYrSn5g==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-create-class-features-plugin": "^7.23.9",
-				"@babel/helper-plugin-utils": "^7.22.5",
-				"@babel/plugin-syntax-decorators": "^7.23.3"
+				"@babel/helper-create-class-features-plugin": "^7.25.9",
+				"@babel/helper-plugin-utils": "^7.25.9",
+				"@babel/plugin-syntax-decorators": "^7.25.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -919,6 +911,7 @@
 			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
 			"integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
 			},
@@ -962,67 +955,30 @@
 				"@babel/core": "^7.0.0-0"
 			}
 		},
-		"node_modules/@babel/plugin-syntax-class-static-block": {
-			"version": "7.14.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
-			"integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
-			"dev": true,
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.14.5"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
 		"node_modules/@babel/plugin-syntax-decorators": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.23.3.tgz",
-			"integrity": "sha512-cf7Niq4/+/juY67E0PbgH0TDhLQ5J7zS8C/Q5FFx+DWyrRa9sUQdTXkjqKu8zGvuqr7vw1muKiukseihU+PJDA==",
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.25.9.tgz",
+			"integrity": "sha512-ryzI0McXUPJnRCvMo4lumIKZUzhYUO/ScI+Mz4YVaTLt04DHNSjEUjKVvbzQjZFLuod/cYEc07mJWhzl6v4DPg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.22.5"
+				"@babel/helper-plugin-utils": "^7.25.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-syntax-dynamic-import": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz",
-			"integrity": "sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==",
-			"dev": true,
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.8.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@babel/plugin-syntax-export-namespace-from": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-export-namespace-from/-/plugin-syntax-export-namespace-from-7.8.3.tgz",
-			"integrity": "sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==",
-			"dev": true,
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.8.3"
 			},
 			"peerDependencies": {
 				"@babel/core": "^7.0.0-0"
 			}
 		},
 		"node_modules/@babel/plugin-syntax-import-assertions": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.23.3.tgz",
-			"integrity": "sha512-lPgDSU+SJLK3xmFDTV2ZRQAiM7UuUjGidwBywFavObCiZc1BeAAcMtHJKUya92hPHO+at63JJPLygilZard8jw==",
+			"version": "7.26.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.26.0.tgz",
+			"integrity": "sha512-QCWT5Hh830hK5EQa7XzuqIkQU9tT/whqbDz7kuaZMHFl1inRRg7JnuAEOQ0Ur0QUl0NufCk1msK2BeY79Aj/eg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.22.5"
+				"@babel/helper-plugin-utils": "^7.25.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1032,12 +988,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-syntax-import-attributes": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.23.3.tgz",
-			"integrity": "sha512-pawnE0P9g10xgoP7yKr6CK63K2FMsTE+FZidZO/1PwRdzmAPVs+HS1mAURUsgaoxammTJvULUdIkEK0gOcU2tA==",
+			"version": "7.26.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.26.0.tgz",
+			"integrity": "sha512-e2dttdsJ1ZTpi3B9UYGLw41hifAubg19AtCu/2I/F1QNVclOBr1dYpTdmdyZ84Xiz43BS/tCUkMAZNLv12Pi+A==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.22.5"
+				"@babel/helper-plugin-utils": "^7.25.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1071,12 +1028,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-syntax-jsx": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.23.3.tgz",
-			"integrity": "sha512-EB2MELswq55OHUoRZLGg/zC7QWUKfNLpE57m/S2yr1uEneIgsTgrSzXP3NXEsMkVn76OlaVVnzN+ugObuYGwhg==",
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.25.9.tgz",
+			"integrity": "sha512-ld6oezHQMZsZfp6pWtbjaNDF2tiiCYYDqQszHt5VV437lewP9aSi2Of99CK0D0XB21k7FLgnLcmQKyKzynfeAA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.22.5"
+				"@babel/helper-plugin-utils": "^7.25.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1157,21 +1115,6 @@
 				"@babel/core": "^7.0.0-0"
 			}
 		},
-		"node_modules/@babel/plugin-syntax-private-property-in-object": {
-			"version": "7.14.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
-			"integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
-			"dev": true,
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.14.5"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
 		"node_modules/@babel/plugin-syntax-top-level-await": {
 			"version": "7.14.5",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
@@ -1188,12 +1131,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-syntax-typescript": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.23.3.tgz",
-			"integrity": "sha512-9EiNjVJOMwCO+43TqoTrgQ8jMwcAd0sWyXi9RPfIsLTj4R2MADDDQXELhffaUx/uJv2AYcxBgPwH6j4TIA4ytQ==",
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.25.9.tgz",
+			"integrity": "sha512-hjMgRy5hb8uJJjUcdWunWVcoi9bGpJp8p5Ol1229PoN6aytsLwNMgmdftO23wnCLMfVmTwZDWMPNq/D1SY60JQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.22.5"
+				"@babel/helper-plugin-utils": "^7.25.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1207,6 +1151,7 @@
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-unicode-sets-regex/-/plugin-syntax-unicode-sets-regex-7.18.6.tgz",
 			"integrity": "sha512-727YkEAPwSIQTv5im8QHz3upqp92JTWhidIC81Tdx4VJYIte/VndKf1qKrfnnhPLiPghStWfvC/iFaMCQu7Nqg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@babel/helper-create-regexp-features-plugin": "^7.18.6",
 				"@babel/helper-plugin-utils": "^7.18.6"
@@ -1219,12 +1164,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-arrow-functions": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.23.3.tgz",
-			"integrity": "sha512-NzQcQrzaQPkaEwoTm4Mhyl8jI1huEL/WWIEvudjTCMJ9aBZNpsJbMASx7EQECtQQPS/DcnFpo0FIh3LvEO9cxQ==",
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.25.9.tgz",
+			"integrity": "sha512-6jmooXYIwn9ca5/RylZADJ+EnSxVUS5sjeJ9UPk6RWRzXCmOJCy6dqItPJFpw2cuCangPK4OYr5uhGKcmrm5Qg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.22.5"
+				"@babel/helper-plugin-utils": "^7.25.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1234,15 +1180,15 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-async-generator-functions": {
-			"version": "7.23.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.23.9.tgz",
-			"integrity": "sha512-8Q3veQEDGe14dTYuwagbRtwxQDnytyg1JFu4/HwEMETeofocrB0U0ejBJIXoeG/t2oXZ8kzCyI0ZZfbT80VFNQ==",
+			"version": "7.26.8",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.26.8.tgz",
+			"integrity": "sha512-He9Ej2X7tNf2zdKMAGOsmg2MrFc+hfoAhd3po4cWfo/NWjzEAKa0oQruj1ROVUdl0e6fb6/kE/G3SSxE0lRJOg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-environment-visitor": "^7.22.20",
-				"@babel/helper-plugin-utils": "^7.22.5",
-				"@babel/helper-remap-async-to-generator": "^7.22.20",
-				"@babel/plugin-syntax-async-generators": "^7.8.4"
+				"@babel/helper-plugin-utils": "^7.26.5",
+				"@babel/helper-remap-async-to-generator": "^7.25.9",
+				"@babel/traverse": "^7.26.8"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1252,14 +1198,15 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-async-to-generator": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.23.3.tgz",
-			"integrity": "sha512-A7LFsKi4U4fomjqXJlZg/u0ft/n8/7n7lpffUP/ZULx/DtV9SGlNKZolHH6PE8Xl1ngCc0M11OaeZptXVkfKSw==",
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.25.9.tgz",
+			"integrity": "sha512-NT7Ejn7Z/LjUH0Gv5KsBCxh7BH3fbLTV0ptHvpeMvrt3cPThHfJfst9Wrb7S8EvJ7vRTFI7z+VAvFVEQn/m5zQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-module-imports": "^7.22.15",
-				"@babel/helper-plugin-utils": "^7.22.5",
-				"@babel/helper-remap-async-to-generator": "^7.22.20"
+				"@babel/helper-module-imports": "^7.25.9",
+				"@babel/helper-plugin-utils": "^7.25.9",
+				"@babel/helper-remap-async-to-generator": "^7.25.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1269,12 +1216,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-block-scoped-functions": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.23.3.tgz",
-			"integrity": "sha512-vI+0sIaPIO6CNuM9Kk5VmXcMVRiOpDh7w2zZt9GXzmE/9KD70CUEVhvPR/etAeNK/FAEkhxQtXOzVF3EuRL41A==",
+			"version": "7.26.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.26.5.tgz",
+			"integrity": "sha512-chuTSY+hq09+/f5lMj8ZSYgCFpppV2CbYrhNFJ1BFoXpiWPnnAb7R0MqrafCpN8E1+YRrtM1MXZHJdIx8B6rMQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.22.5"
+				"@babel/helper-plugin-utils": "^7.26.5"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1284,12 +1232,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-block-scoping": {
-			"version": "7.23.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.23.4.tgz",
-			"integrity": "sha512-0QqbP6B6HOh7/8iNR4CQU2Th/bbRtBp4KS9vcaZd1fZ0wSh5Fyssg0UCIHwxh+ka+pNDREbVLQnHCMHKZfPwfw==",
+			"version": "7.27.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.27.0.tgz",
+			"integrity": "sha512-u1jGphZ8uDI2Pj/HJj6YQ6XQLZCNjOlprjxB5SVz6rq2T6SwAR+CdrWK0CP7F+9rDVMXdB0+r6Am5G5aobOjAQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.22.5"
+				"@babel/helper-plugin-utils": "^7.26.5"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1299,13 +1248,14 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-class-properties": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.23.3.tgz",
-			"integrity": "sha512-uM+AN8yCIjDPccsKGlw271xjJtGii+xQIF/uMPS8H15L12jZTsLfF4o5vNO7d/oUguOyfdikHGc/yi9ge4SGIg==",
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.25.9.tgz",
+			"integrity": "sha512-bbMAII8GRSkcd0h0b4X+36GksxuheLFjP65ul9w6C3KgAamI3JqErNgSrosX6ZPj+Mpim5VvEbawXxJCyEUV3Q==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-create-class-features-plugin": "^7.22.15",
-				"@babel/helper-plugin-utils": "^7.22.5"
+				"@babel/helper-create-class-features-plugin": "^7.25.9",
+				"@babel/helper-plugin-utils": "^7.25.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1315,14 +1265,14 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-class-static-block": {
-			"version": "7.23.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.23.4.tgz",
-			"integrity": "sha512-nsWu/1M+ggti1SOALj3hfx5FXzAY06fwPJsUZD4/A5e1bWi46VUIWtD+kOX6/IdhXGsXBWllLFDSnqSCdUNydQ==",
+			"version": "7.26.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.26.0.tgz",
+			"integrity": "sha512-6J2APTs7BDDm+UMqP1useWqhcRAXo0WIoVj26N7kPFB6S73Lgvyka4KTZYIxtgYXiN5HTyRObA72N2iu628iTQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-create-class-features-plugin": "^7.22.15",
-				"@babel/helper-plugin-utils": "^7.22.5",
-				"@babel/plugin-syntax-class-static-block": "^7.14.5"
+				"@babel/helper-create-class-features-plugin": "^7.25.9",
+				"@babel/helper-plugin-utils": "^7.25.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1332,18 +1282,17 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-classes": {
-			"version": "7.23.8",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.23.8.tgz",
-			"integrity": "sha512-yAYslGsY1bX6Knmg46RjiCiNSwJKv2IUC8qOdYKqMMr0491SXFhcHqOdRDeCRohOOIzwN/90C6mQ9qAKgrP7dg==",
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.25.9.tgz",
+			"integrity": "sha512-mD8APIXmseE7oZvZgGABDyM34GUmK45Um2TXiBUt7PnuAxrgoSVf123qUzPxEr/+/BHrRn5NMZCdE2m/1F8DGg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-annotate-as-pure": "^7.22.5",
-				"@babel/helper-compilation-targets": "^7.23.6",
-				"@babel/helper-environment-visitor": "^7.22.20",
-				"@babel/helper-function-name": "^7.23.0",
-				"@babel/helper-plugin-utils": "^7.22.5",
-				"@babel/helper-replace-supers": "^7.22.20",
-				"@babel/helper-split-export-declaration": "^7.22.6",
+				"@babel/helper-annotate-as-pure": "^7.25.9",
+				"@babel/helper-compilation-targets": "^7.25.9",
+				"@babel/helper-plugin-utils": "^7.25.9",
+				"@babel/helper-replace-supers": "^7.25.9",
+				"@babel/traverse": "^7.25.9",
 				"globals": "^11.1.0"
 			},
 			"engines": {
@@ -1358,18 +1307,20 @@
 			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
 			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=4"
 			}
 		},
 		"node_modules/@babel/plugin-transform-computed-properties": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.23.3.tgz",
-			"integrity": "sha512-dTj83UVTLw/+nbiHqQSFdwO9CbTtwq1DsDqm3CUEtDrZNET5rT5E6bIdTlOftDTDLMYxvxHNEYO4B9SLl8SLZw==",
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.25.9.tgz",
+			"integrity": "sha512-HnBegGqXZR12xbcTHlJ9HGxw1OniltT26J5YpfruGqtUHlz/xKf/G2ak9e+t0rVqrjXa9WOhvYPz1ERfMj23AA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.22.5",
-				"@babel/template": "^7.22.15"
+				"@babel/helper-plugin-utils": "^7.25.9",
+				"@babel/template": "^7.25.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1379,12 +1330,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-destructuring": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.23.3.tgz",
-			"integrity": "sha512-n225npDqjDIr967cMScVKHXJs7rout1q+tt50inyBCPkyZ8KxeI6d+GIbSBTT/w/9WdlWDOej3V9HE5Lgk57gw==",
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.25.9.tgz",
+			"integrity": "sha512-WkCGb/3ZxXepmMiX101nnGiU+1CAdut8oHyEOHxkKuS1qKpU2SMXE2uSvfz8PBuLd49V6LEsbtyPhWC7fnkgvQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.22.5"
+				"@babel/helper-plugin-utils": "^7.25.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1394,13 +1346,14 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-dotall-regex": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.23.3.tgz",
-			"integrity": "sha512-vgnFYDHAKzFaTVp+mneDsIEbnJ2Np/9ng9iviHw3P/KVcgONxpNULEW/51Z/BaFojG2GI2GwwXck5uV1+1NOYQ==",
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.25.9.tgz",
+			"integrity": "sha512-t7ZQ7g5trIgSRYhI9pIJtRl64KHotutUJsh4Eze5l7olJv+mRSg4/MmbZ0tv1eeqRbdvo/+trvJD/Oc5DmW2cA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-create-regexp-features-plugin": "^7.22.15",
-				"@babel/helper-plugin-utils": "^7.22.5"
+				"@babel/helper-create-regexp-features-plugin": "^7.25.9",
+				"@babel/helper-plugin-utils": "^7.25.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1410,12 +1363,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-duplicate-keys": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.23.3.tgz",
-			"integrity": "sha512-RrqQ+BQmU3Oyav3J+7/myfvRCq7Tbz+kKLLshUmMwNlDHExbGL7ARhajvoBJEvc+fCguPPu887N+3RRXBVKZUA==",
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.25.9.tgz",
+			"integrity": "sha512-LZxhJ6dvBb/f3x8xwWIuyiAHy56nrRG3PeYTpBkkzkYRRQ6tJLu68lEF5VIqMUZiAV7a8+Tb78nEoMCMcqjXBw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.22.5"
+				"@babel/helper-plugin-utils": "^7.25.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1424,14 +1378,31 @@
 				"@babel/core": "^7.0.0-0"
 			}
 		},
-		"node_modules/@babel/plugin-transform-dynamic-import": {
-			"version": "7.23.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-7.23.4.tgz",
-			"integrity": "sha512-V6jIbLhdJK86MaLh4Jpghi8ho5fGzt3imHOBu/x0jlBaPYqDoWz4RDXjmMOfnh+JWNaQleEAByZLV0QzBT4YQQ==",
+		"node_modules/@babel/plugin-transform-duplicate-named-capturing-groups-regex": {
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-named-capturing-groups-regex/-/plugin-transform-duplicate-named-capturing-groups-regex-7.25.9.tgz",
+			"integrity": "sha512-0UfuJS0EsXbRvKnwcLjFtJy/Sxc5J5jhLHnFhy7u4zih97Hz6tJkLU+O+FMMrNZrosUPxDi6sYxJ/EA8jDiAog==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.22.5",
-				"@babel/plugin-syntax-dynamic-import": "^7.8.3"
+				"@babel/helper-create-regexp-features-plugin": "^7.25.9",
+				"@babel/helper-plugin-utils": "^7.25.9"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0"
+			}
+		},
+		"node_modules/@babel/plugin-transform-dynamic-import": {
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-7.25.9.tgz",
+			"integrity": "sha512-GCggjexbmSLaFhqsojeugBpeaRIgWNTcgKVq/0qIteFEqY2A+b9QidYadrWlnbWQUrW5fn+mCvf3tr7OeBFTyg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.25.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1441,13 +1412,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-exponentiation-operator": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.23.3.tgz",
-			"integrity": "sha512-5fhCsl1odX96u7ILKHBj4/Y8vipoqwsJMh4csSA8qFfxrZDEA4Ssku2DyNvMJSmZNOEBT750LfFPbtrnTP90BQ==",
+			"version": "7.26.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.26.3.tgz",
+			"integrity": "sha512-7CAHcQ58z2chuXPWblnn1K6rLDnDWieghSOEmqQsrBenH0P9InCUtOJYD89pvngljmZlJcz3fcmgYsXFNGa1ZQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-builder-binary-assignment-operator-visitor": "^7.22.15",
-				"@babel/helper-plugin-utils": "^7.22.5"
+				"@babel/helper-plugin-utils": "^7.25.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1457,13 +1428,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-export-namespace-from": {
-			"version": "7.23.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-7.23.4.tgz",
-			"integrity": "sha512-GzuSBcKkx62dGzZI1WVgTWvkkz84FZO5TC5T8dl/Tht/rAla6Dg/Mz9Yhypg+ezVACf/rgDuQt3kbWEv7LdUDQ==",
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-7.25.9.tgz",
+			"integrity": "sha512-2NsEz+CxzJIVOPx2o9UsW1rXLqtChtLoVnwYHHiB04wS5sgn7mrV45fWMBX0Kk+ub9uXytVYfNP2HjbVbCB3Ww==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.22.5",
-				"@babel/plugin-syntax-export-namespace-from": "^7.8.3"
+				"@babel/helper-plugin-utils": "^7.25.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1473,13 +1444,14 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-for-of": {
-			"version": "7.23.6",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.23.6.tgz",
-			"integrity": "sha512-aYH4ytZ0qSuBbpfhuofbg/e96oQ7U2w1Aw/UQmKT+1l39uEhUPoFS3fHevDc1G0OvewyDudfMKY1OulczHzWIw==",
+			"version": "7.26.9",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.26.9.tgz",
+			"integrity": "sha512-Hry8AusVm8LW5BVFgiyUReuoGzPUpdHQQqJY5bZnbbf+ngOHWuCuYFKw/BqaaWlvEUrF91HMhDtEaI1hZzNbLg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.22.5",
-				"@babel/helper-skip-transparent-expression-wrappers": "^7.22.5"
+				"@babel/helper-plugin-utils": "^7.26.5",
+				"@babel/helper-skip-transparent-expression-wrappers": "^7.25.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1489,14 +1461,15 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-function-name": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.23.3.tgz",
-			"integrity": "sha512-I1QXp1LxIvt8yLaib49dRW5Okt7Q4oaxao6tFVKS/anCdEOMtYwWVKoiOA1p34GOWIZjUK0E+zCp7+l1pfQyiw==",
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.25.9.tgz",
+			"integrity": "sha512-8lP+Yxjv14Vc5MuWBpJsoUCd3hD6V9DgBon2FVYL4jJgbnVQ9fTgYmonchzZJOVNgzEgbxp4OwAf6xz6M/14XA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-compilation-targets": "^7.22.15",
-				"@babel/helper-function-name": "^7.23.0",
-				"@babel/helper-plugin-utils": "^7.22.5"
+				"@babel/helper-compilation-targets": "^7.25.9",
+				"@babel/helper-plugin-utils": "^7.25.9",
+				"@babel/traverse": "^7.25.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1506,13 +1479,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-json-strings": {
-			"version": "7.23.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.23.4.tgz",
-			"integrity": "sha512-81nTOqM1dMwZ/aRXQ59zVubN9wHGqk6UtqRK+/q+ciXmRy8fSolhGVvG09HHRGo4l6fr/c4ZhXUQH0uFW7PZbg==",
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.25.9.tgz",
+			"integrity": "sha512-xoTMk0WXceiiIvsaquQQUaLLXSW1KJ159KP87VilruQm0LNNGxWzahxSS6T6i4Zg3ezp4vA4zuwiNUR53qmQAw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.22.5",
-				"@babel/plugin-syntax-json-strings": "^7.8.3"
+				"@babel/helper-plugin-utils": "^7.25.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1522,12 +1495,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-literals": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.23.3.tgz",
-			"integrity": "sha512-wZ0PIXRxnwZvl9AYpqNUxpZ5BiTGrYt7kueGQ+N5FiQ7RCOD4cm8iShd6S6ggfVIWaJf2EMk8eRzAh52RfP4rQ==",
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.25.9.tgz",
+			"integrity": "sha512-9N7+2lFziW8W9pBl2TzaNht3+pgMIRP74zizeCSrtnSKVdUl8mAjjOP2OOVQAfZ881P2cNjDj1uAMEdeD50nuQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.22.5"
+				"@babel/helper-plugin-utils": "^7.25.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1537,13 +1511,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-logical-assignment-operators": {
-			"version": "7.23.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.23.4.tgz",
-			"integrity": "sha512-Mc/ALf1rmZTP4JKKEhUwiORU+vcfarFVLfcFiolKUo6sewoxSEgl36ak5t+4WamRsNr6nzjZXQjM35WsU+9vbg==",
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.25.9.tgz",
+			"integrity": "sha512-wI4wRAzGko551Y8eVf6iOY9EouIDTtPb0ByZx+ktDGHwv6bHFimrgJM/2T021txPZ2s4c7bqvHbd+vXG6K948Q==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.22.5",
-				"@babel/plugin-syntax-logical-assignment-operators": "^7.10.4"
+				"@babel/helper-plugin-utils": "^7.25.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1553,12 +1527,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-member-expression-literals": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.23.3.tgz",
-			"integrity": "sha512-sC3LdDBDi5x96LA+Ytekz2ZPk8i/Ck+DEuDbRAll5rknJ5XRTSaPKEYwomLcs1AA8wg9b3KjIQRsnApj+q51Ag==",
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.25.9.tgz",
+			"integrity": "sha512-PYazBVfofCQkkMzh2P6IdIUaCEWni3iYEerAsRWuVd8+jlM1S9S9cz1dF9hIzyoZ8IA3+OwVYIp9v9e+GbgZhA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.22.5"
+				"@babel/helper-plugin-utils": "^7.25.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1568,13 +1543,14 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-modules-amd": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.23.3.tgz",
-			"integrity": "sha512-vJYQGxeKM4t8hYCKVBlZX/gtIY2I7mRGFNcm85sgXGMTBcoV3QdVtdpbcWEbzbfUIUZKwvgFT82mRvaQIebZzw==",
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.25.9.tgz",
+			"integrity": "sha512-g5T11tnI36jVClQlMlt4qKDLlWnG5pP9CSM4GhdRciTNMRgkfpo5cR6b4rGIOYPgRRuFAvwjPQ/Yk+ql4dyhbw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-module-transforms": "^7.23.3",
-				"@babel/helper-plugin-utils": "^7.22.5"
+				"@babel/helper-module-transforms": "^7.25.9",
+				"@babel/helper-plugin-utils": "^7.25.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1584,14 +1560,14 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-modules-commonjs": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.23.3.tgz",
-			"integrity": "sha512-aVS0F65LKsdNOtcz6FRCpE4OgsP2OFnW46qNxNIX9h3wuzaNcSQsJysuMwqSibC98HPrf2vCgtxKNwS0DAlgcA==",
+			"version": "7.26.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.26.3.tgz",
+			"integrity": "sha512-MgR55l4q9KddUDITEzEFYn5ZsGDXMSsU9E+kh7fjRXTIC3RHqfCo8RPRbyReYJh44HQ/yomFkqbOFohXvDCiIQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-module-transforms": "^7.23.3",
-				"@babel/helper-plugin-utils": "^7.22.5",
-				"@babel/helper-simple-access": "^7.22.5"
+				"@babel/helper-module-transforms": "^7.26.0",
+				"@babel/helper-plugin-utils": "^7.25.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1601,15 +1577,16 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-modules-systemjs": {
-			"version": "7.23.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.23.9.tgz",
-			"integrity": "sha512-KDlPRM6sLo4o1FkiSlXoAa8edLXFsKKIda779fbLrvmeuc3itnjCtaO6RrtoaANsIJANj+Vk1zqbZIMhkCAHVw==",
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.25.9.tgz",
+			"integrity": "sha512-hyss7iIlH/zLHaehT+xwiymtPOpsiwIIRlCAOwBB04ta5Tt+lNItADdlXw3jAWZ96VJ2jlhl/c+PNIQPKNfvcA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-hoist-variables": "^7.22.5",
-				"@babel/helper-module-transforms": "^7.23.3",
-				"@babel/helper-plugin-utils": "^7.22.5",
-				"@babel/helper-validator-identifier": "^7.22.20"
+				"@babel/helper-module-transforms": "^7.25.9",
+				"@babel/helper-plugin-utils": "^7.25.9",
+				"@babel/helper-validator-identifier": "^7.25.9",
+				"@babel/traverse": "^7.25.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1619,13 +1596,14 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-modules-umd": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.23.3.tgz",
-			"integrity": "sha512-zHsy9iXX2nIsCBFPud3jKn1IRPWg3Ing1qOZgeKV39m1ZgIdpJqvlWVeiHBZC6ITRG0MfskhYe9cLgntfSFPIg==",
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.25.9.tgz",
+			"integrity": "sha512-bS9MVObUgE7ww36HEfwe6g9WakQ0KF07mQF74uuXdkoziUPfKyu/nIm663kz//e5O1nPInPFx36z7WJmJ4yNEw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-module-transforms": "^7.23.3",
-				"@babel/helper-plugin-utils": "^7.22.5"
+				"@babel/helper-module-transforms": "^7.25.9",
+				"@babel/helper-plugin-utils": "^7.25.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1635,13 +1613,14 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-named-capturing-groups-regex": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.22.5.tgz",
-			"integrity": "sha512-YgLLKmS3aUBhHaxp5hi1WJTgOUb/NCuDHzGT9z9WTt3YG+CPRhJs6nprbStx6DnWM4dh6gt7SU3sZodbZ08adQ==",
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.25.9.tgz",
+			"integrity": "sha512-oqB6WHdKTGl3q/ItQhpLSnWWOpjUJLsOCLVyeFgeTktkBSCiurvPOsyt93gibI9CmuKvTUEtWmG5VhZD+5T/KA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-create-regexp-features-plugin": "^7.22.5",
-				"@babel/helper-plugin-utils": "^7.22.5"
+				"@babel/helper-create-regexp-features-plugin": "^7.25.9",
+				"@babel/helper-plugin-utils": "^7.25.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1651,12 +1630,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-new-target": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.23.3.tgz",
-			"integrity": "sha512-YJ3xKqtJMAT5/TIZnpAR3I+K+WaDowYbN3xyxI8zxx/Gsypwf9B9h0VB+1Nh6ACAAPRS5NSRje0uVv5i79HYGQ==",
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.25.9.tgz",
+			"integrity": "sha512-U/3p8X1yCSoKyUj2eOBIx3FOn6pElFOKvAAGf8HTtItuPyB+ZeOqfn+mvTtg9ZlOAjsPdK3ayQEjqHjU/yLeVQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.22.5"
+				"@babel/helper-plugin-utils": "^7.25.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1666,13 +1646,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-nullish-coalescing-operator": {
-			"version": "7.23.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.23.4.tgz",
-			"integrity": "sha512-jHE9EVVqHKAQx+VePv5LLGHjmHSJR76vawFPTdlxR/LVJPfOEGxREQwQfjuZEOPTwG92X3LINSh3M40Rv4zpVA==",
+			"version": "7.26.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.26.6.tgz",
+			"integrity": "sha512-CKW8Vu+uUZneQCPtXmSBUC6NCAUdya26hWCElAWh5mVSlSRsmiCPUUDKb3Z0szng1hiAJa098Hkhg9o4SE35Qw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.22.5",
-				"@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3"
+				"@babel/helper-plugin-utils": "^7.26.5"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1682,13 +1662,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-numeric-separator": {
-			"version": "7.23.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.23.4.tgz",
-			"integrity": "sha512-mps6auzgwjRrwKEZA05cOwuDc9FAzoyFS4ZsG/8F43bTLf/TgkJg7QXOrPO1JO599iA3qgK9MXdMGOEC8O1h6Q==",
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.25.9.tgz",
+			"integrity": "sha512-TlprrJ1GBZ3r6s96Yq8gEQv82s8/5HnCVHtEJScUj90thHQbwe+E5MLhi2bbNHBEJuzrvltXSru+BUxHDoog7Q==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.22.5",
-				"@babel/plugin-syntax-numeric-separator": "^7.10.4"
+				"@babel/helper-plugin-utils": "^7.25.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1698,16 +1678,15 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-object-rest-spread": {
-			"version": "7.23.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.23.4.tgz",
-			"integrity": "sha512-9x9K1YyeQVw0iOXJlIzwm8ltobIIv7j2iLyP2jIhEbqPRQ7ScNgwQufU2I0Gq11VjyG4gI4yMXt2VFags+1N3g==",
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.25.9.tgz",
+			"integrity": "sha512-fSaXafEE9CVHPweLYw4J0emp1t8zYTXyzN3UuG+lylqkvYd7RMrsOQ8TYx5RF231be0vqtFC6jnx3UmpJmKBYg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/compat-data": "^7.23.3",
-				"@babel/helper-compilation-targets": "^7.22.15",
-				"@babel/helper-plugin-utils": "^7.22.5",
-				"@babel/plugin-syntax-object-rest-spread": "^7.8.3",
-				"@babel/plugin-transform-parameters": "^7.23.3"
+				"@babel/helper-compilation-targets": "^7.25.9",
+				"@babel/helper-plugin-utils": "^7.25.9",
+				"@babel/plugin-transform-parameters": "^7.25.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1717,13 +1696,14 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-object-super": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.23.3.tgz",
-			"integrity": "sha512-BwQ8q0x2JG+3lxCVFohg+KbQM7plfpBwThdW9A6TMtWwLsbDA01Ek2Zb/AgDN39BiZsExm4qrXxjk+P1/fzGrA==",
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.25.9.tgz",
+			"integrity": "sha512-Kj/Gh+Rw2RNLbCK1VAWj2U48yxxqL2x0k10nPtSdRa0O2xnHXalD0s+o1A6a0W43gJ00ANo38jxkQreckOzv5A==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.22.5",
-				"@babel/helper-replace-supers": "^7.22.20"
+				"@babel/helper-plugin-utils": "^7.25.9",
+				"@babel/helper-replace-supers": "^7.25.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1733,13 +1713,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-optional-catch-binding": {
-			"version": "7.23.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.23.4.tgz",
-			"integrity": "sha512-XIq8t0rJPHf6Wvmbn9nFxU6ao4c7WhghTR5WyV8SrJfUFzyxhCm4nhC+iAp3HFhbAKLfYpgzhJ6t4XCtVwqO5A==",
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.25.9.tgz",
+			"integrity": "sha512-qM/6m6hQZzDcZF3onzIhZeDHDO43bkNNlOX0i8n3lR6zLbu0GN2d8qfM/IERJZYauhAHSLHy39NF0Ctdvcid7g==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.22.5",
-				"@babel/plugin-syntax-optional-catch-binding": "^7.8.3"
+				"@babel/helper-plugin-utils": "^7.25.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1749,14 +1729,14 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-optional-chaining": {
-			"version": "7.23.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.23.4.tgz",
-			"integrity": "sha512-ZU8y5zWOfjM5vZ+asjgAPwDaBjJzgufjES89Rs4Lpq63O300R/kOz30WCLo6BxxX6QVEilwSlpClnG5cZaikTA==",
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.25.9.tgz",
+			"integrity": "sha512-6AvV0FsLULbpnXeBjrY4dmWF8F7gf8QnvTEoO/wX/5xm/xE1Xo8oPuD3MPS+KS9f9XBEAWN7X1aWr4z9HdOr7A==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.22.5",
-				"@babel/helper-skip-transparent-expression-wrappers": "^7.22.5",
-				"@babel/plugin-syntax-optional-chaining": "^7.8.3"
+				"@babel/helper-plugin-utils": "^7.25.9",
+				"@babel/helper-skip-transparent-expression-wrappers": "^7.25.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1766,12 +1746,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-parameters": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.23.3.tgz",
-			"integrity": "sha512-09lMt6UsUb3/34BbECKVbVwrT9bO6lILWln237z7sLaWnMsTi7Yc9fhX5DLpkJzAGfaReXI22wP41SZmnAA3Vw==",
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.25.9.tgz",
+			"integrity": "sha512-wzz6MKwpnshBAiRmn4jR8LYz/g8Ksg0o80XmwZDlordjwEk9SxBzTWC7F5ef1jhbrbOW2DJ5J6ayRukrJmnr0g==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.22.5"
+				"@babel/helper-plugin-utils": "^7.25.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1781,13 +1762,14 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-private-methods": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.23.3.tgz",
-			"integrity": "sha512-UzqRcRtWsDMTLrRWFvUBDwmw06tCQH9Rl1uAjfh6ijMSmGYQ+fpdB+cnqRC8EMh5tuuxSv0/TejGL+7vyj+50g==",
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.25.9.tgz",
+			"integrity": "sha512-D/JUozNpQLAPUVusvqMxyvjzllRaF8/nSrP1s2YGQT/W4LHK4xxsMcHjhOGTS01mp9Hda8nswb+FblLdJornQw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-create-class-features-plugin": "^7.22.15",
-				"@babel/helper-plugin-utils": "^7.22.5"
+				"@babel/helper-create-class-features-plugin": "^7.25.9",
+				"@babel/helper-plugin-utils": "^7.25.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1797,15 +1779,15 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-private-property-in-object": {
-			"version": "7.23.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.23.4.tgz",
-			"integrity": "sha512-9G3K1YqTq3F4Vt88Djx1UZ79PDyj+yKRnUy7cZGSMe+a7jkwD259uKKuUzQlPkGam7R+8RJwh5z4xO27fA1o2A==",
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.25.9.tgz",
+			"integrity": "sha512-Evf3kcMqzXA3xfYJmZ9Pg1OvKdtqsDMSWBDzZOPLvHiTt36E75jLDQo5w1gtRU95Q4E5PDttrTf25Fw8d/uWLw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-annotate-as-pure": "^7.22.5",
-				"@babel/helper-create-class-features-plugin": "^7.22.15",
-				"@babel/helper-plugin-utils": "^7.22.5",
-				"@babel/plugin-syntax-private-property-in-object": "^7.14.5"
+				"@babel/helper-annotate-as-pure": "^7.25.9",
+				"@babel/helper-create-class-features-plugin": "^7.25.9",
+				"@babel/helper-plugin-utils": "^7.25.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1815,12 +1797,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-property-literals": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.23.3.tgz",
-			"integrity": "sha512-jR3Jn3y7cZp4oEWPFAlRsSWjxKe4PZILGBSd4nis1TsC5qeSpb+nrtihJuDhNI7QHiVbUaiXa0X2RZY3/TI6Nw==",
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.25.9.tgz",
+			"integrity": "sha512-IvIUeV5KrS/VPavfSM/Iu+RE6llrHrYIKY1yfCzyO/lMXHQ+p7uGhonmGVisv6tSBSVgWzMBohTcvkC9vQcQFA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.22.5"
+				"@babel/helper-plugin-utils": "^7.25.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1830,12 +1813,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-react-display-name": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.23.3.tgz",
-			"integrity": "sha512-GnvhtVfA2OAtzdX58FJxU19rhoGeQzyVndw3GgtdECQvQFXPEZIOVULHVZGAYmOgmqjXpVpfocAbSjh99V/Fqw==",
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.25.9.tgz",
+			"integrity": "sha512-KJfMlYIUxQB1CJfO3e0+h0ZHWOTLCPP115Awhaz8U0Zpq36Gl/cXlpoyMRnUWlhNUBAzldnCiAZNvCDj7CrKxQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.22.5"
+				"@babel/helper-plugin-utils": "^7.25.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1845,16 +1829,17 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-react-jsx": {
-			"version": "7.23.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.23.4.tgz",
-			"integrity": "sha512-5xOpoPguCZCRbo/JeHlloSkTA8Bld1J/E1/kLfD1nsuiW1m8tduTA1ERCgIZokDflX/IBzKcqR3l7VlRgiIfHA==",
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.25.9.tgz",
+			"integrity": "sha512-s5XwpQYCqGerXl+Pu6VDL3x0j2d82eiV77UJ8a2mDHAW7j9SWRqQ2y1fNo1Z74CdcYipl5Z41zvjj4Nfzq36rw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-annotate-as-pure": "^7.22.5",
-				"@babel/helper-module-imports": "^7.22.15",
-				"@babel/helper-plugin-utils": "^7.22.5",
-				"@babel/plugin-syntax-jsx": "^7.23.3",
-				"@babel/types": "^7.23.4"
+				"@babel/helper-annotate-as-pure": "^7.25.9",
+				"@babel/helper-module-imports": "^7.25.9",
+				"@babel/helper-plugin-utils": "^7.25.9",
+				"@babel/plugin-syntax-jsx": "^7.25.9",
+				"@babel/types": "^7.25.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1864,12 +1849,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-react-jsx-development": {
-			"version": "7.22.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.22.5.tgz",
-			"integrity": "sha512-bDhuzwWMuInwCYeDeMzyi7TaBgRQei6DqxhbyniL7/VG4RSS7HtSL2QbY4eESy1KJqlWt8g3xeEBGPuo+XqC8A==",
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.25.9.tgz",
+			"integrity": "sha512-9mj6rm7XVYs4mdLIpbZnHOYdpW42uoiBCTVowg7sP1thUOiANgMb4UtpRivR0pp5iL+ocvUv7X4mZgFRpJEzGw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/plugin-transform-react-jsx": "^7.22.5"
+				"@babel/plugin-transform-react-jsx": "^7.25.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1879,13 +1865,14 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-react-pure-annotations": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.23.3.tgz",
-			"integrity": "sha512-qMFdSS+TUhB7Q/3HVPnEdYJDQIk57jkntAwSuz9xfSE4n+3I+vHYCli3HoHawN1Z3RfCz/y1zXA/JXjG6cVImQ==",
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.25.9.tgz",
+			"integrity": "sha512-KQ/Takk3T8Qzj5TppkS1be588lkbTp5uj7w6a0LeQaTMSckU/wK0oJ/pih+T690tkgI5jfmg2TqDJvd41Sj1Cg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-annotate-as-pure": "^7.22.5",
-				"@babel/helper-plugin-utils": "^7.22.5"
+				"@babel/helper-annotate-as-pure": "^7.25.9",
+				"@babel/helper-plugin-utils": "^7.25.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1895,12 +1882,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-regenerator": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.23.3.tgz",
-			"integrity": "sha512-KP+75h0KghBMcVpuKisx3XTu9Ncut8Q8TuvGO4IhY+9D5DFEckQefOuIsB/gQ2tG71lCke4NMrtIPS8pOj18BQ==",
+			"version": "7.27.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.27.0.tgz",
+			"integrity": "sha512-LX/vCajUJQDqE7Aum/ELUMZAY19+cDpghxrnyt5I1tV6X5PyC86AOoWXWFYFeIvauyeSA6/ktn4tQVn/3ZifsA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.22.5",
+				"@babel/helper-plugin-utils": "^7.26.5",
 				"regenerator-transform": "^0.15.2"
 			},
 			"engines": {
@@ -1910,13 +1898,31 @@
 				"@babel/core": "^7.0.0-0"
 			}
 		},
-		"node_modules/@babel/plugin-transform-reserved-words": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.23.3.tgz",
-			"integrity": "sha512-QnNTazY54YqgGxwIexMZva9gqbPa15t/x9VS+0fsEFWplwVpXYZivtgl43Z1vMpc1bdPP2PP8siFeVcnFvA3Cg==",
+		"node_modules/@babel/plugin-transform-regexp-modifiers": {
+			"version": "7.26.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regexp-modifiers/-/plugin-transform-regexp-modifiers-7.26.0.tgz",
+			"integrity": "sha512-vN6saax7lrA2yA/Pak3sCxuD6F5InBjn9IcrIKQPjpsLvuHYLVroTxjdlVRHjjBWxKOqIwpTXDkOssYT4BFdRw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.22.5"
+				"@babel/helper-create-regexp-features-plugin": "^7.25.9",
+				"@babel/helper-plugin-utils": "^7.25.9"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0"
+			}
+		},
+		"node_modules/@babel/plugin-transform-reserved-words": {
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.25.9.tgz",
+			"integrity": "sha512-7DL7DKYjn5Su++4RXu8puKZm2XBPHyjWLUidaPEkCUBbE7IPcsrkRHggAOOKydH1dASWdcUBxrkOGNxUv5P3Jg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.25.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1926,12 +1932,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-shorthand-properties": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.23.3.tgz",
-			"integrity": "sha512-ED2fgqZLmexWiN+YNFX26fx4gh5qHDhn1O2gvEhreLW2iI63Sqm4llRLCXALKrCnbN4Jy0VcMQZl/SAzqug/jg==",
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.25.9.tgz",
+			"integrity": "sha512-MUv6t0FhO5qHnS/W8XCbHmiRWOphNufpE1IVxhK5kuN3Td9FT1x4rx4K42s3RYdMXCXpfWkGSbCSd0Z64xA7Ng==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.22.5"
+				"@babel/helper-plugin-utils": "^7.25.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1941,13 +1948,14 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-spread": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.23.3.tgz",
-			"integrity": "sha512-VvfVYlrlBVu+77xVTOAoxQ6mZbnIq5FM0aGBSFEcIh03qHf+zNqA4DC/3XMUozTg7bZV3e3mZQ0i13VB6v5yUg==",
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.25.9.tgz",
+			"integrity": "sha512-oNknIB0TbURU5pqJFVbOOFspVlrpVwo2H1+HUIsVDvp5VauGGDP1ZEvO8Nn5xyMEs3dakajOxlmkNW7kNgSm6A==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.22.5",
-				"@babel/helper-skip-transparent-expression-wrappers": "^7.22.5"
+				"@babel/helper-plugin-utils": "^7.25.9",
+				"@babel/helper-skip-transparent-expression-wrappers": "^7.25.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1957,12 +1965,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-sticky-regex": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.23.3.tgz",
-			"integrity": "sha512-HZOyN9g+rtvnOU3Yh7kSxXrKbzgrm5X4GncPY1QOquu7epga5MxKHVpYu2hvQnry/H+JjckSYRb93iNfsioAGg==",
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.25.9.tgz",
+			"integrity": "sha512-WqBUSgeVwucYDP9U/xNRQam7xV8W5Zf+6Eo7T2SRVUFlhRiMNFdFz58u0KZmCVVqs2i7SHgpRnAhzRNmKfi2uA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.22.5"
+				"@babel/helper-plugin-utils": "^7.25.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1972,12 +1981,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-template-literals": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.23.3.tgz",
-			"integrity": "sha512-Flok06AYNp7GV2oJPZZcP9vZdszev6vPBkHLwxwSpaIqx75wn6mUd3UFWsSsA0l8nXAKkyCmL/sR02m8RYGeHg==",
+			"version": "7.26.8",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.26.8.tgz",
+			"integrity": "sha512-OmGDL5/J0CJPJZTHZbi2XpO0tyT2Ia7fzpW5GURwdtp2X3fMmN8au/ej6peC/T33/+CRiIpA8Krse8hFGVmT5Q==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.22.5"
+				"@babel/helper-plugin-utils": "^7.26.5"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1987,12 +1997,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-typeof-symbol": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.23.3.tgz",
-			"integrity": "sha512-4t15ViVnaFdrPC74be1gXBSMzXk3B4Us9lP7uLRQHTFpV5Dvt33pn+2MyyNxmN3VTTm3oTrZVMUmuw3oBnQ2oQ==",
+			"version": "7.27.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.27.0.tgz",
+			"integrity": "sha512-+LLkxA9rKJpNoGsbLnAgOCdESl73vwYn+V6b+5wHbrE7OGKVDPHIQvbFSzqE6rwqaCw2RE+zdJrlLkcf8YOA0w==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.22.5"
+				"@babel/helper-plugin-utils": "^7.26.5"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -2002,15 +2013,17 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-typescript": {
-			"version": "7.23.6",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.23.6.tgz",
-			"integrity": "sha512-6cBG5mBvUu4VUD04OHKnYzbuHNP8huDsD3EDqqpIpsswTDoqHCjLoHb6+QgsV1WsT2nipRqCPgxD3LXnEO7XfA==",
+			"version": "7.27.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.27.0.tgz",
+			"integrity": "sha512-fRGGjO2UEGPjvEcyAZXRXAS8AfdaQoq7HnxAbJoAoW10B9xOKesmmndJv+Sym2a+9FHWZ9KbyyLCe9s0Sn5jtg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-annotate-as-pure": "^7.22.5",
-				"@babel/helper-create-class-features-plugin": "^7.23.6",
-				"@babel/helper-plugin-utils": "^7.22.5",
-				"@babel/plugin-syntax-typescript": "^7.23.3"
+				"@babel/helper-annotate-as-pure": "^7.25.9",
+				"@babel/helper-create-class-features-plugin": "^7.27.0",
+				"@babel/helper-plugin-utils": "^7.26.5",
+				"@babel/helper-skip-transparent-expression-wrappers": "^7.25.9",
+				"@babel/plugin-syntax-typescript": "^7.25.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -2020,12 +2033,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-unicode-escapes": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.23.3.tgz",
-			"integrity": "sha512-OMCUx/bU6ChE3r4+ZdylEqAjaQgHAgipgW8nsCfu5pGqDcFytVd91AwRvUJSBZDz0exPGgnjoqhgRYLRjFZc9Q==",
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.25.9.tgz",
+			"integrity": "sha512-s5EDrE6bW97LtxOcGj1Khcx5AaXwiMmi4toFWRDP9/y0Woo6pXC+iyPu/KuhKtfSrNFd7jJB+/fkOtZy6aIC6Q==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.22.5"
+				"@babel/helper-plugin-utils": "^7.25.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -2035,13 +2049,14 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-unicode-property-regex": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-7.23.3.tgz",
-			"integrity": "sha512-KcLIm+pDZkWZQAFJ9pdfmh89EwVfmNovFBcXko8szpBeF8z68kWIPeKlmSOkT9BXJxs2C0uk+5LxoxIv62MROA==",
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-7.25.9.tgz",
+			"integrity": "sha512-Jt2d8Ga+QwRluxRQ307Vlxa6dMrYEMZCgGxoPR8V52rxPyldHu3hdlHspxaqYmE7oID5+kB+UKUB/eWS+DkkWg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-create-regexp-features-plugin": "^7.22.15",
-				"@babel/helper-plugin-utils": "^7.22.5"
+				"@babel/helper-create-regexp-features-plugin": "^7.25.9",
+				"@babel/helper-plugin-utils": "^7.25.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -2051,13 +2066,14 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-unicode-regex": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.23.3.tgz",
-			"integrity": "sha512-wMHpNA4x2cIA32b/ci3AfwNgheiva2W0WUKWTK7vBHBhDKfPsc5cFGNWm69WBqpwd86u1qwZ9PWevKqm1A3yAw==",
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.25.9.tgz",
+			"integrity": "sha512-yoxstj7Rg9dlNn9UQxzk4fcNivwv4nUYz7fYXBaKxvw/lnmPuOm/ikoELygbYq68Bls3D/D+NBPHiLwZdZZ4HA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-create-regexp-features-plugin": "^7.22.15",
-				"@babel/helper-plugin-utils": "^7.22.5"
+				"@babel/helper-create-regexp-features-plugin": "^7.25.9",
+				"@babel/helper-plugin-utils": "^7.25.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -2067,13 +2083,14 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-unicode-sets-regex": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.23.3.tgz",
-			"integrity": "sha512-W7lliA/v9bNR83Qc3q1ip9CQMZ09CcHDbHfbLRDNuAhn1Mvkr1ZNF7hPmztMQvtTGVLJ9m8IZqWsTkXOml8dbw==",
+			"version": "7.25.9",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.25.9.tgz",
+			"integrity": "sha512-8BYqO3GeVNHtx69fdPshN3fnzUNLrWdHhk/icSwigksJGczKSizZ+Z6SBCxTs723Fr5VSNorTIK7a+R2tISvwQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-create-regexp-features-plugin": "^7.22.15",
-				"@babel/helper-plugin-utils": "^7.22.5"
+				"@babel/helper-create-regexp-features-plugin": "^7.25.9",
+				"@babel/helper-plugin-utils": "^7.25.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -2083,90 +2100,80 @@
 			}
 		},
 		"node_modules/@babel/preset-env": {
-			"version": "7.23.9",
-			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.23.9.tgz",
-			"integrity": "sha512-3kBGTNBBk9DQiPoXYS0g0BYlwTQYUTifqgKTjxUwEUkduRT2QOa0FPGBJ+NROQhGyYO5BuTJwGvBnqKDykac6A==",
+			"version": "7.26.9",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.26.9.tgz",
+			"integrity": "sha512-vX3qPGE8sEKEAZCWk05k3cpTAE3/nOYca++JA+Rd0z2NCNzabmYvEiSShKzm10zdquOIAVXsy2Ei/DTW34KlKQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/compat-data": "^7.23.5",
-				"@babel/helper-compilation-targets": "^7.23.6",
-				"@babel/helper-plugin-utils": "^7.22.5",
-				"@babel/helper-validator-option": "^7.23.5",
-				"@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.23.3",
-				"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.23.3",
-				"@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.23.7",
+				"@babel/compat-data": "^7.26.8",
+				"@babel/helper-compilation-targets": "^7.26.5",
+				"@babel/helper-plugin-utils": "^7.26.5",
+				"@babel/helper-validator-option": "^7.25.9",
+				"@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^7.25.9",
+				"@babel/plugin-bugfix-safari-class-field-initializer-scope": "^7.25.9",
+				"@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.25.9",
+				"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.25.9",
+				"@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.25.9",
 				"@babel/plugin-proposal-private-property-in-object": "7.21.0-placeholder-for-preset-env.2",
-				"@babel/plugin-syntax-async-generators": "^7.8.4",
-				"@babel/plugin-syntax-class-properties": "^7.12.13",
-				"@babel/plugin-syntax-class-static-block": "^7.14.5",
-				"@babel/plugin-syntax-dynamic-import": "^7.8.3",
-				"@babel/plugin-syntax-export-namespace-from": "^7.8.3",
-				"@babel/plugin-syntax-import-assertions": "^7.23.3",
-				"@babel/plugin-syntax-import-attributes": "^7.23.3",
-				"@babel/plugin-syntax-import-meta": "^7.10.4",
-				"@babel/plugin-syntax-json-strings": "^7.8.3",
-				"@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
-				"@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
-				"@babel/plugin-syntax-numeric-separator": "^7.10.4",
-				"@babel/plugin-syntax-object-rest-spread": "^7.8.3",
-				"@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
-				"@babel/plugin-syntax-optional-chaining": "^7.8.3",
-				"@babel/plugin-syntax-private-property-in-object": "^7.14.5",
-				"@babel/plugin-syntax-top-level-await": "^7.14.5",
+				"@babel/plugin-syntax-import-assertions": "^7.26.0",
+				"@babel/plugin-syntax-import-attributes": "^7.26.0",
 				"@babel/plugin-syntax-unicode-sets-regex": "^7.18.6",
-				"@babel/plugin-transform-arrow-functions": "^7.23.3",
-				"@babel/plugin-transform-async-generator-functions": "^7.23.9",
-				"@babel/plugin-transform-async-to-generator": "^7.23.3",
-				"@babel/plugin-transform-block-scoped-functions": "^7.23.3",
-				"@babel/plugin-transform-block-scoping": "^7.23.4",
-				"@babel/plugin-transform-class-properties": "^7.23.3",
-				"@babel/plugin-transform-class-static-block": "^7.23.4",
-				"@babel/plugin-transform-classes": "^7.23.8",
-				"@babel/plugin-transform-computed-properties": "^7.23.3",
-				"@babel/plugin-transform-destructuring": "^7.23.3",
-				"@babel/plugin-transform-dotall-regex": "^7.23.3",
-				"@babel/plugin-transform-duplicate-keys": "^7.23.3",
-				"@babel/plugin-transform-dynamic-import": "^7.23.4",
-				"@babel/plugin-transform-exponentiation-operator": "^7.23.3",
-				"@babel/plugin-transform-export-namespace-from": "^7.23.4",
-				"@babel/plugin-transform-for-of": "^7.23.6",
-				"@babel/plugin-transform-function-name": "^7.23.3",
-				"@babel/plugin-transform-json-strings": "^7.23.4",
-				"@babel/plugin-transform-literals": "^7.23.3",
-				"@babel/plugin-transform-logical-assignment-operators": "^7.23.4",
-				"@babel/plugin-transform-member-expression-literals": "^7.23.3",
-				"@babel/plugin-transform-modules-amd": "^7.23.3",
-				"@babel/plugin-transform-modules-commonjs": "^7.23.3",
-				"@babel/plugin-transform-modules-systemjs": "^7.23.9",
-				"@babel/plugin-transform-modules-umd": "^7.23.3",
-				"@babel/plugin-transform-named-capturing-groups-regex": "^7.22.5",
-				"@babel/plugin-transform-new-target": "^7.23.3",
-				"@babel/plugin-transform-nullish-coalescing-operator": "^7.23.4",
-				"@babel/plugin-transform-numeric-separator": "^7.23.4",
-				"@babel/plugin-transform-object-rest-spread": "^7.23.4",
-				"@babel/plugin-transform-object-super": "^7.23.3",
-				"@babel/plugin-transform-optional-catch-binding": "^7.23.4",
-				"@babel/plugin-transform-optional-chaining": "^7.23.4",
-				"@babel/plugin-transform-parameters": "^7.23.3",
-				"@babel/plugin-transform-private-methods": "^7.23.3",
-				"@babel/plugin-transform-private-property-in-object": "^7.23.4",
-				"@babel/plugin-transform-property-literals": "^7.23.3",
-				"@babel/plugin-transform-regenerator": "^7.23.3",
-				"@babel/plugin-transform-reserved-words": "^7.23.3",
-				"@babel/plugin-transform-shorthand-properties": "^7.23.3",
-				"@babel/plugin-transform-spread": "^7.23.3",
-				"@babel/plugin-transform-sticky-regex": "^7.23.3",
-				"@babel/plugin-transform-template-literals": "^7.23.3",
-				"@babel/plugin-transform-typeof-symbol": "^7.23.3",
-				"@babel/plugin-transform-unicode-escapes": "^7.23.3",
-				"@babel/plugin-transform-unicode-property-regex": "^7.23.3",
-				"@babel/plugin-transform-unicode-regex": "^7.23.3",
-				"@babel/plugin-transform-unicode-sets-regex": "^7.23.3",
+				"@babel/plugin-transform-arrow-functions": "^7.25.9",
+				"@babel/plugin-transform-async-generator-functions": "^7.26.8",
+				"@babel/plugin-transform-async-to-generator": "^7.25.9",
+				"@babel/plugin-transform-block-scoped-functions": "^7.26.5",
+				"@babel/plugin-transform-block-scoping": "^7.25.9",
+				"@babel/plugin-transform-class-properties": "^7.25.9",
+				"@babel/plugin-transform-class-static-block": "^7.26.0",
+				"@babel/plugin-transform-classes": "^7.25.9",
+				"@babel/plugin-transform-computed-properties": "^7.25.9",
+				"@babel/plugin-transform-destructuring": "^7.25.9",
+				"@babel/plugin-transform-dotall-regex": "^7.25.9",
+				"@babel/plugin-transform-duplicate-keys": "^7.25.9",
+				"@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^7.25.9",
+				"@babel/plugin-transform-dynamic-import": "^7.25.9",
+				"@babel/plugin-transform-exponentiation-operator": "^7.26.3",
+				"@babel/plugin-transform-export-namespace-from": "^7.25.9",
+				"@babel/plugin-transform-for-of": "^7.26.9",
+				"@babel/plugin-transform-function-name": "^7.25.9",
+				"@babel/plugin-transform-json-strings": "^7.25.9",
+				"@babel/plugin-transform-literals": "^7.25.9",
+				"@babel/plugin-transform-logical-assignment-operators": "^7.25.9",
+				"@babel/plugin-transform-member-expression-literals": "^7.25.9",
+				"@babel/plugin-transform-modules-amd": "^7.25.9",
+				"@babel/plugin-transform-modules-commonjs": "^7.26.3",
+				"@babel/plugin-transform-modules-systemjs": "^7.25.9",
+				"@babel/plugin-transform-modules-umd": "^7.25.9",
+				"@babel/plugin-transform-named-capturing-groups-regex": "^7.25.9",
+				"@babel/plugin-transform-new-target": "^7.25.9",
+				"@babel/plugin-transform-nullish-coalescing-operator": "^7.26.6",
+				"@babel/plugin-transform-numeric-separator": "^7.25.9",
+				"@babel/plugin-transform-object-rest-spread": "^7.25.9",
+				"@babel/plugin-transform-object-super": "^7.25.9",
+				"@babel/plugin-transform-optional-catch-binding": "^7.25.9",
+				"@babel/plugin-transform-optional-chaining": "^7.25.9",
+				"@babel/plugin-transform-parameters": "^7.25.9",
+				"@babel/plugin-transform-private-methods": "^7.25.9",
+				"@babel/plugin-transform-private-property-in-object": "^7.25.9",
+				"@babel/plugin-transform-property-literals": "^7.25.9",
+				"@babel/plugin-transform-regenerator": "^7.25.9",
+				"@babel/plugin-transform-regexp-modifiers": "^7.26.0",
+				"@babel/plugin-transform-reserved-words": "^7.25.9",
+				"@babel/plugin-transform-shorthand-properties": "^7.25.9",
+				"@babel/plugin-transform-spread": "^7.25.9",
+				"@babel/plugin-transform-sticky-regex": "^7.25.9",
+				"@babel/plugin-transform-template-literals": "^7.26.8",
+				"@babel/plugin-transform-typeof-symbol": "^7.26.7",
+				"@babel/plugin-transform-unicode-escapes": "^7.25.9",
+				"@babel/plugin-transform-unicode-property-regex": "^7.25.9",
+				"@babel/plugin-transform-unicode-regex": "^7.25.9",
+				"@babel/plugin-transform-unicode-sets-regex": "^7.25.9",
 				"@babel/preset-modules": "0.1.6-no-external-plugins",
-				"babel-plugin-polyfill-corejs2": "^0.4.8",
-				"babel-plugin-polyfill-corejs3": "^0.9.0",
-				"babel-plugin-polyfill-regenerator": "^0.5.5",
-				"core-js-compat": "^3.31.0",
+				"babel-plugin-polyfill-corejs2": "^0.4.10",
+				"babel-plugin-polyfill-corejs3": "^0.11.0",
+				"babel-plugin-polyfill-regenerator": "^0.6.1",
+				"core-js-compat": "^3.40.0",
 				"semver": "^6.3.1"
 			},
 			"engines": {
@@ -2181,6 +2188,7 @@
 			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
 			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
 			"dev": true,
+			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver.js"
 			}
@@ -2190,6 +2198,7 @@
 			"resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.6-no-external-plugins.tgz",
 			"integrity": "sha512-HrcgcIESLm9aIR842yhJ5RWan/gebQUJ6E/E5+rf0y9o6oj7w0Br+sWuL6kEQ/o/AdfvR1Je9jG18/gnpwjEyA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/types": "^7.4.4",
@@ -2200,17 +2209,18 @@
 			}
 		},
 		"node_modules/@babel/preset-react": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.23.3.tgz",
-			"integrity": "sha512-tbkHOS9axH6Ysf2OUEqoSZ6T3Fa2SrNH6WTWSPBboxKzdxNc9qOICeLXkNG0ZEwbQ1HY8liwOce4aN/Ceyuq6w==",
+			"version": "7.26.3",
+			"resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.26.3.tgz",
+			"integrity": "sha512-Nl03d6T9ky516DGK2YMxrTqvnpUW63TnJMOMonj+Zae0JiPC5BC9xPMSL6L8fiSpA5vP88qfygavVQvnLp+6Cw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.22.5",
-				"@babel/helper-validator-option": "^7.22.15",
-				"@babel/plugin-transform-react-display-name": "^7.23.3",
-				"@babel/plugin-transform-react-jsx": "^7.22.15",
-				"@babel/plugin-transform-react-jsx-development": "^7.22.5",
-				"@babel/plugin-transform-react-pure-annotations": "^7.23.3"
+				"@babel/helper-plugin-utils": "^7.25.9",
+				"@babel/helper-validator-option": "^7.25.9",
+				"@babel/plugin-transform-react-display-name": "^7.25.9",
+				"@babel/plugin-transform-react-jsx": "^7.25.9",
+				"@babel/plugin-transform-react-jsx-development": "^7.25.9",
+				"@babel/plugin-transform-react-pure-annotations": "^7.25.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -2220,16 +2230,17 @@
 			}
 		},
 		"node_modules/@babel/preset-typescript": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.23.3.tgz",
-			"integrity": "sha512-17oIGVlqz6CchO9RFYn5U6ZpWRZIngayYCtrPRSgANSwC2V1Jb+iP74nVxzzXJte8b8BYxrL1yY96xfhTBrNNQ==",
+			"version": "7.27.0",
+			"resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.27.0.tgz",
+			"integrity": "sha512-vxaPFfJtHhgeOVXRKuHpHPAOgymmy8V8I65T1q53R7GCZlefKeCaTyDs3zOPHTTbmquvNlQYC5klEvWsBAtrBQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.22.5",
-				"@babel/helper-validator-option": "^7.22.15",
-				"@babel/plugin-syntax-jsx": "^7.23.3",
-				"@babel/plugin-transform-modules-commonjs": "^7.23.3",
-				"@babel/plugin-transform-typescript": "^7.23.3"
+				"@babel/helper-plugin-utils": "^7.26.5",
+				"@babel/helper-validator-option": "^7.25.9",
+				"@babel/plugin-syntax-jsx": "^7.25.9",
+				"@babel/plugin-transform-modules-commonjs": "^7.26.3",
+				"@babel/plugin-transform-typescript": "^7.27.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -2237,12 +2248,6 @@
 			"peerDependencies": {
 				"@babel/core": "^7.0.0-0"
 			}
-		},
-		"node_modules/@babel/regjsgen": {
-			"version": "0.8.0",
-			"resolved": "https://registry.npmjs.org/@babel/regjsgen/-/regjsgen-0.8.0.tgz",
-			"integrity": "sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA==",
-			"dev": true
 		},
 		"node_modules/@babel/runtime": {
 			"version": "7.25.7",
@@ -2256,30 +2261,30 @@
 			}
 		},
 		"node_modules/@babel/template": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.9.tgz",
-			"integrity": "sha512-9DGttpmPvIxBb/2uwpVo3dqJ+O6RooAFOS+lB+xDqoE2PVCE8nfoHMdZLpfCQRLwvohzXISPZcgxt80xLfsuwg==",
+			"version": "7.27.0",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.0.tgz",
+			"integrity": "sha512-2ncevenBqXI6qRMukPlXwHKHchC7RyMuu4xv5JBXRfOGVcTy1mXCD12qrp7Jsoxll1EV3+9sE4GugBVRjT2jFA==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/code-frame": "^7.25.9",
-				"@babel/parser": "^7.25.9",
-				"@babel/types": "^7.25.9"
+				"@babel/code-frame": "^7.26.2",
+				"@babel/parser": "^7.27.0",
+				"@babel/types": "^7.27.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/traverse": {
-			"version": "7.26.4",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.4.tgz",
-			"integrity": "sha512-fH+b7Y4p3yqvApJALCPJcwb0/XaOSgtK4pzV6WVjPR5GLFQBRI7pfoX2V2iM48NXvX07NUxxm1Vw98YjqTcU5w==",
+			"version": "7.27.0",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.27.0.tgz",
+			"integrity": "sha512-19lYZFzYVQkkHkl4Cy4WrAVcqBkgvV2YM2TU3xG6DIwO7O3ecbDPfW3yM3bjAGcqcQHi+CCtjMR3dIEHxsd6bA==",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/code-frame": "^7.26.2",
-				"@babel/generator": "^7.26.3",
-				"@babel/parser": "^7.26.3",
-				"@babel/template": "^7.25.9",
-				"@babel/types": "^7.26.3",
+				"@babel/generator": "^7.27.0",
+				"@babel/parser": "^7.27.0",
+				"@babel/template": "^7.27.0",
+				"@babel/types": "^7.27.0",
 				"debug": "^4.3.1",
 				"globals": "^11.1.0"
 			},
@@ -2297,9 +2302,9 @@
 			}
 		},
 		"node_modules/@babel/types": {
-			"version": "7.26.3",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.3.tgz",
-			"integrity": "sha512-vN5p+1kl59GVKMvTHt55NzzmYVxprfJD+ql7U9NFIfKCBkYE55LYtS+WtPlaYOyzydrKI8Nezd+aZextrd+FMA==",
+			"version": "7.27.0",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.0.tgz",
+			"integrity": "sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/helper-string-parser": "^7.25.9",
@@ -4482,6 +4487,7 @@
 			"resolved": "https://registry.npmjs.org/@nicolo-ribaudo/chokidar-2/-/chokidar-2-2.1.8-no-fsevents.3.tgz",
 			"integrity": "sha512-s88O1aVtXftvp5bCPB7WnmXc5IwOZZ7YPuwNPt+GtOOXpPvad1LfbmjYv+qII7zP6RU2QGnqve27dnLycEnyEQ==",
 			"dev": true,
+			"license": "MIT",
 			"optional": true
 		},
 		"node_modules/@nodelib/fs.scandir": {
@@ -9914,13 +9920,14 @@
 			}
 		},
 		"node_modules/babel-plugin-polyfill-corejs2": {
-			"version": "0.4.8",
-			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.8.tgz",
-			"integrity": "sha512-OtIuQfafSzpo/LhnJaykc0R/MMnuLSSVjVYy9mHArIZ9qTCSZ6TpWCuEKZYVoN//t8HqBNScHrOtCrIK5IaGLg==",
+			"version": "0.4.13",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.13.tgz",
+			"integrity": "sha512-3sX/eOms8kd3q2KZ6DAhKPc0dgm525Gqq5NtWKZ7QYYZEv57OQ54KtblzJzH1lQF/eQxO8KjWGIK9IPUJNus5g==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@babel/compat-data": "^7.22.6",
-				"@babel/helper-define-polyfill-provider": "^0.5.0",
+				"@babel/helper-define-polyfill-provider": "^0.6.4",
 				"semver": "^6.3.1"
 			},
 			"peerDependencies": {
@@ -9932,30 +9939,33 @@
 			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
 			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
 			"dev": true,
+			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver.js"
 			}
 		},
 		"node_modules/babel-plugin-polyfill-corejs3": {
-			"version": "0.9.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.9.0.tgz",
-			"integrity": "sha512-7nZPG1uzK2Ymhy/NbaOWTg3uibM2BmGASS4vHS4szRZAIR8R6GwA/xAujpdrXU5iyklrimWnLWU+BLF9suPTqg==",
+			"version": "0.11.1",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.11.1.tgz",
+			"integrity": "sha512-yGCqvBT4rwMczo28xkH/noxJ6MZ4nJfkVYdoDaC/utLtWrXxv27HVrzAeSbqR8SxDsp46n0YF47EbHoixy6rXQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-define-polyfill-provider": "^0.5.0",
-				"core-js-compat": "^3.34.0"
+				"@babel/helper-define-polyfill-provider": "^0.6.3",
+				"core-js-compat": "^3.40.0"
 			},
 			"peerDependencies": {
 				"@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
 			}
 		},
 		"node_modules/babel-plugin-polyfill-regenerator": {
-			"version": "0.5.5",
-			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.5.5.tgz",
-			"integrity": "sha512-OJGYZlhLqBh2DDHeqAxWB1XIvr49CxiJ2gIt61/PU55CQK4Z58OzMqjDe1zwQdQk+rBYsRc+1rJmdajM3gimHg==",
+			"version": "0.6.4",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.4.tgz",
+			"integrity": "sha512-7gD3pRadPrbjhjLyxebmx/WrFYcuSjZ0XbdUujQMZ/fcE9oeewk2U/7PCvez84UeuK3oSjmPZ0Ch0dlupQvGzw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-define-polyfill-provider": "^0.5.0"
+				"@babel/helper-define-polyfill-provider": "^0.6.4"
 			},
 			"peerDependencies": {
 				"@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
@@ -10245,9 +10255,9 @@
 			}
 		},
 		"node_modules/browserslist": {
-			"version": "4.24.3",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.3.tgz",
-			"integrity": "sha512-1CPmv8iobE2fyRMV97dAcMVegvvWKxmq94hkLiAkUGwKVTyDLw33K+ZxiFrREKmmps4rIw6grcCFCnTMSZ/YiA==",
+			"version": "4.24.4",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.4.tgz",
+			"integrity": "sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -10755,15 +10765,10 @@
 			"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
 		},
 		"node_modules/chokidar": {
-			"version": "3.5.3",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
-			"integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://paulmillr.com/funding/"
-				}
-			],
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+			"integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+			"license": "MIT",
 			"dependencies": {
 				"anymatch": "~3.1.2",
 				"braces": "~3.0.2",
@@ -10775,6 +10780,9 @@
 			},
 			"engines": {
 				"node": ">= 8.10.0"
+			},
+			"funding": {
+				"url": "https://paulmillr.com/funding/"
 			},
 			"optionalDependencies": {
 				"fsevents": "~2.3.2"
@@ -11400,12 +11408,13 @@
 			"hasInstallScript": true
 		},
 		"node_modules/core-js-compat": {
-			"version": "3.35.1",
-			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.35.1.tgz",
-			"integrity": "sha512-sftHa5qUJY3rs9Zht1WEnmkvXputCyDBczPnr7QDgL8n3qrF3CMXY4VPSYtOLLiOUJcah2WNXREd48iOl6mQIw==",
+			"version": "3.42.0",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.42.0.tgz",
+			"integrity": "sha512-bQasjMfyDGyaeWKBIu33lHh9qlSR0MFE/Nmc6nMjf/iU9b3rSMdAYz1Baxrv4lPdGUsTqZudHA4jIGSJy0SWZQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"browserslist": "^4.22.2"
+				"browserslist": "^4.24.4"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -14656,7 +14665,8 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
 			"integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/fs-temp": {
 			"version": "1.2.1",
@@ -18538,7 +18548,8 @@
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
 			"integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/lodash.defaults": {
 			"version": "4.2.0",
@@ -18597,7 +18608,8 @@
 			"version": "4.6.2",
 			"resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
 			"integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/lodash.once": {
 			"version": "4.1.1",
@@ -22551,13 +22563,15 @@
 			"version": "1.4.2",
 			"resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
 			"integrity": "sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/regenerate-unicode-properties": {
-			"version": "10.1.1",
-			"resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-10.1.1.tgz",
-			"integrity": "sha512-X007RyZLsCJVVrjgEFVpLUTZwyOZk3oiL75ZcuYjlIWd6rNJtOjkBwQc5AsRrpbKVkxN6sklw/k/9m2jJYOf8Q==",
+			"version": "10.2.0",
+			"resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-10.2.0.tgz",
+			"integrity": "sha512-DqHn3DwbmmPVzeKj9woBadqmXxLvQoQIwu7nopMc72ztvxVmVk2SBhSnx67zuye5TP+lJsb/TBQsjLKhnDf3MA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"regenerate": "^1.4.2"
 			},
@@ -22575,6 +22589,7 @@
 			"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.15.2.tgz",
 			"integrity": "sha512-hfMp2BoF0qOk3uc5V20ALGDS2ddjQaLrdl7xrGXvAIow7qeWRM2VA2HuCHkUKk9slq3VwEwLNK3DFBqDfPGYtg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@babel/runtime": "^7.8.4"
 			}
@@ -22601,15 +22616,16 @@
 			}
 		},
 		"node_modules/regexpu-core": {
-			"version": "5.3.2",
-			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-5.3.2.tgz",
-			"integrity": "sha512-RAM5FlZz+Lhmo7db9L298p2vHP5ZywrVXmVXpmAD9GuL5MPH6t9ROw1iA/wfHkQ76Qe7AaPF0nGuim96/IrQMQ==",
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-6.2.0.tgz",
+			"integrity": "sha512-H66BPQMrv+V16t8xtmq+UC0CBpiTBA60V8ibS1QVReIp8T1z8hwFxqcGzm9K6lgsN7sB5edVH8a+ze6Fqm4weA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
-				"@babel/regjsgen": "^0.8.0",
 				"regenerate": "^1.4.2",
-				"regenerate-unicode-properties": "^10.1.0",
-				"regjsparser": "^0.9.1",
+				"regenerate-unicode-properties": "^10.2.0",
+				"regjsgen": "^0.8.0",
+				"regjsparser": "^0.12.0",
 				"unicode-match-property-ecmascript": "^2.0.0",
 				"unicode-match-property-value-ecmascript": "^2.1.0"
 			},
@@ -22617,25 +22633,37 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/regjsparser": {
-			"version": "0.9.1",
-			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.9.1.tgz",
-			"integrity": "sha512-dQUtn90WanSNl+7mQKcXAgZxvUe7Z0SqXlgzv0za4LwiUhyzBC58yQO3liFoUgu8GiJVInAhJjkj1N0EtQ5nkQ==",
+		"node_modules/regjsgen": {
+			"version": "0.8.0",
+			"resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.8.0.tgz",
+			"integrity": "sha512-RvwtGe3d7LvWiDQXeQw8p5asZUmfU1G/l6WbUXeHta7Y2PEIvBTwH6E2EfmYUK8pxcxEdEmaomqyp0vZZ7C+3Q==",
 			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/regjsparser": {
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.12.0.tgz",
+			"integrity": "sha512-cnE+y8bz4NhMjISKbgeVJtqNbtf5QpjZP+Bslo+UqkIt9QPnX9q095eiRRASJG1/tz6dlNr6Z5NsBiWYokp6EQ==",
+			"dev": true,
+			"license": "BSD-2-Clause",
 			"dependencies": {
-				"jsesc": "~0.5.0"
+				"jsesc": "~3.0.2"
 			},
 			"bin": {
 				"regjsparser": "bin/parser"
 			}
 		},
 		"node_modules/regjsparser/node_modules/jsesc": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-			"integrity": "sha512-uZz5UnB7u4T9LvwmFqXii7pZSouaRPorGs5who1Ip7VO0wxanFvBL7GkM6dTHlgX+jhBApRetaWpnDabOeTcnA==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
+			"integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==",
 			"dev": true,
+			"license": "MIT",
 			"bin": {
 				"jsesc": "bin/jsesc"
+			},
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/relateurl": {
@@ -25362,10 +25390,11 @@
 			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
 		},
 		"node_modules/unicode-canonical-property-names-ecmascript": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.0.tgz",
-			"integrity": "sha512-yY5PpDlfVIU5+y/BSCxAJRBIS1Zc2dDG3Ujq+sR0U+JjUevW2JhocOF+soROYDSaAezOzOKuyyixhD6mBknSmQ==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.1.tgz",
+			"integrity": "sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=4"
 			}
@@ -25375,6 +25404,7 @@
 			"resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-2.0.0.tgz",
 			"integrity": "sha512-5kaZCrbp5mmbz5ulBkDkbY0SsPOjKqVS35VpL9ulMPfSl0J0Xsm+9Evphv9CoIZFwre7aJoa94AY6seMKGVN5Q==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"unicode-canonical-property-names-ecmascript": "^2.0.0",
 				"unicode-property-aliases-ecmascript": "^2.0.0"
@@ -25384,10 +25414,11 @@
 			}
 		},
 		"node_modules/unicode-match-property-value-ecmascript": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-2.1.0.tgz",
-			"integrity": "sha512-qxkjQt6qjg/mYscYMC0XKRn3Rh0wFPlfxB0xkt9CfyTvpX1Ra0+rAmdX2QyAobptSEvuy4RtpPRui6XkV+8wjA==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-2.2.0.tgz",
+			"integrity": "sha512-4IehN3V/+kkr5YeSSDDQG8QLqO26XpL2XP3GQtqwlT/QYSECAwFztxVHjlbh0+gjJ3XmNLS0zDsbgs9jWKExLg==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=4"
 			}
@@ -25397,6 +25428,7 @@
 			"resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.1.0.tgz",
 			"integrity": "sha512-6t3foTQI9qne+OZoVQB/8x8rk2k1eVy1gRXhV3oFQ5T6R1dqQ1xtin3XqSlx3+ATBkliTaR/hHyJBm+LVPNM8w==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=4"
 			}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-81

## Proposed Changes

I propose to update wp-babel-makepot to fix security issues.

Note that the package version was not bumped after upgrading its dependencies. I removed it and installed again to install the same version but with updated dependencies.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Test if translation files are correctly generated:

```
npm run make-pot   
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
