### PR TITLE
Attempt to trigger dev builds on `dev/studio-cli-i2`

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -164,7 +164,7 @@ steps:
       - step: dev-mac
       - step: dev-windows
     plugins: [$CI_TOOLKIT_PLUGIN, $NVM_PLUGIN]
-    if: build.branch == 'trunk' && build.tag !~ /^v[0-9]+/
+    if: ( build.branch == 'trunk' && build.tag !~ /^v[0-9]+/ ) || build.branch == 'dev/studio-cli-i2'
     notify:
       - github_commit_status:
           context: Distribute Dev Builds


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

–

## Proposed Changes

To publish the Studio CLI i2 CfT P2 post, we need a dev build that testers can download. Buildkite only creates dev builds for `trunk` commits, but we are using the `dev/studio-cli-i2` branch for the CLI i2 project. So, this PR attempts to also trigger dev builds on the `dev/studio-cli-i2` branch by tweaking `.buildkite/pipeline.yml`.

I already merged this to the `dev/studio-cli-i2` branch, but that didn't make any difference, so I wanted to try and merge it to `trunk`. It'd be great if someone from Apps infra could take a quick look 🙏

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

N/A

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
