### PR TITLE
Use `yauzl` module in `scripts/download-wp-server-files.ts`

### DIFF
--- a/scripts/download-wp-server-files.ts
+++ b/scripts/download-wp-server-files.ts
@@ -1,7 +1,8 @@
 import os from 'os';
 import path from 'path';
-import unzipper from 'unzipper';
 import fs from 'fs-extra';
+import { promisify } from 'util';
+import yauzl from 'yauzl';
 import { getLatestSQLiteCommandRelease } from '../src/lib/sqlite-command-release';
 import { SQLITE_DATABASE_INTEGRATION_RELEASE_URL } from '../src/constants';
 
@@ -44,6 +45,62 @@ const FILES_TO_DOWNLOAD: FileToDownload[] = [
 	},
 ];
 
+const openZip = promisify< string, yauzl.Options, yauzl.ZipFile >( yauzl.open );
+
+async function extractZip( zipPath: string, extractedPath: string ): Promise< void > {
+	const zipFile = await openZip( zipPath, { lazyEntries: true } );
+	const openReadStream = promisify( zipFile.openReadStream.bind( zipFile ) );
+
+	return new Promise( ( resolve, reject ) => {
+		zipFile.on( 'entry', async ( entry: yauzl.Entry ) => {
+			// Skip directory entries
+			if ( entry.fileName.endsWith( '/' ) ) {
+				zipFile.readEntry();
+				return;
+			}
+
+			const fullPath = path.join( extractedPath, entry.fileName );
+			const entryDir = path.dirname( fullPath );
+
+			try {
+				await fs.ensureDir( entryDir );
+
+				const readStream = await openReadStream( entry );
+				const writeStream = fs.createWriteStream( fullPath );
+
+				function onError( error: Error ) {
+					if ( ! readStream.destroyed ) {
+						readStream.destroy();
+					}
+					if ( ! writeStream.destroyed ) {
+						writeStream.destroy();
+					}
+					reject( error );
+				}
+
+				readStream.once( 'error', onError );
+				writeStream.once( 'error', onError );
+
+				writeStream.once( 'finish', () => {
+					zipFile.readEntry();
+				} );
+
+				readStream.pipe( writeStream );
+			} catch ( error ) {
+				reject( error );
+			}
+		} );
+
+		zipFile.on( 'end', () => {
+			resolve();
+		} );
+
+		zipFile.on( 'error', reject );
+
+		zipFile.readEntry();
+	} );
+}
+
 async function downloadFile( file: FileToDownload ): Promise< void > {
 	const { name, description, destinationPath } = file;
 	console.log( `[${ name }] Downloading ${ description } ...` );
@@ -51,7 +108,7 @@ async function downloadFile( file: FileToDownload ): Promise< void > {
 	const extractedPath = destinationPath ?? WP_SERVER_FILES_PATH;
 
 	try {
-		fs.ensureDirSync( extractedPath );
+		await fs.ensureDir( extractedPath );
 	} catch ( error ) {
 		const fsError = error as { code: string };
 		if ( fsError.code !== 'EEXIST' ) throw error;
@@ -75,10 +132,7 @@ async function downloadFile( file: FileToDownload ): Promise< void > {
 		 * We need to move the contents of that folder to the sqlite-database-integration folder
 		 */
 		console.log( `[${ name }] Extracting files from zip ...` );
-		await fs
-			.createReadStream( zipPath )
-			.pipe( unzipper.Extract( { path: extractedPath } ) )
-			.promise();
+		await extractZip( zipPath, extractedPath );
 
 		const files = fs.readdirSync( extractedPath );
 		const sqliteFolder = files.find( ( file ) =>
@@ -95,13 +149,11 @@ async function downloadFile( file: FileToDownload ): Promise< void > {
 		}
 	} else {
 		console.log( `[${ name }] Extracting files from zip ...` );
-		await fs
-			.createReadStream( zipPath )
-			.pipe( unzipper.Extract( { path: extractedPath } ) )
-			.promise();
+		await extractZip( zipPath, extractedPath );
 	}
 
 	console.log( `[${ name }] Files extracted` );
+	await fs.remove( zipPath );
 }
 
 async function downloadFiles() {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Related to STU-1185

## Proposed Changes

In the 1.6.8-beta2 build, the `server-files/sqlite-command` directory contents were incomplete. Our most plausible explanation for this is that the `unzipper` module failed in some way, since the [latest Automattic/wp-cli-sqlite-command release](https://github.com/Automattic/wp-cli-sqlite-command/releases/tag/v1.1.5) ZIP archive contains the files we expect (but the 1.6.8-beta2 installer does not). 

This PR addresses the problem by replacing the `unzipper` module with `yauzl`, which we successfully use elsewhere in Studio. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Remove the `./wp-files` directory
2. Run `npx ts-node scripts/download-wp-server-files.ts`
3. Ensure that the `./wp-files` directory is recreated
4. Run `npm start`
5. Ensure that you can successfully do a full site export

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
