### PR TITLE
Add LearnHow link

### DIFF
--- a/src/components/content-tab-settings.tsx
+++ b/src/components/content-tab-settings.tsx
@@ -99,7 +99,7 @@ export function ContentTabSettings( { selectedSite }: ContentTabSettingsProps ) 
 								</Button>
 							) }
 						</div>
-						{ selectedSite.enableHttps && (
+						{ ! isCertificateTrusted && selectedSite.enableHttps && (
 							<div className="mt-1 max-w-96">
 								<span className="text-a8c-gray-50 mt-1">
 									{ __(

--- a/src/components/content-tab-settings.tsx
+++ b/src/components/content-tab-settings.tsx
@@ -5,6 +5,7 @@ import { PropsWithChildren } from 'react';
 import { decodePassword } from 'common/lib/passwords';
 import { CopyTextButton } from 'src/components/copy-text-button';
 import DeleteSite from 'src/components/delete-site';
+import { LearnMoreLink } from 'src/components/learn-more';
 import { useGetWpVersion } from 'src/hooks/use-get-wp-version';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 import EditSiteDetails from 'src/modules/site-settings/edit-site-details';
@@ -98,24 +99,14 @@ export function ContentTabSettings( { selectedSite }: ContentTabSettingsProps ) 
 								</Button>
 							) }
 						</div>
-						{ ! isCertificateTrusted && selectedSite.enableHttps && (
+						{ selectedSite.enableHttps && (
 							<div className="mt-1 max-w-96">
 								<span className="text-a8c-gray-50 mt-1">
 									{ __(
 										'You need to trust this certificate to prevent your browser from showing a secure connection warning.'
 									) }
 								</span>{ ' ' }
-								<Button
-									variant="link"
-									onClick={ () => {
-										getIpcApi().openURL(
-											'https://developer.wordpress.com/docs/developer-tools/studio/ssl-in-studio/'
-										);
-									} }
-								>
-									{ __( 'Learn how' ) }
-									<span aria-label={ __( '(opens in a web browser)' ) }>&#8599;</span>
-								</Button>
+								<LearnMoreLink docsLinksKey="docsSslInStudio" learnHow />
 							</div>
 						) }
 					</SettingsRow>

--- a/src/components/content-tab-settings.tsx
+++ b/src/components/content-tab-settings.tsx
@@ -5,7 +5,7 @@ import { PropsWithChildren } from 'react';
 import { decodePassword } from 'common/lib/passwords';
 import { CopyTextButton } from 'src/components/copy-text-button';
 import DeleteSite from 'src/components/delete-site';
-import { LearnMoreLink } from 'src/components/learn-more';
+import { LearnHowLink } from 'src/components/learn-more';
 import { useGetWpVersion } from 'src/hooks/use-get-wp-version';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 import EditSiteDetails from 'src/modules/site-settings/edit-site-details';
@@ -106,7 +106,7 @@ export function ContentTabSettings( { selectedSite }: ContentTabSettingsProps ) 
 										'You need to trust this certificate to prevent your browser from showing a secure connection warning.'
 									) }
 								</span>{ ' ' }
-								<LearnMoreLink docsLinksKey="docsSslInStudio" learnHow />
+								<LearnHowLink docsLinksKey="docsSslInStudio" />
 							</div>
 						) }
 					</SettingsRow>

--- a/src/components/learn-more.tsx
+++ b/src/components/learn-more.tsx
@@ -4,15 +4,12 @@ import { getIpcApi } from 'src/lib/get-ipc-api';
 import { getLocalizedLink, type DocsLinkKey } from 'src/lib/get-localized-link';
 import { useI18nLocale } from 'src/stores';
 
-export function LearnMoreLink( {
-	docsLinksKey,
-	className,
-	learnHow,
-}: {
+interface LinkProps {
 	docsLinksKey: DocsLinkKey;
 	className?: string;
-	learnHow?: boolean;
-} ) {
+}
+
+function MoreLink( { docsLinksKey, className, label }: LinkProps & { label: string } ) {
 	const { __ } = useI18n();
 	const locale = useI18nLocale();
 
@@ -26,7 +23,19 @@ export function LearnMoreLink( {
 			} }
 			variant="link"
 		>
-			{ learnHow ? __( 'Learn how' ) : __( 'Learn more' ) }
+			{ label }
 		</Button>
 	);
+}
+
+export function LearnMoreLink( props: LinkProps ) {
+	const { __ } = useI18n();
+
+	return <MoreLink { ...props } label={ __( 'Learn more' ) } />;
+}
+
+export function LearnHowLink( props: LinkProps ) {
+	const { __ } = useI18n();
+
+	return <MoreLink { ...props } label={ __( 'Learn how' ) } />;
 }

--- a/src/components/learn-more.tsx
+++ b/src/components/learn-more.tsx
@@ -7,9 +7,11 @@ import { useI18nLocale } from 'src/stores';
 export function LearnMoreLink( {
 	docsLinksKey,
 	className,
+	learnHow,
 }: {
 	docsLinksKey: DocsLinkKey;
 	className?: string;
+	learnHow?: boolean;
 } ) {
 	const { __ } = useI18n();
 	const locale = useI18nLocale();
@@ -24,7 +26,7 @@ export function LearnMoreLink( {
 			} }
 			variant="link"
 		>
-			{ __( 'Learn more' ) }
+			{ learnHow ? __( 'Learn how' ) : __( 'Learn more' ) }
 		</Button>
 	);
 }

--- a/src/lib/get-localized-link.ts
+++ b/src/lib/get-localized-link.ts
@@ -34,6 +34,9 @@ const DOCS_LINKS = {
 	docsXdebug: {
 		en: 'https://developer.wordpress.com/docs/developer-tools/studio/xdebug/',
 	},
+	docsSslInStudio: {
+		en: 'https://developer.wordpress.com/docs/developer-tools/studio/ssl-in-studio/',
+	},
 } satisfies Record< `docs${ string }`, TranslatedLink >;
 
 const BLOG_LINKS = {

--- a/src/modules/add-site/components/create-site-form.tsx
+++ b/src/modules/add-site/components/create-site-form.tsx
@@ -11,7 +11,6 @@ import { LearnMoreLink } from 'src/components/learn-more';
 import TextControlComponent from 'src/components/text-control';
 import { WPVersionSelector } from 'src/components/wp-version-selector';
 import { cx } from 'src/lib/cx';
-import { getIpcApi } from 'src/lib/get-ipc-api';
 import { AllowedPHPVersion } from 'src/lib/wordpress-provider/constants';
 import { useRootSelector } from 'src/stores';
 import { useCheckCertificateTrustQuery } from 'src/stores/certificate-trust-api';
@@ -380,17 +379,7 @@ export const CreateSiteForm = ( {
 										{ __(
 											'You need to manually add the Studio root certificate authority to your keychain and trust it to enable HTTPS.'
 										) }{ ' ' }
-										<Button
-											variant="link"
-											onClick={ () => {
-												getIpcApi().openURL(
-													'https://developer.wordpress.com/docs/developer-tools/studio/ssl-in-studio/'
-												);
-											} }
-										>
-											{ __( 'Learn how' ) }
-											<span aria-label={ __( '(opens in a web browser)' ) }>&#8599;</span>
-										</Button>
+										<LearnMoreLink docsLinksKey="docsSslInStudio" learnHow />
 									</div>
 								) }
 							</div>

--- a/src/modules/add-site/components/create-site-form.tsx
+++ b/src/modules/add-site/components/create-site-form.tsx
@@ -7,7 +7,7 @@ import { FormEvent, useState, useEffect } from 'react';
 import { generateCustomDomainFromSiteName } from 'common/lib/domains';
 import Button from 'src/components/button';
 import FolderIcon from 'src/components/folder-icon';
-import { LearnMoreLink } from 'src/components/learn-more';
+import { LearnMoreLink, LearnHowLink } from 'src/components/learn-more';
 import TextControlComponent from 'src/components/text-control';
 import { WPVersionSelector } from 'src/components/wp-version-selector';
 import { cx } from 'src/lib/cx';
@@ -379,7 +379,7 @@ export const CreateSiteForm = ( {
 										{ __(
 											'You need to manually add the Studio root certificate authority to your keychain and trust it to enable HTTPS.'
 										) }{ ' ' }
-										<LearnMoreLink docsLinksKey="docsSslInStudio" learnHow />
+										<LearnHowLink docsLinksKey="docsSslInStudio" />
 									</div>
 								) }
 							</div>

--- a/src/modules/site-settings/edit-site-details.tsx
+++ b/src/modules/site-settings/edit-site-details.tsx
@@ -8,7 +8,7 @@ import { generateCustomDomainFromSiteName, getDomainNameValidationError } from '
 import { getWordPressVersionUrl } from 'common/lib/wordpress-version-utils';
 import Button from 'src/components/button';
 import { ErrorInformation } from 'src/components/error-information';
-import { LearnMoreLink } from 'src/components/learn-more';
+import { LearnMoreLink, LearnHowLink } from 'src/components/learn-more';
 import Modal from 'src/components/modal';
 import TextControlComponent from 'src/components/text-control';
 import { Tooltip } from 'src/components/tooltip';
@@ -328,7 +328,7 @@ const EditSiteDetails = ( { currentWpVersion, onSave }: EditSiteDetailsProps ) =
 										{ __(
 											'You need to manually add the Studio certificate authority to your keychain and trust it.'
 										) }{ ' ' }
-										<LearnMoreLink docsLinksKey="docsSslInStudio" learnHow />
+										<LearnHowLink docsLinksKey="docsSslInStudio" />
 									</div>
 								) }
 							</div>

--- a/src/modules/site-settings/edit-site-details.tsx
+++ b/src/modules/site-settings/edit-site-details.tsx
@@ -328,17 +328,7 @@ const EditSiteDetails = ( { currentWpVersion, onSave }: EditSiteDetailsProps ) =
 										{ __(
 											'You need to manually add the Studio certificate authority to your keychain and trust it.'
 										) }{ ' ' }
-										<Button
-											variant="link"
-											onClick={ () => {
-												getIpcApi().openURL(
-													'https://developer.wordpress.com/docs/developer-tools/studio/ssl-in-studio/'
-												);
-											} }
-										>
-											{ __( 'Learn how' ) }
-											<span aria-label={ __( '(opens in a web browser)' ) }>&#8599;</span>
-										</Button>
+										<LearnMoreLink docsLinksKey="docsSslInStudio" learnHow />
 									</div>
 								) }
 							</div>


### PR DESCRIPTION
## Proposed Changes
Follow up to https://github.com/Automattic/studio/pull/2317
@katinthehatsite noticed that [we don't have space](https://github.com/Automattic/studio/pull/2350#pullrequestreview-3627145260) for "Learn how" link. In the previous PR I didn't see this type of links, so this PR utilizes that component to avoid duplications and make that component reuzabled.

## Testing Instructions
Apply the next diff:
```diff
diff --git a/src/components/content-tab-settings.tsx b/src/components/content-tab-settings.tsx
index fa96d5dd..14f79d97 100644
--- a/src/components/content-tab-settings.tsx
+++ b/src/components/content-tab-settings.tsx
@@ -99,7 +99,7 @@ export function ContentTabSettings( { selectedSite }: ContentTabSettingsProps )
                                                                </Button>
                                                        ) }
                                                </div>
-                                               { ! isCertificateTrusted && selectedSite.enableHttps && (
+                                               { selectedSite.enableHttps && (
                                                        <div className="mt-1 max-w-96">
                                                                <span className="text-a8c-gray-50 mt-1">
                                                                        { __(
diff --git a/src/modules/add-site/components/create-site-form.tsx b/src/modules/add-site/components/create-site-form.tsx
index 2778cda5..441e6ad2 100644
--- a/src/modules/add-site/components/create-site-form.tsx
+++ b/src/modules/add-site/components/create-site-form.tsx
@@ -374,7 +374,7 @@ export const CreateSiteForm = ( {
                                                                        </div>
                                                                ) }
 
-                                                               { ! isCertificateTrusted && useCustomDomain && setEnableHttps && (
+                                                               { useCustomDomain && setEnableHttps && (
                                                                        <div className="text-a8c-gray-50 text-xs mt-2">
                                                                                { __(
                                                                                        'You need to manually add the Studio root certificate authority to your keychain and trust it to enable HTTPS.'
diff --git a/src/modules/site-settings/edit-site-details.tsx b/src/modules/site-settings/edit-site-details.tsx
index 4a3d908b..8fde875d 100644
--- a/src/modules/site-settings/edit-site-details.tsx
+++ b/src/modules/site-settings/edit-site-details.tsx
@@ -323,7 +323,7 @@ const EditSiteDetails = ( { currentWpVersion, onSave }: EditSiteDetailsProps ) =
                                                                        </div>
                                                                ) }
 
-                                                               { ! isCertificateTrusted && useCustomDomain && (
+                                                               { useCustomDomain && (
                                                                        <div className="text-a8c-gray-50 text-xs mt-2">
```
1. Open Site settings and assert that link looks and works good<br /><img width="502" height="297" alt="Screenshot 2026-01-05 at 15 50 37" src="https://github.com/user-attachments/assets/5db42eb1-8353-477d-bc08-16c63f5dd7f5" />
2. Open Edit site dialog and assert the same<br /><img width="398" height="173" alt="Screenshot 2026-01-05 at 15 51 31" src="https://github.com/user-attachments/assets/cca653ee-4183-48f2-999e-80dd9b949662" />
3. Click "Add site" and assert the same<br /><img width="428" height="91" alt="Screenshot 2026-01-05 at 15 51 58" src="https://github.com/user-attachments/assets/5265657e-b6a5-4e08-8593-a38f7ba50f9f" />
