### PR TITLE
Change a way of generating dev build version

### DIFF
--- a/scripts/prepare-dev-build-version.mjs
+++ b/scripts/prepare-dev-build-version.mjs
@@ -23,10 +23,11 @@ const packageJsonPath = path.resolve( __dirname, '../package.json' );
 const packageJsonText = await fs.readFile( packageJsonPath, 'utf-8' );
 const packageJson = JSON.parse( packageJsonText );
 
-// Parse the version using semver to get just the core version numbers
-const parsedVersion = semver.parse( packageJson.version );
+// Use version from latestTag (strip leading 'v' if present)
+const tagVersion = latestTag.startsWith('v') ? latestTag.slice(1) : latestTag;
+const parsedVersion = semver.parse( tagVersion );
 if ( ! parsedVersion ) {
-	throw new Error( `Invalid version in package.json: ${ packageJson.version }` );
+	throw new Error( `Invalid version in latestTag: ${ latestTag }` );
 }
 
 // Create dev version using just the core version numbers (major.minor.patch)


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Related discussion: p1753275455765609-slack-C04GESRBWKW

## Proposed Changes

I propose to fix a way of generating dev build version: currently, it handles part that counts commits correctly, but it relies on version from `package.json` for the version part, so it uses incorrect dev version as soon as we release the first beta for the new release.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Pretend you want to release new beta for incoming 1.5.6 and update it to 1.5.6-beta1 in `package.json` file.
2. Run `node ./scripts/prepare-dev-build-version.mjs`
3. Run `git diff` and see that the version was changed to 1.5.5-dev37 in the `package.json`

Before the fix, the generated version would be 1.5.6-dev37.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?