### PR TITLE
Add support for appx for arm64 architecture

### DIFF
--- a/patches/electron2appx+2.1.2.patch
+++ b/patches/electron2appx+2.1.2.patch
@@ -1,0 +1,17 @@
+diff --git a/node_modules/electron2appx/lib/convert.js b/node_modules/electron2appx/lib/convert.js
+index d6944da..0ffe45d 100644
+--- a/node_modules/electron2appx/lib/convert.js
++++ b/node_modules/electron2appx/lib/convert.js
+@@ -146,6 +146,12 @@ function convertWithFileCopy (program) {
+       result = result.replace(/\${packageDescription}/g, program.packageDescription || program.packageName)
+       result = result.replace(/\${packageBackgroundColor}/g, program.packageBackgroundColor || '#464646')
+       
++      // Replace ProcessorArchitecture based on FILE_ARCHITECTURE env var (x64, arm64, etc.)
++      const architecture = process.env.FILE_ARCHITECTURE || 'x64'
++      if (architecture !== 'x64') {
++        result = result.replace(/ProcessorArchitecture="x64"/g, `ProcessorArchitecture="${architecture}"`)
++      }
++
+       fs.writeFile(manifest, result, 'utf8', (err) => {
+         if (err) {
+           const errorMessage = `Could not write manifest file in pre-appx location. Error: ${JSON.stringify(err)}`

--- a/scripts/package-appx.mjs
+++ b/scripts/package-appx.mjs
@@ -13,6 +13,13 @@ if ( ! process.env.WINDOWS_CODE_SIGNING_CERT_PASSWORD ) {
 
 const __dirname = path.dirname( fileURLToPath( import.meta.url ) );
 
+// Get architecture from environment variable, default to x64 for backward compatibility
+const architecture = process.env.FILE_ARCHITECTURE || 'x64';
+if ( architecture !== 'x64' && architecture !== 'arm64' ) {
+	console.error( `Invalid architecture: ${ architecture }. Must be 'x64' or 'arm64'.` );
+	process.exit( 1 );
+}
+
 const windows10SDKVersionPath = path.resolve( __dirname, '..', '.windows-10-sdk-version' );
 try {
 	await fs.access( windows10SDKVersionPath );
@@ -22,7 +29,7 @@ try {
 }
 const windows10SDKVersionContent = await fs.readFile( windows10SDKVersionPath );
 const windows10SDKVersion = windows10SDKVersionContent.toString().trim();
-const windowsKitPath = `C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.${ windows10SDKVersion }.0\\x64`;
+const windowsKitPath = `C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.${ windows10SDKVersion }.0\\${ architecture }`;
 
 console.log( '~~~ Verifying Windows 10 SDK location...' );
 try {
@@ -55,6 +62,22 @@ const appStoreVersion = normalizeWindowsVersion( packageJson.version );
 
 const appxName = packageJson.productName + '-appx';
 
+console.log( `~~~ Packaging AppX for architecture: ${ architecture }` );
+
+// Create a custom manifest with the correct ProcessorArchitecture
+// electron2appx hardcodes ProcessorArchitecture="x64" in its template, so we need to override it
+const manifestTemplatePath = path.resolve( __dirname, '..', 'node_modules', 'electron2appx', 'template', 'appxmanifest.xml' );
+const manifestTemplate = await fs.readFile( manifestTemplatePath, 'utf-8' );
+
+// Replace the hardcoded x64 with the actual architecture
+// Note: We replace ProcessorArchitecture but leave other variables (${identityName}, etc.)
+// for electron2appx to process. The manifest option in electron2appx will use this
+// as a base and still do variable replacements.
+let manifestContent = manifestTemplate.replace( /ProcessorArchitecture="x64"/g, `ProcessorArchitecture="${ architecture }"` );
+const tempManifestPath = path.resolve( outPath, `AppXManifest-${ architecture }.xml` );
+await fs.writeFile( tempManifestPath, manifestContent, 'utf-8' );
+console.log( `~~~ Created architecture-specific manifest at ${ tempManifestPath }` );
+
 const sharedOptions = {
 	containerVirtualization: false,
 	inputDirectory: path.resolve( outPath, `Studio-win32-${ architecture }` ),
@@ -71,6 +94,7 @@ const sharedOptions = {
 	packageDisplayName: 'WordPress Studio',
 	publisherDisplayName: 'Automattic, Inc.',
 	identityName: '22490Automattic.StudiobyWordPress.com',
+	manifest: tempManifestPath, // Use our custom manifest with correct ProcessorArchitecture
 };
 
 const appxOutputPathUnsigned = path.resolve( outPath, `${ appxName }-${ architecture }-unsigned` );

--- a/scripts/package-appx.mjs
+++ b/scripts/package-appx.mjs
@@ -29,7 +29,9 @@ try {
 }
 const windows10SDKVersionContent = await fs.readFile( windows10SDKVersionPath );
 const windows10SDKVersion = windows10SDKVersionContent.toString().trim();
-const windowsKitPath = `C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.${ windows10SDKVersion }.0\\${ architecture }`;
+// Windows SDK tools (makeappx.exe, signtool.exe) are always in the x64 directory,
+// regardless of the target architecture. The architecture only affects the manifest.
+const windowsKitPath = `C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.${ windows10SDKVersion }.0\\x64`;
 
 console.log( '~~~ Verifying Windows 10 SDK location...' );
 try {

--- a/scripts/package-appx.mjs
+++ b/scripts/package-appx.mjs
@@ -49,6 +49,8 @@ const packageJson = JSON.parse( packageJsonText );
 const outPath = path.join( __dirname, '..', 'out' );
 const assetsPath = path.join( __dirname, '..', 'assets', 'appx' );
 
+console.log( `~~~ Packaging AppX for architecture: ${ architecture }` );
+
 const normalizeWindowsVersion = ( version ) => {
 	const noPrerelease = version.replace( /-.*/, '' );
 	return `${ noPrerelease }.0`;
@@ -57,22 +59,6 @@ const normalizeWindowsVersion = ( version ) => {
 const appStoreVersion = normalizeWindowsVersion( packageJson.version );
 
 const appxName = packageJson.productName + '-appx';
-
-console.log( `~~~ Packaging AppX for architecture: ${ architecture }` );
-
-// Create a custom manifest with the correct ProcessorArchitecture
-// electron2appx hardcodes ProcessorArchitecture="x64" in its template, so we need to override it
-const manifestTemplatePath = path.resolve( __dirname, '..', 'node_modules', 'electron2appx', 'template', 'appxmanifest.xml' );
-const manifestTemplate = await fs.readFile( manifestTemplatePath, 'utf-8' );
-
-// Replace the hardcoded x64 with the actual architecture
-// Note: We replace ProcessorArchitecture but leave other variables (${identityName}, etc.)
-// for electron2appx to process. The manifest option in electron2appx will use this
-// as a base and still do variable replacements.
-let manifestContent = manifestTemplate.replace( /ProcessorArchitecture="x64"/g, `ProcessorArchitecture="${ architecture }"` );
-const tempManifestPath = path.resolve( outPath, `AppXManifest-${ architecture }.xml` );
-await fs.writeFile( tempManifestPath, manifestContent, 'utf-8' );
-console.log( `~~~ Created architecture-specific manifest at ${ tempManifestPath }` );
 
 const sharedOptions = {
 	containerVirtualization: false,
@@ -90,9 +76,9 @@ const sharedOptions = {
 	packageDisplayName: 'WordPress Studio',
 	publisherDisplayName: 'Automattic, Inc.',
 	identityName: '22490Automattic.StudiobyWordPress.com',
-	manifest: tempManifestPath, // Use our custom manifest with correct ProcessorArchitecture
 };
 
+// Create unsigned AppX
 const appxOutputPathUnsigned = path.resolve( outPath, `${ appxName }-${ architecture }-unsigned` );
 console.log(
 	`~~~ Creating unsigned .appx for Microsoft Store submission upload at ${ appxOutputPathUnsigned }...`
@@ -106,6 +92,7 @@ await convertToWindowsStore( {
 	outputDirectory: appxOutputPathUnsigned,
 } );
 
+// Create signed AppX
 const appxOutputPathSigned = path.resolve( outPath, `${ appxName }-${ architecture }-signed` );
 console.log( `~~~ Creating signed .appx for local testing at ${ appxOutputPathSigned }...` );
 

--- a/scripts/package-appx.mjs
+++ b/scripts/package-appx.mjs
@@ -49,10 +49,6 @@ const packageJson = JSON.parse( packageJsonText );
 const outPath = path.join( __dirname, '..', 'out' );
 const assetsPath = path.join( __dirname, '..', 'assets', 'appx' );
 
-// Get architecture from environment variable, default to x64 for backward compatibility
-const architecture = process.env.FILE_ARCHITECTURE || 'x64';
-console.log( `~~~ Packaging for architecture: ${ architecture }` );
-
 const normalizeWindowsVersion = ( version ) => {
 	const noPrerelease = version.replace( /-.*/, '' );
 	return `${ noPrerelease }.0`;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- STU-59

## Proposed Changes

AppX packages were hardcoded with `ProcessorArchitecture="x64"` for all builds, causing Microsoft Store to reject ARM64 packages as duplicates.

I propose patching `electron2appx` via `patches/electron2appx+2.1.2.patch` to respect the `FILE_ARCHITECTURE` environment variable when generating manifests. The script now uses architecture-specific input directories and Windows Kit paths.

I considered those alternatives:
- Manual manifest creation before creating appx - too much code duplication
- Polling to fix manifest just after it is generated -  possible race condition concerns 
- Migration to Electron Builder - migration complexity
- Migration to Electron Forge maker-appx - it also uses the same lib, so doesn't solve the problem

Separately, I can contribute the patch upstream to the `electron2appx` repository.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Confirm if the builds work fine
- Confirm that Microsoft Store accepts two packages: x64 and arm64 and doesn't trigger duplicate alert

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
