### PR TITLE
CLI: add `studio site stop-all` command

### DIFF
--- a/cli/commands/site/stop-all.ts
+++ b/cli/commands/site/stop-all.ts
@@ -1,4 +1,4 @@
-import { __, sprintf } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 import { SiteCommandLoggerAction as LoggerAction } from 'common/logger-actions';
 import { clearSiteLatestCliPid, readAppdata, type SiteData } from 'cli/lib/appdata';
 import { connect, disconnect } from 'cli/lib/pm2-manager';
@@ -53,57 +53,51 @@ export async function runCommand(): Promise< void > {
 			)
 		);
 
-		const errors: Array< { siteName: string; error: Error } > = [];
-
 		for ( const site of runningSites ) {
 			try {
+				logger.reportProgress(
+					sprintf(
+						__( 'Stopping site "%s" (%d/%d)...' ),
+						site.name,
+						stoppedSiteIds.length + 1,
+						runningSites.length
+					)
+				);
 				await stopWordPressServer( site.id );
 				await clearSiteLatestCliPid( site.id );
 
 				stoppedSiteIds.push( site.id );
-
-				logger.reportProgress(
-					sprintf(
-						__( 'Stopping all WordPress sites... (%d/%d)' ),
-						stoppedSiteIds.length,
-						runningSites.length
-					)
-				);
 			} catch ( error ) {
-				errors.push( {
-					siteName: site.name,
-					error: error instanceof Error ? error : new Error( String( error ) ),
-				} );
+				logger.reportError(
+					new LoggerError( sprintf( __( 'Failed to stop site %s' ), site.name ) )
+				);
 			}
 		}
 
 		try {
 			await stopProxyIfNoSitesNeedIt( stoppedSiteIds, logger );
 		} catch ( error ) {
-			// Non-critical error, just log it
-			logger.reportWarning( __( 'Failed to stop proxy server' ) );
+			throw new LoggerError( __( 'Failed to stop proxy server' ), error );
 		}
 
-		if ( errors.length === 0 ) {
-			const siteNames = runningSites.map( ( s ) => s.name ).join( ', ' );
+		if ( stoppedSiteIds.length === runningSites.length ) {
 			logger.reportSuccess(
-				sprintf( __( 'Successfully stopped %d site(s): %s' ), runningSites.length, siteNames )
+				sprintf(
+					_n(
+						'Successfully stopped %d site',
+						'Successfully stopped %d sites',
+						runningSites.length
+					),
+					runningSites.length
+				)
 			);
-		} else if ( errors.length === runningSites.length ) {
-			const failedNames = errors.map( ( e ) => e.siteName ).join( ', ' );
+		} else if ( stoppedSiteIds.length === 0 ) {
 			throw new LoggerError(
-				sprintf( __( 'Failed to stop all (%d) sites: %s' ), runningSites.length, failedNames )
+				sprintf( __( 'Failed to stop all (%d) sites' ), runningSites.length )
 			);
 		} else {
-			const successCount = runningSites.length - errors.length;
-			const failedNames = errors.map( ( e ) => e.siteName ).join( ', ' );
 			throw new LoggerError(
-				sprintf(
-					__( 'Stopped %d site(s), but %d failed: %s' ),
-					successCount,
-					errors.length,
-					failedNames
-				)
+				sprintf( __( 'Stopped %d sites out of %d' ), stoppedSiteIds.length, runningSites.length )
 			);
 		}
 	} finally {
@@ -115,9 +109,6 @@ export const registerCommand = ( yargs: StudioArgv ) => {
 	return yargs.command( {
 		command: 'stop-all',
 		describe: __( 'Stop all local sites' ),
-		builder: ( yargs ) => {
-			return yargs;
-		},
 		handler: async () => {
 			try {
 				await runCommand();

--- a/cli/commands/site/stop-all.ts
+++ b/cli/commands/site/stop-all.ts
@@ -1,0 +1,134 @@
+import { __, sprintf } from '@wordpress/i18n';
+import { SiteCommandLoggerAction as LoggerAction } from 'common/logger-actions';
+import { clearSiteLatestCliPid, readAppdata, type SiteData } from 'cli/lib/appdata';
+import { connect, disconnect } from 'cli/lib/pm2-manager';
+import { stopProxyIfNoSitesNeedIt } from 'cli/lib/site-utils';
+import { isServerRunning, stopWordPressServer } from 'cli/lib/wordpress-server-manager';
+import { Logger, LoggerError } from 'cli/logger';
+import { StudioArgv } from 'cli/types';
+
+const logger = new Logger< LoggerAction >();
+
+const filterRunningSites = async ( sites: SiteData[] ): Promise< SiteData[] > => {
+	const runningSites = [];
+
+	for ( const site of sites ) {
+		const runningProcess = await isServerRunning( site.id );
+
+		if ( runningProcess ) {
+			runningSites.push( site );
+		}
+	}
+
+	return runningSites;
+};
+
+export async function runCommand(): Promise< void > {
+	try {
+		const appdata = await readAppdata();
+		const allSites = appdata.sites;
+
+		if ( ! allSites.length ) {
+			logger.reportSuccess( __( 'No sites found' ) );
+			return;
+		}
+
+		await connect();
+
+		const runningSites = await filterRunningSites( allSites );
+
+		if ( ! runningSites.length ) {
+			logger.reportSuccess( __( 'No sites are currently running' ) );
+			return;
+		}
+
+		const stoppedSiteIds: string[] = [];
+
+		logger.reportStart(
+			LoggerAction.STOP_ALL_SITES,
+			sprintf(
+				__( 'Stopping all WordPress sites... (%d/%d)' ),
+				stoppedSiteIds.length,
+				runningSites.length
+			)
+		);
+
+		const errors: Array< { siteName: string; error: Error } > = [];
+
+		for ( const site of runningSites ) {
+			try {
+				await stopWordPressServer( site.id );
+				await clearSiteLatestCliPid( site.id );
+
+				stoppedSiteIds.push( site.id );
+
+				logger.reportProgress(
+					sprintf(
+						__( 'Stopping all WordPress sites... (%d/%d)' ),
+						stoppedSiteIds.length,
+						runningSites.length
+					)
+				);
+			} catch ( error ) {
+				errors.push( {
+					siteName: site.name,
+					error: error instanceof Error ? error : new Error( String( error ) ),
+				} );
+			}
+		}
+
+		try {
+			await stopProxyIfNoSitesNeedIt( stoppedSiteIds, logger );
+		} catch ( error ) {
+			// Non-critical error, just log it
+			logger.reportWarning( __( 'Failed to stop proxy server' ) );
+		}
+
+		if ( errors.length === 0 ) {
+			const siteNames = runningSites.map( ( s ) => s.name ).join( ', ' );
+			logger.reportSuccess(
+				sprintf( __( 'Successfully stopped %d site(s): %s' ), runningSites.length, siteNames )
+			);
+		} else if ( errors.length === runningSites.length ) {
+			const failedNames = errors.map( ( e ) => e.siteName ).join( ', ' );
+			throw new LoggerError(
+				sprintf( __( 'Failed to stop all (%d) sites: %s' ), runningSites.length, failedNames )
+			);
+		} else {
+			const successCount = runningSites.length - errors.length;
+			const failedNames = errors.map( ( e ) => e.siteName ).join( ', ' );
+			throw new LoggerError(
+				sprintf(
+					__( 'Stopped %d site(s), but %d failed: %s' ),
+					successCount,
+					errors.length,
+					failedNames
+				)
+			);
+		}
+	} finally {
+		disconnect();
+	}
+}
+
+export const registerCommand = ( yargs: StudioArgv ) => {
+	return yargs.command( {
+		command: 'stop-all',
+		describe: __( 'Stop all local sites' ),
+		builder: ( yargs ) => {
+			return yargs;
+		},
+		handler: async () => {
+			try {
+				await runCommand();
+			} catch ( error ) {
+				if ( error instanceof LoggerError ) {
+					logger.reportError( error );
+				} else {
+					const loggerError = new LoggerError( __( 'Failed to stop sites' ), error );
+					logger.reportError( loggerError );
+				}
+			}
+		},
+	} );
+};

--- a/cli/commands/site/tests/stop-all.test.ts
+++ b/cli/commands/site/tests/stop-all.test.ts
@@ -91,9 +91,7 @@ describe( 'CLI: studio site stop-all', () => {
 
 			const { runCommand } = await import( '../stop-all' );
 
-			await expect( runCommand() ).rejects.toThrow(
-				'Failed to stop all (3) sites: Test Site 1, Test Site 2, Test Site 3'
-			);
+			await expect( runCommand() ).rejects.toThrow( 'Failed to stop all (3) sites' );
 			expect( disconnect ).toHaveBeenCalled();
 		} );
 
@@ -108,9 +106,7 @@ describe( 'CLI: studio site stop-all', () => {
 
 			const { runCommand } = await import( '../stop-all' );
 
-			await expect( runCommand() ).rejects.toThrow(
-				'Stopped 2 site(s), but 1 failed: Test Site 2'
-			);
+			await expect( runCommand() ).rejects.toThrow( 'Stopped 2 sites out of 3' );
 			expect( disconnect ).toHaveBeenCalled();
 			expect( stopWordPressServer ).toHaveBeenCalledTimes( 3 );
 		} );
@@ -238,7 +234,7 @@ describe( 'CLI: studio site stop-all', () => {
 			expect( disconnect ).toHaveBeenCalled();
 		} );
 
-		it( 'should handle proxy stop failure gracefully', async () => {
+		it( 'should throw when proxy stop fails', async () => {
 			( readAppdata as jest.Mock ).mockResolvedValue( { sites: [ testSites[ 0 ] ] } );
 			( isServerRunning as jest.Mock ).mockResolvedValue( testProcessDescription );
 			( stopProxyIfNoSitesNeedIt as jest.Mock ).mockRejectedValue(
@@ -247,8 +243,8 @@ describe( 'CLI: studio site stop-all', () => {
 
 			const { runCommand } = await import( '../stop-all' );
 
-			// Should not throw even if proxy stop fails
-			await runCommand();
+			// Should throw when proxy stop fails
+			await expect( runCommand() ).rejects.toThrow( 'Failed to stop proxy server' );
 
 			expect( stopWordPressServer ).toHaveBeenCalledWith( 'site-1' );
 			expect( disconnect ).toHaveBeenCalled();

--- a/cli/commands/site/tests/stop-all.test.ts
+++ b/cli/commands/site/tests/stop-all.test.ts
@@ -1,0 +1,305 @@
+import { SiteData, clearSiteLatestCliPid, readAppdata } from 'cli/lib/appdata';
+import { connect, disconnect } from 'cli/lib/pm2-manager';
+import { stopProxyIfNoSitesNeedIt } from 'cli/lib/site-utils';
+import { isServerRunning, stopWordPressServer } from 'cli/lib/wordpress-server-manager';
+
+jest.mock( 'cli/lib/appdata', () => ( {
+	...jest.requireActual( 'cli/lib/appdata' ),
+	readAppdata: jest.fn(),
+	clearSiteLatestCliPid: jest.fn(),
+	getAppdataDirectory: jest.fn().mockReturnValue( '/test/appdata' ),
+} ) );
+jest.mock( 'cli/lib/pm2-manager' );
+jest.mock( 'cli/lib/site-utils' );
+jest.mock( 'cli/lib/wordpress-server-manager' );
+
+describe( 'CLI: studio site stop-all', () => {
+	const testSites: SiteData[] = [
+		{
+			id: 'site-1',
+			name: 'Test Site 1',
+			path: '/test/site1',
+			port: 8080,
+			phpVersion: '8.0',
+			adminUsername: 'admin',
+			adminPassword: 'password123',
+		},
+		{
+			id: 'site-2',
+			name: 'Test Site 2',
+			path: '/test/site2',
+			port: 8081,
+			phpVersion: '8.1',
+			adminUsername: 'admin',
+			adminPassword: 'password456',
+		},
+		{
+			id: 'site-3',
+			name: 'Test Site 3',
+			path: '/test/site3',
+			port: 8082,
+			phpVersion: '8.2',
+			adminUsername: 'admin',
+			adminPassword: 'password789',
+		},
+	];
+
+	const testProcessDescription = {
+		pid: 12345,
+		status: 'online',
+	};
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+
+		( connect as jest.Mock ).mockResolvedValue( undefined );
+		( disconnect as jest.Mock ).mockResolvedValue( undefined );
+		( isServerRunning as jest.Mock ).mockResolvedValue( undefined );
+		( stopWordPressServer as jest.Mock ).mockResolvedValue( undefined );
+		( clearSiteLatestCliPid as jest.Mock ).mockResolvedValue( undefined );
+		( stopProxyIfNoSitesNeedIt as jest.Mock ).mockResolvedValue( undefined );
+	} );
+
+	afterEach( () => {
+		jest.restoreAllMocks();
+	} );
+
+	describe( 'Error Cases', () => {
+		it( 'should throw when appdata cannot be read', async () => {
+			( readAppdata as jest.Mock ).mockRejectedValue( new Error( 'Failed to read appdata' ) );
+
+			const { runCommand } = await import( '../stop-all' );
+
+			await expect( runCommand() ).rejects.toThrow( 'Failed to read appdata' );
+			expect( disconnect ).toHaveBeenCalled();
+		} );
+
+		it( 'should throw when PM2 connection fails', async () => {
+			( readAppdata as jest.Mock ).mockResolvedValue( { sites: testSites } );
+			( connect as jest.Mock ).mockRejectedValue( new Error( 'PM2 connection failed' ) );
+
+			const { runCommand } = await import( '../stop-all' );
+
+			await expect( runCommand() ).rejects.toThrow( 'PM2 connection failed' );
+			expect( disconnect ).toHaveBeenCalled();
+		} );
+
+		it( 'should throw when all sites fail to stop', async () => {
+			( readAppdata as jest.Mock ).mockResolvedValue( { sites: testSites } );
+			( isServerRunning as jest.Mock ).mockResolvedValue( testProcessDescription );
+			( stopWordPressServer as jest.Mock ).mockRejectedValue( new Error( 'Server stop failed' ) );
+
+			const { runCommand } = await import( '../stop-all' );
+
+			await expect( runCommand() ).rejects.toThrow(
+				'Failed to stop all (3) sites: Test Site 1, Test Site 2, Test Site 3'
+			);
+			expect( disconnect ).toHaveBeenCalled();
+		} );
+
+		it( 'should throw when some sites fail to stop', async () => {
+			( readAppdata as jest.Mock ).mockResolvedValue( { sites: testSites } );
+			( isServerRunning as jest.Mock ).mockResolvedValue( testProcessDescription );
+
+			( stopWordPressServer as jest.Mock )
+				.mockResolvedValueOnce( undefined ) // site-1 success
+				.mockRejectedValueOnce( new Error( 'Server stop failed' ) ) // site-2 fails
+				.mockResolvedValueOnce( undefined ); // site-3 success
+
+			const { runCommand } = await import( '../stop-all' );
+
+			await expect( runCommand() ).rejects.toThrow(
+				'Stopped 2 site(s), but 1 failed: Test Site 2'
+			);
+			expect( disconnect ).toHaveBeenCalled();
+			expect( stopWordPressServer ).toHaveBeenCalledTimes( 3 );
+		} );
+	} );
+
+	describe( 'Success Cases', () => {
+		it( 'should handle empty sites list', async () => {
+			( readAppdata as jest.Mock ).mockResolvedValue( { sites: [] } );
+
+			const { runCommand } = await import( '../stop-all' );
+
+			await runCommand();
+
+			expect( connect ).not.toHaveBeenCalled();
+			expect( stopWordPressServer ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should skip if no sites are running', async () => {
+			( readAppdata as jest.Mock ).mockResolvedValue( { sites: testSites } );
+
+			( isServerRunning as jest.Mock ).mockResolvedValue( undefined );
+
+			const { runCommand } = await import( '../stop-all' );
+
+			await runCommand();
+
+			expect( connect ).toHaveBeenCalled();
+			expect( isServerRunning ).toHaveBeenCalledTimes( 3 );
+			expect( stopWordPressServer ).not.toHaveBeenCalled();
+			expect( clearSiteLatestCliPid ).not.toHaveBeenCalled();
+			expect( stopProxyIfNoSitesNeedIt ).not.toHaveBeenCalled();
+			expect( disconnect ).toHaveBeenCalled();
+		} );
+
+		it( 'should handle single site', async () => {
+			( readAppdata as jest.Mock ).mockResolvedValue( { sites: [ testSites[ 0 ] ] } );
+			( isServerRunning as jest.Mock ).mockResolvedValue( testProcessDescription );
+
+			const { runCommand } = await import( '../stop-all' );
+
+			await runCommand();
+
+			expect( stopWordPressServer ).toHaveBeenCalledTimes( 1 );
+			expect( stopWordPressServer ).toHaveBeenCalledWith( 'site-1' );
+			expect( disconnect ).toHaveBeenCalled();
+		} );
+
+		it( 'should stop all running sites', async () => {
+			( readAppdata as jest.Mock ).mockResolvedValue( { sites: testSites } );
+			( isServerRunning as jest.Mock ).mockResolvedValue( testProcessDescription );
+
+			const { runCommand } = await import( '../stop-all' );
+
+			await runCommand();
+
+			expect( readAppdata ).toHaveBeenCalled();
+			expect( connect ).toHaveBeenCalled();
+			expect( isServerRunning ).toHaveBeenCalledTimes( 3 );
+			expect( isServerRunning ).toHaveBeenCalledWith( 'site-1' );
+			expect( isServerRunning ).toHaveBeenCalledWith( 'site-2' );
+			expect( isServerRunning ).toHaveBeenCalledWith( 'site-3' );
+
+			expect( stopWordPressServer ).toHaveBeenCalledTimes( 3 );
+			expect( stopWordPressServer ).toHaveBeenCalledWith( 'site-1' );
+			expect( stopWordPressServer ).toHaveBeenCalledWith( 'site-2' );
+			expect( stopWordPressServer ).toHaveBeenCalledWith( 'site-3' );
+
+			expect( clearSiteLatestCliPid ).toHaveBeenCalledTimes( 3 );
+			expect( clearSiteLatestCliPid ).toHaveBeenCalledWith( 'site-1' );
+			expect( clearSiteLatestCliPid ).toHaveBeenCalledWith( 'site-2' );
+			expect( clearSiteLatestCliPid ).toHaveBeenCalledWith( 'site-3' );
+
+			expect( stopProxyIfNoSitesNeedIt ).toHaveBeenCalledWith(
+				[ 'site-1', 'site-2', 'site-3' ],
+				expect.any( Object )
+			);
+			expect( disconnect ).toHaveBeenCalled();
+		} );
+
+		it( 'should stop only running sites (mixed state)', async () => {
+			( readAppdata as jest.Mock ).mockResolvedValue( { sites: testSites } );
+
+			( isServerRunning as jest.Mock )
+				.mockResolvedValueOnce( testProcessDescription ) // site-1 running
+				.mockResolvedValueOnce( undefined ) // site-2 not running
+				.mockResolvedValueOnce( testProcessDescription ); // site-3 running
+
+			const { runCommand } = await import( '../stop-all' );
+
+			await runCommand();
+
+			expect( isServerRunning ).toHaveBeenCalledTimes( 3 );
+
+			expect( stopWordPressServer ).toHaveBeenCalledTimes( 2 );
+			expect( stopWordPressServer ).toHaveBeenCalledWith( 'site-1' );
+			expect( stopWordPressServer ).toHaveBeenCalledWith( 'site-3' );
+			expect( stopWordPressServer ).not.toHaveBeenCalledWith( 'site-2' );
+
+			expect( clearSiteLatestCliPid ).toHaveBeenCalledTimes( 2 );
+			expect( disconnect ).toHaveBeenCalled();
+		} );
+
+		it( 'should continue stopping other sites even if one fails', async () => {
+			( readAppdata as jest.Mock ).mockResolvedValue( { sites: testSites } );
+			( isServerRunning as jest.Mock ).mockResolvedValue( testProcessDescription );
+
+			( stopWordPressServer as jest.Mock )
+				.mockResolvedValueOnce( undefined ) // site-1 success
+				.mockRejectedValueOnce( new Error( 'Server stop failed' ) ) // site-2 fails
+				.mockResolvedValueOnce( undefined ); // site-3 success
+
+			const { runCommand } = await import( '../stop-all' );
+
+			try {
+				await runCommand();
+			} catch {
+				// Expected to throw due to partial failure
+			}
+
+			expect( stopWordPressServer ).toHaveBeenCalledTimes( 3 );
+			expect( clearSiteLatestCliPid ).toHaveBeenCalledTimes( 2 );
+			expect( clearSiteLatestCliPid ).toHaveBeenCalledWith( 'site-1' );
+			expect( clearSiteLatestCliPid ).toHaveBeenCalledWith( 'site-3' );
+			expect( clearSiteLatestCliPid ).not.toHaveBeenCalledWith( 'site-2' );
+			expect( disconnect ).toHaveBeenCalled();
+		} );
+
+		it( 'should handle proxy stop failure gracefully', async () => {
+			( readAppdata as jest.Mock ).mockResolvedValue( { sites: [ testSites[ 0 ] ] } );
+			( isServerRunning as jest.Mock ).mockResolvedValue( testProcessDescription );
+			( stopProxyIfNoSitesNeedIt as jest.Mock ).mockRejectedValue(
+				new Error( 'Proxy stop failed' )
+			);
+
+			const { runCommand } = await import( '../stop-all' );
+
+			// Should not throw even if proxy stop fails
+			await runCommand();
+
+			expect( stopWordPressServer ).toHaveBeenCalledWith( 'site-1' );
+			expect( disconnect ).toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'Cleanup', () => {
+		it( 'should always disconnect from PM2 on success', async () => {
+			( readAppdata as jest.Mock ).mockResolvedValue( { sites: testSites } );
+			( isServerRunning as jest.Mock ).mockResolvedValue( testProcessDescription );
+
+			const { runCommand } = await import( '../stop-all' );
+
+			await runCommand();
+
+			expect( disconnect ).toHaveBeenCalled();
+		} );
+
+		it( 'should always disconnect from PM2 on error', async () => {
+			( readAppdata as jest.Mock ).mockRejectedValue( new Error( 'Error' ) );
+
+			const { runCommand } = await import( '../stop-all' );
+
+			try {
+				await runCommand();
+			} catch {
+				// Expected
+			}
+
+			expect( disconnect ).toHaveBeenCalled();
+		} );
+
+		it( 'should always disconnect when no sites exist', async () => {
+			( readAppdata as jest.Mock ).mockResolvedValue( { sites: [] } );
+
+			const { runCommand } = await import( '../stop-all' );
+
+			await runCommand();
+
+			expect( disconnect ).toHaveBeenCalled();
+		} );
+
+		it( 'should always disconnect when no sites are running', async () => {
+			( readAppdata as jest.Mock ).mockResolvedValue( { sites: testSites } );
+			( isServerRunning as jest.Mock ).mockResolvedValue( undefined );
+
+			const { runCommand } = await import( '../stop-all' );
+
+			await runCommand();
+
+			expect( disconnect ).toHaveBeenCalled();
+		} );
+	} );
+} );

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -20,6 +20,7 @@ import { registerCommand as registerSiteSetPhpVersionCommand } from 'cli/command
 import { registerCommand as registerSiteStartCommand } from 'cli/commands/site/start';
 import { registerCommand as registerSiteStatusCommand } from 'cli/commands/site/status';
 import { registerCommand as registerSiteStopCommand } from 'cli/commands/site/stop';
+import { registerCommand as registerSiteStopAllCommand } from 'cli/commands/site/stop-all';
 import { readAppdata } from 'cli/lib/appdata';
 import { loadTranslations } from 'cli/lib/i18n';
 import { bumpAggregatedUniqueStat } from 'cli/lib/stats';
@@ -89,6 +90,7 @@ async function main() {
 			registerSiteListCommand( sitesYargs );
 			registerSiteStartCommand( sitesYargs );
 			registerSiteStopCommand( sitesYargs );
+			registerSiteStopAllCommand( sitesYargs );
 			registerSiteDeleteCommand( sitesYargs );
 			registerSiteSetHttpsCommand( sitesYargs );
 			registerSiteSetDomainCommand( sitesYargs );

--- a/cli/lib/site-utils.ts
+++ b/cli/lib/site-utils.ts
@@ -95,15 +95,12 @@ export async function stopProxyIfNoSitesNeedIt(
 
 	const appdata = await readAppdata();
 
-	const remainingSites = appdata.sites.filter(
-		( site ) => ! stoppedSiteIdsArray.includes( site.id )
+	const remainingSitesWithCustomDomains = appdata.sites.filter(
+		( site ) => ! stoppedSiteIdsArray.includes( site.id ) && site.customDomain
 	);
 
-	// Filter to sites with custom domains that might need the proxy
-	const sitesWithCustomDomains = remainingSites.filter( ( site ) => site.customDomain );
-
 	const sitesStillRunning = await Promise.all(
-		sitesWithCustomDomains.map( ( site ) => isServerRunning( site.id ) )
+		remainingSitesWithCustomDomains.map( ( site ) => isServerRunning( site.id ) )
 	);
 
 	if ( sitesStillRunning.some( ( isRunning ) => isRunning ) ) {

--- a/cli/lib/site-utils.ts
+++ b/cli/lib/site-utils.ts
@@ -80,7 +80,7 @@ export async function setupCustomDomain(
  * Stops the HTTP proxy server if no remaining running sites need it.
  * A site needs the proxy if it has a custom domain configured.
  *
- * @param stoppedSiteId - The ID of the site that was just stopped (to exclude from the check)
+ * @param stoppedSiteIds - The ID of the site that was just stopped (to exclude from the check)
  */
 export async function stopProxyIfNoSitesNeedIt(
 	stoppedSiteIds: string | string[],

--- a/cli/lib/site-utils.ts
+++ b/cli/lib/site-utils.ts
@@ -83,9 +83,11 @@ export async function setupCustomDomain(
  * @param stoppedSiteId - The ID of the site that was just stopped (to exclude from the check)
  */
 export async function stopProxyIfNoSitesNeedIt(
-	stoppedSiteId: string,
+	stoppedSiteIds: string | string[],
 	logger: Logger< LoggerAction >
 ): Promise< void > {
+	const stoppedSiteIdsArray = Array.isArray( stoppedSiteIds ) ? stoppedSiteIds : [ stoppedSiteIds ];
+
 	const proxyProcess = await isProxyProcessRunning();
 	if ( ! proxyProcess ) {
 		return;
@@ -93,10 +95,19 @@ export async function stopProxyIfNoSitesNeedIt(
 
 	const appdata = await readAppdata();
 
-	for ( const site of appdata.sites ) {
-		if ( site.id !== stoppedSiteId && site.customDomain && ( await isServerRunning( site.id ) ) ) {
-			return;
-		}
+	const remainingSites = appdata.sites.filter(
+		( site ) => ! stoppedSiteIdsArray.includes( site.id )
+	);
+
+	// Filter to sites with custom domains that might need the proxy
+	const sitesWithCustomDomains = remainingSites.filter( ( site ) => site.customDomain );
+
+	const sitesStillRunning = await Promise.all(
+		sitesWithCustomDomains.map( ( site ) => isServerRunning( site.id ) )
+	);
+
+	if ( sitesStillRunning.some( ( isRunning ) => isRunning ) ) {
+		return;
 	}
 
 	logger.reportStart( LoggerAction.STOP_PROXY, __( 'Stopping HTTP proxy server...' ) );

--- a/common/logger-actions.ts
+++ b/common/logger-actions.ts
@@ -27,6 +27,7 @@ export enum SiteCommandLoggerAction {
 	REMOVE_DOMAIN_FROM_HOSTS = 'removeDomainFromHosts',
 	START_SITE = 'startSite',
 	STOP_SITE = 'stopSite',
+	STOP_ALL_SITES = 'stopAllSites',
 	VALIDATE = 'validate',
 	CREATE_DIRECTORY = 'createDirectory',
 	INSTALL_SQLITE = 'installSqlite',


### PR DESCRIPTION
## Related issues

- Fixes STU-1078

## Proposed Changes

Adds a new studio site stop-all CLI command that stops all running WordPress sites managed by Studio. The command includes graceful error handling, and continues stopping other sites even if some fail.

## Testing Instructions
1. `npm run cli:build`
2. Create 3 sites
3. `node dist/cli/main.js site list`
4. Assert that all of them are run
5. `node dist/cli/main.js site stop-all`
6. Assert that all of them are stopped
7. Run again `node dist/cli/main.js site stop-all`
8. Assert `No sites are currently running`
9. Start 1 site
10. `node dist/cli/main.js site stop-all`
11. Assert that you see the message that only one was stopped


