### PR TITLE
Add E2E tests for creating sites with site name and path params

### DIFF
--- a/e2e/blueprints.test.ts
+++ b/e2e/blueprints.test.ts
@@ -1,12 +1,12 @@
 import path from 'path';
 import { test, expect } from '@playwright/test';
-import fs from 'fs-extra';
 import { E2ESession } from './e2e-helpers';
 import MainSidebar from './page-objects/main-sidebar';
 import Onboarding from './page-objects/onboarding';
 import SiteContent from './page-objects/site-content';
 import WhatsNewModal from './page-objects/whats-new-modal';
 import { getUrlWithAutoLogin } from './utils';
+import { DEFAULT_SITE_NAME } from './constants';
 
 test.describe( 'Blueprints', () => {
 	const session = new E2ESession();
@@ -24,7 +24,7 @@ test.describe( 'Blueprints', () => {
 			await whatsNewModal.closeButton.click();
 		}
 
-		const siteContent = new SiteContent( session.mainWindow, 'My WordPress Website' );
+		const siteContent = new SiteContent( session.mainWindow, DEFAULT_SITE_NAME );
 		await expect( siteContent.siteNameHeading ).toBeVisible( { timeout: 120_000 } );
 	} );
 
@@ -137,7 +137,7 @@ test.describe( 'Blueprints', () => {
 		const wpAdminUrl = await settingsTab.copyWPAdminUrlToClipboard( session.electronApp );
 
 		// Verify plugin was installed
-		const pluginsUrl =  wpAdminUrl + '/plugins.php' ;
+		const pluginsUrl = wpAdminUrl + '/plugins.php';
 		await page.goto( getUrlWithAutoLogin( pluginsUrl ) );
 		await expect( page.locator( 'tr[data-slug="akismet"]' ) ).toBeVisible();
 	} );
@@ -250,7 +250,7 @@ test.describe( 'Blueprints', () => {
 		const wpAdminUrl = await settingsTab.copyWPAdminUrlToClipboard( session.electronApp );
 
 		// Verify the site was created successfully and admin is accessible
-		const optionsGeneralUrl = wpAdminUrl + '/options-general.php'
+		const optionsGeneralUrl = wpAdminUrl + '/options-general.php';
 		await page.goto( getUrlWithAutoLogin( optionsGeneralUrl ) );
 		await expect( page.getByLabel( 'Site Title' ) ).toBeVisible();
 

--- a/e2e/constants.ts
+++ b/e2e/constants.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_SITE_NAME = 'My WordPress Website';

--- a/e2e/e2e-helpers.ts
+++ b/e2e/e2e-helpers.ts
@@ -13,12 +13,14 @@ export class E2ESession {
 	appDataPath: string;
 	homePath: string;
 
-	async launch( testEnv: NodeJS.ProcessEnv = {} ) {
+	public constructor() {
 		// Create temporary folder to hold application data
 		this.sessionPath = path.join( tmpdir(), `studio-app-e2e-session-${ randomUUID() }` );
 		this.appDataPath = path.join( this.sessionPath, 'appData' );
 		this.homePath = path.join( this.sessionPath, 'home' );
+	}
 
+	async launch( testEnv: NodeJS.ProcessEnv = {} ) {
 		await fs.mkdir( this.appDataPath, { recursive: true } );
 		await fs.mkdir( this.homePath, { recursive: true } );
 

--- a/e2e/page-objects/onboarding.ts
+++ b/e2e/page-objects/onboarding.ts
@@ -28,7 +28,7 @@ export default class Onboarding {
 		return this.locator.getByRole( 'button', { name: /Continue|Add site/ } );
 	}
 
-	async selectLocalPathForTesting() {
-		await this.siteForm.clickLocalPathButtonAndSelectFromEnv();
+	async selectLocalPathForTesting( partialExpectedPath: string ) {
+		await this.siteForm.clickLocalPathButtonAndSelectFromEnv( partialExpectedPath );
 	}
 }

--- a/e2e/page-objects/site-form.ts
+++ b/e2e/page-objects/site-form.ts
@@ -28,6 +28,7 @@ export default class SiteForm {
 	async clickLocalPathButtonAndSelectFromEnv() {
 		await this.advancedSettingsToggle.click();
 		await this.localPathButton.click();
+		// Wait an arbitrary amount of time for the IPC handler to resolve
 		await this.page.waitForTimeout( 1000 );
 	}
 }

--- a/e2e/page-objects/site-form.ts
+++ b/e2e/page-objects/site-form.ts
@@ -12,16 +12,22 @@ export default class SiteForm {
 	}
 
 	get localPathInput() {
-		return this.page.getByLabel( 'Local path' );
+		return this.page.getByTestId( 'local-path-input' );
 	}
 
 	private get localPathButton() {
 		return this.page.getByTestId( 'select-path-button' );
 	}
 
+	private get advancedSettingsToggle() {
+		return this.page.getByTestId( 'advanced-settings-button' );
+	}
+
 	// This usually opens an OS folder dialog, except we can't interact with it in Playwright.
 	// In tests the dialog returns the value of the E2E_OPEN_FOLDER_DIALOG environment variable.
 	async clickLocalPathButtonAndSelectFromEnv() {
+		await this.advancedSettingsToggle.click();
 		await this.localPathButton.click();
+		await this.page.waitForTimeout( 1000 );
 	}
 }

--- a/e2e/page-objects/site-form.ts
+++ b/e2e/page-objects/site-form.ts
@@ -1,4 +1,4 @@
-import { type Page } from '@playwright/test';
+import { expect, type Page } from '@playwright/test';
 
 export default class SiteForm {
 	private page: Page;
@@ -25,10 +25,11 @@ export default class SiteForm {
 
 	// This usually opens an OS folder dialog, except we can't interact with it in Playwright.
 	// In tests the dialog returns the value of the E2E_OPEN_FOLDER_DIALOG environment variable.
-	async clickLocalPathButtonAndSelectFromEnv() {
+	async clickLocalPathButtonAndSelectFromEnv( partialExpectedPath: string ) {
 		await this.advancedSettingsToggle.click();
 		await this.localPathButton.click();
-		// Wait an arbitrary amount of time for the IPC handler to resolve
-		await this.page.waitForTimeout( 1000 );
+		await expect( this.localPathInput ).toHaveValue( new RegExp( partialExpectedPath, 'i' ), {
+			timeout: 5000,
+		} );
 	}
 }

--- a/e2e/sites.test.ts
+++ b/e2e/sites.test.ts
@@ -16,18 +16,44 @@ const DEFAULT_SITE_NAME = 'My WordPress Website';
 test.describe( 'Servers', () => {
 	const session = new E2ESession();
 
-	async function completeOnboardingWithDefaults() {
-		await session.launch();
+	async function completeOnboardingWithParams(
+		customSiteName?: string,
+		customFolderName?: string
+	) {
+		const env: NodeJS.ProcessEnv = {};
 
-		// Complete onboarding before tests
+		if ( customFolderName ) {
+			const fullLocalPath = path.join( session.homePath, 'Studio', customFolderName );
+			await fs.mkdir( fullLocalPath, { recursive: true } );
+			env.E2E_OPEN_FOLDER_DIALOG = fullLocalPath;
+		}
+		await session.launch( env );
+
 		const onboarding = new Onboarding( session.mainWindow );
+
+		if ( customSiteName ) {
+			await onboarding.siteNameInput.fill( customSiteName );
+		}
+		await session.mainWindow.waitForTimeout( 1000 );
+		const siteName = await onboarding.siteNameInput.inputValue();
+
+		if ( customFolderName ) {
+			await onboarding.selectLocalPathForTesting();
+		}
+		const localPath = await onboarding.localPathInput.inputValue();
+
 		await expect( onboarding.heading ).toBeVisible();
 		await onboarding.continueButton.click();
 
 		await closeWhatsNew();
 
-		const siteContent = new SiteContent( session.mainWindow, DEFAULT_SITE_NAME );
+		const siteContent = new SiteContent( session.mainWindow, siteName );
 		await expect( siteContent.siteNameHeading ).toBeVisible( { timeout: 120_000 } );
+
+		return {
+			siteName,
+			localPath,
+		};
 	}
 
 	async function closeWhatsNew() {
@@ -45,34 +71,12 @@ test.describe( 'Servers', () => {
 		[ undefined, undefined ],
 		[ 'E2E-Test-Site', undefined ],
 		[ 'E2E-Test-Site 2', 'hello' ],
-	].forEach( ( [ siteName, shortLocalPath ] ) => {
-		test( `create site with name ${ siteName } and path ${ shortLocalPath }`, async () => {
-			const env: NodeJS.ProcessEnv = {};
-
-			if ( shortLocalPath ) {
-				const fullLocalPath = path.join( session.homePath, 'Studio', shortLocalPath );
-				await fs.mkdir( fullLocalPath, { recursive: true } );
-				env.E2E_OPEN_FOLDER_DIALOG = fullLocalPath;
-			}
-			await session.launch( env );
-
-			const onboarding = new Onboarding( session.mainWindow );
-
-			if ( siteName ) {
-				await onboarding.siteNameInput.fill( siteName );
-			} else {
-				siteName = await onboarding.siteNameInput.inputValue();
-			}
-
-			if ( shortLocalPath ) {
-				await onboarding.selectLocalPathForTesting();
-			}
-			const localPath = await onboarding.localPathInput.inputValue();
-
-			await expect( onboarding.heading ).toBeVisible();
-			await onboarding.continueButton.click();
-
-			await closeWhatsNew();
+	].forEach( ( [ customSiteName, customFolderName ] ) => {
+		test( `create site with name ${ customSiteName } and path ${ customFolderName }`, async () => {
+			const { siteName, localPath } = await completeOnboardingWithParams(
+				customSiteName,
+				customFolderName
+			);
 
 			// Check the site is running
 			const siteContent = new SiteContent( session.mainWindow, siteName );
@@ -98,7 +102,7 @@ test.describe( 'Servers', () => {
 	} );
 
 	test( 'change PHP version', async () => {
-		await completeOnboardingWithDefaults();
+		await completeOnboardingWithParams();
 
 		const newPhpVersion = ALLOWED_PHP_VERSIONS.find( ( v ) => v !== DEFAULT_PHP_VERSION ) || '8.2';
 
@@ -125,9 +129,9 @@ test.describe( 'Servers', () => {
 	} );
 
 	test( "edit site's settings in wp-admin", async ( { page } ) => {
-		await completeOnboardingWithDefaults();
+		const { siteName } = await completeOnboardingWithParams();
 
-		const siteContent = new SiteContent( session.mainWindow, DEFAULT_SITE_NAME );
+		const siteContent = new SiteContent( session.mainWindow, siteName );
 		const settingsTab = await siteContent.navigateToTab( 'Settings' );
 
 		const wpAdminUrl = await settingsTab.copyWPAdminUrlToClipboard( session.electronApp );
@@ -145,17 +149,11 @@ test.describe( 'Servers', () => {
 	} );
 
 	skipTestOnWindows( 'delete site but keep directory on disk', async () => {
-		await completeOnboardingWithDefaults();
+		const { siteName, localPath } = await completeOnboardingWithParams();
 
-		const sitePath = path.join(
-			session.homePath,
-			'Studio',
-			DEFAULT_SITE_NAME.replace( /\s/g, '-' )
-		);
+		expect( await pathExists( path.join( localPath, 'wp-config.php' ) ) ).toBe( true );
 
-		expect( await pathExists( path.join( sitePath, 'wp-config.php' ) ) ).toBe( true );
-
-		const siteContent = new SiteContent( session.mainWindow, DEFAULT_SITE_NAME );
+		const siteContent = new SiteContent( session.mainWindow, siteName );
 		const settingsTab = await siteContent.navigateToTab( 'Settings' );
 
 		// Playwright lacks support for interacting with native dialogs, so we mock
@@ -175,13 +173,13 @@ test.describe( 'Servers', () => {
 			timeout: 10000,
 		} );
 
-		expect( await pathExists( sitePath ) ).toBe( true );
+		expect( await pathExists( localPath ) ).toBe( true );
 	} );
 
 	skipTestOnWindows( 'delete site and remove directory from disk', async () => {
-		await completeOnboardingWithDefaults();
+		const { siteName, localPath } = await completeOnboardingWithParams();
 
-		const siteContent = new SiteContent( session.mainWindow, DEFAULT_SITE_NAME );
+		const siteContent = new SiteContent( session.mainWindow, siteName );
 		const settingsTab = await siteContent.navigateToTab( 'Settings' );
 
 		// Playwright lacks support for interacting with native dialogs, so we mock
@@ -197,12 +195,10 @@ test.describe( 'Servers', () => {
 		await session.mainWindow.waitForTimeout( 1000 );
 
 		const sidebar = new MainSidebar( session.mainWindow );
-		await expect( sidebar.getSiteNavButton( DEFAULT_SITE_NAME ) ).not.toBeAttached( {
+		await expect( sidebar.getSiteNavButton( siteName ) ).not.toBeAttached( {
 			timeout: 10000,
 		} );
 
-		expect( await pathExists( path.join( session.homePath, 'Studio', DEFAULT_SITE_NAME ) ) ).toBe(
-			false
-		);
+		expect( await pathExists( localPath ) ).toBe( false );
 	} );
 } );

--- a/e2e/sites.test.ts
+++ b/e2e/sites.test.ts
@@ -9,9 +9,9 @@ import SiteContent from './page-objects/site-content';
 import WhatsNewModal from './page-objects/whats-new-modal';
 import fs from 'fs-extra';
 import { getUrlWithAutoLogin } from './utils';
+import { DEFAULT_SITE_NAME } from './constants';
 
 const skipTestOnWindows = process.platform === 'win32' ? test.skip : test;
-const DEFAULT_SITE_NAME = 'My WordPress Website';
 
 test.describe( 'Servers', () => {
 	const session = new E2ESession();

--- a/e2e/sites.test.ts
+++ b/e2e/sites.test.ts
@@ -35,6 +35,7 @@ test.describe( 'Servers', () => {
 			await onboarding.siteNameInput.fill( customSiteName );
 		}
 		await session.mainWindow.waitForTimeout( 1000 );
+		await expect( onboarding.siteNameInput ).toHaveValue( /\S+/, { timeout: 5000 } );
 		const siteName = await onboarding.siteNameInput.inputValue();
 
 		if ( customFolderName ) {

--- a/e2e/sites.test.ts
+++ b/e2e/sites.test.ts
@@ -1,4 +1,3 @@
-import http from 'http';
 import path from 'path';
 import { test, expect } from '@playwright/test';
 import { pathExists } from '../common/lib/fs-utils';
@@ -8,36 +7,16 @@ import MainSidebar from './page-objects/main-sidebar';
 import Onboarding from './page-objects/onboarding';
 import SiteContent from './page-objects/site-content';
 import WhatsNewModal from './page-objects/whats-new-modal';
+import fs from 'fs-extra';
 import { getUrlWithAutoLogin } from './utils';
 
 const skipTestOnWindows = process.platform === 'win32' ? test.skip : test;
+const DEFAULT_SITE_NAME = 'My WordPress Website';
 
 test.describe( 'Servers', () => {
 	const session = new E2ESession();
 
-	const siteName = 'E2E-Test-Site';
-	const defaultSiteName = 'My WordPress Website';
-
-	const createSite = async ( name: string ) => {
-		const sidebar = new MainSidebar( session.mainWindow );
-		const modal = await sidebar.openAddSiteModal();
-
-		await expect( modal.createSiteButton ).toBeVisible();
-		await modal.createSiteButton.click();
-
-		await modal.siteNameInput.fill( name );
-		await modal.addSiteButton.click();
-
-		const siteTitle = sidebar.getSiteNavButton( name );
-		await expect( siteTitle ).toHaveText( name );
-
-		const siteContent = new SiteContent( session.mainWindow, name );
-		await expect( siteContent.runningButton ).toBeAttached( { timeout: 120_000 } );
-
-		return { sidebar, siteContent };
-	};
-
-	test.beforeAll( async () => {
+	async function completeOnboardingWithDefaults() {
 		await session.launch();
 
 		// Complete onboarding before tests
@@ -45,44 +24,85 @@ test.describe( 'Servers', () => {
 		await expect( onboarding.heading ).toBeVisible();
 		await onboarding.continueButton.click();
 
+		await closeWhatsNew();
+
+		const siteContent = new SiteContent( session.mainWindow, DEFAULT_SITE_NAME );
+		await expect( siteContent.siteNameHeading ).toBeVisible( { timeout: 120_000 } );
+	}
+
+	async function closeWhatsNew() {
 		const whatsNewModal = new WhatsNewModal( session.mainWindow );
 		if ( await whatsNewModal.locator.isVisible( { timeout: 5000 } ) ) {
 			await whatsNewModal.closeButton.click();
 		}
+	}
 
-		const siteContent = new SiteContent( session.mainWindow, defaultSiteName );
-		await expect( siteContent.siteNameHeading ).toBeVisible( { timeout: 120_000 } );
-	} );
-
-	test.afterAll( async () => {
+	test.afterEach( async () => {
 		await session.cleanup();
 	} );
 
-	test( 'create a new site', async () => {
-		const { siteContent } = await createSite( siteName );
+	[
+		[ undefined, undefined ],
+		[ 'E2E-Test-Site', undefined ],
+		[ 'E2E-Test-Site 2', 'hello' ],
+	].forEach( ( [ siteName, shortLocalPath ] ) => {
+		test( `create site with name ${ siteName } and path ${ shortLocalPath }`, async () => {
+			const env: NodeJS.ProcessEnv = {};
 
-		expect( await siteContent.siteNameHeading ).toHaveText( siteName );
+			if ( shortLocalPath ) {
+				const fullLocalPath = path.join( session.homePath, 'Studio', shortLocalPath );
+				await fs.mkdir( fullLocalPath, { recursive: true } );
+				env.E2E_OPEN_FOLDER_DIALOG = fullLocalPath;
+			}
+			await session.launch( env );
 
-		expect(
-			await pathExists( path.join( session.homePath, 'Studio', siteName, 'wp-config.php' ) )
-		).toBe( true );
+			const onboarding = new Onboarding( session.mainWindow );
 
-		await siteContent.navigateToTab( 'Settings' );
+			if ( siteName ) {
+				await onboarding.siteNameInput.fill( siteName );
+			} else {
+				siteName = await onboarding.siteNameInput.inputValue();
+			}
 
-		expect( await siteContent.frontendButton ).toBeVisible();
-		const frontendUrl = await siteContent.frontendButton.textContent();
-		expect( frontendUrl ).not.toBeNull();
-		const response = await new Promise< http.IncomingMessage >( ( resolve, reject ) => {
-			http.get( `http://${ frontendUrl }`, resolve ).on( 'error', reject );
+			if ( shortLocalPath ) {
+				await onboarding.selectLocalPathForTesting();
+			}
+			const localPath = await onboarding.localPathInput.inputValue();
+
+			await expect( onboarding.heading ).toBeVisible();
+			await onboarding.continueButton.click();
+
+			await closeWhatsNew();
+
+			// Check the site is running
+			const siteContent = new SiteContent( session.mainWindow, siteName );
+			await expect( siteContent.runningButton ).toBeAttached( { timeout: 120_000 } );
+			await expect( siteContent.siteNameHeading ).toHaveText( siteName );
+
+			const sidebar = new MainSidebar( session.mainWindow );
+			const siteTitle = sidebar.getSiteNavButton( siteName );
+			await expect( siteTitle ).toHaveText( siteName );
+
+			// Check a WordPress site has been created
+			expect( await pathExists( path.join( localPath, 'wp-config.php' ) ) ).toBe( true );
+
+			await siteContent.navigateToTab( 'Settings' );
+
+			await expect( siteContent.frontendButton ).toBeVisible();
+			const frontendUrl = await siteContent.frontendButton.textContent();
+			expect( frontendUrl ).not.toBeNull();
+			const response = await fetch( `http://${ frontendUrl }` );
+			expect( [ 200, 302 ] ).toContain( response.status );
+			expect( response.headers.get( 'content-type' ) ).toMatch( /text\/html/ );
 		} );
-		expect( [ 200, 302 ] ).toContain( response.statusCode );
-		expect( response.headers[ 'content-type' ] ).toMatch( /text\/html/ );
 	} );
 
 	test( 'change PHP version', async () => {
-		const newPhpVersion = ALLOWED_PHP_VERSIONS.find(v => v !== DEFAULT_PHP_VERSION) || '8.2';
+		await completeOnboardingWithDefaults();
 
-		const siteContent = new SiteContent( session.mainWindow, siteName );
+		const newPhpVersion = ALLOWED_PHP_VERSIONS.find( ( v ) => v !== DEFAULT_PHP_VERSION ) || '8.2';
+
+		const siteContent = new SiteContent( session.mainWindow, DEFAULT_SITE_NAME );
 		const settingsTab = await siteContent.navigateToTab( 'Settings' );
 
 		await settingsTab.editSiteButton.click();
@@ -105,7 +125,9 @@ test.describe( 'Servers', () => {
 	} );
 
 	test( "edit site's settings in wp-admin", async ( { page } ) => {
-		const siteContent = new SiteContent( session.mainWindow, siteName );
+		await completeOnboardingWithDefaults();
+
+		const siteContent = new SiteContent( session.mainWindow, DEFAULT_SITE_NAME );
 		const settingsTab = await siteContent.navigateToTab( 'Settings' );
 
 		const wpAdminUrl = await settingsTab.copyWPAdminUrlToClipboard( session.electronApp );
@@ -123,13 +145,17 @@ test.describe( 'Servers', () => {
 	} );
 
 	skipTestOnWindows( 'delete site but keep directory on disk', async () => {
-		const keepDirSiteName = 'E2E-Test-Site-Keep-Dir';
-		const { sidebar, siteContent } = await createSite( keepDirSiteName );
+		await completeOnboardingWithDefaults();
 
-		expect(
-			await pathExists( path.join( session.homePath, 'Studio', keepDirSiteName, 'wp-config.php' ) )
-		).toBe( true );
+		const sitePath = path.join(
+			session.homePath,
+			'Studio',
+			DEFAULT_SITE_NAME.replace( /\s/g, '-' )
+		);
 
+		expect( await pathExists( path.join( sitePath, 'wp-config.php' ) ) ).toBe( true );
+
+		const siteContent = new SiteContent( session.mainWindow, DEFAULT_SITE_NAME );
 		const settingsTab = await siteContent.navigateToTab( 'Settings' );
 
 		// Playwright lacks support for interacting with native dialogs, so we mock
@@ -142,20 +168,20 @@ test.describe( 'Servers', () => {
 			};
 		} );
 		await settingsTab.openDeleteSiteModal();
-
 		await session.mainWindow.waitForTimeout( 1000 );
 
-		await expect( sidebar.getSiteNavButton( keepDirSiteName ) ).not.toBeAttached( {
+		const sidebar = new MainSidebar( session.mainWindow );
+		await expect( sidebar.getSiteNavButton( DEFAULT_SITE_NAME ) ).not.toBeAttached( {
 			timeout: 10000,
 		} );
 
-		expect( await pathExists( path.join( session.homePath, 'Studio', keepDirSiteName ) ) ).toBe( true );
+		expect( await pathExists( sitePath ) ).toBe( true );
 	} );
 
 	skipTestOnWindows( 'delete site and remove directory from disk', async () => {
-		const secondSiteName = 'E2E-Test-Site-2';
-		const { sidebar, siteContent } = await createSite( secondSiteName );
+		await completeOnboardingWithDefaults();
 
+		const siteContent = new SiteContent( session.mainWindow, DEFAULT_SITE_NAME );
 		const settingsTab = await siteContent.navigateToTab( 'Settings' );
 
 		// Playwright lacks support for interacting with native dialogs, so we mock
@@ -168,13 +194,15 @@ test.describe( 'Servers', () => {
 			};
 		} );
 		await settingsTab.openDeleteSiteModal();
-
 		await session.mainWindow.waitForTimeout( 1000 );
 
-		await expect( sidebar.getSiteNavButton( secondSiteName ) ).not.toBeAttached( {
+		const sidebar = new MainSidebar( session.mainWindow );
+		await expect( sidebar.getSiteNavButton( DEFAULT_SITE_NAME ) ).not.toBeAttached( {
 			timeout: 10000,
 		} );
 
-		expect( await pathExists( path.join( session.homePath, 'Studio', secondSiteName ) ) ).toBe( false );
+		expect( await pathExists( path.join( session.homePath, 'Studio', DEFAULT_SITE_NAME ) ) ).toBe(
+			false
+		);
 	} );
 } );

--- a/e2e/sites.test.ts
+++ b/e2e/sites.test.ts
@@ -34,12 +34,11 @@ test.describe( 'Servers', () => {
 		if ( customSiteName ) {
 			await onboarding.siteNameInput.fill( customSiteName );
 		}
-		await session.mainWindow.waitForTimeout( 1000 );
 		await expect( onboarding.siteNameInput ).toHaveValue( /\S+/, { timeout: 5000 } );
 		const siteName = await onboarding.siteNameInput.inputValue();
 
 		if ( customFolderName ) {
-			await onboarding.selectLocalPathForTesting();
+			await onboarding.selectLocalPathForTesting( customFolderName );
 		}
 		const localPath = await onboarding.localPathInput.inputValue();
 

--- a/src/components/site-form.tsx
+++ b/src/components/site-form.tsx
@@ -34,6 +34,7 @@ interface FormPathInputComponentProps {
 	error?: string;
 	doesPathContainWordPress: boolean;
 	isDisabled: boolean;
+	id?: string;
 }
 
 interface FormImportComponentProps {
@@ -112,6 +113,7 @@ function FormPathInputComponent( {
 	error,
 	doesPathContainWordPress,
 	isDisabled = false,
+	id,
 }: FormPathInputComponentProps ) {
 	const { __ } = useI18n();
 	return (
@@ -136,14 +138,16 @@ function FormPathInputComponent( {
 				data-testid="select-path-button"
 				disabled={ isDisabled }
 				onClick={ onClick }
+				id={ id }
 			>
-				<TextControlComponent
+				<div
 					aria-hidden="true"
 					tabIndex={ -1 }
-					className="[&_.components-text-control\_\_input]:bg-transparent [&_.components-text-control\_\_input]:border-none [&_input]:pointer-events-none w-full"
-					value={ value }
+					className="w-full text-left pl-3 pt-3 h-10"
 					onChange={ () => {} }
-				/>
+				>
+					{ value }
+				</div>
 				<div aria-hidden="true" className="local-path-icon flex items-center py-[9px] px-2.5">
 					<FolderIcon className="text-[#3C434A]" />
 				</div>
@@ -156,6 +160,7 @@ function FormPathInputComponent( {
 						: ''
 				}
 			/>
+			<input type="hidden" data-testid="local-path-input" value={ value } />
 		</div>
 	);
 }
@@ -366,7 +371,11 @@ export const SiteForm = ( {
 				{ onSelectPath && (
 					<>
 						<div className="flex flex-row items-center mb-1">
-							<Button className="pl-0" onClick={ handleAdvancedSettingsClick }>
+							<Button
+								className="pl-0"
+								onClick={ handleAdvancedSettingsClick }
+								data-testid="advanced-settings-button"
+							>
 								<Icon size={ 24 } icon={ chevronIcon } className={ error && 'text-red-500' } />
 								<div className={ cx( 'text-[13px] leading-[16px] ml-2', error && 'text-red-500' ) }>
 									{ __( 'Advanced settings' ) }
@@ -390,7 +399,7 @@ export const SiteForm = ( {
 							) }
 						>
 							<div className={ cx( 'flex flex-col gap-1.5 leading-4 py-4' ) }>
-								<label onClick={ onSelectPath } className="font-semibold">
+								<label onClick={ onSelectPath } className="font-semibold" htmlFor="local-path">
 									{ __( 'Local path' ) }
 								</label>
 								<span className="text-a8c-gray-50 text-xs">
@@ -417,6 +426,7 @@ export const SiteForm = ( {
 									error={ error }
 									value={ sitePath }
 									onClick={ onSelectPath }
+									id="local-path"
 								/>
 								<div className="grid grid-cols-2 gap-4 mt-4">
 									<div className="flex flex-col gap-1.5 leading-4">

--- a/src/components/site-form.tsx
+++ b/src/components/site-form.tsx
@@ -399,7 +399,7 @@ export const SiteForm = ( {
 							) }
 						>
 							<div className={ cx( 'flex flex-col gap-1.5 leading-4 py-4' ) }>
-								<label onClick={ onSelectPath } className="font-semibold" htmlFor="local-path">
+								<label className="font-semibold" htmlFor="local-path">
 									{ __( 'Local path' ) }
 								</label>
 								<span className="text-a8c-gray-50 text-xs">

--- a/src/modules/add-site/tests/add-site.test.tsx
+++ b/src/modules/add-site/tests/add-site.test.tsx
@@ -337,9 +337,7 @@ describe( 'AddSite', () => {
 
 		expect( screen.getByDisplayValue( 'My WordPress Website changed' ) ).toBeVisible();
 		await user.click( screen.getByRole( 'button', { name: 'Advanced settings' } ) );
-		expect(
-			screen.getByDisplayValue( '/default_path/my-wordpress-website-changed' )
-		).toBeVisible();
+		expect( screen.getByText( '/default_path/my-wordpress-website-changed' ) ).toBeVisible();
 
 		await user.keyboard( '{Escape}' );
 		await waitFor( () => {
@@ -354,7 +352,7 @@ describe( 'AddSite', () => {
 
 		expect( screen.getByDisplayValue( 'My WordPress Website' ) ).toBeVisible();
 		await user.click( screen.getByRole( 'button', { name: 'Advanced settings' } ) );
-		expect( screen.getByDisplayValue( '/default_path/my-wordpress-website' ) ).toBeVisible();
+		expect( screen.getByText( '/default_path/my-wordpress-website' ) ).toBeVisible();
 	} );
 
 	it( 'should reset to the proposed path when the path is set to default app directory', async () => {
@@ -395,9 +393,7 @@ describe( 'AddSite', () => {
 		await user.click( screen.getByDisplayValue( 'My WordPress Website' ) );
 		await user.type( screen.getByDisplayValue( 'My WordPress Website' ), ' mutated' );
 
-		expect(
-			screen.getByDisplayValue( '/default_path/my-wordpress-website-mutated' )
-		).toBeVisible();
+		expect( screen.getByText( '/default_path/my-wordpress-website-mutated' ) ).toBeVisible();
 	} );
 
 	it( 'should display WordPress version dropdown', async () => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

–

## Proposed Changes

This PR updates `e2e/sites.test.ts` to include tests for the following scenarios:

- Create a new site with default name and path
- Create a new site with custom name and default path
- Create a new site with custom name and custom path

The PR also includes the following notable changes:

- In `SiteForm`, the site path selector previously rendered a visible `<input>` inside a `<button>`. This is invalid HTML, and it messed with the test selectors, so we fixed the DOM structure. 
- We added a `for` HTML attribute to the `Local path` label

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Run the E2E tests for the PR and ensure that they pass

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
