### PR TITLE
Avoid orphans in sync title

### DIFF
--- a/src/components/content-tab-sync.tsx
+++ b/src/components/content-tab-sync.tsx
@@ -18,9 +18,11 @@ function SiteSyncDescription( { children }: PropsWithChildren ) {
 	const { __ } = useI18n();
 	return (
 		<div className="flex justify-between max-w-3xl gap-4">
-			<div className="flex flex-col p-8">
+			<div className="flex flex-col p-8 pr-7">
 				<div className="flex items-center mb-1">
-					<div className="a8c-subtitle">{ __( 'Sync with WordPress.com or Pressable' ) }</div>
+					<div className="a8c-subtitle text-pretty">
+						{ __( 'Sync with WordPress.com or Pressable' ) }
+					</div>
 				</div>
 				<div className="max-w-[40ch] text-a8c-gray-70 a8c-body">
 					{ __(


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-513

## Proposed Changes

- Increase width on Sync description to avoid Pressable word being an orphan
- Add [text-pretty](https://tailwindcss.com/docs/text-wrap#pretty-text-wrapping) to avoid any orphans in any language. As an alternative we could use [text-balance](https://tailwindcss.com/docs/text-wrap#balanced-text-wrapping).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run `npm start`
- Navigate to Sync tab
- Observe the title in a single line

| Before | After |
|--------|--------|
|  ![Screenshot 2025-05-19 at 22 23 06](https://github.com/user-attachments/assets/e6e2826b-3f09-46d8-916a-4245135ea3e7) | ![Screenshot 2025-05-19 at 23 12 53](https://github.com/user-attachments/assets/2304a5fc-f12b-44b7-84b5-10f706c1768d) |


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
