### PR TITLE
Update debugging flags in Docs and launch.json config

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,24 +1,55 @@
 {
 	"configurations": [
 		{
+			"name": "Debug Main Process",
 			"type": "node",
 			"request": "launch",
-			"name": "Electron Main",
-			"runtimeExecutable": "${workspaceFolder}/node_modules/@electron-forge/cli/script/vscode.sh",
+			"cwd": "${workspaceRoot}",
+			"runtimeExecutable": "${workspaceRoot}/node_modules/.bin/electron-vite",
 			"windows": {
-				"runtimeExecutable": "${workspaceFolder}/node_modules/@electron-forge/cli/script/vscode.cmd"
+				"runtimeExecutable": "${workspaceRoot}/node_modules/.bin/electron-vite.cmd"
 			},
-			"cwd": "${workspaceFolder}",
-			"console": "integratedTerminal"
+			"runtimeArgs": [
+				"--sourcemap",
+				"--outDir=dist",
+			],
+			"env": {
+				"REMOTE_DEBUGGING_PORT": "9222"
+			}
+		},
+		{
+			"name": "Debug Renderer Process",
+			"port": 9222,
+			"request": "attach",
+			"type": "chrome",
+			"webRoot": "${workspaceFolder}/src/renderer",
+			"timeout": 60000,
+			"presentation": {
+				"hidden": true
+			}
 		},
 		{
 			"type": "node",
 			"request": "launch",
 			"name": "Jest All",
 			"program": "${workspaceFolder}/node_modules/.bin/jest",
-			"args": [ "--runInBand" ],
+			"args": [
+				"--runInBand"
+			],
 			"console": "integratedTerminal",
 			"internalConsoleOptions": "neverOpen"
+		}
+	],
+	"compounds": [
+		{
+			"name": "Debug All",
+			"configurations": [
+				"Debug Main Process",
+				"Debug Renderer Process"
+			],
+			"presentation": {
+				"order": 1
+			}
 		}
 	]
 }

--- a/docs/code-contributions.md
+++ b/docs/code-contributions.md
@@ -166,10 +166,10 @@ npm run e2e
 
 The renderer process can be debugged using the Chromium developer tools. To open the developer tools, press <kbd>Cmd</kbd>+<kbd>Option</kbd>+<kbd>I</kbd> on Mac or <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>I</kbd> on Windows. You can also use the [React Developer Tools](https://chromewebstore.google.com/detail/react-developer-tools/fmkadmapgofadopljbjfkapdkoienihi) and [Redux DevTools](https://chromewebstore.google.com/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd) to debug the renderer process.
 
-The main process can be debugged using the Node.js inspector. To do this, run the app with the `--inspect-brk-electron` flag:
+The main process can be debugged using the Node.js inspector. To do this, run the app with the `--inspect-brk` and `--sourcemap` flags:
 
 ```bash
-npm start -- --inspect-brk-electron
+npm start -- --inspect-brk --sourcemap
 ```
 
 Then open `chrome://inspect` in a Chromium-based browser and click "inspect" next to the process you want to debug.


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- N/A

## Proposed Changes

- Update the flags used for debugging [as per documentation](https://electron-vite.org/guide/debugging#v8-inspector-e-g-chrome-devtools)
- Update the `launch` configuration for `vscode` and forks [as per documentation](https://electron-vite.org/guide/debugging#vscode) 
- Use the correct `outDir` for the `launch` configuration

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- You can try to debug using the command by following the instructions
- On VSCode or Cursor, navigate to `Run and Debug` and click on `Debug All`, you can set a breakpoint on any server-side code and check it stops. For the front-end code, you could use the `debugger` statements

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
