### PR TITLE
Studio CLI: Validate access token before starting command operation

### DIFF
--- a/cli/lib/api.ts
+++ b/cli/lib/api.ts
@@ -129,3 +129,12 @@ export async function deleteSnapshot( atomicSiteId: number, token: string ): Pro
 		throw new LoggerError( __( 'Failed to delete preview site' ), error );
 	}
 }
+
+export async function validateAccessToken( token: string ): Promise< void > {
+	const wpcom = new WPCOM( token );
+	try {
+		await wpcom.req.get( '/me', { fields: 'ID' } );
+	} catch ( error ) {
+		throw new LoggerError( __( 'Invalid authentication token' ), error );
+	}
+}

--- a/cli/lib/appdata.ts
+++ b/cli/lib/appdata.ts
@@ -8,6 +8,7 @@ import { getAuthenticationUrl } from 'common/lib/oauth';
 import { snapshotSchema } from 'common/types/snapshot';
 import { StatsGroup, StatsMetric } from 'common/types/stats';
 import { z } from 'zod';
+import { validateAccessToken } from 'cli/lib/api';
 import { LoggerError } from 'cli/logger';
 
 const siteSchema = z
@@ -116,6 +117,8 @@ export async function getAuthToken(): Promise< NonNullable< UserData[ 'authToken
 		if ( ! authToken?.accessToken ) {
 			throw new Error( 'Authentication required' );
 		}
+
+		await validateAccessToken( authToken.accessToken );
 
 		return authToken;
 	} catch ( error ) {

--- a/cli/lib/tests/appdata.test.ts
+++ b/cli/lib/tests/appdata.test.ts
@@ -21,6 +21,10 @@ jest.mock( 'crypto', () => ( {
 	randomUUID: jest.fn().mockReturnValue( 'mock-uuid-1234' ),
 } ) );
 
+jest.mock( 'cli/lib/api', () => ( {
+	validateAccessToken: jest.fn().mockResolvedValue( undefined ),
+} ) );
+
 describe( 'Appdata Module', () => {
 	const mockHomeDir = '/mock/home';
 	const mockSiteFolderName = 'folder';

--- a/cli/lib/tests/snapshots.test.ts
+++ b/cli/lib/tests/snapshots.test.ts
@@ -28,6 +28,10 @@ jest.mock( 'lockfile', () => ( {
 	unlock: jest.fn().mockImplementation( ( path, callback ) => callback( null ) ),
 } ) );
 
+jest.mock( 'cli/lib/api', () => ( {
+	validateAccessToken: jest.fn().mockResolvedValue( undefined ),
+} ) );
+
 describe( 'Snapshots Module', () => {
 	const mockHomeDir = '/mock/home';
 	const mockSiteFolderName = 'folder';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-464

## Proposed Changes

This PR addresses the issue of invalid authentication states in Studio. Currently, the CLI uses the access token without first checking if it's still valid or has been revoked. To fix this, the PR adds a step to validate the access token by calling the `/me` endpoint before starting any CLI process.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out this branch.
2. Start the app:

   ```bash
   npm start  
   ```
3. Log in to your WordPress.com account.
4. Build the CLI:

   ```bash
   npm run cli:build  
   ```
5. Run the following command to create or list preview sites:

   ```bash
   node dist/cli/main.js preview list --path ~/Studio/[SITE_NAME]  
   ```
6. Confirm that it lists existing preview sites. If none exist, create one.
7. Open your `appdata-v1.json` file, located at:  "/Users/[YOUR_USER]/Library/Application Support/Studio/appdata-v1.json"
8. Manually modify the `authToken.accessToken` value to an invalid token.
9. Run the same CLI command again:

   ```bash
   node dist/cli/main.js preview list --path ~/Studio/[SITE_NAME]  
   ```
10. The CLI should now return an **authentication required** message.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
