### PR TITLE
Blueprints: Refactor deeplink handling to use consistent file-based approach; unused code removal

### DIFF
--- a/src/ipc-utils.ts
+++ b/src/ipc-utils.ts
@@ -19,7 +19,7 @@ type SnapshotKeyValueEventData = {
 
 export interface IpcEvents {
 	'add-site': [ void ];
-	'add-site-blueprint-from-url': [ { blueprintPath: string } ];
+	'add-site-with-blueprint': [ { blueprintPath: string } ];
 	'auth-updated': [ { token: StoredToken } | { error: unknown } ];
 	'on-export': [ ImportExportEventData, string ];
 	'on-import': [ ImportExportEventData, string ];

--- a/src/ipc-utils.ts
+++ b/src/ipc-utils.ts
@@ -20,7 +20,6 @@ type SnapshotKeyValueEventData = {
 export interface IpcEvents {
 	'add-site': [ void ];
 	'add-site-blueprint-from-url': [ { blueprintPath: string } ];
-	'add-site-blueprint-from-base64': [ { blueprintJson: string } ];
 	'auth-updated': [ { token: StoredToken } | { error: unknown } ];
 	'on-export': [ ImportExportEventData, string ];
 	'on-import': [ ImportExportEventData, string ];

--- a/src/lib/deeplink/deeplink-handler.ts
+++ b/src/lib/deeplink/deeplink-handler.ts
@@ -1,4 +1,4 @@
-import { handleAddSiteWithBlueprint } from 'src/lib/deeplink/handlers/add-site-blueprint-with-url';
+import { handleAddSiteWithBlueprint } from 'src/lib/deeplink/handlers/add-site-with-blueprint';
 import { handleAuthDeeplink } from 'src/lib/deeplink/handlers/auth';
 import { handleSyncConnectSiteDeeplink } from 'src/lib/deeplink/handlers/sync-connect-site';
 

--- a/src/lib/deeplink/handlers/add-site-blueprint-with-url.ts
+++ b/src/lib/deeplink/handlers/add-site-blueprint-with-url.ts
@@ -47,13 +47,15 @@ export async function handleAddSiteWithBlueprint( urlObject: URL ): Promise< voi
 			const blueprintJsonString = Buffer.from( blueprintBase64, 'base64' ).toString( 'utf-8' );
 			blueprintJson = JSON.parse( blueprintJsonString );
 			await fs.writeJson( blueprintPath, blueprintJson );
-		} else {
+		} else if ( blueprintUrl ) {
 			// Handle blueprint linked in the deeplink URL
-			const decodedUrl = decodeURIComponent( blueprintUrl! );
+			const decodedUrl = decodeURIComponent( blueprintUrl );
 			new URL( decodedUrl );
 
 			await download( decodedUrl, blueprintPath, false, 'blueprint' );
 			blueprintJson = await fs.readJson( blueprintPath );
+		} else {
+			return;
 		}
 
 		const validation = await validateBlueprintData( blueprintJson );

--- a/src/lib/deeplink/handlers/add-site-blueprint-with-url.ts
+++ b/src/lib/deeplink/handlers/add-site-blueprint-with-url.ts
@@ -13,7 +13,7 @@ import { getMainWindow } from 'src/main-window';
  * - wp-studio://add-site?blueprint_url=<encoded-url>
  * - wp-studio://add-site?blueprint=<base64-encoded-json>
  *
- * Both types of blueprints are saved to a temporary file, validated,
+ * Both URL and Base64 encode json types of blueprints are saved to a temporary file, validated,
  * and then the Add Site modal is opened with the blueprint pre-filled.
  */
 export async function handleAddSiteWithBlueprint( urlObject: URL ): Promise< void > {

--- a/src/lib/deeplink/handlers/add-site-blueprint-with-url.ts
+++ b/src/lib/deeplink/handlers/add-site-blueprint-with-url.ts
@@ -1,6 +1,5 @@
 import { app, dialog } from 'electron';
 import nodePath from 'path';
-import * as Sentry from '@sentry/electron/main';
 import { __ } from '@wordpress/i18n';
 import fs from 'fs-extra';
 import { sendIpcEventToRenderer } from 'src/ipc-utils';
@@ -14,8 +13,8 @@ import { getMainWindow } from 'src/main-window';
  * - wp-studio://add-site?blueprint_url=<encoded-url>
  * - wp-studio://add-site?blueprint=<base64-encoded-json>
  *
- * It either downloads the blueprint from the URL or decodes the base64 blueprint,
- * and opens the Add Site modal with the blueprint pre-filled.
+ * Both types of blueprints are saved to a temporary file, validated,
+ * and then the Add Site modal is opened with the blueprint pre-filled.
  */
 export async function handleAddSiteWithBlueprint( urlObject: URL ): Promise< void > {
 	const { searchParams } = urlObject;
@@ -28,52 +27,35 @@ export async function handleAddSiteWithBlueprint( urlObject: URL ): Promise< voi
 	}
 	mainWindow.focus();
 
-	// Handle base64-encoded blueprint in the deeplink URL
-	if ( blueprintBase64 ) {
-		try {
-			const blueprintJson = Buffer.from( blueprintBase64, 'base64' ).toString( 'utf-8' );
-			JSON.parse( blueprintJson );
-			await sendIpcEventToRenderer( 'add-site-blueprint-from-base64', { blueprintJson } );
-		} catch ( error ) {
-			Sentry.captureException( error );
-			console.error( 'Failed to parse blueprint from deeplink:', error );
-
-			await dialog.showMessageBox( mainWindow, {
-				type: 'error',
-				message: __( 'Failed to load blueprint' ),
-				detail: __( 'The blueprint data is invalid. Please check the link and try again.' ),
-				buttons: [ __( 'OK' ) ],
-			} );
-		}
-		return;
-	}
-
-	// Handle blueprint linked in the deeplink URL
-	if ( ! blueprintUrl ) {
+	if ( ! blueprintUrl && ! blueprintBase64 ) {
 		console.error( 'add-site deeplink missing blueprint_url or blueprint parameter' );
 		return;
 	}
 
-	try {
-		const decodedUrl = decodeURIComponent( blueprintUrl );
-		new URL( decodedUrl );
-	} catch ( error ) {
-		console.error( 'Invalid blueprint_url in add-site deeplink:', error );
-		return;
-	}
-
-	const decodedUrl = decodeURIComponent( blueprintUrl );
-
 	const tmpDir = nodePath.join( app.getPath( 'temp' ), 'wp-studio-blueprints' );
 	await fs.mkdir( tmpDir, { recursive: true } );
 
-	const urlHash = Buffer.from( decodedUrl ).toString( 'base64url' ).slice( 0, 16 );
-	const blueprintPath = nodePath.join( tmpDir, `blueprint-${ urlHash }.json` );
+	let blueprintPath: string | undefined;
+	let blueprintJson: Record< string, unknown >;
 
 	try {
-		await download( decodedUrl, blueprintPath, false, 'blueprint' );
+		const timestamp = Date.now();
+		blueprintPath = nodePath.join( tmpDir, `blueprint-${ timestamp }.json` );
 
-		const blueprintJson = await fs.readJson( blueprintPath );
+		// Handle base64-encoded blueprint in the deeplink URL
+		if ( blueprintBase64 ) {
+			const blueprintJsonString = Buffer.from( blueprintBase64, 'base64' ).toString( 'utf-8' );
+			blueprintJson = JSON.parse( blueprintJsonString );
+			await fs.writeJson( blueprintPath, blueprintJson );
+		} else {
+			// Handle blueprint linked in the deeplink URL
+			const decodedUrl = decodeURIComponent( blueprintUrl! );
+			new URL( decodedUrl );
+
+			await download( decodedUrl, blueprintPath, false, 'blueprint' );
+			blueprintJson = await fs.readJson( blueprintPath );
+		}
+
 		const validation = await validateBlueprintData( blueprintJson );
 
 		if ( ! validation.valid ) {
@@ -92,15 +74,18 @@ export async function handleAddSiteWithBlueprint( urlObject: URL ): Promise< voi
 
 		await sendIpcEventToRenderer( 'add-site-blueprint-from-url', { blueprintPath } );
 	} catch ( error ) {
-		console.error( 'Failed to download blueprint from deeplink:', error );
-		await fs.remove( blueprintPath ).catch( () => {
-			// Ignore cleanup errors
-		} );
+		console.error( 'Failed to process blueprint from deeplink:', error );
+
+		if ( blueprintPath ) {
+			await fs.remove( blueprintPath ).catch( () => {
+				// Ignore cleanup errors
+			} );
+		}
 
 		await dialog.showMessageBox( mainWindow, {
 			type: 'error',
-			message: __( 'Failed to download blueprint' ),
-			detail: __( 'The blueprint could not be downloaded. Please check the URL and try again.' ),
+			message: __( 'Failed to load blueprint' ),
+			detail: __( 'The blueprint could not be loaded. Please check the link and try again.' ),
 			buttons: [ __( 'OK' ) ],
 		} );
 	}

--- a/src/lib/deeplink/handlers/add-site-with-blueprint.ts
+++ b/src/lib/deeplink/handlers/add-site-with-blueprint.ts
@@ -61,17 +61,7 @@ export async function handleAddSiteWithBlueprint( urlObject: URL ): Promise< voi
 		const validation = await validateBlueprintData( blueprintJson );
 
 		if ( ! validation.valid ) {
-			await fs.remove( blueprintPath ).catch( () => {
-				// Ignore cleanup errors
-			} );
-
-			await dialog.showMessageBox( mainWindow, {
-				type: 'error',
-				message: __( 'Blueprint validation failed' ),
-				detail: validation.error || __( 'Invalid Blueprint format' ),
-				buttons: [ __( 'OK' ) ],
-			} );
-			return;
+			throw new Error( validation.error || __( 'Invalid Blueprint format' ) );
 		}
 
 		await sendIpcEventToRenderer( 'add-site-with-blueprint', { blueprintPath } );
@@ -84,10 +74,15 @@ export async function handleAddSiteWithBlueprint( urlObject: URL ): Promise< voi
 			} );
 		}
 
+		const errorDetail =
+			error instanceof Error
+				? error.message
+				: __( 'The blueprint could not be loaded. Please check the link and try again.' );
+
 		await dialog.showMessageBox( mainWindow, {
 			type: 'error',
 			message: __( 'Failed to load blueprint' ),
-			detail: __( 'The blueprint could not be loaded. Please check the link and try again.' ),
+			detail: errorDetail,
 			buttons: [ __( 'OK' ) ],
 		} );
 	}

--- a/src/lib/deeplink/handlers/add-site-with-blueprint.ts
+++ b/src/lib/deeplink/handlers/add-site-with-blueprint.ts
@@ -74,7 +74,7 @@ export async function handleAddSiteWithBlueprint( urlObject: URL ): Promise< voi
 			return;
 		}
 
-		await sendIpcEventToRenderer( 'add-site-blueprint-from-url', { blueprintPath } );
+		await sendIpcEventToRenderer( 'add-site-with-blueprint', { blueprintPath } );
 	} catch ( error ) {
 		console.error( 'Failed to process blueprint from deeplink:', error );
 

--- a/src/lib/deeplink/tests/add-site.test.ts
+++ b/src/lib/deeplink/tests/add-site.test.ts
@@ -5,7 +5,7 @@ import { app, dialog, BrowserWindow } from 'electron';
 import fs from 'fs-extra';
 import { sendIpcEventToRenderer } from 'src/ipc-utils';
 import { validateBlueprintData } from 'src/lib/blueprint-features';
-import { handleAddSiteWithBlueprint } from 'src/lib/deeplink/handlers/add-site-blueprint-with-url';
+import { handleAddSiteWithBlueprint } from 'src/lib/deeplink/handlers/add-site-with-blueprint';
 import { download } from 'src/lib/download';
 import { getMainWindow } from 'src/main-window';
 
@@ -67,7 +67,7 @@ describe( 'handleAddSiteWithBlueprint', () => {
 			false,
 			'blueprint'
 		);
-		expect( sendIpcEventToRenderer ).toHaveBeenCalledWith( 'add-site-blueprint-from-url', {
+		expect( sendIpcEventToRenderer ).toHaveBeenCalledWith( 'add-site-with-blueprint', {
 			blueprintPath: expect.stringContaining( 'blueprint-' ),
 		} );
 		expect( mockMainWindow.focus ).toHaveBeenCalled();
@@ -190,7 +190,7 @@ describe( 'handleAddSiteWithBlueprint', () => {
 				expect.stringContaining( 'blueprint-' ),
 				blueprintData
 			);
-			expect( sendIpcEventToRenderer ).toHaveBeenCalledWith( 'add-site-blueprint-from-url', {
+			expect( sendIpcEventToRenderer ).toHaveBeenCalledWith( 'add-site-with-blueprint', {
 				blueprintPath: expect.stringContaining( 'blueprint-' ),
 			} );
 			expect( download ).not.toHaveBeenCalled();

--- a/src/lib/deeplink/tests/add-site.test.ts
+++ b/src/lib/deeplink/tests/add-site.test.ts
@@ -43,7 +43,7 @@ describe( 'handleAddSiteWithBlueprint', () => {
 		jest.clearAllMocks();
 		( mockMainWindow.isMinimized as jest.Mock ).mockReturnValue( false );
 		jest.mocked( app.getPath ).mockReturnValue( '/tmp' );
-		( fs.mkdir as unknown as jest.Mock ).mockResolvedValue( undefined );
+		jest.mocked( fs.mkdir ).mockImplementation( async () => {} );
 		jest.mocked( getMainWindow ).mockResolvedValue( mockMainWindow );
 		jest.mocked( dialog.showMessageBox ).mockResolvedValue( {
 			response: 0,
@@ -87,11 +87,18 @@ describe( 'handleAddSiteWithBlueprint', () => {
 		const encodedUrl = encodeURIComponent( invalidUrl );
 		const url = new URL( `wp-studio://add-site?blueprint_url=${ encodedUrl }` );
 
+		jest.mocked( fs.remove ).mockImplementation( async () => {} );
+
 		await handleAddSiteWithBlueprint( url );
 
 		expect( download ).not.toHaveBeenCalled();
 		expect( sendIpcEventToRenderer ).not.toHaveBeenCalled();
-		expect( dialog.showMessageBox ).not.toHaveBeenCalled();
+		expect( dialog.showMessageBox ).toHaveBeenCalledWith( mockMainWindow, {
+			type: 'error',
+			message: expect.any( String ),
+			detail: expect.any( String ),
+			buttons: expect.any( Array ),
+		} );
 	} );
 
 	it( 'should handle download failure gracefully', async () => {
@@ -99,7 +106,7 @@ describe( 'handleAddSiteWithBlueprint', () => {
 
 		const downloadError = new Error( 'Download failed' );
 		jest.mocked( download ).mockRejectedValue( downloadError );
-		( fs.remove as unknown as jest.Mock ).mockResolvedValue( undefined );
+		jest.mocked( fs.remove ).mockImplementation( async () => {} );
 
 		await handleAddSiteWithBlueprint( url );
 
@@ -119,7 +126,7 @@ describe( 'handleAddSiteWithBlueprint', () => {
 
 		( mockMainWindow.isMinimized as jest.Mock ).mockReturnValue( true );
 		jest.mocked( download ).mockResolvedValue( undefined );
-		( fs.readJson as unknown as jest.Mock ).mockResolvedValue( { steps: [] } );
+		jest.mocked( fs.readJson ).mockResolvedValue( { steps: [] } );
 		jest.mocked( validateBlueprintData ).mockResolvedValue( { valid: true } );
 
 		await handleAddSiteWithBlueprint( url );
@@ -144,12 +151,12 @@ describe( 'handleAddSiteWithBlueprint', () => {
 		const url = createBlueprintUrl( 'https://example.com/blueprint.json' );
 
 		jest.mocked( download ).mockResolvedValue( undefined );
-		( fs.readJson as unknown as jest.Mock ).mockResolvedValue( { invalid: 'data' } );
+		jest.mocked( fs.readJson ).mockResolvedValue( { invalid: 'data' } );
 		jest.mocked( validateBlueprintData ).mockResolvedValue( {
 			valid: false,
 			error: 'Invalid blueprint format',
 		} );
-		( fs.remove as unknown as jest.Mock ).mockResolvedValue( undefined );
+		jest.mocked( fs.remove ).mockImplementation( async () => {} );
 
 		await handleAddSiteWithBlueprint( url );
 
@@ -174,10 +181,17 @@ describe( 'handleAddSiteWithBlueprint', () => {
 			const blueprintBase64 = Buffer.from( blueprintJson ).toString( 'base64' );
 			const url = new URL( `wp-studio://add-site?blueprint=${ blueprintBase64 }` );
 
+			jest.mocked( fs.writeJson ).mockImplementation( async () => {} );
+			jest.mocked( validateBlueprintData ).mockResolvedValue( { valid: true } );
+
 			await handleAddSiteWithBlueprint( url );
 
-			expect( sendIpcEventToRenderer ).toHaveBeenCalledWith( 'add-site-blueprint-from-base64', {
-				blueprintJson,
+			expect( fs.writeJson ).toHaveBeenCalledWith(
+				expect.stringContaining( 'blueprint-' ),
+				blueprintData
+			);
+			expect( sendIpcEventToRenderer ).toHaveBeenCalledWith( 'add-site-blueprint-from-url', {
+				blueprintPath: expect.stringContaining( 'blueprint-' ),
 			} );
 			expect( download ).not.toHaveBeenCalled();
 		} );

--- a/src/modules/add-site/components/blueprints.tsx
+++ b/src/modules/add-site/components/blueprints.tsx
@@ -119,8 +119,6 @@ interface AddSiteBlueprintProps {
 	selectedBlueprint: string | null;
 	onBlueprintChange: ( blueprintId: string ) => void;
 	onFileBlueprintSelect?: ( blueprint: Blueprint ) => void;
-	blueprintError?: string | null;
-	onErrorDismiss?: () => void;
 }
 
 export function AddSiteBlueprintSelector( {
@@ -130,8 +128,6 @@ export function AddSiteBlueprintSelector( {
 	selectedBlueprint,
 	onBlueprintChange,
 	onFileBlueprintSelect,
-	blueprintError,
-	onErrorDismiss,
 }: AddSiteBlueprintProps ) {
 	const { __ } = useI18n();
 	const { refetch: refetchBlueprints, isFetching: isFetchingBlueprints } = useGetBlueprints();
@@ -372,19 +368,6 @@ export function AddSiteBlueprintSelector( {
 				isOpen={ showIssuesModal }
 				onClose={ () => setShowIssuesModal( false ) }
 			/>
-
-			{ blueprintError && (
-				<Notice
-					status="error"
-					isDismissible={ false }
-					onRemove={ onErrorDismiss || ( () => {} ) }
-					className="mx-0 mb-4"
-				>
-					<strong>{ __( 'Blueprint Error' ) }</strong>
-					<br />
-					{ blueprintError }
-				</Notice>
-			) }
 
 			{ validationError && (
 				<Notice

--- a/src/modules/add-site/hooks/use-blueprint-deeplink.ts
+++ b/src/modules/add-site/hooks/use-blueprint-deeplink.ts
@@ -100,5 +100,5 @@ export function useBlueprintDeeplink( options: UseBlueprintDeeplinkOptions ): vo
 			openModal,
 		]
 	);
-	useIpcListener( 'add-site-blueprint-from-url', handleBlueprintFromUrl );
+	useIpcListener( 'add-site-with-blueprint', handleBlueprintFromUrl );
 }

--- a/src/modules/add-site/hooks/use-blueprint-deeplink.ts
+++ b/src/modules/add-site/hooks/use-blueprint-deeplink.ts
@@ -1,5 +1,5 @@
 import { useI18n } from '@wordpress/react-i18n';
-import { useCallback, useState } from 'react';
+import { useCallback } from 'react';
 import { useIpcListener } from 'src/hooks/use-ipc-listener';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 import { Blueprint } from 'src/stores/wpcom-api';
@@ -18,16 +18,7 @@ interface UseBlueprintDeeplinkOptions {
 	setBlueprintPreferredVersions: ( versions: { php?: string; wp?: string } | undefined ) => void;
 }
 
-interface UseBlueprintDeeplinkReturn {
-	initialNavigatorPath: string;
-	blueprintError: string | null;
-	setBlueprintError: ( error: string | null ) => void;
-	resetDeeplinkState: () => void;
-}
-
-export function useBlueprintDeeplink(
-	options: UseBlueprintDeeplinkOptions
-): UseBlueprintDeeplinkReturn {
+export function useBlueprintDeeplink( options: UseBlueprintDeeplinkOptions ): void {
 	const { __ } = useI18n();
 	const {
 		isAnySiteProcessing,
@@ -37,14 +28,6 @@ export function useBlueprintDeeplink(
 		setWpVersion,
 		setBlueprintPreferredVersions,
 	} = options;
-
-	const [ initialNavigatorPath, setInitialNavigatorPath ] = useState< string >( '/' );
-	const [ blueprintError, setBlueprintError ] = useState< string | null >( null );
-
-	const resetDeeplinkState = useCallback( () => {
-		setInitialNavigatorPath( '/' );
-		setBlueprintError( null );
-	}, [] );
 
 	const createBlueprintFromData = useCallback(
 		(
@@ -103,7 +86,6 @@ export function useBlueprintDeeplink(
 
 				setSelectedBlueprint( fileBlueprint );
 				applyPreferredVersions( blueprintJson );
-				setInitialNavigatorPath( '/blueprint/create' );
 				openModal();
 			} catch ( error ) {
 				console.error( 'Failed to load blueprint from URL:', error );
@@ -119,44 +101,4 @@ export function useBlueprintDeeplink(
 		]
 	);
 	useIpcListener( 'add-site-blueprint-from-url', handleBlueprintFromUrl );
-
-	const handleBlueprintFromBase64 = useCallback(
-		( _event: unknown, { blueprintJson }: { blueprintJson: string } ) => {
-			if ( isAnySiteProcessing ) {
-				return;
-			}
-			try {
-				const blueprintData = JSON.parse( blueprintJson );
-				const blueprint = createBlueprintFromData(
-					blueprintData,
-					`deeplink-${ Date.now() }`,
-					__( 'Custom Blueprint' ),
-					__( 'Blueprint from base64' )
-				);
-
-				setSelectedBlueprint( blueprint );
-				applyPreferredVersions( blueprintData );
-				setInitialNavigatorPath( '/blueprint/create' );
-				openModal();
-			} catch ( error ) {
-				console.error( 'Failed to parse blueprint from IPC event:', error );
-			}
-		},
-		[
-			isAnySiteProcessing,
-			__,
-			createBlueprintFromData,
-			setSelectedBlueprint,
-			applyPreferredVersions,
-			openModal,
-		]
-	);
-	useIpcListener( 'add-site-blueprint-from-base64', handleBlueprintFromBase64 );
-
-	return {
-		initialNavigatorPath,
-		blueprintError,
-		setBlueprintError,
-		resetDeeplinkState,
-	};
 }

--- a/src/modules/add-site/index.tsx
+++ b/src/modules/add-site/index.tsx
@@ -65,8 +65,6 @@ interface NavigationContentProps {
 	setBlueprintPreferredVersions: ( versions: { php?: string; wp?: string } | undefined ) => void;
 	selectedRemoteSite?: SyncSite;
 	setSelectedRemoteSite: ( site?: SyncSite ) => void;
-	blueprintError?: string | null;
-	setBlueprintError: ( error: string | null ) => void;
 }
 
 function NavigationContent( props: NavigationContentProps ) {
@@ -80,8 +78,6 @@ function NavigationContent( props: NavigationContentProps ) {
 		setBlueprintPreferredVersions,
 		selectedRemoteSite,
 		setSelectedRemoteSite,
-		blueprintError,
-		setBlueprintError,
 		...createSiteProps
 	} = props;
 
@@ -233,10 +229,6 @@ function NavigationContent( props: NavigationContentProps ) {
 					selectedBlueprint={ createSiteProps.selectedBlueprint?.slug || null }
 					onBlueprintChange={ handleBlueprintChange }
 					onFileBlueprintSelect={ handleFileBlueprintSelect }
-					blueprintError={ blueprintError }
-					onErrorDismiss={ () => {
-						setBlueprintError( null );
-					} }
 				/>
 			</Navigator.Screen>
 			<Navigator.Screen className="flex-1" path="/blueprint/create">
@@ -325,6 +317,7 @@ export default function AddSite( { className, variant = 'outlined' }: AddSitePro
 		setEnableHttps,
 		setFileForImport,
 		loadAllCustomDomains,
+		selectedBlueprint,
 		setSelectedBlueprint,
 		selectedRemoteSite,
 		setSelectedRemoteSite,
@@ -377,21 +370,21 @@ export default function AddSite( { className, variant = 'outlined' }: AddSitePro
 		setShowModal( true );
 	}, [ refetch, isUninitialized ] );
 
-	const { initialNavigatorPath, blueprintError, setBlueprintError, resetDeeplinkState } =
-		useBlueprintDeeplink( {
-			isAnySiteProcessing,
-			openModal,
-			setSelectedBlueprint,
-			setPhpVersion,
-			setWpVersion,
-			setBlueprintPreferredVersions,
-		} );
+	useBlueprintDeeplink( {
+		isAnySiteProcessing,
+		openModal,
+		setSelectedBlueprint,
+		setPhpVersion,
+		setWpVersion,
+		setBlueprintPreferredVersions,
+	} );
+
+	const initialNavigatorPath = selectedBlueprint ? '/blueprint/create' : '/';
 
 	const closeModal = useCallback( () => {
 		setShowModal( false );
 		resetForm();
-		resetDeeplinkState();
-	}, [ resetForm, resetDeeplinkState ] );
+	}, [ resetForm ] );
 
 	const siteAddedMessage = sprintf(
 		// translators: %s is the site name.
@@ -463,8 +456,6 @@ export default function AddSite( { className, variant = 'outlined' }: AddSitePro
 						setBlueprintPreferredVersions={ setBlueprintPreferredVersions }
 						selectedRemoteSite={ selectedRemoteSite }
 						setSelectedRemoteSite={ setSelectedRemoteSite }
-						blueprintError={ blueprintError }
-						setBlueprintError={ setBlueprintError }
 					/>
 				</Navigator>
 			</FullscreenModal>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

Resolves STU-1008

## Proposed Changes

The goal of this PR is to unify blueprint deeplinks handling and remove unnecessary code:

- remove `handleBlueprintFromBase64` callback → instead use `handleBlueprintFromUrl` for both blueprint deeplink types
- unify `blueprintPath` logic to use current timestamp for temporary json file name
- remove unused error state and related notice (we used it before to display errors in the renderer process, now the errors are caught earlier)
- remove unnecessary `initialNavigatorPath` state (we now directly jump to the "Add a site" step so this state is not needed anymore)
- rename `add-site-blueprint-from-url` to `add-site-with-blueprint`
- clean up related unit tests

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR and build the app with `npm install && npm start`.
2. Try to open the blueprint deeplinks provided here: https://jsbin.com/levaburate/2/edit?html,css,output.
  - First two should result in a dialog error message.
  - The third one should get you to the "Add a site" step and allow you to create a new site with it.
3. Try to open the following Base64-encoded blueprint links:
 
This one should result in an error message:

```
wp-studio://add-site?blueprint=ewogICJuYW1lIjogIk1lb3dzeSIsCiAgInNwZWNpZXMiOiAiY2F0IiwKICAiaW52YWxpZCI6ICJ0aGlzIGlzIG5vdCBhIHZhbGlkIGJsdWVwcmludCIKICAibWlzc2luZyI6ICJjb21tYSBhYm92ZSIKfQo=
```
 
This one should work correctly and let you create a site with it (installs Astra theme):

```
wp-studio://add-site?blueprint=eyJwcmVmZXJyZWRWZXJzaW9ucyI6eyJwaHAiOiI4LjMiLCJ3cCI6ImxhdGVzdCJ9LCJzdGVwcyI6W3sic3RlcCI6Imluc3RhbGxUaGVtZSIsInRoZW1lRGF0YSI6eyJyZXNvdXJjZSI6IndvcmRwcmVzcy5vcmcvdGhlbWVzIiwic2x1ZyI6ImFzdHJhIn0sIm9wdGlvbnMiOnsiYWN0aXZhdGUiOnRydWV9fSx7InN0ZXAiOiJpbnN0YWxsUGx1Z2luIiwicGx1Z2luRGF0YSI6eyJyZXNvdXJjZSI6IndvcmRwcmVzcy5vcmcvcGx1Z2lucyIsInNsdWciOiJ3b3JkcHJlc3Mtc2VvIn0sIm9wdGlvbnMiOnsiYWN0aXZhdGUiOnRydWV9fV19
```

4. Try to manually create sites using blueprint files from 39a4e-pb. The results should be as expected - there should be no regressions.

5. If you like, you can also test with your own blueprint files and blueprint deeplinks. 🙂 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
