### PR TITLE
Studio: Add blueprint warnings for unsupported features

### DIFF
--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -34,6 +34,7 @@ import { StatsGroup, StatsMetric } from 'common/types/stats';
 import { ARCHIVER_OPTIONS, DEFAULT_TERMINAL, MAIN_MIN_WIDTH, SIDEBAR_WIDTH } from 'src/constants';
 import { sendIpcEventToRenderer, sendIpcEventToRendererWithWindow } from 'src/ipc-utils';
 import { ACTIVE_SYNC_OPERATIONS } from 'src/lib/active-sync-operations';
+import { scanBlueprintForUnsupportedFeatures } from 'src/lib/blueprint-features';
 import { bumpStat } from 'src/lib/bump-stats';
 import { getImporterMetric, getBlueprintMetric } from 'src/lib/bump-stats/lib';
 import {
@@ -1469,12 +1470,25 @@ export async function getProviderConstants( _event: IpcMainInvokeEvent ) {
 
 export async function validateBlueprint(
 	_event: IpcMainInvokeEvent,
-	blueprintJson: object
-): Promise< { valid: boolean; error?: string } > {
+	blueprintJson: Blueprint[ 'blueprint' ]
+): Promise< {
+	valid: boolean;
+	error?: string;
+	warnings?: Array< { feature: string; reason: string; alternative?: string } >;
+} > {
 	try {
 		await compileBlueprint( blueprintJson );
+		const unsupportedFeatures = scanBlueprintForUnsupportedFeatures( blueprintJson );
 
-		return { valid: true };
+		const warnings = unsupportedFeatures.map( ( feature ) => ( {
+			feature: feature.name,
+			reason: feature.reason,
+		} ) );
+
+		return {
+			valid: true,
+			warnings: warnings.length > 0 ? warnings : undefined,
+		};
 	} catch ( error ) {
 		const errorMessage = error instanceof Error ? error.message : 'Invalid Blueprint format';
 		return {

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -1478,22 +1478,23 @@ export async function validateBlueprint(
 } > {
 	try {
 		await compileBlueprint( blueprintJson );
-		const unsupportedFeatures = scanBlueprintForUnsupportedFeatures( blueprintJson );
-
-		const warnings = unsupportedFeatures.map( ( feature ) => ( {
-			feature: feature.name,
-			reason: feature.reason,
-		} ) );
-
-		return {
-			valid: true,
-			warnings: warnings.length > 0 ? warnings : undefined,
-		};
 	} catch ( error ) {
-		const errorMessage = error instanceof Error ? error.message : 'Invalid Blueprint format';
+		const errorMessage = error instanceof Error ? error.message : __( 'Invalid Blueprint format' );
 		return {
 			valid: false,
 			error: errorMessage,
 		};
 	}
+
+	const unsupportedFeatures = scanBlueprintForUnsupportedFeatures( blueprintJson );
+
+	const warnings = unsupportedFeatures.map( ( feature ) => ( {
+		feature: feature.name,
+		reason: feature.reason,
+	} ) );
+
+	return {
+		valid: true,
+		warnings: warnings.length > 0 ? warnings : undefined,
+	};
 }

--- a/src/lib/blueprint-features.ts
+++ b/src/lib/blueprint-features.ts
@@ -1,6 +1,7 @@
 import { Blueprint } from 'src/stores/wpcom-api';
+import { __ } from '@wordpress/i18n';
 
-export interface UnsupportedFeature {
+interface UnsupportedFeature {
 	type: 'step' | 'property';
 	name: string;
 	reason: string;
@@ -9,48 +10,48 @@ export interface UnsupportedFeature {
 /**
  * List of blueprint features that are not supported in Studio
  */
-export const UNSUPPORTED_BLUEPRINT_FEATURES: UnsupportedFeature[] = [
+const UNSUPPORTED_BLUEPRINT_FEATURES: UnsupportedFeature[] = [
 	{
 		type: 'step',
 		name: 'enableMultisite',
-		reason: 'Multisite functionality is not currently supported in Studio',
+		reason: __( 'Multisite functionality is not currently supported in Studio' ),
 	},
 	{
 		type: 'step',
 		name: 'login',
-		reason: 'Studio automatically creates and logs in the admin user during site creation',
+		reason: __( 'Studio automatically creates and logs in the admin user during site creation' ),
 	},
 	{
 		type: 'step',
 		name: 'defineSiteUrl',
-		reason: 'Studio manages site URLs internally and cannot accept custom URLs from blueprints',
+		reason: __( 'Studio manages site URLs internally and cannot accept custom URLs from blueprints' ),
 	},
 ];
 
 /**
  * Blueprint properties that are not supported in Studio
  */
-export const UNSUPPORTED_BLUEPRINT_PROPERTIES: UnsupportedFeature[] = [
+const UNSUPPORTED_BLUEPRINT_PROPERTIES: UnsupportedFeature[] = [
 	{
 		type: 'property',
 		name: 'landingPage',
-		reason: 'Studio manages its own navigation and landing pages',
+		reason: __( 'Studio manages its own navigation and landing pages' ),
 	},
 ];
 
-export function isStepSupported( stepName: string ): boolean {
+function isStepSupported( stepName: string ): boolean {
 	return ! UNSUPPORTED_BLUEPRINT_FEATURES.some(
 		( feature ) => feature.type === 'step' && feature.name === stepName
 	);
 }
 
-export function isPropertySupported( propertyName: string ): boolean {
+function isPropertySupported( propertyName: string ): boolean {
 	return ! UNSUPPORTED_BLUEPRINT_PROPERTIES.some(
 		( feature ) => feature.type === 'property' && feature.name === propertyName
 	);
 }
 
-export function getUnsupportedFeatureInfo( name: string ): UnsupportedFeature | undefined {
+function getUnsupportedFeatureInfo( name: string ): UnsupportedFeature | undefined {
 	return (
 		UNSUPPORTED_BLUEPRINT_FEATURES.find( ( feature ) => feature.name === name ) ||
 		UNSUPPORTED_BLUEPRINT_PROPERTIES.find( ( feature ) => feature.name === name )
@@ -88,9 +89,12 @@ export function scanBlueprintForUnsupportedFeatures(
 	);
 }
 
-export function filterUnsupportedFeatures(
-	blueprint: Blueprint[ 'blueprint' ]
-): Blueprint[ 'blueprint' ] {
+export function filterUnsupportedBlueprintFeatures(
+	blueprint: Blueprint[ 'blueprint' ] | undefined
+): Blueprint[ 'blueprint' ] | undefined {
+	if ( ! blueprint ) {
+		return undefined;
+	}
 	const filtered = { ...blueprint };
 
 	if ( filtered.steps && Array.isArray( filtered.steps ) ) {

--- a/src/lib/blueprint-features.ts
+++ b/src/lib/blueprint-features.ts
@@ -20,6 +20,22 @@ export const UNSUPPORTED_BLUEPRINT_FEATURES: UnsupportedFeature[] = [
 		name: 'login',
 		reason: 'Studio automatically creates and logs in the admin user during site creation',
 	},
+	{
+		type: 'step',
+		name: 'defineSiteUrl',
+		reason: 'Studio manages site URLs internally and cannot accept custom URLs from blueprints',
+	},
+];
+
+/**
+ * Blueprint properties that are not supported in Studio
+ */
+export const UNSUPPORTED_BLUEPRINT_PROPERTIES: UnsupportedFeature[] = [
+	{
+		type: 'property',
+		name: 'landingPage',
+		reason: 'Studio manages its own navigation and landing pages',
+	},
 ];
 
 export function isStepSupported( stepName: string ): boolean {
@@ -29,13 +45,16 @@ export function isStepSupported( stepName: string ): boolean {
 }
 
 export function isPropertySupported( propertyName: string ): boolean {
-	return ! UNSUPPORTED_BLUEPRINT_FEATURES.some(
+	return ! UNSUPPORTED_BLUEPRINT_PROPERTIES.some(
 		( feature ) => feature.type === 'property' && feature.name === propertyName
 	);
 }
 
 export function getUnsupportedFeatureInfo( name: string ): UnsupportedFeature | undefined {
-	return UNSUPPORTED_BLUEPRINT_FEATURES.find( ( feature ) => feature.name === name );
+	return (
+		UNSUPPORTED_BLUEPRINT_FEATURES.find( ( feature ) => feature.name === name ) ||
+		UNSUPPORTED_BLUEPRINT_PROPERTIES.find( ( feature ) => feature.name === name )
+	);
 }
 
 export function scanBlueprintForUnsupportedFeatures(

--- a/src/lib/blueprint-features.ts
+++ b/src/lib/blueprint-features.ts
@@ -1,5 +1,5 @@
-import { Blueprint } from 'src/stores/wpcom-api';
 import { __ } from '@wordpress/i18n';
+import { Blueprint } from 'src/stores/wpcom-api';
 
 interface UnsupportedFeature {
 	type: 'step' | 'property';
@@ -24,7 +24,9 @@ const UNSUPPORTED_BLUEPRINT_FEATURES: UnsupportedFeature[] = [
 	{
 		type: 'step',
 		name: 'defineSiteUrl',
-		reason: __( 'Studio manages site URLs internally and cannot accept custom URLs from blueprints' ),
+		reason: __(
+			'Studio manages site URLs internally and cannot accept custom URLs from blueprints'
+		),
 	},
 ];
 

--- a/src/lib/blueprint-features.ts
+++ b/src/lib/blueprint-features.ts
@@ -1,0 +1,90 @@
+import { Blueprint } from 'src/stores/wpcom-api';
+
+export interface UnsupportedFeature {
+	type: 'step' | 'property';
+	name: string;
+	reason: string;
+}
+
+/**
+ * List of blueprint features that are not supported in Studio
+ */
+export const UNSUPPORTED_BLUEPRINT_FEATURES: UnsupportedFeature[] = [
+	{
+		type: 'step',
+		name: 'enableMultisite',
+		reason: 'Multisite functionality is not currently supported in Studio',
+	},
+	{
+		type: 'step',
+		name: 'login',
+		reason: 'Studio automatically creates and logs in the admin user during site creation',
+	},
+];
+
+export function isStepSupported( stepName: string ): boolean {
+	return ! UNSUPPORTED_BLUEPRINT_FEATURES.some(
+		( feature ) => feature.type === 'step' && feature.name === stepName
+	);
+}
+
+export function isPropertySupported( propertyName: string ): boolean {
+	return ! UNSUPPORTED_BLUEPRINT_FEATURES.some(
+		( feature ) => feature.type === 'property' && feature.name === propertyName
+	);
+}
+
+export function getUnsupportedFeatureInfo( name: string ): UnsupportedFeature | undefined {
+	return UNSUPPORTED_BLUEPRINT_FEATURES.find( ( feature ) => feature.name === name );
+}
+
+export function scanBlueprintForUnsupportedFeatures(
+	blueprint: Blueprint[ 'blueprint' ]
+): UnsupportedFeature[] {
+	const foundUnsupported: UnsupportedFeature[] = [];
+
+	if ( blueprint.steps && Array.isArray( blueprint.steps ) ) {
+		for ( const step of blueprint.steps ) {
+			if ( step.step && ! isStepSupported( step.step ) ) {
+				const featureInfo = getUnsupportedFeatureInfo( step.step );
+				if ( featureInfo ) {
+					foundUnsupported.push( featureInfo );
+				}
+			}
+		}
+	}
+
+	for ( const [ key ] of Object.entries( blueprint ) ) {
+		if ( ! isPropertySupported( key ) ) {
+			const featureInfo = getUnsupportedFeatureInfo( key );
+			if ( featureInfo ) {
+				foundUnsupported.push( featureInfo );
+			}
+		}
+	}
+
+	return foundUnsupported.filter(
+		( feature, index, self ) =>
+			index === self.findIndex( ( f ) => f.name === feature.name && f.type === feature.type )
+	);
+}
+
+export function filterUnsupportedFeatures(
+	blueprint: Blueprint[ 'blueprint' ]
+): Blueprint[ 'blueprint' ] {
+	const filtered = { ...blueprint };
+
+	if ( filtered.steps && Array.isArray( filtered.steps ) ) {
+		filtered.steps = filtered.steps.filter(
+			( step: { step: string } ) => step.step && isStepSupported( step.step )
+		);
+	}
+
+	for ( const [ key ] of Object.entries( filtered ) ) {
+		if ( ! isPropertySupported( key ) ) {
+			delete filtered[ key ];
+		}
+	}
+
+	return filtered;
+}

--- a/src/lib/wordpress-provider/types.ts
+++ b/src/lib/wordpress-provider/types.ts
@@ -1,4 +1,5 @@
 import { SiteServer } from 'src/site-server';
+import { Blueprint } from 'src/stores/wpcom-api';
 
 export type AllowedPHPVersion = string;
 
@@ -12,6 +13,7 @@ export interface ServerOptions {
 	isWpAutoUpdating?: boolean;
 	absoluteUrl?: string;
 	siteLanguage?: string;
+	blueprint?: Blueprint[ 'blueprint' ];
 }
 
 export interface WordPressServerOptions {

--- a/src/modules/add-site/components/blueprints.css
+++ b/src/modules/add-site/components/blueprints.css
@@ -30,3 +30,7 @@
 .blueprints-container .components-badge {
 	@apply !bg-transparent p-0 !w-full;
 }
+
+.blueprints-issues-modal .components-modal__header + div {
+	height: 100%;
+}

--- a/src/modules/add-site/components/blueprints.tsx
+++ b/src/modules/add-site/components/blueprints.tsx
@@ -300,7 +300,6 @@ export function AddSiteBlueprintSelector( {
 		setUploadedFileName( null );
 
 		if ( file && file.type === 'application/json' && onFileBlueprintSelect ) {
-			// Set the filename immediately so it shows in the UI
 			setUploadedFileName( file.name );
 
 			try {
@@ -311,7 +310,6 @@ export function AddSiteBlueprintSelector( {
 					setValidationError(
 						__( 'Blueprint v2 format is not supported yet. Please use Blueprint v1 format.' )
 					);
-					// Keep the filename displayed but clear the input
 					if ( fileRef.current ) {
 						fileRef.current.value = '';
 					}
@@ -321,19 +319,16 @@ export function AddSiteBlueprintSelector( {
 				const validation = await getIpcApi().validateBlueprint( blueprintJson );
 				if ( ! validation.valid ) {
 					setValidationError( validation.error || __( 'Invalid Blueprint format' ) );
-					// Keep the filename displayed but clear the input
 					if ( fileRef.current ) {
 						fileRef.current.value = '';
 					}
 					return;
 				}
 
-				// Set warnings if any unsupported features are detected
 				if ( validation.warnings && validation.warnings.length > 0 ) {
 					setBlueprintWarnings( validation.warnings );
 				}
 
-				// Create a "fake" Blueprint object from the file
 				const fileBlueprint: Blueprint = {
 					slug: `file:${ file.name }`, // Use filename as part of the slug
 					title: blueprintJson.meta?.title || file.name.replace( '.json', '' ),
@@ -343,7 +338,6 @@ export function AddSiteBlueprintSelector( {
 					blueprint: blueprintJson, // The actual blueprint JSON
 				};
 
-				// Clear the uploaded filename since we're now tracking it through selectedBlueprint
 				setUploadedFileName( null );
 				onFileBlueprintSelect( fileBlueprint );
 			} catch ( error ) {

--- a/src/modules/add-site/components/blueprints.tsx
+++ b/src/modules/add-site/components/blueprints.tsx
@@ -4,12 +4,13 @@ import {
 	__experimentalHeading as Heading,
 	__experimentalText as Text,
 	Button,
+	Modal,
 	Notice,
 } from '@wordpress/components';
 import { DataViews, View } from '@wordpress/dataviews';
 import { createInterpolateElement } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
-import { Icon, external, upload } from '@wordpress/icons';
+import { Icon, external, upload, error, caution } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { useCallback, useRef, useState, useMemo } from 'react';
 import StudioButton from 'src/components/button';
@@ -39,6 +40,114 @@ interface DataViewBlueprint extends Blueprint {
 	categories: string[];
 }
 
+interface BlueprintDetailsModalProps {
+	warnings: Array< { feature: string; reason: string } > | null;
+	validationError: string | null;
+	fileName: string;
+	isOpen: boolean;
+	onClose: () => void;
+}
+
+function BlueprintDetailsModal( {
+	warnings,
+	validationError,
+	fileName,
+	isOpen,
+	onClose,
+}: BlueprintDetailsModalProps ) {
+	const { __ } = useI18n();
+
+	if ( ! isOpen ) {
+		return null;
+	}
+
+	const hasWarnings = warnings && warnings.length > 0;
+	const hasError = !! validationError;
+
+	return (
+		<Modal
+			title={ __( 'Blueprint Details' ) }
+			onRequestClose={ onClose }
+			className="blueprint-details-modal"
+			size="medium"
+		>
+			<VStack spacing={ 4 }>
+				<Text className="font-medium text-gray-900">{ fileName }</Text>
+
+				{ hasError && (
+					<div className="max-h-64 overflow-y-auto">
+						<VStack spacing={ 3 }>
+							<div>
+								<HStack alignment="topLeft" spacing={ 2 }>
+									<Icon icon={ error } className="text-red-500 mt-1 flex-shrink-0" size={ 20 } />
+									<VStack spacing={ 1 }>
+										<Text weight={ 600 } className="text-base">
+											{ __( 'Validation Error' ) }
+										</Text>
+										<Text className="text-sm text-gray-700">{ validationError }</Text>
+									</VStack>
+								</HStack>
+							</div>
+						</VStack>
+					</div>
+				) }
+
+				{ hasWarnings && (
+					<>
+						<Text>
+							{ sprintf(
+								// translators: %d is the number of unsupported features
+								__(
+									'The following %d feature(s) are not supported in Studio and will be automatically removed:'
+								),
+								warnings.length
+							) }
+						</Text>
+
+						<div className="max-h-64 overflow-y-auto">
+							<VStack spacing={ 3 } className="divide-y divide-gray-200">
+								{ warnings.map( ( warningItem, index ) => (
+									<div key={ index } className={ index > 0 ? 'pt-3' : '' }>
+										<HStack alignment="topLeft" spacing={ 2 }>
+											<Icon
+												icon={ caution }
+												className="text-orange-500 mt-1 flex-shrink-0"
+												size={ 20 }
+											/>
+											<VStack spacing={ 1 }>
+												<Text weight={ 600 } className="text-base">
+													{ warningItem.feature }
+												</Text>
+												<Text className="text-sm text-gray-700">{ warningItem.reason }</Text>
+											</VStack>
+										</HStack>
+									</div>
+								) ) }
+							</VStack>
+						</div>
+					</>
+				) }
+
+				{ hasWarnings && ! hasError && (
+					<div className="pt-4 border-t border-gray-200">
+						<Text className="text-sm text-gray-600">
+							{ __(
+								'Your blueprint will still work, but these features will be skipped during site creation.'
+							) }
+						</Text>
+					</div>
+				) }
+
+				<HStack alignment="right">
+					<Button variant="primary" onClick={ onClose }>
+						{ __( 'Got it' ) }
+					</Button>
+				</HStack>
+			</VStack>
+		</Modal>
+	);
+}
+
 interface AddSiteBlueprintProps {
 	blueprints: Blueprint[];
 	errorMessage?: string;
@@ -60,14 +169,24 @@ export function AddSiteBlueprintSelector( {
 	const { refetch: refetchBlueprints, isFetching: isFetchingBlueprints } = useGetBlueprints();
 	const fileRef = useRef< HTMLInputElement | null >( null );
 	const [ validationError, setValidationError ] = useState< string | null >( null );
+	const [ blueprintWarnings, setBlueprintWarnings ] = useState< Array< {
+		feature: string;
+		reason: string;
+		alternative?: string;
+	} > | null >( null );
+	const [ showWarningsModal, setShowWarningsModal ] = useState( false );
+	const [ uploadedFileName, setUploadedFileName ] = useState< string | null >( null );
 
 	// Check if current selection is a file-based blueprint
 	const isFileBasedSelection = selectedBlueprint && selectedBlueprint.startsWith( 'file:' );
-	const selectedFileName = isFileBasedSelection ? selectedBlueprint.replace( 'file:', '' ) : null;
+	const selectedFileName =
+		uploadedFileName || ( isFileBasedSelection ? selectedBlueprint.replace( 'file:', '' ) : null );
 
 	const handleRemoveFile = useCallback( () => {
 		onBlueprintChange( '' );
 		setValidationError( null );
+		setBlueprintWarnings( null );
+		setUploadedFileName( null );
 		if ( fileRef.current ) {
 			fileRef.current.value = '';
 		}
@@ -76,6 +195,7 @@ export function AddSiteBlueprintSelector( {
 	const handleBlueprintClick = useCallback(
 		( item: DataViewBlueprint ) => {
 			setValidationError( null );
+			setBlueprintWarnings( null );
 			onBlueprintChange( item.slug );
 		},
 		[ onBlueprintChange ]
@@ -176,8 +296,13 @@ export function AddSiteBlueprintSelector( {
 	const handleFileSelect = async ( event: React.ChangeEvent< HTMLInputElement > ) => {
 		const file = event.target.files?.[ 0 ];
 		setValidationError( null );
+		setBlueprintWarnings( null );
+		setUploadedFileName( null );
 
 		if ( file && file.type === 'application/json' && onFileBlueprintSelect ) {
+			// Set the filename immediately so it shows in the UI
+			setUploadedFileName( file.name );
+
 			try {
 				const text = await file.text();
 				const blueprintJson = JSON.parse( text );
@@ -186,6 +311,7 @@ export function AddSiteBlueprintSelector( {
 					setValidationError(
 						__( 'Blueprint v2 format is not supported yet. Please use Blueprint v1 format.' )
 					);
+					// Keep the filename displayed but clear the input
 					if ( fileRef.current ) {
 						fileRef.current.value = '';
 					}
@@ -195,10 +321,16 @@ export function AddSiteBlueprintSelector( {
 				const validation = await getIpcApi().validateBlueprint( blueprintJson );
 				if ( ! validation.valid ) {
 					setValidationError( validation.error || __( 'Invalid Blueprint format' ) );
+					// Keep the filename displayed but clear the input
 					if ( fileRef.current ) {
 						fileRef.current.value = '';
 					}
 					return;
+				}
+
+				// Set warnings if any unsupported features are detected
+				if ( validation.warnings && validation.warnings.length > 0 ) {
+					setBlueprintWarnings( validation.warnings );
 				}
 
 				// Create a "fake" Blueprint object from the file
@@ -211,6 +343,8 @@ export function AddSiteBlueprintSelector( {
 					blueprint: blueprintJson, // The actual blueprint JSON
 				};
 
+				// Clear the uploaded filename since we're now tracking it through selectedBlueprint
+				setUploadedFileName( null );
 				onFileBlueprintSelect( fileBlueprint );
 			} catch ( error ) {
 				if ( error instanceof SyntaxError ) {
@@ -267,16 +401,43 @@ export function AddSiteBlueprintSelector( {
 				{ __( 'Start from a blueprint' ) }
 			</Heading>
 
+			<BlueprintDetailsModal
+				warnings={ blueprintWarnings }
+				validationError={ validationError }
+				fileName={ selectedFileName || '' }
+				isOpen={ showWarningsModal }
+				onClose={ () => setShowWarningsModal( false ) }
+			/>
+
 			{ validationError && (
 				<Notice
 					status="error"
-					isDismissible={ true }
+					isDismissible={ false }
 					onRemove={ () => setValidationError( null ) }
 					className="mx-3 mb-4"
 				>
 					<strong>{ __( 'Blueprint validation failed' ) }</strong>
 					<br />
 					{ validationError }
+				</Notice>
+			) }
+
+			{ ! validationError && blueprintWarnings && blueprintWarnings.length > 0 && (
+				<Notice status="warning" isDismissible={ false } className="mx-3 mb-4">
+					<div className="flex justify-between items-center w-full">
+						<span>
+							{ __(
+								'This blueprint uses some unsupported features in Studio and might not work as expected.'
+							) }
+						</span>
+						<Button
+							variant="link"
+							onClick={ () => setShowWarningsModal( true ) }
+							className="!text-inherit !p-0 !underline"
+						>
+							{ __( 'View details' ) }
+						</Button>
+					</div>
 				</Notice>
 			) }
 
@@ -287,20 +448,16 @@ export function AddSiteBlueprintSelector( {
 					</Text>
 				</HStack>
 				{ selectedFileName ? (
-					<HStack className="h-9 w-fit flex-shrink-0 items-center">
+					<HStack className="flex-1 items-center justify-end gap-1">
 						<Text
 							className="text-sm font-medium text-gray-900 truncate max-w-48"
 							title={ selectedFileName }
 						>
 							{ selectedFileName }
 						</Text>
-						<button
-							type="button"
-							className="text-sm text-blue-600 hover:text-blue-700 focus:outline-none"
-							onClick={ handleRemoveFile }
-						>
+						<Button variant="tertiary" size="small" onClick={ handleRemoveFile } isDestructive>
 							{ __( 'Remove' ) }
-						</button>
+						</Button>
 					</HStack>
 				) : (
 					<label className="flex-shrink-0">

--- a/src/modules/add-site/components/blueprints.tsx
+++ b/src/modules/add-site/components/blueprints.tsx
@@ -65,11 +65,7 @@ function BlueprintIssuesModal( {
 	const hasError = !! validationError;
 
 	return (
-		<Modal
-			title={ __( 'Blueprint Details' ) }
-			onRequestClose={ onClose }
-			size="medium"
-		>
+		<Modal title={ __( 'Blueprint Details' ) } onRequestClose={ onClose } size="medium">
 			<VStack spacing={ 4 }>
 				<Text className="font-medium text-gray-900">{ fileName }</Text>
 
@@ -168,11 +164,14 @@ export function AddSiteBlueprintSelector( {
 	const { refetch: refetchBlueprints, isFetching: isFetchingBlueprints } = useGetBlueprints();
 	const fileRef = useRef< HTMLInputElement | null >( null );
 	const [ validationError, setValidationError ] = useState< string | undefined >( undefined );
-	const [ blueprintWarnings, setBlueprintWarnings ] = useState< Array< {
-		feature: string;
-		reason: string;
-		alternative?: string;
-	} > | undefined >( undefined );
+	const [ blueprintWarnings, setBlueprintWarnings ] = useState<
+		| Array< {
+				feature: string;
+				reason: string;
+				alternative?: string;
+		  } >
+		| undefined
+	>( undefined );
 	const [ uploadedFileName, setUploadedFileName ] = useState< string | null >( null );
 	const [ showIssuesModal, setShowIssuesModal ] = useState( false );
 

--- a/src/modules/add-site/components/blueprints.tsx
+++ b/src/modules/add-site/components/blueprints.tsx
@@ -10,7 +10,7 @@ import {
 import { DataViews, View } from '@wordpress/dataviews';
 import { createInterpolateElement } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
-import { Icon, external, upload, error, caution } from '@wordpress/icons';
+import { Icon, external, upload, caution } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { useCallback, useRef, useState, useMemo } from 'react';
 import StudioButton from 'src/components/button';
@@ -42,7 +42,6 @@ interface DataViewBlueprint extends Blueprint {
 
 interface BlueprintIssuesModalProps {
 	warnings: Array< { feature: string; reason: string } > | undefined;
-	validationError: string | undefined;
 	fileName: string;
 	isOpen: boolean;
 	onClose: () => void;
@@ -50,7 +49,6 @@ interface BlueprintIssuesModalProps {
 
 function BlueprintIssuesModal( {
 	warnings,
-	validationError,
 	fileName,
 	isOpen,
 	onClose,
@@ -61,84 +59,59 @@ function BlueprintIssuesModal( {
 		return null;
 	}
 
-	const hasWarnings = warnings && warnings.length > 0;
-	const hasError = !! validationError;
-
 	return (
-		<Modal title={ __( 'Blueprint Details' ) } onRequestClose={ onClose } size="medium">
-			<VStack spacing={ 4 }>
+		<Modal
+			className="blueprints-issues-modal"
+			title={ __( 'Blueprint Details' ) }
+			onRequestClose={ onClose }
+			size="medium"
+		>
+			<div className="h-full flex flex-col gap-1">
 				<Text className="font-medium text-gray-900">{ fileName }</Text>
-
-				{ hasError && (
-					<div className="max-h-64 overflow-y-auto">
-						<VStack spacing={ 3 }>
-							<div>
+				<Text>
+					{ warnings?.length &&
+						sprintf(
+							// translators: %d is the number of unsupported features
+							__(
+								'The following %d feature(s) are not supported in Studio and will be automatically removed:'
+							),
+							warnings.length
+						) }
+				</Text>
+				<div className="flex-1 overflow-y-auto">
+					<VStack spacing={ 3 } className="divide-y divide-gray-200">
+						{ warnings?.map( ( warningItem, index ) => (
+							<div key={ index } className={ index > 0 ? 'pt-3' : '' }>
 								<HStack alignment="topLeft" spacing={ 2 }>
-									<Icon icon={ error } className="text-red-500 mt-1 flex-shrink-0" size={ 20 } />
+									<Icon
+										icon={ caution }
+										className="text-orange-500 mt-1 flex-shrink-0"
+										size={ 20 }
+									/>
 									<VStack spacing={ 1 }>
 										<Text weight={ 600 } className="text-base">
-											{ __( 'Validation Error' ) }
+											{ warningItem.feature }
 										</Text>
-										<Text className="text-sm text-gray-700">{ validationError }</Text>
+										<Text className="text-sm text-gray-700">{ warningItem.reason }</Text>
 									</VStack>
 								</HStack>
 							</div>
-						</VStack>
-					</div>
-				) }
-
-				{ hasWarnings && (
-					<>
-						<Text>
-							{ sprintf(
-								// translators: %d is the number of unsupported features
-								__(
-									'The following %d feature(s) are not supported in Studio and will be automatically removed:'
-								),
-								warnings.length
-							) }
-						</Text>
-
-						<div className="max-h-64 overflow-y-auto">
-							<VStack spacing={ 3 } className="divide-y divide-gray-200">
-								{ warnings.map( ( warningItem, index ) => (
-									<div key={ index } className={ index > 0 ? 'pt-3' : '' }>
-										<HStack alignment="topLeft" spacing={ 2 }>
-											<Icon
-												icon={ caution }
-												className="text-orange-500 mt-1 flex-shrink-0"
-												size={ 20 }
-											/>
-											<VStack spacing={ 1 }>
-												<Text weight={ 600 } className="text-base">
-													{ warningItem.feature }
-												</Text>
-												<Text className="text-sm text-gray-700">{ warningItem.reason }</Text>
-											</VStack>
-										</HStack>
-									</div>
-								) ) }
-							</VStack>
-						</div>
-					</>
-				) }
-
-				{ hasWarnings && ! hasError && (
-					<div className="pt-4 border-t border-gray-200">
-						<Text className="text-sm text-gray-600">
-							{ __(
-								'Your blueprint will still work, but these features will be skipped during site creation.'
-							) }
-						</Text>
-					</div>
-				) }
-
+						) ) }
+					</VStack>
+				</div>
+				<div className="pt-4 border-t border-gray-200">
+					<Text className="text-sm text-gray-600">
+						{ __(
+							'Your blueprint will still work, but these features will be skipped during site creation.'
+						) }
+					</Text>
+				</div>
 				<HStack alignment="right">
 					<Button variant="primary" onClick={ onClose }>
 						{ __( 'Got it' ) }
 					</Button>
 				</HStack>
-			</VStack>
+			</div>
 		</Modal>
 	);
 }
@@ -395,7 +368,6 @@ export function AddSiteBlueprintSelector( {
 
 			<BlueprintIssuesModal
 				warnings={ blueprintWarnings }
-				validationError={ validationError }
 				fileName={ selectedFileName || '' }
 				isOpen={ showIssuesModal }
 				onClose={ () => setShowIssuesModal( false ) }

--- a/src/modules/add-site/components/blueprints.tsx
+++ b/src/modules/add-site/components/blueprints.tsx
@@ -192,8 +192,8 @@ export function AddSiteBlueprintSelector( {
 
 	const handleBlueprintClick = useCallback(
 		( item: DataViewBlueprint ) => {
-			setValidationError( null );
-			setBlueprintWarnings( null );
+			setValidationError( undefined );
+			setBlueprintWarnings( undefined );
 			onBlueprintChange( item.slug );
 		},
 		[ onBlueprintChange ]

--- a/src/modules/add-site/components/blueprints.tsx
+++ b/src/modules/add-site/components/blueprints.tsx
@@ -40,21 +40,21 @@ interface DataViewBlueprint extends Blueprint {
 	categories: string[];
 }
 
-interface BlueprintDetailsModalProps {
-	warnings: Array< { feature: string; reason: string } > | null;
-	validationError: string | null;
+interface BlueprintIssuesModalProps {
+	warnings: Array< { feature: string; reason: string } > | undefined;
+	validationError: string | undefined;
 	fileName: string;
 	isOpen: boolean;
 	onClose: () => void;
 }
 
-function BlueprintDetailsModal( {
+function BlueprintIssuesModal( {
 	warnings,
 	validationError,
 	fileName,
 	isOpen,
 	onClose,
-}: BlueprintDetailsModalProps ) {
+}: BlueprintIssuesModalProps ) {
 	const { __ } = useI18n();
 
 	if ( ! isOpen ) {
@@ -68,7 +68,6 @@ function BlueprintDetailsModal( {
 		<Modal
 			title={ __( 'Blueprint Details' ) }
 			onRequestClose={ onClose }
-			className="blueprint-details-modal"
 			size="medium"
 		>
 			<VStack spacing={ 4 }>
@@ -168,14 +167,14 @@ export function AddSiteBlueprintSelector( {
 	const { __ } = useI18n();
 	const { refetch: refetchBlueprints, isFetching: isFetchingBlueprints } = useGetBlueprints();
 	const fileRef = useRef< HTMLInputElement | null >( null );
-	const [ validationError, setValidationError ] = useState< string | null >( null );
+	const [ validationError, setValidationError ] = useState< string | undefined >( undefined );
 	const [ blueprintWarnings, setBlueprintWarnings ] = useState< Array< {
 		feature: string;
 		reason: string;
 		alternative?: string;
-	} > | null >( null );
-	const [ showWarningsModal, setShowWarningsModal ] = useState( false );
+	} > | undefined >( undefined );
 	const [ uploadedFileName, setUploadedFileName ] = useState< string | null >( null );
+	const [ showIssuesModal, setShowIssuesModal ] = useState( false );
 
 	// Check if current selection is a file-based blueprint
 	const isFileBasedSelection = selectedBlueprint && selectedBlueprint.startsWith( 'file:' );
@@ -184,8 +183,8 @@ export function AddSiteBlueprintSelector( {
 
 	const handleRemoveFile = useCallback( () => {
 		onBlueprintChange( '' );
-		setValidationError( null );
-		setBlueprintWarnings( null );
+		setValidationError( undefined );
+		setBlueprintWarnings( undefined );
 		setUploadedFileName( null );
 		if ( fileRef.current ) {
 			fileRef.current.value = '';
@@ -295,8 +294,8 @@ export function AddSiteBlueprintSelector( {
 
 	const handleFileSelect = async ( event: React.ChangeEvent< HTMLInputElement > ) => {
 		const file = event.target.files?.[ 0 ];
-		setValidationError( null );
-		setBlueprintWarnings( null );
+		setValidationError( undefined );
+		setBlueprintWarnings( undefined );
 		setUploadedFileName( null );
 
 		if ( file && file.type === 'application/json' && onFileBlueprintSelect ) {
@@ -395,19 +394,19 @@ export function AddSiteBlueprintSelector( {
 				{ __( 'Start from a blueprint' ) }
 			</Heading>
 
-			<BlueprintDetailsModal
+			<BlueprintIssuesModal
 				warnings={ blueprintWarnings }
 				validationError={ validationError }
 				fileName={ selectedFileName || '' }
-				isOpen={ showWarningsModal }
-				onClose={ () => setShowWarningsModal( false ) }
+				isOpen={ showIssuesModal }
+				onClose={ () => setShowIssuesModal( false ) }
 			/>
 
 			{ validationError && (
 				<Notice
 					status="error"
 					isDismissible={ false }
-					onRemove={ () => setValidationError( null ) }
+					onRemove={ () => setValidationError( undefined ) }
 					className="mx-0 mb-4"
 				>
 					<strong>{ __( 'Blueprint validation failed' ) }</strong>
@@ -421,12 +420,12 @@ export function AddSiteBlueprintSelector( {
 					<div className="flex justify-between items-center w-full">
 						<span>
 							{ __(
-								'This blueprint uses some unsupported features in Studio and might not work as expected.'
+								'This blueprint uses unsupported features in Studio and might not work as expected.'
 							) }
 						</span>
 						<Button
 							variant="link"
-							onClick={ () => setShowWarningsModal( true ) }
+							onClick={ () => setShowIssuesModal( true ) }
 							className="!text-inherit !p-0 !underline"
 						>
 							{ __( 'View details' ) }

--- a/src/modules/add-site/components/blueprints.tsx
+++ b/src/modules/add-site/components/blueprints.tsx
@@ -408,7 +408,7 @@ export function AddSiteBlueprintSelector( {
 					status="error"
 					isDismissible={ false }
 					onRemove={ () => setValidationError( null ) }
-					className="mx-3 mb-4"
+					className="mx-0 mb-4"
 				>
 					<strong>{ __( 'Blueprint validation failed' ) }</strong>
 					<br />
@@ -417,7 +417,7 @@ export function AddSiteBlueprintSelector( {
 			) }
 
 			{ ! validationError && blueprintWarnings && blueprintWarnings.length > 0 && (
-				<Notice status="warning" isDismissible={ false } className="mx-3 mb-4">
+				<Notice status="warning" isDismissible={ false } className="mx-0 mb-4">
 					<div className="flex justify-between items-center w-full">
 						<span>
 							{ __(

--- a/src/site-server.ts
+++ b/src/site-server.ts
@@ -4,7 +4,7 @@ import * as Sentry from '@sentry/electron/main';
 import fsExtra from 'fs-extra';
 import { parse } from 'shell-quote';
 import { portFinder } from 'common/lib/port-finder';
-import { filterUnsupportedFeatures } from 'src/lib/blueprint-features';
+import { filterUnsupportedBlueprintFeatures } from 'src/lib/blueprint-features';
 import { deleteSiteCertificate, generateSiteCertificate } from 'src/lib/certificate-manager';
 import { getSiteUrl } from 'src/lib/get-site-url';
 import { addDomainToHosts, removeDomainFromHosts, updateDomainInHosts } from 'src/lib/hosts-file';
@@ -133,10 +133,7 @@ export class SiteServer {
 			await startProxyServer();
 		}
 
-		let filteredBlueprint = this.meta.blueprint?.blueprint;
-		if ( filteredBlueprint ) {
-			filteredBlueprint = filterUnsupportedFeatures( filteredBlueprint );
-		}
+		const filteredBlueprint = filterUnsupportedBlueprintFeatures( this.meta.blueprint?.blueprint );
 
 		const serverInstance = await startServer( {
 			path: this.details.path,

--- a/src/site-server.ts
+++ b/src/site-server.ts
@@ -4,6 +4,7 @@ import * as Sentry from '@sentry/electron/main';
 import fsExtra from 'fs-extra';
 import { parse } from 'shell-quote';
 import { portFinder } from 'common/lib/port-finder';
+import { filterUnsupportedFeatures } from 'src/lib/blueprint-features';
 import { deleteSiteCertificate, generateSiteCertificate } from 'src/lib/certificate-manager';
 import { getSiteUrl } from 'src/lib/get-site-url';
 import { addDomainToHosts, removeDomainFromHosts, updateDomainInHosts } from 'src/lib/hosts-file';
@@ -132,10 +133,8 @@ export class SiteServer {
 			await startProxyServer();
 		}
 
-		// Filter out unsupported blueprint features before execution
 		let filteredBlueprint = this.meta.blueprint?.blueprint;
 		if ( filteredBlueprint ) {
-			const { filterUnsupportedFeatures } = await import( 'src/lib/blueprint-features' );
 			filteredBlueprint = filterUnsupportedFeatures( filteredBlueprint );
 		}
 

--- a/src/site-server.ts
+++ b/src/site-server.ts
@@ -132,6 +132,13 @@ export class SiteServer {
 			await startProxyServer();
 		}
 
+		// Filter out unsupported blueprint features before execution
+		let filteredBlueprint = this.meta.blueprint?.blueprint;
+		if ( filteredBlueprint ) {
+			const { filterUnsupportedFeatures } = await import( 'src/lib/blueprint-features' );
+			filteredBlueprint = filterUnsupportedFeatures( filteredBlueprint );
+		}
+
 		const serverInstance = await startServer( {
 			path: this.details.path,
 			port: this.details.port,
@@ -141,6 +148,7 @@ export class SiteServer {
 			wpVersion: this.meta.wpVersion,
 			isWpAutoUpdating: this.details.isWpAutoUpdating,
 			absoluteUrl: getAbsoluteUrl( this.details ),
+			blueprint: filteredBlueprint,
 		} );
 
 		const isPortAvailable = await portFinder.isPortAvailable( this.details.port );


### PR DESCRIPTION
## Related issues

- Fixes STU-808

## Proposed Changes

- Added blueprint feature scanning and filtering functionality to identify unsupported features
- Updated validation in IPC handlers to return warnings for unsupported blueprint features
- Enhanced blueprint selection UI to display clear warnings about unsupported features
- Improved error/warning messaging UX by replacing confusing "View details" with clear explanations
- Added modal for detailed feature warnings with specific information about what's not supported
- Implemented filtering to remove unsupported features before blueprint execution to prevent errors

| Notice | Details |
|--------|--------|
| <img width="2110" height="1496" alt="image" src="https://github.com/user-attachments/assets/5bf8b9b5-eaa9-4ddf-8fb8-3fe3ad4d40cc" /> | <img width="2110" height="1496" alt="image" src="https://github.com/user-attachments/assets/0a940db3-d886-49f6-927f-d410617117f0" /> | 

## Testing Instructions

- Open Studio and navigate to the blueprint selection screen
- Select a blueprint that contains unsupported features (e.g., multisite functionality)
- Verify that warning messages are displayed clearly indicating which features are unsupported
- Confirm that the warning modal provides detailed information about unsupported features
- Test that blueprint creation still proceeds but with unsupported features filtered out
- Verify that no console errors occur during the blueprint selection and creation process
- Test with blueprints that have no unsupported features to ensure normal flow is unaffected

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?