### PR TITLE
Update build scripts to support Windows ARM64 binaries

### DIFF
--- a/.buildkite/commands/build-for-windows.ps1
+++ b/.buildkite/commands/build-for-windows.ps1
@@ -1,7 +1,10 @@
-# Accept a parameter to determine build type (required)
+# Accept parameters to determine build type and architecture
 param (
     [Parameter(Mandatory=$true)]
-    [string]$BuildType
+    [string]$BuildType,
+    
+    [Parameter(Mandatory=$false)]
+    [string]$Architecture = "x64"
 )
 
 # Stop script execution when a non-terminating error occurs
@@ -11,10 +14,17 @@ $ErrorActionPreference = "Stop"
 $BUILD_TYPE_DEV = "dev"
 $BUILD_TYPE_RELEASE = "release"
 $VALID_BUILD_TYPES = @($BUILD_TYPE_DEV, $BUILD_TYPE_RELEASE)
+$VALID_ARCHITECTURES = @("x64", "arm64")
 
 # Validate build type
 if ($BuildType -notin $VALID_BUILD_TYPES) {
     Write-Host "Error: BuildType must be one of: $($VALID_BUILD_TYPES -join ', ')" -ForegroundColor Red
+    Exit 1
+}
+
+# Validate architecture
+if ($Architecture -notin $VALID_ARCHITECTURES) {
+    Write-Host "Error: Architecture must be one of: $($VALID_ARCHITECTURES -join ', ')" -ForegroundColor Red
     Exit 1
 }
 
@@ -26,7 +36,7 @@ Write-Host "--- :npm: Installing Node dependencies"
 bash .buildkite/commands/install-node-dependencies.sh
 If ($LastExitCode -ne 0) { Exit $LastExitCode }
 
-Write-Host "--- :node: Building App for Windows ($BuildType)"
+Write-Host "--- :node: Building App for Windows ($BuildType) - $Architecture"
 
 # Run appropriate script based on build type
 if ($BuildType -eq $BUILD_TYPE_DEV) {
@@ -40,7 +50,11 @@ if ($BuildType -eq $BUILD_TYPE_DEV) {
 	If ($LastExitCode -ne 0) { Exit $LastExitCode }
 }
 
-npm run make
+# Set architecture environment variable for AppX packaging
+$env:FILE_ARCHITECTURE=$Architecture
+
+Write-Host "Building for architecture: $Architecture"
+npm run "make:windows-$Architecture"
 If ($LastExitCode -ne 0) { Exit $LastExitCode }
 
 # Rename NuGet package files with generic name

--- a/.buildkite/commands/build-for-windows.ps1
+++ b/.buildkite/commands/build-for-windows.ps1
@@ -36,7 +36,7 @@ Write-Host "--- :npm: Installing Node dependencies"
 bash .buildkite/commands/install-node-dependencies.sh
 If ($LastExitCode -ne 0) { Exit $LastExitCode }
 
-Write-Host "--- :node: Building App for Windows ($BuildType) - $Architecture"
+Write-Host "--- :node: Building App for Windows ($BuildType - $Architecture)"
 
 # Run appropriate script based on build type
 if ($BuildType -eq $BUILD_TYPE_DEV) {

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -129,23 +129,26 @@ steps:
               context: All Mac Dev Builds
     if: build.tag !~ /^v[0-9]+/
 
-  - label: 🔨 Windows Dev Build
+  - group: 📦 Build for Windows
     key: dev-windows
-    command: npm run make:windows-dev
-    artifact_paths:
-      - out\**\studio-setup.exe
-      - out\**\studio-update.nupkg
-      - out\**\RELEASES
-      - out\**\*.appx
-    agents:
-      queue: windows
-    env:
-      IS_DEV_BUILD: true
-    plugins: [$CI_TOOLKIT_PLUGIN, $NVM_PLUGIN]
+    steps:
+      - label: 🔨 Windows Dev Build - {{matrix}}
+        agents:
+          queue: windows
+        command: powershell -File .buildkite/commands/build-for-windows.ps1 -BuildType dev -Architecture {{matrix}}
+        artifact_paths:
+          - out\**\studio-setup.exe
+          - out\**\studio-update.nupkg
+          - out\**\RELEASES
+          - out\**\*.appx
+        plugins: [$CI_TOOLKIT_PLUGIN, $NVM_PLUGIN]
+        matrix:
+          - x64
+          - arm64
+        notify:
+          - github_commit_status:
+              context: All Windows Dev Builds
     if: build.tag !~ /^v[0-9]+/
-    notify:
-      - github_commit_status:
-          context: Windows Dev Build
 
   - label: ":rocket: Distribute Dev Builds"
     command: |
@@ -234,21 +237,26 @@ steps:
               context: All Mac Release Builds
     if: build.tag =~ /^v[0-9]+/
 
-  - label: 🔨 Windows Release Build
+  - group: 📦 Build for Windows
     key: release-windows
-    agents:
-      queue: windows
-    plugins: [$CI_TOOLKIT_PLUGIN, $NVM_PLUGIN]
-    command: npm run make:windows-release
-    artifact_paths:
-      - out\**\studio-setup.exe
-      - out\**\studio-update.nupkg
-      - out\**\RELEASES
-      - out\**\*.appx
+    steps:
+      - label: 🔨 Windows Release Build - {{matrix}}
+        agents:
+          queue: windows
+        command: powershell -File .buildkite/commands/build-for-windows.ps1 -BuildType release -Architecture {{matrix}}
+        artifact_paths:
+          - out\**\studio-setup.exe
+          - out\**\studio-update.nupkg
+          - out\**\RELEASES
+          - out\**\*.appx
+        plugins: [$CI_TOOLKIT_PLUGIN, $NVM_PLUGIN]
+        matrix:
+          - x64
+          - arm64
+        notify:
+          - github_commit_status:
+              context: All Windows Release Builds
     if: build.tag =~ /^v[0-9]+/
-    notify:
-      - github_commit_status:
-          context: Windows Release Build
 
   - label: ":rocket: Publish Release Builds"
     command: |

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -152,31 +152,57 @@ def distribute_builds(
       extension: 'dmg',
       name: 'Mac Apple Silicon (DMG)'
     },
-    windows: {
+    windows_x64: {
       binary_path: File.join(BUILDS_FOLDER, 'make', 'squirrel.windows', 'x64', 'studio-setup.exe'),
-      filename_core: 'win32',
+      filename_core: 'win32-x64',
       extension: 'exe',
-      name: 'Windows'
+      name: 'Windows x64'
     },
-    windows_update: {
+    windows_x64_update: {
       binary_path: File.join(BUILDS_FOLDER, 'make', 'squirrel.windows', 'x64', "studio-update.nupkg"),
-      filename_core: 'win32',
+      filename_core: 'win32-x64',
       suffix: 'full',
       extension: 'nupkg',
-      name: 'Windows Update'
+      name: 'Windows x64 Update'
     },
-    windows_appx: {
-      binary_path: File.join(BUILDS_FOLDER, 'Studio-appx-signed', "Studio #{appx_version}.appx"),
-      filename_core: 'win32',
+    windows_x64_appx: {
+      binary_path: File.join(BUILDS_FOLDER, 'Studio-appx-x64-signed', "Studio #{appx_version}.appx"),
+      filename_core: 'win32-x64',
       extension: 'appx',
-      name: 'Windows (Appx)'
+      name: 'Windows x64 (Appx)'
     },
-    windows_appx_unsigned: {
-      binary_path: File.join(BUILDS_FOLDER, 'Studio-appx-unsigned', "Studio #{appx_version} unsigned.appx"),
-      filename_core: 'win32',
+    windows_x64_appx_unsigned: {
+      binary_path: File.join(BUILDS_FOLDER, 'Studio-appx-x64-unsigned', "Studio #{appx_version} unsigned.appx"),
+      filename_core: 'win32-x64',
       suffix: 'unsigned',
       extension: 'appx',
-      name: 'Windows (Unsigned Appx)'
+      name: 'Windows x64 (Unsigned Appx)'
+    },
+    windows_arm64: {
+      binary_path: File.join(BUILDS_FOLDER, 'make', 'squirrel.windows', 'arm64', 'studio-setup.exe'),
+      filename_core: 'win32-arm64',
+      extension: 'exe',
+      name: 'Windows ARM64'
+    },
+    windows_arm64_update: {
+      binary_path: File.join(BUILDS_FOLDER, 'make', 'squirrel.windows', 'arm64', "studio-update.nupkg"),
+      filename_core: 'win32-arm64',
+      suffix: 'full',
+      extension: 'nupkg',
+      name: 'Windows ARM64 Update'
+    },
+    windows_arm64_appx: {
+      binary_path: File.join(BUILDS_FOLDER, 'Studio-appx-arm64-signed', "Studio #{appx_version}.appx"),
+      filename_core: 'win32-arm64',
+      extension: 'appx',
+      name: 'Windows ARM64 (Appx)'
+    },
+    windows_arm64_appx_unsigned: {
+      binary_path: File.join(BUILDS_FOLDER, 'Studio-appx-arm64-unsigned', "Studio #{appx_version} unsigned.appx"),
+      filename_core: 'win32-arm64',
+      suffix: 'unsigned',
+      extension: 'appx',
+      name: 'Windows ARM64 (Unsigned Appx)'
     },
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -484,6 +484,7 @@
 			"integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.27.1",
 				"@babel/generator": "^7.28.3",
@@ -2541,6 +2542,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			},
@@ -2564,6 +2566,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -3784,6 +3787,7 @@
 			"version": "11.11.3",
 			"resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.11.3.tgz",
 			"integrity": "sha512-Cnn0kuq4DoONOMcnoVsTOR8E+AdnKFf//6kUWc4LCdnxj31pZWn7rIULd6Y7/Js1PiPHzn7SKCM9vB/jBni8eA==",
+			"peer": true,
 			"dependencies": {
 				"@babel/runtime": "^7.18.3",
 				"@emotion/babel-plugin": "^11.11.0",
@@ -4696,6 +4700,7 @@
 			"integrity": "sha512-yl43JD/86CIj3Mz5mvvLJqAOfIup7ncxfJ0Btnl0/v5TouVUyeEdcpknfgc+yMevS/48oH9WAkkw93m7otLb/A==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@inquirer/checkbox": "^3.0.1",
 				"@inquirer/confirm": "^4.0.1",
@@ -5212,6 +5217,7 @@
 			"integrity": "sha512-7oEJT19WW4oe6HR7oLRvHxwlJk2gev0U9px3ufs8sX9PoD1Eza68KF0/tlN7X0dq/WVsBScXQGgCldA1V9Y/jA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@jest/environment": "30.0.5",
 				"@jest/expect": "30.0.5",
@@ -5855,6 +5861,7 @@
 			"version": "5.2.1",
 			"resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.1.tgz",
 			"integrity": "sha512-dKYCMuPO1bmrpuogcjQ8z7ICCH3FP6WmxpwC03yjzGfZhj9fTJg6+bS1+UAplekbN2C+M61UNllGOOoAfGCrdQ==",
+			"peer": true,
 			"dependencies": {
 				"@octokit/auth-token": "^4.0.0",
 				"@octokit/graphql": "^7.1.0",
@@ -6167,6 +6174,7 @@
 			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
 			"integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
 			"license": "Apache-2.0",
+			"peer": true,
 			"engines": {
 				"node": ">=8.0.0"
 			}
@@ -6188,6 +6196,7 @@
 			"resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.30.1.tgz",
 			"integrity": "sha512-s5vvxXPVdjqS3kTLKMeBMvop9hbWkwzBpu+mUO2M7sZtlkyDJGwFe33wRKnbaYDo8ExRVBIIdwIGrqpxHuKttA==",
 			"license": "Apache-2.0",
+			"peer": true,
 			"engines": {
 				"node": ">=14"
 			},
@@ -6200,6 +6209,7 @@
 			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
 			"integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"@opentelemetry/semantic-conventions": "1.28.0"
 			},
@@ -6224,6 +6234,7 @@
 			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.57.2.tgz",
 			"integrity": "sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==",
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"@opentelemetry/api-logs": "0.57.2",
 				"@types/shimmer": "^1.2.0",
@@ -6629,6 +6640,7 @@
 			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.30.1.tgz",
 			"integrity": "sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==",
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"@opentelemetry/core": "1.30.1",
 				"@opentelemetry/semantic-conventions": "1.28.0"
@@ -6654,6 +6666,7 @@
 			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.30.1.tgz",
 			"integrity": "sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==",
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"@opentelemetry/core": "1.30.1",
 				"@opentelemetry/resources": "1.30.1",
@@ -6680,6 +6693,7 @@
 			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.37.0.tgz",
 			"integrity": "sha512-JD6DerIKdJGmRp4jQyX5FlrQjA4tjOw1cvfsPAZXfOOEErMUHjPcPSICS+6WnM0nB0efSFARh0KAZss+bvExOA==",
 			"license": "Apache-2.0",
+			"peer": true,
 			"engines": {
 				"node": ">=14"
 			}
@@ -6716,7 +6730,6 @@
 			"hasInstallScript": true,
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"detect-libc": "^1.0.3",
 				"is-glob": "^4.0.3",
@@ -6759,7 +6772,6 @@
 			"os": [
 				"android"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">= 10.0.0"
 			},
@@ -6781,7 +6793,6 @@
 			"os": [
 				"darwin"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">= 10.0.0"
 			},
@@ -6803,7 +6814,6 @@
 			"os": [
 				"darwin"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">= 10.0.0"
 			},
@@ -6825,7 +6835,6 @@
 			"os": [
 				"freebsd"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">= 10.0.0"
 			},
@@ -6847,7 +6856,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">= 10.0.0"
 			},
@@ -6869,7 +6877,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">= 10.0.0"
 			},
@@ -6891,7 +6898,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">= 10.0.0"
 			},
@@ -6913,7 +6919,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">= 10.0.0"
 			},
@@ -6935,7 +6940,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">= 10.0.0"
 			},
@@ -6957,7 +6961,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">= 10.0.0"
 			},
@@ -6979,7 +6982,6 @@
 			"os": [
 				"win32"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">= 10.0.0"
 			},
@@ -7001,7 +7003,6 @@
 			"os": [
 				"win32"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">= 10.0.0"
 			},
@@ -7023,7 +7024,6 @@
 			"os": [
 				"win32"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">= 10.0.0"
 			},
@@ -7039,7 +7039,6 @@
 			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
-			"peer": true,
 			"bin": {
 				"detect-libc": "bin/detect-libc.js"
 			},
@@ -8489,6 +8488,7 @@
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"@swc/counter": "^0.1.3",
 				"@swc/types": "^0.1.24"
@@ -8713,7 +8713,8 @@
 			"resolved": "https://registry.npmjs.org/@swc/wasm/-/wasm-1.13.5.tgz",
 			"integrity": "sha512-ZBZcxieydxNwgEU9eFAXGMaDb1Xoh+ZkZcUQ27LNJzc2lPSByoL6CSVqnYiaVo+n9JgqbYyHlMq+i7z0wRNTfA==",
 			"dev": true,
-			"license": "Apache-2.0"
+			"license": "Apache-2.0",
+			"peer": true
 		},
 		"node_modules/@szmarczak/http-timer": {
 			"version": "4.0.6",
@@ -8765,6 +8766,7 @@
 			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.3.4.tgz",
 			"integrity": "sha512-FlS4ZWlp97iiNWig0Muq8p+3rVDjRiYE+YKGbAqXOu9nwJFFOdL00kFpz42M+4huzYi86vAK1sOOfyOG45muIQ==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.10.4",
 				"@babel/runtime": "^7.12.5",
@@ -9050,6 +9052,7 @@
 			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
 			"integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@types/estree": "*",
 				"@types/json-schema": "*"
@@ -9175,6 +9178,7 @@
 			"integrity": "sha512-XTYugzhuwqWjws0CVz8QpM36+T+Dz5mTEBKhNs/esGLnCIlGdRy+Dq78NRjd7ls7r8BC8ZRMOrKlkO1hU0JOwA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"expect": "^30.0.0",
 				"pretty-format": "^30.0.0"
@@ -9329,6 +9333,7 @@
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.10.tgz",
 			"integrity": "sha512-anNG/V/Efn/YZY4pRzbACnKxNKoBng2VTFydVu8RRs5hQjikP8CQfaeAV59VFSCzKNp90mXiVXW2QzV56rwMrg==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"undici-types": "~6.21.0"
 			}
@@ -9389,6 +9394,7 @@
 			"version": "18.3.5",
 			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.5.tgz",
 			"integrity": "sha512-WeqMfGJLGuLCqHGYRGHxnKrXcTitc6L/nBUWfWPcTarG3t9PsquqUMuVeXZeca+mglY4Vo5GZjCi0A3Or2lnxA==",
+			"peer": true,
 			"dependencies": {
 				"@types/prop-types": "*",
 				"csstype": "^3.0.2"
@@ -9555,6 +9561,7 @@
 			"integrity": "sha512-pUXGCuHnnKw6PyYq93lLRiZm3vjuslIy7tus1lIQTYVK9bL8XBgJnCWm8a0KcTtHC84Yya1Q6rtll+duSMj0dg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/scope-manager": "8.39.1",
 				"@typescript-eslint/types": "8.39.1",
@@ -11198,6 +11205,7 @@
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
 			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -11285,6 +11293,7 @@
 			"version": "6.12.6",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
 			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -12197,6 +12206,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"baseline-browser-mapping": "^2.8.9",
 				"caniuse-lite": "^1.0.30001746",
@@ -14905,6 +14915,7 @@
 			"deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.2.0",
 				"@eslint-community/regexpp": "^4.6.1",
@@ -14961,6 +14972,7 @@
 			"integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"eslint-config-prettier": "bin/cli.js"
 			},
@@ -15085,6 +15097,7 @@
 			"integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@rtsao/scc": "^1.1.0",
 				"array-includes": "^3.1.9",
@@ -17154,8 +17167,7 @@
 			"integrity": "sha512-+chQdDfvscSF1SJqv2gn4SRO2ZyS3xL3r7IW/wWEEzrzLisnOlKiQu5ytC/BVNcS15C39WT2Hg/bjKjDMcu+zg==",
 			"dev": true,
 			"license": "MIT",
-			"optional": true,
-			"peer": true
+			"optional": true
 		},
 		"node_modules/import-fresh": {
 			"version": "3.3.0",
@@ -18265,6 +18277,7 @@
 			"integrity": "sha512-y2mfcJywuTUkvLm2Lp1/pFX8kTgMO5yyQGq/Sk/n2mN7XWYp4JsCZ/QXW34M8YScgk8bPZlREH04f6blPnoHnQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@jest/core": "30.0.5",
 				"@jest/types": "30.0.5",
@@ -19573,6 +19586,7 @@
 			"integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"cssstyle": "^4.2.1",
 				"data-urls": "^5.0.0",
@@ -21556,6 +21570,7 @@
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
 			"integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.1",
 				"json-schema-traverse": "^1.0.0",
@@ -21965,8 +21980,7 @@
 			"integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
 			"dev": true,
 			"license": "MIT",
-			"optional": true,
-			"peer": true
+			"optional": true
 		},
 		"node_modules/node-api-version": {
 			"version": "0.2.1",
@@ -23179,6 +23193,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"nanoid": "^3.3.11",
 				"picocolors": "^1.1.1",
@@ -23491,6 +23506,7 @@
 			"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-3.0.3.tgz",
 			"integrity": "sha512-X4UlrxDTH8oom9qXlcjnydsjAOD2BmB6yFmvS4Z2zdTzqqpRWb+fbqrH412+l+OUXmbzJlSXjlMFYPgYG12IAA==",
 			"dev": true,
+			"peer": true,
 			"bin": {
 				"prettier": "bin/prettier.cjs"
 			},
@@ -23803,6 +23819,7 @@
 			"version": "18.3.1",
 			"resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
 			"integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+			"peer": true,
 			"dependencies": {
 				"loose-envify": "^1.1.0"
 			},
@@ -23854,6 +23871,7 @@
 			"version": "18.3.1",
 			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
 			"integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+			"peer": true,
 			"dependencies": {
 				"loose-envify": "^1.1.0",
 				"scheduler": "^0.23.2"
@@ -23897,6 +23915,7 @@
 			"resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
 			"integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@types/use-sync-external-store": "^0.0.6",
 				"use-sync-external-store": "^1.4.0"
@@ -24145,7 +24164,8 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
 			"integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/redux-thunk": {
 			"version": "3.1.0",
@@ -24598,6 +24618,7 @@
 			"integrity": "sha512-BgLRGy7tNS9H66aIMASq1qSYbAAJV6Z6WR4QYTvj5FgF15rZ/ympT1uixHXwzbZUBDbkvqUI1KR0fH1FhMaQ9w==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@types/estree": "1.0.8"
 			},
@@ -24749,7 +24770,6 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"chokidar": "^4.0.0",
 				"immutable": "^5.0.2",
@@ -24772,7 +24792,6 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"readdirp": "^4.0.1"
 			},
@@ -24790,7 +24809,6 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
-			"peer": true,
 			"engines": {
 				"node": ">= 14.18.0"
 			},
@@ -26291,6 +26309,7 @@
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
 			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
 				"fast-uri": "^3.0.1",
@@ -26477,6 +26496,7 @@
 			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -26799,6 +26819,7 @@
 			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
 			"integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"@cspotcode/source-map-support": "^0.8.0",
 				"@tsconfig/node10": "^1.0.7",
@@ -27038,6 +27059,7 @@
 			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
 			"dev": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -27333,6 +27355,7 @@
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"napi-postinstall": "^0.3.0"
 			},
@@ -27669,6 +27692,7 @@
 			"integrity": "sha512-4cKBO9wR75r0BeIWWWId9XK9Lj6La5X846Zw9dFfzMRw38IlTk2iCcUt6hsyiDRcPidc55ZParFYDXi0nXOeLQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.25.0",
 				"fdir": "^6.5.0",
@@ -27998,6 +28022,7 @@
 			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -28086,6 +28111,7 @@
 			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.102.1.tgz",
 			"integrity": "sha512-7h/weGm9d/ywQ6qzJ+Xy+r9n/3qgp/thalBbpOi5i223dPXKi04IBtqPN9nTd+jBc7QKfvDbaBnFipYp4sJAUQ==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@types/eslint-scope": "^3.7.7",
 				"@types/estree": "^1.0.8",
@@ -28150,6 +28176,7 @@
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
 			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
 				"fast-uri": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
 		"make": "electron-vite build --outDir=dist && electron-forge make",
 		"make:windows-release": "powershell -File .buildkite/commands/build-for-windows.ps1 -BuildType release",
 		"make:windows-dev": "powershell -File .buildkite/commands/build-for-windows.ps1 -BuildType dev",
+		"make:windows-x64": "electron-vite build --outDir=dist && electron-forge make --arch=x64 --platform=win32",
+		"make:windows-arm64": "electron-vite build --outDir=dist && electron-forge make --arch=arm64 --platform=win32",
 		"make:macos-x64": "electron-vite build --outDir=dist && SKIP_DMG=true FILE_ARCHITECTURE=x64 electron-forge make --arch=x64 --platform=darwin",
 		"make:macos-arm64": "electron-vite build --outDir=dist && SKIP_DMG=true FILE_ARCHITECTURE=arm64 electron-forge make --arch=arm64 --platform=darwin",
 		"make:dmg-x64": "FILE_ARCHITECTURE=x64 node ./scripts/make-dmg.mjs",

--- a/package.json
+++ b/package.json
@@ -19,8 +19,6 @@
 		"postinstall": "patch-package && ts-node scripts/download-wp-server-files.ts && node ./scripts/download-available-site-translations.mjs",
 		"package": "electron-vite build --outDir=dist && electron-forge package",
 		"make": "electron-vite build --outDir=dist && electron-forge make",
-		"make:windows-release": "powershell -File .buildkite/commands/build-for-windows.ps1 -BuildType release",
-		"make:windows-dev": "powershell -File .buildkite/commands/build-for-windows.ps1 -BuildType dev",
 		"make:windows-x64": "electron-vite build --outDir=dist && electron-forge make --arch=x64 --platform=win32",
 		"make:windows-arm64": "electron-vite build --outDir=dist && electron-forge make --arch=arm64 --platform=win32",
 		"make:macos-x64": "electron-vite build --outDir=dist && SKIP_DMG=true FILE_ARCHITECTURE=x64 electron-forge make --arch=x64 --platform=darwin",

--- a/scripts/generate-releases-manifest.mjs
+++ b/scripts/generate-releases-manifest.mjs
@@ -14,8 +14,14 @@
 //       }
 //     },
 //     "win32": {
-//       "sha": "30a8251",
-//       "url": "https://cdn.a8c-ci.services/studio/studio-win32-v1.2.3-42-full.nupkg"
+//       "arm64": {
+//         "sha": "30a8251",
+//         "url": "https://cdn.a8c-ci.services/studio/studio-win32-arm64-v1.2.3-42-full.nupkg"
+//       },
+//       "x64": {
+//         "sha": "30a8251",
+//         "url": "https://cdn.a8c-ci.services/studio/studio-win32-x64-v1.2.3-42-full.nupkg"
+//       }
 //     }
 //   },
 //   "1.0.0": {
@@ -59,16 +65,16 @@ console.log( 'Downloading current manifest ...' );
 
 const releasesPath = path.join( __dirname, '..', 'out', 'releases.json' );
 
-async function getWindowsReleaseInfo() {
+async function getWindowsReleaseInfo( arch = 'x64' ) {
 	let windowsReleaseInfo = {};
 	try {
 		windowsReleaseInfo = await fs.readFile(
-			path.join( __dirname, '..', 'out', 'make', 'squirrel.windows', 'x64', 'RELEASES' ),
+			path.join( __dirname, '..', 'out', 'make', 'squirrel.windows', arch, 'RELEASES' ),
 			'utf8'
 		);
 	} catch ( error ) {
 		console.log(
-			`Couldn't read RELEASES file of Windows build, please ensure that the file exists to generate the release manifest.`
+			`Couldn't read RELEASES file of Windows ${ arch } build, please ensure that the file exists to generate the release manifest.`
 		);
 		process.exit( 1 );
 	}
@@ -133,11 +139,18 @@ if ( isDevBuild ) {
 	};
 
 	// Windows
-	const windowsReleaseInfo = await getWindowsReleaseInfo();
-	releasesData[ 'dev' ][ 'win32' ] = {
-		sha: windowsReleaseInfo.sha1,
-		url: `${ cdnURL }/${ baseName }-win32-v${ version }-full.nupkg`,
-		size: windowsReleaseInfo.size,
+	releasesData[ 'dev' ][ 'win32' ] = releasesData[ 'dev' ][ 'win32' ] ?? {};
+	const windowsX64ReleaseInfo = await getWindowsReleaseInfo( 'x64' );
+	releasesData[ 'dev' ][ 'win32' ][ 'x64' ] = {
+		sha: windowsX64ReleaseInfo.sha1,
+		url: `${ cdnURL }/${ baseName }-win32-x64-v${ version }-full.nupkg`,
+		size: windowsX64ReleaseInfo.size,
+	};
+	const windowsArm64ReleaseInfo = await getWindowsReleaseInfo( 'arm64' );
+	releasesData[ 'dev' ][ 'win32' ][ 'arm64' ] = {
+		sha: windowsArm64ReleaseInfo.sha1,
+		url: `${ cdnURL }/${ baseName }-win32-arm64-v${ version }-full.nupkg`,
+		size: windowsArm64ReleaseInfo.size,
 	};
 
 	await fs.writeFile( releasesPath, JSON.stringify( releasesData, null, 2 ) );
@@ -159,11 +172,18 @@ if ( isDevBuild ) {
 	};
 
 	// Windows
-	const windowsRelease = await getWindowsReleaseInfo();
-	releasesData[ version ][ 'win32' ] = {
-		sha: windowsRelease.sha1,
-		url: `${ cdnURL }/${ baseName }-win32-v${ version }-full.nupkg`,
-		size: windowsRelease.size,
+	releasesData[ version ][ 'win32' ] = releasesData[ version ][ 'win32' ] ?? {};
+	const windowsX64Release = await getWindowsReleaseInfo( 'x64' );
+	releasesData[ version ][ 'win32' ][ 'x64' ] = {
+		sha: windowsX64Release.sha1,
+		url: `${ cdnURL }/${ baseName }-win32-x64-v${ version }-full.nupkg`,
+		size: windowsX64Release.size,
+	};
+	const windowsArm64Release = await getWindowsReleaseInfo( 'arm64' );
+	releasesData[ version ][ 'win32' ][ 'arm64' ] = {
+		sha: windowsArm64Release.sha1,
+		url: `${ cdnURL }/${ baseName }-win32-arm64-v${ version }-full.nupkg`,
+		size: windowsArm64Release.size,
 	};
 
 	await fs.writeFile( releasesPath, JSON.stringify( releasesData, null, 2 ) );

--- a/scripts/package-appx.mjs
+++ b/scripts/package-appx.mjs
@@ -42,6 +42,10 @@ const packageJson = JSON.parse( packageJsonText );
 const outPath = path.join( __dirname, '..', 'out' );
 const assetsPath = path.join( __dirname, '..', 'assets', 'appx' );
 
+// Get architecture from environment variable, default to x64 for backward compatibility
+const architecture = process.env.FILE_ARCHITECTURE || 'x64';
+console.log( `~~~ Packaging for architecture: ${ architecture }` );
+
 const normalizeWindowsVersion = ( version ) => {
 	const noPrerelease = version.replace( /-.*/, '' );
 	return `${ noPrerelease }.0`;
@@ -53,7 +57,7 @@ const appxName = packageJson.productName + '-appx';
 
 const sharedOptions = {
 	containerVirtualization: false,
-	inputDirectory: path.resolve( outPath, 'Studio-win32-x64' ),
+	inputDirectory: path.resolve( outPath, `Studio-win32-${ architecture }` ),
 	packageVersion: appStoreVersion,
 	// Results in Id being invalid (might just be a matter of escaping, though)
 	// packageName: 'WordPress Studio',
@@ -69,7 +73,7 @@ const sharedOptions = {
 	identityName: '22490Automattic.StudiobyWordPress.com',
 };
 
-const appxOutputPathUnsigned = path.resolve( outPath, `${ appxName }-unsigned` );
+const appxOutputPathUnsigned = path.resolve( outPath, `${ appxName }-${ architecture }-unsigned` );
 console.log(
 	`~~~ Creating unsigned .appx for Microsoft Store submission upload at ${ appxOutputPathUnsigned }...`
 );
@@ -82,7 +86,7 @@ await convertToWindowsStore( {
 	outputDirectory: appxOutputPathUnsigned,
 } );
 
-const appxOutputPathSigned = path.resolve( outPath, `${ appxName }-signed` );
+const appxOutputPathSigned = path.resolve( outPath, `${ appxName }-${ architecture }-signed` );
 console.log( `~~~ Creating signed .appx for local testing at ${ appxOutputPathSigned }...` );
 
 await convertToWindowsStore( {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Related to STU-59

## Proposed Changes

Adds support for building Windows ARM64 binaries alongside x64, following the same architecture matrix pattern used for macOS builds.

### Changes

**Build Scripts:**
- Added `make:windows-x64` and `make:windows-arm64` npm scripts
- Updated `.buildkite/commands/build-for-windows.ps1` to accept architecture parameter
- Made `scripts/package-appx.mjs` architecture-aware

**CI Pipeline:**
- Converted Windows Dev/Release builds to use matrix builds for both x64 and arm64
- Both architectures now build in parallel

**Distribution:**
- Updated Fastlane to handle both Windows architectures separately
- Modified `scripts/generate-releases-manifest.mjs` to generate architecture-specific manifest entries
- Updated CDN filenames to include architecture: `studio-win32-{arch}-v{version}.exe`

**Cleanup:**
- Removed deprecated `make:windows-dev` and `make:windows-release` scripts

### Breaking Change ⚠️

The `releases.json` manifest structure for Windows has changed from:
```json
"win32": { "sha": "...", "url": "..." }
```
To:
```json
"win32": {
  "x64": { "sha": "...", "url": "..." },
  "arm64": { "sha": "...", "url": "..." }
}
```

**The backend update API (`wpcom/v2/studio-app/updates`) will need to be updated** to look up `releases[version][platform][arch]` instead of `releases[version][platform]` for Windows. The app already sends `process.arch` in the update request.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

I tested:
- arch-specific builds locally on a real Windows machine with both `npm run make:windows-x64` and `npm run make:windows-arm64`
- the arm64 build on Windows running on Parallels, and it worked fine (first site creation 24 seconds, next one 13 seconds)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
