### PR TITLE
Revert non-production ready CLI commands before 1.6.6 release

### DIFF
--- a/cli/commands/site/list.ts
+++ b/cli/commands/site/list.ts
@@ -1,93 +1,77 @@
 import { __, _n, sprintf } from '@wordpress/i18n';
 import Table from 'cli-table3';
-import { SiteCommandLoggerAction as LoggerAction } from 'common/logger-actions';
-import { getSiteUrl, readAppdata, type SiteData } from 'cli/lib/appdata';
-import { connect, disconnect } from 'cli/lib/pm2-manager';
-import { getColumnWidths, getPrettyPath } from 'cli/lib/utils';
-import { isServerRunning } from 'cli/lib/wordpress-server-manager';
+import { PreviewCommandLoggerAction as LoggerAction } from 'common/logger-actions';
+import { readAppdata, type SiteData } from 'cli/lib/appdata';
 import { Logger, LoggerError } from 'cli/logger';
 import { StudioArgv } from 'cli/types';
 
-interface SiteListEntry {
-	status: string;
+interface SiteTable {
+	id: string;
 	name: string;
 	path: string;
-	url: string;
+	phpVersion: string;
 }
 
-async function getSiteListData( sites: SiteData[] ) {
-	const result: SiteListEntry[] = [];
+function getSitesCliTable( sites: SiteData[] ) {
+	const table = new Table( {
+		head: [ __( 'Name' ), __( 'Path' ), __( 'ID' ), __( 'PHP' ) ],
+		style: {
+			head: [ 'cyan' ],
+			border: [ 'grey' ],
+		},
+		wordWrap: true,
+		wrapOnWordBoundary: false,
+	} );
 
-	for await ( const site of sites ) {
-		const isOnline = await isServerRunning( site.id );
-		const status = isOnline ? `🟢 ${ __( 'Online' ) }` : `🔴 ${ __( 'Offline' ) }`;
-		const url = getSiteUrl( site );
+	sites.forEach( ( site ) => {
+		table.push( [ site.name, site.path, site.id, site.phpVersion ] );
+	} );
 
-		result.push( {
-			status,
-			name: site.name,
-			path: getPrettyPath( site.path ),
-			url,
-		} );
-	}
-
-	return result;
+	return table;
 }
 
-const logger = new Logger< LoggerAction >();
+function getSitesCliJson( sites: SiteData[] ): SiteTable[] {
+	return sites.map( ( site ) => ( {
+		id: site.id,
+		name: site.name,
+		path: site.path,
+		phpVersion: site.phpVersion,
+	} ) );
+}
 
 export async function runCommand( format: 'table' | 'json' ): Promise< void > {
-	try {
-		logger.reportStart( LoggerAction.LOAD_SITES, __( 'Loading sites…' ) );
-		const appdata = await readAppdata();
+	const logger = new Logger< LoggerAction >();
 
-		if ( appdata.sites.length === 0 ) {
+	try {
+		logger.reportStart( LoggerAction.LOAD, __( 'Loading sites…' ) );
+		const appdata = await readAppdata();
+		const allSites = appdata.sites;
+
+		if ( allSites.length === 0 ) {
 			logger.reportSuccess( __( 'No sites found' ) );
 			return;
 		}
 
 		const sitesMessage = sprintf(
-			_n( 'Found %d site', 'Found %d sites', appdata.sites.length ),
-			appdata.sites.length
+			_n( 'Found %d site', 'Found %d sites', allSites.length ),
+			allSites.length
 		);
 
 		logger.reportSuccess( sitesMessage );
 
-		logger.reportStart( LoggerAction.START_DAEMON, __( 'Connecting to process daemon...' ) );
-		await connect();
-		logger.reportSuccess( __( 'Connected to process daemon' ) );
-
-		const sitesData = await getSiteListData( appdata.sites );
-
 		if ( format === 'table' ) {
-			const colWidths = getColumnWidths( [ 0.1, 0.2, 0.3, 0.4 ] );
-
-			const table = new Table( {
-				head: [ __( 'Status' ), __( 'Name' ), __( 'Path' ), __( 'URL' ) ],
-				wordWrap: true,
-				wrapOnWordBoundary: false,
-				colWidths,
-				style: {
-					head: [],
-					border: [],
-				},
-			} );
-
-			table.push(
-				...sitesData.map( ( site ) => [
-					site.status,
-					site.name,
-					site.path,
-					{ href: new URL( site.url ).toString(), content: site.url },
-				] )
-			);
-
+			const table = getSitesCliTable( allSites );
 			console.log( table.toString() );
 		} else {
-			console.log( JSON.stringify( sitesData, null, 2 ) );
+			console.log( JSON.stringify( getSitesCliJson( allSites ), null, 2 ) );
 		}
-	} finally {
-		disconnect();
+	} catch ( error ) {
+		if ( error instanceof LoggerError ) {
+			logger.reportError( error );
+		} else {
+			const loggerError = new LoggerError( __( 'Failed to load sites' ), error );
+			logger.reportError( loggerError );
+		}
 	}
 }
 
@@ -104,16 +88,7 @@ export const registerCommand = ( yargs: StudioArgv ) => {
 			} );
 		},
 		handler: async ( argv ) => {
-			try {
-				await runCommand( argv.format as 'table' | 'json' );
-			} catch ( error ) {
-				if ( error instanceof LoggerError ) {
-					logger.reportError( error );
-				} else {
-					const loggerError = new LoggerError( __( 'Failed to load site' ), error );
-					logger.reportError( loggerError );
-				}
-			}
+			await runCommand( argv.format as 'table' | 'json' );
 		},
 	} );
 };

--- a/cli/commands/site/tests/list.test.ts
+++ b/cli/commands/site/tests/list.test.ts
@@ -1,131 +1,112 @@
 import { readAppdata } from 'cli/lib/appdata';
-import { connect, disconnect } from 'cli/lib/pm2-manager';
-import { isServerRunning } from 'cli/lib/wordpress-server-manager';
+import { Logger } from 'cli/logger';
 
 jest.mock( 'cli/lib/appdata', () => ( {
 	...jest.requireActual( 'cli/lib/appdata' ),
-	readAppdata: jest.fn(),
 	getAppdataDirectory: jest.fn().mockReturnValue( '/test/appdata' ),
+	readAppdata: jest.fn(),
 } ) );
-jest.mock( 'cli/lib/pm2-manager' );
-jest.mock( 'cli/lib/wordpress-server-manager' );
+jest.mock( 'cli/logger' );
 
-describe( 'CLI: studio site list', () => {
-	// Simple test data
-	const testAppdata = {
+describe( 'Sites List Command', () => {
+	const mockAppdata = {
 		sites: [
 			{
 				id: 'site-1',
 				name: 'Test Site 1',
 				path: '/path/to/site1',
-				port: 8080,
 			},
 			{
 				id: 'site-2',
 				name: 'Test Site 2',
 				path: '/path/to/site2',
-				port: 8081,
-				customDomain: 'my-site.wp.local',
 			},
 		],
 		snapshots: [],
 	};
 
-	const emptyAppdata = {
-		sites: [],
-		snapshots: [],
+	let mockLogger: {
+		reportStart: jest.Mock;
+		reportSuccess: jest.Mock;
+		reportError: jest.Mock;
 	};
 
 	beforeEach( () => {
 		jest.clearAllMocks();
 
-		( readAppdata as jest.Mock ).mockResolvedValue( testAppdata );
-		( connect as jest.Mock ).mockResolvedValue( undefined );
-		( disconnect as jest.Mock ).mockResolvedValue( undefined );
-		( isServerRunning as jest.Mock ).mockResolvedValue( false );
+		mockLogger = {
+			reportStart: jest.fn(),
+			reportSuccess: jest.fn(),
+			reportError: jest.fn(),
+		};
+
+		( Logger as jest.Mock ).mockReturnValue( mockLogger );
+		( readAppdata as jest.Mock ).mockResolvedValue( mockAppdata );
 	} );
 
 	afterEach( () => {
 		jest.restoreAllMocks();
 	} );
 
-	describe( 'Error Cases', () => {
-		it( 'should throw when appdata read fails', async () => {
-			( readAppdata as jest.Mock ).mockRejectedValue( new Error( 'Failed to read appdata' ) );
+	it( 'should list sites successfully', async () => {
+		const { runCommand } = await import( '../list' );
+		await runCommand( 'table' );
 
-			const { runCommand } = await import( '../list' );
-
-			await expect( runCommand( 'table' ) ).rejects.toThrow( 'Failed to read appdata' );
-			expect( disconnect ).toHaveBeenCalled();
-		} );
+		expect( readAppdata ).toHaveBeenCalled();
+		expect( mockLogger.reportStart ).toHaveBeenCalledWith( 'load', 'Loading sites…' );
+		expect( mockLogger.reportSuccess ).toHaveBeenCalledWith( 'Found 2 sites' );
 	} );
 
-	describe( 'Success Cases', () => {
-		it( 'should list sites with table format', async () => {
-			const consoleSpy = jest.spyOn( console, 'log' ).mockImplementation();
-			const { runCommand } = await import( '../list' );
-
-			await runCommand( 'table' );
-
-			expect( readAppdata ).toHaveBeenCalled();
-			expect( consoleSpy ).toHaveBeenCalled();
-			expect( disconnect ).toHaveBeenCalled();
-
-			consoleSpy.mockRestore();
+	it( 'should handle no sites found', async () => {
+		const { runCommand } = await import( '../list' );
+		( readAppdata as jest.Mock ).mockResolvedValue( {
+			sites: [],
+			newSites: [],
+			snapshots: [],
 		} );
 
-		it( 'should list sites with json format', async () => {
-			const consoleSpy = jest.spyOn( console, 'log' ).mockImplementation();
-			const { runCommand } = await import( '../list' );
+		await runCommand( 'table' );
 
-			await runCommand( 'json' );
+		expect( mockLogger.reportStart ).toHaveBeenCalledWith( 'load', 'Loading sites…' );
+		expect( mockLogger.reportSuccess ).toHaveBeenCalledWith( 'No sites found' );
+	} );
 
-			expect( consoleSpy ).toHaveBeenCalledWith(
-				JSON.stringify(
-					[
-						{
-							status: '🔴 Offline',
-							name: 'Test Site 1',
-							path: '/path/to/site1',
-							url: 'http://localhost:8080',
-						},
-						{
-							status: '🔴 Offline',
-							name: 'Test Site 2',
-							path: '/path/to/site2',
-							url: 'http://my-site.wp.local',
-						},
-					],
-					null,
-					2
-				)
-			);
-			expect( disconnect ).toHaveBeenCalled();
+	it( 'should handle appdata read errors', async () => {
+		const { runCommand } = await import( '../list' );
+		( readAppdata as jest.Mock ).mockRejectedValue( new Error( 'Failed to read appdata' ) );
 
-			consoleSpy.mockRestore();
-		} );
+		await runCommand( 'table' );
 
-		it( 'should handle no sites found', async () => {
-			( readAppdata as jest.Mock ).mockResolvedValue( emptyAppdata );
+		expect( mockLogger.reportError ).toHaveBeenCalled();
+	} );
 
-			const { runCommand } = await import( '../list' );
+	it( 'should work with json format', async () => {
+		const consoleSpy = jest.spyOn( console, 'log' ).mockImplementation();
+		const { runCommand } = await import( '../list' );
+		await runCommand( 'json' );
 
-			await runCommand( 'table' );
+		expect( mockLogger.reportSuccess ).toHaveBeenCalledWith( 'Found 2 sites' );
+		expect( consoleSpy ).toHaveBeenCalledWith(
+			JSON.stringify(
+				[
+					{
+						id: 'site-1',
+						name: 'Test Site 1',
+						path: '/path/to/site1',
+						phpVersion: undefined,
+					},
+					{
+						id: 'site-2',
+						name: 'Test Site 2',
+						path: '/path/to/site2',
+						phpVersion: undefined,
+					},
+				],
+				null,
+				2
+			)
+		);
 
-			expect( readAppdata ).toHaveBeenCalled();
-			expect( disconnect ).toHaveBeenCalled();
-		} );
-
-		it( 'should handle custom domain in site URL', async () => {
-			const consoleSpy = jest.spyOn( console, 'log' ).mockImplementation();
-			const { runCommand } = await import( '../list' );
-
-			await runCommand( 'json' );
-
-			expect( consoleSpy ).toHaveBeenCalledWith( expect.stringContaining( 'my-site.wp.local' ) );
-			expect( disconnect ).toHaveBeenCalled();
-
-			consoleSpy.mockRestore();
-		} );
+		consoleSpy.mockRestore();
 	} );
 } );

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -84,15 +84,7 @@ async function main() {
 
 	if ( isSitesCliEnabled ) {
 		studioArgv.command( 'site', __( 'Manage local sites (Beta)' ), ( sitesYargs ) => {
-			registerSiteStatusCommand( sitesYargs );
-			registerSiteCreateCommand( sitesYargs );
 			registerSiteListCommand( sitesYargs );
-			registerSiteStartCommand( sitesYargs );
-			registerSiteStopCommand( sitesYargs );
-			registerSiteDeleteCommand( sitesYargs );
-			registerSiteSetHttpsCommand( sitesYargs );
-			registerSiteSetDomainCommand( sitesYargs );
-			registerSiteSetPhpVersionCommand( sitesYargs );
 			sitesYargs.demandCommand( 1, __( 'You must provide a valid command' ) );
 		} );
 	}

--- a/vite.cli.config.ts
+++ b/vite.cli.config.ts
@@ -4,7 +4,6 @@ import { viteStaticCopy } from 'vite-plugin-static-copy';
 import { existsSync } from 'fs';
 
 const yargsLocalesPath = resolve( __dirname, 'node_modules/yargs/locales' );
-const cliNodeModulesPath = resolve( __dirname, 'cli/node_modules' );
 
 export default defineConfig( {
 	plugins: [
@@ -20,25 +19,11 @@ export default defineConfig( {
 					} ),
 			  ]
 			: [] ),
-		...( existsSync( cliNodeModulesPath )
-			? [
-					viteStaticCopy( {
-						targets: [
-							{
-								src: 'cli/node_modules',
-								dest: '.',
-							},
-						],
-					} ),
-			  ]
-			: [] ),
 	],
 	build: {
 		lib: {
 			entry: {
 				main: resolve( __dirname, 'cli/index.ts' ),
-				'proxy-daemon': resolve( __dirname, 'cli/proxy-daemon.ts' ),
-				'wordpress-server-child': resolve( __dirname, 'cli/wordpress-server-child.ts' ),
 			},
 			name: 'StudioCLI',
 			formats: [ 'cjs' ],


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Related to p1764579169272899/1764578924.299819-slack-C06DRMD6VPZ
- Release post pfHvTO-Or-p2

## Proposed Changes

- Revert the CLI commands that aren't yet ready for production before we cut the 1.6.6 release

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Run `npm run cli:build`
2. Run `node dist/cli/main.js site`
3. Ensure that only the `site list` command is available
4. Run `node dist/cli/main.js site list`
5. Ensure that the output is the same as it was before #2127

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?