### PR TITLE
Update Initializing backup label to mention remote

### DIFF
--- a/src/hooks/use-sync-states-progress-info.ts
+++ b/src/hooks/use-sync-states-progress-info.ts
@@ -62,7 +62,7 @@ export function useSyncStatesProgressInfo() {
 			'in-progress': {
 				key: 'in-progress',
 				progress: IN_PROGRESS_INITIAL_VALUE,
-				message: __( 'Initializing backup…' ),
+				message: __( 'Initializing remote backup…' ),
 			},
 			downloading: {
 				// On backend this key is called backup 'finished'


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-1098

## Proposed Changes

- Rename `Initializing backup...` to `Initializing remote backup` during pull process

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run `npm start`
- Go to the sync tab, connect a site and click on pull
- Observe the new label

<img width="1012" height="712" alt="Screenshot 2025-12-04 at 10 51 23" src="https://github.com/user-attachments/assets/2272c5ca-472d-41e9-8dae-6038d03dcf76" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
