### PR TITLE
Update site selection behavior after site deletion

### DIFF
--- a/src/hooks/tests/use-site-details.test.tsx
+++ b/src/hooks/tests/use-site-details.test.tsx
@@ -68,6 +68,7 @@ describe( 'useSiteDetails', () => {
 		( getIpcApi as jest.Mock ).mockReturnValue( {
 			getSiteDetails: jest.fn().mockResolvedValue( mockSites ),
 			startServer: jest.fn( () => Promise.resolve() ),
+			deleteSite: jest.fn( () => Promise.resolve() ),
 		} );
 	} );
 
@@ -104,6 +105,62 @@ describe( 'useSiteDetails', () => {
 
 			// Verify that startServer was not called for any site
 			expect( getIpcApi().startServer ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'site deletion selection behavior', () => {
+		it( 'should select first site when deleting the currently selected site', async () => {
+			const { result } = renderHook( () => useSiteDetails(), { wrapper } );
+
+			await waitFor( () => {
+				expect( result.current.loadingSites ).toBe( false );
+			} );
+
+			// Select site-3 (the site we'll delete)
+			result.current.setSelectedSiteId( 'site-3' );
+
+			await waitFor( () => {
+				expect( result.current.selectedSite?.id ).toBe( 'site-3' );
+			} );
+
+			// Simulate that after deletion, site-3 is removed
+			const sitesAfterDeletion = mockSites.filter( ( site ) => site.id !== 'site-3' );
+			( getIpcApi().getSiteDetails as jest.Mock ).mockResolvedValueOnce( sitesAfterDeletion );
+
+			// Delete site-3
+			await result.current.deleteSite( 'site-3', false );
+
+			// Should select the first remaining site since the selected site was deleted
+			await waitFor( () => {
+				expect( result.current.selectedSite?.id ).toBe( 'site-1' );
+			} );
+		} );
+
+		it( 'should preserve selection when deleting a different site', async () => {
+			const { result } = renderHook( () => useSiteDetails(), { wrapper } );
+
+			await waitFor( () => {
+				expect( result.current.loadingSites ).toBe( false );
+			} );
+
+			// Select site-2 (NOT the site we'll delete)
+			result.current.setSelectedSiteId( 'site-2' );
+
+			await waitFor( () => {
+				expect( result.current.selectedSite?.id ).toBe( 'site-2' );
+			} );
+
+			// Simulate that after deletion, site-3 is removed (but site-2 still exists)
+			const sitesAfterDeletion = mockSites.filter( ( site ) => site.id !== 'site-3' );
+			( getIpcApi().getSiteDetails as jest.Mock ).mockResolvedValueOnce( sitesAfterDeletion );
+
+			// Delete site-3 (not the selected site)
+			await result.current.deleteSite( 'site-3', false );
+
+			// Selection should stay on site-2 since it still exists
+			await waitFor( () => {
+				expect( result.current.selectedSite?.id ).toBe( 'site-2' );
+			} );
 		} );
 	} );
 } );

--- a/src/hooks/use-site-details.tsx
+++ b/src/hooks/use-site-details.tsx
@@ -238,8 +238,14 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 			await deleteSite( id, removeLocal );
 			const newSites = await getIpcApi().getSiteDetails();
 			setSites( newSites );
-			const selectedSite = newSites.length ? newSites[ 0 ].id : '';
-			setSelectedSiteId( selectedSite );
+			// Only change selection if the currently selected site no longer exists
+			setSelectedSiteId( ( currentSelectedId ) => {
+				const selectedSiteStillExists = newSites.some( ( site ) => site.id === currentSelectedId );
+				if ( selectedSiteStillExists ) {
+					return currentSelectedId;
+				}
+				return newSites.length ? newSites[ 0 ].id : '';
+			} );
 			if ( selectedTab !== 'overview' ) {
 				setSelectedTab( 'overview' );
 			}


### PR DESCRIPTION
- Update site selection logic to preserve the currently selected site if it still exists after deletion.
- Add tests to verify that the first remaining site is selected when the currently selected site is deleted, and that selection remains unchanged when a different site is deleted.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-1241

## Proposed Changes

- Updated `onDeleteSite` to check if the currently selected site still exists after deletion
- If the selected site still exists (user switched to another site), the selection is preserved
- If the selected site was deleted, it switches to the first remaining site
- Added unit tests to verify both scenarios

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Start Studio with `npm start`
2. Create three sites (Site 1, Site 2, Site 3)
3. Delete Site 3
4. While the deletion is going on, quickly select Site 2
5. Check that Site 2 remains selected, and the selection doesn't change to Site 1

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
