### PR TITLE
Studio: Clean up stack traces from .wpress import error dialogs

### DIFF
--- a/src/hooks/use-import-export.tsx
+++ b/src/hooks/use-import-export.tsx
@@ -111,7 +111,10 @@ export const ImportExportProvider = ( { children }: { children: React.ReactNode 
 					} );
 				} else {
 					let errorToShow = error;
-					if ( file instanceof File && file.name.endsWith( '.sql' ) ) {
+					if (
+						file instanceof File &&
+						( file.name.endsWith( '.sql' ) || file.name.endsWith( '.wpress' ) )
+					) {
 						const errorMessage = ( error as Error )?.message;
 						if ( errorMessage ) {
 							const firstLine = errorMessage.split( '\n' )[ 0 ].trim();

--- a/src/hooks/use-import-export.tsx
+++ b/src/hooks/use-import-export.tsx
@@ -111,15 +111,10 @@ export const ImportExportProvider = ( { children }: { children: React.ReactNode 
 					} );
 				} else {
 					let errorToShow = error;
-					if (
-						file instanceof File &&
-						( file.name.endsWith( '.sql' ) || file.name.endsWith( '.wpress' ) )
-					) {
-						const errorMessage = ( error as Error )?.message;
-						if ( errorMessage ) {
-							const firstLine = errorMessage.split( '\n' )[ 0 ].trim();
-							errorToShow = new Error( firstLine );
-						}
+					const errorMessage = ( error as Error )?.message;
+					if ( errorMessage ) {
+						const firstLine = errorMessage.split( '\n' )[ 0 ].trim();
+						errorToShow = new Error( firstLine );
 					}
 
 					getIpcApi().showErrorMessageBox( {


### PR DESCRIPTION
## Related issues

- Fixes STU-814

## Proposed Changes

- Extended error handling in src/hooks/use-import-export.tsx to include .wpress files alongside .sql files
- Stack traces are now stripped from error messages for .wpress file imports, showing only the first line of the error

## Testing Instructions

- Import a corrupted or invalid .wpress file in Studio (you can find one in the Linear issue)
- Verify that the error dialog shows only a clean error message without stack traces
- Test that .sql file error handling still works as expected

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?