### PR TITLE
Fix WP auto-updates not being enforced when enabled in Studio

### DIFF
--- a/common/lib/mu-plugins.ts
+++ b/common/lib/mu-plugins.ts
@@ -245,7 +245,7 @@ function getStandardMuPlugins( options: MuPluginOptions ): MuPlugin[] {
 		`,
 	} );
 
-	// Disable auto-updates if configured
+	// Configure auto-updates based on Studio settings
 	if ( ! options.isWpAutoUpdating ) {
 		muPlugins.push( {
 			filename: '0-disable-auto-updates.php',
@@ -254,6 +254,16 @@ function getStandardMuPlugins( options: MuPluginOptions ): MuPlugin[] {
 			add_filter( 'allow_dev_auto_core_updates', '__return_false' );
 			add_filter( 'allow_minor_auto_core_updates', '__return_false' );
 			add_filter( 'allow_major_auto_core_updates', '__return_false' );
+			`,
+		} );
+	} else {
+		muPlugins.push( {
+			filename: '0-enable-auto-updates.php',
+			content: `<?php
+			// Enable auto-updates
+			add_filter( 'allow_dev_auto_core_updates', '__return_true' );
+			add_filter( 'allow_minor_auto_core_updates', '__return_true' );
+			add_filter( 'allow_major_auto_core_updates', '__return_true' );
 			`,
 		} );
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-1139

## Proposed Changes

Studio only disabled auto-updates when the setting was off, but didn't actively enable them when on. This meant WordPress sites with auto-updates already disabled in their database wouldn't respect Studio's enable setting.

This PR ensures Studio's auto-update setting is the source of truth by explicitly enabling auto-updates when `isWpAutoUpdating` is true.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create a site using WordPress 6.8
2. Open WP Admin
3. Confirm the site uses 6.8.3
4. Navigate to Updates and confirm that auto updates are disabled:

> This site will not receive automatic updates for new versions of WordPress

5. Open Studio site in Terminal
6. Disable auto-updates in WP using option:

```
wp option set auto_update_core_major unset
```

8. Stop Studio
9. Update site in appdata-v1.json file and set isWpAutoUpdating to true
10. Start Studio
11. Open WP Admin
12. Navigate to Updates and confirm that auto updates are enabled

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
