### PR TITLE
Make `preview update --overwrite` command support adding new sites

### DIFF
--- a/cli/commands/preview/tests/update.test.ts
+++ b/cli/commands/preview/tests/update.test.ts
@@ -2,7 +2,7 @@ import os from 'os';
 import path from 'path';
 import { DEMO_SITE_EXPIRATION_DAYS } from 'common/constants';
 import { uploadArchive, waitForSiteReady } from 'cli/lib/api';
-import { getAuthToken, getSiteByFolder } from 'cli/lib/appdata';
+import { getAuthToken, getOrCreateSiteByFolder, getSiteByFolder } from 'cli/lib/appdata';
 import { createArchive, cleanup } from 'cli/lib/archive';
 import { updateSnapshotInAppdata, getSnapshotsFromAppdata } from 'cli/lib/snapshots';
 import { validateSiteFolder } from 'cli/lib/validation';
@@ -12,6 +12,7 @@ jest.mock( 'cli/lib/appdata', () => ( {
 	getAppdataDirectory: jest.fn().mockReturnValue( '/test/appdata' ),
 	getAuthToken: jest.fn(),
 	getSiteByFolder: jest.fn(),
+	getOrCreateSiteByFolder: jest.fn(),
 } ) );
 jest.mock( 'cli/lib/validation' );
 jest.mock( 'cli/lib/archive' );
@@ -262,7 +263,7 @@ describe( 'Preview Update Command', () => {
 
 	it( 'should allow update if overwrite flag is set even if folder does not match', async () => {
 		const { runCommand } = await import( '../update' );
-		( getSiteByFolder as jest.Mock ).mockResolvedValueOnce( {
+		( getOrCreateSiteByFolder as jest.Mock ).mockResolvedValueOnce( {
 			id: 'different-id',
 			path: '/other/path',
 			name: 'Other Site',

--- a/cli/commands/preview/update.ts
+++ b/cli/commands/preview/update.ts
@@ -6,7 +6,7 @@ import { PreviewCommandLoggerAction as LoggerAction } from 'common/logger-action
 import { Snapshot } from 'common/types/snapshot';
 import { addDays } from 'date-fns';
 import { uploadArchive, waitForSiteReady } from 'cli/lib/api';
-import { getAuthToken, getOrCreateSiteByFolder } from 'cli/lib/appdata';
+import { getAuthToken, getOrCreateSiteByFolder, getSiteByFolder } from 'cli/lib/appdata';
 import { cleanup, createArchive } from 'cli/lib/archive';
 import { getSnapshotsFromAppdata, updateSnapshotInAppdata } from 'cli/lib/snapshots';
 import { normalizeHostname } from 'cli/lib/utils';
@@ -14,12 +14,22 @@ import { validateSiteFolder } from 'cli/lib/validation';
 import { Logger, LoggerError } from 'cli/logger';
 import { StudioArgv } from 'cli/types';
 
-function getSnapshotToUpdate(
+async function getSnapshotToUpdate(
 	snapshots: Snapshot[],
 	host: string,
-	currentSiteId: string,
+	siteFolder: string,
 	overwrite: boolean
 ) {
+	let currentSiteId: string;
+
+	if ( overwrite ) {
+		const site = await getOrCreateSiteByFolder( siteFolder );
+		currentSiteId = site.id;
+	} else {
+		const site = await getSiteByFolder( siteFolder );
+		currentSiteId = site.id;
+	}
+
 	const snapshotToUpdate = snapshots.find( ( s ) => s.url === host );
 	if ( ! snapshotToUpdate ) {
 		throw new LoggerError( 'Preview site not found' );
@@ -31,12 +41,6 @@ function getSnapshotToUpdate(
 				'The specified folder does not match the original site for this preview. If you want to overwrite, run the command with --overwrite.'
 			)
 		);
-	}
-
-	const now = new Date();
-	const endDate = addDays( snapshotToUpdate.date, DEMO_SITE_EXPIRATION_DAYS );
-	if ( endDate < now ) {
-		throw new LoggerError( __( 'Cannot update an expired preview site.' ) );
 	}
 
 	return snapshotToUpdate;
@@ -58,9 +62,7 @@ export async function runCommand(
 		validateSiteFolder( siteFolder );
 		const token = await getAuthToken();
 		const snapshots = await getSnapshotsFromAppdata( token.id );
-		const { id: currentSiteId } = await getOrCreateSiteByFolder( siteFolder );
-
-		const snapshotToUpdate = getSnapshotToUpdate( snapshots, host, currentSiteId, overwrite );
+		const snapshotToUpdate = await getSnapshotToUpdate( snapshots, host, siteFolder, overwrite );
 
 		const now = new Date();
 		const endDate = addDays( snapshotToUpdate.date, DEMO_SITE_EXPIRATION_DAYS );

--- a/cli/commands/preview/update.ts
+++ b/cli/commands/preview/update.ts
@@ -6,7 +6,7 @@ import { PreviewCommandLoggerAction as LoggerAction } from 'common/logger-action
 import { Snapshot } from 'common/types/snapshot';
 import { addDays } from 'date-fns';
 import { uploadArchive, waitForSiteReady } from 'cli/lib/api';
-import { getAuthToken, getSiteByFolder } from 'cli/lib/appdata';
+import { getAuthToken, getOrCreateSiteByFolder } from 'cli/lib/appdata';
 import { cleanup, createArchive } from 'cli/lib/archive';
 import { getSnapshotsFromAppdata, updateSnapshotInAppdata } from 'cli/lib/snapshots';
 import { normalizeHostname } from 'cli/lib/utils';
@@ -58,7 +58,7 @@ export async function runCommand(
 		validateSiteFolder( siteFolder );
 		const token = await getAuthToken();
 		const snapshots = await getSnapshotsFromAppdata( token.id );
-		const { id: currentSiteId } = await getSiteByFolder( siteFolder );
+		const { id: currentSiteId } = await getOrCreateSiteByFolder( siteFolder );
 
 		const snapshotToUpdate = getSnapshotToUpdate( snapshots, host, currentSiteId, overwrite );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-437

## Proposed Changes

The `preview create` command supports automatically adding the current folder as a new site to Studio (see https://github.com/Automattic/studio/pull/1272). This PR makes it so the `preview update` command supports the same thing, if the `--overwrite` flag is passed. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Run `npm start`
2. Have a preview site to update
3. Have a WordPress site folder that's not added to Studio already
4. Run `node dist/cli/main.js preview update --overwrite --path PATH` where `PATH` is the path to the aforementioned WordPress site
5. Ensure that the operation completes successfully
6. Ensure that the site shows up in Studio

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
