### PR TITLE
Rename archiver-related functions to avoid confusion

### DIFF
--- a/cli/commands/preview/create.ts
+++ b/cli/commands/preview/create.ts
@@ -4,7 +4,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { PreviewCommandLoggerAction as LoggerAction } from 'common/logger-actions';
 import { uploadArchive, waitForSiteReady } from 'cli/lib/api';
 import { getAuthToken } from 'cli/lib/appdata';
-import { createArchive, cleanup } from 'cli/lib/archive';
+import { archiveSiteContent, cleanup } from 'cli/lib/archive';
 import { saveSnapshotToAppdata } from 'cli/lib/snapshots';
 import { validateSiteFolder, validateSiteSize } from 'cli/lib/validation';
 import { Logger, LoggerError } from 'cli/logger';
@@ -25,7 +25,7 @@ export async function runCommand( siteFolder: string ): Promise< void > {
 		logger.reportSuccess( __( 'Validation successful' ), true );
 
 		logger.reportStart( LoggerAction.ARCHIVE, __( 'Creating archive…' ) );
-		await createArchive( siteFolder, archivePath );
+		await archiveSiteContent( siteFolder, archivePath );
 		logger.reportSuccess( __( 'Archive created' ) );
 
 		logger.reportStart( LoggerAction.UPLOAD, __( 'Uploading archive…' ) );

--- a/cli/commands/preview/tests/create.test.ts
+++ b/cli/commands/preview/tests/create.test.ts
@@ -2,7 +2,7 @@ import os from 'os';
 import path from 'path';
 import { uploadArchive, waitForSiteReady } from 'cli/lib/api';
 import { getAuthToken } from 'cli/lib/appdata';
-import { createArchive, cleanup } from 'cli/lib/archive';
+import { archiveSiteContent, cleanup } from 'cli/lib/archive';
 import { saveSnapshotToAppdata } from 'cli/lib/snapshots';
 import { validateSiteFolder } from 'cli/lib/validation';
 import { Logger, LoggerError } from 'cli/logger';
@@ -55,7 +55,7 @@ describe( 'Preview Create Command', () => {
 
 		( getAuthToken as jest.Mock ).mockResolvedValue( mockAuthToken );
 		( validateSiteFolder as jest.Mock ).mockReturnValue( true );
-		( createArchive as jest.Mock ).mockResolvedValue( mockArchiver );
+		( archiveSiteContent as jest.Mock ).mockResolvedValue( mockArchiver );
 		( cleanup as jest.Mock ).mockImplementation( () => {} );
 		( uploadArchive as jest.Mock ).mockResolvedValue( {
 			site_url: mockSiteUrl,
@@ -77,7 +77,7 @@ describe( 'Preview Create Command', () => {
 		expect( mockLogger.reportStart.mock.calls[ 0 ] ).toEqual( [ 'validate', 'Validating…' ] );
 		expect( mockLogger.reportSuccess.mock.calls[ 0 ] ).toEqual( [ 'Validation successful', true ] );
 
-		expect( createArchive ).toHaveBeenCalledWith( mockFolder, mockArchivePath );
+		expect( archiveSiteContent ).toHaveBeenCalledWith( mockFolder, mockArchivePath );
 		expect( mockLogger.reportStart.mock.calls[ 1 ] ).toEqual( [ 'archive', 'Creating archive…' ] );
 		expect( mockLogger.reportSuccess.mock.calls[ 1 ] ).toEqual( [ 'Archive created' ] );
 
@@ -128,7 +128,7 @@ describe( 'Preview Create Command', () => {
 
 		expect( mockLogger.reportError ).toHaveBeenCalled();
 		expect( mockLogger.reportError ).toHaveBeenCalledWith( expect.any( LoggerError ) );
-		expect( createArchive ).not.toHaveBeenCalled();
+		expect( archiveSiteContent ).not.toHaveBeenCalled();
 	} );
 
 	it( 'should handle authentication errors', async () => {
@@ -143,12 +143,12 @@ describe( 'Preview Create Command', () => {
 
 		expect( mockLogger.reportError ).toHaveBeenCalled();
 		expect( mockLogger.reportError ).toHaveBeenCalledWith( expect.any( LoggerError ) );
-		expect( createArchive ).not.toHaveBeenCalled();
+		expect( archiveSiteContent ).not.toHaveBeenCalled();
 	} );
 
 	it( 'should handle archive creation errors', async () => {
 		const errorMessage = 'Archive creation failed';
-		( createArchive as jest.Mock ).mockImplementation( () => {
+		( archiveSiteContent as jest.Mock ).mockImplementation( () => {
 			throw new LoggerError( errorMessage );
 		} );
 

--- a/cli/commands/preview/tests/update.test.ts
+++ b/cli/commands/preview/tests/update.test.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import { DEMO_SITE_EXPIRATION_DAYS } from 'common/constants';
 import { uploadArchive, waitForSiteReady } from 'cli/lib/api';
 import { getAuthToken, getOrCreateSiteByFolder, getSiteByFolder } from 'cli/lib/appdata';
-import { createArchive, cleanup } from 'cli/lib/archive';
+import { archiveSiteContent, cleanup } from 'cli/lib/archive';
 import { updateSnapshotInAppdata, getSnapshotsFromAppdata } from 'cli/lib/snapshots';
 import { validateSiteFolder } from 'cli/lib/validation';
 import { Logger, LoggerError } from 'cli/logger';
@@ -61,7 +61,7 @@ describe( 'Preview Update Command', () => {
 		( getAuthToken as jest.Mock ).mockResolvedValue( mockAuthToken );
 		( validateSiteFolder as jest.Mock ).mockReturnValue( true );
 		( getSnapshotsFromAppdata as jest.Mock ).mockResolvedValue( [ mockSnapshot ] );
-		( createArchive as jest.Mock ).mockResolvedValue( undefined );
+		( archiveSiteContent as jest.Mock ).mockResolvedValue( undefined );
 		( uploadArchive as jest.Mock ).mockResolvedValue( {
 			site_url: mockSiteUrl,
 			site_id: mockAtomicSiteId,
@@ -87,7 +87,7 @@ describe( 'Preview Update Command', () => {
 		expect( mockLogger.reportStart.mock.calls[ 0 ] ).toEqual( [ 'validate', 'Validating…' ] );
 		expect( mockLogger.reportSuccess.mock.calls[ 0 ] ).toEqual( [ 'Validation successful', true ] );
 
-		expect( createArchive ).toHaveBeenCalledWith( mockFolder, mockArchivePath );
+		expect( archiveSiteContent ).toHaveBeenCalledWith( mockFolder, mockArchivePath );
 		expect( mockLogger.reportStart.mock.calls[ 1 ] ).toEqual( [ 'archive', 'Creating archive…' ] );
 		expect( mockLogger.reportSuccess.mock.calls[ 1 ] ).toEqual( [ 'Archive created' ] );
 
@@ -136,7 +136,7 @@ describe( 'Preview Update Command', () => {
 
 		expect( mockLogger.reportError ).toHaveBeenCalled();
 		expect( mockLogger.reportError ).toHaveBeenCalledWith( expect.any( LoggerError ) );
-		expect( createArchive ).not.toHaveBeenCalled();
+		expect( archiveSiteContent ).not.toHaveBeenCalled();
 	} );
 
 	it( 'should handle authentication errors', async () => {
@@ -151,7 +151,7 @@ describe( 'Preview Update Command', () => {
 
 		expect( mockLogger.reportError ).toHaveBeenCalled();
 		expect( mockLogger.reportError ).toHaveBeenCalledWith( expect.any( LoggerError ) );
-		expect( createArchive ).not.toHaveBeenCalled();
+		expect( archiveSiteContent ).not.toHaveBeenCalled();
 	} );
 
 	it( 'should handle snapshot not found errors', async () => {
@@ -162,12 +162,12 @@ describe( 'Preview Update Command', () => {
 
 		expect( mockLogger.reportError ).toHaveBeenCalled();
 		expect( mockLogger.reportError ).toHaveBeenCalledWith( expect.any( LoggerError ) );
-		expect( createArchive ).not.toHaveBeenCalled();
+		expect( archiveSiteContent ).not.toHaveBeenCalled();
 	} );
 
 	it( 'should handle archive creation errors', async () => {
 		const errorMessage = 'Archive creation failed';
-		( createArchive as jest.Mock ).mockImplementation( () => {
+		( archiveSiteContent as jest.Mock ).mockImplementation( () => {
 			throw new LoggerError( errorMessage );
 		} );
 
@@ -241,7 +241,7 @@ describe( 'Preview Update Command', () => {
 
 		expect( mockLogger.reportError ).toHaveBeenCalled();
 		expect( mockLogger.reportError ).toHaveBeenCalledWith( expect.any( LoggerError ) );
-		expect( createArchive ).not.toHaveBeenCalled();
+		expect( archiveSiteContent ).not.toHaveBeenCalled();
 	} );
 
 	it( 'should throw error if folder does not match original site and no overwrite flag', async () => {
@@ -253,7 +253,7 @@ describe( 'Preview Update Command', () => {
 		} );
 		await runCommand( mockFolder, mockSiteUrl, false );
 		expect( mockLogger.reportError ).toHaveBeenCalledWith( expect.any( LoggerError ) );
-		expect( createArchive ).not.toHaveBeenCalled();
+		expect( archiveSiteContent ).not.toHaveBeenCalled();
 	} );
 
 	it( 'should allow update if overwrite flag is set even if folder does not match', async () => {
@@ -264,6 +264,6 @@ describe( 'Preview Update Command', () => {
 			name: 'Other Site',
 		} );
 		await runCommand( mockFolder, mockSiteUrl, true );
-		expect( createArchive ).toHaveBeenCalledWith( mockFolder, mockArchivePath );
+		expect( archiveSiteContent ).toHaveBeenCalledWith( mockFolder, mockArchivePath );
 	} );
 } );

--- a/cli/commands/preview/update.ts
+++ b/cli/commands/preview/update.ts
@@ -7,7 +7,7 @@ import { Snapshot } from 'common/types/snapshot';
 import { addDays } from 'date-fns';
 import { uploadArchive, waitForSiteReady } from 'cli/lib/api';
 import { getAuthToken, getOrCreateSiteByFolder, getSiteByFolder } from 'cli/lib/appdata';
-import { cleanup, createArchive } from 'cli/lib/archive';
+import { cleanup, archiveSiteContent } from 'cli/lib/archive';
 import { getSnapshotsFromAppdata, updateSnapshotInAppdata } from 'cli/lib/snapshots';
 import { normalizeHostname } from 'cli/lib/utils';
 import { validateSiteFolder } from 'cli/lib/validation';
@@ -73,7 +73,7 @@ export async function runCommand(
 		logger.reportSuccess( __( 'Validation successful' ), true );
 
 		logger.reportStart( LoggerAction.ARCHIVE, __( 'Creating archive…' ) );
-		await createArchive( siteFolder, archivePath );
+		await archiveSiteContent( siteFolder, archivePath );
 		logger.reportSuccess( __( 'Archive created' ) );
 
 		logger.reportStart( LoggerAction.UPLOAD, __( 'Uploading archive…' ) );

--- a/cli/lib/archive.ts
+++ b/cli/lib/archive.ts
@@ -6,26 +6,26 @@ import { LoggerError } from 'cli/logger';
 
 const ZIP_COMPRESSION_LEVEL = 9;
 
-export async function createArchive(
+export async function archiveSiteContent(
 	siteFolder: string,
 	archivePath: string
 ): Promise< archiver.Archiver > {
 	return new Promise( ( resolve, reject ) => {
 		const output = fs.createWriteStream( archivePath );
-		const archive = archiver( 'zip', {
+		const archiveBuilder = archiver( 'zip', {
 			zlib: { level: ZIP_COMPRESSION_LEVEL },
 			followSymlinks: true,
 		} );
 
 		output.on( 'close', () => {
-			resolve( archive );
+			resolve( archiveBuilder );
 		} );
-		archive.on( 'error', ( error: Error ) => {
+		archiveBuilder.on( 'error', ( error: Error ) => {
 			reject( new LoggerError( __( 'Failed to create archive' ), error ) );
 		} );
 
-		archive.pipe( output );
-		archive.directory(
+		archiveBuilder.pipe( output );
+		archiveBuilder.directory(
 			path.join( siteFolder, 'wp-content' ),
 			'wp-content',
 			( entry: EntryData ) => {
@@ -38,10 +38,10 @@ export async function createArchive(
 
 		const wpConfigPath = path.join( siteFolder, 'wp-config.php' );
 		if ( fs.existsSync( wpConfigPath ) ) {
-			archive.file( wpConfigPath, { name: 'wp-config.php' } );
+			archiveBuilder.file( wpConfigPath, { name: 'wp-config.php' } );
 		}
 
-		archive.finalize().catch( reject );
+		archiveBuilder.finalize().catch( reject );
 	} );
 }
 

--- a/cli/lib/tests/archive.test.ts
+++ b/cli/lib/tests/archive.test.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import archiver from 'archiver';
-import { createArchive, cleanup } from 'cli/lib/archive';
+import { archiveSiteContent, cleanup } from 'cli/lib/archive';
 
 jest.mock( 'fs' );
 jest.mock( 'path' );
@@ -45,7 +45,7 @@ describe( 'Archive Module', () => {
 
 			mockArchiver.on.mockImplementation( () => mockArchiver );
 
-			const result = await createArchive( mockSiteFolder, mockArchivePath );
+			const result = await archiveSiteContent( mockSiteFolder, mockArchivePath );
 
 			expect( fs.createWriteStream ).toHaveBeenCalledWith( mockArchivePath );
 			expect( archiver ).toHaveBeenCalledWith( 'zip', {
@@ -78,7 +78,7 @@ describe( 'Archive Module', () => {
 
 			mockArchiver.on.mockImplementation( () => mockArchiver );
 
-			await createArchive( mockSiteFolder, mockArchivePath );
+			await archiveSiteContent( mockSiteFolder, mockArchivePath );
 
 			expect( fs.existsSync ).toHaveBeenCalledWith( mockWpConfigPath );
 			expect( mockArchiver.file ).toHaveBeenCalledWith( mockWpConfigPath, {
@@ -100,7 +100,7 @@ describe( 'Archive Module', () => {
 
 			mockArchiver.finalize.mockRejectedValue( mockError );
 
-			await expect( createArchive( mockSiteFolder, mockArchivePath ) ).rejects.toThrow(
+			await expect( archiveSiteContent( mockSiteFolder, mockArchivePath ) ).rejects.toThrow(
 				'Archive error'
 			);
 		} );

--- a/src/lib/import-export/export/exporters/default-exporter.ts
+++ b/src/lib/import-export/export/exporters/default-exporter.ts
@@ -24,7 +24,7 @@ import { getWordPressVersionFromInstallation } from 'src/lib/wp-versions';
 import { SiteServer } from 'src/site-server';
 
 export class DefaultExporter extends EventEmitter implements Exporter {
-	private archive!: archiver.Archiver;
+	private archiveBuilder!: archiver.Archiver;
 	private backup: BackupContents;
 	private readonly options: ExportOptions;
 	private readonly pathsToExclude = [
@@ -84,24 +84,24 @@ export class DefaultExporter extends EventEmitter implements Exporter {
 	async export(): Promise< void > {
 		this.emit( ExportEvents.EXPORT_START );
 		const output = fs.createWriteStream( this.options.backupFile );
-		this.archive = this.createArchive();
+		this.archiveBuilder = this.createArchiveBuilder();
 
 		const archiveClosedPromise = this.setupArchiveListeners( output );
 
-		this.archive.pipe( output );
+		this.archiveBuilder.pipe( output );
 
 		try {
 			this.addWpConfig();
 			this.addWpContent();
 			await this.addDatabase();
 			const studioJsonPath = await this.createStudioJsonFile();
-			this.archive.file( studioJsonPath, { name: 'meta.json' } );
-			await this.archive.finalize();
+			this.archiveBuilder.file( studioJsonPath, { name: 'meta.json' } );
+			await this.archiveBuilder.finalize();
 			this.emit( ExportEvents.BACKUP_CREATE_COMPLETE );
 			await archiveClosedPromise;
 			this.emit( ExportEvents.EXPORT_COMPLETE );
 		} catch ( error ) {
-			this.archive.abort();
+			this.archiveBuilder.abort();
 			this.emit( ExportEvents.EXPORT_ERROR );
 			throw error;
 		} finally {
@@ -111,7 +111,7 @@ export class DefaultExporter extends EventEmitter implements Exporter {
 		}
 	}
 
-	private createArchive(): archiver.Archiver {
+	private createArchiveBuilder(): archiver.Archiver {
 		this.emit( ExportEvents.BACKUP_CREATE_START );
 		const isZip = this.options.backupFile.endsWith( '.zip' );
 		const format = isZip ? 'zip' : 'tar';
@@ -125,27 +125,27 @@ export class DefaultExporter extends EventEmitter implements Exporter {
 				resolve();
 			} );
 
-			this.archive.on( 'warning', ( err ) => {
+			this.archiveBuilder.on( 'warning', ( err ) => {
 				if ( err.code === 'ENOENT' ) {
 					console.warn( 'Archiver warning:', err );
 				} else {
 					reject( err );
 				}
 			} );
-			this.archive.on( 'progress', ( progress ) => {
+			this.archiveBuilder.on( 'progress', ( progress ) => {
 				this.emit( ExportEvents.BACKUP_CREATE_PROGRESS, {
 					progress,
 				} as BackupCreateProgressEventData );
 			} );
 
-			this.archive.on( 'error', reject );
+			this.archiveBuilder.on( 'error', reject );
 		} );
 	}
 
 	private addWpConfig(): void {
 		const wpConfigPath = path.join( this.options.site.path, 'wp-config.php' );
 		if ( fs.existsSync( wpConfigPath ) ) {
-			this.archive.file( wpConfigPath, {
+			this.archiveBuilder.file( wpConfigPath, {
 				name: 'wp-config.php',
 			} );
 		}
@@ -174,20 +174,20 @@ export class DefaultExporter extends EventEmitter implements Exporter {
 					if ( fs.existsSync( itemPath ) ) {
 						const stat = fs.statSync( itemPath );
 						if ( stat.isDirectory() ) {
-							this.archive.directory( itemPath, itemArchivePath, ( entry ) => {
+							this.archiveBuilder.directory( itemPath, itemArchivePath, ( entry ) => {
 								if ( entry.name.includes( '.git' ) || entry.name.includes( 'node_modules' ) ) {
 									return false;
 								}
 								return entry;
 							} );
 						} else {
-							this.archive.file( itemPath, { name: itemArchivePath } );
+							this.archiveBuilder.file( itemPath, { name: itemArchivePath } );
 						}
 					}
 				}
 			} else {
 				// Add entire directory (existing behavior)
-				this.archive.directory( absolutePath, archivePath, ( entry ) => {
+				this.archiveBuilder.directory( absolutePath, archivePath, ( entry ) => {
 					const fullArchivePath = path.join( archivePath, entry.name );
 					const isExcluded = this.pathsToExclude.some( ( pathToExclude ) =>
 						fullArchivePath.startsWith( path.normalize( pathToExclude ) )
@@ -219,14 +219,14 @@ export class DefaultExporter extends EventEmitter implements Exporter {
 		if ( this.options.splitDatabaseDumpByTable ) {
 			const sqlFiles = await exportDatabaseToMultipleFiles( this.options.site, tmpFolder );
 			sqlFiles.forEach( ( file ) =>
-				this.archive.file( file, { name: `sql/${ path.basename( file ) }` } )
+				this.archiveBuilder.file( file, { name: `sql/${ path.basename( file ) }` } )
 			);
 			this.backup.sqlFiles.push( ...sqlFiles );
 		} else {
 			const fileName = `${ generateBackupFilename( 'db-export' ) }.sql`;
 			const sqlDumpPath = path.join( tmpFolder, fileName );
 			await exportDatabaseToFile( this.options.site, sqlDumpPath );
-			this.archive.file( sqlDumpPath, { name: `sql/${ fileName }` } );
+			this.archiveBuilder.file( sqlDumpPath, { name: `sql/${ fileName }` } );
 			this.backup.sqlFiles.push( sqlDumpPath );
 		}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-483

## Proposed Changes

I propose to rename archiver-related functions to avoid confusion.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Confirm that export works fine
- Confirm that preview site adding works

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
