### PR TITLE
Remove `user-data-updated` listener in `useSiteDetails`

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -26,7 +26,7 @@ export default function App() {
 	const { needsOnboarding } = useOnboarding();
 	const { isSidebarVisible, toggleSidebar } = useSidebarVisibility();
 	const { showWhatsNew, closeWhatsNew } = useWhatsNew();
-	const { data: localSites, loadingSites } = useSiteDetails();
+	const { sites: localSites, loadingSites } = useSiteDetails();
 	const isEmpty = ! loadingSites && ! localSites.length;
 
 	useEffect( () => {

--- a/src/components/main-sidebar.tsx
+++ b/src/components/main-sidebar.tsx
@@ -11,7 +11,7 @@ interface MainSidebarProps {
 }
 
 export default function MainSidebar( { className }: MainSidebarProps ) {
-	const { data: localSites } = useSiteDetails();
+	const { sites: localSites } = useSiteDetails();
 
 	return (
 		<div

--- a/src/components/running-sites.tsx
+++ b/src/components/running-sites.tsx
@@ -6,9 +6,9 @@ import { cx } from 'src/lib/cx';
 
 export function RunningSites() {
 	const { __, _n } = useI18n();
-	const { data, stopAllRunningSites } = useSiteDetails();
+	const { sites, stopAllRunningSites } = useSiteDetails();
 
-	const runningSites = data.filter( ( site ) => site.running );
+	const runningSites = sites.filter( ( site ) => site.running );
 
 	return (
 		<>

--- a/src/components/site-menu.tsx
+++ b/src/components/site-menu.tsx
@@ -189,7 +189,7 @@ function SiteItem( { site }: { site: SiteDetails } ) {
 }
 
 export default function SiteMenu( { className }: SiteMenuProps ) {
-	const { data, selectedSite, setSelectedSiteId, startServer, stopServer, setIsEditModalOpen } =
+	const { sites, selectedSite, setSelectedSiteId, startServer, stopServer, setIsEditModalOpen } =
 		useSiteDetails();
 	const { setSelectedTab } = useContentTabs();
 	const { handleDeleteSite } = useDeleteSite();
@@ -199,7 +199,7 @@ export default function SiteMenu( { className }: SiteMenuProps ) {
 		const unsubscribe = window.ipcListener.subscribe(
 			'site-context-menu-action',
 			async ( _, actionData: { action: string; siteId: string } ) => {
-				const site = data.find( ( site ) => site.id === actionData.siteId );
+				const site = sites.find( ( site ) => site.id === actionData.siteId );
 				if ( ! site ) {
 					return;
 				}
@@ -260,7 +260,7 @@ export default function SiteMenu( { className }: SiteMenuProps ) {
 			unsubscribe?.();
 		};
 	}, [
-		data,
+		sites,
 		editor,
 		selectedSite?.id,
 		setSelectedTab,
@@ -283,7 +283,7 @@ export default function SiteMenu( { className }: SiteMenuProps ) {
 			) }
 		>
 			<ul className="pt-px">
-				{ data.map( ( site ) => (
+				{ sites.map( ( site ) => (
 					<SiteItem key={ site.id } site={ site } />
 				) ) }
 			</ul>

--- a/src/components/tests/app.test.tsx
+++ b/src/components/tests/app.test.tsx
@@ -54,7 +54,7 @@ jest.mock( 'src/stores/wordpress-versions-api', () => {
 	return {
 		...actual,
 		useGetWordPressVersions: jest.fn( () => ( {
-			data: [
+			sites: [
 				{ label: 'Latest', value: 'latest', isBeta: false, isDevelopment: false },
 				{ label: '6.4', value: '6.4', isBeta: false, isDevelopment: false },
 			],
@@ -68,7 +68,7 @@ jest.mock( 'src/stores/wpcom-api', () => {
 	return {
 		...actual,
 		useGetBlueprints: jest.fn( () => ( {
-			data: { blueprints: [], total: 0 },
+			sites: { blueprints: [], total: 0 },
 			isLoading: false,
 		} ) ),
 	};
@@ -114,7 +114,7 @@ describe( 'App', () => {
 			needsOnboarding: false,
 		} );
 		( useSiteDetails as jest.Mock ).mockReturnValue( {
-			data: [],
+			sites: [],
 			loadingSites: false,
 			selectedSite: null,
 			snapshots: [],

--- a/src/components/tests/assistant-code-block.test.tsx
+++ b/src/components/tests/assistant-code-block.test.tsx
@@ -23,7 +23,7 @@ const selectedSite: SiteDetails = {
 };
 
 ( useSiteDetails as jest.Mock ).mockReturnValue( {
-	data: [ selectedSite ],
+	sites: [ selectedSite ],
 	loadingSites: false,
 	selectedSite: selectedSite,
 } );

--- a/src/components/tests/content-tab-settings.test.tsx
+++ b/src/components/tests/content-tab-settings.test.tsx
@@ -80,7 +80,7 @@ jest.mock( 'src/stores/wordpress-versions-api', () => {
 	return {
 		...actual,
 		useGetWordPressVersions: jest.fn( () => ( {
-			data: [
+			sites: [
 				{ label: 'Latest', value: 'latest', isBeta: false, isDevelopment: false },
 				{ label: '6.4', value: '6.4', isBeta: false, isDevelopment: false },
 				{ label: '6.3', value: '6.3', isBeta: false, isDevelopment: false },

--- a/src/components/tests/main-sidebar.test.tsx
+++ b/src/components/tests/main-sidebar.test.tsx
@@ -66,7 +66,7 @@ const site2 = {
 };
 const siteDetailsMocked = {
 	selectedSite: site2,
-	data: [
+	sites: [
 		{
 			name: 'test-1',
 			path: '/fake/test-1',

--- a/src/components/tests/site-content-tabs.test.tsx
+++ b/src/components/tests/site-content-tabs.test.tsx
@@ -42,7 +42,7 @@ jest.mock( 'src/stores/wordpress-versions-api', () => {
 	return {
 		...actual,
 		useGetWordPressVersions: jest.fn( () => ( {
-			data: [
+			sites: [
 				{ label: 'Latest', value: 'latest', isBeta: false, isDevelopment: false },
 				{ label: '6.4', value: '6.4', isBeta: false, isDevelopment: false },
 				{ label: '6.3', value: '6.3', isBeta: false, isDevelopment: false },
@@ -57,7 +57,7 @@ jest.mock( 'src/stores/wpcom-api', () => {
 	return {
 		...actual,
 		useGetBlueprints: jest.fn( () => ( {
-			data: { blueprints: [], total: 0 },
+			sites: { blueprints: [], total: 0 },
 			isLoading: false,
 		} ) ),
 	};
@@ -83,7 +83,7 @@ describe( 'SiteContentTabs', () => {
 		( useSiteDetails as jest.Mock ).mockReturnValue( {
 			selectedSite,
 			snapshots: [],
-			data: [ selectedSite ],
+			sites: [ selectedSite ],
 			loadingServer: {},
 		} );
 		await act( async () => renderWithProvider( <SiteContentTabs /> ) );
@@ -99,7 +99,7 @@ describe( 'SiteContentTabs', () => {
 		( useSiteDetails as jest.Mock ).mockReturnValue( {
 			selectedSite,
 			snapshots: [],
-			data: [ selectedSite ],
+			sites: [ selectedSite ],
 			loadingServer: {},
 		} );
 		await act( async () => renderWithProvider( <SiteContentTabs /> ) );

--- a/src/hooks/tests/use-add-site.test.tsx
+++ b/src/hooks/tests/use-add-site.test.tsx
@@ -67,7 +67,7 @@ describe( 'useAddSite', () => {
 		( useSiteDetails as jest.Mock ).mockReturnValue( {
 			createSite: mockCreateSite,
 			updateSite: mockUpdateSite,
-			data: [],
+			sites: [],
 			loadingSites: false,
 			startServer: mockStartServer,
 		} );

--- a/src/hooks/tests/use-add-site.test.tsx
+++ b/src/hooks/tests/use-add-site.test.tsx
@@ -160,13 +160,13 @@ describe( 'useAddSite', () => {
 
 	it( 'should pass WordPress version to createSite when handleAddSiteClick is called', async () => {
 		mockCreateSite.mockImplementation(
-			( path, name, wpVersion, customDomain, enableHttps, blueprint, callback ) => {
+			( path, name, wpVersion, customDomain, enableHttps, blueprint, phpVersion, callback ) => {
 				callback( {
 					id: 'test-id',
 					name: name || 'Test Site',
-					path: path,
-					wpVersion: wpVersion,
-					phpVersion: '8.2',
+					path,
+					wpVersion,
+					phpVersion,
 				} );
 				return Promise.resolve();
 			}
@@ -190,49 +190,9 @@ describe( 'useAddSite', () => {
 			undefined,
 			false,
 			undefined, // blueprint parameter
+			'8.3',
 			expect.any( Function )
 		);
-	} );
-
-	it( 'should still call updateSite even if wpVersion matches due to object comparison', async () => {
-		const wpVersion = '6.1.7';
-		const newSite = {
-			id: 'test-id',
-			name: 'Test Site',
-			path: '/test/path',
-			wpVersion: wpVersion,
-			phpVersion: '8.3',
-		};
-
-		mockCreateSite.mockImplementation(
-			( path, name, version, customDomain, enableHttps, blueprint, callback ) => {
-				callback( {
-					...newSite,
-					wpVersion: version,
-				} );
-				return Promise.resolve();
-			}
-		);
-
-		const { result } = renderHookWithProvider( () => useAddSite() );
-
-		act( () => {
-			result.current.setWpVersion( wpVersion );
-			result.current.setSitePath( '/test/path' );
-		} );
-
-		mockUpdateSite.mockClear();
-
-		await act( async () => {
-			await result.current.handleAddSiteClick();
-		} );
-
-		expect( mockUpdateSite ).toHaveBeenCalled();
-
-		expect( mockUpdateSite ).toHaveBeenCalledWith( {
-			...newSite,
-			wpVersion,
-		} );
 	} );
 
 	it( 'should connect and start pulling when a remote site is selected', async () => {
@@ -258,7 +218,7 @@ describe( 'useAddSite', () => {
 		};
 
 		mockCreateSite.mockImplementation(
-			( path, name, version, customDomain, enableHttps, blueprint, callback ) => {
+			( path, name, version, customDomain, enableHttps, blueprint, phpVersion, callback ) => {
 				callback( createdSite );
 				return Promise.resolve();
 			}

--- a/src/hooks/use-add-site.ts
+++ b/src/hooks/use-add-site.ts
@@ -20,7 +20,7 @@ import type { SyncOption } from 'src/types';
 
 export function useAddSite() {
 	const { __ } = useI18n();
-	const { createSite, data: sites, loadingSites, startServer, updateSite } = useSiteDetails();
+	const { createSite, sites, loadingSites, startServer } = useSiteDetails();
 	const { importFile, clearImportState } = useImportExport();
 	const [ connectSite ] = useConnectSiteMutation();
 	const { pullSite } = useSyncSites();
@@ -126,20 +126,8 @@ export function useAddSite() {
 				usedCustomDomain,
 				useCustomDomain ? enableHttps : false,
 				selectedBlueprint,
+				phpVersion,
 				async ( newSite ) => {
-					let updatedSite = { ...newSite };
-
-					if ( newSite.phpVersion !== phpVersion ) {
-						updatedSite = {
-							...updatedSite,
-							phpVersion,
-						};
-					}
-
-					if ( updatedSite !== newSite ) {
-						await updateSite( updatedSite );
-					}
-
 					if ( fileForImport ) {
 						await importFile( fileForImport, newSite, {
 							showImportNotification: false,
@@ -183,7 +171,6 @@ export function useAddSite() {
 		siteName,
 		sitePath,
 		startServer,
-		updateSite,
 		wpVersion,
 		phpVersion,
 		customDomain,

--- a/src/hooks/use-site-details.tsx
+++ b/src/hooks/use-site-details.tsx
@@ -22,7 +22,7 @@ import type { Blueprint } from 'src/stores/wpcom-api';
 interface SiteDetailsContext {
 	selectedSite: SiteDetails | null;
 	updateSite: ( site: SiteDetails ) => Promise< void >;
-	data: SiteDetails[];
+	sites: SiteDetails[];
 	setSelectedSiteId: ( selectedSiteId: string ) => void;
 	createSite: (
 		path: string,
@@ -31,6 +31,7 @@ interface SiteDetailsContext {
 		customDomain?: string,
 		enableHttps?: boolean,
 		blueprint?: Blueprint,
+		phpVersion?: string,
 		callback?: ( site: SiteDetails ) => Promise< void >
 	) => Promise< SiteDetails | void >;
 	startServer: ( id: string ) => Promise< void >;
@@ -50,7 +51,7 @@ interface SiteDetailsContext {
 const defaultContext: SiteDetailsContext = {
 	selectedSite: null,
 	updateSite: async () => undefined,
-	data: [],
+	sites: [],
 	siteCreationMessages: {},
 	setSelectedSiteId: () => undefined,
 	createSite: async () => undefined,
@@ -157,13 +158,12 @@ function useDeleteSite() {
 export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 	const { Provider } = siteDetailsContext;
 
-	const [ data, setData ] = useState< SiteDetails[] >( [] );
+	const [ sites, setSites ] = useState< SiteDetails[] >( [] );
 	const [ loadingSites, setLoadingSites ] = useState< boolean >( true );
-	const [ addingSiteIds, setAddingSiteIds ] = useState< string[] >( [] );
 	const [ siteCreationMessages, setSiteCreationMessages ] = useState< {
 		[ siteId: string ]: string;
 	} >( {} );
-	const firstSite = data[ 0 ] || null;
+	const firstSite = sites[ 0 ] || null;
 	const [ loadingServer, setLoadingServer ] = useState< Record< string, boolean > >(
 		firstSite?.id
 			? {
@@ -196,7 +196,7 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 		async ( id: string, removeLocal: boolean ) => {
 			await deleteSite( id, removeLocal );
 			const newSites = await getIpcApi().getSiteDetails();
-			setData( newSites );
+			setSites( newSites );
 			const selectedSite = newSites.length ? newSites[ 0 ].id : '';
 			setSelectedSiteId( selectedSite );
 			if ( selectedTab !== 'overview' ) {
@@ -214,6 +214,7 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 			customDomain?: string,
 			enableHttps?: boolean,
 			blueprint?: Blueprint,
+			phpVersion?: string,
 			callback?: ( site: SiteDetails ) => Promise< void >
 		) => {
 			// Function to handle error messages and cleanup
@@ -255,16 +256,14 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 
 				// Remove the temporary site immediately, but with a minor delay to ensure state updates properly
 				setTimeout( () => {
-					setAddingSiteIds( ( prev ) => prev.filter( ( id ) => id !== tempSiteId ) );
-					setData( ( prevData ) =>
+					setSites( ( prevData ) =>
 						sortSites( prevData.filter( ( site ) => site.id !== tempSiteId ) )
 					);
 				}, 2000 );
 			};
 
 			const tempSiteId = crypto.randomUUID();
-			setAddingSiteIds( ( prev ) => [ ...prev, tempSiteId ] );
-			setData( ( prevData ) =>
+			setSites( ( prevData ) =>
 				sortSites( [
 					...prevData,
 					{
@@ -288,16 +287,13 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 					customDomain,
 					enableHttps,
 					siteId: tempSiteId,
+					phpVersion,
 					blueprint,
 				} );
 				if ( ! newSite ) {
 					showError( undefined, !! blueprint );
 					return;
 				}
-				setAddingSiteIds( ( prev ) => {
-					prev.push( newSite.id );
-					return prev;
-				} );
 				// Update the selected site to the new site's ID if the user didn't change it
 				setSelectedSiteId( ( prevSelectedSiteId ) => {
 					if ( prevSelectedSiteId === tempSiteId ) {
@@ -308,8 +304,13 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 					}
 					return prevSelectedSiteId;
 				} );
-				setData( ( prevData ) =>
-					prevData.map( ( site ) => ( site.id === tempSiteId ? newSite : site ) )
+				setSites( ( prevData ) =>
+					prevData.map( ( site ) => {
+						if ( site.id === newSite.id ) {
+							return { ...newSite, isAddingSite: true };
+						}
+						return site;
+					} )
 				);
 
 				setSiteCreationMessages( ( prev ) => {
@@ -321,13 +322,18 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 					await callback( newSite );
 				}
 
+				setSites( ( prevData ) =>
+					prevData.map( ( site ) => {
+						if ( site.id === newSite.id ) {
+							return { ...site, isAddingSite: false };
+						}
+						return site;
+					} )
+				);
+
 				return newSite;
 			} catch ( error ) {
 				showError( error, !! blueprint );
-			} finally {
-				setAddingSiteIds( ( prev ) =>
-					prev.filter( ( id ) => id !== tempSiteId && id !== newSite?.id )
-				);
 			}
 		},
 		[ selectedTab, setSelectedSiteId, setSelectedTab ]
@@ -336,7 +342,7 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 	const updateSite = useCallback( async ( site: SiteDetails ) => {
 		await getIpcApi().updateSite( site );
 		const updatedSites = await getIpcApi().getSiteDetails();
-		setData( updatedSites );
+		setSites( updatedSites );
 	}, [] );
 
 	const startServer = useCallback(
@@ -401,7 +407,7 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 			}
 
 			if ( updatedSite ) {
-				setData( ( prevData ) =>
+				setSites( ( prevData ) =>
 					prevData.map( ( site ) =>
 						site.id === id && updatedSite ? { ...site, ...updatedSite } : site
 					)
@@ -431,7 +437,7 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 			.getSiteDetails()
 			.then( async ( data ) => {
 				if ( ! cancel ) {
-					setData( data );
+					setSites( data );
 					setLoadingSites( false );
 					autoStartSites( data );
 				}
@@ -446,23 +452,12 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 		};
 	}, [ autoStartSites ] );
 
-	useEffect( () => {
-		const unsubscribe = window.ipcListener.subscribe( 'user-data-updated', async () => {
-			const updatedSites = await getIpcApi().getSiteDetails();
-			setData( updatedSites );
-		} );
-
-		return () => {
-			unsubscribe();
-		};
-	}, [] );
-
 	const stopServer = useCallback(
 		async ( id: string ) => {
 			toggleLoadingServerForSite( id );
 			const updatedSite = await getIpcApi().stopServer( id );
 			if ( updatedSite ) {
-				setData( ( prevData ) =>
+				setSites( ( prevData ) =>
 					prevData.map( ( site ) => ( site.id === id ? { ...site, ...updatedSite } : site ) )
 				);
 			}
@@ -472,26 +467,20 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 	);
 
 	const stopAllRunningSites = useCallback( async () => {
-		const runningSites = data.filter( ( site ) => site.running );
+		const runningSites = sites.filter( ( site ) => site.running );
 		for ( const site of runningSites ) {
 			await getIpcApi().stopServer( site.id );
 		}
-		setData( data.map( ( site ) => ( site.running ? { ...site, running: false } : site ) ) );
-	}, [ data ] );
+		setSites( sites.map( ( site ) => ( site.running ? { ...site, running: false } : site ) ) );
+	}, [ sites ] );
 
 	const [ isEditModalOpen, setIsEditModalOpen ] = useState( false );
-	const selectedSite = useMemo( () => {
-		const site = data.find( ( site ) => site.id === selectedSiteId ) || firstSite;
-		if ( addingSiteIds.includes( site?.id ) ) {
-			site.isAddingSite = true;
-		}
-		return site;
-	}, [ addingSiteIds, data, firstSite, selectedSiteId ] );
+	const selectedSite = sites.find( ( site ) => site.id === selectedSiteId ) || firstSite;
 
 	const context = useMemo(
 		() => ( {
 			selectedSite,
-			data,
+			sites,
 			setSelectedSiteId,
 			createSite,
 			updateSite,
@@ -510,7 +499,7 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 		} ),
 		[
 			selectedSite,
-			data,
+			sites,
 			setSelectedSiteId,
 			createSite,
 			updateSite,

--- a/src/hooks/use-theme-details.tsx
+++ b/src/hooks/use-theme-details.tsx
@@ -37,7 +37,7 @@ interface ThemeDetailsProviderProps {
 
 export const ThemeDetailsProvider: React.FC< ThemeDetailsProviderProps > = ( { children } ) => {
 	const [ initialLoad, setInitialLoad ] = useState( false );
-	const { loadingSites, data: sites, selectedSite } = useSiteDetails();
+	const { loadingSites, sites, selectedSite } = useSiteDetails();
 	const [ thumbnails, setThumbnails ] = useState< Record< string, ThumbnailType > >( {} );
 	const [ themeDetails, setThemeDetails ] = useState< Record< string, ThemeDetailsType > >( {} );
 	const [ loadingThemeDetails, setLoadingThemeDetails ] = useState< Record< string, boolean > >(

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -214,10 +214,19 @@ export async function createSite(
 		customDomain?: string;
 		enableHttps?: boolean;
 		siteId?: string;
+		phpVersion?: string;
 		blueprint?: Blueprint;
 	} = {}
 ): Promise< SiteDetails > {
-	const { siteName, wpVersion, customDomain, enableHttps, siteId, blueprint } = config;
+	const {
+		siteName,
+		wpVersion,
+		customDomain,
+		enableHttps,
+		siteId,
+		blueprint,
+		phpVersion = getWordPressProvider().DEFAULT_PHP_VERSION,
+	} = config;
 
 	const forceSetupSqlite = false;
 
@@ -250,7 +259,7 @@ export async function createSite(
 		adminPassword: createPassword(),
 		port,
 		running: false,
-		phpVersion: getWordPressProvider().DEFAULT_PHP_VERSION,
+		phpVersion,
 		isWpAutoUpdating: wpVersion === getWordPressProvider().DEFAULT_WORDPRESS_VERSION,
 		customDomain,
 		enableHttps,

--- a/src/modules/add-site/tests/add-site.test.tsx
+++ b/src/modules/add-site/tests/add-site.test.tsx
@@ -26,7 +26,7 @@ jest.mock( 'src/stores/wordpress-versions-api', () => {
 	return {
 		...actual,
 		useGetWordPressVersions: () => ( {
-			data: [
+			sites: [
 				{
 					value: '6.5.0-beta1',
 					isBeta: true,
@@ -79,7 +79,7 @@ const mockCreateSite = jest.fn< ( path: string, name?: string, wpVersion?: strin
 jest.mock( 'src/hooks/use-site-details', () => ( {
 	useSiteDetails: () => ( {
 		createSite: mockCreateSite,
-		data: [],
+		sites: [],
 	} ),
 } ) );
 

--- a/src/modules/add-site/tests/add-site.test.tsx
+++ b/src/modules/add-site/tests/add-site.test.tsx
@@ -26,7 +26,7 @@ jest.mock( 'src/stores/wordpress-versions-api', () => {
 	return {
 		...actual,
 		useGetWordPressVersions: () => ( {
-			sites: [
+			data: [
 				{
 					value: '6.5.0-beta1',
 					isBeta: true,
@@ -229,6 +229,7 @@ describe( 'AddSite', () => {
 				undefined,
 				false,
 				undefined, // blueprint parameter
+				'8.3',
 				expect.any( Function )
 			);
 		} );
@@ -444,6 +445,7 @@ describe( 'AddSite', () => {
 				undefined,
 				false,
 				undefined, // blueprint parameter
+				'8.3',
 				expect.any( Function )
 			);
 		} );

--- a/src/modules/onboarding/hooks/use-onboarding.tsx
+++ b/src/modules/onboarding/hooks/use-onboarding.tsx
@@ -20,7 +20,7 @@ interface OnboardingProviderProps {
 }
 
 export const OnboardingProvider: React.FC< OnboardingProviderProps > = ( { children } ) => {
-	const { data, loadingSites } = useSiteDetails();
+	const { sites, loadingSites } = useSiteDetails();
 	const onboardingCompleted = useRootSelector( selectOnboardingCompleted );
 	const onboardingLoading = useRootSelector( selectOnboardingLoading );
 	const dispatch = useAppDispatch();
@@ -37,8 +37,8 @@ export const OnboardingProvider: React.FC< OnboardingProviderProps > = ( { child
 		}
 
 		// Show onboarding only if the user hasn't completed it and has no sites
-		return ! ( loadingSites || data.length > 0 || onboardingCompleted );
-	}, [ loadingSites, onboardingCompleted, onboardingLoading, data ] );
+		return ! ( loadingSites || sites.length > 0 || onboardingCompleted );
+	}, [ loadingSites, onboardingCompleted, onboardingLoading, sites ] );
 
 	const contextValue = useMemo(
 		() => ( {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-1071
- Follow up to #2161 (which fixed a regression I caused in #2148)

## Proposed Changes

The data flow in and around `useSiteDetails` when creating a new site is pretty gnarly. Previously, we were unintentionally relying on the `user-data-updated` listener to refresh the state after writing to the appdata file. When I removed this listener in #2148, it caused a regression in which the `isAddingSite` property on the new site never cleared (which meant the loading screen would display indefinitely). @sejas merged a hotfix for this in #2161.

The `user-data-updated` listener is meant to let Studio pick up changes from the CLI. We should not rely on it for flows that run entirely in Studio, where we already have all the state easily accessible in memory.

This PR removes the `user-data-updated` listener again and fixes the underlying problem by:

1. Not mutating the `selectedSite` object in the `useMemo` callback (this is where we previously set the `isAddingSite` property, but we didn't have any explicit logic to unset it)
2. Updating the `createSite` function in `useSiteDetails` to accept a `phpVersion` argument. Previously, we would set this in a callback function in `useAddSite` that included a state update in`useSiteDetails` (which would unset `isAddingSite` flag).
3. Removing the `addingSiteIds` state and instead explicitly setting and unsetting the `isAddingSite` flag on the site object in the `createSite` function. 
4. Bonus: not using `useMemo` to store `selectedSite`. The way we did this had no effect.
5. Bonus: renaming the site list state from `data` to `sites` in `useSiteDetails`.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create a new site with all the default settings
2. Ensure that the flow behaves as before and that it finishes normally
3. Create another site with a PHP version different than the default
4. Ensure that the process finishes normally and that the PHP version was persisted correctly (check the Settings tab)
5. Create a site with a blueprint
6. Ensure that the process finishes normally
7. Create a site from an existing remote site (see pdtkmj-4cM-p2)
8. Ensure that the process finishes normally

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?