### PR TITLE
Add details about unsupported Sync item states

### DIFF
--- a/src/modules/sync/components/sync-sites-modal-selector.tsx
+++ b/src/modules/sync/components/sync-sites-modal-selector.tsx
@@ -1,4 +1,4 @@
-import { Icon, SearchControl as SearchControlWp } from '@wordpress/components';
+import { Icon, SearchControl as SearchControlWp, Tooltip } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import { useState, useEffect } from 'react';
@@ -339,13 +339,15 @@ function SiteItem( {
 			) }
 			{ needsUpgrade && (
 				<div className="a8c-body-small text-a8c-gray-30 shrink-0 text-right">
-					<Button
-						variant="link"
-						onClick={ () => getIpcApi().openURL( `https://wordpress.com/plans/${ site.id }` ) }
-					>
-						{ __( 'Upgrade plan' ) }
-						<ArrowIcon />
-					</Button>
+					<Tooltip text={ __( 'Sync support is available only with Business plan and above' ) }>
+						<Button
+							variant="link"
+							onClick={ () => getIpcApi().openURL( `https://wordpress.com/plans/${ site.id }` ) }
+						>
+							{ __( 'Upgrade plan' ) }
+							<ArrowIcon />
+						</Button>
+					</Tooltip>
 				</div>
 			) }
 			{ isNeedsTransfer && (
@@ -372,7 +374,11 @@ function SiteItem( {
 				</div>
 			) }
 			{ isUnsupported && (
-				<div className="a8c-body-small text-a8c-gray-30 shrink-0">{ __( 'Unsupported site' ) }</div>
+				<Tooltip text={ __( 'Self-hosted (e.g. jurassic.ninja) sites are not supported' ) }>
+					<div className="a8c-body-small text-a8c-gray-30 shrink-0">
+						{ __( 'Unsupported site' ) }
+					</div>
+				</Tooltip>
 			) }
 		</div>
 	);

--- a/src/modules/sync/components/sync-sites-modal-selector.tsx
+++ b/src/modules/sync/components/sync-sites-modal-selector.tsx
@@ -339,7 +339,10 @@ function SiteItem( {
 			) }
 			{ needsUpgrade && (
 				<div className="a8c-body-small text-a8c-gray-30 shrink-0 text-right">
-					<Tooltip text={ __( 'Sync support is available only with Business plan and above' ) }>
+					<Tooltip
+						text={ __( 'Sync support is available only with Business plan and above' ) }
+						placement="bottom"
+					>
 						<Button
 							variant="link"
 							onClick={ () => getIpcApi().openURL( `https://wordpress.com/plans/${ site.id }` ) }
@@ -374,7 +377,10 @@ function SiteItem( {
 				</div>
 			) }
 			{ isUnsupported && (
-				<Tooltip text={ __( 'Self-hosted (e.g. jurassic.ninja) sites are not supported' ) }>
+				<Tooltip
+					text={ __( 'Self-hosted (e.g. jurassic.ninja) sites are not supported' ) }
+					placement="bottom"
+				>
 					<div className="a8c-body-small text-a8c-gray-30 shrink-0">
 						{ __( 'Unsupported site' ) }
 					</div>


### PR DESCRIPTION
## Proposed Changes
On Sync tab we render “Upgrade plan” button, w/o any details about which one should be chosen.
It can be frustrating for users, if they click in “Upgrade plan” button, purchase for example “Personal” and still Studio asks to upgrade plan, w/o any details.
This PR adds tooltip to specify Business plan.
And also adds tooltip to explain why the site is unsupported. It even usefull for us, developers of Studio, since I had no idea why site can be unsupported and why that predicate can be true, so I had to read commits history.

## Testing Instructions
1. Open sync tab
2. Find any `Unsupported` item and `Upgrade plan` button
3. Assert that you see tooltips