### PR TITLE
Pressable Sync: Fix remaining Sync modal issues

### DIFF
--- a/src/components/sync-sites-modal-selector.tsx
+++ b/src/components/sync-sites-modal-selector.tsx
@@ -15,7 +15,6 @@ import { useOffline } from 'src/hooks/use-offline';
 import { cx } from 'src/lib/cx';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 import { getLocalizedLink } from 'src/lib/get-localized-link';
-import { WordPressLogoCircle } from './wordpress-logo-circle';
 import type { SyncSite } from 'src/hooks/use-fetch-wpcom-sites/types';
 
 const SearchControl = process.env.NODE_ENV === 'test' ? () => null : SearchControlWp;
@@ -208,6 +207,7 @@ function SiteItem( {
 	const isUnsupported = site.syncSupport === 'unsupported';
 	const isPressable = site.isPressable;
 	const environmentType = site.environmentType;
+	const isDisabled = isDeleted || isUnsupported || needsUpgrade || isMissingPermissions;
 
 	return (
 		<div
@@ -252,11 +252,7 @@ function SiteItem( {
 							<WordPressLogoCircle
 								size={ 12 }
 								{ ...( isSelected && { color: '#fff' } ) }
-								{ ...( ( isUnsupported ||
-									needsUpgrade ||
-									isDeleted ||
-									isMissingPermissions ||
-									isNeedsTransfer ) && { color: '#8c8f94' } ) }
+								{ ...( isDisabled && { color: '#8c8f94' } ) }
 							/>
 						</span>
 					) }

--- a/src/components/sync-sites-modal-selector.tsx
+++ b/src/components/sync-sites-modal-selector.tsx
@@ -133,7 +133,7 @@ function SearchSites( {
 				__nextHasNoMarginBottom={ true }
 			/>
 			<p className="a8c-helper-text text-gray-500">
-				{ __( "Can't find your site? " ) }
+				{ __( "Can't find your site?" ) }{ ' ' }
 				<Button
 					variant="link"
 					onClick={ () => getIpcApi().openURL( getLocalizedLink( locale, 'docsSync' ) ) }

--- a/src/components/sync-sites-modal-selector.tsx
+++ b/src/components/sync-sites-modal-selector.tsx
@@ -137,6 +137,7 @@ function SearchSites( {
 				<Button
 					variant="link"
 					onClick={ () => getIpcApi().openURL( getLocalizedLink( locale, 'docsSync' ) ) }
+					className="text-xs"
 				>
 					{ __( 'Learn more about supported sites.' ) }
 					<ArrowIcon />

--- a/src/components/sync-sites-modal-selector.tsx
+++ b/src/components/sync-sites-modal-selector.tsx
@@ -9,6 +9,7 @@ import { EnvironmentBadge } from 'src/components/environment-badge';
 import Modal from 'src/components/modal';
 import offlineIcon from 'src/components/offline-icon';
 import { PressableLogo } from 'src/components/pressable-logo';
+import { WordPressLogoCircle } from 'src/components/wordpress-logo-circle';
 import { useI18nData } from 'src/hooks/use-i18n-data';
 import { useOffline } from 'src/hooks/use-offline';
 import { cx } from 'src/lib/cx';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Related to https://github.com/Automattic/studio/pull/1406

## Proposed Changes

The PR fixes smaller issues I missed in the original PR (https://github.com/Automattic/studio/pull/1406)

- use absolute path for `WordPressLogoCircle` import for consistency 
- extract `isDisabled` into its own const for better readability
- remove space from the `Can't find your site?` translate string
- make the `Learn more about supported sites` link the same size as the leading helper text

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR and build the app with `npm start`.
2. Head over to the Sync tab and click the `Connect site` button.
3. Everything should be looking and working correctly, e.g.: WordPress logo displayed by each WP.com site (should be grayed out for unsupported sites), helper text below the search field should look good.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
