### PR TITLE
Fix bundled node permissions

### DIFF
--- a/entitlements/node.plist
+++ b/entitlements/node.plist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!-- Required for V8 JIT compilation -->
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <!-- Required for V8 to generate unsigned executable code -->
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <!-- Required for V8 memory page management -->
+    <key>com.apple.security.cs.disable-executable-page-protection</key>
+    <true/>
+    <!-- Required for loading native modules -->
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+</dict>
+</plist>

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -16,7 +16,18 @@ const config: ForgeConfig = {
 		extraResource: [ './wp-files', './assets', './bin', './dist/cli' ],
 		executableName: process.platform === 'linux' ? 'studio' : undefined,
 		icon: './assets/studio-app-icon',
-		osxSign: {},
+		osxSign: {
+			optionsForFile: ( filePath ) => {
+				// The bundled Node binary requires specific entitlements for V8 JIT compilation.
+				// Without these, V8 crashes with SIGTRAP when trying to allocate executable memory.
+				if ( filePath.endsWith( 'bin/node' ) ) {
+					return {
+						entitlements: path.join( __dirname, 'entitlements', 'node.plist' ),
+					};
+				}
+				return {};
+			},
+		},
 		ignore: [
 			// Exclude major development directories
 			/^\/\..*/, // All dotfiles and dot directories


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-1253

## Proposed Changes

- Add custom entitlements for the bundled Node.js binary to fix SIGTRAP crashes on Intel Macs

### Root Cause

When electron-forge signs the app, it re-signs the bundled Node binary with Electron's default entitlements. These entitlements are missing critical permissions that Node.js/V8 requires for JIT compilation:

| Entitlement | Official Node | Bundled (before) | Bundled (after) |
|-------------|:-------------:|:----------------:|:---------------:|
| `cs.allow-jit` | ✅ | ✅ | ✅ |
| `cs.allow-unsigned-executable-memory` | ✅ | ❌ | ✅ |
| `cs.disable-executable-page-protection` | ✅ | ❌ | ✅ |
| `cs.disable-library-validation` | ✅ | ❌ | ✅ |

Without these entitlements, V8's baseline compiler crashes when trying to allocate executable memory:
```
Fatal error in , line 0
Check failed: 12 == (*__error()).  // ENOMEM
```

### The Fix

- Created `entitlements/node.plist` with the required V8/JIT entitlements
- Updated `forge.config.ts` to use `optionsForFile` to apply these entitlements specifically to `bin/node` during code signing

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Download the **Intel (x64)** build from CI
2. Install and run Studio
3. Create or start a site - it should work without crashing

**To verify the fix is applied:**
```bash
codesign -d --entitlements - /Applications/Studio.app/Contents/Resources/bin/node
```
Should show:
- `com.apple.security.cs.allow-jit`
- `com.apple.security.cs.allow-unsigned-executable-memory`
- `com.apple.security.cs.disable-executable-page-protection`
- `com.apple.security.cs.disable-library-validation`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?