### PR TITLE
Add benchmark script for site creation performance (STU-1235)

### DIFF
--- a/scripts/benchmark-site-create/README.md
+++ b/scripts/benchmark-site-create/README.md
@@ -1,0 +1,119 @@
+# Studio Site Create Benchmark
+
+Benchmarks Studio CLI `site create` performance against raw Playground CLI to measure overhead.
+
+## Related Issue
+
+[STU-1235](https://linear.app/a8c/issue/STU-1235/studio-benchmark-studio-site-create-performance-compared-with-raw)
+
+## Usage
+
+```bash
+cd scripts/benchmark-site-create
+npm install
+npm run benchmark
+```
+
+### Options
+
+```
+--rounds=N          Number of test rounds (default: 3)
+--skip-playground   Skip Playground CLI benchmarks
+--skip-studio       Skip Studio CLI benchmarks
+--use-bundled       Use Studio's bundled WordPress files for Playground CLI
+                    (for apples-to-apples comparison, requires Studio app installed)
+--help              Show help message
+```
+
+### Examples
+
+```bash
+# Run 5 rounds of all benchmarks
+npm run benchmark -- --rounds=5
+
+# Only benchmark Studio CLI
+npm run benchmark -- --skip-playground
+
+# Only benchmark Playground CLI
+npm run benchmark -- --skip-studio
+```
+
+## What It Measures
+
+| Benchmark | Description |
+|-----------|-------------|
+| **Playground CLI (download)** | Raw `wp-playground server` - downloads WordPress and starts server |
+| **Playground CLI (bundled files)** | Raw `wp-playground server` with pre-copied bundled files (use `--use-bundled`) |
+| **Studio CLI (create only)** | `studio site create` without `--start` - creates site metadata and files |
+| **Studio CLI (create + start)** | `studio site create --start` - full site creation including server startup |
+
+### Default vs Bundled Mode
+
+By default, the benchmark compares:
+- **Playground CLI**: Downloads WordPress from the internet each run
+- **Studio CLI**: Uses pre-bundled WordPress files (optimized)
+
+With `--use-bundled`, both use the same bundled files for an apples-to-apples comparison of the actual overhead Studio adds on top of Playground CLI.
+
+## Output
+
+Results are displayed in a summary table showing:
+- Min/Max/Avg/Median times
+- Success rate
+- Overhead percentage vs Playground CLI baseline
+
+Results are also saved to a JSON file: `results-{platform}-{timestamp}.json`
+
+## Running on Both Platforms
+
+Per STU-1235, benchmarks should be run on both macOS and Windows:
+
+### macOS
+```bash
+cd scripts/benchmark-site-create
+npm install
+npm run benchmark -- --rounds=5
+```
+
+### Windows
+```powershell
+cd scripts\benchmark-site-create
+npm install
+npm run benchmark -- --rounds=5
+```
+
+## Interpreting Results
+
+The overhead analysis shows how much slower Studio CLI is compared to raw Playground CLI:
+
+- **Positive overhead**: Studio adds this much time on top of Playground
+- **Overhead percentage**: `(studio_time / playground_time - 1) * 100`
+
+### Expected Overhead Sources
+
+Based on code analysis, Studio adds overhead for:
+
+1. **File I/O**: Appdata lock/unlock, SQLite file copying
+2. **Process Management**: PM2 connection, lockfile operations
+3. **IPC Messaging**: Activity tracking, message parsing
+4. **Configuration**: Building filesystem mounts, blueprint injection
+
+## Troubleshooting
+
+### Port conflicts
+The benchmark uses port 9876 for Playground. If you see port-related errors, kill any process using that port:
+```bash
+# macOS/Linux
+lsof -ti:9876 | xargs kill -9
+
+# Windows
+netstat -ano | findstr :9876
+taskkill /PID <pid> /F
+```
+
+### Studio CLI not found
+Ensure the CLI is built:
+```bash
+cd ../..  # back to studio root
+npm run cli:build
+```

--- a/scripts/benchmark-site-create/benchmark.ts
+++ b/scripts/benchmark-site-create/benchmark.ts
@@ -30,7 +30,8 @@ process.on( 'uncaughtException', ( err ) => {
 // Configuration
 const DEFAULT_ROUNDS = 3;
 const STUDIO_ROOT = path.resolve( import.meta.dirname, '../..' );
-const PLAYGROUND_CLI_PATH = path.resolve( import.meta.dirname, 'node_modules/.bin/wp-playground-cli' );
+const PLAYGROUND_CLI_BIN = process.platform === 'win32' ? 'wp-playground-cli.cmd' : 'wp-playground-cli';
+const PLAYGROUND_CLI_PATH = path.resolve( import.meta.dirname, 'node_modules/.bin', PLAYGROUND_CLI_BIN );
 const STUDIO_CLI_PATH = path.resolve( STUDIO_ROOT, 'dist/cli/main.js' );
 
 function getBundledWordPressPath(): string {
@@ -246,9 +247,14 @@ async function benchmarkPlaygroundCLI( siteDir: string, port: number, useBundled
 
 		const cleanup = async ( proc: ChildProcess ) => {
 			try {
-				// Kill the process group (negative PID) for detached processes
 				if ( proc.pid ) {
-					process.kill( -proc.pid, 'SIGTERM' );
+					if ( process.platform === 'win32' ) {
+						// On Windows, use taskkill to kill the process tree
+						execSync( `taskkill /F /T /PID ${ proc.pid }`, { stdio: 'ignore' } );
+					} else {
+						// On Unix, kill the process group (negative PID)
+						process.kill( -proc.pid, 'SIGTERM' );
+					}
 					// Give process time to exit gracefully
 					await new Promise( ( r ) => setTimeout( r, 500 ) );
 				}
@@ -271,10 +277,12 @@ async function benchmarkPlaygroundCLI( siteDir: string, port: number, useBundled
 
 		// Start the server with inherited stdio so we can see progress
 		// Use detached: true to prevent signals from propagating to parent
+		// On Windows, use shell: true for proper process handling
 		const proc = spawn( PLAYGROUND_CLI_PATH, args, {
 			stdio: 'inherit',
 			env: { ...process.env, FORCE_COLOR: '1' },
-			detached: true,
+			detached: process.platform !== 'win32',
+			shell: process.platform === 'win32',
 		} );
 
 		// Keepalive to prevent event loop from exiting

--- a/scripts/benchmark-site-create/benchmark.ts
+++ b/scripts/benchmark-site-create/benchmark.ts
@@ -339,10 +339,22 @@ async function benchmarkPlaygroundCLI( siteDir: string, port: number, useBundled
  */
 async function benchmarkStudioCLI( siteDir: string, siteName: string ): Promise<{ durationMs: number; success: boolean; error?: string }> {
 	// Studio CLI site create without --start (just creates the site)
-	return runCommand( 'node', [ STUDIO_CLI_PATH, 'site', 'create', `--path=${ siteDir }`, `--name=${ siteName }`, '--start=false' ], {
+	const result = await runCommand( 'node', [ STUDIO_CLI_PATH, 'site', 'create', `--path=${ siteDir }`, `--name=${ siteName }`, '--start=false' ], {
 		cwd: STUDIO_ROOT,
 		timeout: 300000,
 	} );
+
+	// Clean up: remove site from Studio appdata
+	try {
+		await runCommand( 'node', [ STUDIO_CLI_PATH, 'site', 'delete', `--path=${ siteDir }` ], {
+			cwd: STUDIO_ROOT,
+			timeout: 30000,
+		} );
+	} catch {
+		// Ignore cleanup errors
+	}
+
+	return result;
 }
 
 /**
@@ -358,9 +370,18 @@ async function benchmarkStudioCLIWithStart( siteDir: string, siteName: string ):
 		}
 	);
 
-	// Clean up: stop the site
+	// Clean up: stop the site and remove from Studio appdata
 	try {
 		await runCommand( 'node', [ STUDIO_CLI_PATH, 'site', 'stop', `--path=${ siteDir }` ], {
+			cwd: STUDIO_ROOT,
+			timeout: 30000,
+		} );
+	} catch {
+		// Ignore cleanup errors
+	}
+
+	try {
+		await runCommand( 'node', [ STUDIO_CLI_PATH, 'site', 'delete', `--path=${ siteDir }` ], {
 			cwd: STUDIO_ROOT,
 			timeout: 30000,
 		} );

--- a/scripts/benchmark-site-create/benchmark.ts
+++ b/scripts/benchmark-site-create/benchmark.ts
@@ -1,0 +1,625 @@
+#!/usr/bin/env tsx
+/* eslint-disable no-console */
+/**
+ * Benchmark script for comparing Studio CLI site creation vs raw Playground CLI.
+ *
+ * Usage:
+ *   cd scripts/benchmark-site-create
+ *   npm install
+ *   npm run benchmark
+ *
+ * Or with options:
+ *   npm run benchmark -- --rounds=5 --skip-playground --skip-studio
+ */
+
+import { spawn, execSync, ChildProcess } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import chalk from 'chalk';
+
+// Catch unhandled errors
+process.on( 'unhandledRejection', ( reason, promise ) => {
+	console.error( chalk.red( 'Unhandled Rejection at:' ), promise, 'reason:', reason );
+} );
+
+process.on( 'uncaughtException', ( err ) => {
+	console.error( chalk.red( 'Uncaught Exception:' ), err );
+} );
+
+// Configuration
+const DEFAULT_ROUNDS = 3;
+const STUDIO_ROOT = path.resolve( import.meta.dirname, '../..' );
+const PLAYGROUND_CLI_PATH = path.resolve( import.meta.dirname, 'node_modules/.bin/wp-playground-cli' );
+const STUDIO_CLI_PATH = path.resolve( STUDIO_ROOT, 'dist/cli/main.js' );
+
+function getBundledWordPressPath(): string {
+	if ( process.platform === 'win32' ) {
+		const appData = process.env.APPDATA;
+		if ( ! appData ) {
+			throw new Error( 'APPDATA environment variable not set' );
+		}
+		return path.join( appData, 'Studio', 'server-files', 'wordpress-versions', 'latest' );
+	}
+	return path.join( os.homedir(), 'Library', 'Application Support', 'Studio', 'server-files', 'wordpress-versions', 'latest' );
+}
+
+function copyDirSync( src: string, dest: string ): void {
+	fs.mkdirSync( dest, { recursive: true } );
+	const entries = fs.readdirSync( src, { withFileTypes: true } );
+
+	for ( const entry of entries ) {
+		const srcPath = path.join( src, entry.name );
+		const destPath = path.join( dest, entry.name );
+
+		if ( entry.isDirectory() ) {
+			copyDirSync( srcPath, destPath );
+		} else {
+			fs.copyFileSync( srcPath, destPath );
+		}
+	}
+}
+
+interface BenchmarkResult {
+	name: string;
+	round: number;
+	durationMs: number;
+	success: boolean;
+	error?: string;
+}
+
+interface BenchmarkSummary {
+	name: string;
+	rounds: number;
+	successful: number;
+	failed: number;
+	minMs: number;
+	maxMs: number;
+	avgMs: number;
+	medianMs: number;
+}
+
+function parseArgs(): { rounds: number; skipPlayground: boolean; skipStudio: boolean; useBundled: boolean } {
+	const args = process.argv.slice( 2 );
+	let rounds = DEFAULT_ROUNDS;
+	let skipPlayground = false;
+	let skipStudio = false;
+	let useBundled = false;
+
+	for ( const arg of args ) {
+		if ( arg.startsWith( '--rounds=' ) ) {
+			rounds = parseInt( arg.split( '=' )[ 1 ], 10 );
+		} else if ( arg === '--skip-playground' ) {
+			skipPlayground = true;
+		} else if ( arg === '--skip-studio' ) {
+			skipStudio = true;
+		} else if ( arg === '--use-bundled' ) {
+			useBundled = true;
+		} else if ( arg === '--help' ) {
+			console.log( `
+Usage: npm run benchmark [options]
+
+Options:
+  --rounds=N          Number of test rounds (default: ${ DEFAULT_ROUNDS })
+  --skip-playground   Skip Playground CLI benchmarks
+  --skip-studio       Skip Studio CLI benchmarks
+  --use-bundled       Use Studio's bundled WordPress files for Playground CLI
+                      (for apples-to-apples comparison, requires Studio app installed)
+  --help              Show this help message
+` );
+			process.exit( 0 );
+		}
+	}
+
+	return { rounds, skipPlayground, skipStudio, useBundled };
+}
+
+function median( values: number[] ): number {
+	if ( values.length === 0 ) return 0;
+	const sorted = [ ...values ].sort( ( a, b ) => a - b );
+	const mid = Math.floor( sorted.length / 2 );
+	return sorted.length % 2 !== 0 ? sorted[ mid ] : ( sorted[ mid - 1 ] + sorted[ mid ] ) / 2;
+}
+
+function formatDuration( ms: number ): string {
+	if ( ms < 1000 ) return `${ ms.toFixed( 0 ) }ms`;
+	return `${ ( ms / 1000 ).toFixed( 2 ) }s`;
+}
+
+function createTempDir( prefix: string ): string {
+	return fs.mkdtempSync( path.join( os.tmpdir(), `benchmark-${ prefix }-` ) );
+}
+
+function cleanupDir( dir: string ): void {
+	if ( fs.existsSync( dir ) ) {
+		fs.rmSync( dir, { recursive: true, force: true } );
+	}
+}
+
+async function runCommand(
+	command: string,
+	args: string[],
+	options: { cwd?: string; timeout?: number } = {}
+): Promise<{ durationMs: number; success: boolean; error?: string }> {
+	const start = performance.now();
+	const timeout = options.timeout ?? 300000; // 5 minute default timeout
+
+	return new Promise( ( resolve ) => {
+		let proc: ChildProcess;
+		let timedOut = false;
+		let stdout = '';
+		let stderr = '';
+
+		const timeoutId = setTimeout( () => {
+			timedOut = true;
+			proc?.kill( 'SIGKILL' );
+		}, timeout );
+
+		proc = spawn( command, args, {
+			cwd: options.cwd,
+			stdio: [ 'ignore', 'pipe', 'pipe' ],
+			env: { ...process.env, FORCE_COLOR: '0' },
+		} );
+
+		proc.stdout?.on( 'data', ( data ) => {
+			stdout += data.toString();
+		} );
+
+		proc.stderr?.on( 'data', ( data ) => {
+			stderr += data.toString();
+		} );
+
+		proc.on( 'close', ( code ) => {
+			clearTimeout( timeoutId );
+			const durationMs = performance.now() - start;
+
+			if ( timedOut ) {
+				resolve( { durationMs, success: false, error: 'Timeout' } );
+			} else if ( code !== 0 ) {
+				resolve( { durationMs, success: false, error: stderr || `Exit code ${ code }` } );
+			} else {
+				resolve( { durationMs, success: true } );
+			}
+		} );
+
+		proc.on( 'error', ( err ) => {
+			clearTimeout( timeoutId );
+			const durationMs = performance.now() - start;
+			resolve( { durationMs, success: false, error: err.message } );
+		} );
+	} );
+}
+
+async function waitForServer( port: number, timeoutMs = 30000 ): Promise<boolean> {
+	const start = Date.now();
+	while ( Date.now() - start < timeoutMs ) {
+		try {
+			const response = await fetch( `http://localhost:${ port }/` );
+			if ( response.ok ) {
+				return true;
+			}
+		} catch {
+			// Server not ready yet
+		}
+		await new Promise( ( r ) => setTimeout( r, 500 ) );
+	}
+	return false;
+}
+
+async function killProcessOnPort( port: number ): Promise<void> {
+	return new Promise( ( resolve ) => {
+		try {
+			if ( process.platform === 'win32' ) {
+				execSync( `for /f "tokens=5" %a in ('netstat -aon ^| find ":${ port }"') do taskkill /F /PID %a`, {
+					stdio: 'ignore',
+				} );
+			} else {
+				execSync( `lsof -ti:${ port } | xargs kill -9 2>/dev/null || true`, { stdio: 'ignore' } );
+			}
+		} catch {
+			// Process may not exist
+		}
+		// Give OS time to release the port
+		setTimeout( resolve, 500 );
+	} );
+}
+
+/**
+ * Benchmark raw Playground CLI site creation.
+ * This starts a server and waits for it to be ready, then kills it.
+ */
+async function benchmarkPlaygroundCLI( siteDir: string, port: number, useBundled: boolean = false ): Promise<{ durationMs: number; success: boolean; error?: string }> {
+	// If using bundled files, copy them to siteDir before starting the timer
+	if ( useBundled ) {
+		const bundledPath = getBundledWordPressPath();
+		if ( ! fs.existsSync( bundledPath ) ) {
+			return { durationMs: 0, success: false, error: `Bundled WordPress not found at ${ bundledPath }. Run Studio app first.` };
+		}
+		copyDirSync( bundledPath, siteDir );
+	}
+
+	const start = performance.now();
+
+	return new Promise( ( resolve ) => {
+		let error: string | undefined;
+		let resolved = false;
+
+		const cleanup = async ( proc: ChildProcess ) => {
+			try {
+				// Kill the process group (negative PID) for detached processes
+				if ( proc.pid ) {
+					process.kill( -proc.pid, 'SIGTERM' );
+					// Give process time to exit gracefully
+					await new Promise( ( r ) => setTimeout( r, 500 ) );
+				}
+			} catch {
+				// Process may have already exited
+			}
+			// Also try to kill anything on the port
+			await killProcessOnPort( port );
+		};
+
+		const args = [
+			'server',
+			`--port=${ port }`,
+			'--wp=latest',
+			'--php=8.2',
+			`--mount-before-install=${ siteDir }:/wordpress`,
+			// Use existing files if bundled, otherwise download
+			`--wordpress-install-mode=${ useBundled ? 'install-from-existing-files' : 'download-and-install' }`,
+		];
+
+		// Start the server with inherited stdio so we can see progress
+		// Use detached: true to prevent signals from propagating to parent
+		const proc = spawn( PLAYGROUND_CLI_PATH, args, {
+			stdio: 'inherit',
+			env: { ...process.env, FORCE_COLOR: '1' },
+			detached: true,
+		} );
+
+		// Keepalive to prevent event loop from exiting
+		const keepalive = setInterval( () => {}, 1000 );
+
+		proc.on( 'error', ( err ) => {
+			clearInterval( keepalive );
+			console.log( chalk.red( `Spawn error: ${ err.message }` ) );
+			if ( ! resolved ) {
+				resolved = true;
+				resolve( { durationMs: performance.now() - start, success: false, error: `Spawn error: ${ err.message }` } );
+			}
+		} );
+
+		proc.on( 'exit', ( code, signal ) => {
+			clearInterval( keepalive );
+			if ( ! resolved ) {
+				resolved = true;
+				resolve( { durationMs: performance.now() - start, success: false, error: error || `Process exited unexpectedly (code ${ code }, signal ${ signal })` } );
+			}
+		} );
+
+		// Wait for the server to be ready
+		waitForServer( port, 120000 ).then( async ( serverReady ) => {
+			const durationMs = performance.now() - start;
+			clearInterval( keepalive );
+
+			// Set resolved BEFORE cleanup to prevent exit handler from resolving first
+			if ( ! resolved ) {
+				resolved = true;
+				await cleanup( proc );
+
+				if ( ! serverReady ) {
+					resolve( { durationMs, success: false, error: error || 'Server failed to start within timeout' } );
+				} else {
+					resolve( { durationMs, success: true } );
+				}
+			}
+		} ).catch( () => {
+			clearInterval( keepalive );
+		} );
+	} );
+}
+
+/**
+ * Benchmark Studio CLI site creation.
+ */
+async function benchmarkStudioCLI( siteDir: string, siteName: string ): Promise<{ durationMs: number; success: boolean; error?: string }> {
+	// Studio CLI site create without --start (just creates the site)
+	return runCommand( 'node', [ STUDIO_CLI_PATH, 'site', 'create', `--path=${ siteDir }`, `--name=${ siteName }`, '--start=false' ], {
+		cwd: STUDIO_ROOT,
+		timeout: 300000,
+	} );
+}
+
+/**
+ * Benchmark Studio CLI site creation with --start.
+ */
+async function benchmarkStudioCLIWithStart( siteDir: string, siteName: string ): Promise<{ durationMs: number; success: boolean; error?: string }> {
+	const result = await runCommand(
+		'node',
+		[ STUDIO_CLI_PATH, 'site', 'create', `--path=${ siteDir }`, `--name=${ siteName }`, '--start=true', '--skip-browser' ],
+		{
+			cwd: STUDIO_ROOT,
+			timeout: 300000,
+		}
+	);
+
+	// Clean up: stop the site
+	try {
+		await runCommand( 'node', [ STUDIO_CLI_PATH, 'site', 'stop', `--path=${ siteDir }` ], {
+			cwd: STUDIO_ROOT,
+			timeout: 30000,
+		} );
+	} catch {
+		// Ignore cleanup errors
+	}
+
+	return result;
+}
+
+async function runBenchmarkSuite(
+	name: string,
+	rounds: number,
+	benchmarkFn: ( siteDir: string, extra: string ) => Promise<{ durationMs: number; success: boolean; error?: string }>,
+	extraArg: string
+): Promise<BenchmarkResult[]> {
+	const results: BenchmarkResult[] = [];
+
+	console.log( chalk.cyan( `\n  Running ${ name }...` ) );
+
+	for ( let i = 1; i <= rounds; i++ ) {
+		let siteDir: string;
+		try {
+			// Remove any special characters from temp dir name
+			const safeName = name.toLowerCase().replace( /[^a-z0-9]+/g, '-' );
+			siteDir = createTempDir( safeName );
+		} catch ( err ) {
+			console.error( chalk.red( `    Failed to create temp dir: ${ err }` ) );
+			continue;
+		}
+
+		process.stdout.write( chalk.gray( `    Round ${ i }/${ rounds }: ` ) );
+
+		let result: { durationMs: number; success: boolean; error?: string };
+		try {
+			result = await benchmarkFn( siteDir, extraArg );
+		} catch ( err ) {
+			console.log( chalk.red( `EXCEPTION: ${ err }` ) );
+			result = { durationMs: 0, success: false, error: String( err ) };
+		}
+
+		results.push( {
+			name,
+			round: i,
+			durationMs: result.durationMs,
+			success: result.success,
+			error: result.error,
+		} );
+
+		if ( result.success ) {
+			console.log( chalk.green( `${ formatDuration( result.durationMs ) }` ) );
+		} else {
+			console.log( chalk.red( `FAILED: ${ result.error }` ) );
+		}
+
+		// Cleanup
+		cleanupDir( siteDir );
+
+		// Brief pause between rounds
+		await new Promise( ( r ) => setTimeout( r, 1000 ) );
+	}
+
+	return results;
+}
+
+function calculateSummary( results: BenchmarkResult[] ): BenchmarkSummary {
+	const successful = results.filter( ( r ) => r.success );
+	const durations = successful.map( ( r ) => r.durationMs );
+
+	return {
+		name: results[ 0 ]?.name ?? 'Unknown',
+		rounds: results.length,
+		successful: successful.length,
+		failed: results.length - successful.length,
+		minMs: durations.length > 0 ? Math.min( ...durations ) : 0,
+		maxMs: durations.length > 0 ? Math.max( ...durations ) : 0,
+		avgMs: durations.length > 0 ? durations.reduce( ( a, b ) => a + b, 0 ) / durations.length : 0,
+		medianMs: median( durations ),
+	};
+}
+
+function printSummaryTable( summaries: BenchmarkSummary[] ): void {
+	console.log( chalk.bold( '\n\nResults Summary' ) );
+	console.log( '═'.repeat( 90 ) );
+
+	const headers = [ 'Benchmark', 'Rounds', 'Success', 'Min', 'Max', 'Avg', 'Median' ];
+	const widths = [ 35, 8, 9, 12, 12, 12, 12 ];
+
+	console.log(
+		headers.map( ( h, i ) => h.padEnd( widths[ i ] ) ).join( '' )
+	);
+	console.log( '─'.repeat( 90 ) );
+
+	for ( const s of summaries ) {
+		const row = [
+			s.name.substring( 0, 34 ),
+			`${ s.rounds }`,
+			`${ s.successful }/${ s.rounds }`,
+			formatDuration( s.minMs ),
+			formatDuration( s.maxMs ),
+			formatDuration( s.avgMs ),
+			formatDuration( s.medianMs ),
+		];
+		console.log( row.map( ( c, i ) => c.padEnd( widths[ i ] ) ).join( '' ) );
+	}
+
+	console.log( '═'.repeat( 90 ) );
+
+	// Print overhead comparison if we have both Playground and Studio results
+	const playgroundResult = summaries.find( ( s ) => s.name.includes( 'Playground CLI' ) );
+	const studioResult = summaries.find( ( s ) => s.name === 'Studio CLI (create only)' );
+	const studioStartResult = summaries.find( ( s ) => s.name === 'Studio CLI (create + start)' );
+
+	if ( playgroundResult && playgroundResult.medianMs > 0 ) {
+		console.log( chalk.bold( '\nOverhead Analysis (vs Playground CLI baseline):' ) );
+
+		if ( studioResult && studioResult.medianMs > 0 ) {
+			const overheadMs = studioResult.medianMs - playgroundResult.medianMs;
+			const overheadPct = ( ( studioResult.medianMs / playgroundResult.medianMs - 1 ) * 100 ).toFixed( 1 );
+			console.log(
+				`  Studio CLI (create only): ${ overheadMs > 0 ? '+' : '' }${ formatDuration( overheadMs ) } (${ overheadPct }%)`
+			);
+		}
+
+		if ( studioStartResult && studioStartResult.medianMs > 0 ) {
+			const overheadMs = studioStartResult.medianMs - playgroundResult.medianMs;
+			const overheadPct = ( ( studioStartResult.medianMs / playgroundResult.medianMs - 1 ) * 100 ).toFixed( 1 );
+			console.log(
+				`  Studio CLI (create + start): ${ overheadMs > 0 ? '+' : '' }${ formatDuration( overheadMs ) } (${ overheadPct }%)`
+			);
+		}
+	}
+}
+
+async function ensureStudioCLIBuilt(): Promise<boolean> {
+	if ( ! fs.existsSync( STUDIO_CLI_PATH ) ) {
+		console.log( chalk.yellow( '  Building Studio CLI...' ) );
+		try {
+			execSync( 'npm run cli:build', { cwd: STUDIO_ROOT, stdio: 'inherit' } );
+			return true;
+		} catch ( err ) {
+			console.error( chalk.red( '  Failed to build Studio CLI' ) );
+			return false;
+		}
+	}
+	return true;
+}
+
+async function ensurePlaygroundCLIInstalled(): Promise<boolean> {
+	if ( ! fs.existsSync( PLAYGROUND_CLI_PATH ) ) {
+		console.log( chalk.yellow( '  Installing dependencies (including @wp-playground/cli)...' ) );
+		try {
+			execSync( 'npm install', { cwd: import.meta.dirname, stdio: 'inherit' } );
+			return true;
+		} catch ( err ) {
+			console.error( chalk.red( '  Failed to install Playground CLI' ) );
+			return false;
+		}
+	}
+	return true;
+}
+
+async function main() {
+	const { rounds, skipPlayground, skipStudio, useBundled } = parseArgs();
+
+	console.log( chalk.bold.cyan( '\n=== Studio Site Create Benchmark ===' ) );
+	console.log( chalk.gray( `Platform: ${ os.platform() } ${ os.arch() }` ) );
+	console.log( chalk.gray( `Node: ${ process.version }` ) );
+	console.log( chalk.gray( `Rounds: ${ rounds }` ) );
+	console.log( chalk.gray( `Use bundled: ${ useBundled }` ) );
+	console.log( chalk.gray( `Date: ${ new Date().toISOString() }` ) );
+
+	// Setup
+	console.log( chalk.bold( '\nSetup:' ) );
+
+	if ( ! skipPlayground ) {
+		if ( ! ( await ensurePlaygroundCLIInstalled() ) ) {
+			process.exit( 1 );
+		}
+		console.log( chalk.green( '  Playground CLI ready' ) );
+
+		if ( useBundled ) {
+			const bundledPath = getBundledWordPressPath();
+			if ( ! fs.existsSync( bundledPath ) ) {
+				console.error( chalk.red( `  Bundled WordPress not found at: ${ bundledPath }` ) );
+				console.error( chalk.red( '  Please run the Studio app first to download WordPress files.' ) );
+				process.exit( 1 );
+			}
+			console.log( chalk.green( '  Bundled WordPress files found' ) );
+		}
+	}
+
+	if ( ! skipStudio ) {
+		if ( ! ( await ensureStudioCLIBuilt() ) ) {
+			process.exit( 1 );
+		}
+		console.log( chalk.green( '  Studio CLI ready' ) );
+	}
+
+	const allResults: BenchmarkResult[] = [];
+	const port = 9876; // Use a fixed port for Playground benchmarks
+
+	// Run benchmarks
+	console.log( chalk.bold( '\nBenchmarks:' ) );
+
+	// 1. Raw Playground CLI
+	if ( ! skipPlayground ) {
+		try {
+			await killProcessOnPort( port );
+			const benchmarkName = useBundled
+				? 'Playground CLI (bundled files)'
+				: 'Playground CLI (download)';
+			const results = await runBenchmarkSuite(
+				benchmarkName,
+				rounds,
+				( siteDir ) => benchmarkPlaygroundCLI( siteDir, port, useBundled ),
+				String( port )
+			);
+			allResults.push( ...results );
+		} catch ( err ) {
+			console.error( chalk.red( `\n  Playground benchmark failed: ${ err }` ) );
+		}
+	}
+
+	// 2. Studio CLI (create only, no start)
+	if ( ! skipStudio ) {
+		const results = await runBenchmarkSuite(
+			'Studio CLI (create only)',
+			rounds,
+			( siteDir, name ) => benchmarkStudioCLI( siteDir, name ),
+			`benchmark-site-${ Date.now() }`
+		);
+		allResults.push( ...results );
+	}
+
+	// 3. Studio CLI (create + start)
+	if ( ! skipStudio ) {
+		const results = await runBenchmarkSuite(
+			'Studio CLI (create + start)',
+			rounds,
+			( siteDir, name ) => benchmarkStudioCLIWithStart( siteDir, name ),
+			`benchmark-site-${ Date.now() }`
+		);
+		allResults.push( ...results );
+	}
+
+	// Calculate and display summaries
+	const summaries: BenchmarkSummary[] = [];
+	const benchmarkNames = [ ...new Set( allResults.map( ( r ) => r.name ) ) ];
+
+	for ( const name of benchmarkNames ) {
+		const results = allResults.filter( ( r ) => r.name === name );
+		summaries.push( calculateSummary( results ) );
+	}
+
+	printSummaryTable( summaries );
+
+	// Save results to JSON
+	const outputPath = path.join( import.meta.dirname, `results-${ os.platform() }-${ Date.now() }.json` );
+	const output = {
+		platform: os.platform(),
+		arch: os.arch(),
+		nodeVersion: process.version,
+		date: new Date().toISOString(),
+		rounds,
+		results: allResults,
+		summaries,
+	};
+
+	fs.writeFileSync( outputPath, JSON.stringify( output, null, 2 ) );
+	console.log( chalk.gray( `\nResults saved to: ${ outputPath }` ) );
+}
+
+main().catch( ( err ) => {
+	console.error( chalk.red( 'Benchmark failed:' ), err );
+	process.exit( 1 );
+} );

--- a/scripts/benchmark-site-create/benchmark.ts
+++ b/scripts/benchmark-site-create/benchmark.ts
@@ -270,10 +270,17 @@ async function benchmarkPlaygroundCLI( siteDir: string, port: number, useBundled
 			`--port=${ port }`,
 			'--wp=latest',
 			'--php=8.2',
-			`--mount-before-install=${ siteDir }:/wordpress`,
 			// Use existing files if bundled, otherwise download
 			`--wordpress-install-mode=${ useBundled ? 'install-from-existing-files' : 'download-and-install' }`,
 		];
+
+		// On Windows, use --mount-dir-before-install with separate args (paths contain colons)
+		// On Unix, use --mount-before-install=host:vfs format
+		if ( process.platform === 'win32' ) {
+			args.push( '--mount-dir-before-install', siteDir, '/wordpress' );
+		} else {
+			args.push( `--mount-before-install=${ siteDir }:/wordpress` );
+		}
 
 		// Start the server with inherited stdio so we can see progress
 		// Use detached: true to prevent signals from propagating to parent

--- a/scripts/benchmark-site-create/package-lock.json
+++ b/scripts/benchmark-site-create/package-lock.json
@@ -1,0 +1,3947 @@
+{
+	"name": "benchmark-site-create",
+	"version": "0.0.1",
+	"lockfileVersion": 3,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "benchmark-site-create",
+			"version": "0.0.1",
+			"license": "GPLv2",
+			"dependencies": {
+				"@wp-playground/cli": "^3.0.22",
+				"chalk": "^5.3.0",
+				"tsx": "^4.7.0"
+			},
+			"devDependencies": {
+				"@types/node": "^20.0.0",
+				"typescript": "^5.0.0"
+			}
+		},
+		"node_modules/@esbuild/aix-ppc64": {
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.2.tgz",
+			"integrity": "sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==",
+			"cpu": [
+				"ppc64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"aix"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-arm": {
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.2.tgz",
+			"integrity": "sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==",
+			"cpu": [
+				"arm"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-arm64": {
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.2.tgz",
+			"integrity": "sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/android-x64": {
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.2.tgz",
+			"integrity": "sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"android"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/darwin-arm64": {
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.2.tgz",
+			"integrity": "sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/darwin-x64": {
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.2.tgz",
+			"integrity": "sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/freebsd-arm64": {
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.2.tgz",
+			"integrity": "sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/freebsd-x64": {
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.2.tgz",
+			"integrity": "sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-arm": {
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.2.tgz",
+			"integrity": "sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==",
+			"cpu": [
+				"arm"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-arm64": {
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.2.tgz",
+			"integrity": "sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-ia32": {
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.2.tgz",
+			"integrity": "sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==",
+			"cpu": [
+				"ia32"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-loong64": {
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.2.tgz",
+			"integrity": "sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==",
+			"cpu": [
+				"loong64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-mips64el": {
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.2.tgz",
+			"integrity": "sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==",
+			"cpu": [
+				"mips64el"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-ppc64": {
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.2.tgz",
+			"integrity": "sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==",
+			"cpu": [
+				"ppc64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-riscv64": {
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.2.tgz",
+			"integrity": "sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==",
+			"cpu": [
+				"riscv64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-s390x": {
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.2.tgz",
+			"integrity": "sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==",
+			"cpu": [
+				"s390x"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/linux-x64": {
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.2.tgz",
+			"integrity": "sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/netbsd-arm64": {
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.2.tgz",
+			"integrity": "sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/netbsd-x64": {
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.2.tgz",
+			"integrity": "sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"netbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openbsd-arm64": {
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.2.tgz",
+			"integrity": "sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openbsd-x64": {
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.2.tgz",
+			"integrity": "sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openbsd"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/openharmony-arm64": {
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.2.tgz",
+			"integrity": "sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/sunos-x64": {
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.2.tgz",
+			"integrity": "sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"sunos"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-arm64": {
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.2.tgz",
+			"integrity": "sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-ia32": {
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.2.tgz",
+			"integrity": "sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==",
+			"cpu": [
+				"ia32"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@esbuild/win32-x64": {
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.2.tgz",
+			"integrity": "sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==",
+			"cpu": [
+				"x64"
+			],
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@noble/hashes": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+			"integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 16"
+			},
+			"funding": {
+				"url": "https://paulmillr.com/funding/"
+			}
+		},
+		"node_modules/@octokit/app": {
+			"version": "14.1.0",
+			"resolved": "https://registry.npmjs.org/@octokit/app/-/app-14.1.0.tgz",
+			"integrity": "sha512-g3uEsGOQCBl1+W1rgfwoRFUIR6PtvB2T1E4RpygeUU5LrLvlOqcxrt5lfykIeRpUPpupreGJUYl70fqMDXdTpw==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/auth-app": "^6.0.0",
+				"@octokit/auth-unauthenticated": "^5.0.0",
+				"@octokit/core": "^5.0.0",
+				"@octokit/oauth-app": "^6.0.0",
+				"@octokit/plugin-paginate-rest": "^9.0.0",
+				"@octokit/types": "^12.0.0",
+				"@octokit/webhooks": "^12.0.4"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/auth-app": {
+			"version": "6.1.4",
+			"resolved": "https://registry.npmjs.org/@octokit/auth-app/-/auth-app-6.1.4.tgz",
+			"integrity": "sha512-QkXkSOHZK4dA5oUqY5Dk3S+5pN2s1igPjEASNQV8/vgJgW034fQWR16u7VsNOK/EljA00eyjYF5mWNxWKWhHRQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/auth-oauth-app": "^7.1.0",
+				"@octokit/auth-oauth-user": "^4.1.0",
+				"@octokit/request": "^8.3.1",
+				"@octokit/request-error": "^5.1.0",
+				"@octokit/types": "^13.1.0",
+				"deprecation": "^2.3.1",
+				"lru-cache": "npm:@wolfy1339/lru-cache@^11.0.2-patch.1",
+				"universal-github-app-jwt": "^1.1.2",
+				"universal-user-agent": "^6.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/auth-app/node_modules/@octokit/openapi-types": {
+			"version": "24.2.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+			"integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+			"license": "MIT"
+		},
+		"node_modules/@octokit/auth-app/node_modules/@octokit/types": {
+			"version": "13.10.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+			"integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/openapi-types": "^24.2.0"
+			}
+		},
+		"node_modules/@octokit/auth-oauth-app": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/@octokit/auth-oauth-app/-/auth-oauth-app-7.1.0.tgz",
+			"integrity": "sha512-w+SyJN/b0l/HEb4EOPRudo7uUOSW51jcK1jwLa+4r7PA8FPFpoxEnHBHMITqCsc/3Vo2qqFjgQfz/xUUvsSQnA==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/auth-oauth-device": "^6.1.0",
+				"@octokit/auth-oauth-user": "^4.1.0",
+				"@octokit/request": "^8.3.1",
+				"@octokit/types": "^13.0.0",
+				"@types/btoa-lite": "^1.0.0",
+				"btoa-lite": "^1.0.0",
+				"universal-user-agent": "^6.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/auth-oauth-app/node_modules/@octokit/openapi-types": {
+			"version": "24.2.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+			"integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+			"license": "MIT"
+		},
+		"node_modules/@octokit/auth-oauth-app/node_modules/@octokit/types": {
+			"version": "13.10.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+			"integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/openapi-types": "^24.2.0"
+			}
+		},
+		"node_modules/@octokit/auth-oauth-device": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/@octokit/auth-oauth-device/-/auth-oauth-device-6.1.0.tgz",
+			"integrity": "sha512-FNQ7cb8kASufd6Ej4gnJ3f1QB5vJitkoV1O0/g6e6lUsQ7+VsSNRHRmFScN2tV4IgKA12frrr/cegUs0t+0/Lw==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/oauth-methods": "^4.1.0",
+				"@octokit/request": "^8.3.1",
+				"@octokit/types": "^13.0.0",
+				"universal-user-agent": "^6.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/auth-oauth-device/node_modules/@octokit/openapi-types": {
+			"version": "24.2.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+			"integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+			"license": "MIT"
+		},
+		"node_modules/@octokit/auth-oauth-device/node_modules/@octokit/types": {
+			"version": "13.10.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+			"integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/openapi-types": "^24.2.0"
+			}
+		},
+		"node_modules/@octokit/auth-oauth-user": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@octokit/auth-oauth-user/-/auth-oauth-user-4.1.0.tgz",
+			"integrity": "sha512-FrEp8mtFuS/BrJyjpur+4GARteUCrPeR/tZJzD8YourzoVhRics7u7we/aDcKv+yywRNwNi/P4fRi631rG/OyQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/auth-oauth-device": "^6.1.0",
+				"@octokit/oauth-methods": "^4.1.0",
+				"@octokit/request": "^8.3.1",
+				"@octokit/types": "^13.0.0",
+				"btoa-lite": "^1.0.0",
+				"universal-user-agent": "^6.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/auth-oauth-user/node_modules/@octokit/openapi-types": {
+			"version": "24.2.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+			"integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+			"license": "MIT"
+		},
+		"node_modules/@octokit/auth-oauth-user/node_modules/@octokit/types": {
+			"version": "13.10.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+			"integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/openapi-types": "^24.2.0"
+			}
+		},
+		"node_modules/@octokit/auth-token": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
+			"integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/auth-unauthenticated": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/@octokit/auth-unauthenticated/-/auth-unauthenticated-5.0.1.tgz",
+			"integrity": "sha512-oxeWzmBFxWd+XolxKTc4zr+h3mt+yofn4r7OfoIkR/Cj/o70eEGmPsFbueyJE2iBAGpjgTnEOKM3pnuEGVmiqg==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/request-error": "^5.0.0",
+				"@octokit/types": "^12.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/core": {
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.2.tgz",
+			"integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/auth-token": "^4.0.0",
+				"@octokit/graphql": "^7.1.0",
+				"@octokit/request": "^8.4.1",
+				"@octokit/request-error": "^5.1.1",
+				"@octokit/types": "^13.0.0",
+				"before-after-hook": "^2.2.0",
+				"universal-user-agent": "^6.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/core/node_modules/@octokit/openapi-types": {
+			"version": "24.2.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+			"integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+			"license": "MIT"
+		},
+		"node_modules/@octokit/core/node_modules/@octokit/types": {
+			"version": "13.10.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+			"integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/openapi-types": "^24.2.0"
+			}
+		},
+		"node_modules/@octokit/endpoint": {
+			"version": "9.0.6",
+			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.6.tgz",
+			"integrity": "sha512-H1fNTMA57HbkFESSt3Y9+FBICv+0jFceJFPWDePYlR/iMGrwM5ph+Dd4XRQs+8X+PUFURLQgX9ChPfhJ/1uNQw==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/types": "^13.1.0",
+				"universal-user-agent": "^6.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/endpoint/node_modules/@octokit/openapi-types": {
+			"version": "24.2.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+			"integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+			"license": "MIT"
+		},
+		"node_modules/@octokit/endpoint/node_modules/@octokit/types": {
+			"version": "13.10.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+			"integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/openapi-types": "^24.2.0"
+			}
+		},
+		"node_modules/@octokit/graphql": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.1.1.tgz",
+			"integrity": "sha512-3mkDltSfcDUoa176nlGoA32RGjeWjl3K7F/BwHwRMJUW/IteSa4bnSV8p2ThNkcIcZU2umkZWxwETSSCJf2Q7g==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/request": "^8.4.1",
+				"@octokit/types": "^13.0.0",
+				"universal-user-agent": "^6.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/graphql/node_modules/@octokit/openapi-types": {
+			"version": "24.2.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+			"integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+			"license": "MIT"
+		},
+		"node_modules/@octokit/graphql/node_modules/@octokit/types": {
+			"version": "13.10.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+			"integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/openapi-types": "^24.2.0"
+			}
+		},
+		"node_modules/@octokit/oauth-app": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/@octokit/oauth-app/-/oauth-app-6.1.0.tgz",
+			"integrity": "sha512-nIn/8eUJ/BKUVzxUXd5vpzl1rwaVxMyYbQkNZjHrF7Vk/yu98/YDF/N2KeWO7uZ0g3b5EyiFXFkZI8rJ+DH1/g==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/auth-oauth-app": "^7.0.0",
+				"@octokit/auth-oauth-user": "^4.0.0",
+				"@octokit/auth-unauthenticated": "^5.0.0",
+				"@octokit/core": "^5.0.0",
+				"@octokit/oauth-authorization-url": "^6.0.2",
+				"@octokit/oauth-methods": "^4.0.0",
+				"@types/aws-lambda": "^8.10.83",
+				"universal-user-agent": "^6.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/oauth-authorization-url": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/@octokit/oauth-authorization-url/-/oauth-authorization-url-6.0.2.tgz",
+			"integrity": "sha512-CdoJukjXXxqLNK4y/VOiVzQVjibqoj/xHgInekviUJV73y/BSIcwvJ/4aNHPBPKcPWFnd4/lO9uqRV65jXhcLA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/oauth-methods": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@octokit/oauth-methods/-/oauth-methods-4.1.0.tgz",
+			"integrity": "sha512-4tuKnCRecJ6CG6gr0XcEXdZtkTDbfbnD5oaHBmLERTjTMZNi2CbfEHZxPU41xXLDG4DfKf+sonu00zvKI9NSbw==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/oauth-authorization-url": "^6.0.2",
+				"@octokit/request": "^8.3.1",
+				"@octokit/request-error": "^5.1.0",
+				"@octokit/types": "^13.0.0",
+				"btoa-lite": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/oauth-methods/node_modules/@octokit/openapi-types": {
+			"version": "24.2.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+			"integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+			"license": "MIT"
+		},
+		"node_modules/@octokit/oauth-methods/node_modules/@octokit/types": {
+			"version": "13.10.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+			"integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/openapi-types": "^24.2.0"
+			}
+		},
+		"node_modules/@octokit/openapi-types": {
+			"version": "20.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
+			"integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==",
+			"license": "MIT"
+		},
+		"node_modules/@octokit/plugin-paginate-graphql": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-graphql/-/plugin-paginate-graphql-4.0.1.tgz",
+			"integrity": "sha512-R8ZQNmrIKKpHWC6V2gum4x9LG2qF1RxRjo27gjQcG3j+vf2tLsEfE7I/wRWEPzYMaenr1M+qDAtNcwZve1ce1A==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 18"
+			},
+			"peerDependencies": {
+				"@octokit/core": ">=5"
+			}
+		},
+		"node_modules/@octokit/plugin-paginate-rest": {
+			"version": "9.2.2",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-9.2.2.tgz",
+			"integrity": "sha512-u3KYkGF7GcZnSD/3UP0S7K5XUFT2FkOQdcfXZGZQPGv3lm4F2Xbf71lvjldr8c1H3nNbF+33cLEkWYbokGWqiQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/types": "^12.6.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"peerDependencies": {
+				"@octokit/core": "5"
+			}
+		},
+		"node_modules/@octokit/plugin-rest-endpoint-methods": {
+			"version": "10.4.1",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-10.4.1.tgz",
+			"integrity": "sha512-xV1b+ceKV9KytQe3zCVqjg+8GTGfDYwaT1ATU5isiUyVtlVAO3HNdzpS4sr4GBx4hxQ46s7ITtZrAsxG22+rVg==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/types": "^12.6.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"peerDependencies": {
+				"@octokit/core": "5"
+			}
+		},
+		"node_modules/@octokit/plugin-retry": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-6.1.0.tgz",
+			"integrity": "sha512-WrO3bvq4E1Xh1r2mT9w6SDFg01gFmP81nIG77+p/MqW1JeXXgL++6umim3t6x0Zj5pZm3rXAN+0HEjmmdhIRig==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/request-error": "^5.0.0",
+				"@octokit/types": "^13.0.0",
+				"bottleneck": "^2.15.3"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"peerDependencies": {
+				"@octokit/core": "5"
+			}
+		},
+		"node_modules/@octokit/plugin-retry/node_modules/@octokit/openapi-types": {
+			"version": "24.2.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+			"integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+			"license": "MIT"
+		},
+		"node_modules/@octokit/plugin-retry/node_modules/@octokit/types": {
+			"version": "13.10.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+			"integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/openapi-types": "^24.2.0"
+			}
+		},
+		"node_modules/@octokit/plugin-throttling": {
+			"version": "8.2.0",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-8.2.0.tgz",
+			"integrity": "sha512-nOpWtLayKFpgqmgD0y3GqXafMFuKcA4tRPZIfu7BArd2lEZeb1988nhWhwx4aZWmjDmUfdgVf7W+Tt4AmvRmMQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/types": "^12.2.0",
+				"bottleneck": "^2.15.3"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"peerDependencies": {
+				"@octokit/core": "^5.0.0"
+			}
+		},
+		"node_modules/@octokit/request": {
+			"version": "8.4.1",
+			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.4.1.tgz",
+			"integrity": "sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/endpoint": "^9.0.6",
+				"@octokit/request-error": "^5.1.1",
+				"@octokit/types": "^13.1.0",
+				"universal-user-agent": "^6.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/request-error": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.1.1.tgz",
+			"integrity": "sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/types": "^13.1.0",
+				"deprecation": "^2.0.0",
+				"once": "^1.4.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/request-error/node_modules/@octokit/openapi-types": {
+			"version": "24.2.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+			"integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+			"license": "MIT"
+		},
+		"node_modules/@octokit/request-error/node_modules/@octokit/types": {
+			"version": "13.10.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+			"integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/openapi-types": "^24.2.0"
+			}
+		},
+		"node_modules/@octokit/request/node_modules/@octokit/openapi-types": {
+			"version": "24.2.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+			"integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+			"license": "MIT"
+		},
+		"node_modules/@octokit/request/node_modules/@octokit/types": {
+			"version": "13.10.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+			"integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/openapi-types": "^24.2.0"
+			}
+		},
+		"node_modules/@octokit/types": {
+			"version": "12.6.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
+			"integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/openapi-types": "^20.0.0"
+			}
+		},
+		"node_modules/@octokit/webhooks": {
+			"version": "12.3.2",
+			"resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-12.3.2.tgz",
+			"integrity": "sha512-exj1MzVXoP7xnAcAB3jZ97pTvVPkQF9y6GA/dvYC47HV7vLv+24XRS6b/v/XnyikpEuvMhugEXdGtAlU086WkQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/request-error": "^5.0.0",
+				"@octokit/webhooks-methods": "^4.1.0",
+				"@octokit/webhooks-types": "7.6.1",
+				"aggregate-error": "^3.1.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/webhooks-methods": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@octokit/webhooks-methods/-/webhooks-methods-4.1.0.tgz",
+			"integrity": "sha512-zoQyKw8h9STNPqtm28UGOYFE7O6D4Il8VJwhAtMHFt2C4L0VQT1qGKLeefUOqHNs1mNRYSadVv7x0z8U2yyeWQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/webhooks-types": {
+			"version": "7.6.1",
+			"resolved": "https://registry.npmjs.org/@octokit/webhooks-types/-/webhooks-types-7.6.1.tgz",
+			"integrity": "sha512-S8u2cJzklBC0FgTwWVLaM8tMrDuDMVE4xiTK4EYXM9GntyvrdbSoxqDQa+Fh57CCNApyIpyeqPhhFEmHPfrXgw==",
+			"license": "MIT"
+		},
+		"node_modules/@peculiar/asn1-cms": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.6.0.tgz",
+			"integrity": "sha512-2uZqP+ggSncESeUF/9Su8rWqGclEfEiz1SyU02WX5fUONFfkjzS2Z/F1Li0ofSmf4JqYXIOdCAZqIXAIBAT1OA==",
+			"license": "MIT",
+			"dependencies": {
+				"@peculiar/asn1-schema": "^2.6.0",
+				"@peculiar/asn1-x509": "^2.6.0",
+				"@peculiar/asn1-x509-attr": "^2.6.0",
+				"asn1js": "^3.0.6",
+				"tslib": "^2.8.1"
+			}
+		},
+		"node_modules/@peculiar/asn1-csr": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/@peculiar/asn1-csr/-/asn1-csr-2.6.0.tgz",
+			"integrity": "sha512-BeWIu5VpTIhfRysfEp73SGbwjjoLL/JWXhJ/9mo4vXnz3tRGm+NGm3KNcRzQ9VMVqwYS2RHlolz21svzRXIHPQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@peculiar/asn1-schema": "^2.6.0",
+				"@peculiar/asn1-x509": "^2.6.0",
+				"asn1js": "^3.0.6",
+				"tslib": "^2.8.1"
+			}
+		},
+		"node_modules/@peculiar/asn1-ecc": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.6.0.tgz",
+			"integrity": "sha512-FF3LMGq6SfAOwUG2sKpPXblibn6XnEIKa+SryvUl5Pik+WR9rmRA3OCiwz8R3lVXnYnyRkSZsSLdml8H3UiOcw==",
+			"license": "MIT",
+			"dependencies": {
+				"@peculiar/asn1-schema": "^2.6.0",
+				"@peculiar/asn1-x509": "^2.6.0",
+				"asn1js": "^3.0.6",
+				"tslib": "^2.8.1"
+			}
+		},
+		"node_modules/@peculiar/asn1-pfx": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/@peculiar/asn1-pfx/-/asn1-pfx-2.6.0.tgz",
+			"integrity": "sha512-rtUvtf+tyKGgokHHmZzeUojRZJYPxoD/jaN1+VAB4kKR7tXrnDCA/RAWXAIhMJJC+7W27IIRGe9djvxKgsldCQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@peculiar/asn1-cms": "^2.6.0",
+				"@peculiar/asn1-pkcs8": "^2.6.0",
+				"@peculiar/asn1-rsa": "^2.6.0",
+				"@peculiar/asn1-schema": "^2.6.0",
+				"asn1js": "^3.0.6",
+				"tslib": "^2.8.1"
+			}
+		},
+		"node_modules/@peculiar/asn1-pkcs8": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.6.0.tgz",
+			"integrity": "sha512-KyQ4D8G/NrS7Fw3XCJrngxmjwO/3htnA0lL9gDICvEQ+GJ+EPFqldcJQTwPIdvx98Tua+WjkdKHSC0/Km7T+lA==",
+			"license": "MIT",
+			"dependencies": {
+				"@peculiar/asn1-schema": "^2.6.0",
+				"@peculiar/asn1-x509": "^2.6.0",
+				"asn1js": "^3.0.6",
+				"tslib": "^2.8.1"
+			}
+		},
+		"node_modules/@peculiar/asn1-pkcs9": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.6.0.tgz",
+			"integrity": "sha512-b78OQ6OciW0aqZxdzliXGYHASeCvvw5caqidbpQRYW2mBtXIX2WhofNXTEe7NyxTb0P6J62kAAWLwn0HuMF1Fw==",
+			"license": "MIT",
+			"dependencies": {
+				"@peculiar/asn1-cms": "^2.6.0",
+				"@peculiar/asn1-pfx": "^2.6.0",
+				"@peculiar/asn1-pkcs8": "^2.6.0",
+				"@peculiar/asn1-schema": "^2.6.0",
+				"@peculiar/asn1-x509": "^2.6.0",
+				"@peculiar/asn1-x509-attr": "^2.6.0",
+				"asn1js": "^3.0.6",
+				"tslib": "^2.8.1"
+			}
+		},
+		"node_modules/@peculiar/asn1-rsa": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.6.0.tgz",
+			"integrity": "sha512-Nu4C19tsrTsCp9fDrH+sdcOKoVfdfoQQ7S3VqjJU6vedR7tY3RLkQ5oguOIB3zFW33USDUuYZnPEQYySlgha4w==",
+			"license": "MIT",
+			"dependencies": {
+				"@peculiar/asn1-schema": "^2.6.0",
+				"@peculiar/asn1-x509": "^2.6.0",
+				"asn1js": "^3.0.6",
+				"tslib": "^2.8.1"
+			}
+		},
+		"node_modules/@peculiar/asn1-schema": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.6.0.tgz",
+			"integrity": "sha512-xNLYLBFTBKkCzEZIw842BxytQQATQv+lDTCEMZ8C196iJcJJMBUZxrhSTxLaohMyKK8QlzRNTRkUmanucnDSqg==",
+			"license": "MIT",
+			"dependencies": {
+				"asn1js": "^3.0.6",
+				"pvtsutils": "^1.3.6",
+				"tslib": "^2.8.1"
+			}
+		},
+		"node_modules/@peculiar/asn1-x509": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.6.0.tgz",
+			"integrity": "sha512-uzYbPEpoQiBoTq0/+jZtpM6Gq6zADBx+JNFP3yqRgziWBxQ/Dt/HcuvRfm9zJTPdRcBqPNdaRHTVwpyiq6iNMA==",
+			"license": "MIT",
+			"dependencies": {
+				"@peculiar/asn1-schema": "^2.6.0",
+				"asn1js": "^3.0.6",
+				"pvtsutils": "^1.3.6",
+				"tslib": "^2.8.1"
+			}
+		},
+		"node_modules/@peculiar/asn1-x509-attr": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.6.0.tgz",
+			"integrity": "sha512-MuIAXFX3/dc8gmoZBkwJWxUWOSvG4MMDntXhrOZpJVMkYX+MYc/rUAU2uJOved9iJEoiUx7//3D8oG83a78UJA==",
+			"license": "MIT",
+			"dependencies": {
+				"@peculiar/asn1-schema": "^2.6.0",
+				"@peculiar/asn1-x509": "^2.6.0",
+				"asn1js": "^3.0.6",
+				"tslib": "^2.8.1"
+			}
+		},
+		"node_modules/@peculiar/x509": {
+			"version": "1.14.3",
+			"resolved": "https://registry.npmjs.org/@peculiar/x509/-/x509-1.14.3.tgz",
+			"integrity": "sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA==",
+			"license": "MIT",
+			"dependencies": {
+				"@peculiar/asn1-cms": "^2.6.0",
+				"@peculiar/asn1-csr": "^2.6.0",
+				"@peculiar/asn1-ecc": "^2.6.0",
+				"@peculiar/asn1-pkcs9": "^2.6.0",
+				"@peculiar/asn1-rsa": "^2.6.0",
+				"@peculiar/asn1-schema": "^2.6.0",
+				"@peculiar/asn1-x509": "^2.6.0",
+				"pvtsutils": "^1.3.6",
+				"reflect-metadata": "^0.2.2",
+				"tslib": "^2.8.1",
+				"tsyringe": "^4.10.0"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@php-wasm/cli-util": {
+			"version": "3.0.45",
+			"resolved": "https://registry.npmjs.org/@php-wasm/cli-util/-/cli-util-3.0.45.tgz",
+			"integrity": "sha512-EpVNFuXP36EiQgP+M/Pcv6OtIuYvN8jJa78LHu2rkkm+X8bkxq6GBiz6gn06ABltVsIWtUrgdGjB2Ca7UCA1kQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"fast-xml-parser": "5.3.0",
+				"jsonc-parser": "3.3.1"
+			},
+			"engines": {
+				"node": ">=20.18.3",
+				"npm": ">=10.1.0"
+			},
+			"optionalDependencies": {
+				"fs-ext": "2.1.1"
+			}
+		},
+		"node_modules/@php-wasm/fs-journal": {
+			"version": "3.0.45",
+			"resolved": "https://registry.npmjs.org/@php-wasm/fs-journal/-/fs-journal-3.0.45.tgz",
+			"integrity": "sha512-9JDU4SEl8H+HS+lPA733CpzDrQ4kkdLsYIP8vzosxoD2j4QfD+Aot2iBlWqF0PUZUhT5NL+IBgpTxNWPsKpVcQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/logger": "3.0.45",
+				"@php-wasm/node": "3.0.45",
+				"@php-wasm/universal": "3.0.45",
+				"@php-wasm/util": "3.0.45",
+				"express": "4.22.0",
+				"ini": "4.1.2",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.3",
+				"yargs": "17.7.2"
+			},
+			"engines": {
+				"node": ">=20.18.3",
+				"npm": ">=10.1.0"
+			},
+			"optionalDependencies": {
+				"fs-ext": "2.1.1"
+			}
+		},
+		"node_modules/@php-wasm/logger": {
+			"version": "3.0.45",
+			"resolved": "https://registry.npmjs.org/@php-wasm/logger/-/logger-3.0.45.tgz",
+			"integrity": "sha512-xHPs1cFQ6R2GtDX3iT7am1NHdfv+LsCloCiIEif9H5tKg4iqJT0XRvCXIWsSDFJfaEWfavSiuDNl1wj9tYEQxQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/node-polyfills": "3.0.45"
+			},
+			"engines": {
+				"node": ">=20.18.3",
+				"npm": ">=10.1.0"
+			},
+			"optionalDependencies": {
+				"fs-ext": "2.1.1"
+			}
+		},
+		"node_modules/@php-wasm/node": {
+			"version": "3.0.45",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node/-/node-3.0.45.tgz",
+			"integrity": "sha512-Gc4lA12NSVEo2H/jq6TFgxp01GrE3tEzg5+59EeGnDGvpRw4gacmtr2jAQH3NzSeCCK1RjcTA//K7KGKzJbCzg==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/logger": "3.0.45",
+				"@php-wasm/node-7-4": "3.0.45",
+				"@php-wasm/node-8-0": "3.0.45",
+				"@php-wasm/node-8-1": "3.0.45",
+				"@php-wasm/node-8-2": "3.0.45",
+				"@php-wasm/node-8-3": "3.0.45",
+				"@php-wasm/node-8-4": "3.0.45",
+				"@php-wasm/node-8-5": "3.0.45",
+				"@php-wasm/node-polyfills": "3.0.45",
+				"@php-wasm/universal": "3.0.45",
+				"@php-wasm/util": "3.0.45",
+				"@wp-playground/common": "3.0.45",
+				"express": "4.22.0",
+				"ini": "4.1.2",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.3",
+				"yargs": "17.7.2"
+			},
+			"engines": {
+				"node": ">=20.18.3",
+				"npm": ">=10.1.0"
+			},
+			"optionalDependencies": {
+				"fs-ext": "2.1.1"
+			}
+		},
+		"node_modules/@php-wasm/node-7-4": {
+			"version": "3.0.45",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-7-4/-/node-7-4-3.0.45.tgz",
+			"integrity": "sha512-FefNAgnslcNQxdwy0Lq2SMGmamdevoBS977iuGWD0IjWEautD5XUXQm3ZDTLl7fZK+axup2m9Xk4vE6ZTzR3kg==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.0.45",
+				"ini": "4.1.2",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.3"
+			},
+			"engines": {
+				"node": ">=20.18.3",
+				"npm": ">=10.1.0"
+			},
+			"optionalDependencies": {
+				"fs-ext": "2.1.1"
+			}
+		},
+		"node_modules/@php-wasm/node-8-0": {
+			"version": "3.0.45",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-0/-/node-8-0-3.0.45.tgz",
+			"integrity": "sha512-i7KEvt8oT4ctD4qEPrR5onBKeQ2fm3fI5NpzLFvmoNnE7Nyo7O25nL1Kl4exyhlf4ce1tFTKETspUUNH6/sp4g==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.0.45",
+				"ini": "4.1.2",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.3"
+			},
+			"engines": {
+				"node": ">=20.18.3",
+				"npm": ">=10.1.0"
+			},
+			"optionalDependencies": {
+				"fs-ext": "2.1.1"
+			}
+		},
+		"node_modules/@php-wasm/node-8-1": {
+			"version": "3.0.45",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-1/-/node-8-1-3.0.45.tgz",
+			"integrity": "sha512-4eAn4zer6a6xrORZi9fglkQjIZny3dG9NOuGchdW2N43HJZ/NwBGSHmvw5iSuK9gGun17Wc/ImWcaZ/5x7YIPA==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.0.45",
+				"ini": "4.1.2",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.3"
+			},
+			"engines": {
+				"node": ">=20.18.3",
+				"npm": ">=10.1.0"
+			},
+			"optionalDependencies": {
+				"fs-ext": "2.1.1"
+			}
+		},
+		"node_modules/@php-wasm/node-8-2": {
+			"version": "3.0.45",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-2/-/node-8-2-3.0.45.tgz",
+			"integrity": "sha512-MXQsmN7rH0/W6rIH43jau6l3qSv0qfYhi5qJ2kh/FWOg1L2j8uOZ6hOodR8i8/T1cGcwDIA3a8qUjkSwc5Wt3g==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.0.45",
+				"ini": "4.1.2",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.3"
+			},
+			"engines": {
+				"node": ">=20.18.3",
+				"npm": ">=10.1.0"
+			},
+			"optionalDependencies": {
+				"fs-ext": "2.1.1"
+			}
+		},
+		"node_modules/@php-wasm/node-8-3": {
+			"version": "3.0.45",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-3/-/node-8-3-3.0.45.tgz",
+			"integrity": "sha512-1ThZDTdZSy0kzCQfbp8p2pRazVS0T3HLWOS/Uuk84eDLkhkVAhgoruQUytEhwp3c40fo1wNp2Lz80KhaIsPshQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.0.45",
+				"ini": "4.1.2",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.3"
+			},
+			"engines": {
+				"node": ">=20.18.3",
+				"npm": ">=10.1.0"
+			},
+			"optionalDependencies": {
+				"fs-ext": "2.1.1"
+			}
+		},
+		"node_modules/@php-wasm/node-8-4": {
+			"version": "3.0.45",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-4/-/node-8-4-3.0.45.tgz",
+			"integrity": "sha512-H/YRnlZRR3Z+n29vd0QzLFCoolAt35IAyI498O5On4gGVztIa7fIWgyP7vClI54efcMwdWcn23S+ZCoimQBUbA==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.0.45",
+				"ini": "4.1.2",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.3"
+			},
+			"engines": {
+				"node": ">=20.18.3",
+				"npm": ">=10.1.0"
+			},
+			"optionalDependencies": {
+				"fs-ext": "2.1.1"
+			}
+		},
+		"node_modules/@php-wasm/node-8-5": {
+			"version": "3.0.45",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-5/-/node-8-5-3.0.45.tgz",
+			"integrity": "sha512-XBKsinMicEyG9XrZuixcKL4k1s5Ur25Dy5P7WyXQP2CmEBad3G9zrguSOVG9ya5AknyLyOsKlqpT2iTcNuhhtA==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.0.45",
+				"ini": "4.1.2",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.3"
+			},
+			"engines": {
+				"node": ">=20.18.3",
+				"npm": ">=10.1.0"
+			},
+			"optionalDependencies": {
+				"fs-ext": "2.1.1"
+			}
+		},
+		"node_modules/@php-wasm/node-polyfills": {
+			"version": "3.0.45",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-polyfills/-/node-polyfills-3.0.45.tgz",
+			"integrity": "sha512-11q5j1YRPEg89PZpFPytcwvWuIH6rHpJ8gtgsrD5VS/FJDtXz52poOYo3pUVewL40yg7p4PNZtVMeAGKANAz8A==",
+			"license": "GPL-2.0-or-later",
+			"optionalDependencies": {
+				"fs-ext": "2.1.1"
+			}
+		},
+		"node_modules/@php-wasm/progress": {
+			"version": "3.0.45",
+			"resolved": "https://registry.npmjs.org/@php-wasm/progress/-/progress-3.0.45.tgz",
+			"integrity": "sha512-9cMcrF6+JcPnC12F5gXUk1zrP6TdFILa/6ejHbczvpfTMo+XDAdxMNH/Q5Zr5xEclsGYm3eYjruHFDQEG/zNjA==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/logger": "3.0.45",
+				"@php-wasm/node-polyfills": "3.0.45"
+			},
+			"engines": {
+				"node": ">=20.18.3",
+				"npm": ">=10.1.0"
+			},
+			"optionalDependencies": {
+				"fs-ext": "2.1.1"
+			}
+		},
+		"node_modules/@php-wasm/scopes": {
+			"version": "3.0.45",
+			"resolved": "https://registry.npmjs.org/@php-wasm/scopes/-/scopes-3.0.45.tgz",
+			"integrity": "sha512-hSwdT8+fX90sclFsfJaXzzCDeA6thmHDNu1CAXJYn7tF4QvmQ8VmgmYUsTC3g+h/gIFGMXAnDLVxqQq4+0eQLA==",
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=20.18.3",
+				"npm": ">=10.1.0"
+			},
+			"optionalDependencies": {
+				"fs-ext": "2.1.1"
+			}
+		},
+		"node_modules/@php-wasm/stream-compression": {
+			"version": "3.0.45",
+			"resolved": "https://registry.npmjs.org/@php-wasm/stream-compression/-/stream-compression-3.0.45.tgz",
+			"integrity": "sha512-DDedgiTQLkgHHEWh0neT2uyYRGyxpbFy4/QZh3LjPb4tyqh79shzbWYRAYffUItNJvqdgcczwCq1ZTHhYPzcEg==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/node-polyfills": "3.0.45",
+				"@php-wasm/util": "3.0.45"
+			},
+			"optionalDependencies": {
+				"fs-ext": "2.1.1"
+			}
+		},
+		"node_modules/@php-wasm/universal": {
+			"version": "3.0.45",
+			"resolved": "https://registry.npmjs.org/@php-wasm/universal/-/universal-3.0.45.tgz",
+			"integrity": "sha512-vBqtWWF4izntfYzdEA/BnYsbSaG2OKdTHP/TDzK3ATv53oYC5+UwEtlrkveGloU5Cg2rTr+RHobsmhoHFlfE1Q==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/logger": "3.0.45",
+				"@php-wasm/node-polyfills": "3.0.45",
+				"@php-wasm/progress": "3.0.45",
+				"@php-wasm/stream-compression": "3.0.45",
+				"@php-wasm/util": "3.0.45",
+				"ini": "4.1.2"
+			},
+			"engines": {
+				"node": ">=20.18.3",
+				"npm": ">=10.1.0"
+			},
+			"optionalDependencies": {
+				"fs-ext": "2.1.1"
+			}
+		},
+		"node_modules/@php-wasm/util": {
+			"version": "3.0.45",
+			"resolved": "https://registry.npmjs.org/@php-wasm/util/-/util-3.0.45.tgz",
+			"integrity": "sha512-A+BzuVJUSVXorSlhoAIQCsKtswYKS7Fv7/wCj8qzuHPGPEi3+vM1JprAfiHgkgoj+38St4eFSw9X38Hm1iel2w==",
+			"engines": {
+				"node": ">=20.18.3",
+				"npm": ">=10.1.0"
+			},
+			"optionalDependencies": {
+				"fs-ext": "2.1.1"
+			}
+		},
+		"node_modules/@php-wasm/web": {
+			"version": "3.0.45",
+			"resolved": "https://registry.npmjs.org/@php-wasm/web/-/web-3.0.45.tgz",
+			"integrity": "sha512-2xy2jGLFYUT4OzezONHpHr0VmKw3O/76UkEmFrFxVshJrQEoozJSeXq8wEuJBuORXAUhEYiBJGHPY0gHBcxiGg==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/fs-journal": "3.0.45",
+				"@php-wasm/logger": "3.0.45",
+				"@php-wasm/universal": "3.0.45",
+				"@php-wasm/util": "3.0.45",
+				"@php-wasm/web-7-4": "3.0.45",
+				"@php-wasm/web-8-0": "3.0.45",
+				"@php-wasm/web-8-1": "3.0.45",
+				"@php-wasm/web-8-2": "3.0.45",
+				"@php-wasm/web-8-3": "3.0.45",
+				"@php-wasm/web-8-4": "3.0.45",
+				"@php-wasm/web-8-5": "3.0.45",
+				"@php-wasm/web-service-worker": "3.0.45",
+				"@wp-playground/common": "3.0.45",
+				"express": "4.22.0",
+				"ini": "4.1.2",
+				"selfsigned": "5.5.0",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.3",
+				"yargs": "17.7.2"
+			},
+			"engines": {
+				"node": ">=20.18.3",
+				"npm": ">=10.1.0"
+			},
+			"optionalDependencies": {
+				"fs-ext": "2.1.1"
+			}
+		},
+		"node_modules/@php-wasm/web-7-4": {
+			"version": "3.0.45",
+			"resolved": "https://registry.npmjs.org/@php-wasm/web-7-4/-/web-7-4-3.0.45.tgz",
+			"integrity": "sha512-wljGdjkL5iOCt7JIhxQ3idfNBq+Zubvq+fAOzz8ztfowIFm266RzckiDYI3QRV0YjUGejuLF/SOsYiuRkFgqug==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.0.45",
+				"ini": "4.1.2",
+				"wasm-feature-detect": "1.8.0"
+			},
+			"engines": {
+				"node": ">=20.18.3",
+				"npm": ">=10.1.0"
+			},
+			"optionalDependencies": {
+				"fs-ext": "2.1.1"
+			}
+		},
+		"node_modules/@php-wasm/web-8-0": {
+			"version": "3.0.45",
+			"resolved": "https://registry.npmjs.org/@php-wasm/web-8-0/-/web-8-0-3.0.45.tgz",
+			"integrity": "sha512-G9YWs+uRpoNFFBPoLY3Vicz3/YShvX3lhyIV0tlnboGXXqULVZHnPIobXc78yYi9yJ3GtgKL+cues0vcr2BIOw==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.0.45",
+				"ini": "4.1.2",
+				"wasm-feature-detect": "1.8.0"
+			},
+			"engines": {
+				"node": ">=20.18.3",
+				"npm": ">=10.1.0"
+			},
+			"optionalDependencies": {
+				"fs-ext": "2.1.1"
+			}
+		},
+		"node_modules/@php-wasm/web-8-1": {
+			"version": "3.0.45",
+			"resolved": "https://registry.npmjs.org/@php-wasm/web-8-1/-/web-8-1-3.0.45.tgz",
+			"integrity": "sha512-BBAS/xUruDa8UdXhLI9BIZDX7YViEEncxHy5R5DZEKgN/VVtAlJ7/p+rhiNw4qh/DyUSAbA+LCmVn9lOZONOQg==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.0.45",
+				"ini": "4.1.2",
+				"wasm-feature-detect": "1.8.0"
+			},
+			"engines": {
+				"node": ">=20.18.3",
+				"npm": ">=10.1.0"
+			},
+			"optionalDependencies": {
+				"fs-ext": "2.1.1"
+			}
+		},
+		"node_modules/@php-wasm/web-8-2": {
+			"version": "3.0.45",
+			"resolved": "https://registry.npmjs.org/@php-wasm/web-8-2/-/web-8-2-3.0.45.tgz",
+			"integrity": "sha512-FL4vW1v3sgpaqvrsPquCAdlZyCGuxzpjVVUb8xCstxp9UrqWAxaAS5eD2PYhPv1XfblaXydkt1xrHaEdEfpv5Q==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.0.45",
+				"ini": "4.1.2",
+				"wasm-feature-detect": "1.8.0"
+			},
+			"engines": {
+				"node": ">=20.18.3",
+				"npm": ">=10.1.0"
+			},
+			"optionalDependencies": {
+				"fs-ext": "2.1.1"
+			}
+		},
+		"node_modules/@php-wasm/web-8-3": {
+			"version": "3.0.45",
+			"resolved": "https://registry.npmjs.org/@php-wasm/web-8-3/-/web-8-3-3.0.45.tgz",
+			"integrity": "sha512-MEXWD0zMGyGNdqOwPh0cr82hF7LGHIAYCtfpbXG7oQUVadtyZfTFXTswg8kkAPhIZy3WfWLWED1Y+DHvmAfF6g==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.0.45",
+				"ini": "4.1.2",
+				"wasm-feature-detect": "1.8.0"
+			},
+			"engines": {
+				"node": ">=20.18.3",
+				"npm": ">=10.1.0"
+			},
+			"optionalDependencies": {
+				"fs-ext": "2.1.1"
+			}
+		},
+		"node_modules/@php-wasm/web-8-4": {
+			"version": "3.0.45",
+			"resolved": "https://registry.npmjs.org/@php-wasm/web-8-4/-/web-8-4-3.0.45.tgz",
+			"integrity": "sha512-JtG9GyhH53kxPHut52Qaz6lJphuqrVrVpxhbNsneRTMg13YWTwKCtghdFYgS6Q4DET2xNCVAyguu4QIBHu2uPQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.0.45",
+				"ini": "4.1.2",
+				"wasm-feature-detect": "1.8.0"
+			},
+			"engines": {
+				"node": ">=20.18.3",
+				"npm": ">=10.1.0"
+			},
+			"optionalDependencies": {
+				"fs-ext": "2.1.1"
+			}
+		},
+		"node_modules/@php-wasm/web-8-5": {
+			"version": "3.0.45",
+			"resolved": "https://registry.npmjs.org/@php-wasm/web-8-5/-/web-8-5-3.0.45.tgz",
+			"integrity": "sha512-XJmQwp6/a+dNkBLGlKggZVd4lhho6d/n+j/YUDV3AObUg3uuLRvx9NU6Gm1/z5Tss7Mq90AQfTNdqg/qS4FJoA==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.0.45",
+				"ini": "4.1.2",
+				"wasm-feature-detect": "1.8.0"
+			},
+			"engines": {
+				"node": ">=20.18.3",
+				"npm": ">=10.1.0"
+			},
+			"optionalDependencies": {
+				"fs-ext": "2.1.1"
+			}
+		},
+		"node_modules/@php-wasm/web-service-worker": {
+			"version": "3.0.45",
+			"resolved": "https://registry.npmjs.org/@php-wasm/web-service-worker/-/web-service-worker-3.0.45.tgz",
+			"integrity": "sha512-OSAQl0LyyUtaUeKmrvpezLoNA5sdBCWT/aD95Jzr0O8EiZ1W4aSGctclsFoH3Jf6tgBr5oSz44UOKpK3QolBrA==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/scopes": "3.0.45"
+			},
+			"engines": {
+				"node": ">=20.18.3",
+				"npm": ">=10.1.0"
+			},
+			"optionalDependencies": {
+				"fs-ext": "2.1.1"
+			}
+		},
+		"node_modules/@php-wasm/xdebug-bridge": {
+			"version": "3.0.45",
+			"resolved": "https://registry.npmjs.org/@php-wasm/xdebug-bridge/-/xdebug-bridge-3.0.45.tgz",
+			"integrity": "sha512-y3DfkKZMxsso/1pgv4cCC1Ar3UrilMh8qDbFUeLaj+2sVguM3jmhdxP9V8zpipsAsPtp+jyVTheIzvA5DUQurA==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/logger": "3.0.45",
+				"@php-wasm/node": "3.0.45",
+				"@php-wasm/universal": "3.0.45",
+				"@wp-playground/common": "3.0.45",
+				"express": "4.22.0",
+				"ini": "4.1.2",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.3",
+				"xml2js": "0.6.2",
+				"yargs": "17.7.2"
+			},
+			"bin": {
+				"xdebug-bridge": "xdebug-bridge.js"
+			},
+			"engines": {
+				"node": ">=20.18.3",
+				"npm": ">=10.1.0"
+			},
+			"optionalDependencies": {
+				"fs-ext": "2.1.1"
+			}
+		},
+		"node_modules/@types/aws-lambda": {
+			"version": "8.10.160",
+			"resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.160.tgz",
+			"integrity": "sha512-uoO4QVQNWFPJMh26pXtmtrRfGshPUSpMZGUyUQY20FhfHEElEBOPKgVmFs1z+kbpyBsRs2JnoOPT7++Z4GA9pA==",
+			"license": "MIT"
+		},
+		"node_modules/@types/btoa-lite": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@types/btoa-lite/-/btoa-lite-1.0.2.tgz",
+			"integrity": "sha512-ZYbcE2x7yrvNFJiU7xJGrpF/ihpkM7zKgw8bha3LNJSesvTtUNxbpzaT7WXBIryf6jovisrxTBvymxMeLLj1Mg==",
+			"license": "MIT"
+		},
+		"node_modules/@types/jsonwebtoken": {
+			"version": "9.0.10",
+			"resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz",
+			"integrity": "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/ms": "*",
+				"@types/node": "*"
+			}
+		},
+		"node_modules/@types/ms": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+			"integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+			"license": "MIT"
+		},
+		"node_modules/@types/node": {
+			"version": "20.19.30",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.30.tgz",
+			"integrity": "sha512-WJtwWJu7UdlvzEAUm484QNg5eAoq5QR08KDNx7g45Usrs2NtOPiX8ugDqmKdXkyL03rBqU5dYNYVQetEpBHq2g==",
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~6.21.0"
+			}
+		},
+		"node_modules/@wp-playground/blueprints": {
+			"version": "3.0.45",
+			"resolved": "https://registry.npmjs.org/@wp-playground/blueprints/-/blueprints-3.0.45.tgz",
+			"integrity": "sha512-RnrQI7KwsnbRKIT5F3DGWdL2GEHaTb+JOebTN6XIKOdBwucJX5CyBeTrA44+kxigEvlfnO3Jo7YSGpTeYGa5+A==",
+			"dependencies": {
+				"@php-wasm/logger": "3.0.45",
+				"@php-wasm/node": "3.0.45",
+				"@php-wasm/node-polyfills": "3.0.45",
+				"@php-wasm/progress": "3.0.45",
+				"@php-wasm/scopes": "3.0.45",
+				"@php-wasm/stream-compression": "3.0.45",
+				"@php-wasm/universal": "3.0.45",
+				"@php-wasm/util": "3.0.45",
+				"@php-wasm/web": "3.0.45",
+				"@wp-playground/common": "3.0.45",
+				"@wp-playground/storage": "3.0.45",
+				"@wp-playground/wordpress": "3.0.45",
+				"@zip.js/zip.js": "2.7.57",
+				"ajv": "8.12.0",
+				"async-lock": "1.4.1",
+				"clean-git-ref": "2.0.1",
+				"crc-32": "1.2.2",
+				"diff3": "0.0.4",
+				"express": "4.22.0",
+				"ignore": "5.3.2",
+				"ini": "4.1.2",
+				"minimisted": "2.0.1",
+				"octokit": "3.1.2",
+				"pako": "1.0.10",
+				"pify": "2.3.0",
+				"readable-stream": "3.6.2",
+				"selfsigned": "5.5.0",
+				"sha.js": "2.4.12",
+				"simple-get": "4.0.1",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.3",
+				"yargs": "17.7.2"
+			},
+			"engines": {
+				"node": ">=20.18.3",
+				"npm": ">=10.1.0"
+			},
+			"optionalDependencies": {
+				"fs-ext": "2.1.1"
+			}
+		},
+		"node_modules/@wp-playground/cli": {
+			"version": "3.0.45",
+			"resolved": "https://registry.npmjs.org/@wp-playground/cli/-/cli-3.0.45.tgz",
+			"integrity": "sha512-GvjWYJnexdrIxPlD6BoI39rBgG3dmadBM86UMNxe7t5PGZtcxy0vJITmvAAfubEd5Ks+93stiAJF9tcj4FM4Qg==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/cli-util": "3.0.45",
+				"@php-wasm/logger": "3.0.45",
+				"@php-wasm/node": "3.0.45",
+				"@php-wasm/progress": "3.0.45",
+				"@php-wasm/universal": "3.0.45",
+				"@php-wasm/util": "3.0.45",
+				"@php-wasm/xdebug-bridge": "3.0.45",
+				"@wp-playground/blueprints": "3.0.45",
+				"@wp-playground/common": "3.0.45",
+				"@wp-playground/storage": "3.0.45",
+				"@wp-playground/wordpress": "3.0.45",
+				"@zip.js/zip.js": "2.7.57",
+				"ajv": "8.12.0",
+				"async-lock": "1.4.1",
+				"clean-git-ref": "2.0.1",
+				"crc-32": "1.2.2",
+				"diff3": "0.0.4",
+				"express": "4.22.0",
+				"fast-xml-parser": "5.3.0",
+				"fs-extra": "11.1.1",
+				"ignore": "5.3.2",
+				"ini": "4.1.2",
+				"jsonc-parser": "3.3.1",
+				"minimisted": "2.0.1",
+				"octokit": "3.1.2",
+				"pako": "1.0.10",
+				"pify": "2.3.0",
+				"ps-man": "1.1.8",
+				"readable-stream": "3.6.2",
+				"selfsigned": "5.5.0",
+				"sha.js": "2.4.12",
+				"simple-get": "4.0.1",
+				"tmp-promise": "3.0.3",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.3",
+				"xml2js": "0.6.2",
+				"yargs": "17.7.2"
+			},
+			"bin": {
+				"wp-playground-cli": "wp-playground.js"
+			},
+			"optionalDependencies": {
+				"fs-ext": "2.1.1"
+			}
+		},
+		"node_modules/@wp-playground/common": {
+			"version": "3.0.45",
+			"resolved": "https://registry.npmjs.org/@wp-playground/common/-/common-3.0.45.tgz",
+			"integrity": "sha512-qVgzM9QPvIq32RBuEnRoY3Sj+sSKYMpj3fdKYYMEzqlFS5S3XhLryBGCFPfEqV9+0P4XeUeTnyRnQdtH1dkJvQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.0.45",
+				"@php-wasm/util": "3.0.45",
+				"ini": "4.1.2"
+			},
+			"engines": {
+				"node": ">=20.18.3",
+				"npm": ">=10.1.0"
+			},
+			"optionalDependencies": {
+				"fs-ext": "2.1.1"
+			}
+		},
+		"node_modules/@wp-playground/storage": {
+			"version": "3.0.45",
+			"resolved": "https://registry.npmjs.org/@wp-playground/storage/-/storage-3.0.45.tgz",
+			"integrity": "sha512-q95z/KNtP9ZmWOjSfCXLw0KBhBFqRqXirltgk3+Di9iWLA9YRdCcu7Cj8V/H6ywRTOqb/gAJ0RVkv5f15FwwUA==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/stream-compression": "3.0.45",
+				"@php-wasm/universal": "3.0.45",
+				"@php-wasm/util": "3.0.45",
+				"@php-wasm/web": "3.0.45",
+				"@zip.js/zip.js": "2.7.57",
+				"async-lock": "^1.4.1",
+				"clean-git-ref": "^2.0.1",
+				"crc-32": "^1.2.0",
+				"diff3": "0.0.3",
+				"express": "4.22.0",
+				"ignore": "^5.1.4",
+				"ini": "4.1.2",
+				"minimisted": "^2.0.0",
+				"octokit": "3.1.2",
+				"pako": "^1.0.10",
+				"pify": "^4.0.1",
+				"readable-stream": "^3.4.0",
+				"selfsigned": "5.5.0",
+				"sha.js": "^2.4.9",
+				"simple-get": "^4.0.1",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.3",
+				"yargs": "17.7.2"
+			},
+			"optionalDependencies": {
+				"fs-ext": "2.1.1"
+			}
+		},
+		"node_modules/@wp-playground/storage/node_modules/diff3": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/diff3/-/diff3-0.0.3.tgz",
+			"integrity": "sha512-iSq8ngPOt0K53A6eVr4d5Kn6GNrM2nQZtC740pzIriHtn4pOQ2lyzEXQMBeVcWERN0ye7fhBsk9PbLLQOnUx/g==",
+			"license": "MIT"
+		},
+		"node_modules/@wp-playground/storage/node_modules/pify": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+			"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/@wp-playground/wordpress": {
+			"version": "3.0.45",
+			"resolved": "https://registry.npmjs.org/@wp-playground/wordpress/-/wordpress-3.0.45.tgz",
+			"integrity": "sha512-I1NIZRBP2y+UQCITBu4qHizS0QgftfM+E5DfCBp33lF7yW4h/3xJSwdb9t3jaE8tUaVCLSlmhauKc+4CGqwUgA==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/logger": "3.0.45",
+				"@php-wasm/node": "3.0.45",
+				"@php-wasm/universal": "3.0.45",
+				"@php-wasm/util": "3.0.45",
+				"@wp-playground/common": "3.0.45",
+				"express": "4.22.0",
+				"ini": "4.1.2",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.3",
+				"yargs": "17.7.2"
+			},
+			"engines": {
+				"node": ">=20.18.3",
+				"npm": ">=10.1.0"
+			},
+			"optionalDependencies": {
+				"fs-ext": "2.1.1"
+			}
+		},
+		"node_modules/@zip.js/zip.js": {
+			"version": "2.7.57",
+			"resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.7.57.tgz",
+			"integrity": "sha512-BtonQ1/jDnGiMed6OkV6rZYW78gLmLswkHOzyMrMb+CAR7CZO8phOHO6c2qw6qb1g1betN7kwEHhhZk30dv+NA==",
+			"license": "BSD-3-Clause",
+			"engines": {
+				"bun": ">=0.7.0",
+				"deno": ">=1.0.0",
+				"node": ">=16.5.0"
+			}
+		},
+		"node_modules/accepts": {
+			"version": "1.3.8",
+			"resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+			"integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+			"license": "MIT",
+			"dependencies": {
+				"mime-types": "~2.1.34",
+				"negotiator": "0.6.3"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/aggregate-error": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+			"integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+			"license": "MIT",
+			"dependencies": {
+				"clean-stack": "^2.0.0",
+				"indent-string": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/ajv": {
+			"version": "8.12.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+			"integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+			"license": "MIT",
+			"dependencies": {
+				"fast-deep-equal": "^3.1.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2",
+				"uri-js": "^4.2.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"license": "MIT",
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/array-flatten": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+			"integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+			"license": "MIT"
+		},
+		"node_modules/asn1js": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.7.tgz",
+			"integrity": "sha512-uLvq6KJu04qoQM6gvBfKFjlh6Gl0vOKQuR5cJMDHQkmwfMOQeN3F3SHCv9SNYSL+CRoHvOGFfllDlVz03GQjvQ==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"pvtsutils": "^1.3.6",
+				"pvutils": "^1.1.3",
+				"tslib": "^2.8.1"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/async-lock": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/async-lock/-/async-lock-1.4.1.tgz",
+			"integrity": "sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ==",
+			"license": "MIT"
+		},
+		"node_modules/available-typed-arrays": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+			"integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+			"license": "MIT",
+			"dependencies": {
+				"possible-typed-array-names": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/before-after-hook": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
+			"integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
+			"license": "Apache-2.0"
+		},
+		"node_modules/body-parser": {
+			"version": "1.20.4",
+			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
+			"integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
+			"license": "MIT",
+			"dependencies": {
+				"bytes": "~3.1.2",
+				"content-type": "~1.0.5",
+				"debug": "2.6.9",
+				"depd": "2.0.0",
+				"destroy": "~1.2.0",
+				"http-errors": "~2.0.1",
+				"iconv-lite": "~0.4.24",
+				"on-finished": "~2.4.1",
+				"qs": "~6.14.0",
+				"raw-body": "~2.5.3",
+				"type-is": "~1.6.18",
+				"unpipe": "~1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.8",
+				"npm": "1.2.8000 || >= 1.4.16"
+			}
+		},
+		"node_modules/bottleneck": {
+			"version": "2.19.5",
+			"resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
+			"integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==",
+			"license": "MIT"
+		},
+		"node_modules/btoa-lite": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/btoa-lite/-/btoa-lite-1.0.0.tgz",
+			"integrity": "sha512-gvW7InbIyF8AicrqWoptdW08pUxuhq8BEgowNajy9RhiE86fmGAGl+bLKo6oB8QP0CkqHLowfN0oJdKC/J6LbA==",
+			"license": "MIT"
+		},
+		"node_modules/buffer-equal-constant-time": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+			"integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/bytes": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+			"integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/bytestreamjs": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/bytestreamjs/-/bytestreamjs-2.0.1.tgz",
+			"integrity": "sha512-U1Z/ob71V/bXfVABvNr/Kumf5VyeQRBEm6Txb0PQ6S7V5GpBM3w4Cbqz/xPDicR5tN0uvDifng8C+5qECeGwyQ==",
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/call-bind": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+			"integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.0",
+				"es-define-property": "^1.0.0",
+				"get-intrinsic": "^1.2.4",
+				"set-function-length": "^1.2.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/call-bind-apply-helpers": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+			"integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"function-bind": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/call-bound": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+			"integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.2",
+				"get-intrinsic": "^1.3.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/chalk": {
+			"version": "5.6.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+			"integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+			"license": "MIT",
+			"engines": {
+				"node": "^12.17.0 || ^14.13 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/clean-git-ref": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/clean-git-ref/-/clean-git-ref-2.0.1.tgz",
+			"integrity": "sha512-bLSptAy2P0s6hU4PzuIMKmMJJSE6gLXGH1cntDu7bWJUksvuM+7ReOK61mozULErYvP6a15rnYl0zFDef+pyPw==",
+			"license": "Apache-2.0"
+		},
+		"node_modules/clean-stack": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+			"integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/cliui": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+			"integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+			"license": "ISC",
+			"dependencies": {
+				"string-width": "^4.2.0",
+				"strip-ansi": "^6.0.1",
+				"wrap-ansi": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"license": "MIT",
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"license": "MIT"
+		},
+		"node_modules/content-disposition": {
+			"version": "0.5.4",
+			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+			"integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+			"license": "MIT",
+			"dependencies": {
+				"safe-buffer": "5.2.1"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/content-type": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+			"integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/cookie": {
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+			"integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/cookie-signature": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+			"integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+			"license": "MIT"
+		},
+		"node_modules/crc-32": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+			"integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+			"license": "Apache-2.0",
+			"bin": {
+				"crc32": "bin/crc32.njs"
+			},
+			"engines": {
+				"node": ">=0.8"
+			}
+		},
+		"node_modules/debug": {
+			"version": "2.6.9",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"license": "MIT",
+			"dependencies": {
+				"ms": "2.0.0"
+			}
+		},
+		"node_modules/decompress-response": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+			"integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+			"license": "MIT",
+			"dependencies": {
+				"mimic-response": "^3.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/define-data-property": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+			"integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+			"license": "MIT",
+			"dependencies": {
+				"es-define-property": "^1.0.0",
+				"es-errors": "^1.3.0",
+				"gopd": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/depd": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+			"integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/deprecation": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+			"integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
+			"license": "ISC"
+		},
+		"node_modules/destroy": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+			"integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8",
+				"npm": "1.2.8000 || >= 1.4.16"
+			}
+		},
+		"node_modules/diff3": {
+			"version": "0.0.4",
+			"resolved": "https://registry.npmjs.org/diff3/-/diff3-0.0.4.tgz",
+			"integrity": "sha512-f1rQ7jXDn/3i37hdwRk9ohqcvLRH3+gEIgmA6qEM280WUOh7cOr3GXV8Jm5sPwUs46Nzl48SE8YNLGJoaLuodg==",
+			"license": "MIT"
+		},
+		"node_modules/dunder-proto": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+			"integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.1",
+				"es-errors": "^1.3.0",
+				"gopd": "^1.2.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/ecdsa-sig-formatter": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+			"integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/ee-first": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+			"integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+			"license": "MIT"
+		},
+		"node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"license": "MIT"
+		},
+		"node_modules/encodeurl": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+			"integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/es-define-property": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+			"integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-errors": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+			"integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-object-atoms": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+			"integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/esbuild": {
+			"version": "0.27.2",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.2.tgz",
+			"integrity": "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==",
+			"hasInstallScript": true,
+			"license": "MIT",
+			"bin": {
+				"esbuild": "bin/esbuild"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"optionalDependencies": {
+				"@esbuild/aix-ppc64": "0.27.2",
+				"@esbuild/android-arm": "0.27.2",
+				"@esbuild/android-arm64": "0.27.2",
+				"@esbuild/android-x64": "0.27.2",
+				"@esbuild/darwin-arm64": "0.27.2",
+				"@esbuild/darwin-x64": "0.27.2",
+				"@esbuild/freebsd-arm64": "0.27.2",
+				"@esbuild/freebsd-x64": "0.27.2",
+				"@esbuild/linux-arm": "0.27.2",
+				"@esbuild/linux-arm64": "0.27.2",
+				"@esbuild/linux-ia32": "0.27.2",
+				"@esbuild/linux-loong64": "0.27.2",
+				"@esbuild/linux-mips64el": "0.27.2",
+				"@esbuild/linux-ppc64": "0.27.2",
+				"@esbuild/linux-riscv64": "0.27.2",
+				"@esbuild/linux-s390x": "0.27.2",
+				"@esbuild/linux-x64": "0.27.2",
+				"@esbuild/netbsd-arm64": "0.27.2",
+				"@esbuild/netbsd-x64": "0.27.2",
+				"@esbuild/openbsd-arm64": "0.27.2",
+				"@esbuild/openbsd-x64": "0.27.2",
+				"@esbuild/openharmony-arm64": "0.27.2",
+				"@esbuild/sunos-x64": "0.27.2",
+				"@esbuild/win32-arm64": "0.27.2",
+				"@esbuild/win32-ia32": "0.27.2",
+				"@esbuild/win32-x64": "0.27.2"
+			}
+		},
+		"node_modules/escalade": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+			"integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/escape-html": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+			"integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+			"license": "MIT"
+		},
+		"node_modules/etag": {
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+			"integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/express": {
+			"version": "4.22.0",
+			"resolved": "https://registry.npmjs.org/express/-/express-4.22.0.tgz",
+			"integrity": "sha512-c2iPh3xp5vvCLgaHK03+mWLFPhox7j1LwyxcZwFVApEv5i0X+IjPpbT50SJJwwLpdBVfp45AkK/v+AFgv/XlfQ==",
+			"license": "MIT",
+			"dependencies": {
+				"accepts": "~1.3.8",
+				"array-flatten": "1.1.1",
+				"body-parser": "~1.20.3",
+				"content-disposition": "~0.5.4",
+				"content-type": "~1.0.4",
+				"cookie": "~0.7.1",
+				"cookie-signature": "~1.0.6",
+				"debug": "2.6.9",
+				"depd": "2.0.0",
+				"encodeurl": "~2.0.0",
+				"escape-html": "~1.0.3",
+				"etag": "~1.8.1",
+				"finalhandler": "~1.3.1",
+				"fresh": "~0.5.2",
+				"http-errors": "~2.0.0",
+				"merge-descriptors": "1.0.3",
+				"methods": "~1.1.2",
+				"on-finished": "~2.4.1",
+				"parseurl": "~1.3.3",
+				"path-to-regexp": "~0.1.12",
+				"proxy-addr": "~2.0.7",
+				"qs": "~6.14.0",
+				"range-parser": "~1.2.1",
+				"safe-buffer": "5.2.1",
+				"send": "~0.19.0",
+				"serve-static": "~1.16.2",
+				"setprototypeof": "1.2.0",
+				"statuses": "~2.0.1",
+				"type-is": "~1.6.18",
+				"utils-merge": "1.0.1",
+				"vary": "~1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.10.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/fast-deep-equal": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+			"license": "MIT"
+		},
+		"node_modules/fast-xml-parser": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.0.tgz",
+			"integrity": "sha512-gkWGshjYcQCF+6qtlrqBqELqNqnt4CxruY6UVAWWnqb3DQ6qaNFEIKqzYep1XzHLM/QtrHVCxyPOtTk4LTQ7Aw==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"strnum": "^2.1.0"
+			},
+			"bin": {
+				"fxparser": "src/cli/cli.js"
+			}
+		},
+		"node_modules/finalhandler": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+			"integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+			"license": "MIT",
+			"dependencies": {
+				"debug": "2.6.9",
+				"encodeurl": "~2.0.0",
+				"escape-html": "~1.0.3",
+				"on-finished": "~2.4.1",
+				"parseurl": "~1.3.3",
+				"statuses": "~2.0.2",
+				"unpipe": "~1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/for-each": {
+			"version": "0.3.5",
+			"resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+			"integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+			"license": "MIT",
+			"dependencies": {
+				"is-callable": "^1.2.7"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/forwarded": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+			"integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/fresh": {
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+			"integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/fs-ext": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/fs-ext/-/fs-ext-2.1.1.tgz",
+			"integrity": "sha512-/TrISPOFhCkbgIRWK9lzscRzwPCu0PqtCcvMc9jsHKBgZGoqA0VzhspVht5Zu8lxaXjIYIBWILHpRotYkCCcQA==",
+			"hasInstallScript": true,
+			"optional": true,
+			"dependencies": {
+				"nan": "^2.21.0"
+			},
+			"engines": {
+				"node": ">= 8.0.0"
+			}
+		},
+		"node_modules/fs-extra": {
+			"version": "11.1.1",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
+			"integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
+			"license": "MIT",
+			"dependencies": {
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^6.0.1",
+				"universalify": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=14.14"
+			}
+		},
+		"node_modules/fsevents": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
+		},
+		"node_modules/function-bind": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/get-caller-file": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+			"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+			"license": "ISC",
+			"engines": {
+				"node": "6.* || 8.* || >= 10.*"
+			}
+		},
+		"node_modules/get-intrinsic": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+			"integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.2",
+				"es-define-property": "^1.0.1",
+				"es-errors": "^1.3.0",
+				"es-object-atoms": "^1.1.1",
+				"function-bind": "^1.1.2",
+				"get-proto": "^1.0.1",
+				"gopd": "^1.2.0",
+				"has-symbols": "^1.1.0",
+				"hasown": "^2.0.2",
+				"math-intrinsics": "^1.1.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/get-proto": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+			"integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+			"license": "MIT",
+			"dependencies": {
+				"dunder-proto": "^1.0.1",
+				"es-object-atoms": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/get-tsconfig": {
+			"version": "4.13.0",
+			"resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.0.tgz",
+			"integrity": "sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==",
+			"license": "MIT",
+			"dependencies": {
+				"resolve-pkg-maps": "^1.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+			}
+		},
+		"node_modules/gopd": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+			"integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/graceful-fs": {
+			"version": "4.2.11",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+			"license": "ISC"
+		},
+		"node_modules/has-property-descriptors": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+			"integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+			"license": "MIT",
+			"dependencies": {
+				"es-define-property": "^1.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/has-symbols": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+			"integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/has-tostringtag": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+			"integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+			"license": "MIT",
+			"dependencies": {
+				"has-symbols": "^1.0.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/hasown": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+			"integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+			"license": "MIT",
+			"dependencies": {
+				"function-bind": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/http-errors": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+			"integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+			"license": "MIT",
+			"dependencies": {
+				"depd": "~2.0.0",
+				"inherits": "~2.0.4",
+				"setprototypeof": "~1.2.0",
+				"statuses": "~2.0.2",
+				"toidentifier": "~1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/iconv-lite": {
+			"version": "0.4.24",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+			"license": "MIT",
+			"dependencies": {
+				"safer-buffer": ">= 2.1.2 < 3"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/ignore": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+			"integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
+			}
+		},
+		"node_modules/indent-string": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+			"integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/inherits": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+			"license": "ISC"
+		},
+		"node_modules/ini": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
+			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/ipaddr.js": {
+			"version": "1.9.1",
+			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+			"integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.10"
+			}
+		},
+		"node_modules/is-callable": {
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+			"integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-fullwidth-code-point": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/is-typed-array": {
+			"version": "1.1.15",
+			"resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+			"integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+			"license": "MIT",
+			"dependencies": {
+				"which-typed-array": "^1.1.16"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/isarray": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+			"integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+			"license": "MIT"
+		},
+		"node_modules/json-schema-traverse": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+			"license": "MIT"
+		},
+		"node_modules/jsonc-parser": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+			"integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+			"license": "MIT"
+		},
+		"node_modules/jsonfile": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+			"integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+			"license": "MIT",
+			"dependencies": {
+				"universalify": "^2.0.0"
+			},
+			"optionalDependencies": {
+				"graceful-fs": "^4.1.6"
+			}
+		},
+		"node_modules/jsonwebtoken": {
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+			"integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+			"license": "MIT",
+			"dependencies": {
+				"jws": "^4.0.1",
+				"lodash.includes": "^4.3.0",
+				"lodash.isboolean": "^3.0.3",
+				"lodash.isinteger": "^4.0.4",
+				"lodash.isnumber": "^3.0.3",
+				"lodash.isplainobject": "^4.0.6",
+				"lodash.isstring": "^4.0.1",
+				"lodash.once": "^4.0.0",
+				"ms": "^2.1.1",
+				"semver": "^7.5.4"
+			},
+			"engines": {
+				"node": ">=12",
+				"npm": ">=6"
+			}
+		},
+		"node_modules/jsonwebtoken/node_modules/ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"license": "MIT"
+		},
+		"node_modules/jwa": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+			"integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+			"license": "MIT",
+			"dependencies": {
+				"buffer-equal-constant-time": "^1.0.1",
+				"ecdsa-sig-formatter": "1.0.11",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/jws": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+			"integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+			"license": "MIT",
+			"dependencies": {
+				"jwa": "^2.0.1",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/lodash.includes": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+			"integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+			"license": "MIT"
+		},
+		"node_modules/lodash.isboolean": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+			"integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+			"license": "MIT"
+		},
+		"node_modules/lodash.isinteger": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+			"integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+			"license": "MIT"
+		},
+		"node_modules/lodash.isnumber": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+			"integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+			"license": "MIT"
+		},
+		"node_modules/lodash.isplainobject": {
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+			"integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+			"license": "MIT"
+		},
+		"node_modules/lodash.isstring": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+			"integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+			"license": "MIT"
+		},
+		"node_modules/lodash.once": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+			"integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+			"license": "MIT"
+		},
+		"node_modules/lru-cache": {
+			"name": "@wolfy1339/lru-cache",
+			"version": "11.0.2-patch.1",
+			"resolved": "https://registry.npmjs.org/@wolfy1339/lru-cache/-/lru-cache-11.0.2-patch.1.tgz",
+			"integrity": "sha512-BgYZfL2ADCXKOw2wJtkM3slhHotawWkgIRRxq4wEybnZQPjvAp71SPX35xepMykTw8gXlzWcWPTY31hlbnRsDA==",
+			"license": "ISC",
+			"engines": {
+				"node": "18 >=18.20 || 20 || >=22"
+			}
+		},
+		"node_modules/math-intrinsics": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+			"integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/media-typer": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+			"integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/merge-descriptors": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+			"integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/methods": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+			"integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/mime": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+			"integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+			"license": "MIT",
+			"bin": {
+				"mime": "cli.js"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/mime-db": {
+			"version": "1.52.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/mime-types": {
+			"version": "2.1.35",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+			"integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+			"license": "MIT",
+			"dependencies": {
+				"mime-db": "1.52.0"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/mimic-response": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+			"integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/minimist": {
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+			"integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/minimisted": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/minimisted/-/minimisted-2.0.1.tgz",
+			"integrity": "sha512-1oPjfuLQa2caorJUM8HV8lGgWCc0qqAO1MNv/k05G4qslmsndV/5WdNZrqCiyqiz3wohia2Ij2B7w2Dr7/IyrA==",
+			"license": "MIT",
+			"dependencies": {
+				"minimist": "^1.2.5"
+			}
+		},
+		"node_modules/ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+			"license": "MIT"
+		},
+		"node_modules/nan": {
+			"version": "2.24.0",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.24.0.tgz",
+			"integrity": "sha512-Vpf9qnVW1RaDkoNKFUvfxqAbtI8ncb8OJlqZ9wwpXzWPEsvsB1nvdUi6oYrHIkQ1Y/tMDnr1h4nczS0VB9Xykg==",
+			"license": "MIT",
+			"optional": true
+		},
+		"node_modules/negotiator": {
+			"version": "0.6.3",
+			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+			"integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/object-inspect": {
+			"version": "1.13.4",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+			"integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/octokit": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/octokit/-/octokit-3.1.2.tgz",
+			"integrity": "sha512-MG5qmrTL5y8KYwFgE1A4JWmgfQBaIETE/lOlfwNYx1QOtCQHGVxkRJmdUJltFc1HVn73d61TlMhMyNTOtMl+ng==",
+			"license": "MIT",
+			"dependencies": {
+				"@octokit/app": "^14.0.2",
+				"@octokit/core": "^5.0.0",
+				"@octokit/oauth-app": "^6.0.0",
+				"@octokit/plugin-paginate-graphql": "^4.0.0",
+				"@octokit/plugin-paginate-rest": "^9.0.0",
+				"@octokit/plugin-rest-endpoint-methods": "^10.0.0",
+				"@octokit/plugin-retry": "^6.0.0",
+				"@octokit/plugin-throttling": "^8.0.0",
+				"@octokit/request-error": "^5.0.0",
+				"@octokit/types": "^12.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/on-finished": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+			"integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+			"license": "MIT",
+			"dependencies": {
+				"ee-first": "1.1.1"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+			"license": "ISC",
+			"dependencies": {
+				"wrappy": "1"
+			}
+		},
+		"node_modules/pako": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.10.tgz",
+			"integrity": "sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw==",
+			"license": "(MIT AND Zlib)"
+		},
+		"node_modules/parseurl": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+			"integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/path-to-regexp": {
+			"version": "0.1.12",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+			"integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+			"license": "MIT"
+		},
+		"node_modules/pify": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+			"integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/pkijs": {
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/pkijs/-/pkijs-3.3.3.tgz",
+			"integrity": "sha512-+KD8hJtqQMYoTuL1bbGOqxb4z+nZkTAwVdNtWwe8Tc2xNbEmdJYIYoc6Qt0uF55e6YW6KuTHw1DjQ18gMhzepw==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@noble/hashes": "1.4.0",
+				"asn1js": "^3.0.6",
+				"bytestreamjs": "^2.0.1",
+				"pvtsutils": "^1.3.6",
+				"pvutils": "^1.1.3",
+				"tslib": "^2.8.1"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/possible-typed-array-names": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+			"integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/proxy-addr": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+			"integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+			"license": "MIT",
+			"dependencies": {
+				"forwarded": "0.2.0",
+				"ipaddr.js": "1.9.1"
+			},
+			"engines": {
+				"node": ">= 0.10"
+			}
+		},
+		"node_modules/ps-man": {
+			"version": "1.1.8",
+			"resolved": "https://registry.npmjs.org/ps-man/-/ps-man-1.1.8.tgz",
+			"integrity": "sha512-ZKDPZwHLYVWIk/Q75N7jCFbuQyokSg2+3WBlt8l35S/uBvxoc+LiRUbb3RUt83pwW82dzwiCpoQIHd9PAxUzHg==",
+			"license": "MIT"
+		},
+		"node_modules/punycode": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+			"integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/pvtsutils": {
+			"version": "1.3.6",
+			"resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
+			"integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
+			"license": "MIT",
+			"dependencies": {
+				"tslib": "^2.8.1"
+			}
+		},
+		"node_modules/pvutils": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.5.tgz",
+			"integrity": "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/qs": {
+			"version": "6.14.1",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
+			"integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"side-channel": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=0.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/range-parser": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+			"integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/raw-body": {
+			"version": "2.5.3",
+			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+			"integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+			"license": "MIT",
+			"dependencies": {
+				"bytes": "~3.1.2",
+				"http-errors": "~2.0.1",
+				"iconv-lite": "~0.4.24",
+				"unpipe": "~1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/readable-stream": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+			"license": "MIT",
+			"dependencies": {
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/reflect-metadata": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+			"integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
+			"license": "Apache-2.0"
+		},
+		"node_modules/require-directory": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+			"integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/require-from-string": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/resolve-pkg-maps": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+			"integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+			}
+		},
+		"node_modules/safe-buffer": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/safer-buffer": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+			"license": "MIT"
+		},
+		"node_modules/sax": {
+			"version": "1.4.4",
+			"resolved": "https://registry.npmjs.org/sax/-/sax-1.4.4.tgz",
+			"integrity": "sha512-1n3r/tGXO6b6VXMdFT54SHzT9ytu9yr7TaELowdYpMqY/Ao7EnlQGmAQ1+RatX7Tkkdm6hONI2owqNx2aZj5Sw==",
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=11.0.0"
+			}
+		},
+		"node_modules/selfsigned": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-5.5.0.tgz",
+			"integrity": "sha512-ftnu3TW4+3eBfLRFnDEkzGxSF/10BJBkaLJuBHZX0kiPS7bRdlpZGu6YGt4KngMkdTwJE6MbjavFpqHvqVt+Ew==",
+			"license": "MIT",
+			"dependencies": {
+				"@peculiar/x509": "^1.14.2",
+				"pkijs": "^3.3.3"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/semver": {
+			"version": "7.7.3",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/send": {
+			"version": "0.19.2",
+			"resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+			"integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+			"license": "MIT",
+			"dependencies": {
+				"debug": "2.6.9",
+				"depd": "2.0.0",
+				"destroy": "1.2.0",
+				"encodeurl": "~2.0.0",
+				"escape-html": "~1.0.3",
+				"etag": "~1.8.1",
+				"fresh": "~0.5.2",
+				"http-errors": "~2.0.1",
+				"mime": "1.6.0",
+				"ms": "2.1.3",
+				"on-finished": "~2.4.1",
+				"range-parser": "~1.2.1",
+				"statuses": "~2.0.2"
+			},
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/send/node_modules/ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"license": "MIT"
+		},
+		"node_modules/serve-static": {
+			"version": "1.16.3",
+			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+			"integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+			"license": "MIT",
+			"dependencies": {
+				"encodeurl": "~2.0.0",
+				"escape-html": "~1.0.3",
+				"parseurl": "~1.3.3",
+				"send": "~0.19.1"
+			},
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/set-function-length": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+			"integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+			"license": "MIT",
+			"dependencies": {
+				"define-data-property": "^1.1.4",
+				"es-errors": "^1.3.0",
+				"function-bind": "^1.1.2",
+				"get-intrinsic": "^1.2.4",
+				"gopd": "^1.0.1",
+				"has-property-descriptors": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/setprototypeof": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+			"integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+			"license": "ISC"
+		},
+		"node_modules/sha.js": {
+			"version": "2.4.12",
+			"resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.12.tgz",
+			"integrity": "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==",
+			"license": "(MIT AND BSD-3-Clause)",
+			"dependencies": {
+				"inherits": "^2.0.4",
+				"safe-buffer": "^5.2.1",
+				"to-buffer": "^1.2.0"
+			},
+			"bin": {
+				"sha.js": "bin.js"
+			},
+			"engines": {
+				"node": ">= 0.10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/side-channel": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+			"integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"object-inspect": "^1.13.3",
+				"side-channel-list": "^1.0.0",
+				"side-channel-map": "^1.0.1",
+				"side-channel-weakmap": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/side-channel-list": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+			"integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"object-inspect": "^1.13.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/side-channel-map": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+			"integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+			"license": "MIT",
+			"dependencies": {
+				"call-bound": "^1.0.2",
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.5",
+				"object-inspect": "^1.13.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/side-channel-weakmap": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+			"integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+			"license": "MIT",
+			"dependencies": {
+				"call-bound": "^1.0.2",
+				"es-errors": "^1.3.0",
+				"get-intrinsic": "^1.2.5",
+				"object-inspect": "^1.13.3",
+				"side-channel-map": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/simple-concat": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+			"integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/simple-get": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+			"integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"decompress-response": "^6.0.0",
+				"once": "^1.3.1",
+				"simple-concat": "^1.0.0"
+			}
+		},
+		"node_modules/statuses": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+			"integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/string_decoder": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+			"license": "MIT",
+			"dependencies": {
+				"safe-buffer": "~5.2.0"
+			}
+		},
+		"node_modules/string-width": {
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/strnum": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.2.tgz",
+			"integrity": "sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/tmp": {
+			"version": "0.2.5",
+			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+			"integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.14"
+			}
+		},
+		"node_modules/tmp-promise": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-3.0.3.tgz",
+			"integrity": "sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==",
+			"license": "MIT",
+			"dependencies": {
+				"tmp": "^0.2.0"
+			}
+		},
+		"node_modules/to-buffer": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz",
+			"integrity": "sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==",
+			"license": "MIT",
+			"dependencies": {
+				"isarray": "^2.0.5",
+				"safe-buffer": "^5.2.1",
+				"typed-array-buffer": "^1.0.3"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/toidentifier": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+			"integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.6"
+			}
+		},
+		"node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"license": "0BSD"
+		},
+		"node_modules/tsx": {
+			"version": "4.21.0",
+			"resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+			"integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+			"license": "MIT",
+			"dependencies": {
+				"esbuild": "~0.27.0",
+				"get-tsconfig": "^4.7.5"
+			},
+			"bin": {
+				"tsx": "dist/cli.mjs"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"optionalDependencies": {
+				"fsevents": "~2.3.3"
+			}
+		},
+		"node_modules/tsyringe": {
+			"version": "4.10.0",
+			"resolved": "https://registry.npmjs.org/tsyringe/-/tsyringe-4.10.0.tgz",
+			"integrity": "sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==",
+			"license": "MIT",
+			"dependencies": {
+				"tslib": "^1.9.3"
+			},
+			"engines": {
+				"node": ">= 6.0.0"
+			}
+		},
+		"node_modules/tsyringe/node_modules/tslib": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+			"license": "0BSD"
+		},
+		"node_modules/type-is": {
+			"version": "1.6.18",
+			"resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+			"integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+			"license": "MIT",
+			"dependencies": {
+				"media-typer": "0.3.0",
+				"mime-types": "~2.1.24"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/typed-array-buffer": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+			"integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+			"license": "MIT",
+			"dependencies": {
+				"call-bound": "^1.0.3",
+				"es-errors": "^1.3.0",
+				"is-typed-array": "^1.1.14"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/typescript": {
+			"version": "5.9.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=14.17"
+			}
+		},
+		"node_modules/undici-types": {
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+			"integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+			"license": "MIT"
+		},
+		"node_modules/universal-github-app-jwt": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/universal-github-app-jwt/-/universal-github-app-jwt-1.2.0.tgz",
+			"integrity": "sha512-dncpMpnsKBk0eetwfN8D8OUHGfiDhhJ+mtsbMl+7PfW7mYjiH8LIcqRmYMtzYLgSh47HjfdBtrBwIQ/gizKR3g==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/jsonwebtoken": "^9.0.0",
+				"jsonwebtoken": "^9.0.2"
+			}
+		},
+		"node_modules/universal-user-agent": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
+			"integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==",
+			"license": "ISC"
+		},
+		"node_modules/universalify": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 10.0.0"
+			}
+		},
+		"node_modules/unpipe": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+			"integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/uri-js": {
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"punycode": "^2.1.0"
+			}
+		},
+		"node_modules/util-deprecate": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+			"license": "MIT"
+		},
+		"node_modules/utils-merge": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+			"integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4.0"
+			}
+		},
+		"node_modules/vary": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+			"integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/wasm-feature-detect": {
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/wasm-feature-detect/-/wasm-feature-detect-1.8.0.tgz",
+			"integrity": "sha512-zksaLKM2fVlnB5jQQDqKXXwYHLQUVH9es+5TOOHwGOVJOCeRBCiPjwSg+3tN2AdTCzjgli4jijCH290kXb/zWQ==",
+			"license": "Apache-2.0"
+		},
+		"node_modules/which-typed-array": {
+			"version": "1.1.20",
+			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
+			"integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+			"license": "MIT",
+			"dependencies": {
+				"available-typed-arrays": "^1.0.7",
+				"call-bind": "^1.0.8",
+				"call-bound": "^1.0.4",
+				"for-each": "^0.3.5",
+				"get-proto": "^1.0.1",
+				"gopd": "^1.2.0",
+				"has-tostringtag": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/wrap-ansi": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+			"license": "ISC"
+		},
+		"node_modules/ws": {
+			"version": "8.18.3",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+			"integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": ">=5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/xml2js": {
+			"version": "0.6.2",
+			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+			"integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+			"license": "MIT",
+			"dependencies": {
+				"sax": ">=0.6.0",
+				"xmlbuilder": "~11.0.0"
+			},
+			"engines": {
+				"node": ">=4.0.0"
+			}
+		},
+		"node_modules/xmlbuilder": {
+			"version": "11.0.1",
+			"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+			"integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=4.0"
+			}
+		},
+		"node_modules/y18n": {
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+			"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/yargs": {
+			"version": "17.7.2",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+			"integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+			"license": "MIT",
+			"dependencies": {
+				"cliui": "^8.0.1",
+				"escalade": "^3.1.1",
+				"get-caller-file": "^2.0.5",
+				"require-directory": "^2.1.1",
+				"string-width": "^4.2.3",
+				"y18n": "^5.0.5",
+				"yargs-parser": "^21.1.1"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/yargs-parser": {
+			"version": "21.1.1",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+			"integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		}
+	}
+}

--- a/scripts/benchmark-site-create/package.json
+++ b/scripts/benchmark-site-create/package.json
@@ -1,0 +1,20 @@
+{
+	"name": "benchmark-site-create",
+	"version": "0.0.1",
+	"description": "Benchmark Studio CLI site create vs raw Playground CLI",
+	"author": "Automattic",
+	"license": "GPLv2",
+	"type": "module",
+	"scripts": {
+		"benchmark": "tsx benchmark.ts"
+	},
+	"dependencies": {
+		"@wp-playground/cli": "^3.0.22",
+		"chalk": "^5.3.0",
+		"tsx": "^4.7.0"
+	},
+	"devDependencies": {
+		"@types/node": "^20.0.0",
+		"typescript": "^5.0.0"
+	}
+}

--- a/scripts/benchmark-site-create/tsconfig.json
+++ b/scripts/benchmark-site-create/tsconfig.json
@@ -1,0 +1,13 @@
+{
+	"compilerOptions": {
+		"target": "ES2022",
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"esModuleInterop": true,
+		"strict": true,
+		"skipLibCheck": true,
+		"resolveJsonModule": true,
+		"outDir": "dist"
+	},
+	"include": ["*.ts"]
+}


### PR DESCRIPTION
## Related issues

Related to STU-1235.

## Summary
- Adds a benchmark tool to compare Studio CLI site creation performance against raw Playground CLI
- Supports both download mode (real-world) and bundled WordPress files (`--use-bundled` for apples-to-apples comparison)
- Measures "create only" and "create + start" scenarios
- Outputs min/max/avg/median statistics across configurable rounds

**Note:** Both CLIs are run with the system Node.js, not Electron's bundled Node. This ensures a fair CLI-to-CLI comparison.

## Benchmark Results (5 rounds each)

### Real-world Comparison
*Playground downloads WordPress, Studio uses bundled files*

| Benchmark | macOS ARM64 | Windows ARM64 |
|-----------|-------------|---------------|
| Playground CLI (download) | 6.75s | 15.57s |
| Studio CLI (create only) | 6.24s (-7.5%) | 13.56s (-12.9%) |
| Studio CLI (create + start) | 7.11s (+5.3%) | 13.86s (-11.0%) |

### Apples-to-Apples Comparison (`--use-bundled`)
*Both use bundled WordPress files*

| Benchmark | macOS ARM64 | Windows ARM64 |
|-----------|-------------|---------------|
| Playground CLI (bundled) | 4.26s | 9.20s |
| Studio CLI (create only) | 5.91s (+1.65s / +38.8%) | 12.15s (+2.95s / +32.1%) |
| Studio CLI (create + start) | 7.01s (+2.75s / +64.6%) | 15.12s (+5.92s / +64.3%) |

### Key Findings

1. **Windows is ~2.2x slower overall** - baseline Playground performance, not Studio-specific
2. **Studio's percentage overhead is consistent across platforms** - ~32-39% for create, ~64% for create+start
3. **Real-world users benefit from bundled files** - Studio is faster than Playground (download) on both platforms
4. **Both layers contribute to total time** - Playground is the larger component (4-9s), but Studio adds meaningful overhead (1.6-6s depending on operation/platform)

## Usage
```bash
cd scripts/benchmark-site-create
npm install
npm run benchmark -- --rounds=5
npm run benchmark -- --rounds=5 --use-bundled  # apples-to-apples
```

## Test plan
- [x] Run benchmark on macOS
- [x] Run benchmark on Windows
- [x] Document findings in STU-1235