### PR TITLE
Studio: Avoid showing what's new modal in new empty screen

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -31,6 +31,7 @@ export default function App() {
 	const { showWhatsNew, closeWhatsNew } = useWhatsNew();
 	const { sites: localSites, loadingSites } = useSiteDetails();
 	const isEmpty = ! loadingSites && ! localSites.length;
+	const shouldShowWhatsNew = showWhatsNew && ! isEmpty;
 
 	useEffect( () => {
 		void getIpcApi().setupAppMenu( { needsOnboarding } );
@@ -86,7 +87,7 @@ export default function App() {
 				</VStack>
 			) }
 			<UserSettings />
-			<WhatsNewModal showModal={ showWhatsNew } onClose={ closeWhatsNew } />
+			<WhatsNewModal showModal={ shouldShowWhatsNew } onClose={ closeWhatsNew } />
 		</>
 	);
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-1066

## Proposed Changes

- Do not display the "What's new" modal on the onboarding screen if no sites have been created.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Checkout trunk branch
- Delete or move your existing `appdata-v1.json`. We need fresh installation for testing. It exists at `~/Library/Application Support/Studio`
- Apply following patch to force showing the modal on empty screen. 
```patch
diff --git a/src/modules/whats-new/hooks/use-last-seen-version.tsx b/src/modules/whats-new/hooks/use-last-seen-version.tsx
index e2bb55e4..24047caf 100644
--- a/src/modules/whats-new/hooks/use-last-seen-version.tsx
+++ b/src/modules/whats-new/hooks/use-last-seen-version.tsx
@@ -33,7 +33,7 @@ export function useLastSeenVersion(): UseLastSeenVersion {
 
        return {
                lastSeenVersion,
-               isNewVersion,
+               isNewVersion: true,
                updateLastSeenVersion,
        };
 }
```
- Run `npm start`
- You will be shown onboarding screen that will ask to login to WordPress.com account. 
-  Click on "Skip" button on right bottom
- You will see the "What's new" modal. Don't close it yet.
- Now checkout to this branch. 
- Refresh the window, Assert that "What's new" modal is not shown.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
