### PR TITLE
Add uniques monthly bump stat

### DIFF
--- a/common/types/stats.ts
+++ b/common/types/stats.ts
@@ -3,6 +3,7 @@ export enum StatsGroup {
 	STUDIO_APP_LAUNCH = 'studio-app-launch-first',
 	STUDIO_APP_LAUNCH_TOTAL = 'studio-app-launch-total',
 	STUDIO_APP_LAUNCH_UNIQUE = 'studio-app-launch-uniques',
+	STUDIO_APP_LAUNCH_UNIQUE_MONTHLY = 'studio-app-launch-uniques-monthly',
 	STUDIO_IMPORT = 'studio-app-import',
 	STUDIO_EXPORT = 'studio-app-export',
 	// Studio CLI

--- a/src/index.ts
+++ b/src/index.ts
@@ -310,6 +310,12 @@ async function appBoot() {
 			getPlatformMetric( process.platform ),
 			'weekly'
 		);
+		// Bump stat for unique monthly app launch, approximates monthly active users
+		bumpAggregatedUniqueStat(
+			StatsGroup.STUDIO_APP_LAUNCH_UNIQUE_MONTHLY,
+			getPlatformMetric( process.platform ),
+			'monthly'
+		);
 
 		await installCLIOnWindows();
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-606

## Proposed Changes

- Bump unique monthly anonymous Studio launch

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Open your Studio config: `~/Library/Application Support/Studio/appdata-v1.json`
- Observe a section with `lastBumpStats`
- Observe the property `studio-app-launch-uniques-monthly` doesn't exist.
- Run `npm start`
- Open the same Studio config, and observe a new property `studio-app-launch-uniques-monthly`
- See in the node logs the following messages:
```
Would have bumped stat: studio-app-launch-total=darwin
Would have bumped stat: studio-app-launch-uniques-monthly=darwin
Would have bumped stat: studio-app-launch-uniques=darwin
```



https://github.com/user-attachments/assets/ac04e8dc-842d-474a-a6ea-3958ba6af6d1



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
