### PR TITLE
User Settings: "Command Prompt" shows as "Terminal" in dropdown options on Windows

### DIFF
--- a/src/components/content-tab-overview.tsx
+++ b/src/components/content-tab-overview.tsx
@@ -164,14 +164,7 @@ function ShortcutsSection( { selectedSite }: Pick< ContentTabOverviewProps, 'sel
 		} );
 	}
 
-	let terminalName = getTerminalName( terminal );
-	if ( terminal === 'terminal' ) {
-		terminalName = isWindows()
-			? // translators: name of the default terminal application on Windows
-			  __( 'Command Prompt' )
-			: // translators: name of the default terminal application on macOS
-			  __( 'Terminal' );
-	}
+	const terminalName = getTerminalName( terminal );
 	buttonsArray.push( {
 		label: terminalName,
 		className: 'text-nowrap',

--- a/src/modules/user-settings/components/terminal-picker.tsx
+++ b/src/modules/user-settings/components/terminal-picker.tsx
@@ -1,6 +1,6 @@
 import { SelectControl } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
-import { SupportedTerminal } from 'src/modules/user-settings/lib/terminal';
+import { SupportedTerminal, getTerminalName } from 'src/modules/user-settings/lib/terminal';
 import {
 	useGetInstalledAppsQuery,
 	selectInstalledTerminals,
@@ -31,17 +31,17 @@ export const TerminalPicker = ( { value, onChange }: TerminalPickerProps ) => {
 				__next40pxDefaultSize
 			>
 				<optgroup label={ __( 'Available terminals' ) }>
-					{ installedTerminals.map( ( [ terminal, label ] ) => (
+					{ installedTerminals.map( ( [ terminal ] ) => (
 						<option key={ terminal } value={ terminal }>
-							{ label }
+							{ getTerminalName( terminal ) }
 						</option>
 					) ) }
 				</optgroup>
 				{ uninstalledTerminals.length > 0 && (
 					<optgroup label={ __( 'Not installed' ) }>
-						{ uninstalledTerminals.map( ( [ terminal, label ] ) => (
+						{ uninstalledTerminals.map( ( [ terminal ] ) => (
 							<option key={ terminal } value={ terminal } disabled>
-								{ label }
+								{ getTerminalName( terminal ) }
 							</option>
 						) ) }
 					</optgroup>

--- a/src/modules/user-settings/components/tests/terminal-picker.test.tsx
+++ b/src/modules/user-settings/components/tests/terminal-picker.test.tsx
@@ -7,6 +7,8 @@ import { installedAppsApi } from 'src/stores/installed-apps-api';
 import { testReducer } from 'src/stores/tests/utils/test-reducer';
 
 jest.mock( 'src/lib/get-ipc-api' );
+jest.mock( 'src/lib/app-globals' );
+
 const mockGetIpcApi = getIpcApi as jest.Mock;
 
 store.replaceReducer( testReducer );

--- a/src/modules/user-settings/components/tests/user-settings.test.tsx
+++ b/src/modules/user-settings/components/tests/user-settings.test.tsx
@@ -8,6 +8,7 @@ import { useOffline } from 'src/hooks/use-offline';
 import { UserSettings } from 'src/modules/user-settings';
 import { store } from 'src/stores';
 
+jest.mock( 'src/lib/app-globals' );
 jest.mock( 'src/hooks/use-feature-flags' );
 jest.mock( 'src/hooks/use-auth' );
 jest.mock( 'src/hooks/use-ipc-listener' );

--- a/src/modules/user-settings/lib/terminal.ts
+++ b/src/modules/user-settings/lib/terminal.ts
@@ -1,4 +1,5 @@
 import { __ } from '@wordpress/i18n';
+import { isWindows } from 'src/lib/app-globals';
 
 export type SupportedTerminal = 'terminal' | 'iterm' | 'warp' | 'ghostty';
 
@@ -15,6 +16,11 @@ export const supportedTerminalNames: Record< SupportedTerminal, string > = {
 export function getTerminalName( terminal: SupportedTerminal | undefined ): string {
 	if ( ! terminal ) {
 		return '';
+	}
+
+	// translators: "Command Prompt" is the name of the terminal app on Windows.
+	if ( 'terminal' === terminal && isWindows() ) {
+		return __( 'Command Prompt' );
 	}
 
 	return supportedTerminalNames[ terminal ];


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-530

## Proposed Changes

Currently, on Windows, the "Command Prompt" option shows as "Terminal" in the dropdown options. This PR refactors a way to get a terminal name in the content-tab-overview and terminal-picker components.



| Before on Windows | After on Windows |
|--------|--------|
| ![CleanShot 2025-05-27 at 15 59 02@2x](https://github.com/user-attachments/assets/152ee5e1-5184-47ee-b6e6-f9bdb3d0d2ab) | ![CleanShot 2025-05-27 at 16 42 32@2x](https://github.com/user-attachments/assets/2f0f816d-9761-496f-9dcb-174eb0699658) | 

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Check out this branch on Windows
- Go to Preferences
- Ensure you see "Command Prompt" instead of "Terminal".

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
