### PR TITLE
Increase HTTP request timeout to 60 seconds

### DIFF
--- a/vendor/wp-now/src/wp-now.ts
+++ b/vendor/wp-now/src/wp-now.ts
@@ -621,12 +621,11 @@ async function mountInternalMuPlugins( php: PHP, options: WPNowOptions ) {
 	php.writeFile(
 		path.posix.join( PLAYGROUND_INTERNAL_MU_PLUGINS_FOLDER, '0-http-request-timeout.php' ),
 		`<?php
-		// Set the default HTTP request timeout to 60 seconds
+		// Increase default timeouts to 60 seconds to accommodate slower network conditions and larger requests
 		add_filter( 'http_request_timeout', function() {
 			return 60;
 		} );
 
-		// Set the default cURL timeout to 60 second
 		add_action('http_api_curl', function($curl, $url, $options) {
 			curl_setopt( $curl, CURLOPT_CONNECTTIMEOUT, 60 );
 			curl_setopt($curl, CURLOPT_TIMEOUT, 60);

--- a/vendor/wp-now/src/wp-now.ts
+++ b/vendor/wp-now/src/wp-now.ts
@@ -625,6 +625,13 @@ async function mountInternalMuPlugins( php: PHP, options: WPNowOptions ) {
 		add_filter( 'http_request_timeout', function() {
 			return 60;
 		} );
+
+		// Set the default cURL timeout to 60 second
+		add_action('http_api_curl', function($curl, $url, $options) {
+			curl_setopt( $curl, CURLOPT_CONNECTTIMEOUT, 60 );
+			curl_setopt($curl, CURLOPT_TIMEOUT, 60);
+			return $curl;
+		}, 1, 3);
 		`
 	);
 }

--- a/vendor/wp-now/src/wp-now.ts
+++ b/vendor/wp-now/src/wp-now.ts
@@ -617,6 +617,16 @@ async function mountInternalMuPlugins( php: PHP, options: WPNowOptions ) {
 			`
 		);
 	}
+
+	php.writeFile(
+		path.posix.join( PLAYGROUND_INTERNAL_MU_PLUGINS_FOLDER, '0-http-request-timeout.php' ),
+		`<?php
+		// Set the default HTTP request timeout to 60 seconds
+		add_filter( 'http_request_timeout', function() {
+			return 60;
+		} );
+		`
+	);
 }
 
 async function mountSqlitePlugin( php: PHP, vfsDocumentRoot: string ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

Fixes [STU-323 Feature Request: Plugin Updater Setting (to Fix Timeout)](https://linear.app/a8c/issue/STU-323/feature-request-plugin-updater-setting-to-fix-timeout)

## Proposed Changes
This PR addresses timeout issues with plugin updates by increasing the default HTTP request timeout to 60 seconds.

- Added a new MU plugin `0-http-request-timeout.php` that sets the default HTTP request timeout and curl timeouts to 60 seconds


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Temporarily decrease the timeouts to 1 second:
```diff
--- a/vendor/wp-now/src/wp-now.ts
+++ b/vendor/wp-now/src/wp-now.ts
@@ -623,13 +623,13 @@ async function mountInternalMuPlugins( php: PHP, options: WPNowOptions ) {
                `<?php
                // Set the default HTTP request timeout to 60 seconds
                add_filter( 'http_request_timeout', function() {
-                       return 60;
+                       return 1;
                } );
 
                // Set the default cURL timeout to 60 second
                add_action('http_api_curl', function($curl, $url, $options) {
-                       curl_setopt( $curl, CURLOPT_CONNECTTIMEOUT, 60 );
-                       curl_setopt($curl, CURLOPT_TIMEOUT, 60);
+                       curl_setopt( $curl, CURLOPT_CONNECTTIMEOUT, 1 );
+                       curl_setopt($curl, CURLOPT_TIMEOUT, 1);
                        return $curl;
                }, 1, 3);
```
2. Run `npm start`
3. In one of your sites, open the `functions.php` of the active theme, and add this snippet:
```
add_action(
    'wp_head', function () {
        $response = wp_remote_get('https://httpstat.us/200?sleep=5000'); // 5-second delay

        if (is_wp_error($response) ) {
            echo '<div style="background: #fee; color: #a00; padding: 10px; font-weight: bold;">';
            echo 'Request failed: ' . esc_html($response->get_error_message());
            echo '</div>';
        } else {
            echo '<div style="background: #efe; color: #060; padding: 10px; font-weight: bold;">';
            echo 'Request succeeded: HTTP ' . esc_html(wp_remote_retrieve_response_code($response));
            echo '</div>';
        }
    }
);
```
4. Go to the site's homepage and check that you receive a timeout error
5. Remove the changes from `wp-now.ts`, and kill and restart Studio
6. Go to the site's homepage and check that the request succeeds 

| with 1 second timeout | with 60 seconds timeout |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/a16c0b05-1bad-4c48-96c4-f2f7ab736920) | ![image](https://github.com/user-attachments/assets/22cce3a7-71a0-4a04-919d-5861cabc2387) | 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
