### PR TITLE
Test new Windows AMI and plugin

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -29,7 +29,7 @@ steps:
       queue: "{{matrix}}"
     matrix:
       - mac
-      - windows
+      - $WINDOWS_QUEUE
     notify:
       - github_commit_status:
           context: Unit Tests
@@ -114,7 +114,7 @@ steps:
     steps:
       - label: 🔨 Windows Dev Build - {{matrix}}
         agents:
-          queue: windows
+          queue: $WINDOWS_QUEUE
         command: powershell -File .buildkite/commands/build-for-windows.ps1 -BuildType dev -Architecture {{matrix}}
         artifact_paths:
           - out\**\studio-setup.exe
@@ -222,7 +222,7 @@ steps:
     steps:
       - label: 🔨 Windows Release Build - {{matrix}}
         agents:
-          queue: windows
+          queue: $WINDOWS_QUEUE
         command: powershell -File .buildkite/commands/build-for-windows.ps1 -BuildType release -Architecture {{matrix}}
         artifact_paths:
           - out\**\studio-setup.exe

--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -11,4 +11,4 @@ NVM_PLUGIN_VERSION='0.6.0'
 export IMAGE_ID="$XCODE_VERSION"
 export CI_TOOLKIT_PLUGIN="automattic/a8c-ci-toolkit#$CI_TOOLKIT_VERSION"
 export NVM_PLUGIN="automattic/nvm#$NVM_PLUGIN_VERSION"
-export WINDOWS_QUEUE='windows'
+export WINDOWS_QUEUE='windows-staging'

--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -5,7 +5,7 @@
 
 # The ~> modifier is not currently used, but we check for it just in case
 XCODE_VERSION=$(sed -E -n 's/^(~> )?(.*)/xcode-\2/p' .xcode-version)
-CI_TOOLKIT_VERSION='5.5.0'
+CI_TOOLKIT_VERSION='5.7.0'
 NVM_PLUGIN_VERSION='0.6.0'
 
 export IMAGE_ID="$XCODE_VERSION"

--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -11,3 +11,4 @@ NVM_PLUGIN_VERSION='0.6.0'
 export IMAGE_ID="$XCODE_VERSION"
 export CI_TOOLKIT_PLUGIN="automattic/a8c-ci-toolkit#$CI_TOOLKIT_VERSION"
 export NVM_PLUGIN="automattic/nvm#$NVM_PLUGIN_VERSION"
+export WINDOWS_QUEUE='windows'


### PR DESCRIPTION
This PR shows that the project can run correctly on the new Windows CI image.

<img width="2320" height="583" alt="image" src="https://github.com/user-attachments/assets/70120d80-5ad7-428a-85b5-f8e8608ae6db" />

---

The PR is now closed in favor of #1981 which uses the production Windows queue instead of the staging one, now that everything has been proven to work.