### PR TITLE
Terminal Apps: Use URI scheme to open Warp terminal on Windows

### DIFF
--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -1051,7 +1051,8 @@ END` );
 			: {};
 
 		if ( preferredTerminal === ( 'warp' as SupportedTerminal ) ) {
-			return promiseExec( `start "" "warp" "--cwd=${ targetPath }"`, {
+			const encodedPath = encodeURIComponent( targetPath );
+			return promiseExec( `start "" "warp://action/new_tab?path=${ encodedPath }"`, {
 				env: { ...process.env, ...env },
 			} );
 		}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-519

## Proposed Changes

I propose using the URI Scheme to open Warp Terminal to fix the issue of not opening on Windows. The documentation for URI schemes can be found at https://docs.warp.dev/features/uri-scheme. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Check out this branch
- Install Warp if it is not installed. 
- Select Warp from Preferences as your terminal. 
- Click on the Warp option on the site overview.
- Confirm that the Warp terminal opens correctly with the correct site directly. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
