### PR TITLE
Studio: Fix WordPress installation completion when offline

### DIFF
--- a/src/lib/wordpress-provider/playground-cli/playground-cli-provider.ts
+++ b/src/lib/wordpress-provider/playground-cli/playground-cli-provider.ts
@@ -204,6 +204,13 @@ export class PlaygroundCliProvider implements WordPressProvider {
 	}
 
 	/**
+	 * Properly escape a string for safe use in PHP code
+	 */
+	private escapePhpString( str: string ): string {
+		return str.replace( /\\/g, '\\\\' ).replace( /'/g, "\\'" );
+	}
+
+	/**
 	 * Run WordPress installation steps directly to avoid web-based setup wizard
 	 */
 	private async runWordPressInstallation( options: {
@@ -232,12 +239,12 @@ export class PlaygroundCliProvider implements WordPressProvider {
 			await serverProcess.runPhp( {
 				code: `<?php
 					$_POST = array(
-						'language' => '${ options.siteLanguage }',
+						'language' => '${ this.escapePhpString( options.siteLanguage ) }',
 						'prefix' => 'wp_',
-						'weblog_title' => '${ options.siteTitle.replace( /'/g, "\\'" ) }',
+						'weblog_title' => '${ this.escapePhpString( options.siteTitle ) }',
 						'user_name' => 'admin',
-						'admin_password' => '${ options.adminPassword.replace( /'/g, "\\'" ) }',
-						'admin_password2' => '${ options.adminPassword.replace( /'/g, "\\'" ) }',
+						'admin_password' => '${ this.escapePhpString( options.adminPassword ) }',
+						'admin_password2' => '${ this.escapePhpString( options.adminPassword ) }',
 						'Submit' => 'Install WordPress',
 						'pw_weak' => '1',
 						'admin_email' => 'admin@localhost.com',

--- a/src/lib/wordpress-provider/playground-cli/playground-cli-provider.ts
+++ b/src/lib/wordpress-provider/playground-cli/playground-cli-provider.ts
@@ -144,6 +144,15 @@ export class PlaygroundCliProvider implements WordPressProvider {
 
 				try {
 					await recursiveCopyDirectory( bundledWPPath, path );
+					await installSqliteIntegration( path );
+					await this.runWordPressInstallation( {
+						path,
+						port,
+						adminPassword: adminPassword || 'password',
+						siteTitle: name,
+						siteLanguage: 'en',
+					} );
+					return true;
 				} catch ( error ) {
 					throw new Error(
 						'Failed to copy WordPress files for offline setup. Please check directory permissions.'
@@ -155,10 +164,6 @@ export class PlaygroundCliProvider implements WordPressProvider {
 			const wpConfigPath = path + '/wp-config.php';
 			if ( ! ( await fs.pathExists( wpConfigPath ) ) ) {
 				await installSqliteIntegration( path );
-			}
-
-			if ( ! isOnline ) {
-				return true;
 			}
 
 			const siteLanguage = await getPreferredSiteLanguage( wpVersion );
@@ -196,5 +201,62 @@ export class PlaygroundCliProvider implements WordPressProvider {
 		}
 
 		return { wpContentPath: undefined };
+	}
+
+	/**
+	 * Run WordPress installation steps directly to avoid web-based setup wizard
+	 */
+	private async runWordPressInstallation( options: {
+		path: string;
+		port: number;
+		adminPassword: string;
+		siteTitle: string;
+		siteLanguage: string;
+	} ): Promise< void > {
+		// Start a temporary server instance to run installation steps
+		const serverInstance = await this.startServer( {
+			path: options.path,
+			port: options.port,
+			adminPassword: options.adminPassword,
+			siteTitle: options.siteTitle,
+			phpVersion: this.DEFAULT_PHP_VERSION,
+			wpVersion: 'latest',
+			isWpAutoUpdating: false,
+			isSetupMode: false, // Don't use setup mode to avoid language downloads
+			siteLanguage: options.siteLanguage,
+		} );
+
+		const serverProcess = this.createServerProcess( serverInstance );
+
+		try {
+			await serverProcess.start();
+
+			// Run the installation steps directly using PHP requests
+			// Step 2 is the main installation step that creates database tables
+			await serverProcess.runPhp( {
+				code: `<?php
+					$_POST = array(
+						'language' => '${ options.siteLanguage }',
+						'prefix' => 'wp_',
+						'weblog_title' => '${ options.siteTitle.replace( /'/g, "\\'" ) }',
+						'user_name' => 'admin',
+						'admin_password' => '${ options.adminPassword.replace( /'/g, "\\'" ) }',
+						'admin_password2' => '${ options.adminPassword.replace( /'/g, "\\'" ) }',
+						'Submit' => 'Install WordPress',
+						'pw_weak' => '1',
+						'admin_email' => 'admin@localhost.com',
+					);
+					$_REQUEST = $_POST;
+					$_GET['step'] = 2;
+
+					// Include WordPress installation
+					require_once('/wordpress/wp-admin/install.php');
+				`,
+			} );
+
+			console.log( 'WordPress installation completed successfully' );
+		} finally {
+			await serverProcess.stop();
+		}
 	}
 }

--- a/src/lib/wordpress-provider/playground-cli/playground-cli-provider.ts
+++ b/src/lib/wordpress-provider/playground-cli/playground-cli-provider.ts
@@ -3,10 +3,10 @@ import nodePath from 'path';
 import { SupportedPHPVersions } from '@php-wasm/universal';
 import { Blueprint } from '@wp-playground/blueprints';
 import { RecommendedPHPVersion } from '@wp-playground/common';
-import fs from 'fs-extra';
 import { recursiveCopyDirectory, pathExists } from 'common/lib/fs-utils';
+import { DEFAULT_LOCALE } from 'common/lib/locale';
 import { getPreferredSiteLanguage } from 'src/lib/site-language';
-import { installSqliteIntegration, isSqlLiteInstalled } from 'src/lib/sqlite-versions';
+import { keepSqliteIntegrationUpdated } from 'src/lib/sqlite-versions';
 import { isValidWordPressVersion } from 'src/lib/wordpress-version-utils';
 import { SiteServer } from 'src/site-server';
 import { getResourcesPath, getServerFilesPath } from 'src/storage/paths';
@@ -115,6 +115,20 @@ export class PlaygroundCliProvider implements WordPressProvider {
 	async setupWordPressSite( server: SiteServer, wpVersion = 'latest' ): Promise< boolean > {
 		const { path, port, adminPassword, name, phpVersion } = server.details;
 		const { blueprint } = server.meta;
+		const siteLanguage = await getPreferredSiteLanguage( wpVersion );
+		const serverOptions = {
+			path,
+			port,
+			adminPassword: adminPassword || 'password',
+			siteTitle: name,
+			phpVersion: phpVersion || this.DEFAULT_PHP_VERSION,
+			wpVersion,
+			isWpAutoUpdating: false,
+			isSetupMode: true,
+			blueprint: blueprint?.blueprint,
+			siteLanguage,
+		};
+		let serverProcess;
 
 		try {
 			const isOnline = net.isOnline();
@@ -144,15 +158,11 @@ export class PlaygroundCliProvider implements WordPressProvider {
 
 				try {
 					await recursiveCopyDirectory( bundledWPPath, path );
-					await installSqliteIntegration( path );
-					await this.runWordPressInstallation( {
-						path,
-						port,
-						adminPassword: adminPassword || 'password',
-						siteTitle: name,
-						siteLanguage: 'en',
-					} );
-					return true;
+					serverOptions.wpVersion = this.DEFAULT_WORDPRESS_VERSION;
+					serverOptions.siteLanguage = DEFAULT_LOCALE;
+					serverOptions.isSetupMode = false;
+					serverOptions.isWpAutoUpdating = true;
+					serverOptions.blueprint = undefined;
 				} catch ( error ) {
 					throw new Error(
 						`Failed to copy WordPress files for offline setup: ${ ( error as Error ).message }`
@@ -160,36 +170,25 @@ export class PlaygroundCliProvider implements WordPressProvider {
 				}
 			}
 
-			// Ensure SQLite integration is installed before starting the server
-			const hasSqlite = await isSqlLiteInstalled( path );
-			if ( ! hasSqlite ) {
-				console.log( 'needs sqlite' );
-				const wpConfigPath = path + '/wp-config.php';
-				if ( ! ( await fs.pathExists( wpConfigPath ) ) ) {
-					await installSqliteIntegration( path );
-				}
+			await keepSqliteIntegrationUpdated( path );
+
+			const serverInstance = await this.startServer( serverOptions );
+			serverProcess = this.createServerProcess( serverInstance );
+			await serverProcess.start();
+
+			if ( ! serverOptions.isSetupMode ) {
+				await this.runWordPressInstallation( serverProcess, serverOptions );
 			}
 
-			const siteLanguage = await getPreferredSiteLanguage( wpVersion );
-			const serverInstance = await this.startServer( {
-				path,
-				port,
-				adminPassword: adminPassword || 'password',
-				siteTitle: name,
-				phpVersion: phpVersion || this.DEFAULT_PHP_VERSION,
-				wpVersion,
-				isWpAutoUpdating: false,
-				isSetupMode: true,
-				blueprint: blueprint?.blueprint,
-				siteLanguage,
-			} );
+			// remove blueprint since we only want to run it once
+			server.meta.blueprint = undefined;
 
-			const serverProcess = this.createServerProcess( serverInstance );
-			await serverProcess.start();
 			return true;
 		} catch ( error ) {
 			console.error( 'Failed to setup WordPress site:', error );
 			throw error;
+		} finally {
+			await serverProcess?.stop();
 		}
 	}
 
@@ -217,31 +216,18 @@ export class PlaygroundCliProvider implements WordPressProvider {
 	/**
 	 * Run WordPress installation steps directly to avoid web-based setup wizard
 	 */
-	private async runWordPressInstallation( options: {
-		path: string;
-		port: number;
-		adminPassword: string;
-		siteTitle: string;
-		siteLanguage: string;
-	} ): Promise< void > {
-		const serverInstance = await this.startServer( {
-			path: options.path,
-			port: options.port,
-			adminPassword: options.adminPassword,
-			siteTitle: options.siteTitle,
-			phpVersion: this.DEFAULT_PHP_VERSION,
-			wpVersion: 'latest',
-			isWpAutoUpdating: false,
-			isSetupMode: false,
-			siteLanguage: options.siteLanguage,
-		} );
-
-		const serverProcess = this.createServerProcess( serverInstance );
-
-		try {
-			await serverProcess.start();
-			await serverProcess.runPhp( {
-				code: `<?php
+	private async runWordPressInstallation(
+		serverProcess: WordPressServerProcess,
+		options: {
+			path: string;
+			port: number;
+			adminPassword: string;
+			siteTitle: string;
+			siteLanguage: string;
+		}
+	): Promise< void > {
+		await serverProcess.runPhp( {
+			code: `<?php
 					$_POST = array(
 						'language' => '${ this.escapePhpString( options.siteLanguage ) }',
 						'prefix' => 'wp_',
@@ -259,11 +245,6 @@ export class PlaygroundCliProvider implements WordPressProvider {
 					// Include WordPress installation
 					require_once('/wordpress/wp-admin/install.php');
 				`,
-			} );
-
-			console.log( 'WordPress installation completed successfully' );
-		} finally {
-			await serverProcess.stop();
-		}
+		} );
 	}
 }

--- a/src/lib/wordpress-provider/playground-cli/playground-cli-provider.ts
+++ b/src/lib/wordpress-provider/playground-cli/playground-cli-provider.ts
@@ -155,7 +155,7 @@ export class PlaygroundCliProvider implements WordPressProvider {
 					return true;
 				} catch ( error ) {
 					throw new Error(
-						'Failed to copy WordPress files for offline setup. Please check directory permissions.'
+						`Failed to copy WordPress files for offline setup: ${ ( error as Error ).message }`
 					);
 				}
 			}

--- a/src/lib/wordpress-provider/playground-cli/playground-cli-provider.ts
+++ b/src/lib/wordpress-provider/playground-cli/playground-cli-provider.ts
@@ -213,7 +213,6 @@ export class PlaygroundCliProvider implements WordPressProvider {
 		siteTitle: string;
 		siteLanguage: string;
 	} ): Promise< void > {
-		// Start a temporary server instance to run installation steps
 		const serverInstance = await this.startServer( {
 			path: options.path,
 			port: options.port,
@@ -222,7 +221,7 @@ export class PlaygroundCliProvider implements WordPressProvider {
 			phpVersion: this.DEFAULT_PHP_VERSION,
 			wpVersion: 'latest',
 			isWpAutoUpdating: false,
-			isSetupMode: false, // Don't use setup mode to avoid language downloads
+			isSetupMode: false,
 			siteLanguage: options.siteLanguage,
 		} );
 
@@ -230,9 +229,6 @@ export class PlaygroundCliProvider implements WordPressProvider {
 
 		try {
 			await serverProcess.start();
-
-			// Run the installation steps directly using PHP requests
-			// Step 2 is the main installation step that creates database tables
 			await serverProcess.runPhp( {
 				code: `<?php
 					$_POST = array(

--- a/src/lib/wordpress-provider/playground-cli/playground-cli-provider.ts
+++ b/src/lib/wordpress-provider/playground-cli/playground-cli-provider.ts
@@ -6,7 +6,7 @@ import { RecommendedPHPVersion } from '@wp-playground/common';
 import fs from 'fs-extra';
 import { recursiveCopyDirectory, pathExists } from 'common/lib/fs-utils';
 import { getPreferredSiteLanguage } from 'src/lib/site-language';
-import { installSqliteIntegration } from 'src/lib/sqlite-versions';
+import { installSqliteIntegration, isSqlLiteInstalled } from 'src/lib/sqlite-versions';
 import { isValidWordPressVersion } from 'src/lib/wordpress-version-utils';
 import { SiteServer } from 'src/site-server';
 import { getResourcesPath, getServerFilesPath } from 'src/storage/paths';
@@ -161,9 +161,13 @@ export class PlaygroundCliProvider implements WordPressProvider {
 			}
 
 			// Ensure SQLite integration is installed before starting the server
-			const wpConfigPath = path + '/wp-config.php';
-			if ( ! ( await fs.pathExists( wpConfigPath ) ) ) {
-				await installSqliteIntegration( path );
+			const hasSqlite = await isSqlLiteInstalled( path );
+			if ( ! hasSqlite ) {
+				console.log( 'needs sqlite' );
+				const wpConfigPath = path + '/wp-config.php';
+				if ( ! ( await fs.pathExists( wpConfigPath ) ) ) {
+					await installSqliteIntegration( path );
+				}
 			}
 
 			const siteLanguage = await getPreferredSiteLanguage( wpVersion );

--- a/src/lib/wordpress-provider/playground-cli/playground-server-process.ts
+++ b/src/lib/wordpress-provider/playground-cli/playground-server-process.ts
@@ -140,8 +140,8 @@ export class PlaygroundServerProcess implements WordPressServerProcess {
 			const messageToSend = { id, type, data };
 			this.process!.postMessage( messageToSend );
 
-			// Timeout after 60 seconds for setup mode, 30 seconds otherwise
-			const timeout = this.isSetupMode && type === 'start-server' ? 60000 : 30000;
+			// Timeout after 2 minutes for server start and PHP operations, 30 seconds for other operations
+			const timeout = type === 'start-server' || type === 'run-php' ? 120000 : 30000;
 			setTimeout( () => {
 				if ( this.responseHandlers.has( id ) ) {
 					this.responseHandlers.delete( id );


### PR DESCRIPTION
## Related issues

- Fixes STU-821

## Proposed Changes

- Modified offline installation flow to run complete WordPress installation
- Added `runWordPressInstallation` method that starts temporary server and runs WordPress installation step 2 directly (database setup)
- Ensured WordPress sites created offline are properly installed and don't show setup wizard on startup

## Testing Instructions

- Disconnect from the internet or block network access
- Create a new WordPress site in Studio while offline
- Verify the site creation completes successfully without hanging
- Start the created site and confirm it loads properly without showing the WordPress setup wizard
- Verify the admin user is created and database tables are properly set up
- Test that the site functions normally (admin access, content creation, etc.)

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?