### PR TITLE
Studio: misc improvements for #2264

### DIFF
--- a/src/components/publish-site-button.tsx
+++ b/src/components/publish-site-button.tsx
@@ -22,7 +22,7 @@ export const PublishSiteButton = () => {
 
 	const handlePublishClick = useCallback( () => {
 		if ( ! selectedSite ) return;
-		getIpcApi().openURL( generateCheckoutUrl( selectedSite ) );
+		getIpcApi().openURL( generateCheckoutUrl( selectedSite, 'publish-site' ) );
 	}, [ selectedSite ] );
 
 	if ( ! selectedSite || connectedSites.length !== 0 ) return null;

--- a/src/components/publish-site-button.tsx
+++ b/src/components/publish-site-button.tsx
@@ -21,10 +21,11 @@ export const PublishSiteButton = () => {
 	const isAnySiteSyncing = isAnySitePulling || isAnySitePushing;
 
 	const handlePublishClick = useCallback( () => {
-		getIpcApi().openURL( generateCheckoutUrl( selectedSite ?? undefined ) );
+		if ( ! selectedSite ) return;
+		getIpcApi().openURL( generateCheckoutUrl( selectedSite ) );
 	}, [ selectedSite ] );
 
-	if ( connectedSites.length !== 0 ) return null;
+	if ( ! selectedSite || connectedSites.length !== 0 ) return null;
 
 	return (
 		<ConnectButton

--- a/src/lib/generate-checkout-url.ts
+++ b/src/lib/generate-checkout-url.ts
@@ -4,9 +4,10 @@ export function generateCheckoutUrl(
 	selectedSite?: SiteDetails,
 	section: string = 'studio-sync'
 ): string {
-	const url = new URL(
-		`https://wordpress.com/setup/new-hosted-site?ref=studio&section=${ section }&showDomainStep`
-	);
+	const url = new URL( `https://wordpress.com/setup/new-hosted-site` );
+	url.searchParams.set( 'ref', 'studio' );
+	url.searchParams.set( 'section', section );
+	url.searchParams.set( 'showDomainStep', 'true' );
 
 	if ( ! selectedSite ) {
 		return url.toString();

--- a/src/lib/generate-checkout-url.ts
+++ b/src/lib/generate-checkout-url.ts
@@ -1,8 +1,11 @@
 import { DEFAULT_CUSTOM_DOMAIN_SUFFIX } from 'common/constants';
 
-export function generateCheckoutUrl( selectedSite?: SiteDetails ): string {
+export function generateCheckoutUrl(
+	selectedSite?: SiteDetails,
+	section: string = 'studio-sync'
+): string {
 	const url = new URL(
-		'https://wordpress.com/setup/new-hosted-site?ref=studio&section=studio-sync&showDomainStep'
+		`https://wordpress.com/setup/new-hosted-site?ref=studio&section=${ section }&showDomainStep`
 	);
 
 	if ( ! selectedSite ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

Related to 2264

## Proposed Changes

This PR addressed a couple of comments from https://github.com/Automattic/studio/pull/2264 that were added after that PR was merged.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

A code review should be sufficient but you can also test the full flow by:

* Pull the changes from this branch
* Start Studio
* Navigate to the `Sync` tab
* Make sure that you don't have any WP.com sites connected to your Studio site so that the `Publish site` button displays in the top right corner
* Click on the `Publish site` button
* Observe that you are brought to WP.com
* Complete the purchase
* Wait for the site to go Atomic
* Observe that you see a popup asking you to open Studio
* Confirm that the site you just created is connected in the `Sync` tab (might be a couple of seconds)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
