### PR TITLE
User Settings: Render help when no editors are installed

### DIFF
--- a/src/modules/user-settings/components/editor-picker.tsx
+++ b/src/modules/user-settings/components/editor-picker.tsx
@@ -35,6 +35,7 @@ export const EditorPicker = ( { value, onChange, disabled }: EditorPickerProps )
 					)
 				}
 				variant="link"
+				className="text-xs"
 			>
 				{ props.children } ↗
 			</Button>
@@ -47,7 +48,7 @@ export const EditorPicker = ( { value, onChange, disabled }: EditorPickerProps )
 		}
 
 		return (
-			<p className="text-gray-500">
+			<p className="text-gray-500 text-xs">
 				{ createInterpolateElement(
 					__( 'You can find a list of supported code editors <a>here</a>.' ),
 					{

--- a/src/modules/user-settings/components/editor-picker.tsx
+++ b/src/modules/user-settings/components/editor-picker.tsx
@@ -1,5 +1,8 @@
-import { SelectControl } from '@wordpress/components';
+import { Button, SelectControl } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
 import { useI18n } from '@wordpress/react-i18n';
+import { PropsWithChildren } from 'react';
+import { getIpcApi } from 'src/lib/get-ipc-api';
 import { SupportedEditor } from 'src/modules/user-settings/lib/editor';
 import {
 	useGetInstalledAppsQuery,
@@ -22,6 +25,38 @@ export const EditorPicker = ( { value, onChange, disabled }: EditorPickerProps )
 			uninstalledEditors: selectUninstalledEditors( result.data ),
 		} ),
 	} );
+
+	const ReadMoreLink = ( props: PropsWithChildren ) => {
+		return (
+			<Button
+				onClick={ () =>
+					getIpcApi().openURL(
+						'https://developer.wordpress.com/docs/developer-tools/studio/sites/#site-overview'
+					)
+				}
+				variant="link"
+			>
+				{ props.children } ↗
+			</Button>
+		);
+	};
+
+	const renderHelp = () => {
+		if ( installedEditors.length > 0 ) {
+			return null;
+		}
+
+		return (
+			<p className="text-gray-500">
+				{ createInterpolateElement(
+					__( 'You can find a list of supported code editors <a>here</a>.' ),
+					{
+						a: <ReadMoreLink />,
+					}
+				) }
+			</p>
+		);
+	};
 
 	return (
 		<SettingsFormField label={ __( 'Code editor' ) }>
@@ -48,6 +83,7 @@ export const EditorPicker = ( { value, onChange, disabled }: EditorPickerProps )
 					) ) }
 				</optgroup>
 			</SelectControl>
+			{ renderHelp() }
 		</SettingsFormField>
 	);
 };

--- a/src/modules/user-settings/components/editor-picker.tsx
+++ b/src/modules/user-settings/components/editor-picker.tsx
@@ -75,6 +75,12 @@ export const EditorPicker = ( { value, onChange, disabled }: EditorPickerProps )
 							{ editorConfig.label }
 						</option>
 					) ) }
+
+					{ installedEditors.length === 0 && (
+						<option value={ '' } disabled>
+							{ __( 'None' ) }
+						</option>
+					) }
 				</optgroup>
 				<optgroup label={ __( 'Not installed' ) }>
 					{ uninstalledEditors.map( ( [ editorKey, editorConfig ] ) => (

--- a/src/modules/user-settings/components/tests/editor-picker.test.tsx
+++ b/src/modules/user-settings/components/tests/editor-picker.test.tsx
@@ -34,6 +34,7 @@ describe( 'EditorPicker', () => {
 				ghostty: false,
 			} ),
 			getUserEditor: jest.fn().mockResolvedValue( undefined ),
+			openURL: jest.fn(),
 		} );
 	} );
 

--- a/src/modules/user-settings/components/tests/editor-picker.test.tsx
+++ b/src/modules/user-settings/components/tests/editor-picker.test.tsx
@@ -1,0 +1,188 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { getIpcApi } from 'src/lib/get-ipc-api';
+import { EditorPicker } from 'src/modules/user-settings/components/editor-picker';
+import { store } from 'src/stores';
+import { installedAppsApi } from 'src/stores/installed-apps-api';
+import { testReducer } from 'src/stores/tests/utils/test-reducer';
+
+jest.mock( 'src/lib/get-ipc-api' );
+const mockGetIpcApi = getIpcApi as jest.Mock;
+
+store.replaceReducer( testReducer );
+
+function renderWithProvider( component: React.ReactElement ) {
+	return render( <Provider store={ store }>{ component }</Provider> );
+}
+
+describe( 'EditorPicker', () => {
+	const mockOnChange = jest.fn();
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+		store.dispatch( { type: 'test/resetState' } );
+		mockGetIpcApi.mockReturnValue( {
+			getInstalledAppsAndTerminals: jest.fn().mockResolvedValue( {
+				vscode: true,
+				phpstorm: false,
+				webstorm: false,
+				windsurf: false,
+				cursor: false,
+				terminal: false,
+				iterm: false,
+				warp: false,
+				ghostty: false,
+			} ),
+			getUserEditor: jest.fn().mockResolvedValue( undefined ),
+		} );
+	} );
+
+	it( 'renders select control with no editors installed', async () => {
+		store.dispatch(
+			installedAppsApi.util.updateQueryData( 'getInstalledApps', undefined, ( data ) => {
+				return {
+					vscode: false,
+					phpstorm: false,
+					webstorm: false,
+					windsurf: false,
+					cursor: false,
+					terminal: false,
+					iterm: false,
+					warp: false,
+					ghostty: false,
+				};
+			} )
+		);
+
+		renderWithProvider( <EditorPicker value={ undefined } onChange={ mockOnChange } /> );
+
+		await waitFor( () => {
+			expect( screen.getByRole( 'combobox' ) ).not.toBeDisabled();
+			expect( screen.getByText( 'Select' ) ).toBeInTheDocument();
+		} );
+	} );
+
+	it( 'renders select control with installed editors', async () => {
+		store.dispatch(
+			installedAppsApi.util.updateQueryData( 'getInstalledApps', undefined, ( data ) => {
+				return {
+					vscode: true,
+					phpstorm: false,
+					webstorm: false,
+					windsurf: false,
+					cursor: false,
+					terminal: false,
+					iterm: false,
+					warp: false,
+					ghostty: false,
+				};
+			} )
+		);
+
+		renderWithProvider( <EditorPicker value={ undefined } onChange={ mockOnChange } /> );
+
+		await waitFor( () => {
+			const select = screen.getByRole( 'combobox' );
+			expect( select ).not.toBeDisabled();
+			expect( screen.getByText( 'Select' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'VS Code' ) ).toBeInTheDocument();
+
+			const notInstalledGroup = select.querySelector( 'optgroup[label="Not installed"]' );
+			expect( notInstalledGroup ).toBeInTheDocument();
+			expect( notInstalledGroup ).toHaveTextContent( 'PhpStorm' );
+			expect( notInstalledGroup ).toHaveTextContent( 'WebStorm' );
+			expect( notInstalledGroup ).toHaveTextContent( 'Windsurf' );
+			expect( notInstalledGroup ).toHaveTextContent( 'Cursor' );
+		} );
+	} );
+
+	it( 'handles editor selection change', async () => {
+		store.dispatch(
+			installedAppsApi.util.updateQueryData( 'getInstalledApps', undefined, ( data ) => {
+				return {
+					vscode: true,
+					phpstorm: false,
+					webstorm: false,
+					windsurf: false,
+					cursor: false,
+					terminal: false,
+					iterm: false,
+					warp: false,
+					ghostty: false,
+				};
+			} )
+		);
+
+		renderWithProvider( <EditorPicker value={ undefined } onChange={ mockOnChange } /> );
+
+		const select = await waitFor( () => screen.getByRole( 'combobox' ) );
+		fireEvent.change( select, { target: { value: 'vscode' } } );
+
+		expect( mockOnChange ).toHaveBeenCalledWith( 'vscode' );
+	} );
+
+	it( 'disables uninstalled editors in the select', async () => {
+		store.dispatch(
+			installedAppsApi.util.updateQueryData( 'getInstalledApps', undefined, ( data ) => {
+				return {
+					vscode: true,
+					phpstorm: false,
+					webstorm: false,
+					windsurf: false,
+					cursor: false,
+					terminal: false,
+					iterm: false,
+					warp: false,
+					ghostty: false,
+				};
+			} )
+		);
+
+		renderWithProvider( <EditorPicker value={ undefined } onChange={ mockOnChange } /> );
+
+		await waitFor( () => {
+			const select = screen.getByRole( 'combobox' );
+			expect( select ).not.toBeDisabled();
+		} );
+
+		const select = screen.getByRole( 'combobox' );
+		const options = select.querySelectorAll( 'option' );
+		// First option should be enabled (Select)
+		expect( options[ 0 ] ).not.toBeDisabled();
+		// Second option should be enabled (VS Code)
+		expect( options[ 1 ] ).not.toBeDisabled();
+		// Third option should be disabled (PhpStorm)
+		expect( options[ 2 ] ).toBeDisabled();
+		// Fourth option should be disabled (WebStorm)
+		expect( options[ 3 ] ).toBeDisabled();
+		// Fifth option should be disabled (Windsurf)
+		expect( options[ 4 ] ).toBeDisabled();
+		// Sixth option should be disabled (Cursor)
+		expect( options[ 5 ] ).toBeDisabled();
+	} );
+
+	// add test for value prop
+	it( 'selects user preferred editor', async () => {
+		store.dispatch(
+			installedAppsApi.util.updateQueryData( 'getInstalledApps', undefined, ( data ) => {
+				return {
+					vscode: true,
+					phpstorm: true,
+					webstorm: true,
+					windsurf: false,
+					cursor: false,
+					terminal: false,
+					iterm: false,
+					warp: false,
+					ghostty: false,
+				};
+			} )
+		);
+
+		renderWithProvider( <EditorPicker value={ 'phpstorm' } onChange={ mockOnChange } /> );
+
+		// check if phpstorm option selected
+		const select = screen.getByRole( 'combobox' );
+		expect( select ).toHaveValue( 'phpstorm' );
+	} );
+} );

--- a/src/modules/user-settings/components/tests/editor-picker.test.tsx
+++ b/src/modules/user-settings/components/tests/editor-picker.test.tsx
@@ -144,23 +144,14 @@ describe( 'EditorPicker', () => {
 		await waitFor( () => {
 			const select = screen.getByRole( 'combobox' );
 			expect( select ).not.toBeDisabled();
-			expect( screen.getByText( 'VS Code' ) ).toBeInTheDocument();
+			const options = select.querySelectorAll( 'option' );
+			expect( options[ 0 ] ).not.toBeDisabled();
+			expect( options[ 1 ] ).not.toBeDisabled();
+			expect( options[ 2 ] ).toBeDisabled();
+			expect( options[ 3 ] ).toBeDisabled();
+			expect( options[ 4 ] ).toBeDisabled();
+			expect( options[ 5 ] ).toBeDisabled();
 		} );
-
-		const select = screen.getByRole( 'combobox' );
-		const options = select.querySelectorAll( 'option' );
-		// First option should be enabled (Select)
-		expect( options[ 0 ] ).not.toBeDisabled();
-		// Second option should be enabled (VS Code)
-		expect( options[ 1 ] ).not.toBeDisabled();
-		// Third option should be disabled (PhpStorm)
-		expect( options[ 2 ] ).toBeDisabled();
-		// Fourth option should be disabled (WebStorm)
-		expect( options[ 3 ] ).toBeDisabled();
-		// Fifth option should be disabled (Windsurf)
-		expect( options[ 4 ] ).toBeDisabled();
-		// Sixth option should be disabled (Cursor)
-		expect( options[ 5 ] ).toBeDisabled();
 	} );
 
 	it( 'selects user preferred editor', async () => {

--- a/src/modules/user-settings/components/tests/editor-picker.test.tsx
+++ b/src/modules/user-settings/components/tests/editor-picker.test.tsx
@@ -142,8 +142,7 @@ describe( 'EditorPicker', () => {
 		renderWithProvider( <EditorPicker value={ undefined } onChange={ mockOnChange } /> );
 
 		await waitFor( () => {
-			const select = screen.getByRole( 'combobox' );
-			expect( select ).not.toBeDisabled();
+			expect( screen.getByRole( 'combobox' ) ).toBeInTheDocument();
 		} );
 
 		const select = screen.getByRole( 'combobox' );
@@ -162,7 +161,6 @@ describe( 'EditorPicker', () => {
 		expect( options[ 5 ] ).toBeDisabled();
 	} );
 
-	// add test for value prop
 	it( 'selects user preferred editor', async () => {
 		store.dispatch(
 			installedAppsApi.util.updateQueryData( 'getInstalledApps', undefined, ( data ) => {

--- a/src/modules/user-settings/components/tests/editor-picker.test.tsx
+++ b/src/modules/user-settings/components/tests/editor-picker.test.tsx
@@ -142,7 +142,9 @@ describe( 'EditorPicker', () => {
 		renderWithProvider( <EditorPicker value={ undefined } onChange={ mockOnChange } /> );
 
 		await waitFor( () => {
-			expect( screen.getByRole( 'combobox' ) ).toBeInTheDocument();
+			const select = screen.getByRole( 'combobox' );
+			expect( select ).not.toBeDisabled();
+			expect( screen.getByText( 'VS Code' ) ).toBeInTheDocument();
 		} );
 
 		const select = screen.getByRole( 'combobox' );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-436

## Proposed Changes

- Add a recommendation to download VS Code when no editor is installed. 
- Add tests for the editor picker component

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Make the following changes to mimic uninstalled editors. 

```diff
diff --git a/src/ipc-handlers.ts b/src/ipc-handlers.ts
index e0e5308..e07afdb 100644
--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -108,11 +108,11 @@ export async function getSiteDetails( _event: IpcMainInvokeEvent ): Promise< Sit
 
 export function getInstalledAppsAndTerminals(): InstalledApps & InstalledTerminals {
        return {
-               vscode: isInstalled( 'vscode' ),
-               phpstorm: isInstalled( 'phpstorm' ),
-               webstorm: isInstalled( 'webstorm' ),
-               windsurf: isInstalled( 'windsurf' ),
-               cursor: isInstalled( 'cursor' ),
+               vscode: false, // isInstalled( 'vscode' ),
+               phpstorm: false, // isInstalled( 'phpstorm' ),
+               webstorm: false, // isInstalled( 'webstorm' ),
+               windsurf: false, // isInstalled( 'windsurf' ),
+               cursor: false, // isInstalled( 'cursor' ),
                terminal: true, // Terminal.app is always available on macOS
                iterm: isInstalled( 'iterm' ),
                warp: isInstalled( 'warp' ),
```

- Run `npm start`
- Open the User settings -> Preferences tab
- Make sure you can see the help text pointing to https://developer.wordpress.com/docs/developer-tools/studio/sites/#site-settings

![CleanShot 2025-05-08 at 12 05 51@2x](https://github.com/user-attachments/assets/5bf773c3-87f9-41af-960b-18b8facbfacb)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
