### PR TITLE
Studio: Optimize import workflow by removing unnecessary server start/stop

### DIFF
--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -172,9 +172,7 @@ export async function importSite(
 	}
 	try {
 		if ( ! isWordPressDirectory( site.details.path ) ) {
-			// Workaround to have the necessary WordPress files to run the import - STU-744
-			await site.start();
-			await site.stop();
+			await getWordPressProvider().setupWordPressFilesOnly( site.details.path );
 		}
 
 		const onEvent = ( data: ImportExportEventData ) => {
@@ -188,6 +186,9 @@ export async function importSite(
 		if ( result?.meta?.phpVersion ) {
 			site.details.phpVersion = result.meta.phpVersion;
 		}
+
+		// Clear blueprint so it doesn't overwrite imported data on first start
+		site.meta.blueprint = undefined;
 
 		return site.details;
 	} catch ( e ) {

--- a/src/lib/wordpress-provider/playground-cli/playground-cli-provider.ts
+++ b/src/lib/wordpress-provider/playground-cli/playground-cli-provider.ts
@@ -260,4 +260,20 @@ export class PlaygroundCliProvider implements WordPressProvider {
 
 		return { wpContentPath: undefined };
 	}
+
+	async setupWordPressFilesOnly( path: string ): Promise< void > {
+		try {
+			const bundledWPPath = nodePath.join( getResourcesPath(), 'wp-files', 'latest', 'wordpress' );
+
+			if ( ! ( await pathExists( bundledWPPath ) ) ) {
+				throw new Error( 'Bundled WordPress files not found. Please reinstall WordPress Studio.' );
+			}
+
+			await recursiveCopyDirectory( bundledWPPath, path );
+			await keepSqliteIntegrationUpdated( path );
+		} catch ( error ) {
+			console.error( 'Failed to setup WordPress files:', error );
+			throw error;
+		}
+	}
 }

--- a/src/lib/wordpress-provider/types.ts
+++ b/src/lib/wordpress-provider/types.ts
@@ -70,6 +70,7 @@ export interface WordPressProvider {
 
 	// Core functionality
 	setupWordPressSite( server: SiteServer, wpVersion?: string ): Promise< boolean >;
+	setupWordPressFilesOnly( path: string ): Promise< void >;
 	installWordPressWhenNoWpConfig(
 		server: SiteServer,
 		siteName: string,

--- a/src/lib/wordpress-provider/wp-now/wp-now-provider.ts
+++ b/src/lib/wordpress-provider/wp-now/wp-now-provider.ts
@@ -148,6 +148,10 @@ export class WpNowProvider implements WordPressProvider {
 		}
 	}
 
+	async setupWordPressFilesOnly( _path: string ): Promise< void > {
+		// No-op for wp-now provider
+	}
+
 	async installWordPressWhenNoWpConfig(
 		_server: SiteServer,
 		_siteName: string,

--- a/src/tests/ipc-handlers.test.ts
+++ b/src/tests/ipc-handlers.test.ts
@@ -29,6 +29,7 @@ jest.mock( 'src/lib/wordpress-provider', () => ( {
 		DEFAULT_PHP_VERSION: '8.3',
 		DEFAULT_WORDPRESS_VERSION: 'latest',
 		SQLITE_FILENAME: 'sqlite.php',
+		setupWordPressFilesOnly: jest.fn().mockResolvedValue( undefined ),
 	} ),
 } ) );
 jest.mock( 'src/main-window' );
@@ -207,6 +208,7 @@ describe( 'importSite', () => {
 				id: 'test-site',
 				phpVersion: '8.3',
 			},
+			meta: {},
 			start: jest.fn(),
 			stop: jest.fn(),
 			updateSiteDetails: jest.fn(),


### PR DESCRIPTION
## Related issues

- Fixes STU-744

## Proposed Changes

- Added `setupWordPressFilesOnly()` method to PlaygroundCliProvider that copies WordPress files directly without starting the serve
- Modified import workflow in ipc-handlers.ts to use the new method instead of the start/stop cycle
- Added blueprint clearing after import to prevent imported data from being overwritten on first site start

## Testing Instructions

- Create a new site in Studio using a import file
- Import a backup site into an existing Studio site

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?