### PR TITLE
Fix PHP version not reflected in wp-admin Site Health

### DIFF
--- a/cli/wordpress-server-child.ts
+++ b/cli/wordpress-server-child.ts
@@ -22,6 +22,7 @@ import {
 	InMemoryFilesystem,
 } from '@wp-playground/storage';
 import { WordPressInstallMode } from '@wp-playground/wordpress';
+import { DEFAULT_PHP_VERSION } from 'common/constants';
 import { isWordPressDirectory } from 'common/lib/fs-utils';
 import { getMuPlugins } from 'common/lib/mu-plugins';
 import { decodePassword } from 'common/lib/passwords';
@@ -173,11 +174,22 @@ async function getBaseRunCLIArgs(
 
 	let blueprintBundle: BlueprintBundle | undefined;
 
+	// Build blueprint contents with preferredVersions to ensure PHP version is respected
+	// This is necessary because @wp-playground/cli only reads preferredVersions from the blueprint
+	// when a BlueprintBundle is provided (rather than merging args.php into the blueprint)
+	// Precedence: 1) Studio config (explicit setting), 2) Blueprint's preferredVersions, 3) Default
+	const preferredVersions: { php: string; wp: string } = {
+		php:
+			config.phpVersion || config.blueprint?.contents.preferredVersions?.php || DEFAULT_PHP_VERSION,
+		wp: config.wpVersion || config.blueprint?.contents.preferredVersions?.wp || 'latest',
+	};
+
 	if ( config.blueprint ) {
 		config.blueprint.contents.constants = {
 			...config.blueprint.contents.constants,
 			...defaultConstants,
 		};
+		config.blueprint.contents.preferredVersions = preferredVersions;
 		const blueprintFs = new InMemoryFilesystem( {
 			'blueprint.json': JSON.stringify( config.blueprint.contents ),
 		} );
@@ -198,7 +210,10 @@ async function getBaseRunCLIArgs(
 		}
 	} else {
 		blueprintBundle = new InMemoryFilesystem( {
-			'blueprint.json': JSON.stringify( { constants: defaultConstants } ),
+			'blueprint.json': JSON.stringify( {
+				constants: defaultConstants,
+				preferredVersions,
+			} ),
 		} );
 	}
 


### PR DESCRIPTION
## Related issues

- Fixes STU-1237

## Proposed Changes

- Include `preferredVersions` in the blueprint JSON passed to Playground CLI
- This ensures the PHP version is correctly applied when a `BlueprintBundle` is provided
- The fix establishes proper precedence: Studio config > Blueprint's preferredVersions > Default

**Root cause:** When Studio passes a `BlueprintBundle` to Playground CLI's `runCLI()`, the `args.php` value is ignored. The CLI only reads `preferredVersions.php` from inside the blueprint JSON itself.

## Testing Instructions

1. Create a new site with default settings
   - Verify wp-admin → Tools → Site Health → Info → Server shows PHP 8.3 (default)
2. Change PHP version to 8.1 in Studio
   - Verify wp-admin Site Health shows PHP 8.1.x
3. Change PHP version to 8.0
   - Verify wp-admin Site Health shows PHP 8.0.x
4. Change PHP version back to default
   - Verify wp-admin Site Health shows PHP 8.3.x

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?