### PR TITLE
Add Telex button in overview tab

### DIFF
--- a/src/components/buttons-section.tsx
+++ b/src/components/buttons-section.tsx
@@ -16,8 +16,8 @@ export interface ButtonsSectionProps {
 export function ButtonsSection( { buttonsArray, title, className = '' }: ButtonsSectionProps ) {
 	return (
 		<div className="w-full">
-			<h2 className="a8c-subtitle-small mb-3">{ title }</h2>
-			<div className={ cx( 'gap-3', className || 'grid grid-cols-2 lg:grid-cols-3' ) }>
+			<h2 className="a8c-subtitle-small mb-2">{ title }</h2>
+			<div className={ cx( 'gap-2', className || 'grid grid-cols-2 lg:grid-cols-3' ) }>
 				{ buttonsArray.map( ( button, index ) => (
 					<Button
 						className={ button.className }

--- a/src/components/buttons-section.tsx
+++ b/src/components/buttons-section.tsx
@@ -16,8 +16,8 @@ export interface ButtonsSectionProps {
 export function ButtonsSection( { buttonsArray, title, className = '' }: ButtonsSectionProps ) {
 	return (
 		<div className="w-full">
-			<h2 className="a8c-subtitle-small mb-2">{ title }</h2>
-			<div className={ cx( 'gap-2', className || 'grid grid-cols-2 lg:grid-cols-3' ) }>
+			<h2 className="a8c-subtitle-small mb-3">{ title }</h2>
+			<div className={ cx( 'gap-3', className || 'grid grid-cols-2 lg:grid-cols-3' ) }>
 				{ buttonsArray.map( ( button, index ) => (
 					<Button
 						className={ button.className }

--- a/src/components/content-tab-overview.tsx
+++ b/src/components/content-tab-overview.tsx
@@ -153,18 +153,6 @@ function ShortcutsSection( { selectedSite }: Pick< ContentTabOverviewProps, 'sel
 		},
 	];
 
-	const editorConfig = editor ? supportedEditorConfig[ editor ] : false;
-	if ( editor && editorConfig ) {
-		buttonsArray.push( {
-			label: editorConfig.label,
-			className: 'text-nowrap',
-			icon: code,
-			onClick: async () => {
-				await getIpcApi().openAppAtPath( editor, selectedSite.path );
-			},
-		} );
-	}
-
 	const terminalName = getTerminalName( terminal );
 	buttonsArray.push( {
 		label: terminalName,
@@ -179,6 +167,18 @@ function ShortcutsSection( { selectedSite }: Pick< ContentTabOverviewProps, 'sel
 			}
 		},
 	} );
+
+	const editorConfig = editor ? supportedEditorConfig[ editor ] : false;
+	if ( editor && editorConfig ) {
+		buttonsArray.push( {
+			label: editorConfig.label,
+			className: 'text-nowrap',
+			icon: code,
+			onClick: async () => {
+				await getIpcApi().openAppAtPath( editor, selectedSite.path );
+			},
+		} );
+	}
 
 	buttonsArray.push( {
 		label: __( 'Telex' ),

--- a/src/components/content-tab-overview.tsx
+++ b/src/components/content-tab-overview.tsx
@@ -12,6 +12,7 @@ import {
 	styles,
 	symbolFilled,
 	widget,
+	plugins,
 } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { useState } from 'react';
@@ -181,6 +182,21 @@ function ShortcutsSection( { selectedSite }: Pick< ContentTabOverviewProps, 'sel
 	return <ButtonsSection buttonsArray={ buttonsArray } title={ __( 'Open in…' ) } />;
 }
 
+function BuildInSection() {
+	const buttonsArray: ButtonsSectionProps[ 'buttonsArray' ] = [
+		{
+			label: __( 'Telex' ),
+			className: 'text-nowrap',
+			icon: plugins,
+			onClick: () => {
+				getIpcApi().openURL( 'https://telex.automattic.ai' );
+			},
+		},
+	];
+
+	return <ButtonsSection buttonsArray={ buttonsArray } title={ __( 'Build in…' ) } />;
+}
+
 export function ContentTabOverview( { selectedSite }: ContentTabOverviewProps ) {
 	const [ isThumbnailError, setIsThumbnailError ] = useState( false );
 	const { __ } = useI18n();
@@ -216,7 +232,7 @@ export function ContentTabOverview( { selectedSite }: ContentTabOverviewProps ) 
 	);
 
 	return (
-		<div className="p-8 flex max-w-4xl">
+		<div className="pt-4 pb-8 pl-8 pr-8 flex max-w-4xl">
 			<div className="w-52 ltr:mr-8 rtl:ml-8 flex-col justify-start items-start gap-8">
 				<h2 className="mb-3 a8c-subtitle-small">{ __( 'Theme' ) }</h2>
 				<div
@@ -259,13 +275,14 @@ export function ContentTabOverview( { selectedSite }: ContentTabOverviewProps ) 
 					{ ! loading && ! isThumbnailError && <p>{ themeDetails?.name }</p> }
 				</div>
 			</div>
-			<div className="flex flex-1 flex-col justify-start items-start gap-8">
+			<div className="flex flex-1 flex-col justify-start items-start gap-4">
 				<CustomizeSection
 					selectedSite={ selectedSite }
 					themeDetails={ themeDetails }
 					loading={ loading }
 				/>
 				<ShortcutsSection selectedSite={ selectedSite } />
+				<BuildInSection />
 			</div>
 		</div>
 	);

--- a/src/components/content-tab-overview.tsx
+++ b/src/components/content-tab-overview.tsx
@@ -232,7 +232,7 @@ export function ContentTabOverview( { selectedSite }: ContentTabOverviewProps ) 
 	);
 
 	return (
-		<div className="pt-4 pb-8 pl-8 pr-8 flex max-w-4xl">
+		<div className="p-8 flex max-w-4xl">
 			<div className="w-52 ltr:mr-8 rtl:ml-8 flex-col justify-start items-start gap-8">
 				<h2 className="mb-3 a8c-subtitle-small">{ __( 'Theme' ) }</h2>
 				<div
@@ -275,7 +275,7 @@ export function ContentTabOverview( { selectedSite }: ContentTabOverviewProps ) 
 					{ ! loading && ! isThumbnailError && <p>{ themeDetails?.name }</p> }
 				</div>
 			</div>
-			<div className="flex flex-1 flex-col justify-start items-start gap-4">
+			<div className="flex flex-1 flex-col justify-start items-start gap-8">
 				<CustomizeSection
 					selectedSite={ selectedSite }
 					themeDetails={ themeDetails }

--- a/src/components/content-tab-overview.tsx
+++ b/src/components/content-tab-overview.tsx
@@ -179,22 +179,17 @@ function ShortcutsSection( { selectedSite }: Pick< ContentTabOverviewProps, 'sel
 			}
 		},
 	} );
-	return <ButtonsSection buttonsArray={ buttonsArray } title={ __( 'Open in…' ) } />;
-}
 
-function BuildInSection() {
-	const buttonsArray: ButtonsSectionProps[ 'buttonsArray' ] = [
-		{
-			label: __( 'Telex' ),
-			className: 'text-nowrap',
-			icon: plugins,
-			onClick: () => {
-				getIpcApi().openURL( 'https://telex.automattic.ai' );
-			},
+	buttonsArray.push( {
+		label: __( 'Telex' ),
+		className: 'text-nowrap',
+		icon: plugins,
+		onClick: () => {
+			getIpcApi().openURL( 'https://telex.automattic.ai' );
 		},
-	];
+	} );
 
-	return <ButtonsSection buttonsArray={ buttonsArray } title={ __( 'Build in…' ) } />;
+	return <ButtonsSection buttonsArray={ buttonsArray } title={ __( 'Open…' ) } />;
 }
 
 export function ContentTabOverview( { selectedSite }: ContentTabOverviewProps ) {
@@ -282,7 +277,6 @@ export function ContentTabOverview( { selectedSite }: ContentTabOverviewProps ) 
 					loading={ loading }
 				/>
 				<ShortcutsSection selectedSite={ selectedSite } />
-				<BuildInSection />
 			</div>
 		</div>
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-1056

## Proposed Changes

- Add telex button in overview tab.

<!--img width="1032" height="712" alt="Screenshot 2025-12-18 at 12 41 18" src="https://github.com/user-attachments/assets/6f0f3ec0-94a0-4b09-a07f-5662c7c23a7d" /!-->

<img width="1032" height="712" alt="Screenshot 2025-12-18 at 20 39 51" src="https://github.com/user-attachments/assets/525bf3fc-c335-4ef6-8057-e47be914dc71" />



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run `npm start`
- Go to the overview tab
- Observe that a new button exists named `Telex`
- Click on it
- Observe it opens https://telex.automattic.ai/

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
