### PR TITLE
Remove `downloadWordPress` call in `startWPNow`

### DIFF
--- a/vendor/wp-now/src/wp-now.ts
+++ b/vendor/wp-now/src/wp-now.ts
@@ -33,7 +33,7 @@ import {
 	SQLITE_FILENAME,
 	SQLITE_PLUGIN_FOLDER,
 } from './constants';
-import { downloadWordPress, removeDownloadedMuPlugins } from './download';
+import { removeDownloadedMuPlugins } from './download';
 import getSqlitePath from './get-sqlite-path';
 import getWordpressVersionsPath from './get-wordpress-versions-path';
 import { output } from './output';

--- a/vendor/wp-now/src/wp-now.ts
+++ b/vendor/wp-now/src/wp-now.ts
@@ -90,7 +90,6 @@ export default async function startWPNow(
 		return { php, options };
 	}
 	output?.log( `wp: ${ options.wordPressVersion }` );
-	await downloadWordPress( options.wordPressVersion );
 
 	if ( options.reset ) {
 		fs.removeSync( options.wpContentPath );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

Fixes [STU-509 Studio: Check if we need to call downloadWordPress in the StartWPNow function](https://linear.app/a8c/issue/STU-509/studio-check-if-we-need-to-call-downloadwordpress-in-the-startwpnow)

## Proposed Changes

This PR removes the `downloadWordPress` call from the `startWPNow` function, as it seems unnecessary:
- WordPress core files are downloaded and cached in a shared location (under `getWordpressVersionsPath()`)
- The function was called after site creation, where it's already called from `createSiteWorkingDirectory`.
- Note that the `downloadWordPress` has a check not to re-download WordPress if the version already exists, so this extra call was always returning early.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Check your appdata folder (`~/Library/Application Support/Studio/server-files/wordpress-versions` on Mac), and note the already downloaded WordPress versions
- Start the app with `npm start`
- Create new sites using different WordPress versions than the cached ones
- For each new site:
  - Check that the WordPress version is downloaded to `wordpress-versions`
  - Check that the site is created successfully and opens in the browser
  - Check that there are no errors in the console

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
