### PR TITLE
Update progress bar wording

### DIFF
--- a/src/lib/wordpress-provider/playground-cli/playground-server-process-child.ts
+++ b/src/lib/wordpress-provider/playground-cli/playground-server-process-child.ts
@@ -77,7 +77,7 @@ function formatMessageForUI( message: string ): string {
 		return __( 'Running the Blueprint…' );
 	}
 	if ( message.includes( 'Finished running the blueprint' ) ) {
-		return __( 'Finishing running the Blueprint…' );
+		return __( 'Wrapping up the Blueprint installation…' );
 	}
 	if ( message.includes( 'Preparing workers' ) ) {
 		return __( 'Preparing workers…' );

--- a/src/lib/wordpress-provider/playground-cli/playground-server-process-child.ts
+++ b/src/lib/wordpress-provider/playground-cli/playground-server-process-child.ts
@@ -77,7 +77,7 @@ function formatMessageForUI( message: string ): string {
 		return __( 'Running the Blueprint…' );
 	}
 	if ( message.includes( 'Finished running the blueprint' ) ) {
-		return __( 'Finished running the Blueprint…' );
+		return __( 'Finishing running the Blueprint…' );
 	}
 	if ( message.includes( 'Preparing workers' ) ) {
 		return __( 'Preparing workers…' );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Related to STU-1053
- Follow up to 197117-ghe-Automattic/wpcom

## Proposed Changes

- Update the progress bar wording to not indicate finished action

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Check out this branch and start Studio with `npm start`
- Select "Add Site" -> "Start with Blueprint" -> select a Blueprint
- Check that on the progressbar, the copy is updated

<img width="2024" height="1424" alt="CleanShot 2025-12-03 at 11 27 55@2x" src="https://github.com/user-attachments/assets/bf7ad419-68a6-4ceb-9f81-bda24cc96f00" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?