### PR TITLE
Adopt custom Windows image in CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -29,7 +29,7 @@ steps:
       queue: "{{matrix}}"
     matrix:
       - mac
-      - windows
+      - $WINDOWS_QUEUE
     notify:
       - github_commit_status:
           context: Unit Tests
@@ -114,7 +114,7 @@ steps:
     steps:
       - label: 🔨 Windows Dev Build - {{matrix}}
         agents:
-          queue: windows
+          queue: $WINDOWS_QUEUE
         command: powershell -File .buildkite/commands/build-for-windows.ps1 -BuildType dev -Architecture {{matrix}}
         artifact_paths:
           - out\**\studio-setup.exe
@@ -222,7 +222,7 @@ steps:
     steps:
       - label: 🔨 Windows Release Build - {{matrix}}
         agents:
-          queue: windows
+          queue: $WINDOWS_QUEUE
         command: powershell -File .buildkite/commands/build-for-windows.ps1 -BuildType release -Architecture {{matrix}}
         artifact_paths:
           - out\**\studio-setup.exe

--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -5,7 +5,7 @@
 
 # The ~> modifier is not currently used, but we check for it just in case
 XCODE_VERSION=$(sed -E -n 's/^(~> )?(.*)/xcode-\2/p' .xcode-version)
-CI_TOOLKIT_VERSION='5.5.0'
+CI_TOOLKIT_VERSION='5.7.0'
 NVM_PLUGIN_VERSION='0.6.0'
 
 export IMAGE_ID="$XCODE_VERSION"

--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -11,3 +11,4 @@ NVM_PLUGIN_VERSION='0.6.0'
 export IMAGE_ID="$XCODE_VERSION"
 export CI_TOOLKIT_PLUGIN="automattic/a8c-ci-toolkit#$CI_TOOLKIT_VERSION"
 export NVM_PLUGIN="automattic/nvm#$NVM_PLUGIN_VERSION"
+export WINDOWS_QUEUE='windows'


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- https://linear.app/a8c/issue/AINFRA-1471/adopt-custom-windows-ami-in-studio

## Proposed Changes

- Use our new custom Windows image in CI to save some time during builds, avoid the recent out-of-space issue, and unlock future improvements

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Verify CI is green, especially the Windows steps

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors? — N.A.
