### PR TITLE
Update crash screen styling and fix crash

### DIFF
--- a/src/components/default-error-fallback.tsx
+++ b/src/components/default-error-fallback.tsx
@@ -3,7 +3,6 @@ import {
 	__experimentalHStack as HStack,
 } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
-import { useEffect } from 'react';
 import { DEFAULT_LOCALE } from 'common/lib/locale';
 import Button from 'src/components/button';
 import { DynamicStylesheet } from 'src/components/dynamic-stylesheet';
@@ -90,21 +89,11 @@ const RightPanel = () => {
 };
 
 export default function DefaultErrorFallback() {
-	const { isRTL } = useI18n();
-
-	useEffect( () => {
-		document.documentElement.dir = isRTL() ? 'rtl' : 'ltr';
-	}, [ isRTL ] );
-
 	return (
-		<>
+		<div dir={ 'ltr' }>
 			<DynamicStylesheet
 				id="wordpress-components-style"
-				href={
-					isRTL()
-						? '../main_window/styles/wordpress-components-style-rtl.css'
-						: '../main_window/styles/wordpress-components-style.css'
-				}
+				href={ '../main_window/styles/wordpress-components-style.css' }
 			/>
 			<VStack
 				className={ cx(
@@ -148,6 +137,6 @@ export default function DefaultErrorFallback() {
 					</div>
 				</HStack>
 			</VStack>
-		</>
+		</div>
 	);
 }

--- a/src/components/default-error-fallback.tsx
+++ b/src/components/default-error-fallback.tsx
@@ -3,6 +3,7 @@ import {
 	__experimentalHStack as HStack,
 } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
+import { useEffect } from 'react';
 import { DEFAULT_LOCALE } from 'common/lib/locale';
 import Button from 'src/components/button';
 import { DynamicStylesheet } from 'src/components/dynamic-stylesheet';
@@ -89,14 +90,18 @@ const RightPanel = () => {
 };
 
 export default function DefaultErrorFallback() {
-	const i18n = useI18n();
+	const { isRTL } = useI18n();
+
+	useEffect( () => {
+		document.documentElement.dir = isRTL() ? 'rtl' : 'ltr';
+	}, [ isRTL ] );
 
 	return (
 		<>
 			<DynamicStylesheet
 				id="wordpress-components-style"
 				href={
-					i18n?.isRTL()
+					isRTL()
 						? '../main_window/styles/wordpress-components-style-rtl.css'
 						: '../main_window/styles/wordpress-components-style.css'
 				}

--- a/src/components/default-error-fallback.tsx
+++ b/src/components/default-error-fallback.tsx
@@ -5,6 +5,7 @@ import {
 import { useI18n } from '@wordpress/react-i18n';
 import { DEFAULT_LOCALE } from 'common/lib/locale';
 import Button from 'src/components/button';
+import { DynamicStylesheet } from 'src/components/dynamic-stylesheet';
 import { isMac, isWindows } from 'src/lib/app-globals';
 import { cx } from 'src/lib/cx';
 import { getIpcApi } from 'src/lib/get-ipc-api';
@@ -50,7 +51,7 @@ const RightPanel = () => {
 	const { __ } = useI18n();
 	const locale = DEFAULT_LOCALE;
 	const openLocalizedSupport = () => {
-		getIpcApi().openURL( `https://wordpress.com/${ locale }/support` );
+		getIpcApi().openURL( `https://wordpress.com/${ locale }/support/contact` );
 	};
 	return (
 		<div className="flex flex-col justify-center h-full">
@@ -88,48 +89,60 @@ const RightPanel = () => {
 };
 
 export default function DefaultErrorFallback() {
+	const i18n = useI18n();
+
 	return (
-		<VStack
-			className={ cx(
-				'h-screen bg-chrome backdrop-blur-3xl pr-chrome app-drag-region',
-				isWindows() && 'pt-0 pb-chrome',
-				! isWindows() && 'py-chrome'
-			) }
-			spacing="0"
-		>
-			<HStack spacing="0" alignment="left" className="flex-grow">
-				<div
-					data-testid="main-sidebar"
-					className={ cx(
-						'text-chrome-inverted basis-52 flex-shrink-0 h-full',
-						isMac() && 'pt-[50px]',
-						! isMac() && 'pt-[60px]'
-					) }
-				>
-					<div className="flex flex-col h-full">
-						<div
-							className={ cx(
-								'w-full overflow-y-auto overflow-x-hidden flex flex-col gap-0.5 pb-4'
-							) }
-						>
-							<SitesSkeleton />
-						</div>
-						<div className="mt-auto min-h-[103px] pt-5">
-							<div className={ cx( isMac() ? 'mx-5' : 'mx-4' ) }>
-								<div className="w-full mb-5">
-									<ButtonSkeleton />
-								</div>
-								<div className="flex items-center justify-start w-full ml-1">
-									<GravatarSkeleton />
+		<>
+			<DynamicStylesheet
+				id="wordpress-components-style"
+				href={
+					i18n?.isRTL()
+						? '../main_window/styles/wordpress-components-style-rtl.css'
+						: '../main_window/styles/wordpress-components-style.css'
+				}
+			/>
+			<VStack
+				className={ cx(
+					'h-screen bg-chrome backdrop-blur-3xl pr-chrome app-drag-region',
+					isWindows() && 'pt-0 pb-chrome',
+					! isWindows() && 'py-chrome'
+				) }
+				spacing="0"
+			>
+				<HStack spacing="0" alignment="left" className="flex-grow">
+					<div
+						data-testid="main-sidebar"
+						className={ cx(
+							'text-chrome-inverted basis-52 flex-shrink-0 h-full',
+							isMac() && 'pt-[50px]',
+							! isMac() && 'pt-[60px]'
+						) }
+					>
+						<div className="flex flex-col h-full">
+							<div
+								className={ cx(
+									'w-full overflow-y-auto overflow-x-hidden flex flex-col gap-0.5 pb-4'
+								) }
+							>
+								<SitesSkeleton />
+							</div>
+							<div className="mt-auto min-h-[103px] pt-5">
+								<div className={ cx( isMac() ? 'mx-5' : 'mx-4' ) }>
+									<div className="w-full mb-5">
+										<ButtonSkeleton />
+									</div>
+									<div className="flex items-center justify-start w-full ml-1">
+										<GravatarSkeleton />
+									</div>
 								</div>
 							</div>
 						</div>
 					</div>
-				</div>
-				<div className="p-16 bg-white overflow-y-auto h-full flex-grow rounded-chrome app-no-drag-region">
-					<RightPanel />
-				</div>
-			</HStack>
-		</VStack>
+					<div className="p-16 bg-white overflow-y-auto h-full flex-grow rounded-chrome app-no-drag-region">
+						<RightPanel />
+					</div>
+				</HStack>
+			</VStack>
+		</>
 	);
 }

--- a/src/lib/import-export/tests/import/import-manager.test.ts
+++ b/src/lib/import-export/tests/import/import-manager.test.ts
@@ -13,6 +13,9 @@ jest.mock( 'src/storage/paths', () => ( {
 	getUserDataCertificatesPath: jest
 		.fn()
 		.mockReturnValue( '/path/to/app/appData/App Name/certificates' ),
+	getUserDataLockFilePath: jest
+		.fn()
+		.mockReturnValue( '/path/to/app/appData/App Name/appdata-v1.json.lock' ),
 } ) );
 jest.mock( 'src/lib/import-export/import/handlers/backup-handler-factory' );
 jest.mock( 'fs/promises' );

--- a/src/storage/paths.ts
+++ b/src/storage/paths.ts
@@ -1,4 +1,5 @@
 import path from 'path';
+import { LOCKFILE_NAME } from 'common/constants';
 
 function inChildProcess() {
 	return process.env.STUDIO_IN_CHILD_PROCESS === 'true';
@@ -16,6 +17,10 @@ try {
 
 export function getUserDataFilePath(): string {
 	return path.join( getAppDataPath(), getAppName(), 'appdata-v1.json' );
+}
+
+export function getUserDataLockFilePath(): string {
+	return path.join( getAppDataPath(), getAppName(), LOCKFILE_NAME );
 }
 
 export function getServerFilesPath(): string {

--- a/src/storage/tests/user-data.test.ts
+++ b/src/storage/tests/user-data.test.ts
@@ -12,6 +12,9 @@ jest.mock( 'fs' );
 jest.mock( 'src/storage/paths', () => ( {
 	getResourcesPath: jest.fn().mockReturnValue( '/path/to/app/appData/App Name' ),
 	getUserDataFilePath: jest.fn().mockReturnValue( '/path/to/app/appData/App Name/appdata-v1.json' ),
+	getUserDataLockFilePath: jest
+		.fn()
+		.mockReturnValue( '/path/to/app/appData/App Name/appdata-v1.json.lock' ),
 } ) );
 
 jest.mock( 'atomically', () => ( {

--- a/src/storage/user-data.ts
+++ b/src/storage/user-data.ts
@@ -107,7 +107,7 @@ export async function saveUserData( data: UserData ): Promise< void > {
 	await writeFile( filePath, asString, 'utf-8' );
 }
 
-const LOCKFILE_PATH = nodePath.join( getUserDataLockFilePath(), LOCKFILE_NAME );
+const LOCKFILE_PATH = getUserDataLockFilePath();
 
 export async function lockAppdata() {
 	return lockFileAsync( LOCKFILE_PATH, { stale: LOCKFILE_STALE_TIME, wait: LOCKFILE_WAIT_TIME } );

--- a/src/storage/user-data.ts
+++ b/src/storage/user-data.ts
@@ -4,7 +4,7 @@ import nodePath from 'node:path';
 import { SupportedPHPVersion, SupportedPHPVersions } from '@php-wasm/universal';
 import * as Sentry from '@sentry/electron/main';
 import { readFile, writeFile } from 'atomically';
-import { LOCKFILE_NAME, LOCKFILE_STALE_TIME, LOCKFILE_WAIT_TIME } from 'common/constants';
+import { LOCKFILE_STALE_TIME, LOCKFILE_WAIT_TIME } from 'common/constants';
 import { lockFileAsync, unlockFileAsync } from 'common/lib/lockfile';
 import { isErrnoException } from 'src/lib/is-errno-exception';
 import { sanitizeUnstructuredData, sanitizeUserpath } from 'src/lib/sanitize-for-logging';

--- a/src/storage/user-data.ts
+++ b/src/storage/user-data.ts
@@ -4,13 +4,12 @@ import nodePath from 'node:path';
 import { SupportedPHPVersion, SupportedPHPVersions } from '@php-wasm/universal';
 import * as Sentry from '@sentry/electron/main';
 import { readFile, writeFile } from 'atomically';
-import { getAppdataDirectory } from 'cli/lib/appdata';
 import { LOCKFILE_NAME, LOCKFILE_STALE_TIME, LOCKFILE_WAIT_TIME } from 'common/constants';
 import { lockFileAsync, unlockFileAsync } from 'common/lib/lockfile';
 import { isErrnoException } from 'src/lib/is-errno-exception';
 import { sanitizeUnstructuredData, sanitizeUserpath } from 'src/lib/sanitize-for-logging';
 import { sortSites } from 'src/lib/sort-sites';
-import { getUserDataFilePath } from 'src/storage/paths';
+import { getUserDataFilePath, getUserDataLockFilePath } from 'src/storage/paths';
 import type { PersistedUserData, UserData, WindowBounds } from 'src/storage/storage-types';
 
 // Before persisting the PHP version of sites, the default PHP version used was 8.0.
@@ -108,7 +107,7 @@ export async function saveUserData( data: UserData ): Promise< void > {
 	await writeFile( filePath, asString, 'utf-8' );
 }
 
-const LOCKFILE_PATH = nodePath.join( getAppdataDirectory(), LOCKFILE_NAME );
+const LOCKFILE_PATH = nodePath.join( getUserDataLockFilePath(), LOCKFILE_NAME );
 
 export async function lockAppdata() {
 	return lockFileAsync( LOCKFILE_PATH, { stale: LOCKFILE_STALE_TIME, wait: LOCKFILE_WAIT_TIME } );

--- a/src/storage/user-data.ts
+++ b/src/storage/user-data.ts
@@ -4,12 +4,13 @@ import nodePath from 'node:path';
 import { SupportedPHPVersion, SupportedPHPVersions } from '@php-wasm/universal';
 import * as Sentry from '@sentry/electron/main';
 import { readFile, writeFile } from 'atomically';
+import { getAppdataDirectory } from 'cli/lib/appdata';
 import { LOCKFILE_NAME, LOCKFILE_STALE_TIME, LOCKFILE_WAIT_TIME } from 'common/constants';
 import { lockFileAsync, unlockFileAsync } from 'common/lib/lockfile';
 import { isErrnoException } from 'src/lib/is-errno-exception';
 import { sanitizeUnstructuredData, sanitizeUserpath } from 'src/lib/sanitize-for-logging';
 import { sortSites } from 'src/lib/sort-sites';
-import { getResourcesPath, getUserDataFilePath } from 'src/storage/paths';
+import { getUserDataFilePath } from 'src/storage/paths';
 import type { PersistedUserData, UserData, WindowBounds } from 'src/storage/storage-types';
 
 // Before persisting the PHP version of sites, the default PHP version used was 8.0.
@@ -107,7 +108,7 @@ export async function saveUserData( data: UserData ): Promise< void > {
 	await writeFile( filePath, asString, 'utf-8' );
 }
 
-const LOCKFILE_PATH = nodePath.join( getResourcesPath(), LOCKFILE_NAME );
+const LOCKFILE_PATH = nodePath.join( getAppdataDirectory(), LOCKFILE_NAME );
 
 export async function lockAppdata() {
 	return lockFileAsync( LOCKFILE_PATH, { stale: LOCKFILE_STALE_TIME, wait: LOCKFILE_WAIT_TIME } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-612

## Proposed Changes

- I propose to update crash screen styling and to fix the issue with another crash occurring when starting the site from a read-only location.

<img width="1032" height="731" alt="Screenshot 2025-07-22 at 13 05 41" src="https://github.com/user-attachments/assets/fae35af7-b28c-4433-8467-ced688c13d99" />

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Test crash screen styling
1. Run Studio in dev mode (`npm start`)
2. Trigger renderer failure from Electron menu
3. Close the trace
4. Confirm "contact support" is styled correctly (blue, and no padding) and points to the 'Contact us' page 

Before the fix, there was additional padding around the "contact support", it was black, and pointing to another page.

### Test crash screen styling for RTL language
1. Run Studio in dev mode (`npm start`)
2. Change language to RTL
3. Trigger renderer failure from Electron menu
4. Close the trace
6. Confirm layout uses English in LTR mode
7. Confirm "contact support" is styled correctly and points to the 'Contact us' page

Before the fix, error screen was displayed in English but in RTL mode, with layout slightly broken. Additionally, the user couldn't close the trace with the mouse.

### Test running Studio from read-only container
1. Navigate to build in the Buildkite
2. Download DMG file for your system arch
3. Open DMG, start Studio from DMG
4. Start site if none of site automatically started
6. Confirm it starts and that Studio doesn't crash
7. Trigger Studio update
8. Confirm dialog with correct error is displayed

Before the fix, Studio running from read-only container was crashing when the site was started.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
