### PR TITLE
Compare paths in a case-insensitive manner

### DIFF
--- a/cli/lib/appdata.ts
+++ b/cli/lib/appdata.ts
@@ -4,6 +4,7 @@ import os from 'os';
 import path from 'path';
 import { __, sprintf } from '@wordpress/i18n';
 import { readFile, writeFile } from 'atomically';
+import { arePathsEqual } from 'common/lib/fs-utils';
 import { getAuthenticationUrl } from 'common/lib/oauth';
 import { snapshotSchema } from 'common/types/snapshot';
 import { StatsGroup, StatsMetric } from 'common/types/stats';
@@ -131,19 +132,6 @@ export async function getAuthToken(): Promise< NonNullable< UserData[ 'authToken
 				authUrl
 			)
 		);
-	}
-}
-
-// Compare paths in a case-insensitive manner. `fs.Stats.dev` signifies the device ID, and
-// `fs.Stats.ino` signifies the inode number that uniquely identifies the file or directory.
-function arePathsEqual( path1: string, path2: string ) {
-	try {
-		const stats1 = fs.statSync( path.resolve( path1 ) );
-		const stats2 = fs.statSync( path.resolve( path2 ) );
-
-		return stats1.ino === stats2.ino && stats1.dev === stats2.dev;
-	} catch ( error ) {
-		return false;
 	}
 }
 

--- a/cli/lib/appdata.ts
+++ b/cli/lib/appdata.ts
@@ -134,12 +134,25 @@ export async function getAuthToken(): Promise< NonNullable< UserData[ 'authToken
 	}
 }
 
+// Compare paths in a case-insensitive manner. `fs.Stats.dev` signifies the device ID, and
+// `fs.Stats.ino` signifies the inode number that uniquely identifies the file or directory.
+function arePathsEqual( path1: string, path2: string ) {
+	try {
+		const stats1 = fs.statSync( path.resolve( path1 ) );
+		const stats2 = fs.statSync( path.resolve( path2 ) );
+
+		return stats1.ino === stats2.ino && stats1.dev === stats2.dev;
+	} catch ( error ) {
+		return false;
+	}
+}
+
 export async function getSiteByFolder(
 	siteFolder: string
 ): Promise< z.infer< typeof siteSchema > > {
 	const userData = await readAppdata();
-	const site = [ ...userData.sites, ...userData.newSites ].find(
-		( site ) => site.path === siteFolder
+	const site = [ ...userData.sites, ...userData.newSites ].find( ( site ) =>
+		arePathsEqual( site.path, siteFolder )
 	);
 
 	if ( ! site ) {

--- a/cli/lib/tests/appdata.test.ts
+++ b/cli/lib/tests/appdata.test.ts
@@ -34,10 +34,14 @@ describe( 'Appdata Module', () => {
 		( os.homedir as jest.Mock ).mockReturnValue( mockHomeDir );
 		( path.join as jest.Mock ).mockImplementation( ( ...args ) => args.join( '/' ) );
 		( path.basename as jest.Mock ).mockReturnValue( mockSiteFolderName );
+		( path.resolve as jest.Mock ).mockImplementation( ( path ) => path );
 		jest.spyOn( Date, 'now' ).mockReturnValue( 1234567890 );
 
-		// Default mock implementation for fs functions
 		( fs.existsSync as jest.Mock ).mockReturnValue( true );
+		( fs.statSync as jest.Mock ).mockImplementation( ( path ) => ( {
+			dev: 1234567890,
+			ino: path,
+		} ) );
 		( readFile as jest.Mock ).mockResolvedValue( '{}' );
 		( writeFile as jest.Mock ).mockResolvedValue( undefined );
 	} );

--- a/cli/lib/tests/appdata.test.ts
+++ b/cli/lib/tests/appdata.test.ts
@@ -2,6 +2,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import { readFile, writeFile } from 'atomically';
+import { arePathsEqual } from 'common/lib/fs-utils';
 import {
 	readAppdata,
 	saveAppdata,
@@ -21,6 +22,7 @@ jest.mock( 'crypto', () => ( {
 	randomUUID: jest.fn().mockReturnValue( 'mock-uuid-1234' ),
 } ) );
 
+jest.mock( 'common/lib/fs-utils' );
 jest.mock( 'cli/lib/api', () => ( {
 	validateAccessToken: jest.fn().mockResolvedValue( undefined ),
 } ) );
@@ -38,10 +40,7 @@ describe( 'Appdata Module', () => {
 		jest.spyOn( Date, 'now' ).mockReturnValue( 1234567890 );
 
 		( fs.existsSync as jest.Mock ).mockReturnValue( true );
-		( fs.statSync as jest.Mock ).mockImplementation( ( path ) => ( {
-			dev: 1234567890,
-			ino: path,
-		} ) );
+		( arePathsEqual as jest.Mock ).mockImplementation( ( path1, path2 ) => path1 === path2 );
 		( readFile as jest.Mock ).mockResolvedValue( '{}' );
 		( writeFile as jest.Mock ).mockResolvedValue( undefined );
 	} );

--- a/cli/lib/tests/snapshots.test.ts
+++ b/cli/lib/tests/snapshots.test.ts
@@ -2,6 +2,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import { readFile, writeFile } from 'atomically';
+import { arePathsEqual } from 'common/lib/fs-utils';
 import {
 	deleteSnapshotFromAppdata,
 	getSnapshotsFromAppdata,
@@ -29,6 +30,7 @@ jest.mock( 'lockfile', () => ( {
 	unlock: jest.fn().mockImplementation( ( path, callback ) => callback( null ) ),
 } ) );
 
+jest.mock( 'common/lib/fs-utils' );
 jest.mock( 'cli/lib/api', () => ( {
 	validateAccessToken: jest.fn().mockResolvedValue( undefined ),
 } ) );
@@ -48,10 +50,7 @@ describe( 'Snapshots Module', () => {
 		jest.spyOn( Date, 'now' ).mockReturnValue( 1234567890 );
 
 		( fs.existsSync as jest.Mock ).mockReturnValue( true );
-		( fs.statSync as jest.Mock ).mockImplementation( ( path ) => ( {
-			dev: 1234567890,
-			ino: path,
-		} ) );
+		( arePathsEqual as jest.Mock ).mockImplementation( ( path1, path2 ) => path1 === path2 );
 		( readFile as jest.Mock ).mockResolvedValue( '{}' );
 		( writeFile as jest.Mock ).mockResolvedValue( undefined );
 	} );

--- a/cli/lib/tests/snapshots.test.ts
+++ b/cli/lib/tests/snapshots.test.ts
@@ -14,6 +14,7 @@ jest.mock( 'fs' );
 jest.mock( 'os' );
 jest.mock( 'path', () => ( {
 	join: jest.fn().mockImplementation( ( ...args ) => args.join( '/' ) ),
+	resolve: jest.fn().mockImplementation( ( path ) => path ),
 	basename: jest.fn(),
 } ) );
 jest.mock( 'atomically', () => ( {
@@ -46,8 +47,11 @@ describe( 'Snapshots Module', () => {
 		( path.basename as jest.Mock ).mockReturnValue( mockSiteFolderName );
 		jest.spyOn( Date, 'now' ).mockReturnValue( 1234567890 );
 
-		// Default mock implementation for fs functions
 		( fs.existsSync as jest.Mock ).mockReturnValue( true );
+		( fs.statSync as jest.Mock ).mockImplementation( ( path ) => ( {
+			dev: 1234567890,
+			ino: path,
+		} ) );
 		( readFile as jest.Mock ).mockResolvedValue( '{}' );
 		( writeFile as jest.Mock ).mockResolvedValue( undefined );
 	} );

--- a/common/lib/fs-utils.ts
+++ b/common/lib/fs-utils.ts
@@ -51,6 +51,8 @@ export function isWordPressDirectory( projectPath: string ): boolean {
 
 // Compare paths in a case-insensitive manner. `fs.Stats.dev` signifies the device ID, and
 // `fs.Stats.ino` signifies the inode number that uniquely identifies the file or directory.
+// The benefit of this approach over converting the entire path to lowercase is that it respects
+// the current file system's case sensitivity.
 export function arePathsEqual( path1: string, path2: string ) {
 	try {
 		const stats1 = fs.statSync( path.resolve( path1 ) );

--- a/common/lib/fs-utils.ts
+++ b/common/lib/fs-utils.ts
@@ -1,6 +1,5 @@
 import fs from 'fs';
 import path from 'path';
-import { existsSync } from 'fs-extra';
 
 /**
  * Calculates the total size of a directory by recursively traversing its contents.
@@ -44,8 +43,21 @@ export function calculateDirectorySize( directoryPath: string ): Promise< number
 
 export function isWordPressDirectory( projectPath: string ): boolean {
 	return (
-		existsSync( path.join( projectPath, 'wp-content' ) ) &&
-		existsSync( path.join( projectPath, 'wp-includes' ) ) &&
-		existsSync( path.join( projectPath, 'wp-load.php' ) )
+		fs.existsSync( path.join( projectPath, 'wp-content' ) ) &&
+		fs.existsSync( path.join( projectPath, 'wp-includes' ) ) &&
+		fs.existsSync( path.join( projectPath, 'wp-load.php' ) )
 	);
+}
+
+// Compare paths in a case-insensitive manner. `fs.Stats.dev` signifies the device ID, and
+// `fs.Stats.ino` signifies the inode number that uniquely identifies the file or directory.
+export function arePathsEqual( path1: string, path2: string ) {
+	try {
+		const stats1 = fs.statSync( path.resolve( path1 ) );
+		const stats2 = fs.statSync( path.resolve( path2 ) );
+
+		return stats1.ino === stats2.ino && stats1.dev === stats2.dev;
+	} catch ( error ) {
+		return false;
+	}
 }

--- a/src/hooks/use-add-site.ts
+++ b/src/hooks/use-add-site.ts
@@ -43,8 +43,11 @@ export function useAddSite() {
 	}, [] );
 
 	const siteWithPathAlreadyExists = useCallback(
-		( path: string ) => {
-			return sites.some( ( site ) => site.path.toLowerCase() === path.toLowerCase() );
+		async ( path: string ) => {
+			const results = await Promise.all(
+				sites.map( ( site ) => getIpcApi().comparePaths( site.path, path ) )
+			);
+			return results.some( Boolean );
 		},
 		[ sites ]
 	);
@@ -72,7 +75,12 @@ export function useAddSite() {
 				path === proposedSitePath.substring( 0, proposedSitePath.lastIndexOf( '/' ) );
 
 			setSitePath( pathResetToDefaultSitePath ? '' : path );
-			if ( siteWithPathAlreadyExists( path ) ) {
+			if ( await siteWithPathAlreadyExists( path ) ) {
+				setError(
+					__(
+						'The directory is already associated with another Studio site. Please choose a different custom local path.'
+					)
+				);
 				return;
 			}
 			if ( ! isEmpty && ! isWordPress && ! pathResetToDefaultSitePath ) {
@@ -173,7 +181,12 @@ export function useAddSite() {
 			} = await getIpcApi().generateProposedSitePath( name );
 			setProposedSitePath( proposedPath );
 
-			if ( siteWithPathAlreadyExists( proposedPath ) ) {
+			if ( await siteWithPathAlreadyExists( proposedPath ) ) {
+				setError(
+					__(
+						'The directory is already associated with another Studio site. Please choose a different site name or a custom local path.'
+					)
+				);
 				return;
 			}
 			if ( ! isEmpty && ! isWordPress ) {
@@ -190,28 +203,14 @@ export function useAddSite() {
 	);
 
 	return useMemo( () => {
-		let errorPathIsNotAvailable;
-		if ( siteWithPathAlreadyExists( sitePath ? sitePath : proposedSitePath ) ) {
-			if ( sitePath ) {
-				errorPathIsNotAvailable = __(
-					'The directory is already associated with another Studio site. Please choose a different custom local path.'
-				);
-			} else {
-				errorPathIsNotAvailable = __(
-					'The directory is already associated with another Studio site. Please choose a different site name or a custom local path.'
-				);
-			}
-		}
-
 		return {
 			handleAddSiteClick,
 			handlePathSelectorClick,
 			handleSiteNameChange,
-			error: errorPathIsNotAvailable || error,
+			error,
 			sitePath: sitePath ? sitePath : proposedSitePath,
 			siteName,
 			doesPathContainWordPress,
-			siteWithPathAlreadyExists,
 			setSiteName,
 			proposedSitePath,
 			setProposedSitePath,
@@ -237,12 +236,10 @@ export function useAddSite() {
 			loadAllCustomDomains,
 		};
 	}, [
-		__,
 		doesPathContainWordPress,
 		error,
 		handleAddSiteClick,
 		handlePathSelectorClick,
-		siteWithPathAlreadyExists,
 		handleSiteNameChange,
 		siteName,
 		sitePath,

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -17,7 +17,7 @@ import nodePath from 'path';
 import * as Sentry from '@sentry/electron/main';
 import { __, LocaleData, defaultI18n } from '@wordpress/i18n';
 import archiver from 'archiver';
-import { calculateDirectorySize, isWordPressDirectory } from 'common/lib/fs-utils';
+import { calculateDirectorySize, isWordPressDirectory, arePathsEqual } from 'common/lib/fs-utils';
 import { SupportedLocale } from 'common/lib/locale';
 import { getAuthenticationUrl } from 'common/lib/oauth';
 import { Snapshot } from 'common/types/snapshot';
@@ -1408,4 +1408,8 @@ export async function handleNewSite( event: IpcMainInvokeEvent, newSite: NewSite
 		...userData,
 		newSites: userData.newSites?.filter( ( s ) => s.id !== newSite.id ),
 	} );
+}
+
+export function comparePaths( event: IpcMainInvokeEvent, path1: string, path2: string ) {
+	return arePathsEqual( path1, path2 );
 }

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -118,6 +118,7 @@ const api: IpcApi = {
 	getUserEditor: () => ipcRendererInvoke( 'getUserEditor' ),
 	saveUserEditor: ( editor ) => ipcRendererInvoke( 'saveUserEditor', editor ),
 	handleNewSite: ( newSite ) => ipcRendererInvoke( 'handleNewSite', newSite ),
+	comparePaths: ( path1, path2 ) => ipcRendererInvoke( 'comparePaths', path1, path2 ),
 };
 
 contextBridge.exposeInMainWorld( 'ipcApi', api );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-487

## Proposed Changes

Our existing way of looking up Studio sites produces unexpected results on case-**insensitive** file systems if users have renamed any of the directories in the path to use a different case. Here's a concrete example:

- I'm using macOS's default file system.
- I have a Studio site in `/Users/fredrik/Studio/my-wordpress-website`.
- I rename the `Studio` folder to `STUDIO`.
- Studio continues to function normally, since the path still resolves to an actual location on disk.
- However, the CLI no longer works, since `process.cwd()` returns `/Users/fredrik/STUDIO/my-wordpress-website` and my Studio config file contains `/Users/fredrik/Studio/my-wordpress-website`.

This PR fixes the issue by using `fs.stat` and comparing `fs.Stats.dev` and `fs.Stats.ino` between the CLI path and the config file path. 

**Moreover**, I've updated `src/hooks/use-add-site.ts`. This hook would previously rely on comparing paths by always converting them to lowercase. We now use the same logic there as we do in the CLI.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Test the CLI:
1. Run `npm run cli:build`.
2. Run `node /dist/cli/main.js preview list --path ~/Studio/my-wordpress-website` (update the `--path` option to point to a Studio website).
3. Run `node /dist/cli/main.js preview list --path ~/STUDIO/my-wordpress-website` (use the same `--path` option, but change the case in some part of it).

Test the app:
1. Run `npm start`.
2. Click the `Add site` button.
3. Enter the name of a site that's already added to Studio (and that resides in Studio's default site directory).
4. Ensure that an error is displayed.
5. Change the site name to something else.
6. Manually specify a site path. Choose a site path that's already occupied by an existing Studio site. 
7. Ensure that an error is displayed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
