### PR TITLE
Sync: Add a tooltip to inform user about email notification they will receive once pushing is complete

### DIFF
--- a/src/components/sync-connected-sites.tsx
+++ b/src/components/sync-connected-sites.tsx
@@ -335,7 +335,7 @@ const SyncConnectedSitesList = ( {
 								>
 									<div className="flex flex-col gap-2 min-w-44">
 										<div className="a8c-body-small flex items-center gap-0.5">
-											<Icon icon={ info } size={ 16 } />
+											{ pressableSyncEnabled && <Icon icon={ info } size={ 16 } /> }
 											{ pushState.status.message }
 										</div>
 										<ProgressBar value={ pushState.status.progress } maxValue={ 100 } />

--- a/src/components/sync-connected-sites.tsx
+++ b/src/components/sync-connected-sites.tsx
@@ -324,10 +324,17 @@ const SyncConnectedSitesList = ( {
 								</SyncPullPushClear>
 							) }
 							{ pushState?.status && isPushing && (
-								<div className="flex flex-col gap-2 min-w-44">
-									<div className="a8c-body-small">{ pushState.status.message }</div>
-									<ProgressBar value={ pushState.status.progress } maxValue={ 100 } />
-								</div>
+								<Tooltip
+									text={ __(
+										'Pushing is in progress. We will send you an email when it is completed.'
+									) }
+									placement="top-start"
+								>
+									<div className="flex flex-col gap-2 min-w-44">
+										<div className="a8c-body-small">{ pushState.status.message }</div>
+										<ProgressBar value={ pushState.status.progress } maxValue={ 100 } />
+									</div>
+								</Tooltip>
 							) }
 
 							{ pushState?.status && hasPushFinished && (

--- a/src/components/sync-connected-sites.tsx
+++ b/src/components/sync-connected-sites.tsx
@@ -17,6 +17,7 @@ import { Tooltip, DynamicTooltip } from 'src/components/tooltip';
 import { WordPressLogoCircle } from 'src/components/wordpress-logo-circle';
 import { useSyncSites } from 'src/hooks/sync-sites';
 import { useConfirmationDialog } from 'src/hooks/use-confirmation-dialog';
+import { useFeatureFlags } from 'src/hooks/use-feature-flags';
 import { useI18nData } from 'src/hooks/use-i18n-data';
 import { ImportProgressState, useImportExport } from 'src/hooks/use-import-export';
 import { useOffline } from 'src/hooks/use-offline';
@@ -233,6 +234,7 @@ const SyncConnectedSitesList = ( {
 	const { clearPullState, getPullState, getPushState, clearPushState } = useSyncSites();
 	const { importState } = useImportExport();
 	const { isKeyPulling, isKeyPushing, isKeyFinished, isKeyFailed } = useSyncStatesProgressInfo();
+	const { pressableSyncEnabled } = useFeatureFlags();
 
 	return (
 		<div className="grid grid-cols-[max-content_1fr_max-content]">
@@ -329,6 +331,7 @@ const SyncConnectedSitesList = ( {
 										'Push is in progress. We will send you an email when it is completed.'
 									) }
 									placement="top-start"
+									disabled={ ! pressableSyncEnabled }
 								>
 									<div className="flex flex-col gap-2 min-w-44">
 										<div className="a8c-body-small flex items-center gap-0.5">

--- a/src/components/sync-connected-sites.tsx
+++ b/src/components/sync-connected-sites.tsx
@@ -326,7 +326,7 @@ const SyncConnectedSitesList = ( {
 							{ pushState?.status && isPushing && (
 								<Tooltip
 									text={ __(
-										'Pushing is in progress. We will send you an email when it is completed.'
+										'Push is in progress. We will send you an email when it is completed.'
 									) }
 									placement="top-start"
 								>

--- a/src/components/sync-connected-sites.tsx
+++ b/src/components/sync-connected-sites.tsx
@@ -1,7 +1,7 @@
 import { Icon } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { I18n, sprintf } from '@wordpress/i18n';
-import { cloudUpload, cloudDownload } from '@wordpress/icons';
+import { cloudUpload, cloudDownload, info } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { useMemo } from 'react';
 import { ArrowIcon } from 'src/components/arrow-icon';
@@ -331,7 +331,10 @@ const SyncConnectedSitesList = ( {
 									placement="top-start"
 								>
 									<div className="flex flex-col gap-2 min-w-44">
-										<div className="a8c-body-small">{ pushState.status.message }</div>
+										<div className="a8c-body-small flex items-center gap-0.5">
+											<Icon icon={ info } size={ 16 } />
+											{ pushState.status.message }
+										</div>
 										<ProgressBar value={ pushState.status.progress } maxValue={ 100 } />
 									</div>
 								</Tooltip>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Related to STU-208-linear-issue.

## Proposed Changes

- add a tooltip to inform user about email notification they will receive once pushing is complete

![Markup on 2025-05-13 at 15:21:25](https://github.com/user-attachments/assets/cb792eac-cbf5-475d-90ad-415ee1703e1e)

This is UI update related to a backend change that will trigger an email notification to the user. This is being worked on in 182285-ghe-Automattic/wpcom (not ready for review yet).

**Please do not merge this Studio PR until the backend PR is merged and deployed.**

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR branch and build the app with `STUDIO_PRESSABLE_SYNC=true npm start`.
2. Initiate push operation on one of the connected sites.
3. There should be a new tooltip displayed over the progress bar (as can be seen in the screenshot).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?