### PR TITLE
Performance: Use bundled `latest` WordPress version in online mode

### DIFF
--- a/cli/commands/site/create.ts
+++ b/cli/commands/site/create.ts
@@ -147,21 +147,13 @@ export async function runCommand(
 
 		const isOnlineStatus = await isOnline();
 
-		if ( ! isOnlineStatus ) {
-			if ( options.wpVersion !== 'latest' ) {
-				throw new LoggerError(
-					__(
-						'Cannot set up WordPress while offline. Specific WordPress versions require an internet connection. Try using "latest" version or ensure internet connectivity.'
-					)
-				);
-			}
-
+		if ( options.wpVersion === 'latest' ) {
 			const bundledWPPath = path.join( getServerFilesPath(), 'wordpress-versions', 'latest' );
 
 			if ( ! ( await pathExists( bundledWPPath ) ) ) {
 				throw new LoggerError(
 					__(
-						'Cannot set up WordPress while offline. Bundled WordPress files not found. Please connect to the internet or reinstall Studio.'
+						'Cannot set up WordPress. Bundled WordPress files not found. Please connect to the internet or reinstall Studio.'
 					)
 				);
 			}
@@ -169,6 +161,12 @@ export async function runCommand(
 			logger.reportStart( LoggerAction.SETUP_WORDPRESS, __( 'Copying bundled WordPress…' ) );
 			await recursiveCopyDirectory( bundledWPPath, sitePath );
 			logger.reportSuccess( __( 'WordPress files copied' ) );
+		} else if ( ! isOnlineStatus ) {
+			throw new LoggerError(
+				__(
+					'Cannot set up WordPress while offline. Specific WordPress versions require an internet connection. Try using "latest" version or ensure internet connectivity.'
+				)
+			);
 		}
 
 		if ( ! ( await isSqliteIntegrationAvailable() ) ) {

--- a/cli/commands/site/tests/create.test.ts
+++ b/cli/commands/site/tests/create.test.ts
@@ -106,7 +106,7 @@ describe( 'CLI: studio site create', () => {
 			'wordpress-versions',
 			'latest'
 		);
-		return jest.fn().mockImplementation( ( path: string ) => {
+		const mock = jest.fn().mockImplementation( ( path: string ) => {
 			if ( path === bundledWPPath ) {
 				return Promise.resolve( true );
 			}
@@ -115,6 +115,7 @@ describe( 'CLI: studio site create', () => {
 			}
 			return Promise.resolve( false );
 		} );
+		( pathExists as jest.Mock ).mockImplementation( mock );
 	};
 
 	beforeEach( () => {
@@ -122,8 +123,7 @@ describe( 'CLI: studio site create', () => {
 
 		consoleLogSpy = jest.spyOn( console, 'log' ).mockImplementation();
 		fsMkdirSyncSpy = jest.spyOn( require( 'fs' ), 'mkdirSync' ).mockReturnValue( undefined );
-		const pathExistsMock = createPathExistsMock( false );
-		( pathExists as jest.Mock ).mockImplementation( pathExistsMock );
+		createPathExistsMock( false );
 		( isEmptyDir as jest.Mock ).mockResolvedValue( true );
 		( isWordPressDirectory as jest.Mock ).mockReturnValue( false );
 		( arePathsEqual as jest.Mock ).mockImplementation( ( a, b ) => a === b );
@@ -623,8 +623,7 @@ describe( 'CLI: studio site create', () => {
 		} );
 
 		it( 'should delete site directory when server start fails for new directory', async () => {
-			const pathExistsMock = createPathExistsMock( false );
-			( pathExists as jest.Mock ).mockImplementation( pathExistsMock );
+			createPathExistsMock( false );
 			( isWordPressDirectory as jest.Mock ).mockReturnValue( false );
 			( startWordPressServer as jest.Mock ).mockRejectedValue( new Error( 'Server start failed' ) );
 
@@ -636,8 +635,7 @@ describe( 'CLI: studio site create', () => {
 		} );
 
 		it( 'should NOT delete site directory when server start fails for existing WordPress directory', async () => {
-			const pathExistsMock = createPathExistsMock( true );
-			( pathExists as jest.Mock ).mockImplementation( pathExistsMock );
+			createPathExistsMock( true );
 			( isEmptyDir as jest.Mock ).mockResolvedValue( false );
 			( isWordPressDirectory as jest.Mock ).mockReturnValue( true );
 			( startWordPressServer as jest.Mock ).mockRejectedValue( new Error( 'Server start failed' ) );
@@ -650,8 +648,7 @@ describe( 'CLI: studio site create', () => {
 		} );
 
 		it( 'should delete site directory when blueprint application fails for new directory', async () => {
-			const pathExistsMock = createPathExistsMock( false );
-			( pathExists as jest.Mock ).mockImplementation( pathExistsMock );
+			createPathExistsMock( false );
 			( isWordPressDirectory as jest.Mock ).mockReturnValue( false );
 			const testBlueprint = { steps: [] };
 			( runBlueprint as jest.Mock ).mockRejectedValue( new Error( 'Blueprint failed' ) );
@@ -673,8 +670,7 @@ describe( 'CLI: studio site create', () => {
 		} );
 
 		it( 'should NOT delete site directory when blueprint application fails for existing WordPress directory', async () => {
-			const pathExistsMock = createPathExistsMock( true );
-			( pathExists as jest.Mock ).mockImplementation( pathExistsMock );
+			createPathExistsMock( true );
 			( isEmptyDir as jest.Mock ).mockResolvedValue( false );
 			( isWordPressDirectory as jest.Mock ).mockReturnValue( true );
 			const testBlueprint = { steps: [] };

--- a/cli/commands/site/tests/create.test.ts
+++ b/cli/commands/site/tests/create.test.ts
@@ -101,7 +101,11 @@ describe( 'CLI: studio site create', () => {
 	let fsMkdirSyncSpy: jest.SpyInstance;
 
 	const createPathExistsMock = ( sitePathExists = false ) => {
-		const bundledWPPath = require( 'path' ).join( '/test/server-files', 'wordpress-versions', 'latest' );
+		const bundledWPPath = require( 'path' ).join(
+			'/test/server-files',
+			'wordpress-versions',
+			'latest'
+		);
 		return jest.fn().mockImplementation( ( path: string ) => {
 			if ( path === bundledWPPath ) {
 				return Promise.resolve( true );

--- a/cli/commands/site/tests/create.test.ts
+++ b/cli/commands/site/tests/create.test.ts
@@ -3,7 +3,13 @@ import {
 	filterUnsupportedBlueprintFeatures,
 	validateBlueprintData,
 } from 'common/lib/blueprint-validation';
-import { isEmptyDir, isWordPressDirectory, pathExists, arePathsEqual } from 'common/lib/fs-utils';
+import {
+	isEmptyDir,
+	isWordPressDirectory,
+	pathExists,
+	arePathsEqual,
+	recursiveCopyDirectory,
+} from 'common/lib/fs-utils';
 import { isOnline } from 'common/lib/network-utils';
 import { portFinder } from 'common/lib/port-finder';
 import {
@@ -94,15 +100,30 @@ describe( 'CLI: studio site create', () => {
 	let consoleLogSpy: jest.SpyInstance;
 	let fsMkdirSyncSpy: jest.SpyInstance;
 
+	const createPathExistsMock = ( sitePathExists = false ) => {
+		const bundledWPPath = require( 'path' ).join( '/test/server-files', 'wordpress-versions', 'latest' );
+		return jest.fn().mockImplementation( ( path: string ) => {
+			if ( path === bundledWPPath ) {
+				return Promise.resolve( true );
+			}
+			if ( path === mockSitePath ) {
+				return Promise.resolve( sitePathExists );
+			}
+			return Promise.resolve( false );
+		} );
+	};
+
 	beforeEach( () => {
 		jest.clearAllMocks();
 
 		consoleLogSpy = jest.spyOn( console, 'log' ).mockImplementation();
 		fsMkdirSyncSpy = jest.spyOn( require( 'fs' ), 'mkdirSync' ).mockReturnValue( undefined );
-		( pathExists as jest.Mock ).mockResolvedValue( false );
+		const pathExistsMock = createPathExistsMock( false );
+		( pathExists as jest.Mock ).mockImplementation( pathExistsMock );
 		( isEmptyDir as jest.Mock ).mockResolvedValue( true );
 		( isWordPressDirectory as jest.Mock ).mockReturnValue( false );
 		( arePathsEqual as jest.Mock ).mockImplementation( ( a, b ) => a === b );
+		( recursiveCopyDirectory as jest.Mock ).mockResolvedValue( undefined );
 		( portFinder.getOpenPort as jest.Mock ).mockResolvedValue( mockPort );
 		( readAppdata as jest.Mock ).mockResolvedValue( {
 			sites: [ ...mockAppdata.sites ],
@@ -598,7 +619,8 @@ describe( 'CLI: studio site create', () => {
 		} );
 
 		it( 'should delete site directory when server start fails for new directory', async () => {
-			( pathExists as jest.Mock ).mockResolvedValue( false );
+			const pathExistsMock = createPathExistsMock( false );
+			( pathExists as jest.Mock ).mockImplementation( pathExistsMock );
 			( isWordPressDirectory as jest.Mock ).mockReturnValue( false );
 			( startWordPressServer as jest.Mock ).mockRejectedValue( new Error( 'Server start failed' ) );
 
@@ -610,7 +632,8 @@ describe( 'CLI: studio site create', () => {
 		} );
 
 		it( 'should NOT delete site directory when server start fails for existing WordPress directory', async () => {
-			( pathExists as jest.Mock ).mockResolvedValue( true );
+			const pathExistsMock = createPathExistsMock( true );
+			( pathExists as jest.Mock ).mockImplementation( pathExistsMock );
 			( isEmptyDir as jest.Mock ).mockResolvedValue( false );
 			( isWordPressDirectory as jest.Mock ).mockReturnValue( true );
 			( startWordPressServer as jest.Mock ).mockRejectedValue( new Error( 'Server start failed' ) );
@@ -623,7 +646,8 @@ describe( 'CLI: studio site create', () => {
 		} );
 
 		it( 'should delete site directory when blueprint application fails for new directory', async () => {
-			( pathExists as jest.Mock ).mockResolvedValue( false );
+			const pathExistsMock = createPathExistsMock( false );
+			( pathExists as jest.Mock ).mockImplementation( pathExistsMock );
 			( isWordPressDirectory as jest.Mock ).mockReturnValue( false );
 			const testBlueprint = { steps: [] };
 			( runBlueprint as jest.Mock ).mockRejectedValue( new Error( 'Blueprint failed' ) );
@@ -645,7 +669,8 @@ describe( 'CLI: studio site create', () => {
 		} );
 
 		it( 'should NOT delete site directory when blueprint application fails for existing WordPress directory', async () => {
-			( pathExists as jest.Mock ).mockResolvedValue( true );
+			const pathExistsMock = createPathExistsMock( true );
+			( pathExists as jest.Mock ).mockImplementation( pathExistsMock );
 			( isEmptyDir as jest.Mock ).mockResolvedValue( false );
 			( isWordPressDirectory as jest.Mock ).mockReturnValue( true );
 			const testBlueprint = { steps: [] };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Related to STU-980
- Related to STU-873

## Proposed Changes

- use bundled `latest` WordPress version in the online mode

This PR proposal is to use the bundled WordPress for the online mode as well (not just offline mode). This way we will shorten the site creation time from approx. 37 seconds to 24 seconds (35% speed up).

One disadvantage in this approach I see is that WordPress can be released in the time between two Studio releases. This would mean users who create a new site in that period would not get the most latest WordPress version (as the bundled would be used instead).

Considering our frequent Studio releases and the performance improvement for everyone we can get, I think this is a good trade-off.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR branch and start the app with `npm install && npm start`.
2. Create a new site with the `latest` WordPress version selected.
3. Review the logs in terminal - the bundled WordPress should be used:

<img width="1208" height="128" alt="CleanShot 2026-01-08 at 12 52 39@2x" src="https://github.com/user-attachments/assets/79755636-a162-4163-be38-73663e4bb8b0" />

4. Create a new site with some older WordPress version (e.g. `6.7`).
5. Review the logs in terminal - there should be no bundled version copying, the older WordPress version should be downloaded:

<img width="1208" height="112" alt="CleanShot 2026-01-08 at 12 53 49@2x" src="https://github.com/user-attachments/assets/774b22e3-23a9-4782-94eb-132de77596ac" />

Creating a site using the bundled WordPress version should be generally faster. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
