### PR TITLE
Studio: Don't display What's New for newly onboarded users

### DIFF
--- a/src/components/onboarding.tsx
+++ b/src/components/onboarding.tsx
@@ -9,6 +9,7 @@ import { useAddSite } from 'src/hooks/use-add-site';
 import { generateSiteName } from 'src/lib/generate-site-name';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 import { useAppDispatch, useRootSelector } from 'src/stores';
+import { useSaveLastSeenVersionMutation } from 'src/stores/app-version-api';
 import { saveOnboardingStatus } from 'src/stores/onboarding-slice';
 import { selectMinimumWordPressVersion } from 'src/stores/provider-constants-slice';
 import { useGetWordPressVersions } from 'src/stores/wordpress-versions-api';
@@ -37,6 +38,7 @@ const GradientBox = () => {
 export default function Onboarding() {
 	const { __ } = useI18n();
 	const dispatch = useAppDispatch();
+	const [ saveLastSeenVersion ] = useSaveLastSeenVersionMutation();
 	const {
 		setSiteName,
 		setProposedSitePath,
@@ -105,6 +107,8 @@ export default function Onboarding() {
 	const handleSubmit = useCallback(
 		async ( event: FormEvent ) => {
 			event.preventDefault();
+			// Save current app version to prevent What's New from showing for new users
+			await saveLastSeenVersion( window.appGlobals.appVersion );
 			try {
 				await getIpcApi().promptWindowsSpeedUpSites( { skipIfAlreadyPrompted: true } );
 			} catch ( error ) {
@@ -120,7 +124,7 @@ export default function Onboarding() {
 				// No need to handle error here, it's already handled in handleAddSiteClick
 			}
 		},
-		[ handleAddSiteClick, siteAddedMessage, dispatch ]
+		[ handleAddSiteClick, siteAddedMessage, dispatch, saveLastSeenVersion ]
 	);
 
 	return (

--- a/src/components/tests/onboarding.test.tsx
+++ b/src/components/tests/onboarding.test.tsx
@@ -54,6 +54,14 @@ jest.mock( 'src/stores/certificate-trust-api', () => {
 	};
 } );
 
+jest.mock( 'src/stores/app-version-api', () => {
+	const actual = jest.requireActual( 'src/stores/app-version-api' ) || {};
+	return {
+		...actual,
+		useSaveLastSeenVersionMutation: jest.fn( () => [ jest.fn() ] ),
+	};
+} );
+
 const mockGenerateProposedSitePath =
 	jest.fn< ( siteName: string ) => Promise< FolderDialogResponse > >();
 
@@ -324,5 +332,32 @@ describe( 'Onboarding Component', () => {
 				'You are currently offline so your site will be created with the latest version. Selecting a different WordPress version requires an internet connection.'
 			)
 		).not.toBeInTheDocument();
+	} );
+
+	it( 'should save the current app version when onboarding completes', async () => {
+		const mockSaveLastSeenVersion = jest.fn();
+		const mockAppVersion = '1.0.0';
+
+		// Mock window.appGlobals
+		window.appGlobals = { appVersion: mockAppVersion } as typeof window.appGlobals;
+
+		const appVersionApi = jest.requireMock< {
+			useSaveLastSeenVersionMutation: jest.Mock;
+		} >( 'src/stores/app-version-api' );
+		appVersionApi.useSaveLastSeenVersionMutation.mockReturnValue( [ mockSaveLastSeenVersion ] );
+
+		const mockHandleAddSiteClick = jest.fn();
+		( useAddSite as jest.Mock ).mockReturnValue( {
+			...useAddSiteMockValue,
+			handleAddSiteClick: mockHandleAddSiteClick,
+		} );
+
+		const { getByText } = renderWithProvider( <Onboarding /> );
+
+		await user.click( getByText( 'Continue' ) );
+
+		await waitFor( () => {
+			expect( mockSaveLastSeenVersion ).toHaveBeenCalledWith( mockAppVersion );
+		} );
 	} );
 } );

--- a/src/components/tests/onboarding.test.tsx
+++ b/src/components/tests/onboarding.test.tsx
@@ -54,11 +54,13 @@ jest.mock( 'src/stores/certificate-trust-api', () => {
 	};
 } );
 
+const mockSaveLastSeenVersion = jest.fn();
+
 jest.mock( 'src/stores/app-version-api', () => {
 	const actual = jest.requireActual( 'src/stores/app-version-api' ) || {};
 	return {
 		...actual,
-		useSaveLastSeenVersionMutation: jest.fn( () => [ jest.fn() ] ),
+		useSaveLastSeenVersionMutation: jest.fn( () => [ mockSaveLastSeenVersion ] ),
 	};
 } );
 
@@ -136,6 +138,8 @@ describe( 'Onboarding Component', () => {
 
 	beforeEach( () => {
 		jest.clearAllMocks();
+		mockSaveLastSeenVersion.mockResolvedValue( { data: undefined } as never );
+		window.appGlobals = { appVersion: '1.0.0' } as typeof window.appGlobals;
 
 		( useOnboarding as jest.Mock ).mockReturnValue( {
 			needsOnboarding: true,


### PR DESCRIPTION
## Related issues

- Fixes STU-834

## Proposed Changes

- Modified onboarding flow to save the current app version as the user's "last seen version" when they complete onboarding
- This prevents the "What's New" modal from appearing for new users immediately after creating their first site
- Added test coverage to verify that the last seen version is correctly set during onboarding

## Testing Instructions

- Delete or clean the `appdata-v1.json` file from your Studio data directory to reset onboarding state
- Start Studio and complete the onboarding flow by creating your first site
- Verify that the "What's New" modal does NOT appear after the site is created
- Confirm you see only the site screen without the What's New overlay

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?