### PR TITLE
Studio Sync: Improve the percentage progress and add more states into account in PUSH progress bar

### DIFF
--- a/src/components/sync-connected-sites.tsx
+++ b/src/components/sync-connected-sites.tsx
@@ -1,6 +1,6 @@
 import { Icon } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
-import { I18n, sprintf } from '@wordpress/i18n';
+import { sprintf } from '@wordpress/i18n';
 import { cloudUpload, cloudDownload } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { useMemo } from 'react';
@@ -18,14 +18,9 @@ import { WordPressLogoCircle } from 'src/components/wordpress-logo-circle';
 import { useSyncSites } from 'src/hooks/sync-sites';
 import { useConfirmationDialog } from 'src/hooks/use-confirmation-dialog';
 import { useI18nData } from 'src/hooks/use-i18n-data';
-import { ImportProgressState, useImportExport } from 'src/hooks/use-import-export';
+import { useImportExport } from 'src/hooks/use-import-export';
 import { useOffline } from 'src/hooks/use-offline';
-import {
-	IMPORTING_INITIAL_VALUE,
-	IMPORTING_TO_FINISHED_STEP,
-	PullStateProgressInfo,
-	useSyncStatesProgressInfo,
-} from 'src/hooks/use-sync-states-progress-info';
+import { useSyncStatesProgressInfo } from 'src/hooks/use-sync-states-progress-info';
 import { cx } from 'src/lib/cx';
 import { getDocsLink } from 'src/lib/get-docs-link';
 import { getIpcApi } from 'src/lib/get-ipc-api';
@@ -204,27 +199,6 @@ type SyncConnectedSitesListProps = {
 	connectedSites: SyncSite[];
 };
 
-const getStatusWithProgress = (
-	__: I18n[ '__' ],
-	sitePullState?: PullStateProgressInfo,
-	importState?: ImportProgressState[ string ]
-) => {
-	if ( ! importState && sitePullState ) {
-		return { message: sitePullState.message, progress: sitePullState.progress };
-	}
-	if ( importState ) {
-		if ( importState.progress === 100 ) {
-			return { message: __( 'Applying final details…' ), progress: 99 };
-		}
-		return {
-			message: importState.statusMessage,
-			progress:
-				IMPORTING_INITIAL_VALUE + IMPORTING_TO_FINISHED_STEP * ( importState.progress / 100 ),
-		};
-	}
-	return { message: '', progress: 0 };
-};
-
 const SyncConnectedSitesList = ( {
 	selectedSite,
 	connectedSites,
@@ -232,7 +206,14 @@ const SyncConnectedSitesList = ( {
 	const { __ } = useI18n();
 	const { clearPullState, getPullState, getPushState, clearPushState } = useSyncSites();
 	const { importState, exportState } = useImportExport();
-	const { isKeyPulling, isKeyPushing, isKeyFinished, isKeyFailed } = useSyncStatesProgressInfo();
+	const {
+		isKeyPulling,
+		isKeyPushing,
+		isKeyFinished,
+		isKeyFailed,
+		getPullStatusWithProgress,
+		getPushStatusWithProgress,
+	} = useSyncStatesProgressInfo();
 
 	return (
 		<div className="grid grid-cols-[max-content_1fr_max-content]">
@@ -242,8 +223,7 @@ const SyncConnectedSitesList = ( {
 				const isPullError = sitePullState && isKeyFailed( sitePullState.status.key );
 				const hasPullFinished = sitePullState && isKeyFinished( sitePullState.status.key );
 				const { message: sitePullStatusMessage, progress: sitePullStatusProgress } =
-					getStatusWithProgress(
-						__,
+					getPullStatusWithProgress(
 						sitePullState?.status,
 						importState[ connectedSite.localSiteId ]
 					);
@@ -252,13 +232,8 @@ const SyncConnectedSitesList = ( {
 				const isPushing = pushState && isKeyPushing( pushState.status.key );
 				const isPushError = pushState && isKeyFailed( pushState.status.key );
 				const hasPushFinished = pushState && isKeyFinished( pushState.status.key );
-
-				console.log( {
-					pushStateMessage: pushState?.status?.message,
-					exportStateMessage: exportState[ selectedSite?.id ]?.statusMessage,
-					exportStateProgress: exportState[ selectedSite?.id ]?.progress,
-					exportState,
-				} );
+				const { message: sitePushStatusMessage, progress: sitePushStatusProgress } =
+					getPushStatusWithProgress( pushState?.status, exportState[ connectedSite.localSiteId ] );
 
 				return (
 					<div
@@ -319,8 +294,8 @@ const SyncConnectedSitesList = ( {
 							) }
 							{ pushState?.status && isPushing && (
 								<div className="flex flex-col gap-2 min-w-44">
-									<div className="a8c-body-small">{ pushState.status.message }</div>
-									<ProgressBar value={ pushState.status.progress } maxValue={ 100 } />
+									<div className="a8c-body-small">{ sitePushStatusMessage }</div>
+									<ProgressBar value={ sitePushStatusProgress } maxValue={ 100 } />
 								</div>
 							) }
 

--- a/src/components/sync-connected-sites.tsx
+++ b/src/components/sync-connected-sites.tsx
@@ -231,7 +231,7 @@ const SyncConnectedSitesList = ( {
 }: SyncConnectedSitesListProps ) => {
 	const { __ } = useI18n();
 	const { clearPullState, getPullState, getPushState, clearPushState } = useSyncSites();
-	const { importState } = useImportExport();
+	const { importState, exportState } = useImportExport();
 	const { isKeyPulling, isKeyPushing, isKeyFinished, isKeyFailed } = useSyncStatesProgressInfo();
 
 	return (
@@ -252,6 +252,13 @@ const SyncConnectedSitesList = ( {
 				const isPushing = pushState && isKeyPushing( pushState.status.key );
 				const isPushError = pushState && isKeyFailed( pushState.status.key );
 				const hasPushFinished = pushState && isKeyFinished( pushState.status.key );
+
+				console.log( {
+					pushStateMessage: pushState?.status?.message,
+					exportStateMessage: exportState[ selectedSite?.id ]?.statusMessage,
+					exportStateProgress: exportState[ selectedSite?.id ]?.progress,
+					exportState,
+				} );
 
 				return (
 					<div

--- a/src/hooks/sync-sites/use-sync-pull.ts
+++ b/src/hooks/sync-sites/use-sync-pull.ts
@@ -14,11 +14,9 @@ import { useAuth } from 'src/hooks/use-auth';
 import { useImportExport } from 'src/hooks/use-import-export';
 import { useSiteDetails } from 'src/hooks/use-site-details';
 import {
-	IN_PROGRESS_INITIAL_VALUE,
-	IN_PROGRESS_TO_DOWNLOADING_STEP,
 	PullStateProgressInfo,
-	PullStateProgressInfoValues,
 	useSyncStatesProgressInfo,
+	type SyncBackupResponse,
 } from 'src/hooks/use-sync-states-progress-info';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 import type { SyncSite } from 'src/hooks/use-fetch-wpcom-sites/types';
@@ -43,12 +41,6 @@ type UseSyncPullProps = {
 	onPullSuccess?: OnPullSuccess;
 };
 
-type SyncBackupResponse = {
-	status: 'in-progress' | 'finished' | 'failed';
-	download_url: string;
-	percent: number;
-};
-
 export type UseSyncPull = {
 	pullStates: PullStates;
 	getPullState: GetState< SyncBackupState >;
@@ -66,8 +58,13 @@ export function useSyncPull( {
 	const { __ } = useI18n();
 	const { client } = useAuth();
 	const { importFile, clearImportState } = useImportExport();
-	const { pullStatesProgressInfo, isKeyPulling, isKeyFinished, isKeyFailed } =
-		useSyncStatesProgressInfo();
+	const {
+		pullStatesProgressInfo,
+		isKeyPulling,
+		isKeyFinished,
+		isKeyFailed,
+		getBackupStatusWithProgress,
+	} = useSyncStatesProgressInfo();
 	const {
 		updateState,
 		getState: getPullState,
@@ -308,7 +305,14 @@ export function useSyncPull( {
 				throw error;
 			}
 		},
-		[ client, getPullState, onBackupCompleted, pullStatesProgressInfo, updatePullState ]
+		[
+			client,
+			getBackupStatusWithProgress,
+			getPullState,
+			onBackupCompleted,
+			pullStatesProgressInfo,
+			updatePullState,
+		]
 	);
 
 	useEffect( () => {
@@ -347,23 +351,4 @@ export function useSyncPull( {
 	);
 
 	return { pullStates, getPullState, pullSite, isAnySitePulling, isSiteIdPulling, clearPullState };
-}
-function getBackupStatusWithProgress(
-	hasBackupCompleted: boolean,
-	pullStatesProgressInfo: PullStateProgressInfoValues,
-	response: SyncBackupResponse
-) {
-	const frontendStatus = hasBackupCompleted
-		? pullStatesProgressInfo.downloading.key
-		: response.status;
-	let newProgressInfo: PullStateProgressInfo | null = null;
-	if ( response.status === 'in-progress' ) {
-		newProgressInfo = pullStatesProgressInfo[ frontendStatus ];
-		newProgressInfo.progress =
-			IN_PROGRESS_INITIAL_VALUE + IN_PROGRESS_TO_DOWNLOADING_STEP * ( response.percent / 100 );
-	}
-	const statusWithProgress =
-		newProgressInfo || pullStatesProgressInfo[ frontendStatus ] || pullStatesProgressInfo.failed;
-
-	return statusWithProgress;
 }

--- a/src/hooks/use-import-export.tsx
+++ b/src/hooks/use-import-export.tsx
@@ -26,7 +26,7 @@ export type ImportProgressState = {
 	};
 };
 
-type ExportProgressState = {
+export type ExportProgressState = {
 	[ siteId: string ]: {
 		statusMessage: string;
 		progress: number;

--- a/src/hooks/use-sync-states-progress-info.ts
+++ b/src/hooks/use-sync-states-progress-info.ts
@@ -1,5 +1,6 @@
 import { useI18n } from '@wordpress/react-i18n';
 import { useCallback, useMemo } from 'react';
+import { ExportProgressState, ImportProgressState } from './use-import-export';
 
 export type PullStateProgressInfo = {
 	key: 'in-progress' | 'downloading' | 'importing' | 'finished' | 'failed' | 'cancelled';
@@ -17,13 +18,19 @@ export type PullStateProgressInfoValues = Record<
 	PullStateProgressInfo
 >;
 
-export const IN_PROGRESS_INITIAL_VALUE = 30;
-const DOWNLOADING_INITIAL_VALUE = 60;
-export const IN_PROGRESS_TO_DOWNLOADING_STEP =
-	DOWNLOADING_INITIAL_VALUE - IN_PROGRESS_INITIAL_VALUE;
-export const IMPORTING_INITIAL_VALUE = 80;
-export const IMPORTING_TO_FINISHED_STEP = 100 - IMPORTING_INITIAL_VALUE;
+export type SyncBackupResponse = {
+	status: 'in-progress' | 'finished' | 'failed';
+	download_url: string;
+	percent: number;
+};
 
+const IN_PROGRESS_INITIAL_VALUE = 30;
+const DOWNLOADING_INITIAL_VALUE = 60;
+const IN_PROGRESS_TO_DOWNLOADING_STEP = DOWNLOADING_INITIAL_VALUE - IN_PROGRESS_INITIAL_VALUE;
+const IMPORTING_INITIAL_VALUE = 80;
+const IMPORTING_TO_FINISHED_STEP = 100 - IMPORTING_INITIAL_VALUE;
+
+const EXPORTING_TO_UPLOADING_STEP = 50;
 export function useSyncStatesProgressInfo() {
 	const { __ } = useI18n();
 	const pullStatesProgressInfo = useMemo( () => {
@@ -71,7 +78,7 @@ export function useSyncStatesProgressInfo() {
 			},
 			uploading: {
 				key: 'uploading',
-				progress: 50,
+				progress: EXPORTING_TO_UPLOADING_STEP,
 				message: __( 'Uploading Studio site…' ),
 			},
 			importing: {
@@ -130,6 +137,67 @@ export function useSyncStatesProgressInfo() {
 		[]
 	);
 
+	const getBackupStatusWithProgress = useCallback(
+		(
+			hasBackupCompleted: boolean,
+			pullStatesProgressInfo: PullStateProgressInfoValues,
+			response: SyncBackupResponse
+		) => {
+			const frontendStatus = hasBackupCompleted
+				? pullStatesProgressInfo.downloading.key
+				: response.status;
+			let newProgressInfo: PullStateProgressInfo | null = null;
+			if ( response.status === 'in-progress' ) {
+				newProgressInfo = pullStatesProgressInfo[ frontendStatus ];
+				newProgressInfo.progress =
+					IN_PROGRESS_INITIAL_VALUE + IN_PROGRESS_TO_DOWNLOADING_STEP * ( response.percent / 100 );
+			}
+			const statusWithProgress =
+				newProgressInfo ||
+				pullStatesProgressInfo[ frontendStatus ] ||
+				pullStatesProgressInfo.failed;
+
+			return statusWithProgress;
+		},
+		[]
+	);
+
+	const getPullStatusWithProgress = useCallback(
+		( sitePullState?: PullStateProgressInfo, importState?: ImportProgressState[ string ] ) => {
+			if ( ! importState && sitePullState ) {
+				return { message: sitePullState.message, progress: sitePullState.progress };
+			}
+			if ( importState ) {
+				if ( importState.progress === 100 ) {
+					return { message: __( 'Applying final details…' ), progress: 99 };
+				}
+				return {
+					message: importState.statusMessage,
+					progress:
+						IMPORTING_INITIAL_VALUE + IMPORTING_TO_FINISHED_STEP * ( importState.progress / 100 ),
+				};
+			}
+			return { message: '', progress: 0 };
+		},
+		[ __ ]
+	);
+
+	const getPushStatusWithProgress = useCallback(
+		( sitePushState?: PushStateProgressInfo, exportState?: ExportProgressState[ string ] ) => {
+			if ( exportState && exportState.progress < 100 ) {
+				return {
+					message: exportState.statusMessage,
+					progress: EXPORTING_TO_UPLOADING_STEP * ( exportState.progress / 100 ),
+				};
+			}
+			if ( sitePushState ) {
+				return { message: sitePushState.message, progress: sitePushState.progress };
+			}
+			return { message: '', progress: 0 };
+		},
+		[]
+	);
+
 	return {
 		pullStatesProgressInfo,
 		pushStatesProgressInfo,
@@ -137,5 +205,8 @@ export function useSyncStatesProgressInfo() {
 		isKeyPushing,
 		isKeyFinished,
 		isKeyFailed,
+		getBackupStatusWithProgress,
+		getPullStatusWithProgress,
+		getPushStatusWithProgress,
 	};
 }

--- a/src/hooks/use-sync-states-progress-info.ts
+++ b/src/hooks/use-sync-states-progress-info.ts
@@ -73,8 +73,8 @@ export function useSyncStatesProgressInfo() {
 		return {
 			creatingBackup: {
 				key: 'creatingBackup',
-				progress: 30,
-				message: __( 'Creating backup…' ),
+				progress: 0,
+				message: __( 'Starting export…' ),
 			},
 			uploading: {
 				key: 'uploading',

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -651,7 +651,10 @@ export async function exportSiteToPush( event: IpcMainInvokeEvent, id: string ) 
 		splitDatabaseDumpByTable: true,
 	};
 	// eslint-disable-next-line @typescript-eslint/no-empty-function
-	const onEvent = () => {};
+	const onEvent = ( data: ImportExportEventData ) => {
+		const parentWindow = BrowserWindow.fromWebContents( event.sender );
+		sendIpcEventToRendererWithWindow( parentWindow, 'on-export', data, id );
+	};
 	await exportBackup( exportOptions, onEvent );
 	const stats = fs.statSync( archivePath );
 	const archiveContent = fs.readFileSync( archivePath );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Resolves STU-399

## Proposed Changes

- Implement `onEvent` for the export ipc handler so it emits the server events to the client.
- Refactor `getStatusWithProgress` to `getPullStatusWithProgress` and move it to the `useSyncStatesProgressInfo` hook.
- Refactor `getBackupStatusWithProgress` by moving it to the `useSyncStatesProgressInfo` hook.
- Create `getPushStatusWithProgress` by following a similar (but slightly different) approach than `getPullStatusWithProgress`.
- Use the new `getPushStatusWithProgress` method to update the progress and messages for the `Push` action.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Checkout this branch and run `npm start`
- Navigate to the Sync tab and Connnect a site or use an existing connected site
- Perform a Pull operation and make sure you see the same progress and messages than in Production, i.e. there are no regressions.
- Perform a Push operation and check that the progress and messages for the initial steps are more granular than in production, i.e. you can see more messages and a more linear progress for the initial steps

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
