### PR TITLE
Always emit `site-event` events for site start and site stop operations

### DIFF
--- a/src/modules/cli/lib/cli-events-subscriber.ts
+++ b/src/modules/cli/lib/cli-events-subscriber.ts
@@ -47,6 +47,10 @@ const handleSiteEvent = sequential( async ( event: SiteEvent ): Promise< void > 
 		if ( ! existingServer ) {
 			SiteServer.register( siteDetailsToServerDetails( site, running ) );
 		}
+		// Don't send to renderer if site is being created by UI (createSite IPC will handle it)
+		if ( existingServer?.hasOngoingOperation ) {
+			return;
+		}
 		void sendIpcEventToRenderer( 'site-event', event );
 		return;
 	}

--- a/src/modules/cli/lib/cli-events-subscriber.ts
+++ b/src/modules/cli/lib/cli-events-subscriber.ts
@@ -47,10 +47,6 @@ const handleSiteEvent = sequential( async ( event: SiteEvent ): Promise< void > 
 		if ( ! existingServer ) {
 			SiteServer.register( siteDetailsToServerDetails( site, running ) );
 		}
-		// Don't send to renderer if site is being created by UI (createSite IPC will handle it)
-		if ( existingServer?.hasOngoingOperation ) {
-			return;
-		}
 		void sendIpcEventToRenderer( 'site-event', event );
 		return;
 	}
@@ -58,11 +54,6 @@ const handleSiteEvent = sequential( async ( event: SiteEvent ): Promise< void > 
 	// For UPDATED events, only update if the site already exists
 	const server = SiteServer.get( siteId ) ?? SiteServer.getByPath( site.path );
 	if ( ! server ) {
-		return;
-	}
-
-	// Skip update if Studio has an ongoing operation
-	if ( server.hasOngoingOperation ) {
 		return;
 	}
 

--- a/src/site-server.ts
+++ b/src/site-server.ts
@@ -125,7 +125,6 @@ export class SiteServer {
 			running: false,
 		};
 		const server = SiteServer.register( placeholderDetails, meta );
-
 		server.hasOngoingOperation = true;
 
 		try {

--- a/src/site-server.ts
+++ b/src/site-server.ts
@@ -68,6 +68,13 @@ type SiteServerMeta = {
 export class SiteServer {
 	server: CliServerProcess;
 
+	/**
+	 * Indicates whether a Studio-managed operation (start/stop) is in progress.
+	 * When true, file watchers should ignore site events to prevent interference
+	 * with the ongoing operation.
+	 */
+	hasOngoingOperation = false;
+
 	private constructor(
 		public details: SiteDetails,
 		public meta: SiteServerMeta
@@ -119,40 +126,46 @@ export class SiteServer {
 		};
 		const server = SiteServer.register( placeholderDetails, meta );
 
-		const result = await createSiteViaCli( options );
-		const userData = await loadUserData();
-		const siteData = userData.sites.find( ( s ) => s.id === result.id );
-		if ( ! siteData ) {
-			throw new Error( `Site with ID ${ result.id } not found in appdata after CLI creation` );
+		server.hasOngoingOperation = true;
+
+		try {
+			const result = await createSiteViaCli( options );
+			const userData = await loadUserData();
+			const siteData = userData.sites.find( ( s ) => s.id === result.id );
+			if ( ! siteData ) {
+				throw new Error( `Site with ID ${ result.id } not found in appdata after CLI creation` );
+			}
+
+			let siteDetails: SiteDetails;
+			if ( result.running ) {
+				const url = siteData.customDomain
+					? `${ siteData.enableHttps ? 'https' : 'http' }://${ siteData.customDomain }`
+					: `http://localhost:${ siteData.port }`;
+				siteDetails = {
+					...siteData,
+					running: true,
+					url,
+				};
+			} else {
+				siteDetails = {
+					...siteData,
+					running: false,
+				};
+			}
+
+			// Update the server with the real details from CLI
+			servers.delete( placeholderDetails.id );
+			servers.set( siteDetails.id, server );
+			server.details = siteDetails;
+
+			if ( siteDetails.running && siteDetails.url ) {
+				server.server.url = siteDetails.url;
+			}
+
+			return { server, details: siteDetails };
+		} finally {
+			server.hasOngoingOperation = false;
 		}
-
-		let siteDetails: SiteDetails;
-		if ( result.running ) {
-			const url = siteData.customDomain
-				? `${ siteData.enableHttps ? 'https' : 'http' }://${ siteData.customDomain }`
-				: `http://localhost:${ siteData.port }`;
-			siteDetails = {
-				...siteData,
-				running: true,
-				url,
-			};
-		} else {
-			siteDetails = {
-				...siteData,
-				running: false,
-			};
-		}
-
-		// Update the server with the real details from CLI
-		servers.delete( placeholderDetails.id );
-		servers.set( siteDetails.id, server );
-		server.details = siteDetails;
-
-		if ( siteDetails.running && siteDetails.url ) {
-			server.server.url = siteDetails.url;
-		}
-
-		return { server, details: siteDetails };
 	}
 
 	async delete( deleteFiles: boolean ) {

--- a/src/site-server.ts
+++ b/src/site-server.ts
@@ -68,13 +68,6 @@ type SiteServerMeta = {
 export class SiteServer {
 	server: CliServerProcess;
 
-	/**
-	 * Indicates whether a Studio-managed operation (start/stop) is in progress.
-	 * When true, file watchers should ignore site events to prevent interference
-	 * with the ongoing operation.
-	 */
-	hasOngoingOperation = false;
-
 	private constructor(
 		public details: SiteDetails,
 		public meta: SiteServerMeta
@@ -125,46 +118,41 @@ export class SiteServer {
 			running: false,
 		};
 		const server = SiteServer.register( placeholderDetails, meta );
-		server.hasOngoingOperation = true;
 
-		try {
-			const result = await createSiteViaCli( options );
-			const userData = await loadUserData();
-			const siteData = userData.sites.find( ( s ) => s.id === result.id );
-			if ( ! siteData ) {
-				throw new Error( `Site with ID ${ result.id } not found in appdata after CLI creation` );
-			}
-
-			let siteDetails: SiteDetails;
-			if ( result.running ) {
-				const url = siteData.customDomain
-					? `${ siteData.enableHttps ? 'https' : 'http' }://${ siteData.customDomain }`
-					: `http://localhost:${ siteData.port }`;
-				siteDetails = {
-					...siteData,
-					running: true,
-					url,
-				};
-			} else {
-				siteDetails = {
-					...siteData,
-					running: false,
-				};
-			}
-
-			// Update the server with the real details from CLI
-			servers.delete( placeholderDetails.id );
-			servers.set( siteDetails.id, server );
-			server.details = siteDetails;
-
-			if ( siteDetails.running && siteDetails.url ) {
-				server.server.url = siteDetails.url;
-			}
-
-			return { server, details: siteDetails };
-		} finally {
-			server.hasOngoingOperation = false;
+		const result = await createSiteViaCli( options );
+		const userData = await loadUserData();
+		const siteData = userData.sites.find( ( s ) => s.id === result.id );
+		if ( ! siteData ) {
+			throw new Error( `Site with ID ${ result.id } not found in appdata after CLI creation` );
 		}
+
+		let siteDetails: SiteDetails;
+		if ( result.running ) {
+			const url = siteData.customDomain
+				? `${ siteData.enableHttps ? 'https' : 'http' }://${ siteData.customDomain }`
+				: `http://localhost:${ siteData.port }`;
+			siteDetails = {
+				...siteData,
+				running: true,
+				url,
+			};
+		} else {
+			siteDetails = {
+				...siteData,
+				running: false,
+			};
+		}
+
+		// Update the server with the real details from CLI
+		servers.delete( placeholderDetails.id );
+		servers.set( siteDetails.id, server );
+		server.details = siteDetails;
+
+		if ( siteDetails.running && siteDetails.url ) {
+			server.server.url = siteDetails.url;
+		}
+
+		return { server, details: siteDetails };
 	}
 
 	async delete( deleteFiles: boolean ) {
@@ -179,36 +167,31 @@ export class SiteServer {
 	}
 
 	async start() {
-		if ( this.details.running || this.hasOngoingOperation ) {
+		if ( this.details.running ) {
 			return;
 		}
 
-		this.hasOngoingOperation = true;
-		try {
-			console.log( `Starting server for '${ this.details.name }'` );
-			await this.server.start();
+		console.log( `Starting server for '${ this.details.name }'` );
+		await this.server.start();
 
-			const userData = await loadUserData();
-			const freshSiteData = userData.sites.find( ( s ) => s.id === this.details.id );
+		const userData = await loadUserData();
+		const freshSiteData = userData.sites.find( ( s ) => s.id === this.details.id );
 
-			if ( freshSiteData?.port ) {
-				this.details.port = freshSiteData.port;
-			}
-
-			const url = getAbsoluteUrl( this.details );
-
-			this.details = {
-				...this.details,
-				url,
-				running: true,
-				autoStart: true,
-				latestCliPid: freshSiteData?.latestCliPid,
-			};
-
-			this.server.url = url;
-		} finally {
-			this.hasOngoingOperation = false;
+		if ( freshSiteData?.port ) {
+			this.details.port = freshSiteData.port;
 		}
+
+		const url = getAbsoluteUrl( this.details );
+
+		this.details = {
+			...this.details,
+			url,
+			running: true,
+			autoStart: true,
+			latestCliPid: freshSiteData?.latestCliPid,
+		};
+
+		this.server.url = url;
 	}
 
 	updateSiteDetails( site: SiteDetails ) {
@@ -234,7 +217,6 @@ export class SiteServer {
 	async stop() {
 		console.log( 'Stopping server with ID', this.details.id );
 		try {
-			this.hasOngoingOperation = true;
 			await this.server.stop();
 
 			if ( ! this.details.running ) {
@@ -246,8 +228,6 @@ export class SiteServer {
 			this.details = { running: false, autoStart: false, ...rest };
 		} catch ( error ) {
 			console.error( error );
-		} finally {
-			this.hasOngoingOperation = false;
 		}
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-1227

## Proposed Changes

In https://github.com/Automattic/studio/pull/2424, I changed the `startServer` and `stopServer` IPC functions to return `void`, so the front-end wouldn't immediately update the site's running state. Instead, the front-end would rely on the `site-event` listener to accomplish this.  

This collided with the changes from https://github.com/Automattic/studio/pull/2415, which made it so that no `site-event` events are submitted if `SiteServer.hasOngoingOperation` is true, which it is if the operation (start a site, stop a site) was initiated from Studio.

This is why performance tests started failing after I merged https://github.com/Automattic/studio/pull/2424 to trunk, even though they didn't fail on the PR itself. 

This PR solves this problem by changing the logic in `handleSiteEvent` so that `site-event` events are always emitted when a site starts or stops, even if the operation was initiated from Studio.  

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Run `npm start`
2. Start a site using the button in the header
3. Ensure that it starts correctly
4. Stop the site using the button in the header
5. Ensure that it stops correctly
6. Create a site
7. Ensure that it works as expected
8. Delete the newly created site
9. Ensure that it works as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
