### PR TITLE
Add title to new import remote site screen for unauthenticated users

### DIFF
--- a/src/modules/add-site/components/pull-remote-site.tsx
+++ b/src/modules/add-site/components/pull-remote-site.tsx
@@ -61,52 +61,57 @@ function NoAuthPullRemoteSiteView() {
 	const offlineMessage = __( "You're currently offline." );
 
 	return (
-		<SiteSyncDescription>
-			<div className="mt-8">
-				<Tooltip disabled={ ! isOffline } icon={ offlineIcon } text={ offlineMessage }>
-					<Button
-						aria-description={ isOffline ? offlineMessage : '' }
-						aria-disabled={ isOffline }
-						variant="primary"
-						onClick={ () => {
-							if ( isOffline ) {
-								return;
-							}
-							authenticate();
-						} }
-					>
-						{ __( 'Log in to WordPress.com' ) }
-						<ArrowIcon />
-					</Button>
-				</Tooltip>
-			</div>
-			<div className="mt-3 text-a8c-gray-70 a8c-body">
-				<Tooltip
-					disabled={ ! isOffline }
-					icon={ offlineIcon }
-					text={ offlineMessage }
-					placement="bottom-start"
-				>
-					<span>
-						{ __( 'New to WordPress.com?' ) }{ ' ' }
+		<VStack className="w-full" alignment="top" spacing="1">
+			<Heading className="text-center text-[32px] text-gray-900" weight={ 500 }>
+				{ __( 'Pull your remote site' ) }
+			</Heading>
+			<SiteSyncDescription>
+				<div className="mt-8">
+					<Tooltip disabled={ ! isOffline } icon={ offlineIcon } text={ offlineMessage }>
 						<Button
 							aria-description={ isOffline ? offlineMessage : '' }
 							aria-disabled={ isOffline }
-							className="!p-0 text-a8c-blue-50 hover:opacity-80 h-auto inline-flex items-center"
+							variant="primary"
 							onClick={ () => {
 								if ( isOffline ) {
 									return;
 								}
-								getIpcApi().authenticate( true );
+								authenticate();
 							} }
 						>
-							{ __( 'Create a free account' ) }
+							{ __( 'Log in to WordPress.com' ) }
 							<ArrowIcon />
 						</Button>
-					</span>
-				</Tooltip>
-			</div>
-		</SiteSyncDescription>
+					</Tooltip>
+				</div>
+				<div className="mt-3 text-a8c-gray-70 a8c-body">
+					<Tooltip
+						disabled={ ! isOffline }
+						icon={ offlineIcon }
+						text={ offlineMessage }
+						placement="bottom-start"
+					>
+						<span>
+							{ __( 'New to WordPress.com?' ) }{ ' ' }
+							<Button
+								aria-description={ isOffline ? offlineMessage : '' }
+								aria-disabled={ isOffline }
+								className="!p-0 text-a8c-blue-50 hover:opacity-80 h-auto inline-flex items-center"
+								onClick={ () => {
+									if ( isOffline ) {
+										return;
+									}
+									getIpcApi().authenticate( true );
+								} }
+							>
+								{ __( 'Create a free account' ) }
+								<ArrowIcon />
+							</Button>
+						</span>
+					</Tooltip>
+				</div>
+			</SiteSyncDescription>
+		</VStack>
 	);
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Closes STU-1073

## Proposed Changes

- Adds a title to the new import remote site screen when the user is not authenticated


|Before | After|
|-------|------|
|  <img width="2068" height="1424" alt="CleanShot 2025-12-02 at 11 46 24@2x" src="https://github.com/user-attachments/assets/44815fc9-2734-4ef1-8dca-d6cef7a47405" />|<img width="2068" height="1424" alt="CleanShot 2025-12-02 at 11 46 31@2x" src="https://github.com/user-attachments/assets/dbe2086a-d59a-42f2-b43e-67a2a2b24a99" />|

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Apply this branch and run `npm start`
- Log out of Studio if you are logged in
- Click on `Add site` and select `Import an existing website`
- Verify the title exist and it looks fine

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
