### PR TITLE
Add optgroup labels for editors and terminals

### DIFF
--- a/src/modules/user-settings/components/editor-picker.tsx
+++ b/src/modules/user-settings/components/editor-picker.tsx
@@ -48,11 +48,13 @@ export const EditorPicker = ( { value, onChange }: EditorPickerProps ) => {
 				__next40pxDefaultSize
 			>
 				{ ! value && <option value={ '' }>{ __( 'Select' ) }</option> }
-				{ installedEditors.map( ( [ editorKey, editorConfig ] ) => (
-					<option key={ editorKey } value={ editorKey }>
-						{ editorConfig.label }
-					</option>
-				) ) }
+				<optgroup label={ __( 'Available editors' ) }>
+					{ installedEditors.map( ( [ editorKey, editorConfig ] ) => (
+						<option key={ editorKey } value={ editorKey }>
+							{ editorConfig.label }
+						</option>
+					) ) }
+				</optgroup>
 				<optgroup label={ __( 'Not installed' ) }>
 					{ uninstalledEditors.map( ( [ editorKey, editorConfig ] ) => (
 						<option key={ editorKey } value={ editorKey } disabled>

--- a/src/modules/user-settings/components/terminal-picker.tsx
+++ b/src/modules/user-settings/components/terminal-picker.tsx
@@ -32,11 +32,13 @@ export const TerminalPicker = ( {
 				__nextHasNoMarginBottom
 				__next40pxDefaultSize
 			>
-				{ availableTerminalEntries.map( ( [ terminal, label ] ) => (
-					<option key={ terminal } value={ terminal }>
-						{ label }
-					</option>
-				) ) }
+				<optgroup label={ __( 'Available terminals' ) }>
+					{ availableTerminalEntries.map( ( [ terminal, label ] ) => (
+						<option key={ terminal } value={ terminal }>
+							{ label }
+						</option>
+					) ) }
+				</optgroup>
 				{ unavailableTerminalEntries.length > 0 && (
 					<optgroup label={ __( 'Not installed' ) }>
 						{ unavailableTerminalEntries.map( ( [ terminal, label ] ) => (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes [STU-439](https://linear.app/a8c/issue/STU-439/make-optgroups-consistent-across-dropdowns)

## Proposed Changes

- Added "Available editors" optgroup to the editor picker component
- Added "Available terminals" optgroup to the terminal picker component
- Made optgroups consistent across both components for better UX

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run `STUDIO_PREFERRED_EDITOR=true npm start`
- Open the settings modal, go to the Preferences tab
- Verify that both editor and terminal pickers show options grouped under "Available" and "Not installed" sections
- Confirm that installed options are selectable
- Confirm that not installed options are disabled

| Dropdown | Before | After |
|--------|--------|--------|
| Editor | ![CleanShot 2025-05-01 at 15 55 13@2x](https://github.com/user-attachments/assets/9c497806-3d52-470f-ad39-fd51bc023665) | ![CleanShot 2025-05-01 at 15 50 23@2x](https://github.com/user-attachments/assets/ef5ebd65-e19a-4de1-bc98-a27c4f26be82) |
| Terminal | ![CleanShot 2025-05-01 at 15 55 22@2x](https://github.com/user-attachments/assets/08a46bdd-2252-4ce8-a4f9-86353454867a) | ![CleanShot 2025-05-01 at 15 50 34@2x](https://github.com/user-attachments/assets/9e33ea04-3acb-4eb1-af39-4702abe78297) |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Have you checked for TypeScript, React or other console errors?
