### PR TITLE
Show loading screen while fetching sites in Pull an existing site modal

### DIFF
--- a/src/modules/add-site/components/pull-remote-site.tsx
+++ b/src/modules/add-site/components/pull-remote-site.tsx
@@ -162,7 +162,9 @@ export function PullRemoteSite( {
 			</Heading>
 			{ isAuthenticated ? (
 				<VStack className="flex flex-col w-full max-w-[650px] flex-1 text-a8c-gray-900">
-					{ hasSites && (
+					{ showNoSitesView ? (
+						<NoWpcomSitesView />
+					) : (
 						<SitesListContent
 							isLoading={ isLoading }
 							syncSites={ syncSites }
@@ -170,8 +172,6 @@ export function PullRemoteSite( {
 							onSelectSite={ handleSiteSelect }
 						/>
 					) }
-
-					{ showNoSitesView && <NoWpcomSitesView /> }
 				</VStack>
 			) : (
 				<NoAuthPullRemoteSiteView />

--- a/src/modules/sync/components/sync-sites-modal-selector.tsx
+++ b/src/modules/sync/components/sync-sites-modal-selector.tsx
@@ -172,6 +172,9 @@ export function SitesListContent( {
 		);
 	} );
 	const isEmpty = filteredSites.length === 0;
+	const emptyMessage = searchQuery
+		? sprintf( __( 'No sites found for "%s"' ), searchQuery )
+		: __( 'No sites found' );
 
 	return (
 		<>
@@ -180,16 +183,10 @@ export function SitesListContent( {
 				{ isLoading && (
 					<div className="flex justify-center items-center h-full">{ __( 'Loading sites…' ) }</div>
 				) }
-
-				{ ! isLoading && isEmpty && searchQuery && (
-					<div className="flex justify-center items-center h-full">
-						{ sprintf( __( 'No sites found for "%s"' ), searchQuery ) }
-					</div>
+				{ ! isLoading && isEmpty && (
+					<div className="flex justify-center items-center h-full">{ emptyMessage }</div>
 				) }
-
-				{ ! isLoading && isEmpty ? (
-					<div className="flex justify-center items-center h-full">{ __( 'No sites found' ) }</div>
-				) : (
+				{ ! isLoading && ! isEmpty && (
 					<ListSites
 						syncSites={ filteredSites }
 						selectedSiteId={ selectedSiteId }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Solves STU-1125
- Related to https://github.com/Automattic/studio/pull/2222
- Related to https://github.com/Automattic/studio/pull/2235

## Proposed Changes

- Show the original modal while fetching the sites with the `Loading…` message

https://github.com/user-attachments/assets/612fbffa-eac1-42e7-b5fe-dcb632342d03



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Apply this branch and run `npm start`
- When opening studio, click on `Add site` and `Pull an existing site`
- Check there is a `Loading…` message, if you cannot see the message, try `CMD+R` to refresh data
- Verify that the test steps on linked PR #2222 still work as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
