### PR TITLE
Add architecture labels to Windows build names in CI notifications

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -156,7 +156,7 @@ def distribute_builds(
     },
     windows_update: {
       binary_path: File.join(BUILDS_FOLDER, 'make', 'squirrel.windows', 'x64', "studio-update.nupkg"),
-      name: 'Windows Update',
+      name: 'Windows - x64 Update',
       platform: 'Windows - x64',
 	  arch: 'x64',
       install_type: 'Update',
@@ -164,7 +164,7 @@ def distribute_builds(
     },
 	windows_arm64_update: {
 		binary_path: File.join(BUILDS_FOLDER, 'make', 'squirrel.windows', 'arm64', "studio-update.nupkg"),
-		name: 'Windows Update',
+		name: 'Windows - ARM64 Update',
 		platform: 'Windows - ARM64',
 		arch: 'arm64',
 		install_type: 'Update',
@@ -189,7 +189,7 @@ def distribute_builds(
     },
     windows: {
       binary_path: File.join(BUILDS_FOLDER, 'make', 'squirrel.windows', 'x64', 'studio-setup.exe'),
-      name: 'Windows',
+      name: 'Windows - x64',
       platform: 'Windows - x64',
 	  arch: 'x64',
       install_type: 'Full Install'
@@ -203,14 +203,14 @@ def distribute_builds(
     },
 	windows_appx_unsigned: {
 		binary_path: File.join(BUILDS_FOLDER, 'Studio-appx-x64-unsigned', "Studio #{appx_version} unsigned.appx"),
-		name: 'Windows (Unsigned Appx)',
+		name: 'Windows - x64 (Unsigned Appx)',
 		platform: 'Microsoft Store - x64',
 		arch: 'x64',
 		install_type: 'Full Install',
 	},
 	windows_arm64_appx_unsigned: {
 		binary_path: File.join(BUILDS_FOLDER, 'Studio-appx-arm64-unsigned', "Studio #{appx_version} unsigned.appx"),
-		name: 'Windows (Unsigned Appx)',
+		name: 'Windows - ARM64 (Unsigned Appx)',
 		platform: 'Microsoft Store - ARM64',
 		arch: 'arm64',
 		install_type: 'Full Install',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- N/A

## Proposed Changes

The PR:
- Adds x64/ARM64 architecture labels to Windows build names in Fastfile
- Fixes duplicate "Windows Update" and "Windows (Unsigned Appx)" entries that were missing architecture information
- Improves clarity in Slack notifications and Buildkite UI annotations

These names appear in:
- Slack notifications to #dotcom-studio (release builds)
- Buildkite UI annotations (all builds)
- Console output (dry run mode)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Confirm build goes through.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
