### PR TITLE
Studio: Switch to z.enum instead of z.nativeEnum for zod 4.0 update

### DIFF
--- a/cli/lib/appdata.ts
+++ b/cli/lib/appdata.ts
@@ -9,6 +9,7 @@ import { lockFileAsync, unlockFileAsync } from 'common/lib/lockfile';
 import { getAuthenticationUrl } from 'common/lib/oauth';
 import { siteDetailsSchema } from 'common/lib/site-events';
 import { snapshotSchema } from 'common/types/snapshot';
+import { StatsMetric } from 'common/types/stats';
 import { z } from 'zod';
 import { validateAccessToken } from 'cli/lib/api';
 import { LoggerError } from 'cli/logger';
@@ -45,7 +46,7 @@ const userDataSchema = z
 			} )
 			.loose()
 			.optional(),
-		lastBumpStats: z.record( z.string(), z.record( z.string(), z.number() ) ).optional(),
+		lastBumpStats: z.record( z.string(), z.record( z.enum( StatsMetric ), z.number() ) ).optional(),
 		betaFeatures: betaFeaturesSchema.optional(),
 	} )
 	.loose();

--- a/cli/lib/appdata.ts
+++ b/cli/lib/appdata.ts
@@ -9,7 +9,6 @@ import { lockFileAsync, unlockFileAsync } from 'common/lib/lockfile';
 import { getAuthenticationUrl } from 'common/lib/oauth';
 import { siteDetailsSchema } from 'common/lib/site-events';
 import { snapshotSchema } from 'common/types/snapshot';
-import { StatsMetric } from 'common/types/stats';
 import { z } from 'zod';
 import { validateAccessToken } from 'cli/lib/api';
 import { LoggerError } from 'cli/logger';
@@ -46,7 +45,7 @@ const userDataSchema = z
 			} )
 			.loose()
 			.optional(),
-		lastBumpStats: z.record( z.string(), z.record( z.enum( StatsMetric ), z.number() ) ).optional(),
+		lastBumpStats: z.record( z.string(), z.record( z.string(), z.number() ) ).optional(),
 		betaFeatures: betaFeaturesSchema.optional(),
 	} )
 	.loose();

--- a/cli/lib/appdata.ts
+++ b/cli/lib/appdata.ts
@@ -9,6 +9,7 @@ import { lockFileAsync, unlockFileAsync } from 'common/lib/lockfile';
 import { getAuthenticationUrl } from 'common/lib/oauth';
 import { siteDetailsSchema } from 'common/lib/site-events';
 import { snapshotSchema } from 'common/types/snapshot';
+import { StatsMetric } from 'common/types/stats';
 import { z } from 'zod';
 import { validateAccessToken } from 'cli/lib/api';
 import { LoggerError } from 'cli/logger';
@@ -45,7 +46,9 @@ const userDataSchema = z
 			} )
 			.loose()
 			.optional(),
-		lastBumpStats: z.record( z.string(), z.record( z.string(), z.number() ) ).optional(),
+		lastBumpStats: z
+			.record( z.string(), z.partialRecord( z.enum( StatsMetric ), z.number() ) )
+			.optional(),
 		betaFeatures: betaFeaturesSchema.optional(),
 	} )
 	.loose();

--- a/common/lib/site-events.ts
+++ b/common/lib/site-events.ts
@@ -33,7 +33,7 @@ export enum SITE_EVENTS {
 }
 
 export const siteEventSchema = z.object( {
-	event: z.nativeEnum( SITE_EVENTS ),
+	event: z.enum( SITE_EVENTS ),
 	siteId: z.string(),
 	site: siteDetailsSchema.optional(),
 	running: z.boolean(),

--- a/src/modules/cli/lib/cli-server-process.ts
+++ b/src/modules/cli/lib/cli-server-process.ts
@@ -4,7 +4,7 @@ import { executeCliCommand } from './execute-command';
 import type { WordPressServerProcess } from 'src/lib/wordpress-server-types';
 
 const cliEventSchema = z.object( {
-	action: z.nativeEnum( SiteCommandLoggerAction ),
+	action: z.enum( SiteCommandLoggerAction ),
 	status: z.enum( [ 'inprogress', 'fail', 'success', 'warning' ] ),
 	message: z.string(),
 } );

--- a/src/modules/cli/lib/cli-site-creator.ts
+++ b/src/modules/cli/lib/cli-site-creator.ts
@@ -9,7 +9,7 @@ import type { Blueprint } from '@wp-playground/blueprints';
 
 const cliEventSchema = z.discriminatedUnion( 'action', [
 	z.object( {
-		action: z.nativeEnum( SiteCommandLoggerAction ),
+		action: z.enum( SiteCommandLoggerAction ),
 		status: z.enum( [ 'inprogress', 'fail', 'success', 'warning' ] ),
 		message: z.string(),
 	} ),

--- a/src/modules/cli/lib/cli-site-editor.ts
+++ b/src/modules/cli/lib/cli-site-editor.ts
@@ -3,7 +3,7 @@ import { SiteCommandLoggerAction } from 'common/logger-actions';
 import { executeCliCommand } from './execute-command';
 
 const cliEventSchema = z.object( {
-	action: z.nativeEnum( SiteCommandLoggerAction ),
+	action: z.enum( SiteCommandLoggerAction ),
 	status: z.enum( [ 'inprogress', 'fail', 'success', 'warning' ] ),
 	message: z.string(),
 } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

Related to: https://github.com/Automattic/studio/pull/2394#discussion_r2704015577

## Proposed Changes

This PR ensures that we switch from `z.nativeEnum` to `z.enum` for zod 4.0 since `z.nativeEnum` is deprecated in the new version of zod. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Confirm that all the tests are passing. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
