### PR TITLE
Fix usage ProgressBar width

### DIFF
--- a/src/components/progress-bar.tsx
+++ b/src/components/progress-bar.tsx
@@ -9,7 +9,7 @@ type ProgressBarProps = {
 };
 
 const ProgressBar = ( { value, maxValue, className }: ProgressBarProps ) => {
-	const classNames = cx( 'w-full flex', className );
+	const classNames = cx( '!w-full flex', className );
 	if ( value !== undefined && maxValue !== undefined ) {
 		const percentage = Math.max( 0, Math.min( 100, ( value / maxValue ) * 100 ) );
 		return <WPProgressBar value={ percentage } className={ classNames } />;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-924

## Proposed Changes

- Let's fix the width of usage progress bar

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run `npm start`
- Go to settings
- Go to Usage
- Observe the progress bar takes the full width
- Run import/export and pull push, observe those didn't change.

| Before | After |
|--------|--------|
|  <img width="1012" height="712" alt="Screenshot 2025-10-28 at 17 52 20" src="https://github.com/user-attachments/assets/0001b1e0-74de-4778-b7b0-4fabed5532d8" /> | <img width="1012" height="712" alt="Screenshot 2025-10-28 at 17 52 14" src="https://github.com/user-attachments/assets/ddc84867-10cc-477c-99e8-9d6f4e51b305" /> |



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
