### PR TITLE
Add footer message to stale PRs notifications to explain how it works

### DIFF
--- a/scripts/format-stale-pr-message.js
+++ b/scripts/format-stale-pr-message.js
@@ -72,7 +72,14 @@ const slackPayload = {
 	} PR${
 		stalePRs.length > 1 ? 's' : ''
 	} that haven't been updated in the last ${ stalePeriod } and still need review:`,
-	attachments: attachments,
+	attachments: [
+		...attachments,
+		{
+			color: '#E8E8E8',
+			text: 'To skip a PR from this notification, convert it to draft or approve it with a review. <https://github.com/Automattic/studio/blob/trunk/.github/workflows/stale-pr-notifications.yml|Edit this workflow>',
+			mrkdwn_in: [ 'text' ],
+		},
+	],
 };
 
 // Write to file for the workflow to use


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- N/A

## Proposed Changes

- I propose adding a footer message to stale PRs notifications to explain how it works

<img width="1368" height="908" alt="CleanShot 2025-12-29 at 11 59 05@2x" src="https://github.com/user-attachments/assets/2a86e2d4-5936-4f4e-99b1-ddb48a5e3fe6" />


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Code review should suffice

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
