### PR TITLE
Refactor using site env badge

### DIFF
--- a/src/components/sync-connected-sites.tsx
+++ b/src/components/sync-connected-sites.tsx
@@ -7,7 +7,7 @@ import { useState, useMemo } from 'react';
 import { ArrowIcon } from 'src/components/arrow-icon';
 import Button from 'src/components/button';
 import { OpenSitesSyncSelector } from 'src/components/content-tab-sync';
-import { EnvironmentBadge } from 'src/components/environment-badge';
+import { EnvironmentBadge, getSiteEnvironment } from 'src/components/environment-badge';
 import { CircleRedCrossIcon } from 'src/components/icons/circle-red-cross';
 import offlineIcon from 'src/components/offline-icon';
 import { PressableLogo } from 'src/components/pressable-logo';
@@ -326,29 +326,9 @@ const SyncConnectedSitesList = ( {
 						}` }
 						key={ connectedSite.id }
 					>
-						{ connectedSite.isPressable && connectedSite.environmentType && (
-							<div className="shrink-0">
-								{ connectedSite.environmentType === 'staging' && (
-									<EnvironmentBadge type="staging" />
-								) }
-								{ connectedSite.environmentType === 'production' && (
-									<EnvironmentBadge type="production" />
-								) }
-								{ connectedSite.environmentType === 'sandbox' && (
-									<EnvironmentBadge type="sandbox" />
-								) }
-							</div>
-						) }
-
-						{ ! connectedSite.isPressable && (
-							<div className="shrink-0">
-								{ connectedSite.isStaging ? (
-									<EnvironmentBadge type="staging" />
-								) : (
-									<EnvironmentBadge type="production" />
-								) }
-							</div>
-						) }
+						<div className="shrink-0">
+							<EnvironmentBadge type={ getSiteEnvironment( connectedSite ) } />
+						</div>
 
 						<Button
 							variant="link"

--- a/src/components/sync-sites-modal-selector.tsx
+++ b/src/components/sync-sites-modal-selector.tsx
@@ -5,7 +5,7 @@ import { useState, useEffect } from 'react';
 import { ArrowIcon } from 'src/components/arrow-icon';
 import Button from 'src/components/button';
 import { CreateButton } from 'src/components/connect-create-buttons';
-import { EnvironmentBadge } from 'src/components/environment-badge';
+import { EnvironmentBadge, getSiteEnvironment } from 'src/components/environment-badge';
 import Modal from 'src/components/modal';
 import offlineIcon from 'src/components/offline-icon';
 import { PressableLogo } from 'src/components/pressable-logo';
@@ -209,7 +209,6 @@ function SiteItem( {
 	const isDeleted = site.syncSupport === 'deleted';
 	const isUnsupported = site.syncSupport === 'unsupported';
 	const isPressable = site.isPressable;
-	const environmentType = site.environmentType;
 	const isDisabled = isDeleted || isUnsupported || needsUpgrade || isMissingPermissions;
 
 	return (
@@ -292,19 +291,8 @@ function SiteItem( {
 							) }
 						</>
 					) }
-
-					{ isPressable && environmentType && (
-						<>
-							{ environmentType === 'production' && (
-								<EnvironmentBadge type="production" selected={ isSelected } />
-							) }
-							{ environmentType === 'staging' && (
-								<EnvironmentBadge type="staging" selected={ isSelected } />
-							) }
-							{ environmentType === 'sandbox' && (
-								<EnvironmentBadge type="sandbox" selected={ isSelected } />
-							) }
-						</>
+					{ isPressable && (
+						<EnvironmentBadge type={ getSiteEnvironment( site ) } selected={ isSelected } />
 					) }
 				</div>
 			) }


### PR DESCRIPTION
## Proposed Changes
With this PR we simplify rendering site's env badges with using `getSiteEnvironment` helper function

## Testing Instructions
1. Create all 5 types of sites (Pressable staging, sandbox and live + dotcom production and staging)
2. Open Connect dialog in Studio and assert that all badges are still rendered correctly<br /> <img width="833" alt="Screenshot 2025-06-26 at 15 50 24" src="https://github.com/user-attachments/assets/86c2a509-a4fa-46b5-8c8f-48a6f3d799fa" />
3. Connect All 5 sites and assert that all badges are rendered correctly on Sync tab<br /><img width="1168" alt="Screenshot 2025-06-26 at 15 52 06" src="https://github.com/user-attachments/assets/af4b4fa7-4e92-4dee-9b03-40ff87162450" />
