### PR TITLE
Ignore .git & node_modules in preview archive

### DIFF
--- a/cli/lib/archive.ts
+++ b/cli/lib/archive.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import { __ } from '@wordpress/i18n';
-import archiver from 'archiver';
+import archiver, { EntryData } from 'archiver';
 import { LoggerError } from 'cli/logger';
 
 const ZIP_COMPRESSION_LEVEL = 9;
@@ -24,7 +24,12 @@ export async function createArchive(
 		} );
 
 		archive.pipe( output );
-		archive.directory( path.join( siteFolder, 'wp-content' ), 'wp-content' );
+		archive.directory( path.join( siteFolder, 'wp-content' ), 'wp-content', ( entry: EntryData ) => {
+			if ( entry.name.includes( '.git' ) || entry.name.includes( 'node_modules' ) ) {
+				return false;
+			}
+			return entry;
+		} );
 
 		const wpConfigPath = path.join( siteFolder, 'wp-config.php' );
 		if ( fs.existsSync( wpConfigPath ) ) {

--- a/cli/lib/archive.ts
+++ b/cli/lib/archive.ts
@@ -24,12 +24,16 @@ export async function createArchive(
 		} );
 
 		archive.pipe( output );
-		archive.directory( path.join( siteFolder, 'wp-content' ), 'wp-content', ( entry: EntryData ) => {
-			if ( entry.name.includes( '.git' ) || entry.name.includes( 'node_modules' ) ) {
-				return false;
+		archive.directory(
+			path.join( siteFolder, 'wp-content' ),
+			'wp-content',
+			( entry: EntryData ) => {
+				if ( entry.name.includes( '.git' ) || entry.name.includes( 'node_modules' ) ) {
+					return false;
+				}
+				return entry;
 			}
-			return entry;
-		} );
+		);
 
 		const wpConfigPath = path.join( siteFolder, 'wp-config.php' );
 		if ( fs.existsSync( wpConfigPath ) ) {

--- a/cli/lib/tests/archive.test.ts
+++ b/cli/lib/tests/archive.test.ts
@@ -51,7 +51,11 @@ describe( 'Archive Module', () => {
 			expect( archiver ).toHaveBeenCalledWith( 'zip', { zlib: { level: 9 } } );
 			expect( mockArchiver.pipe ).toHaveBeenCalledWith( mockWriteStream );
 			expect( path.join ).toHaveBeenCalledWith( mockSiteFolder, 'wp-content' );
-			expect( mockArchiver.directory ).toHaveBeenCalledWith( mockWpContentPath, 'wp-content' );
+			expect( mockArchiver.directory ).toHaveBeenCalledWith(
+				mockWpContentPath,
+				'wp-content',
+				expect.any( Function )
+			);
 			expect( path.join ).toHaveBeenCalledWith( mockSiteFolder, 'wp-config.php' );
 			expect( fs.existsSync ).toHaveBeenCalledWith( mockWpConfigPath );
 			expect( mockArchiver.file ).not.toHaveBeenCalled();


### PR DESCRIPTION
Export ignores .git and node_modules:

https://github.com/Automattic/studio/blob/0c0f64d0b881b43be36bf04addc983a087c6d2bc/src/lib/import-export/export/exporters/default-exporter.ts#L233-L234

Preview did not, causing a failure to create the archive for me due to the following error:

> could not open for reading: .git/fsmonitor--daemon.ipc

## Proposed Changes

- Ignore `.git` and `node_modules` in wp-content.

## Testing Instructions

1. `git init` inside wp-content
2. `git config core.fsmonitor true` if not already set globally and trigger the ipc file creation (e.g. run `git status`)
3. Create a preview

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
