### PR TITLE
Fix hiding plugins spinner

### DIFF
--- a/vendor/wp-now/src/wp-now.ts
+++ b/vendor/wp-now/src/wp-now.ts
@@ -639,8 +639,8 @@ async function mountInternalMuPlugins( php: PHP, options: WPNowOptions ) {
 		`<?php
 			// This is a temporary fix for a page-optimize bug that causes spinner icons to show all the time in the plugins list auto-update column
 
-			add_action( 'admin_enqueue_scripts', 'wpcomsh_patch_auto_update_spinner_style', 999 );
-			function wpcomsh_patch_auto_update_spinner_style() {
+			add_action( 'admin_enqueue_scripts', 'studio_patch_auto_update_spinner_style', 999 );
+			function studio_patch_auto_update_spinner_style() {
 				$current_screen = get_current_screen();
 				if ( isset( $current_screen->id ) && 'plugins' === $current_screen->id ) {
 					wp_add_inline_style(

--- a/vendor/wp-now/src/wp-now.ts
+++ b/vendor/wp-now/src/wp-now.ts
@@ -633,6 +633,24 @@ async function mountInternalMuPlugins( php: PHP, options: WPNowOptions ) {
 		}, 1, 3);
 		`
 	);
+
+	php.writeFile(
+		path.posix.join( PLAYGROUND_INTERNAL_MU_PLUGINS_FOLDER, '0-tmp-fix-hide-plugins-spinner.php' ),
+		`<?php
+			// This is a temporary fix for a page-optimize bug that causes spinner icons to show all the time in the plugins list auto-update column
+			// @see https://github.com/Automattic/wpcomsh/pull/975
+			add_action( 'admin_enqueue_scripts', 'wpcomsh_patch_auto_update_spinner_style', 999 );
+			function wpcomsh_patch_auto_update_spinner_style() {
+				$current_screen = get_current_screen();
+				if ( isset( $current_screen->id ) && 'plugins' === $current_screen->id ) {
+					wp_add_inline_style(
+						'dashicons',
+						'.toggle-auto-update .dashicons.hidden { display: none; }'
+					);
+				}
+			}
+	`
+	);
 }
 
 async function mountSqlitePlugin( php: PHP, vfsDocumentRoot: string ) {

--- a/vendor/wp-now/src/wp-now.ts
+++ b/vendor/wp-now/src/wp-now.ts
@@ -638,7 +638,7 @@ async function mountInternalMuPlugins( php: PHP, options: WPNowOptions ) {
 		path.posix.join( PLAYGROUND_INTERNAL_MU_PLUGINS_FOLDER, '0-tmp-fix-hide-plugins-spinner.php' ),
 		`<?php
 			// This is a temporary fix for a page-optimize bug that causes spinner icons to show all the time in the plugins list auto-update column
-			// @see https://github.com/Automattic/wpcomsh/pull/975
+
 			add_action( 'admin_enqueue_scripts', 'wpcomsh_patch_auto_update_spinner_style', 999 );
 			function wpcomsh_patch_auto_update_spinner_style() {
 				$current_screen = get_current_screen();


### PR DESCRIPTION
## Related issues

- Fixes STU-267

## Proposed Changes
We have a bug - after pulling a site from dotcom to Studio - appears a spinner for updating all plugins, but it should be hidden. This is a dotcom bug, specifically in [page-optimize](https://wordpress.org/plugins/page-optimize/), but we have temporary workarounds [here](https://github.com/Automattic/wpcomsh/pull/975) and [here](https://github.com/Automattic/jetpack/blob/550550264caaaea98ca7527b7615cd14257d0aa8/projects/plugins/wpcomsh/plugin-hotfixes.php#L82). So I added this temporary fix to Studio to avoid confusion for our users with using Sync functionality. Later we can remove it, as soon as the initial issue is fixed. I pinged folks [here](https://github.com/Automattic/wpcomsh/pull/975#issuecomment-2893992482) about it.

## Testing Instructions

1. Create a site on dotcom (I haven't managed to reproduce it with Business plan, only Commerce)
2. Creat a site in Studio
3. Connect them
4. Pull site from dotcom to Studio
5. Wait till it's finished
6. Open WP admin of the local Studio's site
7. Open "Plugins" -> "Installed plugins" page
8. Assert that you don't see spinner prev to "Enable auto-updates" link

<table>
<tr>
<td>BEFORE
<td>AFTER
</tr>
<tr>
<td><img width="219" alt="Screenshot 2025-05-20 at 14 53 46" src="https://github.com/user-attachments/assets/ef6c0015-7d8c-42b0-b832-15127bd6e690" />
<td><img width="217" alt="Screenshot 2025-05-20 at 14 53 54" src="https://github.com/user-attachments/assets/0955ab62-9419-416e-a7e1-5a550cad672a" />
</tr>
</table>
