### PR TITLE
Blueprints: Add dedicated `blueprintDeeplink` step flow to handle blueprint deeplinks

### DIFF
--- a/src/modules/add-site/components/blueprint-deeplink.tsx
+++ b/src/modules/add-site/components/blueprint-deeplink.tsx
@@ -33,11 +33,7 @@ export default function BlueprintDeeplink( { selectedBlueprint }: BlueprintDeepl
 							{ __( 'Blueprint selected' ) }
 						</Text>
 					</HStack>
-					<Text
-						className="text-base font-medium text-gray-900 max-w-md px-4"
-						weight={ 400 }
-						title={ blueprintTitle }
-					>
+					<Text className="text-base font-medium text-gray-900 max-w-md px-4" weight={ 400 }>
 						{ blueprintTitle }
 					</Text>
 					{ blueprintDescription && (

--- a/src/modules/add-site/components/blueprint-deeplink.tsx
+++ b/src/modules/add-site/components/blueprint-deeplink.tsx
@@ -1,0 +1,52 @@
+import {
+	__experimentalVStack as VStack,
+	__experimentalHStack as HStack,
+	__experimentalHeading as Heading,
+	__experimentalText as Text,
+	Icon,
+} from '@wordpress/components';
+import { check } from '@wordpress/icons';
+import { useI18n } from '@wordpress/react-i18n';
+import { Blueprint } from 'src/stores/wpcom-api';
+
+interface BlueprintDeeplinkProps {
+	selectedBlueprint?: Blueprint;
+}
+
+export default function BlueprintDeeplink( { selectedBlueprint }: BlueprintDeeplinkProps ) {
+	const { __ } = useI18n();
+
+	const blueprintTitle = selectedBlueprint?.title || __( 'Blueprint' );
+	const blueprintDescription = selectedBlueprint?.excerpt || '';
+
+	return (
+		<VStack className="text-center w-full" alignment="top" spacing={ 0 }>
+			<Heading className="text-center text-[32px] text-gray-900 mb-[59px]" weight={ 500 }>
+				{ __( 'Start from a Blueprint' ) }
+			</Heading>
+
+			<div className="w-full max-w-[400px] h-[200px] mx-auto p-12 border-2 rounded-xl border-gray-300 bg-gray-50">
+				<VStack className="items-center justify-center h-full" spacing={ 2 }>
+					<HStack spacing={ 2 } alignment="center" className="text-green-600">
+						<Icon icon={ check } size={ 24 } />
+						<Text className="text-base font-medium text-gray-900">
+							{ __( 'Blueprint selected' ) }
+						</Text>
+					</HStack>
+					<Text
+						className="text-base font-medium text-gray-900 max-w-md px-4"
+						weight={ 400 }
+						title={ blueprintTitle }
+					>
+						{ blueprintTitle }
+					</Text>
+					{ blueprintDescription && (
+						<Text className="text-sm text-gray-600 max-w-md px-4 line-clamp-2">
+							{ blueprintDescription }
+						</Text>
+					) }
+				</VStack>
+			</div>
+		</VStack>
+	);
+}

--- a/src/modules/add-site/components/blueprint-deeplink.tsx
+++ b/src/modules/add-site/components/blueprint-deeplink.tsx
@@ -24,7 +24,7 @@ export default function BlueprintDeeplink( { selectedBlueprint }: BlueprintDeepl
 				{ __( 'Start from a Blueprint' ) }
 			</Heading>
 
-			<div className="w-full max-w-[400px] h-[200px] mx-auto p-12 border-2 rounded-xl border-gray-300 bg-gray-50">
+			<div className="w-full max-w-[400px] h-[250px] mx-auto p-12 border-2 rounded-xl border-gray-300 bg-gray-50">
 				<VStack className="items-center justify-center h-full" spacing={ 2 }>
 					<Icon icon={ check } size={ 24 } className="text-green-600" />
 					<Text className="text-xl font-medium text-gray-900">{ __( 'Blueprint selected' ) }</Text>

--- a/src/modules/add-site/components/blueprint-deeplink.tsx
+++ b/src/modules/add-site/components/blueprint-deeplink.tsx
@@ -1,6 +1,5 @@
 import {
 	__experimentalVStack as VStack,
-	__experimentalHStack as HStack,
 	__experimentalHeading as Heading,
 	__experimentalText as Text,
 	Icon,
@@ -27,12 +26,8 @@ export default function BlueprintDeeplink( { selectedBlueprint }: BlueprintDeepl
 
 			<div className="w-full max-w-[400px] h-[200px] mx-auto p-12 border-2 rounded-xl border-gray-300 bg-gray-50">
 				<VStack className="items-center justify-center h-full" spacing={ 2 }>
-					<HStack spacing={ 2 } alignment="center" className="text-green-600">
-						<Icon icon={ check } size={ 24 } />
-						<Text className="text-base font-medium text-gray-900">
-							{ __( 'Blueprint selected' ) }
-						</Text>
-					</HStack>
+					<Icon icon={ check } size={ 24 } className="text-green-600" />
+					<Text className="text-xl font-medium text-gray-900">{ __( 'Blueprint selected' ) }</Text>
 					<Text className="text-base font-medium text-gray-900 max-w-md px-4" weight={ 400 }>
 						{ blueprintTitle }
 					</Text>

--- a/src/modules/add-site/components/options.tsx
+++ b/src/modules/add-site/components/options.tsx
@@ -13,7 +13,12 @@ import { cx } from 'src/lib/cx';
 import { useRootSelector } from 'src/stores';
 import { BlueprintIcon } from './blueprint-icon';
 
-export type AddSiteFlowType = 'create' | 'blueprint' | 'backup' | 'pullRemote';
+export type AddSiteFlowType =
+	| 'create'
+	| 'blueprint'
+	| 'blueprintDeeplink'
+	| 'backup'
+	| 'pullRemote';
 interface AddSiteOptionsProps {
 	onOptionSelect: ( option: AddSiteFlowType ) => void;
 }

--- a/src/modules/add-site/components/stepper.tsx
+++ b/src/modules/add-site/components/stepper.tsx
@@ -9,10 +9,12 @@ interface StepperProps {
 	currentPath?: string;
 	onBack?: () => void;
 	onBlueprintContinue?: () => void;
+	onBlueprintDeeplinkContinue?: () => void;
 	onBackupContinue?: () => void;
 	onPullRemoteContinue?: () => void;
 	onCreateSubmit?: ( event: FormEvent ) => void;
 	canSubmitBlueprint?: boolean;
+	canSubmitBlueprintDeeplink?: boolean;
 	canSubmitBackup?: boolean;
 	canSubmitPullRemote?: boolean;
 	canSubmitCreate?: boolean;
@@ -22,10 +24,12 @@ export default function Stepper( {
 	currentPath,
 	onBack,
 	onBlueprintContinue,
+	onBlueprintDeeplinkContinue,
 	onBackupContinue,
 	onPullRemoteContinue,
 	onCreateSubmit,
 	canSubmitBlueprint,
+	canSubmitBlueprintDeeplink,
 	canSubmitBackup,
 	canSubmitPullRemote,
 	canSubmitCreate,
@@ -33,10 +37,12 @@ export default function Stepper( {
 	const { __ } = useI18n();
 	const { steps, isVisible, actionButton, onSubmit, canSubmit } = useStepper( {
 		onBlueprintContinue,
+		onBlueprintDeeplinkContinue,
 		onBackupContinue,
 		onPullRemoteContinue,
 		onCreateSubmit,
 		canSubmitBlueprint,
+		canSubmitBlueprintDeeplink,
 		canSubmitBackup,
 		canSubmitPullRemote,
 		canSubmitCreate,

--- a/src/modules/add-site/hooks/use-blueprint-deeplink.ts
+++ b/src/modules/add-site/hooks/use-blueprint-deeplink.ts
@@ -16,6 +16,7 @@ interface UseBlueprintDeeplinkOptions {
 	setPhpVersion: ( version: string ) => void;
 	setWpVersion: ( version: string ) => void;
 	setBlueprintPreferredVersions: ( versions: { php?: string; wp?: string } | undefined ) => void;
+	navigateToBlueprintDeeplink: () => void;
 }
 
 export function useBlueprintDeeplink( options: UseBlueprintDeeplinkOptions ): void {
@@ -27,6 +28,7 @@ export function useBlueprintDeeplink( options: UseBlueprintDeeplinkOptions ): vo
 		setPhpVersion,
 		setWpVersion,
 		setBlueprintPreferredVersions,
+		navigateToBlueprintDeeplink,
 	} = options;
 
 	const createBlueprintFromData = useCallback(
@@ -87,6 +89,7 @@ export function useBlueprintDeeplink( options: UseBlueprintDeeplinkOptions ): vo
 				setSelectedBlueprint( fileBlueprint );
 				applyPreferredVersions( blueprintJson );
 				openModal();
+				navigateToBlueprintDeeplink();
 			} catch ( error ) {
 				console.error( 'Failed to load blueprint from URL:', error );
 			}
@@ -98,6 +101,7 @@ export function useBlueprintDeeplink( options: UseBlueprintDeeplinkOptions ): vo
 			setSelectedBlueprint,
 			applyPreferredVersions,
 			openModal,
+			navigateToBlueprintDeeplink,
 		]
 	);
 	useIpcListener( 'add-site-with-blueprint', handleBlueprintFromUrl );

--- a/src/modules/add-site/hooks/use-stepper.ts
+++ b/src/modules/add-site/hooks/use-stepper.ts
@@ -16,10 +16,12 @@ interface StepperStep {
 
 interface StepperConfig {
 	onBlueprintContinue?: () => void;
+	onBlueprintDeeplinkContinue?: () => void;
 	onBackupContinue?: () => void;
 	onPullRemoteContinue?: () => void;
 	onCreateSubmit?: ( event: FormEvent ) => void;
 	canSubmitBlueprint?: boolean;
+	canSubmitBlueprintDeeplink?: boolean;
 	canSubmitBackup?: boolean;
 	canSubmitPullRemote?: boolean;
 	canSubmitCreate?: boolean;
@@ -65,6 +67,18 @@ export function useStepper( config?: StepperConfig ): UseStepper {
 			{ id: 'select-remote-site', label: __( 'Select a remote site' ), path: '/pullRemote' },
 			{ id: 'site-details', label: __( 'Site name & details' ), path: '/pullRemote/create' },
 		];
+
+		const blueprintDeeplinkSteps: StepperStep[] = [
+			{ id: 'blueprint-selected', label: __( 'Blueprint selected' ), path: '/blueprintDeeplink' },
+			{ id: 'site-details', label: __( 'Site name & details' ), path: '/blueprintDeeplink/create' },
+		];
+
+		if ( location.path?.startsWith( '/blueprintDeeplink' ) ) {
+			return {
+				flow: 'blueprintDeeplink',
+				steps: blueprintDeeplinkSteps,
+			};
+		}
 
 		if ( location.path?.startsWith( '/blueprint' ) ) {
 			return {
@@ -149,6 +163,7 @@ export function useStepper( config?: StepperConfig ): UseStepper {
 
 		switch ( location.path ) {
 			case '/blueprint':
+			case '/blueprintDeeplink':
 			case '/backup':
 			case '/pullRemote':
 				return {
@@ -157,6 +172,7 @@ export function useStepper( config?: StepperConfig ): UseStepper {
 				};
 			case '/create':
 			case '/blueprint/create':
+			case '/blueprintDeeplink/create':
 			case '/backup/create':
 			case '/pullRemote/create':
 				return {
@@ -176,6 +192,9 @@ export function useStepper( config?: StepperConfig ): UseStepper {
 			case '/blueprint':
 				config?.onBlueprintContinue?.();
 				break;
+			case '/blueprintDeeplink':
+				config?.onBlueprintDeeplinkContinue?.();
+				break;
 			case '/backup':
 				config?.onBackupContinue?.();
 				break;
@@ -184,6 +203,7 @@ export function useStepper( config?: StepperConfig ): UseStepper {
 				break;
 			case '/create':
 			case '/blueprint/create':
+			case '/blueprintDeeplink/create':
 			case '/backup/create':
 			case '/pullRemote/create':
 				config?.onCreateSubmit?.( { preventDefault: () => {} } as FormEvent );
@@ -198,12 +218,15 @@ export function useStepper( config?: StepperConfig ): UseStepper {
 		switch ( location.path ) {
 			case '/blueprint':
 				return config?.canSubmitBlueprint ?? false;
+			case '/blueprintDeeplink':
+				return config?.canSubmitBlueprintDeeplink ?? false;
 			case '/backup':
 				return config?.canSubmitBackup ?? false;
 			case '/pullRemote':
 				return config?.canSubmitPullRemote ?? false;
 			case '/create':
 			case '/blueprint/create':
+			case '/blueprintDeeplink/create':
 			case '/backup/create':
 			case '/pullRemote/create':
 				return config?.canSubmitCreate ?? false;

--- a/src/modules/add-site/hooks/use-stepper.ts
+++ b/src/modules/add-site/hooks/use-stepper.ts
@@ -50,8 +50,8 @@ export function useStepper( config?: StepperConfig ): UseStepper {
 
 	const stepperContext = useMemo( (): StepperContext | null => {
 		const blueprintSteps: StepperStep[] = [
-			{ id: 'choose-blueprint', label: __( 'Choose Blueprint' ), path: '/blueprint' },
-			{ id: 'site-details', label: __( 'Site name & details' ), path: '/blueprint/create' },
+			{ id: 'choose-blueprint', label: __( 'Choose Blueprint' ), path: '/blueprint/select' },
+			{ id: 'site-details', label: __( 'Site name & details' ), path: '/blueprint/select/create' },
 		];
 
 		const backupSteps: StepperStep[] = [
@@ -69,18 +69,22 @@ export function useStepper( config?: StepperConfig ): UseStepper {
 		];
 
 		const blueprintDeeplinkSteps: StepperStep[] = [
-			{ id: 'blueprint-selected', label: __( 'Blueprint details' ), path: '/blueprintDeeplink' },
-			{ id: 'site-details', label: __( 'Site name & details' ), path: '/blueprintDeeplink/create' },
+			{ id: 'blueprint-selected', label: __( 'Blueprint details' ), path: '/blueprint/deeplink' },
+			{
+				id: 'site-details',
+				label: __( 'Site name & details' ),
+				path: '/blueprint/deeplink/create',
+			},
 		];
 
-		if ( location.path?.startsWith( '/blueprintDeeplink' ) ) {
+		if ( location.path?.startsWith( '/blueprint/deeplink' ) ) {
 			return {
 				flow: 'blueprintDeeplink',
 				steps: blueprintDeeplinkSteps,
 			};
 		}
 
-		if ( location.path?.startsWith( '/blueprint' ) ) {
+		if ( location.path?.startsWith( '/blueprint/select' ) ) {
 			return {
 				flow: 'blueprint',
 				steps: blueprintSteps,
@@ -162,8 +166,8 @@ export function useStepper( config?: StepperConfig ): UseStepper {
 		}
 
 		switch ( location.path ) {
-			case '/blueprint':
-			case '/blueprintDeeplink':
+			case '/blueprint/select':
+			case '/blueprint/deeplink':
 			case '/backup':
 			case '/pullRemote':
 				return {
@@ -171,8 +175,8 @@ export function useStepper( config?: StepperConfig ): UseStepper {
 					isVisible: true,
 				};
 			case '/create':
-			case '/blueprint/create':
-			case '/blueprintDeeplink/create':
+			case '/blueprint/select/create':
+			case '/blueprint/deeplink/create':
 			case '/backup/create':
 			case '/pullRemote/create':
 				return {
@@ -189,10 +193,10 @@ export function useStepper( config?: StepperConfig ): UseStepper {
 		if ( ! location.path ) return;
 
 		switch ( location.path ) {
-			case '/blueprint':
+			case '/blueprint/select':
 				config?.onBlueprintContinue?.();
 				break;
-			case '/blueprintDeeplink':
+			case '/blueprint/deeplink':
 				config?.onBlueprintDeeplinkContinue?.();
 				break;
 			case '/backup':
@@ -202,8 +206,8 @@ export function useStepper( config?: StepperConfig ): UseStepper {
 				config?.onPullRemoteContinue?.();
 				break;
 			case '/create':
-			case '/blueprint/create':
-			case '/blueprintDeeplink/create':
+			case '/blueprint/select/create':
+			case '/blueprint/deeplink/create':
 			case '/backup/create':
 			case '/pullRemote/create':
 				config?.onCreateSubmit?.( { preventDefault: () => {} } as FormEvent );
@@ -216,17 +220,17 @@ export function useStepper( config?: StepperConfig ): UseStepper {
 		if ( ! location.path ) return false;
 
 		switch ( location.path ) {
-			case '/blueprint':
+			case '/blueprint/select':
 				return config?.canSubmitBlueprint ?? false;
-			case '/blueprintDeeplink':
+			case '/blueprint/deeplink':
 				return config?.canSubmitBlueprintDeeplink ?? false;
 			case '/backup':
 				return config?.canSubmitBackup ?? false;
 			case '/pullRemote':
 				return config?.canSubmitPullRemote ?? false;
 			case '/create':
-			case '/blueprint/create':
-			case '/blueprintDeeplink/create':
+			case '/blueprint/select/create':
+			case '/blueprint/deeplink/create':
 			case '/backup/create':
 			case '/pullRemote/create':
 				return config?.canSubmitCreate ?? false;

--- a/src/modules/add-site/hooks/use-stepper.ts
+++ b/src/modules/add-site/hooks/use-stepper.ts
@@ -69,7 +69,7 @@ export function useStepper( config?: StepperConfig ): UseStepper {
 		];
 
 		const blueprintDeeplinkSteps: StepperStep[] = [
-			{ id: 'blueprint-selected', label: __( 'Blueprint selected' ), path: '/blueprintDeeplink' },
+			{ id: 'blueprint-selected', label: __( 'Blueprint details' ), path: '/blueprintDeeplink' },
 			{ id: 'site-details', label: __( 'Site name & details' ), path: '/blueprintDeeplink/create' },
 		];
 

--- a/src/modules/add-site/index.tsx
+++ b/src/modules/add-site/index.tsx
@@ -20,6 +20,7 @@ import {
 } from 'src/stores/provider-constants-slice';
 import { useGetWordPressVersions } from 'src/stores/wordpress-versions-api';
 import { useGetBlueprints, Blueprint } from 'src/stores/wpcom-api';
+import BlueprintDeeplink from './components/blueprint-deeplink';
 import { AddSiteBlueprintSelector } from './components/blueprints';
 import CreateSite from './components/create-site';
 import ImportBackup from './components/import-backup';
@@ -131,6 +132,7 @@ function NavigationContent( props: NavigationContentProps ) {
 	const isOnCreatePath =
 		location.path === '/create' ||
 		location.path === '/blueprint/create' ||
+		location.path === '/blueprintDeeplink/create' ||
 		location.path === '/backup/create' ||
 		location.path === '/pullRemote/create';
 	const canSubmit =
@@ -139,9 +141,15 @@ function NavigationContent( props: NavigationContentProps ) {
 		! createSiteProps.error &&
 		( ! createSiteProps.useCustomDomain || ! createSiteProps.customDomainError );
 
+	const handleBlueprintDeeplinkContinue = useCallback( () => {
+		goTo( '/blueprintDeeplink/create' );
+	}, [ goTo ] );
+
 	const handleBack = useCallback( () => {
 		if ( location.path === '/blueprint/create' ) {
 			goTo( '/blueprint' );
+		} else if ( location.path === '/blueprintDeeplink/create' ) {
+			goTo( '/blueprintDeeplink' );
 		} else if ( location.path === '/backup/create' ) {
 			goTo( '/backup' );
 		} else if ( location.path === '/pullRemote/create' ) {
@@ -149,13 +157,14 @@ function NavigationContent( props: NavigationContentProps ) {
 		} else if (
 			location.path === '/backup' ||
 			location.path === '/blueprint' ||
+			location.path === '/blueprintDeeplink' ||
 			location.path === '/create' ||
 			location.path === '/pullRemote'
 		) {
 			if ( location.path === '/backup' ) {
 				createSiteProps.setFileForImport( null );
 			}
-			if ( location.path === '/blueprint' ) {
+			if ( location.path === '/blueprint' || location.path === '/blueprintDeeplink' ) {
 				createSiteProps.setSelectedBlueprint();
 				setBlueprintPreferredVersions( undefined );
 			}
@@ -240,6 +249,15 @@ function NavigationContent( props: NavigationContentProps ) {
 			<Navigator.Screen className="flex-1" path="/create">
 				<CreateSite { ...createSiteProps } />
 			</Navigator.Screen>
+			<Navigator.Screen className="flex-1" path="/blueprintDeeplink">
+				<BlueprintDeeplink selectedBlueprint={ createSiteProps.selectedBlueprint } />
+			</Navigator.Screen>
+			<Navigator.Screen className="flex-1" path="/blueprintDeeplink/create">
+				<CreateSite
+					{ ...createSiteProps }
+					blueprintPreferredVersions={ blueprintPreferredVersions }
+				/>
+			</Navigator.Screen>
 			<Navigator.Screen className="flex-1" path="/backup">
 				<ImportBackup
 					onFileSelect={ handleBackupFileSelect }
@@ -267,10 +285,12 @@ function NavigationContent( props: NavigationContentProps ) {
 				currentPath={ location.path }
 				onBack={ handleBack }
 				onBlueprintContinue={ handleBlueprintContinue }
+				onBlueprintDeeplinkContinue={ handleBlueprintDeeplinkContinue }
 				onBackupContinue={ handleBackupContinue }
 				onPullRemoteContinue={ handlePullRemoteContinue }
 				onCreateSubmit={ createSiteProps.handleSubmit }
 				canSubmitBlueprint={ !! createSiteProps.selectedBlueprint }
+				canSubmitBlueprintDeeplink={ !! createSiteProps.selectedBlueprint }
 				canSubmitBackup={ !! createSiteProps.fileForImport }
 				canSubmitPullRemote={ !! selectedRemoteSite }
 				canSubmitCreate={ !! canSubmit }
@@ -379,7 +399,7 @@ export default function AddSite( { className, variant = 'outlined' }: AddSitePro
 		setBlueprintPreferredVersions,
 	} );
 
-	const initialNavigatorPath = selectedBlueprint ? '/blueprint/create' : '/';
+	const initialNavigatorPath = selectedBlueprint ? '/blueprintDeeplink' : '/';
 
 	const closeModal = useCallback( () => {
 		setShowModal( false );

--- a/src/modules/add-site/index.tsx
+++ b/src/modules/add-site/index.tsx
@@ -66,6 +66,8 @@ interface NavigationContentProps {
 	setBlueprintPreferredVersions: ( versions: { php?: string; wp?: string } | undefined ) => void;
 	selectedRemoteSite?: SyncSite;
 	setSelectedRemoteSite: ( site?: SyncSite ) => void;
+	isDeeplinkFlow: boolean;
+	setIsDeeplinkFlow: ( isDeeplink: boolean ) => void;
 }
 
 function NavigationContent( props: NavigationContentProps ) {
@@ -79,10 +81,19 @@ function NavigationContent( props: NavigationContentProps ) {
 		setBlueprintPreferredVersions,
 		selectedRemoteSite,
 		setSelectedRemoteSite,
+		isDeeplinkFlow,
+		setIsDeeplinkFlow,
 		...createSiteProps
 	} = props;
 
 	const { setSelectedBlueprint, setPhpVersion, setWpVersion } = createSiteProps;
+
+	useEffect( () => {
+		if ( isDeeplinkFlow ) {
+			goTo( '/blueprintDeeplink' );
+			setIsDeeplinkFlow( false );
+		}
+	}, [ isDeeplinkFlow, goTo, setIsDeeplinkFlow ] );
 
 	const handleOptionSelect = useCallback(
 		( option: AddSiteFlowType ) => {
@@ -308,6 +319,7 @@ export default function AddSite( { className, variant = 'outlined' }: AddSitePro
 	const [ blueprintPreferredVersions, setBlueprintPreferredVersions ] = useState<
 		{ php?: string; wp?: string } | undefined
 	>();
+	const [ isDeeplinkFlow, setIsDeeplinkFlow ] = useState( false );
 
 	const {
 		data: blueprintsData,
@@ -397,6 +409,9 @@ export default function AddSite( { className, variant = 'outlined' }: AddSitePro
 		setPhpVersion,
 		setWpVersion,
 		setBlueprintPreferredVersions,
+		navigateToBlueprintDeeplink: () => {
+			setIsDeeplinkFlow( true );
+		},
 	} );
 
 	const initialNavigatorPath = selectedBlueprint ? '/blueprintDeeplink' : '/';
@@ -476,6 +491,8 @@ export default function AddSite( { className, variant = 'outlined' }: AddSitePro
 						setBlueprintPreferredVersions={ setBlueprintPreferredVersions }
 						selectedRemoteSite={ selectedRemoteSite }
 						setSelectedRemoteSite={ setSelectedRemoteSite }
+						isDeeplinkFlow={ isDeeplinkFlow }
+						setIsDeeplinkFlow={ setIsDeeplinkFlow }
 					/>
 				</Navigator>
 			</FullscreenModal>

--- a/src/modules/add-site/index.tsx
+++ b/src/modules/add-site/index.tsx
@@ -90,7 +90,7 @@ function NavigationContent( props: NavigationContentProps ) {
 
 	useEffect( () => {
 		if ( isDeeplinkFlow ) {
-			goTo( '/blueprintDeeplink' );
+			goTo( '/blueprint/deeplink' );
 			setIsDeeplinkFlow( false );
 		}
 	}, [ isDeeplinkFlow, goTo, setIsDeeplinkFlow ] );
@@ -98,7 +98,7 @@ function NavigationContent( props: NavigationContentProps ) {
 	const handleOptionSelect = useCallback(
 		( option: AddSiteFlowType ) => {
 			if ( option === 'blueprint' ) {
-				goTo( '/blueprint' );
+				goTo( '/blueprint/select' );
 			} else if ( option === 'create' ) {
 				goTo( '/create' );
 			} else if ( option === 'backup' ) {
@@ -112,7 +112,7 @@ function NavigationContent( props: NavigationContentProps ) {
 
 	const handleBlueprintContinue = useCallback( () => {
 		if ( createSiteProps.selectedBlueprint ) {
-			goTo( '/blueprint/create' );
+			goTo( '/blueprint/select/create' );
 		}
 	}, [ createSiteProps.selectedBlueprint, goTo ] );
 
@@ -142,8 +142,8 @@ function NavigationContent( props: NavigationContentProps ) {
 
 	const isOnCreatePath =
 		location.path === '/create' ||
-		location.path === '/blueprint/create' ||
-		location.path === '/blueprintDeeplink/create' ||
+		location.path === '/blueprint/select/create' ||
+		location.path === '/blueprint/deeplink/create' ||
 		location.path === '/backup/create' ||
 		location.path === '/pullRemote/create';
 	const canSubmit =
@@ -153,29 +153,29 @@ function NavigationContent( props: NavigationContentProps ) {
 		( ! createSiteProps.useCustomDomain || ! createSiteProps.customDomainError );
 
 	const handleBlueprintDeeplinkContinue = useCallback( () => {
-		goTo( '/blueprintDeeplink/create' );
+		goTo( '/blueprint/deeplink/create' );
 	}, [ goTo ] );
 
 	const handleBack = useCallback( () => {
-		if ( location.path === '/blueprint/create' ) {
-			goTo( '/blueprint' );
-		} else if ( location.path === '/blueprintDeeplink/create' ) {
-			goTo( '/blueprintDeeplink' );
+		if ( location.path === '/blueprint/select/create' ) {
+			goTo( '/blueprint/select' );
+		} else if ( location.path === '/blueprint/deeplink/create' ) {
+			goTo( '/blueprint/deeplink' );
 		} else if ( location.path === '/backup/create' ) {
 			goTo( '/backup' );
 		} else if ( location.path === '/pullRemote/create' ) {
 			goTo( '/pullRemote' );
 		} else if (
 			location.path === '/backup' ||
-			location.path === '/blueprint' ||
-			location.path === '/blueprintDeeplink' ||
+			location.path === '/blueprint/select' ||
+			location.path === '/blueprint/deeplink' ||
 			location.path === '/create' ||
 			location.path === '/pullRemote'
 		) {
 			if ( location.path === '/backup' ) {
 				createSiteProps.setFileForImport( null );
 			}
-			if ( location.path === '/blueprint' || location.path === '/blueprintDeeplink' ) {
+			if ( location.path === '/blueprint/select' || location.path === '/blueprint/deeplink' ) {
 				createSiteProps.setSelectedBlueprint();
 				setBlueprintPreferredVersions( undefined );
 			}
@@ -241,7 +241,7 @@ function NavigationContent( props: NavigationContentProps ) {
 			<Navigator.Screen className="flex-1" path="/">
 				<AddSiteOptions onOptionSelect={ handleOptionSelect } />
 			</Navigator.Screen>
-			<Navigator.Screen className="flex-1" path="/blueprint">
+			<Navigator.Screen className="flex-1" path="/blueprint/select">
 				<AddSiteBlueprintSelector
 					blueprints={ blueprints }
 					errorMessage={ blueprintsErrorMessage }
@@ -251,7 +251,7 @@ function NavigationContent( props: NavigationContentProps ) {
 					onFileBlueprintSelect={ handleFileBlueprintSelect }
 				/>
 			</Navigator.Screen>
-			<Navigator.Screen className="flex-1" path="/blueprint/create">
+			<Navigator.Screen className="flex-1" path="/blueprint/select/create">
 				<CreateSite
 					{ ...createSiteProps }
 					blueprintPreferredVersions={ blueprintPreferredVersions }
@@ -260,10 +260,10 @@ function NavigationContent( props: NavigationContentProps ) {
 			<Navigator.Screen className="flex-1" path="/create">
 				<CreateSite { ...createSiteProps } />
 			</Navigator.Screen>
-			<Navigator.Screen className="flex-1" path="/blueprintDeeplink">
+			<Navigator.Screen className="flex-1" path="/blueprint/deeplink">
 				<BlueprintDeeplink selectedBlueprint={ createSiteProps.selectedBlueprint } />
 			</Navigator.Screen>
-			<Navigator.Screen className="flex-1" path="/blueprintDeeplink/create">
+			<Navigator.Screen className="flex-1" path="/blueprint/deeplink/create">
 				<CreateSite
 					{ ...createSiteProps }
 					blueprintPreferredVersions={ blueprintPreferredVersions }
@@ -414,7 +414,7 @@ export default function AddSite( { className, variant = 'outlined' }: AddSitePro
 		},
 	} );
 
-	const initialNavigatorPath = selectedBlueprint ? '/blueprintDeeplink' : '/';
+	const initialNavigatorPath = selectedBlueprint ? '/blueprint/deeplink' : '/';
 
 	const closeModal = useCallback( () => {
 		setShowModal( false );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Resolves STU-1039

## Proposed Changes

- introduce a new "Start from a Blueprint" step / flow for blueprint deeplinks

<img width="2736" height="1760" alt="CleanShot 2025-11-26 at 11 17 59@2x" src="https://github.com/user-attachments/assets/a6406142-ca4e-4a24-83ce-c73b428b965a" />

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR branch and build the app with `npm install && npm start`.
2. Try to open the blueprint deeplinks provided here: https://jsbin.com/levaburate/2/edit?html,css,output.
  - First two should result in a dialog error message.
  - The third one should get you to the new "Start from a Blueprint" step that displays blueprint title and description. It should also allow you to create a new site with it.
3. Try to open the following Base64-encoded blueprint links:
 
This one should result in an error message:

```
wp-studio://add-site?blueprint=ewogICJuYW1lIjogIk1lb3dzeSIsCiAgInNwZWNpZXMiOiAiY2F0IiwKICAiaW52YWxpZCI6ICJ0aGlzIGlzIG5vdCBhIHZhbGlkIGJsdWVwcmludCIKICAibWlzc2luZyI6ICJjb21tYSBhYm92ZSIKfQo=
```
 
This one should work correctly, display blueprint title and description and let you create a new site with it:

```
wp-studio://add-site?blueprint=eyJtZXRhIjp7InRpdGxlIjoiVGhpcyBpcyBhIHRlc3QgYmx1ZXByaW50IiwiZGVzY3JpcHRpb24iOiJJdCBpbnN0YWxscyBBc3RyYSB0aGVtZSBhbmQgWW9hc3QgU0VPIHBsdWdpbiIsImF1dGhvciI6Iml2YW4iLCJjYXRlZ29yaWVzIjpbInJzcyIsInNvY2lhbCB3ZWIiXX0sInByZWZlcnJlZFZlcnNpb25zIjp7InBocCI6IjguMyIsIndwIjoibGF0ZXN0In0sInN0ZXBzIjpbeyJzdGVwIjoiaW5zdGFsbFRoZW1lIiwidGhlbWVEYXRhIjp7InJlc291cmNlIjoid29yZHByZXNzLm9yZy90aGVtZXMiLCJzbHVnIjoiYXN0cmEifSwib3B0aW9ucyI6eyJhY3RpdmF0ZSI6dHJ1ZX19LHsic3RlcCI6Imluc3RhbGxQbHVnaW4iLCJwbHVnaW5EYXRhIjp7InJlc291cmNlIjoid29yZHByZXNzLm9yZy9wbHVnaW5zIiwic2x1ZyI6IndvcmRwcmVzcy1zZW8ifSwib3B0aW9ucyI6eyJhY3RpdmF0ZSI6dHJ1ZX19XX0=
```

4. Try to manually create sites using blueprint files from 39a4e-pb. The results should be as expected - there should be no regressions.

5. If you like, you can also test with your own blueprint files and blueprint deeplinks. 🙂 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
