### PR TITLE
What's New modal: Fix translations of `Next` and `Previous` buttons

### DIFF
--- a/patches/@wordpress+components+29.7.0.patch
+++ b/patches/@wordpress+components+29.7.0.patch
@@ -1,0 +1,65 @@
+diff --git a/node_modules/@wordpress/components/build-module/guide/index.js b/node_modules/@wordpress/components/build-module/guide/index.js
+index 17df1a7..5bbce41 100644
+--- a/node_modules/@wordpress/components/build-module/guide/index.js
++++ b/node_modules/@wordpress/components/build-module/guide/index.js
+@@ -54,6 +54,8 @@ function Guide({
+   className,
+   contentLabel,
+   finishButtonText = __('Finish'),
++  nextButtonText = __('Next'),
++  previousButtonText = __('Previous'),
+   onFinish,
+   pages = []
+ }) {
+@@ -128,13 +130,13 @@ function Guide({
+           variant: "tertiary",
+           onClick: goBack,
+           __next40pxDefaultSize: true,
+-          children: __('Previous')
++          children: previousButtonText
+         }), canGoForward && /*#__PURE__*/_jsx(Button, {
+           className: "components-guide__forward-button",
+           variant: "primary",
+           onClick: goForward,
+           __next40pxDefaultSize: true,
+-          children: __('Next')
++          children: nextButtonText
+         }), !canGoForward && /*#__PURE__*/_jsx(Button, {
+           className: "components-guide__finish-button",
+           variant: "primary",
+diff --git a/node_modules/@wordpress/components/build-types/guide/index.d.ts b/node_modules/@wordpress/components/build-types/guide/index.d.ts
+index 6b00a78..181454c 100644
+--- a/node_modules/@wordpress/components/build-types/guide/index.d.ts
++++ b/node_modules/@wordpress/components/build-types/guide/index.d.ts
+@@ -31,6 +31,6 @@ import type { GuideProps } from './types';
+  * }
+  * ```
+  */
+-declare function Guide({ children, className, contentLabel, finishButtonText, onFinish, pages, }: GuideProps): import("react").JSX.Element | null;
++declare function Guide({ children, className, contentLabel, finishButtonText, nextButtonText, previousButtonText, onFinish, pages, }: GuideProps): import("react").JSX.Element | null;
+ export default Guide;
+ //# sourceMappingURL=index.d.ts.map
+\ No newline at end of file
+diff --git a/node_modules/@wordpress/components/build-types/guide/types.d.ts b/node_modules/@wordpress/components/build-types/guide/types.d.ts
+index e9a3e0c..59a6527 100644
+--- a/node_modules/@wordpress/components/build-types/guide/types.d.ts
++++ b/node_modules/@wordpress/components/build-types/guide/types.d.ts
+@@ -37,6 +37,18 @@ export type GuideProps = {
+      * @default 'Finish'
+      */
+     finishButtonText?: string;
++    /**
++     * Use this to customize the label of the _Next_ button shown on each page of the guide.
++     *
++     * @default 'Next'
++     */
++    nextButtonText?: string;
++    /**
++     * Use this to customize the label of the _Previous_ button shown on each page of the guide except the first.
++     *
++     * @default 'Previous'
++     */
++    previousButtonText?: string;
+     /**
+      * A function which is called when the guide is finished.
+      */

--- a/src/modules/whats-new/components/whats-new-modal.tsx
+++ b/src/modules/whats-new/components/whats-new-modal.tsx
@@ -129,6 +129,8 @@ export default function WhatsNewModal( { showModal, onClose }: WhatsNewModalProp
 				),
 			} ) ) }
 			finishButtonText={ __( 'Done' ) }
+			nextButtonText={ __( 'Next' ) }
+			previousButtonText={ __( 'Previous' ) }
 		/>
 	);
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Resolves STU-353-linear-issue

## Proposed Changes

- add a patch based on https://github.com/WordPress/gutenberg/pull/69907 that hasn't been release as a part of  
`@wordpress-components`
  - this patch adds customizations for `Next` and `Previous` buttons for the Guide component 
- use custom translated `Next` and `Previous` buttons

![Markup on 2025-05-02 at 17:17:31](https://github.com/user-attachments/assets/e36d1ae1-c2a7-4713-ba16-00840392fe88)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR branch and build the app with `npm install && npm start`.
2. Switch your app locale to non-English.
3. Open the "What's New" modal through the _Help → What's New_ menu.
4. The `Next` and `Previous` buttons should be translated.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?