### PR TITLE
Improve a11y on sync dialog and tree view component

### DIFF
--- a/src/components/tree-view.tsx
+++ b/src/components/tree-view.tsx
@@ -74,27 +74,20 @@ const TreeItem = ( {
 	node,
 	onPatchNode,
 	level,
-	isLast,
-	index = 0,
-	setsize = 1,
+	index,
+	isLast = false,
+	siblingsLength,
 }: {
 	node: TreeNode;
 	onPatchNode: ( id: string, patchNode: Partial< TreeNode > ) => void;
 	level: number;
+	index: number;
+	siblingsLength?: number;
 	isLast?: boolean;
-	index?: number;
-	setsize?: number;
 } ) => {
 	const { __ } = useI18n();
 	const isLevel0 = level === 0;
 	const expanded = node.expanded ?? true;
-
-	const handleKeyDown = ( event: React.KeyboardEvent ) => {
-		if ( event.key === ' ' || event.key === 'Enter' ) {
-			event.preventDefault();
-			onPatchNode( node.id, { checked: node.indeterminate ? true : ! node.checked } );
-		}
-	};
 
 	return (
 		<div>
@@ -102,7 +95,7 @@ const TreeItem = ( {
 				role="treeitem"
 				aria-level={ level }
 				aria-expanded={ node.children ? expanded : undefined }
-				aria-setsize={ setsize }
+				aria-setsize={ siblingsLength }
 				aria-posinset={ index + 1 }
 				aria-checked={ node.indeterminate ? 'mixed' : node.checked }
 				aria-label={ node.label }
@@ -154,7 +147,7 @@ const TreeItem = ( {
 							onPatchNode={ onPatchNode }
 							level={ level + 1 }
 							index={ idx }
-							setsize={ node.children ? node.children.length : 0 }
+							siblingsLength={ node.children?.length }
 						/>
 					) ) }
 				</div>
@@ -182,7 +175,7 @@ export const TreeView = ( { tree, setTree }: TreeViewProps ) => {
 					onPatchNode={ handlePatchNode }
 					level={ 1 }
 					index={ index }
-					setsize={ tree.length }
+					siblingsLength={ tree.length }
 					isLast={ index === tree.length - 1 }
 				/>
 			) ) }

--- a/src/components/tree-view.tsx
+++ b/src/components/tree-view.tsx
@@ -105,7 +105,7 @@ const TreeItem = ( {
 					isLast ? 'border-white' : ''
 				) }
 			>
-				<div className="flex items-center cursor-pointer">
+				<label className="flex items-center cursor-pointer">
 					<CheckboxControl
 						id={ node.id }
 						checked={ node.checked }
@@ -113,18 +113,16 @@ const TreeItem = ( {
 						onChange={ ( checked: boolean ) => onPatchNode( node.id, { checked } ) }
 						__nextHasNoMarginBottom
 					/>
-					<label htmlFor={ node.id } className="flex items-center cursor-pointer">
-						{ node.type && (
-							<Icon
-								aria-hidden
-								icon={ TREE_NODE_ICONS[ node.type ] }
-								size={ 20 }
-								className="me-1.5"
-							/>
-						) }
-						{ node.label }
-					</label>
-				</div>
+					{ node.type && (
+						<Icon
+							aria-hidden
+							icon={ TREE_NODE_ICONS[ node.type ] }
+							size={ 20 }
+							className="me-1.5"
+						/>
+					) }
+					{ node.label }
+				</label>
 				{ node.loading && <Spinner className="!w-[9px] !h-[9px] !m-0" /> }
 				{ ! node.loading && node.children && ! node.hideExpandButton && (
 					<button

--- a/src/components/tree-view.tsx
+++ b/src/components/tree-view.tsx
@@ -1,5 +1,6 @@
 import { CheckboxControl, Icon, Spinner } from '@wordpress/components';
 import { file, page } from '@wordpress/icons';
+import { useRef, useState, useEffect } from 'react';
 import { RightArrowIcon } from 'src/components/icons/right-arrow';
 import { cx } from 'src/lib/cx';
 
@@ -75,6 +76,10 @@ const TreeItem = ( {
 	isLast,
 	index = 0,
 	setsize = 1,
+	focusedId,
+	setFocusedId,
+	nodeRefs,
+	visibleNodeIds,
 }: {
 	node: TreeNode;
 	onPatchNode: ( id: string, patchNode: Partial< TreeNode > ) => void;
@@ -82,9 +87,71 @@ const TreeItem = ( {
 	isLast?: boolean;
 	index?: number;
 	setsize?: number;
+	focusedId: string;
+	setFocusedId: ( id: string ) => void;
+	nodeRefs: Record< string, React.RefObject< HTMLDivElement > >;
+	visibleNodeIds: string[];
 } ) => {
 	const isLevel0 = level === 0;
 	const expanded = node.expanded ?? true;
+	const ref = useRef< HTMLDivElement >( null );
+	const isFocused = focusedId === node.id;
+
+	useEffect( () => {
+		nodeRefs[ node.id ] = ref;
+	}, [ node.id, nodeRefs ] );
+
+	const getNextNodeId = ( key: string, currentIndex: number ): string | null => {
+		const navigationMap: Record< string, () => string | null > = {
+			ArrowDown: () =>
+				currentIndex < visibleNodeIds.length - 1 ? visibleNodeIds[ currentIndex + 1 ] : null,
+			ArrowUp: () => ( currentIndex > 0 ? visibleNodeIds[ currentIndex - 1 ] : null ),
+			Home: () => visibleNodeIds[ 0 ],
+			End: () => visibleNodeIds[ visibleNodeIds.length - 1 ],
+		};
+
+		return navigationMap[ key ]?.() ?? null;
+	};
+
+	const navigateToNode = ( nodeId: string ) => {
+		setFocusedId( nodeId );
+		setTimeout( () => {
+			nodeRefs[ nodeId ]?.current?.focus();
+		}, 0 );
+	};
+
+	const handleKeyDown = ( e: React.KeyboardEvent< HTMLDivElement > ) => {
+		const currentIndex = visibleNodeIds.indexOf( node.id );
+		if ( currentIndex === -1 ) return;
+
+		if ( e.key === ' ' || e.key === 'Enter' ) {
+			e.preventDefault();
+			onPatchNode( node.id, { checked: ! node.checked } );
+			return;
+		}
+
+		if ( e.key === 'ArrowRight' ) {
+			e.preventDefault();
+			if ( node.children && ! expanded ) {
+				onPatchNode( node.id, { expanded: true } );
+			}
+			return;
+		}
+
+		if ( e.key === 'ArrowLeft' ) {
+			e.preventDefault();
+			if ( node.children && expanded ) {
+				onPatchNode( node.id, { expanded: false } );
+			}
+			return;
+		}
+
+		const nextNodeId = getNextNodeId( e.key, currentIndex );
+		if ( nextNodeId ) {
+			e.preventDefault();
+			navigateToNode( nextNodeId );
+		}
+	};
 
 	return (
 		<div>
@@ -94,6 +161,10 @@ const TreeItem = ( {
 				aria-expanded={ node.children ? expanded : undefined }
 				aria-setsize={ setsize }
 				aria-posinset={ index + 1 }
+				tabIndex={ isFocused ? 0 : -1 }
+				ref={ ref }
+				onFocus={ () => setFocusedId( node.id ) }
+				onKeyDown={ handleKeyDown }
 				className={ cx(
 					'flex items-center py-2 relative gap-2',
 					isLevel0 ? 'border-b border-gray-300 py-4' : '',
@@ -126,21 +197,36 @@ const TreeItem = ( {
 					role="group"
 					className={ cx( 'ps-6', isLevel0 ? 'border-b border-gray-300 py-2' : '' ) }
 				>
-					{ node.children.map( ( child, idx ) => (
-						<TreeItem
-							key={ child.id }
-							node={ child }
-							onPatchNode={ onPatchNode }
-							level={ level + 1 }
-							index={ idx }
-							setsize={ node.children ? node.children.length : 0 }
-						/>
-					) ) }
+					{ node.children &&
+						node.children.map( ( child, idx ) => (
+							<TreeItem
+								key={ child.id }
+								node={ child }
+								onPatchNode={ onPatchNode }
+								level={ level + 1 }
+								index={ idx }
+								setsize={ node.children ? node.children.length : 0 }
+								focusedId={ focusedId }
+								setFocusedId={ setFocusedId }
+								nodeRefs={ nodeRefs }
+								visibleNodeIds={ visibleNodeIds }
+							/>
+						) ) }
 				</div>
 			) }
 		</div>
 	);
 };
+
+function flattenVisibleTree( nodes: TreeNode[], result: string[] = [] ): string[] {
+	for ( const node of nodes ) {
+		result.push( node.id );
+		if ( node.children && ( node.expanded ?? true ) ) {
+			flattenVisibleTree( node.children, result );
+		}
+	}
+	return result;
+}
 
 export type TreeViewProps = {
 	tree: TreeNode[];
@@ -148,6 +234,9 @@ export type TreeViewProps = {
 };
 
 export const TreeView = ( { tree, setTree }: TreeViewProps ) => {
+	const [ focusedId, setFocusedId ] = useState( tree[ 0 ]?.id || '' );
+	const nodeRefs = {} as Record< string, React.RefObject< HTMLDivElement > >;
+	const visibleNodeIds = flattenVisibleTree( tree );
 	const handlePatchNode = ( id: string, partialNode: Partial< TreeNode > ) => {
 		setTree( ( prev: TreeNode[] ) => updateNodeById( prev, id, partialNode ) );
 	};
@@ -163,6 +252,10 @@ export const TreeView = ( { tree, setTree }: TreeViewProps ) => {
 					index={ index }
 					setsize={ tree.length }
 					isLast={ index === tree.length - 1 }
+					focusedId={ focusedId }
+					setFocusedId={ setFocusedId }
+					nodeRefs={ nodeRefs }
+					visibleNodeIds={ visibleNodeIds }
 				/>
 			) ) }
 		</div>

--- a/src/components/tree-view.tsx
+++ b/src/components/tree-view.tsx
@@ -1,6 +1,7 @@
 import { CheckboxControl, Icon, Spinner } from '@wordpress/components';
 import { file, page } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
+import React from 'react';
 import { RightArrowIcon } from 'src/components/icons/right-arrow';
 import { cx } from 'src/lib/cx';
 
@@ -88,6 +89,13 @@ const TreeItem = ( {
 	const isLevel0 = level === 0;
 	const expanded = node.expanded ?? true;
 
+	const handleKeyDown = ( event: React.KeyboardEvent ) => {
+		if ( event.key === ' ' || event.key === 'Enter' ) {
+			event.preventDefault();
+			onPatchNode( node.id, { checked: node.indeterminate ? true : ! node.checked } );
+		}
+	};
+
 	return (
 		<div>
 			<div
@@ -96,20 +104,21 @@ const TreeItem = ( {
 				aria-expanded={ node.children ? expanded : undefined }
 				aria-setsize={ setsize }
 				aria-posinset={ index + 1 }
+				aria-checked={ node.indeterminate ? 'mixed' : node.checked }
+				aria-label={ node.label }
 				className={ cx(
 					'flex items-center py-2 relative gap-2',
 					isLevel0 ? 'border-b border-gray-300 py-4' : '',
 					isLast ? 'border-white' : ''
 				) }
 			>
-				<label className="flex items-center cursor-pointer">
+				<div className="flex items-center cursor-pointer">
 					<CheckboxControl
 						id={ node.id }
 						checked={ node.checked }
 						indeterminate={ node.indeterminate }
 						onChange={ ( checked: boolean ) => onPatchNode( node.id, { checked } ) }
 						__nextHasNoMarginBottom
-						aria-label={ node.label }
 					/>
 					{ node.type && (
 						<Icon
@@ -119,8 +128,8 @@ const TreeItem = ( {
 							className="me-1.5"
 						/>
 					) }
-					<span aria-hidden>{ node.label }</span>
-				</label>
+					<label htmlFor={ node.id }>{ node.label }</label>
+				</div>
 				{ node.loading && <Spinner className="!w-[9px] !h-[9px] !m-0" /> }
 				{ ! node.loading && node.children && ! node.hideExpandButton && (
 					<button

--- a/src/components/tree-view.tsx
+++ b/src/components/tree-view.tsx
@@ -113,15 +113,17 @@ const TreeItem = ( {
 						onChange={ ( checked: boolean ) => onPatchNode( node.id, { checked } ) }
 						__nextHasNoMarginBottom
 					/>
-					{ node.type && (
-						<Icon
-							aria-hidden
-							icon={ TREE_NODE_ICONS[ node.type ] }
-							size={ 20 }
-							className="me-1.5"
-						/>
-					) }
-					<label htmlFor={ node.id }>{ node.label }</label>
+					<label htmlFor={ node.id } className="flex items-center cursor-pointer">
+						{ node.type && (
+							<Icon
+								aria-hidden
+								icon={ TREE_NODE_ICONS[ node.type ] }
+								size={ 20 }
+								className="me-1.5"
+							/>
+						) }
+						{ node.label }
+					</label>
 				</div>
 				{ node.loading && <Spinner className="!w-[9px] !h-[9px] !m-0" /> }
 				{ ! node.loading && node.children && ! node.hideExpandButton && (

--- a/src/components/tree-view.tsx
+++ b/src/components/tree-view.tsx
@@ -1,7 +1,6 @@
 import { CheckboxControl, Icon, Spinner } from '@wordpress/components';
 import { file, page } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
-import { useRef, useState, useEffect } from 'react';
 import { RightArrowIcon } from 'src/components/icons/right-arrow';
 import { cx } from 'src/lib/cx';
 
@@ -77,10 +76,6 @@ const TreeItem = ( {
 	isLast,
 	index = 0,
 	setsize = 1,
-	focusedId,
-	setFocusedId,
-	nodeRefs,
-	visibleNodeIds,
 }: {
 	node: TreeNode;
 	onPatchNode: ( id: string, patchNode: Partial< TreeNode > ) => void;
@@ -88,72 +83,10 @@ const TreeItem = ( {
 	isLast?: boolean;
 	index?: number;
 	setsize?: number;
-	focusedId: string;
-	setFocusedId: ( id: string ) => void;
-	nodeRefs: Record< string, React.RefObject< HTMLDivElement > >;
-	visibleNodeIds: string[];
 } ) => {
 	const { __ } = useI18n();
 	const isLevel0 = level === 0;
 	const expanded = node.expanded ?? true;
-	const ref = useRef< HTMLDivElement >( null );
-	const isFocused = focusedId === node.id;
-
-	useEffect( () => {
-		nodeRefs[ node.id ] = ref;
-	}, [ node.id, nodeRefs ] );
-
-	const getNextNodeId = ( key: string, currentIndex: number ): string | null => {
-		const navigationMap: Record< string, () => string | null > = {
-			ArrowDown: () =>
-				currentIndex < visibleNodeIds.length - 1 ? visibleNodeIds[ currentIndex + 1 ] : null,
-			ArrowUp: () => ( currentIndex > 0 ? visibleNodeIds[ currentIndex - 1 ] : null ),
-			Home: () => visibleNodeIds[ 0 ],
-			End: () => visibleNodeIds[ visibleNodeIds.length - 1 ],
-		};
-
-		return navigationMap[ key ]?.() ?? null;
-	};
-
-	const navigateToNode = ( nodeId: string ) => {
-		setFocusedId( nodeId );
-		setTimeout( () => {
-			nodeRefs[ nodeId ]?.current?.focus();
-		}, 0 );
-	};
-
-	const handleKeyDown = ( e: React.KeyboardEvent< HTMLDivElement > ) => {
-		const currentIndex = visibleNodeIds.indexOf( node.id );
-		if ( currentIndex === -1 ) return;
-
-		if ( e.key === ' ' || e.key === 'Enter' ) {
-			e.preventDefault();
-			onPatchNode( node.id, { checked: ! node.checked } );
-			return;
-		}
-
-		if ( e.key === 'ArrowRight' ) {
-			e.preventDefault();
-			if ( node.children && ! expanded ) {
-				onPatchNode( node.id, { expanded: true } );
-			}
-			return;
-		}
-
-		if ( e.key === 'ArrowLeft' ) {
-			e.preventDefault();
-			if ( node.children && expanded ) {
-				onPatchNode( node.id, { expanded: false } );
-			}
-			return;
-		}
-
-		const nextNodeId = getNextNodeId( e.key, currentIndex );
-		if ( nextNodeId ) {
-			e.preventDefault();
-			navigateToNode( nextNodeId );
-		}
-	};
 
 	return (
 		<div>
@@ -163,10 +96,6 @@ const TreeItem = ( {
 				aria-expanded={ node.children ? expanded : undefined }
 				aria-setsize={ setsize }
 				aria-posinset={ index + 1 }
-				tabIndex={ isFocused ? 0 : -1 }
-				ref={ ref }
-				onFocus={ () => setFocusedId( node.id ) }
-				onKeyDown={ handleKeyDown }
 				className={ cx(
 					'flex items-center py-2 relative gap-2',
 					isLevel0 ? 'border-b border-gray-300 py-4' : '',
@@ -209,36 +138,21 @@ const TreeItem = ( {
 					role="group"
 					className={ cx( 'ps-6', isLevel0 ? 'border-b border-gray-300 py-2' : '' ) }
 				>
-					{ node.children &&
-						node.children.map( ( child, idx ) => (
-							<TreeItem
-								key={ child.id }
-								node={ child }
-								onPatchNode={ onPatchNode }
-								level={ level + 1 }
-								index={ idx }
-								setsize={ node.children ? node.children.length : 0 }
-								focusedId={ focusedId }
-								setFocusedId={ setFocusedId }
-								nodeRefs={ nodeRefs }
-								visibleNodeIds={ visibleNodeIds }
-							/>
-						) ) }
+					{ node.children.map( ( child, idx ) => (
+						<TreeItem
+							key={ child.id }
+							node={ child }
+							onPatchNode={ onPatchNode }
+							level={ level + 1 }
+							index={ idx }
+							setsize={ node.children ? node.children.length : 0 }
+						/>
+					) ) }
 				</div>
 			) }
 		</div>
 	);
 };
-
-function flattenVisibleTree( nodes: TreeNode[], result: string[] = [] ): string[] {
-	for ( const node of nodes ) {
-		result.push( node.id );
-		if ( node.children && ( node.expanded ?? true ) ) {
-			flattenVisibleTree( node.children, result );
-		}
-	}
-	return result;
-}
 
 export type TreeViewProps = {
 	tree: TreeNode[];
@@ -246,9 +160,6 @@ export type TreeViewProps = {
 };
 
 export const TreeView = ( { tree, setTree }: TreeViewProps ) => {
-	const [ focusedId, setFocusedId ] = useState( tree[ 0 ]?.id || '' );
-	const nodeRefs = {} as Record< string, React.RefObject< HTMLDivElement > >;
-	const visibleNodeIds = flattenVisibleTree( tree );
 	const handlePatchNode = ( id: string, partialNode: Partial< TreeNode > ) => {
 		setTree( ( prev: TreeNode[] ) => updateNodeById( prev, id, partialNode ) );
 	};
@@ -264,10 +175,6 @@ export const TreeView = ( { tree, setTree }: TreeViewProps ) => {
 					index={ index }
 					setsize={ tree.length }
 					isLast={ index === tree.length - 1 }
-					focusedId={ focusedId }
-					setFocusedId={ setFocusedId }
-					nodeRefs={ nodeRefs }
-					visibleNodeIds={ visibleNodeIds }
 				/>
 			) ) }
 		</div>

--- a/src/components/tree-view.tsx
+++ b/src/components/tree-view.tsx
@@ -1,5 +1,6 @@
 import { CheckboxControl, Icon, Spinner } from '@wordpress/components';
 import { file, page } from '@wordpress/icons';
+import { useI18n } from '@wordpress/react-i18n';
 import { useRef, useState, useEffect } from 'react';
 import { RightArrowIcon } from 'src/components/icons/right-arrow';
 import { cx } from 'src/lib/cx';
@@ -92,6 +93,7 @@ const TreeItem = ( {
 	nodeRefs: Record< string, React.RefObject< HTMLDivElement > >;
 	visibleNodeIds: string[];
 } ) => {
+	const { __ } = useI18n();
 	const isLevel0 = level === 0;
 	const expanded = node.expanded ?? true;
 	const ref = useRef< HTMLDivElement >( null );
@@ -173,19 +175,29 @@ const TreeItem = ( {
 			>
 				<label className="flex items-center cursor-pointer">
 					<CheckboxControl
+						id={ node.id }
 						checked={ node.checked }
 						indeterminate={ node.indeterminate }
 						onChange={ ( checked: boolean ) => onPatchNode( node.id, { checked } ) }
 						__nextHasNoMarginBottom
+						aria-label={ node.label }
 					/>
 					{ node.type && (
-						<Icon icon={ TREE_NODE_ICONS[ node.type ] } size={ 20 } className="me-1.5" />
+						<Icon
+							aria-hidden
+							icon={ TREE_NODE_ICONS[ node.type ] }
+							size={ 20 }
+							className="me-1.5"
+						/>
 					) }
-					<span>{ node.label }</span>
+					<span aria-hidden>{ node.label }</span>
 				</label>
 				{ node.loading && <Spinner className="!w-[9px] !h-[9px] !m-0" /> }
 				{ ! node.loading && node.children && ! node.hideExpandButton && (
-					<button onClick={ () => onPatchNode( node.id, { expanded: ! expanded } ) }>
+					<button
+						aria-label={ expanded ? __( 'Collapse' ) : __( 'Expand' ) }
+						onClick={ () => onPatchNode( node.id, { expanded: ! expanded } ) }
+					>
 						<div className={ expanded ? 'rotate-90' : '' }>
 							<RightArrowIcon width={ 16 } />
 						</div>

--- a/src/components/tree-view.tsx
+++ b/src/components/tree-view.tsx
@@ -73,11 +73,15 @@ const TreeItem = ( {
 	onPatchNode,
 	level,
 	isLast,
+	index = 0,
+	setsize = 1,
 }: {
 	node: TreeNode;
 	onPatchNode: ( id: string, patchNode: Partial< TreeNode > ) => void;
 	level: number;
 	isLast?: boolean;
+	index?: number;
+	setsize?: number;
 } ) => {
 	const isLevel0 = level === 0;
 	const expanded = node.expanded ?? true;
@@ -85,6 +89,11 @@ const TreeItem = ( {
 	return (
 		<div>
 			<div
+				role="treeitem"
+				aria-level={ level }
+				aria-expanded={ node.children ? expanded : undefined }
+				aria-setsize={ setsize }
+				aria-posinset={ index + 1 }
 				className={ cx(
 					'flex items-center py-2 relative gap-2',
 					isLevel0 ? 'border-b border-gray-300 py-4' : '',
@@ -113,13 +122,18 @@ const TreeItem = ( {
 				) }
 			</div>
 			{ expanded && node.children && (
-				<div className={ cx( 'ps-6', isLevel0 ? 'border-b border-gray-300 py-2' : '' ) }>
-					{ node.children.map( ( child ) => (
+				<div
+					role="group"
+					className={ cx( 'ps-6', isLevel0 ? 'border-b border-gray-300 py-2' : '' ) }
+				>
+					{ node.children.map( ( child, idx ) => (
 						<TreeItem
 							key={ child.id }
 							node={ child }
 							onPatchNode={ onPatchNode }
-							level={ ++level }
+							level={ level + 1 }
+							index={ idx }
+							setsize={ node.children ? node.children.length : 0 }
 						/>
 					) ) }
 				</div>
@@ -139,13 +153,15 @@ export const TreeView = ( { tree, setTree }: TreeViewProps ) => {
 	};
 
 	return (
-		<div>
+		<div role="tree">
 			{ tree.map( ( node, index ) => (
 				<TreeItem
 					key={ node.id }
 					node={ node }
 					onPatchNode={ handlePatchNode }
-					level={ 0 }
+					level={ 1 }
+					index={ index }
+					setsize={ tree.length }
 					isLast={ index === tree.length - 1 }
 				/>
 			) ) }

--- a/src/components/tree-view.tsx
+++ b/src/components/tree-view.tsx
@@ -8,6 +8,7 @@ import { cx } from 'src/lib/cx';
 type TreeNodeType = 'folder' | 'file';
 export type TreeNode = {
 	id: string;
+	name: string;
 	label: string;
 	checked: boolean;
 	indeterminate?: boolean;

--- a/src/modules/sync/components/sync-dialog.tsx
+++ b/src/modules/sync/components/sync-dialog.tsx
@@ -48,7 +48,7 @@ const useDynamicTreeState = (
 				const children: TreeNode[] | undefined = error
 					? undefined
 					: items.map( ( item ) => ( {
-							id: item.name,
+							id: `${ wpType }-${ item.name }`,
 							label: item.name,
 							checked: true,
 							type: item.type,
@@ -93,21 +93,17 @@ export function SyncDialog( {
 			<span className="text-gray-600"> { remoteSite.name } </span>
 		</div>
 	);
-	const remoteSiteText = `${ envDetails.label } (${ remoteSite.url.replace(
-		/^https?:\/\//,
-		''
-	) })`;
 
 	let syncFrom, syncTo, syncFromText, syncToText;
 	if ( type === 'push' ) {
 		syncFrom = localSiteName;
 		syncTo = remoteSiteName;
 		syncFromText = localSite.name;
-		syncToText = remoteSiteText;
+		syncToText = remoteSite.name;
 	} else {
 		syncFrom = remoteSiteName;
 		syncTo = localSiteName;
-		syncFromText = remoteSiteText;
+		syncFromText = remoteSite.name;
 		syncToText = localSite.name;
 	}
 

--- a/src/modules/sync/components/sync-dialog.tsx
+++ b/src/modules/sync/components/sync-dialog.tsx
@@ -49,6 +49,7 @@ const useDynamicTreeState = (
 					? undefined
 					: items.map( ( item ) => ( {
 							id: `${ wpType }-${ item.name }`,
+							name: item.name,
 							label: item.name,
 							checked: true,
 							type: item.type,

--- a/src/modules/sync/components/sync-dialog.tsx
+++ b/src/modules/sync/components/sync-dialog.tsx
@@ -1,5 +1,6 @@
 import { SelectControl } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
+import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import { useState, useEffect, useMemo } from 'react';
 import { ArrowIcon } from 'src/components/arrow-icon';
@@ -92,9 +93,23 @@ export function SyncDialog( {
 			<span className="text-gray-600"> { remoteSite.name } </span>
 		</div>
 	);
+	const remoteSiteText = `${ envDetails.label } (${ remoteSite.url.replace(
+		/^https?:\/\//,
+		''
+	) })`;
 
-	const syncFrom = type === 'push' ? localSiteName : remoteSiteName;
-	const syncTo = type === 'push' ? remoteSiteName : localSiteName;
+	let syncFrom, syncTo, syncFromText, syncToText;
+	if ( type === 'push' ) {
+		syncFrom = localSiteName;
+		syncTo = remoteSiteName;
+		syncFromText = localSite.name;
+		syncToText = remoteSiteText;
+	} else {
+		syncFrom = remoteSiteName;
+		syncTo = localSiteName;
+		syncFromText = remoteSiteText;
+		syncToText = localSite.name;
+	}
 
 	const handleExpanderChange = ( value: boolean ) => {
 		setShowAllFiles( value );
@@ -123,7 +138,13 @@ export function SyncDialog( {
 			<div className="pb-[70px]">
 				<div className="px-8 pb-6 pt-2">{ copy[ siteEnv ].description }</div>
 				<div className="px-8">
-					<div className="flex items-start gap-1 pb-7 border-b border-a8c-gray-5">
+					<span className="sr-only">
+						{ sprintf( __( 'From %s to %s' ), syncFromText, syncToText ) }
+					</span>
+					<div
+						aria-hidden="true"
+						className="flex items-start gap-1 pb-7 border-b border-a8c-gray-5"
+					>
 						<div className="flex-1">
 							<div className="leading-[32px]">{ copy.fromLabel }</div>
 							<div className="border border-gray-300 rounded-[2px] min-h-12 px-[19px] flex items-center py-2">

--- a/src/modules/sync/components/sync-dialog.tsx
+++ b/src/modules/sync/components/sync-dialog.tsx
@@ -135,6 +135,7 @@ export function SyncDialog( {
 				<div className="px-8 pb-6 pt-2">{ copy[ siteEnv ].description }</div>
 				<div className="px-8">
 					<span className="sr-only">
+						{ /* translators: first %s is the source site name, second %s is the destination site name */ }
 						{ sprintf( __( 'From %s to %s' ), syncFromText, syncToText ) }
 					</span>
 					<div

--- a/src/modules/sync/hooks/use-default-sync-tree.tsx
+++ b/src/modules/sync/hooks/use-default-sync-tree.tsx
@@ -10,6 +10,7 @@ export const useDefaultSyncTree = (): TreeNode[] => {
 		return [
 			{
 				id: 'filesAndFolders',
+				name: 'filesAndFolders',
 				label: __( 'Files and folders' ),
 				checked: true,
 				indeterminate: false,
@@ -18,6 +19,7 @@ export const useDefaultSyncTree = (): TreeNode[] => {
 				children: [
 					{
 						id: 'wp-content',
+						name: 'wp-content',
 						label: 'wp-content',
 						checked: true,
 						indeterminate: false,
@@ -25,6 +27,7 @@ export const useDefaultSyncTree = (): TreeNode[] => {
 						children: [
 							{
 								id: SYNC_OPTIONS.plugins,
+								name: SYNC_OPTIONS.plugins,
 								label: 'plugins',
 								checked: true,
 								type: 'folder',
@@ -32,6 +35,7 @@ export const useDefaultSyncTree = (): TreeNode[] => {
 							},
 							{
 								id: SYNC_OPTIONS.themes,
+								name: SYNC_OPTIONS.themes,
 								label: 'themes',
 								checked: true,
 								type: 'folder',
@@ -39,6 +43,7 @@ export const useDefaultSyncTree = (): TreeNode[] => {
 							},
 							{
 								id: SYNC_OPTIONS.uploads,
+								name: SYNC_OPTIONS.uploads,
 								label: 'uploads',
 								checked: true,
 								type: 'folder',
@@ -46,6 +51,7 @@ export const useDefaultSyncTree = (): TreeNode[] => {
 							},
 							{
 								id: SYNC_OPTIONS.contents,
+								name: SYNC_OPTIONS.contents,
 								label: __( 'Other files and directories' ),
 								checked: true,
 								type: 'folder',
@@ -56,6 +62,7 @@ export const useDefaultSyncTree = (): TreeNode[] => {
 			},
 			{
 				id: SYNC_OPTIONS.sqls,
+				name: SYNC_OPTIONS.sqls,
 				label: __( 'Database' ),
 				checked: true,
 			},

--- a/src/modules/sync/lib/convert-tree-to-options-to-sync.ts
+++ b/src/modules/sync/lib/convert-tree-to-options-to-sync.ts
@@ -49,7 +49,10 @@ export const convertTreeToOptionsToSync = ( tree: TreeNode[] ): SyncOptionsWithS
 			) {
 				const selectedItems = item.children
 					.filter( ( child ) => child.checked )
-					.map( ( child ) => child.id );
+					.map( ( child ) => {
+						const prefix = `${ item.id }-`;
+						return child.id.startsWith( prefix ) ? child.id.slice( prefix.length ) : child.id;
+					} );
 				if ( selectedItems.length > 0 && selectedItems.length < item.children.length ) {
 					specificSelections = {
 						...specificSelections,

--- a/src/modules/sync/lib/convert-tree-to-options-to-sync.ts
+++ b/src/modules/sync/lib/convert-tree-to-options-to-sync.ts
@@ -49,10 +49,7 @@ export const convertTreeToOptionsToSync = ( tree: TreeNode[] ): SyncOptionsWithS
 			) {
 				const selectedItems = item.children
 					.filter( ( child ) => child.checked )
-					.map( ( child ) => {
-						const prefix = `${ item.id }-`;
-						return child.id.startsWith( prefix ) ? child.id.slice( prefix.length ) : child.id;
-					} );
+					.map( ( child ) => child.name );
 				if ( selectedItems.length > 0 && selectedItems.length < item.children.length ) {
 					specificSelections = {
 						...specificSelections,

--- a/src/modules/sync/tests/convert-tree-to-options-to-sync.tsx
+++ b/src/modules/sync/tests/convert-tree-to-options-to-sync.tsx
@@ -313,4 +313,24 @@ describe( 'convertTreeToOptionsToSync', () => {
 			} );
 		} );
 	} );
+
+	it( 'strips folder type prefix from specific selections', () => {
+		const { result } = renderHook( () => useDefaultSyncTree() );
+		let tree = result.current;
+
+		tree = updateNodeById( tree, 'plugins', {
+			children: [
+				{ id: 'plugins-my-plugin', label: 'my-plugin', checked: true, type: 'folder' },
+				{ id: 'plugins-another-plugin', label: 'another-plugin', checked: false, type: 'folder' },
+			],
+		} );
+
+		const optionsToSync = convertTreeToOptionsToSync( tree );
+		expect( optionsToSync ).toEqual( {
+			optionsToSync: [ 'sqls', 'plugins', 'themes', 'uploads', 'contents' ],
+			specificSelections: {
+				plugins: [ 'my-plugin' ],
+			},
+		} );
+	} );
 } );

--- a/src/modules/sync/tests/convert-tree-to-options-to-sync.tsx
+++ b/src/modules/sync/tests/convert-tree-to-options-to-sync.tsx
@@ -86,9 +86,9 @@ describe( 'convertTreeToOptionsToSync', () => {
 					pluginsNode.checked = false;
 					pluginsNode.indeterminate = true;
 					pluginsNode.children = [
-						{ id: 'plugin1', label: 'Plugin 1', checked: true, type: 'folder' },
-						{ id: 'plugin2', label: 'Plugin 2', checked: false, type: 'folder' },
-						{ id: 'plugin3', label: 'Plugin 3', checked: true, type: 'folder' },
+						{ id: 'plugin1', name: 'plugin1', label: 'Plugin 1', checked: true, type: 'folder' },
+						{ id: 'plugin2', name: 'plugin2', label: 'Plugin 2', checked: false, type: 'folder' },
+						{ id: 'plugin3', name: 'plugin3', label: 'Plugin 3', checked: true, type: 'folder' },
 					];
 				}
 			}
@@ -121,10 +121,10 @@ describe( 'convertTreeToOptionsToSync', () => {
 					themesNode.checked = false;
 					themesNode.indeterminate = true;
 					themesNode.children = [
-						{ id: 'theme1', label: 'Theme 1', checked: true, type: 'folder' },
-						{ id: 'theme2', label: 'Theme 2', checked: false, type: 'folder' },
-						{ id: 'theme3', label: 'Theme 3', checked: true, type: 'folder' },
-						{ id: 'theme4', label: 'Theme 4', checked: false, type: 'folder' },
+						{ id: 'theme1', name: 'theme1', label: 'Theme 1', checked: true, type: 'folder' },
+						{ id: 'theme2', name: 'theme2', label: 'Theme 2', checked: false, type: 'folder' },
+						{ id: 'theme3', name: 'theme3', label: 'Theme 3', checked: true, type: 'folder' },
+						{ id: 'theme4', name: 'theme4', label: 'Theme 4', checked: false, type: 'folder' },
 					];
 				}
 			}
@@ -157,9 +157,9 @@ describe( 'convertTreeToOptionsToSync', () => {
 					uploadsNode.checked = false;
 					uploadsNode.indeterminate = true;
 					uploadsNode.children = [
-						{ id: 'upload1', label: 'Upload 1', checked: true, type: 'folder' },
-						{ id: 'upload2', label: 'Upload 2', checked: true, type: 'folder' },
-						{ id: 'upload3', label: 'Upload 3', checked: false, type: 'folder' },
+						{ id: 'upload1', name: 'upload1', label: 'Upload 1', checked: true, type: 'folder' },
+						{ id: 'upload2', name: 'upload2', label: 'Upload 2', checked: true, type: 'folder' },
+						{ id: 'upload3', name: 'upload3', label: 'Upload 3', checked: false, type: 'folder' },
 					];
 				}
 			}
@@ -191,8 +191,8 @@ describe( 'convertTreeToOptionsToSync', () => {
 					pluginsNode.checked = false;
 					pluginsNode.indeterminate = true;
 					pluginsNode.children = [
-						{ id: 'plugin1', label: 'Plugin 1', checked: true, type: 'folder' },
-						{ id: 'plugin2', label: 'Plugin 2', checked: false, type: 'folder' },
+						{ id: 'plugin1', name: 'plugin1', label: 'Plugin 1', checked: true, type: 'folder' },
+						{ id: 'plugin2', name: 'plugin2', label: 'Plugin 2', checked: false, type: 'folder' },
 					];
 				}
 
@@ -201,9 +201,9 @@ describe( 'convertTreeToOptionsToSync', () => {
 					themesNode.checked = false;
 					themesNode.indeterminate = true;
 					themesNode.children = [
-						{ id: 'theme1', label: 'Theme 1', checked: true, type: 'folder' },
-						{ id: 'theme2', label: 'Theme 2', checked: false, type: 'folder' },
-						{ id: 'theme3', label: 'Theme 3', checked: true, type: 'folder' },
+						{ id: 'theme1', name: 'theme1', label: 'Theme 1', checked: true, type: 'folder' },
+						{ id: 'theme2', name: 'theme2', label: 'Theme 2', checked: false, type: 'folder' },
+						{ id: 'theme3', name: 'theme3', label: 'Theme 3', checked: true, type: 'folder' },
 					];
 				}
 			}
@@ -236,8 +236,8 @@ describe( 'convertTreeToOptionsToSync', () => {
 				if ( pluginsNode ) {
 					pluginsNode.checked = true;
 					pluginsNode.children = [
-						{ id: 'plugin1', label: 'Plugin 1', checked: true, type: 'folder' },
-						{ id: 'plugin2', label: 'Plugin 2', checked: true, type: 'folder' },
+						{ id: 'plugin1', name: 'plugin1', label: 'Plugin 1', checked: true, type: 'folder' },
+						{ id: 'plugin2', name: 'plugin2', label: 'Plugin 2', checked: true, type: 'folder' },
 					];
 				}
 			}
@@ -267,8 +267,8 @@ describe( 'convertTreeToOptionsToSync', () => {
 				if ( pluginsNode ) {
 					pluginsNode.checked = false;
 					pluginsNode.children = [
-						{ id: 'plugin1', label: 'Plugin 1', checked: false, type: 'folder' },
-						{ id: 'plugin2', label: 'Plugin 2', checked: false, type: 'folder' },
+						{ id: 'plugin1', name: 'plugin1', label: 'Plugin 1', checked: false, type: 'folder' },
+						{ id: 'plugin2', name: 'plugin2', label: 'Plugin 2', checked: false, type: 'folder' },
 					];
 				}
 			}
@@ -298,8 +298,8 @@ describe( 'convertTreeToOptionsToSync', () => {
 					pluginsNode.checked = false;
 					pluginsNode.indeterminate = true;
 					pluginsNode.children = [
-						{ id: 'plugin1', label: 'Plugin 1', checked: true, type: 'folder' },
-						{ id: 'plugin2', label: 'Plugin 2', checked: false, type: 'folder' },
+						{ id: 'plugin1', name: 'plugin1', label: 'Plugin 1', checked: true, type: 'folder' },
+						{ id: 'plugin2', name: 'plugin2', label: 'Plugin 2', checked: false, type: 'folder' },
 					];
 				}
 			}
@@ -320,8 +320,20 @@ describe( 'convertTreeToOptionsToSync', () => {
 
 		tree = updateNodeById( tree, 'plugins', {
 			children: [
-				{ id: 'plugins-my-plugin', label: 'my-plugin', checked: true, type: 'folder' },
-				{ id: 'plugins-another-plugin', label: 'another-plugin', checked: false, type: 'folder' },
+				{
+					id: 'plugins-my-plugin',
+					name: 'my-plugin',
+					label: 'my-plugin',
+					checked: true,
+					type: 'folder',
+				},
+				{
+					id: 'plugins-another-plugin',
+					name: 'another-plugin',
+					label: 'another-plugin',
+					checked: false,
+					type: 'folder',
+				},
 			],
 		} );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-561

## Proposed Changes

- Add screen reader section
- Add aria properties and role to tree view component

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- `STUDIO_SELECTIVE_SYNC=true npm start`
- Turn VoiceOver on
- Go to Sync and open push/pull dialog
- Check if navigation and VoiceOver work

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
