### PR TITLE
Make Windows CLI installation tolerate app reinstalls

### DIFF
--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -63,7 +63,7 @@ import { getMainWindow } from 'src/main-window';
 import { popupMenu, setupMenu } from 'src/menu';
 import { editSiteViaCli, EditSiteOptions } from 'src/modules/cli/lib/cli-site-editor';
 import { isStudioCliInstalled } from 'src/modules/cli/lib/ipc-handlers';
-import { unversionedBinDirPath } from 'src/modules/cli/lib/windows-installation-manager';
+import { STABLE_BIN_DIR_PATH } from 'src/modules/cli/lib/windows-installation-manager';
 import { shouldExcludeFromSync, shouldLimitDepth } from 'src/modules/sync/lib/tree-utils';
 import { supportedEditorConfig, SupportedEditor } from 'src/modules/user-settings/lib/editor';
 import { getUserTerminal } from 'src/modules/user-settings/lib/ipc-handlers';
@@ -838,11 +838,11 @@ export async function openTerminalAtPath( _event: IpcMainInvokeEvent, targetPath
 		if ( isCliInstalled ) {
 			const currentPath = process.env.PATH || '';
 			const pathEntries = currentPath.split( ';' ).map( ( p ) => p.toLowerCase() );
-			if ( ! pathEntries.includes( unversionedBinDirPath.toLowerCase() ) ) {
+			if ( ! pathEntries.includes( STABLE_BIN_DIR_PATH.toLowerCase() ) ) {
 				env = { ...process.env };
 				delete env.PATH;
 				delete env.Path;
-				env.PATH = `${ unversionedBinDirPath };${ currentPath }`;
+				env.PATH = `${ STABLE_BIN_DIR_PATH };${ currentPath }`;
 			}
 		}
 

--- a/src/modules/cli/lib/windows-installation-manager.ts
+++ b/src/modules/cli/lib/windows-installation-manager.ts
@@ -8,7 +8,7 @@ import Registry from 'winreg'; // don't update winreg to 1.2.5 - https://github.
 import { getMainWindow } from 'src/main-window';
 import { StudioCliInstallationManager } from 'src/modules/cli/lib/ipc-handlers';
 
-// `stableBinDirPath` resolves to C:\Users\<USERNAME>\AppData\Local\studio\bin
+// `STABLE_BIN_DIR_PATH` resolves to C:\Users\<USERNAME>\AppData\Local\studio\bin
 export const STABLE_BIN_DIR_PATH = path.resolve( path.dirname( app.getPath( 'exe' ) ), '../bin' );
 const PATH_KEY = 'Path';
 

--- a/src/modules/cli/lib/windows-installation-manager.ts
+++ b/src/modules/cli/lib/windows-installation-manager.ts
@@ -29,25 +29,8 @@ export class WindowsCliInstallationManager implements StudioCliInstallationManag
 	 */
 	async isCliInstalled(): Promise< boolean > {
 		try {
-			const currentPath = await this.getPathFromRegistry();
-
-			// Return true if we are running the development version of the app and the production CLI is installed
-			if ( process.env.NODE_ENV !== 'production' && process.env.LOCALAPPDATA ) {
-				const prodStudioCliDir = path.join( process.env.LOCALAPPDATA, 'studio', 'bin' );
-				if ( this.isStudioCliInPath( currentPath, prodStudioCliDir ) ) {
-					return true;
-				}
-			}
-
-			if ( ! this.isStudioCliInPath( currentPath ) ) {
-				return false;
-			}
-
-			if ( ! existsSync( stableBinDirPath ) ) {
-				return false;
-			}
-
-			return true;
+			const isStudioCliDirInPath = await this.isStudioCliDirInPath();
+			return isStudioCliDirInPath && existsSync( stableBinDirPath );
 		} catch ( error ) {
 			console.error( 'Failed to check installation status of CLI', error );
 			return false;
@@ -55,8 +38,7 @@ export class WindowsCliInstallationManager implements StudioCliInstallationManag
 	}
 
 	async updateWindowsCliVersionedPathIfNeeded(): Promise< void > {
-		const currentPath = await this.getPathFromRegistry();
-		if ( this.isStudioCliInPath( currentPath ) ) {
+		if ( await this.isStudioCliDirInPath() ) {
 			await this.installProxyBatFile();
 		}
 	}
@@ -145,8 +127,16 @@ export class WindowsCliInstallationManager implements StudioCliInstallationManag
 		} );
 	}
 
-	private isStudioCliInPath( pathValue: string, studioCliDir: string = stableBinDirPath ): boolean {
-		return pathValue
+	private async isStudioCliDirInPath(): Promise< boolean > {
+		let studioCliDir = stableBinDirPath;
+
+		// Return true if we are running the development version of the app and the production CLI is installed
+		if ( process.env.NODE_ENV !== 'production' && process.env.LOCALAPPDATA ) {
+			studioCliDir = path.join( process.env.LOCALAPPDATA, 'studio', 'bin' );
+		}
+
+		const currentPath = await this.getPathFromRegistry();
+		return currentPath
 			.split( ';' )
 			.map( ( item ) => item.trim().toLowerCase() )
 			.includes( studioCliDir.toLowerCase() );
@@ -155,11 +145,6 @@ export class WindowsCliInstallationManager implements StudioCliInstallationManag
 	private async installPath(): Promise< void > {
 		try {
 			const currentPath = await this.getPathFromRegistry();
-
-			if ( this.isStudioCliInPath( currentPath ) ) {
-				return;
-			}
-
 			const updatedPath = currentPath
 				.split( ';' )
 				.map( ( p ) => p.trim() )

--- a/src/modules/cli/lib/windows-installation-manager.ts
+++ b/src/modules/cli/lib/windows-installation-manager.ts
@@ -9,7 +9,7 @@ import { getMainWindow } from 'src/main-window';
 import { StudioCliInstallationManager } from 'src/modules/cli/lib/ipc-handlers';
 
 // `stableBinDirPath` resolves to C:\Users\<USERNAME>\AppData\Local\studio\bin
-export const stableBinDirPath = path.resolve( path.dirname( app.getPath( 'exe' ) ), '../bin' );
+export const STABLE_BIN_DIR_PATH = path.resolve( path.dirname( app.getPath( 'exe' ) ), '../bin' );
 const PATH_KEY = 'Path';
 
 const currentUserRegistry = new Registry( {
@@ -30,7 +30,7 @@ export class WindowsCliInstallationManager implements StudioCliInstallationManag
 	async isCliInstalled(): Promise< boolean > {
 		try {
 			const isStudioCliDirInPath = await this.isStudioCliDirInPath();
-			return isStudioCliDirInPath && existsSync( stableBinDirPath );
+			return isStudioCliDirInPath && existsSync( STABLE_BIN_DIR_PATH );
 		} catch ( error ) {
 			console.error( 'Failed to check installation status of CLI', error );
 			return false;
@@ -128,7 +128,7 @@ export class WindowsCliInstallationManager implements StudioCliInstallationManag
 	}
 
 	private async isStudioCliDirInPath(): Promise< boolean > {
-		let studioCliDir = stableBinDirPath;
+		let studioCliDir = STABLE_BIN_DIR_PATH;
 
 		// Return true if we are running the development version of the app and the production CLI is installed
 		if ( process.env.NODE_ENV !== 'production' && process.env.LOCALAPPDATA ) {
@@ -149,7 +149,7 @@ export class WindowsCliInstallationManager implements StudioCliInstallationManag
 				.split( ';' )
 				.map( ( p ) => p.trim() )
 				.filter( Boolean )
-				.concat( stableBinDirPath )
+				.concat( STABLE_BIN_DIR_PATH )
 				.join( ';' );
 
 			await this.setPathInRegistry( updatedPath );
@@ -168,17 +168,17 @@ export class WindowsCliInstallationManager implements StudioCliInstallationManag
 	 */
 	private async installProxyBatFile(): Promise< void > {
 		try {
-			await mkdir( stableBinDirPath, { recursive: true } );
+			await mkdir( STABLE_BIN_DIR_PATH, { recursive: true } );
 
 			const versionedCliPath = path.join(
 				path.dirname( app.getPath( 'exe' ) ),
 				'resources/bin/studio-cli.bat'
 			);
-			const relativeVersionedCliPath = path.relative( stableBinDirPath, versionedCliPath );
+			const relativeVersionedCliPath = path.relative( STABLE_BIN_DIR_PATH, versionedCliPath );
 
 			const content = `@echo off\n"%~dp0\\${ relativeVersionedCliPath }" %*`;
 
-			await writeFile( path.join( stableBinDirPath, 'studio.bat' ), content );
+			await writeFile( path.join( STABLE_BIN_DIR_PATH, 'studio.bat' ), content );
 		} catch ( error ) {
 			Sentry.captureException( error );
 			console.error( 'Failed to install CLI: Proxy Bat file', error );
@@ -194,7 +194,7 @@ export class WindowsCliInstallationManager implements StudioCliInstallationManag
 		const currentPath = await this.getPathFromRegistry();
 		const newPath = currentPath
 			.split( ';' )
-			.filter( ( item ) => item.trim().toLowerCase() !== stableBinDirPath.toLowerCase() )
+			.filter( ( item ) => item.trim().toLowerCase() !== STABLE_BIN_DIR_PATH.toLowerCase() )
 			.join( ';' );
 
 		await this.setPathInRegistry( newPath );

--- a/src/modules/cli/lib/windows-installation-manager.ts
+++ b/src/modules/cli/lib/windows-installation-manager.ts
@@ -144,6 +144,10 @@ export class WindowsCliInstallationManager implements StudioCliInstallationManag
 
 	private async installPath(): Promise< void > {
 		try {
+			if ( await this.isStudioCliDirInPath() ) {
+				return;
+			}
+
 			const currentPath = await this.getPathFromRegistry();
 			const updatedPath = currentPath
 				.split( ';' )
@@ -155,7 +159,7 @@ export class WindowsCliInstallationManager implements StudioCliInstallationManag
 			await this.setPathInRegistry( updatedPath );
 		} catch ( error ) {
 			Sentry.captureException( error );
-			console.error( 'Failed to install CLI', error );
+			console.error( 'Failed to install CLI path', error );
 		}
 	}
 

--- a/src/modules/cli/lib/windows-installation-manager.ts
+++ b/src/modules/cli/lib/windows-installation-manager.ts
@@ -8,8 +8,8 @@ import Registry from 'winreg'; // don't update winreg to 1.2.5 - https://github.
 import { getMainWindow } from 'src/main-window';
 import { StudioCliInstallationManager } from 'src/modules/cli/lib/ipc-handlers';
 
-// `unversionedBinDirPath` resolves to C:\Users\<USERNAME>\AppData\Local\studio\bin
-const unversionedBinDirPath = path.resolve( path.dirname( app.getPath( 'exe' ) ), '../bin' );
+// `stableBinDirPath` resolves to C:\Users\<USERNAME>\AppData\Local\studio\bin
+const stableBinDirPath = path.resolve( path.dirname( app.getPath( 'exe' ) ), '../bin' );
 const PATH_KEY = 'Path';
 
 const currentUserRegistry = new Registry( {
@@ -24,6 +24,9 @@ export class WindowsCliInstallationManager implements StudioCliInstallationManag
 		}
 	}
 
+	/**
+	 * Check if the stable bin directory has been created and if it's contained in the registry PATH.
+	 */
 	async isCliInstalled(): Promise< boolean > {
 		try {
 			const currentPath = await this.getPathFromRegistry();
@@ -40,7 +43,7 @@ export class WindowsCliInstallationManager implements StudioCliInstallationManag
 				return false;
 			}
 
-			if ( ! existsSync( unversionedBinDirPath ) ) {
+			if ( ! existsSync( stableBinDirPath ) ) {
 				return false;
 			}
 
@@ -52,7 +55,8 @@ export class WindowsCliInstallationManager implements StudioCliInstallationManag
 	}
 
 	async updateWindowsCliVersionedPathIfNeeded(): Promise< void > {
-		if ( await this.isCliInstalled() ) {
+		const currentPath = await this.getPathFromRegistry();
+		if ( this.isStudioCliInPath( currentPath ) ) {
 			await this.installProxyBatFile();
 		}
 	}
@@ -141,10 +145,7 @@ export class WindowsCliInstallationManager implements StudioCliInstallationManag
 		} );
 	}
 
-	private isStudioCliInPath(
-		pathValue: string,
-		studioCliDir: string = unversionedBinDirPath
-	): boolean {
+	private isStudioCliInPath( pathValue: string, studioCliDir: string = stableBinDirPath ): boolean {
 		return pathValue
 			.split( ';' )
 			.map( ( item ) => item.trim().toLowerCase() )
@@ -163,7 +164,7 @@ export class WindowsCliInstallationManager implements StudioCliInstallationManag
 				.split( ';' )
 				.map( ( p ) => p.trim() )
 				.filter( Boolean )
-				.concat( unversionedBinDirPath )
+				.concat( stableBinDirPath )
 				.join( ';' );
 
 			await this.setPathInRegistry( updatedPath );
@@ -174,7 +175,7 @@ export class WindowsCliInstallationManager implements StudioCliInstallationManag
 	}
 
 	/**
-	 * Creates a proxy batch file in a stable location to handle CLI execution.
+	 * Creates the stable bin directory and write a proxy batch file that will handle CLI execution.
 	 *
 	 * Since our app is installed in a versioned directory, the full path changes with each update.
 	 * Instead of adding the versioned executable directly to PATH, we create a fixed proxy script
@@ -182,17 +183,17 @@ export class WindowsCliInstallationManager implements StudioCliInstallationManag
 	 */
 	private async installProxyBatFile(): Promise< void > {
 		try {
-			await mkdir( unversionedBinDirPath, { recursive: true } );
+			await mkdir( stableBinDirPath, { recursive: true } );
 
 			const versionedCliPath = path.join(
 				path.dirname( app.getPath( 'exe' ) ),
 				'resources/bin/studio-cli.bat'
 			);
-			const relativeVersionedCliPath = path.relative( unversionedBinDirPath, versionedCliPath );
+			const relativeVersionedCliPath = path.relative( stableBinDirPath, versionedCliPath );
 
 			const content = `@echo off\n"%~dp0\\${ relativeVersionedCliPath }" %*`;
 
-			await writeFile( path.join( unversionedBinDirPath, 'studio.bat' ), content );
+			await writeFile( path.join( stableBinDirPath, 'studio.bat' ), content );
 		} catch ( error ) {
 			Sentry.captureException( error );
 			console.error( 'Failed to install CLI: Proxy Bat file', error );
@@ -208,7 +209,7 @@ export class WindowsCliInstallationManager implements StudioCliInstallationManag
 		const currentPath = await this.getPathFromRegistry();
 		const newPath = currentPath
 			.split( ';' )
-			.filter( ( item ) => item.trim().toLowerCase() !== unversionedBinDirPath.toLowerCase() )
+			.filter( ( item ) => item.trim().toLowerCase() !== stableBinDirPath.toLowerCase() )
 			.join( ';' );
 
 		await this.setPathInRegistry( newPath );

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -24,6 +24,9 @@ jest.mock( 'atomically', () => ( {
 	readFile: jest.fn(),
 	writeFile: jest.fn(),
 } ) );
+jest.mock( 'src/modules/cli/lib/windows-installation-manager', () => ( {
+	updateWindowsCliVersionedPathIfNeeded: jest.fn().mockReturnValue( Promise.resolve() ),
+} ) );
 
 ( readFile as jest.Mock ).mockResolvedValue( JSON.stringify( { sites: [] } ) );
 require( 'fs' ).__setFileContents( normalize( '/path/to/app/temp/com.wordpress.studio/' ), '' );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-1247

## Proposed Changes

> [!NOTE]  
> From the user's perspective, I don't believe it's completely necessary to change this behavior. However, it will make the CLI installation more resilient in our internal smoke testing, which seems like a noble cause in and of itself.

When installing the CLI on Windows, `WindowsCliInstallationManager` does two things:
1. It adds `C:\Users\<USERNAME>\AppData\Local\studio\bin` to the `PATH` variable in the registry
2. It creates the `C:\Users\<USERNAME>\AppData\Local\studio\bin` directory and writes a `studio.bat` file to it

The reason we do it this way is that the app resources live in a versioned directory (i.e. `C:\Users\<USERNAME>\AppData\Local\studio\app-1.7.0-beta3`). Instead of changing the `PATH` variable in the registry every time the app starts, we use a known, stable path and change the contents of `C:\Users\<USERNAME>\AppData\Local\studio\bin\studio.bat` when the app starts.

This logic plays nicely with the auto-updater. However, it breaks when the app is **manually reinstalled**. When that happens, the `PATH` variable in the registry isn't touched, but the entire `C:\Users\<USERNAME>\AppData\Local\studio` directory is wiped, effectively uninstalling the CLI.

The `WindowsCliInstallationManager::updateWindowsCliVersionedPathIfNeeded` logic (which runs when the app starts and updates the contents of `C:\Users\<USERNAME>\AppData\Local\studio\bin\studio.bat`) relies on the presence of the `C:\Users\<USERNAME>\AppData\Local\studio` directory. This PR changes that method to only look for `C:\Users\<USERNAME>\AppData\Local\studio\bin` in the registry PATH and proceed with writing the `studio.bat` script if the registry key is there. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Have Studio installed on Windows
2. Have the Studio CLI installed
3. Download the Windows dev build
4. Install it
5. Ensure that the settings modal still shows the CLI to be installed
6. Open a command prompt using the button in the Overview tab
7. Ensure that the `studio` command is available in the command prompt

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
