### PR TITLE
CLI: Add `runOnSites` abstraction and utilize it to refactor `site stop` and `site stop --all` commands

### DIFF
--- a/cli/commands/site/stop.ts
+++ b/cli/commands/site/stop.ts
@@ -1,138 +1,99 @@
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { SiteCommandLoggerAction as LoggerAction } from 'common/logger-actions';
-import {
-	clearSiteLatestCliPid,
-	getSiteByFolder,
-	readAppdata,
-	updateSiteAutoStart,
-	type SiteData,
-} from 'cli/lib/appdata';
+import { clearSiteLatestCliPid, updateSiteAutoStart } from 'cli/lib/appdata';
 import { connect, disconnect } from 'cli/lib/pm2-manager';
-import { stopProxyIfNoSitesNeedIt } from 'cli/lib/site-utils';
+import { ALL_SITES, runOnSites, stopProxyIfNoSitesNeedIt } from 'cli/lib/site-utils';
 import { isServerRunning, stopWordPressServer } from 'cli/lib/wordpress-server-manager';
 import { Logger, LoggerError } from 'cli/logger';
 import { StudioArgv } from 'cli/types';
 
 const logger = new Logger< LoggerAction >();
 
-const filterRunningSites = async ( sites: SiteData[] ): Promise< SiteData[] > => {
-	const runningSites = [];
+export async function runCommand(
+	target: typeof ALL_SITES | string,
+	{ autoStart = false }: { autoStart?: boolean } = {}
+): Promise< void > {
+	const all = target === ALL_SITES;
 
-	for ( const site of sites ) {
-		const runningProcess = await isServerRunning( site.id );
-
-		if ( runningProcess ) {
-			runningSites.push( site );
-		}
-	}
-
-	return runningSites;
-};
-
-export async function runCommand( siteFolder: string, autoStart: boolean ): Promise< void > {
 	try {
-		const site = await getSiteByFolder( siteFolder );
-
 		await connect();
 
-		const runningProcess = await isServerRunning( site.id );
-		if ( ! runningProcess ) {
-			logger.reportSuccess( __( 'WordPress site is not running' ) );
-			return;
+		if ( all ) {
+			logger.reportStart( LoggerAction.STOP_ALL_SITES, __( 'Stopping all WordPress sites...' ) );
+		} else {
+			logger.reportStart( LoggerAction.STOP_SITE, __( 'Stopping WordPress site…' ) );
 		}
 
-		logger.reportStart( LoggerAction.STOP_SITE, __( 'Stopping WordPress site…' ) );
-		try {
-			await stopWordPressServer( site.id );
-			await clearSiteLatestCliPid( site.id );
-			await updateSiteAutoStart( site.id, autoStart );
-			logger.reportSuccess( __( 'WordPress site stopped' ) );
-			await stopProxyIfNoSitesNeedIt( site.id, logger );
-		} catch ( error ) {
-			throw new LoggerError( __( 'Failed to stop WordPress server' ), error );
-		}
-	} finally {
-		disconnect();
-	}
-}
+		const { requested, succeeded, failed } = await runOnSites(
+			target,
+			async ( site, allSitesToProcess ) => {
+				if ( all ) {
+					logger.reportProgress(
+						sprintf(
+							__( 'Stopping site "%s" (%d/%d)…' ),
+							site.name,
+							allSitesToProcess.indexOf( site ) + 1,
+							allSitesToProcess.length
+						)
+					);
+				}
 
-export async function runCommandAll( autoStart: boolean ): Promise< void > {
-	try {
-		const appdata = await readAppdata();
-		const allSites = appdata.sites;
-
-		if ( ! allSites.length ) {
-			logger.reportSuccess( __( 'No sites found' ) );
-			return;
-		}
-
-		await connect();
-
-		const runningSites = await filterRunningSites( allSites );
-
-		if ( ! runningSites.length ) {
-			logger.reportSuccess( __( 'No sites are currently running' ) );
-			return;
-		}
-
-		const stoppedSiteIds: string[] = [];
-
-		logger.reportStart(
-			LoggerAction.STOP_ALL_SITES,
-			sprintf(
-				__( 'Stopping all WordPress sites... (%d/%d)' ),
-				stoppedSiteIds.length,
-				runningSites.length
-			)
+				try {
+					await stopWordPressServer( site.id );
+					await clearSiteLatestCliPid( site.id );
+					await updateSiteAutoStart( site.id, autoStart );
+				} catch ( error ) {
+					logger.reportError(
+						new LoggerError( sprintf( __( 'Failed to stop site %s' ), site.name ) )
+					);
+					throw error;
+				}
+			},
+			{
+				filter: async ( site ) => !! ( await isServerRunning( site.id ) ),
+			}
 		);
 
-		for ( const site of runningSites ) {
-			try {
-				logger.reportProgress(
+		// Handle logging based on results
+		if ( ! all ) {
+			if ( ! succeeded.length && ! failed.length ) {
+				logger.reportSuccess( __( 'WordPress site is not running' ) );
+			} else if ( succeeded.length > 0 ) {
+				logger.reportSuccess( __( 'WordPress site stopped' ) );
+			}
+		} else {
+			if ( requested.length === 0 ) {
+				logger.reportSuccess( __( 'No sites found' ) );
+			} else if ( succeeded.length === 0 && failed.length === 0 ) {
+				logger.reportSuccess( __( 'No sites are currently running' ) );
+			} else if ( failed.length > 0 && succeeded.length === 0 ) {
+				throw new LoggerError( sprintf( __( 'Failed to stop all (%d) sites' ), failed.length ) );
+			} else if ( failed.length > 0 ) {
+				throw new LoggerError(
 					sprintf(
-						__( 'Stopping site "%s" (%d/%d)…' ),
-						site.name,
-						stoppedSiteIds.length + 1,
-						runningSites.length
+						__( 'Stopped %d sites out of %d' ),
+						succeeded.length,
+						succeeded.length + failed.length
 					)
 				);
-				await stopWordPressServer( site.id );
-				await clearSiteLatestCliPid( site.id );
-				await updateSiteAutoStart( site.id, autoStart );
-
-				stoppedSiteIds.push( site.id );
-			} catch ( error ) {
-				logger.reportError(
-					new LoggerError( sprintf( __( 'Failed to stop site %s' ), site.name ) )
+			} else {
+				logger.reportSuccess(
+					sprintf(
+						_n( 'Successfully stopped %d site', 'Successfully stopped %d sites', succeeded.length ),
+						succeeded.length
+					)
 				);
 			}
 		}
 
-		try {
-			await stopProxyIfNoSitesNeedIt( stoppedSiteIds, logger );
-		} catch ( error ) {
-			throw new LoggerError( __( 'Failed to stop proxy server' ), error );
-		}
-
-		if ( stoppedSiteIds.length === runningSites.length ) {
-			logger.reportSuccess(
-				sprintf(
-					_n(
-						'Successfully stopped %d site',
-						'Successfully stopped %d sites',
-						runningSites.length
-					),
-					runningSites.length
-				)
-			);
-		} else if ( stoppedSiteIds.length === 0 ) {
-			throw new LoggerError(
-				sprintf( __( 'Failed to stop all (%d) sites' ), runningSites.length )
-			);
-		} else {
-			throw new LoggerError(
-				sprintf( __( 'Stopped %d sites out of %d' ), stoppedSiteIds.length, runningSites.length )
-			);
+		// Handle proxy cleanup (should be handled as the last step, to ensure that messages above are logged first)
+		const stoppedSiteIds = succeeded.map( ( { site } ) => site.id );
+		if ( stoppedSiteIds.length > 0 ) {
+			try {
+				await stopProxyIfNoSitesNeedIt( stoppedSiteIds, logger );
+			} catch ( error ) {
+				throw new LoggerError( __( 'Failed to stop proxy server' ), error );
+			}
 		}
 	} finally {
 		disconnect();
@@ -159,11 +120,7 @@ export const registerCommand = ( yargs: StudioArgv ) => {
 		},
 		handler: async ( argv ) => {
 			try {
-				if ( argv.all ) {
-					await runCommandAll( argv.autoStart );
-				} else {
-					await runCommand( argv.path, argv.autoStart );
-				}
+				await runCommand( argv.all ? ALL_SITES : argv.path, { autoStart: argv.autoStart } );
 			} catch ( error ) {
 				if ( error instanceof LoggerError ) {
 					logger.reportError( error );

--- a/cli/commands/site/tests/stop.test.ts
+++ b/cli/commands/site/tests/stop.test.ts
@@ -75,10 +75,11 @@ describe( 'CLI: studio site stop', () => {
 		} );
 
 		it( 'should throw when WordPress server stop fails', async () => {
+			const error = new Error( 'Server stop failed' );
 			( isServerRunning as jest.Mock ).mockResolvedValue( testProcessDescription );
-			( stopWordPressServer as jest.Mock ).mockRejectedValue( new Error( 'Server stop failed' ) );
+			( stopWordPressServer as jest.Mock ).mockRejectedValue( error );
 
-			await expect( runCommand( '/test/site' ) ).rejects.toThrow( 'Server stop failed' );
+			await expect( runCommand( '/test/site' ) ).rejects.toThrow( error );
 			expect( disconnect ).toHaveBeenCalled();
 		} );
 	} );

--- a/cli/commands/site/tests/stop.test.ts
+++ b/cli/commands/site/tests/stop.test.ts
@@ -6,9 +6,8 @@ import {
 	updateSiteAutoStart,
 } from 'cli/lib/appdata';
 import { connect, disconnect } from 'cli/lib/pm2-manager';
-import { stopProxyIfNoSitesNeedIt } from 'cli/lib/site-utils';
+import { ALL_SITES, stopProxyIfNoSitesNeedIt } from 'cli/lib/site-utils';
 import { isServerRunning, stopWordPressServer } from 'cli/lib/wordpress-server-manager';
-import { ALL_SITES } from 'cli/lib/site-utils';
 import { runCommand } from '../stop';
 
 jest.mock( 'cli/lib/appdata', () => ( {

--- a/cli/commands/site/tests/stop.test.ts
+++ b/cli/commands/site/tests/stop.test.ts
@@ -75,11 +75,14 @@ describe( 'CLI: studio site stop', () => {
 		} );
 
 		it( 'should throw when WordPress server stop fails', async () => {
-			const error = new Error( 'Server stop failed' );
 			( isServerRunning as jest.Mock ).mockResolvedValue( testProcessDescription );
-			( stopWordPressServer as jest.Mock ).mockRejectedValue( error );
+			( stopWordPressServer as jest.Mock ).mockRejectedValue(
+				new Error( 'Failed to stop WordPress server' )
+			);
 
-			await expect( runCommand( '/test/site' ) ).rejects.toThrow( error );
+			await expect( runCommand( '/test/site' ) ).rejects.toThrow(
+				'Failed to stop WordPress server'
+			);
 			expect( disconnect ).toHaveBeenCalled();
 		} );
 	} );

--- a/cli/commands/site/tests/stop.test.ts
+++ b/cli/commands/site/tests/stop.test.ts
@@ -78,9 +78,7 @@ describe( 'CLI: studio site stop', () => {
 			( isServerRunning as jest.Mock ).mockResolvedValue( testProcessDescription );
 			( stopWordPressServer as jest.Mock ).mockRejectedValue( new Error( 'Server stop failed' ) );
 
-			await expect( runCommand( '/test/site' ) ).rejects.toThrow(
-				'Failed to stop WordPress server'
-			);
+			await expect( runCommand( '/test/site' ) ).rejects.toThrow( 'Server stop failed' );
 			expect( disconnect ).toHaveBeenCalled();
 		} );
 	} );

--- a/cli/commands/site/tests/stop.test.ts
+++ b/cli/commands/site/tests/stop.test.ts
@@ -8,7 +8,8 @@ import {
 import { connect, disconnect } from 'cli/lib/pm2-manager';
 import { stopProxyIfNoSitesNeedIt } from 'cli/lib/site-utils';
 import { isServerRunning, stopWordPressServer } from 'cli/lib/wordpress-server-manager';
-import { runCommand, runCommandAll } from '../stop';
+import { ALL_SITES } from 'cli/lib/site-utils';
+import { runCommand } from '../stop';
 
 jest.mock( 'cli/lib/appdata', () => ( {
 	...jest.requireActual( 'cli/lib/appdata' ),
@@ -19,7 +20,10 @@ jest.mock( 'cli/lib/appdata', () => ( {
 	getAppdataDirectory: jest.fn().mockReturnValue( '/test/appdata' ),
 } ) );
 jest.mock( 'cli/lib/pm2-manager' );
-jest.mock( 'cli/lib/site-utils' );
+jest.mock( 'cli/lib/site-utils', () => ( {
+	...jest.requireActual( 'cli/lib/site-utils' ),
+	stopProxyIfNoSitesNeedIt: jest.fn(),
+} ) );
 jest.mock( 'cli/lib/wordpress-server-manager' );
 
 describe( 'CLI: studio site stop', () => {
@@ -59,14 +63,14 @@ describe( 'CLI: studio site stop', () => {
 		it( 'should throw when site not found', async () => {
 			( getSiteByFolder as jest.Mock ).mockRejectedValue( new Error( 'Site not found' ) );
 
-			await expect( runCommand( '/invalid/path', false ) ).rejects.toThrow( 'Site not found' );
+			await expect( runCommand( '/invalid/path' ) ).rejects.toThrow( 'Site not found' );
 			expect( disconnect ).toHaveBeenCalled();
 		} );
 
 		it( 'should throw when PM2 connection fails', async () => {
 			( connect as jest.Mock ).mockRejectedValue( new Error( 'PM2 connection failed' ) );
 
-			await expect( runCommand( '/test/site', false ) ).rejects.toThrow( 'PM2 connection failed' );
+			await expect( runCommand( '/test/site' ) ).rejects.toThrow( 'PM2 connection failed' );
 			expect( disconnect ).toHaveBeenCalled();
 		} );
 
@@ -74,7 +78,7 @@ describe( 'CLI: studio site stop', () => {
 			( isServerRunning as jest.Mock ).mockResolvedValue( testProcessDescription );
 			( stopWordPressServer as jest.Mock ).mockRejectedValue( new Error( 'Server stop failed' ) );
 
-			await expect( runCommand( '/test/site', false ) ).rejects.toThrow(
+			await expect( runCommand( '/test/site' ) ).rejects.toThrow(
 				'Failed to stop WordPress server'
 			);
 			expect( disconnect ).toHaveBeenCalled();
@@ -83,7 +87,7 @@ describe( 'CLI: studio site stop', () => {
 
 	describe( 'Success Cases', () => {
 		it( 'should skip stop if server is not running', async () => {
-			await runCommand( '/test/site', false );
+			await runCommand( '/test/site' );
 
 			expect( stopWordPressServer ).not.toHaveBeenCalled();
 			expect( clearSiteLatestCliPid ).not.toHaveBeenCalled();
@@ -94,19 +98,22 @@ describe( 'CLI: studio site stop', () => {
 		it( 'should stop a running site', async () => {
 			( isServerRunning as jest.Mock ).mockResolvedValue( testProcessDescription );
 
-			await runCommand( '/test/site', false );
+			await runCommand( '/test/site' );
 
 			expect( getSiteByFolder ).toHaveBeenCalledWith( '/test/site' );
 			expect( connect ).toHaveBeenCalled();
 			expect( isServerRunning ).toHaveBeenCalledWith( testSite.id );
 			expect( stopWordPressServer ).toHaveBeenCalledWith( testSite.id );
 			expect( clearSiteLatestCliPid ).toHaveBeenCalledWith( testSite.id );
-			expect( stopProxyIfNoSitesNeedIt ).toHaveBeenCalledWith( testSite.id, expect.any( Object ) );
+			expect( stopProxyIfNoSitesNeedIt ).toHaveBeenCalledWith(
+				[ testSite.id ],
+				expect.any( Object )
+			);
 			expect( disconnect ).toHaveBeenCalled();
 		} );
 
 		it( 'should not call stopProxyIfNoSitesNeedIt if site is not running', async () => {
-			await runCommand( '/test/site', false );
+			await runCommand( '/test/site' );
 
 			expect( stopProxyIfNoSitesNeedIt ).not.toHaveBeenCalled();
 			expect( disconnect ).toHaveBeenCalled();
@@ -115,7 +122,7 @@ describe( 'CLI: studio site stop', () => {
 		it( 'should set autoStart to true when flag is passed', async () => {
 			( isServerRunning as jest.Mock ).mockResolvedValue( testProcessDescription );
 
-			await runCommand( '/test/site', true );
+			await runCommand( '/test/site', { autoStart: true } );
 
 			expect( updateSiteAutoStart ).toHaveBeenCalledWith( testSite.id, true );
 		} );
@@ -123,7 +130,7 @@ describe( 'CLI: studio site stop', () => {
 		it( 'should set autoStart to false when flag is not passed', async () => {
 			( isServerRunning as jest.Mock ).mockResolvedValue( testProcessDescription );
 
-			await runCommand( '/test/site', false );
+			await runCommand( '/test/site' );
 
 			expect( updateSiteAutoStart ).toHaveBeenCalledWith( testSite.id, false );
 		} );
@@ -131,7 +138,7 @@ describe( 'CLI: studio site stop', () => {
 
 	describe( 'Cleanup', () => {
 		it( 'should always disconnect from PM2 on success', async () => {
-			await runCommand( '/test/site', false );
+			await runCommand( '/test/site' );
 
 			expect( disconnect ).toHaveBeenCalled();
 		} );
@@ -140,7 +147,7 @@ describe( 'CLI: studio site stop', () => {
 			( getSiteByFolder as jest.Mock ).mockRejectedValue( new Error( 'Error' ) );
 
 			try {
-				await runCommand( '/test/site', false );
+				await runCommand( '/test/site' );
 			} catch {
 				// Expected
 			}
@@ -149,7 +156,7 @@ describe( 'CLI: studio site stop', () => {
 		} );
 
 		it( 'should always disconnect when site is not running', async () => {
-			await runCommand( '/test/site', false );
+			await runCommand( '/test/site' );
 
 			expect( disconnect ).toHaveBeenCalled();
 		} );
@@ -211,15 +218,14 @@ describe( 'CLI: studio site stop --all', () => {
 		it( 'should throw when appdata cannot be read', async () => {
 			( readAppdata as jest.Mock ).mockRejectedValue( new Error( 'Failed to read appdata' ) );
 
-			await expect( runCommandAll( false ) ).rejects.toThrow( 'Failed to read appdata' );
+			await expect( runCommand( ALL_SITES ) ).rejects.toThrow( 'Failed to read appdata' );
 			expect( disconnect ).toHaveBeenCalled();
 		} );
 
 		it( 'should throw when PM2 connection fails', async () => {
-			( readAppdata as jest.Mock ).mockResolvedValue( { sites: testSites } );
 			( connect as jest.Mock ).mockRejectedValue( new Error( 'PM2 connection failed' ) );
 
-			await expect( runCommandAll( false ) ).rejects.toThrow( 'PM2 connection failed' );
+			await expect( runCommand( ALL_SITES ) ).rejects.toThrow( 'PM2 connection failed' );
 			expect( disconnect ).toHaveBeenCalled();
 		} );
 
@@ -228,7 +234,7 @@ describe( 'CLI: studio site stop --all', () => {
 			( isServerRunning as jest.Mock ).mockResolvedValue( testProcessDescription );
 			( stopWordPressServer as jest.Mock ).mockRejectedValue( new Error( 'Server stop failed' ) );
 
-			await expect( runCommandAll( false ) ).rejects.toThrow( 'Failed to stop all (3) sites' );
+			await expect( runCommand( ALL_SITES ) ).rejects.toThrow( 'Failed to stop all (3) sites' );
 			expect( disconnect ).toHaveBeenCalled();
 		} );
 
@@ -241,7 +247,7 @@ describe( 'CLI: studio site stop --all', () => {
 				.mockRejectedValueOnce( new Error( 'Server stop failed' ) ) // site-2 fails
 				.mockResolvedValueOnce( undefined ); // site-3 success
 
-			await expect( runCommandAll( false ) ).rejects.toThrow( 'Stopped 2 sites out of 3' );
+			await expect( runCommand( ALL_SITES ) ).rejects.toThrow( 'Stopped 2 sites out of 3' );
 			expect( disconnect ).toHaveBeenCalled();
 			expect( stopWordPressServer ).toHaveBeenCalledTimes( 3 );
 		} );
@@ -251,10 +257,10 @@ describe( 'CLI: studio site stop --all', () => {
 		it( 'should handle empty sites list', async () => {
 			( readAppdata as jest.Mock ).mockResolvedValue( { sites: [] } );
 
-			await runCommandAll( false );
+			await runCommand( ALL_SITES );
 
-			expect( connect ).not.toHaveBeenCalled();
 			expect( stopWordPressServer ).not.toHaveBeenCalled();
+			expect( disconnect ).toHaveBeenCalled();
 		} );
 
 		it( 'should skip if no sites are running', async () => {
@@ -262,7 +268,7 @@ describe( 'CLI: studio site stop --all', () => {
 
 			( isServerRunning as jest.Mock ).mockResolvedValue( undefined );
 
-			await runCommandAll( false );
+			await runCommand( ALL_SITES );
 
 			expect( connect ).toHaveBeenCalled();
 			expect( isServerRunning ).toHaveBeenCalledTimes( 3 );
@@ -276,7 +282,7 @@ describe( 'CLI: studio site stop --all', () => {
 			( readAppdata as jest.Mock ).mockResolvedValue( { sites: [ testSites[ 0 ] ] } );
 			( isServerRunning as jest.Mock ).mockResolvedValue( testProcessDescription );
 
-			await runCommandAll( false );
+			await runCommand( ALL_SITES );
 
 			expect( stopWordPressServer ).toHaveBeenCalledTimes( 1 );
 			expect( stopWordPressServer ).toHaveBeenCalledWith( 'site-1' );
@@ -287,7 +293,7 @@ describe( 'CLI: studio site stop --all', () => {
 			( readAppdata as jest.Mock ).mockResolvedValue( { sites: testSites } );
 			( isServerRunning as jest.Mock ).mockResolvedValue( testProcessDescription );
 
-			await runCommandAll( false );
+			await runCommand( ALL_SITES );
 
 			expect( readAppdata ).toHaveBeenCalled();
 			expect( connect ).toHaveBeenCalled();
@@ -321,7 +327,7 @@ describe( 'CLI: studio site stop --all', () => {
 				.mockResolvedValueOnce( undefined ) // site-2 not running
 				.mockResolvedValueOnce( testProcessDescription ); // site-3 running
 
-			await runCommandAll( false );
+			await runCommand( ALL_SITES );
 
 			expect( isServerRunning ).toHaveBeenCalledTimes( 3 );
 
@@ -344,7 +350,7 @@ describe( 'CLI: studio site stop --all', () => {
 				.mockResolvedValueOnce( undefined ); // site-3 success
 
 			try {
-				await runCommandAll( false );
+				await runCommand( ALL_SITES );
 			} catch {
 				// Expected to throw due to partial failure
 			}
@@ -365,7 +371,7 @@ describe( 'CLI: studio site stop --all', () => {
 			);
 
 			// Should throw when proxy stop fails
-			await expect( runCommandAll( false ) ).rejects.toThrow( 'Failed to stop proxy server' );
+			await expect( runCommand( ALL_SITES ) ).rejects.toThrow( 'Failed to stop proxy server' );
 
 			expect( stopWordPressServer ).toHaveBeenCalledWith( 'site-1' );
 			expect( disconnect ).toHaveBeenCalled();
@@ -377,7 +383,7 @@ describe( 'CLI: studio site stop --all', () => {
 			( readAppdata as jest.Mock ).mockResolvedValue( { sites: testSites } );
 			( isServerRunning as jest.Mock ).mockResolvedValue( testProcessDescription );
 
-			await runCommandAll( false );
+			await runCommand( ALL_SITES );
 
 			expect( disconnect ).toHaveBeenCalled();
 		} );
@@ -386,7 +392,7 @@ describe( 'CLI: studio site stop --all', () => {
 			( readAppdata as jest.Mock ).mockRejectedValue( new Error( 'Error' ) );
 
 			try {
-				await runCommandAll( false );
+				await runCommand( ALL_SITES );
 			} catch {
 				// Expected
 			}
@@ -397,7 +403,7 @@ describe( 'CLI: studio site stop --all', () => {
 		it( 'should always disconnect when no sites exist', async () => {
 			( readAppdata as jest.Mock ).mockResolvedValue( { sites: [] } );
 
-			await runCommandAll( false );
+			await runCommand( ALL_SITES );
 
 			expect( disconnect ).toHaveBeenCalled();
 		} );
@@ -406,7 +412,7 @@ describe( 'CLI: studio site stop --all', () => {
 			( readAppdata as jest.Mock ).mockResolvedValue( { sites: testSites } );
 			( isServerRunning as jest.Mock ).mockResolvedValue( undefined );
 
-			await runCommandAll( false );
+			await runCommand( ALL_SITES );
 
 			expect( disconnect ).toHaveBeenCalled();
 		} );

--- a/cli/lib/site-utils.ts
+++ b/cli/lib/site-utils.ts
@@ -1,12 +1,111 @@
 import { __ } from '@wordpress/i18n';
 import { SiteCommandLoggerAction as LoggerAction } from 'common/logger-actions';
-import { getSiteUrl, readAppdata, SiteData } from 'cli/lib/appdata';
+import { getSiteByFolder, getSiteUrl, readAppdata, SiteData } from 'cli/lib/appdata';
 import { openBrowser } from 'cli/lib/browser';
 import { generateSiteCertificate } from 'cli/lib/certificate-manager';
 import { addDomainToHosts } from 'cli/lib/hosts-file';
 import { isProxyProcessRunning, startProxyProcess, stopProxyProcess } from 'cli/lib/pm2-manager';
 import { isServerRunning } from 'cli/lib/wordpress-server-manager';
 import { Logger, LoggerError } from 'cli/logger';
+
+export const ALL_SITES = Symbol( 'all' );
+
+interface RunOnSitesResult {
+	requested: Array< { site: SiteData } >;
+	succeeded: Array< { site: SiteData } >;
+	failed: Array< { site: SiteData; error: unknown } >;
+}
+
+// Just to have nice type in runOnSites arguments
+type SiteFolderPath = string;
+
+/**
+ * Runs an operation on either a single site (by folder) or all sites.
+ * Caller is responsible for logging/messaging based on results.
+ *
+ * @param target - Site folder path, or ALL_SITES symbol for all sites
+ * @param operation - The operation to run on each site
+ * @param options - Optional filter
+ *
+ * @example
+ * // Single site
+ * const result = await runOnSites('/path/to/site', async (site) => {
+ *   await stopServer(site.id);
+ * });
+ *
+ * @example
+ * // All running sites
+ * const result = await runOnSites(ALL_SITES, async (site) => {
+ *   await stopServer(site.id);
+ * }, { filter: async (site) => await isServerRunning(site.id) });
+ */
+export async function runOnSites(
+	target: typeof ALL_SITES | SiteFolderPath,
+	operation: ( site: SiteData, sitesToProcess: SiteData[] ) => Promise< void >,
+	options: { filter?: ( site: SiteData ) => Promise< boolean > | boolean } = {}
+): Promise< RunOnSitesResult > {
+	const { filter } = options;
+	const all = target === ALL_SITES;
+
+	// Single site mode
+	if ( ! all ) {
+		const site = await getSiteByFolder( target );
+
+		// Apply filter if provided
+		if ( filter ) {
+			const shouldProcess = await filter( site );
+			if ( ! shouldProcess ) {
+				return { requested: [ { site } ], succeeded: [], failed: [] };
+			}
+		}
+
+		// In single-site mode, let errors propagate (don't catch them)
+		await operation( site, [ site ] );
+		return { requested: [ { site } ], succeeded: [ { site } ], failed: [] };
+	}
+
+	// All sites mode
+	const appdata = await readAppdata();
+	const allSites = appdata.sites;
+
+	if ( ! allSites.length ) {
+		return { requested: [], succeeded: [], failed: [] };
+	}
+
+	const requested = allSites.map( ( site ) => ( { site } ) );
+
+	// Apply filter if provided
+	let sitesToProcess: SiteData[];
+	if ( filter ) {
+		sitesToProcess = [];
+		for ( const site of allSites ) {
+			const shouldProcess = await filter( site );
+			if ( shouldProcess ) {
+				sitesToProcess.push( site );
+			}
+		}
+	} else {
+		sitesToProcess = allSites;
+	}
+
+	if ( ! sitesToProcess.length ) {
+		return { requested, succeeded: [], failed: [] };
+	}
+
+	const succeeded: Array< { site: SiteData } > = [];
+	const failed: Array< { site: SiteData; error: unknown } > = [];
+
+	for ( const site of sitesToProcess ) {
+		try {
+			await operation( site, sitesToProcess );
+			succeeded.push( { site } );
+		} catch ( error ) {
+			failed.push( { site, error } );
+		}
+	}
+
+	return { requested, succeeded, failed };
+}
 
 /**
  * Starts the HTTP proxy server if it's not already running

--- a/cli/lib/site-utils.ts
+++ b/cli/lib/site-utils.ts
@@ -51,7 +51,6 @@ export async function runOnSites(
 	if ( ! all ) {
 		const site = await getSiteByFolder( target );
 
-		// Apply filter if provided
 		if ( filter ) {
 			const shouldProcess = await filter( site );
 			if ( ! shouldProcess ) {
@@ -74,7 +73,6 @@ export async function runOnSites(
 
 	const requested = allSites.map( ( site ) => ( { site } ) );
 
-	// Apply filter if provided
 	let sitesToProcess: SiteData[];
 	if ( filter ) {
 		sitesToProcess = [];


### PR DESCRIPTION
## Proposed Changes
This is proposition PR and follow-up to https://github.com/Automattic/studio/pull/2361

This PR:
* Introduces `runOnSites` abstraction in `cli/lib/site-utils.ts` that provides a unified way to execute operations on either a single site or all sites
* Refactors `site stop` command to use this abstraction, merging `runCommand` and `runCommandAll` into a single function
* `runOnSites` can be used across the whole CLI, to avoid code duplications (e.g. `getSiteByFolder`, `readAppdata`, etc), having standardized way of running commands (especially when the command has `--all` flag).

### Examples:
#### Single site
```js
const result = await runOnSites( '/path/to/site', async ( site ) => {
  await stopServer( site.id );
} );
```
#### All sites
```js
const result = await runOnSites( ALL_SITES, async ( site ) => {
  await stopServer( site.id );
} );
```
#### All running sites
```js

const result = await runOnSites(
  ALL_SITES,
  async (site) => {
    await stopServer( site.id );
  },
  {
    filter: async (site) => await isServerRunning(site.id)
  },
);
```

## Testing Instructions
* The same as for the parent PR - https://github.com/Automattic/studio/pull/2361
* Also assert that tests 
