### PR TITLE
Fix redirect to WP_SITEURL

### DIFF
--- a/src/lib/wordpress-provider/playground-cli/mu-plugins.ts
+++ b/src/lib/wordpress-provider/playground-cli/mu-plugins.ts
@@ -86,6 +86,17 @@ function getStandardMuPlugins( options: Partial< WordPressServerOptions > ): MuP
 			$current_host = $_SERVER['HTTP_HOST'] ?? '';
 
 			if ( preg_match( '/^localhost:\\d+$/', $current_host ) ) {
+				$wp_siteurl_host = parse_url( WP_SITEURL, PHP_URL_HOST );
+				$wp_siteurl_port = parse_url( WP_SITEURL, PHP_URL_PORT );
+				$wp_siteurl_host_with_port = $wp_siteurl_host;
+				if ( $wp_siteurl_port ) {
+					$wp_siteurl_host_with_port .= ':' . $wp_siteurl_port;
+				}
+
+				if ( $current_host === $wp_siteurl_host_with_port ) {
+					return;
+				}
+
 				$requested_uri = $_SERVER['REQUEST_URI'] ?? '/';
 				wp_redirect( rtrim( WP_SITEURL, '/' ) . $requested_uri, 302 );
 				exit;


### PR DESCRIPTION
## Related issues

- Fixes STU-742

## Proposed Changes
With this PR we prevent redirect from the same localhost:port to teh same localhost:port since new we have endless loop.

Why we didn't have it before - since wiuth wp-now we didn't have WP_SITEURL explicitly in DB when we used localhost. After migration to playground-cli we have it in DB so we got unexxpectedly endless loop.

## Testing Instructions
1. Create simple site
2. Create site with custom domain and SSL
3. Create site with custom domain and WITHOUT SSL
4. Assert that "Open site" and "WP admin" buttons work well for all 3 sites
5. Open `hosts` file to see which ports are used under the hood for 2 sites with custom domains: <br /><img width="300" height="89" alt="Screenshot 2025-08-29 at 18 17 23" src="https://github.com/user-attachments/assets/3a53dd80-e99f-48bf-b996-702cc3f82aea" />
6. Open in browser `localhost:8882` and assert that you are redirected correctly to `with.wp.local`. Repeat the same for 8883.
