### PR TITLE
fix admin password endpoint timing issue

### DIFF
--- a/src/lib/wordpress-provider/playground-cli/mu-plugins.ts
+++ b/src/lib/wordpress-provider/playground-cli/mu-plugins.ts
@@ -317,14 +317,15 @@ function getStandardMuPlugins( options: Partial< WordPressServerOptions > ): MuP
 		 * This endpoint should only be accessible locally.
 		 */
 
-		add_action( 'init', function() {
-			// Only handle requests to our endpoint
-			$is_api_request = isset( $_GET['studio-admin-api'] ) ||
-			                  strpos( $_SERVER['REQUEST_URI'] ?? '', 'studio-admin-api' ) !== false;
+		// Check if this is an API request before WordPress routing
+		$is_api_request = isset( $_GET['studio-admin-api'] ) ||
+		                  strpos( $_SERVER['REQUEST_URI'] ?? '', 'studio-admin-api' ) !== false;
 
-			if ( ! $is_api_request ) {
-				return;
-			}
+		if ( ! $is_api_request ) {
+			return;
+		}
+
+		add_action( 'plugins_loaded', function() {
 
 			// Security: Only allow POST requests with the correct action
 			if ( $_SERVER['REQUEST_METHOD'] !== 'POST' || empty( $_POST['action'] ) ) {

--- a/src/lib/wordpress-provider/playground-cli/playground-server-process-child.ts
+++ b/src/lib/wordpress-provider/playground-cli/playground-server-process-child.ts
@@ -109,6 +109,10 @@ process.parentPort.on( 'message', async ( event ) => {
 
 process.parentPort.postMessage( { type: 'ready' } );
 
+function escapePhpString( str: string ): string {
+	return str.replace( /\\/g, '\\\\' ).replace( /'/g, "\\'" );
+}
+
 async function setAdminPassword( server: RunCLIServer, adminPassword: string ): Promise< void > {
 	// Use the persistent mu-plugin API endpoint to avoid loading WordPress again
 	await server.playground.request( {
@@ -116,7 +120,7 @@ async function setAdminPassword( server: RunCLIServer, adminPassword: string ): 
 		method: 'POST',
 		body: {
 			action: 'set_admin_password',
-			password: adminPassword,
+			password: escapePhpString( adminPassword ),
 		},
 	} );
 }


### PR DESCRIPTION
## Related issues

- N/A

## Proposed Changes

- Fixed admin password endpoint being redirected (302) instead of executing
- Moved endpoint check to run before WordPress routing by checking request at MU plugin load time
- Changed hook from `init` to `plugins_loaded` with priority 1 to intercept request early
- Added `escapePhpString` helper to properly escape special characters in passwords

## Testing Instructions

- Start a new site 
- Open wp-admin and logout
- Try to login with Studio provided credentials

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?