### PR TITLE
Remove createSiteFromRemote  beta feature enable Publish site

### DIFF
--- a/cli/lib/appdata.ts
+++ b/cli/lib/appdata.ts
@@ -42,7 +42,6 @@ const newSiteSchema = z
 const betaFeaturesSchema = z
 	.object( {
 		studioSitesCli: z.boolean().optional(),
-		createSiteFromRemote: z.boolean().optional(),
 	} )
 	.passthrough();
 

--- a/src/components/publish-site-button.tsx
+++ b/src/components/publish-site-button.tsx
@@ -5,7 +5,6 @@ import { Tooltip } from 'src/components/tooltip';
 import { useSyncSites } from 'src/hooks/sync-sites';
 import { useAuth } from 'src/hooks/use-auth';
 import { useContentTabs } from 'src/hooks/use-content-tabs';
-import { useFeatureFlags } from 'src/hooks/use-feature-flags';
 import { useSiteDetails } from 'src/hooks/use-site-details';
 import { useAppDispatch } from 'src/stores';
 import {
@@ -24,14 +23,13 @@ export const PublishSiteButton = () => {
 		userId: user?.id,
 	} );
 	const { isAnySitePulling, isAnySitePushing } = useSyncSites();
-	const { streamlineOnboarding } = useFeatureFlags();
 	const isAnySiteSyncing = isAnySitePulling || isAnySitePushing;
 	const handlePublishClick = () => {
 		setSelectedTab( 'sync' );
 		dispatch( connectedSitesActions.openModal( 'push' ) );
 	};
 
-	if ( ! streamlineOnboarding || connectedSites.length !== 0 ) return null;
+	if ( connectedSites.length !== 0 ) return null;
 
 	return (
 		<Tooltip

--- a/src/ipc-types.d.ts
+++ b/src/ipc-types.d.ts
@@ -87,7 +87,6 @@ interface FeatureFlags {
 interface BetaFeatures {
 	studioSitesCli: boolean;
 	multiWorkerSupport: boolean;
-	createSiteFromRemote: boolean;
 }
 
 interface AppGlobals extends FeatureFlags {

--- a/src/lib/beta-features.ts
+++ b/src/lib/beta-features.ts
@@ -20,12 +20,6 @@ const BETA_FEATURES_DEFINITION: Record< keyof BetaFeatures, BetaFeatureDefinitio
 		default: false,
 		description: 'Enable multi-worker PHP processing for faster performance',
 	},
-	createSiteFromRemote: {
-		label: 'Site creation from existing remote site',
-		key: 'createSiteFromRemote',
-		default: false,
-		description: 'Enable creating a site from an existing WordPress.com or Pressable site',
-	},
 } as const;
 
 export const BETA_FEATURES: Record< keyof BetaFeatures, BetaFeatureDefinition > =

--- a/src/modules/add-site/components/options.tsx
+++ b/src/modules/add-site/components/options.tsx
@@ -82,7 +82,6 @@ function OptionButton( {
 export default function AddSiteOptions( { onOptionSelect }: AddSiteOptionsProps ) {
 	const { __ } = useI18n();
 	const { enableBlueprints } = useFeatureFlags();
-	const { createSiteFromRemote } = useRootSelector( ( state ) => state.betaFeatures.features );
 	const isOffline = useOffline();
 	const offlineMessage = __( "You're currently offline." );
 
@@ -111,14 +110,12 @@ export default function AddSiteOptions( { onOptionSelect }: AddSiteOptionsProps 
 					disabledTooltip={ offlineMessage }
 				/>
 			) }
-			{ createSiteFromRemote && (
-				<OptionButton
-					icon={ <Icon icon={ download } size={ 24 } fill="#3858E9" /> }
-					title={ __( 'Import an existing website' ) }
-					description={ __( 'Download directly from WordPress.com or Pressable' ) }
-					onClick={ () => onOptionSelect( 'pullRemote' ) }
-				/>
-			) }
+			<OptionButton
+				icon={ <Icon icon={ download } size={ 24 } fill="#3858E9" /> }
+				title={ __( 'Import an existing website' ) }
+				description={ __( 'Download directly from WordPress.com or Pressable' ) }
+				onClick={ () => onOptionSelect( 'pullRemote' ) }
+			/>
 			<OptionButton
 				icon={ <Icon icon={ backup } size={ 24 } fill="#3858E9" /> }
 				title={ __( 'Import from a backup' ) }

--- a/src/stores/beta-features-slice.ts
+++ b/src/stores/beta-features-slice.ts
@@ -10,7 +10,6 @@ interface BetaFeaturesState {
 const initialState: BetaFeaturesState = {
 	features: {
 		studioSitesCli: false,
-		createSiteFromRemote: false,
 		multiWorkerSupport: false,
 	},
 	loading: false,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes stu-1059

## Proposed Changes

- Remove the beta flag `createSiteFromRemote` and enables the `Publish site` in the top bar.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**New create site and import flow"**

- Run `npm start`
- Click on add site
- Observe there is a new option "Import an existing website"

<img width="1084" height="773" alt="Screenshot 2025-11-28 at 11 35 31" src="https://github.com/user-attachments/assets/7353cb75-3943-4a58-9717-7699fe6ea98d" />


**Publish site button**

- Create a site without any remote site connected
- Observe that the Publish site button appears in the top bar
- Go to the sync tab
- Confirm the button that appears says "Connect site". We are not launching the two buttons there.

<img width="1084" height="773" alt="Screenshot 2025-11-28 at 11 40 49" src="https://github.com/user-attachments/assets/6bc688d8-f68f-4e9c-be76-6ee4dd569c87" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
