### PR TITLE
Add feature flags menu

### DIFF
--- a/src/hooks/use-feature-flags.tsx
+++ b/src/hooks/use-feature-flags.tsx
@@ -1,23 +1,24 @@
 import * as Sentry from '@sentry/react';
 import React, { createContext, useContext, ReactNode, useState, useEffect } from 'react';
-import { z } from 'zod';
 import { useAuth } from 'src/hooks/use-auth';
+import { useIpcListener } from 'src/hooks/use-ipc-listener';
 import { getAppGlobals } from 'src/lib/app-globals';
+import { FEATURE_FLAGS, FeatureFlags } from 'src/lib/feature-flags';
+import { getIpcApi } from 'src/lib/get-ipc-api';
 
-// In PHP, empty associative arrays are encoded as regular arrays when converted to JSON.
-// This means an empty feature flags response comes as [] instead of {}.
-const featureFlagsSchema = z
-	.object( {
-		selectiveSyncEnabled: z.boolean().optional(),
-	} )
-	.catch( ( _: unknown ) => ( {} ) );
+export type FeatureFlagsContextType = FeatureFlags;
 
-// Will be extended with feature flags in the future */
-export type FeatureFlagsContextType = {
-	selectiveSyncEnabled?: boolean;
-};
+function createDefaultFeatureFlags(): FeatureFlags {
+	const flags = {} as FeatureFlags;
+	for ( const [ key, def ] of Object.entries( FEATURE_FLAGS ) ) {
+		flags[ key as keyof FeatureFlags ] = def.default;
+	}
+	return flags;
+}
 
-export const FeatureFlagsContext = createContext< FeatureFlagsContextType >( {} );
+const defaultFeatureFlags = createDefaultFeatureFlags();
+
+export const FeatureFlagsContext = createContext< FeatureFlagsContextType >( defaultFeatureFlags );
 
 interface FeatureFlagsProviderProps {
 	children: ReactNode;
@@ -26,9 +27,18 @@ interface FeatureFlagsProviderProps {
 export const FeatureFlagsProvider: React.FC< FeatureFlagsProviderProps > = ( { children } ) => {
 	const selectiveSyncEnabledFromGlobals = getAppGlobals().selectiveSyncEnabled;
 	const [ featureFlags, setFeatureFlags ] = useState< FeatureFlagsContextType >( {
+		...defaultFeatureFlags,
 		selectiveSyncEnabled: selectiveSyncEnabledFromGlobals,
 	} );
 	const { isAuthenticated, client } = useAuth();
+
+	useIpcListener( 'refresh-app-globals', async () => {
+		window.appGlobals = await getIpcApi().getAppGlobals();
+		setFeatureFlags( {
+			...featureFlags,
+			selectiveSyncEnabled: window.appGlobals.selectiveSyncEnabled,
+		} );
+	} );
 
 	useEffect( () => {
 		let cancel = false;
@@ -41,11 +51,12 @@ export const FeatureFlagsProvider: React.FC< FeatureFlagsProviderProps > = ( { c
 					path: '/studio-app/feature-flags',
 					apiNamespace: 'wpcom/v2',
 				} );
-				const flags = featureFlagsSchema.parse( response );
+				const flags = response as Partial< FeatureFlags >;
 				if ( cancel ) {
 					return;
 				}
 				setFeatureFlags( {
+					...defaultFeatureFlags,
 					...flags,
 					selectiveSyncEnabled:
 						Boolean( flags.selectiveSyncEnabled ) || selectiveSyncEnabledFromGlobals,

--- a/src/ipc-utils.ts
+++ b/src/ipc-utils.ts
@@ -38,6 +38,7 @@ export interface IpcEvents {
 	'user-preference-changed': [ void ];
 	'user-data-updated': [ UserData ];
 	'user-data-error': [ string ];
+	'refresh-app-globals': [ void ];
 }
 
 export async function sendIpcEventToRenderer< T extends keyof IpcEvents >(

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -1,0 +1,29 @@
+export interface FeatureFlagDefinition {
+	label: string;
+	env: string;
+	flag: string;
+	default: boolean;
+}
+
+export interface FeatureFlags {
+	selectiveSyncEnabled: boolean;
+}
+
+export const FEATURE_FLAGS: Record< keyof FeatureFlags, FeatureFlagDefinition > = {
+	selectiveSyncEnabled: {
+		label: 'Selective Sync',
+		env: 'STUDIO_SELECTIVE_SYNC',
+		flag: 'selectiveSyncEnabled',
+		default: false,
+	},
+};
+
+export function getFeatureFlagFromEnv( flag: keyof FeatureFlags ): boolean {
+	const envKey = FEATURE_FLAGS[ flag ].env;
+	return process.env[ envKey ] === 'true';
+}
+
+export function setFeatureFlagInEnv( flag: keyof FeatureFlags, value: boolean ): void {
+	const envKey = FEATURE_FLAGS[ flag ].env;
+	process.env[ envKey ] = value ? 'true' : 'false';
+}

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -1,8 +1,21 @@
-import { Menu, type MenuItemConstructorOptions, app, BrowserWindow, autoUpdater } from 'electron';
+import {
+	Menu,
+	type MenuItemConstructorOptions,
+	app,
+	BrowserWindow,
+	autoUpdater,
+	MenuItem,
+} from 'electron';
 import { __ } from '@wordpress/i18n';
 import { openAboutWindow } from 'src/about-menu/open-about-menu';
 import { BUG_REPORT_URL, FEATURE_REQUEST_URL } from 'src/constants';
 import { sendIpcEventToRenderer } from 'src/ipc-utils';
+import {
+	FEATURE_FLAGS,
+	FeatureFlags,
+	getFeatureFlagFromEnv,
+	setFeatureFlagInEnv,
+} from 'src/lib/feature-flags';
 import { getLocalizedLink } from 'src/lib/get-localized-link';
 import { getUserLocaleWithFallback } from 'src/lib/locale-node';
 import { shellOpenExternalWrapper } from 'src/lib/shell-open-external-wrapper';
@@ -66,6 +79,18 @@ function getAppMenu(
 		{ type: 'separator' },
 	];
 
+	const featureFlagsMenu: MenuItemConstructorOptions[] = Object.entries( FEATURE_FLAGS ).map(
+		( [ flag, definition ] ) => ( {
+			label: definition.label,
+			type: 'checkbox' as const,
+			checked: getFeatureFlagFromEnv( flag as keyof FeatureFlags ),
+			click: ( menuItem: MenuItem ) => {
+				setFeatureFlagInEnv( flag as keyof FeatureFlags, menuItem.checked );
+				void sendIpcEventToRenderer( 'refresh-app-globals' );
+			},
+		} )
+	);
+
 	return Menu.buildFromTemplate( [
 		{
 			label: app.name, // macOS ignores this name and uses the name from the .plist
@@ -109,6 +134,14 @@ function getAppMenu(
 					: [ { label: __( 'Hide' ), role: 'hide' } as MenuItemConstructorOptions ] ),
 				{ type: 'separator' },
 				...( process.env.NODE_ENV === 'development' ? crashTestMenuItems : [] ),
+				...( process.env.NODE_ENV === 'development'
+					? [
+							{
+								label: __( 'Feature Flags' ),
+								submenu: featureFlagsMenu,
+							},
+					  ]
+					: [] ),
 				{ type: 'separator' },
 				{ label: __( 'Quit' ), role: 'quit' },
 			],


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- N/A

## Proposed Changes

- Add a feature flags menu to make it easier to toggle feature flags

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- `yarn start`
- At the time of this PR the only available feature flag is "Selective Sync" so confirm that new feature is not available
- Open "Electron" menu
- Confirm the Feature Flags group shows with the option "Selective Sync" and toggle it
- Confirm the new sync feature is not available.

- Start the project with the env var flag to confirm the existing behavior still works. 
For example`STUDIO_SELECTIVE_SYNC=true npm start`

![image](https://github.com/user-attachments/assets/125a5f59-7fa9-4407-8a2e-f9013afa25be)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
