### PR TITLE
Exclude `cli/node_modules` from make-pot script

### DIFF
--- a/scripts/make-pot.mjs
+++ b/scripts/make-pot.mjs
@@ -30,7 +30,7 @@ const commands = [
 	},
 	{
 		command:
-			'wp-babel-makepot "{./src,./cli,./common}/**/*.{js,jsx,ts,tsx}" --ignore "**/*.d.ts" --base "." --dir "./out/pots" --output "./out/pots/bundle-strings.pot"',
+			'wp-babel-makepot "{src,cli/commands,cli/lib,common}/**/*.{js,jsx,ts,tsx}" --ignore "**/*.d.ts" --base "." --dir "./out/pots" --output "./out/pots/bundle-strings.pot"',
 		description: 'Generating pot file with wp-babel-makepot',
 	},
 	{
@@ -40,7 +40,7 @@ const commands = [
 	{
 		command: `open "${ IMPORT_PAGE }"`,
 		description: `Opening the translation import page ${ IMPORT_PAGE } in the browser`,
-	}
+	},
 ];
 
 for ( const { command, description } of commands ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

Related to p1764074778769739-slack-C06DRMD6VPZ

## Proposed Changes

Exclude `cli/node_modules` when extracting strings for pot file. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Run `npm run make-pot`
2. Ensure that it doesn't generate any errors
3. Scan `out/pots/bundle-strings.pot` and ensure that it looks correct

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?