### PR TITLE
Disable main button when all options are unchecked

### DIFF
--- a/src/modules/sync/components/sync-dialog.tsx
+++ b/src/modules/sync/components/sync-dialog.tsx
@@ -80,7 +80,7 @@ export function SyncDialog( {
 
 	const [ showAllFiles, setShowAllFiles ] = useState( false );
 	const [ treeState, setTreeState ] = useState< TreeNode[] >( defaultTree );
-	const isSubmitDisabled = treeState.every((node) => !node.checked);
+	const isSubmitDisabled = treeState.every( ( node ) => !node.checked && !node.indeterminate);
 
 	useDynamicTreeState( type, localSite.id, setTreeState );
 

--- a/src/modules/sync/components/sync-dialog.tsx
+++ b/src/modules/sync/components/sync-dialog.tsx
@@ -80,6 +80,7 @@ export function SyncDialog( {
 
 	const [ showAllFiles, setShowAllFiles ] = useState( false );
 	const [ treeState, setTreeState ] = useState< TreeNode[] >( defaultTree );
+	const isSubmitDisabled = treeState.every((node) => !node.checked);
 
 	useDynamicTreeState( type, localSite.id, setTreeState );
 
@@ -204,7 +205,7 @@ export function SyncDialog( {
 							<Button variant="link" onClick={ onRequestClose }>
 								{ __( 'Cancel' ) }
 							</Button>
-							<Button variant="primary" onClick={ handleSubmit }>
+							<Button variant="primary" onClick={ handleSubmit } disabled={ isSubmitDisabled }>
 								{ copy.submit }
 							</Button>
 						</div>

--- a/src/modules/sync/components/sync-dialog.tsx
+++ b/src/modules/sync/components/sync-dialog.tsx
@@ -80,7 +80,7 @@ export function SyncDialog( {
 
 	const [ showAllFiles, setShowAllFiles ] = useState( false );
 	const [ treeState, setTreeState ] = useState< TreeNode[] >( defaultTree );
-	const isSubmitDisabled = treeState.every( ( node ) => !node.checked && !node.indeterminate);
+	const isSubmitDisabled = treeState.every( ( node ) => ! node.checked && ! node.indeterminate );
 
 	useDynamicTreeState( type, localSite.id, setTreeState );
 

--- a/src/modules/sync/tests/index.test.tsx
+++ b/src/modules/sync/tests/index.test.tsx
@@ -549,6 +549,34 @@ describe('ContentTabSync', () => {
 		await screen.findByText( 'Pull from Production' );
 		const dialogPullButton = screen.getAllByRole( 'button', { name: /Pull/i } )[1];
 		expect( dialogPullButton ).not.toBeDisabled();
+	});
+
+	it( 'enables the pull button when at least one checkbox children is checked', async () => {
+		const mockPullSite = jest.fn();
+		( useAuth as jest.Mock ).mockReturnValue( { isAuthenticated: true, authenticate: jest.fn() } );
+		(useSyncSites as jest.Mock).mockReturnValue({
+			...mockSyncSites,
+			connectedSites: [ fakeSyncSite ],
+		} );
+
+		renderWithProvider( <ContentTabSync selectedSite={ selectedSite } /> );
+
+		const pullButton = screen.getByRole( 'button', { name: /Pull/i } );
+		fireEvent.click(pullButton);
+
+		// leave checked only one children option
+		const filesAndFoldersCheckbox = screen.getByRole( 'checkbox', { name: 'Files and folders' } );
+		fireEvent.click( filesAndFoldersCheckbox );
+		const databaseCheckbox = screen.getByRole( 'checkbox', { name: 'Database' } );
+		fireEvent.click(databaseCheckbox);
+		const select = screen.getByRole( 'combobox', { name: 'Select files and folders to sync' } );
+		fireEvent.change( select, { target: { value: true } } );
+		const pluginsCheckbox = screen.getByRole( 'checkbox', { name: 'plugins' } );
+		fireEvent.click( pluginsCheckbox );
+
+		await screen.findByText( 'Pull from Production' );
+		const dialogPullButton = screen.getAllByRole( 'button', { name: /Pull/i } )[1];
+		expect( dialogPullButton ).not.toBeDisabled();
 	} );
 	it( 'disables the push button when all checkboxes are unchecked', async () => {
 		( useAuth as jest.Mock ).mockReturnValue( { isAuthenticated: true, authenticate: jest.fn() } );
@@ -593,5 +621,33 @@ describe('ContentTabSync', () => {
 		await screen.findByText( 'Push to Production' );
 		const dialogPushButton = screen.getAllByRole( 'button', { name: /Push/i } )[1];
 		expect( dialogPushButton ).not.toBeDisabled();
-	} );
+	});
+
+	it( 'enables the push button when at least one checkbox children is checked', async () => {
+		( useAuth as jest.Mock ).mockReturnValue( { isAuthenticated: true, authenticate: jest.fn() } );
+		(useSyncSites as jest.Mock).mockReturnValue({
+			...mockSyncSites,
+			connectedSites: [ fakeSyncSite ],
+		} );
+
+		renderWithProvider( <ContentTabSync selectedSite={ selectedSite } /> );
+
+		const pushButton = screen.getByRole( 'button', { name: /Push/i } );
+		fireEvent.click(pushButton);
+
+		// leave checked only one children option
+		const filesAndFoldersCheckbox = screen.getByRole( 'checkbox', { name: 'Files and folders' } );
+		fireEvent.click( filesAndFoldersCheckbox );
+		const databaseCheckbox = screen.getByRole( 'checkbox', { name: 'Database' } );
+		fireEvent.click(databaseCheckbox);
+		const select = screen.getByRole( 'combobox', { name: 'Select files and folders to sync' } );
+		fireEvent.change( select, { target: { value: true } } );
+		const pluginsCheckbox = screen.getByRole( 'checkbox', { name: 'plugins' } );
+		fireEvent.click( pluginsCheckbox );
+
+		await screen.findByText( 'Push to Production' );
+		const dialogPushButton = screen.getAllByRole( 'button', { name: /Push/i } )[1];
+		expect( dialogPushButton ).not.toBeDisabled();
+	});
+
 } );

--- a/src/modules/sync/tests/index.test.tsx
+++ b/src/modules/sync/tests/index.test.tsx
@@ -572,7 +572,11 @@ describe('ContentTabSync', () => {
 		const select = screen.getByRole( 'combobox', { name: 'Select files and folders to sync' } );
 		fireEvent.change( select, { target: { value: true } } );
 		const pluginsCheckbox = screen.getByRole( 'checkbox', { name: 'plugins' } );
-		fireEvent.click( pluginsCheckbox );
+		fireEvent.click(pluginsCheckbox);
+
+		expect( pluginsCheckbox ).toBeChecked();
+		expect( databaseCheckbox ).not.toBeChecked();
+		expect( filesAndFoldersCheckbox ).not.toBeChecked();
 
 		await screen.findByText( 'Pull from Production' );
 		const dialogPullButton = screen.getAllByRole( 'button', { name: /Pull/i } )[1];
@@ -643,7 +647,11 @@ describe('ContentTabSync', () => {
 		const select = screen.getByRole( 'combobox', { name: 'Select files and folders to sync' } );
 		fireEvent.change( select, { target: { value: true } } );
 		const pluginsCheckbox = screen.getByRole( 'checkbox', { name: 'plugins' } );
-		fireEvent.click( pluginsCheckbox );
+		fireEvent.click(pluginsCheckbox);
+
+		expect( pluginsCheckbox ).toBeChecked();
+		expect( databaseCheckbox ).not.toBeChecked();
+		expect( filesAndFoldersCheckbox ).not.toBeChecked();
 
 		await screen.findByText( 'Push to Production' );
 		const dialogPushButton = screen.getAllByRole( 'button', { name: /Push/i } )[1];

--- a/src/modules/sync/tests/index.test.tsx
+++ b/src/modules/sync/tests/index.test.tsx
@@ -45,7 +45,7 @@ const fakeSyncSite = {
 	syncSupport: 'already-connected',
 };
 
-describe('ContentTabSync', () => {
+describe( 'ContentTabSync', () => {
 	const mockSyncSites = {
 		connectedSites: [],
 		syncSites: [],
@@ -63,7 +63,7 @@ describe('ContentTabSync', () => {
 		isSyncSitesSelectorOpen: false,
 		setIsSyncSitesSelectorOpen: jest.fn(),
 		closeSyncSitesSelector: jest.fn(),
-	}
+	};
 	beforeEach( () => {
 		jest.resetAllMocks();
 		( useAuth as jest.Mock ).mockReturnValue( { isAuthenticated: false, authenticate: jest.fn() } );
@@ -507,7 +507,7 @@ describe('ContentTabSync', () => {
 
 	it( 'disables the pull button when all checkboxes are unchecked', async () => {
 		( useAuth as jest.Mock ).mockReturnValue( { isAuthenticated: true, authenticate: jest.fn() } );
-		(useSyncSites as jest.Mock).mockReturnValue({
+		( useSyncSites as jest.Mock ).mockReturnValue( {
 			...mockSyncSites,
 			connectedSites: [ fakeSyncSite ],
 		} );
@@ -525,14 +525,14 @@ describe('ContentTabSync', () => {
 		const databaseCheckbox = screen.getByRole( 'checkbox', { name: 'Database' } );
 		fireEvent.click( databaseCheckbox );
 
-		const dialogPullButton = screen.getAllByRole( 'button', { name: /Pull/i } )[1];
+		const dialogPullButton = screen.getAllByRole( 'button', { name: /Pull/i } )[ 1 ];
 		expect( dialogPullButton ).toBeDisabled();
 	} );
 
 	it( 'enables the pull button when at least one checkbox is checked', async () => {
 		const mockPullSite = jest.fn();
 		( useAuth as jest.Mock ).mockReturnValue( { isAuthenticated: true, authenticate: jest.fn() } );
-		(useSyncSites as jest.Mock).mockReturnValue({
+		( useSyncSites as jest.Mock ).mockReturnValue( {
 			...mockSyncSites,
 			connectedSites: [ fakeSyncSite ],
 		} );
@@ -540,21 +540,21 @@ describe('ContentTabSync', () => {
 		renderWithProvider( <ContentTabSync selectedSite={ selectedSite } /> );
 
 		const pullButton = screen.getByRole( 'button', { name: /Pull/i } );
-		fireEvent.click(pullButton);
+		fireEvent.click( pullButton );
 
 		// Uncheck one option, the databases
 		const filesAndFoldersCheckbox = screen.getByRole( 'checkbox', { name: 'Files and folders' } );
 		fireEvent.click( filesAndFoldersCheckbox );
 
 		await screen.findByText( 'Pull from Production' );
-		const dialogPullButton = screen.getAllByRole( 'button', { name: /Pull/i } )[1];
+		const dialogPullButton = screen.getAllByRole( 'button', { name: /Pull/i } )[ 1 ];
 		expect( dialogPullButton ).not.toBeDisabled();
-	});
+	} );
 
 	it( 'enables the pull button when at least one checkbox children is checked', async () => {
 		const mockPullSite = jest.fn();
 		( useAuth as jest.Mock ).mockReturnValue( { isAuthenticated: true, authenticate: jest.fn() } );
-		(useSyncSites as jest.Mock).mockReturnValue({
+		( useSyncSites as jest.Mock ).mockReturnValue( {
 			...mockSyncSites,
 			connectedSites: [ fakeSyncSite ],
 		} );
@@ -562,29 +562,29 @@ describe('ContentTabSync', () => {
 		renderWithProvider( <ContentTabSync selectedSite={ selectedSite } /> );
 
 		const pullButton = screen.getByRole( 'button', { name: /Pull/i } );
-		fireEvent.click(pullButton);
+		fireEvent.click( pullButton );
 
 		// leave checked only one children option
 		const filesAndFoldersCheckbox = screen.getByRole( 'checkbox', { name: 'Files and folders' } );
 		fireEvent.click( filesAndFoldersCheckbox );
 		const databaseCheckbox = screen.getByRole( 'checkbox', { name: 'Database' } );
-		fireEvent.click(databaseCheckbox);
+		fireEvent.click( databaseCheckbox );
 		const select = screen.getByRole( 'combobox', { name: 'Select files and folders to sync' } );
 		fireEvent.change( select, { target: { value: true } } );
 		const pluginsCheckbox = screen.getByRole( 'checkbox', { name: 'plugins' } );
-		fireEvent.click(pluginsCheckbox);
+		fireEvent.click( pluginsCheckbox );
 
 		expect( pluginsCheckbox ).toBeChecked();
 		expect( databaseCheckbox ).not.toBeChecked();
 		expect( filesAndFoldersCheckbox ).not.toBeChecked();
 
 		await screen.findByText( 'Pull from Production' );
-		const dialogPullButton = screen.getAllByRole( 'button', { name: /Pull/i } )[1];
+		const dialogPullButton = screen.getAllByRole( 'button', { name: /Pull/i } )[ 1 ];
 		expect( dialogPullButton ).not.toBeDisabled();
 	} );
 	it( 'disables the push button when all checkboxes are unchecked', async () => {
 		( useAuth as jest.Mock ).mockReturnValue( { isAuthenticated: true, authenticate: jest.fn() } );
-		(useSyncSites as jest.Mock).mockReturnValue({
+		( useSyncSites as jest.Mock ).mockReturnValue( {
 			...mockSyncSites,
 			connectedSites: [ fakeSyncSite ],
 		} );
@@ -602,13 +602,13 @@ describe('ContentTabSync', () => {
 		const databaseCheckbox = screen.getByRole( 'checkbox', { name: 'Database' } );
 		fireEvent.click( databaseCheckbox );
 
-		const dialogPushButton = screen.getAllByRole( 'button', { name: /Push/i } )[1];
+		const dialogPushButton = screen.getAllByRole( 'button', { name: /Push/i } )[ 1 ];
 		expect( dialogPushButton ).toBeDisabled();
 	} );
 
 	it( 'enables the push button when at least one checkbox is checked', async () => {
 		( useAuth as jest.Mock ).mockReturnValue( { isAuthenticated: true, authenticate: jest.fn() } );
-		(useSyncSites as jest.Mock).mockReturnValue({
+		( useSyncSites as jest.Mock ).mockReturnValue( {
 			...mockSyncSites,
 			connectedSites: [ fakeSyncSite ],
 		} );
@@ -616,20 +616,20 @@ describe('ContentTabSync', () => {
 		renderWithProvider( <ContentTabSync selectedSite={ selectedSite } /> );
 
 		const pushButton = screen.getByRole( 'button', { name: /Push/i } );
-		fireEvent.click(pushButton);
+		fireEvent.click( pushButton );
 
 		// Uncheck one option, the databases
 		const filesAndFoldersCheckbox = screen.getByRole( 'checkbox', { name: 'Files and folders' } );
 		fireEvent.click( filesAndFoldersCheckbox );
 
 		await screen.findByText( 'Push to Production' );
-		const dialogPushButton = screen.getAllByRole( 'button', { name: /Push/i } )[1];
+		const dialogPushButton = screen.getAllByRole( 'button', { name: /Push/i } )[ 1 ];
 		expect( dialogPushButton ).not.toBeDisabled();
-	});
+	} );
 
 	it( 'enables the push button when at least one checkbox children is checked', async () => {
 		( useAuth as jest.Mock ).mockReturnValue( { isAuthenticated: true, authenticate: jest.fn() } );
-		(useSyncSites as jest.Mock).mockReturnValue({
+		( useSyncSites as jest.Mock ).mockReturnValue( {
 			...mockSyncSites,
 			connectedSites: [ fakeSyncSite ],
 		} );
@@ -637,25 +637,24 @@ describe('ContentTabSync', () => {
 		renderWithProvider( <ContentTabSync selectedSite={ selectedSite } /> );
 
 		const pushButton = screen.getByRole( 'button', { name: /Push/i } );
-		fireEvent.click(pushButton);
+		fireEvent.click( pushButton );
 
 		// leave checked only one children option
 		const filesAndFoldersCheckbox = screen.getByRole( 'checkbox', { name: 'Files and folders' } );
 		fireEvent.click( filesAndFoldersCheckbox );
 		const databaseCheckbox = screen.getByRole( 'checkbox', { name: 'Database' } );
-		fireEvent.click(databaseCheckbox);
+		fireEvent.click( databaseCheckbox );
 		const select = screen.getByRole( 'combobox', { name: 'Select files and folders to sync' } );
 		fireEvent.change( select, { target: { value: true } } );
 		const pluginsCheckbox = screen.getByRole( 'checkbox', { name: 'plugins' } );
-		fireEvent.click(pluginsCheckbox);
+		fireEvent.click( pluginsCheckbox );
 
 		expect( pluginsCheckbox ).toBeChecked();
 		expect( databaseCheckbox ).not.toBeChecked();
 		expect( filesAndFoldersCheckbox ).not.toBeChecked();
 
 		await screen.findByText( 'Push to Production' );
-		const dialogPushButton = screen.getAllByRole( 'button', { name: /Push/i } )[1];
+		const dialogPushButton = screen.getAllByRole( 'button', { name: /Push/i } )[ 1 ];
 		expect( dialogPushButton ).not.toBeDisabled();
-	});
-
+	} );
 } );

--- a/src/modules/sync/tests/index.test.tsx
+++ b/src/modules/sync/tests/index.test.tsx
@@ -38,7 +38,32 @@ const inProgressPushState: SyncPushState = {
 	remoteSiteUrl: 'https://example.com',
 };
 
-describe( 'ContentTabSync', () => {
+const fakeSyncSite = {
+	id: 6,
+	name: 'My simple business site that needs a transfer',
+	url: 'https:/developer.wordpress.com/studio/',
+	syncSupport: 'already-connected',
+};
+
+describe('ContentTabSync', () => {
+	const mockSyncSites = {
+		connectedSites: [],
+		syncSites: [],
+		pullSite: jest.fn(),
+		isAnySitePulling: false,
+		isAnySitePushing: false,
+		getPullState: jest.fn(),
+		getPushState: jest.fn().mockReturnValue( inProgressPushState ),
+		refetchSites: jest.fn(),
+		updateTimestamp: jest.fn(),
+		getLastSyncTimeWithType: jest.fn().mockReturnValue( 'You have not pulled this site yet.' ),
+		isSiteIdPulling: jest.fn(),
+		isSiteIdPushing: jest.fn(),
+		clearTimeout: jest.fn(),
+		isSyncSitesSelectorOpen: false,
+		setIsSyncSitesSelectorOpen: jest.fn(),
+		closeSyncSitesSelector: jest.fn(),
+	}
 	beforeEach( () => {
 		jest.resetAllMocks();
 		( useAuth as jest.Mock ).mockReturnValue( { isAuthenticated: false, authenticate: jest.fn() } );
@@ -49,24 +74,7 @@ describe( 'ContentTabSync', () => {
 			showMessageBox: jest.fn(),
 			updateConnectedWpcomSites: jest.fn(),
 		} );
-		( useSyncSites as jest.Mock ).mockReturnValue( {
-			connectedSites: [],
-			syncSites: [],
-			pullSite: jest.fn(),
-			isAnySitePulling: false,
-			isAnySitePushing: false,
-			getPullState: jest.fn(),
-			getPushState: jest.fn().mockReturnValue( inProgressPushState ),
-			refetchSites: jest.fn(),
-			updateTimestamp: jest.fn(),
-			getLastSyncTimeWithType: jest.fn().mockReturnValue( 'You have not pulled this site yet.' ),
-			isSiteIdPulling: jest.fn(),
-			isSiteIdPushing: jest.fn(),
-			clearTimeout: jest.fn(),
-			isSyncSitesSelectorOpen: false,
-			setIsSyncSitesSelectorOpen: jest.fn(),
-			closeSyncSitesSelector: jest.fn(),
-		} );
+		( useSyncSites as jest.Mock ).mockReturnValue( mockSyncSites );
 
 		Object.defineProperty( window, 'matchMedia', {
 			writable: true,
@@ -495,5 +503,95 @@ describe( 'ContentTabSync', () => {
 		expect( mockPullSite ).toHaveBeenCalledWith( fakeSyncSite, selectedSite, {
 			optionsToSync: [ 'sqls', 'plugins', 'themes', 'uploads' ],
 		} );
+	} );
+
+	it( 'disables the pull button when all checkboxes are unchecked', async () => {
+		( useAuth as jest.Mock ).mockReturnValue( { isAuthenticated: true, authenticate: jest.fn() } );
+		(useSyncSites as jest.Mock).mockReturnValue({
+			...mockSyncSites,
+			connectedSites: [ fakeSyncSite ],
+		} );
+
+		renderWithProvider( <ContentTabSync selectedSite={ selectedSite } /> );
+
+		const pullButton = screen.getByRole( 'button', { name: /Pull/i } );
+		fireEvent.click( pullButton );
+
+		await screen.findByText( 'Pull from Production' );
+
+		// Uncheck all checkboxes
+		const filesAndFoldersCheckbox = screen.getByRole( 'checkbox', { name: 'Files and folders' } );
+		fireEvent.click( filesAndFoldersCheckbox );
+		const databaseCheckbox = screen.getByRole( 'checkbox', { name: 'Database' } );
+		fireEvent.click( databaseCheckbox );
+
+		const dialogPullButton = screen.getAllByRole( 'button', { name: /Pull/i } )[1];
+		expect( dialogPullButton ).toBeDisabled();
+	} );
+
+	it( 'enables the pull button when at least one checkbox is checked', async () => {
+		const mockPullSite = jest.fn();
+		( useAuth as jest.Mock ).mockReturnValue( { isAuthenticated: true, authenticate: jest.fn() } );
+		(useSyncSites as jest.Mock).mockReturnValue({
+			...mockSyncSites,
+			connectedSites: [ fakeSyncSite ],
+		} );
+
+		renderWithProvider( <ContentTabSync selectedSite={ selectedSite } /> );
+
+		const pullButton = screen.getByRole( 'button', { name: /Pull/i } );
+		fireEvent.click(pullButton);
+
+		// Uncheck one option, the databases
+		const filesAndFoldersCheckbox = screen.getByRole( 'checkbox', { name: 'Files and folders' } );
+		fireEvent.click( filesAndFoldersCheckbox );
+
+		await screen.findByText( 'Pull from Production' );
+		const dialogPullButton = screen.getAllByRole( 'button', { name: /Pull/i } )[1];
+		expect( dialogPullButton ).not.toBeDisabled();
+	} );
+	it( 'disables the push button when all checkboxes are unchecked', async () => {
+		( useAuth as jest.Mock ).mockReturnValue( { isAuthenticated: true, authenticate: jest.fn() } );
+		(useSyncSites as jest.Mock).mockReturnValue({
+			...mockSyncSites,
+			connectedSites: [ fakeSyncSite ],
+		} );
+
+		renderWithProvider( <ContentTabSync selectedSite={ selectedSite } /> );
+
+		const pushButton = screen.getByRole( 'button', { name: /Push/i } );
+		fireEvent.click( pushButton );
+
+		await screen.findByText( 'Push to Production' );
+
+		// Uncheck all checkboxes
+		const filesAndFoldersCheckbox = screen.getByRole( 'checkbox', { name: 'Files and folders' } );
+		fireEvent.click( filesAndFoldersCheckbox );
+		const databaseCheckbox = screen.getByRole( 'checkbox', { name: 'Database' } );
+		fireEvent.click( databaseCheckbox );
+
+		const dialogPushButton = screen.getAllByRole( 'button', { name: /Push/i } )[1];
+		expect( dialogPushButton ).toBeDisabled();
+	} );
+
+	it( 'enables the push button when at least one checkbox is checked', async () => {
+		( useAuth as jest.Mock ).mockReturnValue( { isAuthenticated: true, authenticate: jest.fn() } );
+		(useSyncSites as jest.Mock).mockReturnValue({
+			...mockSyncSites,
+			connectedSites: [ fakeSyncSite ],
+		} );
+
+		renderWithProvider( <ContentTabSync selectedSite={ selectedSite } /> );
+
+		const pushButton = screen.getByRole( 'button', { name: /Push/i } );
+		fireEvent.click(pushButton);
+
+		// Uncheck one option, the databases
+		const filesAndFoldersCheckbox = screen.getByRole( 'checkbox', { name: 'Files and folders' } );
+		fireEvent.click( filesAndFoldersCheckbox );
+
+		await screen.findByText( 'Push to Production' );
+		const dialogPushButton = screen.getAllByRole( 'button', { name: /Push/i } )[1];
+		expect( dialogPushButton ).not.toBeDisabled();
 	} );
 } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-605

## Proposed Changes

- Let's disable the main button when all the options are unchecked

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Execute `npm run start`
- Access the Sync tab
- Click pull or push
- Uncheck files and database
- Observe the button is disabled
- Open the dropdown to check one children like `plugins`
- Observe the main button is enabled


https://github.com/user-attachments/assets/15a5ddcc-5601-4190-a132-073c235b2b79


https://github.com/user-attachments/assets/3d77b9fa-7874-46dd-95dc-c935f3861ede



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
