### PR TITLE
Ensure screenshot taken on Mac has always correct size

### DIFF
--- a/src/screenshot-window.ts
+++ b/src/screenshot-window.ts
@@ -58,7 +58,12 @@ export function createScreenshotWindow( captureUrl: string ) {
 		const LOAD_TIMEOUT = process.platform === 'win32' ? 2000 : 500;
 		await new Promise( ( resolve ) => setTimeout( resolve, LOAD_TIMEOUT ) );
 
-		return window.webContents.capturePage();
+		// Force the window to the exact dimensions we want - in some cases, the window may not
+		// respect the size set in the constructor, especially on macOS, where it might adjust
+		// the size based on the content.
+		window.setSize( SCREENSHOT_WIDTH, SCREENSHOT_HEIGHT );
+
+		return await window.webContents.capturePage();
 	};
 
 	return { window, waitForCapture };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-210

## Proposed Changes

I propose to explicitly set the browser size to ensure the screenshot taken on a Mac always has the correct size. I was consistently getting different thumbnail sizes when connected to an external monitor (correct) and without a monitor (incorrect):

External monitor:

```
Window created with size: { x: 1200, y: 96, width: 1040, height: 1248 }
WebContents zoom factor: 1
WebContents zoom level: 0
Window size after forcing dimensions: { x: 1200, y: 96, width: 1040, height: 1248 }
Before capture - Window bounds: { x: 1200, y: 96, width: 1040, height: 1248 }
Before capture - Zoom factor: 1
Before capture - Zoom level: 0
Window size right before capture: { x: 1200, y: 96, width: 1040, height: 1248 }
Captured image size: { width: 1040, height: 1220 }
```

Macbook:

```
Window created with size: { x: 344, y: 38, width: 1040, height: 1009 }
WebContents zoom factor: 1
WebContents zoom level: 0
Window size after forcing dimensions: { x: 344, y: 38, width: 1040, height: 1248 }
Before capture - Window bounds: { x: 344, y: 38, width: 1040, height: 1248 }
Before capture - Zoom factor: 1
Before capture - Zoom level: 0
Window size right before capture: { x: 344, y: 38, width: 1040, height: 1248 }
Captured image size: { width: 2080, height: 2440 }
```

|**Before**|**After**|
|---|---|
|<img width="654" height="495" alt="423931954-6c60dec5-5c7e-46e4-8b65-788f0a9cbe50 png_jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9 eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NDIzMjkw 2VQt0Tb4-fOrKS4lVpB_hhJqnP0C1Mn8VwaEY5jbCqw" src="https://github.com/user-attachments/assets/ed0570bf-6738-4b39-8f66-d83ffda5e2d8" />|<img width="650" height="492" alt="423931953-29c9cc38-367c-494c-8353-df0a5255e0f1 png_jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9 eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NDIzMjkw CYZT5K2lapWZd0ONx6oa6O0UVw9sljpNgosBoZlGln4" src="https://github.com/user-attachments/assets/b48d656e-d7f5-482e-8ce3-071422b3f942" />|


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Start Studio
2. Start site
3. Confirm that thumbnail has correct size
4. Stop site
5. Connect external monitor
6. Start site
7. Confirm that the thumbnail has correct size

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
