### PR TITLE
Update `studio auth status` response

### DIFF
--- a/cli/commands/auth/status.ts
+++ b/cli/commands/auth/status.ts
@@ -21,7 +21,7 @@ export async function runCommand(): Promise< void > {
 	try {
 		const userData = await getUserInfo( token.accessToken );
 		logger.reportSuccess(
-			sprintf( __( 'Successfully authenticated with WordPress.com as `%s`' ), userData.username )
+			sprintf( __( 'Authenticated with WordPress.com as `%s`' ), userData.username )
 		);
 	} catch ( error ) {
 		if ( error instanceof LoggerError ) {

--- a/cli/commands/auth/tests/status.test.ts
+++ b/cli/commands/auth/tests/status.test.ts
@@ -51,7 +51,7 @@ describe( 'Auth Status Command', () => {
 		expect( getAuthToken ).toHaveBeenCalled();
 		expect( getUserInfo ).toHaveBeenCalledWith( mockToken.accessToken );
 		expect( mockLogger.reportSuccess ).toHaveBeenCalledWith(
-			expect.stringContaining( 'Successfully authenticated with WordPress.com as `testuser`' )
+			expect.stringContaining( 'Authenticated with WordPress.com as `testuser`' )
 		);
 	} );
 

--- a/docs/ai-instructions.md
+++ b/docs/ai-instructions.md
@@ -132,7 +132,7 @@ This command checks if you are currently authenticated with WordPress.com by:
 ```bash
 npm run cli:build
 node dist/cli/main.js auth status
-# Output when authenticated: ✓ Successfully authenticated with WordPress.com as `username`
+# Output when authenticated: ✓ Authenticated with WordPress.com as `username`
 # Output when not authenticated: ✗ Authentication token is invalid or expired
 ```
 


### PR DESCRIPTION
## Proposed Changes

When I run `studio auth status` and receive `Successfully authenticated...` I had the impression that I ran the `login` command and was a bit confused. I [asked ChatGPT about his opinion](https://chatgpt.com/share/693199c7-26f4-8004-bb85-78f0de8a5a8b), w/o providing my confusion description, and it said exactly that improvement, so `Authenticated with WordPress.com as `username ' looks like reasonable.

## Testing Instructions
PR review should suffice