### PR TITLE
Update SQLite plugin to 2.2.6 to fix Jetpack Backup import issues

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -67,7 +67,7 @@ export const WP_CLI_IMPORT_EXPORT_RESPONSE_TIMEOUT =
 	WP_CLI_IMPORT_EXPORT_RESPONSE_TIMEOUT_IN_HRS * 60 * 60 * 1000; // 6hr
 
 // SQLite
-export const SQLITE_DATABASE_INTEGRATION_VERSION = 'v2.2.5';
+export const SQLITE_DATABASE_INTEGRATION_VERSION = 'v2.2.6';
 
 export const SQLITE_DATABASE_INTEGRATION_RELEASE_URL = `https://github.com/WordPress/sqlite-database-integration/archive/refs/tags/${ SQLITE_DATABASE_INTEGRATION_VERSION }.zip`;
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-670

## Proposed Changes

I propose to update the SQLite plugin to 2.2.6 to fix Jetpack Backup import issues.

The fix also relies on https://github.com/Automattic/wp-cli-sqlite-command/releases/tag/v1.1.1, which is applied automatically when Studio starts.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Start Studio
2. Click 'Add site'
3. Choose Jetpack Backup that doesn't have database constants in the `wp-config.php` file
4. Confirm site imports fine and loads fine

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
