### PR TITLE
Update Blueprint details modal styling

### DIFF
--- a/common/lib/blueprint-validation.ts
+++ b/common/lib/blueprint-validation.ts
@@ -26,7 +26,7 @@ const UNSUPPORTED_BLUEPRINT_FEATURES: UnsupportedFeature[] = [
 		type: 'step',
 		name: 'defineSiteUrl',
 		reason: __(
-			'Studio manages site URLs internally and cannot accept custom URLs from blueprints.'
+			'Custom site URLs in blueprints are ignored. You can set a custom site URL on the Settings tab.'
 		),
 	},
 ];

--- a/common/lib/blueprint-validation.ts
+++ b/common/lib/blueprint-validation.ts
@@ -15,18 +15,18 @@ const UNSUPPORTED_BLUEPRINT_FEATURES: UnsupportedFeature[] = [
 	{
 		type: 'step',
 		name: 'enableMultisite',
-		reason: __( 'Multisite functionality is not currently supported in Studio' ),
+		reason: __( 'Multisite functionality is not currently supported in Studio.' ),
 	},
 	{
 		type: 'step',
 		name: 'login',
-		reason: __( 'Studio automatically creates and logs in the admin user during site creation' ),
+		reason: __( 'Studio automatically creates and logs in the admin user during site creation.' ),
 	},
 	{
 		type: 'step',
 		name: 'defineSiteUrl',
 		reason: __(
-			'Studio manages site URLs internally and cannot accept custom URLs from blueprints'
+			'Studio manages site URLs internally and cannot accept custom URLs from blueprints.'
 		),
 	},
 ];
@@ -38,7 +38,7 @@ const UNSUPPORTED_BLUEPRINT_PROPERTIES: UnsupportedFeature[] = [
 	{
 		type: 'property',
 		name: 'landingPage',
-		reason: __( 'Studio manages its own navigation and landing pages' ),
+		reason: __( 'Studio manages its own navigation and landing pages.' ),
 	},
 ];
 

--- a/src/modules/add-site/components/blueprint-warning-notice.tsx
+++ b/src/modules/add-site/components/blueprint-warning-notice.tsx
@@ -33,7 +33,7 @@ function BlueprintIssuesModal( {
 	return (
 		<Modal
 			className="blueprints-issues-modal"
-			title={ __( 'Blueprint Details' ) }
+			title={ __( 'Blueprint details' ) }
 			onRequestClose={ onClose }
 			size="medium"
 		>

--- a/src/modules/add-site/components/blueprint-warning-notice.tsx
+++ b/src/modules/add-site/components/blueprint-warning-notice.tsx
@@ -6,7 +6,7 @@ import {
 	Modal,
 	Notice,
 } from '@wordpress/components';
-import { Icon, caution } from '@wordpress/icons';
+import { Icon, caution, check } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { useState } from 'react';
 import { BlueprintValidationWarning } from 'common/lib/blueprint-validation';
@@ -38,7 +38,10 @@ function BlueprintIssuesModal( {
 			size="medium"
 		>
 			<div className="h-full flex flex-col gap-1">
-				<Text className="font-medium text-gray-900">{ fileName }</Text>
+				<div className="flex items-center">
+					<Icon className="fill-a8c-blue-50 me-2 shrink-0" icon={ check } />
+					<Text className="font-medium text-gray-900">{ fileName }</Text>
+				</div>
 				<Text>
 					{ warnings?.length &&
 						__(

--- a/src/modules/add-site/components/blueprint-warning-notice.tsx
+++ b/src/modules/add-site/components/blueprint-warning-notice.tsx
@@ -37,7 +37,7 @@ function BlueprintIssuesModal( {
 			onRequestClose={ onClose }
 			size="medium"
 		>
-			<div className="h-full flex flex-col gap-1">
+			<VStack spacing={ 6 } className="h-full">
 				<div className="flex items-center">
 					<Icon className="fill-a8c-blue-50 me-2 shrink-0" icon={ check } />
 					<Text className="font-medium text-gray-900">{ fileName }</Text>
@@ -81,7 +81,7 @@ function BlueprintIssuesModal( {
 						{ __( 'Got it' ) }
 					</Button>
 				</HStack>
-			</div>
+			</VStack>
 		</Modal>
 	);
 }

--- a/src/modules/add-site/components/blueprint-warning-notice.tsx
+++ b/src/modules/add-site/components/blueprint-warning-notice.tsx
@@ -49,27 +49,25 @@ function BlueprintIssuesModal( {
 						) }
 				</Text>
 				<div className="flex-1 overflow-y-auto">
-					<VStack spacing={ 3 } className="divide-y divide-gray-200">
+					<VStack spacing={ 3 }>
 						{ warnings?.map( ( warningItem, index ) => (
-							<div key={ index } className={ index > 0 ? 'pt-3' : '' }>
-								<HStack alignment="topLeft" spacing={ 2 }>
-									<Icon
-										icon={ caution }
-										className="text-orange-500 mt-1 flex-shrink-0"
-										size={ 20 }
-									/>
-									<VStack spacing={ 1 }>
-										<Text weight={ 600 } className="text-base">
-											{ warningItem.feature }
-										</Text>
-										<Text className="text-sm text-gray-700">{ warningItem.reason }</Text>
+							<div
+								key={ index }
+								className="rounded-sm p-3 border border-gray-200"
+								style={ { backgroundColor: 'color-mix(in srgb, #d47608 4%, transparent)' } }
+							>
+								<HStack alignment="flex-start" spacing={ 2 }>
+									<Icon icon={ caution } className="fill-[#a77f30] shrink-0 w-6 h-6" />
+									<VStack spacing={ 1 } className="flex-grow py-0.5">
+										<Text weight={ 500 }>{ warningItem.feature }</Text>
+										<div>{ warningItem.reason }</div>
 									</VStack>
 								</HStack>
 							</div>
 						) ) }
 					</VStack>
 				</div>
-				<div className="pt-4 border-t border-gray-200">
+				<div>
 					<Text className="text-sm text-gray-600">
 						{ __(
 							'Your Blueprint will still work, but these features will be skipped during site creation.'


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Related to STU-1151

## Proposed Changes

- update design of the _Blueprint details_ modal
- add periods to Blueprint validation messages

| Before | After |
|--------|--------|
| <img width="2694" height="2024" alt="CleanShot 2025-12-19 at 15 21 41@2x" src="https://github.com/user-attachments/assets/81275b08-1cbb-4bda-834b-78b24a5d364f" /> | <img width="2694" height="2024" alt="CleanShot 2025-12-19 at 15 20 04@2x" src="https://github.com/user-attachments/assets/75162edf-aba1-47d4-9e0a-775b032464da" /> | 

> [!NOTE]
>  Please note that the originally-proposed design (RToz6tIuQ7nlZrikBte4GU-fi-10352_72355) is relying on a custom Calypso `Notice` component which isn't available in `@wordpress/components`. There's a [plan to move this custom component](https://github.com/Automattic/wp-calypso/pull/103578#issuecomment-3666058657) into `@wordpress/io` which we can then use in Studio for all the warning notices as well.
> 
> Because of that, I **did not** introduce any new custom notice component to Studio. Instead, I adjusted the styling of the Blueprint validation warnings to match the custom `Notice` component.
> 
> Currently proposed changes also use standard WordPress `caution` instead of a custom one that will come with the new `Notice` component.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR branch and build the app with `npm install && npm start`.
2. Navigate to _Add site → Start from a Blueprint_ and then select a Blueprint file that has some unsupported steps. For instance, you can pick `test-multiple-warnings-blueprint.json` from 39ef1-pb/#xml.
3. Click on the `View details` button and review the new design.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?