### PR TITLE
Use only reachable tags to generate version

### DIFF
--- a/scripts/lib/git-utils.mjs
+++ b/scripts/lib/git-utils.mjs
@@ -11,7 +11,7 @@ export const getLatestTag = () => {
 
 		// Get the latest reachable release tag that is not a beta tag
 		const latestReleaseTag = child_process
-			.execSync( 'git describe --tags --abbrev=0 --match \'v*\' --exclude \'*-beta*\'' )
+			.execSync( 'git describe --tags --abbrev=0 --match "v*" --exclude "*-beta*"' )
 			.toString()
 			.trim();
 

--- a/scripts/lib/git-utils.mjs
+++ b/scripts/lib/git-utils.mjs
@@ -8,7 +8,7 @@ export const getLatestTag = () => {
 	try {
 		// List all tags sorted by version, then filter for release tags only
 		const tags = child_process
-			.execSync( 'git tag --sort=-v:refname' )
+			.execSync( 'git tag --sort=-v:refname --merged=HEAD' )
 			.toString()
 			.trim()
 			.split( '\n' );

--- a/scripts/lib/git-utils.mjs
+++ b/scripts/lib/git-utils.mjs
@@ -6,6 +6,9 @@ import * as child_process from 'child_process';
  */
 export const getLatestTag = () => {
 	try {
+		// Fetch all tags to ensure they're available
+		child_process.execSync( 'git fetch --tags --force', { stdio: 'pipe' } );
+
 		// Get the latest reachable release tag that is not a beta tag
 		const latestReleaseTag = child_process
 			.execSync( 'git describe --tags --abbrev=0 --match \'v*\' --exclude \'*-beta*\'' )

--- a/scripts/lib/git-utils.mjs
+++ b/scripts/lib/git-utils.mjs
@@ -6,15 +6,12 @@ import * as child_process from 'child_process';
  */
 export const getLatestTag = () => {
 	try {
-		// List all tags sorted by version, then filter for release tags only
-		const tags = child_process
-			.execSync( 'git tag --sort=-v:refname --merged=HEAD' )
+		// Get the latest reachable release tag that is not a beta tag
+		const latestReleaseTag = child_process
+			.execSync( 'git describe --tags --abbrev=0 --match \'v*\' --exclude \'*-beta*\'' )
 			.toString()
-			.trim()
-			.split( '\n' );
+			.trim();
 
-		// Find first tag that doesn't include '-' (no pre-release part)
-		const latestReleaseTag = tags.find( ( tag ) => ! tag.includes( '-' ) );
 		return latestReleaseTag || '';
 	} catch ( error ) {
 		// If no tags exist, return empty string


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Related discussion: p1754569879531659/1752837980.840429-slack-CC7L49W13

## Proposed Changes

I propose to update the build script that generates the version to use only **reachable** tags to fix an edge case in which the build should run for an older tag, but reads a newer tag from the remote.

The chain of events looked as follows:
1. We merged the 583fcaf commit that still should read v1.5.5 as the latest stable tag
2. Within a minute, we merged the 4ffa1a2 commit and tagged it with v1.5.6
3. Build started for the 583fcaf but was able to fetch the latest tag as v1.5.6 at this point instead of 1.5.5.
4. The build failed as it tried to read 1.5.6.0 artifact but 1.5.5.0 was the valid one

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Switch to the commit:
```
gco 583fcaf4d2e4cb268d9670b0461717aa6d5a4d59
```
2. Apply changes from this branch
3. Run script:
```
node ./scripts/prepare-dev-build-version.mjs  
```
4. Confirm the version was generated as `1.5.5-dev65` and not `1.5.6-dev0`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?