### PR TITLE
Add locale parameter support for blueprint translations

### DIFF
--- a/src/modules/add-site/components/blueprints.tsx
+++ b/src/modules/add-site/components/blueprints.tsx
@@ -16,6 +16,7 @@ import StudioButton from 'src/components/button';
 import { LearnMoreLink } from 'src/components/learn-more';
 import { cx } from 'src/lib/cx';
 import { getIpcApi } from 'src/lib/get-ipc-api';
+import { useI18nLocale } from 'src/stores';
 import { useGetBlueprints } from 'src/stores/wpcom-api';
 import { BlueprintWarningNotice } from './blueprint-warning-notice';
 
@@ -59,7 +60,10 @@ export function AddSiteBlueprintSelector( {
 	onFileBlueprintSelect,
 }: AddSiteBlueprintProps ) {
 	const { __ } = useI18n();
-	const { refetch: refetchBlueprints, isFetching: isFetchingBlueprints } = useGetBlueprints();
+	const locale = useI18nLocale();
+	const { refetch: refetchBlueprints, isFetching: isFetchingBlueprints } = useGetBlueprints( {
+		locale,
+	} );
 	const fileRef = useRef< HTMLInputElement | null >( null );
 	const [ validationError, setValidationError ] = useState< string | undefined >( undefined );
 	const [ blueprintWarnings, setBlueprintWarnings ] = useState<

--- a/src/modules/add-site/index.tsx
+++ b/src/modules/add-site/index.tsx
@@ -12,7 +12,7 @@ import { useSiteDetails } from 'src/hooks/use-site-details';
 import { generateSiteName } from 'src/lib/generate-site-name';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 import { SyncSite } from 'src/modules/sync/types';
-import { useRootSelector } from 'src/stores';
+import { useRootSelector, useI18nLocale } from 'src/stores';
 import { formatRtkError } from 'src/stores/format-rtk-error';
 import { selectMinimumWordPressVersion } from 'src/stores/provider-constants-slice';
 import { useGetWordPressVersions } from 'src/stores/wordpress-versions-api';
@@ -322,12 +322,13 @@ export function AddSiteModalContent( {
 }: AddSiteModalContentProps ) {
 	const { __ } = useI18n();
 	const [ nameSuggested, setNameSuggested ] = useState( false );
+	const locale = useI18nLocale();
 
 	const {
 		data: blueprintsData,
 		isLoading: isLoadingBlueprints,
 		error: blueprintsError,
-	} = useGetBlueprints();
+	} = useGetBlueprints( { locale } );
 
 	const { sites, loadingSites } = useSiteDetails();
 

--- a/src/stores/wpcom-api.ts
+++ b/src/stores/wpcom-api.ts
@@ -195,10 +195,10 @@ export const wpcomPublicApi = createApi( {
 	endpoints: ( builder ) => ( {
 		getBlueprints: builder.query<
 			{ blueprints: z.infer< typeof blueprintSchema >[]; total: number },
-			void
+			{ locale?: string }
 		>( {
-			query: () => ( {
-				path: '/studio-app/blueprints',
+			query: ( { locale } = {} ) => ( {
+				path: `/studio-app/blueprints${ locale ? `?locale=${ locale }` : '' }`,
 				apiNamespace: 'wpcom/v2',
 			} ),
 			transformResponse: ( response: unknown ) => {


### PR DESCRIPTION
## Related issues

- Fixes STU-1154

## Proposed Changes

This PR adds locale parameter support to the blueprints endpoint to ensure blueprint descriptions are returned in the user's configured language.

- Modified the `getBlueprints` API query to accept and pass an optional locale parameter to the WordPress.com endpoint
- Updated blueprint components to retrieve the user's configured locale from the i18n store and pass it to the API


## Testing Instructions
1. Apply the following changes to your sandbox 199274-ghe-Automattic/wpcom
2. Sandbox the `public-api`
1. Start the app with `npm start`
3. Change your system language or app locale to a non-English language (e.g., Spanish, French, German)
4. Navigate to "Add New Site" 
5. Select "Create from a blueprint" option
6. Verify that the blueprint descriptions appear in the selected language
7. Test with multiple different locales to ensure the translation works correctly
8. Verify that if locale is not set, the API still works with the default English descriptions


## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?