### PR TITLE
Update arrow symbol in Get Help when Studio can't connect sites

### DIFF
--- a/src/modules/sync/components/sync-connected-sites.tsx
+++ b/src/modules/sync/components/sync-connected-sites.tsx
@@ -399,7 +399,7 @@ const SyncConnectedSiteSection = ( {
 				<div className="flex items-center min-h-14 border-b border-a8c-gray-0 px-8">
 					<div className="text-[#3C434A]">
 						{ createInterpolateElement(
-							__( "Studio couldn't connect to this site. <button>Get help ↗️</button>" ),
+							__( "Studio couldn't connect to this site. <button>Get help ↗</button>" ),
 							{
 								button: (
 									<Button


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

Closes STU-881

## Proposed Changes

This PR updates the arrow symbol in `Get help` text for when Studio can not connect to WP.com sites:

<img width="989" height="74" alt="Screenshot 2025-10-20 at 3 37 47 PM" src="https://github.com/user-attachments/assets/6d203db4-699e-44e3-a0b0-1bef279debf6" />

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
* Apply the following diff:

```diff --git a/src/modules/sync/components/sync-connected-sites.tsx b/src/modules/sync/components/sync-connected-sites.tsx
index 61cbee91..533ad64b 100644
--- a/src/modules/sync/components/sync-connected-sites.tsx
+++ b/src/modules/sync/components/sync-connected-sites.tsx
@@ -351,7 +351,8 @@ const SyncConnectedSiteSection = ( {
        };
 
        const mainSite = section.connectedSites.find( ( item ) => ! item.isStaging );
-       const hasConnectionErrors = mainSite?.syncSupport !== 'already-connected';
+       //const hasConnectionErrors = mainSite?.syncSupport !== 'already-connected';
+       const hasConnectionErrors = true;
        const isPulling = section.connectedSites.some( ( site ) =>
                isSiteIdPulling( selectedSite.id, site.id )
        );
```
* Navigate to `Sync` tab
* Confirm that you can see the correct arrow by the `Get help` text

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
