### PR TITLE
Patch one more file to avoid Playground adding DB_NAME constant

### DIFF
--- a/patches/@wp-playground+wordpress+2.0.7.patch
+++ b/patches/@wp-playground+wordpress+2.0.7.patch
@@ -1,7 +1,13 @@
 diff --git a/node_modules/@wp-playground/wordpress/index.cjs b/node_modules/@wp-playground/wordpress/index.cjs
-index e05c5a8..6d7c71e 100644
+index e05c5a8..daa4263 100644
 --- a/node_modules/@wp-playground/wordpress/index.cjs
 +++ b/node_modules/@wp-playground/wordpress/index.cjs
+@@ -1,4 +1,4 @@
+-"use strict";Object.defineProperty(exports,Symbol.toStringTag,{value:"Module"});const o=require("@php-wasm/util"),p=require("@wp-playground/common"),c=require("@php-wasm/logger"),d=require("@php-wasm/universal"),T=`<?php
++"use strict";console.log("I am cjs");Object.defineProperty(exports,Symbol.toStringTag,{value:"Module"});const o=require("@php-wasm/util"),p=require("@wp-playground/common"),c=require("@php-wasm/logger"),d=require("@php-wasm/universal"),T=`<?php
+ 
+ /**
+  * Rewrites the wp-config.php file to ensure specific constants are defined
 @@ -352,7 +352,7 @@ function skip_whitespace($tokens) {
  			ob_clean();
  			echo false === $return_value ? '0' : '1';
@@ -11,3 +17,15 @@ index e05c5a8..6d7c71e 100644
  			ob_start();
  			$wp_load = getenv('DOCUMENT_ROOT') . '/wp-load.php';
  			if (!file_exists($wp_load)) {
+diff --git a/node_modules/@wp-playground/wordpress/index.js b/node_modules/@wp-playground/wordpress/index.js
+index 3e8435c..71a7411 100644
+--- a/node_modules/@wp-playground/wordpress/index.js
++++ b/node_modules/@wp-playground/wordpress/index.js
+@@ -366,7 +366,6 @@ async function v(e, r, n, t = "rewrite") {
+ }
+ async function x(e, r) {
+   const n = s(r, "wp-config.php"), t = {
+-    DB_NAME: "wordpress"
+   };
+   !e.fileExists(n) && e.fileExists(s(r, "wp-config-sample.php")) && await e.writeFile(
+     n,

--- a/patches/@wp-playground+wordpress+2.0.7.patch
+++ b/patches/@wp-playground+wordpress+2.0.7.patch
@@ -1,13 +1,7 @@
 diff --git a/node_modules/@wp-playground/wordpress/index.cjs b/node_modules/@wp-playground/wordpress/index.cjs
-index e05c5a8..daa4263 100644
+index e05c5a8..6d7c71e 100644
 --- a/node_modules/@wp-playground/wordpress/index.cjs
 +++ b/node_modules/@wp-playground/wordpress/index.cjs
-@@ -1,4 +1,4 @@
--"use strict";Object.defineProperty(exports,Symbol.toStringTag,{value:"Module"});const o=require("@php-wasm/util"),p=require("@wp-playground/common"),c=require("@php-wasm/logger"),d=require("@php-wasm/universal"),T=`<?php
-+"use strict";console.log("I am cjs");Object.defineProperty(exports,Symbol.toStringTag,{value:"Module"});const o=require("@php-wasm/util"),p=require("@wp-playground/common"),c=require("@php-wasm/logger"),d=require("@php-wasm/universal"),T=`<?php
- 
- /**
-  * Rewrites the wp-config.php file to ensure specific constants are defined
 @@ -352,7 +352,7 @@ function skip_whitespace($tokens) {
  			ob_clean();
  			echo false === $return_value ? '0' : '1';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Follow-up to https://github.com/Automattic/studio/pull/1671

## Proposed Changes

I propose to update a patch that removes setting `DB_NAME` constant to `wp-config.php` file to cover both compiled files.

It's a temporary change until we find a solution on the Playground CLI side to support it better.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Run `npm install` and start Studio
2. Enable Blueprints feature flag
3. Create Studio site
4. Stop the site
5. Edit site's `wp-config.php` and remove DB_NAME constan (or all DB_* constants)
6. Start site
7. Confirm that site opens fine in browser
8. Confirm site exports fine
9. Confirm `wp-config.php` doesn't have additional DB_NAME constant definition prepended

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
