### PR TITLE
Use authenticate function to open signup URL from Studio Assistant tab

### DIFF
--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -300,16 +300,7 @@ const UnauthenticatedView = ( { onAuthenticate }: { onAuthenticate: () => void }
 			{ createInterpolateElement(
 				__( "If you don't have an account yet, <a>create one for free</a>." ),
 				{
-					a: (
-						<Button
-							variant="link"
-							onClick={ () =>
-								getIpcApi().openURL(
-									'https://wordpress.com/?utm_source=studio&utm_medium=referral&utm_campaign=assistant_onboarding'
-								)
-							}
-						/>
-					),
+					a: <Button variant="link" onClick={ () => getIpcApi().authenticate( true ) } />,
 				}
 			) }
 		</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-407

## Proposed Changes

- Use `getIpcApi().authenticate` to open signup URL.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run `npm start`
- Log out
- Open the Assistant tab
- Click on `create one for free`
- Observe the signup website opens.


**Before**


https://github.com/user-attachments/assets/3c572b63-a1c9-4a9f-b888-2f81af83aa4b



**After**



https://github.com/user-attachments/assets/b25e3167-c4bd-4473-bfbe-a869d195e471




## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
