### PR TITLE
[Tooling] Tweak Unit Tests memory settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
 		"cli:watch": "webpack --config webpack.cli.config.ts --watch",
 		"lint": "eslint --ext .ts,.tsx,.js,.jsx,.mjs {cli,common,src}",
 		"format": "prettier . --write",
-		"test": "cross-env NODE_OPTIONS='--no-deprecation' jest",
+		"test": "cross-env NODE_OPTIONS='--no-deprecation --max-old-space-size=16384' jest",
 		"test:watch": "cross-env NODE_OPTIONS='--no-deprecation' jest --watch",
 		"e2e": "npx playwright install && npx playwright test",
 		"test:metrics": "npx playwright test --config=./metrics/playwright.metrics.config.ts",


### PR DESCRIPTION
## Related issues

- Fixes AINFRA-1151

This PR should fix the reported error `Jest worker ran out of memory and crashed` seen randomly when running Unit Tests on Windows.

## Proposed Changes

- This PR basically increases the heap memory size for Unit Tests. Our Windows CI Agents currently range from 32GB to 64GB, so a 16GB seemed reasonable for now.
- I've initially added a few more things like calling `global.gc()` on `afterAll()`, adding a `workerIdleMemoryLimit` config to Jest, but it doesn't really seem to be strictly necessary now so I reverted them. We can revisit this kind of optimization if we see similar problems in the future.

## Testing Instructions

- Make sure CI is 🟢 . Feel free to run a few more builds to make sure we don't get any `Jest worker ran out of memory and crashed` failures again.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
