### PR TITLE
Fix site export in offline mode

### DIFF
--- a/cli/commands/site/tests/create.test.ts
+++ b/cli/commands/site/tests/create.test.ts
@@ -101,7 +101,6 @@ describe( 'CLI: studio site create', () => {
 	let consoleLogSpy: jest.SpyInstance;
 	let fsMkdirSyncSpy: jest.SpyInstance;
 	let loggerReportSuccessSpy: jest.SpyInstance;
-	let loggerReportWarningSpy: jest.SpyInstance;
 
 	const createPathExistsMock = ( sitePathExists = false ) => {
 		const bundledWPPath = require( 'path' ).join(
@@ -127,7 +126,7 @@ describe( 'CLI: studio site create', () => {
 		consoleLogSpy = jest.spyOn( console, 'log' ).mockImplementation();
 		fsMkdirSyncSpy = jest.spyOn( require( 'fs' ), 'mkdirSync' ).mockReturnValue( undefined );
 		loggerReportSuccessSpy = jest.spyOn( Logger.prototype, 'reportSuccess' );
-		loggerReportWarningSpy = jest.spyOn( Logger.prototype, 'reportWarning' );
+		jest.spyOn( Logger.prototype, 'reportWarning' );
 		createPathExistsMock( false );
 		( isEmptyDir as jest.Mock ).mockResolvedValue( true );
 		( isWordPressDirectory as jest.Mock ).mockReturnValue( false );

--- a/src/lib/import-export/export/export-database.ts
+++ b/src/lib/import-export/export/export-database.ts
@@ -17,8 +17,10 @@ export async function exportDatabaseToFile(
 	const tempFileName = `${ generateBackupFilename( 'db-export' ) }.sql`;
 
 	// Execute the command to export directly to the temp file
+	// Use absolute path /wordpress/ because that's where site.path is mounted in the WASM filesystem
+	const vfsFilePath = `/wordpress/${ tempFileName }`;
 	const { stderr, exitCode } = await server.executeWpCliCommand(
-		`sqlite export ${ tempFileName } --require=/tmp/sqlite-command/command.php --enable-ast-driver`,
+		`sqlite export ${ vfsFilePath } --require=/tmp/sqlite-command/command.php --enable-ast-driver`,
 		{
 			skipPluginsAndThemes: true,
 		}
@@ -82,10 +84,12 @@ export async function exportDatabaseToMultipleFiles(
 		}
 
 		const fileName = `${ table }.sql`;
+		// Use absolute path /wordpress/ because that's where site.path is mounted in the WASM filesystem
+		const vfsFilePath = `/wordpress/${ fileName }`;
 
 		// Execute the command to export directly to a temporary file in the project directory
 		const { stderr, exitCode } = await server.executeWpCliCommand(
-			`sqlite export ${ fileName } --tables=${ table } --require=/tmp/sqlite-command/command.php --enable-ast-driver`,
+			`sqlite export ${ vfsFilePath } --tables=${ table } --require=/tmp/sqlite-command/command.php --enable-ast-driver`,
 			{
 				skipPluginsAndThemes: true,
 			}

--- a/src/lib/import-export/export/exporters/default-exporter.ts
+++ b/src/lib/import-export/export/exporters/default-exporter.ts
@@ -306,16 +306,17 @@ export class DefaultExporter extends EventEmitter implements Exporter {
 			}
 		);
 
-		if ( stderr ) {
-			console.error( `Could not get information about plugins: ${ stderr }` );
-			throw new Error(
-				'Could not get information about installed plugins to create meta.json file.'
-			);
-		}
-
+		// Try to parse the output first - WordPress may produce warnings on stderr
+		// (e.g., when offline and can't check for updates) while still returning valid data
 		try {
 			return JSON.parse( stdout );
 		} catch ( error ) {
+			if ( stderr ) {
+				console.error( `Could not get information about plugins: ${ stderr }` );
+				throw new Error(
+					'Could not get information about installed plugins to create meta.json file.'
+				);
+			}
 			console.error( `Could not parse plugins list. The WP CLI output: ${ stdout }` );
 			throw new Error(
 				'Could not parse information about installed plugins to create meta.json file.'
@@ -337,16 +338,17 @@ export class DefaultExporter extends EventEmitter implements Exporter {
 			}
 		);
 
-		if ( stderr ) {
-			console.error( `Could not get information about themes: ${ stderr }` );
-			throw new Error(
-				'Could not get information about installed themes to create meta.json file.'
-			);
-		}
-
+		// Try to parse the output first - WordPress may produce warnings on stderr
+		// (e.g., when offline and can't check for updates) while still returning valid data
 		try {
 			return JSON.parse( stdout );
 		} catch ( error ) {
+			if ( stderr ) {
+				console.error( `Could not get information about themes: ${ stderr }` );
+				throw new Error(
+					'Could not get information about installed themes to create meta.json file.'
+				);
+			}
 			console.error( `Could not parse themes list. The WP CLI output: ${ stdout }` );
 			throw new Error(
 				'Could not parse information about installed themes to create meta.json file.'

--- a/src/lib/import-export/export/exporters/default-exporter.ts
+++ b/src/lib/import-export/export/exporters/default-exporter.ts
@@ -306,8 +306,8 @@ export class DefaultExporter extends EventEmitter implements Exporter {
 			}
 		);
 
-		// Try to parse the output first - WordPress may produce warnings on stderr
-		// (e.g., when offline and can't check for updates) while still returning valid data
+		// Try to parse stdout first. WordPress may produce warnings on stderr (e.g., when offline
+		// and can't check for updates) while still returning valid JSON data on stdout.
 		try {
 			return JSON.parse( stdout );
 		} catch ( error ) {
@@ -338,8 +338,8 @@ export class DefaultExporter extends EventEmitter implements Exporter {
 			}
 		);
 
-		// Try to parse the output first - WordPress may produce warnings on stderr
-		// (e.g., when offline and can't check for updates) while still returning valid data
+		// Try to parse stdout first. WordPress may produce warnings on stderr (e.g., when offline
+		// and can't check for updates) while still returning valid JSON data on stdout.
 		try {
 			return JSON.parse( stdout );
 		} catch ( error ) {

--- a/src/lib/import-export/tests/export/exporters/sql-exporter.test.ts
+++ b/src/lib/import-export/tests/export/exporters/sql-exporter.test.ts
@@ -58,7 +58,7 @@ platformTestSuite( 'SqlExporter', ( { normalize } ) => {
 
 		const siteServer = SiteServer.get( '123' );
 		expect( siteServer?.executeWpCliCommand ).toHaveBeenCalledWith(
-			'sqlite export studio-backup-db-export-2024-08-01-12-00-00.sql --require=/tmp/sqlite-command/command.php --enable-ast-driver',
+			'sqlite export /wordpress/studio-backup-db-export-2024-08-01-12-00-00.sql --require=/tmp/sqlite-command/command.php --enable-ast-driver',
 			{ skipPluginsAndThemes: true }
 		);
 	} );


### PR DESCRIPTION
## Related issues

- Fixes STU-1258

## Proposed Changes

- Fix `sqlite export` command to use absolute path `/wordpress/<filename>` instead of relative path. The WASM filesystem mounts the site at `/wordpress` but PHP's working directory isn't set there, causing relative paths to fail. This is the same fix applied to `sqlite import` in PR #2422.
- Fix `getSitePlugins` and `getSiteThemes` to tolerate stderr warnings when stdout contains valid JSON. When offline, WordPress produces warnings about being unable to connect to WordPress.org for update checks, but the plugin/theme list commands still return valid data.

## Testing Instructions

1. Create a site in Studio and start it
2. Disconnect from the internet
3. Export the site using "Export site" option
4. Verify the export completes successfully without errors
5. Reconnect to the internet
6. Export the site again to verify it still works when online
7. (Optional) Import the exported backup to verify it's valid

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?