### PR TITLE
Suppress punycode warnings for both CLI and the app

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
 import { __ } from '@wordpress/i18n';
+import { suppressPunycodeWarning } from 'common/lib/suppress-punycode-warning';
 import { StatsGroup, StatsMetric } from 'common/types/stats';
 import yargs from 'yargs';
 import { registerCommand as registerCreateCommand } from 'cli/commands/preview/create';
@@ -10,6 +11,8 @@ import { loadTranslations } from 'cli/lib/i18n';
 import { bumpAggregatedUniqueStat } from 'cli/lib/stats';
 import { version } from 'cli/package.json';
 import { StudioArgv } from 'cli/types';
+
+suppressPunycodeWarning();
 
 async function main() {
 	const locale = await loadTranslations();

--- a/common/lib/suppress-punycode-warning.ts
+++ b/common/lib/suppress-punycode-warning.ts
@@ -1,0 +1,19 @@
+export function suppressPunycodeWarning() {
+	// Save existing listeners
+	const originalListeners = process.listeners( 'warning' );
+
+	// Remove all current listeners
+	process.removeAllListeners( 'warning' );
+
+	// Add custom listener with filter
+	process.on( 'warning', ( warning: Error & { code?: string } ) => {
+		// Suppress only the punycode deprecation warning
+		if ( warning.name === 'DeprecationWarning' && warning.code === 'DEP0040' ) {
+			return;
+		}
+		// Otherwise, call original listeners (print warning as usual)
+		for ( const listener of originalListeners ) {
+			listener.call( process, warning );
+		}
+	} );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import {
 	REDUX_DEVTOOLS,
 } from 'electron-devtools-installer';
 import { PROTOCOL_PREFIX } from 'common/constants';
+import { suppressPunycodeWarning } from 'common/lib/suppress-punycode-warning';
 import { StatsGroup } from 'common/types/stats';
 import { IPC_VOID_HANDLERS } from 'src/constants';
 import * as ipcHandlers from 'src/ipc-handlers';
@@ -56,6 +57,8 @@ if ( ! process.env.IS_DEV_BUILD ) {
 		environment: isDevEnvironment ? 'development' : 'production',
 	} );
 }
+
+suppressPunycodeWarning();
 
 // Handle creating/removing shortcuts on Windows when installing/uninstalling.
 // eslint-disable-next-line @typescript-eslint/no-require-imports


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-639

## Proposed Changes

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- I propose to suppress punycode warnings for both the CLI and the app. It doesn't cause any problems for the app, but it shows a confusing warning as part of the command output.

|**Before**|**After**|
|---|---|
|<img width="866" height="224" alt="Screenshot 2025-07-17 at 14 23 51" src="https://github.com/user-attachments/assets/a25bfefd-2900-41df-bce8-7d50a67a0b49" />|<img width="590" height="190" alt="Screenshot 2025-07-17 at 14 23 12" src="https://github.com/user-attachments/assets/c9f01f70-d986-4f4d-8639-93d7c07ae9d3" />|

Installing punycode as an explicit dependency didn't help - there is some dependency that loads deprecated punycode. 

## Testing Instructions

1. Rebuild command:
```
npm run cli:watch
```
3. Run command
```
node dist/cli/main.js
```
4. Confirm there is no punycode warning.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
