### PR TITLE
Studio: Capitalize Blueprint throughout the app to match dev docs

### DIFF
--- a/e2e/page-objects/add-site-modal.ts
+++ b/e2e/page-objects/add-site-modal.ts
@@ -13,7 +13,7 @@ export default class AddSiteModal {
 	}
 
 	get blueprintButton() {
-		return this.page.locator( 'button:has-text("Start from a blueprint")' ).first();
+		return this.page.locator( 'button:has-text("Start from a Blueprint")' ).first();
 	}
 
 	get continueButton() {

--- a/src/components/site-form.tsx
+++ b/src/components/site-form.tsx
@@ -445,9 +445,9 @@ export const SiteForm = ( {
 
 								{ showBlueprintVersionWarning && (
 									<Notice status="warning" isDismissible={ false } className="mt-4">
-										<strong>{ __( 'Version differs from blueprint recommendation' ) }</strong>
+										<strong>{ __( 'Version differs from Blueprint recommendation' ) }</strong>
 										<br />
-										{ __( 'This blueprint recommends:' ) }
+										{ __( 'This Blueprint recommends:' ) }
 										<ul style={ { marginTop: '8px', marginBottom: '4px', paddingLeft: '20px' } }>
 											{ blueprintPreferredVersions.php &&
 												blueprintPreferredVersions.php !== phpVersion && (

--- a/src/hooks/use-site-details.tsx
+++ b/src/hooks/use-site-details.tsx
@@ -213,7 +213,7 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 				if ( isBlueprintError && hasBlueprint ) {
 					title = __( 'Blueprint execution failed' );
 					message = __(
-						'The selected blueprint failed to execute properly. This could be due to invalid PHP code, missing plugins, or other issues in the blueprint file. Please check your blueprint file and try again.'
+						'The selected Blueprint failed to execute properly. This could be due to invalid PHP code, missing plugins, or other issues in the Blueprint file. Please check your Blueprint file and try again.'
 					);
 				} else {
 					title = __( 'Failed to create site' );

--- a/src/modules/add-site/components/blueprints.tsx
+++ b/src/modules/add-site/components/blueprints.tsx
@@ -102,7 +102,7 @@ function BlueprintIssuesModal( {
 				<div className="pt-4 border-t border-gray-200">
 					<Text className="text-sm text-gray-600">
 						{ __(
-							'Your blueprint will still work, but these features will be skipped during site creation.'
+							'Your Blueprint will still work, but these features will be skipped during site creation.'
 						) }
 					</Text>
 				</div>
@@ -236,7 +236,7 @@ export function AddSiteBlueprintSelector( {
 								handlePreviewClick( e, item )
 							}
 						>
-							{ __( 'Preview blueprint' ) }
+							{ __( 'Preview Blueprint' ) }
 							<Icon icon={ external } size={ 16 } className="ml-1" />
 						</StudioButton>
 					</HStack>
@@ -321,7 +321,7 @@ export function AddSiteBlueprintSelector( {
 						)
 					);
 				} else {
-					setValidationError( __( 'Failed to load blueprint file. Please try again.' ) );
+					setValidationError( __( 'Failed to load Blueprint file. Please try again.' ) );
 				}
 				console.error( 'Failed to parse blueprint file:', error );
 			}
@@ -353,9 +353,9 @@ export function AddSiteBlueprintSelector( {
 		return (
 			<VStack className="w-full max-w-6xl mx-auto">
 				<Heading className="text-center text-[32px] text-gray-900 mb-[28px]" weight={ 500 }>
-					{ __( 'Start from a blueprint' ) }
+					{ __( 'Start from a Blueprint' ) }
 				</Heading>
-				<Text>{ __( 'Loading blueprints...' ) }</Text>
+				<Text>{ __( 'Loading Blueprints...' ) }</Text>
 			</VStack>
 		);
 	}
@@ -363,7 +363,7 @@ export function AddSiteBlueprintSelector( {
 	return (
 		<VStack className="w-full max-w-4xl mx-auto px-0.5" spacing={ 0 }>
 			<Heading className="text-center text-[32px] text-gray-900 mb-5" weight={ 500 }>
-				{ __( 'Start from a blueprint' ) }
+				{ __( 'Start from a Blueprint' ) }
 			</Heading>
 
 			<BlueprintIssuesModal
@@ -391,7 +391,7 @@ export function AddSiteBlueprintSelector( {
 					<div className="flex justify-between items-center w-full">
 						<span>
 							{ __(
-								'This blueprint uses unsupported features in Studio and might not work as expected.'
+								'This Blueprint uses unsupported features in Studio and might not work as expected.'
 							) }
 						</span>
 						<Button
@@ -408,7 +408,7 @@ export function AddSiteBlueprintSelector( {
 			<HStack alignment="edge" className="w-full mb-5 ">
 				<HStack alignment="left" className="flex-1">
 					<Text className="text-[16px]" weight={ 500 }>
-						{ __( 'Featured blueprints' ) }
+						{ __( 'Featured Blueprints' ) }
 					</Text>
 				</HStack>
 				{ selectedFileName ? (
@@ -440,7 +440,7 @@ export function AddSiteBlueprintSelector( {
 							} }
 							icon={ upload }
 						>
-							{ __( 'Choose blueprint file' ) }
+							{ __( 'Choose Blueprint file' ) }
 						</Button>
 					</label>
 				) }
@@ -449,14 +449,14 @@ export function AddSiteBlueprintSelector( {
 			<div className="blueprints-container w-full pb-1">
 				{ isFetchingBlueprints && (
 					<Text className="text-[14px] block text-center py-[100px]">
-						{ __( 'Loading blueprints...' ) }
+						{ __( 'Loading Blueprints...' ) }
 					</Text>
 				) }
 				{ errorMessage && ! isFetchingBlueprints && (
 					<Text className="text-[14px] block text-center py-[100px]">
 						{ createInterpolateElement(
 							__(
-								'Studio could not load blueprints. <button>Try again</button> or use your own blueprint.'
+								'Studio could not load Blueprints. <button>Try again</button> or use your own Blueprint.'
 							),
 							{
 								button: <Button variant="link" onClick={ refetchBlueprints } />,

--- a/src/modules/add-site/components/options.tsx
+++ b/src/modules/add-site/components/options.tsx
@@ -81,7 +81,7 @@ export default function AddSiteOptions( { onOptionSelect }: AddSiteOptionsProps 
 				{ __( 'Add a site' ) }
 			</Heading>
 			<Text className="text-[15px] font-light text-gray-700 w-72 mb-[28px]">
-				{ __( 'Add a clean site, start from a blueprint or import site from a backup' ) }
+				{ __( 'Add a clean site, start from a Blueprint or import site from a backup' ) }
 			</Text>
 			<OptionButton
 				icon={ <Icon className="" icon={ plus } size={ 26 } fill="#3858E9" /> }
@@ -92,8 +92,8 @@ export default function AddSiteOptions( { onOptionSelect }: AddSiteOptionsProps 
 			{ enableBlueprints && (
 				<OptionButton
 					icon={ <BlueprintIcon size={ 24 } /> }
-					title={ __( 'Start from a blueprint' ) }
-					description={ __( 'Choose a featured blueprint or use your own' ) }
+					title={ __( 'Start from a Blueprint' ) }
+					description={ __( 'Choose a featured Blueprint or use your own' ) }
 					onClick={ () => onOptionSelect( 'blueprint' ) }
 					disabled={ isOffline }
 					disabledTooltip={ offlineMessage }

--- a/src/modules/add-site/hooks/use-stepper.ts
+++ b/src/modules/add-site/hooks/use-stepper.ts
@@ -40,7 +40,7 @@ export function useStepper( config?: StepperConfig ): UseStepper {
 
 	const stepperContext = useMemo( (): StepperContext | null => {
 		const blueprintSteps: StepperStep[] = [
-			{ id: 'choose-blueprint', label: __( 'Choose blueprint' ), path: '/blueprint' },
+			{ id: 'choose-blueprint', label: __( 'Choose Blueprint' ), path: '/blueprint' },
 			{ id: 'site-details', label: __( 'Site name & details' ), path: '/blueprint/create' },
 		];
 

--- a/src/modules/add-site/tests/add-site.test.tsx
+++ b/src/modules/add-site/tests/add-site.test.tsx
@@ -573,7 +573,7 @@ describe( 'AddSite', () => {
 		await user.click( screen.getByRole( 'button', { name: 'Add site' } ) );
 		await user.click(
 			screen.getByRole( 'button', {
-				name: 'Start from a blueprint Choose a featured blueprint or use your own',
+				name: 'Start from a Blueprint Choose a featured Blueprint or use your own',
 			} )
 		);
 
@@ -593,7 +593,7 @@ describe( 'AddSite', () => {
 		// Should show warning since PHP version differs from preferred (8.1)
 		await waitFor( () => {
 			expect(
-				screen.getByText( 'Version differs from blueprint recommendation' )
+				screen.getByText( 'Version differs from Blueprint recommendation' )
 			).toBeInTheDocument();
 			expect( screen.getByText( 'PHP 8.1 (currently 8.3)' ) ).toBeInTheDocument();
 		} );
@@ -635,7 +635,7 @@ describe( 'AddSite', () => {
 		await user.click( screen.getByRole( 'button', { name: 'Add site' } ) );
 		await user.click(
 			screen.getByRole( 'button', {
-				name: 'Start from a blueprint Choose a featured blueprint or use your own',
+				name: 'Start from a Blueprint Choose a featured Blueprint or use your own',
 			} )
 		);
 
@@ -650,7 +650,7 @@ describe( 'AddSite', () => {
 
 		// Should not show warning since versions match preferred versions
 		expect(
-			screen.queryByText( 'Version differs from blueprint recommendation' )
+			screen.queryByText( 'Version differs from Blueprint recommendation' )
 		).not.toBeInTheDocument();
 	} );
 } );

--- a/src/modules/whats-new/components/whats-new-modal.tsx
+++ b/src/modules/whats-new/components/whats-new-modal.tsx
@@ -60,7 +60,7 @@ export default function WhatsNewModal( { showModal, onClose }: WhatsNewModalProp
 			image: blueprintsIllustration,
 			title: __( 'Introducing Blueprints, a new way to streamline site creation.' ),
 			description: __(
-				'Select a blueprint that fits your needs and build your WordPress site even faster.'
+				'Select a Blueprint that fits your needs and build your WordPress site even faster.'
 			),
 			learnMoreUrl: getLocalizedLink( locale, 'docsBlueprints' ),
 		},


### PR DESCRIPTION
## Related issues

- Fixes STU-823

## Proposed Changes

- Capitalized "Blueprint" and "Blueprints" throughout the Studio app to treat it as a proper noun/product name
- Updated all UI strings from "blueprint" to "Blueprint" for consistency with dev documentation

## Testing Instructions

- Navigate through the add site flow and verify all Blueprint-related text uses proper capitalization
- Code review

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?