### PR TITLE
Studio: Pass custom domain to WP.com onboarding flow

### DIFF
--- a/common/constants.ts
+++ b/common/constants.ts
@@ -17,3 +17,6 @@ export const LOCKFILE_WAIT_TIME = 5000;
 export const PLAYGROUND_CLI_INACTIVITY_TIMEOUT = 2 * 60 * 1000; // 2 minutes of no output = timeout
 export const PLAYGROUND_CLI_MAX_TIMEOUT = 10 * 60 * 1000; // 10 minutes absolute maximum
 export const PLAYGROUND_CLI_ACTIVITY_CHECK_INTERVAL = 5 * 1000; // Check for inactivity every 5 seconds
+
+// Custom domains
+export const DEFAULT_CUSTOM_DOMAIN_SUFFIX = '.wp.local';

--- a/common/lib/domains.ts
+++ b/common/lib/domains.ts
@@ -1,5 +1,5 @@
 import { __ } from '@wordpress/i18n';
-import { DEFAULT_CUSTOM_DOMAIN_SUFFIX } from '../constants';
+import { DEFAULT_CUSTOM_DOMAIN_SUFFIX } from 'common/constants';
 import { sanitizeFolderName } from './sanitize-folder-name';
 
 const DOMAIN_PATTERN =

--- a/common/lib/domains.ts
+++ b/common/lib/domains.ts
@@ -1,4 +1,5 @@
 import { __ } from '@wordpress/i18n';
+import { DEFAULT_CUSTOM_DOMAIN_SUFFIX } from '../constants';
 import { sanitizeFolderName } from './sanitize-folder-name';
 
 const DOMAIN_PATTERN =
@@ -10,7 +11,7 @@ const DOMAIN_PATTERN =
 export const generateCustomDomainFromSiteName = ( siteName: string ): string => {
 	const domainBase = sanitizeFolderName( siteName );
 
-	return `${ domainBase }.wp.local`;
+	return `${ domainBase }${ DEFAULT_CUSTOM_DOMAIN_SUFFIX }`;
 };
 
 export const getDomainNameValidationError = (

--- a/src/modules/sync/components/create-button.tsx
+++ b/src/modules/sync/components/create-button.tsx
@@ -33,10 +33,13 @@ export const CreateButton = ( {
 			<Button
 				onClick={ () => {
 					onClick?.();
+					const suggestedName = selectedSite.customDomain
+						? selectedSite.customDomain.replace( /\.wp\.local$/, '' )
+						: selectedSite.name;
 					getIpcApi().openURL(
 						`https://wordpress.com/setup/new-hosted-site?ref=studio&section=studio-sync&showDomainStep&studioSiteId=${
 							selectedSite.id
-						}&new=${ encodeURIComponent( selectedSite.name ) }`
+						}&new=${ encodeURIComponent( suggestedName ) }`
 					);
 				} }
 				variant={ variant }

--- a/src/modules/sync/components/create-button.tsx
+++ b/src/modules/sync/components/create-button.tsx
@@ -6,6 +6,7 @@ import { Tooltip } from 'src/components/tooltip';
 import { useOffline } from 'src/hooks/use-offline';
 import { cx } from 'src/lib/cx';
 import { getIpcApi } from 'src/lib/get-ipc-api';
+import { DEFAULT_CUSTOM_DOMAIN_SUFFIX } from '../../../../common/constants';
 
 interface CreateButtonProps {
 	variant: ButtonVariant;
@@ -34,7 +35,7 @@ export const CreateButton = ( {
 				onClick={ () => {
 					onClick?.();
 					const suggestedName = selectedSite.customDomain
-						? selectedSite.customDomain.replace( /\.wp\.local$/, '' )
+						? selectedSite.customDomain.replace( DEFAULT_CUSTOM_DOMAIN_SUFFIX, '' )
 						: selectedSite.name;
 					getIpcApi().openURL(
 						`https://wordpress.com/setup/new-hosted-site?ref=studio&section=studio-sync&showDomainStep&studioSiteId=${

--- a/src/modules/sync/components/create-button.tsx
+++ b/src/modules/sync/components/create-button.tsx
@@ -1,4 +1,5 @@
 import { __ } from '@wordpress/i18n';
+import { DEFAULT_CUSTOM_DOMAIN_SUFFIX } from 'common/constants';
 import { ArrowIcon } from 'src/components/arrow-icon';
 import Button, { ButtonVariant } from 'src/components/button';
 import offlineIcon from 'src/components/offline-icon';
@@ -6,7 +7,6 @@ import { Tooltip } from 'src/components/tooltip';
 import { useOffline } from 'src/hooks/use-offline';
 import { cx } from 'src/lib/cx';
 import { getIpcApi } from 'src/lib/get-ipc-api';
-import { DEFAULT_CUSTOM_DOMAIN_SUFFIX } from '../../../../common/constants';
 
 interface CreateButtonProps {
 	variant: ButtonVariant;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

Fixes STU-1096

## Proposed Changes

This PR passes the custom domain to WP.com onboarding flow if the user uses the custom domain.

<img width="1408" height="343" alt="Screenshot 2025-12-04 at 10 49 41 AM" src="https://github.com/user-attachments/assets/44c5a236-8e06-4b85-a92b-82ca397f8eb1" />

If not, we pass the Studio site name:

<img width="1479" height="297" alt="Screenshot 2025-12-04 at 10 49 56 AM" src="https://github.com/user-attachments/assets/11bd405c-bd28-4715-ba82-b3179d2bf9ef" />

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
* Create a Studio site with a custom domain name
* Navigate to the `Sync` tab in Studio and open the Sync modal
* At the bottom of the modal, click on `Create a new WordPress.com site`
* Observe that when you are brought to WP.com, the domain name field on WP.com is populated with your Studio site custom domain
* Then, test this flow with a site that does not use a custom domain
* Observe that when you are brought to WP.com, the domain name field on WP.com is populated with your Studio site name

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
