### PR TITLE
Only cleanup old thumbnail file if image was captured successfully

### DIFF
--- a/src/site-server.ts
+++ b/src/site-server.ts
@@ -255,20 +255,27 @@ export class SiteServer {
 		const outPath = getSiteThumbnailPath( this.details.id );
 		const outDir = nodePath.dirname( outPath );
 
+		let capturedImage: Electron.NativeImage | null = null;
+
 		// Continue taking the screenshot asynchronously so we don't prevent the
 		// UI from showing the server is now available.
 		return fs.promises
 			.mkdir( outDir, { recursive: true } )
 			.then( waitForCapture )
-			.then( ( image ) => fs.promises.writeFile( outPath, image.toPNG() ) )
+			.then( ( image ) => {
+				capturedImage = image;
+				return fs.promises.writeFile( outPath, image.toPNG() );
+			} )
 			.catch( async ( error ) => {
 				Sentry.captureException( error );
-				try {
-					await fs.promises.unlink( outPath );
-				} catch ( unlinkError ) {
-					// Ignore ENOENT errors as the file might not exist
-					if ( ( unlinkError as NodeJS.ErrnoException ).code !== 'ENOENT' ) {
-						console.error( 'Failed to cleanup thumbnail file:', unlinkError );
+				if ( capturedImage ) {
+					try {
+						await fs.promises.unlink( outPath );
+					} catch ( unlinkError ) {
+						// Ignore ENOENT errors as the file might not exist
+						if ( ( unlinkError as NodeJS.ErrnoException ).code !== 'ENOENT' ) {
+							console.error( 'Failed to cleanup thumbnail file:', unlinkError );
+						}
 					}
 				}
 			} )


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Resolves STU-1212 

## Proposed Changes

- only clean up old site thumbnail file if the image was captured successfully

| Before | After |
|--------|--------|
| <img width="2704" height="2044" alt="CleanShot 2026-01-21 at 11 30 58@2x" src="https://github.com/user-attachments/assets/8a96dd0b-caef-4372-a09c-2a06d8e5ec7d" /> | <img width="2704" height="2044" alt="CleanShot 2026-01-21 at 11 34 14@2x" src="https://github.com/user-attachments/assets/f7830b22-ff4e-4fae-8c78-6dcd870ce2d4" /> | 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. While still on trunk, create a site and let the thumbnail image get captured.
2. Apply the following diff to simulate image capture failure.

```diff
diff --git a/src/screenshot-window.ts b/src/screenshot-window.ts
index ef6eeecd..7554ef25 100644
--- a/src/screenshot-window.ts
+++ b/src/screenshot-window.ts
@@ -18,6 +18,7 @@ export function createScreenshotWindow( captureUrl: string ) {
 	} );
 
 	const waitForCapture = async () => {
+		throw new Error( 'Simulating capture failure' );
 		await window.loadURL( captureUrl );
 
 		await window.webContents.insertCSS( `
```

3. Observe the "Thumbnail unavailable" message.
4. Check out the PR branch and build the app with `npm install && npm start`.
5. Follow the steps 1. and 2. again.
6. Observe that this time, the previous thumbnail image will be kept. "Thumbnail unavailable" message won't be displayed.
7. Without the simulated failure, the thumbnail should get recaptured correctly.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
