### PR TITLE
Optimize playground cli create site workflow

### DIFF
--- a/src/lib/wordpress-provider/playground-cli/playground-cli-provider.ts
+++ b/src/lib/wordpress-provider/playground-cli/playground-cli-provider.ts
@@ -154,7 +154,6 @@ export class PlaygroundCliProvider implements WordPressProvider {
 			}
 
 			if ( ! isOnline ) {
-				console.log( '[DEBUG] setupWordPressSite - Offline mode, WordPress files copied' );
 				return true;
 			}
 			return true;

--- a/src/lib/wordpress-provider/playground-cli/playground-cli-provider.ts
+++ b/src/lib/wordpress-provider/playground-cli/playground-cli-provider.ts
@@ -4,7 +4,7 @@ import { SupportedPHPVersions } from '@php-wasm/universal';
 import { Blueprint } from '@wp-playground/blueprints';
 import { RecommendedPHPVersion } from '@wp-playground/common';
 import fs from 'fs-extra';
-import { recursiveCopyDirectory, pathExists } from 'common/lib/fs-utils';
+import { recursiveCopyDirectory, pathExists, isWordPressDirectory } from 'common/lib/fs-utils';
 import { installSqliteIntegration } from 'src/lib/sqlite-versions';
 import { isValidWordPressVersion } from 'src/lib/wordpress-version-utils';
 import { SiteServer } from 'src/site-server';
@@ -23,7 +23,6 @@ export interface PlaygroundCliOptions {
 	documentRoot: string;
 	autoMount: boolean;
 	skipWordpressSetup: boolean;
-	isSetupMode?: boolean;
 	blueprint?: Blueprint;
 }
 
@@ -56,20 +55,19 @@ export class PlaygroundCliProvider implements WordPressProvider {
 		isWpAutoUpdating?: boolean;
 		absoluteUrl?: string;
 		siteLanguage?: string;
-		isSetupMode?: boolean;
 		wpCliPharPath?: string;
 		blueprint?: Blueprint;
 	} ): Promise< WordPressServerInstance > {
 		const port = options.port;
 		const phpVersion = options.phpVersion || '8.3';
+		const hasWordPress = isWordPressDirectory( options.path );
 
 		const playgroundOptions: PlaygroundCliOptions = {
 			port,
 			phpVersion,
 			documentRoot: options.path,
 			autoMount: true,
-			skipWordpressSetup: true,
-			isSetupMode: options.isSetupMode || false,
+			skipWordpressSetup: hasWordPress,
 			blueprint: options.blueprint,
 		};
 
@@ -112,8 +110,7 @@ export class PlaygroundCliProvider implements WordPressProvider {
 	}
 
 	async setupWordPressSite( server: SiteServer, wpVersion = 'latest' ): Promise< boolean > {
-		const { path, port, adminPassword, name, phpVersion } = server.details;
-		const { blueprint } = server.meta;
+		const { path } = server.details;
 
 		try {
 			const isOnline = net.isOnline();
@@ -157,24 +154,9 @@ export class PlaygroundCliProvider implements WordPressProvider {
 			}
 
 			if ( ! isOnline ) {
+				console.log( '[DEBUG] setupWordPressSite - Offline mode, WordPress files copied' );
 				return true;
 			}
-
-			// Online mode: run the blueprint setup
-			const serverInstance = await this.startServer( {
-				path,
-				port,
-				adminPassword: adminPassword || 'password',
-				siteTitle: name,
-				phpVersion: phpVersion || this.DEFAULT_PHP_VERSION,
-				wpVersion,
-				isWpAutoUpdating: false,
-				isSetupMode: true,
-				blueprint: blueprint?.blueprint,
-			} );
-
-			const serverProcess = this.createServerProcess( serverInstance );
-			await serverProcess.start();
 			return true;
 		} catch ( error ) {
 			console.error( 'Failed to setup WordPress site:', error );

--- a/src/lib/wordpress-provider/playground-cli/playground-server-process-child.ts
+++ b/src/lib/wordpress-provider/playground-cli/playground-server-process-child.ts
@@ -135,7 +135,7 @@ async function startServer(
 		];
 
 		const args: RunCLIArgs = {
-			command: 'run-blueprint',
+			command: 'server',
 			internalCookieStore: true,
 			followSymlinks: true,
 			skipSqliteSetup: true,
@@ -143,12 +143,8 @@ async function startServer(
 			login: true,
 			'mount-before-install': mounts,
 			'site-url': serverOptions.absoluteUrl,
+			skipWordPressSetup: options.skipWordpressSetup,
 		};
-
-		if ( ! options.isSetupMode ) {
-			args.command = 'server';
-			args.skipWordPressSetup = true;
-		}
 
 		if ( options.phpVersion ) {
 			args.php = options.phpVersion as SupportedPHPVersion;

--- a/src/lib/wordpress-provider/playground-cli/playground-server-process.ts
+++ b/src/lib/wordpress-provider/playground-cli/playground-server-process.ts
@@ -14,15 +14,12 @@ export class PlaygroundServerProcess implements WordPressServerProcess {
 	>();
 	private exitPromise: Promise< void > | null = null;
 	private exitResolve: ( () => void ) | null = null;
-	private isSetupMode = false;
 
 	constructor(
 		public url: string,
 		private options: PlaygroundCliOptions,
 		private serverOptions: WordPressServerOptions
-	) {
-		this.isSetupMode = options.isSetupMode || false;
-	}
+	) {}
 
 	async start(): Promise< void > {
 		if ( this.process ) {
@@ -58,17 +55,9 @@ export class PlaygroundServerProcess implements WordPressServerProcess {
 
 		this.process.on( 'exit', () => {
 			this.process = null;
-
-			// In setup mode (run-blueprint), process exit is expected after completion
-			if ( ! this.isSetupMode ) {
-				this.responseHandlers.forEach( ( { reject } ) => {
-					reject( new Error( 'Process exited unexpectedly' ) );
-				} );
-			} else {
-				this.responseHandlers.forEach( ( { resolve } ) => {
-					resolve( undefined );
-				} );
-			}
+			this.responseHandlers.forEach( ( { reject } ) => {
+				reject( new Error( 'Process exited unexpectedly' ) );
+			} );
 			this.responseHandlers.clear();
 
 			if ( this.exitResolve ) {
@@ -142,8 +131,7 @@ export class PlaygroundServerProcess implements WordPressServerProcess {
 			const messageToSend = { id, type, data };
 			this.process!.postMessage( messageToSend );
 
-			// Timeout after 60 seconds for setup mode, 30 seconds otherwise
-			const timeout = this.isSetupMode && type === 'start-server' ? 60000 : 30000;
+			const timeout = type === 'start-server' ? 60000 : 30000;
 			setTimeout( () => {
 				if ( this.responseHandlers.has( id ) ) {
 					this.responseHandlers.delete( id );

--- a/src/lib/wordpress-provider/types.ts
+++ b/src/lib/wordpress-provider/types.ts
@@ -12,6 +12,7 @@ export interface ServerOptions {
 	isWpAutoUpdating?: boolean;
 	absoluteUrl?: string;
 	siteLanguage?: string;
+	blueprint?: unknown;
 }
 
 export interface WordPressServerOptions {

--- a/src/site-server.ts
+++ b/src/site-server.ts
@@ -173,7 +173,7 @@ export class SiteServer {
 		};
 
 		if ( this.meta.blueprint ) {
-			this.meta.blueprint = undefined;
+			delete this.meta.blueprint;
 		}
 	}
 

--- a/src/site-server.ts
+++ b/src/site-server.ts
@@ -20,8 +20,8 @@ import {
 import WpCliProcess, { MessageCanceled, WpCliResult } from 'src/lib/wp-cli-process';
 import { createScreenshotWindow } from 'src/screenshot-window';
 import { getSiteThumbnailPath } from 'src/storage/paths';
-import type { Blueprint } from 'src/stores/wpcom-api';
 import type { WordPressServerProcess } from 'src/lib/wordpress-provider/types';
+import type { Blueprint } from 'src/stores/wpcom-api';
 
 const servers = new Map< string, SiteServer >();
 const deletedServers: string[] = [];

--- a/src/site-server.ts
+++ b/src/site-server.ts
@@ -20,7 +20,7 @@ import {
 import WpCliProcess, { MessageCanceled, WpCliResult } from 'src/lib/wp-cli-process';
 import { createScreenshotWindow } from 'src/screenshot-window';
 import { getSiteThumbnailPath } from 'src/storage/paths';
-import { Blueprint } from 'src/stores/wpcom-api';
+import type { Blueprint } from 'src/stores/wpcom-api';
 import type { WordPressServerProcess } from 'src/lib/wordpress-provider/types';
 
 const servers = new Map< string, SiteServer >();

--- a/src/site-server.ts
+++ b/src/site-server.ts
@@ -20,7 +20,7 @@ import {
 import WpCliProcess, { MessageCanceled, WpCliResult } from 'src/lib/wp-cli-process';
 import { createScreenshotWindow } from 'src/screenshot-window';
 import { getSiteThumbnailPath } from 'src/storage/paths';
-import { Blueprint } from './stores/wpcom-api';
+import { Blueprint } from 'src/stores/wpcom-api';
 import type { WordPressServerProcess } from 'src/lib/wordpress-provider/types';
 
 const servers = new Map< string, SiteServer >();
@@ -141,6 +141,7 @@ export class SiteServer {
 			wpVersion: this.meta.wpVersion,
 			isWpAutoUpdating: this.details.isWpAutoUpdating,
 			absoluteUrl: getAbsoluteUrl( this.details ),
+			blueprint: this.meta.blueprint?.blueprint,
 		} );
 
 		const isPortAvailable = await portFinder.isPortAvailable( this.details.port );
@@ -170,6 +171,10 @@ export class SiteServer {
 			autoStart: true,
 			themeDetails,
 		};
+
+		if ( this.meta.blueprint ) {
+			this.meta.blueprint = undefined;
+		}
 	}
 
 	async updateSiteDetails( site: SiteDetails ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-724

## Proposed Changes

- Optimize the Playground CLI Provider create site workflow, to avoid running the CLI twice
- Start server now checks for a WordPress directory to assert if it should run the Playground CLI WordPress setup or skip it

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Start Studio
- Create a site with and without blueprint
- Validate the Studio logs and confirm the `[playground-cli]` entries only appear once per site created/started

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
