### PR TITLE
Remove WordPress components override that fixes font size

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -299,10 +299,3 @@ blockquote {
 .sync-dialog-wrapper .components-modal__header {
 	border-bottom-color: #ddd;
 }
-
-/* Fix the font size of the select control in the smaller viewport */
-@media (max-width: 782px) {
-    .components-base-control .components-base-control__field .components-select-control__input {
-        font-size: 13px;
-    }
-}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-609

## Proposed Changes

I'm proposing to remove code added in https://github.com/Automattic/studio/pull/1533 as the issue is now fixed in wordpress/components package.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Start Studio
2. Open Preferences
3. Confirm font doesn't change for smallest window size

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
