### PR TITLE
Add translation to playground-process messages as they can be used in the UI

### DIFF
--- a/src/lib/wordpress-provider/playground-cli/playground-server-process-child.ts
+++ b/src/lib/wordpress-provider/playground-cli/playground-server-process-child.ts
@@ -1,6 +1,6 @@
 import { cpus } from 'os';
 import { SupportedPHPVersion, PHPRunOptions } from '@php-wasm/universal';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { runCLI, RunCLIArgs, RunCLIServer } from '@wp-playground/cli';
 import { getMuPlugins } from 'common/lib/mu-plugins';
 import { isWordPressDevVersion } from 'common/lib/wordpress-version-utils';
@@ -220,7 +220,10 @@ async function startServer(
 		if ( options.enableMultiWorker ) {
 			const workerCount = Math.max( 1, cpus().length - 1 );
 			console.log(
-				`[playground-cli] Enabling experimental multi-worker support with ${ workerCount } workers (CPU cores - 1)`
+				sprintf(
+					__( 'Enabling experimental multi-worker support with %d workers (CPU cores - 1)' ),
+					workerCount
+				)
 			);
 			args.experimentalMultiWorker = workerCount;
 		}
@@ -246,7 +249,7 @@ async function startServer(
 		// Log actual worker count for verification
 		if ( options.enableMultiWorker ) {
 			console.log(
-				`[playground-cli] Server started with ${ server.workerThreadCount } worker thread(s)`
+				sprintf( __( 'Server started with %d worker thread(s)' ), server.workerThreadCount )
 			);
 		}
 


### PR DESCRIPTION


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Closes STU-1048

## Proposed Changes

- Translate messages from playground-server-process-child as they can be used in the UI

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Apply this branch and run `npm start`
- Create a new site and check the messages in the loading screen
- Check there is no `[playground-cli]` preffix in messages
- Check they make sense

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
