### PR TITLE
Add sanitized CLI args context to Sentry error reports

### DIFF
--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -527,17 +527,7 @@ export async function startServer(
 
 		// Include sanitized CLI args if available from error
 		if ( error instanceof Error && 'cliArgs' in error ) {
-			const cliArgs = ( error as Error & { cliArgs: Record< string, unknown > } ).cliArgs;
-
-			// Create a copy without mount paths (they're internal and not useful for debugging)
-			const { mount, 'mount-before-install': mountBeforeInstall, blueprint, ...restArgs } =
-				cliArgs;
-
-			// Stringify blueprint as JSON to avoid Sentry's normalization/filtering
-			contexts.startup = {
-				...restArgs,
-				blueprintJson: blueprint ? JSON.stringify( blueprint ) : undefined,
-			};
+			contexts.startup = ( error as Error & { cliArgs: Record< string, unknown > } ).cliArgs;
 		}
 
 		Sentry.captureException( error, {

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -515,10 +515,36 @@ export async function startServer(
 			throw new Error( 'WASM_ERROR_NOT_ENOUGH_MEMORY' );
 		}
 
+		const contexts: Record< string, Record< string, unknown > > = {
+			server: {
+				running: server.details.running,
+				phpVersion: server.details.phpVersion,
+				port: server.details.port,
+				hasCustomDomain: !! server.details.customDomain,
+				httpsEnabled: !! server.details.enableHttps,
+			},
+		};
+
+		// Include sanitized CLI args if available from error
+		if ( error instanceof Error && 'cliArgs' in error ) {
+			const cliArgs = ( error as Error & { cliArgs: Record< string, unknown > } ).cliArgs;
+
+			// Create a copy without mount paths (they're internal and not useful for debugging)
+			const { mount, 'mount-before-install': mountBeforeInstall, blueprint, ...restArgs } =
+				cliArgs;
+
+			// Stringify blueprint as JSON to avoid Sentry's normalization/filtering
+			contexts.startup = {
+				...restArgs,
+				blueprintJson: blueprint ? JSON.stringify( blueprint ) : undefined,
+			};
+		}
+
 		Sentry.captureException( error, {
 			tags: {
 				provider: getWordPressProvider().PROVIDER_TYPE,
 			},
+			contexts,
 		} );
 		if (
 			error instanceof Error &&

--- a/src/lib/sentry-sanitizer.ts
+++ b/src/lib/sentry-sanitizer.ts
@@ -110,7 +110,8 @@ export function sanitizeBlueprint( blueprint: Blueprint | undefined ): object | 
 
 /**
  * Sanitizes RunCLIArgs to remove only truly sensitive data (passwords, tokens)
- * while preserving paths and configuration useful for debugging local development issues.
+ * while preserving configuration useful for debugging local development issues.
+ * Prepares data for Sentry by stringifying nested objects to avoid normalization limits.
  */
 export function sanitizeRunCLIArgs( args: RunCLIArgs ): Record< string, unknown > {
 	return {
@@ -129,16 +130,17 @@ export function sanitizeRunCLIArgs( args: RunCLIArgs ): Record< string, unknown 
 		experimentalDevtools: args.experimentalDevtools,
 		experimentalMultiWorker: args.experimentalMultiWorker,
 
-		// Include paths and URLs - helpful for debugging Windows path issues
+		// Include site URL - helpful for debugging
 		'site-url': args[ 'site-url' ],
-		mount: args.mount,
-		'mount-before-install': args[ 'mount-before-install' ],
 		outfile: args.outfile,
 
-		// Sanitized blueprint (removes passwords, tokens, code, but keeps structure)
-		blueprint: sanitizeBlueprint( args.blueprint ),
+		// Stringify blueprint as JSON to avoid Sentry's normalization/filtering
+		// (Sentry has depth limits and filters fields containing "auth" like "author")
+		blueprintJson: args.blueprint ? JSON.stringify( sanitizeBlueprint( args.blueprint ) ) : undefined,
 
+		// Omit mount paths - they're internal Studio paths and not useful for debugging
 		// Omit only truly sensitive fields:
+		// - mount, mount-before-install (internal paths)
 		// - db-host, db-user, db-pass, db-name, db-path (database credentials)
 		// - login credentials (if object with username/password)
 	};

--- a/src/lib/sentry-sanitizer.ts
+++ b/src/lib/sentry-sanitizer.ts
@@ -1,0 +1,145 @@
+import { Blueprint } from '@wp-playground/blueprints';
+import { RunCLIArgs } from '@wp-playground/cli';
+
+/**
+ * Sanitizes a Blueprint step to remove sensitive data while keeping useful debugging info.
+ */
+function sanitizeBlueprintStep( step: Blueprint[ 'steps' ][ number ] ): Record< string, unknown > {
+	const baseStep: Record< string, unknown > = { step: step.step };
+	const stepRecord = step as Record< string, unknown >;
+
+	// For steps that might contain secrets, only include safe fields
+	switch ( step.step ) {
+		case 'login':
+			// Omit password, keep username
+			return { ...baseStep, username: stepRecord.username };
+
+		case 'runPHP':
+		case 'runPHPWithOptions':
+			// Omit code (might contain secrets), indicate it exists
+			return { ...baseStep, hasCode: !! stepRecord.code };
+
+		case 'defineWpConfigConsts':
+			// Omit actual constants (might contain DB credentials, auth keys)
+			return {
+				...baseStep,
+				constCount:
+					stepRecord.consts && typeof stepRecord.consts === 'object'
+						? Object.keys( stepRecord.consts as object ).length
+						: 0,
+			};
+
+		case 'runSql':
+			// Omit SQL (might contain sensitive data)
+			return { ...baseStep, hasSql: !! stepRecord.sql };
+
+		case 'writeFile':
+			// Keep path for debugging, omit file content
+			return {
+				...baseStep,
+				path: stepRecord.path,
+				hasData: !! stepRecord.data,
+			};
+
+		case 'request':
+			// Keep URL and method, omit headers and body (might contain auth tokens)
+			return {
+				...baseStep,
+				url:
+					stepRecord.request && typeof stepRecord.request === 'object'
+						? ( stepRecord.request as Record< string, unknown > ).url
+						: undefined,
+				method:
+					stepRecord.request && typeof stepRecord.request === 'object'
+						? ( stepRecord.request as Record< string, unknown > ).method
+						: undefined,
+			};
+
+		case 'setSiteOptions':
+		case 'updateUserMeta':
+			// Keep option/meta keys but not values (values might be API keys)
+			return {
+				...baseStep,
+				keys:
+					stepRecord.options && typeof stepRecord.options === 'object'
+						? Object.keys( stepRecord.options as object )
+						: stepRecord.meta && typeof stepRecord.meta === 'object'
+						? Object.keys( stepRecord.meta as object )
+						: [],
+			};
+
+		case 'installPlugin':
+		case 'installTheme':
+			// These are safe - just WordPress.org slugs or URLs
+			return step as Record< string, unknown >;
+
+		default:
+			// For other steps, include everything (they're generally safe)
+			return step as Record< string, unknown >;
+	}
+}
+
+/**
+ * Sanitizes a Blueprint object to remove sensitive data (passwords, tokens, code)
+ * while preserving useful debugging information.
+ */
+export function sanitizeBlueprint( blueprint: Blueprint | undefined ): object | undefined {
+	if ( ! blueprint ) {
+		return undefined;
+	}
+
+	return {
+		// Keep metadata but omit author (triggers Sentry's "auth" filter)
+		meta: blueprint.meta
+			? {
+					title: blueprint.meta.title,
+					description: blueprint.meta.description,
+			  }
+			: undefined,
+
+		// Sanitize each step individually
+		steps: blueprint.steps?.map( sanitizeBlueprintStep ),
+
+		// Safe configuration
+		features: blueprint.features,
+		preferredVersions: blueprint.preferredVersions,
+		landingPage: blueprint.landingPage,
+		login: typeof blueprint.login === 'boolean' ? blueprint.login : '<credentials>',
+	};
+}
+
+/**
+ * Sanitizes RunCLIArgs to remove only truly sensitive data (passwords, tokens)
+ * while preserving paths and configuration useful for debugging local development issues.
+ */
+export function sanitizeRunCLIArgs( args: RunCLIArgs ): Record< string, unknown > {
+	return {
+		// Safe configuration fields
+		command: args.command,
+		php: args.php,
+		wp: args.wp,
+		port: args.port,
+		debug: args.debug,
+		verbosity: args.verbosity,
+		skipWordPressSetup: args.skipWordPressSetup,
+		skipSqliteSetup: args.skipSqliteSetup,
+		followSymlinks: args.followSymlinks,
+		internalCookieStore: args.internalCookieStore,
+		xdebug: args.xdebug,
+		experimentalDevtools: args.experimentalDevtools,
+		experimentalMultiWorker: args.experimentalMultiWorker,
+
+		// Include paths and URLs - helpful for debugging Windows path issues
+		'site-url': args[ 'site-url' ],
+		mount: args.mount,
+		'mount-before-install': args[ 'mount-before-install' ],
+		outfile: args.outfile,
+
+		// Sanitized blueprint (removes passwords, tokens, code, but keeps structure)
+		blueprint: sanitizeBlueprint( args.blueprint ),
+
+		// Omit only truly sensitive fields:
+		// - db-host, db-user, db-pass, db-name, db-path (database credentials)
+		// - login credentials (if object with username/password)
+	};
+}

--- a/src/lib/sentry-sanitizer.ts
+++ b/src/lib/sentry-sanitizer.ts
@@ -115,7 +115,6 @@ export function sanitizeBlueprint( blueprint: Blueprint | undefined ): object | 
  */
 export function sanitizeRunCLIArgs( args: RunCLIArgs ): Record< string, unknown > {
 	return {
-		// Safe configuration fields
 		command: args.command,
 		php: args.php,
 		wp: args.wp,
@@ -129,19 +128,10 @@ export function sanitizeRunCLIArgs( args: RunCLIArgs ): Record< string, unknown 
 		xdebug: args.xdebug,
 		experimentalDevtools: args.experimentalDevtools,
 		experimentalMultiWorker: args.experimentalMultiWorker,
-
-		// Include site URL - helpful for debugging
 		'site-url': args[ 'site-url' ],
 		outfile: args.outfile,
-
-		// Stringify blueprint as JSON to avoid Sentry's normalization/filtering
-		// (Sentry has depth limits and filters fields containing "auth" like "author")
-		blueprintJson: args.blueprint ? JSON.stringify( sanitizeBlueprint( args.blueprint ) ) : undefined,
-
-		// Omit mount paths - they're internal Studio paths and not useful for debugging
-		// Omit only truly sensitive fields:
-		// - mount, mount-before-install (internal paths)
-		// - db-host, db-user, db-pass, db-name, db-path (database credentials)
-		// - login credentials (if object with username/password)
+		blueprintJson: args.blueprint
+			? JSON.stringify( sanitizeBlueprint( args.blueprint ) )
+			: undefined,
 	};
 }

--- a/src/lib/sentry-sanitizer.ts
+++ b/src/lib/sentry-sanitizer.ts
@@ -11,8 +11,8 @@ function sanitizeBlueprintStep( step: Blueprint[ 'steps' ][ number ] ): Record< 
 	// For steps that might contain secrets, only include safe fields
 	switch ( step.step ) {
 		case 'login':
-			// Omit password, keep username
-			return { ...baseStep, username: stepRecord.username };
+			// Omit login details, indicate it exists
+			return { ...baseStep, hasLogin: true };
 
 		case 'runPHP':
 		case 'runPHPWithOptions':

--- a/src/lib/sentry-sanitizer.ts
+++ b/src/lib/sentry-sanitizer.ts
@@ -56,17 +56,19 @@ function sanitizeBlueprintStep( step: Blueprint[ 'steps' ][ number ] ): Record< 
 			};
 
 		case 'setSiteOptions':
-		case 'updateUserMeta':
+		case 'updateUserMeta': {
 			// Keep option/meta keys but not values (values might be API keys)
+			let keys: string[] = [];
+			if ( stepRecord.options && typeof stepRecord.options === 'object' ) {
+				keys = Object.keys( stepRecord.options as object );
+			} else if ( stepRecord.meta && typeof stepRecord.meta === 'object' ) {
+				keys = Object.keys( stepRecord.meta as object );
+			}
 			return {
 				...baseStep,
-				keys:
-					stepRecord.options && typeof stepRecord.options === 'object'
-						? Object.keys( stepRecord.options as object )
-						: stepRecord.meta && typeof stepRecord.meta === 'object'
-						? Object.keys( stepRecord.meta as object )
-						: [],
+				keys,
 			};
+		}
 
 		case 'installPlugin':
 		case 'installTheme':

--- a/src/lib/wordpress-provider/playground-cli/playground-server-process-child.ts
+++ b/src/lib/wordpress-provider/playground-cli/playground-server-process-child.ts
@@ -1,5 +1,6 @@
 import { SupportedPHPVersion, PHPRunOptions } from '@php-wasm/universal';
 import { runCLI, RunCLIArgs, RunCLIServer } from '@wp-playground/cli';
+import { sanitizeRunCLIArgs } from 'src/lib/sentry-sanitizer';
 import { isWordPressDevVersion } from 'src/lib/wordpress-version-utils';
 import { WordPressServerOptions } from '../types';
 import { getMuPlugins } from './mu-plugins';
@@ -92,6 +93,7 @@ process.stderr.write = function ( ...args: Parameters< typeof originalStderrWrit
 } as typeof process.stderr.write;
 
 let server: RunCLIServer | null = null;
+let lastCliArgs: Record< string, unknown > | null = null;
 
 process.parentPort.on( 'message', async ( event ) => {
 	const message = event.data as Message;
@@ -122,6 +124,7 @@ process.parentPort.on( 'message', async ( event ) => {
 			id: message.id,
 			error: error instanceof Error ? error.message : String( error ),
 			errorStack: error instanceof Error ? error.stack : undefined,
+			cliArgs: lastCliArgs,
 		} );
 	}
 } );
@@ -199,6 +202,8 @@ async function startServer(
 		}
 
 		args.blueprint.constants = { ...args.blueprint.constants, ...defaultConstants };
+
+		lastCliArgs = sanitizeRunCLIArgs( args );
 
 		server = await runCLI( args );
 

--- a/src/lib/wordpress-provider/playground-cli/playground-server-process.ts
+++ b/src/lib/wordpress-provider/playground-cli/playground-server-process.ts
@@ -59,6 +59,7 @@ export class PlaygroundServerProcess implements WordPressServerProcess {
 				errorStack?: string;
 				result?: unknown;
 				message?: string;
+				cliArgs?: Record< string, unknown >;
 			} ) => {
 				if ( message.type === 'ready' ) {
 					return;
@@ -90,9 +91,14 @@ export class PlaygroundServerProcess implements WordPressServerProcess {
 					this.responseHandlers.delete( message.id );
 
 					if ( message.error ) {
-						const error = new Error( message.error );
+						const error = new Error( message.error ) as Error & {
+							cliArgs?: Record< string, unknown >;
+						};
 						if ( message.errorStack ) {
 							error.stack = message.errorStack;
+						}
+						if ( message.cliArgs ) {
+							error.cliArgs = message.cliArgs;
 						}
 						handler.reject( error );
 					} else {


### PR DESCRIPTION
## Related issues

- Related to STU-854

## Proposed Changes

This PR aims to add more detailed context to Sentry error reports to allow us to better debug Playground CLI issues.
- `server` - Studio server options
- `startup` - Playground CLI specific options

Note:
- Since this information might contain user specific sensitive data, I added a function to sanitize data. Please take time to review this information careful as part of the PR review

<img width="824" height="1604" alt="image" src="https://github.com/user-attachments/assets/8fdd725a-2f1a-4929-98ef-8e10c2e9e01c" />

## Testing Instructions

### Test with Failing Blueprint

1. Create a test blueprint at `~/Documents/test-blueprints/failing-plugin-blueprint.json`:

```json
{
  "$schema": "https://playground.wordpress.net/blueprint-schema.json",
  "meta": {
    "title": "Failing Plugin Test Blueprint",
    "description": "Blueprint that should fail due to non-existent plugin",
    "author": "testuser"
  },
  "login": true,
  "preferredVersions": {
    "php": "8.0",
    "wp": "latest"
  },
  "steps": [
    {
      "step": "installPlugin",
      "pluginData": {
        "resource": "wordpress.org/plugins",
        "slug": "this-plugin-does-not-exist-12345"
      },
      "options": {
        "activate": true
      }
    },
    {
      "step": "setSiteOptions",
      "options": {
        "blogname": "This Should Not Be Set"
      }
    }
  ]
}
```

2. **Temporarily enable Sentry** in `src/index.ts` line 70:
   ```typescript
   enabled: true, // TEMP for testing
   ```

3. Start Studio:
   ```bash
   npm start
   ```

4. Create a new site with the failing blueprint

5. **Verify in Sentry dashboard**:
   - Find the error: "Could not start server: Error when executing the blueprint step"
   - Check the **Contexts** section for `server` and `startup` data
   - Verify `blueprintJson` shows as readable JSON string (not `[Filtered]`)
   - Confirm it includes: PHP version, WP version, port, site-url, blueprint steps with plugin slug
   - Confirm sensitive data is omitted (no passwords, no PHP code, no mount paths)

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?