### PR TITLE
Remove quick blink when starting Studio onboarding

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -19,11 +19,14 @@ import { Onboarding } from 'src/modules/onboarding';
 import { useOnboarding } from 'src/modules/onboarding/hooks/use-onboarding';
 import { UserSettings } from 'src/modules/user-settings';
 import { WhatsNewModal, useWhatsNew } from 'src/modules/whats-new';
+import { useRootSelector } from 'src/stores';
+import { selectOnboardingLoading } from 'src/stores/onboarding-slice';
 import 'src/index.css';
 
 export default function App() {
 	useLocalizationSupport();
 	const { needsOnboarding } = useOnboarding();
+	const isOnboardingLoading = useRootSelector( selectOnboardingLoading );
 	const { isSidebarVisible, toggleSidebar } = useSidebarVisibility();
 	const { showWhatsNew, closeWhatsNew } = useWhatsNew();
 	const { sites: localSites, loadingSites } = useSiteDetails();
@@ -32,6 +35,10 @@ export default function App() {
 	useEffect( () => {
 		void getIpcApi().setupAppMenu( { needsOnboarding } );
 	}, [ needsOnboarding ] );
+
+	if ( isOnboardingLoading ) {
+		return null;
+	}
 
 	return (
 		<>

--- a/src/components/tests/app.test.tsx
+++ b/src/components/tests/app.test.tsx
@@ -10,6 +10,7 @@ import { rootReducer } from 'src/stores';
 import { appVersionApi } from 'src/stores/app-version-api';
 import { certificateTrustApi } from 'src/stores/certificate-trust-api';
 import { installedAppsApi } from 'src/stores/installed-apps-api';
+import { selectOnboardingLoading } from 'src/stores/onboarding-slice';
 import { setProviderConstants } from 'src/stores/provider-constants-slice';
 import { connectedSitesApi } from 'src/stores/sync/connected-sites';
 import { wpcomSitesApi } from 'src/stores/sync/wpcom-sites';
@@ -17,6 +18,9 @@ import { wordpressVersionsApi } from 'src/stores/wordpress-versions-api';
 import { wpcomApi, wpcomPublicApi } from 'src/stores/wpcom-api';
 
 jest.mock( 'src/index.css', () => ( {} ) );
+jest.mock( 'src/stores/onboarding-slice', () => ( {
+	selectOnboardingLoading: jest.fn().mockReturnValue( false ),
+} ) );
 jest.mock( 'src/modules/onboarding/hooks/use-onboarding' );
 jest.mock( 'src/hooks/use-site-details' );
 jest.mock( 'src/modules/whats-new/hooks/use-whats-new', () => ( {

--- a/src/components/tests/app.test.tsx
+++ b/src/components/tests/app.test.tsx
@@ -10,7 +10,6 @@ import { rootReducer } from 'src/stores';
 import { appVersionApi } from 'src/stores/app-version-api';
 import { certificateTrustApi } from 'src/stores/certificate-trust-api';
 import { installedAppsApi } from 'src/stores/installed-apps-api';
-import { selectOnboardingLoading } from 'src/stores/onboarding-slice';
 import { setProviderConstants } from 'src/stores/provider-constants-slice';
 import { connectedSitesApi } from 'src/stores/sync/connected-sites';
 import { wpcomSitesApi } from 'src/stores/sync/wpcom-sites';

--- a/src/stores/onboarding-slice.ts
+++ b/src/stores/onboarding-slice.ts
@@ -9,7 +9,7 @@ interface OnboardingState {
 
 const initialState: OnboardingState = {
 	completed: false,
-	loading: false,
+	loading: true,
 };
 
 // Async thunk to load onboarding status

--- a/src/stores/tests/onboarding-slice.test.ts
+++ b/src/stores/tests/onboarding-slice.test.ts
@@ -37,7 +37,7 @@ describe( 'onboarding-slice', () => {
 		it( 'should have correct initial state', () => {
 			const state = store.getState();
 			expect( selectOnboardingCompleted( state ) ).toBe( false );
-			expect( selectOnboardingLoading( state ) ).toBe( false );
+			expect( selectOnboardingLoading( state ) ).toBe( true );
 		} );
 	} );
 
@@ -174,9 +174,9 @@ describe( 'onboarding-slice', () => {
 		} );
 
 		it( 'should select onboarding loading state correctly', () => {
-			// Initial state should be false
+			// Initial state should be true
 			let state = store.getState();
-			expect( selectOnboardingLoading( state ) ).toBe( false );
+			expect( selectOnboardingLoading( state ) ).toBe( true );
 
 			// Mock the API to trigger loading state
 			mockIpcApi.getOnboardingData.mockResolvedValue( true );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-1091

## Proposed Changes

- Avoid showing the zero sites layout when loading the onboarding.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Remove your sites, log out, and set `onboardingCompleted: false` in your Studio config file.
- Run `npm start` or `npm run make`
- Observe that a empty dark screen while loading until it loads the onboarding.
- Press cmd+r multiple times
- Confirm the Sites layout with left main sidebar doesn't appear.


https://github.com/user-attachments/assets/d7d43f75-f619-419e-a044-902a70cf754c



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
