### PR TITLE
Studio: Disable Add Site from the menu for no site empty screen

### DIFF
--- a/src/components/tests/main-sidebar.test.tsx
+++ b/src/components/tests/main-sidebar.test.tsx
@@ -54,6 +54,7 @@ jest.mock( 'src/lib/get-ipc-api', () => ( {
 		getUserEditor: jest.fn().mockResolvedValue( 'cursor' ),
 		getUserTerminal: jest.fn().mockResolvedValue( 'terminal' ),
 		setWindowControlVisibility: jest.fn(),
+		setupAppMenu: jest.fn(),
 	} ),
 } ) );
 

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -918,7 +918,7 @@ export function showNotification(
 
 export async function setupAppMenu(
 	_event: IpcMainInvokeEvent,
-	config: { needsOnboarding: boolean }
+	config: { needsOnboarding: boolean; isAddSiteVisible?: boolean }
 ) {
 	await setupMenu( config );
 }

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -29,7 +29,10 @@ import { promptWindowsSpeedUpSites } from 'src/lib/windows-helpers';
 import { getMainWindow } from 'src/main-window';
 import { isUpdateReadyToInstall, manualCheckForUpdates } from 'src/updates';
 
-export async function setupMenu( config: { needsOnboarding: boolean } ) {
+export async function setupMenu( config: {
+	needsOnboarding: boolean;
+	isAddSiteVisible?: boolean;
+} ) {
 	const mainWindow = await getMainWindow();
 	if ( ! mainWindow && process.platform !== 'darwin' ) {
 		Menu.setApplicationMenu( null );
@@ -83,7 +86,10 @@ async function buildBetaFeaturesMenu(): Promise< MenuItemConstructorOptions[] > 
 
 async function getAppMenu(
 	mainWindow: BrowserWindow | null,
-	{ needsOnboarding = false }: { needsOnboarding?: boolean } = {}
+	{
+		needsOnboarding = false,
+		isAddSiteVisible = false,
+	}: { needsOnboarding?: boolean; isAddSiteVisible?: boolean } = {}
 ) {
 	const crashTestMenuItems: MenuItemConstructorOptions[] = [
 		{
@@ -182,7 +188,7 @@ async function getAppMenu(
 					click: async () => {
 						void sendIpcEventToRenderer( 'add-site' );
 					},
-					enabled: ! needsOnboarding,
+					enabled: ! needsOnboarding && ! isAddSiteVisible,
 				},
 				...( process.platform === 'win32'
 					? []

--- a/src/modules/add-site/index.tsx
+++ b/src/modules/add-site/index.tsx
@@ -526,6 +526,10 @@ export default function AddSiteModal( { className }: AddSiteModalProps ) {
 		( site ) => site.isAddingSite || importState[ site.id ]?.isNewSite
 	);
 
+	useEffect( () => {
+		void getIpcApi().setupAppMenu( { needsOnboarding: false, isAddSiteVisible: showModal } );
+	}, [ showModal ] );
+
 	const openModal = useCallback( () => {
 		setShowModal( true );
 	}, [] );

--- a/src/modules/add-site/tests/add-site.test.tsx
+++ b/src/modules/add-site/tests/add-site.test.tsx
@@ -60,6 +60,7 @@ jest.mock( 'src/lib/get-ipc-api', () => ( {
 		generateProposedSitePath: mockGenerateProposedSitePath,
 		getAllCustomDomains: mockGetAllCustomDomains,
 		setWindowControlVisibility: jest.fn(),
+		setupAppMenu: jest.fn(),
 	} ),
 } ) );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

Fixes STU-1068

## Proposed Changes

This PR disabled the `Add site` menu item in the top bar when the user is on the `Add site` modal. Currently, the menu item is enabled but it does nothing so it does not seem to be needed to have it enabled:

<img width="1408" height="837" alt="Screenshot 2025-12-04 at 9 48 26 AM" src="https://github.com/user-attachments/assets/bc1b8e31-8137-4145-a657-eca953009021" />

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
* Start Studio with `npm start`
* Click on the `Add site` button in the sidebar to open the `Add site` modal
* In the topbar menu, click on `File` > `Add site`
* Confirm that `Add site` is disabled

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
