### PR TITLE
Fix excessive WP-CLI command invocations in Assistant tab

### DIFF
--- a/src/components/content-tab-assistant.tsx
+++ b/src/components/content-tab-assistant.tsx
@@ -386,7 +386,8 @@ export function ContentTabAssistant( { selectedSite }: ContentTabAssistantProps 
 
 	useEffect( () => {
 		void dispatch( chatThunks.updateFromSite( { site: selectedSite } ) );
-	}, [ dispatch, selectedSite ] );
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ dispatch, selectedSite.id ] );
 
 	useEffect( () => {
 		if ( themeDetails ) {

--- a/src/stores/chat-slice.ts
+++ b/src/stores/chat-slice.ts
@@ -1,12 +1,10 @@
-import { createSlice, createAsyncThunk, PayloadAction } from '@reduxjs/toolkit';
+import { createSlice, createAsyncThunk, PayloadAction, isAnyOf } from '@reduxjs/toolkit';
 import * as Sentry from '@sentry/electron/renderer';
 import { WPCOM } from 'wpcom/types';
 import { z } from 'zod';
+import { DEFAULT_PHP_VERSION } from 'common/constants';
 import { LOCAL_STORAGE_CHAT_API_IDS_KEY, LOCAL_STORAGE_CHAT_MESSAGES_KEY } from 'src/constants';
 import { getIpcApi } from 'src/lib/get-ipc-api';
-// Provider constants are retrieved via IPC when needed
-// Default PHP version for initial state
-const DEFAULT_PHP_VERSION = '8.3';
 import { AppDispatch, RootState } from 'src/stores';
 import { assistantQuotaSchema, wpcomApi } from 'src/stores/wpcom-api';
 
@@ -90,6 +88,13 @@ const updateFromSite = createTypedAsyncThunk(
 			themes,
 			siteUrl,
 		};
+	},
+	{
+		condition: ( { site }, { getState } ) => {
+			const { chat } = getState();
+			const thunkIsCurrentlyLoading = chat.isLoadingUpdateFromSiteDict[ site.id ];
+			return ! thunkIsCurrentlyLoading;
+		},
 	}
 );
 
@@ -111,7 +116,7 @@ const assistantResponseSchema = z.object( {
 const assistantHeadersSchema = z.object( {
 	'x-quota-max': z.coerce.number(),
 	'x-quota-remaining': z.coerce.number(),
-	'x-quota-reset': z.string().datetime( { offset: true } ),
+	'x-quota-reset': z.iso.datetime( { offset: true } ),
 } );
 
 type FetchAssistantResponseData = z.infer< typeof assistantResponseSchema >;
@@ -243,6 +248,7 @@ export interface ChatState {
 	chatApiIdDict: { [ key: string ]: number | undefined };
 	chatInputBySite: { [ key: string ]: string };
 	isLoadingDict: Record< string, boolean >;
+	isLoadingUpdateFromSiteDict: Record< string, boolean >;
 }
 
 const getInitialState = (): ChatState => {
@@ -276,6 +282,7 @@ const getInitialState = (): ChatState => {
 		chatApiIdDict: parsedStoredChatIds,
 		chatInputBySite: {},
 		isLoadingDict: {},
+		isLoadingUpdateFromSiteDict: {},
 	};
 };
 
@@ -370,6 +377,7 @@ const chatSlice = createSlice( {
 			.addCase( updateFromSite.pending, ( state, action ) => {
 				const { site } = action.meta.arg;
 
+				state.isLoadingUpdateFromSiteDict[ site.id ] = true;
 				state.phpVersion = site.phpVersion ?? DEFAULT_PHP_VERSION;
 				state.siteName = site.name;
 			} )
@@ -442,7 +450,14 @@ const chatSlice = createSlice( {
 						message.feedbackReceived = true;
 					}
 				} );
-			} );
+			} )
+			.addMatcher(
+				isAnyOf( updateFromSite.fulfilled, updateFromSite.rejected ),
+				( state, action ) => {
+					const siteId = action.meta.arg.site.id;
+					state.isLoadingUpdateFromSiteDict[ siteId ] = false;
+				}
+			);
 	},
 	selectors: {
 		selectChatInput: ( state, siteId: string ) => state.chatInputBySite[ siteId ] ?? '',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-1254

## Proposed Changes

The 1.7.0 release introduced a bug that caused an excessive number of WP-CLI invocations in the Assistant tab (triggered by the `updateFromSite` thunk). This led to the commands failing and showing up as JSON parsing errors in the browser console. This seems to be caused by mutations of the `selectedSite` object returned by the `useSiteDetails` hook. 

This PR fixes the issue by changing the dependency array of the `useEffect` hook that triggers the `updateFromSite` thunk, and by adding a `condition` config to the thunk itself that prevents parallel invocations. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Run `npm start`
2. Open the Assistant tab
3. Send a message
4. Ensure that there are no `Unexpected end of JSON input` messages in the devtools console

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
