### PR TITLE
Auth: Display authorization denied message to the user access is denied

### DIFF
--- a/src/components/auth-provider.tsx
+++ b/src/components/auth-provider.tsx
@@ -70,7 +70,7 @@ const AuthProvider: React.FC< AuthProviderProps > = ( { children } ) => {
 			if ( payload.error instanceof Error && payload.error.message.includes( 'access_denied' ) ) {
 				title = __( 'Authorization denied' );
 				message = __(
-					'You have denied access to the authorization process. Please click the "Approve" option to authorize.'
+					'It looks like you denied the authorization request. To proceed, please click "Approve"'
 				);
 			}
 

--- a/src/components/auth-provider.tsx
+++ b/src/components/auth-provider.tsx
@@ -63,10 +63,18 @@ const AuthProvider: React.FC< AuthProviderProps > = ( { children } ) => {
 
 	useIpcListener( 'auth-updated', ( _event, payload ) => {
 		if ( 'error' in payload ) {
-			getIpcApi().showErrorMessageBox( {
-				title: __( 'Authentication error' ),
-				message: __( 'Please try again.' ),
-			} );
+			let title: string = __( 'Authentication error' );
+			let message: string = __( 'Please try again.' );
+
+			// User has denied access to the authorization dialog.
+			if ( payload.error instanceof Error && payload.error.message.includes( 'access_denied' ) ) {
+				title = __( 'Authorization denied' );
+				message = __(
+					'You have denied access to the authorization process. Please click the "Approve" option to authorize.'
+				);
+			}
+
+			void getIpcApi().showErrorMessageBox( { title, message } );
 			return;
 		}
 


### PR DESCRIPTION
…ation process when access is denied.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-1103

## Proposed Changes

- Display specific error message to the user when authorization is explicitly denied by them while login into Studio.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Switch to this branch  
- Run `npm start`  
- If you’re already logged into WordPress.com, log out  
- Click Log In  
- When the OAuth page opens up, click on Deny  
- You’ll be taken back to the Studio with a message saying you denied the request

| Before | After |
|--------|--------|
| <img width="2238" height="1598" alt="CleanShot 2025-12-11 at 19 22 13@2x" src="https://github.com/user-attachments/assets/7770d553-6389-496d-967e-01a05cc0564a" /> | <img width="2238" height="1598" alt="CleanShot 2025-12-11 at 19 21 49@2x" src="https://github.com/user-attachments/assets/caeadf48-d998-42af-840d-36682ad17d8e" /> | 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
