### PR TITLE
Set what's new forceNewVersion back to false

### DIFF
--- a/src/stores/app-version-api.ts
+++ b/src/stores/app-version-api.ts
@@ -50,7 +50,7 @@ export const selectIsNewVersion = createSelector(
 		( res: GetLastSeenVersionQueryResult, currentVersion: string ) => currentVersion,
 	],
 	( lastSeenVersion, currentVersion ) => {
-		const forceNewVersion = true;
+		const forceNewVersion = false;
 
 		if ( currentVersion === lastSeenVersion ) {
 			return false;

--- a/src/stores/tests/app-version-api.test.ts
+++ b/src/stores/tests/app-version-api.test.ts
@@ -97,7 +97,7 @@ describe( 'App Version API', () => {
 			expect( result ).toBe( false );
 		} );
 
-		it.skip( 'should return false for a new patch version', () => {
+		it( 'should return false for a new patch version', () => {
 			const lastSeenVersion = '1.2.0';
 			const currentVersion = '1.2.1';
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-507

## Proposed Changes

- Avoid displaying the What's new modal for patch versions.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Update the package.json app version to 1.5.3
* Change lastSeenVersion in appdata-v1.json to 1.5.2
* Restart the app
* Confirm the What's new modal doesn't appear

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
