### PR TITLE
Use custom tooltip instead of wordpress components

### DIFF
--- a/src/modules/sync/components/sync-sites-modal-selector.tsx
+++ b/src/modules/sync/components/sync-sites-modal-selector.tsx
@@ -1,4 +1,4 @@
-import { Icon, SearchControl as SearchControlWp, Tooltip } from '@wordpress/components';
+import { Icon, SearchControl as SearchControlWp } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import { useState, useEffect } from 'react';
@@ -21,6 +21,7 @@ import { useI18nLocale } from 'src/stores';
 import { useGetConnectedSitesForLocalSiteQuery } from 'src/stores/sync/connected-sites';
 import { useGetWpComSitesQuery } from 'src/stores/sync/wpcom-sites';
 import type { SyncSite, SyncModalMode } from 'src/modules/sync/types';
+import { Tooltip } from 'src/components/tooltip';
 
 const SearchControl = process.env.NODE_ENV === 'test' ? () => null : SearchControlWp;
 

--- a/src/modules/sync/components/sync-sites-modal-selector.tsx
+++ b/src/modules/sync/components/sync-sites-modal-selector.tsx
@@ -7,6 +7,7 @@ import Button from 'src/components/button';
 import Modal from 'src/components/modal';
 import offlineIcon from 'src/components/offline-icon';
 import { PressableLogo } from 'src/components/pressable-logo';
+import { Tooltip } from 'src/components/tooltip';
 import { WordPressLogoCircle } from 'src/components/wordpress-logo-circle';
 import { useAuth } from 'src/hooks/use-auth';
 import { useOffline } from 'src/hooks/use-offline';
@@ -21,7 +22,6 @@ import { useI18nLocale } from 'src/stores';
 import { useGetConnectedSitesForLocalSiteQuery } from 'src/stores/sync/connected-sites';
 import { useGetWpComSitesQuery } from 'src/stores/sync/wpcom-sites';
 import type { SyncSite, SyncModalMode } from 'src/modules/sync/types';
-import { Tooltip } from 'src/components/tooltip';
 
 const SearchControl = process.env.NODE_ENV === 'test' ? () => null : SearchControlWp;
 


### PR DESCRIPTION
Fixes STU-1201

## Proposed Changes
Follow up to https://github.com/Automattic/studio/pull/2358
To use our Tooltip instead of wordpress/components

## Testing Instructions
1. Open sync tab
2. Find any Unsupported or Upgrade plan button
3. Mouse over
4. Assert that it appears w/o flashing (previously it appeared sometimes for a bit in teh left top corner)