### PR TITLE
Tweak the `--blueprint` option for the `studio site create` command

### DIFF
--- a/cli/commands/site/create.ts
+++ b/cli/commands/site/create.ts
@@ -1,5 +1,6 @@
 import crypto from 'crypto';
 import fs from 'fs';
+import os from 'os';
 import path from 'path';
 import { SupportedPHPVersions } from '@php-wasm/universal';
 import { __, sprintf } from '@wordpress/i18n';
@@ -23,6 +24,7 @@ import { lockAppdata, readAppdata, saveAppdata, SiteData, unlockAppdata } from '
 import { connect, disconnect } from 'cli/lib/pm2-manager';
 import { logSiteDetails, openSiteInBrowser, setupCustomDomain } from 'cli/lib/site-utils';
 import { installSqliteIntegration, isSqliteIntegrationAvailable } from 'cli/lib/sqlite-integration';
+import { untildify } from 'cli/lib/utils';
 import { runBlueprint, startWordPressServer } from 'cli/lib/wordpress-server-manager';
 import { Logger, LoggerError } from 'cli/logger';
 import { StudioArgv } from 'cli/types';
@@ -284,18 +286,18 @@ export const registerCommand = ( yargs: StudioArgv ) => {
 				let blueprintJson: unknown;
 
 				if ( argv.blueprint ) {
-					if ( ! fs.existsSync( argv.blueprint ) ) {
-						throw new LoggerError(
-							sprintf( __( 'Blueprint file not found: %s' ), argv.blueprint )
-						);
+					const blueprintPath = path.resolve( untildify( argv.blueprint ) );
+
+					if ( ! fs.existsSync( blueprintPath ) ) {
+						throw new LoggerError( sprintf( __( 'Blueprint file not found: %s' ), blueprintPath ) );
 					}
 
 					try {
-						const blueprintContent = fs.readFileSync( argv.blueprint, 'utf-8' );
+						const blueprintContent = fs.readFileSync( blueprintPath, 'utf-8' );
 						blueprintJson = JSON.parse( blueprintContent );
 					} catch ( error ) {
 						throw new LoggerError(
-							sprintf( __( 'Invalid blueprint JSON file: %s' ), argv.blueprint ),
+							sprintf( __( 'Invalid blueprint JSON file: %s' ), blueprintPath ),
 							error
 						);
 					}

--- a/cli/commands/site/create.ts
+++ b/cli/commands/site/create.ts
@@ -1,6 +1,5 @@
 import crypto from 'crypto';
 import fs from 'fs';
-import os from 'os';
 import path from 'path';
 import { SupportedPHPVersions } from '@php-wasm/universal';
 import { __, sprintf } from '@wordpress/i18n';
@@ -241,6 +240,38 @@ export async function runCommand(
 	}
 }
 
+async function fetchBlueprint( url: string ) {
+	const res = await fetch( url );
+
+	if ( ! res.ok ) {
+		throw new LoggerError( __( 'Failed to fetch blueprint' ) );
+	}
+
+	try {
+		return await res.json();
+	} catch ( error ) {
+		throw new LoggerError( __( 'Failed to parse blueprint JSON' ), error );
+	}
+}
+
+function readBlueprint( blueprintPath: string ) {
+	blueprintPath = path.resolve( untildify( blueprintPath ) );
+
+	if ( ! fs.existsSync( blueprintPath ) ) {
+		throw new LoggerError( sprintf( __( 'Blueprint file not found: %s' ), blueprintPath ) );
+	}
+
+	try {
+		const blueprintContent = fs.readFileSync( blueprintPath, 'utf-8' );
+		return JSON.parse( blueprintContent );
+	} catch ( error ) {
+		throw new LoggerError(
+			sprintf( __( 'Failed to parse blueprint JSON file: %s' ), blueprintPath ),
+			error
+		);
+	}
+}
+
 export const registerCommand = ( yargs: StudioArgv ) => {
 	return yargs.command( {
 		command: 'create',
@@ -273,7 +304,7 @@ export const registerCommand = ( yargs: StudioArgv ) => {
 				} )
 				.option( 'blueprint', {
 					type: 'string',
-					describe: __( 'Path to blueprint JSON file' ),
+					describe: __( 'Path or URL to blueprint JSON file' ),
 				} )
 				.option( 'start', {
 					type: 'boolean',
@@ -286,20 +317,10 @@ export const registerCommand = ( yargs: StudioArgv ) => {
 				let blueprintJson: unknown;
 
 				if ( argv.blueprint ) {
-					const blueprintPath = path.resolve( untildify( argv.blueprint ) );
-
-					if ( ! fs.existsSync( blueprintPath ) ) {
-						throw new LoggerError( sprintf( __( 'Blueprint file not found: %s' ), blueprintPath ) );
-					}
-
-					try {
-						const blueprintContent = fs.readFileSync( blueprintPath, 'utf-8' );
-						blueprintJson = JSON.parse( blueprintContent );
-					} catch ( error ) {
-						throw new LoggerError(
-							sprintf( __( 'Invalid blueprint JSON file: %s' ), blueprintPath ),
-							error
-						);
+					if ( /^https?:\/\//.test( argv.blueprint ) ) {
+						blueprintJson = await fetchBlueprint( argv.blueprint );
+					} else {
+						blueprintJson = readBlueprint( argv.blueprint );
 					}
 				}
 

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -24,6 +24,7 @@ import { registerCommand as registerSiteStopCommand } from 'cli/commands/site/st
 import { readAppdata } from 'cli/lib/appdata';
 import { loadTranslations } from 'cli/lib/i18n';
 import { bumpAggregatedUniqueStat } from 'cli/lib/stats';
+import { untildify } from 'cli/lib/utils';
 import { version } from 'cli/package.json';
 import { StudioArgv } from 'cli/types';
 
@@ -48,10 +49,7 @@ async function main() {
 			defaultDescription: __( 'Current directory' ),
 			description: __( 'Path to the WordPress files' ),
 			coerce: ( value ) => {
-				if ( process.platform !== 'win32' ) {
-					value = value.replace( /^~/, os.homedir() );
-				}
-				return path.resolve( value );
+				return path.resolve( untildify( value ) );
 			},
 		} )
 		.middleware( async ( argv ) => {

--- a/cli/lib/utils.ts
+++ b/cli/lib/utils.ts
@@ -15,5 +15,14 @@ export function getColumnWidths( widthFactors: number[] ) {
 }
 
 export function getPrettyPath( path: string ): string {
-	return path.replace( process.cwd(), '.' ).replace( os.homedir(), '~' );
+	return process.platform === 'win32'
+		? path
+		: path.replace( process.cwd(), '.' ).replace( os.homedir(), '~' );
+}
+
+// `~` is a shell construct on Posix platforms. The shell expands it to the user's home directory
+// if it's at the beginning of a word, like this: `--path ~/test`. If users specify an option like
+// this: `--path=~/test`, then it's not expanded, and we need to do it in code.
+export function untildify( path: string ): string {
+	return process.platform === 'win32' ? path : path.replace( /^~/, os.homedir() );
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-1094
- Fixes STU-1102

## Proposed Changes

- Expand tilde signs `~` for the `--blueprint` option to the `site create` command in the same way as we do for the global `--path` option (see #2204)
- Support fetching blueprints over HTTP

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Run `npm run cli:build`
2. Run `node dist/cli/main.js site create --blueprint https://blueprintlibrary.wordpress.com/?blueprint=534 --path PATH_TO_NEW_SITE`
3. Ensure that the site is successfully created
4. Download the https://blueprintlibrary.wordpress.com/?blueprint=534 blueprint to `~/blueprint.json`
5. Run `node dist/cli/main.js site create --blueprint=~/blueprint.json --path SECOND_PATH_TO_NEW_SITE`
6. Ensure that the site is successfully created

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
