### PR TITLE
Studio: Solve accessibility warning on user settings 

### DIFF
--- a/src/modules/user-settings/components/snapshot-info.tsx
+++ b/src/modules/user-settings/components/snapshot-info.tsx
@@ -78,8 +78,11 @@ export const SnapshotInfo = ( {
 												 * attribute is used rather than `disabled` so that screen
 												 * readers can focus the item to announce its disabled state.
 												 * Otherwise, dropdown toggle would toggle an empty menu.
+												 * We explicitly set aria-hidden={false} to prevent the menu
+												 * from hiding this item from screen readers.
 												 */
 												aria-disabled={ isDisabled }
+												aria-hidden={ false }
 												icon={ trash }
 												iconPosition="left"
 												isDestructive

--- a/src/modules/user-settings/components/snapshot-info.tsx
+++ b/src/modules/user-settings/components/snapshot-info.tsx
@@ -62,7 +62,7 @@ export const SnapshotInfo = ( {
 							size={ 24 }
 							label={ __( 'More options' ) }
 						>
-							{ ( { onClose }: { onClose: () => void } ) => {
+							{ ( { onClose, isOpen }: { onClose: () => void; isOpen: boolean } ) => {
 								return (
 									<MenuGroup>
 										<Tooltip
@@ -74,15 +74,16 @@ export const SnapshotInfo = ( {
 											<MenuItem
 												aria-description={ isOffline ? offlineMessage : '' }
 												/**
-												 * Because there is a single menu item, the `aria-disabled`
-												 * attribute is used rather than `disabled` so that screen
-												 * readers can focus the item to announce its disabled state.
-												 * Otherwise, dropdown toggle would toggle an empty menu.
-												 * We explicitly set aria-hidden={false} to prevent the menu
-												 * from hiding this item from screen readers.
+												 * When the menu is visible (isOpen=true), we use aria-disabled
+												 * to allow screen readers to focus and announce the disabled state.
+												 * When the menu is hidden, we remove focusable attributes to
+												 * prevent conflicts with aria-hidden.
 												 */
-												aria-disabled={ isDisabled }
-												aria-hidden={ false }
+												{ ...( isDisabled &&
+													isOpen && {
+														'aria-disabled': true,
+														tabIndex: 0,
+													} ) }
 												icon={ trash }
 												iconPosition="left"
 												isDestructive


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

Fixes: STU-504

## Proposed Changes

When the `Popover (dropdown menu)` for `Delete all preview sites` is closed/hidden, it has aria-hidden="true" (set by WordPress components) applied to prevent screen readers from accessing its contents. However, the `MenuItem` still has focusable attributes (`aria-disabled`) even when hidden. I believe this creates a conflict because an element marked as aria-hidden="true" should not contain any focusable descendants.

Solution: 
I propose to use the `DropdownMenu's` isOpen state to only apply focusable attributes when the menu is visible, and remove them when it's hidden. This ensures there are no focusable elements inside the Popover when it's hidden with aria-hidden="true".

This maintains proper accessibility by:
* Allowing focus and state announcements when the menu is open
* Properly hiding all content from screen readers when the menu is close

Sidenote: Another solution that I tried as to render the menu in the root and outside of the DOM structure by using `__unstableSlotName: 'root'` prop but I don't think it is a good solution to do this. Happy to discuss other alternatives as well. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
* Start the app with `npm start`
* Make sure that you have no preview sites
* Open the developer tools
* Navigate to `User Settings` in the top right corner
* Open the `Usage` tab
* Confirm click on the three dots to by `Preview sites`
* Observe that when the focus goes on `Delete all preview sites`, there is no warning in the dev tools
* Try switching between different tabs and site and triggering the `User Settings` a couple of times to confirm it works (as in the issue originally, it is not something that I could always reproduce consistently)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
