### PR TITLE
Fix Windows terminal not finding Studio CLI in PATH

### DIFF
--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -833,17 +833,16 @@ export async function openTerminalAtPath( _event: IpcMainInvokeEvent, targetPath
 		// Ensure the Studio CLI bin directory is in the PATH for the spawned terminal.
 		// Child processes inherit the environment from the Electron process, which may have
 		// been started before the CLI was installed or PATH was updated in the registry.
-		const cliBinPath = unversionedBinDirPath;
 		const isCliInstalled = await isStudioCliInstalled();
 		let env: NodeJS.ProcessEnv | undefined;
-		if ( isCliInstalled && cliBinPath ) {
+		if ( isCliInstalled ) {
 			const currentPath = process.env.PATH || '';
 			const pathEntries = currentPath.split( ';' ).map( ( p ) => p.toLowerCase() );
-			if ( ! pathEntries.includes( cliBinPath.toLowerCase() ) ) {
+			if ( ! pathEntries.includes( unversionedBinDirPath.toLowerCase() ) ) {
 				env = { ...process.env };
 				delete env.PATH;
 				delete env.Path;
-				env.PATH = `${ cliBinPath };${ currentPath }`;
+				env.PATH = `${ unversionedBinDirPath };${ currentPath }`;
 			}
 		}
 

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -62,6 +62,8 @@ import { getLogsFilePath, writeLogToFile, type LogLevel } from 'src/logging';
 import { getMainWindow } from 'src/main-window';
 import { popupMenu, setupMenu } from 'src/menu';
 import { editSiteViaCli, EditSiteOptions } from 'src/modules/cli/lib/cli-site-editor';
+import { isStudioCliInstalled } from 'src/modules/cli/lib/ipc-handlers';
+import { unversionedBinDirPath } from 'src/modules/cli/lib/windows-installation-manager';
 import { shouldExcludeFromSync, shouldLimitDepth } from 'src/modules/sync/lib/tree-utils';
 import { supportedEditorConfig, SupportedEditor } from 'src/modules/user-settings/lib/editor';
 import { getUserTerminal } from 'src/modules/user-settings/lib/ipc-handlers';
@@ -831,9 +833,10 @@ export async function openTerminalAtPath( _event: IpcMainInvokeEvent, targetPath
 		// Ensure the Studio CLI bin directory is in the PATH for the spawned terminal.
 		// Child processes inherit the environment from the Electron process, which may have
 		// been started before the CLI was installed or PATH was updated in the registry.
-		const cliBinPath = windowsHelpers.getWindowsCliBinPath();
+		const cliBinPath = unversionedBinDirPath;
+		const isCliInstalled = await isStudioCliInstalled();
 		let env: NodeJS.ProcessEnv | undefined;
-		if ( cliBinPath ) {
+		if ( isCliInstalled && cliBinPath ) {
 			const currentPath = process.env.PATH || '';
 			const pathEntries = currentPath.split( ';' ).map( ( p ) => p.toLowerCase() );
 			if ( ! pathEntries.includes( cliBinPath.toLowerCase() ) ) {

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -834,10 +834,13 @@ export async function openTerminalAtPath( _event: IpcMainInvokeEvent, targetPath
 		const cliBinPath = windowsHelpers.getWindowsCliBinPath();
 		let env: NodeJS.ProcessEnv | undefined;
 		if ( cliBinPath ) {
-			const currentPath = process.env.Path || process.env.PATH || '';
+			const currentPath = process.env.PATH || '';
 			const pathEntries = currentPath.split( ';' ).map( ( p ) => p.toLowerCase() );
 			if ( ! pathEntries.includes( cliBinPath.toLowerCase() ) ) {
-				env = { ...process.env, Path: `${ cliBinPath };${ currentPath }` };
+				env = { ...process.env };
+				delete env.PATH;
+				delete env.Path;
+				env.PATH = `${ cliBinPath };${ currentPath }`;
 			}
 		}
 

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -828,8 +828,22 @@ export async function openTerminalAtPath( _event: IpcMainInvokeEvent, targetPath
 			return promiseExec( `start "" "warp://action/new_tab?path=${ encodedPath }"` );
 		}
 
+		// Ensure the Studio CLI bin directory is in the PATH for the spawned terminal.
+		// Child processes inherit the environment from the Electron process, which may have
+		// been started before the CLI was installed or PATH was updated in the registry.
+		const cliBinPath = windowsHelpers.getWindowsCliBinPath();
+		let env: NodeJS.ProcessEnv | undefined;
+		if ( cliBinPath ) {
+			const currentPath = process.env.Path || process.env.PATH || '';
+			const pathEntries = currentPath.split( ';' ).map( ( p ) => p.toLowerCase() );
+			if ( ! pathEntries.includes( cliBinPath.toLowerCase() ) ) {
+				env = { ...process.env, Path: `${ cliBinPath };${ currentPath }` };
+			}
+		}
+
 		return promiseExec( `start "Command Prompt" ${ defaultShell }`, {
 			cwd: targetPath,
+			env,
 		} );
 	} else if ( platform === 'linux' ) {
 		return promiseExec( `gnome-terminal --working-directory=${ targetPath }` );

--- a/src/lib/windows-helpers.ts
+++ b/src/lib/windows-helpers.ts
@@ -3,8 +3,8 @@ import path from 'path';
 import sudo from '@vscode/sudo-prompt';
 import { __ } from '@wordpress/i18n';
 import { getMainWindow } from 'src/main-window';
+import { unversionedBinDirPath } from 'src/modules/cli/lib/windows-installation-manager';
 import { loadUserData, updateAppdata } from 'src/storage/user-data';
-
 /**
  * Gets the Studio CLI bin directory path on Windows.
  *
@@ -18,9 +18,7 @@ export function getWindowsCliBinPath(): string | undefined {
 		return undefined;
 	}
 
-	// This matches the `unversionedBinDirPath` calculation in windows-installation-manager.ts:
-	// path.resolve( path.dirname( app.getPath( 'exe' ) ), '../bin' )
-	return path.resolve( path.dirname( app.getPath( 'exe' ) ), '../bin' );
+	return unversionedBinDirPath;
 }
 
 export async function promptWindowsSpeedUpSites( {

--- a/src/lib/windows-helpers.ts
+++ b/src/lib/windows-helpers.ts
@@ -5,6 +5,24 @@ import { __ } from '@wordpress/i18n';
 import { getMainWindow } from 'src/main-window';
 import { loadUserData, updateAppdata } from 'src/storage/user-data';
 
+/**
+ * Gets the Studio CLI bin directory path on Windows.
+ *
+ * This uses the same path calculation as WindowsCliInstallationManager.
+ * In production: C:\Users\<USERNAME>\AppData\Local\studio\bin
+ *
+ * @returns The CLI bin directory path, or undefined on non-Windows platforms.
+ */
+export function getWindowsCliBinPath(): string | undefined {
+	if ( process.platform !== 'win32' ) {
+		return undefined;
+	}
+
+	// This matches the `unversionedBinDirPath` calculation in windows-installation-manager.ts:
+	// path.resolve( path.dirname( app.getPath( 'exe' ) ), '../bin' )
+	return path.resolve( path.dirname( app.getPath( 'exe' ) ), '../bin' );
+}
+
 export async function promptWindowsSpeedUpSites( {
 	skipIfAlreadyPrompted,
 }: {

--- a/src/lib/windows-helpers.ts
+++ b/src/lib/windows-helpers.ts
@@ -3,23 +3,7 @@ import path from 'path';
 import sudo from '@vscode/sudo-prompt';
 import { __ } from '@wordpress/i18n';
 import { getMainWindow } from 'src/main-window';
-import { unversionedBinDirPath } from 'src/modules/cli/lib/windows-installation-manager';
 import { loadUserData, updateAppdata } from 'src/storage/user-data';
-/**
- * Gets the Studio CLI bin directory path on Windows.
- *
- * This uses the same path calculation as WindowsCliInstallationManager.
- * In production: C:\Users\<USERNAME>\AppData\Local\studio\bin
- *
- * @returns The CLI bin directory path, or undefined on non-Windows platforms.
- */
-export function getWindowsCliBinPath(): string | undefined {
-	if ( process.platform !== 'win32' ) {
-		return undefined;
-	}
-
-	return unversionedBinDirPath;
-}
 
 export async function promptWindowsSpeedUpSites( {
 	skipIfAlreadyPrompted,

--- a/src/modules/cli/lib/windows-installation-manager.ts
+++ b/src/modules/cli/lib/windows-installation-manager.ts
@@ -9,7 +9,7 @@ import { getMainWindow } from 'src/main-window';
 import { StudioCliInstallationManager } from 'src/modules/cli/lib/ipc-handlers';
 
 // `unversionedBinDirPath` resolves to C:\Users\<USERNAME>\AppData\Local\studio\bin
-const unversionedBinDirPath = path.resolve( path.dirname( app.getPath( 'exe' ) ), '../bin' );
+export const unversionedBinDirPath = path.resolve( path.dirname( app.getPath( 'exe' ) ), '../bin' );
 const PATH_KEY = 'Path';
 
 const currentUserRegistry = new Registry( {


### PR DESCRIPTION
## Related issues

- Closes STU-1246

## Root Cause:

The Studio CLI is installed from within Studio itself, which updates the Windows Registry PATH. However, the running Electron process doesn't automatically pick up registry changes, it keeps its original PATH from when it launched. So when Studio spawns Command Prompt, the terminal inherits the old PATH (without the CLI directory) from Studio.

Without this fix, users would need to close and reopen Studio after installing the CLI for the terminal shortcut to work.


## Proposed Changes

- Added `getWindowsCliBinPath()` function to `src/lib/windows-helpers.ts` that computes the Studio CLI bin directory path
- Updated `openTerminalAtPath()` in `src/ipc-handlers.ts` to prepend the CLI bin path to the PATH environment variable when spawning Command Prompt on Windows
- Solution preserves all system paths while ensuring the CLI bin directory is available

## Testing Instructions

- On Windows, build and install the app (`npm run make`)
- Open Studio and create a site (or use an existing one)
- Install the Studio CLI via Settings if not already installed
- Use Studio's "Open Terminal" shortcut to open Command Prompt
- Type `studio --version` in the terminal - it should work
- Verify that system commands like `where` still work (confirms system PATH is preserved)

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?