### PR TITLE
Studio: Use bundled version as fallback when offline

### DIFF
--- a/src/setup-wp-server-files.ts
+++ b/src/setup-wp-server-files.ts
@@ -23,7 +23,7 @@ import getSqlitePath from 'vendor/wp-now/src/get-sqlite-path';
 import getWpCliPath from 'vendor/wp-now/src/get-wp-cli-path';
 
 // Tries to copy the app's bundled WordPress version to `wp-now` WP versions if needed
-async function copyBundledLatestWPVersion() {
+export async function copyBundledLatestWPVersion() {
 	const bundledWPVersionPath = path.join( getResourcesPath(), 'wp-files', 'latest', 'wordpress' );
 	const bundledWPVersion = semver.coerce(
 		await getWordPressVersionFromInstallation( bundledWPVersionPath )

--- a/src/site-server.ts
+++ b/src/site-server.ts
@@ -50,8 +50,6 @@ export async function createSiteWorkingDirectory(
 					console.error( `Failed to download WordPress version ${ wpVersion }:`, error );
 				}
 			}
-
-			// For 'latest', try bundled version as fallback
 			if ( wpVersion === 'latest' ) {
 				await copyBundledLatestWPVersion();
 				return await pathExists( wpVersionPath );

--- a/src/site-server.ts
+++ b/src/site-server.ts
@@ -42,23 +42,22 @@ export async function createSiteWorkingDirectory(
 		const wpVersionExists = await pathExists( wpVersionPath );
 
 		if ( ! wpVersionExists ) {
-			if ( ! net.isOnline() ) {
-				if ( wpVersion === 'latest' ) {
-					await copyBundledLatestWPVersion();
-					if ( ! ( await pathExists( wpVersionPath ) ) ) {
-						return false;
-					}
-				} else {
-					return false;
-				}
-			} else {
+			if ( net.isOnline() ) {
 				try {
 					await downloadWordPress( wpVersion, { overwrite: false } );
+					return true;
 				} catch ( error ) {
 					console.error( `Failed to download WordPress version ${ wpVersion }:`, error );
-					return false;
 				}
 			}
+
+			// For 'latest', try bundled version as fallback
+			if ( wpVersion === 'latest' ) {
+				await copyBundledLatestWPVersion();
+				return await pathExists( wpVersionPath );
+			}
+
+			return false;
 		}
 
 		await purgeWpConfig( wpVersion );

--- a/src/site-server.ts
+++ b/src/site-server.ts
@@ -48,6 +48,9 @@ export async function createSiteWorkingDirectory(
 					return true;
 				} catch ( error ) {
 					console.error( `Failed to download WordPress version ${ wpVersion }:`, error );
+					throw new Error(
+						`Failed to download WordPress version ${ wpVersion }. Please try a different version.`
+					);
 				}
 			}
 			if ( wpVersion === 'latest' ) {

--- a/src/site-server.ts
+++ b/src/site-server.ts
@@ -34,6 +34,7 @@ export async function createSiteWorkingDirectory(
 ): Promise< boolean > {
 	try {
 		if ( ( await pathExists( path ) ) && ! ( await isEmptyDir( path ) ) ) {
+			// We can only create into a clean directory
 			return false;
 		}
 

--- a/src/site-server.ts
+++ b/src/site-server.ts
@@ -33,37 +33,26 @@ export async function createSiteWorkingDirectory(
 	wpVersion = 'latest'
 ): Promise< boolean > {
 	try {
-		console.log(
-			`Creating site working directory at ${ path } with WordPress version ${ wpVersion }`
-		);
-
 		if ( ( await pathExists( path ) ) && ! ( await isEmptyDir( path ) ) ) {
-			console.log( 'Target directory exists and is not empty' );
 			return false;
 		}
 
 		const wpVersionPath = getWordPressVersionPath( wpVersion );
-		console.log( `Checking WordPress version path: ${ wpVersionPath }` );
 		const wpVersionExists = await pathExists( wpVersionPath );
-		console.log( `WordPress version exists at path: ${ wpVersionExists }` );
 
 		if ( ! wpVersionExists ) {
 			if ( ! net.isOnline() ) {
 				if ( wpVersion === 'latest' ) {
-					console.log( 'Offline - using bundled WordPress files...' );
 					await copyBundledLatestWPVersion();
 					if ( ! ( await pathExists( wpVersionPath ) ) ) {
-						console.log( 'Failed to copy bundled WordPress files' );
 						return false;
 					}
 				} else {
-					console.log( 'Offline - cannot download specific WordPress version' );
 					return false;
 				}
 			} else {
 				try {
 					await downloadWordPress( wpVersion, { overwrite: false } );
-					console.log( `Successfully downloaded WordPress version ${ wpVersion }` );
 				} catch ( error ) {
 					console.error( `Failed to download WordPress version ${ wpVersion }:`, error );
 					return false;
@@ -71,14 +60,8 @@ export async function createSiteWorkingDirectory(
 			}
 		}
 
-		console.log( 'Purging WP config...' );
 		await purgeWpConfig( wpVersion );
-
-		console.log(
-			`Copying WordPress files from ${ getWordPressVersionPath( wpVersion ) } to ${ path }`
-		);
 		await recursiveCopyDirectory( getWordPressVersionPath( wpVersion ), path );
-		console.log( 'Successfully created site working directory' );
 
 		return true;
 	} catch ( error ) {

--- a/src/site-server.ts
+++ b/src/site-server.ts
@@ -18,7 +18,8 @@ import { updateSiteUrl } from 'src/lib/update-site-url';
 import WpCliProcess, { MessageCanceled, WpCliResult } from 'src/lib/wp-cli-process';
 import { purgeWpConfig } from 'src/lib/wp-versions';
 import { createScreenshotWindow } from 'src/screenshot-window';
-import { getResourcesPath, getSiteThumbnailPath } from 'src/storage/paths';
+import { copyBundledLatestWPVersion } from 'src/setup-wp-server-files';
+import { getSiteThumbnailPath } from 'src/storage/paths';
 import { getWpNowConfig } from 'vendor/wp-now/src';
 import { WPNowMode } from 'vendor/wp-now/src/config';
 import { DEFAULT_PHP_VERSION, SQLITE_FILENAME } from 'vendor/wp-now/src/constants';
@@ -47,35 +48,24 @@ export async function createSiteWorkingDirectory(
 		console.log( `WordPress version exists at path: ${ wpVersionExists }` );
 
 		if ( ! wpVersionExists ) {
-			// For 'latest' version, check bundled version first
-			const bundledWPVersionPath = nodePath.join(
-				getResourcesPath(),
-				'wp-files',
-				'latest',
-				'wordpress'
-			);
-			console.log( `Looking for bundled version at: ${ bundledWPVersionPath }` );
-			const bundledExists = await pathExists( bundledWPVersionPath );
-			console.log( `Bundled version exists: ${ bundledExists }` );
-
-			if ( bundledExists ) {
-				console.log( 'Found bundled WordPress version, copying to version path...' );
-				await recursiveCopyDirectory( bundledWPVersionPath, wpVersionPath );
-				console.log( 'Successfully copied bundled version' );
-			} else {
-				// Only try downloading if we're online
-				const isOnline = net.isOnline();
-				if ( isOnline ) {
-					console.log( 'Online and no bundled version found, attempting to download...' );
-					try {
-						await downloadWordPress( wpVersion, { overwrite: false } );
-						console.log( `Successfully downloaded WordPress version ${ wpVersion }` );
-					} catch ( error ) {
-						console.error( `Failed to download WordPress version ${ wpVersion }:`, error );
+			if ( ! net.isOnline() ) {
+				if ( wpVersion === 'latest' ) {
+					console.log( 'Offline - using bundled WordPress files...' );
+					await copyBundledLatestWPVersion();
+					if ( ! ( await pathExists( wpVersionPath ) ) ) {
+						console.log( 'Failed to copy bundled WordPress files' );
 						return false;
 					}
 				} else {
-					console.log( 'Offline and no bundled version available' );
+					console.log( 'Offline - cannot download specific WordPress version' );
+					return false;
+				}
+			} else {
+				try {
+					await downloadWordPress( wpVersion, { overwrite: false } );
+					console.log( `Successfully downloaded WordPress version ${ wpVersion }` );
+				} catch ( error ) {
+					console.error( `Failed to download WordPress version ${ wpVersion }:`, error );
 					return false;
 				}
 			}

--- a/src/site-server.ts
+++ b/src/site-server.ts
@@ -45,20 +45,17 @@ export async function createSiteWorkingDirectory(
 			if ( net.isOnline() ) {
 				try {
 					await downloadWordPress( wpVersion, { overwrite: false } );
-					return true;
 				} catch ( error ) {
 					console.error( `Failed to download WordPress version ${ wpVersion }:`, error );
 					throw new Error(
 						`Failed to download WordPress version ${ wpVersion }. Please try a different version.`
 					);
 				}
-			}
-			if ( wpVersion === 'latest' ) {
+			} else if ( wpVersion === 'latest' ) {
 				await copyBundledLatestWPVersion();
-				return await pathExists( wpVersionPath );
+			} else {
+				return false;
 			}
-
-			return false;
 		}
 
 		await purgeWpConfig( wpVersion );

--- a/src/site-server.ts
+++ b/src/site-server.ts
@@ -1,3 +1,4 @@
+import { net } from 'electron';
 import fs from 'fs';
 import nodePath from 'path';
 import * as Sentry from '@sentry/electron/main';
@@ -17,7 +18,7 @@ import { updateSiteUrl } from 'src/lib/update-site-url';
 import WpCliProcess, { MessageCanceled, WpCliResult } from 'src/lib/wp-cli-process';
 import { purgeWpConfig } from 'src/lib/wp-versions';
 import { createScreenshotWindow } from 'src/screenshot-window';
-import { getSiteThumbnailPath } from 'src/storage/paths';
+import { getResourcesPath, getSiteThumbnailPath } from 'src/storage/paths';
 import { getWpNowConfig } from 'vendor/wp-now/src';
 import { WPNowMode } from 'vendor/wp-now/src/config';
 import { DEFAULT_PHP_VERSION, SQLITE_FILENAME } from 'vendor/wp-now/src/constants';
@@ -30,29 +31,70 @@ export async function createSiteWorkingDirectory(
 	path: string,
 	wpVersion = 'latest'
 ): Promise< boolean > {
-	if ( ( await pathExists( path ) ) && ! ( await isEmptyDir( path ) ) ) {
-		// We can only create into a clean directory
+	try {
+		console.log(
+			`Creating site working directory at ${ path } with WordPress version ${ wpVersion }`
+		);
+
+		if ( ( await pathExists( path ) ) && ! ( await isEmptyDir( path ) ) ) {
+			console.log( 'Target directory exists and is not empty' );
+			return false;
+		}
+
+		const wpVersionPath = getWordPressVersionPath( wpVersion );
+		console.log( `Checking WordPress version path: ${ wpVersionPath }` );
+		const wpVersionExists = await pathExists( wpVersionPath );
+		console.log( `WordPress version exists at path: ${ wpVersionExists }` );
+
+		if ( ! wpVersionExists ) {
+			// For 'latest' version, check bundled version first
+			const bundledWPVersionPath = nodePath.join(
+				getResourcesPath(),
+				'wp-files',
+				'latest',
+				'wordpress'
+			);
+			console.log( `Looking for bundled version at: ${ bundledWPVersionPath }` );
+			const bundledExists = await pathExists( bundledWPVersionPath );
+			console.log( `Bundled version exists: ${ bundledExists }` );
+
+			if ( bundledExists ) {
+				console.log( 'Found bundled WordPress version, copying to version path...' );
+				await recursiveCopyDirectory( bundledWPVersionPath, wpVersionPath );
+				console.log( 'Successfully copied bundled version' );
+			} else {
+				// Only try downloading if we're online
+				const isOnline = net.isOnline();
+				if ( isOnline ) {
+					console.log( 'Online and no bundled version found, attempting to download...' );
+					try {
+						await downloadWordPress( wpVersion, { overwrite: false } );
+						console.log( `Successfully downloaded WordPress version ${ wpVersion }` );
+					} catch ( error ) {
+						console.error( `Failed to download WordPress version ${ wpVersion }:`, error );
+						return false;
+					}
+				} else {
+					console.log( 'Offline and no bundled version available' );
+					return false;
+				}
+			}
+		}
+
+		console.log( 'Purging WP config...' );
+		await purgeWpConfig( wpVersion );
+
+		console.log(
+			`Copying WordPress files from ${ getWordPressVersionPath( wpVersion ) } to ${ path }`
+		);
+		await recursiveCopyDirectory( getWordPressVersionPath( wpVersion ), path );
+		console.log( 'Successfully created site working directory' );
+
+		return true;
+	} catch ( error ) {
+		console.error( 'Error in createSiteWorkingDirectory:', error );
 		return false;
 	}
-
-	const wpVersionPath = getWordPressVersionPath( wpVersion );
-	const wpVersionExists = await pathExists( wpVersionPath );
-
-	if ( ! wpVersionExists ) {
-		try {
-			await downloadWordPress( wpVersion, { overwrite: false } );
-		} catch ( error ) {
-			console.error( `Failed to download WordPress version ${ wpVersion }:`, error );
-			throw new Error(
-				`Failed to download WordPress version ${ wpVersion }. Please try a different version.`
-			);
-		}
-	}
-
-	await purgeWpConfig( wpVersion );
-	await recursiveCopyDirectory( getWordPressVersionPath( wpVersion ), path );
-
-	return true;
 }
 
 export async function stopAllServersOnQuit() {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

Fixes STU-495

## Proposed Changes

Currently, if there is no `latest` folder in the `/Library/Application Support/Studio/server-files/wordpress-versions`, we are not using the bundled version that is available with Studio as fallback. As a result, if the user is offline and that folder is not present, the app with throw a gibberish error.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Start Studio app 
* Navigate to `/Library/Application Support/Studio/server-files/wordpress-versions`
* Remove `latest` folder or you can remove all folders 
* Once the folder is removed, disconnect yourself from the internet (e.g. cut WiFi)
* Click on `Add site` in the sidebar
* Observe that once the site is being created, you can see the `latest` folder added back to `/Library/Application Support/Studio/server-files/wordpress-versions`
* Confirm that the site is added with the latest version and that it starts successfully
* Repeat the same steps on trunk and observe a jibbersh error thrown when the user is offline, the latest folder is missing and there is an attempted download of WordPress

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
