### PR TITLE
Enable Claude workflows for Dependabot PRs

### DIFF
--- a/.github/workflows/claude-docs-api-sync.yml
+++ b/.github/workflows/claude-docs-api-sync.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true
+          trusted_bots: 'dependabot[bot]'
           prompt: |
             The IPC API or type definitions have changed in this PR. Please:
 

--- a/.github/workflows/claude-docs-api-sync.yml
+++ b/.github/workflows/claude-docs-api-sync.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true
-          trusted_bots: 'dependabot[bot]'
+          allowed_bots: 'dependabot[bot]'
           prompt: |
             The IPC API or type definitions have changed in this PR. Please:
 

--- a/.github/workflows/claude-docs-architecture-sync.yml
+++ b/.github/workflows/claude-docs-architecture-sync.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true
-          trusted_bots: 'dependabot[bot]'
+          allowed_bots: 'dependabot[bot]'
           prompt: |
             Core architecture files have changed in this PR. Please:
 

--- a/.github/workflows/claude-docs-architecture-sync.yml
+++ b/.github/workflows/claude-docs-architecture-sync.yml
@@ -32,6 +32,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true
+          trusted_bots: 'dependabot[bot]'
           prompt: |
             Core architecture files have changed in this PR. Please:
 

--- a/.github/workflows/claude-docs-cli-sync.yml
+++ b/.github/workflows/claude-docs-cli-sync.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true
-          trusted_bots: 'dependabot[bot]'
+          allowed_bots: 'dependabot[bot]'
           prompt: |
             CLI commands or implementation have changed in this PR. Please:
 

--- a/.github/workflows/claude-docs-cli-sync.yml
+++ b/.github/workflows/claude-docs-cli-sync.yml
@@ -27,6 +27,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true
+          trusted_bots: 'dependabot[bot]'
           prompt: |
             CLI commands or implementation have changed in this PR. Please:
 

--- a/.github/workflows/claude-interactive.yml
+++ b/.github/workflows/claude-interactive.yml
@@ -39,7 +39,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          trusted_bots: 'dependabot[bot]'
+          allowed_bots: 'dependabot[bot]'
           # No prompt = interactive mode - Claude responds to the comment/issue
           claude_args: |
             --allowedTools "Read,Write,Edit,Grep,Glob,Bash(npm:*),Bash(node:*),Bash(git:*),Bash(gh:*)"

--- a/.github/workflows/claude-interactive.yml
+++ b/.github/workflows/claude-interactive.yml
@@ -39,6 +39,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          trusted_bots: 'dependabot[bot]'
           # No prompt = interactive mode - Claude responds to the comment/issue
           claude_args: |
             --allowedTools "Read,Write,Edit,Grep,Glob,Bash(npm:*),Bash(node:*),Bash(git:*),Bash(gh:*)"

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true
-          trusted_bots: 'dependabot[bot]'
+          allowed_bots: 'dependabot[bot]'
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -23,6 +23,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: true
+          trusted_bots: 'dependabot[bot]'
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- N/A

## Proposed Changes

I propose adding `allowed_bots: 'dependabot[bot]'` to all Claude Code action workflows, allowing them to properly review, sync documentation, and respond to mentions on Dependabot PRs.

Fixes permission issues that previously prevented these workflows from running on dependency update PRs.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Confirm if build goes through

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
