### PR TITLE
Site Creation: Fix renderer crash for long site names when creating new site

### DIFF
--- a/src/hooks/tests/use-add-site.test.tsx
+++ b/src/hooks/tests/use-add-site.test.tsx
@@ -267,7 +267,7 @@ describe( 'useAddSite', () => {
 
 		it( 'should set user-friendly error when site name causes ENAMETOOLONG error', async () => {
 			const enametoolongError = new Error(
-				"Error invoking remote method 'generateProposedSitePath': Error: ENAMETOOLONG: name too long, stat"
+				'The site name is too long. Please choose a shorter site name.'
 			);
 			mockGenerateProposedSitePath.mockRejectedValueOnce( enametoolongError );
 
@@ -280,6 +280,19 @@ describe( 'useAddSite', () => {
 			expect( result.current.error ).toBe(
 				'The site name is too long. Please choose a shorter site name.'
 			);
+		} );
+
+		it( 'should display error message from generateProposedSitePath', async () => {
+			const customError = new Error( 'Custom error message' );
+			mockGenerateProposedSitePath.mockRejectedValueOnce( customError );
+
+			const { result } = renderHookWithProvider( () => useAddSite() );
+
+			await act( async () => {
+				await result.current.handleSiteNameChange( 'my-site' );
+			} );
+
+			expect( result.current.error ).toBe( 'Custom error message' );
 		} );
 
 		it( 'should successfully update site name when path is valid', async () => {

--- a/src/hooks/tests/use-add-site.test.tsx
+++ b/src/hooks/tests/use-add-site.test.tsx
@@ -267,7 +267,7 @@ describe( 'useAddSite', () => {
 
 		it( 'should set user-friendly error when site name causes ENAMETOOLONG error', async () => {
 			const enametoolongError = new Error(
-				'The site name is too long. Please choose a shorter site name.'
+				"Error invoking remote method 'generateProposedSitePath': Error: ENAMETOOLONG: name too long, stat"
 			);
 			mockGenerateProposedSitePath.mockRejectedValueOnce( enametoolongError );
 
@@ -280,19 +280,6 @@ describe( 'useAddSite', () => {
 			expect( result.current.error ).toBe(
 				'The site name is too long. Please choose a shorter site name.'
 			);
-		} );
-
-		it( 'should display error message from generateProposedSitePath', async () => {
-			const customError = new Error( 'Custom error message' );
-			mockGenerateProposedSitePath.mockRejectedValueOnce( customError );
-
-			const { result } = renderHookWithProvider( () => useAddSite() );
-
-			await act( async () => {
-				await result.current.handleSiteNameChange( 'my-site' );
-			} );
-
-			expect( result.current.error ).toBe( 'Custom error message' );
 		} );
 
 		it( 'should successfully update site name when path is valid', async () => {

--- a/src/hooks/tests/use-add-site.test.tsx
+++ b/src/hooks/tests/use-add-site.test.tsx
@@ -266,10 +266,13 @@ describe( 'useAddSite', () => {
 		} );
 
 		it( 'should set user-friendly error when site name causes ENAMETOOLONG error', async () => {
-			const enametoolongError = new Error(
-				"Error invoking remote method 'generateProposedSitePath': Error: ENAMETOOLONG: name too long, stat"
-			);
-			mockGenerateProposedSitePath.mockRejectedValueOnce( enametoolongError );
+			mockGenerateProposedSitePath.mockResolvedValueOnce( {
+				path: '/default/path/very-long-name',
+				name: 'a'.repeat( 300 ),
+				isEmpty: false,
+				isWordPress: false,
+				isNameTooLong: true,
+			} );
 
 			const { result } = renderHookWithProvider( () => useAddSite() );
 

--- a/src/hooks/tests/use-add-site.test.tsx
+++ b/src/hooks/tests/use-add-site.test.tsx
@@ -23,18 +23,23 @@ jest.mock( 'src/hooks/use-import-export', () => ( {
 } ) );
 
 const mockConnectWpcomSites = jest.fn().mockResolvedValue( undefined );
+const mockGenerateProposedSitePath = jest.fn().mockResolvedValue( {
+	path: '/default/path',
+	name: 'Default Site',
+	isEmpty: true,
+	isWordPress: false,
+} );
+
+const mockComparePaths = jest.fn().mockResolvedValue( false );
+
 jest.mock( 'src/lib/get-ipc-api', () => ( {
 	getIpcApi: () => ( {
-		generateProposedSitePath: jest.fn().mockResolvedValue( {
-			path: '/default/path',
-			name: 'Default Site',
-			isEmpty: true,
-			isWordPress: false,
-		} ),
+		generateProposedSitePath: mockGenerateProposedSitePath,
 		showNotification: jest.fn(),
 		getAllCustomDomains: jest.fn().mockResolvedValue( [] ),
 		connectWpcomSites: mockConnectWpcomSites,
 		getConnectedWpcomSites: jest.fn().mockResolvedValue( [] ),
+		comparePaths: mockComparePaths,
 	} ),
 } ) );
 
@@ -245,5 +250,54 @@ describe( 'useAddSite', () => {
 			optionsToSync: [ 'all' ],
 		} );
 		expect( mockSetSelectedTab ).toHaveBeenCalledWith( 'sync' );
+	} );
+
+	describe( 'handleSiteNameChange', () => {
+		beforeEach( () => {
+			mockGenerateProposedSitePath.mockReset();
+			mockGenerateProposedSitePath.mockResolvedValue( {
+				path: '/default/path',
+				name: 'Default Site',
+				isEmpty: true,
+				isWordPress: false,
+			} );
+			mockComparePaths.mockReset();
+			mockComparePaths.mockResolvedValue( false );
+		} );
+
+		it( 'should set user-friendly error when site name causes ENAMETOOLONG error', async () => {
+			const enametoolongError = new Error(
+				"Error invoking remote method 'generateProposedSitePath': Error: ENAMETOOLONG: name too long, stat"
+			);
+			mockGenerateProposedSitePath.mockRejectedValueOnce( enametoolongError );
+
+			const { result } = renderHookWithProvider( () => useAddSite() );
+
+			await act( async () => {
+				await result.current.handleSiteNameChange( 'a'.repeat( 300 ) );
+			} );
+
+			expect( result.current.error ).toBe(
+				'The site name is too long. Please choose a shorter site name.'
+			);
+		} );
+
+		it( 'should successfully update site name when path is valid', async () => {
+			mockGenerateProposedSitePath.mockResolvedValueOnce( {
+				path: '/default/path/my-site',
+				name: 'my-site',
+				isEmpty: true,
+				isWordPress: false,
+			} );
+
+			const { result } = renderHookWithProvider( () => useAddSite() );
+
+			await act( async () => {
+				await result.current.handleSiteNameChange( 'my-site' );
+			} );
+
+			expect( result.current.siteName ).toBe( 'my-site' );
+			expect( result.current.error ).toBe( '' );
+		} );
 	} );
 } );

--- a/src/hooks/use-add-site.ts
+++ b/src/hooks/use-add-site.ts
@@ -237,7 +237,7 @@ export function useAddSite( options: UseAddSiteOptions = {} ) {
 		setSelectedTab,
 	] );
 
-		const handleSiteNameChange = useCallback(
+	const handleSiteNameChange = useCallback(
 		async ( name: string ) => {
 			setSiteName( name );
 			if ( sitePath ) {
@@ -271,8 +271,8 @@ export function useAddSite( options: UseAddSiteOptions = {} ) {
 				}
 				setDoesPathContainWordPress( ! isEmpty && isWordPress );
 			} catch ( err ) {
-				if ( err instanceof Error ) {
-					setError( err.message );
+				if ( err instanceof Error && err.message.includes( 'ENAMETOOLONG' ) ) {
+					setError( __( 'The site name is too long. Please choose a shorter site name.' ) );
 					return;
 				}
 				throw err;

--- a/src/hooks/use-add-site.ts
+++ b/src/hooks/use-add-site.ts
@@ -245,38 +245,36 @@ export function useAddSite( options: UseAddSiteOptions = {} ) {
 			}
 			setError( '' );
 
-			try {
-				const {
-					path: proposedPath,
-					isEmpty,
-					isWordPress,
-				} = await getIpcApi().generateProposedSitePath( name );
-				setProposedSitePath( proposedPath );
+			const {
+				path: proposedPath,
+				isEmpty,
+				isWordPress,
+				isNameTooLong,
+			} = await getIpcApi().generateProposedSitePath( name );
+			setProposedSitePath( proposedPath );
 
-				if ( await siteWithPathAlreadyExists( proposedPath ) ) {
-					setError(
-						__(
-							'The directory is already associated with another Studio site. Please choose a different site name or a custom local path.'
-						)
-					);
-					return;
-				}
-				if ( ! isEmpty && ! isWordPress ) {
-					setError(
-						__(
-							'This directory is not empty. Please select an empty directory or an existing WordPress folder.'
-						)
-					);
-					return;
-				}
-				setDoesPathContainWordPress( ! isEmpty && isWordPress );
-			} catch ( err ) {
-				if ( err instanceof Error && err.message.includes( 'ENAMETOOLONG' ) ) {
-					setError( __( 'The site name is too long. Please choose a shorter site name.' ) );
-					return;
-				}
-				throw err;
+			if ( isNameTooLong ) {
+				setError( __( 'The site name is too long. Please choose a shorter site name.' ) );
+				return;
 			}
+
+			if ( await siteWithPathAlreadyExists( proposedPath ) ) {
+				setError(
+					__(
+						'The directory is already associated with another Studio site. Please choose a different site name or a custom local path.'
+					)
+				);
+				return;
+			}
+			if ( ! isEmpty && ! isWordPress ) {
+				setError(
+					__(
+						'This directory is not empty. Please select an empty directory or an existing WordPress folder.'
+					)
+				);
+				return;
+			}
+			setDoesPathContainWordPress( ! isEmpty && isWordPress );
 		},
 		[ __, sitePath, siteWithPathAlreadyExists ]
 	);

--- a/src/hooks/use-add-site.ts
+++ b/src/hooks/use-add-site.ts
@@ -244,30 +244,39 @@ export function useAddSite( options: UseAddSiteOptions = {} ) {
 				return;
 			}
 			setError( '' );
-			const {
-				path: proposedPath,
-				isEmpty,
-				isWordPress,
-			} = await getIpcApi().generateProposedSitePath( name );
-			setProposedSitePath( proposedPath );
 
-			if ( await siteWithPathAlreadyExists( proposedPath ) ) {
-				setError(
-					__(
-						'The directory is already associated with another Studio site. Please choose a different site name or a custom local path.'
-					)
-				);
-				return;
+			try {
+				const {
+					path: proposedPath,
+					isEmpty,
+					isWordPress,
+				} = await getIpcApi().generateProposedSitePath( name );
+				setProposedSitePath( proposedPath );
+
+				if ( await siteWithPathAlreadyExists( proposedPath ) ) {
+					setError(
+						__(
+							'The directory is already associated with another Studio site. Please choose a different site name or a custom local path.'
+						)
+					);
+					return;
+				}
+				if ( ! isEmpty && ! isWordPress ) {
+					setError(
+						__(
+							'This directory is not empty. Please select an empty directory or an existing WordPress folder.'
+						)
+					);
+					return;
+				}
+				setDoesPathContainWordPress( ! isEmpty && isWordPress );
+			} catch ( err ) {
+				if ( err instanceof Error && err.message.includes( 'ENAMETOOLONG' ) ) {
+					setError( __( 'The site name is too long. Please choose a shorter site name.' ) );
+					return;
+				}
+				throw err;
 			}
-			if ( ! isEmpty && ! isWordPress ) {
-				setError(
-					__(
-						'This directory is not empty. Please select an empty directory or an existing WordPress folder.'
-					)
-				);
-				return;
-			}
-			setDoesPathContainWordPress( ! isEmpty && isWordPress );
 		},
 		[ __, sitePath, siteWithPathAlreadyExists ]
 	);

--- a/src/hooks/use-add-site.ts
+++ b/src/hooks/use-add-site.ts
@@ -237,7 +237,7 @@ export function useAddSite( options: UseAddSiteOptions = {} ) {
 		setSelectedTab,
 	] );
 
-	const handleSiteNameChange = useCallback(
+		const handleSiteNameChange = useCallback(
 		async ( name: string ) => {
 			setSiteName( name );
 			if ( sitePath ) {
@@ -271,8 +271,8 @@ export function useAddSite( options: UseAddSiteOptions = {} ) {
 				}
 				setDoesPathContainWordPress( ! isEmpty && isWordPress );
 			} catch ( err ) {
-				if ( err instanceof Error && err.message.includes( 'ENAMETOOLONG' ) ) {
-					setError( __( 'The site name is too long. Please choose a shorter site name.' ) );
+				if ( err instanceof Error ) {
+					setError( err.message );
 					return;
 				}
 				throw err;

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -450,6 +450,7 @@ export interface FolderDialogResponse {
 	name: string;
 	isEmpty: boolean;
 	isWordPress: boolean;
+	isNameTooLong?: boolean;
 }
 
 export async function showSaveAsDialog( event: IpcMainInvokeEvent, options: SaveDialogOptions ) {
@@ -711,6 +712,15 @@ export async function generateProposedSitePath(
 				name: siteName,
 				isEmpty: true,
 				isWordPress: false,
+			};
+		}
+		if ( isErrnoException( err ) && err.code === 'ENAMETOOLONG' ) {
+			return {
+				path,
+				name: siteName,
+				isEmpty: false,
+				isWordPress: false,
+				isNameTooLong: true,
 			};
 		}
 		throw err;

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -713,9 +713,6 @@ export async function generateProposedSitePath(
 				isWordPress: false,
 			};
 		}
-		if ( isErrnoException( err ) && err.code === 'ENAMETOOLONG' ) {
-			throw new Error( __( 'The site name is too long. Please choose a shorter site name.' ) );
-		}
 		throw err;
 	}
 }

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -713,6 +713,9 @@ export async function generateProposedSitePath(
 				isWordPress: false,
 			};
 		}
+		if ( isErrnoException( err ) && err.code === 'ENAMETOOLONG' ) {
+			throw new Error( __( 'The site name is too long. Please choose a shorter site name.' ) );
+		}
 		throw err;
 	}
 }


### PR DESCRIPTION
## Related issues

- Fixes STU-1182

## Proposed Changes

- Added error handling in `handleSiteNameChange` to catch ENAMETOOLONG errors and display a user-friendly error message when site name is too long
- Added tests to verify ENAMETOOLONG error handling works correctly
- The renderer now gracefully handles long site names instead of crashing

## Testing Instructions

1. Open the "Add site" modal
2. Enter a very long site name (e.g., a string of 300+ characters)
3. Verify that instead of crashing, a user-friendly error message is displayed: "The site name is too long. Please choose a shorter site name."
4. Run the test suite: `npm test -- src/hooks/tests/use-add-site.test.tsx`
5. Verify all tests pass, including the new ENAMETOOLONG error handling tests

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?