### PR TITLE
Fix line breaks in Add Site subheading

### DIFF
--- a/src/modules/add-site/components/options.tsx
+++ b/src/modules/add-site/components/options.tsx
@@ -92,7 +92,7 @@ export default function AddSiteOptions( { onOptionSelect }: AddSiteOptionsProps 
 			<Heading className="text-[32px] text-gray-900" weight={ 500 }>
 				{ __( 'Add a site' ) }
 			</Heading>
-			<Text className="text-[15px] font-light text-gray-700 w-72 mb-4">
+			<Text className="text-[15px] font-light text-gray-700 max-w-sm mb-4">
 				{ __( 'Add a clean site, start from a Blueprint or import site from a backup' ) }
 			</Text>
 			<OptionButton


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-1239

## Proposed Changes

- Changed the subheading container from fixed width to maximum width (384px)
- This also allows the container to be narrower when needed

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Start Studio with `npm start`
2. Switch language to Polish (or another language with longer translations)
3. Open the "Add site" modal
4. Verify the subheading text wraps into two lines instead of three

| Before | After |
|--------|--------|
| <img width="1982" height="1536" alt="CleanShot 2026-01-22 at 13 04 20@2x" src="https://github.com/user-attachments/assets/580f8bd9-fed4-4c3b-89a1-af074979931b" /> | <img width="1982" height="1536" alt="CleanShot 2026-01-22 at 13 03 32@2x" src="https://github.com/user-attachments/assets/1962fed4-2404-4d65-b783-377e7072756e" /> | 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
