### PR TITLE
Remove unused import to eliminate the eslint warning

### DIFF
--- a/src/tests/show-site-context-menu.test.ts
+++ b/src/tests/show-site-context-menu.test.ts
@@ -2,7 +2,6 @@
  * @jest-environment node
  */
 import { IpcMainInvokeEvent, BrowserWindow, Menu, MenuItem } from 'electron';
-import fs from 'fs';
 import { showSiteContextMenu } from 'src/ipc-handlers';
 import { sendIpcEventToRendererWithWindow } from 'src/ipc-utils';
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Proposed Changes

- Remove unused import to eliminate the eslint warning

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run `npm run lint`

| Before | After |
|--------|--------|
|  <img width="860" height="170" alt="Screenshot 2025-10-13 at 13 04 47" src="https://github.com/user-attachments/assets/929fbb58-bfc8-4cee-b0cf-094d80ba64bd" /> | <img width="864" height="112" alt="Screenshot 2025-10-13 at 13 04 51" src="https://github.com/user-attachments/assets/508bb46f-98bf-482d-b884-774cbc7364a6" /> |


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
