### PR TITLE
Studio: SiteForm path does not accommodate long site names

### DIFF
--- a/src/modules/add-site/components/create-site-form.tsx
+++ b/src/modules/add-site/components/create-site-form.tsx
@@ -116,12 +116,15 @@ function FormPathInputComponent( {
 				<div
 					aria-hidden="true"
 					tabIndex={ -1 }
-					className="w-full text-left pl-3 pt-3 h-10"
+					className="w-full text-left pl-3 py-3 min-h-10 break-all"
 					onChange={ () => {} }
 				>
 					{ value }
 				</div>
-				<div aria-hidden="true" className="local-path-icon flex items-center py-[9px] px-2.5">
+				<div
+					aria-hidden="true"
+					className="local-path-icon flex items-center py-[9px] px-2.5 self-center"
+				>
 					<FolderIcon className="text-[#3C434A]" />
 				</div>
 			</button>

--- a/src/modules/add-site/components/create-site-form.tsx
+++ b/src/modules/add-site/components/create-site-form.tsx
@@ -116,7 +116,7 @@ function FormPathInputComponent( {
 				<div
 					aria-hidden="true"
 					tabIndex={ -1 }
-					className="w-full text-left pl-3 py-3 min-h-10 break-all"
+					className="w-full text-left pl-3 py-3 min-h-10"
 					onChange={ () => {} }
 				>
 					{ value }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

Fixes STU-1181

## Proposed Changes

This PR ensures that when you have a long path name while creating a site, it does not get cut off:

<img width="1042" height="827" alt="Screenshot 2025-12-29 at 4 24 53 PM" src="https://github.com/user-attachments/assets/eaf04aec-44eb-4dee-9b9e-b9337c8b9669" />

**Before**

<img width="1049" height="838" alt="Screenshot 2025-12-29 at 3 58 31 PM" src="https://github.com/user-attachments/assets/a6f2aba9-ddd6-4320-adab-0025f68edf3a" />

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
* Start the app with `npm start`
* Click on the `Add site` option in the sidebar
* Select the first option
* Open `Advanced settings`
* Change the name of a site to a very long name so that the local path breaks into the second line
* Observe that the field does not get cut off 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
