### PR TITLE
Add UTM params to Telex links in Assistant responses

### DIFF
--- a/src/components/ai-input.tsx
+++ b/src/components/ai-input.tsx
@@ -266,10 +266,7 @@ const UnforwardedAIInput = (
 							<MenuItem
 								data-testid="telex-link-button"
 								onClick={ () => {
-									const telexUrl = addUrlParams(
-										`https://${ TELEX_HOSTNAME }/`,
-										TELEX_UTM_PARAMS
-									);
+									const telexUrl = addUrlParams( `https://${ TELEX_HOSTNAME }/`, TELEX_UTM_PARAMS );
 									getIpcApi().openURL( telexUrl );
 									onClose();
 								} }

--- a/src/components/ai-input.tsx
+++ b/src/components/ai-input.tsx
@@ -3,10 +3,11 @@ import { __ } from '@wordpress/i18n';
 import { Icon, moreVertical, keyboardReturn, reset } from '@wordpress/icons';
 import React, { forwardRef, useRef, useEffect, useState } from 'react';
 import { ArrowIcon } from 'src/components/arrow-icon';
-import { TELEX_URL } from 'src/constants';
+import { TELEX_HOSTNAME, TELEX_UTM_PARAMS } from 'src/constants';
 import useAiIcon from 'src/hooks/use-ai-icon';
 import { cx } from 'src/lib/cx';
 import { getIpcApi } from 'src/lib/get-ipc-api';
+import { addUrlParams } from 'src/lib/url-utils';
 
 interface AIInputProps {
 	disabled: boolean;
@@ -265,7 +266,11 @@ const UnforwardedAIInput = (
 							<MenuItem
 								data-testid="telex-link-button"
 								onClick={ () => {
-									getIpcApi().openURL( TELEX_URL );
+									const telexUrl = addUrlParams(
+										`https://${ TELEX_HOSTNAME }/`,
+										TELEX_UTM_PARAMS
+									);
+									getIpcApi().openURL( telexUrl );
 									onClose();
 								} }
 								className="flex flex-row"

--- a/src/components/assistant-anchor.tsx
+++ b/src/components/assistant-anchor.tsx
@@ -1,9 +1,11 @@
 import { speak } from '@wordpress/a11y';
 import { __ } from '@wordpress/i18n';
 import { ExtraProps } from 'react-markdown';
+import { TELEX_HOSTNAME, TELEX_UTM_PARAMS } from 'src/constants';
 import { useSiteDetails } from 'src/hooks/use-site-details';
 import { cx } from 'src/lib/cx';
 import { getIpcApi } from 'src/lib/get-ipc-api';
+import { addUrlParams, getHostnameFromUrl } from 'src/lib/url-utils';
 
 export default function Anchor( props: JSX.IntrinsicElements[ 'a' ] & ExtraProps ) {
 	const { href } = props;
@@ -31,7 +33,9 @@ export default function Anchor( props: JSX.IntrinsicElements[ 'a' ] & ExtraProps
 					await startServer( selectedSite?.id );
 				}
 
-				getIpcApi().openURL( href );
+				const isTelexUrl = getHostnameFromUrl( href ) === TELEX_HOSTNAME;
+				const finalUrl = isTelexUrl ? addUrlParams( href, TELEX_UTM_PARAMS ) : href;
+				getIpcApi().openURL( finalUrl );
 			} }
 		/>
 	);

--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -17,12 +17,13 @@ import { ChatRating } from 'src/components/chat-rating';
 import { LearnMoreLink } from 'src/components/learn-more';
 import offlineIcon from 'src/components/offline-icon';
 import WelcomeComponent from 'src/components/welcome-message-prompt';
-import { LIMIT_OF_PROMPTS_PER_USER, TELEX_URL } from 'src/constants';
+import { LIMIT_OF_PROMPTS_PER_USER, TELEX_HOSTNAME, TELEX_UTM_PARAMS } from 'src/constants';
 import { useAuth } from 'src/hooks/use-auth';
 import { useOffline } from 'src/hooks/use-offline';
 import { useThemeDetails } from 'src/hooks/use-theme-details';
 import { cx } from 'src/lib/cx';
 import { getIpcApi } from 'src/lib/get-ipc-api';
+import { addUrlParams } from 'src/lib/url-utils';
 import { useAppDispatch, useRootSelector } from 'src/stores';
 import {
 	chatThunks,
@@ -460,7 +461,16 @@ export function ContentTabAssistant( { selectedSite }: ContentTabAssistantProps 
 								__( 'Build blocks with <button>Telex <ArrowIcon /></button>' ),
 								{
 									button: (
-										<Button variant="link" onClick={ () => getIpcApi().openURL( TELEX_URL ) } />
+										<Button
+											variant="link"
+											onClick={ () => {
+												const telexUrl = addUrlParams(
+													`https://${ TELEX_HOSTNAME }/`,
+													TELEX_UTM_PARAMS
+												);
+												getIpcApi().openURL( telexUrl );
+											} }
+										/>
 									),
 									ArrowIcon: <ArrowIcon />,
 								}

--- a/src/components/tests/assistant-anchor.test.tsx
+++ b/src/components/tests/assistant-anchor.test.tsx
@@ -76,4 +76,30 @@ describe( 'Anchor', () => {
 
 		expect( screen.getByRole( 'link' ) ).toHaveClass( 'animate-pulse', 'cursor-wait' );
 	} );
+
+	it( 'should add UTM params when clicking a Telex link', () => {
+		( useSiteDetails as jest.Mock ).mockReturnValue( {} );
+		render( <Anchor href="https://telex.automattic.ai/" children="Telex link" /> );
+
+		screen.getByRole( 'link' ).click();
+
+		expect( getIpcApi().openURL ).toHaveBeenCalledWith(
+			expect.stringContaining( 'utm_source=studio' )
+		);
+		expect( getIpcApi().openURL ).toHaveBeenCalledWith(
+			expect.stringContaining( 'utm_medium=app' )
+		);
+		expect( getIpcApi().openURL ).toHaveBeenCalledWith(
+			expect.stringContaining( 'utm_campaign=assistant' )
+		);
+	} );
+
+	it( 'should not modify non-Telex URLs', () => {
+		( useSiteDetails as jest.Mock ).mockReturnValue( {} );
+		render( <Anchor href="https://wordpress.com/" children="WordPress link" /> );
+
+		screen.getByRole( 'link' ).click();
+
+		expect( getIpcApi().openURL ).toHaveBeenCalledWith( 'https://wordpress.com/' );
+	} );
 } );

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -24,8 +24,12 @@ export const AUTO_UPDATE_INTERVAL_MS = 60 * 60 * 1000;
 export const WINDOWS_TITLEBAR_HEIGHT = 32;
 export const ABOUT_WINDOW_WIDTH = 300;
 export const ABOUT_WINDOW_HEIGHT = 350;
-export const TELEX_URL =
-	'https://telex.automattic.ai/?utm_source=studio&utm_medium=app&utm_campaign=assistant';
+export const TELEX_HOSTNAME = 'telex.automattic.ai';
+export const TELEX_UTM_PARAMS = {
+	utm_source: 'studio',
+	utm_medium: 'app',
+	utm_campaign: 'assistant',
+} as const;
 export const BUG_REPORT_URL =
 	'https://github.com/Automattic/studio/issues/new?assignees=&labels=Needs+triage%2C%5BType%5D+Bug&projects=&template=bug_report.yml';
 export const FEATURE_REQUEST_URL =

--- a/src/lib/tests/url-utils.test.ts
+++ b/src/lib/tests/url-utils.test.ts
@@ -1,0 +1,52 @@
+import { addUrlParams, getHostnameFromUrl } from 'src/lib/url-utils';
+
+describe( 'getHostnameFromUrl', () => {
+	it( 'extracts hostname from valid URLs', () => {
+		expect( getHostnameFromUrl( 'https://telex.automattic.ai/' ) ).toBe( 'telex.automattic.ai' );
+		expect( getHostnameFromUrl( 'https://wordpress.com/path' ) ).toBe( 'wordpress.com' );
+		expect( getHostnameFromUrl( 'http://localhost:3000' ) ).toBe( 'localhost' );
+	} );
+
+	it( 'returns original string for invalid URLs', () => {
+		expect( getHostnameFromUrl( 'not-a-url' ) ).toBe( 'not-a-url' );
+		expect( getHostnameFromUrl( '' ) ).toBe( '' );
+	} );
+} );
+
+describe( 'addUrlParams', () => {
+	it( 'adds params to a URL', () => {
+		const result = addUrlParams( 'https://example.com/', { foo: 'bar', baz: 'qux' } );
+		expect( result ).toContain( 'foo=bar' );
+		expect( result ).toContain( 'baz=qux' );
+	} );
+
+	it( 'preserves existing path', () => {
+		const result = addUrlParams( 'https://example.com/some/path', { foo: 'bar' } );
+		expect( result ).toContain( '/some/path' );
+		expect( result ).toContain( 'foo=bar' );
+	} );
+
+	it( 'preserves existing query params', () => {
+		const result = addUrlParams( 'https://example.com/?existing=param', { foo: 'bar' } );
+		expect( result ).toContain( 'existing=param' );
+		expect( result ).toContain( 'foo=bar' );
+	} );
+
+	it( 'preserves existing hash', () => {
+		const result = addUrlParams( 'https://example.com/#section', { foo: 'bar' } );
+		expect( result ).toContain( '#section' );
+		expect( result ).toContain( 'foo=bar' );
+	} );
+
+	it( 'does not override existing params', () => {
+		const result = addUrlParams( 'https://example.com/?foo=existing', { foo: 'new', bar: 'baz' } );
+		expect( result ).toContain( 'foo=existing' );
+		expect( result ).not.toContain( 'foo=new' );
+		expect( result ).toContain( 'bar=baz' );
+	} );
+
+	it( 'returns invalid URLs unchanged', () => {
+		expect( addUrlParams( 'not-a-url', { foo: 'bar' } ) ).toBe( 'not-a-url' );
+		expect( addUrlParams( '', { foo: 'bar' } ) ).toBe( '' );
+	} );
+} );

--- a/src/lib/url-utils.ts
+++ b/src/lib/url-utils.ts
@@ -11,3 +11,25 @@ export function getHostnameFromUrl( url: string ): string {
 		return url;
 	}
 }
+
+/**
+ * Adds query parameters to a URL. Does not override existing parameters.
+ * @param url The URL string to add params to
+ * @param params Object containing key-value pairs to add as query params
+ * @returns The URL with params added, or the original URL if invalid
+ */
+export function addUrlParams( url: string, params: Record< string, string > ): string {
+	try {
+		const parsedUrl = new URL( url );
+
+		for ( const [ key, value ] of Object.entries( params ) ) {
+			if ( ! parsedUrl.searchParams.has( key ) ) {
+				parsedUrl.searchParams.set( key, value );
+			}
+		}
+
+		return parsedUrl.toString();
+	} catch {
+		return url;
+	}
+}


### PR DESCRIPTION
## Related issues

- Fixes STU-1221

## Proposed Changes

- Add UTM params to any Telex link shared by the Studio Assistant

## Testing Instructions

1. Start the app with `npm start`
2. Test the **Telex banner**: Click "Build with Telex" in the banner at the top of the Assistant tab
   - Verify the URL contains `utm_source=studio&utm_medium=app&utm_campaign=assistant`
3. Test the **Assistant menu**: Click the three-dot menu (⋮) in the Assistant input area, then click "Build with Telex"
   - Verify the URL contains the same UTM params
4. Test **Assistant link clicks**: Ask the Assistant something that triggers a Telex recommendation (e.g., "How can I create a custom WordPress block?")
   - Click the Telex link in the response
   - Verify the URL contains the UTM params
5. Run the tests: `npm test -- src/lib/tests/url-utils.test.ts src/components/tests/assistant-anchor.test.tsx`

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?