### PR TITLE
Improve Blueprints error and loading states

### DIFF
--- a/src/modules/add-site/components/blueprints.tsx
+++ b/src/modules/add-site/components/blueprints.tsx
@@ -367,7 +367,7 @@ export function AddSiteBlueprintSelector( {
 					<Text className="text-[14px] block text-center py-[100px]">
 						{ createInterpolateElement(
 							__(
-								'Studio could not load blueprints. <button>Try again</button> or use your own blueprint'
+								'Studio could not load blueprints. <button>Try again</button> or use your own blueprint.'
 							),
 							{
 								button: <Button variant="link" onClick={ refetchBlueprints } />,

--- a/src/modules/add-site/components/blueprints.tsx
+++ b/src/modules/add-site/components/blueprints.tsx
@@ -370,7 +370,7 @@ export function AddSiteBlueprintSelector( {
 								'Studio could not load blueprints. <button>Try again</button> or use your own blueprint'
 							),
 							{
-								button: <Button variant="link" className="text-xs" onClick={ refetchBlueprints } />,
+								button: <Button variant="link" onClick={ refetchBlueprints } />,
 							}
 						) }
 					</Text>

--- a/src/modules/add-site/components/blueprints.tsx
+++ b/src/modules/add-site/components/blueprints.tsx
@@ -8,6 +8,7 @@ import {
 	Tooltip,
 } from '@wordpress/components';
 import { DataViews, View } from '@wordpress/dataviews';
+import { createInterpolateElement } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
 import { Icon, external } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
@@ -15,6 +16,7 @@ import { useCallback, useRef, useState, useMemo } from 'react';
 import StudioButton from 'src/components/button';
 import { cx } from 'src/lib/cx';
 import { getIpcApi } from 'src/lib/get-ipc-api';
+import { useGetBlueprints } from 'src/stores/wpcom-api';
 
 interface Blueprint {
 	slug: string;
@@ -47,7 +49,7 @@ interface AddSiteBlueprintProps {
 
 const MAX_BLUEPRINTS_CATEGORIES = 3;
 
-export default function AddSiteBlueprint( {
+export function AddSiteBlueprintSelector( {
 	blueprints,
 	errorMessage,
 	isLoading,
@@ -56,6 +58,7 @@ export default function AddSiteBlueprint( {
 	onFileBlueprintSelect,
 }: AddSiteBlueprintProps ) {
 	const { __ } = useI18n();
+	const { refetch: refetchBlueprints, isFetching: isFetchingBlueprints } = useGetBlueprints();
 	const fileRef = useRef< HTMLInputElement | null >( null );
 	const [ validationError, setValidationError ] = useState< string | null >( null );
 
@@ -355,13 +358,24 @@ export default function AddSiteBlueprint( {
 			</HStack>
 
 			<div className="w-full px-3 [&_.dataviews-view-grid]:!grid [&_.dataviews-view-grid]:!grid-cols-3 [&_.dataviews-view-grid]:!gap-4 [&_.dataviews-view-grid]:!items-start [&_.components-badge]:!bg-transparent [&_.components-badge]:!p-0">
-				{ errorMessage && (
-					<Text className="text-red-500 text-[14px] block text-center py-[100px]">
-						{ sprintf( __( 'Error loading featured blueprints: %s' ), errorMessage ) }
-						<br />
-						{ __( 'You can use your own blueprint by uploading a file.' ) }
+				{ isFetchingBlueprints && (
+					<Text className="text-[14px] block text-center py-[100px]">
+						{ __( 'Loading blueprints...' ) }
 					</Text>
 				) }
+				{ errorMessage && ! isFetchingBlueprints && (
+					<Text className="text-[14px] block text-center py-[100px]">
+						{ createInterpolateElement(
+							__(
+								'Studio could not load blueprints. <button>Try again</button> or use your own blueprint'
+							),
+							{
+								button: <Button variant="link" className="text-xs" onClick={ refetchBlueprints } />,
+							}
+						) }
+					</Text>
+				) }
+
 				<DataViews
 					data={ dataViewBlueprints }
 					fields={ fields }

--- a/src/modules/add-site/index.tsx
+++ b/src/modules/add-site/index.tsx
@@ -18,7 +18,7 @@ import {
 } from 'src/stores/provider-constants-slice';
 import { useGetWordPressVersions } from 'src/stores/wordpress-versions-api';
 import { useGetBlueprints, Blueprint } from 'src/stores/wpcom-api';
-import AddSiteBlueprintSelector from './components/blueprints';
+import { AddSiteBlueprintSelector } from './components/blueprints';
 import CreateSite from './components/create-site';
 import ImportBackup from './components/import-backup';
 import AddSiteOptions from './components/options';


### PR DESCRIPTION
## Related issues

- Fixes STU-786

## Proposed Changes
With this PR we are improving UI and wording of error, when Blueprints weren't loaded.
Also, we are adding "loading" state for Blueprints

## Testing Instructions
Apply the next diff:
```diff
diff --git a/src/stores/wpcom-api.ts b/src/stores/wpcom-api.ts
index c89509c0..4f697ec3 100644
--- a/src/stores/wpcom-api.ts
+++ b/src/stores/wpcom-api.ts
@@ -167,7 +167,12 @@ export const wpcomPublicApi = createApi( {
                                apiNamespace: 'wpcom/v2',
                        } ),
                        transformResponse: ( response: unknown ) => {
-                               if ( ! response || typeof response !== 'object' ) {
+                               // @ts-ignore
+                               const attempt = window.qq || 0;
+                               // @ts-ignore
+                               window.qq = attempt + 1;
+
+                               if ( ! response || typeof response !== 'object' || attempt < 3 ) {
                                        throw new Error( 'Invalid response format' );
                                }
```
* Click on Add site
* Click on "Start with Blueprints"
* Assert that you see error `'Studio could not load blueprints. <button>Try again</button> or use your own blueprint'`
* Clicik on "Try again"
* Assert that you see loading state
* Click one more time and assert that everythign loaded well