### PR TITLE
CLI initial release

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -3,7 +3,7 @@
 	"author": "Automattic Inc.",
 	"private": true,
 	"productName": "Studio CLI",
-	"version": "0.0.1",
+	"version": "1.0.0",
 	"description": "Studio by WordPress.com CLI",
 	"license": "GPL-2.0-or-later",
 	"main": "index.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,6 @@
 				"archiver": "^6.0.1",
 				"atomically": "^2.0.3",
 				"cli-table3": "^0.6.5",
-				"commander": "^13.1.0",
 				"compressible": "2.0.18",
 				"compression": "1.7.4",
 				"cross-port-killer": "^1.4.0",
@@ -11140,15 +11139,6 @@
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
-		"node_modules/commander": {
-			"version": "13.1.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
-			"integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
 			}
 		},
 		"node_modules/compare-version": {

--- a/package.json
+++ b/package.json
@@ -131,7 +131,6 @@
 		"archiver": "^6.0.1",
 		"atomically": "^2.0.3",
 		"cli-table3": "^0.6.5",
-		"commander": "^13.1.0",
 		"compressible": "2.0.18",
 		"compression": "1.7.4",
 		"cross-port-killer": "^1.4.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,7 +39,6 @@ import {
 import { migrateAllDatabasesInSitu } from 'src/migrations/move-databases-in-situ';
 import { removeSitesWithEmptyDirectories } from 'src/migrations/remove-sites-with-empty-dirs';
 import { installCLIOnWindows } from 'src/modules/cli/lib/install-windows';
-import { isCLIFeatureEnabled } from 'src/modules/cli/lib/is-cli-feature-enabled';
 import { setupWPServerFiles, updateWPServerFiles } from 'src/setup-wp-server-files';
 import { stopAllServersOnQuit } from 'src/site-server';
 import { loadUserData, saveUserData } from 'src/storage/user-data';
@@ -300,9 +299,7 @@ async function appBoot() {
 			'weekly'
 		);
 
-		if ( isCLIFeatureEnabled() ) {
-			await installCLIOnWindows();
-		}
+		await installCLIOnWindows();
 
 		finishedInitialization = true;
 	} );

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -9,7 +9,6 @@ import { shellOpenExternalWrapper } from 'src/lib/shell-open-external-wrapper';
 import { promptWindowsSpeedUpSites } from 'src/lib/windows-helpers';
 import { getMainWindow } from 'src/main-window';
 import { installCLIOnMacOSWithConfirmation } from 'src/modules/cli/lib/install-macos';
-import { isCLIFeatureEnabled } from 'src/modules/cli/lib/is-cli-feature-enabled';
 import { isUpdateReadyToInstall, manualCheckForUpdates } from 'src/updates';
 
 export async function setupMenu( config: { needsOnboarding: boolean } ) {
@@ -92,7 +91,7 @@ function getAppMenu(
 						void sendIpcEventToRenderer( 'user-settings' );
 					},
 				},
-				...( process.platform === 'darwin' && isCLIFeatureEnabled()
+				...( process.platform === 'darwin'
 					? [
 							{
 								label: __( 'Install CLI…' ),

--- a/src/modules/cli/lib/install-windows.ts
+++ b/src/modules/cli/lib/install-windows.ts
@@ -98,7 +98,7 @@ const installProxyBatFile = async () => {
 };
 
 export const installCLIOnWindows = async () => {
-	if ( process.platform !== 'win32' ) {
+	if ( process.platform !== 'win32' || process.env.NODE_ENV === 'development' ) {
 		return;
 	}
 

--- a/src/modules/cli/lib/is-cli-feature-enabled.ts
+++ b/src/modules/cli/lib/is-cli-feature-enabled.ts
@@ -1,7 +1,0 @@
-import { app } from 'electron';
-import { prerelease } from 'semver';
-
-// The Studio CLI is available in development, and in prerelease builds (dev and beta builds).
-export function isCLIFeatureEnabled() {
-	return process.env.NODE_ENV === 'development' || prerelease( app.getVersion() );
-}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-412

## Proposed Changes

- Enable CLI installation for all environments (see https://github.com/Automattic/studio/pull/1253 for previous changes)
- Only run Windows installation in production to prevent `%PATH` pollution
- Set the CLI version to 1.0.0
- Remove the `commander` dependency (which is no longer used by the CLI)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Code review should suffice

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
