### PR TITLE
Upgrade SQLite database integration plugin to fix preview sites

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -76,7 +76,7 @@ export const PLAYGROUND_CLI_MAX_TIMEOUT = 10 * 60 * 1000; // 10 minutes absolute
 export const PLAYGROUND_CLI_ACTIVITY_CHECK_INTERVAL = 5 * 1000; // Check for inactivity every 5 seconds
 
 // SQLite
-export const SQLITE_DATABASE_INTEGRATION_VERSION = 'v2.2.10';
+export const SQLITE_DATABASE_INTEGRATION_VERSION = 'v2.2.11';
 
 export const SQLITE_DATABASE_INTEGRATION_RELEASE_URL = `https://github.com/WordPress/sqlite-database-integration/archive/refs/tags/${ SQLITE_DATABASE_INTEGRATION_VERSION }.zip`;
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Related to https://github.com/WordPress/sqlite-database-integration/pull/256

## Proposed Changes

- Let's upgrade SQLite plugin so we can use the new flag `WP_SQLITE_UNSAFE_ENABLE_UNSUPPORTED_VERSIONS` with `WP_SQLITE_AST_DRIVER`, so new databases with Strict keyword will be able to work on Preview Sites when using these flags.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run `npm start`
- Start a site
- Confirm it works as expected
- Confirm the sqlite plugin has been updated to the new version 2.2.11 `

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
