### PR TITLE
Clean setSelectedRemoteSite when closing modal

### DIFF
--- a/src/modules/add-site/index.tsx
+++ b/src/modules/add-site/index.tsx
@@ -558,8 +558,14 @@ export default function AddSiteModal( { className }: AddSiteModalProps ) {
 	const { importState } = useImportExport();
 
 	const addSiteProps = useAddSite();
-	const { sites, setSelectedBlueprint, setPhpVersion, setWpVersion, setFileForImport } =
-		addSiteProps;
+	const {
+		sites,
+		setSelectedBlueprint,
+		setPhpVersion,
+		setWpVersion,
+		setFileForImport,
+		setSelectedRemoteSite,
+	} = addSiteProps;
 
 	const [ blueprintPreferredVersions, setBlueprintPreferredVersions ] = useState<
 		{ php?: string; wp?: string } | undefined
@@ -588,7 +594,8 @@ export default function AddSiteModal( { className }: AddSiteModalProps ) {
 		setBlueprintPreferredVersions( undefined );
 		setBlueprintDeeplinkWarnings( undefined );
 		setFileForImport( null );
-	}, [ setSelectedBlueprint, setFileForImport ] );
+		setSelectedRemoteSite( undefined );
+	}, [ setSelectedBlueprint, setFileForImport, setSelectedRemoteSite ] );
 
 	const handleSiteAdded = useCallback( () => {
 		closeModal();


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-1121
- Similar fix to https://github.com/Automattic/studio/pull/2220
- We made the AddSite state persistent, even if the modal closes or unmounts in https://github.com/Automattic/studio/pull/2201

## Proposed Changes

- Clean the selected remote site after closing the modal to fix the issue where new created sites were pulling without selecting that path.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run `npm start`
- Click on `Add site`
- Select Pull an existing site
- Finish the process
- Click on Add site again
- Select a blank site
- Observe it creates a blank site and it doesn't pull anything

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
