### PR TITLE
Studio: Implement activity-based timeout for Playground CLI operations

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -70,6 +70,11 @@ export const WP_CLI_IMPORT_EXPORT_RESPONSE_TIMEOUT_IN_HRS = 6;
 export const WP_CLI_IMPORT_EXPORT_RESPONSE_TIMEOUT =
 	WP_CLI_IMPORT_EXPORT_RESPONSE_TIMEOUT_IN_HRS * 60 * 60 * 1000; // 6hr
 
+// Playground CLI
+export const PLAYGROUND_CLI_INACTIVITY_TIMEOUT = 60 * 1000; // 60 seconds of no output = timeout
+export const PLAYGROUND_CLI_MAX_TIMEOUT = 10 * 60 * 1000; // 10 minutes absolute maximum
+export const PLAYGROUND_CLI_ACTIVITY_CHECK_INTERVAL = 5 * 1000; // Check for inactivity every 5 seconds
+
 // SQLite
 export const SQLITE_DATABASE_INTEGRATION_VERSION = 'v2.2.10';
 

--- a/src/lib/wordpress-provider/playground-cli/playground-server-process-child.ts
+++ b/src/lib/wordpress-provider/playground-cli/playground-server-process-child.ts
@@ -22,21 +22,31 @@ const originalConsoleWarn = console.warn;
 
 console.log = ( ...args: any[] ) => {
 	originalConsoleLog( '[playground-cli]', ...args );
-	// Send activity heartbeat to parent process to reset inactivity timeout
 	process.parentPort.postMessage( { type: 'activity' } );
 };
 
 console.error = ( ...args: any[] ) => {
 	originalConsoleError( '[playground-cli]', ...args );
-	// Send activity heartbeat to parent process to reset inactivity timeout
 	process.parentPort.postMessage( { type: 'activity' } );
 };
 
 console.warn = ( ...args: any[] ) => {
 	originalConsoleWarn( '[playground-cli]', ...args );
-	// Send activity heartbeat to parent process to reset inactivity timeout
 	process.parentPort.postMessage( { type: 'activity' } );
 };
+
+const originalStdoutWrite = process.stdout.write.bind( process.stdout );
+const originalStderrWrite = process.stderr.write.bind( process.stderr );
+
+process.stdout.write = function ( ...args: Parameters< typeof originalStdoutWrite > ) {
+	process.parentPort.postMessage( { type: 'activity' } );
+	return originalStdoutWrite( ...args );
+} as typeof process.stdout.write;
+
+process.stderr.write = function ( ...args: Parameters< typeof originalStderrWrite > ) {
+	process.parentPort.postMessage( { type: 'activity' } );
+	return originalStderrWrite( ...args );
+} as typeof process.stderr.write;
 
 let server: RunCLIServer | null = null;
 

--- a/src/lib/wordpress-provider/playground-cli/playground-server-process-child.ts
+++ b/src/lib/wordpress-provider/playground-cli/playground-server-process-child.ts
@@ -22,14 +22,20 @@ const originalConsoleWarn = console.warn;
 
 console.log = ( ...args: any[] ) => {
 	originalConsoleLog( '[playground-cli]', ...args );
+	// Send activity heartbeat to parent process to reset inactivity timeout
+	process.parentPort.postMessage( { type: 'activity' } );
 };
 
 console.error = ( ...args: any[] ) => {
 	originalConsoleError( '[playground-cli]', ...args );
+	// Send activity heartbeat to parent process to reset inactivity timeout
+	process.parentPort.postMessage( { type: 'activity' } );
 };
 
 console.warn = ( ...args: any[] ) => {
 	originalConsoleWarn( '[playground-cli]', ...args );
+	// Send activity heartbeat to parent process to reset inactivity timeout
+	process.parentPort.postMessage( { type: 'activity' } );
 };
 
 let server: RunCLIServer | null = null;

--- a/src/lib/wordpress-provider/playground-cli/playground-server-process.ts
+++ b/src/lib/wordpress-provider/playground-cli/playground-server-process.ts
@@ -1,5 +1,10 @@
 import { utilityProcess } from 'electron';
 import path from 'path';
+import {
+	PLAYGROUND_CLI_INACTIVITY_TIMEOUT,
+	PLAYGROUND_CLI_MAX_TIMEOUT,
+	PLAYGROUND_CLI_ACTIVITY_CHECK_INTERVAL,
+} from 'src/constants';
 import { WordPressServerProcess, WordPressServerOptions } from '../types';
 import { PlaygroundCliOptions } from './playground-cli-provider';
 
@@ -13,6 +18,7 @@ export class PlaygroundServerProcess implements WordPressServerProcess {
 	private exitPromise: Promise< void > | null = null;
 	private exitResolve: ( () => void ) | null = null;
 	private isSetupMode = false;
+	private lastActivityTimestamp = 0;
 
 	constructor(
 		public url: string,
@@ -39,6 +45,10 @@ export class PlaygroundServerProcess implements WordPressServerProcess {
 			( message: { type?: string; id?: number; error?: string; result?: unknown } ) => {
 				if ( message.type === 'ready' ) {
 					return;
+				}
+
+				if ( message.type === 'activity' || message.id !== undefined ) {
+					this.lastActivityTimestamp = Date.now();
 				}
 
 				if ( message.id !== undefined && this.responseHandlers.has( message.id ) ) {
@@ -140,14 +150,36 @@ export class PlaygroundServerProcess implements WordPressServerProcess {
 			const messageToSend = { id, type, data };
 			this.process!.postMessage( messageToSend );
 
-			// Timeout after 2 minutes for server start and PHP operations, 30 seconds for other operations
-			const timeout = type === 'start-server' || type === 'run-php' ? 120000 : 30000;
-			setTimeout( () => {
-				if ( this.responseHandlers.has( id ) ) {
-					this.responseHandlers.delete( id );
-					reject( new Error( `Timeout waiting for response to message ${ id }` ) );
+			this.lastActivityTimestamp = Date.now();
+			const startTime = Date.now();
+
+			const activityCheckInterval = setInterval( () => {
+				if ( ! this.responseHandlers.has( id ) ) {
+					clearInterval( activityCheckInterval );
+					return;
 				}
-			}, timeout );
+
+				const now = Date.now();
+				const timeSinceLastActivity = now - this.lastActivityTimestamp;
+				const totalElapsedTime = now - startTime;
+
+				if (
+					timeSinceLastActivity > PLAYGROUND_CLI_INACTIVITY_TIMEOUT ||
+					totalElapsedTime > PLAYGROUND_CLI_MAX_TIMEOUT
+				) {
+					clearInterval( activityCheckInterval );
+					if ( this.responseHandlers.has( id ) ) {
+						this.responseHandlers.delete( id );
+						const timeoutReason =
+							totalElapsedTime > PLAYGROUND_CLI_MAX_TIMEOUT
+								? `Maximum timeout of ${ PLAYGROUND_CLI_MAX_TIMEOUT / 1000 }s exceeded`
+								: `No activity for ${ PLAYGROUND_CLI_INACTIVITY_TIMEOUT / 1000 }s`;
+						reject(
+							new Error( `Timeout waiting for response to message ${ id }: ${ timeoutReason }` )
+						);
+					}
+				}
+			}, PLAYGROUND_CLI_ACTIVITY_CHECK_INTERVAL );
 		} );
 	}
 


### PR DESCRIPTION
## Related issues

- Fixes STU-827

## Proposed Changes

- Replaced fixed 2-minute timeout for Playground CLI operations with activity-based timeout mechanism
- Child process now sends heartbeat messages on console output (log/error/warn)
- Parent process tracks last activity timestamp and resets timeout on any message
- Timeout occurs only after 60 seconds of inactivity OR 10 minutes absolute maximum
- Added timeout configuration constants: `PLAYGROUND_CLI_INACTIVITY_TIMEOUT`, `PLAYGROUND_CLI_MAX_TIMEOUT`, `PLAYGROUND_CLI_ACTIVITY_CHECK_INTERVAL`

## Testing Instructions

1. Create a new site or start an existing site
2. Verify the site starts successfully without timeout errors
3. Test with a Blueprint that takes longer than the previous 2-minute fixed timeout
4. Check console logs to confirm Playground CLI output appears (indicating heartbeats are being sent)
5. Test with both fast and slow operations to ensure proper timeout behavior

Test blueprint with a long `sleep` that should timeout:
[sleep-test-blueprint.json](https://github.com/user-attachments/files/22617395/sleep-test-blueprint.json)

Complex blueprint that takes a long time but should succeed: 
[blueprint-timeout-100x100.json](https://github.com/user-attachments/files/22617396/blueprint-timeout-100x100.json)


## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?