### PR TITLE
Make Claude PR review workflow trigger only on label

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -2,10 +2,11 @@ name: Claude PR Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize, ready_for_review, reopened]
+    types: [labeled]
 
 jobs:
   code-review:
+    if: github.event.label.name == 'claude-review'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- Changes Claude PR review workflow from automatic triggers (on every PR update) to manual opt-in via label
- Workflow now only runs when the `claude-review` label is added to a PR

## Motivation
The automatic PR review workflow was running too frequently and creating spam. This change allows developers to request Claude reviews only when needed.

## How to use
1. Add the `claude-review` label to any PR where you want a Claude code review
2. The workflow will trigger automatically
3. Remove the label after review if desired

## Notes
- The `claude-review` label needs to be created in the repo if it doesn't exist yet
- This reduces noise while keeping the powerful code review capability available on demand