### PR TITLE
Add platform-specific terminal app checking

### DIFF
--- a/src/modules/user-settings/components/tests/terminal-picker.test.tsx
+++ b/src/modules/user-settings/components/tests/terminal-picker.test.tsx
@@ -7,7 +7,12 @@ import { installedAppsApi } from 'src/stores/installed-apps-api';
 import { testReducer } from 'src/stores/tests/utils/test-reducer';
 
 jest.mock( 'src/lib/get-ipc-api' );
-jest.mock( 'src/lib/app-globals' );
+jest.mock( 'src/lib/app-globals', () => ( {
+	getAppGlobals: jest.fn( () => ( {
+		platform: 'darwin',
+	} ) ),
+	isWindows: jest.fn( () => false ),
+} ) );
 
 const mockGetIpcApi = getIpcApi as jest.Mock;
 

--- a/src/modules/user-settings/components/tests/user-settings.test.tsx
+++ b/src/modules/user-settings/components/tests/user-settings.test.tsx
@@ -8,7 +8,12 @@ import { useOffline } from 'src/hooks/use-offline';
 import { UserSettings } from 'src/modules/user-settings';
 import { store } from 'src/stores';
 
-jest.mock( 'src/lib/app-globals' );
+jest.mock( 'src/lib/app-globals', () => ( {
+	getAppGlobals: jest.fn( () => ( {
+		platform: 'darwin',
+	} ) ),
+	isWindows: jest.fn( () => false ),
+} ) );
 jest.mock( 'src/hooks/use-feature-flags' );
 jest.mock( 'src/hooks/use-auth' );
 jest.mock( 'src/hooks/use-ipc-listener' );

--- a/src/modules/user-settings/lib/terminal.ts
+++ b/src/modules/user-settings/lib/terminal.ts
@@ -33,7 +33,7 @@ export const terminalConfig: Record< SupportedTerminal, TerminalConfig > = {
 };
 
 export function isTerminalSupportedOnPlatform( terminal: SupportedTerminal ): boolean {
-	const platform = getAppGlobals().platform  as TerminalPlatform;
+	const platform = getAppGlobals().platform as TerminalPlatform;
 	return terminalConfig[ terminal ].platforms.includes( platform );
 }
 

--- a/src/modules/user-settings/lib/terminal.ts
+++ b/src/modules/user-settings/lib/terminal.ts
@@ -32,9 +32,11 @@ export const terminalConfig: Record< SupportedTerminal, TerminalConfig > = {
 	},
 };
 
-export function isTerminalSupportedOnPlatform( terminal: SupportedTerminal ): boolean {
+export function getTerminalsSupportedOnPlatform(): SupportedTerminal[] {
 	const platform = getAppGlobals().platform as TerminalPlatform;
-	return terminalConfig[ terminal ].platforms.includes( platform );
+	return ( Object.keys( terminalConfig ) as SupportedTerminal[] ).filter( ( terminal ) =>
+		terminalConfig[ terminal ].platforms.includes( platform )
+	);
 }
 
 export function getTerminalName( terminal: SupportedTerminal | undefined ): string {

--- a/src/modules/user-settings/lib/terminal.ts
+++ b/src/modules/user-settings/lib/terminal.ts
@@ -1,17 +1,41 @@
 import { __ } from '@wordpress/i18n';
-import { isWindows } from 'src/lib/app-globals';
+import { getAppGlobals, isWindows } from 'src/lib/app-globals';
 
 export type SupportedTerminal = 'terminal' | 'iterm' | 'warp' | 'ghostty';
 
-export const supportedTerminalNames: Record< SupportedTerminal, string > = {
-	terminal: __( 'Terminal' ),
-	// translators: "iTerm" is the brand name for a terminal app and does not need to be translated
-	iterm: __( 'iTerm' ),
-	// translators: "Warp" is the brand name for a terminal app and does not need to be translated
-	warp: __( 'Warp' ),
-	// translators: "Ghostty" is the brand name for a terminal app and does not need to be translated
-	ghostty: __( 'Ghostty' ),
+type TerminalPlatform = 'darwin' | 'win32' | 'linux';
+
+export type TerminalConfig = {
+	name: string;
+	platforms: TerminalPlatform[];
 };
+
+export const terminalConfig: Record< SupportedTerminal, TerminalConfig > = {
+	terminal: {
+		name: __( 'Terminal' ),
+		platforms: [ 'darwin', 'linux', 'win32' ],
+	},
+	iterm: {
+		// translators: "iTerm" is the brand name for a terminal app and does not need to be translated
+		name: __( 'iTerm' ),
+		platforms: [ 'darwin' ],
+	},
+	warp: {
+		// translators: "Warp" is the brand name for a terminal app and does not need to be translated
+		name: __( 'Warp' ),
+		platforms: [ 'darwin', 'win32', 'linux' ],
+	},
+	ghostty: {
+		// translators: "Ghostty" is the brand name for a terminal app and does not need to be translated
+		name: __( 'Ghostty' ),
+		platforms: [ 'darwin', 'linux' ],
+	},
+};
+
+export function isTerminalSupportedOnPlatform( terminal: SupportedTerminal ): boolean {
+	const platform = getAppGlobals().platform  as TerminalPlatform;
+	return terminalConfig[ terminal ].platforms.includes( platform );
+}
 
 export function getTerminalName( terminal: SupportedTerminal | undefined ): string {
 	if ( ! terminal ) {
@@ -23,5 +47,5 @@ export function getTerminalName( terminal: SupportedTerminal | undefined ): stri
 		return __( 'Command Prompt' );
 	}
 
-	return supportedTerminalNames[ terminal ];
+	return terminalConfig[ terminal ].name;
 }

--- a/src/stores/installed-apps-api.ts
+++ b/src/stores/installed-apps-api.ts
@@ -10,7 +10,7 @@ import {
 import {
 	SupportedTerminal,
 	terminalConfig,
-	isTerminalSupportedOnPlatform,
+	getTerminalsSupportedOnPlatform,
 } from 'src/modules/user-settings/lib/terminal';
 
 const getFirstInstalledEditor = async (): Promise< SupportedEditor | null > => {
@@ -111,30 +111,25 @@ export const selectUninstalledEditors = createSelector(
 export const selectInstalledTerminals = createSelector(
 	[ ( data?: InstalledApps ) => data ],
 	( installedApps ) => {
-		const entries = Object.entries( terminalConfig ).map( ( [ key, config ] ) => [
-			key as SupportedTerminal,
-			config.name,
-		] ) as [ SupportedTerminal, string ][];
-
-		return entries.filter(
-			( [ terminal ] ) =>
-				isTerminalSupportedOnPlatform( terminal ) && installedApps && installedApps[ terminal ]
-		);
+		const supportedTerminals = getTerminalsSupportedOnPlatform();
+		return supportedTerminals
+			.filter( ( terminal ) => installedApps && installedApps[ terminal ] )
+			.map(
+				( terminal ) =>
+					[ terminal, terminalConfig[ terminal ].name ] as [ SupportedTerminal, string ]
+			);
 	}
 );
 
 export const selectUninstalledTerminals = createSelector(
 	[ ( data?: InstalledApps ) => data ],
 	( installedApps ) => {
-		const entries = Object.entries( terminalConfig ).map( ( [ key, config ] ) => [
-			key as SupportedTerminal,
-			config.name,
-		] ) as [ SupportedTerminal, string ][];
-
-		return entries.filter(
-			( [ terminal ] ) =>
-				isTerminalSupportedOnPlatform( terminal ) &&
-				( ! installedApps || ! installedApps[ terminal ] )
-		);
+		const supportedTerminals = getTerminalsSupportedOnPlatform();
+		return supportedTerminals
+			.filter( ( terminal ) => ! installedApps || ! installedApps[ terminal ] )
+			.map(
+				( terminal ) =>
+					[ terminal, terminalConfig[ terminal ].name ] as [ SupportedTerminal, string ]
+			);
 	}
 );

--- a/src/stores/installed-apps-api.ts
+++ b/src/stores/installed-apps-api.ts
@@ -7,7 +7,11 @@ import {
 	supportedEditorConfig,
 	SUPPORTED_EDITORS,
 } from 'src/modules/user-settings/lib/editor';
-import { SupportedTerminal, supportedTerminalNames } from 'src/modules/user-settings/lib/terminal';
+import {
+	SupportedTerminal,
+	terminalConfig,
+	isTerminalSupportedOnPlatform,
+} from 'src/modules/user-settings/lib/terminal';
 
 const getFirstInstalledEditor = async (): Promise< SupportedEditor | null > => {
 	const installedApps = await getIpcApi().getInstalledAppsAndTerminals();
@@ -107,17 +111,30 @@ export const selectUninstalledEditors = createSelector(
 export const selectInstalledTerminals = createSelector(
 	[ ( data?: InstalledApps ) => data ],
 	( installedApps ) => {
-		const entries = Object.entries( supportedTerminalNames ) as [ SupportedTerminal, string ][];
+		const entries = Object.entries( terminalConfig ).map( ( [ key, config ] ) => [
+			key as SupportedTerminal,
+			config.name,
+		] ) as [ SupportedTerminal, string ][];
 
-		return entries.filter( ( [ terminal ] ) => installedApps && installedApps[ terminal ] );
+		return entries.filter(
+			( [ terminal ] ) =>
+				isTerminalSupportedOnPlatform( terminal ) && installedApps && installedApps[ terminal ]
+		);
 	}
 );
 
 export const selectUninstalledTerminals = createSelector(
 	[ ( data?: InstalledApps ) => data ],
 	( installedApps ) => {
-		const entries = Object.entries( supportedTerminalNames ) as [ SupportedTerminal, string ][];
+		const entries = Object.entries( terminalConfig ).map( ( [ key, config ] ) => [
+			key as SupportedTerminal,
+			config.name,
+		] ) as [ SupportedTerminal, string ][];
 
-		return entries.filter( ( [ terminal ] ) => ! installedApps || ! installedApps[ terminal ] );
+		return entries.filter(
+			( [ terminal ] ) =>
+				isTerminalSupportedOnPlatform( terminal ) &&
+				( ! installedApps || ! installedApps[ terminal ] )
+		);
 	}
 );

--- a/src/stores/tests/installed-apps-api.test.ts
+++ b/src/stores/tests/installed-apps-api.test.ts
@@ -12,6 +12,12 @@ jest.mock( 'src/lib/get-ipc-api', () => ( {
 	getIpcApi: jest.fn(),
 } ) );
 
+jest.mock( 'src/lib/app-globals', () => ( {
+	getAppGlobals: jest.fn( () => ( {
+		platform: 'darwin',
+	} ) ),
+} ) );
+
 const mockIpcApi = {
 	getInstalledAppsAndTerminals: jest.fn(),
 	getUserEditor: jest.fn(),


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

Related to STU-931

## Proposed Changes

- ensure that only the terminal apps available on specific OS are listed
  - this removes iTerm and Ghostty from the Studio app on Windows 

| Before | After |
|--------|--------|
| <img width="1028" height="1066" alt="Screen Shot on 2025-10-31 at 16:47:25" src="https://github.com/user-attachments/assets/8d999064-4d39-4a11-bc6d-a27964cfcfb7" /> | <img width="1032" height="988" alt="Screen Shot on 2025-10-31 at 16:46:35" src="https://github.com/user-attachments/assets/858dee63-699f-416b-9eff-53aa0f54d0c1" /> | 

~~On Monday I am planning to propose adding PowerShell as another terminal option on Windows in another PR.~~

→ Update: After further consideration I don't think it makes sense to add PowerShell. In the future we could consider some additional options though.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR branch and build the app with `npm install && npm start` on Windows.
2. Head over to the app settings modal and take a look at the available Terminal options.
3. There should be only `Command Prompt` and `Warp` app options available.
4. There should be no change on the macOS Studio version.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
