### PR TITLE
Studio: Resolve warnings about memory leaks related to listeners

### DIFF
--- a/src/components/site-menu.tsx
+++ b/src/components/site-menu.tsx
@@ -199,7 +199,7 @@ export default function SiteMenu( { className }: SiteMenuProps ) {
 		const unsubscribe = window.ipcListener.subscribe(
 			'site-context-menu-action',
 			async ( _, actionData: { action: string; siteId: string } ) => {
-				const site = data.find( ( s ) => s.id === actionData.siteId );
+				const site = data.find( ( site ) => site.id === actionData.siteId );
 				if ( ! site ) {
 					return;
 				}

--- a/src/components/site-menu.tsx
+++ b/src/components/site-menu.tsx
@@ -115,16 +115,7 @@ function ButtonToRun( { running, id, name }: Pick< SiteDetails, 'running' | 'id'
 	);
 }
 function SiteItem( { site }: { site: SiteDetails } ) {
-	const {
-		selectedSite,
-		setSelectedSiteId,
-		startServer,
-		stopServer,
-		loadingServer,
-		setIsEditModalOpen,
-	} = useSiteDetails();
-	const { setSelectedTab } = useContentTabs();
-	const { handleDeleteSite } = useDeleteSite();
+	const { selectedSite, setSelectedSiteId, loadingServer } = useSiteDetails();
 	const isSelected = site === selectedSite;
 	const { isSiteImporting, isSiteExporting } = useImportExport();
 	const { isSiteIdPulling } = useSyncSites();
@@ -167,82 +158,6 @@ function SiteItem( { site }: { site: SiteDetails } ) {
 		} );
 	};
 
-	useEffect( () => {
-		const unsubscribe = window.ipcListener.subscribe(
-			'site-context-menu-action',
-			async ( _, data: { action: string; siteId: string } ) => {
-				if ( data.siteId === site.id ) {
-					const ipcApi = getIpcApi();
-					switch ( data.action ) {
-						case 'start':
-							void startServer( site.id );
-							break;
-						case 'stop':
-							void stopServer( site.id );
-							break;
-						case 'open-site':
-							if ( ! site.running ) {
-								await startServer( site.id );
-							}
-							ipcApi.openSiteURL( site.id, '', { autoLogin: false } );
-							break;
-						case 'open-admin':
-							if ( ! site.running ) {
-								await startServer( site.id );
-							}
-							ipcApi.openSiteURL( site.id, '/wp-admin/' );
-							break;
-						case 'open-finder':
-							ipcApi.openLocalPath( site.path );
-							break;
-						case 'open-editor':
-							if ( editor ) {
-								void ipcApi.openAppAtPath( editor, site.path );
-							}
-							break;
-						case 'open-terminal':
-							void ( async () => {
-								try {
-									await ipcApi.openTerminalAtPath( site.path );
-								} catch ( error ) {
-									Sentry.captureException( error );
-									alert( __( 'Could not open the terminal.' ) );
-								}
-							} )();
-							break;
-						case 'edit-site':
-							if ( site.id !== selectedSite?.id ) {
-								setSelectedSiteId( site.id );
-							}
-							setSelectedTab( 'settings' );
-							setIsEditModalOpen( true );
-							break;
-						case 'delete':
-							await handleDeleteSite( site.id, site.name );
-							break;
-					}
-				}
-			}
-		);
-
-		return () => {
-			unsubscribe?.();
-		};
-	}, [
-		site.id,
-		site.name,
-		site.path,
-		site.running,
-		startServer,
-		stopServer,
-		editor,
-		selectedSite?.id,
-		setSelectedTab,
-		setIsEditModalOpen,
-		setSelectedSiteId,
-		handleDeleteSite,
-	] );
-
 	return (
 		<li
 			className={ cx(
@@ -274,7 +189,88 @@ function SiteItem( { site }: { site: SiteDetails } ) {
 }
 
 export default function SiteMenu( { className }: SiteMenuProps ) {
-	const { data } = useSiteDetails();
+	const { data, selectedSite, setSelectedSiteId, startServer, stopServer, setIsEditModalOpen } =
+		useSiteDetails();
+	const { setSelectedTab } = useContentTabs();
+	const { handleDeleteSite } = useDeleteSite();
+	const { data: editor } = useGetUserEditorQuery();
+
+	useEffect( () => {
+		const unsubscribe = window.ipcListener.subscribe(
+			'site-context-menu-action',
+			async ( _, actionData: { action: string; siteId: string } ) => {
+				const site = data.find( ( s ) => s.id === actionData.siteId );
+				if ( ! site ) {
+					return;
+				}
+
+				const ipcApi = getIpcApi();
+				switch ( actionData.action ) {
+					case 'start':
+						void startServer( site.id );
+						break;
+					case 'stop':
+						void stopServer( site.id );
+						break;
+					case 'open-site':
+						if ( ! site.running ) {
+							await startServer( site.id );
+						}
+						ipcApi.openSiteURL( site.id, '', { autoLogin: false } );
+						break;
+					case 'open-admin':
+						if ( ! site.running ) {
+							await startServer( site.id );
+						}
+						ipcApi.openSiteURL( site.id, '/wp-admin/' );
+						break;
+					case 'open-finder':
+						ipcApi.openLocalPath( site.path );
+						break;
+					case 'open-editor':
+						if ( editor ) {
+							void ipcApi.openAppAtPath( editor, site.path );
+						}
+						break;
+					case 'open-terminal':
+						void ( async () => {
+							try {
+								await ipcApi.openTerminalAtPath( site.path );
+							} catch ( error ) {
+								Sentry.captureException( error );
+								alert( __( 'Could not open the terminal.' ) );
+							}
+						} )();
+						break;
+					case 'edit-site':
+						if ( site.id !== selectedSite?.id ) {
+							setSelectedSiteId( site.id );
+						}
+						setSelectedTab( 'settings' );
+						setIsEditModalOpen( true );
+						break;
+					case 'delete':
+						await handleDeleteSite( site.id, site.name );
+						break;
+				}
+			}
+		);
+
+		return () => {
+			unsubscribe?.();
+		};
+	}, [
+		data,
+		editor,
+		selectedSite?.id,
+		setSelectedTab,
+		setIsEditModalOpen,
+		setSelectedSiteId,
+		startServer,
+		stopServer,
+		handleDeleteSite,
+	] );
+
 	return (
 		<nav
 			aria-label={ __( 'Sites' ) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

Closes STU-937

## Proposed Changes

I propose to use one listener for in the parent component for `site-context-menu-action` and find the relevant site after, instead of using an individual listener for each site item. This is how it works: 

  **Before (multiple listeners):**

*  Each `SiteItem` component subscribed to `site-context-menu-action`
 * When the event fired, all 11+ listeners would execute
*  Each listener checked if `(data.siteId === site.id)` to see if it should
  handle the event
*  Only the matching site item would process the action

  **After (single listener):**

* Only the `SiteMenu` parent subscribes once to `site-context-menu-action`
* When the event fires, only 1 listener executes
* It finds the matching site
* It processes the action for that site

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

 * Pull the changes from this branch
 * Start the app with `npm start`
 * Open the developer tools
 * Navigate through the app e.g. switching between sites and tabs
 * Confirm that you don't see the React warning as below:

```
VM4 sandbox_bundle:2 MaxListenersExceededWarning: Possible 
EventEmitter memory leak detected. 11 site-context-menu-action listeners 
added. Use emitter.setMaxListeners() to increase limit
    at _addListener (VM4 sandbox_bundle:2:43268)
    at IpcRenderer.addListener (VM4 sandbox_bundle:2:46156)
    at Object.subscribe (<anonymous>:139:24) 
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
