### PR TITLE
Publish site: Open OAuth page for logged-out users

### DIFF
--- a/src/components/publish-site-button.tsx
+++ b/src/components/publish-site-button.tsx
@@ -26,12 +26,11 @@ export const PublishSiteButton = () => {
 	const isAnySiteSyncing = isAnySitePulling || isAnySitePushing;
 
 	const handlePublishClick = useCallback( () => {
-		setSelectedTab( 'sync' );
 		if ( ! user ) {
 			authenticate();
-		} else {
-			dispatch( connectedSitesActions.openModal( 'push' ) );
 		}
+		dispatch( connectedSitesActions.openModal( 'push' ) );
+		setSelectedTab( 'sync' );
 	}, [ user, setSelectedTab, dispatch, authenticate ] );
 
 	if ( connectedSites.length !== 0 ) return null;

--- a/src/components/publish-site-button.tsx
+++ b/src/components/publish-site-button.tsx
@@ -16,7 +16,7 @@ export const PublishSiteButton = () => {
 	const { __ } = useI18n();
 	const dispatch = useAppDispatch();
 	const { setSelectedTab } = useContentTabs();
-	const { user } = useAuth();
+	const { user, authenticate } = useAuth();
 	const { selectedSite } = useSiteDetails();
 	const { data: connectedSites = [] } = useGetConnectedSitesForLocalSiteQuery( {
 		localSiteId: selectedSite?.id,
@@ -27,8 +27,12 @@ export const PublishSiteButton = () => {
 
 	const handlePublishClick = useCallback( () => {
 		setSelectedTab( 'sync' );
-		dispatch( connectedSitesActions.openModal( 'push' ) );
-	}, [ setSelectedTab, dispatch ] );
+		if ( ! user ) {
+			authenticate();
+		} else {
+			dispatch( connectedSitesActions.openModal( 'push' ) );
+		}
+	}, [ user, setSelectedTab, dispatch, authenticate ] );
 
 	if ( connectedSites.length !== 0 ) return null;
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Closes STU-1062

## Proposed Changes

- When clicking the `Publish site` button, if the user is logged out, open the OAuth page to authenticate the user


|Studio | OAuth page opens|
|-------|------|
|<img width="2460" height="1506" alt="CleanShot 2025-12-04 at 10 02 31@2x" src="https://github.com/user-attachments/assets/acb4c8f3-1b11-43d3-81d2-267f16a28d47" />|<img width="2356" height="2828" alt="CleanShot 2025-12-04 at 10 02 28@2x" src="https://github.com/user-attachments/assets/c7f366cc-8a67-4058-b0d9-ba3077f5f07a" />|


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Apply this branch and run `npm start`
- Log out if you are logged in
- Click on `Publish site` button on the header
- Check that the OAuth page opens and you can log in

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
