### PR TITLE
Use SSL-aware cookie setting for WordPress authentication

### DIFF
--- a/src/lib/wordpress-provider/playground-cli/mu-plugins.ts
+++ b/src/lib/wordpress-provider/playground-cli/mu-plugins.ts
@@ -416,7 +416,7 @@ function getStandardMuPlugins( options: Partial< WordPressServerOptions > ): MuP
 			}
 
 			wp_set_current_user( $user->ID, $user->user_login );
-			wp_set_auth_cookie( $user->ID, true, false );
+			wp_set_auth_cookie( $user->ID, true, is_ssl() );
 			do_action( 'wp_login', $user->user_login, $user );
 			$redirect_url = isset( $_GET['redirect_to'] ) ? $_GET['redirect_to'] : home_url();
 			wp_safe_redirect( $redirect_url );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-975

## Proposed Changes

- pass `is_ssl()` to `wp_set_auth_cookie` on auto-login

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR branch and build the app with `npm install && npm start`.
2. Create a new site with custom domain SSL enabled.
3. Once the site is created and you head over to WP Admin, you should be logged in.
4. There should be no regressions when opening WP Admin on other sites that don't use SSL.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
