### PR TITLE
Update tab selection logic after site deletion

### DIFF
--- a/src/components/site-content-tabs.tsx
+++ b/src/components/site-content-tabs.tsx
@@ -9,45 +9,26 @@ import { ContentTabSettings } from 'src/components/content-tab-settings';
 import Header from 'src/components/header';
 import { SiteIsBeingCreated } from 'src/components/site-is-being-created';
 import { MIN_WIDTH_CLASS_TO_MEASURE } from 'src/constants';
-import { TabName, useContentTabs } from 'src/hooks/use-content-tabs';
+import { TabName } from 'src/hooks/use-content-tabs';
+import { useEffectiveTab } from 'src/hooks/use-effective-tab';
 import { useImportExport } from 'src/hooks/use-import-export';
 import { useSiteDetails } from 'src/hooks/use-site-details';
 import { cx } from 'src/lib/cx';
 import { ContentTabSync } from 'src/modules/sync';
 
 export function SiteContentTabs() {
-	const { selectedSite, sites, siteCreationMessages } = useSiteDetails();
+	const { selectedSite, siteCreationMessages } = useSiteDetails();
 	const { importState } = useImportExport();
-	const { tabs, selectedTab, setSelectedTab } = useContentTabs();
+	const { effectiveTab, selectedTab, setSelectedTab, tabs } = useEffectiveTab();
 	const { __ } = useI18n();
 
 	// Remount: Avoid focus loss on user tab changes (no remount),
 	// but remount on programmatic changes and site switches so initial tab/content state resets.
 	const [ keyCounter, setKeyCounter ] = useState( 0 );
-	const [ programmaticTab, setProgrammaticTab ] = useState( selectedTab );
+	const [ programmaticTab, setProgrammaticTab ] = useState( effectiveTab );
 	const lastChangeWasUser = useRef( false );
 	const isFirstRender = useRef( true );
-	const prevSelectedTab = useRef( selectedTab );
-
-	// Track previous site ID in state so we can safely access it during render
-	const [ prevSiteId, setPrevSiteId ] = useState( selectedSite?.id );
-
-	// Compute effective tab at render time
-	// This ensures TabPanel gets the correct initialTabName on the first render after deletion
-	const siteChanged = prevSiteId !== selectedSite?.id;
-	const prevSiteWasDeleted = prevSiteId && ! sites.some( ( site ) => site.id === prevSiteId );
-	const effectiveTab = siteChanged && prevSiteWasDeleted ? 'overview' : selectedTab;
-
-	// Update prevSiteId selectedTab after render
-	useEffect( () => {
-		if ( siteChanged ) {
-			setPrevSiteId( selectedSite?.id );
-		}
-
-		if ( effectiveTab !== selectedTab ) {
-			setSelectedTab( effectiveTab as TabName );
-		}
-	}, [ siteChanged, selectedSite?.id, effectiveTab, selectedTab, setSelectedTab ] );
+	const prevSelectedTab = useRef( effectiveTab );
 
 	useEffect( () => {
 		if ( isFirstRender.current ) {

--- a/src/components/site-content-tabs.tsx
+++ b/src/components/site-content-tabs.tsx
@@ -16,7 +16,7 @@ import { cx } from 'src/lib/cx';
 import { ContentTabSync } from 'src/modules/sync';
 
 export function SiteContentTabs() {
-	const { selectedSite, siteCreationMessages } = useSiteDetails();
+	const { selectedSite, sites, siteCreationMessages } = useSiteDetails();
 	const { importState } = useImportExport();
 	const { tabs, selectedTab, setSelectedTab } = useContentTabs();
 	const { __ } = useI18n();
@@ -28,6 +28,26 @@ export function SiteContentTabs() {
 	const lastChangeWasUser = useRef( false );
 	const isFirstRender = useRef( true );
 	const prevSelectedTab = useRef( selectedTab );
+
+	// Track previous site ID in state so we can safely access it during render
+	const [ prevSiteId, setPrevSiteId ] = useState( selectedSite?.id );
+
+	// Compute effective tab at render time
+	// This ensures TabPanel gets the correct initialTabName on the first render after deletion
+	const siteChanged = prevSiteId !== selectedSite?.id;
+	const prevSiteWasDeleted = prevSiteId && ! sites.some( ( site ) => site.id === prevSiteId );
+	const effectiveTab = siteChanged && prevSiteWasDeleted ? 'overview' : selectedTab;
+
+	// Update prevSiteId selectedTab after render
+	useEffect( () => {
+		if ( siteChanged ) {
+			setPrevSiteId( selectedSite?.id );
+		}
+
+		if ( effectiveTab !== selectedTab ) {
+			setSelectedTab( effectiveTab as TabName );
+		}
+	}, [ siteChanged, selectedSite?.id, effectiveTab, selectedTab, setSelectedTab ] );
 
 	useEffect( () => {
 		if ( isFirstRender.current ) {
@@ -83,19 +103,19 @@ export function SiteContentTabs() {
 				onSelect={ ( tabName ) => {
 					// Mark this as a user-initiated change BEFORE calling setSelectedTab
 					// so the useEffect can detect it was user-initiated
-					if ( tabName !== selectedTab ) {
+					if ( tabName !== effectiveTab ) {
 						lastChangeWasUser.current = true;
 					}
 					setSelectedTab( tabName as TabName );
 				} }
-				initialTabName={ selectedTab }
+				initialTabName={ effectiveTab }
 				key={ `${ selectedSite.id }-${ keyCounter }-${ programmaticTab }` }
 			>
 				{ ( { name } ) => (
 					<div
 						className={ cx(
 							'h-full overflow-y-auto',
-							selectedTab === 'assistant' && 'bg-gray-50'
+							effectiveTab === 'assistant' && 'bg-gray-50'
 						) }
 						style={ {
 							scrollbarWidth: 'thin',

--- a/src/hooks/use-effective-tab.tsx
+++ b/src/hooks/use-effective-tab.tsx
@@ -1,0 +1,34 @@
+import { useEffect, useState } from 'react';
+import { TabName, useContentTabs } from 'src/hooks/use-content-tabs';
+import { useSiteDetails } from 'src/hooks/use-site-details';
+
+/**
+ * Hook that computes the effective tab, handling the case where a site is deleted.
+ * When the previously selected site is deleted, automatically resets to 'overview'.
+ */
+export function useEffectiveTab() {
+	const { selectedSite, sites } = useSiteDetails();
+	const { selectedTab, setSelectedTab, tabs } = useContentTabs();
+
+	// Track previous site ID in state so we can safely access it during render
+	const [ prevSiteId, setPrevSiteId ] = useState( selectedSite?.id );
+
+	// Compute effective tab at render time
+	// This ensures TabPanel gets the correct initialTabName on the first render after deletion
+	const siteChanged = prevSiteId !== selectedSite?.id;
+	const prevSiteWasDeleted = prevSiteId && ! sites.some( ( site ) => site.id === prevSiteId );
+	const effectiveTab = siteChanged && prevSiteWasDeleted ? 'overview' : selectedTab;
+
+	// Update prevSiteId and sync selectedTab after render
+	useEffect( () => {
+		if ( siteChanged ) {
+			setPrevSiteId( selectedSite?.id );
+		}
+
+		if ( effectiveTab !== selectedTab ) {
+			setSelectedTab( effectiveTab as TabName );
+		}
+	}, [ siteChanged, selectedSite?.id, effectiveTab, selectedTab, setSelectedTab ] );
+
+	return { effectiveTab, selectedTab, setSelectedTab, tabs };
+}

--- a/src/hooks/use-site-details.tsx
+++ b/src/hooks/use-site-details.tsx
@@ -238,14 +238,17 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 			await deleteSite( id, removeLocal );
 			const newSites = await getIpcApi().getSiteDetails();
 			setSites( newSites );
-			// Only change selection and reset tab if the currently selected site no longer exists
-			const selectedSiteStillExists = newSites.some( ( site ) => site.id === selectedSiteId );
-			if ( ! selectedSiteStillExists ) {
-				setSelectedTab( 'overview' );
-				setSelectedSiteId( newSites.length ? newSites[ 0 ].id : '' );
-			}
+			// Use functional update to access current selectedSiteId value
+			// Tab reset is handled in SiteContentTabs when it detects the previous site was deleted
+			setSelectedSiteId( ( currentSelectedId ) => {
+				const selectedSiteStillExists = newSites.some( ( site ) => site.id === currentSelectedId );
+				if ( ! selectedSiteStillExists ) {
+					return newSites.length ? newSites[ 0 ].id : '';
+				}
+				return currentSelectedId;
+			} );
 		},
-		[ deleteSite, setSelectedSiteId, setSelectedTab, selectedSiteId ]
+		[ deleteSite, setSelectedSiteId ]
 	);
 
 	const createSite = useCallback(

--- a/src/hooks/use-site-details.tsx
+++ b/src/hooks/use-site-details.tsx
@@ -239,17 +239,13 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 			const newSites = await getIpcApi().getSiteDetails();
 			setSites( newSites );
 			// Only change selection and reset tab if the currently selected site no longer exists
-
-			setSelectedSiteId( ( currentSelectedId ) => {
-				const selectedSiteStillExists = newSites.some( ( site ) => site.id === currentSelectedId );
-				if ( selectedSiteStillExists ) {
-					return currentSelectedId;
-				}
+			const selectedSiteStillExists = newSites.some( ( site ) => site.id === selectedSiteId );
+			if ( ! selectedSiteStillExists ) {
 				setSelectedTab( 'overview' );
-				return newSites.length ? newSites[ 0 ].id : '';
-			} );
+				setSelectedSiteId( newSites.length ? newSites[ 0 ].id : '' );
+			}
 		},
-		[ deleteSite, setSelectedSiteId, setSelectedTab ]
+		[ deleteSite, setSelectedSiteId, setSelectedTab, selectedSiteId ]
 	);
 
 	const createSite = useCallback(

--- a/src/hooks/use-site-details.tsx
+++ b/src/hooks/use-site-details.tsx
@@ -238,15 +238,17 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 			await deleteSite( id, removeLocal );
 			const newSites = await getIpcApi().getSiteDetails();
 			setSites( newSites );
-			// Only change selection if the currently selected site no longer exists
+			// Only change selection and reset tab if the currently selected site no longer exists
+			let selectionChanged = false;
 			setSelectedSiteId( ( currentSelectedId ) => {
 				const selectedSiteStillExists = newSites.some( ( site ) => site.id === currentSelectedId );
 				if ( selectedSiteStillExists ) {
 					return currentSelectedId;
 				}
+				selectionChanged = true;
 				return newSites.length ? newSites[ 0 ].id : '';
 			} );
-			if ( selectedTab !== 'overview' ) {
+			if ( selectionChanged && selectedTab !== 'overview' ) {
 				setSelectedTab( 'overview' );
 			}
 		},

--- a/src/hooks/use-site-details.tsx
+++ b/src/hooks/use-site-details.tsx
@@ -239,20 +239,17 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 			const newSites = await getIpcApi().getSiteDetails();
 			setSites( newSites );
 			// Only change selection and reset tab if the currently selected site no longer exists
-			let selectionChanged = false;
+
 			setSelectedSiteId( ( currentSelectedId ) => {
 				const selectedSiteStillExists = newSites.some( ( site ) => site.id === currentSelectedId );
 				if ( selectedSiteStillExists ) {
 					return currentSelectedId;
 				}
-				selectionChanged = true;
+				setSelectedTab( 'overview' );
 				return newSites.length ? newSites[ 0 ].id : '';
 			} );
-			if ( selectionChanged && selectedTab !== 'overview' ) {
-				setSelectedTab( 'overview' );
-			}
 		},
-		[ deleteSite, setSelectedSiteId, selectedTab, setSelectedTab ]
+		[ deleteSite, setSelectedSiteId, setSelectedTab ]
 	);
 
 	const createSite = useCallback(


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-1241
- Follow-up to #2459

## Proposed Changes

When the deleted site was the selected site, the tab should reset to "Overview". However, calling `setSelectedTab('overview')` from the site details hook didn't work reliably. The `ContentTabsProvider` wraps `SiteDetailsProvider`, so when both states update, the site change renders the component before the tab update takes effect, causing the TabPanel to remount with the old tab value.

This PR moves the state update call from the `onDeleteSite` callback to `SiteContentTabs`, and adds logic to compute an `effectiveTab` value at render time. The component tracks the previous site ID in state and, during render, checks if the site changed AND the previous site was deleted. If both conditions are true, it uses `'overview'` as the effective tab for `initialTabName`. A useEffect then syncs this back to the tab context.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Start Studio with `npm start`
2. Create three sites (Site 1, Site 2, Site 3)
3. Delete Site 3
4. While the deletion is going on, quickly select Site 2 and switch to the "Sync" tab or any other tab
6. Check that after the deletion, Site 2 and the previously selected tab remain selected
7. Delete Site 2, and stay on the Settings tab until the deletion is completed
8. Check that Site 1 on the Overview tab is selected after the deletion

https://github.com/user-attachments/assets/35ffc9dc-cfc0-4019-a0bf-ad82d8e486ef

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
