### PR TITLE
Move Windows speed-up prompt from onboarding to main window load and update its trigger logic

### DIFF
--- a/src/__mocks__/electron.ts
+++ b/src/__mocks__/electron.ts
@@ -64,6 +64,10 @@ BrowserWindow.prototype.emit = jest.fn( ( event: string, ...args: any[] ) => {
 	handlers.forEach( ( handler ) => handler( ...args ) );
 } );
 
+export const dialog = {
+	showMessageBox: jest.fn(),
+};
+
 export const Menu = {
 	buildFromTemplate: jest.fn(),
 	setApplicationMenu: jest.fn(),

--- a/src/__mocks__/electron.ts
+++ b/src/__mocks__/electron.ts
@@ -37,6 +37,7 @@ BrowserWindow.prototype.isFullScreen = jest.fn( () => false );
 
 const mockWebContents = {
 	on: jest.fn(),
+	once: jest.fn(),
 	send: jest.fn(),
 	isDestroyed: jest.fn( () => false ),
 };

--- a/src/components/onboarding.tsx
+++ b/src/components/onboarding.tsx
@@ -109,11 +109,6 @@ export default function Onboarding() {
 			event.preventDefault();
 			// Save current app version to prevent What's New from showing for new users
 			await saveLastSeenVersion( window.appGlobals.appVersion );
-			try {
-				await getIpcApi().promptWindowsSpeedUpSites( { skipIfAlreadyPrompted: true } );
-			} catch ( error ) {
-				console.error( error );
-			}
 
 			try {
 				await handleAddSiteClick();

--- a/src/lib/tests/windows-helpers.test.ts
+++ b/src/lib/tests/windows-helpers.test.ts
@@ -82,6 +82,7 @@ describe( 'promptWindowsSpeedUpSites', () => {
 				promptWindowsSpeedUpResult: {
 					response: 'no',
 					appVersion: currentVersion,
+					dontAskAgain: false,
 				},
 			} );
 
@@ -97,6 +98,7 @@ describe( 'promptWindowsSpeedUpSites', () => {
 				promptWindowsSpeedUpResult: {
 					response: 'no',
 					appVersion: '1.2.2', // Previous version
+					dontAskAgain: false,
 				},
 			} );
 			mockDialogShowMessageBox.mockResolvedValue( { response: 1, checkboxChecked: false } );
@@ -113,6 +115,7 @@ describe( 'promptWindowsSpeedUpSites', () => {
 				promptWindowsSpeedUpResult: {
 					response: 'yes',
 					appVersion: '1.2.2', // Previous version
+					dontAskAgain: false,
 				},
 			} );
 
@@ -128,6 +131,7 @@ describe( 'promptWindowsSpeedUpSites', () => {
 				promptWindowsSpeedUpResult: {
 					response: 'no',
 					appVersion: currentVersion,
+					dontAskAgain: false,
 				},
 			} );
 			mockDialogShowMessageBox.mockResolvedValue( { response: 1, checkboxChecked: false } );
@@ -168,7 +172,7 @@ describe( 'promptWindowsSpeedUpSites', () => {
 	} );
 
 	describe( 'user response handling', () => {
-		it( 'should save "yes" response with current app version', async () => {
+		it( 'should save "yes" response with current app version and dontAskAgain false', async () => {
 			mockLoadUserData.mockResolvedValue( { sites: [], snapshots: [] } );
 			mockDialogShowMessageBox.mockResolvedValue( { response: 0, checkboxChecked: false } ); // First button (yes)
 
@@ -178,11 +182,12 @@ describe( 'promptWindowsSpeedUpSites', () => {
 				promptWindowsSpeedUpResult: {
 					response: 'yes',
 					appVersion: currentVersion,
+					dontAskAgain: false,
 				},
 			} );
 		} );
 
-		it( 'should save "no" response with current app version', async () => {
+		it( 'should save "no" response with current app version and dontAskAgain false', async () => {
 			mockLoadUserData.mockResolvedValue( { sites: [], snapshots: [] } );
 			mockDialogShowMessageBox.mockResolvedValue( { response: 1, checkboxChecked: false } ); // Second button (no)
 
@@ -192,6 +197,7 @@ describe( 'promptWindowsSpeedUpSites', () => {
 				promptWindowsSpeedUpResult: {
 					response: 'no',
 					appVersion: currentVersion,
+					dontAskAgain: false,
 				},
 			} );
 		} );
@@ -213,6 +219,82 @@ describe( 'promptWindowsSpeedUpSites', () => {
 					buttons: expect.arrayContaining( [ expect.any( String ), expect.any( String ) ] ),
 				} )
 			);
+		} );
+
+		it( 'should show checkbox when skipIfAlreadyPrompted is true', async () => {
+			mockLoadUserData.mockResolvedValue( { sites: [], snapshots: [] } );
+			mockDialogShowMessageBox.mockResolvedValue( { response: 1, checkboxChecked: false } );
+
+			await promptWindowsSpeedUpSites( { skipIfAlreadyPrompted: true } );
+
+			expect( mockDialogShowMessageBox ).toHaveBeenCalledWith(
+				expect.any( BrowserWindow ),
+				expect.objectContaining( {
+					checkboxLabel: expect.any( String ),
+				} )
+			);
+		} );
+
+		it( 'should not show checkbox when skipIfAlreadyPrompted is false', async () => {
+			mockLoadUserData.mockResolvedValue( { sites: [], snapshots: [] } );
+			mockDialogShowMessageBox.mockResolvedValue( { response: 1, checkboxChecked: false } );
+
+			await promptWindowsSpeedUpSites( { skipIfAlreadyPrompted: false } );
+
+			expect( mockDialogShowMessageBox ).toHaveBeenCalledWith(
+				expect.any( BrowserWindow ),
+				expect.not.objectContaining( {
+					checkboxLabel: expect.anything(),
+				} )
+			);
+		} );
+	} );
+
+	describe( 'dontAskAgain functionality', () => {
+		it( 'should skip prompt when dontAskAgain is true regardless of version', async () => {
+			mockLoadUserData.mockResolvedValue( {
+				sites: [],
+				snapshots: [],
+				promptWindowsSpeedUpResult: {
+					response: 'no',
+					appVersion: '1.2.2', // Previous version
+					dontAskAgain: true,
+				},
+			} );
+
+			await promptWindowsSpeedUpSites( { skipIfAlreadyPrompted: true } );
+
+			expect( mockDialogShowMessageBox ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should save dontAskAgain true when checkbox is checked with "yes" response', async () => {
+			mockLoadUserData.mockResolvedValue( { sites: [], snapshots: [] } );
+			mockDialogShowMessageBox.mockResolvedValue( { response: 0, checkboxChecked: true } ); // First button (yes) with checkbox
+
+			await promptWindowsSpeedUpSites( { skipIfAlreadyPrompted: true } );
+
+			expect( mockUpdateAppdata ).toHaveBeenCalledWith( {
+				promptWindowsSpeedUpResult: {
+					response: 'yes',
+					appVersion: currentVersion,
+					dontAskAgain: true,
+				},
+			} );
+		} );
+
+		it( 'should save dontAskAgain true when checkbox is checked with "no" response', async () => {
+			mockLoadUserData.mockResolvedValue( { sites: [], snapshots: [] } );
+			mockDialogShowMessageBox.mockResolvedValue( { response: 1, checkboxChecked: true } ); // Second button (no) with checkbox
+
+			await promptWindowsSpeedUpSites( { skipIfAlreadyPrompted: true } );
+
+			expect( mockUpdateAppdata ).toHaveBeenCalledWith( {
+				promptWindowsSpeedUpResult: {
+					response: 'no',
+					appVersion: currentVersion,
+					dontAskAgain: true,
+				},
+			} );
 		} );
 	} );
 } );

--- a/src/lib/tests/windows-helpers.test.ts
+++ b/src/lib/tests/windows-helpers.test.ts
@@ -9,6 +9,11 @@ import { promptWindowsSpeedUpSites } from '../windows-helpers';
 jest.mock( 'electron' );
 jest.mock( 'src/main-window' );
 jest.mock( 'src/storage/user-data' );
+jest.mock( '@vscode/sudo-prompt', () => ( {
+	exec: jest.fn( ( _command, _options, callback ) => {
+		callback( null );
+	} ),
+} ) );
 
 const mockLoadUserData = loadUserData as jest.MockedFunction< typeof loadUserData >;
 const mockUpdateAppdata = updateAppdata as jest.MockedFunction< typeof updateAppdata >;

--- a/src/lib/tests/windows-helpers.test.ts
+++ b/src/lib/tests/windows-helpers.test.ts
@@ -1,0 +1,213 @@
+/**
+ * @jest-environment node
+ */
+import { app, dialog, BrowserWindow } from 'electron';
+import { getMainWindow } from 'src/main-window';
+import { loadUserData, updateAppdata } from 'src/storage/user-data';
+import { promptWindowsSpeedUpSites } from '../windows-helpers';
+
+jest.mock( 'electron' );
+jest.mock( 'src/main-window' );
+jest.mock( 'src/storage/user-data' );
+
+const mockLoadUserData = loadUserData as jest.MockedFunction< typeof loadUserData >;
+const mockUpdateAppdata = updateAppdata as jest.MockedFunction< typeof updateAppdata >;
+const mockGetMainWindow = getMainWindow as jest.MockedFunction< typeof getMainWindow >;
+const mockAppGetVersion = app.getVersion as jest.MockedFunction< typeof app.getVersion >;
+const mockDialogShowMessageBox = dialog.showMessageBox as jest.MockedFunction<
+	typeof dialog.showMessageBox
+>;
+
+const currentVersion = '1.2.3';
+const originalPlatform = process.platform;
+
+afterEach( () => {
+	jest.clearAllMocks();
+	Object.defineProperty( process, 'platform', {
+		value: originalPlatform,
+	} );
+} );
+
+describe( 'promptWindowsSpeedUpSites', () => {
+	beforeEach( () => {
+		mockGetMainWindow.mockResolvedValue( new BrowserWindow() );
+		mockAppGetVersion.mockReturnValue( currentVersion );
+
+		// Mock platform as Windows
+		Object.defineProperty( process, 'platform', {
+			value: 'win32',
+		} );
+	} );
+
+	describe( 'platform checks', () => {
+		it( 'should return early on non-Windows platforms', async () => {
+			Object.defineProperty( process, 'platform', { value: 'darwin' } );
+
+			mockLoadUserData.mockResolvedValue( { sites: [], snapshots: [] } );
+
+			await promptWindowsSpeedUpSites( { skipIfAlreadyPrompted: false } );
+
+			expect( mockDialogShowMessageBox ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should show prompt on Windows platform', async () => {
+			mockLoadUserData.mockResolvedValue( { sites: [], snapshots: [] } );
+			mockDialogShowMessageBox.mockResolvedValue( { response: 1, checkboxChecked: false } );
+
+			await promptWindowsSpeedUpSites( { skipIfAlreadyPrompted: false } );
+
+			expect( mockDialogShowMessageBox ).toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'version tracking', () => {
+		it( 'should show prompt when no previous response exists', async () => {
+			mockLoadUserData.mockResolvedValue( { sites: [], snapshots: [] } );
+			mockDialogShowMessageBox.mockResolvedValue( { response: 1, checkboxChecked: false } );
+
+			await promptWindowsSpeedUpSites( { skipIfAlreadyPrompted: true } );
+
+			expect( mockDialogShowMessageBox ).toHaveBeenCalled();
+		} );
+
+		it( 'should skip prompt when user said "no" to the current version', async () => {
+			mockLoadUserData.mockResolvedValue( {
+				sites: [],
+				snapshots: [],
+				promptWindowsSpeedUpResult: {
+					response: 'no',
+					appVersion: currentVersion,
+				},
+			} );
+
+			await promptWindowsSpeedUpSites( { skipIfAlreadyPrompted: true } );
+
+			expect( mockDialogShowMessageBox ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should show prompt again when user said "no" to a previous version', async () => {
+			mockLoadUserData.mockResolvedValue( {
+				sites: [],
+				snapshots: [],
+				promptWindowsSpeedUpResult: {
+					response: 'no',
+					appVersion: '1.2.2', // Previous version
+				},
+			} );
+			mockDialogShowMessageBox.mockResolvedValue( { response: 1, checkboxChecked: false } );
+
+			await promptWindowsSpeedUpSites( { skipIfAlreadyPrompted: true } );
+
+			expect( mockDialogShowMessageBox ).toHaveBeenCalled();
+		} );
+
+		it( 'should skip prompt when user said "yes" regardless of version', async () => {
+			mockLoadUserData.mockResolvedValue( {
+				sites: [],
+				snapshots: [],
+				promptWindowsSpeedUpResult: {
+					response: 'yes',
+					appVersion: '1.2.2', // Previous version
+				},
+			} );
+
+			await promptWindowsSpeedUpSites( { skipIfAlreadyPrompted: true } );
+
+			expect( mockDialogShowMessageBox ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should always show prompt when skipIfAlreadyPrompted is false', async () => {
+			mockLoadUserData.mockResolvedValue( {
+				sites: [],
+				snapshots: [],
+				promptWindowsSpeedUpResult: {
+					response: 'no',
+					appVersion: currentVersion,
+				},
+			} );
+			mockDialogShowMessageBox.mockResolvedValue( { response: 1, checkboxChecked: false } );
+
+			await promptWindowsSpeedUpSites( { skipIfAlreadyPrompted: false } );
+
+			expect( mockDialogShowMessageBox ).toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'legacy format handling', () => {
+		it( 'should handle legacy string format "yes" and skip prompt', async () => {
+			mockLoadUserData.mockResolvedValue( {
+				sites: [],
+				snapshots: [],
+				// @ts-expect-error - Testing legacy string format for backward compatibility
+				promptWindowsSpeedUpResult: 'yes',
+			} );
+
+			await promptWindowsSpeedUpSites( { skipIfAlreadyPrompted: true } );
+
+			expect( mockDialogShowMessageBox ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should handle legacy string format "no" and show prompt', async () => {
+			mockLoadUserData.mockResolvedValue( {
+				sites: [],
+				snapshots: [],
+				// @ts-expect-error - Testing legacy string format for backward compatibility
+				promptWindowsSpeedUpResult: 'no',
+			} );
+			mockDialogShowMessageBox.mockResolvedValue( { response: 1, checkboxChecked: false } );
+
+			await promptWindowsSpeedUpSites( { skipIfAlreadyPrompted: true } );
+
+			expect( mockDialogShowMessageBox ).toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'user response handling', () => {
+		it( 'should save "yes" response with current app version', async () => {
+			mockLoadUserData.mockResolvedValue( { sites: [], snapshots: [] } );
+			mockDialogShowMessageBox.mockResolvedValue( { response: 0, checkboxChecked: false } ); // First button (yes)
+
+			await promptWindowsSpeedUpSites( { skipIfAlreadyPrompted: false } );
+
+			expect( mockUpdateAppdata ).toHaveBeenCalledWith( {
+				promptWindowsSpeedUpResult: {
+					response: 'yes',
+					appVersion: currentVersion,
+				},
+			} );
+		} );
+
+		it( 'should save "no" response with current app version', async () => {
+			mockLoadUserData.mockResolvedValue( { sites: [], snapshots: [] } );
+			mockDialogShowMessageBox.mockResolvedValue( { response: 1, checkboxChecked: false } ); // Second button (no)
+
+			await promptWindowsSpeedUpSites( { skipIfAlreadyPrompted: false } );
+
+			expect( mockUpdateAppdata ).toHaveBeenCalledWith( {
+				promptWindowsSpeedUpResult: {
+					response: 'no',
+					appVersion: currentVersion,
+				},
+			} );
+		} );
+	} );
+
+	describe( 'dialog content', () => {
+		it( 'should show correct dialog title and message', async () => {
+			mockLoadUserData.mockResolvedValue( { sites: [], snapshots: [] } );
+			mockDialogShowMessageBox.mockResolvedValue( { response: 1, checkboxChecked: false } );
+
+			await promptWindowsSpeedUpSites( { skipIfAlreadyPrompted: false } );
+
+			expect( mockDialogShowMessageBox ).toHaveBeenCalledWith(
+				expect.any( BrowserWindow ),
+				expect.objectContaining( {
+					type: 'question',
+					title: expect.any( String ),
+					message: expect.stringContaining( 'Microsoft Defender' ),
+					buttons: expect.arrayContaining( [ expect.any( String ), expect.any( String ) ] ),
+				} )
+			);
+		} );
+	} );
+} );

--- a/src/lib/windows-helpers.ts
+++ b/src/lib/windows-helpers.ts
@@ -14,6 +14,7 @@ export async function promptWindowsSpeedUpSites( {
 	const currentAppVersion = app.getVersion();
 	const previousResponse = userData.promptWindowsSpeedUpResult?.response;
 	const previousAppVersion = userData.promptWindowsSpeedUpResult?.appVersion;
+	const dontAskAgain = userData.promptWindowsSpeedUpResult?.dontAskAgain;
 
 	if ( process.platform !== 'win32' ) {
 		return;
@@ -29,6 +30,7 @@ export async function promptWindowsSpeedUpSites( {
 	if (
 		skipIfAlreadyPrompted &&
 		( previousResponse === 'yes' ||
+			dontAskAgain ||
 			( previousResponse === 'no' && previousAppVersion === currentAppVersion ) )
 	) {
 		return;
@@ -40,13 +42,14 @@ export async function promptWindowsSpeedUpSites( {
 	const buttons = [ AUTOMATIC_UPDATE, NOT_INTERESTED ];
 
 	const mainWindow = await getMainWindow();
-	const { response } = await dialog.showMessageBox( mainWindow, {
+	const { response, checkboxChecked } = await dialog.showMessageBox( mainWindow, {
 		type: 'question',
 		buttons,
 		title: __( 'Want to speed up site creation?' ),
 		message: __(
 			"Microsoft Defender's Real-time protection may slow site creation.\n\nTo create sites quickly, we recommend disabling Real-time protection for the Studio app."
 		),
+		...( skipIfAlreadyPrompted && { checkboxLabel: __( "Don't ask me again" ) } ),
 		cancelId: buttons.indexOf( NOT_INTERESTED ),
 	} );
 
@@ -54,7 +57,11 @@ export async function promptWindowsSpeedUpSites( {
 		case buttons.indexOf( AUTOMATIC_UPDATE ):
 			// Update Windows Defender configuration
 			await updateAppdata( {
-				promptWindowsSpeedUpResult: { response: 'yes', appVersion: currentAppVersion },
+				promptWindowsSpeedUpResult: {
+					response: 'yes',
+					appVersion: currentAppVersion,
+					dontAskAgain: checkboxChecked,
+				},
 			} );
 			try {
 				await excludeProcessInWindowsDefender();
@@ -72,7 +79,11 @@ export async function promptWindowsSpeedUpSites( {
 		case buttons.indexOf( NOT_INTERESTED ):
 			// Skip it, user is not interested
 			await updateAppdata( {
-				promptWindowsSpeedUpResult: { response: 'no', appVersion: currentAppVersion },
+				promptWindowsSpeedUpResult: {
+					response: 'no',
+					appVersion: currentAppVersion,
+					dontAskAgain: checkboxChecked,
+				},
 			} );
 			break;
 	}

--- a/src/lib/windows-helpers.ts
+++ b/src/lib/windows-helpers.ts
@@ -11,10 +11,25 @@ export async function promptWindowsSpeedUpSites( {
 	skipIfAlreadyPrompted: boolean;
 } ) {
 	const userData = await loadUserData();
+	const currentAppVersion = app.getVersion();
+	const previousResponse = userData.promptWindowsSpeedUpResult?.response;
+	const previousAppVersion = userData.promptWindowsSpeedUpResult?.appVersion;
+
+	if ( process.platform !== 'win32' ) {
+		return;
+	}
+
+	// Handle legacy promptWindowsSpeedUpResult format
+	if ( skipIfAlreadyPrompted && typeof userData.promptWindowsSpeedUpResult === 'string' ) {
+		if ( userData.promptWindowsSpeedUpResult === 'yes' ) {
+			return;
+		}
+	}
 
 	if (
-		process.platform !== 'win32' ||
-		( skipIfAlreadyPrompted && typeof userData.promptWindowsSpeedUpResult !== 'undefined' )
+		skipIfAlreadyPrompted &&
+		( previousResponse === 'yes' ||
+			( previousResponse === 'no' && previousAppVersion === currentAppVersion ) )
 	) {
 		return;
 	}
@@ -38,7 +53,9 @@ export async function promptWindowsSpeedUpSites( {
 	switch ( response ) {
 		case buttons.indexOf( AUTOMATIC_UPDATE ):
 			// Update Windows Defender configuration
-			await updateAppdata( { promptWindowsSpeedUpResult: 'yes' } );
+			await updateAppdata( {
+				promptWindowsSpeedUpResult: { response: 'yes', appVersion: currentAppVersion },
+			} );
 			try {
 				await excludeProcessInWindowsDefender();
 			} catch ( _error ) {
@@ -54,7 +71,9 @@ export async function promptWindowsSpeedUpSites( {
 			break;
 		case buttons.indexOf( NOT_INTERESTED ):
 			// Skip it, user is not interested
-			await updateAppdata( { promptWindowsSpeedUpResult: 'no' } );
+			await updateAppdata( {
+				promptWindowsSpeedUpResult: { response: 'no', appVersion: currentAppVersion },
+			} );
 			break;
 	}
 }

--- a/src/main-window.ts
+++ b/src/main-window.ts
@@ -15,6 +15,7 @@ import {
 	loadWindowBounds,
 	saveWindowBounds,
 } from 'src/storage/user-data';
+import { promptWindowsSpeedUpSites } from 'src/lib/windows-helpers';
 import type { WindowBounds } from 'src/storage/storage-types';
 
 let mainWindow: BrowserWindow | null;
@@ -106,6 +107,10 @@ export async function createMainWindow(): Promise< BrowserWindow > {
 
 	mainWindow.webContents.on( 'devtools-closed', async () => {
 		await updateAppdata( { devToolsOpen: false } );
+	} );
+
+	mainWindow.webContents.once( 'did-finish-load', () => {
+		void promptWindowsSpeedUpSites( { skipIfAlreadyPrompted: true } );
 	} );
 
 	mainWindow.on( 'closed', () => {

--- a/src/main-window.ts
+++ b/src/main-window.ts
@@ -8,6 +8,7 @@ import {
 	WINDOWS_TITLEBAR_HEIGHT,
 } from 'src/constants';
 import { sendIpcEventToRendererWithWindow } from 'src/ipc-utils';
+import { promptWindowsSpeedUpSites } from 'src/lib/windows-helpers';
 import { removeMenu } from 'src/menu';
 import {
 	loadUserData,
@@ -15,7 +16,6 @@ import {
 	loadWindowBounds,
 	saveWindowBounds,
 } from 'src/storage/user-data';
-import { promptWindowsSpeedUpSites } from 'src/lib/windows-helpers';
 import type { WindowBounds } from 'src/storage/storage-types';
 
 let mainWindow: BrowserWindow | null;

--- a/src/storage/storage-types.ts
+++ b/src/storage/storage-types.ts
@@ -44,4 +44,7 @@ export interface PersistedUserData extends Omit< UserData, 'sites' > {
 	sites: Omit< StoppedSiteDetails, 'running' >[];
 }
 
-export type PromptWindowsSpeedUpResult = 'yes' | 'no';
+export interface PromptWindowsSpeedUpResult {
+	response: 'yes' | 'no';
+	appVersion: string;
+}

--- a/src/storage/storage-types.ts
+++ b/src/storage/storage-types.ts
@@ -47,4 +47,5 @@ export interface PersistedUserData extends Omit< UserData, 'sites' > {
 export interface PromptWindowsSpeedUpResult {
 	response: 'yes' | 'no';
 	appVersion: string;
+	dontAskAgain: boolean;
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Resolves STU-883

## Proposed Changes

The goal of this PR is to make the "Windows speed-up" prompt display on app start after each version update, unless the user has already confirmed the prompt.

- change the type of `PromptWindowsSpeedUpResult` from `'yes' | 'no'` to
```
{
	response: 'yes' | 'no';
	appVersion: string;
	dontAskAgain: boolean;
}
```
  → this will ensure we can record on which app version the prompt has been triggered

- move the prompt trigger from onboarding to app load
- update the prompt logic to allow it to trigger on version update, unless the user already accepted the prompt
- add handling for legacy `promptWindowsSpeedUpResult` format to ensure the prompt won't trigger if the user already accepted it
- add checkbox to let users skip the prompt even after app version updates 
- add related unit tests

<img width="1092" height="446" alt="Markup on 2025-10-24 at 14:51:48" src="https://github.com/user-attachments/assets/7d74001a-65e1-466b-95b0-93d84b2fb6e9" />

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

On Windows:
1. Open the `appdata-v1.json` file for editing (e.g. by running `notepad "$env:APPDATA\Studio\appdata-v1.json"` in PowerShell).
2. Check out the PR branch, build the app and start it.
3. If the `Want to speed up site creation?` prompt displays, clicking:
  - the `Sounds good, do it for me` option should record the following in the `appdata-v1.json` :
  
```
    "promptWindowsSpeedUpResult": {
    "response": "yes",
    "appVersion": "1.6.1" // should match the current app version
  }
```
  
  - the `I'm to interested` option should record the following in the `appdata-v1.json` :
  
```
    "promptWindowsSpeedUpResult": {
    "response": "no",
    "appVersion": "1.6.1" // should match the current app version
    "dontAskAgain": true | false // depending on whether you have checked the box
  }
```

4. Test the following scenarios on app start (by triggering the prompt manually through the app menu (_Help → How can I make WordPress Studio faster?_) - or - by manually editing the `appdata-v1.json` file).

a) if the `appdata-v1.json` file does not include the `promptWindowsSpeedUpResult` record, the prompt should open automatically
b) if the `appdata-v1.json` file includes `promptWindowsSpeedUpResult` in the old format and:
   - the value is `"promptWindowsSpeedUpResult": 'no',`,  the prompt should open automatically
   - the value is `"promptWindowsSpeedUpResult": 'yes',`, the prompt should not open

c) if the `appdata-v1.json` file includes `promptWindowsSpeedUpResult` in the new format and:
   - the `response` value is `no` and the `appVersion` is different from the current app version, the prompt should open automatically
   - the `response` value is `no` and the `appVersion` is the same as the current app version, the prompt should not open automatically
   - the `response` value is `yes`, the prompt should not open regardless of the `appVersion`

5. Triggering the prompt from the app menu (_Help → How can I make WordPress Studio faster?_) should work regardless of the `promptWindowsSpeedUpResult` value in the `appdata-v1.json`. The `dontAskAgain` checkbox should not render in this case.

On macOS:
1. Check out the PR branch, build the app and start it.
2. There should be no regressions.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
