### PR TITLE
Studio: Force latest WP version for creating site if the user goes offline

### DIFF
--- a/src/components/site-form.tsx
+++ b/src/components/site-form.tsx
@@ -424,6 +424,9 @@ export const SiteForm = ( {
 												fallbackOptions={ [
 													{ label: __( 'Latest' ), value: DEFAULT_WORDPRESS_VERSION },
 												] }
+												offlineMessage={ __(
+													'You are currently offline so your site will be created with the latest version. Selecting a different WordPress version requires an internet connection.'
+												) }
 											/>
 										</div>
 

--- a/src/components/tests/add-site.test.tsx
+++ b/src/components/tests/add-site.test.tsx
@@ -416,7 +416,9 @@ describe( 'AddSite', () => {
 		await user.hover( wpVersionSelect );
 
 		expect(
-			screen.getByText( 'Changing WordPress version requires an internet connection.' )
+			screen.getByText(
+				'You are currently offline so your site will be created with the latest version. Selecting a different WordPress version requires an internet connection.'
+			)
 		).toBeInTheDocument();
 	} );
 
@@ -433,7 +435,9 @@ describe( 'AddSite', () => {
 		await user.hover( wpVersionSelect );
 
 		expect(
-			screen.queryByText( 'Changing WordPress version requires an internet connection.' )
+			screen.queryByText(
+				'You are currently offline so your site will be created with the latest version. Selecting a different WordPress version requires an internet connection.'
+			)
 		).not.toBeInTheDocument();
 	} );
 } );

--- a/src/components/tests/onboarding.test.tsx
+++ b/src/components/tests/onboarding.test.tsx
@@ -278,7 +278,9 @@ describe( 'Onboarding Component', () => {
 		await user.hover( wpVersionSelect );
 
 		expect(
-			screen.getByText( 'Changing WordPress version requires an internet connection.' )
+			screen.getByText(
+				'You are currently offline so your site will be created with the latest version. Selecting a different WordPress version requires an internet connection.'
+			)
 		).toBeInTheDocument();
 	} );
 
@@ -292,7 +294,9 @@ describe( 'Onboarding Component', () => {
 		await user.hover( wpVersionSelect );
 
 		expect(
-			screen.queryByText( 'Changing WordPress version requires an internet connection.' )
+			screen.queryByText(
+				'You are currently offline so your site will be created with the latest version. Selecting a different WordPress version requires an internet connection.'
+			)
 		).not.toBeInTheDocument();
 	} );
 } );

--- a/src/components/wp-version-selector/index.tsx
+++ b/src/components/wp-version-selector/index.tsx
@@ -1,6 +1,7 @@
 import { SelectControl, Icon } from '@wordpress/components';
 import { info } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
+import { useEffect } from 'react';
 import offlineIcon from 'src/components/offline-icon';
 import { Tooltip } from 'src/components/tooltip';
 import { useOffline } from 'src/hooks/use-offline';
@@ -34,6 +35,13 @@ export const WPVersionSelector = ( {
 	const isOffline = useOffline();
 	const offlineMessage = __( 'Changing WordPress version requires an internet connection.' );
 	const { data: wpVersions = [] } = useGetWordPressVersions();
+
+	// Force latest version if the user goes offline
+	useEffect( () => {
+		if ( isOffline && selectedValue !== DEFAULT_WORDPRESS_VERSION ) {
+			onChange( DEFAULT_WORDPRESS_VERSION );
+		}
+	}, [ isOffline, selectedValue, onChange ] );
 
 	let betaVersions: { label: string; value: string }[] = wpVersions.filter(
 		( version ) => version.isBeta || version.isDevelopment

--- a/src/components/wp-version-selector/index.tsx
+++ b/src/components/wp-version-selector/index.tsx
@@ -42,10 +42,11 @@ export const WPVersionSelector = ( {
 
 	// Force latest version if the user goes offline
 	useEffect( () => {
-		if ( isOffline && selectedValue !== DEFAULT_WORDPRESS_VERSION ) {
+		if ( isOffline ) {
+			// Always force to latest when offline
 			onChange( DEFAULT_WORDPRESS_VERSION );
 		}
-	}, [ isOffline, selectedValue, onChange ] );
+	}, [ isOffline, onChange ] );
 
 	let betaVersions: { label: string; value: string }[] = wpVersions.filter(
 		( version ) => version.isBeta || version.isDevelopment

--- a/src/components/wp-version-selector/index.tsx
+++ b/src/components/wp-version-selector/index.tsx
@@ -21,6 +21,8 @@ type WPVersionSelectorProps = {
 	extraOptions?: { label: string; value: string }[];
 	/** Fallback options shown when available versions couldn't be fetched */
 	fallbackOptions: { label: string; value: string }[];
+	/** Custom message to show when offline. If not provided, will use the default message */
+	offlineMessage?: string;
 };
 
 export const WPVersionSelector = ( {
@@ -30,10 +32,12 @@ export const WPVersionSelector = ( {
 	disabled = false,
 	extraOptions,
 	fallbackOptions,
+	offlineMessage,
 }: WPVersionSelectorProps ) => {
 	const { __ } = useI18n();
 	const isOffline = useOffline();
-	const offlineMessage = __( 'Changing WordPress version requires an internet connection.' );
+	const defaultOfflineMessage = __( 'Changing WordPress version requires an internet connection.' );
+	const message = offlineMessage || defaultOfflineMessage;
 	const { data: wpVersions = [] } = useGetWordPressVersions();
 
 	// Force latest version if the user goes offline
@@ -81,7 +85,7 @@ export const WPVersionSelector = ( {
 			<Tooltip
 				disabled={ ! isOffline }
 				icon={ offlineIcon }
-				text={ offlineMessage }
+				text={ message }
 				placement="top-start"
 				className="flex flex-1 flex-col"
 			>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

Fixes STU-494

## Proposed Changes

Currently, if the user opens the `Add site` form, chooses a custom WP version that needs to be downloaded and then their connection cuts, Studio attempts to download that WP version and this results in a gibberish error. 

I propose to force the `latest` version for creating a site if the user is offline since this comes with Studio already and should work without connection.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
* Start Studio with `npm start`
* Click on `Add site` in the sidebar
* Select the WP version from the dropdown that is not `latest`
* Keep the form open
* Cut your internet access
* Observe that the option in the dropdown gets set to `latest`
* Confirm that the site gets created and starts successfully with the latest version
* You can repeat the same steps on trunk and confirm that you can attempt site creation with a custom WP version which results into gibberish error when the app attempts downloading WordPress

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
