### PR TITLE
Make `build-for-windows.ps1` fail if `install-node-dependencies.sh` fails

### DIFF
--- a/.buildkite/commands/build-for-windows.ps1
+++ b/.buildkite/commands/build-for-windows.ps1
@@ -33,7 +33,7 @@ if ($Architecture -notin $VALID_ARCHITECTURES) {
 If ($LastExitCode -ne 0) { Exit $LastExitCode }
 
 Write-Host "--- :npm: Installing Node dependencies"
-bash .buildkite/commands/install-node-dependencies.sh
+bash -eu .buildkite/commands/install-node-dependencies.sh
 If ($LastExitCode -ne 0) { Exit $LastExitCode }
 
 Write-Host "--- :node: Building App for Windows ($BuildType - $Architecture)"

--- a/.buildkite/commands/build-for-windows.ps1
+++ b/.buildkite/commands/build-for-windows.ps1
@@ -33,7 +33,7 @@ if ($Architecture -notin $VALID_ARCHITECTURES) {
 If ($LastExitCode -ne 0) { Exit $LastExitCode }
 
 Write-Host "--- :npm: Installing Node dependencies"
-bash -eu .buildkite/commands/install-node-dependencies.sh
+bash .buildkite/commands/install-node-dependencies.sh
 If ($LastExitCode -ne 0) { Exit $LastExitCode }
 
 Write-Host "--- :node: Building App for Windows ($BuildType - $Architecture)"

--- a/.buildkite/commands/install-node-dependencies.sh
+++ b/.buildkite/commands/install-node-dependencies.sh
@@ -1,4 +1,6 @@
-#!/bin/bash -eu
+#!/bin/bash
+
+set -eu
 
 PLATFORM=$(uname -s)
 ARCHITECTURE=$(uname -m)

--- a/.buildkite/commands/install-node-dependencies.sh
+++ b/.buildkite/commands/install-node-dependencies.sh
@@ -42,12 +42,13 @@ npm ci \
   --maxsockets "$MAX_SOCKETS" \
   "$@"
 
-cd cli; npm ci \
+cd cli
+npm ci \
   --prefer-offline \
   --no-audit \
   --no-progress \
-  --maxsockets "$MAX_SOCKETS"; \
-  cd -
+  --maxsockets "$MAX_SOCKETS"
+cd -
 
 echo "--- :npm: Save cache if necessary"
 # Notice that we don't cache the local node_modules.


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-1044

## Proposed Changes

The Windows production build was borked in the recent 1.6.4 release because the `postinstall` script in `package.json` failed (specifically, `scripts/download-wp-server-files.ts` failed due to GitHub rate limits on the SQLite plugin download). This _should_ have caused the entire build to fail, but it didn't. 

The reason it didn't is that we don't call `set -e` in `install-node-dependencies.sh`. Instead, we use the shebang line at the top of that script to set the `-e` flag. However, because we specify that the `bash` executable should be used to run the script in `build-for-windows.ps1`, the shebang line is ignored, and the `-e` flag is never set. 

This PR fixes the problem by setting the `-eu` flags in `install-node-dependencies.sh` with an actual `set` command, and not in the shebang comment. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. The `Build for Windows` step should pass on CI

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
