### PR TITLE
Sync: Update pull and push descriptions in sync modal

### DIFF
--- a/src/modules/sync/hooks/use-sync-dialog-texts.tsx
+++ b/src/modules/sync/hooks/use-sync-dialog-texts.tsx
@@ -10,19 +10,19 @@ export const useSyncDialogTexts = ( type: 'pull' | 'push' ) => {
 				staging: {
 					title: __( 'Pull from Staging' ),
 					description: __(
-						"Pulling synchronizes your Studio site with the staging site. You can pull everything or select specific parts. Unchecked items will not be changed."
+						'Pulling synchronizes your Studio site with the staging site. You can pull everything or select specific parts. Unchecked items will not be changed.'
 					),
 				},
 				sandbox: {
 					title: __( 'Pull from Sandbox' ),
 					description: __(
-						"Pulling synchronizes your Studio site with the sandbox site. You can pull everything or select specific parts. Unchecked items will not be changed."
+						'Pulling synchronizes your Studio site with the sandbox site. You can pull everything or select specific parts. Unchecked items will not be changed.'
 					),
 				},
 				production: {
 					title: __( 'Pull from Production' ),
 					description: __(
-						"Pulling synchronizes your Studio site with the production site. You can pull everything or select specific parts. Unchecked items will not be changed."
+						'Pulling synchronizes your Studio site with the production site. You can pull everything or select specific parts. Unchecked items will not be changed.'
 					),
 				},
 				fromLabel: __( 'Pull' ),

--- a/src/modules/sync/hooks/use-sync-dialog-texts.tsx
+++ b/src/modules/sync/hooks/use-sync-dialog-texts.tsx
@@ -10,19 +10,19 @@ export const useSyncDialogTexts = ( type: 'pull' | 'push' ) => {
 				staging: {
 					title: __( 'Pull from Staging' ),
 					description: __(
-						"Pulling will overwrite your Studio site's selected files and/or database with a copy from your staging site. Unchecked items will not be changed."
+						"Pulling will overwrite your Studio site's selected files and database with a copy from your staging site. Unchecked items will not be changed."
 					),
 				},
 				sandbox: {
 					title: __( 'Pull from Sandbox' ),
 					description: __(
-						"Pulling will overwrite your Studio site's selected files and/or database with a copy from your sandbox site. Unchecked items will not be changed."
+						"Pulling will overwrite your Studio site's selected files and database with a copy from your sandbox site. Unchecked items will not be changed."
 					),
 				},
 				production: {
 					title: __( 'Pull from Production' ),
 					description: __(
-						"Pulling will overwrite your Studio site's selected files and/or database with a copy from your production site. Unchecked items will not be changed."
+						"Pulling will overwrite your Studio site's selected files and database with a copy from your production site. Unchecked items will not be changed."
 					),
 				},
 				fromLabel: __( 'Pull' ),
@@ -36,19 +36,19 @@ export const useSyncDialogTexts = ( type: 'pull' | 'push' ) => {
 				staging: {
 					title: __( 'Push to Staging' ),
 					description: __(
-						"Pushing will overwrite your staging site's selected files and/or database with content from your local site. Unchecked items will not be changed. The staging site will be backed up before any changes are applied."
+						"Pushing will overwrite your staging site's selected files and database with content from your local site. Unchecked items will not be changed. The staging site will be backed up before any changes are applied."
 					),
 				},
 				sandbox: {
 					title: __( 'Push to Sandbox' ),
 					description: __(
-						"Pushing will overwrite your sandbox site's selected files and/or database with content from your local site. Unchecked items will not be changed. The sandbox site will be backed up before any changes are applied."
+						"Pushing will overwrite your sandbox site's selected files and database with content from your local site. Unchecked items will not be changed. The sandbox site will be backed up before any changes are applied."
 					),
 				},
 				production: {
 					title: __( 'Push to Production' ),
 					description: __(
-						"Pushing will overwrite your production site's selected files and/or database with content from your local site. Unchecked items will not be changed. The production site will be backed up before any changes are applied."
+						"Pushing will overwrite your production site's selected files and database with content from your local site. Unchecked items will not be changed. The production site will be backed up before any changes are applied."
 					),
 				},
 				fromLabel: __( 'Push' ),

--- a/src/modules/sync/hooks/use-sync-dialog-texts.tsx
+++ b/src/modules/sync/hooks/use-sync-dialog-texts.tsx
@@ -10,19 +10,19 @@ export const useSyncDialogTexts = ( type: 'pull' | 'push' ) => {
 				staging: {
 					title: __( 'Pull from Staging' ),
 					description: __(
-						"Pulling will overwrite your Studio site's files and database with a copy from your staging site."
+						"Pulling will overwrite your Studio site's selected files and database with a copy from your staging site. You can pull everything or select specific parts. Unchecked items will not be changed."
 					),
 				},
 				sandbox: {
 					title: __( 'Pull from Sandbox' ),
 					description: __(
-						"Pulling will overwrite your Studio site's files and database with a copy from your sandbox site."
+						"Pulling will overwrite your Studio site's selected files and database with a copy from your sandbox site. You can pull everything or select specific parts. Unchecked items will not be changed."
 					),
 				},
 				production: {
 					title: __( 'Pull from Production' ),
 					description: __(
-						"Pulling will overwrite your Studio site's files and database with a copy from your production site."
+						"Pulling will overwrite your Studio site's selected files and database with a copy from your production site. You can pull everything or select specific parts. Unchecked items will not be changed."
 					),
 				},
 				fromLabel: __( 'Pull' ),

--- a/src/modules/sync/hooks/use-sync-dialog-texts.tsx
+++ b/src/modules/sync/hooks/use-sync-dialog-texts.tsx
@@ -10,19 +10,19 @@ export const useSyncDialogTexts = ( type: 'pull' | 'push' ) => {
 				staging: {
 					title: __( 'Pull from Staging' ),
 					description: __(
-						"Pulling will overwrite your Studio site's selected files and database with a copy from your staging site. Unchecked items will not be changed."
+						"Pulling will overwrite your Studio site's selected files and/or database with a copy from your staging site. Unchecked items will not be changed."
 					),
 				},
 				sandbox: {
 					title: __( 'Pull from Sandbox' ),
 					description: __(
-						"Pulling will overwrite your Studio site's selected files and database with a copy from your sandbox site. Unchecked items will not be changed."
+						"Pulling will overwrite your Studio site's selected files and/or database with a copy from your sandbox site. Unchecked items will not be changed."
 					),
 				},
 				production: {
 					title: __( 'Pull from Production' ),
 					description: __(
-						"Pulling will overwrite your Studio site's selected files and database with a copy from your production site. Unchecked items will not be changed."
+						"Pulling will overwrite your Studio site's selected files and/or database with a copy from your production site. Unchecked items will not be changed."
 					),
 				},
 				fromLabel: __( 'Pull' ),
@@ -36,19 +36,19 @@ export const useSyncDialogTexts = ( type: 'pull' | 'push' ) => {
 				staging: {
 					title: __( 'Push to Staging' ),
 					description: __(
-						"Pushing will overwrite your staging site's selected files and database with content from your local site. Unchecked items will not be changed. The staging site will be backed up before any changes are applied."
+						"Pushing will overwrite your staging site's selected files and/or database with content from your local site. Unchecked items will not be changed. The staging site will be backed up before any changes are applied."
 					),
 				},
 				sandbox: {
 					title: __( 'Push to Sandbox' ),
 					description: __(
-						"Pushing will overwrite your sandbox site's selected files and database with content from your local site. Unchecked items will not be changed. The sandbox site will be backed up before any changes are applied."
+						"Pushing will overwrite your sandbox site's selected files and/or database with content from your local site. Unchecked items will not be changed. The sandbox site will be backed up before any changes are applied."
 					),
 				},
 				production: {
 					title: __( 'Push to Production' ),
 					description: __(
-						"Pushing will overwrite your production site's selected files and database with content from your local site. Unchecked items will not be changed. The production site will be backed up before any changes are applied."
+						"Pushing will overwrite your production site's selected files and/or database with content from your local site. Unchecked items will not be changed. The production site will be backed up before any changes are applied."
 					),
 				},
 				fromLabel: __( 'Push' ),

--- a/src/modules/sync/hooks/use-sync-dialog-texts.tsx
+++ b/src/modules/sync/hooks/use-sync-dialog-texts.tsx
@@ -36,19 +36,19 @@ export const useSyncDialogTexts = ( type: 'pull' | 'push' ) => {
 				staging: {
 					title: __( 'Push to Staging' ),
 					description: __(
-						'Pushing will replace the existing files and database with a copy from your local site.\n\n The staging site will be backed up before any changes are applied.'
+						'Pushing synchronizes your local site with the staging site. You can push everything or select specific parts. Unchecked items will not be changed. A backup of the staging site is created before applying changes.'
 					),
 				},
 				sandbox: {
 					title: __( 'Push to Sandbox' ),
 					description: __(
-						'Pushing will replace the existing files and database with a copy from your local site.\n\n The sandbox site will be backed up before any changes are applied.'
+						'Pushing synchronizes your local site with the sandbox site. You can push everything or select specific parts. Unchecked items will not be changed. A backup of the sandbox site is created before applying changes.'
 					),
 				},
 				production: {
 					title: __( 'Push to Production' ),
 					description: __(
-						'Pushing will replace the existing files and database with a copy from your local site.\n\n The production site will be backed up before any changes are applied.'
+						'Pushing synchronizes your local site with the production site. You can push everything or select specific parts. Unchecked items will not be changed. A backup of the production site is created before applying changes.'
 					),
 				},
 				fromLabel: __( 'Push' ),

--- a/src/modules/sync/hooks/use-sync-dialog-texts.tsx
+++ b/src/modules/sync/hooks/use-sync-dialog-texts.tsx
@@ -10,19 +10,19 @@ export const useSyncDialogTexts = ( type: 'pull' | 'push' ) => {
 				staging: {
 					title: __( 'Pull from Staging' ),
 					description: __(
-						"Pulling will replace your Studio site's files and database with a copy from your staging site."
+						"Pulling synchronizes your Studio site with the staging site. You can pull everything or select specific parts. Unchecked items will not be changed."
 					),
 				},
 				sandbox: {
 					title: __( 'Pull from Sandbox' ),
 					description: __(
-						"Pulling will replace your Studio site's files and database with a copy from your sandbox site."
+						"Pulling synchronizes your Studio site with the sandbox site. You can pull everything or select specific parts. Unchecked items will not be changed."
 					),
 				},
 				production: {
 					title: __( 'Pull from Production' ),
 					description: __(
-						"Pulling will replace your Studio site's files and database with a copy from your production site."
+						"Pulling synchronizes your Studio site with the production site. You can pull everything or select specific parts. Unchecked items will not be changed."
 					),
 				},
 				fromLabel: __( 'Pull' ),

--- a/src/modules/sync/hooks/use-sync-dialog-texts.tsx
+++ b/src/modules/sync/hooks/use-sync-dialog-texts.tsx
@@ -10,19 +10,19 @@ export const useSyncDialogTexts = ( type: 'pull' | 'push' ) => {
 				staging: {
 					title: __( 'Pull from Staging' ),
 					description: __(
-						"Pulling will overwrite your Studio site's selected files and database with a copy from your staging site. You can pull everything or select specific parts. Unchecked items will not be changed."
+						"Pulling will overwrite your Studio site's selected files and database with a copy from your staging site. Unchecked items will not be changed."
 					),
 				},
 				sandbox: {
 					title: __( 'Pull from Sandbox' ),
 					description: __(
-						"Pulling will overwrite your Studio site's selected files and database with a copy from your sandbox site. You can pull everything or select specific parts. Unchecked items will not be changed."
+						"Pulling will overwrite your Studio site's selected files and database with a copy from your sandbox site. Unchecked items will not be changed."
 					),
 				},
 				production: {
 					title: __( 'Pull from Production' ),
 					description: __(
-						"Pulling will overwrite your Studio site's selected files and database with a copy from your production site. You can pull everything or select specific parts. Unchecked items will not be changed."
+						"Pulling will overwrite your Studio site's selected files and database with a copy from your production site. Unchecked items will not be changed."
 					),
 				},
 				fromLabel: __( 'Pull' ),
@@ -36,19 +36,19 @@ export const useSyncDialogTexts = ( type: 'pull' | 'push' ) => {
 				staging: {
 					title: __( 'Push to Staging' ),
 					description: __(
-						"Pushing will overwrite your staging site's selected files and database with content from your local site. You can push everything or select specific parts. Unchecked items will not be changed. The staging site will be backed up before any changes are applied."
+						"Pushing will overwrite your staging site's selected files and database with content from your local site. Unchecked items will not be changed. The staging site will be backed up before any changes are applied."
 					),
 				},
 				sandbox: {
 					title: __( 'Push to Sandbox' ),
 					description: __(
-						"Pushing will overwrite your sandbox site's selected files and database with content from your local site. You can push everything or select specific parts. Unchecked items will not be changed. The sandbox site will be backed up before any changes are applied."
+						"Pushing will overwrite your sandbox site's selected files and database with content from your local site. Unchecked items will not be changed. The sandbox site will be backed up before any changes are applied."
 					),
 				},
 				production: {
 					title: __( 'Push to Production' ),
 					description: __(
-						"Pushing will overwrite your production site's selected files and database with content from your local site. You can push everything or select specific parts. Unchecked items will not be changed. The production site will be backed up before any changes are applied."
+						"Pushing will overwrite your production site's selected files and database with content from your local site. Unchecked items will not be changed. The production site will be backed up before any changes are applied."
 					),
 				},
 				fromLabel: __( 'Push' ),

--- a/src/modules/sync/hooks/use-sync-dialog-texts.tsx
+++ b/src/modules/sync/hooks/use-sync-dialog-texts.tsx
@@ -10,19 +10,19 @@ export const useSyncDialogTexts = ( type: 'pull' | 'push' ) => {
 				staging: {
 					title: __( 'Pull from Staging' ),
 					description: __(
-						'Pulling synchronizes your Studio site with the staging site. You can pull everything or select specific parts. Unchecked items will not be changed.'
+						"Pulling will overwrite your Studio site's files and database with a copy from your staging site."
 					),
 				},
 				sandbox: {
 					title: __( 'Pull from Sandbox' ),
 					description: __(
-						'Pulling synchronizes your Studio site with the sandbox site. You can pull everything or select specific parts. Unchecked items will not be changed.'
+						"Pulling will overwrite your Studio site's files and database with a copy from your sandbox site."
 					),
 				},
 				production: {
 					title: __( 'Pull from Production' ),
 					description: __(
-						'Pulling synchronizes your Studio site with the production site. You can pull everything or select specific parts. Unchecked items will not be changed.'
+						"Pulling will overwrite your Studio site's files and database with a copy from your production site."
 					),
 				},
 				fromLabel: __( 'Pull' ),
@@ -36,19 +36,19 @@ export const useSyncDialogTexts = ( type: 'pull' | 'push' ) => {
 				staging: {
 					title: __( 'Push to Staging' ),
 					description: __(
-						'Pushing synchronizes your local site with the staging site. You can push everything or select specific parts. Unchecked items will not be changed. A backup of the staging site is created before applying changes.'
+						"Pushing will overwrite your staging site's selected files and database with content from your local site. You can push everything or select specific parts. Unchecked items will not be changed. The staging site will be backed up before any changes are applied."
 					),
 				},
 				sandbox: {
 					title: __( 'Push to Sandbox' ),
 					description: __(
-						'Pushing synchronizes your local site with the sandbox site. You can push everything or select specific parts. Unchecked items will not be changed. A backup of the sandbox site is created before applying changes.'
+						"Pushing will overwrite your sandbox site's selected files and database with content from your local site. You can push everything or select specific parts. Unchecked items will not be changed. The sandbox site will be backed up before any changes are applied."
 					),
 				},
 				production: {
 					title: __( 'Push to Production' ),
 					description: __(
-						'Pushing synchronizes your local site with the production site. You can push everything or select specific parts. Unchecked items will not be changed. A backup of the production site is created before applying changes.'
+						"Pushing will overwrite your production site's selected files and database with content from your local site. You can push everything or select specific parts. Unchecked items will not be changed. The production site will be backed up before any changes are applied."
 					),
 				},
 				fromLabel: __( 'Push' ),


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-597

## Proposed Changes

- Update pull and push descriptions in sync modal

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Check out this PR
- Run Studio `npm start`
- Log in to your WordPress.com
- Go to the Sync tab
- Connect a site if not connected
- Click on Push and Pull actions
- Check the copy in the Modal

| Push | Pull |
|--------|--------|
|  ![CleanShot 2025-07-08 at 15 18 50@2x](https://github.com/user-attachments/assets/167f13c8-8e89-4b30-b136-987007e45ca1) | ![CleanShot 2025-07-08 at 15 18 44@2x](https://github.com/user-attachments/assets/d4f7dd17-5439-4117-81e0-7dca99558999) | 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
