### PR TITLE
Studio: Show all WordPress.com sites when importing, not just unconnected ones

### DIFF
--- a/src/modules/add-site/components/pull-remote-site.tsx
+++ b/src/modules/add-site/components/pull-remote-site.tsx
@@ -11,12 +11,10 @@ import offlineIcon from 'src/components/offline-icon';
 import { Tooltip } from 'src/components/tooltip';
 import { useAuth } from 'src/hooks/use-auth';
 import { useOffline } from 'src/hooks/use-offline';
-import { useSiteDetails } from 'src/hooks/use-site-details';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 import { NoWpcomSitesContent } from 'src/modules/sync/components/no-wpcom-sites-content';
 import { SitesListContent } from 'src/modules/sync/components/sync-sites-modal-selector';
 import { SyncTabImage } from 'src/modules/sync/components/sync-tab-image';
-import { useGetConnectedSitesForLocalSiteQuery } from 'src/stores/sync/connected-sites';
 import { useGetWpComSitesQuery } from 'src/stores/sync/wpcom-sites';
 import type { SyncSite } from 'src/modules/sync/types';
 

--- a/src/modules/add-site/components/pull-remote-site.tsx
+++ b/src/modules/add-site/components/pull-remote-site.tsx
@@ -142,7 +142,6 @@ export function PullRemoteSite( {
 		isSuccess,
 	} = useGetWpComSitesQuery(
 		{
-			connectedSiteIds: [], // Empty array here because we want to fetch all sites
 			userId: user?.id,
 		},
 		{ refetchOnMountOrArgChange: true }

--- a/src/modules/add-site/components/pull-remote-site.tsx
+++ b/src/modules/add-site/components/pull-remote-site.tsx
@@ -138,19 +138,13 @@ export function PullRemoteSite( {
 	const { __ } = useI18n();
 	const { isAuthenticated, user } = useAuth();
 
-	const { selectedSite } = useSiteDetails();
-	const { data: connectedSites = [] } = useGetConnectedSitesForLocalSiteQuery( {
-		localSiteId: selectedSite?.id,
-		userId: user?.id,
-	} );
-	const connectedSiteIds = connectedSites.map( ( { id } ) => id );
 	const {
 		data: syncSites = [],
 		isLoading,
 		isSuccess,
 	} = useGetWpComSitesQuery(
 		{
-			connectedSiteIds,
+			connectedSiteIds: [], // Empty array here because we want to fetch all sites
 			userId: user?.id,
 		},
 		{ refetchOnMountOrArgChange: true }

--- a/src/stores/sync/wpcom-sites.ts
+++ b/src/stores/sync/wpcom-sites.ts
@@ -79,11 +79,12 @@ function transformSingleSiteResponse(
  * Transforms the WordPress.com sites API response into SyncSite objects.
  *
  * @param sites - Raw site data from the WordPress.com API
- * @param connectedSiteIds - IDs of sites already connected to the current local site.
- *                           Used to: 1) keep deleted sites in the list if they're connected, and
- *                           2) determine sync support status (already-connected vs syncable)
+ * @param connectedSiteIds - Optional IDs of sites already connected to the current local site.
+ *                           When provided, used to: 1) keep deleted sites in the list if they're connected, and
+ *                           2) determine sync support status (already-connected vs syncable).
+ *                           When not provided, no filtering based on connected sites is applied.
  */
-function transformSitesResponse( sites: unknown[], connectedSiteIds: number[] ): SyncSite[] {
+function transformSitesResponse( sites: unknown[], connectedSiteIds?: number[] ): SyncSite[] {
 	const validatedSites = sites.reduce< SitesEndpointSite[] >( ( acc, rawSite ) => {
 		try {
 			const site = sitesEndpointSiteSchema.parse( rawSite );
@@ -100,12 +101,14 @@ function transformSitesResponse( sites: unknown[], connectedSiteIds: number[] ):
 
 	return validatedSites
 		.filter( ( site ) => ! site.is_a8c )
-		.filter( ( site ) => ! site.is_deleted || connectedSiteIds.some( ( id ) => id === site.ID ) )
+		.filter(
+			( site ) => ! site.is_deleted || connectedSiteIds?.some( ( id ) => id === site.ID ) || false
+		)
 		.map( ( site ) => {
 			// The API returns the wrong value for the `is_wpcom_staging_site` prop while staging sites
 			// are being created. Hence the check in other sites' `wpcom_staging_blog_ids` arrays.
 			const isStaging = allStagingSiteIds.includes( site.ID );
-			const syncSupport = getSyncSupport( site, connectedSiteIds );
+			const syncSupport = getSyncSupport( site, connectedSiteIds ?? [] );
 
 			return transformSingleSiteResponse( site, syncSupport, isStaging );
 		} );
@@ -116,7 +119,7 @@ export const wpcomSitesApi = createApi( {
 	baseQuery: fetchBaseQuery(),
 	tagTypes: [ 'WpComSites' ],
 	endpoints: ( builder ) => ( {
-		getWpComSites: builder.query< SyncSite[], { connectedSiteIds: number[]; userId?: number } >( {
+		getWpComSites: builder.query< SyncSite[], { connectedSiteIds?: number[]; userId?: number } >( {
 			queryFn: async ( { connectedSiteIds } ) => {
 				const wpcomClient = getWpcomClient();
 				if ( ! wpcomClient ) {

--- a/src/stores/sync/wpcom-sites.ts
+++ b/src/stores/sync/wpcom-sites.ts
@@ -102,7 +102,10 @@ function transformSitesResponse( sites: unknown[], connectedSiteIds?: number[] )
 	return validatedSites
 		.filter( ( site ) => ! site.is_a8c )
 		.filter(
-			( site ) => ! site.is_deleted || connectedSiteIds?.some( ( id ) => id === site.ID ) || false
+			// Filter out deleted sites, except if they're in the connectedSiteIds list
+			( site ) =>
+				! site.is_deleted ||
+				( connectedSiteIds && connectedSiteIds.some( ( id ) => id === site.ID ) )
 		)
 		.map( ( site ) => {
 			// The API returns the wrong value for the `is_wpcom_staging_site` prop while staging sites


### PR DESCRIPTION
## Related issues

- Fixes STU-1123

## Proposed Changes

- Made `connectedSiteIds` parameter optional in the `useGetWpComSitesQuery` API to avoid filtering them
- Updated the `transformSitesResponse` function to handle optional `connectedSiteIds` using optional chaining
- Do not pass `connectedSiteIds` parameter to the `useGetWpComSitesQuery` in  the PullRemoteSite component

## Testing Instructions

1. Apply this branch and run `npm start`
2. Ensure you have at least one local site already connected to a WordPress.com site
3. Click "Add Site" and select "Pull an existing site"
4. Verify that ALL your WordPress.com sites are displayed in the list, including those already connected to other local sites
5. Confirm you can select and import any site from the list, even if it's already connected elsewhere
6. Navigate to the Sync tab on a site with a connected site
7. Click on `Connect another site`
8. Verify that the connected site appears in the list greyed out with the `Already connected` label


## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?