### PR TITLE
Limit number of blueprint categories displayed in UI

### DIFF
--- a/src/modules/add-site/components/blueprints.tsx
+++ b/src/modules/add-site/components/blueprints.tsx
@@ -163,8 +163,8 @@ export default function AddSiteBlueprint( {
 								</Text>
 							) ) }
 							{ remainingCount > 0 && (
-								<Tooltip 
-									text={ categories.slice( maxCategoriesToShow ).join( ', ' ) } 
+								<Tooltip
+									text={ categories.slice( maxCategoriesToShow ).join( ', ' ) }
 									delay={ 200 }
 									position="top right"
 									className="max-w-xs"

--- a/src/modules/add-site/components/blueprints.tsx
+++ b/src/modules/add-site/components/blueprints.tsx
@@ -352,7 +352,7 @@ export default function AddSiteBlueprint( {
 				) }
 			</HStack>
 
-			<div className="w-full px-3 [&_.dataviews-view-grid]:!grid [&_.dataviews-view-grid]:!grid-cols-3 [&_.dataviews-view-grid]:!gap-4 [&_.components-badge]:!bg-transparent [&_.components-badge]:!p-0">
+			<div className="w-full px-3 [&_.dataviews-view-grid]:!grid [&_.dataviews-view-grid]:!grid-cols-3 [&_.dataviews-view-grid]:!gap-4 [&_.dataviews-view-grid]:!items-start [&_.components-badge]:!bg-transparent [&_.components-badge]:!p-0">
 				<DataViews
 					data={ dataViewBlueprints }
 					fields={ fields }

--- a/src/modules/add-site/components/blueprints.tsx
+++ b/src/modules/add-site/components/blueprints.tsx
@@ -5,6 +5,7 @@ import {
 	__experimentalText as Text,
 	Button,
 	Notice,
+	Tooltip,
 } from '@wordpress/components';
 import { DataViews, View } from '@wordpress/dataviews';
 import { sprintf } from '@wordpress/i18n';
@@ -142,11 +143,17 @@ export default function AddSiteBlueprint( {
 					.flatMap( ( blueprint ) => blueprint.blueprint.meta?.categories || [] )
 					.filter( ( category, index, arr ) => arr.indexOf( category ) === index )
 					.map( ( category ) => ( { label: category, value: category } ) ),
-				render: ( { item }: { item: DataViewBlueprint } ) => (
-					<HStack spacing={ 3 } wrap alignment="left">
-						{ ( item.blueprint.meta?.categories || [] )
-							.filter( ( category ) => category !== 'Studio' )
-							.map( ( category ) => (
+				render: ( { item }: { item: DataViewBlueprint } ) => {
+					const categories = ( item.blueprint.meta?.categories || [] ).filter(
+						( category ) => category !== 'Studio'
+					);
+					const maxCategoriesToShow = 3;
+					const visibleCategories = categories.slice( 0, maxCategoriesToShow );
+					const remainingCount = categories.length - maxCategoriesToShow;
+
+					return (
+						<HStack spacing={ 3 } wrap alignment="left">
+							{ visibleCategories.map( ( category ) => (
 								<Text
 									as="span"
 									key={ category }
@@ -155,8 +162,24 @@ export default function AddSiteBlueprint( {
 									{ category }
 								</Text>
 							) ) }
-					</HStack>
-				),
+							{ remainingCount > 0 && (
+								<Tooltip 
+									text={ categories.slice( maxCategoriesToShow ).join( ', ' ) } 
+									delay={ 200 }
+									position="top right"
+									className="max-w-xs"
+								>
+									<Text
+										as="span"
+										className="px-2.5 py-1 text-xs bg-gray-200 text-gray-600 rounded-sm inline-flex items-center font-medium cursor-default"
+									>
+										+{ remainingCount } more
+									</Text>
+								</Tooltip>
+							) }
+						</HStack>
+					);
+				},
 			},
 			{
 				id: 'preview',

--- a/src/modules/add-site/components/blueprints.tsx
+++ b/src/modules/add-site/components/blueprints.tsx
@@ -171,7 +171,7 @@ export default function AddSiteBlueprint( {
 								>
 									<Text
 										as="span"
-										className="px-2.5 py-1 text-xs bg-gray-200 text-gray-600 rounded-sm inline-flex items-center font-medium cursor-default"
+										className="px-2.5 py-1 text-xs bg-gray-100 text-gray-700 rounded-sm flex items-center font-medium"
 									>
 										+{ remainingCount } more
 									</Text>

--- a/src/modules/add-site/components/blueprints.tsx
+++ b/src/modules/add-site/components/blueprints.tsx
@@ -44,6 +44,8 @@ interface AddSiteBlueprintProps {
 	onFileBlueprintSelect?: ( blueprint: Blueprint ) => void;
 }
 
+const MAX_BLUEPRINTS_CATEGORIES = 3;
+
 export default function AddSiteBlueprint( {
 	blueprints,
 	isLoading,
@@ -147,9 +149,8 @@ export default function AddSiteBlueprint( {
 					const categories = ( item.blueprint.meta?.categories || [] ).filter(
 						( category ) => category !== 'Studio'
 					);
-					const maxCategoriesToShow = 3;
-					const visibleCategories = categories.slice( 0, maxCategoriesToShow );
-					const remainingCount = categories.length - maxCategoriesToShow;
+					const visibleCategories = categories.slice( 0, MAX_BLUEPRINTS_CATEGORIES );
+					const remainingCount = categories.length - MAX_BLUEPRINTS_CATEGORIES;
 
 					return (
 						<HStack spacing={ 3 } wrap alignment="left">
@@ -164,7 +165,7 @@ export default function AddSiteBlueprint( {
 							) ) }
 							{ remainingCount > 0 && (
 								<Tooltip
-									text={ categories.slice( maxCategoriesToShow ).join( ', ' ) }
+									text={ categories.slice( MAX_BLUEPRINTS_CATEGORIES ).join( ', ' ) }
 									delay={ 200 }
 									position="top right"
 									className="max-w-xs"


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-722

## Proposed Changes

- Limits the number of categories displayed in the UI to 3
- Adds a "+X More" label with a tooltip for the remaining categories 

<img width="3024" height="1886" alt="image" src="https://github.com/user-attachments/assets/86679eeb-91ba-4452-9d30-ace1a273b920" />

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Apply this patch

```typescript
  // In src/modules/add-site/components/blueprints.tsx around line 134
  const categories = ( item.blueprint.meta?.categories || [] ).filter(
      ( category ) => category !== 'Studio'
  ).concat( [
      'E-commerce', 'Portfolio', 'Blog', 'Business',
      'Photography', 'Restaurant', 'Real Estate',
      'Health & Fitness', 'Education', 'Technology',
      'Fashion', 'Travel', 'Music', 'Non-profit', 'Entertainment'
  ] );
  ```

- `ENABLE_BLUEPRINTS=true npm start`
- Navigate to "Add Site" > "Create from blueprint"
- Confirm the categories are limited to 3 with a '+X more' indicator

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
