### PR TITLE
Fix lint and test warnings in content-tab-settings test

### DIFF
--- a/src/components/tests/content-tab-settings.test.tsx
+++ b/src/components/tests/content-tab-settings.test.tsx
@@ -116,6 +116,7 @@ describe( 'ContentTabSettings', () => {
 			json: jest.fn().mockResolvedValue( {
 				offers: [],
 			} ),
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		} as any );
 
 		// Create a fresh store for each test

--- a/src/components/tests/content-tab-settings.test.tsx
+++ b/src/components/tests/content-tab-settings.test.tsx
@@ -111,13 +111,12 @@ describe( 'ContentTabSettings', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
 
-		// Mock fetch to prevent console errors from wordpress-versions-api
-		global.fetch = jest.fn().mockResolvedValue( {
+		jest.spyOn( global, 'fetch' ).mockResolvedValue( {
 			ok: true,
 			json: jest.fn().mockResolvedValue( {
 				offers: [],
 			} ),
-		} );
+		} as any );
 
 		// Create a fresh store for each test
 		testStore = createCustomTestStore();

--- a/src/components/tests/content-tab-settings.test.tsx
+++ b/src/components/tests/content-tab-settings.test.tsx
@@ -73,6 +73,21 @@ jest.mock( 'src/lib/app-globals', () => ( {
 	isWindows: () => false,
 } ) );
 
+jest.mock( 'src/stores/wordpress-versions-api', () => {
+	const actual = jest.requireActual( 'src/stores/wordpress-versions-api' );
+	return {
+		...actual,
+		useGetWordPressVersions: jest.fn( () => ( {
+			data: [
+				{ label: 'Latest', value: 'latest', isBeta: false, isDevelopment: false },
+				{ label: '6.4', value: '6.4', isBeta: false, isDevelopment: false },
+				{ label: '6.3', value: '6.3', isBeta: false, isDevelopment: false },
+			],
+			isLoading: false,
+		} ) ),
+	};
+} );
+
 const selectedSite: SiteDetails = {
 	name: 'Test Site',
 	port: 8881,
@@ -110,14 +125,6 @@ describe( 'ContentTabSettings', () => {
 
 	beforeEach( () => {
 		jest.clearAllMocks();
-
-		jest.spyOn( global, 'fetch' ).mockResolvedValue( {
-			ok: true,
-			json: jest.fn().mockResolvedValue( {
-				offers: [],
-			} ),
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		} as any );
 
 		// Create a fresh store for each test
 		testStore = createCustomTestStore();

--- a/src/components/tests/content-tab-settings.test.tsx
+++ b/src/components/tests/content-tab-settings.test.tsx
@@ -1,13 +1,12 @@
 // To run tests, execute `npm run test -- src/components/tests/content-tab-settings.test.tsx` from the root directory
 import { UnknownAction } from '@reduxjs/toolkit';
-import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import { produce } from 'immer';
 import { Provider } from 'react-redux';
 import { Snapshot } from 'common/types/snapshot';
 import { ContentTabSettings } from 'src/components/content-tab-settings';
 import { useGetWpVersion } from 'src/hooks/use-get-wp-version';
-import { useOffline } from 'src/hooks/use-offline';
 import { useSiteDetails } from 'src/hooks/use-site-details';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 import { createTestStore } from 'src/lib/test-utils';
@@ -111,6 +110,14 @@ describe( 'ContentTabSettings', () => {
 
 	beforeEach( () => {
 		jest.clearAllMocks();
+
+		// Mock fetch to prevent console errors from wordpress-versions-api
+		global.fetch = jest.fn().mockResolvedValue( {
+			ok: true,
+			json: jest.fn().mockResolvedValue( {
+				offers: [],
+			} ),
+		} );
 
 		// Create a fresh store for each test
 		testStore = createCustomTestStore();


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- N/A

## Proposed Changes

- `npm run lint` and `npm test` were generating some warnings, this PR aims to clean it up.

<img width="972" height="200" alt="image" src="https://github.com/user-attachments/assets/2f2a9c0f-5468-4da1-823d-e004a8af7589" />

<img width="1111" height="484" alt="image" src="https://github.com/user-attachments/assets/e094966f-306b-4e2c-933c-b18b6b6df079" />


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- `npm run lint`
- `npm test`
- confirm no warnings are shown

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
