### PR TITLE
Ensure all CLI commands can be aborted

### DIFF
--- a/cli/commands/site/list.ts
+++ b/cli/commands/site/list.ts
@@ -71,14 +71,6 @@ function displaySiteList( sitesData: SiteListEntry[], format: 'table' | 'json' )
 const logger = new Logger< LoggerAction >();
 
 export async function runCommand( format: 'table' | 'json', watch: boolean ): Promise< void > {
-	const handleTermination = () => {
-		disconnect();
-		process.exit( 0 );
-	};
-	process.on( 'SIGTERM', handleTermination );
-	process.on( 'SIGHUP', handleTermination );
-	process.on( 'disconnect', handleTermination );
-
 	try {
 		logger.reportStart( LoggerAction.LOAD_SITES, __( 'Loading sites…' ) );
 		const appdata = await readAppdata();

--- a/cli/lib/pm2-manager.ts
+++ b/cli/lib/pm2-manager.ts
@@ -60,9 +60,6 @@ export function disconnect(): void {
 	}
 }
 
-process.on( 'SIGINT', disconnect );
-process.on( 'SIGTERM', disconnect );
-
 // Cache the return value of `pm2.list` for a very short time to make multiple calls in quick
 // succession more efficient
 const listProcesses = cacheFunctionTTL( () => {

--- a/cli/lib/pm2-manager.ts
+++ b/cli/lib/pm2-manager.ts
@@ -60,7 +60,8 @@ export function disconnect(): void {
 	}
 }
 
-process.on( 'exit', disconnect );
+process.on( 'disconnect', disconnect );
+process.on( 'SIGHUP', disconnect );
 process.on( 'SIGINT', disconnect );
 process.on( 'SIGTERM', disconnect );
 

--- a/cli/lib/pm2-manager.ts
+++ b/cli/lib/pm2-manager.ts
@@ -60,8 +60,6 @@ export function disconnect(): void {
 	}
 }
 
-process.on( 'disconnect', disconnect );
-process.on( 'SIGHUP', disconnect );
 process.on( 'SIGINT', disconnect );
 process.on( 'SIGTERM', disconnect );
 

--- a/cli/lib/tests/pm2-manager.test.ts
+++ b/cli/lib/tests/pm2-manager.test.ts
@@ -282,6 +282,7 @@ describe( 'PM2 Manager', () => {
 			const message: ManagerMessage = {
 				topic: 'stop-server',
 				messageId: 1,
+				data: {},
 			};
 
 			await sendMessageToProcess( 42, message );
@@ -303,6 +304,7 @@ describe( 'PM2 Manager', () => {
 			const message: ManagerMessage = {
 				topic: 'stop-server',
 				messageId: 1,
+				data: {},
 			};
 
 			await expect( sendMessageToProcess( 42, message ) ).rejects.toThrow( 'Send failed' );

--- a/cli/lib/types/wordpress-server-ipc.ts
+++ b/cli/lib/types/wordpress-server-ipc.ts
@@ -23,6 +23,10 @@ const serverConfig = z.object( {
 
 export type ServerConfig = z.infer< typeof serverConfig >;
 
+const managerMessageAbort = z.object( {
+	topic: z.literal( 'abort' ),
+} );
+
 const managerMessageStartServer = z.object( {
 	topic: z.literal( 'start-server' ),
 	data: z.object( {
@@ -49,6 +53,7 @@ const managerMessageWpCliCommand = z.object( {
 } );
 
 const _managerMessagePayloadSchema = z.discriminatedUnion( 'topic', [
+	managerMessageAbort,
 	managerMessageStartServer,
 	managerMessageRunBlueprint,
 	managerMessageStopServer,
@@ -58,6 +63,7 @@ export type ManagerMessagePayload = z.infer< typeof _managerMessagePayloadSchema
 
 const managerMessageBase = z.object( { messageId: z.number() } );
 export const managerMessageSchema = z.discriminatedUnion( 'topic', [
+	managerMessageBase.merge( managerMessageAbort ),
 	managerMessageBase.merge( managerMessageStartServer ),
 	managerMessageBase.merge( managerMessageRunBlueprint ),
 	managerMessageBase.merge( managerMessageStopServer ),

--- a/cli/lib/types/wordpress-server-ipc.ts
+++ b/cli/lib/types/wordpress-server-ipc.ts
@@ -25,6 +25,7 @@ export type ServerConfig = z.infer< typeof serverConfig >;
 
 const managerMessageAbort = z.object( {
 	topic: z.literal( 'abort' ),
+	data: z.object( {} ),
 } );
 
 const managerMessageStartServer = z.object( {
@@ -43,6 +44,7 @@ const managerMessageRunBlueprint = z.object( {
 
 const managerMessageStopServer = z.object( {
 	topic: z.literal( 'stop-server' ),
+	data: z.object( {} ),
 } );
 
 const managerMessageWpCliCommand = z.object( {

--- a/cli/lib/wordpress-server-manager.ts
+++ b/cli/lib/wordpress-server-manager.ts
@@ -264,6 +264,7 @@ async function sendMessage(
 		abortController.signal.addEventListener(
 			'abort',
 			() => {
+				void sendMessageToProcess( pmId, { messageId, topic: 'abort' } );
 				reject( new Error( 'Operation aborted' ) );
 			},
 			{ once: true }

--- a/cli/lib/wordpress-server-manager.ts
+++ b/cli/lib/wordpress-server-manager.ts
@@ -31,6 +31,15 @@ import { Logger } from 'cli/logger';
 
 const SITE_PROCESS_PREFIX = 'studio-site-';
 
+// Get an abort signal that's triggered on SIGINT/SIGTERM. This is useful for aborting and cleaning
+// up async operations.
+const abortController = new AbortController();
+function handleProcessTermination() {
+	abortController.abort();
+}
+process.on( 'SIGINT', handleProcessTermination );
+process.on( 'SIGTERM', handleProcessTermination );
+
 function getProcessName( siteId: string ): string {
 	return `${ SITE_PROCESS_PREFIX }${ siteId }`;
 }
@@ -124,27 +133,37 @@ export async function startWordPressServer(
 
 async function waitForReadyMessage( pmId: number ): Promise< void > {
 	const bus = await getPm2Bus();
+	let timeoutId: NodeJS.Timeout;
+	let readyHandler: ( packet: unknown ) => void;
 
-	return new Promise( ( resolve, reject ) => {
-		const timeout = setTimeout( () => {
-			bus.off( 'process:msg', readyHandler );
+	return new Promise< void >( ( resolve, reject ) => {
+		timeoutId = setTimeout( () => {
 			reject( new Error( 'Timeout waiting for ready message from WordPress server child' ) );
 		}, PLAYGROUND_CLI_INACTIVITY_TIMEOUT );
 
-		const readyHandler = ( packet: unknown ) => {
+		readyHandler = ( packet: unknown ) => {
 			const result = childMessagePm2Schema.safeParse( packet );
 			if ( ! result.success ) {
 				return;
 			}
 
 			if ( result.data.process.pm_id === pmId && result.data.raw.topic === 'ready' ) {
-				clearTimeout( timeout );
-				bus.off( 'process:msg', readyHandler );
 				resolve();
 			}
 		};
 
+		abortController.signal.addEventListener(
+			'abort',
+			() => {
+				reject( new Error( 'Operation aborted' ) );
+			},
+			{ once: true }
+		);
+
 		bus.on( 'process:msg', readyHandler );
+	} ).finally( () => {
+		clearTimeout( timeoutId );
+		bus.off( 'process:msg', readyHandler );
 	} );
 }
 
@@ -241,6 +260,14 @@ async function sendMessage(
 				resolve( validPacket.raw.result );
 			}
 		};
+
+		abortController.signal.addEventListener(
+			'abort',
+			() => {
+				reject( new Error( 'Operation aborted' ) );
+			},
+			{ once: true }
+		);
 
 		bus.on( 'process:msg', responseHandler );
 

--- a/cli/lib/wordpress-server-manager.ts
+++ b/cli/lib/wordpress-server-manager.ts
@@ -264,7 +264,7 @@ async function sendMessage(
 		abortController.signal.addEventListener(
 			'abort',
 			() => {
-				void sendMessageToProcess( pmId, { messageId, topic: 'abort' } );
+				void sendMessageToProcess( pmId, { messageId, topic: 'abort', data: {} } );
 				reject( new Error( 'Operation aborted' ) );
 			},
 			{ once: true }
@@ -294,10 +294,8 @@ export async function stopWordPressServer( siteId: string ): Promise< void > {
 		try {
 			await sendMessage(
 				runningProcess.pmId,
-				{ topic: 'stop-server' },
-				{
-					maxTotalElapsedTime: GRACEFUL_STOP_TIMEOUT,
-				}
+				{ topic: 'stop-server', data: {} },
+				{ maxTotalElapsedTime: GRACEFUL_STOP_TIMEOUT }
 			);
 		} catch {
 			// Graceful shutdown failed, PM2 delete will handle it

--- a/cli/lib/wordpress-server-manager.ts
+++ b/cli/lib/wordpress-server-manager.ts
@@ -133,8 +133,10 @@ export async function startWordPressServer(
 
 async function waitForReadyMessage( pmId: number ): Promise< void > {
 	const bus = await getPm2Bus();
+
 	let timeoutId: NodeJS.Timeout;
 	let readyHandler: ( packet: unknown ) => void;
+	let abortListener: () => void;
 
 	return new Promise< void >( ( resolve, reject ) => {
 		timeoutId = setTimeout( () => {
@@ -152,17 +154,15 @@ async function waitForReadyMessage( pmId: number ): Promise< void > {
 			}
 		};
 
-		abortController.signal.addEventListener(
-			'abort',
-			() => {
-				reject( new Error( 'Operation aborted' ) );
-			},
-			{ once: true }
-		);
+		abortListener = () => {
+			reject( new Error( 'Operation aborted' ) );
+		};
+		abortController.signal.addEventListener( 'abort', abortListener );
 
 		bus.on( 'process:msg', readyHandler );
 	} ).finally( () => {
 		clearTimeout( timeoutId );
+		abortController.signal.removeEventListener( 'abort', abortListener );
 		bus.off( 'process:msg', readyHandler );
 	} );
 }
@@ -195,7 +195,9 @@ async function sendMessage(
 	const { maxTotalElapsedTime = PLAYGROUND_CLI_MAX_TIMEOUT, logger } = options;
 	const bus = await getPm2Bus();
 	const messageId = nextMessageId++;
+
 	let responseHandler: ( packet: unknown ) => void;
+	let abortListener: () => void;
 
 	return new Promise( ( resolve, reject ) => {
 		const startTime = Date.now();
@@ -261,19 +263,17 @@ async function sendMessage(
 			}
 		};
 
-		abortController.signal.addEventListener(
-			'abort',
-			() => {
-				void sendMessageToProcess( pmId, { messageId, topic: 'abort', data: {} } );
-				reject( new Error( 'Operation aborted' ) );
-			},
-			{ once: true }
-		);
+		abortListener = () => {
+			void sendMessageToProcess( pmId, { messageId, topic: 'abort', data: {} } );
+			reject( new Error( 'Operation aborted' ) );
+		};
+		abortController.signal.addEventListener( 'abort', abortListener );
 
 		bus.on( 'process:msg', responseHandler );
 
 		sendMessageToProcess( pmId, { ...message, messageId } ).catch( reject );
 	} ).finally( () => {
+		abortController.signal.removeEventListener( 'abort', abortListener );
 		bus.off( 'process:msg', responseHandler );
 
 		const tracker = messageActivityTrackers.get( messageId );

--- a/cli/wordpress-server-child.ts
+++ b/cli/wordpress-server-child.ts
@@ -350,7 +350,7 @@ function sendErrorMessage( messageId: string, error: unknown ) {
 	process.send!( errorResponse );
 }
 
-const abortControllers: Record< number, AbortController > = {};
+const abortControllers: Record< string, AbortController > = {};
 
 async function ipcMessageHandler( packet: unknown ) {
 	const messageResult = managerMessageSchema.safeParse( packet );

--- a/cli/wordpress-server-child.ts
+++ b/cli/wordpress-server-child.ts
@@ -224,30 +224,40 @@ function wrapWithStartingPromise< Args extends unknown[], Return extends void >(
 	};
 }
 
-const startServer = wrapWithStartingPromise( async ( config: ServerConfig ): Promise< void > => {
-	if ( server ) {
-		logToConsole( `Server already running for site ${ config.siteId }` );
-		return;
-	}
-
-	try {
-		const args = await getBaseRunCLIArgs( 'server', config );
-		lastCliArgs = sanitizeRunCLIArgs( args );
-		server = await runCLI( args );
-
-		if ( config.enableMultiWorker && server ) {
-			logToConsole( `Server started with ${ server.workerThreadCount } worker thread(s)` );
+const startServer = wrapWithStartingPromise(
+	async ( config: ServerConfig, signal: AbortSignal ): Promise< void > => {
+		if ( server ) {
+			logToConsole( `Server already running for site ${ config.siteId }` );
+			return;
 		}
 
-		if ( config.adminPassword ) {
-			await setAdminPassword( server, config.adminPassword );
+		try {
+			signal.addEventListener(
+				'abort',
+				() => {
+					throw new Error( 'Operation aborted' );
+				},
+				{ once: true }
+			);
+
+			const args = await getBaseRunCLIArgs( 'server', config );
+			lastCliArgs = sanitizeRunCLIArgs( args );
+			server = await runCLI( args );
+
+			if ( config.enableMultiWorker && server ) {
+				logToConsole( `Server started with ${ server.workerThreadCount } worker thread(s)` );
+			}
+
+			if ( config.adminPassword ) {
+				await setAdminPassword( server, config.adminPassword );
+			}
+		} catch ( error ) {
+			server = null;
+			errorToConsole( `Failed to start server:`, error );
+			throw error;
 		}
-	} catch ( error ) {
-		server = null;
-		errorToConsole( `Failed to start server:`, error );
-		throw error;
 	}
-} );
+);
 
 const STOP_SERVER_TIMEOUT = 5000;
 
@@ -272,8 +282,16 @@ async function stopServer(): Promise< void > {
 	}
 }
 
-async function runBlueprint( config: ServerConfig ): Promise< void > {
+async function runBlueprint( config: ServerConfig, signal: AbortSignal ): Promise< void > {
 	try {
+		signal.addEventListener(
+			'abort',
+			() => {
+				throw new Error( 'Operation aborted' );
+			},
+			{ once: true }
+		);
+
 		const args = await getBaseRunCLIArgs( 'run-blueprint', config );
 		lastCliArgs = sanitizeRunCLIArgs( args );
 		await runCLI( args );
@@ -286,13 +304,22 @@ async function runBlueprint( config: ServerConfig ): Promise< void > {
 }
 
 async function runWpCliCommand(
-	args: string[]
+	args: string[],
+	signal: AbortSignal
 ): Promise< { stdout: string; stderr: string; exitCode: number } > {
 	await Promise.allSettled( [ startingPromise ] );
 
 	if ( ! server ) {
 		throw new Error( `Failed to run WP CLI command because server is not running` );
 	}
+
+	signal.addEventListener(
+		'abort',
+		() => {
+			throw new Error( 'Operation aborted' );
+		},
+		{ once: true }
+	);
 
 	const response = await server.playground.cli( [
 		'php',
@@ -319,6 +346,8 @@ function sendErrorMessage( messageId: number, error: unknown ) {
 	process.send!( errorResponse );
 }
 
+const abortControllers: Record< number, AbortController > = {};
+
 async function ipcMessageHandler( packet: unknown ) {
 	const messageResult = managerMessageSchema.safeParse( packet );
 
@@ -334,22 +363,28 @@ async function ipcMessageHandler( packet: unknown ) {
 	}
 
 	const validMessage = messageResult.data;
+	abortControllers[ validMessage.messageId ] ??= new AbortController();
+	const abortController = abortControllers[ validMessage.messageId ];
 
 	try {
 		let result: unknown;
 
 		switch ( validMessage.topic ) {
+			case 'abort':
+				abortController?.abort();
+				delete abortControllers[ validMessage.messageId ];
+				return;
 			case 'start-server':
-				result = await startServer( validMessage.data.config );
+				result = await startServer( validMessage.data.config, abortController.signal );
 				break;
 			case 'run-blueprint':
-				result = await runBlueprint( validMessage.data.config );
+				result = await runBlueprint( validMessage.data.config, abortController.signal );
 				break;
 			case 'stop-server':
 				result = await stopServer();
 				break;
 			case 'wp-cli-command':
-				result = await runWpCliCommand( validMessage.data.args );
+				result = await runWpCliCommand( validMessage.data.args, abortController.signal );
 				break;
 			default:
 				throw new Error( `Unknown message.` );

--- a/cli/wordpress-server-child.ts
+++ b/cli/wordpress-server-child.ts
@@ -363,7 +363,9 @@ async function ipcMessageHandler( packet: unknown ) {
 	}
 
 	const validMessage = messageResult.data;
-	abortControllers[ validMessage.messageId ] ??= new AbortController();
+	if ( validMessage.topic !== 'abort' ) {
+		abortControllers[ validMessage.messageId ] = new AbortController();
+	}
 	const abortController = abortControllers[ validMessage.messageId ];
 
 	try {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-1140

## Proposed Changes

- Add an `AbortController` in `cli/lib/wordpress-server-manager.ts` that interrupts `sendMessage` promises, ensuring that the CLI process exits when it receives a `SIGINT` or `SIGTERM` (<kbd>Ctrl+C</kbd>)
- Add an `abort` IPC message topic that aborts async operations in `cli/lib/types/wordpress-server-ipc.ts` (most oftenly killing the process). We'll refine this behavior once #2261 has landed.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Run `npm run cli:build`
2. Run `node dist/cli/main.js site create --path PATH_TO_SITE` where `PATH_TO_SITE` is the path to a new folder where the site should be created
3. Once the process reaches the `Starting WordPress server` stage, press <kbd>Ctrl+C</kbd>
4. Ensure that the process is aborted

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
