### PR TITLE
Studio: Sync size calculator ignores database when all files are selected

### DIFF
--- a/src/modules/sync/hooks/use-selected-items-push-size.ts
+++ b/src/modules/sync/hooks/use-selected-items-push-size.ts
@@ -30,6 +30,14 @@ export function useSelectedItemsPushSize(
 		setIsLoading( true );
 
 		try {
+			const isEverythingSelected = treeState.every( ( node ) => node.checked );
+			if ( isEverythingSelected ) {
+				const size = await getIpcApi().getDirectorySize( siteId, [ 'wp-content' ] );
+				setTotalSize( size );
+				setIsPushSelectionOverLimit( size > SYNC_PUSH_SIZE_LIMIT_BYTES );
+				return;
+			}
+
 			const sizePromises: Promise< number >[] = [];
 
 			const databaseNode = treeState.find( ( node ) => node.id === 'sqls' );

--- a/src/modules/sync/hooks/use-selected-items-push-size.ts
+++ b/src/modules/sync/hooks/use-selected-items-push-size.ts
@@ -31,6 +31,7 @@ export function useSelectedItemsPushSize(
 
 		try {
 			const isEverythingSelected = treeState.every( ( node ) => node.checked );
+
 			if ( isEverythingSelected ) {
 				const size = await getIpcApi().getDirectorySize( siteId, [ 'wp-content' ] );
 				setTotalSize( size );
@@ -49,6 +50,7 @@ export function useSelectedItemsPushSize(
 			const wpContentNode = filesAndFoldersNode?.children?.find(
 				( node ) => node.id === 'wp-content'
 			);
+
 			const processNodeRecursively = ( node: TreeNode, pathPrefix: string[] ): void => {
 				// Always skip the database folder - it's handled separately via the sqls node
 				if ( node.name === 'database' ) {

--- a/src/modules/sync/hooks/use-selected-items-push-size.ts
+++ b/src/modules/sync/hooks/use-selected-items-push-size.ts
@@ -30,15 +30,6 @@ export function useSelectedItemsPushSize(
 		setIsLoading( true );
 
 		try {
-			const isEverythingSelected = treeState.every( ( node ) => node.checked );
-
-			if ( isEverythingSelected ) {
-				const size = await getIpcApi().getDirectorySize( siteId, [ 'wp-content' ] );
-				setTotalSize( size );
-				setIsPushSelectionOverLimit( size > SYNC_PUSH_SIZE_LIMIT_BYTES );
-				return;
-			}
-
 			const sizePromises: Promise< number >[] = [];
 
 			const databaseNode = treeState.find( ( node ) => node.id === 'sqls' );
@@ -52,20 +43,25 @@ export function useSelectedItemsPushSize(
 			);
 
 			const processNodeRecursively = ( node: TreeNode, pathPrefix: string[] ): void => {
+				// Always skip the database folder - it's handled separately via the sqls node
+				if ( node.name === 'database' ) {
+					return;
+				}
+
 				if ( node.checked ) {
-					// If the node is fully checked, get its entire size
 					if ( node.type === 'file' ) {
 						sizePromises.push( getIpcApi().getFileSize( siteId, [ ...pathPrefix, node.name ] ) );
-					} else {
-						if ( node.name === 'mu-plugins' && node.children ) {
+					} else if ( node.name === 'wp-content' || node.name === 'mu-plugins' ) {
+						// For wp-content and mu-plugins, always process children to properly skip database
+						if ( node.children ) {
 							for ( const child of node.children ) {
 								processNodeRecursively( child, [ ...pathPrefix, node.name ] );
 							}
-						} else {
-							sizePromises.push(
-								getIpcApi().getDirectorySize( siteId, [ ...pathPrefix, node.name ] )
-							);
 						}
+					} else {
+						sizePromises.push(
+							getIpcApi().getDirectorySize( siteId, [ ...pathPrefix, node.name ] )
+						);
 					}
 				} else if ( node.indeterminate && node.children ) {
 					// If the node is indeterminate, process its children recursively

--- a/src/modules/sync/hooks/use-selected-items-push-size.ts
+++ b/src/modules/sync/hooks/use-selected-items-push-size.ts
@@ -49,7 +49,6 @@ export function useSelectedItemsPushSize(
 			const wpContentNode = filesAndFoldersNode?.children?.find(
 				( node ) => node.id === 'wp-content'
 			);
-
 			const processNodeRecursively = ( node: TreeNode, pathPrefix: string[] ): void => {
 				// Always skip the database folder - it's handled separately via the sqls node
 				if ( node.name === 'database' ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

Fixes STU-1104

## Proposed Changes

This PR ensure that the database size selection is always correctly displayed in the sync modal. 


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
* Navigate to the `Sync` tab
* Connect a site from the `Sync` modal
* Click on the `Push` button
* Select all the files and the database
* Observe the number in the progress bar
* Deselect database
* Confirm that the number goes down
* Try selecting only specific files and database
* Test and confirm that the number goes down when you deselect database and goes up when you select it again

<img width="1384" height="803" alt="Screenshot 2025-12-05 at 11 48 41 AM" src="https://github.com/user-attachments/assets/1d8929a1-d3bc-4d5e-ac49-05bc59e7f63c" />

<img width="820" height="580" alt="Screenshot 2025-12-05 at 11 49 37 AM" src="https://github.com/user-attachments/assets/a87cd374-0a02-4f9f-9003-9e68b83cd4fe" />

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
