### PR TITLE
Escape backslashes in addition to single quotes in About Studio dialog

### DIFF
--- a/src/about-menu/open-about-menu.ts
+++ b/src/about-menu/open-about-menu.ts
@@ -7,6 +7,10 @@ import { shellOpenExternalWrapper } from 'src/lib/shell-open-external-wrapper';
 
 let aboutWindow: BrowserWindow | null = null;
 
+export function escapeSingleQuotes( str: string ) {
+	return str.replace( /\\/g, '\\\\' ).replace( /'/g, "\\'" );
+}
+
 export function openAboutWindow() {
 	const aboutPath = path.join( __dirname, 'menu', 'about-menu.html' );
 
@@ -36,10 +40,6 @@ export function openAboutWindow() {
 
 	// Read package.json and pass version to about window
 	const packageJson = app.getVersion();
-
-	function escapeSingleQuotes( str: string ) {
-		return str.replace( /'/g, "\\'" );
-	}
 
 	aboutWindow.webContents.on( 'dom-ready', () => {
 		if ( aboutWindow ) {

--- a/src/about-menu/tests/open-about-menu.test.tsx
+++ b/src/about-menu/tests/open-about-menu.test.tsx
@@ -1,0 +1,27 @@
+import { escapeSingleQuotes } from 'src/about-menu/open-about-menu';
+
+describe( 'escapeSingleQuotes', () => {
+	it( 'should escape single quotes in a string', () => {
+		const input = "Don't worry about 'it";
+		const expected = "Don\\'t worry about \\'it";
+		expect( escapeSingleQuotes( input ) ).toBe( expected );
+	} );
+
+	it( 'should handle strings with no single quotes', () => {
+		const input = 'This string has no single quotes';
+		const expected = 'This string has no single quotes';
+		expect( escapeSingleQuotes( input ) ).toBe( expected );
+	} );
+
+	it( 'should handle empty string', () => {
+		const input = '';
+		const expected = '';
+		expect( escapeSingleQuotes( input ) ).toBe( expected );
+	} );
+
+	it( 'should handle Windows path with single quotes', () => {
+		const input = "it's just C:\\Users\\O'Reilly\\docs\\.";
+		const expected = "it\\'s just C:\\\\Users\\\\O\\'Reilly\\\\docs\\\\.";
+		expect( escapeSingleQuotes( input ) ).toBe( expected );
+	} );
+} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/studio/security/code-scanning/10

## Proposed Changes

I propose to escape backslashes in addition to single quotes.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Confirm tests pass
2. Confirm About Studio dialog works in different languages

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
