### PR TITLE
Fix navigation e2e tests

### DIFF
--- a/e2e/site-navigation.test.ts
+++ b/e2e/site-navigation.test.ts
@@ -173,8 +173,8 @@ test.describe( 'Site Navigation', () => {
 
 		// Verify media was uploaded by checking the library
 		await page.goto( getUrlWithAutoLogin( `${ wpAdminUrl }/upload.php` ) );
-		const mediaItems = page.locator( '.attachment' );
-		await expect( mediaItems.first() ).toBeVisible();
+		await page.waitForLoadState( 'networkidle' );
+		await expect( page.locator( '.attachment' ).first() ).toBeVisible( { timeout: 30_000 } );
 
 		// Clean up test file — don't fail the test if unlink errors
 		await fs.unlink( testImagePath ).catch( () => {} );

--- a/e2e/site-navigation.test.ts
+++ b/e2e/site-navigation.test.ts
@@ -139,7 +139,10 @@ test.describe( 'Site Navigation', () => {
 
 		// Verify post was created by visiting posts list
 		await page.goto( getUrlWithAutoLogin( `${ wpAdminUrl }/edit.php` ) );
-		await expect( page.locator( 'a.row-title:has-text("E2E Test Post")' ) ).toBeVisible();
+		await page.waitForLoadState( 'networkidle' );
+		await expect( page.locator( 'a.row-title:has-text("E2E Test Post")' ) ).toBeVisible( {
+			timeout: 30_000,
+		} );
 	} );
 
 	test( 'uploads media', async ( { page } ) => {
@@ -268,9 +271,12 @@ test.describe( 'Site Navigation', () => {
 		// Wait for search results
 		await page.waitForLoadState( 'networkidle' );
 
+		// Wait for the search spinner to disappear (indicates API response received)
+		await expect( page.locator( '.spinner' ) ).toBeHidden( { timeout: 30_000 } );
+
 		// Find Contact Form 7 plugin
 		const pluginResult = page.locator( '.plugin-card-contact-form-7' ).first();
-		await expect( pluginResult ).toBeVisible();
+		await expect( pluginResult ).toBeVisible( { timeout: 30_000 } );
 
 		// Install the plugin
 		const installButton = pluginResult.locator( 'a.install-now' );

--- a/e2e/site-navigation.test.ts
+++ b/e2e/site-navigation.test.ts
@@ -10,10 +10,10 @@ import { getUrlWithAutoLogin } from './utils';
 
 /**
  * Closes the WordPress Block Editor welcome guide if it appears.
- * Attempts to close up to 2 times as the modal can appear multiple times.
+ * Attempts to close up to 3 times as the modal reappears while the page loads.
  */
 async function closeWelcomeGuide( page: Page ) {
-	for ( let i = 0; i < 2; i++ ) {
+	for ( let i = 0; i < 3; i++ ) {
 		try {
 			// Wait for the modal frame to appear
 			const modalFrame = page.locator( '.components-modal__frame' );
@@ -23,9 +23,9 @@ async function closeWelcomeGuide( page: Page ) {
 			const closeButton = page.locator( '.components-modal__header > button[aria-label="Close"]' );
 			await closeButton.waitFor( { state: 'visible', timeout: 2000 } );
 			await closeButton.click();
-		} catch ( e ) {
-			// Modal not found or already closed, exit the loop
-			break;
+		} catch {
+			// Modal not found or already closed, try again in next loop iteration
+			continue;
 		}
 	}
 }
@@ -330,6 +330,8 @@ test.describe( 'Site Navigation', () => {
 			'button.editor-post-publish-button__button.editor-post-publish-panel__toggle'
 		);
 
+		// Ensure no welcome/whats-new modal is obscuring the publish button
+		await closeWelcomeGuide( page );
 		await publishButton.waitFor( { state: 'visible', timeout: 10_000 } );
 		await publishButton.click();
 

--- a/e2e/site-navigation.test.ts
+++ b/e2e/site-navigation.test.ts
@@ -10,30 +10,18 @@ import { getUrlWithAutoLogin } from './utils';
 
 /**
  * Closes the WordPress Block Editor welcome guide if it appears.
- * Attempts to close up to 3 times as the modal may reappear while the page loads.
- * If no modal is visible, returns immediately without waiting.
  */
 async function closeWelcomeGuide( page: Page ) {
+	const modalOverlay = page.locator( '.components-modal__screen-overlay' );
+	const closeButton = page.locator( '.components-modal__header > button[aria-label="Close"]' );
+
 	for ( let i = 0; i < 3; i++ ) {
-		// Check if modal is currently visible without waiting
-		const modalFrame = page.locator( '.components-modal__frame' );
-		const isVisible = await modalFrame.isVisible( { timeout: 5000 } );
-
-		if ( ! isVisible ) {
-			// No modal present, exit early
-			break;
-		}
-
 		try {
-			// Find and click the close button using specific selector
-			const closeButton = page.locator( '.components-modal__header > button[aria-label="Close"]' );
+			await modalOverlay.waitFor( { state: 'visible', timeout: 2000 } );
 			await closeButton.waitFor( { state: 'visible', timeout: 2000 } );
 			await closeButton.click();
-
-			// Wait a bit for the modal to close before checking again
-			await page.waitForTimeout( 500 );
+			await modalOverlay.waitFor( { state: 'hidden', timeout: 2000 } );
 		} catch {
-			// Close button not found or click failed, exit loop
 			break;
 		}
 	}
@@ -119,7 +107,7 @@ test.describe( 'Site Navigation', () => {
 
 		// Wait for title to be available in iframe
 		const titleSelector = 'h1.editor-post-title__input';
-		await expect(editorFrame.locator( titleSelector )).toBeVisible( { timeout: 10_000 } );
+		await expect( editorFrame.locator( titleSelector ) ).toBeVisible( { timeout: 10_000 } );
 		await editorFrame.locator( titleSelector ).fill( 'E2E Test Post' );
 
 		// Click into the content area and type
@@ -132,20 +120,21 @@ test.describe( 'Site Navigation', () => {
 			'button.editor-post-publish-button__button.editor-post-publish-panel__toggle'
 		);
 
-		await expect(publishButton).toBeVisible( { timeout: 10_000 } );
+		await expect( publishButton ).toBeVisible( { timeout: 10_000 } );
 		await publishButton.click();
 
 		// Wait for and click the confirm publish button in the panel
 		const confirmPublishButton = page.locator(
 			'.editor-post-publish-panel__header-publish-button button.editor-post-publish-button__button'
 		);
-		await expect(confirmPublishButton).toBeVisible( { timeout: 10_000 } );
+		await expect( confirmPublishButton ).toBeVisible( { timeout: 10_000 } );
+		await closeWelcomeGuide( page );
 		await confirmPublishButton.click();
 
 		// Wait for the "View Post" link to appear
-		await expect(page
-			.locator( '.post-publish-panel__postpublish-buttons a:has-text("View Post")' ))
-			.toBeVisible( { timeout: 60_000 } );
+		await expect(
+			page.locator( '.post-publish-panel__postpublish-buttons a:has-text("View Post")' )
+		).toBeVisible( { timeout: 60_000 } );
 
 		// Verify post was created by visiting posts list
 		await page.goto( getUrlWithAutoLogin( `${ wpAdminUrl }/edit.php` ) );
@@ -325,7 +314,7 @@ test.describe( 'Site Navigation', () => {
 
 		// Wait for title to be available in iframe
 		const titleSelector = 'h1.editor-post-title__input';
-		await editorFrame.locator( titleSelector ).waitFor( { timeout: 30_000 } );
+		await expect( editorFrame.locator( titleSelector ) ).toBeVisible( { timeout: 30_000 } );
 		await editorFrame.locator( titleSelector ).fill( 'Permalink Test Post' );
 
 		// Click into the content area and type
@@ -338,24 +327,21 @@ test.describe( 'Site Navigation', () => {
 			'button.editor-post-publish-button__button.editor-post-publish-panel__toggle'
 		);
 
-		await publishButton.waitFor( { state: 'visible', timeout: 10_000 } );
+		await expect( publishButton ).toBeVisible( { timeout: 10_000 } );
 		await publishButton.click();
 
 		// Wait for and click the confirm publish button in the panel
 		const confirmPublishButton = page.locator(
 			'.editor-post-publish-panel__header-publish-button button.editor-post-publish-button__button'
 		);
-
-		await confirmPublishButton.waitFor( { state: 'visible', timeout: 10_000 } );
+		await expect( confirmPublishButton ).toBeVisible( { timeout: 10_000 } );
+		await closeWelcomeGuide( page );
 		await confirmPublishButton.click();
 
 		// Wait for the "View Post" link to appear
-		await page
-			.locator( '.post-publish-panel__postpublish-buttons a:has-text("View Post")' )
-			.waitFor( {
-				state: 'visible',
-				timeout: 60_000,
-			} );
+		await expect(
+			page.locator( '.post-publish-panel__postpublish-buttons a:has-text("View Post")' )
+		).toBeVisible( { timeout: 60_000 } );
 
 		// Get the post URL from the editor
 		const viewPostLink = page.locator( 'a:has-text("View Post")' ).first();

--- a/e2e/site-navigation.test.ts
+++ b/e2e/site-navigation.test.ts
@@ -134,9 +134,10 @@ test.describe( 'Site Navigation', () => {
 		await confirmPublishButton.click();
 
 		// Wait for the "View Post" link to appear
-		await page
-			.locator( '.post-publish-panel__postpublish-buttons a:has-text("View Post")' )
-			.waitFor( { state: 'visible', timeout: 30_000 } );
+		await page.getByRole( 'link', { name: 'View Post' } ).waitFor( {
+			state: 'visible',
+			timeout: 60_000,
+		} );
 
 		// Verify post was created by visiting posts list
 		await page.goto( getUrlWithAutoLogin( `${ wpAdminUrl }/edit.php` ) );
@@ -341,9 +342,10 @@ test.describe( 'Site Navigation', () => {
 		await confirmPublishButton.click();
 
 		// Wait for the "View Post" link to appear
-		await page
-			.locator( '.post-publish-panel__postpublish-buttons a:has-text("View Post")' )
-			.waitFor( { state: 'visible', timeout: 30_000 } );
+		await page.getByRole( 'link', { name: 'View Post' } ).waitFor( {
+			state: 'visible',
+			timeout: 60_000,
+		} );
 
 		// Get the post URL from the editor
 		const viewPostLink = page.locator( 'a:has-text("View Post")' ).first();

--- a/e2e/site-navigation.test.ts
+++ b/e2e/site-navigation.test.ts
@@ -121,6 +121,7 @@ test.describe( 'Site Navigation', () => {
 		);
 
 		await expect( publishButton ).toBeVisible( { timeout: 10_000 } );
+		await closeWelcomeGuide( page );
 		await publishButton.click();
 
 		// Wait for and click the confirm publish button in the panel
@@ -328,6 +329,7 @@ test.describe( 'Site Navigation', () => {
 		);
 
 		await expect( publishButton ).toBeVisible( { timeout: 10_000 } );
+		await closeWelcomeGuide( page );
 		await publishButton.click();
 
 		// Wait for and click the confirm publish button in the panel

--- a/e2e/site-navigation.test.ts
+++ b/e2e/site-navigation.test.ts
@@ -17,7 +17,7 @@ async function closeWelcomeGuide( page: Page ) {
 	for ( let i = 0; i < 3; i++ ) {
 		// Check if modal is currently visible without waiting
 		const modalFrame = page.locator( '.components-modal__frame' );
-		const isVisible = await modalFrame.isVisible();
+		const isVisible = await modalFrame.isVisible( { timeout: 5000 } );
 
 		if ( ! isVisible ) {
 			// No modal present, exit early
@@ -143,10 +143,12 @@ test.describe( 'Site Navigation', () => {
 		await confirmPublishButton.click();
 
 		// Wait for the "View Post" link to appear
-		await page.getByRole( 'link', { name: 'View Post' } ).waitFor( {
-			state: 'visible',
-			timeout: 60_000,
-		} );
+		await page
+			.locator( '.post-publish-panel__postpublish-buttons a:has-text("View Post")' )
+			.waitFor( {
+				state: 'visible',
+				timeout: 60_000,
+			} );
 
 		// Verify post was created by visiting posts list
 		await page.goto( getUrlWithAutoLogin( `${ wpAdminUrl }/edit.php` ) );
@@ -339,8 +341,6 @@ test.describe( 'Site Navigation', () => {
 			'button.editor-post-publish-button__button.editor-post-publish-panel__toggle'
 		);
 
-		// Ensure no welcome/whats-new modal is obscuring the publish button
-		await closeWelcomeGuide( page );
 		await publishButton.waitFor( { state: 'visible', timeout: 10_000 } );
 		await publishButton.click();
 
@@ -353,10 +353,12 @@ test.describe( 'Site Navigation', () => {
 		await confirmPublishButton.click();
 
 		// Wait for the "View Post" link to appear
-		await page.getByRole( 'link', { name: 'View Post' } ).waitFor( {
-			state: 'visible',
-			timeout: 60_000,
-		} );
+		await page
+			.locator( '.post-publish-panel__postpublish-buttons a:has-text("View Post")' )
+			.waitFor( {
+				state: 'visible',
+				timeout: 60_000,
+			} );
 
 		// Get the post URL from the editor
 		const viewPostLink = page.locator( 'a:has-text("View Post")' ).first();

--- a/e2e/site-navigation.test.ts
+++ b/e2e/site-navigation.test.ts
@@ -10,22 +10,31 @@ import { getUrlWithAutoLogin } from './utils';
 
 /**
  * Closes the WordPress Block Editor welcome guide if it appears.
- * Attempts to close up to 3 times as the modal reappears while the page loads.
+ * Attempts to close up to 3 times as the modal may reappear while the page loads.
+ * If no modal is visible, returns immediately without waiting.
  */
 async function closeWelcomeGuide( page: Page ) {
 	for ( let i = 0; i < 3; i++ ) {
-		try {
-			// Wait for the modal frame to appear
-			const modalFrame = page.locator( '.components-modal__frame' );
-			await modalFrame.waitFor( { state: 'visible', timeout: 2000 } );
+		// Check if modal is currently visible without waiting
+		const modalFrame = page.locator( '.components-modal__frame' );
+		const isVisible = await modalFrame.isVisible();
 
+		if ( ! isVisible ) {
+			// No modal present, exit early
+			break;
+		}
+
+		try {
 			// Find and click the close button using specific selector
 			const closeButton = page.locator( '.components-modal__header > button[aria-label="Close"]' );
 			await closeButton.waitFor( { state: 'visible', timeout: 2000 } );
 			await closeButton.click();
+
+			// Wait a bit for the modal to close before checking again
+			await page.waitForTimeout( 500 );
 		} catch {
-			// Modal not found or already closed, try again in next loop iteration
-			continue;
+			// Close button not found or click failed, exit loop
+			break;
 		}
 	}
 }

--- a/e2e/site-navigation.test.ts
+++ b/e2e/site-navigation.test.ts
@@ -168,8 +168,8 @@ test.describe( 'Site Navigation', () => {
 		// Wait for upload to complete
 		await expect( page.locator( '.media-item .filename' ) ).toBeVisible( { timeout: 30_000 } );
 
-		// Verify media was uploaded by checking the library
-		await page.goto( getUrlWithAutoLogin( `${ wpAdminUrl }/upload.php` ) );
+		// Verify media was uploaded by checking the library (force grid mode for consistent selector)
+		await page.goto( getUrlWithAutoLogin( `${ wpAdminUrl }/upload.php?mode=grid` ) );
 		await page.waitForLoadState( 'networkidle' );
 		await expect( page.locator( '.attachment' ).first() ).toBeVisible( { timeout: 30_000 } );
 

--- a/e2e/site-navigation.test.ts
+++ b/e2e/site-navigation.test.ts
@@ -119,7 +119,7 @@ test.describe( 'Site Navigation', () => {
 
 		// Wait for title to be available in iframe
 		const titleSelector = 'h1.editor-post-title__input';
-		await editorFrame.locator( titleSelector ).waitFor( { timeout: 10_000 } );
+		await expect(editorFrame.locator( titleSelector )).toBeVisible( { timeout: 10_000 } );
 		await editorFrame.locator( titleSelector ).fill( 'E2E Test Post' );
 
 		// Click into the content area and type
@@ -132,23 +132,20 @@ test.describe( 'Site Navigation', () => {
 			'button.editor-post-publish-button__button.editor-post-publish-panel__toggle'
 		);
 
-		await publishButton.waitFor( { state: 'visible', timeout: 10_000 } );
+		await expect(publishButton).toBeVisible( { timeout: 10_000 } );
 		await publishButton.click();
 
 		// Wait for and click the confirm publish button in the panel
 		const confirmPublishButton = page.locator(
 			'.editor-post-publish-panel__header-publish-button button.editor-post-publish-button__button'
 		);
-		await confirmPublishButton.waitFor( { state: 'visible', timeout: 10_000 } );
+		await expect(confirmPublishButton).toBeVisible( { timeout: 10_000 } );
 		await confirmPublishButton.click();
 
 		// Wait for the "View Post" link to appear
-		await page
-			.locator( '.post-publish-panel__postpublish-buttons a:has-text("View Post")' )
-			.waitFor( {
-				state: 'visible',
-				timeout: 60_000,
-			} );
+		await expect(page
+			.locator( '.post-publish-panel__postpublish-buttons a:has-text("View Post")' ))
+			.toBeVisible( { timeout: 60_000 } );
 
 		// Verify post was created by visiting posts list
 		await page.goto( getUrlWithAutoLogin( `${ wpAdminUrl }/edit.php` ) );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

I noticed that after merging #2054, a couple of tests were still flaky on trunk. This PR fixes the issues reported on these runs: 39bbd-pb

## Proposed Changes

- Increases the timeout for the "View Post" button after post creation
- Attempts to close the welcome guide modal more times
- Adds a wait for networkidle after media upload

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- CI should be green
- Visual review

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?