### PR TITLE
Fix plugin download timeouts by using low-speed timeout instead of hard timeout

### DIFF
--- a/src/lib/wordpress-provider/playground-cli/mu-plugins.ts
+++ b/src/lib/wordpress-provider/playground-cli/mu-plugins.ts
@@ -259,14 +259,23 @@ function getStandardMuPlugins( options: Partial< WordPressServerOptions > ): MuP
 	muPlugins.push( {
 		filename: '0-http-request-timeout.php',
 		content: `<?php
-		// Increase default timeouts to 30 seconds to accommodate slower network conditions and larger requests
+		// Use low-speed timeout instead of hard timeout to handle both large downloads and stalled connections
+		// - Allows large plugin downloads (e.g., Jetpack 33MB) to complete with reasonable internet speeds
+		// - Fails fast if connection stalls (speed drops below 1KB/s for 30 seconds)
+		// - Provides quick feedback for genuinely broken/unresponsive servers
+		// Match WordPress core's timeout for plugin downloads (300s)
 		add_filter( 'http_request_timeout', function() {
-			return 30;
+			return 300; // 5 minutes - matches WordPress core, low-speed timeout catches stalls
 		} );
 
 		add_action('http_api_curl', function($curl, $url, $options) {
+			// Abort if connection can't be established within 30 seconds
 			curl_setopt( $curl, CURLOPT_CONNECTTIMEOUT, 30 );
-			curl_setopt($curl, CURLOPT_TIMEOUT, 30);
+
+			// Abort if speed drops below 1KB/s for 30 consecutive seconds
+			// This allows slow but steady downloads while catching truly stalled connections
+			curl_setopt( $curl, CURLOPT_LOW_SPEED_LIMIT, 1024 ); // 1KB/s minimum
+			curl_setopt( $curl, CURLOPT_LOW_SPEED_TIME, 30 );    // Must stay above limit for 30s
 			return $curl;
 		}, 1, 3);
 		`,

--- a/vendor/wp-now/src/wp-now.ts
+++ b/vendor/wp-now/src/wp-now.ts
@@ -589,14 +589,23 @@ async function mountInternalMuPlugins( php: PHP, options: WPNowOptions ) {
 	php.writeFile(
 		path.posix.join( PLAYGROUND_INTERNAL_MU_PLUGINS_FOLDER, '0-http-request-timeout.php' ),
 		`<?php
-		// Increase default timeouts to 30 seconds to accommodate slower network conditions and larger requests
+		// Use low-speed timeout instead of hard timeout to handle both large downloads and stalled connections
+		// - Allows large plugin downloads (e.g., Jetpack 33MB) to complete with reasonable internet speeds
+		// - Fails fast if connection stalls (speed drops below 1KB/s for 30 seconds)
+		// - Provides quick feedback for genuinely broken/unresponsive servers
+		// Match WordPress core's timeout for plugin downloads (300s)
 		add_filter( 'http_request_timeout', function() {
-			return 30;
+			return 300; // 5 minutes - matches WordPress core, low-speed timeout catches stalls
 		} );
 
 		add_action('http_api_curl', function($curl, $url, $options) {
+			// Abort if connection can't be established within 30 seconds
 			curl_setopt( $curl, CURLOPT_CONNECTTIMEOUT, 30 );
-			curl_setopt($curl, CURLOPT_TIMEOUT, 30);
+
+			// Abort if speed drops below 1KB/s for 30 consecutive seconds
+			// This allows slow but steady downloads while catching truly stalled connections
+			curl_setopt( $curl, CURLOPT_LOW_SPEED_LIMIT, 1024 ); // 1KB/s minimum
+			curl_setopt( $curl, CURLOPT_LOW_SPEED_TIME, 30 );    // Must stay above limit for 30s
 			return $curl;
 		}, 1, 3);
 		`


### PR DESCRIPTION
## Related issues

- Fixes STU-858

## Proposed Changes

- Replaced hard CURLOPT_TIMEOUT (30s) with low-speed timeout to allow large plugin downloads
- Set CURLOPT_LOW_SPEED_LIMIT to 1KB/s and CURLOPT_LOW_SPEED_TIME to 30s in the HTTP request timeout mu-plugin
- Kept overall timeout at 300s timeout
- Updated both src/lib/wordpress-provider/playground-cli/mu-plugins.ts and vendor/wp-now/src/wp-now.ts
- This allows large downloads (like Jetpack at 33MB) to complete while still failing fast on stalled connections

## Testing Instructions

- Install Network Link Conditioner (from Apple's Additional Tools for Xcode)
- Set throttling to a slow profile (e.g., "3G" or "Edge")
- In Studio, navigate to /wp-admin/plugin-install.php
- Try installing Jetpack plugin (33MB)
- Expected: Should complete successfully even on throttled connection (may take several minutes)
- With the old 30s timeout, this would fail with "Operation timed out after 30014 milliseconds"
- Optionally verify with normal internet by turning off Network Link Conditioner and installing Jetpack - should complete quickly without any timeout issues

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?