### PR TITLE
Disable the what's new modal for new patch version

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -89,4 +89,4 @@ export const IPC_VOID_HANDLERS = < const >[
 ];
 
 // What's New
-export const FORCE_WHATS_NEW_WHEN_PATCH_CHANGED = true;
+export const FORCE_WHATS_NEW_WHEN_PATCH_CHANGED = false;

--- a/src/stores/app-version-api.ts
+++ b/src/stores/app-version-api.ts
@@ -61,7 +61,11 @@ function isGreaterExceptPatch( versionA: string | undefined, versionB: string ):
 	const a = semver.parse( versionA )!;
 	const b = semver.parse( versionB )!;
 
-	if ( a.major === b.major && a.minor === b.minor && a.patch !== b.patch ) {
+	if (
+		a.major === b.major &&
+		a.minor === b.minor &&
+		( a.patch !== b.patch || a.prerelease?.length !== b.prerelease?.length )
+	) {
 		return FORCE_WHATS_NEW_WHEN_PATCH_CHANGED;
 	}
 	return true;

--- a/src/stores/tests/app-version-api.test.ts
+++ b/src/stores/tests/app-version-api.test.ts
@@ -98,13 +98,13 @@ describe( 'App Version API', () => {
 			expect( result ).toBe( false );
 		} );
 
-		it( 'should return true for a new patch version', () => {
+		it( "should return true or false depending on whether force what's new is enabled for a new patch version", () => {
 			const lastSeenVersion = '1.2.0';
 			const currentVersion = '1.2.1';
 
 			const result = selectIsNewVersion( createMockQueryResult( lastSeenVersion ), currentVersion );
 
-			expect( result ).toBe( true );
+			expect( result ).toBe( FORCE_WHATS_NEW_WHEN_PATCH_CHANGED );
 		} );
 
 		it( 'should return true when going from a stable version to a prerelease version', () => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-595

## Proposed Changes

- Disable constant that forces displaying the what's new modal for patch versions

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Open the Studio config file `~/Library/Application Support/Studio/appdata-v1.json`
- Add or update this property: `"lastSeenVersion": "1.5.4",`.
- Run npm start
- Observe the what's new mdoal doesn't open automatically
- Observe the `"lastSeenVersion": "1.5.4",` has the same value.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
