### PR TITLE
Update SQLite plugin to 2.2.5

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -67,7 +67,7 @@ export const WP_CLI_IMPORT_EXPORT_RESPONSE_TIMEOUT =
 	WP_CLI_IMPORT_EXPORT_RESPONSE_TIMEOUT_IN_HRS * 60 * 60 * 1000; // 6hr
 
 // SQLite
-export const SQLITE_DATABASE_INTEGRATION_VERSION = 'v2.2.3';
+export const SQLITE_DATABASE_INTEGRATION_VERSION = 'v2.2.4';
 
 export const SQLITE_DATABASE_INTEGRATION_RELEASE_URL = `https://github.com/WordPress/sqlite-database-integration/archive/refs/tags/${ SQLITE_DATABASE_INTEGRATION_VERSION }.zip`;
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -67,7 +67,7 @@ export const WP_CLI_IMPORT_EXPORT_RESPONSE_TIMEOUT =
 	WP_CLI_IMPORT_EXPORT_RESPONSE_TIMEOUT_IN_HRS * 60 * 60 * 1000; // 6hr
 
 // SQLite
-export const SQLITE_DATABASE_INTEGRATION_VERSION = 'v2.2.4';
+export const SQLITE_DATABASE_INTEGRATION_VERSION = 'v2.2.5';
 
 export const SQLITE_DATABASE_INTEGRATION_RELEASE_URL = `https://github.com/WordPress/sqlite-database-integration/archive/refs/tags/${ SQLITE_DATABASE_INTEGRATION_VERSION }.zip`;
 

--- a/src/lib/import-export/import/importers/importer.ts
+++ b/src/lib/import-export/import/importers/importer.ts
@@ -419,7 +419,7 @@ export class WpressImporter extends BaseBackupImporter {
 		const serializedPlugins = serializePlugins( plugins );
 		const activatePluginsSql = `
 			INSERT INTO wp_options (option_name, option_value, autoload) VALUES ('active_plugins', '${ serializedPlugins }', 'yes')
-			ON CONFLICT(option_name) DO UPDATE SET option_value = excluded.option_value, autoload = excluded.autoload;
+			ON DUPLICATE KEY UPDATE option_value = VALUES(option_value), autoload = VALUES(autoload);
 		`;
 
 		const sqliteActivatePluginsPath = path.join(


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-647

## Proposed Changes

I propose to update the SQLite plugin to 2.2.5 to ensure Local and WordPress import still work. Additionally, I fix remaining SQLite query as it wouldn't work with AST driver.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Test all supported import formats: https://developer.wordpress.com/docs/developer-tools/studio/import-export/

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
