### PR TITLE
Studio: Hide behind beta flag the Publish button

### DIFF
--- a/src/components/publish-site-button.tsx
+++ b/src/components/publish-site-button.tsx
@@ -6,7 +6,8 @@ import { useAuth } from 'src/hooks/use-auth';
 import { useContentTabs } from 'src/hooks/use-content-tabs';
 import { useSiteDetails } from 'src/hooks/use-site-details';
 import { ConnectButton } from 'src/modules/sync/components/connect-button';
-import { useAppDispatch } from 'src/stores';
+import { useAppDispatch, useRootSelector } from 'src/stores';
+import { betaFeaturesSelectors } from 'src/stores/beta-features-slice';
 import {
 	connectedSitesActions,
 	useGetConnectedSitesForLocalSiteQuery,
@@ -24,6 +25,9 @@ export const PublishSiteButton = () => {
 	} );
 	const { isAnySitePulling, isAnySitePushing } = useSyncSites();
 	const isAnySiteSyncing = isAnySitePulling || isAnySitePushing;
+	const isPublishSiteEnabled = useRootSelector( ( state ) =>
+		betaFeaturesSelectors.selectBetaFeature( state, 'publishSite' )
+	);
 
 	const handlePublishClick = useCallback( () => {
 		if ( ! user ) {
@@ -33,6 +37,7 @@ export const PublishSiteButton = () => {
 		setSelectedTab( 'sync' );
 	}, [ user, setSelectedTab, dispatch, authenticate ] );
 
+	if ( ! isPublishSiteEnabled ) return null;
 	if ( connectedSites.length !== 0 ) return null;
 
 	return (

--- a/src/components/tests/site-management-actions.test.tsx
+++ b/src/components/tests/site-management-actions.test.tsx
@@ -8,6 +8,7 @@ import {
 import { SyncSitesProvider } from 'src/hooks/sync-sites';
 import { ContentTabsProvider } from 'src/hooks/use-content-tabs';
 import { store } from 'src/stores';
+import { setBetaFeatures } from 'src/stores/beta-features-slice';
 import { connectedSitesApi } from 'src/stores/sync/connected-sites';
 
 const mockGetConnectedWpcomSites = jest.fn();
@@ -108,6 +109,17 @@ describe( 'SiteManagementActions', () => {
 	} );
 
 	describe( 'PublishSiteButton', () => {
+		beforeEach( () => {
+			// Enable the publishSite beta feature for these tests
+			store.dispatch(
+				setBetaFeatures( {
+					studioSitesCli: false,
+					multiWorkerSupport: false,
+					publishSite: true,
+				} )
+			);
+		} );
+
 		it( 'should render "Publish site" button when no sites are connected', async () => {
 			renderWithProvider(
 				<SiteManagementActions

--- a/src/ipc-types.d.ts
+++ b/src/ipc-types.d.ts
@@ -84,6 +84,7 @@ interface FeatureFlags {
 interface BetaFeatures {
 	studioSitesCli: boolean;
 	multiWorkerSupport: boolean;
+	publishSite: boolean;
 }
 
 interface AppGlobals extends FeatureFlags {

--- a/src/lib/beta-features.ts
+++ b/src/lib/beta-features.ts
@@ -20,6 +20,12 @@ const BETA_FEATURES_DEFINITION: Record< keyof BetaFeatures, BetaFeatureDefinitio
 		default: false,
 		description: 'Enable multi-worker PHP processing for faster performance',
 	},
+	publishSite: {
+		label: 'Publish Site',
+		key: 'publishSite',
+		default: false,
+		description: 'Show the "Publish site" button to push local sites to WordPress.com',
+	},
 } as const;
 
 export const BETA_FEATURES: Record< keyof BetaFeatures, BetaFeatureDefinition > =

--- a/src/stores/beta-features-slice.ts
+++ b/src/stores/beta-features-slice.ts
@@ -11,6 +11,7 @@ const initialState: BetaFeaturesState = {
 	features: {
 		studioSitesCli: false,
 		multiWorkerSupport: false,
+		publishSite: false,
 	},
 	loading: false,
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

Fixes STU-1108

## Proposed Changes

This PR hides the `Publish site` button behind the beta flag.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
* Start Studio with `npm start`
* In the top bar menu, make sure that beta features > `Publish site` is disabled
* Observe that `Publish site` button in the top right corner does not display on Studio sites that don't have any WP.com sites connected
* Enable beta features > `Publish site` from the top bar menu
* Confirm that `Publish site` button in the top right corner displays on Studio sites that don't have any WP.com sites connected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
