### PR TITLE
Sync push modal: map the `contents` node to appropriate folders

### DIFF
--- a/src/modules/sync/hooks/use-selected-items-push-size.ts
+++ b/src/modules/sync/hooks/use-selected-items-push-size.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { TreeNode } from 'src/components/tree-view';
-import { SYNC_PUSH_SIZE_LIMIT_BYTES } from 'src/constants';
+import { SYNC_OPTIONS, SYNC_PUSH_SIZE_LIMIT_BYTES } from 'src/constants';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 
 export function useSelectedItemsPushSize(
@@ -45,9 +45,19 @@ export function useSelectedItemsPushSize(
 			} else if ( wpContentNode?.children ) {
 				for ( const child of wpContentNode.children ) {
 					if ( child.checked ) {
-						sizePromises.push(
-							getIpcApi().getDirectorySize( siteId, [ 'wp-content', child.name ] )
-						);
+						// The `contents` tree node maps to `wp-content/mu-plugins` and `wp-content/fonts`
+						if ( child.id === SYNC_OPTIONS.contents ) {
+							sizePromises.push(
+								getIpcApi().getDirectorySize( siteId, [ 'wp-content', 'mu-plugins' ] )
+							);
+							sizePromises.push(
+								getIpcApi().getDirectorySize( siteId, [ 'wp-content', 'fonts' ] )
+							);
+						} else {
+							sizePromises.push(
+								getIpcApi().getDirectorySize( siteId, [ 'wp-content', child.name ] )
+							);
+						}
 					} else if ( child.indeterminate && child.children ) {
 						for ( const subChild of child.children ) {
 							if ( subChild.checked || subChild.indeterminate ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

N/A

## Proposed Changes

There's a problem with the `useSelectedItemsPushSize` hook where checking the `mu-plugins and fonts` option generates the following error in the browser console:

```
Error checking selected items size: Error: Error invoking remote method 'getDirectorySize': Error: Failed to read directory /Users/fredrik/Studio/my-site/wp-content/contents: Error: ENOENT: no such file or directory, scandir '/Users/fredrik/Studio/my-site/wp-content/contents'
```

UX-wise, this is actually quite bad, because it means the directory size checker effectively breaks anytime users use selective sync and have selected the `mu-plugins and fonts` option (except if they leave all folders checked).

This happens because the tree node in question represents two folders: `wp-content/mu-plugins` and `wp-content/fonts`. This PR tweaks the `useSelectedItemsPushSize` hook to treat this folder in a special way. 

> [!IMPORTANT]  
> Question: since this tree node isn't dynamically generated, I'm wondering if we should gracefully handle errors if `wp-content/mu-plugins` or `wp-content/fonts` doesn't exist. The current solution of silently failing if any folder doesn't exist seems suboptimal. Thoughts on this?

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Have a Studio site with a `wp-content/uploads` folder exceeding 2GB in size
2. Connect it to a remote site in the Sync tab
3. Open the push dialog
4. Select the `Specific files and folders` option
5. Select `mu-plugins and fonts`
6. Select the entire `uploads` folder
7. Ensure that the 2GB size warning is displayed

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
