### PR TITLE
Fix sync options sent to the backend when pushing a site

### DIFF
--- a/src/modules/sync/lib/convert-tree-to-sync-options.ts
+++ b/src/modules/sync/lib/convert-tree-to-sync-options.ts
@@ -46,11 +46,11 @@ const convertTreeToSyncCategories = (
 		paths.add( nodePath );
 
 		// Determine which category this belongs to for optionsToSync
-		if ( nodePath.startsWith( 'plugins/' ) ) {
+		if ( nodePath.startsWith( 'plugins/' ) || nodePath === 'plugins' ) {
 			options.add( SYNC_OPTIONS.plugins );
-		} else if ( nodePath.startsWith( 'themes/' ) ) {
+		} else if ( nodePath.startsWith( 'themes/' ) || nodePath === 'themes' ) {
 			options.add( SYNC_OPTIONS.themes );
-		} else if ( nodePath.startsWith( 'uploads/' ) ) {
+		} else if ( nodePath.startsWith( 'uploads/' ) || nodePath === 'uploads' ) {
 			options.add( SYNC_OPTIONS.uploads );
 		} else {
 			options.add( SYNC_OPTIONS.contents );

--- a/src/modules/sync/tests/convert-tree-to-options-to-sync.tsx
+++ b/src/modules/sync/tests/convert-tree-to-options-to-sync.tsx
@@ -119,6 +119,124 @@ describe( 'convertTreeToPushOptions', () => {
 		} );
 	} );
 
+	it( 'returns ["plugins", "themes", "uploads", "contents"] when "All files and folders" is selected', () => {
+		const tree = createBaseTree();
+		tree[ 0 ].checked = true; // filesAndFolders
+		tree[ 1 ].checked = false; // sqls
+		const wpContentNode = tree[ 0 ].children![ 0 ];
+		wpContentNode.checked = true;
+		wpContentNode.children = [
+			{
+				id: 'local-wp-content/fonts',
+				name: 'fonts',
+				label: 'fonts',
+				checked: true,
+				type: 'folder',
+				path: 'wp-content/fonts',
+				pathId: 'wp-content/fonts',
+				children: [],
+			},
+			{
+				id: 'local-wp-content/mu-plugins',
+				name: 'mu-plugins',
+				label: 'mu-plugins',
+				checked: true,
+				type: 'folder',
+				path: 'wp-content/mu-plugins',
+				pathId: 'wp-content/mu-plugins',
+				children: [],
+			},
+			{
+				id: 'local-wp-content/plugins',
+				name: 'plugins',
+				label: 'plugins',
+				checked: true,
+				type: 'folder',
+				path: 'wp-content/plugins',
+				pathId: 'wp-content/plugins',
+				children: [
+					{
+						id: 'local-wp-content/plugins/akismet',
+						name: 'akismet',
+						label: 'akismet',
+						checked: true,
+						type: 'plugin',
+						path: 'wp-content/plugins/akismet',
+						pathId: 'wp-content/plugins/akismet',
+						children: [],
+					},
+				],
+				indeterminate: false,
+			},
+			{
+				id: 'local-wp-content/themes',
+				name: 'themes',
+				label: 'themes',
+				checked: true,
+				type: 'folder',
+				path: 'wp-content/themes',
+				pathId: 'wp-content/themes',
+				children: [
+					{
+						id: 'local-wp-content/themes/twentytwentyfive',
+						name: 'twentytwentyfive',
+						label: 'twentytwentyfive',
+						checked: true,
+						type: 'theme',
+						path: 'wp-content/themes/twentytwentyfive',
+						pathId: 'wp-content/themes/twentytwentyfive',
+						children: [],
+					},
+				],
+				indeterminate: false,
+			},
+			{
+				id: 'local-wp-content/uploads',
+				name: 'uploads',
+				label: 'uploads',
+				checked: true,
+				type: 'folder',
+				path: 'wp-content/uploads',
+				pathId: 'wp-content/uploads',
+				children: [
+					{
+						id: 'local-wp-content/uploads/2025',
+						name: '2025',
+						label: '2025',
+						checked: true,
+						type: 'folder',
+						path: 'wp-content/uploads/2025',
+						pathId: 'wp-content/uploads/2025',
+						children: [],
+						indeterminate: false,
+					},
+				],
+				indeterminate: false,
+			},
+			{
+				id: 'local-wp-content/index-php',
+				name: 'index.php',
+				label: 'index.php',
+				checked: true,
+				type: 'file',
+				path: 'wp-content/index.php',
+				pathId: 'wp-content/index.php',
+			},
+		];
+		const optionsToSync = convertTreeToPushOptions( tree );
+		expect( optionsToSync ).toEqual( {
+			optionsToSync: [ 'contents', 'plugins', 'themes', 'uploads' ],
+			specificSelectionPaths: [
+				'fonts',
+				'mu-plugins',
+				'plugins',
+				'themes',
+				'uploads',
+				'index.php',
+			],
+		} );
+	} );
+
 	describe( 'partial selections', () => {
 		it( 'returns partial plugins selection when only some plugins are selected', () => {
 			const tree = createBaseTree();


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-1003

## Proposed Changes

- Fix options sent to the backend when pushing a site when selecting the `All files and folders` option.
- Add a specific test case to validate the conversion from tree to options.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Checkout this branch and apply this diff
```diff
diff --git a/src/ipc-handlers.ts b/src/ipc-handlers.ts
index 2222476e..40fcbdbf 100644
--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -826,6 +826,8 @@ export async function pushArchive(
 		formData.push( [ 'options', optionsToSync.join( ',' ) ] );
 	}
 
+	console.log( 'formData', formData );
+	return { success: true }; // don't add this line if you want to test also the email
 	try {
 		await wpcom.req.post( {
 			path: `/sites/${ remoteSiteId }/studio-app/sync/import`,
```
- Run `npm start`
- Go to the sync tab and click push
- Select "All files and folders"
- Click Push
- Observe that it appears `[ 'options', 'contents,plugins,themes,uploads' ]` in the node console. Before this PR the options sent were only `contents`.
- Test other cases

<img width="915" height="760" alt="Screenshot 2025-11-19 at 10 54 18" src="https://github.com/user-attachments/assets/9d9a1256-68a5-4fb1-b88b-d67255ad7d3f" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
