### PR TITLE
Change space to be overwritten by prettier

### DIFF
--- a/src/components/content-tab-import-export.tsx
+++ b/src/components/content-tab-import-export.tsx
@@ -122,8 +122,7 @@ const InitialImportButton = ( {
 		<Tooltip className="w-full" text={ tooltipText } disabled={ ! disabled }>
 			<Button
 				variant="icon"
-				className={ `w-full 
-				${
+				className={ `w-full ${
 					disabled
 						? '[&>div.border-zinc-300]:border-gray-400 cursor-not-allowed opacity-50'
 						: '[&>div.border-zinc-300]:hover:border-a8c-blueberry'

--- a/src/components/content-tab-import-export.tsx
+++ b/src/components/content-tab-import-export.tsx
@@ -122,11 +122,12 @@ const InitialImportButton = ( {
 		<Tooltip className="w-full" text={ tooltipText } disabled={ ! disabled }>
 			<Button
 				variant="icon"
-				className={ `w-full ${
+				className={ cx(
+					'w-full',
 					disabled
 						? '[&>div.border-zinc-300]:border-gray-400 cursor-not-allowed opacity-50'
 						: '[&>div.border-zinc-300]:hover:border-a8c-blueberry'
-				}` }
+				) }
 				onClick={ openFileSelector }
 				disabled={ disabled }
 			>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Proposed Changes

- We have an empty space between the class and the disabled styles `w-full \n ${`, that space is being removed when I save the file in my code editor.
I suggest using `cx` to safely remove the space at the end of the code lines.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to Import/Export tab.
- Click on Export.
- Move the mouse hover the import area.
-  Confirm the tooltip looks as before.

| Before | After |
|--------|--------|
|  ![Screenshot 2025-05-12 at 21 15 53](https://github.com/user-attachments/assets/d3123aab-2f08-412a-a6ec-663fd232ac66) |  ![Screenshot 2025-05-12 at 21 16 36](https://github.com/user-attachments/assets/a5aa1da2-12e9-4110-bd21-79a9e74b3454) |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
