### PR TITLE
Migrate electron-vite config to v5.0 syntax

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -1,5 +1,5 @@
 import { resolve } from 'path';
-import { defineConfig, externalizeDepsPlugin } from 'electron-vite';
+import { defineConfig } from 'electron-vite';
 import react from '@vitejs/plugin-react';
 import topLevelAwait from 'vite-plugin-top-level-await';
 import { viteStaticCopy } from 'vite-plugin-static-copy';
@@ -15,7 +15,6 @@ console.log( 'Sentry environment:', isDevEnvironment ? 'development' : 'producti
 export default defineConfig( {
 	main: {
 		plugins: [
-			externalizeDepsPlugin(),
 			viteStaticCopy( {
 				targets: [
 					{
@@ -70,8 +69,8 @@ export default defineConfig( {
 		},
 	},
 	preload: {
-		plugins: [ externalizeDepsPlugin( { exclude: [ '@sentry/electron' ] } ) ],
 		build: {
+			externalizeDeps: { exclude: [ '@sentry/electron' ] },
 			lib: {
 				entry: resolve( __dirname, 'src/preload.ts' ),
 			},


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Follow-up to https://github.com/Automattic/studio/pull/2258

## Proposed Changes

I propose migrating electron-vite config to v5.0 syntax (see https://electron-vite.org/blog/#electron-vite-5-0-is-out).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Confirm build goes through.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
