### PR TITLE
Fix Studio Assistant download plugins wp-cli commands by mounting Studio mu-plugins

### DIFF
--- a/src/lib/wordpress-provider/playground-cli/wp-cli-executor.ts
+++ b/src/lib/wordpress-provider/playground-cli/wp-cli-executor.ts
@@ -9,7 +9,9 @@ import {
 	writeFiles,
 	setPhpIniEntries,
 } from '@php-wasm/universal';
+import { setupPlatformLevelMuPlugins } from '@wp-playground/wordpress';
 import { pathExists } from 'common/lib/fs-utils';
+import { getMuPlugins } from 'common/lib/mu-plugins';
 
 const PLAYGROUND_INTERNAL_SHARED_FOLDER = '/internal/shared';
 
@@ -77,6 +79,22 @@ export async function executeWPCli(
 		await setPhpIniEntries( php, {
 			'openssl.cafile': caBundlePath,
 		} );
+
+		// Mount mu-plugins
+		const [ studioMuPluginsHostPath, loaderMuPluginHostPath ] = await getMuPlugins( {
+			isWpAutoUpdating: false,
+		} );
+		await php.mount(
+			'/internal/studio/mu-plugins',
+			createNodeFsMountHandler( studioMuPluginsHostPath ) as unknown as MountHandler
+		);
+		await php.mount(
+			PLAYGROUND_INTERNAL_SHARED_FOLDER + '/mu-plugins/99-studio-loader.php',
+			createNodeFsMountHandler( loaderMuPluginHostPath ) as unknown as MountHandler
+		);
+
+		// Set up platform-level mu-plugins to load the studio loader from /internal/shared/mu-plugins
+		await setupPlatformLevelMuPlugins( php );
 
 		// Execute WP-CLI command
 		return await executeWPCliInPHP( php, args, '/wordpress' );


### PR DESCRIPTION

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-1126

## Proposed Changes

- Mount Studio mu-plugins before executing a wp-cli command

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Confirm the issue is fixed**

- Run `npm start`
- Go to the Assistant tab
- Ask to install woocommerce
- Execute the wp-cli command
- Confirm that it works as expected and the plugin is installed
- Go to the mu-plugins folder of your site and confirm there is no new files. Only the `sqlite-database-integration`.

**Try other wp-cli commands like sqlite export**
- Go to the Import/Export tab
- Export your site
- Confirm that the site is correctly exported

| Before | After |
|--------|--------|
|  <img width="1120" height="556" alt="image (10)" src="https://github.com/user-attachments/assets/1054d355-5e2a-4181-98dd-d4295ce84b8d" /> | <img width="849" height="352" alt="Screenshot 2025-12-12 at 10 52 08" src="https://github.com/user-attachments/assets/610f5b9d-1d5f-4339-abec-845dbce18b6c" /> |


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
