### PR TITLE
Add support for the Sublime Text editor

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 Unreleased
 ==========
 * Upgraded Playground dependencies to support Playground CLI and make offline site creation faster #1594
+* Added support for Sublime Text as a code editor #1723
 
 1.5.6
 =====

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -133,6 +133,7 @@ export function getInstalledAppsAndTerminals(): InstalledApps {
 		webstorm: isInstalled( 'webstorm' ),
 		windsurf: isInstalled( 'windsurf' ),
 		cursor: isInstalled( 'cursor' ),
+		sublime: isInstalled( 'sublime' ),
 		terminal: true, // Terminal.app is always available on macOS
 		iterm: isInstalled( 'iterm' ),
 		warp: isInstalled( 'warp' ),

--- a/src/ipc-types.d.ts
+++ b/src/ipc-types.d.ts
@@ -53,6 +53,7 @@ type InstalledApps = {
 	webstorm: boolean;
 	windsurf: boolean;
 	cursor: boolean;
+	sublime: boolean;
 	terminal: boolean;
 	iterm: boolean;
 	warp: boolean;

--- a/src/lib/is-installed.ts
+++ b/src/lib/is-installed.ts
@@ -44,6 +44,7 @@ const installationPaths: Record< string, PlatformPaths > = {
 		cursor: [ 'Cursor.app' ],
 		windsurf: [ 'Windsurf.app' ],
 		webstorm: [ 'WebStorm.app' ],
+		sublime: [ 'Sublime Text.app' ],
 		iterm: [ 'iTerm.app' ],
 		terminal: [ 'Terminal.app' ],
 		warp: [ 'Warp.app' ],
@@ -55,6 +56,7 @@ const installationPaths: Record< string, PlatformPaths > = {
 		cursor: [ '/usr/bin/cursor' ],
 		windsurf: [ '/usr/bin/windsurf' ],
 		webstorm: [ '/usr/bin/webstorm' ],
+		sublime: [ '/usr/bin/subl' ],
 		iterm: [],
 		terminal: [],
 		warp: [ '/usr/bin/warp' ],
@@ -80,6 +82,11 @@ const installationPaths: Record< string, PlatformPaths > = {
 		webstorm: [
 			path.win32.join( getProgramFilesPath(), 'JetBrains\\WebStorm' ),
 			path.win32.join( getLocalProgramsPath(), 'WebStorm' ),
+		],
+		sublime: [
+			path.win32.join( getProgramFilesPath(), 'Sublime Text' ),
+			path.win32.join( getProgramFilesPath(), 'Sublime Text 4' ),
+			path.win32.join( getProgramFilesPath(), 'Sublime Text 3' ),
 		],
 		iterm: [],
 		terminal: [],

--- a/src/modules/user-settings/components/tests/terminal-picker.test.tsx
+++ b/src/modules/user-settings/components/tests/terminal-picker.test.tsx
@@ -48,6 +48,7 @@ describe( 'TerminalPicker', () => {
 					webstorm: false,
 					windsurf: false,
 					cursor: false,
+					sublime: false,
 					terminal: true,
 					iterm: true,
 					warp: false,
@@ -76,6 +77,7 @@ describe( 'TerminalPicker', () => {
 					webstorm: false,
 					windsurf: false,
 					cursor: false,
+					sublime: false,
 					// Terminal properties
 					terminal: true,
 					iterm: true,

--- a/src/modules/user-settings/lib/editor.ts
+++ b/src/modules/user-settings/lib/editor.ts
@@ -6,6 +6,7 @@ export const SUPPORTED_EDITORS = [
 	'phpstorm',
 	'windsurf',
 	'webstorm',
+	'sublime',
 ] as const;
 export type SupportedEditor = ( typeof SUPPORTED_EDITORS )[ number ];
 
@@ -66,6 +67,17 @@ export const supportedEditorConfig: Record< SupportedEditor, SupportedEditorConf
 		winPaths: [
 			'%LOCALAPPDATA%\\Programs\\cursor\\Cursor.exe',
 			'%PROGRAMFILES%\\cursor\\Cursor.exe',
+		],
+	},
+	sublime: {
+		// translators: "Sublime Text" is the brand name for an IDE and does not need to be translated
+		label: __( 'Sublime Text' ),
+		url: ( path: string ) => `subl://open?url=file://${ path }`,
+		macOSBundleId: 'com.sublimetext.4',
+		winPaths: [
+			'%PROGRAMFILES%\\Sublime Text\\sublime_text.exe',
+			'%PROGRAMFILES%\\Sublime Text 4\\sublime_text.exe',
+			'%PROGRAMFILES%\\Sublime Text 3\\sublime_text.exe',
 		],
 	},
 };

--- a/src/stores/tests/installed-apps-api.test.ts
+++ b/src/stores/tests/installed-apps-api.test.ts
@@ -214,9 +214,9 @@ describe( 'Installed Apps API', () => {
 				const mockInstalledApps = createMockInstalledApps( { vscode: true, cursor: true } );
 				const result = selectUninstalledEditors( mockInstalledApps );
 
-				expect( result ).toHaveLength( 3 );
+				expect( result ).toHaveLength( 4 );
 				expect( result.map( ( [ editor ] ) => editor ) ).toEqual(
-					expect.arrayContaining( [ 'phpstorm', 'windsurf', 'webstorm' ] )
+					expect.arrayContaining( [ 'phpstorm', 'windsurf', 'webstorm', 'sublime' ] )
 				);
 			} );
 
@@ -224,7 +224,7 @@ describe( 'Installed Apps API', () => {
 				const mockInstalledApps = createMockInstalledApps();
 				const result = selectUninstalledEditors( mockInstalledApps );
 
-				expect( result ).toHaveLength( 5 );
+				expect( result ).toHaveLength( 6 );
 			} );
 		} );
 

--- a/src/stores/tests/installed-apps-api.test.ts
+++ b/src/stores/tests/installed-apps-api.test.ts
@@ -40,6 +40,7 @@ const createMockInstalledApps = (
 	webstorm: false,
 	windsurf: false,
 	cursor: false,
+	sublime: false,
 	terminal: false,
 	iterm: false,
 	warp: false,


### PR DESCRIPTION
## Proposed Changes

- Adds support for selecting [Sublime Text](https://www.sublimetext.com/) as a text editor.

<img width="570" height="535" alt="Screenshot 2025-08-29 at 14 15 18" src="https://github.com/user-attachments/assets/77ee5777-05ae-4e1e-b638-bb406d40428e" />

## Testing Instructions

- If you have Sublime Text installed, it should appear in the dropdown in settings.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
