### PR TITLE
Refactor sync-support.ts

### DIFF
--- a/src/modules/sync/lib/sync-support.ts
+++ b/src/modules/sync/lib/sync-support.ts
@@ -7,20 +7,23 @@ export function isPressableSite( site: SitesEndpointSite ): boolean {
 	return site.hosting_provider_guess === 'pressable';
 }
 
-export function isAtomicSite( site: SitesEndpointSite ): boolean {
+function isAtomicSite( site: SitesEndpointSite ): boolean {
 	return site.is_wpcom_atomic;
 }
 
-export function hasSupportedPlan( site: SitesEndpointSite ): boolean {
+function hasSupportedPlan( site: SitesEndpointSite ): boolean {
 	return site.plan?.features.active.includes( STUDIO_SYNC_FEATURE_NAME ) ?? false;
 }
 
-export function isJetpackSite( site: SitesEndpointSite ): boolean {
-	return !! site.jetpack && ! isAtomicSite( site ) && ! isPressableSite( site );
+// Sites hosted outside wp.com and Pressable (e.g. jurassic.ninja).
+function isUnsupported( site: SitesEndpointSite ): boolean {
+	return !! site.jetpack && ! isAtomicSite( site );
 }
 
-export function needsTransfer( site: SitesEndpointSite ): boolean {
-	return ! isJetpackSite( site ) && ! isPressableSite( site ) && ! isAtomicSite( site );
+// needsTransfer means that the site was reverted to "simple" via "bulk-delete-test-sites" tool.
+// Activating e.g. "VaultPress Backup" or "Hosting features" returns "is_wpcom_atomic === true && jetpack === true".
+function needsTransfer( site: SitesEndpointSite ): boolean {
+	return ! site.jetpack && ! isAtomicSite( site );
 }
 
 export function getSyncSupport( site: SitesEndpointSite, connectedSiteIds: number[] ): SyncSupport {
@@ -30,17 +33,18 @@ export function getSyncSupport( site: SitesEndpointSite, connectedSiteIds: numbe
 	if ( ! site.capabilities?.manage_options ) {
 		return 'missing-permissions';
 	}
-	if ( isJetpackSite( site ) ) {
+	if ( isUnsupported( site ) && ! isPressableSite( site ) ) {
 		return 'unsupported';
 	}
 	if ( ! hasSupportedPlan( site ) && ! isPressableSite( site ) ) {
 		return 'needs-upgrade';
 	}
-	if ( needsTransfer( site ) ) {
+	if ( needsTransfer( site ) && ! isPressableSite( site ) ) {
 		return 'needs-transfer';
 	}
 	if ( connectedSiteIds.some( ( id ) => id === site.ID ) ) {
 		return 'already-connected';
 	}
+
 	return 'syncable';
 }


### PR DESCRIPTION
## Proposed Changes
I worked around the sync-support module and didn't get how to reproduce cases, since the conditions are not clear.
See comments.

## Testing Instructions
Assert that everything still works well:
1. Create [jurassic.ninja](https://jurassic.ninja/) site, install jetpack and conntect to dotcom, open Studio sync tab and assert that it's marked as unsupported.
2. Create Business site, open [bulk-delete-test-sites](https://mc.a8c.com/tools/bulk-delete-test-sites/), revert to simple, open Studio sync tab and assert that the site is marked as "Enable hosting features"
3. Test wp.com sites and assert that they are marked as "syncable" only for Business+ plan.
4. Test Pressable sites and assert that they are always marked as "syncable"