### PR TITLE
Explicitly set TS project path in ESLint config

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -7,6 +7,7 @@ import tsEslint from 'typescript-eslint';
 import js from '@eslint/js';
 import pluginReactHooks from 'eslint-plugin-react-hooks';
 import pluginJestDom from 'eslint-plugin-jest-dom';
+import path from 'node:path';
 
 export default defineConfig(
 	globalIgnores( [ '**/node_modules/', '**/dist/', '**/out/', '**/wp-files/', '**/vendor/' ] ),
@@ -36,6 +37,7 @@ export default defineConfig(
 			'import/resolver': {
 				typescript: {
 					alwaysTryTypes: true,
+					project: path.join( import.meta.dirname, 'tsconfig.json' ),
 				},
 			},
 		},


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

N/A

## Proposed Changes

Following up on #2005, this PR tweaks the ESLint config to explicitly set the `project` setting. `eslint-import-resolver-typescript` is supposed to configure this automatically, but I've noticed this isn't always the case for the ESLint LSP in Zed.

Adding the explicit config doesn't hurt, and above all, it makes the ESLint LSP run as expected in my editor. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Run `npm run lint` and ensure that there are no linter issues
2. Restart language servers in your editor (or just restart the entire app) and ensure that there are no unexpected linter issues

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
