### PR TITLE
Performance: Parallelize recursive directory copying

### DIFF
--- a/cli/commands/site/create.ts
+++ b/cli/commands/site/create.ts
@@ -15,13 +15,7 @@ import {
 	validateBlueprintData,
 } from 'common/lib/blueprint-validation';
 import { getDomainNameValidationError } from 'common/lib/domains';
-import {
-	arePathsEqual,
-	isEmptyDir,
-	isWordPressDirectory,
-	pathExists,
-	recursiveCopyDirectory,
-} from 'common/lib/fs-utils';
+import { arePathsEqual, isEmptyDir, isWordPressDirectory, pathExists } from 'common/lib/fs-utils';
 import { DEFAULT_LOCALE } from 'common/lib/locale';
 import { isOnline } from 'common/lib/network-utils';
 import { createPassword } from 'common/lib/passwords';
@@ -33,6 +27,7 @@ import {
 	isWordPressVersionAtLeast,
 } from 'common/lib/wordpress-version-utils';
 import { SiteCommandLoggerAction as LoggerAction } from 'common/logger-actions';
+import fse from 'fs-extra';
 import {
 	lockAppdata,
 	readAppdata,
@@ -161,7 +156,7 @@ export async function runCommand(
 			}
 
 			logger.reportStart( LoggerAction.SETUP_WORDPRESS, __( 'Copying bundled WordPress…' ) );
-			await recursiveCopyDirectory( bundledWPPath, sitePath );
+			await fse.copy( bundledWPPath, sitePath );
 			logger.reportSuccess( __( 'WordPress files copied' ) );
 		} else if ( ! isOnlineStatus ) {
 			throw new LoggerError(

--- a/cli/commands/site/tests/create.test.ts
+++ b/cli/commands/site/tests/create.test.ts
@@ -3,13 +3,7 @@ import {
 	filterUnsupportedBlueprintFeatures,
 	validateBlueprintData,
 } from 'common/lib/blueprint-validation';
-import {
-	isEmptyDir,
-	isWordPressDirectory,
-	pathExists,
-	arePathsEqual,
-	recursiveCopyDirectory,
-} from 'common/lib/fs-utils';
+import { isEmptyDir, isWordPressDirectory, pathExists, arePathsEqual } from 'common/lib/fs-utils';
 import { isOnline } from 'common/lib/network-utils';
 import { portFinder } from 'common/lib/port-finder';
 import {
@@ -39,6 +33,10 @@ jest.mock( 'common/lib/port-finder', () => ( {
 } ) );
 jest.mock( 'common/lib/passwords', () => ( {
 	createPassword: jest.fn().mockReturnValue( 'generated-password-123' ),
+} ) );
+jest.mock( 'fs-extra', () => ( {
+	...jest.requireActual( 'fs-extra' ),
+	copy: jest.fn().mockResolvedValue( undefined ),
 } ) );
 jest.mock( 'common/lib/blueprint-validation' );
 jest.mock( 'cli/lib/appdata', () => ( {
@@ -132,7 +130,6 @@ describe( 'CLI: studio site create', () => {
 		( isEmptyDir as jest.Mock ).mockResolvedValue( true );
 		( isWordPressDirectory as jest.Mock ).mockReturnValue( false );
 		( arePathsEqual as jest.Mock ).mockImplementation( ( a, b ) => a === b );
-		( recursiveCopyDirectory as jest.Mock ).mockResolvedValue( undefined );
 		( portFinder.getOpenPort as jest.Mock ).mockResolvedValue( mockPort );
 		( readAppdata as jest.Mock ).mockResolvedValue( {
 			sites: [ ...mockAppdata.sites ],

--- a/common/lib/fs-utils.ts
+++ b/common/lib/fs-utils.ts
@@ -85,16 +85,18 @@ export async function recursiveCopyDirectory(
 
 	const entries = await fsPromises.readdir( source, { withFileTypes: true } );
 
-	for ( const entry of entries ) {
-		const sourcePath = path.join( source, entry.name );
-		const destinationPath = path.join( destination, entry.name );
+	await Promise.all(
+		entries.map( async ( entry ) => {
+			const sourcePath = path.join( source, entry.name );
+			const destinationPath = path.join( destination, entry.name );
 
-		if ( entry.isDirectory() ) {
-			await recursiveCopyDirectory( sourcePath, destinationPath );
-		} else if ( entry.isFile() ) {
-			await fsPromises.copyFile( sourcePath, destinationPath );
-		}
-	}
+			if ( entry.isDirectory() ) {
+				await recursiveCopyDirectory( sourcePath, destinationPath );
+			} else if ( entry.isFile() ) {
+				await fsPromises.copyFile( sourcePath, destinationPath );
+			}
+		} )
+	);
 }
 
 export async function isEmptyDir( directory: string ): Promise< boolean > {

--- a/common/lib/fs-utils.ts
+++ b/common/lib/fs-utils.ts
@@ -1,5 +1,6 @@
 import fs, { promises as fsPromises } from 'fs';
 import path from 'path';
+import pLimit from 'p-limit';
 import { isErrnoException } from './is-errno-exception';
 
 /**
@@ -85,17 +86,21 @@ export async function recursiveCopyDirectory(
 
 	const entries = await fsPromises.readdir( source, { withFileTypes: true } );
 
-	await Promise.all(
-		entries.map( async ( entry ) => {
-			const sourcePath = path.join( source, entry.name );
-			const destinationPath = path.join( destination, entry.name );
+	const limit = pLimit( 100 );
 
-			if ( entry.isDirectory() ) {
-				await recursiveCopyDirectory( sourcePath, destinationPath );
-			} else if ( entry.isFile() ) {
-				await fsPromises.copyFile( sourcePath, destinationPath );
-			}
-		} )
+	await Promise.all(
+		entries.map( ( entry ) =>
+			limit( async () => {
+				const sourcePath = path.join( source, entry.name );
+				const destinationPath = path.join( destination, entry.name );
+
+				if ( entry.isDirectory() ) {
+					await recursiveCopyDirectory( sourcePath, destinationPath );
+				} else if ( entry.isFile() ) {
+					await fsPromises.copyFile( sourcePath, destinationPath );
+				}
+			} )
+		)
 	);
 }
 

--- a/common/lib/fs-utils.ts
+++ b/common/lib/fs-utils.ts
@@ -1,6 +1,6 @@
 import fs, { promises as fsPromises } from 'fs';
 import path from 'path';
-import pLimit from 'p-limit';
+import fse from 'fs-extra';
 import { isErrnoException } from './is-errno-exception';
 
 /**
@@ -82,26 +82,7 @@ export async function recursiveCopyDirectory(
 	source: string,
 	destination: string
 ): Promise< void > {
-	await fsPromises.mkdir( destination, { recursive: true } );
-
-	const entries = await fsPromises.readdir( source, { withFileTypes: true } );
-
-	const limit = pLimit( 100 );
-
-	await Promise.all(
-		entries.map( ( entry ) =>
-			limit( async () => {
-				const sourcePath = path.join( source, entry.name );
-				const destinationPath = path.join( destination, entry.name );
-
-				if ( entry.isDirectory() ) {
-					await recursiveCopyDirectory( sourcePath, destinationPath );
-				} else if ( entry.isFile() ) {
-					await fsPromises.copyFile( sourcePath, destinationPath );
-				}
-			} )
-		)
-	);
+	await fse.copy( source, destination );
 }
 
 export async function isEmptyDir( directory: string ): Promise< boolean > {

--- a/common/lib/fs-utils.ts
+++ b/common/lib/fs-utils.ts
@@ -1,6 +1,5 @@
 import fs, { promises as fsPromises } from 'fs';
 import path from 'path';
-import fse from 'fs-extra';
 import { isErrnoException } from './is-errno-exception';
 
 /**
@@ -76,13 +75,6 @@ export async function pathExists( path: string ): Promise< boolean > {
 		}
 		throw err;
 	}
-}
-
-export async function recursiveCopyDirectory(
-	source: string,
-	destination: string
-): Promise< void > {
-	await fse.copy( source, destination );
 }
 
 export async function isEmptyDir( directory: string ): Promise< boolean > {

--- a/src/lib/wordpress-setup.ts
+++ b/src/lib/wordpress-setup.ts
@@ -4,7 +4,8 @@
  */
 
 import nodePath from 'path';
-import { recursiveCopyDirectory, pathExists } from 'common/lib/fs-utils';
+import fs from 'fs-extra';
+import { pathExists } from 'common/lib/fs-utils';
 import { getResourcesPath } from 'src/storage/paths';
 
 /**
@@ -18,5 +19,5 @@ export async function setupWordPressFilesOnly( path: string ): Promise< void > {
 		throw new Error( 'Bundled WordPress files not found. Please reinstall WordPress Studio.' );
 	}
 
-	await recursiveCopyDirectory( bundledWPPath, path );
+	await fs.copy( bundledWPPath, path );
 }

--- a/src/lib/wp-versions.ts
+++ b/src/lib/wp-versions.ts
@@ -1,7 +1,6 @@
 import path from 'path';
 import fs from 'fs-extra';
 import semver from 'semver';
-import { recursiveCopyDirectory } from 'common/lib/fs-utils';
 import { downloadWordPress } from 'src/lib/download-utils';
 import { getWordPressVersionPath } from 'src/lib/server-files-paths';
 
@@ -68,10 +67,7 @@ export async function updateLatestWordPressVersion() {
 		const latestVersion = await getLatestWordPressVersion();
 		if ( installedVersion && latestVersion !== 'latest' && installedVersion !== latestVersion ) {
 			// We keep a copy of the latest installed version instead of removing it.
-			await recursiveCopyDirectory(
-				latestVersionPath,
-				getWordPressVersionPath( installedVersion )
-			);
+			await fs.copy( latestVersionPath, getWordPressVersionPath( installedVersion ) );
 			shouldOverwrite = true;
 		}
 	}

--- a/src/migrations/migrate-from-wp-now-folder.ts
+++ b/src/migrations/migrate-from-wp-now-folder.ts
@@ -1,6 +1,7 @@
 import { app } from 'electron';
 import path from 'path';
-import { pathExists, recursiveCopyDirectory } from 'common/lib/fs-utils';
+import fs from 'fs-extra';
+import { pathExists } from 'common/lib/fs-utils';
 import { getServerFilesPath } from 'src/storage/paths';
 import { loadUserData } from 'src/storage/user-data';
 
@@ -26,5 +27,5 @@ export async function needsToMigrateFromWpNowFolder() {
 }
 
 export async function migrateFromWpNowFolder() {
-	await recursiveCopyDirectory( wpNowPath, getServerFilesPath() );
+	await fs.copy( wpNowPath, getServerFilesPath() );
 }

--- a/src/setup-wp-server-files.ts
+++ b/src/setup-wp-server-files.ts
@@ -1,7 +1,6 @@
 import path from 'path';
 import fs from 'fs-extra';
 import semver from 'semver';
-import { recursiveCopyDirectory } from 'common/lib/fs-utils';
 import { updateLatestWPCliVersion } from 'src/lib/download-utils';
 import { getWordPressVersionPath, getSqlitePath, getWpCliPath } from 'src/lib/server-files-paths';
 import {
@@ -42,7 +41,7 @@ export async function copyBundledLatestWPVersion() {
 			} );
 		}
 		console.log( `Copying bundled WP version ${ bundledWPVersion } as 'latest' version…` );
-		await recursiveCopyDirectory( bundledWPVersionPath, latestWPVersionPath );
+		await fs.copy( bundledWPVersionPath, latestWPVersionPath );
 	}
 }
 
@@ -69,7 +68,7 @@ async function copyBundledSqlite() {
 		installedSqliteVersion && semver.gt( bundledSqliteVersion, installedSqliteVersion );
 	if ( ! isSqliteInstalled || isBundledVersionNewer ) {
 		console.log( `Copying bundled SQLite version ${ bundledSqliteVersion }…` );
-		await recursiveCopyDirectory( bundledSqlitePath, getSqlitePath() );
+		await fs.copy( bundledSqlitePath, getSqlitePath() );
 	}
 }
 
@@ -97,7 +96,7 @@ async function copyBundledSQLiteCommand() {
 		semver.gt( bundledSqliteCommandVersion, installedSqliteCommandVersion );
 	if ( ! isSqliteCommandInstalled || isBundledVersionNewer ) {
 		console.log( `Copying bundled SQLite command version ${ bundledSqliteCommandVersion }…` );
-		await recursiveCopyDirectory( bundledSqliteCommandPath, installedSqliteCommandPath );
+		await fs.copy( bundledSqliteCommandPath, installedSqliteCommandPath );
 	}
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Related to STU-980

## Proposed Changes

- parallelize recursive directory copying

Compared to the current `trunk` I have measured about 16% speed-up of the site creation process on macOS (about  1.2 s saving). On Windows the percentage is smaller (about 6%) - as the overall site creation process takes longer there.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR branch and build the app with `npm install && npm start`.
2. Create several new sites.
3. The process should work correctly, the sites should get created and run without any issues.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
