### PR TITLE
Ensure export error is not duplicated

### DIFF
--- a/src/components/content-tab-import-export.tsx
+++ b/src/components/content-tab-import-export.tsx
@@ -79,7 +79,7 @@ export const ExportSite = ( {
 							<div className="text-a8c-gray-70 a8c-body">{ currentProgress.statusMessage }</div>
 						</>
 					) }
-					{ isExportCompleted && (
+					{ isExportCompleted && ! isExportError && (
 						<ClearAction onClick={ handleClearExport }>
 							{ currentProgress.statusMessage }
 						</ClearAction>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-700

## Proposed Changes

I propose to change the condition to ensure that the export error is not duplicated.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create Studio site
2. Enable Blueprints feature flag (to trigger the export error)
3. Remove database constants from the `wp-config.php` field
4. Restart site (Playground CLI will re-add missing constant)
5. Export sites database
6. Confirm that the error message is displayed once

|**Before**|**After**|
|---|---|
| <img width="317" height="144" alt="Screenshot 2025-08-13 at 10 57 01" src="https://github.com/user-attachments/assets/dc88184d-ea1a-46fb-a01e-879ebd07c90c" /> | <img width="307" height="101" alt="Screenshot 2025-08-13 at 10 53 24" src="https://github.com/user-attachments/assets/1e832b2f-9828-4079-9f99-3f90b1de61b5" />|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
