### PR TITLE
Studio: Command Prompt button is truncated on Windows

### DIFF
--- a/src/components/content-tab-overview.tsx
+++ b/src/components/content-tab-overview.tsx
@@ -223,7 +223,7 @@ export function ContentTabOverview( { selectedSite }: ContentTabOverviewProps ) 
 	);
 
 	return (
-		<div className="p-8 flex max-w-3xl">
+		<div className="p-8 flex max-w-4xl">
 			<div className="w-52 ltr:mr-8 rtl:ml-8 flex-col justify-start items-start gap-8">
 				<h2 className="mb-3 a8c-subtitle-small">{ __( 'Theme' ) }</h2>
 				<div


### PR DESCRIPTION

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-501

## Proposed Changes

- The "Command Prompt" button is getting truncated on Windows on the site overview screen. This PR increases the container max to provide a bit more room for the button, so that the Button text doesn't get truncated. 

https://github.com/user-attachments/assets/ba400b44-7f2a-4c42-adfb-8a68595b1044


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Check out this branch
- Visit Site Overview Screen on Windows
- Make sure Command Prompt is set as the default terminal
- Increase the size of windows and see that the button is not truncated. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
