### PR TITLE
Fix default editors when only one installed

### DIFF
--- a/src/modules/user-settings/lib/editor.ts
+++ b/src/modules/user-settings/lib/editor.ts
@@ -1,6 +1,13 @@
 import { __ } from '@wordpress/i18n';
 
-export type SupportedEditor = 'vscode' | 'phpstorm' | 'cursor' | 'windsurf' | 'webstorm';
+export const SUPPORTED_EDITORS = [
+	'cursor',
+	'phpstorm',
+	'vscode',
+	'windsurf',
+	'webstorm',
+] as const;
+export type SupportedEditor = ( typeof SUPPORTED_EDITORS )[ number ];
 
 export type SupportedEditorConfig = {
 	label: string;

--- a/src/modules/user-settings/lib/editor.ts
+++ b/src/modules/user-settings/lib/editor.ts
@@ -2,8 +2,8 @@ import { __ } from '@wordpress/i18n';
 
 export const SUPPORTED_EDITORS = [
 	'cursor',
-	'phpstorm',
 	'vscode',
+	'phpstorm',
 	'windsurf',
 	'webstorm',
 ] as const;

--- a/src/stores/installed-apps-api.ts
+++ b/src/stores/installed-apps-api.ts
@@ -5,8 +5,20 @@ import {
 	SupportedEditorConfig,
 	SupportedEditor,
 	supportedEditorConfig,
+	SUPPORTED_EDITORS,
 } from 'src/modules/user-settings/lib/editor';
 import { SupportedTerminal, supportedTerminalNames } from 'src/modules/user-settings/lib/terminal';
+
+const getFirstInstalledEditor = async (): Promise< SupportedEditor | null > => {
+	const installedApps = await getIpcApi().getInstalledAppsAndTerminals();
+	for ( const editor of SUPPORTED_EDITORS ) {
+		if ( installedApps[ editor ] ) {
+			return editor;
+		}
+	}
+
+	return null;
+};
 
 export const installedAppsApi = createApi( {
 	reducerPath: 'installedAppsApi',
@@ -29,17 +41,10 @@ export const installedAppsApi = createApi( {
 				}
 
 				// If no user preference is set, check for installed editors
-				// and set the default to the first one found
-				// This is a fallback to ensure we keep existing behavior
-				const installedEditors = await getIpcApi().getInstalledAppsAndTerminals();
-				if ( installedEditors.vscode ) {
-					return { data: 'vscode' };
-				} else if ( installedEditors.phpstorm ) {
-					return { data: 'phpstorm' };
-				}
+				// and set the default to the first one found in priority order
+				const defaultEditor = await getFirstInstalledEditor();
 
-				// If no user preference is set, return null
-				return { data: null };
+				return { data: defaultEditor };
 			},
 			providesTags: [ 'UserPreferences' ],
 		} ),

--- a/src/stores/installed-apps-api.ts
+++ b/src/stores/installed-apps-api.ts
@@ -55,17 +55,17 @@ export const installedAppsApi = createApi( {
 			},
 			providesTags: [ 'UserPreferences' ],
 		} ),
-		saveUserEditor: builder.mutation< void, SupportedEditor >( {
+		saveUserEditor: builder.mutation< SupportedEditor, SupportedEditor >( {
 			queryFn: async ( editor ) => {
 				await getIpcApi().saveUserEditor( editor );
-				return { data: undefined };
+				return { data: editor };
 			},
 			invalidatesTags: [ 'UserPreferences' ],
 		} ),
-		saveUserTerminal: builder.mutation< void, SupportedTerminal >( {
+		saveUserTerminal: builder.mutation< SupportedTerminal, SupportedTerminal >( {
 			queryFn: async ( terminal ) => {
 				await getIpcApi().saveUserTerminal( terminal );
-				return { data: undefined };
+				return { data: terminal };
 			},
 			invalidatesTags: [ 'UserPreferences' ],
 		} ),

--- a/src/stores/tests/installed-apps-api.test.ts
+++ b/src/stores/tests/installed-apps-api.test.ts
@@ -160,15 +160,14 @@ describe( 'Installed Apps API', () => {
 		it( 'should save user editor preference', async () => {
 			mockIpcApi.saveUserEditor.mockResolvedValueOnce( undefined );
 
-			const editorToSave: SupportedEditor = 'cursor';
 			const store = createTestStore();
 			const result = await store.dispatch(
-				installedAppsApi.endpoints.saveUserEditor.initiate( editorToSave )
+				installedAppsApi.endpoints.saveUserEditor.initiate( 'cursor' )
 			);
 
 			expect( mockIpcApi.saveUserEditor ).toHaveBeenCalledTimes( 1 );
-			expect( mockIpcApi.saveUserEditor ).toHaveBeenCalledWith( editorToSave );
-			expect( result.data ).toBe( undefined );
+			expect( mockIpcApi.saveUserEditor ).toHaveBeenCalledWith( 'cursor' );
+			expect( result.data ).toBe( 'cursor' );
 		} );
 	} );
 
@@ -176,15 +175,14 @@ describe( 'Installed Apps API', () => {
 		it( 'should save user terminal preference', async () => {
 			mockIpcApi.saveUserTerminal.mockResolvedValueOnce( undefined );
 
-			const terminalToSave: SupportedTerminal = 'warp';
 			const store = createTestStore();
 			const result = await store.dispatch(
-				installedAppsApi.endpoints.saveUserTerminal.initiate( terminalToSave )
+				installedAppsApi.endpoints.saveUserTerminal.initiate( 'warp' )
 			);
 
 			expect( mockIpcApi.saveUserTerminal ).toHaveBeenCalledTimes( 1 );
-			expect( mockIpcApi.saveUserTerminal ).toHaveBeenCalledWith( terminalToSave );
-			expect( result.data ).toBe( undefined );
+			expect( mockIpcApi.saveUserTerminal ).toHaveBeenCalledWith( 'warp' );
+			expect( result.data ).toBe( 'warp' );
 		} );
 	} );
 

--- a/src/stores/tests/installed-apps-api.test.ts
+++ b/src/stores/tests/installed-apps-api.test.ts
@@ -1,0 +1,258 @@
+import { configureStore } from '@reduxjs/toolkit';
+import { getIpcApi } from 'src/lib/get-ipc-api';
+import { SupportedEditor } from 'src/modules/user-settings/lib/editor';
+import { SupportedTerminal } from 'src/modules/user-settings/lib/terminal';
+import {
+	installedAppsApi,
+	selectInstalledEditors,
+	selectUninstalledEditors,
+	selectInstalledTerminals,
+	selectUninstalledTerminals,
+} from 'src/stores/installed-apps-api';
+
+jest.mock( 'src/lib/get-ipc-api', () => ( {
+	getIpcApi: jest.fn(),
+} ) );
+
+const mockIpcApi = {
+	getInstalledAppsAndTerminals: jest.fn(),
+	getUserEditor: jest.fn(),
+	getUserTerminal: jest.fn(),
+	saveUserEditor: jest.fn(),
+	saveUserTerminal: jest.fn(),
+};
+
+( getIpcApi as jest.Mock ).mockReturnValue( mockIpcApi );
+
+const createTestStore = () => {
+	return configureStore( {
+		reducer: {
+			[ installedAppsApi.reducerPath ]: installedAppsApi.reducer,
+		},
+		middleware: ( getDefaultMiddleware ) =>
+			getDefaultMiddleware().concat( installedAppsApi.middleware ),
+	} );
+};
+
+const createMockInstalledApps = (
+	installedApps: Partial< InstalledApps > = {}
+): InstalledApps => ( {
+	vscode: false,
+	phpstorm: false,
+	webstorm: false,
+	windsurf: false,
+	cursor: false,
+	terminal: false,
+	iterm: false,
+	warp: false,
+	ghostty: false,
+	...installedApps,
+} );
+
+describe( 'Installed Apps API', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	describe( 'getInstalledApps', () => {
+		it( 'should fetch installed apps and terminals', async () => {
+			const mockInstalledApps = createMockInstalledApps( { vscode: true, cursor: true } );
+			mockIpcApi.getInstalledAppsAndTerminals.mockResolvedValueOnce( mockInstalledApps );
+
+			const store = createTestStore();
+			const result = await store.dispatch(
+				installedAppsApi.endpoints.getInstalledApps.initiate( undefined )
+			);
+
+			expect( mockIpcApi.getInstalledAppsAndTerminals ).toHaveBeenCalledTimes( 1 );
+			expect( result.data ).toEqual( mockInstalledApps );
+		} );
+	} );
+
+	describe( 'getUserEditor', () => {
+		it( 'should return user preference when set', async () => {
+			mockIpcApi.getUserEditor.mockResolvedValueOnce( 'windsurf' );
+
+			const store = createTestStore();
+			const result = await store.dispatch(
+				installedAppsApi.endpoints.getUserEditor.initiate( undefined )
+			);
+
+			expect( mockIpcApi.getUserEditor ).toHaveBeenCalledTimes( 1 );
+			expect( mockIpcApi.getInstalledAppsAndTerminals ).not.toHaveBeenCalled();
+			expect( result.data ).toBe( 'windsurf' );
+		} );
+
+		it( 'should respect priority order when multiple editors are installed', async () => {
+			mockIpcApi.getUserEditor.mockResolvedValueOnce( null );
+			const mockInstalledApps = createMockInstalledApps( {
+				webstorm: true,
+				phpstorm: true,
+				windsurf: true,
+				cursor: true,
+			} );
+			mockIpcApi.getInstalledAppsAndTerminals.mockResolvedValueOnce( mockInstalledApps );
+
+			const store = createTestStore();
+			const result = await store.dispatch(
+				installedAppsApi.endpoints.getUserEditor.initiate( undefined )
+			);
+
+			// Should return cursor since it has the highest priority
+			expect( result.data ).toBe( 'cursor' );
+		} );
+
+		it( 'should return the installed editor when no preference is set and only one editor is installed', async () => {
+			mockIpcApi.getUserEditor.mockResolvedValueOnce( null );
+			const mockInstalledApps = createMockInstalledApps( { cursor: true } );
+			mockIpcApi.getInstalledAppsAndTerminals.mockResolvedValueOnce( mockInstalledApps );
+
+			const store = createTestStore();
+			const result = await store.dispatch(
+				installedAppsApi.endpoints.getUserEditor.initiate( undefined )
+			);
+
+			expect( result.data ).toBe( 'cursor' );
+		} );
+
+		it( 'should return phpstorm when cursor and vscode are not installed but phpstorm is', async () => {
+			mockIpcApi.getUserEditor.mockResolvedValueOnce( null );
+			const mockInstalledApps = createMockInstalledApps( { phpstorm: true, webstorm: true } );
+			mockIpcApi.getInstalledAppsAndTerminals.mockResolvedValueOnce( mockInstalledApps );
+
+			const store = createTestStore();
+			const result = await store.dispatch(
+				installedAppsApi.endpoints.getUserEditor.initiate( undefined )
+			);
+
+			expect( result.data ).toBe( 'phpstorm' );
+		} );
+
+		it( 'should return null when no preference set and no editors are installed', async () => {
+			mockIpcApi.getUserEditor.mockResolvedValueOnce( null );
+			const mockInstalledApps = createMockInstalledApps();
+			mockIpcApi.getInstalledAppsAndTerminals.mockResolvedValueOnce( mockInstalledApps );
+
+			const store = createTestStore();
+			const result = await store.dispatch(
+				installedAppsApi.endpoints.getUserEditor.initiate( undefined )
+			);
+
+			expect( result.data ).toBe( null );
+		} );
+	} );
+
+	describe( 'getUserTerminal', () => {
+		it( 'should fetch user terminal preference', async () => {
+			mockIpcApi.getUserTerminal.mockResolvedValueOnce( 'iterm' );
+
+			const store = createTestStore();
+			const result = await store.dispatch(
+				installedAppsApi.endpoints.getUserTerminal.initiate( undefined )
+			);
+
+			expect( mockIpcApi.getUserTerminal ).toHaveBeenCalledTimes( 1 );
+			expect( result.data ).toBe( 'iterm' );
+		} );
+	} );
+
+	describe( 'saveUserEditor', () => {
+		it( 'should save user editor preference', async () => {
+			mockIpcApi.saveUserEditor.mockResolvedValueOnce( undefined );
+
+			const editorToSave: SupportedEditor = 'cursor';
+			const store = createTestStore();
+			const result = await store.dispatch(
+				installedAppsApi.endpoints.saveUserEditor.initiate( editorToSave )
+			);
+
+			expect( mockIpcApi.saveUserEditor ).toHaveBeenCalledTimes( 1 );
+			expect( mockIpcApi.saveUserEditor ).toHaveBeenCalledWith( editorToSave );
+			expect( result.data ).toBe( undefined );
+		} );
+	} );
+
+	describe( 'saveUserTerminal', () => {
+		it( 'should save user terminal preference', async () => {
+			mockIpcApi.saveUserTerminal.mockResolvedValueOnce( undefined );
+
+			const terminalToSave: SupportedTerminal = 'warp';
+			const store = createTestStore();
+			const result = await store.dispatch(
+				installedAppsApi.endpoints.saveUserTerminal.initiate( terminalToSave )
+			);
+
+			expect( mockIpcApi.saveUserTerminal ).toHaveBeenCalledTimes( 1 );
+			expect( mockIpcApi.saveUserTerminal ).toHaveBeenCalledWith( terminalToSave );
+			expect( result.data ).toBe( undefined );
+		} );
+	} );
+
+	describe( 'selectors', () => {
+		describe( 'selectInstalledEditors', () => {
+			it( 'should return only installed editors', () => {
+				const mockInstalledApps = createMockInstalledApps( {
+					vscode: true,
+					cursor: true,
+					windsurf: true,
+				} );
+				const result = selectInstalledEditors( mockInstalledApps );
+
+				expect( result ).toHaveLength( 3 );
+				expect( result.map( ( [ editor ] ) => editor ) ).toEqual(
+					expect.arrayContaining( [ 'vscode', 'cursor', 'windsurf' ] )
+				);
+			} );
+
+			it( 'should return empty array when no editors are installed', () => {
+				const mockInstalledApps = createMockInstalledApps();
+				const result = selectInstalledEditors( mockInstalledApps );
+
+				expect( result ).toHaveLength( 0 );
+			} );
+		} );
+
+		describe( 'selectUninstalledEditors', () => {
+			it( 'should return only uninstalled editors', () => {
+				const mockInstalledApps = createMockInstalledApps( { vscode: true, cursor: true } );
+				const result = selectUninstalledEditors( mockInstalledApps );
+
+				expect( result ).toHaveLength( 3 );
+				expect( result.map( ( [ editor ] ) => editor ) ).toEqual(
+					expect.arrayContaining( [ 'phpstorm', 'windsurf', 'webstorm' ] )
+				);
+			} );
+
+			it( 'should return all editors when none are installed', () => {
+				const mockInstalledApps = createMockInstalledApps();
+				const result = selectUninstalledEditors( mockInstalledApps );
+
+				expect( result ).toHaveLength( 5 );
+			} );
+		} );
+
+		describe( 'selectInstalledTerminals', () => {
+			it( 'should return only installed terminals', () => {
+				const mockInstalledApps = createMockInstalledApps( { terminal: true, iterm: true } );
+				const result = selectInstalledTerminals( mockInstalledApps );
+
+				expect( result ).toHaveLength( 2 );
+				expect( result.map( ( [ terminal ] ) => terminal ) ).toEqual(
+					expect.arrayContaining( [ 'terminal', 'iterm' ] )
+				);
+			} );
+		} );
+
+		describe( 'selectUninstalledTerminals', () => {
+			it( 'should return only uninstalled terminals', () => {
+				const mockInstalledApps = createMockInstalledApps( { terminal: true, iterm: true } );
+				const result = selectUninstalledTerminals( mockInstalledApps );
+
+				expect( result ).toHaveLength( 2 );
+				expect( result.map( ( [ terminal ] ) => terminal ) ).toEqual(
+					expect.arrayContaining( [ 'warp', 'ghostty' ] )
+				);
+			} );
+		} );
+	} );
+} );

--- a/src/stores/tests/installed-apps-api.test.ts
+++ b/src/stores/tests/installed-apps-api.test.ts
@@ -1,7 +1,5 @@
 import { configureStore } from '@reduxjs/toolkit';
 import { getIpcApi } from 'src/lib/get-ipc-api';
-import { SupportedEditor } from 'src/modules/user-settings/lib/editor';
-import { SupportedTerminal } from 'src/modules/user-settings/lib/terminal';
 import {
 	installedAppsApi,
 	selectInstalledEditors,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-538

## Proposed Changes

- Fixed a bug where Cursor, Windsurf, and Webstorm were not returned when they were installed and no preferred editor was set.
- Increase priority of Cursor over VSCode
- Return a value when saving preferences instead of undefined.

When I added tests for `useGetUserEditorQuery`, I got these errors in the console. I didn't observe these errors in either the frontend or backend, but I think it's worth fixing them.
```
 console.error
    Error encountered handling the endpoint saveUserEditor.
                      `queryFn` returned an object containing neither a valid `error` and `result`. At least one of them should not be `undefined`
                      It needs to return an object with either the shape `{ data: <value> }` or `{ error: <value> }` that may contain an optional `meta` property.
                      Object returned was: { data: undefined }

      at executeRequest (node_modules/@reduxjs/toolkit/src/query/core/buildThunks.ts:330:21)
      at executeEndpoint (node_modules/@reduxjs/toolkit/src/query/core/buildThunks.ts:421:33)
      at node_modules/@reduxjs/toolkit/src/createAsyncThunk.ts:361:27

  console.error
    Error encountered handling the endpoint saveUserTerminal.
                      `queryFn` returned an object containing neither a valid `error` and `result`. At least one of them should not be `undefined`
                      It needs to return an object with either the shape `{ data: <value> }` or `{ error: <value> }` that may contain an optional `meta` property.
                      Object returned was: { data: undefined }

      at executeRequest (node_modules/@reduxjs/toolkit/src/query/core/buildThunks.ts:330:21)
      at executeEndpoint (node_modules/@reduxjs/toolkit/src/query/core/buildThunks.ts:421:33)
      at node_modules/@reduxjs/toolkit/src/createAsyncThunk.ts:361:27
```

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Install Cursor
* Remove other compatible IDEs
* Make sure you don't have a preferredEditor on appdata.
* Start Studio
* Run `npm start`
* Observe that the Cursor button appears on Studio. The same behavior will also work for any editor.


https://github.com/user-attachments/assets/907cbe30-a762-4086-bd19-ef7ab693bbd4




## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
