### PR TITLE
Overview: Do not show thumbnail and buttons loading indicator on window focus event

### DIFF
--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -769,7 +769,6 @@ export async function getThemeDetails(
 
 	if ( themeChanged ) {
 		const parentWindow = BrowserWindow.fromWebContents( event.sender );
-		sendIpcEventToRendererWithWindow( parentWindow, 'theme-details-updating', { id } );
 		sendIpcEventToRendererWithWindow( parentWindow, 'theme-details-changed', {
 			id,
 			details: themeDetails,


### PR DESCRIPTION
## Related issues

- Fixes STU-1211

## Proposed Changes

- Do not show thumbnail and buttons loading indicator on window focus event by removing `theme-details-updating` event from `getThemeDetails()`

## Testing Instructions

1. Start a site
2. Switch to another app
3. Switch back to Studio
4. Verify thumbnail and buttons don't show loading state
5. Check for any regression with loading behavior. The loading indicator should show when site is created, server started etc. 

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?