### PR TITLE
Fix Log out button not having bottom border when focused

### DIFF
--- a/src/modules/user-settings/components/account-tab.tsx
+++ b/src/modules/user-settings/components/account-tab.tsx
@@ -14,7 +14,7 @@ export const UserInfo = ( {
 } ) => {
 	const { __ } = useI18n();
 	return (
-		<div className="flex w-full gap-5">
+		<div className="flex w-full gap-5 py-1">
 			<div className="flex w-full items-center gap-3">
 				<Tooltip text={ __( 'Edit profile' ) } placement="bottom">
 					<Button


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

N/A

## Proposed Changes

- Add some padding to container of `Log out` button to avoid losing the bottom border when focused

|Before | After|
|-------|------|
| <img width="2330" height="1648" alt="CleanShot 2025-11-18 at 20 00 15@2x" src="https://github.com/user-attachments/assets/ba5d48fd-7ce0-4a96-8011-560231e44b07" />| <img width="2330" height="1648" alt="CleanShot 2025-11-18 at 19 59 35@2x" src="https://github.com/user-attachments/assets/756c4be9-92b3-45f6-905e-1458e04c2b58" />|

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Apply this branch and run `npm start`
- Log in to WordPress.com if you are not already, and click on the user on the top navigation bar
- Press `Tab` until you see that the focus is set to the `Log out` button
- Verify that all the borders are visible

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
