### PR TITLE
Sync: Remove unnecesary ref when initializing Push states

### DIFF
--- a/src/hooks/sync-sites/sync-sites-context.tsx
+++ b/src/hooks/sync-sites/sync-sites-context.tsx
@@ -110,15 +110,12 @@ export function SyncSitesProvider( { children }: { children: React.ReactNode } )
 
 	const { client } = useAuth();
 	const { pushStatesProgressInfo } = useSyncStatesProgressInfo();
-	const hasInitialized = useRef( false );
 
 	// Initialize push states from in-progress server operations on mount
 	useEffect( () => {
-		if ( hasInitialized.current || ! client ) {
+		if ( ! client ) {
 			return;
 		}
-
-		hasInitialized.current = true;
 
 		const initializePushStates = async () => {
 			const allSites = await getIpcApi().getSiteDetails();
@@ -166,7 +163,7 @@ export function SyncSitesProvider( { children }: { children: React.ReactNode } )
 			}
 		};
 
-		void initializePushStates().catch( ( error ) => {
+		initializePushStates().catch( ( error ) => {
 			// Initialization is not critical to app functionality, but log the error
 			console.error( 'Failed to initialize push states from server:', error );
 		} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Related to https://github.com/Automattic/studio/pull/1943

## Proposed Changes

- Removes the ref that prevented the `useEffect` to run multiple times as it is not necessary anymore after https://github.com/Automattic/studio/pull/1943/commits/be16976f40b9faaad6c8b3efeb26778b88e858f9
- Removes the `void` operator as the promise is handled by the `.catch`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Apply these changes and run npm start
- Navigate to the Sync tab and connect a site or use any existing connected site
- Select Push
- Wait for the status to be progressed to Backing up remote site…
- Select another site before leaving Studio
- Press Cmd+Q to quit Studio
- Check that the dialog appears and notify that the operation will continue. Accept and quit Studio
- Open Studio again
- Select the site that has a Push in progress
- Navigate to the Sync tab
- Check the progress continues
- Check in the network tab the `import` endpoint is checked only once for the connected sites initially, and it is not executed when selecting the Sync tab of different sites every time. Please note that if there is an operation in progress, the `import` endpoint will be checked periodically.
 
<img width="459" height="221" alt="CleanShot 2025-10-30 at 18 48 01@2x" src="https://github.com/user-attachments/assets/ec2fd453-b182-4b8b-ab8b-0ea1750ed6c7" />



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
