### PR TITLE
[Tooling] Skip CI jobs if there are no relevant code changes

### DIFF
--- a/.buildkite/commands/run-e2e-tests.sh
+++ b/.buildkite/commands/run-e2e-tests.sh
@@ -3,6 +3,10 @@ set -euo pipefail
 
 MATRIX=${1:-}
 
+if .buildkite/commands/should-skip-job.sh --job-type validation; then
+  exit 0
+fi
+
 echo '--- :package: Install deps'
 bash .buildkite/commands/install-node-dependencies.sh
 

--- a/.buildkite/commands/run-lint.sh
+++ b/.buildkite/commands/run-lint.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 set -euo pipefail
 
 if .buildkite/commands/should-skip-job.sh --job-type validation; then

--- a/.buildkite/commands/run-lint.sh
+++ b/.buildkite/commands/run-lint.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-MATRIX=${1:-}
-
 if .buildkite/commands/should-skip-job.sh --job-type validation; then
   exit 0
 fi
@@ -10,6 +8,5 @@ fi
 echo '--- :package: Install deps'
 bash .buildkite/commands/install-node-dependencies.sh
 
-echo '--- :npm: Run Unit Tests'
-npm run test
-
+echo '--- :eslint: Lint'
+npm run lint

--- a/.buildkite/commands/run-metrics-tests.sh
+++ b/.buildkite/commands/run-metrics-tests.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+if .buildkite/commands/should-skip-job.sh --job-type metrics; then
+  exit 0
+fi
+
 echo '--- :package: Install main dependencies'
 bash .buildkite/commands/install-node-dependencies.sh
 

--- a/.buildkite/commands/should-skip-job.sh
+++ b/.buildkite/commands/should-skip-job.sh
@@ -1,4 +1,6 @@
-#!/bin/bash -eu
+#!/usr/bin/env bash
+
+set -eu
 
 # Determines if a CI job should be skipped based on the files changed in the PR.
 #

--- a/.buildkite/commands/should-skip-job.sh
+++ b/.buildkite/commands/should-skip-job.sh
@@ -1,0 +1,156 @@
+#!/bin/bash -eu
+
+# Determines if a CI job should be skipped based on the files changed in the PR.
+#
+# Usage:
+#   should-skip-job.sh --job-type <type>
+#
+# Job types:
+#   - validation: Skip if changes are limited to documentation, config, localization, and non-code files.
+#                 Used for lint, unit tests, and e2e tests.
+#   - metrics: Same as validation, but also skips on test-only changes (e2e/**, *.test.ts).
+#              Since metrics measure app performance, test file changes don't affect them.
+#   - build: Skip if changes are limited to documentation and config files.
+#            Does NOT skip on localization changes since builds should include translation updates.
+#
+# Exit codes:
+#   0 - Job should be skipped
+#   1 - Job should run
+
+# Files that don't affect code quality, tests, or builds
+# These are documentation, configuration, and metadata files
+COMMON_NON_CODE_PATTERNS=(
+  # Documentation
+  "*.md"
+  "*.txt"
+  "docs/**"
+  "CODE-OF-CONDUCT.md"
+  "SECURITY.md"
+  "LICENSE*"
+
+  # Editor and IDE config
+  ".editorconfig"
+  ".vscode/**"
+
+  # Git config
+  ".gitignore"
+  ".gitattributes"
+
+  # GitHub-specific (workflows, templates, dependabot)
+  ".github/**"
+
+  # Ruby/Fastlane - only affects CI distribution, not app code
+  "fastlane/**"
+  "Gemfile"
+  "Gemfile.lock"
+  ".ruby-version"
+  ".bundle/**"
+
+  # CI configuration changes don't need app tests
+  ".buildkite/**"
+
+  # Installer assets and configuration
+  "installers/**"
+  "assets/appx/**"
+
+  # Claude AI configuration
+  ".claude/**"
+  "CLAUDE.md"
+)
+
+# Localization files - changes here don't affect runtime behavior or performance
+LOCALIZATION_PATTERNS=(
+  "common/translations/**"
+)
+
+# Test files - changes here don't affect app performance (for metrics)
+TEST_PATTERNS=(
+  "e2e/**"
+  "src/tests/**"
+  "src/**/*.test.ts"
+  "src/**/*.test.tsx"
+  "cli/**/*.test.ts"
+  "common/**/*.test.ts"
+  "metrics/**"
+)
+
+show_skip_message() {
+  local job_type=$1
+  local job_label="${BUILDKITE_LABEL:-$job_type}"
+  local message="Skipping ${job_label} - no relevant files changed"
+  local context="skip-$(echo "${job_label}" | sed -E -e 's/[^[:alnum:]]+/-/g' | tr '[:upper:]' '[:lower:]')"
+
+  # Post annotation to Buildkite UI
+  if command -v buildkite-agent &> /dev/null; then
+    echo "$message" | buildkite-agent annotate --style "info" --context "$context"
+  fi
+
+  echo "~~~ :fast_forward: $message"
+}
+
+# Parse arguments
+job_type=""
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --job-type)
+      job_type="$2"
+      shift 2
+      ;;
+    *)
+      echo "Unknown option: $1"
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$job_type" ]]; then
+  echo "Error: --job-type is required"
+  echo "Usage: should-skip-job.sh --job-type <validation|metrics|build>"
+  exit 1
+fi
+
+# Check if pr_changed_files command is available
+if ! command -v pr_changed_files &> /dev/null; then
+  echo "pr_changed_files command not found. Running job."
+  exit 1
+fi
+
+case "$job_type" in
+  "validation")
+    # Skip validation jobs (lint, unit tests, e2e) if ALL changes are in
+    # non-code files OR localization-only changes
+    PATTERNS=("${COMMON_NON_CODE_PATTERNS[@]}" "${LOCALIZATION_PATTERNS[@]}")
+    if pr_changed_files --all-match "${PATTERNS[@]}"; then
+      show_skip_message "$job_type"
+      exit 0
+    fi
+    ;;
+
+  "metrics")
+    # Skip metrics if ALL changes are in non-code files, localization, OR test files.
+    # Test file changes don't affect app performance, so metrics don't need to run.
+    PATTERNS=("${COMMON_NON_CODE_PATTERNS[@]}" "${LOCALIZATION_PATTERNS[@]}" "${TEST_PATTERNS[@]}")
+    if pr_changed_files --all-match "${PATTERNS[@]}"; then
+      show_skip_message "$job_type"
+      exit 0
+    fi
+    ;;
+
+  "build")
+    # Skip build if ALL changes are in non-code files.
+    # Note: Does NOT skip on localization changes - builds should include translation updates.
+    if pr_changed_files --all-match "${COMMON_NON_CODE_PATTERNS[@]}"; then
+      show_skip_message "$job_type"
+      exit 0
+    fi
+    ;;
+
+  *)
+    echo "Unknown job type: $job_type"
+    echo "Valid types: validation, metrics, build"
+    exit 1
+    ;;
+esac
+
+# Job should run
+exit 1

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -11,10 +11,7 @@ steps:
     agents:
       queue: mac
     key: lint
-    command: |
-      .buildkite/commands/install-node-dependencies.sh
-      echo '--- :eslint: Lint'
-      npm run lint
+    command: bash .buildkite/commands/run-lint.sh
     plugins: [$CI_TOOLKIT_PLUGIN, $NVM_PLUGIN]
     notify:
       - github_commit_status:

--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -5,7 +5,7 @@
 
 # The ~> modifier is not currently used, but we check for it just in case
 XCODE_VERSION=$(sed -E -n 's/^(~> )?(.*)/xcode-\2/p' .xcode-version)
-CI_TOOLKIT_VERSION='5.7.0'
+CI_TOOLKIT_VERSION='6.0.1'
 NVM_PLUGIN_VERSION='0.6.0'
 
 export IMAGE_ID="$XCODE_VERSION"


### PR DESCRIPTION
Fixes AINFRA-1706
Details: paaHJt-8r5-p2

## Summary

Optimizes CI wait time for PRs with minor, non-code changes (documentation, config, etc.) by skipping jobs when only irrelevant files change.

Implements `should-skip-job.sh` with three job types:
- `--job-type validation`: Skips lint, unit tests, e2e tests on doc/config/localization changes
- `--job-type metrics`: Same as validation + skips on test-only changes
- `--job-type build`: Skips on doc/config changes (not localization, builds need translations)

## Testing

Verified with PRs built on top of this branch (non-draft to run full CI):

| Test PR | Change Type | Expected | Build | Result |
|---------|-------------|----------|-------|--------|
| [#2384](https://github.com/Automattic/studio/pull/2384) | Docs only (`docs/*.md`) | All validation jobs skip | [#10467](https://buildkite.com/automattic/studio/builds/10467) | ✅ Lint, Unit Tests, E2E all skipped |
| [#2385](https://github.com/Automattic/studio/pull/2385) | Localization only (`common/translations/**`) | All validation jobs skip | [#10468](https://buildkite.com/automattic/studio/builds/10468) | ✅ Lint, Unit Tests, E2E all skipped |
| [#2386](https://github.com/Automattic/studio/pull/2386) | Test only (`e2e/*.ts`) | Validation runs, metrics skips | [#10469](https://buildkite.com/automattic/studio/builds/10469) | ✅ Lint, Unit Tests, E2E ran (no skip annotations) |
| [#2387](https://github.com/Automattic/studio/pull/2387) | Code change (`src/*.ts`) | All jobs run | [#10470](https://buildkite.com/automattic/studio/builds/10470) | ✅ All jobs running (no skip annotations) |

### Skip Annotations Verified

**Docs-only (#10467):**
- `Skipping Lint - no relevant files changed`
- `Skipping Unit Tests on mac - no relevant files changed`
- `Skipping Unit Tests on windows - no relevant files changed`
- `Skipping E2E Tests on mac - no relevant files changed`
- `Skipping E2E Tests on windows - no relevant files changed`

**Localization-only (#10468):**
- `Skipping Lint - no relevant files changed`
- `Skipping Unit Tests on mac - no relevant files changed`
- `Skipping E2E Tests on mac - no relevant files changed`

**Test-only (#10469) & Code-changes (#10470):**
- No skip annotations (jobs ran as expected)

## Test plan

- [x] Verify CI jobs skip on documentation-only PRs
- [x] Verify CI jobs skip on localization-only PRs
- [x] Verify validation jobs run on test-only PRs
- [x] Verify all jobs run on code changes
