### PR TITLE
Fix extended sync tree alignment and copy

### DIFF
--- a/src/modules/sync/components/sync-dialog.tsx
+++ b/src/modules/sync/components/sync-dialog.tsx
@@ -162,7 +162,7 @@ export function SyncDialog( {
 				</div>
 				<div className="px-8 pt-7 pb-3">{ copy.subtitleSelector }</div>
 				<div className="px-8 relative">
-					<div className="absolute end-6 top-2 z-10">
+					<div className="absolute end-6 z-10">
 						<SelectControl
 							value={ showAllFiles ? 'true' : 'false' }
 							variant="minimal"
@@ -180,6 +180,7 @@ export function SyncDialog( {
 							__next40pxDefaultSize
 							__nextHasNoMarginBottom
 							aria-label={ __( 'Select files and folders to sync' ) }
+							className="h-9"
 						/>
 					</div>
 					<TreeView tree={ treeState } setTree={ setTreeState } />

--- a/src/modules/sync/hooks/use-sync-dialog-texts.tsx
+++ b/src/modules/sync/hooks/use-sync-dialog-texts.tsx
@@ -36,19 +36,19 @@ export const useSyncDialogTexts = ( type: 'pull' | 'push' ) => {
 				staging: {
 					title: __( 'Push to Staging' ),
 					description: __(
-						'Pushing will replace the existing files and database with a copy from your local site.\n\n The staging site will be backed-up before any changes are applied.'
+						'Pushing will replace the existing files and database with a copy from your local site.\n\n The staging site will be backed up before any changes are applied.'
 					),
 				},
 				sandbox: {
 					title: __( 'Push to Sandbox' ),
 					description: __(
-						'Pushing will replace the existing files and database with a copy from your local site.\n\n The sandbox site will be backed-up before any changes are applied.'
+						'Pushing will replace the existing files and database with a copy from your local site.\n\n The sandbox site will be backed up before any changes are applied.'
 					),
 				},
 				production: {
 					title: __( 'Push to Production' ),
 					description: __(
-						'Pushing will replace the existing files and database with a copy from your local site.\n\n The production site will be backed-up before any changes are applied.'
+						'Pushing will replace the existing files and database with a copy from your local site.\n\n The production site will be backed up before any changes are applied.'
 					),
 				},
 				fromLabel: __( 'Push' ),


### PR DESCRIPTION
## Related issues

- Fixes STU-600

## Proposed Changes

With this PR we fix alignment of selectbox for extended Sync tree and fix copy:
<img width="659" alt="Screenshot 2025-07-03 at 15 08 46" src="https://github.com/user-attachments/assets/762b1171-545a-4af6-8390-b0960181e861" />


## Testing Instructions
1. Open Sync tab
2. Click Pull or Push
3. Assert that selecbiox is aligned vertically:<br />
<img width="762" alt="Screenshot 2025-07-03 at 15 09 47" src="https://github.com/user-attachments/assets/657ace23-bee2-4c42-af54-2300f677dc9c" />
