### PR TITLE
Revert winreg to 1.2.4 to avoid CLI install issue

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,6 +44,7 @@ updates:
           - "@php-wasm/*"
     ignore:
       - dependency-name: "eslint-plugin-studio"
+      - dependency-name: "winreg" # v1.2.5 has a known issue: https://github.com/fresc81/node-winreg/issues/65
 
   # Enable version updates for GitHub Actions
   - package-ecosystem: "github-actions"

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
 				"tar": "^7.5.2",
 				"ts-node": "^10.9.2",
 				"tus-js-client": "^4.3.1",
-				"winreg": "^1.2.5",
+				"winreg": "1.2.4",
 				"wpcom": "^7.1.1",
 				"wpcom-xhr-request": "^1.3.0",
 				"yargs": "^18.0.0",
@@ -28576,9 +28576,9 @@
 			}
 		},
 		"node_modules/winreg": {
-			"version": "1.2.5",
-			"resolved": "https://registry.npmjs.org/winreg/-/winreg-1.2.5.tgz",
-			"integrity": "sha512-uf7tHf+tw0B1y+x+mKTLHkykBgK2KMs3g+KlzmyMbLvICSHQyB/xOFjTT8qZ3oeTFyU7Bbj4FzXitGG6jvKhYw==",
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/winreg/-/winreg-1.2.4.tgz",
+			"integrity": "sha512-IHpzORub7kYlb8A43Iig3reOvlcBJGX9gZ0WycHhghHtA65X0LYnMRuJs+aH1abVnMJztQkvQNlltnbPi5aGIA==",
 			"license": "BSD-2-Clause"
 		},
 		"node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
 		"tar": "^7.5.2",
 		"ts-node": "^10.9.2",
 		"tus-js-client": "^4.3.1",
-		"winreg": "^1.2.5",
+		"winreg": "1.2.4",
 		"wpcom": "^7.1.1",
 		"wpcom-xhr-request": "^1.3.0",
 		"yargs": "^18.0.0",


### PR DESCRIPTION
## Summary
- Downgrade `winreg` from `^1.2.5` to `1.2.4` (pinned) to avoid a [known issue](https://github.com/fresc81/node-winreg/issues/65) that breaks the module
- add `winreg` to the Dependabot ignore list

Fixes STU-1240

## Test plan
1. Check out the PR branch and build the app on Windows.
2. Verify Windows CLI installation/uninstallation through the app settings → _Studio CLI_ toggle works correctly.
