### PR TITLE
Studio: Limit depth on mu-plugins for selecting local tree

### DIFF
--- a/src/modules/sync/lib/tree-utils.ts
+++ b/src/modules/sync/lib/tree-utils.ts
@@ -27,6 +27,7 @@ export const shouldLimitDepth = ( relativePath: string ): boolean => {
 		return true;
 	}
 
+	// Match mu-plugins/mu-plugin or mu-plugins/mu-plugin/
 	if ( normalizedPath.match( /^mu-plugins\/[^/]+\/?$/ ) ) {
 		return true;
 	}

--- a/src/modules/sync/lib/tree-utils.ts
+++ b/src/modules/sync/lib/tree-utils.ts
@@ -27,6 +27,10 @@ export const shouldLimitDepth = ( relativePath: string ): boolean => {
 		return true;
 	}
 
+	if ( normalizedPath.match( /^mu-plugins\/[^/]+\/?$/ ) ) {
+		return true;
+	}
+
 	return false;
 };
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

Closes STU-969

## Proposed Changes

This PR ensures that we limit depth on folders for `mu-plugins` when selecting items for push. This will ensure that it works consistently with `themes` and `plugins`.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
* Start the app with `npm start`
* In your Studio site, add a custom folder with a plugin to `mu-plugins`
* Navigate to the `Sync` tab
* Connect that Studio site to one of the WP.com sites
* Click on `Push` option to open the `Sync` dialog`
* Confirm that you can select the plugin folders for `mu-plugins` but you can't go deeper than that and that the behaviour is consistent with `plugins` and `themes`:

<img width="394" height="255" alt="Screenshot 2025-11-05 at 11 09 49 AM" src="https://github.com/user-attachments/assets/e56c90d9-617c-4c68-a085-24ecdf0e3582" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
