### PR TITLE
Unify Windows Defender prompt checkbox text

### DIFF
--- a/src/lib/windows-helpers.ts
+++ b/src/lib/windows-helpers.ts
@@ -50,7 +50,7 @@ export async function promptWindowsSpeedUpSites( {
 		message: __(
 			"Microsoft Defender's Real-time protection may slow site creation.\n\nTo create sites quickly, we recommend disabling Real-time protection for the Studio app."
 		),
-		...( skipIfAlreadyPrompted && { checkboxLabel: __( "Don't ask me again" ) } ),
+		...( skipIfAlreadyPrompted && { checkboxLabel: __( "Don't ask again" ) } ),
 		cancelId: buttons.indexOf( NOT_INTERESTED ),
 	} );
 


### PR DESCRIPTION
Changes checkbox label from 'Don't ask me again' to 'Don't ask again' to match phrasing used elsewhere in the application.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- N/A

## Proposed Changes

- I propose unifying Windows Defender prompt checkbox text to make it consistent with other places, and to limit number of phrases to translate.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Review should be enough

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
