### PR TITLE
Fix snapshot schema format - name optional

### DIFF
--- a/cli/commands/preview/create.ts
+++ b/cli/commands/preview/create.ts
@@ -46,7 +46,7 @@ export async function runCommand( siteFolder: string ): Promise< void > {
 		);
 		logger.reportSuccess( __( 'Preview site saved to Studio' ) );
 
-		logger.reportKeyValuePair( 'name', snapshot.name );
+		logger.reportKeyValuePair( 'name', snapshot.name ?? '' );
 		logger.reportKeyValuePair( 'url', snapshot.url );
 	} catch ( error ) {
 		if ( error instanceof LoggerError ) {

--- a/cli/commands/preview/update.ts
+++ b/cli/commands/preview/update.ts
@@ -94,7 +94,7 @@ export async function runCommand(
 		const snapshot = await updateSnapshotInAppdata( uploadResponse.site_id, siteFolder );
 		logger.reportSuccess( __( 'Preview site saved to Studio' ) );
 
-		logger.reportKeyValuePair( 'name', snapshot.name );
+		logger.reportKeyValuePair( 'name', snapshot.name ?? '' );
 		logger.reportKeyValuePair( 'url', snapshot.url );
 	} catch ( error ) {
 		if ( error instanceof LoggerError ) {

--- a/common/types/snapshot.ts
+++ b/common/types/snapshot.ts
@@ -5,7 +5,7 @@ export const snapshotSchema = z.object( {
 	atomicSiteId: z.number(),
 	localSiteId: z.string(),
 	date: z.number(),
-	name: z.string(),
+	name: z.string().optional(),
 	userId: z.number().optional(),
 	sequence: z.number().optional(),
 } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-475

## Proposed Changes

- Make the snapshot name optional in the schema to allow for older `appdata` file formats

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Edit your `appdata-v1.json` file and add a snapshot like this:
```

  "snapshots": [
    {
      "url": "secretly-cognitive.jurassic.ninja",
      "atomicSiteId": 150570991,
      "localSiteId": "64e2ffab-590c-455a-ac98-cb1f61f46d9e",
      "date": 1711097456449
    }
  ],
```
- Run `npm run start`
- Create a new site and login to WordPress.com
- Try to create a preview site
- Preview site is created successfully

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
