### PR TITLE
Fix backup import for Jetpack, Local, Wpress and Studio formats

### DIFF
--- a/cli/commands/wp.ts
+++ b/cli/commands/wp.ts
@@ -132,7 +132,10 @@ export async function commandHandler( argv: ArgumentsCamelCase< WpCommandOptions
 			);
 		}
 
-		const phpVersion = parsedWpCliArgs[ 'php-version' ] as string | undefined;
+		const phpVersion =
+			parsedWpCliArgs[ 'php-version' ] !== undefined
+				? String( parsedWpCliArgs[ 'php-version' ] )
+				: undefined;
 		wpCliArgv = removeArgumentFromArgv( wpCliArgv, 'php-version' );
 		wpCliArgv = removeArgumentFromArgv( wpCliArgv, 'avoid-telemetry', false );
 

--- a/src/lib/import-export/import/importers/importer.ts
+++ b/src/lib/import-export/import/importers/importer.ts
@@ -74,7 +74,7 @@ abstract class BaseImporter extends EventEmitter implements Importer {
 				await this.prepareSqlFile( tmpPath );
 				console.log( `Importing ${ sqlFile }` );
 				const { stderr, exitCode, stdout } = await server.executeWpCliCommand(
-					`sqlite import ${ sqlTempFile } --require=/tmp/sqlite-command/command.php --enable-ast-driver`,
+					`sqlite import /wordpress/${ sqlTempFile } --require=/tmp/sqlite-command/command.php --enable-ast-driver`,
 					// SQLite plugin requires PHP 8+
 					{
 						targetPhpVersion: DEFAULT_PHP_VERSION,

--- a/src/lib/import-export/tests/import/importer/jetpack-importer.test.ts
+++ b/src/lib/import-export/tests/import/importer/jetpack-importer.test.ts
@@ -84,7 +84,7 @@ platformTestSuite( 'JetpackImporter', ( { normalize } ) => {
 			const siteServer = SiteServer.get( mockStudioSiteId );
 
 			const expectedCommand =
-				'sqlite import studio-backup-sql-2024-08-01-12-00-00.sql --require=/tmp/sqlite-command/command.php --enable-ast-driver';
+				'sqlite import /wordpress/studio-backup-sql-2024-08-01-12-00-00.sql --require=/tmp/sqlite-command/command.php --enable-ast-driver';
 			expect( siteServer?.executeWpCliCommand ).toHaveBeenNthCalledWith( 1, expectedCommand, {
 				targetPhpVersion: '8.3',
 				skipPluginsAndThemes: true,


### PR DESCRIPTION
## Related issues

- Fixes STU-1217

## Proposed Changes

- Fix PHP version type conversion in CLI: `yargs-parser` converts `--php-version 8.3` from string to number, causing Zod validation to fail silently. Now explicitly converts back to string.
- Fix SQL file path for standalone PHP-WASM: The `sqlite import` command needs an absolute path `/wordpress/<file>` because standalone PHP-WASM mounts the site at `/wordpress` but doesn't set the working directory there.

## Testing Instructions

1. Create a new site in Studio
2. Export a backup from the site
3. Create another new site
4. Import the backup using "Import" option
5. Verify the import completes successfully without "Database import failed" error
6. Test with different backup formats: Jetpack, Local, Wpress, Studio backups

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?