### PR TITLE
Add GH action to notify about stale PRs

### DIFF
--- a/.github/workflows/stale-pr-notifications.yml
+++ b/.github/workflows/stale-pr-notifications.yml
@@ -1,0 +1,90 @@
+name: Stale PR Notifications
+
+on:
+  schedule:
+    # Run daily at 9:00 AM UTC (adjust timezone as needed)
+    - cron: '0 9 * * *'
+  workflow_dispatch: # Allow manual triggering for testing
+    inputs:
+      channel_id:
+        description: 'Slack channel ID (leave empty to use default)'
+        required: false
+        type: string
+
+permissions:
+  pull-requests: read
+  contents: read
+
+jobs:
+  notify-stale-prs:
+    name: Notify team about stale PRs
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Fetch stale PRs
+        id: fetch-prs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Fetch open PRs not updated in the last 24 hours
+          # Exclude draft PRs and PRs that are already approved
+          STALE_PRS=$(gh pr list \
+            --repo ${{ github.repository }} \
+            --state open \
+            --limit 100 \
+            --json number,title,url,updatedAt,author,isDraft,reviewDecision,labels \
+            --jq '[.[] | select(
+              (.updatedAt | fromdateiso8601) < (now - 86400) and
+              .isDraft == false and
+              (.reviewDecision != "APPROVED")
+            )]')
+
+          # Count stale PRs
+          COUNT=$(echo "$STALE_PRS" | jq 'length')
+          echo "count=$COUNT" >> $GITHUB_OUTPUT
+
+          # Save to file for next step
+          echo "$STALE_PRS" > /tmp/stale-prs.json
+
+          echo "Found $COUNT stale PR(s) needing review"
+
+      - name: Format Slack message
+        id: format-message
+        if: steps.fetch-prs.outputs.count > 0
+        run: node scripts/format-stale-pr-message.js
+
+      - name: Send Slack notification
+        if: steps.fetch-prs.outputs.count > 0
+        env:
+          SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
+          # Use manual input if provided, otherwise use secret, otherwise use default channel
+          SLACK_CHANNEL_ID: ${{ github.event.inputs.channel_id || secrets.SLACK_CHANNEL_ID || 'C056D54B98U' }}
+        run: |
+          MESSAGE=$(cat /tmp/slack-message.json)
+
+          # Post to Slack using the Bot API
+          curl -X POST https://slack.com/api/chat.postMessage \
+            -H "Authorization: Bearer $SLACK_TOKEN" \
+            -H 'Content-Type: application/json; charset=utf-8' \
+            -d "{
+              \"channel\": \"$SLACK_CHANNEL_ID\",
+              \"username\": \"PR Review Bot\",
+              \"icon_emoji\": \":github:\",
+              \"text\": $(echo "$MESSAGE" | jq -r '.text'),
+              \"attachments\": $(echo "$MESSAGE" | jq -c '.attachments')
+            }"
+
+          echo "✅ Sent notification about ${{ steps.fetch-prs.outputs.count }} stale PR(s) to Slack channel $SLACK_CHANNEL_ID"
+
+      - name: No stale PRs
+        if: steps.fetch-prs.outputs.count == 0
+        run: echo "✨ No stale PRs found - all PRs are up to date!"

--- a/.github/workflows/stale-pr-notifications.yml
+++ b/.github/workflows/stale-pr-notifications.yml
@@ -2,8 +2,8 @@ name: Stale PR Notifications
 
 on:
   schedule:
-    # Run daily at 9:00 AM UTC (adjust timezone as needed)
-    - cron: '0 9 * * *'
+    # Run Monday-Friday at 9:00 AM UTC (skip weekends)
+    - cron: '0 9 * * 1-5'
   workflow_dispatch: # Allow manual triggering for testing
     inputs:
       channel_id:
@@ -35,15 +35,29 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Fetch open PRs not updated in the last 24 hours
+          # Determine stale threshold based on day of week
+          # Monday (1): 72 hours (to account for weekend)
+          # Tuesday-Friday (2-5): 24 hours
+          DAY_OF_WEEK=$(date +%u)
+          if [ "$DAY_OF_WEEK" = "1" ]; then
+            STALE_SECONDS=259200  # 72 hours
+            STALE_DESCRIPTION="72 hours (weekend inclusive)"
+          else
+            STALE_SECONDS=86400   # 24 hours
+            STALE_DESCRIPTION="24 hours"
+          fi
+
+          echo "Checking for PRs not updated in the last $STALE_DESCRIPTION"
+
+          # Fetch open PRs not updated in the threshold period
           # Exclude draft PRs and PRs that are already approved
           STALE_PRS=$(gh pr list \
             --repo ${{ github.repository }} \
             --state open \
             --limit 100 \
             --json number,title,url,updatedAt,author,isDraft,reviewDecision,labels \
-            --jq '[.[] | select(
-              (.updatedAt | fromdateiso8601) < (now - 86400) and
+            --jq --arg seconds "$STALE_SECONDS" '[.[] | select(
+              (.updatedAt | fromdateiso8601) < (now - ($seconds | tonumber)) and
               .isDraft == false and
               (.reviewDecision != "APPROVED")
             )]')

--- a/scripts/format-stale-pr-message.js
+++ b/scripts/format-stale-pr-message.js
@@ -59,13 +59,19 @@ const attachments = stalePRs.map( ( pr ) => {
 	};
 } );
 
+// Determine the time period based on day of week
+const dayOfWeek = new Date().getDay();
+const stalePeriod = dayOfWeek === 1 ? '72 hours' : '24 hours';
+
 // Build complete Slack payload
 const slackPayload = {
 	username: 'PR Review Bot',
 	icon_emoji: ':github:',
-	text: `:sad-panda: *Stale Pull Requests Needing Review*\n\nHey <!subteam^S04HJ6B0JRF|@yolo-team>! I found ${ stalePRs.length } PR${
+	text: `:sad-panda: *Stale Pull Requests Needing Review*\n\nHey <!subteam^S04HJ6B0JRF|@yolo-team>! I found ${
+		stalePRs.length
+	} PR${
 		stalePRs.length > 1 ? 's' : ''
-	} that haven't been updated in the last 24 hours and still need review:`,
+	} that haven't been updated in the last ${ stalePeriod } and still need review:`,
 	attachments: attachments,
 };
 

--- a/scripts/format-stale-pr-message.js
+++ b/scripts/format-stale-pr-message.js
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+
+/**
+ * Format stale PR data into a Slack message payload
+ *
+ * This script reads PR data from /tmp/stale-prs.json and generates
+ * a formatted Slack message at /tmp/slack-message.json
+ */
+
+const fs = require( 'fs' );
+
+// Read stale PRs data
+const stalePRs = JSON.parse( fs.readFileSync( '/tmp/stale-prs.json', 'utf8' ) );
+
+if ( stalePRs.length === 0 ) {
+	console.log( 'No stale PRs to format' );
+	process.exit( 0 );
+}
+
+// Calculate how long ago each PR was updated
+function getTimeAgo( updatedAt ) {
+	const now = Date.now();
+	const updated = new Date( updatedAt ).getTime();
+	const diffMs = now - updated;
+	const diffHours = Math.floor( diffMs / ( 1000 * 60 * 60 ) );
+	const diffDays = Math.floor( diffHours / 24 );
+
+	if ( diffDays > 0 ) {
+		return `${ diffDays } day${ diffDays > 1 ? 's' : '' } ago`;
+	} else {
+		return `${ diffHours } hour${ diffHours > 1 ? 's' : '' } ago`;
+	}
+}
+
+// Format PR status
+function getStatusEmoji( pr ) {
+	if ( pr.reviewDecision === 'REVIEW_REQUIRED' ) {
+		return '▶️';
+	} else if ( pr.reviewDecision === 'CHANGES_REQUESTED' ) {
+		return '⏩️️';
+	} else {
+		return '⏸️';
+	}
+}
+
+// Build Slack message attachments
+const attachments = stalePRs.map( ( pr ) => {
+	const timeAgo = getTimeAgo( pr.updatedAt );
+	const status = getStatusEmoji( pr );
+	const author = pr.author.login;
+
+	return {
+		color: pr.reviewDecision === 'CHANGES_REQUESTED' ? 'warning' : 'good',
+		fallback: `${ pr.title } by @${ author }`,
+		title: `${ status } #${ pr.number }: ${ pr.title }`,
+		title_link: pr.url,
+		text: `@${ author } • ${ timeAgo }`,
+		mrkdwn_in: [ 'text' ],
+	};
+} );
+
+// Build complete Slack payload
+const slackPayload = {
+	username: 'PR Review Bot',
+	icon_emoji: ':github:',
+	text: `:sad-panda: *Stale Pull Requests Needing Review*\n\nHey <!subteam^S04HJ6B0JRF|@yolo-team>! I found ${ stalePRs.length } PR${
+		stalePRs.length > 1 ? 's' : ''
+	} that haven't been updated in the last 24 hours and still need review:`,
+	attachments: attachments,
+};
+
+// Write to file for the workflow to use
+fs.writeFileSync( '/tmp/slack-message.json', JSON.stringify( slackPayload, null, 2 ) );
+
+console.log( `✅ Formatted message for ${ stalePRs.length } stale PR(s)` );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-1134

## Proposed Changes

- I propose adding GH action to notify about stale PRs.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Code review should suffice, and we can test when merged to trunk. See how the test message looks on Slack: p1765903484005839-slack-C056D54B98U

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?