### PR TITLE
Studio: Fix Windsurf spelling

### DIFF
--- a/src/modules/user-settings/lib/editor.ts
+++ b/src/modules/user-settings/lib/editor.ts
@@ -25,7 +25,7 @@ export const supportedEditorConfig: Record< SupportedEditor, SupportedEditorConf
 	},
 	windsurf: {
 		// translators: "Windsurf" is the brand name for an IDE and does not need to be translated
-		label: __( 'WindSurf' ),
+		label: __( 'Windsurf' ),
 		url: ( path: string ) => `windsurf://file/${ path }?windowId=_blank`,
 	},
 	cursor: {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

Fixes STU-448

## Proposed Changes

This PR proposes to change the name of `WindSurf` to `Windsurf` to correspond to more conventional spelling. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
* Start the app with `STUDIO_PREFERRED_EDITOR=true npm start`
* Navigate to `User settings` by clicking the profile icon in the top right corner
* For the code editors, confirm that `Windsurf` is spelled correctly in the list of editors

<img width="509" alt="Screenshot 2025-05-06 at 10 29 02 AM" src="https://github.com/user-attachments/assets/2755671b-06cd-4926-a75c-4e46d19bbadb" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
