### PR TITLE
Set WP_ENVIRONMENT_TYPE to local by default

### DIFF
--- a/vendor/wp-now/src/wp-now.ts
+++ b/vendor/wp-now/src/wp-now.ts
@@ -603,6 +603,15 @@ async function mountInternalMuPlugins( php: PHP, options: WPNowOptions ) {
 		`
 	);
 
+	php.writeFile(
+		path.posix.join( PLAYGROUND_INTERNAL_MU_PLUGINS_FOLDER, '0-wp-environment-type.php' ),
+		`<?php
+		if ( ! defined( 'WP_ENVIRONMENT_TYPE' ) ) {
+			putenv( 'WP_ENVIRONMENT_TYPE=local' );
+		}
+		`
+	);
+
 	if ( ! options.isWpAutoUpdating ) {
 		php.writeFile(
 			path.posix.join( PLAYGROUND_INTERNAL_MU_PLUGINS_FOLDER, '0-disable-auto-updates.php' ),

--- a/vendor/wp-now/src/wp-now.ts
+++ b/vendor/wp-now/src/wp-now.ts
@@ -581,6 +581,9 @@ async function mountInternalMuPlugins( php: PHP, options: WPNowOptions ) {
 		if (!defined('DB_HOST')) define('DB_HOST', 'localhost');
 		if (!defined('DB_CHARSET')) define('DB_CHARSET', 'utf8');
 		if (!defined('DB_COLLATE')) define('DB_COLLATE', '');
+
+		// Set environment type to local if not already defined
+		if (!defined('WP_ENVIRONMENT_TYPE')) define('WP_ENVIRONMENT_TYPE', 'local');
 		`
 	);
 
@@ -600,15 +603,6 @@ async function mountInternalMuPlugins( php: PHP, options: WPNowOptions ) {
 			}
 			return false;
 		});
-		`
-	);
-
-	php.writeFile(
-		path.posix.join( PLAYGROUND_INTERNAL_MU_PLUGINS_FOLDER, '0-wp-environment-type.php' ),
-		`<?php
-		if ( ! defined( 'WP_ENVIRONMENT_TYPE' ) ) {
-			putenv( 'WP_ENVIRONMENT_TYPE=local' );
-		}
 		`
 	);
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-17
- Fixes https://github.com/Automattic/studio/issues/165

## Proposed Changes

- Set the default environment type to `local`.  
- If the user defines the WP_ENVIRONMENT_TYPE constant in wp-config.php, respect that value and do not override it.

I also considered setting it in `defineWpConfigConsts`, but that would override the constants defined by the user, potentially causing issues when trying to replicate production environments.

https://github.com/Automattic/studio/blob/18a8e7cf111f555db6d38da33e91b744b6b47de0/vendor/wp-now/src/wp-now.ts#L418

More information  about [wp_get_environment_type](https://developer.wordpress.org/reference/functions/wp_get_environment_type/).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run `npm start`
- Install and activate this plugin or similar:
```php
<?php
/**
* Plugin Name: Env Type
* Description: This plugin is used to display the current environment type.
* Author: Automattic
* Version: 1.0.0
*/

function env_type_notice() { ?>
    <div class="notice notice-info">
        <p>Current environment type: 
            <?php echo wp_get_environment_type(); ?>
        </p>
    </div>
<?php }
add_action( 'admin_notices', 'env_type_notice' );
```
- Observe the displayed value is `local`
- Define the constant at the top of wp-config.php `define( 'WP_ENVIRONMENT_TYPE', 'production' );`
- Observe the displayed value is `production`


https://github.com/user-attachments/assets/4fb1abe0-7c7d-4da4-a835-c4b32e0bc765



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
