### PR TITLE
What's New modal: Remove unnecessary state tracking and evaluate `isNewVersion` only when ready

### DIFF
--- a/src/modules/whats-new/hooks/use-last-seen-version.tsx
+++ b/src/modules/whats-new/hooks/use-last-seen-version.tsx
@@ -16,7 +16,7 @@ export function useLastSeenVersion(): UseLastSeenVersion {
 	const { lastSeenVersion, isNewVersion } = useGetLastSeenVersionQuery( undefined, {
 		selectFromResult: ( result ) => ( {
 			lastSeenVersion: result.data,
-			isNewVersion: selectIsNewVersion( result, currentVersion ),
+			isNewVersion: result.isSuccess && selectIsNewVersion( result, currentVersion ),
 		} ),
 	} );
 	const [ saveLastSeenVersion ] = useSaveLastSeenVersionMutation();

--- a/src/modules/whats-new/hooks/use-last-seen-version.tsx
+++ b/src/modules/whats-new/hooks/use-last-seen-version.tsx
@@ -16,7 +16,11 @@ export function useLastSeenVersion(): UseLastSeenVersion {
 	const { lastSeenVersion, isNewVersion } = useGetLastSeenVersionQuery( undefined, {
 		selectFromResult: ( result ) => ( {
 			lastSeenVersion: result.data,
-			isNewVersion: result.isSuccess && selectIsNewVersion( result, currentVersion ),
+			isNewVersion:
+				! result.isLoading &&
+				! result.isFetching &&
+				result.isSuccess &&
+				selectIsNewVersion( result, currentVersion ),
 		} ),
 	} );
 	const [ saveLastSeenVersion ] = useSaveLastSeenVersionMutation();

--- a/src/modules/whats-new/hooks/use-whats-new.tsx
+++ b/src/modules/whats-new/hooks/use-whats-new.tsx
@@ -9,24 +9,21 @@ interface UseWhatsNew {
 }
 
 export function useWhatsNew(): UseWhatsNew {
-	const [ showWhatsNew, setShowWhatsNew ] = useState( true );
 	const [ manuallyTriggered, setManuallyTriggered ] = useState( false );
 	const { needsOnboarding } = useOnboarding();
 	const { isNewVersion, updateLastSeenVersion } = useLastSeenVersion();
 
 	useIpcListener( 'show-whats-new', () => {
 		setManuallyTriggered( true );
-		setShowWhatsNew( true );
 	} );
 
 	const closeWhatsNew = async () => {
-		setShowWhatsNew( false );
 		setManuallyTriggered( false );
 		await updateLastSeenVersion();
 	};
 
 	return {
-		showWhatsNew: ( manuallyTriggered || ( showWhatsNew && isNewVersion ) ) && ! needsOnboarding,
+		showWhatsNew: ( manuallyTriggered || isNewVersion ) && ! needsOnboarding,
 		closeWhatsNew,
 	};
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

Fixes STU-932

## Proposed Changes

- remove unnecessary `showWhatsNew` state
- add `isSuccess` check before evaluating `isNewVersion`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

As the STU-932 issue is more visible on Windows, it might be more suitable to test this PR on Windows.

1. Check out the PR branch and build the app with `npm install && npm start`.
2. When the app starts, the _What's New_ modal **should not** render briefly for a fraction of a second and then disappear. It should either render and stay rendered - or - do not render at all.
3. To test different cases, you can try to manipulate the `lastSeenVersion` value stored in the `appdata-v1.json`, e.g.:
  - if the `lastSeenVersion` is the same as the current app version, the modal should not render
  - if the minor or major version stored in `lastSeenVersion` is different, the modal should render
4. It should still be possible to open the _What's New_ modal from the app's _Help_ menu.
5. There should be no regressions.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
