### PR TITLE
E2E: remove backward compatibility for onboarding header

### DIFF
--- a/e2e/page-objects/onboarding.ts
+++ b/e2e/page-objects/onboarding.ts
@@ -11,11 +11,7 @@ export default class Onboarding {
 	}
 
 	get heading() {
-		return this.locator.getByTestId( 'onboarding-welcome-title' ).or(
-			this.locator.getByRole( 'heading', {
-				name: /Connect to your WordPress\.com account|Connect your WordPress\.com account/,
-			} )
-		);
+		return this.locator.getByTestId( 'onboarding-welcome-title' );
 	}
 
 	async completeOnboarding( options?: { customSiteName?: string; customFolderName?: string } ) {


### PR DESCRIPTION
## Proposed Changes
Previously, we added this `.or()` when we introduced `id` for the onboarding header. Now it looks like perfect time to remove it and at teh same time point the new commit hash for comparison Performance metrics in `trunk` tests (after mergign PRs to trunk)- https://github.com/Automattic/studio/pull/2224

# Testing instructions
Tests should be green