### PR TITLE
Increase timeout for expect() as 5s timeout fails in some cases

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -13,4 +13,9 @@ export default defineConfig( {
 	},
 
 	timeout: 60_000,
+
+	// Global expect timeout for all assertions
+	expect: {
+		timeout: 10_000,
+	},
 } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes https://buildkite.com/automattic/studio/builds/7461

## Proposed Changes

I propose to increase timeout for `expect()` as 5s timeout results in e2e tests failing in some cases.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Confirm builds work fine.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
