### PR TITLE
CLI: Hide `--path` option for relevant commands

### DIFF
--- a/cli/commands/auth/login.ts
+++ b/cli/commands/auth/login.ts
@@ -92,6 +92,11 @@ export const registerCommand = ( yargs: StudioArgv ) => {
 	return yargs.command( {
 		command: 'login',
 		describe: __( 'Log in to WordPress.com' ),
+		builder: ( yargs ) => {
+			return yargs.option( 'path', {
+				hidden: true,
+			} );
+		},
 		handler: async () => {
 			await runCommand();
 		},

--- a/cli/commands/auth/logout.ts
+++ b/cli/commands/auth/logout.ts
@@ -47,6 +47,11 @@ export const registerCommand = ( yargs: StudioArgv ) => {
 	return yargs.command( {
 		command: 'logout',
 		describe: __( 'Log out and clear WordPress.com authentication' ),
+		builder: ( yargs ) => {
+			return yargs.option( 'path', {
+				hidden: true,
+			} );
+		},
 		handler: async () => {
 			await runCommand();
 		},

--- a/cli/commands/auth/status.ts
+++ b/cli/commands/auth/status.ts
@@ -36,6 +36,11 @@ export const registerCommand = ( yargs: StudioArgv ) => {
 	return yargs.command( {
 		command: 'status',
 		describe: __( 'Check authentication status' ),
+		builder: ( yargs ) => {
+			return yargs.option( 'path', {
+				hidden: true,
+			} );
+		},
 		handler: async () => {
 			await runCommand();
 		},

--- a/cli/commands/preview/delete.ts
+++ b/cli/commands/preview/delete.ts
@@ -44,11 +44,15 @@ export const registerCommand = ( yargs: StudioArgv ) => {
 		command: 'delete <host>',
 		describe: __( 'Delete a preview site' ),
 		builder: ( yargs ) => {
-			return yargs.positional( 'host', {
-				type: 'string',
-				description: __( 'Hostname of the preview site to delete' ),
-				demandOption: true,
-			} );
+			return yargs
+				.positional( 'host', {
+					type: 'string',
+					description: __( 'Hostname of the preview site to delete' ),
+					demandOption: true,
+				} )
+				.option( 'path', {
+					hidden: true,
+				} );
 		},
 		handler: async ( argv ) => {
 			const normalizedHost = normalizeHostname( argv.host );

--- a/cli/commands/site/list.ts
+++ b/cli/commands/site/list.ts
@@ -150,6 +150,9 @@ export const registerCommand = ( yargs: StudioArgv ) => {
 					type: 'boolean',
 					default: false,
 					description: __( 'Watch for site status changes and update the list in real-time' ),
+				} )
+				.option( 'path', {
+					hidden: true,
 				} );
 		},
 		handler: async ( argv ) => {

--- a/cli/commands/site/stop-all.ts
+++ b/cli/commands/site/stop-all.ts
@@ -116,12 +116,16 @@ export const registerCommand = ( yargs: StudioArgv ) => {
 		command: 'stop-all',
 		describe: __( 'Stop all local sites' ),
 		builder: ( yargs ) => {
-			return yargs.option( 'auto-start', {
-				type: 'boolean',
-				describe: __( 'Set auto-start flag for all sites' ),
-				default: false,
-				hidden: true,
-			} );
+			return yargs
+				.option( 'auto-start', {
+					type: 'boolean',
+					describe: __( 'Set auto-start flag for all sites' ),
+					default: false,
+					hidden: true,
+				} )
+				.option( 'path', {
+					hidden: true,
+				} );
 		},
 		handler: async ( argv ) => {
 			try {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-1190

## Proposed Changes

- Hide the global CLI `--path` option for the commands where it isn't actually used. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Run `npm run cli:build`
2. Run `node dist/cli/main.js auth login --help` 
3. Ensure that the `--path` option isn't included in the help output
4. Repeat the process for the other affected commands

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
