### PR TITLE
Fix blueprints support in wp-now code

### DIFF
--- a/vendor/wp-now/src/wp-now.ts
+++ b/vendor/wp-now/src/wp-now.ts
@@ -100,9 +100,11 @@ export default async function startWPNow(
 
 	await prepareWordPress( php, options );
 
+	await installationSteps( php, options );
+
 	if ( options.blueprintObject ) {
 		output?.log( `blueprint steps: ${ options.blueprintObject.steps.length }` );
-		const compiled = compileBlueprint( options.blueprintObject, {
+		const compiled = await compileBlueprint( options.blueprintObject, {
 			onStepCompleted: ( result, step: StepDefinition ) => {
 				output?.log( `Blueprint step completed: ${ step.step }` );
 			},
@@ -110,7 +112,6 @@ export default async function startWPNow(
 		await runBlueprintSteps( compiled, php );
 	}
 
-	await installationSteps( php, options );
 	await login( php, options );
 
 	if ( isFirstTimeProject && [ WPNowMode.PLUGIN, WPNowMode.THEME ].includes( options.mode ) ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- N/A

## Proposed Changes

I propose to fix blueprints support in the `wp-now` code. It doesn't cause any issue in the current Studio, but it prevents as from exploring blueprint in Studio.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Confirm that the site can still be created and started without any issues
2. Apply a patch that hardcodes the blueprint (feel free to use different set of plugins):

```
diff --git a/src/site-server.ts b/src/site-server.ts
index 14869c1e..04177f08 100644
--- a/src/site-server.ts
+++ b/src/site-server.ts
@@ -177,6 +177,38 @@ export class SiteServer {
 			isWpAutoUpdating: this.details.isWpAutoUpdating,
 		} );
 
+		options.blueprintObject = JSON.parse(
+			`{
+			"steps": [
+				{
+					"step": "installPlugin",
+					"pluginData": {
+						"resource": "wordpress.org/plugins",
+						"slug": "akismet"
+					}
+				}, {
+					"step": "installPlugin",
+					"pluginData": {
+						"resource": "wordpress.org/plugins",
+						"slug": "crowdsignal-forms"
+					}
+				}, {
+					"step": "installPlugin",
+					"pluginData": {
+						"resource": "wordpress.org/plugins",
+						"slug": "polldaddy"
+					}
+				}, {
+					"step": "installPlugin",
+					"pluginData": {
+						"resource": "wordpress.org/plugins",
+						"slug": "gutenberg"
+					}
+				}
+			]
+		}`
+		);
+
 		options.absoluteUrl = getAbsoluteUrl( this.details );
 		options.siteLanguage = await getPreferredSiteLanguage( options.wordPressVersion );
 
```

3. Create a new Studio site
4. Confirm it was created and started successfully
5. Open WP Admin and confirm plugins were installed

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
