### PR TITLE
blueprints optimize datafiels render

### DIFF
--- a/src/modules/add-site/index.tsx
+++ b/src/modules/add-site/index.tsx
@@ -73,6 +73,8 @@ function NavigationContent( props: NavigationContentProps ) {
 		...createSiteProps
 	} = props;
 
+	const { setSelectedBlueprint, setPhpVersion, setWpVersion } = createSiteProps;
+
 	const handleOptionSelect = useCallback(
 		( option: 'create' | 'blueprint' | 'backup' ) => {
 			if ( option === 'blueprint' ) {
@@ -155,16 +157,16 @@ function NavigationContent( props: NavigationContentProps ) {
 
 				// Apply the preferred versions to the form
 				if ( preferredVersions.php && preferredVersions.php !== 'latest' ) {
-					createSiteProps.setPhpVersion( preferredVersions.php );
+					setPhpVersion( preferredVersions.php );
 				}
 				if ( preferredVersions.wp && preferredVersions.wp !== 'latest' ) {
-					createSiteProps.setWpVersion( preferredVersions.wp );
+					setWpVersion( preferredVersions.wp );
 				}
 			} else {
 				setBlueprintPreferredVersions( undefined );
 			}
 		},
-		[ createSiteProps, setBlueprintPreferredVersions ]
+		[ setBlueprintPreferredVersions, setPhpVersion, setWpVersion ]
 	);
 
 	const handleBlueprintChange = useCallback(
@@ -172,18 +174,18 @@ function NavigationContent( props: NavigationContentProps ) {
 			const blueprint = blueprintsData?.blueprints.find(
 				( b: Blueprint ) => b.slug === blueprintId
 			);
-			createSiteProps.setSelectedBlueprint( blueprint );
+			setSelectedBlueprint( blueprint );
 			applyBlueprintVersions( blueprint );
 		},
-		[ blueprintsData?.blueprints, createSiteProps, applyBlueprintVersions ]
+		[ blueprintsData?.blueprints, setSelectedBlueprint, applyBlueprintVersions ]
 	);
 
 	const handleFileBlueprintSelect = useCallback(
 		( blueprint: Blueprint ) => {
-			createSiteProps.setSelectedBlueprint( blueprint );
+			setSelectedBlueprint( blueprint );
 			applyBlueprintVersions( blueprint );
 		},
-		[ createSiteProps, applyBlueprintVersions ]
+		[ setSelectedBlueprint, applyBlueprintVersions ]
 	);
 
 	return (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- https://github.com/Automattic/studio/pull/1794#pullrequestreview-3253360260

## Proposed Changes

- Adjust some `useCallback` dependencies to prevent unnecessary re-renders

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Start Studio
- Add Site -> Blueprints
- In the blueprint selection page, the thumbnail images should not blink while navigating the screen (selecting different blueprints, selecting from file or remove selected file) 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
