### PR TITLE
Add ARM64 app download nudge for users running Intel build under emulation on Windows

### DIFF
--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -137,7 +137,6 @@ void Promise.all( [ getIpcApi().getAppGlobals(), getIpcApi().getSentryUserId() ]
 
 		// Show warning if running an ARM64 translator
 		if (
-			( appGlobals.platform === 'darwin' || appGlobals.platform === 'win32' ) &&
 			appGlobals.arm64Translation &&
 			! localStorage.getItem( 'dontShowARM64Warning' )
 		) {

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -137,7 +137,7 @@ void Promise.all( [ getIpcApi().getAppGlobals(), getIpcApi().getSentryUserId() ]
 
 		// Show warning if running an ARM64 translator
 		if (
-			appGlobals.platform === 'darwin' &&
+			( appGlobals.platform === 'darwin' || appGlobals.platform === 'win32' ) &&
 			appGlobals.arm64Translation &&
 			! localStorage.getItem( 'dontShowARM64Warning' )
 		) {
@@ -149,6 +149,10 @@ void Promise.all( [ getIpcApi().getAppGlobals(), getIpcApi().getSentryUserId() ]
 						window.appGlobals.platform === 'darwin'
 							? __(
 									'Downloading the Mac with Apple Silicon Chip version of Studio will provide better performance.'
+							  )
+							: window.appGlobals.platform === 'win32'
+							? __(
+									'Downloading the ARM64 version of Studio will provide better performance.'
 							  )
 							: __(
 									'Downloading the optimized version of Studio will provide better performance.'

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -136,10 +136,7 @@ void Promise.all( [ getIpcApi().getAppGlobals(), getIpcApi().getSentryUserId() ]
 		window.appGlobals = appGlobals;
 
 		// Show warning if running an ARM64 translator
-		if (
-			appGlobals.arm64Translation &&
-			! localStorage.getItem( 'dontShowARM64Warning' )
-		) {
+		if ( appGlobals.arm64Translation && ! localStorage.getItem( 'dontShowARM64Warning' ) ) {
 			const showARM64MessageBox = async () => {
 				const platformMessages: Record< string, string > = {
 					darwin: __(

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -146,9 +146,7 @@ void Promise.all( [ getIpcApi().getAppGlobals(), getIpcApi().getSentryUserId() ]
 					darwin: __(
 						'Downloading the Mac with Apple Silicon Chip version of Studio will provide better performance.'
 					),
-					win32: __(
-						'Downloading the ARM64 version of Studio will provide better performance.'
-					),
+					win32: __( 'Downloading the ARM64 version of Studio will provide better performance.' ),
 				};
 
 				const detailMessage =

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -142,21 +142,23 @@ void Promise.all( [ getIpcApi().getAppGlobals(), getIpcApi().getSentryUserId() ]
 			! localStorage.getItem( 'dontShowARM64Warning' )
 		) {
 			const showARM64MessageBox = async () => {
+				const platformMessages: Record< string, string > = {
+					darwin: __(
+						'Downloading the Mac with Apple Silicon Chip version of Studio will provide better performance.'
+					),
+					win32: __(
+						'Downloading the ARM64 version of Studio will provide better performance.'
+					),
+				};
+
+				const detailMessage =
+					platformMessages[ window.appGlobals.platform ] ||
+					__( 'Downloading the optimized version of Studio will provide better performance.' );
+
 				const { response, checkboxChecked } = await getIpcApi().showMessageBox( {
 					type: 'warning',
 					message: __( 'This version of Studio is not optimized for your computer' ),
-					detail:
-						window.appGlobals.platform === 'darwin'
-							? __(
-									'Downloading the Mac with Apple Silicon Chip version of Studio will provide better performance.'
-							  )
-							: window.appGlobals.platform === 'win32'
-							? __(
-									'Downloading the ARM64 version of Studio will provide better performance.'
-							  )
-							: __(
-									'Downloading the optimized version of Studio will provide better performance.'
-							  ),
+					detail: detailMessage,
 					checkboxLabel: __( "Don't show this warning again" ),
 					buttons: [ __( 'Download' ), __( 'Not now' ) ],
 					cancelId: 1,

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -140,9 +140,9 @@ void Promise.all( [ getIpcApi().getAppGlobals(), getIpcApi().getSentryUserId() ]
 			const showARM64MessageBox = async () => {
 				const platformMessages: Record< string, string > = {
 					darwin: __(
-						'Downloading the Mac with Apple Silicon Chip version of Studio will provide better performance.'
+						'Downloading the Apple Silicon Chip version of Studio will provide better performance.'
 					),
-					win32: __( 'Downloading the ARM64 version of Studio will provide better performance.' ),
+					win32: __( 'Downloading the ARM version of Studio will provide better performance.' ),
 				};
 
 				const detailMessage =


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

Resolves STU-882

## Proposed Changes

- add ARM64 app download nudge for users running Intel build under emulation on Windows
- remove platform check from the logic (since we will now display the nudge on both macOS and Windows)

<img width="952" height="516" alt="Screen Shot on 2025-10-31 at 14:34:08" src="https://github.com/user-attachments/assets/27985ba9-8f4c-4997-84e8-d271af24ef69" />

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR branch, build and run the app on Windows for x64 (`npm run make:windows-x64`) and arm64 (`npm run make:windows-arm64`).
2. The nudge should render only when running x64 on arm64 architecture.
3. There should be no change for the nudge on macOS.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
