### PR TITLE
Statically import `runCommand` functions in CLI tests

### DIFF
--- a/cli/commands/auth/tests/login.test.ts
+++ b/cli/commands/auth/tests/login.test.ts
@@ -11,6 +11,7 @@ import {
 import { openBrowser } from 'cli/lib/browser';
 import { getAppLocale } from 'cli/lib/i18n';
 import { Logger, LoggerError } from 'cli/logger';
+import { runCommand } from '../login';
 
 jest.mock( '@inquirer/prompts' );
 jest.mock( 'common/lib/oauth' );
@@ -76,7 +77,6 @@ describe( 'Auth Login Command', () => {
 	it( 'should skip login if already authenticated', async () => {
 		( getAuthToken as jest.Mock ).mockResolvedValue( mockAppdata.authToken );
 
-		const { runCommand } = await import( '../login' );
 		await runCommand();
 
 		expect( openBrowser ).not.toHaveBeenCalled();
@@ -84,7 +84,6 @@ describe( 'Auth Login Command', () => {
 	} );
 
 	it( 'should complete the login process successfully', async () => {
-		const { runCommand } = await import( '../login' );
 		await runCommand();
 
 		expect( getAuthenticationUrl ).toHaveBeenCalledWith(
@@ -111,7 +110,6 @@ describe( 'Auth Login Command', () => {
 	} );
 
 	it( 'should proceed with login if existing token is invalid', async () => {
-		const { runCommand } = await import( '../login' );
 		await runCommand();
 
 		expect( openBrowser ).toHaveBeenCalled();
@@ -122,7 +120,6 @@ describe( 'Auth Login Command', () => {
 		const browserError = new LoggerError( 'Failed to open browser' );
 		( openBrowser as jest.Mock ).mockRejectedValue( browserError );
 
-		const { runCommand } = await import( '../login' );
 		await runCommand();
 
 		expect( input ).toHaveBeenCalled();
@@ -132,7 +129,6 @@ describe( 'Auth Login Command', () => {
 		const apiError = new LoggerError( 'Failed to fetch user info' );
 		( getUserInfo as jest.Mock ).mockRejectedValue( apiError );
 
-		const { runCommand } = await import( '../login' );
 		await runCommand();
 
 		expect( mockLogger.reportError ).toHaveBeenCalled();
@@ -144,7 +140,6 @@ describe( 'Auth Login Command', () => {
 		const saveError = new Error( 'Failed to save' );
 		( saveAppdata as jest.Mock ).mockRejectedValue( saveError );
 
-		const { runCommand } = await import( '../login' );
 		await runCommand();
 
 		expect( mockLogger.reportError ).toHaveBeenCalled();
@@ -157,7 +152,6 @@ describe( 'Auth Login Command', () => {
 		const lockError = new Error( 'Failed to lock' );
 		( lockAppdata as jest.Mock ).mockRejectedValue( lockError );
 
-		const { runCommand } = await import( '../login' );
 		await runCommand();
 
 		expect( mockLogger.reportError ).toHaveBeenCalled();
@@ -167,7 +161,6 @@ describe( 'Auth Login Command', () => {
 	it( 'should use provided locale', async () => {
 		( getAppLocale as jest.Mock ).mockResolvedValue( 'fr' );
 
-		const { runCommand } = await import( '../login' );
 		await runCommand();
 
 		expect( getAuthenticationUrl ).toHaveBeenCalledWith(

--- a/cli/commands/auth/tests/logout.test.ts
+++ b/cli/commands/auth/tests/logout.test.ts
@@ -7,6 +7,7 @@ import {
 	unlockAppdata,
 } from 'cli/lib/appdata';
 import { Logger, LoggerError } from 'cli/logger';
+import { runCommand } from '../logout';
 
 jest.mock( 'cli/lib/appdata' );
 jest.mock( 'cli/logger' );
@@ -55,7 +56,6 @@ describe( 'Auth Logout Command', () => {
 	} );
 
 	it( 'should complete the logout process successfully', async () => {
-		const { runCommand } = await import( '../logout' );
 		await runCommand();
 
 		expect( getAuthToken ).toHaveBeenCalled();
@@ -72,7 +72,6 @@ describe( 'Auth Logout Command', () => {
 	it( 'should report an error if revoking the token fails', async () => {
 		( revokeAuthToken as jest.Mock ).mockRejectedValue( new Error( 'Failed to revoke token' ) );
 
-		const { runCommand } = await import( '../logout' );
 		await runCommand();
 
 		expect( getAuthToken ).toHaveBeenCalled();
@@ -87,7 +86,6 @@ describe( 'Auth Logout Command', () => {
 	it( 'should report already logged out if no auth token exists', async () => {
 		( getAuthToken as jest.Mock ).mockRejectedValue( new Error( 'No auth token' ) );
 
-		const { runCommand } = await import( '../logout' );
 		await runCommand();
 
 		expect( getAuthToken ).toHaveBeenCalled();
@@ -101,7 +99,6 @@ describe( 'Auth Logout Command', () => {
 	it( 'should unlock appdata even if save fails', async () => {
 		( saveAppdata as jest.Mock ).mockRejectedValue( new Error( 'Failed to save' ) );
 
-		const { runCommand } = await import( '../logout' );
 		await runCommand();
 
 		expect( revokeAuthToken ).toHaveBeenCalled();

--- a/cli/commands/auth/tests/status.test.ts
+++ b/cli/commands/auth/tests/status.test.ts
@@ -1,6 +1,7 @@
 import { getUserInfo } from 'cli/lib/api';
 import { getAuthToken } from 'cli/lib/appdata';
 import { Logger, LoggerError } from 'cli/logger';
+import { runCommand } from '../status';
 
 jest.mock( 'cli/lib/api' );
 jest.mock( 'cli/lib/appdata' );
@@ -44,7 +45,6 @@ describe( 'Auth Status Command', () => {
 	} );
 
 	it( 'should report success when authenticated', async () => {
-		const { runCommand } = await import( '../status' );
 		await runCommand();
 
 		expect( mockLogger.reportStart ).toHaveBeenCalled();
@@ -58,7 +58,6 @@ describe( 'Auth Status Command', () => {
 	it( 'should report error when token is invalid', async () => {
 		( getAuthToken as jest.Mock ).mockRejectedValue( new Error( 'Token error' ) );
 
-		const { runCommand } = await import( '../status' );
 		await runCommand();
 
 		expect( mockLogger.reportError ).toHaveBeenCalled();
@@ -70,7 +69,6 @@ describe( 'Auth Status Command', () => {
 		const apiError = new LoggerError( 'API error' );
 		( getUserInfo as jest.Mock ).mockRejectedValue( apiError );
 
-		const { runCommand } = await import( '../status' );
 		await runCommand();
 
 		expect( mockLogger.reportError ).toHaveBeenCalledWith( apiError );
@@ -79,7 +77,6 @@ describe( 'Auth Status Command', () => {
 	it( 'should wrap unknown error when getUserInfo fails', async () => {
 		( getUserInfo as jest.Mock ).mockRejectedValue( new Error( 'Unknown error' ) );
 
-		const { runCommand } = await import( '../status' );
 		await runCommand();
 
 		expect( mockLogger.reportError ).toHaveBeenCalledWith( expect.any( LoggerError ) );

--- a/cli/commands/preview/tests/create.test.ts
+++ b/cli/commands/preview/tests/create.test.ts
@@ -6,6 +6,7 @@ import { getAuthToken, getSiteByFolder } from 'cli/lib/appdata';
 import { archiveSiteContent, cleanup } from 'cli/lib/archive';
 import { saveSnapshotToAppdata } from 'cli/lib/snapshots';
 import { Logger, LoggerError } from 'cli/logger';
+import { runCommand } from '../create';
 
 jest.mock( 'common/lib/get-wordpress-version' );
 jest.mock( 'cli/lib/appdata', () => ( {
@@ -79,7 +80,6 @@ describe( 'Preview Create Command', () => {
 
 	it( 'should complete the preview creation process successfully', async () => {
 		( getWordPressVersion as jest.Mock ).mockReturnValue( '6.8.1' );
-		const { runCommand } = await import( '../create' );
 		await runCommand( mockFolder );
 
 		expect( getSiteByFolder ).toHaveBeenCalledWith( mockFolder );
@@ -124,7 +124,6 @@ describe( 'Preview Create Command', () => {
 	} );
 
 	it( 'should use current directory when no folder is specified', async () => {
-		const { runCommand } = await import( '../create' );
 		await runCommand( process.cwd() );
 
 		expect( getSiteByFolder ).toHaveBeenCalledWith( process.cwd() );
@@ -137,7 +136,6 @@ describe( 'Preview Create Command', () => {
 			throw new LoggerError( errorMessage );
 		} );
 
-		const { runCommand } = await import( '../create' );
 		await runCommand( mockFolder );
 
 		expect( mockLogger.reportError ).toHaveBeenCalled();
@@ -152,7 +150,6 @@ describe( 'Preview Create Command', () => {
 			throw new LoggerError( errorMessage );
 		} );
 
-		const { runCommand } = await import( '../create' );
 		await runCommand( mockFolder );
 
 		expect( mockLogger.reportError ).toHaveBeenCalled();
@@ -166,7 +163,6 @@ describe( 'Preview Create Command', () => {
 			throw new LoggerError( errorMessage );
 		} );
 
-		const { runCommand } = await import( '../create' );
 		await runCommand( mockFolder );
 
 		expect( mockLogger.reportError ).toHaveBeenCalled();
@@ -180,7 +176,6 @@ describe( 'Preview Create Command', () => {
 			throw new LoggerError( errorMessage );
 		} );
 
-		const { runCommand } = await import( '../create' );
 		await runCommand( mockFolder );
 
 		expect( mockLogger.reportError ).toHaveBeenCalled();
@@ -194,7 +189,6 @@ describe( 'Preview Create Command', () => {
 			throw new LoggerError( errorMessage );
 		} );
 
-		const { runCommand } = await import( '../create' );
 		await runCommand( mockFolder );
 
 		expect( mockLogger.reportError ).toHaveBeenCalled();
@@ -208,7 +202,6 @@ describe( 'Preview Create Command', () => {
 			throw new LoggerError( errorMessage );
 		} );
 
-		const { runCommand } = await import( '../create' );
 		await runCommand( mockFolder );
 
 		expect( mockLogger.reportError ).toHaveBeenCalled();
@@ -220,7 +213,6 @@ describe( 'Preview Create Command', () => {
 			throw new LoggerError( 'Upload failed' );
 		} );
 
-		const { runCommand } = await import( '../create' );
 		await runCommand( mockFolder );
 
 		expect( cleanup ).toHaveBeenCalledWith( mockArchivePath );

--- a/cli/commands/preview/tests/delete.test.ts
+++ b/cli/commands/preview/tests/delete.test.ts
@@ -2,6 +2,7 @@ import { deleteSnapshot } from 'cli/lib/api';
 import { getAuthToken } from 'cli/lib/appdata';
 import { getSnapshotsFromAppdata, deleteSnapshotFromAppdata } from 'cli/lib/snapshots';
 import { Logger, LoggerError } from 'cli/logger';
+import { runCommand } from '../delete';
 
 jest.mock( 'cli/lib/appdata', () => ( {
 	...jest.requireActual( 'cli/lib/appdata' ),
@@ -52,7 +53,6 @@ describe( 'Preview Delete Command', () => {
 	} );
 
 	it( 'should complete the preview deletion process successfully', async () => {
-		const { runCommand } = await import( '../delete' );
 		await runCommand( mockSiteUrl );
 
 		expect( getAuthToken ).toHaveBeenCalled();
@@ -73,7 +73,6 @@ describe( 'Preview Delete Command', () => {
 			throw new LoggerError( errorMessage );
 		} );
 
-		const { runCommand } = await import( '../delete' );
 		await runCommand( mockSiteUrl );
 
 		expect( mockLogger.reportError ).toHaveBeenCalled();
@@ -84,7 +83,6 @@ describe( 'Preview Delete Command', () => {
 	it( 'should handle snapshot not found errors', async () => {
 		( getSnapshotsFromAppdata as jest.Mock ).mockResolvedValue( [] );
 
-		const { runCommand } = await import( '../delete' );
 		await runCommand( mockSiteUrl );
 
 		expect( mockLogger.reportError ).toHaveBeenCalled();
@@ -98,7 +96,6 @@ describe( 'Preview Delete Command', () => {
 			throw new LoggerError( errorMessage );
 		} );
 
-		const { runCommand } = await import( '../delete' );
 		await runCommand( mockSiteUrl );
 
 		expect( mockLogger.reportError ).toHaveBeenCalled();
@@ -112,7 +109,6 @@ describe( 'Preview Delete Command', () => {
 			throw new LoggerError( errorMessage );
 		} );
 
-		const { runCommand } = await import( '../delete' );
 		await runCommand( mockSiteUrl );
 
 		expect( mockLogger.reportError ).toHaveBeenCalled();

--- a/cli/commands/preview/tests/list.test.ts
+++ b/cli/commands/preview/tests/list.test.ts
@@ -1,6 +1,7 @@
 import { getAuthToken, getSiteByFolder } from 'cli/lib/appdata';
 import { getSnapshotsFromAppdata } from 'cli/lib/snapshots';
 import { Logger } from 'cli/logger';
+import { runCommand } from '../list';
 
 jest.mock( 'cli/lib/appdata', () => ( {
 	...jest.requireActual( 'cli/lib/appdata' ),
@@ -65,7 +66,6 @@ describe( 'Preview List Command', () => {
 	} );
 
 	it( 'should list preview sites successfully', async () => {
-		const { runCommand } = await import( '../list' );
 		await runCommand( mockFolder, 'table' );
 
 		expect( getSiteByFolder ).toHaveBeenCalledWith( mockFolder );
@@ -80,7 +80,6 @@ describe( 'Preview List Command', () => {
 	} );
 
 	it( 'should handle validation errors', async () => {
-		const { runCommand } = await import( '../list' );
 		( getSiteByFolder as jest.Mock ).mockImplementation( () => {
 			throw new Error( 'Invalid site folder' );
 		} );
@@ -91,7 +90,6 @@ describe( 'Preview List Command', () => {
 	} );
 
 	it( 'should handle no snapshots found', async () => {
-		const { runCommand } = await import( '../list' );
 		( getSnapshotsFromAppdata as jest.Mock ).mockResolvedValue( [] );
 
 		await runCommand( mockFolder, 'table' );

--- a/cli/commands/preview/tests/update.test.ts
+++ b/cli/commands/preview/tests/update.test.ts
@@ -7,6 +7,7 @@ import { getAuthToken, getSiteByFolder } from 'cli/lib/appdata';
 import { archiveSiteContent, cleanup } from 'cli/lib/archive';
 import { updateSnapshotInAppdata, getSnapshotsFromAppdata } from 'cli/lib/snapshots';
 import { Logger, LoggerError } from 'cli/logger';
+import { runCommand } from '../update';
 
 jest.mock( 'common/lib/get-wordpress-version' );
 jest.mock( 'cli/lib/appdata', () => ( {
@@ -79,7 +80,6 @@ describe( 'Preview Update Command', () => {
 
 	it( 'should complete the preview update process successfully', async () => {
 		( getWordPressVersion as jest.Mock ).mockReturnValue( '6.8.1' );
-		const { runCommand } = await import( '../update' );
 		await runCommand( mockFolder, mockSiteUrl, false );
 		expect( getSiteByFolder ).toHaveBeenCalledWith( mockFolder );
 		expect( mockLogger.reportStart.mock.calls[ 0 ] ).toEqual( [ 'validate', 'Validating…' ] );
@@ -118,7 +118,6 @@ describe( 'Preview Update Command', () => {
 	} );
 
 	it( 'should use current directory when no folder is specified', async () => {
-		const { runCommand } = await import( '../update' );
 		await runCommand( process.cwd(), mockSiteUrl, false );
 
 		expect( getSiteByFolder ).toHaveBeenCalledWith( process.cwd() );
@@ -131,7 +130,6 @@ describe( 'Preview Update Command', () => {
 			throw new LoggerError( errorMessage );
 		} );
 
-		const { runCommand } = await import( '../update' );
 		await runCommand( mockFolder, mockSiteUrl, false );
 
 		expect( mockLogger.reportError ).toHaveBeenCalled();
@@ -142,7 +140,6 @@ describe( 'Preview Update Command', () => {
 	it( 'should handle snapshot not found errors', async () => {
 		( getSnapshotsFromAppdata as jest.Mock ).mockResolvedValue( [] );
 
-		const { runCommand } = await import( '../update' );
 		await runCommand( mockFolder, mockSiteUrl, false );
 
 		expect( mockLogger.reportError ).toHaveBeenCalled();
@@ -156,7 +153,6 @@ describe( 'Preview Update Command', () => {
 			throw new LoggerError( errorMessage );
 		} );
 
-		const { runCommand } = await import( '../update' );
 		await runCommand( mockFolder, mockSiteUrl, false );
 
 		expect( mockLogger.reportError ).toHaveBeenCalled();
@@ -170,7 +166,6 @@ describe( 'Preview Update Command', () => {
 			throw new LoggerError( errorMessage );
 		} );
 
-		const { runCommand } = await import( '../update' );
 		await runCommand( mockFolder, mockSiteUrl, false );
 
 		expect( mockLogger.reportError ).toHaveBeenCalled();
@@ -184,7 +179,6 @@ describe( 'Preview Update Command', () => {
 			throw new LoggerError( errorMessage );
 		} );
 
-		const { runCommand } = await import( '../update' );
 		await runCommand( mockFolder, mockSiteUrl, false );
 
 		expect( mockLogger.reportError ).toHaveBeenCalled();
@@ -198,7 +192,6 @@ describe( 'Preview Update Command', () => {
 			throw new LoggerError( errorMessage );
 		} );
 
-		const { runCommand } = await import( '../update' );
 		await runCommand( mockFolder, mockSiteUrl, false );
 
 		expect( mockLogger.reportError ).toHaveBeenCalled();
@@ -210,14 +203,12 @@ describe( 'Preview Update Command', () => {
 			throw new LoggerError( 'Upload failed' );
 		} );
 
-		const { runCommand } = await import( '../update' );
 		await runCommand( mockFolder, mockSiteUrl, false );
 
 		expect( cleanup ).toHaveBeenCalledWith( mockArchivePath );
 	} );
 
 	it( 'should not allow updating an expired preview site', async () => {
-		const { runCommand } = await import( '../update' );
 		const expiredDate = mockDate - ( DEMO_SITE_EXPIRATION_DAYS + 1 ) * 24 * 60 * 60 * 1000;
 		const expiredSnapshot = { ...mockSnapshot, date: expiredDate };
 		( getSnapshotsFromAppdata as jest.Mock ).mockResolvedValue( [ expiredSnapshot ] );
@@ -230,7 +221,6 @@ describe( 'Preview Update Command', () => {
 	} );
 
 	it( 'should throw error if folder does not match original site and no overwrite flag', async () => {
-		const { runCommand } = await import( '../update' );
 		( getSiteByFolder as jest.Mock ).mockResolvedValueOnce( {
 			id: 'different-id',
 			path: '/other/path',
@@ -242,7 +232,6 @@ describe( 'Preview Update Command', () => {
 	} );
 
 	it( 'should allow update if overwrite flag is set even if folder does not match', async () => {
-		const { runCommand } = await import( '../update' );
 		( getSiteByFolder as jest.Mock ).mockResolvedValueOnce( {
 			id: 'different-id',
 			path: '/other/path',

--- a/cli/commands/site/tests/create.test.ts
+++ b/cli/commands/site/tests/create.test.ts
@@ -21,6 +21,7 @@ import { logSiteDetails, openSiteInBrowser, setupCustomDomain } from 'cli/lib/si
 import { isSqliteIntegrationAvailable, installSqliteIntegration } from 'cli/lib/sqlite-integration';
 import { runBlueprint, startWordPressServer } from 'cli/lib/wordpress-server-manager';
 import { Logger } from 'cli/logger';
+import { runCommand } from '../create';
 
 jest.mock( 'common/lib/fs-utils' );
 jest.mock( 'common/lib/network-utils' );
@@ -137,8 +138,6 @@ describe( 'CLI: studio site create', () => {
 			( isEmptyDir as jest.Mock ).mockResolvedValue( false );
 			( isWordPressDirectory as jest.Mock ).mockReturnValue( false );
 
-			const { runCommand } = await import( '../create' );
-
 			await expect( runCommand( mockSitePath, { ...defaultTestOptions } ) ).rejects.toThrow(
 				'The selected directory is not empty nor an existing WordPress site.'
 			);
@@ -153,8 +152,6 @@ describe( 'CLI: studio site create', () => {
 			} );
 			( arePathsEqual as jest.Mock ).mockReturnValue( true );
 
-			const { runCommand } = await import( '../create' );
-
 			await expect( runCommand( mockSitePath, { ...defaultTestOptions } ) ).rejects.toThrow(
 				'The selected directory is already in use.'
 			);
@@ -163,8 +160,6 @@ describe( 'CLI: studio site create', () => {
 		} );
 
 		it( 'should error if custom domain is invalid', async () => {
-			const { runCommand } = await import( '../create' );
-
 			await expect(
 				runCommand( mockSitePath, {
 					...defaultTestOptions,
@@ -180,8 +175,6 @@ describe( 'CLI: studio site create', () => {
 				sites: [ { ...mockExistingSite, customDomain: 'mysite.local' } ],
 				snapshots: [],
 			} );
-
-			const { runCommand } = await import( '../create' );
 
 			await expect(
 				runCommand( mockSitePath, {
@@ -199,8 +192,6 @@ describe( 'CLI: studio site create', () => {
 				error: 'Invalid blueprint',
 			} );
 
-			const { runCommand } = await import( '../create' );
-
 			await expect(
 				runCommand( mockSitePath, {
 					...defaultTestOptions,
@@ -217,8 +208,6 @@ describe( 'CLI: studio site create', () => {
 		it( 'should error if SQLite integration is not available', async () => {
 			( isSqliteIntegrationAvailable as jest.Mock ).mockResolvedValue( false );
 
-			const { runCommand } = await import( '../create' );
-
 			await expect( runCommand( mockSitePath, { ...defaultTestOptions } ) ).rejects.toThrow(
 				'SQLite integration files not found'
 			);
@@ -229,8 +218,6 @@ describe( 'CLI: studio site create', () => {
 
 	describe( 'Success Cases', () => {
 		it( 'should create a basic site successfully', async () => {
-			const { runCommand } = await import( '../create' );
-
 			await runCommand( mockSitePath, { ...defaultTestOptions } );
 
 			expect( fsMkdirSyncSpy ).toHaveBeenCalledWith( mockSitePath, { recursive: true } );
@@ -248,8 +235,6 @@ describe( 'CLI: studio site create', () => {
 		} );
 
 		it( 'should create site with custom name', async () => {
-			const { runCommand } = await import( '../create' );
-
 			await runCommand( mockSitePath, {
 				...defaultTestOptions,
 				name: 'My Custom Site',
@@ -281,8 +266,6 @@ describe( 'CLI: studio site create', () => {
 		} );
 
 		it( 'should use folder name as site name if no name provided', async () => {
-			const { runCommand } = await import( '../create' );
-
 			await runCommand( mockSitePath, { ...defaultTestOptions } );
 
 			expect( saveAppdata ).toHaveBeenCalledWith(
@@ -300,8 +283,6 @@ describe( 'CLI: studio site create', () => {
 			( pathExists as jest.Mock ).mockResolvedValue( true );
 			( isEmptyDir as jest.Mock ).mockResolvedValue( true );
 
-			const { runCommand } = await import( '../create' );
-
 			await runCommand( mockSitePath, { ...defaultTestOptions } );
 
 			expect( fsMkdirSyncSpy ).not.toHaveBeenCalled();
@@ -312,16 +293,12 @@ describe( 'CLI: studio site create', () => {
 			( isEmptyDir as jest.Mock ).mockResolvedValue( false );
 			( isWordPressDirectory as jest.Mock ).mockReturnValue( true );
 
-			const { runCommand } = await import( '../create' );
-
 			await runCommand( mockSitePath, { ...defaultTestOptions } );
 
 			expect( fsMkdirSyncSpy ).not.toHaveBeenCalled();
 		} );
 
 		it( 'should create site with custom domain', async () => {
-			const { runCommand } = await import( '../create' );
-
 			await runCommand( mockSitePath, {
 				...defaultTestOptions,
 				customDomain: 'mysite.local',
@@ -340,8 +317,6 @@ describe( 'CLI: studio site create', () => {
 		} );
 
 		it( 'should create site with HTTPS enabled', async () => {
-			const { runCommand } = await import( '../create' );
-
 			await runCommand( mockSitePath, {
 				...defaultTestOptions,
 				customDomain: 'mysite.local',
@@ -365,16 +340,12 @@ describe( 'CLI: studio site create', () => {
 				snapshots: [],
 			} );
 
-			const { runCommand } = await import( '../create' );
-
 			await runCommand( mockSitePath, { ...defaultTestOptions } );
 
 			expect( portFinder.addUnavailablePort ).toHaveBeenCalledWith( mockExistingSite.port );
 		} );
 
 		it( 'should set isWpAutoUpdating true for latest WordPress version', async () => {
-			const { runCommand } = await import( '../create' );
-
 			await runCommand( mockSitePath, { ...defaultTestOptions } );
 
 			expect( saveAppdata ).toHaveBeenCalledWith(
@@ -389,8 +360,6 @@ describe( 'CLI: studio site create', () => {
 		} );
 
 		it( 'should set isWpAutoUpdating false for specific WordPress version', async () => {
-			const { runCommand } = await import( '../create' );
-
 			await runCommand( mockSitePath, {
 				...defaultTestOptions,
 				wpVersion: '6.4',
@@ -414,8 +383,6 @@ describe( 'CLI: studio site create', () => {
 		};
 
 		it( 'should apply blueprint when provided', async () => {
-			const { runCommand } = await import( '../create' );
-
 			await runCommand( mockSitePath, {
 				...defaultTestOptions,
 				blueprint: {
@@ -435,8 +402,6 @@ describe( 'CLI: studio site create', () => {
 		} );
 
 		it( 'should prepend setSiteOptions step when name is provided with blueprint', async () => {
-			const { runCommand } = await import( '../create' );
-
 			await runCommand( mockSitePath, {
 				...defaultTestOptions,
 				name: 'My Site',
@@ -474,8 +439,6 @@ describe( 'CLI: studio site create', () => {
 				],
 			} );
 
-			const { runCommand } = await import( '../create' );
-
 			await runCommand( mockSitePath, {
 				...defaultTestOptions,
 				blueprint: {
@@ -488,8 +451,6 @@ describe( 'CLI: studio site create', () => {
 
 	describe( 'noStart Option', () => {
 		it( 'should not start server when noStart is true', async () => {
-			const { runCommand } = await import( '../create' );
-
 			await runCommand( mockSitePath, {
 				...defaultTestOptions,
 				noStart: true,
@@ -505,8 +466,6 @@ describe( 'CLI: studio site create', () => {
 
 		it( 'should apply blueprint without starting server when noStart is true', async () => {
 			const testBlueprint: Blueprint = { steps: [] };
-
-			const { runCommand } = await import( '../create' );
 
 			await runCommand( mockSitePath, {
 				...defaultTestOptions,
@@ -526,8 +485,6 @@ describe( 'CLI: studio site create', () => {
 
 		it( 'should run blueprint when preferred language is configured but no blueprint was given', async () => {
 			( getPreferredSiteLanguage as jest.Mock ).mockResolvedValue( 'es_ES' );
-
-			const { runCommand } = await import( '../create' );
 
 			await runCommand( mockSitePath, {
 				...defaultTestOptions,
@@ -553,7 +510,6 @@ describe( 'CLI: studio site create', () => {
 		it( 'should handle WordPress server start failure', async () => {
 			( startWordPressServer as jest.Mock ).mockRejectedValue( new Error( 'Server start failed' ) );
 
-			const { runCommand } = await import( '../create' );
 			await expect( runCommand( mockSitePath, { ...defaultTestOptions } ) ).rejects.toThrow(
 				'Failed to start WordPress server'
 			);
@@ -565,7 +521,6 @@ describe( 'CLI: studio site create', () => {
 			const testBlueprint: Blueprint = { steps: [] };
 			( runBlueprint as jest.Mock ).mockRejectedValue( new Error( 'Blueprint failed' ) );
 
-			const { runCommand } = await import( '../create' );
 			await expect(
 				runCommand( mockSitePath, {
 					...defaultTestOptions,
@@ -585,8 +540,6 @@ describe( 'CLI: studio site create', () => {
 				new Error( 'SQLite setup failed' )
 			);
 
-			const { runCommand } = await import( '../create' );
-
 			await expect( runCommand( mockSitePath, { ...defaultTestOptions } ) ).rejects.toThrow();
 
 			expect( disconnect ).toHaveBeenCalled();
@@ -596,8 +549,6 @@ describe( 'CLI: studio site create', () => {
 	describe( 'Cleanup', () => {
 		it( 'should disconnect from PM2 even on error', async () => {
 			( readAppdata as jest.Mock ).mockRejectedValue( new Error( 'Appdata error' ) );
-
-			const { runCommand } = await import( '../create' );
 
 			try {
 				await runCommand( mockSitePath, { ...defaultTestOptions } );
@@ -609,16 +560,12 @@ describe( 'CLI: studio site create', () => {
 		} );
 
 		it( 'should disconnect from PM2 on success', async () => {
-			const { runCommand } = await import( '../create' );
-
 			await runCommand( mockSitePath, { ...defaultTestOptions } );
 
 			expect( disconnect ).toHaveBeenCalled();
 		} );
 
 		it( 'should unlock appdata after saving', async () => {
-			const { runCommand } = await import( '../create' );
-
 			await runCommand( mockSitePath, { ...defaultTestOptions } );
 
 			expect( unlockAppdata ).toHaveBeenCalled();
@@ -626,8 +573,6 @@ describe( 'CLI: studio site create', () => {
 
 		it( 'should remove site from appdata when server start fails', async () => {
 			( startWordPressServer as jest.Mock ).mockRejectedValue( new Error( 'Server start failed' ) );
-
-			const { runCommand } = await import( '../create' );
 
 			await expect( runCommand( mockSitePath, { ...defaultTestOptions } ) ).rejects.toThrow();
 
@@ -637,8 +582,6 @@ describe( 'CLI: studio site create', () => {
 		it( 'should remove site from appdata when blueprint application fails', async () => {
 			const testBlueprint = { steps: [] };
 			( runBlueprint as jest.Mock ).mockRejectedValue( new Error( 'Blueprint failed' ) );
-
-			const { runCommand } = await import( '../create' );
 
 			await expect(
 				runCommand( mockSitePath, {
@@ -661,8 +604,6 @@ describe( 'CLI: studio site create', () => {
 
 			const fsRmSpy = jest.spyOn( require( 'fs' ).promises, 'rm' ).mockResolvedValue( undefined );
 
-			const { runCommand } = await import( '../create' );
-
 			await expect( runCommand( mockSitePath, { ...defaultTestOptions } ) ).rejects.toThrow();
 
 			expect( fsRmSpy ).toHaveBeenCalledWith( mockSitePath, { recursive: true, force: true } );
@@ -676,8 +617,6 @@ describe( 'CLI: studio site create', () => {
 
 			const fsRmSpy = jest.spyOn( require( 'fs' ).promises, 'rm' ).mockResolvedValue( undefined );
 
-			const { runCommand } = await import( '../create' );
-
 			await expect( runCommand( mockSitePath, { ...defaultTestOptions } ) ).rejects.toThrow();
 
 			expect( fsRmSpy ).not.toHaveBeenCalled();
@@ -690,8 +629,6 @@ describe( 'CLI: studio site create', () => {
 			( runBlueprint as jest.Mock ).mockRejectedValue( new Error( 'Blueprint failed' ) );
 
 			const fsRmSpy = jest.spyOn( require( 'fs' ).promises, 'rm' ).mockResolvedValue( undefined );
-
-			const { runCommand } = await import( '../create' );
 
 			await expect(
 				runCommand( mockSitePath, {
@@ -715,8 +652,6 @@ describe( 'CLI: studio site create', () => {
 			( runBlueprint as jest.Mock ).mockRejectedValue( new Error( 'Blueprint failed' ) );
 
 			const fsRmSpy = jest.spyOn( require( 'fs' ).promises, 'rm' ).mockResolvedValue( undefined );
-
-			const { runCommand } = await import( '../create' );
 
 			await expect(
 				runCommand( mockSitePath, {

--- a/cli/commands/site/tests/delete.test.ts
+++ b/cli/commands/site/tests/delete.test.ts
@@ -15,6 +15,7 @@ import { connect, disconnect } from 'cli/lib/pm2-manager';
 import { stopProxyIfNoSitesNeedIt } from 'cli/lib/site-utils';
 import { getSnapshotsFromAppdata, deleteSnapshotFromAppdata } from 'cli/lib/snapshots';
 import { isServerRunning, stopWordPressServer } from 'cli/lib/wordpress-server-manager';
+import { runCommand } from '../delete';
 
 jest.mock( 'fs/promises' );
 jest.mock( 'cli/lib/api' );
@@ -121,16 +122,12 @@ describe( 'CLI: studio site delete', () => {
 		it( 'should throw when PM2 connection fails', async () => {
 			( connect as jest.Mock ).mockRejectedValue( new Error( 'PM2 connection failed' ) );
 
-			const { runCommand } = await import( '../delete' );
-
 			await expect( runCommand( testSiteFolder ) ).rejects.toThrow();
 			expect( disconnect ).toHaveBeenCalled();
 		} );
 
 		it( 'should throw when appdata read fails', async () => {
 			( readAppdata as jest.Mock ).mockRejectedValue( new Error( 'Read failed' ) );
-
-			const { runCommand } = await import( '../delete' );
 
 			await expect( runCommand( testSiteFolder ) ).rejects.toThrow();
 			expect( disconnect ).toHaveBeenCalled();
@@ -142,8 +139,6 @@ describe( 'CLI: studio site delete', () => {
 				snapshots: [],
 			} );
 
-			const { runCommand } = await import( '../delete' );
-
 			await expect( runCommand( testSiteFolder ) ).rejects.toThrow(
 				'The specified folder is not added to Studio.'
 			);
@@ -154,8 +149,6 @@ describe( 'CLI: studio site delete', () => {
 			( isServerRunning as jest.Mock ).mockResolvedValue( testProcessDescription );
 			( stopWordPressServer as jest.Mock ).mockRejectedValue( new Error( 'Server stop failed' ) );
 
-			const { runCommand } = await import( '../delete' );
-
 			await expect( runCommand( testSiteFolder ) ).rejects.toThrow();
 			expect( disconnect ).toHaveBeenCalled();
 		} );
@@ -165,7 +158,6 @@ describe( 'CLI: studio site delete', () => {
 				__esModule: true,
 				default: jest.fn().mockRejectedValueOnce( new Error( 'File deletion failed' ) ),
 			} ) );
-			const { runCommand } = await import( '../delete' );
 
 			await expect( runCommand( testSiteFolder, true ) ).rejects.toThrow( 'File deletion failed' );
 			expect( disconnect ).toHaveBeenCalled();
@@ -174,8 +166,6 @@ describe( 'CLI: studio site delete', () => {
 		it( 'should proceed when getAuthToken fails', async () => {
 			( getAuthToken as jest.Mock ).mockRejectedValue( new Error( 'Auth failed' ) );
 			( getSnapshotsFromAppdata as jest.Mock ).mockResolvedValue( [] );
-
-			const { runCommand } = await import( '../delete' );
 
 			await expect( runCommand( testSiteFolder, false ) ).resolves.not.toThrow();
 			expect( saveAppdata ).toHaveBeenCalled();
@@ -186,8 +176,6 @@ describe( 'CLI: studio site delete', () => {
 	describe( 'Success Cases', () => {
 		it( 'should delete a stopped site without removing files and no preview sites', async () => {
 			( getSnapshotsFromAppdata as jest.Mock ).mockResolvedValue( [] );
-
-			const { runCommand } = await import( '../delete' );
 
 			await runCommand( testSiteFolder, false );
 
@@ -208,8 +196,6 @@ describe( 'CLI: studio site delete', () => {
 			( isServerRunning as jest.Mock ).mockResolvedValue( testProcessDescription );
 			( getSnapshotsFromAppdata as jest.Mock ).mockResolvedValue( [] );
 
-			const { runCommand } = await import( '../delete' );
-
 			await runCommand( testSiteFolder, false );
 
 			expect( isServerRunning ).toHaveBeenCalledWith( testSite.id );
@@ -224,8 +210,6 @@ describe( 'CLI: studio site delete', () => {
 		it( 'should delete a site and remove files when files flag is set', async () => {
 			( getSnapshotsFromAppdata as jest.Mock ).mockResolvedValue( [] );
 
-			const { runCommand } = await import( '../delete' );
-
 			await runCommand( testSiteFolder, true );
 
 			expect( saveAppdata ).toHaveBeenCalled();
@@ -239,8 +223,6 @@ describe( 'CLI: studio site delete', () => {
 				testSnapshot1,
 				testSnapshot2,
 			] );
-
-			const { runCommand } = await import( '../delete' );
 
 			await runCommand( testSiteFolder );
 
@@ -261,8 +243,6 @@ describe( 'CLI: studio site delete', () => {
 		it( 'should delete a running site and remove files along with preview sites', async () => {
 			( isServerRunning as jest.Mock ).mockResolvedValue( testProcessDescription );
 			( getSnapshotsFromAppdata as jest.Mock ).mockResolvedValue( [ testSnapshot1 ] );
-
-			const { runCommand } = await import( '../delete' );
 
 			await runCommand( testSiteFolder, true );
 
@@ -285,8 +265,6 @@ describe( 'CLI: studio site delete', () => {
 			} );
 			( getSnapshotsFromAppdata as jest.Mock ).mockResolvedValue( [] );
 
-			const { runCommand } = await import( '../delete' );
-
 			await runCommand( testSiteFolder, false );
 
 			expect( removeDomainFromHosts ).toHaveBeenCalledWith( 'example.local' );
@@ -303,8 +281,6 @@ describe( 'CLI: studio site delete', () => {
 			} );
 			( getSnapshotsFromAppdata as jest.Mock ).mockResolvedValue( [] );
 
-			const { runCommand } = await import( '../delete' );
-
 			await runCommand( testSiteFolder, false );
 
 			expect( removeDomainFromHosts ).toHaveBeenCalledWith( 'example.local' );
@@ -314,8 +290,6 @@ describe( 'CLI: studio site delete', () => {
 
 		it( 'should not remove domain or certificate if no custom domain', async () => {
 			( getSnapshotsFromAppdata as jest.Mock ).mockResolvedValue( [] );
-
-			const { runCommand } = await import( '../delete' );
 
 			await runCommand( testSiteFolder, false );
 

--- a/cli/commands/site/tests/list.test.ts
+++ b/cli/commands/site/tests/list.test.ts
@@ -1,6 +1,7 @@
 import { readAppdata } from 'cli/lib/appdata';
 import { connect, disconnect } from 'cli/lib/pm2-manager';
 import { isServerRunning } from 'cli/lib/wordpress-server-manager';
+import { runCommand } from '../list';
 
 jest.mock( 'cli/lib/appdata', () => ( {
 	...jest.requireActual( 'cli/lib/appdata' ),
@@ -53,8 +54,6 @@ describe( 'CLI: studio site list', () => {
 		it( 'should throw when appdata read fails', async () => {
 			( readAppdata as jest.Mock ).mockRejectedValue( new Error( 'Failed to read appdata' ) );
 
-			const { runCommand } = await import( '../list' );
-
 			await expect( runCommand( 'table', false ) ).rejects.toThrow( 'Failed to read appdata' );
 			expect( disconnect ).toHaveBeenCalled();
 		} );
@@ -63,7 +62,6 @@ describe( 'CLI: studio site list', () => {
 	describe( 'Success Cases', () => {
 		it( 'should list sites with table format', async () => {
 			const consoleSpy = jest.spyOn( console, 'log' ).mockImplementation();
-			const { runCommand } = await import( '../list' );
 
 			await runCommand( 'table', false );
 
@@ -76,7 +74,6 @@ describe( 'CLI: studio site list', () => {
 
 		it( 'should list sites with json format', async () => {
 			const consoleSpy = jest.spyOn( console, 'log' ).mockImplementation();
-			const { runCommand } = await import( '../list' );
 
 			await runCommand( 'json', false );
 
@@ -110,8 +107,6 @@ describe( 'CLI: studio site list', () => {
 		it( 'should handle no sites found', async () => {
 			( readAppdata as jest.Mock ).mockResolvedValue( emptyAppdata );
 
-			const { runCommand } = await import( '../list' );
-
 			await runCommand( 'table', false );
 
 			expect( readAppdata ).toHaveBeenCalled();
@@ -120,7 +115,6 @@ describe( 'CLI: studio site list', () => {
 
 		it( 'should handle custom domain in site URL', async () => {
 			const consoleSpy = jest.spyOn( console, 'log' ).mockImplementation();
-			const { runCommand } = await import( '../list' );
 
 			await runCommand( 'json', false );
 

--- a/cli/commands/site/tests/set-domain.test.ts
+++ b/cli/commands/site/tests/set-domain.test.ts
@@ -17,6 +17,7 @@ import {
 	stopWordPressServer,
 } from 'cli/lib/wordpress-server-manager';
 import { Logger } from 'cli/logger';
+import { runCommand } from '../set-domain';
 
 jest.mock( 'cli/lib/appdata', () => ( {
 	...jest.requireActual( 'cli/lib/appdata' ),
@@ -91,8 +92,6 @@ describe( 'CLI: studio site set-domain', () => {
 				snapshots: [],
 			} );
 
-			const { runCommand } = await import( '../set-domain' );
-
 			await expect( runCommand( testSitePath, testDomainName ) ).rejects.toThrow(
 				'The specified folder is not added to Studio.'
 			);
@@ -104,8 +103,6 @@ describe( 'CLI: studio site set-domain', () => {
 				'Please enter a valid domain name'
 			);
 
-			const { runCommand } = await import( '../set-domain' );
-
 			await expect( runCommand( testSitePath, 'invalid domain' ) ).rejects.toThrow();
 			expect( saveAppdata ).not.toHaveBeenCalled();
 			expect( disconnect ).toHaveBeenCalled();
@@ -115,8 +112,6 @@ describe( 'CLI: studio site set-domain', () => {
 			( getDomainNameValidationError as jest.Mock ).mockReturnValue(
 				'The domain name is already in use'
 			);
-
-			const { runCommand } = await import( '../set-domain' );
 
 			await expect( runCommand( testSitePath, testDomainName ) ).rejects.toThrow();
 			expect( saveAppdata ).not.toHaveBeenCalled();
@@ -129,8 +124,6 @@ describe( 'CLI: studio site set-domain', () => {
 				snapshots: [],
 			} );
 
-			const { runCommand } = await import( '../set-domain' );
-
 			await expect( runCommand( testSitePath, testDomainName ) ).rejects.toThrow(
 				'The specified domain is already set for this site.'
 			);
@@ -141,8 +134,6 @@ describe( 'CLI: studio site set-domain', () => {
 		it( 'should throw when appdata save fails', async () => {
 			( saveAppdata as jest.Mock ).mockRejectedValue( new Error( 'Save failed' ) );
 
-			const { runCommand } = await import( '../set-domain' );
-
 			await expect( runCommand( testSitePath, testDomainName ) ).rejects.toThrow();
 			expect( disconnect ).toHaveBeenCalled();
 		} );
@@ -150,8 +141,6 @@ describe( 'CLI: studio site set-domain', () => {
 
 	describe( 'Success Cases', () => {
 		it( 'should set domain on a stopped site', async () => {
-			const { runCommand } = await import( '../set-domain' );
-
 			await runCommand( testSitePath, testDomainName );
 
 			expect( lockAppdata ).toHaveBeenCalled();
@@ -176,8 +165,6 @@ describe( 'CLI: studio site set-domain', () => {
 
 		it( 'should set domain and restart a running site', async () => {
 			( isServerRunning as jest.Mock ).mockResolvedValue( testProcessDescription );
-
-			const { runCommand } = await import( '../set-domain' );
 
 			await runCommand( testSitePath, testDomainName );
 
@@ -204,8 +191,6 @@ describe( 'CLI: studio site set-domain', () => {
 				sites: [ { ...testSite, customDomain: oldDomain } ],
 				snapshots: [],
 			} );
-
-			const { runCommand } = await import( '../set-domain' );
 
 			await runCommand( testSitePath, testDomainName );
 

--- a/cli/commands/site/tests/set-https.test.ts
+++ b/cli/commands/site/tests/set-https.test.ts
@@ -14,6 +14,7 @@ import {
 	stopWordPressServer,
 } from 'cli/lib/wordpress-server-manager';
 import { Logger } from 'cli/logger';
+import { runCommand } from '../set-https';
 
 jest.mock( 'cli/lib/appdata', () => ( {
 	...jest.requireActual( 'cli/lib/appdata' ),
@@ -85,8 +86,6 @@ describe( 'CLI: studio site set-https', () => {
 				snapshots: [],
 			} );
 
-			const { runCommand } = await import( '../set-https' );
-
 			await expect( runCommand( mockSiteFolder, true ) ).rejects.toThrow(
 				'The specified folder is not added to Studio.'
 			);
@@ -100,8 +99,6 @@ describe( 'CLI: studio site set-https', () => {
 				snapshots: [],
 			} );
 
-			const { runCommand } = await import( '../set-https' );
-
 			await expect( runCommand( mockSiteFolder, true ) ).rejects.toThrow(
 				'Site does not have a custom domain.'
 			);
@@ -114,8 +111,6 @@ describe( 'CLI: studio site set-https', () => {
 				snapshots: [],
 			} );
 
-			const { runCommand } = await import( '../set-https' );
-
 			await expect( runCommand( mockSiteFolder, true ) ).rejects.toThrow(
 				'HTTPS is already enabled for this site.'
 			);
@@ -125,16 +120,12 @@ describe( 'CLI: studio site set-https', () => {
 		it( 'should throw when appdata save fails', async () => {
 			( saveAppdata as jest.Mock ).mockRejectedValue( new Error( 'Save failed' ) );
 
-			const { runCommand } = await import( '../set-https' );
-
 			await expect( runCommand( mockSiteFolder, true ) ).rejects.toThrow();
 			expect( disconnect ).toHaveBeenCalled();
 		} );
 
 		it( 'should throw when PM2 connection fails', async () => {
 			( connect as jest.Mock ).mockRejectedValue( new Error( 'PM2 connection failed' ) );
-
-			const { runCommand } = await import( '../set-https' );
 
 			await expect( runCommand( mockSiteFolder, true ) ).rejects.toThrow();
 			expect( disconnect ).toHaveBeenCalled();
@@ -144,8 +135,6 @@ describe( 'CLI: studio site set-https', () => {
 			( isServerRunning as jest.Mock ).mockResolvedValue( mockProcessDescription );
 			( stopWordPressServer as jest.Mock ).mockRejectedValue( new Error( 'Server stop failed' ) );
 
-			const { runCommand } = await import( '../set-https' );
-
 			await expect( runCommand( mockSiteFolder, true ) ).rejects.toThrow();
 			expect( disconnect ).toHaveBeenCalled();
 		} );
@@ -153,8 +142,6 @@ describe( 'CLI: studio site set-https', () => {
 
 	describe( 'Success Cases', () => {
 		it( 'should enable HTTPS on a stopped site', async () => {
-			const { runCommand } = await import( '../set-https' );
-
 			await runCommand( mockSiteFolder, true );
 
 			expect( lockAppdata ).toHaveBeenCalled();
@@ -179,8 +166,6 @@ describe( 'CLI: studio site set-https', () => {
 				snapshots: [],
 			} );
 
-			const { runCommand } = await import( '../set-https' );
-
 			await runCommand( mockSiteFolder, false );
 
 			expect( saveAppdata ).toHaveBeenCalled();
@@ -195,8 +180,6 @@ describe( 'CLI: studio site set-https', () => {
 
 		it( 'should enable HTTPS and restart a running site', async () => {
 			( isServerRunning as jest.Mock ).mockResolvedValue( mockProcessDescription );
-
-			const { runCommand } = await import( '../set-https' );
 
 			await runCommand( mockSiteFolder, true );
 
@@ -224,8 +207,6 @@ describe( 'CLI: studio site set-https', () => {
 				snapshots: [],
 			} );
 			( isServerRunning as jest.Mock ).mockResolvedValue( mockProcessDescription );
-
-			const { runCommand } = await import( '../set-https' );
 
 			await runCommand( mockSiteFolder, false );
 

--- a/cli/commands/site/tests/set-php-version.test.ts
+++ b/cli/commands/site/tests/set-php-version.test.ts
@@ -15,6 +15,7 @@ import {
 	stopWordPressServer,
 } from 'cli/lib/wordpress-server-manager';
 import { Logger } from 'cli/logger';
+import { runCommand } from '../set-php-version';
 
 jest.mock( 'cli/lib/appdata', () => ( {
 	...jest.requireActual( 'cli/lib/appdata' ),
@@ -83,8 +84,6 @@ describe( 'CLI: studio site set-php-version', () => {
 
 	describe( 'Error Cases', () => {
 		it( 'should throw when PHP version is identical to current version', async () => {
-			const { runCommand } = await import( '../set-php-version' );
-
 			await expect( runCommand( testSitePath, '8.0' ) ).rejects.toThrow(
 				'Site is already using the specified PHP version.'
 			);
@@ -97,8 +96,6 @@ describe( 'CLI: studio site set-php-version', () => {
 				snapshots: [],
 			} );
 
-			const { runCommand } = await import( '../set-php-version' );
-
 			await expect( runCommand( testSitePath, '7.4' ) ).rejects.toThrow(
 				'The specified folder is not added to Studio.'
 			);
@@ -108,16 +105,12 @@ describe( 'CLI: studio site set-php-version', () => {
 		it( 'should throw when appdata save fails', async () => {
 			( saveAppdata as jest.Mock ).mockRejectedValue( new Error( 'Save failed' ) );
 
-			const { runCommand } = await import( '../set-php-version' );
-
 			await expect( runCommand( testSitePath, '7.4' ) ).rejects.toThrow();
 			expect( disconnect ).toHaveBeenCalled();
 		} );
 
 		it( 'should throw when PM2 connection fails', async () => {
 			( connect as jest.Mock ).mockRejectedValue( new Error( 'PM2 connection failed' ) );
-
-			const { runCommand } = await import( '../set-php-version' );
 
 			await expect( runCommand( testSitePath, '7.4' ) ).rejects.toThrow();
 			expect( disconnect ).toHaveBeenCalled();
@@ -127,8 +120,6 @@ describe( 'CLI: studio site set-php-version', () => {
 			( isServerRunning as jest.Mock ).mockResolvedValue( testProcessDescription );
 			( stopWordPressServer as jest.Mock ).mockRejectedValue( new Error( 'Server stop failed' ) );
 
-			const { runCommand } = await import( '../set-php-version' );
-
 			await expect( runCommand( testSitePath, '7.4' ) ).rejects.toThrow();
 			expect( disconnect ).toHaveBeenCalled();
 		} );
@@ -136,8 +127,6 @@ describe( 'CLI: studio site set-php-version', () => {
 
 	describe( 'Success Cases', () => {
 		it( 'should update PHP version on a stopped site', async () => {
-			const { runCommand } = await import( '../set-php-version' );
-
 			await runCommand( testSitePath, '7.4' );
 
 			expect( getSiteByFolder ).toHaveBeenCalledWith( testSitePath );
@@ -158,8 +147,6 @@ describe( 'CLI: studio site set-php-version', () => {
 
 		it( 'should update PHP version and restart a running site', async () => {
 			( isServerRunning as jest.Mock ).mockResolvedValue( testProcessDescription );
-
-			const { runCommand } = await import( '../set-php-version' );
 
 			await runCommand( testSitePath, '7.4' );
 

--- a/cli/commands/site/tests/set-wp-version.test.ts
+++ b/cli/commands/site/tests/set-wp-version.test.ts
@@ -16,6 +16,7 @@ import {
 	stopWordPressServer,
 } from 'cli/lib/wordpress-server-manager';
 import { Logger } from 'cli/logger';
+import { runCommand } from '../set-wp-version';
 
 jest.mock( 'cli/lib/appdata', () => ( {
 	...jest.requireActual( 'cli/lib/appdata' ),
@@ -96,8 +97,6 @@ describe( 'CLI: studio site set-wp-version', () => {
 				jest.fn().mockResolvedValue( undefined ),
 			] );
 
-			const { runCommand } = await import( '../set-wp-version' );
-
 			await expect( runCommand( testSitePath, '6.5' ) ).rejects.toThrow(
 				'Failed to update WordPress version to 6.5'
 			);
@@ -110,8 +109,6 @@ describe( 'CLI: studio site set-wp-version', () => {
 				snapshots: [],
 			} );
 
-			const { runCommand } = await import( '../set-wp-version' );
-
 			await expect( runCommand( testSitePath, '6.5' ) ).rejects.toThrow(
 				'The specified folder is not added to Studio.'
 			);
@@ -121,16 +118,12 @@ describe( 'CLI: studio site set-wp-version', () => {
 		it( 'should throw when appdata save fails', async () => {
 			( saveAppdata as jest.Mock ).mockRejectedValue( new Error( 'Save failed' ) );
 
-			const { runCommand } = await import( '../set-wp-version' );
-
 			await expect( runCommand( testSitePath, '6.5' ) ).rejects.toThrow();
 			expect( disconnect ).toHaveBeenCalled();
 		} );
 
 		it( 'should throw when PM2 connection fails', async () => {
 			( connect as jest.Mock ).mockRejectedValue( new Error( 'PM2 connection failed' ) );
-
-			const { runCommand } = await import( '../set-wp-version' );
 
 			await expect( runCommand( testSitePath, '6.5' ) ).rejects.toThrow();
 			expect( disconnect ).toHaveBeenCalled();
@@ -140,16 +133,12 @@ describe( 'CLI: studio site set-wp-version', () => {
 			( isServerRunning as jest.Mock ).mockResolvedValue( testProcessDescription );
 			( stopWordPressServer as jest.Mock ).mockRejectedValue( new Error( 'Server stop failed' ) );
 
-			const { runCommand } = await import( '../set-wp-version' );
-
 			await expect( runCommand( testSitePath, '6.5' ) ).rejects.toThrow();
 			expect( disconnect ).toHaveBeenCalled();
 		} );
 
 		it( 'should throw when WP-CLI command execution fails', async () => {
 			( runWpCliCommand as jest.Mock ).mockRejectedValue( new Error( 'WP-CLI failed' ) );
-
-			const { runCommand } = await import( '../set-wp-version' );
 
 			await expect( runCommand( testSitePath, '6.5' ) ).rejects.toThrow();
 			expect( disconnect ).toHaveBeenCalled();
@@ -158,8 +147,6 @@ describe( 'CLI: studio site set-wp-version', () => {
 
 	describe( 'Success Cases', () => {
 		it( 'should update WordPress version on a stopped site', async () => {
-			const { runCommand } = await import( '../set-wp-version' );
-
 			await runCommand( testSitePath, '6.5' );
 
 			expect( getSiteByFolder ).toHaveBeenCalledWith( testSitePath );
@@ -191,8 +178,6 @@ describe( 'CLI: studio site set-wp-version', () => {
 
 		it( 'should update WordPress version and restart a running site', async () => {
 			( isServerRunning as jest.Mock ).mockResolvedValue( testProcessDescription );
-
-			const { runCommand } = await import( '../set-wp-version' );
 
 			await runCommand( testSitePath, '6.5' );
 

--- a/cli/commands/site/tests/start.test.ts
+++ b/cli/commands/site/tests/start.test.ts
@@ -9,6 +9,7 @@ import { logSiteDetails, openSiteInBrowser, setupCustomDomain } from 'cli/lib/si
 import { keepSqliteIntegrationUpdated } from 'cli/lib/sqlite-integration';
 import { isServerRunning, startWordPressServer } from 'cli/lib/wordpress-server-manager';
 import { Logger } from 'cli/logger';
+import { runCommand } from '../start';
 
 jest.mock( 'cli/lib/appdata', () => ( {
 	...jest.requireActual( 'cli/lib/appdata' ),
@@ -67,8 +68,6 @@ describe( 'CLI: studio site start', () => {
 		it( 'should throw when site not found', async () => {
 			( getSiteByFolder as jest.Mock ).mockRejectedValue( new Error( 'Site not found' ) );
 
-			const { runCommand } = await import( '../start' );
-
 			await expect( runCommand( '/invalid/path' ) ).rejects.toThrow( 'Site not found' );
 			expect( disconnect ).toHaveBeenCalled();
 		} );
@@ -76,16 +75,12 @@ describe( 'CLI: studio site start', () => {
 		it( 'should throw when PM2 connection fails', async () => {
 			( connect as jest.Mock ).mockRejectedValue( new Error( 'PM2 connection failed' ) );
 
-			const { runCommand } = await import( '../start' );
-
 			await expect( runCommand( '/test/site' ) ).rejects.toThrow( 'PM2 connection failed' );
 			expect( disconnect ).toHaveBeenCalled();
 		} );
 
 		it( 'should throw when WordPress server fails to start', async () => {
 			( startWordPressServer as jest.Mock ).mockRejectedValue( new Error( 'Server start failed' ) );
-
-			const { runCommand } = await import( '../start' );
 
 			await expect( runCommand( '/test/site' ) ).rejects.toThrow(
 				'Failed to start WordPress server'
@@ -99,8 +94,6 @@ describe( 'CLI: studio site start', () => {
 				new Error( ' Custom domain setup failed' )
 			);
 
-			const { runCommand } = await import( '../start' );
-
 			await expect( runCommand( '/test/site' ) ).rejects.toThrow( 'Custom domain setup failed' );
 			expect( disconnect ).toHaveBeenCalled();
 		} );
@@ -110,16 +103,12 @@ describe( 'CLI: studio site start', () => {
 				new Error( 'SQLite setup failed' )
 			);
 
-			const { runCommand } = await import( '../start' );
-
 			await expect( runCommand( '/test/site' ) ).rejects.toThrow( 'SQLite setup failed' );
 			expect( disconnect ).toHaveBeenCalled();
 		} );
 
 		it( 'should throw when browser fails', async () => {
 			( openSiteInBrowser as jest.Mock ).mockRejectedValue( new Error( 'Browser error' ) );
-
-			const { runCommand } = await import( '../start' );
 
 			await expect( runCommand( '/test/site' ) ).rejects.toThrow( 'Browser error' );
 			expect( disconnect ).toHaveBeenCalled();
@@ -129,8 +118,6 @@ describe( 'CLI: studio site start', () => {
 			( isServerRunning as jest.Mock ).mockResolvedValue( testProcessDescription );
 			( openSiteInBrowser as jest.Mock ).mockRejectedValue( new Error( 'Browser error' ) );
 
-			const { runCommand } = await import( '../start' );
-
 			await expect( runCommand( '/test/site' ) ).rejects.toThrow( 'Browser error' );
 			expect( disconnect ).toHaveBeenCalled();
 		} );
@@ -138,8 +125,6 @@ describe( 'CLI: studio site start', () => {
 
 	describe( 'Success Cases', () => {
 		it( 'should start a basic site', async () => {
-			const { runCommand } = await import( '../start' );
-
 			await runCommand( '/test/site' );
 
 			expect( getSiteByFolder ).toHaveBeenCalledWith( '/test/site' );
@@ -161,8 +146,6 @@ describe( 'CLI: studio site start', () => {
 		it( 'should skip server start if already running', async () => {
 			( isServerRunning as jest.Mock ).mockResolvedValue( testProcessDescription );
 
-			const { runCommand } = await import( '../start' );
-
 			await runCommand( '/test/site' );
 
 			expect( startWordPressServer ).not.toHaveBeenCalled();
@@ -179,8 +162,6 @@ describe( 'CLI: studio site start', () => {
 		it( 'should setup custom domain when present', async () => {
 			( getSiteByFolder as jest.Mock ).mockResolvedValue( testSiteWithDomain );
 
-			const { runCommand } = await import( '../start' );
-
 			await runCommand( '/test/site' );
 
 			expect( setupCustomDomain ).toHaveBeenCalledWith( testSiteWithDomain, expect.any( Logger ) );
@@ -192,16 +173,12 @@ describe( 'CLI: studio site start', () => {
 		} );
 
 		it( 'should update SQLite integration', async () => {
-			const { runCommand } = await import( '../start' );
-
 			await runCommand( '/test/site' );
 
 			expect( keepSqliteIntegrationUpdated ).toHaveBeenCalledWith( '/test/site' );
 		} );
 
 		it( 'should skip browser when skipBrowser is true', async () => {
-			const { runCommand } = await import( '../start' );
-
 			await runCommand( '/test/site', true );
 
 			expect( startWordPressServer ).toHaveBeenCalledWith( testSite, expect.any( Logger ) );
@@ -212,8 +189,6 @@ describe( 'CLI: studio site start', () => {
 
 		it( 'should skip browser when already running and skipBrowser is true', async () => {
 			( isServerRunning as jest.Mock ).mockResolvedValue( testProcessDescription );
-
-			const { runCommand } = await import( '../start' );
 
 			await runCommand( '/test/site', true );
 

--- a/cli/commands/site/tests/status.test.ts
+++ b/cli/commands/site/tests/status.test.ts
@@ -2,6 +2,7 @@ import { getWordPressVersion } from 'common/lib/get-wordpress-version';
 import { getSiteByFolder, getSiteUrl } from 'cli/lib/appdata';
 import { connect, disconnect } from 'cli/lib/pm2-manager';
 import { isServerRunning } from 'cli/lib/wordpress-server-manager';
+import { runCommand } from '../status';
 
 jest.mock( 'cli/lib/appdata', () => ( {
 	...jest.requireActual( 'cli/lib/appdata' ),
@@ -49,8 +50,6 @@ describe( 'CLI: studio site status', () => {
 		it( 'should throw when site not found', async () => {
 			( getSiteByFolder as jest.Mock ).mockRejectedValue( new Error( 'Site not found' ) );
 
-			const { runCommand } = await import( '../status' );
-
 			await expect( runCommand( '/invalid/path', 'table' ) ).rejects.toThrow( 'Site not found' );
 			expect( disconnect ).toHaveBeenCalled();
 		} );
@@ -58,8 +57,6 @@ describe( 'CLI: studio site status', () => {
 
 	describe( 'Success Cases', () => {
 		it( 'should display site status with table format', async () => {
-			const { runCommand } = await import( '../status' );
-
 			await runCommand( '/path/to/site', 'table' );
 
 			expect( getSiteByFolder ).toHaveBeenCalledWith( '/path/to/site' );
@@ -70,8 +67,6 @@ describe( 'CLI: studio site status', () => {
 
 		it( 'should output JSON format correctly', async () => {
 			const consoleSpy = jest.spyOn( console, 'log' ).mockImplementation();
-
-			const { runCommand } = await import( '../status' );
 
 			await runCommand( '/path/to/site', 'json' );
 
@@ -98,8 +93,6 @@ describe( 'CLI: studio site status', () => {
 			( isServerRunning as jest.Mock ).mockResolvedValue( { pid: 12345 } );
 
 			const consoleSpy = jest.spyOn( console, 'log' ).mockImplementation();
-
-			const { runCommand } = await import( '../status' );
 
 			await runCommand( '/path/to/site', 'json' );
 
@@ -128,8 +121,6 @@ describe( 'CLI: studio site status', () => {
 
 			const consoleSpy = jest.spyOn( console, 'log' ).mockImplementation();
 
-			const { runCommand } = await import( '../status' );
-
 			await runCommand( '/path/to/site', 'json' );
 
 			expect( consoleSpy ).toHaveBeenCalledWith(
@@ -143,8 +134,6 @@ describe( 'CLI: studio site status', () => {
 			( getSiteByFolder as jest.Mock ).mockResolvedValue( testSiteWithoutOptional );
 
 			const consoleSpy = jest.spyOn( console, 'log' ).mockImplementation();
-
-			const { runCommand } = await import( '../status' );
 
 			await runCommand( '/path/to/site', 'json' );
 
@@ -170,8 +159,6 @@ describe( 'CLI: studio site status', () => {
 
 	describe( 'Cleanup', () => {
 		it( 'should always disconnect from PM2 on success', async () => {
-			const { runCommand } = await import( '../status' );
-
 			await runCommand( '/path/to/site', 'table' );
 
 			expect( disconnect ).toHaveBeenCalled();
@@ -179,8 +166,6 @@ describe( 'CLI: studio site status', () => {
 
 		it( 'should always disconnect from PM2 on error', async () => {
 			( getSiteByFolder as jest.Mock ).mockRejectedValue( new Error( 'Error' ) );
-
-			const { runCommand } = await import( '../status' );
 
 			try {
 				await runCommand( '/path/to/site', 'table' );

--- a/cli/commands/site/tests/stop-all.test.ts
+++ b/cli/commands/site/tests/stop-all.test.ts
@@ -2,6 +2,7 @@ import { SiteData, clearSiteLatestCliPid, readAppdata } from 'cli/lib/appdata';
 import { connect, disconnect } from 'cli/lib/pm2-manager';
 import { stopProxyIfNoSitesNeedIt } from 'cli/lib/site-utils';
 import { isServerRunning, stopWordPressServer } from 'cli/lib/wordpress-server-manager';
+import { runCommand } from '../stop-all';
 
 jest.mock( 'cli/lib/appdata', () => ( {
 	...jest.requireActual( 'cli/lib/appdata' ),
@@ -69,8 +70,6 @@ describe( 'CLI: studio site stop-all', () => {
 		it( 'should throw when appdata cannot be read', async () => {
 			( readAppdata as jest.Mock ).mockRejectedValue( new Error( 'Failed to read appdata' ) );
 
-			const { runCommand } = await import( '../stop-all' );
-
 			await expect( runCommand( false ) ).rejects.toThrow( 'Failed to read appdata' );
 			expect( disconnect ).toHaveBeenCalled();
 		} );
@@ -78,8 +77,6 @@ describe( 'CLI: studio site stop-all', () => {
 		it( 'should throw when PM2 connection fails', async () => {
 			( readAppdata as jest.Mock ).mockResolvedValue( { sites: testSites } );
 			( connect as jest.Mock ).mockRejectedValue( new Error( 'PM2 connection failed' ) );
-
-			const { runCommand } = await import( '../stop-all' );
 
 			await expect( runCommand( false ) ).rejects.toThrow( 'PM2 connection failed' );
 			expect( disconnect ).toHaveBeenCalled();
@@ -89,8 +86,6 @@ describe( 'CLI: studio site stop-all', () => {
 			( readAppdata as jest.Mock ).mockResolvedValue( { sites: testSites } );
 			( isServerRunning as jest.Mock ).mockResolvedValue( testProcessDescription );
 			( stopWordPressServer as jest.Mock ).mockRejectedValue( new Error( 'Server stop failed' ) );
-
-			const { runCommand } = await import( '../stop-all' );
 
 			await expect( runCommand( false ) ).rejects.toThrow( 'Failed to stop all (3) sites' );
 			expect( disconnect ).toHaveBeenCalled();
@@ -105,8 +100,6 @@ describe( 'CLI: studio site stop-all', () => {
 				.mockRejectedValueOnce( new Error( 'Server stop failed' ) ) // site-2 fails
 				.mockResolvedValueOnce( undefined ); // site-3 success
 
-			const { runCommand } = await import( '../stop-all' );
-
 			await expect( runCommand( false ) ).rejects.toThrow( 'Stopped 2 sites out of 3' );
 			expect( disconnect ).toHaveBeenCalled();
 			expect( stopWordPressServer ).toHaveBeenCalledTimes( 3 );
@@ -116,8 +109,6 @@ describe( 'CLI: studio site stop-all', () => {
 	describe( 'Success Cases', () => {
 		it( 'should handle empty sites list', async () => {
 			( readAppdata as jest.Mock ).mockResolvedValue( { sites: [] } );
-
-			const { runCommand } = await import( '../stop-all' );
 
 			await runCommand( false );
 
@@ -129,8 +120,6 @@ describe( 'CLI: studio site stop-all', () => {
 			( readAppdata as jest.Mock ).mockResolvedValue( { sites: testSites } );
 
 			( isServerRunning as jest.Mock ).mockResolvedValue( undefined );
-
-			const { runCommand } = await import( '../stop-all' );
 
 			await runCommand( false );
 
@@ -146,8 +135,6 @@ describe( 'CLI: studio site stop-all', () => {
 			( readAppdata as jest.Mock ).mockResolvedValue( { sites: [ testSites[ 0 ] ] } );
 			( isServerRunning as jest.Mock ).mockResolvedValue( testProcessDescription );
 
-			const { runCommand } = await import( '../stop-all' );
-
 			await runCommand( false );
 
 			expect( stopWordPressServer ).toHaveBeenCalledTimes( 1 );
@@ -158,8 +145,6 @@ describe( 'CLI: studio site stop-all', () => {
 		it( 'should stop all running sites', async () => {
 			( readAppdata as jest.Mock ).mockResolvedValue( { sites: testSites } );
 			( isServerRunning as jest.Mock ).mockResolvedValue( testProcessDescription );
-
-			const { runCommand } = await import( '../stop-all' );
 
 			await runCommand( false );
 
@@ -195,8 +180,6 @@ describe( 'CLI: studio site stop-all', () => {
 				.mockResolvedValueOnce( undefined ) // site-2 not running
 				.mockResolvedValueOnce( testProcessDescription ); // site-3 running
 
-			const { runCommand } = await import( '../stop-all' );
-
 			await runCommand( false );
 
 			expect( isServerRunning ).toHaveBeenCalledTimes( 3 );
@@ -219,8 +202,6 @@ describe( 'CLI: studio site stop-all', () => {
 				.mockRejectedValueOnce( new Error( 'Server stop failed' ) ) // site-2 fails
 				.mockResolvedValueOnce( undefined ); // site-3 success
 
-			const { runCommand } = await import( '../stop-all' );
-
 			try {
 				await runCommand( false );
 			} catch {
@@ -242,8 +223,6 @@ describe( 'CLI: studio site stop-all', () => {
 				new Error( 'Proxy stop failed' )
 			);
 
-			const { runCommand } = await import( '../stop-all' );
-
 			// Should throw when proxy stop fails
 			await expect( runCommand( false ) ).rejects.toThrow( 'Failed to stop proxy server' );
 
@@ -257,8 +236,6 @@ describe( 'CLI: studio site stop-all', () => {
 			( readAppdata as jest.Mock ).mockResolvedValue( { sites: testSites } );
 			( isServerRunning as jest.Mock ).mockResolvedValue( testProcessDescription );
 
-			const { runCommand } = await import( '../stop-all' );
-
 			await runCommand( false );
 
 			expect( disconnect ).toHaveBeenCalled();
@@ -266,8 +243,6 @@ describe( 'CLI: studio site stop-all', () => {
 
 		it( 'should always disconnect from PM2 on error', async () => {
 			( readAppdata as jest.Mock ).mockRejectedValue( new Error( 'Error' ) );
-
-			const { runCommand } = await import( '../stop-all' );
 
 			try {
 				await runCommand( false );
@@ -281,8 +256,6 @@ describe( 'CLI: studio site stop-all', () => {
 		it( 'should always disconnect when no sites exist', async () => {
 			( readAppdata as jest.Mock ).mockResolvedValue( { sites: [] } );
 
-			const { runCommand } = await import( '../stop-all' );
-
 			await runCommand( false );
 
 			expect( disconnect ).toHaveBeenCalled();
@@ -291,8 +264,6 @@ describe( 'CLI: studio site stop-all', () => {
 		it( 'should always disconnect when no sites are running', async () => {
 			( readAppdata as jest.Mock ).mockResolvedValue( { sites: testSites } );
 			( isServerRunning as jest.Mock ).mockResolvedValue( undefined );
-
-			const { runCommand } = await import( '../stop-all' );
 
 			await runCommand( false );
 

--- a/cli/commands/site/tests/stop.test.ts
+++ b/cli/commands/site/tests/stop.test.ts
@@ -7,6 +7,7 @@ import {
 import { connect, disconnect } from 'cli/lib/pm2-manager';
 import { stopProxyIfNoSitesNeedIt } from 'cli/lib/site-utils';
 import { isServerRunning, stopWordPressServer } from 'cli/lib/wordpress-server-manager';
+import { runCommand } from '../stop';
 
 jest.mock( 'cli/lib/appdata', () => ( {
 	...jest.requireActual( 'cli/lib/appdata' ),
@@ -56,16 +57,12 @@ describe( 'CLI: studio site stop', () => {
 		it( 'should throw when site not found', async () => {
 			( getSiteByFolder as jest.Mock ).mockRejectedValue( new Error( 'Site not found' ) );
 
-			const { runCommand } = await import( '../stop' );
-
 			await expect( runCommand( '/invalid/path', false ) ).rejects.toThrow( 'Site not found' );
 			expect( disconnect ).toHaveBeenCalled();
 		} );
 
 		it( 'should throw when PM2 connection fails', async () => {
 			( connect as jest.Mock ).mockRejectedValue( new Error( 'PM2 connection failed' ) );
-
-			const { runCommand } = await import( '../stop' );
 
 			await expect( runCommand( '/test/site', false ) ).rejects.toThrow( 'PM2 connection failed' );
 			expect( disconnect ).toHaveBeenCalled();
@@ -74,8 +71,6 @@ describe( 'CLI: studio site stop', () => {
 		it( 'should throw when WordPress server stop fails', async () => {
 			( isServerRunning as jest.Mock ).mockResolvedValue( testProcessDescription );
 			( stopWordPressServer as jest.Mock ).mockRejectedValue( new Error( 'Server stop failed' ) );
-
-			const { runCommand } = await import( '../stop' );
 
 			await expect( runCommand( '/test/site', false ) ).rejects.toThrow(
 				'Failed to stop WordPress server'
@@ -86,8 +81,6 @@ describe( 'CLI: studio site stop', () => {
 
 	describe( 'Success Cases', () => {
 		it( 'should skip stop if server is not running', async () => {
-			const { runCommand } = await import( '../stop' );
-
 			await runCommand( '/test/site', false );
 
 			expect( stopWordPressServer ).not.toHaveBeenCalled();
@@ -98,8 +91,6 @@ describe( 'CLI: studio site stop', () => {
 
 		it( 'should stop a running site', async () => {
 			( isServerRunning as jest.Mock ).mockResolvedValue( testProcessDescription );
-
-			const { runCommand } = await import( '../stop' );
 
 			await runCommand( '/test/site', false );
 
@@ -113,8 +104,6 @@ describe( 'CLI: studio site stop', () => {
 		} );
 
 		it( 'should not call stopProxyIfNoSitesNeedIt if site is not running', async () => {
-			const { runCommand } = await import( '../stop' );
-
 			await runCommand( '/test/site', false );
 
 			expect( stopProxyIfNoSitesNeedIt ).not.toHaveBeenCalled();
@@ -124,8 +113,6 @@ describe( 'CLI: studio site stop', () => {
 		it( 'should set autoStart to true when flag is passed', async () => {
 			( isServerRunning as jest.Mock ).mockResolvedValue( testProcessDescription );
 
-			const { runCommand } = await import( '../stop' );
-
 			await runCommand( '/test/site', true );
 
 			expect( updateSiteAutoStart ).toHaveBeenCalledWith( testSite.id, true );
@@ -133,8 +120,6 @@ describe( 'CLI: studio site stop', () => {
 
 		it( 'should set autoStart to false when flag is not passed', async () => {
 			( isServerRunning as jest.Mock ).mockResolvedValue( testProcessDescription );
-
-			const { runCommand } = await import( '../stop' );
 
 			await runCommand( '/test/site', false );
 
@@ -144,8 +129,6 @@ describe( 'CLI: studio site stop', () => {
 
 	describe( 'Cleanup', () => {
 		it( 'should always disconnect from PM2 on success', async () => {
-			const { runCommand } = await import( '../stop' );
-
 			await runCommand( '/test/site', false );
 
 			expect( disconnect ).toHaveBeenCalled();
@@ -153,8 +136,6 @@ describe( 'CLI: studio site stop', () => {
 
 		it( 'should always disconnect from PM2 on error', async () => {
 			( getSiteByFolder as jest.Mock ).mockRejectedValue( new Error( 'Error' ) );
-
-			const { runCommand } = await import( '../stop' );
 
 			try {
 				await runCommand( '/test/site', false );
@@ -166,8 +147,6 @@ describe( 'CLI: studio site stop', () => {
 		} );
 
 		it( 'should always disconnect when site is not running', async () => {
-			const { runCommand } = await import( '../stop' );
-
 			await runCommand( '/test/site', false );
 
 			expect( disconnect ).toHaveBeenCalled();


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-1187

## Proposed Changes

@wojtekn asked (p1766602221612649-slack-C06DRMD6VPZ) why we dynamically import the `runCommand` functions in the CLI tests. When I dug into this, I quickly concluded that it's not necessary. Static imports yield better performance and better error propagation.

So, why did we use the dynamic imports previously? I believe it's because we used to call `process.exit()` in some of the CLI command implementations, and dynamically importing the functions helped work around that in the tests. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Unit tests should pass

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?