### PR TITLE
CLI: Set UTF8 encoding for output on Windows

### DIFF
--- a/bin/studio-cli.bat
+++ b/bin/studio-cli.bat
@@ -1,7 +1,17 @@
 @echo off
 setlocal
 
+rem Save original code page
+for /f "tokens=2 delims=:" %%i in ('chcp') do set "ORIGINAL_CP=%%i"
+set ORIGINAL_CP=%ORIGINAL_CP: =%
+
+rem Set code page to UTF-8
+chcp 65001 >nul
+
 set ELECTRON_RUN_AS_NODE=1
 call "%~dp0..\..\Studio.exe" "%~dp0..\cli\main.js" %*
 
-endlocal 
+rem Restore original code page
+chcp %ORIGINAL_CP% >nul
+
+endlocal

--- a/src/modules/cli/lib/install-windows.ts
+++ b/src/modules/cli/lib/install-windows.ts
@@ -68,15 +68,11 @@ const installPath = async () => {
 };
 
 /**
- * Our app is installed in a versioned directory, so the
- * full path changes with every update. This makes it unreliable to add the
- * executable directly to the system PATH — we'd also need to handle cleaning up
- * outdated entries manually.
+ * Creates a proxy batch file in a stable location to handle CLI execution.
  *
- * To solve this, we generate a fixed entry point (a proxy script) in a
- * stable location within AppData, outside the versioned folder. This script
- * simply forwards execution to the current version’s actual CLI entry point.
- * On update, we just rewrite the proxy to point to the new version.
+ * Since our app is installed in a versioned directory, the full path changes with each update.
+ * Instead of adding the versioned executable directly to PATH, we create a fixed proxy script
+ * in the AppData directory that forwards execution to the current version's CLI entry point.
  */
 const installProxyBatFile = async () => {
 	try {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-463

## Proposed Changes

`cmd.exe` on Windows defaults to `OEM` encoding for output. This causes plenty of characters in the Studio CLI output to render incorrectly. This PR uses the `chcp` command to change the "code page" to UTF8. It also saves the original code page and restores it after running the CLI command. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Have Studio installed on your Windows system
2. Open `C:\Users\USERNAME\AppData\Local\studio\app-1.5.1\resources\bin\studio-cli.bat` in a text editor
3. Paste the contents of `bin/studio-cli.bat` from this PR into that file
4. Open a new Command Prompt window
5. Run `studio preview list` for any site
6. Ensure that the output renders correctly

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
