### PR TITLE
Sync: Show file upload progress in the UI

### DIFF
--- a/src/hooks/sync-sites/use-sync-push.ts
+++ b/src/hooks/sync-sites/use-sync-push.ts
@@ -27,7 +27,7 @@ export type SyncPushState = {
 	status: PushStateProgressInfo;
 	selectedSite: SiteDetails;
 	remoteSiteUrl: string;
-	uploadProgress?: number; // Raw upload percentage (0-100%) when uploading
+	uploadProgress?: number;
 };
 
 type PushSiteOptions = {
@@ -100,11 +100,13 @@ export function useSyncPush( {
 	const {
 		pushStatesProgressInfo,
 		isKeyPushing,
+		isKeyUploading,
 		isKeyImporting,
 		isKeyFinished,
 		isKeyFailed,
 		isKeyCancelled,
 		getPushStatusWithProgress,
+		mapUploadProgressToOverallProgress,
 	} = useSyncStatesProgressInfo();
 
 	const updatePushState = useCallback< UpdateState< SyncPushState > >(
@@ -397,7 +399,6 @@ export function useSyncPush( {
 			const currentState = getPushState( payload.selectedSiteId, payload.remoteSiteId );
 			updatePushState( payload.selectedSiteId, payload.remoteSiteId, {
 				status: pushStatesProgressInfo.uploading,
-				// Keep existing uploadProgress if available, otherwise it will be set by sync-upload-progress
 				uploadProgress: currentState?.uploadProgress,
 			} );
 		}
@@ -407,22 +408,15 @@ export function useSyncPush( {
 		'sync-upload-progress',
 		( _event, payload: { selectedSiteId: string; remoteSiteId: number; progress: number } ) => {
 			const currentState = getPushState( payload.selectedSiteId, payload.remoteSiteId );
-			// Only update progress if we're in the uploading state
-			if ( currentState && currentState.status.key === 'uploading' ) {
-				// Map upload progress (0-100%) to the uploading state range (40-50%)
-				const uploadingProgressRange =
-					pushStatesProgressInfo.creatingRemoteBackup.progress -
-					pushStatesProgressInfo.uploading.progress;
-				const mappedProgress =
-					pushStatesProgressInfo.uploading.progress +
-					( payload.progress / 100 ) * uploadingProgressRange;
+			if ( currentState && isKeyUploading( currentState.status.key ) ) {
+				const mappedProgress = mapUploadProgressToOverallProgress( payload.progress );
 
 				updatePushState( payload.selectedSiteId, payload.remoteSiteId, {
 					status: {
 						...currentState.status,
 						progress: mappedProgress,
 					},
-					uploadProgress: payload.progress, // Store raw upload percentage (0-100%)
+					uploadProgress: payload.progress,
 				} );
 			}
 		}

--- a/src/hooks/sync-sites/use-sync-push.ts
+++ b/src/hooks/sync-sites/use-sync-push.ts
@@ -27,6 +27,7 @@ export type SyncPushState = {
 	status: PushStateProgressInfo;
 	selectedSite: SiteDetails;
 	remoteSiteUrl: string;
+	uploadProgress?: number; // Raw upload percentage (0-100%) when uploading
 };
 
 type PushSiteOptions = {
@@ -324,6 +325,7 @@ export function useSyncPush( {
 				if ( response.success ) {
 					updatePushState( selectedSite.id, remoteSiteId, {
 						status: pushStatesProgressInfo.creatingRemoteBackup,
+						uploadProgress: undefined, // Clear upload progress when transitioning to next state
 					} );
 				} else {
 					throw response;
@@ -392,9 +394,37 @@ export function useSyncPush( {
 	useIpcListener(
 		'sync-upload-resumed',
 		( _event, payload: { selectedSiteId: string; remoteSiteId: number } ) => {
+			const currentState = getPushState( payload.selectedSiteId, payload.remoteSiteId );
 			updatePushState( payload.selectedSiteId, payload.remoteSiteId, {
 				status: pushStatesProgressInfo.uploading,
+				// Keep existing uploadProgress if available, otherwise it will be set by sync-upload-progress
+				uploadProgress: currentState?.uploadProgress,
 			} );
+		}
+	);
+
+	useIpcListener(
+		'sync-upload-progress',
+		( _event, payload: { selectedSiteId: string; remoteSiteId: number; progress: number } ) => {
+			const currentState = getPushState( payload.selectedSiteId, payload.remoteSiteId );
+			// Only update progress if we're in the uploading state
+			if ( currentState && currentState.status.key === 'uploading' ) {
+				// Map upload progress (0-100%) to the uploading state range (40-50%)
+				const uploadingProgressRange =
+					pushStatesProgressInfo.creatingRemoteBackup.progress -
+					pushStatesProgressInfo.uploading.progress;
+				const mappedProgress =
+					pushStatesProgressInfo.uploading.progress +
+					( payload.progress / 100 ) * uploadingProgressRange;
+
+				updatePushState( payload.selectedSiteId, payload.remoteSiteId, {
+					status: {
+						...currentState.status,
+						progress: mappedProgress,
+					},
+					uploadProgress: payload.progress, // Store raw upload percentage (0-100%)
+				} );
+			}
 		}
 	);
 

--- a/src/hooks/use-sync-states-progress-info.ts
+++ b/src/hooks/use-sync-states-progress-info.ts
@@ -57,7 +57,7 @@ const DOWNLOADING_INITIAL_VALUE = 60;
 const IN_PROGRESS_TO_DOWNLOADING_STEP = DOWNLOADING_INITIAL_VALUE - IN_PROGRESS_INITIAL_VALUE;
 const PULL_IMPORTING_INITIAL_VALUE = 80;
 
-export function isKeyPulling( key: PullStateProgressInfo[ 'key' ] | undefined ): boolean {
+function isKeyPulling( key: PullStateProgressInfo[ 'key' ] | undefined ): boolean {
 	const pullingStateKeys: PullStateProgressInfo[ 'key' ][] = [
 		'in-progress',
 		'downloading',
@@ -69,7 +69,7 @@ export function isKeyPulling( key: PullStateProgressInfo[ 'key' ] | undefined ):
 	return pullingStateKeys.includes( key );
 }
 
-export function isKeyPushing( key: PushStateProgressInfo[ 'key' ] | undefined ): boolean {
+function isKeyPushing( key: PushStateProgressInfo[ 'key' ] | undefined ): boolean {
 	const pushingStateKeys: PushStateProgressInfo[ 'key' ][] = [
 		'creatingBackup',
 		'uploading',
@@ -83,15 +83,15 @@ export function isKeyPushing( key: PushStateProgressInfo[ 'key' ] | undefined ):
 	return pushingStateKeys.includes( key );
 }
 
-export function isKeyUploadingPaused( key: PushStateProgressInfo[ 'key' ] | undefined ): boolean {
+function isKeyUploadingPaused( key: PushStateProgressInfo[ 'key' ] | undefined ): boolean {
 	return key === 'uploadingPaused';
 }
 
-export function isKeyUploading( key: PushStateProgressInfo[ 'key' ] | undefined ): boolean {
+function isKeyUploading( key: PushStateProgressInfo[ 'key' ] | undefined ): boolean {
 	return key === 'uploading';
 }
 
-export function isKeyImporting( key: PushStateProgressInfo[ 'key' ] | undefined ): boolean {
+function isKeyImporting( key: PushStateProgressInfo[ 'key' ] | undefined ): boolean {
 	const pushingStateKeys: PushStateProgressInfo[ 'key' ][] = [
 		'creatingRemoteBackup',
 		'applyingChanges',
@@ -103,25 +103,25 @@ export function isKeyImporting( key: PushStateProgressInfo[ 'key' ] | undefined 
 	return pushingStateKeys.includes( key );
 }
 
-export function isKeyFinished(
+function isKeyFinished(
 	key: PullStateProgressInfo[ 'key' ] | PushStateProgressInfo[ 'key' ] | undefined
 ): boolean {
 	return key === 'finished';
 }
 
-export function isKeyFailed(
+function isKeyFailed(
 	key: PullStateProgressInfo[ 'key' ] | PushStateProgressInfo[ 'key' ] | undefined
 ): boolean {
 	return key === 'failed';
 }
 
-export function isKeyCancelled(
+function isKeyCancelled(
 	key: PullStateProgressInfo[ 'key' ] | PushStateProgressInfo[ 'key' ] | undefined
 ): boolean {
 	return key === 'cancelled';
 }
 
-export function getPushUploadPercentage(
+function getPushUploadPercentage(
 	statusKey: PushStateProgressInfo[ 'key' ] | undefined,
 	uploadProgress: number | undefined
 ): number | null {

--- a/src/hooks/use-sync-states-progress-info.ts
+++ b/src/hooks/use-sync-states-progress-info.ts
@@ -219,6 +219,8 @@ export function useSyncStatesProgressInfo() {
 		} as const satisfies PushStateProgressInfoValues;
 	}, [ __ ] );
 
+	const uploadingProgressMessageTemplate = useMemo( () => __( 'Uploading site (%d%%)…' ), [ __ ] );
+
 	const getBackupStatusWithProgress = useCallback(
 		(
 			hasBackupCompleted: boolean,
@@ -311,11 +313,11 @@ export function useSyncStatesProgressInfo() {
 		( message: string, uploadPercentage: number | null ): string => {
 			if ( uploadPercentage !== null ) {
 				// translators: %d is the upload progress percentage
-				return sprintf( __( 'Uploading site (%d%%)…' ), uploadPercentage );
+				return sprintf( uploadingProgressMessageTemplate, uploadPercentage );
 			}
 			return message;
 		},
-		[ __ ]
+		[ uploadingProgressMessageTemplate ]
 	);
 
 	const mapUploadProgressToOverallProgress = useCallback(

--- a/src/hooks/use-sync-states-progress-info.ts
+++ b/src/hooks/use-sync-states-progress-info.ts
@@ -57,6 +57,80 @@ const DOWNLOADING_INITIAL_VALUE = 60;
 const IN_PROGRESS_TO_DOWNLOADING_STEP = DOWNLOADING_INITIAL_VALUE - IN_PROGRESS_INITIAL_VALUE;
 const PULL_IMPORTING_INITIAL_VALUE = 80;
 
+export function isKeyPulling( key: PullStateProgressInfo[ 'key' ] | undefined ): boolean {
+	const pullingStateKeys: PullStateProgressInfo[ 'key' ][] = [
+		'in-progress',
+		'downloading',
+		'importing',
+	];
+	if ( ! key ) {
+		return false;
+	}
+	return pullingStateKeys.includes( key );
+}
+
+export function isKeyPushing( key: PushStateProgressInfo[ 'key' ] | undefined ): boolean {
+	const pushingStateKeys: PushStateProgressInfo[ 'key' ][] = [
+		'creatingBackup',
+		'uploading',
+		'creatingRemoteBackup',
+		'applyingChanges',
+		'finishing',
+	];
+	if ( ! key ) {
+		return false;
+	}
+	return pushingStateKeys.includes( key );
+}
+
+export function isKeyUploadingPaused( key: PushStateProgressInfo[ 'key' ] | undefined ): boolean {
+	return key === 'uploadingPaused';
+}
+
+export function isKeyUploading( key: PushStateProgressInfo[ 'key' ] | undefined ): boolean {
+	return key === 'uploading';
+}
+
+export function isKeyImporting( key: PushStateProgressInfo[ 'key' ] | undefined ): boolean {
+	const pushingStateKeys: PushStateProgressInfo[ 'key' ][] = [
+		'creatingRemoteBackup',
+		'applyingChanges',
+		'finishing',
+	];
+	if ( ! key ) {
+		return false;
+	}
+	return pushingStateKeys.includes( key );
+}
+
+export function isKeyFinished(
+	key: PullStateProgressInfo[ 'key' ] | PushStateProgressInfo[ 'key' ] | undefined
+): boolean {
+	return key === 'finished';
+}
+
+export function isKeyFailed(
+	key: PullStateProgressInfo[ 'key' ] | PushStateProgressInfo[ 'key' ] | undefined
+): boolean {
+	return key === 'failed';
+}
+
+export function isKeyCancelled(
+	key: PullStateProgressInfo[ 'key' ] | PushStateProgressInfo[ 'key' ] | undefined
+): boolean {
+	return key === 'cancelled';
+}
+
+export function getPushUploadPercentage(
+	statusKey: PushStateProgressInfo[ 'key' ] | undefined,
+	uploadProgress: number | undefined
+): number | null {
+	if ( isKeyUploading( statusKey ) && uploadProgress !== undefined ) {
+		return Math.round( uploadProgress );
+	}
+	return null;
+}
+
 export function useSyncStatesProgressInfo() {
 	const { __ } = useI18n();
 	const pullStatesProgressInfo = useMemo( () => {
@@ -145,72 +219,6 @@ export function useSyncStatesProgressInfo() {
 		} as const satisfies PushStateProgressInfoValues;
 	}, [ __ ] );
 
-	const isKeyPulling = ( key: PullStateProgressInfo[ 'key' ] | undefined ) => {
-		const pullingStateKeys: PullStateProgressInfo[ 'key' ][] = [
-			'in-progress',
-			'downloading',
-			'importing',
-		];
-		if ( ! key ) {
-			return false;
-		}
-		return pullingStateKeys.includes( key );
-	};
-
-	const isKeyPushing = ( key: PushStateProgressInfo[ 'key' ] | undefined ) => {
-		const pushingStateKeys: PushStateProgressInfo[ 'key' ][] = [
-			'creatingBackup',
-			'uploading',
-			'creatingRemoteBackup',
-			'applyingChanges',
-			'finishing',
-		];
-		if ( ! key ) {
-			return false;
-		}
-		return pushingStateKeys.includes( key );
-	};
-
-	const isKeyUploadingPaused = ( key: PushStateProgressInfo[ 'key' ] | undefined ) => {
-		return key === 'uploadingPaused';
-	};
-
-	const isKeyUploading = useCallback( ( key: PushStateProgressInfo[ 'key' ] | undefined ) => {
-		return key === 'uploading';
-	}, [] );
-
-	const isKeyImporting = ( key: PushStateProgressInfo[ 'key' ] | undefined ) => {
-		const pushingStateKeys: PushStateProgressInfo[ 'key' ][] = [
-			'creatingRemoteBackup',
-			'applyingChanges',
-			'finishing',
-		];
-		if ( ! key ) {
-			return false;
-		}
-		return pushingStateKeys.includes( key );
-	};
-	const isKeyFinished = useCallback(
-		( key: PullStateProgressInfo[ 'key' ] | PushStateProgressInfo[ 'key' ] | undefined ) => {
-			return key === 'finished';
-		},
-		[]
-	);
-
-	const isKeyFailed = useCallback(
-		( key: PullStateProgressInfo[ 'key' ] | PushStateProgressInfo[ 'key' ] | undefined ) => {
-			return key === 'failed';
-		},
-		[]
-	);
-
-	const isKeyCancelled = useCallback(
-		( key: PullStateProgressInfo[ 'key' ] | PushStateProgressInfo[ 'key' ] | undefined ) => {
-			return key === 'cancelled';
-		},
-		[]
-	);
-
 	const getBackupStatusWithProgress = useCallback(
 		(
 			hasBackupCompleted: boolean,
@@ -297,19 +305,6 @@ export function useSyncStatesProgressInfo() {
 			pushStatesProgressInfo.creatingRemoteBackup.progress,
 			pushStatesProgressInfo.finishing.progress,
 		]
-	);
-
-	const getPushUploadPercentage = useCallback(
-		(
-			statusKey: PushStateProgressInfo[ 'key' ] | undefined,
-			uploadProgress: number | undefined
-		): number | null => {
-			if ( isKeyUploading( statusKey ) && uploadProgress !== undefined ) {
-				return Math.round( uploadProgress );
-			}
-			return null;
-		},
-		[ isKeyUploading ]
 	);
 
 	const getPushUploadMessage = useCallback(

--- a/src/hooks/use-sync-states-progress-info.ts
+++ b/src/hooks/use-sync-states-progress-info.ts
@@ -1,3 +1,4 @@
+import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import { useCallback, useMemo } from 'react';
 import { ImportProgressState } from './use-import-export';
@@ -104,7 +105,7 @@ export function useSyncStatesProgressInfo() {
 			uploading: {
 				key: 'uploading',
 				progress: 40,
-				message: __( 'Uploading Studio site…' ),
+				message: __( 'Uploading site…' ),
 			},
 			uploadingPaused: {
 				key: 'uploadingPaused',
@@ -173,6 +174,10 @@ export function useSyncStatesProgressInfo() {
 	const isKeyUploadingPaused = ( key: PushStateProgressInfo[ 'key' ] | undefined ) => {
 		return key === 'uploadingPaused';
 	};
+
+	const isKeyUploading = useCallback( ( key: PushStateProgressInfo[ 'key' ] | undefined ) => {
+		return key === 'uploading';
+	}, [] );
 
 	const isKeyImporting = ( key: PushStateProgressInfo[ 'key' ] | undefined ) => {
 		const pushingStateKeys: PushStateProgressInfo[ 'key' ][] = [
@@ -294,6 +299,47 @@ export function useSyncStatesProgressInfo() {
 		]
 	);
 
+	const getPushUploadPercentage = useCallback(
+		(
+			statusKey: PushStateProgressInfo[ 'key' ] | undefined,
+			uploadProgress: number | undefined
+		): number | null => {
+			if ( isKeyUploading( statusKey ) && uploadProgress !== undefined ) {
+				return Math.round( uploadProgress );
+			}
+			return null;
+		},
+		[ isKeyUploading ]
+	);
+
+	const getPushUploadMessage = useCallback(
+		( message: string, uploadPercentage: number | null ): string => {
+			if ( uploadPercentage !== null ) {
+				// translators: %d is the upload progress percentage
+				return sprintf( __( 'Uploading site (%d%%)…' ), uploadPercentage );
+			}
+			return message;
+		},
+		[ __ ]
+	);
+
+	const mapUploadProgressToOverallProgress = useCallback(
+		( uploadProgress: number ): number => {
+			// Map upload progress (0-100%) to the uploading state range (40-50%)
+			const uploadingProgressRange =
+				pushStatesProgressInfo.creatingRemoteBackup.progress -
+				pushStatesProgressInfo.uploading.progress;
+			return (
+				pushStatesProgressInfo.uploading.progress +
+				( uploadProgress / 100 ) * uploadingProgressRange
+			);
+		},
+		[
+			pushStatesProgressInfo.creatingRemoteBackup.progress,
+			pushStatesProgressInfo.uploading.progress,
+		]
+	);
+
 	return {
 		pullStatesProgressInfo,
 		pushStatesProgressInfo,
@@ -303,9 +349,13 @@ export function useSyncStatesProgressInfo() {
 		isKeyFinished,
 		isKeyFailed,
 		isKeyCancelled,
+		isKeyUploading,
 		getBackupStatusWithProgress,
 		getPullStatusWithProgress,
 		getPushStatusWithProgress,
+		getPushUploadPercentage,
+		getPushUploadMessage,
+		mapUploadProgressToOverallProgress,
 		isKeyUploadingPaused,
 	};
 }

--- a/src/ipc-utils.ts
+++ b/src/ipc-utils.ts
@@ -40,6 +40,7 @@ export interface IpcEvents {
 	'site-context-menu-action': [ { action: string; siteId: string } ];
 	'sync-upload-paused': [ { error: string; selectedSiteId: string; remoteSiteId: number } ];
 	'sync-upload-resumed': [ { selectedSiteId: string; remoteSiteId: number } ];
+	'sync-upload-progress': [ { selectedSiteId: string; remoteSiteId: number; progress: number } ];
 	'snapshot-error': [ { operationId: crypto.UUID; data: SnapshotEventData } ];
 	'snapshot-fatal-error': [ { operationId: crypto.UUID; data: { message: string } } ];
 	'snapshot-output': [ { operationId: crypto.UUID; data: SnapshotEventData } ];

--- a/src/modules/sync/components/sync-connected-sites.tsx
+++ b/src/modules/sync/components/sync-connected-sites.tsx
@@ -217,6 +217,12 @@ const SyncConnectedSitesSectionItem = ( {
 	const hasPushFinished = pushState && isKeyFinished( pushState.status.key );
 	const hasPushCancelled = pushState && isKeyCancelled( pushState.status.key );
 
+	// Get raw upload percentage (0-100%) when in uploading state
+	const uploadPercentage =
+		pushState?.status.key === 'uploading' && pushState.uploadProgress !== undefined
+			? Math.round( pushState.uploadProgress )
+			: null;
+
 	return (
 		<div className="grid grid-cols-[max-content_1fr_max-content]">
 			<div
@@ -323,6 +329,9 @@ const SyncConnectedSitesSectionItem = ( {
 									<div className="a8c-body-small flex items-center gap-0.5">
 										<Icon icon={ info } size={ 16 } />
 										{ pushState.status.message }
+										{ uploadPercentage !== null && (
+											<span className="text-a8c-gray-70"> { uploadPercentage }%</span>
+										) }
 									</div>
 									<ProgressBar value={ pushState.status.progress } maxValue={ 100 } />
 								</div>

--- a/src/modules/sync/components/sync-connected-sites.tsx
+++ b/src/modules/sync/components/sync-connected-sites.tsx
@@ -199,6 +199,8 @@ const SyncConnectedSitesSectionItem = ( {
 		isKeyFailed,
 		isKeyCancelled,
 		getPullStatusWithProgress,
+		getPushUploadPercentage,
+		getPushUploadMessage,
 		isKeyUploadingPaused,
 	} = useSyncStatesProgressInfo();
 
@@ -217,11 +219,10 @@ const SyncConnectedSitesSectionItem = ( {
 	const hasPushFinished = pushState && isKeyFinished( pushState.status.key );
 	const hasPushCancelled = pushState && isKeyCancelled( pushState.status.key );
 
-	// Get raw upload percentage (0-100%) when in uploading state
-	const uploadPercentage =
-		pushState?.status.key === 'uploading' && pushState.uploadProgress !== undefined
-			? Math.round( pushState.uploadProgress )
-			: null;
+	const uploadPercentage = getPushUploadPercentage(
+		pushState?.status.key,
+		pushState?.uploadProgress
+	);
 
 	return (
 		<div className="grid grid-cols-[max-content_1fr_max-content]">
@@ -328,10 +329,7 @@ const SyncConnectedSitesSectionItem = ( {
 								<div className="flex flex-col gap-2 min-w-44 flex-shrink">
 									<div className="a8c-body-small flex items-center gap-0.5">
 										<Icon icon={ info } size={ 16 } />
-										{ pushState.status.message }
-										{ uploadPercentage !== null && (
-											<span className="text-a8c-gray-70"> { uploadPercentage }%</span>
-										) }
+										{ getPushUploadMessage( pushState.status.message, uploadPercentage ) }
 									</div>
 									<ProgressBar value={ pushState.status.progress } maxValue={ 100 } />
 								</div>

--- a/src/modules/sync/lib/ipc-handlers.ts
+++ b/src/modules/sync/lib/ipc-handlers.ts
@@ -194,7 +194,7 @@ export async function pushArchive(
 				console.error( '[TUS] Upload error', error );
 				reject( error );
 			},
-			onProgress: () => {
+			onProgress: ( bytesSent: number, bytesTotal: number ) => {
 				if ( isUploadingPaused ) {
 					isUploadingPaused = false;
 					void sendIpcEventToRenderer( 'sync-upload-resumed', {
@@ -207,6 +207,14 @@ export async function pushArchive(
 				if ( ! hasUploadStarted ) {
 					hasUploadStarted = true;
 				}
+
+				// Calculate upload progress percentage (0-100)
+				const uploadProgress = bytesTotal > 0 ? ( bytesSent / bytesTotal ) * 100 : 0;
+				void sendIpcEventToRenderer( 'sync-upload-progress', {
+					selectedSiteId: selectedSiteId,
+					remoteSiteId: remoteSiteId,
+					progress: uploadProgress,
+				} );
 			},
 			onSuccess: ( payload ) => {
 				if ( ! payload.lastResponse ) {


### PR DESCRIPTION
## Related
Fixes STU-1144

## Summary
This PR implements file upload progress tracking for sync operations, showing the upload percentage (0-100%) next to the "Uploading Studio site…" message in the UI.

## Changes
- Adds progress updates in real-time as chunks are uploaded via Tus protocol for sync uploads
- Updated UI component to display upload percentage in parentheses before ellipsis

## Testing

- Checkout this branch
- Connect your site for sync
- Start push action with different granular options.
- Check followings:
  - Test upload progress displays correctly during sync push operations
  - Verify percentage updates smoothly as chunks are uploaded
  - Confirm percentage is cleared when upload completes and transitions to next state
  - Test with various push options to ensure progress calculation is accurate
  - The progress bar also moves with progress between the range of 40%-50%
  - The progress bar also moves with progress between the range of 40%-50% to indicate overall push progress.
  
 <img src="https://github.com/user-attachments/assets/9959e1a7-2244-4b3c-a017-f837874e5cf0" />