### PR TITLE
Open Overview tab after deleting and creating site

### DIFF
--- a/src/components/root.tsx
+++ b/src/components/root.tsx
@@ -26,21 +26,21 @@ const Root = () => {
 			<ReduxProvider store={ store }>
 				<I18nProvider i18n={ defaultI18n }>
 					<AuthProvider>
-						<SiteDetailsProvider>
-							<FeatureFlagsProvider>
-								<ThemeDetailsProvider>
-									<OnboardingProvider>
-										<ImportExportProvider>
-											<ContentTabsProvider>
+						<ContentTabsProvider>
+							<SiteDetailsProvider>
+								<FeatureFlagsProvider>
+									<ThemeDetailsProvider>
+										<OnboardingProvider>
+											<ImportExportProvider>
 												<SyncSitesProvider>
 													<App />
 												</SyncSitesProvider>
-											</ContentTabsProvider>
-										</ImportExportProvider>
-									</OnboardingProvider>
-								</ThemeDetailsProvider>
-							</FeatureFlagsProvider>
-						</SiteDetailsProvider>
+											</ImportExportProvider>
+										</OnboardingProvider>
+									</ThemeDetailsProvider>
+								</FeatureFlagsProvider>
+							</SiteDetailsProvider>
+						</ContentTabsProvider>
 					</AuthProvider>
 				</I18nProvider>
 			</ReduxProvider>

--- a/src/hooks/tests/use-site-details.test.tsx
+++ b/src/hooks/tests/use-site-details.test.tsx
@@ -5,6 +5,7 @@
 import { renderHook, waitFor } from '@testing-library/react';
 import { ReactNode } from 'react';
 import { Provider } from 'react-redux';
+import { ContentTabsProvider } from 'src/hooks/use-content-tabs';
 import { SiteDetailsProvider, useSiteDetails } from 'src/hooks/use-site-details';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 import { store } from 'src/stores';
@@ -46,7 +47,9 @@ const mockSites = [
 
 const wrapper = ( { children }: { children: ReactNode } ) => (
 	<Provider store={ store }>
-		<SiteDetailsProvider>{ children }</SiteDetailsProvider>
+		<ContentTabsProvider>
+			<SiteDetailsProvider>{ children }</SiteDetailsProvider>
+		</ContentTabsProvider>
 	</Provider>
 );
 

--- a/src/hooks/use-site-details.tsx
+++ b/src/hooks/use-site-details.tsx
@@ -9,6 +9,7 @@ import {
 	useMemo,
 	useState,
 } from 'react';
+import { useContentTabs } from 'src/hooks/use-content-tabs';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 import { sortSites } from 'src/lib/sort-sites';
 import { useAppDispatch } from 'src/stores';
@@ -151,6 +152,7 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 	const { selectedSiteId, setSelectedSiteId } = useSelectedSite( firstSite?.id );
 	const [ uploadingSites, setUploadingSites ] = useState< { [ siteId: string ]: boolean } >( {} );
 	const { deleteSite, isLoading: isDeleting } = useDeleteSite();
+	const { setSelectedTab, selectedTab } = useContentTabs();
 
 	const toggleLoadingServerForSite = useCallback( ( siteId: string ) => {
 		setLoadingServer( ( currentLoading ) => ( {
@@ -166,8 +168,11 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 			setData( newSites );
 			const selectedSite = newSites.length ? newSites[ 0 ].id : '';
 			setSelectedSiteId( selectedSite );
+			if ( selectedTab !== 'overview' ) {
+				setSelectedTab( 'overview' );
+			}
 		},
-		[ deleteSite, setSelectedSiteId ]
+		[ deleteSite, setSelectedSiteId, selectedTab, setSelectedTab ]
 	);
 
 	const createSite = useCallback(
@@ -231,6 +236,9 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 				// Update the selected site to the new site's ID if the user didn't change it
 				setSelectedSiteId( ( prevSelectedSiteId ) => {
 					if ( prevSelectedSiteId === tempSiteId ) {
+						if ( selectedTab !== 'overview' ) {
+							setSelectedTab( 'overview' );
+						}
 						return newSite.id;
 					}
 					return prevSelectedSiteId;
@@ -257,7 +265,7 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 				showError( error );
 			}
 		},
-		[ setSelectedSiteId ]
+		[ selectedTab, setSelectedSiteId, setSelectedTab ]
 	);
 
 	const updateSite = useCallback( async ( site: SiteDetails ) => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-640

## Proposed Changes

Currently, when users delete a site or create a new one, they are directed to the first site on the list or the new site, but the tab is preserved. Let's ensure that Studio displays the Overview tab in these cases.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
Let's test a few cases.

### Create site
1. Open the Settings tab for a site
2. Add a new site
3. Confirm that the Overview of the new site is displayed

### Delete site
1. Open the Settings tab for a site
2. Delete a site
3. Confirm that the Overview of the first site is displayed

### Create and switch site
1. Open the Settings tab for a site
2. Add a new site
3. Quickly switch to another site
4. Confirm that the current site and tab is preserved

### Switch site
1. Open the Settings tab for a site
2. Switch site
4. Confirm that the current tab is preserved

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
