### PR TITLE
Studio: Add e2e test for changing PHP version

### DIFF
--- a/e2e/page-objects/settings-tab.ts
+++ b/e2e/page-objects/settings-tab.ts
@@ -46,4 +46,32 @@ export default class SettingsTab {
 		await this.optionsMenu.click();
 		await this.deleteButton.click();
 	}
+
+	get editSiteButton() {
+		return this.locator.getByRole( 'button', { name: 'Edit site' } );
+	}
+
+	get editSiteDialog() {
+		return this.page.getByRole( 'dialog' );
+	}
+
+	get phpVersionSelect() {
+		return this.editSiteDialog.getByLabel( 'PHP version' );
+	}
+
+	get saveButton() {
+		return this.editSiteDialog.getByRole( 'button', { name: 'Save' } );
+	}
+
+	async changePhpVersion( version: string ) {
+		await this.editSiteButton.click();
+		await this.editSiteDialog.waitFor( { state: 'visible' } );
+		await this.phpVersionSelect.selectOption( version );
+		await this.saveButton.click();
+		await this.editSiteDialog.waitFor( { state: 'hidden' } );
+	}
+
+	async getCurrentPhpVersion() {
+		return await this.phpVersionSelect.inputValue();
+	}
 }

--- a/e2e/page-objects/settings-tab.ts
+++ b/e2e/page-objects/settings-tab.ts
@@ -70,8 +70,4 @@ export default class SettingsTab {
 		await this.saveButton.click();
 		await this.editSiteDialog.waitFor( { state: 'hidden' } );
 	}
-
-	async getCurrentPhpVersion() {
-		return await this.phpVersionSelect.inputValue();
-	}
 }

--- a/e2e/sites.test.ts
+++ b/e2e/sites.test.ts
@@ -2,6 +2,7 @@ import http from 'http';
 import path from 'path';
 import { test, expect } from '@playwright/test';
 import { pathExists } from '../common/lib/fs-utils';
+import { DEFAULT_PHP_VERSION } from '../vendor/wp-now/src/constants';
 import { E2ESession } from './e2e-helpers';
 import MainSidebar from './page-objects/main-sidebar';
 import Onboarding from './page-objects/onboarding';
@@ -71,6 +72,30 @@ test.describe( 'Servers', () => {
 		} );
 		expect( [ 200, 302 ] ).toContain( response.statusCode );
 		expect( response.headers[ 'content-type' ] ).toMatch( /text\/html/ );
+	} );
+
+	test( 'change PHP version', async () => {
+		const newPhpVersion = '8.2';
+		const siteContent = new SiteContent( session.mainWindow, siteName );
+		const settingsTab = await siteContent.navigateToTab( 'Settings' );
+
+		await settingsTab.editSiteButton.click();
+		await expect( settingsTab.editSiteDialog ).toBeVisible();
+
+		const initialPhpVersion = await settingsTab.phpVersionSelect.inputValue();
+		expect( initialPhpVersion ).toBe( DEFAULT_PHP_VERSION );
+
+		await settingsTab.phpVersionSelect.selectOption( newPhpVersion );
+		await settingsTab.saveButton.click();
+		await expect( settingsTab.editSiteDialog ).not.toBeVisible();
+
+		await settingsTab.editSiteButton.click();
+		await expect( settingsTab.editSiteDialog ).toBeVisible();
+
+		const updatedPhpVersion = await settingsTab.phpVersionSelect.inputValue();
+		expect( updatedPhpVersion ).toBe( newPhpVersion );
+
+		await settingsTab.editSiteDialog.getByRole( 'button', { name: 'Cancel' } ).click();
 	} );
 
 	test( "edit site's settings in wp-admin", async ( { page } ) => {

--- a/e2e/sites.test.ts
+++ b/e2e/sites.test.ts
@@ -107,7 +107,7 @@ test.describe( 'Servers', () => {
 		const frontendUrl = await settingsTab.copySiteUrlToClipboard( session.electronApp );
 
 		// page.goto opens a browser
-		const optionsGeneralUrl = wpAdminUrl + '/options-general.php'
+		const optionsGeneralUrl = wpAdminUrl + '/options-general.php';
 		await page.goto( getUrlWithAutoLogin( optionsGeneralUrl ) );
 		const siteTitleInput = page.getByLabel( 'Site Title' );
 		await siteTitleInput.fill( 'testing site title' );

--- a/e2e/sites.test.ts
+++ b/e2e/sites.test.ts
@@ -2,7 +2,7 @@ import http from 'http';
 import path from 'path';
 import { test, expect } from '@playwright/test';
 import { pathExists } from '../common/lib/fs-utils';
-import { DEFAULT_PHP_VERSION } from '../vendor/wp-now/src/constants';
+import { DEFAULT_PHP_VERSION, ALLOWED_PHP_VERSIONS } from '../vendor/wp-now/src/constants';
 import { E2ESession } from './e2e-helpers';
 import MainSidebar from './page-objects/main-sidebar';
 import Onboarding from './page-objects/onboarding';
@@ -75,7 +75,8 @@ test.describe( 'Servers', () => {
 	} );
 
 	test( 'change PHP version', async () => {
-		const newPhpVersion = '8.2';
+		const newPhpVersion = ALLOWED_PHP_VERSIONS.find(v => v !== DEFAULT_PHP_VERSION) || '8.2';
+
 		const siteContent = new SiteContent( session.mainWindow, siteName );
 		const settingsTab = await siteContent.navigateToTab( 'Settings' );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Proposed Changes

This PR adds e2e test for changing PHP versions.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
* Run `npm run make`
* Run `npx playwright test --grep "change PHP version"`
* Confirm that the test is passing
* Look through the code and ensure it makes sense

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
