### PR TITLE
Reduce timeout for HTTP request to 30 seconds

### DIFF
--- a/src/lib/site-server-process.ts
+++ b/src/lib/site-server-process.ts
@@ -11,7 +11,7 @@ declare const SITE_SERVER_PROCESS_MODULE_PATH: string;
 
 export type MessageName = 'start-server' | 'stop-server' | 'run-php';
 
-const DEFAULT_RESPONSE_TIMEOUT = 180000;
+const DEFAULT_RESPONSE_TIMEOUT = 150000;
 
 export default class SiteServerProcess {
 	lastMessageId = 0;

--- a/src/lib/site-server-process.ts
+++ b/src/lib/site-server-process.ts
@@ -11,7 +11,7 @@ declare const SITE_SERVER_PROCESS_MODULE_PATH: string;
 
 export type MessageName = 'start-server' | 'stop-server' | 'run-php';
 
-const DEFAULT_RESPONSE_TIMEOUT = 150000;
+const DEFAULT_RESPONSE_TIMEOUT = 120000;
 
 export default class SiteServerProcess {
 	lastMessageId = 0;

--- a/src/lib/site-server-process.ts
+++ b/src/lib/site-server-process.ts
@@ -11,7 +11,7 @@ declare const SITE_SERVER_PROCESS_MODULE_PATH: string;
 
 export type MessageName = 'start-server' | 'stop-server' | 'run-php';
 
-const DEFAULT_RESPONSE_TIMEOUT = 120000;
+const DEFAULT_RESPONSE_TIMEOUT = 180000;
 
 export default class SiteServerProcess {
 	lastMessageId = 0;

--- a/vendor/wp-now/src/wp-now.ts
+++ b/vendor/wp-now/src/wp-now.ts
@@ -586,14 +586,14 @@ async function mountInternalMuPlugins( php: PHP, options: WPNowOptions ) {
 	php.writeFile(
 		path.posix.join( PLAYGROUND_INTERNAL_MU_PLUGINS_FOLDER, '0-http-request-timeout.php' ),
 		`<?php
-		// Increase default timeouts to 60 seconds to accommodate slower network conditions and larger requests
+		// Increase default timeouts to 30 seconds to accommodate slower network conditions and larger requests
 		add_filter( 'http_request_timeout', function() {
-			return 60;
+			return 30;
 		} );
 
 		add_action('http_api_curl', function($curl, $url, $options) {
-			curl_setopt( $curl, CURLOPT_CONNECTTIMEOUT, 60 );
-			curl_setopt($curl, CURLOPT_TIMEOUT, 60);
+			curl_setopt( $curl, CURLOPT_CONNECTTIMEOUT, 30 );
+			curl_setopt($curl, CURLOPT_TIMEOUT, 30);
 			return $curl;
 		}, 1, 3);
 		`


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-523
- Related task https://github.com/Automattic/studio/pull/1407

## Proposed Changes

- Reduces the timeout of the HTTP requests from 60 seconds to 30 seconds because in offline mode, this is the timeout it takes to perform some installation steps [step 0 here](https://github.com/Automattic/studio/blob/b8c1ecb8c70ab5af30c089d22fc7bb01e0221c76/vendor/wp-now/src/wp-now.ts#L701) and [step 1 here](https://github.com/Automattic/studio/blob/b8c1ecb8c70ab5af30c089d22fc7bb01e0221c76/vendor/wp-now/src/wp-now.ts#L702). Moreover, the start server default timeout is [2 minutes](https://github.com/Automattic/studio/blob/b8c1ecb8c70ab5af30c089d22fc7bb01e0221c76/src/lib/site-server-process.ts#L14) so it sometimes triggers and the start server fails.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Apply this branch and run `npm start`
- Disconnect internet so Studio works in Offline mode
- Create a site and make sure the site starts successfully
- This was originally found in Windows, as it was slightly slower, so testing in Windows would also be beneficial.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
