### PR TITLE
Studio: Make the import process more verbose

### DIFF
--- a/src/components/content-tab-import-export.tsx
+++ b/src/components/content-tab-import-export.tsx
@@ -76,7 +76,7 @@ export const ExportSite = ( {
 				<div className="flex flex-col gap-4 max-w-[300px]">
 					{ isExporting && (
 						<>
-							<ProgressBar value={ currentProgress.progress } maxValue={ 100 } />
+							<ProgressBar />
 							<div className="text-a8c-gray-70 a8c-body">{ currentProgress.statusMessage }</div>
 						</>
 					) }
@@ -267,10 +267,10 @@ const ImportSite = ( {
 						{ isImporting && (
 							<>
 								<div className="w-[240px]">
-									<ProgressBar value={ currentProgress.progress } maxValue={ 100 } />
+									<ProgressBar />
 								</div>
 								<div className="text-a8c-gray-70 a8c-body mt-4">
-									{ currentProgress.statusMessage }
+									{ currentProgress.statusMessage || __( 'Importing…' ) }
 								</div>
 							</>
 						) }

--- a/src/components/progress-bar.tsx
+++ b/src/components/progress-bar.tsx
@@ -1,26 +1,22 @@
+import { ProgressBar as WPProgressBar } from '@wordpress/components';
 import { useEffect, useState } from 'react';
+import { cx } from 'src/lib/cx';
 
 type ProgressBarProps = {
-	value: number;
-	maxValue: number;
+	value?: number;
+	maxValue?: number;
+	className?: string;
 };
 
-const ProgressBar = ( { value, maxValue }: ProgressBarProps ) => {
-	// Calculate width percentage of the filled part
-	const fillPercentage = Math.max( 0, Math.min( 100, ( value / maxValue ) * 100 ) );
+const ProgressBar = ( { value, maxValue, className }: ProgressBarProps ) => {
+	const classNames = cx( 'w-full flex', className );
+	if ( value !== undefined && maxValue !== undefined ) {
+		const percentage = Math.max( 0, Math.min( 100, ( value / maxValue ) * 100 ) );
+		return <WPProgressBar value={ percentage } className={ classNames } />;
+	}
 
-	return (
-		<div className="w-full flex h-0.5 self-stretch rounded-[4.5px] bg-a8c-gray-5">
-			<div
-				role="progressbar"
-				aria-valuenow={ fillPercentage }
-				className="h-full bg-a8c-blue-50 rounded-[4.5px] transition-all"
-				style={ {
-					width: `${ fillPercentage }%`,
-				} }
-			></div>
-		</div>
-	);
+	// Otherwise, use indeterminate progress bar
+	return <WPProgressBar className={ classNames } />;
 };
 
 export default ProgressBar;

--- a/src/components/site-content-tabs.tsx
+++ b/src/components/site-content-tabs.tsx
@@ -16,7 +16,7 @@ import { cx } from 'src/lib/cx';
 import { ContentTabSync } from 'src/modules/sync';
 
 export function SiteContentTabs() {
-	const { selectedSite, data: localSites } = useSiteDetails();
+	const { selectedSite, data: localSites, siteCreationMessages } = useSiteDetails();
 	const { importState } = useImportExport();
 	const { tabs, selectedTab, setSelectedTab } = useContentTabs();
 	const { __ } = useI18n();
@@ -35,10 +35,11 @@ export function SiteContentTabs() {
 
 	if ( selectedSite?.isAddingSite || importState[ selectedSite?.id ]?.isNewSite ) {
 		const siteImportState = importState[ selectedSite?.id ];
+		const creationMessage = selectedSite?.id ? siteCreationMessages[ selectedSite.id ] : undefined;
 		return (
 			<SiteIsBeingCreated
 				siteName={ selectedSite?.name }
-				importStatusMessage={ siteImportState?.statusMessage }
+				statusMessage={ siteImportState?.statusMessage || creationMessage }
 			/>
 		);
 	}

--- a/src/components/site-content-tabs.tsx
+++ b/src/components/site-content-tabs.tsx
@@ -34,7 +34,13 @@ export function SiteContentTabs() {
 	}
 
 	if ( selectedSite?.isAddingSite || importState[ selectedSite?.id ]?.isNewSite ) {
-		return <SiteIsBeingCreated siteName={ selectedSite?.name } />;
+		const siteImportState = importState[ selectedSite?.id ];
+		return (
+			<SiteIsBeingCreated
+				siteName={ selectedSite?.name }
+				importStatusMessage={ siteImportState?.statusMessage }
+			/>
+		);
 	}
 
 	return (

--- a/src/components/site-is-being-created.tsx
+++ b/src/components/site-is-being-created.tsx
@@ -7,10 +7,7 @@ interface SiteIsBeingCreatedProps {
 	importStatusMessage?: string;
 }
 
-export function SiteIsBeingCreated( {
-	siteName,
-	importStatusMessage,
-}: SiteIsBeingCreatedProps ) {
+export function SiteIsBeingCreated( { siteName, importStatusMessage }: SiteIsBeingCreatedProps ) {
 	const { __ } = useI18n();
 	const [ currentMessageIndex, setCurrentMessageIndex ] = useState( 0 );
 

--- a/src/components/site-is-being-created.tsx
+++ b/src/components/site-is-being-created.tsx
@@ -32,7 +32,6 @@ export function SiteIsBeingCreated( { siteName, importStatusMessage }: SiteIsBei
 		return () => clearInterval( interval );
 	}, [ statusMessages.length ] );
 
-	// Use import message if available, otherwise use generic cycling messages
 	const displayMessage = importStatusMessage || statusMessages[ currentMessageIndex ];
 
 	return (

--- a/src/components/site-is-being-created.tsx
+++ b/src/components/site-is-being-created.tsx
@@ -2,7 +2,15 @@ import { ProgressBar } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
 import { useEffect, useState } from 'react';
 
-export function SiteIsBeingCreated( { siteName }: { siteName: string } ) {
+interface SiteIsBeingCreatedProps {
+	siteName: string;
+	importStatusMessage?: string;
+}
+
+export function SiteIsBeingCreated( {
+	siteName,
+	importStatusMessage,
+}: SiteIsBeingCreatedProps ) {
 	const { __ } = useI18n();
 	const [ currentMessageIndex, setCurrentMessageIndex ] = useState( 0 );
 
@@ -27,14 +35,15 @@ export function SiteIsBeingCreated( { siteName }: { siteName: string } ) {
 		return () => clearInterval( interval );
 	}, [ statusMessages.length ] );
 
+	// Use import message if available, otherwise use generic cycling messages
+	const displayMessage = importStatusMessage || statusMessages[ currentMessageIndex ];
+
 	return (
 		<div className="flex flex-col w-full h-full app-no-drag-region pt-8 overflow-y-auto justify-center items-center">
 			<div className="w-[300px] text-center">
 				<div className="text-black a8c-subtitle-small mb-4">{ siteName }</div>
 				<ProgressBar className="w-full" />
-				<div className="text-a8c-gray-70 a8c-body mt-4">
-					{ statusMessages[ currentMessageIndex ] }
-				</div>
+				<div className="text-a8c-gray-70 a8c-body mt-4">{ displayMessage }</div>
 			</div>
 		</div>
 	);

--- a/src/components/site-is-being-created.tsx
+++ b/src/components/site-is-being-created.tsx
@@ -4,10 +4,10 @@ import { useEffect, useState } from 'react';
 
 interface SiteIsBeingCreatedProps {
 	siteName: string;
-	importStatusMessage?: string;
+	statusMessage?: string;
 }
 
-export function SiteIsBeingCreated( { siteName, importStatusMessage }: SiteIsBeingCreatedProps ) {
+export function SiteIsBeingCreated( { siteName, statusMessage }: SiteIsBeingCreatedProps ) {
 	const { __ } = useI18n();
 	const [ currentMessageIndex, setCurrentMessageIndex ] = useState( 0 );
 
@@ -32,7 +32,7 @@ export function SiteIsBeingCreated( { siteName, importStatusMessage }: SiteIsBei
 		return () => clearInterval( interval );
 	}, [ statusMessages.length ] );
 
-	const displayMessage = importStatusMessage || statusMessages[ currentMessageIndex ];
+	const displayMessage = statusMessage || statusMessages[ currentMessageIndex ];
 
 	return (
 		<div className="flex flex-col w-full h-full app-no-drag-region pt-8 overflow-y-auto justify-center items-center">

--- a/src/components/site-is-being-created.tsx
+++ b/src/components/site-is-being-created.tsx
@@ -1,6 +1,6 @@
-import { ProgressBar } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
 import { useEffect, useState } from 'react';
+import ProgressBar from './progress-bar';
 
 interface SiteIsBeingCreatedProps {
 	siteName: string;

--- a/src/components/tests/content-tab-import-export.test.tsx
+++ b/src/components/tests/content-tab-import-export.test.tsx
@@ -143,7 +143,7 @@ describe( 'ContentTabImportExport Import', () => {
 		} );
 
 		expect( screen.getByText( 'Extracting backup…' ) ).toBeVisible();
-		expect( screen.getByRole( 'progressbar', { value: { now: 5 } } ) ).toBeVisible();
+		expect( screen.getByRole( 'progressbar' ) ).toBeInTheDocument();
 	} );
 } );
 
@@ -189,7 +189,7 @@ describe( 'ContentTabImportExport Export', () => {
 		} );
 
 		expect( screen.getByText( 'Starting export…' ) ).toBeVisible();
-		expect( screen.getByRole( 'progressbar', { value: { now: 5 } } ) ).toBeVisible();
+		expect( screen.getByRole( 'progressbar' ) ).toBeInTheDocument();
 	} );
 
 	test( 'should be blocked', async () => {

--- a/src/hooks/tests/use-import-export.test.tsx
+++ b/src/hooks/tests/use-import-export.test.tsx
@@ -509,4 +509,209 @@ describe( 'useImportExport hook', () => {
 
 		expect( useSiteDetails().updateSite ).toHaveBeenCalledWith( importedSite );
 	} );
+
+	it( 'handles verbose backup extraction progress with file counts', async () => {
+		let onEvent: ( ...args: any[] ) => void = jest.fn();
+		( useIpcListener as jest.Mock ).mockImplementation( ( event, callback ) => {
+			if ( event === 'on-import' ) {
+				onEvent = callback;
+			}
+		} );
+		const emitImportEvent = ( siteId: string, event: ImportEventType, data: unknown = {} ) =>
+			act( () => onEvent( null, { event, data }, siteId ) );
+
+		const { result } = renderHook( () => useImportExport(), { wrapper } );
+		const file = { path: 'backup.zip', type: 'application/zip' };
+		await act( () => result.current.importFile( file, selectedSite ) );
+
+		// Test extraction progress with file count data
+		emitImportEvent( SITE_ID, ImportEvents.BACKUP_EXTRACT_PROGRESS, {
+			progress: 0.5,
+			processedFiles: 123,
+			totalFiles: 250,
+			currentFile: 'wp-content/themes/twentytwentythree/style.css',
+			extractedBytes: 1024000,
+			totalBytes: 2048000,
+		} );
+
+		expect( result.current.importState ).toEqual( {
+			[ SITE_ID ]: {
+				statusMessage: 'Extracting backup… (123/250 files)',
+				progress: 27.5, // 5 + (0.5 * 45)
+				isNewSite: false,
+			},
+		} );
+
+		// Test extraction progress without file count data (fallback)
+		emitImportEvent( SITE_ID, ImportEvents.BACKUP_EXTRACT_PROGRESS, {
+			progress: 0.8,
+		} );
+
+		expect( result.current.importState ).toEqual( {
+			[ SITE_ID ]: {
+				statusMessage: 'Extracting backup files…',
+				progress: 41, // 5 + (0.8 * 45)
+				isNewSite: false,
+			},
+		} );
+	} );
+
+	it( 'handles verbose database import progress', async () => {
+		let onEvent: ( ...args: any[] ) => void = jest.fn();
+		( useIpcListener as jest.Mock ).mockImplementation( ( event, callback ) => {
+			if ( event === 'on-import' ) {
+				onEvent = callback;
+			}
+		} );
+		const emitImportEvent = ( siteId: string, event: ImportEventType, data: unknown = {} ) =>
+			act( () => onEvent( null, { event, data }, siteId ) );
+
+		const { result } = renderHook( () => useImportExport(), { wrapper } );
+		const file = { path: 'backup.zip', type: 'application/zip' };
+		await act( () => result.current.importFile( file, selectedSite ) );
+
+		// Start database import
+		emitImportEvent( SITE_ID, ImportEvents.IMPORT_DATABASE_START );
+		expect( result.current.importState ).toEqual( {
+			[ SITE_ID ]: {
+				statusMessage: 'Importing database…',
+				progress: 60,
+				isNewSite: false,
+			},
+		} );
+
+		// Test database progress with SQL file tracking
+		emitImportEvent( SITE_ID, ImportEvents.IMPORT_DATABASE_PROGRESS, {
+			currentFile: 'database1.sql',
+			processedFiles: 1,
+			totalFiles: 3,
+		} );
+
+		expect( result.current.importState ).toEqual( {
+			[ SITE_ID ]: {
+				statusMessage: 'Importing database… (1/3 SQL files)',
+				progress: Math.min( 80, 60 + ( 1 / 3 ) * 20 ), // ~66.67
+				isNewSite: false,
+			},
+		} );
+
+		// Test database progress with multiple files
+		emitImportEvent( SITE_ID, ImportEvents.IMPORT_DATABASE_PROGRESS, {
+			currentFile: 'database2.sql',
+			processedFiles: 2,
+			totalFiles: 3,
+		} );
+
+		expect( result.current.importState ).toEqual( {
+			[ SITE_ID ]: {
+				statusMessage: 'Importing database… (2/3 SQL files)',
+				progress: Math.min( 80, 60 + ( 2 / 3 ) * 20 ), // ~73.33
+				isNewSite: false,
+			},
+		} );
+	} );
+
+	it( 'handles verbose WordPress content import progress with categorization', async () => {
+		let onEvent: ( ...args: any[] ) => void = jest.fn();
+		( useIpcListener as jest.Mock ).mockImplementation( ( event, callback ) => {
+			if ( event === 'on-import' ) {
+				onEvent = callback;
+			}
+		} );
+		const emitImportEvent = ( siteId: string, event: ImportEventType, data: unknown = {} ) =>
+			act( () => onEvent( null, { event, data }, siteId ) );
+
+		const { result } = renderHook( () => useImportExport(), { wrapper } );
+		const file = { path: 'backup.zip', type: 'application/zip' };
+		await act( () => result.current.importFile( file, selectedSite ) );
+
+		// Start WordPress content import
+		emitImportEvent( SITE_ID, ImportEvents.IMPORT_WP_CONTENT_START );
+		expect( result.current.importState ).toEqual( {
+			[ SITE_ID ]: {
+				statusMessage: 'Importing WordPress content…',
+				progress: 5, // Progress is preserved from the initial import file call
+				isNewSite: false,
+			},
+		} );
+
+		// Test plugins import progress
+		emitImportEvent( SITE_ID, ImportEvents.IMPORT_WP_CONTENT_PROGRESS, {
+			type: 'plugins',
+			currentItem: 'wp-content/plugins/akismet/akismet.php',
+			processedItems: 5,
+			totalItems: 12,
+		} );
+
+		expect( result.current.importState ).toEqual( {
+			[ SITE_ID ]: {
+				statusMessage: 'Importing plugins… (5/12)',
+				progress: Math.min( 90, 80 + ( 5 / 12 ) * 10 ), // ~84.17
+				isNewSite: false,
+			},
+		} );
+
+		// Test themes import progress
+		emitImportEvent( SITE_ID, ImportEvents.IMPORT_WP_CONTENT_PROGRESS, {
+			type: 'themes',
+			currentItem: 'wp-content/themes/twentytwentythree/style.css',
+			processedItems: 2,
+			totalItems: 3,
+		} );
+
+		expect( result.current.importState ).toEqual( {
+			[ SITE_ID ]: {
+				statusMessage: 'Importing themes… (2/3)',
+				progress: Math.min( 90, 80 + ( 2 / 3 ) * 10 ), // ~86.67
+				isNewSite: false,
+			},
+		} );
+
+		// Test uploads import progress
+		emitImportEvent( SITE_ID, ImportEvents.IMPORT_WP_CONTENT_PROGRESS, {
+			type: 'uploads',
+			currentItem: 'wp-content/uploads/2024/01/image.jpg',
+			processedItems: 150,
+			totalItems: 500,
+		} );
+
+		expect( result.current.importState ).toEqual( {
+			[ SITE_ID ]: {
+				statusMessage: 'Importing media uploads… (150/500)',
+				progress: Math.min( 90, 80 + ( 150 / 500 ) * 10 ), // 83
+				isNewSite: false,
+			},
+		} );
+
+		// Test other files import progress
+		emitImportEvent( SITE_ID, ImportEvents.IMPORT_WP_CONTENT_PROGRESS, {
+			type: 'other',
+			currentItem: 'wp-content/index.php',
+			processedItems: 10,
+			totalItems: 25,
+		} );
+
+		expect( result.current.importState ).toEqual( {
+			[ SITE_ID ]: {
+				statusMessage: 'Importing other files… (10/25)',
+				progress: Math.min( 90, 80 + ( 10 / 25 ) * 10 ), // 84
+				isNewSite: false,
+			},
+		} );
+
+		// Test fallback for unknown content type
+		emitImportEvent( SITE_ID, ImportEvents.IMPORT_WP_CONTENT_PROGRESS, {
+			type: 'unknown',
+			processedItems: 10,
+			totalItems: 25,
+		} );
+
+		expect( result.current.importState ).toEqual( {
+			[ SITE_ID ]: {
+				statusMessage: 'Importing files… (10/25)',
+				progress: Math.min( 90, 80 + ( 10 / 25 ) * 10 ), // 84
+				isNewSite: false,
+			},
+		} );
+	} );
 } );

--- a/src/hooks/tests/use-import-export.test.tsx
+++ b/src/hooks/tests/use-import-export.test.tsx
@@ -536,7 +536,7 @@ describe( 'useImportExport hook', () => {
 
 		expect( result.current.importState ).toEqual( {
 			[ SITE_ID ]: {
-				statusMessage: 'Extracting backup… (123/250 files)',
+				statusMessage: 'Extracting backup… (49%)',
 				progress: 27.5, // 5 + (0.5 * 45)
 				isNewSite: false,
 			},
@@ -589,7 +589,7 @@ describe( 'useImportExport hook', () => {
 
 		expect( result.current.importState ).toEqual( {
 			[ SITE_ID ]: {
-				statusMessage: 'Importing database… (1/3 SQL files)',
+				statusMessage: 'Importing database… (33%)',
 				progress: Math.min( 80, 60 + ( 1 / 3 ) * 20 ), // ~66.67
 				isNewSite: false,
 			},
@@ -604,7 +604,7 @@ describe( 'useImportExport hook', () => {
 
 		expect( result.current.importState ).toEqual( {
 			[ SITE_ID ]: {
-				statusMessage: 'Importing database… (2/3 SQL files)',
+				statusMessage: 'Importing database… (67%)',
 				progress: Math.min( 80, 60 + ( 2 / 3 ) * 20 ), // ~73.33
 				isNewSite: false,
 			},
@@ -645,7 +645,7 @@ describe( 'useImportExport hook', () => {
 
 		expect( result.current.importState ).toEqual( {
 			[ SITE_ID ]: {
-				statusMessage: 'Importing plugins… (5/12)',
+				statusMessage: 'Importing plugins… (42%)',
 				progress: Math.min( 90, 80 + ( 5 / 12 ) * 10 ), // ~84.17
 				isNewSite: false,
 			},
@@ -661,7 +661,7 @@ describe( 'useImportExport hook', () => {
 
 		expect( result.current.importState ).toEqual( {
 			[ SITE_ID ]: {
-				statusMessage: 'Importing themes… (2/3)',
+				statusMessage: 'Importing themes… (67%)',
 				progress: Math.min( 90, 80 + ( 2 / 3 ) * 10 ), // ~86.67
 				isNewSite: false,
 			},
@@ -677,7 +677,7 @@ describe( 'useImportExport hook', () => {
 
 		expect( result.current.importState ).toEqual( {
 			[ SITE_ID ]: {
-				statusMessage: 'Importing media uploads… (150/500)',
+				statusMessage: 'Importing media uploads… (30%)',
 				progress: Math.min( 90, 80 + ( 150 / 500 ) * 10 ), // 83
 				isNewSite: false,
 			},
@@ -693,7 +693,7 @@ describe( 'useImportExport hook', () => {
 
 		expect( result.current.importState ).toEqual( {
 			[ SITE_ID ]: {
-				statusMessage: 'Importing other files… (10/25)',
+				statusMessage: 'Importing other files… (40%)',
 				progress: Math.min( 90, 80 + ( 10 / 25 ) * 10 ), // 84
 				isNewSite: false,
 			},
@@ -708,7 +708,7 @@ describe( 'useImportExport hook', () => {
 
 		expect( result.current.importState ).toEqual( {
 			[ SITE_ID ]: {
-				statusMessage: 'Importing files… (10/25)',
+				statusMessage: 'Importing files… (40%)',
 				progress: Math.min( 90, 80 + ( 10 / 25 ) * 10 ), // 84
 				isNewSite: false,
 			},

--- a/src/hooks/tests/use-import-export.test.tsx
+++ b/src/hooks/tests/use-import-export.test.tsx
@@ -429,7 +429,7 @@ describe( 'useImportExport hook', () => {
 		emitImportEvent( SITE_ID, ImportEvents.BACKUP_EXTRACT_START );
 		expect( result.current.importState ).toEqual( {
 			[ SITE_ID ]: {
-				statusMessage: 'Extracting backup…',
+				statusMessage: 'Extracting backup files…',
 				progress: 5,
 				isNewSite: false,
 			},

--- a/src/hooks/use-import-export.tsx
+++ b/src/hooks/use-import-export.tsx
@@ -17,6 +17,8 @@ import {
 import {
 	BackupArchiveInfo,
 	BackupExtractProgressEventData,
+	ImportDatabaseProgressEventData,
+	ImportWpContentProgressEventData,
 } from 'src/lib/import-export/import/types';
 
 export type ImportProgressState = {
@@ -176,12 +178,23 @@ export const ImportExportProvider = ( { children }: { children: React.ReactNode 
 
 		switch ( event ) {
 			case BackupExtractEvents.BACKUP_EXTRACT_PROGRESS: {
-				const progress = ( data as BackupExtractProgressEventData )?.progress ?? 0;
+				const progressData = data as BackupExtractProgressEventData;
+				const progress = progressData?.progress ?? 0;
+				let statusMessage: string = __( 'Extracting backup files…' );
+
+				if ( progressData.processedFiles && progressData.totalFiles ) {
+					statusMessage = sprintf(
+						__( 'Extracting backup… (%1$d/%2$d files)' ),
+						progressData.processedFiles,
+						progressData.totalFiles
+					);
+				}
+
 				setImportState( ( { [ siteId ]: currentProgress, ...rest } ) => ( {
 					...rest,
 					[ siteId ]: {
 						...currentProgress,
-						statusMessage: __( 'Extracting backup files…' ),
+						statusMessage,
 						progress: 5 + progress * 45, // Backup extraction takes progress from 5% to 50%
 					},
 				} ) );
@@ -207,6 +220,32 @@ export const ImportExportProvider = ( { children }: { children: React.ReactNode 
 					},
 				} ) );
 				break;
+			case ImporterEvents.IMPORT_DATABASE_PROGRESS: {
+				const progressData = data as ImportDatabaseProgressEventData;
+				let statusMessage: string = __( 'Importing database…' );
+
+				if ( progressData.processedFiles && progressData.totalFiles ) {
+					statusMessage = sprintf(
+						__( 'Importing database… (%1$d/%2$d SQL files)' ),
+						progressData.processedFiles,
+						progressData.totalFiles
+					);
+				}
+
+				const progressIncrement = progressData.totalFiles
+					? ( ( progressData.processedFiles || 0 ) / progressData.totalFiles ) * 20
+					: 0;
+
+				setImportState( ( { [ siteId ]: currentProgress, ...rest } ) => ( {
+					...rest,
+					[ siteId ]: {
+						...currentProgress,
+						statusMessage,
+						progress: Math.min( 80, 60 + progressIncrement ),
+					},
+				} ) );
+				break;
+			}
 			case ImporterEvents.IMPORT_DATABASE_COMPLETE:
 				setImportState( ( { [ siteId ]: currentProgress, ...rest } ) => ( {
 					...rest,
@@ -225,6 +264,40 @@ export const ImportExportProvider = ( { children }: { children: React.ReactNode 
 					},
 				} ) );
 				break;
+			case ImporterEvents.IMPORT_WP_CONTENT_PROGRESS: {
+				const progressData = data as ImportWpContentProgressEventData;
+				let statusMessage: string = __( 'Importing WordPress content…' );
+
+				if ( progressData.type && progressData.processedItems && progressData.totalItems ) {
+					const typeLabels: Record< string, string > = {
+						plugins: __( 'Importing plugins…' ),
+						themes: __( 'Importing themes…' ),
+						uploads: __( 'Importing media uploads…' ),
+						other: __( 'Importing other files…' ),
+					};
+
+					statusMessage = sprintf(
+						__( '%1$s (%2$d/%3$d)' ),
+						typeLabels[ progressData.type ] || __( 'Importing files…' ),
+						progressData.processedItems,
+						progressData.totalItems
+					);
+				}
+
+				const progressIncrement = progressData.totalItems
+					? ( ( progressData.processedItems || 0 ) / progressData.totalItems ) * 10
+					: 0;
+
+				setImportState( ( { [ siteId ]: currentProgress, ...rest } ) => ( {
+					...rest,
+					[ siteId ]: {
+						...currentProgress,
+						statusMessage,
+						progress: Math.min( 90, 80 + progressIncrement ),
+					},
+				} ) );
+				break;
+			}
 			case ImporterEvents.IMPORT_WP_CONTENT_COMPLETE:
 				setImportState( ( { [ siteId ]: currentProgress, ...rest } ) => ( {
 					...rest,

--- a/src/hooks/use-import-export.tsx
+++ b/src/hooks/use-import-export.tsx
@@ -189,7 +189,11 @@ export const ImportExportProvider = ( { children }: { children: React.ReactNode 
 				const progress = progressData?.progress ?? 0;
 				let statusMessage: string = __( 'Extracting backup files…' );
 
-				if ( progressData.processedFiles && progressData.totalFiles ) {
+				if (
+					progressData.processedFiles != null &&
+					progressData.totalFiles != null &&
+					progressData.totalFiles > 0
+				) {
 					statusMessage = sprintf(
 						__( 'Extracting backup… (%1$d/%2$d files)' ),
 						progressData.processedFiles,
@@ -231,7 +235,11 @@ export const ImportExportProvider = ( { children }: { children: React.ReactNode 
 				const progressData = data as ImportDatabaseProgressEventData;
 				let statusMessage: string = __( 'Importing database…' );
 
-				if ( progressData.processedFiles && progressData.totalFiles ) {
+				if (
+					progressData.processedFiles != null &&
+					progressData.totalFiles != null &&
+					progressData.totalFiles > 0
+				) {
 					statusMessage = sprintf(
 						__( 'Importing database… (%1$d/%2$d SQL files)' ),
 						progressData.processedFiles,
@@ -275,7 +283,12 @@ export const ImportExportProvider = ( { children }: { children: React.ReactNode 
 				const progressData = data as ImportWpContentProgressEventData;
 				let statusMessage: string = __( 'Importing WordPress content…' );
 
-				if ( progressData.type && progressData.processedItems && progressData.totalItems ) {
+				if (
+					progressData.type &&
+					progressData.processedItems != null &&
+					progressData.totalItems != null &&
+					progressData.totalItems > 0
+				) {
 					statusMessage = sprintf(
 						__( '%1$s (%2$d/%3$d)' ),
 						WP_CONTENT_TYPE_LABELS[ progressData.type ] || __( 'Importing files…' ),

--- a/src/hooks/use-import-export.tsx
+++ b/src/hooks/use-import-export.tsx
@@ -184,6 +184,7 @@ export const ImportExportProvider = ( { children }: { children: React.ReactNode 
 		}
 
 		switch ( event ) {
+			case BackupExtractEvents.BACKUP_EXTRACT_START:
 			case BackupExtractEvents.BACKUP_EXTRACT_PROGRESS: {
 				const progressData = data as BackupExtractProgressEventData;
 				const progress = progressData?.progress ?? 0;
@@ -200,12 +201,15 @@ export const ImportExportProvider = ( { children }: { children: React.ReactNode 
 					statusMessage = sprintf( __( 'Extracting backup… (%d%%)' ), percentage );
 				}
 
+				// Normalize progress: some handlers emit 0-100, others emit 0-1
+				const normalizedProgress = progress > 1 ? progress / 100 : progress;
+
 				setImportState( ( { [ siteId ]: currentProgress, ...rest } ) => ( {
 					...rest,
 					[ siteId ]: {
 						...currentProgress,
 						statusMessage,
-						progress: 5 + progress * 45, // Backup extraction takes progress from 5% to 50%
+						progress: 5 + normalizedProgress * 45, // Backup extraction takes progress from 5% to 50%
 					},
 				} ) );
 				break;

--- a/src/hooks/use-import-export.tsx
+++ b/src/hooks/use-import-export.tsx
@@ -65,6 +65,13 @@ const ImportExportContext = createContext< ImportExportContext >( {
 	clearExportState: () => undefined,
 } );
 
+const WP_CONTENT_TYPE_LABELS: Record< string, string > = {
+	plugins: __( 'Importing plugins…' ),
+	themes: __( 'Importing themes…' ),
+	uploads: __( 'Importing media uploads…' ),
+	other: __( 'Importing other files…' ),
+};
+
 export const ImportExportProvider = ( { children }: { children: React.ReactNode } ) => {
 	const [ importState, setImportState ] = useState< ImportProgressState >( {} );
 	const [ exportState, setExportState ] = useState< ExportProgressState >( {} );
@@ -269,16 +276,9 @@ export const ImportExportProvider = ( { children }: { children: React.ReactNode 
 				let statusMessage: string = __( 'Importing WordPress content…' );
 
 				if ( progressData.type && progressData.processedItems && progressData.totalItems ) {
-					const typeLabels: Record< string, string > = {
-						plugins: __( 'Importing plugins…' ),
-						themes: __( 'Importing themes…' ),
-						uploads: __( 'Importing media uploads…' ),
-						other: __( 'Importing other files…' ),
-					};
-
 					statusMessage = sprintf(
 						__( '%1$s (%2$d/%3$d)' ),
-						typeLabels[ progressData.type ] || __( 'Importing files…' ),
+						WP_CONTENT_TYPE_LABELS[ progressData.type ] || __( 'Importing files…' ),
 						progressData.processedItems,
 						progressData.totalItems
 					);

--- a/src/hooks/use-import-export.tsx
+++ b/src/hooks/use-import-export.tsx
@@ -194,11 +194,10 @@ export const ImportExportProvider = ( { children }: { children: React.ReactNode 
 					progressData.totalFiles != null &&
 					progressData.totalFiles > 0
 				) {
-					statusMessage = sprintf(
-						__( 'Extracting backup… (%1$d/%2$d files)' ),
-						progressData.processedFiles,
-						progressData.totalFiles
+					const percentage = Math.round(
+						( progressData.processedFiles / progressData.totalFiles ) * 100
 					);
+					statusMessage = sprintf( __( 'Extracting backup… (%d%%)' ), percentage );
 				}
 
 				setImportState( ( { [ siteId ]: currentProgress, ...rest } ) => ( {
@@ -240,11 +239,10 @@ export const ImportExportProvider = ( { children }: { children: React.ReactNode 
 					progressData.totalFiles != null &&
 					progressData.totalFiles > 0
 				) {
-					statusMessage = sprintf(
-						__( 'Importing database… (%1$d/%2$d SQL files)' ),
-						progressData.processedFiles,
-						progressData.totalFiles
+					const percentage = Math.round(
+						( progressData.processedFiles / progressData.totalFiles ) * 100
 					);
+					statusMessage = sprintf( __( 'Importing database… (%d%%)' ), percentage );
 				}
 
 				const progressIncrement = progressData.totalFiles
@@ -289,12 +287,11 @@ export const ImportExportProvider = ( { children }: { children: React.ReactNode 
 					progressData.totalItems != null &&
 					progressData.totalItems > 0
 				) {
-					statusMessage = sprintf(
-						__( '%1$s (%2$d/%3$d)' ),
-						WP_CONTENT_TYPE_LABELS[ progressData.type ] || __( 'Importing files…' ),
-						progressData.processedItems,
-						progressData.totalItems
+					const percentage = Math.round(
+						( progressData.processedItems / progressData.totalItems ) * 100
 					);
+					const baseLabel = WP_CONTENT_TYPE_LABELS[ progressData.type ] || __( 'Importing files…' );
+					statusMessage = sprintf( __( '%1$s (%2$d%%)' ), baseLabel, percentage );
 				}
 
 				const progressIncrement = progressData.totalItems

--- a/src/hooks/use-site-details.tsx
+++ b/src/hooks/use-site-details.tsx
@@ -11,6 +11,7 @@ import {
 } from 'react';
 import { useAuth } from 'src/hooks/use-auth';
 import { useContentTabs } from 'src/hooks/use-content-tabs';
+import { useIpcListener } from 'src/hooks/use-ipc-listener';
 import { useOffline } from 'src/hooks/use-offline';
 import { simplifyErrorForDisplay } from 'src/lib/error-formatting';
 import { getIpcApi } from 'src/lib/get-ipc-api';
@@ -42,12 +43,14 @@ interface SiteDetailsContext {
 	isDeleting: boolean;
 	uploadingSites: { [ siteId: string ]: boolean };
 	setUploadingSites: React.Dispatch< React.SetStateAction< { [ siteId: string ]: boolean } > >;
+	siteCreationMessages: { [ siteId: string ]: string };
 }
 
 const defaultContext: SiteDetailsContext = {
 	selectedSite: null,
 	updateSite: async () => undefined,
 	data: [],
+	siteCreationMessages: {},
 	setSelectedSiteId: () => undefined,
 	createSite: async () => undefined,
 	startServer: async () => undefined,
@@ -154,6 +157,9 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 	const [ data, setData ] = useState< SiteDetails[] >( [] );
 	const [ loadingSites, setLoadingSites ] = useState< boolean >( true );
 	const [ addingSiteIds, setAddingSiteIds ] = useState< string[] >( [] );
+	const [ siteCreationMessages, setSiteCreationMessages ] = useState< {
+		[ siteId: string ]: string;
+	} >( {} );
 	const firstSite = data[ 0 ] || null;
 	const [ loadingServer, setLoadingServer ] = useState< Record< string, boolean > >(
 		firstSite?.id
@@ -166,6 +172,15 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 	const [ uploadingSites, setUploadingSites ] = useState< { [ siteId: string ]: boolean } >( {} );
 	const { deleteSite, isLoading: isDeleting } = useDeleteSite();
 	const { setSelectedTab, selectedTab } = useContentTabs();
+
+	useIpcListener( 'on-site-create-progress', ( _, { siteId, message } ) => {
+		if ( siteId && message ) {
+			setSiteCreationMessages( ( prev ) => ( {
+				...prev,
+				[ siteId ]: message,
+			} ) );
+		}
+	} );
 
 	const toggleLoadingServerForSite = useCallback( ( siteId: string ) => {
 		setLoadingServer( ( currentLoading ) => ( {
@@ -269,6 +284,7 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 					wpVersion,
 					customDomain,
 					enableHttps,
+					siteId: tempSiteId,
 					blueprint,
 				} );
 				if ( ! newSite ) {
@@ -292,6 +308,11 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 				setData( ( prevData ) =>
 					prevData.map( ( site ) => ( site.id === tempSiteId ? newSite : site ) )
 				);
+
+				setSiteCreationMessages( ( prev ) => {
+					const { [ newSite.id ]: _, ...rest } = prev;
+					return rest;
+				} );
 
 				if ( callback ) {
 					await callback( newSite );
@@ -495,6 +516,7 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 			loadingSites,
 			uploadingSites,
 			setUploadingSites,
+			siteCreationMessages,
 		} ),
 		[
 			selectedSite,
@@ -511,6 +533,7 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 			isDeleting,
 			loadingSites,
 			uploadingSites,
+			siteCreationMessages,
 		]
 	);
 

--- a/src/ipc-utils.ts
+++ b/src/ipc-utils.ts
@@ -22,6 +22,7 @@ export interface IpcEvents {
 	'auth-updated': [ { token: StoredToken } | { error: unknown } ];
 	'on-export': [ ImportExportEventData, string ];
 	'on-import': [ ImportExportEventData, string ];
+	'on-site-create-progress': [ { siteId: string; message: string } ];
 	providerConstantsChanged: [
 		{
 			defaultPhpVersion: string;

--- a/src/lib/import-export/import/events.ts
+++ b/src/lib/import-export/import/events.ts
@@ -3,6 +3,7 @@ export const BackupExtractEvents = {
 	BACKUP_EXTRACT_PROGRESS: 'backup_extract_progress',
 	BACKUP_EXTRACT_FILE_START: 'backup_extract_file_start',
 	BACKUP_EXTRACT_COMPLETE: 'backup_extract_complete',
+	BACKUP_EXTRACT_WARNING: 'backup_extract_warning',
 	BACKUP_EXTRACT_ERROR: 'backup_extract_error',
 } as const;
 

--- a/src/lib/import-export/import/events.ts
+++ b/src/lib/import-export/import/events.ts
@@ -1,6 +1,7 @@
 export const BackupExtractEvents = {
 	BACKUP_EXTRACT_START: 'backup_extract_start',
 	BACKUP_EXTRACT_PROGRESS: 'backup_extract_progress',
+	BACKUP_EXTRACT_FILE_START: 'backup_extract_file_start',
 	BACKUP_EXTRACT_COMPLETE: 'backup_extract_complete',
 	BACKUP_EXTRACT_ERROR: 'backup_extract_error',
 } as const;
@@ -14,8 +15,10 @@ export const ValidatorEvents = {
 export const ImporterEvents = {
 	IMPORT_START: 'import_start',
 	IMPORT_DATABASE_START: 'import_database_start',
+	IMPORT_DATABASE_PROGRESS: 'import_database_progress',
 	IMPORT_DATABASE_COMPLETE: 'import_database_complete',
 	IMPORT_WP_CONTENT_START: 'import_wp_content_start',
+	IMPORT_WP_CONTENT_PROGRESS: 'import_wp_content_progress',
 	IMPORT_WP_CONTENT_COMPLETE: 'import_wp_content_complete',
 	IMPORT_META_START: 'import_meta',
 	IMPORT_META_COMPLETE: 'import_meta_complete',

--- a/src/lib/import-export/import/handlers/backup-handler-sql.ts
+++ b/src/lib/import-export/import/handlers/backup-handler-sql.ts
@@ -14,10 +14,35 @@ export class BackupHandlerSql extends EventEmitter implements BackupHandler {
 	}
 
 	async extractFiles( file: BackupArchiveInfo, extractionDirectory: string ): Promise< void > {
-		this.emit( ImportEvents.BACKUP_EXTRACT_START );
-		const destPath = path.join( extractionDirectory, path.basename( file.path ) );
-		this.emit( ImportEvents.BACKUP_EXTRACT_PROGRESS );
+		const fileName = path.basename( file.path );
+		const destPath = path.join( extractionDirectory, fileName );
+
+		this.emit( ImportEvents.BACKUP_EXTRACT_START, {
+			progress: 0,
+			totalFiles: 1,
+			processedFiles: 0,
+		} );
+
+		this.emit( ImportEvents.BACKUP_EXTRACT_FILE_START, {
+			progress: 0,
+			processedFiles: 0,
+			totalFiles: 1,
+			currentFile: fileName,
+		} );
+
 		await fs.promises.copyFile( file.path, destPath );
-		this.emit( ImportEvents.BACKUP_EXTRACT_COMPLETE );
+
+		this.emit( ImportEvents.BACKUP_EXTRACT_PROGRESS, {
+			progress: 100,
+			processedFiles: 1,
+			totalFiles: 1,
+			currentFile: fileName,
+		} );
+
+		this.emit( ImportEvents.BACKUP_EXTRACT_COMPLETE, {
+			progress: 100,
+			processedFiles: 1,
+			totalFiles: 1,
+		} );
 	}
 }

--- a/src/lib/import-export/import/handlers/backup-handler-tar-gz.ts
+++ b/src/lib/import-export/import/handlers/backup-handler-tar-gz.ts
@@ -43,10 +43,6 @@ export class BackupHandlerTarGz extends EventEmitter implements BackupHandler {
 			throw error;
 		}
 
-		// Get total file count first
-		const fileList = await this.listFiles( file );
-		const totalFiles = fileList.length;
-
 		return new Promise< void >( ( resolve, reject ) => {
 			this.emit( ImportEvents.BACKUP_EXTRACT_START );
 			fs.createReadStream( file.path )
@@ -55,7 +51,6 @@ export class BackupHandlerTarGz extends EventEmitter implements BackupHandler {
 					this.emit( ImportEvents.BACKUP_EXTRACT_PROGRESS, {
 						progress: processedSize / totalSize,
 						processedFiles,
-						totalFiles,
 						currentFile,
 						extractedBytes: processedSize,
 						totalBytes: totalSize,
@@ -69,14 +64,15 @@ export class BackupHandlerTarGz extends EventEmitter implements BackupHandler {
 				.pipe(
 					tar.extract( {
 						cwd: extractionDirectory,
-						onwarn: ( _code, message ) => console.warn( message ),
+						onwarn: ( _code, message ) => {
+							this.emit( ImportEvents.BACKUP_EXTRACT_WARNING, { message } );
+						},
 						onReadEntry: ( entry ) => {
 							currentFile = entry.path;
 							processedFiles++;
 							this.emit( ImportEvents.BACKUP_EXTRACT_FILE_START, {
 								currentFile,
 								processedFiles,
-								totalFiles,
 							} as BackupExtractProgressEventData );
 						},
 					} )

--- a/src/lib/import-export/import/handlers/backup-handler-tar-gz.ts
+++ b/src/lib/import-export/import/handlers/backup-handler-tar-gz.ts
@@ -33,6 +33,8 @@ export class BackupHandlerTarGz extends EventEmitter implements BackupHandler {
 	async extractFiles( file: BackupArchiveInfo, extractionDirectory: string ): Promise< void > {
 		let totalSize: number;
 		let processedSize = 0;
+		let processedFiles = 0;
+		let currentFile = '';
 
 		try {
 			totalSize = fs.statSync( file.path ).size;
@@ -41,6 +43,10 @@ export class BackupHandlerTarGz extends EventEmitter implements BackupHandler {
 			throw error;
 		}
 
+		// Get total file count first
+		const fileList = await this.listFiles( file );
+		const totalFiles = fileList.length;
+
 		return new Promise< void >( ( resolve, reject ) => {
 			this.emit( ImportEvents.BACKUP_EXTRACT_START );
 			fs.createReadStream( file.path )
@@ -48,6 +54,11 @@ export class BackupHandlerTarGz extends EventEmitter implements BackupHandler {
 					processedSize += chunk.length;
 					this.emit( ImportEvents.BACKUP_EXTRACT_PROGRESS, {
 						progress: processedSize / totalSize,
+						processedFiles,
+						totalFiles,
+						currentFile,
+						extractedBytes: processedSize,
+						totalBytes: totalSize,
 					} as BackupExtractProgressEventData );
 				} )
 				.on( 'error', ( error ) => {
@@ -55,7 +66,21 @@ export class BackupHandlerTarGz extends EventEmitter implements BackupHandler {
 					reject( error );
 				} )
 				.pipe( zlib.createGunzip() )
-				.pipe( tar.extract( { cwd: extractionDirectory } ) )
+				.pipe(
+					tar.extract( {
+						cwd: extractionDirectory,
+						onwarn: ( _code, message ) => console.warn( message ),
+						onReadEntry: ( entry ) => {
+							currentFile = entry.path;
+							processedFiles++;
+							this.emit( ImportEvents.BACKUP_EXTRACT_FILE_START, {
+								currentFile,
+								processedFiles,
+								totalFiles,
+							} as BackupExtractProgressEventData );
+						},
+					} )
+				)
 				.on( 'finish', () => {
 					this.emit( ImportEvents.BACKUP_EXTRACT_COMPLETE );
 					resolve();

--- a/src/lib/import-export/import/handlers/backup-handler-tar-gz.ts
+++ b/src/lib/import-export/import/handlers/backup-handler-tar-gz.ts
@@ -43,6 +43,10 @@ export class BackupHandlerTarGz extends EventEmitter implements BackupHandler {
 			throw error;
 		}
 
+		// Get total file count first
+		const fileList = await this.listFiles( file );
+		const totalFiles = fileList.length;
+
 		return new Promise< void >( ( resolve, reject ) => {
 			this.emit( ImportEvents.BACKUP_EXTRACT_START );
 			fs.createReadStream( file.path )
@@ -51,6 +55,7 @@ export class BackupHandlerTarGz extends EventEmitter implements BackupHandler {
 					this.emit( ImportEvents.BACKUP_EXTRACT_PROGRESS, {
 						progress: processedSize / totalSize,
 						processedFiles,
+						totalFiles,
 						currentFile,
 						extractedBytes: processedSize,
 						totalBytes: totalSize,
@@ -73,6 +78,7 @@ export class BackupHandlerTarGz extends EventEmitter implements BackupHandler {
 							this.emit( ImportEvents.BACKUP_EXTRACT_FILE_START, {
 								currentFile,
 								processedFiles,
+								totalFiles,
 							} as BackupExtractProgressEventData );
 						},
 					} )

--- a/src/lib/import-export/import/handlers/backup-handler-wpress.ts
+++ b/src/lib/import-export/import/handlers/backup-handler-wpress.ts
@@ -4,6 +4,7 @@ import { constants } from 'fs';
 import * as path from 'path';
 import * as Sentry from '@sentry/electron/main';
 import * as fse from 'fs-extra';
+import { ImportEvents } from 'src/lib/import-export/import/events';
 import { BackupHandler } from 'src/lib/import-export/import/handlers/backup-handler-factory';
 import { BackupArchiveInfo } from 'src/lib/import-export/import/types';
 
@@ -139,6 +140,8 @@ async function readBlockToFile( fd: fs.promises.FileHandle, header: Header, outp
 export class BackupHandlerWpress extends EventEmitter implements BackupHandler {
 	private bytesRead: number;
 	private eof: Buffer;
+	private totalFiles: number = 0;
+	private processedFiles: number = 0;
 
 	constructor() {
 		super();
@@ -199,6 +202,17 @@ export class BackupHandlerWpress extends EventEmitter implements BackupHandler {
 
 		await fse.emptyDir( extractionDirectory );
 
+		// First pass: count total files
+		const fileNames = await this.listFiles( file );
+		this.totalFiles = fileNames.length;
+		this.processedFiles = 0;
+
+		this.emit( ImportEvents.BACKUP_EXTRACT_START, {
+			progress: 0,
+			totalFiles: this.totalFiles,
+			processedFiles: 0,
+		} );
+
 		const inputFile = await fs.promises.open( file.path, 'r' );
 
 		let header;
@@ -207,8 +221,38 @@ export class BackupHandlerWpress extends EventEmitter implements BackupHandler {
 				if ( ! header ) {
 					break;
 				}
+
+				// Emit progress before processing file
+				const currentFile = path.join( header.prefix, header.name );
+				const progress =
+					this.totalFiles > 0 ? Math.round( ( this.processedFiles / this.totalFiles ) * 100 ) : 0;
+
+				this.emit( ImportEvents.BACKUP_EXTRACT_FILE_START, {
+					progress,
+					processedFiles: this.processedFiles,
+					totalFiles: this.totalFiles,
+					currentFile,
+				} );
+
 				await readBlockToFile( inputFile, header, extractionDirectory );
+				this.processedFiles++;
+
+				// Emit progress after processing file
+				const newProgress =
+					this.totalFiles > 0 ? Math.round( ( this.processedFiles / this.totalFiles ) * 100 ) : 100;
+				this.emit( ImportEvents.BACKUP_EXTRACT_PROGRESS, {
+					progress: newProgress,
+					processedFiles: this.processedFiles,
+					totalFiles: this.totalFiles,
+					currentFile,
+				} );
 			}
+
+			this.emit( ImportEvents.BACKUP_EXTRACT_COMPLETE, {
+				progress: 100,
+				processedFiles: this.totalFiles,
+				totalFiles: this.totalFiles,
+			} );
 		} catch ( err ) {
 			Sentry.captureException( err, {
 				extra: {

--- a/src/lib/import-export/import/handlers/backup-handler-wpress.ts
+++ b/src/lib/import-export/import/handlers/backup-handler-wpress.ts
@@ -149,6 +149,10 @@ export class BackupHandlerWpress extends EventEmitter implements BackupHandler {
 		this.eof = Buffer.alloc( HEADER_SIZE, '\0' );
 	}
 
+	private calculateProgress(): number {
+		return this.totalFiles > 0 ? Math.round( ( this.processedFiles / this.totalFiles ) * 100 ) : 0;
+	}
+
 	/**
 	 * Lists all files in a .wpress backup file by reading the headers sequentially.
 	 *
@@ -224,11 +228,9 @@ export class BackupHandlerWpress extends EventEmitter implements BackupHandler {
 
 				// Emit progress before processing file
 				const currentFile = path.join( header.prefix, header.name );
-				const progress =
-					this.totalFiles > 0 ? Math.round( ( this.processedFiles / this.totalFiles ) * 100 ) : 0;
 
 				this.emit( ImportEvents.BACKUP_EXTRACT_FILE_START, {
-					progress,
+					progress: this.calculateProgress(),
 					processedFiles: this.processedFiles,
 					totalFiles: this.totalFiles,
 					currentFile,
@@ -238,10 +240,8 @@ export class BackupHandlerWpress extends EventEmitter implements BackupHandler {
 				this.processedFiles++;
 
 				// Emit progress after processing file
-				const newProgress =
-					this.totalFiles > 0 ? Math.round( ( this.processedFiles / this.totalFiles ) * 100 ) : 100;
 				this.emit( ImportEvents.BACKUP_EXTRACT_PROGRESS, {
-					progress: newProgress,
+					progress: this.calculateProgress(),
 					processedFiles: this.processedFiles,
 					totalFiles: this.totalFiles,
 					currentFile,

--- a/src/lib/import-export/import/handlers/backup-handler-zip.ts
+++ b/src/lib/import-export/import/handlers/backup-handler-zip.ts
@@ -44,6 +44,8 @@ export class BackupHandlerZip extends EventEmitter implements BackupHandler {
 		const openReadStream = promisify( zipFile.openReadStream.bind( zipFile ) );
 		const totalSize = fs.statSync( file.path ).size;
 		let processedSize = 0;
+		let processedFiles = 0;
+		const totalFiles = zipFile.entryCount;
 
 		this.emit( ImportEvents.BACKUP_EXTRACT_START );
 
@@ -73,6 +75,12 @@ export class BackupHandlerZip extends EventEmitter implements BackupHandler {
 					return;
 				}
 
+				this.emit( ImportEvents.BACKUP_EXTRACT_FILE_START, {
+					currentFile: entry.fileName,
+					processedFiles,
+					totalFiles,
+				} as BackupExtractProgressEventData );
+
 				try {
 					const readStream = await openReadStream( entry );
 					const writeStream = fs.createWriteStream( fullPath );
@@ -94,11 +102,17 @@ export class BackupHandlerZip extends EventEmitter implements BackupHandler {
 						processedSize += chunk.length;
 						this.emit( ImportEvents.BACKUP_EXTRACT_PROGRESS, {
 							progress: processedSize / totalSize,
+							processedFiles,
+							totalFiles,
+							currentFile: entry.fileName,
+							extractedBytes: processedSize,
+							totalBytes: totalSize,
 						} as BackupExtractProgressEventData );
 					} );
 
 					writeStream.once( 'finish', () => {
 						if ( ! extractionFailed ) {
+							processedFiles++;
 							zipFile.readEntry();
 						}
 					} );

--- a/src/lib/import-export/import/importers/importer.ts
+++ b/src/lib/import-export/import/importers/importer.ts
@@ -230,23 +230,24 @@ abstract class BaseBackupImporter extends BaseImporter {
 					continue;
 				}
 
-				processedItems++;
 				const relativePath = path.relative(
 					path.join( extractionDirectory, wpContentSourceDir ),
 					file
 				);
 
-				// Emit progress event
+				const destPath = path.join( wpContentDestDir, relativePath );
+				await fsPromises.mkdir( path.dirname( destPath ), { recursive: true } );
+				await fsPromises.copyFile( file, destPath );
+
+				processedItems++;
+
+				// Emit progress event after file is copied
 				this.emit( ImportEvents.IMPORT_WP_CONTENT_PROGRESS, {
 					type: type as 'plugins' | 'themes' | 'uploads' | 'other',
 					currentItem: relativePath,
 					processedItems,
 					totalItems,
 				} as ImportWpContentProgressEventData );
-
-				const destPath = path.join( wpContentDestDir, relativePath );
-				await fsPromises.mkdir( path.dirname( destPath ), { recursive: true } );
-				await fsPromises.copyFile( file, destPath );
 			}
 		}
 		this.emit( ImportEvents.IMPORT_WP_CONTENT_COMPLETE );

--- a/src/lib/import-export/import/importers/importer.ts
+++ b/src/lib/import-export/import/importers/importer.ts
@@ -261,11 +261,14 @@ abstract class BaseBackupImporter extends BaseImporter {
 		};
 
 		for ( const file of files ) {
-			if ( file.includes( '/plugins/' ) || file.includes( '\\plugins\\' ) ) {
+			// Split path by both Unix and Windows separators to handle cross-platform paths
+			const segments = file.split( /[/\\]/ );
+
+			if ( segments.includes( 'plugins' ) ) {
 				categorized.plugins.push( file );
-			} else if ( file.includes( '/themes/' ) || file.includes( '\\themes\\' ) ) {
+			} else if ( segments.includes( 'themes' ) ) {
 				categorized.themes.push( file );
-			} else if ( file.includes( '/uploads/' ) || file.includes( '\\uploads\\' ) ) {
+			} else if ( segments.includes( 'uploads' ) ) {
 				categorized.uploads.push( file );
 			} else {
 				categorized.other.push( file );

--- a/src/lib/import-export/import/importers/importer.ts
+++ b/src/lib/import-export/import/importers/importer.ts
@@ -10,7 +10,11 @@ import semver from 'semver';
 import { getSiteUrl } from 'src/lib/get-site-url';
 import { generateBackupFilename } from 'src/lib/import-export/export/generate-backup-filename';
 import { ImportEvents } from 'src/lib/import-export/import/events';
-import { BackupContents, MetaFileData } from 'src/lib/import-export/import/types';
+import {
+	BackupContents,
+	MetaFileData,
+	ImportWpContentProgressEventData,
+} from 'src/lib/import-export/import/types';
 import { serializePlugins } from 'src/lib/serialize-plugins';
 import { updateSiteUrl } from 'src/lib/update-site-url';
 import { getWordPressProvider } from 'src/lib/wordpress-provider';
@@ -51,9 +55,19 @@ abstract class BaseImporter extends EventEmitter implements Importer {
 		this.emit( ImportEvents.IMPORT_DATABASE_START );
 
 		const sortedSqlFiles = sqlFiles.sort( ( a, b ) => a.localeCompare( b ) );
+		let processedFiles = 0;
+		const totalFiles = sortedSqlFiles.length;
+
 		for ( const sqlFile of sortedSqlFiles ) {
 			const sqlTempFile = `${ generateBackupFilename( 'sql' ) }.sql`;
 			const tmpPath = path.join( rootPath, sqlTempFile );
+			processedFiles++;
+
+			this.emit( ImportEvents.IMPORT_DATABASE_PROGRESS, {
+				currentFile: path.basename( sqlFile ),
+				processedFiles,
+				totalFiles,
+			} );
 
 			try {
 				await move( sqlFile, tmpPath );
@@ -194,30 +208,71 @@ abstract class BaseBackupImporter extends BaseImporter {
 		const wpContentSourceDir = this.backup.wpContentDirectory;
 		const wpContentDestDir = path.join( rootPath, 'wp-content' );
 
-		for ( const file of this.backup.wpContentFiles ) {
-			try {
-				const stats = await lstat( file );
-				// Skip if it's a directory
-				if ( stats.isDirectory() ) {
+		// Group files by type
+		const filesByType = this.categorizeWpContentFiles( this.backup.wpContentFiles );
+		let processedItems = 0;
+		const totalItems = this.backup.wpContentFiles.length;
+
+		for ( const [ type, files ] of Object.entries( filesByType ) ) {
+			for ( const file of files ) {
+				try {
+					const stats = await lstat( file );
+					// Skip if it's a directory
+					if ( stats.isDirectory() ) {
+						continue;
+					}
+				} catch {
+					/**
+					 * If the file does not exist, skip it.
+					 * This can happen if a empty directory is included in the backup
+					 * because the empty directory won't be included in the extraction.
+					 */
 					continue;
 				}
-			} catch {
-				/**
-				 * If the file does not exist, skip it.
-				 * This can happen if a empty directory is included in the backup
-				 * because the empty directory won't be included in the extraction.
-				 */
-				continue;
+
+				processedItems++;
+				const relativePath = path.relative(
+					path.join( extractionDirectory, wpContentSourceDir ),
+					file
+				);
+
+				// Emit progress event
+				this.emit( ImportEvents.IMPORT_WP_CONTENT_PROGRESS, {
+					type: type as 'plugins' | 'themes' | 'uploads' | 'other',
+					currentItem: relativePath,
+					processedItems,
+					totalItems,
+				} as ImportWpContentProgressEventData );
+
+				const destPath = path.join( wpContentDestDir, relativePath );
+				await fsPromises.mkdir( path.dirname( destPath ), { recursive: true } );
+				await fsPromises.copyFile( file, destPath );
 			}
-			const relativePath = path.relative(
-				path.join( extractionDirectory, wpContentSourceDir ),
-				file
-			);
-			const destPath = path.join( wpContentDestDir, relativePath );
-			await fsPromises.mkdir( path.dirname( destPath ), { recursive: true } );
-			await fsPromises.copyFile( file, destPath );
 		}
 		this.emit( ImportEvents.IMPORT_WP_CONTENT_COMPLETE );
+	}
+
+	protected categorizeWpContentFiles( files: string[] ): Record< string, string[] > {
+		const categorized: Record< string, string[] > = {
+			plugins: [],
+			themes: [],
+			uploads: [],
+			other: [],
+		};
+
+		for ( const file of files ) {
+			if ( file.includes( '/plugins/' ) || file.includes( '\\plugins\\' ) ) {
+				categorized.plugins.push( file );
+			} else if ( file.includes( '/themes/' ) || file.includes( '\\themes\\' ) ) {
+				categorized.themes.push( file );
+			} else if ( file.includes( '/uploads/' ) || file.includes( '\\uploads\\' ) ) {
+				categorized.uploads.push( file );
+			} else {
+				categorized.other.push( file );
+			}
+		}
+
+		return categorized;
 	}
 
 	protected parsePhpVersion( version: string | undefined ): string {

--- a/src/lib/import-export/import/importers/importer.ts
+++ b/src/lib/import-export/import/importers/importer.ts
@@ -262,7 +262,6 @@ abstract class BaseBackupImporter extends BaseImporter {
 		};
 
 		for ( const file of files ) {
-			// Split path by both Unix and Windows separators to handle cross-platform paths
 			const segments = file.split( /[/\\]/ );
 
 			if ( segments.includes( 'plugins' ) ) {

--- a/src/lib/import-export/import/types.ts
+++ b/src/lib/import-export/import/types.ts
@@ -25,4 +25,27 @@ export type NewImporter = new ( backup: BackupContents ) => Importer;
 
 export interface BackupExtractProgressEventData {
 	progress: number;
+	processedFiles?: number;
+	totalFiles?: number;
+	currentFile?: string;
+	extractedBytes?: number;
+	totalBytes?: number;
+}
+
+export interface ImportDatabaseProgressEventData {
+	currentTable?: string;
+	processedTables?: number;
+	totalTables?: number;
+	currentFile?: string;
+	processedFiles?: number;
+	totalFiles?: number;
+}
+
+export interface ImportWpContentProgressEventData {
+	type?: 'plugins' | 'themes' | 'uploads' | 'other';
+	currentItem?: string;
+	processedItems?: number;
+	totalItems?: number;
+	processedBytes?: number;
+	totalBytes?: number;
 }

--- a/src/lib/import-export/tests/import/handlers/backup-handler.test.ts
+++ b/src/lib/import-export/tests/import/handlers/backup-handler.test.ts
@@ -177,6 +177,8 @@ describe( 'BackupHandlerFactory', () => {
 			).resolves.not.toThrow();
 			expect( tar.x ).toHaveBeenCalledWith( {
 				cwd: extractionDirectory,
+				onReadEntry: expect.any( Function ),
+				onwarn: expect.any( Function ),
 			} );
 		} );
 

--- a/src/lib/import-export/tests/import/importer/jetpack-importer.test.ts
+++ b/src/lib/import-export/tests/import/importer/jetpack-importer.test.ts
@@ -168,5 +168,103 @@ platformTestSuite( 'JetpackImporter', ( { normalize } ) => {
 			expect( fs.mkdir ).toHaveBeenCalled();
 			expect( fs.copyFile ).toHaveBeenCalledTimes( 4 ); // One for each wp-content file + wp-config.php - fonts
 		} );
+
+		it( 'should categorize WordPress content files correctly', () => {
+			const testFiles = [
+				// Plugin files
+				normalize( '/tmp/extracted/wp-content/plugins/akismet/akismet.php' ),
+				normalize( '/tmp/extracted/wp-content/plugins/jetpack/jetpack.php' ),
+				normalize( '/tmp/extracted/wp-content/plugins/woocommerce/woocommerce.php' ),
+				// Theme files
+				normalize( '/tmp/extracted/wp-content/themes/twentytwentyone/style.css' ),
+				normalize( '/tmp/extracted/wp-content/themes/twentytwentythree/index.php' ),
+				// Upload files
+				normalize( '/tmp/extracted/wp-content/uploads/2023/01/image.jpg' ),
+				normalize( '/tmp/extracted/wp-content/uploads/2024/02/document.pdf' ),
+				normalize( '/tmp/extracted/wp-content/uploads/2024/03/video.mp4' ),
+				// Other files
+				normalize( '/tmp/extracted/wp-content/index.php' ),
+				normalize( '/tmp/extracted/wp-content/fonts/open-sans.woff2' ),
+				normalize( '/tmp/extracted/wp-content/mu-plugins/custom.php' ),
+				// Windows path style testing
+				'C:\\tmp\\extracted\\wp-content\\plugins\\hello-world\\hello.php',
+				'C:\\tmp\\extracted\\wp-content\\themes\\custom\\functions.php',
+				'C:\\tmp\\extracted\\wp-content\\uploads\\2024\\image.png',
+				'C:\\tmp\\extracted\\wp-content\\advanced-cache.php',
+			];
+
+			const importer = new JetpackImporter( mockBackupContents );
+			// Access the protected method for testing
+			const categorizedFiles = (
+				importer as unknown as {
+					categorizeWpContentFiles: ( files: string[] ) => Record< string, string[] >;
+				}
+			 ).categorizeWpContentFiles( testFiles );
+
+			expect( categorizedFiles ).toEqual( {
+				plugins: [
+					normalize( '/tmp/extracted/wp-content/plugins/akismet/akismet.php' ),
+					normalize( '/tmp/extracted/wp-content/plugins/jetpack/jetpack.php' ),
+					normalize( '/tmp/extracted/wp-content/plugins/woocommerce/woocommerce.php' ),
+					'C:\\tmp\\extracted\\wp-content\\plugins\\hello-world\\hello.php',
+				],
+				themes: [
+					normalize( '/tmp/extracted/wp-content/themes/twentytwentyone/style.css' ),
+					normalize( '/tmp/extracted/wp-content/themes/twentytwentythree/index.php' ),
+					'C:\\tmp\\extracted\\wp-content\\themes\\custom\\functions.php',
+				],
+				uploads: [
+					normalize( '/tmp/extracted/wp-content/uploads/2023/01/image.jpg' ),
+					normalize( '/tmp/extracted/wp-content/uploads/2024/02/document.pdf' ),
+					normalize( '/tmp/extracted/wp-content/uploads/2024/03/video.mp4' ),
+					'C:\\tmp\\extracted\\wp-content\\uploads\\2024\\image.png',
+				],
+				other: [
+					normalize( '/tmp/extracted/wp-content/index.php' ),
+					normalize( '/tmp/extracted/wp-content/fonts/open-sans.woff2' ),
+					normalize( '/tmp/extracted/wp-content/mu-plugins/custom.php' ),
+					'C:\\tmp\\extracted\\wp-content\\advanced-cache.php',
+				],
+			} );
+		} );
+
+		it( 'should handle empty file list for categorization', () => {
+			const importer = new JetpackImporter( mockBackupContents );
+			const categorizedFiles = (
+				importer as unknown as {
+					categorizeWpContentFiles: ( files: string[] ) => Record< string, string[] >;
+				}
+			 ).categorizeWpContentFiles( [] );
+
+			expect( categorizedFiles ).toEqual( {
+				plugins: [],
+				themes: [],
+				uploads: [],
+				other: [],
+			} );
+		} );
+
+		it( 'should categorize files without wp-content prefix', () => {
+			const testFiles = [
+				'/plugins/test-plugin/test.php',
+				'/themes/test-theme/style.css',
+				'/uploads/image.jpg',
+				'/index.php',
+			];
+
+			const importer = new JetpackImporter( mockBackupContents );
+			const categorizedFiles = (
+				importer as unknown as {
+					categorizeWpContentFiles: ( files: string[] ) => Record< string, string[] >;
+				}
+			 ).categorizeWpContentFiles( testFiles );
+
+			expect( categorizedFiles ).toEqual( {
+				plugins: [ '/plugins/test-plugin/test.php' ],
+				themes: [ '/themes/test-theme/style.css' ],
+				uploads: [ '/uploads/image.jpg' ],
+				other: [ '/index.php' ],
+			} );
+		} );
 	} );
 } );

--- a/src/lib/wordpress-provider/playground-cli/playground-server-process-child.ts
+++ b/src/lib/wordpress-provider/playground-cli/playground-server-process-child.ts
@@ -48,9 +48,24 @@ const originalConsoleLog = console.log;
 const originalConsoleError = console.error;
 const originalConsoleWarn = console.warn;
 
+function formatMessageForUI( message: string ): string | null {
+	if ( message.includes( 'WordPress is running on' ) ) {
+		return 'WordPress is running';
+	}
+	if ( message.includes( 'Resolved WordPress release URL' ) ) {
+		return 'Downloading WordPress…';
+	}
+	return message;
+}
+
 console.log = ( ...args: any[] ) => {
 	originalConsoleLog( '[playground-cli]', ...args );
+	const message = args.join( ' ' );
 	process.parentPort.postMessage( { type: 'activity' } );
+	const formattedMessage = formatMessageForUI( message );
+	if ( formattedMessage ) {
+		process.parentPort.postMessage( { type: 'console-message', message: formattedMessage } );
+	}
 };
 
 console.error = ( ...args: any[] ) => {

--- a/src/lib/wordpress-provider/playground-cli/playground-server-process-child.ts
+++ b/src/lib/wordpress-provider/playground-cli/playground-server-process-child.ts
@@ -48,7 +48,7 @@ const originalConsoleLog = console.log;
 const originalConsoleError = console.error;
 const originalConsoleWarn = console.warn;
 
-function formatMessageForUI( message: string ): string | null {
+function formatMessageForUI( message: string ): string {
 	if ( message.includes( 'WordPress is running on' ) ) {
 		return 'WordPress is running';
 	}

--- a/src/lib/wordpress-provider/playground-cli/playground-server-process.ts
+++ b/src/lib/wordpress-provider/playground-cli/playground-server-process.ts
@@ -1,4 +1,4 @@
-import { BrowserWindow, utilityProcess } from 'electron';
+import { utilityProcess } from 'electron';
 import path from 'path';
 import {
 	PLAYGROUND_CLI_INACTIVITY_TIMEOUT,
@@ -6,11 +6,13 @@ import {
 	PLAYGROUND_CLI_ACTIVITY_CHECK_INTERVAL,
 } from 'src/constants';
 import { sendIpcEventToRendererWithWindow } from 'src/ipc-utils';
+import { getMainWindow } from 'src/main-window';
 import { WordPressServerProcess, WordPressServerOptions } from '../types';
 import { PlaygroundCliOptions } from './playground-cli-provider';
 
 export class PlaygroundServerProcess implements WordPressServerProcess {
-	private process: ( Electron.UtilityProcess & { siteId?: string } ) | null = null;
+	private process: Electron.UtilityProcess | null = null;
+	private siteId: string | null = null;
 	private messageId = 0;
 	private responseHandlers = new Map<
 		number,
@@ -44,13 +46,13 @@ export class PlaygroundServerProcess implements WordPressServerProcess {
 
 		this.process = utilityProcess.fork( path.join( __dirname, 'playgroundServerProcess.js' ) );
 
-		if ( siteId && this.process ) {
-			this.process.siteId = siteId;
+		if ( siteId ) {
+			this.siteId = siteId;
 		}
 
 		this.process.on(
 			'message',
-			( message: {
+			async ( message: {
 				type?: string;
 				id?: number;
 				error?: string;
@@ -62,14 +64,15 @@ export class PlaygroundServerProcess implements WordPressServerProcess {
 				}
 
 				if ( message.type === 'console-message' && message.message ) {
-					const siteId = this.process?.siteId;
-					if ( siteId ) {
-						const allWindows = BrowserWindow.getAllWindows();
-						if ( allWindows.length > 0 ) {
-							sendIpcEventToRendererWithWindow( allWindows[ 0 ], 'on-site-create-progress', {
-								siteId,
+					if ( this.siteId ) {
+						try {
+							const mainWindow = await getMainWindow();
+							sendIpcEventToRendererWithWindow( mainWindow, 'on-site-create-progress', {
+								siteId: this.siteId,
 								message: message.message,
 							} );
+						} catch ( error ) {
+							console.error( 'Failed to get main window for site creation progress:', error );
 						}
 					}
 					if ( this.consoleMessageCallback ) {

--- a/src/lib/wordpress-provider/playground-cli/playground-server-process.ts
+++ b/src/lib/wordpress-provider/playground-cli/playground-server-process.ts
@@ -1,15 +1,16 @@
-import { utilityProcess } from 'electron';
+import { BrowserWindow, utilityProcess } from 'electron';
 import path from 'path';
 import {
 	PLAYGROUND_CLI_INACTIVITY_TIMEOUT,
 	PLAYGROUND_CLI_MAX_TIMEOUT,
 	PLAYGROUND_CLI_ACTIVITY_CHECK_INTERVAL,
 } from 'src/constants';
+import { sendIpcEventToRendererWithWindow } from 'src/ipc-utils';
 import { WordPressServerProcess, WordPressServerOptions } from '../types';
 import { PlaygroundCliOptions } from './playground-cli-provider';
 
 export class PlaygroundServerProcess implements WordPressServerProcess {
-	private process: Electron.UtilityProcess | null = null;
+	private process: ( Electron.UtilityProcess & { siteId?: string } ) | null = null;
 	private messageId = 0;
 	private responseHandlers = new Map<
 		number,
@@ -19,6 +20,7 @@ export class PlaygroundServerProcess implements WordPressServerProcess {
 	private exitResolve: ( () => void ) | null = null;
 	private isSetupMode = false;
 	private lastActivityTimestamp = 0;
+	private consoleMessageCallback?: ( message: string ) => void;
 
 	constructor(
 		public url: string,
@@ -26,7 +28,11 @@ export class PlaygroundServerProcess implements WordPressServerProcess {
 		private serverOptions: WordPressServerOptions
 	) {}
 
-	async start(): Promise< void > {
+	setConsoleMessageCallback( callback: ( message: string ) => void ): void {
+		this.consoleMessageCallback = callback;
+	}
+
+	async start( siteId?: string ): Promise< void > {
 		if ( this.process ) {
 			return;
 		}
@@ -38,11 +44,37 @@ export class PlaygroundServerProcess implements WordPressServerProcess {
 
 		this.process = utilityProcess.fork( path.join( __dirname, 'playgroundServerProcess.js' ) );
 
+		if ( siteId && this.process ) {
+			this.process.siteId = siteId;
+		}
+
 		this.process.on(
 			'message',
-			( message: { type?: string; id?: number; error?: string; result?: unknown } ) => {
+			( message: {
+				type?: string;
+				id?: number;
+				error?: string;
+				result?: unknown;
+				message?: string;
+			} ) => {
 				if ( message.type === 'ready' ) {
 					return;
+				}
+
+				if ( message.type === 'console-message' && message.message ) {
+					const siteId = this.process?.siteId;
+					if ( siteId ) {
+						const allWindows = BrowserWindow.getAllWindows();
+						if ( allWindows.length > 0 ) {
+							sendIpcEventToRendererWithWindow( allWindows[ 0 ], 'on-site-create-progress', {
+								siteId,
+								message: message.message,
+							} );
+						}
+					}
+					if ( this.consoleMessageCallback ) {
+						this.consoleMessageCallback( message.message );
+					}
 				}
 
 				if ( message.type === 'activity' || message.id !== undefined ) {

--- a/src/lib/wordpress-provider/types.ts
+++ b/src/lib/wordpress-provider/types.ts
@@ -48,7 +48,7 @@ export interface WordPressServerProcess {
 			body: Record< string, string >;
 		} ) => Promise< { text: string } >;
 	};
-	start(): Promise< void >;
+	start( siteId?: string ): Promise< void >;
 	stop(): Promise< void >;
 	runPhp( data: { code: string; [ key: string ]: unknown } ): Promise< string >;
 }

--- a/src/site-server.ts
+++ b/src/site-server.ts
@@ -155,7 +155,7 @@ export class SiteServer {
 
 		console.log( `Starting server for '${ this.details.name }'` );
 		this.server = createServerProcess( serverInstance );
-		await this.server.start();
+		await this.server.start( this.details.id );
 
 		if ( serverInstance.options.port === undefined ) {
 			throw new Error( 'Server started with no port' );


### PR DESCRIPTION
## Related issues

- Fixes STU-746

## Proposed Changes

- Added detailed progress tracking during import with file counts and type-specific messages
- Added detailed progress tracking during site creation, with messages from Playground CLI.
- Enhanced extraction progress to show "Extracting backup… (XX%)"
- Added database import details showing "Importing database… (XX%)"
- Implemented WordPress content breakdown by type: "Importing plugins… (XX%)", "Importing themes… (XX%)", "Importing media uploads… (XX%)"
- Added new progress events: BACKUP_EXTRACT_FILE_START, IMPORT_DATABASE_PROGRESS, IMPORT_WP_CONTENT_PROGRESS
- Updated backup handlers (ZIP, tar.gz) to emit granular progress data
- Fixed unit test expectations for tar.gz handler

## Testing Instructions

- Create a test site with multiple plugins, themes, and content (use FakerPress for posts with images)
- Verify the create site window shows detailed progress messages
- Export the site as a backup
- Import into a new site and observe detailed progress messages
- Test with different backup types (ZIP, tar.gz, .wpress)
- Verify progress shows file counts and content type information
- For slower testing to observe messages, temporarily add delays in handlers (remove before merge)

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?