### PR TITLE
Change execution order in `site stop --all` command

### DIFF
--- a/cli/commands/site/create.ts
+++ b/cli/commands/site/create.ts
@@ -326,7 +326,7 @@ export async function runCommand(
 				}
 			}
 			console.log( '' );
-			console.log( __( 'Site created successfully!' ) );
+			console.log( __( 'Site created successfully' ) );
 			console.log( '' );
 			if ( ! options.skipLogDetails ) {
 				logSiteDetails( siteDetails );

--- a/cli/commands/site/stop.ts
+++ b/cli/commands/site/stop.ts
@@ -10,7 +10,7 @@ import {
 	updateSiteAutoStart,
 	type SiteData,
 } from 'cli/lib/appdata';
-import { connect, disconnect, killDaemonAndAllChildren } from 'cli/lib/pm2-manager';
+import { connect, disconnect, killDaemonAndChildrenAndExitProcess } from 'cli/lib/pm2-manager';
 import { stopProxyIfNoSitesNeedIt } from 'cli/lib/site-utils';
 import { isServerRunning, stopWordPressServer } from 'cli/lib/wordpress-server-manager';
 import { Logger, LoggerError } from 'cli/logger';
@@ -77,9 +77,6 @@ export async function runCommand(
 				return;
 			}
 
-			logger.reportStart( LoggerAction.STOP_ALL_SITES, __( 'Stopping all WordPress servers…' ) );
-			await killDaemonAndAllChildren();
-
 			try {
 				await lockAppdata();
 				const appdata = await readAppdata();
@@ -94,20 +91,20 @@ export async function runCommand(
 				await unlockAppdata();
 			}
 
-			logger.reportSuccess(
-				sprintf(
-					_n(
-						'Successfully stopped %d site',
-						'Successfully stopped %d sites',
-						runningSites.length
-					),
-					runningSites.length
-				)
-			);
+			logger.reportStart( LoggerAction.STOP_ALL_SITES, __( 'Stopping all WordPress servers…' ) );
 
-			// Calling `pm2.killDaemon` requires us to forcefully exit the process. pm2 does the same
-			// thing internally in its CLI.
-			process.exit( 0 );
+			await killDaemonAndChildrenAndExitProcess( () => {
+				logger.reportSuccess(
+					sprintf(
+						_n(
+							'Successfully stopped %d site',
+							'Successfully stopped %d sites',
+							runningSites.length
+						),
+						runningSites.length
+					)
+				);
+			} );
 		}
 	} finally {
 		await disconnect();

--- a/cli/commands/site/tests/create.test.ts
+++ b/cli/commands/site/tests/create.test.ts
@@ -485,7 +485,7 @@ describe( 'CLI: studio site create', () => {
 			expect( connect ).not.toHaveBeenCalled();
 			expect( startWordPressServer ).not.toHaveBeenCalled();
 			expect( setupCustomDomain ).not.toHaveBeenCalled();
-			expect( consoleLogSpy ).toHaveBeenCalledWith( 'Site created successfully!' );
+			expect( consoleLogSpy ).toHaveBeenCalledWith( 'Site created successfully' );
 			expect( consoleLogSpy ).toHaveBeenCalledWith( 'Run "studio site start" to start the site.' );
 			expect( disconnect ).toHaveBeenCalled();
 		} );
@@ -527,7 +527,7 @@ describe( 'CLI: studio site create', () => {
 				} )
 			);
 			expect( startWordPressServer ).not.toHaveBeenCalled();
-			expect( consoleLogSpy ).toHaveBeenCalledWith( 'Site created successfully!' );
+			expect( consoleLogSpy ).toHaveBeenCalledWith( 'Site created successfully' );
 			expect( disconnect ).toHaveBeenCalled();
 		} );
 	} );

--- a/cli/commands/site/tests/stop.test.ts
+++ b/cli/commands/site/tests/stop.test.ts
@@ -6,7 +6,7 @@ import {
 	saveAppdata,
 	updateSiteAutoStart,
 } from 'cli/lib/appdata';
-import { connect, disconnect, killDaemonAndAllChildren } from 'cli/lib/pm2-manager';
+import { connect, disconnect, killDaemonAndChildrenAndExitProcess } from 'cli/lib/pm2-manager';
 import { stopProxyIfNoSitesNeedIt } from 'cli/lib/site-utils';
 import { isServerRunning, stopWordPressServer } from 'cli/lib/wordpress-server-manager';
 import { Mode, runCommand } from '../stop';
@@ -51,7 +51,7 @@ describe( 'CLI: studio site stop', () => {
 		( stopWordPressServer as jest.Mock ).mockResolvedValue( undefined );
 		( clearSiteLatestCliPid as jest.Mock ).mockResolvedValue( undefined );
 		( stopProxyIfNoSitesNeedIt as jest.Mock ).mockResolvedValue( undefined );
-		( killDaemonAndAllChildren as jest.Mock ).mockResolvedValue( undefined );
+		( killDaemonAndChildrenAndExitProcess as jest.Mock ).mockResolvedValue( undefined );
 	} );
 
 	afterEach( () => {
@@ -208,7 +208,7 @@ describe( 'CLI: studio site stop --all', () => {
 		( connect as jest.Mock ).mockResolvedValue( undefined );
 		( disconnect as jest.Mock ).mockResolvedValue( undefined );
 		( isServerRunning as jest.Mock ).mockResolvedValue( undefined );
-		( killDaemonAndAllChildren as jest.Mock ).mockResolvedValue( undefined );
+		( killDaemonAndChildrenAndExitProcess as jest.Mock ).mockResolvedValue( undefined );
 		( clearSiteLatestCliPid as jest.Mock ).mockResolvedValue( undefined );
 	} );
 
@@ -239,7 +239,7 @@ describe( 'CLI: studio site stop --all', () => {
 		it( 'should throw when killDaemonAndAllChildren fails', async () => {
 			( readAppdata as jest.Mock ).mockResolvedValue( { sites: testSites } );
 			( isServerRunning as jest.Mock ).mockResolvedValue( testProcessDescription );
-			( killDaemonAndAllChildren as jest.Mock ).mockRejectedValue(
+			( killDaemonAndChildrenAndExitProcess as jest.Mock ).mockRejectedValue(
 				new Error( 'Failed to kill daemon' )
 			);
 
@@ -257,7 +257,7 @@ describe( 'CLI: studio site stop --all', () => {
 			await runCommand( Mode.STOP_ALL_SITES, undefined, false );
 
 			expect( connect ).toHaveBeenCalled();
-			expect( killDaemonAndAllChildren ).not.toHaveBeenCalled();
+			expect( killDaemonAndChildrenAndExitProcess ).not.toHaveBeenCalled();
 			expect( disconnect ).toHaveBeenCalled();
 		} );
 
@@ -270,7 +270,7 @@ describe( 'CLI: studio site stop --all', () => {
 
 			expect( connect ).toHaveBeenCalled();
 			expect( isServerRunning ).toHaveBeenCalledTimes( 3 );
-			expect( killDaemonAndAllChildren ).not.toHaveBeenCalled();
+			expect( killDaemonAndChildrenAndExitProcess ).not.toHaveBeenCalled();
 			expect( clearSiteLatestCliPid ).not.toHaveBeenCalled();
 			expect( disconnect ).toHaveBeenCalled();
 		} );
@@ -281,7 +281,7 @@ describe( 'CLI: studio site stop --all', () => {
 
 			await runCommand( Mode.STOP_ALL_SITES, undefined, false );
 
-			expect( killDaemonAndAllChildren ).toHaveBeenCalledTimes( 1 );
+			expect( killDaemonAndChildrenAndExitProcess ).toHaveBeenCalledTimes( 1 );
 			expect( saveAppdata ).toHaveBeenCalledTimes( 1 );
 			expect( saveAppdata ).toHaveBeenCalledWith(
 				expect.objectContaining( {
@@ -309,7 +309,7 @@ describe( 'CLI: studio site stop --all', () => {
 			expect( isServerRunning ).toHaveBeenCalledWith( 'site-2' );
 			expect( isServerRunning ).toHaveBeenCalledWith( 'site-3' );
 
-			expect( killDaemonAndAllChildren ).toHaveBeenCalledTimes( 1 );
+			expect( killDaemonAndChildrenAndExitProcess ).toHaveBeenCalledTimes( 1 );
 
 			expect( saveAppdata ).toHaveBeenCalledTimes( 1 );
 			expect( saveAppdata ).toHaveBeenCalledWith(
@@ -346,7 +346,7 @@ describe( 'CLI: studio site stop --all', () => {
 
 			expect( isServerRunning ).toHaveBeenCalledTimes( 3 );
 
-			expect( killDaemonAndAllChildren ).toHaveBeenCalledTimes( 1 );
+			expect( killDaemonAndChildrenAndExitProcess ).toHaveBeenCalledTimes( 1 );
 
 			expect( saveAppdata ).toHaveBeenCalledTimes( 1 );
 			expect( saveAppdata ).toHaveBeenCalledWith(

--- a/cli/commands/site/tests/stop.test.ts
+++ b/cli/commands/site/tests/stop.test.ts
@@ -202,9 +202,6 @@ describe( 'CLI: studio site stop --all', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
 
-		// Mock process.exit to prevent tests from exiting
-		jest.spyOn( process, 'exit' ).mockImplementation( () => undefined as never );
-
 		( connect as jest.Mock ).mockResolvedValue( undefined );
 		( disconnect as jest.Mock ).mockResolvedValue( undefined );
 		( isServerRunning as jest.Mock ).mockResolvedValue( undefined );
@@ -293,7 +290,6 @@ describe( 'CLI: studio site stop --all', () => {
 					] ),
 				} )
 			);
-			expect( process.exit ).toHaveBeenCalledWith( 0 );
 		} );
 
 		it( 'should stop all running sites', async () => {
@@ -330,8 +326,6 @@ describe( 'CLI: studio site stop --all', () => {
 					] ),
 				} )
 			);
-
-			expect( process.exit ).toHaveBeenCalledWith( 0 );
 		} );
 
 		it( 'should stop only running sites (mixed state)', async () => {
@@ -373,8 +367,6 @@ describe( 'CLI: studio site stop --all', () => {
 					] ),
 				} )
 			);
-
-			expect( process.exit ).toHaveBeenCalledWith( 0 );
 		} );
 	} );
 } );

--- a/cli/lib/pm2-manager.ts
+++ b/cli/lib/pm2-manager.ts
@@ -97,25 +97,37 @@ export async function disconnect(): Promise< void > {
 	} );
 }
 
-export async function killDaemonAndAllChildren() {
-	return new Promise< void >( ( resolve, reject ) => {
-		const timeout = setTimeout( () => {
-			reject(
-				new Error(
-					'PM2 kill timeout after 25 seconds. Try running: PM2_HOME=~/.studio/pm2 pm2 kill'
-				)
-			);
-		}, KILL_TIMEOUT );
+// On Posix platforms, pm2 sends a SIGQUIT signal from the daemon to the caller process (this
+// process) as part of its shutdown sequence. SIGQUIT signals cannot be ignored and the kernel will
+// kill this process after a short delay. Empirically, this delay is long enough to allow a
+// synchronous callback to run.
+export async function killDaemonAndChildrenAndExitProcess( callback: () => void ) {
+	try {
+		await new Promise< void >( ( resolve, reject ) => {
+			const timeout = setTimeout( () => {
+				reject(
+					new Error(
+						'PM2 kill timeout after 25 seconds. Try running: PM2_HOME=~/.studio/pm2 pm2 kill'
+					)
+				);
+			}, KILL_TIMEOUT );
 
-		pm2.killDaemon( ( error ) => {
-			clearTimeout( timeout );
-			if ( error ) {
-				reject( error );
-				return;
-			}
-			resolve();
+			pm2.killDaemon( ( error ) => {
+				clearTimeout( timeout );
+				if ( error ) {
+					reject( error );
+					return;
+				}
+				resolve();
+			} );
 		} );
-	} );
+
+		callback();
+	} catch ( error ) {
+		// Do nothing
+	} finally {
+		process.exit( 0 );
+	}
 }
 
 // Cache the return value of `pm2.list` for a very short time to make multiple calls in quick


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-1225

## Proposed Changes

As noted by @epeicher in https://github.com/Automattic/studio/pull/2424#pullrequestreview-3681215893, the `site stop --all` command doesn't save the `autoStart` prop to the appdata file as expected. 

This apparently happens because pm2 sends a SIGQUIT signal from the daemon to the client process (the `site stop --all` process) as part of the shutdown sequence. SIGQUIT doesn't immediately interrupt the process – it's allowed to run a bit of cleanup logic – but the kernel forces it to quit eventually. That's why the logic that updates the `autoStart` properties in the appdata file never ran previously.

In this PR, we flip the order: the appdata file is updated first, and pm2 is killed second. I've also moved the `process.exit( 0 )` call into the `killDaemonAndChildrenAndExitProcess` function to clarify the logic flow.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Run `npm start`
2. Start at least two sites
3. Click the `Stop all` button
4. Quit Studio
5. Run `npm start` again
6. Ensure that no sites are automatically started when the application launches

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
