### PR TITLE
Studio: Improve plans modal in the pull during existing site creation flow

### DIFF
--- a/src/modules/add-site/components/pull-remote-site.tsx
+++ b/src/modules/add-site/components/pull-remote-site.tsx
@@ -9,12 +9,11 @@ import { ArrowIcon } from 'src/components/arrow-icon';
 import Button from 'src/components/button';
 import offlineIcon from 'src/components/offline-icon';
 import { Tooltip } from 'src/components/tooltip';
-import { WordPressShortLogo } from 'src/components/wordpress-short-logo';
 import { useAuth } from 'src/hooks/use-auth';
 import { useOffline } from 'src/hooks/use-offline';
 import { useSiteDetails } from 'src/hooks/use-site-details';
 import { getIpcApi } from 'src/lib/get-ipc-api';
-import { CreateButton } from 'src/modules/sync/components/create-button';
+import { NoWpcomSitesContent } from 'src/modules/sync/components/no-wpcom-sites-content';
 import { SitesListContent } from 'src/modules/sync/components/sync-sites-modal-selector';
 import { SyncTabImage } from 'src/modules/sync/components/sync-tab-image';
 import { useGetConnectedSitesForLocalSiteQuery } from 'src/stores/sync/connected-sites';
@@ -62,34 +61,9 @@ function NoWpcomSitesView() {
 
 	return (
 		<div className="p-8 pt-16 flex">
-			<div className="flex flex-col">
-				<div className="flex items-center mb-1">
-					<div className="a8c-subtitle text-pretty">{ __( 'Find a perfect plan' ) }</div>
-				</div>
-				<div className="max-w-[40ch] text-a8c-gray-70 a8c-body">
-					{ __( 'Unlock the power of WordPress and share your work with the world with' ) }{ ' ' }
-					<WordPressShortLogo className="inline-block h-4 align-middle" />
-				</div>
-				<div className="mt-6">
-					{ [
-						__( 'Push and pull changes from your live site.' ),
-						__( 'Supports staging and production sites.' ),
-						__( 'Sync database and files.' ),
-					].map( ( text ) => (
-						<div key={ text } className="text-a8c-gray-70 a8c-body flex items-center">
-							<Icon className="fill-a8c-blue-50 me-2 shrink-0" icon={ check } />
-							{ text }
-						</div>
-					) ) }
-				</div>
-				<div className="mt-8">
-					<CreateButton
-						variant="primary"
-						selectedSite={ undefined }
-						text={ __( 'Choose a plan to publish your site' ) }
-						className="!text-white !shadow-a8c-blue-50"
-					/>
-				</div>
+			<div className="flex flex-col gap-6">
+				<div className="a8c-subtitle text-pretty">{ __( 'Find a perfect plan' ) }</div>
+				<NoWpcomSitesContent buttonClassName="!text-white !shadow-a8c-blue-50 mt-2" />
 			</div>
 			<div className="flex flex-col shrink-0 items-end">
 				<SyncTabImage />

--- a/src/modules/add-site/components/pull-remote-site.tsx
+++ b/src/modules/add-site/components/pull-remote-site.tsx
@@ -5,6 +5,7 @@ import {
 import { check, Icon } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { PropsWithChildren } from 'react';
+import { NoWpcomSitesContent } from 'src/modules/sync/components/no-wpcom-sites-content';
 import { ArrowIcon } from 'src/components/arrow-icon';
 import Button from 'src/components/button';
 import offlineIcon from 'src/components/offline-icon';
@@ -13,7 +14,6 @@ import { useAuth } from 'src/hooks/use-auth';
 import { useOffline } from 'src/hooks/use-offline';
 import { useSiteDetails } from 'src/hooks/use-site-details';
 import { getIpcApi } from 'src/lib/get-ipc-api';
-import { NoWpcomSitesContent } from 'src/modules/sync/components/no-wpcom-sites-content';
 import { SitesListContent } from 'src/modules/sync/components/sync-sites-modal-selector';
 import { SyncTabImage } from 'src/modules/sync/components/sync-tab-image';
 import { useGetConnectedSitesForLocalSiteQuery } from 'src/stores/sync/connected-sites';
@@ -60,7 +60,7 @@ function NoWpcomSitesView() {
 	const { __ } = useI18n();
 
 	return (
-		<div className="p-8 pt-16 flex">
+		<div className="p-8 flex">
 			<div className="flex flex-col gap-6">
 				<div className="a8c-subtitle text-pretty">{ __( 'Find a perfect plan' ) }</div>
 				<NoWpcomSitesContent buttonClassName="!text-white !shadow-a8c-blue-50 mt-2" />

--- a/src/modules/add-site/components/pull-remote-site.tsx
+++ b/src/modules/add-site/components/pull-remote-site.tsx
@@ -5,7 +5,6 @@ import {
 import { check, Icon } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { PropsWithChildren } from 'react';
-import { NoWpcomSitesContent } from 'src/modules/sync/components/no-wpcom-sites-content';
 import { ArrowIcon } from 'src/components/arrow-icon';
 import Button from 'src/components/button';
 import offlineIcon from 'src/components/offline-icon';
@@ -14,6 +13,7 @@ import { useAuth } from 'src/hooks/use-auth';
 import { useOffline } from 'src/hooks/use-offline';
 import { useSiteDetails } from 'src/hooks/use-site-details';
 import { getIpcApi } from 'src/lib/get-ipc-api';
+import { NoWpcomSitesContent } from 'src/modules/sync/components/no-wpcom-sites-content';
 import { SitesListContent } from 'src/modules/sync/components/sync-sites-modal-selector';
 import { SyncTabImage } from 'src/modules/sync/components/sync-tab-image';
 import { useGetConnectedSitesForLocalSiteQuery } from 'src/stores/sync/connected-sites';

--- a/src/modules/add-site/components/pull-remote-site.tsx
+++ b/src/modules/add-site/components/pull-remote-site.tsx
@@ -4,16 +4,17 @@ import {
 } from '@wordpress/components';
 import { check, Icon } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
-import { PropsWithChildren, useState } from 'react';
+import { PropsWithChildren } from 'react';
 import { ArrowIcon } from 'src/components/arrow-icon';
 import Button from 'src/components/button';
 import offlineIcon from 'src/components/offline-icon';
 import { Tooltip } from 'src/components/tooltip';
+import { WordPressShortLogo } from 'src/components/wordpress-short-logo';
 import { useAuth } from 'src/hooks/use-auth';
 import { useOffline } from 'src/hooks/use-offline';
 import { useSiteDetails } from 'src/hooks/use-site-details';
 import { getIpcApi } from 'src/lib/get-ipc-api';
-import { NoWpcomSitesModal } from 'src/modules/sync/components/no-wpcom-sites-modal';
+import { CreateButton } from 'src/modules/sync/components/create-button';
 import { SitesListContent } from 'src/modules/sync/components/sync-sites-modal-selector';
 import { SyncTabImage } from 'src/modules/sync/components/sync-tab-image';
 import { useGetConnectedSitesForLocalSiteQuery } from 'src/stores/sync/connected-sites';
@@ -48,6 +49,47 @@ function SiteSyncDescription( { children }: PropsWithChildren ) {
 					) ) }
 				</div>
 				{ children }
+			</div>
+			<div className="flex flex-col shrink-0 items-end">
+				<SyncTabImage />
+			</div>
+		</div>
+	);
+}
+
+function NoWpcomSitesView() {
+	const { __ } = useI18n();
+
+	return (
+		<div className="p-8 pt-16 flex">
+			<div className="flex flex-col">
+				<div className="flex items-center mb-1">
+					<div className="a8c-subtitle text-pretty">{ __( 'Find a perfect plan' ) }</div>
+				</div>
+				<div className="max-w-[40ch] text-a8c-gray-70 a8c-body">
+					{ __( 'Unlock the power of WordPress and share your work with the world with' ) }{ ' ' }
+					<WordPressShortLogo className="inline-block h-4 align-middle" />
+				</div>
+				<div className="mt-6">
+					{ [
+						__( 'Push and pull changes from your live site.' ),
+						__( 'Supports staging and production sites.' ),
+						__( 'Sync database and files.' ),
+					].map( ( text ) => (
+						<div key={ text } className="text-a8c-gray-70 a8c-body flex items-center">
+							<Icon className="fill-a8c-blue-50 me-2 shrink-0" icon={ check } />
+							{ text }
+						</div>
+					) ) }
+				</div>
+				<div className="mt-8">
+					<CreateButton
+						variant="primary"
+						selectedSite={ undefined }
+						text={ __( 'Choose a plan to publish your site' ) }
+						className="!text-white !shadow-a8c-blue-50"
+					/>
+				</div>
 			</div>
 			<div className="flex flex-col shrink-0 items-end">
 				<SyncTabImage />
@@ -121,7 +163,6 @@ export function PullRemoteSite( {
 } ) {
 	const { __ } = useI18n();
 	const { isAuthenticated, user } = useAuth();
-	const [ isNoWpcomSitesModalClosed, setIsNoWpcomSitesModalClosed ] = useState( false );
 
 	const { selectedSite } = useSiteDetails();
 	const { data: connectedSites = [] } = useGetConnectedSitesForLocalSiteQuery( {
@@ -141,6 +182,9 @@ export function PullRemoteSite( {
 		{ refetchOnMountOrArgChange: true }
 	);
 
+	const hasSites = syncSites.length > 0;
+	const showNoSitesView = ! hasSites && isSuccess && ! isLoading;
+
 	const handleSiteSelect = ( siteId: number ) => {
 		const site = syncSites.find( ( s ) => s.id === siteId );
 		setSelectedRemoteSite( site );
@@ -153,19 +197,16 @@ export function PullRemoteSite( {
 			</Heading>
 			{ isAuthenticated ? (
 				<VStack className="flex flex-col w-full max-w-[650px] flex-1 text-a8c-gray-900">
-					<SitesListContent
-						isLoading={ isLoading }
-						syncSites={ syncSites }
-						selectedSiteId={ selectedRemoteSite?.id || null }
-						onSelectSite={ handleSiteSelect }
-					/>
-
-					{ syncSites.length === 0 && isSuccess && ! isLoading && ! isNoWpcomSitesModalClosed && (
-						<NoWpcomSitesModal
-							onRequestClose={ () => setIsNoWpcomSitesModalClosed( true ) }
-							selectedSite={ undefined }
+					{ hasSites && (
+						<SitesListContent
+							isLoading={ isLoading }
+							syncSites={ syncSites }
+							selectedSiteId={ selectedRemoteSite?.id || null }
+							onSelectSite={ handleSiteSelect }
 						/>
 					) }
+
+					{ showNoSitesView && <NoWpcomSitesView /> }
 				</VStack>
 			) : (
 				<NoAuthPullRemoteSiteView />

--- a/src/modules/sync/components/no-wpcom-sites-content.tsx
+++ b/src/modules/sync/components/no-wpcom-sites-content.tsx
@@ -1,0 +1,48 @@
+import { Icon, check } from '@wordpress/icons';
+import { useI18n } from '@wordpress/react-i18n';
+import { WordPressShortLogo } from 'src/components/wordpress-short-logo';
+import { CreateButton } from 'src/modules/sync/components/create-button';
+
+interface NoWpcomSitesContentProps {
+	selectedSite?: SiteDetails;
+	onButtonClick?: () => void;
+	buttonClassName?: string;
+}
+
+export function NoWpcomSitesContent( {
+	selectedSite,
+	onButtonClick,
+	buttonClassName,
+}: NoWpcomSitesContentProps ) {
+	const { __ } = useI18n();
+
+	const features = [
+		__( 'Push and pull changes from your live site.' ),
+		__( 'Supports staging and production sites.' ),
+		__( 'Sync database and files.' ),
+	];
+
+	return (
+		<>
+			<div className="text-a8c-gray-70 a8c-body">
+				{ __( 'Unlock the power of WordPress and share your work with the world with' ) }{ ' ' }
+				<WordPressShortLogo className="inline-block h-4 align-middle" />
+			</div>
+			<div>
+				{ features.map( ( text ) => (
+					<div key={ text } className="text-a8c-gray-70 a8c-body flex items-center">
+						<Icon className="fill-a8c-blue-50 me-2 shrink-0" icon={ check } />
+						{ text }
+					</div>
+				) ) }
+			</div>
+			<CreateButton
+				variant="primary"
+				selectedSite={ selectedSite }
+				text={ __( 'Choose a plan to publish your site' ) }
+				onClick={ onButtonClick }
+				className={ buttonClassName }
+			/>
+		</>
+	);
+}

--- a/src/modules/sync/components/no-wpcom-sites-modal.tsx
+++ b/src/modules/sync/components/no-wpcom-sites-modal.tsx
@@ -1,8 +1,6 @@
-import { Icon, check } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import Modal from 'src/components/modal';
-import { WordPressShortLogo } from 'src/components/wordpress-short-logo';
-import { CreateButton } from 'src/modules/sync/components/create-button';
+import { NoWpcomSitesContent } from 'src/modules/sync/components/no-wpcom-sites-content';
 
 interface NoWpcomSitesModalProps {
 	onRequestClose: () => void;
@@ -19,31 +17,11 @@ export function NoWpcomSitesModal( { onRequestClose, selectedSite }: NoWpcomSite
 			title={ __( 'Find a perfect plan' ) }
 		>
 			<div className="flex flex-col gap-4">
-				<div className="text-a8c-gray-70 a8c-body">
-					{ __( 'Unlock the power of WordPress and share your work with the world with' ) }
-					<WordPressShortLogo className="inline-block h-4 align-middle" />
-				</div>
-				<div>
-					{ [
-						__( 'Push and pull changes from your live site.' ),
-						__( 'Supports staging and production sites.' ),
-						__( 'Sync database and files.' ),
-					].map( ( text ) => (
-						<div key={ text } className="text-a8c-gray-70 a8c-body flex items-center">
-							<Icon className="fill-a8c-blue-50 me-2 shrink-0" icon={ check } />
-							{ text }
-						</div>
-					) ) }
-				</div>
-				<div className="flex justify-center gap-4">
-					<CreateButton
-						variant="primary"
-						selectedSite={ selectedSite }
-						text={ __( 'Choose a plan to publish your site' ) }
-						onClick={ onRequestClose }
-						className="w-full !text-white !shadow-a8c-blue-50"
-					/>
-				</div>
+				<NoWpcomSitesContent
+					selectedSite={ selectedSite }
+					onButtonClick={ onRequestClose }
+					buttonClassName="w-full !text-white !shadow-a8c-blue-50"
+				/>
 			</div>
 		</Modal>
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

Fixes STU-1113

## Proposed Changes

This PR embeds the content for NoWPcomSite modal directly into `Add site` > `Pull an existing site` screen when the user does not have any sites on WP.com:

<img width="1064" height="804" alt="Screenshot 2025-12-09 at 12 08 54 PM" src="https://github.com/user-attachments/assets/33b68649-d248-4665-a68d-609564009bad" />

Currently, when you navigate to  `Add site` > `Pull an existing site` and have no sites, you see the following view:

<img width="678" height="458" alt="Screenshot 2025-12-09 at 12 12 28 PM" src="https://github.com/user-attachments/assets/23c7584c-2f79-4db3-9004-fb22b9a143d2" />

There are two issues with this implementation:

* The modal is dismissible so when you dismiss it, you are stuck with the search bar on the screen with no sites and no actions that you can take from there
* It also doesn't make sense to have to have the search bar behind the modal

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
* Apply the following diff:

```diff --git a/src/stores/sync/wpcom-sites.ts b/src/stores/sync/wpcom-sites.ts
index dbf92f16..903f078c 100644
--- a/src/stores/sync/wpcom-sites.ts
+++ b/src/stores/sync/wpcom-sites.ts
@@ -123,6 +123,9 @@ export const wpcomSitesApi = createApi( {
                                        return { error: { status: 401, data: 'Not authenticated' } };
                                }
 
+                               return { data: [] };
+
                                try {
                                        const allConnectedSites = await getIpcApi().getConnectedWpcomSites();
```
* Start the app with `npm start`
* Click on `Add site` in the sidebar
* Open the `Pull an exisiting site` option
* Confirm that you can see the view from the screenshot above (modal content embedded)
* Test with a real account with no sites and confirm you can see the correct modal

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
