### PR TITLE
Remove Sentry tracking for errors that are already handled in UI

### DIFF
--- a/src/modules/cli/lib/install-macos.ts
+++ b/src/modules/cli/lib/install-macos.ts
@@ -30,13 +30,13 @@ export async function installCLIOnMacOSWithConfirmation() {
 			message: __( 'The CLI has been installed successfully.' ),
 		} );
 	} catch ( error ) {
-		Sentry.captureException( error );
 		console.error( 'Failed to install CLI', error );
 
 		let message: string = __(
 			'There was an unknown error. Please check the logs for more information.'
 		);
 
+		// Don't report expected user errors to Sentry
 		if ( error instanceof Error ) {
 			if ( error.message === ERROR_FILE_ALREADY_EXISTS ) {
 				message = sprintf(
@@ -48,7 +48,12 @@ export async function installCLIOnMacOSWithConfirmation() {
 				);
 			} else if ( error.message === ERROR_PERMISSION ) {
 				message = __( 'Please ensure you grant Studio admin permissions when prompted.' );
+			} else if ( error.message !== ERROR_WRONG_PLATFORM ) {
+				// Only report unexpected errors to Sentry
+				Sentry.captureException( error );
 			}
+		} else {
+			Sentry.captureException( error );
 		}
 
 		const mainWindow = await getMainWindow();


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STUDIO-43D (Sentry)

## Proposed Changes

- Let's stop reporting expected user errors to Sentry during CLI installation.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Remove Studio CLI:
```
rm /usr/local/bin/studio
```
2. Click "Install CLI..." in the top menu
3. Cancel prompt
4. Confirm the Sentry message was not logged in the console.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
