### PR TITLE
E2E: Skip 'creates a post' and 'uploads media' tests

### DIFF
--- a/e2e/site-navigation.test.ts
+++ b/e2e/site-navigation.test.ts
@@ -94,7 +94,7 @@ test.describe( 'Site Navigation', () => {
 		await expect( userMenu ).toBeVisible();
 	} );
 
-	test( 'creates a post', async ( { page } ) => {
+	test.skip( 'creates a post', async ( { page } ) => {
 		// Navigate to new post page
 		const newPostUrl = `${ wpAdminUrl }/post-new.php`;
 		await page.goto( getUrlWithAutoLogin( newPostUrl ) );
@@ -144,7 +144,7 @@ test.describe( 'Site Navigation', () => {
 		} );
 	} );
 
-	test( 'uploads media', async ( { page } ) => {
+	test.skip( 'uploads media', async ( { page } ) => {
 		// Navigate to media library
 		const addNewMediaUrl = `${ wpAdminUrl }/media-new.php`;
 		await page.goto( getUrlWithAutoLogin( addNewMediaUrl ) );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

Related thread p1764590332678119-slack-C06DRMD6VPZ

## Proposed Changes

- Skip 'creates a post' and 'uploads media' tests to stabilize builds
- These are running flaky on CI, I'll work on a fix for these in a follow-up

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- CI should pass
- Visual review

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?