### PR TITLE
Upgrade Electron Forge lib to 7.9.0 and unlock packager

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -71,13 +71,13 @@
 			"devDependencies": {
 				"@automattic/color-studio": "^4.1.0",
 				"@automattic/wp-babel-makepot": "^1.2.0",
-				"@electron-forge/cli": "^7.8.3",
-				"@electron-forge/maker-deb": "^7.8.3",
-				"@electron-forge/maker-dmg": "^7.8.3",
-				"@electron-forge/maker-squirrel": "^7.8.3",
-				"@electron-forge/maker-zip": "^7.8.3",
-				"@electron-forge/plugin-auto-unpack-natives": "^7.8.3",
-				"@electron-forge/plugin-webpack": "^7.8.3",
+				"@electron-forge/cli": "^7.9.0",
+				"@electron-forge/maker-deb": "^7.9.0",
+				"@electron-forge/maker-dmg": "^7.9.0",
+				"@electron-forge/maker-squirrel": "^7.9.0",
+				"@electron-forge/maker-zip": "^7.9.0",
+				"@electron-forge/plugin-auto-unpack-natives": "^7.9.0",
+				"@electron-forge/plugin-webpack": "^7.9.0",
 				"@playwright/test": "^1.52.0",
 				"@sentry/react": "^7.120.3",
 				"@studio/eslint-plugin": "file:packages/eslint-plugin-studio",
@@ -2560,9 +2560,9 @@
 			}
 		},
 		"node_modules/@electron-forge/cli": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@electron-forge/cli/-/cli-7.8.3.tgz",
-			"integrity": "sha512-BSAjGGfVf0yp3NQhXYmyCw9T//YCQHuktMv4HXfDVfo7AoV6DA1oEhqldI4Q7aHKeRob5+yBkvRRYPiu5ayCPw==",
+			"version": "7.9.0",
+			"resolved": "https://registry.npmjs.org/@electron-forge/cli/-/cli-7.9.0.tgz",
+			"integrity": "sha512-FIs9rV6gN1v8rY73j/dvhQWF8tht035bN2LatY/z99H2KpWr0lhD03MOkIM2lRgrPEqVTExA4JEl9ja9yXBD3Q==",
 			"dev": true,
 			"funding": [
 				{
@@ -2576,10 +2576,12 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"@electron-forge/core": "7.8.3",
-				"@electron-forge/core-utils": "7.8.3",
-				"@electron-forge/shared-types": "7.8.3",
+				"@electron-forge/core": "7.9.0",
+				"@electron-forge/core-utils": "7.9.0",
+				"@electron-forge/shared-types": "7.9.0",
 				"@electron/get": "^3.0.0",
+				"@inquirer/prompts": "^6.0.1",
+				"@listr2/prompt-adapter-inquirer": "^2.0.22",
 				"chalk": "^4.0.0",
 				"commander": "^11.1.0",
 				"debug": "^4.3.1",
@@ -2612,9 +2614,9 @@
 			}
 		},
 		"node_modules/@electron-forge/core": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@electron-forge/core/-/core-7.8.3.tgz",
-			"integrity": "sha512-qX2vi/LP3HcSqSfLfzMeH2ll8SFZQnOk8VN/b3bq6XrBCbrfrSsTYYWakN6mmfalLJcQRm4jCEc6gcyuGO4i6Q==",
+			"version": "7.9.0",
+			"resolved": "https://registry.npmjs.org/@electron-forge/core/-/core-7.9.0.tgz",
+			"integrity": "sha512-S5uFv9sFAVYSO80/K4HZsJL9L2Bs51IxCqR0a2Lk4NdKr9Fpzp6txwuALSJzM1bIpohtqbjmgut49o95wg30ZA==",
 			"dev": true,
 			"funding": [
 				{
@@ -2628,21 +2630,22 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"@electron-forge/core-utils": "7.8.3",
-				"@electron-forge/maker-base": "7.8.3",
-				"@electron-forge/plugin-base": "7.8.3",
-				"@electron-forge/publisher-base": "7.8.3",
-				"@electron-forge/shared-types": "7.8.3",
-				"@electron-forge/template-base": "7.8.3",
-				"@electron-forge/template-vite": "7.8.3",
-				"@electron-forge/template-vite-typescript": "7.8.3",
-				"@electron-forge/template-webpack": "7.8.3",
-				"@electron-forge/template-webpack-typescript": "7.8.3",
-				"@electron-forge/tracer": "7.8.3",
+				"@electron-forge/core-utils": "7.9.0",
+				"@electron-forge/maker-base": "7.9.0",
+				"@electron-forge/plugin-base": "7.9.0",
+				"@electron-forge/publisher-base": "7.9.0",
+				"@electron-forge/shared-types": "7.9.0",
+				"@electron-forge/template-base": "7.9.0",
+				"@electron-forge/template-vite": "7.9.0",
+				"@electron-forge/template-vite-typescript": "7.9.0",
+				"@electron-forge/template-webpack": "7.9.0",
+				"@electron-forge/template-webpack-typescript": "7.9.0",
+				"@electron-forge/tracer": "7.9.0",
 				"@electron/get": "^3.0.0",
 				"@electron/packager": "^18.3.5",
 				"@electron/rebuild": "^3.7.0",
 				"@malept/cross-spawn-promise": "^2.0.0",
+				"@vscode/sudo-prompt": "^9.3.1",
 				"chalk": "^4.0.0",
 				"debug": "^4.3.1",
 				"fast-glob": "^3.2.7",
@@ -2660,7 +2663,6 @@
 				"rechoir": "^0.8.0",
 				"semver": "^7.2.1",
 				"source-map-support": "^0.5.13",
-				"sudo-prompt": "^9.1.1",
 				"username": "^5.1.0"
 			},
 			"engines": {
@@ -2668,13 +2670,13 @@
 			}
 		},
 		"node_modules/@electron-forge/core-utils": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@electron-forge/core-utils/-/core-utils-7.8.3.tgz",
-			"integrity": "sha512-8jhK7AvUKEqDyTMMuRhvS1TkE73YEnHYAxVvkJq35e1KdCwGbGnSRhaEs7OOqRfkKxfepdJ7BMKFSoKFeP+z0Q==",
+			"version": "7.9.0",
+			"resolved": "https://registry.npmjs.org/@electron-forge/core-utils/-/core-utils-7.9.0.tgz",
+			"integrity": "sha512-votOf1+20cUJim0smYZW7OylXrl89JlpuFTgFpn5WFpDfAV6C0iH9202K1sa33v9OQ989JnpWDZtQNQzQHHNtg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@electron-forge/shared-types": "7.8.3",
+				"@electron-forge/shared-types": "7.9.0",
 				"@electron/rebuild": "^3.7.0",
 				"@malept/cross-spawn-promise": "^2.0.0",
 				"chalk": "^4.0.0",
@@ -2729,13 +2731,13 @@
 			}
 		},
 		"node_modules/@electron-forge/maker-base": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@electron-forge/maker-base/-/maker-base-7.8.3.tgz",
-			"integrity": "sha512-WmF66cHdziaK8Asi7IRTLxZjCZ8IqXXHr6IPl4d5oatN6s5RG+HHzG1hiJ7LzlOEntqdSpE8Wh2nB2TmyR4huQ==",
+			"version": "7.9.0",
+			"resolved": "https://registry.npmjs.org/@electron-forge/maker-base/-/maker-base-7.9.0.tgz",
+			"integrity": "sha512-u0jo2kaYRxh/Rai6DyFSGJcNLRVWxiKaGUjMhX1LrKolufUkCxxR4TEmv4Hvl03WTr9pQb06umlIrVMaNb+j9A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@electron-forge/shared-types": "7.8.3",
+				"@electron-forge/shared-types": "7.9.0",
 				"fs-extra": "^10.0.0",
 				"which": "^2.0.2"
 			},
@@ -2759,14 +2761,14 @@
 			}
 		},
 		"node_modules/@electron-forge/maker-deb": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@electron-forge/maker-deb/-/maker-deb-7.8.3.tgz",
-			"integrity": "sha512-GZHJU06LRFJkv1wMc3bjMVzedQhyxnyMZqgDJjE9TIlXXZkN2EqGmKLw/HxwNRA1R8yuQeA4Ih6/dEB4bZTevg==",
+			"version": "7.9.0",
+			"resolved": "https://registry.npmjs.org/@electron-forge/maker-deb/-/maker-deb-7.9.0.tgz",
+			"integrity": "sha512-b1TRMKkeuZ2PTKVsTMWLY+82O6UQVPQ17x5hkWe0lyIxRyCfJr6hD+AqYbvEJ50ncDkvyCtENBT6GnhfbKOGxA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@electron-forge/maker-base": "7.8.3",
-				"@electron-forge/shared-types": "7.8.3"
+				"@electron-forge/maker-base": "7.9.0",
+				"@electron-forge/shared-types": "7.9.0"
 			},
 			"engines": {
 				"node": ">= 16.4.0"
@@ -2776,14 +2778,14 @@
 			}
 		},
 		"node_modules/@electron-forge/maker-dmg": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@electron-forge/maker-dmg/-/maker-dmg-7.8.3.tgz",
-			"integrity": "sha512-N3yKU89D7pC/xPeblSQyBQT1DLKzZMl4V5kla6nc3LIA0oyjz99Gosv8IAj9vFkreQ5QRqpTIlu1ecDL9JY9dQ==",
+			"version": "7.9.0",
+			"resolved": "https://registry.npmjs.org/@electron-forge/maker-dmg/-/maker-dmg-7.9.0.tgz",
+			"integrity": "sha512-W3kqbFuBIqxe/56eZmBv80Fw0RdXIL1DXF0D4O56ILnx7jW/d/j+8fJdie5dcw6nBySDIZbWnxsZiOIV2k2hrg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@electron-forge/maker-base": "7.8.3",
-				"@electron-forge/shared-types": "7.8.3",
+				"@electron-forge/maker-base": "7.9.0",
+				"@electron-forge/shared-types": "7.9.0",
 				"fs-extra": "^10.0.0"
 			},
 			"engines": {
@@ -2808,14 +2810,14 @@
 			}
 		},
 		"node_modules/@electron-forge/maker-squirrel": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@electron-forge/maker-squirrel/-/maker-squirrel-7.8.3.tgz",
-			"integrity": "sha512-6XSEhZMbgfjAaCm8A54pNjn4ghfxJgPu4i7ok3PhP44WOrFPaPivLttpvKRnxRb0PGZstPjPBFcwL1F9S1trjA==",
+			"version": "7.9.0",
+			"resolved": "https://registry.npmjs.org/@electron-forge/maker-squirrel/-/maker-squirrel-7.9.0.tgz",
+			"integrity": "sha512-Ea3MrieWC1KRct1QSZeOBY+GIqHZO5bXj6xCuj81f6nz8JMCsXdgvKosdbfcJMSKu4SYZ52PtoweA6uAACfLww==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@electron-forge/maker-base": "7.8.3",
-				"@electron-forge/shared-types": "7.8.3",
+				"@electron-forge/maker-base": "7.9.0",
+				"@electron-forge/shared-types": "7.9.0",
 				"fs-extra": "^10.0.0"
 			},
 			"engines": {
@@ -2840,14 +2842,14 @@
 			}
 		},
 		"node_modules/@electron-forge/maker-zip": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@electron-forge/maker-zip/-/maker-zip-7.8.3.tgz",
-			"integrity": "sha512-ytao285wKAjKBO6eULzLeqUDP5Zh7beQlGyHjgOMknk7FI0sNy+zGdh3CrCGIhkXSHU/DpukPwRu2SiKvIaIGA==",
+			"version": "7.9.0",
+			"resolved": "https://registry.npmjs.org/@electron-forge/maker-zip/-/maker-zip-7.9.0.tgz",
+			"integrity": "sha512-UGeziReiz8yuDTjliOjvbdyulIHpKAWkDeW3kOcMTUmRcCgrCkBNr+Pp6ih8Q3aBhG+CCd4++oe2rDnnuVvxFw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@electron-forge/maker-base": "7.8.3",
-				"@electron-forge/shared-types": "7.8.3",
+				"@electron-forge/maker-base": "7.9.0",
+				"@electron-forge/shared-types": "7.9.0",
 				"cross-zip": "^4.0.0",
 				"fs-extra": "^10.0.0",
 				"got": "^11.8.5"
@@ -2871,43 +2873,43 @@
 			}
 		},
 		"node_modules/@electron-forge/plugin-auto-unpack-natives": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@electron-forge/plugin-auto-unpack-natives/-/plugin-auto-unpack-natives-7.8.3.tgz",
-			"integrity": "sha512-7tRhySvfdTrBC4PEhAzjzjJGT5dBSU6jhy3XlQ8LJH50jHIT9bioQq6dfn/3iw/VaD1ftGWKx+HlntYCmBhViw==",
+			"version": "7.9.0",
+			"resolved": "https://registry.npmjs.org/@electron-forge/plugin-auto-unpack-natives/-/plugin-auto-unpack-natives-7.9.0.tgz",
+			"integrity": "sha512-PQeTq7Mp2bQkj/fdf+DjnSFKLWyBCSdLqZqNadszA9+2QcxFVv+v2ckTuwkHAdoecVNOdza/VZZIDbVFLhUHkQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@electron-forge/plugin-base": "7.8.3",
-				"@electron-forge/shared-types": "7.8.3"
+				"@electron-forge/plugin-base": "7.9.0",
+				"@electron-forge/shared-types": "7.9.0"
 			},
 			"engines": {
 				"node": ">= 16.4.0"
 			}
 		},
 		"node_modules/@electron-forge/plugin-base": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@electron-forge/plugin-base/-/plugin-base-7.8.3.tgz",
-			"integrity": "sha512-0CzPQlO3BGu5bLCrx2Xqo6B1yoHhA9wG9boZE58ANr8Qma1NQfAWZU3LnMmF3EdWNTX76PxpZeeb3QbPNcxSuA==",
+			"version": "7.9.0",
+			"resolved": "https://registry.npmjs.org/@electron-forge/plugin-base/-/plugin-base-7.9.0.tgz",
+			"integrity": "sha512-2cnShgfes0sqH7A3+54fWhfJEfU++1OC2HE50a4sWtWEDwyWLGbwW7tp9BgSXrvIexO2AGKHQ1pKIjpZYVC0fA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@electron-forge/shared-types": "7.8.3"
+				"@electron-forge/shared-types": "7.9.0"
 			},
 			"engines": {
 				"node": ">= 16.4.0"
 			}
 		},
 		"node_modules/@electron-forge/plugin-webpack": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@electron-forge/plugin-webpack/-/plugin-webpack-7.8.3.tgz",
-			"integrity": "sha512-euFE8zhuBGvuokpLjUbkPWL9AI3vx35so1jmegZ0+cuSY9r6e0xmJdlJ34i7PG0FnK++4wvMamy/zR0gqDVHrA==",
+			"version": "7.9.0",
+			"resolved": "https://registry.npmjs.org/@electron-forge/plugin-webpack/-/plugin-webpack-7.9.0.tgz",
+			"integrity": "sha512-sRLcAYKeTPTRtaTqLU4bzPke3npAe0JmdwGHCT7QMTOdSzfh92ieRMs8e09VymPTHeWF7MplKXRmVSVevZG27g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@electron-forge/core-utils": "7.8.3",
-				"@electron-forge/plugin-base": "7.8.3",
-				"@electron-forge/shared-types": "7.8.3",
-				"@electron-forge/web-multi-logger": "7.8.3",
+				"@electron-forge/core-utils": "7.9.0",
+				"@electron-forge/plugin-base": "7.9.0",
+				"@electron-forge/shared-types": "7.9.0",
+				"@electron-forge/web-multi-logger": "7.9.0",
 				"chalk": "^4.0.0",
 				"debug": "^4.3.1",
 				"fast-glob": "^3.2.7",
@@ -2937,26 +2939,26 @@
 			}
 		},
 		"node_modules/@electron-forge/publisher-base": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@electron-forge/publisher-base/-/publisher-base-7.8.3.tgz",
-			"integrity": "sha512-kurRKVNyLsK2JgmVl88UHu0+qSH+PysMtk/xP0YX5sYNMVxRay8+S1T10tAh6Qom94KwpF3CLYtkebvxb/fq+A==",
+			"version": "7.9.0",
+			"resolved": "https://registry.npmjs.org/@electron-forge/publisher-base/-/publisher-base-7.9.0.tgz",
+			"integrity": "sha512-z3eH4+C++LiDqlKmri04IbSNNWLRYLvc49uNiOgfvnejplLsos720TTbwgruyI3D2fbpmhrVmz9kp9H9YzXdVg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@electron-forge/shared-types": "7.8.3"
+				"@electron-forge/shared-types": "7.9.0"
 			},
 			"engines": {
 				"node": ">= 16.4.0"
 			}
 		},
 		"node_modules/@electron-forge/shared-types": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@electron-forge/shared-types/-/shared-types-7.8.3.tgz",
-			"integrity": "sha512-gkZtD7ALXHPDOthJo1rQYLDNfG09fdDRMWvjEgaXdF3Z69xXFfnOWPNuOkRUODNalMnuuGs6l7jDl+QFQgHlDg==",
+			"version": "7.9.0",
+			"resolved": "https://registry.npmjs.org/@electron-forge/shared-types/-/shared-types-7.9.0.tgz",
+			"integrity": "sha512-6jZF+zq3SYMnweQpgr5fwlSgOd2yOZ5qlfz/CgXyVljiv0e0UThzpOjfTLuwuVgZX7a60xV+h0mg1h82Glu3wQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@electron-forge/tracer": "7.8.3",
+				"@electron-forge/tracer": "7.9.0",
 				"@electron/packager": "^18.3.5",
 				"@electron/rebuild": "^3.7.0",
 				"listr2": "^7.0.2"
@@ -2966,17 +2968,18 @@
 			}
 		},
 		"node_modules/@electron-forge/template-base": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@electron-forge/template-base/-/template-base-7.8.3.tgz",
-			"integrity": "sha512-C0tVODDNKoqhCf7T1HRONJs9DKAmjmk8Of0t8rVjT0ERDzMvLGlBByd785v5lFlKbGERyoaXsYltxPAu92G3aA==",
+			"version": "7.9.0",
+			"resolved": "https://registry.npmjs.org/@electron-forge/template-base/-/template-base-7.9.0.tgz",
+			"integrity": "sha512-DvXdJHh4qP+LBX6xNBlO0nfljvJNTmiQNfLRfSouRdYCWbr5hC7wyWAX803HqwRsVLRZj2oiLYZjmyG3jESp8Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@electron-forge/core-utils": "7.8.3",
-				"@electron-forge/shared-types": "7.8.3",
+				"@electron-forge/core-utils": "7.9.0",
+				"@electron-forge/shared-types": "7.9.0",
 				"@malept/cross-spawn-promise": "^2.0.0",
 				"debug": "^4.3.1",
 				"fs-extra": "^10.0.0",
+				"semver": "^7.2.1",
 				"username": "^5.1.0"
 			},
 			"engines": {
@@ -2999,14 +3002,14 @@
 			}
 		},
 		"node_modules/@electron-forge/template-vite": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@electron-forge/template-vite/-/template-vite-7.8.3.tgz",
-			"integrity": "sha512-tDL5h+UO5iOzdEYNVsSu4zkUVN4RTxti5iXzcBquKd9Kgt/A/M7xHeuKj7g1Ds7Ul/n2XcFvcfgLcRmiXQeVDA==",
+			"version": "7.9.0",
+			"resolved": "https://registry.npmjs.org/@electron-forge/template-vite/-/template-vite-7.9.0.tgz",
+			"integrity": "sha512-m8Fi40XaF7YDJo7YqmfJbkjRRsttN9EEHkmq+McLrDUbln15Ppm59RAwUhizDQzs4enmLcNQPaFllbAg/2t8vQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@electron-forge/shared-types": "7.8.3",
-				"@electron-forge/template-base": "7.8.3",
+				"@electron-forge/shared-types": "7.9.0",
+				"@electron-forge/template-base": "7.9.0",
 				"fs-extra": "^10.0.0"
 			},
 			"engines": {
@@ -3014,14 +3017,14 @@
 			}
 		},
 		"node_modules/@electron-forge/template-vite-typescript": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@electron-forge/template-vite-typescript/-/template-vite-typescript-7.8.3.tgz",
-			"integrity": "sha512-HJjjY9xmlpl0vx10mrXdWn2RYHExfazACxmDNNmGO1eq3eqrQk/3R+NDGyqMJ7ajBsRVbkQNt+wayH7HkRJUjA==",
+			"version": "7.9.0",
+			"resolved": "https://registry.npmjs.org/@electron-forge/template-vite-typescript/-/template-vite-typescript-7.9.0.tgz",
+			"integrity": "sha512-qGK649YnC3iOVrj/hHUu/TXG7Nn/a7QykEOPrCrxROWL7mtw8CMUE+FOVETd+eew7/4ldUNzl+5b9ebP8jHOmg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@electron-forge/shared-types": "7.8.3",
-				"@electron-forge/template-base": "7.8.3",
+				"@electron-forge/shared-types": "7.9.0",
+				"@electron-forge/template-base": "7.9.0",
 				"fs-extra": "^10.0.0"
 			},
 			"engines": {
@@ -3059,14 +3062,14 @@
 			}
 		},
 		"node_modules/@electron-forge/template-webpack": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@electron-forge/template-webpack/-/template-webpack-7.8.3.tgz",
-			"integrity": "sha512-1zkji5px1kDXbigFN5959anCf3HAVBvam3bHh2VejnCScegLQP3JBjAn2Nw2ILWq6ej5JNuA/V99b1dr11hPOw==",
+			"version": "7.9.0",
+			"resolved": "https://registry.npmjs.org/@electron-forge/template-webpack/-/template-webpack-7.9.0.tgz",
+			"integrity": "sha512-ser22QczYGor7N6bnMUwexdWbLMNApr6zpBoT+Xfn6P4Ks67ttzcfkAges7GXHNjXwox4ePYZ3+D7cWQem5C4g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@electron-forge/shared-types": "7.8.3",
-				"@electron-forge/template-base": "7.8.3",
+				"@electron-forge/shared-types": "7.9.0",
+				"@electron-forge/template-base": "7.9.0",
 				"fs-extra": "^10.0.0"
 			},
 			"engines": {
@@ -3074,14 +3077,14 @@
 			}
 		},
 		"node_modules/@electron-forge/template-webpack-typescript": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@electron-forge/template-webpack-typescript/-/template-webpack-typescript-7.8.3.tgz",
-			"integrity": "sha512-Xz3X7YJvot08Xm+0BLIS28GJH+0z9vEN9xYX76SOL4jqDcHH8lRFpNWcE2HsxxxRbCVH+s0etVmACZcWoujUrw==",
+			"version": "7.9.0",
+			"resolved": "https://registry.npmjs.org/@electron-forge/template-webpack-typescript/-/template-webpack-typescript-7.9.0.tgz",
+			"integrity": "sha512-z7PB72sI11LBSPz9w9nwwk0le/lZ3VT8TrLc0NYh4F4LbZ19Z+lxcraaAdf21efvWzodhWx8khAyA8WvkNxVSw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@electron-forge/shared-types": "7.8.3",
-				"@electron-forge/template-base": "7.8.3",
+				"@electron-forge/shared-types": "7.9.0",
+				"@electron-forge/template-base": "7.9.0",
 				"fs-extra": "^10.0.0"
 			},
 			"engines": {
@@ -3119,9 +3122,9 @@
 			}
 		},
 		"node_modules/@electron-forge/tracer": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@electron-forge/tracer/-/tracer-7.8.3.tgz",
-			"integrity": "sha512-YVVDaPEUOvR1z+DDdj8wR/vO9OSlC91wz4/2Iqe9rqQz8sztnnQBClMAZTqu9bkDTFyHrns8j8v7tPVuVS6ULQ==",
+			"version": "7.9.0",
+			"resolved": "https://registry.npmjs.org/@electron-forge/tracer/-/tracer-7.9.0.tgz",
+			"integrity": "sha512-7itsjW1WJQADg7Ly61ggI5CCRt+QDVx3HOZC1w69jMUtnipKyPRCbvTBf1oplsNqbIzZxceXdfex6W53YNehvA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3132,9 +3135,9 @@
 			}
 		},
 		"node_modules/@electron-forge/web-multi-logger": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@electron-forge/web-multi-logger/-/web-multi-logger-7.8.3.tgz",
-			"integrity": "sha512-JgyZGGZX/xhtTOf2TlT1nKjF+eM/hPqRo0IMgA/lig4+zyS7iqV4hIdl843jXBcnYyYgwGNAh55yB8ABHIem3w==",
+			"version": "7.9.0",
+			"resolved": "https://registry.npmjs.org/@electron-forge/web-multi-logger/-/web-multi-logger-7.9.0.tgz",
+			"integrity": "sha512-O1de4CKkSkdVyoB2yynEAvFYFOwbIzm13kX22/SCYLC+M1QFkCr3DG9NwsFn9Yp0Sp3vROR8lv+uM1BiwN7zWA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3410,19 +3413,19 @@
 			}
 		},
 		"node_modules/@electron/packager": {
-			"version": "18.1.3",
-			"resolved": "https://registry.npmjs.org/@electron/packager/-/packager-18.1.3.tgz",
-			"integrity": "sha512-21T5MxUf7DwV07IIes3jO/571mXCjOGVPdmYJFPCVDTimFiHQSW0Oy+OIGQaKBiNIXfnP29KylsCQbmds6O6Iw==",
+			"version": "18.4.4",
+			"resolved": "https://registry.npmjs.org/@electron/packager/-/packager-18.4.4.tgz",
+			"integrity": "sha512-fTUCmgL25WXTcFpM1M72VmFP8w3E4d+KNzWxmTDRpvwkfn/S206MAtM2cy0GF78KS9AwASMOUmlOIzCHeNxcGQ==",
 			"dev": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
-				"@electron/asar": "^3.2.1",
+				"@electron/asar": "^3.2.13",
 				"@electron/get": "^3.0.0",
 				"@electron/notarize": "^2.1.0",
 				"@electron/osx-sign": "^1.0.5",
 				"@electron/universal": "^2.0.1",
 				"@electron/windows-sign": "^1.0.0",
-				"cross-spawn-windows-exe": "^1.2.0",
+				"@malept/cross-spawn-promise": "^2.0.0",
 				"debug": "^4.0.1",
 				"extract-zip": "^2.0.0",
 				"filenamify": "^4.1.0",
@@ -3432,7 +3435,8 @@
 				"junk": "^3.1.0",
 				"parse-author": "^2.0.0",
 				"plist": "^3.0.0",
-				"rcedit": "^4.0.0",
+				"prettier": "^3.4.2",
+				"resedit": "^2.0.0",
 				"resolve": "^1.1.6",
 				"semver": "^7.1.3",
 				"yargs-parser": "^21.1.1"
@@ -3445,6 +3449,22 @@
 			},
 			"funding": {
 				"url": "https://github.com/electron/packager?sponsor=1"
+			}
+		},
+		"node_modules/@electron/packager/node_modules/prettier": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+			"integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"prettier": "bin/prettier.cjs"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/prettier/prettier?sponsor=1"
 			}
 		},
 		"node_modules/@electron/rebuild": {
@@ -3525,9 +3545,9 @@
 			}
 		},
 		"node_modules/@electron/rebuild/node_modules/node-abi": {
-			"version": "3.75.0",
-			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.75.0.tgz",
-			"integrity": "sha512-OhYaY5sDsIka7H7AtijtI9jwGYLyl29eQn/W623DiN/MIv5sUqc4g7BIDThX+gb7di9f6xK02nkp8sdfFWZLTg==",
+			"version": "3.77.0",
+			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.77.0.tgz",
+			"integrity": "sha512-DSmt0OEcLoK4i3NuscSbGjOf3bqiDEutejqENSplMSFA/gmB8mkED9G4pKWnPl7MDU4rSHebKPHeitpDfyH0cQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4052,6 +4072,298 @@
 			"deprecated": "Use @eslint/object-schema instead",
 			"dev": true,
 			"license": "BSD-3-Clause"
+		},
+		"node_modules/@inquirer/checkbox": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-3.0.1.tgz",
+			"integrity": "sha512-0hm2nrToWUdD6/UHnel/UKGdk1//ke5zGUpHIvk5ZWmaKezlGxZkOJXNSWsdxO/rEqTkbB3lNC2J6nBElV2aAQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/core": "^9.2.1",
+				"@inquirer/figures": "^1.0.6",
+				"@inquirer/type": "^2.0.0",
+				"ansi-escapes": "^4.3.2",
+				"yoctocolors-cjs": "^2.1.2"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@inquirer/confirm": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-4.0.1.tgz",
+			"integrity": "sha512-46yL28o2NJ9doViqOy0VDcoTzng7rAb6yPQKU7VDLqkmbCaH4JqK4yk4XqlzNWy9PVC5pG1ZUXPBQv+VqnYs2w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/core": "^9.2.1",
+				"@inquirer/type": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@inquirer/core": {
+			"version": "9.2.1",
+			"resolved": "https://registry.npmjs.org/@inquirer/core/-/core-9.2.1.tgz",
+			"integrity": "sha512-F2VBt7W/mwqEU4bL0RnHNZmC/OxzNx9cOYxHqnXX3MP6ruYvZUZAW9imgN9+h/uBT/oP8Gh888J2OZSbjSeWcg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/figures": "^1.0.6",
+				"@inquirer/type": "^2.0.0",
+				"@types/mute-stream": "^0.0.4",
+				"@types/node": "^22.5.5",
+				"@types/wrap-ansi": "^3.0.0",
+				"ansi-escapes": "^4.3.2",
+				"cli-width": "^4.1.0",
+				"mute-stream": "^1.0.0",
+				"signal-exit": "^4.1.0",
+				"strip-ansi": "^6.0.1",
+				"wrap-ansi": "^6.2.0",
+				"yoctocolors-cjs": "^2.1.2"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@inquirer/core/node_modules/cli-width": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+			"integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">= 12"
+			}
+		},
+		"node_modules/@inquirer/core/node_modules/mute-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz",
+			"integrity": "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@inquirer/core/node_modules/signal-exit": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@inquirer/core/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@inquirer/core/node_modules/wrap-ansi": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+			"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@inquirer/editor": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-3.0.1.tgz",
+			"integrity": "sha512-VA96GPFaSOVudjKFraokEEmUQg/Lub6OXvbIEZU1SDCmBzRkHGhxoFAVaF30nyiB4m5cEbDgiI2QRacXZ2hw9Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/core": "^9.2.1",
+				"@inquirer/type": "^2.0.0",
+				"external-editor": "^3.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@inquirer/expand": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-3.0.1.tgz",
+			"integrity": "sha512-ToG8d6RIbnVpbdPdiN7BCxZGiHOTomOX94C2FaT5KOHupV40tKEDozp12res6cMIfRKrXLJyexAZhWVHgbALSQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/core": "^9.2.1",
+				"@inquirer/type": "^2.0.0",
+				"yoctocolors-cjs": "^2.1.2"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@inquirer/figures": {
+			"version": "1.0.13",
+			"resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.13.tgz",
+			"integrity": "sha512-lGPVU3yO9ZNqA7vTYz26jny41lE7yoQansmqdMLBEfqaGsmdg7V3W9mK9Pvb5IL4EVZ9GnSDGMO/cJXud5dMaw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@inquirer/input": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@inquirer/input/-/input-3.0.1.tgz",
+			"integrity": "sha512-BDuPBmpvi8eMCxqC5iacloWqv+5tQSJlUafYWUe31ow1BVXjW2a5qe3dh4X/Z25Wp22RwvcaLCc2siHobEOfzg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/core": "^9.2.1",
+				"@inquirer/type": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@inquirer/number": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@inquirer/number/-/number-2.0.1.tgz",
+			"integrity": "sha512-QpR8jPhRjSmlr/mD2cw3IR8HRO7lSVOnqUvQa8scv1Lsr3xoAMMworcYW3J13z3ppjBFBD2ef1Ci6AE5Qn8goQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/core": "^9.2.1",
+				"@inquirer/type": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@inquirer/password": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@inquirer/password/-/password-3.0.1.tgz",
+			"integrity": "sha512-haoeEPUisD1NeE2IanLOiFr4wcTXGWrBOyAyPZi1FfLJuXOzNmxCJPgUrGYKVh+Y8hfGJenIfz5Wb/DkE9KkMQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/core": "^9.2.1",
+				"@inquirer/type": "^2.0.0",
+				"ansi-escapes": "^4.3.2"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@inquirer/prompts": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-6.0.1.tgz",
+			"integrity": "sha512-yl43JD/86CIj3Mz5mvvLJqAOfIup7ncxfJ0Btnl0/v5TouVUyeEdcpknfgc+yMevS/48oH9WAkkw93m7otLb/A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/checkbox": "^3.0.1",
+				"@inquirer/confirm": "^4.0.1",
+				"@inquirer/editor": "^3.0.1",
+				"@inquirer/expand": "^3.0.1",
+				"@inquirer/input": "^3.0.1",
+				"@inquirer/number": "^2.0.1",
+				"@inquirer/password": "^3.0.1",
+				"@inquirer/rawlist": "^3.0.1",
+				"@inquirer/search": "^2.0.1",
+				"@inquirer/select": "^3.0.1"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@inquirer/rawlist": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-3.0.1.tgz",
+			"integrity": "sha512-VgRtFIwZInUzTiPLSfDXK5jLrnpkuSOh1ctfaoygKAdPqjcjKYmGh6sCY1pb0aGnCGsmhUxoqLDUAU0ud+lGXQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/core": "^9.2.1",
+				"@inquirer/type": "^2.0.0",
+				"yoctocolors-cjs": "^2.1.2"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@inquirer/search": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@inquirer/search/-/search-2.0.1.tgz",
+			"integrity": "sha512-r5hBKZk3g5MkIzLVoSgE4evypGqtOannnB3PKTG9NRZxyFRKcfzrdxXXPcoJQsxJPzvdSU2Rn7pB7lw0GCmGAg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/core": "^9.2.1",
+				"@inquirer/figures": "^1.0.6",
+				"@inquirer/type": "^2.0.0",
+				"yoctocolors-cjs": "^2.1.2"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@inquirer/select": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@inquirer/select/-/select-3.0.1.tgz",
+			"integrity": "sha512-lUDGUxPhdWMkN/fHy1Lk7pF3nK1fh/gqeyWXmctefhxLYxlDsc7vsPBEpxrfVGDsVdyYJsiJoD4bJ1b623cV1Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/core": "^9.2.1",
+				"@inquirer/figures": "^1.0.6",
+				"@inquirer/type": "^2.0.0",
+				"ansi-escapes": "^4.3.2",
+				"yoctocolors-cjs": "^2.1.2"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@inquirer/type": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@inquirer/type/-/type-2.0.0.tgz",
+			"integrity": "sha512-XvJRx+2KR3YXyYtPUUy+qd9i7p+GO9Ko6VIIpWlBrpWwXDv8WLFeHTxz35CfQFUiBMLXlGHhGzys7lqit9gWag==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"mute-stream": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@inquirer/type/node_modules/mute-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz",
+			"integrity": "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
 		},
 		"node_modules/@isaacs/cliui": {
 			"version": "8.0.2",
@@ -4792,6 +5104,45 @@
 			"resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
 			"integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==",
 			"dev": true
+		},
+		"node_modules/@listr2/prompt-adapter-inquirer": {
+			"version": "2.0.22",
+			"resolved": "https://registry.npmjs.org/@listr2/prompt-adapter-inquirer/-/prompt-adapter-inquirer-2.0.22.tgz",
+			"integrity": "sha512-hV36ZoY+xKL6pYOt1nPNnkciFkn89KZwqLhAFzJvYysAvL5uBQdiADZx/8bIDXIukzzwG0QlPYolgMzQUtKgpQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/type": "^1.5.5"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"peerDependencies": {
+				"@inquirer/prompts": ">= 3 < 8"
+			}
+		},
+		"node_modules/@listr2/prompt-adapter-inquirer/node_modules/@inquirer/type": {
+			"version": "1.5.5",
+			"resolved": "https://registry.npmjs.org/@inquirer/type/-/type-1.5.5.tgz",
+			"integrity": "sha512-MzICLu4yS7V8AA61sANROZ9vT1H3ooca5dSmI1FjZkzq7o/koMsRfQSzRtFo+F3Ao4Sf1C0bpLKejpKB/+j6MA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"mute-stream": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@listr2/prompt-adapter-inquirer/node_modules/mute-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz",
+			"integrity": "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
 		},
 		"node_modules/@malept/cross-spawn-promise": {
 			"version": "2.0.0",
@@ -7623,6 +7974,16 @@
 			"integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
 			"license": "MIT"
 		},
+		"node_modules/@types/mute-stream": {
+			"version": "0.0.4",
+			"resolved": "https://registry.npmjs.org/@types/mute-stream/-/mute-stream-0.0.4.tgz",
+			"integrity": "sha512-CPM9nzrCPPJHQNA9keH9CVkVI+WR5kMa+7XEs5jcGQ0VoAGnLv242w8lIVgwAEfmE4oufJRaTc9PNLQl0ioAow==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
 		"node_modules/@types/mysql": {
 			"version": "2.15.26",
 			"resolved": "https://registry.npmjs.org/@types/mysql/-/mysql-2.15.26.tgz",
@@ -7842,6 +8203,13 @@
 			"version": "1.2.36",
 			"resolved": "https://registry.npmjs.org/@types/winreg/-/winreg-1.2.36.tgz",
 			"integrity": "sha512-DtafHy5A8hbaosXrbr7YdjQZaqVewXmiasRS5J4tYMzt3s1gkh40ixpxgVFfKiQ0JIYetTJABat47v9cpr/sQg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/wrap-ansi": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@types/wrap-ansi/-/wrap-ansi-3.0.0.tgz",
+			"integrity": "sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -9536,9 +9904,9 @@
 			}
 		},
 		"node_modules/@xmldom/xmldom": {
-			"version": "0.8.10",
-			"resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
-			"integrity": "sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==",
+			"version": "0.8.11",
+			"resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
+			"integrity": "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -11865,54 +12233,6 @@
 				"node": ">= 8"
 			}
 		},
-		"node_modules/cross-spawn-windows-exe": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/cross-spawn-windows-exe/-/cross-spawn-windows-exe-1.2.0.tgz",
-			"integrity": "sha512-mkLtJJcYbDCxEG7Js6eUnUNndWjyUZwJ3H7bErmmtOYU/Zb99DyUkpamuIZE0b3bhmJyZ7D90uS6f+CGxRRjOw==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://github.com/sponsors/malept"
-				},
-				{
-					"type": "tidelift",
-					"url": "https://tidelift.com/subscription/pkg/npm-cross-spawn-windows-exe?utm_medium=referral&utm_source=npm_fund"
-				}
-			],
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@malept/cross-spawn-promise": "^1.1.0",
-				"is-wsl": "^2.2.0",
-				"which": "^2.0.2"
-			},
-			"engines": {
-				"node": ">= 10"
-			}
-		},
-		"node_modules/cross-spawn-windows-exe/node_modules/@malept/cross-spawn-promise": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-1.1.1.tgz",
-			"integrity": "sha512-RTBGWL5FWQcg9orDOCcp4LvItNzUPcyEU9bwaeJX0rJ1IQxzucC48Y0/sQLp/g6t99IQgAlGIaesJS+gTn7tVQ==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://github.com/sponsors/malept"
-				},
-				{
-					"type": "tidelift",
-					"url": "https://tidelift.com/subscription/pkg/npm-.malept-cross-spawn-promise?utm_medium=referral&utm_source=npm_fund"
-				}
-			],
-			"license": "Apache-2.0",
-			"dependencies": {
-				"cross-spawn": "^7.0.1"
-			},
-			"engines": {
-				"node": ">= 10"
-			}
-		},
 		"node_modules/cross-zip": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/cross-zip/-/cross-zip-4.0.0.tgz",
@@ -12416,9 +12736,9 @@
 			}
 		},
 		"node_modules/detect-libc": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
-			"integrity": "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.0.tgz",
+			"integrity": "sha512-vEtk+OcP7VBRtQZ1EJ3bdgzSfBjgnEalLTp5zjJrS+2Z1w2KZly4SBdac/WDU3hhsNAZ9E8SC96ME4Ey8MZ7cg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
@@ -21933,6 +22253,21 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/pe-library": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/pe-library/-/pe-library-1.0.1.tgz",
+			"integrity": "sha512-nh39Mo1eGWmZS7y+mK/dQIqg7S1lp38DpRxkyoHf0ZcUs/HDc+yyTjuOtTvSMZHmfSLuSQaX945u05Y2Q6UWZg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14",
+				"npm": ">=7"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/jet2jet"
+			}
+		},
 		"node_modules/pend": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
@@ -22761,19 +23096,6 @@
 				"node": ">= 0.8"
 			}
 		},
-		"node_modules/rcedit": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/rcedit/-/rcedit-4.0.1.tgz",
-			"integrity": "sha512-bZdaQi34krFWhrDn+O53ccBDw0MkAT2Vhu75SqhtvhQu4OPyFM4RoVheyYiVQYdjhUi6EJMVWQ0tR6bCIYVkUg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"cross-spawn-windows-exe": "^1.1.0"
-			},
-			"engines": {
-				"node": ">= 14.0.0"
-			}
-		},
 		"node_modules/re-resizable": {
 			"version": "6.9.11",
 			"resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-6.9.11.tgz",
@@ -23415,6 +23737,24 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
 			"integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
+		},
+		"node_modules/resedit": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/resedit/-/resedit-2.0.3.tgz",
+			"integrity": "sha512-oTeemxwoMuxxTYxXUwjkrOPfngTQehlv0/HoYFNkB4uzsP1Un1A9nI8JQKGOFkxpqkC7qkMs0lUsGrvUlbLNUA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"pe-library": "^1.0.1"
+			},
+			"engines": {
+				"node": ">=14",
+				"npm": ">=7"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/jet2jet"
+			}
 		},
 		"node_modules/reselect": {
 			"version": "5.1.1",
@@ -24902,14 +25242,6 @@
 			"engines": {
 				"node": ">=16 || 14 >=14.17"
 			}
-		},
-		"node_modules/sudo-prompt": {
-			"version": "9.2.1",
-			"resolved": "https://registry.npmjs.org/sudo-prompt/-/sudo-prompt-9.2.1.tgz",
-			"integrity": "sha512-Mu7R0g4ig9TUuGSxJavny5Rv0egCEtpZRNMrZaYS1vxkiIxGiGUwoezU3LazIQ+KE04hTrTfNPgxU5gzi7F5Pw==",
-			"deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/sumchecker": {
 			"version": "3.0.1",
@@ -27533,6 +27865,19 @@
 			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
 			"engines": {
 				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/yoctocolors-cjs": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
+			"integrity": "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -39,13 +39,13 @@
 	"devDependencies": {
 		"@automattic/color-studio": "^4.1.0",
 		"@automattic/wp-babel-makepot": "^1.2.0",
-		"@electron-forge/cli": "^7.8.3",
-		"@electron-forge/maker-deb": "^7.8.3",
-		"@electron-forge/maker-dmg": "^7.8.3",
-		"@electron-forge/maker-squirrel": "^7.8.3",
-		"@electron-forge/maker-zip": "^7.8.3",
-		"@electron-forge/plugin-auto-unpack-natives": "^7.8.3",
-		"@electron-forge/plugin-webpack": "^7.8.3",
+		"@electron-forge/cli": "^7.9.0",
+		"@electron-forge/maker-deb": "^7.9.0",
+		"@electron-forge/maker-dmg": "^7.9.0",
+		"@electron-forge/maker-squirrel": "^7.9.0",
+		"@electron-forge/maker-zip": "^7.9.0",
+		"@electron-forge/plugin-auto-unpack-natives": "^7.9.0",
+		"@electron-forge/plugin-webpack": "^7.9.0",
 		"@playwright/test": "^1.52.0",
 		"@sentry/react": "^7.120.3",
 		"@studio/eslint-plugin": "file:packages/eslint-plugin-studio",
@@ -173,8 +173,5 @@
 	},
 	"optionalDependencies": {
 		"appdmg": "^0.6.6"
-	},
-	"overrides": {
-		"@electron/packager": "18.1.3"
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Relates to #201 and #795

## Proposed Changes

I propose to remove the override for `@electron/packager` that locked it with the 18.1.3 version. We introduced that as higher versions of the packager have a change that prevents versions with alpha characters appearing in the fourth part of the version string from working (#1714). The related issue shows such a version as unsupported:

```
2024.07.0-hourly+56.pro14
```

And we used such a format, which also had the fourth element alphanumeric:

```
1.0.3-dev.f8140f6
```

We can remove the override now as we switched to a simpler version format:

```
1.5.6-dev104
```

As a part of this PR, I upgraded Electron Forge to the latest version.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Check if builds go through.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
