### PR TITLE
Avoid overwriting site name when adding existing WordPress installations

### DIFF
--- a/cli/commands/site/create.ts
+++ b/cli/commands/site/create.ts
@@ -207,13 +207,21 @@ export async function runCommand(
 			}
 		}
 
+		logger.reportStart( LoggerAction.SET_SITE_NAME, __( 'Setting site name…' ) );
 		if ( options.name ) {
-			setupSteps.push( {
-				step: 'setSiteOptions',
-				options: {
-					blogname: options.name,
-				},
-			} );
+			if ( isWordPressDirResult ) {
+				logger.reportWarning(
+					__( 'Site name ignored because the directory contains a WordPress site.' )
+				);
+			} else {
+				logger.reportSuccess( sprintf( __( 'Site name set to: %s' ), options.name ) );
+				setupSteps.push( {
+					step: 'setSiteOptions',
+					options: {
+						blogname: options.name,
+					},
+				} );
+			}
 		}
 
 		if ( setupSteps.length > 0 ) {

--- a/cli/commands/site/create.ts
+++ b/cli/commands/site/create.ts
@@ -209,7 +209,8 @@ export async function runCommand(
 
 		logger.reportStart( LoggerAction.SET_SITE_NAME, __( 'Setting site name…' ) );
 		if ( options.name ) {
-			if ( isWordPressDirResult ) {
+			const hasWpConfig = await pathExists( path.join( sitePath, 'wp-config.php' ) );
+			if ( isWordPressDirResult && hasWpConfig ) {
 				logger.reportWarning(
 					__( 'Site name ignored because the directory contains a WordPress site.' )
 				);

--- a/cli/commands/site/create.ts
+++ b/cli/commands/site/create.ts
@@ -207,22 +207,15 @@ export async function runCommand(
 			}
 		}
 
-		logger.reportStart( LoggerAction.SET_SITE_NAME, __( 'Setting site name…' ) );
-		if ( options.name ) {
-			const hasWpConfig = await pathExists( path.join( sitePath, 'wp-config.php' ) );
-			if ( isWordPressDirResult && hasWpConfig ) {
-				logger.reportWarning(
-					__( 'Site name ignored because the directory contains a WordPress site.' )
-				);
-			} else {
-				logger.reportSuccess( sprintf( __( 'Site name set to: %s' ), options.name ) );
-				setupSteps.push( {
-					step: 'setSiteOptions',
-					options: {
-						blogname: options.name,
-					},
-				} );
-			}
+		const hasWpConfig = await pathExists( path.join( sitePath, 'wp-config.php' ) );
+		const isWordPressDirectoryInitialized = isWordPressDirResult && hasWpConfig;
+		if ( options.name && ! isWordPressDirectoryInitialized ) {
+			setupSteps.push( {
+				step: 'setSiteOptions',
+				options: {
+					blogname: options.name,
+				},
+			} );
 		}
 
 		if ( setupSteps.length > 0 ) {

--- a/cli/commands/site/tests/create.test.ts
+++ b/cli/commands/site/tests/create.test.ts
@@ -1,4 +1,4 @@
-import { Blueprint } from '@wp-playground/blueprints';
+import { Blueprint, StepDefinition } from '@wp-playground/blueprints';
 import {
 	filterUnsupportedBlueprintFeatures,
 	validateBlueprintData,
@@ -101,6 +101,7 @@ describe( 'CLI: studio site create', () => {
 	let consoleLogSpy: jest.SpyInstance;
 	let fsMkdirSyncSpy: jest.SpyInstance;
 	let loggerReportSuccessSpy: jest.SpyInstance;
+	let loggerReportWarningSpy: jest.SpyInstance;
 
 	const createPathExistsMock = ( sitePathExists = false ) => {
 		const bundledWPPath = require( 'path' ).join(
@@ -126,6 +127,7 @@ describe( 'CLI: studio site create', () => {
 		consoleLogSpy = jest.spyOn( console, 'log' ).mockImplementation();
 		fsMkdirSyncSpy = jest.spyOn( require( 'fs' ), 'mkdirSync' ).mockReturnValue( undefined );
 		loggerReportSuccessSpy = jest.spyOn( Logger.prototype, 'reportSuccess' );
+		loggerReportWarningSpy = jest.spyOn( Logger.prototype, 'reportWarning' );
 		createPathExistsMock( false );
 		( isEmptyDir as jest.Mock ).mockResolvedValue( true );
 		( isWordPressDirectory as jest.Mock ).mockReturnValue( false );
@@ -301,6 +303,33 @@ describe( 'CLI: studio site create', () => {
 					} ),
 				} )
 			);
+			expect( loggerReportSuccessSpy ).toHaveBeenCalledWith( 'Site name set to: My Custom Site' );
+			expect( loggerReportWarningSpy ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should NOT override blogname when adding existing WordPress directory with name', async () => {
+			( pathExists as jest.Mock ).mockResolvedValue( true );
+			( isEmptyDir as jest.Mock ).mockResolvedValue( false );
+			( isWordPressDirectory as jest.Mock ).mockReturnValue( true );
+
+			await runCommand( mockSitePath, {
+				...defaultTestOptions,
+				name: 'My Custom Site',
+			} );
+
+			// Verify setSiteOptions step is NOT in the blueprint steps
+			const calls = ( startWordPressServer as jest.Mock ).mock.calls;
+			const blueprintCall = calls.find(
+				( call ) =>
+					call[ 2 ]?.blueprint?.steps?.some(
+						( step: StepDefinition ) => step.step === 'setSiteOptions'
+					)
+			);
+			expect( blueprintCall ).toBeUndefined();
+
+			expect( loggerReportWarningSpy ).toHaveBeenCalledWith(
+				'Site name ignored because the directory contains a WordPress site.'
+			);
 		} );
 
 		it( 'should use folder name as site name if no name provided', async () => {
@@ -463,6 +492,7 @@ describe( 'CLI: studio site create', () => {
 					} ),
 				} )
 			);
+			expect( loggerReportSuccessSpy ).toHaveBeenCalledWith( 'Site name set to: My Site' );
 		} );
 
 		it( 'should warn about unsupported Blueprint features', async () => {

--- a/cli/commands/site/tests/create.test.ts
+++ b/cli/commands/site/tests/create.test.ts
@@ -303,8 +303,6 @@ describe( 'CLI: studio site create', () => {
 					} ),
 				} )
 			);
-			expect( loggerReportSuccessSpy ).toHaveBeenCalledWith( 'Site name set to: My Custom Site' );
-			expect( loggerReportWarningSpy ).not.toHaveBeenCalled();
 		} );
 
 		it( 'should NOT override blogname when adding existing WordPress directory with wp-config.php and name', async () => {
@@ -343,10 +341,6 @@ describe( 'CLI: studio site create', () => {
 					)
 			);
 			expect( blueprintCall ).toBeUndefined();
-
-			expect( loggerReportWarningSpy ).toHaveBeenCalledWith(
-				'Site name ignored because the directory contains a WordPress site.'
-			);
 		} );
 
 		it( 'should set blogname when WordPress directory exists but has no wp-config.php', async () => {
@@ -391,9 +385,6 @@ describe( 'CLI: studio site create', () => {
 					} ),
 				} )
 			);
-
-			expect( loggerReportSuccessSpy ).toHaveBeenCalledWith( 'Site name set to: My Custom Site' );
-			expect( loggerReportWarningSpy ).not.toHaveBeenCalled();
 		} );
 
 		it( 'should use folder name as site name if no name provided', async () => {
@@ -556,7 +547,6 @@ describe( 'CLI: studio site create', () => {
 					} ),
 				} )
 			);
-			expect( loggerReportSuccessSpy ).toHaveBeenCalledWith( 'Site name set to: My Site' );
 		} );
 
 		it( 'should warn about unsupported Blueprint features', async () => {

--- a/cli/commands/site/tests/create.test.ts
+++ b/cli/commands/site/tests/create.test.ts
@@ -336,24 +336,14 @@ describe( 'CLI: studio site create', () => {
 		} );
 
 		it( 'should set blogname when WordPress directory exists but has no wp-config.php', async () => {
-			const wpConfigPath = require( 'path' ).join( mockSitePath, 'wp-config.php' );
 			const bundledWPPath = require( 'path' ).join(
 				'/test/server-files',
 				'wordpress-versions',
 				'latest'
 			);
-			( pathExists as jest.Mock ).mockImplementation( ( path: string ) => {
-				if ( path === bundledWPPath ) {
-					return Promise.resolve( true );
-				}
-				if ( path === wpConfigPath ) {
-					return Promise.resolve( false );
-				}
-				if ( path === mockSitePath ) {
-					return Promise.resolve( true );
-				}
-				return Promise.resolve( false );
-			} );
+			( pathExists as jest.Mock ).mockImplementation(
+				async ( path: string ) => path === bundledWPPath || path === mockSitePath
+			);
 			( isEmptyDir as jest.Mock ).mockResolvedValue( false );
 			( isWordPressDirectory as jest.Mock ).mockReturnValue( true );
 

--- a/cli/commands/site/tests/create.test.ts
+++ b/cli/commands/site/tests/create.test.ts
@@ -312,18 +312,10 @@ describe( 'CLI: studio site create', () => {
 				'wordpress-versions',
 				'latest'
 			);
-			( pathExists as jest.Mock ).mockImplementation( ( path: string ) => {
-				if ( path === bundledWPPath ) {
-					return Promise.resolve( true );
-				}
-				if ( path === wpConfigPath ) {
-					return Promise.resolve( true );
-				}
-				if ( path === mockSitePath ) {
-					return Promise.resolve( true );
-				}
-				return Promise.resolve( false );
-			} );
+			( pathExists as jest.Mock ).mockImplementation(
+				async ( path: string ) =>
+					path === bundledWPPath || path === wpConfigPath || path === mockSitePath
+			);
 			( isEmptyDir as jest.Mock ).mockResolvedValue( false );
 			( isWordPressDirectory as jest.Mock ).mockReturnValue( true );
 

--- a/cli/commands/site/tests/create.test.ts
+++ b/cli/commands/site/tests/create.test.ts
@@ -307,8 +307,25 @@ describe( 'CLI: studio site create', () => {
 			expect( loggerReportWarningSpy ).not.toHaveBeenCalled();
 		} );
 
-		it( 'should NOT override blogname when adding existing WordPress directory with name', async () => {
-			( pathExists as jest.Mock ).mockResolvedValue( true );
+		it( 'should NOT override blogname when adding existing WordPress directory with wp-config.php and name', async () => {
+			const wpConfigPath = require( 'path' ).join( mockSitePath, 'wp-config.php' );
+			const bundledWPPath = require( 'path' ).join(
+				'/test/server-files',
+				'wordpress-versions',
+				'latest'
+			);
+			( pathExists as jest.Mock ).mockImplementation( ( path: string ) => {
+				if ( path === bundledWPPath ) {
+					return Promise.resolve( true );
+				}
+				if ( path === wpConfigPath ) {
+					return Promise.resolve( true );
+				}
+				if ( path === mockSitePath ) {
+					return Promise.resolve( true );
+				}
+				return Promise.resolve( false );
+			} );
 			( isEmptyDir as jest.Mock ).mockResolvedValue( false );
 			( isWordPressDirectory as jest.Mock ).mockReturnValue( true );
 
@@ -330,6 +347,53 @@ describe( 'CLI: studio site create', () => {
 			expect( loggerReportWarningSpy ).toHaveBeenCalledWith(
 				'Site name ignored because the directory contains a WordPress site.'
 			);
+		} );
+
+		it( 'should set blogname when WordPress directory exists but has no wp-config.php', async () => {
+			const wpConfigPath = require( 'path' ).join( mockSitePath, 'wp-config.php' );
+			const bundledWPPath = require( 'path' ).join(
+				'/test/server-files',
+				'wordpress-versions',
+				'latest'
+			);
+			( pathExists as jest.Mock ).mockImplementation( ( path: string ) => {
+				if ( path === bundledWPPath ) {
+					return Promise.resolve( true );
+				}
+				if ( path === wpConfigPath ) {
+					return Promise.resolve( false );
+				}
+				if ( path === mockSitePath ) {
+					return Promise.resolve( true );
+				}
+				return Promise.resolve( false );
+			} );
+			( isEmptyDir as jest.Mock ).mockResolvedValue( false );
+			( isWordPressDirectory as jest.Mock ).mockReturnValue( true );
+
+			await runCommand( mockSitePath, {
+				...defaultTestOptions,
+				name: 'My Custom Site',
+			} );
+
+			// Verify setSiteOptions step IS in the blueprint steps (because wp-config.php doesn't exist)
+			expect( startWordPressServer ).toHaveBeenCalledWith(
+				expect.anything(),
+				expect.any( Logger ),
+				expect.objectContaining( {
+					blueprint: expect.objectContaining( {
+						steps: expect.arrayContaining( [
+							expect.objectContaining( {
+								step: 'setSiteOptions',
+								options: { blogname: 'My Custom Site' },
+							} ),
+						] ),
+					} ),
+				} )
+			);
+
+			expect( loggerReportSuccessSpy ).toHaveBeenCalledWith( 'Site name set to: My Custom Site' );
+			expect( loggerReportWarningSpy ).not.toHaveBeenCalled();
 		} );
 
 		it( 'should use folder name as site name if no name provided', async () => {

--- a/common/logger-actions.ts
+++ b/common/logger-actions.ts
@@ -18,6 +18,7 @@ export enum PreviewCommandLoggerAction {
 }
 
 export enum SiteCommandLoggerAction {
+	SET_SITE_NAME = 'setName',
 	START_DAEMON = 'startDaemon',
 	LOAD_SITES = 'loadSites',
 	START_PROXY = 'startProxy',

--- a/common/logger-actions.ts
+++ b/common/logger-actions.ts
@@ -18,7 +18,6 @@ export enum PreviewCommandLoggerAction {
 }
 
 export enum SiteCommandLoggerAction {
-	SET_SITE_NAME = 'setName',
 	START_DAEMON = 'startDaemon',
 	LOAD_SITES = 'loadSites',
 	START_PROXY = 'startProxy',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-1233

## Proposed Changes

- Ignore the `--name` argument if the target folder contains an existing WordPress site with a wp-config.php file, which means it was initialized in the past.
- Add new tests to cover this usage.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Existing WordPress site directory**

- Run `npm run cli:build`
- Run `studio site create /path/to/existing-wordpress --name "My New Site name that will be ignored"`
- Observe the started site uses the original site name


**New sites**

- Run `npm run cli:build`
- Run `studio site create /path/to/new-empty-folder --name "My New Site Name"`
- Observe the started site uses the provided name

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
