### PR TITLE
Studio: Ability to cancel the push and pull

### DIFF
--- a/src/hooks/sync-sites/sync-sites-context.tsx
+++ b/src/hooks/sync-sites/sync-sites-context.tsx
@@ -79,24 +79,34 @@ export function SyncSitesProvider( { children }: { children: React.ReactNode } )
 		[ connectedSites, dispatch ]
 	);
 
-	const { pullSite, isAnySitePulling, isSiteIdPulling, clearPullState, getPullState } = useSyncPull(
-		{
-			pullStates,
-			setPullStates,
-			onPullSuccess: ( remoteSiteId, localSiteId ) =>
-				updateSiteTimestamp( remoteSiteId, localSiteId, 'pull' ),
-		}
-	);
+	const {
+		pullSite,
+		isAnySitePulling,
+		isSiteIdPulling,
+		clearPullState,
+		getPullState,
+		cancelPull,
+	} = useSyncPull( {
+		pullStates,
+		setPullStates,
+		onPullSuccess: ( remoteSiteId, localSiteId ) =>
+			updateSiteTimestamp( remoteSiteId, localSiteId, 'pull' ),
+	} );
 
 	const [ pushStates, setPushStates ] = useState< PushStates >( {} );
-	const { pushSite, isAnySitePushing, isSiteIdPushing, clearPushState, getPushState } = useSyncPush(
-		{
-			pushStates,
-			setPushStates,
-			onPushSuccess: ( remoteSiteId, localSiteId ) =>
-				updateSiteTimestamp( remoteSiteId, localSiteId, 'push' ),
-		}
-	);
+	const {
+		pushSite,
+		isAnySitePushing,
+		isSiteIdPushing,
+		clearPushState,
+		getPushState,
+		cancelPush,
+	} = useSyncPush( {
+		pushStates,
+		setPushStates,
+		onPushSuccess: ( remoteSiteId, localSiteId ) =>
+			updateSiteTimestamp( remoteSiteId, localSiteId, 'push' ),
+	} );
 
 	const { syncSites, isFetching, refetchSites } = useSyncSitesData();
 	useListenDeepLinkConnection( { refetchSites } );
@@ -108,6 +118,7 @@ export function SyncSitesProvider( { children }: { children: React.ReactNode } )
 				isAnySitePulling,
 				isSiteIdPulling,
 				clearPullState,
+				cancelPull,
 				syncSites,
 				refetchSites,
 				isFetching,
@@ -117,6 +128,7 @@ export function SyncSitesProvider( { children }: { children: React.ReactNode } )
 				isAnySitePushing,
 				isSiteIdPushing,
 				clearPushState,
+				cancelPush,
 				getLastSyncTimeText,
 			} }
 		>

--- a/src/hooks/sync-sites/sync-sites-context.tsx
+++ b/src/hooks/sync-sites/sync-sites-context.tsx
@@ -79,34 +79,22 @@ export function SyncSitesProvider( { children }: { children: React.ReactNode } )
 		[ connectedSites, dispatch ]
 	);
 
-	const {
-		pullSite,
-		isAnySitePulling,
-		isSiteIdPulling,
-		clearPullState,
-		getPullState,
-		cancelPull,
-	} = useSyncPull( {
-		pullStates,
-		setPullStates,
-		onPullSuccess: ( remoteSiteId, localSiteId ) =>
-			updateSiteTimestamp( remoteSiteId, localSiteId, 'pull' ),
-	} );
+	const { pullSite, isAnySitePulling, isSiteIdPulling, clearPullState, getPullState, cancelPull } =
+		useSyncPull( {
+			pullStates,
+			setPullStates,
+			onPullSuccess: ( remoteSiteId, localSiteId ) =>
+				updateSiteTimestamp( remoteSiteId, localSiteId, 'pull' ),
+		} );
 
 	const [ pushStates, setPushStates ] = useState< PushStates >( {} );
-	const {
-		pushSite,
-		isAnySitePushing,
-		isSiteIdPushing,
-		clearPushState,
-		getPushState,
-		cancelPush,
-	} = useSyncPush( {
-		pushStates,
-		setPushStates,
-		onPushSuccess: ( remoteSiteId, localSiteId ) =>
-			updateSiteTimestamp( remoteSiteId, localSiteId, 'push' ),
-	} );
+	const { pushSite, isAnySitePushing, isSiteIdPushing, clearPushState, getPushState, cancelPush } =
+		useSyncPush( {
+			pushStates,
+			setPushStates,
+			onPushSuccess: ( remoteSiteId, localSiteId ) =>
+				updateSiteTimestamp( remoteSiteId, localSiteId, 'push' ),
+		} );
 
 	const { syncSites, isFetching, refetchSites } = useSyncSitesData();
 	useListenDeepLinkConnection( { refetchSites } );

--- a/src/hooks/sync-sites/use-pull-push-states.ts
+++ b/src/hooks/sync-sites/use-pull-push-states.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useRef, useEffect } from 'react';
 
 export const generateStateId = ( selectedSiteId: string, remoteSiteId: number ) =>
 	`${ selectedSiteId }-${ remoteSiteId }`;
@@ -22,24 +22,34 @@ export function usePullPushStates< T >(
 	states: States< T >,
 	setStates: React.Dispatch< React.SetStateAction< States< T > > >
 ): UsePullPushStates< T > {
+	const statesRef = useRef( states );
+
+	useEffect( () => {
+		statesRef.current = states;
+	}, [ states ] );
+
 	const updateState = useCallback< UpdateState< T > >(
 		( selectedSiteId, remoteSiteId, state ) => {
-			setStates( ( prevStates ) => ( {
-				...prevStates,
-				[ generateStateId( selectedSiteId, remoteSiteId ) ]: {
-					...prevStates[ generateStateId( selectedSiteId, remoteSiteId ) ],
-					...state,
-				},
-			} ) );
+			setStates( ( prevStates ) => {
+				const newStates = {
+					...prevStates,
+					[ generateStateId( selectedSiteId, remoteSiteId ) ]: {
+						...prevStates[ generateStateId( selectedSiteId, remoteSiteId ) ],
+						...state,
+					},
+				};
+				statesRef.current = newStates;
+				return newStates;
+			} );
 		},
 		[ setStates ]
 	);
 
 	const getState = useCallback< GetState< T > >(
 		( selectedSiteId, remoteSiteId ): T | undefined => {
-			return states[ generateStateId( selectedSiteId, remoteSiteId ) ];
+			return statesRef.current[ generateStateId( selectedSiteId, remoteSiteId ) ];
 		},
-		[ states ]
+		[]
 	);
 
 	const clearState = useCallback< ClearState >(
@@ -47,6 +57,7 @@ export function usePullPushStates< T >(
 			setStates( ( prevStates ) => {
 				const newStates = { ...prevStates };
 				delete newStates[ generateStateId( selectedSiteId, remoteSiteId ) ];
+				statesRef.current = newStates;
 				return newStates;
 			} );
 		},

--- a/src/hooks/sync-sites/use-sync-pull.ts
+++ b/src/hooks/sync-sites/use-sync-pull.ts
@@ -77,6 +77,7 @@ export function useSyncPull( {
 		isKeyPulling,
 		isKeyFinished,
 		isKeyFailed,
+		isKeyCancelled,
 		getBackupStatusWithProgress,
 	} = useSyncStatesProgressInfo();
 	const {
@@ -90,13 +91,13 @@ export function useSyncPull( {
 			updateState( selectedSiteId, remoteSiteId, state );
 			const statusKey = state.status?.key;
 
-			if ( isKeyFailed( statusKey ) || isKeyFinished( statusKey ) ) {
+			if ( isKeyFailed( statusKey ) || isKeyFinished( statusKey ) || isKeyCancelled( statusKey ) ) {
 				getIpcApi().clearSyncOperation( generateStateId( selectedSiteId, remoteSiteId ) );
 			} else {
 				getIpcApi().addSyncOperation( generateStateId( selectedSiteId, remoteSiteId ) );
 			}
 		},
-		[ isKeyFailed, isKeyFinished, updateState ]
+		[ isKeyFailed, isKeyFinished, isKeyCancelled, updateState ]
 	);
 
 	const clearPullState = useCallback< ClearState >(
@@ -117,6 +118,8 @@ export function useSyncPull( {
 
 			const remoteSiteId = connectedSite.id;
 			const remoteSiteUrl = connectedSite.url;
+
+			clearPullState( selectedSite.id, remoteSiteId );
 			updatePullState( selectedSite.id, remoteSiteId, {
 				backupId: null,
 				status: pullStatesProgressInfo[ 'in-progress' ],
@@ -164,7 +167,7 @@ export function useSyncPull( {
 				} );
 			}
 		},
-		[ __, client, pullStatesProgressInfo, updatePullState ]
+		[ __, clearPullState, client, pullStatesProgressInfo, updatePullState ]
 	);
 
 	const checkBackupFileSize = async ( downloadUrl: string ): Promise< number > => {
@@ -223,6 +226,11 @@ export function useSyncPull( {
 					operationId
 				);
 
+				const stateAfterDownload = getPullState( selectedSite.id, remoteSiteId );
+				if ( stateAfterDownload?.status.key === 'cancelled' ) {
+					return;
+				}
+
 				// Starting import process
 				updatePullState( selectedSite.id, remoteSiteId, {
 					status: pullStatesProgressInfo.importing,
@@ -260,6 +268,12 @@ export function useSyncPull( {
 				onPullSuccess?.( remoteSiteId, selectedSite.id );
 			} catch ( error ) {
 				console.error( 'Backup completion failed:', error );
+
+				const currentState = getPullState( selectedSite.id, remoteSiteId );
+				if ( currentState && isKeyCancelled( currentState?.status.key ) ) {
+					return;
+				}
+
 				Sentry.captureException( error );
 				updatePullState( selectedSite.id, remoteSiteId, {
 					status: pullStatesProgressInfo.failed,
@@ -274,8 +288,10 @@ export function useSyncPull( {
 			__,
 			clearImportState,
 			clearPullState,
+			getPullState,
 			importFile,
 			onPullSuccess,
+			isKeyCancelled,
 			pullStatesProgressInfo.cancelled,
 			pullStatesProgressInfo.downloading,
 			pullStatesProgressInfo.failed,
@@ -292,7 +308,12 @@ export function useSyncPull( {
 				return;
 			}
 
-			const backupId = getPullState( selectedSiteId, remoteSiteId )?.backupId;
+			const currentState = getPullState( selectedSiteId, remoteSiteId );
+			if ( currentState && isKeyCancelled( currentState.status.key ) ) {
+				return;
+			}
+
+			const backupId = currentState?.backupId;
 			if ( ! backupId ) {
 				console.error( 'No backup ID found' );
 				return;
@@ -343,6 +364,7 @@ export function useSyncPull( {
 			onBackupCompleted,
 			pullStatesProgressInfo,
 			updatePullState,
+			isKeyCancelled,
 		]
 	);
 
@@ -350,6 +372,10 @@ export function useSyncPull( {
 		const intervals: Record< string, NodeJS.Timeout > = {};
 
 		Object.entries( pullStates ).forEach( ( [ key, state ] ) => {
+			if ( isKeyCancelled( state.status.key ) ) {
+				return;
+			}
+
 			if ( state.backupId && state.status.key === 'in-progress' ) {
 				intervals[ key ] = setTimeout( () => {
 					void fetchAndUpdateBackup( state.remoteSiteId, state.selectedSite.id );
@@ -360,7 +386,7 @@ export function useSyncPull( {
 		return () => {
 			Object.values( intervals ).forEach( clearTimeout );
 		};
-	}, [ pullStates, fetchAndUpdateBackup ] );
+	}, [ pullStates, fetchAndUpdateBackup, isKeyCancelled ] );
 
 	const isAnySitePulling = useMemo< boolean >( () => {
 		return Object.values( pullStates ).some( ( state ) => isKeyPulling( state.status.key ) );
@@ -369,6 +395,9 @@ export function useSyncPull( {
 	const isSiteIdPulling = useCallback< IsSiteIdPulling >(
 		( selectedSiteId, remoteSiteId ) => {
 			return Object.values( pullStates ).some( ( state ) => {
+				if ( ! state.selectedSite ) {
+					return false;
+				}
 				if ( state.selectedSite.id !== selectedSiteId ) {
 					return false;
 				}
@@ -382,21 +411,24 @@ export function useSyncPull( {
 	);
 
 	const cancelPull = useCallback< CancelPull >(
-		( selectedSiteId, remoteSiteId ) => {
+		async ( selectedSiteId, remoteSiteId ) => {
 			const operationId = generateStateId( selectedSiteId, remoteSiteId );
-			getIpcApi().cancelSyncOperation( operationId );
+
+			await getIpcApi().cancelSyncOperation( operationId );
 
 			updatePullState( selectedSiteId, remoteSiteId, {
 				status: pullStatesProgressInfo.cancelled,
 			} );
 
 			// Clean up any downloaded backup file
-			getIpcApi().removeSyncBackup( remoteSiteId ).catch( () => {
-				// Ignore errors if file doesn't exist
-			} );
+			getIpcApi()
+				.removeSyncBackup( remoteSiteId )
+				.catch( () => {
+					// Ignore errors if file doesn't exist
+				} );
 
 			getIpcApi().showNotification( {
-				title: __(  'Pull cancelled' ),
+				title: __( 'Pull cancelled' ),
 				body: __( 'The pull operation has been cancelled.' ),
 			} );
 		},

--- a/src/hooks/sync-sites/use-sync-pull.ts
+++ b/src/hooks/sync-sites/use-sync-pull.ts
@@ -52,6 +52,8 @@ type UseSyncPullProps = {
 	onPullSuccess?: OnPullSuccess;
 };
 
+type CancelPull = ( selectedSiteId: string, remoteSiteId: number ) => void;
+
 export type UseSyncPull = {
 	pullStates: PullStates;
 	getPullState: GetState< SyncBackupState >;
@@ -59,6 +61,7 @@ export type UseSyncPull = {
 	isAnySitePulling: boolean;
 	isSiteIdPulling: IsSiteIdPulling;
 	clearPullState: ClearState;
+	cancelPull: CancelPull;
 };
 
 export function useSyncPull( {
@@ -213,7 +216,12 @@ export function useSyncPull( {
 					downloadUrl,
 				} );
 
-				const filePath = await getIpcApi().downloadSyncBackup( remoteSiteId, downloadUrl );
+				const operationId = generateStateId( selectedSite.id, remoteSiteId );
+				const filePath = await getIpcApi().downloadSyncBackup(
+					remoteSiteId,
+					downloadUrl,
+					operationId
+				);
 
 				// Starting import process
 				updatePullState( selectedSite.id, remoteSiteId, {
@@ -373,5 +381,35 @@ export function useSyncPull( {
 		[ pullStates, isKeyPulling ]
 	);
 
-	return { pullStates, getPullState, pullSite, isAnySitePulling, isSiteIdPulling, clearPullState };
+	const cancelPull = useCallback< CancelPull >(
+		( selectedSiteId, remoteSiteId ) => {
+			const operationId = generateStateId( selectedSiteId, remoteSiteId );
+			getIpcApi().cancelSyncOperation( operationId );
+
+			updatePullState( selectedSiteId, remoteSiteId, {
+				status: pullStatesProgressInfo.cancelled,
+			} );
+
+			// Clean up any downloaded backup file
+			getIpcApi().removeSyncBackup( remoteSiteId ).catch( () => {
+				// Ignore errors if file doesn't exist
+			} );
+
+			getIpcApi().showNotification( {
+				title: __(  'Pull cancelled' ),
+				body: __( 'The pull operation has been cancelled.' ),
+			} );
+		},
+		[ __, pullStatesProgressInfo.cancelled, updatePullState ]
+	);
+
+	return {
+		pullStates,
+		getPullState,
+		pullSite,
+		isAnySitePulling,
+		isSiteIdPulling,
+		clearPullState,
+		cancelPull,
+	};
 }

--- a/src/hooks/sync-sites/use-sync-pull.ts
+++ b/src/hooks/sync-sites/use-sync-pull.ts
@@ -420,7 +420,6 @@ export function useSyncPull( {
 				status: pullStatesProgressInfo.cancelled,
 			} );
 
-			// Clean up any downloaded backup file
 			getIpcApi()
 				.removeSyncBackup( remoteSiteId )
 				.catch( () => {

--- a/src/hooks/sync-sites/use-sync-pull.ts
+++ b/src/hooks/sync-sites/use-sync-pull.ts
@@ -227,7 +227,7 @@ export function useSyncPull( {
 				);
 
 				const stateAfterDownload = getPullState( selectedSite.id, remoteSiteId );
-				if ( stateAfterDownload?.status.key === 'cancelled' ) {
+				if ( ! stateAfterDownload || isKeyCancelled( stateAfterDownload?.status.key ) ) {
 					return;
 				}
 

--- a/src/hooks/sync-sites/use-sync-push.ts
+++ b/src/hooks/sync-sites/use-sync-push.ts
@@ -52,6 +52,8 @@ type UseSyncPushProps = {
 	onPushSuccess?: OnPushSuccess;
 };
 
+type CancelPush = ( selectedSiteId: string, remoteSiteId: number ) => void;
+
 export type UseSyncPush = {
 	pushStates: PushStates;
 	getPushState: GetState< SyncPushState >;
@@ -59,6 +61,7 @@ export type UseSyncPush = {
 	isAnySitePushing: boolean;
 	isSiteIdPushing: IsSiteIdPushing;
 	clearPushState: ClearState;
+	cancelPush: CancelPush;
 };
 
 export function useSyncPush( {
@@ -198,7 +201,8 @@ export function useSyncPush( {
 			let archiveContent, archivePath, archiveSizeInBytes;
 
 			try {
-				const result = await getIpcApi().exportSiteToPush( selectedSite.id, {
+				const operationId = generateStateId( selectedSite.id, remoteSiteId );
+				const result = await getIpcApi().exportSiteToPush( selectedSite.id, operationId, {
 					optionsToSync: options?.optionsToSync,
 					specificSelections: options?.specificSelections,
 				} );
@@ -321,5 +325,30 @@ export function useSyncPush( {
 		[ pushStates, isKeyPushing ]
 	);
 
-	return { pushStates, getPushState, pushSite, isAnySitePushing, isSiteIdPushing, clearPushState };
+	const cancelPush = useCallback< CancelPush >(
+		( selectedSiteId, remoteSiteId ) => {
+			const operationId = generateStateId( selectedSiteId, remoteSiteId );
+			getIpcApi().cancelSyncOperation( operationId );
+
+			updatePushState( selectedSiteId, remoteSiteId, {
+				status: pushStatesProgressInfo.cancelled,
+			} );
+
+			getIpcApi().showNotification( {
+				title: __( 'Push cancelled' ),
+				body: __( 'The push operation has been cancelled.' ),
+			} );
+		},
+		[ __, pushStatesProgressInfo.cancelled, updatePushState ]
+	);
+
+	return {
+		pushStates,
+		getPushState,
+		pushSite,
+		isAnySitePushing,
+		isSiteIdPushing,
+		clearPushState,
+		cancelPush,
+	};
 }

--- a/src/hooks/sync-sites/use-sync-push.ts
+++ b/src/hooks/sync-sites/use-sync-push.ts
@@ -82,6 +82,7 @@ export function useSyncPush( {
 		isKeyImporting,
 		isKeyFinished,
 		isKeyFailed,
+		isKeyCancelled,
 		getPushStatusWithProgress,
 	} = useSyncStatesProgressInfo();
 
@@ -90,13 +91,13 @@ export function useSyncPush( {
 			updateState( selectedSiteId, remoteSiteId, state );
 			const statusKey = state.status?.key;
 
-			if ( isKeyFailed( statusKey ) || isKeyFinished( statusKey ) ) {
+			if ( isKeyFailed( statusKey ) || isKeyFinished( statusKey ) || isKeyCancelled( statusKey ) ) {
 				getIpcApi().clearSyncOperation( generateStateId( selectedSiteId, remoteSiteId ) );
 			} else {
 				getIpcApi().addSyncOperation( generateStateId( selectedSiteId, remoteSiteId ) );
 			}
 		},
-		[ isKeyFailed, isKeyFinished, updateState ]
+		[ isKeyFailed, isKeyFinished, isKeyCancelled, updateState ]
 	);
 
 	const clearPushState = useCallback< ClearState >(
@@ -110,6 +111,11 @@ export function useSyncPush( {
 	const getPushProgressInfo = useCallback(
 		async ( remoteSiteId: number, syncPushState: SyncPushState ) => {
 			if ( ! client ) {
+				return;
+			}
+			const currentState = getPushState( syncPushState.selectedSite.id, remoteSiteId );
+
+			if ( isKeyCancelled( currentState?.status.key ) ) {
 				return;
 			}
 
@@ -157,6 +163,7 @@ export function useSyncPush( {
 		[
 			__,
 			client,
+			getPushState,
 			getPushStatusWithProgress,
 			onPushSuccess,
 			pushStatesProgressInfo.applyingChanges,
@@ -165,6 +172,7 @@ export function useSyncPush( {
 			pushStatesProgressInfo.failed,
 			pushStatesProgressInfo.finished,
 			updatePushState,
+			isKeyCancelled,
 		]
 	);
 
@@ -191,6 +199,9 @@ export function useSyncPush( {
 			}
 			const remoteSiteId = connectedSite.id;
 			const remoteSiteUrl = connectedSite.url;
+			const operationId = generateStateId( selectedSite.id, remoteSiteId );
+
+			clearPushState( selectedSite.id, remoteSiteId );
 			updatePushState( selectedSite.id, remoteSiteId, {
 				remoteSiteId,
 				status: pushStatesProgressInfo.creatingBackup,
@@ -201,13 +212,19 @@ export function useSyncPush( {
 			let archiveContent, archivePath, archiveSizeInBytes;
 
 			try {
-				const operationId = generateStateId( selectedSite.id, remoteSiteId );
 				const result = await getIpcApi().exportSiteToPush( selectedSite.id, operationId, {
 					optionsToSync: options?.optionsToSync,
 					specificSelections: options?.specificSelections,
 				} );
 				( { archiveContent, archivePath, archiveSizeInBytes } = result );
 			} catch ( error ) {
+				if ( error instanceof Error && error.message === 'Export aborted' ) {
+					updatePushState( selectedSite.id, remoteSiteId, {
+						status: pushStatesProgressInfo.cancelled,
+					} );
+					return;
+				}
+
 				Sentry.captureException( error );
 				updatePushState( selectedSite.id, remoteSiteId, {
 					status: pushStatesProgressInfo.failed,
@@ -236,6 +253,13 @@ export function useSyncPush( {
 				return;
 			}
 
+			// Check if cancelled before starting upload
+			const stateBeforeUpload = getPushState( selectedSite.id, remoteSiteId );
+
+			if ( isKeyCancelled( stateBeforeUpload?.status.key ) ) {
+				return;
+			}
+
 			updatePushState( selectedSite.id, remoteSiteId, {
 				status: pushStatesProgressInfo.uploading,
 			} );
@@ -260,6 +284,14 @@ export function useSyncPush( {
 				} ) ) as {
 					success: boolean;
 				};
+
+				// Check if cancelled after upload
+				const stateAfterUpload = getPushState( selectedSite.id, remoteSiteId );
+
+				if ( isKeyCancelled( stateAfterUpload?.status.key ) ) {
+					return;
+				}
+
 				if ( response.success ) {
 					updatePushState( selectedSite.id, remoteSiteId, {
 						status: pushStatesProgressInfo.creatingRemoteBackup,
@@ -281,13 +313,26 @@ export function useSyncPush( {
 				await getIpcApi().removeTemporalFile( archivePath );
 			}
 		},
-		[ __, client, pushStatesProgressInfo, updatePushState, getErrorFromResponse ]
+		[
+			__,
+			clearPushState,
+			client,
+			getPushState,
+			pushStatesProgressInfo,
+			updatePushState,
+			getErrorFromResponse,
+			isKeyCancelled,
+		]
 	);
 
 	useEffect( () => {
 		const intervals: Record< string, NodeJS.Timeout > = {};
 
 		Object.entries( pushStates ).forEach( ( [ key, state ] ) => {
+			if ( isKeyCancelled( state.status.key ) ) {
+				return;
+			}
+
 			if ( isKeyImporting( state.status.key ) ) {
 				intervals[ key ] = setTimeout( () => {
 					void getPushProgressInfo( state.remoteSiteId, state );
@@ -304,6 +349,7 @@ export function useSyncPush( {
 		pushStatesProgressInfo.creatingBackup.key,
 		pushStatesProgressInfo.applyingChanges.key,
 		isKeyImporting,
+		isKeyCancelled,
 	] );
 
 	const isAnySitePushing = useMemo< boolean >( () => {
@@ -313,6 +359,9 @@ export function useSyncPush( {
 	const isSiteIdPushing = useCallback< IsSiteIdPushing >(
 		( selectedSiteId, remoteSiteId ) => {
 			return Object.values( pushStates ).some( ( state ) => {
+				if ( ! state.selectedSite ) {
+					return false;
+				}
 				if ( state.selectedSite.id !== selectedSiteId ) {
 					return false;
 				}
@@ -326,9 +375,9 @@ export function useSyncPush( {
 	);
 
 	const cancelPush = useCallback< CancelPush >(
-		( selectedSiteId, remoteSiteId ) => {
+		async ( selectedSiteId, remoteSiteId ) => {
 			const operationId = generateStateId( selectedSiteId, remoteSiteId );
-			getIpcApi().cancelSyncOperation( operationId );
+			await getIpcApi().cancelSyncOperation( operationId );
 
 			updatePushState( selectedSiteId, remoteSiteId, {
 				status: pushStatesProgressInfo.cancelled,

--- a/src/hooks/sync-sites/use-sync-push.ts
+++ b/src/hooks/sync-sites/use-sync-push.ts
@@ -253,7 +253,6 @@ export function useSyncPush( {
 				return;
 			}
 
-			// Check if cancelled before starting upload
 			const stateBeforeUpload = getPushState( selectedSite.id, remoteSiteId );
 
 			if ( isKeyCancelled( stateBeforeUpload?.status.key ) ) {
@@ -285,7 +284,6 @@ export function useSyncPush( {
 					success: boolean;
 				};
 
-				// Check if cancelled after upload
 				const stateAfterUpload = getPushState( selectedSite.id, remoteSiteId );
 
 				if ( isKeyCancelled( stateAfterUpload?.status.key ) ) {

--- a/src/hooks/sync-sites/use-sync-push.ts
+++ b/src/hooks/sync-sites/use-sync-push.ts
@@ -115,7 +115,7 @@ export function useSyncPush( {
 			}
 			const currentState = getPushState( syncPushState.selectedSite.id, remoteSiteId );
 
-			if ( isKeyCancelled( currentState?.status.key ) ) {
+			if ( ! currentState || isKeyCancelled( currentState?.status.key ) ) {
 				return;
 			}
 
@@ -255,7 +255,7 @@ export function useSyncPush( {
 
 			const stateBeforeUpload = getPushState( selectedSite.id, remoteSiteId );
 
-			if ( isKeyCancelled( stateBeforeUpload?.status.key ) ) {
+			if ( ! stateBeforeUpload || isKeyCancelled( stateBeforeUpload?.status.key ) ) {
 				return;
 			}
 

--- a/src/hooks/use-sync-states-progress-info.ts
+++ b/src/hooks/use-sync-states-progress-info.ts
@@ -182,6 +182,13 @@ export function useSyncStatesProgressInfo() {
 		[]
 	);
 
+	const isKeyCancelled = useCallback(
+		( key: PullStateProgressInfo[ 'key' ] | PushStateProgressInfo[ 'key' ] | undefined ) => {
+			return key === 'cancelled';
+		},
+		[]
+	);
+
 	const getBackupStatusWithProgress = useCallback(
 		(
 			hasBackupCompleted: boolean,
@@ -270,33 +277,21 @@ export function useSyncStatesProgressInfo() {
 		]
 	);
 
-	const canCancelPull = useCallback(
-		( key: PullStateProgressInfo[ 'key' ] | undefined ) => {
-			const cancellableStateKeys: PullStateProgressInfo[ 'key' ][] = [
-				'in-progress',
-				'downloading',
-			];
-			if ( ! key ) {
-				return false;
-			}
-			return cancellableStateKeys.includes( key );
-		},
-		[]
-	);
+	const canCancelPull = useCallback( ( key: PullStateProgressInfo[ 'key' ] | undefined ) => {
+		const cancellableStateKeys: PullStateProgressInfo[ 'key' ][] = [ 'in-progress', 'downloading' ];
+		if ( ! key ) {
+			return false;
+		}
+		return cancellableStateKeys.includes( key );
+	}, [] );
 
-	const canCancelPush = useCallback(
-		( key: PushStateProgressInfo[ 'key' ] | undefined ) => {
-			const cancellableStateKeys: PushStateProgressInfo[ 'key' ][] = [
-				'creatingBackup',
-				'uploading',
-			];
-			if ( ! key ) {
-				return false;
-			}
-			return cancellableStateKeys.includes( key );
-		},
-		[]
-	);
+	const canCancelPush = useCallback( ( key: PushStateProgressInfo[ 'key' ] | undefined ) => {
+		const cancellableStateKeys: PushStateProgressInfo[ 'key' ][] = [ 'creatingBackup' ];
+		if ( ! key ) {
+			return false;
+		}
+		return cancellableStateKeys.includes( key );
+	}, [] );
 
 	return {
 		pullStatesProgressInfo,
@@ -306,6 +301,7 @@ export function useSyncStatesProgressInfo() {
 		isKeyImporting,
 		isKeyFinished,
 		isKeyFailed,
+		isKeyCancelled,
 		getBackupStatusWithProgress,
 		getPullStatusWithProgress,
 		getPushStatusWithProgress,

--- a/src/hooks/use-sync-states-progress-info.ts
+++ b/src/hooks/use-sync-states-progress-info.ts
@@ -15,7 +15,8 @@ export type PushStateProgressInfo = {
 		| 'applyingChanges'
 		| 'finishing'
 		| 'finished'
-		| 'failed';
+		| 'failed'
+		| 'cancelled';
 	progress: number;
 	message: string;
 };
@@ -121,6 +122,11 @@ export function useSyncStatesProgressInfo() {
 				key: 'failed',
 				progress: 100,
 				message: __( 'Error pushing changes' ),
+			},
+			cancelled: {
+				key: 'cancelled',
+				progress: 0,
+				message: __( 'Cancelled' ),
 			},
 		} as const satisfies PushStateProgressInfoValues;
 	}, [ __ ] );
@@ -264,6 +270,34 @@ export function useSyncStatesProgressInfo() {
 		]
 	);
 
+	const canCancelPull = useCallback(
+		( key: PullStateProgressInfo[ 'key' ] | undefined ) => {
+			const cancellableStateKeys: PullStateProgressInfo[ 'key' ][] = [
+				'in-progress',
+				'downloading',
+			];
+			if ( ! key ) {
+				return false;
+			}
+			return cancellableStateKeys.includes( key );
+		},
+		[]
+	);
+
+	const canCancelPush = useCallback(
+		( key: PushStateProgressInfo[ 'key' ] | undefined ) => {
+			const cancellableStateKeys: PushStateProgressInfo[ 'key' ][] = [
+				'creatingBackup',
+				'uploading',
+			];
+			if ( ! key ) {
+				return false;
+			}
+			return cancellableStateKeys.includes( key );
+		},
+		[]
+	);
+
 	return {
 		pullStatesProgressInfo,
 		pushStatesProgressInfo,
@@ -275,5 +309,7 @@ export function useSyncStatesProgressInfo() {
 		getBackupStatusWithProgress,
 		getPullStatusWithProgress,
 		getPushStatusWithProgress,
+		canCancelPull,
+		canCancelPush,
 	};
 }

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -37,6 +37,12 @@ import { StatsGroup, StatsMetric } from 'common/types/stats';
 import { ARCHIVER_OPTIONS, DEFAULT_TERMINAL, MAIN_MIN_WIDTH, SIDEBAR_WIDTH } from 'src/constants';
 import { sendIpcEventToRenderer, sendIpcEventToRendererWithWindow } from 'src/ipc-utils';
 import { ACTIVE_SYNC_OPERATIONS } from 'src/lib/active-sync-operations';
+
+/**
+ * Registry to store AbortControllers for ongoing sync operations (push/pull).
+ * Key format: `${selectedSiteId}-${remoteSiteId}`
+ */
+const SYNC_ABORT_CONTROLLERS = new Map< string, AbortController >();
 import { scanBlueprintForUnsupportedFeatures } from 'src/lib/blueprint-features';
 import { bumpStat } from 'src/lib/bump-stats';
 import { getImporterMetric, getBlueprintMetric } from 'src/lib/bump-stats/lib';
@@ -699,6 +705,7 @@ export async function archiveSite( event: IpcMainInvokeEvent, id: string, format
 export async function exportSiteToPush(
 	event: IpcMainInvokeEvent,
 	id: string,
+	operationId: string,
 	configuration?: {
 		optionsToSync?: SyncOption[];
 		specificSelections?: {
@@ -715,36 +722,58 @@ export async function exportSiteToPush(
 	const extension = 'tar.gz';
 	const archivePath = `${ TEMP_DIR }site_${ id }.${ extension }`;
 
-	const shouldIncludeSyncOption = (
-		optionsToSync: SyncOption[] | undefined,
-		option: SyncOption
-	): boolean => {
-		return optionsToSync?.includes( option ) || optionsToSync?.includes( 'all' ) || ! optionsToSync;
-	};
+	// Create and register AbortController for this operation
+	const abortController = new AbortController();
+	SYNC_ABORT_CONTROLLERS.set( operationId, abortController );
 
-	const includes = {
-		database: shouldIncludeSyncOption( configuration?.optionsToSync, 'sqls' ),
-		uploads: shouldIncludeSyncOption( configuration?.optionsToSync, 'uploads' ),
-		plugins: shouldIncludeSyncOption( configuration?.optionsToSync, 'plugins' ),
-		themes: shouldIncludeSyncOption( configuration?.optionsToSync, 'themes' ),
-		muPlugins: shouldIncludeSyncOption( configuration?.optionsToSync, 'contents' ),
-		fonts: shouldIncludeSyncOption( configuration?.optionsToSync, 'contents' ),
-	};
+	try {
+		// Check if already aborted before starting
+		if ( abortController.signal.aborted ) {
+			throw new Error( 'Export aborted' );
+		}
 
-	const exportOptions: ExportOptions = {
-		site: site.details,
-		backupFile: archivePath,
-		includes,
-		phpVersion: site.details.phpVersion,
-		splitDatabaseDumpByTable: true,
-		specificSelections: configuration?.specificSelections,
-	};
-	// eslint-disable-next-line @typescript-eslint/no-empty-function
-	const onEvent = () => {};
-	await exportBackup( exportOptions, onEvent );
-	const stats = fs.statSync( archivePath );
-	const archiveContent = fs.readFileSync( archivePath );
-	return { archivePath, archiveContent, archiveSizeInBytes: stats.size };
+		const shouldIncludeSyncOption = (
+			optionsToSync: SyncOption[] | undefined,
+			option: SyncOption
+		): boolean => {
+			return optionsToSync?.includes( option ) || optionsToSync?.includes( 'all' ) || ! optionsToSync;
+		};
+
+		const includes = {
+			database: shouldIncludeSyncOption( configuration?.optionsToSync, 'sqls' ),
+			uploads: shouldIncludeSyncOption( configuration?.optionsToSync, 'uploads' ),
+			plugins: shouldIncludeSyncOption( configuration?.optionsToSync, 'plugins' ),
+			themes: shouldIncludeSyncOption( configuration?.optionsToSync, 'themes' ),
+			muPlugins: shouldIncludeSyncOption( configuration?.optionsToSync, 'contents' ),
+			fonts: shouldIncludeSyncOption( configuration?.optionsToSync, 'contents' ),
+		};
+
+		const exportOptions: ExportOptions = {
+			site: site.details,
+			backupFile: archivePath,
+			includes,
+			phpVersion: site.details.phpVersion,
+			splitDatabaseDumpByTable: true,
+			specificSelections: configuration?.specificSelections,
+		};
+		// eslint-disable-next-line @typescript-eslint/no-empty-function
+		const onEvent = () => {};
+		await exportBackup( exportOptions, onEvent );
+
+		// Check if aborted after export completes
+		if ( abortController.signal.aborted ) {
+			await fsPromises.unlink( archivePath ).catch( () => {
+				// Ignore cleanup errors
+			} );
+			throw new Error( 'Export aborted' );
+		}
+
+		const stats = fs.statSync( archivePath );
+		const archiveContent = fs.readFileSync( archivePath );
+		return { archivePath, archiveContent, archiveSizeInBytes: stats.size };
+	} finally {
+		SYNC_ABORT_CONTROLLERS.delete( operationId );
+	}
 }
 
 export function removeTemporalFile( event: IpcMainInvokeEvent, path: string ) {
@@ -1254,14 +1283,24 @@ export async function openFileInIDE(
 export async function downloadSyncBackup(
 	event: Electron.IpcMainInvokeEvent,
 	remoteSiteId: number,
-	downloadUrl: string
+	downloadUrl: string,
+	operationId: string
 ) {
 	const tmpDir = nodePath.join( app.getPath( 'temp' ), 'wp-studio-backups' );
 	await fsPromises.mkdir( tmpDir, { recursive: true } );
 
 	const filePath = getSyncBackupTempPath( remoteSiteId );
-	await download( downloadUrl, filePath );
-	return filePath;
+
+	// Create and register AbortController for this operation
+	const abortController = new AbortController();
+	SYNC_ABORT_CONTROLLERS.set( operationId, abortController );
+
+	try {
+		await download( downloadUrl, filePath, false, '', abortController.signal );
+		return filePath;
+	} finally {
+		SYNC_ABORT_CONTROLLERS.delete( operationId );
+	}
 }
 
 export async function removeSyncBackup( event: IpcMainInvokeEvent, remoteSiteId: number ) {
@@ -1288,6 +1327,19 @@ export function addSyncOperation( event: IpcMainInvokeEvent, id: string ) {
  * Clear the ID of a push/pull operation.
  */
 export function clearSyncOperation( event: IpcMainInvokeEvent, id: string ) {
+	ACTIVE_SYNC_OPERATIONS.delete( id );
+	SYNC_ABORT_CONTROLLERS.delete( id );
+}
+
+/**
+ * Cancel an ongoing push/pull operation by triggering its AbortController.
+ */
+export function cancelSyncOperation( event: IpcMainInvokeEvent, id: string ) {
+	const abortController = SYNC_ABORT_CONTROLLERS.get( id );
+	if ( abortController ) {
+		abortController.abort();
+		SYNC_ABORT_CONTROLLERS.delete( id );
+	}
 	ACTIVE_SYNC_OPERATIONS.delete( id );
 }
 

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -37,12 +37,6 @@ import { StatsGroup, StatsMetric } from 'common/types/stats';
 import { ARCHIVER_OPTIONS, DEFAULT_TERMINAL, MAIN_MIN_WIDTH, SIDEBAR_WIDTH } from 'src/constants';
 import { sendIpcEventToRenderer, sendIpcEventToRendererWithWindow } from 'src/ipc-utils';
 import { ACTIVE_SYNC_OPERATIONS } from 'src/lib/active-sync-operations';
-
-/**
- * Registry to store AbortControllers for ongoing sync operations (push/pull).
- * Key format: `${selectedSiteId}-${remoteSiteId}`
- */
-const SYNC_ABORT_CONTROLLERS = new Map< string, AbortController >();
 import { scanBlueprintForUnsupportedFeatures } from 'src/lib/blueprint-features';
 import { bumpStat } from 'src/lib/bump-stats';
 import { getImporterMetric, getBlueprintMetric } from 'src/lib/bump-stats/lib';
@@ -99,6 +93,12 @@ import type { SyncSite } from 'src/hooks/use-fetch-wpcom-sites/types';
 import type { WpCliResult } from 'src/lib/wp-cli-process';
 import type { GranularSyncFolders } from 'src/modules/sync/types';
 import type { SyncOption } from 'src/types';
+
+/**
+ * Registry to store AbortControllers for ongoing sync operations (push/pull).
+ * Key format: `${selectedSiteId}-${remoteSiteId}`
+ */
+const SYNC_ABORT_CONTROLLERS = new Map< string, AbortController >();
 
 const TEMP_DIR = nodePath.join( app.getPath( 'temp' ), 'com.wordpress.studio' ) + nodePath.sep;
 if ( ! fs.existsSync( TEMP_DIR ) ) {
@@ -727,7 +727,6 @@ export async function exportSiteToPush(
 	SYNC_ABORT_CONTROLLERS.set( operationId, abortController );
 
 	try {
-		// Check if already aborted before starting
 		if ( abortController.signal.aborted ) {
 			throw new Error( 'Export aborted' );
 		}
@@ -736,7 +735,9 @@ export async function exportSiteToPush(
 			optionsToSync: SyncOption[] | undefined,
 			option: SyncOption
 		): boolean => {
-			return optionsToSync?.includes( option ) || optionsToSync?.includes( 'all' ) || ! optionsToSync;
+			return (
+				optionsToSync?.includes( option ) || optionsToSync?.includes( 'all' ) || ! optionsToSync
+			);
 		};
 
 		const includes = {
@@ -1298,6 +1299,13 @@ export async function downloadSyncBackup(
 	try {
 		await download( downloadUrl, filePath, false, '', abortController.signal );
 		return filePath;
+	} catch ( error ) {
+		if ( error instanceof Error && error.name === 'AbortError' ) {
+			// Download was cancelled, throw the error
+		} else {
+			console.error( `[Download] Download failed for operation: ${ operationId }`, error );
+		}
+		throw error;
 	} finally {
 		SYNC_ABORT_CONTROLLERS.delete( operationId );
 	}
@@ -1331,9 +1339,6 @@ export function clearSyncOperation( event: IpcMainInvokeEvent, id: string ) {
 	SYNC_ABORT_CONTROLLERS.delete( id );
 }
 
-/**
- * Cancel an ongoing push/pull operation by triggering its AbortController.
- */
 export function cancelSyncOperation( event: IpcMainInvokeEvent, id: string ) {
 	const abortController = SYNC_ABORT_CONTROLLERS.get( id );
 	if ( abortController ) {

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -722,7 +722,6 @@ export async function exportSiteToPush(
 	const extension = 'tar.gz';
 	const archivePath = `${ TEMP_DIR }site_${ id }.${ extension }`;
 
-	// Create and register AbortController for this operation
 	const abortController = new AbortController();
 	SYNC_ABORT_CONTROLLERS.set( operationId, abortController );
 
@@ -761,7 +760,6 @@ export async function exportSiteToPush(
 		const onEvent = () => {};
 		await exportBackup( exportOptions, onEvent );
 
-		// Check if aborted after export completes
 		if ( abortController.signal.aborted ) {
 			await fsPromises.unlink( archivePath ).catch( () => {
 				// Ignore cleanup errors
@@ -1292,7 +1290,6 @@ export async function downloadSyncBackup(
 
 	const filePath = getSyncBackupTempPath( remoteSiteId );
 
-	// Create and register AbortController for this operation
 	const abortController = new AbortController();
 	SYNC_ABORT_CONTROLLERS.set( operationId, abortController );
 

--- a/src/lib/download.ts
+++ b/src/lib/download.ts
@@ -1,11 +1,17 @@
 import { https } from 'follow-redirects';
 import fs from 'fs-extra';
 
-export async function download( url: string, filePath: string, showProgress = false, name = '' ) {
+export async function download(
+	url: string,
+	filePath: string,
+	showProgress = false,
+	name = '',
+	signal?: AbortSignal
+) {
 	const file = fs.createWriteStream( filePath );
 
 	await new Promise< void >( ( resolve, reject ) => {
-		https.get( url, ( response ) => {
+		const request = https.get( url, ( response ) => {
 			if ( response.statusCode !== 200 ) {
 				reject( new Error( `Request failed with status code: ${ response.statusCode }` ) );
 				return;
@@ -33,6 +39,25 @@ export async function download( url: string, filePath: string, showProgress = fa
 				file.close( () => resolve() );
 			} );
 			response.on( 'error', ( err ) => reject( err ) );
+		} );
+
+		if ( signal ) {
+			signal.addEventListener( 'abort', () => {
+				request.destroy();
+				file.close();
+				fs.remove( filePath ).catch( () => {
+					// Ignore errors during cleanup
+				} );
+				reject( new Error( 'Download aborted' ) );
+			} );
+		}
+
+		request.on( 'error', ( err ) => {
+			file.close();
+			fs.remove( filePath ).catch( () => {
+				// Ignore errors during cleanup
+			} );
+			reject( err );
 		} );
 	} );
 }

--- a/src/modules/sync/components/sync-connected-sites.tsx
+++ b/src/modules/sync/components/sync-connected-sites.tsx
@@ -215,6 +215,7 @@ const SyncConnectedSitesList = ( {
 				const isPushing = pushState && isKeyPushing( pushState.status.key );
 				const isPushError = pushState && isKeyFailed( pushState.status.key );
 				const hasPushFinished = pushState && isKeyFinished( pushState.status.key );
+				const hasPushCancelled = pushState && isKeyCancelled( pushState.status.key );
 
 				return (
 					<div
@@ -242,8 +243,8 @@ const SyncConnectedSitesList = ( {
 
 						<div className="flex shrink-0 justify-self-end">
 							{ isPulling && (
-								<div className="flex items-center gap-2">
-									<div className="flex flex-col gap-2 min-w-44">
+								<div className="flex items-center gap-2 max-w-full">
+									<div className="flex flex-col gap-2 min-w-44 flex-shrink">
 										<div className="a8c-body-small">{ sitePullStatusMessage }</div>
 										<ProgressBar value={ sitePullStatusProgress } maxValue={ 100 } />
 									</div>
@@ -259,7 +260,7 @@ const SyncConnectedSitesList = ( {
 											variant="link"
 											onClick={ () => cancelPull( selectedSite.id, connectedSite.id ) }
 											disabled={ ! canCancelPull( sitePullState?.status.key ) }
-											className="!p-0"
+											className="!p-0 flex-shrink-0"
 										>
 											<Icon icon={ close } size={ 20 } />
 										</Button>
@@ -293,14 +294,14 @@ const SyncConnectedSitesList = ( {
 								</ClearAction>
 							) }
 							{ pushState?.status && isPushing && (
-								<div className="flex items-center gap-2">
+								<div className="flex items-center gap-2 max-w-full">
 									<Tooltip
 										text={ __(
 											'Push is in progress. We will send you an email when it is completed.'
 										) }
 										placement="top-start"
 									>
-										<div className="flex flex-col gap-2 min-w-44">
+										<div className="flex flex-col gap-2 min-w-44 flex-shrink">
 											<div className="a8c-body-small flex items-center gap-0.5">
 												<Icon icon={ info } size={ 16 } />
 												{ pushState.status.message }
@@ -320,14 +321,14 @@ const SyncConnectedSitesList = ( {
 											variant="link"
 											onClick={ () => cancelPush( selectedSite.id, connectedSite.id ) }
 											disabled={ ! canCancelPush( pushState?.status.key ) }
-											className="!p-0"
+											className="!p-0 flex-shrink-0"
 										>
 											<Icon icon={ close } size={ 20 } />
 										</Button>
 									</Tooltip>
 								</div>
 							) }
-							{ pushState?.status && hasPullCancelled && (
+							{ pushState?.status && hasPushCancelled && (
 								<ClearAction onClick={ () => clearPushState( selectedSite.id, connectedSite.id ) }>
 									{ __( 'Push cancelled' ) }
 								</ClearAction>
@@ -344,7 +345,8 @@ const SyncConnectedSitesList = ( {
 								! isPushError &&
 								! isPushing &&
 								! hasPushFinished &&
-								! hasPullCancelled && (
+								! hasPullCancelled &&
+								! hasPushCancelled && (
 									<SyncConnectedSiteControls
 										connectedSite={ connectedSite }
 										selectedSite={ selectedSite }

--- a/src/modules/sync/components/sync-connected-sites.tsx
+++ b/src/modules/sync/components/sync-connected-sites.tsx
@@ -1,7 +1,7 @@
 import { Icon } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
-import { cloudUpload, cloudDownload, info } from '@wordpress/icons';
+import { cloudUpload, cloudDownload, info, close } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { useState, useMemo } from 'react';
 import { ArrowIcon } from 'src/components/arrow-icon';
@@ -183,10 +183,18 @@ const SyncConnectedSitesList = ( {
 	connectedSites,
 }: SyncConnectedSitesListProps ) => {
 	const { __ } = useI18n();
-	const { clearPullState, getPullState, getPushState, clearPushState } = useSyncSites();
+	const { clearPullState, getPullState, getPushState, clearPushState, cancelPull, cancelPush } =
+		useSyncSites();
 	const { importState } = useImportExport();
-	const { isKeyPulling, isKeyPushing, isKeyFinished, isKeyFailed, getPullStatusWithProgress } =
-		useSyncStatesProgressInfo();
+	const {
+		isKeyPulling,
+		isKeyPushing,
+		isKeyFinished,
+		isKeyFailed,
+		getPullStatusWithProgress,
+		canCancelPull,
+		canCancelPush,
+	} = useSyncStatesProgressInfo();
 
 	return (
 		<div className="grid grid-cols-[max-content_1fr_max-content]">
@@ -232,10 +240,34 @@ const SyncConnectedSitesList = ( {
 
 						<div className="flex shrink-0 justify-self-end">
 							{ isPulling && (
-								<div className="flex flex-col gap-2 min-w-44">
-									<div className="a8c-body-small">{ sitePullStatusMessage }</div>
-									<ProgressBar value={ sitePullStatusProgress } maxValue={ 100 } />
+								<div className="flex items-center gap-2">
+									<div className="flex flex-col gap-2 min-w-44">
+										<div className="a8c-body-small">{ sitePullStatusMessage }</div>
+										<ProgressBar value={ sitePullStatusProgress } maxValue={ 100 } />
+									</div>
+									<Tooltip
+										text={
+											canCancelPull( sitePullState?.status.key )
+												? __( 'Cancel pull' )
+												: __( 'Cannot cancel while importing changes to your local site' )
+										}
+										placement="top-start"
+									>
+										<Button
+											variant="link"
+											onClick={ () => cancelPull( selectedSite.id, connectedSite.id ) }
+											disabled={ ! canCancelPull( sitePullState?.status.key ) }
+											className="!p-0"
+										>
+											<Icon icon={ close } size={ 20 } />
+										</Button>
+									</Tooltip>
 								</div>
+							) }
+							{ sitePullState?.status.key === 'cancelled' && (
+								<ClearAction onClick={ () => clearPullState( selectedSite.id, connectedSite.id ) }>
+									{ __( 'Pull cancelled' ) }
+								</ClearAction>
 							) }
 							{ isPullError && (
 								<ClearAction
@@ -259,20 +291,44 @@ const SyncConnectedSitesList = ( {
 								</ClearAction>
 							) }
 							{ pushState?.status && isPushing && (
-								<Tooltip
-									text={ __(
-										'Push is in progress. We will send you an email when it is completed.'
-									) }
-									placement="top-start"
-								>
-									<div className="flex flex-col gap-2 min-w-44">
-										<div className="a8c-body-small flex items-center gap-0.5">
-											<Icon icon={ info } size={ 16 } />
-											{ pushState.status.message }
+								<div className="flex items-center gap-2">
+									<Tooltip
+										text={ __(
+											'Push is in progress. We will send you an email when it is completed.'
+										) }
+										placement="top-start"
+									>
+										<div className="flex flex-col gap-2 min-w-44">
+											<div className="a8c-body-small flex items-center gap-0.5">
+												<Icon icon={ info } size={ 16 } />
+												{ pushState.status.message }
+											</div>
+											<ProgressBar value={ pushState.status.progress } maxValue={ 100 } />
 										</div>
-										<ProgressBar value={ pushState.status.progress } maxValue={ 100 } />
-									</div>
-								</Tooltip>
+									</Tooltip>
+									<Tooltip
+										text={
+											canCancelPush( pushState?.status.key )
+												? __( 'Cancel push' )
+												: __( 'Cannot cancel while applying changes to the remote site' )
+										}
+										placement="top-start"
+									>
+										<Button
+											variant="link"
+											onClick={ () => cancelPush( selectedSite.id, connectedSite.id ) }
+											disabled={ ! canCancelPush( pushState?.status.key ) }
+											className="!p-0"
+										>
+											<Icon icon={ close } size={ 20 } />
+										</Button>
+									</Tooltip>
+								</div>
+							) }
+							{ pushState?.status.key === 'cancelled' && (
+								<ClearAction onClick={ () => clearPushState( selectedSite.id, connectedSite.id ) }>
+									{ __( 'Push cancelled' ) }
+								</ClearAction>
 							) }
 
 							{ pushState?.status && hasPushFinished && (

--- a/src/modules/sync/components/sync-connected-sites.tsx
+++ b/src/modules/sync/components/sync-connected-sites.tsx
@@ -316,7 +316,7 @@ const SyncConnectedSitesList = ( {
 											canCancelPush( pushState?.status.key )
 												? __( 'Cancel push' )
 												: __(
-														'Push can not be cancelled while importing changes to your local site'
+														'Push can not be cancelled while applying changes to the remote site'
 												  )
 										}
 										placement="top-start"

--- a/src/modules/sync/components/sync-connected-sites.tsx
+++ b/src/modules/sync/components/sync-connected-sites.tsx
@@ -252,7 +252,9 @@ const SyncConnectedSitesList = ( {
 										text={
 											canCancelPull( sitePullState?.status.key )
 												? __( 'Cancel pull' )
-												: __( 'Cannot cancel while importing changes to your local site' )
+												: __(
+														'Pull can not be cancelled while importing changes to your local site'
+												  )
 										}
 										placement="top-start"
 									>
@@ -313,7 +315,9 @@ const SyncConnectedSitesList = ( {
 										text={
 											canCancelPush( pushState?.status.key )
 												? __( 'Cancel push' )
-												: __( 'Cannot cancel while applying changes to the remote site' )
+												: __(
+														'Push can not be cancelled while importing changes to your local site'
+												  )
 										}
 										placement="top-start"
 									>

--- a/src/modules/sync/components/sync-connected-sites.tsx
+++ b/src/modules/sync/components/sync-connected-sites.tsx
@@ -191,6 +191,7 @@ const SyncConnectedSitesList = ( {
 		isKeyPushing,
 		isKeyFinished,
 		isKeyFailed,
+		isKeyCancelled,
 		getPullStatusWithProgress,
 		canCancelPull,
 		canCancelPush,
@@ -203,6 +204,7 @@ const SyncConnectedSitesList = ( {
 				const isPulling = sitePullState && isKeyPulling( sitePullState.status.key );
 				const isPullError = sitePullState && isKeyFailed( sitePullState.status.key );
 				const hasPullFinished = sitePullState && isKeyFinished( sitePullState.status.key );
+				const hasPullCancelled = sitePullState && isKeyCancelled( sitePullState.status.key );
 				const { message: sitePullStatusMessage, progress: sitePullStatusProgress } =
 					getPullStatusWithProgress(
 						sitePullState?.status,
@@ -264,7 +266,7 @@ const SyncConnectedSitesList = ( {
 									</Tooltip>
 								</div>
 							) }
-							{ sitePullState?.status.key === 'cancelled' && (
+							{ sitePullState?.status && hasPullCancelled && (
 								<ClearAction onClick={ () => clearPullState( selectedSite.id, connectedSite.id ) }>
 									{ __( 'Pull cancelled' ) }
 								</ClearAction>
@@ -325,7 +327,7 @@ const SyncConnectedSitesList = ( {
 									</Tooltip>
 								</div>
 							) }
-							{ pushState?.status.key === 'cancelled' && (
+							{ pushState?.status && hasPullCancelled && (
 								<ClearAction onClick={ () => clearPushState( selectedSite.id, connectedSite.id ) }>
 									{ __( 'Push cancelled' ) }
 								</ClearAction>
@@ -341,7 +343,8 @@ const SyncConnectedSitesList = ( {
 								! isPullError &&
 								! isPushError &&
 								! isPushing &&
-								! hasPushFinished && (
+								! hasPushFinished &&
+								! hasPullCancelled && (
 									<SyncConnectedSiteControls
 										connectedSite={ connectedSite }
 										selectedSite={ selectedSite }

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -22,8 +22,8 @@ function ipcRendererSend< T extends keyof IpcHandlers >(
 
 const api: IpcApi = {
 	archiveSite: ( id, format ) => ipcRendererInvoke( 'archiveSite', id, format ),
-	exportSiteToPush: ( id, configuration ) =>
-		ipcRendererInvoke( 'exportSiteToPush', id, configuration ),
+	exportSiteToPush: ( id, operationId, configuration ) =>
+		ipcRendererInvoke( 'exportSiteToPush', id, operationId, configuration ),
 	deleteSite: ( id, deleteFiles ) => ipcRendererInvoke( 'deleteSite', id, deleteFiles ),
 	createSite: ( path, config ) => ipcRendererInvoke( 'createSite', path, config ),
 	updateSite: ( updatedSite ) => ipcRendererInvoke( 'updateSite', updatedSite ),
@@ -99,13 +99,14 @@ const api: IpcApi = {
 		ipcRendererSend( 'openFileInIDE', relativePath, siteId ),
 	isImportExportSupported: ( siteId ) => ipcRendererInvoke( 'isImportExportSupported', siteId ),
 	checkSyncBackupSize: ( downloadUrl ) => ipcRendererInvoke( 'checkSyncBackupSize', downloadUrl ),
-	downloadSyncBackup: ( remoteSiteId, downloadUrl ) =>
-		ipcRendererInvoke( 'downloadSyncBackup', remoteSiteId, downloadUrl ),
+	downloadSyncBackup: ( remoteSiteId, downloadUrl, operationId ) =>
+		ipcRendererInvoke( 'downloadSyncBackup', remoteSiteId, downloadUrl, operationId ),
 	removeSyncBackup: ( remoteSiteId ) => ipcRendererInvoke( 'removeSyncBackup', remoteSiteId ),
 	getConnectedWpcomSites: ( localSiteId ) =>
 		ipcRendererInvoke( 'getConnectedWpcomSites', localSiteId ),
 	addSyncOperation: ( id ) => ipcRendererSend( 'addSyncOperation', id ),
 	clearSyncOperation: ( id ) => ipcRendererSend( 'clearSyncOperation', id ),
+	cancelSyncOperation: ( id ) => ipcRendererSend( 'cancelSyncOperation', id ),
 	getDirectorySize: ( id, subdir ) => ipcRendererInvoke( 'getDirectorySize', id, subdir ),
 	getFileSize: ( id, filePath ) => ipcRendererInvoke( 'getFileSize', id, filePath ),
 	getPathForFile: ( file ) => webUtils.getPathForFile( file ),


### PR DESCRIPTION
## Related issues

- Fixes STU-156

## Proposed Changes

- Add cancel button UI to sync operations
- Push can be canceled during backup creation
- Pull can be cancelled while remote backup creation and download

| Cancel button | Cancelled |
|--------|--------|
| <img width="2396" height="1538" alt="image" src="https://github.com/user-attachments/assets/7f49fc82-0c0c-4593-814e-207bd301be3f" /> | <img width="2396" height="1538" alt="image" src="https://github.com/user-attachments/assets/8efeb331-1eaf-42eb-8df7-caa0fe920e75" /> | 

## Testing Instructions

- Start a push/pull operation from Studio to WordPress.com
- During the sync progress, click the X icon to the right of the progress bar
- Verify the operation cancels
- Test cancellation at different stages of the sync process to ensure it works during safe stages
- Confirm cancellation is disabled after safe stages

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?