### PR TITLE
Add support for blueprint preferred PHP and WordPress versions

### DIFF
--- a/src/components/site-form.tsx
+++ b/src/components/site-form.tsx
@@ -1,4 +1,4 @@
-import { Icon, SelectControl } from '@wordpress/components';
+import { Icon, SelectControl, Notice } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf, _n } from '@wordpress/i18n';
 import { tip, warning, trash, chevronRight, chevronDown, chevronLeft } from '@wordpress/icons';
@@ -72,6 +72,7 @@ interface SiteFormProps {
 	setEnableHttps?: ( use: boolean ) => void;
 	wpVersion: string;
 	setWpVersion: ( version: string ) => void;
+	blueprintPreferredVersions?: { php?: string; wp?: string };
 }
 
 const SiteFormError = ( { error, tipMessage = '', className = '' }: SiteFormErrorProps ) => {
@@ -262,6 +263,7 @@ export const SiteForm = ( {
 	customDomainError,
 	enableHttps,
 	setEnableHttps,
+	blueprintPreferredVersions,
 }: SiteFormProps ) => {
 	const { __, isRTL } = useI18n();
 	const locale = useI18nLocale();
@@ -295,6 +297,12 @@ export const SiteForm = ( {
 		chevronIcon = chevronRight;
 	}
 	const generatedDomainName = generateCustomDomainFromSiteName( siteName );
+
+	// Check if current versions differ from blueprint recommendations
+	const showBlueprintVersionWarning =
+		blueprintPreferredVersions &&
+		( ( blueprintPreferredVersions.php && blueprintPreferredVersions.php !== phpVersion ) ||
+			( blueprintPreferredVersions.wp && blueprintPreferredVersions.wp !== wpVersion ) );
 
 	return (
 		<form className={ className } onSubmit={ onSubmit }>
@@ -434,6 +442,39 @@ export const SiteForm = ( {
 										) }
 									/>
 								</div>
+
+								{ showBlueprintVersionWarning && (
+									<Notice status="warning" isDismissible={ false } className="mt-4">
+										<strong>{ __( 'Version differs from blueprint recommendation' ) }</strong>
+										<br />
+										{ __( 'This blueprint recommends:' ) }
+										<ul style={ { marginTop: '8px', marginBottom: '4px', paddingLeft: '20px' } }>
+											{ blueprintPreferredVersions.php &&
+												blueprintPreferredVersions.php !== phpVersion && (
+													<li>
+														{ sprintf(
+															/* translators: %1$s: recommended PHP version, %2$s: currently selected PHP version */
+															__( 'PHP %s (currently %s)' ),
+															blueprintPreferredVersions.php,
+															phpVersion
+														) }
+													</li>
+												) }
+											{ blueprintPreferredVersions.wp &&
+												blueprintPreferredVersions.wp !== wpVersion && (
+													<li>
+														{ sprintf(
+															/* translators: %1$s: recommended WordPress version, %2$s: currently selected WordPress version */
+															__( 'WordPress %s (currently %s)' ),
+															blueprintPreferredVersions.wp,
+															wpVersion
+														) }
+													</li>
+												) }
+										</ul>
+										{ __( 'Using different versions may cause compatibility issues.' ) }
+									</Notice>
+								) }
 
 								{ setUseCustomDomain && setCustomDomain && (
 									<div className="flex items-center gap-2 mt-4">

--- a/src/modules/add-site/components/create-site.tsx
+++ b/src/modules/add-site/components/create-site.tsx
@@ -25,6 +25,7 @@ interface CreateSiteProps {
 	customDomainError: string;
 	enableHttps: boolean;
 	setEnableHttps: ( enable: boolean ) => void;
+	blueprintPreferredVersions?: { php?: string; wp?: string };
 }
 
 export default function CreateSite( {
@@ -46,6 +47,7 @@ export default function CreateSite( {
 	customDomainError,
 	enableHttps,
 	setEnableHttps,
+	blueprintPreferredVersions,
 }: CreateSiteProps ) {
 	const { __ } = useI18n();
 
@@ -74,6 +76,7 @@ export default function CreateSite( {
 				customDomainError={ customDomainError }
 				enableHttps={ enableHttps }
 				setEnableHttps={ setEnableHttps }
+				blueprintPreferredVersions={ blueprintPreferredVersions }
 			/>
 		</VStack>
 	);

--- a/src/modules/add-site/index.tsx
+++ b/src/modules/add-site/index.tsx
@@ -57,12 +57,21 @@ interface NavigationContentProps {
 	setSelectedBlueprint: ( blueprint?: Blueprint ) => void;
 	selectedBlueprint?: Blueprint;
 	blueprintsErrorMessage?: string | undefined;
+	blueprintPreferredVersions?: { php?: string; wp?: string };
+	setBlueprintPreferredVersions: ( versions: { php?: string; wp?: string } | undefined ) => void;
 }
 
 function NavigationContent( props: NavigationContentProps ) {
 	const { __ } = useI18n();
 	const { goTo, location } = useNavigator();
-	const { blueprintsData, isLoadingBlueprints, blueprintsErrorMessage, ...createSiteProps } = props;
+	const {
+		blueprintsData,
+		isLoadingBlueprints,
+		blueprintsErrorMessage,
+		blueprintPreferredVersions,
+		setBlueprintPreferredVersions,
+		...createSiteProps
+	} = props;
 
 	const handleOptionSelect = useCallback(
 		( option: 'create' | 'blueprint' | 'backup' ) => {
@@ -127,12 +136,36 @@ function NavigationContent( props: NavigationContentProps ) {
 			}
 			if ( location.path === '/blueprint' ) {
 				createSiteProps.setSelectedBlueprint();
+				setBlueprintPreferredVersions( undefined );
 			}
 			goTo( '/' );
 		} else {
 			goTo( '/' );
 		}
-	}, [ goTo, location.path, createSiteProps ] );
+	}, [ location.path, goTo, createSiteProps, setBlueprintPreferredVersions ] );
+
+	const applyBlueprintVersions = useCallback(
+		( blueprint?: Blueprint ) => {
+			if ( blueprint?.blueprint?.preferredVersions ) {
+				const preferredVersions = blueprint.blueprint.preferredVersions as {
+					php?: string;
+					wp?: string;
+				};
+				setBlueprintPreferredVersions( preferredVersions );
+
+				// Apply the preferred versions to the form
+				if ( preferredVersions.php && preferredVersions.php !== 'latest' ) {
+					createSiteProps.setPhpVersion( preferredVersions.php );
+				}
+				if ( preferredVersions.wp && preferredVersions.wp !== 'latest' ) {
+					createSiteProps.setWpVersion( preferredVersions.wp );
+				}
+			} else {
+				setBlueprintPreferredVersions( undefined );
+			}
+		},
+		[ createSiteProps, setBlueprintPreferredVersions ]
+	);
 
 	const handleBlueprintChange = useCallback(
 		( blueprintId: string ) => {
@@ -140,15 +173,17 @@ function NavigationContent( props: NavigationContentProps ) {
 				( b: Blueprint ) => b.slug === blueprintId
 			);
 			createSiteProps.setSelectedBlueprint( blueprint );
+			applyBlueprintVersions( blueprint );
 		},
-		[ blueprintsData?.blueprints, createSiteProps ]
+		[ blueprintsData?.blueprints, createSiteProps, applyBlueprintVersions ]
 	);
 
 	const handleFileBlueprintSelect = useCallback(
 		( blueprint: Blueprint ) => {
 			createSiteProps.setSelectedBlueprint( blueprint );
+			applyBlueprintVersions( blueprint );
 		},
-		[ createSiteProps ]
+		[ createSiteProps, applyBlueprintVersions ]
 	);
 
 	return (
@@ -167,7 +202,10 @@ function NavigationContent( props: NavigationContentProps ) {
 				/>
 			</Navigator.Screen>
 			<Navigator.Screen className="flex-1" path="/blueprint/create">
-				<CreateSite { ...createSiteProps } />
+				<CreateSite
+					{ ...createSiteProps }
+					blueprintPreferredVersions={ blueprintPreferredVersions }
+				/>
 			</Navigator.Screen>
 			<Navigator.Screen className="flex-1" path="/create">
 				<CreateSite { ...createSiteProps } />
@@ -198,6 +236,9 @@ export default function AddSite( { className, variant = 'outlined' }: AddSitePro
 	const [ nameSuggested, setNameSuggested ] = useState( false );
 	const defaultPhpVersion = useRootSelector( selectDefaultPhpVersion );
 	const defaultWordPressVersion = useRootSelector( selectDefaultWordPressVersion );
+	const [ blueprintPreferredVersions, setBlueprintPreferredVersions ] = useState<
+		{ php?: string; wp?: string } | undefined
+	>();
 
 	const {
 		data: blueprintsData,
@@ -249,6 +290,7 @@ export default function AddSite( { className, variant = 'outlined' }: AddSitePro
 		setEnableHttps( false );
 		setFileForImport( null );
 		setSelectedBlueprint( undefined );
+		setBlueprintPreferredVersions( undefined );
 	}, [
 		setSitePath,
 		setDoesPathContainWordPress,
@@ -342,6 +384,8 @@ export default function AddSite( { className, variant = 'outlined' }: AddSitePro
 						blueprintsErrorMessage={ formatRtkError( blueprintsError ) }
 						isLoadingBlueprints={ isLoadingBlueprints }
 						handleSubmit={ handleSubmit }
+						blueprintPreferredVersions={ blueprintPreferredVersions }
+						setBlueprintPreferredVersions={ setBlueprintPreferredVersions }
 					/>
 				</Navigator>
 			</FullscreenModal>

--- a/src/modules/add-site/tests/add-site.test.tsx
+++ b/src/modules/add-site/tests/add-site.test.tsx
@@ -7,6 +7,7 @@ import { useOffline } from 'src/hooks/use-offline';
 import { FolderDialogResponse } from 'src/ipc-handlers';
 import { createTestStore } from 'src/lib/test-utils';
 import AddSite from 'src/modules/add-site';
+import { useGetBlueprints } from 'src/stores/wpcom-api';
 
 jest.mock( 'src/stores/certificate-trust-api', () => {
 	const actual = jest.requireActual( 'src/stores/certificate-trust-api' ) || {};
@@ -85,6 +86,8 @@ jest.mock( 'src/stores/wpcom-api', () => {
 		} ),
 	};
 } );
+
+const mockUseGetBlueprints = useGetBlueprints as jest.MockedFunction< typeof useGetBlueprints >;
 
 const renderWithProvider = ( children: React.ReactElement ) => {
 	const store = createTestStore( {
@@ -507,6 +510,123 @@ describe( 'AddSite', () => {
 			screen.queryByText(
 				'You are currently offline so your site will be created with the latest version. Selecting a different WordPress version requires an internet connection.'
 			)
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'should show warning when blueprint preferred versions differ from selected versions', async () => {
+		const mockBlueprintData = {
+			data: {
+				blueprints: [
+					{
+						slug: 'test-blueprint',
+						title: 'Test Blueprint',
+						excerpt: 'A test blueprint',
+						image: '',
+						playground_url: '',
+						blueprint: {
+							preferredVersions: {
+								php: '8.1',
+								wp: '6.4.0',
+							},
+						},
+					},
+				],
+				total: 1,
+			},
+			isLoading: false,
+			refetch: jest.fn(),
+			isUninitialized: false,
+		};
+
+		mockUseGetBlueprints.mockReturnValue(
+			mockBlueprintData as ReturnType< typeof useGetBlueprints >
+		);
+
+		renderWithProvider( <AddSite /> );
+		const user = userEvent.setup();
+
+		// Open modal and navigate to blueprint selection
+		await user.click( screen.getByRole( 'button', { name: 'Add site' } ) );
+		await user.click(
+			screen.getByRole( 'button', {
+				name: 'Start from a blueprint Choose a featured blueprint or use your own',
+			} )
+		);
+
+		// Select the blueprint with preferred versions
+		await user.click( screen.getByText( 'Test Blueprint' ) );
+
+		// Continue to create site form
+		await user.click( screen.getByRole( 'button', { name: 'Continue' } ) );
+
+		// Open advanced settings to access version selectors
+		await user.click( screen.getByRole( 'button', { name: 'Advanced settings' } ) );
+
+		// Change PHP version to something different from preferred
+		const phpVersionSelect = screen.getByLabelText( 'PHP version' );
+		await user.selectOptions( phpVersionSelect, '8.3' );
+
+		// Should show warning since PHP version differs from preferred (8.1)
+		await waitFor( () => {
+			expect(
+				screen.getByText( 'Version differs from blueprint recommendation' )
+			).toBeInTheDocument();
+			expect( screen.getByText( 'PHP 8.1 (currently 8.3)' ) ).toBeInTheDocument();
+		} );
+	} );
+
+	it( 'should not show warning when versions match blueprint preferred versions', async () => {
+		const mockBlueprintData = {
+			data: {
+				blueprints: [
+					{
+						slug: 'test-blueprint-2',
+						title: 'Test Blueprint 2',
+						excerpt: 'Another test blueprint',
+						image: '',
+						playground_url: '',
+						blueprint: {
+							preferredVersions: {
+								php: '8.3', // Same as default in store
+								wp: 'latest',
+							},
+						},
+					},
+				],
+				total: 1,
+			},
+			isLoading: false,
+			refetch: jest.fn(),
+			isUninitialized: false,
+		};
+
+		mockUseGetBlueprints.mockReturnValue(
+			mockBlueprintData as ReturnType< typeof useGetBlueprints >
+		);
+
+		renderWithProvider( <AddSite /> );
+		const user = userEvent.setup();
+
+		// Open modal and navigate to blueprint selection
+		await user.click( screen.getByRole( 'button', { name: 'Add site' } ) );
+		await user.click(
+			screen.getByRole( 'button', {
+				name: 'Start from a blueprint Choose a featured blueprint or use your own',
+			} )
+		);
+
+		// Select the blueprint
+		await user.click( screen.getByText( 'Test Blueprint 2' ) );
+
+		// Continue to create site form
+		await user.click( screen.getByRole( 'button', { name: 'Continue' } ) );
+
+		// Open advanced settings
+		await user.click( screen.getByRole( 'button', { name: 'Advanced settings' } ) );
+
+		// Should not show warning since versions match preferred versions
+		expect(
+			screen.queryByText( 'Version differs from blueprint recommendation' )
 		).not.toBeInTheDocument();
 	} );
 } );


### PR DESCRIPTION
## Related issues

- Fixes STU-763

## Proposed Changes

- Added support for BlueprintDeclaration.preferredVersions property
- Auto-populate PHP and WordPress version fields when selecting a blueprint with version preferences
- Show warning when user changes versions from blueprint recommendations
- Extract duplicate version application logic into reusable function

<img width="2350" height="1820" alt="image" src="https://github.com/user-attachments/assets/bb201f53-add0-4f5f-86da-f0a6b8865e20" />

## Testing Instructions

1. Run Studio
2. Click on "Add site" -> "Start from a blueprint"
3. Select a blueprint that has preferredVersions (e.g., a custom blueprint with preferredVersions defined)
4. Verify that PHP and WordPress version fields auto-populate with the blueprint's preferred versions
5. Change the versions to different values - a warning should appear
6. Change the versions back to the recommended values - warning should disappear
7. Select a blueprint without preferredVersions - no warning should appear
8. Run `npm test src/modules/add-site/tests/add-site.test.tsx` to verify unit tests pass

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?