### PR TITLE
Studio: Clean up unused locale in import-backup.tsx

### DIFF
--- a/src/modules/add-site/components/import-backup.tsx
+++ b/src/modules/add-site/components/import-backup.tsx
@@ -13,7 +13,6 @@ import { ErrorIcon } from 'src/components/error-icon';
 import { LearnMoreLink } from 'src/components/learn-more';
 import { ACCEPTED_IMPORT_FILE_TYPES } from 'src/constants';
 import { cx } from 'src/lib/cx';
-import { useI18nLocale } from 'src/stores';
 
 const formatFileSize = ( bytes: number ) => {
 	if ( bytes === 0 ) return '0 Bytes';

--- a/src/modules/add-site/components/import-backup.tsx
+++ b/src/modules/add-site/components/import-backup.tsx
@@ -54,7 +54,6 @@ export default function ImportBackup( {
 	selectedFile: initialFile,
 }: ImportBackupProps ) {
 	const { __ } = useI18n();
-	const locale = useI18nLocale();
 	const [ isDragging, setIsDragging ] = useState( false );
 	const [ selectedFile, setSelectedFile ] = useState< File | null >( initialFile || null );
 	const [ fileError, setFileError ] = useState< string | null >( null );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

N/A

I just came across this while working on something else.

## Proposed Changes

This PR removes unused `locale` from `import-backup.tsx`. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Visual review should be sufficient. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
