### PR TITLE
Sync: Do not update local site title with the imported site title

### DIFF
--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -160,17 +160,6 @@ export async function importSite(
 			site.details.phpVersion = result.meta.phpVersion;
 		}
 
-		try {
-			const { stdout: siteTitle } = await site.executeWpCliCommand( 'option get blogname', {
-				skipPluginsAndThemes: true,
-			} );
-			if ( siteTitle && siteTitle.trim() ) {
-				site.details.name = siteTitle.trim();
-			}
-		} catch ( error ) {
-			console.warn( 'Failed to get site title after import:', error );
-		}
-
 		return site.details;
 	} catch ( e ) {
 		bumpStat( StatsGroup.STUDIO_IMPORT, StatsMetric.FAILURE );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-725

## Proposed Changes

- Delete code that renames the local site title with the imported site title

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Apply this branch and run `npm start`
- Create a site
- Navigate to the Sync tab 
- Connect the site to the WordPress.com site
- Start full pull
- Check the local site name is not updated

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
