### PR TITLE
Add new icon for Other Wp-content option

### DIFF
--- a/src/components/tree-view.tsx
+++ b/src/components/tree-view.tsx
@@ -1,11 +1,11 @@
 import { CheckboxControl, Icon, Spinner } from '@wordpress/components';
-import { file, page } from '@wordpress/icons';
+import { file, moreHorizontal, page } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import React from 'react';
 import { RightArrowIcon } from 'src/components/icons/right-arrow';
 import { cx } from 'src/lib/cx';
 
-type TreeNodeType = 'folder' | 'file';
+type TreeNodeType = 'folder' | 'file' | 'more';
 export type TreeNode = {
 	id: string;
 	name: string;
@@ -22,6 +22,7 @@ export type TreeNode = {
 const TREE_NODE_ICONS: Record< TreeNodeType, React.JSX.Element > = {
 	folder: file,
 	file: page,
+	more: moreHorizontal,
 };
 
 const updateNode = ( node: TreeNode, partialNode: Partial< TreeNode > ): TreeNode => {

--- a/src/modules/sync/hooks/use-default-sync-tree.tsx
+++ b/src/modules/sync/hooks/use-default-sync-tree.tsx
@@ -54,7 +54,7 @@ export const useDefaultSyncTree = (): TreeNode[] => {
 								name: SYNC_OPTIONS.contents,
 								label: __( 'Other files and directories' ),
 								checked: true,
-								type: 'folder',
+								type: 'more',
 							},
 						],
 					},


### PR DESCRIPTION
## Related issues

- Fixes STU-591

## Proposed Changes

According to this discussion p1751371337350929/1751370351.812089-slack-C06DRMD6VPZ we are updaing icon for "Other fodlers" item in Sync tree

<img width="739" alt="Screenshot 2025-07-02 at 12 54 16" src="https://github.com/user-attachments/assets/148fe337-d7a8-44f3-a409-10ace6930356" />


## Testing Instructions
1. Run `STUDIO_SELECTIVE_SYNC=true npm start`
2. Open Sync tab
3. Click on Push
4. Assert that Other files and directories has "new icon"
<table>
<tr>
<td>BEFORE
<td>AFTER
</tr>
<tr>
<td><img width="740" alt="Screenshot 2025-07-02 at 12 56 51" src="https://github.com/user-attachments/assets/f4f383ff-811e-42c0-a3c5-b3ffcd8b3967" />
<td><img width="739" alt="Screenshot 2025-07-02 at 12 54 16" src="https://github.com/user-attachments/assets/148fe337-d7a8-44f3-a409-10ace6930356" />
</tr>
</table>