### PR TITLE
Upgrade @automattic/wp-babel-makepot to latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -363,9 +363,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@babel/cli": {
-			"version": "7.27.0",
-			"resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.27.0.tgz",
-			"integrity": "sha512-bZfxn8DRxwiVzDO5CEeV+7IqXeCkzI4yYnrQbpwjT76CUyossQc6RYE7n+xfm0/2k40lPaCpW0FhxYs7EBAetw==",
+			"version": "7.27.2",
+			"resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.27.2.tgz",
+			"integrity": "sha512-cfd7DnGlhH6OIyuPSSj3vcfIdnbXukhAyKY8NaZrFadC7pXyL9mOL5WgjcptiEJLi5k3j8aYvLIVCzezrWTaiA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -447,23 +447,23 @@
 			}
 		},
 		"node_modules/@babel/code-frame": {
-			"version": "7.26.2",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
-			"integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+			"integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.25.9",
+				"@babel/helper-validator-identifier": "^7.27.1",
 				"js-tokens": "^4.0.0",
-				"picocolors": "^1.0.0"
+				"picocolors": "^1.1.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/compat-data": {
-			"version": "7.26.8",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.8.tgz",
-			"integrity": "sha512-oH5UPLMWR3L2wEFLnFJ1TZXqHufiTKAiLfqw5zkhS4dKXLJ10yVztfil/twG8EDTA4F/tvVNw9nOl4ZMslB8rQ==",
+			"version": "7.27.5",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.27.5.tgz",
+			"integrity": "sha512-KiRAp/VoJaWkkte84TvUd9qjdbZAdiqyvMxrGl1N6vzFogKmaLgoM3L1kgtLicp2HP5fBJS8JrZKLVIZGVJAVg==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
@@ -508,13 +508,13 @@
 			}
 		},
 		"node_modules/@babel/generator": {
-			"version": "7.27.0",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.27.0.tgz",
-			"integrity": "sha512-VybsKvpiN1gU1sdMZIp7FcqphVVKEwcuj02x73uvcHE0PTihx1nlBcowYWhDwjpoAXRv43+gDzyggGnn1XZhVw==",
+			"version": "7.27.5",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.27.5.tgz",
+			"integrity": "sha512-ZGhA37l0e/g2s1Cnzdix0O3aLYm66eF8aufiVteOgnwxgnRP8GoyMj7VWsgWnQbVKXyge7hqrFh2K2TQM6t1Hw==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/parser": "^7.27.0",
-				"@babel/types": "^7.27.0",
+				"@babel/parser": "^7.27.5",
+				"@babel/types": "^7.27.3",
 				"@jridgewell/gen-mapping": "^0.3.5",
 				"@jridgewell/trace-mapping": "^0.3.25",
 				"jsesc": "^3.0.2"
@@ -524,26 +524,26 @@
 			}
 		},
 		"node_modules/@babel/helper-annotate-as-pure": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.25.9.tgz",
-			"integrity": "sha512-gv7320KBUFJz1RnylIg5WWYPRXKZ884AGkYpgpWW02TH66Dl+HaC1t1CKd0z3R4b6hdYEcmrNZHUmfCP+1u3/g==",
+			"version": "7.27.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.27.3.tgz",
+			"integrity": "sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/types": "^7.25.9"
+				"@babel/types": "^7.27.3"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-compilation-targets": {
-			"version": "7.27.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.0.tgz",
-			"integrity": "sha512-LVk7fbXml0H2xH34dFzKQ7TDZ2G4/rVTOrq9V+icbbadjbVxxeFeDsNHv2SrZeWoA+6ZiTyWYWtScEIW07EAcA==",
+			"version": "7.27.2",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
+			"integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/compat-data": "^7.26.8",
-				"@babel/helper-validator-option": "^7.25.9",
+				"@babel/compat-data": "^7.27.2",
+				"@babel/helper-validator-option": "^7.27.1",
 				"browserslist": "^4.24.0",
 				"lru-cache": "^5.1.1",
 				"semver": "^6.3.1"
@@ -561,18 +561,18 @@
 			}
 		},
 		"node_modules/@babel/helper-create-class-features-plugin": {
-			"version": "7.27.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.27.0.tgz",
-			"integrity": "sha512-vSGCvMecvFCd/BdpGlhpXYNhhC4ccxyvQWpbGL4CWbvfEoLFWUZuSuf7s9Aw70flgQF+6vptvgK2IfOnKlRmBg==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.27.1.tgz",
+			"integrity": "sha512-QwGAmuvM17btKU5VqXfb+Giw4JcN0hjuufz3DYnpeVDvZLAObloM77bhMXiqry3Iio+Ai4phVRDwl6WU10+r5A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-annotate-as-pure": "^7.25.9",
-				"@babel/helper-member-expression-to-functions": "^7.25.9",
-				"@babel/helper-optimise-call-expression": "^7.25.9",
-				"@babel/helper-replace-supers": "^7.26.5",
-				"@babel/helper-skip-transparent-expression-wrappers": "^7.25.9",
-				"@babel/traverse": "^7.27.0",
+				"@babel/helper-annotate-as-pure": "^7.27.1",
+				"@babel/helper-member-expression-to-functions": "^7.27.1",
+				"@babel/helper-optimise-call-expression": "^7.27.1",
+				"@babel/helper-replace-supers": "^7.27.1",
+				"@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
+				"@babel/traverse": "^7.27.1",
 				"semver": "^6.3.1"
 			},
 			"engines": {
@@ -593,13 +593,13 @@
 			}
 		},
 		"node_modules/@babel/helper-create-regexp-features-plugin": {
-			"version": "7.27.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.27.0.tgz",
-			"integrity": "sha512-fO8l08T76v48BhpNRW/nQ0MxfnSdoSKUJBMjubOAYffsVuGG5qOfMq7N6Es7UJvi7Y8goXXo07EfcHZXDPuELQ==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.27.1.tgz",
+			"integrity": "sha512-uVDC72XVf8UbrH5qQTc18Agb8emwjTiZrQE11Nv3CuBEZmVvTwwE9CBUEvHku06gQCAyYf8Nv6ja1IN+6LMbxQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-annotate-as-pure": "^7.25.9",
+				"@babel/helper-annotate-as-pure": "^7.27.1",
 				"regexpu-core": "^6.2.0",
 				"semver": "^6.3.1"
 			},
@@ -638,41 +638,41 @@
 			}
 		},
 		"node_modules/@babel/helper-member-expression-to-functions": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.25.9.tgz",
-			"integrity": "sha512-wbfdZ9w5vk0C0oyHqAJbc62+vet5prjj01jjJ8sKn3j9h3MQQlflEdXYvuqRWjHnM12coDEqiC1IRCi0U/EKwQ==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.27.1.tgz",
+			"integrity": "sha512-E5chM8eWjTp/aNoVpcbfM7mLxu9XGLWYise2eBKGQomAk/Mb4XoxyqXTZbuTohbsl8EKqdlMhnDI2CCLfcs9wA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/traverse": "^7.25.9",
-				"@babel/types": "^7.25.9"
+				"@babel/traverse": "^7.27.1",
+				"@babel/types": "^7.27.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-module-imports": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.25.9.tgz",
-			"integrity": "sha512-tnUA4RsrmflIM6W6RFTLFSXITtl0wKjgpnLgXyowocVPrbYrLUXSBXDgTs8BlbmIzIdlBySRQjINYs2BAkiLtw==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
+			"integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/traverse": "^7.25.9",
-				"@babel/types": "^7.25.9"
+				"@babel/traverse": "^7.27.1",
+				"@babel/types": "^7.27.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-module-transforms": {
-			"version": "7.26.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.26.0.tgz",
-			"integrity": "sha512-xO+xu6B5K2czEnQye6BHA7DolFFmS3LB7stHZFaOLb1pAwO1HWLS8fXA+eh0A2yIvltPVmx3eNNDBJA2SLHXFw==",
+			"version": "7.27.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.27.3.tgz",
+			"integrity": "sha512-dSOvYwvyLsWBeIRyOeHXp5vPj5l1I011r52FM1+r1jCERv+aFXYk4whgQccYEGYxK2H3ZAIA8nuPkQ0HaUo3qg==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-module-imports": "^7.25.9",
-				"@babel/helper-validator-identifier": "^7.25.9",
-				"@babel/traverse": "^7.25.9"
+				"@babel/helper-module-imports": "^7.27.1",
+				"@babel/helper-validator-identifier": "^7.27.1",
+				"@babel/traverse": "^7.27.3"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -682,22 +682,22 @@
 			}
 		},
 		"node_modules/@babel/helper-optimise-call-expression": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.25.9.tgz",
-			"integrity": "sha512-FIpuNaz5ow8VyrYcnXQTDRGvV6tTjkNtCK/RYNDXGSLlUD6cBuQTSw43CShGxjvfBTfcUA/r6UhUCbtYqkhcuQ==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.27.1.tgz",
+			"integrity": "sha512-URMGH08NzYFhubNSGJrpUEphGKQwMQYBySzat5cAByY1/YgIRkULnIy3tAMeszlL/so2HbeilYloUmSpd7GdVw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/types": "^7.25.9"
+				"@babel/types": "^7.27.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-plugin-utils": {
-			"version": "7.26.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.26.5.tgz",
-			"integrity": "sha512-RS+jZcRdZdRFzMyr+wcsaqOmld1/EqTghfaBGQQd/WnRdzdlvSZ//kF7U8VQTxf1ynZ4cjUcYgjVGx13ewNPMg==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz",
+			"integrity": "sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -705,15 +705,15 @@
 			}
 		},
 		"node_modules/@babel/helper-remap-async-to-generator": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.25.9.tgz",
-			"integrity": "sha512-IZtukuUeBbhgOcaW2s06OXTzVNJR0ybm4W5xC1opWFFJMZbwRj5LCk+ByYH7WdZPZTt8KnFwA8pvjN2yqcPlgw==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.27.1.tgz",
+			"integrity": "sha512-7fiA521aVw8lSPeI4ZOD3vRFkoqkJcS+z4hFo82bFSH/2tNd6eJ5qCVMS5OzDmZh/kaHQeBaeyxK6wljcPtveA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-annotate-as-pure": "^7.25.9",
-				"@babel/helper-wrap-function": "^7.25.9",
-				"@babel/traverse": "^7.25.9"
+				"@babel/helper-annotate-as-pure": "^7.27.1",
+				"@babel/helper-wrap-function": "^7.27.1",
+				"@babel/traverse": "^7.27.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -723,15 +723,15 @@
 			}
 		},
 		"node_modules/@babel/helper-replace-supers": {
-			"version": "7.26.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.26.5.tgz",
-			"integrity": "sha512-bJ6iIVdYX1YooY2X7w1q6VITt+LnUILtNk7zT78ykuwStx8BauCzxvFqFaHjOpW1bVnSUM1PN1f0p5P21wHxvg==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.27.1.tgz",
+			"integrity": "sha512-7EHz6qDZc8RYS5ElPoShMheWvEgERonFCs7IAonWLLUTXW59DP14bCZt89/GKyreYn8g3S83m21FelHKbeDCKA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-member-expression-to-functions": "^7.25.9",
-				"@babel/helper-optimise-call-expression": "^7.25.9",
-				"@babel/traverse": "^7.26.5"
+				"@babel/helper-member-expression-to-functions": "^7.27.1",
+				"@babel/helper-optimise-call-expression": "^7.27.1",
+				"@babel/traverse": "^7.27.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -741,56 +741,56 @@
 			}
 		},
 		"node_modules/@babel/helper-skip-transparent-expression-wrappers": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.25.9.tgz",
-			"integrity": "sha512-K4Du3BFa3gvyhzgPcntrkDgZzQaq6uozzcpGbOO1OEJaI+EJdqWIMTLgFgQf6lrfiDFo5FU+BxKepI9RmZqahA==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.27.1.tgz",
+			"integrity": "sha512-Tub4ZKEXqbPjXgWLl2+3JpQAYBJ8+ikpQ2Ocj/q/r0LwE3UhENh7EUabyHjz2kCEsrRY83ew2DQdHluuiDQFzg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/traverse": "^7.25.9",
-				"@babel/types": "^7.25.9"
+				"@babel/traverse": "^7.27.1",
+				"@babel/types": "^7.27.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-string-parser": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
-			"integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+			"integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-validator-identifier": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
-			"integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+			"integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-validator-option": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.25.9.tgz",
-			"integrity": "sha512-e/zv1co8pp55dNdEcCynfj9X7nyUKUXoUEwfXqaZt0omVOmDe9oOTdKStH4GmAw6zxMFs50ZayuMfHDKlO7Tfw==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+			"integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-wrap-function": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.25.9.tgz",
-			"integrity": "sha512-ETzz9UTjQSTmw39GboatdymDq4XIQbR8ySgVrylRhPOFpsd+JrKHIuF0de7GCWmem+T4uC5z7EZguod7Wj4A4g==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.27.1.tgz",
+			"integrity": "sha512-NFJK2sHUvrjo8wAU/nQTWU890/zB2jj0qBcCbZbbf+005cAsv6tMjXz31fBign6M5ov1o0Bllu+9nbqkfsjjJQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/template": "^7.25.9",
-				"@babel/traverse": "^7.25.9",
-				"@babel/types": "^7.25.9"
+				"@babel/template": "^7.27.1",
+				"@babel/traverse": "^7.27.1",
+				"@babel/types": "^7.27.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -810,12 +810,12 @@
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.27.0",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.0.tgz",
-			"integrity": "sha512-iaepho73/2Pz7w2eMS0Q5f83+0RKI7i4xmiYeBmDzfRVbQtTOG7Ts0S4HzJVsTMGI9keU8rNfuZr8DKfSt7Yyg==",
+			"version": "7.27.5",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.5.tgz",
+			"integrity": "sha512-OsQd175SxWkGlzbny8J3K8TnnDD0N3lrIUtB92xwyRpzaenGZhxDvxN/JgU00U3CDZNj9tPuDJ5H0WS4Nt3vKg==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/types": "^7.27.0"
+				"@babel/types": "^7.27.3"
 			},
 			"bin": {
 				"parser": "bin/babel-parser.js"
@@ -825,14 +825,14 @@
 			}
 		},
 		"node_modules/@babel/plugin-bugfix-firefox-class-in-computed-class-key": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-7.25.9.tgz",
-			"integrity": "sha512-ZkRyVkThtxQ/J6nv3JFYv1RYY+JT5BvU0y3k5bWrmuG4woXypRa4PXmm9RhOwodRkYFWqC0C0cqcJ4OqR7kW+g==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-7.27.1.tgz",
+			"integrity": "sha512-QPG3C9cCVRQLxAVwmefEmwdTanECuUBMQZ/ym5kiw3XKCGA7qkuQLcjWWHcrD/GKbn/WmJwaezfuuAOcyKlRPA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.9",
-				"@babel/traverse": "^7.25.9"
+				"@babel/helper-plugin-utils": "^7.27.1",
+				"@babel/traverse": "^7.27.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -842,13 +842,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-bugfix-safari-class-field-initializer-scope": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-class-field-initializer-scope/-/plugin-bugfix-safari-class-field-initializer-scope-7.25.9.tgz",
-			"integrity": "sha512-MrGRLZxLD/Zjj0gdU15dfs+HH/OXvnw/U4jJD8vpcP2CJQapPEv1IWwjc/qMg7ItBlPwSv1hRBbb7LeuANdcnw==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-class-field-initializer-scope/-/plugin-bugfix-safari-class-field-initializer-scope-7.27.1.tgz",
+			"integrity": "sha512-qNeq3bCKnGgLkEXUuFry6dPlGfCdQNZbn7yUAPCInwAJHMU7THJfrBSozkcWq5sNM6RcF3S8XyQL2A52KNR9IA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.9"
+				"@babel/helper-plugin-utils": "^7.27.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -858,13 +858,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.25.9.tgz",
-			"integrity": "sha512-2qUwwfAFpJLZqxd02YW9btUCZHl+RFvdDkNfZwaIJrvB8Tesjsk8pEQkTvGwZXLqXUx/2oyY3ySRhm6HOXuCug==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.27.1.tgz",
+			"integrity": "sha512-g4L7OYun04N1WyqMNjldFwlfPCLVkgB54A/YCXICZYBsvJJE3kByKv9c9+R/nAfmIfjl2rKYLNyMHboYbZaWaA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.9"
+				"@babel/helper-plugin-utils": "^7.27.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -874,15 +874,15 @@
 			}
 		},
 		"node_modules/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.25.9.tgz",
-			"integrity": "sha512-6xWgLZTJXwilVjlnV7ospI3xi+sl8lN8rXXbBD6vYn3UYDlGsag8wrZkKcSI8G6KgqKP7vNFaDgeDnfAABq61g==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.27.1.tgz",
+			"integrity": "sha512-oO02gcONcD5O1iTLi/6frMJBIwWEHceWGSGqrpCmEL8nogiS6J9PBlE48CaK20/Jx1LuRml9aDftLgdjXT8+Cw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.9",
-				"@babel/helper-skip-transparent-expression-wrappers": "^7.25.9",
-				"@babel/plugin-transform-optional-chaining": "^7.25.9"
+				"@babel/helper-plugin-utils": "^7.27.1",
+				"@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
+				"@babel/plugin-transform-optional-chaining": "^7.27.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -892,14 +892,14 @@
 			}
 		},
 		"node_modules/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.25.9.tgz",
-			"integrity": "sha512-aLnMXYPnzwwqhYSCyXfKkIkYgJ8zv9RK+roo9DkTXz38ynIhd9XCbN08s3MGvqL2MYGVUGdRQLL/JqBIeJhJBg==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.27.1.tgz",
+			"integrity": "sha512-6BpaYGDavZqkI6yT+KSPdpZFfpnd68UKXbcjI9pJ13pvHhPrCKWOOLp+ysvMeA+DxnhuPpgIaRpxRxo5A9t5jw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.9",
-				"@babel/traverse": "^7.25.9"
+				"@babel/helper-plugin-utils": "^7.27.1",
+				"@babel/traverse": "^7.27.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -909,15 +909,15 @@
 			}
 		},
 		"node_modules/@babel/plugin-proposal-decorators": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.25.9.tgz",
-			"integrity": "sha512-smkNLL/O1ezy9Nhy4CNosc4Va+1wo5w4gzSZeLe6y6dM4mmHfYOCPolXQPHQxonZCF+ZyebxN9vqOolkYrSn5g==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.27.1.tgz",
+			"integrity": "sha512-DTxe4LBPrtFdsWzgpmbBKevg3e9PBy+dXRt19kSbucbZvL2uqtdqwwpluL1jfxYE0wIDTFp1nTy/q6gNLsxXrg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-create-class-features-plugin": "^7.25.9",
-				"@babel/helper-plugin-utils": "^7.25.9",
-				"@babel/plugin-syntax-decorators": "^7.25.9"
+				"@babel/helper-create-class-features-plugin": "^7.27.1",
+				"@babel/helper-plugin-utils": "^7.27.1",
+				"@babel/plugin-syntax-decorators": "^7.27.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -976,13 +976,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-syntax-decorators": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.25.9.tgz",
-			"integrity": "sha512-ryzI0McXUPJnRCvMo4lumIKZUzhYUO/ScI+Mz4YVaTLt04DHNSjEUjKVvbzQjZFLuod/cYEc07mJWhzl6v4DPg==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.27.1.tgz",
+			"integrity": "sha512-YMq8Z87Lhl8EGkmb0MwYkt36QnxC+fzCgrl66ereamPlYToRpIk5nUjKUY3QKLWq8mwUB1BgbeXcTJhZOCDg5A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.9"
+				"@babel/helper-plugin-utils": "^7.27.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -992,13 +992,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-syntax-import-assertions": {
-			"version": "7.26.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.26.0.tgz",
-			"integrity": "sha512-QCWT5Hh830hK5EQa7XzuqIkQU9tT/whqbDz7kuaZMHFl1inRRg7JnuAEOQ0Ur0QUl0NufCk1msK2BeY79Aj/eg==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.27.1.tgz",
+			"integrity": "sha512-UT/Jrhw57xg4ILHLFnzFpPDlMbcdEicaAtjPQpbj9wa8T4r5KVWCimHcL/460g8Ht0DMxDyjsLgiWSkVjnwPFg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.9"
+				"@babel/helper-plugin-utils": "^7.27.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1008,13 +1008,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-syntax-import-attributes": {
-			"version": "7.26.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.26.0.tgz",
-			"integrity": "sha512-e2dttdsJ1ZTpi3B9UYGLw41hifAubg19AtCu/2I/F1QNVclOBr1dYpTdmdyZ84Xiz43BS/tCUkMAZNLv12Pi+A==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.27.1.tgz",
+			"integrity": "sha512-oFT0FrKHgF53f4vOsZGi2Hh3I35PfSmVs4IBFLFj4dnafP+hIWDLg3VyKmUHfLoLHlyxY4C7DGtmHuJgn+IGww==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.9"
+				"@babel/helper-plugin-utils": "^7.27.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1048,13 +1048,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-syntax-jsx": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.25.9.tgz",
-			"integrity": "sha512-ld6oezHQMZsZfp6pWtbjaNDF2tiiCYYDqQszHt5VV437lewP9aSi2Of99CK0D0XB21k7FLgnLcmQKyKzynfeAA==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.27.1.tgz",
+			"integrity": "sha512-y8YTNIeKoyhGd9O0Jiyzyyqk8gdjnumGTQPsz0xOZOQ2RmkVJeZ1vmmfIvFEKqucBG6axJGBZDE/7iI5suUI/w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.9"
+				"@babel/helper-plugin-utils": "^7.27.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1151,13 +1151,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-syntax-typescript": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.25.9.tgz",
-			"integrity": "sha512-hjMgRy5hb8uJJjUcdWunWVcoi9bGpJp8p5Ol1229PoN6aytsLwNMgmdftO23wnCLMfVmTwZDWMPNq/D1SY60JQ==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.27.1.tgz",
+			"integrity": "sha512-xfYCBMxveHrRMnAWl1ZlPXOZjzkN82THFvLhQhFXFt81Z5HnN+EtUkZhv/zcKpmT3fzmWZB0ywiBrbC3vogbwQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.9"
+				"@babel/helper-plugin-utils": "^7.27.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1184,13 +1184,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-arrow-functions": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.25.9.tgz",
-			"integrity": "sha512-6jmooXYIwn9ca5/RylZADJ+EnSxVUS5sjeJ9UPk6RWRzXCmOJCy6dqItPJFpw2cuCangPK4OYr5uhGKcmrm5Qg==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.27.1.tgz",
+			"integrity": "sha512-8Z4TGic6xW70FKThA5HYEKKyBpOOsucTOD1DjU3fZxDg+K3zBJcXMFnt/4yQiZnf5+MiOMSXQ9PaEK/Ilh1DeA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.9"
+				"@babel/helper-plugin-utils": "^7.27.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1200,15 +1200,15 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-async-generator-functions": {
-			"version": "7.26.8",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.26.8.tgz",
-			"integrity": "sha512-He9Ej2X7tNf2zdKMAGOsmg2MrFc+hfoAhd3po4cWfo/NWjzEAKa0oQruj1ROVUdl0e6fb6/kE/G3SSxE0lRJOg==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.27.1.tgz",
+			"integrity": "sha512-eST9RrwlpaoJBDHShc+DS2SG4ATTi2MYNb4OxYkf3n+7eb49LWpnS+HSpVfW4x927qQwgk8A2hGNVaajAEw0EA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.26.5",
-				"@babel/helper-remap-async-to-generator": "^7.25.9",
-				"@babel/traverse": "^7.26.8"
+				"@babel/helper-plugin-utils": "^7.27.1",
+				"@babel/helper-remap-async-to-generator": "^7.27.1",
+				"@babel/traverse": "^7.27.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1218,15 +1218,15 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-async-to-generator": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.25.9.tgz",
-			"integrity": "sha512-NT7Ejn7Z/LjUH0Gv5KsBCxh7BH3fbLTV0ptHvpeMvrt3cPThHfJfst9Wrb7S8EvJ7vRTFI7z+VAvFVEQn/m5zQ==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.27.1.tgz",
+			"integrity": "sha512-NREkZsZVJS4xmTr8qzE5y8AfIPqsdQfRuUiLRTEzb7Qii8iFWCyDKaUV2c0rCuh4ljDZ98ALHP/PetiBV2nddA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-module-imports": "^7.25.9",
-				"@babel/helper-plugin-utils": "^7.25.9",
-				"@babel/helper-remap-async-to-generator": "^7.25.9"
+				"@babel/helper-module-imports": "^7.27.1",
+				"@babel/helper-plugin-utils": "^7.27.1",
+				"@babel/helper-remap-async-to-generator": "^7.27.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1236,13 +1236,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-block-scoped-functions": {
-			"version": "7.26.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.26.5.tgz",
-			"integrity": "sha512-chuTSY+hq09+/f5lMj8ZSYgCFpppV2CbYrhNFJ1BFoXpiWPnnAb7R0MqrafCpN8E1+YRrtM1MXZHJdIx8B6rMQ==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.27.1.tgz",
+			"integrity": "sha512-cnqkuOtZLapWYZUYM5rVIdv1nXYuFVIltZ6ZJ7nIj585QsjKM5dhL2Fu/lICXZ1OyIAFc7Qy+bvDAtTXqGrlhg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.26.5"
+				"@babel/helper-plugin-utils": "^7.27.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1252,13 +1252,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-block-scoping": {
-			"version": "7.27.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.27.0.tgz",
-			"integrity": "sha512-u1jGphZ8uDI2Pj/HJj6YQ6XQLZCNjOlprjxB5SVz6rq2T6SwAR+CdrWK0CP7F+9rDVMXdB0+r6Am5G5aobOjAQ==",
+			"version": "7.27.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.27.5.tgz",
+			"integrity": "sha512-JF6uE2s67f0y2RZcm2kpAUEbD50vH62TyWVebxwHAlbSdM49VqPz8t4a1uIjp4NIOIZ4xzLfjY5emt/RCyC7TQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.26.5"
+				"@babel/helper-plugin-utils": "^7.27.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1268,14 +1268,14 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-class-properties": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.25.9.tgz",
-			"integrity": "sha512-bbMAII8GRSkcd0h0b4X+36GksxuheLFjP65ul9w6C3KgAamI3JqErNgSrosX6ZPj+Mpim5VvEbawXxJCyEUV3Q==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.27.1.tgz",
+			"integrity": "sha512-D0VcalChDMtuRvJIu3U/fwWjf8ZMykz5iZsg77Nuj821vCKI3zCyRLwRdWbsuJ/uRwZhZ002QtCqIkwC/ZkvbA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-create-class-features-plugin": "^7.25.9",
-				"@babel/helper-plugin-utils": "^7.25.9"
+				"@babel/helper-create-class-features-plugin": "^7.27.1",
+				"@babel/helper-plugin-utils": "^7.27.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1285,14 +1285,14 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-class-static-block": {
-			"version": "7.26.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.26.0.tgz",
-			"integrity": "sha512-6J2APTs7BDDm+UMqP1useWqhcRAXo0WIoVj26N7kPFB6S73Lgvyka4KTZYIxtgYXiN5HTyRObA72N2iu628iTQ==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.27.1.tgz",
+			"integrity": "sha512-s734HmYU78MVzZ++joYM+NkJusItbdRcbm+AGRgJCt3iA+yux0QpD9cBVdz3tKyrjVYWRl7j0mHSmv4lhV0aoA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-create-class-features-plugin": "^7.25.9",
-				"@babel/helper-plugin-utils": "^7.25.9"
+				"@babel/helper-create-class-features-plugin": "^7.27.1",
+				"@babel/helper-plugin-utils": "^7.27.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1302,17 +1302,17 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-classes": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.25.9.tgz",
-			"integrity": "sha512-mD8APIXmseE7oZvZgGABDyM34GUmK45Um2TXiBUt7PnuAxrgoSVf123qUzPxEr/+/BHrRn5NMZCdE2m/1F8DGg==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.27.1.tgz",
+			"integrity": "sha512-7iLhfFAubmpeJe/Wo2TVuDrykh/zlWXLzPNdL0Jqn/Xu8R3QQ8h9ff8FQoISZOsw74/HFqFI7NX63HN7QFIHKA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-annotate-as-pure": "^7.25.9",
-				"@babel/helper-compilation-targets": "^7.25.9",
-				"@babel/helper-plugin-utils": "^7.25.9",
-				"@babel/helper-replace-supers": "^7.25.9",
-				"@babel/traverse": "^7.25.9",
+				"@babel/helper-annotate-as-pure": "^7.27.1",
+				"@babel/helper-compilation-targets": "^7.27.1",
+				"@babel/helper-plugin-utils": "^7.27.1",
+				"@babel/helper-replace-supers": "^7.27.1",
+				"@babel/traverse": "^7.27.1",
 				"globals": "^11.1.0"
 			},
 			"engines": {
@@ -1333,14 +1333,14 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-computed-properties": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.25.9.tgz",
-			"integrity": "sha512-HnBegGqXZR12xbcTHlJ9HGxw1OniltT26J5YpfruGqtUHlz/xKf/G2ak9e+t0rVqrjXa9WOhvYPz1ERfMj23AA==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.27.1.tgz",
+			"integrity": "sha512-lj9PGWvMTVksbWiDT2tW68zGS/cyo4AkZ/QTp0sQT0mjPopCmrSkzxeXkznjqBxzDI6TclZhOJbBmbBLjuOZUw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.9",
-				"@babel/template": "^7.25.9"
+				"@babel/helper-plugin-utils": "^7.27.1",
+				"@babel/template": "^7.27.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1350,13 +1350,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-destructuring": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.25.9.tgz",
-			"integrity": "sha512-WkCGb/3ZxXepmMiX101nnGiU+1CAdut8oHyEOHxkKuS1qKpU2SMXE2uSvfz8PBuLd49V6LEsbtyPhWC7fnkgvQ==",
+			"version": "7.27.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.27.3.tgz",
+			"integrity": "sha512-s4Jrok82JpiaIprtY2nHsYmrThKvvwgHwjgd7UMiYhZaN0asdXNLr0y+NjTfkA7SyQE5i2Fb7eawUOZmLvyqOA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.9"
+				"@babel/helper-plugin-utils": "^7.27.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1366,14 +1366,14 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-dotall-regex": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.25.9.tgz",
-			"integrity": "sha512-t7ZQ7g5trIgSRYhI9pIJtRl64KHotutUJsh4Eze5l7olJv+mRSg4/MmbZ0tv1eeqRbdvo/+trvJD/Oc5DmW2cA==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.27.1.tgz",
+			"integrity": "sha512-gEbkDVGRvjj7+T1ivxrfgygpT7GUd4vmODtYpbs0gZATdkX8/iSnOtZSxiZnsgm1YjTgjI6VKBGSJJevkrclzw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-create-regexp-features-plugin": "^7.25.9",
-				"@babel/helper-plugin-utils": "^7.25.9"
+				"@babel/helper-create-regexp-features-plugin": "^7.27.1",
+				"@babel/helper-plugin-utils": "^7.27.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1383,13 +1383,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-duplicate-keys": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.25.9.tgz",
-			"integrity": "sha512-LZxhJ6dvBb/f3x8xwWIuyiAHy56nrRG3PeYTpBkkzkYRRQ6tJLu68lEF5VIqMUZiAV7a8+Tb78nEoMCMcqjXBw==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.27.1.tgz",
+			"integrity": "sha512-MTyJk98sHvSs+cvZ4nOauwTTG1JeonDjSGvGGUNHreGQns+Mpt6WX/dVzWBHgg+dYZhkC4X+zTDfkTU+Vy9y7Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.9"
+				"@babel/helper-plugin-utils": "^7.27.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1399,14 +1399,14 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-duplicate-named-capturing-groups-regex": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-named-capturing-groups-regex/-/plugin-transform-duplicate-named-capturing-groups-regex-7.25.9.tgz",
-			"integrity": "sha512-0UfuJS0EsXbRvKnwcLjFtJy/Sxc5J5jhLHnFhy7u4zih97Hz6tJkLU+O+FMMrNZrosUPxDi6sYxJ/EA8jDiAog==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-named-capturing-groups-regex/-/plugin-transform-duplicate-named-capturing-groups-regex-7.27.1.tgz",
+			"integrity": "sha512-hkGcueTEzuhB30B3eJCbCYeCaaEQOmQR0AdvzpD4LoN0GXMWzzGSuRrxR2xTnCrvNbVwK9N6/jQ92GSLfiZWoQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-create-regexp-features-plugin": "^7.25.9",
-				"@babel/helper-plugin-utils": "^7.25.9"
+				"@babel/helper-create-regexp-features-plugin": "^7.27.1",
+				"@babel/helper-plugin-utils": "^7.27.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1416,13 +1416,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-dynamic-import": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-7.25.9.tgz",
-			"integrity": "sha512-GCggjexbmSLaFhqsojeugBpeaRIgWNTcgKVq/0qIteFEqY2A+b9QidYadrWlnbWQUrW5fn+mCvf3tr7OeBFTyg==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-7.27.1.tgz",
+			"integrity": "sha512-MHzkWQcEmjzzVW9j2q8LGjwGWpG2mjwaaB0BNQwst3FIjqsg8Ct/mIZlvSPJvfi9y2AC8mi/ktxbFVL9pZ1I4A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.9"
+				"@babel/helper-plugin-utils": "^7.27.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1432,13 +1432,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-exponentiation-operator": {
-			"version": "7.26.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.26.3.tgz",
-			"integrity": "sha512-7CAHcQ58z2chuXPWblnn1K6rLDnDWieghSOEmqQsrBenH0P9InCUtOJYD89pvngljmZlJcz3fcmgYsXFNGa1ZQ==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.27.1.tgz",
+			"integrity": "sha512-uspvXnhHvGKf2r4VVtBpeFnuDWsJLQ6MF6lGJLC89jBR1uoVeqM416AZtTuhTezOfgHicpJQmoD5YUakO/YmXQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.9"
+				"@babel/helper-plugin-utils": "^7.27.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1448,13 +1448,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-export-namespace-from": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-7.25.9.tgz",
-			"integrity": "sha512-2NsEz+CxzJIVOPx2o9UsW1rXLqtChtLoVnwYHHiB04wS5sgn7mrV45fWMBX0Kk+ub9uXytVYfNP2HjbVbCB3Ww==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-7.27.1.tgz",
+			"integrity": "sha512-tQvHWSZ3/jH2xuq/vZDy0jNn+ZdXJeM8gHvX4lnJmsc3+50yPlWdZXIc5ay+umX+2/tJIqHqiEqcJvxlmIvRvQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.9"
+				"@babel/helper-plugin-utils": "^7.27.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1464,14 +1464,14 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-for-of": {
-			"version": "7.26.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.26.9.tgz",
-			"integrity": "sha512-Hry8AusVm8LW5BVFgiyUReuoGzPUpdHQQqJY5bZnbbf+ngOHWuCuYFKw/BqaaWlvEUrF91HMhDtEaI1hZzNbLg==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.27.1.tgz",
+			"integrity": "sha512-BfbWFFEJFQzLCQ5N8VocnCtA8J1CLkNTe2Ms2wocj75dd6VpiqS5Z5quTYcUoo4Yq+DN0rtikODccuv7RU81sw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.26.5",
-				"@babel/helper-skip-transparent-expression-wrappers": "^7.25.9"
+				"@babel/helper-plugin-utils": "^7.27.1",
+				"@babel/helper-skip-transparent-expression-wrappers": "^7.27.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1481,15 +1481,15 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-function-name": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.25.9.tgz",
-			"integrity": "sha512-8lP+Yxjv14Vc5MuWBpJsoUCd3hD6V9DgBon2FVYL4jJgbnVQ9fTgYmonchzZJOVNgzEgbxp4OwAf6xz6M/14XA==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.27.1.tgz",
+			"integrity": "sha512-1bQeydJF9Nr1eBCMMbC+hdwmRlsv5XYOMu03YSWFwNs0HsAmtSxxF1fyuYPqemVldVyFmlCU7w8UE14LupUSZQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-compilation-targets": "^7.25.9",
-				"@babel/helper-plugin-utils": "^7.25.9",
-				"@babel/traverse": "^7.25.9"
+				"@babel/helper-compilation-targets": "^7.27.1",
+				"@babel/helper-plugin-utils": "^7.27.1",
+				"@babel/traverse": "^7.27.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1499,13 +1499,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-json-strings": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.25.9.tgz",
-			"integrity": "sha512-xoTMk0WXceiiIvsaquQQUaLLXSW1KJ159KP87VilruQm0LNNGxWzahxSS6T6i4Zg3ezp4vA4zuwiNUR53qmQAw==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.27.1.tgz",
+			"integrity": "sha512-6WVLVJiTjqcQauBhn1LkICsR2H+zm62I3h9faTDKt1qP4jn2o72tSvqMwtGFKGTpojce0gJs+76eZ2uCHRZh0Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.9"
+				"@babel/helper-plugin-utils": "^7.27.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1515,13 +1515,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-literals": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.25.9.tgz",
-			"integrity": "sha512-9N7+2lFziW8W9pBl2TzaNht3+pgMIRP74zizeCSrtnSKVdUl8mAjjOP2OOVQAfZ881P2cNjDj1uAMEdeD50nuQ==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.27.1.tgz",
+			"integrity": "sha512-0HCFSepIpLTkLcsi86GG3mTUzxV5jpmbv97hTETW3yzrAij8aqlD36toB1D0daVFJM8NK6GvKO0gslVQmm+zZA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.9"
+				"@babel/helper-plugin-utils": "^7.27.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1531,13 +1531,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-logical-assignment-operators": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.25.9.tgz",
-			"integrity": "sha512-wI4wRAzGko551Y8eVf6iOY9EouIDTtPb0ByZx+ktDGHwv6bHFimrgJM/2T021txPZ2s4c7bqvHbd+vXG6K948Q==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.27.1.tgz",
+			"integrity": "sha512-SJvDs5dXxiae4FbSL1aBJlG4wvl594N6YEVVn9e3JGulwioy6z3oPjx/sQBO3Y4NwUu5HNix6KJ3wBZoewcdbw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.9"
+				"@babel/helper-plugin-utils": "^7.27.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1547,13 +1547,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-member-expression-literals": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.25.9.tgz",
-			"integrity": "sha512-PYazBVfofCQkkMzh2P6IdIUaCEWni3iYEerAsRWuVd8+jlM1S9S9cz1dF9hIzyoZ8IA3+OwVYIp9v9e+GbgZhA==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.27.1.tgz",
+			"integrity": "sha512-hqoBX4dcZ1I33jCSWcXrP+1Ku7kdqXf1oeah7ooKOIiAdKQ+uqftgCFNOSzA5AMS2XIHEYeGFg4cKRCdpxzVOQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.9"
+				"@babel/helper-plugin-utils": "^7.27.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1563,14 +1563,14 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-modules-amd": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.25.9.tgz",
-			"integrity": "sha512-g5T11tnI36jVClQlMlt4qKDLlWnG5pP9CSM4GhdRciTNMRgkfpo5cR6b4rGIOYPgRRuFAvwjPQ/Yk+ql4dyhbw==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.27.1.tgz",
+			"integrity": "sha512-iCsytMg/N9/oFq6n+gFTvUYDZQOMK5kEdeYxmxt91fcJGycfxVP9CnrxoliM0oumFERba2i8ZtwRUCMhvP1LnA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-module-transforms": "^7.25.9",
-				"@babel/helper-plugin-utils": "^7.25.9"
+				"@babel/helper-module-transforms": "^7.27.1",
+				"@babel/helper-plugin-utils": "^7.27.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1580,14 +1580,14 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-modules-commonjs": {
-			"version": "7.26.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.26.3.tgz",
-			"integrity": "sha512-MgR55l4q9KddUDITEzEFYn5ZsGDXMSsU9E+kh7fjRXTIC3RHqfCo8RPRbyReYJh44HQ/yomFkqbOFohXvDCiIQ==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.27.1.tgz",
+			"integrity": "sha512-OJguuwlTYlN0gBZFRPqwOGNWssZjfIUdS7HMYtN8c1KmwpwHFBwTeFZrg9XZa+DFTitWOW5iTAG7tyCUPsCCyw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-module-transforms": "^7.26.0",
-				"@babel/helper-plugin-utils": "^7.25.9"
+				"@babel/helper-module-transforms": "^7.27.1",
+				"@babel/helper-plugin-utils": "^7.27.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1597,16 +1597,16 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-modules-systemjs": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.25.9.tgz",
-			"integrity": "sha512-hyss7iIlH/zLHaehT+xwiymtPOpsiwIIRlCAOwBB04ta5Tt+lNItADdlXw3jAWZ96VJ2jlhl/c+PNIQPKNfvcA==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.27.1.tgz",
+			"integrity": "sha512-w5N1XzsRbc0PQStASMksmUeqECuzKuTJer7kFagK8AXgpCMkeDMO5S+aaFb7A51ZYDF7XI34qsTX+fkHiIm5yA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-module-transforms": "^7.25.9",
-				"@babel/helper-plugin-utils": "^7.25.9",
-				"@babel/helper-validator-identifier": "^7.25.9",
-				"@babel/traverse": "^7.25.9"
+				"@babel/helper-module-transforms": "^7.27.1",
+				"@babel/helper-plugin-utils": "^7.27.1",
+				"@babel/helper-validator-identifier": "^7.27.1",
+				"@babel/traverse": "^7.27.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1616,14 +1616,14 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-modules-umd": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.25.9.tgz",
-			"integrity": "sha512-bS9MVObUgE7ww36HEfwe6g9WakQ0KF07mQF74uuXdkoziUPfKyu/nIm663kz//e5O1nPInPFx36z7WJmJ4yNEw==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.27.1.tgz",
+			"integrity": "sha512-iQBE/xC5BV1OxJbp6WG7jq9IWiD+xxlZhLrdwpPkTX3ydmXdvoCpyfJN7acaIBZaOqTfr76pgzqBJflNbeRK+w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-module-transforms": "^7.25.9",
-				"@babel/helper-plugin-utils": "^7.25.9"
+				"@babel/helper-module-transforms": "^7.27.1",
+				"@babel/helper-plugin-utils": "^7.27.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1633,14 +1633,14 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-named-capturing-groups-regex": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.25.9.tgz",
-			"integrity": "sha512-oqB6WHdKTGl3q/ItQhpLSnWWOpjUJLsOCLVyeFgeTktkBSCiurvPOsyt93gibI9CmuKvTUEtWmG5VhZD+5T/KA==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.27.1.tgz",
+			"integrity": "sha512-SstR5JYy8ddZvD6MhV0tM/j16Qds4mIpJTOd1Yu9J9pJjH93bxHECF7pgtc28XvkzTD6Pxcm/0Z73Hvk7kb3Ng==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-create-regexp-features-plugin": "^7.25.9",
-				"@babel/helper-plugin-utils": "^7.25.9"
+				"@babel/helper-create-regexp-features-plugin": "^7.27.1",
+				"@babel/helper-plugin-utils": "^7.27.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1650,13 +1650,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-new-target": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.25.9.tgz",
-			"integrity": "sha512-U/3p8X1yCSoKyUj2eOBIx3FOn6pElFOKvAAGf8HTtItuPyB+ZeOqfn+mvTtg9ZlOAjsPdK3ayQEjqHjU/yLeVQ==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.27.1.tgz",
+			"integrity": "sha512-f6PiYeqXQ05lYq3TIfIDu/MtliKUbNwkGApPUvyo6+tc7uaR4cPjPe7DFPr15Uyycg2lZU6btZ575CuQoYh7MQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.9"
+				"@babel/helper-plugin-utils": "^7.27.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1666,13 +1666,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-nullish-coalescing-operator": {
-			"version": "7.26.6",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.26.6.tgz",
-			"integrity": "sha512-CKW8Vu+uUZneQCPtXmSBUC6NCAUdya26hWCElAWh5mVSlSRsmiCPUUDKb3Z0szng1hiAJa098Hkhg9o4SE35Qw==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.27.1.tgz",
+			"integrity": "sha512-aGZh6xMo6q9vq1JGcw58lZ1Z0+i0xB2x0XaauNIUXd6O1xXc3RwoWEBlsTQrY4KQ9Jf0s5rgD6SiNkaUdJegTA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.26.5"
+				"@babel/helper-plugin-utils": "^7.27.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1682,13 +1682,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-numeric-separator": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.25.9.tgz",
-			"integrity": "sha512-TlprrJ1GBZ3r6s96Yq8gEQv82s8/5HnCVHtEJScUj90thHQbwe+E5MLhi2bbNHBEJuzrvltXSru+BUxHDoog7Q==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.27.1.tgz",
+			"integrity": "sha512-fdPKAcujuvEChxDBJ5c+0BTaS6revLV7CJL08e4m3de8qJfNIuCc2nc7XJYOjBoTMJeqSmwXJ0ypE14RCjLwaw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.9"
+				"@babel/helper-plugin-utils": "^7.27.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1698,15 +1698,16 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-object-rest-spread": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.25.9.tgz",
-			"integrity": "sha512-fSaXafEE9CVHPweLYw4J0emp1t8zYTXyzN3UuG+lylqkvYd7RMrsOQ8TYx5RF231be0vqtFC6jnx3UmpJmKBYg==",
+			"version": "7.27.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.27.3.tgz",
+			"integrity": "sha512-7ZZtznF9g4l2JCImCo5LNKFHB5eXnN39lLtLY5Tg+VkR0jwOt7TBciMckuiQIOIW7L5tkQOCh3bVGYeXgMx52Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-compilation-targets": "^7.25.9",
-				"@babel/helper-plugin-utils": "^7.25.9",
-				"@babel/plugin-transform-parameters": "^7.25.9"
+				"@babel/helper-compilation-targets": "^7.27.2",
+				"@babel/helper-plugin-utils": "^7.27.1",
+				"@babel/plugin-transform-destructuring": "^7.27.3",
+				"@babel/plugin-transform-parameters": "^7.27.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1716,14 +1717,14 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-object-super": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.25.9.tgz",
-			"integrity": "sha512-Kj/Gh+Rw2RNLbCK1VAWj2U48yxxqL2x0k10nPtSdRa0O2xnHXalD0s+o1A6a0W43gJ00ANo38jxkQreckOzv5A==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.27.1.tgz",
+			"integrity": "sha512-SFy8S9plRPbIcxlJ8A6mT/CxFdJx/c04JEctz4jf8YZaVS2px34j7NXRrlGlHkN/M2gnpL37ZpGRGVFLd3l8Ng==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.9",
-				"@babel/helper-replace-supers": "^7.25.9"
+				"@babel/helper-plugin-utils": "^7.27.1",
+				"@babel/helper-replace-supers": "^7.27.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1733,13 +1734,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-optional-catch-binding": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.25.9.tgz",
-			"integrity": "sha512-qM/6m6hQZzDcZF3onzIhZeDHDO43bkNNlOX0i8n3lR6zLbu0GN2d8qfM/IERJZYauhAHSLHy39NF0Ctdvcid7g==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.27.1.tgz",
+			"integrity": "sha512-txEAEKzYrHEX4xSZN4kJ+OfKXFVSWKB2ZxM9dpcE3wT7smwkNmXo5ORRlVzMVdJbD+Q8ILTgSD7959uj+3Dm3Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.9"
+				"@babel/helper-plugin-utils": "^7.27.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1749,14 +1750,14 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-optional-chaining": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.25.9.tgz",
-			"integrity": "sha512-6AvV0FsLULbpnXeBjrY4dmWF8F7gf8QnvTEoO/wX/5xm/xE1Xo8oPuD3MPS+KS9f9XBEAWN7X1aWr4z9HdOr7A==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.27.1.tgz",
+			"integrity": "sha512-BQmKPPIuc8EkZgNKsv0X4bPmOoayeu4F1YCwx2/CfmDSXDbp7GnzlUH+/ul5VGfRg1AoFPsrIThlEBj2xb4CAg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.9",
-				"@babel/helper-skip-transparent-expression-wrappers": "^7.25.9"
+				"@babel/helper-plugin-utils": "^7.27.1",
+				"@babel/helper-skip-transparent-expression-wrappers": "^7.27.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1766,13 +1767,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-parameters": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.25.9.tgz",
-			"integrity": "sha512-wzz6MKwpnshBAiRmn4jR8LYz/g8Ksg0o80XmwZDlordjwEk9SxBzTWC7F5ef1jhbrbOW2DJ5J6ayRukrJmnr0g==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.27.1.tgz",
+			"integrity": "sha512-018KRk76HWKeZ5l4oTj2zPpSh+NbGdt0st5S6x0pga6HgrjBOJb24mMDHorFopOOd6YHkLgOZ+zaCjZGPO4aKg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.9"
+				"@babel/helper-plugin-utils": "^7.27.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1782,14 +1783,14 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-private-methods": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.25.9.tgz",
-			"integrity": "sha512-D/JUozNpQLAPUVusvqMxyvjzllRaF8/nSrP1s2YGQT/W4LHK4xxsMcHjhOGTS01mp9Hda8nswb+FblLdJornQw==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.27.1.tgz",
+			"integrity": "sha512-10FVt+X55AjRAYI9BrdISN9/AQWHqldOeZDUoLyif1Kn05a56xVBXb8ZouL8pZ9jem8QpXaOt8TS7RHUIS+GPA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-create-class-features-plugin": "^7.25.9",
-				"@babel/helper-plugin-utils": "^7.25.9"
+				"@babel/helper-create-class-features-plugin": "^7.27.1",
+				"@babel/helper-plugin-utils": "^7.27.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1799,15 +1800,15 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-private-property-in-object": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.25.9.tgz",
-			"integrity": "sha512-Evf3kcMqzXA3xfYJmZ9Pg1OvKdtqsDMSWBDzZOPLvHiTt36E75jLDQo5w1gtRU95Q4E5PDttrTf25Fw8d/uWLw==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.27.1.tgz",
+			"integrity": "sha512-5J+IhqTi1XPa0DXF83jYOaARrX+41gOewWbkPyjMNRDqgOCqdffGh8L3f/Ek5utaEBZExjSAzcyjmV9SSAWObQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-annotate-as-pure": "^7.25.9",
-				"@babel/helper-create-class-features-plugin": "^7.25.9",
-				"@babel/helper-plugin-utils": "^7.25.9"
+				"@babel/helper-annotate-as-pure": "^7.27.1",
+				"@babel/helper-create-class-features-plugin": "^7.27.1",
+				"@babel/helper-plugin-utils": "^7.27.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1817,13 +1818,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-property-literals": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.25.9.tgz",
-			"integrity": "sha512-IvIUeV5KrS/VPavfSM/Iu+RE6llrHrYIKY1yfCzyO/lMXHQ+p7uGhonmGVisv6tSBSVgWzMBohTcvkC9vQcQFA==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.27.1.tgz",
+			"integrity": "sha512-oThy3BCuCha8kDZ8ZkgOg2exvPYUlprMukKQXI1r1pJ47NCvxfkEy8vK+r/hT9nF0Aa4H1WUPZZjHTFtAhGfmQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.9"
+				"@babel/helper-plugin-utils": "^7.27.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1833,13 +1834,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-react-display-name": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.25.9.tgz",
-			"integrity": "sha512-KJfMlYIUxQB1CJfO3e0+h0ZHWOTLCPP115Awhaz8U0Zpq36Gl/cXlpoyMRnUWlhNUBAzldnCiAZNvCDj7CrKxQ==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.27.1.tgz",
+			"integrity": "sha512-p9+Vl3yuHPmkirRrg021XiP+EETmPMQTLr6Ayjj85RLNEbb3Eya/4VI0vAdzQG9SEAl2Lnt7fy5lZyMzjYoZQQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.9"
+				"@babel/helper-plugin-utils": "^7.27.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1849,17 +1850,17 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-react-jsx": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.25.9.tgz",
-			"integrity": "sha512-s5XwpQYCqGerXl+Pu6VDL3x0j2d82eiV77UJ8a2mDHAW7j9SWRqQ2y1fNo1Z74CdcYipl5Z41zvjj4Nfzq36rw==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.27.1.tgz",
+			"integrity": "sha512-2KH4LWGSrJIkVf5tSiBFYuXDAoWRq2MMwgivCf+93dd0GQi8RXLjKA/0EvRnVV5G0hrHczsquXuD01L8s6dmBw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-annotate-as-pure": "^7.25.9",
-				"@babel/helper-module-imports": "^7.25.9",
-				"@babel/helper-plugin-utils": "^7.25.9",
-				"@babel/plugin-syntax-jsx": "^7.25.9",
-				"@babel/types": "^7.25.9"
+				"@babel/helper-annotate-as-pure": "^7.27.1",
+				"@babel/helper-module-imports": "^7.27.1",
+				"@babel/helper-plugin-utils": "^7.27.1",
+				"@babel/plugin-syntax-jsx": "^7.27.1",
+				"@babel/types": "^7.27.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1869,13 +1870,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-react-jsx-development": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.25.9.tgz",
-			"integrity": "sha512-9mj6rm7XVYs4mdLIpbZnHOYdpW42uoiBCTVowg7sP1thUOiANgMb4UtpRivR0pp5iL+ocvUv7X4mZgFRpJEzGw==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.27.1.tgz",
+			"integrity": "sha512-ykDdF5yI4f1WrAolLqeF3hmYU12j9ntLQl/AOG1HAS21jxyg1Q0/J/tpREuYLfatGdGmXp/3yS0ZA76kOlVq9Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/plugin-transform-react-jsx": "^7.25.9"
+				"@babel/plugin-transform-react-jsx": "^7.27.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1885,14 +1886,14 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-react-pure-annotations": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.25.9.tgz",
-			"integrity": "sha512-KQ/Takk3T8Qzj5TppkS1be588lkbTp5uj7w6a0LeQaTMSckU/wK0oJ/pih+T690tkgI5jfmg2TqDJvd41Sj1Cg==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.27.1.tgz",
+			"integrity": "sha512-JfuinvDOsD9FVMTHpzA/pBLisxpv1aSf+OIV8lgH3MuWrks19R27e6a6DipIg4aX1Zm9Wpb04p8wljfKrVSnPA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-annotate-as-pure": "^7.25.9",
-				"@babel/helper-plugin-utils": "^7.25.9"
+				"@babel/helper-annotate-as-pure": "^7.27.1",
+				"@babel/helper-plugin-utils": "^7.27.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1902,14 +1903,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-regenerator": {
-			"version": "7.27.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.27.0.tgz",
-			"integrity": "sha512-LX/vCajUJQDqE7Aum/ELUMZAY19+cDpghxrnyt5I1tV6X5PyC86AOoWXWFYFeIvauyeSA6/ktn4tQVn/3ZifsA==",
+			"version": "7.27.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.27.5.tgz",
+			"integrity": "sha512-uhB8yHerfe3MWnuLAhEbeQ4afVoqv8BQsPqrTv7e/jZ9y00kJL6l9a/f4OWaKxotmjzewfEyXE1vgDJenkQ2/Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.26.5",
-				"regenerator-transform": "^0.15.2"
+				"@babel/helper-plugin-utils": "^7.27.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1919,14 +1919,14 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-regexp-modifiers": {
-			"version": "7.26.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regexp-modifiers/-/plugin-transform-regexp-modifiers-7.26.0.tgz",
-			"integrity": "sha512-vN6saax7lrA2yA/Pak3sCxuD6F5InBjn9IcrIKQPjpsLvuHYLVroTxjdlVRHjjBWxKOqIwpTXDkOssYT4BFdRw==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regexp-modifiers/-/plugin-transform-regexp-modifiers-7.27.1.tgz",
+			"integrity": "sha512-TtEciroaiODtXvLZv4rmfMhkCv8jx3wgKpL68PuiPh2M4fvz5jhsA7697N1gMvkvr/JTF13DrFYyEbY9U7cVPA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-create-regexp-features-plugin": "^7.25.9",
-				"@babel/helper-plugin-utils": "^7.25.9"
+				"@babel/helper-create-regexp-features-plugin": "^7.27.1",
+				"@babel/helper-plugin-utils": "^7.27.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1936,13 +1936,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-reserved-words": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.25.9.tgz",
-			"integrity": "sha512-7DL7DKYjn5Su++4RXu8puKZm2XBPHyjWLUidaPEkCUBbE7IPcsrkRHggAOOKydH1dASWdcUBxrkOGNxUv5P3Jg==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.27.1.tgz",
+			"integrity": "sha512-V2ABPHIJX4kC7HegLkYoDpfg9PVmuWy/i6vUM5eGK22bx4YVFD3M5F0QQnWQoDs6AGsUWTVOopBiMFQgHaSkVw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.9"
+				"@babel/helper-plugin-utils": "^7.27.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1952,13 +1952,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-shorthand-properties": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.25.9.tgz",
-			"integrity": "sha512-MUv6t0FhO5qHnS/W8XCbHmiRWOphNufpE1IVxhK5kuN3Td9FT1x4rx4K42s3RYdMXCXpfWkGSbCSd0Z64xA7Ng==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.27.1.tgz",
+			"integrity": "sha512-N/wH1vcn4oYawbJ13Y/FxcQrWk63jhfNa7jef0ih7PHSIHX2LB7GWE1rkPrOnka9kwMxb6hMl19p7lidA+EHmQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.9"
+				"@babel/helper-plugin-utils": "^7.27.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1968,14 +1968,14 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-spread": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.25.9.tgz",
-			"integrity": "sha512-oNknIB0TbURU5pqJFVbOOFspVlrpVwo2H1+HUIsVDvp5VauGGDP1ZEvO8Nn5xyMEs3dakajOxlmkNW7kNgSm6A==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.27.1.tgz",
+			"integrity": "sha512-kpb3HUqaILBJcRFVhFUs6Trdd4mkrzcGXss+6/mxUd273PfbWqSDHRzMT2234gIg2QYfAjvXLSquP1xECSg09Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.9",
-				"@babel/helper-skip-transparent-expression-wrappers": "^7.25.9"
+				"@babel/helper-plugin-utils": "^7.27.1",
+				"@babel/helper-skip-transparent-expression-wrappers": "^7.27.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1985,13 +1985,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-sticky-regex": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.25.9.tgz",
-			"integrity": "sha512-WqBUSgeVwucYDP9U/xNRQam7xV8W5Zf+6Eo7T2SRVUFlhRiMNFdFz58u0KZmCVVqs2i7SHgpRnAhzRNmKfi2uA==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.27.1.tgz",
+			"integrity": "sha512-lhInBO5bi/Kowe2/aLdBAawijx+q1pQzicSgnkB6dUPc1+RC8QmJHKf2OjvU+NZWitguJHEaEmbV6VWEouT58g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.9"
+				"@babel/helper-plugin-utils": "^7.27.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -2001,13 +2001,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-template-literals": {
-			"version": "7.26.8",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.26.8.tgz",
-			"integrity": "sha512-OmGDL5/J0CJPJZTHZbi2XpO0tyT2Ia7fzpW5GURwdtp2X3fMmN8au/ej6peC/T33/+CRiIpA8Krse8hFGVmT5Q==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.27.1.tgz",
+			"integrity": "sha512-fBJKiV7F2DxZUkg5EtHKXQdbsbURW3DZKQUWphDum0uRP6eHGGa/He9mc0mypL680pb+e/lDIthRohlv8NCHkg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.26.5"
+				"@babel/helper-plugin-utils": "^7.27.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -2017,13 +2017,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-typeof-symbol": {
-			"version": "7.27.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.27.0.tgz",
-			"integrity": "sha512-+LLkxA9rKJpNoGsbLnAgOCdESl73vwYn+V6b+5wHbrE7OGKVDPHIQvbFSzqE6rwqaCw2RE+zdJrlLkcf8YOA0w==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.27.1.tgz",
+			"integrity": "sha512-RiSILC+nRJM7FY5srIyc4/fGIwUhyDuuBSdWn4y6yT6gm652DpCHZjIipgn6B7MQ1ITOUnAKWixEUjQRIBIcLw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.26.5"
+				"@babel/helper-plugin-utils": "^7.27.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -2033,17 +2033,17 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-typescript": {
-			"version": "7.27.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.27.0.tgz",
-			"integrity": "sha512-fRGGjO2UEGPjvEcyAZXRXAS8AfdaQoq7HnxAbJoAoW10B9xOKesmmndJv+Sym2a+9FHWZ9KbyyLCe9s0Sn5jtg==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.27.1.tgz",
+			"integrity": "sha512-Q5sT5+O4QUebHdbwKedFBEwRLb02zJ7r4A5Gg2hUoLuU3FjdMcyqcywqUrLCaDsFCxzokf7u9kuy7qz51YUuAg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-annotate-as-pure": "^7.25.9",
-				"@babel/helper-create-class-features-plugin": "^7.27.0",
-				"@babel/helper-plugin-utils": "^7.26.5",
-				"@babel/helper-skip-transparent-expression-wrappers": "^7.25.9",
-				"@babel/plugin-syntax-typescript": "^7.25.9"
+				"@babel/helper-annotate-as-pure": "^7.27.1",
+				"@babel/helper-create-class-features-plugin": "^7.27.1",
+				"@babel/helper-plugin-utils": "^7.27.1",
+				"@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
+				"@babel/plugin-syntax-typescript": "^7.27.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -2053,13 +2053,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-unicode-escapes": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.25.9.tgz",
-			"integrity": "sha512-s5EDrE6bW97LtxOcGj1Khcx5AaXwiMmi4toFWRDP9/y0Woo6pXC+iyPu/KuhKtfSrNFd7jJB+/fkOtZy6aIC6Q==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.27.1.tgz",
+			"integrity": "sha512-Ysg4v6AmF26k9vpfFuTZg8HRfVWzsh1kVfowA23y9j/Gu6dOuahdUVhkLqpObp3JIv27MLSii6noRnuKN8H0Mg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.9"
+				"@babel/helper-plugin-utils": "^7.27.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -2069,14 +2069,14 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-unicode-property-regex": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-7.25.9.tgz",
-			"integrity": "sha512-Jt2d8Ga+QwRluxRQ307Vlxa6dMrYEMZCgGxoPR8V52rxPyldHu3hdlHspxaqYmE7oID5+kB+UKUB/eWS+DkkWg==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-7.27.1.tgz",
+			"integrity": "sha512-uW20S39PnaTImxp39O5qFlHLS9LJEmANjMG7SxIhap8rCHqu0Ik+tLEPX5DKmHn6CsWQ7j3lix2tFOa5YtL12Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-create-regexp-features-plugin": "^7.25.9",
-				"@babel/helper-plugin-utils": "^7.25.9"
+				"@babel/helper-create-regexp-features-plugin": "^7.27.1",
+				"@babel/helper-plugin-utils": "^7.27.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -2086,14 +2086,14 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-unicode-regex": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.25.9.tgz",
-			"integrity": "sha512-yoxstj7Rg9dlNn9UQxzk4fcNivwv4nUYz7fYXBaKxvw/lnmPuOm/ikoELygbYq68Bls3D/D+NBPHiLwZdZZ4HA==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.27.1.tgz",
+			"integrity": "sha512-xvINq24TRojDuyt6JGtHmkVkrfVV3FPT16uytxImLeBZqW3/H52yN+kM1MGuyPkIQxrzKwPHs5U/MP3qKyzkGw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-create-regexp-features-plugin": "^7.25.9",
-				"@babel/helper-plugin-utils": "^7.25.9"
+				"@babel/helper-create-regexp-features-plugin": "^7.27.1",
+				"@babel/helper-plugin-utils": "^7.27.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -2103,14 +2103,14 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-unicode-sets-regex": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.25.9.tgz",
-			"integrity": "sha512-8BYqO3GeVNHtx69fdPshN3fnzUNLrWdHhk/icSwigksJGczKSizZ+Z6SBCxTs723Fr5VSNorTIK7a+R2tISvwQ==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.27.1.tgz",
+			"integrity": "sha512-EtkOujbc4cgvb0mlpQefi4NTPBzhSIevblFevACNLUspmrALgmEBdL/XfnyyITfd8fKBZrZys92zOWcik7j9Tw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-create-regexp-features-plugin": "^7.25.9",
-				"@babel/helper-plugin-utils": "^7.25.9"
+				"@babel/helper-create-regexp-features-plugin": "^7.27.1",
+				"@babel/helper-plugin-utils": "^7.27.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -2120,75 +2120,75 @@
 			}
 		},
 		"node_modules/@babel/preset-env": {
-			"version": "7.26.9",
-			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.26.9.tgz",
-			"integrity": "sha512-vX3qPGE8sEKEAZCWk05k3cpTAE3/nOYca++JA+Rd0z2NCNzabmYvEiSShKzm10zdquOIAVXsy2Ei/DTW34KlKQ==",
+			"version": "7.27.2",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.27.2.tgz",
+			"integrity": "sha512-Ma4zSuYSlGNRlCLO+EAzLnCmJK2vdstgv+n7aUP+/IKZrOfWHOJVdSJtuub8RzHTj3ahD37k5OKJWvzf16TQyQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/compat-data": "^7.26.8",
-				"@babel/helper-compilation-targets": "^7.26.5",
-				"@babel/helper-plugin-utils": "^7.26.5",
-				"@babel/helper-validator-option": "^7.25.9",
-				"@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^7.25.9",
-				"@babel/plugin-bugfix-safari-class-field-initializer-scope": "^7.25.9",
-				"@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.25.9",
-				"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.25.9",
-				"@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.25.9",
+				"@babel/compat-data": "^7.27.2",
+				"@babel/helper-compilation-targets": "^7.27.2",
+				"@babel/helper-plugin-utils": "^7.27.1",
+				"@babel/helper-validator-option": "^7.27.1",
+				"@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^7.27.1",
+				"@babel/plugin-bugfix-safari-class-field-initializer-scope": "^7.27.1",
+				"@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.27.1",
+				"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.27.1",
+				"@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.27.1",
 				"@babel/plugin-proposal-private-property-in-object": "7.21.0-placeholder-for-preset-env.2",
-				"@babel/plugin-syntax-import-assertions": "^7.26.0",
-				"@babel/plugin-syntax-import-attributes": "^7.26.0",
+				"@babel/plugin-syntax-import-assertions": "^7.27.1",
+				"@babel/plugin-syntax-import-attributes": "^7.27.1",
 				"@babel/plugin-syntax-unicode-sets-regex": "^7.18.6",
-				"@babel/plugin-transform-arrow-functions": "^7.25.9",
-				"@babel/plugin-transform-async-generator-functions": "^7.26.8",
-				"@babel/plugin-transform-async-to-generator": "^7.25.9",
-				"@babel/plugin-transform-block-scoped-functions": "^7.26.5",
-				"@babel/plugin-transform-block-scoping": "^7.25.9",
-				"@babel/plugin-transform-class-properties": "^7.25.9",
-				"@babel/plugin-transform-class-static-block": "^7.26.0",
-				"@babel/plugin-transform-classes": "^7.25.9",
-				"@babel/plugin-transform-computed-properties": "^7.25.9",
-				"@babel/plugin-transform-destructuring": "^7.25.9",
-				"@babel/plugin-transform-dotall-regex": "^7.25.9",
-				"@babel/plugin-transform-duplicate-keys": "^7.25.9",
-				"@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^7.25.9",
-				"@babel/plugin-transform-dynamic-import": "^7.25.9",
-				"@babel/plugin-transform-exponentiation-operator": "^7.26.3",
-				"@babel/plugin-transform-export-namespace-from": "^7.25.9",
-				"@babel/plugin-transform-for-of": "^7.26.9",
-				"@babel/plugin-transform-function-name": "^7.25.9",
-				"@babel/plugin-transform-json-strings": "^7.25.9",
-				"@babel/plugin-transform-literals": "^7.25.9",
-				"@babel/plugin-transform-logical-assignment-operators": "^7.25.9",
-				"@babel/plugin-transform-member-expression-literals": "^7.25.9",
-				"@babel/plugin-transform-modules-amd": "^7.25.9",
-				"@babel/plugin-transform-modules-commonjs": "^7.26.3",
-				"@babel/plugin-transform-modules-systemjs": "^7.25.9",
-				"@babel/plugin-transform-modules-umd": "^7.25.9",
-				"@babel/plugin-transform-named-capturing-groups-regex": "^7.25.9",
-				"@babel/plugin-transform-new-target": "^7.25.9",
-				"@babel/plugin-transform-nullish-coalescing-operator": "^7.26.6",
-				"@babel/plugin-transform-numeric-separator": "^7.25.9",
-				"@babel/plugin-transform-object-rest-spread": "^7.25.9",
-				"@babel/plugin-transform-object-super": "^7.25.9",
-				"@babel/plugin-transform-optional-catch-binding": "^7.25.9",
-				"@babel/plugin-transform-optional-chaining": "^7.25.9",
-				"@babel/plugin-transform-parameters": "^7.25.9",
-				"@babel/plugin-transform-private-methods": "^7.25.9",
-				"@babel/plugin-transform-private-property-in-object": "^7.25.9",
-				"@babel/plugin-transform-property-literals": "^7.25.9",
-				"@babel/plugin-transform-regenerator": "^7.25.9",
-				"@babel/plugin-transform-regexp-modifiers": "^7.26.0",
-				"@babel/plugin-transform-reserved-words": "^7.25.9",
-				"@babel/plugin-transform-shorthand-properties": "^7.25.9",
-				"@babel/plugin-transform-spread": "^7.25.9",
-				"@babel/plugin-transform-sticky-regex": "^7.25.9",
-				"@babel/plugin-transform-template-literals": "^7.26.8",
-				"@babel/plugin-transform-typeof-symbol": "^7.26.7",
-				"@babel/plugin-transform-unicode-escapes": "^7.25.9",
-				"@babel/plugin-transform-unicode-property-regex": "^7.25.9",
-				"@babel/plugin-transform-unicode-regex": "^7.25.9",
-				"@babel/plugin-transform-unicode-sets-regex": "^7.25.9",
+				"@babel/plugin-transform-arrow-functions": "^7.27.1",
+				"@babel/plugin-transform-async-generator-functions": "^7.27.1",
+				"@babel/plugin-transform-async-to-generator": "^7.27.1",
+				"@babel/plugin-transform-block-scoped-functions": "^7.27.1",
+				"@babel/plugin-transform-block-scoping": "^7.27.1",
+				"@babel/plugin-transform-class-properties": "^7.27.1",
+				"@babel/plugin-transform-class-static-block": "^7.27.1",
+				"@babel/plugin-transform-classes": "^7.27.1",
+				"@babel/plugin-transform-computed-properties": "^7.27.1",
+				"@babel/plugin-transform-destructuring": "^7.27.1",
+				"@babel/plugin-transform-dotall-regex": "^7.27.1",
+				"@babel/plugin-transform-duplicate-keys": "^7.27.1",
+				"@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^7.27.1",
+				"@babel/plugin-transform-dynamic-import": "^7.27.1",
+				"@babel/plugin-transform-exponentiation-operator": "^7.27.1",
+				"@babel/plugin-transform-export-namespace-from": "^7.27.1",
+				"@babel/plugin-transform-for-of": "^7.27.1",
+				"@babel/plugin-transform-function-name": "^7.27.1",
+				"@babel/plugin-transform-json-strings": "^7.27.1",
+				"@babel/plugin-transform-literals": "^7.27.1",
+				"@babel/plugin-transform-logical-assignment-operators": "^7.27.1",
+				"@babel/plugin-transform-member-expression-literals": "^7.27.1",
+				"@babel/plugin-transform-modules-amd": "^7.27.1",
+				"@babel/plugin-transform-modules-commonjs": "^7.27.1",
+				"@babel/plugin-transform-modules-systemjs": "^7.27.1",
+				"@babel/plugin-transform-modules-umd": "^7.27.1",
+				"@babel/plugin-transform-named-capturing-groups-regex": "^7.27.1",
+				"@babel/plugin-transform-new-target": "^7.27.1",
+				"@babel/plugin-transform-nullish-coalescing-operator": "^7.27.1",
+				"@babel/plugin-transform-numeric-separator": "^7.27.1",
+				"@babel/plugin-transform-object-rest-spread": "^7.27.2",
+				"@babel/plugin-transform-object-super": "^7.27.1",
+				"@babel/plugin-transform-optional-catch-binding": "^7.27.1",
+				"@babel/plugin-transform-optional-chaining": "^7.27.1",
+				"@babel/plugin-transform-parameters": "^7.27.1",
+				"@babel/plugin-transform-private-methods": "^7.27.1",
+				"@babel/plugin-transform-private-property-in-object": "^7.27.1",
+				"@babel/plugin-transform-property-literals": "^7.27.1",
+				"@babel/plugin-transform-regenerator": "^7.27.1",
+				"@babel/plugin-transform-regexp-modifiers": "^7.27.1",
+				"@babel/plugin-transform-reserved-words": "^7.27.1",
+				"@babel/plugin-transform-shorthand-properties": "^7.27.1",
+				"@babel/plugin-transform-spread": "^7.27.1",
+				"@babel/plugin-transform-sticky-regex": "^7.27.1",
+				"@babel/plugin-transform-template-literals": "^7.27.1",
+				"@babel/plugin-transform-typeof-symbol": "^7.27.1",
+				"@babel/plugin-transform-unicode-escapes": "^7.27.1",
+				"@babel/plugin-transform-unicode-property-regex": "^7.27.1",
+				"@babel/plugin-transform-unicode-regex": "^7.27.1",
+				"@babel/plugin-transform-unicode-sets-regex": "^7.27.1",
 				"@babel/preset-modules": "0.1.6-no-external-plugins",
 				"babel-plugin-polyfill-corejs2": "^0.4.10",
 				"babel-plugin-polyfill-corejs3": "^0.11.0",
@@ -2229,18 +2229,18 @@
 			}
 		},
 		"node_modules/@babel/preset-react": {
-			"version": "7.26.3",
-			"resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.26.3.tgz",
-			"integrity": "sha512-Nl03d6T9ky516DGK2YMxrTqvnpUW63TnJMOMonj+Zae0JiPC5BC9xPMSL6L8fiSpA5vP88qfygavVQvnLp+6Cw==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.27.1.tgz",
+			"integrity": "sha512-oJHWh2gLhU9dW9HHr42q0cI0/iHHXTLGe39qvpAZZzagHy0MzYLCnCVV0symeRvzmjHyVU7mw2K06E6u/JwbhA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.9",
-				"@babel/helper-validator-option": "^7.25.9",
-				"@babel/plugin-transform-react-display-name": "^7.25.9",
-				"@babel/plugin-transform-react-jsx": "^7.25.9",
-				"@babel/plugin-transform-react-jsx-development": "^7.25.9",
-				"@babel/plugin-transform-react-pure-annotations": "^7.25.9"
+				"@babel/helper-plugin-utils": "^7.27.1",
+				"@babel/helper-validator-option": "^7.27.1",
+				"@babel/plugin-transform-react-display-name": "^7.27.1",
+				"@babel/plugin-transform-react-jsx": "^7.27.1",
+				"@babel/plugin-transform-react-jsx-development": "^7.27.1",
+				"@babel/plugin-transform-react-pure-annotations": "^7.27.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -2250,17 +2250,17 @@
 			}
 		},
 		"node_modules/@babel/preset-typescript": {
-			"version": "7.27.0",
-			"resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.27.0.tgz",
-			"integrity": "sha512-vxaPFfJtHhgeOVXRKuHpHPAOgymmy8V8I65T1q53R7GCZlefKeCaTyDs3zOPHTTbmquvNlQYC5klEvWsBAtrBQ==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.27.1.tgz",
+			"integrity": "sha512-l7WfQfX0WK4M0v2RudjuQK4u99BS6yLHYEmdtVPP7lKV013zr9DygFuWNlnbvQ9LR+LS0Egz/XAvGx5U9MX0fQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.26.5",
-				"@babel/helper-validator-option": "^7.25.9",
-				"@babel/plugin-syntax-jsx": "^7.25.9",
-				"@babel/plugin-transform-modules-commonjs": "^7.26.3",
-				"@babel/plugin-transform-typescript": "^7.27.0"
+				"@babel/helper-plugin-utils": "^7.27.1",
+				"@babel/helper-validator-option": "^7.27.1",
+				"@babel/plugin-syntax-jsx": "^7.27.1",
+				"@babel/plugin-transform-modules-commonjs": "^7.27.1",
+				"@babel/plugin-transform-typescript": "^7.27.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -2281,30 +2281,30 @@
 			}
 		},
 		"node_modules/@babel/template": {
-			"version": "7.27.0",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.0.tgz",
-			"integrity": "sha512-2ncevenBqXI6qRMukPlXwHKHchC7RyMuu4xv5JBXRfOGVcTy1mXCD12qrp7Jsoxll1EV3+9sE4GugBVRjT2jFA==",
+			"version": "7.27.2",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
+			"integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/code-frame": "^7.26.2",
-				"@babel/parser": "^7.27.0",
-				"@babel/types": "^7.27.0"
+				"@babel/code-frame": "^7.27.1",
+				"@babel/parser": "^7.27.2",
+				"@babel/types": "^7.27.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/traverse": {
-			"version": "7.27.0",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.27.0.tgz",
-			"integrity": "sha512-19lYZFzYVQkkHkl4Cy4WrAVcqBkgvV2YM2TU3xG6DIwO7O3ecbDPfW3yM3bjAGcqcQHi+CCtjMR3dIEHxsd6bA==",
+			"version": "7.27.4",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.27.4.tgz",
+			"integrity": "sha512-oNcu2QbHqts9BtOWJosOVJapWjBDSxGCpFvikNR5TGDYDQf3JwpIoMzIKrvfoti93cLfPJEG4tH9SPVeyCGgdA==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/code-frame": "^7.26.2",
-				"@babel/generator": "^7.27.0",
-				"@babel/parser": "^7.27.0",
-				"@babel/template": "^7.27.0",
-				"@babel/types": "^7.27.0",
+				"@babel/code-frame": "^7.27.1",
+				"@babel/generator": "^7.27.3",
+				"@babel/parser": "^7.27.4",
+				"@babel/template": "^7.27.2",
+				"@babel/types": "^7.27.3",
 				"debug": "^4.3.1",
 				"globals": "^11.1.0"
 			},
@@ -2322,13 +2322,13 @@
 			}
 		},
 		"node_modules/@babel/types": {
-			"version": "7.27.0",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.0.tgz",
-			"integrity": "sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==",
+			"version": "7.27.3",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.3.tgz",
+			"integrity": "sha512-Y1GkI4ktrtvmawoSq+4FCVHNryea6uR+qUQy0AGxLSsjCX0nVmkYQMBLHDkXZuo5hGx7eYdnIaslsdBFm7zbUw==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-string-parser": "^7.25.9",
-				"@babel/helper-validator-identifier": "^7.25.9"
+				"@babel/helper-string-parser": "^7.27.1",
+				"@babel/helper-validator-identifier": "^7.27.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -22591,16 +22591,6 @@
 			"version": "0.14.1",
 			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
 			"integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
-		},
-		"node_modules/regenerator-transform": {
-			"version": "0.15.2",
-			"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.15.2.tgz",
-			"integrity": "sha512-hfMp2BoF0qOk3uc5V20ALGDS2ddjQaLrdl7xrGXvAIow7qeWRM2VA2HuCHkUKk9slq3VwEwLNK3DFBqDfPGYtg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/runtime": "^7.8.4"
-			}
 		},
 		"node_modules/regexp.prototype.flags": {
 			"version": "1.5.4",


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Related to https://github.com/Automattic/studio/security/dependabot/42 and https://github.com/Automattic/studio/security/dependabot/41

## Proposed Changes

- I propose to upgrade @automattic/wp-babel-makepot to latest version. It upgraded dependencies but didn't bump package version.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Test if translation files can still be generated:
```
npm run make-pot
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
