### PR TITLE
Studio: Make sure that Publish site button navigates to WP.com

### DIFF
--- a/src/components/publish-site-button.tsx
+++ b/src/components/publish-site-button.tsx
@@ -1,8 +1,8 @@
 import { cloudUpload } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { useCallback } from 'react';
+import { useSyncSites } from 'src/hooks/sync-sites';
 import { useAuth } from 'src/hooks/use-auth';
-import { useOffline } from 'src/hooks/use-offline';
 import { useSiteDetails } from 'src/hooks/use-site-details';
 import { generateCheckoutUrl } from 'src/lib/generate-checkout-url';
 import { getIpcApi } from 'src/lib/get-ipc-api';
@@ -11,13 +11,14 @@ import { useGetConnectedSitesForLocalSiteQuery } from 'src/stores/sync/connected
 
 export const PublishSiteButton = () => {
 	const { __ } = useI18n();
-	const isOffline = useOffline();
 	const { user } = useAuth();
 	const { selectedSite } = useSiteDetails();
 	const { data: connectedSites = [] } = useGetConnectedSitesForLocalSiteQuery( {
 		localSiteId: selectedSite?.id,
 		userId: user?.id,
 	} );
+	const { isAnySitePulling, isAnySitePushing } = useSyncSites();
+	const isAnySiteSyncing = isAnySitePulling || isAnySitePushing;
 
 	const handlePublishClick = useCallback( () => {
 		getIpcApi().openURL( generateCheckoutUrl( selectedSite ?? undefined ) );
@@ -30,8 +31,14 @@ export const PublishSiteButton = () => {
 			variant="primary"
 			icon={ cloudUpload }
 			connectSite={ handlePublishClick }
-			disabled={ isOffline }
-			tooltipText={ __( 'Publishing your site requires an internet connection.' ) }
+			disabled={ isAnySiteSyncing }
+			tooltipText={
+				isAnySiteSyncing
+					? __(
+							'Another site is syncing. Please wait for the sync to finish before you publish your site.'
+					  )
+					: __( 'Publishing your site requires an internet connection.' )
+			}
 		>
 			{ __( 'Publish site' ) }
 		</ConnectButton>

--- a/src/components/publish-site-button.tsx
+++ b/src/components/publish-site-button.tsx
@@ -1,37 +1,27 @@
 import { cloudUpload } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { useCallback } from 'react';
-import { useSyncSites } from 'src/hooks/sync-sites';
 import { useAuth } from 'src/hooks/use-auth';
-import { useContentTabs } from 'src/hooks/use-content-tabs';
+import { useOffline } from 'src/hooks/use-offline';
 import { useSiteDetails } from 'src/hooks/use-site-details';
+import { generateCheckoutUrl } from 'src/lib/generate-checkout-url';
+import { getIpcApi } from 'src/lib/get-ipc-api';
 import { ConnectButton } from 'src/modules/sync/components/connect-button';
-import { useAppDispatch } from 'src/stores';
-import {
-	connectedSitesActions,
-	useGetConnectedSitesForLocalSiteQuery,
-} from 'src/stores/sync/connected-sites';
+import { useGetConnectedSitesForLocalSiteQuery } from 'src/stores/sync/connected-sites';
 
 export const PublishSiteButton = () => {
 	const { __ } = useI18n();
-	const dispatch = useAppDispatch();
-	const { setSelectedTab } = useContentTabs();
-	const { user, authenticate } = useAuth();
+	const isOffline = useOffline();
+	const { user } = useAuth();
 	const { selectedSite } = useSiteDetails();
 	const { data: connectedSites = [] } = useGetConnectedSitesForLocalSiteQuery( {
 		localSiteId: selectedSite?.id,
 		userId: user?.id,
 	} );
-	const { isAnySitePulling, isAnySitePushing } = useSyncSites();
-	const isAnySiteSyncing = isAnySitePulling || isAnySitePushing;
 
 	const handlePublishClick = useCallback( () => {
-		if ( ! user ) {
-			authenticate();
-		}
-		dispatch( connectedSitesActions.openModal( 'push' ) );
-		setSelectedTab( 'sync' );
-	}, [ user, setSelectedTab, dispatch, authenticate ] );
+		getIpcApi().openURL( generateCheckoutUrl( selectedSite ?? undefined ) );
+	}, [ selectedSite ] );
 
 	if ( connectedSites.length !== 0 ) return null;
 
@@ -40,14 +30,8 @@ export const PublishSiteButton = () => {
 			variant="primary"
 			icon={ cloudUpload }
 			connectSite={ handlePublishClick }
-			disabled={ isAnySiteSyncing }
-			tooltipText={
-				isAnySiteSyncing
-					? __(
-							'Another site is syncing. Please wait for the sync to finish before you publish your site.'
-					  )
-					: __( 'Publishing your site requires an internet connection.' )
-			}
+			disabled={ isOffline }
+			tooltipText={ __( 'Publishing your site requires an internet connection.' ) }
 		>
 			{ __( 'Publish site' ) }
 		</ConnectButton>

--- a/src/lib/generate-checkout-url.ts
+++ b/src/lib/generate-checkout-url.ts
@@ -1,0 +1,20 @@
+import { DEFAULT_CUSTOM_DOMAIN_SUFFIX } from 'common/constants';
+
+export function generateCheckoutUrl( selectedSite?: SiteDetails ): string {
+	const url = new URL(
+		'https://wordpress.com/setup/new-hosted-site?ref=studio&section=studio-sync&showDomainStep'
+	);
+
+	if ( ! selectedSite ) {
+		return url.toString();
+	}
+
+	const suggestedName = selectedSite.customDomain
+		? selectedSite.customDomain.replace( DEFAULT_CUSTOM_DOMAIN_SUFFIX, '' )
+		: selectedSite.name;
+
+	url.searchParams.set( 'studioSiteId', String( selectedSite.id ) );
+	url.searchParams.set( 'new', suggestedName );
+
+	return url.toString();
+}

--- a/src/modules/sync/components/create-button.tsx
+++ b/src/modules/sync/components/create-button.tsx
@@ -1,11 +1,11 @@
 import { __ } from '@wordpress/i18n';
-import { DEFAULT_CUSTOM_DOMAIN_SUFFIX } from 'common/constants';
 import { ArrowIcon } from 'src/components/arrow-icon';
 import Button, { ButtonVariant } from 'src/components/button';
 import offlineIcon from 'src/components/offline-icon';
 import { Tooltip } from 'src/components/tooltip';
 import { useOffline } from 'src/hooks/use-offline';
 import { cx } from 'src/lib/cx';
+import { generateCheckoutUrl } from 'src/lib/generate-checkout-url';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 
 interface CreateButtonProps {
@@ -24,24 +24,6 @@ export const CreateButton = ( {
 	onClick,
 }: CreateButtonProps ) => {
 	const isOffline = useOffline();
-	function generateCheckoutUrl( selectedSite?: SiteDetails ): string {
-		const url = new URL(
-			'https://wordpress.com/setup/new-hosted-site?ref=studio&section=studio-sync&showDomainStep'
-		);
-
-		if ( ! selectedSite ) {
-			return url.toString();
-		}
-
-		const suggestedName = selectedSite.customDomain
-			? selectedSite.customDomain.replace( DEFAULT_CUSTOM_DOMAIN_SUFFIX, '' )
-			: selectedSite.name;
-
-		url.searchParams.set( 'studioSiteId', String( selectedSite.id ) );
-		url.searchParams.set( 'new', suggestedName );
-
-		return url.toString();
-	}
 
 	return (
 		<Tooltip


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

Fixes STU-1108

## Proposed Changes

This PR ensures that when you click on the `Publish site` button in Studio, it navigates to WP.com and takes you through the purchase flow, then bringing back to Studio. It should behave identical to `Create a new WordPress.com site` button inside the `Sync` modal.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
* Start Studio
* Navigate to the `Sync` tab
* Make sure that you don't have any WP.com sites connected to your Studio site so that the `Publish site` button displays in the top right corner
* Click on the `Publish site` button
* Observe that you are brought to WP.com
* Complete the purchase
* Wait for the site to go Atomic
* Observe that you see a popup asking you to open Studio
* Confirm that the site you just created is connected in the `Sync` tab (might be a couple of seconds)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
