### PR TITLE
Settings: Fix click events when no sites exist

### DIFF
--- a/src/modules/user-settings/components/user-settings.tsx
+++ b/src/modules/user-settings/components/user-settings.tsx
@@ -90,7 +90,7 @@ export default function UserSettings() {
 					size="medium"
 					className={ cx( 'min-h-[350px]', '[&_[role="document"]]:px-0' ) }
 				>
-					<TabPanel className="w-full" tabs={ tabs } orientation="horizontal">
+					<TabPanel className="w-full app-no-drag-region" tabs={ tabs } orientation="horizontal">
 						{ ( { name } ) => (
 							<div className="mt-6 px-8 flex gap-4 flex-col">
 								{ name === 'account' &&

--- a/src/modules/user-settings/components/user-settings.tsx
+++ b/src/modules/user-settings/components/user-settings.tsx
@@ -88,9 +88,9 @@ export default function UserSettings() {
 					isDismissible
 					onRequestClose={ resetLocalState }
 					size="medium"
-					className={ cx( 'min-h-[350px]', '[&_[role="document"]]:px-0' ) }
+					className={ cx( 'min-h-[350px]', '[&_[role="document"]]:px-0', 'app-no-drag-region' ) }
 				>
-					<TabPanel className="w-full app-no-drag-region" tabs={ tabs } orientation="horizontal">
+					<TabPanel className="w-full" tabs={ tabs } orientation="horizontal">
 						{ ( { name } ) => (
 							<div className="mt-6 px-8 flex gap-4 flex-col">
 								{ name === 'account' &&


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-498
- Fixes https://github.com/Automattic/studio/issues/1387

## Proposed Changes

- Add `app-no-drag-region` class to the Modal so pointer events are listened.
- The div that was causing the pointer events to be ignored is [this one](https://github.com/Automattic/studio/blob/9e05b4c601a069698a563d56baa4aef6d0bea121/src/components/onboarding.tsx#L149)

https://github.com/user-attachments/assets/dbd8586a-4d50-4555-ae7e-e42d61f8aa30


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Apply this branch and run `npm start`
- Delete all sites
- Open the settings or press `Cmd+,`
- Check that you can click on the `Preferences` and `Usage` tabs

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
