### PR TITLE
Remove Python from Windows unit tests

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -37,7 +37,7 @@ steps:
   - label: Windows Unit Tests
     command: |
       # prepare_windows_host_for_app_distribution.ps1 comes from CI Toolkit Plugin
-      & "prepare_windows_host_for_app_distribution.ps1" -InstallPython $true -InstallNativeCompilationTools $true
+      & "prepare_windows_host_for_app_distribution.ps1" -InstallNativeCompilationTools $true
 
       bash .buildkite/commands/install-node-dependencies.sh
       echo '--- :npm: Run Unit Tests'


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Follow up to https://github.com/Automattic/studio/pull/1954

## Proposed Changes

- As Python turned out not to be needed for the build script, it wouldn't be required for E2E as well. Let's go ahead and remove it.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Confirm build works fine

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
