### PR TITLE
Convert performance logging to use native fetch with redirect support

### DIFF
--- a/scripts/compare-perf/log-to-codevitals.ts
+++ b/scripts/compare-perf/log-to-codevitals.ts
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 /* eslint-disable no-console */
 import fs from 'fs';
-import https from 'https';
 import path from 'path';
+
 const [ token, branch, hash, baseHash, timestamp ] = process.argv.slice( 2 );
 
 const resultsFiles = [
@@ -22,58 +22,52 @@ const performanceResults = resultsFiles.map( ( { file } ) =>
 	)
 );
 
-const data = new TextEncoder().encode(
-	JSON.stringify( {
-		branch,
-		hash,
-		baseHash,
-		timestamp,
-		metrics: resultsFiles.reduce( ( result, { metricsPrefix }, index ) => {
-			return {
-				...result,
-				...Object.fromEntries(
-					Object.entries( performanceResults[ index ][ hash ] ?? {} ).map( ( [ key, value ] ) => [
-						metricsPrefix + key,
-						value,
-					] )
-				),
-			};
-		}, {} ),
-		baseMetrics: resultsFiles.reduce( ( result, { metricsPrefix }, index ) => {
-			return {
-				...result,
-				...Object.fromEntries(
-					Object.entries( performanceResults[ index ][ baseHash ] ?? {} ).map(
-						( [ key, value ] ) => [ metricsPrefix + key, value ]
-					)
-				),
-			};
-		}, {} ),
-	} )
-);
-
-const options = {
-	hostname: 'www.codevitals.run',
-	port: 443,
-	path: '/api/log?token=' + token,
-	method: 'POST',
-	headers: {
-		'Content-Type': 'application/json',
-		'Content-Length': data.length,
-	},
+const payload = {
+	branch,
+	hash,
+	baseHash,
+	timestamp,
+	metrics: resultsFiles.reduce( ( result, { metricsPrefix }, index ) => {
+		return {
+			...result,
+			...Object.fromEntries(
+				Object.entries( performanceResults[ index ][ hash ] ?? {} ).map( ( [ key, value ] ) => [
+					metricsPrefix + key,
+					value,
+				] )
+			),
+		};
+	}, {} ),
+	baseMetrics: resultsFiles.reduce( ( result, { metricsPrefix }, index ) => {
+		return {
+			...result,
+			...Object.fromEntries(
+				Object.entries( performanceResults[ index ][ baseHash ] ?? {} ).map( ( [ key, value ] ) => [
+					metricsPrefix + key,
+					value,
+				] )
+			),
+		};
+	}, {} ),
 };
 
-const req = https.request( options, ( res ) => {
-	console.log( `statusCode: ${ res.statusCode }` );
-
-	res.on( 'data', ( d ) => {
-		process.stdout.write( d );
+try {
+	const response = await fetch( `https://www.codevitals.run/api/log?token=${ token }`, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify( payload ),
 	} );
-} );
 
-req.on( 'error', ( error ) => {
+	const responseText = await response.text();
+	console.log( `statusCode: ${ response.status }` );
+	if ( responseText ) {
+		console.log( responseText );
+	}
+
+	if ( ! response.ok ) {
+		process.exit( 1 );
+	}
+} catch ( error ) {
 	console.error( error );
-} );
-
-req.write( data );
-req.end();
+	process.exit( 1 );
+}


### PR DESCRIPTION
The perf jobs is currently silently failing because codevitals hosting changed a bit and now the log api redirects first.

## Proposed Changes

- Replace `https.request()` with native `fetch()` to automatically follow HTTP redirects (301, 302, etc.)
- Add proper error handling with `process.exit(1)` on non-2xx responses or network errors
- Simplify code by using async/await instead of callback-based approach

## Testing Instructions

This script is run during `npm run test:metrics` in CI. The change is backwards compatible - if the endpoint doesn't redirect, behavior is identical to before. If it does redirect, the metrics will now properly reach the destination instead of failing silently.

## Pre-merge Checklist

- [x] TypeScript linting passed