### PR TITLE
Studio: Update Studio deeplink URL scheme from `wpcom-local-dev` to `wp-studio`

### DIFF
--- a/common/constants.ts
+++ b/common/constants.ts
@@ -6,7 +6,7 @@ export const DAY_MS = HOUR_MS * 24;
 
 // OAuth constants
 export const CLIENT_ID = '95109';
-export const PROTOCOL_PREFIX = 'wpcom-local-dev';
+export const PROTOCOL_PREFIX = 'wp-studio';
 export const DEFAULT_TOKEN_LIFETIME_MS = DAY_MS * 14;
 
 export const LOCKFILE_NAME = 'appdata-v1.json.lock';

--- a/common/lib/tests/oauth.test.ts
+++ b/common/lib/tests/oauth.test.ts
@@ -5,7 +5,7 @@ describe( 'getAuthenticationUrl', () => {
 		const result = getAuthenticationUrl( 'en' );
 
 		expect( result ).toBe(
-			'https://public-api.wordpress.com/oauth2/authorize?response_type=token&client_id=95109&redirect_uri=wpcom-local-dev%3A%2F%2Fauth&scope=global&locale=en'
+			'https://public-api.wordpress.com/oauth2/authorize?response_type=token&client_id=95109&redirect_uri=wp-studio%3A%2F%2Fauth&scope=global&locale=en'
 		);
 	} );
 
@@ -13,7 +13,7 @@ describe( 'getAuthenticationUrl', () => {
 		const result = getAuthenticationUrl( 'es' );
 
 		expect( result ).toBe(
-			'https://public-api.wordpress.com/oauth2/authorize?response_type=token&client_id=95109&redirect_uri=wpcom-local-dev%3A%2F%2Fauth&scope=global&locale=es'
+			'https://public-api.wordpress.com/oauth2/authorize?response_type=token&client_id=95109&redirect_uri=wp-studio%3A%2F%2Fauth&scope=global&locale=es'
 		);
 	} );
 } );

--- a/docs/linux.md
+++ b/docs/linux.md
@@ -73,7 +73,7 @@ For easier access, you can create a desktop entry file that will add Studio to y
    Exec=<absolute-path-to-repo>/out/Studio-linux-x64/studio %U
    Type=Application
    Terminal=false
-   MimeType=x-scheme-handler/wpcom-local-dev;
+   MimeType=x-scheme-handler/wp-studio;
    Categories=Development;
    ```
 
@@ -93,7 +93,7 @@ For easier access, you can create a desktop entry file that will add Studio to y
    update-desktop-database ~/.local/share/applications
    ```
 
-Studio should now appear in your application launcher and can handle `wpcom-local-dev://` protocol URLs.
+Studio should now appear in your application launcher and can handle `wp-studio://` protocol URLs.
 
 ## Running with Wayland
 

--- a/src/lib/deeplink/deeplink-handler.ts
+++ b/src/lib/deeplink/deeplink-handler.ts
@@ -5,9 +5,9 @@ import { handleSyncConnectSiteDeeplink } from 'src/lib/deeplink/handlers/sync-co
 /**
  * Main deeplink handler that routes incoming deeplinks to the appropriate handler.
  * Supports the following deeplink schemes:
- * - wpcom-local-dev://auth - OAuth authentication callback
- * - wpcom-local-dev://sync-connect-site - Sync site connection from WordPress.com
- * - wpcom-local-dev://add-site?blueprint_url=<encoded-url> - Add site with blueprint from URL
+ * - wp-studio://auth - OAuth authentication callback
+ * - wp-studio://sync-connect-site - Sync site connection from WordPress.com
+ * - wp-studio://add-site?blueprint_url=<encoded-url> - Add site with blueprint from URL
  */
 export async function handleDeeplink( url: string ): Promise< void > {
 	const urlObject = new URL( url );

--- a/src/lib/deeplink/handlers/auth.ts
+++ b/src/lib/deeplink/handlers/auth.ts
@@ -56,7 +56,7 @@ async function handleAuthCallback( hash: string ): Promise< StoredToken > {
 /**
  * Handles the OAuth authentication deeplink callback.
  * This function is called when the user completes authentication on WordPress.com
- * and is redirected back to the app via wpcom-local-dev://auth
+ * and is redirected back to the app via wp-studio://auth
  */
 export async function handleAuthDeeplink( urlObject: URL ): Promise< void > {
 	const { hash } = urlObject;

--- a/src/lib/deeplink/handlers/sync-connect-site.ts
+++ b/src/lib/deeplink/handlers/sync-connect-site.ts
@@ -3,7 +3,7 @@ import { sendIpcEventToRenderer } from 'src/ipc-utils';
 /**
  * Handles the sync-connect-site deeplink callback.
  * This function is called when a user initiates a sync connection from WordPress.com
- * and is redirected back to the app via wpcom-local-dev://sync-connect-site
+ * and is redirected back to the app via wp-studio://sync-connect-site
  */
 export async function handleSyncConnectSiteDeeplink( urlObject: URL ): Promise< void > {
 	const { searchParams } = urlObject;

--- a/src/lib/deeplink/tests/auth.test.ts
+++ b/src/lib/deeplink/tests/auth.test.ts
@@ -33,7 +33,7 @@ describe( 'handleAuthDeeplink', () => {
 			req: { get: mockWpcomGet },
 		} as unknown as WPCOM );
 
-		const url = new URL( 'wpcom-local-dev://auth#access_token=mock-token&expires_in=3600' );
+		const url = new URL( 'wp-studio://auth#access_token=mock-token&expires_in=3600' );
 		await handleAuthDeeplink( url );
 
 		expect( sendIpcEventToRenderer ).toHaveBeenCalledWith( 'auth-updated', {
@@ -49,7 +49,7 @@ describe( 'handleAuthDeeplink', () => {
 	} );
 
 	it( 'should handle authentication error from WordPress.com', async () => {
-		const url = new URL( 'wpcom-local-dev://auth#error=access_denied' );
+		const url = new URL( 'wp-studio://auth#error=access_denied' );
 		await handleAuthDeeplink( url );
 
 		expect( sendIpcEventToRenderer ).toHaveBeenCalledWith( 'auth-updated', {
@@ -59,7 +59,7 @@ describe( 'handleAuthDeeplink', () => {
 	} );
 
 	it( 'should handle invalid token response', async () => {
-		const url = new URL( 'wpcom-local-dev://auth#access_token=mock-token&expires_in=invalid' );
+		const url = new URL( 'wp-studio://auth#access_token=mock-token&expires_in=invalid' );
 		await handleAuthDeeplink( url );
 
 		expect( sendIpcEventToRenderer ).toHaveBeenCalledWith( 'auth-updated', {
@@ -74,7 +74,7 @@ describe( 'handleAuthDeeplink', () => {
 			req: { get: mockWpcomGet },
 		} as unknown as WPCOM );
 
-		const url = new URL( 'wpcom-local-dev://auth#access_token=mock-token&expires_in=3600' );
+		const url = new URL( 'wp-studio://auth#access_token=mock-token&expires_in=3600' );
 		await handleAuthDeeplink( url );
 
 		expect( sendIpcEventToRenderer ).toHaveBeenCalledWith( 'auth-updated', {

--- a/src/lib/deeplink/tests/sync-connect-site.test.ts
+++ b/src/lib/deeplink/tests/sync-connect-site.test.ts
@@ -12,9 +12,7 @@ describe( 'handleSyncConnectSiteDeeplink', () => {
 	} );
 
 	it( 'should handle sync connect site callback', async () => {
-		const url = new URL(
-			'wpcom-local-dev://sync-connect-site?remoteSiteId=123&studioSiteId=local-site'
-		);
+		const url = new URL( 'wp-studio://sync-connect-site?remoteSiteId=123&studioSiteId=local-site' );
 		await handleSyncConnectSiteDeeplink( url );
 
 		expect( sendIpcEventToRenderer ).toHaveBeenCalledWith( 'sync-connect-site', {
@@ -24,7 +22,7 @@ describe( 'handleSyncConnectSiteDeeplink', () => {
 	} );
 
 	it( 'should not send sync connect site event if parameters are missing', async () => {
-		const url = new URL( 'wpcom-local-dev://sync-connect-site?remoteSiteId=123' );
+		const url = new URL( 'wp-studio://sync-connect-site?remoteSiteId=123' );
 		await handleSyncConnectSiteDeeplink( url );
 
 		expect( sendIpcEventToRenderer ).not.toHaveBeenCalled();

--- a/src/lib/tests/oauth.test.ts
+++ b/src/lib/tests/oauth.test.ts
@@ -90,7 +90,7 @@ describe( 'getSignUpUrl', () => {
 	it( 'should include encoded authentication URL as oauth2_redirect parameter', () => {
 		const locale: SupportedLocale = 'es';
 		const mockAuthUrl =
-			'https://public-api.wordpress.com/oauth2/authorize?response_type=token&client_id=95109&redirect_uri=wpcom-local-dev%3A%2F%2Fauth&scope=global&locale=es';
+			'https://public-api.wordpress.com/oauth2/authorize?response_type=token&client_id=95109&redirect_uri=wp-studio%3A%2F%2Fauth&scope=global&locale=es';
 		const result = getSignUpUrl( locale );
 
 		const url = new URL( result );

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -100,7 +100,7 @@ describe( 'App initialization', () => {
 			require( '../index' );
 			const { 'open-url': openUrl } = mockedEvents;
 
-			const testUrl = 'wpcom-local-dev://auth#test-hash';
+			const testUrl = 'wp-studio://auth#test-hash';
 			await openUrl( {}, testUrl );
 			expect( mockHandleDeeplink ).toHaveBeenCalledWith( testUrl );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-936

## Proposed Changes

- Update Studio deeplink URL scheme from `wpcom-local-dev://` to `wp-studio://`. 
- Update docs

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Check out this branch in Studio
- Run Studio. `npm start`
- Try to log in to the WordPress.com account
- Make sure you are logged in without any regression. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?