### PR TITLE
Disable topbar log in button when offline

### DIFF
--- a/src/components/tests/topbar.test.tsx
+++ b/src/components/tests/topbar.test.tsx
@@ -10,6 +10,7 @@ jest.mock( 'src/hooks/use-auth' );
 jest.mock( 'src/hooks/use-offline' );
 
 const mockOpenURL = jest.fn();
+const mockAuthenticate = jest.fn();
 const toggleMinWindowWidth = jest.fn();
 jest.mock( 'src/lib/get-ipc-api', () => ( {
 	__esModule: true,
@@ -18,6 +19,7 @@ jest.mock( 'src/lib/get-ipc-api', () => ( {
 		showOpenFolderDialog: jest.fn(),
 		generateProposedSitePath: jest.fn(),
 		openURL: mockOpenURL,
+		authenticate: mockAuthenticate,
 		toggleMinWindowWidth,
 	} ),
 } ) );
@@ -87,5 +89,50 @@ describe( 'TopBar', () => {
 
 		expect( onToggleSidebar ).toHaveBeenCalledTimes( 1 );
 		expect( toggleMinWindowWidth ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	describe( 'login button with offline state', () => {
+		it( 'disables login button when offline and unauthenticated', async () => {
+			const user = userEvent.setup();
+			( useAuth as jest.Mock ).mockReturnValue( { isAuthenticated: false } );
+			( useOffline as jest.Mock ).mockReturnValue( true );
+
+			renderWithProvider( <TopBar onToggleSidebar={ jest.fn() } /> );
+
+			const loginButton = screen.getByRole( 'button', {
+				name: 'Log in to Studio with WordPress.com',
+			} );
+			expect( loginButton ).toBeDisabled();
+			// Try to click the disabled button
+			await user.click( loginButton );
+
+			// Authentication should not be called since button is disabled
+			expect( mockAuthenticate ).not.toHaveBeenCalled();
+		} );
+
+		it( 'enables login button when online and unauthenticated', async () => {
+			( useAuth as jest.Mock ).mockReturnValue( { isAuthenticated: false } );
+			( useOffline as jest.Mock ).mockReturnValue( false );
+
+			renderWithProvider( <TopBar onToggleSidebar={ jest.fn() } /> );
+
+			const loginButton = screen.getByRole( 'button', {
+				name: 'Log in to Studio with WordPress.com',
+			} );
+			expect( loginButton ).not.toBeDisabled();
+		} );
+
+		it( 'shows offline tooltip when offline and unauthenticated', async () => {
+			const user = userEvent.setup();
+			( useAuth as jest.Mock ).mockReturnValue( { isAuthenticated: false } );
+			( useOffline as jest.Mock ).mockReturnValue( true );
+			renderWithProvider( <TopBar onToggleSidebar={ jest.fn() } /> );
+			const loginButton = screen.getByRole( 'button', {
+				name: 'Log in to Studio with WordPress.com',
+			} );
+			expect( loginButton ).toBeDisabled();
+			await user.hover( loginButton );
+			expect( screen.getByText( "You're currently offline." ) ).toBeInTheDocument();
+		} );
 	} );
 } );

--- a/src/components/top-bar.tsx
+++ b/src/components/top-bar.tsx
@@ -72,6 +72,7 @@ function OfflineIndicator() {
 function Authentication() {
 	const { __ } = useI18n();
 	const { isAuthenticated, user } = useAuth();
+	const isOffline = useOffline();
 	if ( isAuthenticated ) {
 		return (
 			<Button
@@ -87,15 +88,22 @@ function Authentication() {
 	}
 
 	return (
-		<Button
-			onClick={ () => getIpcApi().authenticate( false ) }
-			aria-label={ __( 'Log in to Studio with WordPress.com' ) }
-			className="flex gap-x-2 justify-between w-full text-white rounded !px-2 !py-0 h-auto active:!text-white hover:!text-white hover:underline items-center"
+		<Tooltip
+			disabled={ ! isOffline }
+			icon={ offlineIcon }
+			text={ __( "You're currently offline." ) }
 		>
-			<WordPressLogo />
+			<Button
+				onClick={ () => getIpcApi().authenticate( false ) }
+				aria-label={ __( 'Log in to Studio with WordPress.com' ) }
+				className="flex gap-x-2 justify-between w-full text-white rounded !px-2 !py-0 h-auto active:!text-white hover:!text-white hover:underline items-center"
+				disabled={ isOffline }
+			>
+				<WordPressLogo />
 
-			<div className="text-s text-right">{ __( 'Log in' ) }</div>
-		</Button>
+				<div className="text-s text-right">{ __( 'Log in' ) }</div>
+			</Button>
+		</Tooltip>
 	);
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-582

## Proposed Changes

- Disable main login button when offline and add tooltip.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run `npm start`
- Make sure you are logged out
- Disable your internet connection
- Observe the login button has a lower opacity
- Move the mouse hover
- Observe the tooltip that says "You're currently offline."


https://github.com/user-attachments/assets/fdae4476-f81b-4115-862b-39a830dae137



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
