### PR TITLE
Loosen stats validation for CLI

### DIFF
--- a/cli/lib/appdata.ts
+++ b/cli/lib/appdata.ts
@@ -36,10 +36,7 @@ const userDataSchema = z
 			.passthrough()
 			.optional(),
 		lastBumpStats: z
-			.record(
-				z.union( [ z.nativeEnum( StatsGroup ), z.literal( 'local-environment-launch-uniques' ) ] ),
-				z.record( z.nativeEnum( StatsMetric ), z.number() )
-			)
+			.record( z.string(), z.record( z.nativeEnum( StatsMetric ), z.number() ) )
 			.optional(),
 	} )
 	.passthrough();


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-732

## Proposed Changes

I propose to fix CLI preview site creation by relaxing the Zod schema for lastBumpStats to accept arbitrary metric keys, preventing parse failures on older stat names like `studio-app-launch-uniques-monthly`.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Ensure you're authenticated in Studio (Sync, pull, push, assistant should work)
2. Try to create a preview site for any existing site
3. Verify the preview site creation completes without the "Invalid Studio config file format" error
4. Confirm the preview site appears in the previews tab and is accessible

To reproduce the issue in trunk, ensure to add an incorrect stat to appdata config files before launching Studio e.g.:

```
"lastBumpStats": {
    "studio-cli-usage-unique": {
      "success": 1747138805686
    },
    "studio-app-launch-uniques": {
      "darwin": 1755617494935
    },
    "studio-app-launch-uniques-monthly": {
      "darwin": 1754296649792
    },
    "studio-app-launch-uniqs-mon": {
      "darwin": 1754924827013
    }
  },

```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
