### PR TITLE
Add hover color for links in "Connect site" modal

### DIFF
--- a/src/modules/sync/components/sync-sites-modal-selector.tsx
+++ b/src/modules/sync/components/sync-sites-modal-selector.tsx
@@ -261,8 +261,10 @@ function SiteItem( {
 				<Button
 					variant="link"
 					className={ cx(
-						'a8c-body-small truncate !p-0 w-full !justify-start hover:!text-a8c-blue-50',
-						isSelected ? '!text-inherit hover:!text-a8c-blue-10' : '!text-a8c-gray-30'
+						'a8c-body-small truncate !p-0 w-full !justify-start',
+						isSelected
+							? '!text-inherit hover:!text-a8c-blue-10'
+							: '!text-a8c-gray-30 hover:!text-a8c-blue-50'
 					) }
 					onClick={ () => getIpcApi().openURL( site.url ) }
 					onKeyDown={ ( e: React.KeyboardEvent ) => {

--- a/src/modules/sync/components/sync-sites-modal-selector.tsx
+++ b/src/modules/sync/components/sync-sites-modal-selector.tsx
@@ -261,10 +261,8 @@ function SiteItem( {
 				<Button
 					variant="link"
 					className={ cx(
-						'a8c-body-small truncate !p-0 w-full !justify-start',
-						isSelected
-							? '!text-inherit hover:!text-inherit'
-							: '!text-a8c-gray-30 hover:!text-a8c-gray-30'
+						'a8c-body-small truncate !p-0 w-full !justify-start hover:!text-a8c-blue-50',
+						isSelected ? '!text-inherit hover:!text-a8c-blue-10' : '!text-a8c-gray-30'
 					) }
 					onClick={ () => getIpcApi().openURL( site.url ) }
 					onKeyDown={ ( e: React.KeyboardEvent ) => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

–

## Proposed Changes

The site links in the "Connect site" modal didn't previously have a hover color. This made it easier to overlook that every row actually has two clickable areas: the row itself and the site link. 

With this PR, the site links now have a blue hover color (same as other links in the app).

https://github.com/user-attachments/assets/7db2e00c-1049-4dba-a5dc-cb0f77a1ff18


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Open the "Connect site" modal from the Sync tab
2. Ensure that the site links have a hover color and that they are clickable
3. After selecting a site in the modal, ensure that the site link still has an appropriate color when hovered

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
