### PR TITLE
Bring back the Publish site button

### DIFF
--- a/src/components/publish-site-button.tsx
+++ b/src/components/publish-site-button.tsx
@@ -6,8 +6,7 @@ import { useAuth } from 'src/hooks/use-auth';
 import { useContentTabs } from 'src/hooks/use-content-tabs';
 import { useSiteDetails } from 'src/hooks/use-site-details';
 import { ConnectButton } from 'src/modules/sync/components/connect-button';
-import { useAppDispatch, useRootSelector } from 'src/stores';
-import { betaFeaturesSelectors } from 'src/stores/beta-features-slice';
+import { useAppDispatch } from 'src/stores';
 import {
 	connectedSitesActions,
 	useGetConnectedSitesForLocalSiteQuery,
@@ -25,9 +24,6 @@ export const PublishSiteButton = () => {
 	} );
 	const { isAnySitePulling, isAnySitePushing } = useSyncSites();
 	const isAnySiteSyncing = isAnySitePulling || isAnySitePushing;
-	const isPublishSiteEnabled = useRootSelector( ( state ) =>
-		betaFeaturesSelectors.selectBetaFeature( state, 'publishSite' )
-	);
 
 	const handlePublishClick = useCallback( () => {
 		if ( ! user ) {
@@ -37,7 +33,6 @@ export const PublishSiteButton = () => {
 		setSelectedTab( 'sync' );
 	}, [ user, setSelectedTab, dispatch, authenticate ] );
 
-	if ( ! isPublishSiteEnabled ) return null;
 	if ( connectedSites.length !== 0 ) return null;
 
 	return (

--- a/src/components/tests/site-management-actions.test.tsx
+++ b/src/components/tests/site-management-actions.test.tsx
@@ -8,7 +8,6 @@ import {
 import { SyncSitesProvider } from 'src/hooks/sync-sites';
 import { ContentTabsProvider } from 'src/hooks/use-content-tabs';
 import { store } from 'src/stores';
-import { setBetaFeatures } from 'src/stores/beta-features-slice';
 import { connectedSitesApi } from 'src/stores/sync/connected-sites';
 
 const mockGetConnectedWpcomSites = jest.fn();
@@ -109,17 +108,6 @@ describe( 'SiteManagementActions', () => {
 	} );
 
 	describe( 'PublishSiteButton', () => {
-		beforeEach( () => {
-			// Enable the publishSite beta feature for these tests
-			store.dispatch(
-				setBetaFeatures( {
-					studioSitesCli: false,
-					multiWorkerSupport: false,
-					publishSite: true,
-				} )
-			);
-		} );
-
 		it( 'should render "Publish site" button when no sites are connected', async () => {
 			renderWithProvider(
 				<SiteManagementActions

--- a/src/ipc-types.d.ts
+++ b/src/ipc-types.d.ts
@@ -84,7 +84,6 @@ interface FeatureFlags {
 interface BetaFeatures {
 	studioSitesCli: boolean;
 	multiWorkerSupport: boolean;
-	publishSite: boolean;
 }
 
 interface AppGlobals extends FeatureFlags {

--- a/src/lib/beta-features.ts
+++ b/src/lib/beta-features.ts
@@ -20,12 +20,6 @@ const BETA_FEATURES_DEFINITION: Record< keyof BetaFeatures, BetaFeatureDefinitio
 		default: false,
 		description: 'Enable multi-worker PHP processing for faster performance',
 	},
-	publishSite: {
-		label: 'Publish Site',
-		key: 'publishSite',
-		default: false,
-		description: 'Show the "Publish site" button to push local sites to WordPress.com',
-	},
 } as const;
 
 export const BETA_FEATURES: Record< keyof BetaFeatures, BetaFeatureDefinition > =

--- a/src/stores/beta-features-slice.ts
+++ b/src/stores/beta-features-slice.ts
@@ -11,7 +11,6 @@ const initialState: BetaFeaturesState = {
 	features: {
 		studioSitesCli: false,
 		multiWorkerSupport: false,
-		publishSite: false,
 	},
 	loading: false,
 };


### PR DESCRIPTION
I thought postpoining the Publish site button was a good idea, but we prefer to keep it in the release. See pdtkmj-4cM-p2#comment-8190 
Reverts Automattic/studio#2206

@katinthehatsite, sorry for the misdirection! 🙏 