### PR TITLE
Studio: Avoid showing import progress when pulling a site

### DIFF
--- a/src/components/content-tab-import-export.tsx
+++ b/src/components/content-tab-import-export.tsx
@@ -229,8 +229,8 @@ const ImportSite = ( {
 	const startLoadingCursorClassName =
 		loadingServer[ selectedSite.id ] && 'animate-pulse duration-100 cursor-wait';
 
-	const isImporting = currentProgress?.progress < 100;
-	const isImported = currentProgress?.progress === 100 && ! isDraggingOver;
+	const isImporting = currentProgress?.progress < 100 && ! isThisSiteSyncing;
+	const isImported = currentProgress?.progress === 100 && ! isDraggingOver && ! isThisSiteSyncing;
 	const isInitial = ! isImporting && ! isImported;
 	return (
 		<div className={ cx( 'flex flex-col w-full', startLoadingCursorClassName ) }>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

Fixes STU-1100

## Proposed Changes

This PR ensures that during the `Pull` progress, we are not showing the progress in the `Import/Export` tab and that the UI in the `Import/Export` tab remains disabled at all times.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
* Start the app with `npm start`
* Connect a WP.com site from the `Sync` tab
* Once connected, click on the `Pull` button and start the pull process 
* Wait for the backup to initialize and then when you see the percentage progress on the `Sync` tab, switch to the `Import/Export` tab and confirm that the progress is not visible there

https://github.com/user-attachments/assets/ad4a49c4-cb8d-4851-b3b7-246d35c65bb5


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
