### PR TITLE
Add Xdebug support

### DIFF
--- a/src/components/content-tab-settings.tsx
+++ b/src/components/content-tab-settings.tsx
@@ -132,6 +132,9 @@ export function ContentTabSettings( { selectedSite }: ContentTabSettingsProps ) 
 							<span className="line-clamp-1 break-all">{ selectedSite.phpVersion }</span>
 						</div>
 					</SettingsRow>
+					<SettingsRow label={ __( 'Xdebug' ) }>
+						<span>{ selectedSite.enableXdebug ? __( 'Enabled' ) : __( 'Disabled' ) }</span>
+					</SettingsRow>
 
 					<tr>
 						<th colSpan={ 2 } className="pb-4 ltr:text-left rtl:text-right">

--- a/src/components/content-tab-settings.tsx
+++ b/src/components/content-tab-settings.tsx
@@ -8,7 +8,8 @@ import DeleteSite from 'src/components/delete-site';
 import { useGetWpVersion } from 'src/hooks/use-get-wp-version';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 import EditSiteDetails from 'src/modules/site-settings/edit-site-details';
-import { useAppDispatch } from 'src/stores';
+import { useAppDispatch, useRootSelector } from 'src/stores';
+import { betaFeaturesSelectors } from 'src/stores/beta-features-slice';
 import {
 	certificateTrustApi,
 	useCheckCertificateTrustQuery,
@@ -33,6 +34,7 @@ export function ContentTabSettings( { selectedSite }: ContentTabSettingsProps ) 
 	const dispatch = useAppDispatch();
 	const { __ } = useI18n();
 	const { data: isCertificateTrusted } = useCheckCertificateTrustQuery();
+	const betaFeatures = useRootSelector( betaFeaturesSelectors.selectBetaFeatures );
 	const username = 'admin';
 	// Empty strings account for legacy sites lacking a stored password.
 	const storedPassword = decodePassword( selectedSite.adminPassword ?? '' );
@@ -132,9 +134,11 @@ export function ContentTabSettings( { selectedSite }: ContentTabSettingsProps ) 
 							<span className="line-clamp-1 break-all">{ selectedSite.phpVersion }</span>
 						</div>
 					</SettingsRow>
-					<SettingsRow label={ __( 'Xdebug' ) }>
-						<span>{ selectedSite.enableXdebug ? __( 'Enabled' ) : __( 'Disabled' ) }</span>
-					</SettingsRow>
+					{ betaFeatures.xdebugSupport && (
+						<SettingsRow label={ __( 'Xdebug' ) }>
+							<span>{ selectedSite.enableXdebug ? __( 'Enabled' ) : __( 'Disabled' ) }</span>
+						</SettingsRow>
+					) }
 
 					<tr>
 						<th colSpan={ 2 } className="pb-4 ltr:text-left rtl:text-right">

--- a/src/components/tests/content-tab-settings.test.tsx
+++ b/src/components/tests/content-tab-settings.test.tsx
@@ -24,18 +24,19 @@ function snapshotTestReducer( state: RootState | undefined, action: UnknownActio
 		} );
 	}
 
-	// Use the test reducer but preserve provider constants
+	// Use the test reducer but preserve provider constants and beta features
 	const newState = testReducer( state, action );
 
-	// If we have provider constants in the current state, preserve them
+	// If we have provider constants or beta features in the current state, preserve them
+	const preservedState = { ...newState };
 	if ( state?.providerConstants ) {
-		return {
-			...newState,
-			providerConstants: state.providerConstants,
-		};
+		preservedState.providerConstants = state.providerConstants;
+	}
+	if ( state?.betaFeatures ) {
+		preservedState.betaFeatures = state.betaFeatures;
 	}
 
-	return newState;
+	return preservedState;
 }
 
 const snapshotTestActions = {
@@ -52,6 +53,15 @@ let testStore = createTestStore( {
 		allowedPhpVersions: [ '8.0', '8.1', '8.2', '8.3' ],
 		minimumWordPressVersion: '6.2.6',
 	},
+	preloadedState: {
+		betaFeatures: {
+			features: {
+				multiWorkerSupport: false,
+				xdebugSupport: true,
+			},
+			loading: false,
+		},
+	},
 } );
 
 // We need to create a new store each time to avoid reducer conflicts
@@ -62,6 +72,15 @@ function createCustomTestStore() {
 			defaultWordPressVersion: 'latest',
 			allowedPhpVersions: [ '8.0', '8.1', '8.2', '8.3' ],
 			minimumWordPressVersion: '6.2.6',
+		},
+		preloadedState: {
+			betaFeatures: {
+				features: {
+					multiWorkerSupport: false,
+					xdebugSupport: true,
+				},
+				loading: false,
+			},
 		},
 	} );
 	store.replaceReducer( snapshotTestReducer );
@@ -116,6 +135,7 @@ describe( 'ContentTabSettings', () => {
 	const openLocalPath = jest.fn();
 	const generateProposedSitePath = jest.fn();
 	const getAllCustomDomains = jest.fn().mockResolvedValue( [] );
+	const getXdebugEnabledSite = jest.fn().mockResolvedValue( null );
 	const mockSnapshot = {
 		localSiteId: selectedSite.id,
 		url: 'http://localhost:8881',
@@ -137,6 +157,7 @@ describe( 'ContentTabSettings', () => {
 			openLocalPath,
 			generateProposedSitePath,
 			getAllCustomDomains,
+			getXdebugEnabledSite,
 			isCATrusted: jest.fn( () => Promise.resolve( true ) ),
 		} );
 
@@ -252,6 +273,42 @@ describe( 'ContentTabSettings', () => {
 			await user.click( adminPasswordButton );
 			expect( copyText ).toHaveBeenCalledTimes( 1 );
 			expect( copyText ).toHaveBeenCalledWith( 'password' );
+		} );
+	} );
+
+	describe( 'Xdebug beta feature', () => {
+		it( 'hides Xdebug row when beta feature is disabled', async () => {
+			// Create a store with xdebugSupport disabled
+			const storeWithoutXdebug = createTestStore( {
+				providerConstants: {
+					defaultPhpVersion: '8.3',
+					defaultWordPressVersion: 'latest',
+					allowedPhpVersions: [ '8.0', '8.1', '8.2', '8.3' ],
+					minimumWordPressVersion: '6.2.6',
+				},
+				preloadedState: {
+					betaFeatures: {
+						features: {
+							multiWorkerSupport: false,
+							xdebugSupport: false,
+						},
+						loading: false,
+					},
+				},
+			} );
+
+			render(
+				<Provider store={ storeWithoutXdebug }>
+					<ContentTabSettings selectedSite={ selectedSite } />
+				</Provider>
+			);
+
+			await waitFor( () => {
+				expect( getAllCustomDomains ).toHaveBeenCalled();
+			} );
+
+			// Xdebug row should not be visible
+			expect( screen.queryByText( 'Xdebug' ) ).not.toBeInTheDocument();
 		} );
 	} );
 

--- a/src/components/tests/content-tab-settings.test.tsx
+++ b/src/components/tests/content-tab-settings.test.tsx
@@ -164,7 +164,9 @@ describe( 'ContentTabSettings', () => {
 			screen.getByRole( 'button', { name: 'localhost:8881, Copy site url to clipboard' } )
 		).toHaveTextContent( 'localhost:8881' );
 		expect( screen.getByText( 'HTTPS' ) ).toBeVisible();
-		expect( screen.getByText( 'Disabled' ) ).toBeVisible();
+		expect( screen.getByText( 'Xdebug' ) ).toBeVisible();
+		// Both HTTPS and Xdebug show "Disabled"
+		expect( screen.getAllByText( 'Disabled' ) ).toHaveLength( 2 );
 		expect( screen.getByRole( 'button', { name: 'Copy local path to clipboard' } ) ).toBeVisible();
 		expect( screen.getByText( '7.7.7' ) ).toBeVisible();
 		expect(

--- a/src/components/tests/content-tab-settings.test.tsx
+++ b/src/components/tests/content-tab-settings.test.tsx
@@ -56,6 +56,7 @@ let testStore = createTestStore( {
 	preloadedState: {
 		betaFeatures: {
 			features: {
+				studioSitesCli: false,
 				multiWorkerSupport: false,
 				xdebugSupport: true,
 			},
@@ -76,6 +77,7 @@ function createCustomTestStore() {
 		preloadedState: {
 			betaFeatures: {
 				features: {
+					studioSitesCli: false,
 					multiWorkerSupport: false,
 					xdebugSupport: true,
 				},
@@ -289,6 +291,7 @@ describe( 'ContentTabSettings', () => {
 				preloadedState: {
 					betaFeatures: {
 						features: {
+							studioSitesCli: false,
 							multiWorkerSupport: false,
 							xdebugSupport: false,
 						},

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -162,6 +162,18 @@ export async function getSiteDetails( _event: IpcMainInvokeEvent ): Promise< Sit
 	return mergeSiteDetailsWithRunningDetails( sites );
 }
 
+export async function getXdebugEnabledSite(
+	_event: IpcMainInvokeEvent
+): Promise< SiteDetails | null > {
+	const userData = await loadUserData();
+	const { sites } = userData;
+	const xdebugSite = sites.find( ( site ) => site.enableXdebug );
+	if ( ! xdebugSite ) {
+		return null;
+	}
+	return mergeSiteDetailsWithRunningDetails( [ xdebugSite ] )[ 0 ] || null;
+}
+
 export async function importSite(
 	event: IpcMainInvokeEvent,
 	{ id, backupFile }: { id: string; backupFile: BackupArchiveInfo }

--- a/src/ipc-types.d.ts
+++ b/src/ipc-types.d.ts
@@ -29,6 +29,7 @@ interface StoppedSiteDetails {
 	};
 	isAddingSite?: boolean;
 	autoStart?: boolean;
+	enableXdebug?: boolean;
 }
 
 interface StartedSiteDetails extends StoppedSiteDetails {
@@ -84,6 +85,7 @@ interface FeatureFlags {
 interface BetaFeatures {
 	studioSitesCli: boolean;
 	multiWorkerSupport: boolean;
+	xdebugSupport: boolean;
 }
 
 interface AppGlobals extends FeatureFlags {

--- a/src/lib/beta-features.ts
+++ b/src/lib/beta-features.ts
@@ -20,6 +20,12 @@ const BETA_FEATURES_DEFINITION: Record< keyof BetaFeatures, BetaFeatureDefinitio
 		default: false,
 		description: 'Enable multi-worker PHP processing for faster performance',
 	},
+	xdebugSupport: {
+		label: 'Xdebug Support',
+		key: 'xdebugSupport',
+		default: false,
+		description: 'Enable PHP debugging with Xdebug (one site at a time)',
+	},
 } as const;
 
 export const BETA_FEATURES: Record< keyof BetaFeatures, BetaFeatureDefinition > =

--- a/src/lib/wordpress-provider/playground-cli/playground-cli-provider.ts
+++ b/src/lib/wordpress-provider/playground-cli/playground-cli-provider.ts
@@ -62,16 +62,21 @@ export class PlaygroundCliProvider implements WordPressProvider {
 		siteLanguage?: string;
 		wpCliPharPath?: string;
 		blueprint?: Blueprint;
+		enableXdebug?: boolean;
 	} ): Promise< WordPressServerInstance > {
 		const port = options.port;
 		const phpVersion = options.phpVersion || '8.3';
 		const hasWordPress = isWordPressDirectory( options.path );
 
-		// Get beta features to check if multi-worker support is enabled
+		// Get beta features to check if multi-worker and xdebug support are enabled
 		const betaFeatures = await getBetaFeatures();
 
 		if ( betaFeatures.multiWorkerSupport ) {
 			console.log( '[PlaygroundCliProvider] Multi-worker support is enabled via beta features' );
+		}
+
+		if ( betaFeatures.xdebugSupport && options.enableXdebug ) {
+			console.log( '[PlaygroundCliProvider] Xdebug support is enabled for this site' );
 		}
 
 		const playgroundOptions: PlaygroundCliOptions = {
@@ -84,6 +89,7 @@ export class PlaygroundCliProvider implements WordPressProvider {
 				: 'download-and-install',
 			blueprint: options.blueprint,
 			enableMultiWorker: betaFeatures.multiWorkerSupport,
+			enableXdebug: betaFeatures.xdebugSupport && options.enableXdebug,
 		};
 
 		const serverOptions: WordPressServerOptions = {

--- a/src/lib/wordpress-provider/playground-cli/playground-cli-provider.ts
+++ b/src/lib/wordpress-provider/playground-cli/playground-cli-provider.ts
@@ -28,6 +28,7 @@ export interface PlaygroundCliOptions {
 	wordpressInstallMode: WordPressInstallMode;
 	blueprint?: Blueprint;
 	enableMultiWorker?: boolean;
+	enableXdebug?: boolean;
 }
 
 export const PLAYGROUND_CLI_PROVIDER_NAME = 'playground-cli';

--- a/src/lib/wordpress-provider/playground-cli/playground-server-process-child.ts
+++ b/src/lib/wordpress-provider/playground-cli/playground-server-process-child.ts
@@ -232,7 +232,6 @@ async function startServer(
 		if ( options.enableXdebug ) {
 			console.log( __( 'Enabling Xdebug support' ) );
 			args.xdebug = true;
-			//args.experimentalUnsafeIdeIntegration = 'phpstorm';
 		}
 
 		if ( options.phpVersion ) {

--- a/src/lib/wordpress-provider/playground-cli/playground-server-process-child.ts
+++ b/src/lib/wordpress-provider/playground-cli/playground-server-process-child.ts
@@ -228,6 +228,13 @@ async function startServer(
 			args.experimentalMultiWorker = workerCount;
 		}
 
+		// Enable Xdebug support if requested
+		if ( options.enableXdebug ) {
+			console.log( __( 'Enabling Xdebug support' ) );
+			args.xdebug = true;
+			//args.experimentalUnsafeIdeIntegration = 'phpstorm';
+		}
+
 		if ( options.phpVersion ) {
 			args.php = options.phpVersion as SupportedPHPVersion;
 		}

--- a/src/lib/wordpress-provider/types.ts
+++ b/src/lib/wordpress-provider/types.ts
@@ -14,6 +14,7 @@ export interface ServerOptions {
 	absoluteUrl?: string;
 	siteLanguage?: string;
 	blueprint?: Blueprint[ 'blueprint' ];
+	enableXdebug?: boolean;
 }
 
 export interface WordPressServerOptions {

--- a/src/modules/site-settings/edit-site-details.tsx
+++ b/src/modules/site-settings/edit-site-details.tsx
@@ -342,7 +342,15 @@ const EditSiteDetails = ( { currentWpVersion, onSave }: EditSiteDetailsProps ) =
 							</div>
 
 							{ isXdebugFeatureEnabled && (
-								<div className="flex flex-col gap-2 mt-4 p-4 border border-a8c-gray-200 rounded">
+								<div
+								className={ cx(
+									'flex flex-col gap-2 mt-4 p-4 border border-a8c-gray-200 rounded',
+									isEditingSite ||
+										( xdebugEnabledSite && xdebugEnabledSite.id !== selectedSite?.id )
+										? 'opacity-50 cursor-not-allowed'
+										: ''
+								) }
+							>
 									<Tooltip
 										disabled={ ! xdebugEnabledSite || xdebugEnabledSite.id === selectedSite?.id }
 										text={ sprintf(

--- a/src/modules/site-settings/edit-site-details.tsx
+++ b/src/modules/site-settings/edit-site-details.tsx
@@ -343,14 +343,14 @@ const EditSiteDetails = ( { currentWpVersion, onSave }: EditSiteDetailsProps ) =
 
 							{ isXdebugFeatureEnabled && (
 								<div
-								className={ cx(
-									'flex flex-col gap-2 mt-4 p-4 border border-a8c-gray-200 rounded',
-									isEditingSite ||
-										( xdebugEnabledSite && xdebugEnabledSite.id !== selectedSite?.id )
-										? 'opacity-50 cursor-not-allowed'
-										: ''
-								) }
-							>
+									className={ cx(
+										'flex flex-col gap-2 mt-4',
+										isEditingSite ||
+											( xdebugEnabledSite && xdebugEnabledSite.id !== selectedSite?.id )
+											? 'opacity-50 cursor-not-allowed'
+											: ''
+									) }
+								>
 									<Tooltip
 										disabled={ ! xdebugEnabledSite || xdebugEnabledSite.id === selectedSite?.id }
 										text={ sprintf(
@@ -361,28 +361,49 @@ const EditSiteDetails = ( { currentWpVersion, onSave }: EditSiteDetailsProps ) =
 										) }
 										placement="top-start"
 									>
-										<div className="flex items-center gap-2">
-											<input
-												type="checkbox"
-												id="enable-xdebug"
-												checked={ enableXdebug }
-												onChange={ ( e ) => setEnableXdebug( e.target.checked ) }
-												disabled={
-													isEditingSite ||
-													!! ( xdebugEnabledSite && xdebugEnabledSite.id !== selectedSite?.id )
-												}
-											/>
-											<label htmlFor="enable-xdebug" className="font-semibold">
-												{ __( 'Enable Xdebug' ) }
-											</label>
+										<div>
+											<div className="flex items-center gap-2">
+												<input
+													type="checkbox"
+													id="enable-xdebug"
+													checked={ enableXdebug }
+													onChange={ ( e ) => setEnableXdebug( e.target.checked ) }
+													disabled={
+														isEditingSite ||
+														!! ( xdebugEnabledSite && xdebugEnabledSite.id !== selectedSite?.id )
+													}
+												/>
+												<label
+													htmlFor="enable-xdebug"
+													className={ cx(
+														'font-semibold',
+														isEditingSite ||
+															( xdebugEnabledSite && xdebugEnabledSite.id !== selectedSite?.id )
+															? 'cursor-not-allowed'
+															: ''
+													) }
+												>
+													{ __( 'Enable Xdebug' ) }
+												</label>
+											</div>
+											<div className="text-a8c-gray-50 text-xs mt-2">
+												{ __(
+													'Enable PHP debugging with Xdebug. Only one site can have Xdebug enabled at a time. Note that Xdebug may slow down site performance.'
+												) }{ ' ' }
+												<Button
+													variant="link"
+													onClick={ () => {
+														getIpcApi().openURL(
+															'https://developer.wordpress.com/docs/developer-tools/studio/xdebug/'
+														);
+													} }
+												>
+													{ __( 'Learn more' ) }
+													<span aria-label={ __( '(opens in a web browser)' ) }>&#8599;</span>
+												</Button>
+											</div>
 										</div>
 									</Tooltip>
-									<div className="text-a8c-gray-50 text-xs">
-										{ __(
-											'Enable PHP debugging with Xdebug. Only one site can have Xdebug enabled at a time.'
-										) }{ ' ' }
-										{ __( 'Note: Xdebug may slow down site performance.' ) }
-									</div>
 								</div>
 							) }
 						</div>

--- a/src/modules/site-settings/edit-site-details.tsx
+++ b/src/modules/site-settings/edit-site-details.tsx
@@ -376,7 +376,6 @@ const EditSiteDetails = ( { currentWpVersion, onSave }: EditSiteDetailsProps ) =
 												<label
 													htmlFor="enable-xdebug"
 													className={ cx(
-														'font-semibold',
 														isEditingSite ||
 															( xdebugEnabledSite && xdebugEnabledSite.id !== selectedSite?.id )
 															? 'cursor-not-allowed'

--- a/src/modules/site-settings/edit-site-details.tsx
+++ b/src/modules/site-settings/edit-site-details.tsx
@@ -1,4 +1,5 @@
 import { SelectControl } from '@wordpress/components';
+import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import { FormEvent, useCallback, useEffect, useState } from 'react';
 import stripAnsi from 'strip-ansi';
@@ -8,12 +9,14 @@ import Button from 'src/components/button';
 import { ErrorInformation } from 'src/components/error-information';
 import Modal from 'src/components/modal';
 import TextControlComponent from 'src/components/text-control';
+import { Tooltip } from 'src/components/tooltip';
 import { WPVersionSelector } from 'src/components/wp-version-selector';
 import { useSiteDetails } from 'src/hooks/use-site-details';
 import { cx } from 'src/lib/cx';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 import { AllowedPHPVersion } from 'src/lib/wordpress-provider/constants';
 import { useRootSelector } from 'src/stores';
+import { betaFeaturesSelectors } from 'src/stores/beta-features-slice';
 import { useCheckCertificateTrustQuery } from 'src/stores/certificate-trust-api';
 import {
 	selectDefaultWordPressVersion,
@@ -33,9 +36,13 @@ const EditSiteDetails = ( { currentWpVersion, onSave }: EditSiteDetailsProps ) =
 	const defaultWordPressVersion = useRootSelector( selectDefaultWordPressVersion );
 	const allowedPhpVersions = useRootSelector( selectAllowedPhpVersions );
 	const defaultPhpVersion = useRootSelector( selectDefaultPhpVersion );
+	const betaFeatures = useRootSelector( betaFeaturesSelectors.selectBetaFeatures );
+	const isXdebugFeatureEnabled = betaFeatures.xdebugSupport;
 	const [ errorUpdatingWpVersion, setErrorUpdatingWpVersion ] = useState< string | null >( null );
 	const [ isEditingSite, setIsEditingSite ] = useState( false );
 	const [ needsRestart, setNeedsRestart ] = useState( false );
+	const [ enableXdebug, setEnableXdebug ] = useState( selectedSite?.enableXdebug ?? false );
+	const [ xdebugEnabledSite, setXdebugEnabledSite ] = useState< SiteDetails | null >( null );
 
 	const { data: isCertificateTrusted } = useCheckCertificateTrustQuery();
 	const closeModal = useCallback( () => {
@@ -79,6 +86,17 @@ const EditSiteDetails = ( { currentWpVersion, onSave }: EditSiteDetailsProps ) =
 			} );
 	}, [ selectedSite?.customDomain ] );
 
+	useEffect( () => {
+		if ( isXdebugFeatureEnabled ) {
+			getIpcApi()
+				.getXdebugEnabledSite()
+				.then( setXdebugEnabledSite )
+				.catch( () => {
+					// Do nothing
+				} );
+		}
+	}, [ isXdebugFeatureEnabled, selectedSite ] );
+
 	const generatedDomainName = generateCustomDomainFromSiteName( siteName );
 	const usedCustomDomain = ! useCustomDomain ? customDomain : undefined;
 	const isFormUnchanged =
@@ -88,7 +106,8 @@ const EditSiteDetails = ( { currentWpVersion, onSave }: EditSiteDetailsProps ) =
 		getEffectiveWpVersion() === selectedWpVersion &&
 		Boolean( selectedSite.customDomain ) === useCustomDomain &&
 		usedCustomDomain === customDomain &&
-		!! selectedSite.enableHttps === ( !! usedCustomDomain && enableHttps );
+		!! selectedSite.enableHttps === ( !! usedCustomDomain && enableHttps ) &&
+		!! selectedSite.enableXdebug === enableXdebug;
 	const hasValidationErrors =
 		! selectedSite || ! siteName.trim() || ( useCustomDomain && !! customDomainError );
 
@@ -104,6 +123,7 @@ const EditSiteDetails = ( { currentWpVersion, onSave }: EditSiteDetailsProps ) =
 		setCustomDomainError( '' );
 		setErrorUpdatingWpVersion( null );
 		setEnableHttps( selectedSite.enableHttps ?? false );
+		setEnableXdebug( selectedSite.enableXdebug ?? false );
 	}, [ selectedSite, getEffectiveWpVersion ] );
 
 	const onSiteEdit = async ( event: FormEvent ) => {
@@ -116,7 +136,9 @@ const EditSiteDetails = ( { currentWpVersion, onSave }: EditSiteDetailsProps ) =
 
 		const hasWpVersionChanged = selectedWpVersion !== getEffectiveWpVersion();
 		const hasPhpVersionChanged = selectedPhpVersion !== selectedSite.phpVersion;
-		const needsRestart = selectedSite.running && ( hasWpVersionChanged || hasPhpVersionChanged );
+		const hasXdebugChanged = enableXdebug !== selectedSite.enableXdebug;
+		const needsRestart =
+			selectedSite.running && ( hasWpVersionChanged || hasPhpVersionChanged || hasXdebugChanged );
 		setNeedsRestart( needsRestart );
 
 		try {
@@ -163,6 +185,7 @@ const EditSiteDetails = ( { currentWpVersion, onSave }: EditSiteDetailsProps ) =
 				isWpAutoUpdating: selectedWpVersion === defaultWordPressVersion,
 				customDomain: usedCustomDomain,
 				enableHttps: !! usedCustomDomain && enableHttps,
+				enableXdebug,
 			} );
 
 			if ( needsRestart ) {
@@ -317,6 +340,43 @@ const EditSiteDetails = ( { currentWpVersion, onSave }: EditSiteDetailsProps ) =
 									</div>
 								) }
 							</div>
+
+							{ isXdebugFeatureEnabled && (
+								<div className="flex flex-col gap-2 mt-4 p-4 border border-a8c-gray-200 rounded">
+									<Tooltip
+										disabled={ ! xdebugEnabledSite || xdebugEnabledSite.id === selectedSite?.id }
+										text={ sprintf(
+											__(
+												'Xdebug is currently enabled for "%s" site. Disable it there first to enable it for this site.'
+											),
+											xdebugEnabledSite?.name || ''
+										) }
+										placement="top-start"
+									>
+										<div className="flex items-center gap-2">
+											<input
+												type="checkbox"
+												id="enable-xdebug"
+												checked={ enableXdebug }
+												onChange={ ( e ) => setEnableXdebug( e.target.checked ) }
+												disabled={
+													isEditingSite ||
+													!! ( xdebugEnabledSite && xdebugEnabledSite.id !== selectedSite?.id )
+												}
+											/>
+											<label htmlFor="enable-xdebug" className="font-semibold">
+												{ __( 'Enable Xdebug' ) }
+											</label>
+										</div>
+									</Tooltip>
+									<div className="text-a8c-gray-50 text-xs">
+										{ __(
+											'Enable PHP debugging with Xdebug. Only one site can have Xdebug enabled at a time.'
+										) }{ ' ' }
+										{ __( 'Note: Xdebug may slow down site performance.' ) }
+									</div>
+								</div>
+							) }
 						</div>
 
 						<div className="flex flex-row justify-end gap-x-5 mt-8">

--- a/src/modules/site-settings/edit-site-details.tsx
+++ b/src/modules/site-settings/edit-site-details.tsx
@@ -136,7 +136,7 @@ const EditSiteDetails = ( { currentWpVersion, onSave }: EditSiteDetailsProps ) =
 
 		const hasWpVersionChanged = selectedWpVersion !== getEffectiveWpVersion();
 		const hasPhpVersionChanged = selectedPhpVersion !== selectedSite.phpVersion;
-		const hasXdebugChanged = enableXdebug !== selectedSite.enableXdebug;
+		const hasXdebugChanged = enableXdebug !== ( selectedSite.enableXdebug ?? false );
 		const needsRestart =
 			selectedSite.running && ( hasWpVersionChanged || hasPhpVersionChanged || hasXdebugChanged );
 		setNeedsRestart( needsRestart );

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -54,6 +54,7 @@ const api: IpcApi = {
 	getLastSeenVersion: () => ipcRendererInvoke( 'getLastSeenVersion' ),
 	saveLastSeenVersion: ( version ) => ipcRendererInvoke( 'saveLastSeenVersion', version ),
 	getSiteDetails: () => ipcRendererInvoke( 'getSiteDetails' ),
+	getXdebugEnabledSite: () => ipcRendererInvoke( 'getXdebugEnabledSite' ),
 	openSiteURL: ( id, relativeURL = '', { autoLogin = true } = {} ) =>
 		ipcRendererSend( 'openSiteURL', id, relativeURL, { autoLogin } ),
 	openURL: ( url ) => ipcRendererSend( 'openURL', url ),

--- a/src/site-server.ts
+++ b/src/site-server.ts
@@ -193,6 +193,7 @@ export class SiteServer {
 			isWpAutoUpdating: site.isWpAutoUpdating,
 			customDomain: site.customDomain,
 			enableHttps: site.enableHttps,
+			enableXdebug: site.enableXdebug,
 		};
 
 		if ( this.server && this.details.running ) {

--- a/src/site-server.ts
+++ b/src/site-server.ts
@@ -144,6 +144,7 @@ export class SiteServer {
 			isWpAutoUpdating: this.details.isWpAutoUpdating,
 			absoluteUrl: getAbsoluteUrl( this.details ),
 			blueprint: filteredBlueprint,
+			enableXdebug: this.details.enableXdebug,
 		} );
 
 		const isPortAvailable = await portFinder.isPortAvailable( this.details.port );

--- a/src/storage/user-data.ts
+++ b/src/storage/user-data.ts
@@ -164,6 +164,7 @@ function toDiskFormat( { sites, ...rest }: UserData ): PersistedUserData {
 				customDomain,
 				enableHttps,
 				autoStart,
+				enableXdebug,
 			} ) => {
 				// No object spreading allowed. TypeScript's structural typing is too permissive and
 				// will permit us to persist properties that aren't in the type definition.
@@ -179,6 +180,7 @@ function toDiskFormat( { sites, ...rest }: UserData ): PersistedUserData {
 					customDomain,
 					enableHttps,
 					autoStart,
+					enableXdebug,
 					themeDetails: {
 						name: themeDetails?.name || '',
 						path: themeDetails?.path || '',

--- a/src/stores/beta-features-slice.ts
+++ b/src/stores/beta-features-slice.ts
@@ -11,6 +11,7 @@ const initialState: BetaFeaturesState = {
 	features: {
 		studioSitesCli: false,
 		multiWorkerSupport: false,
+		xdebugSupport: false,
 	},
 	loading: false,
 };

--- a/src/tests/ipc-handlers.test.ts
+++ b/src/tests/ipc-handlers.test.ts
@@ -9,7 +9,13 @@ import { readFile } from 'atomically';
 import { bumpStat } from 'common/lib/bump-stat';
 import { isEmptyDir, pathExists } from 'common/lib/fs-utils';
 import { StatsGroup, StatsMetric } from 'common/types/stats';
-import { createSite, startServer, isFullscreen, importSite } from 'src/ipc-handlers';
+import {
+	createSite,
+	startServer,
+	isFullscreen,
+	importSite,
+	getXdebugEnabledSite,
+} from 'src/ipc-handlers';
 import { importBackup, defaultImporterOptions } from 'src/lib/import-export/import/import-manager';
 import { BackupArchiveInfo } from 'src/lib/import-export/import/types';
 import { keepSqliteIntegrationUpdated } from 'src/lib/sqlite-versions';
@@ -270,5 +276,82 @@ describe( 'importSite', () => {
 
 		// Verify failure stats were bumped
 		expect( bumpStat ).toHaveBeenCalledWith( StatsGroup.STUDIO_IMPORT, StatsMetric.FAILURE );
+	} );
+} );
+
+describe( 'getXdebugEnabledSite', () => {
+	it( 'should return null when no site has Xdebug enabled', async () => {
+		const mockUserDataWithoutXdebug = {
+			sites: [
+				{ id: 'site-1', name: 'Site 1', path: '/path/to/site-1', enableXdebug: false },
+				{ id: 'site-2', name: 'Site 2', path: '/path/to/site-2' },
+			],
+		};
+		( readFile as jest.Mock ).mockResolvedValue( JSON.stringify( mockUserDataWithoutXdebug ) );
+		( fs.existsSync as jest.Mock ).mockReturnValue( true );
+
+		const result = await getXdebugEnabledSite( mockIpcMainInvokeEvent );
+
+		expect( result ).toBeNull();
+	} );
+
+	it( 'should return the site that has Xdebug enabled', async () => {
+		const mockUserDataWithXdebug = {
+			sites: [
+				{ id: 'site-1', name: 'Site 1', path: '/path/to/site-1', enableXdebug: false },
+				{ id: 'site-2', name: 'Site 2', path: '/path/to/site-2', enableXdebug: true },
+			],
+		};
+		( readFile as jest.Mock ).mockResolvedValue( JSON.stringify( mockUserDataWithXdebug ) );
+		( fs.existsSync as jest.Mock ).mockReturnValue( true );
+		( SiteServer.get as jest.Mock ).mockReturnValue( {
+			details: {
+				id: 'site-2',
+				name: 'Site 2',
+				path: '/path/to/site-2',
+				running: true,
+				enableXdebug: true,
+			},
+		} );
+
+		const result = await getXdebugEnabledSite( mockIpcMainInvokeEvent );
+
+		expect( result ).toEqual( {
+			id: 'site-2',
+			name: 'Site 2',
+			path: '/path/to/site-2',
+			running: true,
+			enableXdebug: true,
+		} );
+	} );
+
+	it( 'should return the first site when multiple have Xdebug enabled', async () => {
+		const mockUserDataWithMultipleXdebug = {
+			sites: [
+				{ id: 'site-1', name: 'Site 1', path: '/path/to/site-1', enableXdebug: true },
+				{ id: 'site-2', name: 'Site 2', path: '/path/to/site-2', enableXdebug: true },
+			],
+		};
+		( readFile as jest.Mock ).mockResolvedValue( JSON.stringify( mockUserDataWithMultipleXdebug ) );
+		( fs.existsSync as jest.Mock ).mockReturnValue( true );
+		( SiteServer.get as jest.Mock ).mockReturnValue( {
+			details: {
+				id: 'site-1',
+				name: 'Site 1',
+				path: '/path/to/site-1',
+				running: false,
+				enableXdebug: true,
+			},
+		} );
+
+		const result = await getXdebugEnabledSite( mockIpcMainInvokeEvent );
+
+		expect( result ).toEqual( {
+			id: 'site-1',
+			name: 'Site 1',
+			path: '/path/to/site-1',
+			running: false,
+			enableXdebug: true,
+		} );
 	} );
 } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-1156

## Proposed Changes

  - Add Xdebug support for WordPress sites with beta feature flag
  - Implement UI toggle in Edit Site Details modal with one-site-at-a-time constraint
  - Add full persistence across app restarts (site details, storage, and IPC layer)
  - Show tooltip when Xdebug is enabled on another site
  - Show Xdebug status in site's Settings

|**Xdebug enabled for a site**|**Restarting site on save**|**Xdebug not available for other site**|
|---|---|---|
|<img width="1028" height="712" alt="CleanShot 2025-12-17 at 16 09 38" src="https://github.com/user-attachments/assets/c36bf8b9-390f-4588-acd1-d3c1f14c1279" />|<img width="1028" height="712" alt="CleanShot 2025-12-17 at 16 09 44" src="https://github.com/user-attachments/assets/8a93239c-acfa-4b3b-a398-5cf9f115f776" />|<img width="1028" height="712" alt="CleanShot 2025-12-17 at 16 10 02" src="https://github.com/user-attachments/assets/5014e966-88d0-49d8-8bfa-5f702eda97e1" />|

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Test feature in Studio

  1. Enable "Xdebug Support" beta feature in Settings → Beta Features
  2. Open Edit Site Details for any site
  3. Check "Enable Xdebug" checkbox and save
  4. Verify site restarts ~~and console shows "Enabling Xdebug support"~~
  5. Open Edit Site Details again - verify checkbox remains checked
  6. Restart the app - verify Xdebug setting persists
  7. Try enabling Xdebug on a second site - verify checkbox is disabled with tooltip explaining why
  8. Disable Xdebug on first site - verify second site's checkbox becomes enabled

### Test debugging in IDE

I used PhpStorm:

1. Create a site
2. Enable Xdebug and start the site
3. Open the site in PhpStorm
4. To stop breaking at the first line in PHPStorm, open Settings > PHP > Debug > Xdebug:
    - Disable > Force break at first line when no path mapping specified
    - Disable > Force break at first line when a script is outside the project
5. Open WP Admin using link in Studio
6. In PhpStorm, open the path mapping notification (or navigate to PHP|Servers) and configure mapping for your site's server:
   - Host: localhost:8884
   - Port: 80
   - File directory: /Users/USERNAME/Studio/SITEDIR
   - Absolute path on the server: `/wordpress`
7. Add a breakpoint somewhere, e.g. in wp-config.php file
8. Refresh WP Admin
9. Confirm PhpStorm stops execution on the breakpoint

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
