### PR TITLE
Preview Sites: Add preview site status check when visiting preview tab

### DIFF
--- a/src/modules/preview-site/components/preview-site-row.tsx
+++ b/src/modules/preview-site/components/preview-site-row.tsx
@@ -16,6 +16,7 @@ import { DeleteProgressRow } from 'src/modules/preview-site/components/delete-pr
 import { PreviewActionButtonsMenu } from 'src/modules/preview-site/components/preview-action-buttons-menu';
 import { useAppDispatch, useRootSelector } from 'src/stores';
 import { snapshotActions, snapshotSelectors } from 'src/stores/snapshot-slice';
+import { useGetSnapshotStatus } from 'src/stores/wpcom-api';
 
 interface PreviewSiteRowProps {
 	snapshot: Snapshot;
@@ -42,9 +43,12 @@ export function PreviewSiteRow( {
 	const deleteOperation = useRootSelector( ( state ) =>
 		snapshotSelectors.selectDeleteOperationForSnapshot( state, snapshot.url )
 	);
+	const { data: snapshotStatus, refetch: refetchSnapshotStatus } = useGetSnapshotStatus( snapshot.atomicSiteId );
 	const { formatRelativeTime } = useFormatLocalizedTimestamps();
 	const [ showUpdatedMessage, setShowUpdatedMessage ] = useState( false );
 	const wasUpdating = useRef( false );
+	const isDeleted = snapshotStatus?.isDeleted;
+	const isSiteInactive = isExpired || isDeleted;
 
 	useEffect( () => {
 		if ( ! updateOperation ) {
@@ -72,6 +76,11 @@ export function PreviewSiteRow( {
 
 		return () => clearTimeout( timeoutId );
 	}, [ updateOperation ] );
+
+	// Refetch snapshot status to check if the site has been deleted
+	useEffect( () => {
+		refetchSnapshotStatus();
+	}, [ refetchSnapshotStatus ] );
 
 	const getLastUpdateTimeText = () => {
 		if ( ! date ) {
@@ -108,31 +117,41 @@ export function PreviewSiteRow( {
 		<div className="self-stretch flex-col">
 			<div className="flex items-center px-8 py-6">
 				<div className="w-[51%] overflow-hidden pe-4">
-					<div className="flex items-center">
-						<div
-							className={ cx(
-								'text-[13px] leading-5 line-clamp-1 break-all',
-								isExpired && 'line-through text-a8c-gray-700'
-							) }
-						>
-							{ /* translators: %s: Site name (e.g. "My Site Preview") */ }
-							{ snapshot.name || sprintf( __( '%s Preview' ), selectedSite.name ) }
-						</div>
-					</div>
-					<Button
-						variant="link"
-						disabled={ isExpired }
-						className={ cx(
-							'!text-a8c-gray-700 max-w-full',
-							isExpired ? 'pointer-events-none' : 'hover:!text-a8c-blue-50'
+					<Tooltip
+						text={ __(
+							'This preview site has been marked as deleted. You can no longer access it. You can clear it from you list by clicking the Clear button.'
 						) }
-						onClick={ () => getIpcApi().openURL( `https://${ url }` ) }
+						disabled={ ! isDeleted }
 					>
-						<span className={ cx( 'truncate', isExpired && 'line-through text-a8c-gray-700' ) }>
-							{ url }
-						</span>
-						{ ! isExpired && <ArrowIcon /> }
-					</Button>
+						<div className="flex flex-col">
+							<div
+								className={ cx(
+									'text-[13px] leading-5 line-clamp-1 break-all',
+									isExpired && 'line-through text-a8c-gray-700',
+									isDeleted && 'line-through text-a8c-red-50'
+								) }
+							>
+								{ /* translators: %s: Site name (e.g. "My Site Preview") */ }
+								{ snapshot.name || sprintf( __( '%s Preview' ), selectedSite.name ) }
+							</div>
+							<Button
+								variant="link"
+								disabled={ isSiteInactive }
+								className={ cx(
+									'!text-a8c-gray-700 max-w-full',
+									isSiteInactive ? 'pointer-events-none' : 'hover:!text-a8c-blue-50'
+								) }
+								onClick={ () => getIpcApi().openURL( `https://${ url }` ) }
+							>
+								<span
+									className={ cx( 'truncate', isSiteInactive && 'line-through text-a8c-gray-700' ) }
+								>
+									{ url }
+								</span>
+								{ ! isSiteInactive && <ArrowIcon /> }
+							</Button>
+						</div>
+					</Tooltip>
 				</div>
 				<div className="flex ltr:ml-auto rtl:mr-auto">
 					<div className="w-[150px] text-a8c-gray-700 flex items-center pl-4">
@@ -142,18 +161,18 @@ export function PreviewSiteRow( {
 								{ __( 'Updating' ) }
 							</div>
 						) : (
-							<Tooltip text={ dateString } disabled={ ! date }>
+							<Tooltip text={ dateString } disabled={ ! date || isSiteInactive }>
 								{ getLastUpdateTimeText() }
 							</Tooltip>
 						) }
 					</div>
 					<div className="flex items-center">
-						<Tooltip text={ expireDateString } disabled={ isExpired }>
+						<Tooltip text={ expireDateString } disabled={ isSiteInactive }>
 							<div className="w-[150px] text-a8c-gray-700 pl-4">{ countDown }</div>
 						</Tooltip>
 					</div>
 					<div className="w-[60px] flex justify-end">
-						{ isExpired ? (
+						{ isSiteInactive ? (
 							<Button
 								variant="link"
 								onClick={ () => {

--- a/src/modules/preview-site/components/preview-site-row.tsx
+++ b/src/modules/preview-site/components/preview-site-row.tsx
@@ -166,7 +166,9 @@ export function PreviewSiteRow( {
 					</div>
 					<div className="flex items-center">
 						<Tooltip text={ expireDateString } disabled={ isSiteInactive }>
-							<div className="w-[150px] text-a8c-gray-700 pl-4">{ countDown }</div>
+							<div className="w-[150px] text-a8c-gray-700 pl-4">
+								{ isDeleted ? __( 'Deleted' ) : countDown }
+							</div>
 						</Tooltip>
 					</div>
 					<div className="w-[60px] flex justify-end">

--- a/src/modules/preview-site/components/preview-site-row.tsx
+++ b/src/modules/preview-site/components/preview-site-row.tsx
@@ -117,7 +117,7 @@ export function PreviewSiteRow( {
 					<Tooltip
 						placement="top-start"
 						text={ __(
-							'This preview site has been deleted on the server. Remove it from the list by clicking the Clear button.'
+							'This preview site has been deleted from the server. You can remove it from the list by clicking Clear button.'
 						) }
 						disabled={ isExpired || ! isDeleted }
 					>

--- a/src/modules/preview-site/components/preview-site-row.tsx
+++ b/src/modules/preview-site/components/preview-site-row.tsx
@@ -43,7 +43,9 @@ export function PreviewSiteRow( {
 	const deleteOperation = useRootSelector( ( state ) =>
 		snapshotSelectors.selectDeleteOperationForSnapshot( state, snapshot.url )
 	);
-	const { data: snapshotStatus, refetch: refetchSnapshotStatus } = useGetSnapshotStatus( snapshot.atomicSiteId );
+	const { data: snapshotStatus, refetch: refetchSnapshotStatus } = useGetSnapshotStatus(
+		snapshot.atomicSiteId
+	);
 	const { formatRelativeTime } = useFormatLocalizedTimestamps();
 	const [ showUpdatedMessage, setShowUpdatedMessage ] = useState( false );
 	const wasUpdating = useRef( false );

--- a/src/modules/preview-site/components/preview-site-row.tsx
+++ b/src/modules/preview-site/components/preview-site-row.tsx
@@ -43,9 +43,9 @@ export function PreviewSiteRow( {
 	const deleteOperation = useRootSelector( ( state ) =>
 		snapshotSelectors.selectDeleteOperationForSnapshot( state, snapshot.url )
 	);
-	const { data: snapshotStatus, refetch: refetchSnapshotStatus } = useGetSnapshotStatus(
-		snapshot.atomicSiteId
-	);
+	const { data: snapshotStatus } = useGetSnapshotStatus( snapshot.atomicSiteId, {
+		refetchOnMountOrArgChange: true,
+	} );
 	const { formatRelativeTime } = useFormatLocalizedTimestamps();
 	const [ showUpdatedMessage, setShowUpdatedMessage ] = useState( false );
 	const wasUpdating = useRef( false );
@@ -78,11 +78,6 @@ export function PreviewSiteRow( {
 
 		return () => clearTimeout( timeoutId );
 	}, [ updateOperation ] );
-
-	// Refetch snapshot status to check if the site has been deleted
-	useEffect( () => {
-		refetchSnapshotStatus();
-	}, [ refetchSnapshotStatus ] );
 
 	const getLastUpdateTimeText = () => {
 		if ( ! date ) {

--- a/src/modules/preview-site/components/preview-site-row.tsx
+++ b/src/modules/preview-site/components/preview-site-row.tsx
@@ -37,7 +37,7 @@ export function PreviewSiteRow( {
 	const { url, date } = snapshot;
 	const { countDown, dateString, expireDateString, isExpired } = useExpirationDate( date );
 	const dispatch = useAppDispatch();
-	const updateOperation = useRootSelector( ( state ) =>
+	const updateOperation = useRootSelector( ( state ) =>	
 		snapshotSelectors.selectUpdateOperationForSnapshot( state, snapshot.atomicSiteId )
 	);
 	const deleteOperation = useRootSelector( ( state ) =>
@@ -113,19 +113,20 @@ export function PreviewSiteRow( {
 	return (
 		<div className="self-stretch flex-col">
 			<div className="flex items-center px-8 py-6">
-				<div className="w-[51%] overflow-hidden pe-4">
+				<div className="overflow-hidden pe-4">
 					<Tooltip
+						placement="top-start"
 						text={ __(
-							'This preview site has been marked as deleted. You can no longer access it. You can clear it from you list by clicking the Clear button.'
+							'This preview site has been deleted on the server. Remove it from the list by clicking the Clear button.'
 						) }
-						disabled={ ! isDeleted }
+						disabled={ isExpired || ! isDeleted }
 					>
 						<div className="flex flex-col">
 							<div
 								className={ cx(
 									'text-[13px] leading-5 line-clamp-1 break-all',
 									isExpired && 'line-through text-a8c-gray-700',
-									isDeleted && 'line-through text-a8c-red-50'
+									( ! isExpired && isDeleted ) && 'line-through text-a8c-red-50'
 								) }
 							>
 								{ /* translators: %s: Site name (e.g. "My Site Preview") */ }

--- a/src/modules/preview-site/components/preview-site-row.tsx
+++ b/src/modules/preview-site/components/preview-site-row.tsx
@@ -37,7 +37,7 @@ export function PreviewSiteRow( {
 	const { url, date } = snapshot;
 	const { countDown, dateString, expireDateString, isExpired } = useExpirationDate( date );
 	const dispatch = useAppDispatch();
-	const updateOperation = useRootSelector( ( state ) =>	
+	const updateOperation = useRootSelector( ( state ) =>
 		snapshotSelectors.selectUpdateOperationForSnapshot( state, snapshot.atomicSiteId )
 	);
 	const deleteOperation = useRootSelector( ( state ) =>
@@ -126,7 +126,7 @@ export function PreviewSiteRow( {
 								className={ cx(
 									'text-[13px] leading-5 line-clamp-1 break-all',
 									isExpired && 'line-through text-a8c-gray-700',
-									( ! isExpired && isDeleted ) && 'line-through text-a8c-red-50'
+									! isExpired && isDeleted && 'line-through text-a8c-red-50'
 								) }
 							>
 								{ /* translators: %s: Site name (e.g. "My Site Preview") */ }

--- a/src/stores/wpcom-api.ts
+++ b/src/stores/wpcom-api.ts
@@ -59,8 +59,6 @@ const snapshotStatusSchema = z
 		isDeleted: data.is_deleted === '1',
 	} ) );
 
-export type LiveSnapshotStatus = z.infer< typeof snapshotStatusSchema >;
-
 const blueprintSchema = z.object( {
 	slug: z.string(),
 	title: z.string(),
@@ -167,7 +165,7 @@ export const wpcomApi = createApi( {
 			keepUnusedDataFor: 60 * 60,
 			providesTags: [ 'SnapshotUsage' ],
 		} ),
-		getSnapshotStatus: builder.query< LiveSnapshotStatus, number >( {
+		getSnapshotStatus: builder.query< z.infer< typeof snapshotStatusSchema >, number >( {
 			query: ( siteId ) => ( {
 				path: `/jurassic-ninja/status?site_id=${ siteId }`,
 				apiNamespace: 'wpcom/v2',

--- a/src/stores/wpcom-api.ts
+++ b/src/stores/wpcom-api.ts
@@ -45,6 +45,22 @@ const snapshotUsageSchema = z
 		siteCreationBlocked: data.site_creation_blocked,
 	} ) );
 
+const snapshotStatusSchema = z
+	.object( {
+		domain_name: z.string(),
+		atomic_site_id: z.number(),
+		status: z.string(),
+		is_deleted: z.string(),
+	} )
+	.transform( ( data ) => ( {
+		domainName: data.domain_name,
+		atomicSiteId: data.atomic_site_id,
+		status: data.status,
+		isDeleted: data.is_deleted === '1',
+	} ) );
+
+export type LiveSnapshotStatus = z.infer< typeof snapshotStatusSchema >;
+
 const blueprintSchema = z.object( {
 	slug: z.string(),
 	title: z.string(),
@@ -151,6 +167,14 @@ export const wpcomApi = createApi( {
 			keepUnusedDataFor: 60 * 60,
 			providesTags: [ 'SnapshotUsage' ],
 		} ),
+		getSnapshotStatus: builder.query< LiveSnapshotStatus, number >( {
+			query: ( siteId ) => ( {
+				path: `/jurassic-ninja/status?site_id=${ siteId }`,
+				apiNamespace: 'wpcom/v2',
+			} ),
+			transformResponse: ( response: unknown ) => parseResponse( response, snapshotStatusSchema ),
+			keepUnusedDataFor: 60 * 60,
+		} ),
 		deleteAllSnapshots: builder.mutation< void, void >( {
 			query: () => ( {
 				path: '/jurassic-ninja/delete/all',
@@ -251,6 +275,10 @@ export const useGetAssistantQuota = withWpcomClientCheck(
 
 export const useGetSnapshotUsage = withWpcomClientCheck(
 	withOfflineCheck( wpcomApi.useGetSnapshotUsageQuery )
+);
+
+export const useGetSnapshotStatus = withWpcomClientCheck(
+	withOfflineCheck( wpcomApi.useGetSnapshotStatusQuery )
 );
 
 export const useDeleteAllSnapshots = withWpcomClientCheckMutation(


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-209

## Proposed Changes

- Add a check for getting the preview site status by using the API endpoint
- Add RTK query for getting preview site status

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Check out 194679-ghe-Automattic/wpcom on your sandbox
- Check out this branch on Studio
- Run Studio using `npm start`
- Create new preview site if one doesn't exists
- Go to https://developer.wordpress.com/docs/api/console/
- Select `WP REST API` -> `wpcom/v2`
- Search for `/jurassic-ninja/delete/all` route and select it. 
- Send the request and wait for a couple of seconds.
- Come back to Studio, navigate between the preview tab & other tabs.
- Confirm the preview site is automatically marked as deleted. 

<img width="1788" height="536" alt="CleanShot 2025-10-29 at 14 45 47@2x" src="https://github.com/user-attachments/assets/699133ee-7fc5-444b-87c0-5b1f97001752" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?