### PR TITLE
Escape regex used in tests

### DIFF
--- a/src/components/tests/content-tab-sync.test.tsx
+++ b/src/components/tests/content-tab-sync.test.tsx
@@ -1,5 +1,6 @@
 // To run tests, execute `npm run test -- src/components/tests/content-tab-sync.test.tsx` from the root directory
 import { render, screen, fireEvent } from '@testing-library/react';
+import escapeRegExp from 'lodash/escapeRegExp';
 import { Provider } from 'react-redux';
 import { ContentTabSync } from 'src/components/content-tab-sync';
 import { SyncSitesProvider, useSyncSites } from 'src/hooks/sync-sites';
@@ -196,7 +197,9 @@ describe( 'ContentTabSync', () => {
 		} );
 		renderWithProvider( <ContentTabSync selectedSite={ selectedSite } /> );
 
-		const urlButton = screen.getByRole( 'button', { name: new RegExp( fakeSyncSite.url, 'i' ) } );
+		const urlButton = screen.getByRole( 'button', {
+			name: new RegExp( escapeRegExp( fakeSyncSite.url ), 'i' ),
+		} );
 		expect( urlButton ).toBeInTheDocument();
 
 		fireEvent.click( urlButton );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/studio/security/code-scanning/3

## Proposed Changes

I propose to escape the regex used in tests.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Run tests and confirm they go through:

```
npm run test
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
