### PR TITLE
Studio: Improve error logging for Playground CLI

### DIFF
--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -509,7 +509,11 @@ export async function startServer(
 			throw new Error( 'WASM_ERROR_NOT_ENOUGH_MEMORY' );
 		}
 
-		Sentry.captureException( error );
+		Sentry.captureException( error, {
+			tags: {
+				provider: getWordPressProvider().PROVIDER_TYPE,
+			},
+		} );
 		if (
 			error instanceof Error &&
 			error.message.includes( '"unreachable" WASM instruction executed' )

--- a/src/lib/wordpress-provider/playground-cli/playground-server-process-child.ts
+++ b/src/lib/wordpress-provider/playground-cli/playground-server-process-child.ts
@@ -118,7 +118,11 @@ process.parentPort.on( 'message', async ( event ) => {
 
 		process.parentPort.postMessage( { id: message.id, result } );
 	} catch ( error ) {
-		process.parentPort.postMessage( { id: message.id, error: ( error as Error ).message } );
+		process.parentPort.postMessage( {
+			id: message.id,
+			error: error instanceof Error ? error.message : String( error ),
+			errorStack: error instanceof Error ? error.stack : undefined,
+		} );
 	}
 } );
 

--- a/src/lib/wordpress-provider/playground-cli/playground-server-process-child.ts
+++ b/src/lib/wordpress-provider/playground-cli/playground-server-process-child.ts
@@ -207,6 +207,11 @@ async function startServer(
 		}
 	} catch ( error ) {
 		server = null;
+		// Re-throw the original error to preserve stack trace
+		if ( error instanceof Error ) {
+			error.message = `Could not start server: ${ error.message }`;
+			throw error;
+		}
 		throw new Error( `Could not start server: ${ error }` );
 	}
 }

--- a/src/lib/wordpress-provider/playground-cli/playground-server-process.ts
+++ b/src/lib/wordpress-provider/playground-cli/playground-server-process.ts
@@ -56,6 +56,7 @@ export class PlaygroundServerProcess implements WordPressServerProcess {
 				type?: string;
 				id?: number;
 				error?: string;
+				errorStack?: string;
 				result?: unknown;
 				message?: string;
 			} ) => {
@@ -89,7 +90,11 @@ export class PlaygroundServerProcess implements WordPressServerProcess {
 					this.responseHandlers.delete( message.id );
 
 					if ( message.error ) {
-						handler.reject( new Error( message.error ) );
+						const error = new Error( message.error );
+						if ( message.errorStack ) {
+							error.stack = message.errorStack;
+						}
+						handler.reject( error );
 					} else {
 						handler.resolve( message.result );
 					}


### PR DESCRIPTION
## Related issues

- Related to STU-854

## Proposed Changes

- Child process now sends full stack traces alongside error messages to parent process
- Parent process reconstructs Error objects with original stack traces for Sentry
- IPC handler tags errors with provider type for easier filtering in Sentry
- Original errors are preserved in catch blocks instead of creating new Error objects

## Testing Instructions

- Temporarily add a forced error in the child process startServer function
- Verify that error stack traces are properly passed from child to parent process
- Check that Sentry captures the error with the full stack trace showing the exact function name and line number in the child process
- Confirm that original errors from deep in the call stack (e.g., from runCLI) are preserved with full context
- Verify that stack traces now show the actual location in playgroundServerProcess.js where the error originated, not just the parent process location

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?