### PR TITLE
CLI: Expand tilde in path option on Posix systems

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -1,4 +1,5 @@
 import 'cli/polyfills/browser-globals.js';
+import os from 'node:os';
 import path from 'node:path';
 import { __ } from '@wordpress/i18n';
 import { suppressPunycodeWarning } from 'common/lib/suppress-punycode-warning';
@@ -42,10 +43,16 @@ async function main() {
 		} )
 		.option( 'path', {
 			type: 'string',
+			normalize: true,
 			default: process.cwd(),
 			defaultDescription: __( 'Current directory' ),
 			description: __( 'Path to the WordPress files' ),
-			coerce: ( value ) => path.resolve( process.cwd(), value ),
+			coerce: ( value ) => {
+				if ( process.platform !== 'win32' ) {
+					value = value.replace( /^~/, os.homedir() );
+				}
+				return path.resolve( value );
+			},
 		} )
 		.middleware( async ( argv ) => {
 			if ( ! argv.avoidTelemetry ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-1101

## Proposed Changes

If I run `studio site create --path ~/Downloads/ddd2` (note the space after `--path`), the path is expanded as expected. However, if I run `studio site create --path=~/Downloads/ddd2`, it doesn't work. This is because `~` is a shell construct, and my shell doesn't expand `~` if it's not at the start of a string.

This PR fixes the problem by expanding `~` in the yargs `coerce` callback (so long as we're not running on Windows, where `~` isn't a thing).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Run `npm run cli:build`
2. Run `node dist/cli/main.js site status --path=PATH_TO_SITE` (where `PATH_TO_SITE` is the path to a Studio site)
3. Ensure that it works as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
