### PR TITLE
Add selective sync to uploads folders

### DIFF
--- a/src/components/sync-connected-sites.tsx
+++ b/src/components/sync-connected-sites.tsx
@@ -74,9 +74,9 @@ export const convertTreeToOptionsToSync = ( tree: TreeNode[] ): SyncOptionsWithS
 
 			if (
 				item.children &&
-				( item.id === SYNC_OPTIONS.plugins ||
-					item.id === SYNC_OPTIONS.themes ||
-					item.id === SYNC_OPTIONS.uploads )
+				[ SYNC_OPTIONS.plugins, SYNC_OPTIONS.themes, SYNC_OPTIONS.uploads ].includes(
+					item.id as 'plugins' | 'themes' | 'uploads'
+				)
 			) {
 				const selectedItems = item.children
 					.filter( ( child ) => child.checked )

--- a/src/components/sync-connected-sites.tsx
+++ b/src/components/sync-connected-sites.tsx
@@ -42,12 +42,15 @@ export type SyncOptionsWithSelections = {
 	specificSelections?: {
 		plugins?: string[];
 		themes?: string[];
+		uploads?: string[];
 	};
 };
 
 export const convertTreeToOptionsToSync = ( tree: TreeNode[] ): SyncOptionsWithSelections => {
 	const optionsToSync: SyncOption[] = [];
-	let specificSelections: { plugins?: string[]; themes?: string[] } | undefined = undefined;
+	let specificSelections:
+		| { plugins?: string[]; themes?: string[]; uploads?: string[] }
+		| undefined = undefined;
 
 	const isAll = tree.every( ( node ) => node.checked );
 	if ( isAll ) {
@@ -73,7 +76,9 @@ export const convertTreeToOptionsToSync = ( tree: TreeNode[] ): SyncOptionsWithS
 
 			if (
 				item.children &&
-				( item.id === SYNC_OPTIONS.plugins || item.id === SYNC_OPTIONS.themes )
+				( item.id === SYNC_OPTIONS.plugins ||
+					item.id === SYNC_OPTIONS.themes ||
+					item.id === SYNC_OPTIONS.uploads )
 			) {
 				const selectedItems = item.children
 					.filter( ( child ) => child.checked )

--- a/src/components/sync-connected-sites.tsx
+++ b/src/components/sync-connected-sites.tsx
@@ -48,9 +48,7 @@ export type SyncOptionsWithSelections = {
 
 export const convertTreeToOptionsToSync = ( tree: TreeNode[] ): SyncOptionsWithSelections => {
 	const optionsToSync: SyncOption[] = [];
-	let specificSelections:
-		| { plugins?: string[]; themes?: string[]; uploads?: string[] }
-		| undefined = undefined;
+	let specificSelections: SyncOptionsWithSelections[ 'specificSelections' ] = undefined;
 
 	const isAll = tree.every( ( node ) => node.checked );
 	if ( isAll ) {

--- a/src/components/sync-dialog.tsx
+++ b/src/components/sync-dialog.tsx
@@ -7,8 +7,9 @@ import Button from 'src/components/button';
 import { RightArrowIcon } from 'src/components/icons/right-arrow';
 import Modal from 'src/components/modal';
 import { TreeView, TreeNode, updateNodeById } from 'src/components/tree-view';
+import { WP_CONTENT_FOLDERS } from 'src/constants';
 import { SYNC_OPTIONS } from 'src/hooks/sync-sites/sync-option';
-import { useContentFolders, WpContentFolder } from 'src/hooks/use-content-folders';
+import { useContentFolders } from 'src/hooks/use-content-folders';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 import { getLocalizedLink } from 'src/lib/get-localized-link';
 import { useI18nLocale } from 'src/stores';
@@ -108,18 +109,21 @@ export const useDefaultTree = (): TreeNode[] => {
 								label: 'plugins',
 								checked: true,
 								type: 'folder',
+								expanded: false,
 							},
 							{
 								id: SYNC_OPTIONS.themes,
 								label: 'themes',
 								checked: true,
 								type: 'folder',
+								expanded: false,
 							},
 							{
 								id: SYNC_OPTIONS.uploads,
 								label: 'uploads',
 								checked: true,
 								type: 'folder',
+								expanded: false,
 							},
 							{
 								id: SYNC_OPTIONS.contents,
@@ -145,7 +149,7 @@ const useDynamicTreeState = (
 	localSiteId: string,
 	setTreeState: React.Dispatch< React.SetStateAction< TreeNode[] > >
 ) => {
-	const wpFolders: WpContentFolder[] = useMemo( () => [ 'plugins', 'themes' ], [] );
+	const wpFolders = useMemo( () => [ ...WP_CONTENT_FOLDERS ], [] );
 	const wpContent = useContentFolders( localSiteId, wpFolders );
 
 	useEffect( () => {

--- a/src/components/tests/convert-tree-to-options-to-sync.tsx
+++ b/src/components/tests/convert-tree-to-options-to-sync.tsx
@@ -65,4 +65,252 @@ describe( 'convertTreeToOptionsToSync', () => {
 			specificSelections: undefined,
 		} );
 	} );
+
+	describe( 'partial selections', () => {
+		it( 'returns partial plugins selection when only some plugins are selected', () => {
+			const { result } = renderHook( () => useDefaultTree() );
+			let tree = result.current;
+
+			tree = updateNodeById( tree, 'filesAndFolders', { checked: false } );
+			tree = updateNodeById( tree, 'sqls', { checked: false } );
+			tree = updateNodeById( tree, 'themes', { checked: false } );
+			tree = updateNodeById( tree, 'uploads', { checked: false } );
+			tree = updateNodeById( tree, 'contents', { checked: false } );
+
+			const wpContentNode = tree
+				.find( ( node ) => node.id === 'filesAndFolders' )
+				?.children?.find( ( node ) => node.id === 'wp-content' );
+			if ( wpContentNode?.children ) {
+				const pluginsNode = wpContentNode.children.find( ( node ) => node.id === 'plugins' );
+				if ( pluginsNode ) {
+					pluginsNode.checked = false;
+					pluginsNode.indeterminate = true;
+					pluginsNode.children = [
+						{ id: 'plugin1', label: 'Plugin 1', checked: true, type: 'folder' },
+						{ id: 'plugin2', label: 'Plugin 2', checked: false, type: 'folder' },
+						{ id: 'plugin3', label: 'Plugin 3', checked: true, type: 'folder' },
+					];
+				}
+			}
+
+			const optionsToSync = convertTreeToOptionsToSync( tree );
+			expect( optionsToSync ).toEqual( {
+				optionsToSync: [ 'plugins' ],
+				specificSelections: {
+					plugins: [ 'plugin1', 'plugin3' ],
+				},
+			} );
+		} );
+
+		it( 'returns partial themes selection when only some themes are selected', () => {
+			const { result } = renderHook( () => useDefaultTree() );
+			let tree = result.current;
+
+			tree = updateNodeById( tree, 'filesAndFolders', { checked: false } );
+			tree = updateNodeById( tree, 'sqls', { checked: false } );
+			tree = updateNodeById( tree, 'plugins', { checked: false } );
+			tree = updateNodeById( tree, 'uploads', { checked: false } );
+			tree = updateNodeById( tree, 'contents', { checked: false } );
+
+			const wpContentNode = tree
+				.find( ( node ) => node.id === 'filesAndFolders' )
+				?.children?.find( ( node ) => node.id === 'wp-content' );
+			if ( wpContentNode?.children ) {
+				const themesNode = wpContentNode.children.find( ( node ) => node.id === 'themes' );
+				if ( themesNode ) {
+					themesNode.checked = false;
+					themesNode.indeterminate = true;
+					themesNode.children = [
+						{ id: 'theme1', label: 'Theme 1', checked: true, type: 'folder' },
+						{ id: 'theme2', label: 'Theme 2', checked: false, type: 'folder' },
+						{ id: 'theme3', label: 'Theme 3', checked: true, type: 'folder' },
+						{ id: 'theme4', label: 'Theme 4', checked: false, type: 'folder' },
+					];
+				}
+			}
+
+			const optionsToSync = convertTreeToOptionsToSync( tree );
+			expect( optionsToSync ).toEqual( {
+				optionsToSync: [ 'themes' ],
+				specificSelections: {
+					themes: [ 'theme1', 'theme3' ],
+				},
+			} );
+		} );
+
+		it( 'returns partial uploads selection when only some uploads are selected', () => {
+			const { result } = renderHook( () => useDefaultTree() );
+			let tree = result.current;
+
+			tree = updateNodeById( tree, 'filesAndFolders', { checked: false } );
+			tree = updateNodeById( tree, 'sqls', { checked: false } );
+			tree = updateNodeById( tree, 'plugins', { checked: false } );
+			tree = updateNodeById( tree, 'themes', { checked: false } );
+			tree = updateNodeById( tree, 'contents', { checked: false } );
+
+			const wpContentNode = tree
+				.find( ( node ) => node.id === 'filesAndFolders' )
+				?.children?.find( ( node ) => node.id === 'wp-content' );
+			if ( wpContentNode?.children ) {
+				const uploadsNode = wpContentNode.children.find( ( node ) => node.id === 'uploads' );
+				if ( uploadsNode ) {
+					uploadsNode.checked = false;
+					uploadsNode.indeterminate = true;
+					uploadsNode.children = [
+						{ id: 'upload1', label: 'Upload 1', checked: true, type: 'folder' },
+						{ id: 'upload2', label: 'Upload 2', checked: true, type: 'folder' },
+						{ id: 'upload3', label: 'Upload 3', checked: false, type: 'folder' },
+					];
+				}
+			}
+
+			const optionsToSync = convertTreeToOptionsToSync( tree );
+			expect( optionsToSync ).toEqual( {
+				optionsToSync: [ 'uploads' ],
+				specificSelections: {
+					uploads: [ 'upload1', 'upload2' ],
+				},
+			} );
+		} );
+
+		it( 'returns mixed partial selections for plugins and themes', () => {
+			const { result } = renderHook( () => useDefaultTree() );
+			let tree = result.current;
+
+			tree = updateNodeById( tree, 'filesAndFolders', { checked: false } );
+			tree = updateNodeById( tree, 'sqls', { checked: false } );
+			tree = updateNodeById( tree, 'uploads', { checked: false } );
+			tree = updateNodeById( tree, 'contents', { checked: false } );
+
+			const wpContentNode = tree
+				.find( ( node ) => node.id === 'filesAndFolders' )
+				?.children?.find( ( node ) => node.id === 'wp-content' );
+			if ( wpContentNode?.children ) {
+				const pluginsNode = wpContentNode.children.find( ( node ) => node.id === 'plugins' );
+				if ( pluginsNode ) {
+					pluginsNode.checked = false;
+					pluginsNode.indeterminate = true;
+					pluginsNode.children = [
+						{ id: 'plugin1', label: 'Plugin 1', checked: true, type: 'folder' },
+						{ id: 'plugin2', label: 'Plugin 2', checked: false, type: 'folder' },
+					];
+				}
+
+				const themesNode = wpContentNode.children.find( ( node ) => node.id === 'themes' );
+				if ( themesNode ) {
+					themesNode.checked = false;
+					themesNode.indeterminate = true;
+					themesNode.children = [
+						{ id: 'theme1', label: 'Theme 1', checked: true, type: 'folder' },
+						{ id: 'theme2', label: 'Theme 2', checked: false, type: 'folder' },
+						{ id: 'theme3', label: 'Theme 3', checked: true, type: 'folder' },
+					];
+				}
+			}
+
+			const optionsToSync = convertTreeToOptionsToSync( tree );
+			expect( optionsToSync ).toEqual( {
+				optionsToSync: [ 'plugins', 'themes' ],
+				specificSelections: {
+					plugins: [ 'plugin1' ],
+					themes: [ 'theme1', 'theme3' ],
+				},
+			} );
+		} );
+
+		it( 'returns no specificSelections when all children are selected in a category', () => {
+			const { result } = renderHook( () => useDefaultTree() );
+			let tree = result.current;
+
+			tree = updateNodeById( tree, 'filesAndFolders', { checked: false } );
+			tree = updateNodeById( tree, 'sqls', { checked: false } );
+			tree = updateNodeById( tree, 'themes', { checked: false } );
+			tree = updateNodeById( tree, 'uploads', { checked: false } );
+			tree = updateNodeById( tree, 'contents', { checked: false } );
+
+			const wpContentNode = tree
+				.find( ( node ) => node.id === 'filesAndFolders' )
+				?.children?.find( ( node ) => node.id === 'wp-content' );
+			if ( wpContentNode?.children ) {
+				const pluginsNode = wpContentNode.children.find( ( node ) => node.id === 'plugins' );
+				if ( pluginsNode ) {
+					pluginsNode.checked = true;
+					pluginsNode.children = [
+						{ id: 'plugin1', label: 'Plugin 1', checked: true, type: 'folder' },
+						{ id: 'plugin2', label: 'Plugin 2', checked: true, type: 'folder' },
+					];
+				}
+			}
+
+			const optionsToSync = convertTreeToOptionsToSync( tree );
+			expect( optionsToSync ).toEqual( {
+				optionsToSync: [ 'plugins' ],
+				specificSelections: undefined,
+			} );
+		} );
+
+		it( 'returns no specificSelections when no children are selected in a category', () => {
+			const { result } = renderHook( () => useDefaultTree() );
+			let tree = result.current;
+
+			tree = updateNodeById( tree, 'filesAndFolders', { checked: false } );
+			tree = updateNodeById( tree, 'sqls', { checked: false } );
+			tree = updateNodeById( tree, 'themes', { checked: false } );
+			tree = updateNodeById( tree, 'uploads', { checked: false } );
+			tree = updateNodeById( tree, 'contents', { checked: false } );
+
+			const wpContentNode = tree
+				.find( ( node ) => node.id === 'filesAndFolders' )
+				?.children?.find( ( node ) => node.id === 'wp-content' );
+			if ( wpContentNode?.children ) {
+				const pluginsNode = wpContentNode.children.find( ( node ) => node.id === 'plugins' );
+				if ( pluginsNode ) {
+					pluginsNode.checked = false;
+					pluginsNode.children = [
+						{ id: 'plugin1', label: 'Plugin 1', checked: false, type: 'folder' },
+						{ id: 'plugin2', label: 'Plugin 2', checked: false, type: 'folder' },
+					];
+				}
+			}
+
+			const optionsToSync = convertTreeToOptionsToSync( tree );
+			expect( optionsToSync ).toEqual( {
+				optionsToSync: [],
+				specificSelections: undefined,
+			} );
+		} );
+
+		it( 'handles mixed selection with database and partial plugins', () => {
+			const { result } = renderHook( () => useDefaultTree() );
+			let tree = result.current;
+
+			tree = updateNodeById( tree, 'filesAndFolders', { checked: false } );
+			tree = updateNodeById( tree, 'themes', { checked: false } );
+			tree = updateNodeById( tree, 'uploads', { checked: false } );
+			tree = updateNodeById( tree, 'contents', { checked: false } );
+
+			const wpContentNode = tree
+				.find( ( node ) => node.id === 'filesAndFolders' )
+				?.children?.find( ( node ) => node.id === 'wp-content' );
+			if ( wpContentNode?.children ) {
+				const pluginsNode = wpContentNode.children.find( ( node ) => node.id === 'plugins' );
+				if ( pluginsNode ) {
+					pluginsNode.checked = false;
+					pluginsNode.indeterminate = true;
+					pluginsNode.children = [
+						{ id: 'plugin1', label: 'Plugin 1', checked: true, type: 'folder' },
+						{ id: 'plugin2', label: 'Plugin 2', checked: false, type: 'folder' },
+					];
+				}
+			}
+
+			const optionsToSync = convertTreeToOptionsToSync( tree );
+			expect( optionsToSync ).toEqual( {
+				optionsToSync: [ 'sqls', 'plugins' ],
+				specificSelections: {
+					plugins: [ 'plugin1' ],
+				},
+			} );
+		} );
+	} );
 } );

--- a/src/components/tests/convert-tree-to-options-to-sync.tsx
+++ b/src/components/tests/convert-tree-to-options-to-sync.tsx
@@ -37,6 +37,21 @@ describe( 'convertTreeToOptionsToSync', () => {
 		} );
 	} );
 
+	it( 'returns ["uploads"] when only uploads are selected', () => {
+		const { result } = renderHook( () => useDefaultTree() );
+		let tree = result.current;
+
+		tree = updateNodeById( tree, 'filesAndFolders', { checked: false } );
+		tree = updateNodeById( tree, 'sqls', { checked: false } );
+		tree = updateNodeById( tree, 'uploads', { checked: true } );
+
+		const optionsToSync = convertTreeToOptionsToSync( tree );
+		expect( optionsToSync ).toEqual( {
+			optionsToSync: [ 'uploads' ],
+			specificSelections: undefined,
+		} );
+	} );
+
 	it( 'returns ["sqls", "plugins"] when both are selected', () => {
 		const { result } = renderHook( () => useDefaultTree() );
 		let tree = result.current;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -78,3 +78,7 @@ export const IPC_VOID_HANDLERS = < const >[
 	'showNotification',
 	'authenticate',
 ];
+
+// Folders in wp-content that can be selectively synced
+export const WP_CONTENT_FOLDERS = [ 'plugins', 'themes', 'uploads' ] as const;
+export type WpContentFolder = ( typeof WP_CONTENT_FOLDERS )[ number ];

--- a/src/hooks/sync-sites/use-sync-push.ts
+++ b/src/hooks/sync-sites/use-sync-push.ts
@@ -33,6 +33,7 @@ type PushSiteOptions = {
 	specificSelections?: {
 		plugins?: string[];
 		themes?: string[];
+		uploads?: string[];
 	};
 };
 

--- a/src/hooks/use-content-folders.ts
+++ b/src/hooks/use-content-folders.ts
@@ -1,8 +1,8 @@
 import * as Sentry from '@sentry/electron/renderer';
 import { useState, useEffect } from 'react';
+import { WpContentFolder } from 'src/constants';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 
-export type WpContentFolder = 'plugins' | 'themes';
 export type WpContentFolderEntry = { name: string; type: 'file' | 'folder' };
 export type WpContentFolderResult = {
 	items: WpContentFolderEntry[];
@@ -17,6 +17,7 @@ export function useContentFolders(
 	const [ results, setResults ] = useState< Record< WpContentFolder, WpContentFolderResult > >( {
 		plugins: { items: [], isLoading: true, error: null },
 		themes: { items: [], isLoading: true, error: null },
+		uploads: { items: [], isLoading: true, error: null },
 	} );
 
 	useEffect( () => {

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -1422,7 +1422,7 @@ export async function listWpContentFolders(
 				name: e.name.toString(),
 				type: e.isDirectory() ? ( 'folder' as const ) : ( 'file' as const ),
 			} ) )
-			.filter( ( entry: { name: string; type: string } ) => {
+			.filter( ( entry: { name: string } ) => {
 				return ! entry.name.startsWith( '.' );
 			} );
 	} catch ( err ) {

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -1421,9 +1421,10 @@ export async function listWpContentFolders(
 			.map( ( e ) => ( {
 				name: e.name.toString(),
 				type: e.isDirectory() ? ( 'folder' as const ) : ( 'file' as const ),
+				hidden: e.name.startsWith( '.' ),
 			} ) )
-			.filter( ( entry: { name: string } ) => {
-				return ! entry.name.startsWith( '.' );
+			.filter( ( entry: { name: string; hidden: boolean } ) => {
+				return ! entry.hidden;
 			} );
 	} catch ( err ) {
 		return [];

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -22,7 +22,13 @@ import { SupportedLocale } from 'common/lib/locale';
 import { getAuthenticationUrl } from 'common/lib/oauth';
 import { Snapshot } from 'common/types/snapshot';
 import { StatsGroup, StatsMetric } from 'common/types/stats';
-import { ARCHIVER_OPTIONS, DEFAULT_TERMINAL, MAIN_MIN_WIDTH, SIDEBAR_WIDTH } from 'src/constants';
+import {
+	ARCHIVER_OPTIONS,
+	DEFAULT_TERMINAL,
+	MAIN_MIN_WIDTH,
+	SIDEBAR_WIDTH,
+	WpContentFolder,
+} from 'src/constants';
 import { sendIpcEventToRenderer, sendIpcEventToRendererWithWindow } from 'src/ipc-utils';
 import { ACTIVE_SYNC_OPERATIONS } from 'src/lib/active-sync-operations';
 import { bumpStat } from 'src/lib/bump-stats';
@@ -664,6 +670,7 @@ export async function exportSiteToPush(
 		specificSelections?: {
 			plugins?: string[];
 			themes?: string[];
+			uploads?: string[];
 		};
 	}
 ) {
@@ -1402,7 +1409,7 @@ export function comparePaths( event: IpcMainInvokeEvent, path1: string, path2: s
 export async function listWpContentFolders(
 	_event: Electron.IpcMainInvokeEvent,
 	siteId: string,
-	subdir: 'plugins' | 'themes'
+	subdir: WpContentFolder
 ): Promise< { name: string; type: 'file' | 'folder' }[] > {
 	const server = SiteServer.get( siteId );
 	if ( ! server ) throw new Error( 'Site not found' );

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -1423,8 +1423,7 @@ export async function listWpContentFolders(
 				type: e.isDirectory() ? ( 'folder' as const ) : ( 'file' as const ),
 			} ) )
 			.filter( ( entry: { name: string; type: string } ) => {
-				if ( entry.type === 'folder' ) return true;
-				return entry.type === 'file' && entry.name.toLowerCase().endsWith( '.php' );
+				return ! entry.name.startsWith( '.' );
 			} );
 	} catch ( err ) {
 		return [];

--- a/src/lib/import-export/export/exporters/default-exporter.ts
+++ b/src/lib/import-export/export/exporters/default-exporter.ts
@@ -164,7 +164,8 @@ export class DefaultExporter extends EventEmitter implements Exporter {
 			const partialFolderItems =
 				this.options.specificSelections &&
 				( ( category === 'plugins' && this.options.specificSelections.plugins ) ||
-					( category === 'themes' && this.options.specificSelections.themes ) );
+					( category === 'themes' && this.options.specificSelections.themes ) ||
+					( category === 'uploads' && this.options.specificSelections.uploads ) );
 
 			if ( partialFolderItems ) {
 				for ( const itemName of partialFolderItems ) {
@@ -186,7 +187,6 @@ export class DefaultExporter extends EventEmitter implements Exporter {
 					}
 				}
 			} else {
-				// Add entire directory (existing behavior)
 				this.archive.directory( absolutePath, archivePath, ( entry ) => {
 					const fullArchivePath = path.join( archivePath, entry.name );
 					const isExcluded = this.pathsToExclude.some( ( pathToExclude ) =>

--- a/src/lib/import-export/export/exporters/default-exporter.ts
+++ b/src/lib/import-export/export/exporters/default-exporter.ts
@@ -160,12 +160,7 @@ export class DefaultExporter extends EventEmitter implements Exporter {
 			const folderName = category === 'muPlugins' ? 'mu-plugins' : category;
 			const absolutePath = path.join( this.options.site.path, 'wp-content', folderName );
 			const archivePath = path.relative( this.options.site.path, absolutePath );
-
-			const partialFolderItems =
-				this.options.specificSelections &&
-				( ( category === 'plugins' && this.options.specificSelections.plugins ) ||
-					( category === 'themes' && this.options.specificSelections.themes ) ||
-					( category === 'uploads' && this.options.specificSelections.uploads ) );
+			const partialFolderItems = this.getCategorySelections( category );
 
 			if ( partialFolderItems ) {
 				for ( const itemName of partialFolderItems ) {
@@ -206,6 +201,23 @@ export class DefaultExporter extends EventEmitter implements Exporter {
 			this.emit( ExportEvents.WP_CONTENT_EXPORT_PROGRESS, { directory: absolutePath } );
 		}
 		this.emit( ExportEvents.WP_CONTENT_EXPORT_COMPLETE );
+	}
+
+	private getCategorySelections( category: BackupContentsCategory ): string[] | null {
+		if ( ! this.options.specificSelections ) {
+			return null;
+		}
+
+		switch ( category ) {
+			case 'plugins':
+				return this.options.specificSelections?.plugins || null;
+			case 'themes':
+				return this.options.specificSelections?.themes || null;
+			case 'uploads':
+				return this.options.specificSelections?.uploads || null;
+			default:
+				return null;
+		}
 	}
 
 	private async addDatabase(): Promise< void > {

--- a/src/lib/import-export/export/types.ts
+++ b/src/lib/import-export/export/types.ts
@@ -10,6 +10,7 @@ export interface ExportOptions {
 	specificSelections?: {
 		plugins?: string[];
 		themes?: string[];
+		uploads?: string[];
 	};
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-579

## Proposed Changes

- Allows selective sync for `uploads` folder content
- `plugins`, `themes` and `uploads` are collapsed by default
- Display more files types in the sync dialog tree

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- `STUDIO_SELECTIVE_SYNC=true npm start`
- Create a site or use an existing one and connect it with a remote site.
- Use "Push" option
- Select "Specific files and folders"
- Validate `wp-content` is expanded but `plugins`, `themes` and `uploads` are collapsed by default
- Expand `uploads` and verify the options match the file contents from your site folder
- Do the push operation and validate only the selected options were pushed to the remote site.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
