### PR TITLE
Fix appearance Query Manager plugin in wp-admin

### DIFF
--- a/common/lib/mu-plugins.ts
+++ b/common/lib/mu-plugins.ts
@@ -78,6 +78,16 @@ async function createLoaderMuPlugin(): Promise< string > {
 function getStandardMuPlugins( options: MuPluginOptions ): MuPlugin[] {
 	const muPlugins: MuPlugin[] = [];
 
+	muPlugins.push( {
+		filename: '0-tmp-fix-qm-plugin-sapi.php',
+		content: `<?php
+		// This is a temporary fix for a Query Manager plugin, which isn't rendered in wp-admin if sapi is "cli" (it's the case for wordpress-playground).
+		// See https://github.com/WordPress/wordpress-playground/pull/2424#issuecomment-3686951491
+		// It's not the best fix, but it's simple and for consistency it's the same as used in wordpress-playground (https://github.com/WordPress/wordpress-playground/pull/2415)		
+		define('QM_TESTS', true);
+		`,
+	} );
+
 	// HTTPS detection for reverse proxy
 	muPlugins.push( {
 		filename: '0-https-for-reverse-proxy.php',


### PR DESCRIPTION
- Fixes STU-1005

## Proposed Changes
Previously, Query Manager plugin didn't work with Sites that are run under Studio. The reason is - `php_sapi_name()` return `cli`. Since it's essential to be "cli" in playground, that's why we needed to go with soem workaround. It would be great to go with some more specific fix as checkoing kinds "is playground-cli", but just for consistency I decided to go with the same fix as applyied for [playground](https://github.com/WordPress/wordpress-playground/pull/2415). It's a workaround, but actually it's robust.

## Testing Instructions
1. Create Studio site
2. Open wp-admin
3. Install "Query Manager" plugin and activate it
4. Assert that you see it in admin bar (before it wasn't rendered for sites in Studio)<br />
<img width="1011" height="310" alt="Screenshot 2025-12-23 at 15 14 23" src="https://github.com/user-attachments/assets/bcd27381-2d19-48a9-ab9d-7dd007a77fd9" />
5. Open "Installed plugins" page
6. Assert that you see all buttons
<table>
<tr>
<td>BEFORE
<td>AFTER
</tr>
<tr>
<td><img width="559" height="64" alt="Screenshot 2025-12-23 at 15 15 58" src="https://github.com/user-attachments/assets/47fc3087-48fb-4c3c-9cc9-baab291eaaf3" />
<td><img width="746" height="79" alt="Screenshot 2025-12-23 at 15 16 08" src="https://github.com/user-attachments/assets/4c2cf2d0-b97a-4f6f-b94d-3b41e0d0704d" />
</tr>
</table>
