### PR TITLE
Reduce the length of unique monthly launches stat

### DIFF
--- a/common/types/stats.ts
+++ b/common/types/stats.ts
@@ -3,7 +3,7 @@ export enum StatsGroup {
 	STUDIO_APP_LAUNCH = 'studio-app-launch-first',
 	STUDIO_APP_LAUNCH_TOTAL = 'studio-app-launch-total',
 	STUDIO_APP_LAUNCH_UNIQUE = 'studio-app-launch-uniques',
-	STUDIO_APP_LAUNCH_UNIQUE_MONTHLY = 'studio-app-launch-uniques-monthly',
+	STUDIO_APP_LAUNCH_UNIQUE_MONTHLY = 'studio-app-launch-uniqs-mon',
 	STUDIO_IMPORT = 'studio-app-import',
 	STUDIO_EXPORT = 'studio-app-export',
 	// Studio CLI


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Related to STU-638 
- Follow-up from https://github.com/Automattic/studio/pull/1570

## Proposed Changes

- Make the stat key shorter to fit the 32 length limit. It's even shorter to support the -a11n suffix
- I created an issue to avoid falling into the same mistake in the future. STU-694
- I created a backend PR to start tracking the old long stat: 190268-ghe-Automattic/wpcom

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run `npm start`
- Observe the node console it mentions the new stat name

```
Would have bumped stat: studio-app-launch-total=darwin
Would have bumped stat: studio-app-launch-uniqs-mon=darwin
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?