### PR TITLE
Align skip button in Authentication onboarding

### DIFF
--- a/src/modules/onboarding/components/connect-to-wpcom.tsx
+++ b/src/modules/onboarding/components/connect-to-wpcom.tsx
@@ -84,10 +84,9 @@ export function OnboardingConnectToWpcom( { onSkip }: { onSkip: () => void } ) {
 				</Tooltip>
 			</div>
 
-			<div className="text-center">
-				<Button onClick={ onSkip }>
-					{ __( 'Skip' ) }
-					{ ' →' }
+			<div className="text-right">
+				<Button className="pl-0" onClick={ onSkip }>
+					{ __( 'Skip  →' ) }
 				</Button>
 			</div>
 		</div>

--- a/src/modules/onboarding/components/connect-to-wpcom.tsx
+++ b/src/modules/onboarding/components/connect-to-wpcom.tsx
@@ -85,7 +85,7 @@ export function OnboardingConnectToWpcom( { onSkip }: { onSkip: () => void } ) {
 			</div>
 
 			<div className="text-right">
-				<Button className="pl-0" onClick={ onSkip }>
+				<Button className="pr-0" onClick={ onSkip }>
 					{ __( 'Skip  →' ) }
 				</Button>
 			</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-1097

## Proposed Changes

- Align skip button in Authentication onboarding screen
- Unify the translation string to include the arrow

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Remove sites
- Log out
- Edit your `"onboardingCompleted": false,`
- Run `npm start`
- Confirm the skip button is correctly aligned

| Before | After |
|--------|--------|
|  <img width="1012" height="712" alt="Screenshot 2025-12-04 at 11 19 46" src="https://github.com/user-attachments/assets/c0ae2a27-852b-44ec-903c-109d737d94ed" /> | <img width="1012" height="712" alt="Screenshot 2025-12-04 at 11 15 11" src="https://github.com/user-attachments/assets/299cdb70-546a-4b1e-bbd8-b470d6ffc0be" /> |


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
