### PR TITLE
HTTPS: Convert domain name Unicode characters to ASCII characters

### DIFF
--- a/src/lib/certificate-manager.ts
+++ b/src/lib/certificate-manager.ts
@@ -236,10 +236,9 @@ export async function generateSiteCertificate(
 	domain: string
 ): Promise< { cert: string; key: string } > {
 	try {
-		// Convert domain to punycode for certificate generation
 		const punycodeDomain = domainToASCII( domain );
-		const siteCertPath = path.join( CERT_DIRECTORY, 'domains', `${ punycodeDomain }.crt` );
-		const siteKeyPath = path.join( CERT_DIRECTORY, 'domains', `${ punycodeDomain }.key` );
+		const siteCertPath = path.join( CERT_DIRECTORY, 'domains', `${ domain }.crt` );
+		const siteKeyPath = path.join( CERT_DIRECTORY, 'domains', `${ domain }.key` );
 
 		// If the certificate already exists, no need to generate a new one
 		if ( fs.existsSync( siteCertPath ) && fs.existsSync( siteKeyPath ) ) {
@@ -319,9 +318,8 @@ export async function generateSiteCertificate(
  */
 export function deleteSiteCertificate( domain: string ): boolean {
 	try {
-		const punycodeDomain = domainToASCII( domain );
-		const siteCertPath = path.join( CERT_DIRECTORY, 'domains', `${ punycodeDomain }.crt` );
-		const siteKeyPath = path.join( CERT_DIRECTORY, 'domains', `${ punycodeDomain }.key` );
+		const siteCertPath = path.join( CERT_DIRECTORY, 'domains', `${ domain }.crt` );
+		const siteKeyPath = path.join( CERT_DIRECTORY, 'domains', `${ domain }.key` );
 		let deletedFiles = false;
 		if ( fs.existsSync( siteCertPath ) ) {
 			fs.unlinkSync( siteCertPath );

--- a/src/lib/certificate-manager.ts
+++ b/src/lib/certificate-manager.ts
@@ -3,6 +3,7 @@ import { execFile } from 'node:child_process';
 import crypto from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
+import { domainToASCII } from 'node:url';
 import { promisify } from 'node:util';
 import * as Sentry from '@sentry/electron/main';
 import sudo from '@vscode/sudo-prompt';
@@ -235,8 +236,10 @@ export async function generateSiteCertificate(
 	domain: string
 ): Promise< { cert: string; key: string } > {
 	try {
-		const siteCertPath = path.join( CERT_DIRECTORY, 'domains', `${ domain }.crt` );
-		const siteKeyPath = path.join( CERT_DIRECTORY, 'domains', `${ domain }.key` );
+		// Convert domain to punycode for certificate generation
+		const punycodeDomain = domainToASCII( domain );
+		const siteCertPath = path.join( CERT_DIRECTORY, 'domains', `${ punycodeDomain }.crt` );
+		const siteKeyPath = path.join( CERT_DIRECTORY, 'domains', `${ punycodeDomain }.key` );
 
 		// If the certificate already exists, no need to generate a new one
 		if ( fs.existsSync( siteCertPath ) && fs.existsSync( siteKeyPath ) ) {
@@ -260,7 +263,7 @@ export async function generateSiteCertificate(
 		cert.validity.notAfter = new Date( now.getTime() );
 		cert.validity.notAfter.setDate( now.getDate() + SITE_CERT_VALIDITY_DAYS );
 		const attrs = [
-			{ name: 'commonName', value: domain },
+			{ name: 'commonName', value: punycodeDomain },
 			{ name: 'countryName', value: 'US' },
 			{ name: 'organizationName', value: 'WordPress Studio' },
 		];
@@ -288,7 +291,7 @@ export async function generateSiteCertificate(
 				altNames: [
 					{
 						type: 2, // DNS
-						value: domain,
+						value: punycodeDomain,
 					},
 				],
 			},
@@ -316,8 +319,9 @@ export async function generateSiteCertificate(
  */
 export function deleteSiteCertificate( domain: string ): boolean {
 	try {
-		const siteCertPath = path.join( CERT_DIRECTORY, 'domains', `${ domain }.crt` );
-		const siteKeyPath = path.join( CERT_DIRECTORY, 'domains', `${ domain }.key` );
+		const punycodeDomain = domainToASCII( domain );
+		const siteCertPath = path.join( CERT_DIRECTORY, 'domains', `${ punycodeDomain }.crt` );
+		const siteKeyPath = path.join( CERT_DIRECTORY, 'domains', `${ punycodeDomain }.key` );
 		let deletedFiles = false;
 		if ( fs.existsSync( siteCertPath ) ) {
 			fs.unlinkSync( siteCertPath );

--- a/src/lib/proxy-server.ts
+++ b/src/lib/proxy-server.ts
@@ -170,8 +170,7 @@ export const startProxyServer = sequential( async (): Promise< boolean > => {
 			const defaultOptions: https.ServerOptions = {
 				SNICallback: async ( servername, cb ) => {
 					try {
-						const punycodeServerName = domainToASCII( servername );
-						const site = await getSiteByHost( punycodeServerName );
+						const site = await getSiteByHost( servername );
 						if ( ! site || ! site.customDomain ) {
 							console.error( `SNI: Invalid hostname: ${ servername }` );
 							cb( new Error( `Invalid hostname: ${ servername }` ) );

--- a/src/lib/proxy-server.ts
+++ b/src/lib/proxy-server.ts
@@ -170,7 +170,8 @@ export const startProxyServer = sequential( async (): Promise< boolean > => {
 			const defaultOptions: https.ServerOptions = {
 				SNICallback: async ( servername, cb ) => {
 					try {
-						const site = await getSiteByHost( servername );
+						const punycodeServerName = domainToASCII( servername );
+						const site = await getSiteByHost( punycodeServerName );
 						if ( ! site || ! site.customDomain ) {
 							console.error( `SNI: Invalid hostname: ${ servername }` );
 							cb( new Error( `Invalid hostname: ${ servername }` ) );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-497

## Proposed Changes

Convert the domain name Unicode characters to ASCII characters for the SSL certificate name. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this branch.
* Run `npm start`.
* Change your locale to Japanese (日本語).
* Click **Add new site**, choose **Custom domain**, and enable **HTTPS**. 
Keep the default value for the domain. (E.g. `マイ-wordpress-サイト.wp.local`)
* Click **Add site**.
* Confirm that the site is created successfully and opens in the browser.
* Verify that there are no errors in the console.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
