### PR TITLE
Sync: Add offline status indicator to push progress UI

### DIFF
--- a/src/modules/sync/components/sync-connected-sites.tsx
+++ b/src/modules/sync/components/sync-connected-sites.tsx
@@ -189,6 +189,7 @@ const SyncConnectedSitesSectionItem = ( {
 	connectedSite,
 }: SyncConnectedSitesListProps ) => {
 	const { __ } = useI18n();
+	const isOffline = useOffline();
 	const { clearPullState, getPullState, getPushState, clearPushState, cancelPull, cancelPush } =
 		useSyncSites();
 	const { importState } = useImportExport();
@@ -223,6 +224,20 @@ const SyncConnectedSitesSectionItem = ( {
 		pushState?.status.key,
 		pushState?.uploadProgress
 	);
+
+	const getPushProgressTooltip = () => {
+		if ( isOffline ) {
+			return __(
+				"Your internet connection appears to be offline. Sync will continue running remotely. We will send you an email once it's completed."
+			);
+		}
+		if ( pushBackupIsUploading( pushState?.status.key ) ) {
+			return __( 'Push is in progress. We will send you an email when it is completed.' );
+		}
+		return __(
+			"The push is in progress and will continue running remotely. We will send you an email once it's completed."
+		);
+	};
 
 	return (
 		<div className="grid grid-cols-[max-content_1fr_max-content]">
@@ -312,19 +327,14 @@ const SyncConnectedSitesSectionItem = ( {
 					) }
 					{ pushState?.status && isPushing && (
 						<div className="flex items-center gap-2 max-w-full">
-							<Tooltip
-								text={
-									pushBackupIsUploading( pushState?.status.key )
-										? __( 'Push is in progress. We will send you an email when it is completed.' )
-										: __(
-												"The push is in progress and will continue running remotely. We will send you an email once it's completed."
-										  )
-								}
-								placement="top-start"
-							>
+							<Tooltip text={ getPushProgressTooltip() } placement="top-start">
 								<div className="flex flex-col gap-2 min-w-44 flex-shrink">
 									<div className="a8c-body-small flex items-center gap-0.5">
-										<Icon icon={ info } size={ 16 } />
+										{ isOffline ? (
+											<Icon icon={ offlineIcon } size={ 12 } className="fill-a8c-gray-70" />
+										) : (
+											<Icon icon={ info } size={ 14 } />
+										) }
 										{ getPushUploadMessage( pushState.status.message, uploadPercentage ) }
 									</div>
 									<ProgressBar value={ pushState.status.progress } maxValue={ 100 } />

--- a/src/modules/sync/components/sync-connected-sites.tsx
+++ b/src/modules/sync/components/sync-connected-sites.tsx
@@ -228,7 +228,7 @@ const SyncConnectedSitesSectionItem = ( {
 	const getPushProgressTooltip = () => {
 		if ( isOffline ) {
 			return __(
-				"Your internet connection appears to be offline. Sync will continue running remotely. We will send you an email once it's completed."
+				"You are currently offline. Sync will continue running remotely. We will send you an email once it's completed."
 			);
 		}
 		if ( pushBackupIsUploading( pushState?.status.key ) ) {


### PR DESCRIPTION
## Related issues

- Fixes STU-1195

## Proposed Changes

- Shows offline icon instead of info icon when user is offline during push
- Updated tooltip message to explain offline status and that sync will continue remotely

## Testing Instructions

1. Start a push sync operation
2. Let the upload phase complete
3. When remote backup phase starts, disconnect from the internet (turn off WiFi/network)
4. Observe the push progress UI - it should now show:
   - An offline icon (cloud with slash) instead of the info icon
   - A tooltip explaining the offline status: "Your internet connection appears to be offline. Sync will continue running remotely. We will send you an email once it's completed."
5. Reconnect to the internet and verify the icon changes back to the info icon

### Screenshot

<img width="868" height="382" alt="CleanShot 2026-01-09 at 15 14 38@2x" src="https://github.com/user-attachments/assets/916c7943-bed7-4201-88a2-4af330b35c84" />

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?