### PR TITLE
Remove --path option from studio sites list commands

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -51,6 +51,9 @@ async function main() {
 			previewYargs.demandCommand( 1, __( 'You must provide a valid command' ) );
 		} )
 		.command( 'sites', __( 'Manage local sites' ), ( sitesYargs ) => {
+			sitesYargs.option( 'path', {
+				hidden: true,
+			} );
 			registerSitesListCommand( sitesYargs );
 			sitesYargs.demandCommand( 1, __( 'You must provide a valid command' ) );
 		} )


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- https://github.com/Automattic/studio/pull/1742

## Proposed Changes

- I suggest removing the `--path` option from the `studio sites` group of commands.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run `npm run cli:build`
- Run `node ./dist/cli/main.js sites list --help`
- Observe the `--path` parameter option is not offered as a possibility
- Run node ./dist/cli/main.js sites
- Observe the `--path` parameter option is not offered as a possibility
- Run `node dist/cli/main.js preview --help`
- Observe the `--path` parameter is still offered as an option: `--path     Path to the WordPress files   [string] [default: Current directory]`

| Before | After |
|--------|--------|
| <img width="1208" height="778" alt="studio-cli-paths-before" src="https://github.com/user-attachments/assets/81993813-42aa-4dcf-aab5-a08ae3599a16" /> | <img width="1226" height="750" alt="studio-cli-paths-after" src="https://github.com/user-attachments/assets/df1b19bf-4dd4-494f-af6d-f786e211b68b" /> |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
