### PR TITLE
Update terminal field label to more common one

### DIFF
--- a/src/modules/user-settings/components/terminal-picker.tsx
+++ b/src/modules/user-settings/components/terminal-picker.tsx
@@ -25,7 +25,7 @@ export const TerminalPicker = ( {
 	);
 
 	return (
-		<SettingsFormField label={ __( 'Shell' ) }>
+		<SettingsFormField label={ __( 'Terminal application' ) }>
 			<SelectControl
 				value={ value }
 				onChange={ ( newValue ) => onChange( newValue as SupportedTerminal ) }

--- a/src/modules/user-settings/components/tests/terminal-picker.test.tsx
+++ b/src/modules/user-settings/components/tests/terminal-picker.test.tsx
@@ -11,7 +11,7 @@ describe( 'TerminalPicker', () => {
 	it( 'renders correctly with initial props', () => {
 		render( <TerminalPicker value="terminal" onChange={ mockOnChange } /> );
 
-		expect( screen.getByText( 'Shell' ) ).toBeVisible();
+		expect( screen.getByText( 'Terminal application' ) ).toBeVisible();
 		expect( screen.getByRole( 'combobox' ) ).toBeVisible();
 	} );
 

--- a/src/modules/user-settings/components/tests/user-settings.test.tsx
+++ b/src/modules/user-settings/components/tests/user-settings.test.tsx
@@ -132,7 +132,7 @@ describe( 'UserSettings', () => {
 				expect( screen.getByText( 'Preferences' ) ).toHaveAttribute( 'aria-selected', 'true' );
 			} );
 			expect( screen.getByText( 'Language' ) ).toBeVisible();
-			expect( screen.getByText( 'Shell' ) ).toBeVisible();
+			expect( screen.getByText( 'Terminal application' ) ).toBeVisible();
 
 			// Switch to Usage tab
 			fireEvent.click( screen.getByText( 'Usage' ) );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-444

## Proposed Changes

- I propose to update terminal field label to more common one.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Start app:
```
STUDIO_PREFERRED_EDITOR=true npm start
```
2. Open settings, preferences tab
3. Confirm labels are clear

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
