### PR TITLE
Fix assorted CLI CfT issues

### DIFF
--- a/cli/commands/preview/create.ts
+++ b/cli/commands/preview/create.ts
@@ -22,7 +22,7 @@ export async function runCommand( siteFolder: string ): Promise< void > {
 		validateSiteFolder( siteFolder );
 		await validateSiteSize( siteFolder );
 		const token = await getAuthToken();
-		logger.reportSuccess( __( 'Validation successful' ) );
+		logger.reportSuccess( __( 'Validation successful' ), true );
 
 		logger.reportStart( LoggerAction.ARCHIVE, __( 'Creating archive...' ) );
 		await createArchive( siteFolder, archivePath );

--- a/cli/commands/preview/delete.ts
+++ b/cli/commands/preview/delete.ts
@@ -23,7 +23,7 @@ export async function runCommand( host: string ): Promise< void > {
 				)
 			);
 		}
-		logger.reportSuccess( __( 'Validation successful' ) );
+		logger.reportSuccess( __( 'Validation successful' ), true );
 
 		logger.reportStart( LoggerAction.DELETE, __( 'Deleting...' ) );
 		await deleteSnapshot( snapshotToDelete.atomicSiteId, token.accessToken );

--- a/cli/commands/preview/list.ts
+++ b/cli/commands/preview/list.ts
@@ -5,6 +5,7 @@ import {
 	getSnapshotCliJson,
 	getSnapshotCliTable,
 	getSnapshotsFromAppdata,
+	isSnapshotExpired,
 } from 'cli/lib/snapshots';
 import { validateSiteFolder } from 'cli/lib/validation';
 import { Logger, LoggerError } from 'cli/logger';
@@ -17,7 +18,7 @@ export async function runCommand( siteFolder: string, format: 'table' | 'json' )
 		logger.reportStart( LoggerAction.VALIDATE, __( 'Validating...' ) );
 		validateSiteFolder( siteFolder );
 		const token = await getAuthToken();
-		logger.reportSuccess( __( 'Validation successful' ) );
+		logger.reportSuccess( __( 'Validation successful' ), true );
 
 		logger.reportStart( LoggerAction.LOAD, __( 'Loading preview sites...' ) );
 		const snapshots = await getSnapshotsFromAppdata( token.id, siteFolder );
@@ -27,12 +28,23 @@ export async function runCommand( siteFolder: string, format: 'table' | 'json' )
 			return;
 		}
 
-		logger.reportSuccess(
-			sprintf(
-				_n( 'Found %d preview site', 'Found %d preview sites', snapshots.length ),
-				snapshots.length
-			)
+		const expiredSnapshots = snapshots.filter( isSnapshotExpired );
+		const snapshotsMessage = sprintf(
+			_n( 'Found %d preview site', 'Found %d preview sites', snapshots.length ),
+			snapshots.length
 		);
+
+		if ( expiredSnapshots.length > 0 ) {
+			const expiredSnapshotsMessage = sprintf(
+				/* translators: This string is appended to "Found %d preview sites" if there are expired preview sites */
+				_n( '(%d expired)', '(%d expired)', expiredSnapshots.length ),
+				expiredSnapshots.length
+			);
+
+			logger.reportSuccess( `${ snapshotsMessage } ${ expiredSnapshotsMessage }` );
+		} else {
+			logger.reportSuccess( snapshotsMessage );
+		}
 
 		if ( format === 'table' ) {
 			const table = getSnapshotCliTable( snapshots );

--- a/cli/commands/preview/tests/create.test.ts
+++ b/cli/commands/preview/tests/create.test.ts
@@ -74,7 +74,7 @@ describe( 'Preview Create Command', () => {
 
 		expect( validateSiteFolder ).toHaveBeenCalledWith( mockFolder );
 		expect( mockLogger.reportStart.mock.calls[ 0 ] ).toEqual( [ 'validate', 'Validating...' ] );
-		expect( mockLogger.reportSuccess.mock.calls[ 0 ] ).toEqual( [ 'Validation successful' ] );
+		expect( mockLogger.reportSuccess.mock.calls[ 0 ] ).toEqual( [ 'Validation successful', true ] );
 
 		expect( createArchive ).toHaveBeenCalledWith( mockFolder, mockArchivePath );
 		expect( mockLogger.reportStart.mock.calls[ 1 ] ).toEqual( [

--- a/cli/commands/preview/tests/delete.test.ts
+++ b/cli/commands/preview/tests/delete.test.ts
@@ -60,7 +60,7 @@ describe( 'Preview Delete Command', () => {
 		expect( deleteSnapshotFromAppdata ).toHaveBeenCalledWith( mockSiteUrl );
 
 		expect( mockLogger.reportStart.mock.calls[ 0 ] ).toEqual( [ 'validate', 'Validating...' ] );
-		expect( mockLogger.reportSuccess.mock.calls[ 0 ] ).toEqual( [ 'Validation successful' ] );
+		expect( mockLogger.reportSuccess.mock.calls[ 0 ] ).toEqual( [ 'Validation successful', true ] );
 		expect( mockLogger.reportStart.mock.calls[ 1 ] ).toEqual( [ 'delete', 'Deleting...' ] );
 		expect( mockLogger.reportSuccess.mock.calls[ 1 ] ).toEqual( [ 'Deletion successful' ] );
 	} );

--- a/cli/commands/preview/tests/list.test.ts
+++ b/cli/commands/preview/tests/list.test.ts
@@ -66,7 +66,7 @@ describe( 'Preview List Command', () => {
 		expect( validateSiteFolder ).toHaveBeenCalledWith( mockFolder );
 		expect( getSnapshotsFromAppdata ).toHaveBeenCalledWith( mockAuthToken.id, mockFolder );
 		expect( mockLogger.reportStart.mock.calls[ 0 ] ).toEqual( [ 'validate', 'Validating...' ] );
-		expect( mockLogger.reportSuccess.mock.calls[ 0 ] ).toEqual( [ 'Validation successful' ] );
+		expect( mockLogger.reportSuccess.mock.calls[ 0 ] ).toEqual( [ 'Validation successful', true ] );
 		expect( mockLogger.reportStart.mock.calls[ 1 ] ).toEqual( [
 			'load',
 			'Loading preview sites...',
@@ -92,7 +92,7 @@ describe( 'Preview List Command', () => {
 		await runCommand( mockFolder, 'table' );
 
 		expect( mockLogger.reportStart.mock.calls[ 0 ] ).toEqual( [ 'validate', 'Validating...' ] );
-		expect( mockLogger.reportSuccess.mock.calls[ 0 ] ).toEqual( [ 'Validation successful' ] );
+		expect( mockLogger.reportSuccess.mock.calls[ 0 ] ).toEqual( [ 'Validation successful', true ] );
 		expect( mockLogger.reportStart.mock.calls[ 1 ] ).toEqual( [
 			'load',
 			'Loading preview sites...',

--- a/cli/commands/preview/tests/update.test.ts
+++ b/cli/commands/preview/tests/update.test.ts
@@ -83,7 +83,7 @@ describe( 'Preview Update Command', () => {
 
 		expect( validateSiteFolder ).toHaveBeenCalledWith( mockFolder );
 		expect( mockLogger.reportStart.mock.calls[ 0 ] ).toEqual( [ 'validate', 'Validating...' ] );
-		expect( mockLogger.reportSuccess.mock.calls[ 0 ] ).toEqual( [ 'Validation successful' ] );
+		expect( mockLogger.reportSuccess.mock.calls[ 0 ] ).toEqual( [ 'Validation successful', true ] );
 
 		expect( createArchive ).toHaveBeenCalledWith( mockFolder, mockArchivePath );
 		expect( mockLogger.reportStart.mock.calls[ 1 ] ).toEqual( [

--- a/cli/commands/preview/update.ts
+++ b/cli/commands/preview/update.ts
@@ -68,7 +68,7 @@ export async function runCommand(
 			throw new LoggerError( __( 'Cannot update an expired preview site.' ) );
 		}
 
-		logger.reportSuccess( __( 'Validation successful' ) );
+		logger.reportSuccess( __( 'Validation successful' ), true );
 
 		logger.reportStart( LoggerAction.ARCHIVE, __( 'Creating archive...' ) );
 		await createArchive( siteFolder, archivePath );

--- a/cli/lib/appdata.ts
+++ b/cli/lib/appdata.ts
@@ -20,9 +20,9 @@ const siteSchema = z
 
 const userDataSchema = z
 	.object( {
-		newSites: z.array( siteSchema ).optional(),
-		sites: z.array( siteSchema ).optional(),
-		snapshots: z.array( snapshotSchema ).optional(),
+		newSites: z.array( siteSchema ).default( () => [] ),
+		sites: z.array( siteSchema ).default( () => [] ),
+		snapshots: z.array( snapshotSchema ).default( () => [] ),
 		locale: z.string().optional(),
 		authToken: z
 			.object( {
@@ -66,9 +66,7 @@ export async function readAppdata(): Promise< UserData > {
 	try {
 		const fileContent = await readFile( appDataPath, { encoding: 'utf8' } );
 		const userData = JSON.parse( fileContent );
-		const result = userDataSchema.parse( userData );
-
-		return result;
+		return userDataSchema.parse( userData );
 	} catch ( error ) {
 		if ( error instanceof LoggerError ) {
 			throw error;
@@ -137,9 +135,9 @@ export async function getSiteByFolder(
 	siteFolder: string
 ): Promise< z.infer< typeof siteSchema > > {
 	const userData = await readAppdata();
-	const sites = userData.sites ?? [];
-	const newSites = userData.newSites ?? [];
-	const site = [ ...sites, ...newSites ].find( ( site ) => site.path === siteFolder );
+	const site = [ ...userData.sites, ...userData.newSites ].find(
+		( site ) => site.path === siteFolder
+	);
 
 	if ( ! site ) {
 		throw new LoggerError( __( 'The specified folder is not added to Studio.' ) );

--- a/cli/lib/snapshots.ts
+++ b/cli/lib/snapshots.ts
@@ -59,7 +59,7 @@ export async function getSnapshotsFromAppdata(
 	siteFolder?: string
 ): Promise< Snapshot[] > {
 	const userData = await readAppdata();
-	let snapshots = userData.snapshots ?? [];
+	let snapshots = userData.snapshots;
 	snapshots = snapshots.filter( ( snapshot ) => snapshot.userId === userId );
 
 	if ( siteFolder ) {
@@ -76,10 +76,6 @@ export async function updateSnapshotInAppdata(
 ): Promise< Snapshot > {
 	const site = await getOrCreateSiteByFolder( siteFolder );
 	const userData = await readAppdata();
-	if ( ! userData.snapshots ) {
-		userData.snapshots = [];
-	}
-
 	const snapshot = userData.snapshots.find( ( s ) => s.atomicSiteId === atomicSiteId );
 	if ( ! snapshot ) {
 		throw new LoggerError( __( 'Failed to find existing preview site in appdata' ) );
@@ -115,10 +111,6 @@ export async function saveSnapshotToAppdata(
 	const userData = await readAppdata();
 	const authToken = await getAuthToken();
 
-	if ( ! userData.snapshots ) {
-		userData.snapshots = [];
-	}
-
 	const nextSequenceNumber = getNextSequenceNumber( site.id, userData.snapshots, authToken.id );
 	const snapshot: Snapshot = {
 		url: previewUrl,
@@ -142,9 +134,6 @@ export async function saveSnapshotToAppdata(
 
 export const deleteSnapshotFromAppdata = withLock( async ( snapshotUrl: string ) => {
 	const userData = await readAppdata();
-	if ( ! userData.snapshots ) {
-		return;
-	}
 	const snapshotIndex = userData.snapshots.findIndex( ( s ) => s.url === snapshotUrl );
 	if ( snapshotIndex === -1 ) {
 		return;
@@ -152,6 +141,12 @@ export const deleteSnapshotFromAppdata = withLock( async ( snapshotUrl: string )
 	userData.snapshots.splice( snapshotIndex, 1 );
 	await saveAppdata( userData );
 } );
+
+export function isSnapshotExpired( snapshot: Snapshot ) {
+	const now = new Date();
+	const endDate = addDays( snapshot.date, DEMO_SITE_EXPIRATION_DAYS );
+	return endDate < now;
+}
 
 function formatDurationUntilExpiry( lastUpdatedAt: number ) {
 	const now = new Date();

--- a/cli/lib/tests/appdata.test.ts
+++ b/cli/lib/tests/appdata.test.ts
@@ -47,6 +47,7 @@ describe( 'Appdata Module', () => {
 		it( 'should return parsed appdata if it exists and is valid', async () => {
 			const mockUserData = {
 				version: 1,
+				newSites: [],
 				sites: [],
 				snapshots: [
 					{
@@ -82,6 +83,7 @@ describe( 'Appdata Module', () => {
 		it( 'should save the userData to the appdata file', async () => {
 			const mockUserData = {
 				version: 1,
+				newSites: [],
 				sites: [],
 				snapshots: [],
 			};
@@ -98,6 +100,7 @@ describe( 'Appdata Module', () => {
 		it( 'should throw LoggerError if there is an error saving the file', async () => {
 			const mockUserData = {
 				version: 1,
+				newSites: [],
 				sites: [],
 				snapshots: [],
 			};
@@ -109,6 +112,7 @@ describe( 'Appdata Module', () => {
 
 		it( 'should add version 1 if version is not provided', async () => {
 			const mockUserData = {
+				newSites: [],
 				sites: [],
 				snapshots: [],
 			};

--- a/cli/logger.ts
+++ b/cli/logger.ts
@@ -25,11 +25,10 @@ export class LoggerError extends Error {
 
 export class Logger< T extends string > {
 	private spinner: Ora;
-	private currentAction: T | 'keyValuePair' | null;
+	private currentAction: T | 'keyValuePair' | null = null;
 
 	constructor() {
 		this.spinner = ora();
-		this.currentAction = null;
 	}
 
 	public reportStart( action: T, message: string ) {
@@ -51,9 +50,11 @@ export class Logger< T extends string > {
 		this.spinner.text = message;
 	}
 
-	public reportSuccess( message: string ) {
+	public reportSuccess( message: string, shouldClearSpinner = false ) {
 		if ( process.send ) {
 			process.send( { action: this.currentAction, status: 'success', message } );
+		} else if ( shouldClearSpinner ) {
+			this.spinner.clear();
 		} else {
 			this.spinner.succeed( message );
 		}

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
 				"wpcom": "^5.4.2",
 				"yargs": "17.7.2",
 				"yauzl": "^3.2.0",
-				"zod": "^3.24.2"
+				"zod": "^3.24.3"
 			},
 			"devDependencies": {
 				"@automattic/color-studio": "^2.5.0",
@@ -26983,10 +26983,9 @@
 			}
 		},
 		"node_modules/zod": {
-			"version": "3.24.2",
-			"resolved": "https://registry.npmjs.org/zod/-/zod-3.24.2.tgz",
-			"integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==",
-			"license": "MIT",
+			"version": "3.24.3",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-3.24.3.tgz",
+			"integrity": "sha512-HhY1oqzWCQWuUqvBFnsyrtZRhyPeR7SUGv+C4+MsisMuVfSPx8HpwWqH8tRahSlt6M3PiFAcoeFhZAqIXTxoSg==",
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
 			}

--- a/package.json
+++ b/package.json
@@ -163,7 +163,7 @@
 		"wpcom": "^5.4.2",
 		"yargs": "17.7.2",
 		"yauzl": "^3.2.0",
-		"zod": "^3.24.2"
+		"zod": "^3.24.3"
 	},
 	"optionalDependencies": {
 		"appdmg": "^0.6.6"


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-434
- Fixes STU-433

## Proposed Changes

- Don't persist `Validation successful` spinner message
- Display expired count in `preview list` command output
- Use default values for `newSites`, `sites`, and `snapshots` in `userDataSchema` to simplify code
- Update zod to newest patch version

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Run `npm run cli:build`
2. Run `node dist/cli/main.js preview list --path PATH` where `PATH` is the path to a Studio site with more than one preview site where at least one preview site is expired
3. Ensure that no `Validation successful` message is persisted in the terminal
4. Ensure that the output includes `(N expired)`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
