### PR TITLE
Fix playground CLI to respect Studio language settings

### DIFF
--- a/src/lib/wordpress-provider/playground-cli/playground-cli-provider.ts
+++ b/src/lib/wordpress-provider/playground-cli/playground-cli-provider.ts
@@ -71,6 +71,7 @@ export class PlaygroundCliProvider implements WordPressProvider {
 			autoMount: true,
 			skipWordpressSetup: true,
 			isSetupMode: options.isSetupMode || false,
+			blueprint: options.blueprint,
 		};
 
 		const serverOptions: WordPressServerOptions = {

--- a/src/lib/wordpress-provider/playground-cli/playground-cli-provider.ts
+++ b/src/lib/wordpress-provider/playground-cli/playground-cli-provider.ts
@@ -5,6 +5,7 @@ import { Blueprint } from '@wp-playground/blueprints';
 import { RecommendedPHPVersion } from '@wp-playground/common';
 import fs from 'fs-extra';
 import { recursiveCopyDirectory, pathExists } from 'common/lib/fs-utils';
+import { getPreferredSiteLanguage } from 'src/lib/site-language';
 import { installSqliteIntegration } from 'src/lib/sqlite-versions';
 import { isValidWordPressVersion } from 'src/lib/wordpress-version-utils';
 import { SiteServer } from 'src/site-server';
@@ -70,7 +71,6 @@ export class PlaygroundCliProvider implements WordPressProvider {
 			autoMount: true,
 			skipWordpressSetup: true,
 			isSetupMode: options.isSetupMode || false,
-			blueprint: options.blueprint,
 		};
 
 		const serverOptions: WordPressServerOptions = {
@@ -81,9 +81,9 @@ export class PlaygroundCliProvider implements WordPressProvider {
 			projectPath: options.path,
 			adminPassword: options.adminPassword,
 			siteTitle: options.siteTitle,
-			siteLanguage: options.siteLanguage,
 			wordPressVersion: options.wpVersion,
 			isWpAutoUpdating: options.isWpAutoUpdating,
+			siteLanguage: options.siteLanguage,
 		};
 
 		return {
@@ -160,7 +160,7 @@ export class PlaygroundCliProvider implements WordPressProvider {
 				return true;
 			}
 
-			// Online mode: run the blueprint setup
+			const siteLanguage = await getPreferredSiteLanguage( wpVersion );
 			const serverInstance = await this.startServer( {
 				path,
 				port,
@@ -171,6 +171,7 @@ export class PlaygroundCliProvider implements WordPressProvider {
 				isWpAutoUpdating: false,
 				isSetupMode: true,
 				blueprint: blueprint?.blueprint,
+				siteLanguage,
 			} );
 
 			const serverProcess = this.createServerProcess( serverInstance );

--- a/src/lib/wordpress-provider/playground-cli/playground-cli-provider.ts
+++ b/src/lib/wordpress-provider/playground-cli/playground-cli-provider.ts
@@ -81,9 +81,9 @@ export class PlaygroundCliProvider implements WordPressProvider {
 			projectPath: options.path,
 			adminPassword: options.adminPassword,
 			siteTitle: options.siteTitle,
+			siteLanguage: options.siteLanguage,
 			wordPressVersion: options.wpVersion,
 			isWpAutoUpdating: options.isWpAutoUpdating,
-			siteLanguage: options.siteLanguage,
 		};
 
 		return {

--- a/src/lib/wordpress-provider/playground-cli/playground-server-process-child.ts
+++ b/src/lib/wordpress-provider/playground-cli/playground-server-process-child.ts
@@ -176,6 +176,27 @@ async function startServer(
 			};
 		}
 
+		if ( serverOptions.siteLanguage ) {
+			if ( ! args.blueprint.steps ) {
+				args.blueprint.steps = [];
+			}
+
+			args.blueprint.steps.unshift(
+				...[
+					{
+						step: 'setSiteLanguage',
+						language: serverOptions.siteLanguage,
+					},
+					{
+						step: 'runPHP',
+						code: `<?php require_once( '/wordpress/wp-load.php' ); update_option( 'WPLANG', '${ escapePhpString(
+							serverOptions.siteLanguage
+						) }' ); echo "Language set to: ${ escapePhpString( serverOptions.siteLanguage ) }"; ?>`,
+					},
+				]
+			);
+		}
+
 		server = await runCLI( args );
 
 		if ( serverOptions.siteTitle || serverOptions.adminPassword ) {

--- a/src/lib/wordpress-provider/playground-cli/playground-server-process-child.ts
+++ b/src/lib/wordpress-provider/playground-cli/playground-server-process-child.ts
@@ -3,6 +3,7 @@ import { runCLI, RunCLIArgs, RunCLIServer } from '@wp-playground/cli';
 import { WordPressServerOptions } from '../types';
 import { getMuPlugins } from './mu-plugins';
 import { PlaygroundCliOptions } from './playground-cli-provider';
+import { DEFAULT_LOCALE } from 'common/lib/locale';
 
 interface Message {
 	id: number;
@@ -176,7 +177,7 @@ async function startServer(
 			};
 		}
 
-		if ( serverOptions.siteLanguage ) {
+		if ( serverOptions.siteLanguage && serverOptions.siteLanguage !== DEFAULT_LOCALE ) {
 			if ( ! args.blueprint.steps ) {
 				args.blueprint.steps = [];
 			}

--- a/src/lib/wordpress-provider/playground-cli/playground-server-process-child.ts
+++ b/src/lib/wordpress-provider/playground-cli/playground-server-process-child.ts
@@ -1,9 +1,9 @@
 import { SupportedPHPVersion, PHPRunOptions } from '@php-wasm/universal';
 import { runCLI, RunCLIArgs, RunCLIServer } from '@wp-playground/cli';
+import { DEFAULT_LOCALE } from 'common/lib/locale';
 import { WordPressServerOptions } from '../types';
 import { getMuPlugins } from './mu-plugins';
 import { PlaygroundCliOptions } from './playground-cli-provider';
-import { DEFAULT_LOCALE } from 'common/lib/locale';
 
 interface Message {
 	id: number;

--- a/src/lib/wordpress-provider/playground-cli/playground-server-process-child.ts
+++ b/src/lib/wordpress-provider/playground-cli/playground-server-process-child.ts
@@ -178,11 +178,7 @@ async function startServer(
 		}
 
 		if ( serverOptions.siteLanguage && serverOptions.siteLanguage !== DEFAULT_LOCALE ) {
-			if ( ! args.blueprint.steps ) {
-				args.blueprint.steps = [];
-			}
-
-			args.blueprint.steps.unshift(
+			args.blueprint.steps = [
 				...[
 					{
 						step: 'setSiteLanguage',
@@ -194,8 +190,9 @@ async function startServer(
 							serverOptions.siteLanguage
 						) }' ); echo "Language set to: ${ escapePhpString( serverOptions.siteLanguage ) }"; ?>`,
 					},
-				]
-			);
+				],
+				...( args.blueprint.steps || [] ),
+			];
 		}
 
 		server = await runCLI( args );


### PR DESCRIPTION
Fixes [STU-822](https://linear.app/a8c/issue/STU-822/create-sites-language-doesnt-match-studio-language)

## Proposed Changes
- Import `getPreferredSiteLanguage` to detect Studio language preference
- Pass language setting through to playground CLI during site setup
- Add `setSiteLanguage` blueprint step to download and install language packs
- Add `runPHP` step to ensure WPLANG option is set correctly

## Testing Instructions
1. Set your Studio to a non-English locale
2. Create a new WordPress site in Studio
3. Verify the site language matches your Studio settings
4. Stop and restart the site
5. Verify the language setting persists

## Pre-merge Checklist
- [ ] Have you checked for TypeScript, React or other console errors?