### PR TITLE
Refactor useAddSite reset form and simplify the state

### DIFF
--- a/src/hooks/use-add-site.ts
+++ b/src/hooks/use-add-site.ts
@@ -81,6 +81,24 @@ export function useAddSite( options: UseAddSiteOptions = {} ) {
 		navigateToBlueprintDeeplink: () => setIsDeeplinkFlow( true ),
 	} );
 
+	const resetForm = useCallback( () => {
+		setSitePath( '' );
+		setError( '' );
+		setDoesPathContainWordPress( false );
+		setWpVersion( defaultWordPressVersion );
+		setPhpVersion( defaultPhpVersion );
+		setUseCustomDomain( false );
+		setCustomDomain( null );
+		setCustomDomainError( '' );
+		setEnableHttps( false );
+		setFileForImport( null );
+		setSelectedBlueprint( undefined );
+		setBlueprintPreferredVersions( undefined );
+		setBlueprintDeeplinkWarnings( undefined );
+		setSelectedRemoteSite( undefined );
+		clearDeeplinkState();
+	}, [ clearDeeplinkState, defaultPhpVersion, defaultWordPressVersion ] );
+
 	const loadAllCustomDomains = useCallback( () => {
 		getIpcApi()
 			.getAllCustomDomains()
@@ -256,6 +274,7 @@ export function useAddSite( options: UseAddSiteOptions = {} ) {
 
 	return useMemo( () => {
 		return {
+			resetForm,
 			handleAddSiteClick,
 			handlePathSelectorClick,
 			handleSiteNameChange,
@@ -300,6 +319,7 @@ export function useAddSite( options: UseAddSiteOptions = {} ) {
 			clearDeeplinkState,
 		};
 	}, [
+		resetForm,
 		doesPathContainWordPress,
 		error,
 		handleAddSiteClick,

--- a/src/hooks/use-add-site.ts
+++ b/src/hooks/use-add-site.ts
@@ -27,7 +27,7 @@ interface UseAddSiteOptions {
 export function useAddSite( options: UseAddSiteOptions = {} ) {
 	const { openModal = () => {} } = options;
 	const { __ } = useI18n();
-	const { createSite, sites, loadingSites, startServer } = useSiteDetails();
+	const { createSite, sites, startServer } = useSiteDetails();
 	const { importFile, clearImportState, importState } = useImportExport();
 	const [ connectSite ] = useConnectSiteMutation();
 	const { pullSite } = useSyncSites();
@@ -288,8 +288,6 @@ export function useAddSite( options: UseAddSiteOptions = {} ) {
 			setSitePath,
 			setError,
 			setDoesPathContainWordPress,
-			sites,
-			loadingSites,
 			fileForImport,
 			setFileForImport,
 			phpVersion,
@@ -328,8 +326,6 @@ export function useAddSite( options: UseAddSiteOptions = {} ) {
 		siteName,
 		sitePath,
 		proposedSitePath,
-		sites,
-		loadingSites,
 		fileForImport,
 		phpVersion,
 		wpVersion,

--- a/src/modules/add-site/index.tsx
+++ b/src/modules/add-site/index.tsx
@@ -313,14 +313,14 @@ export interface AddSiteModalContentProps {
 	isOpen?: boolean;
 	onSubmit?: () => void;
 	className?: string;
-	addSiteProps?: ReturnType< typeof useAddSite >;
+	addSiteProps: ReturnType< typeof useAddSite >;
 }
 
 export function AddSiteModalContent( {
 	isOpen = true,
 	onSubmit,
 	className,
-	addSiteProps: externalAddSiteProps,
+	addSiteProps,
 }: AddSiteModalContentProps ) {
 	const { __ } = useI18n();
 	const [ nameSuggested, setNameSuggested ] = useState( false );
@@ -332,9 +332,6 @@ export function AddSiteModalContent( {
 		isLoading: isLoadingBlueprints,
 		error: blueprintsError,
 	} = useGetBlueprints();
-
-	const localAddSiteProps = useAddSite();
-	const addSiteProps = externalAddSiteProps ?? localAddSiteProps;
 
 	const {
 		handleAddSiteClick,

--- a/src/modules/add-site/index.tsx
+++ b/src/modules/add-site/index.tsx
@@ -13,11 +13,7 @@ import { getIpcApi } from 'src/lib/get-ipc-api';
 import { SyncSite } from 'src/modules/sync/types';
 import { useRootSelector } from 'src/stores';
 import { formatRtkError } from 'src/stores/format-rtk-error';
-import {
-	selectDefaultPhpVersion,
-	selectDefaultWordPressVersion,
-	selectMinimumWordPressVersion,
-} from 'src/stores/provider-constants-slice';
+import { selectMinimumWordPressVersion } from 'src/stores/provider-constants-slice';
 import { useGetWordPressVersions } from 'src/stores/wordpress-versions-api';
 import { useGetBlueprints, Blueprint } from 'src/stores/wpcom-api';
 import BlueprintDeeplink from './components/blueprint-deeplink';
@@ -324,8 +320,6 @@ export function AddSiteModalContent( {
 }: AddSiteModalContentProps ) {
 	const { __ } = useI18n();
 	const [ nameSuggested, setNameSuggested ] = useState( false );
-	const defaultPhpVersion = useRootSelector( selectDefaultPhpVersion );
-	const defaultWordPressVersion = useRootSelector( selectDefaultWordPressVersion );
 
 	const {
 		data: blueprintsData,
@@ -337,19 +331,11 @@ export function AddSiteModalContent( {
 		handleAddSiteClick,
 		siteName,
 		setSiteName,
-		setPhpVersion,
 		setWpVersion,
 		setProposedSitePath,
-		setSitePath,
-		setError,
 		setDoesPathContainWordPress,
 		loadingSites,
 		sites,
-		setUseCustomDomain,
-		setCustomDomain,
-		setCustomDomainError,
-		setEnableHttps,
-		setFileForImport,
 		loadAllCustomDomains,
 		selectedBlueprint,
 		setSelectedBlueprint,
@@ -358,10 +344,8 @@ export function AddSiteModalContent( {
 		blueprintPreferredVersions,
 		setBlueprintPreferredVersions,
 		blueprintDeeplinkWarnings,
-		setBlueprintDeeplinkWarnings,
 		isDeeplinkFlow,
 		setIsDeeplinkFlow,
-		clearDeeplinkState,
 	} = addSiteProps;
 
 	const minimumWordPressVersion = useRootSelector( selectMinimumWordPressVersion );
@@ -369,39 +353,6 @@ export function AddSiteModalContent( {
 		minimumVersion: minimumWordPressVersion,
 	} );
 	const latestStableVersion = versions.find( ( version ) => version.value === 'latest' );
-
-	const resetForm = useCallback( () => {
-		setNameSuggested( false );
-		setSitePath( '' );
-		setDoesPathContainWordPress( false );
-		setWpVersion( defaultWordPressVersion );
-		setPhpVersion( defaultPhpVersion );
-		setUseCustomDomain( false );
-		setCustomDomain( null );
-		setCustomDomainError( '' );
-		setEnableHttps( false );
-		setFileForImport( null );
-		setSelectedBlueprint( undefined );
-		setBlueprintPreferredVersions( undefined );
-		setBlueprintDeeplinkWarnings( undefined );
-		setSelectedRemoteSite( undefined );
-	}, [
-		setSitePath,
-		setDoesPathContainWordPress,
-		setPhpVersion,
-		setWpVersion,
-		setUseCustomDomain,
-		setCustomDomain,
-		setCustomDomainError,
-		setEnableHttps,
-		setFileForImport,
-		setSelectedBlueprint,
-		setSelectedRemoteSite,
-		setBlueprintPreferredVersions,
-		setBlueprintDeeplinkWarnings,
-		defaultWordPressVersion,
-		defaultPhpVersion,
-	] );
 
 	const initialNavigatorPath = selectedBlueprint ? '/blueprint/deeplink' : '/';
 
@@ -421,16 +372,12 @@ export function AddSiteModalContent( {
 		setNameSuggested( true );
 		setSiteName( name );
 		setProposedSitePath( path );
-		setSitePath( '' );
-		setError( '' );
 		setDoesPathContainWordPress( isWordPress );
 		loadAllCustomDomains();
 	}, [
 		sites,
 		setSiteName,
 		setProposedSitePath,
-		setSitePath,
-		setError,
 		setDoesPathContainWordPress,
 		setWpVersion,
 		latestStableVersion,
@@ -443,23 +390,15 @@ export function AddSiteModalContent( {
 		}
 	}, [ isOpen, nameSuggested, loadingSites, initializeForm ] );
 
-	// Reset form when closed
-	useEffect( () => {
-		if ( ! isOpen ) {
-			resetForm();
-		}
-	}, [ isOpen, resetForm ] );
-
 	const handleSubmit = useCallback(
 		async ( event: FormEvent ) => {
 			event.preventDefault();
 			onSubmit?.();
 			await handleAddSiteClick();
-			clearDeeplinkState();
 			speak( siteAddedMessage );
 			setNameSuggested( false );
 		},
-		[ handleAddSiteClick, siteAddedMessage, onSubmit, clearDeeplinkState ]
+		[ handleAddSiteClick, siteAddedMessage, onSubmit ]
 	);
 
 	return (
@@ -504,19 +443,12 @@ export default function AddSiteModal( { className }: AddSiteModalProps ) {
 	}, [] );
 
 	const addSiteProps = useAddSite( { openModal } );
-	const { setFileForImport, clearDeeplinkState, isAnySiteProcessing, setSelectedRemoteSite } =
-		addSiteProps;
+	const { resetForm, isAnySiteProcessing } = addSiteProps;
 
 	const closeModal = useCallback( () => {
+		resetForm();
 		setShowModal( false );
-		clearDeeplinkState();
-		setFileForImport( null );
-		setSelectedRemoteSite( undefined );
-	}, [ clearDeeplinkState, setFileForImport, setSelectedRemoteSite ] );
-
-	const handleSiteAdded = useCallback( () => {
-		closeModal();
-	}, [ closeModal ] );
+	}, [ resetForm ] );
 
 	useIpcListener( 'add-site', () => {
 		if ( isAnySiteProcessing ) {
@@ -530,7 +462,7 @@ export default function AddSiteModal( { className }: AddSiteModalProps ) {
 			<FullscreenModal isOpen={ showModal } onClose={ closeModal }>
 				<AddSiteModalContent
 					isOpen={ showModal }
-					onSubmit={ handleSiteAdded }
+					onSubmit={ closeModal }
 					addSiteProps={ addSiteProps }
 				/>
 			</FullscreenModal>

--- a/src/modules/add-site/index.tsx
+++ b/src/modules/add-site/index.tsx
@@ -8,6 +8,7 @@ import Button from 'src/components/button';
 import { FullscreenModal } from 'src/components/fullscreen-modal';
 import { useAddSite } from 'src/hooks/use-add-site';
 import { useIpcListener } from 'src/hooks/use-ipc-listener';
+import { useSiteDetails } from 'src/hooks/use-site-details';
 import { generateSiteName } from 'src/lib/generate-site-name';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 import { SyncSite } from 'src/modules/sync/types';
@@ -327,6 +328,8 @@ export function AddSiteModalContent( {
 		error: blueprintsError,
 	} = useGetBlueprints();
 
+	const { sites, loadingSites } = useSiteDetails();
+
 	const {
 		handleAddSiteClick,
 		siteName,
@@ -334,8 +337,6 @@ export function AddSiteModalContent( {
 		setWpVersion,
 		setProposedSitePath,
 		setDoesPathContainWordPress,
-		loadingSites,
-		sites,
 		loadAllCustomDomains,
 		selectedBlueprint,
 		setSelectedBlueprint,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Follow up:
  - https://github.com/Automattic/studio/pull/2216
  - https://github.com/Automattic/studio/pull/2230


## Proposed Changes

- This PR is a refactor; it does not add new functionality or fix any issues.
- It refactors how we reset the Add Site form after closing the modal or creating a site.
- Removes the unnecessary `localAddSiteProps` variable.
- Clean sites and loadingSites from useAddSite. These values should be consumed directly from useSiteDetails.
- It doesn't reset the form in NoStudioSites because that component will reset its state when it gets unmounted.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run `npm start`
- Click on Add site
- Try each option
- Confirm there are no regressions and that the creation of one site doesn't affect another. For example, after pulling an existing site, creating a blank site should result in just a blank site being created.
- Repeat the testing but this time remove all your local sites to try the site creation without the modal.
- Try to open blueprint deeplinks, e.g.:

```
wp-studio://add-site?blueprint=eyJtZXRhIjp7InRpdGxlIjoiVGhpcyBpcyBhIHRlc3QgYmx1ZXByaW50IiwiZGVzY3JpcHRpb24iOiJJdCBpbnN0YWxscyBBc3RyYSB0aGVtZSBhbmQgWW9hc3QgU0VPIHBsdWdpbiIsImF1dGhvciI6Iml2YW4iLCJjYXRlZ29yaWVzIjpbInJzcyIsInNvY2lhbCB3ZWIiXX0sInByZWZlcnJlZFZlcnNpb25zIjp7InBocCI6IjguMyIsIndwIjoibGF0ZXN0In0sInN0ZXBzIjpbeyJzdGVwIjoiaW5zdGFsbFRoZW1lIiwidGhlbWVEYXRhIjp7InJlc291cmNlIjoid29yZHByZXNzLm9yZy90aGVtZXMiLCJzbHVnIjoiYXN0cmEifSwib3B0aW9ucyI6eyJhY3RpdmF0ZSI6dHJ1ZX19LHsic3RlcCI6Imluc3RhbGxQbHVnaW4iLCJwbHVnaW5EYXRhIjp7InJlc291cmNlIjoid29yZHByZXNzLm9yZy9wbHVnaW5zIiwic2x1ZyI6IndvcmRwcmVzcy1zZW8ifSwib3B0aW9ucyI6eyJhY3RpdmF0ZSI6dHJ1ZX19LHsic3RlcCI6ImxvZ2luIiwidXNlcm5hbWUiOiJhZG1pbiIsInBhc3N3b3JkIjoicGFzc3dvcmQifV19 
```

or the ones in https://jsbin.com/levaburate/2/edit?html,css,output .

3. Confirm there are no unexpected behavior, and all sites should be created correctly.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
