### PR TITLE
Fix regression related to Windows CLI installer

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,7 @@ import {
 } from 'src/migrations/migrate-from-wp-now-folder';
 import { removeSitesWithEmptyDirectories } from 'src/migrations/remove-sites-with-empty-dirs';
 import { renameLaunchUniquesStat } from 'src/migrations/rename-launch-uniques-stat';
+import { updateWindowsCliVersionedPathIfNeeded } from 'src/modules/cli/lib/windows-installation-manager';
 import { setupWPServerFiles, updateWPServerFiles } from 'src/setup-wp-server-files';
 import { stopAllServersOnQuit } from 'src/site-server';
 import { loadUserData, lockAppdata, saveUserData, unlockAppdata } from 'src/storage/user-data';
@@ -332,6 +333,7 @@ async function appBoot() {
 			'monthly'
 		);
 
+		await updateWindowsCliVersionedPathIfNeeded();
 		getWordPressProvider();
 
 		finishedInitialization = true;

--- a/src/modules/cli/lib/windows-installation-manager.ts
+++ b/src/modules/cli/lib/windows-installation-manager.ts
@@ -17,9 +17,6 @@ const currentUserRegistry = new Registry( {
 	key: '\\Environment',
 } );
 
-/**
- * Windows implementation of CLI installation manager
- */
 export class WindowsCliInstallationManager implements StudioCliInstallationManager {
 	constructor() {
 		if ( process.platform !== 'win32' ) {
@@ -51,6 +48,12 @@ export class WindowsCliInstallationManager implements StudioCliInstallationManag
 		} catch ( error ) {
 			console.error( 'Failed to check installation status of CLI', error );
 			return false;
+		}
+	}
+
+	async updateWindowsCliVersionedPathIfNeeded(): Promise< void > {
+		if ( await this.isCliInstalled() ) {
+			await this.installProxyBatFile();
 		}
 	}
 
@@ -209,5 +212,13 @@ export class WindowsCliInstallationManager implements StudioCliInstallationManag
 			.join( ';' );
 
 		await this.setPathInRegistry( newPath );
+	}
+}
+
+// See the `WindowsCliInstallationManager::installProxyBatFile` comment for more details
+export async function updateWindowsCliVersionedPathIfNeeded() {
+	if ( process.platform === 'win32' ) {
+		const manager = new WindowsCliInstallationManager();
+		await manager.updateWindowsCliVersionedPathIfNeeded();
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Related to #2041

## Proposed Changes

In #2041, we changed the CLI installer's behavior on Windows so that it no longer installs automatically when the app starts. Users can now install the CLI through the Studio settings modal. 

Unfortunately, my PR also introduced a regression, which is that the `%LOCALAPPDATA%\studio\bin\studio.bat` script would no longer be updated automatically after Studio updates. 

The `%LOCALAPPDATA%\studio` directory on Windows is structured so that the `resources` directory lives inside a versioned directory. For example, I have both `%LOCALAPPDATA%\studio\app-1.6.4` and `%LOCALAPPDATA%\studio\app-1.6.5` on my machine. Every time the app updates, a new directory is created, and we need to update the `%LOCALAPPDATA%\studio\bin\studio.bat` file to point to the newest directory (see #1152 for the original implementation).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Code review should suffice

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
