### PR TITLE
Studio: Ensure the add site screen can be dragged by the header

### DIFF
--- a/src/components/fullscreen-modal.tsx
+++ b/src/components/fullscreen-modal.tsx
@@ -63,10 +63,13 @@ export const FullscreenModal: React.FC< FullscreenModalProps > = ( {
 			role="dialog"
 			aria-modal="true"
 		>
-			<HStack
-				className={ cx( 'flex justify-end p-4 app-no-drag-region', isWindows() && 'ltr:pt-8' ) }
-			>
-				<Button icon={ close } onClick={ onClose } label={ __( 'Close' ) } />
+			<HStack className={ cx( 'flex justify-end p-4 app-drag-region', isWindows() && 'ltr:pt-8' ) }>
+				<Button
+					icon={ close }
+					onClick={ onClose }
+					label={ __( 'Close' ) }
+					className="app-no-drag-region"
+				/>
 			</HStack>
 			<VStack alignment="top" className="w-full flex-1 overflow-y-auto px-6 pb-6">
 				{ children }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

Fixes STU-1076

## Proposed Changes

This PR ensures that Studio app can be dragged by the top header when the user is on the `Add site` screen:

<img width="1337" height="849" alt="Screenshot 2025-12-11 at 9 45 38 AM" src="https://github.com/user-attachments/assets/78d611e3-2664-4d83-8462-e96f7c20b7ab" />


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
* Start the app with `npm start`
* Click on `Add site`
* Confirm that you can drag the app by the header

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
