### PR TITLE
Move WordPress config constants into loader mu-plugin

### DIFF
--- a/src/lib/wordpress-provider/playground-cli/mu-plugins.ts
+++ b/src/lib/wordpress-provider/playground-cli/mu-plugins.ts
@@ -31,6 +31,31 @@ async function createLoaderMuPlugin(): Promise< string > {
 		 * Loads Studio-specific mu-plugins from /internal/studio/mu-plugins/
 		 */
 
+		// Define database constants if not already defined. It fixes the error
+		// for imported sites that don't have those defined e.g. WP Cloud and
+		// include plugins which try to access those directly e.g. Mailpoet
+		if ( ! defined( 'DB_NAME' ) ) {
+			define( 'DB_NAME', 'database_name_here' );
+		}
+		if ( ! defined( 'DB_USER' ) ) {
+			define( 'DB_USER', 'username_here' );
+		}
+		if ( ! defined( 'DB_PASSWORD' ) ) {
+			define( 'DB_PASSWORD', 'password_here' );
+		}
+		if ( ! defined( 'DB_HOST' ) ) {
+			define( 'DB_HOST', 'localhost' );
+		}
+		if ( ! defined( 'DB_CHARSET' ) ) {
+			define( 'DB_CHARSET', 'utf8' );
+		}
+		if ( ! defined( 'DB_COLLATE' ) ) {
+			define( 'DB_COLLATE', '' );
+		}
+		if ( ! defined( 'WP_ENVIRONMENT_TYPE' ) ) {
+			define( 'WP_ENVIRONMENT_TYPE', 'local' );
+		}
+
 		$studio_mu_plugins_dir = '/internal/studio/mu-plugins';
 
 		if ( is_dir( $studio_mu_plugins_dir ) ) {
@@ -214,25 +239,6 @@ function getStandardMuPlugins( options: Partial< WordPressServerOptions > ): MuP
 				return $active;
 			}
 	`,
-	} );
-
-	// WordPress config constants polyfill
-	muPlugins.push( {
-		filename: '0-wp-config-constants-polyfill.php',
-		content: `<?php
-		// Define database constants if not already defined. It fixes the error
-		// for imported sites that don't have those defined e.g. WP Cloud and
-		// include plugins which try to access those directly e.g. Mailpoet
-		if (!defined('DB_NAME')) define('DB_NAME', 'database_name_here');
-		if (!defined('DB_USER')) define('DB_USER', 'username_here');
-		if (!defined('DB_PASSWORD')) define('DB_PASSWORD', 'password_here');
-		if (!defined('DB_HOST')) define('DB_HOST', 'localhost');
-		if (!defined('DB_CHARSET')) define('DB_CHARSET', 'utf8');
-		if (!defined('DB_COLLATE')) define('DB_COLLATE', '');
-
-		// Set environment type to local if not already defined
-		if (!defined('WP_ENVIRONMENT_TYPE')) define('WP_ENVIRONMENT_TYPE', 'local');
-		`,
 	} );
 
 	// Suppress DNS warnings

--- a/src/lib/wordpress-provider/playground-cli/mu-plugins.ts
+++ b/src/lib/wordpress-provider/playground-cli/mu-plugins.ts
@@ -34,27 +34,13 @@ async function createLoaderMuPlugin(): Promise< string > {
 		// Define database constants if not already defined. It fixes the error
 		// for imported sites that don't have those defined e.g. WP Cloud and
 		// include plugins which try to access those directly e.g. Mailpoet
-		if ( ! defined( 'DB_NAME' ) ) {
-			define( 'DB_NAME', 'database_name_here' );
-		}
-		if ( ! defined( 'DB_USER' ) ) {
-			define( 'DB_USER', 'username_here' );
-		}
-		if ( ! defined( 'DB_PASSWORD' ) ) {
-			define( 'DB_PASSWORD', 'password_here' );
-		}
-		if ( ! defined( 'DB_HOST' ) ) {
-			define( 'DB_HOST', 'localhost' );
-		}
-		if ( ! defined( 'DB_CHARSET' ) ) {
-			define( 'DB_CHARSET', 'utf8' );
-		}
-		if ( ! defined( 'DB_COLLATE' ) ) {
-			define( 'DB_COLLATE', '' );
-		}
-		if ( ! defined( 'WP_ENVIRONMENT_TYPE' ) ) {
-			define( 'WP_ENVIRONMENT_TYPE', 'local' );
-		}
+		if ( ! defined( 'DB_NAME' ) ) define( 'DB_NAME', 'database_name_here' );
+		if ( ! defined( 'DB_USER' ) ) define( 'DB_USER', 'username_here' );
+		if ( ! defined( 'DB_PASSWORD' ) ) define( 'DB_PASSWORD', 'password_here' );
+		if ( ! defined( 'DB_HOST' ) ) define( 'DB_HOST', 'localhost' );
+		if ( ! defined( 'DB_CHARSET' ) ) define( 'DB_CHARSET', 'utf8' );
+		if ( ! defined( 'DB_COLLATE' ) ) define( 'DB_COLLATE', '' );
+		if ( ! defined( 'WP_ENVIRONMENT_TYPE' ) ) define( 'WP_ENVIRONMENT_TYPE', 'local' );
 
 		$studio_mu_plugins_dir = '/internal/studio/mu-plugins';
 

--- a/src/lib/wordpress-provider/playground-cli/mu-plugins.ts
+++ b/src/lib/wordpress-provider/playground-cli/mu-plugins.ts
@@ -40,6 +40,8 @@ async function createLoaderMuPlugin(): Promise< string > {
 		if ( ! defined( 'DB_HOST' ) ) define( 'DB_HOST', 'localhost' );
 		if ( ! defined( 'DB_CHARSET' ) ) define( 'DB_CHARSET', 'utf8' );
 		if ( ! defined( 'DB_COLLATE' ) ) define( 'DB_COLLATE', '' );
+		
+		// Set environment type to local if not already defined
 		if ( ! defined( 'WP_ENVIRONMENT_TYPE' ) ) define( 'WP_ENVIRONMENT_TYPE', 'local' );
 
 		$studio_mu_plugins_dir = '/internal/studio/mu-plugins';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-760.

## Proposed Changes

- move WordPress config constants polyfill into loader mu-plugin to ensure all the requests get the WordPress constants defined

After looking into the issue with @bcotrim today, we noticed that when the related MailPoet code runs, it is already in a different context where the constants are not defined.

Moving the definition to an earlier mu-plugin does not solve the issue. Instead, the definitions need to be set in the mu-plugin loader.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR branch and build the app.
2. Try to reproduce the following issue: STU-760.
  - import a new site using the attached Jetpack backup
  - let the site start
3. The site should run correctly, without any errors.
5. Try to start and access other local sites. There should be no regressions.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
