### PR TITLE
Fix jq argument handling in stale PR workflow

### DIFF
--- a/.github/workflows/stale-pr-notifications.yml
+++ b/.github/workflows/stale-pr-notifications.yml
@@ -55,8 +55,8 @@ jobs:
             --repo ${{ github.repository }} \
             --state open \
             --limit 100 \
-            --json number,title,url,updatedAt,author,isDraft,reviewDecision,labels \
-            --jq --arg seconds "$STALE_SECONDS" '[.[] | select(
+            --json number,title,url,updatedAt,author,isDraft,reviewDecision,labels | \
+            jq --arg seconds "$STALE_SECONDS" '[.[] | select(
               (.updatedAt | fromdateiso8601) < (now - ($seconds | tonumber)) and
               .isDraft == false and
               (.reviewDecision != "APPROVED")

--- a/.github/workflows/stale-pr-notifications.yml
+++ b/.github/workflows/stale-pr-notifications.yml
@@ -83,19 +83,14 @@ jobs:
           # Use manual input if provided, otherwise use secret, otherwise use default channel
           SLACK_CHANNEL_ID: ${{ github.event.inputs.channel_id || secrets.SLACK_CHANNEL_ID || 'C056D54B98U' }}
         run: |
-          MESSAGE=$(cat /tmp/slack-message.json)
-
-          # Post to Slack using the Bot API
+          # Build complete JSON payload using jq to ensure proper escaping
+          jq --arg channel "$SLACK_CHANNEL_ID" \
+            '. + {channel: $channel, username: "PR Review Bot", icon_emoji: ":github:"}' \
+            /tmp/slack-message.json | \
           curl -X POST https://slack.com/api/chat.postMessage \
             -H "Authorization: Bearer $SLACK_TOKEN" \
             -H 'Content-Type: application/json; charset=utf-8' \
-            -d "{
-              \"channel\": \"$SLACK_CHANNEL_ID\",
-              \"username\": \"PR Review Bot\",
-              \"icon_emoji\": \":github:\",
-              \"text\": $(echo "$MESSAGE" | jq -r '.text'),
-              \"attachments\": $(echo "$MESSAGE" | jq -c '.attachments')
-            }"
+            --data-binary @-
 
           echo "✅ Sent notification about ${{ steps.fetch-prs.outputs.count }} stale PR(s) to Slack channel $SLACK_CHANNEL_ID"
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Follow up to https://github.com/Automattic/studio/pull/2266

## Proposed Changes

I found two issues when running newly added workflow.

The GitHub CLI's `--jq` flag doesn't support jq's `--arg` parameter. I fixed it by piping JSON output to jq separately.

Also, I use jq to properly construct the Slack API payload with correct JSON escaping, instead of shell string interpolation which caused "invalid_json" errors.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Confirm build goes through.
- Run the action from the branch.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
