### PR TITLE
Add patch to fix the accessibility with modals

### DIFF
--- a/patches/@wordpress+components+29.9.0.patch
+++ b/patches/@wordpress+components+29.9.0.patch
@@ -1,0 +1,45 @@
+diff --git a/node_modules/@wordpress/components/build-module/modal/aria-helper.js b/node_modules/@wordpress/components/build-module/modal/aria-helper.js
+index e1e1371..54775d2 100644
+--- a/node_modules/@wordpress/components/build-module/modal/aria-helper.js
++++ b/node_modules/@wordpress/components/build-module/modal/aria-helper.js
+@@ -22,7 +22,7 @@ export function modalize(modalElement) {
+       continue;
+     }
+     if (elementShouldBeHidden(element)) {
+-      element.setAttribute('aria-hidden', 'true');
++      element.setAttribute('inert', '');
+       hiddenElements.push(element);
+     }
+   }
+@@ -37,7 +37,7 @@ export function modalize(modalElement) {
+  */
+ export function elementShouldBeHidden(element) {
+   const role = element.getAttribute('role');
+-  return !(element.tagName === 'SCRIPT' || element.hasAttribute('hidden') || element.hasAttribute('aria-hidden') || element.hasAttribute('aria-live') || role && LIVE_REGION_ARIA_ROLES.has(role));
++  return !(element.tagName === 'SCRIPT' || element.hasAttribute('hidden') || element.hasAttribute('aria-hidden') || element.hasAttribute('inert') || element.hasAttribute('aria-live') || role && LIVE_REGION_ARIA_ROLES.has(role));
+ }
+ 
+ /**
+@@ -49,7 +49,7 @@ export function unmodalize() {
+     return;
+   }
+   for (const element of hiddenElements) {
+-    element.removeAttribute('aria-hidden');
++    element.removeAttribute('inert');
+   }
+ }
+ //# sourceMappingURL=aria-helper.js.map
+\ No newline at end of file
+diff --git a/node_modules/@wordpress/components/build-module/modal/index.js b/node_modules/@wordpress/components/build-module/modal/index.js
+index 7ae5a49..b9ccf96 100644
+--- a/node_modules/@wordpress/components/build-module/modal/index.js
++++ b/node_modules/@wordpress/components/build-module/modal/index.js
+@@ -96,7 +96,7 @@ function UnforwardedModal(props, forwardedRef) {
+   }, [contentRef]);
+ 
+   // Accessibly isolates/unisolates the modal.
+-  useEffect(() => {
++  useLayoutEffect(() => {
+     ariaHelper.modalize(ref.current);
+     return () => ariaHelper.unmodalize();
+   }, []);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

Closes STU-504

## Proposed Changes

This PR changes the `aria-hidden` to `inert` attribute for everything else that is shown behind the modal when the modal is open. This will allow us to fix the two following warnings:

* On the `Add site` modal:

<img width="1681" alt="Screenshot 2025-05-21 at 11 04 40 AM" src="https://github.com/user-attachments/assets/834b784d-3bee-4a43-a7d1-e6f033e8006a" />

* On the `User Settings` modal:

<img width="669" alt="Screenshot 2025-05-21 at 12 09 30 PM" src="https://github.com/user-attachments/assets/4b3db7de-e790-4b73-b755-be3a3ccafde9" />

The issue originally comes from the [`wordpress/components` ](https://github.com/WordPress/gutenberg/issues/41503) and there is a draft PR to fix it but it [has not been reviewed or merged](https://github.com/WordPress/gutenberg/pull/53829). I propose that we use a patch to fix the accessibility issue on our end until it is fixed in the wordpress/components. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Pull the changes from this branch
- Build the app with `npm install && npm start`
- Open the browser dev tools
- Open `Add site` modal and confirm that there is no error that is indicated on the screenshot
- Open the `User Settings` modal
- Click on the `Usage` tab
- Click on the three dots by `Preview sites` 
- Confirm that you see no errors in the console 

It is quite tricky to reproduce the error on trunk but I was able to do it this way if you want to confirm that the fix works:

* If you initially tested the fix, make sure to remove your `node_modules` first
* On trunk, start the app with `npm install && npm start`
* Open the browser dev tools
* Follow the steps on the screencast below: 

https://github.com/user-attachments/assets/158c08d8-c6b3-459e-a220-55a6c2fd3c3d

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
