### PR TITLE
Revert "Studio Sync: Improve the percentage progress and add more states into account in PUSH progress bar"

### DIFF
--- a/src/components/sync-connected-sites.tsx
+++ b/src/components/sync-connected-sites.tsx
@@ -1,6 +1,6 @@
 import { Icon } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
-import { sprintf } from '@wordpress/i18n';
+import { I18n, sprintf } from '@wordpress/i18n';
 import { cloudUpload, cloudDownload } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { useMemo } from 'react';
@@ -18,9 +18,14 @@ import { WordPressLogoCircle } from 'src/components/wordpress-logo-circle';
 import { useSyncSites } from 'src/hooks/sync-sites';
 import { useConfirmationDialog } from 'src/hooks/use-confirmation-dialog';
 import { useI18nData } from 'src/hooks/use-i18n-data';
-import { useImportExport } from 'src/hooks/use-import-export';
+import { ImportProgressState, useImportExport } from 'src/hooks/use-import-export';
 import { useOffline } from 'src/hooks/use-offline';
-import { useSyncStatesProgressInfo } from 'src/hooks/use-sync-states-progress-info';
+import {
+	IMPORTING_INITIAL_VALUE,
+	IMPORTING_TO_FINISHED_STEP,
+	PullStateProgressInfo,
+	useSyncStatesProgressInfo,
+} from 'src/hooks/use-sync-states-progress-info';
 import { cx } from 'src/lib/cx';
 import { getDocsLink } from 'src/lib/get-docs-link';
 import { getIpcApi } from 'src/lib/get-ipc-api';
@@ -199,21 +204,35 @@ type SyncConnectedSitesListProps = {
 	connectedSites: SyncSite[];
 };
 
+const getStatusWithProgress = (
+	__: I18n[ '__' ],
+	sitePullState?: PullStateProgressInfo,
+	importState?: ImportProgressState[ string ]
+) => {
+	if ( ! importState && sitePullState ) {
+		return { message: sitePullState.message, progress: sitePullState.progress };
+	}
+	if ( importState ) {
+		if ( importState.progress === 100 ) {
+			return { message: __( 'Applying final details…' ), progress: 99 };
+		}
+		return {
+			message: importState.statusMessage,
+			progress:
+				IMPORTING_INITIAL_VALUE + IMPORTING_TO_FINISHED_STEP * ( importState.progress / 100 ),
+		};
+	}
+	return { message: '', progress: 0 };
+};
+
 const SyncConnectedSitesList = ( {
 	selectedSite,
 	connectedSites,
 }: SyncConnectedSitesListProps ) => {
 	const { __ } = useI18n();
 	const { clearPullState, getPullState, getPushState, clearPushState } = useSyncSites();
-	const { importState, exportState } = useImportExport();
-	const {
-		isKeyPulling,
-		isKeyPushing,
-		isKeyFinished,
-		isKeyFailed,
-		getPullStatusWithProgress,
-		getPushStatusWithProgress,
-	} = useSyncStatesProgressInfo();
+	const { importState } = useImportExport();
+	const { isKeyPulling, isKeyPushing, isKeyFinished, isKeyFailed } = useSyncStatesProgressInfo();
 
 	return (
 		<div className="grid grid-cols-[max-content_1fr_max-content]">
@@ -223,7 +242,8 @@ const SyncConnectedSitesList = ( {
 				const isPullError = sitePullState && isKeyFailed( sitePullState.status.key );
 				const hasPullFinished = sitePullState && isKeyFinished( sitePullState.status.key );
 				const { message: sitePullStatusMessage, progress: sitePullStatusProgress } =
-					getPullStatusWithProgress(
+					getStatusWithProgress(
+						__,
 						sitePullState?.status,
 						importState[ connectedSite.localSiteId ]
 					);
@@ -232,8 +252,6 @@ const SyncConnectedSitesList = ( {
 				const isPushing = pushState && isKeyPushing( pushState.status.key );
 				const isPushError = pushState && isKeyFailed( pushState.status.key );
 				const hasPushFinished = pushState && isKeyFinished( pushState.status.key );
-				const { message: sitePushStatusMessage, progress: sitePushStatusProgress } =
-					getPushStatusWithProgress( pushState?.status, exportState[ connectedSite.localSiteId ] );
 
 				return (
 					<div
@@ -307,8 +325,8 @@ const SyncConnectedSitesList = ( {
 							) }
 							{ pushState?.status && isPushing && (
 								<div className="flex flex-col gap-2 min-w-44">
-									<div className="a8c-body-small">{ sitePushStatusMessage }</div>
-									<ProgressBar value={ sitePushStatusProgress } maxValue={ 100 } />
+									<div className="a8c-body-small">{ pushState.status.message }</div>
+									<ProgressBar value={ pushState.status.progress } maxValue={ 100 } />
 								</div>
 							) }
 

--- a/src/hooks/sync-sites/use-sync-pull.ts
+++ b/src/hooks/sync-sites/use-sync-pull.ts
@@ -14,9 +14,11 @@ import { useAuth } from 'src/hooks/use-auth';
 import { useImportExport } from 'src/hooks/use-import-export';
 import { useSiteDetails } from 'src/hooks/use-site-details';
 import {
+	IN_PROGRESS_INITIAL_VALUE,
+	IN_PROGRESS_TO_DOWNLOADING_STEP,
 	PullStateProgressInfo,
+	PullStateProgressInfoValues,
 	useSyncStatesProgressInfo,
-	type SyncBackupResponse,
 } from 'src/hooks/use-sync-states-progress-info';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 import type { SyncSite } from 'src/hooks/use-fetch-wpcom-sites/types';
@@ -41,6 +43,12 @@ type UseSyncPullProps = {
 	onPullSuccess?: OnPullSuccess;
 };
 
+type SyncBackupResponse = {
+	status: 'in-progress' | 'finished' | 'failed';
+	download_url: string;
+	percent: number;
+};
+
 export type UseSyncPull = {
 	pullStates: PullStates;
 	getPullState: GetState< SyncBackupState >;
@@ -58,13 +66,8 @@ export function useSyncPull( {
 	const { __ } = useI18n();
 	const { client } = useAuth();
 	const { importFile, clearImportState } = useImportExport();
-	const {
-		pullStatesProgressInfo,
-		isKeyPulling,
-		isKeyFinished,
-		isKeyFailed,
-		getBackupStatusWithProgress,
-	} = useSyncStatesProgressInfo();
+	const { pullStatesProgressInfo, isKeyPulling, isKeyFinished, isKeyFailed } =
+		useSyncStatesProgressInfo();
 	const {
 		updateState,
 		getState: getPullState,
@@ -305,14 +308,7 @@ export function useSyncPull( {
 				throw error;
 			}
 		},
-		[
-			client,
-			getBackupStatusWithProgress,
-			getPullState,
-			onBackupCompleted,
-			pullStatesProgressInfo,
-			updatePullState,
-		]
+		[ client, getPullState, onBackupCompleted, pullStatesProgressInfo, updatePullState ]
 	);
 
 	useEffect( () => {
@@ -351,4 +347,23 @@ export function useSyncPull( {
 	);
 
 	return { pullStates, getPullState, pullSite, isAnySitePulling, isSiteIdPulling, clearPullState };
+}
+function getBackupStatusWithProgress(
+	hasBackupCompleted: boolean,
+	pullStatesProgressInfo: PullStateProgressInfoValues,
+	response: SyncBackupResponse
+) {
+	const frontendStatus = hasBackupCompleted
+		? pullStatesProgressInfo.downloading.key
+		: response.status;
+	let newProgressInfo: PullStateProgressInfo | null = null;
+	if ( response.status === 'in-progress' ) {
+		newProgressInfo = pullStatesProgressInfo[ frontendStatus ];
+		newProgressInfo.progress =
+			IN_PROGRESS_INITIAL_VALUE + IN_PROGRESS_TO_DOWNLOADING_STEP * ( response.percent / 100 );
+	}
+	const statusWithProgress =
+		newProgressInfo || pullStatesProgressInfo[ frontendStatus ] || pullStatesProgressInfo.failed;
+
+	return statusWithProgress;
 }

--- a/src/hooks/use-import-export.tsx
+++ b/src/hooks/use-import-export.tsx
@@ -26,7 +26,7 @@ export type ImportProgressState = {
 	};
 };
 
-export type ExportProgressState = {
+type ExportProgressState = {
 	[ siteId: string ]: {
 		statusMessage: string;
 		progress: number;

--- a/src/hooks/use-sync-states-progress-info.ts
+++ b/src/hooks/use-sync-states-progress-info.ts
@@ -1,6 +1,5 @@
 import { useI18n } from '@wordpress/react-i18n';
 import { useCallback, useMemo } from 'react';
-import { ExportProgressState, ImportProgressState } from './use-import-export';
 
 export type PullStateProgressInfo = {
 	key: 'in-progress' | 'downloading' | 'importing' | 'finished' | 'failed' | 'cancelled';
@@ -18,19 +17,13 @@ export type PullStateProgressInfoValues = Record<
 	PullStateProgressInfo
 >;
 
-export type SyncBackupResponse = {
-	status: 'in-progress' | 'finished' | 'failed';
-	download_url: string;
-	percent: number;
-};
-
-const IN_PROGRESS_INITIAL_VALUE = 30;
+export const IN_PROGRESS_INITIAL_VALUE = 30;
 const DOWNLOADING_INITIAL_VALUE = 60;
-const IN_PROGRESS_TO_DOWNLOADING_STEP = DOWNLOADING_INITIAL_VALUE - IN_PROGRESS_INITIAL_VALUE;
-const IMPORTING_INITIAL_VALUE = 80;
-const IMPORTING_TO_FINISHED_STEP = 100 - IMPORTING_INITIAL_VALUE;
+export const IN_PROGRESS_TO_DOWNLOADING_STEP =
+	DOWNLOADING_INITIAL_VALUE - IN_PROGRESS_INITIAL_VALUE;
+export const IMPORTING_INITIAL_VALUE = 80;
+export const IMPORTING_TO_FINISHED_STEP = 100 - IMPORTING_INITIAL_VALUE;
 
-const EXPORTING_TO_UPLOADING_STEP = 50;
 export function useSyncStatesProgressInfo() {
 	const { __ } = useI18n();
 	const pullStatesProgressInfo = useMemo( () => {
@@ -73,12 +66,12 @@ export function useSyncStatesProgressInfo() {
 		return {
 			creatingBackup: {
 				key: 'creatingBackup',
-				progress: 0,
-				message: __( 'Starting export…' ),
+				progress: 30,
+				message: __( 'Creating backup…' ),
 			},
 			uploading: {
 				key: 'uploading',
-				progress: EXPORTING_TO_UPLOADING_STEP,
+				progress: 50,
 				message: __( 'Uploading Studio site…' ),
 			},
 			importing: {
@@ -137,67 +130,6 @@ export function useSyncStatesProgressInfo() {
 		[]
 	);
 
-	const getBackupStatusWithProgress = useCallback(
-		(
-			hasBackupCompleted: boolean,
-			pullStatesProgressInfo: PullStateProgressInfoValues,
-			response: SyncBackupResponse
-		) => {
-			const frontendStatus = hasBackupCompleted
-				? pullStatesProgressInfo.downloading.key
-				: response.status;
-			let newProgressInfo: PullStateProgressInfo | null = null;
-			if ( response.status === 'in-progress' ) {
-				newProgressInfo = pullStatesProgressInfo[ frontendStatus ];
-				newProgressInfo.progress =
-					IN_PROGRESS_INITIAL_VALUE + IN_PROGRESS_TO_DOWNLOADING_STEP * ( response.percent / 100 );
-			}
-			const statusWithProgress =
-				newProgressInfo ||
-				pullStatesProgressInfo[ frontendStatus ] ||
-				pullStatesProgressInfo.failed;
-
-			return statusWithProgress;
-		},
-		[]
-	);
-
-	const getPullStatusWithProgress = useCallback(
-		( sitePullState?: PullStateProgressInfo, importState?: ImportProgressState[ string ] ) => {
-			if ( ! importState && sitePullState ) {
-				return { message: sitePullState.message, progress: sitePullState.progress };
-			}
-			if ( importState ) {
-				if ( importState.progress === 100 ) {
-					return { message: __( 'Applying final details…' ), progress: 99 };
-				}
-				return {
-					message: importState.statusMessage,
-					progress:
-						IMPORTING_INITIAL_VALUE + IMPORTING_TO_FINISHED_STEP * ( importState.progress / 100 ),
-				};
-			}
-			return { message: '', progress: 0 };
-		},
-		[ __ ]
-	);
-
-	const getPushStatusWithProgress = useCallback(
-		( sitePushState?: PushStateProgressInfo, exportState?: ExportProgressState[ string ] ) => {
-			if ( exportState && exportState.progress < 100 ) {
-				return {
-					message: exportState.statusMessage,
-					progress: EXPORTING_TO_UPLOADING_STEP * ( exportState.progress / 100 ),
-				};
-			}
-			if ( sitePushState ) {
-				return { message: sitePushState.message, progress: sitePushState.progress };
-			}
-			return { message: '', progress: 0 };
-		},
-		[]
-	);
-
 	return {
 		pullStatesProgressInfo,
 		pushStatesProgressInfo,
@@ -205,8 +137,5 @@ export function useSyncStatesProgressInfo() {
 		isKeyPushing,
 		isKeyFinished,
 		isKeyFailed,
-		getBackupStatusWithProgress,
-		getPullStatusWithProgress,
-		getPushStatusWithProgress,
 	};
 }

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -658,10 +658,7 @@ export async function exportSiteToPush( event: IpcMainInvokeEvent, id: string ) 
 		splitDatabaseDumpByTable: true,
 	};
 	// eslint-disable-next-line @typescript-eslint/no-empty-function
-	const onEvent = ( data: ImportExportEventData ) => {
-		const parentWindow = BrowserWindow.fromWebContents( event.sender );
-		sendIpcEventToRendererWithWindow( parentWindow, 'on-export', data, id );
-	};
+	const onEvent = () => {};
 	await exportBackup( exportOptions, onEvent );
 	const stats = fs.statSync( archivePath );
 	const archiveContent = fs.readFileSync( archivePath );


### PR DESCRIPTION
This reverts commit 8f2c14efa0d4af57ffcff2b490378676c847ff87.


https://github.com/user-attachments/assets/c0cb7a37-5e6e-4ec3-89cc-f1091e1c8492



<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues
- STU-465
- https://github.com/Automattic/studio/pull/1332#pullrequestreview-2821765849

## Proposed Changes

- We have found issues as part of https://github.com/Automattic/studio/pull/1332 as reported [here](https://github.com/Automattic/studio/pull/1332#pullrequestreview-2821765849)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Checkout this branch and run `npm start`
- Navigate to the Sync tab and Connnect a site or use an existing connected site
- Ensure you see the previous behaviour with the Sync push than in Production
- As an additional check, navigate to the Export tab and check you don't see any progress bars while syncing
- Once the Sync Push has finished, go to the Export tab and export a site
- Ensure the site is Exported without unexpected errors.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
