### PR TITLE
Add @wp-playground to Dependabot configs to enable autoupdates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,7 @@ updates:
       - dependency-name: "@electron-forge/*"
       - dependency-name: "@wordpress/*"
       - dependency-name: "@wp-playground/*"
+      - dependency-name: "@php-wasm/*"
       - dependency-name: "@types/*"
       - dependency-name: "eslint"
       - dependency-name: "eslint-*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,7 @@ updates:
       - dependency-name: "@automattic/*"
       - dependency-name: "@electron-forge/*"
       - dependency-name: "@wordpress/*"
+      - dependency-name: "@wp-playground/*"
       - dependency-name: "@types/*"
       - dependency-name: "eslint"
       - dependency-name: "eslint-*"


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- N/A

## Proposed Changes

I propose to add @wp-playground to Dependabot configs to enable autoupdates.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- N/A

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
