### PR TITLE
Update SQLite plugin to 2.2.9

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -71,7 +71,7 @@ export const WP_CLI_IMPORT_EXPORT_RESPONSE_TIMEOUT =
 	WP_CLI_IMPORT_EXPORT_RESPONSE_TIMEOUT_IN_HRS * 60 * 60 * 1000; // 6hr
 
 // SQLite
-export const SQLITE_DATABASE_INTEGRATION_VERSION = 'v2.2.6';
+export const SQLITE_DATABASE_INTEGRATION_VERSION = 'v2.2.8';
 
 export const SQLITE_DATABASE_INTEGRATION_RELEASE_URL = `https://github.com/WordPress/sqlite-database-integration/archive/refs/tags/${ SQLITE_DATABASE_INTEGRATION_VERSION }.zip`;
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -71,7 +71,7 @@ export const WP_CLI_IMPORT_EXPORT_RESPONSE_TIMEOUT =
 	WP_CLI_IMPORT_EXPORT_RESPONSE_TIMEOUT_IN_HRS * 60 * 60 * 1000; // 6hr
 
 // SQLite
-export const SQLITE_DATABASE_INTEGRATION_VERSION = 'v2.2.8';
+export const SQLITE_DATABASE_INTEGRATION_VERSION = 'v2.2.9';
 
 export const SQLITE_DATABASE_INTEGRATION_RELEASE_URL = `https://github.com/WordPress/sqlite-database-integration/archive/refs/tags/${ SQLITE_DATABASE_INTEGRATION_VERSION }.zip`;
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-585, and STU-735 and STU-698

## Proposed Changes

I propose to update the SQLite plugin to 2.2.8 to fix multiple issues:
- ambiguous column name in ORDER BY which pops out in Everest Forms
- FOREIGN KEY and CHECK constraints not supported that break Woo
- Action Scheduler error on WooCommerce installs, which pops up when importing site with the Gravity Form plugin installed

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Everest Forms

1. Create Studio site
2. Install Everest Forms
3. Navigate to All forms, open form Preview
4. Submit form
5. Navigate to Entries
6. Confirm that the entry is displayed on the grid

### Gravity Form

1. Import Studio site from backup that includes Gravity Forms plugin
2. Confirm the import works fine and the WP Admin includes Gravity Forms plugin

### WooCommerce
1. Create Studio site
2. Install and activate WooCommerce
3. Confirm it works fine

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
