### PR TITLE
Add full sentence translations to the pull push dialog to support languages with declinations

### DIFF
--- a/src/modules/sync/hooks/use-sync-dialog-texts.tsx
+++ b/src/modules/sync/hooks/use-sync-dialog-texts.tsx
@@ -85,7 +85,7 @@ export const useSyncDialogTexts = (
 				local: {
 					title: __( 'Push to remote Local' ),
 					description: __(
-						"Pushing will overwrite your remote site's selected files and database with content from your Studio site. Unchecked items will not be changed. The local site will be backed up before any changes are applied."
+						"Pushing will overwrite your remote site's selected files and database with content from your Studio site. Unchecked items will not be changed. The remote site will be backed up before any changes are applied."
 					),
 				},
 			};

--- a/src/modules/sync/hooks/use-sync-dialog-texts.tsx
+++ b/src/modules/sync/hooks/use-sync-dialog-texts.tsx
@@ -49,7 +49,7 @@ export const useSyncDialogTexts = (
 				local: {
 					title: __( 'Pull from remote Local' ),
 					description: __(
-						"Pulling will overwrite your Studio site's selected files and database with a copy from your local site. Unchecked items will not be changed."
+						"Pulling will overwrite your Studio site's selected files and database with a copy from your remote site with local environment. Unchecked items will not be changed."
 					),
 				},
 			};
@@ -67,25 +67,25 @@ export const useSyncDialogTexts = (
 				production: {
 					title: __( 'Push to Production' ),
 					description: __(
-						"Pushing will overwrite your production site's selected files and database with content from your local site. Unchecked items will not be changed. The production site will be backed up before any changes are applied."
+						"Pushing will overwrite your production site's selected files and database with content from your Studio site. Unchecked items will not be changed. The production site will be backed up before any changes are applied."
 					),
 				},
 				staging: {
 					title: __( 'Push to Staging' ),
 					description: __(
-						"Pushing will overwrite your staging site's selected files and database with content from your local site. Unchecked items will not be changed. The staging site will be backed up before any changes are applied."
+						"Pushing will overwrite your staging site's selected files and database with content from your Studio site. Unchecked items will not be changed. The staging site will be backed up before any changes are applied."
 					),
 				},
 				development: {
 					title: __( 'Push to Development' ),
 					description: __(
-						"Pushing will overwrite your development site's selected files and database with content from your local site. Unchecked items will not be changed. The development site will be backed up before any changes are applied."
+						"Pushing will overwrite your development site's selected files and database with content from your Studio site. Unchecked items will not be changed. The development site will be backed up before any changes are applied."
 					),
 				},
 				local: {
 					title: __( 'Push to remote Local' ),
 					description: __(
-						"Pushing will overwrite your local site's selected files and database with content from your local site. Unchecked items will not be changed. The local site will be backed up before any changes are applied."
+						"Pushing will overwrite your remote site's selected files and database with content from your Studio site. Unchecked items will not be changed. The local site will be backed up before any changes are applied."
 					),
 				},
 			};

--- a/src/modules/sync/hooks/use-sync-dialog-texts.tsx
+++ b/src/modules/sync/hooks/use-sync-dialog-texts.tsx
@@ -1,46 +1,103 @@
-import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import { useMemo } from 'react';
-import { getEnvironmentLabel } from 'src/modules/sync/lib/environment-utils';
+import { EnvironmentType } from 'src/modules/sync/lib/environment-utils';
 
-export const useSyncDialogTexts = ( type: 'pull' | 'push', envType: string ) => {
+type TextByEnvironment = {
+	[ key in EnvironmentType ]: {
+		title: string;
+		description: string;
+	};
+};
+
+type SyncDialogTexts = {
+	title: string;
+	description: string;
+	fromLabel: string;
+	toLabel: string;
+	subtitleSelector: string;
+	envSync: string;
+	submit: string;
+};
+
+export const useSyncDialogTexts = (
+	type: 'pull' | 'push',
+	siteEnv: EnvironmentType
+): SyncDialogTexts => {
 	const { __ } = useI18n();
 
 	return useMemo( () => {
-		const envLabel = getEnvironmentLabel( envType );
-
 		if ( type === 'pull' ) {
-			return {
-				/* translators: %s is the environment name (e.g., "Production", "Staging", "Sandbox") */
-				title: sprintf( __( 'Pull from %s' ), envLabel ),
-				/* translators: %s is the environment type (e.g., "production", "staging", "sandbox") */
-				description: sprintf(
-					__(
-						"Pulling will overwrite your Studio site's selected files and database with a copy from your %s site. Unchecked items will not be changed."
+			const textByEnvironment: TextByEnvironment = {
+				production: {
+					title: __( 'Pull from Production' ),
+					description: __(
+						"Pulling will overwrite your Studio site's selected files and database with a copy from your production site. Unchecked items will not be changed."
 					),
-					envType
-				),
+				},
+				staging: {
+					title: __( 'Pull from Staging' ),
+					description: __(
+						"Pulling will overwrite your Studio site's selected files and database with a copy from your staging site. Unchecked items will not be changed."
+					),
+				},
+				development: {
+					title: __( 'Pull from Development' ),
+					description: __(
+						"Pulling will overwrite your Studio site's selected files and database with a copy from your development site. Unchecked items will not be changed."
+					),
+				},
+				local: {
+					title: __( 'Pull from remote Local' ),
+					description: __(
+						"Pulling will overwrite your Studio site's selected files and database with a copy from your local site. Unchecked items will not be changed."
+					),
+				},
+			};
+			return {
+				title: textByEnvironment[ siteEnv ].title,
+				description: textByEnvironment[ siteEnv ].description,
 				fromLabel: __( 'Pull' ),
+				toLabel: __( 'To' ),
 				subtitleSelector: __( 'What would you like to pull?' ),
 				envSync: __( 'Read more about <a>environment pull <ArrowIcon /></a>' ),
 				submit: __( 'Pull' ),
 			};
 		} else {
-			return {
-				/* translators: %s is the environment name (e.g., "Production", "Staging", "Sandbox") */
-				title: sprintf( __( 'Push to %s' ), envLabel ),
-				/* translators: first %1s is the environment type, which is used twice in the sentence (e.g., "production", "staging", "sandbox") */
-				description: sprintf(
-					__(
-						"Pushing will overwrite your %s site's selected files and database with content from your local site. Unchecked items will not be changed. The %1s site will be backed up before any changes are applied."
+			const textByEnvironment: TextByEnvironment = {
+				production: {
+					title: __( 'Push to Production' ),
+					description: __(
+						"Pushing will overwrite your production site's selected files and database with content from your local site. Unchecked items will not be changed. The production site will be backed up before any changes are applied."
 					),
-					envType
-				),
+				},
+				staging: {
+					title: __( 'Push to Staging' ),
+					description: __(
+						"Pushing will overwrite your staging site's selected files and database with content from your local site. Unchecked items will not be changed. The staging site will be backed up before any changes are applied."
+					),
+				},
+				development: {
+					title: __( 'Push to Development' ),
+					description: __(
+						"Pushing will overwrite your development site's selected files and database with content from your local site. Unchecked items will not be changed. The development site will be backed up before any changes are applied."
+					),
+				},
+				local: {
+					title: __( 'Push to remote Local' ),
+					description: __(
+						"Pushing will overwrite your local site's selected files and database with content from your local site. Unchecked items will not be changed. The local site will be backed up before any changes are applied."
+					),
+				},
+			};
+			return {
+				title: textByEnvironment[ siteEnv ].title,
+				description: textByEnvironment[ siteEnv ].description,
 				fromLabel: __( 'Push' ),
+				toLabel: __( 'To' ),
 				subtitleSelector: __( 'What would you like to push?' ),
 				envSync: __( 'Read more about <a>environment push <ArrowIcon /></a>' ),
 				submit: __( 'Push' ),
 			};
 		}
-	}, [ envType, type, __ ] );
+	}, [ type, __, siteEnv ] );
 };

--- a/src/modules/sync/lib/environment-utils.ts
+++ b/src/modules/sync/lib/environment-utils.ts
@@ -1,11 +1,13 @@
 import { __ } from '@wordpress/i18n';
+import { z } from 'zod';
 import { SyncSite } from 'src/hooks/use-fetch-wpcom-sites/types';
 
-export const getSiteEnvironment = ( connectedSite: SyncSite ): string => {
-	if ( connectedSite.isPressable ) {
-		return connectedSite.environmentType ?? 'production';
-	}
-	return connectedSite.isStaging ? 'staging' : 'production';
+const EnvironmentSchema = z.enum( [ 'production', 'staging', 'development', 'local' ] );
+export type EnvironmentType = z.infer< typeof EnvironmentSchema >;
+
+export const getSiteEnvironment = ( site: SyncSite ): EnvironmentType => {
+	const parsed = EnvironmentSchema.safeParse( site.environmentType );
+	return parsed.success ? parsed.data : 'production';
 };
 
 export const getEnvironmentLabel = ( type: string ): string => {

--- a/src/modules/sync/tests/index.test.tsx
+++ b/src/modules/sync/tests/index.test.tsx
@@ -460,6 +460,44 @@ describe( 'ContentTabSync', () => {
 		);
 	} );
 
+	it( 'opens sync pullSite dialog and displays production when the environment is not supported', async () => {
+		const mockPullSite = jest.fn();
+		( useAuth as jest.Mock ).mockReturnValue( { isAuthenticated: true, authenticate: jest.fn() } );
+		const fakeSyncSite = {
+			id: 6,
+			name: 'My simple business site that needs a transfer',
+			url: 'https:/developer.wordpress.com/studio/',
+			syncSupport: 'already-connected',
+			isPressable: true,
+			environmentType: 'non-supported-environment-example-or-sandbox',
+		};
+		( useSyncSites as jest.Mock ).mockReturnValue( {
+			connectedSites: [ fakeSyncSite ],
+			syncSites: [ fakeSyncSite ],
+			pullSite: mockPullSite,
+			isAnySitePulling: false,
+			isAnySitePushing: false,
+			getPullState: jest.fn(),
+			getPushState: jest.fn(),
+			refetchSites: jest.fn(),
+			getLastSyncTimeText: jest.fn().mockReturnValue( 'You have not pulled this site yet.' ),
+			isSiteIdPulling: jest.fn(),
+			isSiteIdPushing: jest.fn(),
+			clearTimeout: jest.fn(),
+		} );
+
+		renderWithProvider( <ContentTabSync selectedSite={ selectedSite } /> );
+
+		const pullButton = screen.getByRole( 'button', { name: /Pull/i } );
+		expect( pullButton ).toBeInTheDocument();
+		fireEvent.click( pullButton );
+
+		await screen.findByText( 'Pull from Production' );
+		await screen.findByText(
+			"Pulling will overwrite your Studio site's selected files and database with a copy from your production site. Unchecked items will not be changed."
+		);
+	} );
+
 	it( 'calls pullSite with correct optionsToSync when all options are selected', async () => {
 		const mockPullSite = jest.fn();
 		( useAuth as jest.Mock ).mockReturnValue( { isAuthenticated: true, authenticate: jest.fn() } );

--- a/src/modules/sync/tests/index.test.tsx
+++ b/src/modules/sync/tests/index.test.tsx
@@ -217,6 +217,7 @@ describe( 'ContentTabSync', () => {
 			isStaging: false,
 			stagingSiteIds: [ 7 ],
 			syncSupport: 'already-connected',
+			environmentType: 'production',
 		};
 		const fakeStagingSite = {
 			id: 7,
@@ -225,6 +226,7 @@ describe( 'ContentTabSync', () => {
 			isStaging: true,
 			stagingSiteIds: [],
 			syncSupport: 'already-connected',
+			environmentType: 'staging',
 		};
 		( useAuth as jest.Mock ).mockReturnValue( { isAuthenticated: true, authenticate: jest.fn() } );
 
@@ -332,7 +334,7 @@ describe( 'ContentTabSync', () => {
 		expect( connectButton ).toBeInTheDocument();
 	} );
 
-	it( 'displays environment badges for Pressable sites with production, staging and sandbox environments', () => {
+	it( 'displays environment badges for Pressable sites with production, staging and development environments', () => {
 		const fakePressableProductionSite = {
 			id: 6,
 			name: 'My Pressable Production site',
@@ -353,13 +355,13 @@ describe( 'ContentTabSync', () => {
 			stagingSiteIds: [],
 			syncSupport: 'already-connected',
 		};
-		const fakePressableSandboxSite = {
+		const fakePressableDevelopmentSite = {
 			id: 8,
-			name: 'My Pressable Sandbox site',
-			url: 'https://sandbox-pressable-site.com',
+			name: 'My Pressable Development site',
+			url: 'https://development-pressable-site.com',
 			isStaging: false,
 			isPressable: true,
-			environmentType: 'sandbox',
+			environmentType: 'development',
 			stagingSiteIds: [],
 			syncSupport: 'already-connected',
 		};
@@ -368,7 +370,7 @@ describe( 'ContentTabSync', () => {
 			connectedSites: [
 				fakePressableProductionSite,
 				fakePressableStagingSite,
-				fakePressableSandboxSite,
+				fakePressableDevelopmentSite,
 			],
 			syncSites: [ fakePressableProductionSite ],
 			pullSite: jest.fn(),
@@ -387,11 +389,11 @@ describe( 'ContentTabSync', () => {
 
 		expect( screen.getByText( fakePressableProductionSite.name ) ).toBeInTheDocument();
 		expect( screen.getByText( fakePressableStagingSite.name ) ).toBeInTheDocument();
-		expect( screen.getByText( fakePressableSandboxSite.name ) ).toBeInTheDocument();
+		expect( screen.getByText( fakePressableDevelopmentSite.name ) ).toBeInTheDocument();
 
 		expect( screen.getByText( 'Production' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Staging' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Sandbox' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Development' ) ).toBeInTheDocument();
 	} );
 	it( 'displays the progress bar when the site is being pushed', () => {
 		( useAuth as jest.Mock ).mockReturnValue( { isAuthenticated: true, authenticate: jest.fn() } );
@@ -420,7 +422,7 @@ describe( 'ContentTabSync', () => {
 		expect( screen.getByRole( 'progressbar' ) ).toBeInTheDocument();
 	} );
 
-	it( 'opens sync pullSite dialog with sandbox environment label', async () => {
+	it( 'opens sync pullSite dialog with development environment label', async () => {
 		const mockPullSite = jest.fn();
 		( useAuth as jest.Mock ).mockReturnValue( { isAuthenticated: true, authenticate: jest.fn() } );
 		const fakeSyncSite = {
@@ -429,7 +431,7 @@ describe( 'ContentTabSync', () => {
 			url: 'https:/developer.wordpress.com/studio/',
 			syncSupport: 'already-connected',
 			isPressable: true,
-			environmentType: 'sandbox',
+			environmentType: 'development',
 		};
 		( useSyncSites as jest.Mock ).mockReturnValue( {
 			connectedSites: [ fakeSyncSite ],
@@ -452,9 +454,9 @@ describe( 'ContentTabSync', () => {
 		expect( pullButton ).toBeInTheDocument();
 		fireEvent.click( pullButton );
 
-		await screen.findByText( 'Pull from Sandbox' );
+		await screen.findByText( 'Pull from Development' );
 		await screen.findByText(
-			"Pulling will overwrite your Studio site's selected files and database with a copy from your sandbox site. Unchecked items will not be changed."
+			"Pulling will overwrite your Studio site's selected files and database with a copy from your development site. Unchecked items will not be changed."
 		);
 	} );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-672

## Proposed Changes

- Add full string translations so the environment type will correctly appear in the pull/push dialog
- Support only the four valid environment types (production, staging, development and local) other types will appear as `Production`.
- Update and add tests

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Modify your **production** or **staging** WPcom's environment_type to `development` in network admin settings tab.
- Run `npm start`
- Observe your site appears in Studio
- Open the sync modal
- Connect the site
- Open the pull and push dialogs.
- Observe the texts remain the same as before. Now it also supports `Local`, for that case I added "remote Local" to differentiate with Studio site.

| Push  | Pull  |
|--------|--------|
|  <img width="2024" height="1424" alt="Screenshot 2025-08-06 at 17 00 50" src="https://github.com/user-attachments/assets/6d29e669-91d5-4e98-bf75-7ece86f1804c" />  | <img width="2024" height="1424" alt="Screenshot 2025-08-06 at 17 00 48" src="https://github.com/user-attachments/assets/7f8b42b6-138f-4bf7-8bf6-de760a40e320" /> |
| <img width="2024" height="1424" alt="Screenshot 2025-08-06 at 17 01 05" src="https://github.com/user-attachments/assets/2c6c7df3-4ee7-499a-852c-71bbe4e7c1a8" /> | <img width="2024" height="1424" alt="Screenshot 2025-08-06 at 17 01 02" src="https://github.com/user-attachments/assets/6e11bc5c-017e-48fa-80f4-f80e993b8b4f" /> |
| <img width="2024" height="1424" alt="Screenshot 2025-08-06 at 17 01 16" src="https://github.com/user-attachments/assets/6a18518a-abe9-4e1a-ab10-f71815c2a71c" /> | <img width="2024" height="1424" alt="Screenshot 2025-08-06 at 17 01 14" src="https://github.com/user-attachments/assets/ccf935a6-63bb-450b-a6b8-6b0215a1cd73" /> |


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
