### PR TITLE
Fix auto-updates on app launch by setting the value in NODE_ENV

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -38,6 +38,7 @@ export default defineConfig( {
 			},
 		},
 		define: {
+			'process.env.NODE_ENV': JSON.stringify( process.env.NODE_ENV ),
 			COMMIT_HASH: JSON.stringify(
 				process.env.GITHUB_SHA ?? process.env.BUILDKITE_COMMIT ?? 'dev'
 			),

--- a/src/index.ts
+++ b/src/index.ts
@@ -243,6 +243,7 @@ async function appBoot() {
 		}
 
 		console.log( `App version: ${ app.getVersion() }` );
+		console.log( `Environment: ${ process.env.NODE_ENV ?? 'undefined' }` );
 		console.log( `Built from commit: ${ COMMIT_HASH ?? 'undefined' }` );
 		console.log( `Local timezone: ${ Intl.DateTimeFormat().resolvedOptions().timeZone }` );
 		console.log( `App locale: ${ app.getLocale() }` );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-1122

## Proposed Changes

- It passes the `process.env.NODE_ENV` to the packaged version
- That will fix the auto-updates that expect the `NODE_ENV` to be `production`. See: https://github.com/Automattic/studio/blob/acacf62e089f723c3e34155a771ad14846361596/src/updates.ts#L22-L24

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Production**

- Locate the latest updated log in `~/Library/Logs/Studio/studio-20251210.0.log`
- Checkout this branch
- Run `npm install && npm run make`
- Find the .dmg created in `out/make`
- Install and open the Studio app
- Confirm you see in the log this output, and it doesn't mention `Skipping auto-updates`:
```
[2025-12-10T15:24:47.750Z][info][main] App version: 1.6.6
[2025-12-10T15:24:47.750Z][info][main] Environment: production
```

**Development**

- Close the app and run `npm start`
- Open the logs and confirm the output says `development`:

```
[2025-12-10T15:24:47.554Z][info][main] Skipping auto-updates {
  "env": "development",
  "isPackaged": false,
  "version": "1.6.6"
}
...
[2025-12-10T15:24:47.750Z][info][main] App version: 1.6.6
[2025-12-10T15:24:47.750Z][info][main] Environment: development
```

**Before this changes NODE_EN was undefined**

If you remove the [line](https://github.com/Automattic/studio/blob/e060314c183351de6b4983b9b40a5b743510c2a7/electron.vite.config.ts#L41) added in `electron.vite.config.ts`, and then make another build, then you'll see how  NODE_ENV was undefined with this output in the log:

```
[2025-12-10T15:24:09.012Z][info][main] Skipping auto-updates {
  "isPackaged": true,
  "version": "1.6.6"
}
[2025-12-10T15:24:09.133Z][info][main] App version: 1.6.6
[2025-12-10T15:24:09.133Z][info][main] Environment: undefined
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
