### PR TITLE
Studio: Improve performance for create site

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -71,7 +71,7 @@ export const WP_CLI_IMPORT_EXPORT_RESPONSE_TIMEOUT =
 	WP_CLI_IMPORT_EXPORT_RESPONSE_TIMEOUT_IN_HRS * 60 * 60 * 1000; // 6hr
 
 // Playground CLI
-export const PLAYGROUND_CLI_INACTIVITY_TIMEOUT = 60 * 1000; // 60 seconds of no output = timeout
+export const PLAYGROUND_CLI_INACTIVITY_TIMEOUT = 2 * 60 * 1000; // 2 minutes of no output = timeout
 export const PLAYGROUND_CLI_MAX_TIMEOUT = 10 * 60 * 1000; // 10 minutes absolute maximum
 export const PLAYGROUND_CLI_ACTIVITY_CHECK_INTERVAL = 5 * 1000; // Check for inactivity every 5 seconds
 

--- a/src/hooks/use-add-site.ts
+++ b/src/hooks/use-add-site.ts
@@ -143,12 +143,12 @@ export function useAddSite() {
 							body: __( 'Your new site was imported' ),
 						} );
 					} else {
+						await startServer( newSite.id );
+
 						getIpcApi().showNotification( {
 							title: newSite.name,
 							body: __( 'Your new site was created' ),
 						} );
-
-						await startServer( newSite.id );
 					}
 				}
 			);

--- a/src/hooks/use-site-details.tsx
+++ b/src/hooks/use-site-details.tsx
@@ -153,6 +153,7 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 
 	const [ data, setData ] = useState< SiteDetails[] >( [] );
 	const [ loadingSites, setLoadingSites ] = useState< boolean >( true );
+	const [ addingSiteIds, setAddingSiteIds ] = useState< string[] >( [] );
 	const firstSite = data[ 0 ] || null;
 	const [ loadingServer, setLoadingServer ] = useState< Record< string, boolean > >(
 		firstSite?.id
@@ -236,6 +237,7 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 
 				// Remove the temporary site immediately, but with a minor delay to ensure state updates properly
 				setTimeout( () => {
+					setAddingSiteIds( ( prev ) => prev.filter( ( id ) => id !== tempSiteId ) );
 					setData( ( prevData ) =>
 						sortSites( prevData.filter( ( site ) => site.id !== tempSiteId ) )
 					);
@@ -243,6 +245,7 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 			};
 
 			const tempSiteId = crypto.randomUUID();
+			setAddingSiteIds( ( prev ) => [ ...prev, tempSiteId ] );
 			setData( ( prevData ) =>
 				sortSites( [
 					...prevData,
@@ -259,8 +262,9 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 			);
 			setSelectedSiteId( tempSiteId ); // Set the temporary ID as the selected site
 
+			let newSite: SiteDetails;
 			try {
-				const newSite = await getIpcApi().createSite( path, {
+				newSite = await getIpcApi().createSite( path, {
 					siteName,
 					wpVersion,
 					customDomain,
@@ -271,6 +275,10 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 					showError( undefined, !! blueprint );
 					return;
 				}
+				setAddingSiteIds( ( prev ) => {
+					prev.push( newSite.id );
+					return prev;
+				} );
 				// Update the selected site to the new site's ID if the user didn't change it
 				setSelectedSiteId( ( prevSelectedSiteId ) => {
 					if ( prevSelectedSiteId === tempSiteId ) {
@@ -281,9 +289,6 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 					}
 					return prevSelectedSiteId;
 				} );
-				// It replaces the temporary site created in React
-				// with the new site generated in the backend, but keeps isAddingSite to true
-				newSite.isAddingSite = true;
 				setData( ( prevData ) =>
 					prevData.map( ( site ) => ( site.id === tempSiteId ? newSite : site ) )
 				);
@@ -292,15 +297,13 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 					await callback( newSite );
 				}
 
-				setData( ( prevData ) =>
-					prevData.map( ( site ) =>
-						site.id === newSite.id ? { ...site, isAddingSite: false } : site
-					)
-				);
-
 				return newSite;
 			} catch ( error ) {
 				showError( error, !! blueprint );
+			} finally {
+				setAddingSiteIds( ( prev ) =>
+					prev.filter( ( id ) => id !== tempSiteId && id !== newSite?.id )
+				);
 			}
 		},
 		[ selectedTab, setSelectedSiteId, setSelectedTab ]
@@ -402,7 +405,7 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 			if ( ! fastDeepEqual( payload.newSites, payload.sites ) ) {
 				const updatedSites = await getIpcApi().getSiteDetails();
 				setData( ( prevData ) => {
-					const tempSite = prevData.find( ( site ) => site.isAddingSite );
+					const tempSite = prevData.find( ( site ) => addingSiteIds.includes( site.id ) );
 
 					if ( ! tempSite ) {
 						return updatedSites;
@@ -422,7 +425,7 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 		return () => {
 			unsubscribe();
 		};
-	}, [] );
+	}, [ addingSiteIds ] );
 
 	useEffect( () => {
 		let cancel = false;
@@ -468,9 +471,17 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 		setData( data.map( ( site ) => ( site.running ? { ...site, running: false } : site ) ) );
 	}, [ data ] );
 
+	const selectedSite = useMemo( () => {
+		const site = data.find( ( site ) => site.id === selectedSiteId ) || firstSite;
+		if ( addingSiteIds.includes( site?.id ) ) {
+			site.isAddingSite = true;
+		}
+		return site;
+	}, [ addingSiteIds, data, firstSite, selectedSiteId ] );
+
 	const context = useMemo(
 		() => ( {
-			selectedSite: data.find( ( site ) => site.id === selectedSiteId ) || firstSite,
+			selectedSite,
 			data,
 			setSelectedSiteId,
 			createSite,
@@ -486,8 +497,8 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 			setUploadingSites,
 		} ),
 		[
+			selectedSite,
 			data,
-			firstSite,
 			setSelectedSiteId,
 			createSite,
 			updateSite,

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -234,12 +234,10 @@ export async function createSite(
 
 	const server = SiteServer.create( details, { wpVersion, blueprint } );
 
-	let createdNewSite = false;
 	if ( ( await pathExists( path ) ) && ( await isEmptyDir( path ) ) ) {
 		try {
 			const setupDirStart = Date.now();
 			await createSiteWorkingDirectory( server, wpVersion );
-			createdNewSite = true;
 			console.log(
 				`[PERF] createSite: createSiteWorkingDirectory took ${ Date.now() - setupDirStart }ms`
 			);
@@ -274,14 +272,10 @@ export async function createSite(
 			const installStart = Date.now();
 			await installSqliteIntegration( path );
 			console.log( `[PERF] createSite: installSqliteIntegration took ${ Date.now() - installStart }ms` );
-		} else if ( ! createdNewSite ) {
-			// Only update site URL if this is an existing site being imported
-			// If we just created the site, the URL is already correct
+		} else {
 			const updateUrlStart = Date.now();
 			await updateSiteUrl( server, getSiteUrl( details ) );
 			console.log( `[PERF] createSite: updateSiteUrl took ${ Date.now() - updateUrlStart }ms` );
-		} else {
-			console.log( `[PERF] createSite: Skipping updateSiteUrl for newly created site` );
 		}
 		console.log(
 			`[PERF] createSite: SQLite integration operations took ${ Date.now() - sqliteStart }ms`

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -194,9 +194,6 @@ export async function createSite(
 		blueprint?: Blueprint;
 	} = {}
 ): Promise< SiteDetails > {
-	const perfStart = performance.now();
-	console.log( '[PERF] createSite: Starting site creation' );
-
 	const { siteName, wpVersion, customDomain, enableHttps, siteId, blueprint } = config;
 
 	const forceSetupSqlite = false;
@@ -206,7 +203,6 @@ export async function createSite(
 
 	// We only recursively create the directory if the user has not selected a
 	// path from the dialog (and thus they use the "default" or suggested path).
-	const validationStart = performance.now();
 	if ( ! ( await pathExists( path ) ) && path.startsWith( DEFAULT_SITE_PATH ) ) {
 		fs.mkdirSync( path, { recursive: true } );
 	}
@@ -223,7 +219,6 @@ export async function createSite(
 	}
 
 	const port = await portFinder.getOpenPort();
-	console.log( `[PERF] createSite: Validation and port allocation took ${ ( performance.now() - validationStart ).toFixed( 2 ) }ms` );
 
 	const details = {
 		id: siteId || crypto.randomUUID(),
@@ -242,9 +237,7 @@ export async function createSite(
 
 	if ( ( await pathExists( path ) ) && ( await isEmptyDir( path ) ) ) {
 		try {
-			const setupStart = performance.now();
 			await createSiteWorkingDirectory( server, wpVersion );
-			console.log( `[PERF] createSite: WordPress setup took ${ ( performance.now() - setupStart ).toFixed( 2 ) }ms` );
 		} catch ( error ) {
 			// If site creation failed, remove the generated files and re-throw the
 			// error so it can be handled by the caller.
@@ -254,7 +247,6 @@ export async function createSite(
 	}
 
 	if ( isWordPressDirectory( path ) ) {
-		const existingWpStart = performance.now();
 		// If the directory contains a WordPress installation, and user wants to force SQLite
 		// integration, let's rename the wp-config.php file to allow WP Now to create a new one
 		// and initialize things properly.
@@ -269,13 +261,11 @@ export async function createSite(
 		} else {
 			await updateSiteUrl( server, getSiteUrl( details ) );
 		}
-		console.log( `[PERF] createSite: Existing WordPress setup took ${ ( performance.now() - existingWpStart ).toFixed( 2 ) }ms` );
 	}
 
 	const parentWindow = BrowserWindow.fromWebContents( event.sender );
 	sendIpcEventToRendererWithWindow( parentWindow, 'theme-details-updating', { id: details.id } );
 	try {
-		const saveStart = performance.now();
 		await lockAppdata();
 		userData = await loadUserData();
 
@@ -283,8 +273,6 @@ export async function createSite(
 		sortSites( userData.sites );
 
 		await saveUserData( userData );
-		console.log( `[PERF] createSite: Save user data took ${ ( performance.now() - saveStart ).toFixed( 2 ) }ms` );
-		console.log( `[PERF] createSite: Total time ${ ( performance.now() - perfStart ).toFixed( 2 ) }ms` );
 		return server.details;
 	} finally {
 		await unlockAppdata();
@@ -480,24 +468,16 @@ export async function startServer(
 	event: IpcMainInvokeEvent,
 	id: string
 ): Promise< SiteDetails | null > {
-	const perfStart = performance.now();
-	console.log( `[PERF] startServer: Starting server for site ${ id }` );
-
 	const server = SiteServer.get( id );
 	if ( ! server ) {
 		return null;
 	}
 
-	const sqliteStart = performance.now();
 	await keepSqliteIntegrationUpdated( server.details.path );
-	console.log( `[PERF] startServer: SQLite integration update took ${ ( performance.now() - sqliteStart ).toFixed( 2 ) }ms` );
 
 	const parentWindow = BrowserWindow.fromWebContents( event.sender );
 	try {
-		const serverStartTime = performance.now();
 		await server.start();
-		console.log( `[PERF] startServer: server.start() took ${ ( performance.now() - serverStartTime ).toFixed( 2 ) }ms` );
-		console.log( `[PERF] startServer: Total time ${ ( performance.now() - perfStart ).toFixed( 2 ) }ms` );
 	} catch ( error ) {
 		/**
 		 * We don't want to track WASM memory errors in Sentry

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -510,12 +510,12 @@ export async function startServer(
 	} );
 
 	if ( server.details.running ) {
-		try {
-			await server.updateCachedThumbnail();
-			await sendThumbnailChangedEvent( event, id );
-		} catch ( error ) {
-			console.error( `Failed to update thumbnail for server ${ id }:`, error );
-		}
+		void server
+			.updateCachedThumbnail()
+			.then( () => sendThumbnailChangedEvent( event, id ) )
+			.catch( ( error ) => {
+				console.error( `Failed to update thumbnail for server ${ id }:`, error );
+			} );
 	}
 
 	console.log( `Server started for '${ server.details.name }'` );

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -510,12 +510,14 @@ export async function startServer(
 	} );
 
 	if ( server.details.running ) {
-		void server
-			.updateCachedThumbnail()
-			.then( () => sendThumbnailChangedEvent( event, id ) )
-			.catch( ( error ) => {
+		void ( async () => {
+			try {
+				await server.updateCachedThumbnail();
+				await sendThumbnailChangedEvent( event, id );
+			} catch ( error ) {
 				console.error( `Failed to update thumbnail for server ${ id }:`, error );
-			} );
+			}
+		} )();
 	}
 
 	console.log( `Server started for '${ server.details.name }'` );

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -158,6 +158,7 @@ export async function importSite(
 	}
 	try {
 		if ( ! isWordPressDirectory( site.details.path ) ) {
+			// Workaround to have the necessary WordPress files to run the import - STU-744
 			await site.start();
 			await site.stop();
 		}

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -157,6 +157,11 @@ export async function importSite(
 		throw new Error( 'Site not found.' );
 	}
 	try {
+		if ( ! isWordPressDirectory( site.details.path ) ) {
+			await site.start();
+			await site.stop();
+		}
+
 		const onEvent = ( data: ImportExportEventData ) => {
 			const parentWindow = BrowserWindow.fromWebContents( event.sender );
 			sendIpcEventToRendererWithWindow( parentWindow, 'on-import', data, id );
@@ -189,10 +194,6 @@ export async function createSite(
 		blueprint?: Blueprint;
 	} = {}
 ): Promise< SiteDetails > {
-	const createSiteStartTime = Date.now();
-	console.log( `[PERF] createSite: Starting at ${new Date().toISOString()}` );
-	console.log( `[PERF] createSite: Start timestamp: ${createSiteStartTime}` );
-
 	const { siteName, wpVersion, customDomain, enableHttps, siteId, blueprint } = config;
 
 	const forceSetupSqlite = false;
@@ -232,15 +233,11 @@ export async function createSite(
 		enableHttps,
 	} as const;
 
-	const server = SiteServer.create( details, { wpVersion, blueprint } );
+	const server = SiteServer.create( details, { wpVersion, blueprint: blueprint?.blueprint } );
 
 	if ( ( await pathExists( path ) ) && ( await isEmptyDir( path ) ) ) {
 		try {
-			const setupDirStart = Date.now();
 			await createSiteWorkingDirectory( server, wpVersion );
-			console.log(
-				`[PERF] createSite: createSiteWorkingDirectory took ${ Date.now() - setupDirStart }ms`
-			);
 		} catch ( error ) {
 			// If site creation failed, remove the generated files and re-throw the
 			// error so it can be handled by the caller.
@@ -249,9 +246,7 @@ export async function createSite(
 		}
 	}
 
-	const sqliteStart = Date.now();
 	const isWpDir = isWordPressDirectory( path );
-	console.log( `[PERF] createSite: isWordPressDirectory check took ${ Date.now() - sqliteStart }ms, result: ${isWpDir}` );
 
 	if ( isWpDir ) {
 		// If the directory contains a WordPress installation, and user wants to force SQLite
@@ -263,28 +258,16 @@ export async function createSite(
 				nodePath.join( path, 'wp-config-studio.php' )
 			);
 		}
-
-		const wpConfigCheckStart = Date.now();
 		const wpConfigExists = await pathExists( nodePath.join( path, 'wp-config.php' ) );
-		console.log( `[PERF] createSite: wp-config.php exists check took ${ Date.now() - wpConfigCheckStart }ms, exists: ${wpConfigExists}` );
-
 		if ( ! wpConfigExists ) {
-			const installStart = Date.now();
 			await installSqliteIntegration( path );
-			console.log( `[PERF] createSite: installSqliteIntegration took ${ Date.now() - installStart }ms` );
 		} else {
-			const updateUrlStart = Date.now();
 			await updateSiteUrl( server, getSiteUrl( details ) );
-			console.log( `[PERF] createSite: updateSiteUrl took ${ Date.now() - updateUrlStart }ms` );
 		}
-		console.log(
-			`[PERF] createSite: SQLite integration operations took ${ Date.now() - sqliteStart }ms`
-		);
 	}
 
 	const parentWindow = BrowserWindow.fromWebContents( event.sender );
 	sendIpcEventToRendererWithWindow( parentWindow, 'theme-details-updating', { id: details.id } );
-	const appdataStart = Date.now();
 	try {
 		await lockAppdata();
 		userData = await loadUserData();
@@ -293,14 +276,6 @@ export async function createSite(
 		sortSites( userData.sites );
 
 		await saveUserData( userData );
-		console.log( `[PERF] createSite: Appdata operations took ${ Date.now() - appdataStart }ms` );
-
-		const createSiteEndTime = Date.now();
-		console.log( `[PERF] createSite: Finished at ${new Date().toISOString()}` );
-		console.log( `[PERF] createSite: End timestamp: ${createSiteEndTime}` );
-		console.log(
-			`[PERF] createSite: Total time ${ createSiteEndTime - createSiteStartTime }ms`
-		);
 
 		return server.details;
 	} finally {
@@ -497,28 +472,16 @@ export async function startServer(
 	event: IpcMainInvokeEvent,
 	id: string
 ): Promise< SiteDetails | null > {
-	const startServerIpcTime = Date.now();
-	console.log( `[PERF] startServer IPC: Starting at ${new Date().toISOString()}` );
-	console.log( `[PERF] startServer IPC: Start timestamp: ${startServerIpcTime}` );
-
 	const server = SiteServer.get( id );
 	if ( ! server ) {
 		return null;
 	}
 
-	const sqliteUpdateStart = Date.now();
 	await keepSqliteIntegrationUpdated( server.details.path );
-	console.log(
-		`[PERF] startServer IPC: keepSqliteIntegrationUpdated took ${ Date.now() - sqliteUpdateStart }ms`
-	);
 
 	const parentWindow = BrowserWindow.fromWebContents( event.sender );
 	try {
-		const serverStartCall = Date.now();
 		await server.start();
-		console.log(
-			`[PERF] startServer IPC: server.start() took ${ Date.now() - serverStartCall }ms`
-		);
 	} catch ( error ) {
 		/**
 		 * We don't want to track WASM memory errors in Sentry
@@ -552,12 +515,8 @@ export async function startServer(
 
 	if ( server.details.running ) {
 		try {
-			const thumbnailStart = Date.now();
 			await server.updateCachedThumbnail();
 			await sendThumbnailChangedEvent( event, id );
-			console.log(
-				`[PERF] startServer IPC: Thumbnail update took ${ Date.now() - thumbnailStart }ms`
-			);
 		} catch ( error ) {
 			console.error( `Failed to update thumbnail for server ${ id }:`, error );
 		}
@@ -565,16 +524,7 @@ export async function startServer(
 
 	console.log( `Server started for '${ server.details.name }'` );
 
-	const updateSiteStart = Date.now();
 	await updateSite( event, server.details );
-	console.log( `[PERF] startServer IPC: updateSite took ${ Date.now() - updateSiteStart }ms` );
-
-	const startServerIpcEndTime = Date.now();
-	console.log( `[PERF] startServer IPC: Finished at ${new Date().toISOString()}` );
-	console.log( `[PERF] startServer IPC: End timestamp: ${startServerIpcEndTime}` );
-	console.log(
-		`[PERF] startServer IPC: Total time ${ startServerIpcEndTime - startServerIpcTime }ms`
-	);
 
 	return server.details;
 }

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -246,9 +246,7 @@ export async function createSite(
 		}
 	}
 
-	const isWpDir = isWordPressDirectory( path );
-
-	if ( isWpDir ) {
+	if ( isWordPressDirectory( path ) ) {
 		// If the directory contains a WordPress installation, and user wants to force SQLite
 		// integration, let's rename the wp-config.php file to allow WP Now to create a new one
 		// and initialize things properly.
@@ -258,8 +256,7 @@ export async function createSite(
 				nodePath.join( path, 'wp-config-studio.php' )
 			);
 		}
-		const wpConfigExists = await pathExists( nodePath.join( path, 'wp-config.php' ) );
-		if ( ! wpConfigExists ) {
+		if ( ! ( await pathExists( nodePath.join( path, 'wp-config.php' ) ) ) ) {
 			await installSqliteIntegration( path );
 		} else {
 			await updateSiteUrl( server, getSiteUrl( details ) );
@@ -276,7 +273,6 @@ export async function createSite(
 		sortSites( userData.sites );
 
 		await saveUserData( userData );
-
 		return server.details;
 	} finally {
 		await unlockAppdata();
@@ -523,9 +519,7 @@ export async function startServer(
 	}
 
 	console.log( `Server started for '${ server.details.name }'` );
-
 	await updateSite( event, server.details );
-
 	return server.details;
 }
 

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -194,6 +194,9 @@ export async function createSite(
 		blueprint?: Blueprint;
 	} = {}
 ): Promise< SiteDetails > {
+	const perfStart = performance.now();
+	console.log( '[PERF] createSite: Starting site creation' );
+
 	const { siteName, wpVersion, customDomain, enableHttps, siteId, blueprint } = config;
 
 	const forceSetupSqlite = false;
@@ -203,6 +206,7 @@ export async function createSite(
 
 	// We only recursively create the directory if the user has not selected a
 	// path from the dialog (and thus they use the "default" or suggested path).
+	const validationStart = performance.now();
 	if ( ! ( await pathExists( path ) ) && path.startsWith( DEFAULT_SITE_PATH ) ) {
 		fs.mkdirSync( path, { recursive: true } );
 	}
@@ -219,6 +223,7 @@ export async function createSite(
 	}
 
 	const port = await portFinder.getOpenPort();
+	console.log( `[PERF] createSite: Validation and port allocation took ${ ( performance.now() - validationStart ).toFixed( 2 ) }ms` );
 
 	const details = {
 		id: siteId || crypto.randomUUID(),
@@ -237,7 +242,9 @@ export async function createSite(
 
 	if ( ( await pathExists( path ) ) && ( await isEmptyDir( path ) ) ) {
 		try {
+			const setupStart = performance.now();
 			await createSiteWorkingDirectory( server, wpVersion );
+			console.log( `[PERF] createSite: WordPress setup took ${ ( performance.now() - setupStart ).toFixed( 2 ) }ms` );
 		} catch ( error ) {
 			// If site creation failed, remove the generated files and re-throw the
 			// error so it can be handled by the caller.
@@ -247,6 +254,7 @@ export async function createSite(
 	}
 
 	if ( isWordPressDirectory( path ) ) {
+		const existingWpStart = performance.now();
 		// If the directory contains a WordPress installation, and user wants to force SQLite
 		// integration, let's rename the wp-config.php file to allow WP Now to create a new one
 		// and initialize things properly.
@@ -261,11 +269,13 @@ export async function createSite(
 		} else {
 			await updateSiteUrl( server, getSiteUrl( details ) );
 		}
+		console.log( `[PERF] createSite: Existing WordPress setup took ${ ( performance.now() - existingWpStart ).toFixed( 2 ) }ms` );
 	}
 
 	const parentWindow = BrowserWindow.fromWebContents( event.sender );
 	sendIpcEventToRendererWithWindow( parentWindow, 'theme-details-updating', { id: details.id } );
 	try {
+		const saveStart = performance.now();
 		await lockAppdata();
 		userData = await loadUserData();
 
@@ -273,6 +283,8 @@ export async function createSite(
 		sortSites( userData.sites );
 
 		await saveUserData( userData );
+		console.log( `[PERF] createSite: Save user data took ${ ( performance.now() - saveStart ).toFixed( 2 ) }ms` );
+		console.log( `[PERF] createSite: Total time ${ ( performance.now() - perfStart ).toFixed( 2 ) }ms` );
 		return server.details;
 	} finally {
 		await unlockAppdata();
@@ -468,16 +480,24 @@ export async function startServer(
 	event: IpcMainInvokeEvent,
 	id: string
 ): Promise< SiteDetails | null > {
+	const perfStart = performance.now();
+	console.log( `[PERF] startServer: Starting server for site ${ id }` );
+
 	const server = SiteServer.get( id );
 	if ( ! server ) {
 		return null;
 	}
 
+	const sqliteStart = performance.now();
 	await keepSqliteIntegrationUpdated( server.details.path );
+	console.log( `[PERF] startServer: SQLite integration update took ${ ( performance.now() - sqliteStart ).toFixed( 2 ) }ms` );
 
 	const parentWindow = BrowserWindow.fromWebContents( event.sender );
 	try {
+		const serverStartTime = performance.now();
 		await server.start();
+		console.log( `[PERF] startServer: server.start() took ${ ( performance.now() - serverStartTime ).toFixed( 2 ) }ms` );
+		console.log( `[PERF] startServer: Total time ${ ( performance.now() - perfStart ).toFixed( 2 ) }ms` );
 	} catch ( error ) {
 		/**
 		 * We don't want to track WASM memory errors in Sentry

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -234,10 +234,12 @@ export async function createSite(
 
 	const server = SiteServer.create( details, { wpVersion, blueprint } );
 
+	let createdNewSite = false;
 	if ( ( await pathExists( path ) ) && ( await isEmptyDir( path ) ) ) {
 		try {
 			const setupDirStart = Date.now();
 			await createSiteWorkingDirectory( server, wpVersion );
+			createdNewSite = true;
 			console.log(
 				`[PERF] createSite: createSiteWorkingDirectory took ${ Date.now() - setupDirStart }ms`
 			);
@@ -272,10 +274,14 @@ export async function createSite(
 			const installStart = Date.now();
 			await installSqliteIntegration( path );
 			console.log( `[PERF] createSite: installSqliteIntegration took ${ Date.now() - installStart }ms` );
-		} else {
+		} else if ( ! createdNewSite ) {
+			// Only update site URL if this is an existing site being imported
+			// If we just created the site, the URL is already correct
 			const updateUrlStart = Date.now();
 			await updateSiteUrl( server, getSiteUrl( details ) );
 			console.log( `[PERF] createSite: updateSiteUrl took ${ Date.now() - updateUrlStart }ms` );
+		} else {
+			console.log( `[PERF] createSite: Skipping updateSiteUrl for newly created site` );
 		}
 		console.log(
 			`[PERF] createSite: SQLite integration operations took ${ Date.now() - sqliteStart }ms`

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -189,6 +189,10 @@ export async function createSite(
 		blueprint?: Blueprint;
 	} = {}
 ): Promise< SiteDetails > {
+	const createSiteStartTime = Date.now();
+	console.log( `[PERF] createSite: Starting at ${new Date().toISOString()}` );
+	console.log( `[PERF] createSite: Start timestamp: ${createSiteStartTime}` );
+
 	const { siteName, wpVersion, customDomain, enableHttps, siteId, blueprint } = config;
 
 	const forceSetupSqlite = false;
@@ -232,7 +236,11 @@ export async function createSite(
 
 	if ( ( await pathExists( path ) ) && ( await isEmptyDir( path ) ) ) {
 		try {
+			const setupDirStart = Date.now();
 			await createSiteWorkingDirectory( server, wpVersion );
+			console.log(
+				`[PERF] createSite: createSiteWorkingDirectory took ${ Date.now() - setupDirStart }ms`
+			);
 		} catch ( error ) {
 			// If site creation failed, remove the generated files and re-throw the
 			// error so it can be handled by the caller.
@@ -241,7 +249,11 @@ export async function createSite(
 		}
 	}
 
-	if ( isWordPressDirectory( path ) ) {
+	const sqliteStart = Date.now();
+	const isWpDir = isWordPressDirectory( path );
+	console.log( `[PERF] createSite: isWordPressDirectory check took ${ Date.now() - sqliteStart }ms, result: ${isWpDir}` );
+
+	if ( isWpDir ) {
 		// If the directory contains a WordPress installation, and user wants to force SQLite
 		// integration, let's rename the wp-config.php file to allow WP Now to create a new one
 		// and initialize things properly.
@@ -252,15 +264,27 @@ export async function createSite(
 			);
 		}
 
-		if ( ! ( await pathExists( nodePath.join( path, 'wp-config.php' ) ) ) ) {
+		const wpConfigCheckStart = Date.now();
+		const wpConfigExists = await pathExists( nodePath.join( path, 'wp-config.php' ) );
+		console.log( `[PERF] createSite: wp-config.php exists check took ${ Date.now() - wpConfigCheckStart }ms, exists: ${wpConfigExists}` );
+
+		if ( ! wpConfigExists ) {
+			const installStart = Date.now();
 			await installSqliteIntegration( path );
+			console.log( `[PERF] createSite: installSqliteIntegration took ${ Date.now() - installStart }ms` );
 		} else {
+			const updateUrlStart = Date.now();
 			await updateSiteUrl( server, getSiteUrl( details ) );
+			console.log( `[PERF] createSite: updateSiteUrl took ${ Date.now() - updateUrlStart }ms` );
 		}
+		console.log(
+			`[PERF] createSite: SQLite integration operations took ${ Date.now() - sqliteStart }ms`
+		);
 	}
 
 	const parentWindow = BrowserWindow.fromWebContents( event.sender );
 	sendIpcEventToRendererWithWindow( parentWindow, 'theme-details-updating', { id: details.id } );
+	const appdataStart = Date.now();
 	try {
 		await lockAppdata();
 		userData = await loadUserData();
@@ -269,6 +293,15 @@ export async function createSite(
 		sortSites( userData.sites );
 
 		await saveUserData( userData );
+		console.log( `[PERF] createSite: Appdata operations took ${ Date.now() - appdataStart }ms` );
+
+		const createSiteEndTime = Date.now();
+		console.log( `[PERF] createSite: Finished at ${new Date().toISOString()}` );
+		console.log( `[PERF] createSite: End timestamp: ${createSiteEndTime}` );
+		console.log(
+			`[PERF] createSite: Total time ${ createSiteEndTime - createSiteStartTime }ms`
+		);
+
 		return server.details;
 	} finally {
 		await unlockAppdata();
@@ -464,16 +497,28 @@ export async function startServer(
 	event: IpcMainInvokeEvent,
 	id: string
 ): Promise< SiteDetails | null > {
+	const startServerIpcTime = Date.now();
+	console.log( `[PERF] startServer IPC: Starting at ${new Date().toISOString()}` );
+	console.log( `[PERF] startServer IPC: Start timestamp: ${startServerIpcTime}` );
+
 	const server = SiteServer.get( id );
 	if ( ! server ) {
 		return null;
 	}
 
+	const sqliteUpdateStart = Date.now();
 	await keepSqliteIntegrationUpdated( server.details.path );
+	console.log(
+		`[PERF] startServer IPC: keepSqliteIntegrationUpdated took ${ Date.now() - sqliteUpdateStart }ms`
+	);
 
 	const parentWindow = BrowserWindow.fromWebContents( event.sender );
 	try {
+		const serverStartCall = Date.now();
 		await server.start();
+		console.log(
+			`[PERF] startServer IPC: server.start() took ${ Date.now() - serverStartCall }ms`
+		);
 	} catch ( error ) {
 		/**
 		 * We don't want to track WASM memory errors in Sentry
@@ -507,15 +552,30 @@ export async function startServer(
 
 	if ( server.details.running ) {
 		try {
+			const thumbnailStart = Date.now();
 			await server.updateCachedThumbnail();
 			await sendThumbnailChangedEvent( event, id );
+			console.log(
+				`[PERF] startServer IPC: Thumbnail update took ${ Date.now() - thumbnailStart }ms`
+			);
 		} catch ( error ) {
 			console.error( `Failed to update thumbnail for server ${ id }:`, error );
 		}
 	}
 
 	console.log( `Server started for '${ server.details.name }'` );
+
+	const updateSiteStart = Date.now();
 	await updateSite( event, server.details );
+	console.log( `[PERF] startServer IPC: updateSite took ${ Date.now() - updateSiteStart }ms` );
+
+	const startServerIpcEndTime = Date.now();
+	console.log( `[PERF] startServer IPC: Finished at ${new Date().toISOString()}` );
+	console.log( `[PERF] startServer IPC: End timestamp: ${startServerIpcEndTime}` );
+	console.log(
+		`[PERF] startServer IPC: Total time ${ startServerIpcEndTime - startServerIpcTime }ms`
+	);
+
 	return server.details;
 }
 

--- a/src/lib/php-get-theme-details.ts
+++ b/src/lib/php-get-theme-details.ts
@@ -18,13 +18,9 @@ export async function phpGetThemeDetails(
 		throw Error( 'PHP is not instantiated' );
 	}
 
-	const perfStart = performance.now();
-
 	try {
 		// Try to use the persistent mu-plugin API endpoint if available (Playground CLI)
 		if ( server.php.request ) {
-			console.log( '[PERF] phpGetThemeDetails: Using persistent API endpoint' );
-
 			const response = await server.php.request( {
 				url: '/?studio-admin-api',
 				method: 'POST',
@@ -33,16 +29,11 @@ export async function phpGetThemeDetails(
 				},
 			} );
 
-			console.log(
-				`[PERF] phpGetThemeDetails: Total time ${ ( performance.now() - perfStart ).toFixed( 2 ) }ms`
-			);
-
 			const themeDetailsParsed = JSON.parse( response.text );
 			return themeDetailsSchema.parse( themeDetailsParsed );
 		}
 
 		// Fallback to runPhp for WP-Now
-		console.log( '[PERF] phpGetThemeDetails: Using fallback runPhp method' );
 		const wpLoadPath = getWpLoadPath( server );
 
 		const themeDetailsPhp = `<?php
@@ -61,10 +52,6 @@ export async function phpGetThemeDetails(
 		const themeDetailsRaw = await server.runPhp( {
 			code: themeDetailsPhp,
 		} );
-
-		console.log(
-			`[PERF] phpGetThemeDetails: Total time ${ ( performance.now() - perfStart ).toFixed( 2 ) }ms`
-		);
 
 		const themeDetailsParsed = JSON.parse( themeDetailsRaw );
 		return themeDetailsSchema.parse( themeDetailsParsed );

--- a/src/lib/php-get-theme-details.ts
+++ b/src/lib/php-get-theme-details.ts
@@ -18,28 +18,58 @@ export async function phpGetThemeDetails(
 		throw Error( 'PHP is not instantiated' );
 	}
 
-	const wpLoadPath = getWpLoadPath( server );
-
-	const themeDetailsPhp = `<?php
-	require_once('${ wpLoadPath }');
-	$theme = wp_get_theme();
-	echo json_encode([
-		'name' => $theme->get('Name'),
-		'path' => $theme->get_stylesheet_directory(),
-		'slug' => $theme->get_stylesheet(),
-		'isBlockTheme' => $theme->is_block_theme(),
-		'supportsWidgets' => current_theme_supports('widgets'),
-		'supportsMenus' => get_registered_nav_menus() || current_theme_supports('menus'),
-	]);
-	`;
+	const perfStart = performance.now();
 
 	try {
+		// Try to use the persistent mu-plugin API endpoint if available (Playground CLI)
+		if ( server.php.request ) {
+			console.log( '[PERF] phpGetThemeDetails: Using persistent API endpoint' );
+
+			const response = await server.php.request( {
+				url: '/?studio-admin-api',
+				method: 'POST',
+				body: {
+					action: 'get_theme_details',
+				},
+			} );
+
+			console.log(
+				`[PERF] phpGetThemeDetails: Total time ${ ( performance.now() - perfStart ).toFixed( 2 ) }ms`
+			);
+
+			const themeDetailsParsed = JSON.parse( response.text );
+			return themeDetailsSchema.parse( themeDetailsParsed );
+		}
+
+		// Fallback to runPhp for WP-Now
+		console.log( '[PERF] phpGetThemeDetails: Using fallback runPhp method' );
+		const wpLoadPath = getWpLoadPath( server );
+
+		const themeDetailsPhp = `<?php
+		require_once('${ wpLoadPath }');
+		$theme = wp_get_theme();
+		echo json_encode([
+			'name' => $theme->get('Name'),
+			'path' => $theme->get_stylesheet_directory(),
+			'slug' => $theme->get_stylesheet(),
+			'isBlockTheme' => $theme->is_block_theme(),
+			'supportsWidgets' => current_theme_supports('widgets'),
+			'supportsMenus' => get_registered_nav_menus() || current_theme_supports('menus'),
+		]);
+		`;
+
 		const themeDetailsRaw = await server.runPhp( {
 			code: themeDetailsPhp,
 		} );
+
+		console.log(
+			`[PERF] phpGetThemeDetails: Total time ${ ( performance.now() - perfStart ).toFixed( 2 ) }ms`
+		);
+
 		const themeDetailsParsed = JSON.parse( themeDetailsRaw );
 		return themeDetailsSchema.parse( themeDetailsParsed );
 	} catch ( error ) {
+		console.error( 'Failed to get theme details:', error );
 		return undefined;
 	}
 }

--- a/src/lib/wordpress-provider/playground-cli/mu-plugins.ts
+++ b/src/lib/wordpress-provider/playground-cli/mu-plugins.ts
@@ -319,7 +319,6 @@ function getStandardMuPlugins( options: Partial< WordPressServerOptions > ): MuP
 
 		add_action( 'init', function() {
 			// Only handle requests to our endpoint
-			// Check both query string and REQUEST_URI
 			$is_api_request = isset( $_GET['studio-admin-api'] ) ||
 			                  strpos( $_SERVER['REQUEST_URI'] ?? '', 'studio-admin-api' ) !== false;
 
@@ -327,29 +326,20 @@ function getStandardMuPlugins( options: Partial< WordPressServerOptions > ): MuP
 				return;
 			}
 
-			error_log("[PERF-PHP] Studio Admin API: Received request");
-
 			// Security: Only allow POST requests with the correct action
 			if ( $_SERVER['REQUEST_METHOD'] !== 'POST' || empty( $_POST['action'] ) ) {
 				status_header( 400 );
 				header( 'Content-Type: application/json' );
-				echo json_encode( [ 'error' => 'Invalid request', 'method' => $_SERVER['REQUEST_METHOD'], 'post' => $_POST ] );
+				echo json_encode( [ 'error' => 'Invalid request' ] );
 				exit;
 			}
 
 			$action = $_POST['action'];
 			$result = null;
 
-			$start = microtime(true);
-			error_log("[PERF-PHP] Studio Admin API: Processing action '$action'");
-
 			switch ( $action ) {
 				case 'get_theme_details':
-					$themeStart = microtime(true);
 					$theme = wp_get_theme();
-					$themeTime = (microtime(true) - $themeStart) * 1000;
-					error_log("[PERF-PHP] API wp_get_theme took " . number_format($themeTime, 2) . "ms");
-
 					$result = [
 						'name' => $theme->get('Name'),
 						'path' => $theme->get_stylesheet_directory(),
@@ -362,17 +352,13 @@ function getStandardMuPlugins( options: Partial< WordPressServerOptions > ): MuP
 
 				case 'set_admin_password':
 					if ( empty( $_POST['password'] ) ) {
-						http_response_code( 400 );
+						status_header( 400 );
+						header( 'Content-Type: application/json' );
 						echo json_encode( [ 'error' => 'Password is required' ] );
 						exit;
 					}
 
-					$userStart = microtime(true);
 					$user = get_user_by( 'login', 'admin' );
-					$userTime = (microtime(true) - $userStart) * 1000;
-					error_log("[PERF-PHP] API get_user_by took " . number_format($userTime, 2) . "ms");
-
-					$pwStart = microtime(true);
 					if ( $user ) {
 						wp_set_password( $_POST['password'], $user->ID );
 					} else {
@@ -384,84 +370,7 @@ function getStandardMuPlugins( options: Partial< WordPressServerOptions > ): MuP
 						);
 						wp_insert_user( $user_data );
 					}
-					$pwTime = (microtime(true) - $pwStart) * 1000;
-					error_log("[PERF-PHP] API password operation took " . number_format($pwTime, 2) . "ms");
-
 					$result = [ 'success' => true ];
-					break;
-
-				case 'combined_startup':
-					// Combined operation: set password and get theme details in one call
-					if ( !empty( $_POST['password'] ) ) {
-						$user = get_user_by( 'login', 'admin' );
-						if ( $user ) {
-							wp_set_password( $_POST['password'], $user->ID );
-						} else {
-							$user_data = array(
-								'user_login' => 'admin',
-								'user_pass' => $_POST['password'],
-								'user_email' => 'admin@localhost.com',
-								'role' => 'administrator',
-							);
-							wp_insert_user( $user_data );
-						}
-					}
-
-					$theme = wp_get_theme();
-					$result = [
-						'theme' => [
-							'name' => $theme->get('Name'),
-							'path' => $theme->get_stylesheet_directory(),
-							'slug' => $theme->get_stylesheet(),
-							'isBlockTheme' => $theme->is_block_theme(),
-							'supportsWidgets' => current_theme_supports('widgets'),
-							'supportsMenus' => get_registered_nav_menus() || current_theme_supports('menus'),
-						],
-					];
-					break;
-
-				case 'wp_cli':
-					// Execute WP-CLI command using the persistent WordPress instance
-					if ( empty( $_POST['command'] ) ) {
-						status_header( 400 );
-						header( 'Content-Type: application/json' );
-						echo json_encode( [ 'error' => 'Command is required' ] );
-						exit;
-					}
-
-					$wpCliPath = '/tmp/wp-cli.phar';
-					if ( !file_exists( $wpCliPath ) ) {
-						status_header( 500 );
-						header( 'Content-Type: application/json' );
-						echo json_encode( [ 'error' => 'WP-CLI not found' ] );
-						exit;
-					}
-
-					// Parse the command string into arguments
-					$command = $_POST['command'];
-					error_log("[PERF-PHP] API executing WP-CLI command: $command");
-
-					// Set up WP-CLI environment
-					$_SERVER['argv'] = explode( ' ', $command );
-					$_SERVER['argc'] = count( $_SERVER['argv'] );
-
-					// Capture WP-CLI output
-					ob_start();
-					$exit_code = 0;
-					try {
-						define( 'WP_CLI', true );
-						include( $wpCliPath );
-					} catch ( Exception $e ) {
-						$exit_code = 1;
-						error_log("[PERF-PHP] WP-CLI error: " . $e->getMessage());
-					}
-					$output = ob_get_clean();
-
-					$result = [
-						'stdout' => $output,
-						'stderr' => '',
-						'exitCode' => $exit_code,
-					];
 					break;
 
 				default:
@@ -470,9 +379,6 @@ function getStandardMuPlugins( options: Partial< WordPressServerOptions > ): MuP
 					echo json_encode( [ 'error' => 'Unknown action' ] );
 					exit;
 			}
-
-			$totalTime = (microtime(true) - $start) * 1000;
-			error_log("[PERF-PHP] API action '$action' total took " . number_format($totalTime, 2) . "ms");
 
 			status_header( 200 );
 			header( 'Content-Type: application/json' );

--- a/src/lib/wordpress-provider/playground-cli/mu-plugins.ts
+++ b/src/lib/wordpress-provider/playground-cli/mu-plugins.ts
@@ -303,6 +303,185 @@ function getStandardMuPlugins( options: Partial< WordPressServerOptions > ): MuP
 		`,
 	} );
 
+	// Studio Admin API: Persistent endpoint for admin operations
+	muPlugins.push( {
+		filename: '0-studio-admin-api.php',
+		content: `<?php
+		/**
+		 * Studio Admin API
+		 *
+		 * Provides a persistent endpoint for admin operations that can reuse
+		 * the already-loaded WordPress instance, avoiding the overhead of
+		 * loading wp-load.php multiple times.
+		 *
+		 * This endpoint should only be accessible locally.
+		 */
+
+		add_action( 'init', function() {
+			// Only handle requests to our endpoint
+			// Check both query string and REQUEST_URI
+			$is_api_request = isset( $_GET['studio-admin-api'] ) ||
+			                  strpos( $_SERVER['REQUEST_URI'] ?? '', 'studio-admin-api' ) !== false;
+
+			if ( ! $is_api_request ) {
+				return;
+			}
+
+			error_log("[PERF-PHP] Studio Admin API: Received request");
+
+			// Security: Only allow POST requests with the correct action
+			if ( $_SERVER['REQUEST_METHOD'] !== 'POST' || empty( $_POST['action'] ) ) {
+				status_header( 400 );
+				header( 'Content-Type: application/json' );
+				echo json_encode( [ 'error' => 'Invalid request', 'method' => $_SERVER['REQUEST_METHOD'], 'post' => $_POST ] );
+				exit;
+			}
+
+			$action = $_POST['action'];
+			$result = null;
+
+			$start = microtime(true);
+			error_log("[PERF-PHP] Studio Admin API: Processing action '$action'");
+
+			switch ( $action ) {
+				case 'get_theme_details':
+					$themeStart = microtime(true);
+					$theme = wp_get_theme();
+					$themeTime = (microtime(true) - $themeStart) * 1000;
+					error_log("[PERF-PHP] API wp_get_theme took " . number_format($themeTime, 2) . "ms");
+
+					$result = [
+						'name' => $theme->get('Name'),
+						'path' => $theme->get_stylesheet_directory(),
+						'slug' => $theme->get_stylesheet(),
+						'isBlockTheme' => $theme->is_block_theme(),
+						'supportsWidgets' => current_theme_supports('widgets'),
+						'supportsMenus' => get_registered_nav_menus() || current_theme_supports('menus'),
+					];
+					break;
+
+				case 'set_admin_password':
+					if ( empty( $_POST['password'] ) ) {
+						http_response_code( 400 );
+						echo json_encode( [ 'error' => 'Password is required' ] );
+						exit;
+					}
+
+					$userStart = microtime(true);
+					$user = get_user_by( 'login', 'admin' );
+					$userTime = (microtime(true) - $userStart) * 1000;
+					error_log("[PERF-PHP] API get_user_by took " . number_format($userTime, 2) . "ms");
+
+					$pwStart = microtime(true);
+					if ( $user ) {
+						wp_set_password( $_POST['password'], $user->ID );
+					} else {
+						$user_data = array(
+							'user_login' => 'admin',
+							'user_pass' => $_POST['password'],
+							'user_email' => 'admin@localhost.com',
+							'role' => 'administrator',
+						);
+						wp_insert_user( $user_data );
+					}
+					$pwTime = (microtime(true) - $pwStart) * 1000;
+					error_log("[PERF-PHP] API password operation took " . number_format($pwTime, 2) . "ms");
+
+					$result = [ 'success' => true ];
+					break;
+
+				case 'combined_startup':
+					// Combined operation: set password and get theme details in one call
+					if ( !empty( $_POST['password'] ) ) {
+						$user = get_user_by( 'login', 'admin' );
+						if ( $user ) {
+							wp_set_password( $_POST['password'], $user->ID );
+						} else {
+							$user_data = array(
+								'user_login' => 'admin',
+								'user_pass' => $_POST['password'],
+								'user_email' => 'admin@localhost.com',
+								'role' => 'administrator',
+							);
+							wp_insert_user( $user_data );
+						}
+					}
+
+					$theme = wp_get_theme();
+					$result = [
+						'theme' => [
+							'name' => $theme->get('Name'),
+							'path' => $theme->get_stylesheet_directory(),
+							'slug' => $theme->get_stylesheet(),
+							'isBlockTheme' => $theme->is_block_theme(),
+							'supportsWidgets' => current_theme_supports('widgets'),
+							'supportsMenus' => get_registered_nav_menus() || current_theme_supports('menus'),
+						],
+					];
+					break;
+
+				case 'wp_cli':
+					// Execute WP-CLI command using the persistent WordPress instance
+					if ( empty( $_POST['command'] ) ) {
+						status_header( 400 );
+						header( 'Content-Type: application/json' );
+						echo json_encode( [ 'error' => 'Command is required' ] );
+						exit;
+					}
+
+					$wpCliPath = '/tmp/wp-cli.phar';
+					if ( !file_exists( $wpCliPath ) ) {
+						status_header( 500 );
+						header( 'Content-Type: application/json' );
+						echo json_encode( [ 'error' => 'WP-CLI not found' ] );
+						exit;
+					}
+
+					// Parse the command string into arguments
+					$command = $_POST['command'];
+					error_log("[PERF-PHP] API executing WP-CLI command: $command");
+
+					// Set up WP-CLI environment
+					$_SERVER['argv'] = explode( ' ', $command );
+					$_SERVER['argc'] = count( $_SERVER['argv'] );
+
+					// Capture WP-CLI output
+					ob_start();
+					$exit_code = 0;
+					try {
+						define( 'WP_CLI', true );
+						include( $wpCliPath );
+					} catch ( Exception $e ) {
+						$exit_code = 1;
+						error_log("[PERF-PHP] WP-CLI error: " . $e->getMessage());
+					}
+					$output = ob_get_clean();
+
+					$result = [
+						'stdout' => $output,
+						'stderr' => '',
+						'exitCode' => $exit_code,
+					];
+					break;
+
+				default:
+					status_header( 400 );
+					header( 'Content-Type: application/json' );
+					echo json_encode( [ 'error' => 'Unknown action' ] );
+					exit;
+			}
+
+			$totalTime = (microtime(true) - $start) * 1000;
+			error_log("[PERF-PHP] API action '$action' total took " . number_format($totalTime, 2) . "ms");
+
+			status_header( 200 );
+			header( 'Content-Type: application/json' );
+			echo json_encode( $result );
+			exit;
+		}, 1 );
+		`,
+	} );
+
 	return muPlugins;
 }
 

--- a/src/lib/wordpress-provider/playground-cli/playground-cli-provider.ts
+++ b/src/lib/wordpress-provider/playground-cli/playground-cli-provider.ts
@@ -116,9 +116,16 @@ export class PlaygroundCliProvider implements WordPressProvider {
 	}
 
 	async setupWordPressSite( server: SiteServer, wpVersion = 'latest' ): Promise< boolean > {
+		const setupStartTime = Date.now();
+		console.log( '[PERF] setupWordPressSite: Starting setup' );
+
 		const { path, port, adminPassword, name, phpVersion } = server.details;
 		const { blueprint } = server.meta;
+
+		const languageStart = Date.now();
 		const siteLanguage = await getPreferredSiteLanguage( wpVersion );
+		console.log( `[PERF] setupWordPressSite: getPreferredSiteLanguage took ${ Date.now() - languageStart }ms` );
+
 		const serverOptions = {
 			path,
 			port,
@@ -134,9 +141,12 @@ export class PlaygroundCliProvider implements WordPressProvider {
 		let serverProcess;
 
 		try {
+			const isOnlineCheckStart = Date.now();
 			const isOnline = net.isOnline();
+			console.log( `[PERF] setupWordPressSite: Online check took ${ Date.now() - isOnlineCheckStart }ms` );
 
 			if ( ! isOnline ) {
+				console.log( '[PERF] setupWordPressSite: Offline mode detected' );
 				if ( wpVersion !== 'latest' ) {
 					throw new Error(
 						`Cannot set up WordPress version '${ wpVersion }' while offline. ` +
@@ -160,7 +170,9 @@ export class PlaygroundCliProvider implements WordPressProvider {
 				}
 
 				try {
+					const copyStartTime = Date.now();
 					await recursiveCopyDirectory( bundledWPPath, path );
+					console.log( `[PERF] setupWordPressSite: Copy WordPress files took ${ Date.now() - copyStartTime }ms` );
 					serverOptions.wpVersion = this.DEFAULT_WORDPRESS_VERSION;
 					serverOptions.siteLanguage = DEFAULT_LOCALE;
 					serverOptions.isSetupMode = false;
@@ -173,25 +185,40 @@ export class PlaygroundCliProvider implements WordPressProvider {
 				}
 			}
 
+			const sqliteStartTime = Date.now();
 			await keepSqliteIntegrationUpdated( path );
+			console.log( `[PERF] setupWordPressSite: SQLite integration update took ${ Date.now() - sqliteStartTime }ms` );
 
+			const serverInstanceStart = Date.now();
 			const serverInstance = await this.startServer( serverOptions );
+			console.log( `[PERF] setupWordPressSite: startServer took ${ Date.now() - serverInstanceStart }ms` );
+
+			const processCreateStart = Date.now();
 			serverProcess = this.createServerProcess( serverInstance );
+			console.log( `[PERF] setupWordPressSite: createServerProcess took ${ Date.now() - processCreateStart }ms` );
+
+			const processStartTime = Date.now();
 			await serverProcess.start();
+			console.log( `[PERF] setupWordPressSite: serverProcess.start took ${ Date.now() - processStartTime }ms` );
 
 			if ( ! serverOptions.isSetupMode ) {
+				const installStartTime = Date.now();
 				await this.runWordPressInstallation( serverProcess, serverOptions );
+				console.log( `[PERF] setupWordPressSite: WordPress installation took ${ Date.now() - installStartTime }ms` );
 			}
 
 			// remove blueprint since we only want to run it once
 			server.meta.blueprint = undefined;
 
+			console.log( `[PERF] setupWordPressSite: Total setup time ${ Date.now() - setupStartTime }ms` );
 			return true;
 		} catch ( error ) {
 			console.error( 'Failed to setup WordPress site:', error );
 			throw error;
 		} finally {
+			const stopStart = Date.now();
 			await serverProcess?.stop();
+			console.log( `[PERF] setupWordPressSite: Stop server took ${ Date.now() - stopStart }ms` );
 		}
 	}
 

--- a/src/lib/wordpress-provider/playground-cli/playground-cli-provider.ts
+++ b/src/lib/wordpress-provider/playground-cli/playground-cli-provider.ts
@@ -1,7 +1,7 @@
 import { net } from 'electron';
 import nodePath from 'path';
 import { SupportedPHPVersions } from '@php-wasm/universal';
-import { Blueprint } from '@wp-playground/blueprints';
+import { Blueprint, StepDefinition } from '@wp-playground/blueprints';
 import { RecommendedPHPVersion } from '@wp-playground/common';
 import { recursiveCopyDirectory, pathExists, isWordPressDirectory } from 'common/lib/fs-utils';
 import { DEFAULT_LOCALE } from 'common/lib/locale';
@@ -123,7 +123,7 @@ export class PlaygroundCliProvider implements WordPressProvider {
 			const isOnline = net.isOnline();
 			const siteLanguage = await getPreferredSiteLanguage( wpVersion );
 
-			const setupSteps = [];
+			const setupSteps: StepDefinition[] = [];
 
 			if ( isOnline && siteLanguage && siteLanguage !== DEFAULT_LOCALE ) {
 				setupSteps.push(
@@ -206,7 +206,7 @@ export class PlaygroundCliProvider implements WordPressProvider {
 			if ( ! server.meta.blueprint ) {
 				server.meta.blueprint = {};
 			}
-			const existingSteps = ( server.meta.blueprint.steps as unknown[] ) || [];
+			const existingSteps = server.meta.blueprint.steps || [];
 			server.meta.blueprint.steps = [ ...setupSteps, ...existingSteps ];
 
 			await keepSqliteIntegrationUpdated( path );

--- a/src/lib/wordpress-provider/playground-cli/playground-cli-provider.ts
+++ b/src/lib/wordpress-provider/playground-cli/playground-cli-provider.ts
@@ -117,14 +117,17 @@ export class PlaygroundCliProvider implements WordPressProvider {
 
 	async setupWordPressSite( server: SiteServer, wpVersion = 'latest' ): Promise< boolean > {
 		const setupStartTime = Date.now();
-		console.log( '[PERF] setupWordPressSite: Starting setup' );
+		console.log( `[PERF] setupWordPressSite: Starting setup at ${new Date().toISOString()}` );
+		console.log( `[PERF] setupWordPressSite: Start timestamp: ${setupStartTime}` );
 
 		const { path, port, adminPassword, name, phpVersion } = server.details;
 		const { blueprint } = server.meta;
 
 		const languageStart = Date.now();
 		const siteLanguage = await getPreferredSiteLanguage( wpVersion );
-		console.log( `[PERF] setupWordPressSite: getPreferredSiteLanguage took ${ Date.now() - languageStart }ms` );
+		console.log(
+			`[PERF] setupWordPressSite: getPreferredSiteLanguage took ${ Date.now() - languageStart }ms`
+		);
 
 		const serverOptions = {
 			path,
@@ -143,7 +146,9 @@ export class PlaygroundCliProvider implements WordPressProvider {
 		try {
 			const isOnlineCheckStart = Date.now();
 			const isOnline = net.isOnline();
-			console.log( `[PERF] setupWordPressSite: Online check took ${ Date.now() - isOnlineCheckStart }ms` );
+			console.log(
+				`[PERF] setupWordPressSite: Online check took ${ Date.now() - isOnlineCheckStart }ms`
+			);
 
 			if ( ! isOnline ) {
 				console.log( '[PERF] setupWordPressSite: Offline mode detected' );
@@ -172,7 +177,9 @@ export class PlaygroundCliProvider implements WordPressProvider {
 				try {
 					const copyStartTime = Date.now();
 					await recursiveCopyDirectory( bundledWPPath, path );
-					console.log( `[PERF] setupWordPressSite: Copy WordPress files took ${ Date.now() - copyStartTime }ms` );
+					console.log(
+						`[PERF] setupWordPressSite: Copy WordPress files took ${ Date.now() - copyStartTime }ms`
+					);
 					serverOptions.wpVersion = this.DEFAULT_WORDPRESS_VERSION;
 					serverOptions.siteLanguage = DEFAULT_LOCALE;
 					serverOptions.isSetupMode = false;
@@ -187,30 +194,49 @@ export class PlaygroundCliProvider implements WordPressProvider {
 
 			const sqliteStartTime = Date.now();
 			await keepSqliteIntegrationUpdated( path );
-			console.log( `[PERF] setupWordPressSite: SQLite integration update took ${ Date.now() - sqliteStartTime }ms` );
+			console.log(
+				`[PERF] setupWordPressSite: SQLite integration update took ${
+					Date.now() - sqliteStartTime
+				}ms`
+			);
 
 			const serverInstanceStart = Date.now();
 			const serverInstance = await this.startServer( serverOptions );
-			console.log( `[PERF] setupWordPressSite: startServer took ${ Date.now() - serverInstanceStart }ms` );
+			console.log(
+				`[PERF] setupWordPressSite: startServer took ${ Date.now() - serverInstanceStart }ms`
+			);
 
 			const processCreateStart = Date.now();
 			serverProcess = this.createServerProcess( serverInstance );
-			console.log( `[PERF] setupWordPressSite: createServerProcess took ${ Date.now() - processCreateStart }ms` );
+			console.log(
+				`[PERF] setupWordPressSite: createServerProcess took ${ Date.now() - processCreateStart }ms`
+			);
 
 			const processStartTime = Date.now();
 			await serverProcess.start();
-			console.log( `[PERF] setupWordPressSite: serverProcess.start took ${ Date.now() - processStartTime }ms` );
+			console.log(
+				`[PERF] setupWordPressSite: serverProcess.start took ${ Date.now() - processStartTime }ms`
+			);
 
 			if ( ! serverOptions.isSetupMode ) {
 				const installStartTime = Date.now();
 				await this.runWordPressInstallation( serverProcess, serverOptions );
-				console.log( `[PERF] setupWordPressSite: WordPress installation took ${ Date.now() - installStartTime }ms` );
+				console.log(
+					`[PERF] setupWordPressSite: WordPress installation took ${
+						Date.now() - installStartTime
+					}ms`
+				);
 			}
 
 			// remove blueprint since we only want to run it once
 			server.meta.blueprint = undefined;
 
-			console.log( `[PERF] setupWordPressSite: Total setup time ${ Date.now() - setupStartTime }ms` );
+			const setupEndTime = Date.now();
+			console.log( `[PERF] setupWordPressSite: Finished at ${new Date().toISOString()}` );
+			console.log( `[PERF] setupWordPressSite: End timestamp: ${setupEndTime}` );
+			console.log(
+				`[PERF] setupWordPressSite: Total setup time ${ setupEndTime - setupStartTime }ms`
+			);
 			return true;
 		} catch ( error ) {
 			console.error( 'Failed to setup WordPress site:', error );

--- a/src/lib/wordpress-provider/playground-cli/playground-cli-provider.ts
+++ b/src/lib/wordpress-provider/playground-cli/playground-cli-provider.ts
@@ -150,7 +150,6 @@ export class PlaygroundCliProvider implements WordPressProvider {
 			}
 
 			if ( ! isOnline ) {
-				console.log( '[DEBUG] setupWordPressSite - Offline mode, copying WordPress files' );
 				if ( wpVersion !== 'latest' ) {
 					throw new Error(
 						`Cannot set up WordPress version '${ wpVersion }' while offline. ` +
@@ -175,7 +174,6 @@ export class PlaygroundCliProvider implements WordPressProvider {
 
 				try {
 					await recursiveCopyDirectory( bundledWPPath, path );
-					console.log( '[DEBUG] setupWordPressSite - WordPress files copied successfully' );
 				} catch ( error ) {
 					throw new Error(
 						`Failed to copy WordPress files for offline setup: ${ ( error as Error ).message }`

--- a/src/lib/wordpress-provider/playground-cli/playground-cli-provider.ts
+++ b/src/lib/wordpress-provider/playground-cli/playground-cli-provider.ts
@@ -3,7 +3,7 @@ import nodePath from 'path';
 import { SupportedPHPVersions } from '@php-wasm/universal';
 import { Blueprint } from '@wp-playground/blueprints';
 import { RecommendedPHPVersion } from '@wp-playground/common';
-import { recursiveCopyDirectory, pathExists } from 'common/lib/fs-utils';
+import { recursiveCopyDirectory, pathExists, isWordPressDirectory } from 'common/lib/fs-utils';
 import { DEFAULT_LOCALE } from 'common/lib/locale';
 import { getPreferredSiteLanguage } from 'src/lib/site-language';
 import { keepSqliteIntegrationUpdated } from 'src/lib/sqlite-versions';
@@ -24,7 +24,6 @@ export interface PlaygroundCliOptions {
 	documentRoot: string;
 	autoMount: boolean;
 	skipWordpressSetup: boolean;
-	isSetupMode?: boolean;
 	blueprint?: Blueprint;
 }
 
@@ -59,20 +58,19 @@ export class PlaygroundCliProvider implements WordPressProvider {
 		isWpAutoUpdating?: boolean;
 		absoluteUrl?: string;
 		siteLanguage?: string;
-		isSetupMode?: boolean;
 		wpCliPharPath?: string;
 		blueprint?: Blueprint;
 	} ): Promise< WordPressServerInstance > {
 		const port = options.port;
 		const phpVersion = options.phpVersion || '8.3';
+		const hasWordPress = isWordPressDirectory( options.path );
 
 		const playgroundOptions: PlaygroundCliOptions = {
 			port,
 			phpVersion,
 			documentRoot: options.path,
 			autoMount: true,
-			skipWordpressSetup: true,
-			isSetupMode: options.isSetupMode || false,
+			skipWordpressSetup: hasWordPress,
 			blueprint: options.blueprint,
 		};
 
@@ -87,7 +85,6 @@ export class PlaygroundCliProvider implements WordPressProvider {
 			siteLanguage: options.siteLanguage,
 			wordPressVersion: options.wpVersion,
 			isWpAutoUpdating: options.isWpAutoUpdating,
-			isSetupMode: options.isSetupMode,
 		};
 
 		return {
@@ -115,43 +112,45 @@ export class PlaygroundCliProvider implements WordPressProvider {
 		return '/wordpress/wp-load.php';
 	}
 
+	private escapePhpString( str: string ): string {
+		return str.replace( /\\/g, '\\\\' ).replace( /'/g, "\\'" );
+	}
+
 	async setupWordPressSite( server: SiteServer, wpVersion = 'latest' ): Promise< boolean > {
-		const setupStartTime = Date.now();
-		console.log( `[PERF] setupWordPressSite: Starting setup at ${new Date().toISOString()}` );
-		console.log( `[PERF] setupWordPressSite: Start timestamp: ${setupStartTime}` );
-
-		const { path, port, adminPassword, name, phpVersion } = server.details;
-		const { blueprint } = server.meta;
-
-		const languageStart = Date.now();
-		const siteLanguage = await getPreferredSiteLanguage( wpVersion );
-		console.log(
-			`[PERF] setupWordPressSite: getPreferredSiteLanguage took ${ Date.now() - languageStart }ms`
-		);
-
-		const serverOptions = {
-			path,
-			port,
-			adminPassword: adminPassword || 'password',
-			siteTitle: name,
-			phpVersion: phpVersion || this.DEFAULT_PHP_VERSION,
-			wpVersion,
-			isWpAutoUpdating: false,
-			isSetupMode: true,
-			blueprint: blueprint?.blueprint,
-			siteLanguage,
-		};
-		let serverProcess;
+		const { path, name, adminPassword } = server.details;
 
 		try {
-			const isOnlineCheckStart = Date.now();
 			const isOnline = net.isOnline();
-			console.log(
-				`[PERF] setupWordPressSite: Online check took ${ Date.now() - isOnlineCheckStart }ms`
-			);
+			const siteLanguage = await getPreferredSiteLanguage( wpVersion );
+
+			const setupSteps = [];
+
+			if ( isOnline && siteLanguage && siteLanguage !== DEFAULT_LOCALE ) {
+				setupSteps.push(
+					{
+						step: 'setSiteLanguage',
+						language: siteLanguage,
+					},
+					{
+						step: 'setSiteOptions',
+						options: {
+							WPLANG: siteLanguage,
+						},
+					}
+				);
+			}
+
+			if ( name ) {
+				setupSteps.push( {
+					step: 'setSiteOptions',
+					options: {
+						blogname: name,
+					},
+				} );
+			}
 
 			if ( ! isOnline ) {
-				console.log( '[PERF] setupWordPressSite: Offline mode detected' );
+				console.log( '[DEBUG] setupWordPressSite - Offline mode, copying WordPress files' );
 				if ( wpVersion !== 'latest' ) {
 					throw new Error(
 						`Cannot set up WordPress version '${ wpVersion }' while offline. ` +
@@ -175,76 +174,49 @@ export class PlaygroundCliProvider implements WordPressProvider {
 				}
 
 				try {
-					const copyStartTime = Date.now();
 					await recursiveCopyDirectory( bundledWPPath, path );
-					console.log(
-						`[PERF] setupWordPressSite: Copy WordPress files took ${ Date.now() - copyStartTime }ms`
-					);
-					serverOptions.wpVersion = this.DEFAULT_WORDPRESS_VERSION;
-					serverOptions.siteLanguage = DEFAULT_LOCALE;
-					serverOptions.isSetupMode = false;
-					serverOptions.isWpAutoUpdating = true;
-					serverOptions.blueprint = undefined;
+					console.log( '[DEBUG] setupWordPressSite - WordPress files copied successfully' );
 				} catch ( error ) {
 					throw new Error(
 						`Failed to copy WordPress files for offline setup: ${ ( error as Error ).message }`
 					);
 				}
+
+				setupSteps.push( {
+					step: 'runPHP',
+					code: `<?php
+					$_POST = array(
+						'language' => '${ this.escapePhpString( DEFAULT_LOCALE ) }',
+						'prefix' => 'wp_',
+						'weblog_title' => '${ this.escapePhpString( name ) }',
+						'user_name' => 'admin',
+						'admin_password' => '${ this.escapePhpString( adminPassword || '' ) }',
+						'admin_password2' => '${ this.escapePhpString( adminPassword || '' ) }',
+						'Submit' => 'Install WordPress',
+						'pw_weak' => '1',
+						'admin_email' => 'admin@localhost.com',
+					);
+					$_REQUEST = $_POST;
+					$_GET['step'] = 2;
+
+					// Include WordPress installation
+					require_once('/wordpress/wp-admin/install.php');
+				`,
+				} );
 			}
 
-			const sqliteStartTime = Date.now();
+			if ( ! server.meta.blueprint ) {
+				server.meta.blueprint = {};
+			}
+			const existingSteps = ( server.meta.blueprint.steps as unknown[] ) || [];
+			server.meta.blueprint.steps = [ ...setupSteps, ...existingSteps ];
+
 			await keepSqliteIntegrationUpdated( path );
-			console.log(
-				`[PERF] setupWordPressSite: SQLite integration update took ${
-					Date.now() - sqliteStartTime
-				}ms`
-			);
 
-			const serverInstanceStart = Date.now();
-			const serverInstance = await this.startServer( serverOptions );
-			console.log(
-				`[PERF] setupWordPressSite: startServer took ${ Date.now() - serverInstanceStart }ms`
-			);
-
-			const processCreateStart = Date.now();
-			serverProcess = this.createServerProcess( serverInstance );
-			console.log(
-				`[PERF] setupWordPressSite: createServerProcess took ${ Date.now() - processCreateStart }ms`
-			);
-
-			const processStartTime = Date.now();
-			await serverProcess.start();
-			console.log(
-				`[PERF] setupWordPressSite: serverProcess.start took ${ Date.now() - processStartTime }ms`
-			);
-
-			if ( ! serverOptions.isSetupMode ) {
-				const installStartTime = Date.now();
-				await this.runWordPressInstallation( serverProcess, serverOptions );
-				console.log(
-					`[PERF] setupWordPressSite: WordPress installation took ${
-						Date.now() - installStartTime
-					}ms`
-				);
-			}
-
-			// remove blueprint since we only want to run it once
-			server.meta.blueprint = undefined;
-
-			const setupEndTime = Date.now();
-			console.log( `[PERF] setupWordPressSite: Finished at ${new Date().toISOString()}` );
-			console.log( `[PERF] setupWordPressSite: End timestamp: ${setupEndTime}` );
-			console.log(
-				`[PERF] setupWordPressSite: Total setup time ${ setupEndTime - setupStartTime }ms`
-			);
 			return true;
 		} catch ( error ) {
 			console.error( 'Failed to setup WordPress site:', error );
 			throw error;
-		} finally {
-			const stopStart = Date.now();
-			await serverProcess?.stop();
-			console.log( `[PERF] setupWordPressSite: Stop server took ${ Date.now() - stopStart }ms` );
 		}
 	}
 
@@ -260,47 +232,5 @@ export class PlaygroundCliProvider implements WordPressProvider {
 		}
 
 		return { wpContentPath: undefined };
-	}
-
-	/**
-	 * Properly escape a string for safe use in PHP code
-	 */
-	private escapePhpString( str: string ): string {
-		return str.replace( /\\/g, '\\\\' ).replace( /'/g, "\\'" );
-	}
-
-	/**
-	 * Run WordPress installation steps directly to avoid web-based setup wizard
-	 */
-	private async runWordPressInstallation(
-		serverProcess: WordPressServerProcess,
-		options: {
-			path: string;
-			port: number;
-			adminPassword: string;
-			siteTitle: string;
-			siteLanguage: string;
-		}
-	): Promise< void > {
-		await serverProcess.runPhp( {
-			code: `<?php
-					$_POST = array(
-						'language' => '${ this.escapePhpString( options.siteLanguage ) }',
-						'prefix' => 'wp_',
-						'weblog_title' => '${ this.escapePhpString( options.siteTitle ) }',
-						'user_name' => 'admin',
-						'admin_password' => '${ this.escapePhpString( options.adminPassword ) }',
-						'admin_password2' => '${ this.escapePhpString( options.adminPassword ) }',
-						'Submit' => 'Install WordPress',
-						'pw_weak' => '1',
-						'admin_email' => 'admin@localhost.com',
-					);
-					$_REQUEST = $_POST;
-					$_GET['step'] = 2;
-
-					// Include WordPress installation
-					require_once('/wordpress/wp-admin/install.php');
-				`,
-		} );
 	}
 }

--- a/src/lib/wordpress-provider/playground-cli/playground-server-process-child.ts
+++ b/src/lib/wordpress-provider/playground-cli/playground-server-process-child.ts
@@ -48,63 +48,18 @@ const originalConsoleLog = console.log;
 const originalConsoleError = console.error;
 const originalConsoleWarn = console.warn;
 
-let lastLogTimestamp = performance.now();
-let runCliStartTimestamp = 0;
-
 console.log = ( ...args: any[] ) => {
-	const now = performance.now();
-	const timeSinceLastLog = runCliStartTimestamp > 0 ? now - lastLogTimestamp : 0;
-	const timeSinceRunCliStart = runCliStartTimestamp > 0 ? now - runCliStartTimestamp : 0;
-
-	if ( timeSinceLastLog > 0 ) {
-		originalConsoleLog(
-			'[playground-cli]',
-			`[+${ timeSinceLastLog.toFixed( 2 ) }ms | Total: ${ timeSinceRunCliStart.toFixed( 2 ) }ms]`,
-			...args
-		);
-	} else {
-		originalConsoleLog( '[playground-cli]', ...args );
-	}
-
-	lastLogTimestamp = now;
+	originalConsoleLog( '[playground-cli]', ...args );
 	process.parentPort.postMessage( { type: 'activity' } );
 };
 
 console.error = ( ...args: any[] ) => {
-	const now = performance.now();
-	const timeSinceLastLog = runCliStartTimestamp > 0 ? now - lastLogTimestamp : 0;
-	const timeSinceRunCliStart = runCliStartTimestamp > 0 ? now - runCliStartTimestamp : 0;
-
-	if ( timeSinceLastLog > 0 ) {
-		originalConsoleError(
-			'[playground-cli]',
-			`[+${ timeSinceLastLog.toFixed( 2 ) }ms | Total: ${ timeSinceRunCliStart.toFixed( 2 ) }ms]`,
-			...args
-		);
-	} else {
-		originalConsoleError( '[playground-cli]', ...args );
-	}
-
-	lastLogTimestamp = now;
+	originalConsoleError( '[playground-cli]', ...args );
 	process.parentPort.postMessage( { type: 'activity' } );
 };
 
 console.warn = ( ...args: any[] ) => {
-	const now = performance.now();
-	const timeSinceLastLog = runCliStartTimestamp > 0 ? now - lastLogTimestamp : 0;
-	const timeSinceRunCliStart = runCliStartTimestamp > 0 ? now - runCliStartTimestamp : 0;
-
-	if ( timeSinceLastLog > 0 ) {
-		originalConsoleWarn(
-			'[playground-cli]',
-			`[+${ timeSinceLastLog.toFixed( 2 ) }ms | Total: ${ timeSinceRunCliStart.toFixed( 2 ) }ms]`,
-			...args
-		);
-	} else {
-		originalConsoleWarn( '[playground-cli]', ...args );
-	}
-
-	lastLogTimestamp = now;
+	originalConsoleWarn( '[playground-cli]', ...args );
 	process.parentPort.postMessage( { type: 'activity' } );
 };
 
@@ -143,7 +98,7 @@ process.parentPort.on( 'message', async ( event ) => {
 				result = await httpRequest( message.data );
 				break;
 			default:
-				throw new Error( `Unknown message type: ${ message.type }` );
+				throw new Error( `Unknown message type: ${ message }` );
 		}
 
 		process.parentPort.postMessage( { id: message.id, result } );
@@ -222,8 +177,6 @@ async function startServer(
 
 		args.blueprint.constants = { ...args.blueprint.constants, ...defaultConstants };
 
-		runCliStartTimestamp = performance.now();
-		lastLogTimestamp = runCliStartTimestamp;
 		server = await runCLI( args );
 
 		if ( serverOptions.adminPassword ) {

--- a/src/lib/wordpress-provider/playground-cli/playground-server-process-child.ts
+++ b/src/lib/wordpress-provider/playground-cli/playground-server-process-child.ts
@@ -159,8 +159,6 @@ async function startServer(
 		}
 
 		args.blueprint.constants = { ...args.blueprint.constants, ...defaultConstants };
-
-		console.log( args );
 		server = await runCLI( args );
 
 		if ( serverOptions.adminPassword ) {

--- a/src/lib/wordpress-provider/playground-cli/playground-server-process-child.ts
+++ b/src/lib/wordpress-provider/playground-cli/playground-server-process-child.ts
@@ -1,6 +1,5 @@
 import { SupportedPHPVersion, PHPRunOptions } from '@php-wasm/universal';
 import { runCLI, RunCLIArgs, RunCLIServer } from '@wp-playground/cli';
-import { DEFAULT_LOCALE } from 'common/lib/locale';
 import { isWordPressDevVersion } from 'src/lib/wordpress-version-utils';
 import { WordPressServerOptions } from '../types';
 import { getMuPlugins } from './mu-plugins';
@@ -110,21 +109,12 @@ async function startServer(
 	options: PlaygroundCliOptions,
 	serverOptions: WordPressServerOptions
 ): Promise< void > {
-	const startServerTime = Date.now();
-	console.log( `[PERF] startServer (child): Starting server at ${new Date().toISOString()}` );
-	console.log( `[PERF] startServer (child): Start timestamp: ${startServerTime}` );
-
 	if ( server ) {
 		return;
 	}
 
 	try {
-		const muPluginsStart = Date.now();
 		const [ studioMuPluginsHostPath, loaderMuPluginHostPath ] = await getMuPlugins( serverOptions );
-		console.log(
-			`[PERF] startServer (child): getMuPlugins took ${ Date.now() - muPluginsStart }ms`
-		);
-		const setupSteps = [];
 		const defaultConstants = {
 			WP_SQLITE_AST_DRIVER: true,
 		};
@@ -144,7 +134,7 @@ async function startServer(
 		];
 
 		const args: RunCLIArgs = {
-			command: 'run-blueprint',
+			command: 'server',
 			internalCookieStore: true,
 			followSymlinks: true,
 			skipSqliteSetup: true,
@@ -153,12 +143,8 @@ async function startServer(
 			'mount-before-install': mounts,
 			'site-url': serverOptions.absoluteUrl,
 			blueprint: options.blueprint || {},
+			skipWordPressSetup: options.skipWordpressSetup,
 		};
-
-		if ( ! options.isSetupMode ) {
-			args.command = 'server';
-			args.skipWordPressSetup = true;
-		}
 
 		if ( options.phpVersion ) {
 			args.php = options.phpVersion as SupportedPHPVersion;
@@ -172,70 +158,14 @@ async function startServer(
 			}
 		}
 
-		if ( options.isSetupMode ) {
-			/* Workaround for https://github.com/WordPress/wordpress-playground/issues/2700
-			 * Let's revisit this code when the issue is fixed
-			 * If setSiteLanguage is set in blueprint we shouldn't need to change the language */
-			const blueprintLanguageStep = args.blueprint?.steps?.find(
-				( step: { step: string; language?: string } ) => step.step === 'setSiteLanguage'
-			);
-			const siteLanguage = blueprintLanguageStep?.language || serverOptions.siteLanguage;
-			if ( siteLanguage && siteLanguage !== DEFAULT_LOCALE ) {
-				setupSteps.push(
-					{
-						step: 'setSiteLanguage',
-						language: siteLanguage,
-					},
-					{
-						step: 'setSiteOptions',
-						options: {
-							WPLANG: escapePhpString( siteLanguage ),
-						},
-					}
-				);
-			}
-
-			if ( serverOptions.siteTitle ) {
-				setupSteps.push( {
-					step: 'setSiteOptions',
-					options: {
-						blogname: escapePhpString( serverOptions.siteTitle ),
-					},
-				} );
-			}
-		}
-
-		args.blueprint.steps = [ ...setupSteps, ...( args.blueprint.steps || [] ) ];
 		args.blueprint.constants = { ...args.blueprint.constants, ...defaultConstants };
 
-		console.log( '[PERF] startServer (child): Calling runCLI' );
-		console.log(
-			`[PERF] startServer (child): Blueprint has ${ args.blueprint.steps.length } steps`
-		);
-		const runCLIStart = Date.now();
+		console.log( args );
 		server = await runCLI( args );
-		console.log( `[PERF] startServer (child): runCLI took ${ Date.now() - runCLIStart }ms` );
 
 		if ( serverOptions.adminPassword ) {
-			try {
-				const setPasswordStart = Date.now();
-				await setAdminPassword( server, serverOptions.adminPassword );
-				console.log(
-					`[PERF] startServer (child): setAdminPassword took ${ Date.now() - setPasswordStart }ms`
-				);
-			} catch {
-				console.warn(
-					'Failed to set admin password, but the server started successfully. Please check your site error log in wp-content/debug.log for more details'
-				);
-			}
+			await setAdminPassword( server, serverOptions.adminPassword );
 		}
-
-		const endTime = Date.now();
-		console.log( `[PERF] startServer (child): Finished at ${new Date().toISOString()}` );
-		console.log( `[PERF] startServer (child): End timestamp: ${endTime}` );
-		console.log(
-			`[PERF] startServer (child): Total server start time ${ endTime - startServerTime }ms`
-		);
 	} catch ( error ) {
 		server = null;
 		throw new Error( `Could not start server: ${ error }` );

--- a/src/lib/wordpress-provider/playground-cli/playground-server-process-child.ts
+++ b/src/lib/wordpress-provider/playground-cli/playground-server-process-child.ts
@@ -110,12 +110,17 @@ async function startServer(
 	options: PlaygroundCliOptions,
 	serverOptions: WordPressServerOptions
 ): Promise< void > {
+	const startServerTime = Date.now();
+	console.log( '[PERF] startServer (child): Starting server' );
+
 	if ( server ) {
 		return;
 	}
 
 	try {
+		const muPluginsStart = Date.now();
 		const [ studioMuPluginsHostPath, loaderMuPluginHostPath ] = await getMuPlugins( serverOptions );
+		console.log( `[PERF] startServer (child): getMuPlugins took ${ Date.now() - muPluginsStart }ms` );
 		const setupSteps = [];
 		const defaultConstants = {
 			WP_SQLITE_AST_DRIVER: true,
@@ -179,22 +184,20 @@ async function startServer(
 						language: siteLanguage,
 					},
 					{
-						step: 'runPHP',
-						code: `<?php require_once( '/wordpress/wp-load.php' ); update_option( 'WPLANG', '${ escapePhpString(
-							siteLanguage
-						) }' ); echo "Language set to: ${ escapePhpString( siteLanguage ) }"; ?>`,
+						step: 'setSiteOptions',
+						options: {
+							WPLANG: escapePhpString( siteLanguage ),
+						},
 					}
 				);
 			}
 
 			if ( serverOptions.siteTitle ) {
 				setupSteps.push( {
-					step: 'runPHP',
-					code: `<?php
-						require_once( '/wordpress/wp-load.php' );
-						update_option( 'blogname', '${ escapePhpString( serverOptions.siteTitle ) }' );
-						echo "Site title set to: ${ escapePhpString( serverOptions.siteTitle ) }";
-					?>`,
+					step: 'setSiteOptions',
+					options: {
+						blogname: escapePhpString( serverOptions.siteTitle ),
+					},
 				} );
 			}
 		}
@@ -202,17 +205,31 @@ async function startServer(
 		args.blueprint.steps = [ ...setupSteps, ...( args.blueprint.steps || [] ) ];
 		args.blueprint.constants = { ...args.blueprint.constants, ...defaultConstants };
 
+		console.log( '[PERF] startServer (child): Calling runCLI' );
+		console.log(
+			`[PERF] startServer (child): Blueprint has ${ args.blueprint.steps.length } steps`
+		);
+		const runCLIStart = Date.now();
 		server = await runCLI( args );
+		console.log( `[PERF] startServer (child): runCLI took ${ Date.now() - runCLIStart }ms` );
 
 		if ( serverOptions.adminPassword ) {
 			try {
+				const setPasswordStart = Date.now();
 				await setAdminPassword( server, serverOptions.adminPassword );
+				console.log(
+					`[PERF] startServer (child): setAdminPassword took ${ Date.now() - setPasswordStart }ms`
+				);
 			} catch {
 				console.warn(
 					'Failed to set admin password, but the server started successfully. Please check your site error log in wp-content/debug.log for more details'
 				);
 			}
 		}
+
+		console.log(
+			`[PERF] startServer (child): Total server start time ${ Date.now() - startServerTime }ms`
+		);
 	} catch ( error ) {
 		server = null;
 		throw new Error( `Could not start server: ${ error }` );

--- a/src/lib/wordpress-provider/playground-cli/playground-server-process-child.ts
+++ b/src/lib/wordpress-provider/playground-cli/playground-server-process-child.ts
@@ -20,18 +20,63 @@ const originalConsoleLog = console.log;
 const originalConsoleError = console.error;
 const originalConsoleWarn = console.warn;
 
+let lastLogTimestamp = performance.now();
+let runCliStartTimestamp = 0;
+
 console.log = ( ...args: any[] ) => {
-	originalConsoleLog( '[playground-cli]', ...args );
+	const now = performance.now();
+	const timeSinceLastLog = runCliStartTimestamp > 0 ? now - lastLogTimestamp : 0;
+	const timeSinceRunCliStart = runCliStartTimestamp > 0 ? now - runCliStartTimestamp : 0;
+
+	if ( timeSinceLastLog > 0 ) {
+		originalConsoleLog(
+			'[playground-cli]',
+			`[+${ timeSinceLastLog.toFixed( 2 ) }ms | Total: ${ timeSinceRunCliStart.toFixed( 2 ) }ms]`,
+			...args
+		);
+	} else {
+		originalConsoleLog( '[playground-cli]', ...args );
+	}
+
+	lastLogTimestamp = now;
 	process.parentPort.postMessage( { type: 'activity' } );
 };
 
 console.error = ( ...args: any[] ) => {
-	originalConsoleError( '[playground-cli]', ...args );
+	const now = performance.now();
+	const timeSinceLastLog = runCliStartTimestamp > 0 ? now - lastLogTimestamp : 0;
+	const timeSinceRunCliStart = runCliStartTimestamp > 0 ? now - runCliStartTimestamp : 0;
+
+	if ( timeSinceLastLog > 0 ) {
+		originalConsoleError(
+			'[playground-cli]',
+			`[+${ timeSinceLastLog.toFixed( 2 ) }ms | Total: ${ timeSinceRunCliStart.toFixed( 2 ) }ms]`,
+			...args
+		);
+	} else {
+		originalConsoleError( '[playground-cli]', ...args );
+	}
+
+	lastLogTimestamp = now;
 	process.parentPort.postMessage( { type: 'activity' } );
 };
 
 console.warn = ( ...args: any[] ) => {
-	originalConsoleWarn( '[playground-cli]', ...args );
+	const now = performance.now();
+	const timeSinceLastLog = runCliStartTimestamp > 0 ? now - lastLogTimestamp : 0;
+	const timeSinceRunCliStart = runCliStartTimestamp > 0 ? now - runCliStartTimestamp : 0;
+
+	if ( timeSinceLastLog > 0 ) {
+		originalConsoleWarn(
+			'[playground-cli]',
+			`[+${ timeSinceLastLog.toFixed( 2 ) }ms | Total: ${ timeSinceRunCliStart.toFixed( 2 ) }ms]`,
+			...args
+		);
+	} else {
+		originalConsoleWarn( '[playground-cli]', ...args );
+	}
+
+	lastLogTimestamp = now;
 	process.parentPort.postMessage( { type: 'activity' } );
 };
 
@@ -66,6 +111,9 @@ process.parentPort.on( 'message', async ( event ) => {
 			case 'run-php':
 				result = await runPhp( message.data );
 				break;
+			case 'http-request':
+				result = await httpRequest( message.data );
+				break;
 			default:
 				throw new Error( `Unknown message type: ${ message.type }` );
 		}
@@ -83,26 +131,22 @@ function escapePhpString( str: string ): string {
 }
 
 async function setAdminPassword( server: RunCLIServer, adminPassword: string ): Promise< void > {
-	const phpCode = `<?php
-		require_once( '/wordpress/wp-load.php' );
-		$user = get_user_by( 'login', 'admin' );
-		if ( $user ) {
-			wp_set_password( '${ escapePhpString( adminPassword ) }', $user->ID );
-		} else {
-			$user_data = array(
-				'user_login' => 'admin',
-				'user_pass' => '${ escapePhpString( adminPassword ) }',
-				'user_email' => 'admin@localhost.com',
-				'role' => 'administrator',
-			);
-			wp_insert_user( $user_data );
-		}
-		echo "Admin password updated";
-	?>`;
+	const perfStart = performance.now();
+	console.log( '[PERF] setAdminPassword: Using persistent API endpoint' );
 
-	await server.playground.run( {
-		code: phpCode,
+	// Use the persistent mu-plugin API endpoint to avoid loading WordPress again
+	await server.playground.request( {
+		url: '/?studio-admin-api',
+		method: 'POST',
+		body: {
+			action: 'set_admin_password',
+			password: adminPassword,
+		},
 	} );
+
+	console.log(
+		`[PERF] setAdminPassword: Total time ${ ( performance.now() - perfStart ).toFixed( 2 ) }ms`
+	);
 }
 
 async function startServer(
@@ -113,8 +157,18 @@ async function startServer(
 		return;
 	}
 
+	const perfStart = performance.now();
+	console.log( '[PERF] playground-server-process-child.startServer: Starting server' );
+
 	try {
+		const muPluginsStart = performance.now();
 		const [ studioMuPluginsHostPath, loaderMuPluginHostPath ] = await getMuPlugins( serverOptions );
+		console.log(
+			`[PERF] playground-server-process-child.startServer: MU-plugins generation took ${ (
+				performance.now() - muPluginsStart
+			).toFixed( 2 ) }ms`
+		);
+
 		const defaultConstants = {
 			WP_SQLITE_AST_DRIVER: true,
 		};
@@ -159,11 +213,32 @@ async function startServer(
 		}
 
 		args.blueprint.constants = { ...args.blueprint.constants, ...defaultConstants };
+
+		const runCliStart = performance.now();
+		runCliStartTimestamp = runCliStart;
+		lastLogTimestamp = runCliStart;
 		server = await runCLI( args );
+		console.log(
+			`[PERF] playground-server-process-child.startServer: runCLI took ${ (
+				performance.now() - runCliStart
+			).toFixed( 2 ) }ms`
+		);
 
 		if ( serverOptions.adminPassword ) {
+			const passwordStart = performance.now();
 			await setAdminPassword( server, serverOptions.adminPassword );
+			console.log(
+				`[PERF] playground-server-process-child.startServer: Set admin password took ${ (
+					performance.now() - passwordStart
+				).toFixed( 2 ) }ms`
+			);
 		}
+
+		console.log(
+			`[PERF] playground-server-process-child.startServer: Total time ${ (
+				performance.now() - perfStart
+			).toFixed( 2 ) }ms`
+		);
 	} catch ( error ) {
 		server = null;
 		throw new Error( `Could not start server: ${ error }` );
@@ -193,6 +268,37 @@ async function stopServerFunc(): Promise< void > {
 		}
 	} finally {
 		server = null;
+	}
+}
+
+async function httpRequest( options: {
+	url: string;
+	method: string;
+	body: Record< string, string >;
+} ): Promise< { text: string } > {
+	if ( ! server ) {
+		throw new Error( 'Server is not initialized. Make sure the server is started.' );
+	}
+
+	try {
+		const perfStart = performance.now();
+		console.log( `[PERF] httpRequest: Making request to ${ options.url }` );
+
+		const response = await server.playground.request( {
+			url: options.url,
+			method: options.method as 'GET' | 'POST',
+			body: options.body,
+		} );
+
+		console.log(
+			`[PERF] httpRequest: Request completed in ${ ( performance.now() - perfStart ).toFixed(
+				2
+			) }ms`
+		);
+
+		return { text: response.text };
+	} catch ( error ) {
+		throw new Error( `Failed to make HTTP request: ${ error }` );
 	}
 }
 

--- a/src/lib/wordpress-provider/playground-cli/playground-server-process-child.ts
+++ b/src/lib/wordpress-provider/playground-cli/playground-server-process-child.ts
@@ -111,7 +111,8 @@ async function startServer(
 	serverOptions: WordPressServerOptions
 ): Promise< void > {
 	const startServerTime = Date.now();
-	console.log( '[PERF] startServer (child): Starting server' );
+	console.log( `[PERF] startServer (child): Starting server at ${new Date().toISOString()}` );
+	console.log( `[PERF] startServer (child): Start timestamp: ${startServerTime}` );
 
 	if ( server ) {
 		return;
@@ -120,7 +121,9 @@ async function startServer(
 	try {
 		const muPluginsStart = Date.now();
 		const [ studioMuPluginsHostPath, loaderMuPluginHostPath ] = await getMuPlugins( serverOptions );
-		console.log( `[PERF] startServer (child): getMuPlugins took ${ Date.now() - muPluginsStart }ms` );
+		console.log(
+			`[PERF] startServer (child): getMuPlugins took ${ Date.now() - muPluginsStart }ms`
+		);
 		const setupSteps = [];
 		const defaultConstants = {
 			WP_SQLITE_AST_DRIVER: true,
@@ -227,8 +230,11 @@ async function startServer(
 			}
 		}
 
+		const endTime = Date.now();
+		console.log( `[PERF] startServer (child): Finished at ${new Date().toISOString()}` );
+		console.log( `[PERF] startServer (child): End timestamp: ${endTime}` );
 		console.log(
-			`[PERF] startServer (child): Total server start time ${ Date.now() - startServerTime }ms`
+			`[PERF] startServer (child): Total server start time ${ endTime - startServerTime }ms`
 		);
 	} catch ( error ) {
 		server = null;

--- a/src/lib/wordpress-provider/playground-cli/playground-server-process-child.ts
+++ b/src/lib/wordpress-provider/playground-cli/playground-server-process-child.ts
@@ -5,15 +5,43 @@ import { WordPressServerOptions } from '../types';
 import { getMuPlugins } from './mu-plugins';
 import { PlaygroundCliOptions } from './playground-cli-provider';
 
-interface Message {
+interface BaseMessage {
 	id: number;
 	type: string;
+}
+
+interface StartServerMessage extends BaseMessage {
+	type: 'start-server';
 	data: {
 		options: PlaygroundCliOptions;
 		serverOptions: WordPressServerOptions;
-		code: string;
 	};
 }
+
+interface StopServerMessage extends BaseMessage {
+	type: 'stop-server';
+	data: Record< string, never >;
+}
+
+interface RunPhpMessage extends BaseMessage {
+	type: 'run-php';
+	data: {
+		code: string;
+		scriptPath?: string;
+		phpVersion?: string;
+	};
+}
+
+interface HttpRequestMessage extends BaseMessage {
+	type: 'http-request';
+	data: {
+		url: string;
+		method: string;
+		body: Record< string, string >;
+	};
+}
+
+type Message = StartServerMessage | StopServerMessage | RunPhpMessage | HttpRequestMessage;
 
 // Intercept and prefix all console output from playground-cli
 const originalConsoleLog = console.log;
@@ -126,14 +154,7 @@ process.parentPort.on( 'message', async ( event ) => {
 
 process.parentPort.postMessage( { type: 'ready' } );
 
-function escapePhpString( str: string ): string {
-	return str.replace( /\\/g, '\\\\' ).replace( /'/g, "\\'" );
-}
-
 async function setAdminPassword( server: RunCLIServer, adminPassword: string ): Promise< void > {
-	const perfStart = performance.now();
-	console.log( '[PERF] setAdminPassword: Using persistent API endpoint' );
-
 	// Use the persistent mu-plugin API endpoint to avoid loading WordPress again
 	await server.playground.request( {
 		url: '/?studio-admin-api',
@@ -143,10 +164,6 @@ async function setAdminPassword( server: RunCLIServer, adminPassword: string ): 
 			password: adminPassword,
 		},
 	} );
-
-	console.log(
-		`[PERF] setAdminPassword: Total time ${ ( performance.now() - perfStart ).toFixed( 2 ) }ms`
-	);
 }
 
 async function startServer(
@@ -157,17 +174,8 @@ async function startServer(
 		return;
 	}
 
-	const perfStart = performance.now();
-	console.log( '[PERF] playground-server-process-child.startServer: Starting server' );
-
 	try {
-		const muPluginsStart = performance.now();
 		const [ studioMuPluginsHostPath, loaderMuPluginHostPath ] = await getMuPlugins( serverOptions );
-		console.log(
-			`[PERF] playground-server-process-child.startServer: MU-plugins generation took ${ (
-				performance.now() - muPluginsStart
-			).toFixed( 2 ) }ms`
-		);
 
 		const defaultConstants = {
 			WP_SQLITE_AST_DRIVER: true,
@@ -214,31 +222,13 @@ async function startServer(
 
 		args.blueprint.constants = { ...args.blueprint.constants, ...defaultConstants };
 
-		const runCliStart = performance.now();
-		runCliStartTimestamp = runCliStart;
-		lastLogTimestamp = runCliStart;
+		runCliStartTimestamp = performance.now();
+		lastLogTimestamp = runCliStartTimestamp;
 		server = await runCLI( args );
-		console.log(
-			`[PERF] playground-server-process-child.startServer: runCLI took ${ (
-				performance.now() - runCliStart
-			).toFixed( 2 ) }ms`
-		);
 
 		if ( serverOptions.adminPassword ) {
-			const passwordStart = performance.now();
 			await setAdminPassword( server, serverOptions.adminPassword );
-			console.log(
-				`[PERF] playground-server-process-child.startServer: Set admin password took ${ (
-					performance.now() - passwordStart
-				).toFixed( 2 ) }ms`
-			);
 		}
-
-		console.log(
-			`[PERF] playground-server-process-child.startServer: Total time ${ (
-				performance.now() - perfStart
-			).toFixed( 2 ) }ms`
-		);
 	} catch ( error ) {
 		server = null;
 		throw new Error( `Could not start server: ${ error }` );
@@ -281,20 +271,11 @@ async function httpRequest( options: {
 	}
 
 	try {
-		const perfStart = performance.now();
-		console.log( `[PERF] httpRequest: Making request to ${ options.url }` );
-
 		const response = await server.playground.request( {
 			url: options.url,
 			method: options.method as 'GET' | 'POST',
 			body: options.body,
 		} );
-
-		console.log(
-			`[PERF] httpRequest: Request completed in ${ ( performance.now() - perfStart ).toFixed(
-				2
-			) }ms`
-		);
 
 		return { text: response.text };
 	} catch ( error ) {

--- a/src/lib/wordpress-provider/playground-cli/playground-server-process-child.ts
+++ b/src/lib/wordpress-provider/playground-cli/playground-server-process-child.ts
@@ -175,8 +175,15 @@ async function stopServerFunc(): Promise< void > {
 		return;
 	}
 
+	const serverToDispose = server;
+	server = null;
+
 	try {
-		await server[ Symbol.asyncDispose ]();
+		const disposalTimeout = new Promise( ( _, reject ) =>
+			setTimeout( () => reject( new Error( 'Disposal timeout' ) ), 5000 )
+		);
+
+		await Promise.race( [ serverToDispose[ Symbol.asyncDispose ](), disposalTimeout ] );
 	} catch ( error ) {
 		// Suppress expected disposal errors that occur during site deletion
 		// These are typically race conditions that don't affect functionality

--- a/src/lib/wordpress-provider/playground-cli/playground-server-process.ts
+++ b/src/lib/wordpress-provider/playground-cli/playground-server-process.ts
@@ -44,7 +44,9 @@ export class PlaygroundServerProcess implements WordPressServerProcess {
 
 		const forkStartTime = Date.now();
 		this.process = utilityProcess.fork( path.join( __dirname, 'playgroundServerProcess.js' ) );
-		console.log( `[PERF] PlaygroundServerProcess.start: Fork process took ${ Date.now() - forkStartTime }ms` );
+		console.log(
+			`[PERF] PlaygroundServerProcess.start: Fork process took ${ Date.now() - forkStartTime }ms`
+		);
 
 		const setupListenersStart = Date.now();
 		this.process.on(
@@ -91,7 +93,11 @@ export class PlaygroundServerProcess implements WordPressServerProcess {
 				this.exitResolve = null;
 			}
 		} );
-		console.log( `[PERF] PlaygroundServerProcess.start: Setup listeners took ${ Date.now() - setupListenersStart }ms` );
+		console.log(
+			`[PERF] PlaygroundServerProcess.start: Setup listeners took ${
+				Date.now() - setupListenersStart
+			}ms`
+		);
 
 		// Wait for child process to be ready
 		const readyWaitStart = Date.now();
@@ -104,15 +110,23 @@ export class PlaygroundServerProcess implements WordPressServerProcess {
 			};
 			this.process!.on( 'message', readyHandler );
 		} );
-		console.log( `[PERF] PlaygroundServerProcess.start: Wait for ready took ${ Date.now() - readyWaitStart }ms` );
+		console.log(
+			`[PERF] PlaygroundServerProcess.start: Wait for ready took ${ Date.now() - readyWaitStart }ms`
+		);
 
 		const sendMessageStart = Date.now();
 		await this.sendMessage( 'start-server', {
 			options: this.options,
 			serverOptions: this.serverOptions,
 		} );
-		console.log( `[PERF] PlaygroundServerProcess.start: Send start-server message took ${ Date.now() - sendMessageStart }ms` );
-		console.log( `[PERF] PlaygroundServerProcess.start: Total start time ${ Date.now() - startTime }ms` );
+		console.log(
+			`[PERF] PlaygroundServerProcess.start: Send start-server message took ${
+				Date.now() - sendMessageStart
+			}ms`
+		);
+		console.log(
+			`[PERF] PlaygroundServerProcess.start: Total start time ${ Date.now() - startTime }ms`
+		);
 	}
 
 	async stop(): Promise< void > {

--- a/src/lib/wordpress-provider/playground-cli/playground-server-process.ts
+++ b/src/lib/wordpress-provider/playground-cli/playground-server-process.ts
@@ -31,21 +31,12 @@ export class PlaygroundServerProcess implements WordPressServerProcess {
 			return;
 		}
 
-		const perfStart = performance.now();
-		console.log( '[PERF] PlaygroundServerProcess.start: Starting process' );
-
 		// Create exit promise before starting the process
 		this.exitPromise = new Promise( ( resolve ) => {
 			this.exitResolve = resolve;
 		} );
 
-		const forkStart = performance.now();
 		this.process = utilityProcess.fork( path.join( __dirname, 'playgroundServerProcess.js' ) );
-		console.log(
-			`[PERF] PlaygroundServerProcess.start: Process fork took ${ (
-				performance.now() - forkStart
-			).toFixed( 2 ) }ms`
-		);
 
 		this.process.on(
 			'message',
@@ -93,7 +84,6 @@ export class PlaygroundServerProcess implements WordPressServerProcess {
 		} );
 
 		// Wait for child process to be ready
-		const readyStart = performance.now();
 		await new Promise< void >( ( resolve ) => {
 			const readyHandler = ( message: { type?: string } ) => {
 				if ( message.type === 'ready' ) {
@@ -103,27 +93,11 @@ export class PlaygroundServerProcess implements WordPressServerProcess {
 			};
 			this.process!.on( 'message', readyHandler );
 		} );
-		console.log(
-			`[PERF] PlaygroundServerProcess.start: Wait for ready took ${ (
-				performance.now() - readyStart
-			).toFixed( 2 ) }ms`
-		);
 
-		const startServerStart = performance.now();
 		await this.sendMessage( 'start-server', {
 			options: this.options,
 			serverOptions: this.serverOptions,
 		} );
-		console.log(
-			`[PERF] PlaygroundServerProcess.start: Start server message took ${ (
-				performance.now() - startServerStart
-			).toFixed( 2 ) }ms`
-		);
-		console.log(
-			`[PERF] PlaygroundServerProcess.start: Total time ${ (
-				performance.now() - perfStart
-			).toFixed( 2 ) }ms`
-		);
 	}
 
 	async stop(): Promise< void > {

--- a/src/lib/wordpress-provider/playground-cli/playground-server-process.ts
+++ b/src/lib/wordpress-provider/playground-cli/playground-server-process.ts
@@ -31,12 +31,22 @@ export class PlaygroundServerProcess implements WordPressServerProcess {
 			return;
 		}
 
+		const perfStart = performance.now();
+		console.log( '[PERF] PlaygroundServerProcess.start: Starting process' );
+
 		// Create exit promise before starting the process
 		this.exitPromise = new Promise( ( resolve ) => {
 			this.exitResolve = resolve;
 		} );
 
+		const forkStart = performance.now();
 		this.process = utilityProcess.fork( path.join( __dirname, 'playgroundServerProcess.js' ) );
+		console.log(
+			`[PERF] PlaygroundServerProcess.start: Process fork took ${ (
+				performance.now() - forkStart
+			).toFixed( 2 ) }ms`
+		);
+
 		this.process.on(
 			'message',
 			( message: { type?: string; id?: number; error?: string; result?: unknown } ) => {
@@ -83,6 +93,7 @@ export class PlaygroundServerProcess implements WordPressServerProcess {
 		} );
 
 		// Wait for child process to be ready
+		const readyStart = performance.now();
 		await new Promise< void >( ( resolve ) => {
 			const readyHandler = ( message: { type?: string } ) => {
 				if ( message.type === 'ready' ) {
@@ -92,11 +103,27 @@ export class PlaygroundServerProcess implements WordPressServerProcess {
 			};
 			this.process!.on( 'message', readyHandler );
 		} );
+		console.log(
+			`[PERF] PlaygroundServerProcess.start: Wait for ready took ${ (
+				performance.now() - readyStart
+			).toFixed( 2 ) }ms`
+		);
 
+		const startServerStart = performance.now();
 		await this.sendMessage( 'start-server', {
 			options: this.options,
 			serverOptions: this.serverOptions,
 		} );
+		console.log(
+			`[PERF] PlaygroundServerProcess.start: Start server message took ${ (
+				performance.now() - startServerStart
+			).toFixed( 2 ) }ms`
+		);
+		console.log(
+			`[PERF] PlaygroundServerProcess.start: Total time ${ (
+				performance.now() - perfStart
+			).toFixed( 2 ) }ms`
+		);
 	}
 
 	async stop(): Promise< void > {
@@ -185,6 +212,14 @@ export class PlaygroundServerProcess implements WordPressServerProcess {
 			documentRoot: this.options.documentRoot,
 			run: ( options: { code: string; scriptPath?: string } ) =>
 				this.runPhp( { ...options, phpVersion: this.options.phpVersion } ),
+			request: async ( options: {
+				url: string;
+				method: string;
+				body: Record< string, string >;
+			} ) => {
+				const result = await this.sendMessage( 'http-request', options );
+				return result as { text: string };
+			},
 		};
 	}
 }

--- a/src/lib/wordpress-provider/playground-cli/playground-server-process.ts
+++ b/src/lib/wordpress-provider/playground-cli/playground-server-process.ts
@@ -29,7 +29,11 @@ export class PlaygroundServerProcess implements WordPressServerProcess {
 	}
 
 	async start(): Promise< void > {
+		const startTime = Date.now();
+		console.log( '[PERF] PlaygroundServerProcess.start: Starting process' );
+
 		if ( this.process ) {
+			console.log( '[PERF] PlaygroundServerProcess.start: Process already running, skipping' );
 			return;
 		}
 
@@ -38,8 +42,11 @@ export class PlaygroundServerProcess implements WordPressServerProcess {
 			this.exitResolve = resolve;
 		} );
 
+		const forkStartTime = Date.now();
 		this.process = utilityProcess.fork( path.join( __dirname, 'playgroundServerProcess.js' ) );
+		console.log( `[PERF] PlaygroundServerProcess.start: Fork process took ${ Date.now() - forkStartTime }ms` );
 
+		const setupListenersStart = Date.now();
 		this.process.on(
 			'message',
 			( message: { type?: string; id?: number; error?: string; result?: unknown } ) => {
@@ -84,8 +91,10 @@ export class PlaygroundServerProcess implements WordPressServerProcess {
 				this.exitResolve = null;
 			}
 		} );
+		console.log( `[PERF] PlaygroundServerProcess.start: Setup listeners took ${ Date.now() - setupListenersStart }ms` );
 
 		// Wait for child process to be ready
+		const readyWaitStart = Date.now();
 		await new Promise< void >( ( resolve ) => {
 			const readyHandler = ( message: { type?: string } ) => {
 				if ( message.type === 'ready' ) {
@@ -95,11 +104,15 @@ export class PlaygroundServerProcess implements WordPressServerProcess {
 			};
 			this.process!.on( 'message', readyHandler );
 		} );
+		console.log( `[PERF] PlaygroundServerProcess.start: Wait for ready took ${ Date.now() - readyWaitStart }ms` );
 
+		const sendMessageStart = Date.now();
 		await this.sendMessage( 'start-server', {
 			options: this.options,
 			serverOptions: this.serverOptions,
 		} );
+		console.log( `[PERF] PlaygroundServerProcess.start: Send start-server message took ${ Date.now() - sendMessageStart }ms` );
+		console.log( `[PERF] PlaygroundServerProcess.start: Total start time ${ Date.now() - startTime }ms` );
 	}
 
 	async stop(): Promise< void > {

--- a/src/lib/wordpress-provider/playground-cli/playground-server-process.ts
+++ b/src/lib/wordpress-provider/playground-cli/playground-server-process.ts
@@ -24,16 +24,10 @@ export class PlaygroundServerProcess implements WordPressServerProcess {
 		public url: string,
 		private options: PlaygroundCliOptions,
 		private serverOptions: WordPressServerOptions
-	) {
-		this.isSetupMode = options.isSetupMode || false;
-	}
+	) {}
 
 	async start(): Promise< void > {
-		const startTime = Date.now();
-		console.log( '[PERF] PlaygroundServerProcess.start: Starting process' );
-
 		if ( this.process ) {
-			console.log( '[PERF] PlaygroundServerProcess.start: Process already running, skipping' );
 			return;
 		}
 
@@ -42,13 +36,7 @@ export class PlaygroundServerProcess implements WordPressServerProcess {
 			this.exitResolve = resolve;
 		} );
 
-		const forkStartTime = Date.now();
 		this.process = utilityProcess.fork( path.join( __dirname, 'playgroundServerProcess.js' ) );
-		console.log(
-			`[PERF] PlaygroundServerProcess.start: Fork process took ${ Date.now() - forkStartTime }ms`
-		);
-
-		const setupListenersStart = Date.now();
 		this.process.on(
 			'message',
 			( message: { type?: string; id?: number; error?: string; result?: unknown } ) => {
@@ -93,14 +81,8 @@ export class PlaygroundServerProcess implements WordPressServerProcess {
 				this.exitResolve = null;
 			}
 		} );
-		console.log(
-			`[PERF] PlaygroundServerProcess.start: Setup listeners took ${
-				Date.now() - setupListenersStart
-			}ms`
-		);
 
 		// Wait for child process to be ready
-		const readyWaitStart = Date.now();
 		await new Promise< void >( ( resolve ) => {
 			const readyHandler = ( message: { type?: string } ) => {
 				if ( message.type === 'ready' ) {
@@ -110,23 +92,11 @@ export class PlaygroundServerProcess implements WordPressServerProcess {
 			};
 			this.process!.on( 'message', readyHandler );
 		} );
-		console.log(
-			`[PERF] PlaygroundServerProcess.start: Wait for ready took ${ Date.now() - readyWaitStart }ms`
-		);
 
-		const sendMessageStart = Date.now();
 		await this.sendMessage( 'start-server', {
 			options: this.options,
 			serverOptions: this.serverOptions,
 		} );
-		console.log(
-			`[PERF] PlaygroundServerProcess.start: Send start-server message took ${
-				Date.now() - sendMessageStart
-			}ms`
-		);
-		console.log(
-			`[PERF] PlaygroundServerProcess.start: Total start time ${ Date.now() - startTime }ms`
-		);
 	}
 
 	async stop(): Promise< void > {

--- a/src/lib/wordpress-provider/types.ts
+++ b/src/lib/wordpress-provider/types.ts
@@ -40,7 +40,14 @@ export interface WordPressServerInstance {
 
 export interface WordPressServerProcess {
 	url: string;
-	php?: { documentRoot: string };
+	php?: {
+		documentRoot: string;
+		request?: ( options: {
+			url: string;
+			method: string;
+			body: Record< string, string >;
+		} ) => Promise< { text: string } >;
+	};
 	start(): Promise< void >;
 	stop(): Promise< void >;
 	runPhp( data: { code: string; [ key: string ]: unknown } ): Promise< string >;

--- a/src/site-server.ts
+++ b/src/site-server.ts
@@ -109,12 +109,17 @@ export class SiteServer {
 	}
 
 	async start() {
+		const siteStartTime = Date.now();
+		console.log( `[PERF] SiteServer.start: Starting site '${ this.details.name }'` );
+
 		if ( this.details.running || this.server ) {
+			console.log( '[PERF] SiteServer.start: Site already running, skipping' );
 			return;
 		}
 
 		// Handle custom domain if necessary
 		if ( this.details.customDomain ) {
+			const domainSetupStart = Date.now();
 			await addDomainToHosts( this.details.customDomain, this.details.port );
 			// Generate certificates for HTTPS sites *before* the server starts
 			// This ensures the certs are ready when the proxy server needs them
@@ -123,7 +128,9 @@ export class SiteServer {
 					`Generating certificates for ${ this.details.customDomain } during server start`
 				);
 
+				const certStart = Date.now();
 				const { cert, key } = await generateSiteCertificate( this.details.customDomain );
+				console.log( `[PERF] SiteServer.start: Certificate generation took ${ Date.now() - certStart }ms` );
 				this.details = {
 					...this.details,
 					tlsKey: key,
@@ -131,10 +138,14 @@ export class SiteServer {
 				};
 			}
 			await startProxyServer();
+			console.log( `[PERF] SiteServer.start: Domain setup took ${ Date.now() - domainSetupStart }ms` );
 		}
 
+		const blueprintFilterStart = Date.now();
 		const filteredBlueprint = filterUnsupportedBlueprintFeatures( this.meta.blueprint?.blueprint );
+		console.log( `[PERF] SiteServer.start: Blueprint filtering took ${ Date.now() - blueprintFilterStart }ms` );
 
+		const startServerCallTime = Date.now();
 		const serverInstance = await startServer( {
 			path: this.details.path,
 			port: this.details.port,
@@ -146,23 +157,33 @@ export class SiteServer {
 			absoluteUrl: getAbsoluteUrl( this.details ),
 			blueprint: filteredBlueprint,
 		} );
+		console.log( `[PERF] SiteServer.start: startServer call took ${ Date.now() - startServerCallTime }ms` );
 
+		const portCheckStart = Date.now();
 		const isPortAvailable = await portFinder.isPortAvailable( this.details.port );
 		if ( ! isPortAvailable ) {
 			throw new Error(
 				`Port ${ this.details.port } is not available. error code: ERROR_PORT_IN_USE`
 			);
 		}
+		console.log( `[PERF] SiteServer.start: Port check took ${ Date.now() - portCheckStart }ms` );
 
 		console.log( `Starting server for '${ this.details.name }'` );
+		const createProcessStart = Date.now();
 		this.server = createServerProcess( serverInstance );
+		console.log( `[PERF] SiteServer.start: createServerProcess took ${ Date.now() - createProcessStart }ms` );
+
+		const serverProcessStart = Date.now();
 		await this.server.start();
+		console.log( `[PERF] SiteServer.start: server.start took ${ Date.now() - serverProcessStart }ms` );
 
 		if ( serverInstance.options.port === undefined ) {
 			throw new Error( 'Server started with no port' );
 		}
 
+		const themeDetailsStart = Date.now();
 		const themeDetails = await phpGetThemeDetails( this.server );
+		console.log( `[PERF] SiteServer.start: phpGetThemeDetails took ${ Date.now() - themeDetailsStart }ms` );
 
 		this.details = {
 			...this.details,
@@ -174,6 +195,8 @@ export class SiteServer {
 			autoStart: true,
 			themeDetails,
 		};
+
+		console.log( `[PERF] SiteServer.start: Total site start time ${ Date.now() - siteStartTime }ms` );
 	}
 
 	async updateSiteDetails( site: SiteDetails ) {

--- a/src/site-server.ts
+++ b/src/site-server.ts
@@ -113,12 +113,8 @@ export class SiteServer {
 			return;
 		}
 
-		const perfStart = performance.now();
-		console.log( `[PERF] SiteServer.start: Starting site '${ this.details.name }'` );
-
 		// Handle custom domain if necessary
 		if ( this.details.customDomain ) {
-			const customDomainStart = performance.now();
 			await addDomainToHosts( this.details.customDomain, this.details.port );
 			// Generate certificates for HTTPS sites *before* the server starts
 			// This ensures the certs are ready when the proxy server needs them
@@ -127,9 +123,7 @@ export class SiteServer {
 					`Generating certificates for ${ this.details.customDomain } during server start`
 				);
 
-				const certStart = performance.now();
 				const { cert, key } = await generateSiteCertificate( this.details.customDomain );
-				console.log( `[PERF] SiteServer.start: Certificate generation took ${ ( performance.now() - certStart ).toFixed( 2 ) }ms` );
 				this.details = {
 					...this.details,
 					tlsKey: key,
@@ -137,10 +131,8 @@ export class SiteServer {
 				};
 			}
 			await startProxyServer();
-			console.log( `[PERF] SiteServer.start: Custom domain setup took ${ ( performance.now() - customDomainStart ).toFixed( 2 ) }ms` );
 		}
 
-		const blueprintStart = performance.now();
 		const filteredBlueprint = filterUnsupportedBlueprintFeatures( this.meta.blueprint );
 		const serverInstance = await startServer( {
 			path: this.details.path,
@@ -153,7 +145,6 @@ export class SiteServer {
 			absoluteUrl: getAbsoluteUrl( this.details ),
 			blueprint: filteredBlueprint,
 		} );
-		console.log( `[PERF] SiteServer.start: Provider startServer took ${ ( performance.now() - blueprintStart ).toFixed( 2 ) }ms` );
 
 		const isPortAvailable = await portFinder.isPortAvailable( this.details.port );
 		if ( ! isPortAvailable ) {
@@ -163,18 +154,14 @@ export class SiteServer {
 		}
 
 		console.log( `Starting server for '${ this.details.name }'` );
-		const processStart = performance.now();
 		this.server = createServerProcess( serverInstance );
 		await this.server.start();
-		console.log( `[PERF] SiteServer.start: Server process start took ${ ( performance.now() - processStart ).toFixed( 2 ) }ms` );
 
 		if ( serverInstance.options.port === undefined ) {
 			throw new Error( 'Server started with no port' );
 		}
 
-		const themeStart = performance.now();
 		const themeDetails = await phpGetThemeDetails( this.server );
-		console.log( `[PERF] SiteServer.start: Get theme details took ${ ( performance.now() - themeStart ).toFixed( 2 ) }ms` );
 
 		this.details = {
 			...this.details,
@@ -190,8 +177,6 @@ export class SiteServer {
 		if ( this.meta.blueprint ) {
 			this.meta.blueprint = undefined;
 		}
-
-		console.log( `[PERF] SiteServer.start: Total time ${ ( performance.now() - perfStart ).toFixed( 2 ) }ms` );
 	}
 
 	async updateSiteDetails( site: SiteDetails ) {

--- a/src/site-server.ts
+++ b/src/site-server.ts
@@ -110,7 +110,8 @@ export class SiteServer {
 
 	async start() {
 		const siteStartTime = Date.now();
-		console.log( `[PERF] SiteServer.start: Starting site '${ this.details.name }'` );
+		console.log( `[PERF] SiteServer.start: Starting site '${ this.details.name }' at ${new Date().toISOString()}` );
+		console.log( `[PERF] SiteServer.start: Timestamp: ${siteStartTime}` );
 
 		if ( this.details.running || this.server ) {
 			console.log( '[PERF] SiteServer.start: Site already running, skipping' );
@@ -130,7 +131,9 @@ export class SiteServer {
 
 				const certStart = Date.now();
 				const { cert, key } = await generateSiteCertificate( this.details.customDomain );
-				console.log( `[PERF] SiteServer.start: Certificate generation took ${ Date.now() - certStart }ms` );
+				console.log(
+					`[PERF] SiteServer.start: Certificate generation took ${ Date.now() - certStart }ms`
+				);
 				this.details = {
 					...this.details,
 					tlsKey: key,
@@ -138,12 +141,16 @@ export class SiteServer {
 				};
 			}
 			await startProxyServer();
-			console.log( `[PERF] SiteServer.start: Domain setup took ${ Date.now() - domainSetupStart }ms` );
+			console.log(
+				`[PERF] SiteServer.start: Domain setup took ${ Date.now() - domainSetupStart }ms`
+			);
 		}
 
 		const blueprintFilterStart = Date.now();
 		const filteredBlueprint = filterUnsupportedBlueprintFeatures( this.meta.blueprint?.blueprint );
-		console.log( `[PERF] SiteServer.start: Blueprint filtering took ${ Date.now() - blueprintFilterStart }ms` );
+		console.log(
+			`[PERF] SiteServer.start: Blueprint filtering took ${ Date.now() - blueprintFilterStart }ms`
+		);
 
 		const startServerCallTime = Date.now();
 		const serverInstance = await startServer( {
@@ -157,7 +164,9 @@ export class SiteServer {
 			absoluteUrl: getAbsoluteUrl( this.details ),
 			blueprint: filteredBlueprint,
 		} );
-		console.log( `[PERF] SiteServer.start: startServer call took ${ Date.now() - startServerCallTime }ms` );
+		console.log(
+			`[PERF] SiteServer.start: startServer call took ${ Date.now() - startServerCallTime }ms`
+		);
 
 		const portCheckStart = Date.now();
 		const isPortAvailable = await portFinder.isPortAvailable( this.details.port );
@@ -171,11 +180,15 @@ export class SiteServer {
 		console.log( `Starting server for '${ this.details.name }'` );
 		const createProcessStart = Date.now();
 		this.server = createServerProcess( serverInstance );
-		console.log( `[PERF] SiteServer.start: createServerProcess took ${ Date.now() - createProcessStart }ms` );
+		console.log(
+			`[PERF] SiteServer.start: createServerProcess took ${ Date.now() - createProcessStart }ms`
+		);
 
 		const serverProcessStart = Date.now();
 		await this.server.start();
-		console.log( `[PERF] SiteServer.start: server.start took ${ Date.now() - serverProcessStart }ms` );
+		console.log(
+			`[PERF] SiteServer.start: server.start took ${ Date.now() - serverProcessStart }ms`
+		);
 
 		if ( serverInstance.options.port === undefined ) {
 			throw new Error( 'Server started with no port' );
@@ -183,7 +196,9 @@ export class SiteServer {
 
 		const themeDetailsStart = Date.now();
 		const themeDetails = await phpGetThemeDetails( this.server );
-		console.log( `[PERF] SiteServer.start: phpGetThemeDetails took ${ Date.now() - themeDetailsStart }ms` );
+		console.log(
+			`[PERF] SiteServer.start: phpGetThemeDetails took ${ Date.now() - themeDetailsStart }ms`
+		);
 
 		this.details = {
 			...this.details,
@@ -196,7 +211,12 @@ export class SiteServer {
 			themeDetails,
 		};
 
-		console.log( `[PERF] SiteServer.start: Total site start time ${ Date.now() - siteStartTime }ms` );
+		const endTime = Date.now();
+		console.log( `[PERF] SiteServer.start: Finished at ${new Date().toISOString()}` );
+		console.log( `[PERF] SiteServer.start: End timestamp: ${endTime}` );
+		console.log(
+			`[PERF] SiteServer.start: Total site start time ${ endTime - siteStartTime }ms`
+		);
 	}
 
 	async updateSiteDetails( site: SiteDetails ) {

--- a/src/site-server.ts
+++ b/src/site-server.ts
@@ -21,7 +21,6 @@ import {
 import WpCliProcess, { MessageCanceled, WpCliResult } from 'src/lib/wp-cli-process';
 import { createScreenshotWindow } from 'src/screenshot-window';
 import { getSiteThumbnailPath } from 'src/storage/paths';
-import { Blueprint } from './stores/wpcom-api';
 import type { WordPressServerProcess } from 'src/lib/wordpress-provider/types';
 
 const servers = new Map< string, SiteServer >();
@@ -52,7 +51,7 @@ function getAbsoluteUrl( details: SiteDetails ): string {
 // We use SiteDetails for storing it in appdata-v1.json, so this meta was introduced for extra data which is not stored locally
 type SiteServerMeta = {
 	wpVersion?: string;
-	blueprint?: Blueprint;
+	blueprint?: Record< string, unknown >;
 };
 
 export class SiteServer {
@@ -109,18 +108,12 @@ export class SiteServer {
 	}
 
 	async start() {
-		const siteStartTime = Date.now();
-		console.log( `[PERF] SiteServer.start: Starting site '${ this.details.name }' at ${new Date().toISOString()}` );
-		console.log( `[PERF] SiteServer.start: Timestamp: ${siteStartTime}` );
-
 		if ( this.details.running || this.server ) {
-			console.log( '[PERF] SiteServer.start: Site already running, skipping' );
 			return;
 		}
 
 		// Handle custom domain if necessary
 		if ( this.details.customDomain ) {
-			const domainSetupStart = Date.now();
 			await addDomainToHosts( this.details.customDomain, this.details.port );
 			// Generate certificates for HTTPS sites *before* the server starts
 			// This ensures the certs are ready when the proxy server needs them
@@ -129,11 +122,7 @@ export class SiteServer {
 					`Generating certificates for ${ this.details.customDomain } during server start`
 				);
 
-				const certStart = Date.now();
 				const { cert, key } = await generateSiteCertificate( this.details.customDomain );
-				console.log(
-					`[PERF] SiteServer.start: Certificate generation took ${ Date.now() - certStart }ms`
-				);
 				this.details = {
 					...this.details,
 					tlsKey: key,
@@ -141,18 +130,9 @@ export class SiteServer {
 				};
 			}
 			await startProxyServer();
-			console.log(
-				`[PERF] SiteServer.start: Domain setup took ${ Date.now() - domainSetupStart }ms`
-			);
 		}
 
-		const blueprintFilterStart = Date.now();
-		const filteredBlueprint = filterUnsupportedBlueprintFeatures( this.meta.blueprint?.blueprint );
-		console.log(
-			`[PERF] SiteServer.start: Blueprint filtering took ${ Date.now() - blueprintFilterStart }ms`
-		);
-
-		const startServerCallTime = Date.now();
+		const filteredBlueprint = filterUnsupportedBlueprintFeatures( this.meta.blueprint );
 		const serverInstance = await startServer( {
 			path: this.details.path,
 			port: this.details.port,
@@ -164,41 +144,23 @@ export class SiteServer {
 			absoluteUrl: getAbsoluteUrl( this.details ),
 			blueprint: filteredBlueprint,
 		} );
-		console.log(
-			`[PERF] SiteServer.start: startServer call took ${ Date.now() - startServerCallTime }ms`
-		);
 
-		const portCheckStart = Date.now();
 		const isPortAvailable = await portFinder.isPortAvailable( this.details.port );
 		if ( ! isPortAvailable ) {
 			throw new Error(
 				`Port ${ this.details.port } is not available. error code: ERROR_PORT_IN_USE`
 			);
 		}
-		console.log( `[PERF] SiteServer.start: Port check took ${ Date.now() - portCheckStart }ms` );
 
 		console.log( `Starting server for '${ this.details.name }'` );
-		const createProcessStart = Date.now();
 		this.server = createServerProcess( serverInstance );
-		console.log(
-			`[PERF] SiteServer.start: createServerProcess took ${ Date.now() - createProcessStart }ms`
-		);
 
-		const serverProcessStart = Date.now();
 		await this.server.start();
-		console.log(
-			`[PERF] SiteServer.start: server.start took ${ Date.now() - serverProcessStart }ms`
-		);
-
 		if ( serverInstance.options.port === undefined ) {
 			throw new Error( 'Server started with no port' );
 		}
 
-		const themeDetailsStart = Date.now();
 		const themeDetails = await phpGetThemeDetails( this.server );
-		console.log(
-			`[PERF] SiteServer.start: phpGetThemeDetails took ${ Date.now() - themeDetailsStart }ms`
-		);
 
 		this.details = {
 			...this.details,
@@ -211,12 +173,9 @@ export class SiteServer {
 			themeDetails,
 		};
 
-		const endTime = Date.now();
-		console.log( `[PERF] SiteServer.start: Finished at ${new Date().toISOString()}` );
-		console.log( `[PERF] SiteServer.start: End timestamp: ${endTime}` );
-		console.log(
-			`[PERF] SiteServer.start: Total site start time ${ endTime - siteStartTime }ms`
-		);
+		if ( this.meta.blueprint ) {
+			this.meta.blueprint = undefined;
+		}
 	}
 
 	async updateSiteDetails( site: SiteDetails ) {

--- a/src/site-server.ts
+++ b/src/site-server.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import nodePath from 'path';
 import * as Sentry from '@sentry/electron/main';
+import { BlueprintV1Declaration } from '@wp-playground/blueprints';
 import fsExtra from 'fs-extra';
 import { parse } from 'shell-quote';
 import { portFinder } from 'common/lib/port-finder';
@@ -51,7 +52,7 @@ function getAbsoluteUrl( details: SiteDetails ): string {
 // We use SiteDetails for storing it in appdata-v1.json, so this meta was introduced for extra data which is not stored locally
 type SiteServerMeta = {
 	wpVersion?: string;
-	blueprint?: Record< string, unknown >;
+	blueprint?: BlueprintV1Declaration;
 };
 
 export class SiteServer {

--- a/src/site-server.ts
+++ b/src/site-server.ts
@@ -154,8 +154,8 @@ export class SiteServer {
 
 		console.log( `Starting server for '${ this.details.name }'` );
 		this.server = createServerProcess( serverInstance );
-
 		await this.server.start();
+
 		if ( serverInstance.options.port === undefined ) {
 			throw new Error( 'Server started with no port' );
 		}

--- a/src/site-server.ts
+++ b/src/site-server.ts
@@ -113,8 +113,12 @@ export class SiteServer {
 			return;
 		}
 
+		const perfStart = performance.now();
+		console.log( `[PERF] SiteServer.start: Starting site '${ this.details.name }'` );
+
 		// Handle custom domain if necessary
 		if ( this.details.customDomain ) {
+			const customDomainStart = performance.now();
 			await addDomainToHosts( this.details.customDomain, this.details.port );
 			// Generate certificates for HTTPS sites *before* the server starts
 			// This ensures the certs are ready when the proxy server needs them
@@ -123,7 +127,9 @@ export class SiteServer {
 					`Generating certificates for ${ this.details.customDomain } during server start`
 				);
 
+				const certStart = performance.now();
 				const { cert, key } = await generateSiteCertificate( this.details.customDomain );
+				console.log( `[PERF] SiteServer.start: Certificate generation took ${ ( performance.now() - certStart ).toFixed( 2 ) }ms` );
 				this.details = {
 					...this.details,
 					tlsKey: key,
@@ -131,8 +137,10 @@ export class SiteServer {
 				};
 			}
 			await startProxyServer();
+			console.log( `[PERF] SiteServer.start: Custom domain setup took ${ ( performance.now() - customDomainStart ).toFixed( 2 ) }ms` );
 		}
 
+		const blueprintStart = performance.now();
 		const filteredBlueprint = filterUnsupportedBlueprintFeatures( this.meta.blueprint );
 		const serverInstance = await startServer( {
 			path: this.details.path,
@@ -145,6 +153,7 @@ export class SiteServer {
 			absoluteUrl: getAbsoluteUrl( this.details ),
 			blueprint: filteredBlueprint,
 		} );
+		console.log( `[PERF] SiteServer.start: Provider startServer took ${ ( performance.now() - blueprintStart ).toFixed( 2 ) }ms` );
 
 		const isPortAvailable = await portFinder.isPortAvailable( this.details.port );
 		if ( ! isPortAvailable ) {
@@ -154,14 +163,18 @@ export class SiteServer {
 		}
 
 		console.log( `Starting server for '${ this.details.name }'` );
+		const processStart = performance.now();
 		this.server = createServerProcess( serverInstance );
 		await this.server.start();
+		console.log( `[PERF] SiteServer.start: Server process start took ${ ( performance.now() - processStart ).toFixed( 2 ) }ms` );
 
 		if ( serverInstance.options.port === undefined ) {
 			throw new Error( 'Server started with no port' );
 		}
 
+		const themeStart = performance.now();
 		const themeDetails = await phpGetThemeDetails( this.server );
+		console.log( `[PERF] SiteServer.start: Get theme details took ${ ( performance.now() - themeStart ).toFixed( 2 ) }ms` );
 
 		this.details = {
 			...this.details,
@@ -177,6 +190,8 @@ export class SiteServer {
 		if ( this.meta.blueprint ) {
 			this.meta.blueprint = undefined;
 		}
+
+		console.log( `[PERF] SiteServer.start: Total time ${ ( performance.now() - perfStart ).toFixed( 2 ) }ms` );
 	}
 
 	async updateSiteDetails( site: SiteDetails ) {

--- a/src/tests/ipc-handlers.test.ts
+++ b/src/tests/ipc-handlers.test.ts
@@ -207,6 +207,8 @@ describe( 'importSite', () => {
 				id: 'test-site',
 				phpVersion: '8.3',
 			},
+			start: jest.fn(),
+			stop: jest.fn(),
 			updateSiteDetails: jest.fn(),
 			executeWpCliCommand: jest
 				.fn()
@@ -246,6 +248,8 @@ describe( 'importSite', () => {
 			details: {
 				id: 'test-site',
 			},
+			start: jest.fn(),
+			stop: jest.fn(),
 			executeWpCliCommand: jest
 				.fn()
 				.mockResolvedValue( { stdout: 'New Site Title', stderr: '', exitCode: 0 } ),


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-842
- Related STU-744

## Proposed Changes

- During `createSite` store setup steps in a blueprint to run at first site start. This will avoid having to run Playground CLI twice (once for `run-blueprint` and another for `server`)
- Made thumbnail generation async
- Fixed race-condition in the UI, to make the creating site component display until `startSite` is done.
- Created Studio Admin API mu-plugin with persistent endpoints that reuse the already-loaded WordPress instance, avoiding the overhead of loading wp-load.php multiple times:
  - `get_theme_details` endpoint - Retrieves active theme information without loading WordPress
  - `set_admin_password` endpoint - Sets/updates admin user password without loading WordPress
- Added `request()` method to Playground CLI server process to communicate with persistent WordPress instance via HTTP requests
- Added fallback logic in `phpGetThemeDetails` to support WP-Now provider (uses `runPhp()` when `request()` is not available)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- As much tests as possible around, creating, starting, stopping, importing and exporting sites (including sync and preview sites)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?