### PR TITLE
Disable add site import from WordPress.com if Studio is offline

### DIFF
--- a/src/modules/add-site/components/options.tsx
+++ b/src/modules/add-site/components/options.tsx
@@ -114,6 +114,8 @@ export default function AddSiteOptions( { onOptionSelect }: AddSiteOptionsProps 
 				title={ __( 'Pull an existing site' ) }
 				description={ __( 'Download directly from WordPress.com or Pressable' ) }
 				onClick={ () => onOptionSelect( 'pullRemote' ) }
+				disabled={ isOffline }
+				disabledTooltip={ offlineMessage }
 			/>
 			<OptionButton
 				icon={ <Icon icon={ backup } size={ 24 } fill="#3858E9" /> }

--- a/src/modules/add-site/components/options.tsx
+++ b/src/modules/add-site/components/options.tsx
@@ -82,7 +82,10 @@ export default function AddSiteOptions( { onOptionSelect }: AddSiteOptionsProps 
 	const { __ } = useI18n();
 	const { enableBlueprints } = useFeatureFlags();
 	const isOffline = useOffline();
-	const offlineMessage = __( "You're currently offline." );
+	const blueprintOfflineMessage = __(
+		'Starting from a Blueprint requires an internet connection.'
+	);
+	const importOfflineMessage = __( 'Importing a site requires an internet connection.' );
 
 	return (
 		<VStack className="text-center w-full" alignment="top" spacing="3">
@@ -106,7 +109,7 @@ export default function AddSiteOptions( { onOptionSelect }: AddSiteOptionsProps 
 					description={ __( 'Choose a featured Blueprint or use your own' ) }
 					onClick={ () => onOptionSelect( 'blueprint' ) }
 					disabled={ isOffline }
-					disabledTooltip={ offlineMessage }
+					disabledTooltip={ blueprintOfflineMessage }
 				/>
 			) }
 			<OptionButton
@@ -115,7 +118,7 @@ export default function AddSiteOptions( { onOptionSelect }: AddSiteOptionsProps 
 				description={ __( 'Download directly from WordPress.com or Pressable' ) }
 				onClick={ () => onOptionSelect( 'pullRemote' ) }
 				disabled={ isOffline }
-				disabledTooltip={ offlineMessage }
+				disabledTooltip={ importOfflineMessage }
 			/>
 			<OptionButton
 				icon={ <Icon icon={ backup } size={ 24 } fill="#3858E9" /> }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- N/A

## Proposed Changes

- Disable the option to "Import from WordPress.com" when adding a site if Studio is offline
<img width="1179" height="801" alt="Screenshot 2025-12-18 at 10 52 43" src="https://github.com/user-attachments/assets/1c783c89-9e3a-4101-9c99-ff450160e96d" />

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- `npm start`
- disable your network connection
- add site
- confirm option to import from WordPress.com is disable
- enable network connection
- confirm option to import from WordPress.com is enabled

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
