### PR TITLE
Exclude the database folder and db.php file when pushing a site

### DIFF
--- a/src/lib/import-export/export/exporters/default-exporter.ts
+++ b/src/lib/import-export/export/exporters/default-exporter.ts
@@ -26,19 +26,27 @@ export class DefaultExporter extends EventEmitter implements Exporter {
 	private archiveBuilder!: archiver.Archiver;
 	private backup: BackupContents;
 	private readonly options: ExportOptions;
-	private readonly pathsToExclude = [
-		'wp-content/mu-plugins/sqlite-database-integration',
-		'wp-content/mu-plugins/0-allowed-redirect-hosts.php',
-		'wp-content/mu-plugins/0-check-theme-availability.php',
-		'wp-content/mu-plugins/0-deactivate-jetpack-modules.php',
-		'wp-content/mu-plugins/0-dns-functions.php',
-		'wp-content/mu-plugins/0-permalinks.php',
-		'wp-content/mu-plugins/0-wp-config-constants-polyfill.php',
-		'wp-content/mu-plugins/0-sqlite.php',
-		'wp-content/mu-plugins/0-thumbnails.php',
-		'wp-content/mu-plugins/0-https-for-reverse-proxy.php',
-		'wp-content/mu-plugins/0-sqlite-command.php',
-	];
+
+	private isExcludedPath( pathToCheck: string ) {
+		const pathsToExclude = [
+			'wp-content/mu-plugins/sqlite-database-integration',
+			'wp-content/database',
+			'wp-content/db.php',
+			'wp-content/mu-plugins/0-allowed-redirect-hosts.php',
+			'wp-content/mu-plugins/0-check-theme-availability.php',
+			'wp-content/mu-plugins/0-deactivate-jetpack-modules.php',
+			'wp-content/mu-plugins/0-dns-functions.php',
+			'wp-content/mu-plugins/0-permalinks.php',
+			'wp-content/mu-plugins/0-wp-config-constants-polyfill.php',
+			'wp-content/mu-plugins/0-sqlite.php',
+			'wp-content/mu-plugins/0-thumbnails.php',
+			'wp-content/mu-plugins/0-https-for-reverse-proxy.php',
+			'wp-content/mu-plugins/0-sqlite-command.php',
+		];
+		return pathsToExclude.some( ( pathToExclude ) =>
+			pathToCheck.startsWith( path.normalize( pathToExclude ) )
+		);
+	}
 
 	constructor( options: ExportOptions ) {
 		super();
@@ -177,11 +185,8 @@ export class DefaultExporter extends EventEmitter implements Exporter {
 				if ( stat.isDirectory() ) {
 					this.archiveBuilder.directory( fullPath, archivePath, ( entry ) => {
 						const fullArchivePath = path.join( archivePath, entry.name );
-						const isExcluded = this.pathsToExclude.some( ( pathToExclude ) =>
-							fullArchivePath.startsWith( path.normalize( pathToExclude ) )
-						);
 						if (
-							isExcluded ||
+							this.isExcludedPath( fullArchivePath ) ||
 							entry.name.includes( '.git' ) ||
 							entry.name.includes( 'node_modules' ) ||
 							entry.name.includes( 'cache' )
@@ -191,6 +196,9 @@ export class DefaultExporter extends EventEmitter implements Exporter {
 						return entry;
 					} );
 				} else {
+					if ( this.isExcludedPath( archivePath ) ) {
+						continue;
+					}
 					this.archiveBuilder.file( fullPath, { name: archivePath } );
 				}
 			}

--- a/src/lib/import-export/export/exporters/default-exporter.ts
+++ b/src/lib/import-export/export/exporters/default-exporter.ts
@@ -32,6 +32,7 @@ export class DefaultExporter extends EventEmitter implements Exporter {
 			'wp-content/mu-plugins/sqlite-database-integration',
 			'wp-content/database',
 			'wp-content/db.php',
+			'wp-content/debug.log',
 			'wp-content/mu-plugins/0-allowed-redirect-hosts.php',
 			'wp-content/mu-plugins/0-check-theme-availability.php',
 			'wp-content/mu-plugins/0-deactivate-jetpack-modules.php',

--- a/src/lib/import-export/tests/export/exporters/default-exporter.test.ts
+++ b/src/lib/import-export/tests/export/exporters/default-exporter.test.ts
@@ -603,19 +603,35 @@ platformTestSuite( 'DefaultExporter', ( { normalize } ) => {
 		const exporter = new DefaultExporter( options );
 		await exporter.export();
 
+		expect( fsPromises.stat ).toHaveBeenCalledWith(
+			normalize( '/path/to/site/wp-content/debug.log' )
+		);
 		expect( mockArchiver.file ).not.toHaveBeenCalledWith(
 			normalize( '/path/to/site/wp-content/debug.log' ),
 			{ name: 'wp-content/debug.log' }
 		);
+
+		expect( fsPromises.stat ).toHaveBeenCalledWith(
+			normalize( '/path/to/site/wp-content/db.php' )
+		);
 		expect( mockArchiver.file ).not.toHaveBeenCalledWith(
 			normalize( '/path/to/site/wp-content/db.php' ),
 			{ name: 'wp-content/db.php' }
+		);
+
+		expect( fsPromises.stat ).toHaveBeenCalledWith(
+			normalize( '/path/to/site/wp-content/database/.ht.sqlite' )
 		);
 		expect( mockArchiver.file ).not.toHaveBeenCalledWith(
 			normalize( '/path/to/site/wp-content/database/.ht.sqlite' ),
 			{ name: 'wp-content/database/.ht.sqlite' }
 		);
 
+		expect( fsPromises.stat ).toHaveBeenCalledWith(
+			normalize(
+				'/path/to/site/wp-content/mu-plugins/sqlite-database-integration/example-load.php'
+			)
+		);
 		expect( mockArchiver.file ).not.toHaveBeenCalledWith(
 			normalize(
 				'/path/to/site/wp-content/mu-plugins/sqlite-database-integration/example-load.php'

--- a/src/lib/import-export/tests/export/exporters/default-exporter.test.ts
+++ b/src/lib/import-export/tests/export/exporters/default-exporter.test.ts
@@ -132,8 +132,18 @@ platformTestSuite( 'DefaultExporter', ( { normalize } ) => {
 				isFile: () => true,
 			},
 			{
-				path: normalize( '/path/to/site' ),
-				name: 'wp-config.php',
+				path: normalize( '/path/to/site/wp-content' ),
+				name: 'debug.log',
+				isFile: () => true,
+			},
+			{
+				path: normalize( '/path/to/site/wp-content' ),
+				name: 'db.php',
+				isFile: () => true,
+			},
+			{
+				path: normalize( '/path/to/site/wp-content/database' ),
+				name: '.ht.sqlite',
 				isFile: () => true,
 			},
 		];
@@ -568,5 +578,32 @@ platformTestSuite( 'DefaultExporter', ( { normalize } ) => {
 			backupFile: normalize( '/path/to/test-backup.tar.gz' ),
 			sqlFiles: [],
 		} );
+	} );
+
+	it( "shouldn't include files like database, db.php and debug.log to the archive, even if specified", async () => {
+		const options = {
+			...mockOptions,
+			includes: {
+				database: true,
+				wpContent: true,
+			},
+			specificSelectionPaths: [ 'database/.ht.sqlite', 'db.php', 'debug.log' ],
+		};
+
+		const exporter = new DefaultExporter( options );
+		await exporter.export();
+
+		expect( mockArchiver.file ).not.toHaveBeenCalledWith(
+			normalize( '/path/to/site/wp-content/debug.log' ),
+			{ name: 'wp-content/debug.log' }
+		);
+		expect( mockArchiver.file ).not.toHaveBeenCalledWith(
+			normalize( '/path/to/site/wp-content/db.php' ),
+			{ name: 'wp-content/db.php' }
+		);
+		expect( mockArchiver.file ).not.toHaveBeenCalledWith(
+			normalize( '/path/to/site/wp-content/database/.ht.sqlite' ),
+			{ name: 'wp-content/database/.ht.sqlite' }
+		);
 	} );
 } );

--- a/src/lib/import-export/tests/export/exporters/default-exporter.test.ts
+++ b/src/lib/import-export/tests/export/exporters/default-exporter.test.ts
@@ -146,6 +146,11 @@ platformTestSuite( 'DefaultExporter', ( { normalize } ) => {
 				name: '.ht.sqlite',
 				isFile: () => true,
 			},
+			{
+				path: normalize( '/path/to/site/wp-content/mu-plugins/sqlite-database-integration' ),
+				name: 'example-load.php',
+				isFile: () => true,
+			},
 		];
 
 		( fsPromises.readdir as jest.Mock ).mockResolvedValue( mockFiles );
@@ -587,7 +592,12 @@ platformTestSuite( 'DefaultExporter', ( { normalize } ) => {
 				database: true,
 				wpContent: true,
 			},
-			specificSelectionPaths: [ 'database/.ht.sqlite', 'db.php', 'debug.log' ],
+			specificSelectionPaths: [
+				'database/.ht.sqlite',
+				'db.php',
+				'debug.log',
+				'mu-plugins/sqlite-database-integration/example-load.php',
+			],
 		};
 
 		const exporter = new DefaultExporter( options );
@@ -604,6 +614,13 @@ platformTestSuite( 'DefaultExporter', ( { normalize } ) => {
 		expect( mockArchiver.file ).not.toHaveBeenCalledWith(
 			normalize( '/path/to/site/wp-content/database/.ht.sqlite' ),
 			{ name: 'wp-content/database/.ht.sqlite' }
+		);
+
+		expect( mockArchiver.file ).not.toHaveBeenCalledWith(
+			normalize(
+				'/path/to/site/wp-content/mu-plugins/sqlite-database-integration/example-load.php'
+			),
+			{ name: 'wp-content/mu-plugins/sqlite-database-integration/example-load.php' }
 		);
 	} );
 } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-1009
- Related to https://github.com/Automattic/studio/issues/2063

## Proposed Changes

* Database folder and db.php were included when pushing the whole site after we enabled the selective push. This PR excludes them.
* Also exclude debug.log file
* Add tests to avoid including these files in the future

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Checkout this branch and apply this diff to produce an archive you can easily review:
```diff
diff --git a/src/ipc-handlers.ts b/src/ipc-handlers.ts
index 2222476e..a1054304 100644
--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -794,6 +794,9 @@ export async function exportSiteForPush(
 		const stats = fs.statSync( archivePath );
 		return { archivePath, archiveSizeInBytes: stats.size };
 	} finally {
+		const destCopyPath = `${ TEMP_DIR }site_${ id }_${ new Date().getTime() }.tar.gz`;
+		fs.copyFileSync( archivePath, destCopyPath );
+		shell.showItemInFolder( destCopyPath );
 		SYNC_ABORT_CONTROLLERS.delete( operationId );
 	}
 }
@@ -826,6 +829,8 @@ export async function pushArchive(
 		formData.push( [ 'options', optionsToSync.join( ',' ) ] );
 	}
 
+	return { success: true };
 	try {
 		await wpcom.req.post( {
 			path: `/sites/${ remoteSiteId }/studio-app/sync/import`,
```
- Run `npm start`
- Go to the sync tab and push your Studio site selecting both checkboxes (database and all files and folders)
- Observe that the finder opens a tar.gz
- Unzip the file
- Observe its contents
- Confirm the archive didn't include the `database` folder nor the `db.php` file.

| Before | After |
|--------|--------|
| <img width="573" height="248" alt="Screenshot 2025-11-18 at 18 48 41" src="https://github.com/user-attachments/assets/1d1a251a-ea63-4f31-a01e-630e3aa5c152" /> | <img width="496" height="186" alt="Screenshot 2025-11-18 at 19 32 44" src="https://github.com/user-attachments/assets/acee705f-194a-4219-9b74-88c015e032f9" /> |



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
