### PR TITLE
Render app arch inside About dialog

### DIFF
--- a/src/about-menu/about-menu.html
+++ b/src/about-menu/about-menu.html
@@ -72,6 +72,10 @@
     font-weight: 600;
     line-height: 20px;
   }
+
+  .version {
+    user-select: all;
+  }
 </style>
   <title>About WordPress Studio</title>
 </head>
@@ -81,7 +85,7 @@
     Please make sure to update the corresponding strings in the open-about-menu.ts file -->
     <img src="./studio-app-icon.png" alt="Studio App Icon" width="64" height="64">
         <p class="studio-name" id="studio-by-wpcom">WordPress Studio</p>
-        <p class="version"><span id="version-text">Version x.y.z</span></p>
+        <p class="version"><span id="version-text">x.y.z (...)</span></p>
         <p class="links">
           <a href="https://github.com/Automattic/studio" target="_blank">GitHub</a>
           <span class="separator">&middot;</span>

--- a/src/about-menu/open-about-menu.ts
+++ b/src/about-menu/open-about-menu.ts
@@ -1,7 +1,7 @@
 import { BrowserWindow, app } from 'electron';
 import path from 'path';
 import * as Sentry from '@sentry/electron/renderer';
-import { sprintf, __ } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { ABOUT_WINDOW_HEIGHT, ABOUT_WINDOW_WIDTH } from 'src/constants';
 import { shellOpenExternalWrapper } from 'src/lib/shell-open-external-wrapper';
 
@@ -16,10 +16,10 @@ function getPlatformLabel(): string {
 	const arch = process.arch;
 
 	if ( platform === 'darwin' ) {
-		return arch === 'arm64' ? 'macOS Apple Silicon' : 'macOS Intel';
+		return arch === 'arm64' ? __( 'Mac with Apple Silicon Chip' ) : __( 'Mac with Intel Chip' );
 	}
 	if ( platform === 'win32' ) {
-		return arch === 'arm64' ? 'Windows ARM64' : 'Windows x64';
+		return arch === 'arm64' ? __( 'Windows on ARM' ) : __( 'Windows on Intel/AMD' );
 	}
 	return `${ platform } ${ arch }`;
 }
@@ -57,20 +57,18 @@ export function openAboutWindow() {
 	aboutWindow.webContents.on( 'dom-ready', () => {
 		if ( aboutWindow ) {
 			//When updating these strings, make sure to update the corresponding strings in the about-menu.html file
-			const versionText = sprintf( __( 'Version %s' ), packageJson );
+			const versionText = escapeSingleQuotes( `${ packageJson } (${ getPlatformLabel() })` );
 			const studioByWpcomText = escapeSingleQuotes( __( 'WordPress Studio' ) );
 			const aboutStudioText = escapeSingleQuotes( __( 'About WordPress Studio' ) );
 			const shareFeedbackText = escapeSingleQuotes( __( 'Share Feedback' ) );
 			const releasesText = escapeSingleQuotes( __( 'Release Notes' ) );
 			const demoSitesText = escapeSingleQuotes( __( 'Preview sites powered by' ) );
 			const localSitesText = escapeSingleQuotes( __( 'Local sites powered by' ) );
-			const systemInfoTooltip = escapeSingleQuotes( getPlatformLabel() );
 
 			const script = `
 				document.title = '${ aboutStudioText }';
 				document.getElementById('studio-by-wpcom').innerText = '${ studioByWpcomText }';
 				document.getElementById('version-text').innerText = '${ versionText }';
-				document.getElementById('version-text').title = '${ systemInfoTooltip }';
 				document.getElementById('share-feedback').innerText = '${ shareFeedbackText }';
 				document.getElementById('release-notes').innerText = '${ releasesText }';
 				document.getElementById('demo-sites').innerText = '${ demoSitesText }';

--- a/src/about-menu/open-about-menu.ts
+++ b/src/about-menu/open-about-menu.ts
@@ -11,6 +11,19 @@ export function escapeSingleQuotes( str: string ) {
 	return str.replace( /\\/g, '\\\\' ).replace( /'/g, "\\'" );
 }
 
+function getPlatformLabel(): string {
+	const platform = process.platform;
+	const arch = process.arch;
+
+	if ( platform === 'darwin' ) {
+		return arch === 'arm64' ? 'macOS Apple Silicon' : 'macOS Intel';
+	}
+	if ( platform === 'win32' ) {
+		return arch === 'arm64' ? 'Windows ARM64' : 'Windows x64';
+	}
+	return `${ platform } ${ arch }`;
+}
+
 export function openAboutWindow() {
 	const aboutPath = path.join( __dirname, 'about-menu.html' );
 
@@ -51,11 +64,13 @@ export function openAboutWindow() {
 			const releasesText = escapeSingleQuotes( __( 'Release Notes' ) );
 			const demoSitesText = escapeSingleQuotes( __( 'Preview sites powered by' ) );
 			const localSitesText = escapeSingleQuotes( __( 'Local sites powered by' ) );
+			const systemInfoTooltip = escapeSingleQuotes( getPlatformLabel() );
 
 			const script = `
 				document.title = '${ aboutStudioText }';
 				document.getElementById('studio-by-wpcom').innerText = '${ studioByWpcomText }';
 				document.getElementById('version-text').innerText = '${ versionText }';
+				document.getElementById('version-text').title = '${ systemInfoTooltip }';
 				document.getElementById('share-feedback').innerText = '${ shareFeedbackText }';
 				document.getElementById('release-notes').innerText = '${ releasesText }';
 				document.getElementById('demo-sites').innerText = '${ demoSitesText }';


### PR DESCRIPTION
## Proposed Changes
I am working on STU-1069, and I didn't know how to determine whether the arm version is installed or not. I had an assumption that maybe the bug is on the frontend and it's just UI bug. I decided that would be usefull to somewhere render the arch. So I added it as a title for the Studio version, to avoid being intrusive in the dialog. I think it will be useful for our team in the future.

## Testing Instructions
1. Build Studio and run it on macOS and Windows.
2. Assert that you see correct app version and arch inside About window<br /><img width="303" height="354" alt="Screenshot 2025-12-12 at 15 58 09" src="https://github.com/user-attachments/assets/19a005a1-b81a-43f2-92d6-0c55b718d664" />