### PR TITLE
Fix space on selective sync dialog

### DIFF
--- a/src/modules/sync/components/sync-dialog.tsx
+++ b/src/modules/sync/components/sync-dialog.tsx
@@ -161,7 +161,7 @@ export function SyncDialog( {
 					</div>
 				</div>
 				<div className="px-8 pt-7 pb-3">{ copy.subtitleSelector }</div>
-				<div className="px-8 relative">
+				<div className="px-8 pb-2 relative">
 					<div className="absolute end-6 z-10">
 						<SelectControl
 							value={ showAllFiles ? 'true' : 'false' }

--- a/src/modules/sync/components/sync-dialog.tsx
+++ b/src/modules/sync/components/sync-dialog.tsx
@@ -133,7 +133,7 @@ export function SyncDialog( {
 			title={ copy[ siteEnv ].title }
 		>
 			<div className="pb-[70px]">
-				<div className="px-8 pb-6 pt-2">{ copy[ siteEnv ].description }</div>
+				<div className="px-8 pb-6 pt-3">{ copy[ siteEnv ].description }</div>
 				<div className="px-8">
 					<span className="sr-only">
 						{ /* translators: first %s is the source site name, second %s is the destination site name */ }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-604

## Proposed Changes

- Add more space between the database and the bottom bar
- Add more space between the title and the first paragraph

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run `npm start`
- Go to sync
- Click on pull
- Expand the files and scroll down
- Observe the new space

| Before | After |
|--------|--------|
|  ![Screenshot 2025-07-05 at 01 37 26](https://github.com/user-attachments/assets/282e0d31-05f9-4f96-b970-e8dedd9c5014) | ![Screenshot 2025-07-05 at 01 37 12](https://github.com/user-attachments/assets/9e3a21d5-c56e-4155-8009-ea86f74e2c2c) |
| ![Screenshot 2025-07-05 at 01 45 00](https://github.com/user-attachments/assets/67be8e9f-69ac-45c7-8016-e471f1e5115a) | ![Screenshot 2025-07-05 at 01 44 22](https://github.com/user-attachments/assets/b01e9506-34c8-442e-97de-d9f410c03e35) |



## Pre-merge Checklist


<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
