### PR TITLE
Rename Windows updates appending suffix `-full.nupkg`

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -260,6 +260,9 @@ def create_versioned_file(original_file_path:, version:, arch:)
   if original_filename.match(/\.app\.zip$/i)
 	original_filename = original_filename.gsub(/\.app\.zip$/i, '')
     extension = '.zip'
+  elsif original_filename.match(/\.nupkg$/i)
+    original_filename = original_filename.gsub(/\.nupkg$/i, '')
+    extension = '-full.nupkg'
   else
     extension = File.extname(original_filename)
   end


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-1043

## Proposed Changes

- Rename Windows updates to finish in `-full.nupkg`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- I already tested this PR by uploading the 1.6.4 versions.
- Download the Windows update files from Buildkite in `out/make/squirrel.windows/arm64` and `x64`
- Comment other builds that you won't test in https://github.com/Automattic/studio/blob/c2d8b1295fa4c6e2a2979023cc2feae374e616c9/fastlane/Fastfile#L140-L217 , or if you want to test all follow the testing steps from https://github.com/Automattic/studio/pull/1422
- Run `bundle install`
- Run `DRY_RUN=true BUILDKITE_BUILD_NUMBER=9237 BUILDKITE_TAG=v1.6.4 bundle exec fastlane distribute_release_build`
- Observe the renamed files in your out folder.

<img width="515" height="427" alt="Screenshot 2025-11-25 at 10 31 12" src="https://github.com/user-attachments/assets/774bf266-41a3-47af-90cb-f35534d357a8" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
