### PR TITLE
Fix Eslint warning when importing cli-table3

### DIFF
--- a/cli/commands/site/list.ts
+++ b/cli/commands/site/list.ts
@@ -1,4 +1,5 @@
 import { __, _n, sprintf } from '@wordpress/i18n';
+// eslint-disable-next-line import/no-named-as-default
 import Table from 'cli-table3';
 import { PreviewCommandLoggerAction as LoggerAction } from 'common/logger-actions';
 import { readAppdata, type SiteData } from 'cli/lib/appdata';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->


## Proposed Changes

- We have a eslint warning when importing Table from `cli-table3`. We followed the same approach in:
https://github.com/Automattic/studio/blob/a4fe0ab401aa7c20534d4cce6903fd9b9e77696d/cli/lib/snapshots.ts#L2-L3

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run `npm run lint`
- Observe no errors or warnings

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
