### PR TITLE
Migrate blueberry to blue and clean up Tailwind config

### DIFF
--- a/src/components/ai-input.tsx
+++ b/src/components/ai-input.tsx
@@ -213,7 +213,7 @@ const UnforwardedAIInput = (
 		<div
 			className={ cx(
 				`flex items-end w-full border rounded-sm bg-white/[0.9] ${
-					disabled ? 'border-a8c-gray-5' : 'border-gray-300 focus-within:border-a8c-blueberry'
+					disabled ? 'border-a8c-gray-5' : 'border-gray-300 focus-within:border-a8c-blue-50'
 				}`
 			) }
 		>

--- a/src/components/assistant-thinking.tsx
+++ b/src/components/assistant-thinking.tsx
@@ -7,12 +7,12 @@ export function MessageThinking() {
 			className="flex justify-center items-center gap-1 p-0.5 min-h-5"
 		>
 			<div
-				className="animate-pulse h-1.5 w-1.5 bg-a8c-blueberry rounded-full"
+				className="animate-pulse h-1.5 w-1.5 bg-a8c-blue-50 rounded-full"
 				style={ { animationDelay: '0.2s' } }
 			/>
-			<div className="animate-pulse h-1.5 w-1.5 bg-a8c-blueberry rounded-full" />
+			<div className="animate-pulse h-1.5 w-1.5 bg-a8c-blue-50 rounded-full" />
 			<div
-				className="animate-pulse h-1.5 w-1.5 bg-a8c-blueberry rounded-full"
+				className="animate-pulse h-1.5 w-1.5 bg-a8c-blue-50 rounded-full"
 				style={ { animationDelay: '0.4s' } }
 			/>
 		</div>

--- a/src/components/button.tsx
+++ b/src/components/button.tsx
@@ -37,7 +37,7 @@ disabled:cursor-not-allowed
 aria-disabled:cursor-not-allowed
 [&.components-button]:focus:shadow-[inset_0_0_0_1px_transparent]
 [&.components-button]:focus-visible:shadow-[0_0_0_1px_#3858E9]
-[&.components-button]:focus-visible:shadow-a8c-blueberry
+[&.components-button]:focus-visible:shadow-a8c-blue-50
 [&.components-button.is-destructive]:focus-visible:shadow-a8c-red-50
 [&_svg]:shrink-0
 `.replace( /\n/g, ' ' );
@@ -52,8 +52,8 @@ const secondaryStyles = `
 [&.is-secondary]:shadow-[inset_0_0_0_1px_black]
 [&.is-secondary]:shadow-a8c-gray-5
 [&.is-secondary]:focus:shadow-a8c-gray-5
-[&.is-secondary]:focus-visible:shadow-a8c-blueberry
-[&.is-secondary:not(.is-destructive,:disabled,[aria-disabled=true])]:hover:text-a8c-blueberry
+[&.is-secondary]:focus-visible:shadow-a8c-blue-50
+[&.is-secondary:not(.is-destructive,:disabled,[aria-disabled=true])]:hover:text-a8c-blue-50
 [&.is-secondary:not(.is-destructive,:disabled,[aria-disabled=true])]:active:text-black
 [&.is-secondary:disabled:not(:focus)]:shadow-[inset_0_0_0_1px_black]
 [&.is-secondary:disabled:not(:focus)]:shadow-a8c-gray-5
@@ -74,7 +74,7 @@ text-white
 [&.components-button.outlined]:focus:shadow-[inset_0_0_0_1px_white]
 [&.components-button]:focus-visible:outline-none
 [&.components-button.outlined]:focus-visible:shadow-[inset_0_0_0_1px_#3858E9]
-[&.components-button]:focus-visible:shadow-a8c-blueberry
+[&.components-button]:focus-visible:shadow-a8c-blue-50
 `.replace( /\n/g, ' ' );
 
 const destructiveStyles = `

--- a/src/components/content-tab-import-export.tsx
+++ b/src/components/content-tab-import-export.tsx
@@ -82,7 +82,7 @@ export const ExportSite = ( {
 							type="submit"
 							variant="secondary"
 							className={ cx(
-								isExportDisabled ? '' : '!text-a8c-blueberry !shadow-a8c-blueberry'
+								isExportDisabled ? '' : '!text-a8c-blue-50 !shadow-a8c-blue-50'
 							) }
 							disabled={ isExportDisabled }
 						>
@@ -128,7 +128,7 @@ const InitialImportButton = ( {
 					'w-full',
 					disabled
 						? '[&>div.border-zinc-300]:border-gray-400 cursor-not-allowed opacity-50'
-						: '[&>div.border-zinc-300]:hover:border-a8c-blueberry'
+						: '[&>div.border-zinc-300]:hover:border-a8c-blue-50'
 				) }
 				onClick={ openFileSelector }
 				disabled={ disabled }
@@ -239,7 +239,7 @@ const ImportSite = ( {
 					<div
 						className={ cx(
 							'h-36 w-full rounded-sm border border-zinc-300 flex-col justify-center items-center inline-flex',
-							isDraggingOver && ! isImporting && 'border-a8c-blueberry bg-a8c-gray-0'
+							isDraggingOver && ! isImporting && 'border-a8c-blue-50 bg-a8c-gray-0'
 						) }
 					>
 						{ isImporting && (

--- a/src/components/content-tab-import-export.tsx
+++ b/src/components/content-tab-import-export.tsx
@@ -81,9 +81,7 @@ export const ExportSite = ( {
 							onClick={ () => handleExport( exportDatabase ) }
 							type="submit"
 							variant="secondary"
-							className={ cx(
-								isExportDisabled ? '' : '!text-a8c-blue-50 !shadow-a8c-blue-50'
-							) }
+							className={ cx( isExportDisabled ? '' : '!text-a8c-blue-50 !shadow-a8c-blue-50' ) }
 							disabled={ isExportDisabled }
 						>
 							{ __( 'Export database' ) }

--- a/src/components/content-tab-overview.tsx
+++ b/src/components/content-tab-overview.tsx
@@ -224,7 +224,7 @@ export function ContentTabOverview( { selectedSite }: ContentTabOverviewProps ) 
 						'w-full min-h-40 max-h-64 rounded-sm border border-a8c-gray-5 bg-a8c-gray-0 mb-2 flex justify-center',
 						loading && `h-64 ${ skeletonBg }`,
 						isThumbnailError && 'border-none',
-						! loading && 'hover:border-a8c-blueberry duration-300'
+						! loading && 'hover:border-a8c-blue-50 duration-300'
 					) }
 				>
 					{ isThumbnailError && ! loading && (
@@ -236,7 +236,7 @@ export function ContentTabOverview( { selectedSite }: ContentTabOverviewProps ) 
 						<button
 							aria-label={ __( 'Open site' ) }
 							className={ cx(
-								'relative group focus-visible:outline-a8c-blueberry',
+								'relative group focus-visible:outline-a8c-blue-50',
 								isServerLoading && 'cursor-not-allowed'
 							) }
 							onClick={ handleThumbnailClick }
@@ -244,7 +244,7 @@ export function ContentTabOverview( { selectedSite }: ContentTabOverviewProps ) 
 						>
 							<div
 								className={
-									'opacity-0 group-hover:opacity-90 group-hover:bg-white group-focus:opacity-90 group-focus:bg-white duration-300 absolute size-full flex justify-center items-center bg-white text-a8c-blueberry'
+									'opacity-0 group-hover:opacity-90 group-hover:bg-white group-focus:opacity-90 group-focus:bg-white duration-300 absolute size-full flex justify-center items-center bg-white text-a8c-blue-50'
 								}
 							>
 								{ __( 'Open site' ) }

--- a/src/components/content-tab-previews.tsx
+++ b/src/components/content-tab-previews.tsx
@@ -62,7 +62,7 @@ function EmptyGeneric( {
 							key={ typeof text === 'string' ? text : 'wordpress-com' }
 							className="text-a8c-gray-70 a8c-body flex items-center"
 						>
-							<Icon className="fill-a8c-blueberry ltr:mr-2 rtl:ml-2 shrink-0" icon={ check } />
+							<Icon className="fill-a8c-blue-50 ltr:mr-2 rtl:ml-2 shrink-0" icon={ check } />
 							{ text }
 						</div>
 					) ) }
@@ -114,7 +114,7 @@ function NoAuth( { selectedSite }: React.ComponentProps< typeof EmptyGeneric > )
 						<Button
 							aria-description={ isOffline ? offlineMessage : '' }
 							aria-disabled={ isOffline }
-							className="!p-0 text-a8c-blueberry hover:opacity-80 h-auto inline-flex items-center"
+							className="!p-0 text-a8c-blue-50 hover:opacity-80 h-auto inline-flex items-center"
 							onClick={ () => {
 								if ( isOffline ) {
 									return;

--- a/src/components/default-error-fallback.tsx
+++ b/src/components/default-error-fallback.tsx
@@ -76,7 +76,7 @@ const RightPanel = () => {
 			</div>
 			<div>
 				<Button
-					className="bg-a8c-blueberry hover:text-white text-white"
+					className="bg-a8c-blue-50 hover:text-white text-white"
 					variant="primary"
 					onClick={ () => window.location.reload() }
 				>

--- a/src/components/drag-and-drop-overlay.tsx
+++ b/src/components/drag-and-drop-overlay.tsx
@@ -4,7 +4,7 @@ import { download, Icon } from '@wordpress/icons';
 const DragAndDropOverlay = () => {
 	return (
 		<div className="absolute inset-0 bg-white bg-opacity-80 z-10 backdrop-blur-sm flex flex-col items-center justify-center">
-			<Icon width={ 49 } height={ 51 } icon={ download } className="fill-a8c-blueberry" />
+			<Icon width={ 49 } height={ 51 } icon={ download } className="fill-a8c-blue-50" />
 			<span className="text-[13px] leading-[16px] text-black mt-4">
 				{ __( 'Drop backup to import' ) }
 			</span>

--- a/src/components/environment-badge.tsx
+++ b/src/components/environment-badge.tsx
@@ -17,7 +17,7 @@ interface EnvironmentBadgeProps {
 export function EnvironmentBadge( { type, selected, className }: EnvironmentBadgeProps ) {
 	const getClassName = () => {
 		if ( selected ) {
-			return 'bg-white text-a8c-blueberry text-a8c-blueberry';
+			return 'bg-white text-a8c-blue-50 text-a8c-blue-50';
 		}
 
 		if ( type === 'production' ) {

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -40,7 +40,7 @@ export default function Header() {
 					</h1>
 					<div className="flex mt-1 gap-x-4">
 						<Button
-							className="[&.is-link]:text-a8c-gray-70 [&.is-link]:hover:text-a8c-blueberry !px-0 h-0 leading-4"
+							className="[&.is-link]:text-a8c-gray-70 [&.is-link]:hover:text-a8c-blue-50 !px-0 h-0 leading-4"
 							onClick={ handleWpAdminClick }
 							variant="link"
 							disabled={ isLoading }
@@ -49,7 +49,7 @@ export default function Header() {
 							<ArrowIcon />
 						</Button>
 						<Button
-							className="[&.is-link]:text-a8c-gray-70 [&.is-link]:hover:text-a8c-blueberry !px-0 h-0 leading-4"
+							className="[&.is-link]:text-a8c-gray-70 [&.is-link]:hover:text-a8c-blue-50 !px-0 h-0 leading-4"
 							onClick={ handleOpenSiteClick }
 							variant="link"
 							disabled={ isLoading }

--- a/src/components/onboarding.tsx
+++ b/src/components/onboarding.tsx
@@ -146,7 +146,7 @@ export default function Onboarding() {
 
 	return (
 		<div className="flex flex-row flex-grow" data-testid="onboarding">
-			<div className="w-1/2 bg-a8c-blueberry pb-[50px] pt-[46px] px-[50px] flex flex-col justify-between">
+			<div className="w-1/2 bg-a8c-blue-50 pb-[50px] pt-[46px] px-[50px] flex flex-col justify-between">
 				<div className="flex justify-end fill-white items-center gap-1">
 					<Icon size={ 24 } icon={ wordpress } />
 				</div>

--- a/src/components/progress-bar.tsx
+++ b/src/components/progress-bar.tsx
@@ -14,7 +14,7 @@ const ProgressBar = ( { value, maxValue }: ProgressBarProps ) => {
 			<div
 				role="progressbar"
 				aria-valuenow={ fillPercentage }
-				className="h-full bg-a8c-blueberry rounded-[4.5px] transition-all"
+				className="h-full bg-a8c-blue-50 rounded-[4.5px] transition-all"
 				style={ {
 					width: `${ fillPercentage }%`,
 				} }

--- a/src/components/site-form.tsx
+++ b/src/components/site-form.tsx
@@ -122,7 +122,7 @@ function FormPathInputComponent( {
 				type="button"
 				aria-label={ `${ value }, ${ __( 'Select different local path' ) }` }
 				className={ cx(
-					'flex flex-row items-stretch rounded-sm border border-[#949494] focus:border-a8c-blueberry focus:shadow-[0_0_0_0.5px_black] focus:shadow-a8c-blueberry outline-none transition-shadow transition-linear duration-100 [&_.local-path-icon]:focus:border-l-a8c-blueberry [&:disabled]:cursor-not-allowed',
+					'flex flex-row items-stretch rounded-sm border border-[#949494] focus:border-a8c-blue-50 focus:shadow-[0_0_0_0.5px_black] focus:shadow-a8c-blue-50 outline-none transition-shadow transition-linear duration-100 [&_.local-path-icon]:focus:border-l-a8c-blue-50 [&:disabled]:cursor-not-allowed',
 					error ? 'border-red-500 [&_.local-path-icon]:border-l-red-500' : ''
 				) }
 				data-testid="select-path-button"
@@ -191,7 +191,7 @@ function FormImportComponent( {
 					type="button"
 					aria-label={ `${ value }, ${ __( 'Select different file' ) }` }
 					className={ cx(
-						'flex items-center flex-grow rounded-sm border border-[#949494] focus:border-a8c-blueberry focus:shadow-[0_0_0_0.5px_black] focus:shadow-a8c-blueberry outline-none transition-shadow transition-linear duration-100 [&_.local-path-icon]:focus:border-l-a8c-blueberry [&:disabled]:cursor-not-allowed',
+						'flex items-center flex-grow rounded-sm border border-[#949494] focus:border-a8c-blue-50 focus:shadow-[0_0_0_0.5px_black] focus:shadow-a8c-blue-50 outline-none transition-shadow transition-linear duration-100 [&_.local-path-icon]:focus:border-l-a8c-blue-50 [&:disabled]:cursor-not-allowed',
 						error ? 'border-red-500 [&_.local-path-icon]:border-l-red-500' : '',
 						fileName ? 'border-r-0 rounded-r-none focus:border' : ''
 					) }

--- a/src/components/site-menu.tsx
+++ b/src/components/site-menu.tsx
@@ -76,7 +76,7 @@ function ButtonToRun( { running, id, name }: Pick< SiteDetails, 'running' | 'id'
 					}
 					return running ? stopServer( id ) : startServer( id );
 				} }
-				className="w-7 h-8 rounded-tr rounded-br group grid focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-a8c-blueberry"
+				className="w-7 h-8 rounded-tr rounded-br group grid focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-a8c-blue-50"
 				aria-label={ sprintf( running ? __( 'stop %s site' ) : __( 'start %s site' ), name ) }
 			>
 				{ /* Circle */ }
@@ -137,7 +137,7 @@ function SiteItem( { site }: { site: SiteDetails } ) {
 			) }
 		>
 			<button
-				className="p-2 text-xs rounded-tl rounded-bl whitespace-nowrap overflow-hidden text-ellipsis w-full text-left rtl:text-right focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-a8c-blueberry"
+				className="p-2 text-xs rounded-tl rounded-bl whitespace-nowrap overflow-hidden text-ellipsis w-full text-left rtl:text-right focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-a8c-blue-50"
 				onClick={ () => {
 					setSelectedSiteId( site.id );
 				} }

--- a/src/components/tests/environment-badge.test.tsx
+++ b/src/components/tests/environment-badge.test.tsx
@@ -57,6 +57,6 @@ describe( 'EnvironmentBadge', () => {
 		expect( badgeElement ).toBeInTheDocument();
 
 		expect( badgeElement.className ).toContain( 'bg-white' );
-		expect( badgeElement.className ).toContain( 'text-a8c-blueberry' );
+		expect( badgeElement.className ).toContain( 'text-a8c-blue-50' );
 	} );
 } );

--- a/src/index.css
+++ b/src/index.css
@@ -152,8 +152,8 @@ blockquote {
 }
 
 .assistant-markdown code.file-block {
-	color: theme( 'colors.a8c-blueberry' );
-	fill: theme( 'colors.a8c-blueberry' );
+	color: theme( 'colors.a8c-blue.50' );
+	fill: theme( 'colors.a8c-blue.50' );
 	display: inline-flex;
 	align-items: center;
 	padding: 0 0 0 3px;
@@ -161,8 +161,8 @@ blockquote {
 }
 
 .assistant-markdown code.file-block:hover {
-	color: theme( 'colors.a8c-blueberry-70' );
-	fill: theme( 'colors.a8c-blueberry-70' );
+	color: theme( 'colors.a8c-blue.70' );
+	fill: theme( 'colors.a8c-blue.70' );
 }
 
 .assistant-markdown pre {
@@ -293,7 +293,7 @@ blockquote {
 
 .components-button.components-guide__back-button {
 	outline: none;
-	border: 1px solid theme( 'colors.a8c-blueberry' );
+	border: 1px solid theme( 'colors.a8c-blue.50' );
 }
 
 .sync-dialog-wrapper .components-modal__header {

--- a/src/modules/preview-site/components/preview-site-row.tsx
+++ b/src/modules/preview-site/components/preview-site-row.tsx
@@ -124,7 +124,7 @@ export function PreviewSiteRow( {
 						disabled={ isExpired }
 						className={ cx(
 							'!text-a8c-gray-700 max-w-full',
-							isExpired ? 'pointer-events-none' : 'hover:!text-a8c-blueberry'
+							isExpired ? 'pointer-events-none' : 'hover:!text-a8c-blue-50'
 						) }
 						onClick={ () => getIpcApi().openURL( `https://${ url }` ) }
 					>
@@ -163,7 +163,7 @@ export function PreviewSiteRow( {
 										} )
 									);
 								} }
-								className={ '!text-a8c-blueberry hover:!text-a8c-red-50' }
+								className={ '!text-a8c-blue-50 hover:!text-a8c-red-50' }
 							>
 								{ __( 'Clear' ) }
 							</Button>

--- a/src/modules/sync/components/connect-button.tsx
+++ b/src/modules/sync/components/connect-button.tsx
@@ -34,7 +34,7 @@ export const ConnectButton = ( {
 				aria-disabled={ isOffline }
 				variant={ variant }
 				className={ cx(
-					! disableConnectButtonStyle && ! isOffline && '!text-a8c-blueberry !shadow-a8c-blueberry',
+					! disableConnectButtonStyle && ! isOffline && '!text-a8c-blue-50 !shadow-a8c-blue-50',
 					className
 				) }
 			>

--- a/src/modules/sync/components/create-button.tsx
+++ b/src/modules/sync/components/create-button.tsx
@@ -35,7 +35,7 @@ export const CreateButton = ( {
 					);
 				} }
 				variant={ variant }
-				className={ cx( ! isOffline && '!text-a8c-blueberry !shadow-a8c-blueberry', className ) }
+				className={ cx( ! isOffline && '!text-a8c-blue-50 !shadow-a8c-blue-50', className ) }
 				disabled={ isOffline }
 				aria-disabled={ isOffline }
 			>

--- a/src/modules/sync/components/sync-connected-sites.tsx
+++ b/src/modules/sync/components/sync-connected-sites.tsx
@@ -98,7 +98,7 @@ const SyncConnectedSiteControls = ( {
 								! isOffline &&
 									! isAnySitePulling &&
 									! isAnySitePushing &&
-									'!text-black hover:!text-a8c-blueberry'
+									'!text-black hover:!text-a8c-blue-50'
 							) }
 							onClick={ () => setSyncDialogType( 'pull' ) }
 							disabled={ isAnySiteSyncing || isOffline }
@@ -138,7 +138,7 @@ const SyncConnectedSiteControls = ( {
 								! isOffline &&
 									! isAnySitePulling &&
 									! isAnySitePushing &&
-									'!text-black hover:!text-a8c-blueberry'
+									'!text-black hover:!text-a8c-blue-50'
 							) }
 							onClick={ () => setSyncDialogType( 'push' ) }
 							disabled={ isAnySiteSyncing || isOffline }
@@ -218,7 +218,7 @@ const SyncConnectedSitesList = ( {
 
 						<Button
 							variant="link"
-							className="!text-a8c-gray-70 hover:!text-a8c-blueberry max-w-full overflow-hidden"
+							className="!text-a8c-gray-70 hover:!text-a8c-blue-50 max-w-full overflow-hidden"
 							onClick={ () => {
 								getIpcApi().openURL( connectedSite.url );
 							} }

--- a/src/modules/sync/components/sync-sites-modal-selector.tsx
+++ b/src/modules/sync/components/sync-sites-modal-selector.tsx
@@ -215,11 +215,11 @@ function SiteItem( {
 		<div
 			className={ cx(
 				'flex py-3 px-8 items-center border-b justify-between gap-4',
-				isSelected && 'bg-a8c-blueberry text-white border-a8c-blueberry',
+				isSelected && 'bg-a8c-blue-50 text-white border-a8c-blue-50',
 				! isSelected && 'border-a8c-gray-0',
-				! isSelected && isSyncable && 'hover:bg-a8c-blueberry-5',
+				! isSelected && isSyncable && 'hover:bg-a8c-blue-5',
 				isSyncable &&
-					'focus:outline-none focus:ring-1 focus:ring-a8c-blueberry focus:relative focus:z-10'
+					'focus:outline-none focus:ring-1 focus:ring-a8c-blue-50 focus:relative focus:z-10'
 			) }
 			role={ isSyncable ? 'button' : undefined }
 			tabIndex={ isSyncable ? 0 : -1 }

--- a/src/modules/sync/index.tsx
+++ b/src/modules/sync/index.tsx
@@ -37,7 +37,7 @@ function SiteSyncDescription( { children }: PropsWithChildren ) {
 						__( 'Sync database and file changes.' ),
 					].map( ( text ) => (
 						<div key={ text } className="text-a8c-gray-70 a8c-body flex items-center">
-							<Icon className="fill-a8c-blueberry me-2 shrink-0" icon={ check } />
+							<Icon className="fill-a8c-blue-50 me-2 shrink-0" icon={ check } />
 							{ text }
 						</div>
 					) ) }
@@ -89,7 +89,7 @@ function NoAuthSyncTab() {
 						<Button
 							aria-description={ isOffline ? offlineMessage : '' }
 							aria-disabled={ isOffline }
-							className="!p-0 text-a8c-blueberry hover:opacity-80 h-auto inline-flex items-center"
+							className="!p-0 text-a8c-blue-50 hover:opacity-80 h-auto inline-flex items-center"
 							onClick={ () => {
 								if ( isOffline ) {
 									return;

--- a/src/modules/whats-new/components/whats-new-modal.tsx
+++ b/src/modules/whats-new/components/whats-new-modal.tsx
@@ -45,7 +45,7 @@ const PageContent = ( {
 			{ learnMoreUrl && (
 				<button
 					onClick={ () => getIpcApi().openURL( learnMoreUrl ) }
-					className="text-a8c-blueberry text-m leading-s cursor-pointer"
+					className="text-a8c-blue-50 text-m leading-s cursor-pointer"
 				>
 					{ __( 'Learn more' ) }
 				</button>
@@ -125,7 +125,7 @@ export default function WhatsNewModal( { showModal, onClose }: WhatsNewModalProp
 			onFinish={ onClose }
 			contentLabel={ __( "What's New in Studio" ) }
 			className={ cx(
-				"whats-new-modal !w-[360px] !h-[470px] overflow-hidden [&_button[aria-label='Close']_svg]:fill-white [&_.components-button.is-tertiary]:!outline-1 [&_.components-button.is-tertiary]:!outline-solid [&_.components-button.is-tertiary]:!outline-a8c-blueberry",
+				"whats-new-modal !w-[360px] !h-[470px] overflow-hidden [&_button[aria-label='Close']_svg]:fill-white [&_.components-button.is-tertiary]:!outline-1 [&_.components-button.is-tertiary]:!outline-solid [&_.components-button.is-tertiary]:!outline-a8c-blue-50",
 				'[&_*]:select-none',
 				'focus:outline-none'
 			) }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -127,11 +127,8 @@ for ( const [ key, value ] of Object.entries( palette.colors ) ) {
 	a8cToTailwindColors[ colorName ][ shade ] = value;
 }
 
-// These colors are in the palette but not included because the color name contains more than one word.
-// Reference: https://github.com/Automattic/color-studio/blob/55218ffdaecc770cd697639071f1d2083f744f66/dist/colors.json#L123-L187
-a8cToTailwindColors[ `${ PREFIX }-blueberry-5` ] = '#F7F8FE'; // WordPress Blue 5
-a8cToTailwindColors[ `${ PREFIX }-blueberry` ] = '#3858E9'; // WordPress Blue
-a8cToTailwindColors[ `${ PREFIX }-blueberry-70` ] = '#1d35b4'; // WordPress Blue 70
+// These colors are not in the color studio but are used in the design system.
+// Reference: https://github.com/WordPress/gutenberg/blob/trunk/packages/base-styles/_colors.scss
 a8cToTailwindColors[ `${ PREFIX }-gray-700` ] = '#757575'; // Gray 700
 a8cToTailwindColors[ `${ PREFIX }-gray-400` ] = '#CCC'; // Gray 400
 a8cToTailwindColors[ `${ PREFIX }-gray-600` ] = '#949494'; // Gray 600


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

It's a follow-up to https://github.com/Automattic/studio/pull/1565, which implements changes from https://github.com/Automattic/color-studio/pull/764

## Proposed Changes

I propose cleaning up the custom Tailwind colors configuration to follow the Blueberry -> Blue color cleanup made in the color studio.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Confirm if colors in Studio, especially blue, are still correct.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
