### PR TITLE
Update localized docs links for Studio Sync  and Studio CLI

### DIFF
--- a/src/components/sync-sites-modal-selector.tsx
+++ b/src/components/sync-sites-modal-selector.tsx
@@ -136,7 +136,9 @@ function SearchSites( {
 				{ __( "Can't find your site?" ) }{ ' ' }
 				<Button
 					variant="link"
-					onClick={ () => getIpcApi().openURL( getLocalizedLink( locale, 'docsSync' ) ) }
+					onClick={ () =>
+						getIpcApi().openURL( getLocalizedLink( locale, 'docsSyncSupportedSites' ) )
+					}
 					className="text-xs"
 				>
 					{ __( 'Learn more about supported sites.' ) }

--- a/src/lib/get-localized-link.ts
+++ b/src/lib/get-localized-link.ts
@@ -22,6 +22,7 @@ const DOCS_LINKS = {
 	},
 	docsCli: {
 		en: 'https://developer.wordpress.com/docs/developer-tools/studio/cli/',
+		es: 'https://developer.wordpress.com/es/docs/herramientas-para-desarrolladores/studio/cli/',
 	},
 } satisfies Record< `docs${ string }`, TranslatedLink >;
 

--- a/src/lib/get-localized-link.ts
+++ b/src/lib/get-localized-link.ts
@@ -20,6 +20,10 @@ const DOCS_LINKS = {
 		en: 'https://developer.wordpress.com/docs/developer-tools/studio/sync/',
 		es: 'https://developer.wordpress.com/es/docs/herramientas-para-desarrolladores/studio/sync/',
 	},
+	docsSyncSupportedSites: {
+		en: 'https://developer.wordpress.com/docs/developer-tools/studio/sync/#supported-sites',
+		es: 'https://developer.wordpress.com/es/docs/herramientas-para-desarrolladores/studio/sync/#sitios-compatibles',
+	},
 	docsCli: {
 		en: 'https://developer.wordpress.com/docs/developer-tools/studio/cli/',
 		es: 'https://developer.wordpress.com/es/docs/herramientas-para-desarrolladores/studio/cli/',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-524
- FIxes STU-525

## Proposed Changes

Two changes
- Add missing link to new Spanish Studio CLI docs , it's visible in what's new.
- Add hash link for future section on Studio Sync link

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**1. Spanish Studio CLI docs**

- Run `npm start`
- Change Studio language to Spanish
- Open the what's new modal
- Observe the link of CLI opens the Spanish version of the docs. (It's still in draft, but we'll publish it today).

![Screenshot 2025-05-23 at 13 00 31](https://github.com/user-attachments/assets/da31322a-57d5-4ea1-a6b5-c6f79e79ff7c)

**2. Studio Pressable Sync navigates to specific section**

- Run `npm start`
- Go to the Sync tab
- Click on connect to open the modal
- Click on `Learn more about supported sites.` observe it adds a hash. We'll create a new section with that anchor.

![Screenshot 2025-05-23 at 12 27 04](https://github.com/user-attachments/assets/4b26c6d8-714b-41ec-b0a1-748f40ab57a4)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
