### PR TITLE
Small type fixes and cleanup

### DIFF
--- a/src/components/tests/content-tab-overview-shortcuts-section.test.tsx
+++ b/src/components/tests/content-tab-overview-shortcuts-section.test.tsx
@@ -207,7 +207,7 @@ describe( 'ShortcutsSection', () => {
 		mockGetIpcApi.mockReturnValue( {
 			openLocalPath: jest.fn(),
 			getUserEditor: jest.fn().mockResolvedValue( 'cursor' ),
-			getUserTerminal: jest.fn().mockResolvedValue( null ),
+			getUserTerminal: jest.fn().mockResolvedValue( 'terminal' ),
 		} );
 
 		const { queryByLabelText, findByLabelText } = renderWithProvider(

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -1027,7 +1027,7 @@ export async function openTerminalAtPath(
 		initScriptSteps.push( `cd \\"${ escapedPath }\\"`, 'clear' );
 
 		const userData = await loadUserData();
-		const preferredTerminal = ( userData.preferredTerminal || 'terminal' ) as SupportedTerminal;
+		const preferredTerminal = userData.preferredTerminal || DEFAULT_TERMINAL;
 
 		if ( preferredTerminal === 'warp' ) {
 			return promiseExec( `open -a Warp "${ targetPath }"` );
@@ -1324,7 +1324,7 @@ export async function saveUserTerminal(
 
 export async function getUserTerminal( _event: IpcMainInvokeEvent ): Promise< SupportedTerminal > {
 	const userData = await loadUserData();
-	return ( userData.preferredTerminal || DEFAULT_TERMINAL ) as SupportedTerminal;
+	return userData.preferredTerminal || DEFAULT_TERMINAL;
 }
 
 export async function isFullscreen( _event: IpcMainInvokeEvent ): Promise< boolean > {
@@ -1338,10 +1338,6 @@ export async function getAllCustomDomains(): Promise< string[] > {
 	return userData.sites
 		.map( ( site ) => site.customDomain )
 		.filter( ( domain ): domain is string => domain !== undefined );
-}
-
-export function getRandomUUID(): crypto.UUID {
-	return crypto.randomUUID();
 }
 
 export async function createSnapshot(

--- a/src/modules/user-settings/components/editor-picker.tsx
+++ b/src/modules/user-settings/components/editor-picker.tsx
@@ -25,9 +25,9 @@ export const EditorPicker = ( { value, onChange, disabled }: EditorPickerProps )
 
 	return (
 		<SettingsFormField label={ __( 'Code editor' ) }>
-			<SelectControl
+			<SelectControl< SupportedEditor >
 				value={ value }
-				onChange={ ( newValue ) => onChange( newValue as SupportedEditor ) }
+				onChange={ ( newValue ) => onChange( newValue ) }
 				__nextHasNoMarginBottom
 				__next40pxDefaultSize
 				disabled={ disabled }

--- a/src/modules/user-settings/components/terminal-picker.tsx
+++ b/src/modules/user-settings/components/terminal-picker.tsx
@@ -24,9 +24,9 @@ export const TerminalPicker = ( { value, onChange }: TerminalPickerProps ) => {
 
 	return (
 		<SettingsFormField label={ __( 'Terminal application' ) }>
-			<SelectControl
+			<SelectControl< SupportedTerminal >
 				value={ value }
-				onChange={ ( newValue ) => onChange( newValue as SupportedTerminal ) }
+				onChange={ ( newValue ) => onChange( newValue ) }
 				__nextHasNoMarginBottom
 				__next40pxDefaultSize
 			>

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -44,7 +44,6 @@ const api: IpcApi = {
 	updateSnapshot: ( siteFolder, hostname ) =>
 		ipcRendererInvoke( 'updateSnapshot', siteFolder, hostname ),
 	deleteSnapshot: ( hostname ) => ipcRendererInvoke( 'deleteSnapshot', hostname ),
-	getRandomUUID: () => ipcRendererInvoke( 'getRandomUUID' ),
 	getLastSeenVersion: () => ipcRendererInvoke( 'getLastSeenVersion' ),
 	saveLastSeenVersion: ( version ) => ipcRendererInvoke( 'saveLastSeenVersion', version ),
 	getSiteDetails: () => ipcRendererInvoke( 'getSiteDetails' ),

--- a/src/stores/installed-apps-api.ts
+++ b/src/stores/installed-apps-api.ts
@@ -45,7 +45,7 @@ export const installedAppsApi = createApi( {
 		getUserTerminal: builder.query< SupportedTerminal, void >( {
 			queryFn: async () => {
 				const terminal = await getIpcApi().getUserTerminal();
-				return { data: terminal || 'terminal' };
+				return { data: terminal };
 			},
 			providesTags: [ 'UserPreferences' ],
 		} ),

--- a/src/stores/snapshot-slice.ts
+++ b/src/stores/snapshot-slice.ts
@@ -1,4 +1,3 @@
-import crypto from 'crypto';
 import {
 	createAction,
 	createAsyncThunk,
@@ -15,6 +14,7 @@ import { LIMIT_OF_ZIP_SITES_PER_USER } from 'src/constants';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 import { RootState, store } from 'src/stores/index';
 import { wpcomApi } from 'src/stores/wpcom-api';
+import type { UUID } from 'crypto';
 
 type BaseOperation = {
 	error: string | null;
@@ -41,7 +41,7 @@ type DeleteOperation = BaseOperation & {
 };
 
 type BulkOperation = Omit< BaseOperation, 'progress' > & {
-	operationIds: crypto.UUID[];
+	operationIds: UUID[];
 	siteId?: string;
 	type: 'bulk';
 	userId?: number;
@@ -50,7 +50,7 @@ type BulkOperation = Omit< BaseOperation, 'progress' > & {
 export type SnapshotOperation = CreateOperation | UpdateOperation | DeleteOperation | BulkOperation;
 
 type SnapshotState = {
-	operations: Record< crypto.UUID, SnapshotOperation >;
+	operations: Record< UUID, SnapshotOperation >;
 	snapshots: Snapshot[];
 	snapshotQuota: number;
 };
@@ -97,7 +97,7 @@ const deleteSnapshot = createAsyncThunk(
 
 async function deleteMultipleSnapshots(
 	snapshots: Snapshot[]
-): Promise< [ url: string, operationId: crypto.UUID ][] > {
+): Promise< [ url: string, operationId: UUID ][] > {
 	return await Promise.all(
 		snapshots.map( async ( snapshot ) => {
 			const { operationId } = await getIpcApi().deleteSnapshot( snapshot.url );
@@ -112,7 +112,7 @@ const deleteAllSnapshotsForSite = createAsyncThunk(
 		const state = thunkAPI.getState() as RootState;
 		const snapshots = snapshotSelectors.selectSnapshotsBySite( state, siteId );
 		const operations = await deleteMultipleSnapshots( snapshots );
-		const bulkOperationId = await getIpcApi().getRandomUUID();
+		const bulkOperationId = window.crypto.randomUUID();
 
 		return { operations, bulkOperationId };
 	}
@@ -124,7 +124,7 @@ const deleteAllSnapshotsForUser = createAsyncThunk(
 		const state = thunkAPI.getState() as RootState;
 		const snapshots = snapshotSelectors.selectSnapshotsByUser( state, userId );
 		const operations = await deleteMultipleSnapshots( snapshots );
-		const bulkOperationId = await getIpcApi().getRandomUUID();
+		const bulkOperationId = window.crypto.randomUUID();
 
 		return { operations, bulkOperationId };
 	}
@@ -149,7 +149,7 @@ const snapshotSlice = createSlice( {
 		},
 		updateOperation: (
 			state,
-			action: PayloadAction< { operationId: crypto.UUID; operation: Partial< SnapshotOperation > } >
+			action: PayloadAction< { operationId: UUID; operation: Partial< SnapshotOperation > } >
 		) => {
 			Object.assign( state.operations[ action.payload.operationId ], action.payload.operation );
 		},
@@ -336,19 +336,14 @@ function getCreateProgress( action: PreviewCommandLoggerAction ): [ string, numb
 	}
 }
 
-function getOperation( operationId: crypto.UUID ) {
+function getOperation( operationId: UUID ) {
 	const state = store.getState();
 	return state.snapshot.operations[ operationId ];
 }
 
-function getAssociatedBulkOperation(
-	targetOperationId: crypto.UUID
-): [ crypto.UUID, BulkOperation ] | [] {
+function getAssociatedBulkOperation( targetOperationId: UUID ): [ UUID, BulkOperation ] | [] {
 	const state = store.getState();
-	const entries = Object.entries( state.snapshot.operations ) as [
-		crypto.UUID,
-		SnapshotOperation,
-	][];
+	const entries = Object.entries( state.snapshot.operations ) as [ UUID, SnapshotOperation ][];
 
 	for ( const [ operationId, operation ] of entries ) {
 		if ( operation.type === 'bulk' && operation.operationIds.includes( targetOperationId ) ) {
@@ -399,7 +394,7 @@ window.ipcListener.subscribe( 'snapshot-key-value', ( event, payload ) => {
 	);
 } );
 
-function errorEventHandler( operationId: crypto.UUID, message: string ) {
+function errorEventHandler( operationId: UUID, message: string ) {
 	const operation = getOperation( operationId );
 	if ( ! operation || operation.status !== 'pending' ) {
 		return;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Related to https://github.com/Automattic/studio/pull/1320#discussion_r2073190779

## Proposed Changes

- Removed a few superfluous `as` operators. 
- Removed a superfluous fallback value from `src/stores/installed-apps-api.ts`. 
- Removed the `getRandomUUID` function from ipc-handlers because we can use `window.crypto.randomUUID()` instead in `src/stores/snapshot-slice.ts`.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Code review should suffice for the type fixes
2. For the UUID generation, follow these steps:
3. Have at least one preview site
4. Open the settings modal and go to the Usage tab
5. Delete all preview sites from there
6. Ensure that the operation completes successfully, and you see a desktop notification

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
