### PR TITLE
Use the same style for the Preview and Sync tabs

### DIFF
--- a/src/components/content-tab-sync.tsx
+++ b/src/components/content-tab-sync.tsx
@@ -17,8 +17,8 @@ import type { SyncSite } from 'src/hooks/use-fetch-wpcom-sites/types';
 function SiteSyncDescription( { children }: PropsWithChildren ) {
 	const { __ } = useI18n();
 	return (
-		<div className="flex justify-between max-w-3xl gap-4">
-			<div className="flex flex-col p-8 pr-7">
+		<div className="p-8 flex justify-between max-w-3xl gap-4">
+			<div className="flex flex-col">
 				<div className="flex items-center mb-1">
 					<div className="a8c-subtitle text-pretty">
 						{ __( 'Sync with WordPress.com or Pressable' ) }
@@ -43,7 +43,7 @@ function SiteSyncDescription( { children }: PropsWithChildren ) {
 				</div>
 				{ children }
 			</div>
-			<div className="flex flex-col shrink-0 items-end p-4 rtl:order-first">
+			<div className="flex flex-col shrink-0 items-end">
 				<SyncTabImage />
 			</div>
 		</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes p1748248185249619-slack-C06DRMD6VPZ

## Proposed Changes

- Let's make the tabs Sync and Preview tabs consistent with styling and fix the two lines title when the scrollbar is visible
- Removes `rtl:order-first`, which was added in https://github.com/Automattic/studio/pull/910, although there is no mention of making that change intentionally.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run `npm start`
- Set your Mac Preferences > Appearance > Show Scroll bar  > Always
- Navigate to the sync tab when not authenticated
- Observe the screen looks good.

| Before | After |
|--------|--------|
| ![Screenshot 2025-05-26 at 10 30 57](https://github.com/user-attachments/assets/89c4b700-23b5-4bc9-a129-852505bac506) | ![Screenshot 2025-05-26 at 10 30 40](https://github.com/user-attachments/assets/16e502fb-5a94-4692-82e5-9db12120af18) |



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?