### PR TITLE
Studio: Fix auto-installation for sites created from existing WordPress folders

### DIFF
--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -261,7 +261,7 @@ export async function createSite(
 		}
 		if ( ! ( await pathExists( nodePath.join( path, 'wp-config.php' ) ) ) ) {
 			await installSqliteIntegration( path );
-			await getWordPressProvider().installWordPress(
+			await getWordPressProvider().installWordPressWhenNoWpConfig(
 				server,
 				siteName || nodePath.basename( path ),
 				details.adminPassword

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -261,6 +261,11 @@ export async function createSite(
 		}
 		if ( ! ( await pathExists( nodePath.join( path, 'wp-config.php' ) ) ) ) {
 			await installSqliteIntegration( path );
+			await getWordPressProvider().installWordPress(
+				server,
+				siteName || nodePath.basename( path ),
+				details.adminPassword
+			);
 		} else {
 			await updateSiteUrl( server, getSiteUrl( details ) );
 		}

--- a/src/lib/wordpress-provider/index.ts
+++ b/src/lib/wordpress-provider/index.ts
@@ -73,6 +73,9 @@ export const getWpLoadPath = ( ...args: Parameters< WordPressProvider[ 'getWpLoa
 export const setupWordPressSite = (
 	...args: Parameters< WordPressProvider[ 'setupWordPressSite' ] >
 ) => getWordPressProvider().setupWordPressSite( ...args );
+export const installWordPress = (
+	...args: Parameters< WordPressProvider[ 'installWordPress' ] >
+) => getWordPressProvider().installWordPress( ...args );
 export const startServer = ( ...args: Parameters< WordPressProvider[ 'startServer' ] > ) =>
 	getWordPressProvider().startServer( ...args );
 export const isValidWordPressVersion = (

--- a/src/lib/wordpress-provider/index.ts
+++ b/src/lib/wordpress-provider/index.ts
@@ -73,9 +73,9 @@ export const getWpLoadPath = ( ...args: Parameters< WordPressProvider[ 'getWpLoa
 export const setupWordPressSite = (
 	...args: Parameters< WordPressProvider[ 'setupWordPressSite' ] >
 ) => getWordPressProvider().setupWordPressSite( ...args );
-export const installWordPress = (
-	...args: Parameters< WordPressProvider[ 'installWordPress' ] >
-) => getWordPressProvider().installWordPress( ...args );
+export const installWordPressWhenNoWpConfig = (
+	...args: Parameters< WordPressProvider[ 'installWordPressWhenNoWpConfig' ] >
+) => getWordPressProvider().installWordPressWhenNoWpConfig( ...args );
 export const startServer = ( ...args: Parameters< WordPressProvider[ 'startServer' ] > ) =>
 	getWordPressProvider().startServer( ...args );
 export const isValidWordPressVersion = (

--- a/src/lib/wordpress-provider/playground-cli/playground-cli-provider.ts
+++ b/src/lib/wordpress-provider/playground-cli/playground-cli-provider.ts
@@ -1,4 +1,3 @@
-import fs from 'fs';
 import nodePath from 'path';
 import { SupportedPHPVersions } from '@php-wasm/universal';
 import { Blueprint, StepDefinition } from '@wp-playground/blueprints';
@@ -221,38 +220,34 @@ export class PlaygroundCliProvider implements WordPressProvider {
 		}
 	}
 
+	// Install WordPress if user adds a WordPress folder with no wp-config.php and no database.
 	async installWordPress(
 		server: SiteServer,
 		siteName: string,
 		adminPassword: string
 	): Promise< void > {
 		const { path } = server.details;
-		const dbPath = nodePath.join( path, 'wp-content', 'database', '.ht.sqlite' );
-		let needsInstallation = true;
+		const databaseExists = await pathExists(
+			nodePath.join( path, 'wp-content', 'database', '.ht.sqlite' )
+		);
+		const wpConfigExists = await pathExists( nodePath.join( path, 'wp-config.php' ) );
 
-		try {
-			const stats = await fs.promises.stat( dbPath );
-			// If database exists and is larger than 10KB, WordPress is already installed
-			needsInstallation = stats.size < 10 * 1024;
-		} catch {
-			// Database doesn't exist, needs installation
-			needsInstallation = true;
+		if ( wpConfigExists || databaseExists ) {
+			return;
 		}
 
-		if ( needsInstallation ) {
-			// Add installation blueprint step to auto-install WordPress
-			if ( ! server.meta.blueprint ) {
-				server.meta.blueprint = {};
-			}
-
-			const installationStep = this.createInstallationStep(
-				siteName || nodePath.basename( path ),
-				adminPassword || ''
-			);
-
-			const existingSteps = server.meta.blueprint.steps || [];
-			server.meta.blueprint.steps = [ installationStep, ...existingSteps ];
+		// Add installation blueprint step to auto-install WordPress
+		if ( ! server.meta.blueprint ) {
+			server.meta.blueprint = {};
 		}
+
+		const installationStep = this.createInstallationStep(
+			siteName || nodePath.basename( path ),
+			adminPassword || ''
+		);
+
+		const existingSteps = server.meta.blueprint.steps || [];
+		server.meta.blueprint.steps = [ installationStep, ...existingSteps ];
 	}
 
 	isValidWordPressVersion( version: string ): boolean {

--- a/src/lib/wordpress-provider/playground-cli/playground-cli-provider.ts
+++ b/src/lib/wordpress-provider/playground-cli/playground-cli-provider.ts
@@ -221,7 +221,7 @@ export class PlaygroundCliProvider implements WordPressProvider {
 	}
 
 	// Install WordPress if user adds a WordPress folder with no wp-config.php and no database.
-	async installWordPress(
+	async installWordPressWhenNoWpConfig(
 		server: SiteServer,
 		siteName: string,
 		adminPassword: string

--- a/src/lib/wordpress-provider/playground-cli/playground-cli-provider.ts
+++ b/src/lib/wordpress-provider/playground-cli/playground-cli-provider.ts
@@ -117,8 +117,32 @@ export class PlaygroundCliProvider implements WordPressProvider {
 		return str.replace( /\\/g, '\\\\' ).replace( /'/g, "\\'" );
 	}
 
+	private createInstallationStep( siteName: string, adminPassword: string ): StepDefinition {
+		return {
+			step: 'runPHP',
+			code: `<?php
+			$_POST = array(
+				'language' => 'en_US',
+				'prefix' => 'wp_',
+				'weblog_title' => '${ this.escapePhpString( siteName ) }',
+				'user_name' => 'admin',
+				'admin_password' => '${ this.escapePhpString( adminPassword ) }',
+				'admin_password2' => '${ this.escapePhpString( adminPassword ) }',
+				'Submit' => 'Install WordPress',
+				'pw_weak' => '1',
+				'admin_email' => 'admin@localhost.com',
+			);
+			$_REQUEST = $_POST;
+			$_GET['step'] = 2;
+
+			// Include WordPress installation
+			require_once('/wordpress/wp-admin/install.php');
+		`,
+		};
+	}
+
 	async setupWordPressSite( server: SiteServer, wpVersion = 'latest' ): Promise< boolean > {
-		const { path, name, adminPassword } = server.details;
+		const { path, name } = server.details;
 
 		try {
 			const isOnlineStatus = await isOnline();
@@ -180,28 +204,6 @@ export class PlaygroundCliProvider implements WordPressProvider {
 						`Failed to copy WordPress files for offline setup: ${ ( error as Error ).message }`
 					);
 				}
-
-				setupSteps.push( {
-					step: 'runPHP',
-					code: `<?php
-					$_POST = array(
-						'language' => '${ this.escapePhpString( DEFAULT_LOCALE ) }',
-						'prefix' => 'wp_',
-						'weblog_title' => '${ this.escapePhpString( name ) }',
-						'user_name' => 'admin',
-						'admin_password' => '${ this.escapePhpString( adminPassword || '' ) }',
-						'admin_password2' => '${ this.escapePhpString( adminPassword || '' ) }',
-						'Submit' => 'Install WordPress',
-						'pw_weak' => '1',
-						'admin_email' => 'admin@localhost.com',
-					);
-					$_REQUEST = $_POST;
-					$_GET['step'] = 2;
-
-					// Include WordPress installation
-					require_once('/wordpress/wp-admin/install.php');
-				`,
-				} );
 			}
 
 			if ( ! server.meta.blueprint ) {
@@ -219,7 +221,11 @@ export class PlaygroundCliProvider implements WordPressProvider {
 		}
 	}
 
-	async installWordPress( server: SiteServer, siteName: string, adminPassword: string ): Promise< void > {
+	async installWordPress(
+		server: SiteServer,
+		siteName: string,
+		adminPassword: string
+	): Promise< void > {
 		const { path } = server.details;
 		const dbPath = nodePath.join( path, 'wp-content', 'database', '.ht.sqlite' );
 		let needsInstallation = true;
@@ -239,27 +245,10 @@ export class PlaygroundCliProvider implements WordPressProvider {
 				server.meta.blueprint = {};
 			}
 
-			const installationStep = {
-				step: 'runPHP',
-				code: `<?php
-				$_POST = array(
-					'language' => 'en_US',
-					'prefix' => 'wp_',
-					'weblog_title' => '${ this.escapePhpString( siteName || nodePath.basename( path ) ) }',
-					'user_name' => 'admin',
-					'admin_password' => '${ this.escapePhpString( adminPassword || '' ) }',
-					'admin_password2' => '${ this.escapePhpString( adminPassword || '' ) }',
-					'Submit' => 'Install WordPress',
-					'pw_weak' => '1',
-					'admin_email' => 'admin@localhost.com',
-				);
-				$_REQUEST = $_POST;
-				$_GET['step'] = 2;
-
-				// Include WordPress installation
-				require_once('/wordpress/wp-admin/install.php');
-			`,
-			};
+			const installationStep = this.createInstallationStep(
+				siteName || nodePath.basename( path ),
+				adminPassword || ''
+			);
 
 			const existingSteps = server.meta.blueprint.steps || [];
 			server.meta.blueprint.steps = [ installationStep, ...existingSteps ];

--- a/src/lib/wordpress-provider/playground-cli/playground-cli-provider.ts
+++ b/src/lib/wordpress-provider/playground-cli/playground-cli-provider.ts
@@ -1,3 +1,4 @@
+import fs from 'fs';
 import nodePath from 'path';
 import { SupportedPHPVersions } from '@php-wasm/universal';
 import { Blueprint, StepDefinition } from '@wp-playground/blueprints';
@@ -215,6 +216,53 @@ export class PlaygroundCliProvider implements WordPressProvider {
 		} catch ( error ) {
 			console.error( 'Failed to setup WordPress site:', error );
 			throw error;
+		}
+	}
+
+	async installWordPress( server: SiteServer, siteName: string, adminPassword: string ): Promise< void > {
+		const { path } = server.details;
+		const dbPath = nodePath.join( path, 'wp-content', 'database', '.ht.sqlite' );
+		let needsInstallation = true;
+
+		try {
+			const stats = await fs.promises.stat( dbPath );
+			// If database exists and is larger than 10KB, WordPress is already installed
+			needsInstallation = stats.size < 10 * 1024;
+		} catch {
+			// Database doesn't exist, needs installation
+			needsInstallation = true;
+		}
+
+		if ( needsInstallation ) {
+			// Add installation blueprint step to auto-install WordPress
+			if ( ! server.meta.blueprint ) {
+				server.meta.blueprint = {};
+			}
+
+			const installationStep = {
+				step: 'runPHP',
+				code: `<?php
+				$_POST = array(
+					'language' => 'en_US',
+					'prefix' => 'wp_',
+					'weblog_title' => '${ this.escapePhpString( siteName || nodePath.basename( path ) ) }',
+					'user_name' => 'admin',
+					'admin_password' => '${ this.escapePhpString( adminPassword || '' ) }',
+					'admin_password2' => '${ this.escapePhpString( adminPassword || '' ) }',
+					'Submit' => 'Install WordPress',
+					'pw_weak' => '1',
+					'admin_email' => 'admin@localhost.com',
+				);
+				$_REQUEST = $_POST;
+				$_GET['step'] = 2;
+
+				// Include WordPress installation
+				require_once('/wordpress/wp-admin/install.php');
+			`,
+			};
+
+			const existingSteps = server.meta.blueprint.steps || [];
+			server.meta.blueprint.steps = [ installationStep, ...existingSteps ];
 		}
 	}
 

--- a/src/lib/wordpress-provider/playground-cli/playground-cli-provider.ts
+++ b/src/lib/wordpress-provider/playground-cli/playground-cli-provider.ts
@@ -241,10 +241,7 @@ export class PlaygroundCliProvider implements WordPressProvider {
 			server.meta.blueprint = {};
 		}
 
-		const installationStep = this.createInstallationStep(
-			siteName || nodePath.basename( path ),
-			adminPassword || ''
-		);
+		const installationStep = this.createInstallationStep( siteName, adminPassword );
 
 		const existingSteps = server.meta.blueprint.steps || [];
 		server.meta.blueprint.steps = [ installationStep, ...existingSteps ];

--- a/src/lib/wordpress-provider/types.ts
+++ b/src/lib/wordpress-provider/types.ts
@@ -70,6 +70,7 @@ export interface WordPressProvider {
 
 	// Core functionality
 	setupWordPressSite( server: SiteServer, wpVersion?: string ): Promise< boolean >;
+	installWordPress( server: SiteServer, siteName: string, adminPassword: string ): Promise< void >;
 	startServer( options: ServerOptions ): Promise< WordPressServerInstance >;
 
 	// Server process management

--- a/src/lib/wordpress-provider/types.ts
+++ b/src/lib/wordpress-provider/types.ts
@@ -70,7 +70,11 @@ export interface WordPressProvider {
 
 	// Core functionality
 	setupWordPressSite( server: SiteServer, wpVersion?: string ): Promise< boolean >;
-	installWordPress( server: SiteServer, siteName: string, adminPassword: string ): Promise< void >;
+	installWordPressWhenNoWpConfig(
+		server: SiteServer,
+		siteName: string,
+		adminPassword: string
+	): Promise< void >;
 	startServer( options: ServerOptions ): Promise< WordPressServerInstance >;
 
 	// Server process management

--- a/src/lib/wordpress-provider/wp-now/wp-now-provider.ts
+++ b/src/lib/wordpress-provider/wp-now/wp-now-provider.ts
@@ -148,7 +148,11 @@ export class WpNowProvider implements WordPressProvider {
 		}
 	}
 
-	async installWordPress( server: SiteServer, siteName: string, adminPassword: string ): Promise< void > {
+	async installWordPress(
+		_server: SiteServer,
+		_siteName: string,
+		_adminPassword: string
+	): Promise< void > {
 		// wp-now handles WordPress installation automatically via installationSteps
 		// in vendor/wp-now/src/wp-now.ts, so no action needed here
 	}

--- a/src/lib/wordpress-provider/wp-now/wp-now-provider.ts
+++ b/src/lib/wordpress-provider/wp-now/wp-now-provider.ts
@@ -148,7 +148,7 @@ export class WpNowProvider implements WordPressProvider {
 		}
 	}
 
-	async installWordPress(
+	async installWordPressWhenNoWpConfig(
 		_server: SiteServer,
 		_siteName: string,
 		_adminPassword: string

--- a/src/lib/wordpress-provider/wp-now/wp-now-provider.ts
+++ b/src/lib/wordpress-provider/wp-now/wp-now-provider.ts
@@ -148,6 +148,11 @@ export class WpNowProvider implements WordPressProvider {
 		}
 	}
 
+	async installWordPress( server: SiteServer, siteName: string, adminPassword: string ): Promise< void > {
+		// wp-now handles WordPress installation automatically via installationSteps
+		// in vendor/wp-now/src/wp-now.ts, so no action needed here
+	}
+
 	async startServer( options: ServerOptions ): Promise< WordPressServerInstance > {
 		const wpNowOptions = await getWpNowConfig( {
 			path: options.path,


### PR DESCRIPTION
## Related issues

- Fixes STU-863

## Proposed Changes

- Added `installWordPress` method to the WordPressProvider interface to check and install WordPress when needed
- Implemented the method in PlaygroundCliProvider to detect if WordPress is installed by checking .ht.sqlite database file size
- If WordPress is not installed, automatically adds a blueprint step to complete installation via /wp-admin/install.php
- Added no-op implementation in WpNowProvider since wp-now handles installation automatically
- Extracted installation blueprint step to `createInstallationStep` helper function to eliminate code duplication
- Updated ipc-handlers to use the new provider method for WordPress installation

## Testing Instructions

- Enable the blueprints feature flag in settings
- Download a fresh WordPress zip from wordpress.org and extract it to a folder
- In Studio, create a new site and select "Add existing site" with the WordPress folder
- Verify that the site is created successfully without showing the WordPress installation screen
- Confirm the site loads with WordPress already installed and configured
- Test creating sites with wp-now provider (blueprints disabled) to ensure no regression

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?