### PR TITLE
Fix password displayed in CLI and used in site creation

### DIFF
--- a/cli/commands/site/status.ts
+++ b/cli/commands/site/status.ts
@@ -1,6 +1,7 @@
 import { __, _n } from '@wordpress/i18n';
 import CliTable3 from 'cli-table3';
 import { getWordPressVersion } from 'common/lib/get-wordpress-version';
+import { decodePassword } from 'common/lib/passwords';
 import { SiteCommandLoggerAction as LoggerAction } from 'common/logger-actions';
 import { getSiteByFolder, getSiteUrl, isXdebugBetaEnabled } from 'cli/lib/appdata';
 import { connect, disconnect } from 'cli/lib/pm2-manager';
@@ -52,7 +53,10 @@ export async function runCommand( siteFolder: string, format: 'table' | 'json' )
 			{ key: __( 'WP version' ), value: wpVersion },
 			{ key: __( 'Xdebug' ), value: xdebugStatus, hidden: ! showXdebug },
 			{ key: __( 'Admin username' ), value: 'admin' },
-			{ key: __( 'Admin password' ), value: site.adminPassword },
+			{
+				key: __( 'Admin password' ),
+				value: site.adminPassword ? decodePassword( site.adminPassword ) : undefined,
+			},
 		].filter( ( { value, hidden } ) => value && ! hidden );
 
 		if ( format === 'table' ) {

--- a/cli/commands/site/tests/status.test.ts
+++ b/cli/commands/site/tests/status.test.ts
@@ -17,14 +17,14 @@ jest.mock( 'common/lib/get-wordpress-version' );
 
 describe( 'CLI: studio site status', () => {
 	// Simple test data
-	// adminPassword is stored as Base64-encoded, so we use btoa('password123')
 	const testSite = {
 		id: 'site-1',
 		name: 'Test Site',
 		path: '/path/to/site',
 		port: 8080,
 		phpVersion: '8.0',
-		adminPassword: 'cGFzc3dvcmQxMjM=', // btoa('password123')
+		// createPassword returns a Base64-encoded string
+		adminPassword: btoa( 'password123' ),
 	};
 
 	const testSiteWithoutOptional = {

--- a/cli/commands/site/tests/status.test.ts
+++ b/cli/commands/site/tests/status.test.ts
@@ -17,13 +17,14 @@ jest.mock( 'common/lib/get-wordpress-version' );
 
 describe( 'CLI: studio site status', () => {
 	// Simple test data
+	// adminPassword is stored as Base64-encoded, so we use btoa('password123')
 	const testSite = {
 		id: 'site-1',
 		name: 'Test Site',
 		path: '/path/to/site',
 		port: 8080,
 		phpVersion: '8.0',
-		adminPassword: 'password123',
+		adminPassword: 'cGFzc3dvcmQxMjM=', // btoa('password123')
 	};
 
 	const testSiteWithoutOptional = {

--- a/cli/lib/site-utils.ts
+++ b/cli/lib/site-utils.ts
@@ -1,4 +1,5 @@
 import { __ } from '@wordpress/i18n';
+import { decodePassword } from 'common/lib/passwords';
 import { SiteCommandLoggerAction as LoggerAction } from 'common/logger-actions';
 import { getSiteUrl, readAppdata, SiteData } from 'cli/lib/appdata';
 import { openBrowser } from 'cli/lib/browser';
@@ -45,7 +46,7 @@ export function logSiteDetails( site: SiteData ): void {
 	console.log( __( 'Site URL: ' ), siteUrl );
 	console.log( __( 'Username: ' ), 'admin' );
 	if ( site.adminPassword ) {
-		console.log( __( 'Password: ' ), site.adminPassword );
+		console.log( __( 'Password: ' ), decodePassword( site.adminPassword ) );
 	}
 }
 

--- a/cli/wordpress-server-child.ts
+++ b/cli/wordpress-server-child.ts
@@ -24,6 +24,7 @@ import {
 import { WordPressInstallMode } from '@wp-playground/wordpress';
 import { isWordPressDirectory } from 'common/lib/fs-utils';
 import { getMuPlugins } from 'common/lib/mu-plugins';
+import { decodePassword } from 'common/lib/passwords';
 import { formatPlaygroundCliMessage } from 'common/lib/playground-cli-messages';
 import { sequential } from 'common/lib/sequential';
 import { isWordPressDevVersion } from 'common/lib/wordpress-version-utils';
@@ -97,7 +98,7 @@ async function setAdminPassword( server: RunCLIServer, adminPassword: string ): 
 		method: 'POST',
 		body: {
 			action: 'set_admin_password',
-			password: escapePhpString( adminPassword ),
+			password: escapePhpString( decodePassword( adminPassword ) ),
 		},
 	} );
 }


### PR DESCRIPTION
Passwords are stored Base64-encoded but were being displayed and sent to WordPress without decoding. This caused:
1. CLI showing encoded passwords instead of actual passwords
2. Users unable to log into WordPress with displayed password

Now decode passwords before display and before sending to WordPress.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

Fixes STU-1215

  ## Issue
  The CLI displayed Base64-encoded passwords instead of decoded ones, and passed
  encoded passwords to WordPress during site creation. This caused a mismatch where
  users couldn't log in with the displayed password.

  ## Proposed Changes
  - Decode password before displaying in `studio site status` command
  - Decode password in `logSiteDetails()` used after site creation
  - Decode password before sending to WordPress in `setAdminPassword()`
  - Update tests to use Base64-encoded test data

  ## Testing Instructions

**From CLI**
  1. Build CLI: `npm run cli:build`
  2. Create a new site: `node dist/cli/main.js site create /tmp/test-site`
  3. Note the password displayed
  4. Navigate to `http://localhost:<port>/wp-admin`
  5. Log in with username `admin` and the displayed password
  6. Verify login succeeds

**From Studio App**
1. Open Studio by running NPM Start
2. Select that site
3. Go to the settings tab
4. Copy the password
5. Navigate to wp-admin manually in your browser
6. Log in with Username, Admin, and the copied password
7. Verify login succeeds

**From preview site:**
1. Go to the previews tab
2. Create a new preview site
3. Open the preview site URL/wp-admin
4. Try logging in with the admin and copied password from the settings tab
5. Confirm login succeeds

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
