### PR TITLE
`--https` option to `studio site create` implies `--domain`

### DIFF
--- a/cli/commands/site/create.ts
+++ b/cli/commands/site/create.ts
@@ -267,7 +267,7 @@ export const registerCommand = ( yargs: StudioArgv ) => {
 				.option( 'https', {
 					type: 'boolean',
 					describe: __( 'Enable HTTPS for custom domain' ),
-					default: false,
+					implies: 'domain',
 				} )
 				.option( 'blueprint', {
 					type: 'string',
@@ -306,7 +306,7 @@ export const registerCommand = ( yargs: StudioArgv ) => {
 					wpVersion: argv.wp,
 					phpVersion: argv.php,
 					customDomain: argv.domain,
-					enableHttps: argv.https,
+					enableHttps: !! argv.https,
 					blueprintJson: blueprintJson,
 					noStart: ! argv.start,
 				} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-1089

## Proposed Changes

- Passing the `--https` option to `studio site create` now throws an error if `--domain` isn't also specified

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Run `npm run cli:build`
2. Run `node dist/cli/main.js site create --https --path PATH_TO_NEW_SITE`
3. Ensure that an error is printed

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
