### PR TITLE
Include stdout in SQL import error messages

### DIFF
--- a/src/lib/import-export/import/importers/importer.ts
+++ b/src/lib/import-export/import/importers/importer.ts
@@ -91,7 +91,12 @@ abstract class BaseImporter extends EventEmitter implements Importer {
 				}
 
 				if ( exitCode ) {
-					throw new Error( 'Database import failed: ' + stderr );
+					// Include both stderr and stdout in the error message since the database
+					// driver error could be in either stream depending on how WP-CLI/PHP outputs it
+					const errorDetails = [ stderr, stdout ].filter( Boolean ).join( '\n' ).trim();
+					throw new Error(
+						errorDetails ? `Database import failed: ${ errorDetails }` : 'Database import failed'
+					);
 				}
 			} finally {
 				await this.safelyDeletePath( tmpPath );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

Fixes STU-1216

## Issue

When importing an invalid `.sql` file, Studio showed "Database import failed:" with no details because WP-CLI/PHP outputs errors to stdout, not stderr.

## Proposed Changes

- Capture both `stderr` and `stdout` when database import fails
- Combine non-empty streams with newline separator
- Display the actual database driver error to users

## Testing Instructions

1. Start Studio and create a site
2. Go to Import / Export tab
3. Import a .sql file with invalid SQL (e.g., syntax error)
4. Verify the specific database error is now shown in the error message
5. Verify valid SQL imports still work correctly

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
