### PR TITLE
Fix using localhost instead of 127.0.0.1

### DIFF
--- a/src/lib/wordpress-provider/playground-cli/playground-cli-provider.ts
+++ b/src/lib/wordpress-provider/playground-cli/playground-cli-provider.ts
@@ -86,10 +86,8 @@ export class PlaygroundCliProvider implements WordPressProvider {
 			isWpAutoUpdating: options.isWpAutoUpdating,
 		};
 
-		const url = `http://127.0.0.1:${ port }`;
-
 		return {
-			url,
+			url: `http://localhost:${ port }`,
 			options: serverOptions,
 			_internal: playgroundOptions,
 		};


### PR DESCRIPTION
## Related issues

- Fixes STU-703

## Proposed Changes
After introducing playground CLI we started seeing 127.0.0.1 insterad iof localhost for all sites in browser. It was mistake, localhost shoudl be used, as previously with wp-now.

## Testing Instructions
1. Run `ENABLE_BLUEPRINTS=true npm start`
2. Create a site
3. Click on "Open site" or just open `http://localhost:8881` in browser
4. Assert that you wasn't redirected to `http://127.0.0.1:8881/`