### PR TITLE
Add site: Update stepper to use numbered circles instead of icons

### DIFF
--- a/src/modules/add-site/components/stepper.tsx
+++ b/src/modules/add-site/components/stepper.tsx
@@ -1,12 +1,8 @@
-import {
-	__experimentalHStack as HStack,
-	Icon,
-	__experimentalText as Text,
-} from '@wordpress/components';
-import { published, border } from '@wordpress/icons';
+import { __experimentalHStack as HStack, __experimentalText as Text } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
 import { FormEvent } from 'react';
 import Button from 'src/components/button';
+import { cx } from 'src/lib/cx';
 import { useStepper } from '../hooks/use-stepper';
 
 interface StepperProps {
@@ -47,18 +43,28 @@ export default function Stepper( {
 	return (
 		<div className="flex justify-between items-center p-6">
 			<HStack spacing={ 6 } alignment="left">
-				{ steps.map( ( step ) => {
-					const isCompleted = step.status === 'completed';
+				{ steps.map( ( step, index ) => {
 					const isCurrent = step.status === 'current';
+					const stepNumber = index + 1;
 
 					return (
 						<HStack key={ step.id } spacing={ 2 } alignment="left" className="w-fit">
-							<Icon
-								icon={ isCompleted || isCurrent ? published : border }
-								size={ 24 }
-								className={ isCompleted && ! isCurrent ? 'fill-a8c-blue-50' : 'fill-gray-500' }
-							/>
-							<Text className={ 'text-[13px] text-gray-500' }>{ step.label }</Text>
+							<div
+								className={ cx(
+									`w-6 h-6 rounded-full flex items-center justify-center text-xs font-normal border-2  bg-transparent `,
+									isCurrent ? 'text-gray-900 border-gray-900' : 'border-gray-500 text-gray-500'
+								) }
+							>
+								{ stepNumber }
+							</div>
+							<Text
+								className={ cx(
+									`text-sm`,
+									isCurrent ? 'text-gray-900 font-medium' : 'text-gray-500'
+								) }
+							>
+								{ step.label }
+							</Text>
 						</HStack>
 					);
 				} ) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-796

## Proposed Changes

- Changed Add site stepper from existing icons to numbers

<img width="1012" height="712" alt="image" src="https://github.com/user-attachments/assets/c54f2897-f6b0-47bb-a50a-dbd0f86c8be2" />

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Start Studio
- Open "Add site"
- Navigate through the steps and confirm the new stepper works as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
