### PR TITLE
Studio: Adjust margin on Advanced Settings 

### DIFF
--- a/src/components/site-form.tsx
+++ b/src/components/site-form.tsx
@@ -296,7 +296,7 @@ export const SiteForm = ( {
 
 				{ setFileForImport && (
 					<>
-						<div className="flex flex-col gap-1.5 leading-4 mb-6">
+						<div className="flex flex-col gap-1.5 leading-4 mb-4">
 							<label className="font-semibold">
 								{ __( 'Import a backup' ) }
 								<span className="font-normal">{ __( ' (optional)' ) }</span>

--- a/src/components/site-form.tsx
+++ b/src/components/site-form.tsx
@@ -363,7 +363,7 @@ export const SiteForm = ( {
 										isAdvancedSettingsVisible ? 'h-auto opacity-100' : 'h-0 opacity-0'
 									) }
 								>
-									<div className={ cx( 'flex flex-col gap-1.5 leading-4 py-2' ) }>
+									<div className={ cx( 'flex flex-col gap-1.5 leading-4 py-4' ) }>
 										<label onClick={ onSelectPath } className="font-semibold">
 											{ __( 'Local path' ) }
 										</label>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

STU-340

## Proposed Changes

This PR adjusts margin for `Advanced settings` so that the distance looks visually the same below and above that field. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
* Start the app with `npm start`
* Click on the `Add site` button in the sidebar
* Confirm that the margin / padding below and above `Advanced Settings` looks the same

**Before**

<img width="484" alt="Screenshot 2025-05-06 at 1 56 12 PM" src="https://github.com/user-attachments/assets/76b65d24-eca4-4879-b48f-644ba0c8d325" />

**After**

<img width="503" alt="Screenshot 2025-05-06 at 1 55 22 PM" src="https://github.com/user-attachments/assets/395cfd03-f65a-4a06-b4a9-47ff348c1ed6" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
