### PR TITLE
Add `$LastExitCode` checks to calls to external commands/scripts in PS1

### DIFF
--- a/.buildkite/commands/build-for-windows.ps1
+++ b/.buildkite/commands/build-for-windows.ps1
@@ -20,8 +20,10 @@ if ($BuildType -notin $VALID_BUILD_TYPES) {
 
 Write-Host "--- :npm: Installing Node dependencies"
 bash .buildkite/commands/install-node-dependencies.sh
+If ($LastExitCode -ne 0) { Exit $LastExitCode }
 
 & "prepare_windows_host_for_app_distribution.ps1" # via CI toolkit plugin
+If ($LastExitCode -ne 0) { Exit $LastExitCode }
 
 Write-Host "--- :node: Building App for Windows ($BuildType)"
 
@@ -29,23 +31,22 @@ Write-Host "--- :node: Building App for Windows ($BuildType)"
 if ($BuildType -eq $BUILD_TYPE_DEV) {
     Write-Host "Preparing dev build..."
     node ./scripts/prepare-dev-build-version.mjs
+	If ($LastExitCode -ne 0) { Exit $LastExitCode }
     $env:IS_DEV_BUILD="true"
 } else {
     Write-Host "Preparing release build..."
     node ./scripts/confirm-tag-matches-version.mjs
+	If ($LastExitCode -ne 0) { Exit $LastExitCode }
 }
 
-If ($LastExitCode -ne 0) { Exit $LastExitCode }
-
 npm run make
+If ($LastExitCode -ne 0) { Exit $LastExitCode }
 
 # Rename NuGet package files with generic name
 $artifactsPath = Get-Item ".\out" | Select-Object -ExpandProperty FullName
 Get-ChildItem -Path $artifactsPath -Recurse -Include "*.nupkg" | Rename-Item -NewName "studio-update.nupkg"
-
 If ($LastExitCode -ne 0) { Exit $LastExitCode }
 
 Write-Host "--- :package: Building AppX package"
 node scripts/package-appx.mjs
-
 If ($LastExitCode -ne 0) { Exit $LastExitCode }


### PR DESCRIPTION
## Related issues

- Fixes https://github.com/Automattic/studio/issues/644
- Fixes STU-45
- See also research done in https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/pull/133

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->
## Proposed Changes

Add `$LastExitCode` handling to all calls to an external command, be that an installed command like `npm` or a script, in the Windows PowerShell script in CI. 

This should ensure the script will fail as soon as possible, giving us faster feedback and saving CI time.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

#644 showed that the release build step did not fail when the script that checks if the build originated from a tag run. I replicated the setup in https://github.com/Automattic/studio/pull/1507 and you can see in CI that it now fails.

<img width="1390" alt="image" src="https://github.com/user-attachments/assets/73679eb4-2a93-4698-8173-28ec52f9e05c" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
