### PR TITLE
Studio: Update UI text for better clarity and consistency

### DIFF
--- a/src/components/empty-studio/index.tsx
+++ b/src/components/empty-studio/index.tsx
@@ -10,10 +10,10 @@ export function EmptyStudio() {
 			<div className="mx-auto px-[85px] flex items-center gap-[44px] max-w-[786px]">
 				<div>
 					<div className="text-[16px] font-semibold text-black mb-[4px]">
-						{ __( 'Ready for a new start?' ) }
+						{ __( 'Ready to start building?' ) }
 					</div>
 					<p className="text-[13px] text-gray-700 mb-[32px]">
-						{ __( "You don't have any sites right now. Add a new one to get started again." ) }
+						{ __( "You don't have any sites right now. Add a new site to get started." ) }
 					</p>
 
 					<AddSite variant="primary" />

--- a/src/components/tests/site-content-tabs.test.tsx
+++ b/src/components/tests/site-content-tabs.test.tsx
@@ -124,7 +124,7 @@ describe( 'SiteContentTabs', () => {
 		expect( screen.queryByRole( 'tab', { name: 'Publish' } ) ).toBeNull();
 		expect( screen.queryByRole( 'tab', { name: 'Export' } ) ).toBeNull();
 		expect(
-			screen.getByText( "You don't have any sites right now. Add a new one to get started again." )
+			screen.getByText( "You don't have any sites right now. Add a new site to get started." )
 		).toBeVisible();
 	} );
 } );

--- a/src/modules/add-site/components/blueprints.tsx
+++ b/src/modules/add-site/components/blueprints.tsx
@@ -313,7 +313,7 @@ export default function AddSiteBlueprint( {
 			<HStack alignment="edge" className="w-full mb-[22px] px-3">
 				<HStack alignment="left" className="flex-1">
 					<Text className="text-[16px]" weight={ 500 }>
-						{ __( 'Suggested blueprints' ) }
+						{ __( 'Featured blueprints' ) }
 					</Text>
 				</HStack>
 				{ selectedFileName ? (
@@ -357,7 +357,7 @@ export default function AddSiteBlueprint( {
 			<div className="w-full px-3 [&_.dataviews-view-grid]:!grid [&_.dataviews-view-grid]:!grid-cols-3 [&_.dataviews-view-grid]:!gap-4 [&_.dataviews-view-grid]:!items-start [&_.components-badge]:!bg-transparent [&_.components-badge]:!p-0">
 				{ errorMessage && (
 					<Text className="text-red-500 text-[14px] block text-center py-[100px]">
-						{ sprintf( __( 'Error loading suggested blueprints: %s' ), errorMessage ) }
+						{ sprintf( __( 'Error loading featured blueprints: %s' ), errorMessage ) }
 						<br />
 						{ __( 'You can use your own blueprint by uploading a file.' ) }
 					</Text>

--- a/src/modules/add-site/components/options.tsx
+++ b/src/modules/add-site/components/options.tsx
@@ -93,7 +93,7 @@ export default function AddSiteOptions( { onOptionSelect }: AddSiteOptionsProps 
 				<OptionButton
 					icon={ <BlueprintIcon size={ 24 } /> }
 					title={ __( 'Start from a blueprint' ) }
-					description={ __( 'Choose a featured blueprint or use your own.' ) }
+					description={ __( 'Choose a featured blueprint or use your own' ) }
 					onClick={ () => onOptionSelect( 'blueprint' ) }
 					disabled={ isOffline }
 					disabledTooltip={ offlineMessage }

--- a/src/modules/add-site/components/options.tsx
+++ b/src/modules/add-site/components/options.tsx
@@ -86,14 +86,14 @@ export default function AddSiteOptions( { onOptionSelect }: AddSiteOptionsProps 
 			<OptionButton
 				icon={ <Icon className="" icon={ plus } size={ 26 } fill="#3858E9" /> }
 				title={ __( 'Create a site' ) }
-				description={ __( 'Create a clean site' ) }
+				description={ __( 'Start from scratch' ) }
 				onClick={ () => onOptionSelect( 'create' ) }
 			/>
 			{ enableBlueprints && (
 				<OptionButton
 					icon={ <BlueprintIcon size={ 24 } /> }
 					title={ __( 'Start from a blueprint' ) }
-					description={ __( 'Choose one from the list or select your own' ) }
+					description={ __( 'Choose a featured blueprint or use your own.' ) }
 					onClick={ () => onOptionSelect( 'blueprint' ) }
 					disabled={ isOffline }
 					disabledTooltip={ offlineMessage }

--- a/src/modules/add-site/tests/add-site.test.tsx
+++ b/src/modules/add-site/tests/add-site.test.tsx
@@ -169,7 +169,7 @@ describe( 'AddSite', () => {
 		await user.click( screen.getByRole( 'button', { name: 'Add site' } ) );
 		expect( screen.getByRole( 'dialog' ) ).toBeVisible();
 
-		await user.click( screen.getByRole( 'button', { name: 'Create a site Create a clean site' } ) );
+		await user.click( screen.getByRole( 'button', { name: 'Create a site Start from scratch' } ) );
 
 		await user.click( screen.getByRole( 'button', { name: 'Advanced settings' } ) );
 		await user.click( screen.getByTestId( 'select-path-button' ) );
@@ -211,7 +211,7 @@ describe( 'AddSite', () => {
 		await user.click( screen.getAllByRole( 'button', { name: 'Add site' } )[ 0 ] );
 		expect( screen.getByRole( 'dialog' ) ).toBeVisible();
 
-		await user.click( screen.getByRole( 'button', { name: 'Create a site Create a clean site' } ) );
+		await user.click( screen.getByRole( 'button', { name: 'Create a site Start from scratch' } ) );
 
 		await user.click( screen.getByRole( 'button', { name: 'Advanced settings' } ) );
 		await user.click( screen.getByTestId( 'select-path-button' ) );
@@ -248,7 +248,7 @@ describe( 'AddSite', () => {
 		await user.click( screen.getByRole( 'button', { name: 'Add site' } ) );
 		expect( screen.getByRole( 'dialog' ) ).toBeVisible();
 
-		await user.click( screen.getByRole( 'button', { name: 'Create a site Create a clean site' } ) );
+		await user.click( screen.getByRole( 'button', { name: 'Create a site Start from scratch' } ) );
 
 		await user.click( screen.getByRole( 'button', { name: 'Advanced settings' } ) );
 		await user.click( screen.getByTestId( 'select-path-button' ) );
@@ -281,7 +281,7 @@ describe( 'AddSite', () => {
 		await user.click( screen.getByRole( 'button', { name: 'Add site' } ) );
 		expect( screen.getByRole( 'dialog' ) ).toBeVisible();
 
-		await user.click( screen.getByRole( 'button', { name: 'Create a site Create a clean site' } ) );
+		await user.click( screen.getByRole( 'button', { name: 'Create a site Start from scratch' } ) );
 
 		const siteNameInput = screen.getByDisplayValue( 'My WordPress Website' );
 		await user.click( siteNameInput );
@@ -300,7 +300,7 @@ describe( 'AddSite', () => {
 		await user.click( screen.getByRole( 'button', { name: 'Add site' } ) );
 		expect( screen.getByRole( 'dialog' ) ).toBeVisible();
 
-		await user.click( screen.getByRole( 'button', { name: 'Create a site Create a clean site' } ) );
+		await user.click( screen.getByRole( 'button', { name: 'Create a site Start from scratch' } ) );
 
 		expect( screen.getByDisplayValue( 'My WordPress Website' ) ).toBeVisible();
 		await user.click( screen.getByRole( 'button', { name: 'Advanced settings' } ) );
@@ -328,7 +328,7 @@ describe( 'AddSite', () => {
 
 		await user.click( screen.getByRole( 'button', { name: 'Add site' } ) );
 
-		await user.click( screen.getByRole( 'button', { name: 'Create a site Create a clean site' } ) );
+		await user.click( screen.getByRole( 'button', { name: 'Create a site Start from scratch' } ) );
 
 		await user.click( screen.getByRole( 'button', { name: 'Advanced settings' } ) );
 		await user.click( screen.getByTestId( 'select-path-button' ) );
@@ -361,7 +361,7 @@ describe( 'AddSite', () => {
 
 		await user.click( screen.getByRole( 'button', { name: 'Add site' } ) );
 
-		await user.click( screen.getByRole( 'button', { name: 'Create a site Create a clean site' } ) );
+		await user.click( screen.getByRole( 'button', { name: 'Create a site Start from scratch' } ) );
 
 		await user.click( screen.getByRole( 'button', { name: 'Advanced settings' } ) );
 
@@ -412,7 +412,7 @@ describe( 'AddSite', () => {
 
 		await user.click( screen.getByRole( 'button', { name: 'Add site' } ) );
 
-		await user.click( screen.getByRole( 'button', { name: 'Create a site Create a clean site' } ) );
+		await user.click( screen.getByRole( 'button', { name: 'Create a site Start from scratch' } ) );
 
 		await user.click( screen.getByRole( 'button', { name: 'Advanced settings' } ) );
 
@@ -449,7 +449,7 @@ describe( 'AddSite', () => {
 		const user = userEvent.setup();
 
 		await user.click( screen.getByRole( 'button', { name: 'Add site' } ) );
-		await user.click( screen.getByRole( 'button', { name: 'Create a site Create a clean site' } ) );
+		await user.click( screen.getByRole( 'button', { name: 'Create a site Start from scratch' } ) );
 		await user.click( screen.getByRole( 'button', { name: 'Advanced settings' } ) );
 
 		const wpVersionSelect = screen.getByLabelText( 'WordPress version' );
@@ -463,7 +463,7 @@ describe( 'AddSite', () => {
 		const user = userEvent.setup();
 
 		await user.click( screen.getByRole( 'button', { name: 'Add site' } ) );
-		await user.click( screen.getByRole( 'button', { name: 'Create a site Create a clean site' } ) );
+		await user.click( screen.getByRole( 'button', { name: 'Create a site Start from scratch' } ) );
 		await user.click( screen.getByRole( 'button', { name: 'Advanced settings' } ) );
 
 		const wpVersionSelect = screen.getByLabelText( 'WordPress version' );
@@ -477,7 +477,7 @@ describe( 'AddSite', () => {
 		const user = userEvent.setup();
 
 		await user.click( screen.getByRole( 'button', { name: 'Add site' } ) );
-		await user.click( screen.getByRole( 'button', { name: 'Create a site Create a clean site' } ) );
+		await user.click( screen.getByRole( 'button', { name: 'Create a site Start from scratch' } ) );
 		await user.click( screen.getByRole( 'button', { name: 'Advanced settings' } ) );
 
 		const wpVersionSelect = screen.getByLabelText( 'WordPress version' );
@@ -497,7 +497,7 @@ describe( 'AddSite', () => {
 		const user = userEvent.setup();
 
 		await user.click( screen.getByRole( 'button', { name: 'Add site' } ) );
-		await user.click( screen.getByRole( 'button', { name: 'Create a site Create a clean site' } ) );
+		await user.click( screen.getByRole( 'button', { name: 'Create a site Start from scratch' } ) );
 		await user.click( screen.getByRole( 'button', { name: 'Advanced settings' } ) );
 
 		const wpVersionSelect = screen.getByLabelText( 'WordPress version' );

--- a/src/modules/whats-new/components/whats-new-modal.tsx
+++ b/src/modules/whats-new/components/whats-new-modal.tsx
@@ -58,9 +58,9 @@ export default function WhatsNewModal( { showModal, onClose }: WhatsNewModalProp
 	const whatsNewPages: WhatsNewPage[] = [
 		{
 			image: blueprintsIllustration,
-			title: __( 'Introducing Blueprints, a way to streamline your process' ),
+			title: __( 'Introducing Blueprints, a new way to streamline site creation.' ),
 			description: __(
-				'Select a setup that fits your needs and build your WordPress site even faster.'
+				'Select a blueprint that fits your needs and build your WordPress site even faster.'
 			),
 			learnMoreUrl: getLocalizedLink( locale, 'docsBlueprints' ),
 		},


### PR DESCRIPTION
## Related issues

- Fixes STU-765

## Proposed Changes

- Updated What's New Modal text: Changed "your process" to "site creation" and "setup" to "blueprint"
- Changed "Create a clean site" to "Start from scratch" in Add Site Options
- Updated blueprint description to "Choose a featured blueprint or use your own."
- Changed "Suggested blueprints" to "Featured blueprints" throughout the app
- Updated empty state text to "Ready to start building?" and "Add a new site to get started."

## Testing Instructions

- Navigate to the Studio dashboard and verify the empty state shows "Ready to start building?" and "Add a new site to get started."
- Click "Add Site" and verify the option shows "Start from scratch" instead of "Create a clean site"
- Check that the blueprint section shows "Choose a featured blueprint or use your own." as the description
- Verify that "Featured blueprints" is displayed instead of "Suggested blueprints"
- Open the What's New modal and confirm the updated text references "site creation" and "blueprint" appropriately

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?