### PR TITLE
Adjust Bluepriunts UI according to designs

### DIFF
--- a/src/modules/add-site/components/blueprint-icon.tsx
+++ b/src/modules/add-site/components/blueprint-icon.tsx
@@ -7,53 +7,53 @@ export const BlueprintIcon = ( { size = 32 }: { size?: number } ) => (
 		xmlns="http://www.w3.org/2000/svg"
 	>
 		<path
-			d="M17.3334 19.8828C14.6667 19.8828 10.6667 21.2161 10.6667 26.5495"
+			d="M13.2434 14.7355C11.242 14.7355 8.23975 15.7362 8.23975 19.7392"
 			stroke="#3858E9"
-			strokeWidth="2"
-			strokeLinecap="round"
-			strokeLinejoin="round"
+			stroke-width="1.5011"
+			stroke-linecap="round"
+			stroke-linejoin="round"
 		/>
 		<path
-			d="M5.33374 17.2214C5.33374 16.5141 5.61469 15.8358 6.11479 15.3357C6.61489 14.8356 7.29316 14.5547 8.00041 14.5547H14.6671C15.3743 14.5547 16.0526 14.8356 16.5527 15.3357C17.0528 15.8358 17.3337 16.5141 17.3337 17.2214V23.888C17.3337 24.5953 17.0528 25.2735 16.5527 25.7736C16.0526 26.2737 15.3743 26.5547 14.6671 26.5547H8.00041C7.29316 26.5547 6.61489 26.2737 6.11479 25.7736C5.61469 25.2735 5.33374 24.5953 5.33374 23.888V17.2214Z"
+			d="M4.23682 12.734C4.23682 12.2031 4.44769 11.694 4.82303 11.3187C5.19838 10.9434 5.70746 10.7325 6.23829 10.7325H11.242C11.7728 10.7325 12.2819 10.9434 12.6572 11.3187C13.0326 11.694 13.2434 12.2031 13.2434 12.734V17.7376C13.2434 18.2685 13.0326 18.7775 12.6572 19.1529C12.2819 19.5282 11.7728 19.7391 11.242 19.7391H6.23829C5.70746 19.7391 5.19838 19.5282 4.82303 19.1529C4.44769 18.7775 4.23682 18.2685 4.23682 17.7376V12.734Z"
 			stroke="#3858E9"
-			strokeWidth="2"
-			strokeLinecap="round"
-			strokeLinejoin="round"
+			stroke-width="1.5011"
+			stroke-linecap="round"
+			stroke-linejoin="round"
 		/>
 		<path
-			d="M5.33374 9.21094V6.54427C5.33374 6.19065 5.47422 5.85151 5.72426 5.60146C5.97431 5.35141 6.31345 5.21094 6.66707 5.21094H9.33374"
+			d="M4.23682 6.72956V4.72809C4.23682 4.46268 4.34225 4.20814 4.52993 4.02046C4.7176 3.83279 4.97214 3.72736 5.23755 3.72736H7.23902"
 			stroke="#3858E9"
-			strokeWidth="2"
-			strokeLinecap="round"
-			strokeLinejoin="round"
+			stroke-width="1.5011"
+			stroke-linecap="round"
+			stroke-linejoin="round"
 		/>
 		<path
-			d="M14.6667 5.21094H17.3334"
+			d="M11.2422 3.72736H13.2437"
 			stroke="#3858E9"
-			strokeWidth="2"
-			strokeLinecap="round"
-			strokeLinejoin="round"
+			stroke-width="1.5011"
+			stroke-linecap="round"
+			stroke-linejoin="round"
 		/>
 		<path
-			d="M22.6667 5.21094H25.3334C25.687 5.21094 26.0262 5.35141 26.2762 5.60146C26.5263 5.85151 26.6667 6.19065 26.6667 6.54427V9.21094"
+			d="M17.2466 3.72736H19.2481C19.5135 3.72736 19.768 3.83279 19.9557 4.02046C20.1434 4.20814 20.2488 4.46268 20.2488 4.72809V6.72956"
 			stroke="#3858E9"
-			strokeWidth="2"
-			strokeLinecap="round"
-			strokeLinejoin="round"
+			stroke-width="1.5011"
+			stroke-linecap="round"
+			stroke-linejoin="round"
 		/>
 		<path
-			d="M26.6667 14.5547V17.2214"
+			d="M20.2485 10.7325V12.734"
 			stroke="#3858E9"
-			strokeWidth="2"
-			strokeLinecap="round"
-			strokeLinejoin="round"
+			stroke-width="1.5011"
+			stroke-linecap="round"
+			stroke-linejoin="round"
 		/>
 		<path
-			d="M26.6667 22.5547V25.2214C26.6667 25.575 26.5263 25.9141 26.2762 26.1642C26.0262 26.4142 25.687 26.5547 25.3334 26.5547H22.6667"
+			d="M20.2488 16.7369V18.7384C20.2488 19.0038 20.1434 19.2584 19.9557 19.446C19.768 19.6337 19.5135 19.7391 19.2481 19.7391H17.2466"
 			stroke="#3858E9"
-			strokeWidth="2"
-			strokeLinecap="round"
-			strokeLinejoin="round"
+			stroke-width="1.5011"
+			stroke-linecap="round"
+			stroke-linejoin="round"
 		/>
 	</svg>
 );

--- a/src/modules/add-site/components/blueprint-icon.tsx
+++ b/src/modules/add-site/components/blueprint-icon.tsx
@@ -9,51 +9,51 @@ export const BlueprintIcon = ( { size = 32 }: { size?: number } ) => (
 		<path
 			d="M13.2434 14.7355C11.242 14.7355 8.23975 15.7362 8.23975 19.7392"
 			stroke="#3858E9"
-			stroke-width="1.5011"
-			stroke-linecap="round"
-			stroke-linejoin="round"
+			strokeWidth="1.5011"
+			strokeLinecap="round"
+			strokeLinejoin="round"
 		/>
 		<path
 			d="M4.23682 12.734C4.23682 12.2031 4.44769 11.694 4.82303 11.3187C5.19838 10.9434 5.70746 10.7325 6.23829 10.7325H11.242C11.7728 10.7325 12.2819 10.9434 12.6572 11.3187C13.0326 11.694 13.2434 12.2031 13.2434 12.734V17.7376C13.2434 18.2685 13.0326 18.7775 12.6572 19.1529C12.2819 19.5282 11.7728 19.7391 11.242 19.7391H6.23829C5.70746 19.7391 5.19838 19.5282 4.82303 19.1529C4.44769 18.7775 4.23682 18.2685 4.23682 17.7376V12.734Z"
 			stroke="#3858E9"
-			stroke-width="1.5011"
-			stroke-linecap="round"
-			stroke-linejoin="round"
+			strokeWidth="1.5011"
+			strokeLinecap="round"
+			strokeLinejoin="round"
 		/>
 		<path
 			d="M4.23682 6.72956V4.72809C4.23682 4.46268 4.34225 4.20814 4.52993 4.02046C4.7176 3.83279 4.97214 3.72736 5.23755 3.72736H7.23902"
 			stroke="#3858E9"
-			stroke-width="1.5011"
-			stroke-linecap="round"
-			stroke-linejoin="round"
+			strokeWidth="1.5011"
+			strokeLinecap="round"
+			strokeLinejoin="round"
 		/>
 		<path
 			d="M11.2422 3.72736H13.2437"
 			stroke="#3858E9"
-			stroke-width="1.5011"
-			stroke-linecap="round"
-			stroke-linejoin="round"
+			strokeWidth="1.5011"
+			strokeLinecap="round"
+			strokeLinejoin="round"
 		/>
 		<path
 			d="M17.2466 3.72736H19.2481C19.5135 3.72736 19.768 3.83279 19.9557 4.02046C20.1434 4.20814 20.2488 4.46268 20.2488 4.72809V6.72956"
 			stroke="#3858E9"
-			stroke-width="1.5011"
-			stroke-linecap="round"
-			stroke-linejoin="round"
+			strokeWidth="1.5011"
+			strokeLinecap="round"
+			strokeLinejoin="round"
 		/>
 		<path
 			d="M20.2485 10.7325V12.734"
 			stroke="#3858E9"
-			stroke-width="1.5011"
-			stroke-linecap="round"
-			stroke-linejoin="round"
+			strokeWidth="1.5011"
+			strokeLinecap="round"
+			strokeLinejoin="round"
 		/>
 		<path
 			d="M20.2488 16.7369V18.7384C20.2488 19.0038 20.1434 19.2584 19.9557 19.446C19.768 19.6337 19.5135 19.7391 19.2481 19.7391H17.2466"
 			stroke="#3858E9"
-			stroke-width="1.5011"
-			stroke-linecap="round"
-			stroke-linejoin="round"
+			strokeWidth="1.5011"
+			strokeLinecap="round"
+			strokeLinejoin="round"
 		/>
 	</svg>
 );

--- a/src/modules/add-site/components/blueprints.tsx
+++ b/src/modules/add-site/components/blueprints.tsx
@@ -86,7 +86,7 @@ export default function AddSiteBlueprint( {
 						src={ item.image }
 						alt={ item.title }
 						className={ cx(
-							'w-full h-48 object-cover object-top cursor-pointer transition-all duration-150 rounded-lg group',
+							'w-full h-32 object-cover object-top cursor-pointer transition-all duration-150 rounded-lg group',
 							'hover:shadow-md hover:outline hover:outline-2 hover:outline-blue-500',
 							'transition-transform duration-150',
 							'hover:scale-105',
@@ -100,7 +100,7 @@ export default function AddSiteBlueprint( {
 				label: __( 'Title' ),
 				type: 'text' as const,
 				render: ( { item }: { item: DataViewBlueprint } ) => (
-					<Heading level={ 3 } className="text-sm mt-3 mb-2 text-gray-800" weight={ 500 }>
+					<Heading level={ 3 } className="text-[13px] mt-3 mb-2 text-gray-800" weight={ 500 }>
 						{ item.title }
 					</Heading>
 				),
@@ -111,7 +111,7 @@ export default function AddSiteBlueprint( {
 				type: 'text' as const,
 				render: ( { item }: { item: DataViewBlueprint } ) => (
 					<Text
-						className="text-sm text-gray-600 h-16"
+						className="text-[13px] text-gray-600 h-[454x]"
 						weight={ 400 }
 						truncate
 						numberOfLines={ 3 }
@@ -152,8 +152,7 @@ export default function AddSiteBlueprint( {
 				render: ( { item }: { item: DataViewBlueprint } ) => (
 					<StudioButton
 						variant="link"
-						size="small"
-						className="!p-0"
+						className="!p-0 text-[12px]"
 						onClick={ () => getIpcApi().openURL( item.playground_url ) }
 					>
 						{ __( 'Preview blueprint' ) }
@@ -212,25 +211,29 @@ export default function AddSiteBlueprint( {
 
 	if ( isLoading ) {
 		return (
-			<VStack className="w-full max-w-6xl mx-auto" spacing={ 6 }>
-				<Heading className="text-center text-4xl">{ __( 'Start from a blueprint' ) }</Heading>
+			<VStack className="w-full max-w-6xl mx-auto">
+				<Heading className="text-center text-[32px] text-gray-900 mb-[28px]" weight={ 500 }>
+					{ __( 'Start from a blueprint' ) }
+				</Heading>
 				<Text>{ __( 'Loading blueprints...' ) }</Text>
 			</VStack>
 		);
 	}
 
 	return (
-		<VStack className="w-full max-w-6xl mx-auto p-2" spacing={ 6 }>
-			<Heading className="text-center text-4xl">{ __( 'Start from a blueprint' ) }</Heading>
+		<VStack className="w-full max-w-6xl mx-auto" spacing={ 0 }>
+			<Heading className="text-center text-[32px] text-gray-900 mb-[28px]" weight={ 500 }>
+				{ __( 'Start from a blueprint' ) }
+			</Heading>
 
-			<HStack spacing={ 2 } alignment="edge" className="w-full pr-1">
+			<HStack alignment="edge" className="w-full mb-[22px] px-3">
 				<HStack alignment="left" className="flex-1">
-					<Text className="text-xl" weight={ 500 }>
+					<Text className="text-[16px]" weight={ 500 }>
 						{ __( 'Suggested blueprints' ) }
 					</Text>
 				</HStack>
 				{ selectedFileName ? (
-					<HStack spacing={ 2 } className="h-9 w-fit flex-shrink-0 items-center">
+					<HStack className="h-9 w-fit flex-shrink-0 items-center">
 						<Text
 							className="text-sm font-medium text-gray-900 truncate max-w-48"
 							title={ selectedFileName }
@@ -267,7 +270,7 @@ export default function AddSiteBlueprint( {
 				) }
 			</HStack>
 
-			<div className="w-full px-2 [&_.dataviews-view-grid]:!grid [&_.dataviews-view-grid]:!grid-cols-3 [&_.dataviews-view-grid]:!gap-4 [&_.components-badge]:!bg-transparent [&_.components-badge]:!p-0">
+			<div className="w-full px-3 [&_.dataviews-view-grid]:!grid [&_.dataviews-view-grid]:!grid-cols-3 [&_.dataviews-view-grid]:!gap-4 [&_.components-badge]:!bg-transparent [&_.components-badge]:!p-0">
 				<DataViews
 					data={ dataViewBlueprints }
 					fields={ fields }

--- a/src/modules/add-site/components/create-site.tsx
+++ b/src/modules/add-site/components/create-site.tsx
@@ -52,7 +52,7 @@ export default function CreateSite( {
 	return (
 		<VStack className="w-full max-w-[402px] mx-auto text-black" spacing={ 6 }>
 			<Heading className="text-[32px] text-gray-900 text-center" weight={ 500 }>
-				{ __( 'Add a site 2' ) }
+				{ __( 'Add a site' ) }
 			</Heading>
 
 			<SiteForm

--- a/src/modules/add-site/components/create-site.tsx
+++ b/src/modules/add-site/components/create-site.tsx
@@ -50,8 +50,10 @@ export default function CreateSite( {
 	const { __ } = useI18n();
 
 	return (
-		<VStack className="w-full max-w-xl mx-auto text-black" spacing={ 6 }>
-			<Heading className="text-center text-4xl">{ __( 'Add a site' ) }</Heading>
+		<VStack className="w-full max-w-[402px] mx-auto text-black" spacing={ 6 }>
+			<Heading className="text-[32px] text-gray-900 text-center" weight={ 500 }>
+				{ __( 'Add a site 2' ) }
+			</Heading>
 
 			<SiteForm
 				siteName={ siteName || '' }

--- a/src/modules/add-site/components/import-backup.tsx
+++ b/src/modules/add-site/components/import-backup.tsx
@@ -108,12 +108,14 @@ export default function ImportBackup( { onFileSelect }: ImportBackupProps ) {
 	}, [] );
 
 	return (
-		<VStack className="text-center w-full" alignment="top" spacing={ 6 }>
-			<Heading className="text-4xl mb-10">{ __( 'Import from a backup' ) }</Heading>
+		<VStack className="text-center w-full" alignment="top" spacing={ 0 }>
+			<Heading className="text-center text-[32px] text-gray-900 mb-[59px]" weight={ 500 }>
+				{ __( 'Import from a backup' ) }
+			</Heading>
 
 			<div
 				className={ cx(
-					'w-full max-w-2xl h-80 mx-auto p-12 border-2 rounded-xl',
+					'w-full max-w-[400px] h-[200px] mx-auto p-12 border-2 rounded-xl',
 					'transition-colors cursor-pointer',
 					isDragging
 						? 'border-blue-500 bg-blue-50'
@@ -154,11 +156,11 @@ export default function ImportBackup( { onFileSelect }: ImportBackupProps ) {
 						</HStack>
 					</VStack>
 				) : (
-					<VStack className="items-center justify-center h-full" spacing={ 4 }>
+					<VStack className="items-center justify-center h-full" spacing={ 2 }>
 						<Icon icon={ download } size={ 24 } className="fill-gray-400" />
 						<>
 							<Heading
-								className="text-base leading-4 font-normal text-center text-gray-700"
+								className="text-[14px] leading-4 font-normal text-center text-gray-700"
 								weight="400"
 							>
 								{ isDragging

--- a/src/modules/add-site/components/options.tsx
+++ b/src/modules/add-site/components/options.tsx
@@ -4,7 +4,7 @@ import {
 	__experimentalHeading as Heading,
 	__experimentalText as Text,
 } from '@wordpress/components';
-import { Icon, create, backup, chevronRight, chevronLeft } from '@wordpress/icons';
+import { Icon, plus, backup, chevronRight, chevronLeft } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { useOffline } from 'src/hooks/use-offline';
 import { cx } from 'src/lib/cx';
@@ -35,7 +35,7 @@ function OptionButton( {
 		<HStack
 			as="button"
 			className={ cx(
-				'w-full max-w-lg p-5 border border-gray-200 rounded-xl text-left',
+				'w-full max-w-[422px] p-[24px] border border-gray-200 rounded-xl text-left',
 				'rtl:text-right',
 				'hover:border-gray-300 hover:bg-gray-50',
 				'disabled:opacity-50 disabled:cursor-not-allowed'
@@ -45,12 +45,12 @@ function OptionButton( {
 			disabled={ disabled }
 			spacing={ 5 }
 		>
-			{ icon }
-			<VStack className="flex-1" spacing={ 1 }>
-				<Heading className="text-xl" weight="500">
+			<div className="mt-[-2px]">{ icon }</div>
+			<VStack className="flex-1 gap-[8px]">
+				<Heading className="text-[15px]" weight="500">
 					{ title }
 				</Heading>
-				<Text className="text-base text-gray-500" weight="300">
+				<Text className="text-[13px] text-gray-500" weight="400">
 					{ description }
 				</Text>
 			</VStack>
@@ -65,25 +65,27 @@ export default function AddSiteOptions( { onOptionSelect }: AddSiteOptionsProps 
 
 	return (
 		<VStack className="text-center w-full" alignment="top" spacing="3">
-			<Heading className="text-4xl">{ __( 'Add a site' ) }</Heading>
-			<Text className="text-xl font-light text-gray-500 w-96 mb-10">
+			<Heading className="text-[32px] text-gray-900" weight={ 500 }>
+				{ __( 'Add a site 1' ) }
+			</Heading>
+			<Text className="text-[15px] font-light text-gray-700 w-72 mb-[28px]">
 				{ __( 'Add a clean site, start from a blueprint or import site from a backup' ) }
 			</Text>
 			<OptionButton
-				icon={ <Icon className="" icon={ create } size={ 32 } fill="#3858E9" /> }
+				icon={ <Icon className="" icon={ plus } size={ 26 } fill="#3858E9" /> }
 				title={ __( 'Create a site' ) }
 				description={ __( 'Create a clean site' ) }
 				onClick={ () => onOptionSelect( 'create' ) }
 			/>
 			<OptionButton
-				icon={ <BlueprintIcon size={ 32 } /> }
+				icon={ <BlueprintIcon size={ 24 } /> }
 				title={ __( 'Start from a blueprint' ) }
 				description={ __( 'Choose one from the list or select your own' ) }
 				onClick={ () => onOptionSelect( 'blueprint' ) }
 				disabled={ isOffline }
 			/>
 			<OptionButton
-				icon={ <Icon icon={ backup } size={ 32 } fill="#3858E9" /> }
+				icon={ <Icon icon={ backup } size={ 24 } fill="#3858E9" /> }
 				title={ __( 'Import from a backup' ) }
 				description={ __( 'Start a site from a backup' ) }
 				onClick={ () => onOptionSelect( 'backup' ) }

--- a/src/modules/add-site/components/options.tsx
+++ b/src/modules/add-site/components/options.tsx
@@ -66,7 +66,7 @@ export default function AddSiteOptions( { onOptionSelect }: AddSiteOptionsProps 
 	return (
 		<VStack className="text-center w-full" alignment="top" spacing="3">
 			<Heading className="text-[32px] text-gray-900" weight={ 500 }>
-				{ __( 'Add a site 1' ) }
+				{ __( 'Add a site' ) }
 			</Heading>
 			<Text className="text-[15px] font-light text-gray-700 w-72 mb-[28px]">
 				{ __( 'Add a clean site, start from a blueprint or import site from a backup' ) }

--- a/src/modules/add-site/components/stepper.tsx
+++ b/src/modules/add-site/components/stepper.tsx
@@ -55,10 +55,10 @@ export default function Stepper( {
 						<HStack key={ step.id } spacing={ 2 } alignment="left" className="w-fit">
 							<Icon
 								icon={ isCompleted || isCurrent ? published : border }
-								size={ 30 }
+								size={ 24 }
 								className={ isCompleted && ! isCurrent ? 'fill-a8c-blue-50' : 'fill-gray-500' }
 							/>
-							<Text className={ 'text-base text-gray-500' }>{ step.label }</Text>
+							<Text className={ 'text-[13px] text-gray-500' }>{ step.label }</Text>
 						</HStack>
 					);
 				} ) }


### PR DESCRIPTION
## Related issues

- Fixes STU-705

## Proposed Changes
With this PR we adjust Blueprints UI according to teh designs [RToz6tIuQ7nlZrikBte4GU-fi-9470_275077](https://href.li/?https://www.figma.com/file/RToz6tIuQ7nlZrikBte4GU/?node-id=9470-275077)

## Testing Instructions
1. `ENABLE_BLUEPRINTS=true npm start`
2. Click on add site
3. Compare UI with the designs of all pages
NOTE: I intentionally made smaller paddings and sizes for Blueprints screen to avoiud scroll for 900x600 window. And also some colors are not perfect, to avoid custom colors I decided that it's better to use `text-gray-<NUMBER>` etc.

<img width="903" height="601" alt="Screenshot 2025-08-13 at 21 00 13" src="https://github.com/user-attachments/assets/8c630aa2-8f67-4104-a765-4abe4a137aac" />
