### PR TITLE
Studio: Fix classic theme Customize links for Menus and Widgets

### DIFF
--- a/src/lib/php-get-theme-details.ts
+++ b/src/lib/php-get-theme-details.ts
@@ -19,21 +19,6 @@ export async function phpGetThemeDetails(
 	}
 
 	try {
-		// Try to use the persistent mu-plugin API endpoint if available (Playground CLI)
-		if ( server.php.request ) {
-			const response = await server.php.request( {
-				url: '/?studio-admin-api',
-				method: 'POST',
-				body: {
-					action: 'get_theme_details',
-				},
-			} );
-
-			const themeDetailsParsed = JSON.parse( response.text );
-			return themeDetailsSchema.parse( themeDetailsParsed );
-		}
-
-		// Fallback to runPhp for WP-Now
 		const wpLoadPath = getWpLoadPath( server );
 
 		const themeDetailsPhp = `<?php

--- a/src/lib/wordpress-provider/playground-cli/mu-plugins.ts
+++ b/src/lib/wordpress-provider/playground-cli/mu-plugins.ts
@@ -339,18 +339,6 @@ function getStandardMuPlugins( options: Partial< WordPressServerOptions > ): MuP
 			$result = null;
 
 			switch ( $action ) {
-				case 'get_theme_details':
-					$theme = wp_get_theme();
-					$result = [
-						'name' => $theme->get('Name'),
-						'path' => $theme->get_stylesheet_directory(),
-						'slug' => $theme->get_stylesheet(),
-						'isBlockTheme' => $theme->is_block_theme(),
-						'supportsWidgets' => current_theme_supports('widgets'),
-						'supportsMenus' => get_registered_nav_menus() || current_theme_supports('menus'),
-					];
-					break;
-
 				case 'set_admin_password':
 					if ( empty( $_POST['password'] ) ) {
 						status_header( 400 );


### PR DESCRIPTION
## Related issues

- Fixes STU-864

## Proposed Changes

- Fixed theme details fetching to ensure WordPress is fully initialized before reading theme features
- Simplified theme details logic by always using `runPhp` method instead of mu-plugin endpoint
- Removed unused `get_theme_details` action from mu-plugins

## Testing Instructions

- Create a new site with a classic theme (e.g., Twenty Twenty-One or Seedlet)
- Start the site and navigate to the Overview tab
- Verify the theme information displays correctly
- Check that "Customize Menus" and "Customize Widgets" links appear in the Customize section
- Click on the Customize links to verify they work correctly
- Test with both classic themes and block themes

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?