### PR TITLE
"Add site" Stepper: Introduce click handler to allow clicks on the previous step that is already complete

### DIFF
--- a/src/modules/add-site/components/import-backup.tsx
+++ b/src/modules/add-site/components/import-backup.tsx
@@ -43,13 +43,17 @@ const truncateMiddle = ( filename: string, maxLength: number = 30 ): string => {
 
 interface ImportBackupProps {
 	onFileSelect: ( file?: File ) => void;
+	selectedFile?: File | null;
 }
 
-export default function ImportBackup( { onFileSelect }: ImportBackupProps ) {
+export default function ImportBackup( {
+	onFileSelect,
+	selectedFile: initialFile,
+}: ImportBackupProps ) {
 	const { __ } = useI18n();
 	const locale = useI18nLocale();
 	const [ isDragging, setIsDragging ] = useState( false );
-	const [ selectedFile, setSelectedFile ] = useState< File | null >( null );
+	const [ selectedFile, setSelectedFile ] = useState< File | null >( initialFile || null );
 	const fileInputRef = useRef< HTMLInputElement >( null );
 
 	const handleFileSelection = useCallback(

--- a/src/modules/add-site/components/stepper.tsx
+++ b/src/modules/add-site/components/stepper.tsx
@@ -1,8 +1,4 @@
-import {
-	__experimentalHStack as HStack,
-	__experimentalText as Text,
-	useNavigator,
-} from '@wordpress/components';
+import { __experimentalHStack as HStack, __experimentalText as Text } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
 import { FormEvent } from 'react';
 import Button from 'src/components/button';
@@ -31,8 +27,7 @@ export default function Stepper( {
 	canSubmitCreate,
 }: StepperProps ) {
 	const { __ } = useI18n();
-	const { goTo } = useNavigator();
-	const { steps, isVisible, actionButton, onSubmit, canSubmit } = useStepper( {
+	const { steps, isVisible, actionButton, onSubmit, canSubmit, goTo } = useStepper( {
 		onBlueprintContinue,
 		onBackupContinue,
 		onCreateSubmit,

--- a/src/modules/add-site/components/stepper.tsx
+++ b/src/modules/add-site/components/stepper.tsx
@@ -27,7 +27,7 @@ export default function Stepper( {
 	canSubmitCreate,
 }: StepperProps ) {
 	const { __ } = useI18n();
-	const { steps, isVisible, actionButton, onSubmit, canSubmit, goTo } = useStepper( {
+	const { steps, isVisible, actionButton, onSubmit, canSubmit } = useStepper( {
 		onBlueprintContinue,
 		onBackupContinue,
 		onCreateSubmit,
@@ -44,16 +44,7 @@ export default function Stepper( {
 		<div className="flex justify-between items-center p-6">
 			<HStack spacing={ 6 } alignment="left">
 				{ steps.map( ( step, index ) => {
-					const isCurrent = step.status === 'current';
-					const isCompleted = step.status === 'completed';
-					const isClickable = isCompleted && step.path;
 					const stepNumber = index + 1;
-
-					const handleStepClick = () => {
-						if ( isClickable && step.path ) {
-							goTo( step.path );
-						}
-					};
 
 					return (
 						<HStack
@@ -62,14 +53,14 @@ export default function Stepper( {
 							alignment="left"
 							className={ cx(
 								'w-fit',
-								isClickable && 'cursor-pointer hover:opacity-80 transition-opacity'
+								step.isClickable && 'cursor-pointer hover:opacity-80 transition-opacity'
 							) }
-							onClick={ handleStepClick }
+							onClick={ step.onClick }
 						>
 							<div
 								className={ cx(
 									`w-6 h-6 rounded-full flex items-center justify-center text-xs font-normal border-2  bg-transparent `,
-									isCurrent ? 'text-gray-900 border-gray-900' : 'border-gray-500 text-gray-500'
+									step.isCurrent ? 'text-gray-900 border-gray-900' : 'border-gray-500 text-gray-500'
 								) }
 							>
 								{ stepNumber }
@@ -77,7 +68,7 @@ export default function Stepper( {
 							<Text
 								className={ cx(
 									`text-sm font-medium`,
-									isCurrent ? 'text-gray-900' : 'text-gray-500'
+									step.isCurrent ? 'text-gray-900' : 'text-gray-500'
 								) }
 							>
 								{ step.label }

--- a/src/modules/add-site/components/stepper.tsx
+++ b/src/modules/add-site/components/stepper.tsx
@@ -81,8 +81,8 @@ export default function Stepper( {
 							</div>
 							<Text
 								className={ cx(
-									`text-sm`,
-									isCurrent ? 'text-gray-900 font-medium' : 'text-gray-500'
+									`text-sm font-medium`,
+									isCurrent ? 'text-gray-900' : 'text-gray-500'
 								) }
 							>
 								{ step.label }

--- a/src/modules/add-site/components/stepper.tsx
+++ b/src/modules/add-site/components/stepper.tsx
@@ -1,4 +1,8 @@
-import { __experimentalHStack as HStack, __experimentalText as Text } from '@wordpress/components';
+import {
+	__experimentalHStack as HStack,
+	__experimentalText as Text,
+	useNavigator,
+} from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
 import { FormEvent } from 'react';
 import Button from 'src/components/button';
@@ -27,6 +31,7 @@ export default function Stepper( {
 	canSubmitCreate,
 }: StepperProps ) {
 	const { __ } = useI18n();
+	const { goTo } = useNavigator();
 	const { steps, isVisible, actionButton, onSubmit, canSubmit } = useStepper( {
 		onBlueprintContinue,
 		onBackupContinue,
@@ -45,10 +50,27 @@ export default function Stepper( {
 			<HStack spacing={ 6 } alignment="left">
 				{ steps.map( ( step, index ) => {
 					const isCurrent = step.status === 'current';
+					const isCompleted = step.status === 'completed';
+					const isClickable = isCompleted && step.path;
 					const stepNumber = index + 1;
 
+					const handleStepClick = () => {
+						if ( isClickable && step.path ) {
+							goTo( step.path );
+						}
+					};
+
 					return (
-						<HStack key={ step.id } spacing={ 2 } alignment="left" className="w-fit">
+						<HStack
+							key={ step.id }
+							spacing={ 2 }
+							alignment="left"
+							className={ cx(
+								'w-fit',
+								isClickable && 'cursor-pointer hover:opacity-80 transition-opacity'
+							) }
+							onClick={ handleStepClick }
+						>
 							<div
 								className={ cx(
 									`w-6 h-6 rounded-full flex items-center justify-center text-xs font-normal border-2  bg-transparent `,

--- a/src/modules/add-site/hooks/use-stepper.ts
+++ b/src/modules/add-site/hooks/use-stepper.ts
@@ -99,6 +99,7 @@ export function useStepper( config?: StepperConfig ): UseStepper {
 				id: step.id,
 				label: step.label,
 				status,
+				path: step.path,
 			};
 		} );
 	}, [ stepperContext, location.path ] );

--- a/src/modules/add-site/hooks/use-stepper.ts
+++ b/src/modules/add-site/hooks/use-stepper.ts
@@ -7,6 +7,10 @@ interface StepperStep {
 	label: string;
 	status?: 'completed' | 'current' | 'pending';
 	path?: string;
+	isClickable?: boolean;
+	isCurrent?: boolean;
+	isCompleted?: boolean;
+	onClick?: () => void;
 }
 
 interface StepperConfig {
@@ -96,14 +100,28 @@ export function useStepper( config?: StepperConfig ): UseStepper {
 				status = 'current';
 			}
 
+			const isCurrent = status === 'current';
+			const isCompleted = status === 'completed';
+			const isClickable = isCompleted && Boolean( step.path );
+
+			const onClick = () => {
+				if ( isClickable && step.path ) {
+					goTo( step.path );
+				}
+			};
+
 			return {
 				id: step.id,
 				label: step.label,
 				status,
 				path: step.path,
+				isClickable,
+				isCurrent,
+				isCompleted,
+				onClick,
 			};
 		} );
-	}, [ stepperContext, location.path ] );
+	}, [ stepperContext, location.path, goTo ] );
 
 	// Only show stepper when we're in a multi-step flow
 	const isVisible = stepperContext !== null && location.path !== '/';

--- a/src/modules/add-site/hooks/use-stepper.ts
+++ b/src/modules/add-site/hooks/use-stepper.ts
@@ -32,11 +32,12 @@ interface UseStepper {
 	};
 	onSubmit: () => void;
 	canSubmit: boolean;
+	goTo: ( path: string ) => void;
 }
 
 export function useStepper( config?: StepperConfig ): UseStepper {
 	const { __ } = useI18n();
-	const { location } = useNavigator();
+	const { location, goTo } = useNavigator();
 
 	const stepperContext = useMemo( (): StepperContext | null => {
 		const blueprintSteps: StepperStep[] = [
@@ -175,5 +176,6 @@ export function useStepper( config?: StepperConfig ): UseStepper {
 		actionButton,
 		onSubmit,
 		canSubmit,
+		goTo,
 	};
 }

--- a/src/modules/add-site/index.tsx
+++ b/src/modules/add-site/index.tsx
@@ -127,7 +127,6 @@ function NavigationContent( props: NavigationContentProps ) {
 		if ( location.path === '/blueprint/create' ) {
 			goTo( '/blueprint' );
 		} else if ( location.path === '/backup/create' ) {
-			createSiteProps.setFileForImport( null );
 			goTo( '/backup' );
 		} else if (
 			location.path === '/backup' ||
@@ -214,7 +213,10 @@ function NavigationContent( props: NavigationContentProps ) {
 				<CreateSite { ...createSiteProps } />
 			</Navigator.Screen>
 			<Navigator.Screen className="flex-1" path="/backup">
-				<ImportBackup onFileSelect={ handleBackupFileSelect } />
+				<ImportBackup
+					onFileSelect={ handleBackupFileSelect }
+					selectedFile={ createSiteProps.fileForImport }
+				/>
 			</Navigator.Screen>
 			<Navigator.Screen className="flex-1" path="/backup/create">
 				<CreateSite { ...createSiteProps } />


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Resolves STU-852

## Proposed Changes

- introduce `handleStepClick` to handle clicks on the previous step that is already complete
- ensure the selected import file is remembered when navigating between steps
- adjust styling of the previous step label

https://github.com/user-attachments/assets/e77084c4-c405-45bf-9233-9d86c124023e

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR branch and build the app with `npm install && npm start`.
2. Click the `Add site` button in the app sidebar and try to navigate through the steps of `Start from Blueprint` and `Import from backup` flows.
3. When you complete the first step and get to the second one by clicking the `Continue` button, it should be possible to get back to the first step by clicking the step label (not just the `Back` button).
4. When you are in the `Import from backup` flow and navigating back to the step where the import file is selected, it should be remembered.
5. When you review how the step labels are animated during transition between steps, there should be no odd movement / shift in those labels.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
