### PR TITLE
Sync: Update Sync modal content

### DIFF
--- a/src/components/sync-sites-modal-selector.tsx
+++ b/src/components/sync-sites-modal-selector.tsx
@@ -9,9 +9,11 @@ import { EnvironmentBadge } from 'src/components/environment-badge';
 import Modal from 'src/components/modal';
 import offlineIcon from 'src/components/offline-icon';
 import { PressableLogo } from 'src/components/pressable-logo';
+import { useI18nData } from 'src/hooks/use-i18n-data';
 import { useOffline } from 'src/hooks/use-offline';
 import { cx } from 'src/lib/cx';
 import { getIpcApi } from 'src/lib/get-ipc-api';
+import { getLocalizedLink } from 'src/lib/get-localized-link';
 import { WordPressLogoCircle } from './wordpress-logo-circle';
 import type { SyncSite } from 'src/hooks/use-fetch-wpcom-sites/types';
 
@@ -117,6 +119,7 @@ function SearchSites( {
 	setSearchQuery: ( value: string ) => void;
 } ) {
 	const { __ } = useI18n();
+	const { locale } = useI18nData();
 	return (
 		<div className="flex flex-col px-8 pb-6 border-b border-a8c-gray-5">
 			<SearchControl
@@ -133,11 +136,7 @@ function SearchSites( {
 				{ __( "Can't find your site? " ) }
 				<Button
 					variant="link"
-					onClick={ () =>
-						getIpcApi().openURL(
-							'https://developer.wordpress.com/docs/developer-tools/studio/sync/'
-						)
-					}
+					onClick={ () => getIpcApi().openURL( getLocalizedLink( locale, 'docsSync' ) ) }
 				>
 					{ __( 'Learn more about supported sites.' ) }
 					<ArrowIcon />

--- a/src/components/sync-sites-modal-selector.tsx
+++ b/src/components/sync-sites-modal-selector.tsx
@@ -13,6 +13,7 @@ import { PressableLogo } from 'src/components/pressable-logo';
 import { useOffline } from 'src/hooks/use-offline';
 import { cx } from 'src/lib/cx';
 import { getIpcApi } from 'src/lib/get-ipc-api';
+import { WordPressLogoCircle } from './wordpress-logo-circle';
 import type { SyncSite } from 'src/hooks/use-fetch-wpcom-sites/types';
 
 const SearchControl = process.env.NODE_ENV === 'test' ? () => null : SearchControlWp;
@@ -239,7 +240,30 @@ function SiteItem( {
 			} }
 		>
 			<div className="flex flex-col gap-0.5 min-w-0">
-				<div className={ cx( 'a8c-body truncate', ! isSyncable && 'text-a8c-gray-30' ) }>
+				<div
+					className={ cx(
+						'a8c-body truncate flex items-center',
+						! isSyncable && 'text-a8c-gray-30'
+					) }
+				>
+					{ isPressable && (
+						<span className="me-1.5">
+							<PressableLogo size={ 12 } />
+						</span>
+					) }
+					{ ! isPressable && (
+						<span className="me-1.5">
+							<WordPressLogoCircle
+								size={ 12 }
+								{ ...( isSelected && { color: '#fff' } ) }
+								{ ...( ( isUnsupported ||
+									needsUpgrade ||
+									isDeleted ||
+									isMissingPermissions ||
+									isNeedsTransfer ) && { color: '#8c8f94' } ) }
+							/>
+						</span>
+					) }
 					{ site.name }
 				</div>
 				<Button
@@ -259,11 +283,6 @@ function SiteItem( {
 						}
 					} }
 				>
-					{ isPressable && (
-						<span className="me-1.5">
-							<PressableLogo size={ 12 } />
-						</span>
-					) }
 					<div className="truncate">{ site.url.replace( /^https?:\/\//, '' ) }</div>
 					<ArrowIcon />
 				</Button>

--- a/src/components/sync-sites-modal-selector.tsx
+++ b/src/components/sync-sites-modal-selector.tsx
@@ -59,7 +59,7 @@ export function SyncSitesModalSelector( {
 		<Modal
 			className="w-3/5 min-w-[550px] h-full max-h-[84vh] [&>div]:!p-0"
 			onRequestClose={ onRequestClose }
-			title={ __( 'Connect a WP.com or Pressable site' ) }
+			title={ __( 'Connect your site' ) }
 		>
 			<div className="relative" data-testid="sync-sites-modal-selector">
 				<SearchSites searchQuery={ searchQuery } setSearchQuery={ setSearchQuery } />

--- a/src/components/sync-sites-modal-selector.tsx
+++ b/src/components/sync-sites-modal-selector.tsx
@@ -1,5 +1,4 @@
 import { Icon, SearchControl as SearchControlWp } from '@wordpress/components';
-import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import { useState, useEffect } from 'react';
@@ -131,21 +130,18 @@ function SearchSites( {
 				__nextHasNoMarginBottom={ true }
 			/>
 			<p className="a8c-helper-text text-gray-500">
-				{ createInterpolateElement(
-					__( "Can't find your site? <button>Learn more about supported sites. ↗</button>" ),
-					{
-						button: (
-							<Button
-								variant="link"
-								onClick={ () =>
-									getIpcApi().openURL(
-										'https://developer.wordpress.com/docs/developer-tools/studio/sync/'
-									)
-								}
-							/>
-						),
+				{ __( "Can't find your site? " ) }
+				<Button
+					variant="link"
+					onClick={ () =>
+						getIpcApi().openURL(
+							'https://developer.wordpress.com/docs/developer-tools/studio/sync/'
+						)
 					}
-				) }
+				>
+					{ __( 'Learn more about supported sites.' ) }
+					<ArrowIcon />
+				</Button>
 			</p>
 		</div>
 	);
@@ -324,7 +320,8 @@ function SiteItem( {
 						variant="link"
 						onClick={ () => getIpcApi().openURL( `https://wordpress.com/plans/${ site.id }` ) }
 					>
-						{ __( 'Upgrade plan ↗' ) }
+						{ __( 'Upgrade plan' ) }
+						<ArrowIcon />
 					</Button>
 				</div>
 			) }
@@ -336,7 +333,8 @@ function SiteItem( {
 							getIpcApi().openURL( `https://wordpress.com/hosting-features/${ site.id }` )
 						}
 					>
-						{ __( 'Enable hosting features ↗' ) }
+						{ __( 'Enable hosting features' ) }
+						<ArrowIcon />
 					</Button>
 				</div>
 			) }

--- a/src/components/sync-sites-modal-selector.tsx
+++ b/src/components/sync-sites-modal-selector.tsx
@@ -1,4 +1,5 @@
 import { Icon, SearchControl as SearchControlWp } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import { useState, useEffect } from 'react';
@@ -129,7 +130,21 @@ function SearchSites( {
 				__nextHasNoMarginBottom={ true }
 			/>
 			<p className="a8c-helper-text text-gray-500">
-				{ __( 'Syncing is supported for WP.com sites on the Business plan or above.' ) }
+				{ createInterpolateElement(
+					__( "Can't find your site? <button>Learn more about supported sites. ↗</button>" ),
+					{
+						button: (
+							<Button
+								variant="link"
+								onClick={ () =>
+									getIpcApi().openURL(
+										'https://developer.wordpress.com/docs/developer-tools/studio/sync/'
+									)
+								}
+							/>
+						),
+					}
+				) }
 			</p>
 		</div>
 	);

--- a/src/components/wordpress-logo-circle.tsx
+++ b/src/components/wordpress-logo-circle.tsx
@@ -9,7 +9,7 @@ export function WordPressLogoCircle( {
 		<svg
 			width={ size }
 			height={ size }
-			viewBox={ `0 0 ${ size } ${ size }` }
+			viewBox="0 0 16 16"
 			fill="none"
 			xmlns="http://www.w3.org/2000/svg"
 		>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Resolves STU-506
- Resolves STU-508

## Proposed Changes

The PR makes the following changes related to the Sync modal:

- add WordPress.com logo to WordPress.com sites
  - ensure the WordPress.com logo is correctly colored when a site is not ready to be synced; or when the site is selected 
- move the site icon (Pressable or WordPress.com) from site address to site name
- update the modal heading and text below the search field
- replaced a couple hardcoded `↗` icons with ArrowIcon component

| Main changes | WordPress.com logo colors |
|--------|--------|
| ![Markup on 2025-05-16 at 14:56:27](https://github.com/user-attachments/assets/e2f9c54a-79c4-4994-aa19-46c127543348) | ![Markup on 2025-05-16 at 14:57:50](https://github.com/user-attachments/assets/b7ee3c8b-187c-4662-88ab-f812e9d73ff5) | 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR branch and build the app with `npm start`.
2. Head over to the Sync tab and open the modal.
3. Review the changes: copy, icons, colors, link to the documentation. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?