### PR TITLE
Pressable Sync: Add environment badge tests

### DIFF
--- a/src/components/tests/content-tab-sync.test.tsx
+++ b/src/components/tests/content-tab-sync.test.tsx
@@ -387,9 +387,9 @@ describe( 'ContentTabSync', () => {
 		renderWithProvider( <ContentTabSync selectedSite={ selectedSite } /> );
 
 		expect( screen.getByText( fakePressableProductionSite.name ) ).toBeInTheDocument();
-		expect( screen.getAllByText( 'Production' ) ).toHaveLength( 1 );
-
 		expect( screen.getByText( fakePressableStagingSite.name ) ).toBeInTheDocument();
-		expect( screen.getAllByText( 'Staging' ) ).toHaveLength( 1 );
+
+		expect( screen.getByText( 'Production' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Staging' ) ).toBeInTheDocument();
 	} );
 } );

--- a/src/components/tests/content-tab-sync.test.tsx
+++ b/src/components/tests/content-tab-sync.test.tsx
@@ -346,4 +346,50 @@ describe( 'ContentTabSync', () => {
 		const connectButton = screen.getByRole( 'button', { name: /Connect site/i } );
 		expect( connectButton ).toBeInTheDocument();
 	} );
+
+	it( 'displays environment badges for Pressable sites with production and staging environments', () => {
+		const fakePressableProductionSite = {
+			id: 6,
+			name: 'My Pressable Production site',
+			url: 'https://pressable-site.com',
+			isStaging: false,
+			isPressable: true,
+			environmentType: 'production',
+			stagingSiteIds: [],
+			syncSupport: 'already-connected',
+		};
+		const fakePressableStagingSite = {
+			id: 7,
+			name: 'My Pressable Staging site',
+			url: 'https://staging-pressable-site.com',
+			isStaging: false,
+			isPressable: true,
+			environmentType: 'staging',
+			stagingSiteIds: [],
+			syncSupport: 'already-connected',
+		};
+		( useAuth as jest.Mock ).mockReturnValue( { isAuthenticated: true, authenticate: jest.fn() } );
+		( useSyncSites as jest.Mock ).mockReturnValue( {
+			connectedSites: [ fakePressableProductionSite, fakePressableStagingSite ],
+			syncSites: [ fakePressableProductionSite ],
+			pullSite: jest.fn(),
+			isAnySitePulling: false,
+			isAnySitePushing: false,
+			getPullState: jest.fn(),
+			getPushState: jest.fn().mockReturnValue( undefined ),
+			refetchSites: jest.fn(),
+			getLastSyncTimeText: jest.fn().mockReturnValue( 'You have not pulled this site yet.' ),
+			isSiteIdPulling: jest.fn(),
+			isSiteIdPushing: jest.fn(),
+			clearTimeout: jest.fn(),
+		} );
+
+		renderWithProvider( <ContentTabSync selectedSite={ selectedSite } /> );
+
+		expect( screen.getByText( fakePressableProductionSite.name ) ).toBeInTheDocument();
+		expect( screen.getAllByText( 'Production' ) ).toHaveLength( 1 );
+
+		expect( screen.getByText( fakePressableStagingSite.name ) ).toBeInTheDocument();
+		expect( screen.getAllByText( 'Staging' ) ).toHaveLength( 1 );
+	} );
 } );

--- a/src/components/tests/environment-badge.test.tsx
+++ b/src/components/tests/environment-badge.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from '@testing-library/react';
+import { EnvironmentBadge } from 'src/components/environment-badge';
+
+describe( 'EnvironmentBadge', () => {
+	it( 'renders the Production badge with correct label', () => {
+		render( <EnvironmentBadge type="production" /> );
+		const badge = screen.getByText( 'Production' );
+		expect( badge ).toBeInTheDocument();
+	} );
+
+	it( 'renders the Staging badge with correct label', () => {
+		render( <EnvironmentBadge type="staging" /> );
+		const badge = screen.getByText( 'Staging' );
+		expect( badge ).toBeInTheDocument();
+	} );
+
+	it( 'applies specific classes for the Production badge', () => {
+		const { container } = render( <EnvironmentBadge type="production" /> );
+
+		const badgeElement = container.firstChild as HTMLElement;
+		expect( badgeElement ).not.toBeNull();
+
+		expect( badgeElement.className ).toContain( 'bg-a8c-green-5' );
+		expect( badgeElement.className ).toContain( 'text-a8c-green-80' );
+	} );
+
+	it( 'applies specific classes for the Staging badge', () => {
+		const { container } = render( <EnvironmentBadge type="staging" /> );
+
+		const badgeElement = container.firstChild as HTMLElement;
+		expect( badgeElement ).not.toBeNull();
+
+		expect( badgeElement.className ).toContain( 'text-a8c-yellow-80' );
+		expect( badgeElement.className ).toContain( 'bg-a8c-yellow-10' );
+	} );
+
+	it( 'applies "selected" styling when selected prop is true', () => {
+		const { container } = render( <EnvironmentBadge type="production" selected={ true } /> );
+
+		const badgeElement = container.firstChild as HTMLElement;
+		expect( badgeElement ).not.toBeNull();
+
+		expect( badgeElement.className ).toContain( 'bg-white' );
+		expect( badgeElement.className ).toContain( 'text-a8c-blueberry' );
+	} );
+} );

--- a/src/components/tests/environment-badge.test.tsx
+++ b/src/components/tests/environment-badge.test.tsx
@@ -18,7 +18,7 @@ describe( 'EnvironmentBadge', () => {
 		const { container } = render( <EnvironmentBadge type="production" /> );
 
 		const badgeElement = container.firstChild as HTMLElement;
-		expect( badgeElement ).not.toBeNull();
+		expect( badgeElement ).toBeInTheDocument();
 
 		expect( badgeElement.className ).toContain( 'bg-a8c-green-5' );
 		expect( badgeElement.className ).toContain( 'text-a8c-green-80' );
@@ -28,7 +28,7 @@ describe( 'EnvironmentBadge', () => {
 		const { container } = render( <EnvironmentBadge type="staging" /> );
 
 		const badgeElement = container.firstChild as HTMLElement;
-		expect( badgeElement ).not.toBeNull();
+		expect( badgeElement ).toBeInTheDocument();
 
 		expect( badgeElement.className ).toContain( 'text-a8c-yellow-80' );
 		expect( badgeElement.className ).toContain( 'bg-a8c-yellow-10' );
@@ -38,7 +38,7 @@ describe( 'EnvironmentBadge', () => {
 		const { container } = render( <EnvironmentBadge type="production" selected={ true } /> );
 
 		const badgeElement = container.firstChild as HTMLElement;
-		expect( badgeElement ).not.toBeNull();
+		expect( badgeElement ).toBeInTheDocument();
 
 		expect( badgeElement.className ).toContain( 'bg-white' );
 		expect( badgeElement.className ).toContain( 'text-a8c-blueberry' );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Related to STU-346
- Related to https://github.com/Automattic/studio/pull/1329 
- Related discussion: https://github.com/Automattic/studio/pull/1329#issuecomment-2859947598

## Proposed Changes

Add tests related to:
- the new `EnvironmentBadge` component
- badge displayed for connected Pressable Staging and Production sites

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Please review the proposed tests.
2. Running `npm run test -- src/components/tests/environment-badge.test.tsx` should pass.
3. Running `npm run test -- src/components/tests/content-tab-sync.test.tsx` should pass.
4. Running all unit tests with `npm run test` should pass as well.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?