### PR TITLE
Remove other files and folders option from pull

### DIFF
--- a/src/modules/sync/components/sync-dialog.tsx
+++ b/src/modules/sync/components/sync-dialog.tsx
@@ -77,7 +77,7 @@ export function SyncDialog( {
 	const locale = useI18nLocale();
 	const { __ } = useI18n();
 	const copy = useSyncDialogTexts( type );
-	const defaultTree = useDefaultSyncTree( type );
+	const defaultTree = useDefaultSyncTree();
 
 	const [ showAllFiles, setShowAllFiles ] = useState( false );
 	const [ treeState, setTreeState ] = useState< TreeNode[] >( defaultTree );

--- a/src/modules/sync/hooks/use-default-sync-tree.tsx
+++ b/src/modules/sync/hooks/use-default-sync-tree.tsx
@@ -3,7 +3,7 @@ import { useMemo } from 'react';
 import { TreeNode } from 'src/components/tree-view';
 import { SYNC_OPTIONS } from 'src/constants';
 
-export const useDefaultSyncTree = ( type: 'push' | 'pull' ): TreeNode[] => {
+export const useDefaultSyncTree = (): TreeNode[] => {
 	const { __ } = useI18n();
 
 	return useMemo( () => {
@@ -49,17 +49,6 @@ export const useDefaultSyncTree = ( type: 'push' | 'pull' ): TreeNode[] => {
 								type: 'folder',
 								expanded: false,
 							},
-							...( type === 'pull'
-								? [
-										{
-											id: SYNC_OPTIONS.contents,
-											name: SYNC_OPTIONS.contents,
-											label: __( 'Other files and directories' ),
-											checked: true,
-											type: 'more' as const,
-										},
-								  ]
-								: [] ),
 						],
 					},
 				],
@@ -71,5 +60,5 @@ export const useDefaultSyncTree = ( type: 'push' | 'pull' ): TreeNode[] => {
 				checked: true,
 			},
 		];
-	}, [ __, type ] );
+	}, [ __ ] );
 };

--- a/src/modules/sync/tests/convert-tree-to-options-to-sync.tsx
+++ b/src/modules/sync/tests/convert-tree-to-options-to-sync.tsx
@@ -5,7 +5,7 @@ import { convertTreeToOptionsToSync } from 'src/modules/sync/lib/convert-tree-to
 
 describe( 'convertTreeToOptionsToSync', () => {
 	it( 'returns ["all"] when all options are selected', () => {
-		const { result } = renderHook( () => useDefaultSyncTree( 'push' ) );
+		const { result } = renderHook( () => useDefaultSyncTree() );
 		const tree = result.current;
 
 		const optionsToSync = convertTreeToOptionsToSync( tree );
@@ -13,7 +13,7 @@ describe( 'convertTreeToOptionsToSync', () => {
 	} );
 
 	it( 'returns ["sqls"] when only database is selected', () => {
-		const { result } = renderHook( () => useDefaultSyncTree( 'push' ) );
+		const { result } = renderHook( () => useDefaultSyncTree() );
 		let tree = result.current;
 
 		tree = updateNodeById( tree, 'filesAndFolders', { checked: false } );
@@ -23,7 +23,7 @@ describe( 'convertTreeToOptionsToSync', () => {
 	} );
 
 	it( 'returns ["plugins"] when only plugins are selected', () => {
-		const { result } = renderHook( () => useDefaultSyncTree( 'push' ) );
+		const { result } = renderHook( () => useDefaultSyncTree() );
 		let tree = result.current;
 
 		tree = updateNodeById( tree, 'filesAndFolders', { checked: false } );
@@ -38,7 +38,7 @@ describe( 'convertTreeToOptionsToSync', () => {
 	} );
 
 	it( 'returns ["uploads"] when only uploads are selected', () => {
-		const { result } = renderHook( () => useDefaultSyncTree( 'push' ) );
+		const { result } = renderHook( () => useDefaultSyncTree() );
 		let tree = result.current;
 
 		tree = updateNodeById( tree, 'filesAndFolders', { checked: false } );
@@ -53,7 +53,7 @@ describe( 'convertTreeToOptionsToSync', () => {
 	} );
 
 	it( 'returns ["sqls", "plugins"] when both are selected', () => {
-		const { result } = renderHook( () => useDefaultSyncTree( 'push' ) );
+		const { result } = renderHook( () => useDefaultSyncTree() );
 		let tree = result.current;
 
 		tree = updateNodeById( tree, 'filesAndFolders', { checked: false } );
@@ -68,7 +68,7 @@ describe( 'convertTreeToOptionsToSync', () => {
 
 	describe( 'partial selections', () => {
 		it( 'returns partial plugins selection when only some plugins are selected', () => {
-			const { result } = renderHook( () => useDefaultSyncTree( 'push' ) );
+			const { result } = renderHook( () => useDefaultSyncTree() );
 			let tree = result.current;
 
 			tree = updateNodeById( tree, 'filesAndFolders', { checked: false } );
@@ -103,7 +103,7 @@ describe( 'convertTreeToOptionsToSync', () => {
 		} );
 
 		it( 'returns partial themes selection when only some themes are selected', () => {
-			const { result } = renderHook( () => useDefaultSyncTree( 'push' ) );
+			const { result } = renderHook( () => useDefaultSyncTree() );
 			let tree = result.current;
 
 			tree = updateNodeById( tree, 'filesAndFolders', { checked: false } );
@@ -139,7 +139,7 @@ describe( 'convertTreeToOptionsToSync', () => {
 		} );
 
 		it( 'returns partial uploads selection when only some uploads are selected', () => {
-			const { result } = renderHook( () => useDefaultSyncTree( 'push' ) );
+			const { result } = renderHook( () => useDefaultSyncTree() );
 			let tree = result.current;
 
 			tree = updateNodeById( tree, 'filesAndFolders', { checked: false } );
@@ -174,7 +174,7 @@ describe( 'convertTreeToOptionsToSync', () => {
 		} );
 
 		it( 'returns mixed partial selections for plugins and themes', () => {
-			const { result } = renderHook( () => useDefaultSyncTree( 'push' ) );
+			const { result } = renderHook( () => useDefaultSyncTree() );
 			let tree = result.current;
 
 			tree = updateNodeById( tree, 'filesAndFolders', { checked: false } );
@@ -219,7 +219,7 @@ describe( 'convertTreeToOptionsToSync', () => {
 		} );
 
 		it( 'returns no specificSelections when all children are selected in a category', () => {
-			const { result } = renderHook( () => useDefaultSyncTree( 'push' ) );
+			const { result } = renderHook( () => useDefaultSyncTree() );
 			let tree = result.current;
 
 			tree = updateNodeById( tree, 'filesAndFolders', { checked: false } );
@@ -250,7 +250,7 @@ describe( 'convertTreeToOptionsToSync', () => {
 		} );
 
 		it( 'returns no specificSelections when no children are selected in a category', () => {
-			const { result } = renderHook( () => useDefaultSyncTree( 'push' ) );
+			const { result } = renderHook( () => useDefaultSyncTree() );
 			let tree = result.current;
 
 			tree = updateNodeById( tree, 'filesAndFolders', { checked: false } );
@@ -281,7 +281,7 @@ describe( 'convertTreeToOptionsToSync', () => {
 		} );
 
 		it( 'handles mixed selection with database and partial plugins', () => {
-			const { result } = renderHook( () => useDefaultSyncTree( 'push' ) );
+			const { result } = renderHook( () => useDefaultSyncTree() );
 			let tree = result.current;
 
 			tree = updateNodeById( tree, 'filesAndFolders', { checked: false } );
@@ -315,7 +315,7 @@ describe( 'convertTreeToOptionsToSync', () => {
 	} );
 
 	it( 'strips folder type prefix from specific selections', () => {
-		const { result } = renderHook( () => useDefaultSyncTree( 'push' ) );
+		const { result } = renderHook( () => useDefaultSyncTree() );
 		let tree = result.current;
 
 		tree = updateNodeById( tree, 'plugins', {

--- a/src/modules/sync/tests/index.test.tsx
+++ b/src/modules/sync/tests/index.test.tsx
@@ -495,13 +495,13 @@ describe( 'ContentTabSync', () => {
 		const select = screen.getByRole( 'combobox', { name: 'Select files and folders to sync' } );
 		fireEvent.change( select, { target: { value: true } } );
 
-		fireEvent.click( screen.getByText( 'Other files and directories' ) );
+		fireEvent.click( screen.getByText( 'themes' ) );
 
 		const dialogPullButton = screen.getAllByRole( 'button', { name: /Pull/i } );
 		fireEvent.click( dialogPullButton[ 1 ] );
 
 		expect( mockPullSite ).toHaveBeenCalledWith( fakeSyncSite, selectedSite, {
-			optionsToSync: [ 'sqls', 'plugins', 'themes', 'uploads' ],
+			optionsToSync: [ 'sqls', 'plugins', 'uploads' ],
 		} );
 	} );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

Related to:
- #1552
- STU-618

## Proposed Changes

- Remove contents option from pull, as it seems to work only in same cases as the push did, with with mu-plugins and fonts 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run `npm start`
- Go to the sync tab and connect a site
- Click pull
- Select the dropdown to specific files
- Observe the Other files and folders option doesn't appear anymore

| Before | After |
|--------|--------|
| <img width="2064" height="1424" alt="Screenshot 2025-07-11 at 00 35 44" src="https://github.com/user-attachments/assets/86f2a549-9e76-4754-bafe-1b1acac28681" /> | <img width="2064" height="1424" alt="Screenshot 2025-07-11 at 00 30 27" src="https://github.com/user-attachments/assets/b7145df6-6861-4cd8-8174-a409cd7179da" /> |




## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
