### PR TITLE
Fix importing Jetpack backups after changes on partial sync

### DIFF
--- a/src/lib/import-export/import/importers/importer.ts
+++ b/src/lib/import-export/import/importers/importer.ts
@@ -98,6 +98,12 @@ abstract class BaseBackupImporter extends BaseImporter {
 		this.emit( ImportEvents.IMPORT_START );
 
 		try {
+			await this.moveExistingWpContentToTrash( rootPath );
+			await this.importWpConfig( rootPath );
+			await this.importWpContent( rootPath );
+			if ( this.backup.metaFile ) {
+				this.meta = await this.parseMetaFile();
+			}
 			if ( this.backup.sqlFiles.length ) {
 				const databaseDir = path.join( rootPath, 'wp-content', 'database' );
 				const dbPath = path.join( databaseDir, '.ht.sqlite' );
@@ -105,13 +111,6 @@ abstract class BaseBackupImporter extends BaseImporter {
 				await this.moveExistingDatabaseToTrash( dbPath );
 				await this.createEmptyDatabase( dbPath );
 				await this.importDatabase( rootPath, siteId, this.backup.sqlFiles );
-			}
-
-			await this.moveExistingWpContentToTrash( rootPath );
-			await this.importWpConfig( rootPath );
-			await this.importWpContent( rootPath );
-			if ( this.backup.metaFile ) {
-				this.meta = await this.parseMetaFile();
 			}
 
 			this.emit( ImportEvents.IMPORT_COMPLETE );

--- a/src/lib/import-export/import/validators/jetpack-validator.ts
+++ b/src/lib/import-export/import/validators/jetpack-validator.ts
@@ -9,13 +9,12 @@ export class JetpackValidator extends EventEmitter implements Validator {
 		const optionalDirs = [ 'sql', 'wp-content/uploads', 'wp-content/plugins', 'wp-content/themes' ];
 		const optionalFiles = [ 'wp-config.php' ];
 
-		const hasRequiredMetaJson = fileList.some( ( file ) => file === 'meta.json' );
 		const hasOptionalDir = optionalDirs.some( ( dir ) =>
 			fileList.some( ( file ) => file.startsWith( dir + '/' ) )
 		);
 		const hasOptionalFile = optionalFiles.some( ( file ) => fileList.includes( file ) );
 
-		return hasRequiredMetaJson && ( hasOptionalDir || hasOptionalFile );
+		return hasOptionalDir || hasOptionalFile;
 	}
 
 	parseBackupContents( fileList: string[], extractionDirectory: string ): BackupContents {

--- a/src/lib/import-export/tests/import/validators/jetpack-validator.test.ts
+++ b/src/lib/import-export/tests/import/validators/jetpack-validator.test.ts
@@ -11,7 +11,6 @@ platformTestSuite( 'JetpackValidator', ( { normalize } ) => {
 	describe( 'canHandle', () => {
 		it( 'should return true for valid Jetpack backup structure', () => {
 			const fileList = [
-				'meta.json',
 				'sql/wp_options.sql',
 				'wp-content/uploads/2023/image.jpg',
 				'wp-content/plugins/jetpack/jetpack.php',
@@ -23,7 +22,6 @@ platformTestSuite( 'JetpackValidator', ( { normalize } ) => {
 
 		it( 'should not fail if core files exists.', () => {
 			const fileList = [
-				'meta.json',
 				'sql/wp_options.sql',
 				'wp-admin/wp-admin.php',
 				'wp-admin/about.php',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-598

## Proposed Changes

- Fix importing backups related to https://github.com/Automattic/studio/pull/1503/files#diff-fd22d7f0e834e583a2d43143bad94ebef897974f0ab114cddb662394172c3975
- Remove the requirement of having a meta.json file
- Import database as last step of the import

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run `npm start`
- Create a new site importing a jetpack backup without meta.json
- Observe the site is imported correctly



https://github.com/user-attachments/assets/f4cc9246-5156-40c1-ae54-91f3686b0f85


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
