### PR TITLE
Truncate filename in "Import from a backup" modal

### DIFF
--- a/src/modules/add-site/components/import-backup.tsx
+++ b/src/modules/add-site/components/import-backup.tsx
@@ -24,6 +24,23 @@ const formatFileSize = ( bytes: number ) => {
 	return Math.round( ( bytes / Math.pow( k, i ) ) * 100 ) / 100 + ' ' + sizes[ i ];
 };
 
+const truncateMiddle = ( filename: string, maxLength: number = 30 ): string => {
+	if ( filename.length <= maxLength ) {
+		return filename;
+	}
+
+	const ellipsis = '…';
+	const charsToShow = maxLength - ellipsis.length;
+	const frontChars = Math.ceil( charsToShow / 2 );
+	const backChars = Math.floor( charsToShow / 2 );
+
+	return (
+		filename.substring( 0, frontChars ) +
+		ellipsis +
+		filename.substring( filename.length - backChars )
+	);
+};
+
 interface ImportBackupProps {
 	onFileSelect: ( file?: File ) => void;
 }
@@ -130,11 +147,11 @@ export default function ImportBackup( { onFileSelect }: ImportBackupProps ) {
 				{ selectedFile ? (
 					<VStack className="items-center justify-center h-full" spacing={ 2 }>
 						<Text
-							className="text-base font-medium text-gray-900 max-w-md truncate px-4"
+							className="text-base font-medium text-gray-900 max-w-md px-4"
 							weight={ 400 }
 							title={ selectedFile.name }
 						>
-							{ selectedFile.name }
+							{ truncateMiddle( selectedFile.name ) }
 						</Text>
 						<HStack spacing={ 2 } alignment="center">
 							<Text className="text-base text-gray-600">


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes [STU-757 Studio: Fix file name overflow in "Import from a backup" modal](https://linear.app/a8c/issue/STU-757/studio-fix-file-name-overflow-in-import-from-a-backup-modal)

## Proposed Changes

- Add a utility to truncate the middle of long filenames
- Keep the file extension shown to make the file easier to identify

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Start Studio
- Click on 'Add site' and then 'Import from a backup'
- Select a file with a long filename (larger than 30 characters)
- Check that the filename is not overflowing the container

| Before | After |
|--------|--------|
| <img width="2036" height="1546" alt="CleanShot 2025-09-04 at 10 39 23@2x" src="https://github.com/user-attachments/assets/042f93be-84eb-48c8-8f26-921a4d7a3207" /> | <img width="2040" height="1546" alt="CleanShot 2025-09-04 at 10 49 40@2x" src="https://github.com/user-attachments/assets/41678bd5-8f5d-4701-92ed-c5817eaea600" /> | 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
