### PR TITLE
Fix application passwords by disabling playground-cli auto log in

### DIFF
--- a/e2e/blueprints.test.ts
+++ b/e2e/blueprints.test.ts
@@ -62,7 +62,8 @@ test.describe( 'Blueprints', () => {
 		const wpAdminUrl = await settingsTab.copyWPAdminUrlToClipboard( session.electronApp );
 
 		// Verify theme was installed
-		await page.goto( wpAdminUrl + '/themes.php?playground-auto-login=true' );
+		const themesUrl = wpAdminUrl + '/themes.php'
+		await page.goto( `/playground-auto-login?redirect_to=${encodeURIComponent( themesUrl )}` );
 		await expect( page.locator( '.theme[data-slug="twentytwentytwo"]' ) ).toBeVisible();
 	} );
 
@@ -97,7 +98,8 @@ test.describe( 'Blueprints', () => {
 		const wpAdminUrl = await settingsTab.copyWPAdminUrlToClipboard( session.electronApp );
 
 		// Verify theme was activated
-		await page.goto( wpAdminUrl + '/themes.php?playground-auto-login=true' );
+		const themesUrl = wpAdminUrl + '/themes.php'
+		await page.goto( `/playground-auto-login?redirect_to=${encodeURIComponent( themesUrl )}` );
 		const activeTheme = page.locator( '.theme.active' );
 		await expect( activeTheme ).toBeVisible();
 		await expect( activeTheme ).toHaveAttribute( 'data-slug', 'twentytwentyone' );
@@ -134,7 +136,8 @@ test.describe( 'Blueprints', () => {
 		const wpAdminUrl = await settingsTab.copyWPAdminUrlToClipboard( session.electronApp );
 
 		// Verify plugin was installed
-		await page.goto( wpAdminUrl + '/plugins.php?playground-auto-login=true' );
+		const pluginsUrl = wpAdminUrl + '/plugins.php'
+		await page.goto( `/playground-auto-login?redirect_to=${encodeURIComponent( pluginsUrl )}` );
 		await expect( page.locator( 'tr[data-slug="akismet"]' ) ).toBeVisible();
 	} );
 
@@ -169,7 +172,8 @@ test.describe( 'Blueprints', () => {
 		const wpAdminUrl = await settingsTab.copyWPAdminUrlToClipboard( session.electronApp );
 
 		// Verify plugin was activated
-		await page.goto( wpAdminUrl + '/plugins.php?playground-auto-login=true' );
+		const pluginsUrl = wpAdminUrl + '/plugins.php'
+		await page.goto( `/playground-auto-login?redirect_to=${encodeURIComponent( pluginsUrl )}` );
 		// Be more specific - look for the active Hello Dolly plugin
 		const pluginRow = page.locator( 'tr[data-slug="hello-dolly"].active' );
 		await expect( pluginRow ).toBeVisible();
@@ -206,7 +210,8 @@ test.describe( 'Blueprints', () => {
 		const wpAdminUrl = await settingsTab.copyWPAdminUrlToClipboard( session.electronApp );
 
 		// Verify the site was created successfully and admin is accessible
-		await page.goto( wpAdminUrl + '/options-general.php?playground-auto-login=true' );
+		const optionsGeneralUrl = wpAdminUrl + '/options-general.php'
+		await page.goto( `/playground-auto-login?redirect_to=${encodeURIComponent( optionsGeneralUrl )}` );
 		await expect( page.getByLabel( 'Site Title' ) ).toBeVisible();
 
 		// Verify the blueprint's landing page works
@@ -244,7 +249,8 @@ test.describe( 'Blueprints', () => {
 		const wpAdminUrl = await settingsTab.copyWPAdminUrlToClipboard( session.electronApp );
 
 		// Verify the site was created successfully and admin is accessible
-		await page.goto( wpAdminUrl + '/options-general.php?playground-auto-login=true' );
+		const optionsGeneralUrl = wpAdminUrl + '/options-general.php'
+		await page.goto( `/playground-auto-login?redirect_to=${encodeURIComponent( optionsGeneralUrl )}` );
 		await expect( page.getByLabel( 'Site Title' ) ).toBeVisible();
 
 		// Verify the blueprint's landing page works

--- a/e2e/blueprints.test.ts
+++ b/e2e/blueprints.test.ts
@@ -65,7 +65,6 @@ test.describe( 'Blueprints', () => {
 		// Verify theme was installed
 		const themesUrl = wpAdminUrl + '/themes.php';
 		await page.goto( getUrlWithAutoLogin( themesUrl ) );
-
 		await expect( page.locator( '.theme[data-slug="twentytwentytwo"]' ) ).toBeVisible();
 	} );
 

--- a/e2e/blueprints.test.ts
+++ b/e2e/blueprints.test.ts
@@ -6,6 +6,7 @@ import MainSidebar from './page-objects/main-sidebar';
 import Onboarding from './page-objects/onboarding';
 import SiteContent from './page-objects/site-content';
 import WhatsNewModal from './page-objects/whats-new-modal';
+import { getUrlWithAutoLogin } from './utils';
 
 test.describe( 'Blueprints', () => {
 	const session = new E2ESession();
@@ -62,8 +63,9 @@ test.describe( 'Blueprints', () => {
 		const wpAdminUrl = await settingsTab.copyWPAdminUrlToClipboard( session.electronApp );
 
 		// Verify theme was installed
-		const themesUrl = wpAdminUrl + '/themes.php'
-		await page.goto( `/playground-auto-login?redirect_to=${encodeURIComponent( themesUrl )}` );
+		const themesUrl = wpAdminUrl + '/themes.php';
+		await page.goto( getUrlWithAutoLogin( themesUrl ) );
+
 		await expect( page.locator( '.theme[data-slug="twentytwentytwo"]' ) ).toBeVisible();
 	} );
 
@@ -98,8 +100,8 @@ test.describe( 'Blueprints', () => {
 		const wpAdminUrl = await settingsTab.copyWPAdminUrlToClipboard( session.electronApp );
 
 		// Verify theme was activated
-		const themesUrl = wpAdminUrl + '/themes.php'
-		await page.goto( `/playground-auto-login?redirect_to=${encodeURIComponent( themesUrl )}` );
+		const themesUrl = wpAdminUrl + '/themes.php';
+		await page.goto( getUrlWithAutoLogin( themesUrl ) );
 		const activeTheme = page.locator( '.theme.active' );
 		await expect( activeTheme ).toBeVisible();
 		await expect( activeTheme ).toHaveAttribute( 'data-slug', 'twentytwentyone' );
@@ -136,8 +138,8 @@ test.describe( 'Blueprints', () => {
 		const wpAdminUrl = await settingsTab.copyWPAdminUrlToClipboard( session.electronApp );
 
 		// Verify plugin was installed
-		const pluginsUrl = wpAdminUrl + '/plugins.php'
-		await page.goto( `/playground-auto-login?redirect_to=${encodeURIComponent( pluginsUrl )}` );
+		const pluginsUrl =  wpAdminUrl + '/plugins.php' ;
+		await page.goto( getUrlWithAutoLogin( pluginsUrl ) );
 		await expect( page.locator( 'tr[data-slug="akismet"]' ) ).toBeVisible();
 	} );
 
@@ -172,8 +174,8 @@ test.describe( 'Blueprints', () => {
 		const wpAdminUrl = await settingsTab.copyWPAdminUrlToClipboard( session.electronApp );
 
 		// Verify plugin was activated
-		const pluginsUrl = wpAdminUrl + '/plugins.php'
-		await page.goto( `/playground-auto-login?redirect_to=${encodeURIComponent( pluginsUrl )}` );
+		const pluginsUrl = wpAdminUrl + '/plugins.php';
+		await page.goto( getUrlWithAutoLogin( pluginsUrl ) );
 		// Be more specific - look for the active Hello Dolly plugin
 		const pluginRow = page.locator( 'tr[data-slug="hello-dolly"].active' );
 		await expect( pluginRow ).toBeVisible();
@@ -210,8 +212,8 @@ test.describe( 'Blueprints', () => {
 		const wpAdminUrl = await settingsTab.copyWPAdminUrlToClipboard( session.electronApp );
 
 		// Verify the site was created successfully and admin is accessible
-		const optionsGeneralUrl = wpAdminUrl + '/options-general.php'
-		await page.goto( `/playground-auto-login?redirect_to=${encodeURIComponent( optionsGeneralUrl )}` );
+		const optionsGeneralUrl = wpAdminUrl + '/options-general.php';
+		await page.goto( getUrlWithAutoLogin( optionsGeneralUrl ) );
 		await expect( page.getByLabel( 'Site Title' ) ).toBeVisible();
 
 		// Verify the blueprint's landing page works
@@ -250,7 +252,7 @@ test.describe( 'Blueprints', () => {
 
 		// Verify the site was created successfully and admin is accessible
 		const optionsGeneralUrl = wpAdminUrl + '/options-general.php'
-		await page.goto( `/playground-auto-login?redirect_to=${encodeURIComponent( optionsGeneralUrl )}` );
+		await page.goto( getUrlWithAutoLogin( optionsGeneralUrl ) );
 		await expect( page.getByLabel( 'Site Title' ) ).toBeVisible();
 
 		// Verify the blueprint's landing page works

--- a/e2e/sites.test.ts
+++ b/e2e/sites.test.ts
@@ -7,6 +7,7 @@ import MainSidebar from './page-objects/main-sidebar';
 import Onboarding from './page-objects/onboarding';
 import SiteContent from './page-objects/site-content';
 import WhatsNewModal from './page-objects/whats-new-modal';
+import { getUrlWithAutoLogin } from './utils';
 
 const skipTestOnWindows = process.platform === 'win32' ? test.skip : test;
 
@@ -81,7 +82,7 @@ test.describe( 'Servers', () => {
 
 		// page.goto opens a browser
 		const optionsGeneralUrl = wpAdminUrl + '/options-general.php'
-		await page.goto( `/playground-auto-login?redirect_to=${encodeURIComponent( optionsGeneralUrl )}` );
+		await page.goto( getUrlWithAutoLogin( optionsGeneralUrl ) );
 		const siteTitleInput = page.getByLabel( 'Site Title' );
 		await siteTitleInput.fill( 'testing site title' );
 		await siteTitleInput.press( 'Enter' );

--- a/e2e/sites.test.ts
+++ b/e2e/sites.test.ts
@@ -80,7 +80,8 @@ test.describe( 'Servers', () => {
 		const frontendUrl = await settingsTab.copySiteUrlToClipboard( session.electronApp );
 
 		// page.goto opens a browser
-		await page.goto( wpAdminUrl + '/options-general.php?playground-auto-login=true' );
+		const optionsGeneralUrl = wpAdminUrl + '/options-general.php'
+		await page.goto( `/playground-auto-login?redirect_to=${encodeURIComponent( optionsGeneralUrl )}` );
 		const siteTitleInput = page.getByLabel( 'Site Title' );
 		await siteTitleInput.fill( 'testing site title' );
 		await siteTitleInput.press( 'Enter' );

--- a/e2e/utils.ts
+++ b/e2e/utils.ts
@@ -1,5 +1,5 @@
 export function getUrlWithAutoLogin( destinationUrl: string): string {
 	const parsedUrl = new URL(destinationUrl);
 	const baseUrl = `${parsedUrl.protocol}//${parsedUrl.hostname}:${parsedUrl.port}`;
-	return `${baseUrl}/playground-auto-login?redirect_to=${encodeURIComponent( destinationUrl )}`;
+	return `${baseUrl}/studio-auto-login?redirect_to=${encodeURIComponent( destinationUrl )}`;
 }

--- a/e2e/utils.ts
+++ b/e2e/utils.ts
@@ -1,0 +1,5 @@
+export function getUrlWithAutoLogin( destinationUrl: string): string {
+	const parsedUrl = new URL(destinationUrl);
+	const baseUrl = `${parsedUrl.protocol}//${parsedUrl.hostname}:${parsedUrl.port}`;
+	return `${baseUrl}/playground-auto-login?redirect_to=${encodeURIComponent( destinationUrl )}`;
+}

--- a/metrics/tests/site-editor.test.ts
+++ b/metrics/tests/site-editor.test.ts
@@ -62,7 +62,7 @@ test.describe( 'Site Editor Load Metrics', () => {
 		const browser = await chromium.launch();
 		const context = await browser.newContext();
 		const page = await context.newPage();
-		await page.goto( `${ wpAdminUrl }?playground-auto-login=true` );
+		await page.goto( `/playground-auto-login?redirect_to=${encodeURIComponent( wpAdminUrl )}` );
 		await page.waitForLoadState( 'networkidle' );
 
 		// Run 2 iterations: 1 warmup + 1 measurement

--- a/metrics/tests/site-editor.test.ts
+++ b/metrics/tests/site-editor.test.ts
@@ -3,6 +3,7 @@ import { E2ESession } from '../../e2e/e2e-helpers';
 import Onboarding from '../../e2e/page-objects/onboarding';
 import SiteContent from '../../e2e/page-objects/site-content';
 import WhatsNewModal from '../../e2e/page-objects/whats-new-modal';
+import { getUrlWithAutoLogin } from '../../e2e/utils';
 import { median } from '../utils';
 
 test.describe( 'Site Editor Load Metrics', () => {
@@ -62,7 +63,7 @@ test.describe( 'Site Editor Load Metrics', () => {
 		const browser = await chromium.launch();
 		const context = await browser.newContext();
 		const page = await context.newPage();
-		await page.goto( `/playground-auto-login?redirect_to=${encodeURIComponent( wpAdminUrl )}` );
+		await page.goto( getUrlWithAutoLogin( wpAdminUrl ) );
 		await page.waitForLoadState( 'networkidle' );
 
 		// Run 2 iterations: 1 warmup + 1 measurement

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -932,9 +932,11 @@ export async function openSiteURL(
 		return;
 	}
 
-	const url = new URL( relativeURL, site.server.url );
+	let url = new URL( relativeURL, site.server.url );
 	if ( autoLogin ) {
-		url.searchParams.append( 'playground-auto-login', 'true' );
+		const autoLoginUrl = new URL( '/playground-auto-login', site.server.url );
+		autoLoginUrl.searchParams.append( 'redirect_to', autoLoginUrl.toString() );
+		url = autoLoginUrl;
 	}
 
 	void shellOpenExternalWrapper( url.toString() );

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -934,7 +934,7 @@ export async function openSiteURL(
 
 	let url = new URL( relativeURL, site.server.url );
 	if ( autoLogin ) {
-		const autoLoginUrl = new URL( '/playground-auto-login', site.server.url );
+		const autoLoginUrl = new URL( '/studio-auto-login', site.server.url );
 		autoLoginUrl.searchParams.append( 'redirect_to', url.toString() );
 		url = autoLoginUrl;
 	}

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -935,7 +935,7 @@ export async function openSiteURL(
 	let url = new URL( relativeURL, site.server.url );
 	if ( autoLogin ) {
 		const autoLoginUrl = new URL( '/playground-auto-login', site.server.url );
-		autoLoginUrl.searchParams.append( 'redirect_to', autoLoginUrl.toString() );
+		autoLoginUrl.searchParams.append( 'redirect_to', url.toString() );
 		url = autoLoginUrl;
 	}
 

--- a/src/lib/wordpress-provider/playground-cli/mu-plugins.ts
+++ b/src/lib/wordpress-provider/playground-cli/mu-plugins.ts
@@ -40,7 +40,7 @@ async function createLoaderMuPlugin(): Promise< string > {
 		if ( ! defined( 'DB_HOST' ) ) define( 'DB_HOST', 'localhost' );
 		if ( ! defined( 'DB_CHARSET' ) ) define( 'DB_CHARSET', 'utf8' );
 		if ( ! defined( 'DB_COLLATE' ) ) define( 'DB_COLLATE', '' );
-		
+
 		// Set environment type to local if not already defined
 		if ( ! defined( 'WP_ENVIRONMENT_TYPE' ) ) define( 'WP_ENVIRONMENT_TYPE', 'local' );
 
@@ -383,6 +383,46 @@ function getStandardMuPlugins( options: Partial< WordPressServerOptions > ): MuP
 			echo json_encode( $result );
 			exit;
 		}, 1 );
+		`,
+	} );
+
+	// Auto-login functionality via dedicated endpoint
+	muPlugins.push( {
+		filename: '0-auto-login.php',
+		content: `<?php
+		/**
+		 * Auto-Login Endpoint
+		 *
+		 * Provides /playground-auto-login endpoint for automatic authentication
+		 * Usage: /playground-auto-login?redirect_to=/wp-admin/
+		 */
+
+		// Intercept requests to /playground-auto-login
+		add_action( 'init', function() {
+			$request_uri = $_SERVER['REQUEST_URI'] ?? '';
+			if ( strpos( $request_uri, '/playground-auto-login' ) === false ) {
+				return;
+			}
+
+			if ( is_user_logged_in() ) {
+				$redirect_url = isset( $_GET['redirect_to'] ) ? $_GET['redirect_to'] : home_url();
+				wp_safe_redirect( $redirect_url );
+				exit;
+			}
+
+			$user = get_user_by( 'login', 'admin' );
+			if ( ! $user ) {
+				wp_die( 'Auto-login failed: admin user not found' );
+			}
+
+			wp_set_current_user( $user->ID, $user->user_login );
+			wp_set_auth_cookie( $user->ID, true, false );
+			do_action( 'wp_login', $user->user_login, $user );
+			$redirect_url = isset( $_GET['redirect_to'] ) ? $_GET['redirect_to'] : home_url();
+			wp_safe_redirect( $redirect_url );
+			exit;
+
+		}, 1 ); // Priority 1 to run early
 		`,
 	} );
 

--- a/src/lib/wordpress-provider/playground-cli/mu-plugins.ts
+++ b/src/lib/wordpress-provider/playground-cli/mu-plugins.ts
@@ -393,14 +393,14 @@ function getStandardMuPlugins( options: Partial< WordPressServerOptions > ): MuP
 		/**
 		 * Auto-Login Endpoint
 		 *
-		 * Provides /playground-auto-login endpoint for automatic authentication
-		 * Usage: /playground-auto-login?redirect_to=/wp-admin/
+		 * Provides /studio-auto-login endpoint for automatic authentication
+		 * Usage: /studio-auto-login?redirect_to=/wp-admin/
 		 */
-		
-		// Intercept requests to /playground-auto-login
+
+		// Intercept requests to /studio-auto-login
 		add_action( 'init', function() {
 			$request_uri = $_SERVER['REQUEST_URI'] ?? '';
-			if ( strpos( $request_uri, '/playground-auto-login' ) === false ) {
+			if ( strpos( $request_uri, '/studio-auto-login' ) === false ) {
 				return;
 			}
 
@@ -422,7 +422,7 @@ function getStandardMuPlugins( options: Partial< WordPressServerOptions > ): MuP
 			wp_safe_redirect( $redirect_url );
 			exit;
 
-		}, 1 ); // Priority 1 to run early
+		}, 1 );
 		`,
 	} );
 

--- a/src/lib/wordpress-provider/playground-cli/mu-plugins.ts
+++ b/src/lib/wordpress-provider/playground-cli/mu-plugins.ts
@@ -396,7 +396,7 @@ function getStandardMuPlugins( options: Partial< WordPressServerOptions > ): MuP
 		 * Provides /playground-auto-login endpoint for automatic authentication
 		 * Usage: /playground-auto-login?redirect_to=/wp-admin/
 		 */
-
+		
 		// Intercept requests to /playground-auto-login
 		add_action( 'init', function() {
 			$request_uri = $_SERVER['REQUEST_URI'] ?? '';

--- a/src/lib/wordpress-provider/playground-cli/playground-server-process-child.ts
+++ b/src/lib/wordpress-provider/playground-cli/playground-server-process-child.ts
@@ -179,7 +179,7 @@ async function startServer(
 			followSymlinks: true,
 			skipSqliteSetup: true,
 			port: options.port,
-			login: true,
+			login: false,
 			'mount-before-install': mounts,
 			'site-url': serverOptions.absoluteUrl,
 			blueprint: options.blueprint || {},

--- a/src/lib/wordpress-provider/playground-cli/playground-server-process-child.ts
+++ b/src/lib/wordpress-provider/playground-cli/playground-server-process-child.ts
@@ -175,11 +175,11 @@ async function startServer(
 
 		const args: RunCLIArgs = {
 			command: 'server',
-			internalCookieStore: true,
+			internalCookieStore: false,
+			login: false,
 			followSymlinks: true,
 			skipSqliteSetup: true,
 			port: options.port,
-			login: false,
 			'mount-before-install': mounts,
 			'site-url': serverOptions.absoluteUrl,
 			blueprint: options.blueprint || {},


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-867

## Proposed Changes

- Disable auto-login from the Playground CLI.
- Fix POST request using basic auth with application passwords
- Created new mu-plugin that adds a new custom route `/studio-auto-login` to enable auto log in from Studio

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Test autologin**

- Run `npm start`
- Click on open site
- Observer that you are not logged in
- Click on WP-admin or any other shortcut in the Overview tab.
- Observe that you can access the wp-admin dashboard without entering a password.
- Open `/wp-admin` in incognito mode.
- Observe that you are not logged in and are asked to enter your username and password. 

**Test application password**

- Run `npm start`
- Access wp-admin and navigate to Users > Profile > Application Passwords: `/wp-admin/profile.php?wp_http_referer=%2Fwp-admin%2Fusers.php#application-passwords-section`
- Type an application name and click on Add application password
- Run this curl command, replacing the `APPLICATION_PASSWORD_HERE` with your new created password.
```
curl -X POST "http://localhost:8892/wp-json/wp/v2/posts" \
  -u "admin:APPLICATION_PASSWORD_HERE" \
  -H "Content-Type: application/json" \
  -d '{
    "title": "Test Post from app password",
    "content": "Created with Application Password",
    "status": "publish"
}'
```
- Observe the post has been created without any issues


https://github.com/user-attachments/assets/c8536962-1afb-4833-9296-331d611e8178



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
