### PR TITLE
Fix add site modal cross position for RTL languages

### DIFF
--- a/src/components/fullscreen-modal.tsx
+++ b/src/components/fullscreen-modal.tsx
@@ -57,7 +57,7 @@ export const FullscreenModal: React.FC< FullscreenModalProps > = ( {
 			role="dialog"
 			aria-modal="true"
 		>
-			<HStack className="flex justify-end rtl:justify-start p-4">
+			<HStack className="flex justify-end p-4 rtl:mt-6">
 				<Button icon={ close } onClick={ onClose } label="Close" />
 			</HStack>
 			<VStack alignment="top" className="w-full flex-1 overflow-y-auto px-6 pb-6">

--- a/src/components/fullscreen-modal.tsx
+++ b/src/components/fullscreen-modal.tsx
@@ -60,7 +60,7 @@ export const FullscreenModal: React.FC< FullscreenModalProps > = ( {
 			role="dialog"
 			aria-modal="true"
 		>
-			<HStack className="flex justify-end p-4">
+			<HStack className="flex justify-end p-4 app-no-drag-region">
 				<Button icon={ close } onClick={ onClose } label="Close" />
 			</HStack>
 			<VStack alignment="top" className="w-full flex-1 overflow-y-auto px-6 pb-6">

--- a/src/components/fullscreen-modal.tsx
+++ b/src/components/fullscreen-modal.tsx
@@ -5,6 +5,8 @@ import {
 } from '@wordpress/components';
 import { close } from '@wordpress/icons';
 import React, { useEffect, useRef } from 'react';
+import { isWindows } from 'src/lib/app-globals';
+import { cx } from 'src/lib/cx';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 
 interface FullscreenModalProps {
@@ -60,7 +62,9 @@ export const FullscreenModal: React.FC< FullscreenModalProps > = ( {
 			role="dialog"
 			aria-modal="true"
 		>
-			<HStack className="flex justify-end p-4 app-no-drag-region">
+			<HStack
+				className={ cx( 'flex justify-end p-4 app-no-drag-region', isWindows() && 'ltr:pt-8' ) }
+			>
 				<Button icon={ close } onClick={ onClose } label="Close" />
 			</HStack>
 			<VStack alignment="top" className="w-full flex-1 overflow-y-auto px-6 pb-6">

--- a/src/components/fullscreen-modal.tsx
+++ b/src/components/fullscreen-modal.tsx
@@ -5,6 +5,7 @@ import {
 } from '@wordpress/components';
 import { close } from '@wordpress/icons';
 import React, { useEffect, useRef } from 'react';
+import { getIpcApi } from 'src/lib/get-ipc-api';
 
 interface FullscreenModalProps {
 	isOpen: boolean;
@@ -28,6 +29,7 @@ export const FullscreenModal: React.FC< FullscreenModalProps > = ( {
 		};
 
 		if ( isOpen ) {
+			void getIpcApi().setWindowControlVisibility( false );
 			document.addEventListener( 'keydown', handleEscKey );
 			document.body.style.overflow = 'hidden';
 			previousActiveElement.current = document.activeElement as HTMLElement;
@@ -37,6 +39,7 @@ export const FullscreenModal: React.FC< FullscreenModalProps > = ( {
 		}
 
 		return () => {
+			void getIpcApi().setWindowControlVisibility( true );
 			document.removeEventListener( 'keydown', handleEscKey );
 			document.body.style.overflow = '';
 			if ( previousActiveElement.current && previousActiveElement.current.focus ) {

--- a/src/components/fullscreen-modal.tsx
+++ b/src/components/fullscreen-modal.tsx
@@ -60,7 +60,7 @@ export const FullscreenModal: React.FC< FullscreenModalProps > = ( {
 			role="dialog"
 			aria-modal="true"
 		>
-			<HStack className="flex justify-end p-4 rtl:mt-6">
+			<HStack className="flex justify-end p-4">
 				<Button icon={ close } onClick={ onClose } label="Close" />
 			</HStack>
 			<VStack alignment="top" className="w-full flex-1 overflow-y-auto px-6 pb-6">

--- a/src/components/tests/main-sidebar.test.tsx
+++ b/src/components/tests/main-sidebar.test.tsx
@@ -50,6 +50,7 @@ jest.mock( 'src/lib/get-ipc-api', () => ( {
 		generateProposedSitePath: jest.fn(),
 		openURL: jest.fn(),
 		getAllCustomDomains: jest.fn().mockResolvedValue( [] ),
+		setWindowControlVisibility: jest.fn(),
 	} ),
 } ) );
 

--- a/src/components/tests/site-content-tabs.test.tsx
+++ b/src/components/tests/site-content-tabs.test.tsx
@@ -33,6 +33,7 @@ jest.mock( 'src/lib/get-ipc-api', () => ( {
 		updateConnectedWpcomSites: jest.fn(),
 		getUserTerminal: jest.fn().mockResolvedValue( 'terminal' ),
 		getUserEditor: jest.fn().mockResolvedValue( 'vscode' ),
+		setWindowControlVisibility: jest.fn(),
 	} ),
 } ) );
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -86,6 +86,7 @@ export const IPC_VOID_HANDLERS = < const >[
 	'openSiteURL',
 	'openURL',
 	'popupAppMenu',
+	'setWindowButtonVisibility',
 	'showErrorMessageBox',
 	'showItemInFolder',
 	'showNotification',

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -1500,8 +1500,8 @@ export async function validateBlueprint(
 }
 
 export async function setWindowControlVisibility( event: IpcMainInvokeEvent, visible: boolean ) {
-	const window = BrowserWindow.fromWebContents( event.sender );
-	if ( window && process.platform === 'darwin' ) {
-		window.setWindowButtonVisibility( visible );
+	const parentWindow = BrowserWindow.fromWebContents( event.sender );
+	if ( parentWindow && process.platform === 'darwin' ) {
+		parentWindow.setWindowButtonVisibility( visible );
 	}
 }

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -1498,3 +1498,10 @@ export async function validateBlueprint(
 		warnings: warnings.length > 0 ? warnings : undefined,
 	};
 }
+
+export async function setWindowControlVisibility( event: IpcMainInvokeEvent, visible: boolean ) {
+	const window = BrowserWindow.fromWebContents( event.sender );
+	if ( window && process.platform === 'darwin' ) {
+		window.setWindowButtonVisibility( visible );
+	}
+}

--- a/src/modules/add-site/tests/add-site.test.tsx
+++ b/src/modules/add-site/tests/add-site.test.tsx
@@ -56,6 +56,7 @@ jest.mock( 'src/lib/get-ipc-api', () => ( {
 		showOpenFolderDialog: mockShowOpenFolderDialog,
 		generateProposedSitePath: mockGenerateProposedSitePath,
 		getAllCustomDomains: mockGetAllCustomDomains,
+		setWindowControlVisibility: jest.fn(),
 	} ),
 } ) );
 

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -123,6 +123,8 @@ const api: IpcApi = {
 		ipcRenderer.invoke( 'listWpContentFolders', siteId, subdir ),
 	getProviderConstants: () => ipcRendererInvoke( 'getProviderConstants' ),
 	validateBlueprint: ( blueprintJson ) => ipcRendererInvoke( 'validateBlueprint', blueprintJson ),
+	setWindowControlVisibility: ( visible ) =>
+		ipcRendererInvoke( 'setWindowControlVisibility', visible ),
 };
 
 contextBridge.exposeInMainWorld( 'ipcApi', api );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-820

## Proposed Changes

- Hide the window controls on Mac to fix the close cross button for RTL and LTR languages in add site modal
- Fix the position of the close button for Windows on LTR languages. Hiding the window controls would require a big refactor.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run `npm start`
- Change the Studio language to RTL form the settings menu
- Click on `Add site` in the sidebar
- Observe the close button is on the left

| Before | After |
|--------|--------|
|  <img width="2138" height="1424" alt="Screenshot 2025-09-26 at 01 43 23" src="https://github.com/user-attachments/assets/bcf58017-313a-443c-ae25-a63ad6be41a7" /> | <img width="2138" height="1424" alt="Screenshot 2025-09-26 at 13 05 04" src="https://github.com/user-attachments/assets/c784609e-6ea7-44b1-879b-d0724ee4e2e0" /> |
| <img width="1800" height="1274" alt="Screenshot 2025-09-26 at 13 23 59" src="https://github.com/user-attachments/assets/5e8c6b24-d999-4b30-8d8a-f048d4ea1805" /> | <img width="1796" height="1270" alt="Screenshot 2025-09-26 at 13 04 07" src="https://github.com/user-attachments/assets/99604514-61f4-4ce7-b545-0cef58649861" /> |




## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
