### PR TITLE
Extend the plan and include other property types returned by the wpcom sites endpoint

### DIFF
--- a/src/hooks/use-fetch-wpcom-sites/index.tsx
+++ b/src/hooks/use-fetch-wpcom-sites/index.tsx
@@ -15,7 +15,10 @@ export const sitesEndpointSiteSchema = z.object( {
 	jetpack: z.boolean().optional(),
 	is_deleted: z.boolean(),
 	hosting_provider_guess: z.string().optional(),
-	environment_type: z.string().nullable().optional(),
+	environment_type: z
+		.enum( [ 'production', 'staging', 'development', 'sandbox', 'local' ] )
+		.nullable()
+		.optional(),
 	is_a8c: z.boolean().optional(),
 	options: z
 		.object( {

--- a/src/hooks/use-fetch-wpcom-sites/index.tsx
+++ b/src/hooks/use-fetch-wpcom-sites/index.tsx
@@ -30,16 +30,16 @@ export const sitesEndpointSiteSchema = z.object( {
 		.optional(),
 	plan: z
 		.object( {
-			expired: z.boolean(),
+			expired: z.boolean().optional(),
 			features: z.object( {
 				active: z.array( z.string() ),
 				available: z.record( z.string(), z.array( z.string() ) ).optional(),
 			} ),
-			is_free: z.boolean(),
-			product_id: z.number(),
+			is_free: z.boolean().optional(),
+			product_id: z.coerce.number(),
 			product_name_short: z.string(),
 			product_slug: z.string(),
-			user_is_owner: z.boolean(),
+			user_is_owner: z.boolean().optional(),
 		} )
 		.optional(),
 } );

--- a/src/modules/sync/lib/environment-utils.ts
+++ b/src/modules/sync/lib/environment-utils.ts
@@ -2,7 +2,7 @@ import { __ } from '@wordpress/i18n';
 import { z } from 'zod';
 import { SyncSite } from 'src/hooks/use-fetch-wpcom-sites/types';
 
-const EnvironmentSchema = z.enum( [ 'production', 'staging', 'development' ] );
+const EnvironmentSchema = z.enum( [ 'production', 'staging', 'development', 'local' ] );
 export type EnvironmentType = z.infer< typeof EnvironmentSchema >;
 
 export const getSiteEnvironment = ( site: SyncSite ): EnvironmentType => {
@@ -18,6 +18,7 @@ export const getEnvironmentLabel = ( type: EnvironmentType ): string => {
 		production: __( 'Production' ),
 		staging: __( 'Staging' ),
 		development: __( 'Development' ),
+		local: __( 'Local' ),
 	};
 	return labels[ type ] || type.charAt( 0 ).toUpperCase() + type.slice( 1 );
 };

--- a/src/modules/sync/lib/environment-utils.ts
+++ b/src/modules/sync/lib/environment-utils.ts
@@ -2,7 +2,7 @@ import { __ } from '@wordpress/i18n';
 import { z } from 'zod';
 import { SyncSite } from 'src/hooks/use-fetch-wpcom-sites/types';
 
-const EnvironmentSchema = z.enum( [ 'production', 'staging', 'development', 'local' ] );
+const EnvironmentSchema = z.enum( [ 'production', 'staging', 'development' ] );
 export type EnvironmentType = z.infer< typeof EnvironmentSchema >;
 
 export const getSiteEnvironment = ( site: SyncSite ): EnvironmentType => {
@@ -18,7 +18,6 @@ export const getEnvironmentLabel = ( type: EnvironmentType ): string => {
 		production: __( 'Production' ),
 		staging: __( 'Staging' ),
 		development: __( 'Development' ),
-		local: __( 'Local' ),
 	};
 	return labels[ type ] || type.charAt( 0 ).toUpperCase() + type.slice( 1 );
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-673 and this [Sentry error](https://a8c.sentry.io/issues/6315200823/?project=4506612776501248).

## Proposed Changes

- Make the wpcom sites type more flexible to reduce the number of errors on Sentry, and make those sites visible to connect to them.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run `npm start`
- Go to the sync tab
- Click on connect a site
- Observe that the modal opens and all your sites are still there



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
