### PR TITLE
CLI: Add `--skip-log-details` option

### DIFF
--- a/cli/commands/site/create.ts
+++ b/cli/commands/site/create.ts
@@ -69,6 +69,7 @@ type CreateCommandOptions = {
 	};
 	noStart: boolean;
 	skipBrowser: boolean;
+	skipLogDetails: boolean;
 };
 
 export async function runCommand(
@@ -287,7 +288,9 @@ export async function runCommand(
 					? `${ siteDetails.enableHttps ? 'https' : 'http' }://${ siteDetails.customDomain }`
 					: `http://localhost:${ siteDetails.port }`;
 
-				logSiteDetails( siteDetails );
+				if ( ! options.skipLogDetails ) {
+					logSiteDetails( siteDetails );
+				}
 				if ( ! options.skipBrowser ) {
 					await openSiteInBrowser( siteDetails );
 				}
@@ -323,7 +326,9 @@ export async function runCommand(
 			console.log( '' );
 			console.log( __( 'Site created successfully!' ) );
 			console.log( '' );
-			logSiteDetails( siteDetails );
+			if ( ! options.skipLogDetails ) {
+				logSiteDetails( siteDetails );
+			}
 			console.log( __( 'Run "studio site start" to start the site.' ) );
 		}
 
@@ -428,7 +433,12 @@ export const registerCommand = ( yargs: StudioArgv ) => {
 				} )
 				.option( 'skip-browser', {
 					type: 'boolean',
-					describe: __( 'Do not open browser after starting' ),
+					describe: __( 'Skip opening the site in browser after starting' ),
+					default: false,
+				} )
+				.option( 'skip-log-details', {
+					type: 'boolean',
+					describe: __( 'Skip logging default wp-admin user details after starting' ),
 					default: false,
 				} );
 		},
@@ -441,6 +451,7 @@ export const registerCommand = ( yargs: StudioArgv ) => {
 				enableHttps: !! argv.https,
 				noStart: ! argv.start,
 				skipBrowser: !! argv.skipBrowser,
+				skipLogDetails: !! argv.skipLogDetails,
 			};
 
 			if ( argv.blueprint ) {

--- a/cli/commands/site/start.ts
+++ b/cli/commands/site/start.ts
@@ -10,7 +10,11 @@ import { StudioArgv } from 'cli/types';
 
 const logger = new Logger< LoggerAction >();
 
-export async function runCommand( sitePath: string, skipBrowser = false ): Promise< void > {
+export async function runCommand(
+	sitePath: string,
+	skipBrowser = false,
+	skipLogDetails = false
+): Promise< void > {
 	try {
 		logger.reportStart( LoggerAction.LOAD_SITES, __( 'Loading site…' ) );
 		const site = await getSiteByFolder( sitePath );
@@ -51,7 +55,10 @@ export async function runCommand( sitePath: string, skipBrowser = false ): Promi
 				await updateSiteLatestCliPid( site.id, processDesc.pid );
 			}
 			await updateSiteAutoStart( site.id, true );
-			logSiteDetails( site );
+
+			if ( ! skipLogDetails ) {
+				logSiteDetails( site );
+			}
 
 			if ( ! skipBrowser ) {
 				await openSiteInBrowser( site );
@@ -69,15 +76,21 @@ export const registerCommand = ( yargs: StudioArgv ) => {
 		command: 'start',
 		describe: __( 'Start local site' ),
 		builder: ( yargs ) => {
-			return yargs.option( 'skip-browser', {
-				type: 'boolean',
-				describe: __( 'Skip opening the site in browser after starting' ),
-				default: false,
-			} );
+			return yargs
+				.option( 'skip-browser', {
+					type: 'boolean',
+					describe: __( 'Skip opening the site in browser after starting' ),
+					default: false,
+				} )
+				.option( 'skip-log-details', {
+					type: 'boolean',
+					describe: __( 'Skip logging default wp-admin user details after starting' ),
+					default: false,
+				} );
 		},
 		handler: async ( argv ) => {
 			try {
-				await runCommand( argv.path, argv.skipBrowser );
+				await runCommand( argv.path, argv.skipBrowser, argv.skipLogDetails );
 			} catch ( error ) {
 				if ( error instanceof LoggerError ) {
 					logger.reportError( error );

--- a/cli/commands/site/tests/create.test.ts
+++ b/cli/commands/site/tests/create.test.ts
@@ -72,6 +72,7 @@ describe( 'CLI: studio site create', () => {
 		enableHttps: false,
 		noStart: false,
 		skipBrowser: false,
+		skipLogDetails: false,
 	};
 
 	const mockAppdata = {

--- a/src/modules/cli/lib/cli-server-process.ts
+++ b/src/modules/cli/lib/cli-server-process.ts
@@ -28,7 +28,7 @@ export class CliServerProcess implements WordPressServerProcess {
 	async start(): Promise< void > {
 		return new Promise( ( resolve, reject ) => {
 			const [ emitter ] = executeCliCommand(
-				[ 'site', 'start', '--path', this.sitePath, '--skip-browser' ],
+				[ 'site', 'start', '--path', this.sitePath, '--skip-browser', '--skip-log-details' ],
 				{ output: 'capture', logPrefix: this.siteId }
 			);
 

--- a/src/modules/cli/lib/cli-site-creator.ts
+++ b/src/modules/cli/lib/cli-site-creator.ts
@@ -104,7 +104,7 @@ export async function createSiteViaCli( options: CreateSiteOptions ): Promise< C
 }
 
 function buildCliArgs( options: CreateSiteOptions ): string[] {
-	const args = [ 'site', 'create', '--path', options.path, '--skip-browser' ];
+	const args = [ 'site', 'create', '--path', options.path, '--skip-browser', '--skip-log-details' ];
 
 	if ( options.name ) {
 		args.push( '--name', options.name );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-1200

## Proposed Changes

Add a `--skip-log-details` option to the `site create` and `site start` commands. The stdout of child processes is forwarded to the Studio logs, and we want to avoid logging sensitive details (e.g., wp-admin passwords) to logs that might end up in Sentry. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Run `npm start`
2. Start a site
3. Ensure that the wp-admin `admin` user password isn't logged to the terminal

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
