### PR TITLE
Suppress expected warnings at server disposal

### DIFF
--- a/src/lib/wordpress-provider/playground-cli/playground-server-process-child.ts
+++ b/src/lib/wordpress-provider/playground-cli/playground-server-process-child.ts
@@ -195,7 +195,12 @@ async function stopServerFunc(): Promise< void > {
 	try {
 		await server[ Symbol.asyncDispose ]();
 	} catch ( error ) {
-		console.warn( error );
+		// Suppress expected disposal errors that occur during site deletion
+		// These are typically race conditions that don't affect functionality
+		const errorMessage = error instanceof Error ? error.message : String( error );
+		if ( ! errorMessage.includes( 'Cannot read properties of undefined' ) ) {
+			console.warn( 'Error during server disposal:', error );
+		}
 	} finally {
 		server = null;
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Resolves [STU-723 Error is visible in console after removing site](https://linear.app/a8c/issue/STU-723/error-is-visible-in-console-after-removing-site)

## Proposed Changes

When deleting sites in Studio, users were seeing console errors that appeared alarming but were actually harmless race conditions during the playground CLI server disposal process. The error only occurred during site deletion (not stopping) because deletion involves stopping both the server and wpCliExecutor simultaneously.

The error is caused by a timing issue where the playground CLI's `Symbol.asyncDispose()` method tried to access resources that were being disposed of concurrently. I initially tried  fixing the timing within the delete method.

Even though we're awaiting the result of the [server's stop call](https://github.com/Automattic/studio/blob/87b44e5455cb6e5ca4173a45a316124b98a6603d/src/site-server.ts#L103-L104), I tried adding a 100ms delay to see if this would let the first process complete and prevent the race condition, but this was unsuccessful.

I also tried reversing the order of calls to stop `wpCliExecutor` first, adding a 100ms delay, then stopping the server. I also extended the timeout for stop-server messages to 10 seconds. This caused the UI to be blocked and also didn't eliminate the race condition.

Ultimately, as this warning is only related to site deletion, and not causing an error on the UI, I added a suppression for these warnings for the time being.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Start Studio
2. Enable Blueprints flag
3. Create a new site
4. Delete the site (not just stop it)
5. Check the console - you should no longer see the "Cannot read properties of undefined (reading 'FS')" error

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
