### PR TITLE
Add fs-extra types to fix TS issue on Windows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -87,6 +87,7 @@
 				"@types/archiver": "^6.0.2",
 				"@types/ejs": "^3.1.5",
 				"@types/follow-redirects": "^1.14.4",
+				"@types/fs-extra": "^11.0.4",
 				"@types/http-proxy": "^1.17.16",
 				"@types/jest": "^30.0.0",
 				"@types/lockfile": "^1.0.4",
@@ -8717,12 +8718,13 @@
 			}
 		},
 		"node_modules/@types/fs-extra": {
-			"version": "9.0.13",
-			"resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.13.tgz",
-			"integrity": "sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==",
+			"version": "11.0.4",
+			"resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-11.0.4.tgz",
+			"integrity": "sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ==",
 			"dev": true,
-			"optional": true,
+			"license": "MIT",
 			"dependencies": {
+				"@types/jsonfile": "*",
 				"@types/node": "*"
 			}
 		},
@@ -8864,6 +8866,16 @@
 			"resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
 			"integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
 			"dev": true
+		},
+		"node_modules/@types/jsonfile": {
+			"version": "6.1.4",
+			"resolved": "https://registry.npmjs.org/@types/jsonfile/-/jsonfile-6.1.4.tgz",
+			"integrity": "sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*"
+			}
 		},
 		"node_modules/@types/jsonwebtoken": {
 			"version": "9.0.9",
@@ -13610,6 +13622,17 @@
 			},
 			"engines": {
 				"node": ">= 10"
+			}
+		},
+		"node_modules/electron-installer-common/node_modules/@types/fs-extra": {
+			"version": "9.0.13",
+			"resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.13.tgz",
+			"integrity": "sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@types/node": "*"
 			}
 		},
 		"node_modules/electron-installer-common/node_modules/fs-extra": {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
 		"@types/archiver": "^6.0.2",
 		"@types/ejs": "^3.1.5",
 		"@types/follow-redirects": "^1.14.4",
+		"@types/fs-extra": "^11.0.4",
 		"@types/http-proxy": "^1.17.16",
 		"@types/jest": "^30.0.0",
 		"@types/lockfile": "^1.0.4",

--- a/src/__mocks__/fs-extra.ts
+++ b/src/__mocks__/fs-extra.ts
@@ -11,7 +11,19 @@ fsExtra.__setFileContents = ( path: string, fileContents: string | string[] ) =>
 	fsExtra.__mockFiles[ path ] = fileContents;
 };
 
-( fsExtra.readFile as jest.Mock ).mockImplementation( async ( path: string ): Promise< string > => {
+( fsExtra.readFile as unknown as jest.Mock ).mockImplementation(
+	async ( path: string ): Promise< string > => {
+		const fileContents = fsExtra.__mockFiles[ path ];
+
+		if ( typeof fileContents === 'string' ) {
+			return fileContents;
+		}
+
+		return '';
+	}
+);
+
+( fsExtra.readFileSync as unknown as jest.Mock ).mockImplementation( ( path: string ): string => {
 	const fileContents = fsExtra.__mockFiles[ path ];
 
 	if ( typeof fileContents === 'string' ) {
@@ -21,17 +33,7 @@ fsExtra.__setFileContents = ( path: string, fileContents: string | string[] ) =>
 	return '';
 } );
 
-( fsExtra.readFileSync as jest.Mock ).mockImplementation( ( path: string ): string => {
-	const fileContents = fsExtra.__mockFiles[ path ];
-
-	if ( typeof fileContents === 'string' ) {
-		return fileContents;
-	}
-
-	return '';
-} );
-
-( fsExtra.readdir as jest.Mock ).mockImplementation(
+( fsExtra.readdir as unknown as jest.Mock ).mockImplementation(
 	async ( path: string ): Promise< Array< string > > => {
 		const dirContents = fsExtra.__mockFiles[ path ];
 
@@ -43,7 +45,7 @@ fsExtra.__setFileContents = ( path: string, fileContents: string | string[] ) =>
 	}
 );
 
-( fsExtra.pathExists as jest.Mock ).mockImplementation(
+( fsExtra.pathExists as unknown as jest.Mock ).mockImplementation(
 	async ( path: string ): Promise< boolean > => {
 		return !! fsExtra.__mockFiles[ path ];
 	}

--- a/src/lib/import-export/tests/import/importer/jetpack-importer.test.ts
+++ b/src/lib/import-export/tests/import/importer/jetpack-importer.test.ts
@@ -41,12 +41,12 @@ platformTestSuite( 'JetpackImporter', ( { normalize } ) => {
 		} );
 
 		// mock move
-		( move as jest.Mock ).mockResolvedValue( null );
+		( move as unknown as jest.Mock ).mockResolvedValue( null );
 
 		jest.useFakeTimers();
 		jest.setSystemTime( new Date( '2024-08-01T12:00:00Z' ) );
 
-		( lstat as jest.Mock ).mockResolvedValue( {
+		( lstat as unknown as jest.Mock ).mockResolvedValue( {
 			isDirectory: jest.fn().mockReturnValue( false ),
 		} );
 	} );

--- a/src/lib/import-export/tests/import/importer/local-importer.test.ts
+++ b/src/lib/import-export/tests/import/importer/local-importer.test.ts
@@ -41,12 +41,12 @@ platformTestSuite( 'LocalImporter', ( { normalize } ) => {
 		} );
 
 		// mock rename
-		( rename as jest.Mock ).mockResolvedValue( null );
+		( rename as unknown as jest.Mock ).mockResolvedValue( null );
 
 		jest.useFakeTimers();
 		jest.setSystemTime( new Date( '2024-08-01T12:00:00Z' ) );
 
-		( lstat as jest.Mock ).mockResolvedValue( {
+		( lstat as unknown as jest.Mock ).mockResolvedValue( {
 			isDirectory: jest.fn().mockReturnValue( false ),
 		} );
 	} );

--- a/src/lib/import-export/tests/import/importer/playground-importer.test.ts
+++ b/src/lib/import-export/tests/import/importer/playground-importer.test.ts
@@ -37,12 +37,12 @@ platformTestSuite( 'PlaygroundImporter', ( { normalize } ) => {
 		} );
 
 		// mock rename
-		( move as jest.Mock ).mockResolvedValue( null );
+		( move as unknown as jest.Mock ).mockResolvedValue( null );
 
 		jest.useFakeTimers();
 		jest.setSystemTime( new Date( '2024-08-01T12:00:00Z' ) );
 
-		( lstat as jest.Mock ).mockResolvedValue( {
+		( lstat as unknown as jest.Mock ).mockResolvedValue( {
 			isDirectory: jest.fn().mockReturnValue( false ),
 		} );
 	} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- N/A

## Proposed Changes

I propose to add fs-extra types to fix the TypeScript issue on Windows. Without that, `npm install` fails with a TS issue in `download-wp-server-files.ts`.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Confirm `npm install` and `npm start` work on Windows.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
