### PR TITLE
Avoid focus loss on switching tabs

### DIFF
--- a/src/components/site-content-tabs.tsx
+++ b/src/components/site-content-tabs.tsx
@@ -1,5 +1,6 @@
 import { TabPanel } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
+import { useEffect, useRef, useState } from 'react';
 import { ContentTabAssistant } from 'src/components/content-tab-assistant';
 import { ContentTabImportExport } from 'src/components/content-tab-import-export';
 import { ContentTabOverview } from 'src/components/content-tab-overview';
@@ -20,6 +21,24 @@ export function SiteContentTabs() {
 	const { importState } = useImportExport();
 	const { tabs, selectedTab, setSelectedTab } = useContentTabs();
 	const { __ } = useI18n();
+
+	// Remount: Avoid focus loss on user tab changes (no remount),
+	// but remount on programmatic changes and site switches so initial tab/content state resets.
+	const [ keyCounter, setKeyCounter ] = useState( 0 );
+	const lastChangeWasUser = useRef( false );
+	const isFirstRender = useRef( true );
+
+	useEffect( () => {
+		if ( isFirstRender.current ) {
+			isFirstRender.current = false;
+			return;
+		}
+		if ( lastChangeWasUser.current ) {
+			lastChangeWasUser.current = false;
+			return;
+		}
+		setKeyCounter( ( k ) => k + 1 );
+	}, [ selectedTab ] );
 
 	if ( ! localSites.length ) {
 		return <EmptyStudio />;
@@ -44,9 +63,13 @@ export function SiteContentTabs() {
 				className={ `mt-6 h-full flex flex-col overflow-hidden ${ MIN_WIDTH_CLASS_TO_MEASURE }` }
 				tabs={ tabs }
 				orientation="horizontal"
-				onSelect={ ( tabName ) => setSelectedTab( tabName as TabName ) }
+				onSelect={ ( tabName ) => {
+					// Mark this as a user-initiated change so we don't remount
+					lastChangeWasUser.current = true;
+					setSelectedTab( tabName as TabName );
+				} }
 				initialTabName={ selectedTab }
-				key={ selectedTab + selectedSite.id }
+				key={ `${ selectedSite.id }-${ keyCounter }` }
 			>
 				{ ( { name } ) => (
 					<div


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Closes STU-53

## Proposed Changes

This PR ensures that we don't lose focus when we use the keyboard navigation when switching between tabs.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
* Start Studio
* Click on one of the tabs e.g. Overview
* Try using left and right arrows to move through tabs
* Confirm that you can move between tabs and that they do not lose focus
* Compare this behaviour to trunk and observe that keyboard navigation does not work correctly there and you can't move through tabs

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
