### PR TITLE
Add support of partial pulling sites

### DIFF
--- a/src/lib/import-export/import/importers/importer.ts
+++ b/src/lib/import-export/import/importers/importer.ts
@@ -98,17 +98,21 @@ abstract class BaseBackupImporter extends BaseImporter {
 		this.emit( ImportEvents.IMPORT_START );
 
 		try {
-			const databaseDir = path.join( rootPath, 'wp-content', 'database' );
-			const dbPath = path.join( databaseDir, '.ht.sqlite' );
-			await this.moveExistingDatabaseToTrash( dbPath );
+			if ( this.backup.sqlFiles.length ) {
+				const databaseDir = path.join( rootPath, 'wp-content', 'database' );
+				const dbPath = path.join( databaseDir, '.ht.sqlite' );
+
+				await this.moveExistingDatabaseToTrash( dbPath );
+				await this.createEmptyDatabase( dbPath );
+				await this.importDatabase( rootPath, siteId, this.backup.sqlFiles );
+			}
+
 			await this.moveExistingWpContentToTrash( rootPath );
-			await this.createEmptyDatabase( dbPath );
 			await this.importWpConfig( rootPath );
 			await this.importWpContent( rootPath );
 			if ( this.backup.metaFile ) {
 				this.meta = await this.parseMetaFile();
 			}
-			await this.importDatabase( rootPath, siteId, this.backup.sqlFiles );
 
 			this.emit( ImportEvents.IMPORT_COMPLETE );
 			return {

--- a/src/lib/import-export/import/validators/jetpack-validator.ts
+++ b/src/lib/import-export/import/validators/jetpack-validator.ts
@@ -6,11 +6,16 @@ import { Validator } from 'src/lib/import-export/import/validators/validator';
 
 export class JetpackValidator extends EventEmitter implements Validator {
 	canHandle( fileList: string[] ): boolean {
-		const requiredDirs = [ 'sql', 'wp-content/uploads', 'wp-content/plugins', 'wp-content/themes' ];
-		return (
-			requiredDirs.some( ( dir ) => fileList.some( ( file ) => file.startsWith( dir + '/' ) ) ) &&
-			fileList.some( ( file ) => file.startsWith( 'sql/' ) && file.endsWith( '.sql' ) )
+		const optionalDirs = [ 'sql', 'wp-content/uploads', 'wp-content/plugins', 'wp-content/themes' ];
+		const optionalFiles = [ 'wp-config.php' ];
+
+		const hasRequiredMetaJson = fileList.some( ( file ) => file === 'meta.json' );
+		const hasOptionalDir = optionalDirs.some( ( dir ) =>
+			fileList.some( ( file ) => file.startsWith( dir + '/' ) )
 		);
+		const hasOptionalFile = optionalFiles.some( ( file ) => fileList.includes( file ) );
+
+		return hasRequiredMetaJson && ( hasOptionalDir || hasOptionalFile );
 	}
 
 	parseBackupContents( fileList: string[], extractionDirectory: string ): BackupContents {

--- a/src/lib/import-export/tests/import/validators/jetpack-validator.test.ts
+++ b/src/lib/import-export/tests/import/validators/jetpack-validator.test.ts
@@ -11,6 +11,7 @@ platformTestSuite( 'JetpackValidator', ( { normalize } ) => {
 	describe( 'canHandle', () => {
 		it( 'should return true for valid Jetpack backup structure', () => {
 			const fileList = [
+				'meta.json',
 				'sql/wp_options.sql',
 				'wp-content/uploads/2023/image.jpg',
 				'wp-content/plugins/jetpack/jetpack.php',
@@ -22,6 +23,7 @@ platformTestSuite( 'JetpackValidator', ( { normalize } ) => {
 
 		it( 'should not fail if core files exists.', () => {
 			const fileList = [
+				'meta.json',
 				'sql/wp_options.sql',
 				'wp-admin/wp-admin.php',
 				'wp-admin/about.php',
@@ -38,6 +40,20 @@ platformTestSuite( 'JetpackValidator', ( { normalize } ) => {
 			const fileList = [ 'random.txt', 'another-file.js' ];
 			expect( validator.canHandle( fileList ) ).toBe( false );
 		} );
+
+		it.each( [
+			'sql/wp_options.sql',
+			'wp-content/plugins/jetpack/jetpack.php',
+			'wp-content/themes/twentytwentyone/style.css',
+			'wp-content/uploads/img.jpg',
+			'wp-config.php',
+		] )(
+			'should return true if meta.json exists and at least one of the optional files or dirs exists: %s',
+			( fileOrDir ) => {
+				const fileList = [ 'meta.json', fileOrDir ];
+				expect( validator.canHandle( fileList ) ).toBe( true );
+			}
+		);
 	} );
 
 	describe( 'parseBackupContents', () => {


### PR DESCRIPTION
## Related issues

- Fixes STU-559

## Proposed Changes

Previously, it was possible to pull only the whole site to Studio. With this PR we are adding support of pulling partially (when selective sync is used).

## Testing Instructions
1. Run `STUDIO_SELECTIVE_SYNC=true npm start`
2. Crete Studio site, create dotcom site and connect them in Studio
3. Open `Sync` tab
4. Click `Pull`
5. Try:
	5.1 Pull the whole site
	5.2 Pull different parts separately and assert that pulling works well and doesn't break other parts (for example, it was a case, when pulling just `plugins`, `themes` or `uploads` erased the whole database)
6. Also, since pulling and import are connected things, necessary to make sure taht import still works well:
	6.1. Try to import different backups (wpress, playground, local, jetpack) and assert that it works well



To simplify review and testing, here is example of different backups (I tested all of them, so you can try other options/combination):
<table>
<tr>
<td>Only Database selected
<td><img width="312" alt="Screenshot 2025-06-24 at 15 53 32" src="https://github.com/user-attachments/assets/62831e59-6192-4eff-a7fa-f58fc4fc958e" />
</tr>

<tr>
<td>Only Plugins selected
<td><img width="287" alt="Screenshot 2025-06-24 at 15 53 44" src="https://github.com/user-attachments/assets/66dfc7fb-b79f-4e68-a97e-1ab57a7c3cba" />
</tr>

<tr>
<td>Only Themes selected
<td><img width="308" alt="Screenshot 2025-06-24 at 15 53 55" src="https://github.com/user-attachments/assets/52264c29-5076-4edb-881a-05f5afe384a3" />
</tr>

<tr>
<td>Only Uploads selected
<td><img width="284" alt="Screenshot 2025-06-24 at 15 54 06" src="https://github.com/user-attachments/assets/4196242a-feb8-4890-9fef-cc99a6beb068" />
</tr>

<tr>
<td>Only "Other files and directories" selected
<td><img width="299" alt="Screenshot 2025-06-24 at 15 54 17" src="https://github.com/user-attachments/assets/09723171-7153-4513-9539-a4b6aff25070" />
</tr>

<tr>
<td> backup downloaded directly on wordpress.com
<td><img width="500" alt="Screenshot 2025-06-24 at 15 54 28" src="https://github.com/user-attachments/assets/9a40fefa-77d4-4861-89e0-0b26747b0cee" />
</tr>

</table>






