### PR TITLE
Reset file import state on `Add site` modal close

### DIFF
--- a/src/modules/add-site/index.tsx
+++ b/src/modules/add-site/index.tsx
@@ -586,7 +586,8 @@ export default function AddSiteModal( { className }: AddSiteModalProps ) {
 		setSelectedBlueprint( undefined );
 		setBlueprintPreferredVersions( undefined );
 		setBlueprintDeeplinkWarnings( undefined );
-	}, [ setSelectedBlueprint ] );
+		addSiteProps.setFileForImport( null );
+	}, [ setSelectedBlueprint, addSiteProps ] );
 
 	const handleSiteAdded = useCallback( () => {
 		closeModal();

--- a/src/modules/add-site/index.tsx
+++ b/src/modules/add-site/index.tsx
@@ -558,7 +558,8 @@ export default function AddSiteModal( { className }: AddSiteModalProps ) {
 	const { importState } = useImportExport();
 
 	const addSiteProps = useAddSite();
-	const { sites, setSelectedBlueprint, setPhpVersion, setWpVersion } = addSiteProps;
+	const { sites, setSelectedBlueprint, setPhpVersion, setWpVersion, setFileForImport } =
+		addSiteProps;
 
 	const [ blueprintPreferredVersions, setBlueprintPreferredVersions ] = useState<
 		{ php?: string; wp?: string } | undefined
@@ -586,8 +587,8 @@ export default function AddSiteModal( { className }: AddSiteModalProps ) {
 		setSelectedBlueprint( undefined );
 		setBlueprintPreferredVersions( undefined );
 		setBlueprintDeeplinkWarnings( undefined );
-		addSiteProps.setFileForImport( null );
-	}, [ setSelectedBlueprint, addSiteProps ] );
+		setFileForImport( null );
+	}, [ setSelectedBlueprint, setFileForImport ] );
 
 	const handleSiteAdded = useCallback( () => {
 		closeModal();


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- related discussion: p1765213216265759/1765198096.499159-slack-C06DRMD6VPZ
- fixes STU-1117

## Proposed Changes

- reset file import state on `Add site` modal close

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR branch and build the app with `npm install && npm start`.
2. Click the `Add site` button to open the modal and select "Import from a backup" option.
3. Select a backup file.
4. Close modal or progress with site creation.
5. Open the modal by clicking on the `Add site` button again.
6. If you select the "Import from a backup" option, the old file should not be selected there anymore.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?