### PR TITLE
Add Site modal: make sure deeplink hook is always mounted

### DIFF
--- a/src/components/no-studio-sites/index.tsx
+++ b/src/components/no-studio-sites/index.tsx
@@ -1,10 +1,10 @@
-import { AddSiteModalContent } from 'src/modules/add-site';
+import { AddSiteContentWithDeeplinkSupport } from 'src/modules/add-site';
 
 export function NoStudioSites() {
 	return (
 		<main className="bg-white h-full flex items-center justify-center overflow-hidden z-10">
 			<div className="h-full w-full pt-14 pb-4 max-w-[786px]">
-				<AddSiteModalContent />
+				<AddSiteContentWithDeeplinkSupport />
 			</div>
 		</main>
 	);

--- a/src/modules/add-site/index.tsx
+++ b/src/modules/add-site/index.tsx
@@ -59,7 +59,7 @@ interface NavigationContentProps {
 	selectedBlueprint?: Blueprint;
 	blueprintsErrorMessage?: string | undefined;
 	blueprintPreferredVersions?: { php?: string; wp?: string };
-	setBlueprintPreferredVersions: ( versions: { php?: string; wp?: string } | undefined ) => void;
+	setBlueprintPreferredVersions?: ( versions: { php?: string; wp?: string } | undefined ) => void;
 	blueprintDeeplinkWarnings?: BlueprintValidationWarning[];
 	selectedRemoteSite?: SyncSite;
 	setSelectedRemoteSite: ( site?: SyncSite ) => void;
@@ -175,7 +175,7 @@ function NavigationContent( props: NavigationContentProps ) {
 			}
 			if ( location.path === '/blueprint/select' || location.path === '/blueprint/deeplink' ) {
 				createSiteProps.setSelectedBlueprint();
-				setBlueprintPreferredVersions( undefined );
+				setBlueprintPreferredVersions?.( undefined );
 			}
 			if ( location.path === '/pullRemote' ) {
 				setSelectedRemoteSite( undefined );
@@ -199,7 +199,7 @@ function NavigationContent( props: NavigationContentProps ) {
 					php?: string;
 					wp?: string;
 				};
-				setBlueprintPreferredVersions( preferredVersions );
+				setBlueprintPreferredVersions?.( preferredVersions );
 
 				// Apply the preferred versions to the form
 				if ( preferredVersions.php && preferredVersions.php !== 'latest' ) {
@@ -209,7 +209,7 @@ function NavigationContent( props: NavigationContentProps ) {
 					setWpVersion( preferredVersions.wp );
 				}
 			} else {
-				setBlueprintPreferredVersions( undefined );
+				setBlueprintPreferredVersions?.( undefined );
 			}
 		},
 		[ setBlueprintPreferredVersions, setPhpVersion, setWpVersion ]
@@ -314,37 +314,42 @@ function NavigationContent( props: NavigationContentProps ) {
 export interface AddSiteModalContentProps {
 	isOpen?: boolean;
 	onSubmit?: () => void;
-	onRequestOpen?: () => void;
 	className?: string;
+	blueprintPreferredVersions?: { php?: string; wp?: string };
+	setBlueprintPreferredVersions?: ( versions: { php?: string; wp?: string } | undefined ) => void;
+	blueprintDeeplinkWarnings?: BlueprintValidationWarning[];
+	setBlueprintDeeplinkWarnings?: ( warnings: BlueprintValidationWarning[] | undefined ) => void;
+	isDeeplinkFlow?: boolean;
+	setIsDeeplinkFlow?: ( isDeeplink: boolean ) => void;
 }
 
 export function AddSiteModalContent( {
 	isOpen = true,
 	onSubmit,
-	onRequestOpen,
 	className,
+	blueprintPreferredVersions,
+	setBlueprintPreferredVersions,
+	blueprintDeeplinkWarnings,
+	setBlueprintDeeplinkWarnings,
+	isDeeplinkFlow: propIsDeeplinkFlow,
+	setIsDeeplinkFlow: propSetIsDeeplinkFlow,
 }: AddSiteModalContentProps ) {
 	const { __ } = useI18n();
 	const [ nameSuggested, setNameSuggested ] = useState( false );
 	const defaultPhpVersion = useRootSelector( selectDefaultPhpVersion );
 	const defaultWordPressVersion = useRootSelector( selectDefaultWordPressVersion );
-	const [ blueprintPreferredVersions, setBlueprintPreferredVersions ] = useState<
-		{ php?: string; wp?: string } | undefined
-	>();
-	const [ blueprintDeeplinkWarnings, setBlueprintDeeplinkWarnings ] = useState<
-		BlueprintValidationWarning[] | undefined
-	>();
-	const [ isDeeplinkFlow, setIsDeeplinkFlow ] = useState( false );
+
+	// Use props if provided (from AddSiteModal), otherwise use local state (for NoStudioSites)
+	const [ localIsDeeplinkFlow, setLocalIsDeeplinkFlow ] = useState( false );
+	const isDeeplinkFlow = propIsDeeplinkFlow ?? localIsDeeplinkFlow;
+	const setIsDeeplinkFlow = propSetIsDeeplinkFlow ?? setLocalIsDeeplinkFlow;
 
 	const {
 		data: blueprintsData,
 		isLoading: isLoadingBlueprints,
-		refetch,
-		isUninitialized,
 		error: blueprintsError,
 	} = useGetBlueprints();
 
-	const { importState } = useImportExport();
 	const addSiteProps = useAddSite();
 	const {
 		handleAddSiteClick,
@@ -370,10 +375,6 @@ export function AddSiteModalContent( {
 		setSelectedRemoteSite,
 	} = addSiteProps;
 
-	const isAnySiteProcessing = sites.some(
-		( site ) => site.isAddingSite || importState[ site.id ]?.isNewSite
-	);
-
 	const minimumWordPressVersion = useRootSelector( selectMinimumWordPressVersion );
 	const { data: versions = [] } = useGetWordPressVersions( {
 		minimumVersion: minimumWordPressVersion,
@@ -392,8 +393,8 @@ export function AddSiteModalContent( {
 		setEnableHttps( false );
 		setFileForImport( null );
 		setSelectedBlueprint( undefined );
-		setBlueprintPreferredVersions( undefined );
-		setBlueprintDeeplinkWarnings( undefined );
+		setBlueprintPreferredVersions?.( undefined );
+		setBlueprintDeeplinkWarnings?.( undefined );
 		setSelectedRemoteSite( undefined );
 	}, [
 		setSitePath,
@@ -407,29 +408,11 @@ export function AddSiteModalContent( {
 		setFileForImport,
 		setSelectedBlueprint,
 		setSelectedRemoteSite,
+		setBlueprintPreferredVersions,
+		setBlueprintDeeplinkWarnings,
 		defaultWordPressVersion,
 		defaultPhpVersion,
 	] );
-
-	const handleOpen = useCallback( () => {
-		if ( ! isUninitialized ) {
-			void refetch();
-		}
-		onRequestOpen?.();
-	}, [ refetch, isUninitialized, onRequestOpen ] );
-
-	useBlueprintDeeplink( {
-		isAnySiteProcessing,
-		openModal: handleOpen,
-		setSelectedBlueprint,
-		setPhpVersion,
-		setWpVersion,
-		setBlueprintPreferredVersions,
-		setBlueprintDeeplinkWarnings,
-		navigateToBlueprintDeeplink: () => {
-			setIsDeeplinkFlow( true );
-		},
-	} );
 
 	const initialNavigatorPath = selectedBlueprint ? '/blueprint/deeplink' : '/';
 
@@ -520,7 +503,14 @@ export default function AddSiteModal( { className }: AddSiteModalProps ) {
 	const { __ } = useI18n();
 	const [ showModal, setShowModal ] = useState( false );
 	const { importState } = useImportExport();
-	const { sites } = useAddSite();
+	const { sites, setSelectedBlueprint, setPhpVersion, setWpVersion } = useAddSite();
+	const [ blueprintPreferredVersions, setBlueprintPreferredVersions ] = useState<
+		{ php?: string; wp?: string } | undefined
+	>();
+	const [ blueprintDeeplinkWarnings, setBlueprintDeeplinkWarnings ] = useState<
+		BlueprintValidationWarning[] | undefined
+	>();
+	const [ isDeeplinkFlow, setIsDeeplinkFlow ] = useState( false );
 
 	const isAnySiteProcessing = sites.some(
 		( site ) => site.isAddingSite || importState[ site.id ]?.isNewSite
@@ -549,13 +539,32 @@ export default function AddSiteModal( { className }: AddSiteModalProps ) {
 		openModal();
 	} );
 
+	// This hook must be always mounted to listen for blueprint deeplinks
+	useBlueprintDeeplink( {
+		isAnySiteProcessing,
+		openModal,
+		setSelectedBlueprint,
+		setPhpVersion,
+		setWpVersion,
+		setBlueprintPreferredVersions,
+		setBlueprintDeeplinkWarnings,
+		navigateToBlueprintDeeplink: () => {
+			setIsDeeplinkFlow( true );
+		},
+	} );
+
 	return (
 		<>
 			<FullscreenModal isOpen={ showModal } onClose={ closeModal }>
 				<AddSiteModalContent
 					isOpen={ showModal }
 					onSubmit={ handleSiteAdded }
-					onRequestOpen={ openModal }
+					blueprintPreferredVersions={ blueprintPreferredVersions }
+					setBlueprintPreferredVersions={ setBlueprintPreferredVersions }
+					blueprintDeeplinkWarnings={ blueprintDeeplinkWarnings }
+					setBlueprintDeeplinkWarnings={ setBlueprintDeeplinkWarnings }
+					isDeeplinkFlow={ isDeeplinkFlow }
+					setIsDeeplinkFlow={ setIsDeeplinkFlow }
 				/>
 			</FullscreenModal>
 			<Button

--- a/src/modules/add-site/index.tsx
+++ b/src/modules/add-site/index.tsx
@@ -533,7 +533,11 @@ export default function AddSiteModal( { className }: AddSiteModalProps ) {
 
 	const closeModal = useCallback( () => {
 		setShowModal( false );
-	}, [] );
+		setIsDeeplinkFlow( false );
+		setSelectedBlueprint( undefined );
+		setBlueprintPreferredVersions( undefined );
+		setBlueprintDeeplinkWarnings( undefined );
+	}, [ setSelectedBlueprint ] );
 
 	const handleSiteAdded = useCallback( () => {
 		closeModal();

--- a/src/modules/add-site/index.tsx
+++ b/src/modules/add-site/index.tsx
@@ -84,14 +84,14 @@ function NavigationContent( props: NavigationContentProps ) {
 		...createSiteProps
 	} = props;
 
-	const { setSelectedBlueprint, setPhpVersion, setWpVersion } = createSiteProps;
+	const { selectedBlueprint, setSelectedBlueprint, setPhpVersion, setWpVersion } = createSiteProps;
 
 	useEffect( () => {
-		if ( isDeeplinkFlow ) {
+		if ( isDeeplinkFlow && selectedBlueprint ) {
 			goTo( '/blueprint/deeplink' );
 			setIsDeeplinkFlow( false );
 		}
-	}, [ isDeeplinkFlow, goTo, setIsDeeplinkFlow ] );
+	}, [ isDeeplinkFlow, goTo, setIsDeeplinkFlow, selectedBlueprint ] );
 
 	const handleOptionSelect = useCallback(
 		( option: AddSiteFlowType ) => {
@@ -109,10 +109,10 @@ function NavigationContent( props: NavigationContentProps ) {
 	);
 
 	const handleBlueprintContinue = useCallback( () => {
-		if ( createSiteProps.selectedBlueprint ) {
+		if ( selectedBlueprint ) {
 			goTo( '/blueprint/select/create' );
 		}
-	}, [ createSiteProps.selectedBlueprint, goTo ] );
+	}, [ selectedBlueprint, goTo ] );
 
 	const handleBackupFileSelect = useCallback(
 		( file?: File ) => {
@@ -244,7 +244,7 @@ function NavigationContent( props: NavigationContentProps ) {
 					blueprints={ blueprints }
 					errorMessage={ blueprintsErrorMessage }
 					isLoading={ isLoadingBlueprints }
-					selectedBlueprint={ createSiteProps.selectedBlueprint?.slug || null }
+					selectedBlueprint={ selectedBlueprint?.slug || null }
 					onBlueprintChange={ handleBlueprintChange }
 					onFileBlueprintSelect={ handleFileBlueprintSelect }
 				/>
@@ -260,7 +260,7 @@ function NavigationContent( props: NavigationContentProps ) {
 			</Navigator.Screen>
 			<Navigator.Screen className="flex-1" path="/blueprint/deeplink">
 				<BlueprintDeeplink
-					selectedBlueprint={ createSiteProps.selectedBlueprint }
+					selectedBlueprint={ selectedBlueprint }
 					warnings={ blueprintDeeplinkWarnings }
 				/>
 			</Navigator.Screen>
@@ -301,8 +301,8 @@ function NavigationContent( props: NavigationContentProps ) {
 				onBackupContinue={ handleBackupContinue }
 				onPullRemoteContinue={ handlePullRemoteContinue }
 				onCreateSubmit={ createSiteProps.handleSubmit }
-				canSubmitBlueprint={ !! createSiteProps.selectedBlueprint }
-				canSubmitBlueprintDeeplink={ !! createSiteProps.selectedBlueprint }
+				canSubmitBlueprint={ !! selectedBlueprint }
+				canSubmitBlueprintDeeplink={ !! selectedBlueprint }
 				canSubmitBackup={ !! createSiteProps.fileForImport }
 				canSubmitPullRemote={ !! selectedRemoteSite }
 				canSubmitCreate={ !! canSubmit }
@@ -321,6 +321,9 @@ export interface AddSiteModalContentProps {
 	setBlueprintDeeplinkWarnings?: ( warnings: BlueprintValidationWarning[] | undefined ) => void;
 	isDeeplinkFlow?: boolean;
 	setIsDeeplinkFlow?: ( isDeeplink: boolean ) => void;
+	// Blueprint state passed from AddSiteModal (useAddSite creates separate state per component)
+	selectedBlueprint?: Blueprint;
+	setSelectedBlueprint?: ( blueprint?: Blueprint ) => void;
 }
 
 export function AddSiteModalContent( {
@@ -333,6 +336,8 @@ export function AddSiteModalContent( {
 	setBlueprintDeeplinkWarnings,
 	isDeeplinkFlow = false,
 	setIsDeeplinkFlow = () => {},
+	selectedBlueprint: propSelectedBlueprint,
+	setSelectedBlueprint: propSetSelectedBlueprint,
 }: AddSiteModalContentProps ) {
 	const { __ } = useI18n();
 	const [ nameSuggested, setNameSuggested ] = useState( false );
@@ -364,11 +369,15 @@ export function AddSiteModalContent( {
 		setEnableHttps,
 		setFileForImport,
 		loadAllCustomDomains,
-		selectedBlueprint,
-		setSelectedBlueprint,
+		selectedBlueprint: localSelectedBlueprint,
+		setSelectedBlueprint: localSetSelectedBlueprint,
 		selectedRemoteSite,
 		setSelectedRemoteSite,
 	} = addSiteProps;
+
+	// Use props if provided (from AddSiteModal), otherwise use local state (for NoStudioSites)
+	const selectedBlueprint = propSelectedBlueprint ?? localSelectedBlueprint;
+	const setSelectedBlueprint = propSetSelectedBlueprint ?? localSetSelectedBlueprint;
 
 	const minimumWordPressVersion = useRootSelector( selectMinimumWordPressVersion );
 	const { data: versions = [] } = useGetWordPressVersions( {
@@ -474,6 +483,8 @@ export function AddSiteModalContent( {
 		>
 			<NavigationContent
 				{ ...addSiteProps }
+				selectedBlueprint={ selectedBlueprint }
+				setSelectedBlueprint={ setSelectedBlueprint }
 				blueprintsData={ blueprintsData }
 				blueprintsErrorMessage={ formatRtkError( blueprintsError ) }
 				isLoadingBlueprints={ isLoadingBlueprints }
@@ -498,7 +509,8 @@ export default function AddSiteModal( { className }: AddSiteModalProps ) {
 	const { __ } = useI18n();
 	const [ showModal, setShowModal ] = useState( false );
 	const { importState } = useImportExport();
-	const { sites, setSelectedBlueprint, setPhpVersion, setWpVersion } = useAddSite();
+	const { sites, selectedBlueprint, setSelectedBlueprint, setPhpVersion, setWpVersion } =
+		useAddSite();
 	const [ blueprintPreferredVersions, setBlueprintPreferredVersions ] = useState<
 		{ php?: string; wp?: string } | undefined
 	>();
@@ -560,6 +572,8 @@ export default function AddSiteModal( { className }: AddSiteModalProps ) {
 					setBlueprintDeeplinkWarnings={ setBlueprintDeeplinkWarnings }
 					isDeeplinkFlow={ isDeeplinkFlow }
 					setIsDeeplinkFlow={ setIsDeeplinkFlow }
+					selectedBlueprint={ selectedBlueprint }
+					setSelectedBlueprint={ setSelectedBlueprint }
 				/>
 			</FullscreenModal>
 			<Button

--- a/src/modules/add-site/index.tsx
+++ b/src/modules/add-site/index.tsx
@@ -321,9 +321,7 @@ export interface AddSiteModalContentProps {
 	setBlueprintDeeplinkWarnings?: ( warnings: BlueprintValidationWarning[] | undefined ) => void;
 	isDeeplinkFlow?: boolean;
 	setIsDeeplinkFlow?: ( isDeeplink: boolean ) => void;
-	// Blueprint state passed from AddSiteModal (useAddSite creates separate state per component)
-	selectedBlueprint?: Blueprint;
-	setSelectedBlueprint?: ( blueprint?: Blueprint ) => void;
+	addSiteProps?: ReturnType< typeof useAddSite >;
 }
 
 export function AddSiteModalContent( {
@@ -336,8 +334,7 @@ export function AddSiteModalContent( {
 	setBlueprintDeeplinkWarnings,
 	isDeeplinkFlow = false,
 	setIsDeeplinkFlow = () => {},
-	selectedBlueprint: propSelectedBlueprint,
-	setSelectedBlueprint: propSetSelectedBlueprint,
+	addSiteProps: externalAddSiteProps,
 }: AddSiteModalContentProps ) {
 	const { __ } = useI18n();
 	const [ nameSuggested, setNameSuggested ] = useState( false );
@@ -350,7 +347,9 @@ export function AddSiteModalContent( {
 		error: blueprintsError,
 	} = useGetBlueprints();
 
-	const addSiteProps = useAddSite();
+	const localAddSiteProps = useAddSite();
+	const addSiteProps = externalAddSiteProps ?? localAddSiteProps;
+
 	const {
 		handleAddSiteClick,
 		siteName,
@@ -369,15 +368,11 @@ export function AddSiteModalContent( {
 		setEnableHttps,
 		setFileForImport,
 		loadAllCustomDomains,
-		selectedBlueprint: localSelectedBlueprint,
-		setSelectedBlueprint: localSetSelectedBlueprint,
+		selectedBlueprint,
+		setSelectedBlueprint,
 		selectedRemoteSite,
 		setSelectedRemoteSite,
 	} = addSiteProps;
-
-	// Use props if provided (from AddSiteModal), otherwise use local state (for NoStudioSites)
-	const selectedBlueprint = propSelectedBlueprint ?? localSelectedBlueprint;
-	const setSelectedBlueprint = propSetSelectedBlueprint ?? localSetSelectedBlueprint;
 
 	const minimumWordPressVersion = useRootSelector( selectMinimumWordPressVersion );
 	const { data: versions = [] } = useGetWordPressVersions( {
@@ -509,8 +504,11 @@ export default function AddSiteModal( { className }: AddSiteModalProps ) {
 	const { __ } = useI18n();
 	const [ showModal, setShowModal ] = useState( false );
 	const { importState } = useImportExport();
-	const { sites, selectedBlueprint, setSelectedBlueprint, setPhpVersion, setWpVersion } =
-		useAddSite();
+
+	const addSiteProps = useAddSite();
+	const { sites, setSelectedBlueprint, setPhpVersion, setWpVersion } =
+		addSiteProps;
+
 	const [ blueprintPreferredVersions, setBlueprintPreferredVersions ] = useState<
 		{ php?: string; wp?: string } | undefined
 	>();
@@ -576,8 +574,7 @@ export default function AddSiteModal( { className }: AddSiteModalProps ) {
 					setBlueprintDeeplinkWarnings={ setBlueprintDeeplinkWarnings }
 					isDeeplinkFlow={ isDeeplinkFlow }
 					setIsDeeplinkFlow={ setIsDeeplinkFlow }
-					selectedBlueprint={ selectedBlueprint }
-					setSelectedBlueprint={ setSelectedBlueprint }
+					addSiteProps={ addSiteProps }
 				/>
 			</FullscreenModal>
 			<Button

--- a/src/modules/add-site/index.tsx
+++ b/src/modules/add-site/index.tsx
@@ -331,18 +331,13 @@ export function AddSiteModalContent( {
 	setBlueprintPreferredVersions,
 	blueprintDeeplinkWarnings,
 	setBlueprintDeeplinkWarnings,
-	isDeeplinkFlow: propIsDeeplinkFlow,
-	setIsDeeplinkFlow: propSetIsDeeplinkFlow,
+	isDeeplinkFlow = false,
+	setIsDeeplinkFlow = () => {},
 }: AddSiteModalContentProps ) {
 	const { __ } = useI18n();
 	const [ nameSuggested, setNameSuggested ] = useState( false );
 	const defaultPhpVersion = useRootSelector( selectDefaultPhpVersion );
 	const defaultWordPressVersion = useRootSelector( selectDefaultWordPressVersion );
-
-	// Use props if provided (from AddSiteModal), otherwise use local state (for NoStudioSites)
-	const [ localIsDeeplinkFlow, setLocalIsDeeplinkFlow ] = useState( false );
-	const isDeeplinkFlow = propIsDeeplinkFlow ?? localIsDeeplinkFlow;
-	const setIsDeeplinkFlow = propSetIsDeeplinkFlow ?? setLocalIsDeeplinkFlow;
 
 	const {
 		data: blueprintsData,

--- a/src/modules/add-site/index.tsx
+++ b/src/modules/add-site/index.tsx
@@ -496,6 +496,58 @@ export function AddSiteModalContent( {
 	);
 }
 
+interface AddSiteContentWithDeeplinkSupportProps {
+	isOpen?: boolean;
+	onSubmit?: () => void;
+	openModal?: () => void;
+	isAnySiteProcessing?: boolean;
+}
+
+export function AddSiteContentWithDeeplinkSupport( {
+	isOpen = true,
+	onSubmit,
+	openModal = () => {},
+	isAnySiteProcessing = false,
+}: AddSiteContentWithDeeplinkSupportProps ) {
+	const addSiteProps = useAddSite();
+	const { setSelectedBlueprint, setPhpVersion, setWpVersion, sites } = addSiteProps;
+
+	const [ blueprintPreferredVersions, setBlueprintPreferredVersions ] = useState<
+		{ php?: string; wp?: string } | undefined
+	>();
+	const [ blueprintDeeplinkWarnings, setBlueprintDeeplinkWarnings ] = useState<
+		BlueprintValidationWarning[] | undefined
+	>();
+	const [ isDeeplinkFlow, setIsDeeplinkFlow ] = useState( false );
+
+	useBlueprintDeeplink( {
+		isAnySiteProcessing: isAnySiteProcessing || sites.some( ( site ) => site.isAddingSite ),
+		openModal,
+		setSelectedBlueprint,
+		setPhpVersion,
+		setWpVersion,
+		setBlueprintPreferredVersions,
+		setBlueprintDeeplinkWarnings,
+		navigateToBlueprintDeeplink: () => {
+			setIsDeeplinkFlow( true );
+		},
+	} );
+
+	return (
+		<AddSiteModalContent
+			isOpen={ isOpen }
+			onSubmit={ onSubmit }
+			blueprintPreferredVersions={ blueprintPreferredVersions }
+			setBlueprintPreferredVersions={ setBlueprintPreferredVersions }
+			blueprintDeeplinkWarnings={ blueprintDeeplinkWarnings }
+			setBlueprintDeeplinkWarnings={ setBlueprintDeeplinkWarnings }
+			isDeeplinkFlow={ isDeeplinkFlow }
+			setIsDeeplinkFlow={ setIsDeeplinkFlow }
+			addSiteProps={ addSiteProps }
+		/>
+	);
+}
+
 interface AddSiteModalProps {
 	className?: string;
 }
@@ -506,8 +558,7 @@ export default function AddSiteModal( { className }: AddSiteModalProps ) {
 	const { importState } = useImportExport();
 
 	const addSiteProps = useAddSite();
-	const { sites, setSelectedBlueprint, setPhpVersion, setWpVersion } =
-		addSiteProps;
+	const { sites, setSelectedBlueprint, setPhpVersion, setWpVersion } = addSiteProps;
 
 	const [ blueprintPreferredVersions, setBlueprintPreferredVersions ] = useState<
 		{ php?: string; wp?: string } | undefined
@@ -548,7 +599,9 @@ export default function AddSiteModal( { className }: AddSiteModalProps ) {
 		openModal();
 	} );
 
-	// This hook must be always mounted to listen for blueprint deeplinks
+	// This hook must also be here because FullscreenModal doesn't render children when closed.
+	// AddSiteModal and NoStudioSites (which uses AddSiteContentWithDeeplinkSupport)
+	// are mutually exclusive, only one is mounted based on whether sites exist.
 	useBlueprintDeeplink( {
 		isAnySiteProcessing,
 		openModal,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-1105

## Proposed Changes

- Move `useBlueprintDeeplink` hook from `AddSiteModalContent` to `AddSiteModal` to ensure the hook is always mounted and listening for deeplink events
- Move `isDeeplinkFlow` state to `AddSiteModal` to allow `navigateToBlueprintDeeplink()` to trigger navigation when the modal opens
- Pass blueprint-related state as props from `AddSiteModal` to `AddSiteModalContent`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to https://jsbin.com/levaburate/2/edit?html,css,output and test opening blueprints
- Check that the Valid Blueprint link is opening as expected
- Test for regressions using the steps on https://github.com/Automattic/studio/pull/2149/files

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
