### PR TITLE
Dynamic blueprints category overflow

### DIFF
--- a/src/modules/add-site/components/blueprints.tsx
+++ b/src/modules/add-site/components/blueprints.tsx
@@ -47,6 +47,7 @@ interface AddSiteBlueprintProps {
 }
 
 function CategoryBadges( { categories }: { categories: string[] } ) {
+	const { __ } = useI18n();
 	const containerRef = useRef< HTMLDivElement >( null );
 	const { visible, hidden, hiddenCount, itemRefs } = useOverflowItems( categories, containerRef );
 
@@ -79,7 +80,8 @@ function CategoryBadges( { categories }: { categories: string[] } ) {
 						as="span"
 						className="px-2.5 py-1 text-xs bg-gray-100 text-gray-700 rounded-sm flex items-center font-medium whitespace-nowrap flex-shrink-0"
 					>
-						+{ hiddenCount } more
+						{ /* translators: %d: Number of hidden categories */ }
+						{ sprintf( __( '+%d more' ), hiddenCount ) }
 					</Text>
 				</Tooltip>
 			) }

--- a/src/modules/add-site/components/blueprints.tsx
+++ b/src/modules/add-site/components/blueprints.tsx
@@ -15,6 +15,7 @@ import { useCallback, useRef, useState, useMemo } from 'react';
 import StudioButton from 'src/components/button';
 import { cx } from 'src/lib/cx';
 import { getIpcApi } from 'src/lib/get-ipc-api';
+import { useOverflowItems } from '../hooks/use-overflow-items';
 
 interface Blueprint {
 	slug: string;
@@ -45,7 +46,46 @@ interface AddSiteBlueprintProps {
 	onFileBlueprintSelect?: ( blueprint: Blueprint ) => void;
 }
 
-const MAX_BLUEPRINTS_CATEGORIES = 3;
+function CategoryBadges( { categories }: { categories: string[] } ) {
+	const containerRef = useRef< HTMLDivElement >( null );
+	const { visible, hidden, hiddenCount, itemRefs } = useOverflowItems( categories, containerRef );
+
+	return (
+		<HStack ref={ containerRef } spacing={ 3 } alignment="left" className="w-full">
+			{ categories.map( ( category, index ) => (
+				<Text
+					as="span"
+					key={ category }
+					ref={ ( el ) => {
+						itemRefs.current[ index ] = el;
+					} }
+					className="px-2.5 py-1 text-xs bg-gray-100 text-gray-700 rounded-sm flex items-center flex-shrink-0 max-w-32 truncate"
+					style={ {
+						visibility: index < visible.length ? 'visible' : 'hidden',
+						position: index >= visible.length ? 'absolute' : 'static',
+					} }
+				>
+					{ category }
+				</Text>
+			) ) }
+			{ hiddenCount > 0 && (
+				<Tooltip
+					text={ hidden.join( ', ' ) }
+					delay={ 200 }
+					placement="top-end"
+					className="max-w-xs"
+				>
+					<Text
+						as="span"
+						className="px-2.5 py-1 text-xs bg-gray-100 text-gray-700 rounded-sm flex items-center font-medium whitespace-nowrap flex-shrink-0"
+					>
+						+{ hiddenCount } more
+					</Text>
+				</Tooltip>
+			) }
+		</HStack>
+	);
+}
 
 export default function AddSiteBlueprint( {
 	blueprints,
@@ -152,37 +192,7 @@ export default function AddSiteBlueprint( {
 					const categories = ( item.blueprint.meta?.categories || [] ).filter(
 						( category ) => category !== 'Studio'
 					);
-					const visibleCategories = categories.slice( 0, MAX_BLUEPRINTS_CATEGORIES );
-					const remainingCount = categories.length - MAX_BLUEPRINTS_CATEGORIES;
-
-					return (
-						<HStack spacing={ 3 } alignment="left">
-							{ visibleCategories.map( ( category ) => (
-								<Text
-									as="span"
-									key={ category }
-									className="px-2.5 py-1 text-xs bg-gray-100 text-gray-700 rounded-sm flex items-center flex-shrink-0"
-								>
-									{ category }
-								</Text>
-							) ) }
-							{ remainingCount > 0 && (
-								<Tooltip
-									text={ categories.slice( MAX_BLUEPRINTS_CATEGORIES ).join( ', ' ) }
-									delay={ 200 }
-									position="top right"
-									className="max-w-xs"
-								>
-									<Text
-										as="span"
-										className="px-2.5 py-1 text-xs bg-gray-100 text-gray-700 rounded-sm flex items-center font-medium"
-									>
-										+{ remainingCount } more
-									</Text>
-								</Tooltip>
-							) }
-						</HStack>
-					);
+					return <CategoryBadges categories={ categories } />;
 				},
 			},
 			{
@@ -355,7 +365,7 @@ export default function AddSiteBlueprint( {
 				) }
 			</HStack>
 
-			<div className="w-full px-3 [&_.dataviews-view-grid]:!grid [&_.dataviews-view-grid]:!grid-cols-3 [&_.dataviews-view-grid]:!gap-4 [&_.dataviews-view-grid]:!items-start [&_.components-badge]:!bg-transparent [&_.components-badge]:!p-0">
+			<div className="w-full px-3 [&_.dataviews-view-grid]:!grid [&_.dataviews-view-grid]:!grid-cols-3 [&_.dataviews-view-grid]:!gap-4 [&_.dataviews-view-grid]:!items-start [&_.components-badge]:!bg-transparent [&_.components-badge]:!p-0 [&_.components-badge]:!w-full [&_.components-badge_.components-badge__content]:!w-full [&_.components-badge>*]:!w-full">
 				{ errorMessage && (
 					<Text className="text-red-500 text-[14px] block text-center py-[100px]">
 						{ sprintf( __( 'Error loading featured blueprints: %s' ), errorMessage ) }

--- a/src/modules/add-site/hooks/use-overflow-items.ts
+++ b/src/modules/add-site/hooks/use-overflow-items.ts
@@ -1,0 +1,71 @@
+import { useLayoutEffect, useState, useRef, useCallback } from 'react';
+
+export function useOverflowItems( items: string[], containerRef: React.RefObject< HTMLElement > ) {
+	const [ visibleCount, setVisibleCount ] = useState( items.length );
+	const itemRefs = useRef< ( HTMLElement | null )[] >( [] );
+	const lastWidth = useRef( 0 );
+	const debounceTimeout = useRef< NodeJS.Timeout | null >( null );
+
+	const calculate = useCallback( () => {
+		if ( ! containerRef.current || items.length === 0 ) {
+			return;
+		}
+
+		const container = containerRef.current;
+		const containerWidth = container.offsetWidth;
+
+		if ( containerWidth === 0 || containerWidth === lastWidth.current ) {
+			return;
+		}
+
+		lastWidth.current = containerWidth;
+
+		let totalWidth = 0;
+		let count = 0;
+
+		for ( let i = 0; i < itemRefs.current.length; i++ ) {
+			const item = itemRefs.current[ i ];
+			if ( ! item ) continue;
+
+			const itemWidth = item.offsetWidth;
+			const spacing = i > 0 ? 12 : 0;
+			const moreButtonSpace = i < items.length - 1 ? 70 : 0;
+
+			if ( totalWidth + spacing + itemWidth + moreButtonSpace <= containerWidth ) {
+				totalWidth += spacing + itemWidth;
+				count = i + 1;
+			} else {
+				break;
+			}
+		}
+
+		if ( count === items.length - 1 && itemRefs.current[ items.length - 1 ] ) {
+			const lastItem = itemRefs.current[ items.length - 1 ];
+			const lastItemWidth = lastItem?.offsetWidth || 0;
+			if ( totalWidth + 12 + lastItemWidth <= containerWidth + 10 ) {
+				count = items.length;
+			}
+		}
+
+		setVisibleCount( Math.max( 1, count ) );
+	}, [ items, containerRef ] );
+
+	useLayoutEffect( () => {
+		if ( debounceTimeout.current ) {
+			clearTimeout( debounceTimeout.current );
+		}
+		debounceTimeout.current = setTimeout( calculate, 50 );
+		return () => {
+			if ( debounceTimeout.current ) {
+				clearTimeout( debounceTimeout.current );
+			}
+		};
+	}, [ calculate ] );
+
+	return {
+		visible: items.slice( 0, visibleCount ),
+		hidden: items.slice( visibleCount ),
+		hiddenCount: items.length - visibleCount,
+		itemRefs,
+	};
+}

--- a/src/modules/add-site/hooks/use-overflow-items.ts
+++ b/src/modules/add-site/hooks/use-overflow-items.ts
@@ -1,5 +1,11 @@
 import { useLayoutEffect, useState, useRef, useCallback } from 'react';
 
+// Constants for layout calculations
+const ITEM_SPACING = 12; // Gap between category items in pixels
+const MORE_BUTTON_WIDTH = 70; // Estimated width of "+X more" button in pixels
+const DEBOUNCE_DELAY = 50; // Delay in milliseconds for debounced recalculation
+const TOLERANCE = 10; // Extra pixels to account for measurement precision
+
 export function useOverflowItems( items: string[], containerRef: React.RefObject< HTMLElement > ) {
 	const [ visibleCount, setVisibleCount ] = useState( items.length );
 	const itemRefs = useRef< ( HTMLElement | null )[] >( [] );
@@ -28,8 +34,8 @@ export function useOverflowItems( items: string[], containerRef: React.RefObject
 			if ( ! item ) continue;
 
 			const itemWidth = item.offsetWidth;
-			const spacing = i > 0 ? 12 : 0;
-			const moreButtonSpace = i < items.length - 1 ? 70 : 0;
+			const spacing = i > 0 ? ITEM_SPACING : 0;
+			const moreButtonSpace = i < items.length - 1 ? MORE_BUTTON_WIDTH : 0;
 
 			if ( totalWidth + spacing + itemWidth + moreButtonSpace <= containerWidth ) {
 				totalWidth += spacing + itemWidth;
@@ -42,7 +48,7 @@ export function useOverflowItems( items: string[], containerRef: React.RefObject
 		if ( count === items.length - 1 && itemRefs.current[ items.length - 1 ] ) {
 			const lastItem = itemRefs.current[ items.length - 1 ];
 			const lastItemWidth = lastItem?.offsetWidth || 0;
-			if ( totalWidth + 12 + lastItemWidth <= containerWidth + 10 ) {
+			if ( totalWidth + ITEM_SPACING + lastItemWidth <= containerWidth + TOLERANCE ) {
 				count = items.length;
 			}
 		}
@@ -54,7 +60,7 @@ export function useOverflowItems( items: string[], containerRef: React.RefObject
 		if ( debounceTimeout.current ) {
 			clearTimeout( debounceTimeout.current );
 		}
-		debounceTimeout.current = setTimeout( calculate, 50 );
+		debounceTimeout.current = setTimeout( calculate, DEBOUNCE_DELAY );
 		return () => {
 			if ( debounceTimeout.current ) {
 				clearTimeout( debounceTimeout.current );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Related to STU-766

## Proposed Changes

- Dynamic display of blueprints category based on available width.

<img width="1648" height="1442" alt="image" src="https://github.com/user-attachments/assets/2be82aba-f571-4e21-8e5a-e33f0562c8f8" />

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run Studio
- Click on "Add a site" -> "Start from a blueprint"
- Increase/decrease window's width
- Assert that the number of categories displays adjust, using the existing width

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
