### PR TITLE
Fix broken CLI on Windows

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -10,15 +10,7 @@ import { registerCommand as registerCreateCommand } from 'cli/commands/preview/c
 import { registerCommand as registerDeleteCommand } from 'cli/commands/preview/delete';
 import { registerCommand as registerListCommand } from 'cli/commands/preview/list';
 import { registerCommand as registerUpdateCommand } from 'cli/commands/preview/update';
-import { registerCommand as registerSiteCreateCommand } from 'cli/commands/site/create';
-import { registerCommand as registerSiteDeleteCommand } from 'cli/commands/site/delete';
 import { registerCommand as registerSiteListCommand } from 'cli/commands/site/list';
-import { registerCommand as registerSiteSetDomainCommand } from 'cli/commands/site/set-domain';
-import { registerCommand as registerSiteSetHttpsCommand } from 'cli/commands/site/set-https';
-import { registerCommand as registerSiteSetPhpVersionCommand } from 'cli/commands/site/set-php-version';
-import { registerCommand as registerSiteStartCommand } from 'cli/commands/site/start';
-import { registerCommand as registerSiteStatusCommand } from 'cli/commands/site/status';
-import { registerCommand as registerSiteStopCommand } from 'cli/commands/site/stop';
 import { readAppdata } from 'cli/lib/appdata';
 import { loadTranslations } from 'cli/lib/i18n';
 import { bumpAggregatedUniqueStat } from 'cli/lib/stats';

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -1,4 +1,3 @@
-import 'cli/polyfills/browser-globals.js';
 import path from 'node:path';
 import { __ } from '@wordpress/i18n';
 import { suppressPunycodeWarning } from 'common/lib/suppress-punycode-warning';

--- a/src/modules/cli/lib/execute-preview-command.ts
+++ b/src/modules/cli/lib/execute-preview-command.ts
@@ -57,6 +57,13 @@ export async function executePreviewCliCommand(
 		} );
 	} );
 
+	cliEventEmitter.on( 'failure', () => {
+		sendIpcEventToRendererWithWindow( parentWindow, 'snapshot-fatal-error', {
+			operationId,
+			data: { message: 'Unknown error' },
+		} );
+	} );
+
 	cliEventEmitter.on( 'success', () => {
 		sendIpcEventToRendererWithWindow( parentWindow, 'snapshot-success', {
 			operationId,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Related to p1765274799851279/1765198096.499159-slack-C06DRMD6VPZ

## Proposed Changes

After upgrading yargs to v18, there's some logic in that module that breaks the Studio CLI on Windows. This happens because `cli/polyfills/browser-globals.js` sets a global `document` object, which leads yargs to think we're in a browser context. 

This PR removes that import (and a bunch of unused imports), which fixes the problem. I didn't notice any side effects, but we're also not sure exactly why @bcotrim had to add it in the first place.

Moreover, Studio didn't display any feedback to users when the CLI failed to start on Windows. I added a `failure` event listener to address this.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Run `npm run cli:build` on Windows
2. Run `node dist\cli\main.js`
3. Ensure that a help page is printed

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?