### PR TITLE
Log out the user when the token is invalid

### DIFF
--- a/src/components/auth-provider.tsx
+++ b/src/components/auth-provider.tsx
@@ -198,12 +198,12 @@ function createWpcomClient(
 
 	return Object.assign( wpcom, {
 		request: function ( params: WpcomParams, callback: unknown ) {
-			const wrappedCallback = ( err: unknown, response: unknown ) => {
+			const wrappedCallback = ( err: unknown, response: unknown, headers: unknown ) => {
 				if ( err ) {
 					void handleInvalidTokenError( err );
 				}
 				if ( typeof callback === 'function' ) {
-					callback( err, response );
+					callback( err, response, headers );
 				}
 			};
 

--- a/src/components/auth-provider.tsx
+++ b/src/components/auth-provider.tsx
@@ -164,13 +164,17 @@ function createWpcomClient(
 ): WPCOM {
 	const wpcom = new WPCOM( token );
 
+	let isAuthErrorDialogOpen = false;
 	const handleInvalidTokenError = async ( response: unknown ) => {
-		if ( isInvalidTokenError( response ) && onInvalidToken ) {
-			getIpcApi().showErrorMessageBox( {
-				title: 'Session Expired',
-				message: 'Your session has expired. Please log in again.',
-			} );
+		if ( isInvalidTokenError( response ) && onInvalidToken && ! isAuthErrorDialogOpen ) {
+			isAuthErrorDialogOpen = true;
 			await onInvalidToken();
+			await getIpcApi().showMessageBox( {
+				type: 'error',
+				message: 'Session Expired',
+				detail: 'Your session has expired. Please log in again.',
+			} );
+			isAuthErrorDialogOpen = false;
 		}
 	};
 

--- a/src/components/auth-provider.tsx
+++ b/src/components/auth-provider.tsx
@@ -5,6 +5,7 @@ import WPCOM from 'wpcom';
 import { useIpcListener } from 'src/hooks/use-ipc-listener';
 import { useOffline } from 'src/hooks/use-offline';
 import { getIpcApi } from 'src/lib/get-ipc-api';
+import { isInvalidTokenError } from 'src/lib/is-invalid-oauth-token-error';
 import { useI18nLocale } from 'src/stores';
 import { setWpcomClient } from 'src/stores/wpcom-api';
 
@@ -44,6 +45,20 @@ const AuthProvider: React.FC< AuthProviderProps > = ( { children } ) => {
 
 	const authenticate = useCallback( () => getIpcApi().authenticate(), [] );
 
+	const handleInvalidToken = useCallback( async () => {
+		try {
+			void getIpcApi().logRendererMessage( 'info', 'Detected invalid token. Logging out.' );
+			await getIpcApi().clearAuthenticationToken();
+			setIsAuthenticated( false );
+			setClient( undefined );
+			setWpcomClient( undefined );
+			setUser( undefined );
+		} catch ( err ) {
+			console.error( 'Failed to handle invalid token:', err );
+			Sentry.captureException( err );
+		}
+	}, [] );
+
 	useIpcListener( 'auth-updated', ( _event, payload ) => {
 		if ( 'error' in payload ) {
 			getIpcApi().showErrorMessageBox( {
@@ -54,7 +69,7 @@ const AuthProvider: React.FC< AuthProviderProps > = ( { children } ) => {
 		}
 
 		const { token } = payload;
-		const newClient = createWpcomClient( token.accessToken, locale );
+		const newClient = createWpcomClient( token.accessToken, locale, handleInvalidToken );
 
 		setIsAuthenticated( true );
 		setClient( newClient );
@@ -109,7 +124,7 @@ const AuthProvider: React.FC< AuthProviderProps > = ( { children } ) => {
 					return;
 				}
 
-				const newClient = createWpcomClient( token.accessToken, locale );
+				const newClient = createWpcomClient( token.accessToken, locale, handleInvalidToken );
 
 				setIsAuthenticated( true );
 				setClient( newClient );
@@ -125,7 +140,7 @@ const AuthProvider: React.FC< AuthProviderProps > = ( { children } ) => {
 			}
 		}
 		void run();
-	}, [ locale ] );
+	}, [ locale, handleInvalidToken ] );
 
 	// Memoize the context value to avoid unnecessary renders
 	const contextValue: AuthContextType = useMemo(
@@ -142,17 +157,27 @@ const AuthProvider: React.FC< AuthProviderProps > = ( { children } ) => {
 	return <AuthContext.Provider value={ contextValue }>{ children }</AuthContext.Provider>;
 };
 
-function createWpcomClient( token?: string, locale?: string ): WPCOM {
+function createWpcomClient(
+	token?: string,
+	locale?: string,
+	onInvalidToken?: () => Promise< void >
+): WPCOM {
 	const wpcom = new WPCOM( token );
 
-	if ( ! locale || locale === 'en' ) {
-		return wpcom;
-	}
+	const handleInvalidTokenError = async ( response: unknown ) => {
+		if ( isInvalidTokenError( response ) && onInvalidToken ) {
+			getIpcApi().showErrorMessageBox( {
+				title: 'Session Expired',
+				message: 'Your session has expired. Please log in again.',
+			} );
+			await onInvalidToken();
+		}
+	};
 
 	const originalRequestHandler = wpcom.request.bind( wpcom );
 
-	return Object.assign( wpcom, {
-		request: function ( params: WpcomParams, callback: unknown ) {
+	const addLocaleToParams = ( params: WpcomParams ) => {
+		if ( locale && locale !== 'en' ) {
 			const queryParams = new URLSearchParams(
 				'query' in params && typeof params.query === 'string' ? params.query : ''
 			);
@@ -163,8 +188,22 @@ function createWpcomClient( token?: string, locale?: string ): WPCOM {
 			Object.assign( params, {
 				query: queryParams.toString(),
 			} );
+		}
+		return params;
+	};
 
-			return originalRequestHandler( params, callback );
+	return Object.assign( wpcom, {
+		request: function ( params: WpcomParams, callback: unknown ) {
+			const wrappedCallback = ( err: unknown, response: unknown ) => {
+				if ( err ) {
+					void handleInvalidTokenError( err );
+				}
+				if ( typeof callback === 'function' ) {
+					callback( err, response );
+				}
+			};
+
+			return originalRequestHandler( addLocaleToParams( params ), wrappedCallback );
 		},
 	} );
 }

--- a/src/lib/is-invalid-oauth-token-error.ts
+++ b/src/lib/is-invalid-oauth-token-error.ts
@@ -1,0 +1,12 @@
+export interface InvalidTokenError {
+	error: 'invalid_token';
+}
+
+export function isInvalidTokenError( response: unknown ): response is InvalidTokenError {
+	return (
+		response !== null &&
+		typeof response === 'object' &&
+		'error' in response &&
+		response.error === 'invalid_token'
+	);
+}

--- a/src/lib/tests/is-invalid-oauth-token-error.test.ts
+++ b/src/lib/tests/is-invalid-oauth-token-error.test.ts
@@ -1,0 +1,58 @@
+import { isInvalidTokenError } from '../is-invalid-oauth-token-error';
+
+describe( 'isInvalidTokenError', () => {
+	describe( 'valid invalid token errors', () => {
+		it( 'should return true for invalid token error with additional fields', () => {
+			const response = {
+				error: 'invalid_token',
+				message: 'The OAuth2 token is invalid.',
+				code: 401,
+			};
+
+			expect( isInvalidTokenError( response ) ).toBe( true );
+		} );
+
+		it( 'should return true for invalid token error with no additional fields', () => {
+			const response = {
+				error: 'invalid_token',
+			};
+
+			expect( isInvalidTokenError( response ) ).toBe( true );
+		} );
+	} );
+
+	describe( 'invalid responses', () => {
+		it( 'should return false for different error types', () => {
+			const response = {
+				error: 'access_denied',
+				message: 'Access denied.',
+			};
+
+			expect( isInvalidTokenError( response ) ).toBe( false );
+		} );
+
+		it( 'should return false for empty error field', () => {
+			const response = {
+				error: '',
+			};
+
+			expect( isInvalidTokenError( response ) ).toBe( false );
+		} );
+
+		it( 'should return false for numeric error field', () => {
+			const response = {
+				error: 401,
+			};
+
+			expect( isInvalidTokenError( response ) ).toBe( false );
+		} );
+
+		it( 'should return false for boolean error field', () => {
+			const response = {
+				error: true,
+			};
+
+			expect( isInvalidTokenError( response ) ).toBe( false );
+		} );
+	} );
+} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-669

## Proposed Changes

- Check every request and logout the user when the token is invalid

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Log in with your WordPress.com account.
- Close Studio.
- Modify the `~/Library/Application Support/Studio/appdata-v1.json` file and change the accessToken text to make it invalid
- Open Studio.
- Observe a dialog that appears.
- Click OK.
- Observe that you are logged out.
- Log in again with your WordPress.com account.
- Observe that you have successfully logged in and can see the list of sites, create a preview site, or talk to the assistant.



https://github.com/user-attachments/assets/5b409277-287e-45b6-867f-fe9dbe4bd530

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
