### PR TITLE
Onboarding: Update tooltip position to left to unwanted overlay and screen shaking 

### DIFF
--- a/src/components/wp-version-selector/index.tsx
+++ b/src/components/wp-version-selector/index.tsx
@@ -64,7 +64,7 @@ export const WPVersionSelector = ( {
 				{ selectedValue !== 'latest' && (
 					<Tooltip
 						text={ __( 'WordPress Core automatic updates will be disabled for this site.' ) }
-						placement="left"
+						placement="top-start"
 					>
 						<Icon icon={ warning } size={ 16 } />
 					</Tooltip>

--- a/src/components/wp-version-selector/index.tsx
+++ b/src/components/wp-version-selector/index.tsx
@@ -64,7 +64,7 @@ export const WPVersionSelector = ( {
 				{ selectedValue !== 'latest' && (
 					<Tooltip
 						text={ __( 'WordPress Core automatic updates will be disabled for this site.' ) }
-						placement="top"
+						placement="left"
 					>
 						<Icon icon={ warning } size={ 16 } />
 					</Tooltip>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-454 and https://github.com/Automattic/studio/issues/1334

## Proposed Changes

- Update tooltip rendering position to avoid unwanted overlay and screen shaking 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Check out this PR.
- Apply temp change to see the onboarding screen.
```diff
diff --git a/src/components/app.tsx b/src/components/app.tsx
index c06b9cb..3224a7d 100644
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -20,7 +20,7 @@ import { WhatsNewModal, useWhatsNew } from 'src/modules/whats-new';
 
 export default function App() {
        useLocalizationSupport();
-       const { needsOnboarding } = useOnboarding();
+       const { needsOnboarding } = { needsOnboarding: true }; //useOnboarding();
        const { isSidebarVisible, toggleSidebar } = useSidebarVisibility();
        const { showWhatsNew, closeWhatsNew } = useWhatsNew();
```
- Start the Studio by running `npm start`
- Click on `Advanced settings`
- Select a WordPress version number other than `latest`. 
- The tooltip will be displayed. 
- Hover the cursor on the info icon. 
- Make sure the screen doesn't shake or create any additional overlay. 

![CleanShot 2025-05-07 at 12 35 18@2x](https://github.com/user-attachments/assets/5dfa05ef-4457-4171-a514-6427ac776006)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
