### PR TITLE
Studio Sync: add more granular selection to wp-content folders

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -56,7 +56,7 @@ export const SYNC_OPTIONS = {
 } as const;
 
 export const CONTENTS_SYNC_OPTIONS = {
-	muPlugins: 'mu-plugins',
+	'mu-plugins': 'mu-plugins',
 	fonts: 'fonts',
 } as const;
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -55,6 +55,11 @@ export const SYNC_OPTIONS = {
 	contents: 'contents',
 } as const;
 
+export const CONTENTS_SYNC_OPTIONS = {
+	muPlugins: 'mu-plugins',
+	fonts: 'fonts',
+} as const;
+
 // AI Assistant constants
 // IMPORTANT: When updating this value, we need to update the string located in `AIClearHistoryReminder` component.
 // Reference: https://github.com/Automattic/studio/blob/3dd5c58cdb7998e458d191e508e8e859177225a9/src/components/ai-clear-history-reminder.tsx#L78

--- a/src/hooks/sync-sites/use-sync-push.ts
+++ b/src/hooks/sync-sites/use-sync-push.ts
@@ -277,7 +277,7 @@ export function useSyncPush( {
 					message: getErrorFromResponse( error ),
 				} );
 			} finally {
-				// await getIpcApi().removeTemporalFile( archivePath );
+				await getIpcApi().removeTemporalFile( archivePath );
 			}
 		},
 		[ __, client, pushStatesProgressInfo, updatePushState, getErrorFromResponse ]

--- a/src/hooks/sync-sites/use-sync-push.ts
+++ b/src/hooks/sync-sites/use-sync-push.ts
@@ -277,7 +277,7 @@ export function useSyncPush( {
 					message: getErrorFromResponse( error ),
 				} );
 			} finally {
-				await getIpcApi().removeTemporalFile( archivePath );
+				// await getIpcApi().removeTemporalFile( archivePath );
 			}
 		},
 		[ __, client, pushStatesProgressInfo, updatePushState, getErrorFromResponse ]

--- a/src/hooks/use-content-folders.ts
+++ b/src/hooks/use-content-folders.ts
@@ -19,6 +19,8 @@ export function useContentFolders(
 			plugins: { items: [], isLoading: true, error: null },
 			themes: { items: [], isLoading: true, error: null },
 			uploads: { items: [], isLoading: true, error: null },
+			'mu-plugins': { items: [], isLoading: true, error: null },
+			fonts: { items: [], isLoading: true, error: null },
 		}
 	);
 

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -38,6 +38,7 @@ import { getImageData } from 'src/lib/get-image-data';
 import { getSiteUrl } from 'src/lib/get-site-url';
 import { getSyncBackupTempPath } from 'src/lib/get-sync-backup-temp-path';
 import { exportBackup } from 'src/lib/import-export/export/export-manager';
+import { DefaultExporter } from 'src/lib/import-export/export/exporters';
 import { ExportOptions } from 'src/lib/import-export/export/types';
 import { ImportExportEventData } from 'src/lib/import-export/handle-events';
 import { defaultImporterOptions, importBackup } from 'src/lib/import-export/import/import-manager';
@@ -685,21 +686,13 @@ export async function exportSiteToPush(
 		return optionsToSync?.includes( option ) || optionsToSync?.includes( 'all' ) || ! optionsToSync;
 	};
 
-	console.log( 'configuration', configuration );
-
 	const includes = {
 		database: shouldIncludeSyncOption( configuration?.optionsToSync, 'sqls' ),
 		uploads: shouldIncludeSyncOption( configuration?.optionsToSync, 'uploads' ),
 		plugins: shouldIncludeSyncOption( configuration?.optionsToSync, 'plugins' ),
 		themes: shouldIncludeSyncOption( configuration?.optionsToSync, 'themes' ),
-		muPlugins:
-			shouldIncludeSyncOption( configuration?.optionsToSync, 'contents' ) &&
-			( !! configuration?.specificSelections?.[ 'mu-plugins' ]?.length ||
-				! configuration?.specificSelections ),
-		fonts:
-			shouldIncludeSyncOption( configuration?.optionsToSync, 'contents' ) &&
-			( !! configuration?.specificSelections?.fonts?.length ||
-				! configuration?.specificSelections ),
+		muPlugins: shouldIncludeSyncOption( configuration?.optionsToSync, 'contents' ),
+		fonts: shouldIncludeSyncOption( configuration?.optionsToSync, 'contents' ),
 	};
 
 	const exportOptions: ExportOptions = {
@@ -1426,9 +1419,15 @@ export async function listWpContentFolders(
 				name: e.name.toString(),
 				type: e.isDirectory() ? ( 'folder' as const ) : ( 'file' as const ),
 				hidden: e.name.startsWith( '.' ),
+				excluded: DefaultExporter.pathsToExclude.some( ( pathToExclude ) => {
+					const fullPath = nodePath.join( e.parentPath || '', e.name );
+					const normalizedFullPath = nodePath.normalize( fullPath );
+					const normalizedPathToExclude = nodePath.normalize( pathToExclude );
+					return normalizedFullPath.includes( normalizedPathToExclude );
+				} ),
 			} ) )
-			.filter( ( entry: { name: string; hidden: boolean } ) => {
-				return ! entry.hidden;
+			.filter( ( entry: { name: string; hidden: boolean; excluded: boolean } ) => {
+				return ! entry.hidden && ! entry.excluded;
 			} );
 	} catch ( err ) {
 		return [];

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -666,6 +666,8 @@ export async function exportSiteToPush(
 			plugins?: string[];
 			themes?: string[];
 			uploads?: string[];
+			'mu-plugins'?: string[];
+			fonts?: string[];
 		};
 	}
 ) {
@@ -683,13 +685,21 @@ export async function exportSiteToPush(
 		return optionsToSync?.includes( option ) || optionsToSync?.includes( 'all' ) || ! optionsToSync;
 	};
 
+	console.log( 'configuration', configuration );
+
 	const includes = {
 		database: shouldIncludeSyncOption( configuration?.optionsToSync, 'sqls' ),
 		uploads: shouldIncludeSyncOption( configuration?.optionsToSync, 'uploads' ),
 		plugins: shouldIncludeSyncOption( configuration?.optionsToSync, 'plugins' ),
 		themes: shouldIncludeSyncOption( configuration?.optionsToSync, 'themes' ),
-		muPlugins: shouldIncludeSyncOption( configuration?.optionsToSync, 'contents' ),
-		fonts: shouldIncludeSyncOption( configuration?.optionsToSync, 'contents' ),
+		muPlugins:
+			shouldIncludeSyncOption( configuration?.optionsToSync, 'contents' ) &&
+			( !! configuration?.specificSelections?.[ 'mu-plugins' ]?.length ||
+				! configuration?.specificSelections ),
+		fonts:
+			shouldIncludeSyncOption( configuration?.optionsToSync, 'contents' ) &&
+			( !! configuration?.specificSelections?.fonts?.length ||
+				! configuration?.specificSelections ),
 	};
 
 	const exportOptions: ExportOptions = {

--- a/src/lib/import-export/export/exporters/default-exporter.ts
+++ b/src/lib/import-export/export/exporters/default-exporter.ts
@@ -215,6 +215,10 @@ export class DefaultExporter extends EventEmitter implements Exporter {
 				return this.options.specificSelections?.themes || null;
 			case 'uploads':
 				return this.options.specificSelections?.uploads || null;
+			case 'muPlugins':
+				return this.options.specificSelections?.muPlugins || null;
+			case 'fonts':
+				return this.options.specificSelections?.fonts || null;
 			default:
 				return null;
 		}

--- a/src/lib/import-export/export/exporters/default-exporter.ts
+++ b/src/lib/import-export/export/exporters/default-exporter.ts
@@ -27,7 +27,8 @@ export class DefaultExporter extends EventEmitter implements Exporter {
 	private archiveBuilder!: archiver.Archiver;
 	private backup: BackupContents;
 	private readonly options: ExportOptions;
-	private readonly pathsToExclude = [
+
+	public static readonly pathsToExclude = [
 		'wp-content/mu-plugins/sqlite-database-integration',
 		'wp-content/mu-plugins/0-allowed-redirect-hosts.php',
 		'wp-content/mu-plugins/0-check-theme-availability.php',
@@ -184,7 +185,7 @@ export class DefaultExporter extends EventEmitter implements Exporter {
 			} else {
 				this.archiveBuilder.directory( absolutePath, archivePath, ( entry ) => {
 					const fullArchivePath = path.join( archivePath, entry.name );
-					const isExcluded = this.pathsToExclude.some( ( pathToExclude ) =>
+					const isExcluded = DefaultExporter.pathsToExclude.some( ( pathToExclude ) =>
 						fullArchivePath.startsWith( path.normalize( pathToExclude ) )
 					);
 					if (
@@ -216,7 +217,7 @@ export class DefaultExporter extends EventEmitter implements Exporter {
 			case 'uploads':
 				return this.options.specificSelections?.uploads || null;
 			case 'muPlugins':
-				return this.options.specificSelections?.muPlugins || null;
+				return this.options.specificSelections?.[ 'mu-plugins' ] || null;
 			case 'fonts':
 				return this.options.specificSelections?.fonts || null;
 			default:

--- a/src/lib/import-export/export/types.ts
+++ b/src/lib/import-export/export/types.ts
@@ -11,7 +11,7 @@ export interface ExportOptions {
 		plugins?: string[];
 		themes?: string[];
 		uploads?: string[];
-		muPlugins?: string[];
+		'mu-plugins'?: string[];
 		fonts?: string[];
 	};
 }

--- a/src/lib/import-export/export/types.ts
+++ b/src/lib/import-export/export/types.ts
@@ -11,6 +11,8 @@ export interface ExportOptions {
 		plugins?: string[];
 		themes?: string[];
 		uploads?: string[];
+		muPlugins?: string[];
+		fonts?: string[];
 	};
 }
 

--- a/src/modules/sync/components/sync-dialog.tsx
+++ b/src/modules/sync/components/sync-dialog.tsx
@@ -81,7 +81,7 @@ export function SyncDialog( {
 	const locale = useI18nLocale();
 	const { __ } = useI18n();
 	const copy = useSyncDialogTexts( type );
-	const defaultTree = useDefaultSyncTree();
+	const defaultTree = useDefaultSyncTree( type );
 
 	const [ showAllFiles, setShowAllFiles ] = useState( false );
 	const [ treeState, setTreeState ] = useState< TreeNode[] >( defaultTree );

--- a/src/modules/sync/components/sync-dialog.tsx
+++ b/src/modules/sync/components/sync-dialog.tsx
@@ -27,6 +27,10 @@ type SyncDialogProps = {
 	onRequestClose: () => void;
 };
 
+const wpTypeIsFolder = ( wpType: string ): wpType is keyof typeof SYNC_OPTIONS => {
+	return Object.keys( SYNC_OPTIONS ).includes( wpType );
+};
+
 const useDynamicTreeState = (
 	type: 'push' | 'pull',
 	localSiteId: string,
@@ -55,7 +59,8 @@ const useDynamicTreeState = (
 							type: item.type,
 					  } ) );
 
-				newState = updateNodeById( newState, SYNC_OPTIONS[ wpType ], {
+				const nodeId = wpTypeIsFolder( wpType ) ? SYNC_OPTIONS[ wpType ] : wpType;
+				newState = updateNodeById( newState, nodeId, {
 					loading: isLoading,
 					children,
 				} );

--- a/src/modules/sync/constants.ts
+++ b/src/modules/sync/constants.ts
@@ -1,1 +1,7 @@
-export const GRANULAR_SYNC_FOLDERS = [ 'plugins', 'themes', 'uploads' ] as const;
+export const GRANULAR_SYNC_FOLDERS = [
+	'plugins',
+	'themes',
+	'uploads',
+	'mu-plugins',
+	'fonts',
+] as const;

--- a/src/modules/sync/hooks/use-default-sync-tree.tsx
+++ b/src/modules/sync/hooks/use-default-sync-tree.tsx
@@ -50,6 +50,22 @@ export const useDefaultSyncTree = (): TreeNode[] => {
 								expanded: false,
 							},
 							{
+								id: 'mu-plugins',
+								name: 'mu-plugins',
+								label: 'mu-plugins',
+								checked: true,
+								type: 'folder',
+								expanded: false,
+							},
+							{
+								id: 'fonts',
+								name: 'fonts',
+								label: 'fonts',
+								checked: true,
+								type: 'folder',
+								expanded: false,
+							},
+							{
 								id: SYNC_OPTIONS.contents,
 								name: SYNC_OPTIONS.contents,
 								label: __( 'Other files and directories' ),

--- a/src/modules/sync/hooks/use-default-sync-tree.tsx
+++ b/src/modules/sync/hooks/use-default-sync-tree.tsx
@@ -3,10 +3,39 @@ import { useMemo } from 'react';
 import { TreeNode } from 'src/components/tree-view';
 import { SYNC_OPTIONS } from 'src/constants';
 
-export const useDefaultSyncTree = (): TreeNode[] => {
+export const useDefaultSyncTree = ( type: 'push' | 'pull' ): TreeNode[] => {
 	const { __ } = useI18n();
 
 	return useMemo( () => {
+		const pushOptions: TreeNode[] = [
+			{
+				id: 'mu-plugins',
+				name: 'mu-plugins',
+				label: 'mu-plugins',
+				checked: true,
+				type: 'folder',
+				expanded: false,
+			},
+			{
+				id: 'fonts',
+				name: 'fonts',
+				label: 'fonts',
+				checked: true,
+				type: 'folder',
+				expanded: false,
+			},
+		];
+
+		const pullOptions: TreeNode[] = [
+			{
+				id: SYNC_OPTIONS.contents,
+				name: SYNC_OPTIONS.contents,
+				label: __( 'Other files and directories' ),
+				checked: true,
+				type: 'more',
+			},
+		];
+
 		return [
 			{
 				id: 'filesAndFolders',
@@ -49,29 +78,7 @@ export const useDefaultSyncTree = (): TreeNode[] => {
 								type: 'folder',
 								expanded: false,
 							},
-							{
-								id: 'mu-plugins',
-								name: 'mu-plugins',
-								label: 'mu-plugins',
-								checked: true,
-								type: 'folder',
-								expanded: false,
-							},
-							{
-								id: 'fonts',
-								name: 'fonts',
-								label: 'fonts',
-								checked: true,
-								type: 'folder',
-								expanded: false,
-							},
-							{
-								id: SYNC_OPTIONS.contents,
-								name: SYNC_OPTIONS.contents,
-								label: __( 'Other files and directories' ),
-								checked: true,
-								type: 'more',
-							},
+							...( type === 'push' ? pushOptions : pullOptions ),
 						],
 					},
 				],
@@ -83,5 +90,5 @@ export const useDefaultSyncTree = (): TreeNode[] => {
 				checked: true,
 			},
 		];
-	}, [ __ ] );
+	}, [ __, type ] );
 };

--- a/src/modules/sync/lib/convert-tree-to-options-to-sync.ts
+++ b/src/modules/sync/lib/convert-tree-to-options-to-sync.ts
@@ -8,7 +8,7 @@ type SyncOptionsWithSelections = {
 		plugins?: string[];
 		themes?: string[];
 		uploads?: string[];
-		muPlugins?: string[];
+		'mu-plugins'?: string[];
 		fonts?: string[];
 	};
 };
@@ -54,7 +54,7 @@ export const convertTreeToOptionsToSync = ( tree: TreeNode[] ): SyncOptionsWithS
 					SYNC_OPTIONS.plugins,
 					SYNC_OPTIONS.themes,
 					SYNC_OPTIONS.uploads,
-					CONTENTS_SYNC_OPTIONS.muPlugins,
+					CONTENTS_SYNC_OPTIONS[ 'mu-plugins' ],
 					CONTENTS_SYNC_OPTIONS.fonts,
 				].includes( item.id as 'plugins' | 'themes' | 'uploads' | 'mu-plugins' | 'fonts' )
 			) {
@@ -70,6 +70,9 @@ export const convertTreeToOptionsToSync = ( tree: TreeNode[] ): SyncOptionsWithS
 			}
 		} );
 	}
+
+	console.log( 'optionsToSync', optionsToSync );
+	console.log( 'specificSelections', specificSelections );
 
 	return {
 		optionsToSync,

--- a/src/modules/sync/lib/convert-tree-to-options-to-sync.ts
+++ b/src/modules/sync/lib/convert-tree-to-options-to-sync.ts
@@ -47,11 +47,13 @@ export const convertTreeToOptionsToSync = ( tree: TreeNode[] ): SyncOptionsWithS
 				const itemId = isContentsSyncOption( item.id ) ? SYNC_OPTIONS.contents : item.id;
 				if ( ! optionsToSync.includes( itemId ) ) {
 					optionsToSync.push( itemId );
-					specificSelections = {
-						[ 'mu-plugins' ]: [],
-						fonts: [],
-						...specificSelections,
-					};
+					if ( itemId === SYNC_OPTIONS.contents ) {
+						specificSelections = {
+							[ 'mu-plugins' ]: [],
+							fonts: [],
+							...specificSelections,
+						};
+					}
 				}
 			}
 

--- a/src/modules/sync/lib/convert-tree-to-options-to-sync.ts
+++ b/src/modules/sync/lib/convert-tree-to-options-to-sync.ts
@@ -45,7 +45,14 @@ export const convertTreeToOptionsToSync = ( tree: TreeNode[] ): SyncOptionsWithS
 
 			if ( item.checked || item.indeterminate ) {
 				const itemId = isContentsSyncOption( item.id ) ? SYNC_OPTIONS.contents : item.id;
-				optionsToSync.push( itemId );
+				if ( ! optionsToSync.includes( itemId ) ) {
+					optionsToSync.push( itemId );
+					specificSelections = {
+						[ 'mu-plugins' ]: [],
+						fonts: [],
+						...specificSelections,
+					};
+				}
 			}
 
 			if (
@@ -61,7 +68,10 @@ export const convertTreeToOptionsToSync = ( tree: TreeNode[] ): SyncOptionsWithS
 				const selectedItems = item.children
 					.filter( ( child ) => child.checked )
 					.map( ( child ) => child.name );
-				if ( selectedItems.length > 0 && selectedItems.length < item.children.length ) {
+				if (
+					selectedItems.length > 0 &&
+					( selectedItems.length < item.children.length || isContentsSyncOption( item.id ) )
+				) {
 					specificSelections = {
 						...specificSelections,
 						[ item.id ]: selectedItems,

--- a/src/modules/sync/lib/convert-tree-to-options-to-sync.ts
+++ b/src/modules/sync/lib/convert-tree-to-options-to-sync.ts
@@ -1,6 +1,6 @@
-import { SYNC_OPTIONS } from 'src/constants';
+import { CONTENTS_SYNC_OPTIONS, SYNC_OPTIONS } from 'src/constants';
 import type { TreeNode } from 'src/components/tree-view';
-import type { SyncOption } from 'src/types';
+import type { ContentsSyncOption, SyncOption } from 'src/types';
 
 type SyncOptionsWithSelections = {
 	optionsToSync: SyncOption[];
@@ -8,11 +8,17 @@ type SyncOptionsWithSelections = {
 		plugins?: string[];
 		themes?: string[];
 		uploads?: string[];
+		muPlugins?: string[];
+		fonts?: string[];
 	};
 };
 
 const isSyncOption = ( value: string ): value is SyncOption => {
 	return Object.keys( SYNC_OPTIONS ).includes( value );
+};
+
+const isContentsSyncOption = ( value: string ): value is ContentsSyncOption => {
+	return Object.keys( CONTENTS_SYNC_OPTIONS ).includes( value );
 };
 
 export const convertTreeToOptionsToSync = ( tree: TreeNode[] ): SyncOptionsWithSelections => {
@@ -33,19 +39,24 @@ export const convertTreeToOptionsToSync = ( tree: TreeNode[] ): SyncOptionsWithS
 		const wpContent = filesAndFolders.find( ( node ) => node.id === 'wp-content' )?.children || [];
 
 		wpContent.forEach( ( item ) => {
-			if ( ! isSyncOption( item.id ) ) {
+			if ( ! isSyncOption( item.id ) && ! isContentsSyncOption( item.id ) ) {
 				return;
 			}
 
 			if ( item.checked || item.indeterminate ) {
-				optionsToSync.push( item.id );
+				const itemId = isContentsSyncOption( item.id ) ? SYNC_OPTIONS.contents : item.id;
+				optionsToSync.push( itemId );
 			}
 
 			if (
 				item.children &&
-				[ SYNC_OPTIONS.plugins, SYNC_OPTIONS.themes, SYNC_OPTIONS.uploads ].includes(
-					item.id as 'plugins' | 'themes' | 'uploads'
-				)
+				[
+					SYNC_OPTIONS.plugins,
+					SYNC_OPTIONS.themes,
+					SYNC_OPTIONS.uploads,
+					CONTENTS_SYNC_OPTIONS.muPlugins,
+					CONTENTS_SYNC_OPTIONS.fonts,
+				].includes( item.id as 'plugins' | 'themes' | 'uploads' | 'mu-plugins' | 'fonts' )
 			) {
 				const selectedItems = item.children
 					.filter( ( child ) => child.checked )

--- a/src/modules/sync/tests/convert-tree-to-options-to-sync.tsx
+++ b/src/modules/sync/tests/convert-tree-to-options-to-sync.tsx
@@ -5,7 +5,7 @@ import { convertTreeToOptionsToSync } from 'src/modules/sync/lib/convert-tree-to
 
 describe( 'convertTreeToOptionsToSync', () => {
 	it( 'returns ["all"] when all options are selected', () => {
-		const { result } = renderHook( () => useDefaultSyncTree() );
+		const { result } = renderHook( () => useDefaultSyncTree( 'push' ) );
 		const tree = result.current;
 
 		const optionsToSync = convertTreeToOptionsToSync( tree );
@@ -13,7 +13,7 @@ describe( 'convertTreeToOptionsToSync', () => {
 	} );
 
 	it( 'returns ["sqls"] when only database is selected', () => {
-		const { result } = renderHook( () => useDefaultSyncTree() );
+		const { result } = renderHook( () => useDefaultSyncTree( 'push' ) );
 		let tree = result.current;
 
 		tree = updateNodeById( tree, 'filesAndFolders', { checked: false } );
@@ -23,7 +23,7 @@ describe( 'convertTreeToOptionsToSync', () => {
 	} );
 
 	it( 'returns ["plugins"] when only plugins are selected', () => {
-		const { result } = renderHook( () => useDefaultSyncTree() );
+		const { result } = renderHook( () => useDefaultSyncTree( 'push' ) );
 		let tree = result.current;
 
 		tree = updateNodeById( tree, 'filesAndFolders', { checked: false } );
@@ -38,7 +38,7 @@ describe( 'convertTreeToOptionsToSync', () => {
 	} );
 
 	it( 'returns ["uploads"] when only uploads are selected', () => {
-		const { result } = renderHook( () => useDefaultSyncTree() );
+		const { result } = renderHook( () => useDefaultSyncTree( 'push' ) );
 		let tree = result.current;
 
 		tree = updateNodeById( tree, 'filesAndFolders', { checked: false } );
@@ -53,7 +53,7 @@ describe( 'convertTreeToOptionsToSync', () => {
 	} );
 
 	it( 'returns ["sqls", "plugins"] when both are selected', () => {
-		const { result } = renderHook( () => useDefaultSyncTree() );
+		const { result } = renderHook( () => useDefaultSyncTree( 'push' ) );
 		let tree = result.current;
 
 		tree = updateNodeById( tree, 'filesAndFolders', { checked: false } );
@@ -68,7 +68,7 @@ describe( 'convertTreeToOptionsToSync', () => {
 
 	describe( 'partial selections', () => {
 		it( 'returns partial plugins selection when only some plugins are selected', () => {
-			const { result } = renderHook( () => useDefaultSyncTree() );
+			const { result } = renderHook( () => useDefaultSyncTree( 'push' ) );
 			let tree = result.current;
 
 			tree = updateNodeById( tree, 'filesAndFolders', { checked: false } );
@@ -103,7 +103,7 @@ describe( 'convertTreeToOptionsToSync', () => {
 		} );
 
 		it( 'returns partial themes selection when only some themes are selected', () => {
-			const { result } = renderHook( () => useDefaultSyncTree() );
+			const { result } = renderHook( () => useDefaultSyncTree( 'push' ) );
 			let tree = result.current;
 
 			tree = updateNodeById( tree, 'filesAndFolders', { checked: false } );
@@ -139,7 +139,7 @@ describe( 'convertTreeToOptionsToSync', () => {
 		} );
 
 		it( 'returns partial uploads selection when only some uploads are selected', () => {
-			const { result } = renderHook( () => useDefaultSyncTree() );
+			const { result } = renderHook( () => useDefaultSyncTree( 'push' ) );
 			let tree = result.current;
 
 			tree = updateNodeById( tree, 'filesAndFolders', { checked: false } );
@@ -174,7 +174,7 @@ describe( 'convertTreeToOptionsToSync', () => {
 		} );
 
 		it( 'returns mixed partial selections for plugins and themes', () => {
-			const { result } = renderHook( () => useDefaultSyncTree() );
+			const { result } = renderHook( () => useDefaultSyncTree( 'push' ) );
 			let tree = result.current;
 
 			tree = updateNodeById( tree, 'filesAndFolders', { checked: false } );
@@ -219,7 +219,7 @@ describe( 'convertTreeToOptionsToSync', () => {
 		} );
 
 		it( 'returns no specificSelections when all children are selected in a category', () => {
-			const { result } = renderHook( () => useDefaultSyncTree() );
+			const { result } = renderHook( () => useDefaultSyncTree( 'push' ) );
 			let tree = result.current;
 
 			tree = updateNodeById( tree, 'filesAndFolders', { checked: false } );
@@ -250,7 +250,7 @@ describe( 'convertTreeToOptionsToSync', () => {
 		} );
 
 		it( 'returns no specificSelections when no children are selected in a category', () => {
-			const { result } = renderHook( () => useDefaultSyncTree() );
+			const { result } = renderHook( () => useDefaultSyncTree( 'push' ) );
 			let tree = result.current;
 
 			tree = updateNodeById( tree, 'filesAndFolders', { checked: false } );
@@ -281,7 +281,7 @@ describe( 'convertTreeToOptionsToSync', () => {
 		} );
 
 		it( 'handles mixed selection with database and partial plugins', () => {
-			const { result } = renderHook( () => useDefaultSyncTree() );
+			const { result } = renderHook( () => useDefaultSyncTree( 'push' ) );
 			let tree = result.current;
 
 			tree = updateNodeById( tree, 'filesAndFolders', { checked: false } );
@@ -315,7 +315,7 @@ describe( 'convertTreeToOptionsToSync', () => {
 	} );
 
 	it( 'strips folder type prefix from specific selections', () => {
-		const { result } = renderHook( () => useDefaultSyncTree() );
+		const { result } = renderHook( () => useDefaultSyncTree( 'push' ) );
 		let tree = result.current;
 
 		tree = updateNodeById( tree, 'plugins', {
@@ -341,6 +341,8 @@ describe( 'convertTreeToOptionsToSync', () => {
 		expect( optionsToSync ).toEqual( {
 			optionsToSync: [ 'sqls', 'plugins', 'themes', 'uploads', 'contents' ],
 			specificSelections: {
+				'mu-plugins': [],
+				fonts: [],
 				plugins: [ 'my-plugin' ],
 			},
 		} );

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,4 @@
-import { SYNC_OPTIONS } from 'src/constants';
+import { CONTENTS_SYNC_OPTIONS, SYNC_OPTIONS } from 'src/constants';
 
 export type SyncOption = keyof typeof SYNC_OPTIONS;
+export type ContentsSyncOption = keyof typeof CONTENTS_SYNC_OPTIONS;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-584

## Proposed Changes

- Adds `mu-plugins` and `fonts` to the sync granular selection

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- start Studio
- using a connected site, start a push operation
- `mu-plugins` and `fonts` folders and their content appear on the tree
- Selection works as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
