### PR TITLE
Fix nightly WordPress version selection

### DIFF
--- a/cli/wordpress-server-child.ts
+++ b/cli/wordpress-server-child.ts
@@ -12,7 +12,6 @@
  */
 import { cpus } from 'os';
 import { dirname } from 'path';
-import { SupportedPHPVersion } from '@php-wasm/universal';
 import { BlueprintBundle } from '@wp-playground/blueprints';
 import { runCLI, RunCLIArgs, RunCLIServer } from '@wp-playground/cli';
 import {
@@ -229,10 +228,6 @@ async function getBaseRunCLIArgs(
 		blueprint: blueprintBundle,
 		wordpressInstallMode,
 	};
-
-	if ( config.phpVersion ) {
-		args.php = config.phpVersion as SupportedPHPVersion;
-	}
 
 	if ( config.wpVersion ) {
 		if ( isWordPressDevVersion( config.wpVersion ) ) {

--- a/common/lib/tests/wordpress-version-utils.test.ts
+++ b/common/lib/tests/wordpress-version-utils.test.ts
@@ -7,6 +7,7 @@ import {
 
 describe( 'isWordPressDevVersion', () => {
 	test( 'should identify WordPress development versions', () => {
+		expect( isWordPressDevVersion( 'nightly' ) ).toBe( true );
 		expect( isWordPressDevVersion( '6.8-beta2-59979' ) ).toBe( true );
 		expect( isWordPressDevVersion( '6.8-59979' ) ).toBe( true );
 		expect( isWordPressDevVersion( '6.8.3-59979' ) ).toBe( true );

--- a/common/lib/wordpress-version-utils.ts
+++ b/common/lib/wordpress-version-utils.ts
@@ -20,9 +20,9 @@ export function isValidWordPressVersion( version: string ): boolean {
 }
 
 export function isWordPressDevVersion( version: string ): boolean {
-	// Match nightly build patterns that end with a build number
-	// Examples: 6.8-alpha1-12345, 6.8-beta2-59979, 6.8-dev-12345, 6.8-59979
-	return /^\d+\.\d+(?:\.\d+)?(?:-[a-zA-Z0-9]+)*-\d+$/.test( version );
+	// Match 'nightly' keyword or nightly build patterns that end with a build number
+	// Examples: nightly, 6.8-alpha1-12345, 6.8-beta2-59979, 6.8-dev-12345, 6.8-59979
+	return version === 'nightly' || /^\d+\.\d+(?:\.\d+)?(?:-[a-zA-Z0-9]+)*-\d+$/.test( version );
 }
 
 export function isWordPressBetaVersion( version: string ): boolean {

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -30,6 +30,7 @@ import {
 import { getWordPressVersion } from 'common/lib/get-wordpress-version';
 import { isErrnoException } from 'common/lib/is-errno-exception';
 import { getAuthenticationUrl } from 'common/lib/oauth';
+import { isWordPressDevVersion } from 'common/lib/wordpress-version-utils';
 import { Snapshot } from 'common/types/snapshot';
 import { StatsGroup, StatsMetric } from 'common/types/stats';
 import { MAIN_MIN_WIDTH, SIDEBAR_WIDTH } from 'src/constants';
@@ -315,7 +316,7 @@ export async function updateSite(
 	}
 
 	if ( wpVersion ) {
-		options.wp = wpVersion;
+		options.wp = isWordPressDevVersion( wpVersion ) ? 'nightly' : wpVersion;
 	}
 
 	if ( updatedSite.enableXdebug !== currentSite.enableXdebug ) {

--- a/src/modules/cli/lib/cli-site-creator.ts
+++ b/src/modules/cli/lib/cli-site-creator.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { z } from 'zod';
+import { isWordPressDevVersion } from 'common/lib/wordpress-version-utils';
 import { SiteCommandLoggerAction } from 'common/logger-actions';
 import { sendIpcEventToRenderer } from 'src/ipc-utils';
 import { executeCliCommand } from './execute-command';
@@ -111,7 +112,8 @@ function buildCliArgs( options: CreateSiteOptions ): string[] {
 	}
 
 	if ( options.wpVersion ) {
-		args.push( '--wp', options.wpVersion );
+		const wp = isWordPressDevVersion( options.wpVersion ) ? 'nightly' : options.wpVersion;
+		args.push( '--wp', wp );
 	}
 
 	if ( options.phpVersion ) {


### PR DESCRIPTION
## Related issues

- Fixes STU-1242

## Proposed Changes

1. **Fix `isWordPressDevVersion()` to recognize `'nightly'` keyword** - The function now returns `true` for the literal string `'nightly'`, not just version patterns like `7.0-alpha-61507`

2. **Convert dev versions to `'nightly'` in Studio app** - When calling CLI from Studio UI with a dev version (e.g., `7.0-alpha-61507`), it's now converted to `'nightly'` before passing to CLI

3. **Remove redundant `args.php` assignment** - Follow-up cleanup from STU-1237; this parameter was ignored by Playground CLI when using BlueprintBundle

## Testing Instructions

1. Create a new site with nightly WordPress version
   - `studio site create --name "Test" --path ~/Studio/test --wp nightly`
   - Verify site starts and shows dev version in wp-admin
   
2. Change an existing site to nightly
   - `studio site set --path ~/Studio/existing-site --wp nightly`
   - Verify WordPress is updated and site shows dev version

3. From Studio app, change a site to nightly version and verify it works

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?