### PR TITLE
Blueprints: Update validation

### DIFF
--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -18,7 +18,6 @@ import https from 'node:https';
 import nodePath from 'path';
 import * as Sentry from '@sentry/electron/main';
 import { __, sprintf, LocaleData, defaultI18n } from '@wordpress/i18n';
-import { compileBlueprint } from '@wp-playground/blueprints';
 import archiver from 'archiver';
 import { z } from 'zod';
 import {
@@ -39,7 +38,7 @@ import { ARCHIVER_OPTIONS, DEFAULT_TERMINAL, MAIN_MIN_WIDTH, SIDEBAR_WIDTH } fro
 import { sendIpcEventToRenderer, sendIpcEventToRendererWithWindow } from 'src/ipc-utils';
 import { ACTIVE_SYNC_OPERATIONS } from 'src/lib/active-sync-operations';
 import { getBetaFeatures as getBetaFeaturesFromLib } from 'src/lib/beta-features';
-import { scanBlueprintForUnsupportedFeatures } from 'src/lib/blueprint-features';
+import { validateBlueprintData } from 'src/lib/blueprint-features';
 import { bumpStat } from 'src/lib/bump-stats';
 import { getImporterMetric, getBlueprintMetric } from 'src/lib/bump-stats/lib';
 import {
@@ -1846,27 +1845,7 @@ export async function validateBlueprint(
 	error?: string;
 	warnings?: Array< { feature: string; reason: string; alternative?: string } >;
 } > {
-	try {
-		await compileBlueprint( blueprintJson );
-	} catch ( error ) {
-		const errorMessage = error instanceof Error ? error.message : __( 'Invalid Blueprint format' );
-		return {
-			valid: false,
-			error: errorMessage,
-		};
-	}
-
-	const unsupportedFeatures = scanBlueprintForUnsupportedFeatures( blueprintJson );
-
-	const warnings = unsupportedFeatures.map( ( feature ) => ( {
-		feature: feature.name,
-		reason: feature.reason,
-	} ) );
-
-	return {
-		valid: true,
-		warnings: warnings.length > 0 ? warnings : undefined,
-	};
+	return validateBlueprintData( blueprintJson );
 }
 
 export async function readBlueprintFile(

--- a/src/lib/blueprint-features.ts
+++ b/src/lib/blueprint-features.ts
@@ -1,4 +1,5 @@
 import { __ } from '@wordpress/i18n';
+import { compileBlueprint } from '@wp-playground/blueprints';
 import { Blueprint } from 'src/stores/wpcom-api';
 
 interface UnsupportedFeature {
@@ -112,4 +113,39 @@ export function filterUnsupportedBlueprintFeatures(
 	}
 
 	return filtered;
+}
+
+export interface BlueprintValidationResult {
+	valid: boolean;
+	error?: string;
+	warnings?: Array< { feature: string; reason: string; alternative?: string } >;
+}
+
+/**
+ * Validates a blueprint by compiling it and scanning for unsupported features.
+ */
+export async function validateBlueprintData(
+	blueprintJson: Blueprint[ 'blueprint' ]
+): Promise< BlueprintValidationResult > {
+	try {
+		await compileBlueprint( blueprintJson );
+	} catch ( error ) {
+		const errorMessage = error instanceof Error ? error.message : __( 'Invalid Blueprint format' );
+		return {
+			valid: false,
+			error: errorMessage,
+		};
+	}
+
+	const unsupportedFeatures = scanBlueprintForUnsupportedFeatures( blueprintJson );
+
+	const warnings = unsupportedFeatures.map( ( feature ) => ( {
+		feature: feature.name,
+		reason: feature.reason,
+	} ) );
+
+	return {
+		valid: true,
+		warnings: warnings.length > 0 ? warnings : undefined,
+	};
 }

--- a/src/lib/deeplink/handlers/add-site-blueprint-with-url.ts
+++ b/src/lib/deeplink/handlers/add-site-blueprint-with-url.ts
@@ -4,6 +4,7 @@ import * as Sentry from '@sentry/electron/main';
 import { __ } from '@wordpress/i18n';
 import fs from 'fs-extra';
 import { sendIpcEventToRenderer } from 'src/ipc-utils';
+import { validateBlueprintData } from 'src/lib/blueprint-features';
 import { download } from 'src/lib/download';
 import { getMainWindow } from 'src/main-window';
 
@@ -71,6 +72,24 @@ export async function handleAddSiteWithBlueprint( urlObject: URL ): Promise< voi
 
 	try {
 		await download( decodedUrl, blueprintPath, false, 'blueprint' );
+
+		const blueprintJson = await fs.readJson( blueprintPath );
+		const validation = await validateBlueprintData( blueprintJson );
+
+		if ( ! validation.valid ) {
+			await fs.remove( blueprintPath ).catch( () => {
+				// Ignore cleanup errors
+			} );
+
+			await dialog.showMessageBox( mainWindow, {
+				type: 'error',
+				message: __( 'Blueprint validation failed' ),
+				detail: validation.error || __( 'Invalid Blueprint format' ),
+				buttons: [ __( 'OK' ) ],
+			} );
+			return;
+		}
+
 		await sendIpcEventToRenderer( 'add-site-blueprint-from-url', { blueprintPath } );
 	} catch ( error ) {
 		console.error( 'Failed to download blueprint from deeplink:', error );

--- a/src/lib/deeplink/handlers/add-site-blueprint-with-url.ts
+++ b/src/lib/deeplink/handlers/add-site-blueprint-with-url.ts
@@ -11,8 +11,8 @@ import { getMainWindow } from 'src/main-window';
 /**
  * Handles the add-site deeplink callback.
  * This function is called when a user clicks a deeplink like:
- * - wpcom-local-dev://add-site?blueprint_url=<encoded-url>
- * - wpcom-local-dev://add-site?blueprint=<base64-encoded-json>
+ * - wp-studio://add-site?blueprint_url=<encoded-url>
+ * - wp-studio://add-site?blueprint=<base64-encoded-json>
  *
  * It either downloads the blueprint from the URL or decodes the base64 blueprint,
  * and opens the Add Site modal with the blueprint pre-filled.

--- a/src/lib/deeplink/tests/add-site.test.ts
+++ b/src/lib/deeplink/tests/add-site.test.ts
@@ -4,6 +4,7 @@
 import { app, dialog, BrowserWindow } from 'electron';
 import fs from 'fs-extra';
 import { sendIpcEventToRenderer } from 'src/ipc-utils';
+import { validateBlueprintData } from 'src/lib/blueprint-features';
 import { handleAddSiteWithBlueprint } from 'src/lib/deeplink/handlers/add-site-blueprint-with-url';
 import { download } from 'src/lib/download';
 import { getMainWindow } from 'src/main-window';
@@ -33,8 +34,14 @@ describe( 'handleAddSiteWithBlueprint', () => {
 		focus: jest.fn(),
 	} as unknown as BrowserWindow;
 
+	const createBlueprintUrl = ( blueprintUrl: string ) => {
+		const encodedUrl = encodeURIComponent( blueprintUrl );
+		return new URL( `wpcom-local-dev://add-site?blueprint_url=${ encodedUrl }` );
+	};
+
 	beforeEach( () => {
 		jest.clearAllMocks();
+		( mockMainWindow.isMinimized as jest.Mock ).mockReturnValue( false );
 		jest.mocked( app.getPath ).mockReturnValue( '/tmp' );
 		( fs.mkdir as unknown as jest.Mock ).mockResolvedValue( undefined );
 		jest.mocked( getMainWindow ).mockResolvedValue( mockMainWindow );
@@ -46,12 +53,10 @@ describe( 'handleAddSiteWithBlueprint', () => {
 
 	it( 'should handle add-site with valid blueprint_url', async () => {
 		const blueprintUrl = 'https://example.com/blueprint.json';
-		const encodedUrl = encodeURIComponent( blueprintUrl );
-		const url = new URL( `wpcom-local-dev://add-site?blueprint_url=${ encodedUrl }` );
+		const url = createBlueprintUrl( blueprintUrl );
 
-		const { validateBlueprintData } = await import( 'src/lib/blueprint-features' );
 		jest.mocked( download ).mockResolvedValue( undefined );
-		( fs.readJson as unknown as jest.Mock ).mockResolvedValue( { steps: [] } );
+		jest.mocked( fs.readJson ).mockResolvedValue( { steps: [] } );
 		jest.mocked( validateBlueprintData ).mockResolvedValue( { valid: true } );
 
 		await handleAddSiteWithBlueprint( url );
@@ -90,9 +95,7 @@ describe( 'handleAddSiteWithBlueprint', () => {
 	} );
 
 	it( 'should handle download failure gracefully', async () => {
-		const blueprintUrl = 'https://example.com/blueprint.json';
-		const encodedUrl = encodeURIComponent( blueprintUrl );
-		const url = new URL( `wpcom-local-dev://add-site?blueprint_url=${ encodedUrl }` );
+		const url = createBlueprintUrl( 'https://example.com/blueprint.json' );
 
 		const downloadError = new Error( 'Download failed' );
 		jest.mocked( download ).mockRejectedValue( downloadError );
@@ -112,11 +115,8 @@ describe( 'handleAddSiteWithBlueprint', () => {
 	} );
 
 	it( 'should restore and focus window when minimized', async () => {
-		const blueprintUrl = 'https://example.com/blueprint.json';
-		const encodedUrl = encodeURIComponent( blueprintUrl );
-		const url = new URL( `wpcom-local-dev://add-site?blueprint_url=${ encodedUrl }` );
+		const url = createBlueprintUrl( 'https://example.com/blueprint.json' );
 
-		const { validateBlueprintData } = await import( 'src/lib/blueprint-features' );
 		( mockMainWindow.isMinimized as jest.Mock ).mockReturnValue( true );
 		jest.mocked( download ).mockResolvedValue( undefined );
 		( fs.readJson as unknown as jest.Mock ).mockResolvedValue( { steps: [] } );
@@ -129,9 +129,7 @@ describe( 'handleAddSiteWithBlueprint', () => {
 	} );
 
 	it( 'should handle cleanup errors gracefully on download failure', async () => {
-		const blueprintUrl = 'https://example.com/blueprint.json';
-		const encodedUrl = encodeURIComponent( blueprintUrl );
-		const url = new URL( `wpcom-local-dev://add-site?blueprint_url=${ encodedUrl }` );
+		const url = createBlueprintUrl( 'https://example.com/blueprint.json' );
 
 		const downloadError = new Error( 'Download failed' );
 		jest.mocked( download ).mockRejectedValue( downloadError );
@@ -143,11 +141,8 @@ describe( 'handleAddSiteWithBlueprint', () => {
 	} );
 
 	it( 'should handle invalid blueprint and show error dialog', async () => {
-		const blueprintUrl = 'https://example.com/blueprint.json';
-		const encodedUrl = encodeURIComponent( blueprintUrl );
-		const url = new URL( `wpcom-local-dev://add-site?blueprint_url=${ encodedUrl }` );
+		const url = createBlueprintUrl( 'https://example.com/blueprint.json' );
 
-		const { validateBlueprintData } = await import( 'src/lib/blueprint-features' );
 		jest.mocked( download ).mockResolvedValue( undefined );
 		( fs.readJson as unknown as jest.Mock ).mockResolvedValue( { invalid: 'data' } );
 		jest.mocked( validateBlueprintData ).mockResolvedValue( {

--- a/src/lib/deeplink/tests/add-site.test.ts
+++ b/src/lib/deeplink/tests/add-site.test.ts
@@ -36,7 +36,7 @@ describe( 'handleAddSiteWithBlueprint', () => {
 
 	const createBlueprintUrl = ( blueprintUrl: string ) => {
 		const encodedUrl = encodeURIComponent( blueprintUrl );
-		return new URL( `wpcom-local-dev://add-site?blueprint_url=${ encodedUrl }` );
+		return new URL( `wp-studio://add-site?blueprint_url=${ encodedUrl }` );
 	};
 
 	beforeEach( () => {
@@ -74,7 +74,7 @@ describe( 'handleAddSiteWithBlueprint', () => {
 	} );
 
 	it( 'should not send event if blueprint_url parameter is missing', async () => {
-		const url = new URL( 'wpcom-local-dev://add-site' );
+		const url = new URL( 'wp-studio://add-site' );
 
 		await handleAddSiteWithBlueprint( url );
 
@@ -85,7 +85,7 @@ describe( 'handleAddSiteWithBlueprint', () => {
 	it( 'should handle invalid blueprint_url gracefully', async () => {
 		const invalidUrl = 'not-a-valid-url';
 		const encodedUrl = encodeURIComponent( invalidUrl );
-		const url = new URL( `wpcom-local-dev://add-site?blueprint_url=${ encodedUrl }` );
+		const url = new URL( `wp-studio://add-site?blueprint_url=${ encodedUrl }` );
 
 		await handleAddSiteWithBlueprint( url );
 
@@ -172,7 +172,7 @@ describe( 'handleAddSiteWithBlueprint', () => {
 			};
 			const blueprintJson = JSON.stringify( blueprintData );
 			const blueprintBase64 = Buffer.from( blueprintJson ).toString( 'base64' );
-			const url = new URL( `wpcom-local-dev://add-site?blueprint=${ blueprintBase64 }` );
+			const url = new URL( `wp-studio://add-site?blueprint=${ blueprintBase64 }` );
 
 			await handleAddSiteWithBlueprint( url );
 
@@ -183,7 +183,7 @@ describe( 'handleAddSiteWithBlueprint', () => {
 		} );
 
 		it( 'should handle invalid base64-encoded blueprint and display error message', async () => {
-			const url = new URL( 'wpcom-local-dev://add-site?blueprint=invalid-base64!!!' );
+			const url = new URL( 'wp-studio://add-site?blueprint=invalid-base64!!!' );
 			await handleAddSiteWithBlueprint( url );
 
 			expect( sendIpcEventToRenderer ).not.toHaveBeenCalled();

--- a/src/lib/deeplink/tests/add-site.test.ts
+++ b/src/lib/deeplink/tests/add-site.test.ts
@@ -13,6 +13,9 @@ jest.mock( 'fs-extra' );
 jest.mock( 'src/ipc-utils' );
 jest.mock( 'src/lib/download' );
 jest.mock( 'src/main-window' );
+jest.mock( 'src/lib/blueprint-features', () => ( {
+	validateBlueprintData: jest.fn(),
+} ) );
 
 // Silence console.error output
 beforeAll( () => {
@@ -46,7 +49,10 @@ describe( 'handleAddSiteWithBlueprint', () => {
 		const encodedUrl = encodeURIComponent( blueprintUrl );
 		const url = new URL( `wpcom-local-dev://add-site?blueprint_url=${ encodedUrl }` );
 
+		const { validateBlueprintData } = await import( 'src/lib/blueprint-features' );
 		jest.mocked( download ).mockResolvedValue( undefined );
+		( fs.readJson as unknown as jest.Mock ).mockResolvedValue( { steps: [] } );
+		jest.mocked( validateBlueprintData ).mockResolvedValue( { valid: true } );
 
 		await handleAddSiteWithBlueprint( url );
 
@@ -110,8 +116,11 @@ describe( 'handleAddSiteWithBlueprint', () => {
 		const encodedUrl = encodeURIComponent( blueprintUrl );
 		const url = new URL( `wpcom-local-dev://add-site?blueprint_url=${ encodedUrl }` );
 
+		const { validateBlueprintData } = await import( 'src/lib/blueprint-features' );
 		( mockMainWindow.isMinimized as jest.Mock ).mockReturnValue( true );
 		jest.mocked( download ).mockResolvedValue( undefined );
+		( fs.readJson as unknown as jest.Mock ).mockResolvedValue( { steps: [] } );
+		jest.mocked( validateBlueprintData ).mockResolvedValue( { valid: true } );
 
 		await handleAddSiteWithBlueprint( url );
 
@@ -131,6 +140,33 @@ describe( 'handleAddSiteWithBlueprint', () => {
 		await expect( handleAddSiteWithBlueprint( url ) ).resolves.not.toThrow();
 
 		expect( dialog.showMessageBox ).toHaveBeenCalled();
+	} );
+
+	it( 'should handle invalid blueprint and show error dialog', async () => {
+		const blueprintUrl = 'https://example.com/blueprint.json';
+		const encodedUrl = encodeURIComponent( blueprintUrl );
+		const url = new URL( `wpcom-local-dev://add-site?blueprint_url=${ encodedUrl }` );
+
+		const { validateBlueprintData } = await import( 'src/lib/blueprint-features' );
+		jest.mocked( download ).mockResolvedValue( undefined );
+		( fs.readJson as unknown as jest.Mock ).mockResolvedValue( { invalid: 'data' } );
+		jest.mocked( validateBlueprintData ).mockResolvedValue( {
+			valid: false,
+			error: 'Invalid blueprint format',
+		} );
+		( fs.remove as unknown as jest.Mock ).mockResolvedValue( undefined );
+
+		await handleAddSiteWithBlueprint( url );
+
+		expect( download ).toHaveBeenCalled();
+		expect( sendIpcEventToRenderer ).not.toHaveBeenCalled();
+		expect( fs.remove ).toHaveBeenCalledWith( expect.stringContaining( 'blueprint-' ) );
+		expect( dialog.showMessageBox ).toHaveBeenCalledWith( mockMainWindow, {
+			type: 'error',
+			message: expect.any( String ),
+			detail: 'Invalid blueprint format',
+			buttons: expect.any( Array ),
+		} );
 	} );
 
 	describe( 'base64 blueprint handling', () => {

--- a/src/modules/add-site/hooks/use-blueprint-deeplink.ts
+++ b/src/modules/add-site/hooks/use-blueprint-deeplink.ts
@@ -1,5 +1,5 @@
 import { useI18n } from '@wordpress/react-i18n';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { useIpcListener } from 'src/hooks/use-ipc-listener';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 import { Blueprint } from 'src/stores/wpcom-api';
@@ -10,7 +10,6 @@ type BlueprintMetadata = {
 };
 
 interface UseBlueprintDeeplinkOptions {
-	showModal: boolean;
 	isAnySiteProcessing: boolean;
 	openModal: () => void;
 	setSelectedBlueprint: ( blueprint?: Blueprint ) => void;
@@ -31,7 +30,6 @@ export function useBlueprintDeeplink(
 ): UseBlueprintDeeplinkReturn {
 	const { __ } = useI18n();
 	const {
-		showModal,
 		isAnySiteProcessing,
 		openModal,
 		setSelectedBlueprint,
@@ -40,13 +38,11 @@ export function useBlueprintDeeplink(
 		setBlueprintPreferredVersions,
 	} = options;
 
-	const [ pendingBlueprintPath, setPendingBlueprintPath ] = useState< string | null >( null );
 	const [ initialNavigatorPath, setInitialNavigatorPath ] = useState< string >( '/' );
 	const [ blueprintError, setBlueprintError ] = useState< string | null >( null );
 
 	const resetDeeplinkState = useCallback( () => {
 		setInitialNavigatorPath( '/' );
-		setPendingBlueprintPath( null );
 		setBlueprintError( null );
 	}, [] );
 
@@ -94,11 +90,33 @@ export function useBlueprintDeeplink(
 			if ( isAnySiteProcessing ) {
 				return;
 			}
-			setPendingBlueprintPath( blueprintPath );
-			setInitialNavigatorPath( '/blueprint/create' );
-			openModal();
+			try {
+				const blueprintJson = await getIpcApi().readBlueprintFile( blueprintPath );
+
+				const fileName = blueprintPath.split( /[/\\]/ ).pop() || 'blueprint.json';
+				const fileBlueprint = createBlueprintFromData(
+					blueprintJson,
+					`file:${ fileName }`,
+					fileName.replace( '.json', '' ),
+					__( 'Blueprint loaded from URL' )
+				);
+
+				setSelectedBlueprint( fileBlueprint );
+				applyPreferredVersions( blueprintJson );
+				setInitialNavigatorPath( '/blueprint/create' );
+				openModal();
+			} catch ( error ) {
+				console.error( 'Failed to load blueprint from URL:', error );
+			}
 		},
-		[ isAnySiteProcessing, openModal ]
+		[
+			isAnySiteProcessing,
+			__,
+			createBlueprintFromData,
+			setSelectedBlueprint,
+			applyPreferredVersions,
+			openModal,
+		]
 	);
 	useIpcListener( 'add-site-blueprint-from-url', handleBlueprintFromUrl );
 
@@ -134,53 +152,6 @@ export function useBlueprintDeeplink(
 		]
 	);
 	useIpcListener( 'add-site-blueprint-from-base64', handleBlueprintFromBase64 );
-
-	// Load and set blueprint when modal opens with a pending blueprint
-	useEffect( () => {
-		if ( showModal && pendingBlueprintPath ) {
-			const loadBlueprintFromPath = async () => {
-				try {
-					const blueprintJson = await getIpcApi().readBlueprintFile( pendingBlueprintPath );
-
-					const validation = await getIpcApi().validateBlueprint( blueprintJson );
-
-					if ( ! validation.valid ) {
-						const errorMessage = validation.error || __( 'Invalid Blueprint format' );
-						throw new Error( errorMessage );
-					}
-
-					const fileName = pendingBlueprintPath.split( /[/\\]/ ).pop() || 'blueprint.json';
-					const fileBlueprint = createBlueprintFromData(
-						blueprintJson,
-						`file:${ fileName }`,
-						fileName.replace( '.json', '' ),
-						__( 'Blueprint loaded from URL' )
-					);
-
-					setSelectedBlueprint( fileBlueprint );
-					applyPreferredVersions( blueprintJson );
-					setPendingBlueprintPath( null );
-				} catch ( error ) {
-					const errorMessage =
-						error instanceof Error
-							? error.message
-							: __( 'Failed to load blueprint. Please check the blueprint file and try again.' );
-					setBlueprintError( errorMessage );
-					setPendingBlueprintPath( null );
-				}
-			};
-
-			void loadBlueprintFromPath();
-		}
-	}, [
-		showModal,
-		pendingBlueprintPath,
-		createBlueprintFromData,
-		setSelectedBlueprint,
-		applyPreferredVersions,
-		setBlueprintError,
-		__,
-	] );
 
 	return {
 		initialNavigatorPath,

--- a/src/modules/add-site/hooks/use-blueprint-deeplink.ts
+++ b/src/modules/add-site/hooks/use-blueprint-deeplink.ts
@@ -95,7 +95,7 @@ export function useBlueprintDeeplink(
 				return;
 			}
 			setPendingBlueprintPath( blueprintPath );
-			setInitialNavigatorPath( '/blueprint' );
+			setInitialNavigatorPath( '/blueprint/create' );
 			openModal();
 		},
 		[ isAnySiteProcessing, openModal ]

--- a/src/modules/add-site/index.tsx
+++ b/src/modules/add-site/index.tsx
@@ -379,7 +379,6 @@ export default function AddSite( { className, variant = 'outlined' }: AddSitePro
 
 	const { initialNavigatorPath, blueprintError, setBlueprintError, resetDeeplinkState } =
 		useBlueprintDeeplink( {
-			showModal,
 			isAnySiteProcessing,
 			openModal,
 			setSelectedBlueprint,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Resolves STU-1007
- Related to STU-1008

## Proposed Changes

- extract out the blueprint validation logic into utility `validateBlueprintData` function - so it can be reused easily
- display validation error message in a dialog when incorrect blueprint is passed in a deeplink
- remove unnecessary second deeplink blueprint validation from the renderer process
- update and add related unit tests
- ensure the deeplink that opens blueprint from a linked URL gets the user to the "Add a site" step directly (instead of the previous "Start from a Blueprint" step)

ℹ️ Please note that this PR does not add validation to the handling of deeplinks that include the base64-encoded blueprint. This is because we will have another PR that will refactor and unify the logic that handles both deeplink types: STU-1008.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR and build the app with `npm install && npm start`.
2. Try to open the blueprint deeplinks provided here: https://jsbin.com/levaburate/2/edit?html,css,output.
  - First two should result in a dialog error message.
  - The third one should get you to the "Add a site" step and allow you to create a new site with it.
3. Try to manually create sites using blueprint files from 39a4e-pb. The results should be as expected - there should be no regressions.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?