### PR TITLE
Studio: Improve site e2e deletion tests

### DIFF
--- a/e2e/sites.test.ts
+++ b/e2e/sites.test.ts
@@ -91,8 +91,66 @@ test.describe( 'Servers', () => {
 		expect( await page.title() ).toBe( 'testing site title' );
 	} );
 
-	skipTestOnWindows( 'delete site', async () => {
-		const siteContent = new SiteContent( session.mainWindow, siteName );
+	skipTestOnWindows( 'delete site but keep directory on disk', async () => {
+		const keepDirSiteName = 'E2E-Test-Site-Keep-Dir';
+
+		const sidebar = new MainSidebar( session.mainWindow );
+		const modal = await sidebar.openAddSiteModal();
+
+		await expect( modal.createSiteButton ).toBeVisible();
+		await modal.createSiteButton.click();
+
+		await modal.siteNameInput.fill( keepDirSiteName );
+		await modal.addSiteButton.click();
+
+		const siteTitle = sidebar.getSiteNavButton( keepDirSiteName );
+		await expect( siteTitle ).toHaveText( keepDirSiteName );
+
+		const siteContent = new SiteContent( session.mainWindow, keepDirSiteName );
+		await expect( siteContent.runningButton ).toBeAttached( { timeout: 120_000 } );
+
+		expect(
+			await pathExists( path.join( session.homePath, 'Studio', keepDirSiteName, 'wp-config.php' ) )
+		).toBe( true );
+
+		const settingsTab = await siteContent.navigateToTab( 'Settings' );
+
+		// Playwright lacks support for interacting with native dialogs, so we mock
+		// the dialog module to simulate the user clicking the "Delete site"
+		// confirmation button without "Delete site files from my computer" checked.
+		// See: https://github.com/microsoft/playwright/issues/21432
+		await session.electronApp.evaluate( ( { dialog } ) => {
+			dialog.showMessageBox = async () => {
+				return { response: 0, checkboxChecked: false };
+			};
+		} );
+		await settingsTab.openDeleteSiteModal();
+
+		await session.mainWindow.waitForTimeout( 200 );
+
+		await expect( sidebar.getSiteNavButton( keepDirSiteName ) ).not.toBeAttached();
+
+		expect( await pathExists( path.join( session.homePath, 'Studio', keepDirSiteName ) ) ).toBe( true );
+	} );
+
+	skipTestOnWindows( 'delete site and remove directory from disk', async () => {
+		const secondSiteName = 'E2E-Test-Site-2';
+
+		const sidebar = new MainSidebar( session.mainWindow );
+		const modal = await sidebar.openAddSiteModal();
+
+		await expect( modal.createSiteButton ).toBeVisible();
+		await modal.createSiteButton.click();
+
+		await modal.siteNameInput.fill( secondSiteName );
+		await modal.addSiteButton.click();
+
+		const siteTitle = sidebar.getSiteNavButton( secondSiteName );
+		await expect( siteTitle ).toHaveText( secondSiteName );
+
+		const siteContent = new SiteContent( session.mainWindow, secondSiteName );
+		await expect( siteContent.runningButton ).toBeAttached( { timeout: 120_000 } );
+
 		const settingsTab = await siteContent.navigateToTab( 'Settings' );
 
 		// Playwright lacks support for interacting with native dialogs, so we mock
@@ -106,11 +164,10 @@ test.describe( 'Servers', () => {
 		} );
 		await settingsTab.openDeleteSiteModal();
 
-		await session.mainWindow.waitForTimeout( 200 ); // Short pause for site to delete.
+		await session.mainWindow.waitForTimeout( 200 );
 
-		const sidebar = new MainSidebar( session.mainWindow );
-		await expect( sidebar.getSiteNavButton( siteName ) ).not.toBeAttached();
+		await expect( sidebar.getSiteNavButton( secondSiteName ) ).not.toBeAttached();
 
-		expect( await pathExists( path.join( session.homePath, 'Studio', siteName ) ) ).toBe( false );
+		expect( await pathExists( path.join( session.homePath, 'Studio', secondSiteName ) ) ).toBe( false );
 	} );
 } );

--- a/e2e/sites.test.ts
+++ b/e2e/sites.test.ts
@@ -117,9 +117,11 @@ test.describe( 'Servers', () => {
 		} );
 		await settingsTab.openDeleteSiteModal();
 
-		await session.mainWindow.waitForTimeout( 200 );
+		await session.mainWindow.waitForTimeout( 1000 );
 
-		await expect( sidebar.getSiteNavButton( keepDirSiteName ) ).not.toBeAttached();
+		await expect( sidebar.getSiteNavButton( keepDirSiteName ) ).not.toBeAttached( {
+			timeout: 10000,
+		} );
 
 		expect( await pathExists( path.join( session.homePath, 'Studio', keepDirSiteName ) ) ).toBe( true );
 	} );
@@ -141,9 +143,11 @@ test.describe( 'Servers', () => {
 		} );
 		await settingsTab.openDeleteSiteModal();
 
-		await session.mainWindow.waitForTimeout( 200 );
+		await session.mainWindow.waitForTimeout( 1000 );
 
-		await expect( sidebar.getSiteNavButton( secondSiteName ) ).not.toBeAttached();
+		await expect( sidebar.getSiteNavButton( secondSiteName ) ).not.toBeAttached( {
+			timeout: 10000,
+		} );
 
 		expect( await pathExists( path.join( session.homePath, 'Studio', secondSiteName ) ) ).toBe( false );
 	} );

--- a/e2e/sites.test.ts
+++ b/e2e/sites.test.ts
@@ -17,6 +17,25 @@ test.describe( 'Servers', () => {
 	const siteName = 'E2E-Test-Site';
 	const defaultSiteName = 'My WordPress Website';
 
+	const createSite = async ( name: string ) => {
+		const sidebar = new MainSidebar( session.mainWindow );
+		const modal = await sidebar.openAddSiteModal();
+
+		await expect( modal.createSiteButton ).toBeVisible();
+		await modal.createSiteButton.click();
+
+		await modal.siteNameInput.fill( name );
+		await modal.addSiteButton.click();
+
+		const siteTitle = sidebar.getSiteNavButton( name );
+		await expect( siteTitle ).toHaveText( name );
+
+		const siteContent = new SiteContent( session.mainWindow, name );
+		await expect( siteContent.runningButton ).toBeAttached( { timeout: 120_000 } );
+
+		return { sidebar, siteContent };
+	};
+
 	test.beforeAll( async () => {
 		await session.launch();
 
@@ -39,24 +58,10 @@ test.describe( 'Servers', () => {
 	} );
 
 	test( 'create a new site', async () => {
-		const sidebar = new MainSidebar( session.mainWindow );
-		const modal = await sidebar.openAddSiteModal();
+		const { siteContent } = await createSite( siteName );
 
-		await expect( modal.createSiteButton ).toBeVisible();
-		await modal.createSiteButton.click();
-
-		await modal.siteNameInput.fill( siteName );
-		await modal.addSiteButton.click();
-
-		const siteTitle = sidebar.getSiteNavButton( siteName );
-		await expect( siteTitle ).toHaveText( siteName );
-
-		// Check the site is running
-		const siteContent = new SiteContent( session.mainWindow, siteName );
-		await expect( siteContent.runningButton ).toBeAttached( { timeout: 120_000 } );
 		expect( await siteContent.siteNameHeading ).toHaveText( siteName );
 
-		// Check a WordPress site has been created
 		expect(
 			await pathExists( path.join( session.homePath, 'Studio', siteName, 'wp-config.php' ) )
 		).toBe( true );
@@ -93,21 +98,7 @@ test.describe( 'Servers', () => {
 
 	skipTestOnWindows( 'delete site but keep directory on disk', async () => {
 		const keepDirSiteName = 'E2E-Test-Site-Keep-Dir';
-
-		const sidebar = new MainSidebar( session.mainWindow );
-		const modal = await sidebar.openAddSiteModal();
-
-		await expect( modal.createSiteButton ).toBeVisible();
-		await modal.createSiteButton.click();
-
-		await modal.siteNameInput.fill( keepDirSiteName );
-		await modal.addSiteButton.click();
-
-		const siteTitle = sidebar.getSiteNavButton( keepDirSiteName );
-		await expect( siteTitle ).toHaveText( keepDirSiteName );
-
-		const siteContent = new SiteContent( session.mainWindow, keepDirSiteName );
-		await expect( siteContent.runningButton ).toBeAttached( { timeout: 120_000 } );
+		const { sidebar, siteContent } = await createSite( keepDirSiteName );
 
 		expect(
 			await pathExists( path.join( session.homePath, 'Studio', keepDirSiteName, 'wp-config.php' ) )
@@ -135,21 +126,7 @@ test.describe( 'Servers', () => {
 
 	skipTestOnWindows( 'delete site and remove directory from disk', async () => {
 		const secondSiteName = 'E2E-Test-Site-2';
-
-		const sidebar = new MainSidebar( session.mainWindow );
-		const modal = await sidebar.openAddSiteModal();
-
-		await expect( modal.createSiteButton ).toBeVisible();
-		await modal.createSiteButton.click();
-
-		await modal.siteNameInput.fill( secondSiteName );
-		await modal.addSiteButton.click();
-
-		const siteTitle = sidebar.getSiteNavButton( secondSiteName );
-		await expect( siteTitle ).toHaveText( secondSiteName );
-
-		const siteContent = new SiteContent( session.mainWindow, secondSiteName );
-		await expect( siteContent.runningButton ).toBeAttached( { timeout: 120_000 } );
+		const { sidebar, siteContent } = await createSite( secondSiteName );
 
 		const settingsTab = await siteContent.navigateToTab( 'Settings' );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Proposed Changes

This PR adds e2e test for deleting sites: for the case when site directory should be on disk and when it should be removed from the disk. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
* Run `npm run make`
* Run `npm run e2e`
* Confirm that the tests are passing
* Look through the code and ensure it makes sense

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
