### PR TITLE
Simplify Windows build setup

### DIFF
--- a/.buildkite/commands/build-for-windows.ps1
+++ b/.buildkite/commands/build-for-windows.ps1
@@ -28,8 +28,8 @@ if ($Architecture -notin $VALID_ARCHITECTURES) {
     Exit 1
 }
 
-# prepare_windows_host_for_app_distribution.ps1 comes from CI Toolkit Plugin
-& "prepare_windows_host_for_app_distribution.ps1" -InstallNativeCompilationTools $true
+# setup_windows_code_signing.ps1 comes from CI Toolkit Plugin
+& "setup_windows_code_signing.ps1"
 If ($LastExitCode -ne 0) { Exit $LastExitCode }
 
 Write-Host "--- :npm: Installing Node dependencies"

--- a/.buildkite/commands/run-e2e-tests.sh
+++ b/.buildkite/commands/run-e2e-tests.sh
@@ -3,12 +3,6 @@ set -euo pipefail
 
 MATRIX=${1:-}
 
-echo '--- :wrench: Matrix setup'
-if [ "$MATRIX" = "windows" ]; then
-  # prepare_windows_host_for_app_distribution.ps1 comes from CI Toolkit Plugin
-  powershell -Command "& 'prepare_windows_host_for_app_distribution.ps1' -InstallNativeCompilationTools \$true"
-fi
-
 echo '--- :package: Install deps'
 bash .buildkite/commands/install-node-dependencies.sh
 

--- a/.buildkite/commands/run-unit-tests.sh
+++ b/.buildkite/commands/run-unit-tests.sh
@@ -3,12 +3,6 @@ set -euo pipefail
 
 MATRIX=${1:-}
 
-echo '--- :wrench: Matrix setup'
-if [ "$MATRIX" = "windows" ]; then
-  # prepare_windows_host_for_app_distribution.ps1 comes from CI Toolkit Plugin
-  powershell -Command "& 'prepare_windows_host_for_app_distribution.ps1' -InstallNativeCompilationTools \$true"
-fi
-
 echo '--- :package: Install deps'
 bash .buildkite/commands/install-node-dependencies.sh
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Follow up to https://github.com/Automattic/studio/pull/1981

## Proposed Changes

This PR simplifies the Windows build and CI configuration:

  - Build script: Replace `prepare_windows_host_for_app_distribution.ps1` script with the more focused `setup_windows_code_signing.ps1`
  - Test scripts: Remove unnecessary Windows-specific setup from e2e and unit test scripts

The native compilation tools installation is no longer needed, streamlining the CI pipeline and reducing setup time for Windows builds and tests.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Confirm builds go through.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
