### PR TITLE
Add electron agnostic isOnline utility

### DIFF
--- a/common/lib/network-utils.ts
+++ b/common/lib/network-utils.ts
@@ -1,0 +1,20 @@
+import dns from 'dns/promises';
+
+/**
+ * Check if the system has internet connectivity by testing DNS resolution.
+ *
+ * @returns Promise that resolves to true if online, false if offline
+ */
+export async function isOnline(): Promise< boolean > {
+	try {
+		const timeoutPromise = new Promise( ( _, reject ) =>
+			setTimeout( () => reject( new Error( 'Timeout' ) ), 5000 )
+		);
+
+		await Promise.race( [ dns.resolve( 'google.com' ), timeoutPromise ] );
+
+		return true;
+	} catch {
+		return false;
+	}
+}

--- a/common/lib/network-utils.ts
+++ b/common/lib/network-utils.ts
@@ -11,7 +11,7 @@ export async function isOnline(): Promise< boolean > {
 			setTimeout( () => reject( new Error( 'Timeout' ) ), 5000 )
 		);
 
-		await Promise.race( [ dns.resolve( 'google.com' ), timeoutPromise ] );
+		await Promise.race( [ dns.resolve( 'public-api.wordpress.com' ), timeoutPromise ] );
 
 		return true;
 	} catch {

--- a/metrics/playwright.metrics.config.ts
+++ b/metrics/playwright.metrics.config.ts
@@ -17,7 +17,7 @@ export default defineConfig( {
 	reportSlowTests: null,
 	use: {
 		...baseConfig.use,
-		actionTimeout: 120_000, // 2 minutes.
+		actionTimeout: 240_000, // 4 minutes.
 		headless: true,
 		// Enable only for debugging.
 		trace: 'off',
@@ -25,6 +25,6 @@ export default defineConfig( {
 		video: 'off',
 	},
 	expect: {
-		timeout: 120_000, // 2 minutes.
+		timeout: 240_000, // 4 minutes.
 	},
 } );

--- a/src/lib/wordpress-provider/playground-cli/playground-cli-provider.ts
+++ b/src/lib/wordpress-provider/playground-cli/playground-cli-provider.ts
@@ -1,10 +1,10 @@
-import { net } from 'electron';
 import nodePath from 'path';
 import { SupportedPHPVersions } from '@php-wasm/universal';
 import { Blueprint, StepDefinition } from '@wp-playground/blueprints';
 import { RecommendedPHPVersion } from '@wp-playground/common';
 import { recursiveCopyDirectory, pathExists, isWordPressDirectory } from 'common/lib/fs-utils';
 import { DEFAULT_LOCALE } from 'common/lib/locale';
+import { isOnline } from 'common/lib/network-utils';
 import { getPreferredSiteLanguage } from 'src/lib/site-language';
 import { keepSqliteIntegrationUpdated } from 'src/lib/sqlite-versions';
 import { isValidWordPressVersion } from 'src/lib/wordpress-version-utils';
@@ -120,12 +120,12 @@ export class PlaygroundCliProvider implements WordPressProvider {
 		const { path, name, adminPassword } = server.details;
 
 		try {
-			const isOnline = net.isOnline();
+			const isOnlineStatus = await isOnline();
 			const siteLanguage = await getPreferredSiteLanguage( wpVersion );
 
 			const setupSteps: StepDefinition[] = [];
 
-			if ( isOnline && siteLanguage && siteLanguage !== DEFAULT_LOCALE ) {
+			if ( isOnlineStatus && siteLanguage && siteLanguage !== DEFAULT_LOCALE ) {
 				setupSteps.push(
 					{
 						step: 'setSiteLanguage',
@@ -149,7 +149,7 @@ export class PlaygroundCliProvider implements WordPressProvider {
 				} );
 			}
 
-			if ( ! isOnline ) {
+			if ( ! isOnlineStatus ) {
 				if ( wpVersion !== 'latest' ) {
 					throw new Error(
 						`Cannot set up WordPress version '${ wpVersion }' while offline. ` +

--- a/src/lib/wordpress-provider/wp-now/wp-now-provider.ts
+++ b/src/lib/wordpress-provider/wp-now/wp-now-provider.ts
@@ -1,8 +1,8 @@
-import { net } from 'electron';
 import path from 'path';
 import fs from 'fs-extra';
 import semver from 'semver';
 import { pathExists, recursiveCopyDirectory, isEmptyDir } from 'common/lib/fs-utils';
+import { isOnline } from 'common/lib/network-utils';
 import { getPreferredSiteLanguage } from 'src/lib/site-language';
 import { isValidWordPressVersion } from 'src/lib/wordpress-version-utils';
 import { copyBundledLatestWPVersion } from 'src/setup-wp-server-files';
@@ -121,7 +121,7 @@ export class WpNowProvider implements WordPressProvider {
 			const wpVersionExists = await pathExists( wpVersionPath );
 
 			if ( ! wpVersionExists ) {
-				if ( net.isOnline() ) {
+				if ( await isOnline() ) {
 					try {
 						await WpNowProvider.downloadWordPress( wpVersion, { overwrite: false } );
 					} catch ( error ) {
@@ -250,7 +250,7 @@ export class WpNowProvider implements WordPressProvider {
 	 * @param wpVersion - The WordPress version to verify
 	 */
 	private async verifyWordPressChecksums( wpVersion: string ): Promise< void > {
-		if ( ! net.isOnline() ) {
+		if ( ! ( await isOnline() ) ) {
 			console.log( 'Skipping WordPress checksum verification - offline mode' );
 			return;
 		}


### PR DESCRIPTION
## Related issues

- Fixes STU-775

This is a small refactoring PR that adds an isOnline common utility to be used by both CLI and Electron App since net.isOnline is an electron/node only utility.

I would like to use this utility later to download the resources necessary for the CLI to work properly (launch and create sites fully without the electron app). These resources include WP latest, the WPCLI phar and SQLite command. See this commit https://github.com/Automattic/studio/commit/3f180139042061a755aa63ff261f2136c8858878 which is going to be extracted to a follow-up PR to the current one.

## Testing instructions

Ideally, this shouldn't have any impact on the electron app.