### PR TITLE
Import/Export: Display progress only if not syncing

### DIFF
--- a/src/components/content-tab-import-export.tsx
+++ b/src/components/content-tab-import-export.tsx
@@ -34,8 +34,7 @@ export const ExportSite = ( {
 	const { [ selectedSite.id ]: currentProgress } = exportState;
 	const isImporting = importState[ selectedSite.id ]?.progress < 100;
 	const isExportDisabled = isImporting || isThisSiteSyncing;
-	const shouldDisplayProgress =
-		currentProgress && currentProgress.progress < 100 && ! isThisSiteSyncing;
+	const shouldDisplayProgress = currentProgress && ! isThisSiteSyncing;
 
 	let tooltipText;
 	if ( isThisSiteSyncing ) {

--- a/src/components/content-tab-import-export.tsx
+++ b/src/components/content-tab-import-export.tsx
@@ -34,6 +34,8 @@ export const ExportSite = ( {
 	const { [ selectedSite.id ]: currentProgress } = exportState;
 	const isImporting = importState[ selectedSite.id ]?.progress < 100;
 	const isExportDisabled = isImporting || isThisSiteSyncing;
+	const shouldDisplayProgress =
+		currentProgress && currentProgress.progress < 100 && ! isThisSiteSyncing;
 
 	let tooltipText;
 	if ( isThisSiteSyncing ) {
@@ -61,7 +63,7 @@ export const ExportSite = ( {
 					{ __( 'Export your entire site or only the database.' ) }
 				</p>
 			</div>
-			{ currentProgress ? (
+			{ shouldDisplayProgress ? (
 				<div className="flex flex-col gap-4 max-w-[300px]">
 					<ProgressBar value={ currentProgress.progress } maxValue={ 100 } />
 					<div className="text-a8c-gray-70 a8c-body">{ currentProgress.statusMessage }</div>

--- a/src/hooks/sync-sites/use-sync-push.ts
+++ b/src/hooks/sync-sites/use-sync-push.ts
@@ -11,6 +11,7 @@ import {
 	usePullPushStates,
 } from 'src/hooks/sync-sites/use-pull-push-states';
 import { useAuth } from 'src/hooks/use-auth';
+import { useImportExport } from 'src/hooks/use-import-export';
 import {
 	useSyncStatesProgressInfo,
 	PushStateProgressInfo,
@@ -57,6 +58,7 @@ export function useSyncPush( {
 		getState: getPushState,
 		clearState,
 	} = usePullPushStates< SyncPushState >( pushStates, setPushStates );
+	const { clearExportState } = useImportExport();
 	const { pushStatesProgressInfo, isKeyPushing, isKeyFinished, isKeyFailed } =
 		useSyncStatesProgressInfo();
 
@@ -107,6 +109,7 @@ export function useSyncPush( {
 						? __( 'Staging has been updated' )
 						: __( 'Production has been updated' ),
 				} );
+				clearExportState( syncPushState.selectedSite.id );
 			} else if ( response.success && response.status === 'failed' ) {
 				status = pushStatesProgressInfo.failed;
 				getIpcApi().showErrorMessageBox( {
@@ -121,6 +124,7 @@ export function useSyncPush( {
 							  ),
 					showOpenLogs: true,
 				} );
+				clearExportState( syncPushState.selectedSite.id );
 			}
 			// Update state in any case to keep polling push state
 			updatePushState( syncPushState.selectedSite.id, syncPushState.remoteSiteId, {
@@ -129,6 +133,7 @@ export function useSyncPush( {
 		},
 		[
 			__,
+			clearExportState,
 			client,
 			onPushSuccess,
 			pushStatesProgressInfo.failed,

--- a/src/hooks/use-import-export.tsx
+++ b/src/hooks/use-import-export.tsx
@@ -44,6 +44,7 @@ interface ImportExportContext {
 	isSiteImporting: ( siteId: string ) => boolean;
 	isSiteExporting: ( siteId: string ) => boolean;
 	exportState: ExportProgressState;
+	clearExportState: ( siteId: string ) => void;
 	exportFullSite: ( selectedSite: SiteDetails ) => Promise< string | undefined >;
 	exportDatabase: ( selectedSite: SiteDetails ) => Promise< string | undefined >;
 }
@@ -55,6 +56,7 @@ const ImportExportContext = createContext< ImportExportContext >( {
 	isSiteImporting: () => false,
 	isSiteExporting: () => false,
 	exportState: {},
+	clearExportState: () => undefined,
 	exportFullSite: async () => undefined,
 	exportDatabase: async () => undefined,
 } );
@@ -303,6 +305,12 @@ export const ImportExportProvider = ( { children }: { children: React.ReactNode 
 		[ exportState ]
 	);
 
+	const clearExportState = useCallback( ( siteId: string ) => {
+		setExportState( ( { [ siteId ]: currentProgress, ...rest } ) => ( {
+			...rest,
+		} ) );
+	}, [] );
+
 	const isSiteExporting = useCallback(
 		( siteId: string ) => !! exportState[ siteId ] && exportState[ siteId ].progress < 100,
 		[ exportState ]
@@ -463,6 +471,7 @@ export const ImportExportProvider = ( { children }: { children: React.ReactNode 
 			isSiteImporting,
 			isSiteExporting,
 			exportState,
+			clearExportState,
 			exportFullSite,
 			exportDatabase,
 		} ),
@@ -473,6 +482,7 @@ export const ImportExportProvider = ( { children }: { children: React.ReactNode 
 			isSiteImporting,
 			isSiteExporting,
 			exportState,
+			clearExportState,
 			exportFullSite,
 			exportDatabase,
 		]


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-465

## Proposed Changes

- Refine the condition to display the Export progress bar so it is not displayed when Syncing
- Additionally, do not display the Export progress bar when it reaches 100 as it will be disabled anyway.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Run `npm start`
3. Go to Sync tab
5. Connect a site
7. Click on Push
9. Observe the progress bar appears with messages
11. Go to Import/Export tab
13. The progress bar should not be visible
15. When the Push finishes, the export progress bar should not be visible and the button should be enabled

In the linked task, there is a Video with the expected behaviour, [link here](https://linear.app/a8c/issue/STU-465/when-pushing-a-site-a-progress-bar-appears-in-the-importexport-tab#heading-expectation-9c56de4f)

#### Regression testing
11. Go to Import/Export tab
12. Export a site
13. The progress bar should be work as before. It should be displayed and progressed.
15. When the Export finishes, the export progress bar should not be visible and the button should be enabled


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
