### PR TITLE
Simplify the version check function for what's new modal

### DIFF
--- a/src/stores/app-version-api.ts
+++ b/src/stores/app-version-api.ts
@@ -44,6 +44,28 @@ type GetLastSeenVersionQueryResult = TypedUseQueryStateResult<
 	BaseQueryFn
 >;
 
+function isGreaterExceptPatch( versionA: string | undefined, versionB: string ): boolean {
+	if ( ! versionA ) {
+		return true;
+	}
+
+	if (
+		! semver.valid( versionA ) ||
+		! semver.valid( versionB ) ||
+		semver.gte( versionA, versionB )
+	) {
+		return false;
+	}
+
+	const a = semver.parse( versionA )!;
+	const b = semver.parse( versionB )!;
+
+	if ( a.major === b.major && a.minor === b.minor && a.patch !== b.patch ) {
+		return false;
+	}
+	return true;
+}
+
 export const selectIsNewVersion = createSelector(
 	[
 		( res: GetLastSeenVersionQueryResult ) => res.data,
@@ -51,51 +73,7 @@ export const selectIsNewVersion = createSelector(
 	],
 	( lastSeenVersion, currentVersion ) => {
 		const forceNewVersion = false;
-
-		if ( currentVersion === lastSeenVersion ) {
-			return false;
-		}
-
-		if ( ! currentVersion || ! lastSeenVersion ) {
-			return !! currentVersion && lastSeenVersion !== currentVersion;
-		}
-
-		try {
-			const currentPrerelease = semver.prerelease( currentVersion );
-			const lastSeenPrerelease = semver.prerelease( lastSeenVersion );
-
-			// Handle prerelease to prerelease transitions
-			if ( currentPrerelease && lastSeenPrerelease ) {
-				return lastSeenVersion !== currentVersion;
-			}
-
-			// Handle prerelease to stable transitions (or vice versa)
-			if ( currentPrerelease || lastSeenPrerelease ) {
-				return true;
-			}
-
-			const cleanLastSeen = semver.valid( semver.coerce( lastSeenVersion ) );
-			const cleanCurrent = semver.valid( semver.coerce( currentVersion ) );
-
-			if ( ! cleanLastSeen || ! cleanCurrent ) {
-				return false;
-			}
-
-			const lastSeenParts = semver.parse( cleanLastSeen );
-			const currentParts = semver.parse( cleanCurrent );
-
-			if ( ! lastSeenParts || ! currentParts ) {
-				return false;
-			}
-
-			return (
-				lastSeenParts.major !== currentParts.major ||
-				lastSeenParts.minor !== currentParts.minor ||
-				forceNewVersion
-			);
-		} catch ( error ) {
-			console.error( 'Error comparing versions:', error );
-			return lastSeenVersion !== currentVersion;
-		}
+		const isSignificantNewVersion = isGreaterExceptPatch( lastSeenVersion, currentVersion );
+		return isSignificantNewVersion || forceNewVersion;
 	}
 );

--- a/src/stores/tests/app-version-api.test.ts
+++ b/src/stores/tests/app-version-api.test.ts
@@ -124,6 +124,15 @@ describe( 'App Version API', () => {
 			expect( result ).toBe( true );
 		} );
 
+		it( 'should return false when going from a stable version to a prerelease version that increases only the patch', () => {
+			const lastSeenVersion = '1.2.0';
+			const currentVersion = '1.2.1-beta1';
+
+			const result = selectIsNewVersion( createMockQueryResult( lastSeenVersion ), currentVersion );
+
+			expect( result ).toBe( false );
+		} );
+
 		it( 'should return true for a new prerelease version', () => {
 			const lastSeenVersion = '1.2.0-beta1';
 			const currentVersion = '1.2.0-beta2';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-516

## Proposed Changes

- Let's have a function that compares two versions and return true for minor and major updates.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Tests should pass
- Modify the package version to version 1.5.2
- Modify the appdata lastSeenVersion to 1.5.1
- Run `npm start`
- Observe the modal doesn't appear

- Modify the package version to version 1.6.2
- Modify the appdata lastSeenVersion to 1.5.1
- Run `npm start`
- Observe the modal appears

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
