### PR TITLE
 [Experiment] Update network timeout to 1 second when network is offline

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -12,6 +12,7 @@ import TopBar from 'src/components/top-bar';
 import WindowsTitlebar from 'src/components/windows-titlebar';
 import { useI18nData } from 'src/hooks/use-i18n-data';
 import { useLocalizationSupport } from 'src/hooks/use-localization-support';
+import { useNetworkConnection } from 'src/hooks/use-network-connection';
 import { useOnboarding } from 'src/hooks/use-onboarding';
 import { useSidebarVisibility } from 'src/hooks/use-sidebar-visibility';
 import { isWindows } from 'src/lib/app-globals';
@@ -23,6 +24,7 @@ import 'src/index.css';
 
 export default function App() {
 	useLocalizationSupport();
+	useNetworkConnection();
 	const { needsOnboarding } = useOnboarding();
 	const { isSidebarVisible, toggleSidebar } = useSidebarVisibility();
 	const { showWhatsNew, closeWhatsNew } = useWhatsNew();

--- a/src/hooks/use-network-connection.ts
+++ b/src/hooks/use-network-connection.ts
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
-import { useSiteDetails } from './use-site-details';
 import { useOffline } from './use-offline';
+import { useSiteDetails } from './use-site-details';
 
 export function useNetworkConnection() {
 	const { data: sites, stopServer, startServer } = useSiteDetails();

--- a/src/hooks/use-network-connection.ts
+++ b/src/hooks/use-network-connection.ts
@@ -1,0 +1,23 @@
+import { useEffect } from 'react';
+import { useSiteDetails } from './use-site-details';
+import { useOffline } from './use-offline';
+
+export function useNetworkConnection() {
+    const { data: sites, stopServer, startServer } = useSiteDetails();
+    const isOffline = useOffline();
+
+    const restartRunningSites = async () => {
+        const runningSites = sites.filter(site => site.running);
+        await Promise.all(runningSites.map(site => stopServer(site.id)));
+        await Promise.all(runningSites.map(site => startServer(site.id)));
+    };
+
+    useEffect(() => {
+        window.addEventListener('online', restartRunningSites);
+        window.addEventListener('offline', restartRunningSites);
+        return () => {
+            window.removeEventListener('online', restartRunningSites);
+            window.removeEventListener('offline', restartRunningSites);
+        };
+    }, [sites, stopServer, startServer, isOffline]);
+} 

--- a/src/hooks/use-network-connection.ts
+++ b/src/hooks/use-network-connection.ts
@@ -3,21 +3,21 @@ import { useSiteDetails } from './use-site-details';
 import { useOffline } from './use-offline';
 
 export function useNetworkConnection() {
-    const { data: sites, stopServer, startServer } = useSiteDetails();
-    const isOffline = useOffline();
+	const { data: sites, stopServer, startServer } = useSiteDetails();
+	const isOffline = useOffline();
 
-    const restartRunningSites = async () => {
-        const runningSites = sites.filter(site => site.running);
-        await Promise.all(runningSites.map(site => stopServer(site.id)));
-        await Promise.all(runningSites.map(site => startServer(site.id)));
-    };
+	const restartRunningSites = async () => {
+		const runningSites = sites.filter( ( site ) => site.running );
+		await Promise.all( runningSites.map( ( site ) => stopServer( site.id ) ) );
+		await Promise.all( runningSites.map( ( site ) => startServer( site.id ) ) );
+	};
 
-    useEffect(() => {
-        window.addEventListener('online', restartRunningSites);
-        window.addEventListener('offline', restartRunningSites);
-        return () => {
-            window.removeEventListener('online', restartRunningSites);
-            window.removeEventListener('offline', restartRunningSites);
-        };
-    }, [sites, stopServer, startServer, isOffline]);
-} 
+	useEffect( () => {
+		window.addEventListener( 'online', restartRunningSites );
+		window.addEventListener( 'offline', restartRunningSites );
+		return () => {
+			window.removeEventListener( 'online', restartRunningSites );
+			window.removeEventListener( 'offline', restartRunningSites );
+		};
+	}, [ sites, stopServer, startServer, isOffline ] );
+}

--- a/src/lib/site-server-process.ts
+++ b/src/lib/site-server-process.ts
@@ -1,4 +1,4 @@
-import { app, utilityProcess, UtilityProcess } from 'electron';
+import { app, utilityProcess, UtilityProcess, net } from 'electron';
 import { kill } from 'process';
 import { PHPRunOptions } from '@php-wasm/universal';
 import * as Sentry from '@sentry/electron/renderer';
@@ -49,6 +49,8 @@ export default class SiteServerProcess {
 					reject( new Error( `Site server process exited with code ${ code } upon starting` ) );
 				}
 			};
+
+			this.options[ 'isOffline' ] = ! net.isOnline();
 
 			this.process = utilityProcess
 				.fork( SITE_SERVER_PROCESS_MODULE_PATH, [ JSON.stringify( this.options ) ], {

--- a/vendor/wp-now/src/config.ts
+++ b/vendor/wp-now/src/config.ts
@@ -22,6 +22,7 @@ export interface CliOptions {
 	siteTitle?: string;
 	mode?: WPNowMode;
 	isWpAutoUpdating?: boolean;
+	isOffline?: boolean; 
 }
 
 export const enum WPNowMode {
@@ -52,6 +53,7 @@ export interface WPNowOptions {
 	adminPassword?: string;
 	siteTitle?: string;
 	siteLanguage?: string;
+	isOffline?: boolean;
 }
 
 export const DEFAULT_OPTIONS: WPNowOptions = {

--- a/vendor/wp-now/src/wp-now.ts
+++ b/vendor/wp-now/src/wp-now.ts
@@ -586,14 +586,15 @@ async function mountInternalMuPlugins( php: PHP, options: WPNowOptions ) {
 	php.writeFile(
 		path.posix.join( PLAYGROUND_INTERNAL_MU_PLUGINS_FOLDER, '0-http-request-timeout.php' ),
 		`<?php
+		
 		// Increase default timeouts to 30 seconds to accommodate slower network conditions and larger requests
 		add_filter( 'http_request_timeout', function() {
-			return 30;
+			return ${options.isOffline ? 1 : 30};
 		} );
 
 		add_action('http_api_curl', function($curl, $url, $options) {
-			curl_setopt( $curl, CURLOPT_CONNECTTIMEOUT, 30 );
-			curl_setopt($curl, CURLOPT_TIMEOUT, 30);
+			curl_setopt( $curl, CURLOPT_CONNECTTIMEOUT, ${options.isOffline ? 1 : 30} );
+			curl_setopt($curl, CURLOPT_TIMEOUT, ${options.isOffline ? 1 : 30} );
 			return $curl;
 		}, 1, 3);
 		`


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-550

## Proposed Changes

> [!WARNING]
> This is an experimental PR. I would like to know what others think about the approach first. 

I propose updating the network request timeout to 1 second when the studio is running in offline mode. By default, WordPress is not built for offline mode, and it assumes that it is running on a server with an internet connection. That's why it doesn't have checks in place for network status. The reason for the slow site creation is the network requests that WordPress makes during the initial load. While we can not prevent WordPress from making those requests, But we can reduce the timeout for network requests when the site is running in offline mode. So this PR does the following:

1. Updates the timeout based on network status. 1 second when offline and restores it to 30 seconds when online. 
2. Automatically restart running servers when the network changes.
    - I am aware this has some consequences. Like logging out from WP Admin on reload. 
    - Network fluctuations will automatically restart servers, even in the event of shorter disruptions. 

In tests:
This change has drastically improved timing in offline mode. The new sites are created almost instantly, and WP Admin loads instantly. 

https://github.com/user-attachments/assets/44400964-d93b-4a59-82e1-e5913b534a9a

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Check out this branch
- Turn off the Wi-Fi adaptor or the network
- Create a new site and observe the timing
- Open WP Admin and observe the timing
- Both of the above should be improved in comparison to the trunk
- Turn on internet
- Observe the studio UI; all running servers will be automatically restarted. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
