### PR TITLE
Studio: Add e2e tests for blueprint functionality

### DIFF
--- a/e2e/blueprints.test.ts
+++ b/e2e/blueprints.test.ts
@@ -1,0 +1,253 @@
+import path from 'path';
+import { test, expect } from '@playwright/test';
+import fs from 'fs-extra';
+import { E2ESession } from './e2e-helpers';
+import MainSidebar from './page-objects/main-sidebar';
+import Onboarding from './page-objects/onboarding';
+import SiteContent from './page-objects/site-content';
+import WhatsNewModal from './page-objects/whats-new-modal';
+
+test.describe( 'Blueprints', () => {
+	const session = new E2ESession();
+
+	test.beforeAll( async () => {
+		await session.launch();
+
+		// Complete onboarding before tests
+		const onboarding = new Onboarding( session.mainWindow );
+		await expect( onboarding.heading ).toBeVisible();
+		await onboarding.continueButton.click();
+
+		const whatsNewModal = new WhatsNewModal( session.mainWindow );
+		if ( await whatsNewModal.locator.isVisible( { timeout: 5000 } ) ) {
+			await whatsNewModal.closeButton.click();
+		}
+
+		const siteContent = new SiteContent( session.mainWindow, 'My WordPress Website' );
+		await expect( siteContent.siteNameHeading ).toBeVisible( { timeout: 60_000 } );
+	} );
+
+	test.afterAll( async () => {
+		await session.cleanup();
+	} );
+
+	test( 'create site with blueprint that installs a theme', async ( { page } ) => {
+		const siteName = 'Blueprint-Theme-Install';
+		const blueprintPath = path.join( __dirname, 'test-blueprints', 'install-theme.json' );
+
+		const sidebar = new MainSidebar( session.mainWindow );
+		const modal = await sidebar.openAddSiteModal();
+
+		// Select blueprint option
+		await expect( modal.blueprintButton ).toBeVisible();
+		await modal.blueprintButton.click();
+
+		// Upload blueprint file
+		await modal.selectBlueprintFile( blueprintPath );
+
+		// Wait for file to be processed and continue button to be enabled
+		await session.mainWindow.waitForTimeout( 1000 );
+		await modal.continueButton.click();
+
+		// Fill in site name
+		await modal.siteNameInput.fill( siteName );
+		await modal.addSiteButton.click();
+
+		// Wait for site to be created and running
+		const siteContent = new SiteContent( session.mainWindow, siteName );
+		await expect( siteContent.runningButton ).toBeAttached( { timeout: 60_000 } );
+
+		// Navigate to Settings tab to get admin URL
+		const settingsTab = await siteContent.navigateToTab( 'Settings' );
+		const wpAdminUrl = await settingsTab.copyWPAdminUrlToClipboard( session.electronApp );
+
+		// Verify theme was installed
+		await page.goto( wpAdminUrl + '/themes.php?playground-auto-login=true' );
+		await expect( page.locator( '.theme[data-slug="twentytwentytwo"]' ) ).toBeVisible();
+	} );
+
+	test( 'create site with blueprint that activates a theme', async ( { page } ) => {
+		const siteName = 'Blueprint-Theme-Activate';
+		const blueprintPath = path.join( __dirname, 'test-blueprints', 'activate-theme.json' );
+
+		const sidebar = new MainSidebar( session.mainWindow );
+		const modal = await sidebar.openAddSiteModal();
+
+		// Select blueprint option
+		await expect( modal.blueprintButton ).toBeVisible();
+		await modal.blueprintButton.click();
+
+		// Upload blueprint file
+		await modal.selectBlueprintFile( blueprintPath );
+
+		// Wait for file to be processed and continue button to be enabled
+		await session.mainWindow.waitForTimeout( 1000 );
+		await modal.continueButton.click();
+
+		// Fill in site name
+		await modal.siteNameInput.fill( siteName );
+		await modal.addSiteButton.click();
+
+		// Wait for site to be created and running
+		const siteContent = new SiteContent( session.mainWindow, siteName );
+		await expect( siteContent.runningButton ).toBeAttached( { timeout: 60_000 } );
+
+		// Navigate to Settings tab to get admin URL
+		const settingsTab = await siteContent.navigateToTab( 'Settings' );
+		const wpAdminUrl = await settingsTab.copyWPAdminUrlToClipboard( session.electronApp );
+
+		// Verify theme was activated
+		await page.goto( wpAdminUrl + '/themes.php?playground-auto-login=true' );
+		const activeTheme = page.locator( '.theme.active' );
+		await expect( activeTheme ).toBeVisible();
+		await expect( activeTheme ).toHaveAttribute( 'data-slug', 'twentytwentyone' );
+	} );
+
+	test( 'create site with blueprint that installs a plugin', async ( { page } ) => {
+		const siteName = 'Blueprint-Plugin-Install';
+		const blueprintPath = path.join( __dirname, 'test-blueprints', 'install-plugin.json' );
+
+		const sidebar = new MainSidebar( session.mainWindow );
+		const modal = await sidebar.openAddSiteModal();
+
+		// Select blueprint option
+		await expect( modal.blueprintButton ).toBeVisible();
+		await modal.blueprintButton.click();
+
+		// Upload blueprint file
+		await modal.selectBlueprintFile( blueprintPath );
+
+		// Wait for file to be processed and continue button to be enabled
+		await session.mainWindow.waitForTimeout( 1000 );
+		await modal.continueButton.click();
+
+		// Fill in site name
+		await modal.siteNameInput.fill( siteName );
+		await modal.addSiteButton.click();
+
+		// Wait for site to be created and running
+		const siteContent = new SiteContent( session.mainWindow, siteName );
+		await expect( siteContent.runningButton ).toBeAttached( { timeout: 60_000 } );
+
+		// Navigate to Settings tab to get admin URL
+		const settingsTab = await siteContent.navigateToTab( 'Settings' );
+		const wpAdminUrl = await settingsTab.copyWPAdminUrlToClipboard( session.electronApp );
+
+		// Verify plugin was installed
+		await page.goto( wpAdminUrl + '/plugins.php?playground-auto-login=true' );
+		await expect( page.locator( 'tr[data-slug="akismet"]' ) ).toBeVisible();
+	} );
+
+	test( 'create site with blueprint that activates a plugin', async ( { page } ) => {
+		const siteName = 'Blueprint-Plugin-Activate';
+		const blueprintPath = path.join( __dirname, 'test-blueprints', 'activate-plugin.json' );
+
+		const sidebar = new MainSidebar( session.mainWindow );
+		const modal = await sidebar.openAddSiteModal();
+
+		// Select blueprint option
+		await expect( modal.blueprintButton ).toBeVisible();
+		await modal.blueprintButton.click();
+
+		// Upload blueprint file
+		await modal.selectBlueprintFile( blueprintPath );
+
+		// Wait for file to be processed and continue button to be enabled
+		await session.mainWindow.waitForTimeout( 1000 );
+		await modal.continueButton.click();
+
+		// Fill in site name
+		await modal.siteNameInput.fill( siteName );
+		await modal.addSiteButton.click();
+
+		// Wait for site to be created and running
+		const siteContent = new SiteContent( session.mainWindow, siteName );
+		await expect( siteContent.runningButton ).toBeAttached( { timeout: 60_000 } );
+
+		// Navigate to Settings tab to get admin URL
+		const settingsTab = await siteContent.navigateToTab( 'Settings' );
+		const wpAdminUrl = await settingsTab.copyWPAdminUrlToClipboard( session.electronApp );
+
+		// Verify plugin was activated
+		await page.goto( wpAdminUrl + '/plugins.php?playground-auto-login=true' );
+		// Be more specific - look for the active Hello Dolly plugin
+		const pluginRow = page.locator( 'tr[data-slug="hello-dolly"].active' );
+		await expect( pluginRow ).toBeVisible();
+	} );
+
+	test( 'create site with blueprint that runs PHP code', async ( { page } ) => {
+		const siteName = 'Blueprint-PHP-Code';
+		const blueprintPath = path.join( __dirname, 'test-blueprints', 'run-php-code.json' );
+
+		const sidebar = new MainSidebar( session.mainWindow );
+		const modal = await sidebar.openAddSiteModal();
+
+		// Select blueprint option
+		await expect( modal.blueprintButton ).toBeVisible();
+		await modal.blueprintButton.click();
+
+		// Upload blueprint file
+		await modal.selectBlueprintFile( blueprintPath );
+
+		// Wait for file to be processed and continue button to be enabled
+		await session.mainWindow.waitForTimeout( 1000 );
+		await modal.continueButton.click();
+
+		// Fill in site name
+		await modal.siteNameInput.fill( siteName );
+		await modal.addSiteButton.click();
+
+		// Wait for site to be created and running
+		const siteContent = new SiteContent( session.mainWindow, siteName );
+		await expect( siteContent.runningButton ).toBeAttached( { timeout: 60_000 } );
+
+		// Navigate to Settings tab to verify site is accessible
+		const settingsTab = await siteContent.navigateToTab( 'Settings' );
+		const wpAdminUrl = await settingsTab.copyWPAdminUrlToClipboard( session.electronApp );
+
+		// Verify the site was created successfully and admin is accessible
+		await page.goto( wpAdminUrl + '/options-general.php?playground-auto-login=true' );
+		await expect( page.getByLabel( 'Site Title' ) ).toBeVisible();
+
+		// Verify the blueprint's landing page works
+		await expect( page ).toHaveURL( /options-general\.php/ );
+	} );
+
+	test( 'create site with blueprint that runs WP-CLI commands', async ( { page } ) => {
+		const siteName = 'Blueprint-WP-CLI';
+		const blueprintPath = path.join( __dirname, 'test-blueprints', 'wp-cli-command.json' );
+
+		const sidebar = new MainSidebar( session.mainWindow );
+		const modal = await sidebar.openAddSiteModal();
+
+		// Select blueprint option
+		await expect( modal.blueprintButton ).toBeVisible();
+		await modal.blueprintButton.click();
+
+		// Upload blueprint file
+		await modal.selectBlueprintFile( blueprintPath );
+
+		// Wait for file to be processed and continue button to be enabled
+		await session.mainWindow.waitForTimeout( 1000 );
+		await modal.continueButton.click();
+
+		// Fill in site name
+		await modal.siteNameInput.fill( siteName );
+		await modal.addSiteButton.click();
+
+		// Wait for site to be created and running
+		const siteContent = new SiteContent( session.mainWindow, siteName );
+		await expect( siteContent.runningButton ).toBeAttached( { timeout: 60_000 } );
+
+		// Navigate to Settings tab to verify site is accessible
+		const settingsTab = await siteContent.navigateToTab( 'Settings' );
+		const wpAdminUrl = await settingsTab.copyWPAdminUrlToClipboard( session.electronApp );
+
+		// Verify the site was created successfully and admin is accessible
+		await page.goto( wpAdminUrl + '/options-general.php?playground-auto-login=true' );
+		await expect( page.getByLabel( 'Site Title' ) ).toBeVisible();
+
+		// Verify the blueprint's landing page works
+		await expect( page ).toHaveURL( /options-general\.php/ );
+	} );
+} );

--- a/e2e/page-objects/add-site-modal.ts
+++ b/e2e/page-objects/add-site-modal.ts
@@ -12,6 +12,18 @@ export default class AddSiteModal {
 		return this.page.locator( 'button:has-text("Create a site")' ).first();
 	}
 
+	get blueprintButton() {
+		return this.page.locator( 'button:has-text("Start from a blueprint")' ).first();
+	}
+
+	get continueButton() {
+		return this.locator.getByRole( 'button', { name: 'Continue' } );
+	}
+
+	get fileInput() {
+		return this.page.locator( 'input[type="file"][accept=".json,application/json"]' );
+	}
+
 	private get siteForm() {
 		return new SiteForm( this.page );
 	}
@@ -30,5 +42,9 @@ export default class AddSiteModal {
 
 	async selectLocalPathForTesting() {
 		await this.siteForm.clickLocalPathButtonAndSelectFromEnv();
+	}
+
+	async selectBlueprintFile( filePath: string ) {
+		await this.fileInput.setInputFiles( filePath );
 	}
 }

--- a/e2e/test-blueprints/activate-plugin.json
+++ b/e2e/test-blueprints/activate-plugin.json
@@ -1,0 +1,17 @@
+{
+	"$schema": "https://playground.wordpress.net/blueprint-schema.json",
+	"landingPage": "/wp-admin/plugins.php",
+	"steps": [
+		{
+			"step": "installPlugin",
+			"pluginZipFile": {
+				"resource": "wordpress.org/plugins",
+				"slug": "hello-dolly"
+			}
+		},
+		{
+			"step": "activatePlugin",
+			"pluginPath": "hello-dolly/hello.php"
+		}
+	]
+}

--- a/e2e/test-blueprints/activate-theme.json
+++ b/e2e/test-blueprints/activate-theme.json
@@ -1,0 +1,17 @@
+{
+	"$schema": "https://playground.wordpress.net/blueprint-schema.json",
+	"landingPage": "/wp-admin/themes.php",
+	"steps": [
+		{
+			"step": "installTheme",
+			"themeZipFile": {
+				"resource": "wordpress.org/themes",
+				"slug": "twentytwentyone"
+			}
+		},
+		{
+			"step": "activateTheme",
+			"themeFolderName": "twentytwentyone"
+		}
+	]
+}

--- a/e2e/test-blueprints/install-plugin.json
+++ b/e2e/test-blueprints/install-plugin.json
@@ -1,0 +1,13 @@
+{
+	"$schema": "https://playground.wordpress.net/blueprint-schema.json",
+	"landingPage": "/wp-admin/plugins.php",
+	"steps": [
+		{
+			"step": "installPlugin",
+			"pluginZipFile": {
+				"resource": "wordpress.org/plugins",
+				"slug": "akismet"
+			}
+		}
+	]
+}

--- a/e2e/test-blueprints/install-theme.json
+++ b/e2e/test-blueprints/install-theme.json
@@ -1,0 +1,13 @@
+{
+	"$schema": "https://playground.wordpress.net/blueprint-schema.json",
+	"landingPage": "/wp-admin/themes.php",
+	"steps": [
+		{
+			"step": "installTheme",
+			"themeZipFile": {
+				"resource": "wordpress.org/themes",
+				"slug": "twentytwentytwo"
+			}
+		}
+	]
+}

--- a/e2e/test-blueprints/run-php-code.json
+++ b/e2e/test-blueprints/run-php-code.json
@@ -1,0 +1,10 @@
+{
+	"$schema": "https://playground.wordpress.net/blueprint-schema.json",
+	"landingPage": "/wp-admin/options-general.php",
+	"steps": [
+		{
+			"step": "runPHP",
+			"code": "<?php require_once '/wordpress/wp-load.php'; update_option('blogname', 'Blueprint Test Site'); update_option('blogdescription', 'Created via Blueprint');"
+		}
+	]
+}

--- a/e2e/test-blueprints/wp-cli-command.json
+++ b/e2e/test-blueprints/wp-cli-command.json
@@ -1,0 +1,14 @@
+{
+	"$schema": "https://playground.wordpress.net/blueprint-schema.json",
+	"landingPage": "/wp-admin/options-general.php",
+	"steps": [
+		{
+			"step": "wp-cli",
+			"command": "wp option update blogname 'WP-CLI Test Site'"
+		},
+		{
+			"step": "wp-cli",
+			"command": "wp option update blogdescription 'Updated via WP-CLI'"
+		}
+	]
+}


### PR DESCRIPTION
## Related issues

- Fixes STU-807

## Proposed Changes

- Added comprehensive e2e test file `e2e/blueprints.test.ts` with 6 test cases covering blueprint workflows
- Created 6 test blueprint JSON files for testing different blueprint scenarios (theme install/activate, plugin install/activate, PHP code execution, WP-CLI commands)
- Updated `add-site-modal.ts` page object to support blueprint workflow with new selectors and file upload functionality
- Added test coverage for blueprint site creation flow from UI through to verification in WordPress admin

## Testing Instructions

- `npm run make`
- Run the e2e tests: `npm run e2e`
- Verify all 6 test cases pass:
  - Blueprint theme installation verification
  - Blueprint theme activation verification  
  - Blueprint plugin installation verification
  - Blueprint plugin activation verification
  - Blueprint PHP code execution verification
  - Blueprint WP-CLI command execution verification
- Ensure test blueprint JSON files are properly structured and functional
- Confirm page object changes don't break existing site creation tests

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?