### PR TITLE
Add migration to rename launch uniques stat

### DIFF
--- a/cli/lib/appdata.ts
+++ b/cli/lib/appdata.ts
@@ -34,7 +34,10 @@ const userDataSchema = z
 			.passthrough()
 			.optional(),
 		lastBumpStats: z
-			.record( z.nativeEnum( StatsGroup ), z.record( z.nativeEnum( StatsMetric ), z.number() ) )
+			.record(
+				z.union( [ z.nativeEnum( StatsGroup ), z.literal( 'local-environment-launch-uniques' ) ] ),
+				z.record( z.nativeEnum( StatsMetric ), z.number() )
+			)
 			.optional(),
 	} )
 	.passthrough();

--- a/cli/lib/tests/appdata.test.ts
+++ b/cli/lib/tests/appdata.test.ts
@@ -3,6 +3,7 @@ import os from 'os';
 import path from 'path';
 import { readFile, writeFile } from 'atomically';
 import { arePathsEqual } from 'common/lib/fs-utils';
+import { StatsMetric } from 'common/types/stats';
 import {
 	readAppdata,
 	saveAppdata,
@@ -65,6 +66,25 @@ describe( 'Appdata Module', () => {
 						date: 1234567,
 					},
 				],
+			};
+
+			( readFile as jest.Mock ).mockResolvedValueOnce( JSON.stringify( mockUserData ) );
+
+			const result = await readAppdata();
+			expect( result ).toEqual( mockUserData );
+		} );
+
+		it( 'should correctly validate lastBumpStats with local-environment-launch-uniques key', async () => {
+			const mockUserData = {
+				version: 1,
+				newSites: [],
+				sites: [],
+				snapshots: [],
+				lastBumpStats: {
+					'local-environment-launch-uniques': {
+						[ StatsMetric.DARWIN ]: 5,
+					},
+				},
 			};
 
 			( readFile as jest.Mock ).mockResolvedValueOnce( JSON.stringify( mockUserData ) );

--- a/common/types/stats.ts
+++ b/common/types/stats.ts
@@ -2,7 +2,7 @@ export enum StatsGroup {
 	// Studio app
 	STUDIO_APP_LAUNCH = 'studio-app-launch-first',
 	STUDIO_APP_LAUNCH_TOTAL = 'studio-app-launch-total',
-	STUDIO_APP_LAUNCH_UNIQUE = 'local-environment-launch-uniques',
+	STUDIO_APP_LAUNCH_UNIQUE = 'studio-app-launch-uniques',
 	STUDIO_IMPORT = 'studio-app-import',
 	STUDIO_EXPORT = 'studio-app-export',
 	// Studio CLI

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,7 @@ import {
 } from 'src/migrations/migrate-from-wp-now-folder';
 import { migrateAllDatabasesInSitu } from 'src/migrations/move-databases-in-situ';
 import { removeSitesWithEmptyDirectories } from 'src/migrations/remove-sites-with-empty-dirs';
+import { renameLaunchUniquesStat } from 'src/migrations/rename-launch-uniques-stat';
 import { installCLIOnWindows } from 'src/modules/cli/lib/install-windows';
 import { setupWPServerFiles, updateWPServerFiles } from 'src/setup-wp-server-files';
 import { stopAllServersOnQuit } from 'src/site-server';
@@ -300,6 +301,8 @@ async function appBoot() {
 		await removeSitesWithEmptyDirectories();
 
 		await migrateAllDatabasesInSitu();
+
+		await renameLaunchUniquesStat();
 
 		createMainWindow();
 		await startUserDataWatcher();

--- a/src/migrations/rename-launch-uniques-stat.ts
+++ b/src/migrations/rename-launch-uniques-stat.ts
@@ -1,0 +1,16 @@
+import { StatsGroup } from 'common/types/stats';
+import { loadUserData, saveUserData } from 'src/storage/user-data';
+
+export async function renameLaunchUniquesStat() {
+	const userData = await loadUserData();
+	const lastBumpStat = userData.lastBumpStats?.[ 'local-environment-launch-uniques' ];
+
+	if ( lastBumpStat === undefined ) {
+		return;
+	}
+
+	userData.lastBumpStats![ StatsGroup.STUDIO_APP_LAUNCH_UNIQUE ] = lastBumpStat;
+	delete userData.lastBumpStats![ 'local-environment-launch-uniques' ];
+
+	await saveUserData( userData );
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Related to STU-515

## Proposed Changes

- Add migration to rename `local-environment-launch-uniques` stat to `studio-app-launch-uniques`. See STU-515 for reasoning.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Open your Studio config file
2. Ensure that there's a `local-environment-launch-uniques` key in the `lastBumpStats` object
3. Run `npm start`
4. Ensure that the `local-environment-launch-uniques` key is replaced by `studio-app-launch-uniques` after the app launches

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
