### PR TITLE
Add loading check before showing empty Studio state

### DIFF
--- a/src/components/site-content-tabs.tsx
+++ b/src/components/site-content-tabs.tsx
@@ -17,7 +17,7 @@ import { cx } from 'src/lib/cx';
 import { ContentTabSync } from 'src/modules/sync';
 
 export function SiteContentTabs() {
-	const { selectedSite, data: localSites, siteCreationMessages } = useSiteDetails();
+	const { selectedSite, data: localSites, siteCreationMessages, loadingSites } = useSiteDetails();
 	const { importState } = useImportExport();
 	const { tabs, selectedTab, setSelectedTab } = useContentTabs();
 	const { __ } = useI18n();
@@ -40,7 +40,7 @@ export function SiteContentTabs() {
 		setKeyCounter( ( k ) => k + 1 );
 	}, [ selectedTab ] );
 
-	if ( ! localSites.length ) {
+	if ( ! loadingSites && ! localSites.length ) {
 		return <EmptyStudio />;
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-971

## Proposed Changes

- ensure the `EmptyStudio` does not render while local sites are still loading

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Basically, it should not be possible to reproduce the STU-971 issue anymore.

1. Check out the PR branch and build the app with `npm install && npm start`.
2. Start the app with some local sites created already.
3. There `EmptyStudio` component should not render at all.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
