### PR TITLE
Studio: Add site does not duplicate sites

### DIFF
--- a/src/modules/cli/lib/cli-events-subscriber.ts
+++ b/src/modules/cli/lib/cli-events-subscriber.ts
@@ -26,16 +26,17 @@ function siteDetailsToServerDetails(
 	};
 }
 
-const handleSiteEvent = sequential( async ( event: SiteEvent ): Promise< boolean > => {
+const handleSiteEvent = sequential( async ( event: SiteEvent ): Promise< void > => {
 	const { event: eventType, siteId, site, running } = event;
 
 	if ( eventType === SITE_EVENTS.DELETED ) {
 		SiteServer.unregister( siteId );
-		return true;
+		void sendIpcEventToRenderer( 'site-event', event );
+		return;
 	}
 
 	if ( ! site ) {
-		return true;
+		return;
 	}
 
 	// Only register new sites on CREATED events to prevent duplicates
@@ -45,18 +46,22 @@ const handleSiteEvent = sequential( async ( event: SiteEvent ): Promise< boolean
 			SiteServer.register( siteDetailsToServerDetails( site, running ) );
 		}
 		// Don't send to renderer if site is being created by UI (createSite IPC will handle it)
-		return ! existingServer?.hasOngoingOperation;
+		if ( existingServer?.hasOngoingOperation ) {
+			return;
+		}
+		void sendIpcEventToRenderer( 'site-event', event );
+		return;
 	}
 
 	// For UPDATED events, only update if the site already exists
 	const server = SiteServer.get( siteId ) ?? SiteServer.getByPath( site.path );
 	if ( ! server ) {
-		return false;
+		return;
 	}
 
 	// Skip update if Studio has an ongoing operation
 	if ( server.hasOngoingOperation ) {
-		return false;
+		return;
 	}
 
 	server.details = siteDetailsToServerDetails( site, running );
@@ -65,7 +70,7 @@ const handleSiteEvent = sequential( async ( event: SiteEvent ): Promise< boolean
 		server.server.url = site.url;
 	}
 
-	return true;
+	void sendIpcEventToRenderer( 'site-event', event );
 } );
 
 export async function startCliEventsSubscriber(): Promise< void > {
@@ -91,11 +96,7 @@ export async function startCliEventsSubscriber(): Promise< void > {
 			}
 
 			const siteEvent = parsed.data.value;
-			void handleSiteEvent( siteEvent ).then( ( shouldSendToRenderer ) => {
-				if ( shouldSendToRenderer ) {
-					void sendIpcEventToRenderer( 'site-event', siteEvent );
-				}
-			} );
+			void handleSiteEvent( siteEvent );
 		} );
 
 		eventEmitter.on( 'error', ( { error } ) => {

--- a/src/modules/cli/lib/cli-events-subscriber.ts
+++ b/src/modules/cli/lib/cli-events-subscriber.ts
@@ -26,16 +26,16 @@ function siteDetailsToServerDetails(
 	};
 }
 
-const handleSiteEvent = sequential( async ( event: SiteEvent ): Promise< void > => {
+const handleSiteEvent = sequential( async ( event: SiteEvent ): Promise< boolean > => {
 	const { event: eventType, siteId, site, running } = event;
 
 	if ( eventType === SITE_EVENTS.DELETED ) {
 		SiteServer.unregister( siteId );
-		return;
+		return true;
 	}
 
 	if ( ! site ) {
-		return;
+		return true;
 	}
 
 	// Only register new sites on CREATED events to prevent duplicates
@@ -44,18 +44,19 @@ const handleSiteEvent = sequential( async ( event: SiteEvent ): Promise< void > 
 		if ( ! existingServer ) {
 			SiteServer.register( siteDetailsToServerDetails( site, running ) );
 		}
-		return;
+		// Don't send to renderer if site is being created by UI (createSite IPC will handle it)
+		return ! existingServer?.hasOngoingOperation;
 	}
 
 	// For UPDATED events, only update if the site already exists
 	const server = SiteServer.get( siteId ) ?? SiteServer.getByPath( site.path );
 	if ( ! server ) {
-		return;
+		return false;
 	}
 
 	// Skip update if Studio has an ongoing operation
 	if ( server.hasOngoingOperation ) {
-		return;
+		return false;
 	}
 
 	server.details = siteDetailsToServerDetails( site, running );
@@ -63,6 +64,8 @@ const handleSiteEvent = sequential( async ( event: SiteEvent ): Promise< void > 
 	if ( server.server && site.url ) {
 		server.server.url = site.url;
 	}
+
+	return true;
 } );
 
 export async function startCliEventsSubscriber(): Promise< void > {
@@ -88,19 +91,11 @@ export async function startCliEventsSubscriber(): Promise< void > {
 			}
 
 			const siteEvent = parsed.data.value;
-			void handleSiteEvent( siteEvent );
-
-			// Don't send CREATED events to renderer if the site is currently being created by the UI
-			// (the createSite IPC call will handle updating the UI state to prevent duplicates)
-			if ( siteEvent.event === SITE_EVENTS.CREATED && siteEvent.site ) {
-				const existingServer =
-					SiteServer.get( siteEvent.siteId ) ?? SiteServer.getByPath( siteEvent.site.path );
-				if ( existingServer?.hasOngoingOperation ) {
-					return;
+			void handleSiteEvent( siteEvent ).then( ( shouldSendToRenderer ) => {
+				if ( shouldSendToRenderer ) {
+					void sendIpcEventToRenderer( 'site-event', siteEvent );
 				}
-			}
-
-			void sendIpcEventToRenderer( 'site-event', siteEvent );
+			} );
 		} );
 
 		eventEmitter.on( 'error', ( { error } ) => {

--- a/src/modules/cli/lib/cli-events-subscriber.ts
+++ b/src/modules/cli/lib/cli-events-subscriber.ts
@@ -89,6 +89,17 @@ export async function startCliEventsSubscriber(): Promise< void > {
 
 			const siteEvent = parsed.data.value;
 			void handleSiteEvent( siteEvent );
+
+			// Don't send CREATED events to renderer if the site is currently being created by the UI
+			// (the createSite IPC call will handle updating the UI state to prevent duplicates)
+			if ( siteEvent.event === SITE_EVENTS.CREATED && siteEvent.site ) {
+				const existingServer =
+					SiteServer.get( siteEvent.siteId ) ?? SiteServer.getByPath( siteEvent.site.path );
+				if ( existingServer?.hasOngoingOperation ) {
+					return;
+				}
+			}
+
 			void sendIpcEventToRenderer( 'site-event', siteEvent );
 		} );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

Fixes STU-1210

## Proposed Changes

This PR ensures that when you add a site from `Add site` in the sidebar, only one site gets added and there is no duplication. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
* Start Studio with `npm start`
* In the sidebar, click on `Add site`
* Observe that once the site is added, it only gets added once and you don't see any duplicate sites

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
