### PR TITLE
Pressable Sync: Add `Production` and `Staging` badges

### DIFF
--- a/src/components/environment-badge.tsx
+++ b/src/components/environment-badge.tsx
@@ -26,12 +26,9 @@ export function EnvironmentBadge( { type, selected }: EnvironmentBadgeProps ) {
 	};
 
 	const getLabel = () => {
-		if ( type === 'production' ) {
-			return __( 'Production' );
-		} else if ( type === 'staging' ) {
+		if ( type === 'staging' ) {
 			return __( 'Staging' );
 		}
-
 		return __( 'Production' );
 	};
 

--- a/src/components/environment-badge.tsx
+++ b/src/components/environment-badge.tsx
@@ -1,0 +1,39 @@
+import { __ } from '@wordpress/i18n';
+import { Badge } from 'src/components/badge';
+import { cx } from 'src/lib/cx';
+
+export type EnvironmentType = 'production' | 'staging';
+
+interface EnvironmentBadgeProps {
+	type: EnvironmentType;
+	selected?: boolean;
+}
+
+/**
+ * A badge component for displaying environment types (production, staging)
+ */
+export function EnvironmentBadge( { type, selected }: EnvironmentBadgeProps ) {
+	const getClassName = () => {
+		if ( selected ) {
+			return 'bg-white text-a8c-blueberry text-a8c-blueberry';
+		}
+
+		if ( type === 'production' ) {
+			return 'bg-a8c-green-5 text-a8c-green-80';
+		}
+
+		return '';
+	};
+
+	const getLabel = () => {
+		if ( type === 'production' ) {
+			return __( 'Production' );
+		} else if ( type === 'staging' ) {
+			return __( 'Staging' );
+		}
+
+		return __( 'Production' );
+	};
+
+	return <Badge className={ cx( getClassName() ) }>{ getLabel() }</Badge>;
+}

--- a/src/components/sync-connected-sites.tsx
+++ b/src/components/sync-connected-sites.tsx
@@ -5,9 +5,9 @@ import { cloudUpload, cloudDownload } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { useMemo } from 'react';
 import { ArrowIcon } from 'src/components/arrow-icon';
-import { Badge } from 'src/components/badge';
 import Button from 'src/components/button';
 import { OpenSitesSyncSelector } from 'src/components/content-tab-sync';
+import { EnvironmentBadge } from 'src/components/environment-badge';
 import { CircleRedCrossIcon } from 'src/components/icons/circle-red-cross';
 import offlineIcon from 'src/components/offline-icon';
 import { PressableLogo } from 'src/components/pressable-logo';
@@ -266,22 +266,18 @@ const SyncConnectedSitesList = ( {
 							{ connectedSite.isPressable ? (
 								<>
 									{ connectedSite.environment_type === 'staging' && (
-										<Badge>{ __( 'Staging' ) }</Badge>
+										<EnvironmentBadge type="staging" />
 									) }
 									{ connectedSite.environment_type === 'production' && (
-										<Badge className="bg-a8c-green-5 text-a8c-green-80">
-											{ __( 'Production' ) }
-										</Badge>
+										<EnvironmentBadge type="production" />
 									) }
 								</>
 							) : (
 								<>
 									{ connectedSite.isStaging ? (
-										<Badge>{ __( 'Staging' ) }</Badge>
+										<EnvironmentBadge type="staging" />
 									) : (
-										<Badge className="bg-a8c-green-5 text-a8c-green-80">
-											{ __( 'Production' ) }
-										</Badge>
+										<EnvironmentBadge type="production" />
 									) }
 								</>
 							) }

--- a/src/components/sync-connected-sites.tsx
+++ b/src/components/sync-connected-sites.tsx
@@ -256,18 +256,18 @@ const SyncConnectedSitesList = ( {
 				return (
 					<div
 						className={ `col-span-3 grid min-h-14 px-8 gap-4 justify-items-start items-center border-b border-a8c-gray-0 ${
-							connectedSite.isPressable && ! connectedSite.environment_type
+							connectedSite.isPressable && ! connectedSite.environmentType
 								? 'grid-cols-[1fr_auto]'
 								: 'grid-cols-subgrid'
 						}` }
 						key={ connectedSite.id }
 					>
-						{ connectedSite.isPressable && connectedSite.environment_type && (
+						{ connectedSite.isPressable && connectedSite.environmentType && (
 							<div className="shrink-0">
-								{ connectedSite.environment_type === 'staging' && (
+								{ connectedSite.environmentType === 'staging' && (
 									<EnvironmentBadge type="staging" />
 								) }
-								{ connectedSite.environment_type === 'production' && (
+								{ connectedSite.environmentType === 'production' && (
 									<EnvironmentBadge type="production" />
 								) }
 							</div>

--- a/src/components/sync-connected-sites.tsx
+++ b/src/components/sync-connected-sites.tsx
@@ -256,19 +256,36 @@ const SyncConnectedSitesList = ( {
 				return (
 					<div
 						className={ `col-span-3 grid min-h-14 px-8 gap-4 justify-items-start items-center border-b border-a8c-gray-0 ${
-							connectedSite.isPressable ? 'grid-cols-[1fr_auto]' : 'grid-cols-subgrid'
+							connectedSite.isPressable && ! connectedSite.environment_type
+								? 'grid-cols-[1fr_auto]'
+								: 'grid-cols-subgrid'
 						}` }
 						key={ connectedSite.id }
 					>
-						{ ! connectedSite.isPressable && (
-							<div className="shrink-0">
-								{ connectedSite.isStaging ? (
-									<Badge>{ __( 'Staging' ) }</Badge>
-								) : (
-									<Badge className="bg-a8c-green-5 text-a8c-green-80">{ __( 'Production' ) }</Badge>
-								) }
-							</div>
-						) }
+						<div className="shrink-0">
+							{ connectedSite.isPressable ? (
+								<>
+									{ connectedSite.environment_type === 'staging' && (
+										<Badge>{ __( 'Staging' ) }</Badge>
+									) }
+									{ connectedSite.environment_type === 'production' && (
+										<Badge className="bg-a8c-green-5 text-a8c-green-80">
+											{ __( 'Production' ) }
+										</Badge>
+									) }
+								</>
+							) : (
+								<>
+									{ connectedSite.isStaging ? (
+										<Badge>{ __( 'Staging' ) }</Badge>
+									) : (
+										<Badge className="bg-a8c-green-5 text-a8c-green-80">
+											{ __( 'Production' ) }
+										</Badge>
+									) }
+								</>
+							) }
+						</div>
 
 						<Button
 							variant="link"

--- a/src/components/sync-connected-sites.tsx
+++ b/src/components/sync-connected-sites.tsx
@@ -262,26 +262,26 @@ const SyncConnectedSitesList = ( {
 						}` }
 						key={ connectedSite.id }
 					>
-						<div className="shrink-0">
-							{ connectedSite.isPressable ? (
-								<>
-									{ connectedSite.environment_type === 'staging' && (
-										<EnvironmentBadge type="staging" />
-									) }
-									{ connectedSite.environment_type === 'production' && (
-										<EnvironmentBadge type="production" />
-									) }
-								</>
-							) : (
-								<>
-									{ connectedSite.isStaging ? (
-										<EnvironmentBadge type="staging" />
-									) : (
-										<EnvironmentBadge type="production" />
-									) }
-								</>
-							) }
-						</div>
+						{ connectedSite.isPressable && connectedSite.environment_type && (
+							<div className="shrink-0">
+								{ connectedSite.environment_type === 'staging' && (
+									<EnvironmentBadge type="staging" />
+								) }
+								{ connectedSite.environment_type === 'production' && (
+									<EnvironmentBadge type="production" />
+								) }
+							</div>
+						) }
+
+						{ ! connectedSite.isPressable && (
+							<div className="shrink-0">
+								{ connectedSite.isStaging ? (
+									<EnvironmentBadge type="staging" />
+								) : (
+									<EnvironmentBadge type="production" />
+								) }
+							</div>
+						) }
 
 						<Button
 							variant="link"

--- a/src/components/sync-sites-modal-selector.tsx
+++ b/src/components/sync-sites-modal-selector.tsx
@@ -3,9 +3,9 @@ import { __, sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import { useState, useEffect } from 'react';
 import { ArrowIcon } from 'src/components/arrow-icon';
-import { Badge } from 'src/components/badge';
 import Button from 'src/components/button';
 import { CreateButton } from 'src/components/connect-create-buttons';
+import { EnvironmentBadge } from 'src/components/environment-badge';
 import Modal from 'src/components/modal';
 import offlineIcon from 'src/components/offline-icon';
 import { PressableLogo } from 'src/components/pressable-logo';
@@ -272,21 +272,9 @@ function SiteItem( {
 				<div className="flex gap-2">
 					{ ! isPressable && (
 						<>
-							<Badge
-								className={ cx(
-									isSelected
-										? 'bg-white text-a8c-blueberry text-a8c-blueberry'
-										: 'bg-a8c-green-5 text-a8c-green-80'
-								) }
-							>
-								{ __( 'Production' ) }
-							</Badge>
+							<EnvironmentBadge type="production" selected={ isSelected } />
 							{ site.stagingSiteIds.length > 0 && (
-								<Badge
-									className={ cx( isSelected && 'bg-white text-a8c-blueberry text-a8c-blueberry' ) }
-								>
-									{ __( 'Staging' ) }
-								</Badge>
+								<EnvironmentBadge type="staging" selected={ isSelected } />
 							) }
 						</>
 					) }
@@ -294,22 +282,10 @@ function SiteItem( {
 					{ isPressable && environmentType && (
 						<>
 							{ environmentType === 'production' && (
-								<Badge
-									className={ cx(
-										isSelected
-											? 'bg-white text-a8c-blueberry text-a8c-blueberry'
-											: 'bg-a8c-green-5 text-a8c-green-80'
-									) }
-								>
-									{ __( 'Production' ) }
-								</Badge>
+								<EnvironmentBadge type="production" selected={ isSelected } />
 							) }
 							{ environmentType === 'staging' && (
-								<Badge
-									className={ cx( isSelected && 'bg-white text-a8c-blueberry text-a8c-blueberry' ) }
-								>
-									{ __( 'Staging' ) }
-								</Badge>
+								<EnvironmentBadge type="staging" selected={ isSelected } />
 							) }
 						</>
 					) }

--- a/src/components/sync-sites-modal-selector.tsx
+++ b/src/components/sync-sites-modal-selector.tsx
@@ -210,7 +210,7 @@ function SiteItem( {
 	const isDeleted = site.syncSupport === 'deleted';
 	const isUnsupported = site.syncSupport === 'unsupported';
 	const isPressable = site.isPressable;
-	const environmentType = site.environment_type;
+	const environmentType = site.environmentType;
 
 	return (
 		<div

--- a/src/components/sync-sites-modal-selector.tsx
+++ b/src/components/sync-sites-modal-selector.tsx
@@ -210,6 +210,7 @@ function SiteItem( {
 	const isDeleted = site.syncSupport === 'deleted';
 	const isUnsupported = site.syncSupport === 'unsupported';
 	const isPressable = site.isPressable;
+	const environmentType = site.environment_type;
 
 	return (
 		<div
@@ -267,23 +268,50 @@ function SiteItem( {
 					<ArrowIcon />
 				</Button>
 			</div>
-			{ isSyncable && ! isPressable && (
+			{ isSyncable && (
 				<div className="flex gap-2">
-					<Badge
-						className={ cx(
-							isSelected
-								? 'bg-white text-a8c-blueberry text-a8c-blueberry'
-								: 'bg-a8c-green-5 text-a8c-green-80'
-						) }
-					>
-						{ __( 'Production' ) }
-					</Badge>
-					{ site.stagingSiteIds.length > 0 && (
-						<Badge
-							className={ cx( isSelected && 'bg-white text-a8c-blueberry text-a8c-blueberry' ) }
-						>
-							{ __( 'Staging' ) }
-						</Badge>
+					{ ! isPressable && (
+						<>
+							<Badge
+								className={ cx(
+									isSelected
+										? 'bg-white text-a8c-blueberry text-a8c-blueberry'
+										: 'bg-a8c-green-5 text-a8c-green-80'
+								) }
+							>
+								{ __( 'Production' ) }
+							</Badge>
+							{ site.stagingSiteIds.length > 0 && (
+								<Badge
+									className={ cx( isSelected && 'bg-white text-a8c-blueberry text-a8c-blueberry' ) }
+								>
+									{ __( 'Staging' ) }
+								</Badge>
+							) }
+						</>
+					) }
+
+					{ isPressable && environmentType && (
+						<>
+							{ environmentType === 'production' && (
+								<Badge
+									className={ cx(
+										isSelected
+											? 'bg-white text-a8c-blueberry text-a8c-blueberry'
+											: 'bg-a8c-green-5 text-a8c-green-80'
+									) }
+								>
+									{ __( 'Production' ) }
+								</Badge>
+							) }
+							{ environmentType === 'staging' && (
+								<Badge
+									className={ cx( isSelected && 'bg-white text-a8c-blueberry text-a8c-blueberry' ) }
+								>
+									{ __( 'Staging' ) }
+								</Badge>
+							) }
+						</>
 					) }
 				</div>
 			) }

--- a/src/hooks/use-fetch-wpcom-sites/index.tsx
+++ b/src/hooks/use-fetch-wpcom-sites/index.tsx
@@ -108,7 +108,7 @@ export function transformSingleSiteResponse(
 		url: site.URL,
 		isStaging,
 		isPressable: isPressableSite( site ),
-		environment_type: site.environment_type,
+		environmentType: site.environment_type,
 		stagingSiteIds: site.options?.wpcom_staging_blog_ids ?? [],
 		syncSupport,
 		lastPullTimestamp: null,

--- a/src/hooks/use-fetch-wpcom-sites/index.tsx
+++ b/src/hooks/use-fetch-wpcom-sites/index.tsx
@@ -16,6 +16,7 @@ export const sitesEndpointSiteSchema = z.object( {
 	jetpack: z.boolean().optional(),
 	is_deleted: z.boolean(),
 	hosting_provider_guess: z.string().optional(),
+	environment_type: z.string().optional(),
 	is_a8c: z.boolean().optional(),
 	options: z
 		.object( {
@@ -107,6 +108,7 @@ export function transformSingleSiteResponse(
 		url: site.URL,
 		isStaging,
 		isPressable: isPressableSite( site ),
+		environment_type: site.environment_type,
 		stagingSiteIds: site.options?.wpcom_staging_blog_ids ?? [],
 		syncSupport,
 		lastPullTimestamp: null,
@@ -174,7 +176,9 @@ export const useFetchWpComSites = ( connectedSiteIdsOnlyForSelectedSite: number[
 
 			const baseFields =
 				'name,ID,URL,plan,capabilities,is_wpcom_atomic,options,jetpack,is_deleted,is_a8c';
-			const fields = pressableSyncEnabled ? `${ baseFields },hosting_provider_guess` : baseFields;
+			const fields = pressableSyncEnabled
+				? `${ baseFields },hosting_provider_guess,environment_type`
+				: baseFields;
 
 			const response = await client.req.get(
 				{

--- a/src/hooks/use-fetch-wpcom-sites/index.tsx
+++ b/src/hooks/use-fetch-wpcom-sites/index.tsx
@@ -16,7 +16,7 @@ export const sitesEndpointSiteSchema = z.object( {
 	jetpack: z.boolean().optional(),
 	is_deleted: z.boolean(),
 	hosting_provider_guess: z.string().optional(),
-	environment_type: z.string().optional(),
+	environment_type: z.string().nullable().optional(),
 	is_a8c: z.boolean().optional(),
 	options: z
 		.object( {

--- a/src/hooks/use-fetch-wpcom-sites/reconcile-connected-sites.tsx
+++ b/src/hooks/use-fetch-wpcom-sites/reconcile-connected-sites.tsx
@@ -38,6 +38,7 @@ export const reconcileConnectedSites = (
 			stagingSiteIds: site.stagingSiteIds,
 			isStaging: site.isStaging,
 			isPressable: site.isPressable,
+			environment_type: site.environment_type,
 		};
 	}, [] );
 

--- a/src/hooks/use-fetch-wpcom-sites/reconcile-connected-sites.tsx
+++ b/src/hooks/use-fetch-wpcom-sites/reconcile-connected-sites.tsx
@@ -38,7 +38,7 @@ export const reconcileConnectedSites = (
 			stagingSiteIds: site.stagingSiteIds,
 			isStaging: site.isStaging,
 			isPressable: site.isPressable,
-			environment_type: site.environment_type,
+			environmentType: site.environmentType,
 		};
 	}, [] );
 

--- a/src/hooks/use-fetch-wpcom-sites/types.ts
+++ b/src/hooks/use-fetch-wpcom-sites/types.ts
@@ -14,6 +14,7 @@ export type SyncSite = {
 	url: string;
 	isStaging: boolean;
 	isPressable: boolean;
+	environment_type?: string;
 	stagingSiteIds: number[];
 	syncSupport: SyncSupport;
 	lastPullTimestamp: string | null;

--- a/src/hooks/use-fetch-wpcom-sites/types.ts
+++ b/src/hooks/use-fetch-wpcom-sites/types.ts
@@ -14,7 +14,7 @@ export type SyncSite = {
 	url: string;
 	isStaging: boolean;
 	isPressable: boolean;
-	environment_type?: string;
+	environment_type?: string | null;
 	stagingSiteIds: number[];
 	syncSupport: SyncSupport;
 	lastPullTimestamp: string | null;

--- a/src/hooks/use-fetch-wpcom-sites/types.ts
+++ b/src/hooks/use-fetch-wpcom-sites/types.ts
@@ -14,7 +14,7 @@ export type SyncSite = {
 	url: string;
 	isStaging: boolean;
 	isPressable: boolean;
-	environment_type?: string | null;
+	environmentType?: string | null;
 	stagingSiteIds: number[];
 	syncSupport: SyncSupport;
 	lastPullTimestamp: string | null;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Related to STU-346-linear-issue.

## Proposed Changes

- add `Staging` and `Production` environment badges for Pressable sites
- introduce a new `EnvironmentBadge` component

| Sync modal | Sync tab |
|--------|--------|
| ![Markup on 2025-05-06 at 13:02:54](https://github.com/user-attachments/assets/ee4fdf27-4326-4851-b818-b83abdd2feb8) | ![Markup on 2025-05-06 at 13:01:50](https://github.com/user-attachments/assets/61daa198-bc3d-43e7-9187-388ba1676825) | 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Ensure you have at least one `staging` and one `production` Pressable site connected to your WPCOM account using Jetpack.
2. If the related backend PR (181818-ghe-Automattic/wpcom) hasn't been merged and deployed yet, check it out and sandbox `public-api.wordpress.com`.
3. Check out this Studio PR and build the app with `STUDIO_PRESSABLE_SYNC=true npm start`.
4. Head over to the Sync tab of one of your local sites.
5. Try to connect your Pressable sites.
6. The `Staging` and `Production` badges displayed should match the site type (please review both: the Sync modal and Sync tab).
7. There should be no unexpected regressions related to badges displayed by Atomic sites that have or do not have a staging site.
8. There should be no issues when building the app with `npm start` either. Please note that already-connected Pressable sites will show broken connection. This is expected behavior.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?