### PR TITLE
Preview Sites: Delete all preview sites using `/delete/all` API endpoint

### DIFF
--- a/src/modules/user-settings/components/snapshot-info.tsx
+++ b/src/modules/user-settings/components/snapshot-info.tsx
@@ -25,7 +25,7 @@ export const SnapshotInfo = ( {
 	const { __ } = useI18n();
 	const { data: snapshotUsage } = useGetSnapshotUsage( undefined, {
 		refetchOnMountOrArgChange: true,
-	});
+	} );
 	const snapshotCreationBlocked = snapshotUsage?.siteCreationBlocked ?? false;
 	const menuItemStyles = cx(
 		'[&_span]:min-w-0 [&_span]:p-[1px]',

--- a/src/modules/user-settings/components/snapshot-info.tsx
+++ b/src/modules/user-settings/components/snapshot-info.tsx
@@ -23,7 +23,9 @@ export const SnapshotInfo = ( {
 	isDeleting?: boolean;
 } ) => {
 	const { __ } = useI18n();
-	const { data: snapshotUsage } = useGetSnapshotUsage();
+	const { data: snapshotUsage } = useGetSnapshotUsage( undefined, {
+		refetchOnMountOrArgChange: true,
+	});
 	const snapshotCreationBlocked = snapshotUsage?.siteCreationBlocked ?? false;
 	const menuItemStyles = cx(
 		'[&_span]:min-w-0 [&_span]:p-[1px]',

--- a/src/modules/user-settings/components/usage-tab.tsx
+++ b/src/modules/user-settings/components/usage-tab.tsx
@@ -19,7 +19,12 @@ export const UsageTab = ( {
 	<>
 		<SnapshotInfo
 			isDeleting={ loadingDeletingAllSnapshots || isLoadingSnapshotUsage }
-			isDisabled={ isOffline || loadingDeletingAllSnapshots || isLoadingSnapshotUsage }
+			isDisabled={
+				activeSnapshotCount === 0 ||
+				isOffline ||
+				loadingDeletingAllSnapshots ||
+				isLoadingSnapshotUsage
+			}
 			siteCount={ activeSnapshotCount }
 			siteLimit={ snapshotQuota }
 			onRemoveSnapshots={ onRemoveSnapshots }

--- a/src/modules/user-settings/components/usage-tab.tsx
+++ b/src/modules/user-settings/components/usage-tab.tsx
@@ -1,4 +1,3 @@
-import { Snapshot } from 'common/types/snapshot';
 import { PromptInfo } from './prompt-info';
 import { SnapshotInfo } from './snapshot-info';
 
@@ -6,7 +5,6 @@ export const UsageTab = ( {
 	loadingDeletingAllSnapshots,
 	activeSnapshotCount,
 	isLoadingSnapshotUsage,
-	allSnapshots,
 	isOffline,
 	snapshotQuota,
 	onRemoveSnapshots,
@@ -14,21 +12,14 @@ export const UsageTab = ( {
 	loadingDeletingAllSnapshots: boolean;
 	activeSnapshotCount: number;
 	isLoadingSnapshotUsage: boolean;
-	allSnapshots: Pick< Snapshot, 'atomicSiteId' >[] | null;
 	isOffline: boolean;
 	snapshotQuota: number;
 	onRemoveSnapshots: () => void;
 } ) => (
 	<>
 		<SnapshotInfo
-			isDeleting={ loadingDeletingAllSnapshots }
-			isDisabled={
-				activeSnapshotCount === 0 ||
-				loadingDeletingAllSnapshots ||
-				isLoadingSnapshotUsage ||
-				allSnapshots?.length === 0 ||
-				isOffline
-			}
+			isDeleting={ loadingDeletingAllSnapshots || isLoadingSnapshotUsage }
+			isDisabled={ isOffline || loadingDeletingAllSnapshots || isLoadingSnapshotUsage }
 			siteCount={ activeSnapshotCount }
 			siteLimit={ snapshotQuota }
 			onRemoveSnapshots={ onRemoveSnapshots }

--- a/src/modules/user-settings/components/user-settings.tsx
+++ b/src/modules/user-settings/components/user-settings.tsx
@@ -1,6 +1,6 @@
 import { TabPanel } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import Modal from 'src/components/modal';
 import { useAuth } from 'src/hooks/use-auth';
 import { useIpcListener } from 'src/hooks/use-ipc-listener';
@@ -11,19 +11,15 @@ import { AccountTab } from 'src/modules/user-settings/components/account-tab';
 import { NonAuthenticatedAccountTab } from 'src/modules/user-settings/components/non-authenticated-account-tab';
 import { PreferencesTab } from 'src/modules/user-settings/components/preferences-tab';
 import { UsageTab } from 'src/modules/user-settings/components/usage-tab';
-import { useRootSelector, useAppDispatch } from 'src/stores';
-import { snapshotSelectors, snapshotThunks } from 'src/stores/snapshot-slice';
-import { useGetSnapshotUsage } from 'src/stores/wpcom-api';
-import { UserSettingsTab } from '../user-settings-types';
+import { useAppDispatch, useRootSelector } from 'src/stores';
+import { snapshotSelectors } from 'src/stores/snapshot-slice';
+import { useDeleteAllSnapshots, useGetSnapshotUsage, wpcomApi } from 'src/stores/wpcom-api';
+import { UserSettingsTab } from 'src/modules/user-settings/user-settings-types';
 
 export default function UserSettings() {
 	const { __ } = useI18n();
-	const dispatch = useAppDispatch();
 	const { isAuthenticated, logout, user } = useAuth();
-
-	const activeBulkOperationForUser = useRootSelector( ( state ) =>
-		snapshotSelectors.selectActiveBulkOperationForUser( state, user?.id ?? 0 )
-	);
+	const dispatch = useAppDispatch();
 	const snapshotsByUser = useRootSelector( ( state ) =>
 		snapshotSelectors.selectSnapshotsByUser( state, user?.id ?? 0 )
 	);
@@ -34,6 +30,8 @@ export default function UserSettings() {
 	const [ needsToOpenUserSettings, setNeedsToOpenUserSettings ] = useState( false );
 	const [ selectedTabName, setSelectedTabName ] = useState< string | undefined >();
 
+	const [ deleteAllSnapshots, { isLoading: isDeletingAllSnapshots, isError: isErrorDeletingAllSnapshots } ] = useDeleteAllSnapshots();
+
 	const isOffline = useOffline();
 
 	const resetLocalState = useCallback( () => {
@@ -41,10 +39,25 @@ export default function UserSettings() {
 		setSelectedTabName( undefined );
 	}, [] );
 
+	const showErrorMessageBox = useCallback( () => {
+		getIpcApi().showMessageBox( {
+			type: 'warning',
+			message: __( 'Failed to delete all preview sites' ),
+			detail: __( 'An error occurred while deleting all preview sites. Please try again.' ),
+			buttons: [ __( 'OK' ) ],
+		} );
+	}, [] );
+
 	useIpcListener( 'user-settings', ( _event, { tabName } ) => {
 		setSelectedTabName( tabName );
 		setNeedsToOpenUserSettings( ! needsToOpenUserSettings );
 	} );
+
+	useEffect( () => {
+		if ( isErrorDeletingAllSnapshots ) {
+			showErrorMessageBox();
+		}
+	}, [ isErrorDeletingAllSnapshots ] );
 
 	const onRemoveSnapshots = useCallback( async () => {
 		const CANCEL_BUTTON_INDEX = 0;
@@ -61,9 +74,18 @@ export default function UserSettings() {
 		} );
 
 		if ( response === DELETE_BUTTON_INDEX ) {
-			await dispatch( snapshotThunks.deleteAllSnapshotsForUser( { userId: user?.id ?? 0 } ) );
+			try {
+				await deleteAllSnapshots();
+
+				// Wait for changes to take effect on the back-end before invalidating the query
+				setTimeout( () => {
+					dispatch( wpcomApi.util.invalidateTags( [ 'SnapshotUsage' ] ) );
+				}, 8000 );
+			} catch ( error ) {
+				showErrorMessageBox();
+			}
 		}
-	}, [ __, dispatch, user?.id ] );
+	}, [ __, deleteAllSnapshots ] );
 
 	const tabs: UserSettingsTab[] = [
 		{
@@ -113,10 +135,9 @@ export default function UserSettings() {
 								{ name === 'preferences' && <PreferencesTab onClose={ resetLocalState } /> }
 								{ name === 'usage' && isAuthenticated && (
 									<UsageTab
-										loadingDeletingAllSnapshots={ !! activeBulkOperationForUser }
+										loadingDeletingAllSnapshots={ isDeletingAllSnapshots }
 										activeSnapshotCount={ definitiveSnapshotCount }
 										isLoadingSnapshotUsage={ isLoadingSnapshotUsage }
-										allSnapshots={ snapshotsByUser }
 										isOffline={ isOffline }
 										snapshotQuota={ snapshotQuota }
 										onRemoveSnapshots={ onRemoveSnapshots }

--- a/src/modules/user-settings/components/user-settings.tsx
+++ b/src/modules/user-settings/components/user-settings.tsx
@@ -13,9 +13,8 @@ import { PreferencesTab } from 'src/modules/user-settings/components/preferences
 import { UsageTab } from 'src/modules/user-settings/components/usage-tab';
 import { useRootSelector } from 'src/stores';
 import { snapshotSelectors } from 'src/stores/snapshot-slice';
-import { useDeleteAllSnapshots, useGetSnapshotUsage, wpcomApi } from 'src/stores/wpcom-api';
+import { useDeleteAllSnapshots, useGetSnapshotUsage } from 'src/stores/wpcom-api';
 import { UserSettingsTab } from 'src/modules/user-settings/user-settings-types';
-import { updateAppdata } from 'src/storage/user-data';
 
 export default function UserSettings() {
 	const { __ } = useI18n();
@@ -61,7 +60,7 @@ export default function UserSettings() {
 		if ( response === DELETE_BUTTON_INDEX ) {
 			try {
 				await deleteAllSnapshots().unwrap();
-				await updateAppdata( { snapshots: [] } );
+				await getIpcApi().saveSnapshotsToStorage( [] );
 			} catch ( error ) {
 				await getIpcApi().showMessageBox( {
 					type: 'warning',

--- a/src/modules/user-settings/components/user-settings.tsx
+++ b/src/modules/user-settings/components/user-settings.tsx
@@ -1,6 +1,6 @@
 import { TabPanel } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useState } from 'react';
 import Modal from 'src/components/modal';
 import { useAuth } from 'src/hooks/use-auth';
 import { useIpcListener } from 'src/hooks/use-ipc-listener';
@@ -11,10 +11,10 @@ import { AccountTab } from 'src/modules/user-settings/components/account-tab';
 import { NonAuthenticatedAccountTab } from 'src/modules/user-settings/components/non-authenticated-account-tab';
 import { PreferencesTab } from 'src/modules/user-settings/components/preferences-tab';
 import { UsageTab } from 'src/modules/user-settings/components/usage-tab';
+import { UserSettingsTab } from 'src/modules/user-settings/user-settings-types';
 import { useRootSelector } from 'src/stores';
 import { snapshotSelectors } from 'src/stores/snapshot-slice';
 import { useDeleteAllSnapshots, useGetSnapshotUsage } from 'src/stores/wpcom-api';
-import { UserSettingsTab } from 'src/modules/user-settings/user-settings-types';
 
 export default function UserSettings() {
 	const { __ } = useI18n();

--- a/src/modules/user-settings/components/user-settings.tsx
+++ b/src/modules/user-settings/components/user-settings.tsx
@@ -11,15 +11,15 @@ import { AccountTab } from 'src/modules/user-settings/components/account-tab';
 import { NonAuthenticatedAccountTab } from 'src/modules/user-settings/components/non-authenticated-account-tab';
 import { PreferencesTab } from 'src/modules/user-settings/components/preferences-tab';
 import { UsageTab } from 'src/modules/user-settings/components/usage-tab';
-import { useAppDispatch, useRootSelector } from 'src/stores';
+import { useRootSelector } from 'src/stores';
 import { snapshotSelectors } from 'src/stores/snapshot-slice';
 import { useDeleteAllSnapshots, useGetSnapshotUsage, wpcomApi } from 'src/stores/wpcom-api';
 import { UserSettingsTab } from 'src/modules/user-settings/user-settings-types';
+import { updateAppdata } from 'src/storage/user-data';
 
 export default function UserSettings() {
 	const { __ } = useI18n();
 	const { isAuthenticated, logout, user } = useAuth();
-	const dispatch = useAppDispatch();
 	const snapshotsByUser = useRootSelector( ( state ) =>
 		snapshotSelectors.selectSnapshotsByUser( state, user?.id ?? 0 )
 	);
@@ -30,7 +30,7 @@ export default function UserSettings() {
 	const [ needsToOpenUserSettings, setNeedsToOpenUserSettings ] = useState( false );
 	const [ selectedTabName, setSelectedTabName ] = useState< string | undefined >();
 
-	const [ deleteAllSnapshots, { isLoading: isDeletingAllSnapshots, isError: isErrorDeletingAllSnapshots } ] = useDeleteAllSnapshots();
+	const [ deleteAllSnapshots, { isLoading: isDeletingAllSnapshots } ] = useDeleteAllSnapshots();
 
 	const isOffline = useOffline();
 
@@ -39,25 +39,10 @@ export default function UserSettings() {
 		setSelectedTabName( undefined );
 	}, [] );
 
-	const showErrorMessageBox = useCallback( () => {
-		getIpcApi().showMessageBox( {
-			type: 'warning',
-			message: __( 'Failed to delete all preview sites' ),
-			detail: __( 'An error occurred while deleting all preview sites. Please try again.' ),
-			buttons: [ __( 'OK' ) ],
-		} );
-	}, [] );
-
 	useIpcListener( 'user-settings', ( _event, { tabName } ) => {
 		setSelectedTabName( tabName );
 		setNeedsToOpenUserSettings( ! needsToOpenUserSettings );
 	} );
-
-	useEffect( () => {
-		if ( isErrorDeletingAllSnapshots ) {
-			showErrorMessageBox();
-		}
-	}, [ isErrorDeletingAllSnapshots ] );
 
 	const onRemoveSnapshots = useCallback( async () => {
 		const CANCEL_BUTTON_INDEX = 0;
@@ -75,14 +60,15 @@ export default function UserSettings() {
 
 		if ( response === DELETE_BUTTON_INDEX ) {
 			try {
-				await deleteAllSnapshots();
-
-				// Wait for changes to take effect on the back-end before invalidating the query
-				setTimeout( () => {
-					dispatch( wpcomApi.util.invalidateTags( [ 'SnapshotUsage' ] ) );
-				}, 8000 );
+				await deleteAllSnapshots().unwrap();
+				await updateAppdata( { snapshots: [] } );
 			} catch ( error ) {
-				showErrorMessageBox();
+				await getIpcApi().showMessageBox( {
+					type: 'warning',
+					message: __( 'Failed to delete all preview sites' ),
+					detail: __( 'An error occurred while deleting all preview sites. Please try again.' ),
+					buttons: [ __( 'OK' ) ],
+				} );
 			}
 		}
 	}, [ __, deleteAllSnapshots ] );

--- a/src/storage/user-data.ts
+++ b/src/storage/user-data.ts
@@ -121,6 +121,7 @@ type UserDataSafeKeys =
 	| 'devToolsOpen'
 	| 'windowBounds'
 	| 'authToken'
+	| 'snapshots'
 	| 'onboardingCompleted'
 	| 'locale'
 	| 'promptWindowsSpeedUpResult'

--- a/src/stores/utils/with-offline-check.ts
+++ b/src/stores/utils/with-offline-check.ts
@@ -23,7 +23,9 @@ export function withOfflineCheckMutation< TResult, TArg, TBaseQuery extends Base
 
 		const wrappedTrigger = ( ( ...args: Parameters< typeof trigger > ) => {
 			if ( isOffline ) {
-				return Promise.reject( new Error( 'Cannot perform mutation while offline' ) ) as ReturnType< typeof trigger >;
+				return Promise.reject( new Error( 'Cannot perform mutation while offline' ) ) as ReturnType<
+					typeof trigger
+				>;
 			}
 			return trigger( ...args );
 		} ) as typeof trigger;

--- a/src/stores/utils/with-offline-check.ts
+++ b/src/stores/utils/with-offline-check.ts
@@ -1,6 +1,6 @@
 import { useOffline } from 'src/hooks/use-offline';
 import type { BaseQueryFn } from '@reduxjs/toolkit/query';
-import type { TypedUseQuery } from '@reduxjs/toolkit/query/react';
+import type { TypedUseQuery, TypedUseMutation } from '@reduxjs/toolkit/query/react';
 
 export function withOfflineCheck< TResult, TArg, TBaseQuery extends BaseQueryFn >(
 	useQueryHook: TypedUseQuery< TResult, TArg, TBaseQuery >
@@ -11,5 +11,23 @@ export function withOfflineCheck< TResult, TArg, TBaseQuery extends BaseQueryFn 
 			...options,
 			skip: isOffline || options?.skip,
 		} );
+	};
+}
+
+export function withOfflineCheckMutation< TResult, TArg, TBaseQuery extends BaseQueryFn >(
+	useMutationHook: TypedUseMutation< TResult, TArg, TBaseQuery >
+): TypedUseMutation< TResult, TArg, TBaseQuery > {
+	return ( options = {} ) => {
+		const isOffline = useOffline();
+		const [ trigger, result ] = useMutationHook( options );
+
+		const wrappedTrigger = ( ( ...args: Parameters< typeof trigger > ) => {
+			if ( isOffline ) {
+				return Promise.reject( new Error( 'Cannot perform mutation while offline' ) ) as ReturnType< typeof trigger >;
+			}
+			return trigger( ...args );
+		} ) as typeof trigger;
+
+		return [ wrappedTrigger, result ] as const;
 	};
 }

--- a/src/stores/wpcom-api.ts
+++ b/src/stores/wpcom-api.ts
@@ -158,7 +158,6 @@ export const wpcomApi = createApi( {
 				apiNamespace: 'wpcom/v2',
 				method: 'POST',
 			} ),
-			invalidatesTags: [ 'SnapshotUsage' ],
 		} )
 	} ),
 } );

--- a/src/stores/wpcom-api.ts
+++ b/src/stores/wpcom-api.ts
@@ -1,10 +1,10 @@
-import { createApi, TypedUseQuery } from '@reduxjs/toolkit/query/react';
+import { createApi, TypedUseQuery, TypedUseMutation } from '@reduxjs/toolkit/query/react';
 import * as Sentry from '@sentry/electron/renderer';
 import { z } from 'zod';
 import { DAY_MS } from 'common/constants';
 import wpcomFactory from 'src/lib/wpcom-factory';
 import wpcomXhrRequest from 'src/lib/wpcom-xhr-request-factory';
-import { withOfflineCheck } from 'src/stores/utils/with-offline-check';
+import { withOfflineCheck, withOfflineCheckMutation } from 'src/stores/utils/with-offline-check';
 import type { BaseQueryFn, FetchBaseQueryError } from '@reduxjs/toolkit/query';
 
 type WPCOM = ReturnType< typeof wpcomFactory >;
@@ -152,6 +152,14 @@ export const wpcomApi = createApi( {
 			keepUnusedDataFor: 60 * 60,
 			providesTags: [ 'SnapshotUsage' ],
 		} ),
+		deleteAllSnapshots: builder.mutation< void, void >( {
+			query: () => ( {
+				path: '/jurassic-ninja/delete/all',
+				apiNamespace: 'wpcom/v2',
+				method: 'POST',
+			} ),
+			invalidatesTags: [ 'SnapshotUsage' ],
+		} )
 	} ),
 } );
 
@@ -220,6 +228,21 @@ function withWpcomClientCheck< TResult, TArg >(
 	};
 }
 
+function withWpcomClientCheckMutation< TResult, TArg >(
+	useMutationHook: TypedUseMutation< TResult, TArg, typeof wpcomBaseQuery >
+): TypedUseMutation< TResult, TArg, typeof wpcomBaseQuery > {
+	return ( options = {} ) => {
+		const [ trigger, result ] = useMutationHook( options );
+		const wrappedTrigger = ( ( ...args: Parameters< typeof trigger > ) => {
+			if ( ! wpcomClient ) {
+				return Promise.reject( new Error( 'Not authenticated' ) ) as ReturnType< typeof trigger >;
+			}
+			return trigger( ...args );
+		} ) as typeof trigger;
+		return [ wrappedTrigger, result ] as const;
+	};
+}
+
 export const useGetWelcomeMessages = withWpcomClientCheck(
 	withOfflineCheck( wpcomApi.useGetWelcomeMessagesQuery )
 );
@@ -230,6 +253,10 @@ export const useGetAssistantQuota = withWpcomClientCheck(
 
 export const useGetSnapshotUsage = withWpcomClientCheck(
 	withOfflineCheck( wpcomApi.useGetSnapshotUsageQuery )
+);
+
+export const useDeleteAllSnapshots = withWpcomClientCheckMutation(
+	withOfflineCheckMutation( wpcomApi.useDeleteAllSnapshotsMutation )
 );
 
 // Blueprints use the public API and don't require authentication

--- a/src/stores/wpcom-api.ts
+++ b/src/stores/wpcom-api.ts
@@ -158,7 +158,7 @@ export const wpcomApi = createApi( {
 				apiNamespace: 'wpcom/v2',
 				method: 'POST',
 			} ),
-		} )
+		} ),
 	} ),
 } );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-851

## Proposed Changes

- Add a new mutation endpoint for deleting all preview sites for the user 
- Use the API endpoint to delete preview sites in the preference modal

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Apply the patch 194679-ghe-Automattic/wpcom on your sandbox.
2. Run Studio using this branch.
3. Start the application with:

   ```bash
   npm start
   ```
4. Open Developer Tools and keep the Network tab open.
5. Navigate to the Preferences tab in Studio and log in (if not already).
6. Go to the Usage tab and click Delete all preview sites.
7. Verify that a request to

   ```
   /jurassic-ninja/delete/all/delete/all
   ```

   was sent and returned a successful response
8. Confirm that the usage numbers are reset.
9. Close and reopen the Usage tab.
10. Ensure the updated usage numbers are still reflected.
11. Open the following file on your system:

    ```
    ~/Library/Application Support/Studio/appdata-v1.json
    ```
12. Verify that the snapshots array is cleared and shows as `[]`.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?