### PR TITLE
Make `Stop all` button run `site stop --all` (which is much faster)

### DIFF
--- a/src/components/tests/header.test.tsx
+++ b/src/components/tests/header.test.tsx
@@ -36,7 +36,7 @@ function mockGetIpcApi( mocks: Record< string, jest.Mock > ) {
 		getSiteDetails: jest.fn( () => Promise.resolve( mockedSites ) ),
 		getSnapshots: jest.fn( () => Promise.resolve( [] ) ),
 		saveSnapshotsToStorage: jest.fn( () => Promise.resolve() ),
-		startServer: jest.fn( () => Promise.resolve( { running: true } ) ),
+		startServer: jest.fn( () => Promise.resolve() ),
 		showErrorMessageBox: jest.fn(),
 		...mocks,
 	} );
@@ -70,7 +70,6 @@ describe( 'Header', () => {
 		await user.click( startButton );
 
 		expect( mockedGetIpcApi().startServer ).toHaveBeenCalledTimes( 1 );
-		expect( screen.getByText( 'Stop' ) ).toBeVisible();
 	} );
 
 	describe( 'when starting a server fails', () => {

--- a/src/hooks/tests/use-site-details.test.tsx
+++ b/src/hooks/tests/use-site-details.test.tsx
@@ -67,7 +67,7 @@ describe( 'useSiteDetails', () => {
 		jest.clearAllMocks();
 		( getIpcApi as jest.Mock ).mockReturnValue( {
 			getSiteDetails: jest.fn().mockResolvedValue( mockSites ),
-			startServer: jest.fn().mockResolvedValue( undefined ),
+			startServer: jest.fn( () => Promise.resolve() ),
 		} );
 	} );
 
@@ -93,7 +93,7 @@ describe( 'useSiteDetails', () => {
 						autoStart: false,
 					} ) )
 				),
-				startServer: jest.fn().mockResolvedValue( undefined ),
+				startServer: jest.fn( () => Promise.resolve() ),
 			} );
 
 			const { result } = renderHook( () => useSiteDetails(), { wrapper } );

--- a/src/hooks/use-site-details.tsx
+++ b/src/hooks/use-site-details.tsx
@@ -389,10 +389,9 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 	const startServer = useCallback(
 		async ( id: string ) => {
 			toggleLoadingServerForSite( id );
-			let updatedSite: SiteDetails | null = null;
 
 			try {
-				updatedSite = await getIpcApi().startServer( id );
+				await getIpcApi().startServer( id );
 			} catch ( error ) {
 				if ( error instanceof Error && error.message.includes( 'PROXY_ERROR_PORT_IN_USE' ) ) {
 					getIpcApi().showErrorMessageBox( {
@@ -447,14 +446,6 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 				await getIpcApi().stopServer( id );
 			}
 
-			if ( updatedSite ) {
-				setSites( ( prevData ) =>
-					prevData.map( ( site ) =>
-						site.id === id && updatedSite ? { ...site, ...updatedSite } : site
-					)
-				);
-			}
-
 			toggleLoadingServerForSite( id );
 		},
 		[ toggleLoadingServerForSite ]
@@ -496,24 +487,15 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 	const stopServer = useCallback(
 		async ( id: string ) => {
 			toggleLoadingServerForSite( id );
-			const updatedSite = await getIpcApi().stopServer( id );
-			if ( updatedSite ) {
-				setSites( ( prevData ) =>
-					prevData.map( ( site ) => ( site.id === id ? { ...site, ...updatedSite } : site ) )
-				);
-			}
+			await getIpcApi().stopServer( id );
 			toggleLoadingServerForSite( id );
 		},
 		[ toggleLoadingServerForSite ]
 	);
 
 	const stopAllRunningSites = useCallback( async () => {
-		const runningSites = sites.filter( ( site ) => site.running );
-		for ( const site of runningSites ) {
-			await getIpcApi().stopServer( site.id );
-		}
-		setSites( sites.map( ( site ) => ( site.running ? { ...site, running: false } : site ) ) );
-	}, [ sites ] );
+		await getIpcApi().stopAllServers();
+	}, [] );
 
 	const [ isEditModalOpen, setIsEditModalOpen ] = useState( false );
 	const selectedSite = sites.find( ( site ) => site.id === selectedSiteId ) || firstSite;

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,7 @@ import {
 import { isStudioCliInstalled } from 'src/modules/cli/lib/ipc-handlers';
 import { updateWindowsCliVersionedPathIfNeeded } from 'src/modules/cli/lib/windows-installation-manager';
 import { setupWPServerFiles, updateWPServerFiles } from 'src/setup-wp-server-files';
-import { getRunningSiteCount, stopAllServersOnQuit } from 'src/site-server';
+import { getRunningSiteCount, stopAllServers } from 'src/site-server';
 import {
 	loadUserData,
 	lockAppdata,
@@ -517,7 +517,7 @@ async function appBoot() {
 
 		if ( shouldStopSitesOnQuit ) {
 			event.preventDefault();
-			stopAllServersOnQuit()
+			stopAllServers( true )
 				.then( () => {
 					app.exit();
 				} )

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -65,7 +65,7 @@ import { shouldExcludeFromSync, shouldLimitDepth } from 'src/modules/sync/lib/tr
 import { supportedEditorConfig, SupportedEditor } from 'src/modules/user-settings/lib/editor';
 import { getUserTerminal } from 'src/modules/user-settings/lib/ipc-handlers';
 import { winFindEditorPath } from 'src/modules/user-settings/lib/win-editor-path';
-import { SiteServer } from 'src/site-server';
+import { SiteServer, stopAllServers as triggerStopAllServers } from 'src/site-server';
 import { DEFAULT_SITE_PATH, getSiteThumbnailPath } from 'src/storage/paths';
 import {
 	loadUserData,
@@ -404,13 +404,10 @@ export async function updateSite(
 	}
 }
 
-export async function startServer(
-	event: IpcMainInvokeEvent,
-	id: string
-): Promise< SiteDetails | null > {
+export async function startServer( event: IpcMainInvokeEvent, id: string ): Promise< void > {
 	const server = SiteServer.get( id );
 	if ( ! server ) {
-		return null;
+		return;
 	}
 
 	const parentWindow = BrowserWindow.fromWebContents( event.sender );
@@ -455,22 +452,19 @@ export async function startServer(
 	}
 
 	console.log( `Server started for '${ server.details.name }'` );
-	await updateSite( event, server.details );
-	return server.details;
 }
 
-export async function stopServer(
-	event: IpcMainInvokeEvent,
-	id: string
-): Promise< SiteDetails | null > {
+export async function stopServer( event: IpcMainInvokeEvent, id: string ): Promise< void > {
 	const server = SiteServer.get( id );
 	if ( ! server ) {
-		return null;
+		return;
 	}
 
 	await server.stop();
-	await updateSite( event, server.details );
-	return server.details;
+}
+
+export async function stopAllServers(): Promise< void > {
+	await triggerStopAllServers( false );
 }
 
 export interface FolderDialogResponse {

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -77,6 +77,7 @@ const api: IpcApi = {
 	showUserSettings: ( tabName ) => ipcRendererInvoke( 'showUserSettings', tabName ),
 	startServer: ( id ) => ipcRendererInvoke( 'startServer', id ),
 	stopServer: ( id ) => ipcRendererInvoke( 'stopServer', id ),
+	stopAllServers: () => ipcRendererInvoke( 'stopAllServers' ),
 	copyText: ( text ) => ipcRendererInvoke( 'copyText', text ),
 	getAppGlobals: () => ipcRendererInvoke( 'getAppGlobals' ),
 	removeExportedSiteTmpFile: ( path ) => ipcRendererInvoke( 'removeExportedSiteTmpFile', path ),

--- a/src/site-server.ts
+++ b/src/site-server.ts
@@ -22,14 +22,18 @@ export type WpCliResult = { stdout: string; stderr: string; exitCode: number };
 const servers = new Map< string, SiteServer >();
 const deletedServers: string[] = [];
 
-export async function stopAllServersOnQuit() {
-	// The `--auto-start` option ensures sites will restart on next app launch.
+/**
+ * Stop all running sites using the CLI `site stop --all` command.
+ *
+ * @param shouldSaveAutoStartProp Makes it so sites are automatically started the next time Studio launches. Typically only true when this function runs during the application close sequence.
+ */
+export async function stopAllServers( shouldSaveAutoStartProp: boolean ) {
 	return new Promise< void >( ( resolve ) => {
-		const [ emitter, childProcess ] = executeCliCommand(
-			[ 'site', 'stop', '--all', '--auto-start' ],
-			{ output: 'ignore' }
-		);
-		console.log( `Spawned stop-all child process with pid ${ childProcess.pid }` );
+		const args = [ 'site', 'stop', '--all' ];
+		if ( shouldSaveAutoStartProp ) {
+			args.push( '--auto-start' );
+		}
+		const [ emitter ] = executeCliCommand( args, { output: 'ignore' } );
 		emitter.on( 'success', () => resolve() );
 		emitter.on( 'failure', () => resolve() );
 		emitter.on( 'error', () => resolve() );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-1223

## Proposed Changes

- Make the `Stop all` button in the Studio sidebar run the `site stop --all` CLI command instead of iterating over the running sites and sequentially triggering `site stop`. The new solution is _much_ faster.
- Remove redundant `setSites` calls from the `startServer` and `stopServer` functions in `src/hooks/use-site-details.tsx`. The `site-event` event listener already does the same thing.
- Remove redundant `updateSite` calls from the `startServer` and `stopServer` functions in `src/ipc-handlers.ts`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Run `npm start`
2. Start at least two sites
3. Ensure that starting them works as normal and that they are marked as running in the sidebar
4. Click the `Stop all` button
5. Ensure that all sites are immediately stopped
6. Start a site again
7. Stop that individual site (not by clicking the `Stop all` button`
8. Ensure that it works as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
