### PR TITLE
Add environment feature flag for CLI V2

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -50,15 +50,18 @@ async function main() {
 			registerUpdateCommand( previewYargs );
 			previewYargs.demandCommand( 1, __( 'You must provide a valid command' ) );
 		} )
-		.command( 'site', __( 'Manage local sites' ), ( sitesYargs ) => {
+		.demandCommand( 1, __( 'You must provide a valid command' ) )
+		.strict();
+
+	if ( process.env.ENABLE_CLI_V2 === 'true' ) {
+		studioArgv.command( 'site', __( 'Manage local sites' ), ( sitesYargs ) => {
 			sitesYargs.option( 'path', {
 				hidden: true,
 			} );
 			registerSiteListCommand( sitesYargs );
 			sitesYargs.demandCommand( 1, __( 'You must provide a valid command' ) );
-		} )
-		.demandCommand( 1, __( 'You must provide a valid command' ) )
-		.strict();
+		} );
+	}
 
 	await studioArgv.argv;
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Add feature flag to merge https://github.com/Automattic/studio/pull/1742

## Proposed Changes

- Add `ENABLE_CLI_V2` environment feature flag where new commands will be added.
- This PR doesn't add the feature flag in the UI. If/when needed it can be added in [`feature-flags.ts`](https://github.com/Automattic/studio/blob/e698d509b0e97fdc2e6462a4c75c57dfc639ce9d/src/lib/feature-flags.ts#L8-L15) as we usually do.
- To execute the new commands developers will need to run `ENABLE_CLI_V2=true node dist/cli/main.js site list` or export that environment variable in your system. `~/.bashrc`, `~/.zshrc` ...

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run `npm run cli:build`
- Run `node dist/cli/main.js site list`
- Observe the error output: `Unknown arguments: site, list`
- Run `ENABLE_CLI_V2=true node dist/cli/main.js site list`
- Observe that the list of sites is displayed successfully.


<img width="2522" height="864" alt="Screenshot 2025-09-11 at 12 22 24" src="https://github.com/user-attachments/assets/9574e521-b3ec-491f-a4e7-0ad898fde723" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
