### PR TITLE
Studio: Fix extreme window height for long error messages

### DIFF
--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -46,6 +46,7 @@ import {
 	trustRootCA,
 } from 'src/lib/certificate-manager';
 import { download } from 'src/lib/download';
+import { simplifyErrorForDisplay } from 'src/lib/error-formatting';
 import { buildFeatureFlags } from 'src/lib/feature-flags';
 import { sanitizeFolderName } from 'src/lib/generate-site-name';
 import { getImageData } from 'src/lib/get-image-data';
@@ -1170,8 +1171,9 @@ export async function showErrorMessageBox(
 		showOpenLogs = false,
 	}: { title: string; message: string; error?: unknown; showOpenLogs?: boolean }
 ) {
+	const simplifiedError = simplifyErrorForDisplay( error );
 	// Remove prepended error message added by IPC handler
-	const filteredError = ( error as Error )?.message?.replace(
+	const filteredError = ( simplifiedError as Error )?.message?.replace(
 		/Error invoking remote method '\w+': Error:/g,
 		''
 	);

--- a/src/modules/site-settings/edit-site-details.tsx
+++ b/src/modules/site-settings/edit-site-details.tsx
@@ -140,7 +140,9 @@ const EditSiteDetails = ( { currentWpVersion, onSave }: EditSiteDetailsProps ) =
 					const errorMessage = stripAnsi( ( wpError as Error )?.message );
 					getIpcApi().showErrorMessageBox( {
 						title: __( 'Error changing WordPress version' ),
-						message: errorMessage,
+						message: __( 'An error occurred while updating the WordPress version.' ),
+						error: new Error( errorMessage ),
+						showOpenLogs: true,
 					} );
 					setSelectedWpVersion( getEffectiveWpVersion() );
 					setIsEditingSite( false );

--- a/src/modules/site-settings/tests/edit-site-details.test.tsx
+++ b/src/modules/site-settings/tests/edit-site-details.test.tsx
@@ -364,7 +364,9 @@ describe( 'EditSiteDetails', () => {
 		await waitFor( () => {
 			expect( mockShowErrorMessageBox ).toHaveBeenCalledWith( {
 				title: 'Error changing WordPress version',
-				message: 'Update failed',
+				message: 'An error occurred while updating the WordPress version.',
+				error: new Error( 'Update failed' ),
+				showOpenLogs: true,
 			} );
 		} );
 


### PR DESCRIPTION
## Related issues

- Fixes STU-905

## Proposed Changes

- Modified error message display in dialog boxes to show only the first line of error messages
- Added import for `simplifyErrorForDisplay` utility function from `src/lib/error-formatting.ts`
- Applied `simplifyErrorForDisplay` to error messages in `showErrorMessageBox` function
- Prevents extremely tall dialog windows that can exceed screen height (e.g., 1600px vertical resolution)

## Testing Instructions

- On a site with the 2025 theme installed
- Change WP version to 5.8.12 (modify the source code to allow that)
- Change WP version to latest
- Verify that the error dialog now shows only the first line of the error message instead of full stack traces
- Confirm the dialog window height is reasonable and the close button is accessible
- Verify that the "Open Studio Logs" button still provides access to full error details

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?