### PR TITLE
Adjust sync sites after untangling

### DIFF
--- a/src/modules/sync/components/sync-connected-sites.tsx
+++ b/src/modules/sync/components/sync-connected-sites.tsx
@@ -214,7 +214,7 @@ const SyncConnectedSitesSectionItem = ( {
 	return (
 		<div className="grid grid-cols-[max-content_1fr_max-content]">
 			<div
-				className={ `col-span-3 grid min-h-14 px-8 gap-4 justify-items-start items-center border-b border-a8c-gray-0 ${
+				className={ `col-span-3 grid px-8 gap-2 justify-items-start items-center ${
 					connectedSite.isPressable && ! connectedSite.environmentType
 						? 'grid-cols-[1fr_auto]'
 						: 'grid-cols-subgrid'
@@ -414,8 +414,8 @@ const SyncConnectedSiteSection = ( {
 	}
 
 	return (
-		<div key={ connectedSite.id } className="flex flex-col gap-2 mb-6">
-			<div className="flex items-center gap-2 border-b border-a8c-gray-0 px-8 pb-2.5">
+		<div key={ connectedSite.id } className="flex flex-col gap-2 border-b border-a8c-gray-0 py-5">
+			<div className="flex items-center gap-2 px-8">
 				{ logo }
 				<div className={ cx( 'a8c-label-semibold', hasConnectionErrors && 'error-message' ) }>
 					{ connectedSite.name }
@@ -443,7 +443,7 @@ const SyncConnectedSiteSection = ( {
 			</div>
 
 			{ hasConnectionErrors && (
-				<div className="flex items-center min-h-14 border-b border-a8c-gray-0 px-8">
+				<div className="flex items-center px-8">
 					<div className="text-[#3C434A]">
 						{ createInterpolateElement(
 							__(


### PR DESCRIPTION
## Related issues

- Fixes STU-918

## Proposed Changes
After untangling production and staging sites in Sync tab - there is more reasons to adjust the design to make items more gathered

## Testing Instructions
1. Run Studio
2. Open Sync tab
3. Connnect a few sites
4. Assert that everything looks good

<table>
<tr>
<td>BEFORE
<td>AFTER
</tr>
<tr>
<td><img width="1001" height="421" alt="Screenshot 2025-11-25 at 13 40 27" src="https://github.com/user-attachments/assets/379cabb1-b3d7-41db-a8b8-847990d45388" />
<td><img width="1028" height="454" alt="Screenshot 2025-11-25 at 13 39 52" src="https://github.com/user-attachments/assets/b13e300c-01c7-4763-8181-6e3de43b9692" />
</tr>
</table>