### PR TITLE
Add Telex banner and link to AI tab

### DIFF
--- a/src/components/ai-input.tsx
+++ b/src/components/ai-input.tsx
@@ -2,6 +2,8 @@ import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { Icon, moreVertical, keyboardReturn, reset } from '@wordpress/icons';
 import React, { forwardRef, useRef, useEffect, useState } from 'react';
+import { ArrowIcon } from 'src/components/arrow-icon';
+import { TELEX_URL } from 'src/constants';
 import useAiIcon from 'src/hooks/use-ai-icon';
 import { cx } from 'src/lib/cx';
 import { getIpcApi } from 'src/lib/get-ipc-api';
@@ -17,6 +19,30 @@ interface AIInputProps {
 }
 
 const MAX_ROWS = 10;
+
+// Sparkles icon used in Assistant tab (24px to match Icon component size)
+const SparklesIcon = () => (
+	<svg
+		width="24"
+		height="24"
+		viewBox="0 0 24 24"
+		fill="none"
+		xmlns="http://www.w3.org/2000/svg"
+		style={ { display: 'inline-block' } }
+	>
+		<g transform="translate(5, 5)" clipPath="url(#clip0_2870_30744)">
+			<path
+				d="M13.7035 6.58213L10.8309 5.59124C9.69491 5.20089 8.79911 4.30509 8.40876 3.16908L7.41787 0.296515C7.28275 -0.0988382 6.71725 -0.0988382 6.58213 0.296515L5.59124 3.16908C5.20089 4.30509 4.30509 5.20089 3.16908 5.59124L0.296515 6.58213C-0.0988382 6.71725 -0.0988382 7.28275 0.296515 7.41787L3.16908 8.40876C4.30509 8.79911 5.20089 9.69491 5.59124 10.8309L6.58213 13.7035C6.71725 14.0988 7.28275 14.0988 7.41787 13.7035L8.40876 10.8309C8.79911 9.69491 9.69491 8.79911 10.8309 8.40876L13.7035 7.41787C14.0988 7.28275 14.0988 6.71725 13.7035 6.58213ZM10.3505 7.21269L8.91421 7.70813C8.3437 7.90331 7.8983 8.35371 7.70313 8.91921L7.20768 10.3555C7.13762 10.5557 6.85737 10.5557 6.79231 10.3555L6.29687 8.91921C6.1017 8.3487 5.6513 7.90331 5.08579 7.70813L3.64951 7.21269C3.44933 7.14263 3.44933 6.86238 3.64951 6.79232L5.08579 6.29687C5.6563 6.1017 6.1017 5.6513 6.29687 5.08579L6.79231 3.64951C6.86238 3.44933 7.14263 3.44933 7.20768 3.64951L7.70313 5.08579C7.8983 5.6563 8.3487 6.1017 8.91421 6.29687L10.3505 6.79232C10.5507 6.86238 10.5507 7.14263 10.3505 7.21269Z"
+				fill="black"
+			/>
+		</g>
+		<defs>
+			<clipPath id="clip0_2870_30744">
+				<rect width="14" height="14" fill="white" />
+			</clipPath>
+		</defs>
+	</svg>
+);
 
 const UnforwardedAIInput = (
 	{
@@ -236,6 +262,18 @@ const UnforwardedAIInput = (
 				{ ( { onClose }: { onClose: () => void } ) => (
 					<>
 						<MenuGroup>
+							<MenuItem
+								data-testid="telex-link-button"
+								onClick={ () => {
+									getIpcApi().openURL( TELEX_URL );
+									onClose();
+								} }
+								className="flex flex-row"
+							>
+								<SparklesIcon />
+								<span className="ltr:pl-2 rtl:pl-2">{ __( 'Build with Telex' ) }</span>
+								<ArrowIcon />
+							</MenuItem>
 							<MenuItem
 								isDestructive
 								data-testid="clear-conversation-button"

--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -456,11 +456,12 @@ export function ContentTabAssistant( { selectedSite }: ContentTabAssistantProps 
 						<TelexIcon />
 						<span className="text-gray-900">
 							{ createInterpolateElement(
-								__( 'Build blocks with Telex. <button>Learn more</button>' ),
+								__( 'Build blocks with <button>Telex <ArrowIcon /></button>' ),
 								{
 									button: (
 										<Button variant="link" onClick={ () => getIpcApi().openURL( TELEX_URL ) } />
 									),
+									ArrowIcon: <ArrowIcon />,
 								}
 							) }
 						</span>

--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -16,7 +16,7 @@ import { ChatMessage, MarkDownWithCode } from 'src/components/chat-message';
 import { ChatRating } from 'src/components/chat-rating';
 import offlineIcon from 'src/components/offline-icon';
 import WelcomeComponent from 'src/components/welcome-message-prompt';
-import { AI_GUIDELINES_URL, LIMIT_OF_PROMPTS_PER_USER } from 'src/constants';
+import { AI_GUIDELINES_URL, LIMIT_OF_PROMPTS_PER_USER, TELEX_URL } from 'src/constants';
 import { useAuth } from 'src/hooks/use-auth';
 import { useOffline } from 'src/hooks/use-offline';
 import { useThemeDetails } from 'src/hooks/use-theme-details';

--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -16,7 +16,7 @@ import { ChatMessage, MarkDownWithCode } from 'src/components/chat-message';
 import { ChatRating } from 'src/components/chat-rating';
 import offlineIcon from 'src/components/offline-icon';
 import WelcomeComponent from 'src/components/welcome-message-prompt';
-import { AI_GUIDELINES_URL, LIMIT_OF_PROMPTS_PER_USER } from 'src/constants';
+import { AI_GUIDELINES_URL, LIMIT_OF_PROMPTS_PER_USER, TELEX_URL } from 'src/constants';
 import { useAuth } from 'src/hooks/use-auth';
 import { useOffline } from 'src/hooks/use-offline';
 import { useThemeDetails } from 'src/hooks/use-theme-details';
@@ -482,12 +482,22 @@ export function ContentTabAssistant( { selectedSite }: ContentTabAssistantProps 
 						clearConversation={ clearConversation }
 						isAssistantThinking={ isAssistantThinking }
 					/>
-					<div data-testid="guidelines-link" className="text-a8c-gray-50 self-end py-2">
-						{ createInterpolateElement( __( 'Powered by experimental AI. <a>Learn more</a>' ), {
-							a: (
-								<Button variant="link" onClick={ () => getIpcApi().openURL( AI_GUIDELINES_URL ) } />
-							),
-						} ) }
+					<div className="w-full flex justify-between items-center text-a8c-gray-50 py-2">
+						<div data-testid="telex-link">
+							{ createInterpolateElement( __( 'Build blocks with <a>Telex</a>' ), {
+								a: <Button variant="link" onClick={ () => getIpcApi().openURL( TELEX_URL ) } />,
+							} ) }
+						</div>
+						<div data-testid="guidelines-link">
+							{ createInterpolateElement( __( 'Powered by experimental AI. <a>Learn more</a>' ), {
+								a: (
+									<Button
+										variant="link"
+										onClick={ () => getIpcApi().openURL( AI_GUIDELINES_URL ) }
+									/>
+								),
+							} ) }
+						</div>
 					</div>
 				</div>
 			</div>

--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -34,6 +34,24 @@ import { useGetAssistantQuota, useGetWelcomeMessages } from 'src/stores/wpcom-ap
 
 export const MIMIC_CONVERSATION_DELAY = 500;
 
+// Telex icon with red/orange background
+const TelexIcon = () => (
+	<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+		<rect width="24" height="24" rx="2" fill="rgb(229, 74, 39)" />
+		<g transform="translate(5, 5)" clipPath="url(#clip0_telex_icon)">
+			<path
+				d="M13.7035 6.58213L10.8309 5.59124C9.69491 5.20089 8.79911 4.30509 8.40876 3.16908L7.41787 0.296515C7.28275 -0.0988382 6.71725 -0.0988382 6.58213 0.296515L5.59124 3.16908C5.20089 4.30509 4.30509 5.20089 3.16908 5.59124L0.296515 6.58213C-0.0988382 6.71725 -0.0988382 7.28275 0.296515 7.41787L3.16908 8.40876C4.30509 8.79911 5.20089 9.69491 5.59124 10.8309L6.58213 13.7035C6.71725 14.0988 7.28275 14.0988 7.41787 13.7035L8.40876 10.8309C8.79911 9.69491 9.69491 8.79911 10.8309 8.40876L13.7035 7.41787C14.0988 7.28275 14.0988 6.71725 13.7035 6.58213ZM10.3505 7.21269L8.91421 7.70813C8.3437 7.90331 7.8983 8.35371 7.70313 8.91921L7.20768 10.3555C7.13762 10.5557 6.85737 10.5557 6.79231 10.3555L6.29687 8.91921C6.1017 8.3487 5.6513 7.90331 5.08579 7.70813L3.64951 7.21269C3.44933 7.14263 3.44933 6.86238 3.64951 6.79232L5.08579 6.29687C5.6563 6.1017 6.1017 5.6513 6.29687 5.08579L6.79231 3.64951C6.86238 3.44933 7.14263 3.44933 7.20768 3.64951L7.70313 5.08579C7.8983 5.6563 8.3487 6.1017 8.91421 6.29687L10.3505 6.79232C10.5507 6.86238 10.5507 7.14263 10.3505 7.21269Z"
+				fill="#2C2C2C"
+			/>
+		</g>
+		<defs>
+			<clipPath id="clip0_telex_icon">
+				<rect width="14" height="14" fill="white" />
+			</clipPath>
+		</defs>
+	</svg>
+);
+
 interface ContentTabAssistantProps {
 	selectedSite: SiteDetails;
 }
@@ -421,8 +439,41 @@ export function ContentTabAssistant( { selectedSite }: ContentTabAssistantProps 
 
 	const disabled = isOffline || ! isAuthenticated || ! userCanSendMessage || hasFailedMessage;
 
+	const [ isTelexBannerVisible, setIsTelexBannerVisible ] = useState(
+		() => localStorage.getItem( 'dontShowTelexBanner' ) !== 'true'
+	);
+
+	const handleDismissBanner = () => {
+		localStorage.setItem( 'dontShowTelexBanner', 'true' );
+		setIsTelexBannerVisible( false );
+	};
+
 	return (
 		<div className="relative min-h-full flex flex-col" ref={ wrapperRef }>
+			{ isTelexBannerVisible && (
+				<div className="bg-white border border-gray-300 rounded-sm m-8 mb-0 p-2 pr-4 flex items-center justify-between">
+					<div className="flex items-center gap-3">
+						<TelexIcon />
+						<span className="text-gray-900">
+							{ createInterpolateElement(
+								__( 'Build blocks with Telex. <button>Learn more</button>' ),
+								{
+									button: (
+										<Button variant="link" onClick={ () => getIpcApi().openURL( TELEX_URL ) } />
+									),
+								}
+							) }
+						</span>
+					</div>
+					<button
+						onClick={ handleDismissBanner }
+						className="text-gray-500 hover:text-gray-700"
+						aria-label={ __( 'Dismiss' ) }
+					>
+						✕
+					</button>
+				</div>
+			) }
 			<div
 				data-testid="assistant-chat"
 				className={ cx(

--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -16,7 +16,7 @@ import { ChatMessage, MarkDownWithCode } from 'src/components/chat-message';
 import { ChatRating } from 'src/components/chat-rating';
 import offlineIcon from 'src/components/offline-icon';
 import WelcomeComponent from 'src/components/welcome-message-prompt';
-import { AI_GUIDELINES_URL, LIMIT_OF_PROMPTS_PER_USER, TELEX_URL } from 'src/constants';
+import { AI_GUIDELINES_URL, LIMIT_OF_PROMPTS_PER_USER } from 'src/constants';
 import { useAuth } from 'src/hooks/use-auth';
 import { useOffline } from 'src/hooks/use-offline';
 import { useThemeDetails } from 'src/hooks/use-theme-details';
@@ -533,22 +533,12 @@ export function ContentTabAssistant( { selectedSite }: ContentTabAssistantProps 
 						clearConversation={ clearConversation }
 						isAssistantThinking={ isAssistantThinking }
 					/>
-					<div className="w-full flex justify-between items-center text-a8c-gray-50 py-2">
-						<div data-testid="telex-link">
-							{ createInterpolateElement( __( 'Build blocks with <a>Telex</a>' ), {
-								a: <Button variant="link" onClick={ () => getIpcApi().openURL( TELEX_URL ) } />,
-							} ) }
-						</div>
-						<div data-testid="guidelines-link">
-							{ createInterpolateElement( __( 'Powered by experimental AI. <a>Learn more</a>' ), {
-								a: (
-									<Button
-										variant="link"
-										onClick={ () => getIpcApi().openURL( AI_GUIDELINES_URL ) }
-									/>
-								),
-							} ) }
-						</div>
+					<div data-testid="guidelines-link" className="text-a8c-gray-50 self-end py-2">
+						{ createInterpolateElement( __( 'Powered by experimental AI. <a>Learn more</a>' ), {
+							a: (
+								<Button variant="link" onClick={ () => getIpcApi().openURL( AI_GUIDELINES_URL ) } />
+							),
+						} ) }
 					</div>
 				</div>
 			</div>

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -25,7 +25,8 @@ export const WINDOWS_TITLEBAR_HEIGHT = 32;
 export const ABOUT_WINDOW_WIDTH = 300;
 export const ABOUT_WINDOW_HEIGHT = 350;
 export const AI_GUIDELINES_URL = 'https://automattic.com/ai-guidelines/';
-export const TELEX_URL = 'https://telex.automattic.ai/?utm_source=studio&utm_medium=app&utm_campaign=assistant';
+export const TELEX_URL =
+	'https://telex.automattic.ai/?utm_source=studio&utm_medium=app&utm_campaign=assistant';
 export const BUG_REPORT_URL =
 	'https://github.com/Automattic/studio/issues/new?assignees=&labels=Needs+triage%2C%5BType%5D+Bug&projects=&template=bug_report.yml';
 export const FEATURE_REQUEST_URL =

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -25,6 +25,7 @@ export const WINDOWS_TITLEBAR_HEIGHT = 32;
 export const ABOUT_WINDOW_WIDTH = 300;
 export const ABOUT_WINDOW_HEIGHT = 350;
 export const AI_GUIDELINES_URL = 'https://automattic.com/ai-guidelines/';
+export const TELEX_URL = 'https://telex.automattic.ai/';
 export const BUG_REPORT_URL =
 	'https://github.com/Automattic/studio/issues/new?assignees=&labels=Needs+triage%2C%5BType%5D+Bug&projects=&template=bug_report.yml';
 export const FEATURE_REQUEST_URL =

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -25,7 +25,7 @@ export const WINDOWS_TITLEBAR_HEIGHT = 32;
 export const ABOUT_WINDOW_WIDTH = 300;
 export const ABOUT_WINDOW_HEIGHT = 350;
 export const AI_GUIDELINES_URL = 'https://automattic.com/ai-guidelines/';
-export const TELEX_URL = 'https://telex.automattic.ai/';
+export const TELEX_URL = 'https://telex.automattic.ai/?utm_source=studio&utm_medium=app&utm_campaign=assistant';
 export const BUG_REPORT_URL =
 	'https://github.com/Automattic/studio/issues/new?assignees=&labels=Needs+triage%2C%5BType%5D+Bug&projects=&template=bug_report.yml';
 export const FEATURE_REQUEST_URL =


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-1056

## Proposed Changes

I propose adding a new Telex banner at the top of the Assistant tab and "Build with Telex" menu item in the AI input dropdown.

<img width="2028" height="1424" alt="CleanShot 2025-12-30 at 09 48 39@2x" src="https://github.com/user-attachments/assets/358be51e-ef7f-4a7f-8cde-594b8e44c77c" />

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Start the app with `npm start`
2. Create or open a site
3. Navigate to the Assistant tab
5. Verify the conversation shows "Build blocks with Telex" banner
6. Verify "Learn more" is clickable and points to Telex landing page
7. Verify Assistant text area three-dots menu shows Telex link

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
