### PR TITLE
Fix regression where `themeDetails` are not persisted to appdata file

### DIFF
--- a/src/hooks/use-theme-details.tsx
+++ b/src/hooks/use-theme-details.tsx
@@ -45,7 +45,13 @@ export const ThemeDetailsProvider: React.FC< ThemeDetailsProviderProps > = ( { c
 	);
 	const [ loadingThumbnails, setLoadingThumbnails ] = useState< Record< string, boolean > >( {} );
 
-	useIpcListener( 'theme-details-changed', ( _evt, { id, details } ) => {
+	useIpcListener( 'theme-details-loading', ( _evt, { id } ) => {
+		setLoadingThemeDetails( ( loadingThemeDetails ) => {
+			return { ...loadingThemeDetails, [ id ]: true };
+		} );
+	} );
+
+	useIpcListener( 'theme-details-loaded', ( _evt, { id, details } ) => {
 		setThemeDetails( ( themeDetails ) => {
 			return { ...themeDetails, [ id ]: details };
 		} );
@@ -54,7 +60,13 @@ export const ThemeDetailsProvider: React.FC< ThemeDetailsProviderProps > = ( { c
 		} );
 	} );
 
-	useIpcListener( 'thumbnail-changed', ( _evt, { id, imageData } ) => {
+	useIpcListener( 'thumbnail-loading', ( _evt, { id } ) => {
+		setLoadingThumbnails( ( loadingThumbnails ) => {
+			return { ...loadingThumbnails, [ id ]: true };
+		} );
+	} );
+
+	useIpcListener( 'thumbnail-loaded', ( _evt, { id, imageData } ) => {
 		setThumbnails( ( thumbnails ) => {
 			return { ...thumbnails, [ id ]: imageData ?? undefined };
 		} );
@@ -63,12 +75,9 @@ export const ThemeDetailsProvider: React.FC< ThemeDetailsProviderProps > = ( { c
 		} );
 	} );
 
-	useIpcListener( 'theme-details-updating', ( _evt, { id } ) => {
-		setLoadingThemeDetails( ( loadingThemeDetails ) => {
-			return { ...loadingThemeDetails, [ id ]: true };
-		} );
+	useIpcListener( 'thumbnail-load-error', ( _evt, { id } ) => {
 		setLoadingThumbnails( ( loadingThumbnails ) => {
-			return { ...loadingThumbnails, [ id ]: true };
+			return { ...loadingThumbnails, [ id ]: false };
 		} );
 	} );
 

--- a/src/hooks/use-theme-details.tsx
+++ b/src/hooks/use-theme-details.tsx
@@ -86,7 +86,7 @@ export const ThemeDetailsProvider: React.FC< ThemeDetailsProviderProps > = ( { c
 		if ( ! selectedSite?.id || selectedSite.running === false ) {
 			return;
 		}
-		await getIpcApi().loadThemeDetails( selectedSite.id );
+		await getIpcApi().loadThemeDetails( selectedSite.id, false );
 	} );
 
 	useEffect( () => {

--- a/src/hooks/use-theme-details.tsx
+++ b/src/hooks/use-theme-details.tsx
@@ -86,7 +86,7 @@ export const ThemeDetailsProvider: React.FC< ThemeDetailsProviderProps > = ( { c
 		if ( ! selectedSite?.id || selectedSite.running === false ) {
 			return;
 		}
-		await getIpcApi().getThemeDetails( selectedSite.id );
+		await getIpcApi().loadThemeDetails( selectedSite.id );
 	} );
 
 	useEffect( () => {

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -117,56 +117,6 @@ export {
 	showUserSettings,
 } from 'src/modules/user-settings/lib/ipc-handlers';
 
-async function sendThumbnailChangedEvent( event: IpcMainInvokeEvent, id: string ) {
-	if ( event.sender.isDestroyed() ) {
-		return;
-	}
-	const thumbnailData = await getThumbnailData( event, id );
-	const parentWindow = BrowserWindow.fromWebContents( event.sender );
-	sendIpcEventToRendererWithWindow( parentWindow, 'thumbnail-changed', {
-		id,
-		imageData: thumbnailData,
-	} );
-}
-
-/**
- * Refreshes site metadata (theme details and thumbnail) and notifies the renderer.
- * This is typically called after a site is started or created.
- */
-async function refreshSiteMetadataAndNotify(
-	event: IpcMainInvokeEvent,
-	server: SiteServer,
-	parentWindow: BrowserWindow | null
-): Promise< void > {
-	const id = server.details.id;
-
-	sendIpcEventToRendererWithWindow( parentWindow, 'theme-details-updating', { id } );
-
-	try {
-		const themeDetails = await server.getThemeDetails();
-		if ( themeDetails ) {
-			server.details.themeDetails = themeDetails;
-		}
-	} catch ( error ) {
-		console.error( `Failed to get theme details for server ${ id }:`, error );
-	}
-
-	// Always send theme-details-changed to reset loading state, even if fetching failed
-	sendIpcEventToRendererWithWindow( parentWindow, 'theme-details-changed', {
-		id,
-		details: server.details.themeDetails,
-	} );
-
-	await updateSite( event, server.details );
-
-	try {
-		await server.updateCachedThumbnail();
-		await sendThumbnailChangedEvent( event, id );
-	} catch ( error ) {
-		console.error( `Failed to update thumbnail for server ${ id }:`, error );
-	}
-}
-
 function mergeSiteDetailsWithRunningDetails( sites: SiteDetails[] ): SiteDetails[] {
 	return sites.map( ( site ) => {
 		const server = SiteServer.get( site.id );
@@ -291,11 +241,9 @@ export async function createSite(
 			{ wpVersion, blueprint: blueprint?.blueprint }
 		);
 
-		const parentWindow = BrowserWindow.fromWebContents( event.sender );
-
 		// If the site is running after creation, fetch theme details and update thumbnail
 		if ( server.details.running ) {
-			void refreshSiteMetadataAndNotify( event, server, parentWindow );
+			void getThemeDetails( event, server.details.id );
 		}
 
 		return server.details;
@@ -410,7 +358,6 @@ export async function startServer( event: IpcMainInvokeEvent, id: string ): Prom
 		return;
 	}
 
-	const parentWindow = BrowserWindow.fromWebContents( event.sender );
 	try {
 		await server.start();
 	} catch ( error ) {
@@ -448,7 +395,7 @@ export async function startServer( event: IpcMainInvokeEvent, id: string ): Prom
 	}
 
 	if ( server.details.running ) {
-		void refreshSiteMetadataAndNotify( event, server, parentWindow );
+		void getThemeDetails( event, id );
 	}
 
 	console.log( `Server started for '${ server.details.name }'` );
@@ -757,26 +704,34 @@ export async function getThemeDetails(
 		throw new Error( 'Site not found.' );
 	}
 
+	const parentWindow = BrowserWindow.fromWebContents( event.sender );
+	sendIpcEventToRendererWithWindow( parentWindow, 'theme-details-loading', { id } );
+
+	const oldThemePath = server.details.themeDetails?.path;
 	const themeDetails = await server.getThemeDetails();
-	const themeChanged =
-		themeDetails?.path && themeDetails.path !== server.details.themeDetails?.path;
+	const hasThemeChanged = themeDetails?.path !== oldThemePath;
 
-	if ( themeChanged ) {
-		const parentWindow = BrowserWindow.fromWebContents( event.sender );
-		sendIpcEventToRendererWithWindow( parentWindow, 'theme-details-changed', {
-			id,
-			details: themeDetails,
-		} );
+	sendIpcEventToRendererWithWindow( parentWindow, 'theme-details-loaded', {
+		id,
+		details: themeDetails,
+	} );
 
-		server.details.themeDetails = themeDetails;
-		await updateSite( event, server.details );
+	if ( hasThemeChanged ) {
+		await server.persistThemeDetails();
 
-		void server
-			.updateCachedThumbnail()
-			.then( () => sendThumbnailChangedEvent( event, id ) )
-			.catch( ( error ) =>
-				console.error( `Failed to update thumbnail for server ${ id }:`, error )
-			);
+		try {
+			sendIpcEventToRendererWithWindow( parentWindow, 'thumbnail-loading', { id } );
+			await server.updateCachedThumbnail();
+			const thumbnailPath = getSiteThumbnailPath( id );
+			const thumbnailData = await getImageData( thumbnailPath );
+			sendIpcEventToRendererWithWindow( parentWindow, 'thumbnail-loaded', {
+				id,
+				imageData: thumbnailData,
+			} );
+		} catch ( error ) {
+			sendIpcEventToRendererWithWindow( parentWindow, 'thumbnail-load-error', { id } );
+			console.error( `Failed to update thumbnail for server ${ id }:`, error );
+		}
 	}
 
 	return themeDetails;

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -701,7 +701,8 @@ export function showItemInFolder( _event: IpcMainInvokeEvent, path: string ) {
 // process.
 export async function loadThemeDetails(
 	event: IpcMainInvokeEvent,
-	id: string
+	id: string,
+	emitThemeDetailsLoadingEvent = true
 ): Promise< StartedSiteDetails[ 'themeDetails' ] > {
 	const server = SiteServer.get( id );
 	if ( ! server ) {
@@ -709,7 +710,9 @@ export async function loadThemeDetails(
 	}
 
 	const parentWindow = BrowserWindow.fromWebContents( event.sender );
-	sendIpcEventToRendererWithWindow( parentWindow, 'theme-details-loading', { id } );
+	if ( emitThemeDetailsLoadingEvent ) {
+		sendIpcEventToRendererWithWindow( parentWindow, 'theme-details-loading', { id } );
+	}
 
 	const oldThemePath = server.details.themeDetails?.path;
 	const themeDetails = await server.getThemeDetails();

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -243,7 +243,7 @@ export async function createSite(
 
 		// If the site is running after creation, fetch theme details and update thumbnail
 		if ( server.details.running ) {
-			void getThemeDetails( event, server.details.id );
+			void loadThemeDetails( event, server.details.id );
 		}
 
 		return server.details;
@@ -279,6 +279,8 @@ export async function createSite(
 	}
 }
 
+// Update a site's details (name, custom domain, PHP version, etc). This function calls the
+// `site set` CLI command and updates the `SiteServer` instance after the CLI completes.
 export async function updateSite(
 	event: IpcMainInvokeEvent,
 	updatedSite: SiteDetails,
@@ -395,7 +397,7 @@ export async function startServer( event: IpcMainInvokeEvent, id: string ): Prom
 	}
 
 	if ( server.details.running ) {
-		void getThemeDetails( event, id );
+		void loadThemeDetails( event, id );
 	}
 
 	console.log( `Server started for '${ server.details.name }'` );
@@ -695,7 +697,9 @@ export function showItemInFolder( _event: IpcMainInvokeEvent, path: string ) {
 	shell.showItemInFolder( path );
 }
 
-export async function getThemeDetails(
+// Update a site's theme details and thumbnail. Emit the appropriate IPC events to the renderer
+// process.
+export async function loadThemeDetails(
 	event: IpcMainInvokeEvent,
 	id: string
 ): Promise< StartedSiteDetails[ 'themeDetails' ] > {

--- a/src/ipc-utils.ts
+++ b/src/ipc-utils.ts
@@ -44,9 +44,11 @@ export interface IpcEvents {
 	'show-whats-new': [ void ];
 	'sync-connect-site': [ { remoteSiteId: number; studioSiteId: string; autoOpenPush?: boolean } ];
 	'test-render-failure': [ void ];
-	'theme-details-changed': [ { id: string; details: StartedSiteDetails[ 'themeDetails' ] } ];
-	'theme-details-updating': [ { id: string } ];
-	'thumbnail-changed': [ { id: string; imageData: string | null } ];
+	'theme-details-loading': [ { id: string } ];
+	'theme-details-loaded': [ { id: string; details: StartedSiteDetails[ 'themeDetails' ] } ];
+	'thumbnail-loading': [ { id: string } ];
+	'thumbnail-loaded': [ { id: string; imageData: string | null } ];
+	'thumbnail-load-error': [ { id: string } ];
 	'user-settings': [ { tabName?: string } ];
 	'window-fullscreen-change': [ boolean ];
 	'user-preference-changed': [ void ];

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -86,7 +86,7 @@ const api: IpcApi = {
 		ipcRendererInvoke( 'generateProposedSitePath', siteName ),
 	openLocalPath: ( path ) => ipcRendererSend( 'openLocalPath', path ),
 	showItemInFolder: ( path ) => ipcRendererSend( 'showItemInFolder', path ),
-	getThemeDetails: ( id ) => ipcRendererInvoke( 'getThemeDetails', id ),
+	loadThemeDetails: ( id ) => ipcRendererInvoke( 'loadThemeDetails', id ),
 	getThumbnailData: ( id ) => ipcRendererInvoke( 'getThumbnailData', id ),
 	getInstalledAppsAndTerminals: () => ipcRendererInvoke( 'getInstalledAppsAndTerminals' ),
 	importSite: ( { id, backupFile } ) => ipcRendererInvoke( 'importSite', { id, backupFile } ),

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -86,7 +86,8 @@ const api: IpcApi = {
 		ipcRendererInvoke( 'generateProposedSitePath', siteName ),
 	openLocalPath: ( path ) => ipcRendererSend( 'openLocalPath', path ),
 	showItemInFolder: ( path ) => ipcRendererSend( 'showItemInFolder', path ),
-	loadThemeDetails: ( id ) => ipcRendererInvoke( 'loadThemeDetails', id ),
+	loadThemeDetails: ( id, emitThemeDetailsLoadingEvent = true ) =>
+		ipcRendererInvoke( 'loadThemeDetails', id, emitThemeDetailsLoadingEvent ),
 	getThumbnailData: ( id ) => ipcRendererInvoke( 'getThumbnailData', id ),
 	getInstalledAppsAndTerminals: () => ipcRendererInvoke( 'getInstalledAppsAndTerminals' ),
 	importSite: ( { id, backupFile } ) => ipcRendererInvoke( 'importSite', { id, backupFile } ),

--- a/src/site-server.ts
+++ b/src/site-server.ts
@@ -14,7 +14,7 @@ import { createSiteViaCli, type CreateSiteOptions } from 'src/modules/cli/lib/cl
 import { executeCliCommand } from 'src/modules/cli/lib/execute-command';
 import { createScreenshotWindow } from 'src/screenshot-window';
 import { getSiteThumbnailPath } from 'src/storage/paths';
-import { loadUserData } from 'src/storage/user-data';
+import { loadUserData, lockAppdata, saveUserData, unlockAppdata } from 'src/storage/user-data';
 import type { BlueprintV1Declaration } from '@wp-playground/blueprints';
 
 export type WpCliResult = { stdout: string; stderr: string; exitCode: number };
@@ -395,10 +395,25 @@ export class SiteServer {
 			}
 
 			const themeDetailsParsed = JSON.parse( stdout );
-			return SiteServer.themeDetailsSchema.parse( themeDetailsParsed );
+			this.details.themeDetails = SiteServer.themeDetailsSchema.parse( themeDetailsParsed );
 		} catch ( error ) {
 			console.error( 'Failed to get theme details:', error );
-			return this.details.themeDetails;
+		}
+
+		return this.details.themeDetails;
+	}
+
+	async persistThemeDetails(): Promise< void > {
+		try {
+			await lockAppdata();
+			const userData = await loadUserData();
+			const existingSite = userData.sites.find( ( site ) => site.id === this.details.id );
+			if ( existingSite ) {
+				existingSite.themeDetails = this.details.themeDetails;
+			}
+			await saveUserData( userData );
+		} finally {
+			await unlockAppdata();
 		}
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-1236

## Proposed Changes

We recently introduced a regression where `SiteDetails.themeDetails` objects stopped being persisted to the appdata file. This caused two problems:

1. After restarting Studio, the Overview tab was missing the appropriate navigation buttons for stopped sites with block themes (`Site Editor`, etc). This happened because `themeDetails` object contained all empty values. 
2. The Overview tab always showed a loading state when focusing the app window. This happened because the `SiteDetails.themeDetails` object wasn't updated properly. https://github.com/Automattic/studio/pull/2420 alleviated this problem, but it kept appearing due to the underlying regression. 

This PR fixes the problem by:

1. Consolidating the logic for updating `themeDetails` in a single function in `src/ipc-handlers.ts`. Previously, there were multiple execution paths to achieve this, which I believe explains why this regression surfaced in the first place. 
2. Clean up the last remaining `updateSite` calls in `src/ipc-handlers.ts` that were using this function for an ambiguous purpose (maybe update the settings, but also update the appdata file). 
3. Add a `SiteDetails.persistThemeDetails` method that does what you'd expect (update the `themeDetails` object of the site in the appdata file).
4. Clarifying when the different IPC events are emitted, renaming them for clarity, and adding a `thumbnail-load-error` to reset the loading state if there's an error when loading the thumbnail.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Run `npm start`
2. Start a site
3. Open the appdata file (`~/Library/Application\ Support/Studio/appdata-v1.json`) and ensure that the site you just started has a `themeDetails` object that contains the values you'd expect
4. Focus the Studio window again
5. Ensure that there's no "loading state" flash in the Overview tab
6. Open wp-admin
7. Switch the theme
8. Focus the Studio window again
9. Ensure that the site thumbnail in the Overview tab reloads after a few seconds

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
