### PR TITLE
Enable AST driver for Playground CLI

### DIFF
--- a/src/lib/wordpress-provider/playground-cli/playground-server-process-child.ts
+++ b/src/lib/wordpress-provider/playground-cli/playground-server-process-child.ts
@@ -157,8 +157,22 @@ async function startServer(
 			args.wp = serverOptions.wordPressVersion;
 		}
 
+		const defaultConstants = {
+			WP_SQLITE_AST_DRIVER: true,
+		};
+
 		if ( options.blueprint ) {
-			args.blueprint = options.blueprint;
+			args.blueprint = {
+				...options.blueprint,
+				constants: {
+					...options.blueprint.constants,
+					...defaultConstants,
+				},
+			};
+		} else {
+			args.blueprint = {
+				constants: defaultConstants,
+			};
 		}
 
 		server = await runCLI( args );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-704

## Proposed Changes

Playground CLI doesn't set a constant that enables the AST driver for the SQLite plugin, unlike `wp-now`. Studio needs to use the new driver to benefit from all compatibility fixes.

I propose to enable the AST driver for the Playground CLI.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Start Studio
2. Enable Blueprints feature flag
3. Create Studio site
4. Open WP Admin
5. Navigate to Site Health -> Database
6. Confirm it uses the new driver:

|**Before**|**After**|
|---|---|
|<img width="779" height="392" alt="Screenshot 2025-08-13 at 11 51 14" src="https://github.com/user-attachments/assets/2ffdfe15-135a-4e2b-9bda-44447b807c5d" /> | <img width="780" height="393" alt="Screenshot 2025-08-13 at 11 53 30" src="https://github.com/user-attachments/assets/39be32d6-6428-47cd-9b5a-81349dc8b0a6" />|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
