### PR TITLE
Fix thumbnail not loading for newly created sites (approach 1)

### DIFF
--- a/src/components/content-tab-overview.tsx
+++ b/src/components/content-tab-overview.tsx
@@ -202,10 +202,10 @@ export function ContentTabOverview( { selectedSite }: ContentTabOverviewProps ) 
 	const isServerLoading = loadingServer[ selectedSite.id ];
 
 	useEffect( () => {
-		if ( loadingThumbnails ) {
+		if ( thumbnailData ) {
 			setIsThumbnailError( false );
 		}
-	}, [ loadingThumbnails ] );
+	}, [ thumbnailData ] );
 
 	const handleThumbnailClick = async () => {
 		if ( isServerLoading ) return;

--- a/src/components/content-tab-overview.tsx
+++ b/src/components/content-tab-overview.tsx
@@ -14,7 +14,7 @@ import {
 	widget,
 } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { ArrowIcon } from 'src/components/arrow-icon';
 import { ButtonsSection, ButtonsSectionProps } from 'src/components/buttons-section';
 import { useSiteDetails } from 'src/hooks/use-site-details';
@@ -190,11 +190,22 @@ export function ContentTabOverview( { selectedSite }: ContentTabOverviewProps ) 
 		selectedThumbnail: thumbnailData,
 		selectedLoadingThemeDetails: loadingThemeDetails,
 		selectedLoadingThumbnails: loadingThumbnails,
+		selectedThumbnailLoadError: thumbnailLoadError,
 		initialLoading,
 	} = useThemeDetails();
 
-	const loading = loadingThemeDetails || loadingThumbnails || initialLoading;
+	const loading =
+		loadingThemeDetails ||
+		loadingThumbnails ||
+		initialLoading ||
+		( selectedSite.running && ! thumbnailData && ! thumbnailLoadError );
 	const isServerLoading = loadingServer[ selectedSite.id ];
+
+	useEffect( () => {
+		if ( loadingThumbnails ) {
+			setIsThumbnailError( false );
+		}
+	}, [ loadingThumbnails ] );
 
 	const handleThumbnailClick = async () => {
 		if ( isServerLoading ) return;

--- a/src/components/tests/content-tab-overview.test.tsx
+++ b/src/components/tests/content-tab-overview.test.tsx
@@ -74,7 +74,11 @@ describe( 'ContentTabOverview', () => {
 				supportsWidgets,
 				supportsMenus,
 			},
+			selectedThumbnail: 'data:image/png;base64,test',
 			selectedLoadingThemeDetails: false,
+			selectedLoadingThumbnails: false,
+			selectedThumbnailLoadError: false,
+			initialLoading: false,
 		} );
 		render(
 			<Provider store={ store }>

--- a/src/hooks/use-theme-details.tsx
+++ b/src/hooks/use-theme-details.tsx
@@ -10,6 +10,7 @@ type ThumbnailType = string | undefined;
 interface ThemeDetailsContextType {
 	loadingThemeDetails: Record< string, boolean >;
 	loadingThumbnails: Record< string, boolean >;
+	thumbnailLoadErrors: Record< string, boolean >;
 	themeDetails: Record< string, ThemeDetailsType >;
 	thumbnails: Record< string, ThumbnailType >;
 	initialLoading: boolean;
@@ -17,11 +18,13 @@ interface ThemeDetailsContextType {
 	selectedThumbnail: ThumbnailType;
 	selectedLoadingThemeDetails: boolean;
 	selectedLoadingThumbnails: boolean;
+	selectedThumbnailLoadError: boolean;
 }
 
 export const ThemeDetailsContext = createContext< ThemeDetailsContextType >( {
 	loadingThemeDetails: {},
 	loadingThumbnails: {},
+	thumbnailLoadErrors: {},
 	themeDetails: {},
 	thumbnails: {},
 	initialLoading: false,
@@ -29,6 +32,7 @@ export const ThemeDetailsContext = createContext< ThemeDetailsContextType >( {
 	selectedThumbnail: undefined,
 	selectedLoadingThemeDetails: false,
 	selectedLoadingThumbnails: false,
+	selectedThumbnailLoadError: false,
 } );
 
 interface ThemeDetailsProviderProps {
@@ -44,6 +48,9 @@ export const ThemeDetailsProvider: React.FC< ThemeDetailsProviderProps > = ( { c
 		{}
 	);
 	const [ loadingThumbnails, setLoadingThumbnails ] = useState< Record< string, boolean > >( {} );
+	const [ thumbnailLoadErrors, setThumbnailLoadErrors ] = useState< Record< string, boolean > >(
+		{}
+	);
 
 	useIpcListener( 'theme-details-loading', ( _evt, { id } ) => {
 		setLoadingThemeDetails( ( loadingThemeDetails ) => {
@@ -64,6 +71,9 @@ export const ThemeDetailsProvider: React.FC< ThemeDetailsProviderProps > = ( { c
 		setLoadingThumbnails( ( loadingThumbnails ) => {
 			return { ...loadingThumbnails, [ id ]: true };
 		} );
+		setThumbnailLoadErrors( ( errors ) => {
+			return { ...errors, [ id ]: false };
+		} );
 	} );
 
 	useIpcListener( 'thumbnail-loaded', ( _evt, { id, imageData } ) => {
@@ -73,11 +83,17 @@ export const ThemeDetailsProvider: React.FC< ThemeDetailsProviderProps > = ( { c
 		setLoadingThumbnails( ( loadingThumbnails ) => {
 			return { ...loadingThumbnails, [ id ]: false };
 		} );
+		setThumbnailLoadErrors( ( errors ) => {
+			return { ...errors, [ id ]: false };
+		} );
 	} );
 
 	useIpcListener( 'thumbnail-load-error', ( _evt, { id } ) => {
 		setLoadingThumbnails( ( loadingThumbnails ) => {
 			return { ...loadingThumbnails, [ id ]: false };
+		} );
+		setThumbnailLoadErrors( ( errors ) => {
+			return { ...errors, [ id ]: true };
 		} );
 	} );
 
@@ -122,16 +138,19 @@ export const ThemeDetailsProvider: React.FC< ThemeDetailsProviderProps > = ( { c
 			themeDetails,
 			loadingThemeDetails,
 			loadingThumbnails,
+			thumbnailLoadErrors,
 			initialLoading: ! initialLoad,
 			selectedThemeDetails: themeDetails[ selectedSite?.id ?? '' ],
 			selectedThumbnail: thumbnails[ selectedSite?.id ?? '' ],
 			selectedLoadingThemeDetails: loadingThemeDetails[ selectedSite?.id ?? '' ],
 			selectedLoadingThumbnails: loadingThumbnails[ selectedSite?.id ?? '' ],
+			selectedThumbnailLoadError: thumbnailLoadErrors[ selectedSite?.id ?? '' ] ?? false,
 		};
 	}, [
 		initialLoad,
 		loadingThemeDetails,
 		loadingThumbnails,
+		thumbnailLoadErrors,
 		selectedSite?.id,
 		themeDetails,
 		thumbnails,


### PR DESCRIPTION
## Summary
- Fixes an issue where newly created sites would show "Preview unavailable" instead of loading the thumbnail
- The thumbnail would only appear after navigating away and back to the Overview tab
- Root cause: the error state was set when the img tried to load with empty src, and could never be reset because the img was replaced by a div

## Changes
- Added `thumbnailLoadErrors` tracking at the context level in `use-theme-details.tsx`
- Added a `useEffect` to reset local error state when thumbnail loading starts
- Updated loading condition to show skeleton for running sites without thumbnail data (unless a load error occurred)

## Test plan
- [ ] Create a new site
- [ ] Verify the thumbnail loads without needing to navigate away
- [ ] Verify existing sites still show thumbnails correctly
- [ ] Verify "Preview unavailable" still shows when thumbnail generation actually fails

Fixes [STU-1212](https://linear.app/a8c/issue/STU-1212/newly-added-site-doesnt-have-thumbnail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)