### PR TITLE
Change WP to WordPress in the version label

### DIFF
--- a/src/components/content-tab-settings.tsx
+++ b/src/components/content-tab-settings.tsx
@@ -21,7 +21,7 @@ interface ContentTabSettingsProps {
 function SettingsRow( { children, label }: PropsWithChildren< { label: string } > ) {
 	return (
 		<tr className="align-top">
-			<th className="text-nowrap text-a8c-gray-50 pb-4 ltr:pr-6 rtl:pl-6 ltr:text-left rtl:text-right font-normal">
+			<th className="text-nowrap text-a8c-gray-50 pb-4 ltr:pr-10 rtl:pl-10 ltr:text-left rtl:text-right font-normal">
 				{ label }
 			</th>
 			<td className="pb-4">{ children }</td>
@@ -126,8 +126,8 @@ export function ContentTabSettings( { selectedSite }: ContentTabSettingsProps ) 
 							<span className="line-clamp-1 break-all">{ selectedSite.path }</span>
 						</CopyTextButton>
 					</SettingsRow>
-					<SettingsRow label={ __( 'WP Version' ) }>{ wpVersion }</SettingsRow>
-					<SettingsRow label={ __( 'PHP Version' ) }>
+					<SettingsRow label={ __( 'WordPress version' ) }>{ wpVersion }</SettingsRow>
+					<SettingsRow label={ __( 'PHP version' ) }>
 						<div className="flex">
 							<span className="line-clamp-1 break-all">{ selectedSite.phpVersion }</span>
 						</div>

--- a/src/components/content-tab-settings.tsx
+++ b/src/components/content-tab-settings.tsx
@@ -21,7 +21,7 @@ interface ContentTabSettingsProps {
 function SettingsRow( { children, label }: PropsWithChildren< { label: string } > ) {
 	return (
 		<tr className="align-top">
-			<th className="text-nowrap text-a8c-gray-50 pb-4 ltr:pr-10 rtl:pl-10 ltr:text-left rtl:text-right font-normal">
+			<th className="text-nowrap text-a8c-gray-50 pb-4 pe-10 ltr:text-left rtl:text-right font-normal">
 				{ label }
 			</th>
 			<td className="pb-4">{ children }</td>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- N/A

## Proposed Changes

- I propose to change WP to WordPress in the version label.

<img width="573" height="570" alt="Screenshot 2025-10-16 at 14 07 04" src="https://github.com/user-attachments/assets/54888b3c-a261-4e26-9ec3-090c7e6deef2" />

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Confirm if label is clear and layout is correct.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
