### PR TITLE
Open editors using bundle IDs

### DIFF
--- a/src/components/content-tab-overview.tsx
+++ b/src/components/content-tab-overview.tsx
@@ -20,11 +20,11 @@ import { ButtonsSection, ButtonsSectionProps } from 'src/components/buttons-sect
 import { useFeatureFlags } from 'src/hooks/use-feature-flags';
 import { useSiteDetails } from 'src/hooks/use-site-details';
 import { useThemeDetails } from 'src/hooks/use-theme-details';
-import { isWindows } from 'src/lib/app-globals';
+import { isMac, isWindows } from 'src/lib/app-globals';
 import { cx } from 'src/lib/cx';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 import { supportedEditorConfig } from 'src/modules/user-settings/lib/editor';
-import { getTerminalName, supportedTerminalNames } from 'src/modules/user-settings/lib/terminal';
+import { getTerminalName } from 'src/modules/user-settings/lib/terminal';
 import { useGetUserEditorQuery, useGetUserTerminalQuery } from 'src/stores/installed-apps-api';
 
 interface ContentTabOverviewProps {
@@ -164,8 +164,12 @@ function ShortcutsSection( { selectedSite }: Pick< ContentTabOverviewProps, 'sel
 			label: editorConfig.label,
 			className: 'text-nowrap',
 			icon: code,
-			onClick: () => {
-				getIpcApi().openURL( editorConfig.url( selectedSite.path ) );
+			onClick: async () => {
+				if ( isMac() ) {
+					await getIpcApi().openAppAtPath( editorConfig.bundleId, selectedSite.path );
+				} else {
+					getIpcApi().openURL( editorConfig.url( selectedSite.path ) );
+				}
 			},
 		} );
 	}

--- a/src/components/tests/content-tab-overview-shortcuts-section.test.tsx
+++ b/src/components/tests/content-tab-overview-shortcuts-section.test.tsx
@@ -4,12 +4,14 @@ import { Provider } from 'react-redux';
 import { ContentTabOverview } from 'src/components/content-tab-overview';
 import { useFeatureFlags } from 'src/hooks/use-feature-flags';
 import { useThemeDetails } from 'src/hooks/use-theme-details';
+import { isMac } from 'src/lib/app-globals';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 import { store } from 'src/stores';
 import { testReducer } from 'src/stores/tests/utils/test-reducer';
 
 jest.mock( 'src/lib/app-globals', () => ( {
 	isWindows: jest.fn().mockReturnValue( false ),
+	isMac: jest.fn().mockReturnValue( false ),
 } ) );
 
 const selectedSite: StartedSiteDetails = {
@@ -55,8 +57,10 @@ describe( 'ShortcutsSection', () => {
 	it( 'opens site in VS Code when the user select VS Code and clicked the button', async () => {
 		// Mock the IPC API with getInstalledApps returning the installed apps
 		const openURLMock = jest.fn();
+		const openAppAtPathMock = jest.fn();
 		mockGetIpcApi.mockReturnValue( {
 			openURL: openURLMock,
+			openAppAtPath: openAppAtPathMock,
 			getUserEditor: jest.fn().mockResolvedValue( 'vscode' ),
 			getUserTerminal: jest.fn().mockResolvedValue( 'terminal' ),
 			getInstalledAppsAndTerminals: jest.fn().mockResolvedValue( {
@@ -88,10 +92,12 @@ describe( 'ShortcutsSection', () => {
 	} );
 
 	it( 'opens site in PhpStorm when PhpStorm is installed and the button is clicked, only available on MacOS', async () => {
+		( isMac as jest.Mock ).mockReturnValue( true );
+
 		// Mock the IPC API with getInstalledApps returning the installed apps
-		const openURLMock = jest.fn();
+		const openAppAtPathMock = jest.fn();
 		mockGetIpcApi.mockReturnValue( {
-			openURL: openURLMock,
+			openAppAtPath: openAppAtPathMock,
 			getUserEditor: jest.fn().mockResolvedValue( 'phpstorm' ), // User prefers PhpStorm
 			getUserTerminal: jest.fn().mockResolvedValue( 'terminal' ),
 			getInstalledAppsAndTerminals: jest.fn().mockResolvedValue( {
@@ -116,7 +122,7 @@ describe( 'ShortcutsSection', () => {
 		fireEvent.click( phpStormButton );
 
 		await waitFor( () =>
-			expect( openURLMock ).toHaveBeenCalledWith( expect.stringContaining( 'phpstorm://' ) )
+			expect( openAppAtPathMock ).toHaveBeenCalledWith( 'com.jetbrains.PhpStorm', '/path/to/site' )
 		);
 	} );
 

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -986,6 +986,17 @@ function promiseExec( command: string, options: ExecOptions = {} ): Promise< voi
 	} );
 }
 
+export async function openAppAtPath(
+	_event: IpcMainInvokeEvent,
+	bundleId: string,
+	targetPath: string
+) {
+	const platform = process.platform;
+	if ( platform === 'darwin' ) {
+		return promiseExec( `open -b ${ bundleId } "${ targetPath }"` );
+	}
+}
+
 export async function openTerminalAtPath(
 	_event: IpcMainInvokeEvent,
 	targetPath: string,

--- a/src/modules/user-settings/lib/editor.ts
+++ b/src/modules/user-settings/lib/editor.ts
@@ -5,6 +5,7 @@ export type SupportedEditor = 'vscode' | 'phpstorm' | 'cursor' | 'windsurf' | 'w
 export type SupportedEditorConfig = {
 	label: string;
 	url: ( path: string ) => string;
+	bundleId: string;
 };
 
 export const supportedEditorConfig: Record< SupportedEditor, SupportedEditorConfig > = {
@@ -12,25 +13,30 @@ export const supportedEditorConfig: Record< SupportedEditor, SupportedEditorConf
 		// translators: "VS Code" is the brand name for an IDE and does not need to be translated
 		label: __( 'VS Code' ),
 		url: ( path: string ) => `vscode://file/${ path }?windowId=_blank`,
+		bundleId: 'com.microsoft.VSCode',
 	},
 	phpstorm: {
 		// translators: "PhpStorm" is the brand name for an IDE and does not need to be translated
 		label: __( 'PhpStorm' ),
 		url: ( path: string ) => `phpstorm://open?file=${ path }`,
+		bundleId: 'com.jetbrains.PhpStorm',
 	},
 	webstorm: {
 		// translators: "WebStorm" is the brand name for an IDE and does not need to be translated
 		label: __( 'WebStorm' ),
 		url: ( path: string ) => `webstorm://open?file=${ path }`,
+		bundleId: 'com.jetbrains.WebStorm',
 	},
 	windsurf: {
 		// translators: "Windsurf" is the brand name for an IDE and does not need to be translated
 		label: __( 'Windsurf' ),
 		url: ( path: string ) => `windsurf://file/${ path }?windowId=_blank`,
+		bundleId: 'com.exafunction.windsurf',
 	},
 	cursor: {
 		// translators: "Cursor" is the brand name for an IDE and does not need to be translated
 		label: __( 'Cursor' ),
 		url: ( path: string ) => `cursor://file/${ path }?windowId=_blank`,
+		bundleId: 'com.todesktop.230313mzl4w4u92',
 	},
 };

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -76,6 +76,8 @@ const api: IpcApi = {
 	getOnboardingData: () => ipcRendererInvoke( 'getOnboardingData' ),
 	saveOnboarding: ( onboardingCompleted ) =>
 		ipcRendererInvoke( 'saveOnboarding', onboardingCompleted ),
+	openAppAtPath: ( bundleId, targetPath ) =>
+		ipcRendererInvoke( 'openAppAtPath', bundleId, targetPath ),
 	openTerminalAtPath: ( targetPath, extraParams = {} ) =>
 		ipcRendererInvoke( 'openTerminalAtPath', targetPath, extraParams ),
 	showMessageBox: ( options ) => ipcRendererInvoke( 'showMessageBox', options ),


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Partly addresses [STU-450 Use CLI to open IDE instead of app URI](https://linear.app/a8c/issue/STU-450/use-cli-to-open-ide-instead-of-app-uri)

## Proposed Changes

This PR changes how we open IDEs on macOS by using bundle IDs instead of URL schemes. This change helps avoid the warning thrown by VSCode and forked editors when first opening a directory.

- Add `bundleId` property to editor configurations
- Add a new `openAppAtPath` IPC handler for macOS
- Update the editor opening logic to use bundle IDs on macOS

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Prerequisites: either VSCode, Cursor, or Windsurf installed

- Run `STUDIO_PREFERRED_EDITOR=true npm start`
- Go to preferences and choose VSCode, Cursor, or Windsurf
- On a site's Overview tab, try opening the directory using the selected editor
- Check that the app opens the directory, and that this warning isn't shown:

![image](https://github.com/user-attachments/assets/33421435-98ed-4945-a3d9-55177f538d13)

#### Regression
- If you have Jetbrains IDEs installed on Mac, test that there are no changes to opening directories
- If you have Windows, test that there are no changes to opening directories

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Have you checked for TypeScript, React or other console errors?
