### PR TITLE
Clean releases json leftovers and fix versioning docs

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -160,11 +160,6 @@ steps:
       bundle exec fastlane distribute_dev_build
     agents:
       queue: mac
-    # Using concurrency_group to ensure the CI builds from `trunk` & the git tag, which are likely to run at roughly the
-    # same time, don't run into a race condition when downloading+updating+uploading the `releases.json` file from/to S3
-    concurrency_group: studio/release-manifest-update
-    concurrency: 1
-    concurrency_method: eager
     depends_on:
       - step: dev-mac
       - step: dev-windows
@@ -260,11 +255,6 @@ steps:
       bundle exec fastlane distribute_release_build
     agents:
       queue: mac
-    # Using concurrency_group to ensure the CI builds from `trunk` & the git tag, which are likely to run at roughly the
-    # same time, don't run into a race condition when downloading+updating+uploading the `releases.json` file from/to S3
-    concurrency_group: studio/release-manifest-update
-    concurrency: 1
-    concurrency_method: eager
     depends_on:
       - step: release-mac
       - step: release-windows

--- a/docs/versioning-and-updates.md
+++ b/docs/versioning-and-updates.md
@@ -31,7 +31,8 @@ duplicating the version number in the tag is still useful for comparing
 changesets in GitHub.
 
 To generate dev builds CI modifies `package.json`, using the first part of the
-version (before the hyphen) and appending `-dev.abc123`.
+version (before the hyphen) and appending `-devN` where N is the number of commits
+since the last release tag. For example: `1.0.0-dev123`.
 See `scripts/prepare-dev-build-version.mjs`.
 
 ## Updating Logic
@@ -40,6 +41,13 @@ Studio checks for updates on launch and every hour after that, for both release
 and dev builds. In case of dev build, if there is prod build bigger than the
 latest dev build, then will be updated to the prod build. Otherwise, to the latest dev build.
 
-## Releases Manifest and CDN
+## Update System
 
-The `releases.json` file serves as an authoritative source of update information for the App to update. It is generated entirely by the Apps CDN endpoint https://appscdn.wordpress.com/builds/wordpress-com-studio/releases.json proxied from https://public-api.wordpress.com/wpcom/v2/studio-app/updates?platform=darwin&arch=arm64&version=1.5.3-dev2
+Studio uses Electron's built-in auto-updater to check for updates. The update feed URL
+is constructed dynamically based on the current platform, architecture, and version,
+and queries the WordPress.com API endpoint:
+
+`https://public-api.wordpress.com/wpcom/v2/studio-app/updates?platform={platform}&arch={arch}&version={version}`
+
+The API returns information about available updates, and the app downloads and installs
+them automatically. See `src/updates.ts` for the implementation.


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-578

## Proposed Changes

- I propose to clean `releases json` leftovers and fix versioning docs to account for recent changes.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Confirm build goes through
- Confirm if updates are clear

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
