### PR TITLE
Return original URL param when it cannot be parsed

### DIFF
--- a/src/lib/url-utils.ts
+++ b/src/lib/url-utils.ts
@@ -1,13 +1,13 @@
 /**
  * Extracts the hostname from a URL string.
  * @param url The URL string to extract the hostname from
- * @returns The hostname (domain and port if specified), or an empty string if the URL is invalid
+ * @returns The hostname (domain and port if specified), or the passed url param if invalid
  */
 export function getHostnameFromUrl( url: string ): string {
 	try {
 		const parsedUrl = new URL( url );
 		return parsedUrl.hostname;
 	} catch ( error ) {
-		return '';
+		return url;
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Related STU-510
- Related https://github.com/Automattic/studio/pull/1412#discussion_r2097632392

## Proposed Changes

- Return the passed URL parameter when it cannot be parsed instead of an empty string

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Apply this branch and run `npm start`
- Go to the Sync tab and connect a site, or use one of your connected sites
- Run a Push or a Pull
- Check that the notification contains the hostname of the connected site

### Additional testing
- You can force the URL to be invalid, for example applying this diff
```diff
diff --git i/src/hooks/sync-sites/use-sync-pull.ts w/src/hooks/sync-sites/use-sync-pull.ts
index ef0864e7..e4de1d71 100644
--- i/src/hooks/sync-sites/use-sync-pull.ts
+++ w/src/hooks/sync-sites/use-sync-pull.ts
@@ -226,7 +226,7 @@ export function useSyncPull( {
 					body: sprintf(
 						// translators: %s is the site url without the protocol.
 						__( 'Studio site has been updated from %s' ),
-						getHostnameFromUrl( remoteSiteUrl )
+						getHostnameFromUrl( remoteSiteUrl.replace( 'https://', '' ) )
 					),
 				} );

```
- And running a Pull and checking that you can still see the URL in the notification

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
