### PR TITLE
add delete token request to logout

### DIFF
--- a/src/components/auth-provider.tsx
+++ b/src/components/auth-provider.tsx
@@ -66,6 +66,36 @@ const AuthProvider: React.FC< AuthProviderProps > = ( { children } ) => {
 
 	const logout = useCallback( async () => {
 		try {
+			// Get the token before clearing authentication
+			const token = await getIpcApi().getAuthenticationToken();
+
+			if ( token?.accessToken ) {
+				try {
+					// Call the token revocation endpoint directly using fetch
+					// client.req.del is not working, so we need to use fetch
+					const response = await fetch(
+						'https://public-api.wordpress.com/wpcom/v2/studio-app/token',
+						{
+							method: 'DELETE',
+							headers: {
+								Authorization: `Bearer ${ token.accessToken }`,
+								'Content-Type': 'application/json',
+							},
+							signal: AbortSignal.timeout( 5000 ),
+						}
+					);
+
+					if ( ! response.ok ) {
+						console.error( 'Failed to revoke token:', response.status, response.statusText );
+					}
+				} catch ( revokeError ) {
+					// Log the error but continue with local logout
+					console.error( 'Failed to revoke token:', revokeError );
+					Sentry.captureException( revokeError );
+				}
+			}
+
+			// Clear local authentication state
 			await getIpcApi().clearAuthenticationToken();
 			setIsAuthenticated( false );
 			setClient( undefined );

--- a/src/components/auth-provider.tsx
+++ b/src/components/auth-provider.tsx
@@ -66,36 +66,22 @@ const AuthProvider: React.FC< AuthProviderProps > = ( { children } ) => {
 
 	const logout = useCallback( async () => {
 		try {
-			// Get the token before clearing authentication
-			const token = await getIpcApi().getAuthenticationToken();
-
-			if ( token?.accessToken ) {
-				try {
-					// Call the token revocation endpoint directly using fetch
-					// client.req.del is not working, so we need to use fetch
-					const response = await fetch(
-						'https://public-api.wordpress.com/wpcom/v2/studio-app/token',
-						{
-							method: 'DELETE',
-							headers: {
-								Authorization: `Bearer ${ token.accessToken }`,
-								'Content-Type': 'application/json',
-							},
-							signal: AbortSignal.timeout( 5000 ),
-						}
-					);
-
-					if ( ! response.ok ) {
-						console.error( 'Failed to revoke token:', response.status, response.statusText );
+			client?.request(
+				{
+					apiNamespace: 'wpcom/v2',
+					method: 'DELETE',
+					path: '/studio-app/token',
+				},
+				( err: unknown, response: unknown ) => {
+					if ( err ) {
+						console.error( 'Failed to revoke token:', err );
+						Sentry.captureException( err );
+					} else {
+						console.log( 'Token revoked:', response );
 					}
-				} catch ( revokeError ) {
-					// Log the error but continue with local logout
-					console.error( 'Failed to revoke token:', revokeError );
-					Sentry.captureException( revokeError );
 				}
-			}
+			);
 
-			// Clear local authentication state
 			await getIpcApi().clearAuthenticationToken();
 			setIsAuthenticated( false );
 			setClient( undefined );
@@ -105,7 +91,7 @@ const AuthProvider: React.FC< AuthProviderProps > = ( { children } ) => {
 			console.error( err );
 			Sentry.captureException( err );
 		}
-	}, [] );
+	}, [ client ] );
 
 	useEffect( () => {
 		async function run() {

--- a/src/modules/user-settings/components/account-tab.tsx
+++ b/src/modules/user-settings/components/account-tab.tsx
@@ -3,6 +3,7 @@ import Button from 'src/components/button';
 import { Gravatar } from 'src/components/gravatar';
 import { Tooltip } from 'src/components/tooltip';
 import { WPCOM_PROFILE_URL } from 'src/constants';
+import { useOffline } from 'src/hooks/use-offline';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 
 export const UserInfo = ( {
@@ -13,6 +14,7 @@ export const UserInfo = ( {
 	onLogout: () => void;
 } ) => {
 	const { __ } = useI18n();
+	const isOffline = useOffline();
 	return (
 		<div className="flex w-full gap-5">
 			<div className="flex w-full items-center gap-3">
@@ -30,7 +32,7 @@ export const UserInfo = ( {
 					<span className="text-a8c-gray-700 text-[10px] leading-[10px]">{ user?.email }</span>
 				</div>
 			</div>
-			<Button variant="secondary" className="!gap-3" onClick={ onLogout }>
+			<Button variant="secondary" className="!gap-3" onClick={ onLogout } disabled={ isOffline }>
 				{ __( 'Log out' ) }
 			</Button>
 		</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-488

## Proposed Changes

- Add revoke token call during logout

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- check 187112-ghe-Automattic/wpcom
- Run Studio and log in to WordPress.com
- Cut your internet connection
- Confirm logout button is disabled
- Restore your internet connection
- Confirm logout button is enabled
- Logout and confirm the request was made to revoke the token
- Using the token from Studio, try to make a request to WordPress.com API (you can just copy/paste the auth info from appdata from before you logged out)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?