### PR TITLE
Prioritize Blueprint setSiteLanguage step over Studio language settings

### DIFF
--- a/src/lib/wordpress-provider/playground-cli/playground-server-process-child.ts
+++ b/src/lib/wordpress-provider/playground-cli/playground-server-process-child.ts
@@ -177,6 +177,9 @@ async function startServer(
 			};
 		}
 
+		/* Workaround for https://github.com/WordPress/wordpress-playground/issues/2700
+		 * Let's revisit this code when the issue is fixed
+		 * If setSiteLanguage is set in blueprint we shouldn't need to change the language*/
 		const blueprintLanguageStep = args.blueprint?.steps?.find(
 			( step: { step: string; language?: string } ) => step.step === 'setSiteLanguage'
 		);

--- a/src/lib/wordpress-provider/playground-cli/playground-server-process-child.ts
+++ b/src/lib/wordpress-provider/playground-cli/playground-server-process-child.ts
@@ -177,18 +177,23 @@ async function startServer(
 			};
 		}
 
-		if ( serverOptions.siteLanguage && serverOptions.siteLanguage !== DEFAULT_LOCALE ) {
+		const blueprintLanguageStep = args.blueprint?.steps?.find(
+			( step: { step: string; language?: string } ) => step.step === 'setSiteLanguage'
+		);
+		const siteLanguage = blueprintLanguageStep?.language || serverOptions.siteLanguage;
+
+		if ( siteLanguage && siteLanguage !== DEFAULT_LOCALE ) {
 			args.blueprint.steps = [
 				...[
 					{
 						step: 'setSiteLanguage',
-						language: serverOptions.siteLanguage,
+						language: siteLanguage,
 					},
 					{
 						step: 'runPHP',
 						code: `<?php require_once( '/wordpress/wp-load.php' ); update_option( 'WPLANG', '${ escapePhpString(
-							serverOptions.siteLanguage
-						) }' ); echo "Language set to: ${ escapePhpString( serverOptions.siteLanguage ) }"; ?>`,
+							siteLanguage
+						) }' ); echo "Language set to: ${ escapePhpString( siteLanguage ) }"; ?>`,
 					},
 				],
 				...( args.blueprint.steps || [] ),


### PR DESCRIPTION
## Related issues

- Fixes STU-826

## Proposed Changes

- Modified Playground CLI server startup to prioritize Blueprint's `setSiteLanguage` step over Studio's automatic language detection
- Extract language from Blueprint's `setSiteLanguage` step if present, otherwise use `serverOptions.siteLanguage` from user preferences
- Includes workaround that adds `runPHP` step to set `WPLANG` option, addressing issue where `setSiteLanguage` doesn't persist on site restart in Playground CLI

## Testing Instructions

**Test 1: Blueprint with setSiteLanguage step**
1. Create a Blueprint with a `setSiteLanguage` step (e.g., set to `es_ES`)
2. Create a new site with this Blueprint
3. Verify the site language is set to the Blueprint's language (`es_ES`), not your Studio language preference

**Test 2: Blueprint without setSiteLanguage step**
1. Create a Blueprint without any `setSiteLanguage` step
2. Create a new site with this Blueprint
3. Verify the site language matches your Studio language preference

**Test 3: Site restart with Blueprint language**
1. Create a site with a Blueprint that has `setSiteLanguage` set to a non-English language
2. Stop and restart the site
3. Verify the language persists after restart (this tests the `runPHP` workaround)

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?