### PR TITLE
Avoid `failure` event when deliberately killing events subscriber

### DIFF
--- a/src/modules/cli/lib/cli-events-subscriber.ts
+++ b/src/modules/cli/lib/cli-events-subscriber.ts
@@ -59,7 +59,6 @@ const handleSiteEvent = sequential( async ( event: SiteEvent ): Promise< void > 
 	void sendIpcEventToRenderer( 'site-event', event );
 } );
 
-// Hello
 const cliSiteEventSchema = z.object( {
 	action: z.literal( 'keyValuePair' ),
 	key: z.literal( 'site-event' ),

--- a/src/modules/cli/lib/cli-events-subscriber.ts
+++ b/src/modules/cli/lib/cli-events-subscriber.ts
@@ -5,17 +5,6 @@ import { sendIpcEventToRenderer } from 'src/ipc-utils';
 import { executeCliCommand } from 'src/modules/cli/lib/execute-command';
 import { SiteServer } from 'src/site-server';
 
-const cliSiteEventSchema = z.object( {
-	action: z.literal( 'keyValuePair' ),
-	key: z.literal( 'site-event' ),
-	value: z
-		.string()
-		.transform( ( val ) => JSON.parse( val ) )
-		.pipe( siteEventSchema ),
-} );
-
-let subscriber: ReturnType< typeof executeCliCommand > | null = null;
-
 function siteDetailsToServerDetails(
 	site: SiteDetails,
 	running: boolean,
@@ -70,6 +59,18 @@ const handleSiteEvent = sequential( async ( event: SiteEvent ): Promise< void > 
 	void sendIpcEventToRenderer( 'site-event', event );
 } );
 
+// Hello
+const cliSiteEventSchema = z.object( {
+	action: z.literal( 'keyValuePair' ),
+	key: z.literal( 'site-event' ),
+	value: z
+		.string()
+		.transform( ( val ) => JSON.parse( val ) )
+		.pipe( siteEventSchema ),
+} );
+
+let subscriber: ReturnType< typeof executeCliCommand > | null = null;
+
 export async function startCliEventsSubscriber(): Promise< void > {
 	return new Promise( ( resolve, reject ) => {
 		if ( subscriber ) {
@@ -111,8 +112,8 @@ export async function startCliEventsSubscriber(): Promise< void > {
 
 export function stopCliEventsSubscriber(): void {
 	if ( subscriber ) {
-		const [ , childProcess ] = subscriber;
+		const [ eventEmitter, childProcess ] = subscriber;
+		eventEmitter.removeAllListeners();
 		childProcess.kill( 'SIGKILL' );
-		subscriber = null;
 	}
 }

--- a/src/modules/cli/lib/execute-command.ts
+++ b/src/modules/cli/lib/execute-command.ts
@@ -107,7 +107,14 @@ export function executeCliCommand(
 	function appQuitHandler() {
 		const pid = child.pid;
 		const result = child.kill();
-		console.log( `Child process with pid ${ pid } killed with result: ${ result }` );
+		if ( result ) {
+			console.log( `Successfully killed child process with pid ${ pid }` );
+		} else {
+			console.error(
+				`Failed to kill child process with pid ${ pid }. This likely means the process is already terminated. CLI args:`,
+				args
+			);
+		}
 	}
 
 	child.on( 'close', ( code ) => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-1231

## Proposed Changes

The CLI `_events` child process is killed with a SIGKILL signal before the Electron app quits (see https://github.com/Automattic/studio/pull/2398#discussion_r2698116355 for background). This triggers a `failure` event on the `CliCommandEventEmitter` instance, which logs "CLI events subscriber exited unexpectedly" to stdout. This is misleading, because it didn't exit unexpectedly.

This PR fixes the problem by removing all event listeners from the `CliCommandEventEmitter` instance before sending the SIGKILL signal. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Run `npm start`
2. Add a line somewhere in the "back-end code" and save the file (a comment in `src/index.ts`, for example)
3. Ensure that no `CLI events subscriber exited unexpectedly` is logged to stdout

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
