### PR TITLE
Delete https protocol from urls in UI

### DIFF
--- a/src/components/sync-connected-sites.tsx
+++ b/src/components/sync-connected-sites.tsx
@@ -290,7 +290,7 @@ const SyncConnectedSitesList = ( {
 								getIpcApi().openURL( connectedSite.url );
 							} }
 						>
-							<span className="truncate">{ connectedSite.url }</span> <ArrowIcon />
+							<span className="truncate">{ connectedSite.url.replace( /^https?:\/\//, '' ) }</span> <ArrowIcon />
 						</Button>
 
 						<div className="flex shrink-0 justify-self-end">

--- a/src/components/sync-connected-sites.tsx
+++ b/src/components/sync-connected-sites.tsx
@@ -290,7 +290,8 @@ const SyncConnectedSitesList = ( {
 								getIpcApi().openURL( connectedSite.url );
 							} }
 						>
-							<span className="truncate">{ connectedSite.url.replace( /^https?:\/\//, '' ) }</span> <ArrowIcon />
+							<span className="truncate">{ connectedSite.url.replace( /^https?:\/\//, '' ) }</span>{ ' ' }
+							<ArrowIcon />
 						</Button>
 
 						<div className="flex shrink-0 justify-self-end">

--- a/src/components/tests/content-tab-sync.test.tsx
+++ b/src/components/tests/content-tab-sync.test.tsx
@@ -236,12 +236,12 @@ describe( 'ContentTabSync', () => {
 		expect( pushButtons ).toHaveLength( 2 );
 
 		const productionUrl = screen.getAllByRole( 'button', {
-			name: 'https://developer.wordpress.com/studio/ ↗',
+			name: 'developer.wordpress.com/studio/ ↗',
 		} );
 		expect( productionUrl ).toHaveLength( 1 );
 
 		const stagingUrl = screen.getAllByRole( 'button', {
-			name: 'https://developer-staging.wordpress.com/studio/ ↗',
+			name: 'developer-staging.wordpress.com/studio/ ↗',
 		} );
 		expect( stagingUrl ).toHaveLength( 1 );
 	} );

--- a/src/modules/preview-site/components/preview-site-row.tsx
+++ b/src/modules/preview-site/components/preview-site-row.tsx
@@ -100,8 +100,6 @@ export function PreviewSiteRow( {
 		return sprintf( __( '%s ago' ), timeDistance );
 	};
 
-	const urlWithHTTPS = `https://${ url }`;
-
 	if ( deleteOperation?.status === 'pending' ) {
 		return <DeleteProgressRow />;
 	}
@@ -128,10 +126,10 @@ export function PreviewSiteRow( {
 							'!text-a8c-gray-700 max-w-full',
 							isExpired ? 'pointer-events-none' : 'hover:!text-a8c-blueberry'
 						) }
-						onClick={ () => getIpcApi().openURL( urlWithHTTPS ) }
+						onClick={ () => getIpcApi().openURL( `https://${ url }` ) }
 					>
 						<span className={ cx( 'truncate', isExpired && 'line-through text-a8c-gray-700' ) }>
-							{ urlWithHTTPS }
+							{ url }
 						</span>
 						{ ! isExpired && <ArrowIcon /> }
 					</Button>

--- a/src/modules/preview-site/components/tests/preview-site-row.test.tsx
+++ b/src/modules/preview-site/components/tests/preview-site-row.test.tsx
@@ -90,7 +90,7 @@ describe( 'PreviewSiteRow', () => {
 		);
 
 		const siteName = screen.getByText( mockSnapshot.name );
-		const siteUrl = screen.getByText( `https://${ mockSnapshot.url }` );
+		const siteUrl = screen.getByText( mockSnapshot.url );
 
 		expect( siteName.className ).toContain( 'line-through' );
 		expect( siteUrl.className ).toContain( 'line-through' );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-479

## Proposed Changes

- I propose deleting the `https://` protocol from URLs in the UI. It will make the UI more readable.

![Screenshot 2025-05-13 at 14 32 26](https://github.com/user-attachments/assets/530f2fc2-19fa-4883-bc05-1b2466c5ce1f)

![Screenshot 2025-05-13 at 14 32 13](https://github.com/user-attachments/assets/07b1e31f-f297-4126-b2a9-fe6fb86d1942)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Start Studio
2. Add site and navigate to the Sync tab
3. Connect to the WordPress.com site
4. Confirm that it doesn't show protocol on the list of connected sites and ensure it still points to the correct URL when clicked
5. Navigate to the Previews tab
6. Add a preview site
7. Confirm it doesn't show protocol and ensure it still points to the correct URL when clicked

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
