### PR TITLE
Blueprints: Add validation warning display to the deeplink flow

### DIFF
--- a/common/lib/blueprint-validation.ts
+++ b/common/lib/blueprint-validation.ts
@@ -117,13 +117,18 @@ export function filterUnsupportedBlueprintFeatures(
 	return filtered;
 }
 
+export type BlueprintValidationWarning = {
+	feature: string;
+	reason: string;
+};
+
 type BlueprintValidationError = {
 	valid: false;
 	error: string;
 };
 type BlueprintValidationSuccess = {
 	valid: true;
-	warnings: { feature: string; reason: string }[];
+	warnings: BlueprintValidationWarning[];
 };
 export type BlueprintValidationResult = BlueprintValidationError | BlueprintValidationSuccess;
 

--- a/src/ipc-utils.ts
+++ b/src/ipc-utils.ts
@@ -1,5 +1,6 @@
 import crypto from 'crypto';
 import { BrowserWindow } from 'electron';
+import { BlueprintValidationWarning } from 'common/lib/blueprint-validation';
 import { PreviewCommandLoggerAction } from 'common/logger-actions';
 import { ImportExportEventData } from 'src/lib/import-export/handle-events';
 import { StoredToken } from 'src/lib/oauth';
@@ -22,7 +23,7 @@ export interface IpcEvents {
 	'add-site-with-blueprint': [
 		{
 			blueprintPath: string;
-			warnings?: Array< { feature: string; reason: string } >;
+			warnings?: BlueprintValidationWarning[];
 		},
 	];
 	'auth-updated': [ { token: StoredToken } | { error: unknown } ];

--- a/src/ipc-utils.ts
+++ b/src/ipc-utils.ts
@@ -19,7 +19,12 @@ type SnapshotKeyValueEventData = {
 
 export interface IpcEvents {
 	'add-site': [ void ];
-	'add-site-with-blueprint': [ { blueprintPath: string } ];
+	'add-site-with-blueprint': [
+		{
+			blueprintPath: string;
+			warnings?: Array< { feature: string; reason: string } >;
+		},
+	];
 	'auth-updated': [ { token: StoredToken } | { error: unknown } ];
 	'on-export': [ ImportExportEventData, string ];
 	'on-import': [ ImportExportEventData, string ];

--- a/src/lib/deeplink/handlers/add-site-with-blueprint.ts
+++ b/src/lib/deeplink/handlers/add-site-with-blueprint.ts
@@ -64,7 +64,10 @@ export async function handleAddSiteWithBlueprint( urlObject: URL ): Promise< voi
 			throw new Error( validation.error || __( 'Invalid Blueprint format' ) );
 		}
 
-		await sendIpcEventToRenderer( 'add-site-with-blueprint', { blueprintPath } );
+		await sendIpcEventToRenderer( 'add-site-with-blueprint', {
+			blueprintPath,
+			warnings: validation.warnings,
+		} );
 	} catch ( error ) {
 		console.error( 'Failed to process blueprint from deeplink:', error );
 

--- a/src/lib/deeplink/tests/add-site.test.ts
+++ b/src/lib/deeplink/tests/add-site.test.ts
@@ -69,6 +69,7 @@ describe( 'handleAddSiteWithBlueprint', () => {
 		);
 		expect( sendIpcEventToRenderer ).toHaveBeenCalledWith( 'add-site-with-blueprint', {
 			blueprintPath: expect.stringContaining( 'blueprint-' ),
+			warnings: [],
 		} );
 		expect( mockMainWindow.focus ).toHaveBeenCalled();
 	} );
@@ -192,6 +193,7 @@ describe( 'handleAddSiteWithBlueprint', () => {
 			);
 			expect( sendIpcEventToRenderer ).toHaveBeenCalledWith( 'add-site-with-blueprint', {
 				blueprintPath: expect.stringContaining( 'blueprint-' ),
+				warnings: [],
 			} );
 			expect( download ).not.toHaveBeenCalled();
 		} );

--- a/src/modules/add-site/components/blueprint-deeplink.tsx
+++ b/src/modules/add-site/components/blueprint-deeplink.tsx
@@ -7,7 +7,7 @@ import {
 import { check } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { Blueprint } from 'src/stores/wpcom-api';
-import { BlueprintWarningNotice } from './blueprints';
+import { BlueprintWarningNotice } from './blueprint-warning-notice';
 
 interface BlueprintDeeplinkProps {
 	selectedBlueprint?: Blueprint;

--- a/src/modules/add-site/components/blueprint-deeplink.tsx
+++ b/src/modules/add-site/components/blueprint-deeplink.tsx
@@ -6,12 +6,13 @@ import {
 } from '@wordpress/components';
 import { check } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
+import { BlueprintValidationWarning } from 'common/lib/blueprint-validation';
 import { Blueprint } from 'src/stores/wpcom-api';
 import { BlueprintWarningNotice } from './blueprint-warning-notice';
 
 interface BlueprintDeeplinkProps {
 	selectedBlueprint?: Blueprint;
-	warnings?: Array< { feature: string; reason: string } >;
+	warnings?: BlueprintValidationWarning[];
 }
 
 export default function BlueprintDeeplink( {

--- a/src/modules/add-site/components/blueprint-deeplink.tsx
+++ b/src/modules/add-site/components/blueprint-deeplink.tsx
@@ -7,12 +7,17 @@ import {
 import { check } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { Blueprint } from 'src/stores/wpcom-api';
+import { BlueprintWarningNotice } from './blueprints';
 
 interface BlueprintDeeplinkProps {
 	selectedBlueprint?: Blueprint;
+	warnings?: Array< { feature: string; reason: string } >;
 }
 
-export default function BlueprintDeeplink( { selectedBlueprint }: BlueprintDeeplinkProps ) {
+export default function BlueprintDeeplink( {
+	selectedBlueprint,
+	warnings,
+}: BlueprintDeeplinkProps ) {
 	const { __ } = useI18n();
 
 	const blueprintTitle = selectedBlueprint?.title || __( 'Blueprint' );
@@ -23,6 +28,12 @@ export default function BlueprintDeeplink( { selectedBlueprint }: BlueprintDeepl
 			<Heading className="text-center text-[32px] text-gray-900 mb-[59px]" weight={ 500 }>
 				{ __( 'Start from a Blueprint' ) }
 			</Heading>
+
+			<BlueprintWarningNotice
+				warnings={ warnings }
+				fileName={ blueprintTitle }
+				className="w-full max-w-4xl mx-auto mb-4"
+			/>
 
 			<div className="w-full max-w-[400px] h-[250px] mx-auto p-12 border-2 rounded-xl border-gray-300 bg-gray-50">
 				<VStack className="items-center justify-center h-full" spacing={ 2 }>

--- a/src/modules/add-site/components/blueprint-deeplink.tsx
+++ b/src/modules/add-site/components/blueprint-deeplink.tsx
@@ -26,14 +26,14 @@ export default function BlueprintDeeplink( {
 
 	return (
 		<VStack className="text-center w-full" alignment="top" spacing={ 0 }>
-			<Heading className="text-center text-[32px] text-gray-900 mb-[59px]" weight={ 500 }>
+			<Heading className="text-center text-[32px] text-gray-900 mb-5" weight={ 500 }>
 				{ __( 'Start from a Blueprint' ) }
 			</Heading>
 
 			<BlueprintWarningNotice
 				warnings={ warnings }
 				fileName={ blueprintTitle }
-				className="w-full max-w-4xl mx-auto mb-4"
+				className="w-full max-w-4xl mx-auto mb-6"
 			/>
 
 			<div className="w-full max-w-[400px] h-[250px] mx-auto p-12 border-2 rounded-xl border-gray-300 bg-gray-50">

--- a/src/modules/add-site/components/blueprint-warning-notice.tsx
+++ b/src/modules/add-site/components/blueprint-warning-notice.tsx
@@ -9,9 +9,10 @@ import {
 import { Icon, caution } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { useState } from 'react';
+import { BlueprintValidationWarning } from 'common/lib/blueprint-validation';
 
 interface BlueprintIssuesModalProps {
-	warnings: Array< { feature: string; reason: string } > | undefined;
+	warnings: BlueprintValidationWarning[] | undefined;
 	fileName: string;
 	isOpen: boolean;
 	onClose: () => void;
@@ -83,7 +84,7 @@ function BlueprintIssuesModal( {
 }
 
 interface BlueprintWarningNoticeProps {
-	warnings: Array< { feature: string; reason: string } > | undefined;
+	warnings: BlueprintValidationWarning[] | undefined;
 	fileName: string;
 	className?: string;
 }

--- a/src/modules/add-site/components/blueprint-warning-notice.tsx
+++ b/src/modules/add-site/components/blueprint-warning-notice.tsx
@@ -1,0 +1,129 @@
+import {
+	__experimentalVStack as VStack,
+	__experimentalHStack as HStack,
+	__experimentalText as Text,
+	Button,
+	Modal,
+	Notice,
+} from '@wordpress/components';
+import { Icon, caution } from '@wordpress/icons';
+import { useI18n } from '@wordpress/react-i18n';
+import { useState } from 'react';
+
+interface BlueprintIssuesModalProps {
+	warnings: Array< { feature: string; reason: string } > | undefined;
+	fileName: string;
+	isOpen: boolean;
+	onClose: () => void;
+}
+
+function BlueprintIssuesModal( {
+	warnings,
+	fileName,
+	isOpen,
+	onClose,
+}: BlueprintIssuesModalProps ) {
+	const { __ } = useI18n();
+
+	if ( ! isOpen ) {
+		return null;
+	}
+
+	return (
+		<Modal
+			className="blueprints-issues-modal"
+			title={ __( 'Blueprint Details' ) }
+			onRequestClose={ onClose }
+			size="medium"
+		>
+			<div className="h-full flex flex-col gap-1">
+				<Text className="font-medium text-gray-900">{ fileName }</Text>
+				<Text>
+					{ warnings?.length &&
+						__(
+							'The following features are not supported in Studio and will be automatically removed:'
+						) }
+				</Text>
+				<div className="flex-1 overflow-y-auto">
+					<VStack spacing={ 3 } className="divide-y divide-gray-200">
+						{ warnings?.map( ( warningItem, index ) => (
+							<div key={ index } className={ index > 0 ? 'pt-3' : '' }>
+								<HStack alignment="topLeft" spacing={ 2 }>
+									<Icon
+										icon={ caution }
+										className="text-orange-500 mt-1 flex-shrink-0"
+										size={ 20 }
+									/>
+									<VStack spacing={ 1 }>
+										<Text weight={ 600 } className="text-base">
+											{ warningItem.feature }
+										</Text>
+										<Text className="text-sm text-gray-700">{ warningItem.reason }</Text>
+									</VStack>
+								</HStack>
+							</div>
+						) ) }
+					</VStack>
+				</div>
+				<div className="pt-4 border-t border-gray-200">
+					<Text className="text-sm text-gray-600">
+						{ __(
+							'Your Blueprint will still work, but these features will be skipped during site creation.'
+						) }
+					</Text>
+				</div>
+				<HStack alignment="right">
+					<Button variant="primary" onClick={ onClose }>
+						{ __( 'Got it' ) }
+					</Button>
+				</HStack>
+			</div>
+		</Modal>
+	);
+}
+
+interface BlueprintWarningNoticeProps {
+	warnings: Array< { feature: string; reason: string } > | undefined;
+	fileName: string;
+	className?: string;
+}
+
+export function BlueprintWarningNotice( {
+	warnings,
+	fileName,
+	className,
+}: BlueprintWarningNoticeProps ) {
+	const { __ } = useI18n();
+	const [ showIssuesModal, setShowIssuesModal ] = useState( false );
+
+	if ( ! warnings || warnings.length === 0 ) {
+		return null;
+	}
+
+	return (
+		<>
+			<BlueprintIssuesModal
+				warnings={ warnings }
+				fileName={ fileName }
+				isOpen={ showIssuesModal }
+				onClose={ () => setShowIssuesModal( false ) }
+			/>
+			<Notice status="warning" isDismissible={ false } className={ className }>
+				<div className="flex justify-between items-center w-full">
+					<span>
+						{ __(
+							'This Blueprint uses unsupported features in Studio and might not work as expected.'
+						) }
+					</span>
+					<Button
+						variant="link"
+						onClick={ () => setShowIssuesModal( true ) }
+						className="!text-inherit !p-0 !underline"
+					>
+						{ __( 'View details' ) }
+					</Button>
+				</div>
+			</Notice>
+		</>
+	);
+}

--- a/src/modules/add-site/components/blueprints.tsx
+++ b/src/modules/add-site/components/blueprints.tsx
@@ -4,19 +4,19 @@ import {
 	__experimentalHeading as Heading,
 	__experimentalText as Text,
 	Button,
-	Modal,
 	Notice,
 } from '@wordpress/components';
 import { DataViews, View } from '@wordpress/dataviews';
 import { createInterpolateElement } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
-import { Icon, external, upload, caution } from '@wordpress/icons';
+import { Icon, external, upload } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { useCallback, useRef, useState, useMemo } from 'react';
 import StudioButton from 'src/components/button';
 import { cx } from 'src/lib/cx';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 import { useGetBlueprints } from 'src/stores/wpcom-api';
+import { BlueprintWarningNotice } from './blueprint-warning-notice';
 
 import './blueprints.css';
 
@@ -38,124 +38,6 @@ interface Blueprint {
 interface DataViewBlueprint extends Blueprint {
 	isSelected: boolean;
 	categories: string[];
-}
-
-interface BlueprintIssuesModalProps {
-	warnings: Array< { feature: string; reason: string } > | undefined;
-	fileName: string;
-	isOpen: boolean;
-	onClose: () => void;
-}
-
-function BlueprintIssuesModal( {
-	warnings,
-	fileName,
-	isOpen,
-	onClose,
-}: BlueprintIssuesModalProps ) {
-	const { __ } = useI18n();
-
-	if ( ! isOpen ) {
-		return null;
-	}
-
-	return (
-		<Modal
-			className="blueprints-issues-modal"
-			title={ __( 'Blueprint Details' ) }
-			onRequestClose={ onClose }
-			size="medium"
-		>
-			<div className="h-full flex flex-col gap-1">
-				<Text className="font-medium text-gray-900">{ fileName }</Text>
-				<Text>
-					{ warnings?.length &&
-						__(
-							'The following features are not supported in Studio and will be automatically removed:'
-						) }
-				</Text>
-				<div className="flex-1 overflow-y-auto">
-					<VStack spacing={ 3 } className="divide-y divide-gray-200">
-						{ warnings?.map( ( warningItem, index ) => (
-							<div key={ index } className={ index > 0 ? 'pt-3' : '' }>
-								<HStack alignment="topLeft" spacing={ 2 }>
-									<Icon
-										icon={ caution }
-										className="text-orange-500 mt-1 flex-shrink-0"
-										size={ 20 }
-									/>
-									<VStack spacing={ 1 }>
-										<Text weight={ 600 } className="text-base">
-											{ warningItem.feature }
-										</Text>
-										<Text className="text-sm text-gray-700">{ warningItem.reason }</Text>
-									</VStack>
-								</HStack>
-							</div>
-						) ) }
-					</VStack>
-				</div>
-				<div className="pt-4 border-t border-gray-200">
-					<Text className="text-sm text-gray-600">
-						{ __(
-							'Your Blueprint will still work, but these features will be skipped during site creation.'
-						) }
-					</Text>
-				</div>
-				<HStack alignment="right">
-					<Button variant="primary" onClick={ onClose }>
-						{ __( 'Got it' ) }
-					</Button>
-				</HStack>
-			</div>
-		</Modal>
-	);
-}
-
-interface BlueprintWarningNoticeProps {
-	warnings: Array< { feature: string; reason: string } > | undefined;
-	fileName: string;
-	className?: string;
-}
-
-export function BlueprintWarningNotice( {
-	warnings,
-	fileName,
-	className,
-}: BlueprintWarningNoticeProps ) {
-	const { __ } = useI18n();
-	const [ showIssuesModal, setShowIssuesModal ] = useState( false );
-
-	if ( ! warnings || warnings.length === 0 ) {
-		return null;
-	}
-
-	return (
-		<>
-			<BlueprintIssuesModal
-				warnings={ warnings }
-				fileName={ fileName }
-				isOpen={ showIssuesModal }
-				onClose={ () => setShowIssuesModal( false ) }
-			/>
-			<Notice status="warning" isDismissible={ false } className={ className }>
-				<div className="flex justify-between items-center w-full">
-					<span>
-						{ __(
-							'This Blueprint uses unsupported features in Studio and might not work as expected.'
-						) }
-					</span>
-					<Button
-						variant="link"
-						onClick={ () => setShowIssuesModal( true ) }
-						className="!text-inherit !p-0 !underline"
-					>
-						{ __( 'View details' ) }
-					</Button>
-				</div>
-			</Notice>
-		</>
-	);
 }
 
 interface AddSiteBlueprintProps {

--- a/src/modules/add-site/components/blueprints.tsx
+++ b/src/modules/add-site/components/blueprints.tsx
@@ -112,6 +112,52 @@ function BlueprintIssuesModal( {
 	);
 }
 
+interface BlueprintWarningNoticeProps {
+	warnings: Array< { feature: string; reason: string } > | undefined;
+	fileName: string;
+	className?: string;
+}
+
+export function BlueprintWarningNotice( {
+	warnings,
+	fileName,
+	className,
+}: BlueprintWarningNoticeProps ) {
+	const { __ } = useI18n();
+	const [ showIssuesModal, setShowIssuesModal ] = useState( false );
+
+	if ( ! warnings || warnings.length === 0 ) {
+		return null;
+	}
+
+	return (
+		<>
+			<BlueprintIssuesModal
+				warnings={ warnings }
+				fileName={ fileName }
+				isOpen={ showIssuesModal }
+				onClose={ () => setShowIssuesModal( false ) }
+			/>
+			<Notice status="warning" isDismissible={ false } className={ className }>
+				<div className="flex justify-between items-center w-full">
+					<span>
+						{ __(
+							'This Blueprint uses unsupported features in Studio and might not work as expected.'
+						) }
+					</span>
+					<Button
+						variant="link"
+						onClick={ () => setShowIssuesModal( true ) }
+						className="!text-inherit !p-0 !underline"
+					>
+						{ __( 'View details' ) }
+					</Button>
+				</div>
+			</Notice>
+		</>
+	);
+}
+
 interface AddSiteBlueprintProps {
 	blueprints: Blueprint[];
 	errorMessage?: string;
@@ -142,7 +188,6 @@ export function AddSiteBlueprintSelector( {
 		| undefined
 	>( undefined );
 	const [ uploadedFileName, setUploadedFileName ] = useState< string | null >( null );
-	const [ showIssuesModal, setShowIssuesModal ] = useState( false );
 
 	// Check if current selection is a file-based blueprint
 	const isFileBasedSelection = selectedBlueprint && selectedBlueprint.startsWith( 'file:' );
@@ -362,13 +407,6 @@ export function AddSiteBlueprintSelector( {
 				{ __( 'Start from a Blueprint' ) }
 			</Heading>
 
-			<BlueprintIssuesModal
-				warnings={ blueprintWarnings }
-				fileName={ selectedFileName || '' }
-				isOpen={ showIssuesModal }
-				onClose={ () => setShowIssuesModal( false ) }
-			/>
-
 			{ validationError && (
 				<Notice
 					status="error"
@@ -382,23 +420,12 @@ export function AddSiteBlueprintSelector( {
 				</Notice>
 			) }
 
-			{ ! validationError && blueprintWarnings && blueprintWarnings.length > 0 && (
-				<Notice status="warning" isDismissible={ false } className="mx-0 mb-4">
-					<div className="flex justify-between items-center w-full">
-						<span>
-							{ __(
-								'This Blueprint uses unsupported features in Studio and might not work as expected.'
-							) }
-						</span>
-						<Button
-							variant="link"
-							onClick={ () => setShowIssuesModal( true ) }
-							className="!text-inherit !p-0 !underline"
-						>
-							{ __( 'View details' ) }
-						</Button>
-					</div>
-				</Notice>
+			{ ! validationError && (
+				<BlueprintWarningNotice
+					warnings={ blueprintWarnings }
+					fileName={ selectedFileName || '' }
+					className="mx-0 mb-4"
+				/>
 			) }
 
 			<HStack alignment="edge" className="w-full mb-5 ">

--- a/src/modules/add-site/hooks/use-blueprint-deeplink.ts
+++ b/src/modules/add-site/hooks/use-blueprint-deeplink.ts
@@ -1,5 +1,6 @@
 import { useI18n } from '@wordpress/react-i18n';
 import { useCallback } from 'react';
+import { BlueprintValidationWarning } from 'common/lib/blueprint-validation';
 import { useIpcListener } from 'src/hooks/use-ipc-listener';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 import { Blueprint } from 'src/stores/wpcom-api';
@@ -9,8 +10,6 @@ type BlueprintMetadata = {
 	description?: string;
 };
 
-type BlueprintWarning = { feature: string; reason: string };
-
 interface UseBlueprintDeeplinkOptions {
 	isAnySiteProcessing: boolean;
 	openModal: () => void;
@@ -18,7 +17,7 @@ interface UseBlueprintDeeplinkOptions {
 	setPhpVersion: ( version: string ) => void;
 	setWpVersion: ( version: string ) => void;
 	setBlueprintPreferredVersions: ( versions: { php?: string; wp?: string } | undefined ) => void;
-	setBlueprintDeeplinkWarnings: ( warnings: BlueprintWarning[] | undefined ) => void;
+	setBlueprintDeeplinkWarnings: ( warnings: BlueprintValidationWarning[] | undefined ) => void;
 	navigateToBlueprintDeeplink: () => void;
 }
 
@@ -77,7 +76,10 @@ export function useBlueprintDeeplink( options: UseBlueprintDeeplinkOptions ): vo
 	const handleBlueprintFromUrl = useCallback(
 		async (
 			_event: unknown,
-			{ blueprintPath, warnings }: { blueprintPath: string; warnings?: BlueprintWarning[] }
+			{
+				blueprintPath,
+				warnings,
+			}: { blueprintPath: string; warnings?: BlueprintValidationWarning[] }
 		) => {
 			if ( isAnySiteProcessing ) {
 				return;

--- a/src/modules/add-site/hooks/use-blueprint-deeplink.ts
+++ b/src/modules/add-site/hooks/use-blueprint-deeplink.ts
@@ -9,6 +9,8 @@ type BlueprintMetadata = {
 	description?: string;
 };
 
+type BlueprintWarning = { feature: string; reason: string };
+
 interface UseBlueprintDeeplinkOptions {
 	isAnySiteProcessing: boolean;
 	openModal: () => void;
@@ -16,6 +18,7 @@ interface UseBlueprintDeeplinkOptions {
 	setPhpVersion: ( version: string ) => void;
 	setWpVersion: ( version: string ) => void;
 	setBlueprintPreferredVersions: ( versions: { php?: string; wp?: string } | undefined ) => void;
+	setBlueprintDeeplinkWarnings: ( warnings: BlueprintWarning[] | undefined ) => void;
 	navigateToBlueprintDeeplink: () => void;
 }
 
@@ -28,6 +31,7 @@ export function useBlueprintDeeplink( options: UseBlueprintDeeplinkOptions ): vo
 		setPhpVersion,
 		setWpVersion,
 		setBlueprintPreferredVersions,
+		setBlueprintDeeplinkWarnings,
 		navigateToBlueprintDeeplink,
 	} = options;
 
@@ -71,7 +75,10 @@ export function useBlueprintDeeplink( options: UseBlueprintDeeplinkOptions ): vo
 	);
 
 	const handleBlueprintFromUrl = useCallback(
-		async ( _event: unknown, { blueprintPath }: { blueprintPath: string } ) => {
+		async (
+			_event: unknown,
+			{ blueprintPath, warnings }: { blueprintPath: string; warnings?: BlueprintWarning[] }
+		) => {
 			if ( isAnySiteProcessing ) {
 				return;
 			}
@@ -88,6 +95,7 @@ export function useBlueprintDeeplink( options: UseBlueprintDeeplinkOptions ): vo
 
 				setSelectedBlueprint( fileBlueprint );
 				applyPreferredVersions( blueprintJson );
+				setBlueprintDeeplinkWarnings( warnings );
 				openModal();
 				navigateToBlueprintDeeplink();
 			} catch ( error ) {
@@ -100,6 +108,7 @@ export function useBlueprintDeeplink( options: UseBlueprintDeeplinkOptions ): vo
 			createBlueprintFromData,
 			setSelectedBlueprint,
 			applyPreferredVersions,
+			setBlueprintDeeplinkWarnings,
 			openModal,
 			navigateToBlueprintDeeplink,
 		]

--- a/src/modules/add-site/index.tsx
+++ b/src/modules/add-site/index.tsx
@@ -64,6 +64,7 @@ interface NavigationContentProps {
 	blueprintsErrorMessage?: string | undefined;
 	blueprintPreferredVersions?: { php?: string; wp?: string };
 	setBlueprintPreferredVersions: ( versions: { php?: string; wp?: string } | undefined ) => void;
+	blueprintDeeplinkWarnings?: Array< { feature: string; reason: string } >;
 	selectedRemoteSite?: SyncSite;
 	setSelectedRemoteSite: ( site?: SyncSite ) => void;
 	isDeeplinkFlow: boolean;
@@ -79,6 +80,7 @@ function NavigationContent( props: NavigationContentProps ) {
 		blueprintsErrorMessage,
 		blueprintPreferredVersions,
 		setBlueprintPreferredVersions,
+		blueprintDeeplinkWarnings,
 		selectedRemoteSite,
 		setSelectedRemoteSite,
 		isDeeplinkFlow,
@@ -261,7 +263,10 @@ function NavigationContent( props: NavigationContentProps ) {
 				<CreateSite { ...createSiteProps } />
 			</Navigator.Screen>
 			<Navigator.Screen className="flex-1" path="/blueprint/deeplink">
-				<BlueprintDeeplink selectedBlueprint={ createSiteProps.selectedBlueprint } />
+				<BlueprintDeeplink
+					selectedBlueprint={ createSiteProps.selectedBlueprint }
+					warnings={ blueprintDeeplinkWarnings }
+				/>
 			</Navigator.Screen>
 			<Navigator.Screen className="flex-1" path="/blueprint/deeplink/create">
 				<CreateSite
@@ -318,6 +323,9 @@ export default function AddSite( { className, variant = 'outlined' }: AddSitePro
 	const defaultWordPressVersion = useRootSelector( selectDefaultWordPressVersion );
 	const [ blueprintPreferredVersions, setBlueprintPreferredVersions ] = useState<
 		{ php?: string; wp?: string } | undefined
+	>();
+	const [ blueprintDeeplinkWarnings, setBlueprintDeeplinkWarnings ] = useState<
+		Array< { feature: string; reason: string } > | undefined
 	>();
 	const [ isDeeplinkFlow, setIsDeeplinkFlow ] = useState( false );
 
@@ -378,6 +386,7 @@ export default function AddSite( { className, variant = 'outlined' }: AddSitePro
 		setFileForImport( null );
 		setSelectedBlueprint( undefined );
 		setBlueprintPreferredVersions( undefined );
+		setBlueprintDeeplinkWarnings( undefined );
 		setSelectedRemoteSite( undefined );
 	}, [
 		setSitePath,
@@ -409,6 +418,7 @@ export default function AddSite( { className, variant = 'outlined' }: AddSitePro
 		setPhpVersion,
 		setWpVersion,
 		setBlueprintPreferredVersions,
+		setBlueprintDeeplinkWarnings,
 		navigateToBlueprintDeeplink: () => {
 			setIsDeeplinkFlow( true );
 		},
@@ -489,6 +499,7 @@ export default function AddSite( { className, variant = 'outlined' }: AddSitePro
 						handleSubmit={ handleSubmit }
 						blueprintPreferredVersions={ blueprintPreferredVersions }
 						setBlueprintPreferredVersions={ setBlueprintPreferredVersions }
+						blueprintDeeplinkWarnings={ blueprintDeeplinkWarnings }
 						selectedRemoteSite={ selectedRemoteSite }
 						setSelectedRemoteSite={ setSelectedRemoteSite }
 						isDeeplinkFlow={ isDeeplinkFlow }

--- a/src/modules/add-site/index.tsx
+++ b/src/modules/add-site/index.tsx
@@ -3,6 +3,7 @@ import { Navigator, useNavigator } from '@wordpress/components';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import { FormEvent, useCallback, useEffect, useMemo, useState } from 'react';
+import { BlueprintValidationWarning } from 'common/lib/blueprint-validation';
 import Button, { ButtonVariant } from 'src/components/button';
 import { FullscreenModal } from 'src/components/fullscreen-modal';
 import { useAddSite } from 'src/hooks/use-add-site';
@@ -64,7 +65,7 @@ interface NavigationContentProps {
 	blueprintsErrorMessage?: string | undefined;
 	blueprintPreferredVersions?: { php?: string; wp?: string };
 	setBlueprintPreferredVersions: ( versions: { php?: string; wp?: string } | undefined ) => void;
-	blueprintDeeplinkWarnings?: Array< { feature: string; reason: string } >;
+	blueprintDeeplinkWarnings?: BlueprintValidationWarning[];
 	selectedRemoteSite?: SyncSite;
 	setSelectedRemoteSite: ( site?: SyncSite ) => void;
 	isDeeplinkFlow: boolean;
@@ -325,7 +326,7 @@ export default function AddSite( { className, variant = 'outlined' }: AddSitePro
 		{ php?: string; wp?: string } | undefined
 	>();
 	const [ blueprintDeeplinkWarnings, setBlueprintDeeplinkWarnings ] = useState<
-		Array< { feature: string; reason: string } > | undefined
+		BlueprintValidationWarning[] | undefined
 	>();
 	const [ isDeeplinkFlow, setIsDeeplinkFlow ] = useState( false );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- STU-1047

## Proposed Changes

- add warning notice to the blueprint deeplink flow if the related blueprint includes unsupported features
- extract out `BlueprintWarningNotice` and `BlueprintIssuesModal` components into separate file
- adjust related unit tests

<img width="2616" height="1686" alt="CleanShot 2025-11-28 at 10 29 19@2x" src="https://github.com/user-attachments/assets/b5e28858-da2d-49d4-8fd9-0d8ac2bb9324" />

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR branch and build the app with `npm install && npm start`.
2. Try to open a blueprint deeplink that has some unsupported features, e.g.:

```
wp-studio://add-site?blueprint=eyJtZXRhIjp7InRpdGxlIjoiVGhpcyBpcyBhIHRlc3QgYmx1ZXByaW50IiwiZGVzY3JpcHRpb24iOiJJdCBpbnN0YWxscyBBc3RyYSB0aGVtZSBhbmQgWW9hc3QgU0VPIHBsdWdpbiIsImF1dGhvciI6Iml2YW4iLCJjYXRlZ29yaWVzIjpbInJzcyIsInNvY2lhbCB3ZWIiXX0sInByZWZlcnJlZFZlcnNpb25zIjp7InBocCI6IjguMyIsIndwIjoibGF0ZXN0In0sInN0ZXBzIjpbeyJzdGVwIjoiaW5zdGFsbFRoZW1lIiwidGhlbWVEYXRhIjp7InJlc291cmNlIjoid29yZHByZXNzLm9yZy90aGVtZXMiLCJzbHVnIjoiYXN0cmEifSwib3B0aW9ucyI6eyJhY3RpdmF0ZSI6dHJ1ZX19LHsic3RlcCI6Imluc3RhbGxQbHVnaW4iLCJwbHVnaW5EYXRhIjp7InJlc291cmNlIjoid29yZHByZXNzLm9yZy9wbHVnaW5zIiwic2x1ZyI6IndvcmRwcmVzcy1zZW8ifSwib3B0aW9ucyI6eyJhY3RpdmF0ZSI6dHJ1ZX19LHsic3RlcCI6ImxvZ2luIiwidXNlcm5hbWUiOiJhZG1pbiIsInBhc3N3b3JkIjoicGFzc3dvcmQifV19
```

3. The blueprint deeplink flow should start and display the related warning in the modal (as can be seen in the screenshot above). The warning should render correctly and open up details without any issues.
4. Close the flow and try to add a new site with the existing blueprint flow. Select one of the blueprint files that has unsupported features from 39a4e-pb (e.g. `blueprint-portfolio-v1.json`).
5. Similarly as in the deeplink flow, the warning should render correctly and open up details without any issues.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
