### PR TITLE
Remove `$WINDOWS_QUEUE` abstraction in CI scripts

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -29,7 +29,7 @@ steps:
       queue: "{{matrix}}"
     matrix:
       - mac
-      - $WINDOWS_QUEUE
+      - windows
     notify:
       - github_commit_status:
           context: Unit Tests
@@ -114,7 +114,7 @@ steps:
     steps:
       - label: 🔨 Windows Dev Build - {{matrix}}
         agents:
-          queue: $WINDOWS_QUEUE
+          queue: windows
         command: powershell -File .buildkite/commands/build-for-windows.ps1 -BuildType dev -Architecture {{matrix}}
         artifact_paths:
           - out\**\studio-setup.exe
@@ -222,7 +222,7 @@ steps:
     steps:
       - label: 🔨 Windows Release Build - {{matrix}}
         agents:
-          queue: $WINDOWS_QUEUE
+          queue: windows
         command: powershell -File .buildkite/commands/build-for-windows.ps1 -BuildType release -Architecture {{matrix}}
         artifact_paths:
           - out\**\studio-setup.exe

--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -11,4 +11,3 @@ NVM_PLUGIN_VERSION='0.6.0'
 export IMAGE_ID="$XCODE_VERSION"
 export CI_TOOLKIT_PLUGIN="automattic/a8c-ci-toolkit#$CI_TOOLKIT_VERSION"
 export NVM_PLUGIN="automattic/nvm#$NVM_PLUGIN_VERSION"
-export WINDOWS_QUEUE='windows'


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Addresses @AliSoftware 's https://github.com/Automattic/studio/pull/1981#pullrequestreview-3411944616

## Proposed Changes

Removes the `$WINDOWS_QUEUE` env var from the CI pipeline in favor of hardcoding "windows". 

I was on the fence on it myself, so I'm okay to revert straightaway.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- If the Windows build run on the `windows` queue in CI, then we're good.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors? — N.A.
