### PR TITLE
Studio: Don't display available editors label when no editors are present

### DIFF
--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -582,9 +582,9 @@ export async function getUserLocale( _event: IpcMainInvokeEvent ): Promise< Supp
 
 export async function getUserEditor(
 	_event: IpcMainInvokeEvent
-): Promise< SupportedEditor | undefined > {
+): Promise< SupportedEditor | null > {
 	const userData = await loadUserData();
-	return userData.preferredEditor;
+	return userData.preferredEditor ?? null;
 }
 
 export function showUserSettings( event: IpcMainInvokeEvent ) {

--- a/src/modules/user-settings/components/editor-picker.tsx
+++ b/src/modules/user-settings/components/editor-picker.tsx
@@ -27,7 +27,7 @@ export const EditorPicker = ( { value, onChange, disabled }: EditorPickerProps )
 		<SettingsFormField label={ __( 'Code editor' ) }>
 			<SelectControl< SupportedEditor | '' >
 				value={ value || '' }
-				onChange={ ( newValue ) => onChange( newValue ? ( newValue as SupportedEditor ) : null ) }
+				onChange={ ( newValue ) => onChange( newValue ? newValue : null ) }
 				__nextHasNoMarginBottom
 				__next40pxDefaultSize
 				disabled={ disabled }

--- a/src/modules/user-settings/components/editor-picker.tsx
+++ b/src/modules/user-settings/components/editor-picker.tsx
@@ -32,9 +32,7 @@ export const EditorPicker = ( { value, onChange, disabled }: EditorPickerProps )
 				__next40pxDefaultSize
 				disabled={ disabled }
 			>
-				{ ( ! value || installedEditors.length === 0 ) && (
-					<option value="">{ __( 'Select' ) }</option>
-				) }
+				{ installedEditors.length === 0 && <option value="">{ __( 'Select' ) }</option> }
 				{ installedEditors.length > 0 && (
 					<optgroup label={ __( 'Available editors' ) }>
 						{ installedEditors.map( ( [ editorKey, editorConfig ] ) => (

--- a/src/modules/user-settings/components/editor-picker.tsx
+++ b/src/modules/user-settings/components/editor-picker.tsx
@@ -33,13 +33,15 @@ export const EditorPicker = ( { value, onChange, disabled }: EditorPickerProps )
 				disabled={ disabled }
 			>
 				{ ! value && <option value={ '' }>{ __( 'Select' ) }</option> }
-				<optgroup label={ __( 'Available editors' ) }>
-					{ installedEditors.map( ( [ editorKey, editorConfig ] ) => (
-						<option key={ editorKey } value={ editorKey }>
-							{ editorConfig.label }
-						</option>
-					) ) }
-				</optgroup>
+				{ installedEditors.length > 0 && (
+					<optgroup label={ __( 'Available editors' ) }>
+						{ installedEditors.map( ( [ editorKey, editorConfig ] ) => (
+							<option key={ editorKey } value={ editorKey }>
+								{ editorConfig.label }
+							</option>
+						) ) }
+					</optgroup>
+				) }
 				<optgroup label={ __( 'Not installed' ) }>
 					{ uninstalledEditors.map( ( [ editorKey, editorConfig ] ) => (
 						<option key={ editorKey } value={ editorKey } disabled>

--- a/src/modules/user-settings/components/editor-picker.tsx
+++ b/src/modules/user-settings/components/editor-picker.tsx
@@ -9,8 +9,8 @@ import {
 import { SettingsFormField } from './settings-form-field';
 
 interface EditorPickerProps {
-	value: SupportedEditor | undefined;
-	onChange: ( value: SupportedEditor ) => void;
+	value: SupportedEditor | null;
+	onChange: ( value: SupportedEditor | null ) => void;
 	disabled?: boolean;
 }
 
@@ -25,14 +25,16 @@ export const EditorPicker = ( { value, onChange, disabled }: EditorPickerProps )
 
 	return (
 		<SettingsFormField label={ __( 'Code editor' ) }>
-			<SelectControl< SupportedEditor >
-				value={ value }
-				onChange={ ( newValue ) => onChange( newValue ) }
+			<SelectControl< SupportedEditor | '' >
+				value={ value || '' }
+				onChange={ ( newValue ) => onChange( newValue ? ( newValue as SupportedEditor ) : null ) }
 				__nextHasNoMarginBottom
 				__next40pxDefaultSize
 				disabled={ disabled }
 			>
-				{ ! value && <option value={ '' }>{ __( 'Select' ) }</option> }
+				{ ( ! value || installedEditors.length === 0 ) && (
+					<option value="">{ __( 'Select' ) }</option>
+				) }
 				{ installedEditors.length > 0 && (
 					<optgroup label={ __( 'Available editors' ) }>
 						{ installedEditors.map( ( [ editorKey, editorConfig ] ) => (

--- a/src/modules/user-settings/components/preferences-tab.tsx
+++ b/src/modules/user-settings/components/preferences-tab.tsx
@@ -23,9 +23,7 @@ export const PreferencesTab = ( { onClose }: { onClose: () => void } ) => {
 	const [ saveEditor ] = useSaveUserEditorMutation();
 	const [ saveTerminal ] = useSaveUserTerminalMutation();
 
-	const [ currentEditor, setCurrentEditor ] = useState< SupportedEditor | undefined >(
-		editor ?? undefined
-	);
+	const [ currentEditor, setCurrentEditor ] = useState< SupportedEditor | null >( editor ?? null );
 	const [ currentTerminal, setCurrentTerminal ] = useState( terminal );
 
 	const savePreferences = async () => {
@@ -39,7 +37,7 @@ export const PreferencesTab = ( { onClose }: { onClose: () => void } ) => {
 
 	const cancelChanges = () => {
 		setLocale( savedLocale );
-		setCurrentEditor( editor ?? undefined );
+		setCurrentEditor( editor ?? null );
 		setCurrentTerminal( terminal );
 		onClose();
 	};

--- a/src/stores/installed-apps-api.ts
+++ b/src/stores/installed-apps-api.ts
@@ -28,16 +28,7 @@ export const installedAppsApi = createApi( {
 					return { data: editor };
 				}
 
-				// If no user preference is set, check for installed editors
-				// and set the default to the first one found
-				// This is a fallback to ensure we keep existing behavior
-				const installedEditors = await getIpcApi().getInstalledAppsAndTerminals();
-				if ( installedEditors.vscode ) {
-					return { data: 'vscode' };
-				} else if ( installedEditors.phpstorm ) {
-					return { data: 'phpstorm' };
-				}
-
+				// If no user preference is set, return null
 				return { data: null };
 			},
 			providesTags: [ 'UserPreferences' ],

--- a/src/stores/installed-apps-api.ts
+++ b/src/stores/installed-apps-api.ts
@@ -16,15 +16,6 @@ export const installedAppsApi = createApi( {
 		getInstalledApps: builder.query< InstalledApps, void >( {
 			queryFn: async () => {
 				const installedApps = await getIpcApi().getInstalledAppsAndTerminals();
-				console.log( 'getInstalledApps - keys:', Object.keys( installedApps ) );
-				console.log(
-					'getInstalledApps - values:',
-					Object.fromEntries(
-						Object.entries( installedApps ).filter( ( [ key ] ) =>
-							Object.keys( supportedEditorConfig ).includes( key )
-						)
-					)
-				);
 				return { data: installedApps };
 			},
 			providesTags: [ 'InstalledApps' ],
@@ -92,16 +83,7 @@ export const selectInstalledEditors = createSelector(
 			SupportedEditorConfig,
 		][];
 
-		console.log(
-			'selectInstalledEditors - installedApps keys:',
-			installedApps ? Object.keys( installedApps ) : 'undefined'
-		);
-		const result = entries.filter( ( [ editor ] ) => installedApps && installedApps[ editor ] );
-		console.log(
-			'selectInstalledEditors - installed editor keys:',
-			result.map( ( [ key ] ) => key )
-		);
-		return result;
+		return entries.filter( ( [ editor ] ) => installedApps && installedApps[ editor ] );
 	}
 );
 
@@ -113,16 +95,7 @@ export const selectUninstalledEditors = createSelector(
 			SupportedEditorConfig,
 		][];
 
-		console.log(
-			'selectUninstalledEditors - installedApps keys:',
-			installedApps ? Object.keys( installedApps ) : 'undefined'
-		);
-		const result = entries.filter( ( [ editor ] ) => ! installedApps || ! installedApps[ editor ] );
-		console.log(
-			'selectUninstalledEditors - uninstalled editor keys:',
-			result.map( ( [ key ] ) => key )
-		);
-		return result;
+		return entries.filter( ( [ editor ] ) => ! installedApps || ! installedApps[ editor ] );
 	}
 );
 

--- a/src/stores/installed-apps-api.ts
+++ b/src/stores/installed-apps-api.ts
@@ -16,6 +16,15 @@ export const installedAppsApi = createApi( {
 		getInstalledApps: builder.query< InstalledApps, void >( {
 			queryFn: async () => {
 				const installedApps = await getIpcApi().getInstalledAppsAndTerminals();
+				console.log( 'getInstalledApps - keys:', Object.keys( installedApps ) );
+				console.log(
+					'getInstalledApps - values:',
+					Object.fromEntries(
+						Object.entries( installedApps ).filter( ( [ key ] ) =>
+							Object.keys( supportedEditorConfig ).includes( key )
+						)
+					)
+				);
 				return { data: installedApps };
 			},
 			providesTags: [ 'InstalledApps' ],
@@ -26,6 +35,16 @@ export const installedAppsApi = createApi( {
 				// Respect user preference if it is set
 				if ( editor ) {
 					return { data: editor };
+				}
+
+				// If no user preference is set, check for installed editors
+				// and set the default to the first one found
+				// This is a fallback to ensure we keep existing behavior
+				const installedEditors = await getIpcApi().getInstalledAppsAndTerminals();
+				if ( installedEditors.vscode ) {
+					return { data: 'vscode' };
+				} else if ( installedEditors.phpstorm ) {
+					return { data: 'phpstorm' };
 				}
 
 				// If no user preference is set, return null
@@ -73,7 +92,16 @@ export const selectInstalledEditors = createSelector(
 			SupportedEditorConfig,
 		][];
 
-		return entries.filter( ( [ editor ] ) => installedApps && installedApps[ editor ] );
+		console.log(
+			'selectInstalledEditors - installedApps keys:',
+			installedApps ? Object.keys( installedApps ) : 'undefined'
+		);
+		const result = entries.filter( ( [ editor ] ) => installedApps && installedApps[ editor ] );
+		console.log(
+			'selectInstalledEditors - installed editor keys:',
+			result.map( ( [ key ] ) => key )
+		);
+		return result;
 	}
 );
 
@@ -85,7 +113,16 @@ export const selectUninstalledEditors = createSelector(
 			SupportedEditorConfig,
 		][];
 
-		return entries.filter( ( [ editor ] ) => ! installedApps || ! installedApps[ editor ] );
+		console.log(
+			'selectUninstalledEditors - installedApps keys:',
+			installedApps ? Object.keys( installedApps ) : 'undefined'
+		);
+		const result = entries.filter( ( [ editor ] ) => ! installedApps || ! installedApps[ editor ] );
+		console.log(
+			'selectUninstalledEditors - uninstalled editor keys:',
+			result.map( ( [ key ] ) => key )
+		);
+		return result;
 	}
 );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

Fixes STU-502

## Proposed Changes

This PR ensures that we do not display `Available editors` editors label when there are no editors installed. Additionally, I made some improvements around the `Select` label which was not displaying before. 

When there are no installed editors:

<img width="1062" alt="Screenshot 2025-05-15 at 11 38 06 AM" src="https://github.com/user-attachments/assets/776aae16-8770-48e5-b414-41a3a2f3c61d" />

When the user selected a preferred editor:

<img width="893" alt="Screenshot 2025-05-15 at 11 43 08 AM" src="https://github.com/user-attachments/assets/6e0af8dc-37c9-4e90-85b7-05b92e3a6f96" />

When there are installed editor but the user have not selected a preferred editor:

<img width="890" alt="Screenshot 2025-05-15 at 11 42 59 AM" src="https://github.com/user-attachments/assets/9835aa15-de7e-4767-9bb0-78d2274d6518" />

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
**When there are no installed editors:**

* Pull the changes from this branch
* Apply the following diff:

```diff --git a/src/ipc-handlers.ts b/src/ipc-handlers.ts
index 31db948e..3b675a96 100644
--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -113,11 +113,11 @@ export async function getSiteDetails( _event: IpcMainInvokeEvent ): Promise< Sit
 
 export function getInstalledAppsAndTerminals(): InstalledApps {
        return {
-               vscode: isInstalled( 'vscode' ),
-               phpstorm: isInstalled( 'phpstorm' ),
-               webstorm: isInstalled( 'webstorm' ),
-               windsurf: isInstalled( 'windsurf' ),
-               cursor: isInstalled( 'cursor' ),
+               vscode: false,
+               phpstorm: false,
+               webstorm: false,
+               windsurf: false,
+               cursor: false,
                terminal: true, // Terminal.app is always available on macOS
                iterm: isInstalled( 'iterm' ),
                warp: isInstalled( 'warp' ),
```

* Start the app with `npm start`
* Click on User Settings in the top right corner
* Navigate to `Preferences` tab 
* Confirm that you can see Select as a default there
* Confirm that you do not see `Available editors` label

**When the user selected a preferred editor:**

* Start the app with `npm start`
* Click on User Settings in the top right corner
* Navigate to `Preferences` tab 
* Confirm that you can see your selected editor
* Confirm that `Available editors` label is present
* Confirm that there is no `Select`

**When there are installed editor but the user have not selected a preferred editor:**

* Before testing, make sure to remove the `preferredEditor` from the `appdata` under `/Users/{yourUser}/Library/Application Support/Studio/appdata-v1.json`
* Pull the changes from this branch
* Start the app with `npm start`
* Click on User Settings in the top right corner
* Navigate to `Preferences` tab 
* Confirm that for the `Code editor` option, you can see `Select` option
* Confirm that `Available editors` label is present

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
