### PR TITLE
Submit site creation on Enter and add tooltip to disabled Blueprints

### DIFF
--- a/src/components/site-form.tsx
+++ b/src/components/site-form.tsx
@@ -301,7 +301,16 @@ export const SiteForm = ( {
 			<div className="flex flex-col">
 				<label className="flex flex-col gap-1.5 leading-4 mb-6">
 					<span className="font-semibold">{ __( 'Site name' ) }</span>
-					<TextControlComponent onChange={ setSiteName } value={ siteName }></TextControlComponent>
+					<TextControlComponent
+						onChange={ setSiteName }
+						value={ siteName }
+						onKeyDown={ ( event ) => {
+							if ( event.key === 'Enter' ) {
+								event.preventDefault();
+								onSubmit( event as FormEvent );
+							}
+						} }
+					></TextControlComponent>
 				</label>
 
 				{ setFileForImport && (

--- a/src/modules/add-site/components/options.tsx
+++ b/src/modules/add-site/components/options.tsx
@@ -6,6 +6,7 @@ import {
 } from '@wordpress/components';
 import { Icon, plus, backup, chevronRight, chevronLeft } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
+import { Tooltip } from 'src/components/tooltip';
 import { useOffline } from 'src/hooks/use-offline';
 import { cx } from 'src/lib/cx';
 import { BlueprintIcon } from './blueprint-icon';
@@ -20,6 +21,7 @@ interface OptionButtonProps {
 	description: string;
 	onClick: () => void;
 	disabled?: boolean;
+	disabledTooltip?: string;
 }
 
 function OptionButton( {
@@ -28,40 +30,48 @@ function OptionButton( {
 	description,
 	onClick,
 	disabled = false,
+	disabledTooltip,
 }: OptionButtonProps ) {
 	const { isRTL } = useI18n();
 	const chevron = isRTL() ? chevronLeft : chevronRight;
 	return (
-		<HStack
-			as="button"
-			className={ cx(
-				'w-full max-w-[422px] p-[24px] border border-gray-200 rounded-xl text-left',
-				'rtl:text-right',
-				'hover:border-gray-300 hover:bg-gray-50',
-				'disabled:opacity-50 disabled:cursor-not-allowed'
-			) }
-			alignment="top"
-			onClick={ onClick }
-			disabled={ disabled }
-			spacing={ 5 }
+		<Tooltip
+			text={ disabledTooltip }
+			disabled={ ! disabled }
+			className={ cx( 'w-full max-w-[422px]' ) }
 		>
-			<div className="mt-[-2px]">{ icon }</div>
-			<VStack className="flex-1 gap-[8px]">
-				<Heading className="text-[15px]" weight="500">
-					{ title }
-				</Heading>
-				<Text className="text-[13px] text-gray-500" weight="400">
-					{ description }
-				</Text>
-			</VStack>
-			<Icon className="mt-0.5" icon={ chevron } size={ 24 } fill="#949494" />
-		</HStack>
+			<HStack
+				as="button"
+				className={ cx(
+					'w-full p-[24px] border border-gray-200 rounded-xl text-left',
+					'rtl:text-right',
+					'hover:border-gray-300 hover:bg-gray-50',
+					'disabled:opacity-50 disabled:cursor-not-allowed'
+				) }
+				alignment="top"
+				onClick={ onClick }
+				disabled={ disabled }
+				spacing={ 5 }
+			>
+				<div className="mt-[-2px]">{ icon }</div>
+				<VStack className="flex-1 gap-[8px]">
+					<Heading className="text-[15px]" weight="500">
+						{ title }
+					</Heading>
+					<Text className="text-[13px] text-gray-500" weight="400">
+						{ description }
+					</Text>
+				</VStack>
+				<Icon className="mt-0.5" icon={ chevron } size={ 24 } fill="#949494" />
+			</HStack>
+		</Tooltip>
 	);
 }
 
 export default function AddSiteOptions( { onOptionSelect }: AddSiteOptionsProps ) {
 	const { __ } = useI18n();
 	const isOffline = useOffline();
+	const offlineMessage = __( "You're currently offline." );
 
 	return (
 		<VStack className="text-center w-full" alignment="top" spacing="3">
@@ -83,6 +93,7 @@ export default function AddSiteOptions( { onOptionSelect }: AddSiteOptionsProps 
 				description={ __( 'Choose one from the list or select your own' ) }
 				onClick={ () => onOptionSelect( 'blueprint' ) }
 				disabled={ isOffline }
+				disabledTooltip={ offlineMessage }
 			/>
 			<OptionButton
 				icon={ <Icon icon={ backup } size={ 24 } fill="#3858E9" /> }


### PR DESCRIPTION
## Related issues

- Fixes STU-706

## Proposed Changes
It's follow-up to https://github.com/Automattic/studio/pull/1630

1. We add tooltip to disabled Blueprints button when it's offline
2. We add oportunity to initiate creation of a new site with the help of Enter button inside "Site name" field

## Testing Instructions
1. `ENABLE_BLUEPRINTS=true npm start`
4. Click on "Add site"
5. Disable wifi
6. Assert that `Start from a blueprint` button is disabled and hover on it shows tooltip
7. Click on "Create a site"
8. On the new screen immidiatelly click Enter (while cursor is inside "Site name" field)
9. Assert that creation of a new site is started