### PR TITLE
Sync: Implement the selective sync archive to prepare only the selected parts on UI

### DIFF
--- a/src/components/sync-connected-sites.tsx
+++ b/src/components/sync-connected-sites.tsx
@@ -37,8 +37,17 @@ interface ConnectedSiteSection {
 	connectedSites: SyncSite[];
 }
 
-export const convertTreeToOptionsToSync = ( tree: TreeNode[] ): SyncOption[] => {
+export type SyncOptionsWithSelections = {
+	optionsToSync: SyncOption[];
+	specificSelections?: {
+		plugins?: string[];
+		themes?: string[];
+	};
+};
+
+export const convertTreeToOptionsToSync = ( tree: TreeNode[] ): SyncOptionsWithSelections => {
 	const optionsToSync: SyncOption[] = [];
+	const specificSelections: { plugins?: string[]; themes?: string[] } = {};
 
 	const isAll = tree.every( ( node ) => node.checked );
 	if ( isAll ) {
@@ -54,13 +63,41 @@ export const convertTreeToOptionsToSync = ( tree: TreeNode[] ): SyncOption[] => 
 		const wpContent = filesAndFolders.find( ( node ) => node.id === 'wp-content' )?.children || [];
 
 		wpContent.forEach( ( item ) => {
-			if ( item.checked && isSyncOption( item.id ) ) {
-				optionsToSync.push( item.id );
+			if ( isSyncOption( item.id ) ) {
+				const hasCheckedChildren = item.children?.some( ( child ) => child.checked );
+				const shouldInclude = item.checked || hasCheckedChildren;
+
+				if ( shouldInclude ) {
+					optionsToSync.push( item.id );
+
+					if ( item.id === SYNC_OPTIONS.plugins && item.children ) {
+						const selectedPlugins = item.children
+							.filter( ( plugin ) => plugin.checked )
+							.map( ( plugin ) => plugin.id );
+						if ( selectedPlugins.length > 0 && selectedPlugins.length < item.children.length ) {
+							specificSelections.plugins = selectedPlugins;
+						}
+					}
+
+					if ( item.id === SYNC_OPTIONS.themes && item.children ) {
+						const selectedThemes = item.children
+							.filter( ( theme ) => theme.checked )
+							.map( ( theme ) => theme.id );
+						if ( selectedThemes.length > 0 && selectedThemes.length < item.children.length ) {
+							specificSelections.themes = selectedThemes;
+						}
+					}
+				}
 			}
 		} );
 	}
 
-	return optionsToSync;
+	const hasSpecificSelections = specificSelections.plugins || specificSelections.themes;
+
+	return {
+		optionsToSync,
+		specificSelections: hasSpecificSelections ? specificSelections : undefined,
+	};
 };
 
 const SyncConnectedSiteControls = ( {
@@ -237,12 +274,14 @@ const SyncConnectedSiteControls = ( {
 						localSite={ selectedSite }
 						remoteSite={ connectedSite }
 						onSubmit={ ( tree ) => {
-							const optionsToSync = convertTreeToOptionsToSync( tree );
+							const syncOptions = convertTreeToOptionsToSync( tree );
 
 							if ( syncDialogType === 'push' ) {
-								void pushSite( connectedSite, selectedSite, { optionsToSync } );
+								void pushSite( connectedSite, selectedSite, syncOptions );
 							} else {
-								pullSite( connectedSite, selectedSite, { optionsToSync } );
+								pullSite( connectedSite, selectedSite, {
+									optionsToSync: syncOptions.optionsToSync,
+								} );
 							}
 						} }
 						onRequestClose={ () => setSyncDialogType( null ) }

--- a/src/components/sync-connected-sites.tsx
+++ b/src/components/sync-connected-sites.tsx
@@ -47,7 +47,7 @@ export type SyncOptionsWithSelections = {
 
 export const convertTreeToOptionsToSync = ( tree: TreeNode[] ): SyncOptionsWithSelections => {
 	const optionsToSync: SyncOption[] = [];
-	const specificSelections: { plugins?: string[]; themes?: string[] } = {};
+	let specificSelections: { plugins?: string[]; themes?: string[] } | undefined = undefined;
 
 	const isAll = tree.every( ( node ) => node.checked );
 	if ( isAll ) {
@@ -79,17 +79,18 @@ export const convertTreeToOptionsToSync = ( tree: TreeNode[] ): SyncOptionsWithS
 					.filter( ( child ) => child.checked )
 					.map( ( child ) => child.id );
 				if ( selectedItems.length > 0 && selectedItems.length < item.children.length ) {
-					specificSelections[ item.id ] = selectedItems;
+					specificSelections = {
+						...specificSelections,
+						[ item.id ]: selectedItems,
+					};
 				}
 			}
 		} );
 	}
 
-	const hasSpecificSelections = specificSelections.plugins || specificSelections.themes;
-
 	return {
 		optionsToSync,
-		specificSelections: hasSpecificSelections ? specificSelections : undefined,
+		specificSelections,
 	};
 };
 
@@ -272,9 +273,7 @@ const SyncConnectedSiteControls = ( {
 							if ( syncDialogType === 'push' ) {
 								void pushSite( connectedSite, selectedSite, syncOptions );
 							} else {
-								pullSite( connectedSite, selectedSite, {
-									optionsToSync: syncOptions.optionsToSync,
-								} );
+								pullSite( connectedSite, selectedSite, syncOptions );
 							}
 						} }
 						onRequestClose={ () => setSyncDialogType( null ) }

--- a/src/components/sync-connected-sites.tsx
+++ b/src/components/sync-connected-sites.tsx
@@ -63,30 +63,23 @@ export const convertTreeToOptionsToSync = ( tree: TreeNode[] ): SyncOptionsWithS
 		const wpContent = filesAndFolders.find( ( node ) => node.id === 'wp-content' )?.children || [];
 
 		wpContent.forEach( ( item ) => {
-			if ( isSyncOption( item.id ) ) {
-				const hasCheckedChildren = item.children?.some( ( child ) => child.checked );
-				const shouldInclude = item.checked || hasCheckedChildren;
+			if ( ! isSyncOption( item.id ) ) {
+				return;
+			}
 
-				if ( shouldInclude ) {
-					optionsToSync.push( item.id );
+			if ( item.checked || item.indeterminate ) {
+				optionsToSync.push( item.id );
+			}
 
-					if ( item.id === SYNC_OPTIONS.plugins && item.children ) {
-						const selectedPlugins = item.children
-							.filter( ( plugin ) => plugin.checked )
-							.map( ( plugin ) => plugin.id );
-						if ( selectedPlugins.length > 0 && selectedPlugins.length < item.children.length ) {
-							specificSelections.plugins = selectedPlugins;
-						}
-					}
-
-					if ( item.id === SYNC_OPTIONS.themes && item.children ) {
-						const selectedThemes = item.children
-							.filter( ( theme ) => theme.checked )
-							.map( ( theme ) => theme.id );
-						if ( selectedThemes.length > 0 && selectedThemes.length < item.children.length ) {
-							specificSelections.themes = selectedThemes;
-						}
-					}
+			if (
+				item.children &&
+				( item.id === SYNC_OPTIONS.plugins || item.id === SYNC_OPTIONS.themes )
+			) {
+				const selectedItems = item.children
+					.filter( ( child ) => child.checked )
+					.map( ( child ) => child.id );
+				if ( selectedItems.length > 0 && selectedItems.length < item.children.length ) {
+					specificSelections[ item.id ] = selectedItems;
 				}
 			}
 		} );

--- a/src/components/tests/convert-tree-to-options-to-sync.tsx
+++ b/src/components/tests/convert-tree-to-options-to-sync.tsx
@@ -9,7 +9,7 @@ describe( 'convertTreeToOptionsToSync', () => {
 		const tree = result.current;
 
 		const optionsToSync = convertTreeToOptionsToSync( tree );
-		expect( optionsToSync ).toEqual( [ 'all' ] );
+		expect( optionsToSync ).toEqual( { optionsToSync: [ 'all' ], specificSelections: undefined } );
 	} );
 
 	it( 'returns ["sqls"] when only database is selected', () => {
@@ -19,7 +19,7 @@ describe( 'convertTreeToOptionsToSync', () => {
 		tree = updateNodeById( tree, 'filesAndFolders', { checked: false } );
 
 		const optionsToSync = convertTreeToOptionsToSync( tree );
-		expect( optionsToSync ).toEqual( [ 'sqls' ] );
+		expect( optionsToSync ).toEqual( { optionsToSync: [ 'sqls' ], specificSelections: undefined } );
 	} );
 
 	it( 'returns ["plugins"] when only plugins are selected', () => {
@@ -31,7 +31,7 @@ describe( 'convertTreeToOptionsToSync', () => {
 		tree = updateNodeById( tree, 'plugins', { checked: true } );
 
 		const optionsToSync = convertTreeToOptionsToSync( tree );
-		expect( optionsToSync ).toEqual( [ 'plugins' ] );
+		expect( optionsToSync ).toEqual( { optionsToSync: [ 'plugins' ], specificSelections: undefined } );
 	} );
 
 	it( 'returns ["sqls", "plugins"] when both are selected', () => {
@@ -42,6 +42,6 @@ describe( 'convertTreeToOptionsToSync', () => {
 		tree = updateNodeById( tree, 'plugins', { checked: true } );
 
 		const optionsToSync = convertTreeToOptionsToSync( tree );
-		expect( optionsToSync ).toEqual( [ 'sqls', 'plugins' ] );
+		expect( optionsToSync ).toEqual( { optionsToSync: [ 'sqls', 'plugins' ], specificSelections: undefined } );
 	} );
 } );

--- a/src/components/tests/convert-tree-to-options-to-sync.tsx
+++ b/src/components/tests/convert-tree-to-options-to-sync.tsx
@@ -31,7 +31,10 @@ describe( 'convertTreeToOptionsToSync', () => {
 		tree = updateNodeById( tree, 'plugins', { checked: true } );
 
 		const optionsToSync = convertTreeToOptionsToSync( tree );
-		expect( optionsToSync ).toEqual( { optionsToSync: [ 'plugins' ], specificSelections: undefined } );
+		expect( optionsToSync ).toEqual( {
+			optionsToSync: [ 'plugins' ],
+			specificSelections: undefined,
+		} );
 	} );
 
 	it( 'returns ["sqls", "plugins"] when both are selected', () => {
@@ -42,6 +45,9 @@ describe( 'convertTreeToOptionsToSync', () => {
 		tree = updateNodeById( tree, 'plugins', { checked: true } );
 
 		const optionsToSync = convertTreeToOptionsToSync( tree );
-		expect( optionsToSync ).toEqual( { optionsToSync: [ 'sqls', 'plugins' ], specificSelections: undefined } );
+		expect( optionsToSync ).toEqual( {
+			optionsToSync: [ 'sqls', 'plugins' ],
+			specificSelections: undefined,
+		} );
 	} );
 } );

--- a/src/hooks/sync-sites/use-sync-push.ts
+++ b/src/hooks/sync-sites/use-sync-push.ts
@@ -30,6 +30,10 @@ export type SyncPushState = {
 
 type PushSiteOptions = {
 	optionsToSync?: SyncOption[];
+	specificSelections?: {
+		plugins?: string[];
+		themes?: string[];
+	};
 };
 
 export type PushStates = Record< string, SyncPushState >;
@@ -198,7 +202,8 @@ export function useSyncPush( {
 			try {
 				const result = await getIpcApi().exportSiteToPush(
 					selectedSite.id,
-					options?.optionsToSync
+					options?.optionsToSync,
+					options?.specificSelections
 				);
 				( { archiveContent, archivePath, archiveSizeInBytes } = result );
 			} catch ( error ) {

--- a/src/hooks/sync-sites/use-sync-push.ts
+++ b/src/hooks/sync-sites/use-sync-push.ts
@@ -196,7 +196,10 @@ export function useSyncPush( {
 			let archiveContent, archivePath, archiveSizeInBytes;
 
 			try {
-				const result = await getIpcApi().exportSiteToPush( selectedSite.id );
+				const result = await getIpcApi().exportSiteToPush(
+					selectedSite.id,
+					options?.optionsToSync
+				);
 				( { archiveContent, archivePath, archiveSizeInBytes } = result );
 			} catch ( error ) {
 				Sentry.captureException( error );

--- a/src/hooks/sync-sites/use-sync-push.ts
+++ b/src/hooks/sync-sites/use-sync-push.ts
@@ -200,11 +200,10 @@ export function useSyncPush( {
 			let archiveContent, archivePath, archiveSizeInBytes;
 
 			try {
-				const result = await getIpcApi().exportSiteToPush(
-					selectedSite.id,
-					options?.optionsToSync,
-					options?.specificSelections
-				);
+				const result = await getIpcApi().exportSiteToPush( selectedSite.id, {
+					optionsToSync: options?.optionsToSync,
+					specificSelections: options?.specificSelections,
+				} );
 				( { archiveContent, archivePath, archiveSizeInBytes } = result );
 			} catch ( error ) {
 				Sentry.captureException( error );

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -668,13 +668,20 @@ export async function exportSiteToPush(
 	const extension = 'tar.gz';
 	const archivePath = `${ TEMP_DIR }site_${ id }.${ extension }`;
 
+	const shouldIncludeSyncOption = (
+		optionsToSync: SyncOption[] | undefined,
+		option: SyncOption
+	): boolean => {
+		return optionsToSync?.includes( option ) || optionsToSync?.includes( 'all' ) || ! optionsToSync;
+	};
+
 	const includes = {
-		database: optionsToSync?.includes( 'sqls' ) || optionsToSync?.includes( 'all' ) || false,
-		uploads: optionsToSync?.includes( 'uploads' ) || optionsToSync?.includes( 'all' ) || false,
-		plugins: optionsToSync?.includes( 'plugins' ) || optionsToSync?.includes( 'all' ) || false,
-		themes: optionsToSync?.includes( 'themes' ) || optionsToSync?.includes( 'all' ) || false,
-		muPlugins: optionsToSync?.includes( 'contents' ) || optionsToSync?.includes( 'all' ) || false,
-		fonts: optionsToSync?.includes( 'contents' ) || optionsToSync?.includes( 'all' ) || false,
+		database: shouldIncludeSyncOption( optionsToSync, 'sqls' ),
+		uploads: shouldIncludeSyncOption( optionsToSync, 'uploads' ),
+		plugins: shouldIncludeSyncOption( optionsToSync, 'plugins' ),
+		themes: shouldIncludeSyncOption( optionsToSync, 'themes' ),
+		muPlugins: shouldIncludeSyncOption( optionsToSync, 'contents' ),
+		fonts: shouldIncludeSyncOption( optionsToSync, 'contents' ),
 	};
 
 	const exportOptions: ExportOptions = {

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -659,7 +659,11 @@ export async function archiveSite( event: IpcMainInvokeEvent, id: string, format
 export async function exportSiteToPush(
 	event: IpcMainInvokeEvent,
 	id: string,
-	optionsToSync?: SyncOption[]
+	optionsToSync?: SyncOption[],
+	specificSelections?: {
+		plugins?: string[];
+		themes?: string[];
+	}
 ) {
 	const site = SiteServer.get( id );
 	if ( ! site ) {
@@ -690,6 +694,7 @@ export async function exportSiteToPush(
 		includes,
 		phpVersion: site.details.phpVersion,
 		splitDatabaseDumpByTable: true,
+		specificSelections,
 	};
 	// eslint-disable-next-line @typescript-eslint/no-empty-function
 	const onEvent = () => {};

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -73,6 +73,7 @@ import {
 	updateAppdata,
 } from 'src/storage/user-data';
 import { DEFAULT_PHP_VERSION, DEFAULT_WORDPRESS_VERSION } from 'vendor/wp-now/src/constants';
+import type { SyncOption } from 'src/hooks/sync-sites/sync-option';
 import type { SyncSite } from 'src/hooks/use-fetch-wpcom-sites/types';
 import type { WpCliResult } from 'src/lib/wp-cli-process';
 
@@ -655,24 +656,31 @@ export async function archiveSite( event: IpcMainInvokeEvent, id: string, format
 	return { archivePath, archiveSizeInBytes: stats.size };
 }
 
-export async function exportSiteToPush( event: IpcMainInvokeEvent, id: string ) {
+export async function exportSiteToPush(
+	event: IpcMainInvokeEvent,
+	id: string,
+	optionsToSync?: SyncOption[]
+) {
 	const site = SiteServer.get( id );
 	if ( ! site ) {
 		throw new Error( 'Site not found.' );
 	}
 	const extension = 'tar.gz';
 	const archivePath = `${ TEMP_DIR }site_${ id }.${ extension }`;
+
+	const includes = {
+		database: optionsToSync?.includes( 'sqls' ) || optionsToSync?.includes( 'all' ) || false,
+		uploads: optionsToSync?.includes( 'uploads' ) || optionsToSync?.includes( 'all' ) || false,
+		plugins: optionsToSync?.includes( 'plugins' ) || optionsToSync?.includes( 'all' ) || false,
+		themes: optionsToSync?.includes( 'themes' ) || optionsToSync?.includes( 'all' ) || false,
+		muPlugins: optionsToSync?.includes( 'contents' ) || optionsToSync?.includes( 'all' ) || false,
+		fonts: optionsToSync?.includes( 'contents' ) || optionsToSync?.includes( 'all' ) || false,
+	};
+
 	const exportOptions: ExportOptions = {
 		site: site.details,
 		backupFile: archivePath,
-		includes: {
-			database: true,
-			uploads: true,
-			plugins: true,
-			themes: true,
-			muPlugins: true,
-			fonts: true,
-		},
+		includes,
 		phpVersion: site.details.phpVersion,
 		splitDatabaseDumpByTable: true,
 	};

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -659,10 +659,12 @@ export async function archiveSite( event: IpcMainInvokeEvent, id: string, format
 export async function exportSiteToPush(
 	event: IpcMainInvokeEvent,
 	id: string,
-	optionsToSync?: SyncOption[],
-	specificSelections?: {
-		plugins?: string[];
-		themes?: string[];
+	configuration?: {
+		optionsToSync?: SyncOption[];
+		specificSelections?: {
+			plugins?: string[];
+			themes?: string[];
+		};
 	}
 ) {
 	const site = SiteServer.get( id );
@@ -680,12 +682,12 @@ export async function exportSiteToPush(
 	};
 
 	const includes = {
-		database: shouldIncludeSyncOption( optionsToSync, 'sqls' ),
-		uploads: shouldIncludeSyncOption( optionsToSync, 'uploads' ),
-		plugins: shouldIncludeSyncOption( optionsToSync, 'plugins' ),
-		themes: shouldIncludeSyncOption( optionsToSync, 'themes' ),
-		muPlugins: shouldIncludeSyncOption( optionsToSync, 'contents' ),
-		fonts: shouldIncludeSyncOption( optionsToSync, 'contents' ),
+		database: shouldIncludeSyncOption( configuration?.optionsToSync, 'sqls' ),
+		uploads: shouldIncludeSyncOption( configuration?.optionsToSync, 'uploads' ),
+		plugins: shouldIncludeSyncOption( configuration?.optionsToSync, 'plugins' ),
+		themes: shouldIncludeSyncOption( configuration?.optionsToSync, 'themes' ),
+		muPlugins: shouldIncludeSyncOption( configuration?.optionsToSync, 'contents' ),
+		fonts: shouldIncludeSyncOption( configuration?.optionsToSync, 'contents' ),
 	};
 
 	const exportOptions: ExportOptions = {
@@ -694,7 +696,7 @@ export async function exportSiteToPush(
 		includes,
 		phpVersion: site.details.phpVersion,
 		splitDatabaseDumpByTable: true,
-		specificSelections,
+		specificSelections: configuration?.specificSelections,
 	};
 	// eslint-disable-next-line @typescript-eslint/no-empty-function
 	const onEvent = () => {};

--- a/src/lib/import-export/export/exporters/default-exporter.ts
+++ b/src/lib/import-export/export/exporters/default-exporter.ts
@@ -160,20 +160,54 @@ export class DefaultExporter extends EventEmitter implements Exporter {
 			const folderName = category === 'muPlugins' ? 'mu-plugins' : category;
 			const absolutePath = path.join( this.options.site.path, 'wp-content', folderName );
 			const archivePath = path.relative( this.options.site.path, absolutePath );
-			this.archive.directory( absolutePath, archivePath, ( entry ) => {
-				const fullArchivePath = path.join( archivePath, entry.name );
-				const isExcluded = this.pathsToExclude.some( ( pathToExclude ) =>
-					fullArchivePath.startsWith( path.normalize( pathToExclude ) )
-				);
-				if (
-					isExcluded ||
-					entry.name.includes( '.git' ) ||
-					entry.name.includes( 'node_modules' )
-				) {
-					return false;
+
+			const hasSpecificSelections =
+				this.options.specificSelections &&
+				( ( category === 'plugins' && this.options.specificSelections.plugins ) ||
+					( category === 'themes' && this.options.specificSelections.themes ) );
+
+			if ( hasSpecificSelections ) {
+				const selectedItems =
+					category === 'plugins'
+						? this.options.specificSelections!.plugins!
+						: this.options.specificSelections!.themes!;
+
+				for ( const itemName of selectedItems ) {
+					const itemPath = path.join( absolutePath, itemName );
+					const itemArchivePath = path.join( archivePath, itemName );
+
+					if ( fs.existsSync( itemPath ) ) {
+						const stat = fs.statSync( itemPath );
+						if ( stat.isDirectory() ) {
+							this.archive.directory( itemPath, itemArchivePath, ( entry ) => {
+								if ( entry.name.includes( '.git' ) || entry.name.includes( 'node_modules' ) ) {
+									return false;
+								}
+								return entry;
+							} );
+						} else {
+							this.archive.file( itemPath, { name: itemArchivePath } );
+						}
+					}
 				}
-				return entry;
-			} );
+			} else {
+				// Add entire directory (existing behavior)
+				this.archive.directory( absolutePath, archivePath, ( entry ) => {
+					const fullArchivePath = path.join( archivePath, entry.name );
+					const isExcluded = this.pathsToExclude.some( ( pathToExclude ) =>
+						fullArchivePath.startsWith( path.normalize( pathToExclude ) )
+					);
+					if (
+						isExcluded ||
+						entry.name.includes( '.git' ) ||
+						entry.name.includes( 'node_modules' )
+					) {
+						return false;
+					}
+					return entry;
+				} );
+			}
+
 			this.emit( ExportEvents.WP_CONTENT_EXPORT_PROGRESS, { directory: absolutePath } );
 		}
 		this.emit( ExportEvents.WP_CONTENT_EXPORT_COMPLETE );

--- a/src/lib/import-export/export/exporters/default-exporter.ts
+++ b/src/lib/import-export/export/exporters/default-exporter.ts
@@ -161,18 +161,13 @@ export class DefaultExporter extends EventEmitter implements Exporter {
 			const absolutePath = path.join( this.options.site.path, 'wp-content', folderName );
 			const archivePath = path.relative( this.options.site.path, absolutePath );
 
-			const hasSpecificSelections =
+			const partialFolderItems =
 				this.options.specificSelections &&
 				( ( category === 'plugins' && this.options.specificSelections.plugins ) ||
 					( category === 'themes' && this.options.specificSelections.themes ) );
 
-			if ( hasSpecificSelections ) {
-				const selectedItems =
-					category === 'plugins'
-						? this.options.specificSelections!.plugins!
-						: this.options.specificSelections!.themes!;
-
-				for ( const itemName of selectedItems ) {
+			if ( partialFolderItems ) {
+				for ( const itemName of partialFolderItems ) {
 					const itemPath = path.join( absolutePath, itemName );
 					const itemArchivePath = path.join( archivePath, itemName );
 

--- a/src/lib/import-export/export/types.ts
+++ b/src/lib/import-export/export/types.ts
@@ -7,6 +7,10 @@ export interface ExportOptions {
 	includes: { [ index in ExportOptionsIncludes ]: boolean };
 	phpVersion: string;
 	splitDatabaseDumpByTable?: boolean;
+	specificSelections?: {
+		plugins?: string[];
+		themes?: string[];
+	};
 }
 
 export type ExportOptionsIncludes = BackupContentsCategory | 'database';

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -22,7 +22,8 @@ function ipcRendererSend< T extends keyof IpcHandlers >(
 
 const api: IpcApi = {
 	archiveSite: ( id, format ) => ipcRendererInvoke( 'archiveSite', id, format ),
-	exportSiteToPush: ( id ) => ipcRendererInvoke( 'exportSiteToPush', id ),
+	exportSiteToPush: ( id, optionsToSync? ) =>
+		ipcRendererInvoke( 'exportSiteToPush', id, optionsToSync ),
 	deleteSite: ( id, deleteFiles ) => ipcRendererInvoke( 'deleteSite', id, deleteFiles ),
 	createSite: ( path, name, wpVersion, customDomain, enableHttps ) =>
 		ipcRendererInvoke( 'createSite', path, name, wpVersion, customDomain, enableHttps ),

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -22,8 +22,8 @@ function ipcRendererSend< T extends keyof IpcHandlers >(
 
 const api: IpcApi = {
 	archiveSite: ( id, format ) => ipcRendererInvoke( 'archiveSite', id, format ),
-	exportSiteToPush: ( id, optionsToSync?, specificSelections? ) =>
-		ipcRendererInvoke( 'exportSiteToPush', id, optionsToSync, specificSelections ),
+	exportSiteToPush: ( id, configuration ) =>
+		ipcRendererInvoke( 'exportSiteToPush', id, configuration ),
 	deleteSite: ( id, deleteFiles ) => ipcRendererInvoke( 'deleteSite', id, deleteFiles ),
 	createSite: ( path, name, wpVersion, customDomain, enableHttps ) =>
 		ipcRendererInvoke( 'createSite', path, name, wpVersion, customDomain, enableHttps ),

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -22,8 +22,8 @@ function ipcRendererSend< T extends keyof IpcHandlers >(
 
 const api: IpcApi = {
 	archiveSite: ( id, format ) => ipcRendererInvoke( 'archiveSite', id, format ),
-	exportSiteToPush: ( id, optionsToSync? ) =>
-		ipcRendererInvoke( 'exportSiteToPush', id, optionsToSync ),
+	exportSiteToPush: ( id, optionsToSync?, specificSelections? ) =>
+		ipcRendererInvoke( 'exportSiteToPush', id, optionsToSync, specificSelections ),
 	deleteSite: ( id, deleteFiles ) => ipcRendererInvoke( 'deleteSite', id, deleteFiles ),
 	createSite: ( path, name, wpVersion, customDomain, enableHttps ) =>
 		ipcRendererInvoke( 'createSite', path, name, wpVersion, customDomain, enableHttps ),


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-560

## Proposed Changes

- Added selected options to the exporter

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- `STUDIO_SELECTIVE_SYNC=true npm start`
- Comment this line: https://github.com/Automattic/studio/blob/trunk/src/hooks/sync-sites/use-sync-push.ts#L272
- Start a Studio site push
- In your terminal check for the message like `Backup created at: ...`
- Confirm the backup has the selected options in your test
- After your test disable the STUDIO_SELECTIVE_SYNC or stop and start the server with `npm start`
- Repeat the test and check the backup contains all files

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
