### PR TITLE
Studio: Add translations for Playground CLI console messages during site creation

### DIFF
--- a/src/lib/wordpress-provider/playground-cli/playground-server-process-child.ts
+++ b/src/lib/wordpress-provider/playground-cli/playground-server-process-child.ts
@@ -50,6 +50,12 @@ const originalConsoleLog = console.log;
 const originalConsoleError = console.error;
 const originalConsoleWarn = console.warn;
 
+/**
+ * Messages come from the playground-cli, they can be found on the calls to `logger.log`
+ * in the playground-cli source code, for example:
+ * https://github.com/WordPress/wordpress-playground/blob/5ce5752af3cde8b65c745c527c54f3b4bc164a00/packages/playground/cli/src/run-cli.ts#L927
+ *
+ */
 function formatMessageForUI( message: string ): string {
 	if ( message.includes( 'WordPress is running' ) ) {
 		return __( 'WordPress is running' );

--- a/src/lib/wordpress-provider/playground-cli/playground-server-process-child.ts
+++ b/src/lib/wordpress-provider/playground-cli/playground-server-process-child.ts
@@ -1,4 +1,5 @@
 import { SupportedPHPVersion, PHPRunOptions } from '@php-wasm/universal';
+import { __ } from '@wordpress/i18n';
 import { runCLI, RunCLIArgs, RunCLIServer } from '@wp-playground/cli';
 import { sanitizeRunCLIArgs } from 'src/lib/sentry-sanitizer';
 import { isWordPressDevVersion } from 'src/lib/wordpress-version-utils';
@@ -50,11 +51,29 @@ const originalConsoleError = console.error;
 const originalConsoleWarn = console.warn;
 
 function formatMessageForUI( message: string ): string {
-	if ( message.includes( 'WordPress is running on' ) ) {
-		return 'WordPress is running';
+	if ( message.includes( 'WordPress is running' ) ) {
+		return __( 'WordPress is running' );
 	}
 	if ( message.includes( 'Resolved WordPress release URL' ) ) {
-		return 'Downloading WordPress…';
+		return __( 'Downloading WordPress…' );
+	}
+	if ( message.includes( 'Downloading WordPress' ) ) {
+		return __( 'Downloading WordPress…' );
+	}
+	if ( message.includes( 'Starting up workers' ) ) {
+		return __( 'Starting up workers…' );
+	}
+	if ( message.includes( 'Booting WordPress' ) ) {
+		return __( 'Booting WordPress…' );
+	}
+	if ( message.includes( 'Running the Blueprint' ) ) {
+		return __( 'Running the Blueprint…' );
+	}
+	if ( message.includes( 'Finished running the blueprint' ) ) {
+		return __( 'Finished running the Blueprint…' );
+	}
+	if ( message.includes( 'Preparing workers' ) ) {
+		return __( 'Preparing workers…' );
 	}
 	return message;
 }


### PR DESCRIPTION
## Related issues

- Fixes STU-981

## Proposed Changes

- Updated `formatMessageForUI()` function to wrap all user-facing console messages with translation calls

## Testing Instructions

- Change your system language to a non-English language that Studio supports (e.g., Spanish, French, German, Polish). Please note that most of the strings need to be translated
- Create a new site in Studio
- Observe the loading messages that appear during site creation
- Verify that the console messages are displayed in the selected language instead of English

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?