### PR TITLE
Clarify that `site delete --files` moves files to trash

### DIFF
--- a/cli/commands/site/delete.ts
+++ b/cli/commands/site/delete.ts
@@ -118,13 +118,13 @@ export async function runCommand(
 		}
 
 		if ( deleteFiles ) {
-			logger.reportStart( LoggerAction.DELETE_FILES, __( 'Deleting site files…' ) );
+			logger.reportStart( LoggerAction.DELETE_FILES, __( 'Moving site files to trash…' ) );
 			// We configure `trash` as an external module, since it includes a native macOS binary that Vite
 			// inlines as a base64 string, which produces a runtime error. Since `trash` is also an ESM-only
 			// module, we need to import it dynamically (since Rollup doesn't get a chance to process it)
 			const trash = ( await import( 'trash' ) ).default;
 			await trash( siteFolder );
-			logger.reportSuccess( __( 'Site files deleted' ) );
+			logger.reportSuccess( __( 'Site files moved to trash' ) );
 		}
 
 		await emitSiteEvent( SITE_EVENTS.DELETED, { siteId: site.id } );
@@ -140,7 +140,7 @@ export const registerCommand = ( yargs: StudioArgv ) => {
 		builder: ( yargs ) => {
 			return yargs.option( 'files', {
 				type: 'boolean',
-				description: __( 'Also remove site files from disk' ),
+				description: __( 'Also move site files to trash' ),
 				default: false,
 			} );
 		},


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

N/A

## Proposed Changes

Change the logger messages and option description in `cli/commands/site/delete.ts` to clarify that the `--files` option doesn't delete the site files permanently, it just moves them to the trash. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Code review should suffice

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
