### PR TITLE
Replace electron-devtools-installer with native Electron API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -102,7 +102,6 @@
 				"@wordpress/react-i18n": "^4.36.0",
 				"cross-env": "^7.0.3",
 				"electron": "^39.2.7",
-				"electron-devtools-installer": "^4.0.0",
 				"electron-playwright-helpers": "^2.0.1",
 				"electron-vite": "^5.0.0",
 				"eslint": "^9.39.2",
@@ -469,7 +468,6 @@
 			"integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.27.1",
 				"@babel/generator": "^7.28.5",
@@ -2523,7 +2521,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			},
@@ -2547,7 +2544,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -4126,7 +4122,6 @@
 			"version": "11.11.3",
 			"resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.11.3.tgz",
 			"integrity": "sha512-Cnn0kuq4DoONOMcnoVsTOR8E+AdnKFf//6kUWc4LCdnxj31pZWn7rIULd6Y7/Js1PiPHzn7SKCM9vB/jBni8eA==",
-			"peer": true,
 			"dependencies": {
 				"@babel/runtime": "^7.18.3",
 				"@emotion/babel-plugin": "^11.11.0",
@@ -5207,7 +5202,6 @@
 			"resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.10.1.tgz",
 			"integrity": "sha512-Dx/y9bCQcXLI5ooQ5KyvA4FTgeo2jYj/7plWfV5Ak5wDPKQZgudKez2ixyfz7tKXzcJciTxqLeK7R9HItwiByg==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@inquirer/checkbox": "^4.3.2",
 				"@inquirer/confirm": "^5.1.21",
@@ -6567,7 +6561,6 @@
 			"version": "5.2.1",
 			"resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.1.tgz",
 			"integrity": "sha512-dKYCMuPO1bmrpuogcjQ8z7ICCH3FP6WmxpwC03yjzGfZhj9fTJg6+bS1+UAplekbN2C+M61UNllGOOoAfGCrdQ==",
-			"peer": true,
 			"dependencies": {
 				"@octokit/auth-token": "^4.0.0",
 				"@octokit/graphql": "^7.1.0",
@@ -6880,7 +6873,6 @@
 			"resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
 			"integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
 			"license": "Apache-2.0",
-			"peer": true,
 			"engines": {
 				"node": ">=8.0.0"
 			}
@@ -6902,7 +6894,6 @@
 			"resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.30.1.tgz",
 			"integrity": "sha512-s5vvxXPVdjqS3kTLKMeBMvop9hbWkwzBpu+mUO2M7sZtlkyDJGwFe33wRKnbaYDo8ExRVBIIdwIGrqpxHuKttA==",
 			"license": "Apache-2.0",
-			"peer": true,
 			"engines": {
 				"node": ">=14"
 			},
@@ -6915,7 +6906,6 @@
 			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
 			"integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"@opentelemetry/semantic-conventions": "1.28.0"
 			},
@@ -6940,7 +6930,6 @@
 			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.57.2.tgz",
 			"integrity": "sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==",
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"@opentelemetry/api-logs": "0.57.2",
 				"@types/shimmer": "^1.2.0",
@@ -7346,7 +7335,6 @@
 			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.30.1.tgz",
 			"integrity": "sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==",
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"@opentelemetry/core": "1.30.1",
 				"@opentelemetry/semantic-conventions": "1.28.0"
@@ -7372,7 +7360,6 @@
 			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.30.1.tgz",
 			"integrity": "sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==",
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"@opentelemetry/core": "1.30.1",
 				"@opentelemetry/resources": "1.30.1",
@@ -7399,7 +7386,6 @@
 			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.37.0.tgz",
 			"integrity": "sha512-JD6DerIKdJGmRp4jQyX5FlrQjA4tjOw1cvfsPAZXfOOEErMUHjPcPSICS+6WnM0nB0efSFARh0KAZss+bvExOA==",
 			"license": "Apache-2.0",
-			"peer": true,
 			"engines": {
 				"node": ">=14"
 			}
@@ -7436,6 +7422,7 @@
 			"hasInstallScript": true,
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"detect-libc": "^1.0.3",
 				"is-glob": "^4.0.3",
@@ -7478,6 +7465,7 @@
 			"os": [
 				"android"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">= 10.0.0"
 			},
@@ -7499,6 +7487,7 @@
 			"os": [
 				"darwin"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">= 10.0.0"
 			},
@@ -7520,6 +7509,7 @@
 			"os": [
 				"darwin"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">= 10.0.0"
 			},
@@ -7541,6 +7531,7 @@
 			"os": [
 				"freebsd"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">= 10.0.0"
 			},
@@ -7562,6 +7553,7 @@
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">= 10.0.0"
 			},
@@ -7583,6 +7575,7 @@
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">= 10.0.0"
 			},
@@ -7604,6 +7597,7 @@
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">= 10.0.0"
 			},
@@ -7625,6 +7619,7 @@
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">= 10.0.0"
 			},
@@ -7646,6 +7641,7 @@
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">= 10.0.0"
 			},
@@ -7667,6 +7663,7 @@
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">= 10.0.0"
 			},
@@ -7688,6 +7685,7 @@
 			"os": [
 				"win32"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">= 10.0.0"
 			},
@@ -7709,6 +7707,7 @@
 			"os": [
 				"win32"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">= 10.0.0"
 			},
@@ -7730,6 +7729,7 @@
 			"os": [
 				"win32"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">= 10.0.0"
 			},
@@ -7745,6 +7745,7 @@
 			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
+			"peer": true,
 			"bin": {
 				"detect-libc": "bin/detect-libc.js"
 			},
@@ -9414,7 +9415,6 @@
 			"devOptional": true,
 			"hasInstallScript": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"@swc/counter": "^0.1.3",
 				"@swc/types": "^0.1.24"
@@ -9639,8 +9639,7 @@
 			"resolved": "https://registry.npmjs.org/@swc/wasm/-/wasm-1.13.5.tgz",
 			"integrity": "sha512-ZBZcxieydxNwgEU9eFAXGMaDb1Xoh+ZkZcUQ27LNJzc2lPSByoL6CSVqnYiaVo+n9JgqbYyHlMq+i7z0wRNTfA==",
 			"devOptional": true,
-			"license": "Apache-2.0",
-			"peer": true
+			"license": "Apache-2.0"
 		},
 		"node_modules/@szmarczak/http-timer": {
 			"version": "4.0.6",
@@ -9842,7 +9841,8 @@
 			"version": "5.0.4",
 			"resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
 			"integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/@types/aws-lambda": {
 			"version": "8.10.159",
@@ -10209,7 +10209,6 @@
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.3.tgz",
 			"integrity": "sha512-1N9SBnWYOJTrNZCdh/yJE+t910Y128BoyY+zBLWhL3r0TYzlTmFdXrPwHL9DyFZmlEXNQQolTZh3KHV31QDhyA==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"undici-types": "~6.21.0"
 			}
@@ -10260,7 +10259,6 @@
 			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.27.tgz",
 			"integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@types/prop-types": "*",
 				"csstype": "^3.2.2"
@@ -10271,7 +10269,6 @@
 			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
 			"integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
 			"license": "MIT",
-			"peer": true,
 			"peerDependencies": {
 				"@types/react": "^18.0.0"
 			}
@@ -10440,7 +10437,6 @@
 			"integrity": "sha512-6/cmF2piao+f6wSxUsJLZjck7OQsYyRtcOZS02k7XINSNlz93v6emM8WutDQSXnroG2xwYlEVHJI+cPA7CPM3Q==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/scope-manager": "8.50.0",
 				"@typescript-eslint/types": "8.50.0",
@@ -12183,7 +12179,6 @@
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
 			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -13117,7 +13112,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"baseline-browser-mapping": "^2.8.9",
 				"caniuse-lite": "^1.0.30001746",
@@ -14692,7 +14686,8 @@
 			"version": "0.5.16",
 			"resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
 			"integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/dot-case": {
 			"version": "3.0.4",
@@ -14813,16 +14808,6 @@
 			},
 			"engines": {
 				"node": ">= 12.20.55"
-			}
-		},
-		"node_modules/electron-devtools-installer": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/electron-devtools-installer/-/electron-devtools-installer-4.0.0.tgz",
-			"integrity": "sha512-9Tntu/jtfSn0n6N/ZI6IdvRqXpDyLQiDuuIbsBI+dL+1Ef7C8J2JwByw58P3TJiNeuqyV3ZkphpNWuZK5iSY2w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"unzip-crx-3": "^0.2.0"
 			}
 		},
 		"node_modules/electron-installer-common": {
@@ -15729,7 +15714,6 @@
 			"resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.2.tgz",
 			"integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.8.0",
 				"@eslint-community/regexpp": "^4.12.1",
@@ -15789,7 +15773,6 @@
 			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
 			"integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"eslint-config-prettier": "bin/cli.js"
 			},
@@ -15914,7 +15897,6 @@
 			"integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@rtsao/scc": "^1.1.0",
 				"array-includes": "^3.1.9",
@@ -16055,7 +16037,6 @@
 			"integrity": "sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
 			}
@@ -17929,7 +17910,8 @@
 			"integrity": "sha512-+chQdDfvscSF1SJqv2gn4SRO2ZyS3xL3r7IW/wWEEzrzLisnOlKiQu5ytC/BVNcS15C39WT2Hg/bjKjDMcu+zg==",
 			"dev": true,
 			"license": "MIT",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/import-fresh": {
 			"version": "3.3.0",
@@ -19050,7 +19032,6 @@
 			"integrity": "sha512-y2mfcJywuTUkvLm2Lp1/pFX8kTgMO5yyQGq/Sk/n2mN7XWYp4JsCZ/QXW34M8YScgk8bPZlREH04f6blPnoHnQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@jest/core": "30.0.5",
 				"@jest/types": "30.0.5",
@@ -20578,7 +20559,6 @@
 			"integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"cssstyle": "^4.2.1",
 				"data-urls": "^5.0.0",
@@ -20776,52 +20756,6 @@
 				"npm": ">=6"
 			}
 		},
-		"node_modules/jszip": {
-			"version": "3.10.1",
-			"resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
-			"integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
-			"dev": true,
-			"license": "(MIT OR GPL-3.0-or-later)",
-			"dependencies": {
-				"lie": "~3.3.0",
-				"pako": "~1.0.2",
-				"readable-stream": "~2.3.6",
-				"setimmediate": "^1.0.5"
-			}
-		},
-		"node_modules/jszip/node_modules/isarray": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/jszip/node_modules/readable-stream": {
-			"version": "2.3.8",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-			"integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"core-util-is": "~1.0.0",
-				"inherits": "~2.0.3",
-				"isarray": "~1.0.0",
-				"process-nextick-args": "~2.0.0",
-				"safe-buffer": "~5.1.1",
-				"string_decoder": "~1.1.1",
-				"util-deprecate": "~1.0.1"
-			}
-		},
-		"node_modules/jszip/node_modules/string_decoder": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"safe-buffer": "~5.1.0"
-			}
-		},
 		"node_modules/junk": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/junk/-/junk-3.1.0.tgz",
@@ -20926,16 +20860,6 @@
 			},
 			"engines": {
 				"node": ">= 0.8.0"
-			}
-		},
-		"node_modules/lie": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
-			"integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"immediate": "~3.0.5"
 			}
 		},
 		"node_modules/lilconfig": {
@@ -21436,6 +21360,7 @@
 			"resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
 			"integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
 			"dev": true,
+			"peer": true,
 			"bin": {
 				"lz-string": "bin/bin.js"
 			}
@@ -22872,7 +22797,8 @@
 			"integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
 			"dev": true,
 			"license": "MIT",
-			"optional": true
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/node-api-version": {
 			"version": "0.2.1",
@@ -23977,7 +23903,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"nanoid": "^3.3.11",
 				"picocolors": "^1.1.1",
@@ -24182,7 +24107,6 @@
 			"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-3.0.3.tgz",
 			"integrity": "sha512-X4UlrxDTH8oom9qXlcjnydsjAOD2BmB6yFmvS4Z2zdTzqqpRWb+fbqrH412+l+OUXmbzJlSXjlMFYPgYG12IAA==",
 			"dev": true,
-			"peer": true,
 			"bin": {
 				"prettier": "bin/prettier.cjs"
 			},
@@ -24210,6 +24134,7 @@
 			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
 			"integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"ansi-regex": "^5.0.1",
 				"ansi-styles": "^5.0.0",
@@ -24224,6 +24149,7 @@
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
 			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
 			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": ">=10"
 			},
@@ -24235,7 +24161,8 @@
 			"version": "17.0.2",
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
 			"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/proc-log": {
 			"version": "2.0.1",
@@ -24496,7 +24423,6 @@
 			"version": "18.3.1",
 			"resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
 			"integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-			"peer": true,
 			"dependencies": {
 				"loose-envify": "^1.1.0"
 			},
@@ -24548,7 +24474,6 @@
 			"version": "18.3.1",
 			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
 			"integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
-			"peer": true,
 			"dependencies": {
 				"loose-envify": "^1.1.0",
 				"scheduler": "^0.23.2"
@@ -24592,7 +24517,6 @@
 			"resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
 			"integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@types/use-sync-external-store": "^0.0.6",
 				"use-sync-external-store": "^1.4.0"
@@ -24841,8 +24765,7 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
 			"integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/redux-thunk": {
 			"version": "3.1.0",
@@ -25292,7 +25215,6 @@
 			"integrity": "sha512-BgLRGy7tNS9H66aIMASq1qSYbAAJV6Z6WR4QYTvj5FgF15rZ/ympT1uixHXwzbZUBDbkvqUI1KR0fH1FhMaQ9w==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@types/estree": "1.0.8"
 			},
@@ -25444,6 +25366,7 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"chokidar": "^4.0.0",
 				"immutable": "^5.0.2",
@@ -25466,6 +25389,7 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"readdirp": "^4.0.1"
 			},
@@ -25483,6 +25407,7 @@
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">= 14.18.0"
 			},
@@ -25700,12 +25625,6 @@
 			"engines": {
 				"node": ">= 0.4"
 			}
-		},
-		"node_modules/setimmediate": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-			"integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
-			"dev": true
 		},
 		"node_modules/setprototypeof": {
 			"version": "1.2.0",
@@ -26917,7 +26836,6 @@
 			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
 				"fast-uri": "^3.0.1",
@@ -27097,7 +27015,6 @@
 			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -27380,7 +27297,6 @@
 			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
 			"integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@cspotcode/source-map-support": "^0.8.0",
 				"@tsconfig/node10": "^1.0.7",
@@ -27605,7 +27521,6 @@
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
 			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
 			"license": "Apache-2.0",
-			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -27912,7 +27827,6 @@
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"napi-postinstall": "^0.3.0"
 			},
@@ -27939,31 +27853,6 @@
 				"@unrs/resolver-binding-win32-arm64-msvc": "1.11.1",
 				"@unrs/resolver-binding-win32-ia32-msvc": "1.11.1",
 				"@unrs/resolver-binding-win32-x64-msvc": "1.11.1"
-			}
-		},
-		"node_modules/unzip-crx-3": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/unzip-crx-3/-/unzip-crx-3-0.2.0.tgz",
-			"integrity": "sha512-0+JiUq/z7faJ6oifVB5nSwt589v1KCduqIJupNVDoWSXZtWDmjDGO3RAEOvwJ07w90aoXoP4enKsR7ecMrJtWQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"jszip": "^3.1.0",
-				"mkdirp": "^0.5.1",
-				"yaku": "^0.16.6"
-			}
-		},
-		"node_modules/unzip-crx-3/node_modules/mkdirp": {
-			"version": "0.5.6",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-			"integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"minimist": "^1.2.6"
-			},
-			"bin": {
-				"mkdirp": "bin/cmd.js"
 			}
 		},
 		"node_modules/unzipper": {
@@ -28187,7 +28076,6 @@
 			"integrity": "sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.27.0",
 				"fdir": "^6.5.0",
@@ -28837,7 +28725,6 @@
 			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -28993,7 +28880,6 @@
 			"integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
 				"fast-uri": "^3.0.1",
@@ -29440,13 +29326,6 @@
 			"engines": {
 				"node": ">=10"
 			}
-		},
-		"node_modules/yaku": {
-			"version": "0.16.7",
-			"resolved": "https://registry.npmjs.org/yaku/-/yaku-0.16.7.tgz",
-			"integrity": "sha512-Syu3IB3rZvKvYk7yTiyl1bo/jiEFaaStrgv1V2TIJTqYPStSMQVO8EQjg/z+DRzLq/4LIIharNT3iH1hylEIRw==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/yallist": {
 			"version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
 		"@wordpress/react-i18n": "^4.36.0",
 		"cross-env": "^7.0.3",
 		"electron": "^39.2.7",
-		"electron-devtools-installer": "^4.0.0",
 		"electron-playwright-helpers": "^2.0.1",
 		"electron-vite": "^5.0.0",
 		"eslint": "^9.39.2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,11 +13,6 @@ import path from 'path';
 import { pathToFileURL } from 'url';
 import * as Sentry from '@sentry/electron/main';
 import { __ } from '@wordpress/i18n';
-import {
-	installExtension,
-	REACT_DEVELOPER_TOOLS,
-	REDUX_DEVTOOLS,
-} from 'electron-devtools-installer';
 import { PROTOCOL_PREFIX } from 'common/constants';
 import {
 	bumpStat,
@@ -121,6 +116,34 @@ async function setupSentryUserId() {
 		await saveUserData( userData );
 	} finally {
 		await unlockAppdata();
+	}
+}
+
+// Load DevTools extensions from the extensions directory
+// Extension IDs are hardcoded Chrome extension IDs for React DevTools and Redux DevTools
+const EXTENSION_IDS = {
+	REACT_DEVELOPER_TOOLS: 'fmkadmapgofadopljbjfkapdkoienihi',
+	REDUX_DEVTOOLS: 'lmhkpmbekcpmknklioeibfkpmmfibljd',
+};
+
+async function loadDevToolsExtensions( appSession = session.defaultSession ) {
+	const extensionsPath = path.join( app.getPath( 'userData' ), 'extensions' );
+
+	for ( const [ name, extensionId ] of Object.entries( EXTENSION_IDS ) ) {
+		const extensionPath = path.join( extensionsPath, extensionId );
+		try {
+			// Check if extension directory exists
+			const fs = await import( 'fs/promises' );
+			await fs.access( extensionPath );
+
+			// Load extension using the new API with allowFileAccess option
+			await appSession.extensions.loadExtension( extensionPath, {
+				allowFileAccess: true,
+			} );
+			console.log( `Loaded ${ name } extension from ${ extensionPath }` );
+		} catch ( error ) {
+			console.warn( `Failed to load ${ name } extension:`, error );
+		}
 	}
 }
 
@@ -253,8 +276,7 @@ async function appBoot() {
 	app.on( 'ready', async () => {
 		const locale = await getUserLocaleWithFallback();
 		if ( process.env.NODE_ENV === 'development' ) {
-			await installExtension( REACT_DEVELOPER_TOOLS );
-			await installExtension( REDUX_DEVTOOLS );
+			await loadDevToolsExtensions();
 			await launchExtensionBackgroundWorkers();
 		}
 

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -55,6 +55,7 @@ function mockElectron() {
 					...electron.session.defaultSession,
 					extensions: {
 						getAllExtensions: jest.fn().mockReturnValue( [] ),
+						loadExtension: jest.fn().mockResolvedValue( { id: 'test-extension' } ),
 					},
 					serviceWorkers: {
 						startWorkerForScope: jest.fn().mockResolvedValue( undefined ),


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- N/A

## Proposed Changes

I propose removing `electron-devtools-installer` dependency which uses deprecated Electron APIs and implementing native extension loading using `session.extensions.loadExtension()`. It eliminates deprecation warnings for `session.loadExtension` and `session.getAllExtensions`.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Confirm:
- Builds go through
- React DevTools and Redux DevTools load successfully in development mode
- There are no deprecation warnings for extension-related APIs

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
