### PR TITLE
Blueprints cards: Fix border radius in card image

### DIFF
--- a/src/modules/add-site/components/blueprints.tsx
+++ b/src/modules/add-site/components/blueprints.tsx
@@ -112,7 +112,7 @@ export function AddSiteBlueprintSelector( {
 				render: ( { item }: { item: DataViewBlueprint } ) => (
 					<div
 						className={ cx(
-							'w-full bg-gray-50 h-32 rounded-t-sm overflow-hidden',
+							'w-full bg-gray-50 h-32 rounded-t overflow-hidden',
 							'[@media(min-height:680px)]:h-[175px]',
 							item.isSelected && 'is-selected'
 						) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes p1758139987023379-slack-C06DRMD6VPZ
- Related STU-783

## Proposed Changes

- Fix the border-radius of the image when hovering in the Blueprints card container 

|Before | After|
|-------|------|
|<img width="666" height="356" alt="CleanShot 2025-09-18 at 11 10 02@2x" src="https://github.com/user-attachments/assets/40709102-2f7b-47ed-b140-f877d28a1f6b" />| <img width="666" height="356" alt="CleanShot 2025-09-18 at 11 08 44@2x" src="https://github.com/user-attachments/assets/ea472181-0bfd-474b-be39-91b4610bbfb1" />|

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Apply this branch and run `npm start`
- Add a site and select `Start from a blueprint`
- Hover over the cards and check the top right and left corners
- Check there is no overflow on the corners

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?