### PR TITLE
Studio: Handle error when reading backup directories from /ls endpoint

### DIFF
--- a/src/components/tree-view.tsx
+++ b/src/components/tree-view.tsx
@@ -17,7 +17,7 @@ export type TreeNode = {
 	children?: TreeNode[];
 	type?: TreeNodeType;
 	loading?: boolean;
-	error?: string;
+	hasError?: boolean;
 	pathId?: string;
 	path?: string;
 };

--- a/src/components/tree-view.tsx
+++ b/src/components/tree-view.tsx
@@ -17,6 +17,7 @@ export type TreeNode = {
 	children?: TreeNode[];
 	type?: TreeNodeType;
 	loading?: boolean;
+	error?: string;
 	pathId?: string;
 	path?: string;
 };
@@ -97,7 +98,7 @@ const TreeItem = ( {
 	isLast?: boolean;
 	disabled?: boolean;
 	renderAfterChildren?: ( nodeId: string ) => React.ReactNode;
-	renderEmptyContent?: ( nodeId: string ) => React.ReactNode;
+	renderEmptyContent?: ( nodeId: string, node: TreeNode ) => React.ReactNode;
 } ) => {
 	const { __ } = useI18n();
 	const isFirstLevel = level === 1;
@@ -139,10 +140,11 @@ const TreeItem = ( {
 					<button
 						aria-label={ expanded ? __( 'Collapse' ) : __( 'Expand' ) }
 						onClick={ async () => {
+							// Call onExpand if expanding and either children are empty or there's an error (for retry)
 							if (
 								! expanded &&
 								onExpand &&
-								node.children?.length === 0 &&
+								( node.children?.length === 0 || node.error ) &&
 								node.type === 'folder'
 							) {
 								onPatchNode( node.id, { loading: true } );
@@ -168,7 +170,7 @@ const TreeItem = ( {
 				>
 					{ node.children.length === 0 ? (
 						renderEmptyContent ? (
-							renderEmptyContent( node.id )
+							renderEmptyContent( node.id, node )
 						) : (
 							<div className="text-gray-500 italic" aria-label={ __( 'Empty folder' ) }>
 								{ __( 'Empty' ) }
@@ -202,7 +204,7 @@ export type TreeViewProps = {
 	onExpand?: ( node: TreeNode ) => Promise< void >;
 	disabled?: boolean;
 	renderAfterChildren?: ( nodeId: string ) => React.ReactNode;
-	renderEmptyContent?: ( nodeId: string ) => React.ReactNode;
+	renderEmptyContent?: ( nodeId: string, node: TreeNode ) => React.ReactNode;
 };
 
 export const TreeView = ( {

--- a/src/components/tree-view.tsx
+++ b/src/components/tree-view.tsx
@@ -140,11 +140,10 @@ const TreeItem = ( {
 					<button
 						aria-label={ expanded ? __( 'Collapse' ) : __( 'Expand' ) }
 						onClick={ async () => {
-							// Call onExpand if expanding and either children are empty or there's an error (for retry)
 							if (
 								! expanded &&
 								onExpand &&
-								( node.children?.length === 0 || node.error ) &&
+								node.children?.length === 0 &&
 								node.type === 'folder'
 							) {
 								onPatchNode( node.id, { loading: true } );

--- a/src/modules/sync/components/sync-dialog.tsx
+++ b/src/modules/sync/components/sync-dialog.tsx
@@ -238,14 +238,14 @@ export function SyncDialog( {
 				try {
 					const children = await fetchChildren( remoteSite.id, rewindId, node.path, node.checked );
 					setTreeState( ( prev ) =>
-						updateNodeById( prev, node.id, { children, loading: false, error: undefined } )
+						updateNodeById( prev, node.id, { children, loading: false, hasError: false } )
 					);
 				} catch ( error ) {
 					setTreeState( ( prev ) =>
 						updateNodeById( prev, node.id, {
 							children: [],
 							loading: false,
-							error: 'Error retrieving files and directories',
+							hasError: true,
 						} )
 					);
 				}
@@ -402,7 +402,7 @@ export function SyncDialog( {
 												</div>
 											);
 										}
-										if ( node.error ) {
+										if ( node.hasError ) {
 											return (
 												<div className="text-gray-500 italic">
 													{ __(

--- a/src/modules/sync/components/sync-dialog.tsx
+++ b/src/modules/sync/components/sync-dialog.tsx
@@ -393,16 +393,10 @@ export function SyncDialog( {
 												</div>
 											);
 										}
-										if ( nodeId === 'wp-content' && type === 'pull' && remoteFileTreeError ) {
-											return (
-												<div className="text-gray-500 italic">
-													{ __(
-														'Error retrieving remote files and directories. Please close and reopen this dialog to try again.'
-													) }
-												</div>
-											);
-										}
-										if ( node.hasError ) {
+										if (
+											( nodeId === 'wp-content' && type === 'pull' && remoteFileTreeError ) ||
+											node.hasError
+										) {
 											return (
 												<div className="text-gray-500 italic">
 													{ __(

--- a/src/modules/sync/components/sync-dialog.tsx
+++ b/src/modules/sync/components/sync-dialog.tsx
@@ -57,6 +57,7 @@ const useDynamicTreeState = (
 		isLoading: isLoadingLocalFileTree,
 		error: localFileTreeError,
 	} = useLocalFileTree();
+	const [ remoteFileTreeError, setRemoteFileTreeError ] = useState< Error | null >( null );
 
 	// If the site was just created and if there is no rewind_id yet,
 	// then all options are pre-checked to allow only a full sync
@@ -73,6 +74,7 @@ const useDynamicTreeState = (
 		if ( type === 'pull' && remoteSiteId ) {
 			let isCancelled = false;
 			const loadRemoteTree = async () => {
+				setRemoteFileTreeError( null );
 				try {
 					if ( rewindId ) {
 						const remoteTree = await fetchChildren( remoteSiteId, rewindId, '/wp-content/', false );
@@ -83,7 +85,10 @@ const useDynamicTreeState = (
 						}
 					}
 				} catch ( error ) {
-					console.error( 'Failed to load remote file tree:', error );
+					const errorObj = error instanceof Error ? error : new Error( 'Unknown error occurred' );
+					if ( ! isCancelled ) {
+						setRemoteFileTreeError( errorObj );
+					}
 				}
 			};
 			void loadRemoteTree();
@@ -125,6 +130,7 @@ const useDynamicTreeState = (
 		isErrorRewindId,
 		isLoadingLocalFileTree,
 		localFileTreeError,
+		remoteFileTreeError,
 	};
 };
 
@@ -162,6 +168,7 @@ export function SyncDialog( {
 		isErrorRewindId,
 		isLoadingLocalFileTree,
 		localFileTreeError,
+		remoteFileTreeError,
 	} = useDynamicTreeState( type, localSite.id, remoteSite.id, setTreeState );
 
 	const [ wpVersion ] = useGetWpVersion( localSite );
@@ -224,9 +231,36 @@ export function SyncDialog( {
 				return;
 			}
 
-			if ( type === 'pull' && rewindId && node.path && node.children?.length === 0 ) {
-				const children = await fetchChildren( remoteSite.id, rewindId, node.path, node.checked );
-				setTreeState( ( prev ) => updateNodeById( prev, node.id, { children } ) );
+			if ( type === 'pull' && rewindId && node.path ) {
+				// Allow refetching if there's an error or if children are empty
+				const shouldFetch = node.children?.length === 0 || node.error;
+
+				if ( shouldFetch ) {
+					// Set loading state and clear any previous error
+					setTreeState( ( prev ) =>
+						updateNodeById( prev, node.id, { loading: true, error: undefined } )
+					);
+
+					try {
+						const children = await fetchChildren(
+							remoteSite.id,
+							rewindId,
+							node.path,
+							node.checked
+						);
+						setTreeState( ( prev ) =>
+							updateNodeById( prev, node.id, { children, loading: false, error: undefined } )
+						);
+					} catch ( error ) {
+						setTreeState( ( prev ) =>
+							updateNodeById( prev, node.id, {
+								children: [],
+								loading: false,
+								error: 'Error retrieving files and directories',
+							} )
+						);
+					}
+				}
 			}
 			// For push operations, children are already loaded - no async fetching needed
 		},
@@ -361,12 +395,30 @@ export function SyncDialog( {
 										}
 										return null;
 									} }
-									renderEmptyContent={ ( nodeId ) => {
+									renderEmptyContent={ ( nodeId, node ) => {
 										if ( nodeId === 'wp-content' && type === 'push' && localFileTreeError ) {
 											return (
 												<div className="text-gray-500 italic">
 													{ __(
 														'Could not load files. Please close and reopen this dialog to try again.'
+													) }
+												</div>
+											);
+										}
+										if ( nodeId === 'wp-content' && type === 'pull' && remoteFileTreeError ) {
+											return (
+												<div className="text-gray-500 italic">
+													{ __(
+														'Error retrieving remote files and directories. Please close and reopen this dialog to try again.'
+													) }
+												</div>
+											);
+										}
+										if ( node.error ) {
+											return (
+												<div className="text-gray-500 italic">
+													{ __(
+														'Error retrieving remote files and directories. Please close and reopen this dialog to try again.'
 													) }
 												</div>
 											);

--- a/src/modules/sync/components/sync-dialog.tsx
+++ b/src/modules/sync/components/sync-dialog.tsx
@@ -231,35 +231,23 @@ export function SyncDialog( {
 				return;
 			}
 
-			if ( type === 'pull' && rewindId && node.path ) {
-				// Allow refetching if there's an error or if children are empty
-				const shouldFetch = node.children?.length === 0 || node.error;
+			if ( type === 'pull' && rewindId && node.path && node.children?.length === 0 ) {
+				// Set loading state for the node
+				setTreeState( ( prev ) => updateNodeById( prev, node.id, { loading: true } ) );
 
-				if ( shouldFetch ) {
-					// Set loading state and clear any previous error
+				try {
+					const children = await fetchChildren( remoteSite.id, rewindId, node.path, node.checked );
 					setTreeState( ( prev ) =>
-						updateNodeById( prev, node.id, { loading: true, error: undefined } )
+						updateNodeById( prev, node.id, { children, loading: false, error: undefined } )
 					);
-
-					try {
-						const children = await fetchChildren(
-							remoteSite.id,
-							rewindId,
-							node.path,
-							node.checked
-						);
-						setTreeState( ( prev ) =>
-							updateNodeById( prev, node.id, { children, loading: false, error: undefined } )
-						);
-					} catch ( error ) {
-						setTreeState( ( prev ) =>
-							updateNodeById( prev, node.id, {
-								children: [],
-								loading: false,
-								error: 'Error retrieving files and directories',
-							} )
-						);
-					}
+				} catch ( error ) {
+					setTreeState( ( prev ) =>
+						updateNodeById( prev, node.id, {
+							children: [],
+							loading: false,
+							error: 'Error retrieving files and directories',
+						} )
+					);
 				}
 			}
 			// For push operations, children are already loaded - no async fetching needed

--- a/src/stores/sync/sync-api.ts
+++ b/src/stores/sync/sync-api.ts
@@ -125,6 +125,7 @@ export const fetchRemoteFileTree = createAsyncThunk(
 
 		const validationResult = BackupLsResponseSchema.shape.body.safeParse( rawResponse );
 		if ( ! validationResult.success ) {
+			console.error( 'Invalid response format:', validationResult.error );
 			throw new Error( 'Invalid response format from server' );
 		}
 
@@ -139,6 +140,8 @@ export const fetchRemoteFileTree = createAsyncThunk(
 			if ( itemValidation.success ) {
 				const node = convertBackupItemToTreeNode( name, itemValidation.data, path, parentChecked );
 				children.push( node );
+			} else {
+				console.warn( `Invalid item format for ${ name }:`, itemValidation.error );
 			}
 		}
 

--- a/src/stores/sync/sync-api.ts
+++ b/src/stores/sync/sync-api.ts
@@ -110,15 +110,21 @@ export const fetchRemoteFileTree = createAsyncThunk(
 			path,
 		};
 
-		const rawResponse = await client.req.post( {
-			path: `/sites/${ remoteSiteId }/rewind/backup/ls`,
-			apiNamespace: 'wpcom/v2',
-			body: requestBody,
-		} );
+		let rawResponse;
+		try {
+			rawResponse = await client.req.post( {
+				path: `/sites/${ remoteSiteId }/rewind/backup/ls`,
+				apiNamespace: 'wpcom/v2',
+				body: requestBody,
+			} );
+		} catch ( err ) {
+			const errorMessage =
+				err instanceof Error ? err.message : 'Network error while fetching remote file tree';
+			throw new Error( errorMessage );
+		}
 
 		const validationResult = BackupLsResponseSchema.shape.body.safeParse( rawResponse );
 		if ( ! validationResult.success ) {
-			console.error( 'Invalid response format:', validationResult.error );
 			throw new Error( 'Invalid response format from server' );
 		}
 
@@ -133,8 +139,6 @@ export const fetchRemoteFileTree = createAsyncThunk(
 			if ( itemValidation.success ) {
 				const node = convertBackupItemToTreeNode( name, itemValidation.data, path, parentChecked );
 				children.push( node );
-			} else {
-				console.warn( `Invalid item format for ${ name }:`, itemValidation.error );
 			}
 		}
 

--- a/src/stores/sync/sync-hooks.ts
+++ b/src/stores/sync/sync-hooks.ts
@@ -60,8 +60,9 @@ export function useRemoteFileTree() {
 
 				return result.children;
 			} catch ( err ) {
-				console.error( 'Failed to fetch remote file tree:', err );
-				return [];
+				const errorMessage =
+					err instanceof Error ? err.message : 'Failed to fetch remote file tree';
+				throw new Error( errorMessage );
 			}
 		},
 		[ client, dispatch ]


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

Fixes [STU-702](https://linear.app/a8c/issue/STU-702)

## Proposed Changes

This PR adds the error handling for when there is an error fetching remote children in the file tree:

<img width="1492" height="689" alt="Screenshot 2026-01-08 at 4 02 21 PM" src="https://github.com/user-attachments/assets/9b40eed3-ea90-4251-bac9-3dd095bb958b" />


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
* Apply the following diff:

```diff --git a/src/stores/sync/sync-api.ts b/src/stores/sync/sync-api.ts
index 7babf7fd..d98eaf13 100644
--- a/src/stores/sync/sync-api.ts
+++ b/src/stores/sync/sync-api.ts
@@ -112,6 +112,11 @@ export const fetchRemoteFileTree = createAsyncThunk(
 
                let rawResponse;
                try {
+                       // TEMPORARY: Simulate error for testing specific node
+                       if ( path === '/wp-content/themes/' ) {
+                               throw new Error( 'Simulated error for themes folder' );
+                       }
+
                        rawResponse = await client.req.post( {
                                path: `/sites/${ remoteSiteId }/rewind/backup/ls`,
                                apiNamespace: 'wpcom/v2',
```

* Start Studio with `npm start`
* Ensure that you have at least one WP.com site connected to a local Studio site
* Navigate to the Sync tab
* Click on the Pull button
* Open the `Specific files and folders section`
* Open the `themes` folder
* Confirm that you can see the error indicated on the screenshot

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
