### PR TITLE
Reset translations after changing any language

### DIFF
--- a/src/stores/i18n-slice.ts
+++ b/src/stores/i18n-slice.ts
@@ -29,6 +29,7 @@ const i18nSlice = createSlice( {
 			// I18n functions from `@wordpress/i18n` package.
 			// Note we need to update this in both the renderer and main processes.
 			if ( translations ) {
+				defaultI18n.resetLocaleData();
 				defaultI18n.setLocaleData( translations );
 				void getIpcApi().setDefaultLocaleData( translations );
 			} else {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-602

## Proposed Changes

- Fix mixed translations and use English as a fallback. There was a bug where, when a translation was missing in the selected language, switching from another language would display the previous language's string instead of English.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run `npm start`
- Set your language to Ukranian
- Open the push dialog
- Observe everything is translated to Ukrainian
- Change the language to Spanish or Hebrew
- Observe most is translated to those languages, but some parts like the title and description are in English because those translations doesn't exist yet.


https://github.com/user-attachments/assets/f55ca830-39d2-4696-91d2-7295850e04a4



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
