### PR TITLE
Graceful degradation for response with invalid blueprints

### DIFF
--- a/src/stores/wpcom-api.ts
+++ b/src/stores/wpcom-api.ts
@@ -52,13 +52,7 @@ const blueprintSchema = z.object( {
 	blueprint: z.record( z.unknown() ),
 } );
 
-const blueprintsResponseSchema = z.object( {
-	blueprints: z.array( blueprintSchema ),
-	total: z.number(),
-} );
-
 export type Blueprint = z.infer< typeof blueprintSchema >;
-export type BlueprintsResponse = z.infer< typeof blueprintsResponseSchema >;
 
 let wpcomClient: WPCOM | undefined;
 const publicWpcomClient = new WPCOM();
@@ -164,13 +158,55 @@ export const wpcomPublicApi = createApi( {
 	baseQuery: wpcomPublicBaseQuery,
 	tagTypes: [ 'Blueprints' ],
 	endpoints: ( builder ) => ( {
-		getBlueprints: builder.query< z.infer< typeof blueprintsResponseSchema >, void >( {
+		getBlueprints: builder.query<
+			{ blueprints: z.infer< typeof blueprintSchema >[]; total: number },
+			void
+		>( {
 			query: () => ( {
 				path: '/studio-app/blueprints',
 				apiNamespace: 'wpcom/v2',
 			} ),
-			transformResponse: ( response: unknown ) =>
-				parseResponse( response, blueprintsResponseSchema ),
+			transformResponse: ( response: unknown ) => {
+				if ( ! response || typeof response !== 'object' ) {
+					throw new Error( 'Invalid response format' );
+				}
+
+				const responseObj = response as Record< string, unknown >;
+				const blueprints = responseObj.blueprints;
+				const total = responseObj.total;
+
+				if ( typeof total !== 'number' ) {
+					throw new Error( 'Invalid total count in response' );
+				}
+
+				if ( ! Array.isArray( blueprints ) ) {
+					throw new Error( 'Invalid blueprints array in response' );
+				}
+
+				// Filter out invalid blueprint items to avoid failing the request
+				const validBlueprints: z.infer< typeof blueprintSchema >[] = [];
+
+				for ( const blueprint of blueprints ) {
+					try {
+						const validatedBlueprint = blueprintSchema.parse( blueprint );
+						validBlueprints.push( validatedBlueprint );
+					} catch ( error ) {
+						console.warn( 'Invalid blueprint item filtered out:', blueprint, error );
+					}
+				}
+
+				const invalidBlueprintsLength = blueprints.length - validBlueprints.length;
+				if ( invalidBlueprintsLength > 0 ) {
+					console.warn(
+						`Filtered out ${ invalidBlueprintsLength } invalid blueprint items out of ${ blueprints.length } total`
+					);
+				}
+
+				return {
+					blueprints: validBlueprints,
+					total: total,
+				};
+			},
 			keepUnusedDataFor: 60 * 60,
 			providesTags: [ 'Blueprints' ],
 		} ),

--- a/src/stores/wpcom-api.ts
+++ b/src/stores/wpcom-api.ts
@@ -195,13 +195,6 @@ export const wpcomPublicApi = createApi( {
 					}
 				}
 
-				const invalidBlueprintsLength = blueprints.length - validBlueprints.length;
-				if ( invalidBlueprintsLength > 0 ) {
-					console.warn(
-						`Filtered out ${ invalidBlueprintsLength } invalid blueprint items out of ${ blueprints.length } total`
-					);
-				}
-
 				return {
 					blueprints: validBlueprints,
 					total: total,


### PR DESCRIPTION
## Related issues

- Fixes STU-728

## Proposed Changes
With this PR, we don't fail parsing blueprints; instead, we just filter out invalid ones.

## Testing Instructions
Apply the next diff to backend:
``` diff
diff --git a/wp-content/rest-api-plugins/endpoints/studio-app/class-studio-app-blueprints.php b/wp-content/rest-api-plugins/endpoints/studio-app/class-studio-app-blueprints.php
index d80d535991c..7fa8938e151 100644
--- a/wp-content/rest-api-plugins/endpoints/studio-app/class-studio-app-blueprints.php
+++ b/wp-content/rest-api-plugins/endpoints/studio-app/class-studio-app-blueprints.php
@@ -50,13 +50,13 @@ class WPCOM_REST_API_V2_Endpoint_Studio_App_Blueprints extends WP_REST_Controlle
                        'posts_per_page' => -1,
                        'orderby'        => 'date',
                        'order'          => 'DESC',
-                       'tax_query'      => array(
-                               array(
-                                       'taxonomy' => 'blueprint-category',
-                                       'field'    => 'slug',
-                                       'terms'    => array( 'studio' ),
-                               ),
-                       ),
+                       // 'tax_query'      => array(
+                       //      array(
+                       //              'taxonomy' => 'blueprint-category',
+                       //              'field'    => 'slug',
+                       //              'terms'    => array( 'studio' ),
+                       //      ),
+                       // ),
                );
 
                $query = new \WP_Query( $args );
```
1. Run Studio 
2. Click on "Add site" and "Start from a blueprint"
3. Assert that you see blueprints (before you would see white screen, due to at least 1 invalid blueprint)
