### PR TITLE
Remove backslashes when creating host entry as security measure

### DIFF
--- a/src/lib/hosts-file.ts
+++ b/src/lib/hosts-file.ts
@@ -67,9 +67,13 @@ export const writeHostsFile = async ( content: string ): Promise< void > => {
  * Create a regular expression matching the hosts entry for a given domain:
  *
  * 	127.0.0.1 foo.wp.cloud # Port 8000
+ *
+ * 	Remove backslashes and escape dots as a security measure.
  */
-function createHostsEntryPattern( domain: string ): RegExp {
-	return new RegExp( `127\\.0\\.0\\.1\\s+${ domain.replace( /\./g, '\\.' ) }(\\s|$)`, 'i' );
+export function createHostsEntryPattern( domain: string ): RegExp {
+	const sanitizedDomain = domain.replace( /\\/g, '' );
+	const escapedDomain = sanitizedDomain.replace( /\./g, '\\.' );
+	return new RegExp( `127\\.0\\.0\\.1\\s+${ escapedDomain }(\\s|$)`, 'i' );
 }
 
 /**

--- a/src/lib/hosts-file.ts
+++ b/src/lib/hosts-file.ts
@@ -4,6 +4,7 @@ import { platform, tmpdir } from 'os';
 import path from 'path';
 import { promisify } from 'util';
 import * as Sentry from '@sentry/electron/main';
+import escapeRegExp from 'lodash/escapeRegExp';
 import { sudoExec } from 'src/lib/sudo-exec';
 
 const readFile = promisify( fs.readFile );
@@ -68,11 +69,11 @@ export const writeHostsFile = async ( content: string ): Promise< void > => {
  *
  * 	127.0.0.1 foo.wp.cloud # Port 8000
  *
- * 	Remove backslashes and escape dots as a security measure.
+ * 	Remove backslashes as a security measure and escape regex special characters.
  */
 export function createHostsEntryPattern( domain: string ): RegExp {
 	const sanitizedDomain = domain.replace( /\\/g, '' );
-	const escapedDomain = sanitizedDomain.replace( /\./g, '\\.' );
+	const escapedDomain = escapeRegExp( sanitizedDomain );
 	return new RegExp( `127\\.0\\.0\\.1\\s+${ escapedDomain }(\\s|$)`, 'i' );
 }
 

--- a/src/lib/tests/hosts-file.test.ts
+++ b/src/lib/tests/hosts-file.test.ts
@@ -150,23 +150,34 @@ describe( 'hosts-file', () => {
 	describe( 'createHostsEntryPattern', () => {
 		it( 'should remove backslashes as a security measure', () => {
 			const pattern = createHostsEntryPattern( 'test\\backslash.wp.cloud' );
-			// The pattern should match a domain with backslashes removed
-			expect( '127.0.0.1 testbackslash.wp.cloud # Port 8000' ).toMatch( pattern );
-			expect( '127.0.0.1 test\\backslash.wp.cloud # Port 8000' ).not.toMatch( pattern );
+			const expectedPattern = /127\.0\.0\.1\s+testbackslash\.wp\.cloud(\s|$)/i;
+
+			expect( pattern.source ).toBe( expectedPattern.source );
+			expect( pattern.flags ).toBe( expectedPattern.flags );
 		} );
 
-		it( 'should escape dots in domain names', () => {
+		it( 'should escape dots and other regex special characters', () => {
 			const pattern = createHostsEntryPattern( 'test.example.com' );
-			// Should match the exact domain
-			expect( '127.0.0.1 test.example.com # Port 8000' ).toMatch( pattern );
-			// Should not match a domain with extra dots
-			expect( '127.0.0.1 testxexample.com # Port 8000' ).not.toMatch( pattern );
+			const expectedPattern = /127\.0\.0\.1\s+test\.example\.com(\s|$)/i;
+
+			expect( pattern.source ).toBe( expectedPattern.source );
+			expect( pattern.flags ).toBe( expectedPattern.flags );
 		} );
 
 		it( 'should handle domains with multiple backslashes', () => {
 			const pattern = createHostsEntryPattern( 'test\\\\backslash.wp.cloud' );
-			// Should match the domain with all backslashes removed
-			expect( '127.0.0.1 testbackslash.wp.cloud # Port 8000' ).toMatch( pattern );
+			const expectedPattern = /127\.0\.0\.1\s+testbackslash\.wp\.cloud(\s|$)/i;
+
+			expect( pattern.source ).toBe( expectedPattern.source );
+			expect( pattern.flags ).toBe( expectedPattern.flags );
+		} );
+
+		it( 'should escape other regex special characters', () => {
+			const pattern = createHostsEntryPattern( 'test+example*com' );
+			const expectedPattern = /127\.0\.0\.1\s+test\+example\*com(\s|$)/i;
+
+			expect( pattern.source ).toBe( expectedPattern.source );
+			expect( pattern.flags ).toBe( expectedPattern.flags );
 		} );
 	} );
 

--- a/src/lib/tests/hosts-file.test.ts
+++ b/src/lib/tests/hosts-file.test.ts
@@ -1,5 +1,10 @@
 import { readFile, writeFile } from 'fs';
-import { addDomainToHosts, removeDomainFromHosts, updateDomainInHosts } from '../hosts-file';
+import {
+	addDomainToHosts,
+	removeDomainFromHosts,
+	updateDomainInHosts,
+	createHostsEntryPattern,
+} from '../hosts-file';
 
 const readFileCallbackMock = jest.fn();
 
@@ -139,6 +144,29 @@ describe( 'hosts-file', () => {
 
 			expect( readFile ).toHaveBeenCalled();
 			expect( writeFile ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'createHostsEntryPattern', () => {
+		it( 'should remove backslashes as a security measure', () => {
+			const pattern = createHostsEntryPattern( 'test\\backslash.wp.cloud' );
+			// The pattern should match a domain with backslashes removed
+			expect( '127.0.0.1 testbackslash.wp.cloud # Port 8000' ).toMatch( pattern );
+			expect( '127.0.0.1 test\\backslash.wp.cloud # Port 8000' ).not.toMatch( pattern );
+		} );
+
+		it( 'should escape dots in domain names', () => {
+			const pattern = createHostsEntryPattern( 'test.example.com' );
+			// Should match the exact domain
+			expect( '127.0.0.1 test.example.com # Port 8000' ).toMatch( pattern );
+			// Should not match a domain with extra dots
+			expect( '127.0.0.1 testxexample.com # Port 8000' ).not.toMatch( pattern );
+		} );
+
+		it( 'should handle domains with multiple backslashes', () => {
+			const pattern = createHostsEntryPattern( 'test\\\\backslash.wp.cloud' );
+			// Should match the domain with all backslashes removed
+			expect( '127.0.0.1 testbackslash.wp.cloud # Port 8000' ).toMatch( pattern );
 		} );
 	} );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/studio/security/code-scanning/11

## Proposed Changes

I propose to remove backslashes when creating host entry as security measure.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Check if a site with a custom domain can still be created.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
