### PR TITLE
Miscellaneous translation tweaks

### DIFF
--- a/cli/commands/preview/update.ts
+++ b/cli/commands/preview/update.ts
@@ -31,7 +31,7 @@ async function getSnapshotToUpdate(
 	if ( snapshotToUpdate.localSiteId !== currentSiteId && ! overwrite ) {
 		throw new LoggerError(
 			__(
-				'The specified folder does not match the original site for this preview. If you want to overwrite, run the command with --overwrite.'
+				'The specified directory does not match the original site for this preview. If you want to overwrite, run the command with --overwrite.'
 			)
 		);
 	}
@@ -117,7 +117,7 @@ export const registerCommand = ( yargs: StudioArgv ) => {
 					alias: 'o',
 					type: 'boolean',
 					default: false,
-					description: __( 'Allow updating a preview site from a different folder' ),
+					description: __( 'Allow updating a preview site from a different directory' ),
 				} );
 		},
 		handler: async ( argv ) => {

--- a/cli/commands/site/create.ts
+++ b/cli/commands/site/create.ts
@@ -267,7 +267,7 @@ export async function runCommand(
 			await setupCustomDomain( siteDetails, logger );
 
 			const startMessage = blueprint
-				? __( 'Starting WordPress server and applying blueprint…' )
+				? __( 'Starting WordPress server and applying Blueprint…' )
 				: __( 'Starting WordPress server…' );
 			logger.reportStart( LoggerAction.START_SITE, startMessage );
 			try {
@@ -305,7 +305,7 @@ export async function runCommand(
 				await connect();
 				logger.reportSuccess( __( 'Process daemon started' ) );
 
-				logger.reportStart( LoggerAction.START_SITE, __( 'Applying blueprint…' ) );
+				logger.reportStart( LoggerAction.START_SITE, __( 'Applying Blueprint…' ) );
 				try {
 					await runBlueprint( siteDetails, logger, {
 						wpVersion: options.wpVersion,
@@ -318,7 +318,7 @@ export async function runCommand(
 					if ( ! isWordPressDirResult ) {
 						await fs.promises.rm( sitePath, { recursive: true, force: true } );
 					}
-					throw new LoggerError( __( 'Failed to apply blueprint' ), error );
+					throw new LoggerError( __( 'Failed to apply Blueprint' ), error );
 				}
 			}
 			console.log( '' );
@@ -339,13 +339,13 @@ async function fetchBlueprint( url: string ) {
 	const res = await fetch( url );
 
 	if ( ! res.ok ) {
-		throw new LoggerError( __( 'Failed to fetch blueprint' ) );
+		throw new LoggerError( __( 'Failed to fetch Blueprint' ) );
 	}
 
 	try {
 		return await res.json();
 	} catch ( error ) {
-		throw new LoggerError( __( 'Failed to parse blueprint JSON' ), error );
+		throw new LoggerError( __( 'Failed to parse Blueprint JSON' ), error );
 	}
 }
 
@@ -359,7 +359,7 @@ function readBlueprint( blueprintPath: string ) {
 		return JSON.parse( blueprintContent );
 	} catch ( error ) {
 		throw new LoggerError(
-			sprintf( __( 'Failed to parse blueprint JSON file: %s' ), blueprintPath ),
+			sprintf( __( 'Failed to parse Blueprint JSON file: %s' ), blueprintPath ),
 			error
 		);
 	}
@@ -420,7 +420,7 @@ export const registerCommand = ( yargs: StudioArgv ) => {
 				} )
 				.option( 'blueprint', {
 					type: 'string',
-					describe: __( 'Path or URL to blueprint JSON file' ),
+					describe: __( 'Path or URL to Blueprint JSON file' ),
 				} )
 				.option( 'start', {
 					type: 'boolean',

--- a/cli/commands/site/create.ts
+++ b/cli/commands/site/create.ts
@@ -172,7 +172,7 @@ export async function runCommand(
 		if ( ! ( await isSqliteIntegrationAvailable() ) ) {
 			throw new LoggerError(
 				__(
-					'SQLite integration files not found. Please ensure Studio Desktop is installed and has been run at least once.'
+					'SQLite integration files not found. Please ensure Studio is installed and has been run at least once.'
 				)
 			);
 		}
@@ -182,7 +182,8 @@ export async function runCommand(
 
 		logger.reportStart( LoggerAction.ASSIGN_PORT, __( 'Assigning port…' ) );
 		const port = await portFinder.getOpenPort();
-		logger.reportSuccess( __( 'Port assigned: ' ) + port );
+		// translators: %d is the port number
+		logger.reportSuccess( sprintf( __( 'Port assigned: %d' ), port ) );
 
 		const siteName = options.name || path.basename( sitePath );
 		const siteId = crypto.randomUUID();
@@ -266,8 +267,8 @@ export async function runCommand(
 			await setupCustomDomain( siteDetails, logger );
 
 			const startMessage = blueprint
-				? __( 'Starting WordPress site and applying blueprint…' )
-				: __( 'Starting WordPress site…' );
+				? __( 'Starting WordPress server and applying blueprint…' )
+				: __( 'Starting WordPress server…' );
 			logger.reportStart( LoggerAction.START_SITE, startMessage );
 			try {
 				const processDesc = await startWordPressServer( siteDetails, logger, {
@@ -275,7 +276,7 @@ export async function runCommand(
 					blueprint,
 					blueprintUri,
 				} );
-				logger.reportSuccess( __( 'WordPress site started' ) );
+				logger.reportSuccess( __( 'WordPress server started' ) );
 
 				if ( processDesc.pid ) {
 					await updateSiteLatestCliPid( siteDetails.id, processDesc.pid );
@@ -389,7 +390,7 @@ function coerceWpVersion( value: string ) {
 export const registerCommand = ( yargs: StudioArgv ) => {
 	return yargs.command( {
 		command: 'create',
-		describe: __( 'Create a new local site' ),
+		describe: __( 'Create a new site' ),
 		builder: ( yargs ) => {
 			return yargs
 				.option( 'name', {

--- a/cli/commands/site/delete.ts
+++ b/cli/commands/site/delete.ts
@@ -75,9 +75,9 @@ export async function runCommand(
 
 		const runningProcess = await isServerRunning( site.id );
 		if ( runningProcess ) {
-			logger.reportStart( LoggerAction.STOP_SITE, __( 'Stopping WordPress site…' ) );
+			logger.reportStart( LoggerAction.STOP_SITE, __( 'Stopping WordPress server…' ) );
 			await stopWordPressServer( site.id );
-			logger.reportSuccess( __( 'WordPress site stopped' ) );
+			logger.reportSuccess( __( 'WordPress server stopped' ) );
 			await stopProxyIfNoSitesNeedIt( site.id, logger );
 		}
 
@@ -108,7 +108,7 @@ export async function runCommand(
 			const appdata = await readAppdata();
 			const siteIndex = appdata.sites.findIndex( ( s ) => arePathsEqual( s.path, siteFolder ) );
 			if ( siteIndex === -1 ) {
-				throw new LoggerError( __( 'The specified folder is not added to Studio.' ) );
+				throw new LoggerError( __( 'The specified directory is not added to Studio.' ) );
 			}
 			appdata.sites.splice( siteIndex, 1 );
 			await saveAppdata( appdata );
@@ -133,7 +133,7 @@ export async function runCommand(
 export const registerCommand = ( yargs: StudioArgv ) => {
 	return yargs.command( {
 		command: 'delete',
-		describe: __( 'Delete local site' ),
+		describe: __( 'Delete site' ),
 		builder: ( yargs ) => {
 			return yargs.option( 'files', {
 				type: 'boolean',

--- a/cli/commands/site/list.ts
+++ b/cli/commands/site/list.ts
@@ -137,13 +137,14 @@ export async function runCommand( format: 'table' | 'json', watch: boolean ): Pr
 export const registerCommand = ( yargs: StudioArgv ) => {
 	return yargs.command( {
 		command: 'list',
-		describe: __( 'List local sites' ),
+		describe: __( 'List sites' ),
 		builder: ( yargs ) => {
 			return yargs
 				.option( 'format', {
 					type: 'string',
 					choices: [ 'table', 'json' ] as const,
 					default: 'table' as const,
+					// translators: Refers to the output format of the `studio site list` CLI command ("table" or "json")
 					description: __( 'Output format' ),
 				} )
 				.option( 'watch', {

--- a/cli/commands/site/set.ts
+++ b/cli/commands/site/set.ts
@@ -144,7 +144,7 @@ export async function runCommand(
 			const appdata = await readAppdata();
 			const foundSite = appdata.sites.find( ( s ) => arePathsEqual( s.path, sitePath ) );
 			if ( ! foundSite ) {
-				throw new LoggerError( __( 'The specified folder is not added to Studio.' ) );
+				throw new LoggerError( __( 'The specified directory is not added to Studio.' ) );
 			}
 
 			if ( nameChanged ) {
@@ -182,13 +182,13 @@ export async function runCommand(
 		const wasRunning = await isServerRunning( site.id );
 
 		if ( needsRestart && wasRunning ) {
-			logger.reportStart( LoggerAction.STOP_SITE, __( 'Stopping WordPress site…' ) );
+			logger.reportStart( LoggerAction.STOP_SITE, __( 'Stopping WordPress server…' ) );
 			await stopWordPressServer( site.id );
-			logger.reportSuccess( __( 'WordPress site stopped' ) );
+			logger.reportSuccess( __( 'WordPress server stopped' ) );
 		}
 
 		if ( wpChanged ) {
-			logger.reportStart( LoggerAction.SET_WP_VERSION, __( 'Changing WordPress version…' ) );
+			logger.reportStart( LoggerAction.SET_WP_VERSION, __( 'Updating WordPress version…' ) );
 			const phpVersion = validatePhpVersion( site.phpVersion );
 			const zipUrl = getWordPressVersionUrl( wp );
 
@@ -211,7 +211,7 @@ export async function runCommand(
 				await closeWpCliServer();
 				throw new LoggerError( sprintf( __( 'Failed to update WordPress version to %s' ), wp ) );
 			}
-			logger.reportSuccess( __( 'WordPress version changed' ) );
+			logger.reportSuccess( __( 'WordPress version updated' ) );
 
 			try {
 				await lockAppdata();
@@ -234,12 +234,12 @@ export async function runCommand(
 				await setupCustomDomain( site, logger, { skipHostsUpdate: true } );
 			}
 
-			logger.reportStart( LoggerAction.START_SITE, __( 'Starting WordPress site…' ) );
+			logger.reportStart( LoggerAction.START_SITE, __( 'Starting WordPress server…' ) );
 			const processDesc = await startWordPressServer( site, logger );
 			if ( processDesc.pid ) {
 				await updateSiteLatestCliPid( site.id, processDesc.pid );
 			}
-			logger.reportSuccess( __( 'WordPress site started' ) );
+			logger.reportSuccess( __( 'WordPress server started' ) );
 		}
 
 		logger.reportSuccess( __( 'Site configuration updated' ) );

--- a/cli/commands/site/start.ts
+++ b/cli/commands/site/start.ts
@@ -22,7 +22,7 @@ export async function runCommand( sitePath: string, skipBrowser = false ): Promi
 
 		const runningProcess = await isServerRunning( site.id );
 		if ( runningProcess ) {
-			logger.reportSuccess( __( 'WordPress site is already running' ) );
+			logger.reportSuccess( __( 'WordPress server is already running' ) );
 			if ( runningProcess.pid ) {
 				await updateSiteLatestCliPid( site.id, runningProcess.pid );
 			}
@@ -42,11 +42,11 @@ export async function runCommand( sitePath: string, skipBrowser = false ): Promi
 		await keepSqliteIntegrationUpdated( sitePath );
 		logger.reportSuccess( __( 'SQLite integration configured as needed' ) );
 
-		logger.reportStart( LoggerAction.START_SITE, __( 'Starting WordPress site…' ) );
+		logger.reportStart( LoggerAction.START_SITE, __( 'Starting WordPress server…' ) );
 		try {
 			const processDesc = await startWordPressServer( site, logger );
 
-			logger.reportSuccess( __( 'WordPress site started' ) );
+			logger.reportSuccess( __( 'WordPress server started' ) );
 			if ( processDesc.pid ) {
 				await updateSiteLatestCliPid( site.id, processDesc.pid );
 			}
@@ -67,7 +67,7 @@ export async function runCommand( sitePath: string, skipBrowser = false ): Promi
 export const registerCommand = ( yargs: StudioArgv ) => {
 	return yargs.command( {
 		command: 'start',
-		describe: __( 'Start local site' ),
+		describe: __( 'Start site' ),
 		builder: ( yargs ) => {
 			return yargs.option( 'skip-browser', {
 				type: 'boolean',

--- a/cli/commands/site/status.ts
+++ b/cli/commands/site/status.ts
@@ -81,7 +81,7 @@ export async function runCommand( siteFolder: string, format: 'table' | 'json' )
 export const registerCommand = ( yargs: StudioArgv ) => {
 	return yargs.command( {
 		command: 'status',
-		describe: __( 'Get status of local site' ),
+		describe: __( 'Get status of site' ),
 		builder: ( yargs ) => {
 			return yargs.option( 'format', {
 				type: 'string',

--- a/cli/commands/site/stop.ts
+++ b/cli/commands/site/stop.ts
@@ -46,11 +46,11 @@ export async function runCommand(
 
 			const runningProcess = await isServerRunning( site.id );
 			if ( ! runningProcess ) {
-				logger.reportSuccess( __( 'WordPress site is not running' ) );
+				logger.reportSuccess( __( 'WordPress server is not running' ) );
 				return;
 			}
 
-			logger.reportStart( LoggerAction.STOP_SITE, __( 'Stopping WordPress site…' ) );
+			logger.reportStart( LoggerAction.STOP_SITE, __( 'Stopping WordPress server…' ) );
 		} else {
 			const appdata = await readAppdata();
 
@@ -130,12 +130,12 @@ export async function runCommand(
 export const registerCommand = ( yargs: StudioArgv ) => {
 	return yargs.command( {
 		command: 'stop',
-		describe: __( 'Stop local site(s)' ),
+		describe: __( 'Stop site(s)' ),
 		builder: ( yargs ) => {
 			return yargs
 				.option( 'all', {
 					type: 'boolean',
-					describe: __( 'Stop all local sites' ),
+					describe: __( 'Stop all sites' ),
 					default: false,
 				} )
 				.option( 'auto-start', {

--- a/cli/commands/site/tests/create.test.ts
+++ b/cli/commands/site/tests/create.test.ts
@@ -211,10 +211,10 @@ describe( 'CLI: studio site create', () => {
 			expect( disconnect ).toHaveBeenCalled();
 		} );
 
-		it( 'should error if blueprint validation fails', async () => {
+		it( 'should error if Blueprint validation fails', async () => {
 			( validateBlueprintData as jest.Mock ).mockResolvedValue( {
 				valid: false,
-				error: 'Invalid blueprint',
+				error: 'Invalid Blueprint',
 			} );
 
 			await expect(
@@ -225,7 +225,7 @@ describe( 'CLI: studio site create', () => {
 						contents: {},
 					},
 				} )
-			).rejects.toThrow( 'Invalid blueprint' );
+			).rejects.toThrow( 'Invalid Blueprint' );
 
 			expect( disconnect ).toHaveBeenCalled();
 		} );
@@ -407,7 +407,7 @@ describe( 'CLI: studio site create', () => {
 			steps: [ { step: 'installPlugin', pluginData: { slug: 'akismet' } } ],
 		};
 
-		it( 'should apply blueprint when provided', async () => {
+		it( 'should apply Blueprint when provided', async () => {
 			await runCommand( mockSitePath, {
 				...defaultTestOptions,
 				blueprint: {
@@ -426,7 +426,7 @@ describe( 'CLI: studio site create', () => {
 			);
 		} );
 
-		it( 'should prepend setSiteOptions step when name is provided with blueprint', async () => {
+		it( 'should prepend setSiteOptions step when name is provided with Blueprint', async () => {
 			await runCommand( mockSitePath, {
 				...defaultTestOptions,
 				name: 'My Site',
@@ -452,7 +452,7 @@ describe( 'CLI: studio site create', () => {
 			);
 		} );
 
-		it( 'should warn about unsupported blueprint features', async () => {
+		it( 'should warn about unsupported Blueprint features', async () => {
 			( validateBlueprintData as jest.Mock ).mockReturnValue( {
 				valid: true,
 				warnings: [
@@ -489,7 +489,7 @@ describe( 'CLI: studio site create', () => {
 			expect( disconnect ).toHaveBeenCalled();
 		} );
 
-		it( 'should apply blueprint without starting server when noStart is true', async () => {
+		it( 'should apply Blueprint without starting server when noStart is true', async () => {
 			const testBlueprint: Blueprint = { steps: [] };
 
 			await runCommand( mockSitePath, {
@@ -508,7 +508,7 @@ describe( 'CLI: studio site create', () => {
 			expect( disconnect ).toHaveBeenCalled();
 		} );
 
-		it( 'should run blueprint when preferred language is configured but no blueprint was given', async () => {
+		it( 'should run Blueprint when preferred language is configured but no Blueprint was given', async () => {
 			( getPreferredSiteLanguage as jest.Mock ).mockResolvedValue( 'es_ES' );
 
 			await runCommand( mockSitePath, {
@@ -542,7 +542,7 @@ describe( 'CLI: studio site create', () => {
 			expect( disconnect ).toHaveBeenCalled();
 		} );
 
-		it( 'should handle blueprint application failure', async () => {
+		it( 'should handle Blueprint application failure', async () => {
 			const testBlueprint: Blueprint = { steps: [] };
 			( runBlueprint as jest.Mock ).mockRejectedValue( new Error( 'Blueprint failed' ) );
 
@@ -555,7 +555,7 @@ describe( 'CLI: studio site create', () => {
 					},
 					noStart: true,
 				} )
-			).rejects.toThrow( 'Failed to apply blueprint' );
+			).rejects.toThrow( 'Failed to apply Blueprint' );
 
 			expect( disconnect ).toHaveBeenCalled();
 		} );
@@ -604,7 +604,7 @@ describe( 'CLI: studio site create', () => {
 			expect( removeSiteFromAppdata ).toHaveBeenCalled();
 		} );
 
-		it( 'should remove site from appdata when blueprint application fails', async () => {
+		it( 'should remove site from appdata when Blueprint application fails', async () => {
 			const testBlueprint = { steps: [] };
 			( runBlueprint as jest.Mock ).mockRejectedValue( new Error( 'Blueprint failed' ) );
 
@@ -647,7 +647,7 @@ describe( 'CLI: studio site create', () => {
 			expect( fsRmSpy ).not.toHaveBeenCalled();
 		} );
 
-		it( 'should delete site directory when blueprint application fails for new directory', async () => {
+		it( 'should delete site directory when Blueprint application fails for new directory', async () => {
 			createPathExistsMock( false );
 			( isWordPressDirectory as jest.Mock ).mockReturnValue( false );
 			const testBlueprint = { steps: [] };
@@ -669,7 +669,7 @@ describe( 'CLI: studio site create', () => {
 			expect( fsRmSpy ).toHaveBeenCalledWith( mockSitePath, { recursive: true, force: true } );
 		} );
 
-		it( 'should NOT delete site directory when blueprint application fails for existing WordPress directory', async () => {
+		it( 'should NOT delete site directory when Blueprint application fails for existing WordPress directory', async () => {
 			createPathExistsMock( true );
 			( isEmptyDir as jest.Mock ).mockResolvedValue( false );
 			( isWordPressDirectory as jest.Mock ).mockReturnValue( true );

--- a/cli/commands/site/tests/delete.test.ts
+++ b/cli/commands/site/tests/delete.test.ts
@@ -140,7 +140,7 @@ describe( 'CLI: studio site delete', () => {
 			} );
 
 			await expect( runCommand( testSiteFolder ) ).rejects.toThrow(
-				'The specified folder is not added to Studio.'
+				'The specified directory is not added to Studio.'
 			);
 			expect( disconnect ).toHaveBeenCalled();
 		} );

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -88,7 +88,7 @@ async function main() {
 			registerUpdateCommand( previewYargs );
 			previewYargs.version( false ).demandCommand( 1, __( 'You must provide a valid command' ) );
 		} )
-		.command( 'site', __( 'Manage local sites' ), ( sitesYargs ) => {
+		.command( 'site', __( 'Manage sites' ), ( sitesYargs ) => {
 			registerSiteStatusCommand( sitesYargs );
 			registerSiteCreateCommand( sitesYargs );
 			registerSiteListCommand( sitesYargs );

--- a/cli/lib/appdata.ts
+++ b/cli/lib/appdata.ts
@@ -190,11 +190,11 @@ export async function getSiteByFolder( siteFolder: string ): Promise< SiteData >
 	if ( ! site ) {
 		if ( isWordPressDirectory( siteFolder ) ) {
 			throw new LoggerError(
-				__( 'The specified folder is not added to Studio. Use `studio site create` to add it.' )
+				__( 'The specified directory is not added to Studio. Use `studio site create` to add it.' )
 			);
 		}
 
-		throw new LoggerError( __( 'The specified folder is not added to Studio.' ) );
+		throw new LoggerError( __( 'The specified directory is not added to Studio.' ) );
 	}
 
 	return site;

--- a/cli/wordpress-server-child.ts
+++ b/cli/wordpress-server-child.ts
@@ -304,7 +304,7 @@ async function runBlueprint( config: ServerConfig, signal: AbortSignal ): Promis
 
 		logToConsole( `Blueprint applied successfully for site ${ config.siteId }` );
 	} catch ( error ) {
-		errorToConsole( `Failed to run blueprint:`, error );
+		errorToConsole( `Failed to run Blueprint:`, error );
 		throw error;
 	}
 }

--- a/common/lib/sqlite-integration.ts
+++ b/common/lib/sqlite-integration.ts
@@ -38,9 +38,7 @@ export abstract class SqliteIntegrationProvider {
 
 	async installSqliteIntegration( sitePath: string ): Promise< void > {
 		if ( ! ( await this.isSqliteIntegrationAvailable() ) ) {
-			throw new Error(
-				'SQLite integration files not found. Please ensure Studio Desktop is installed.'
-			);
+			throw new Error( 'SQLite integration files not found. Please ensure Studio is installed.' );
 		}
 
 		const wpContentPath = path.join( sitePath, 'wp-content' );

--- a/e2e/blueprints.test.ts
+++ b/e2e/blueprints.test.ts
@@ -25,7 +25,7 @@ test.describe( 'Blueprints', () => {
 		await session.cleanup();
 	} );
 
-	test( 'create site with blueprint that installs a theme', async ( { page } ) => {
+	test( 'create site with Blueprint that installs a theme', async ( { page } ) => {
 		const siteName = 'Blueprint-Theme-Install';
 		const blueprintPath = path.join( __dirname, 'fixtures', 'blueprints', 'install-theme.json' );
 
@@ -61,7 +61,7 @@ test.describe( 'Blueprints', () => {
 		await expect( page.locator( '.theme[data-slug="twentytwentytwo"]' ) ).toBeVisible();
 	} );
 
-	test( 'create site with blueprint that activates a theme', async ( { page } ) => {
+	test( 'create site with Blueprint that activates a theme', async ( { page } ) => {
 		const siteName = 'Blueprint-Theme-Activate';
 		const blueprintPath = path.join( __dirname, 'fixtures', 'blueprints', 'activate-theme.json' );
 
@@ -99,7 +99,7 @@ test.describe( 'Blueprints', () => {
 		await expect( activeTheme ).toHaveAttribute( 'data-slug', 'twentytwentyone' );
 	} );
 
-	test( 'create site with blueprint that installs a plugin', async ( { page } ) => {
+	test( 'create site with Blueprint that installs a plugin', async ( { page } ) => {
 		const siteName = 'Blueprint-Plugin-Install';
 		const blueprintPath = path.join( __dirname, 'fixtures', 'blueprints', 'install-plugin.json' );
 
@@ -135,7 +135,7 @@ test.describe( 'Blueprints', () => {
 		await expect( page.locator( 'tr[data-slug="akismet"]' ) ).toBeVisible();
 	} );
 
-	test( 'create site with blueprint that activates a plugin', async ( { page } ) => {
+	test( 'create site with Blueprint that activates a plugin', async ( { page } ) => {
 		const siteName = 'Blueprint-Plugin-Activate';
 		const blueprintPath = path.join( __dirname, 'fixtures', 'blueprints', 'activate-plugin.json' );
 
@@ -173,7 +173,7 @@ test.describe( 'Blueprints', () => {
 		await expect( pluginRow ).toBeVisible();
 	} );
 
-	test( 'create site with blueprint that runs PHP code', async ( { page } ) => {
+	test( 'create site with Blueprint that runs PHP code', async ( { page } ) => {
 		const siteName = 'Blueprint-PHP-Code';
 		const blueprintPath = path.join( __dirname, 'fixtures', 'blueprints', 'run-php-code.json' );
 
@@ -212,7 +212,7 @@ test.describe( 'Blueprints', () => {
 		await expect( page ).toHaveURL( /options-general\.php/ );
 	} );
 
-	test( 'create site with blueprint that runs WP-CLI commands', async ( { page } ) => {
+	test( 'create site with Blueprint that runs WP-CLI commands', async ( { page } ) => {
 		const siteName = 'Blueprint-WP-CLI';
 		const blueprintPath = path.join( __dirname, 'fixtures', 'blueprints', 'wp-cli-command.json' );
 

--- a/src/components/content-tab-settings.tsx
+++ b/src/components/content-tab-settings.tsx
@@ -81,7 +81,7 @@ export function ContentTabSettings( { selectedSite }: ContentTabSettingsProps ) 
 							<span className="line-clamp-1 break-all">{ selectedSite.name }</span>
 						</div>
 					</SettingsRow>
-					<SettingsRow label={ __( 'Local URL' ) }>
+					<SettingsRow label={ __( 'Site URL' ) }>
 						<CopyTextButton
 							text={ `${ protocol }://${ domain }` }
 							label={ `${ domain }, ${ __( 'Copy site url to clipboard' ) }` }

--- a/src/hooks/use-is-valid-blueprint.ts
+++ b/src/hooks/use-is-valid-blueprint.ts
@@ -27,7 +27,7 @@ export function useIsValidBlueprint( className?: string, content?: string ) {
 				const validation = await getIpcApi().validateBlueprint( blueprintJson );
 				setIsBlueprintValid( Boolean( validation.valid ) );
 			} catch {
-				console.error( 'Failed to validate blueprint' );
+				console.error( 'Failed to validate Blueprint' );
 			}
 		};
 

--- a/src/lib/deeplink/handlers/add-site-with-blueprint.ts
+++ b/src/lib/deeplink/handlers/add-site-with-blueprint.ts
@@ -69,7 +69,7 @@ export async function handleAddSiteWithBlueprint( urlObject: URL ): Promise< voi
 			warnings: validation.warnings,
 		} );
 	} catch ( error ) {
-		console.error( 'Failed to process blueprint from deeplink:', error );
+		console.error( 'Failed to process Blueprint from deeplink:', error );
 
 		if ( blueprintPath ) {
 			await fs.remove( blueprintPath ).catch( () => {
@@ -80,11 +80,11 @@ export async function handleAddSiteWithBlueprint( urlObject: URL ): Promise< voi
 		const errorDetail =
 			error instanceof Error
 				? error.message
-				: __( 'The blueprint could not be loaded. Please check the link and try again.' );
+				: __( 'The Blueprint could not be loaded. Please check the link and try again.' );
 
 		await dialog.showMessageBox( mainWindow, {
 			type: 'error',
-			message: __( 'Failed to load blueprint' ),
+			message: __( 'Failed to load Blueprint' ),
 			detail: errorDetail,
 			buttons: [ __( 'OK' ) ],
 		} );

--- a/src/lib/deeplink/tests/add-site.test.ts
+++ b/src/lib/deeplink/tests/add-site.test.ts
@@ -148,14 +148,14 @@ describe( 'handleAddSiteWithBlueprint', () => {
 		expect( dialog.showMessageBox ).toHaveBeenCalled();
 	} );
 
-	it( 'should handle invalid blueprint and show error dialog', async () => {
+	it( 'should handle invalid Blueprint and show error dialog', async () => {
 		const url = createBlueprintUrl( 'https://example.com/blueprint.json' );
 
 		jest.mocked( download ).mockResolvedValue( undefined );
 		jest.mocked( fs.readJson ).mockResolvedValue( { invalid: 'data' } );
 		jest.mocked( validateBlueprintData ).mockResolvedValue( {
 			valid: false,
-			error: 'Invalid blueprint format',
+			error: 'Invalid Blueprint format',
 		} );
 		jest.mocked( fs.remove ).mockImplementation( async () => {} );
 
@@ -167,13 +167,13 @@ describe( 'handleAddSiteWithBlueprint', () => {
 		expect( dialog.showMessageBox ).toHaveBeenCalledWith( mockMainWindow, {
 			type: 'error',
 			message: expect.any( String ),
-			detail: 'Invalid blueprint format',
+			detail: 'Invalid Blueprint format',
 			buttons: expect.any( Array ),
 		} );
 	} );
 
 	describe( 'base64 blueprint handling', () => {
-		it( 'should handle add-site with valid base64-encoded blueprint', async () => {
+		it( 'should handle add-site with valid base64-encoded Blueprint', async () => {
 			const blueprintData = {
 				steps: [ { step: 'login', username: 'admin' } ],
 				meta: { title: 'Test Blueprint', description: 'A test blueprint' },
@@ -198,7 +198,7 @@ describe( 'handleAddSiteWithBlueprint', () => {
 			expect( download ).not.toHaveBeenCalled();
 		} );
 
-		it( 'should handle invalid base64-encoded blueprint and display error message', async () => {
+		it( 'should handle invalid base64-encoded Blueprint and display error message', async () => {
 			const url = new URL( 'wp-studio://add-site?blueprint=invalid-base64!!!' );
 			await handleAddSiteWithBlueprint( url );
 

--- a/src/modules/add-site/components/blueprints.tsx
+++ b/src/modules/add-site/components/blueprints.tsx
@@ -251,7 +251,7 @@ export function AddSiteBlueprintSelector( {
 				} else {
 					setValidationError( __( 'Failed to load Blueprint file. Please try again.' ) );
 				}
-				console.error( 'Failed to parse blueprint file:', error );
+				console.error( 'Failed to parse Blueprint file:', error );
 			}
 		}
 		if ( fileRef.current ) {

--- a/src/modules/add-site/hooks/use-blueprint-deeplink.ts
+++ b/src/modules/add-site/hooks/use-blueprint-deeplink.ts
@@ -102,7 +102,7 @@ export function useBlueprintDeeplink( options: UseBlueprintDeeplinkOptions ): vo
 				dispatch( openAddSiteModal() );
 				navigateToBlueprintDeeplink();
 			} catch ( error ) {
-				console.error( 'Failed to load blueprint from URL:', error );
+				console.error( 'Failed to load Blueprint from URL:', error );
 			}
 		},
 		[

--- a/src/modules/add-site/tests/add-site.test.tsx
+++ b/src/modules/add-site/tests/add-site.test.tsx
@@ -582,7 +582,7 @@ describe( 'AddSite', () => {
 		).not.toBeInTheDocument();
 	} );
 
-	it( 'should show warning when blueprint preferred versions differ from selected versions', async () => {
+	it( 'should show warning when Blueprint preferred versions differ from selected versions', async () => {
 		const mockBlueprintData = {
 			data: {
 				blueprints: [

--- a/src/modules/cli/lib/cli-site-creator.ts
+++ b/src/modules/cli/lib/cli-site-creator.ts
@@ -138,7 +138,7 @@ function cleanupTempFile( filePath: string | undefined ): void {
 		try {
 			fs.unlinkSync( filePath );
 		} catch ( error ) {
-			console.error( 'Failed to clean up temp blueprint file:', error );
+			console.error( 'Failed to clean up temp Blueprint file:', error );
 		}
 	}
 }

--- a/src/modules/user-settings/components/studio-cli-toggle.tsx
+++ b/src/modules/user-settings/components/studio-cli-toggle.tsx
@@ -36,12 +36,12 @@ export function StudioCliToggle( { value, onChange }: StudioCLIToggleProps ) {
 							: createInterpolateElement(
 									sprintf(
 										/* translators: %s is the name of the WordPress Studio CLI command ("studio") */
-										__( 'Enable the <code>%s</code> command in the terminal. <learn-more-link />' ),
+										__( 'Enable the <code>%s</code> command in the terminal. <learn_more_link />' ),
 										'studio'
 									),
 									{
 										code: <code />,
-										'learn-more-link': <LearnMoreLink docsLinksKey="docsCli" />,
+										learn_more_link: <LearnMoreLink docsLinksKey="docsCli" />,
 									}
 							  ) }
 					</label>

--- a/src/modules/user-settings/components/studio-cli-toggle.tsx
+++ b/src/modules/user-settings/components/studio-cli-toggle.tsx
@@ -28,21 +28,20 @@ export function StudioCliToggle( { value, onChange }: StudioCLIToggleProps ) {
 							? createInterpolateElement(
 									sprintf(
 										/* translators: %s is the name of the WordPress Studio CLI command ("studio") */
-										__( 'Enable the %s command in the terminal.' ),
-										'<code>studio</code>'
+										__( 'Enable the <code>%s</code> command in the terminal.' ),
+										'studio'
 									),
 									{ code: <code /> }
 							  )
 							: createInterpolateElement(
 									sprintf(
 										/* translators: %s is the name of the WordPress Studio CLI command ("studio") */
-										__( 'Enable the %s command in the terminal. %s' ),
-										'<code>studio</code>',
-										'<learn_more_link />'
+										__( 'Enable the <code>%s</code> command in the terminal. <learn-more-link />' ),
+										'studio'
 									),
 									{
 										code: <code />,
-										learn_more_link: <LearnMoreLink docsLinksKey="docsCli" />,
+										'learn-more-link': <LearnMoreLink docsLinksKey="docsCli" />,
 									}
 							  ) }
 					</label>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Related to p1768209426233719/1767093925.737899-slack-C06DRMD6VPZ
- Fixes STU-1206

## Proposed Changes

As noted by @wojtekn, the newfangled CLI code has some inconsistencies in the translation strings. This PR addresses the following things:

- When saying that we're starting/stopping a Playground instance, say "WordPress server" instead of "WordPress site"
- Say "directory" instead of "folder"
- Don't use the phrase "Studio Desktop"
- Use the phrase "site" instead of "local site"
- A couple of one-off edits
- Capitalize "Blueprint" where applicable

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Code review should suffice

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?