### PR TITLE
Remove status code check in screenshot capture flow

### DIFF
--- a/src/screenshot-window.ts
+++ b/src/screenshot-window.ts
@@ -17,28 +17,9 @@ export function createScreenshotWindow( captureUrl: string ) {
 		webPreferences: { session: newSession },
 	} );
 
-	const responseStatusCodePromise = new Promise< void >( ( resolve, reject ) => {
-		newSession.webRequest.onCompleted( ( details ) => {
-			if ( details.resourceType !== 'mainFrame' ) {
-				return;
-			}
-
-			if ( details.statusCode < 200 || details.statusCode >= 400 ) {
-				reject( new Error( `Page returned status code: ${ details.statusCode }` ) );
-			} else {
-				resolve();
-			}
-		} );
-	} );
-
-	responseStatusCodePromise.catch( () => {
-		// This catch is intentionally empty - prevents unhandled rejection warnings
-		// The actual error handling is done in the waitForCapture function
-	} );
-
 	const waitForCapture = async () => {
 		await window.loadURL( captureUrl );
-		await responseStatusCodePromise;
+
 		await window.webContents.insertCSS( `
 			body, html {
 				overflow: hidden;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Resolves STU-658
- Related PR: https://github.com/Automattic/studio/pull/1081/

## Proposed Changes

- Remove status code check in screenshot capture flow to ensure site screenshot is taken even if there's a site error. This will provide clear feedback to the user that the site isn't working. The screenshot will capture the site as-is.


| Before | After |
|--------|--------|
| <img width="2696" height="2144" alt="Markup on 2025-09-16 at 13:44:10" src="https://github.com/user-attachments/assets/5063f620-7156-44bb-ad3a-5e0aa500c888" /> | <img width="2752" height="2136" alt="Markup on 2025-09-16 at 13:40:18" src="https://github.com/user-attachments/assets/d743e01b-5fef-4430-867c-59e28850ab80" /> | 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR branch and build the app with `npm install && npm start`.
2. Create a site and make it crash in some way. For example, you can:
  - open the site's `wp-content/` and remove the following from it: 
    - `database/`
    - `db.php`
    - `mu-plugins/sqlite-database-integration`
3. Restart the site.
4. The error should be captured in the site screenshot in Studio (instead of current `Preview unavailable` message).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
