### PR TITLE
Fix sync tab items

### DIFF
--- a/src/modules/sync/components/sync-connected-sites.tsx
+++ b/src/modules/sync/components/sync-connected-sites.tsx
@@ -220,11 +220,7 @@ const SyncConnectedSitesSectionItem = ( {
 	return (
 		<div className="grid grid-cols-[max-content_1fr_max-content]">
 			<div
-				className={ `col-span-3 grid px-8 gap-2 justify-items-start items-center ${
-					connectedSite.isPressable && ! connectedSite.environmentType
-						? 'grid-cols-[1fr_auto]'
-						: 'grid-cols-subgrid'
-				}` }
+				className="col-span-3 grid px-8 gap-2 justify-items-start items-center grid-cols-subgrid"
 				key={ connectedSite.id }
 			>
 				<div className="shrink-0">


### PR DESCRIPTION
## Proposed Changes
I had case when `connectedSite.environmentType` was `null` and UI was broken. It seems that we handled it previously with different grid, but it's not relevant to the current UI, that's why it breaks it.

<table>
<tr>
<td>BEFORE
<td>AFTER
</tr>
<tr>
<td><img width="1037" height="307" alt="Screenshot 2026-01-06 at 21 07 43" src="https://github.com/user-attachments/assets/566bb70e-3fca-4db5-8651-9b177205cab8" />
<td><img width="1041" height="290" alt="Screenshot 2026-01-06 at 21 07 21" src="https://github.com/user-attachments/assets/5ad72930-6f2e-4d52-809b-308c488ab078" />
</tr>
</table>

## Testing Instructions
Visual code review should suffice