### PR TITLE
Rename wordpress components patch to cover new version

### DIFF
--- a/patches/@wordpress+components+30.3.0.patch
+++ b/patches/@wordpress+components+30.3.0.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/@wordpress/components/build-module/modal/aria-helper.js b/node_modules/@wordpress/components/build-module/modal/aria-helper.js
-index e1e1371..54775d2 100644
+index e1e1371..db4ce8c 100644
 --- a/node_modules/@wordpress/components/build-module/modal/aria-helper.js
 +++ b/node_modules/@wordpress/components/build-module/modal/aria-helper.js
 @@ -22,7 +22,7 @@ export function modalize(modalElement) {
@@ -31,10 +31,10 @@ index e1e1371..54775d2 100644
  //# sourceMappingURL=aria-helper.js.map
 \ No newline at end of file
 diff --git a/node_modules/@wordpress/components/build-module/modal/index.js b/node_modules/@wordpress/components/build-module/modal/index.js
-index 7ae5a49..b9ccf96 100644
+index 4545ba9..552820f 100644
 --- a/node_modules/@wordpress/components/build-module/modal/index.js
 +++ b/node_modules/@wordpress/components/build-module/modal/index.js
-@@ -96,7 +96,7 @@ function UnforwardedModal(props, forwardedRef) {
+@@ -97,7 +97,7 @@ function UnforwardedModal(props, forwardedRef) {
    }, [contentRef]);
  
    // Accessibly isolates/unisolates the modal.


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- N/A

## Proposed Changes

- I propose to rename the WordPress components patch to cover the new version. In trunk, it applies correctly, but results in a warning.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Confirm builds work fine.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
