### PR TITLE
Remove Pressable Sync feature flag

### DIFF
--- a/src/components/content-tab-sync.tsx
+++ b/src/components/content-tab-sync.tsx
@@ -18,7 +18,6 @@ import { getIpcApi } from 'src/lib/get-ipc-api';
 import type { SyncSite } from 'src/hooks/use-fetch-wpcom-sites/types';
 function SiteSyncDescription( { children }: PropsWithChildren ) {
 	const { __ } = useI18n();
-	const { pressableSyncEnabled } = useFeatureFlags();
 	return (
 		<div className="flex justify-between max-w-3xl gap-4">
 			<div className="flex flex-col p-8">
@@ -27,13 +26,9 @@ function SiteSyncDescription( { children }: PropsWithChildren ) {
 					<WordPressShortLogo className="ms-2 h-5" />
 				</div>
 				<div className="max-w-[40ch] text-a8c-gray-70 a8c-body">
-					{ pressableSyncEnabled
-						? __(
-								'Connect your existing WordPress.com or Jetpack-activated Pressable sites, or create a new one. Then, share your work with the world.'
-						  )
-						: __(
-								'Connect an existing WordPress.com site, or create a new one and share your site with the world.'
-						  ) }
+					{ __(
+						'Connect your existing WordPress.com or Jetpack-activated Pressable sites, or create a new one. Then, share your work with the world.'
+					) }
 				</div>
 				<div className="mt-6">
 					{ [
@@ -128,7 +123,6 @@ export function ContentTabSync( { selectedSite }: { selectedSite: SiteDetails } 
 		closeSyncSitesSelector,
 	} = useSyncSites();
 	const { isAuthenticated } = useAuth();
-	const { pressableSyncEnabled } = useFeatureFlags();
 
 	useEffect( () => {
 		if ( isAuthenticated ) {
@@ -161,15 +155,13 @@ export function ContentTabSync( { selectedSite }: { selectedSite: SiteDetails } 
 						openSitesSyncSelector={ ( options ) => setIsSyncSitesSelectorOpen( options || true ) }
 						disconnectSite={ ( id: number ) => disconnectSite( id ) }
 					/>
-					{ pressableSyncEnabled && (
-						<div className="sticky bottom-0 bg-white/[0.8] backdrop-blur-sm w-full px-8 py-6 mt-auto">
-							<ConnectButton
-								variant="primary"
-								connectSite={ () => setIsSyncSitesSelectorOpen( true ) }
-								disableConnectButtonStyle={ true }
-							/>
-						</div>
-					) }
+					<div className="sticky bottom-0 bg-white/[0.8] backdrop-blur-sm w-full px-8 py-6 mt-auto">
+						<ConnectButton
+							variant="primary"
+							connectSite={ () => setIsSyncSitesSelectorOpen( true ) }
+							disableConnectButtonStyle={ true }
+						/>
+					</div>
 				</div>
 			) : (
 				<SiteSyncDescription>

--- a/src/components/content-tab-sync.tsx
+++ b/src/components/content-tab-sync.tsx
@@ -12,7 +12,6 @@ import { Tooltip } from 'src/components/tooltip';
 import { WordPressShortLogo } from 'src/components/wordpress-short-logo';
 import { useSyncSites } from 'src/hooks/sync-sites';
 import { useAuth } from 'src/hooks/use-auth';
-import { useFeatureFlags } from 'src/hooks/use-feature-flags';
 import { useOffline } from 'src/hooks/use-offline';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 import type { SyncSite } from 'src/hooks/use-fetch-wpcom-sites/types';

--- a/src/components/sync-connected-sites.tsx
+++ b/src/components/sync-connected-sites.tsx
@@ -17,7 +17,6 @@ import { Tooltip, DynamicTooltip } from 'src/components/tooltip';
 import { WordPressLogoCircle } from 'src/components/wordpress-logo-circle';
 import { useSyncSites } from 'src/hooks/sync-sites';
 import { useConfirmationDialog } from 'src/hooks/use-confirmation-dialog';
-import { useFeatureFlags } from 'src/hooks/use-feature-flags';
 import { useI18nData } from 'src/hooks/use-i18n-data';
 import { ImportProgressState, useImportExport } from 'src/hooks/use-import-export';
 import { useOffline } from 'src/hooks/use-offline';

--- a/src/components/sync-connected-sites.tsx
+++ b/src/components/sync-connected-sites.tsx
@@ -234,7 +234,6 @@ const SyncConnectedSitesList = ( {
 	const { clearPullState, getPullState, getPushState, clearPushState } = useSyncSites();
 	const { importState } = useImportExport();
 	const { isKeyPulling, isKeyPushing, isKeyFinished, isKeyFailed } = useSyncStatesProgressInfo();
-	const { pressableSyncEnabled } = useFeatureFlags();
 
 	return (
 		<div className="grid grid-cols-[max-content_1fr_max-content]">
@@ -332,11 +331,10 @@ const SyncConnectedSitesList = ( {
 										'Push is in progress. We will send you an email when it is completed.'
 									) }
 									placement="top-start"
-									disabled={ ! pressableSyncEnabled }
 								>
 									<div className="flex flex-col gap-2 min-w-44">
 										<div className="a8c-body-small flex items-center gap-0.5">
-											{ pressableSyncEnabled && <Icon icon={ info } size={ 16 } /> }
+											<Icon icon={ info } size={ 16 } />
 											{ pushState.status.message }
 										</div>
 										<ProgressBar value={ pushState.status.progress } maxValue={ 100 } />

--- a/src/components/sync-sites-modal-selector.tsx
+++ b/src/components/sync-sites-modal-selector.tsx
@@ -41,7 +41,6 @@ export function SyncSitesModalSelector( {
 	const [ selectedSiteId, setSelectedSiteId ] = useState< number | null >( null );
 	const [ searchQuery, setSearchQuery ] = useState< string >( '' );
 	const isOffline = useOffline();
-	const { pressableSyncEnabled } = useFeatureFlags();
 	const filteredSites = syncSites.filter( ( site ) => {
 		const searchQueryLower = searchQuery.toLowerCase();
 		return (
@@ -61,11 +60,7 @@ export function SyncSitesModalSelector( {
 		<Modal
 			className="w-3/5 min-w-[550px] h-full max-h-[84vh] [&>div]:!p-0"
 			onRequestClose={ onRequestClose }
-			title={
-				pressableSyncEnabled
-					? __( 'Connect a WP.com or Pressable site' )
-					: __( 'Connect a WordPress.com site' )
-			}
+			title={ __( 'Connect a WP.com or Pressable site' ) }
 		>
 			<div className="relative">
 				<SearchSites searchQuery={ searchQuery } setSearchQuery={ setSearchQuery } />
@@ -89,7 +84,6 @@ export function SyncSitesModalSelector( {
 							syncSites={ filteredSites }
 							selectedSiteId={ selectedSiteId }
 							onSelectSite={ setSelectedSiteId }
-							pressableSyncEnabled={ pressableSyncEnabled }
 						/>
 					) }
 				</div>
@@ -123,7 +117,6 @@ function SearchSites( {
 	setSearchQuery: ( value: string ) => void;
 } ) {
 	const { __ } = useI18n();
-	const { pressableSyncEnabled } = useFeatureFlags();
 	return (
 		<div className="flex flex-col px-8 pb-6 border-b border-a8c-gray-5">
 			<SearchControl
@@ -137,9 +130,7 @@ function SearchSites( {
 				__nextHasNoMarginBottom={ true }
 			/>
 			<p className="a8c-helper-text text-gray-500">
-				{ pressableSyncEnabled
-					? __( 'Syncing is supported for WP.com sites on the Business plan or above.' )
-					: __( 'Syncing is supported for sites on the Business plan or above.' ) }
+				{ __( 'Syncing is supported for WP.com sites on the Business plan or above.' ) }
 			</p>
 		</div>
 	);
@@ -163,12 +154,10 @@ function ListSites( {
 	syncSites,
 	selectedSiteId,
 	onSelectSite,
-	pressableSyncEnabled,
 }: {
 	syncSites: SyncSite[];
 	selectedSiteId: null | number;
 	onSelectSite: ( id: number ) => void;
-	pressableSyncEnabled: boolean;
 } ) {
 	const sortedSites = getSortedSites( syncSites );
 
@@ -180,7 +169,6 @@ function ListSites( {
 					site={ site }
 					isSelected={ site.id === selectedSiteId }
 					onClick={ () => onSelectSite( site.id ) }
-					pressableSyncEnabled={ pressableSyncEnabled }
 				/>
 			) ) }
 		</div>
@@ -191,12 +179,10 @@ function SiteItem( {
 	site,
 	isSelected,
 	onClick,
-	pressableSyncEnabled,
 }: {
 	site: SyncSite;
 	isSelected: boolean;
 	onClick: () => void;
-	pressableSyncEnabled: boolean;
 } ) {
 	const { __ } = useI18n();
 	if ( site.isStaging ) {
@@ -259,7 +245,7 @@ function SiteItem( {
 						}
 					} }
 				>
-					{ pressableSyncEnabled && isPressable && (
+					{ isPressable && (
 						<span className="me-1.5">
 							<PressableLogo size={ 12 } />
 						</span>

--- a/src/components/sync-sites-modal-selector.tsx
+++ b/src/components/sync-sites-modal-selector.tsx
@@ -9,7 +9,6 @@ import { EnvironmentBadge } from 'src/components/environment-badge';
 import Modal from 'src/components/modal';
 import offlineIcon from 'src/components/offline-icon';
 import { PressableLogo } from 'src/components/pressable-logo';
-import { useFeatureFlags } from 'src/hooks/use-feature-flags';
 import { useOffline } from 'src/hooks/use-offline';
 import { cx } from 'src/lib/cx';
 import { getIpcApi } from 'src/lib/get-ipc-api';

--- a/src/components/sync-sites-modal-selector.tsx
+++ b/src/components/sync-sites-modal-selector.tsx
@@ -62,7 +62,7 @@ export function SyncSitesModalSelector( {
 			onRequestClose={ onRequestClose }
 			title={ __( 'Connect a WP.com or Pressable site' ) }
 		>
-			<div className="relative">
+			<div className="relative" data-testid="sync-sites-modal-selector">
 				<SearchSites searchQuery={ searchQuery } setSearchQuery={ setSearchQuery } />
 				<div className="h-[calc(84vh-232px)]">
 					{ isLoading && (

--- a/src/components/tests/content-tab-sync.test.tsx
+++ b/src/components/tests/content-tab-sync.test.tsx
@@ -5,7 +5,6 @@ import { SyncSitesProvider, useSyncSites } from 'src/hooks/sync-sites';
 import { SyncPushState } from 'src/hooks/sync-sites/use-sync-push';
 import { useAuth } from 'src/hooks/use-auth';
 import { ContentTabsProvider } from 'src/hooks/use-content-tabs';
-import { useFeatureFlags } from 'src/hooks/use-feature-flags';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 
 jest.mock( 'src/hooks/use-auth' );

--- a/src/components/tests/content-tab-sync.test.tsx
+++ b/src/components/tests/content-tab-sync.test.tsx
@@ -66,9 +66,6 @@ describe( 'ContentTabSync', () => {
 			setIsSyncSitesSelectorOpen: jest.fn(),
 			closeSyncSitesSelector: jest.fn(),
 		} );
-		( useFeatureFlags as jest.Mock ).mockReturnValue( {
-			pressableSyncEnabled: false,
-		} );
 	} );
 
 	const renderWithProvider = ( children: React.ReactElement ) => {
@@ -116,7 +113,7 @@ describe( 'ContentTabSync', () => {
 		} );
 
 		renderWithProvider( <ContentTabSync selectedSite={ selectedSite } /> );
-		expect( screen.getByText( 'Connect a WordPress.com site' ) ).toBeInTheDocument();
+		expect( screen.getByTestId( 'sync-sites-modal-selector' ) ).toBeInTheDocument();
 	} );
 
 	it( 'displays the list of connected sites', async () => {
@@ -273,7 +270,7 @@ describe( 'ContentTabSync', () => {
 		expect( connectButton ).toBeInTheDocument();
 	} );
 
-	it( 'does not display ConnectButton at the bottom when there are connected sites', () => {
+	it( 'displays the ConnectButton at the bottom when there are multiple connected sites', () => {
 		const fakeSyncSite = {
 			id: 6,
 			name: 'My simple business site',
@@ -300,45 +297,6 @@ describe( 'ContentTabSync', () => {
 			isSyncSitesSelectorOpen: false,
 			setIsSyncSitesSelectorOpen: jest.fn(),
 			closeSyncSitesSelector: jest.fn(),
-		} );
-
-		renderWithProvider( <ContentTabSync selectedSite={ selectedSite } /> );
-
-		const connectButton = screen.queryByRole( 'button', { name: /Connect site/i } );
-		expect( connectButton ).not.toBeInTheDocument();
-	} );
-
-	it( 'displays ConnectButton at the bottom when there are connected sites and pressableSyncEnabled is true', () => {
-		const fakeSyncSite = {
-			id: 6,
-			name: 'My simple business site',
-			url: 'https://developer.wordpress.com/studio/',
-			isStaging: false,
-			stagingSiteIds: [],
-			syncSupport: 'already-connected',
-		};
-
-		( useAuth as jest.Mock ).mockReturnValue( { isAuthenticated: true, authenticate: jest.fn() } );
-		( useSyncSites as jest.Mock ).mockReturnValue( {
-			connectedSites: [ fakeSyncSite ],
-			syncSites: [ fakeSyncSite ],
-			pullSite: jest.fn(),
-			isAnySitePulling: false,
-			isAnySitePushing: false,
-			getPullState: jest.fn(),
-			getPushState: jest.fn().mockReturnValue( undefined ),
-			refetchSites: jest.fn(),
-			getLastSyncTimeText: jest.fn().mockReturnValue( 'You have not pulled this site yet.' ),
-			isSiteIdPulling: jest.fn(),
-			isSiteIdPushing: jest.fn(),
-			clearTimeout: jest.fn(),
-			isSyncSitesSelectorOpen: false,
-			setIsSyncSitesSelectorOpen: jest.fn(),
-			closeSyncSitesSelector: jest.fn(),
-		} );
-
-		( useFeatureFlags as jest.Mock ).mockReturnValue( {
-			pressableSyncEnabled: true,
 		} );
 
 		renderWithProvider( <ContentTabSync selectedSite={ selectedSite } /> );

--- a/src/hooks/use-feature-flags.tsx
+++ b/src/hooks/use-feature-flags.tsx
@@ -10,18 +10,15 @@ const featureFlagsSchema = z
 	.object( {
 		terminal_wp_cli_enabled: z.boolean().optional(),
 		preferred_editor: z.boolean().optional(),
-		pressable_sync_enabled: z.boolean().optional(),
 	} )
 	.catch( ( _ ) => ( {} ) );
 
 export interface FeatureFlagsContextType {
 	terminalWpCliEnabled: boolean;
-	pressableSyncEnabled: boolean;
 }
 
 export const FeatureFlagsContext = createContext< FeatureFlagsContextType >( {
 	terminalWpCliEnabled: false,
-	pressableSyncEnabled: false,
 } );
 
 interface FeatureFlagsProviderProps {
@@ -30,10 +27,8 @@ interface FeatureFlagsProviderProps {
 
 export const FeatureFlagsProvider: React.FC< FeatureFlagsProviderProps > = ( { children } ) => {
 	const terminalWpCliEnabledFromGlobals = getAppGlobals().terminalWpCliEnabled;
-	const pressableSyncEnabledFromGlobals = getAppGlobals().pressableSyncEnabled;
 	const [ featureFlags, setFeatureFlags ] = useState< FeatureFlagsContextType >( {
 		terminalWpCliEnabled: terminalWpCliEnabledFromGlobals,
-		pressableSyncEnabled: pressableSyncEnabledFromGlobals,
 	} );
 	const { isAuthenticated, client } = useAuth();
 
@@ -55,8 +50,6 @@ export const FeatureFlagsProvider: React.FC< FeatureFlagsProviderProps > = ( { c
 				setFeatureFlags( {
 					terminalWpCliEnabled:
 						Boolean( flags.terminal_wp_cli_enabled ) || terminalWpCliEnabledFromGlobals,
-					pressableSyncEnabled:
-						Boolean( flags.pressable_sync_enabled ) || pressableSyncEnabledFromGlobals,
 				} );
 			} catch ( error ) {
 				Sentry.captureException( error );
@@ -67,12 +60,7 @@ export const FeatureFlagsProvider: React.FC< FeatureFlagsProviderProps > = ( { c
 		return () => {
 			cancel = true;
 		};
-	}, [
-		isAuthenticated,
-		client,
-		terminalWpCliEnabledFromGlobals,
-		pressableSyncEnabledFromGlobals,
-	] );
+	}, [ isAuthenticated, client, terminalWpCliEnabledFromGlobals ] );
 
 	return (
 		<FeatureFlagsContext.Provider value={ featureFlags }>{ children }</FeatureFlagsContext.Provider>

--- a/src/hooks/use-feature-flags.tsx
+++ b/src/hooks/use-feature-flags.tsx
@@ -9,7 +9,6 @@ import { getAppGlobals } from 'src/lib/app-globals';
 const featureFlagsSchema = z
 	.object( {
 		terminal_wp_cli_enabled: z.boolean().optional(),
-		preferred_editor: z.boolean().optional(),
 	} )
 	.catch( ( _ ) => ( {} ) );
 

--- a/src/hooks/use-fetch-wpcom-sites/index.tsx
+++ b/src/hooks/use-fetch-wpcom-sites/index.tsx
@@ -2,7 +2,6 @@ import * as Sentry from '@sentry/electron/renderer';
 import { useState, useEffect, useRef, useMemo, useCallback } from 'react';
 import { z } from 'zod';
 import { useAuth } from 'src/hooks/use-auth';
-import { useFeatureFlags } from 'src/hooks/use-feature-flags';
 import { reconcileConnectedSites } from 'src/hooks/use-fetch-wpcom-sites/reconcile-connected-sites';
 import { useOffline } from 'src/hooks/use-offline';
 import { getIpcApi } from 'src/lib/get-ipc-api';

--- a/src/hooks/use-fetch-wpcom-sites/index.tsx
+++ b/src/hooks/use-fetch-wpcom-sites/index.tsx
@@ -173,8 +173,20 @@ export const useFetchWpComSites = ( connectedSiteIdsOnlyForSelectedSite: number[
 		try {
 			const allConnectedSites = await getIpcApi().getConnectedWpcomSites();
 
-			const fields =
-				'name,ID,URL,plan,capabilities,is_wpcom_atomic,options,jetpack,is_deleted,is_a8c,hosting_provider_guess,environment_type';
+			const fields = [
+				'name',
+				'ID',
+				'URL',
+				'plan',
+				'capabilities',
+				'is_wpcom_atomic',
+				'options',
+				'jetpack',
+				'is_deleted',
+				'is_a8c',
+				'hosting_provider_guess',
+				'environment_type',
+			].join( ',' );
 
 			const response = await client.req.get(
 				{

--- a/src/hooks/use-fetch-wpcom-sites/index.tsx
+++ b/src/hooks/use-fetch-wpcom-sites/index.tsx
@@ -151,7 +151,6 @@ export const useFetchWpComSites = ( connectedSiteIdsOnlyForSelectedSite: number[
 	const { isAuthenticated, client } = useAuth();
 	const isFetchingSites = useRef( false );
 	const isOffline = useOffline();
-	const { pressableSyncEnabled } = useFeatureFlags();
 
 	const joinedConnectedSiteIds = connectedSiteIdsOnlyForSelectedSite.join( ',' );
 	// we need this trick to avoid unnecessary re-renders,
@@ -174,11 +173,8 @@ export const useFetchWpComSites = ( connectedSiteIdsOnlyForSelectedSite: number[
 		try {
 			const allConnectedSites = await getIpcApi().getConnectedWpcomSites();
 
-			const baseFields =
-				'name,ID,URL,plan,capabilities,is_wpcom_atomic,options,jetpack,is_deleted,is_a8c';
-			const fields = pressableSyncEnabled
-				? `${ baseFields },hosting_provider_guess,environment_type`
-				: baseFields;
+			const fields =
+				'name,ID,URL,plan,capabilities,is_wpcom_atomic,options,jetpack,is_deleted,is_a8c,hosting_provider_guess,environment_type';
 
 			const response = await client.req.get(
 				{
@@ -233,7 +229,7 @@ export const useFetchWpComSites = ( connectedSiteIdsOnlyForSelectedSite: number[
 		} finally {
 			isFetchingSites.current = false;
 		}
-	}, [ client?.req, isAuthenticated, isOffline, pressableSyncEnabled ] );
+	}, [ client?.req, isAuthenticated, isOffline ] );
 
 	useEffect( () => {
 		void fetchSites();

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -841,7 +841,6 @@ export function getAppGlobals(): AppGlobals {
 		appName: app.name,
 		appVersion: app.getVersion(),
 		arm64Translation: app.runningUnderARM64Translation,
-		pressableSyncEnabled: process.env.STUDIO_PRESSABLE_SYNC === 'true',
 		terminalWpCliEnabled: process.env.STUDIO_TERMINAL_WP_CLI === 'true',
 	};
 }

--- a/src/ipc-types.d.ts
+++ b/src/ipc-types.d.ts
@@ -89,7 +89,6 @@ interface AppGlobals {
 	appName: string;
 	appVersion: string;
 	arm64Translation: boolean;
-	pressableSyncEnabled: boolean;
 	terminalWpCliEnabled: boolean;
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-499

## Proposed Changes

- Removes the feature flag added on STU-358, making all Pressable sync features available on trunk

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run `npm start`
- Navigate to the sync tab
- Observe you can connect multiple sites
- Observe you see the pressable lable
- Observe you see the push tooltip when pushing

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
