### PR TITLE
Reduce number of performance tests run, enable rerun for flaky tests

### DIFF
--- a/metrics/playwright.metrics.config.ts
+++ b/metrics/playwright.metrics.config.ts
@@ -12,7 +12,7 @@ export default defineConfig( {
 	outputDir: path.join( process.env.ARTIFACTS_PATH, 'test-results' ),
 	forbidOnly: !! process.env.CI,
 	fullyParallel: false,
-	retries: 0,
+	retries: 2, // Retry flaky tests up to 2 times
 	timeout: parseInt( process.env.TIMEOUT || '', 10 ) || 600_000, // Defaults to 10 minutes.
 	reportSlowTests: null,
 	use: {

--- a/metrics/tests/site-editor.test.ts
+++ b/metrics/tests/site-editor.test.ts
@@ -65,18 +65,26 @@ test.describe( 'Site Editor Load Metrics', () => {
 		await page.goto( `${ wpAdminUrl }?playground-auto-login=true` );
 		await page.waitForLoadState( 'networkidle' );
 
-		for ( let i = 0; i < 5; i++ ) {
+		// Run 2 iterations: 1 warmup + 1 measurement
+		// Outer rounds in CI provide additional samples across full rebuilds
+		for ( let i = 0; i < 2; i++ ) {
 			// Start timer just before navigating to the site editor
 			const startTime = Date.now();
-			await page.goto( `${ wpAdminUrl }/site-editor.php` );
+			await page.goto( `${ wpAdminUrl }/site-editor.php`, { waitUntil: 'commit' } );
 
-			// First wait for the iframe to appear
-			await page.waitForSelector( 'iframe[name="editor-canvas"]' );
+			// First wait for the iframe to appear with explicit timeout
+			await page.waitForSelector( 'iframe[name="editor-canvas"]', {
+				state: 'visible',
+				timeout: 120_000 // 2 minutes, half of the default action timeout
+			} );
 			const frame = page.frame( { name: 'editor-canvas' } );
 			if ( ! frame ) {
 				throw new Error( 'Frame not found' );
 			}
-			await frame.waitForSelector( '[data-block]' );
+
+			// Wait for frame to be ready before checking for blocks
+			await frame.waitForLoadState( 'domcontentloaded' );
+			await frame.waitForSelector( '[data-block]', { timeout: 60_000 } );
 
 			// Make sure blocks are loaded and spinners are gone
 			await frame.waitForFunction( () => {
@@ -86,7 +94,7 @@ test.describe( 'Site Editor Load Metrics', () => {
 					! document.querySelector( '.is-loading' ) &&
 					! document.querySelector( '.wp-block-editor__loading' )
 				);
-			} );
+			}, { timeout: 60_000 } );
 
 			const endTime = Date.now();
 			const duration = endTime - startTime;
@@ -94,8 +102,14 @@ test.describe( 'Site Editor Load Metrics', () => {
 				results.load.push( duration );
 			}
 
-			// Wait between runs
-			await new Promise( ( resolve ) => setTimeout( resolve, 500 ) );
+			// Wait longer between runs to let the system settle
+			await new Promise( ( resolve ) => setTimeout( resolve, 2000 ) );
+
+			// Navigate away to clear state before next iteration
+			if ( i < 1 ) {
+				await page.goto( `${ wpAdminUrl }` );
+				await page.waitForLoadState( 'networkidle' );
+			}
 		}
 		await page.close();
 		await context.close();


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- N/A

## Proposed Changes

This PR addresses flaky timeout failures in the performance metrics workflow and tries to reduce test execution time.

### Changes

- **Reduced test iterations**: Changed from 5 to 2 inner loop iterations (1 warmup + 1 measurement). With 3 rounds in CI, we still get 3 statistically valid samples per branch while reducing execution time by ~60%.

- **Added automatic retries**: Enabled 2 retries in the Playwright metrics config to handle transient failures that often succeed on rerun.

- **Improved wait logic**: Added explicit timeouts (120s for iframe, 60s for blocks), frame load state checks, and better state cleanup between iterations to prevent race conditions and cascading failures.

###

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Confirm builds work fine.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
