### PR TITLE
Handle selective sync for Pull action

### DIFF
--- a/src/components/sync-connected-sites.tsx
+++ b/src/components/sync-connected-sites.tsx
@@ -242,7 +242,7 @@ const SyncConnectedSiteControls = ( {
 							if ( syncDialogType === 'push' ) {
 								void pushSite( connectedSite, selectedSite, { optionsToSync } );
 							} else {
-								pullSite( connectedSite, selectedSite );
+								pullSite( connectedSite, selectedSite, { optionsToSync } );
 							}
 						} }
 						onRequestClose={ () => setSyncDialogType( null ) }

--- a/src/components/sync-dialog.tsx
+++ b/src/components/sync-dialog.tsx
@@ -273,6 +273,7 @@ export function SyncDialog( {
 							onChange={ ( value ) => handleExpanderChange( value === 'true' ) }
 							__next40pxDefaultSize
 							__nextHasNoMarginBottom
+							aria-label={ __( 'Select files and folders to sync' ) }
 						/>
 					</div>
 					<TreeView tree={ treeState } setTree={ setTreeState } />

--- a/src/components/tests/content-tab-sync.test.tsx
+++ b/src/components/tests/content-tab-sync.test.tsx
@@ -71,6 +71,20 @@ describe( 'ContentTabSync', () => {
 		( useFeatureFlags as jest.Mock ).mockReturnValue( {
 			selectiveSyncEnabled: false,
 		} );
+
+		Object.defineProperty( window, 'matchMedia', {
+			writable: true,
+			value: jest.fn().mockImplementation( ( query ) => ( {
+				matches: false,
+				media: query,
+				onchange: null,
+				addListener: jest.fn(), // deprecated
+				removeListener: jest.fn(), // deprecated
+				addEventListener: jest.fn(),
+				removeEventListener: jest.fn(),
+				dispatchEvent: jest.fn(),
+			} ) ),
+		} );
 	} );
 
 	const renderWithProvider = ( children: React.ReactElement ) => {
@@ -398,5 +412,98 @@ describe( 'ContentTabSync', () => {
 		renderWithProvider( <ContentTabSync selectedSite={ selectedSite } /> );
 
 		expect( screen.getByRole( 'progressbar' ) ).toBeInTheDocument();
+	} );
+
+	it( 'calls pullSite with correct optionsToSync when all options are selected', async () => {
+		( useFeatureFlags as jest.Mock ).mockReturnValue( {
+			selectiveSyncEnabled: true,
+		} );
+
+		const mockPullSite = jest.fn();
+		( useAuth as jest.Mock ).mockReturnValue( { isAuthenticated: true, authenticate: jest.fn() } );
+		const fakeSyncSite = {
+			id: 6,
+			name: 'My simple business site that needs a transfer',
+			url: 'https:/developer.wordpress.com/studio/',
+			syncSupport: 'already-connected',
+		};
+		( useSyncSites as jest.Mock ).mockReturnValue( {
+			connectedSites: [ fakeSyncSite ],
+			syncSites: [ fakeSyncSite ],
+			pullSite: mockPullSite,
+			isAnySitePulling: false,
+			isAnySitePushing: false,
+			getPullState: jest.fn(),
+			getPushState: jest.fn(),
+			refetchSites: jest.fn(),
+			getLastSyncTimeText: jest.fn().mockReturnValue( 'You have not pulled this site yet.' ),
+			isSiteIdPulling: jest.fn(),
+			isSiteIdPushing: jest.fn(),
+			clearTimeout: jest.fn(),
+		} );
+
+		renderWithProvider( <ContentTabSync selectedSite={ selectedSite } /> );
+
+		const pullButton = screen.getByRole( 'button', { name: /Pull/i } );
+		expect( pullButton ).toBeInTheDocument();
+		fireEvent.click( pullButton );
+
+		await screen.findByText( 'Pull from Production' );
+
+		const dialogPullButton = screen.getAllByRole( 'button', { name: /Pull/i } );
+		fireEvent.click( dialogPullButton[ 1 ] );
+
+		expect( mockPullSite ).toHaveBeenCalledWith( fakeSyncSite, selectedSite, {
+			optionsToSync: [ 'all' ],
+		} );
+	} );
+
+	it( 'calls pullSite with correct optionsToSync when options partially are selected', async () => {
+		( useFeatureFlags as jest.Mock ).mockReturnValue( {
+			selectiveSyncEnabled: true,
+		} );
+
+		const mockPullSite = jest.fn();
+		( useAuth as jest.Mock ).mockReturnValue( { isAuthenticated: true, authenticate: jest.fn() } );
+		const fakeSyncSite = {
+			id: 6,
+			name: 'My simple business site that needs a transfer',
+			url: 'https:/developer.wordpress.com/studio/',
+			syncSupport: 'already-connected',
+		};
+		( useSyncSites as jest.Mock ).mockReturnValue( {
+			connectedSites: [ fakeSyncSite ],
+			syncSites: [ fakeSyncSite ],
+			pullSite: mockPullSite,
+			isAnySitePulling: false,
+			isAnySitePushing: false,
+			getPullState: jest.fn(),
+			getPushState: jest.fn(),
+			refetchSites: jest.fn(),
+			getLastSyncTimeText: jest.fn().mockReturnValue( 'You have not pulled this site yet.' ),
+			isSiteIdPulling: jest.fn(),
+			isSiteIdPushing: jest.fn(),
+			clearTimeout: jest.fn(),
+		} );
+
+		renderWithProvider( <ContentTabSync selectedSite={ selectedSite } /> );
+
+		const pullButton = screen.getByRole( 'button', { name: /Pull/i } );
+		expect( pullButton ).toBeInTheDocument();
+		fireEvent.click( pullButton );
+
+		await screen.findByText( 'Pull from Production' );
+
+		const select = screen.getByRole( 'combobox', { name: 'Select files and folders to sync' } );
+		fireEvent.change( select, { target: { value: true } } );
+
+		fireEvent.click( screen.getByText( 'Other files and directories' ) );
+
+		const dialogPullButton = screen.getAllByRole( 'button', { name: /Pull/i } );
+		fireEvent.click( dialogPullButton[ 1 ] );
+
+		expect( mockPullSite ).toHaveBeenCalledWith( fakeSyncSite, selectedSite, {
+			optionsToSync: [ 'sqls', 'plugins', 'themes', 'uploads' ],
+		} );
 	} );
 } );

--- a/src/hooks/sync-sites/use-sync-pull.ts
+++ b/src/hooks/sync-sites/use-sync-pull.ts
@@ -3,6 +3,7 @@ import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import { useCallback, useEffect, useMemo } from 'react';
 import { SYNC_PUSH_SIZE_LIMIT_GB, SYNC_PUSH_SIZE_LIMIT_BYTES } from 'src/constants';
+import { SyncOption } from 'src/hooks/sync-sites/sync-option';
 import {
 	ClearState,
 	generateStateId,
@@ -31,9 +32,17 @@ export type SyncBackupState = {
 	remoteSiteUrl: string;
 };
 
+type PullSiteOptions = {
+	optionsToSync?: SyncOption[];
+};
+
 export type PullStates = Record< string, SyncBackupState >;
 type OnPullSuccess = ( siteId: number, localSiteId: string ) => void;
-type PullSite = ( connectedSite: SyncSite, selectedSite: SiteDetails ) => void;
+type PullSite = (
+	connectedSite: SyncSite,
+	selectedSite: SiteDetails,
+	options?: PullSiteOptions
+) => void;
 type IsSiteIdPulling = ( selectedSiteId: string, remoteSiteId?: number ) => boolean;
 
 type UseSyncPullProps = {
@@ -97,7 +106,7 @@ export function useSyncPull( {
 	const { startServer } = useSiteDetails();
 
 	const pullSite = useCallback< PullSite >(
-		async ( connectedSite, selectedSite ) => {
+		async ( connectedSite, selectedSite, options ) => {
 			if ( ! client ) {
 				return;
 			}
@@ -118,6 +127,9 @@ export function useSyncPull( {
 				const response = await client.req.post< { success: boolean; backup_id: string } >( {
 					path: `/sites/${ remoteSiteId }/studio-app/sync/backup`,
 					apiNamespace: 'wpcom/v2',
+					body: {
+						options: options?.optionsToSync,
+					},
 				} );
 
 				if ( response.success ) {


### PR DESCRIPTION
## Related issues

- Fixes STU-575

## Proposed Changes
With this PR we are sending selective sync options to backend of Pull action.

## Testing Instructions
Apply this patch at dotcom:
```
diff --git a/wp-content/rest-api-plugins/endpoints/studio-app/class-studio-app-sync.php b/wp-content/rest-api-plugins/endpoints/studio-app/class-studio-app-sync.php
index 845aabd29dc..1c4bac8fe2a 100644
--- a/wp-content/rest-api-plugins/endpoints/studio-app/class-studio-app-sync.php
+++ b/wp-content/rest-api-plugins/endpoints/studio-app/class-studio-app-sync.php
@@ -149,8 +149,11 @@ class WPCOM_REST_API_V2_Endpoint_Studio_App_Sync extends WP_REST_Controller {
         */
        public function backup_wpcom_site( WP_REST_Request $request ): WP_REST_Response {
                $options = $request->get_param( 'options' );
+               \l('$options1', $options);
                $options = array_values( array_intersect( $options, self::ALLOWED_SYNC_OPTIONS ) );
+               \l('$options2', $options);
                $options = empty( $options ) ? [ 'all' ] : $options;
+               \l('$options3', $options);
 
                $backup_manager = new Site_Studio_Backup_Manager( get_current_user_id(), get_current_blog_id() );
                $process_id = $backup_manager->backup_wpcom_site( $options );
```
1. Run `STUDIO_SELECTIVE_SYNC=true npm start`
2. Connect dotcom site to your Stuio site
3. Open Sync tab and click "Pull"
4. Holistically test different variations of options
5. Assert that they are correctly received at backend, e.g.<br /><img width="442" alt="Screenshot 2025-06-18 at 16 12 18" src="https://github.com/user-attachments/assets/d7daac3a-1335-4977-91c1-f7056ecdb993" />
6. Open `src/hooks/sync-sites/use-sync-pull.ts` and on 131 line replace `options: options?.optionsToSync,` with options: undefined, to make sure that everything works correctly w/o selective sync dialog
7. Assert that you see:<br /><img width="443" alt="Screenshot 2025-06-18 at 16 14 03" src="https://github.com/user-attachments/assets/e78a1aa0-5cde-4e36-abee-8d4b1d1a3b46" />
8. Additionally, you can Take a look at teh backup and make sure that it includes only selected options, to do so apply the next patch and you can find the path in console<br />
```
diff --git a/src/hooks/sync-sites/use-sync-pull.ts b/src/hooks/sync-sites/use-sync-pull.ts
index 9000940a..3f66d21e 100644
--- a/src/hooks/sync-sites/use-sync-pull.ts
+++ b/src/hooks/sync-sites/use-sync-pull.ts
@@ -222,7 +222,8 @@ export function useSyncPull( {
                                        { showImportNotification: false }
                                );
 
-                               await getIpcApi().removeSyncBackup( remoteSiteId );
+                               const path = await getIpcApi().removeSyncBackup( remoteSiteId );
+                               console.log(path);
 
                                await startServer( selectedSite.id );
 
diff --git a/src/ipc-handlers.ts b/src/ipc-handlers.ts
index e685578e..257af558 100644
--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -1208,7 +1208,8 @@ export async function downloadSyncBackup(
 
 export async function removeSyncBackup( event: IpcMainInvokeEvent, remoteSiteId: number ) {
        const filePath = getSyncBackupTempPath( remoteSiteId );
-       await fsPromises.unlink( filePath );
+       // await fsPromises.unlink( filePath );
+       return filePath;
 }
 
 export async function isImportExportSupported( _event: IpcMainInvokeEvent, siteId: string ) {
```
9. And finally, you can make a complete test from UI perspective with testing different variations. I tested these two:
	9.1. Added theme A
	9.2 Added plugin B and removed plugin C
	9.3 Pull everything except themes
	9.4 Asserted that I still see theme A and plugins were reverted back
	9.5 Did the same steps, but this time excluded plugins