### PR TITLE
Specify explicit fonts to fix issue on MacOS Tahoe

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -12,7 +12,12 @@
 }
 
 body {
-	font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+	font-family:
+	  -apple-system, BlinkMacSystemFont, /* macOS/iOS system UI */
+	  'Segoe UI', Roboto, /* Windows + Android system UI */
+	  'Apple Color Emoji', 'Segoe UI Emoji', 'Noto Color Emoji', /* emoji */
+	  'Noto Sans', 'Arial Unicode MS', /* broad Unicode coverage */
+	  sans-serif;
 }
 
 .app-drag-region {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-840

## Proposed Changes

This update extends the default font-family stack to include emoji and Unicode-friendly fonts. Previously, Hebrew, emoji, and other non-Latin characters rendered as missing glyphs (tofu boxes) due to stricter fallback handling in macOS Tahoe.

With this change, Studio will:
- Keep a native look with system UI fonts
- Correctly render emoji across platforms
- Support broader language coverage via Noto Sans / Arial Unicode MS

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Start Studio
2. Create a site
3. Edit site and add emoji in name
4. Confirm emoji is displayed in UI
5. Change language to Hebrew and other non-latin langages
6. Confirm translations are displayed correctly

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
