### PR TITLE
Bump group max length should be 27

### DIFF
--- a/common/lib/bump-stat.ts
+++ b/common/lib/bump-stat.ts
@@ -1,8 +1,8 @@
 import { StatsGroup, StatsMetric } from 'common/types/stats';
 
-// Database columns are varchar(32). Group limit is 26 to account for the '-a11n' suffix
-// added by the backend for Automattic requests (26 + 6 = 32).
-const MAX_GROUP_LENGTH = 26;
+// Database columns are varchar(32). Group limit is 27 to account for the '-a11n' suffix
+// added by the backend for Automattic requests (27 + 5 = 32).
+const MAX_GROUP_LENGTH = 27;
 const MAX_STAT_LENGTH = 32;
 
 // Returns true if we attempted to bump the stat

--- a/src/lib/tests/bump-stats.test.ts
+++ b/src/lib/tests/bump-stats.test.ts
@@ -80,15 +80,15 @@ describe( 'bumpStat', () => {
 		await waitFor( () => expect( nock.isDone() ).toBe( true ) );
 	} );
 
-	test( 'should not bump stat when group exceeds 26 characters', () => {
+	test( 'should not bump stat when group exceeds 27 characters', () => {
 		const errorLogger = jest.spyOn( console, 'error' ).mockImplementation( () => {} );
-		const longGroup = 'this-is-a-very-long-group-name-over-26-chars' as StatsGroup;
+		const longGroup = 'this-is-a-very-long-group-name-over-27-chars' as StatsGroup;
 
 		const result = bumpStat( longGroup, StatsMetric.SUCCESS );
 
 		expect( result ).toBe( false );
 		expect( errorLogger ).toHaveBeenCalledWith(
-			expect.stringContaining( 'exceeds maximum length of 26 characters' )
+			expect.stringContaining( 'exceeds maximum length of 27 characters' )
 		);
 		errorLogger.mockRestore();
 	} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Follow-up to #2114 
- Related to p1764590478423009-slack-C06DRMD6VPZ

## Proposed Changes

`-a11n` is 5 characters, so `MAX_GROUP_LENGTH` should be 27, not 26.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Code review should suffice. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?