### PR TITLE
Sync: Do not check Push state for disconnected sites

### DIFF
--- a/src/hooks/sync-sites/sync-sites-context.tsx
+++ b/src/hooks/sync-sites/sync-sites-context.tsx
@@ -131,6 +131,10 @@ export function SyncSitesProvider( { children }: { children: React.ReactNode } )
 						continue;
 					}
 
+					if ( connectedSite?.syncSupport !== 'already-connected' ) {
+						continue;
+					}
+
 					const response = await client.req.get< ImportResponse >(
 						`/sites/${ connectedSite.id }/studio-app/sync/import`,
 						{

--- a/src/hooks/sync-sites/sync-sites-context.tsx
+++ b/src/hooks/sync-sites/sync-sites-context.tsx
@@ -126,12 +126,9 @@ export function SyncSitesProvider( { children }: { children: React.ReactNode } )
 			for ( const connectedSite of allConnectedSites ) {
 				try {
 					const localSite = allSites.find( ( site ) => site.id === connectedSite.localSiteId );
+					const hasConnectionErrors = connectedSite?.syncSupport !== 'already-connected';
 
-					if ( ! localSite ) {
-						continue;
-					}
-
-					if ( connectedSite?.syncSupport !== 'already-connected' ) {
+					if ( ! localSite || hasConnectionErrors ) {
 						continue;
 					}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes p1761904615848549-slack-C06DRMD6VPZ
- Related to https://github.com/Automattic/studio/pull/1943
- Related to STU-751

## Proposed Changes

- Adds a condition to prevent checking the sync status for non-connected sites

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Apply this branch and run `npm start`
- On Studio, navigate to the Sync tab and connect a site or use an existing connected site
- In order to simulate an error, revert that WordPress.com site to Simple, you can use the `bulk-delete-test-sites` tool for that. Alternatively, navigate to the `~/Library/Application Support/Studio/appdata-v1.json` file, select the connectedSite you want to test, and change `syncSupport` to a different value than `already-connected` (e.g. `needs-transfer`)
- Close Studio and open it again with Developer Tools open
- Check that there are no errors in the Console

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?