### PR TITLE
Capitalize "File Explorer" in the Windows shortcut label

### DIFF
--- a/src/components/content-tab-overview.tsx
+++ b/src/components/content-tab-overview.tsx
@@ -141,7 +141,7 @@ function ShortcutsSection( { selectedSite }: Pick< ContentTabOverviewProps, 'sel
 		{
 			label: isWindows()
 				? // translators: name of app used to navigate files and folders on Windows
-				  __( 'File explorer' )
+				  __( 'File Explorer' )
 				: // translators: name of app used to navigate files and folders on macOS
 				  __( 'Finder' ),
 			className: 'text-nowrap',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-930

## Proposed Changes

- capitalize `File Explorer` in the Windows shortcut label

| Before | After |
|--------|--------|
| <img width="854" height="270" alt="Screen Shot on 2025-11-05 at 17:39:56" src="https://github.com/user-attachments/assets/34417302-385e-4b89-adfc-925edccefc5a" /> | <img width="824" height="252" alt="Screen Shot on 2025-11-05 at 17:48:17" src="https://github.com/user-attachments/assets/151c818a-f6d0-4e90-9958-46a1295df717" /> | 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR branch and build the app with `npm install` and `npm start` on Windows.
2. Ensure the `File Explorer` shortcut label is capitalized.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
