### PR TITLE
What's New Modal: Improve version comparison logic to handle prerelease version transitions

### DIFF
--- a/src/stores/app-version-api.ts
+++ b/src/stores/app-version-api.ts
@@ -61,8 +61,17 @@ export const selectIsNewVersion = createSelector(
 		}
 
 		try {
-			if ( semver.prerelease( currentVersion ) ) {
-				return false;
+			const currentPrerelease = semver.prerelease( currentVersion );
+			const lastSeenPrerelease = semver.prerelease( lastSeenVersion );
+
+			// Handle prerelease to prerelease transitions
+			if ( currentPrerelease && lastSeenPrerelease ) {
+				return lastSeenVersion !== currentVersion;
+			}
+
+			// Handle prerelease to stable transitions (or vice versa)
+			if ( currentPrerelease || lastSeenPrerelease ) {
+				return true;
 			}
 
 			const cleanLastSeen = semver.valid( semver.coerce( lastSeenVersion ) );

--- a/src/stores/tests/app-version-api.test.ts
+++ b/src/stores/tests/app-version-api.test.ts
@@ -106,13 +106,31 @@ describe( 'App Version API', () => {
 			expect( result ).toBe( false );
 		} );
 
-		it( 'should return false for prerelease versions', () => {
+		it( 'should return true when going from a stable version to a prerelease version', () => {
 			const lastSeenVersion = '1.2.0';
 			const currentVersion = '1.3.0-beta1';
 
 			const result = selectIsNewVersion( createMockQueryResult( lastSeenVersion ), currentVersion );
 
-			expect( result ).toBe( false );
+			expect( result ).toBe( true );
+		} );
+
+		it( 'should return true when going from a prerelease version to a stable version', () => {
+			const lastSeenVersion = '1.2.0-beta2';
+			const currentVersion = '1.2.0';
+
+			const result = selectIsNewVersion( createMockQueryResult( lastSeenVersion ), currentVersion );
+
+			expect( result ).toBe( true );
+		} );
+
+		it( 'should return true for a new prerelease version', () => {
+			const lastSeenVersion = '1.2.0-beta1';
+			const currentVersion = '1.2.0-beta2';
+
+			const result = selectIsNewVersion( createMockQueryResult( lastSeenVersion ), currentVersion );
+
+			expect( result ).toBe( true );
 		} );
 
 		it( 'should return true for undefined lastSeenVersion', () => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Resolves STU-449
- Related discussion: p1746514247326159-slack-C06DRMD6VPZ 

## Proposed Changes

- update the What's New modal display logic to make the modal rendered in the following extra cases:
  - transitions from one prerelease to another prerelease version (e.g. `1.5.1-beta1` to `1.5.1-beta2`)
  - transitions from prerelease to stable version (and vice-versa) (e.g. `1.5.1-beta1` to `1.5.2`)
- add related unit tests

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR branch and build the app with `npm start`.
2. Head over to the `appdata-v1.json` and try changing the `lastSeenVersion` in it and then reload the app.

For example (if the current app version (in `package.json`) is `1.5.2-beta2`):
- change the `lastSeenVersion` to `1.5.2-beta3` → modal should render
- change the `lastSeenVersion` to `1.5.2` → modal should render

3. All related tests should pass (`npm test src/stores/tests/app-version-api.test.ts`).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?