### PR TITLE
Add CLI site create/start logs to Studio console

### DIFF
--- a/src/modules/cli/lib/cli-server-process.ts
+++ b/src/modules/cli/lib/cli-server-process.ts
@@ -1,5 +1,13 @@
+import { z } from 'zod';
+import { SiteCommandLoggerAction } from 'common/logger-actions';
 import { executeCliCommand } from './execute-command';
 import type { WordPressServerProcess } from 'src/lib/wordpress-provider/types';
+
+const cliEventSchema = z.object( {
+	action: z.nativeEnum( SiteCommandLoggerAction ),
+	status: z.enum( [ 'inprogress', 'fail', 'success', 'warning' ] ),
+	message: z.string(),
+} );
 
 /**
  * A WordPressServerProcess implementation that delegates to CLI commands.
@@ -19,13 +27,17 @@ export class CliServerProcess implements WordPressServerProcess {
 
 	async start(): Promise< void > {
 		return new Promise( ( resolve, reject ) => {
-			const [ emitter ] = executeCliCommand( [
-				'site',
-				'start',
-				'--path',
-				this.sitePath,
-				'--skip-browser',
-			] );
+			const [ emitter ] = executeCliCommand(
+				[ 'site', 'start', '--path', this.sitePath, '--skip-browser' ],
+				{ output: 'capture', logPrefix: this.siteId }
+			);
+
+			emitter.on( 'data', ( { data } ) => {
+				const parsed = cliEventSchema.safeParse( data );
+				if ( parsed.success && parsed.data.status === 'inprogress' ) {
+					console.log( `[CLI - ${ this.siteId }] ${ parsed.data.message }` );
+				}
+			} );
 
 			emitter.on( 'success', () => {
 				resolve();

--- a/src/modules/cli/lib/cli-site-creator.ts
+++ b/src/modules/cli/lib/cli-site-creator.ts
@@ -52,12 +52,17 @@ export async function createSiteViaCli( options: CreateSiteOptions ): Promise< C
 		const result: Partial< CreateSiteResult > = {};
 		let lastErrorMessage: string | null = null;
 
-		const [ emitter ] = executeCliCommand( args );
+		const [ emitter ] = executeCliCommand( args, { output: 'capture', logPrefix: siteId } );
 
 		emitter.on( 'data', ( { data } ) => {
 			const parsed = cliEventSchema.safeParse( data );
 			if ( ! parsed.success ) {
 				return;
+			}
+
+			if ( parsed.data.action !== 'keyValuePair' && parsed.data.status === 'inprogress' ) {
+				const prefix = siteId ? `[CLI - ${ siteId }]` : '[CLI]';
+				console.log( `${ prefix } ${ parsed.data.message }` );
 			}
 
 			if ( parsed.data.action === 'keyValuePair' ) {

--- a/src/modules/cli/lib/execute-command.ts
+++ b/src/modules/cli/lib/execute-command.ts
@@ -40,6 +40,7 @@ export interface ExecuteCliCommandOptions {
 	 * - 'capture': capture stdout/stderr, available in success/failure events
 	 */
 	output: 'ignore' | 'capture';
+	logPrefix?: string;
 }
 
 export function executeCliCommand(
@@ -69,8 +70,14 @@ export function executeCliCommand(
 	let stderr = '';
 
 	if ( options.output === 'capture' ) {
+		const logPrefix = options.logPrefix ? `[CLI - ${ options.logPrefix }]` : '[CLI]';
 		child.stdout?.on( 'data', ( data: Buffer ) => {
-			stdout += data.toString();
+			const text = data.toString();
+			stdout += text;
+			const trimmed = text.trimEnd();
+			if ( trimmed ) {
+				console.log( `${ logPrefix } ${ trimmed }` );
+			}
 		} );
 		child.stderr?.on( 'data', ( data: Buffer ) => {
 			stderr += data.toString();

--- a/src/site-server.ts
+++ b/src/site-server.ts
@@ -380,7 +380,10 @@ export class SiteServer {
 		let timeoutId: NodeJS.Timeout;
 
 		return new Promise< WpCliResult >( ( resolve ) => {
-			const [ emitter, childProcess ] = executeCliCommand( cliArgs, { output: 'capture' } );
+			const [ emitter, childProcess ] = executeCliCommand( cliArgs, {
+				output: 'capture',
+				logPrefix: this.details.id,
+			} );
 
 			timeoutId = setTimeout( () => {
 				childProcess.kill();


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-1157

## Proposed Changes

- Add `logPrefix` option to `executeCliCommand` to identify which site the logs belong to
- Capture stdout from CLI child processes and log in real-time with `[CLI - {siteId}]` prefix
- Add logging for site create operations via CLI (`cli-site-creator.ts`)
- Add logging for site start operations via CLI (`cli-server-process.ts`)
- Add logging for WP-CLI command execution (`site-server.ts`)

This restores the logging behavior that was available before switching to CLI for site create/start operations, making debugging easier.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. `npm start`
2. Create a site
3. Verify logs appear in Studio console with prefix `[CLI - {siteId}]`
4. Start a stopped site
5. Verify startup logs appear in Studio console with the same prefix format
6. Run a WP-CLI from the AI Assistant command on a running site
7. Verify the command output appears in Studio console with the site ID prefix

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?