### PR TITLE
Clean up claude mention trigger code review

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -5,16 +5,16 @@ on:
     types: [created]
   pull_request_review_comment:
     types: [created]
-  pull_request_review:
-    types: [submitted]
 
 jobs:
   code-review:
-    # Only run if @claude is mentioned
+    # Only run if @claude is mentioned, and it's on a PR (not a regular issue)
     if: |
-      contains(github.event.comment.body, '@claude') ||
-      contains(github.event.issue.body, '@claude') ||
-      contains(github.event.review.body, '@claude')
+      (
+        github.event.pull_request != null ||
+        github.event.issue.pull_request != null
+      ) &&
+      contains(github.event.comment.body, '@claude')
 
     runs-on: ubuntu-latest
     permissions:
@@ -36,7 +36,7 @@ jobs:
           allowed_bots: 'dependabot[bot]'
           prompt: |
             REPO: ${{ github.repository }}
-            PR NUMBER: ${{ github.event.pull_request.number }}
+            PR NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
 
             Perform a comprehensive code review for WordPress Studio, focusing on:
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- N/A

## Proposed Changes

 Changes:
  - Removes unnecessary `pull_request_review` trigger
  - Reverts the check to check only the `comment.body`
  - Adds a condition to avoid triggering on non-PR issue comments
  - Adds PR number for PR comments

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

-

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
