### PR TITLE
Improve localization process to remove old phrases

### DIFF
--- a/docs/localization.md
+++ b/docs/localization.md
@@ -17,9 +17,9 @@ If you want to add support for another language you will need to add it to the
 
 #### Step 1: Extract Strings:
 
-   1. Run `npm run make-pot` to get the text out of the source
-   files.
-   
+   1. Remove `out/pots/` directory if it exists.
+   2. Run `npm run make-pot` to get the text out of the source files.
+
    This will create a `*.pot` file for each module, as well as a bundle
    of all translatable strings in `out/pots/bundle-strings.pot`.
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- N/A

## Proposed Changes

I propose to improve the localization process to remove old phrases when new bundle is generated. It seems that if previously created `out/pots/bundle-strings.pot` is not removed, running `npm run make-pot` will add phrases to the duplicate files. It results in leaving old phrases there.

To test the issue:

1. Run `wp-babel-makepot`
2. Update any phrase
3. Run `wp-babel-makepot` again
4. Confirm that both old and new phrase appear in the file

I checked `wp-babel-makepot` and I couldn't find any option that would allow me to purge the file.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Review new steps to ensure they are clear.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
