### PR TITLE
Simplify unsupported Blueprint features message

### DIFF
--- a/src/modules/add-site/components/blueprints.tsx
+++ b/src/modules/add-site/components/blueprints.tsx
@@ -72,8 +72,7 @@ function BlueprintIssuesModal( {
 					{ warnings?.length &&
 						__(
 							'The following features are not supported in Studio and will be automatically removed:'
-						)
-					}
+						) }
 				</Text>
 				<div className="flex-1 overflow-y-auto">
 					<VStack spacing={ 3 } className="divide-y divide-gray-200">

--- a/src/modules/add-site/components/blueprints.tsx
+++ b/src/modules/add-site/components/blueprints.tsx
@@ -70,13 +70,10 @@ function BlueprintIssuesModal( {
 				<Text className="font-medium text-gray-900">{ fileName }</Text>
 				<Text>
 					{ warnings?.length &&
-						sprintf(
-							// translators: %d is the number of unsupported features
-							__(
-								'The following %d feature(s) are not supported in Studio and will be automatically removed:'
-							),
-							warnings.length
-						) }
+						__(
+							'The following features are not supported in Studio and will be automatically removed:'
+						)
+					}
 				</Text>
 				<div className="flex-1 overflow-y-auto">
 					<VStack spacing={ 3 } className="divide-y divide-gray-200">


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- N/A

## Proposed Changes

I propose to simplify the unsupported Blueprint features message by removing the number of warnings completely.

Initially, I wanted to add proper support for plurals, but it seems that the number of warnings is not even necessary there.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Open 'Add site' form
2. Choose blueprint flow
3. Use blueprint which has one or more unsupported features
4. Confirm warning is displayed properly

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
