### PR TITLE
Fix preview site component

### DIFF
--- a/src/components/content-tab-overview.tsx
+++ b/src/components/content-tab-overview.tsx
@@ -182,7 +182,7 @@ function ShortcutsSection( { selectedSite }: Pick< ContentTabOverviewProps, 'sel
 }
 
 export function ContentTabOverview( { selectedSite }: ContentTabOverviewProps ) {
-	let [ isThumbnailError, setIsThumbnailError ] = useState( false );
+	const [ isThumbnailError, setIsThumbnailError ] = useState( false );
 	const { __ } = useI18n();
 	const { startServer, loadingServer } = useSiteDetails();
 	const {

--- a/src/components/content-tab-overview.tsx
+++ b/src/components/content-tab-overview.tsx
@@ -182,7 +182,7 @@ function ShortcutsSection( { selectedSite }: Pick< ContentTabOverviewProps, 'sel
 }
 
 export function ContentTabOverview( { selectedSite }: ContentTabOverviewProps ) {
-	const [ isThumbnailError, setIsThumbnailError ] = useState( false );
+	let [ isThumbnailError, setIsThumbnailError ] = useState( false );
 	const { __ } = useI18n();
 	const { startServer, loadingServer } = useSiteDetails();
 	const {
@@ -209,7 +209,7 @@ export function ContentTabOverview( { selectedSite }: ContentTabOverviewProps ) 
 		<img
 			onError={ () => setIsThumbnailError( true ) }
 			onLoad={ () => setIsThumbnailError( false ) }
-			className={ ! isThumbnailError ? 'w-full h-full' : 'absolute invisible' }
+			className="w-full h-full"
 			src={ thumbnailData || '' }
 			alt={ themeDetails?.name }
 		/>
@@ -227,30 +227,34 @@ export function ContentTabOverview( { selectedSite }: ContentTabOverviewProps ) 
 						! loading && 'hover:border-a8c-blue-50 duration-300'
 					) }
 				>
-					{ isThumbnailError && ! loading && (
-						<div className="flex items-center justify-center w-full h-64 leading-5 text-a8c-gray-50">
-							{ __( 'Preview unavailable' ) }
-						</div>
-					) }
 					{ ! loading && (
 						<button
 							aria-label={ __( 'Open site' ) }
 							className={ cx(
-								'relative group focus-visible:outline-a8c-blue-50',
+								'w-full relative group focus-visible:outline-a8c-blue-50',
 								isServerLoading && 'cursor-not-allowed'
 							) }
 							onClick={ handleThumbnailClick }
 							disabled={ isServerLoading }
 						>
 							<div
-								className={
-									'opacity-0 group-hover:opacity-90 group-hover:bg-white group-focus:opacity-90 group-focus:bg-white duration-300 absolute size-full flex justify-center items-center bg-white text-a8c-blue-50'
-								}
+								className={ cx(
+									'opacity-0 group-hover:bg-white group-focus:bg-white duration-300 absolute size-full flex justify-center items-center bg-white text-a8c-blue-50',
+									isThumbnailError
+										? 'group-hover:opacity-100 group-focus:opacity-100'
+										: 'group-hover:opacity-90 group-focus:opacity-90'
+								) }
 							>
 								{ __( 'Open site' ) }
 								<ArrowIcon />
 							</div>
-							{ thumbnailImage }
+							{ isThumbnailError ? (
+								<div className="flex w-full items-center justify-center h-64 leading-5 text-a8c-gray-50 text-center">
+									{ __( 'Preview unavailable' ) }
+								</div>
+							) : (
+								thumbnailImage
+							) }
 						</button>
 					) }
 				</div>


### PR DESCRIPTION
## Related issues

- Fixes STU-850

## Proposed Changes
1. This PR fixes mentioned bug with texts which has 2+ lines
2. Also, I noticed broken "Open site" link (see testing instructions), so it fixes it too

## Testing Instructions
Apply the next diff:
```diff
diff --git a/src/components/content-tab-overview.tsx b/src/components/content-tab-overview.tsx
index d47aa219..5474c3a2 100644
--- a/src/components/content-tab-overview.tsx
+++ b/src/components/content-tab-overview.tsx
@@ -208,7 +208,7 @@ export function ContentTabOverview( { selectedSite }: ContentTabOverviewProps )
        const thumbnailImage = (
                <img
                        onError={ () => setIsThumbnailError( true ) }
-                       onLoad={ () => setIsThumbnailError( false ) }
+                       onLoad={ () => setIsThumbnailError( true ) }
                        className="w-full h-full"
                        src={ thumbnailData || '' }
                        alt={ themeDetails?.name }
```

1. Create a site and open Overview
2. Mouseover on preview
3. Assert that it looks good
<table>
<tr>
<td>BEFORE
<td>AFTER
</tr>
<tr>
<td><img width="784" height="341" alt="Screenshot 2025-12-24 at 22 40 55" src="https://github.com/user-attachments/assets/d30b2891-f0a1-4b2d-9cd2-8c43cdcf7af7" />
<td><img width="241" height="316" alt="Screenshot 2025-12-24 at 22 41 49" src="https://github.com/user-attachments/assets/49a5a36a-74da-44ad-ae38-e41fecc7fada" />
</tr>
</table>

4. Change language to "Українська"
5. Assert that it's centered
<table>
<tr>
<td>BEFORE
<td>AFTER
</tr>
<tr>
<td><img width="210" height="258" alt="Screenshot 2025-12-24 at 22 43 29" src="https://github.com/user-attachments/assets/af8497f5-b528-4777-b1f3-8c9d82abbfaf" />
<td><img width="207" height="257" alt="Screenshot 2025-12-24 at 22 42 55" src="https://github.com/user-attachments/assets/33742164-94c8-4927-8f1c-8f800164d7d1" />
</tr>
</table>