### PR TITLE
Change `./cli` paths in `make-pot` script

### DIFF
--- a/scripts/make-pot.mjs
+++ b/scripts/make-pot.mjs
@@ -30,7 +30,7 @@ const commands = [
 	},
 	{
 		command:
-			'wp-babel-makepot "{src,cli/commands,cli/lib,common}/**/*.{js,jsx,ts,tsx}" --ignore "**/*.d.ts" --base "." --dir "./out/pots" --output "./out/pots/bundle-strings.pot"',
+			'npx wp-babel-makepot "{src,cli,common}/**/*.{js,jsx,ts,tsx}" --ignore "cli/node_modules/**/*,**/*.d.ts" --base "." --dir "./out/pots" --output "./out/pots/bundle-strings.pot"',
 		description: 'Generating pot file with wp-babel-makepot',
 	},
 	{


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-1226

## Proposed Changes

- Change the path globs passed to `wp-babel-makepot` in `scripts/make-pot.mjs`. Previously, top-level files in the `./cli` directory weren't targeted (like `cli/index.ts`).

> [!NOTE]  
> I've already generated a new pot file and imported it to the Studio project on translate.wordpress.com

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Run `node scripts/make-pot.mjs`
2. Open `out/pots/bundle-strings.pot`
3. Ensure that strings from `cli/index.ts` are included
4. Ensure that no strings from `cli/node_modules` are included

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
