### PR TITLE
Avoid showing a path conflict when pulling a remote site multiple times

### DIFF
--- a/src/modules/add-site/hooks/tests/use-find-available-site-name.test.ts
+++ b/src/modules/add-site/hooks/tests/use-find-available-site-name.test.ts
@@ -1,0 +1,188 @@
+import { jest } from '@jest/globals';
+import { renderHook } from '@testing-library/react';
+import { FolderDialogResponse } from 'src/ipc-handlers';
+import { getIpcApi } from 'src/lib/get-ipc-api';
+import { useFindAvailableSiteName } from '../use-find-available-site-name';
+
+jest.mock( 'src/lib/get-ipc-api' );
+
+const mockGenerateProposedSitePath =
+	jest.fn< ( siteName: string ) => Promise< FolderDialogResponse > >();
+
+describe( 'useFindAvailableSiteName', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		( getIpcApi as jest.Mock ).mockReturnValue( {
+			generateProposedSitePath: mockGenerateProposedSitePath,
+		} );
+	} );
+
+	it( 'should return the base name if it is available', async () => {
+		mockGenerateProposedSitePath.mockResolvedValue( {
+			path: '/path/to/site',
+			name: 'My Site',
+			isEmpty: true,
+			isWordPress: false,
+		} );
+
+		const { result } = renderHook( () => useFindAvailableSiteName() );
+
+		const availableName = await result.current( 'My Site' );
+
+		expect( availableName ).toBe( 'My Site' );
+		expect( mockGenerateProposedSitePath ).toHaveBeenCalledTimes( 1 );
+		expect( mockGenerateProposedSitePath ).toHaveBeenCalledWith( 'My Site' );
+	} );
+
+	it( 'should return "baseName 2" if base name is not available', async () => {
+		mockGenerateProposedSitePath
+			.mockResolvedValueOnce( {
+				path: '/path/to/site',
+				name: 'My Site',
+				isEmpty: false,
+				isWordPress: false,
+			} )
+			.mockResolvedValueOnce( {
+				path: '/path/to/site-2',
+				name: 'My Site 2',
+				isEmpty: true,
+				isWordPress: false,
+			} );
+
+		const { result } = renderHook( () => useFindAvailableSiteName() );
+
+		const availableName = await result.current( 'My Site' );
+
+		expect( availableName ).toBe( 'My Site 2' );
+		expect( mockGenerateProposedSitePath ).toHaveBeenCalledTimes( 2 );
+		expect( mockGenerateProposedSitePath ).toHaveBeenNthCalledWith( 1, 'My Site' );
+		expect( mockGenerateProposedSitePath ).toHaveBeenNthCalledWith( 2, 'My Site 2' );
+	} );
+
+	it( 'should return "baseName 3" if base name and "baseName 2" are not available', async () => {
+		mockGenerateProposedSitePath
+			.mockResolvedValueOnce( {
+				path: '/path/to/site',
+				name: 'My Site',
+				isEmpty: false,
+				isWordPress: false,
+			} )
+			.mockResolvedValueOnce( {
+				path: '/path/to/site-2',
+				name: 'My Site 2',
+				isEmpty: false,
+				isWordPress: false,
+			} )
+			.mockResolvedValueOnce( {
+				path: '/path/to/site-3',
+				name: 'My Site 3',
+				isEmpty: true,
+				isWordPress: false,
+			} );
+
+		const { result } = renderHook( () => useFindAvailableSiteName() );
+
+		const availableName = await result.current( 'My Site' );
+
+		expect( availableName ).toBe( 'My Site 3' );
+		expect( mockGenerateProposedSitePath ).toHaveBeenCalledTimes( 3 );
+		expect( mockGenerateProposedSitePath ).toHaveBeenNthCalledWith( 1, 'My Site' );
+		expect( mockGenerateProposedSitePath ).toHaveBeenNthCalledWith( 2, 'My Site 2' );
+		expect( mockGenerateProposedSitePath ).toHaveBeenNthCalledWith( 3, 'My Site 3' );
+	} );
+
+	it( 'should continue iterating until finding an available name', async () => {
+		const mockCalls = [];
+		for ( let i = 1; i <= 5; i++ ) {
+			mockCalls.push( {
+				path: `/path/to/site-${ i }`,
+				name: i === 1 ? 'My Site' : `My Site ${ i }`,
+				isEmpty: i === 5,
+				isWordPress: false,
+			} );
+		}
+
+		mockGenerateProposedSitePath
+			.mockResolvedValueOnce( mockCalls[ 0 ] )
+			.mockResolvedValueOnce( mockCalls[ 1 ] )
+			.mockResolvedValueOnce( mockCalls[ 2 ] )
+			.mockResolvedValueOnce( mockCalls[ 3 ] )
+			.mockResolvedValueOnce( mockCalls[ 4 ] );
+
+		const { result } = renderHook( () => useFindAvailableSiteName() );
+
+		const availableName = await result.current( 'My Site' );
+
+		expect( availableName ).toBe( 'My Site 5' );
+		expect( mockGenerateProposedSitePath ).toHaveBeenCalledTimes( 5 );
+	} );
+
+	it( 'should handle WordPress directories as not available', async () => {
+		mockGenerateProposedSitePath
+			.mockResolvedValueOnce( {
+				path: '/path/to/site',
+				name: 'My Site',
+				isEmpty: false,
+				isWordPress: true,
+			} )
+			.mockResolvedValueOnce( {
+				path: '/path/to/site-2',
+				name: 'My Site 2',
+				isEmpty: true,
+				isWordPress: false,
+			} );
+
+		const { result } = renderHook( () => useFindAvailableSiteName() );
+
+		const availableName = await result.current( 'My Site' );
+
+		expect( availableName ).toBe( 'My Site 2' );
+		expect( mockGenerateProposedSitePath ).toHaveBeenCalledTimes( 2 );
+	} );
+
+	it( 'should return "baseName 500" if all previous names are not available (max iterations)', async () => {
+		mockGenerateProposedSitePath.mockImplementation( async ( name: string ) => {
+			const match = name.match( /^My Site(?: (\d+))?$/ );
+			if ( ! match ) {
+				return {
+					path: '/path/to/site',
+					name,
+					isEmpty: false,
+					isWordPress: false,
+				};
+			}
+			const num = match[ 1 ] ? parseInt( match[ 1 ], 10 ) : 1;
+			if ( num < 500 ) {
+				return {
+					path: `/path/to/site-${ num }`,
+					name: num === 1 ? 'My Site' : `My Site ${ num }`,
+					isEmpty: false,
+					isWordPress: false,
+				};
+			}
+			return {
+				path: '/path/to/site-500',
+				name: 'My Site 500',
+				isEmpty: true,
+				isWordPress: false,
+			};
+		} );
+
+		const { result } = renderHook( () => useFindAvailableSiteName() );
+
+		const availableName = await result.current( 'My Site' );
+
+		expect( availableName ).toBe( 'My Site 500' );
+		expect( mockGenerateProposedSitePath ).toHaveBeenCalledTimes( 499 );
+	} );
+
+	it( 'should return a stable function reference across renders', () => {
+		const { result, rerender } = renderHook( () => useFindAvailableSiteName() );
+
+		const firstRender = result.current;
+		rerender();
+		const secondRender = result.current;
+
+		expect( firstRender ).toBe( secondRender );
+	} );
+} );

--- a/src/modules/add-site/hooks/use-find-available-site-name.ts
+++ b/src/modules/add-site/hooks/use-find-available-site-name.ts
@@ -1,0 +1,16 @@
+import { useCallback } from 'react';
+import { getIpcApi } from 'src/lib/get-ipc-api';
+
+export function useFindAvailableSiteName() {
+	return useCallback( async ( baseName: string ): Promise< string > => {
+		const MAX_NAME_ITERATIONS = 500;
+		for ( let suffix = 1; suffix < MAX_NAME_ITERATIONS; suffix++ ) {
+			const candidateName = suffix === 1 ? baseName : `${ baseName } ${ suffix }`;
+			const pathInfo = await getIpcApi().generateProposedSitePath( candidateName );
+			if ( pathInfo.isEmpty ) {
+				return candidateName;
+			}
+		}
+		return `${ baseName } ${ MAX_NAME_ITERATIONS }`;
+	}, [] );
+}

--- a/src/modules/add-site/index.tsx
+++ b/src/modules/add-site/index.tsx
@@ -123,12 +123,14 @@ function NavigationContent( props: NavigationContentProps ) {
 		}
 	}, [ createSiteProps, goTo ] );
 
+	const findAvailableSiteName = useFindAvailableSiteName();
 	const handlePullRemoteContinue = useCallback( async () => {
 		if ( selectedRemoteSite ) {
-			void createSiteProps.handleSiteNameChange( selectedRemoteSite.name );
+			const availableName = await findAvailableSiteName( selectedRemoteSite.name );
+			void createSiteProps.handleSiteNameChange( availableName );
 			goTo( '/pullRemote/create' );
 		}
-	}, [ createSiteProps, goTo, selectedRemoteSite ] );
+	}, [ createSiteProps, findAvailableSiteName, goTo, selectedRemoteSite ] );
 
 	const blueprints = useMemo(
 		() => blueprintsData?.blueprints.slice().reverse() || [],

--- a/src/modules/add-site/index.tsx
+++ b/src/modules/add-site/index.tsx
@@ -127,7 +127,7 @@ function NavigationContent( props: NavigationContentProps ) {
 	const handlePullRemoteContinue = useCallback( async () => {
 		if ( selectedRemoteSite ) {
 			const availableName = await findAvailableSiteName( selectedRemoteSite.name );
-			void createSiteProps.handleSiteNameChange( availableName );
+			await createSiteProps.handleSiteNameChange( availableName );
 			goTo( '/pullRemote/create' );
 		}
 	}, [ createSiteProps, findAvailableSiteName, goTo, selectedRemoteSite ] );

--- a/src/modules/add-site/index.tsx
+++ b/src/modules/add-site/index.tsx
@@ -24,6 +24,7 @@ import ImportBackup from './components/import-backup';
 import AddSiteOptions, { type AddSiteFlowType } from './components/options';
 import { PullRemoteSite } from './components/pull-remote-site';
 import Stepper from './components/stepper';
+import { useFindAvailableSiteName } from './hooks/use-find-available-site-name';
 
 type BlueprintsData = ReturnType< typeof useGetBlueprints >[ 'data' ];
 
@@ -122,11 +123,12 @@ function NavigationContent( props: NavigationContentProps ) {
 		}
 	}, [ createSiteProps, goTo ] );
 
-	const handlePullRemoteContinue = useCallback( () => {
+	const handlePullRemoteContinue = useCallback( async () => {
 		if ( selectedRemoteSite ) {
+			void createSiteProps.handleSiteNameChange( selectedRemoteSite.name );
 			goTo( '/pullRemote/create' );
 		}
-	}, [ selectedRemoteSite, goTo ] );
+	}, [ createSiteProps, goTo, selectedRemoteSite ] );
 
 	const blueprints = useMemo(
 		() => blueprintsData?.blueprints.slice().reverse() || [],
@@ -277,11 +279,8 @@ function NavigationContent( props: NavigationContentProps ) {
 			<Navigator.Screen className="flex-1 flex justify-center" path="/pullRemote">
 				<PullRemoteSite
 					selectedRemoteSite={ selectedRemoteSite }
-					setSelectedRemoteSite={ ( remoteSite?: SyncSite ) => {
+					setSelectedRemoteSite={ async ( remoteSite?: SyncSite ) => {
 						setSelectedRemoteSite( remoteSite );
-						if ( remoteSite?.name ) {
-							void createSiteProps.handleSiteNameChange( remoteSite.name );
-						}
 					} }
 				/>
 			</Navigator.Screen>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-1118

## Proposed Changes

- When pulling an existing remote site multiple times, the user received an error conflicting in the path. In this PR I suggest appending a suffix number to generate a new clean path.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run `npm start`
- Click on Add site and then select Pull an existing site
- Continue and create the site
- Observe that the site name does not contain any numeric suffix.
- Repeat the operation selecting the same site.
- Observe that the generated name is "Sitename 2" so it doesn't show any error to the user.

| Before | After |
|--------|--------|
| <img width="1012" height="712" alt="Screenshot 2025-12-11 at 17 19 41" src="https://github.com/user-attachments/assets/50db0f43-01d6-48bc-b103-0aa89701e57e" /> |<img width="1012" height="712" alt="Screenshot 2025-12-11 at 17 21 30" src="https://github.com/user-attachments/assets/621ece9b-731e-48d8-90dd-d885f5f75c0c" /> |

https://github.com/user-attachments/assets/55e1f6c0-7b84-4c0f-ba59-c641a39d1acd



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
