### PR TITLE
Update wordpress i18n library to 6.1.0

### DIFF
--- a/cli/lib/validation.ts
+++ b/cli/lib/validation.ts
@@ -30,7 +30,7 @@ export async function validateSiteSize( siteFolder: string ): Promise< true > {
 		throw new LoggerError(
 			sprintf(
 				__(
-					'Your site exceeds the %s GB size limit. Please, consider removing unnecessary media files, plugins, or themes from wp-content.'
+					'Your site exceeds the %d GB size limit. Please, consider removing unnecessary media files, plugins, or themes from wp-content.'
 				),
 				DEMO_SITE_SIZE_LIMIT_GB
 			)

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
 				"@types/yargs": "^17.0.33",
 				"@vscode/sudo-prompt": "^9.3.1",
 				"@wordpress/compose": "^7.26.0",
-				"@wordpress/i18n": "^5.26.0",
+				"@wordpress/i18n": "^6.1.0",
 				"@wordpress/icons": "^10.10.0",
 				"@wp-playground/blueprints": "^2.0.7",
 				"@wp-playground/cli": "^2.0.7",
@@ -8670,6 +8670,42 @@
 				"npm": ">=8.19.2"
 			}
 		},
+		"node_modules/@wordpress/a11y/node_modules/@wordpress/hooks": {
+			"version": "4.28.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.28.0.tgz",
+			"integrity": "sha512-NE7ObdwcVDNHz19UVOjcbO6BlRLXQtRnZWWyFLNttFTmXEJo5wNbG1hTPaDQCGdV71mmHvGYJat9JqY04tIO9g==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "7.25.7"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/a11y/node_modules/@wordpress/i18n": {
+			"version": "5.26.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-5.26.0.tgz",
+			"integrity": "sha512-YHzaUWlCuN2ynl47qbsdMkTGtP52+E1giDOdWBgUaSexUYjbeFxKFUzRMB0Wuh1psL80+VzvJOH/mU440KAJnA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "7.25.7",
+				"@wordpress/hooks": "^4.26.0",
+				"gettext-parser": "^1.3.1",
+				"memize": "^2.1.0",
+				"sprintf-js": "^1.1.1",
+				"tannin": "^1.2.0"
+			},
+			"bin": {
+				"pot-to-php": "tools/pot-to-php.js"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
 		"node_modules/@wordpress/components": {
 			"version": "29.12.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-29.12.0.tgz",
@@ -8740,6 +8776,28 @@
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "7.25.7"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/components/node_modules/@wordpress/i18n": {
+			"version": "5.26.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-5.26.0.tgz",
+			"integrity": "sha512-YHzaUWlCuN2ynl47qbsdMkTGtP52+E1giDOdWBgUaSexUYjbeFxKFUzRMB0Wuh1psL80+VzvJOH/mU440KAJnA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "7.25.7",
+				"@wordpress/hooks": "^4.26.0",
+				"gettext-parser": "^1.3.1",
+				"memize": "^2.1.0",
+				"sprintf-js": "^1.1.1",
+				"tannin": "^1.2.0"
+			},
+			"bin": {
+				"pot-to-php": "tools/pot-to-php.js"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -8957,16 +9015,16 @@
 			}
 		},
 		"node_modules/@wordpress/i18n": {
-			"version": "5.26.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-5.26.0.tgz",
-			"integrity": "sha512-YHzaUWlCuN2ynl47qbsdMkTGtP52+E1giDOdWBgUaSexUYjbeFxKFUzRMB0Wuh1psL80+VzvJOH/mU440KAJnA==",
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.1.0.tgz",
+			"integrity": "sha512-C7GJ0xjGF2bMrcMsnNdSaRr+vufaUhsFOOEFtUi/YjYtjwBbCkNck+2IGrO8MwHYBVPq+elQZIAA0tiix+rW0w==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "7.25.7",
-				"@wordpress/hooks": "^4.26.0",
+				"@tannin/sprintf": "^1.3.1",
+				"@wordpress/hooks": "^4.28.0",
 				"gettext-parser": "^1.3.1",
 				"memize": "^2.1.0",
-				"sprintf-js": "^1.1.1",
 				"tannin": "^1.2.0"
 			},
 			"bin": {
@@ -8978,9 +9036,9 @@
 			}
 		},
 		"node_modules/@wordpress/i18n/node_modules/@wordpress/hooks": {
-			"version": "4.26.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.26.0.tgz",
-			"integrity": "sha512-pYbk2Oz4EbFge2AYnCeaLXKOP9JOleJDw3qTn8NY863ufKqU2i4Ttu3lYjJPk/+YIE3LZ7bdUtYypD1cltWVcg==",
+			"version": "4.28.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.28.0.tgz",
+			"integrity": "sha512-NE7ObdwcVDNHz19UVOjcbO6BlRLXQtRnZWWyFLNttFTmXEJo5wNbG1hTPaDQCGdV71mmHvGYJat9JqY04tIO9g==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "7.25.7"
@@ -9026,40 +9084,6 @@
 			"dependencies": {
 				"@babel/runtime": "7.25.7",
 				"@wordpress/i18n": "^6.1.0"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			}
-		},
-		"node_modules/@wordpress/keycodes/node_modules/@wordpress/hooks": {
-			"version": "4.28.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.28.0.tgz",
-			"integrity": "sha512-NE7ObdwcVDNHz19UVOjcbO6BlRLXQtRnZWWyFLNttFTmXEJo5wNbG1hTPaDQCGdV71mmHvGYJat9JqY04tIO9g==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@babel/runtime": "7.25.7"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			}
-		},
-		"node_modules/@wordpress/keycodes/node_modules/@wordpress/i18n": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.1.0.tgz",
-			"integrity": "sha512-C7GJ0xjGF2bMrcMsnNdSaRr+vufaUhsFOOEFtUi/YjYtjwBbCkNck+2IGrO8MwHYBVPq+elQZIAA0tiix+rW0w==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@tannin/sprintf": "^1.3.1",
-				"@wordpress/hooks": "^4.28.0",
-				"gettext-parser": "^1.3.1",
-				"memize": "^2.1.0",
-				"tannin": "^1.2.0"
-			},
-			"bin": {
-				"pot-to-php": "tools/pot-to-php.js"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -9225,6 +9249,42 @@
 			},
 			"peerDependencies": {
 				"react": "^18.0.0"
+			}
+		},
+		"node_modules/@wordpress/rich-text/node_modules/@wordpress/hooks": {
+			"version": "4.28.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.28.0.tgz",
+			"integrity": "sha512-NE7ObdwcVDNHz19UVOjcbO6BlRLXQtRnZWWyFLNttFTmXEJo5wNbG1hTPaDQCGdV71mmHvGYJat9JqY04tIO9g==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "7.25.7"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/rich-text/node_modules/@wordpress/i18n": {
+			"version": "5.26.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-5.26.0.tgz",
+			"integrity": "sha512-YHzaUWlCuN2ynl47qbsdMkTGtP52+E1giDOdWBgUaSexUYjbeFxKFUzRMB0Wuh1psL80+VzvJOH/mU440KAJnA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@babel/runtime": "7.25.7",
+				"@wordpress/hooks": "^4.26.0",
+				"gettext-parser": "^1.3.1",
+				"memize": "^2.1.0",
+				"sprintf-js": "^1.1.1",
+				"tannin": "^1.2.0"
+			},
+			"bin": {
+				"pot-to-php": "tools/pot-to-php.js"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/undo-manager": {
@@ -24358,7 +24418,8 @@
 		"node_modules/sprintf-js": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
-			"integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="
+			"integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+			"dev": true
 		},
 		"node_modules/ssri": {
 			"version": "9.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8649,40 +8649,6 @@
 				"npm": ">=8.19.2"
 			}
 		},
-		"node_modules/@wordpress/a11y/node_modules/@wordpress/hooks": {
-			"version": "4.28.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.28.0.tgz",
-			"integrity": "sha512-NE7ObdwcVDNHz19UVOjcbO6BlRLXQtRnZWWyFLNttFTmXEJo5wNbG1hTPaDQCGdV71mmHvGYJat9JqY04tIO9g==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@babel/runtime": "7.25.7"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			}
-		},
-		"node_modules/@wordpress/a11y/node_modules/@wordpress/i18n": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.1.0.tgz",
-			"integrity": "sha512-C7GJ0xjGF2bMrcMsnNdSaRr+vufaUhsFOOEFtUi/YjYtjwBbCkNck+2IGrO8MwHYBVPq+elQZIAA0tiix+rW0w==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@tannin/sprintf": "^1.3.1",
-				"@wordpress/hooks": "^4.28.0",
-				"gettext-parser": "^1.3.1",
-				"memize": "^2.1.0",
-				"tannin": "^1.2.0"
-			},
-			"bin": {
-				"pot-to-php": "tools/pot-to-php.js"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			}
-		},
 		"node_modules/@wordpress/base-styles": {
 			"version": "6.4.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-6.4.0.tgz",
@@ -8995,27 +8961,6 @@
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "7.25.7"
-			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			}
-		},
-		"node_modules/@wordpress/dataviews/node_modules/@wordpress/i18n": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.1.0.tgz",
-			"integrity": "sha512-C7GJ0xjGF2bMrcMsnNdSaRr+vufaUhsFOOEFtUi/YjYtjwBbCkNck+2IGrO8MwHYBVPq+elQZIAA0tiix+rW0w==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@babel/runtime": "7.25.7",
-				"@tannin/sprintf": "^1.3.1",
-				"@wordpress/hooks": "^4.28.0",
-				"gettext-parser": "^1.3.1",
-				"memize": "^2.1.0",
-				"tannin": "^1.2.0"
-			},
-			"bin": {
-				"pot-to-php": "tools/pot-to-php.js"
 			},
 			"engines": {
 				"node": ">=18.12.0",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
 		"@types/yargs": "^17.0.33",
 		"@vscode/sudo-prompt": "^9.3.1",
 		"@wordpress/compose": "^7.26.0",
-		"@wordpress/i18n": "^5.26.0",
+		"@wordpress/i18n": "^6.1.0",
 		"@wordpress/icons": "^10.10.0",
 		"@wp-playground/blueprints": "^2.0.7",
 		"@wp-playground/cli": "^2.0.7",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
 		"@types/yargs": "^17.0.33",
 		"@vscode/sudo-prompt": "^9.3.1",
 		"@wordpress/compose": "^7.26.0",
-	    "@wordpress/dataviews": "^6.0.0",
+		"@wordpress/dataviews": "^6.0.0",
 		"@wordpress/i18n": "^6.1.0",
 		"@wordpress/icons": "^10.10.0",
 		"@wp-playground/blueprints": "^2.0.7",

--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -75,8 +75,8 @@ const UsageLimitReached = () => {
 			? __( "You've reached your <a>usage limit</a> for this month. Your limit will reset today." )
 			: sprintf(
 					_n(
-						"You've reached your <a>usage limit</a> for this month. Your limit will reset in %s day.",
-						"You've reached your <a>usage limit</a> for this month. Your limit will reset in %s days.",
+						"You've reached your <a>usage limit</a> for this month. Your limit will reset in %d day.",
+						"You've reached your <a>usage limit</a> for this month. Your limit will reset in %d days.",
 						daysUntilReset
 					),
 					daysUntilReset

--- a/src/components/onboarding.tsx
+++ b/src/components/onboarding.tsx
@@ -67,7 +67,7 @@ export default function Onboarding() {
 	const siteAddedMessage = sprintf(
 		// translators: %s is the site name.
 		__( '%s site added.' ),
-		siteName
+		siteName || ''
 	);
 
 	const { data: versions = [] } = useGetWordPressVersions();

--- a/src/components/site-management-actions.tsx
+++ b/src/components/site-management-actions.tsx
@@ -29,7 +29,7 @@ export const SiteManagementActions = ( {
 	const isPulling = isSiteIdPulling( selectedSite.id );
 	const disabled = isImporting || isPulling;
 
-	let buttonLabelOnDisabled = __( 'Importing…' );
+	let buttonLabelOnDisabled: string = __( 'Importing…' );
 	if ( isPulling ) {
 		buttonLabelOnDisabled = __( 'Pulling…' );
 	}

--- a/src/components/top-bar.tsx
+++ b/src/components/top-bar.tsx
@@ -81,7 +81,7 @@ function Authentication() {
 				variant="icon"
 				className="text-white hover:!text-white !px-1 py-1 !h-6 gap-2"
 			>
-				<span>{ sprintf( __( 'Howdy, %s' ), user?.displayName ) }</span>{ ' ' }
+				<span>{ sprintf( __( 'Howdy, %s' ), user?.displayName || '' ) }</span>{ ' ' }
 				<Gravatar size={ 18 } className="border-white border-[1.5px]" />
 			</Button>
 		);

--- a/src/hooks/sync-sites/use-sync-pull.ts
+++ b/src/hooks/sync-sites/use-sync-pull.ts
@@ -182,7 +182,7 @@ export function useSyncPull( {
 						message: __( "Large site's backup" ),
 						detail: sprintf(
 							__(
-								"Your site's backup exceeds %s GB. Pulling it will prevent you from pushing the site back.\n\nDo you want to continue?"
+								"Your site's backup exceeds %d GB. Pulling it will prevent you from pushing the site back.\n\nDo you want to continue?"
 							),
 							SYNC_PUSH_SIZE_LIMIT_GB
 						),

--- a/src/hooks/use-localization-support.ts
+++ b/src/hooks/use-localization-support.ts
@@ -7,7 +7,7 @@ export function useLocalizationSupport() {
 	const locale = useI18nLocale();
 
 	// Some languages may need to set an html lang attribute that is different from their slug
-	let lang = __( 'html_lang_attribute' );
+	let lang: string = __( 'html_lang_attribute' );
 
 	// Some languages don't have the translation for html_lang_attribute
 	// or maybe we are dealing with the default `en` locale. Return the general purpose locale slug

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -10,17 +10,13 @@ import { FormatDistanceFn } from 'date-fns';
  * @returns localized distance string
  */
 export const formatDistance: FormatDistanceFn = ( token, count ) => {
-	let stringToFormat = '';
 	switch ( token ) {
 		case 'xDays':
-			stringToFormat = _n( '%d day', '%d days', count );
-			break;
+			return sprintf( _n( '%d day', '%d days', count ), count );
 		case 'xHours':
-			stringToFormat = _n( '%d hour', '%d hours', count );
-			break;
+			return sprintf( _n( '%d hour', '%d hours', count ), count );
 		case 'xMinutes':
-			stringToFormat = _n( '%d minute', '%d minutes', count );
-			break;
+			return sprintf( _n( '%d minute', '%d minutes', count ), count );
 	}
-	return sprintf( stringToFormat, count );
+	return '';
 };

--- a/src/modules/add-site/components/add-site-legacy.tsx
+++ b/src/modules/add-site/components/add-site-legacy.tsx
@@ -74,7 +74,7 @@ export default function AddSite( { className, showModal, setShowModal }: AddSite
 	const siteAddedMessage = sprintf(
 		// translators: %s is the site name.
 		__( '%s site added.' ),
-		siteName
+		siteName || ''
 	);
 
 	const { data: versions = [] } = useGetWordPressVersions();

--- a/src/modules/add-site/hooks/use-stepper.ts
+++ b/src/modules/add-site/hooks/use-stepper.ts
@@ -10,12 +10,12 @@ interface StepperStep {
 }
 
 interface StepperConfig {
-	onBlueprintContinue?: () => void;
-	onBackupContinue?: () => void;
-	onCreateSubmit?: ( event: FormEvent ) => void;
-	canSubmitBlueprint?: boolean;
-	canSubmitBackup?: boolean;
-	canSubmitCreate?: boolean;
+	onBlueprintContinue: () => void;
+	onBackupContinue: () => void;
+	onCreateSubmit: ( event: FormEvent ) => void;
+	canSubmitBlueprint: boolean;
+	canSubmitBackup: boolean;
+	canSubmitCreate: boolean;
 }
 
 interface StepperContext {

--- a/src/modules/add-site/hooks/use-stepper.ts
+++ b/src/modules/add-site/hooks/use-stepper.ts
@@ -19,7 +19,11 @@ interface StepperConfig {
 }
 
 interface StepperContext {
-	flow?: 'blueprint' | 'backup' | 'create';
+	flow: 'blueprint' | 'backup' | 'create';
+	steps: StepperStep[];
+}
+
+interface UseStepper {
 	steps: StepperStep[];
 	isVisible?: boolean;
 	actionButton?: {
@@ -30,7 +34,7 @@ interface StepperContext {
 	canSubmit?: boolean;
 }
 
-export function useStepper( config?: StepperConfig ): StepperContext {
+export function useStepper( config?: StepperConfig ): UseStepper {
 	const { __ } = useI18n();
 	const { location } = useNavigator();
 

--- a/src/modules/add-site/hooks/use-stepper.ts
+++ b/src/modules/add-site/hooks/use-stepper.ts
@@ -10,12 +10,12 @@ interface StepperStep {
 }
 
 interface StepperConfig {
-	onBlueprintContinue: () => void;
-	onBackupContinue: () => void;
-	onCreateSubmit: ( event: FormEvent ) => void;
-	canSubmitBlueprint: boolean;
-	canSubmitBackup: boolean;
-	canSubmitCreate: boolean;
+	onBlueprintContinue?: () => void;
+	onBackupContinue?: () => void;
+	onCreateSubmit?: ( event: FormEvent ) => void;
+	canSubmitBlueprint?: boolean;
+	canSubmitBackup?: boolean;
+	canSubmitCreate?: boolean;
 }
 
 interface StepperContext {

--- a/src/modules/add-site/hooks/use-stepper.ts
+++ b/src/modules/add-site/hooks/use-stepper.ts
@@ -34,7 +34,7 @@ export function useStepper( config?: StepperConfig ): StepperContext {
 	const { __ } = useI18n();
 	const { location } = useNavigator();
 
-	const stepperConfig = useMemo( (): StepperContext | null => {
+	const stepperContext = useMemo( (): StepperContext | null => {
 		const blueprintSteps: StepperStep[] = [
 			{ id: 'choose-blueprint', label: __( 'Choose blueprint' ), path: '/blueprint' },
 			{ id: 'site-details', label: __( 'Site name & details' ), path: '/blueprint/create' },
@@ -74,16 +74,16 @@ export function useStepper( config?: StepperConfig ): StepperContext {
 	}, [ location.path, __ ] );
 
 	const steps = useMemo( (): StepperStep[] => {
-		if ( ! stepperConfig ) {
+		if ( ! stepperContext ) {
 			return [];
 		}
 
-		return stepperConfig.steps.map( ( step ): StepperStep => {
+		return stepperContext.steps.map( ( step ): StepperStep => {
 			let status: 'completed' | 'current' | 'pending' = 'pending';
 
 			// Determine status based on current path
-			const currentStepIndex = stepperConfig.steps.findIndex( ( s ) => location.path === s.path );
-			const stepIndex = stepperConfig.steps.indexOf( step );
+			const currentStepIndex = stepperContext.steps.findIndex( ( s ) => location.path === s.path );
+			const stepIndex = stepperContext.steps.indexOf( step );
 
 			if ( stepIndex < currentStepIndex ) {
 				status = 'completed';
@@ -97,10 +97,10 @@ export function useStepper( config?: StepperConfig ): StepperContext {
 				status,
 			};
 		} );
-	}, [ stepperConfig, location.path ] );
+	}, [ stepperContext, location.path ] );
 
 	// Only show stepper when we're in a multi-step flow
-	const isVisible = stepperConfig !== null && location.path !== '/';
+	const isVisible = stepperContext !== null && location.path !== '/';
 
 	// Determine action button configuration based on current path
 	const actionButton = useMemo( () => {

--- a/src/modules/add-site/hooks/use-stepper.ts
+++ b/src/modules/add-site/hooks/use-stepper.ts
@@ -25,13 +25,13 @@ interface StepperContext {
 
 interface UseStepper {
 	steps: StepperStep[];
-	isVisible?: boolean;
+	isVisible: boolean;
 	actionButton?: {
 		label: string;
 		isVisible: boolean;
 	};
-	onSubmit?: () => void;
-	canSubmit?: boolean;
+	onSubmit: () => void;
+	canSubmit: boolean;
 }
 
 export function useStepper( config?: StepperConfig ): UseStepper {

--- a/src/modules/add-site/hooks/use-stepper.ts
+++ b/src/modules/add-site/hooks/use-stepper.ts
@@ -5,7 +5,8 @@ import { FormEvent, useCallback, useMemo } from 'react';
 interface StepperStep {
 	id: string;
 	label: string;
-	status: 'completed' | 'current' | 'pending';
+	status?: 'completed' | 'current' | 'pending';
+	path?: string;
 }
 
 interface StepperConfig {
@@ -18,32 +19,33 @@ interface StepperConfig {
 }
 
 interface StepperContext {
+	flow?: 'blueprint' | 'backup' | 'create';
 	steps: StepperStep[];
-	isVisible: boolean;
+	isVisible?: boolean;
 	actionButton?: {
 		label: string;
 		isVisible: boolean;
 	};
-	onSubmit: () => void;
-	canSubmit: boolean;
+	onSubmit?: () => void;
+	canSubmit?: boolean;
 }
 
 export function useStepper( config?: StepperConfig ): StepperContext {
 	const { __ } = useI18n();
 	const { location } = useNavigator();
 
-	const stepperConfig = useMemo( () => {
-		const blueprintSteps = [
+	const stepperConfig = useMemo( (): StepperContext | null => {
+		const blueprintSteps: StepperStep[] = [
 			{ id: 'choose-blueprint', label: __( 'Choose blueprint' ), path: '/blueprint' },
 			{ id: 'site-details', label: __( 'Site name & details' ), path: '/blueprint/create' },
 		];
 
-		const backupSteps = [
+		const backupSteps: StepperStep[] = [
 			{ id: 'select-file', label: __( 'Select or drop a file' ), path: '/backup' },
 			{ id: 'add-site', label: __( 'Site name & details' ), path: '/backup/create' },
 		];
 
-		const createSteps = [
+		const createSteps: StepperStep[] = [
 			{ id: 'create-site', label: __( 'Site name & details' ), path: '/create' },
 		];
 
@@ -71,12 +73,12 @@ export function useStepper( config?: StepperConfig ): StepperContext {
 		return null;
 	}, [ location.path, __ ] );
 
-	const steps = useMemo( () => {
+	const steps = useMemo( (): StepperStep[] => {
 		if ( ! stepperConfig ) {
 			return [];
 		}
 
-		return stepperConfig.steps.map( ( step ) => {
+		return stepperConfig.steps.map( ( step ): StepperStep => {
 			let status: 'completed' | 'current' | 'pending' = 'pending';
 
 			// Determine status based on current path

--- a/src/modules/add-site/index.tsx
+++ b/src/modules/add-site/index.tsx
@@ -277,7 +277,7 @@ export default function AddSite( { className }: AddSiteProps ) {
 	const siteAddedMessage = sprintf(
 		// translators: %s is the site name.
 		__( '%s site added.' ),
-		siteName
+		siteName || ''
 	);
 
 	const initializeForm = useCallback( async () => {

--- a/src/modules/cli/lib/install-macos.ts
+++ b/src/modules/cli/lib/install-macos.ts
@@ -33,7 +33,9 @@ export async function installCLIOnMacOSWithConfirmation() {
 		Sentry.captureException( error );
 		console.error( 'Failed to install CLI', error );
 
-		let message = __( 'There was an unknown error. Please check the logs for more information.' );
+		let message: string = __(
+			'There was an unknown error. Please check the logs for more information.'
+		);
 
 		if ( error instanceof Error ) {
 			if ( error.message === ERROR_FILE_ALREADY_EXISTS ) {

--- a/src/modules/preview-site/components/create-preview-button.tsx
+++ b/src/modules/preview-site/components/create-preview-button.tsx
@@ -65,8 +65,8 @@ export function CreatePreviewButton( { onClick, selectedSite, user }: CreatePrev
 	);
 	const allotmentConsumptionMessage = sprintf(
 		_n(
-			"You've used %s preview sites available on your account.",
-			"You've used all %s preview sites available on your account.",
+			"You've used %d preview sites available on your account.",
+			"You've used all %d preview sites available on your account.",
 			snapshotQuota
 		),
 		snapshotQuota
@@ -74,7 +74,7 @@ export function CreatePreviewButton( { onClick, selectedSite, user }: CreatePrev
 	const offlineMessage = __( 'Creating a preview site requires an internet connection.' );
 	const overLimitMessage = sprintf(
 		__(
-			'Your site exceeds the %s GB size limit. Please, consider removing unnecessary media files, plugins, or themes from wp-content.'
+			'Your site exceeds the %d GB size limit. Please, consider removing unnecessary media files, plugins, or themes from wp-content.'
 		),
 		DEMO_SITE_SIZE_LIMIT_GB
 	);

--- a/src/modules/preview-site/hooks/use-update-button-tooltip.ts
+++ b/src/modules/preview-site/hooks/use-update-button-tooltip.ts
@@ -32,7 +32,7 @@ export function useUpdateButtonTooltip( {
 			return {
 				text: sprintf(
 					__(
-						'Your site exceeds the %s GB size limit. Please, consider removing unnecessary media files, plugins, or themes from wp-content.'
+						'Your site exceeds the %d GB size limit. Please, consider removing unnecessary media files, plugins, or themes from wp-content.'
 					),
 					DEMO_SITE_SIZE_LIMIT_GB
 				),

--- a/src/modules/user-settings/components/prompt-info.tsx
+++ b/src/modules/user-settings/components/prompt-info.tsx
@@ -23,7 +23,7 @@ export function PromptInfo() {
 							<span className="text-a8c-gray-70">
 								{ isOffline
 									? __( "You're currently offline" )
-									: sprintf( __( '%1s of %2s monthly prompts used' ), promptCount, promptLimit ) }
+									: sprintf( __( '%1$d of %2$d monthly prompts used' ), promptCount, promptLimit ) }
 							</span>
 						</div>
 					</div>

--- a/src/modules/user-settings/components/snapshot-info.tsx
+++ b/src/modules/user-settings/components/snapshot-info.tsx
@@ -47,7 +47,7 @@ export const SnapshotInfo = ( {
 								<div className="flex flex-row items-center text-right">
 									{ isDeleting && <Spinner className="!mt-0 !mx-2" /> }
 									<span className="text-a8c-gray-70">
-										{ sprintf( __( '%1s of %2s active preview sites' ), siteCount, siteLimit ) }
+										{ sprintf( __( '%1$d of %2$d active preview sites' ), siteCount, siteLimit ) }
 									</span>
 								</div>
 							</div>

--- a/src/stores/snapshot-slice.ts
+++ b/src/stores/snapshot-slice.ts
@@ -461,18 +461,18 @@ window.ipcListener.subscribe( 'snapshot-success', ( event, payload ) => {
 	if ( operation.type === 'create' ) {
 		getIpcApi().showNotification( {
 			title: operation.snapshotName,
-			body: sprintf( __( "Preview site '%s' has been created." ), operation.snapshotUrl ),
+			body: sprintf( __( "Preview site '%s' has been created." ), operation.snapshotUrl || '' ),
 		} );
 	} else if ( operation.type === 'update' ) {
 		getIpcApi().showNotification( {
 			title: operation.snapshotName,
-			body: sprintf( __( "Preview site '%s' has been updated." ), operation.snapshotUrl ),
+			body: sprintf( __( "Preview site '%s' has been updated." ), operation.snapshotUrl || '' ),
 		} );
 	} else if ( operation.type === 'delete' ) {
 		if ( ! bulkOperation ) {
 			getIpcApi().showNotification( {
 				title: operation.snapshotName,
-				body: sprintf( __( "Preview site '%s' has been deleted." ), operation.snapshotUrl ),
+				body: sprintf( __( "Preview site '%s' has been deleted." ), operation.snapshotUrl || '' ),
 			} );
 		} else if ( bulkOperationIsSettled ) {
 			getIpcApi().showNotification( {

--- a/src/stores/snapshot-slice.ts
+++ b/src/stores/snapshot-slice.ts
@@ -458,21 +458,23 @@ window.ipcListener.subscribe( 'snapshot-success', ( event, payload ) => {
 		);
 	}
 
+	const { snapshotUrl = '' } = operation;
+
 	if ( operation.type === 'create' ) {
 		getIpcApi().showNotification( {
 			title: operation.snapshotName,
-			body: sprintf( __( "Preview site '%s' has been created." ), operation.snapshotUrl || '' ),
+			body: sprintf( __( "Preview site '%s' has been created." ), snapshotUrl ),
 		} );
 	} else if ( operation.type === 'update' ) {
 		getIpcApi().showNotification( {
 			title: operation.snapshotName,
-			body: sprintf( __( "Preview site '%s' has been updated." ), operation.snapshotUrl || '' ),
+			body: sprintf( __( "Preview site '%s' has been updated." ), snapshotUrl ),
 		} );
 	} else if ( operation.type === 'delete' ) {
 		if ( ! bulkOperation ) {
 			getIpcApi().showNotification( {
 				title: operation.snapshotName,
-				body: sprintf( __( "Preview site '%s' has been deleted." ), operation.snapshotUrl || '' ),
+				body: sprintf( __( "Preview site '%s' has been deleted." ), snapshotUrl ),
 			} );
 		} else if ( bulkOperationIsSettled ) {
 			getIpcApi().showNotification( {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Relates to https://github.com/Automattic/studio/pull/1662

## Proposed Changes

I propose updating @wordpress/i18n to 6.1.0. I opened a PR, as Dependabot won't be able to upgrade the package since it requires several changes to the translation function and sprintf usage.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Test if translations work fine, especially those that use string or decimal placeholders.
2. Confirm that the build works fine.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
