### PR TITLE
Studio: Only set site title during initial setup to preserve existing site titles

### DIFF
--- a/src/lib/wordpress-provider/playground-cli/playground-cli-provider.ts
+++ b/src/lib/wordpress-provider/playground-cli/playground-cli-provider.ts
@@ -87,6 +87,7 @@ export class PlaygroundCliProvider implements WordPressProvider {
 			siteLanguage: options.siteLanguage,
 			wordPressVersion: options.wpVersion,
 			isWpAutoUpdating: options.isWpAutoUpdating,
+			isSetupMode: options.isSetupMode,
 		};
 
 		return {

--- a/src/lib/wordpress-provider/playground-cli/playground-server-process-child.ts
+++ b/src/lib/wordpress-provider/playground-cli/playground-server-process-child.ts
@@ -167,7 +167,7 @@ async function startServer(
 		if ( options.isSetupMode ) {
 			/* Workaround for https://github.com/WordPress/wordpress-playground/issues/2700
 			 * Let's revisit this code when the issue is fixed
-			 * If setSiteLanguage is set in blueprint we shouldn't need to change the language*/
+			 * If setSiteLanguage is set in blueprint we shouldn't need to change the language */
 			const blueprintLanguageStep = args.blueprint?.steps?.find(
 				( step: { step: string; language?: string } ) => step.step === 'setSiteLanguage'
 			);

--- a/src/lib/wordpress-provider/playground-cli/playground-server-process-child.ts
+++ b/src/lib/wordpress-provider/playground-cli/playground-server-process-child.ts
@@ -1,7 +1,6 @@
 import { SupportedPHPVersion, PHPRunOptions } from '@php-wasm/universal';
 import { runCLI, RunCLIArgs, RunCLIServer } from '@wp-playground/cli';
 import { DEFAULT_LOCALE } from 'common/lib/locale';
-import { simplifyErrorForDisplay } from 'src/lib/error-formatting';
 import { isWordPressDevVersion } from 'src/lib/wordpress-version-utils';
 import { WordPressServerOptions } from '../types';
 import { getMuPlugins } from './mu-plugins';
@@ -84,42 +83,22 @@ function escapePhpString( str: string ): string {
 	return str.replace( /\\/g, '\\\\' ).replace( /'/g, "\\'" );
 }
 
-async function setSiteOptions(
-	server: RunCLIServer,
-	serverOptions: WordPressServerOptions
-): Promise< void > {
+async function setAdminPassword( server: RunCLIServer, adminPassword: string ): Promise< void > {
 	const phpCode = `<?php
 		require_once( '/wordpress/wp-load.php' );
-
-		// Set site title if provided (wp-now doesn't do this post-install, but it's the correct way)
-		${
-			serverOptions.siteTitle
-				? `update_option( 'blogname', '${ escapePhpString( serverOptions.siteTitle ) }' );`
-				: ''
-		}
-
-		// Set admin password
-		${
-			serverOptions.adminPassword
-				? `
 		$user = get_user_by( 'login', 'admin' );
 		if ( $user ) {
-			wp_set_password( '${ escapePhpString( serverOptions.adminPassword ) }', $user->ID );
+			wp_set_password( '${ escapePhpString( adminPassword ) }', $user->ID );
 		} else {
 			$user_data = array(
 				'user_login' => 'admin',
-				'user_pass' => '${ escapePhpString( serverOptions.adminPassword ) }',
+				'user_pass' => '${ escapePhpString( adminPassword ) }',
 				'user_email' => 'admin@localhost.com',
 				'role' => 'administrator',
 			);
-			$user_id = wp_insert_user( $user_data );
-			$user = get_user_by( 'id', $user_id );
+			wp_insert_user( $user_data );
 		}
-		`
-				: ''
-		}
-
-		echo "Site options updated successfully";
+		echo "Admin password updated";
 	?>`;
 
 	await server.playground.run( {
@@ -137,7 +116,10 @@ async function startServer(
 
 	try {
 		const [ studioMuPluginsHostPath, loaderMuPluginHostPath ] = await getMuPlugins( serverOptions );
-
+		const setupSteps = [];
+		const defaultConstants = {
+			WP_SQLITE_AST_DRIVER: true,
+		};
 		const mounts = [
 			{
 				hostPath: options.documentRoot,
@@ -162,6 +144,7 @@ async function startServer(
 			login: true,
 			'mount-before-install': mounts,
 			'site-url': serverOptions.absoluteUrl,
+			blueprint: options.blueprint || {},
 		};
 
 		if ( ! options.isSetupMode ) {
@@ -181,35 +164,16 @@ async function startServer(
 			}
 		}
 
-		const defaultConstants = {
-			WP_SQLITE_AST_DRIVER: true,
-		};
-
-		if ( options.blueprint ) {
-			args.blueprint = {
-				...options.blueprint,
-				constants: {
-					...options.blueprint.constants,
-					...defaultConstants,
-				},
-			};
-		} else {
-			args.blueprint = {
-				constants: defaultConstants,
-			};
-		}
-
-		/* Workaround for https://github.com/WordPress/wordpress-playground/issues/2700
-		 * Let's revisit this code when the issue is fixed
-		 * If setSiteLanguage is set in blueprint we shouldn't need to change the language*/
-		const blueprintLanguageStep = args.blueprint?.steps?.find(
-			( step: { step: string; language?: string } ) => step.step === 'setSiteLanguage'
-		);
-		const siteLanguage = blueprintLanguageStep?.language || serverOptions.siteLanguage;
-
-		if ( siteLanguage && siteLanguage !== DEFAULT_LOCALE ) {
-			args.blueprint.steps = [
-				...[
+		if ( options.isSetupMode ) {
+			/* Workaround for https://github.com/WordPress/wordpress-playground/issues/2700
+			 * Let's revisit this code when the issue is fixed
+			 * If setSiteLanguage is set in blueprint we shouldn't need to change the language*/
+			const blueprintLanguageStep = args.blueprint?.steps?.find(
+				( step: { step: string; language?: string } ) => step.step === 'setSiteLanguage'
+			);
+			const siteLanguage = blueprintLanguageStep?.language || serverOptions.siteLanguage;
+			if ( siteLanguage && siteLanguage !== DEFAULT_LOCALE ) {
+				setupSteps.push(
 					{
 						step: 'setSiteLanguage',
 						language: siteLanguage,
@@ -219,17 +183,30 @@ async function startServer(
 						code: `<?php require_once( '/wordpress/wp-load.php' ); update_option( 'WPLANG', '${ escapePhpString(
 							siteLanguage
 						) }' ); echo "Language set to: ${ escapePhpString( siteLanguage ) }"; ?>`,
-					},
-				],
-				...( args.blueprint.steps || [] ),
-			];
+					}
+				);
+			}
+
+			if ( serverOptions.siteTitle ) {
+				setupSteps.push( {
+					step: 'runPHP',
+					code: `<?php
+						require_once( '/wordpress/wp-load.php' );
+						update_option( 'blogname', '${ escapePhpString( serverOptions.siteTitle ) }' );
+						echo "Site title set to: ${ escapePhpString( serverOptions.siteTitle ) }";
+					?>`,
+				} );
+			}
 		}
+
+		args.blueprint.steps = [ ...setupSteps, ...( args.blueprint.steps || [] ) ];
+		args.blueprint.constants = { ...args.blueprint.constants, ...defaultConstants };
 
 		server = await runCLI( args );
 
-		if ( serverOptions.siteTitle || serverOptions.adminPassword ) {
+		if ( serverOptions.adminPassword ) {
 			try {
-				await setSiteOptions( server, serverOptions );
+				await setAdminPassword( server, serverOptions.adminPassword );
 			} catch {
 				console.warn(
 					'Failed to set site options, but the server started successfully. Please check your site error log in wp-content/debug.log for more details'

--- a/src/lib/wordpress-provider/playground-cli/playground-server-process-child.ts
+++ b/src/lib/wordpress-provider/playground-cli/playground-server-process-child.ts
@@ -209,7 +209,7 @@ async function startServer(
 				await setAdminPassword( server, serverOptions.adminPassword );
 			} catch {
 				console.warn(
-					'Failed to set site options, but the server started successfully. Please check your site error log in wp-content/debug.log for more details'
+					'Failed to set admin password, but the server started successfully. Please check your site error log in wp-content/debug.log for more details'
 				);
 			}
 		}

--- a/src/lib/wordpress-provider/types.ts
+++ b/src/lib/wordpress-provider/types.ts
@@ -28,6 +28,7 @@ export interface WordPressServerOptions {
 	adminPassword?: string;
 	siteTitle?: string;
 	siteLanguage?: string;
+	isSetupMode?: boolean;
 }
 
 export interface WordPressServerInstance {


### PR DESCRIPTION
## Related issues

- Fixes STU-833

## Proposed Changes

- Refactored site option configuration to only set language and title during initial WordPress installation as blueprint steps
- Admin password is now set every time after server starts via `setAdminPassword()` function using `runPhp` to ensure Studio can always access the site
- Split blueprint steps for language and title into separate steps for cleaner error handling
- Cleaned up blueprint and constants initialization for better code organization

## Testing Instructions

- **New site creation**: 
  - Create a new site with name "My Test Site" and verify the title appears correctly in WordPress admin
- **Existing WordPress directory**: 
  - Create a WordPress site with Studio named "My Cool Blog"
  - Delete the site without deleting the files
  - Add it to Studio from the existing directory
  - Verify the title remains "My Cool Blog" and is not overwritten by Studio's site name
  - Stop and start the site multiple times to verify the title stays "My Cool Blog"
- **Studio access**: 
 - Verify Studio can log into all sites with the stored password after starting them

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?