### PR TITLE
Refactor the `openSiteURL` IPC handler not to throw

### DIFF
--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -804,7 +804,7 @@ export async function openSiteURL(
 	if ( ! site?.server?.url ) {
 		await showMessageBox( event, {
 			type: 'error',
-			message: __( 'Could not open link' ),
+			message: __( 'Failed to open link' ),
 			detail: __( 'Please ensure your site files have not been moved or deleted.' ),
 		} );
 		return;

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -794,20 +794,23 @@ export async function getLastSeenVersion(
 	return userData.lastSeenVersion;
 }
 
-export function openSiteURL(
+export async function openSiteURL(
 	event: IpcMainInvokeEvent,
 	id: string,
 	relativeURL = '',
 	{ autoLogin = true }: { autoLogin?: boolean } = {}
 ) {
 	const site = SiteServer.get( id );
-	if ( ! site ) {
-		throw new Error( 'Site not found.' );
+	if ( ! site?.server?.url ) {
+		await showMessageBox( event, {
+			type: 'error',
+			message: __( 'Site server URL not found.' ),
+			detail: __( 'Please try again later.' ),
+		} );
+		return;
 	}
-	if ( ! site.server?.url ) {
-		throw new Error( 'Site server URL not found.' );
-	}
-	const url = new URL( site.server.url + relativeURL );
+
+	const url = new URL( relativeURL, site.server.url );
 	if ( autoLogin ) {
 		url.searchParams.append( 'playground-auto-login', 'true' );
 	}
@@ -1064,10 +1067,7 @@ END` );
 	}
 }
 
-export async function showMessageBox(
-	event: IpcMainInvokeEvent,
-	options: Electron.MessageBoxOptions
-) {
+export function showMessageBox( event: IpcMainInvokeEvent, options: Electron.MessageBoxOptions ) {
 	const parentWindow = BrowserWindow.fromWebContents( event.sender );
 	if ( parentWindow && ! parentWindow.isDestroyed() && ! event.sender.isDestroyed() ) {
 		return dialog.showMessageBox( parentWindow, options );

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -805,7 +805,7 @@ export async function openSiteURL(
 		await showMessageBox( event, {
 			type: 'error',
 			message: __( 'Site server URL not found.' ),
-			detail: __( 'Please try again later.' ),
+			detail: __( 'Please ensure your site files have not been moved or deleted.' ),
 		} );
 		return;
 	}

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -804,7 +804,7 @@ export async function openSiteURL(
 	if ( ! site?.server?.url ) {
 		await showMessageBox( event, {
 			type: 'error',
-			message: __( 'Site server URL not found.' ),
+			message: __( 'Could not open link' ),
 			detail: __( 'Please ensure your site files have not been moved or deleted.' ),
 		} );
 		return;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-451

## Proposed Changes

Sentry reported (STUDIO-65W) that exceptions from the `openSiteURL` handler are unhandled. This function throws errors when the provided site ID cannot be mapped to a URL (which is a clear signal that the site is malfunctioning).

The same error was present before v1.5.0, too (see STUDIO-1M6 in Sentry), but it was handled differently by Electron because `openSiteURL` used the `ipcRenderer.invoke` handler then instead of `ipcRenderer.send`. 

This PR fixes the issue by displaying a deliberate error modal instead of throwing an error. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Apply the following diff:

```diff
diff --git a/src/ipc-handlers.ts b/src/ipc-handlers.ts
index 32baadc4..dbf5b925 100644
--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -801,7 +801,7 @@ export async function openSiteURL(
        { autoLogin = true }: { autoLogin?: boolean } = {}
 ) {
        const site = SiteServer.get( id );
-       if ( ! site?.server?.url ) {
+       if ( true ) {
                await showMessageBox( event, {
                        type: 'error',
                        message: __( 'Failed to open link' ),
```

2. Start Studio
3. Click the `Site Editor` button in the Overview tab
4. Ensure that you see a modal like this:

<img width="271" alt="Screenshot 2025-05-06 at 13 52 25" src="https://github.com/user-attachments/assets/b6dd59d4-2244-4f29-88b1-5558467529ab" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
