### PR TITLE
Update the `make-pot` command to open the browser and select the POT file to simplify uploading localized strings

### DIFF
--- a/docs/localization.md
+++ b/docs/localization.md
@@ -30,6 +30,12 @@ If you want to add support for another language you will need to add it to the
    3. Click **Import Originals**.
    4. Import `out/pots/bundle-strings.pot` (auto-detecting the file format is fine).
 
+#### Alternative: Use the Smart Import
+
+If you want to import the strings directly into GlotPress, you can use the
+`npm run make-pot:smart` command. This will run the `make-pot` command and then
+open the import page in your browser and select the `bundle-strings.pot` file.
+
 ### Export and Add
 
 #### Step 1: Export from GlotPress:

--- a/docs/localization.md
+++ b/docs/localization.md
@@ -26,7 +26,7 @@ If you want to add support for another language you will need to add it to the
 #### Step 2: Import to GlotPress:
 
    1. Drag and drop the `out/pots/bundle-strings.pot` to the file input in the GlotPress Studio page https://translate.wordpress.com/projects/studio/import-originals/
-   2. Leave the format as "auto-detecting".
+   2. Leave the format as "_Auto Detect_".
    3. Click **Import** and wait for the import to complete.
 
 ### Export and Add

--- a/docs/localization.md
+++ b/docs/localization.md
@@ -17,24 +17,17 @@ If you want to add support for another language you will need to add it to the
 
 #### Step 1: Extract Strings:
 
-   1. Remove `out/pots/` directory if it exists.
-   2. Run `npm run make-pot` to get the text out of the source files.
+   1. Run `npm run make-pot` to get the text out of the source files.
 
-   This will create a `*.pot` file for each module, as well as a bundle
+   This will remove the `out/pots/` directory and create a `*.pot` file for each module, as well as a bundle
    of all translatable strings in `out/pots/bundle-strings.pot`.
+   It will also open the import page in your browser and select the `bundle-strings.pot` file.
 
 #### Step 2: Import to GlotPress:
 
-   1. Open [our project in GlotPress](https://translate.wordpress.com/projects/studio/).
-   2. Click the **Project actions** menu. You must be a proxied Automattician to view the menu.
-   3. Click **Import Originals**.
-   4. Import `out/pots/bundle-strings.pot` (auto-detecting the file format is fine).
-
-#### Alternative: Use the Smart Import
-
-If you want to import the strings directly into GlotPress, you can use the
-`npm run make-pot:smart` command. This will run the `make-pot` command and then
-open the import page in your browser and select the `bundle-strings.pot` file.
+   1. Drag and drop the `out/pots/bundle-strings.pot` to the file input in the GlotPress Studio page https://translate.wordpress.com/projects/studio/import-originals/
+   2. Leave the format as "auto-detecting".
+   3. Click **Import** and wait for the import to complete.
 
 ### Export and Add
 

--- a/package.json
+++ b/package.json
@@ -36,8 +36,7 @@
 		"test:watch": "cross-env NODE_OPTIONS='--no-deprecation' jest --watch",
 		"e2e": "npx playwright install && npx playwright test",
 		"test:metrics": "npx playwright test --config=./metrics/playwright.metrics.config.ts",
-		"make-pot": "wp-babel-makepot \"{./src,./cli,./common}/**/*.{js,jsx,ts,tsx}\" --ignore \"**/*.d.ts\" --base \".\" --dir \"./out/pots\" --output \"./out/pots/bundle-strings.pot\"",
-		"make-pot:smart": "npm run make-pot && open https://translate.wordpress.com/projects/studio/import-originals/ && open -R ./out/pots/bundle-strings.pot"
+		"make-pot": "node ./scripts/make-pot.mjs"
 	},
 	"devDependencies": {
 		"@automattic/color-studio": "^2.5.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
 		"test:watch": "cross-env NODE_OPTIONS='--no-deprecation' jest --watch",
 		"e2e": "npx playwright install && npx playwright test",
 		"test:metrics": "npx playwright test --config=./metrics/playwright.metrics.config.ts",
-		"make-pot": "wp-babel-makepot \"{./src,./cli,./common}/**/*.{js,jsx,ts,tsx}\" --ignore \"**/*.d.ts\" --base \".\" --dir \"./out/pots\" --output \"./out/pots/bundle-strings.pot\""
+		"make-pot": "wp-babel-makepot \"{./src,./cli,./common}/**/*.{js,jsx,ts,tsx}\" --ignore \"**/*.d.ts\" --base \".\" --dir \"./out/pots\" --output \"./out/pots/bundle-strings.pot\"",
+		"make-pot:smart": "npm run make-pot && open https://translate.wordpress.com/projects/studio/import-originals/ && open -R ./out/pots/bundle-strings.pot"
 	},
 	"devDependencies": {
 		"@automattic/color-studio": "^2.5.0",

--- a/scripts/make-pot.mjs
+++ b/scripts/make-pot.mjs
@@ -2,7 +2,6 @@ import { execSync } from 'child_process';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
 
-// Get the directory of this script and the project root
 const __filename = fileURLToPath( import.meta.url );
 const __dirname = dirname( __filename );
 const projectRoot = dirname( __dirname );
@@ -10,7 +9,7 @@ const projectRoot = dirname( __dirname );
 const POT_FILE = join( projectRoot, 'out', 'pots', 'bundle-strings.pot' );
 const IMPORT_PAGE = 'https://translate.wordpress.com/projects/studio/import-originals/';
 
-function executeCommand( command, description, exitOnError = true ) {
+function executeCommand( command, description ) {
 	try {
 		console.log( `🔄 ${ description }` );
 		execSync( command, { stdio: 'inherit', cwd: projectRoot } );

--- a/scripts/make-pot.mjs
+++ b/scripts/make-pot.mjs
@@ -1,6 +1,6 @@
 import { execSync } from 'child_process';
-import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
 
 const __filename = fileURLToPath( import.meta.url );
 const __dirname = dirname( __filename );

--- a/scripts/make-pot.mjs
+++ b/scripts/make-pot.mjs
@@ -1,0 +1,57 @@
+import { execSync } from 'child_process';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+// Get the directory of this script and the project root
+const __filename = fileURLToPath( import.meta.url );
+const __dirname = dirname( __filename );
+const projectRoot = dirname( __dirname );
+
+const POT_FILE = join( projectRoot, 'out', 'pots', 'bundle-strings.pot' );
+const IMPORT_PAGE = 'https://translate.wordpress.com/projects/studio/import-originals/';
+
+function executeCommand( command, description, exitOnError = true ) {
+	try {
+		console.log( `🔄 ${ description }` );
+		execSync( command, { stdio: 'inherit', cwd: projectRoot } );
+		return true;
+	} catch ( error ) {
+		console.error( `❌ Error: ${ description } failed` );
+		console.error( error.message );
+		return false;
+	}
+}
+
+console.log( '✨ Starting pot files generation...\n' );
+
+const commands = [
+	{
+		command: 'rm -rf ./out/pots',
+		description: 'Removing existing pot files',
+	},
+	{
+		command:
+			'wp-babel-makepot "{./src,./cli,./common}/**/*.{js,jsx,ts,tsx}" --ignore "**/*.d.ts" --base "." --dir "./out/pots" --output "./out/pots/bundle-strings.pot"',
+		description: 'Generating pot file wp-babel-makepot',
+	},
+	{
+		command: `open "${ IMPORT_PAGE }"`,
+		description: `Opening the translation import page ${ IMPORT_PAGE } in the browser`,
+	},
+	{
+		command: 'sleep 0.5',
+		description: 'Waiting for the browser to open',
+	},
+	{
+		command: `open -R "${ POT_FILE }"`,
+		description: `Revealing pot file in Finder: ${ POT_FILE }`,
+	},
+];
+
+for ( const { command, description } of commands ) {
+	if ( ! executeCommand( command, description ) ) {
+		process.exit( 1 );
+	}
+}
+
+console.log( '\n✅ Drag and drop the pot file into GlotPress!' );

--- a/scripts/make-pot.mjs
+++ b/scripts/make-pot.mjs
@@ -31,7 +31,7 @@ const commands = [
 	{
 		command:
 			'wp-babel-makepot "{./src,./cli,./common}/**/*.{js,jsx,ts,tsx}" --ignore "**/*.d.ts" --base "." --dir "./out/pots" --output "./out/pots/bundle-strings.pot"',
-		description: 'Generating pot file wp-babel-makepot',
+		description: 'Generating pot file with wp-babel-makepot',
 	},
 	{
 		command: `open "${ IMPORT_PAGE }"`,
@@ -53,4 +53,4 @@ for ( const { command, description } of commands ) {
 	}
 }
 
-console.log( '\n✅ Drag and drop the pot file into GlotPress!' );
+console.log( '\n✅ Success! Now drag and drop the "bundle-strings.pot" file into GlotPress.' );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- pfHvTO-yN-p2 

## Proposed Changes

- This PR adds a `make-pot.mjs` script to simplify the process of uploading `bundle-strings.pot` to [Studio GlotPress](https://translate.wordpress.com/projects/studio/). Logic described in [localization.md](https://github.com/Automattic/studio/blob/trunk/docs/localization.md#extract-and-import).
- Update documentation describing the new suggested way.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run `npm run make-pot`
- Wait a few seconds
- Observe the browser correctly opens GlotPress import page so you can simply drag and drop the selected file.


https://github.com/user-attachments/assets/f735e67e-9be1-467d-a186-ed1f2c6bed15

**Output**



![Screenshot 2025-06-18 at 18 21 07](https://github.com/user-attachments/assets/9d7e35c4-8d1e-4857-8e7f-9c2d0ca47b5f)



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?