### PR TITLE
Open browser as the last step to ensure it works with Choosy

### DIFF
--- a/scripts/make-pot.mjs
+++ b/scripts/make-pot.mjs
@@ -38,10 +38,6 @@ const commands = [
 		description: `Revealing pot file in Finder: ${ POT_FILE }`,
 	},
 	{
-		command: 'sleep 0.5',
-		description: 'Waiting for the Finder to open',
-	},
-	{
 		command: `open "${ IMPORT_PAGE }"`,
 		description: `Opening the translation import page ${ IMPORT_PAGE } in the browser`,
 	}

--- a/scripts/make-pot.mjs
+++ b/scripts/make-pot.mjs
@@ -34,17 +34,17 @@ const commands = [
 		description: 'Generating pot file with wp-babel-makepot',
 	},
 	{
-		command: `open "${ IMPORT_PAGE }"`,
-		description: `Opening the translation import page ${ IMPORT_PAGE } in the browser`,
-	},
-	{
-		command: 'sleep 0.5',
-		description: 'Waiting for the browser to open',
-	},
-	{
 		command: `open -R "${ POT_FILE }"`,
 		description: `Revealing pot file in Finder: ${ POT_FILE }`,
 	},
+	{
+		command: 'sleep 0.5',
+		description: 'Waiting for the Finder to open',
+	},
+	{
+		command: `open "${ IMPORT_PAGE }"`,
+		description: `Opening the translation import page ${ IMPORT_PAGE } in the browser`,
+	}
 ];
 
 for ( const { command, description } of commands ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Follow up to https://github.com/Automattic/studio/pull/1485

## Proposed Changes

I propose to open the browser as the last step to ensure it works with Choosy. In other cases, opening Finder immediately closes Choosy selector, so the browser is not opened.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Test if the browser and Finder are opening.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
