### PR TITLE
[Tooling] Run Windows Setup before installing npm dependencies

### DIFF
--- a/.buildkite/commands/build-for-windows.ps1
+++ b/.buildkite/commands/build-for-windows.ps1
@@ -18,7 +18,8 @@ if ($BuildType -notin $VALID_BUILD_TYPES) {
     Exit 1
 }
 
-& "prepare_windows_host_for_app_distribution.ps1" # via CI toolkit plugin
+# prepare_windows_host_for_app_distribution.ps1 comes from CI Toolkit Plugin
+& "prepare_windows_host_for_app_distribution.ps1" -InstallPython $true -InstallNativeCompilationTools $true
 If ($LastExitCode -ne 0) { Exit $LastExitCode }
 
 Write-Host "--- :npm: Installing Node dependencies"

--- a/.buildkite/commands/build-for-windows.ps1
+++ b/.buildkite/commands/build-for-windows.ps1
@@ -18,11 +18,11 @@ if ($BuildType -notin $VALID_BUILD_TYPES) {
     Exit 1
 }
 
-Write-Host "--- :npm: Installing Node dependencies"
-bash .buildkite/commands/install-node-dependencies.sh
+& "prepare_windows_host_for_app_distribution.ps1" # via CI toolkit plugin
 If ($LastExitCode -ne 0) { Exit $LastExitCode }
 
-& "prepare_windows_host_for_app_distribution.ps1" # via CI toolkit plugin
+Write-Host "--- :npm: Installing Node dependencies"
+bash .buildkite/commands/install-node-dependencies.sh
 If ($LastExitCode -ne 0) { Exit $LastExitCode }
 
 Write-Host "--- :node: Building App for Windows ($BuildType)"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -36,6 +36,8 @@ steps:
 
   - label: Windows Unit Tests
     command: |
+      & "prepare_windows_host_for_app_distribution.ps1"
+
       bash .buildkite/commands/install-node-dependencies.sh
       echo '--- :npm: Run Unit Tests'
       npm run test

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -36,7 +36,8 @@ steps:
 
   - label: Windows Unit Tests
     command: |
-      & "prepare_windows_host_for_app_distribution.ps1"
+      # prepare_windows_host_for_app_distribution.ps1 comes from CI Toolkit Plugin
+      & "prepare_windows_host_for_app_distribution.ps1" -InstallPython $true -InstallNativeCompilationTools $true
 
       bash .buildkite/commands/install-node-dependencies.sh
       echo '--- :npm: Run Unit Tests'

--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -5,7 +5,7 @@
 
 # The ~> modifier is not currently used, but we check for it just in case
 XCODE_VERSION=$(sed -E -n 's/^(~> )?(.*)/xcode-\2/p' .xcode-version)
-CI_TOOLKIT_VERSION='5.1.2'
+CI_TOOLKIT_VERSION='iangmaia/add-node-native-modules'
 NVM_PLUGIN_VERSION='0.6.0'
 
 export IMAGE_ID="$XCODE_VERSION"

--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -5,7 +5,7 @@
 
 # The ~> modifier is not currently used, but we check for it just in case
 XCODE_VERSION=$(sed -E -n 's/^(~> )?(.*)/xcode-\2/p' .xcode-version)
-CI_TOOLKIT_VERSION='iangmaia/add-node-native-modules'
+CI_TOOLKIT_VERSION='5.5.0'
 NVM_PLUGIN_VERSION='0.6.0'
 
 export IMAGE_ID="$XCODE_VERSION"


### PR DESCRIPTION
Fixes AINFRA-987

To fix the issue seen in https://github.com/Automattic/studio/pull/1594, this PR runs the Windows setup before installing the Node dependencies.
We also had to install Python and additional Visual Studio Build Tools components in both the Windows build and unit test jobs.

Depends on CI Toolkit Plugin PR https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/pull/186