### PR TITLE
Remove unnecessary usage of DEFAULT_WORDPRESS_VERSION in getWordPressVersionUrl

### DIFF
--- a/src/lib/tests/wordpress-version-utils.test.ts
+++ b/src/lib/tests/wordpress-version-utils.test.ts
@@ -95,8 +95,4 @@ describe( 'getWordPressVersionUrl', () => {
 		expect( () => getWordPressVersionUrl( '6.invalid' ) ).toThrow();
 		expect( () => getWordPressVersionUrl( '' ) ).toThrow();
 	} );
-
-	test( 'should use default version when none provided', () => {
-		expect( () => getWordPressVersionUrl() ).not.toThrow();
-	} );
 } );

--- a/src/lib/wordpress-version-utils.ts
+++ b/src/lib/wordpress-version-utils.ts
@@ -1,4 +1,3 @@
-import { DEFAULT_WORDPRESS_VERSION } from 'vendor/wp-now/src/constants';
 import { isValidWordPressVersion } from 'vendor/wp-now/src/wp-playground-wordpress/is-valid-wordpress-version';
 
 export function isWordPressDevVersion( version: string ): boolean {
@@ -11,7 +10,7 @@ export function isWordPressBetaVersion( version: string ): boolean {
 	return version.includes( 'beta' ) || version.includes( 'RC' );
 }
 
-export function getWordPressVersionUrl( version = DEFAULT_WORDPRESS_VERSION ) {
+export function getWordPressVersionUrl( version: string ) {
 	if ( isWordPressDevVersion( version ) ) {
 		return 'https://wordpress.org/nightly-builds/wordpress-latest.zip';
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Related to https://github.com/Automattic/studio/pull/1568

## Proposed Changes

- Remove DEFAULT_WORDPRESS_VERSION from wordpress-verson-utils.ts

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run `npm start`
- Remove the `latest` folder from `~/Library/Application Support/Studio/server-files/wordpress-versions/latest`
- Create a new site
- Observe the site is created and starts correctly

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
