### PR TITLE
Gate behind a feature flag the new Publish and Import buttons

### DIFF
--- a/src/modules/sync/components/connect-button.tsx
+++ b/src/modules/sync/components/connect-button.tsx
@@ -6,6 +6,7 @@ import { useOffline } from 'src/hooks/use-offline';
 
 interface ConnectButtonProps {
 	variant: ButtonVariant;
+	icon?: JSX.Element;
 	connectSite?: () => void;
 	disabled?: boolean;
 	className?: string;
@@ -16,6 +17,7 @@ interface ConnectButtonProps {
 
 export const ConnectButton = ( {
 	variant,
+	icon,
 	connectSite,
 	disabled,
 	className,
@@ -39,6 +41,7 @@ export const ConnectButton = ( {
 				disabled={ isDisabled }
 				aria-disabled={ isDisabled }
 				variant={ variant }
+				icon={ icon }
 				className={ className }
 				isBusy={ isBusy }
 			>

--- a/src/modules/sync/index.tsx
+++ b/src/modules/sync/index.tsx
@@ -7,6 +7,7 @@ import offlineIcon from 'src/components/offline-icon';
 import { Tooltip } from 'src/components/tooltip';
 import { useSyncSites } from 'src/hooks/sync-sites';
 import { useAuth } from 'src/hooks/use-auth';
+import { useFeatureFlags } from 'src/hooks/use-feature-flags';
 import { useOffline } from 'src/hooks/use-offline';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 import { ConnectButton } from 'src/modules/sync/components/connect-button';
@@ -134,6 +135,7 @@ export function ContentTabSync( { selectedSite }: { selectedSite: SiteDetails } 
 	const { connectSite, disconnectSite } = useConnectedSitesOperations();
 	const { pushSite, pullSite, isAnySitePulling, isAnySitePushing } = useSyncSites();
 	const isAnySiteSyncing = isAnySitePulling || isAnySitePushing;
+	const { streamlineOnboarding } = useFeatureFlags();
 
 	const [ selectedRemoteSite, setSelectedRemoteSite ] = useState< SyncSite | null >( null );
 	const [ pendingModalMode, setPendingModalMode ] = useState< 'push' | 'pull' | null >( null );
@@ -226,43 +228,54 @@ export function ContentTabSync( { selectedSite }: { selectedSite: SiteDetails } 
 				</div>
 			) : (
 				<SiteSyncDescription>
-					<div className="mt-8 flex flex-wrap gap-4">
-						<ConnectButton
-							variant="primary"
-							connectSite={ handleLaunchSite }
-							disabled={ isAnySiteSyncing || pendingModalMode !== null }
-							isBusy={ pendingModalMode === 'push' }
-							tooltipText={
-								pendingModalMode === 'pull'
-									? __( 'Please wait for the current operation to finish.' )
-									: isAnySiteSyncing
-									? __(
-											'Another site is syncing. Please wait for the sync to finish before you publish your site.'
-									  )
-									: __( 'Publishing your site requires an internet connection.' )
-							}
-						>
-							{ __( 'Publish site' ) }
-						</ConnectButton>
-						<ConnectButton
-							variant="secondary"
-							connectSite={ handleImportSite }
-							className={ isAnySiteSyncing ? '' : '!text-a8c-blue-50 !shadow-a8c-blue-50' }
-							disabled={ isAnySiteSyncing || pendingModalMode !== null }
-							isBusy={ pendingModalMode === 'pull' }
-							tooltipText={
-								pendingModalMode === 'push'
-									? __( 'Please wait for the current operation to finish.' )
-									: isAnySiteSyncing
-									? __(
-											'Another site is syncing. Please wait for the sync to finish before you pull a site.'
-									  )
-									: __( 'Importing a remote site requires an internet connection.' )
-							}
-						>
-							{ __( 'Pull site' ) }
-						</ConnectButton>
-					</div>
+					{ streamlineOnboarding ? (
+						<div className="mt-8 flex flex-wrap gap-4">
+							<ConnectButton
+								variant="primary"
+								connectSite={ handleLaunchSite }
+								disabled={ isAnySiteSyncing || pendingModalMode !== null }
+								isBusy={ pendingModalMode === 'push' }
+								tooltipText={
+									pendingModalMode === 'pull'
+										? __( 'Please wait for the current operation to finish.' )
+										: isAnySiteSyncing
+										? __(
+												'Another site is syncing. Please wait for the sync to finish before you publish your site.'
+										  )
+										: __( 'Publishing your site requires an internet connection.' )
+								}
+							>
+								{ __( 'Publish site' ) }
+							</ConnectButton>
+							<ConnectButton
+								variant="secondary"
+								connectSite={ handleImportSite }
+								className={ isAnySiteSyncing ? '' : '!text-a8c-blue-50 !shadow-a8c-blue-50' }
+								disabled={ isAnySiteSyncing || pendingModalMode !== null }
+								isBusy={ pendingModalMode === 'pull' }
+								tooltipText={
+									pendingModalMode === 'push'
+										? __( 'Please wait for the current operation to finish.' )
+										: isAnySiteSyncing
+										? __(
+												'Another site is syncing. Please wait for the sync to finish before you pull a site.'
+										  )
+										: __( 'Importing a remote site requires an internet connection.' )
+								}
+							>
+								{ __( 'Pull site' ) }
+							</ConnectButton>
+						</div>
+					) : (
+						<div className="mt-8">
+							<ConnectButton
+								variant="primary"
+								connectSite={ () => dispatch( connectedSitesActions.openModal( 'connect' ) ) }
+							>
+								{ __( 'Connect site' ) }
+							</ConnectButton>
+						</div>
+					) }
 				</SiteSyncDescription>
 			) }
 

--- a/src/modules/sync/index.tsx
+++ b/src/modules/sync/index.tsx
@@ -1,4 +1,4 @@
-import { check, Icon } from '@wordpress/icons';
+import { check, cloudUpload, Icon } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { PropsWithChildren, useEffect, useState } from 'react';
 import { ArrowIcon } from 'src/components/arrow-icon';
@@ -232,6 +232,7 @@ export function ContentTabSync( { selectedSite }: { selectedSite: SiteDetails } 
 						<div className="mt-8 flex flex-wrap gap-4">
 							<ConnectButton
 								variant="primary"
+								icon={ cloudUpload }
 								connectSite={ handleLaunchSite }
 								disabled={ isAnySiteSyncing || pendingModalMode !== null }
 								isBusy={ pendingModalMode === 'push' }

--- a/src/modules/sync/tests/index.test.tsx
+++ b/src/modules/sync/tests/index.test.tsx
@@ -5,6 +5,7 @@ import { SyncSitesProvider, useSyncSites } from 'src/hooks/sync-sites';
 import { SyncPushState } from 'src/hooks/sync-sites/use-sync-push';
 import { useAuth } from 'src/hooks/use-auth';
 import { ContentTabsProvider } from 'src/hooks/use-content-tabs';
+import { useFeatureFlags } from 'src/hooks/use-feature-flags';
 import { SyncSite } from 'src/hooks/use-fetch-wpcom-sites/types';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 import { ContentTabSync } from 'src/modules/sync';
@@ -21,6 +22,7 @@ import {
 
 jest.mock( 'src/hooks/use-auth' );
 jest.mock( 'src/lib/get-ipc-api' );
+jest.mock( 'src/hooks/use-feature-flags' );
 jest.mock( 'src/hooks/sync-sites/sync-sites-context', () => ( {
 	...jest.requireActual( '../../../hooks/sync-sites/sync-sites-context' ),
 	useSyncSites: jest.fn(),
@@ -126,6 +128,10 @@ describe( 'ContentTabSync', () => {
 	beforeEach( () => {
 		jest.resetAllMocks();
 		( useAuth as jest.Mock ).mockReturnValue( createAuthMock( false ) );
+		( useFeatureFlags as jest.Mock ).mockReturnValue( {
+			enableBlueprints: true,
+			streamlineOnboarding: false,
+		} );
 		( getIpcApi as jest.Mock ).mockReturnValue( {
 			authenticate: jest.fn(),
 			generateProposedSitePath: jest.fn(),
@@ -269,6 +275,10 @@ describe( 'ContentTabSync', () => {
 
 	it( 'displays publish and import actions to authenticated user', () => {
 		( useAuth as jest.Mock ).mockReturnValue( createAuthMock( true ) );
+		( useFeatureFlags as jest.Mock ).mockReturnValue( {
+			enableBlueprints: true,
+			streamlineOnboarding: true,
+		} );
 		renderWithProvider( <ContentTabSync selectedSite={ selectedSite } /> );
 		const publishButton = screen.getByRole( 'button', { name: /Publish site/i } );
 		const importButton = screen.getByRole( 'button', { name: /Pull site/i } );
@@ -291,6 +301,10 @@ describe( 'ContentTabSync', () => {
 		};
 
 		( useAuth as jest.Mock ).mockReturnValue( createAuthMock( true ) );
+		( useFeatureFlags as jest.Mock ).mockReturnValue( {
+			enableBlueprints: true,
+			streamlineOnboarding: true,
+		} );
 		setupConnectedSitesMocks( [], [ mockSyncSite ] );
 		( connectedSitesSelectors.selectIsModalOpen as jest.Mock ).mockReturnValue( true );
 		( connectedSitesSelectors.selectModalMode as jest.Mock ).mockReturnValue( 'pull' );
@@ -397,6 +411,10 @@ describe( 'ContentTabSync', () => {
 
 	it( 'displays publish and import buttons when there are no connected sites', () => {
 		( useAuth as jest.Mock ).mockReturnValue( createAuthMock( true ) );
+		( useFeatureFlags as jest.Mock ).mockReturnValue( {
+			enableBlueprints: true,
+			streamlineOnboarding: true,
+		} );
 		renderWithProvider( <ContentTabSync selectedSite={ selectedSite } /> );
 
 		const publishButton = screen.getByRole( 'button', { name: /Publish site/i } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Resolve STU-1012

## Proposed Changes

- Gate behind the feature flag `streamlineOnboarding` the new Publish and Import site buttons added as part of #2002 
- Adds the `cloudUpload` icon to the `Publish site` button as agreed in https://github.com/Automattic/studio/pull/2025#issuecomment-3551737476

|Flage disabled | Flag enabled|
|-------|------|
|<img width="2254" height="1560" alt="CleanShot 2025-11-20 at 12 05 11@2x" src="https://github.com/user-attachments/assets/08adaa17-e396-4c5e-8706-07069cf3b41b" />|<img width="2342" height="1648" alt="CleanShot 2025-11-20 at 12 15 21@2x" src="https://github.com/user-attachments/assets/e5cd77de-f11c-4bdc-912a-7da5aa059bcd" />|

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Apply this branch and run `npm start`
- In the menu, navigate to Electron > Feature Flags and disable Streamline Onboarding
<img width="254" height="185" alt="CleanShot 2025-11-20 at 12 00 48@2x" src="https://github.com/user-attachments/assets/c8dcc0ec-e82d-43fb-8903-6d25e3a789b9" />

- Navigate to the Sync tab on a site that does not have any connected sites
- Verify that you can see the `Connect site` button, and it works as expected
- Connect another stie and verify it works as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
