### PR TITLE
add blueprints feature flag

### DIFF
--- a/src/hooks/use-feature-flags.tsx
+++ b/src/hooks/use-feature-flags.tsx
@@ -2,7 +2,7 @@ import * as Sentry from '@sentry/react';
 import React, { createContext, useContext, ReactNode, useState, useEffect } from 'react';
 import { useAuth } from 'src/hooks/use-auth';
 import { useIpcListener } from 'src/hooks/use-ipc-listener';
-import { FEATURE_FLAGS, FeatureFlags } from 'src/lib/feature-flags';
+import { FEATURE_FLAGS } from 'src/lib/feature-flags';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 
 export type FeatureFlagsContextType = FeatureFlags;

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -33,6 +33,7 @@ import {
 	trustRootCA,
 } from 'src/lib/certificate-manager';
 import { download } from 'src/lib/download';
+import { buildFeatureFlags } from 'src/lib/feature-flags';
 import { isEmptyDir, pathExists, sanitizeFolderName } from 'src/lib/fs-utils';
 import { getImageData } from 'src/lib/get-image-data';
 import { getSiteUrl } from 'src/lib/get-site-url';
@@ -73,7 +74,6 @@ import {
 	updateAppdata,
 } from 'src/storage/user-data';
 import { DEFAULT_PHP_VERSION, DEFAULT_WORDPRESS_VERSION } from 'vendor/wp-now/src/constants';
-import { buildFeatureFlags } from './lib/feature-flags';
 import type { SyncSite } from 'src/hooks/use-fetch-wpcom-sites/types';
 import type { WpCliResult } from 'src/lib/wp-cli-process';
 import type { GranularSyncFolders } from 'src/modules/sync/types';

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -73,6 +73,7 @@ import {
 	updateAppdata,
 } from 'src/storage/user-data';
 import { DEFAULT_PHP_VERSION, DEFAULT_WORDPRESS_VERSION } from 'vendor/wp-now/src/constants';
+import { buildFeatureFlags } from './lib/feature-flags';
 import type { SyncSite } from 'src/hooks/use-fetch-wpcom-sites/types';
 import type { WpCliResult } from 'src/lib/wp-cli-process';
 import type { GranularSyncFolders } from 'src/modules/sync/types';
@@ -882,6 +883,7 @@ export function getAppGlobals(): AppGlobals {
 		appName: app.name,
 		appVersion: app.getVersion(),
 		arm64Translation: app.runningUnderARM64Translation,
+		...buildFeatureFlags(),
 	};
 }
 

--- a/src/ipc-types.d.ts
+++ b/src/ipc-types.d.ts
@@ -84,7 +84,12 @@ type IpcApi = {
 	getPathForFile: ( file: File ) => string;
 };
 
-interface AppGlobals {
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+interface FeatureFlags {
+	enableBlueprints: boolean;
+}
+
+interface AppGlobals extends FeatureFlags {
 	platform: NodeJS.Platform;
 	appName: string;
 	appVersion: string;

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -5,7 +5,7 @@ export interface FeatureFlagDefinition {
 	default: boolean;
 }
 
-export const FEATURE_FLAGS_DEFINITION = {
+export const FEATURE_FLAGS_DEFINITION: Record< keyof FeatureFlags, FeatureFlagDefinition > = {
 	enableBlueprints: {
 		label: 'Enable Blueprints',
 		env: 'ENABLE_BLUEPRINTS',
@@ -16,11 +16,6 @@ export const FEATURE_FLAGS_DEFINITION = {
 
 export const FEATURE_FLAGS: Record< keyof FeatureFlags, FeatureFlagDefinition > =
 	FEATURE_FLAGS_DEFINITION;
-
-// Automatically generate the FeatureFlags interface from the FEATURE_FLAGS object
-export type FeatureFlags = {
-	[ K in keyof typeof FEATURE_FLAGS_DEFINITION ]: boolean;
-};
 
 export function getFeatureFlagFromEnv( flag: keyof FeatureFlags ): boolean {
 	const flagDefinition = FEATURE_FLAGS[ flag ] as FeatureFlagDefinition | undefined;
@@ -42,10 +37,12 @@ export function setFeatureFlagInEnv( flag: keyof FeatureFlags, value: boolean ):
  * Builds a FeatureFlags object with current values from environment variables
  */
 export function buildFeatureFlags(): FeatureFlags {
-	return Object.fromEntries(
-		Object.keys( FEATURE_FLAGS ).map( ( key ) => [
-			key,
-			getFeatureFlagFromEnv( key as keyof FeatureFlags ),
-		] )
-	) as FeatureFlags;
+	const flags: Partial< FeatureFlags > = {};
+	const keys = Object.keys( FEATURE_FLAGS );
+	keys.forEach( ( key ) => {
+		( flags as Record< string, boolean > )[ key ] = getFeatureFlagFromEnv(
+			key as keyof FeatureFlags
+		);
+	} );
+	return flags as FeatureFlags;
 }

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -5,10 +5,22 @@ export interface FeatureFlagDefinition {
 	default: boolean;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export interface FeatureFlags {}
+export const FEATURE_FLAGS_DEFINITION = {
+	enableBlueprints: {
+		label: 'Enable Blueprints',
+		env: 'ENABLE_BLUEPRINTS',
+		flag: 'enableBlueprints',
+		default: false,
+	},
+} as const;
 
-export const FEATURE_FLAGS: Record< keyof FeatureFlags, FeatureFlagDefinition > = {};
+export const FEATURE_FLAGS: Record< keyof FeatureFlags, FeatureFlagDefinition > =
+	FEATURE_FLAGS_DEFINITION;
+
+// Automatically generate the FeatureFlags interface from the FEATURE_FLAGS object
+export type FeatureFlags = {
+	[ K in keyof typeof FEATURE_FLAGS_DEFINITION ]: boolean;
+};
 
 export function getFeatureFlagFromEnv( flag: keyof FeatureFlags ): boolean {
 	const flagDefinition = FEATURE_FLAGS[ flag ] as FeatureFlagDefinition | undefined;
@@ -24,4 +36,16 @@ export function setFeatureFlagInEnv( flag: keyof FeatureFlags, value: boolean ):
 		return;
 	}
 	process.env[ flagDefinition.env ] = value ? 'true' : 'false';
+}
+
+/**
+ * Builds a FeatureFlags object with current values from environment variables
+ */
+export function buildFeatureFlags(): FeatureFlags {
+	return Object.fromEntries(
+		Object.keys( FEATURE_FLAGS ).map( ( key ) => [
+			key,
+			getFeatureFlagFromEnv( key as keyof FeatureFlags ),
+		] )
+	) as FeatureFlags;
 }

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -13,7 +13,6 @@ import { sendIpcEventToRenderer } from 'src/ipc-utils';
 import {
 	FEATURE_FLAGS,
 	FeatureFlagDefinition,
-	FeatureFlags,
 	getFeatureFlagFromEnv,
 	setFeatureFlagInEnv,
 } from 'src/lib/feature-flags';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-621

## Proposed Changes

- Adds feature flag for blueprints project

<img width="449" height="346" alt="image" src="https://github.com/user-attachments/assets/406f9620-c165-47b2-9328-8d110831e8f8" />

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Code review
- Run `npm start` and `ENABLE_BLUEPRINTS=true npm start`
- Both should work and set the correct value for the feature flag (you can confirm on the app menu as shown above)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
