### PR TITLE
Studio: Fix error connecting to external MySQL database

### DIFF
--- a/cli/lib/sqlite-integration.ts
+++ b/cli/lib/sqlite-integration.ts
@@ -30,7 +30,3 @@ export async function installSqliteIntegration( sitePath: string ) {
 export async function keepSqliteIntegrationUpdated( sitePath: string ) {
 	return provider.keepSqliteIntegrationUpdated( sitePath );
 }
-
-export async function isSqliteInstalled( sitePath: string ) {
-	return provider.isSqliteInstalled( sitePath );
-}

--- a/cli/lib/sqlite-integration.ts
+++ b/cli/lib/sqlite-integration.ts
@@ -30,3 +30,7 @@ export async function installSqliteIntegration( sitePath: string ) {
 export async function keepSqliteIntegrationUpdated( sitePath: string ) {
 	return provider.keepSqliteIntegrationUpdated( sitePath );
 }
+
+export async function isSqliteInstalled( sitePath: string ) {
+	return provider.isSqliteInstalled( sitePath );
+}

--- a/cli/wordpress-server-child.ts
+++ b/cli/wordpress-server-child.ts
@@ -21,12 +21,13 @@ import {
 	OverlayFilesystem,
 	InMemoryFilesystem,
 } from '@wp-playground/storage';
+import { WordPressInstallMode } from '@wp-playground/wordpress';
 import { isWordPressDirectory } from 'common/lib/fs-utils';
-import { isSqliteInstalled } from 'cli/lib/sqlite-integration';
 import { getMuPlugins } from 'common/lib/mu-plugins';
 import { formatPlaygroundCliMessage } from 'common/lib/playground-cli-messages';
 import { sequential } from 'common/lib/sequential';
 import { isWordPressDevVersion } from 'common/lib/wordpress-version-utils';
+import { isSqliteInstalled } from 'src/lib/sqlite-versions';
 import { z } from 'zod';
 import { sanitizeRunCLIArgs } from 'cli/lib/cli-args-sanitizer';
 import { getSqliteCommandPath, getWpCliPharPath } from 'cli/lib/server-files';
@@ -101,6 +102,29 @@ async function setAdminPassword( server: RunCLIServer, adminPassword: string ): 
 	} );
 }
 
+/**
+ * Gets the WordPress installation mode based on whether WordPress files
+ * and SQLite integration are present.
+ *
+ * @param sitePath - The path to the site
+ * @returns The WordPressInstallMode to use for the site
+ */
+async function getWordPressInstallMode( sitePath: string ): Promise< WordPressInstallMode > {
+	const hasWordPress = isWordPressDirectory( sitePath );
+	const hasSqlite = await isSqliteInstalled( sitePath );
+
+	if ( ! hasWordPress ) {
+		return 'download-and-install';
+	}
+
+	if ( hasSqlite ) {
+		return 'install-from-existing-files-if-needed';
+	}
+
+	// We don't want playground to attempt installing WordPress when site is using MySQL.
+	return 'do-not-attempt-installing';
+}
+
 function getBaseRunCLIArgs(
 	command: 'server',
 	config: ServerConfig
@@ -113,8 +137,7 @@ async function getBaseRunCLIArgs(
 	command: RunCLIArgs[ 'command' ],
 	config: ServerConfig
 ): Promise< RunCLIArgs > {
-	const hasWordPress = isWordPressDirectory( config.sitePath );
-	const hasSqlite = await isSqliteInstalled( config.sitePath );
+	const wordpressInstallMode = await getWordPressInstallMode( config.sitePath );
 
 	const [ studioMuPluginsHostPath, loaderMuPluginHostPath ] = await getMuPlugins( {
 		isWpAutoUpdating: config.isWpAutoUpdating,
@@ -188,14 +211,8 @@ async function getBaseRunCLIArgs(
 		'mount-before-install': mounts,
 		'site-url': config.absoluteUrl || `http://localhost:${ config.port }`,
 		blueprint: blueprintBundle,
-		wordpressInstallMode: 'download-and-install',
+		wordpressInstallMode,
 	};
-
-	if ( hasWordPress ) {
-		args.wordpressInstallMode = hasSqlite
-			? 'install-from-existing-files-if-needed'
-			: 'do-not-attempt-installing';
-	}
 
 	if ( config.phpVersion ) {
 		args.php = config.phpVersion as SupportedPHPVersion;

--- a/cli/wordpress-server-child.ts
+++ b/cli/wordpress-server-child.ts
@@ -22,6 +22,7 @@ import {
 	InMemoryFilesystem,
 } from '@wp-playground/storage';
 import { isWordPressDirectory } from 'common/lib/fs-utils';
+import { isSqliteInstalled } from 'cli/lib/sqlite-integration';
 import { getMuPlugins } from 'common/lib/mu-plugins';
 import { formatPlaygroundCliMessage } from 'common/lib/playground-cli-messages';
 import { sequential } from 'common/lib/sequential';
@@ -113,6 +114,7 @@ async function getBaseRunCLIArgs(
 	config: ServerConfig
 ): Promise< RunCLIArgs > {
 	const hasWordPress = isWordPressDirectory( config.sitePath );
+	const hasSqlite = await isSqliteInstalled( config.sitePath );
 
 	const [ studioMuPluginsHostPath, loaderMuPluginHostPath ] = await getMuPlugins( {
 		isWpAutoUpdating: config.isWpAutoUpdating,
@@ -190,7 +192,9 @@ async function getBaseRunCLIArgs(
 	};
 
 	if ( hasWordPress ) {
-		args.wordpressInstallMode = 'install-from-existing-files-if-needed';
+		args.wordpressInstallMode = hasSqlite
+			? 'install-from-existing-files-if-needed'
+			: 'do-not-attempt-installing';
 	}
 
 	if ( config.phpVersion ) {

--- a/common/lib/sqlite-integration.ts
+++ b/common/lib/sqlite-integration.ts
@@ -64,4 +64,12 @@ export abstract class SqliteIntegrationProvider {
 			await this.installSqliteIntegration( sitePath );
 		}
 	}
+
+	async isSqliteInstalled( sitePath: string ): Promise< boolean > {
+		return (
+			fs.existsSync(
+				path.join( sitePath, 'wp-content', 'mu-plugins', this.getSqliteFilename() )
+			) && fs.existsSync( path.join( sitePath, 'wp-content', 'db.php' ) )
+		);
+	}
 }

--- a/common/lib/sqlite-integration.ts
+++ b/common/lib/sqlite-integration.ts
@@ -67,9 +67,8 @@ export abstract class SqliteIntegrationProvider {
 
 	async isSqliteInstalled( sitePath: string ): Promise< boolean > {
 		return (
-			fs.existsSync(
-				path.join( sitePath, 'wp-content', 'mu-plugins', this.getSqliteFilename() )
-			) && fs.existsSync( path.join( sitePath, 'wp-content', 'db.php' ) )
+			fs.existsSync( path.join( sitePath, 'wp-content', 'mu-plugins', this.getSqliteDirname() ) ) &&
+			fs.existsSync( path.join( sitePath, 'wp-content', 'db.php' ) )
 		);
 	}
 }

--- a/src/lib/sqlite-versions.ts
+++ b/src/lib/sqlite-versions.ts
@@ -24,3 +24,5 @@ export const installSqliteIntegration = sequential( ( sitePath: string ) =>
 
 export const keepSqliteIntegrationUpdated = ( sitePath: string ) =>
 	provider.keepSqliteIntegrationUpdated( sitePath );
+
+export const isSqliteInstalled = ( sitePath: string ) => provider.isSqliteInstalled( sitePath );


### PR DESCRIPTION
## Related issues

- Fixes STU-1203

## Proposed Changes

- I propose to use `do-not-attempt-installing` WordPress installation mode when site is configured to use MySQL. 
- Otherwise use `install-from-existing-files-if-needed` as it was configured before.
- The MySQL config is checked using existence of sqlite plugin directory and `db.php`. 

## Why

The actual error is originating from [this line](https://github.com/WordPress/wordpress-playground/blob/fffde71af232231749175e6cb2ebf9d29ed85efb/packages/playground/wordpress/src/boot.ts#L360) in playground CLI. Its part of `assertValidDatabaseConnection` function where some pre-test are done to make sure sqlite is configured correctly. This validation only runs if either `install-from-existing-files-if-needed` or `download-and-install` installation mode is used. You can check condition [here](https://github.com/WordPress/wordpress-playground/blob/fffde71af232231749175e6cb2ebf9d29ed85efb/packages/playground/wordpress/src/boot.ts#L360). This PR updates WordPress installation mode based on sqlite plugin status to avoid these checks.

## Testing Instructions

1. Create a new site or open an existing one in WordPress Studio
2. Configure `wp-config.php` to use an external MySQL database (`127.0.0.1`). Follow this guide to [use Studio with MySQL server](https://developer.wordpress.com/docs/developer-tools/studio/frequently-asked-questions/#use-studio-with-mysql-server).
3. Start the server - it should attempt to connect to MySQL and server should start normally.
4. Verify the if site is using MySQL database. Goto `Tools -> Site heath -> Info -> Database`
<img width="1684" height="970" alt="CleanShot 2026-01-14 at 17 22 17@2x" src="https://github.com/user-attachments/assets/bfb705e8-1364-4a8f-9d64-8704550b1bdd" /> 
5. Check for regression. Existing sites should start normally. 

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?