### PR TITLE
CLI: Fix auth token validation for older config files

### DIFF
--- a/cli/lib/appdata.ts
+++ b/cli/lib/appdata.ts
@@ -53,6 +53,7 @@ const userDataSchema = z
 type UserData = z.infer< typeof userDataSchema >;
 type NewSiteData = z.infer< typeof newSiteSchema >;
 export type SiteData = z.infer< typeof siteSchema >;
+type ValidatedAuthToken = Required< NonNullable< UserData[ 'authToken' ] > >;
 
 export function getAppdataDirectory(): string {
 	if ( process.platform === 'win32' ) {
@@ -133,7 +134,7 @@ export async function unlockAppdata(): Promise< void > {
 	await unlockFileAsync( LOCKFILE_PATH );
 }
 
-export async function getAuthToken(): Promise< NonNullable< UserData[ 'authToken' ] > > {
+export async function getAuthToken(): Promise< ValidatedAuthToken > {
 	try {
 		const { authToken } = await readAppdata();
 
@@ -143,7 +144,7 @@ export async function getAuthToken(): Promise< NonNullable< UserData[ 'authToken
 
 		await validateAccessToken( authToken.accessToken );
 
-		return authToken;
+		return authToken as ValidatedAuthToken;
 	} catch ( error ) {
 		const authUrl = getAuthenticationUrl( 'en' );
 

--- a/cli/lib/appdata.ts
+++ b/cli/lib/appdata.ts
@@ -40,7 +40,7 @@ const userDataSchema = z
 		authToken: z
 			.object( {
 				accessToken: z.string().min( 1, __( 'Access token cannot be empty' ) ),
-				id: z.number(),
+				id: z.number().optional(),
 			} )
 			.passthrough()
 			.optional(),
@@ -137,7 +137,7 @@ export async function getAuthToken(): Promise< NonNullable< UserData[ 'authToken
 	try {
 		const { authToken } = await readAppdata();
 
-		if ( ! authToken?.accessToken ) {
+		if ( ! authToken?.accessToken || ! authToken?.id ) {
 			throw new Error( 'Authentication required' );
 		}
 


### PR DESCRIPTION
## Related issues

- Fixes https://linear.app/a8c/issue/STU-836

## Proposed Changes

- Make `authToken.id` optional in the CLI schema to support older config files
- Add validation in `getAuthToken()` to ensure `id` exists when the token is actually used

## Testing Instructions

1. Edit your `appdata-v1.json` file (located at `~/Library/Application Support/Studio/appdata-v1.json` on macOS)
2. Remove the `id` field from the `authToken` object
3. Run `npm run cli:build`
4. Run `node ./dist/cli/main.js` in terminal - should show help without errors
5. Try to use a preview command (e.g., `node ./dist/cli/main.js preview create`) - should get a clear "Authentication required" message
6. Re-authenticate via the Studio app
7. Preview commands should now work correctly

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?