### PR TITLE
STU-1203: Add SQLite installation check and update WordPress install mode

### DIFF
--- a/cli/lib/sqlite-integration.ts
+++ b/cli/lib/sqlite-integration.ts
@@ -41,3 +41,7 @@ export async function installSqliteIntegration( sitePath: string ) {
 export async function keepSqliteIntegrationUpdated( sitePath: string ) {
 	return provider.keepSqliteIntegrationUpdated( sitePath );
 }
+
+export async function isSqliteInstalled( sitePath: string ) {
+	return provider.isSqliteInstalled( sitePath );
+}

--- a/common/lib/sqlite-integration.ts
+++ b/common/lib/sqlite-integration.ts
@@ -66,4 +66,12 @@ export abstract class SqliteIntegrationProvider {
 			await this.installSqliteIntegration( sitePath );
 		}
 	}
+
+	async isSqliteInstalled( sitePath: string ): Promise< boolean > {
+		return (
+			fs.existsSync(
+				path.join( sitePath, 'wp-content', 'mu-plugins', this.getSqliteFilename() )
+			) && fs.existsSync( path.join( sitePath, 'wp-content', 'db.php' ) )
+		);
+	}
 }

--- a/src/components/icons/pause.tsx
+++ b/src/components/icons/pause.tsx
@@ -1,0 +1,6 @@
+export const PauseIcon = () => (
+	<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+		<rect x="6" y="4" width="3" height="12" rx="1" fill="currentColor" />
+		<rect x="11" y="4" width="3" height="12" rx="1" fill="currentColor" />
+	</svg>
+);

--- a/src/components/icons/play.tsx
+++ b/src/components/icons/play.tsx
@@ -1,0 +1,5 @@
+export const PlayIcon = () => (
+	<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+		<path d="M7 4L15 10L7 16V4Z" fill="currentColor" />
+	</svg>
+);

--- a/src/hooks/sync-sites/sync-sites-context.tsx
+++ b/src/hooks/sync-sites/sync-sites-context.tsx
@@ -58,13 +58,21 @@ export function SyncSitesProvider( { children }: { children: React.ReactNode } )
 		} );
 
 	const [ pushStates, setPushStates ] = useState< PushStates >( {} );
-	const { pushSite, isAnySitePushing, isSiteIdPushing, clearPushState, getPushState, cancelPush } =
-		useSyncPush( {
-			pushStates,
-			setPushStates,
-			onPushSuccess: ( remoteSiteId, localSiteId ) =>
-				updateSiteTimestamp( { siteId: remoteSiteId, localSiteId, type: 'push' } ),
-		} );
+	const {
+		pushSite,
+		isAnySitePushing,
+		isSiteIdPushing,
+		clearPushState,
+		getPushState,
+		cancelPush,
+		pauseUpload,
+		resumeUpload,
+	} = useSyncPush( {
+		pushStates,
+		setPushStates,
+		onPushSuccess: ( remoteSiteId, localSiteId ) =>
+			updateSiteTimestamp( { siteId: remoteSiteId, localSiteId, type: 'push' } ),
+	} );
 
 	useListenDeepLinkConnection();
 
@@ -145,6 +153,8 @@ export function SyncSitesProvider( { children }: { children: React.ReactNode } )
 				isSiteIdPushing,
 				clearPushState,
 				cancelPush,
+				pauseUpload,
+				resumeUpload,
 				getLastSyncTimeText,
 			} }
 		>

--- a/src/hooks/sync-sites/use-sync-push.ts
+++ b/src/hooks/sync-sites/use-sync-push.ts
@@ -51,6 +51,8 @@ type UseSyncPushProps = {
 };
 
 type CancelPush = ( selectedSiteId: string, remoteSiteId: number ) => void;
+type PauseUpload = ( selectedSiteId: string, remoteSiteId: number ) => Promise< boolean >;
+type ResumeUpload = ( selectedSiteId: string, remoteSiteId: number ) => Promise< boolean >;
 
 export type UseSyncPush = {
 	pushStates: PushStates;
@@ -60,6 +62,8 @@ export type UseSyncPush = {
 	isSiteIdPushing: IsSiteIdPushing;
 	clearPushState: ClearState;
 	cancelPush: CancelPush;
+	pauseUpload: PauseUpload;
+	resumeUpload: ResumeUpload;
 };
 
 /**
@@ -401,10 +405,21 @@ export function useSyncPush( {
 	] );
 
 	useIpcListener(
-		'sync-upload-paused',
+		'sync-upload-network-paused',
 		( _event, payload: { selectedSiteId: string; remoteSiteId: number; error: string } ) => {
 			updatePushState( payload.selectedSiteId, payload.remoteSiteId, {
 				status: pushStatesProgressInfo.uploadingPaused,
+			} );
+		}
+	);
+
+	useIpcListener(
+		'sync-upload-manually-paused',
+		( _event, payload: { selectedSiteId: string; remoteSiteId: number } ) => {
+			const currentState = getPushState( payload.selectedSiteId, payload.remoteSiteId );
+			updatePushState( payload.selectedSiteId, payload.remoteSiteId, {
+				status: pushStatesProgressInfo.uploadingManuallyPaused,
+				uploadProgress: currentState?.uploadProgress,
 			} );
 		}
 	);
@@ -477,6 +492,14 @@ export function useSyncPush( {
 		[ __, pushStatesProgressInfo.cancelled, updatePushState ]
 	);
 
+	const pauseUpload = useCallback< PauseUpload >( async ( selectedSiteId, remoteSiteId ) => {
+		return getIpcApi().pauseSyncUpload( selectedSiteId, remoteSiteId );
+	}, [] );
+
+	const resumeUpload = useCallback< ResumeUpload >( async ( selectedSiteId, remoteSiteId ) => {
+		return getIpcApi().resumeSyncUpload( selectedSiteId, remoteSiteId );
+	}, [] );
+
 	return {
 		pushStates,
 		getPushState,
@@ -485,5 +508,7 @@ export function useSyncPush( {
 		isSiteIdPushing,
 		clearPushState,
 		cancelPush,
+		pauseUpload,
+		resumeUpload,
 	};
 }

--- a/src/hooks/tests/use-add-site.test.tsx
+++ b/src/hooks/tests/use-add-site.test.tsx
@@ -101,6 +101,8 @@ describe( 'useAddSite', () => {
 			getPushState: jest.fn(),
 			getLastSyncTimeText: jest.fn(),
 			cancelPush: jest.fn(),
+			pauseUpload: jest.fn(),
+			resumeUpload: jest.fn(),
 		} as SyncSitesContextType );
 
 		mockSetSelectedTab.mockReset();

--- a/src/hooks/use-sync-states-progress-info.ts
+++ b/src/hooks/use-sync-states-progress-info.ts
@@ -18,7 +18,8 @@ export type PushStateProgressInfo = {
 		| 'finished'
 		| 'failed'
 		| 'cancelled'
-		| 'uploadingPaused';
+		| 'uploadingPaused'
+		| 'uploadingManuallyPaused';
 	progress: number;
 	message: string;
 };
@@ -85,6 +86,10 @@ function isKeyPushing( key: PushStateProgressInfo[ 'key' ] | undefined ): boolea
 
 function isKeyUploadingPaused( key: PushStateProgressInfo[ 'key' ] | undefined ): boolean {
 	return key === 'uploadingPaused';
+}
+
+function isKeyUploadingManuallyPaused( key: PushStateProgressInfo[ 'key' ] | undefined ): boolean {
+	return key === 'uploadingManuallyPaused';
 }
 
 function isKeyUploading( key: PushStateProgressInfo[ 'key' ] | undefined ): boolean {
@@ -183,6 +188,11 @@ export function useSyncStatesProgressInfo() {
 			},
 			uploadingPaused: {
 				key: 'uploadingPaused',
+				progress: 45,
+				message: __( 'Uploading paused' ),
+			},
+			uploadingManuallyPaused: {
+				key: 'uploadingManuallyPaused',
 				progress: 45,
 				message: __( 'Uploading paused' ),
 			},
@@ -354,5 +364,6 @@ export function useSyncStatesProgressInfo() {
 		getPushUploadMessage,
 		mapUploadProgressToOverallProgress,
 		isKeyUploadingPaused,
+		isKeyUploadingManuallyPaused,
 	};
 }

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -101,9 +101,11 @@ export {
 	downloadSyncBackup,
 	exportSiteForPush,
 	getConnectedWpcomSites,
+	pauseSyncUpload,
 	pushArchive,
 	removeExportedSiteTmpFile,
 	removeSyncBackup,
+	resumeSyncUpload,
 	updateConnectedWpcomSites,
 	updateSingleConnectedWpcomSite,
 } from 'src/modules/sync/lib/ipc-handlers';

--- a/src/ipc-utils.ts
+++ b/src/ipc-utils.ts
@@ -38,9 +38,10 @@ export interface IpcEvents {
 		},
 	];
 	'site-context-menu-action': [ { action: string; siteId: string } ];
-	'sync-upload-paused': [ { error: string; selectedSiteId: string; remoteSiteId: number } ];
+	'sync-upload-network-paused': [ { error: string; selectedSiteId: string; remoteSiteId: number } ];
 	'sync-upload-resumed': [ { selectedSiteId: string; remoteSiteId: number } ];
 	'sync-upload-progress': [ { selectedSiteId: string; remoteSiteId: number; progress: number } ];
+	'sync-upload-manually-paused': [ { selectedSiteId: string; remoteSiteId: number } ];
 	'snapshot-error': [ { operationId: crypto.UUID; data: SnapshotEventData } ];
 	'snapshot-fatal-error': [ { operationId: crypto.UUID; data: { message: string } } ];
 	'snapshot-output': [ { operationId: crypto.UUID; data: SnapshotEventData } ];

--- a/src/lib/active-sync-operations.ts
+++ b/src/lib/active-sync-operations.ts
@@ -33,7 +33,11 @@ export function canCancelPull( key: PullStateProgressInfo[ 'key' ] | undefined )
  * Check if a push operation can be cancelled based on its current state.
  */
 export function canCancelPush( key: PushStateProgressInfo[ 'key' ] | undefined ): boolean {
-	const cancellableStateKeys: PushStateProgressInfo[ 'key' ][] = [ 'creatingBackup' ];
+	const cancellableStateKeys: PushStateProgressInfo[ 'key' ][] = [
+		'creatingBackup',
+		'uploading',
+		'uploadingManuallyPaused',
+	];
 	if ( ! key ) {
 		return false;
 	}
@@ -44,7 +48,11 @@ export function canCancelPush( key: PushStateProgressInfo[ 'key' ] | undefined )
  * Check if a push operation has finished uploading the backup file.
  */
 export function pushBackupIsUploading( key: PushStateProgressInfo[ 'key' ] | undefined ): boolean {
-	const uploadingStateKeys: PushStateProgressInfo[ 'key' ][] = [ 'creatingBackup', 'uploading' ];
+	const uploadingStateKeys: PushStateProgressInfo[ 'key' ][] = [
+		'creatingBackup',
+		'uploading',
+		'uploadingManuallyPaused',
+	];
 	if ( ! key ) {
 		return false;
 	}

--- a/src/lib/wordpress-provider/playground-cli/playground-cli-provider.ts
+++ b/src/lib/wordpress-provider/playground-cli/playground-cli-provider.ts
@@ -3,13 +3,13 @@ import { SupportedPHPVersions } from '@php-wasm/universal';
 import { Blueprint, StepDefinition } from '@wp-playground/blueprints';
 import { RecommendedPHPVersion } from '@wp-playground/common';
 import { WordPressInstallMode } from '@wp-playground/wordpress';
+import { keepSqliteIntegrationUpdated, isSqliteInstalled } from 'cli/lib/sqlite-integration';
 import { recursiveCopyDirectory, pathExists, isWordPressDirectory } from 'common/lib/fs-utils';
 import { DEFAULT_LOCALE } from 'common/lib/locale';
 import { isOnline } from 'common/lib/network-utils';
 import { isValidWordPressVersion } from 'common/lib/wordpress-version-utils';
 import { getBetaFeatures } from 'src/lib/beta-features';
 import { getPreferredSiteLanguage } from 'src/lib/site-language';
-import { keepSqliteIntegrationUpdated } from 'src/lib/sqlite-versions';
 import { SiteServer } from 'src/site-server';
 import { getResourcesPath, getServerFilesPath } from 'src/storage/paths';
 import {
@@ -67,6 +67,7 @@ export class PlaygroundCliProvider implements WordPressProvider {
 		const port = options.port;
 		const phpVersion = options.phpVersion || '8.3';
 		const hasWordPress = isWordPressDirectory( options.path );
+		const hasSqlite = await isSqliteInstalled( options.path );
 
 		// Get beta features to check if multi-worker and xdebug support are enabled
 		const betaFeatures = await getBetaFeatures();
@@ -79,14 +80,20 @@ export class PlaygroundCliProvider implements WordPressProvider {
 			console.log( '[PlaygroundCliProvider] Xdebug support is enabled for this site' );
 		}
 
+		let wordpressInstallMode: WordPressInstallMode = 'download-and-install';
+
+		if ( hasWordPress ) {
+			wordpressInstallMode = hasSqlite
+				? 'install-from-existing-files-if-needed'
+				: 'do-not-attempt-installing';
+		}
+
 		const playgroundOptions: PlaygroundCliOptions = {
 			port,
 			phpVersion,
 			documentRoot: options.path,
 			autoMount: true,
-			wordpressInstallMode: hasWordPress
-				? 'install-from-existing-files-if-needed'
-				: 'download-and-install',
+			wordpressInstallMode: wordpressInstallMode,
 			blueprint: options.blueprint,
 			enableMultiWorker: betaFeatures.multiWorkerSupport,
 			enableXdebug: betaFeatures.xdebugSupport && options.enableXdebug,

--- a/src/modules/add-site/tests/add-site.test.tsx
+++ b/src/modules/add-site/tests/add-site.test.tsx
@@ -145,6 +145,8 @@ beforeEach( () => {
 		getPushState: jest.fn(),
 		getLastSyncTimeText: jest.fn(),
 		cancelPush: jest.fn(),
+		pauseUpload: jest.fn(),
+		resumeUpload: jest.fn(),
 	} as SyncSitesContextType );
 	mockSetSelectedTab.mockReset();
 

--- a/src/modules/sync/components/sync-connected-sites.tsx
+++ b/src/modules/sync/components/sync-connected-sites.tsx
@@ -8,6 +8,8 @@ import { ArrowIcon } from 'src/components/arrow-icon';
 import Button from 'src/components/button';
 import { ClearAction } from 'src/components/clear-action';
 import { CircleRedCrossIcon } from 'src/components/icons/circle-red-cross';
+import { PauseIcon } from 'src/components/icons/pause';
+import { PlayIcon } from 'src/components/icons/play';
 import offlineIcon from 'src/components/offline-icon';
 import { PressableLogo } from 'src/components/pressable-logo';
 import ProgressBar from 'src/components/progress-bar';
@@ -190,8 +192,16 @@ const SyncConnectedSitesSectionItem = ( {
 }: SyncConnectedSitesListProps ) => {
 	const { __ } = useI18n();
 	const isOffline = useOffline();
-	const { clearPullState, getPullState, getPushState, clearPushState, cancelPull, cancelPush } =
-		useSyncSites();
+	const {
+		clearPullState,
+		getPullState,
+		getPushState,
+		clearPushState,
+		cancelPull,
+		cancelPush,
+		pauseUpload,
+		resumeUpload,
+	} = useSyncSites();
 	const { importState } = useImportExport();
 	const {
 		isKeyPulling,
@@ -203,6 +213,8 @@ const SyncConnectedSitesSectionItem = ( {
 		getPushUploadPercentage,
 		getPushUploadMessage,
 		isKeyUploadingPaused,
+		isKeyUploadingManuallyPaused,
+		isKeyUploading,
 	} = useSyncStatesProgressInfo();
 
 	const sitePullState = getPullState( selectedSite.id, connectedSite.id );
@@ -215,7 +227,10 @@ const SyncConnectedSitesSectionItem = ( {
 
 	const pushState = getPushState( selectedSite.id, connectedSite.id );
 	const isPushing = pushState && isKeyPushing( pushState.status.key );
-	const isUploadingPaused = pushState && isKeyUploadingPaused( pushState.status.key );
+	const isUploadingNetworkPaused = pushState && isKeyUploadingPaused( pushState.status.key );
+	const isUploadingManuallyPaused =
+		pushState && isKeyUploadingManuallyPaused( pushState.status.key );
+	const isUploading = pushState && isKeyUploading( pushState.status.key );
 	const isPushError = pushState && isKeyFailed( pushState.status.key );
 	const hasPushFinished = pushState && isKeyFinished( pushState.status.key );
 	const hasPushCancelled = pushState && isKeyCancelled( pushState.status.key );
@@ -276,12 +291,15 @@ const SyncConnectedSitesSectionItem = ( {
 								placement="top-start"
 							>
 								<Button
-									variant="link"
+									variant="icon"
 									onClick={ () => cancelPull( selectedSite.id, connectedSite.id ) }
 									disabled={ ! canCancelPull( sitePullState?.status.key ) }
-									className="!p-0 flex-shrink-0"
+									className="flex-shrink-0"
+									aria-label={ __( 'Cancel pull' ) }
 								>
-									<Icon icon={ close } size={ 20 } />
+									<span className="flex items-center justify-center w-5 h-5">
+										<Icon icon={ close } size={ 20 } />
+									</span>
 								</Button>
 							</Tooltip>
 						</div>
@@ -312,7 +330,7 @@ const SyncConnectedSitesSectionItem = ( {
 							{ __( 'Pull complete' ) }
 						</ClearAction>
 					) }
-					{ pushState?.status && isUploadingPaused && (
+					{ pushState?.status && isUploadingNetworkPaused && (
 						<Tooltip
 							text={ __(
 								'The site uploading has been paused due to an internet connection issue. We will retry automatically in a few seconds.'
@@ -324,6 +342,48 @@ const SyncConnectedSitesSectionItem = ( {
 								{ pushState.status.message }
 							</Button>
 						</Tooltip>
+					) }
+					{ pushState?.status && isUploadingManuallyPaused && (
+						<div className="flex items-center gap-2 max-w-full">
+							<Tooltip
+								text={ __(
+									'Upload is manually paused. Click the resume button to continue uploading.'
+								) }
+								placement="top-start"
+							>
+								<div className="flex flex-col gap-2 min-w-44 flex-shrink">
+									<div className="a8c-body-small flex items-center gap-0.5">
+										<Icon icon={ info } size={ 14 } />
+										{ pushState.status.message }
+									</div>
+									<ProgressBar value={ pushState.status.progress } maxValue={ 100 } />
+								</div>
+							</Tooltip>
+							<Tooltip text={ __( 'Resume upload' ) } placement="top-start">
+								<Button
+									variant="icon"
+									onClick={ () => resumeUpload( selectedSite.id, connectedSite.id ) }
+									className="flex-shrink-0"
+									aria-label={ __( 'Resume upload' ) }
+								>
+									<span className="flex items-center justify-center w-5 h-5">
+										<PlayIcon />
+									</span>
+								</Button>
+							</Tooltip>
+							<Tooltip text={ __( 'Cancel push' ) } placement="top-start">
+								<Button
+									variant="icon"
+									onClick={ () => cancelPush( selectedSite.id, connectedSite.id ) }
+									className="flex-shrink-0"
+									aria-label={ __( 'Cancel push' ) }
+								>
+									<span className="flex items-center justify-center w-5 h-5">
+										<Icon icon={ close } size={ 20 } />
+									</span>
+								</Button>
+							</Tooltip>
+						</div>
 					) }
 					{ pushState?.status && isPushing && (
 						<div className="flex items-center gap-2 max-w-full">
@@ -340,6 +400,20 @@ const SyncConnectedSitesSectionItem = ( {
 									<ProgressBar value={ pushState.status.progress } maxValue={ 100 } />
 								</div>
 							</Tooltip>
+							{ isUploading && (
+								<Tooltip text={ __( 'Pause upload' ) } placement="top-start">
+									<Button
+										variant="icon"
+										onClick={ () => pauseUpload( selectedSite.id, connectedSite.id ) }
+										className="flex-shrink-0"
+										aria-label={ __( 'Pause upload' ) }
+									>
+										<span className="flex items-center justify-center w-5 h-5">
+											<PauseIcon />
+										</span>
+									</Button>
+								</Tooltip>
+							) }
 							<Tooltip
 								text={
 									canCancelPush( pushState?.status.key )
@@ -349,12 +423,15 @@ const SyncConnectedSitesSectionItem = ( {
 								placement="top-start"
 							>
 								<Button
-									variant="link"
+									variant="icon"
 									onClick={ () => cancelPush( selectedSite.id, connectedSite.id ) }
 									disabled={ ! canCancelPush( pushState?.status.key ) }
-									className="!p-0 flex-shrink-0"
+									className="flex-shrink-0"
+									aria-label={ __( 'Cancel push' ) }
 								>
-									<Icon icon={ close } size={ 20 } />
+									<span className="flex items-center justify-center w-5 h-5">
+										<Icon icon={ close } size={ 20 } />
+									</span>
 								</Button>
 							</Tooltip>
 						</div>
@@ -375,7 +452,8 @@ const SyncConnectedSitesSectionItem = ( {
 						! isPullError &&
 						! isPushError &&
 						! isPushing &&
-						! isUploadingPaused &&
+						! isUploadingNetworkPaused &&
+						! isUploadingManuallyPaused &&
 						! hasPushFinished &&
 						! hasPullCancelled &&
 						! hasPushCancelled && (

--- a/src/modules/sync/lib/ipc-handlers.ts
+++ b/src/modules/sync/lib/ipc-handlers.ts
@@ -38,6 +38,66 @@ if ( ! fs.existsSync( TEMP_DIR ) ) {
 const SYNC_ABORT_CONTROLLERS = new Map< string, AbortController >();
 
 /**
+ * Registry to store TUS upload instances and their pause state for ongoing uploads.
+ * Key format: `${selectedSiteId}-${remoteSiteId}`
+ * This allows pause/resume functionality for uploads.
+ */
+type UploadState = {
+	upload: Upload;
+	isManuallyPaused: boolean;
+};
+
+const SYNC_TUS_UPLOADS = new Map< string, UploadState >();
+
+/**
+ * Pause an ongoing sync upload.
+ */
+export function pauseSyncUpload(
+	event: IpcMainInvokeEvent,
+	selectedSiteId: string,
+	remoteSiteId: number
+) {
+	const uploadKey = `${ selectedSiteId }-${ remoteSiteId }`;
+	const uploadState = SYNC_TUS_UPLOADS.get( uploadKey );
+
+	if ( uploadState ) {
+		uploadState.isManuallyPaused = true;
+		void uploadState.upload.abort();
+		void sendIpcEventToRenderer( 'sync-upload-manually-paused', {
+			selectedSiteId,
+			remoteSiteId,
+		} );
+		return true;
+	}
+
+	return false;
+}
+
+/**
+ * Resume a paused sync upload.
+ */
+export function resumeSyncUpload(
+	event: IpcMainInvokeEvent,
+	selectedSiteId: string,
+	remoteSiteId: number
+) {
+	const uploadKey = `${ selectedSiteId }-${ remoteSiteId }`;
+	const uploadState = SYNC_TUS_UPLOADS.get( uploadKey );
+
+	if ( uploadState ) {
+		uploadState.isManuallyPaused = false;
+		uploadState.upload.start();
+		void sendIpcEventToRenderer( 'sync-upload-resumed', {
+			selectedSiteId,
+			remoteSiteId,
+		} );
+		return true;
+	}
+
+	return false;
+}
+
+/**
  * Clear the ID of a push/pull operation.
  */
 export function clearSyncOperation( event: IpcMainInvokeEvent, id: string ) {
@@ -167,6 +227,8 @@ export async function pushArchive(
 	const fileSize = fs.statSync( archivePath ).size;
 	const filename = path.basename( archivePath );
 
+	const uploadKey = `${ selectedSiteId }-${ remoteSiteId }`;
+
 	const attachmentPromise = new Promise< string >( ( resolve, reject ) => {
 		const upload = new Upload( file, {
 			endpoint: `https://public-api.wordpress.com/rest/v1.1/studio-file-uploads/${ remoteSiteId }`,
@@ -230,15 +292,21 @@ export async function pushArchive(
 				}
 			},
 			onShouldRetry: ( error ) => {
-				// Update the UI only if the upload has started and is paused for any reason.
+				// Don't retry or send events if this is a manual pause
+				const uploadState = SYNC_TUS_UPLOADS.get( uploadKey );
+				if ( uploadState?.isManuallyPaused ) {
+					return false;
+				}
+
+				// Update the UI only if the upload has started and is paused for network reasons.
 				if ( hasUploadStarted ) {
 					isUploadingPaused = true;
-					void sendIpcEventToRenderer( 'sync-upload-paused', {
+					void sendIpcEventToRenderer( 'sync-upload-network-paused', {
 						selectedSiteId: selectedSiteId,
 						remoteSiteId: remoteSiteId,
 						error: error.message,
 					} );
-					console.error( '[TUS] Upload paused: ', error.message );
+					console.error( '[TUS] Upload paused due to network error: ', error.message );
 				}
 
 				const status = error.originalResponse ? error.originalResponse.getStatus() : 0;
@@ -251,8 +319,14 @@ export async function pushArchive(
 			},
 		} );
 
+		SYNC_TUS_UPLOADS.set( uploadKey, {
+			upload,
+			isManuallyPaused: false,
+		} );
+
 		upload.start();
 	} ).finally( () => {
+		SYNC_TUS_UPLOADS.delete( uploadKey );
 		file.destroy();
 		file.close();
 	} );

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -123,6 +123,10 @@ const api: IpcApi = {
 	addSyncOperation: ( id, status ) => ipcRendererSend( 'addSyncOperation', id, status ),
 	clearSyncOperation: ( id ) => ipcRendererSend( 'clearSyncOperation', id ),
 	cancelSyncOperation: ( id ) => ipcRendererSend( 'cancelSyncOperation', id ),
+	pauseSyncUpload: ( selectedSiteId, remoteSiteId ) =>
+		ipcRendererInvoke( 'pauseSyncUpload', selectedSiteId, remoteSiteId ),
+	resumeSyncUpload: ( selectedSiteId, remoteSiteId ) =>
+		ipcRendererInvoke( 'resumeSyncUpload', selectedSiteId, remoteSiteId ),
 	getDirectorySize: ( id, subdir ) => ipcRendererInvoke( 'getDirectorySize', id, subdir ),
 	getFileSize: ( id, filePath ) => ipcRendererInvoke( 'getFileSize', id, filePath ),
 	getPathForFile: ( file ) => webUtils.getPathForFile( file ),


### PR DESCRIPTION
## Summary
This PR adds SQLite installation detection and updates the WordPress install mode logic in PlaygroundCliProvider.

## Changes
- Added `isSqliteInstalled` method to `SqliteIntegrationProvider` base class
- Exported `isSqliteInstalled` from CLI sqlite-integration module  
- Updated `PlaygroundCliProvider` to check SQLite installation status before determining WordPress install mode
- Adjusted WordPress install mode based on SQLite presence:
  - If WordPress exists and SQLite is installed: use `install-from-existing-files-if-needed`
  - If WordPress exists but SQLite is not installed: use `do-not-attempt-installing`
- Updated import to use `cli/lib/sqlite-integration` instead of `src/lib/sqlite-versions`

## Testing
- [ ] Verified SQLite installation detection works correctly
- [ ] Confirmed WordPress install mode is set appropriately based on SQLite status