### PR TITLE
Fix: update latestCliPid after restart in set-* CLI commands

### DIFF
--- a/cli/commands/site/set-domain.ts
+++ b/cli/commands/site/set-domain.ts
@@ -2,7 +2,14 @@ import { __, _n } from '@wordpress/i18n';
 import { getDomainNameValidationError } from 'common/lib/domains';
 import { arePathsEqual } from 'common/lib/fs-utils';
 import { SiteCommandLoggerAction as LoggerAction } from 'common/logger-actions';
-import { lockAppdata, readAppdata, saveAppdata, SiteData, unlockAppdata } from 'cli/lib/appdata';
+import {
+	lockAppdata,
+	readAppdata,
+	saveAppdata,
+	SiteData,
+	unlockAppdata,
+	updateSiteLatestCliPid,
+} from 'cli/lib/appdata';
 import { removeDomainFromHosts } from 'cli/lib/hosts-file';
 import { connect, disconnect } from 'cli/lib/pm2-manager';
 import { setupCustomDomain } from 'cli/lib/site-utils';
@@ -71,7 +78,10 @@ export async function runCommand( sitePath: string, domainName: string ): Promis
 			await stopWordPressServer( site.id );
 			await setupCustomDomain( site, logger );
 			logger.reportStart( LoggerAction.START_SITE, __( 'Restarting site...' ) );
-			await startWordPressServer( site, logger );
+			const processDesc = await startWordPressServer( site, logger );
+			if ( processDesc.pid ) {
+				await updateSiteLatestCliPid( site.id, processDesc.pid );
+			}
 			logger.reportSuccess( __( 'Site restarted' ) );
 		}
 	} finally {

--- a/cli/commands/site/set-https.ts
+++ b/cli/commands/site/set-https.ts
@@ -1,7 +1,14 @@
 import { __, _n } from '@wordpress/i18n';
 import { arePathsEqual } from 'common/lib/fs-utils';
 import { SiteCommandLoggerAction as LoggerAction } from 'common/logger-actions';
-import { lockAppdata, readAppdata, saveAppdata, SiteData, unlockAppdata } from 'cli/lib/appdata';
+import {
+	lockAppdata,
+	readAppdata,
+	saveAppdata,
+	SiteData,
+	unlockAppdata,
+	updateSiteLatestCliPid,
+} from 'cli/lib/appdata';
 import { connect, disconnect } from 'cli/lib/pm2-manager';
 import {
 	isServerRunning,
@@ -55,7 +62,10 @@ export async function runCommand( sitePath: string, enableHttps: boolean ): Prom
 		if ( runningProcess ) {
 			logger.reportStart( LoggerAction.START_SITE, __( 'Restarting site...' ) );
 			await stopWordPressServer( site.id );
-			await startWordPressServer( site, logger );
+			const processDesc = await startWordPressServer( site, logger );
+			if ( processDesc.pid ) {
+				await updateSiteLatestCliPid( site.id, processDesc.pid );
+			}
 			logger.reportSuccess( __( 'Site restarted' ) );
 		}
 	} finally {

--- a/cli/commands/site/set-php-version.ts
+++ b/cli/commands/site/set-php-version.ts
@@ -8,6 +8,7 @@ import {
 	readAppdata,
 	saveAppdata,
 	unlockAppdata,
+	updateSiteLatestCliPid,
 } from 'cli/lib/appdata';
 import { connect, disconnect } from 'cli/lib/pm2-manager';
 import {
@@ -57,7 +58,10 @@ export async function runCommand(
 		if ( runningProcess ) {
 			logger.reportStart( LoggerAction.START_SITE, __( 'Restarting site...' ) );
 			await stopWordPressServer( site.id );
-			await startWordPressServer( site, logger );
+			const processDesc = await startWordPressServer( site, logger );
+			if ( processDesc.pid ) {
+				await updateSiteLatestCliPid( site.id, processDesc.pid );
+			}
 			logger.reportSuccess( __( 'Site restarted' ) );
 		}
 	} finally {

--- a/cli/commands/site/set-wp-version.ts
+++ b/cli/commands/site/set-wp-version.ts
@@ -13,6 +13,7 @@ import {
 	readAppdata,
 	saveAppdata,
 	unlockAppdata,
+	updateSiteLatestCliPid,
 } from 'cli/lib/appdata';
 import { connect, disconnect } from 'cli/lib/pm2-manager';
 import { runWpCliCommand } from 'cli/lib/run-wp-cli-command';
@@ -77,7 +78,10 @@ export async function runCommand( siteFolder: string, wpVersion: string ): Promi
 
 		if ( processDescription ) {
 			logger.reportStart( LoggerAction.START_SITE, __( 'Starting WordPress site...' ) );
-			await startWordPressServer( site, logger );
+			const processDesc = await startWordPressServer( site, logger );
+			if ( processDesc.pid ) {
+				await updateSiteLatestCliPid( site.id, processDesc.pid );
+			}
 			logger.reportSuccess( __( 'WordPress site started' ) );
 		}
 

--- a/cli/commands/site/tests/set-domain.test.ts
+++ b/cli/commands/site/tests/set-domain.test.ts
@@ -1,6 +1,13 @@
 import { getDomainNameValidationError } from 'common/lib/domains';
 import { arePathsEqual } from 'common/lib/fs-utils';
-import { SiteData, lockAppdata, readAppdata, saveAppdata, unlockAppdata } from 'cli/lib/appdata';
+import {
+	SiteData,
+	lockAppdata,
+	readAppdata,
+	saveAppdata,
+	unlockAppdata,
+	updateSiteLatestCliPid,
+} from 'cli/lib/appdata';
 import { removeDomainFromHosts } from 'cli/lib/hosts-file';
 import { connect, disconnect } from 'cli/lib/pm2-manager';
 import { setupCustomDomain } from 'cli/lib/site-utils';
@@ -17,6 +24,7 @@ jest.mock( 'cli/lib/appdata', () => ( {
 	readAppdata: jest.fn(),
 	saveAppdata: jest.fn(),
 	unlockAppdata: jest.fn(),
+	updateSiteLatestCliPid: jest.fn(),
 } ) );
 jest.mock( 'cli/lib/pm2-manager' );
 jest.mock( 'cli/lib/wordpress-server-manager' );
@@ -69,6 +77,7 @@ describe( 'CLI: studio site set-domain', () => {
 		( removeDomainFromHosts as jest.Mock ).mockResolvedValue( undefined );
 		( setupCustomDomain as jest.Mock ).mockResolvedValue( undefined );
 		( getDomainNameValidationError as jest.Mock ).mockReturnValue( '' );
+		( updateSiteLatestCliPid as jest.Mock ).mockResolvedValue( undefined );
 	} );
 
 	afterEach( () => {
@@ -156,6 +165,7 @@ describe( 'CLI: studio site set-domain', () => {
 			expect( isServerRunning ).toHaveBeenCalledWith( testSite.id );
 			expect( stopWordPressServer ).not.toHaveBeenCalled();
 			expect( startWordPressServer ).not.toHaveBeenCalled();
+			expect( updateSiteLatestCliPid ).not.toHaveBeenCalled();
 			expect( removeDomainFromHosts ).not.toHaveBeenCalled();
 			expect( disconnect ).toHaveBeenCalled();
 		} );
@@ -175,6 +185,10 @@ describe( 'CLI: studio site set-domain', () => {
 			expect( stopWordPressServer ).toHaveBeenCalledWith( testSite.id );
 			expect( setupCustomDomain ).toHaveBeenCalledWith( testSite, expect.any( Logger ) );
 			expect( startWordPressServer ).toHaveBeenCalledWith( testSite, expect.any( Logger ) );
+			expect( updateSiteLatestCliPid ).toHaveBeenCalledWith(
+				testSite.id,
+				testProcessDescription.pid
+			);
 			expect( disconnect ).toHaveBeenCalled();
 		} );
 

--- a/cli/commands/site/tests/set-https.test.ts
+++ b/cli/commands/site/tests/set-https.test.ts
@@ -1,5 +1,12 @@
 import { arePathsEqual } from 'common/lib/fs-utils';
-import { SiteData, lockAppdata, readAppdata, saveAppdata, unlockAppdata } from 'cli/lib/appdata';
+import {
+	SiteData,
+	lockAppdata,
+	readAppdata,
+	saveAppdata,
+	unlockAppdata,
+	updateSiteLatestCliPid,
+} from 'cli/lib/appdata';
 import { connect, disconnect } from 'cli/lib/pm2-manager';
 import {
 	isServerRunning,
@@ -14,6 +21,7 @@ jest.mock( 'cli/lib/appdata', () => ( {
 	readAppdata: jest.fn(),
 	saveAppdata: jest.fn(),
 	unlockAppdata: jest.fn(),
+	updateSiteLatestCliPid: jest.fn(),
 } ) );
 jest.mock( 'cli/lib/pm2-manager' );
 jest.mock( 'cli/lib/wordpress-server-manager' );
@@ -63,6 +71,7 @@ describe( 'CLI: studio site set-https', () => {
 		( startWordPressServer as jest.Mock ).mockResolvedValue( mockProcessDescription );
 		( stopWordPressServer as jest.Mock ).mockResolvedValue( undefined );
 		( arePathsEqual as jest.Mock ).mockImplementation( ( a: string, b: string ) => a === b );
+		( updateSiteLatestCliPid as jest.Mock ).mockResolvedValue( undefined );
 	} );
 
 	afterEach( () => {
@@ -159,6 +168,7 @@ describe( 'CLI: studio site set-https', () => {
 			expect( isServerRunning ).toHaveBeenCalledWith( mockSiteData.id );
 			expect( stopWordPressServer ).not.toHaveBeenCalled();
 			expect( startWordPressServer ).not.toHaveBeenCalled();
+			expect( updateSiteLatestCliPid ).not.toHaveBeenCalled();
 			expect( disconnect ).toHaveBeenCalled();
 		} );
 
@@ -179,6 +189,7 @@ describe( 'CLI: studio site set-https', () => {
 
 			expect( stopWordPressServer ).not.toHaveBeenCalled();
 			expect( startWordPressServer ).not.toHaveBeenCalled();
+			expect( updateSiteLatestCliPid ).not.toHaveBeenCalled();
 			expect( disconnect ).toHaveBeenCalled();
 		} );
 
@@ -198,6 +209,10 @@ describe( 'CLI: studio site set-https', () => {
 			expect( startWordPressServer ).toHaveBeenCalledWith(
 				expect.any( Object ),
 				expect.any( Logger )
+			);
+			expect( updateSiteLatestCliPid ).toHaveBeenCalledWith(
+				mockSiteData.id,
+				mockProcessDescription.pid
 			);
 			expect( disconnect ).toHaveBeenCalled();
 		} );
@@ -221,6 +236,10 @@ describe( 'CLI: studio site set-https', () => {
 			expect( isServerRunning ).toHaveBeenCalledWith( mockSiteData.id );
 			expect( stopWordPressServer ).toHaveBeenCalledWith( mockSiteData.id );
 			expect( startWordPressServer ).toHaveBeenCalled();
+			expect( updateSiteLatestCliPid ).toHaveBeenCalledWith(
+				mockSiteData.id,
+				mockProcessDescription.pid
+			);
 			expect( disconnect ).toHaveBeenCalled();
 		} );
 	} );

--- a/cli/commands/site/tests/set-php-version.test.ts
+++ b/cli/commands/site/tests/set-php-version.test.ts
@@ -6,6 +6,7 @@ import {
 	readAppdata,
 	saveAppdata,
 	unlockAppdata,
+	updateSiteLatestCliPid,
 } from 'cli/lib/appdata';
 import { connect, disconnect } from 'cli/lib/pm2-manager';
 import {
@@ -22,6 +23,7 @@ jest.mock( 'cli/lib/appdata', () => ( {
 	readAppdata: jest.fn(),
 	saveAppdata: jest.fn(),
 	unlockAppdata: jest.fn(),
+	updateSiteLatestCliPid: jest.fn(),
 } ) );
 jest.mock( 'cli/lib/pm2-manager' );
 jest.mock( 'cli/lib/wordpress-server-manager' );
@@ -72,6 +74,7 @@ describe( 'CLI: studio site set-php-version', () => {
 		( startWordPressServer as jest.Mock ).mockResolvedValue( testProcessDescription );
 		( stopWordPressServer as jest.Mock ).mockResolvedValue( undefined );
 		( arePathsEqual as jest.Mock ).mockImplementation( ( a: string, b: string ) => a === b );
+		( updateSiteLatestCliPid as jest.Mock ).mockResolvedValue( undefined );
 	} );
 
 	afterEach( () => {
@@ -149,6 +152,7 @@ describe( 'CLI: studio site set-php-version', () => {
 			expect( isServerRunning ).toHaveBeenCalledWith( testSite.id );
 			expect( stopWordPressServer ).not.toHaveBeenCalled();
 			expect( startWordPressServer ).not.toHaveBeenCalled();
+			expect( updateSiteLatestCliPid ).not.toHaveBeenCalled();
 			expect( disconnect ).toHaveBeenCalled();
 		} );
 
@@ -168,6 +172,10 @@ describe( 'CLI: studio site set-php-version', () => {
 			expect( startWordPressServer ).toHaveBeenCalledWith(
 				expect.any( Object ),
 				expect.any( Logger )
+			);
+			expect( updateSiteLatestCliPid ).toHaveBeenCalledWith(
+				testSite.id,
+				testProcessDescription.pid
 			);
 			expect( disconnect ).toHaveBeenCalled();
 		} );

--- a/cli/commands/site/tests/set-wp-version.test.ts
+++ b/cli/commands/site/tests/set-wp-version.test.ts
@@ -6,6 +6,7 @@ import {
 	readAppdata,
 	saveAppdata,
 	unlockAppdata,
+	updateSiteLatestCliPid,
 } from 'cli/lib/appdata';
 import { connect, disconnect } from 'cli/lib/pm2-manager';
 import { runWpCliCommand } from 'cli/lib/run-wp-cli-command';
@@ -23,6 +24,7 @@ jest.mock( 'cli/lib/appdata', () => ( {
 	readAppdata: jest.fn(),
 	saveAppdata: jest.fn(),
 	unlockAppdata: jest.fn(),
+	updateSiteLatestCliPid: jest.fn(),
 } ) );
 jest.mock( 'cli/lib/pm2-manager' );
 jest.mock( 'cli/lib/run-wp-cli-command' );
@@ -80,6 +82,7 @@ describe( 'CLI: studio site set-wp-version', () => {
 			{ exitCode: 0 },
 			jest.fn().mockResolvedValue( undefined ),
 		] );
+		( updateSiteLatestCliPid as jest.Mock ).mockResolvedValue( undefined );
 	} );
 
 	afterEach( () => {
@@ -182,6 +185,7 @@ describe( 'CLI: studio site set-wp-version', () => {
 
 			expect( unlockAppdata ).toHaveBeenCalled();
 			expect( startWordPressServer ).not.toHaveBeenCalled();
+			expect( updateSiteLatestCliPid ).not.toHaveBeenCalled();
 			expect( disconnect ).toHaveBeenCalled();
 		} );
 
@@ -211,6 +215,10 @@ describe( 'CLI: studio site set-wp-version', () => {
 			expect( startWordPressServer ).toHaveBeenCalledWith(
 				expect.any( Object ),
 				expect.any( Logger )
+			);
+			expect( updateSiteLatestCliPid ).toHaveBeenCalledWith(
+				testSite.id,
+				testProcessDescription.pid
 			);
 			expect( disconnect ).toHaveBeenCalled();
 		} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-1153

## Proposed Changes

- Update `set-domain`, `set-https`, `set-php-version`, and `set-wp-version` CLI commands to call `updateSiteLatestCliPid()` after restarting a site
- Add unit test assertions to verify `updateSiteLatestCliPid` is called with correct site ID and PID when restarting
- Add unit test assertions to verify `updateSiteLatestCliPid` is NOT called when site is stopped (no restart needed)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Build the CLI: `npm run cli:build`
2. Start a site: `studio site start --path ~/Studio/mysite --skip-browser`
3. Confirm online: `studio site list` → 🟢 Online
4. Run a set command: `studio site set-php-version 8.4 --path ~/Studio/mysite`
5. Check again: `studio site list` → should show 🟢 Online (was 🔴 Offline before fix)
6. Run unit tests: `npm test -- cli/commands/site/tests/set-php-version.test.ts cli/commands/site/tests/set-domain.test.ts cli/commands/site/tests/set-https.test.ts cli/commands/site/tests/set-wp-version.test.ts`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?