### PR TITLE
Studio: Update Studio scheme protocol handler to AppxManifest for Windows

### DIFF
--- a/scripts/package-appx.mjs
+++ b/scripts/package-appx.mjs
@@ -67,7 +67,7 @@ async function addProtocolHandlerToManifest( manifestPath ) {
 	const manifestContent = await fs.readFile( manifestPath, 'utf-8' );
 
 	// Check if protocol handler already exists
-	if ( manifestContent.includes( 'wpcom-local-dev' ) ) {
+	if ( manifestContent.includes( 'wp-studio' ) ) {
 		console.log( '~~~ Protocol handler already exists, skipping...' );
 		return;
 	}
@@ -75,7 +75,7 @@ async function addProtocolHandlerToManifest( manifestPath ) {
 	// Insert the protocol handler extension before </Application>
 	const protocolExtension = `      <Extensions>
         <uap:Extension Category="windows.protocol">
-          <uap:Protocol Name="wpcom-local-dev">
+          <uap:Protocol Name="wp-studio">
             <uap:DisplayName>WordPress.com Local Dev Protocol</uap:DisplayName>
           </uap:Protocol>
         </uap:Extension>


### PR DESCRIPTION
## Related issues

- Fixes STU-936

## Proposed Changes

- Update Studio protocol from  from wpcom-local-dev to wp-studio to the existing app manifest

## Testing Instructions

Taken from https://github.com/Automattic/studio/pull/1969, Props to @bcotrim 

1. Download the signed .appx file from the CI build artifacts for this PR (https://buildkite.com/automattic/studio/builds/9170/steps/canvas?jid=019aa14c-6f7d-4be5-bbac-d950b13e7e91)
2. Install the .appx on a Windows machine (right click -> Install)
3. Open Studio and click the "Login" button in the top right
4. Authenticate in the browser when redirected to WordPress.com
5. After approving, verify the browser shows "Authorized. You can now open Studio and close this window."
6. Verify Studio successfully logs you in and displays your account information


## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?