### PR TITLE
Introduce back the user-data-updated listener to quick fix the site creation

### DIFF
--- a/src/hooks/use-site-details.tsx
+++ b/src/hooks/use-site-details.tsx
@@ -446,6 +446,17 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 		};
 	}, [ autoStartSites ] );
 
+	useEffect( () => {
+		const unsubscribe = window.ipcListener.subscribe( 'user-data-updated', async () => {
+			const updatedSites = await getIpcApi().getSiteDetails();
+			setData( updatedSites );
+		} );
+
+		return () => {
+			unsubscribe();
+		};
+	}, [] );
+
 	const stopServer = useCallback(
 		async ( id: string ) => {
 			toggleLoadingServerForSite( id );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-1071

## Proposed Changes

- Quick fix site creation. Before this PR the site creation got stuck and never updated the UI.
- The issue was introduced in  #2148 
- That's the reason most of e2e tests were failing, and also the Performance CI, as it always failed on trunk.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run `npm start`
- Click on Add site
- Observe that the site creation finishes correctly and you see the overview tab after a few seconds.

**Before**

https://github.com/user-attachments/assets/123e83c3-a09d-42ff-84b1-4cb92853c88f



**After**


https://github.com/user-attachments/assets/60281846-984f-426f-9795-26aa3dc389a7



 
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
