### PR TITLE
Enable Windows E2E tests in CI

### DIFF
--- a/.buildkite/commands/run-e2e-tests.sh
+++ b/.buildkite/commands/run-e2e-tests.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MATRIX=${1:-}
+
+echo '--- :wrench: Matrix setup'
+if [ "$MATRIX" = "windows" ]; then
+  # prepare_windows_host_for_app_distribution.ps1 comes from CI Toolkit Plugin
+  powershell -Command "& 'prepare_windows_host_for_app_distribution.ps1' -InstallPython $true -InstallNativeCompilationTools $true"
+fi
+
+echo '--- :package: Install deps'
+bash .buildkite/commands/install-node-dependencies.sh
+
+export IS_DEV_BUILD=true
+
+echo '--- :package: Package app for testing'
+npm run package
+
+echo '--- :playwright: Run End To End Tests'
+npm run e2e
+
+

--- a/.buildkite/commands/run-e2e-tests.sh
+++ b/.buildkite/commands/run-e2e-tests.sh
@@ -18,4 +18,7 @@ echo '--- :package: Package app for testing'
 npm run package
 
 echo '--- :playwright: Run End To End Tests'
-npm run e2e
+echo 'Installing Playwright browsers...'
+npx playwright install
+echo 'Running Playwright tests...'
+npx playwright test

--- a/.buildkite/commands/run-e2e-tests.sh
+++ b/.buildkite/commands/run-e2e-tests.sh
@@ -6,7 +6,7 @@ MATRIX=${1:-}
 echo '--- :wrench: Matrix setup'
 if [ "$MATRIX" = "windows" ]; then
   # prepare_windows_host_for_app_distribution.ps1 comes from CI Toolkit Plugin
-  powershell -Command "& 'prepare_windows_host_for_app_distribution.ps1' -InstallPython $true -InstallNativeCompilationTools $true"
+  powershell -Command "& 'prepare_windows_host_for_app_distribution.ps1' -InstallPython \$true -InstallNativeCompilationTools \$true"
 fi
 
 echo '--- :package: Install deps'
@@ -19,5 +19,3 @@ npm run package
 
 echo '--- :playwright: Run End To End Tests'
 npm run e2e
-
-

--- a/.buildkite/commands/run-unit-tests.sh
+++ b/.buildkite/commands/run-unit-tests.sh
@@ -12,10 +12,6 @@ fi
 echo '--- :package: Install deps'
 bash .buildkite/commands/install-node-dependencies.sh
 
-export IS_DEV_BUILD=true
+echo '--- :npm: Run Unit Tests'
+npm run test
 
-echo '--- :package: Package app for testing'
-npm run package
-
-echo '--- :playwright: Run End To End Tests'
-npm run e2e

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -32,7 +32,7 @@ steps:
       - windows
     notify:
       - github_commit_status:
-          context: All Unit Tests
+          context: Unit Tests
 
   # Notice that we use the queue name (matrix value) in the label.
   # We could have added values for queue and label, but that would have resulted in 'macOS + windows' and 'Windows + mac' combinations, which we don't want.
@@ -56,7 +56,7 @@ steps:
       - windows
     notify:
       - github_commit_status:
-          context: All E2E Tests
+          context: E2E Tests
 
   - group: 📦 Build for Mac
     key: dev-mac

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -21,33 +21,18 @@ steps:
       - github_commit_status:
           context: Lint
 
-  - label: Unit Tests
-    agents:
-      queue: mac
+  - label: Unit Tests on {{matrix}}
     key: unit_tests
-    command: |
-      .buildkite/commands/install-node-dependencies.sh
-      echo '--- :npm: Run Unit Tests'
-      npm run test
+    command: bash .buildkite/commands/run-unit-tests.sh "{{matrix}}"
     plugins: [$CI_TOOLKIT_PLUGIN, $NVM_PLUGIN]
-    notify:
-      - github_commit_status:
-          context: Unit Tests
-
-  - label: Windows Unit Tests
-    command: |
-      # prepare_windows_host_for_app_distribution.ps1 comes from CI Toolkit Plugin
-      & "prepare_windows_host_for_app_distribution.ps1" -InstallNativeCompilationTools $true
-
-      bash .buildkite/commands/install-node-dependencies.sh
-      echo '--- :npm: Run Unit Tests'
-      npm run test
     agents:
-      queue: windows
-    plugins: [$CI_TOOLKIT_PLUGIN, $NVM_PLUGIN]
+      queue: "{{matrix}}"
+    matrix:
+      - mac
+      - windows
     notify:
       - github_commit_status:
-          context: Windows Unit Tests
+          context: All Unit Tests
 
   # Notice that we use the queue name (matrix value) in the label.
   # We could have added values for queue and label, but that would have resulted in 'macOS + windows' and 'Windows + mac' combinations, which we don't want.

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -55,20 +55,7 @@ steps:
   # See https://buildkite.com/docs/pipelines/build-matrix#removing-combinations-from-the-build-matrix
   - label: E2E Tests on {{matrix}}
     key: e2e_tests
-    command: |
-      # Windows-specific setup
-      if [ "{{matrix}}" = "windows" ]; then
-        # prepare_windows_host_for_app_distribution.ps1 comes from CI Toolkit Plugin
-        powershell -Command "& 'prepare_windows_host_for_app_distribution.ps1' -InstallPython \$true -InstallNativeCompilationTools \$true"
-      fi
-
-      # call with bash explicitly because we run this on Windows, too
-      bash .buildkite/commands/install-node-dependencies.sh
-      export IS_DEV_BUILD=true
-      echo '--- :package: Package app for testing'
-      npm run package
-      echo '--- :playwright: Run End To End Tests'
-      npm run e2e
+    command: bash .buildkite/commands/run-e2e-tests.sh "{{matrix}}"
     artifact_paths:
       - test-results/**/*.zip
       - test-results/**/*.png

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -56,6 +56,12 @@ steps:
   - label: E2E Tests on {{matrix}}
     key: e2e_tests
     command: |
+      # Windows-specific setup
+      if [ "{{matrix}}" = "windows" ]; then
+        # prepare_windows_host_for_app_distribution.ps1 comes from CI Toolkit Plugin
+        powershell -Command "& 'prepare_windows_host_for_app_distribution.ps1' -InstallPython \$true -InstallNativeCompilationTools \$true"
+      fi
+
       # call with bash explicitly because we run this on Windows, too
       bash .buildkite/commands/install-node-dependencies.sh
       export IS_DEV_BUILD=true
@@ -65,6 +71,8 @@ steps:
       npm run e2e
     artifact_paths:
       - test-results/**/*.zip
+      - test-results/**/*.png
+      - test-results/**/*error-context.md
     plugins: [$CI_TOOLKIT_PLUGIN, $NVM_PLUGIN]
     agents:
       queue: "{{matrix}}"
@@ -73,7 +81,7 @@ steps:
       DEBUG: "pw:browser"
     matrix:
       - mac
-      #- windows
+      - windows
     notify:
       - github_commit_status:
           context: All E2E Tests

--- a/e2e/blueprints.test.ts
+++ b/e2e/blueprints.test.ts
@@ -25,7 +25,7 @@ test.describe( 'Blueprints', () => {
 		}
 
 		const siteContent = new SiteContent( session.mainWindow, 'My WordPress Website' );
-		await expect( siteContent.siteNameHeading ).toBeVisible( { timeout: 60_000 } );
+		await expect( siteContent.siteNameHeading ).toBeVisible( { timeout: 120_000 } );
 	} );
 
 	test.afterAll( async () => {
@@ -56,7 +56,7 @@ test.describe( 'Blueprints', () => {
 
 		// Wait for site to be created and running
 		const siteContent = new SiteContent( session.mainWindow, siteName );
-		await expect( siteContent.runningButton ).toBeAttached( { timeout: 60_000 } );
+		await expect( siteContent.runningButton ).toBeAttached( { timeout: 120_000 } );
 
 		// Navigate to Settings tab to get admin URL
 		const settingsTab = await siteContent.navigateToTab( 'Settings' );
@@ -92,7 +92,7 @@ test.describe( 'Blueprints', () => {
 
 		// Wait for site to be created and running
 		const siteContent = new SiteContent( session.mainWindow, siteName );
-		await expect( siteContent.runningButton ).toBeAttached( { timeout: 60_000 } );
+		await expect( siteContent.runningButton ).toBeAttached( { timeout: 120_000 } );
 
 		// Navigate to Settings tab to get admin URL
 		const settingsTab = await siteContent.navigateToTab( 'Settings' );
@@ -130,7 +130,7 @@ test.describe( 'Blueprints', () => {
 
 		// Wait for site to be created and running
 		const siteContent = new SiteContent( session.mainWindow, siteName );
-		await expect( siteContent.runningButton ).toBeAttached( { timeout: 60_000 } );
+		await expect( siteContent.runningButton ).toBeAttached( { timeout: 120_000 } );
 
 		// Navigate to Settings tab to get admin URL
 		const settingsTab = await siteContent.navigateToTab( 'Settings' );
@@ -166,7 +166,7 @@ test.describe( 'Blueprints', () => {
 
 		// Wait for site to be created and running
 		const siteContent = new SiteContent( session.mainWindow, siteName );
-		await expect( siteContent.runningButton ).toBeAttached( { timeout: 60_000 } );
+		await expect( siteContent.runningButton ).toBeAttached( { timeout: 120_000 } );
 
 		// Navigate to Settings tab to get admin URL
 		const settingsTab = await siteContent.navigateToTab( 'Settings' );
@@ -204,7 +204,7 @@ test.describe( 'Blueprints', () => {
 
 		// Wait for site to be created and running
 		const siteContent = new SiteContent( session.mainWindow, siteName );
-		await expect( siteContent.runningButton ).toBeAttached( { timeout: 60_000 } );
+		await expect( siteContent.runningButton ).toBeAttached( { timeout: 120_000 } );
 
 		// Navigate to Settings tab to verify site is accessible
 		const settingsTab = await siteContent.navigateToTab( 'Settings' );
@@ -243,7 +243,7 @@ test.describe( 'Blueprints', () => {
 
 		// Wait for site to be created and running
 		const siteContent = new SiteContent( session.mainWindow, siteName );
-		await expect( siteContent.runningButton ).toBeAttached( { timeout: 60_000 } );
+		await expect( siteContent.runningButton ).toBeAttached( { timeout: 120_000 } );
 
 		// Navigate to Settings tab to verify site is accessible
 		const settingsTab = await siteContent.navigateToTab( 'Settings' );

--- a/e2e/sites.test.ts
+++ b/e2e/sites.test.ts
@@ -31,7 +31,7 @@ test.describe( 'Servers', () => {
 		}
 
 		const siteContent = new SiteContent( session.mainWindow, defaultSiteName );
-		await expect( siteContent.siteNameHeading ).toBeVisible( { timeout: 60_000 } );
+		await expect( siteContent.siteNameHeading ).toBeVisible( { timeout: 120_000 } );
 	} );
 
 	test.afterAll( async () => {
@@ -53,7 +53,7 @@ test.describe( 'Servers', () => {
 
 		// Check the site is running
 		const siteContent = new SiteContent( session.mainWindow, siteName );
-		await expect( siteContent.runningButton ).toBeAttached( { timeout: 30_000 } );
+		await expect( siteContent.runningButton ).toBeAttached( { timeout: 120_000 } );
 		expect( await siteContent.siteNameHeading ).toHaveText( siteName );
 
 		// Check a WordPress site has been created

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -12,7 +12,7 @@ export default defineConfig( {
 		trace: 'retain-on-failure',
 	},
 
-	timeout: 60_000,
+	timeout: 180_000,
 
 	// Global expect timeout for all assertions
 	expect: {

--- a/src/lib/windows-helpers.ts
+++ b/src/lib/windows-helpers.ts
@@ -28,10 +28,11 @@ export async function promptWindowsSpeedUpSites( {
 	}
 
 	if (
-		skipIfAlreadyPrompted &&
-		( previousResponse === 'yes' ||
-			dontAskAgain ||
-			( previousResponse === 'no' && previousAppVersion === currentAppVersion ) )
+		process.env.E2E ||
+		( skipIfAlreadyPrompted &&
+			( previousResponse === 'yes' ||
+				dontAskAgain ||
+				( previousResponse === 'no' && previousAppVersion === currentAppVersion ) ) )
 	) {
 		return;
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-34

## Proposed Changes

- Add Windows E2E tests to CI
- Group Unit Tests and E2E CI checks

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Code and CI logs review
 
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
