### PR TITLE
Simplify edit site state when called from context menu in the sidebar

### DIFF
--- a/src/components/content-tab-settings.tsx
+++ b/src/components/content-tab-settings.tsx
@@ -16,8 +16,6 @@ import {
 
 interface ContentTabSettingsProps {
 	selectedSite: SiteDetails;
-	isEditModalOpen: boolean;
-	setIsEditModalOpen: ( isEditModalOpen: boolean ) => void;
 }
 
 function SettingsRow( { children, label }: PropsWithChildren< { label: string } > ) {
@@ -31,11 +29,7 @@ function SettingsRow( { children, label }: PropsWithChildren< { label: string } 
 	);
 }
 
-export function ContentTabSettings( {
-	selectedSite,
-	isEditModalOpen,
-	setIsEditModalOpen,
-}: ContentTabSettingsProps ) {
+export function ContentTabSettings( { selectedSite }: ContentTabSettingsProps ) {
 	const dispatch = useAppDispatch();
 	const { __ } = useI18n();
 	const { data: isCertificateTrusted } = useCheckCertificateTrustQuery();
@@ -63,12 +57,7 @@ export function ContentTabSettings( {
 					{ __( 'Site details' ) }
 				</h3>
 				<div className="flex items-center gap-1">
-					<EditSiteDetails
-						currentWpVersion={ wpVersion }
-						onSave={ refreshWpVersion }
-						isEditModalOpen={ isEditModalOpen }
-						setIsEditModalOpen={ setIsEditModalOpen }
-					/>
+					<EditSiteDetails currentWpVersion={ wpVersion } onSave={ refreshWpVersion } />
 					<DropdownMenu
 						icon={ moreVertical }
 						label={ __( 'More options' ) }

--- a/src/components/content-tab-settings.tsx
+++ b/src/components/content-tab-settings.tsx
@@ -1,13 +1,13 @@
 import { DropdownMenu, MenuGroup, Button } from '@wordpress/components';
 import { moreVertical } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
-import { PropsWithChildren, useEffect, useRef } from 'react';
+import { PropsWithChildren } from 'react';
 import { CopyTextButton } from 'src/components/copy-text-button';
 import DeleteSite from 'src/components/delete-site';
 import { useGetWpVersion } from 'src/hooks/use-get-wp-version';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 import { decodePassword } from 'src/lib/passwords';
-import EditSiteDetails, { EditSiteDetailsRef } from 'src/modules/site-settings/edit-site-details';
+import EditSiteDetails from 'src/modules/site-settings/edit-site-details';
 import { useAppDispatch } from 'src/stores';
 import {
 	certificateTrustApi,
@@ -16,8 +16,8 @@ import {
 
 interface ContentTabSettingsProps {
 	selectedSite: SiteDetails;
-	shouldOpenEditModal?: boolean;
-	onEditModalOpened?: () => void;
+	isEditModalOpen: boolean;
+	setIsEditModalOpen: ( isEditModalOpen: boolean ) => void;
 }
 
 function SettingsRow( { children, label }: PropsWithChildren< { label: string } > ) {
@@ -33,13 +33,12 @@ function SettingsRow( { children, label }: PropsWithChildren< { label: string } 
 
 export function ContentTabSettings( {
 	selectedSite,
-	shouldOpenEditModal,
-	onEditModalOpened,
+	isEditModalOpen,
+	setIsEditModalOpen,
 }: ContentTabSettingsProps ) {
 	const dispatch = useAppDispatch();
 	const { __ } = useI18n();
 	const { data: isCertificateTrusted } = useCheckCertificateTrustQuery();
-	const editSiteRef = useRef< EditSiteDetailsRef >( null );
 	const username = 'admin';
 	// Empty strings account for legacy sites lacking a stored password.
 	const storedPassword = decodePassword( selectedSite.adminPassword ?? '' );
@@ -57,16 +56,6 @@ export function ContentTabSettings( {
 		await dispatch( certificateTrustApi.util.invalidateTags( [ 'CertificateTrust' ] ) );
 	};
 
-	// Open edit modal when requested from context menu
-	useEffect( () => {
-		if ( shouldOpenEditModal ) {
-			setTimeout( () => {
-				editSiteRef.current?.openModal();
-				onEditModalOpened?.();
-			}, 100 );
-		}
-	}, [ shouldOpenEditModal, onEditModalOpened ] );
-
 	return (
 		<div className="p-8 ltr:pr-4 rtl:pl-4">
 			<div className="flex justify-between items-center mb-4">
@@ -75,9 +64,10 @@ export function ContentTabSettings( {
 				</h3>
 				<div className="flex items-center gap-1">
 					<EditSiteDetails
-						ref={ editSiteRef }
 						currentWpVersion={ wpVersion }
 						onSave={ refreshWpVersion }
+						isEditModalOpen={ isEditModalOpen }
+						setIsEditModalOpen={ setIsEditModalOpen }
 					/>
 					<DropdownMenu
 						icon={ moreVertical }

--- a/src/components/site-content-tabs.tsx
+++ b/src/components/site-content-tabs.tsx
@@ -21,7 +21,7 @@ export function SiteContentTabs() {
 	const { importState } = useImportExport();
 	const { tabs, selectedTab, setSelectedTab } = useContentTabs();
 	const { __ } = useI18n();
-	const [ shouldOpenEditModal, setShouldOpenEditModal ] = useState( false );
+	const [ isEditModalOpen, setIsEditModalOpen ] = useState( false );
 
 	useEffect( () => {
 		const handleEditSiteRequest = ( event: CustomEvent ) => {
@@ -37,7 +37,7 @@ export function SiteContentTabs() {
 			}
 
 			setSelectedTab( 'settings' );
-			setShouldOpenEditModal( true );
+			setIsEditModalOpen( true );
 		};
 
 		window.addEventListener( 'edit-site-request', handleEditSiteRequest as EventListener );
@@ -90,8 +90,8 @@ export function SiteContentTabs() {
 						{ name === 'settings' && (
 							<ContentTabSettings
 								selectedSite={ selectedSite }
-								shouldOpenEditModal={ shouldOpenEditModal }
-								onEditModalOpened={ () => setShouldOpenEditModal( false ) }
+								isEditModalOpen={ isEditModalOpen }
+								setIsEditModalOpen={ setIsEditModalOpen }
 							/>
 						) }
 						{ name === 'assistant' && <ContentTabAssistant selectedSite={ selectedSite } /> }

--- a/src/components/site-content-tabs.tsx
+++ b/src/components/site-content-tabs.tsx
@@ -1,6 +1,5 @@
 import { TabPanel } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
-import { useEffect, useState } from 'react';
 import { ContentTabAssistant } from 'src/components/content-tab-assistant';
 import { ContentTabImportExport } from 'src/components/content-tab-import-export';
 import { ContentTabOverview } from 'src/components/content-tab-overview';
@@ -17,34 +16,10 @@ import { cx } from 'src/lib/cx';
 import { ContentTabSync } from 'src/modules/sync';
 
 export function SiteContentTabs() {
-	const { selectedSite, data: localSites, setSelectedSiteId } = useSiteDetails();
+	const { selectedSite, data: localSites } = useSiteDetails();
 	const { importState } = useImportExport();
 	const { tabs, selectedTab, setSelectedTab } = useContentTabs();
 	const { __ } = useI18n();
-	const [ isEditModalOpen, setIsEditModalOpen ] = useState( false );
-
-	useEffect( () => {
-		const handleEditSiteRequest = ( event: CustomEvent ) => {
-			const { siteId } = event.detail;
-			const targetSite = localSites.find( ( site ) => site.id === siteId );
-
-			if ( ! targetSite ) {
-				return;
-			}
-
-			if ( siteId !== selectedSite?.id ) {
-				setSelectedSiteId( siteId );
-			}
-
-			setSelectedTab( 'settings' );
-			setIsEditModalOpen( true );
-		};
-
-		window.addEventListener( 'edit-site-request', handleEditSiteRequest as EventListener );
-		return () => {
-			window.removeEventListener( 'edit-site-request', handleEditSiteRequest as EventListener );
-		};
-	}, [ selectedSite?.id, localSites, setSelectedTab, setSelectedSiteId ] );
 
 	if ( ! localSites.length ) {
 		return <EmptyStudio />;
@@ -87,13 +62,7 @@ export function SiteContentTabs() {
 						{ name === 'overview' && <ContentTabOverview selectedSite={ selectedSite } /> }
 						{ name === 'previews' && <ContentTabPreviews selectedSite={ selectedSite } /> }
 						{ name === 'sync' && <ContentTabSync selectedSite={ selectedSite } /> }
-						{ name === 'settings' && (
-							<ContentTabSettings
-								selectedSite={ selectedSite }
-								isEditModalOpen={ isEditModalOpen }
-								setIsEditModalOpen={ setIsEditModalOpen }
-							/>
-						) }
+						{ name === 'settings' && <ContentTabSettings selectedSite={ selectedSite } /> }
 						{ name === 'assistant' && <ContentTabAssistant selectedSite={ selectedSite } /> }
 						{ name === 'import-export' && <ContentTabImportExport selectedSite={ selectedSite } /> }
 					</div>

--- a/src/components/site-menu.tsx
+++ b/src/components/site-menu.tsx
@@ -5,6 +5,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { useEffect } from 'react';
 import { Tooltip } from 'src/components/tooltip';
 import { useSyncSites } from 'src/hooks/sync-sites';
+import { useContentTabs } from 'src/hooks/use-content-tabs';
 import { useImportExport } from 'src/hooks/use-import-export';
 import { useSiteDetails } from 'src/hooks/use-site-details';
 import { isMac, isWindows } from 'src/lib/app-globals';
@@ -113,8 +114,16 @@ function ButtonToRun( { running, id, name }: Pick< SiteDetails, 'running' | 'id'
 	);
 }
 function SiteItem( { site }: { site: SiteDetails } ) {
-	const { selectedSite, setSelectedSiteId, startServer, stopServer, deleteSite, loadingServer } =
-		useSiteDetails();
+	const {
+		selectedSite,
+		setSelectedSiteId,
+		startServer,
+		stopServer,
+		deleteSite,
+		loadingServer,
+		setIsEditModalOpen,
+	} = useSiteDetails();
+	const { setSelectedTab } = useContentTabs();
 	const isSelected = site === selectedSite;
 	const { isSiteImporting, isSiteExporting } = useImportExport();
 	const { isSiteIdPulling } = useSyncSites();
@@ -203,11 +212,11 @@ function SiteItem( { site }: { site: SiteDetails } ) {
 							} )();
 							break;
 						case 'edit-site':
-							window.dispatchEvent(
-								new CustomEvent( 'edit-site-request', {
-									detail: { siteId: site.id },
-								} )
-							);
+							if ( site.id !== selectedSite?.id ) {
+								setSelectedSiteId( site.id );
+							}
+							setSelectedTab( 'settings' );
+							setIsEditModalOpen( true );
 							break;
 						case 'delete': {
 							const DELETE_BUTTON_INDEX = 0;

--- a/src/components/tests/content-tab-settings.test.tsx
+++ b/src/components/tests/content-tab-settings.test.tsx
@@ -267,6 +267,8 @@ describe( 'ContentTabSettings', () => {
 				updateSite,
 				startServer,
 				stopServer,
+				isEditModalOpen: false,
+				setIsEditModalOpen: jest.fn(),
 			} );
 
 			const { rerender } = renderWithProvider(
@@ -274,6 +276,19 @@ describe( 'ContentTabSettings', () => {
 			);
 			expect( screen.getByText( '8.3' ) ).toBeVisible();
 			await user.click( screen.getByRole( 'button', { name: 'Edit site' } ) );
+			( useSiteDetails as jest.Mock ).mockReturnValue( {
+				selectedSite: { ...selectedSite, running: false } as SiteDetails,
+				updateSite,
+				startServer,
+				stopServer,
+				isEditModalOpen: true,
+				setIsEditModalOpen: jest.fn(),
+			} );
+			rerenderWithProvider( rerender, <ContentTabSettings selectedSite={ selectedSite } /> );
+			await waitFor( () => {
+				expect( screen.getByRole( 'dialog' ) ).toBeInTheDocument();
+			} );
+
 			const dialog = screen.getByRole( 'dialog' );
 			expect( dialog ).toBeVisible();
 			await user.selectOptions( within( dialog ).getByLabelText( 'PHP version' ), '8.2' );
@@ -282,6 +297,16 @@ describe( 'ContentTabSettings', () => {
 					name: 'Save',
 				} )
 			);
+
+			( useSiteDetails as jest.Mock ).mockReturnValue( {
+				selectedSite: { ...selectedSite, running: false } as SiteDetails,
+				updateSite,
+				startServer,
+				stopServer,
+				isEditModalOpen: false,
+				setIsEditModalOpen: jest.fn(),
+			} );
+			rerenderWithProvider( rerender, <ContentTabSettings selectedSite={ selectedSite } /> );
 
 			await waitFor( () => {
 				expect( updateSite ).toHaveBeenCalledWith(
@@ -313,6 +338,8 @@ describe( 'ContentTabSettings', () => {
 				updateSite,
 				startServer,
 				stopServer,
+				isEditModalOpen: false,
+				setIsEditModalOpen: jest.fn(),
 			} );
 
 			const { rerender } = renderWithProvider(
@@ -320,6 +347,18 @@ describe( 'ContentTabSettings', () => {
 			);
 			expect( screen.getByText( '8.3' ) ).toBeVisible();
 			await user.click( screen.getByRole( 'button', { name: 'Edit site' } ) );
+			( useSiteDetails as jest.Mock ).mockReturnValue( {
+				selectedSite: { ...selectedSite, running: true } as SiteDetails,
+				updateSite,
+				startServer,
+				stopServer,
+				isEditModalOpen: true,
+				setIsEditModalOpen: jest.fn(),
+			} );
+			rerenderWithProvider( rerender, <ContentTabSettings selectedSite={ selectedSite } /> );
+			await waitFor( () => {
+				expect( screen.getByRole( 'dialog' ) ).toBeInTheDocument();
+			} );
 			const dialog = screen.getByRole( 'dialog' );
 			expect( dialog ).toBeVisible();
 			await user.selectOptions( within( dialog ).getByLabelText( 'PHP version' ), '8.2' );
@@ -328,6 +367,16 @@ describe( 'ContentTabSettings', () => {
 					name: 'Save',
 				} )
 			);
+
+			( useSiteDetails as jest.Mock ).mockReturnValue( {
+				selectedSite: { ...selectedSite, running: true } as SiteDetails,
+				updateSite,
+				startServer,
+				stopServer,
+				isEditModalOpen: false,
+				setIsEditModalOpen: jest.fn(),
+			} );
+			rerenderWithProvider( rerender, <ContentTabSettings selectedSite={ selectedSite } /> );
 
 			await waitFor( () => {
 				expect( updateSite ).toHaveBeenCalledWith(

--- a/src/hooks/use-site-details.tsx
+++ b/src/hooks/use-site-details.tsx
@@ -41,6 +41,8 @@ interface SiteDetailsContext {
 	isDeleting: boolean;
 	uploadingSites: { [ siteId: string ]: boolean };
 	setUploadingSites: React.Dispatch< React.SetStateAction< { [ siteId: string ]: boolean } > >;
+	isEditModalOpen: boolean;
+	setIsEditModalOpen: React.Dispatch< React.SetStateAction< boolean > >;
 }
 
 const defaultContext: SiteDetailsContext = {
@@ -58,6 +60,8 @@ const defaultContext: SiteDetailsContext = {
 	isDeleting: false,
 	uploadingSites: {},
 	setUploadingSites: () => undefined,
+	isEditModalOpen: false,
+	setIsEditModalOpen: () => undefined,
 };
 
 export const siteDetailsContext = createContext< SiteDetailsContext >( defaultContext );
@@ -462,6 +466,8 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 		setData( data.map( ( site ) => ( site.running ? { ...site, running: false } : site ) ) );
 	}, [ data ] );
 
+	const [ isEditModalOpen, setIsEditModalOpen ] = useState( false );
+
 	const context = useMemo(
 		() => ( {
 			selectedSite: data.find( ( site ) => site.id === selectedSiteId ) || firstSite,
@@ -478,6 +484,8 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 			loadingSites,
 			uploadingSites,
 			setUploadingSites,
+			isEditModalOpen,
+			setIsEditModalOpen,
 		} ),
 		[
 			data,
@@ -494,6 +502,8 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 			isDeleting,
 			loadingSites,
 			uploadingSites,
+			isEditModalOpen,
+			setIsEditModalOpen,
 		]
 	);
 

--- a/src/modules/site-settings/edit-site-details.tsx
+++ b/src/modules/site-settings/edit-site-details.tsx
@@ -24,18 +24,12 @@ import {
 type EditSiteDetailsProps = {
 	currentWpVersion: string;
 	onSave: () => void;
-	isEditModalOpen: boolean;
-	setIsEditModalOpen: ( isEditModalOpen: boolean ) => void;
 };
 
-const EditSiteDetails = ( {
-	currentWpVersion,
-	onSave,
-	isEditModalOpen,
-	setIsEditModalOpen,
-}: EditSiteDetailsProps ) => {
+const EditSiteDetails = ( { currentWpVersion, onSave }: EditSiteDetailsProps ) => {
 	const { __ } = useI18n();
-	const { updateSite, selectedSite, stopServer, startServer } = useSiteDetails();
+	const { updateSite, selectedSite, stopServer, startServer, isEditModalOpen, setIsEditModalOpen } =
+		useSiteDetails();
 	const defaultWordPressVersion = useRootSelector( selectDefaultWordPressVersion );
 	const allowedPhpVersions = useRootSelector( selectAllowedPhpVersions );
 	const defaultPhpVersion = useRootSelector( selectDefaultPhpVersion );

--- a/src/modules/site-settings/edit-site-details.tsx
+++ b/src/modules/site-settings/edit-site-details.tsx
@@ -1,13 +1,6 @@
 import { SelectControl } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
-import {
-	FormEvent,
-	useCallback,
-	useEffect,
-	useState,
-	forwardRef,
-	useImperativeHandle,
-} from 'react';
+import { FormEvent, useCallback, useEffect, useState } from 'react';
 import stripAnsi from 'strip-ansi';
 import Button from 'src/components/button';
 import { ErrorInformation } from 'src/components/error-information';
@@ -31,350 +24,337 @@ import {
 type EditSiteDetailsProps = {
 	currentWpVersion: string;
 	onSave: () => void;
+	isEditModalOpen: boolean;
+	setIsEditModalOpen: ( isEditModalOpen: boolean ) => void;
 };
 
-export interface EditSiteDetailsRef {
-	openModal: () => void;
-}
+const EditSiteDetails = ( {
+	currentWpVersion,
+	onSave,
+	isEditModalOpen,
+	setIsEditModalOpen,
+}: EditSiteDetailsProps ) => {
+	const { __ } = useI18n();
+	const { updateSite, selectedSite, stopServer, startServer } = useSiteDetails();
+	const defaultWordPressVersion = useRootSelector( selectDefaultWordPressVersion );
+	const allowedPhpVersions = useRootSelector( selectAllowedPhpVersions );
+	const defaultPhpVersion = useRootSelector( selectDefaultPhpVersion );
+	const [ errorUpdatingWpVersion, setErrorUpdatingWpVersion ] = useState< string | null >( null );
+	const [ isEditingSite, setIsEditingSite ] = useState( false );
+	const [ needsRestart, setNeedsRestart ] = useState( false );
 
-const EditSiteDetails = forwardRef< EditSiteDetailsRef, EditSiteDetailsProps >(
-	( { currentWpVersion, onSave }, ref ) => {
-		const { __ } = useI18n();
-		const { updateSite, selectedSite, stopServer, startServer } = useSiteDetails();
-		const defaultWordPressVersion = useRootSelector( selectDefaultWordPressVersion );
-		const allowedPhpVersions = useRootSelector( selectAllowedPhpVersions );
-		const defaultPhpVersion = useRootSelector( selectDefaultPhpVersion );
-		const [ errorUpdatingWpVersion, setErrorUpdatingWpVersion ] = useState< string | null >( null );
-		const [ showModal, setShowModal ] = useState( false );
-		const [ isEditingSite, setIsEditingSite ] = useState( false );
-		const [ needsRestart, setNeedsRestart ] = useState( false );
+	const { data: isCertificateTrusted } = useCheckCertificateTrustQuery();
+	const closeModal = useCallback( () => {
+		if ( isEditingSite ) {
+			return;
+		}
+		setIsEditModalOpen( false );
+	}, [ isEditingSite, setIsEditModalOpen ] );
+	const [ siteName, setSiteName ] = useState( selectedSite?.name ?? '' );
+	const [ selectedPhpVersion, setSelectedPhpVersion ] = useState< AllowedPHPVersion >(
+		( selectedSite?.phpVersion as AllowedPHPVersion ) ?? defaultPhpVersion
+	);
+	const getEffectiveWpVersion = useCallback(
+		() =>
+			// undefined means that this site was created before the isWpAutoUpdating option was introduced to Studio
+			[ undefined, true ].includes( selectedSite?.isWpAutoUpdating )
+				? defaultWordPressVersion
+				: currentWpVersion,
+		[ selectedSite, currentWpVersion, defaultWordPressVersion ]
+	);
+	const [ selectedWpVersion, setSelectedWpVersion ] = useState( getEffectiveWpVersion() );
+	const [ useCustomDomain, setUseCustomDomain ] = useState( Boolean( selectedSite?.customDomain ) );
+	const [ customDomain, setCustomDomain ] = useState< string | null >(
+		selectedSite?.customDomain ?? null
+	);
+	const [ customDomainError, setCustomDomainError ] = useState( '' );
+	const [ existingDomainNames, setExistingDomainNames ] = useState< string[] >( [] );
+	const [ enableHttps, setEnableHttps ] = useState( false );
 
-		const { data: isCertificateTrusted } = useCheckCertificateTrustQuery();
-		const closeModal = useCallback( () => {
-			if ( isEditingSite ) {
-				return;
-			}
-			setShowModal( false );
-		}, [ isEditingSite ] );
-		const [ siteName, setSiteName ] = useState( selectedSite?.name ?? '' );
-		const [ selectedPhpVersion, setSelectedPhpVersion ] = useState< AllowedPHPVersion >(
-			( selectedSite?.phpVersion as AllowedPHPVersion ) ?? defaultPhpVersion
-		);
-		const getEffectiveWpVersion = useCallback(
-			() =>
-				// undefined means that this site was created before the isWpAutoUpdating option was introduced to Studio
-				[ undefined, true ].includes( selectedSite?.isWpAutoUpdating )
-					? defaultWordPressVersion
-					: currentWpVersion,
-			[ selectedSite, currentWpVersion, defaultWordPressVersion ]
-		);
-		const [ selectedWpVersion, setSelectedWpVersion ] = useState( getEffectiveWpVersion() );
-		const [ useCustomDomain, setUseCustomDomain ] = useState(
-			Boolean( selectedSite?.customDomain )
-		);
-		const [ customDomain, setCustomDomain ] = useState< string | null >(
-			selectedSite?.customDomain ?? null
-		);
-		const [ customDomainError, setCustomDomainError ] = useState( '' );
-		const [ existingDomainNames, setExistingDomainNames ] = useState< string[] >( [] );
-		const [ enableHttps, setEnableHttps ] = useState( false );
-
-		useImperativeHandle(
-			ref,
-			() => ( {
-				openModal: () => setShowModal( true ),
-			} ),
-			[]
-		);
-
-		useEffect( () => {
-			getIpcApi()
-				.getAllCustomDomains()
-				.then( ( domains ) => {
-					const domainsWithoutSelectedSite = domains.filter(
-						( domain ) => domain !== selectedSite?.customDomain
-					);
-					setExistingDomainNames( domainsWithoutSelectedSite );
-				} )
-				.catch( () => {
-					// Do nothing
-				} );
-		}, [ selectedSite?.customDomain ] );
-
-		const generatedDomainName = generateCustomDomainFromSiteName( siteName );
-		const usedCustomDomain = ! useCustomDomain ? customDomain : undefined;
-		const isFormUnchanged =
-			!! selectedSite &&
-			selectedSite.name === siteName &&
-			selectedSite.phpVersion === selectedPhpVersion &&
-			getEffectiveWpVersion() === selectedWpVersion &&
-			Boolean( selectedSite.customDomain ) === useCustomDomain &&
-			usedCustomDomain === customDomain &&
-			!! selectedSite.enableHttps === ( !! usedCustomDomain && enableHttps );
-		const hasValidationErrors =
-			! selectedSite || ! siteName.trim() || ( useCustomDomain && !! customDomainError );
-
-		const resetFormState = useCallback( () => {
-			if ( ! selectedSite ) {
-				return;
-			}
-			setSiteName( selectedSite.name );
-			setSelectedPhpVersion( selectedSite.phpVersion as AllowedPHPVersion );
-			setSelectedWpVersion( getEffectiveWpVersion() );
-			setUseCustomDomain( Boolean( selectedSite.customDomain ) );
-			setCustomDomain( selectedSite.customDomain ?? null );
-			setCustomDomainError( '' );
-			setErrorUpdatingWpVersion( null );
-			setEnableHttps( selectedSite.enableHttps ?? false );
-		}, [ selectedSite, getEffectiveWpVersion ] );
-
-		const onSiteEdit = async ( event: FormEvent ) => {
-			event.preventDefault();
-			if ( ! selectedSite?.id ) {
-				return;
-			}
-			setIsEditingSite( true );
-			setErrorUpdatingWpVersion( null );
-
-			const hasWpVersionChanged = selectedWpVersion !== getEffectiveWpVersion();
-			const hasPhpVersionChanged = selectedPhpVersion !== selectedSite.phpVersion;
-			const needsRestart = selectedSite.running && ( hasWpVersionChanged || hasPhpVersionChanged );
-			setNeedsRestart( needsRestart );
-
-			try {
-				if ( needsRestart ) {
-					await stopServer( selectedSite.id );
-				}
-
-				if ( hasWpVersionChanged ) {
-					try {
-						const zipUrl = getWordPressVersionUrl( selectedWpVersion );
-						const result = await getIpcApi().executeWPCLiInline( {
-							siteId: selectedSite.id,
-							args: `core update ${ zipUrl } --force`,
-							skipPluginsAndThemes: true,
-						} );
-						if ( result.exitCode !== 0 ) {
-							throw new Error( result.stderr );
-						}
-					} catch ( wpError ) {
-						console.error( 'Error changing WordPress version:', wpError );
-						const errorMessage = stripAnsi( ( wpError as Error )?.message );
-						getIpcApi().showErrorMessageBox( {
-							title: __( 'Error changing WordPress version' ),
-							message: errorMessage,
-						} );
-						setSelectedWpVersion( getEffectiveWpVersion() );
-						setIsEditingSite( false );
-						return;
-					}
-				}
-
-				// Determine custom domain setting
-				let usedCustomDomain = useCustomDomain && customDomain ? customDomain : undefined;
-				if ( useCustomDomain && ! customDomain ) {
-					usedCustomDomain = generateCustomDomainFromSiteName( siteName ?? '' );
-				}
-
-				await updateSite( {
-					...selectedSite,
-					name: siteName,
-					phpVersion: selectedPhpVersion,
-					isWpAutoUpdating: selectedWpVersion === defaultWordPressVersion,
-					customDomain: usedCustomDomain,
-					enableHttps: !! usedCustomDomain && enableHttps,
-				} );
-
-				if ( needsRestart ) {
-					await startServer( selectedSite.id );
-				}
-				onSave();
-				closeModal();
-				resetFormState();
-			} catch ( e ) {
-				setErrorUpdatingWpVersion( ( e as Error )?.message );
-			}
-			setIsEditingSite( false );
-			setNeedsRestart( false );
-		};
-
-		const getEditSiteButtonText = () => {
-			if ( ! isEditingSite ) {
-				return __( 'Save' );
-			}
-			return needsRestart ? __( 'Saving and restarting…' ) : __( 'Saving…' );
-		};
-
-		const handleCustomDomainChange = useCallback(
-			( value: string | null ) => {
-				setCustomDomain( value );
-				setCustomDomainError(
-					getDomainNameValidationError( useCustomDomain, value, existingDomainNames )
+	useEffect( () => {
+		getIpcApi()
+			.getAllCustomDomains()
+			.then( ( domains ) => {
+				const domainsWithoutSelectedSite = domains.filter(
+					( domain ) => domain !== selectedSite?.customDomain
 				);
-			},
-			[ useCustomDomain, setCustomDomain, setCustomDomainError, existingDomainNames ]
-		);
+				setExistingDomainNames( domainsWithoutSelectedSite );
+			} )
+			.catch( () => {
+				// Do nothing
+			} );
+	}, [ selectedSite?.customDomain ] );
 
-		return (
-			<>
-				{ showModal && (
-					<Modal
-						size="medium"
-						title={ __( 'Edit site' ) }
-						isDismissible
-						focusOnMount="firstContentElement"
-						onRequestClose={ closeModal }
-						className={ cx(
-							isEditingSite &&
-								'[&_[aria-label="Close"]_svg]:opacity-50 [&_[aria-label="Close"]]:cursor-not-allowed'
-						) }
-					>
-						<form onSubmit={ onSiteEdit }>
-							<div className="flex flex-col">
-								<label className="flex flex-col gap-1.5 leading-4 mb-6">
-									<span className="font-semibold">{ __( 'Site name' ) }</span>
-									<TextControlComponent
+	const generatedDomainName = generateCustomDomainFromSiteName( siteName );
+	const usedCustomDomain = ! useCustomDomain ? customDomain : undefined;
+	const isFormUnchanged =
+		!! selectedSite &&
+		selectedSite.name === siteName &&
+		selectedSite.phpVersion === selectedPhpVersion &&
+		getEffectiveWpVersion() === selectedWpVersion &&
+		Boolean( selectedSite.customDomain ) === useCustomDomain &&
+		usedCustomDomain === customDomain &&
+		!! selectedSite.enableHttps === ( !! usedCustomDomain && enableHttps );
+	const hasValidationErrors =
+		! selectedSite || ! siteName.trim() || ( useCustomDomain && !! customDomainError );
+
+	const resetFormState = useCallback( () => {
+		if ( ! selectedSite ) {
+			return;
+		}
+		setSiteName( selectedSite.name );
+		setSelectedPhpVersion( selectedSite.phpVersion as AllowedPHPVersion );
+		setSelectedWpVersion( getEffectiveWpVersion() );
+		setUseCustomDomain( Boolean( selectedSite.customDomain ) );
+		setCustomDomain( selectedSite.customDomain ?? null );
+		setCustomDomainError( '' );
+		setErrorUpdatingWpVersion( null );
+		setEnableHttps( selectedSite.enableHttps ?? false );
+	}, [ selectedSite, getEffectiveWpVersion ] );
+
+	const onSiteEdit = async ( event: FormEvent ) => {
+		event.preventDefault();
+		if ( ! selectedSite?.id ) {
+			return;
+		}
+		setIsEditingSite( true );
+		setErrorUpdatingWpVersion( null );
+
+		const hasWpVersionChanged = selectedWpVersion !== getEffectiveWpVersion();
+		const hasPhpVersionChanged = selectedPhpVersion !== selectedSite.phpVersion;
+		const needsRestart = selectedSite.running && ( hasWpVersionChanged || hasPhpVersionChanged );
+		setNeedsRestart( needsRestart );
+
+		try {
+			if ( needsRestart ) {
+				await stopServer( selectedSite.id );
+			}
+
+			if ( hasWpVersionChanged ) {
+				try {
+					const zipUrl = getWordPressVersionUrl( selectedWpVersion );
+					const result = await getIpcApi().executeWPCLiInline( {
+						siteId: selectedSite.id,
+						args: `core update ${ zipUrl } --force`,
+						skipPluginsAndThemes: true,
+					} );
+					if ( result.exitCode !== 0 ) {
+						throw new Error( result.stderr );
+					}
+				} catch ( wpError ) {
+					console.error( 'Error changing WordPress version:', wpError );
+					const errorMessage = stripAnsi( ( wpError as Error )?.message );
+					getIpcApi().showErrorMessageBox( {
+						title: __( 'Error changing WordPress version' ),
+						message: errorMessage,
+					} );
+					setSelectedWpVersion( getEffectiveWpVersion() );
+					setIsEditingSite( false );
+					return;
+				}
+			}
+
+			// Determine custom domain setting
+			let usedCustomDomain = useCustomDomain && customDomain ? customDomain : undefined;
+			if ( useCustomDomain && ! customDomain ) {
+				usedCustomDomain = generateCustomDomainFromSiteName( siteName ?? '' );
+			}
+
+			await updateSite( {
+				...selectedSite,
+				name: siteName,
+				phpVersion: selectedPhpVersion,
+				isWpAutoUpdating: selectedWpVersion === defaultWordPressVersion,
+				customDomain: usedCustomDomain,
+				enableHttps: !! usedCustomDomain && enableHttps,
+			} );
+
+			if ( needsRestart ) {
+				await startServer( selectedSite.id );
+			}
+			onSave();
+			closeModal();
+			resetFormState();
+		} catch ( e ) {
+			setErrorUpdatingWpVersion( ( e as Error )?.message );
+		}
+		setIsEditingSite( false );
+		setNeedsRestart( false );
+	};
+
+	const getEditSiteButtonText = () => {
+		if ( ! isEditingSite ) {
+			return __( 'Save' );
+		}
+		return needsRestart ? __( 'Saving and restarting…' ) : __( 'Saving…' );
+	};
+
+	const handleCustomDomainChange = useCallback(
+		( value: string | null ) => {
+			setCustomDomain( value );
+			setCustomDomainError(
+				getDomainNameValidationError( useCustomDomain, value, existingDomainNames )
+			);
+		},
+		[ useCustomDomain, setCustomDomain, setCustomDomainError, existingDomainNames ]
+	);
+
+	return (
+		<>
+			{ isEditModalOpen && (
+				<Modal
+					size="medium"
+					title={ __( 'Edit site' ) }
+					isDismissible
+					focusOnMount="firstContentElement"
+					onRequestClose={ closeModal }
+					className={ cx(
+						isEditingSite &&
+							'[&_[aria-label="Close"]_svg]:opacity-50 [&_[aria-label="Close"]]:cursor-not-allowed'
+					) }
+				>
+					<form onSubmit={ onSiteEdit }>
+						<div className="flex flex-col">
+							<label className="flex flex-col gap-1.5 leading-4 mb-6">
+								<span className="font-semibold">{ __( 'Site name' ) }</span>
+								<TextControlComponent
+									disabled={ isEditingSite }
+									onChange={ setSiteName }
+									value={ siteName }
+								></TextControlComponent>
+							</label>
+
+							<div className="flex flex-row gap-x-6">
+								<label
+									htmlFor="php-version-select"
+									className="flex flex-1 flex-col gap-1.5 leading-4"
+								>
+									<span className="font-semibold">{ __( 'PHP version' ) }</span>
+									<SelectControl
+										id="php-version-select"
 										disabled={ isEditingSite }
-										onChange={ setSiteName }
-										value={ siteName }
-									></TextControlComponent>
+										value={ selectedPhpVersion }
+										options={ allowedPhpVersions.map( ( version ) => ( {
+											label: version,
+											value: version,
+										} ) ) }
+										onChange={ ( version: AllowedPHPVersion ) => setSelectedPhpVersion( version ) }
+										__next40pxDefaultSize
+										__nextHasNoMarginBottom
+									/>
 								</label>
 
-								<div className="flex flex-row gap-x-6">
-									<label
-										htmlFor="php-version-select"
-										className="flex flex-1 flex-col gap-1.5 leading-4"
-									>
-										<span className="font-semibold">{ __( 'PHP version' ) }</span>
-										<SelectControl
-											id="php-version-select"
-											disabled={ isEditingSite }
-											value={ selectedPhpVersion }
-											options={ allowedPhpVersions.map( ( version ) => ( {
-												label: version,
-												value: version,
-											} ) ) }
-											onChange={ ( version: AllowedPHPVersion ) =>
-												setSelectedPhpVersion( version )
-											}
-											__next40pxDefaultSize
-											__nextHasNoMarginBottom
-										/>
-									</label>
+								<WPVersionSelector
+									selectedValue={ selectedWpVersion }
+									onChange={ setSelectedWpVersion }
+									disabled={ isEditingSite }
+									errorMessage={ errorUpdatingWpVersion }
+									extraOptions={ [ { label: currentWpVersion, value: currentWpVersion } ] }
+									fallbackOptions={ [ { label: currentWpVersion, value: currentWpVersion } ] }
+								/>
+							</div>
+							{ errorUpdatingWpVersion && (
+								<ErrorInformation className="mt-2">{ errorUpdatingWpVersion }</ErrorInformation>
+							) }
 
-									<WPVersionSelector
-										selectedValue={ selectedWpVersion }
-										onChange={ setSelectedWpVersion }
+							<div className="flex flex-col gap-2 mt-4">
+								<div className="flex items-center gap-2">
+									<input
+										type="checkbox"
+										id="use-custom-domain"
+										checked={ useCustomDomain }
+										onChange={ ( e ) => setUseCustomDomain( e.target.checked ) }
 										disabled={ isEditingSite }
-										errorMessage={ errorUpdatingWpVersion }
-										extraOptions={ [ { label: currentWpVersion, value: currentWpVersion } ] }
-										fallbackOptions={ [ { label: currentWpVersion, value: currentWpVersion } ] }
 									/>
+									<label htmlFor="use-custom-domain">{ __( 'Use custom domain' ) }</label>
 								</div>
-								{ errorUpdatingWpVersion && (
-									<ErrorInformation className="mt-2">{ errorUpdatingWpVersion }</ErrorInformation>
+
+								{ useCustomDomain && (
+									<div className="flex flex-col gap-2 mt-2">
+										<label htmlFor="custom-domain" className="font-semibold">
+											{ __( 'Domain name' ) }
+										</label>
+										<TextControlComponent
+											id="custom-domain"
+											value={ customDomain ?? generatedDomainName }
+											onChange={ handleCustomDomainChange }
+											disabled={ isEditingSite }
+										/>
+										{ customDomainError && (
+											<ErrorInformation className="mt-1">{ customDomainError }</ErrorInformation>
+										) }
+										<div className="text-a8c-gray-50 text-xs mt-1">
+											{ __( 'Your system password will be required to set up the domain.' ) }
+										</div>
+									</div>
 								) }
 
-								<div className="flex flex-col gap-2 mt-4">
-									<div className="flex items-center gap-2">
+								{ useCustomDomain && (
+									<div className="flex items-center gap-2 mt-4">
 										<input
 											type="checkbox"
-											id="use-custom-domain"
-											checked={ useCustomDomain }
-											onChange={ ( e ) => setUseCustomDomain( e.target.checked ) }
+											id="enable-https"
+											checked={ enableHttps }
+											onChange={ ( e ) => setEnableHttps( e.target.checked ) }
 											disabled={ isEditingSite }
 										/>
-										<label htmlFor="use-custom-domain">{ __( 'Use custom domain' ) }</label>
+										<label htmlFor="enable-https">{ __( 'Enable HTTPS' ) }</label>
 									</div>
+								) }
 
-									{ useCustomDomain && (
-										<div className="flex flex-col gap-2 mt-2">
-											<label htmlFor="custom-domain" className="font-semibold">
-												{ __( 'Domain name' ) }
-											</label>
-											<TextControlComponent
-												id="custom-domain"
-												value={ customDomain ?? generatedDomainName }
-												onChange={ handleCustomDomainChange }
-												disabled={ isEditingSite }
-											/>
-											{ customDomainError && (
-												<ErrorInformation className="mt-1">{ customDomainError }</ErrorInformation>
-											) }
-											<div className="text-a8c-gray-50 text-xs mt-1">
-												{ __( 'Your system password will be required to set up the domain.' ) }
-											</div>
-										</div>
-									) }
-
-									{ useCustomDomain && (
-										<div className="flex items-center gap-2 mt-4">
-											<input
-												type="checkbox"
-												id="enable-https"
-												checked={ enableHttps }
-												onChange={ ( e ) => setEnableHttps( e.target.checked ) }
-												disabled={ isEditingSite }
-											/>
-											<label htmlFor="enable-https">{ __( 'Enable HTTPS' ) }</label>
-										</div>
-									) }
-
-									{ ! isCertificateTrusted && useCustomDomain && (
-										<div className="text-a8c-gray-50 text-xs mt-2">
-											{ __(
-												'You need to manually add the Studio certificate authority to your keychain and trust it.'
-											) }{ ' ' }
-											<Button
-												variant="link"
-												onClick={ () => {
-													getIpcApi().openURL(
-														'https://developer.wordpress.com/docs/developer-tools/studio/ssl-in-studio/'
-													);
-												} }
-											>
-												{ __( 'Learn how' ) }
-												<span aria-label={ __( '(opens in a web browser)' ) }>&#8599;</span>
-											</Button>
-										</div>
-									) }
-								</div>
+								{ ! isCertificateTrusted && useCustomDomain && (
+									<div className="text-a8c-gray-50 text-xs mt-2">
+										{ __(
+											'You need to manually add the Studio certificate authority to your keychain and trust it.'
+										) }{ ' ' }
+										<Button
+											variant="link"
+											onClick={ () => {
+												getIpcApi().openURL(
+													'https://developer.wordpress.com/docs/developer-tools/studio/ssl-in-studio/'
+												);
+											} }
+										>
+											{ __( 'Learn how' ) }
+											<span aria-label={ __( '(opens in a web browser)' ) }>&#8599;</span>
+										</Button>
+									</div>
+								) }
 							</div>
+						</div>
 
-							<div className="flex flex-row justify-end gap-x-5 mt-8">
-								<Button onClick={ closeModal } disabled={ isEditingSite } variant="tertiary">
-									{ __( 'Cancel' ) }
-								</Button>
-								<Button
-									type="submit"
-									variant="primary"
-									isBusy={ isEditingSite }
-									disabled={ isEditingSite || isFormUnchanged || hasValidationErrors }
-								>
-									{ getEditSiteButtonText() }
-								</Button>
-							</div>
-							<div className="components-popover__fallback-container"></div>
-						</form>
-					</Modal>
-				) }
-				<Button
-					disabled={ ! selectedSite }
-					className="shrink-0"
-					onClick={ () => {
-						setShowModal( true );
-						resetFormState();
-					} }
-					label={ __( 'Edit site' ) }
-					variant="secondary"
-				>
-					{ __( 'Edit site' ) }
-				</Button>
-			</>
-		);
-	}
-);
-
+						<div className="flex flex-row justify-end gap-x-5 mt-8">
+							<Button onClick={ closeModal } disabled={ isEditingSite } variant="tertiary">
+								{ __( 'Cancel' ) }
+							</Button>
+							<Button
+								type="submit"
+								variant="primary"
+								isBusy={ isEditingSite }
+								disabled={ isEditingSite || isFormUnchanged || hasValidationErrors }
+							>
+								{ getEditSiteButtonText() }
+							</Button>
+						</div>
+						<div className="components-popover__fallback-container"></div>
+					</form>
+				</Modal>
+			) }
+			<Button
+				disabled={ ! selectedSite }
+				className="shrink-0"
+				onClick={ () => {
+					setIsEditModalOpen( true );
+					resetFormState();
+				} }
+				label={ __( 'Edit site' ) }
+				variant="secondary"
+			>
+				{ __( 'Edit site' ) }
+			</Button>
+		</>
+	);
+};
 EditSiteDetails.displayName = 'EditSiteDetails';
 
 export default EditSiteDetails;

--- a/src/modules/site-settings/tests/edit-site-details.test.tsx
+++ b/src/modules/site-settings/tests/edit-site-details.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import { Provider } from 'react-redux';
 import { useOffline } from 'src/hooks/use-offline';
+import { useSiteDetails } from 'src/hooks/use-site-details';
 import { createTestStore } from 'src/lib/test-utils';
 import EditSiteDetails from 'src/modules/site-settings/edit-site-details';
 import { useGetWordPressVersions } from 'src/stores/wordpress-versions-api';
@@ -18,20 +19,7 @@ jest.mock( 'src/lib/app-globals', () => ( {
 	isWindows: () => false,
 } ) );
 
-jest.mock( 'src/hooks/use-site-details', () => ( {
-	useSiteDetails: () => ( {
-		selectedSite: {
-			id: 'site-123',
-			name: 'Test Site',
-			phpVersion: '8.3',
-			wpVersion: 'latest',
-			running: true,
-		},
-		updateSite: mockUpdateSite,
-		stopServer: mockStopServer,
-		startServer: mockStartServer,
-	} ),
-} ) );
+jest.mock( 'src/hooks/use-site-details' );
 
 jest.mock( 'src/lib/get-ipc-api', () => ( {
 	getIpcApi: () => ( {
@@ -96,6 +84,20 @@ describe( 'EditSiteDetails', () => {
 
 	beforeEach( () => {
 		jest.clearAllMocks();
+		( useSiteDetails as jest.Mock ).mockReturnValue( {
+			selectedSite: {
+				id: 'site-123',
+				name: 'Test Site',
+				phpVersion: '8.3',
+				wpVersion: 'latest',
+				running: true,
+			},
+			updateSite: mockUpdateSite,
+			stopServer: mockStopServer,
+			startServer: mockStartServer,
+			setIsEditModalOpen: jest.fn(),
+			isEditModalOpen: false,
+		} );
 		mockExecuteWPCLiInline.mockResolvedValue( { exitCode: 0 } );
 	} );
 
@@ -116,7 +118,19 @@ describe( 'EditSiteDetails', () => {
 
 		await user.click( screen.getByRole( 'button', { name: 'Edit site' } ) );
 
-		expect( screen.getByRole( 'dialog' ) ).toBeInTheDocument();
+		expect( useSiteDetails().setIsEditModalOpen ).toHaveBeenCalledWith( true );
+
+		( useSiteDetails as jest.Mock ).mockReturnValue( {
+			...useSiteDetails(),
+			isEditModalOpen: true,
+		} );
+
+		renderWithProvider( <EditSiteDetails { ...defaultProps } /> );
+
+		await waitFor( () => {
+			expect( screen.getByRole( 'dialog' ) ).toBeInTheDocument();
+		} );
+
 		expect( screen.getByLabelText( 'Site name' ) ).toHaveValue( 'Test Site' );
 		expect( screen.getByLabelText( 'PHP version' ) ).toHaveValue( '8.3' );
 		expect( screen.getByLabelText( 'WordPress version' ) ).toHaveValue( 'latest' );
@@ -130,31 +144,44 @@ describe( 'EditSiteDetails', () => {
 		const user = userEvent.setup();
 
 		await user.click( screen.getByRole( 'button', { name: 'Edit site' } ) );
-		await user.click( screen.getByRole( 'button', { name: 'Cancel' } ) );
+		expect( useSiteDetails().setIsEditModalOpen ).toHaveBeenCalledWith( true );
 
-		expect( screen.queryByRole( 'dialog' ) ).not.toBeInTheDocument();
+		( useSiteDetails as jest.Mock ).mockReturnValue( {
+			...useSiteDetails(),
+			isEditModalOpen: true,
+		} );
+		renderWithProvider( <EditSiteDetails { ...defaultProps } /> );
+		await waitFor( () => {
+			expect( screen.getByRole( 'dialog' ) ).toBeInTheDocument();
+		} );
+
+		await user.click( screen.getByRole( 'button', { name: 'Cancel' } ) );
+		expect( useSiteDetails().setIsEditModalOpen ).toHaveBeenCalledWith( false );
 	} );
 
 	it( 'should disable the save button when no changes are made', async () => {
+		( useSiteDetails as jest.Mock ).mockReturnValue( {
+			...useSiteDetails(),
+			isEditModalOpen: true,
+		} );
 		renderWithProvider( <EditSiteDetails { ...defaultProps } /> );
 		await waitFor( () => {
 			expect( mockGetAllCustomDomains ).toHaveBeenCalled();
 		} );
-		const user = userEvent.setup();
-
-		await user.click( screen.getByRole( 'button', { name: 'Edit site' } ) );
 
 		expect( screen.getByRole( 'button', { name: 'Save' } ) ).toBeDisabled();
 	} );
 
 	it( 'should enable the save button when site name is changed', async () => {
+		( useSiteDetails as jest.Mock ).mockReturnValue( {
+			...useSiteDetails(),
+			isEditModalOpen: true,
+		} );
 		renderWithProvider( <EditSiteDetails { ...defaultProps } /> );
 		await waitFor( () => {
 			expect( mockGetAllCustomDomains ).toHaveBeenCalled();
 		} );
 		const user = userEvent.setup();
-
-		await user.click( screen.getByRole( 'button', { name: 'Edit site' } ) );
 
 		const siteNameInput = screen.getByLabelText( 'Site name' );
 		await user.clear( siteNameInput );
@@ -164,13 +191,15 @@ describe( 'EditSiteDetails', () => {
 	} );
 
 	it( 'should enable the save button when PHP version is changed', async () => {
+		( useSiteDetails as jest.Mock ).mockReturnValue( {
+			...useSiteDetails(),
+			isEditModalOpen: true,
+		} );
 		renderWithProvider( <EditSiteDetails { ...defaultProps } /> );
 		await waitFor( () => {
 			expect( mockGetAllCustomDomains ).toHaveBeenCalled();
 		} );
 		const user = userEvent.setup();
-
-		await user.click( screen.getByRole( 'button', { name: 'Edit site' } ) );
 
 		const phpVersionSelect = screen.getByLabelText( 'PHP version' );
 		await user.selectOptions( phpVersionSelect, '8.2' );
@@ -179,13 +208,15 @@ describe( 'EditSiteDetails', () => {
 	} );
 
 	it( 'should enable the save button when WordPress version is changed', async () => {
+		( useSiteDetails as jest.Mock ).mockReturnValue( {
+			...useSiteDetails(),
+			isEditModalOpen: true,
+		} );
 		renderWithProvider( <EditSiteDetails { ...defaultProps } /> );
 		await waitFor( () => {
 			expect( mockGetAllCustomDomains ).toHaveBeenCalled();
 		} );
 		const user = userEvent.setup();
-
-		await user.click( screen.getByRole( 'button', { name: 'Edit site' } ) );
 
 		const wpVersionSelect = screen.getByLabelText( 'WordPress version' );
 		await user.selectOptions( wpVersionSelect, '6.4' );
@@ -194,13 +225,15 @@ describe( 'EditSiteDetails', () => {
 	} );
 
 	it( 'should disable the save button when site name is empty', async () => {
+		( useSiteDetails as jest.Mock ).mockReturnValue( {
+			...useSiteDetails(),
+			isEditModalOpen: true,
+		} );
 		renderWithProvider( <EditSiteDetails { ...defaultProps } /> );
 		await waitFor( () => {
 			expect( mockGetAllCustomDomains ).toHaveBeenCalled();
 		} );
 		const user = userEvent.setup();
-
-		await user.click( screen.getByRole( 'button', { name: 'Edit site' } ) );
 
 		const siteNameInput = screen.getByLabelText( 'Site name' );
 		await user.clear( siteNameInput );
@@ -209,13 +242,15 @@ describe( 'EditSiteDetails', () => {
 	} );
 
 	it( 'should update site when save button is clicked with changed site name', async () => {
+		( useSiteDetails as jest.Mock ).mockReturnValue( {
+			...useSiteDetails(),
+			isEditModalOpen: true,
+		} );
 		renderWithProvider( <EditSiteDetails { ...defaultProps } /> );
 		await waitFor( () => {
 			expect( mockGetAllCustomDomains ).toHaveBeenCalled();
 		} );
 		const user = userEvent.setup();
-
-		await user.click( screen.getByRole( 'button', { name: 'Edit site' } ) );
 
 		const siteNameInput = screen.getByLabelText( 'Site name' );
 		await user.clear( siteNameInput );
@@ -231,13 +266,15 @@ describe( 'EditSiteDetails', () => {
 	} );
 
 	it( 'should update site and restart server when PHP version is changed', async () => {
+		( useSiteDetails as jest.Mock ).mockReturnValue( {
+			...useSiteDetails(),
+			isEditModalOpen: true,
+		} );
 		renderWithProvider( <EditSiteDetails { ...defaultProps } /> );
 		await waitFor( () => {
 			expect( mockGetAllCustomDomains ).toHaveBeenCalled();
 		} );
 		const user = userEvent.setup();
-
-		await user.click( screen.getByRole( 'button', { name: 'Edit site' } ) );
 
 		const phpVersionSelect = screen.getByLabelText( 'PHP version' );
 		await user.selectOptions( phpVersionSelect, '8.2' );
@@ -254,10 +291,15 @@ describe( 'EditSiteDetails', () => {
 	} );
 
 	it( 'should update isWpAutoUpdating to false when changed from latest to specific version', async () => {
+		( useSiteDetails as jest.Mock ).mockReturnValue( {
+			...useSiteDetails(),
+			isEditModalOpen: true,
+		} );
 		renderWithProvider( <EditSiteDetails { ...defaultProps } /> );
+		await waitFor( () => {
+			expect( screen.getByRole( 'dialog' ) ).toBeInTheDocument();
+		} );
 		const user = userEvent.setup();
-
-		await user.click( screen.getByRole( 'button', { name: 'Edit site' } ) );
 
 		const wpVersionSelect = screen.getByLabelText( 'WordPress version' );
 		await user.selectOptions( wpVersionSelect, '6.4' );
@@ -277,10 +319,15 @@ describe( 'EditSiteDetails', () => {
 	} );
 
 	it( 'should update WordPress version when changed to beta', async () => {
+		( useSiteDetails as jest.Mock ).mockReturnValue( {
+			...useSiteDetails(),
+			isEditModalOpen: true,
+		} );
 		renderWithProvider( <EditSiteDetails { ...defaultProps } /> );
+		await waitFor( () => {
+			expect( screen.getByRole( 'dialog' ) ).toBeInTheDocument();
+		} );
 		const user = userEvent.setup();
-
-		await user.click( screen.getByRole( 'button', { name: 'Edit site' } ) );
 
 		const wpVersionSelect = screen.getByLabelText( 'WordPress version' );
 		await user.selectOptions( wpVersionSelect, '6.8-beta1' );
@@ -295,13 +342,18 @@ describe( 'EditSiteDetails', () => {
 	} );
 
 	it( 'should show error when WordPress version update fails', async () => {
+		( useSiteDetails as jest.Mock ).mockReturnValue( {
+			...useSiteDetails(),
+			isEditModalOpen: true,
+		} );
 		const consoleSpy = jest.spyOn( console, 'error' ).mockImplementation( () => {} );
 		mockExecuteWPCLiInline.mockResolvedValue( { exitCode: 1, stderr: 'Update failed' } );
 
 		renderWithProvider( <EditSiteDetails { ...defaultProps } /> );
+		await waitFor( () => {
+			expect( screen.getByRole( 'dialog' ) ).toBeInTheDocument();
+		} );
 		const user = userEvent.setup();
-
-		await user.click( screen.getByRole( 'button', { name: 'Edit site' } ) );
 
 		const wpVersionSelect = screen.getByLabelText( 'WordPress version' );
 		await user.selectOptions( wpVersionSelect, '6.4' );
@@ -319,15 +371,20 @@ describe( 'EditSiteDetails', () => {
 	} );
 
 	it( 'should disable form controls when site is being edited', async () => {
+		( useSiteDetails as jest.Mock ).mockReturnValue( {
+			...useSiteDetails(),
+			isEditModalOpen: true,
+		} );
 		// Mock the updateSite to delay completion
 		mockUpdateSite.mockImplementation(
 			() => new Promise( ( resolve ) => setTimeout( resolve, 100 ) )
 		);
 
 		renderWithProvider( <EditSiteDetails { ...defaultProps } /> );
+		await waitFor( () => {
+			expect( screen.getByRole( 'dialog' ) ).toBeInTheDocument();
+		} );
 		const user = userEvent.setup();
-
-		await user.click( screen.getByRole( 'button', { name: 'Edit site' } ) );
 
 		const siteNameInput = screen.getByLabelText( 'Site name' );
 		await user.clear( siteNameInput );
@@ -350,36 +407,49 @@ describe( 'EditSiteDetails', () => {
 	} );
 
 	it( 'should disable WordPress version field when offline', async () => {
+		( useSiteDetails as jest.Mock ).mockReturnValue( {
+			...useSiteDetails(),
+			isEditModalOpen: true,
+		} );
 		( useOffline as jest.Mock ).mockReturnValue( true );
 
 		renderWithProvider( <EditSiteDetails { ...defaultProps } /> );
-		const user = userEvent.setup();
-
-		await user.click( screen.getByRole( 'button', { name: 'Edit site' } ) );
+		await waitFor( () => {
+			expect( screen.getByRole( 'dialog' ) ).toBeInTheDocument();
+		} );
 
 		const wpVersionSelect = screen.getByLabelText( 'WordPress version' );
 		expect( wpVersionSelect ).toBeDisabled();
 	} );
 
 	it( 'should enable WordPress version field when online', async () => {
+		( useSiteDetails as jest.Mock ).mockReturnValue( {
+			...useSiteDetails(),
+			isEditModalOpen: true,
+		} );
 		( useOffline as jest.Mock ).mockReturnValue( false );
 
 		renderWithProvider( <EditSiteDetails { ...defaultProps } /> );
-		const user = userEvent.setup();
-
-		await user.click( screen.getByRole( 'button', { name: 'Edit site' } ) );
+		await waitFor( () => {
+			expect( screen.getByRole( 'dialog' ) ).toBeInTheDocument();
+		} );
 
 		const wpVersionSelect = screen.getByLabelText( 'WordPress version' );
 		expect( wpVersionSelect ).not.toBeDisabled();
 	} );
 
 	it( 'should show tooltip with offline message when hovering over disabled WordPress version field', async () => {
+		( useSiteDetails as jest.Mock ).mockReturnValue( {
+			...useSiteDetails(),
+			isEditModalOpen: true,
+		} );
 		( useOffline as jest.Mock ).mockReturnValue( true );
 
 		renderWithProvider( <EditSiteDetails { ...defaultProps } /> );
+		await waitFor( () => {
+			expect( screen.getByRole( 'dialog' ) ).toBeInTheDocument();
+		} );
 		const user = userEvent.setup();
-
-		await user.click( screen.getByRole( 'button', { name: 'Edit site' } ) );
 
 		const wpVersionSelect = screen.getByLabelText( 'WordPress version' );
 		await user.hover( wpVersionSelect );
@@ -390,12 +460,14 @@ describe( 'EditSiteDetails', () => {
 	} );
 
 	it( 'should not show tooltip when hovering over WordPress version field while online', async () => {
+		( useSiteDetails as jest.Mock ).mockReturnValue( {
+			...useSiteDetails(),
+			isEditModalOpen: true,
+		} );
 		( useOffline as jest.Mock ).mockReturnValue( false );
 
 		renderWithProvider( <EditSiteDetails { ...defaultProps } /> );
 		const user = userEvent.setup();
-
-		await user.click( screen.getByRole( 'button', { name: 'Edit site' } ) );
 
 		const wpVersionSelect = screen.getByLabelText( 'WordPress version' );
 		await user.hover( wpVersionSelect );
@@ -405,11 +477,16 @@ describe( 'EditSiteDetails', () => {
 		).not.toBeInTheDocument();
 	} );
 
-	it( 'should fetch WordPress versions when clicking edit site', async () => {
+	it( 'should fetch WordPress versions when modal opens', async () => {
+		( useSiteDetails as jest.Mock ).mockReturnValue( {
+			...useSiteDetails(),
+			isEditModalOpen: true,
+		} );
 		renderWithProvider( <EditSiteDetails { ...defaultProps } /> );
-		const user = userEvent.setup();
+		await waitFor( () => {
+			expect( screen.getByRole( 'dialog' ) ).toBeInTheDocument();
+		} );
 
-		await user.click( screen.getByRole( 'button', { name: 'Edit site' } ) );
 		expect( useGetWordPressVersions ).toHaveBeenCalled();
 	} );
 } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Related to  #1796

## Proposed Changes

- Remove setTimeout and move setIsEditModalOpen to site details context

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run `npm start`
- Double click  a site
- Click on edit site
- Observe Studio selects that site and goes to the settings tab and open the edit site dialog

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
