### PR TITLE
Test if adding mdast-util-to-hast  to allow list fixes security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,6 +33,7 @@ updates:
       - dependency-name: "vite-*"
       - dependency-name: "@vitejs/*"
       - dependency-name: "electron-vite"
+      - dependency-name: "mdast-util-to-hast"
     groups:
       electron-forge:
         patterns:


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- https://github.com/Automattic/studio/security/dependabot/85

## Proposed Changes

I want to test if adding mdast-util-to-hast to the allow list fixes Dependabot security updates. Currently, they are not being applied due to error:

```
+------------------------------------------------------------------+
|                              Errors                              |
+----------------------+-------------------------------------------+
| Type                 | Details                                   |
+----------------------+-------------------------------------------+
| all_versions_ignored | {                                         |
|                      |   "dependency-name": "mdast-util-to-hast" |
|                      | }                                         |
+----------------------+-------------------------------------------+
```

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Code review should suffice.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
