### PR TITLE
Escape backslash in the path opened by terminal

### DIFF
--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -1008,7 +1008,7 @@ export async function openTerminalAtPath( _event: IpcMainInvokeEvent, targetPath
 	const preferredTerminal = await getUserTerminal();
 
 	if ( platform === 'darwin' ) {
-		const escapedPath = targetPath.replace( /"/g, '\\"' );
+		const escapedPath = targetPath.replace( /\\/g, '\\\\' ).replace( /"/g, '\\"' );
 		const bundleIds = {
 			warp: 'dev.warp.Warp-Stable',
 			ghostty: 'com.mitchellh.ghostty',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/studio/security/code-scanning/13

## Proposed Changes

- I propose to escape backslash in the path opened by the terminal.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Test if terminal can be correctly opened at the site's path.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
