### PR TITLE
Normalize and validate path names when extracting downloaded tools

### DIFF
--- a/vendor/wp-now/src/download.ts
+++ b/vendor/wp-now/src/download.ts
@@ -120,7 +120,15 @@ async function downloadFileAndUnzip( {
 		await response
 			.pipe( unzipper.Parse() )
 			.on( 'entry', ( entry ) => {
-				const filePath = path.join( destinationFolder, entry.path );
+				const normalizedPath = path.normalize( entry.path );
+				const filePath = path.join( destinationFolder, normalizedPath );
+
+				if ( ! filePath.startsWith( destinationFolder ) ) {
+					output?.log( `Skipping invalid path: ${ entry.path }` );
+					entryPromises.push( entry.autodrain().promise() );
+					return;
+				}
+
 				/*
 				 * Use the sync version to ensure entry is piped to
 				 * a write stream before moving on to the next entry.


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://github.com/Automattic/studio/security/code-scanning/2

## Proposed Changes

I propose normalizing and validating path names when extracting downloaded tools.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Remove `sqlite-command` from `~/Library/Application\ Support/Studio/server-files`
2. Apply patch to always download the library:
```
diff --git a/src/lib/sqlite-command-versions.ts b/src/lib/sqlite-command-versions.ts
index 23bbb7ea..8d6ae9ab 100644
--- a/src/lib/sqlite-command-versions.ts
+++ b/src/lib/sqlite-command-versions.ts
@@ -42,10 +42,10 @@ export async function updateLatestSQLiteCommandVersion() {
                return;
        }
 
-       if ( ! distributionCheck.needsDownload ) {
-               console.log( 'SQLite Command is up to date.' );
-               return;
-       }
+       // if ( ! distributionCheck.needsDownload ) {
+       //      console.log( 'SQLite Command is up to date.' );
+       //      return;
+       // }
 
        try {
                await downloadSQLiteCommand( distributionCheck.downloadUrl, getSqliteCommandPath() );

```
3. Start Studio in dev mode
4. Confirm output logs `Downloading SQLite Command...` and that tool is downloaded

I haven't tested the fix with a ZIP file that has paths that exploit path traversal. However, I tested modifying `! filePath.startsWith( destinationFolder )` condition to include one of the files included in the sqlite-command. It worked well - the file was skipped and the message was logged.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
