### PR TITLE
Display the plans modal in the pull an existing site creation flow

### DIFF
--- a/src/modules/add-site/components/pull-remote-site.tsx
+++ b/src/modules/add-site/components/pull-remote-site.tsx
@@ -4,7 +4,7 @@ import {
 } from '@wordpress/components';
 import { check, Icon } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
-import { PropsWithChildren } from 'react';
+import { PropsWithChildren, useState } from 'react';
 import { ArrowIcon } from 'src/components/arrow-icon';
 import Button from 'src/components/button';
 import offlineIcon from 'src/components/offline-icon';
@@ -13,6 +13,7 @@ import { useAuth } from 'src/hooks/use-auth';
 import { useOffline } from 'src/hooks/use-offline';
 import { useSiteDetails } from 'src/hooks/use-site-details';
 import { getIpcApi } from 'src/lib/get-ipc-api';
+import { NoWpcomSitesModal } from 'src/modules/sync/components/no-wpcom-sites-modal';
 import { SitesListContent } from 'src/modules/sync/components/sync-sites-modal-selector';
 import { SyncTabImage } from 'src/modules/sync/components/sync-tab-image';
 import { useGetConnectedSitesForLocalSiteQuery } from 'src/stores/sync/connected-sites';
@@ -120,6 +121,7 @@ export function PullRemoteSite( {
 } ) {
 	const { __ } = useI18n();
 	const { isAuthenticated, user } = useAuth();
+	const [ isNoWpcomSitesModalClosed, setIsNoWpcomSitesModalClosed ] = useState( false );
 
 	const { selectedSite } = useSiteDetails();
 	const { data: connectedSites = [] } = useGetConnectedSitesForLocalSiteQuery( {
@@ -127,7 +129,11 @@ export function PullRemoteSite( {
 		userId: user?.id,
 	} );
 	const connectedSiteIds = connectedSites.map( ( { id } ) => id );
-	const { data: syncSites = [], isLoading } = useGetWpComSitesQuery(
+	const {
+		data: syncSites = [],
+		isLoading,
+		isSuccess,
+	} = useGetWpComSitesQuery(
 		{
 			connectedSiteIds,
 			userId: user?.id,
@@ -153,6 +159,13 @@ export function PullRemoteSite( {
 						selectedSiteId={ selectedRemoteSite?.id || null }
 						onSelectSite={ handleSiteSelect }
 					/>
+
+					{ syncSites.length === 0 && isSuccess && ! isLoading && ! isNoWpcomSitesModalClosed && (
+						<NoWpcomSitesModal
+							onRequestClose={ () => setIsNoWpcomSitesModalClosed( true ) }
+							selectedSite={ undefined }
+						/>
+					) }
 				</VStack>
 			) : (
 				<NoAuthPullRemoteSiteView />

--- a/src/modules/sync/components/create-button.tsx
+++ b/src/modules/sync/components/create-button.tsx
@@ -10,7 +10,7 @@ import { getIpcApi } from 'src/lib/get-ipc-api';
 
 interface CreateButtonProps {
 	variant: ButtonVariant;
-	selectedSite: SiteDetails;
+	selectedSite?: SiteDetails;
 	text?: string;
 	className?: string;
 	onClick?: () => void;
@@ -24,6 +24,25 @@ export const CreateButton = ( {
 	onClick,
 }: CreateButtonProps ) => {
 	const isOffline = useOffline();
+	function generateCheckoutUrl( selectedSite?: SiteDetails ): string {
+		const url = new URL(
+			'https://wordpress.com/setup/new-hosted-site?ref=studio&section=studio-sync&showDomainStep'
+		);
+
+		if ( ! selectedSite ) {
+			return url.toString();
+		}
+
+		const suggestedName = selectedSite.customDomain
+			? selectedSite.customDomain.replace( DEFAULT_CUSTOM_DOMAIN_SUFFIX, '' )
+			: selectedSite.name;
+
+		url.searchParams.set( 'studioSiteId', String( selectedSite.id ) );
+		url.searchParams.set( 'new', suggestedName );
+
+		return url.toString();
+	}
+
 	return (
 		<Tooltip
 			disabled={ ! isOffline }
@@ -34,14 +53,8 @@ export const CreateButton = ( {
 			<Button
 				onClick={ () => {
 					onClick?.();
-					const suggestedName = selectedSite.customDomain
-						? selectedSite.customDomain.replace( DEFAULT_CUSTOM_DOMAIN_SUFFIX, '' )
-						: selectedSite.name;
-					getIpcApi().openURL(
-						`https://wordpress.com/setup/new-hosted-site?ref=studio&section=studio-sync&showDomainStep&studioSiteId=${
-							selectedSite.id
-						}&new=${ encodeURIComponent( suggestedName ) }`
-					);
+
+					getIpcApi().openURL( generateCheckoutUrl( selectedSite ) );
 				} }
 				variant={ variant }
 				className={ cx( ! isOffline && className ) }

--- a/src/modules/sync/components/no-wpcom-sites-modal.tsx
+++ b/src/modules/sync/components/no-wpcom-sites-modal.tsx
@@ -6,7 +6,7 @@ import { CreateButton } from 'src/modules/sync/components/create-button';
 
 interface NoWpcomSitesModalProps {
 	onRequestClose: () => void;
-	selectedSite: SiteDetails;
+	selectedSite?: SiteDetails;
 }
 
 export function NoWpcomSitesModal( { onRequestClose, selectedSite }: NoWpcomSitesModalProps ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-1085

## Proposed Changes

- Display NoWpcomSitesModal for new users without any site.
- Updated the purchase button to don't add `studioSiteId` when running the pull an existing site creation flow.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Logout
- Run `npm start`
- Click Add site > Pull an existing site
- Login or create a new account without any sites
- Observe that the modal appears
- Close the modal
- Go back
- Repeat
- Confirm that the modal appears again
- Remove all sites to display the empty state
- Confirm that the same behaviour occurs




https://github.com/user-attachments/assets/46e70b27-8cb3-461e-af14-9e423321c63d


https://github.com/user-attachments/assets/8129ac83-0586-4341-841a-257a6c23fa7d



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
