### PR TITLE
[WIP] Custom Domains: handle permission errors on windows when the custom domain proxy

### DIFF
--- a/src/hooks/tests/use-site-details.test.tsx
+++ b/src/hooks/tests/use-site-details.test.tsx
@@ -106,4 +106,35 @@ describe( 'useSiteDetails', () => {
 			expect( getIpcApi().startServer ).not.toHaveBeenCalled();
 		} );
 	} );
+
+	describe( 'it can handle permission related errors', () => {
+		it( 'should show permission denied error message when PROXY_ERROR_PERMISSION_DENIED occurs', async () => {
+			const mockShowErrorMessageBox = jest.fn();
+			const mockStopServer = jest.fn();
+
+			( getIpcApi as jest.Mock ).mockReturnValue( {
+				getSiteDetails: jest.fn().mockResolvedValue( mockSites ),
+				startServer: jest.fn().mockRejectedValue( new Error( 'PROXY_ERROR_PERMISSION_DENIED' ) ),
+				showErrorMessageBox: mockShowErrorMessageBox,
+				stopServer: mockStopServer,
+			} );
+
+			const { result } = renderHook( () => useSiteDetails(), { wrapper } );
+
+			await waitFor( () => {
+				expect( result.current.loadingSites ).toBe( false );
+			} );
+
+			// Wait for error handling to complete
+			await waitFor( () => {
+				expect( mockShowErrorMessageBox ).toHaveBeenCalledWith( {
+					title: 'Studio failed to initialize custom domains',
+					message:
+						'We could not create a custom domain for your site due to a lack of permissions. On Windows, Studio requires administrator privileges to bind to ports 80 and 443, which are necessary for custom domains to work properly.',
+					showOpenLogs: false,
+				} );
+				expect( mockStopServer ).toHaveBeenCalled();
+			} );
+		} );
+	} );
 } );

--- a/src/hooks/use-site-details.tsx
+++ b/src/hooks/use-site-details.tsx
@@ -348,7 +348,18 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 			try {
 				updatedSite = await getIpcApi().startServer( id );
 			} catch ( error ) {
-				if ( error instanceof Error && error.message.includes( 'PROXY_ERROR_PORT_IN_USE' ) ) {
+				if ( error instanceof Error && error.message.includes( 'PROXY_ERROR_PERMISSION_DENIED' ) ) {
+					getIpcApi().showErrorMessageBox( {
+						title: __( 'Studio failed to initialize custom domains' ),
+						message: __(
+							'We could not create a custom domain for your site due to a lack of permissions. On Windows, Studio requires administrator privileges to bind to ports 80 and 443, which are necessary for custom domains to work properly.'
+						),
+						showOpenLogs: false,
+					} );
+				} else if (
+					error instanceof Error &&
+					error.message.includes( 'PROXY_ERROR_PORT_IN_USE' )
+				) {
 					getIpcApi().showErrorMessageBox( {
 						title: __( 'Studio failed to initialize custom domains' ),
 						message: __(

--- a/src/lib/proxy-server.ts
+++ b/src/lib/proxy-server.ts
@@ -159,7 +159,12 @@ export const startProxyServer = sequential( async (): Promise< boolean > => {
 					} )
 					.on( 'error', ( err ) => {
 						console.error( `Error starting HTTP proxy server on port 80:`, err );
-						reject( err );
+						// Check for permission denied error
+						if ( ( err as NodeJS.ErrnoException ).code === 'EACCES' ) {
+							reject( new Error( 'PROXY_ERROR_PERMISSION_DENIED' ) );
+						} else {
+							reject( err );
+						}
 					} );
 			} );
 		}
@@ -212,7 +217,12 @@ export const startProxyServer = sequential( async (): Promise< boolean > => {
 					} )
 					.on( 'error', ( err ) => {
 						console.error( `Error starting HTTPS proxy server on port 443:`, err );
-						reject( err );
+						// Check for permission denied error
+						if ( ( err as NodeJS.ErrnoException ).code === 'EACCES' ) {
+							reject( new Error( 'PROXY_ERROR_PERMISSION_DENIED' ) );
+						} else {
+							reject( err );
+						}
 					} );
 			} );
 		}
@@ -220,6 +230,10 @@ export const startProxyServer = sequential( async (): Promise< boolean > => {
 		return true;
 	} catch ( error ) {
 		if ( error instanceof Error && error.message === 'PROXY_ERROR_PORT_IN_USE' ) {
+			throw error;
+		}
+
+		if ( error instanceof Error && error.message === 'PROXY_ERROR_PERMISSION_DENIED' ) {
 			throw error;
 		}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-311

## Proposed Changes

- Raise a new error type PROXY_ERROR_PERMISSION_DENIED when starting proxy servers. 
- Add a new message box in UI for handling permissions errors. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- TBD

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
