### PR TITLE
Fix metrics test timeout for slow site creation

### DIFF
--- a/metrics/tests/site-editor.test.ts
+++ b/metrics/tests/site-editor.test.ts
@@ -32,7 +32,7 @@ test.describe( 'Site Editor Load Metrics', () => {
 		await session.launch();
 
 		const onboarding = new Onboarding( session.mainWindow );
-		await expect( onboarding.heading ).toBeVisible();
+		await expect( onboarding.heading ).toBeVisible( { timeout: 120_000 } );
 
 		// Wait for store initialization to complete (provider constants loading)
 		await new Promise( ( resolve ) => setTimeout( resolve, 500 ) );
@@ -41,8 +41,9 @@ test.describe( 'Site Editor Load Metrics', () => {
 
 		const siteContent = new SiteContent( session.mainWindow, siteName );
 
-		await expect( siteContent.siteNameHeading ).toBeVisible();
-		await expect( siteContent.runningButton ).toBeAttached();
+		// Site creation can take a while, use explicit timeout matching E2E tests
+		await expect( siteContent.siteNameHeading ).toBeVisible( { timeout: 120_000 } );
+		await expect( siteContent.runningButton ).toBeAttached( { timeout: 120_000 } );
 
 		// Get the WordPress admin URL from settings
 		const settingsTab = await siteContent.navigateToTab( 'Settings' );


### PR DESCRIPTION
Fixes AINFRA-1760

## Summary

Fixes the metrics test failure introduced in #2399. The reduced global `expect.timeout` (30s) is too short for app startup and site creation operations.

Added explicit 120s timeouts matching the pattern used in E2E tests:
- `onboarding.heading` visibility check
- `siteContent.siteNameHeading` visibility check  
- `siteContent.runningButton` attached check

## Test plan
- [ ] Metrics test passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)