### PR TITLE
Add translation to label in modal

### DIFF
--- a/src/components/fullscreen-modal.tsx
+++ b/src/components/fullscreen-modal.tsx
@@ -3,8 +3,8 @@ import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 import { close } from '@wordpress/icons';
-import { useI18n } from '@wordpress/react-i18n';
 import React, { useEffect, useRef } from 'react';
 import { isWindows } from 'src/lib/app-globals';
 import { cx } from 'src/lib/cx';
@@ -21,7 +21,6 @@ export const FullscreenModal: React.FC< FullscreenModalProps > = ( {
 	onClose,
 	children,
 } ) => {
-	const { __ } = useI18n();
 	const modalRef = useRef< HTMLDivElement >( null );
 	const previousActiveElement = useRef< HTMLElement | null >( null );
 

--- a/src/components/fullscreen-modal.tsx
+++ b/src/components/fullscreen-modal.tsx
@@ -4,6 +4,7 @@ import {
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { close } from '@wordpress/icons';
+import { useI18n } from '@wordpress/react-i18n';
 import React, { useEffect, useRef } from 'react';
 import { isWindows } from 'src/lib/app-globals';
 import { cx } from 'src/lib/cx';
@@ -20,6 +21,7 @@ export const FullscreenModal: React.FC< FullscreenModalProps > = ( {
 	onClose,
 	children,
 } ) => {
+	const { __ } = useI18n();
 	const modalRef = useRef< HTMLDivElement >( null );
 	const previousActiveElement = useRef< HTMLElement | null >( null );
 
@@ -65,7 +67,7 @@ export const FullscreenModal: React.FC< FullscreenModalProps > = ( {
 			<HStack
 				className={ cx( 'flex justify-end p-4 app-no-drag-region', isWindows() && 'ltr:pt-8' ) }
 			>
-				<Button icon={ close } onClick={ onClose } label="Close" />
+				<Button icon={ close } onClick={ onClose } label={ __( 'Close' ) } />
 			</HStack>
 			<VStack alignment="top" className="w-full flex-1 overflow-y-auto px-6 pb-6">
 				{ children }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

N/A

## Proposed Changes

- Add translation to the label in modal 

|Before | After|
|-------|------|
|  <img width="2402" height="1524" alt="CleanShot 2025-10-01 at 10 27 36@2x" src="https://github.com/user-attachments/assets/a2d2ad1c-9c65-470d-a83b-7ab23f78ce57" />|<img width="2400" height="1524" alt="CleanShot 2025-10-01 at 10 26 51@2x" src="https://github.com/user-attachments/assets/0231b573-4df5-424e-a96a-683b933003a1" />|

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Apply this branch and open Studio by running `npm start`
- Change the language to any different than English, for example Spanish
- Select add a site
- Hover over the cross icon on the top right of the modal to open the tooltip
- Check the `Close` word is translated (if the language has the translation added)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
