### PR TITLE
Sync: Update notification to include Hostname

### DIFF
--- a/src/components/tests/content-tab-sync.test.tsx
+++ b/src/components/tests/content-tab-sync.test.tsx
@@ -33,7 +33,7 @@ const inProgressPushState: SyncPushState = {
 		message: '',
 	},
 	selectedSite,
-	isStaging: false,
+	remoteSiteUrl: 'https://example.com',
 };
 
 describe( 'ContentTabSync', () => {

--- a/src/hooks/sync-sites/use-sync-pull.ts
+++ b/src/hooks/sync-sites/use-sync-pull.ts
@@ -224,6 +224,7 @@ export function useSyncPull( {
 				getIpcApi().showNotification( {
 					title: selectedSite.name,
 					body: sprintf(
+						// translators: %s is the site url without the protocol.
 						__( 'Studio site has been updated from %s' ),
 						getHostnameFromUrl( remoteSiteUrl )
 					),

--- a/src/hooks/sync-sites/use-sync-pull.ts
+++ b/src/hooks/sync-sites/use-sync-pull.ts
@@ -19,6 +19,7 @@ import {
 	useSyncStatesProgressInfo,
 } from 'src/hooks/use-sync-states-progress-info';
 import { getIpcApi } from 'src/lib/get-ipc-api';
+import { getHostnameFromUrl } from 'src/lib/url-utils';
 import type { SyncSite } from 'src/hooks/use-fetch-wpcom-sites/types';
 
 export type SyncBackupState = {
@@ -27,7 +28,7 @@ export type SyncBackupState = {
 	status: PullStateProgressInfo;
 	downloadUrl: string | null;
 	selectedSite: SiteDetails;
-	isStaging: boolean;
+	remoteSiteUrl: string;
 };
 
 export type PullStates = Record< string, SyncBackupState >;
@@ -102,13 +103,14 @@ export function useSyncPull( {
 			}
 
 			const remoteSiteId = connectedSite.id;
+			const remoteSiteUrl = connectedSite.url;
 			updatePullState( selectedSite.id, remoteSiteId, {
 				backupId: null,
 				status: pullStatesProgressInfo[ 'in-progress' ],
 				downloadUrl: null,
 				remoteSiteId,
+				remoteSiteUrl,
 				selectedSite,
-				isStaging: connectedSite.isStaging,
 			} );
 
 			try {
@@ -155,7 +157,7 @@ export function useSyncPull( {
 
 	const onBackupCompleted = useCallback(
 		async ( remoteSiteId: number, backupState: SyncBackupState & { downloadUrl: string } ) => {
-			const { downloadUrl, selectedSite, isStaging } = backupState;
+			const { downloadUrl, selectedSite, remoteSiteUrl } = backupState;
 
 			try {
 				const fileSize = await checkBackupFileSize( downloadUrl );
@@ -221,9 +223,10 @@ export function useSyncPull( {
 
 				getIpcApi().showNotification( {
 					title: selectedSite.name,
-					body: isStaging
-						? __( 'Studio site updated from Staging' )
-						: __( 'Studio site updated from Production' ),
+					body: sprintf(
+						__( 'Studio site has been updated from %s' ),
+						getHostnameFromUrl( remoteSiteUrl )
+					),
 				} );
 
 				onPullSuccess?.( remoteSiteId, selectedSite.id );

--- a/src/hooks/sync-sites/use-sync-push.ts
+++ b/src/hooks/sync-sites/use-sync-push.ts
@@ -24,7 +24,6 @@ export type SyncPushState = {
 	remoteSiteId: number;
 	status: PushStateProgressInfo;
 	selectedSite: SiteDetails;
-	isStaging: boolean;
 	remoteSiteUrl: string;
 };
 
@@ -181,7 +180,6 @@ export function useSyncPush( {
 				remoteSiteId,
 				status: pushStatesProgressInfo.creatingBackup,
 				selectedSite,
-				isStaging: connectedSite.isStaging,
 				remoteSiteUrl,
 			} );
 

--- a/src/hooks/sync-sites/use-sync-push.ts
+++ b/src/hooks/sync-sites/use-sync-push.ts
@@ -110,6 +110,7 @@ export function useSyncPush( {
 				getIpcApi().showNotification( {
 					title: syncPushState.selectedSite.name,
 					body: sprintf(
+						// translators: %s is the site url without the protocol.
 						__( '%s has been updated' ),
 						getHostnameFromUrl( syncPushState.remoteSiteUrl )
 					),

--- a/src/hooks/sync-sites/use-sync-push.ts
+++ b/src/hooks/sync-sites/use-sync-push.ts
@@ -16,6 +16,7 @@ import {
 	PushStateProgressInfo,
 } from 'src/hooks/use-sync-states-progress-info';
 import { getIpcApi } from 'src/lib/get-ipc-api';
+import { getHostnameFromUrl } from 'src/lib/url-utils';
 import type { SyncSite } from 'src/hooks/use-fetch-wpcom-sites/types';
 import type { ImportResponse } from 'src/hooks/use-sync-states-progress-info';
 
@@ -24,6 +25,7 @@ export type SyncPushState = {
 	status: PushStateProgressInfo;
 	selectedSite: SiteDetails;
 	isStaging: boolean;
+	remoteSiteUrl: string;
 };
 
 export type PushStates = Record< string, SyncPushState >;
@@ -108,9 +110,10 @@ export function useSyncPush( {
 				onPushSuccess?.( remoteSiteId, syncPushState.selectedSite.id );
 				getIpcApi().showNotification( {
 					title: syncPushState.selectedSite.name,
-					body: syncPushState.isStaging
-						? __( 'Staging has been updated' )
-						: __( 'Production has been updated' ),
+					body: sprintf(
+						__( '%s has been updated' ),
+						getHostnameFromUrl( syncPushState.remoteSiteUrl )
+					),
 				} );
 			} else if ( response.success && response.status === 'failed' ) {
 				status = pushStatesProgressInfo.failed;
@@ -173,11 +176,13 @@ export function useSyncPush( {
 				return;
 			}
 			const remoteSiteId = connectedSite.id;
+			const remoteSiteUrl = connectedSite.url;
 			updatePushState( selectedSite.id, remoteSiteId, {
 				remoteSiteId,
 				status: pushStatesProgressInfo.creatingBackup,
 				selectedSite,
 				isStaging: connectedSite.isStaging,
+				remoteSiteUrl,
 			} );
 
 			let archiveContent, archivePath, archiveSizeInBytes;

--- a/src/lib/url-utils.ts
+++ b/src/lib/url-utils.ts
@@ -1,0 +1,13 @@
+/**
+ * Extracts the hostname from a URL string.
+ * @param url The URL string to extract the hostname from
+ * @returns The hostname (domain and port if specified), or an empty string if the URL is invalid
+ */
+export function getHostnameFromUrl( url: string ): string {
+	try {
+		const parsedUrl = new URL( url );
+		return parsedUrl.hostname;
+	} catch ( error ) {
+		return '';
+	}
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-510

## Proposed Changes

- Add the Hostname of the connected site to the Push Notification
- Add the Hostname of the connected site to the Pull Notification

|Operation|Before | After|
|-------|-------|------|
|Pull|  ![CleanShot 2025-05-19 at 18 19 18@2x](https://github.com/user-attachments/assets/d1d033cd-9e28-4214-9066-9e92ab4c10a3)| ![CleanShot 2025-05-19 at 17 13 33@2x](https://github.com/user-attachments/assets/1144759f-e064-4ecc-bc85-882ad7888b70)|
|Push|     ![CleanShot 2025-05-19 at 18 22 40@2x](https://github.com/user-attachments/assets/9608a63b-9ce4-498b-a3ae-e48908d771d4)|![CleanShot 2025-05-19 at 17 00 05@2x](https://github.com/user-attachments/assets/de75f04e-3381-4a0f-8a9b-3ef5da40dcef)|


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Apply this patch and run `npm start`
- Navigate to the Sync tab and connect a site or use one of your connected sites
- Click on Push
- Check the notification includes the URL of the connected site
* Click on Pull
* Check the notification includes the URL of the connected site

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
