### PR TITLE
Update connect site text button when connecting another site

### DIFF
--- a/src/components/connect-create-buttons.tsx
+++ b/src/components/connect-create-buttons.tsx
@@ -12,6 +12,7 @@ interface ConnectButtonProps {
 	connectSite?: () => void;
 	disableConnectButtonStyle?: boolean;
 	className?: string;
+	children?: React.ReactNode;
 }
 
 interface CreateButtonProps {
@@ -26,6 +27,7 @@ export const ConnectButton = ( {
 	connectSite,
 	disableConnectButtonStyle,
 	className,
+	children,
 }: ConnectButtonProps ) => {
 	const isOffline = useOffline();
 	return (
@@ -45,7 +47,7 @@ export const ConnectButton = ( {
 					className
 				) }
 			>
-				{ __( 'Connect site' ) }
+				{ children }
 			</Button>
 		</Tooltip>
 	);

--- a/src/components/content-tab-sync.tsx
+++ b/src/components/content-tab-sync.tsx
@@ -157,7 +157,9 @@ export function ContentTabSync( { selectedSite }: { selectedSite: SiteDetails } 
 							variant="primary"
 							connectSite={ () => setIsSyncSitesSelectorOpen( true ) }
 							disableConnectButtonStyle={ true }
-						/>
+						>
+							{ __( 'Connect another site' ) }
+						</ConnectButton>
 					</div>
 				</div>
 			) : (
@@ -167,7 +169,9 @@ export function ContentTabSync( { selectedSite }: { selectedSite: SiteDetails } 
 							variant="primary"
 							connectSite={ () => setIsSyncSitesSelectorOpen( true ) }
 							disableConnectButtonStyle={ true }
-						/>
+						>
+							{ __( 'Connect site' ) }
+						</ConnectButton>
 					</div>
 				</SiteSyncDescription>
 			) }

--- a/src/components/tests/content-tab-sync.test.tsx
+++ b/src/components/tests/content-tab-sync.test.tsx
@@ -300,7 +300,7 @@ describe( 'ContentTabSync', () => {
 
 		renderWithProvider( <ContentTabSync selectedSite={ selectedSite } /> );
 
-		const connectButton = screen.getByRole( 'button', { name: /Connect site/i } );
+		const connectButton = screen.getByRole( 'button', { name: /Connect another site/i } );
 		expect( connectButton ).toBeInTheDocument();
 	} );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-514

## Proposed Changes

- Let's rename the button to make sure user understand the current site is already connected and they can connect extra sites.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run `npm start`
- Go to sync tab
- Observe the `Connect site` button
- Connect a site
- Observe the same button now says `Connect another site`


| Before | After |
|--------|--------|
|  ![Screenshot 2025-05-19 at 20 29 58](https://github.com/user-attachments/assets/4c53acb1-6f46-4b80-b73c-2be631301652) | ![Screenshot 2025-05-19 at 20 29 38](https://github.com/user-attachments/assets/1801cd94-ec2d-4fb3-8a03-86fe72d60afa) |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
