### PR TITLE
Update CTA label when Assistant proposes to add site from Blueprint

### DIFF
--- a/src/components/add-site-with-blueprint-button.tsx
+++ b/src/components/add-site-with-blueprint-button.tsx
@@ -31,7 +31,7 @@ export function AddSiteWithBlueprintButton( {
 				getIpcApi().openURL( url );
 			} }
 		>
-			{ children || __( 'Add new site' ) }
+			{ children || __( 'Add site from a Blueprint' ) }
 		</Button>
 	);
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-1160

## Proposed Changes

Changes the button text in the Assistant's blueprint responses from "Add new site" to "Add site from a Blueprint" for better clarity.

This makes it clearer to users what action they're taking when they click the button that appears in Assistant responses containing blueprints.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Ask Assistant to generate blueprint
2. Confirm that new label is displayed

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
