### PR TITLE
Studio: Bulk delete preview sites action not working

### DIFF
--- a/patches/@wordpress+components+29.9.0.patch
+++ b/patches/@wordpress+components+29.9.0.patch
@@ -7,7 +7,7 @@ index e1e1371..54775d2 100644
      }
      if (elementShouldBeHidden(element)) {
 -      element.setAttribute('aria-hidden', 'true');
-+      element.setAttribute('inert', '');
++      element.setAttribute('aria-modal', 'true');
        hiddenElements.push(element);
      }
    }
@@ -16,7 +16,7 @@ index e1e1371..54775d2 100644
  export function elementShouldBeHidden(element) {
    const role = element.getAttribute('role');
 -  return !(element.tagName === 'SCRIPT' || element.hasAttribute('hidden') || element.hasAttribute('aria-hidden') || element.hasAttribute('aria-live') || role && LIVE_REGION_ARIA_ROLES.has(role));
-+  return !(element.tagName === 'SCRIPT' || element.hasAttribute('hidden') || element.hasAttribute('aria-hidden') || element.hasAttribute('inert') || element.hasAttribute('aria-live') || role && LIVE_REGION_ARIA_ROLES.has(role));
++  return !(element.tagName === 'SCRIPT' || element.hasAttribute('hidden') || element.hasAttribute('aria-hidden') || element.hasAttribute('aria-modal') || element.hasAttribute('aria-live') || role && LIVE_REGION_ARIA_ROLES.has(role));
  }
  
  /**
@@ -25,7 +25,7 @@ index e1e1371..54775d2 100644
    }
    for (const element of hiddenElements) {
 -    element.removeAttribute('aria-hidden');
-+    element.removeAttribute('inert');
++    element.removeAttribute('aria-modal');
    }
  }
  //# sourceMappingURL=aria-helper.js.map

--- a/src/modules/user-settings/components/snapshot-info.tsx
+++ b/src/modules/user-settings/components/snapshot-info.tsx
@@ -53,56 +53,53 @@ export const SnapshotInfo = ( {
 							</div>
 							<ProgressBar value={ siteCount } maxValue={ siteLimit } />
 						</div>
-						<div className="relative">
-							<DropdownMenu
-								className={
-									'ml-auto flex items-center [&_button:first-child]:p-0 [&_button:first-child]:min-w-6 [&_button:first-child]:h-6'
-								}
-								popoverProps={ { position: 'bottom left', resize: true } }
-								icon={ <Icon icon={ moreVertical }></Icon> }
-								size={ 24 }
-								label={ __( 'More options' ) }
-							>
-								{ ( { onClose }: { onClose: () => void } ) => {
-									return (
-										<MenuGroup>
-											<Tooltip
-												disabled={ ! isOffline }
-												icon={ offlineIcon }
-												text={ offlineMessage }
-												placement="bottom"
-											>
-												<MenuItem
-													aria-description={ isOffline ? offlineMessage : '' }
-													/**
-													 * Because there is a single menu item, the `aria-disabled`
-													 * attribute is used rather than `disabled` so that screen
-													 * readers can focus the item to announce its disabled state.
-													 * Otherwise, dropdown toggle would toggle an empty menu.
-													 */
-													aria-disabled={ isDisabled }
-													icon={ trash }
-													iconPosition="left"
-													isDestructive
-													className={ menuItemStyles }
-													onClick={ () => {
-														if ( isDisabled ) {
-															return;
-														}
+						<DropdownMenu
+							className={
+								'ml-auto flex items-center [&_button:first-child]:p-0 [&_button:first-child]:min-w-6 [&_button:first-child]:h-6'
+							}
+							popoverProps={ { position: 'bottom left', resize: true } }
+							icon={ <Icon icon={ moreVertical }></Icon> }
+							size={ 24 }
+							label={ __( 'More options' ) }
+						>
+							{ ( { onClose }: { onClose: () => void } ) => {
+								return (
+									<MenuGroup>
+										<Tooltip
+											disabled={ ! isOffline }
+											icon={ offlineIcon }
+											text={ offlineMessage }
+											placement="bottom"
+										>
+											<MenuItem
+												aria-description={ isOffline ? offlineMessage : '' }
+												/**
+												 * Because there is a single menu item, the `aria-disabled`
+												 * attribute is used rather than `disabled` so that screen
+												 * readers can focus the item to announce its disabled state.
+												 * Otherwise, dropdown toggle would toggle an empty menu.
+												 */
+												aria-disabled={ isDisabled }
+												icon={ trash }
+												iconPosition="left"
+												isDestructive
+												className={ menuItemStyles }
+												onClick={ () => {
+													if ( isDisabled ) {
+														return;
+													}
 
-														onRemoveSnapshots();
-														onClose();
-													} }
-												>
-													{ __( 'Delete all preview sites' ) }
-												</MenuItem>
-											</Tooltip>
-										</MenuGroup>
-									);
-								} }
-							</DropdownMenu>
-							<div className="components-popover__fallback-container"></div>
-						</div>
+													onRemoveSnapshots();
+													onClose();
+												} }
+											>
+												{ __( 'Delete all preview sites' ) }
+											</MenuItem>
+										</Tooltip>
+									</MenuGroup>
+								);
+							} }
+						</DropdownMenu>
 					</>
 				) }
 			</div>

--- a/src/modules/user-settings/components/snapshot-info.tsx
+++ b/src/modules/user-settings/components/snapshot-info.tsx
@@ -53,53 +53,56 @@ export const SnapshotInfo = ( {
 							</div>
 							<ProgressBar value={ siteCount } maxValue={ siteLimit } />
 						</div>
-						<DropdownMenu
-							className={
-								'ml-auto flex items-center [&_button:first-child]:p-0 [&_button:first-child]:min-w-6 [&_button:first-child]:h-6'
-							}
-							popoverProps={ { position: 'bottom left', resize: true } }
-							icon={ <Icon icon={ moreVertical }></Icon> }
-							size={ 24 }
-							label={ __( 'More options' ) }
-						>
-							{ ( { onClose }: { onClose: () => void } ) => {
-								return (
-									<MenuGroup>
-										<Tooltip
-											disabled={ ! isOffline }
-											icon={ offlineIcon }
-											text={ offlineMessage }
-											placement="bottom"
-										>
-											<MenuItem
-												aria-description={ isOffline ? offlineMessage : '' }
-												/**
-												 * Because there is a single menu item, the `aria-disabled`
-												 * attribute is used rather than `disabled` so that screen
-												 * readers can focus the item to announce its disabled state.
-												 * Otherwise, dropdown toggle would toggle an empty menu.
-												 */
-												aria-disabled={ isDisabled }
-												icon={ trash }
-												iconPosition="left"
-												isDestructive
-												className={ menuItemStyles }
-												onClick={ () => {
-													if ( isDisabled ) {
-														return;
-													}
-
-													onRemoveSnapshots();
-													onClose();
-												} }
+						<div className="relative">
+							<DropdownMenu
+								className={
+									'ml-auto flex items-center [&_button:first-child]:p-0 [&_button:first-child]:min-w-6 [&_button:first-child]:h-6'
+								}
+								popoverProps={ { position: 'bottom left', resize: true } }
+								icon={ <Icon icon={ moreVertical }></Icon> }
+								size={ 24 }
+								label={ __( 'More options' ) }
+							>
+								{ ( { onClose }: { onClose: () => void } ) => {
+									return (
+										<MenuGroup>
+											<Tooltip
+												disabled={ ! isOffline }
+												icon={ offlineIcon }
+												text={ offlineMessage }
+												placement="bottom"
 											>
-												{ __( 'Delete all preview sites' ) }
-											</MenuItem>
-										</Tooltip>
-									</MenuGroup>
-								);
-							} }
-						</DropdownMenu>
+												<MenuItem
+													aria-description={ isOffline ? offlineMessage : '' }
+													/**
+													 * Because there is a single menu item, the `aria-disabled`
+													 * attribute is used rather than `disabled` so that screen
+													 * readers can focus the item to announce its disabled state.
+													 * Otherwise, dropdown toggle would toggle an empty menu.
+													 */
+													aria-disabled={ isDisabled }
+													icon={ trash }
+													iconPosition="left"
+													isDestructive
+													className={ menuItemStyles }
+													onClick={ () => {
+														if ( isDisabled ) {
+															return;
+														}
+
+														onRemoveSnapshots();
+														onClose();
+													} }
+												>
+													{ __( 'Delete all preview sites' ) }
+												</MenuItem>
+											</Tooltip>
+										</MenuGroup>
+									);
+								} }
+							</DropdownMenu>
+							<div className="components-popover__fallback-container"></div>
+						</div>
 					</>
 				) }
 			</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-549

## Proposed Changes

I proposed a fix for the bulk delete preview sites action not working by using `aria-modal` instead of `inert` attribute. That attribute was added as part of https://github.com/Automattic/studio/pull/1423 PR to fix the accessibility warning. Using aria-modal fixes those issues and it also fixes the issues with Bulk delete preview sites action. 

Read more about aria-modal attribute:  https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-modal

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Check out this PR
- Delete `rm node_modules` folder and then run `npm install && npm start`
- Make sure you have a couple of preview sites
- Navigate to a different tab than Overview and go back to the Overview tab, for example, navigate from Overview -> Sync and then from Sync -> Overview
- Go to the Preferences screen
- Navigate to the Usage tab
- Click the ︙(three dots) menu
- Check that "Delete all preview sites" is clickable. 

Also, follow the test instructions from PR https://github.com/Automattic/studio/pull/1423 for any regression.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
