### PR TITLE
Only allow a single `startProxyServer` call at a time

### DIFF
--- a/src/lib/proxy-server.ts
+++ b/src/lib/proxy-server.ts
@@ -13,6 +13,22 @@ let httpsProxyServer: https.Server | null = null;
 let isHttpProxyRunning = false;
 let isHttpsProxyRunning = false;
 
+const locks = new Map< () => Promise< unknown >, Promise< unknown > >();
+
+// Ensures that only one instance of the function is running at a time
+function sequential< Args extends unknown[], Return >(
+	fn: ( ...args: Args ) => Promise< Return >
+) {
+	return async ( ...args: Args ) => {
+		const lock = locks.get( fn ) ?? Promise.resolve();
+		await Promise.allSettled( [ lock ] );
+		locks.delete( fn );
+		const promise = fn( ...args );
+		locks.set( fn, promise );
+		return await promise;
+	};
+}
+
 const proxy = httpProxy.createProxyServer();
 
 // Setup error handling for the proxy
@@ -115,7 +131,7 @@ export async function checkIfPortIsFree( port: number ): Promise< boolean > {
  * Attempts to start the proxy servers on ports 80 and 443
  * This requires admin/root privileges
  */
-export async function startProxyServer(): Promise< boolean > {
+export const startProxyServer = sequential( async (): Promise< boolean > => {
 	try {
 		// Start HTTP server if not already running
 		if ( ! isHttpProxyRunning ) {
@@ -199,7 +215,7 @@ export async function startProxyServer(): Promise< boolean > {
 
 		throw new Error( 'PROXY_ERROR_START_FAILED' );
 	}
-}
+} );
 
 /**
  * Stop the proxy servers

--- a/src/lib/proxy-server.ts
+++ b/src/lib/proxy-server.ts
@@ -15,7 +15,7 @@ let isHttpsProxyRunning = false;
 
 const sequentialLocks = new Map< () => Promise< unknown >, Set< Promise< unknown > > >();
 
-// Ensures that only one instance of the function is running at a time
+// Ensures that calls to the provided function are executed sequentially
 function sequential< Args extends unknown[], Return >(
 	fn: ( ...args: Args ) => Promise< Return >
 ) {

--- a/src/lib/proxy-server.ts
+++ b/src/lib/proxy-server.ts
@@ -13,19 +13,32 @@ let httpsProxyServer: https.Server | null = null;
 let isHttpProxyRunning = false;
 let isHttpsProxyRunning = false;
 
-const locks = new Map< () => Promise< unknown >, Promise< unknown > >();
+const sequentialLocks = new Map< () => Promise< unknown >, Set< Promise< unknown > > >();
 
 // Ensures that only one instance of the function is running at a time
 function sequential< Args extends unknown[], Return >(
 	fn: ( ...args: Args ) => Promise< Return >
 ) {
 	return async ( ...args: Args ) => {
-		const lock = locks.get( fn ) ?? Promise.resolve();
-		await Promise.allSettled( [ lock ] );
-		locks.delete( fn );
-		const promise = fn( ...args );
-		locks.set( fn, promise );
-		return await promise;
+		const locks = sequentialLocks.get( fn ) ?? new Set();
+		if ( ! sequentialLocks.has( fn ) ) {
+			sequentialLocks.set( fn, locks );
+		}
+
+		const settledPromise = Promise.allSettled( [ ...locks ] );
+		// Push the settled promise to the queue to ensure that subsequent calls wait their turn
+		locks.add( settledPromise );
+		await settledPromise;
+
+		const fnPromise = fn( ...args );
+
+		try {
+			locks.add( fnPromise );
+			return await fnPromise;
+		} finally {
+			locks.delete( settledPromise );
+			locks.delete( fnPromise );
+		}
 	};
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-440

## Proposed Changes

`startProxyServer` is called in `SiteServer::start`. It's called every time a server with a custom domain config starts and returns early if the proxy server is already initiated. 

This can become an issue when the Studio app starts, because Studio will re-initiate the servers that were running when the app quit, and if there were multiple servers with custom domain configs, there will be multiple `startProxyServer` calls in rapid succession. This leads to errors like this:

![](https://github.com/user-attachments/assets/1e343d0f-0bf2-4275-87c0-632bb4b27fea)

This PR fixes the problem by adding a `sequential` helper in `src/lib/proxy-server.ts` that makes it so `startProxyServer` calls are executed sequentially.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Apply the following diff

```diff
diff --git a/src/lib/proxy-server.ts b/src/lib/proxy-server.ts
index bf861da9..1efd425c 100644
--- a/src/lib/proxy-server.ts
+++ b/src/lib/proxy-server.ts
@@ -145,6 +145,7 @@ export async function checkIfPortIsFree( port: number ): Promise< boolean > {
  * This requires admin/root privileges
  */
 export const startProxyServer = sequential( async (): Promise< boolean > => {
+       console.log( 'startProxyServer' );
        try {
                // Start HTTP server if not already running
                if ( ! isHttpProxyRunning ) {
@@ -227,6 +228,8 @@ export const startProxyServer = sequential( async (): Promise< boolean > => {
                console.error( 'Failed to start proxy servers:', error );
 
                throw new Error( 'PROXY_ERROR_START_FAILED' );
+       } finally {
+               console.log( 'startProxyServer done' );
        }
 } );
```

2. Run `npm start`
3. Ensure that you have at least three sites with custom domains
4. Ensure that those sites are all started
5. Quit the app
6. Run `npm start`
7. Ensure that the app starts without any warnings
8. Looking at the terminal logs, ensure that the `startProxyServer` calls were executed sequentially (by looking at the output from the `console.log` calls you added)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
