### PR TITLE
Fix close modal when adding a blank site

### DIFF
--- a/src/modules/add-site/index.tsx
+++ b/src/modules/add-site/index.tsx
@@ -481,10 +481,10 @@ export function AddSiteModalContent( {
 	const handleSubmit = useCallback(
 		async ( event: FormEvent ) => {
 			event.preventDefault();
+			onSubmit?.();
 			await handleAddSiteClick();
 			speak( siteAddedMessage );
 			setNameSuggested( false );
-			onSubmit?.();
 		},
 		[ handleAddSiteClick, siteAddedMessage, onSubmit ]
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-1072
- Related https://github.com/Automattic/studio/pull/2149

## Proposed Changes

- Make sure the add site modal closes after creating the site

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Click on "Add Site" in the left sidebar.
- Click on "Create a blank site"
- Continue the process
- Observe that the modal closes the moment that you click the last "Add site" button



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
