### PR TITLE
Add site: Start from blueprint - add icon to choose blueprint button

### DIFF
--- a/src/modules/add-site/components/blueprints.tsx
+++ b/src/modules/add-site/components/blueprints.tsx
@@ -363,7 +363,7 @@ export function AddSiteBlueprintSelector( {
 						/>
 						<Button
 							variant="secondary"
-							className="flex-shrink-0 cursor-pointer flex items-center"
+							className="flex-shrink-0 cursor-pointer"
 							onClick={ () => {
 								fileRef.current?.click();
 							} }

--- a/src/modules/add-site/components/blueprints.tsx
+++ b/src/modules/add-site/components/blueprints.tsx
@@ -10,7 +10,7 @@ import {
 import { DataViews, View } from '@wordpress/dataviews';
 import { createInterpolateElement } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
-import { Icon, external } from '@wordpress/icons';
+import { Icon, external, upload } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { useCallback, useRef, useState, useMemo } from 'react';
 import StudioButton from 'src/components/button';
@@ -363,11 +363,12 @@ export function AddSiteBlueprintSelector( {
 						/>
 						<Button
 							variant="secondary"
-							className="flex-shrink-0 cursor-pointer"
+							className="flex-shrink-0 cursor-pointer flex items-center"
 							onClick={ () => {
 								fileRef.current?.click();
 							} }
 						>
+							<Icon icon={ upload } size={ 20 } className="mr-1.5" />
 							{ __( 'Choose blueprint file' ) }
 						</Button>
 					</label>

--- a/src/modules/add-site/components/blueprints.tsx
+++ b/src/modules/add-site/components/blueprints.tsx
@@ -367,8 +367,8 @@ export function AddSiteBlueprintSelector( {
 							onClick={ () => {
 								fileRef.current?.click();
 							} }
+							icon={ upload }
 						>
-							<Icon icon={ upload } size={ 20 } className="me-1.5" />
 							{ __( 'Choose blueprint file' ) }
 						</Button>
 					</label>

--- a/src/modules/add-site/components/blueprints.tsx
+++ b/src/modules/add-site/components/blueprints.tsx
@@ -368,7 +368,7 @@ export function AddSiteBlueprintSelector( {
 								fileRef.current?.click();
 							} }
 						>
-							<Icon icon={ upload } size={ 20 } className="mr-1.5" />
+							<Icon icon={ upload } size={ 20 } className="me-1.5" />
 							{ __( 'Choose blueprint file' ) }
 						</Button>
 					</label>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-787

## Proposed Changes

- Add icon to the "Choose blueprint file"

<img width="1012" height="712" alt="Screenshot 2025-09-16 at 19 28 49" src="https://github.com/user-attachments/assets/e9bd1124-3afe-4d98-ace8-603daeeb1437" />

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Start Studio
- Go to "Add Site" > "Start from blueprint"
- Confirm "Choose blueprint file" button has an icon

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
