### PR TITLE
Fix issue with unchecking empty folder

### DIFF
--- a/src/components/tree-view.tsx
+++ b/src/components/tree-view.tsx
@@ -143,7 +143,7 @@ const TreeItem = ( {
 					className={ cx( 'ps-6', isLevel0 ? 'border-b border-gray-300 py-2' : '' ) }
 				>
 					{ node.children.length === 0 ? (
-						<div className="py-2 ps-6 text-gray-500 italic" aria-label={ __( 'Empty folder' ) }>
+						<div className="text-gray-500 italic" aria-label={ __( 'Empty folder' ) }>
 							{ __( 'Empty' ) }
 						</div>
 					) : (

--- a/src/components/tree-view.tsx
+++ b/src/components/tree-view.tsx
@@ -63,7 +63,7 @@ export const updateNodeById = (
 
 			return {
 				...node,
-				checked: checkedCount === totalChildren,
+				checked: checkedCount > 0 && checkedCount === totalChildren,
 				indeterminate: ( checkedCount > 0 && checkedCount < totalChildren ) || anyIndeterminate,
 				children: updatedChildren,
 			};

--- a/src/components/tree-view.tsx
+++ b/src/components/tree-view.tsx
@@ -55,7 +55,7 @@ export const updateNodeById = (
 		if ( node.id === id ) {
 			return updateNode( node, partialNode );
 		}
-		if ( node.children ) {
+		if ( node.children && node.children.length > 0 ) {
 			const updatedChildren = updateNodeById( node.children, id, partialNode );
 			const checkedCount = updatedChildren.filter( ( c ) => c.checked ).length;
 			const totalChildren = updatedChildren.length;

--- a/src/components/tree-view.tsx
+++ b/src/components/tree-view.tsx
@@ -142,16 +142,22 @@ const TreeItem = ( {
 					role="group"
 					className={ cx( 'ps-6', isLevel0 ? 'border-b border-gray-300 py-2' : '' ) }
 				>
-					{ node.children.map( ( child, idx ) => (
-						<TreeItem
-							key={ child.id }
-							node={ child }
-							onPatchNode={ onPatchNode }
-							level={ level + 1 }
-							index={ idx }
-							siblingsLength={ node.children?.length }
-						/>
-					) ) }
+					{ node.children.length === 0 ? (
+						<div className="py-2 ps-6 text-gray-500 italic" aria-label={ __( 'Empty folder' ) }>
+							{ __( 'Empty' ) }
+						</div>
+					) : (
+						node.children.map( ( child, idx ) => (
+							<TreeItem
+								key={ child.id }
+								node={ child }
+								onPatchNode={ onPatchNode }
+								level={ level + 1 }
+								index={ idx }
+								siblingsLength={ node.children?.length }
+							/>
+						) )
+					) }
 				</div>
 			) }
 		</div>

--- a/src/components/tree-view.tsx
+++ b/src/components/tree-view.tsx
@@ -28,7 +28,7 @@ const TREE_NODE_ICONS: Record< TreeNodeType, React.JSX.Element > = {
 const updateNode = ( node: TreeNode, partialNode: Partial< TreeNode > ): TreeNode => {
 	const updatedNode = { ...node, ...partialNode };
 
-	if ( updatedNode.children ) {
+	if ( updatedNode.children && updatedNode.children.length > 0 ) {
 		updatedNode.children = updatedNode.children.map( ( child ) => {
 			if ( 'checked' in partialNode ) {
 				return updateNode( child, { checked: partialNode.checked } );
@@ -63,7 +63,7 @@ export const updateNodeById = (
 
 			return {
 				...node,
-				checked: checkedCount > 0 && checkedCount === totalChildren,
+				checked: checkedCount === totalChildren,
 				indeterminate: ( checkedCount > 0 && checkedCount < totalChildren ) || anyIndeterminate,
 				children: updatedChildren,
 			};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-607

## Proposed Changes

- Fix an issue where it wasn't possible to uncheck an empty folder

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Open Studio, log-in to WordPress.com and connect an existing or new site to a WordPress.com site
- Empty one of site folders like `wp-content/uploads`
- Select option to "Push" changes
- Select "Specific files and folders"
- Confirm you can check/uncheck the empty folder

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
