### PR TITLE
Onboarding: Update WordPress Version Tooltip Icon and Position 

### DIFF
--- a/src/components/add-site.tsx
+++ b/src/components/add-site.tsx
@@ -231,6 +231,7 @@ export default function AddSite( { className }: AddSiteProps ) {
 									{ __( 'Add site' ) }
 								</Button>
 							</div>
+							<div className="components-popover__fallback-container"></div>
 						</SiteForm>
 					</div>
 				</Modal>

--- a/src/components/wp-version-selector/index.tsx
+++ b/src/components/wp-version-selector/index.tsx
@@ -1,5 +1,5 @@
 import { SelectControl, Icon } from '@wordpress/components';
-import { warning } from '@wordpress/icons';
+import { info } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import offlineIcon from 'src/components/offline-icon';
 import { Tooltip } from 'src/components/tooltip';
@@ -66,7 +66,7 @@ export const WPVersionSelector = ( {
 						text={ __( 'WordPress Core automatic updates will be disabled for this site.' ) }
 						placement="top-start"
 					>
-						<Icon icon={ warning } size={ 16 } />
+						<Icon icon={ info } size={ 16 } />
 					</Tooltip>
 				) }
 			</span>

--- a/src/components/wp-version-selector/index.tsx
+++ b/src/components/wp-version-selector/index.tsx
@@ -59,7 +59,7 @@ export const WPVersionSelector = ( {
 
 	return (
 		<label className="flex flex-1 flex-col gap-1.5 leading-4">
-			<span className="font-semibold flex items-center gap-2">
+			<span className="font-semibold flex items-center gap-0.5">
 				{ __( 'WordPress version' ) }
 				{ selectedValue !== 'latest' && (
 					<Tooltip

--- a/src/modules/site-settings/edit-site-details.tsx
+++ b/src/modules/site-settings/edit-site-details.tsx
@@ -326,6 +326,7 @@ export default function EditSiteDetails( { currentWpVersion, onSave }: EditSiteD
 								{ getEditSiteButtonText() }
 							</Button>
 						</div>
+						<div className="components-popover__fallback-container"></div>
 					</form>
 				</Modal>
 			) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-458 and https://github.com/Automattic/studio/issues/1338

## Proposed Changes

- Replace warning sign icon with info icon. 
- Reduce the gap between the title and the icon. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Check out this PR.
- Apply temp change to see the onboarding screen.
```diff
diff --git a/src/components/app.tsx b/src/components/app.tsx
index c06b9cb..3224a7d 100644
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -20,7 +20,7 @@ import { WhatsNewModal, useWhatsNew } from 'src/modules/whats-new';
 
 export default function App() {
        useLocalizationSupport();
-       const { needsOnboarding } = useOnboarding();
+       const { needsOnboarding } = { needsOnboarding: true }; //useOnboarding();
        const { isSidebarVisible, toggleSidebar } = useSidebarVisibility();
        const { showWhatsNew, closeWhatsNew } = useWhatsNew();
```
- Start the Studio by running `npm start`
- Click on `Advanced settings`
- Select a WordPress version number other than `latest`. 
- The tooltip (i) will be displayed. 
- Check that the icon is positioned close to the title. 
- The updated icon is readable. 
- Also, check the tooltip position on the add site and edit site form.

| Before | After |
|--------|--------|
| ![CleanShot 2025-05-07 at 12 35 18@2x](https://github.com/user-attachments/assets/5dfa05ef-4457-4171-a514-6427ac776006) | ![CleanShot 2025-05-08 at 14 23 32@2x](https://github.com/user-attachments/assets/64ad9864-3736-4dee-83f5-8232f0b41afe) | 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
