### PR TITLE
Studio: Remove deprecated PHP versions 7.2 and 7.3

### DIFF
--- a/cli/commands/site/create.ts
+++ b/cli/commands/site/create.ts
@@ -2,7 +2,6 @@ import crypto from 'crypto';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import { SupportedPHPVersions } from '@php-wasm/universal';
 import { __, sprintf } from '@wordpress/i18n';
 import { Blueprint, StepDefinition } from '@wp-playground/blueprints';
 import {
@@ -33,6 +32,7 @@ import {
 	isWordPressVersionAtLeast,
 } from 'common/lib/wordpress-version-utils';
 import { SiteCommandLoggerAction as LoggerAction } from 'common/logger-actions';
+import { SupportedPHPVersions } from 'common/types/php-versions';
 import {
 	lockAppdata,
 	readAppdata,

--- a/cli/commands/site/set.ts
+++ b/cli/commands/site/set.ts
@@ -1,4 +1,3 @@
-import { SupportedPHPVersions } from '@php-wasm/universal';
 import { __, sprintf } from '@wordpress/i18n';
 import { DEFAULT_WORDPRESS_VERSION, MINIMUM_WORDPRESS_VERSION } from 'common/constants';
 import { getDomainNameValidationError } from 'common/lib/domains';
@@ -11,6 +10,7 @@ import {
 	isWordPressVersionAtLeast,
 } from 'common/lib/wordpress-version-utils';
 import { SiteCommandLoggerAction as LoggerAction } from 'common/logger-actions';
+import { SupportedPHPVersions } from 'common/types/php-versions';
 import {
 	getSiteByFolder,
 	isXdebugBetaEnabled,

--- a/cli/lib/utils.ts
+++ b/cli/lib/utils.ts
@@ -1,6 +1,6 @@
 import os from 'node:os';
-import { SupportedPHPVersion, SupportedPHPVersions } from '@php-wasm/universal';
 import { __, sprintf } from '@wordpress/i18n';
+import { SupportedPHPVersion, SupportedPHPVersions } from 'common/types/php-versions';
 import { z } from 'zod';
 import { LoggerError } from 'cli/logger';
 

--- a/common/types/php-versions.ts
+++ b/common/types/php-versions.ts
@@ -5,16 +5,7 @@
  * Note: Keep these values in sync with @php-wasm/universal if the upstream package changes.
  */
 
-export const SupportedPHPVersions = [
-	'8.4',
-	'8.3',
-	'8.2',
-	'8.1',
-	'8.0',
-	'7.4',
-	'7.3',
-	'7.2',
-] as const;
+export const SupportedPHPVersions = [ '8.4', '8.3', '8.2', '8.1', '8.0', '7.4' ] as const;
 
 export const LatestSupportedPHPVersion = '8.4' as const;
 


### PR DESCRIPTION
## Related issues

- Fixes STU-1114
- https://github.com/WordPress/wordpress-playground/pull/3127

## Proposed Changes

- Removed PHP 7.2 and 7.3 from `SupportedPHPVersions` array in `common/types/php-versions.ts`
- Updated CLI commands to use `common/types/php-versions` instead of `@php-wasm/universal` for PHP version types
- Modified `cli/commands/site/create.ts` to import from common types
- Modified `cli/commands/site/set.ts` to import from common types
- Modified `cli/lib/utils.ts` to import from common types

These PHP versions are no longer supported by WordPress Playground and cause timeout errors when attempting to create sites.

## Testing Instructions

- Build the app: `npm run cli:build && npm start`
- Test that creating a new site works with PHP 7.4 and above (8.0, 8.1, 8.2, 8.3, 8.4)
- Verify PHP 7.2 and 7.3 are no longer available in the UI dropdown for site creation
- Test CLI: `npm run cli:build && node dist/cli/main.js site create --name test-site --php 8.3`
- Verify CLI `site create` command does not accept `--php 7.2` or `--php 7.3` options
- Test changing PHP version on existing site works with supported versions

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?