### PR TITLE
Persist preferred locale

### DIFF
--- a/src/hooks/use-i18n-data.tsx
+++ b/src/hooks/use-i18n-data.tsx
@@ -48,7 +48,6 @@ export const I18nDataProvider = ( { children }: { children: React.ReactNode } ) 
 	useEffect( () => {
 		if ( initialized ) {
 			void initI18n( locale );
-			void getIpcApi().saveUserLocale( locale );
 			return;
 		}
 
@@ -62,7 +61,10 @@ export const I18nDataProvider = ( { children }: { children: React.ReactNode } ) 
 
 	const contextValue = useMemo(
 		() => ( {
-			setLocale,
+			setLocale: async ( localeKey: SupportedLocale ) => {
+				setLocale( localeKey );
+				await getIpcApi().saveUserLocale( localeKey );
+			},
 			locale,
 		} ),
 		[ locale ]

--- a/src/modules/user-settings/components/preferences-tab.tsx
+++ b/src/modules/user-settings/components/preferences-tab.tsx
@@ -29,7 +29,7 @@ export const PreferencesTab = ( { onClose }: { onClose: () => void } ) => {
 	const [ currentTerminal, setCurrentTerminal ] = useState( terminal );
 
 	const savePreferences = async () => {
-		setSavedLocale( locale );
+		await setSavedLocale( locale );
 		if ( currentEditor ) {
 			await saveEditor( currentEditor );
 		}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-471

## Proposed Changes

- Persist preferred locale by refactoring saveLocale and make it async
- The issue was that the locale was saved, and before it was saved, we were calling the editor to save, which read the app data with the previous locale and then overwrote it.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run `npm start`.
- Click your profile name on the top right corner to open the settings modal.
- Click preferences.
- Change the language to any other language.
- Observe that the locale is correctly saved in the AppData
- Press cmd+r to refresh Studio. Or restart the app.
- Observe that the language is the same as the one you selected in the preferences menu.


https://github.com/user-attachments/assets/a1b628e5-d704-4af1-b04c-d6de972806ba

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
