### PR TITLE
Include `common` folder into lint and make-pot commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,13 +30,13 @@
 		"publish": "electron-forge publish",
 		"cli:build": "webpack --config webpack.cli.config.ts",
 		"cli:watch": "webpack --config webpack.cli.config.ts --watch",
-		"lint": "eslint --ext .ts,.tsx,.js,.jsx,.mjs {cli,src}",
+		"lint": "eslint --ext .ts,.tsx,.js,.jsx,.mjs {cli,common,src}",
 		"format": "prettier . --write",
 		"test": "cross-env NODE_OPTIONS='--no-deprecation' jest",
 		"test:watch": "cross-env NODE_OPTIONS='--no-deprecation' jest --watch",
 		"e2e": "npx playwright install && npx playwright test",
 		"test:metrics": "npx playwright test --config=./metrics/playwright.metrics.config.ts",
-		"make-pot": "wp-babel-makepot \"{./src,./cli}/**/*.{js,jsx,ts,tsx}\" --ignore \"**/*.d.ts\" --base \".\" --dir \"./out/pots\" --output \"./out/pots/bundle-strings.pot\""
+		"make-pot": "wp-babel-makepot \"{./src,./cli,./common}/**/*.{js,jsx,ts,tsx}\" --ignore \"**/*.d.ts\" --base \".\" --dir \"./out/pots\" --output \"./out/pots/bundle-strings.pot\""
 	},
 	"devDependencies": {
 		"@automattic/color-studio": "^2.5.0",


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-531

## Proposed Changes

- Add `common` folder into `npm run lint` and `npm run make-pot` commands.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Apply this diff:
```diff
diff --git a/common/lib/locale.ts b/common/lib/locale.ts
index d5a290a2..f053be30 100644
--- a/common/lib/locale.ts
+++ b/common/lib/locale.ts
@@ -1,5 +1,5 @@
 // This file can be used in React and Node
-import { localeDataDictionary } from 'common/translations';
+import {localeDataDictionary} from 'common/translations';
 
 export const DEFAULT_LOCALE = 'en';
 

```
- Observe an error in the console
- Before this PR `npm run lint` was not returning any error from folder inside the common folder. Same for `npm run make-pot`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
