### PR TITLE
Change the option title and make it consistent to say Pull an existing site

### DIFF
--- a/src/modules/add-site/components/options.tsx
+++ b/src/modules/add-site/components/options.tsx
@@ -111,7 +111,7 @@ export default function AddSiteOptions( { onOptionSelect }: AddSiteOptionsProps 
 			) }
 			<OptionButton
 				icon={ <Icon icon={ download } size={ 24 } fill="#3858E9" /> }
-				title={ __( 'Import an existing website' ) }
+				title={ __( 'Pull an existing site' ) }
 				description={ __( 'Download directly from WordPress.com or Pressable' ) }
 				onClick={ () => onOptionSelect( 'pullRemote' ) }
 			/>

--- a/src/modules/add-site/components/pull-remote-site.tsx
+++ b/src/modules/add-site/components/pull-remote-site.tsx
@@ -145,7 +145,7 @@ export function PullRemoteSite( {
 	return (
 		<VStack className="w-full" alignment="top" spacing={ isAuthenticated ? 3 : 1 }>
 			<Heading className="text-center text-[32px] text-gray-900" weight={ 500 }>
-				{ __( 'Pull your remote site' ) }
+				{ __( 'Pull an existing site' ) }
 			</Heading>
 			{ isAuthenticated ? (
 				<VStack className="flex flex-col w-full max-w-[650px] flex-1">


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-1084

## Proposed Changes

- Change the new option title to `Pull an existing site`.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run `npm start`
- Click on add site
- Observe that the new option says `Pull an existing site`
- Click on it
- Observe the main title also says `Pull an existing site`

| Title | Before | After |
|--------|--------|--------|
|  Option | <img width="1012" height="712" alt="Screenshot 2025-12-03 at 12 03 39" src="https://github.com/user-attachments/assets/179785f6-0d89-47bf-9490-d477716b21dd" />  | <img width="1012" height="712" alt="Screenshot 2025-12-03 at 11 55 26" src="https://github.com/user-attachments/assets/326b8a24-4196-4eb6-a27e-71e70af5f393" /> |
| Title | <img width="1012" height="712" alt="Screenshot 2025-12-03 at 12 03 42" src="https://github.com/user-attachments/assets/e5276e46-46fb-4110-92c5-bc95a3e6ca8c" /> | <img width="1012" height="712" alt="Screenshot 2025-12-03 at 11 55 46" src="https://github.com/user-attachments/assets/d5c2f6c8-3893-4c26-8c6d-ac869911eeaf" /> |


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
