### PR TITLE
Ensure to delete preview sites only when the user is authenticated

### DIFF
--- a/src/hooks/use-site-details.tsx
+++ b/src/hooks/use-site-details.tsx
@@ -9,6 +9,7 @@ import {
 	useMemo,
 	useState,
 } from 'react';
+import { useAuth } from 'src/hooks/use-auth';
 import { useContentTabs } from 'src/hooks/use-content-tabs';
 import { useOffline } from 'src/hooks/use-offline';
 import { getIpcApi } from 'src/lib/get-ipc-api';
@@ -93,6 +94,7 @@ function useDeleteSite() {
 	const [ isLoading, setIsLoading ] = useState< Record< string, boolean > >( {} );
 	const dispatch = useAppDispatch();
 	const isOffline = useOffline();
+	const { isAuthenticated } = useAuth();
 
 	const deleteSite = useCallback(
 		async ( siteId: string, removeLocal: boolean ): Promise< void > => {
@@ -100,16 +102,18 @@ function useDeleteSite() {
 				return;
 			}
 
-			const allSiteRemovePromises = isOffline
-				? Promise.resolve()
-				: dispatch( snapshotThunks.deleteAllSnapshotsForSite( { siteId } ) );
+			const shouldDeletePreviewSites = ! isOffline && isAuthenticated;
+
+			const allSiteRemovePromises = shouldDeletePreviewSites
+				? dispatch( snapshotThunks.deleteAllSnapshotsForSite( { siteId } ) )
+				: Promise.resolve();
 
 			try {
 				setIsLoading( ( loading ) => ( { ...loading, [ siteId ]: true } ) );
 
 				await getIpcApi().deleteSite( siteId, removeLocal );
 
-				if ( ! isOffline ) {
+				if ( shouldDeletePreviewSites ) {
 					await allSiteRemovePromises;
 				}
 
@@ -136,7 +140,7 @@ function useDeleteSite() {
 				setIsLoading( ( loading ) => ( { ...loading, [ siteId ]: false } ) );
 			}
 		},
-		[ dispatch, isOffline ]
+		[ dispatch, isOffline, isAuthenticated ]
 	);
 	return { deleteSite, isLoading };
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Resolves STU-659

## Proposed Changes

- ensure to delete preview sites only when the user is authenticated

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR branch and build the app with `npm start`.
2. Create a preview site for one of your local Studio sites.
3. Check the current number of preview sites in the _Settings → Usage_ tab.
4. Log out from WordPress.com.
5. Try to delete that local site that has preview site linked to it.
6. The local site should get deleted without any error message.
7. When you check the _Settings → Usage_ tab, the number of preview sites should not be reduced - as the site has not been deleted.
8. Repeat the steps 2 and 3.
9. Go offline (e.g. by deactivating wifi).
10. Repeat the steps 5 to 7.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
