### PR TITLE
Sync: Fix renderer crash when network disconnects after upload

### DIFF
--- a/src/hooks/sync-sites/use-sync-push.ts
+++ b/src/hooks/sync-sites/use-sync-push.ts
@@ -151,11 +151,8 @@ export function useSyncPush( {
 					}
 				);
 			} catch ( error ) {
-				// Network errors (e.g., offline) should be handled gracefully
-				// The error will be handled when the user comes back online
-				console.error( 'Failed to get push progress:', error );
-
-				// Skip Sentry reporting for expected network errors (crossDomain errors)
+				// Skip Sentry reporting for expected network errors (crossDomain errors). The client throws this error
+				// when the user is offline.
 				if (
 					error instanceof Error &&
 					'crossDomain' in error &&

--- a/src/hooks/sync-sites/use-sync-push.ts
+++ b/src/hooks/sync-sites/use-sync-push.ts
@@ -142,12 +142,31 @@ export function useSyncPush( {
 				return;
 			}
 
-			const response = await client.req.get< ImportResponse >(
-				`/sites/${ remoteSiteId }/studio-app/sync/import`,
-				{
-					apiNamespace: 'wpcom/v2',
+			let response: ImportResponse;
+			try {
+				response = await client.req.get< ImportResponse >(
+					`/sites/${ remoteSiteId }/studio-app/sync/import`,
+					{
+						apiNamespace: 'wpcom/v2',
+					}
+				);
+			} catch ( error ) {
+				// Network errors (e.g., offline) should be handled gracefully
+				// The error will be handled when the user comes back online
+				console.error( 'Failed to get push progress:', error );
+
+				// Skip Sentry reporting for expected network errors (crossDomain errors)
+				if (
+					error instanceof Error &&
+					'crossDomain' in error &&
+					( error as Error & { crossDomain?: boolean } ).crossDomain
+				) {
+					return;
 				}
-			);
+
+				Sentry.captureException( error );
+				return;
+			}
 
 			let status: PushStateProgressInfo = pushStatesProgressInfo.creatingRemoteBackup;
 			if ( response.success && response.status === 'finished' ) {


### PR DESCRIPTION
## Related issues

- Fixes STU-1180

## Proposed Changes

- Added error handling in `getPushProgressInfo` to catch network errors gracefully
- Skip Sentry reporting for expected `crossDomain` network errors (offline scenarios)
- Prevent unhandled promise rejections when network goes offline

## Testing Instructions

1. Start a new sync operation
2. Allow the upload step to complete successfully
3. Disconnect the network (e.g., turn off Wi‑Fi) during subsequent sync steps
4. Verify the renderer no longer crashes and handles the offline state gracefully
5. Verify that when the network reconnects, the sync operation can continue

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?