### PR TITLE
Blueprints: Improve error handling for deeplink failures

### DIFF
--- a/src/__mocks__/electron.ts
+++ b/src/__mocks__/electron.ts
@@ -77,6 +77,7 @@ export const Menu = {
 
 export const shell = {
 	openExternal: vi.fn(),
+	openPath: vi.fn( async () => '' ),
 	trashItem: vi.fn(),
 };
 

--- a/src/lib/deeplink/handlers/add-site-with-blueprint.ts
+++ b/src/lib/deeplink/handlers/add-site-with-blueprint.ts
@@ -18,7 +18,7 @@ function getBlueprintDeeplinkErrorMessage( error: unknown ): string {
 		);
 	}
 
-	return __( 'The Blueprint could not be loaded. Please check the link and try again.' );
+	return __( 'Please check the link and try again.' );
 }
 
 /**

--- a/src/lib/deeplink/handlers/add-site-with-blueprint.ts
+++ b/src/lib/deeplink/handlers/add-site-with-blueprint.ts
@@ -1,11 +1,41 @@
-import { app, dialog } from 'electron';
+import { app, dialog, shell } from 'electron';
 import nodePath from 'path';
 import { __ } from '@wordpress/i18n';
 import fs from 'fs-extra';
 import { validateBlueprintData } from 'common/lib/blueprint-validation';
 import { sendIpcEventToRenderer } from 'src/ipc-utils';
 import { download } from 'src/lib/download';
+import { getLogsFilePath } from 'src/logging';
 import { getMainWindow } from 'src/main-window';
+
+function getBlueprintDeeplinkErrorMessage( error: unknown ): {
+	message: string;
+	showLogs: boolean;
+} {
+	if ( ! ( error instanceof Error ) ) {
+		return {
+			message: __( 'The Blueprint could not be loaded. Please check the link and try again.' ),
+			showLogs: false,
+		};
+	}
+
+	const errorMessage = error.message.toLowerCase();
+
+	const networkErrors = [ 'enotfound', 'econnrefused', 'etimedout', 'network' ];
+	if ( networkErrors.some( ( err ) => errorMessage.includes( err ) ) ) {
+		return {
+			message: __(
+				'Could not connect to the server. Please check your internet connection and try again.'
+			),
+			showLogs: true,
+		};
+	}
+
+	return {
+		message: __( 'The Blueprint could not be loaded. Please check the link and try again.' ),
+		showLogs: true,
+	};
+}
 
 /**
  * Handles the add-site deeplink callback.
@@ -77,16 +107,22 @@ export async function handleAddSiteWithBlueprint( urlObject: URL ): Promise< voi
 			} );
 		}
 
-		const errorDetail =
-			error instanceof Error
-				? error.message
-				: __( 'The Blueprint could not be loaded. Please check the link and try again.' );
+		const { message: userMessage, showLogs } = getBlueprintDeeplinkErrorMessage( error );
+		const buttons = showLogs ? [ __( 'Open Studio Logs' ), __( 'OK' ) ] : [ __( 'OK' ) ];
 
-		await dialog.showMessageBox( mainWindow, {
+		const response = await dialog.showMessageBox( mainWindow, {
 			type: 'error',
 			message: __( 'Failed to load Blueprint' ),
-			detail: errorDetail,
-			buttons: [ __( 'OK' ) ],
+			detail: userMessage,
+			buttons,
 		} );
+
+		if ( showLogs && response.response === 0 ) {
+			const logFilePath = getLogsFilePath();
+			const err = await shell.openPath( logFilePath );
+			if ( err ) {
+				console.error( `Error opening logs file: ${ logFilePath } ${ err }` );
+			}
+		}
 	}
 }

--- a/src/lib/deeplink/handlers/add-site-with-blueprint.ts
+++ b/src/lib/deeplink/handlers/add-site-with-blueprint.ts
@@ -8,26 +8,17 @@ import { download } from 'src/lib/download';
 import { getLogsFilePath } from 'src/logging';
 import { getMainWindow } from 'src/main-window';
 
-function getBlueprintDeeplinkErrorMessage( error: unknown ): {
-	message: string;
-	showLogs: boolean;
-} {
+function getBlueprintDeeplinkErrorMessage( error: unknown ): string {
 	const errorMessage = ( error instanceof Error ? error.message : '' ).toLowerCase();
 
 	const networkErrors = [ 'enotfound', 'econnrefused', 'etimedout', 'network' ];
 	if ( networkErrors.some( ( err ) => errorMessage.includes( err ) ) ) {
-		return {
-			message: __(
-				'Could not connect to the server. Please check your internet connection and try again.'
-			),
-			showLogs: true,
-		};
+		return __(
+			'Could not connect to the server. Please check your internet connection and try again.'
+		);
 	}
 
-	return {
-		message: __( 'The Blueprint could not be loaded. Please check the link and try again.' ),
-		showLogs: true,
-	};
+	return __( 'The Blueprint could not be loaded. Please check the link and try again.' );
 }
 
 /**
@@ -100,17 +91,14 @@ export async function handleAddSiteWithBlueprint( urlObject: URL ): Promise< voi
 			} );
 		}
 
-		const { message: userMessage, showLogs } = getBlueprintDeeplinkErrorMessage( error );
-		const buttons = showLogs ? [ __( 'Open Studio Logs' ), __( 'OK' ) ] : [ __( 'OK' ) ];
-
 		const response = await dialog.showMessageBox( mainWindow, {
 			type: 'error',
 			message: __( 'Failed to load Blueprint' ),
-			detail: userMessage,
-			buttons,
+			detail: getBlueprintDeeplinkErrorMessage( error ),
+			buttons: [ __( 'Open Studio Logs' ), __( 'OK' ) ],
 		} );
 
-		if ( showLogs && response.response === 0 ) {
+		if ( response.response === 0 ) {
 			const logFilePath = getLogsFilePath();
 			const err = await shell.openPath( logFilePath );
 			if ( err ) {

--- a/src/lib/deeplink/handlers/add-site-with-blueprint.ts
+++ b/src/lib/deeplink/handlers/add-site-with-blueprint.ts
@@ -12,14 +12,7 @@ function getBlueprintDeeplinkErrorMessage( error: unknown ): {
 	message: string;
 	showLogs: boolean;
 } {
-	if ( ! ( error instanceof Error ) ) {
-		return {
-			message: __( 'The Blueprint could not be loaded. Please check the link and try again.' ),
-			showLogs: false,
-		};
-	}
-
-	const errorMessage = error.message.toLowerCase();
+	const errorMessage = ( error instanceof Error ? error.message : '' ).toLowerCase();
 
 	const networkErrors = [ 'enotfound', 'econnrefused', 'etimedout', 'network' ];
 	if ( networkErrors.some( ( err ) => errorMessage.includes( err ) ) ) {

--- a/src/lib/deeplink/handlers/add-site-with-blueprint.ts
+++ b/src/lib/deeplink/handlers/add-site-with-blueprint.ts
@@ -96,6 +96,7 @@ export async function handleAddSiteWithBlueprint( urlObject: URL ): Promise< voi
 			message: __( 'Failed to load Blueprint' ),
 			detail: getBlueprintDeeplinkErrorMessage( error ),
 			buttons: [ __( 'Open Studio Logs' ), __( 'OK' ) ],
+			defaultId: 1,
 		} );
 
 		if ( response.response === 0 ) {

--- a/src/lib/deeplink/tests/add-site.test.ts
+++ b/src/lib/deeplink/tests/add-site.test.ts
@@ -222,7 +222,8 @@ describe( 'handleAddSiteWithBlueprint', () => {
 			expect( dialog.showMessageBox ).toHaveBeenCalledWith( mockMainWindow, {
 				type: 'error',
 				message: 'Failed to load Blueprint',
-				detail: expect.stringContaining( 'internet connection' ),
+				detail:
+					'Could not connect to the server. Please check your internet connection and try again.',
 				buttons: [ 'Open Studio Logs', 'OK' ],
 			} );
 		} );
@@ -240,7 +241,7 @@ describe( 'handleAddSiteWithBlueprint', () => {
 			expect( dialog.showMessageBox ).toHaveBeenCalledWith( mockMainWindow, {
 				type: 'error',
 				message: 'Failed to load Blueprint',
-				detail: expect.stringContaining( 'could not be loaded' ),
+				detail: 'The Blueprint could not be loaded. Please check the link and try again.',
 				buttons: [ 'Open Studio Logs', 'OK' ],
 			} );
 		} );

--- a/src/lib/deeplink/tests/add-site.test.ts
+++ b/src/lib/deeplink/tests/add-site.test.ts
@@ -1,4 +1,4 @@
-import { app, dialog, BrowserWindow } from 'electron';
+import { app, dialog, shell, BrowserWindow } from 'electron';
 import fs from 'fs-extra';
 import { vi, beforeAll, afterAll } from 'vitest';
 import { validateBlueprintData } from 'common/lib/blueprint-validation';
@@ -12,6 +12,9 @@ vi.mock( 'fs-extra' );
 vi.mock( 'src/ipc-utils' );
 vi.mock( 'src/lib/download' );
 vi.mock( 'src/main-window' );
+vi.mock( 'src/logging', () => ( {
+	getLogsFilePath: vi.fn( () => '/mock/path/to/logs.log' ),
+} ) );
 vi.mock( 'common/lib/blueprint-validation', () => ( {
 	validateBlueprintData: vi.fn(),
 } ) );
@@ -244,6 +247,21 @@ describe( 'handleAddSiteWithBlueprint', () => {
 				detail: 'The Blueprint could not be loaded. Please check the link and try again.',
 				buttons: [ 'Open Studio Logs', 'OK' ],
 			} );
+		} );
+
+		it( 'should open logs file when user clicks Open Studio Logs button', async () => {
+			const url = createBlueprintUrl( 'https://example.com/blueprint.json' );
+
+			vi.mocked( download ).mockRejectedValue( new Error( 'Some error' ) );
+			vi.mocked( fs.remove ).mockImplementation( async () => {} );
+			vi.mocked( dialog.showMessageBox ).mockResolvedValue( {
+				response: 0, // "Open Studio Logs" button
+				checkboxChecked: false,
+			} );
+
+			await handleAddSiteWithBlueprint( url );
+
+			expect( shell.openPath ).toHaveBeenCalledWith( '/mock/path/to/logs.log' );
 		} );
 	} );
 } );

--- a/src/lib/deeplink/tests/add-site.test.ts
+++ b/src/lib/deeplink/tests/add-site.test.ts
@@ -98,7 +98,7 @@ describe( 'handleAddSiteWithBlueprint', () => {
 		expect( dialog.showMessageBox ).toHaveBeenCalledWith( mockMainWindow, {
 			type: 'error',
 			message: 'Failed to load Blueprint',
-			detail: 'The Blueprint could not be loaded. Please check the link and try again.',
+			detail: 'Please check the link and try again.',
 			buttons: [ 'Open Studio Logs', 'OK' ],
 			defaultId: 1,
 		} );
@@ -119,7 +119,7 @@ describe( 'handleAddSiteWithBlueprint', () => {
 		expect( dialog.showMessageBox ).toHaveBeenCalledWith( mockMainWindow, {
 			type: 'error',
 			message: 'Failed to load Blueprint',
-			detail: 'The Blueprint could not be loaded. Please check the link and try again.',
+			detail: 'Please check the link and try again.',
 			buttons: [ 'Open Studio Logs', 'OK' ],
 			defaultId: 1,
 		} );
@@ -170,7 +170,7 @@ describe( 'handleAddSiteWithBlueprint', () => {
 		expect( dialog.showMessageBox ).toHaveBeenCalledWith( mockMainWindow, {
 			type: 'error',
 			message: 'Failed to load Blueprint',
-			detail: 'The Blueprint could not be loaded. Please check the link and try again.',
+			detail: 'Please check the link and try again.',
 			buttons: [ 'Open Studio Logs', 'OK' ],
 			defaultId: 1,
 		} );
@@ -210,7 +210,7 @@ describe( 'handleAddSiteWithBlueprint', () => {
 			expect( dialog.showMessageBox ).toHaveBeenCalledWith( mockMainWindow, {
 				type: 'error',
 				message: 'Failed to load Blueprint',
-				detail: 'The Blueprint could not be loaded. Please check the link and try again.',
+				detail: 'Please check the link and try again.',
 				buttons: [ 'Open Studio Logs', 'OK' ],
 				defaultId: 1,
 			} );
@@ -249,7 +249,7 @@ describe( 'handleAddSiteWithBlueprint', () => {
 			expect( dialog.showMessageBox ).toHaveBeenCalledWith( mockMainWindow, {
 				type: 'error',
 				message: 'Failed to load Blueprint',
-				detail: 'The Blueprint could not be loaded. Please check the link and try again.',
+				detail: 'Please check the link and try again.',
 				buttons: [ 'Open Studio Logs', 'OK' ],
 				defaultId: 1,
 			} );

--- a/src/lib/deeplink/tests/add-site.test.ts
+++ b/src/lib/deeplink/tests/add-site.test.ts
@@ -44,7 +44,7 @@ describe( 'handleAddSiteWithBlueprint', () => {
 		vi.mocked( fs.mkdir ).mockImplementation( async () => {} );
 		vi.mocked( getMainWindow ).mockResolvedValue( mockMainWindow );
 		vi.mocked( dialog.showMessageBox ).mockResolvedValue( {
-			response: 0,
+			response: 1,
 			checkboxChecked: false,
 		} );
 	} );
@@ -165,7 +165,7 @@ describe( 'handleAddSiteWithBlueprint', () => {
 		expect( dialog.showMessageBox ).toHaveBeenCalledWith( mockMainWindow, {
 			type: 'error',
 			message: expect.any( String ),
-			detail: 'Invalid Blueprint format',
+			detail: expect.any( String ),
 			buttons: expect.any( Array ),
 		} );
 	} );
@@ -206,6 +206,42 @@ describe( 'handleAddSiteWithBlueprint', () => {
 				message: expect.any( String ),
 				detail: expect.any( String ),
 				buttons: expect.any( Array ),
+			} );
+		} );
+	} );
+
+	describe( 'user-friendly error messages', () => {
+		it( 'should show user-friendly message for network connectivity errors', async () => {
+			const url = createBlueprintUrl( 'https://example.com/blueprint.json' );
+
+			vi.mocked( download ).mockRejectedValue( new Error( 'getaddrinfo ENOTFOUND example.com' ) );
+			vi.mocked( fs.remove ).mockImplementation( async () => {} );
+
+			await handleAddSiteWithBlueprint( url );
+
+			expect( dialog.showMessageBox ).toHaveBeenCalledWith( mockMainWindow, {
+				type: 'error',
+				message: 'Failed to load Blueprint',
+				detail: expect.stringContaining( 'internet connection' ),
+				buttons: [ 'Open Studio Logs', 'OK' ],
+			} );
+		} );
+
+		it( 'should show generic error message for other errors', async () => {
+			const url = createBlueprintUrl( 'https://example.com/blueprint.json' );
+
+			vi.mocked( download ).mockRejectedValue(
+				new Error( 'Request failed with status code: 500' )
+			);
+			vi.mocked( fs.remove ).mockImplementation( async () => {} );
+
+			await handleAddSiteWithBlueprint( url );
+
+			expect( dialog.showMessageBox ).toHaveBeenCalledWith( mockMainWindow, {
+				type: 'error',
+				message: 'Failed to load Blueprint',
+				detail: expect.stringContaining( 'could not be loaded' ),
+				buttons: [ 'Open Studio Logs', 'OK' ],
 			} );
 		} );
 	} );

--- a/src/lib/deeplink/tests/add-site.test.ts
+++ b/src/lib/deeplink/tests/add-site.test.ts
@@ -35,6 +35,16 @@ describe( 'handleAddSiteWithBlueprint', () => {
 		focus: vi.fn(),
 	} );
 
+	const expectErrorDialog = ( detail: string ) => {
+		expect( dialog.showMessageBox ).toHaveBeenCalledWith( mockMainWindow, {
+			type: 'error',
+			message: 'Failed to load Blueprint',
+			detail,
+			buttons: [ 'Open Studio Logs', 'OK' ],
+			defaultId: 1,
+		} );
+	};
+
 	const createBlueprintUrl = ( blueprintUrl: string ) => {
 		const encodedUrl = encodeURIComponent( blueprintUrl );
 		return new URL( `wp-studio://add-site?blueprint_url=${ encodedUrl }` );
@@ -95,13 +105,7 @@ describe( 'handleAddSiteWithBlueprint', () => {
 
 		expect( download ).not.toHaveBeenCalled();
 		expect( sendIpcEventToRenderer ).not.toHaveBeenCalled();
-		expect( dialog.showMessageBox ).toHaveBeenCalledWith( mockMainWindow, {
-			type: 'error',
-			message: 'Failed to load Blueprint',
-			detail: 'Please check the link and try again.',
-			buttons: [ 'Open Studio Logs', 'OK' ],
-			defaultId: 1,
-		} );
+		expectErrorDialog( 'Please check the link and try again.' );
 	} );
 
 	it( 'should handle download failure gracefully', async () => {
@@ -116,13 +120,7 @@ describe( 'handleAddSiteWithBlueprint', () => {
 		expect( download ).toHaveBeenCalled();
 		expect( sendIpcEventToRenderer ).not.toHaveBeenCalled();
 		expect( fs.remove ).toHaveBeenCalledWith( expect.stringContaining( 'blueprint-' ) );
-		expect( dialog.showMessageBox ).toHaveBeenCalledWith( mockMainWindow, {
-			type: 'error',
-			message: 'Failed to load Blueprint',
-			detail: 'Please check the link and try again.',
-			buttons: [ 'Open Studio Logs', 'OK' ],
-			defaultId: 1,
-		} );
+		expectErrorDialog( 'Please check the link and try again.' );
 	} );
 
 	it( 'should restore and focus window when minimized', async () => {
@@ -167,13 +165,7 @@ describe( 'handleAddSiteWithBlueprint', () => {
 		expect( download ).toHaveBeenCalled();
 		expect( sendIpcEventToRenderer ).not.toHaveBeenCalled();
 		expect( fs.remove ).toHaveBeenCalledWith( expect.stringContaining( 'blueprint-' ) );
-		expect( dialog.showMessageBox ).toHaveBeenCalledWith( mockMainWindow, {
-			type: 'error',
-			message: 'Failed to load Blueprint',
-			detail: 'Please check the link and try again.',
-			buttons: [ 'Open Studio Logs', 'OK' ],
-			defaultId: 1,
-		} );
+		expectErrorDialog( 'Please check the link and try again.' );
 	} );
 
 	describe( 'base64 blueprint handling', () => {
@@ -207,13 +199,7 @@ describe( 'handleAddSiteWithBlueprint', () => {
 			await handleAddSiteWithBlueprint( url );
 
 			expect( sendIpcEventToRenderer ).not.toHaveBeenCalled();
-			expect( dialog.showMessageBox ).toHaveBeenCalledWith( mockMainWindow, {
-				type: 'error',
-				message: 'Failed to load Blueprint',
-				detail: 'Please check the link and try again.',
-				buttons: [ 'Open Studio Logs', 'OK' ],
-				defaultId: 1,
-			} );
+			expectErrorDialog( 'Please check the link and try again.' );
 		} );
 	} );
 
@@ -226,14 +212,9 @@ describe( 'handleAddSiteWithBlueprint', () => {
 
 			await handleAddSiteWithBlueprint( url );
 
-			expect( dialog.showMessageBox ).toHaveBeenCalledWith( mockMainWindow, {
-				type: 'error',
-				message: 'Failed to load Blueprint',
-				detail:
-					'Could not connect to the server. Please check your internet connection and try again.',
-				buttons: [ 'Open Studio Logs', 'OK' ],
-				defaultId: 1,
-			} );
+			expectErrorDialog(
+				'Could not connect to the server. Please check your internet connection and try again.'
+			);
 		} );
 
 		it( 'should show generic error message for other errors', async () => {
@@ -246,13 +227,7 @@ describe( 'handleAddSiteWithBlueprint', () => {
 
 			await handleAddSiteWithBlueprint( url );
 
-			expect( dialog.showMessageBox ).toHaveBeenCalledWith( mockMainWindow, {
-				type: 'error',
-				message: 'Failed to load Blueprint',
-				detail: 'Please check the link and try again.',
-				buttons: [ 'Open Studio Logs', 'OK' ],
-				defaultId: 1,
-			} );
+			expectErrorDialog( 'Please check the link and try again.' );
 		} );
 
 		it( 'should open logs file when user clicks Open Studio Logs button', async () => {

--- a/src/lib/deeplink/tests/add-site.test.ts
+++ b/src/lib/deeplink/tests/add-site.test.ts
@@ -97,9 +97,10 @@ describe( 'handleAddSiteWithBlueprint', () => {
 		expect( sendIpcEventToRenderer ).not.toHaveBeenCalled();
 		expect( dialog.showMessageBox ).toHaveBeenCalledWith( mockMainWindow, {
 			type: 'error',
-			message: expect.any( String ),
-			detail: expect.any( String ),
-			buttons: expect.any( Array ),
+			message: 'Failed to load Blueprint',
+			detail: 'The Blueprint could not be loaded. Please check the link and try again.',
+			buttons: [ 'Open Studio Logs', 'OK' ],
+			defaultId: 1,
 		} );
 	} );
 
@@ -117,9 +118,10 @@ describe( 'handleAddSiteWithBlueprint', () => {
 		expect( fs.remove ).toHaveBeenCalledWith( expect.stringContaining( 'blueprint-' ) );
 		expect( dialog.showMessageBox ).toHaveBeenCalledWith( mockMainWindow, {
 			type: 'error',
-			message: expect.any( String ),
-			detail: expect.any( String ),
-			buttons: expect.any( Array ),
+			message: 'Failed to load Blueprint',
+			detail: 'The Blueprint could not be loaded. Please check the link and try again.',
+			buttons: [ 'Open Studio Logs', 'OK' ],
+			defaultId: 1,
 		} );
 	} );
 
@@ -167,9 +169,10 @@ describe( 'handleAddSiteWithBlueprint', () => {
 		expect( fs.remove ).toHaveBeenCalledWith( expect.stringContaining( 'blueprint-' ) );
 		expect( dialog.showMessageBox ).toHaveBeenCalledWith( mockMainWindow, {
 			type: 'error',
-			message: expect.any( String ),
-			detail: expect.any( String ),
-			buttons: expect.any( Array ),
+			message: 'Failed to load Blueprint',
+			detail: 'The Blueprint could not be loaded. Please check the link and try again.',
+			buttons: [ 'Open Studio Logs', 'OK' ],
+			defaultId: 1,
 		} );
 	} );
 
@@ -206,9 +209,10 @@ describe( 'handleAddSiteWithBlueprint', () => {
 			expect( sendIpcEventToRenderer ).not.toHaveBeenCalled();
 			expect( dialog.showMessageBox ).toHaveBeenCalledWith( mockMainWindow, {
 				type: 'error',
-				message: expect.any( String ),
-				detail: expect.any( String ),
-				buttons: expect.any( Array ),
+				message: 'Failed to load Blueprint',
+				detail: 'The Blueprint could not be loaded. Please check the link and try again.',
+				buttons: [ 'Open Studio Logs', 'OK' ],
+				defaultId: 1,
 			} );
 		} );
 	} );
@@ -228,6 +232,7 @@ describe( 'handleAddSiteWithBlueprint', () => {
 				detail:
 					'Could not connect to the server. Please check your internet connection and try again.',
 				buttons: [ 'Open Studio Logs', 'OK' ],
+				defaultId: 1,
 			} );
 		} );
 
@@ -246,6 +251,7 @@ describe( 'handleAddSiteWithBlueprint', () => {
 				message: 'Failed to load Blueprint',
 				detail: 'The Blueprint could not be loaded. Please check the link and try again.',
 				buttons: [ 'Open Studio Logs', 'OK' ],
+				defaultId: 1,
 			} );
 		} );
 

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -169,6 +169,7 @@ vi.mock( 'electron', () => {
 		},
 		BrowserWindow: MockBrowserWindow,
 		shell: {
+			openPath: vi.fn( async () => '' ),
 			trashItem: vi.fn(),
 		},
 		Menu: vi.fn(),


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Resolves STU-1209

## Proposed Changes

- add user-friendly error messages when Blueprint deeplink open fails
- add related tests 

| Before | After |
|--------|--------|
| <img width="2704" height="2044" alt="CleanShot 2026-01-23 at 10 53 59@2x" src="https://github.com/user-attachments/assets/34a10a96-a283-4cc2-9b02-aabed8df8299" /> | <img width="2236" height="1740" alt="CleanShot 2026-01-29 at 14 02 40@2x" src="https://github.com/user-attachments/assets/bbfdd466-5a89-459a-88ab-30f061f7c7a4" /> |
| <img width="2704" height="2044" alt="CleanShot 2026-01-23 at 10 49 15@2x" src="https://github.com/user-attachments/assets/cc630327-abda-4519-9f5d-731e71bf8279" /> | <img width="2236" height="1740" alt="CleanShot 2026-01-29 at 14 04 33@2x" src="https://github.com/user-attachments/assets/c3bae7f0-3bb8-4ceb-8b89-4353eeadbfa9" /> |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR branch and build the app with `npm install && npm start`.
2. Try opening first two broken Blueprint deeplinks at https://jsbin.com/kulaqijega/1/edit?html,css,output or try these:

```
## "Please check the link and try again." (non-network errors)

# Invalid base64 JSON (parse failure)
wp-studio://add-site?blueprint=bm90LXZhbGlkLWpzb24=

# Invalid blueprint URL (malformed URL)
wp-studio://add-site?blueprint_url=not-a-url

# Valid JSON but invalid blueprint schema
wp-studio://add-site?blueprint=eyJmb28iOiJiYXIifQ==

## "Could not connect to the server..." (network error)

# Non-existent host (ENOTFOUND)
wp-studio://add-site?blueprint_url=https%3A%2F%2Fthis-domain-does-not-exist-xyz123.example%2Fblueprint.json
```

3. Both should open an user-friendly error message with option to see the exact error message in the Studio app logs.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
