### PR TITLE
Stats: Unify `bumpStat` function and validate its parameters length

### DIFF
--- a/cli/lib/stats.ts
+++ b/cli/lib/stats.ts
@@ -1,3 +1,4 @@
+import { bumpStat } from 'common/lib/bump-stat';
 import { AggregateInterval, StatsGroup, StatsMetric } from 'common/types/stats';
 import { isSameDay, isSameMonth, isSameWeek } from 'date-fns';
 import { lockAppdata, readAppdata, saveAppdata, unlockAppdata } from 'cli/lib/appdata';
@@ -40,26 +41,7 @@ export async function bumpAggregatedUniqueStat(
 	}
 }
 
-// Returns true if we attempted to bump the stat
-export function bumpStat( group: StatsGroup, stat: StatsMetric, bumpInDev = false ) {
-	if ( process.env.NODE_ENV === 'development' && ! bumpInDev ) {
-		console.info( `Would have bumped stat: ${ group }=${ stat }` );
-		return false;
-	}
-
-	// Fire and forget POST request
-	fetch( 'https://public-api.wordpress.com/wpcom/v2/studio-app/bump-stat', {
-		method: 'POST',
-		headers: {
-			'Content-Type': 'application/json',
-		},
-		body: JSON.stringify( { group, stat } ),
-	} ).catch( () => {
-		// A failed request typically indicates a network issue, which we don't need to report
-	} );
-
-	return true;
-}
+export { bumpStat } from 'common/lib/bump-stat';
 
 // Returns UTC timestamp of the last time the stat was bumped, or null if it has never been bumped.
 async function getLastBump( group: StatsGroup, stat: StatsMetric ): Promise< number | null > {

--- a/cli/lib/stats.ts
+++ b/cli/lib/stats.ts
@@ -41,8 +41,6 @@ export async function bumpAggregatedUniqueStat(
 	}
 }
 
-export { bumpStat } from 'common/lib/bump-stat';
-
 // Returns UTC timestamp of the last time the stat was bumped, or null if it has never been bumped.
 async function getLastBump( group: StatsGroup, stat: StatsMetric ): Promise< number | null > {
 	const { lastBumpStats } = await readAppdata();

--- a/common/lib/bump-stat.ts
+++ b/common/lib/bump-stat.ts
@@ -1,0 +1,22 @@
+import { StatsGroup, StatsMetric } from 'common/types/stats';
+
+// Returns true if we attempted to bump the stat
+export function bumpStat( group: StatsGroup, stat: StatsMetric, bumpInDev = false ) {
+	if ( process.env.E2E || ( process.env.NODE_ENV === 'development' && ! bumpInDev ) ) {
+		console.info( `Would have bumped stat: ${ group }=${ stat }` );
+		return false;
+	}
+
+	// Fire and forget POST request
+	fetch( 'https://public-api.wordpress.com/wpcom/v2/studio-app/bump-stat', {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json',
+		},
+		body: JSON.stringify( { group, stat } ),
+	} ).catch( () => {
+		// A failed request typically indicates a network issue, which we don't need to report
+	} );
+
+	return true;
+}

--- a/common/lib/bump-stat.ts
+++ b/common/lib/bump-stat.ts
@@ -1,7 +1,26 @@
 import { StatsGroup, StatsMetric } from 'common/types/stats';
 
+// Database columns are varchar(32). Group limit is 26 to account for the '-a11n' suffix
+// added by the backend for Automattic requests (26 + 6 = 32).
+const MAX_GROUP_LENGTH = 26;
+const MAX_STAT_LENGTH = 32;
+
 // Returns true if we attempted to bump the stat
 export function bumpStat( group: StatsGroup, stat: StatsMetric, bumpInDev = false ) {
+	if ( group.length > MAX_GROUP_LENGTH ) {
+		console.error(
+			`Stat group "${ group }" exceeds maximum length of ${ MAX_GROUP_LENGTH } characters (actual: ${ group.length }). Stat will not be bumped.`
+		);
+		return false;
+	}
+
+	if ( stat.length > MAX_STAT_LENGTH ) {
+		console.error(
+			`Stat name "${ stat }" exceeds maximum length of ${ MAX_STAT_LENGTH } characters (actual: ${ stat.length }). Stat will not be bumped.`
+		);
+		return false;
+	}
+
 	if ( process.env.E2E || ( process.env.NODE_ENV === 'development' && ! bumpInDev ) ) {
 		console.info( `Would have bumped stat: ${ group }=${ stat }` );
 		return false;

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ import {
 	REDUX_DEVTOOLS,
 } from 'electron-devtools-installer';
 import { PROTOCOL_PREFIX } from 'common/constants';
+import { bumpStat } from 'common/lib/bump-stat';
 import { suppressPunycodeWarning } from 'common/lib/suppress-punycode-warning';
 import { StatsGroup } from 'common/types/stats';
 import { IPC_VOID_HANDLERS } from 'src/constants';
@@ -26,7 +27,7 @@ import {
 	hasActiveSyncOperations,
 	hasCancelableSyncOperations,
 } from 'src/lib/active-sync-operations';
-import { bumpAggregatedUniqueStat, bumpStat } from 'src/lib/bump-stats';
+import { bumpAggregatedUniqueStat } from 'src/lib/bump-stats';
 import { getPlatformMetric } from 'src/lib/bump-stats/lib';
 import { handleDeeplink } from 'src/lib/deeplink';
 import { getUserLocaleWithFallback } from 'src/lib/locale-node';

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -20,6 +20,7 @@ import * as Sentry from '@sentry/electron/main';
 import { __, sprintf, LocaleData, defaultI18n } from '@wordpress/i18n';
 import archiver from 'archiver';
 import { z } from 'zod';
+import { bumpStat } from 'common/lib/bump-stat';
 import {
 	calculateDirectorySize,
 	isWordPressDirectory,
@@ -39,7 +40,6 @@ import { sendIpcEventToRenderer, sendIpcEventToRendererWithWindow } from 'src/ip
 import { ACTIVE_SYNC_OPERATIONS } from 'src/lib/active-sync-operations';
 import { getBetaFeatures as getBetaFeaturesFromLib } from 'src/lib/beta-features';
 import { validateBlueprintData } from 'src/lib/blueprint-features';
-import { bumpStat } from 'src/lib/bump-stats';
 import { getImporterMetric, getBlueprintMetric } from 'src/lib/bump-stats/lib';
 import {
 	openCertificate as openCertificateDialog,

--- a/src/lib/bump-stats/index.ts
+++ b/src/lib/bump-stats/index.ts
@@ -47,8 +47,6 @@ export function bumpAggregatedUniqueStat(
 		.catch( ( err ) => Sentry.captureException( err ) );
 }
 
-export { bumpStat } from 'common/lib/bump-stat';
-
 // Returns UTC timestamp of the last time the stat was bumped, or null if it has never been bumped.
 async function getLastBump( group: string, stat: string ): Promise< number | null > {
 	const { lastBumpStats } = await loadUserData();

--- a/src/lib/bump-stats/index.ts
+++ b/src/lib/bump-stats/index.ts
@@ -1,5 +1,6 @@
 import * as Sentry from '@sentry/electron/main';
 import { isSameDay, isSameMonth, isSameWeek } from 'date-fns';
+import { bumpStat } from 'common/lib/bump-stat';
 import { AggregateInterval, StatsGroup, StatsMetric } from 'common/types/stats';
 import { loadUserData, lockAppdata, saveUserData, unlockAppdata } from 'src/storage/user-data';
 
@@ -46,26 +47,7 @@ export function bumpAggregatedUniqueStat(
 		.catch( ( err ) => Sentry.captureException( err ) );
 }
 
-// Returns true if we attempted to bump the stat
-export function bumpStat( group: StatsGroup, stat: StatsMetric, bumpInDev = false ) {
-	if ( process.env.E2E || ( process.env.NODE_ENV === 'development' && ! bumpInDev ) ) {
-		console.info( `Would have bumped stat: ${ group }=${ stat }` );
-		return false;
-	}
-
-	// Fire and forget POST request
-	fetch( 'https://public-api.wordpress.com/wpcom/v2/studio-app/bump-stat', {
-		method: 'POST',
-		headers: {
-			'Content-Type': 'application/json',
-		},
-		body: JSON.stringify( { group, stat } ),
-	} ).catch( () => {
-		// A failed request typically indicates a network issue, which we don't need to report
-	} );
-
-	return true;
-}
+export { bumpStat } from 'common/lib/bump-stat';
 
 // Returns UTC timestamp of the last time the stat was bumped, or null if it has never been bumped.
 async function getLastBump( group: string, stat: string ): Promise< number | null > {

--- a/src/lib/tests/bump-stats.test.ts
+++ b/src/lib/tests/bump-stats.test.ts
@@ -78,6 +78,32 @@ describe( 'bumpStat', () => {
 		expect( logger ).not.toHaveBeenCalled();
 		await waitFor( () => expect( nock.isDone() ).toBe( true ) );
 	} );
+
+	test( 'should not bump stat when group exceeds 26 characters', () => {
+		const errorLogger = jest.spyOn( console, 'error' ).mockImplementation( () => {} );
+		const longGroup = 'this-is-a-very-long-group-name-over-26-chars' as StatsGroup;
+
+		const result = bumpStat( longGroup, StatsMetric.SUCCESS );
+
+		expect( result ).toBe( false );
+		expect( errorLogger ).toHaveBeenCalledWith(
+			expect.stringContaining( 'exceeds maximum length of 26 characters' )
+		);
+		errorLogger.mockRestore();
+	} );
+
+	test( 'should not bump stat when stat exceeds 32 characters', () => {
+		const errorLogger = jest.spyOn( console, 'error' ).mockImplementation( () => {} );
+		const longStat = 'this-is-a-very-long-stat-name-over-32-characters' as StatsMetric;
+
+		const result = bumpStat( StatsGroup.STUDIO_APP_LAUNCH, longStat );
+
+		expect( result ).toBe( false );
+		expect( errorLogger ).toHaveBeenCalledWith(
+			expect.stringContaining( 'exceeds maximum length of 32 characters' )
+		);
+		errorLogger.mockRestore();
+	} );
 } );
 
 describe( 'bumpAggregatedUniqueStat', () => {

--- a/src/lib/tests/bump-stats.test.ts
+++ b/src/lib/tests/bump-stats.test.ts
@@ -1,8 +1,9 @@
 import { waitFor } from '@testing-library/react';
 import { readFile, writeFile } from 'atomically';
 import nock from 'nock';
+import { bumpStat } from 'common/lib/bump-stat';
 import { AggregateInterval, StatsGroup, StatsMetric } from 'common/types/stats';
-import { bumpAggregatedUniqueStat, bumpStat } from 'src/lib/bump-stats';
+import { bumpAggregatedUniqueStat } from 'src/lib/bump-stats';
 
 jest.mock( 'atomically', () => ( {
 	readFile: jest.fn(),

--- a/src/tests/ipc-handlers.test.ts
+++ b/src/tests/ipc-handlers.test.ts
@@ -6,10 +6,10 @@ import fs from 'fs';
 import { normalize } from 'path';
 import * as Sentry from '@sentry/electron/main';
 import { readFile } from 'atomically';
+import { bumpStat } from 'common/lib/bump-stat';
 import { isEmptyDir, pathExists } from 'common/lib/fs-utils';
 import { StatsGroup, StatsMetric } from 'common/types/stats';
 import { createSite, startServer, isFullscreen, importSite } from 'src/ipc-handlers';
-import { bumpStat } from 'src/lib/bump-stats';
 import { importBackup, defaultImporterOptions } from 'src/lib/import-export/import/import-manager';
 import { BackupArchiveInfo } from 'src/lib/import-export/import/types';
 import { keepSqliteIntegrationUpdated } from 'src/lib/sqlite-versions';
@@ -35,7 +35,7 @@ jest.mock( 'src/lib/wordpress-provider', () => ( {
 jest.mock( 'src/main-window' );
 jest.mock( '@sentry/electron/main' );
 jest.mock( 'src/lib/import-export/import/import-manager' );
-jest.mock( 'src/lib/bump-stats' );
+jest.mock( 'common/lib/bump-stat' );
 jest.mock( 'atomically' );
 
 jest.mock( 'common/lib/port-finder', () => ( {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

Resolves STU-694

## Proposed Changes

- unify two `bumpStat` functions into one
  - validate its parameter length to ensure requirements are met (PCYsg-G3-p2)
  - add related unit tests

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Testing long stat group:

1. Check out the branch and apply a change like this one:
```diff
diff --git a/common/types/stats.ts b/common/types/stats.ts
index 286132de..a1495a41 100644
--- a/common/types/stats.ts
+++ b/common/types/stats.ts
@@ -4,7 +4,7 @@ export enum StatsGroup {
 	STUDIO_APP_LAUNCH_TOTAL = 'studio-app-launch-total',
 	STUDIO_APP_LAUNCH_UNIQUE = 'studio-app-launch-uniques',
 	STUDIO_APP_LAUNCH_UNIQUE_MONTHLY = 'studio-app-launch-uniqs-mon',
-	STUDIO_SITE_CREATE = 'studio-app-site-create',
+	STUDIO_SITE_CREATE = 'studio-app-site-create-very-long-group-name',
 	STUDIO_IMPORT = 'studio-app-import',
 	STUDIO_EXPORT = 'studio-app-export',
 	// Studio CLI
```
2. Build the app with `npm install && npm start`.
3. Create a new site.
4. When you look into the terminal, there should be a similar error message logged:

<img width="1234" height="84" alt="CleanShot 2025-11-24 at 12 57 30@2x" src="https://github.com/user-attachments/assets/c5260061-8a3b-4b34-8ad0-c78084a8804e" />

5. Without the diff from the step 1 applied, the logs in the terminal should include stat bumps:

<img width="1234" height="84" alt="CleanShot 2025-11-24 at 15 19 45@2x" src="https://github.com/user-attachments/assets/aa9bd21a-59ed-448f-aa27-bff068aa8348" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?