### PR TITLE
Add which table is being imported and SQLite import stdout to Studio logs

### DIFF
--- a/src/lib/import-export/import/importers/importer.ts
+++ b/src/lib/import-export/import/importers/importer.ts
@@ -58,7 +58,8 @@ abstract class BaseImporter extends EventEmitter implements Importer {
 			try {
 				await move( sqlFile, tmpPath );
 				await this.prepareSqlFile( tmpPath );
-				const { stderr, exitCode } = await server.executeWpCliCommand(
+				console.log( `Importing ${ sqlFile }...` );
+				const { stderr, exitCode, stdout } = await server.executeWpCliCommand(
 					`sqlite import ${ sqlTempFile } --require=/tmp/sqlite-command/command.php --enable-ast-driver`,
 					// SQLite plugin requires PHP 8+
 					{
@@ -66,6 +67,10 @@ abstract class BaseImporter extends EventEmitter implements Importer {
 						skipPluginsAndThemes: true,
 					}
 				);
+
+				if ( stdout ) {
+					console.log( `SQLite import stdout: ${ stdout }` );
+				}
 
 				if ( stderr ) {
 					console.error( `Error during import of ${ sqlFile }:`, stderr );

--- a/src/lib/import-export/import/importers/importer.ts
+++ b/src/lib/import-export/import/importers/importer.ts
@@ -58,7 +58,7 @@ abstract class BaseImporter extends EventEmitter implements Importer {
 			try {
 				await move( sqlFile, tmpPath );
 				await this.prepareSqlFile( tmpPath );
-				console.log( `Importing ${ sqlFile }...` );
+				console.log( `Importing ${ sqlFile }` );
 				const { stderr, exitCode, stdout } = await server.executeWpCliCommand(
 					`sqlite import ${ sqlTempFile } --require=/tmp/sqlite-command/command.php --enable-ast-driver`,
 					// SQLite plugin requires PHP 8+


### PR DESCRIPTION

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Related to https://github.com/Automattic/wp-cli-sqlite-command/pull/13

## Proposed Changes

This PR helps with debugging when a SQLite import error occurs.
In https://github.com/Automattic/wp-cli-sqlite-command/pull/13, I'm moving some WP-CLI warnings to regular stdout. This way, users will receive better messages when they encounter errors while importing a database or site. It also adds more infromation to Studio logs.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run `npm start`
- Import a Jetpack site or sql file
- Observe the new logs for each table similarly to:

```
Importing /var/folders/_x/rbv26n3925q_01dbs4jzd8t80000gn/T/studio_backupldWovT/sql/wp_actionscheduler_actions.sql...
Success: Imported from 'studio-backup-sql-2025-10-08-15-25-59.sql'.
```
<!--

- Try importing twice a sql file with a create table query and observe a better message. This might require applying https://github.com/Automattic/wp-cli-sqlite-command/pull/13

<img width="1072" height="712" alt="Screenshot 2025-10-08 at 15 43 33" src="https://github.com/user-attachments/assets/a91e4e75-a35c-48e3-ba85-d7661b6337e1" />
-->



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
