### PR TITLE
Remove mu-plugins from file system and add them to VFS instead

### DIFF
--- a/src/lib/wordpress-provider/playground-cli/mu-plugins.ts
+++ b/src/lib/wordpress-provider/playground-cli/mu-plugins.ts
@@ -286,6 +286,18 @@ function getStandardMuPlugins( options: Partial< WordPressServerOptions > ): MuP
 	`,
 	} );
 
+	// WP-CLI specific: SQLite command support
+	muPlugins.push( {
+		filename: '0-sqlite-command.php',
+		content: `<?php
+		// Ensure SQLite command can find the plugin
+		add_filter( 'sqlite_command_sqlite_plugin_directories', function( $directories ) {
+			$directories[] = '/wordpress/wp-content/mu-plugins/sqlite-database-integration';
+			return $directories;
+		} );
+		`,
+	} );
+
 	return muPlugins;
 }
 

--- a/src/lib/wordpress-provider/playground-cli/wp-cli-executor.ts
+++ b/src/lib/wordpress-provider/playground-cli/wp-cli-executor.ts
@@ -67,9 +67,6 @@ export async function executeWPCli(
 			php.writeFile( '/tmp/wp-cli.phar', readFileSync( wpCliPharPath ) );
 		}
 
-		// Create minimal MU plugins for CLI mode
-		await mountCleanMuPlugins( php );
-
 		// Create CA bundle certificate file for SSL verification (following wp-now approach)
 		php.mkdir( PLAYGROUND_INTERNAL_SHARED_FOLDER );
 		const caBundlePath = nodePath.posix.join( PLAYGROUND_INTERNAL_SHARED_FOLDER, 'ca-bundle.crt' );
@@ -86,47 +83,6 @@ export async function executeWPCli(
 	} finally {
 		// Clean up PHP instance
 		php.exit();
-	}
-}
-
-/**
- * Mount only essential MU plugins for CLI mode (no database setup plugins)
- */
-async function mountCleanMuPlugins( php: PHP ): Promise< void > {
-	const muPluginsPath = '/wordpress/wp-content/mu-plugins';
-	php.mkdir( muPluginsPath );
-
-	// Only include essential plugins that don't interfere with database
-	const cleanMuPlugins = [
-		{
-			filename: '0-https-for-reverse-proxy.php',
-			content: `<?php
-				if( isset( $_SERVER['HTTP_X_FORWARDED_PROTO'] ) && strpos( $_SERVER['HTTP_X_FORWARDED_PROTO'], 'https') !== false ){
-					$_SERVER['HTTPS'] = 'on';
-				}
-			`,
-		},
-		{
-			filename: '0-permalinks.php',
-			content: `<?php
-				// Support permalinks without "index.php"
-				add_filter( 'got_url_rewrite', '__return_true' );
-			`,
-		},
-		{
-			filename: '0-sqlite-command.php',
-			content: `<?php
-				// Ensure SQLite command can find the plugin
-				add_filter( 'sqlite_command_sqlite_plugin_directories', function( $directories ) {
-					$directories[] = '/wordpress/wp-content/mu-plugins/sqlite-database-integration';
-					return $directories;
-				} );
-			`,
-		},
-	];
-
-	for ( const plugin of cleanMuPlugins ) {
-		php.writeFile( nodePath.posix.join( muPluginsPath, plugin.filename ), plugin.content );
 	}
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-689

## Proposed Changes

- Removes plugins from `mu-plugins` folder and uses the Playground VFS instead
- Keeps sqlite plugins to preserve existing logic to create and update db and plugin version

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- `ENABLE_BLUEPRINTS=true npm start`
- Create a new site
- Confirm `mu-plugins` folder in the file system only has the `sqlite-database-integration` plugin

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
