### PR TITLE
Fix lint errors in E2E tests

### DIFF
--- a/e2e/import-export.test.ts
+++ b/e2e/import-export.test.ts
@@ -4,13 +4,7 @@ import { E2ESession } from './e2e-helpers';
 import Onboarding from './page-objects/onboarding';
 import SiteContent from './page-objects/site-content';
 import WhatsNewModal from './page-objects/whats-new-modal';
-
-type DialogCall = {
-	type?: string;
-	title?: string;
-	message?: string;
-	[ key: string ]: unknown;
-};
+import type { MessageBoxOptions } from 'electron';
 
 test.describe( 'Import / Export', () => {
 	const session = new E2ESession();
@@ -61,13 +55,15 @@ test.describe( 'Import / Export', () => {
 		// See: https://github.com/microsoft/playwright/issues/21432
 		await session.electronApp.evaluate( ( { dialog } ) => {
 			// Create storage for dialog calls
-			( global as unknown as { testDialogCalls: DialogCall[] } ).testDialogCalls = [];
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			( global as any ).testDialogCalls = [];
 
 			// Mock the function to track calls
-			dialog.showMessageBox = async ( ...args: unknown[] ) => {
+			dialog.showMessageBox = async ( ...args: any[] ) => {
 				// Store the call details
-				const options = ( args.length === 2 ? args[ 1 ] : args[ 0 ] ) as DialogCall;
-				( global as unknown as { testDialogCalls: DialogCall[] } ).testDialogCalls.push( options );
+				const options = args.length === 2 ? args[ 1 ] : args[ 0 ];
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+				( global as any ).testDialogCalls.push( options );
 
 				// Auto-confirm by clicking the first button
 				return { response: 0, checkboxChecked: false };
@@ -81,19 +77,18 @@ test.describe( 'Import / Export', () => {
 		await importExportTab.uploadFile( invalidSqlPath );
 
 		// Wait for the error dialog to be shown (after the confirmation dialog)
-		let dialogCalls: DialogCall[] = [];
-		let errorDialog: DialogCall | undefined;
+		let dialogCalls: MessageBoxOptions[] = [];
+		let errorDialog: MessageBoxOptions | undefined;
 		await expect
 			.poll(
 				async () => {
 					dialogCalls = await session.electronApp.evaluate( () => {
-						return (
-							( global as unknown as { testDialogCalls?: DialogCall[] } ).testDialogCalls || []
-						);
+						// eslint-disable-next-line @typescript-eslint/no-explicit-any
+						return ( global as any ).testDialogCalls || [];
 					} );
 					// Look for the error dialog specifically
 					errorDialog = dialogCalls.find(
-						( call: DialogCall ) =>
+						( call ) =>
 							call.type === 'error' &&
 							( call.title?.includes( 'Failed importing site' ) ||
 								call.message?.includes( 'Failed importing site' ) )
@@ -107,11 +102,8 @@ test.describe( 'Import / Export', () => {
 			)
 			.toBeDefined();
 
-		const ensuredErrorDialog = errorDialog as DialogCall;
-		expect( ensuredErrorDialog ).toBeDefined();
-		expect( ensuredErrorDialog.type ).toBe( 'error' );
-		expect( ensuredErrorDialog.title || ensuredErrorDialog.message ).toContain(
-			'Failed importing site'
-		);
+		expect( errorDialog ).toBeDefined();
+		expect( errorDialog?.type ).toBe( 'error' );
+		expect( errorDialog?.title || errorDialog?.message ).toContain( 'Failed importing site' );
 	} );
 } );

--- a/e2e/import-export.test.ts
+++ b/e2e/import-export.test.ts
@@ -5,6 +5,13 @@ import Onboarding from './page-objects/onboarding';
 import SiteContent from './page-objects/site-content';
 import WhatsNewModal from './page-objects/whats-new-modal';
 
+type DialogCall = {
+	type?: string;
+	title?: string;
+	message?: string;
+	[ key: string ]: unknown;
+};
+
 test.describe( 'Import / Export', () => {
 	const session = new E2ESession();
 	const defaultSiteName = 'My WordPress Website';
@@ -54,13 +61,13 @@ test.describe( 'Import / Export', () => {
 		// See: https://github.com/microsoft/playwright/issues/21432
 		await session.electronApp.evaluate( ( { dialog } ) => {
 			// Create storage for dialog calls
-			( global as any ).testDialogCalls = [];
+			( global as unknown as { testDialogCalls: DialogCall[] } ).testDialogCalls = [];
 
 			// Mock the function to track calls
-			dialog.showMessageBox = async ( ...args: any[] ) => {
+			dialog.showMessageBox = async ( ...args: unknown[] ) => {
 				// Store the call details
-				const options = args.length === 2 ? args[ 1 ] : args[ 0 ];
-				( global as any ).testDialogCalls.push( options );
+				const options = ( args.length === 2 ? args[ 1 ] : args[ 0 ] ) as DialogCall;
+				( global as unknown as { testDialogCalls: DialogCall[] } ).testDialogCalls.push( options );
 
 				// Auto-confirm by clicking the first button
 				return { response: 0, checkboxChecked: false };
@@ -74,30 +81,37 @@ test.describe( 'Import / Export', () => {
 		await importExportTab.uploadFile( invalidSqlPath );
 
 		// Wait for the error dialog to be shown (after the confirmation dialog)
-		let dialogCalls: any[] = [];
-		let errorDialog: any;
-		await expect.poll(
-			async () => {
-				dialogCalls = await session.electronApp.evaluate( () => {
-					return ( global as any ).testDialogCalls || [];
-				} );
-				// Look for the error dialog specifically
-				errorDialog = dialogCalls.find(
-					( call: any ) =>
-						call.type === 'error' &&
-						( call.title?.includes( 'Failed importing site' ) ||
-							call.message?.includes( 'Failed importing site' ) )
-				);
-				return errorDialog;
-			},
-			{
-				timeout: 15000,
-				message: 'Expected error dialog to be shown',
-			}
-		).toBeDefined();
+		let dialogCalls: DialogCall[] = [];
+		let errorDialog: DialogCall | undefined;
+		await expect
+			.poll(
+				async () => {
+					dialogCalls = await session.electronApp.evaluate( () => {
+						return (
+							( global as unknown as { testDialogCalls?: DialogCall[] } ).testDialogCalls || []
+						);
+					} );
+					// Look for the error dialog specifically
+					errorDialog = dialogCalls.find(
+						( call: DialogCall ) =>
+							call.type === 'error' &&
+							( call.title?.includes( 'Failed importing site' ) ||
+								call.message?.includes( 'Failed importing site' ) )
+					);
+					return errorDialog;
+				},
+				{
+					timeout: 15000,
+					message: 'Expected error dialog to be shown',
+				}
+			)
+			.toBeDefined();
 
-		expect( errorDialog ).toBeDefined();
-		expect( errorDialog.type ).toBe( 'error' );
-		expect( errorDialog.title || errorDialog.message ).toContain( 'Failed importing site' );
+		const ensuredErrorDialog = errorDialog as DialogCall;
+		expect( ensuredErrorDialog ).toBeDefined();
+		expect( ensuredErrorDialog.type ).toBe( 'error' );
+		expect( ensuredErrorDialog.title || ensuredErrorDialog.message ).toContain(
+			'Failed importing site'
+		);
 	} );
 } );

--- a/e2e/import-export.test.ts
+++ b/e2e/import-export.test.ts
@@ -6,6 +6,10 @@ import SiteContent from './page-objects/site-content';
 import WhatsNewModal from './page-objects/whats-new-modal';
 import type { MessageBoxOptions } from 'electron';
 
+const global = globalThis as unknown as {
+	testDialogCalls?: MessageBoxOptions[];
+};
+
 test.describe( 'Import / Export', () => {
 	const session = new E2ESession();
 	const defaultSiteName = 'My WordPress Website';
@@ -55,15 +59,13 @@ test.describe( 'Import / Export', () => {
 		// See: https://github.com/microsoft/playwright/issues/21432
 		await session.electronApp.evaluate( ( { dialog } ) => {
 			// Create storage for dialog calls
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-			( global as any ).testDialogCalls = [];
+			global.testDialogCalls = [];
 
 			// Mock the function to track calls
-			dialog.showMessageBox = async ( ...args: any[] ) => {
+			dialog.showMessageBox = async ( ...args: unknown[] ) => {
 				// Store the call details
-				const options = args.length === 2 ? args[ 1 ] : args[ 0 ];
-				// eslint-disable-next-line @typescript-eslint/no-explicit-any
-				( global as any ).testDialogCalls.push( options );
+				const options = ( args.length === 2 ? args[ 1 ] : args[ 0 ] ) as MessageBoxOptions;
+				global.testDialogCalls?.push( options );
 
 				// Auto-confirm by clicking the first button
 				return { response: 0, checkboxChecked: false };
@@ -77,15 +79,13 @@ test.describe( 'Import / Export', () => {
 		await importExportTab.uploadFile( invalidSqlPath );
 
 		// Wait for the error dialog to be shown (after the confirmation dialog)
-		let dialogCalls: MessageBoxOptions[] = [];
 		let errorDialog: MessageBoxOptions | undefined;
 		await expect
 			.poll(
 				async () => {
-					dialogCalls = await session.electronApp.evaluate( () => {
-						// eslint-disable-next-line @typescript-eslint/no-explicit-any
-						return ( global as any ).testDialogCalls || [];
-					} );
+					const dialogCalls: MessageBoxOptions[] = await session.electronApp.evaluate(
+						() => global.testDialogCalls || []
+					);
 					// Look for the error dialog specifically
 					errorDialog = dialogCalls.find(
 						( call ) =>

--- a/e2e/page-objects/site-content.ts
+++ b/e2e/page-objects/site-content.ts
@@ -1,12 +1,6 @@
 import { type Page, expect } from '@playwright/test';
-import SettingsTab from './settings-tab';
 import ImportExportTab from './import-export-tab';
-
-type TabMap = {
-	'Preview': SettingsTab;
-	'Settings': SettingsTab;
-	'Import / Export': ImportExportTab;
-};
+import SettingsTab from './settings-tab';
 
 export default class SiteContent {
 	constructor(
@@ -45,7 +39,9 @@ export default class SiteContent {
 
 	async navigateToTab( tabName: 'Settings' ): Promise< SettingsTab >;
 	async navigateToTab( tabName: 'Import / Export' ): Promise< ImportExportTab >;
-	async navigateToTab( tabName: 'Preview' | 'Settings' | 'Import / Export' ): Promise< SettingsTab | ImportExportTab > {
+	async navigateToTab(
+		tabName: 'Preview' | 'Settings' | 'Import / Export'
+	): Promise< SettingsTab | ImportExportTab > {
 		const tabButton = this.getTabButton( tabName );
 		await tabButton.click();
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

N/A

## Proposed Changes

- fix several lint errors in E2E tests

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR branch.
2. Run `npm run lint`. It should pass.
3. Run `npm run e2e -- e2e/import-export.test.ts`. I should still pass.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
