### PR TITLE
Studio: Improve code logic for when local tree has push errors

### DIFF
--- a/src/components/tree-view.tsx
+++ b/src/components/tree-view.tsx
@@ -167,7 +167,7 @@ const TreeItem = ( {
 					className={ cx( 'ps-6', isFirstLevel && 'border border-gray-300 rounded-sm py-2' ) }
 				>
 					{ node.children.length === 0 ? (
-						renderEmptyContent && renderEmptyContent( node.id ) ? (
+						renderEmptyContent ? (
 							renderEmptyContent( node.id )
 						) : (
 							<div className="text-gray-500 italic" aria-label={ __( 'Empty folder' ) }>

--- a/src/modules/sync/components/sync-dialog.tsx
+++ b/src/modules/sync/components/sync-dialog.tsx
@@ -117,13 +117,6 @@ const useDynamicTreeState = (
 		localSiteId,
 	] );
 
-	// Handle local file tree errors by clearing children to show custom error message
-	useEffect( () => {
-		if ( type === 'push' && localFileTreeError ) {
-			setTreeState( ( treeState ) => updateNodeById( treeState, 'wp-content', { children: [] } ) );
-		}
-	}, [ type, localFileTreeError, setTreeState ] );
-
 	return {
 		rewindId,
 		fetchChildren,

--- a/src/modules/sync/components/sync-dialog.tsx
+++ b/src/modules/sync/components/sync-dialog.tsx
@@ -371,7 +371,11 @@ export function SyncDialog( {
 												</div>
 											);
 										}
-										return null;
+										return (
+											<div className="text-gray-500 italic" aria-label={ __( 'Empty folder' ) }>
+												{ __( 'Empty' ) }
+											</div>
+										);
 									} }
 								/>
 							</>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

Fixes:

* https://github.com/Automattic/studio/pull/2271#pullrequestreview-3615879713
* https://github.com/Automattic/studio/pull/2271#discussion_r2650985405

## Proposed Changes

This PR addresses misc comments from https://github.com/Automattic/studio/pull/2271 that were submitted after the PR was merged. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
* Apply the following diff: 

```diff --git a/src/stores/sync/sync-hooks.ts b/src/stores/sync/sync-hooks.ts
index 31db0fc9..b538c66b 100644
--- a/src/stores/sync/sync-hooks.ts
+++ b/src/stores/sync/sync-hooks.ts
@@ -83,6 +83,9 @@ export function useLocalFileTree() {
                        setIsLoading( true );
                        setError( null );
                        try {
+                               // TEMPORARY: Simulate error for testing
+                               throw new Error( 'Simulated error for testing error handling' );
+                               
                                const rawNodes = await getIpcApi().listLocalFileTree( siteId, path, 3 );
                                return convertRawToTreeNodes( rawNodes );
                        } catch ( err ) {
```

* Start Studio with `npm start`
* Ensure that you have at least one WP.com site connected to Studio
* Navigate to the `Sync` tab
* Click on `Push`
* Select `Specific files and folders` option
* Confirm that when you open `wp-content`, you see the error shown on the screenshot above

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
