### PR TITLE
Remove streamlineOnboarding feature flag

### DIFF
--- a/src/ipc-types.d.ts
+++ b/src/ipc-types.d.ts
@@ -79,7 +79,6 @@ type IpcApi = {
 
 interface FeatureFlags {
 	enableBlueprints: boolean;
-	streamlineOnboarding: boolean;
 }
 
 interface BetaFeatures {

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -12,12 +12,6 @@ export const FEATURE_FLAGS_DEFINITION: Record< keyof FeatureFlags, FeatureFlagDe
 		flag: 'enableBlueprints',
 		default: true,
 	},
-	streamlineOnboarding: {
-		label: 'Streamline Onboarding',
-		env: 'STREAMLINE_ONBOARDING',
-		flag: 'streamlineOnboarding',
-		default: false,
-	},
 } as const;
 
 export const FEATURE_FLAGS: Record< keyof FeatureFlags, FeatureFlagDefinition > =

--- a/src/modules/sync/index.tsx
+++ b/src/modules/sync/index.tsx
@@ -1,4 +1,4 @@
-import { check, cloudUpload, Icon } from '@wordpress/icons';
+import { check, Icon } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { PropsWithChildren, useEffect, useState } from 'react';
 import { ArrowIcon } from 'src/components/arrow-icon';
@@ -7,7 +7,6 @@ import offlineIcon from 'src/components/offline-icon';
 import { Tooltip } from 'src/components/tooltip';
 import { useSyncSites } from 'src/hooks/sync-sites';
 import { useAuth } from 'src/hooks/use-auth';
-import { useFeatureFlags } from 'src/hooks/use-feature-flags';
 import { useFetchWpComSites } from 'src/hooks/use-fetch-wpcom-sites';
 import { useOffline } from 'src/hooks/use-offline';
 import { getIpcApi } from 'src/lib/get-ipc-api';
@@ -143,8 +142,7 @@ export function ContentTabSync( { selectedSite }: { selectedSite: SiteDetails } 
 	} = useFetchWpComSites( connectedSites.map( ( { id } ) => id ) );
 	const [ connectSite ] = useConnectSiteMutation();
 	const [ disconnectSite ] = useDisconnectSiteMutation();
-	const { pushSite, pullSite, isAnySitePulling, isAnySitePushing } = useSyncSites();
-	const isAnySiteSyncing = isAnySitePulling || isAnySitePushing;
+	const { pushSite, pullSite } = useSyncSites();
 
 	const [ selectedRemoteSite, setSelectedRemoteSite ] = useState< SyncSite | null >( null );
 	const [ pendingModalMode, setPendingModalMode ] = useState< 'push' | 'pull' | null >( null );

--- a/src/modules/sync/index.tsx
+++ b/src/modules/sync/index.tsx
@@ -145,7 +145,6 @@ export function ContentTabSync( { selectedSite }: { selectedSite: SiteDetails } 
 	const [ disconnectSite ] = useDisconnectSiteMutation();
 	const { pushSite, pullSite, isAnySitePulling, isAnySitePushing } = useSyncSites();
 	const isAnySiteSyncing = isAnySitePulling || isAnySitePushing;
-	const { streamlineOnboarding } = useFeatureFlags();
 
 	const [ selectedRemoteSite, setSelectedRemoteSite ] = useState< SyncSite | null >( null );
 	const [ pendingModalMode, setPendingModalMode ] = useState< 'push' | 'pull' | null >( null );
@@ -214,55 +213,14 @@ export function ContentTabSync( { selectedSite }: { selectedSite: SiteDetails } 
 				</div>
 			) : (
 				<SiteSyncDescription>
-					{ streamlineOnboarding ? (
-						<div className="mt-8 flex flex-wrap gap-4">
-							<ConnectButton
-								variant="primary"
-								icon={ cloudUpload }
-								connectSite={ () => setPendingModalMode( 'push' ) }
-								disabled={ isAnySiteSyncing || pendingModalMode !== null }
-								isBusy={ pendingModalMode === 'push' }
-								tooltipText={
-									pendingModalMode === 'pull'
-										? __( 'Please wait for the current operation to finish.' )
-										: isAnySiteSyncing
-										? __(
-												'Another site is syncing. Please wait for the sync to finish before you publish your site.'
-										  )
-										: __( 'Publishing your site requires an internet connection.' )
-								}
-							>
-								{ __( 'Publish site' ) }
-							</ConnectButton>
-							<ConnectButton
-								variant="secondary"
-								connectSite={ () => setPendingModalMode( 'pull' ) }
-								className={ isAnySiteSyncing ? '' : '!text-a8c-blue-50 !shadow-a8c-blue-50' }
-								disabled={ isAnySiteSyncing || pendingModalMode !== null }
-								isBusy={ pendingModalMode === 'pull' }
-								tooltipText={
-									pendingModalMode === 'push'
-										? __( 'Please wait for the current operation to finish.' )
-										: isAnySiteSyncing
-										? __(
-												'Another site is syncing. Please wait for the sync to finish before you pull a site.'
-										  )
-										: __( 'Importing a remote site requires an internet connection.' )
-								}
-							>
-								{ __( 'Pull site' ) }
-							</ConnectButton>
-						</div>
-					) : (
-						<div className="mt-8">
-							<ConnectButton
-								variant="primary"
-								connectSite={ () => dispatch( connectedSitesActions.openModal( 'connect' ) ) }
-							>
-								{ __( 'Connect site' ) }
-							</ConnectButton>
-						</div>
-					) }
+					<div className="mt-8">
+						<ConnectButton
+							variant="primary"
+							connectSite={ () => dispatch( connectedSitesActions.openModal( 'connect' ) ) }
+						>
+							{ __( 'Connect site' ) }
+						</ConnectButton>
+					</div>
 				</SiteSyncDescription>
 			) }
 

--- a/src/modules/sync/tests/index.test.tsx
+++ b/src/modules/sync/tests/index.test.tsx
@@ -129,7 +129,6 @@ describe( 'ContentTabSync', () => {
 		( useAuth as jest.Mock ).mockReturnValue( createAuthMock( false ) );
 		( useFeatureFlags as jest.Mock ).mockReturnValue( {
 			enableBlueprints: true,
-			streamlineOnboarding: false,
 		} );
 		( getIpcApi as jest.Mock ).mockReturnValue( {
 			authenticate: jest.fn(),
@@ -258,35 +257,6 @@ describe( 'ContentTabSync', () => {
 		expect( getIpcApi().authenticate ).toHaveBeenCalled();
 	} );
 
-	it( 'displays publish and import actions to authenticated user', () => {
-		( useAuth as jest.Mock ).mockReturnValue( createAuthMock( true ) );
-		( useFeatureFlags as jest.Mock ).mockReturnValue( {
-			enableBlueprints: true,
-			streamlineOnboarding: true,
-		} );
-		renderWithProvider( <ContentTabSync selectedSite={ selectedSite } /> );
-		const publishButton = screen.getByRole( 'button', { name: /Publish site/i } );
-		const importButton = screen.getByRole( 'button', { name: /Pull site/i } );
-
-		expect( publishButton ).toBeInTheDocument();
-		expect( importButton ).toBeInTheDocument();
-	} );
-
-	it( 'opens the site selector modal when clicking "Pull site" button', async () => {
-		( useAuth as jest.Mock ).mockReturnValue( createAuthMock( true ) );
-		( useFeatureFlags as jest.Mock ).mockReturnValue( {
-			enableBlueprints: true,
-			streamlineOnboarding: true,
-		} );
-		setupConnectedSitesMocks( [], [ fakeSyncSite ] );
-
-		renderWithProvider( <ContentTabSync selectedSite={ selectedSite } /> );
-		const pullSiteButton = await screen.findByRole( 'button', { name: 'Pull site' } );
-		fireEvent.click( pullSiteButton );
-
-		expect( await screen.findByTestId( 'sync-sites-modal-selector' ) ).toBeInTheDocument();
-	} );
-
 	it( 'displays the list of connected sites', async () => {
 		( useAuth as jest.Mock ).mockReturnValue( createAuthMock( true ) );
 		setupConnectedSitesMocks( [ fakeSyncSite ], [ fakeSyncSite ] );
@@ -339,21 +309,6 @@ describe( 'ContentTabSync', () => {
 			name: /Create a new WordPress.com site ↗/i,
 		} );
 		expect( createNewSiteButton ).toBeInTheDocument();
-	} );
-
-	it( 'displays publish and import buttons when there are no connected sites', () => {
-		( useAuth as jest.Mock ).mockReturnValue( createAuthMock( true ) );
-		( useFeatureFlags as jest.Mock ).mockReturnValue( {
-			enableBlueprints: true,
-			streamlineOnboarding: true,
-		} );
-		renderWithProvider( <ContentTabSync selectedSite={ selectedSite } /> );
-
-		const publishButton = screen.getByRole( 'button', { name: /Publish site/i } );
-		const importButton = screen.getByRole( 'button', { name: /Pull site/i } );
-
-		expect( publishButton ).toBeInTheDocument();
-		expect( importButton ).toBeInTheDocument();
 	} );
 
 	it( 'displays environment badges for Pressable sites with production, staging and development environments', async () => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-1067

## Proposed Changes

- Remove `streamlineOnboarding` feature flag
- It also removes the Publish and Pull site buttons in favor of always displaying the connect site button.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run `npm start`
- Create a site
- Go to the sync tab
- Observe that the connect a site button is visible
- Also observe that the Publish site button next to the start button is present

<img width="1012" height="712" alt="Screenshot 2025-12-02 at 17 41 43" src="https://github.com/user-attachments/assets/d26d9991-decd-494c-8707-fb284797582d" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
