### PR TITLE
Update Customize buttons to make them always active

### DIFF
--- a/src/components/content-tab-overview.tsx
+++ b/src/components/content-tab-overview.tsx
@@ -50,51 +50,49 @@ function CustomizeSection( {
 	themeDetails?: SiteDetails[ 'themeDetails' ];
 	loading?: boolean;
 } ) {
+	const { startServer, loadingServer } = useSiteDetails();
+	const isLoading = selectedSite?.id ? loadingServer[ selectedSite.id ] : false;
+
+	const handleCustomizeClick = (url: string) => async () => {
+		if ( isLoading ) return;
+		if ( !selectedSite.running ) {
+			await startServer( selectedSite.id );
+		}
+		getIpcApi().openSiteURL( selectedSite.id, url );
+	};
+
 	const blockThemeButtons: ButtonsSectionProps[ 'buttonsArray' ] = [
 		{
 			label: __( 'Site Editor' ),
 			icon: desktop,
-			onClick: () => {
-				getIpcApi().openSiteURL( selectedSite.id, '/wp-admin/site-editor.php' );
-			},
+			onClick: handleCustomizeClick( '/wp-admin/site-editor.php' ),
 		},
 		{
 			label: __( 'Styles' ),
 			icon: styles,
-			onClick: () => {
-				getIpcApi().openSiteURL(
-					selectedSite.id,
-					'/wp-admin/site-editor.php?path=%2Fwp_global_styles'
-				);
-			},
+			onClick: handleCustomizeClick(
+				'/wp-admin/site-editor.php?path=%2Fwp_global_styles'
+			),
 		},
 		{
 			label: __( 'Patterns' ),
 			icon: symbolFilled,
-			onClick: () => {
-				getIpcApi().openSiteURL( selectedSite.id, '/wp-admin/site-editor.php?path=%2Fpatterns' );
-			},
+			onClick: handleCustomizeClick( '/wp-admin/site-editor.php?path=%2Fpatterns' ),
 		},
 		{
 			label: __( 'Navigation' ),
 			icon: navigation,
-			onClick: () => {
-				getIpcApi().openSiteURL( selectedSite.id, '/wp-admin/site-editor.php?path=%2Fnavigation' );
-			},
+			onClick: handleCustomizeClick( '/wp-admin/site-editor.php?path=%2Fnavigation' ),
 		},
 		{
 			label: __( 'Templates' ),
 			icon: layout,
-			onClick: () => {
-				getIpcApi().openSiteURL( selectedSite.id, '/wp-admin/site-editor.php?path=%2Fwp_template' );
-			},
+			onClick: handleCustomizeClick( '/wp-admin/site-editor.php?path=%2Fwp_template' ),
 		},
 		{
 			label: __( 'Pages' ),
 			icon: page,
-			onClick: () => {
-				getIpcApi().openSiteURL( selectedSite.id, '/wp-admin/site-editor.php?path=%2Fpage' );
-			},
+			onClick: handleCustomizeClick( '/wp-admin/site-editor.php?path=%2Fpage' ),
 		},
 	];
 
@@ -102,7 +100,7 @@ function CustomizeSection( {
 		{
 			label: __( 'Customizer' ),
 			icon: edit,
-			onClick: () => getIpcApi().openSiteURL( selectedSite.id, '/wp-admin/customize.php' ),
+			onClick: handleCustomizeClick( '/wp-admin/customize.php' ),
 		},
 	];
 
@@ -110,7 +108,7 @@ function CustomizeSection( {
 		classicThemeButtons.push( {
 			label: __( 'Menus' ),
 			icon: navigation,
-			onClick: () => getIpcApi().openSiteURL( selectedSite.id, '/wp-admin/nav-menus.php' ),
+			onClick: handleCustomizeClick( '/wp-admin/nav-menus.php' ),
 		} );
 	}
 
@@ -118,7 +116,7 @@ function CustomizeSection( {
 		classicThemeButtons.push( {
 			label: __( 'Widgets' ),
 			icon: widget,
-			onClick: () => getIpcApi().openSiteURL( selectedSite.id, '/wp-admin/widgets.php' ),
+			onClick: handleCustomizeClick( '/wp-admin/widgets.php' ),
 		} );
 	}
 
@@ -126,7 +124,7 @@ function CustomizeSection( {
 
 	const processedButtons = buttonsArray.map( ( button ) => ( {
 		...button,
-		disabled: ! selectedSite.running,
+		disabled: isLoading,
 	} ) );
 
 	const sectionHeading = __( 'Customize' );

--- a/src/components/content-tab-overview.tsx
+++ b/src/components/content-tab-overview.tsx
@@ -53,9 +53,9 @@ function CustomizeSection( {
 	const { startServer, loadingServer } = useSiteDetails();
 	const isLoading = selectedSite?.id ? loadingServer[ selectedSite.id ] : false;
 
-	const handleCustomizeClick = (url: string) => async () => {
+	const handleCustomizeClick = ( url: string ) => async () => {
 		if ( isLoading ) return;
-		if ( !selectedSite.running ) {
+		if ( ! selectedSite.running ) {
 			await startServer( selectedSite.id );
 		}
 		getIpcApi().openSiteURL( selectedSite.id, url );
@@ -70,9 +70,7 @@ function CustomizeSection( {
 		{
 			label: __( 'Styles' ),
 			icon: styles,
-			onClick: handleCustomizeClick(
-				'/wp-admin/site-editor.php?path=%2Fwp_global_styles'
-			),
+			onClick: handleCustomizeClick( '/wp-admin/site-editor.php?path=%2Fwp_global_styles' ),
 		},
 		{
 			label: __( 'Patterns' ),

--- a/src/components/tests/content-tab-overview.test.tsx
+++ b/src/components/tests/content-tab-overview.test.tsx
@@ -2,6 +2,7 @@
 import { render, screen } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { ContentTabOverview } from 'src/components/content-tab-overview';
+import { useSiteDetails } from 'src/hooks/use-site-details';
 import { useThemeDetails } from 'src/hooks/use-theme-details';
 import { store } from 'src/stores';
 import { testActions, testReducer } from 'src/stores/tests/utils/test-reducer';
@@ -9,7 +10,7 @@ import { testActions, testReducer } from 'src/stores/tests/utils/test-reducer';
 jest.mock( 'src/lib/app-globals', () => ( {
 	isWindows: jest.fn().mockReturnValue( false ),
 } ) );
-
+jest.mock( 'src/hooks/use-site-details' );
 jest.mock( 'src/hooks/use-theme-details' );
 jest.mock( 'src/lib/get-ipc-api', () => ( {
 	getIpcApi: jest.fn().mockReturnValue( {
@@ -51,6 +52,7 @@ const blockThemeButtonLabels = [
 describe( 'ContentTabOverview', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
+		( useSiteDetails as jest.Mock ).mockReturnValue( {} );
 		store.dispatch( testActions.resetState() );
 	} );
 
@@ -82,6 +84,10 @@ describe( 'ContentTabOverview', () => {
 
 	describe( 'with block theme', () => {
 		test( 'renders all relevant "Customize" buttons for block themes', () => {
+			( useSiteDetails as jest.Mock ).mockReturnValue( {
+				loadingServer: { 'site-id': false },
+			} );
+
 			renderWithThemeDetails( { isBlockTheme: true } );
 
 			blockThemeButtonLabels.forEach( ( label ) => {
@@ -94,7 +100,12 @@ describe( 'ContentTabOverview', () => {
 			expect( screen.queryByText( 'Widgets' ) ).not.toBeInTheDocument();
 		} );
 
-		test( '"Customize" buttons are disabled when the server is not running', () => {
+		test( '"Customize" buttons are disabled when the server is starting', () => {
+			( useSiteDetails as jest.Mock ).mockReturnValue( {
+				selectedSite: { id: 'site-id' },
+				loadingServer: { 'site-id': true },
+			} );
+
 			renderWithThemeDetails( { isBlockTheme: true, selectedSite: notRunningSite } );
 
 			blockThemeButtonLabels.forEach( ( label ) => {
@@ -107,6 +118,10 @@ describe( 'ContentTabOverview', () => {
 	describe( 'with classic theme', () => {
 		describe( 'without widget support', () => {
 			test( 'renders only Customizer and Menus buttons', () => {
+				( useSiteDetails as jest.Mock ).mockReturnValue( {
+					loadingServer: { 'site-id': false },
+				} );
+
 				renderWithThemeDetails( {
 					isBlockTheme: false,
 					supportsWidgets: false,
@@ -126,6 +141,10 @@ describe( 'ContentTabOverview', () => {
 
 		describe( 'without menu support', () => {
 			test( 'renders only Customizer and Widgets buttons', () => {
+				( useSiteDetails as jest.Mock ).mockReturnValue( {
+					loadingServer: { 'site-id': false },
+				} );
+
 				renderWithThemeDetails( {
 					isBlockTheme: false,
 					supportsWidgets: true,
@@ -145,6 +164,10 @@ describe( 'ContentTabOverview', () => {
 
 		describe( 'with both widget and menu support', () => {
 			test( 'renders Customizer, Menus, and Widgets buttons', () => {
+				( useSiteDetails as jest.Mock ).mockReturnValue( {
+					loadingServer: { 'site-id': false },
+				} );
+
 				renderWithThemeDetails( {
 					isBlockTheme: false,
 					supportsWidgets: true,
@@ -161,7 +184,12 @@ describe( 'ContentTabOverview', () => {
 				} );
 			} );
 
-			test( '"Customize" buttons are disabled when the server is not running', () => {
+			test( '"Customize" buttons are disabled when the server is starting', () => {
+				( useSiteDetails as jest.Mock ).mockReturnValue( {
+					selectedSite: { id: 'site-id' },
+					loadingServer: { 'site-id': true },
+				} );
+
 				renderWithThemeDetails( {
 					isBlockTheme: false,
 					supportsWidgets: true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-357

## Proposed Changes

- I propose to change Customize buttons to make them always active and auto-start site when clicked.

<img width="1012" alt="Screenshot 2025-05-07 at 18 49 22" src="https://github.com/user-attachments/assets/6fd64178-6aae-4cf4-b595-c8006c6ab608" />

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Stop the site
2. Click Customize buttons and confirm they open site after it is started
3. Test Classic theme, too.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
