### PR TITLE
Studio: Fix bottom outline cut on Advanced settings button

### DIFF
--- a/src/components/site-form.tsx
+++ b/src/components/site-form.tsx
@@ -360,7 +360,7 @@ export const SiteForm = ( {
 
 				{ onSelectPath && (
 					<>
-						<div className="flex flex-row items-center mb-0">
+						<div className="flex flex-row items-center mb-1">
 							<Button className="pl-0" onClick={ handleAdvancedSettingsClick }>
 								<Icon size={ 24 } icon={ chevronIcon } className={ error && 'text-red-500' } />
 								<div className={ cx( 'text-[13px] leading-[16px] ml-2', error && 'text-red-500' ) }>


### PR DESCRIPTION
## Related issues

- Fixes STU-838

## Proposed Changes

- Changed bottom margin from `mb-0` to `mb-1` on the Advanced settings button container in the site form

<img width="930" height="712" alt="image" src="https://github.com/user-attachments/assets/93120641-b082-4cb0-b2fc-8800fead74b6" />

## Testing Instructions

- Start Studio
- Open the Add site form
- Choose empty site
- Use tab navigation to focus the Advanced settings button
- Verify the focus outline is fully visible (not cut off at the bottom)

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?