### PR TITLE
Refine export exclusion patterns

### DIFF
--- a/src/lib/import-export/export/exporters/default-exporter.ts
+++ b/src/lib/import-export/export/exporters/default-exporter.ts
@@ -27,7 +27,7 @@ export class DefaultExporter extends EventEmitter implements Exporter {
 	private backup: BackupContents;
 	private readonly options: ExportOptions;
 
-	private isExactPathExcluded( pathToCheck: string ) {
+	isExactPathExcluded( pathToCheck: string ) {
 		const PATHS_TO_EXCLUDE = [
 			'wp-content/mu-plugins/sqlite-database-integration',
 			'wp-content/database',
@@ -50,17 +50,18 @@ export class DefaultExporter extends EventEmitter implements Exporter {
 		);
 	}
 
-	// Look for directory names in a given path. If found, determine whether that part of the path is
-	// a directory or not.
-	private isPathExcludedByPattern( pathToCheck: string ) {
+	// Look for disallowed directory names in a given path. If found, determine whether that part of
+	// the path is a directory or not.
+	isPathExcludedByPattern( pathToCheck: string ) {
 		const DIRECTORY_NAMES_TO_EXCLUDE = [ '.git', 'node_modules', 'cache' ];
-		const offenderRegex = new RegExp(
-			`${ path.sep }(${ DIRECTORY_NAMES_TO_EXCLUDE.join( '|' ) })(${ path.sep }|$)`,
-			'g'
-		);
+		const pathParts = pathToCheck.split( path.sep );
 
-		if ( offenderRegex.test( pathToCheck ) ) {
-			const offenderPath = pathToCheck.substring( 0, offenderRegex.lastIndex );
+		for ( const directoryName of DIRECTORY_NAMES_TO_EXCLUDE ) {
+			if ( ! pathParts.includes( directoryName ) ) {
+				continue;
+			}
+			const offenderIndex = pathToCheck.lastIndexOf( directoryName );
+			const offenderPath = pathToCheck.substring( 0, offenderIndex + directoryName.length );
 			try {
 				const stat = fs.statSync( offenderPath );
 				return stat.isDirectory();

--- a/src/lib/import-export/export/exporters/default-exporter.ts
+++ b/src/lib/import-export/export/exporters/default-exporter.ts
@@ -50,17 +50,26 @@ export class DefaultExporter extends EventEmitter implements Exporter {
 		);
 	}
 
+	// Look for directory names in a given path. If found, determine whether that part of the path is
+	// a directory or not.
 	private isPathExcludedByPattern( pathToCheck: string ) {
-		const stat = fs.statSync( pathToCheck );
+		const DIRECTORY_NAMES_TO_EXCLUDE = [ '.git', 'node_modules', 'cache' ];
+		const offenderRegex = new RegExp(
+			`${ path.sep }(${ DIRECTORY_NAMES_TO_EXCLUDE.join( '|' ) })(${ path.sep }|$)`,
+			'g'
+		);
 
-		if ( ! stat.isDirectory() ) {
-			return false;
+		if ( offenderRegex.test( pathToCheck ) ) {
+			const offenderPath = pathToCheck.substring( 0, offenderRegex.lastIndex );
+			try {
+				const stat = fs.statSync( offenderPath );
+				return stat.isDirectory();
+			} catch ( error ) {
+				return false;
+			}
 		}
 
-		const basename = path.basename( pathToCheck );
-		const DIRECTORY_NAMES_TO_EXCLUDE = [ '.git', 'node_modules', 'cache' ];
-
-		return DIRECTORY_NAMES_TO_EXCLUDE.includes( basename );
+		return false;
 	}
 
 	constructor( options: ExportOptions ) {

--- a/src/lib/import-export/export/exporters/default-exporter.ts
+++ b/src/lib/import-export/export/exporters/default-exporter.ts
@@ -27,8 +27,8 @@ export class DefaultExporter extends EventEmitter implements Exporter {
 	private backup: BackupContents;
 	private readonly options: ExportOptions;
 
-	private isExcludedPath( pathToCheck: string ) {
-		const pathsToExclude = [
+	private isExactPathExcluded( pathToCheck: string ) {
+		const PATHS_TO_EXCLUDE = [
 			'wp-content/mu-plugins/sqlite-database-integration',
 			'wp-content/database',
 			'wp-content/db.php',
@@ -44,9 +44,23 @@ export class DefaultExporter extends EventEmitter implements Exporter {
 			'wp-content/mu-plugins/0-https-for-reverse-proxy.php',
 			'wp-content/mu-plugins/0-sqlite-command.php',
 		];
-		return pathsToExclude.some( ( pathToExclude ) =>
+
+		return PATHS_TO_EXCLUDE.some( ( pathToExclude ) =>
 			pathToCheck.startsWith( path.normalize( pathToExclude ) )
 		);
+	}
+
+	private isPathExcludedByPattern( pathToCheck: string ) {
+		const stat = fs.statSync( pathToCheck );
+
+		if ( ! stat.isDirectory() ) {
+			return false;
+		}
+
+		const basename = path.basename( pathToCheck );
+		const DIRECTORY_NAMES_TO_EXCLUDE = [ '.git', 'node_modules', 'cache' ];
+
+		return DIRECTORY_NAMES_TO_EXCLUDE.includes( basename );
 	}
 
 	constructor( options: ExportOptions ) {
@@ -57,6 +71,7 @@ export class DefaultExporter extends EventEmitter implements Exporter {
 			sqlFiles: [],
 		};
 	}
+
 	async canHandle(): Promise< boolean > {
 		const supportedExtension = [ 'tar.gz', 'tzg', 'zip' ].find( ( ext ) =>
 			this.options.backupFile.endsWith( ext )
@@ -185,19 +200,21 @@ export class DefaultExporter extends EventEmitter implements Exporter {
 				const stat = await fsPromises.stat( fullPath );
 				if ( stat.isDirectory() ) {
 					this.archiveBuilder.directory( fullPath, archivePath, ( entry ) => {
-						const fullArchivePath = path.join( archivePath, entry.name );
+						const entryPathRelativeToArchiveRoot = path.join( archivePath, entry.name );
+						const fullEntryPathOnDisk = path.join(
+							this.options.site.path,
+							entryPathRelativeToArchiveRoot
+						);
 						if (
-							this.isExcludedPath( fullArchivePath ) ||
-							entry.name.includes( '.git' ) ||
-							entry.name.includes( 'node_modules' ) ||
-							entry.name.includes( 'cache' )
+							this.isExactPathExcluded( entryPathRelativeToArchiveRoot ) ||
+							this.isPathExcludedByPattern( fullEntryPathOnDisk )
 						) {
 							return false;
 						}
 						return entry;
 					} );
 				} else {
-					if ( this.isExcludedPath( archivePath ) ) {
+					if ( this.isExactPathExcluded( archivePath ) ) {
 						continue;
 					}
 					this.archiveBuilder.file( fullPath, { name: archivePath } );

--- a/src/lib/import-export/tests/export/exporters/default-exporter.test.ts
+++ b/src/lib/import-export/tests/export/exporters/default-exporter.test.ts
@@ -151,6 +151,26 @@ platformTestSuite( 'DefaultExporter', ( { normalize } ) => {
 				name: 'example-load.php',
 				isFile: () => true,
 			},
+			{
+				path: normalize( '/path/to/site/wp-content/plugins/hello' ),
+				name: '.git',
+				isFile: () => false,
+			},
+			{
+				path: normalize( '/path/to/site/wp-content/plugins/hello' ),
+				name: 'node_modules',
+				isFile: () => false,
+			},
+			{
+				path: normalize( '/path/to/site/wp-content' ),
+				name: 'cache',
+				isFile: () => false,
+			},
+			{
+				path: normalize( '/path/to/site/wp-content/plugins/hello/my-cache' ),
+				name: 'test.php',
+				isFile: () => false,
+			},
 		];
 
 		( fsPromises.readdir as jest.Mock ).mockResolvedValue( mockFiles );
@@ -179,6 +199,20 @@ platformTestSuite( 'DefaultExporter', ( { normalize } ) => {
 		} );
 
 		( fs.existsSync as jest.Mock ).mockImplementation( pathExistsMockImplementation );
+
+		( fs.statSync as jest.Mock ).mockImplementation( ( filePath: string ) => {
+			const normalizedPath = normalize( filePath );
+			if (
+				mockFiles.some(
+					( file ) => normalizedPath === normalize( path.join( file.path, file.name ) )
+				)
+			) {
+				return { isDirectory: () => false, isFile: () => true };
+			} else if ( pathExistsMockImplementation( normalizedPath ) ) {
+				return { isDirectory: () => true, isFile: () => false };
+			}
+			throw new Error( `File not found: ${ normalizedPath }` );
+		} );
 
 		mockBackup = {
 			backupFile: normalize( '/path/to/backup.tar.gz' ),
@@ -637,6 +671,55 @@ platformTestSuite( 'DefaultExporter', ( { normalize } ) => {
 				'/path/to/site/wp-content/mu-plugins/sqlite-database-integration/example-load.php'
 			),
 			{ name: 'wp-content/mu-plugins/sqlite-database-integration/example-load.php' }
+		);
+	} );
+
+	it( 'should exclude .git, node_modules, and cache directories', async () => {
+		const options = {
+			...mockOptions,
+			includes: {
+				database: false,
+				wpContent: true,
+			},
+			specificSelectionPaths: [
+				'uploads',
+				'cache',
+				'plugins/hello/.git',
+				'plugins/hello/my-cache',
+				'plugins/hello/node_modules',
+			],
+		};
+
+		const exporter = new DefaultExporter( options );
+		await exporter.export();
+
+		// Verify that directories which are excluded by pattern are NOT added to the archive
+		expect( mockArchiver.directory ).not.toHaveBeenCalledWith(
+			normalize( '/path/to/site/wp-content/.git' ),
+			normalize( 'wp-content/.git' ),
+			expect.any( Function )
+		);
+		expect( mockArchiver.directory ).not.toHaveBeenCalledWith(
+			normalize( '/path/to/site/wp-content/plugins/hello/node_modules' ),
+			normalize( 'wp-content/plugins/hello/node_modules' ),
+			expect.any( Function )
+		);
+		expect( mockArchiver.directory ).not.toHaveBeenCalledWith(
+			normalize( '/path/to/site/wp-content/plugins/hello/cache' ),
+			normalize( 'wp-content/plugins/hello/cache' ),
+			expect.any( Function )
+		);
+
+		// Verify that other directories are still added
+		expect( mockArchiver.directory ).toHaveBeenCalledWith(
+			normalize( '/path/to/site/wp-content/uploads' ),
+			normalize( 'wp-content/uploads' ),
+			expect.any( Function )
+		);
+		expect( mockArchiver.directory ).toHaveBeenCalledWith(
+			normalize( '/path/to/site/wp-content/plugins/hello/my-cache' ),
+			normalize( 'wp-content/plugins/hello/my-cache' ),
+			expect.any( Function )
 		);
 	} );
 } );

--- a/src/lib/import-export/tests/export/exporters/default-exporter.test.ts
+++ b/src/lib/import-export/tests/export/exporters/default-exporter.test.ts
@@ -674,52 +674,141 @@ platformTestSuite( 'DefaultExporter', ( { normalize } ) => {
 		);
 	} );
 
-	it( 'should exclude .git, node_modules, and cache directories', async () => {
-		const options = {
-			...mockOptions,
-			includes: {
-				database: false,
-				wpContent: true,
-			},
-			specificSelectionPaths: [
-				'uploads',
-				'cache',
-				'plugins/hello/.git',
-				'plugins/hello/my-cache',
-				'plugins/hello/node_modules',
-			],
-		};
+	describe( 'isExactPathExcluded', () => {
+		it( 'should exclude exact paths from PATHS_TO_EXCLUDE list', () => {
+			const exporter = new DefaultExporter( mockOptions );
 
-		const exporter = new DefaultExporter( options );
-		await exporter.export();
+			expect( exporter.isExactPathExcluded( normalize( 'wp-content/database' ) ) ).toBe( true );
+			expect( exporter.isExactPathExcluded( normalize( 'wp-content/db.php' ) ) ).toBe( true );
+			expect( exporter.isExactPathExcluded( normalize( 'wp-content/debug.log' ) ) ).toBe( true );
+			expect(
+				exporter.isExactPathExcluded(
+					normalize( 'wp-content/mu-plugins/sqlite-database-integration' )
+				)
+			).toBe( true );
+			expect(
+				exporter.isExactPathExcluded(
+					normalize( 'wp-content/mu-plugins/0-allowed-redirect-hosts.php' )
+				)
+			).toBe( true );
+		} );
 
-		// Verify that directories which are excluded by pattern are NOT added to the archive
-		expect( mockArchiver.directory ).not.toHaveBeenCalledWith(
-			normalize( '/path/to/site/wp-content/.git' ),
-			normalize( 'wp-content/.git' ),
-			expect.any( Function )
-		);
-		expect( mockArchiver.directory ).not.toHaveBeenCalledWith(
-			normalize( '/path/to/site/wp-content/plugins/hello/node_modules' ),
-			normalize( 'wp-content/plugins/hello/node_modules' ),
-			expect.any( Function )
-		);
-		expect( mockArchiver.directory ).not.toHaveBeenCalledWith(
-			normalize( '/path/to/site/wp-content/plugins/hello/cache' ),
-			normalize( 'wp-content/plugins/hello/cache' ),
-			expect.any( Function )
-		);
+		it( 'should return false for paths not in the exclusion list', () => {
+			const exporter = new DefaultExporter( mockOptions );
 
-		// Verify that other directories are still added
-		expect( mockArchiver.directory ).toHaveBeenCalledWith(
-			normalize( '/path/to/site/wp-content/uploads' ),
-			normalize( 'wp-content/uploads' ),
-			expect.any( Function )
-		);
-		expect( mockArchiver.directory ).toHaveBeenCalledWith(
-			normalize( '/path/to/site/wp-content/plugins/hello/my-cache' ),
-			normalize( 'wp-content/plugins/hello/my-cache' ),
-			expect.any( Function )
-		);
+			expect( exporter.isExactPathExcluded( normalize( 'wp-content/plugins' ) ) ).toBe( false );
+			expect( exporter.isExactPathExcluded( normalize( 'wp-content/themes' ) ) ).toBe( false );
+			expect( exporter.isExactPathExcluded( normalize( 'wp-content/uploads' ) ) ).toBe( false );
+			expect( exporter.isExactPathExcluded( normalize( 'wp-config.php' ) ) ).toBe( false );
+		} );
+
+		it( 'should match paths that start with excluded prefixes', () => {
+			const exporter = new DefaultExporter( mockOptions );
+
+			expect(
+				exporter.isExactPathExcluded( normalize( 'wp-content/database/something.sql' ) )
+			).toBe( true );
+			expect(
+				exporter.isExactPathExcluded(
+					normalize( 'wp-content/mu-plugins/sqlite-database-integration/load.php' )
+				)
+			).toBe( true );
+		} );
+	} );
+
+	describe( 'isPathExcludedByPattern', () => {
+		it( 'should exclude disallowed directories based on their names', () => {
+			( fs.statSync as jest.Mock ).mockReturnValue( {
+				isDirectory: () => true,
+				isFile: () => false,
+			} );
+
+			const exporter = new DefaultExporter( mockOptions );
+
+			expect(
+				exporter.isPathExcludedByPattern( normalize( '/path/to/site/wp-content/.git' ) )
+			).toBe( true );
+			expect(
+				exporter.isPathExcludedByPattern(
+					normalize( '/path/to/site/wp-content/node_modules/hello' )
+				)
+			).toBe( true );
+			expect(
+				exporter.isPathExcludedByPattern( normalize( '/path/to/site/wp-content/cache' ) )
+			).toBe( true );
+			expect(
+				exporter.isPathExcludedByPattern( normalize( '/path/to/site/wp-content/my-cache' ) )
+			).toBe( false );
+		} );
+
+		it( 'should return false for non-excluded directories', () => {
+			( fs.statSync as jest.Mock ).mockReturnValue( {
+				isDirectory: () => true,
+				isFile: () => false,
+			} );
+
+			const exporter = new DefaultExporter( mockOptions );
+
+			expect(
+				exporter.isPathExcludedByPattern( normalize( '/path/to/site/wp-content/uploads' ) )
+			).toBe( false );
+			expect(
+				exporter.isPathExcludedByPattern( normalize( '/path/to/site/wp-content/plugins' ) )
+			).toBe( false );
+			expect(
+				exporter.isPathExcludedByPattern( normalize( '/path/to/site/wp-content/themes' ) )
+			).toBe( false );
+		} );
+
+		it( 'should return false for non-existent paths (stat fails)', () => {
+			const exporter = new DefaultExporter( mockOptions );
+
+			// Paths that don't exist in mockFiles will cause statSync to throw, returning false
+			expect(
+				exporter.isPathExcludedByPattern( normalize( '/path/to/site/wp-content/nonexistent' ) )
+			).toBe( false );
+			expect(
+				exporter.isPathExcludedByPattern( normalize( '/path/to/site/nonexistent/.git' ) )
+			).toBe( false );
+		} );
+
+		it( 'should return false for files (not directories)', () => {
+			( fs.statSync as jest.Mock ).mockReturnValue( {
+				isDirectory: () => false,
+				isFile: () => true,
+			} );
+
+			const exporter = new DefaultExporter( mockOptions );
+
+			expect(
+				exporter.isPathExcludedByPattern(
+					normalize( '/path/to/site/wp-content/uploads/file1.jpg' )
+				)
+			).toBe( false );
+			expect( exporter.isPathExcludedByPattern( normalize( '/path/to/site/wp-config.php' ) ) ).toBe(
+				false
+			);
+			expect( exporter.isPathExcludedByPattern( normalize( '/path/to/site/node_modules' ) ) ).toBe(
+				false
+			);
+		} );
+
+		it( 'should handle directory names found at any position in the path', () => {
+			( fs.statSync as jest.Mock ).mockReturnValue( {
+				isDirectory: () => true,
+				isFile: () => false,
+			} );
+
+			const exporter = new DefaultExporter( mockOptions );
+
+			expect(
+				exporter.isPathExcludedByPattern( normalize( '/path/to/site/wp-content/.git' ) )
+			).toBe( true );
+			expect(
+				exporter.isPathExcludedByPattern(
+					normalize( '/path/to/site/wp-content/plugins/akismet/node_modules/webpack/index.js' )
+				)
+			).toBe( true );
+		} );
 	} );
 } );

--- a/src/lib/import-export/tests/export/exporters/default-exporter.test.ts
+++ b/src/lib/import-export/tests/export/exporters/default-exporter.test.ts
@@ -151,26 +151,6 @@ platformTestSuite( 'DefaultExporter', ( { normalize } ) => {
 				name: 'example-load.php',
 				isFile: () => true,
 			},
-			{
-				path: normalize( '/path/to/site/wp-content/plugins/hello' ),
-				name: '.git',
-				isFile: () => false,
-			},
-			{
-				path: normalize( '/path/to/site/wp-content/plugins/hello' ),
-				name: 'node_modules',
-				isFile: () => false,
-			},
-			{
-				path: normalize( '/path/to/site/wp-content' ),
-				name: 'cache',
-				isFile: () => false,
-			},
-			{
-				path: normalize( '/path/to/site/wp-content/plugins/hello/my-cache' ),
-				name: 'test.php',
-				isFile: () => false,
-			},
 		];
 
 		( fsPromises.readdir as jest.Mock ).mockResolvedValue( mockFiles );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-1189

## Proposed Changes

In #1264, we implemented some logic in `DefaultExporter` to exclude `.git` and `node_modules` folders from export archives. The logic looked for those substrings anywhere in the path. This could be considered a risky approach, but since those terms are pretty esoteric, it likely didn't cause much trouble. 

In #1940, we added the term `cache` to this list, which is much more generic. When combined with the simplistic path-checking logic, this change would actually break exports containing files or directories with "cache" in the name that weren't meant to be excluded.

STU-1189 documents one such example, where the Yoast SEO plugin would break during export (since certain required files were excluded). It's worth noting that sync pushes containing Yoast SEO plugins wouldn't have broken, since plugins aren't restored directly from the push archive on the back-end.

In any case, this PR addresses the issue by:

1. Moving this path exclusion logic to a method `DefaultExporter::isPathExcludedByPattern`
2. Only excluding a path if it's a directory, AND
3. If `.git`, `node_modules`, or `cache` is the full name of that directory. `hellonode_modules` or `my-cache` are not excluded. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Run `npm start`
2. Create a new site
3. Install Yoast SEO on that site
4. Do a full site export for that site
5. Create a new site from the backup you just created
6. Ensure that the site is created successfully and starts successfully

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
