### PR TITLE
Force What's New modal to display in 1.6.4 (due to the new survey card) 

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -101,4 +101,4 @@ export const IPC_VOID_HANDLERS = < const >[
 ];
 
 // What's New
-export const FORCE_WHATS_NEW_WHEN_PATCH_CHANGED = false;
+export const FORCE_WHATS_NEW_WHEN_PATCH_CHANGED = true;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Related discussion p1763563680649809-slack-C06DRMD6VPZ

## Proposed Changes

- set `FORCE_WHATS_NEW_WHEN_PATCH_CHANGED` constant to `true` temporarily

We will put it back to `false` once the 1.6.4 version is released (or keep it in for longer - depending on the discussion).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR branch and build the app with `npm install && npm start`.
2. Change the `lastSeenVersion` in your `appdata-v1.json` to an earlier patch version.
3. When the app starts, the "What's New" modal should render (even though we are bumping just the patch version when the modal wouldn't normally show up).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?