### PR TITLE
Improve the site box within the Selective Sync dialog

### DIFF
--- a/src/components/badge.tsx
+++ b/src/components/badge.tsx
@@ -11,7 +11,7 @@ export function Badge( {
 		<div
 			className={ cx(
 				'badge rounded-sm justify-center items-center a8c-body-small flex h-4 px-2 whitespace-nowrap',
-				className || 'text-a8c-yellow-80 bg-a8c-yellow-10'
+				className
 			) }
 		>
 			{ children }

--- a/src/components/environment-badge.tsx
+++ b/src/components/environment-badge.tsx
@@ -3,7 +3,7 @@ import { Badge } from 'src/components/badge';
 import { cx } from 'src/lib/cx';
 import type { SyncSite } from 'src/hooks/use-fetch-wpcom-sites/types';
 
-export type EnvironmentType = 'production' | 'staging' | 'sandbox';
+export type EnvironmentType = 'production' | 'staging' | 'sandbox' | 'studio';
 
 interface EnvironmentBadgeProps {
 	type: EnvironmentType;
@@ -28,6 +28,10 @@ export function EnvironmentBadge( { type, selected, className }: EnvironmentBadg
 			return 'text-sandbox-text bg-sandbox-bg';
 		}
 
+		if ( type === 'studio' ) {
+			return 'bg-a8c-gray-5 text-a8c-gray-80';
+		}
+
 		return 'text-a8c-yellow-80 bg-a8c-yellow-10';
 	};
 
@@ -35,14 +39,11 @@ export function EnvironmentBadge( { type, selected, className }: EnvironmentBadg
 		staging: __( 'Staging' ),
 		sandbox: __( 'Sandbox' ),
 		production: __( 'Production' ),
+		studio: __( 'Studio' ),
 	};
 
 	return <Badge className={ cx( getClassName(), className ) }>{ labels[ type ] }</Badge>;
 }
-
-export const StudioBadge = ( { className }: { className?: string } ) => {
-	return <Badge className={ cx( 'bg-a8c-gray-5 text-a8c-gray-80', className ) }>Studio</Badge>;
-};
 
 export const getSiteEnvironment = ( connectedSite: SyncSite ): EnvironmentType => {
 	if ( connectedSite.isPressable ) {

--- a/src/components/environment-badge.tsx
+++ b/src/components/environment-badge.tsx
@@ -8,12 +8,13 @@ export type EnvironmentType = 'production' | 'staging' | 'sandbox';
 interface EnvironmentBadgeProps {
 	type: EnvironmentType;
 	selected?: boolean;
+	className?: string;
 }
 
 /**
  * A badge component for displaying environment types (production, staging)
  */
-export function EnvironmentBadge( { type, selected }: EnvironmentBadgeProps ) {
+export function EnvironmentBadge( { type, selected, className }: EnvironmentBadgeProps ) {
 	const getClassName = () => {
 		if ( selected ) {
 			return 'bg-white text-a8c-blueberry text-a8c-blueberry';
@@ -27,7 +28,7 @@ export function EnvironmentBadge( { type, selected }: EnvironmentBadgeProps ) {
 			return 'text-sandbox-text bg-sandbox-bg';
 		}
 
-		return '';
+		return 'text-a8c-yellow-80 bg-a8c-yellow-10';
 	};
 
 	const labels: Record< EnvironmentType, string > = {
@@ -36,8 +37,12 @@ export function EnvironmentBadge( { type, selected }: EnvironmentBadgeProps ) {
 		production: __( 'Production' ),
 	};
 
-	return <Badge className={ cx( getClassName() ) }>{ labels[ type ] }</Badge>;
+	return <Badge className={ cx( getClassName(), className ) }>{ labels[ type ] }</Badge>;
 }
+
+export const StudioBadge = ( { className }: { className?: string } ) => {
+	return <Badge className={ cx( 'bg-a8c-gray-5 text-a8c-gray-80', className ) }>Studio</Badge>;
+};
 
 export const getSiteEnvironment = ( connectedSite: SyncSite ): EnvironmentType => {
 	if ( connectedSite.isPressable ) {

--- a/src/components/environment-badge.tsx
+++ b/src/components/environment-badge.tsx
@@ -41,7 +41,11 @@ export function EnvironmentBadge( { type, selected, className }: EnvironmentBadg
 }
 
 export const StudioBadge = ( { className }: { className?: string } ) => {
-	return <Badge className={ cx( 'bg-a8c-gray-5 text-a8c-gray-80', className ) }>{ __( 'Studio' ) }</Badge>;
+	return (
+		<Badge className={ cx( 'bg-a8c-gray-5 text-a8c-gray-80', className ) }>
+			{ __( 'Studio' ) }
+		</Badge>
+	);
 };
 
 export const getSiteEnvironment = ( connectedSite: SyncSite ): EnvironmentType => {

--- a/src/components/environment-badge.tsx
+++ b/src/components/environment-badge.tsx
@@ -3,7 +3,7 @@ import { Badge } from 'src/components/badge';
 import { cx } from 'src/lib/cx';
 import type { SyncSite } from 'src/hooks/use-fetch-wpcom-sites/types';
 
-export type EnvironmentType = 'production' | 'staging' | 'sandbox' | 'studio';
+export type EnvironmentType = 'production' | 'staging' | 'sandbox';
 
 interface EnvironmentBadgeProps {
 	type: EnvironmentType;
@@ -28,10 +28,6 @@ export function EnvironmentBadge( { type, selected, className }: EnvironmentBadg
 			return 'text-sandbox-text bg-sandbox-bg';
 		}
 
-		if ( type === 'studio' ) {
-			return 'bg-a8c-gray-5 text-a8c-gray-80';
-		}
-
 		return 'text-a8c-yellow-80 bg-a8c-yellow-10';
 	};
 
@@ -39,11 +35,14 @@ export function EnvironmentBadge( { type, selected, className }: EnvironmentBadg
 		staging: __( 'Staging' ),
 		sandbox: __( 'Sandbox' ),
 		production: __( 'Production' ),
-		studio: __( 'Studio' ),
 	};
 
 	return <Badge className={ cx( getClassName(), className ) }>{ labels[ type ] }</Badge>;
 }
+
+export const StudioBadge = ( { className }: { className?: string } ) => {
+	return <Badge className={ cx( 'bg-a8c-gray-5 text-a8c-gray-80', className ) }>{ __( 'Studio' ) }</Badge>;
+};
 
 export const getSiteEnvironment = ( connectedSite: SyncSite ): EnvironmentType => {
 	if ( connectedSite.isPressable ) {

--- a/src/modules/sync/components/site-name-box.tsx
+++ b/src/modules/sync/components/site-name-box.tsx
@@ -1,0 +1,18 @@
+import { EnvironmentBadge } from 'src/components/environment-badge';
+import type { EnvironmentType } from 'src/components/environment-badge';
+
+type SiteNameBoxProps = {
+	siteName: string;
+	envType: EnvironmentType;
+};
+
+export const SiteNameBox = ( { siteName, envType }: SiteNameBoxProps ) => {
+	return (
+		<>
+			<span className="inline-block">
+				<EnvironmentBadge type={ envType } className="h-6" />
+			</span>
+			<span className="text-gray-600"> { siteName } </span>
+		</>
+	);
+};

--- a/src/modules/sync/components/site-name-box.tsx
+++ b/src/modules/sync/components/site-name-box.tsx
@@ -1,16 +1,16 @@
-import { EnvironmentBadge } from 'src/components/environment-badge';
+import { EnvironmentBadge, StudioBadge } from 'src/components/environment-badge';
 import type { EnvironmentType } from 'src/components/environment-badge';
 
 type SiteNameBoxProps = {
 	siteName: string;
-	envType: EnvironmentType;
+	envType: EnvironmentType | 'studio';
 };
 
 export const SiteNameBox = ( { siteName, envType }: SiteNameBoxProps ) => {
 	return (
 		<>
 			<span className="inline-block">
-				<EnvironmentBadge type={ envType } className="h-6" />
+				{ envType === 'studio' ? <StudioBadge className="h-6" /> : <EnvironmentBadge type={ envType } className="h-6" />}
 			</span>
 			<span className="text-gray-600"> { siteName } </span>
 		</>

--- a/src/modules/sync/components/site-name-box.tsx
+++ b/src/modules/sync/components/site-name-box.tsx
@@ -10,7 +10,11 @@ export const SiteNameBox = ( { siteName, envType }: SiteNameBoxProps ) => {
 	return (
 		<>
 			<span className="inline-block">
-				{ envType === 'studio' ? <StudioBadge className="h-6" /> : <EnvironmentBadge type={ envType } className="h-6" />}
+				{ envType === 'studio' ? (
+					<StudioBadge className="h-6" />
+				) : (
+					<EnvironmentBadge type={ envType } className="h-6" />
+				) }
 			</span>
 			<span className="text-gray-600"> { siteName } </span>
 		</>

--- a/src/modules/sync/components/sync-dialog.tsx
+++ b/src/modules/sync/components/sync-dialog.tsx
@@ -5,11 +5,7 @@ import { useI18n } from '@wordpress/react-i18n';
 import { useState, useEffect, useMemo } from 'react';
 import { ArrowIcon } from 'src/components/arrow-icon';
 import Button from 'src/components/button';
-import {
-	EnvironmentBadge,
-	StudioBadge,
-	getSiteEnvironment,
-} from 'src/components/environment-badge';
+import { EnvironmentBadge, getSiteEnvironment } from 'src/components/environment-badge';
 import { RightArrowIcon } from 'src/components/icons/right-arrow';
 import Modal from 'src/components/modal';
 import { TreeView, TreeNode, updateNodeById } from 'src/components/tree-view';
@@ -22,6 +18,7 @@ import { useDefaultSyncTree } from 'src/modules/sync/hooks/use-default-sync-tree
 import { useSyncDialogTexts } from 'src/modules/sync/hooks/use-sync-dialog-texts';
 import { useI18nLocale } from 'src/stores';
 import type { SyncSite } from 'src/hooks/use-fetch-wpcom-sites/types';
+import { SiteNameBox } from 'src/modules/sync/components/site-name-box';
 
 type SyncDialogProps = {
 	type: 'push' | 'pull';
@@ -90,22 +87,8 @@ export function SyncDialog( {
 
 	const siteEnv = getSiteEnvironment( remoteSite );
 
-	const localSiteName = (
-		<>
-			<span className="inline-block">
-				<StudioBadge className="h-6" />
-			</span>
-			<span className="text-gray-600"> { localSite.name } </span>
-		</>
-	);
-	const remoteSiteName = (
-		<>
-			<span className="inline-block">
-				<EnvironmentBadge type={ siteEnv } className="h-6" />
-			</span>
-			<span className="text-gray-600"> { remoteSite.name } </span>
-		</>
-	);
+	const localSiteName = <SiteNameBox siteName={ localSite.name } envType="studio" />;
+	const remoteSiteName = <SiteNameBox siteName={ remoteSite.name } envType={ siteEnv } />;
 
 	let syncFrom, syncTo, syncFromText, syncToText;
 	if ( type === 'push' ) {
@@ -159,7 +142,7 @@ export function SyncDialog( {
 							<div className="leading-[32px]">{ copy.fromLabel }</div>
 							<div className="whitespace-nowrap truncate">{ syncFrom }</div>
 						</div>
-						<div className="mt-[32px] w-[50px] flex items-center justify-center">
+						<div className="mt-[32px] w-[50px] flex items-center justify-center text-a8c-gray-600">
 							<RightArrowIcon />
 						</div>
 						<div className="overflow-hidden max-w-[calc(50%-25px)]">

--- a/src/modules/sync/components/sync-dialog.tsx
+++ b/src/modules/sync/components/sync-dialog.tsx
@@ -5,7 +5,7 @@ import { useI18n } from '@wordpress/react-i18n';
 import { useState, useEffect, useMemo } from 'react';
 import { ArrowIcon } from 'src/components/arrow-icon';
 import Button from 'src/components/button';
-import { EnvironmentBadge, getSiteEnvironment } from 'src/components/environment-badge';
+import { getSiteEnvironment } from 'src/components/environment-badge';
 import { RightArrowIcon } from 'src/components/icons/right-arrow';
 import Modal from 'src/components/modal';
 import { TreeView, TreeNode, updateNodeById } from 'src/components/tree-view';

--- a/src/modules/sync/components/sync-dialog.tsx
+++ b/src/modules/sync/components/sync-dialog.tsx
@@ -8,7 +8,7 @@ import Button from 'src/components/button';
 import {
 	EnvironmentBadge,
 	StudioBadge,
-	getSiteEnvironment
+	getSiteEnvironment,
 } from 'src/components/environment-badge';
 import { RightArrowIcon } from 'src/components/icons/right-arrow';
 import Modal from 'src/components/modal';

--- a/src/modules/sync/components/sync-dialog.tsx
+++ b/src/modules/sync/components/sync-dialog.tsx
@@ -13,12 +13,12 @@ import { SYNC_OPTIONS } from 'src/constants';
 import { useContentFolders } from 'src/hooks/use-content-folders';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 import { getLocalizedLink } from 'src/lib/get-localized-link';
+import { SiteNameBox } from 'src/modules/sync/components/site-name-box';
 import { GRANULAR_SYNC_FOLDERS } from 'src/modules/sync/constants';
 import { useDefaultSyncTree } from 'src/modules/sync/hooks/use-default-sync-tree';
 import { useSyncDialogTexts } from 'src/modules/sync/hooks/use-sync-dialog-texts';
 import { useI18nLocale } from 'src/stores';
 import type { SyncSite } from 'src/hooks/use-fetch-wpcom-sites/types';
-import { SiteNameBox } from 'src/modules/sync/components/site-name-box';
 
 type SyncDialogProps = {
 	type: 'push' | 'pull';

--- a/src/modules/sync/components/sync-dialog.tsx
+++ b/src/modules/sync/components/sync-dialog.tsx
@@ -5,7 +5,7 @@ import { useI18n } from '@wordpress/react-i18n';
 import { useState, useEffect, useMemo } from 'react';
 import { ArrowIcon } from 'src/components/arrow-icon';
 import Button from 'src/components/button';
-import { EnvironmentBadge, getSiteEnvironment } from 'src/components/environment-badge';
+import { EnvironmentBadge, StudioBadge, getSiteEnvironment } from 'src/components/environment-badge';
 import { RightArrowIcon } from 'src/components/icons/right-arrow';
 import Modal from 'src/components/modal';
 import { TreeView, TreeNode, updateNodeById } from 'src/components/tree-view';
@@ -86,14 +86,21 @@ export function SyncDialog( {
 
 	const siteEnv = getSiteEnvironment( remoteSite );
 
-	const localSiteName = localSite.name;
-	const remoteSiteName = (
-		<div>
+	const localSiteName = (
+		<>
 			<span className="inline-block">
-				<EnvironmentBadge type={ siteEnv } />
+				<StudioBadge className="h-6" />
+			</span>
+			<span className="text-gray-600"> { localSite.name } </span>
+		</>
+	);
+	const remoteSiteName = (
+		<>
+			<span className="inline-block">
+				<EnvironmentBadge type={ siteEnv } className="h-6" />
 			</span>
 			<span className="text-gray-600"> { remoteSite.name } </span>
-		</div>
+		</>
 	);
 
 	let syncFrom, syncTo, syncFromText, syncToText;
@@ -142,20 +149,20 @@ export function SyncDialog( {
 					</span>
 					<div
 						aria-hidden="true"
-						className="flex items-start gap-1 pb-7 border-b border-a8c-gray-5"
+						className="flex max-w-full overflow-hidden pb-6 border-b border-a8c-gray-5"
 					>
-						<div className="flex-1">
+						<div className="overflow-hidden max-w-[calc(50%-25px)]">
 							<div className="leading-[32px]">{ copy.fromLabel }</div>
-							<div className="border border-gray-300 rounded-[2px] min-h-12 px-[19px] flex items-center py-2">
+							<div className="whitespace-nowrap truncate">
 								{ syncFrom }
 							</div>
 						</div>
-						<div className="w-10 mt-[32px] h-12 flex items-center justify-center">
+						<div className="mt-[32px] w-[50px] flex items-center justify-center">
 							<RightArrowIcon />
 						</div>
-						<div className="flex-1">
+						<div className="overflow-hidden max-w-[calc(50%-25px)]">
 							<div className="leading-[32px]">{ copy.toLabel }</div>
-							<div className="border border-gray-300 rounded-[2px] min-h-12 px-[19px] flex items-center py-2">
+							<div className="whitespace-nowrap truncate">
 								{ syncTo }
 							</div>
 						</div>

--- a/src/modules/sync/components/sync-dialog.tsx
+++ b/src/modules/sync/components/sync-dialog.tsx
@@ -5,7 +5,11 @@ import { useI18n } from '@wordpress/react-i18n';
 import { useState, useEffect, useMemo } from 'react';
 import { ArrowIcon } from 'src/components/arrow-icon';
 import Button from 'src/components/button';
-import { EnvironmentBadge, StudioBadge, getSiteEnvironment } from 'src/components/environment-badge';
+import {
+	EnvironmentBadge,
+	StudioBadge,
+	getSiteEnvironment
+} from 'src/components/environment-badge';
 import { RightArrowIcon } from 'src/components/icons/right-arrow';
 import Modal from 'src/components/modal';
 import { TreeView, TreeNode, updateNodeById } from 'src/components/tree-view';
@@ -153,18 +157,14 @@ export function SyncDialog( {
 					>
 						<div className="overflow-hidden max-w-[calc(50%-25px)]">
 							<div className="leading-[32px]">{ copy.fromLabel }</div>
-							<div className="whitespace-nowrap truncate">
-								{ syncFrom }
-							</div>
+							<div className="whitespace-nowrap truncate">{ syncFrom }</div>
 						</div>
 						<div className="mt-[32px] w-[50px] flex items-center justify-center">
 							<RightArrowIcon />
 						</div>
 						<div className="overflow-hidden max-w-[calc(50%-25px)]">
 							<div className="leading-[32px]">{ copy.toLabel }</div>
-							<div className="whitespace-nowrap truncate">
-								{ syncTo }
-							</div>
+							<div className="whitespace-nowrap truncate">{ syncTo }</div>
 						</div>
 					</div>
 				</div>

--- a/src/modules/sync/hooks/use-sync-dialog-texts.tsx
+++ b/src/modules/sync/hooks/use-sync-dialog-texts.tsx
@@ -25,6 +25,10 @@ export const useSyncDialogTexts = ( type: 'pull' | 'push' ) => {
 						"Pulling will overwrite your Studio site's selected files and database with a copy from your production site. Unchecked items will not be changed."
 					),
 				},
+				studio: {
+					title: '',
+					description: '',
+				},
 				fromLabel: __( 'Pull' ),
 				toLabel: __( 'To' ),
 				subtitleSelector: __( 'What would you like to pull?' ),
@@ -50,6 +54,10 @@ export const useSyncDialogTexts = ( type: 'pull' | 'push' ) => {
 					description: __(
 						"Pushing will overwrite your production site's selected files and database with content from your local site. Unchecked items will not be changed. The production site will be backed up before any changes are applied."
 					),
+				},
+				studio: {
+					title: '',
+					description: '',
 				},
 				fromLabel: __( 'Push' ),
 				toLabel: __( 'To' ),

--- a/src/modules/sync/hooks/use-sync-dialog-texts.tsx
+++ b/src/modules/sync/hooks/use-sync-dialog-texts.tsx
@@ -25,10 +25,6 @@ export const useSyncDialogTexts = ( type: 'pull' | 'push' ) => {
 						"Pulling will overwrite your Studio site's selected files and database with a copy from your production site. Unchecked items will not be changed."
 					),
 				},
-				studio: {
-					title: '',
-					description: '',
-				},
 				fromLabel: __( 'Pull' ),
 				toLabel: __( 'To' ),
 				subtitleSelector: __( 'What would you like to pull?' ),
@@ -54,10 +50,6 @@ export const useSyncDialogTexts = ( type: 'pull' | 'push' ) => {
 					description: __(
 						"Pushing will overwrite your production site's selected files and database with content from your local site. Unchecked items will not be changed. The production site will be backed up before any changes are applied."
 					),
-				},
-				studio: {
-					title: '',
-					description: '',
 				},
 				fromLabel: __( 'Push' ),
 				toLabel: __( 'To' ),


### PR DESCRIPTION
## Related issues

- Fixes STU-599

## Proposed Changes

With this PR we are improving how long sitenames look inside the Sync dialog
<img width="582" alt="Screenshot 2025-07-09 at 15 02 17" src="https://github.com/user-attachments/assets/33917c37-96bc-4ec2-8823-fc6072416163" />

## Testing Instructions
1. Open Sync tab
2. Click on `Push` / `Pull`
3. Assert that short and long names look good (with ellipsis)<br /><img width="731" alt="Screenshot 2025-07-09 at 15 04 04" src="https://github.com/user-attachments/assets/ed7d3c5f-b534-47d2-8c24-9ed43c97bfd2" /><br /><img width="728" alt="Screenshot 2025-07-09 at 15 04 50" src="https://github.com/user-attachments/assets/e1227f68-6b1d-48dc-8126-036a2020e385" />

Open question is what to do if one site name is bigger then 50% and another one is smaller, but it's definitelly edge case to have so long name so I think we are good to go with the proposed implementation.

