### PR TITLE
Pressable Sync: Add `Sandbox` environment badge for sandbox sites

### DIFF
--- a/src/components/environment-badge.tsx
+++ b/src/components/environment-badge.tsx
@@ -2,7 +2,7 @@ import { __ } from '@wordpress/i18n';
 import { Badge } from 'src/components/badge';
 import { cx } from 'src/lib/cx';
 
-export type EnvironmentType = 'production' | 'staging';
+export type EnvironmentType = 'production' | 'staging' | 'sandbox';
 
 interface EnvironmentBadgeProps {
 	type: EnvironmentType;
@@ -22,12 +22,19 @@ export function EnvironmentBadge( { type, selected }: EnvironmentBadgeProps ) {
 			return 'bg-a8c-green-5 text-a8c-green-80';
 		}
 
+		if ( type === 'sandbox' ) {
+			return 'text-sandbox-text bg-sandbox-bg';
+		}
+
 		return '';
 	};
 
 	const getLabel = () => {
 		if ( type === 'staging' ) {
 			return __( 'Staging' );
+		}
+		if ( type === 'sandbox' ) {
+			return __( 'Sandbox' );
 		}
 		return __( 'Production' );
 	};

--- a/src/components/environment-badge.tsx
+++ b/src/components/environment-badge.tsx
@@ -29,15 +29,11 @@ export function EnvironmentBadge( { type, selected }: EnvironmentBadgeProps ) {
 		return '';
 	};
 
-	const getLabel = () => {
-		if ( type === 'staging' ) {
-			return __( 'Staging' );
-		}
-		if ( type === 'sandbox' ) {
-			return __( 'Sandbox' );
-		}
-		return __( 'Production' );
+	const labels: Record< EnvironmentType, string > = {
+		staging: __( 'Staging' ),
+		sandbox: __( 'Sandbox' ),
+		production: __( 'Production' ),
 	};
 
-	return <Badge className={ cx( getClassName() ) }>{ getLabel() }</Badge>;
+	return <Badge className={ cx( getClassName() ) }>{ labels[ type ] }</Badge>;
 }

--- a/src/components/environment-badge.tsx
+++ b/src/components/environment-badge.tsx
@@ -2,7 +2,7 @@ import { __ } from '@wordpress/i18n';
 import { Badge } from 'src/components/badge';
 import { cx } from 'src/lib/cx';
 
-export type EnvironmentType = 'production' | 'staging' | 'sandbox';
+type EnvironmentType = 'production' | 'staging' | 'sandbox';
 
 interface EnvironmentBadgeProps {
 	type: EnvironmentType;

--- a/src/components/sync-connected-sites.tsx
+++ b/src/components/sync-connected-sites.tsx
@@ -270,6 +270,9 @@ const SyncConnectedSitesList = ( {
 								{ connectedSite.environmentType === 'production' && (
 									<EnvironmentBadge type="production" />
 								) }
+								{ connectedSite.environmentType === 'sandbox' && (
+									<EnvironmentBadge type="sandbox" />
+								) }
 							</div>
 						) }
 

--- a/src/components/sync-sites-modal-selector.tsx
+++ b/src/components/sync-sites-modal-selector.tsx
@@ -272,6 +272,9 @@ function SiteItem( {
 							{ environmentType === 'staging' && (
 								<EnvironmentBadge type="staging" selected={ isSelected } />
 							) }
+							{ environmentType === 'sandbox' && (
+								<EnvironmentBadge type="sandbox" selected={ isSelected } />
+							) }
 						</>
 					) }
 				</div>

--- a/src/components/tests/content-tab-sync.test.tsx
+++ b/src/components/tests/content-tab-sync.test.tsx
@@ -304,7 +304,7 @@ describe( 'ContentTabSync', () => {
 		expect( connectButton ).toBeInTheDocument();
 	} );
 
-	it( 'displays environment badges for Pressable sites with production and staging environments', () => {
+	it( 'displays environment badges for Pressable sites with production, staging and sandbox environments', () => {
 		const fakePressableProductionSite = {
 			id: 6,
 			name: 'My Pressable Production site',
@@ -325,9 +325,23 @@ describe( 'ContentTabSync', () => {
 			stagingSiteIds: [],
 			syncSupport: 'already-connected',
 		};
+		const fakePressableSandboxSite = {
+			id: 8,
+			name: 'My Pressable Sandbox site',
+			url: 'https://sandbox-pressable-site.com',
+			isStaging: false,
+			isPressable: true,
+			environmentType: 'sandbox',
+			stagingSiteIds: [],
+			syncSupport: 'already-connected',
+		};
 		( useAuth as jest.Mock ).mockReturnValue( { isAuthenticated: true, authenticate: jest.fn() } );
 		( useSyncSites as jest.Mock ).mockReturnValue( {
-			connectedSites: [ fakePressableProductionSite, fakePressableStagingSite ],
+			connectedSites: [
+				fakePressableProductionSite,
+				fakePressableStagingSite,
+				fakePressableSandboxSite,
+			],
 			syncSites: [ fakePressableProductionSite ],
 			pullSite: jest.fn(),
 			isAnySitePulling: false,
@@ -345,8 +359,10 @@ describe( 'ContentTabSync', () => {
 
 		expect( screen.getByText( fakePressableProductionSite.name ) ).toBeInTheDocument();
 		expect( screen.getByText( fakePressableStagingSite.name ) ).toBeInTheDocument();
+		expect( screen.getByText( fakePressableSandboxSite.name ) ).toBeInTheDocument();
 
 		expect( screen.getByText( 'Production' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Staging' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Sandbox' ) ).toBeInTheDocument();
 	} );
 } );

--- a/src/components/tests/environment-badge.test.tsx
+++ b/src/components/tests/environment-badge.test.tsx
@@ -14,6 +14,12 @@ describe( 'EnvironmentBadge', () => {
 		expect( badge ).toBeInTheDocument();
 	} );
 
+	it( 'renders the Sandbox badge with correct label', () => {
+		render( <EnvironmentBadge type="sandbox" /> );
+		const badge = screen.getByText( 'Sandbox' );
+		expect( badge ).toBeInTheDocument();
+	} );
+
 	it( 'applies specific classes for the Production badge', () => {
 		const { container } = render( <EnvironmentBadge type="production" /> );
 
@@ -32,6 +38,16 @@ describe( 'EnvironmentBadge', () => {
 
 		expect( badgeElement.className ).toContain( 'text-a8c-yellow-80' );
 		expect( badgeElement.className ).toContain( 'bg-a8c-yellow-10' );
+	} );
+
+	it( 'applies specific classes for the Sandbox badge', () => {
+		const { container } = render( <EnvironmentBadge type="sandbox" /> );
+
+		const badgeElement = container.firstChild as HTMLElement;
+		expect( badgeElement ).toBeInTheDocument();
+
+		expect( badgeElement.className ).toContain( 'text-sandbox-text' );
+		expect( badgeElement.className ).toContain( 'bg-sandbox-bg' );
 	} );
 
 	it( 'applies "selected" styling when selected prop is true', () => {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -146,6 +146,8 @@ module.exports = {
 				...a8cToTailwindColors,
 				chrome: 'rgba(30, 30, 30, 1)',
 				'chrome-inverted': '#fff',
+				'sandbox-bg': 'hsl(200, 95%, 85%)',
+				'sandbox-text': 'hsl(200, 95%, 28%)',
 			},
 			spacing: {
 				chrome: `${ APP_CHROME_SPACING }px`,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Related to STU-469-linear-issue.

## Proposed Changes

- add `Sandbox` badge to Pressable sandbox sites.
- update related tests

| Sync modal | Sync tab |
|--------|--------|
| ![Markup on 2025-05-14 at 13:57:28](https://github.com/user-attachments/assets/c724b8c0-346f-4686-a5cd-50be50f2abe0) | ![Markup on 2025-05-14 at 13:56:43](https://github.com/user-attachments/assets/a24f56ed-1f19-4c1f-bc33-a6e5d4873dad) | 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Follow the testing instructions on the related Jetpack PR: https://github.com/Automattic/jetpack/pull/43430.
2. Check out this Studio PR branch and build the app with `STUDIO_PRESSABLE_SYNC=true npm start`.
3. Head over to the Sync tab on one of your local Studio sites.
4. Search for your Pressable sandbox site in the modal. It should have the `Sandbox` badge displayed.
5. Connect the site and review it on the Sync tab. It should have the `Sandbox` badge displayed there as well.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?