### PR TITLE
Record more error details on CLI failure

### DIFF
--- a/src/modules/cli/lib/cli-server-process.ts
+++ b/src/modules/cli/lib/cli-server-process.ts
@@ -43,13 +43,9 @@ export class CliServerProcess implements WordPressServerProcess {
 				resolve();
 			} );
 
-			emitter.on( 'failure', ( { result, lastErrorMessage } ) => {
-				const errorDetail =
-					lastErrorMessage ||
-					result.stderr.trim() ||
-					result.stdout.trim() ||
-					`Failed to start site ${ this.siteId }`;
-				reject( new Error( errorDetail ) );
+			emitter.on( 'failure', ( { error } ) => {
+				error.baseMessage = 'Failed to start site';
+				reject( error );
 			} );
 
 			emitter.on( 'error', ( { error } ) => {
@@ -69,13 +65,9 @@ export class CliServerProcess implements WordPressServerProcess {
 				resolve();
 			} );
 
-			emitter.on( 'failure', ( { result, lastErrorMessage } ) => {
-				const errorDetail =
-					lastErrorMessage ||
-					result.stderr.trim() ||
-					result.stdout.trim() ||
-					`Failed to stop site ${ this.siteId }`;
-				reject( new Error( errorDetail ) );
+			emitter.on( 'failure', ( { error } ) => {
+				error.baseMessage = 'Failed to stop site';
+				reject( error );
 			} );
 
 			emitter.on( 'error', ( { error } ) => {
@@ -99,13 +91,9 @@ export class CliServerProcess implements WordPressServerProcess {
 				resolve();
 			} );
 
-			emitter.on( 'failure', ( { result, lastErrorMessage } ) => {
-				const errorDetail =
-					lastErrorMessage ||
-					result.stderr.trim() ||
-					result.stdout.trim() ||
-					`Failed to delete site ${ this.siteId }`;
-				reject( new Error( errorDetail ) );
+			emitter.on( 'failure', ( { error } ) => {
+				error.baseMessage = 'Failed to delete site';
+				reject( error );
 			} );
 
 			emitter.on( 'error', ( { error } ) => {

--- a/src/modules/cli/lib/cli-server-process.ts
+++ b/src/modules/cli/lib/cli-server-process.ts
@@ -43,8 +43,13 @@ export class CliServerProcess implements WordPressServerProcess {
 				resolve();
 			} );
 
-			emitter.on( 'failure', () => {
-				reject( new Error( `Failed to start site ${ this.siteId }` ) );
+			emitter.on( 'failure', ( { result, lastErrorMessage } ) => {
+				const errorDetail =
+					lastErrorMessage ||
+					result.stderr.trim() ||
+					result.stdout.trim() ||
+					`Failed to start site ${ this.siteId }`;
+				reject( new Error( errorDetail ) );
 			} );
 
 			emitter.on( 'error', ( { error } ) => {
@@ -55,14 +60,22 @@ export class CliServerProcess implements WordPressServerProcess {
 
 	async stop(): Promise< void > {
 		return new Promise( ( resolve, reject ) => {
-			const [ emitter ] = executeCliCommand( [ 'site', 'stop', '--path', this.sitePath ] );
+			const [ emitter ] = executeCliCommand( [ 'site', 'stop', '--path', this.sitePath ], {
+				output: 'capture',
+				logPrefix: this.siteId,
+			} );
 
 			emitter.on( 'success', () => {
 				resolve();
 			} );
 
-			emitter.on( 'failure', () => {
-				reject( new Error( `Failed to stop site ${ this.siteId }` ) );
+			emitter.on( 'failure', ( { result, lastErrorMessage } ) => {
+				const errorDetail =
+					lastErrorMessage ||
+					result.stderr.trim() ||
+					result.stdout.trim() ||
+					`Failed to stop site ${ this.siteId }`;
+				reject( new Error( errorDetail ) );
 			} );
 
 			emitter.on( 'error', ( { error } ) => {
@@ -71,20 +84,28 @@ export class CliServerProcess implements WordPressServerProcess {
 		} );
 	}
 
-	async delete( deleteFiles: boolean ): Promise< void > {
+	async delete( trashFiles: boolean ): Promise< void > {
 		return new Promise( ( resolve, reject ) => {
 			const args = [ 'site', 'delete', '--path', this.sitePath ];
-			if ( deleteFiles ) {
+			if ( trashFiles ) {
 				args.push( '--files' );
 			}
-			const [ emitter ] = executeCliCommand( args );
+			const [ emitter ] = executeCliCommand( args, {
+				output: 'capture',
+				logPrefix: this.siteId,
+			} );
 
 			emitter.on( 'success', () => {
 				resolve();
 			} );
 
-			emitter.on( 'failure', () => {
-				reject( new Error( `Failed to delete site ${ this.siteId }` ) );
+			emitter.on( 'failure', ( { result, lastErrorMessage } ) => {
+				const errorDetail =
+					lastErrorMessage ||
+					result.stderr.trim() ||
+					result.stdout.trim() ||
+					`Failed to delete site ${ this.siteId }`;
+				reject( new Error( errorDetail ) );
 			} );
 
 			emitter.on( 'error', ( { error } ) => {

--- a/src/modules/cli/lib/cli-site-creator.ts
+++ b/src/modules/cli/lib/cli-site-creator.ts
@@ -89,6 +89,7 @@ export async function createSiteViaCli( options: CreateSiteOptions ): Promise< C
 		} );
 
 		emitter.on( 'failure', ( { error } ) => {
+			cleanupTempFile( blueprintTempPath );
 			error.baseMessage = 'Failed to create site';
 			reject( error );
 		} );

--- a/src/modules/cli/lib/cli-site-creator.ts
+++ b/src/modules/cli/lib/cli-site-creator.ts
@@ -51,8 +51,6 @@ export async function createSiteViaCli( options: CreateSiteOptions ): Promise< C
 
 	return new Promise( ( resolve, reject ) => {
 		const result: Partial< CreateSiteResult > = {};
-		let lastErrorMessage: string | null = null;
-
 		const [ emitter ] = executeCliCommand( args, { output: 'capture', logPrefix: siteId } );
 
 		emitter.on( 'data', ( { data } ) => {
@@ -78,8 +76,6 @@ export async function createSiteViaCli( options: CreateSiteOptions ): Promise< C
 					siteId,
 					message: parsed.data.message,
 				} );
-			} else if ( parsed.data.status === 'fail' ) {
-				lastErrorMessage = parsed.data.message;
 			}
 		} );
 
@@ -92,9 +88,14 @@ export async function createSiteViaCli( options: CreateSiteOptions ): Promise< C
 			}
 		} );
 
-		emitter.on( 'failure', () => {
+		emitter.on( 'failure', ( { result, lastErrorMessage } ) => {
 			cleanupTempFile( blueprintTempPath );
-			reject( new Error( lastErrorMessage || 'CLI create site failed' ) );
+			const errorDetail =
+				lastErrorMessage ||
+				result.stderr.trim() ||
+				result.stdout.trim() ||
+				'CLI create site failed';
+			reject( new Error( errorDetail ) );
 		} );
 
 		emitter.on( 'error', ( { error } ) => {

--- a/src/modules/cli/lib/cli-site-creator.ts
+++ b/src/modules/cli/lib/cli-site-creator.ts
@@ -88,14 +88,9 @@ export async function createSiteViaCli( options: CreateSiteOptions ): Promise< C
 			}
 		} );
 
-		emitter.on( 'failure', ( { result, lastErrorMessage } ) => {
-			cleanupTempFile( blueprintTempPath );
-			const errorDetail =
-				lastErrorMessage ||
-				result.stderr.trim() ||
-				result.stdout.trim() ||
-				'CLI create site failed';
-			reject( new Error( errorDetail ) );
+		emitter.on( 'failure', ( { error } ) => {
+			error.baseMessage = 'Failed to create site';
+			reject( error );
 		} );
 
 		emitter.on( 'error', ( { error } ) => {

--- a/src/modules/cli/lib/cli-site-editor.ts
+++ b/src/modules/cli/lib/cli-site-editor.ts
@@ -24,8 +24,6 @@ export async function editSiteViaCli( options: EditSiteOptions ): Promise< void 
 	console.log( `[CLI Site Editor] Executing: studio ${ args.join( ' ' ) }` );
 
 	return new Promise( ( resolve, reject ) => {
-		let lastErrorMessage: string | null = null;
-
 		const [ emitter ] = executeCliCommand( args, { output: 'capture', logPrefix: options.siteId } );
 
 		emitter.on( 'data', ( { data } ) => {
@@ -36,8 +34,6 @@ export async function editSiteViaCli( options: EditSiteOptions ): Promise< void 
 
 			if ( parsed.data.status === 'inprogress' ) {
 				console.log( `[CLI - ${ options.siteId }] ${ parsed.data.message }` );
-			} else if ( parsed.data.status === 'fail' ) {
-				lastErrorMessage = parsed.data.message;
 			}
 		} );
 
@@ -45,9 +41,14 @@ export async function editSiteViaCli( options: EditSiteOptions ): Promise< void 
 			resolve();
 		} );
 
-		emitter.on( 'failure', () => {
-			console.error( `[CLI Site Editor] Command failed: ${ lastErrorMessage }` );
-			reject( new Error( lastErrorMessage || 'CLI site set failed' ) );
+		emitter.on( 'failure', ( { result, lastErrorMessage } ) => {
+			const errorDetail =
+				lastErrorMessage ||
+				result?.stderr?.trim() ||
+				result?.stdout?.trim() ||
+				'CLI site set failed';
+			console.error( `[CLI Site Editor] Command failed: ${ errorDetail }` );
+			reject( new Error( errorDetail ) );
 		} );
 
 		emitter.on( 'error', ( { error } ) => {

--- a/src/modules/cli/lib/cli-site-editor.ts
+++ b/src/modules/cli/lib/cli-site-editor.ts
@@ -41,14 +41,9 @@ export async function editSiteViaCli( options: EditSiteOptions ): Promise< void 
 			resolve();
 		} );
 
-		emitter.on( 'failure', ( { result, lastErrorMessage } ) => {
-			const errorDetail =
-				lastErrorMessage ||
-				result?.stderr?.trim() ||
-				result?.stdout?.trim() ||
-				'CLI site set failed';
-			console.error( `[CLI Site Editor] Command failed: ${ errorDetail }` );
-			reject( new Error( errorDetail ) );
+		emitter.on( 'failure', ( { error } ) => {
+			error.baseMessage = 'Failed to edit site';
+			reject( error );
 		} );
 
 		emitter.on( 'error', ( { error } ) => {

--- a/src/modules/cli/lib/execute-command.ts
+++ b/src/modules/cli/lib/execute-command.ts
@@ -104,6 +104,11 @@ export function executeCliCommand(
 	const cliPath = getCliPath();
 
 	let stdio: StdioOptions | undefined;
+	/**
+	 * If there's an IPC channel, the CLI `Logger` uses IPC to communicate all expected events. This
+	 * means that for many CLI commands, the captured stdout/stderr will be empty, unless something
+	 * unexpected was logged.
+	 */
 	if ( options.output === 'capture' ) {
 		stdio = [ 'ignore', 'pipe', 'pipe', 'ipc' ];
 	} else if ( options.output === 'ignore' ) {

--- a/src/modules/cli/lib/execute-command.ts
+++ b/src/modules/cli/lib/execute-command.ts
@@ -5,31 +5,30 @@ import * as Sentry from '@sentry/electron/main';
 import { z } from 'zod';
 import { getBundledNodeBinaryPath, getCliPath } from 'src/storage/paths';
 
-type CliCommandResultExitCode = {
+export type CliCommandResult = {
 	stdout: string;
 	stderr: string;
-	exitCode: number;
 };
-type CliCommandResultSignal = {
-	stdout: string;
-	stderr: string;
-	signal: NodeJS.Signals;
-};
-export type CliCommandResult = CliCommandResultExitCode | CliCommandResultSignal;
 
-export class CliCommandFailureError extends Error {
+export class CliCommandError extends Error {
 	baseMessage = 'CLI command failed';
 	readonly lastErrorMessage: string | undefined;
 	readonly cliCommandResult: CliCommandResult | undefined;
+	readonly exitCode: number | null;
+	readonly signal: NodeJS.Signals | null;
 
-	constructor(
-		lastErrorMessage: string | undefined,
-		cliCommandResult: CliCommandResult | undefined
-	) {
+	constructor( options: {
+		lastErrorMessage: string | undefined;
+		cliCommandResult: CliCommandResult | undefined;
+		exitCode: number | null;
+		signal: NodeJS.Signals | null;
+	} ) {
 		super();
-		this.lastErrorMessage = lastErrorMessage;
-		this.cliCommandResult = cliCommandResult;
-		this.name = 'CliCommandFailureError';
+		this.lastErrorMessage = options.lastErrorMessage;
+		this.cliCommandResult = options.cliCommandResult;
+		this.exitCode = options.exitCode;
+		this.signal = options.signal;
+		this.name = 'CliCommandError';
 	}
 
 	get message(): string {
@@ -47,12 +46,10 @@ export class CliCommandFailureError extends Error {
 			}
 		}
 
-		if ( this.cliCommandResult ) {
-			if ( 'signal' in this.cliCommandResult ) {
-				messageParts.push( `Terminated by signal: ${ this.cliCommandResult.signal }` );
-			} else if ( 'exitCode' in this.cliCommandResult ) {
-				messageParts.push( `Exit code: ${ this.cliCommandResult.exitCode }` );
-			}
+		if ( this.signal !== null ) {
+			messageParts.push( `Terminated by signal: ${ this.signal }` );
+		} else if ( this.exitCode !== null ) {
+			messageParts.push( `Exit code: ${ this.exitCode }` );
 		}
 
 		return messageParts
@@ -66,7 +63,7 @@ type CliCommandEventMap = {
 	error: { error: Error };
 	data: { data: unknown };
 	success: { result: CliCommandResult | undefined };
-	failure: { error: CliCommandFailureError };
+	failure: { error: CliCommandError };
 };
 
 // Schema to detect error messages from CLI IPC regardless of the specific action type
@@ -91,15 +88,14 @@ class CliCommandEventEmitter extends EventEmitter {
 	}
 }
 
-export interface ExecuteCliCommandOptions {
-	/**
-	 * Controls how stdout/stderr is handled:
-	 * - 'ignore': ignore stdout/stderr completely
-	 * - 'capture': capture stdout/stderr, available in success/failure events
-	 */
-	output: 'ignore' | 'capture';
+type ExecuteCliCommandOptionsIgnore = {
+	output: 'ignore';
+};
+type ExecuteCliCommandOptionsCapture = {
+	output: 'capture';
 	logPrefix?: string;
-}
+};
+type ExecuteCliCommandOptions = ExecuteCliCommandOptionsIgnore | ExecuteCliCommandOptionsCapture;
 
 export function executeCliCommand(
 	args: string[],
@@ -135,9 +131,7 @@ export function executeCliCommand(
 	let lastErrorMessage: string | undefined;
 
 	if ( options.output === 'capture' ) {
-		const logPrefix = options.logPrefix
-			? `[CLI - pid ${ child.pid } - site ID ${ options.logPrefix }]`
-			: '[CLI]';
+		const logPrefix = options.logPrefix ? `[CLI - site ID ${ options.logPrefix }]` : '[CLI]';
 		child.stdout?.on( 'data', ( data: Buffer ) => {
 			const text = data.toString();
 			stdout += text;
@@ -181,19 +175,19 @@ export function executeCliCommand(
 		let result: CliCommandResult | undefined;
 
 		if ( options.output === 'capture' ) {
-			if ( exitCode !== null ) {
-				result = { stdout, stderr, exitCode };
-			} else if ( signal !== null ) {
-				result = { stdout, stderr, signal };
-			}
+			result = { stdout, stderr };
 		}
 
 		if ( exitCode === 0 ) {
 			eventEmitter.emit( 'success', { result } );
 		} else {
-			eventEmitter.emit( 'failure', {
-				error: new CliCommandFailureError( lastErrorMessage, result ),
+			const error = new CliCommandError( {
+				lastErrorMessage,
+				cliCommandResult: result,
+				exitCode,
+				signal,
 			} );
+			eventEmitter.emit( 'failure', { error } );
 		}
 	} );
 

--- a/src/modules/cli/lib/execute-command.ts
+++ b/src/modules/cli/lib/execute-command.ts
@@ -32,24 +32,30 @@ export class CliCommandError extends Error {
 	}
 
 	get message(): string {
-		const messageParts: string[] = [ this.baseMessage ];
+		const messageParts: string[] = [];
 
 		if ( this.lastErrorMessage ) {
-			messageParts.push( `Last error message: ${ this.lastErrorMessage }` );
-		} else if ( this.cliCommandResult ) {
+			messageParts.push( `[Last error message] ${ this.lastErrorMessage }` );
+		}
+
+		if ( this.baseMessage ) {
+			messageParts.push( `[Base message] ${ this.baseMessage }` );
+		}
+
+		if ( this.cliCommandResult ) {
 			const stderr = this.cliCommandResult.stderr.trim();
 			const stdout = this.cliCommandResult.stdout.trim();
 			if ( stderr ) {
-				messageParts.push( `stderr: ${ stderr }` );
+				messageParts.push( `[stderr] ${ stderr }` );
 			} else if ( stdout ) {
-				messageParts.push( `stdout: ${ stdout }` );
+				messageParts.push( `[stdout] ${ stdout }` );
 			}
 		}
 
 		if ( this.signal !== null ) {
-			messageParts.push( `Terminated by signal: ${ this.signal }` );
+			messageParts.push( `[Terminated by signal] ${ this.signal }` );
 		} else if ( this.exitCode !== null ) {
-			messageParts.push( `Exit code: ${ this.exitCode }` );
+			messageParts.push( `[Exit code] ${ this.exitCode }` );
 		}
 
 		return messageParts

--- a/src/modules/cli/lib/execute-command.ts
+++ b/src/modules/cli/lib/execute-command.ts
@@ -5,23 +5,66 @@ import * as Sentry from '@sentry/electron/main';
 import { z } from 'zod';
 import { getBundledNodeBinaryPath, getCliPath } from 'src/storage/paths';
 
-export interface CliCommandResult {
+type CliCommandResultExitCode = {
 	stdout: string;
 	stderr: string;
 	exitCode: number;
+};
+type CliCommandResultSignal = {
+	stdout: string;
+	stderr: string;
+	signal: NodeJS.Signals;
+};
+export type CliCommandResult = CliCommandResultExitCode | CliCommandResultSignal;
+
+export class CliCommandFailureError extends Error {
+	baseMessage = 'CLI command failed';
+	readonly lastErrorMessage: string | undefined;
+	readonly cliCommandResult: CliCommandResult | undefined;
+
+	constructor(
+		lastErrorMessage: string | undefined,
+		cliCommandResult: CliCommandResult | undefined
+	) {
+		super();
+		this.lastErrorMessage = lastErrorMessage;
+		this.cliCommandResult = cliCommandResult;
+		this.name = 'CliCommandFailureError';
+	}
+
+	get message(): string {
+		const messageParts: string[] = [ this.baseMessage ];
+
+		if ( this.lastErrorMessage ) {
+			messageParts.push( this.lastErrorMessage );
+		} else if ( this.cliCommandResult ) {
+			const stderr = this.cliCommandResult.stderr.trim();
+			const stdout = this.cliCommandResult.stdout.trim();
+			if ( stderr ) {
+				messageParts.push( stderr );
+			} else if ( stdout ) {
+				messageParts.push( stdout );
+			}
+		}
+
+		if ( this.cliCommandResult ) {
+			if ( 'signal' in this.cliCommandResult ) {
+				messageParts.push( `Terminated by signal: ${ this.cliCommandResult.signal }` );
+			} else if ( 'exitCode' in this.cliCommandResult ) {
+				messageParts.push( `Exit code: ${ this.cliCommandResult.exitCode }` );
+			}
+		}
+
+		return messageParts.join( '\n' );
+	}
 }
 
-type CliCommandEventMap< CapturesStdio extends boolean = false > = {
+type CliCommandEventMap = {
 	started: void;
 	error: { error: Error };
 	data: { data: unknown };
-	success: {
-		result: CapturesStdio extends true ? CliCommandResult : undefined;
-	};
-	failure: {
-		lastErrorMessage: string | undefined;
-		result: CapturesStdio extends true ? CliCommandResult : undefined;
-	};
+	success: { result: CliCommandResult | undefined };
+	failure: { error: CliCommandFailureError };
 };
 
 // Schema to detect error messages from CLI IPC regardless of the specific action type
@@ -30,17 +73,17 @@ const cliErrorMessageSchema = z.object( {
 	message: z.string(),
 } );
 
-class CliCommandEventEmitter< HasResult extends boolean = false > extends EventEmitter {
-	on< K extends keyof CliCommandEventMap< HasResult > >(
+class CliCommandEventEmitter extends EventEmitter {
+	on< K extends keyof CliCommandEventMap >(
 		event: K,
-		listener: ( payload: CliCommandEventMap< HasResult >[ K ] ) => void
+		listener: ( payload: CliCommandEventMap[ K ] ) => void
 	): this {
 		return super.on( event, listener );
 	}
 
-	emit< K extends keyof CliCommandEventMap< HasResult > >(
+	emit< K extends keyof CliCommandEventMap >(
 		event: K,
-		payload?: CliCommandEventMap< HasResult >[ K ]
+		payload?: CliCommandEventMap[ K ]
 	): boolean {
 		return super.emit( event, payload );
 	}
@@ -58,20 +101,8 @@ export interface ExecuteCliCommandOptions {
 
 export function executeCliCommand(
 	args: string[],
-	options: { output: 'capture'; logPrefix?: string }
-): [ CliCommandEventEmitter< true >, ChildProcess ];
-export function executeCliCommand(
-	args: string[],
-	options: { output: 'ignore'; logPrefix?: string }
-): [ CliCommandEventEmitter< false >, ChildProcess ];
-export function executeCliCommand(
-	args: string[],
-	options?: ExecuteCliCommandOptions
-): [ CliCommandEventEmitter< false >, ChildProcess ];
-export function executeCliCommand(
-	args: string[],
 	options: ExecuteCliCommandOptions = { output: 'ignore' }
-): [ CliCommandEventEmitter< boolean >, ChildProcess ] {
+): [ CliCommandEventEmitter, ChildProcess ] {
 	const cliPath = getCliPath();
 
 	let stdio: StdioOptions | undefined;
@@ -85,7 +116,7 @@ export function executeCliCommand(
 		stdio,
 		execPath: getBundledNodeBinaryPath(),
 	} );
-	const eventEmitter = new CliCommandEventEmitter< boolean >();
+	const eventEmitter = new CliCommandEventEmitter();
 
 	child.on( 'spawn', () => {
 		eventEmitter.emit( 'started' );
@@ -127,17 +158,12 @@ export function executeCliCommand(
 		eventEmitter.emit( 'data', { data: message } );
 	} );
 
-	let capturedExitCode: number | null = null;
-
-	child.on( 'exit', ( code, signal ) => {
-		capturedExitCode = code;
-	} );
-
 	function appQuitHandler() {
 		const pid = child.pid;
+		child.removeAllListeners();
 		const result = child.kill();
 		if ( result ) {
-			console.log( `Successfully killed child process with pid ${ pid }` );
+			console.log( `Successfully killed child process with pid ${ pid }. Args:`, args );
 		} else {
 			console.error(
 				`Failed to kill child process with pid ${ pid }. This likely means the process is already terminated. CLI args:`,
@@ -146,18 +172,26 @@ export function executeCliCommand(
 		}
 	}
 
-	child.on( 'close', ( code ) => {
+	child.on( 'close', ( exitCode, signal ) => {
 		child.removeAllListeners();
 		app.off( 'will-quit', appQuitHandler );
 
-		const exitCode = capturedExitCode ?? code ?? 1;
-		const result: CliCommandResult | undefined =
-			options.output === 'capture' ? { stdout, stderr, exitCode } : undefined;
+		let result: CliCommandResult | undefined;
+
+		if ( options.output === 'capture' ) {
+			if ( exitCode !== null ) {
+				result = { stdout, stderr, exitCode };
+			} else if ( signal !== null ) {
+				result = { stdout, stderr, signal };
+			}
+		}
 
 		if ( exitCode === 0 ) {
 			eventEmitter.emit( 'success', { result } );
 		} else {
-			eventEmitter.emit( 'failure', { lastErrorMessage, result } );
+			eventEmitter.emit( 'failure', {
+				error: new CliCommandFailureError( lastErrorMessage, result ),
+			} );
 		}
 	} );
 

--- a/src/modules/cli/lib/execute-command.ts
+++ b/src/modules/cli/lib/execute-command.ts
@@ -36,14 +36,14 @@ export class CliCommandFailureError extends Error {
 		const messageParts: string[] = [ this.baseMessage ];
 
 		if ( this.lastErrorMessage ) {
-			messageParts.push( this.lastErrorMessage );
+			messageParts.push( `Last error message: ${ this.lastErrorMessage }` );
 		} else if ( this.cliCommandResult ) {
 			const stderr = this.cliCommandResult.stderr.trim();
 			const stdout = this.cliCommandResult.stdout.trim();
 			if ( stderr ) {
-				messageParts.push( stderr );
+				messageParts.push( `stderr: ${ stderr }` );
 			} else if ( stdout ) {
-				messageParts.push( stdout );
+				messageParts.push( `stdout: ${ stdout }` );
 			}
 		}
 

--- a/src/modules/cli/lib/execute-command.ts
+++ b/src/modules/cli/lib/execute-command.ts
@@ -10,7 +10,7 @@ export type CliCommandResult = {
 	stderr: string;
 };
 
-export class CliCommandError extends Error {
+class CliCommandError extends Error {
 	baseMessage = 'CLI command failed';
 	readonly lastErrorMessage: string | undefined;
 	readonly cliCommandResult: CliCommandResult | undefined;

--- a/src/modules/cli/lib/execute-command.ts
+++ b/src/modules/cli/lib/execute-command.ts
@@ -2,6 +2,7 @@ import { app } from 'electron';
 import { fork, ChildProcess, StdioOptions } from 'node:child_process';
 import EventEmitter from 'node:events';
 import * as Sentry from '@sentry/electron/main';
+import { z } from 'zod';
 import { getBundledNodeBinaryPath, getCliPath } from 'src/storage/paths';
 
 export interface CliCommandResult {
@@ -10,25 +11,36 @@ export interface CliCommandResult {
 	exitCode: number;
 }
 
-type CliCommandEventMap = {
+type CliCommandEventMap< CapturesStdio extends boolean = false > = {
 	started: void;
 	error: { error: Error };
 	data: { data: unknown };
-	success: { result?: CliCommandResult };
-	failure: { result?: CliCommandResult };
+	success: {
+		result: CapturesStdio extends true ? CliCommandResult : undefined;
+	};
+	failure: {
+		lastErrorMessage: string | undefined;
+		result: CapturesStdio extends true ? CliCommandResult : undefined;
+	};
 };
 
-class CliCommandEventEmitter extends EventEmitter {
-	on< K extends keyof CliCommandEventMap >(
+// Schema to detect error messages from CLI IPC regardless of the specific action type
+const cliErrorMessageSchema = z.object( {
+	status: z.literal( 'fail' ),
+	message: z.string(),
+} );
+
+class CliCommandEventEmitter< HasResult extends boolean = false > extends EventEmitter {
+	on< K extends keyof CliCommandEventMap< HasResult > >(
 		event: K,
-		listener: ( payload: CliCommandEventMap[ K ] ) => void
+		listener: ( payload: CliCommandEventMap< HasResult >[ K ] ) => void
 	): this {
 		return super.on( event, listener );
 	}
 
-	emit< K extends keyof CliCommandEventMap >(
+	emit< K extends keyof CliCommandEventMap< HasResult > >(
 		event: K,
-		payload?: CliCommandEventMap[ K ]
+		payload?: CliCommandEventMap< HasResult >[ K ]
 	): boolean {
 		return super.emit( event, payload );
 	}
@@ -37,7 +49,6 @@ class CliCommandEventEmitter extends EventEmitter {
 export interface ExecuteCliCommandOptions {
 	/**
 	 * Controls how stdout/stderr is handled:
-	 * - undefined (default): inherit from parent (shows output in terminal)
 	 * - 'ignore': ignore stdout/stderr completely
 	 * - 'capture': capture stdout/stderr, available in success/failure events
 	 */
@@ -47,8 +58,20 @@ export interface ExecuteCliCommandOptions {
 
 export function executeCliCommand(
 	args: string[],
+	options: { output: 'capture'; logPrefix?: string }
+): [ CliCommandEventEmitter< true >, ChildProcess ];
+export function executeCliCommand(
+	args: string[],
+	options: { output: 'ignore'; logPrefix?: string }
+): [ CliCommandEventEmitter< false >, ChildProcess ];
+export function executeCliCommand(
+	args: string[],
+	options?: ExecuteCliCommandOptions
+): [ CliCommandEventEmitter< false >, ChildProcess ];
+export function executeCliCommand(
+	args: string[],
 	options: ExecuteCliCommandOptions = { output: 'ignore' }
-): [ CliCommandEventEmitter, ChildProcess ] {
+): [ CliCommandEventEmitter< boolean >, ChildProcess ] {
 	const cliPath = getCliPath();
 
 	let stdio: StdioOptions | undefined;
@@ -62,7 +85,7 @@ export function executeCliCommand(
 		stdio,
 		execPath: getBundledNodeBinaryPath(),
 	} );
-	const eventEmitter = new CliCommandEventEmitter();
+	const eventEmitter = new CliCommandEventEmitter< boolean >();
 
 	child.on( 'spawn', () => {
 		eventEmitter.emit( 'started' );
@@ -76,6 +99,7 @@ export function executeCliCommand(
 
 	let stdout = '';
 	let stderr = '';
+	let lastErrorMessage: string | undefined;
 
 	if ( options.output === 'capture' ) {
 		const logPrefix = options.logPrefix
@@ -95,12 +119,17 @@ export function executeCliCommand(
 	}
 
 	child.on( 'message', ( message: unknown ) => {
+		const errorParsed = cliErrorMessageSchema.safeParse( message );
+		if ( errorParsed.success ) {
+			lastErrorMessage = errorParsed.data.message;
+		}
+
 		eventEmitter.emit( 'data', { data: message } );
 	} );
 
 	let capturedExitCode: number | null = null;
 
-	child.on( 'exit', ( code ) => {
+	child.on( 'exit', ( code, signal ) => {
 		capturedExitCode = code;
 	} );
 
@@ -128,7 +157,7 @@ export function executeCliCommand(
 		if ( exitCode === 0 ) {
 			eventEmitter.emit( 'success', { result } );
 		} else {
-			eventEmitter.emit( 'failure', { result } );
+			eventEmitter.emit( 'failure', { lastErrorMessage, result } );
 		}
 	} );
 

--- a/src/modules/cli/lib/execute-command.ts
+++ b/src/modules/cli/lib/execute-command.ts
@@ -64,12 +64,14 @@ export class CliCommandError extends Error {
 	}
 }
 
-type CliCommandEventMap = {
+type CliCommandEventMap< CapturesOutput extends boolean = false > = {
 	started: void;
 	error: { error: Error };
 	data: { data: unknown };
-	success: { result: CliCommandResult | undefined };
-	failure: { error: CliCommandError };
+	success: { result: CapturesOutput extends true ? CliCommandResult : undefined };
+	failure: CapturesOutput extends true
+		? { error: CliCommandError; result: CliCommandResult }
+		: { error: CliCommandError };
 };
 
 // Schema to detect error messages from CLI IPC regardless of the specific action type
@@ -78,17 +80,17 @@ const cliErrorMessageSchema = z.object( {
 	message: z.string(),
 } );
 
-class CliCommandEventEmitter extends EventEmitter {
-	on< K extends keyof CliCommandEventMap >(
+class CliCommandEventEmitter< CapturesOutput extends boolean = false > extends EventEmitter {
+	on< K extends keyof CliCommandEventMap< CapturesOutput > >(
 		event: K,
-		listener: ( payload: CliCommandEventMap[ K ] ) => void
+		listener: ( payload: CliCommandEventMap< CapturesOutput >[ K ] ) => void
 	): this {
 		return super.on( event, listener );
 	}
 
-	emit< K extends keyof CliCommandEventMap >(
+	emit< K extends keyof CliCommandEventMap< CapturesOutput > >(
 		event: K,
-		payload?: CliCommandEventMap[ K ]
+		payload?: CliCommandEventMap< CapturesOutput >[ K ]
 	): boolean {
 		return super.emit( event, payload );
 	}
@@ -105,8 +107,20 @@ type ExecuteCliCommandOptions = ExecuteCliCommandOptionsIgnore | ExecuteCliComma
 
 export function executeCliCommand(
 	args: string[],
+	options: { output: 'capture'; logPrefix?: string }
+): [ CliCommandEventEmitter< true >, ChildProcess ];
+export function executeCliCommand(
+	args: string[],
+	options: { output: 'ignore'; logPrefix?: string }
+): [ CliCommandEventEmitter< false >, ChildProcess ];
+export function executeCliCommand(
+	args: string[],
+	options?: ExecuteCliCommandOptions
+): [ CliCommandEventEmitter< false >, ChildProcess ];
+export function executeCliCommand(
+	args: string[],
 	options: ExecuteCliCommandOptions = { output: 'ignore' }
-): [ CliCommandEventEmitter, ChildProcess ] {
+): [ CliCommandEventEmitter< boolean >, ChildProcess ] {
 	const cliPath = getCliPath();
 
 	let stdio: StdioOptions | undefined;
@@ -125,7 +139,7 @@ export function executeCliCommand(
 		stdio,
 		execPath: getBundledNodeBinaryPath(),
 	} );
-	const eventEmitter = new CliCommandEventEmitter();
+	const eventEmitter = new CliCommandEventEmitter< boolean >();
 
 	child.on( 'spawn', () => {
 		eventEmitter.emit( 'started' );
@@ -198,7 +212,11 @@ export function executeCliCommand(
 				exitCode,
 				signal,
 			} );
-			eventEmitter.emit( 'failure', { error } );
+			if ( options.output === 'capture' ) {
+				eventEmitter.emit( 'failure', { error, result } );
+			} else {
+				eventEmitter.emit( 'failure', { error } );
+			}
 		}
 	} );
 

--- a/src/modules/cli/lib/execute-command.ts
+++ b/src/modules/cli/lib/execute-command.ts
@@ -55,7 +55,9 @@ export class CliCommandFailureError extends Error {
 			}
 		}
 
-		return messageParts.join( '\n' );
+		return messageParts
+			.map( ( part, index ) => ( index === 0 ? part : `  ${ part }` ) )
+			.join( '\n' );
 	}
 }
 

--- a/src/modules/cli/lib/execute-preview-command.ts
+++ b/src/modules/cli/lib/execute-preview-command.ts
@@ -22,7 +22,7 @@ export async function executePreviewCliCommand(
 	parentWindow: Electron.BrowserWindow | null
 ): Promise< { operationId: crypto.UUID } > {
 	const operationId = crypto.randomUUID();
-	const [ cliEventEmitter ] = executeCliCommand( args );
+	const [ cliEventEmitter ] = executeCliCommand( args, { output: 'capture' } );
 
 	cliEventEmitter.on( 'data', ( { data } ) => {
 		const parsed = snapshotEventSchema.safeParse( data );
@@ -57,10 +57,13 @@ export async function executePreviewCliCommand(
 		} );
 	} );
 
-	cliEventEmitter.on( 'failure', () => {
+	cliEventEmitter.on( 'failure', ( { result, lastErrorMessage } ) => {
+		const errorDetail =
+			lastErrorMessage || result.stderr.trim() || result.stdout.trim() || 'Unknown error';
+
 		sendIpcEventToRendererWithWindow( parentWindow, 'snapshot-fatal-error', {
 			operationId,
-			data: { message: 'Unknown error' },
+			data: { message: errorDetail },
 		} );
 	} );
 

--- a/src/modules/cli/lib/execute-preview-command.ts
+++ b/src/modules/cli/lib/execute-preview-command.ts
@@ -57,13 +57,10 @@ export async function executePreviewCliCommand(
 		} );
 	} );
 
-	cliEventEmitter.on( 'failure', ( { result, lastErrorMessage } ) => {
-		const errorDetail =
-			lastErrorMessage || result.stderr.trim() || result.stdout.trim() || 'Unknown error';
-
+	cliEventEmitter.on( 'failure', ( { error } ) => {
 		sendIpcEventToRendererWithWindow( parentWindow, 'snapshot-fatal-error', {
 			operationId,
-			data: { message: errorDetail },
+			data: { message: error.message },
 		} );
 	} );
 

--- a/src/site-server.ts
+++ b/src/site-server.ts
@@ -349,11 +349,11 @@ export class SiteServer {
 			}, timeout );
 
 			emitter.on( 'success', ( { result } ) => {
-				resolve( result ?? { stdout: '', stderr: '', exitCode: 0 } );
+				resolve( { stdout: result.stdout, stderr: result.stderr, exitCode: 0 } );
 			} );
 
 			emitter.on( 'failure', ( { result } ) => {
-				resolve( result ?? { stdout: '', stderr: '', exitCode: 1 } );
+				resolve( { stdout: result.stdout, stderr: result.stderr, exitCode: 1 } );
 			} );
 
 			emitter.on( 'error', ( { error } ) => {

--- a/src/site-server.ts
+++ b/src/site-server.ts
@@ -33,7 +33,7 @@ export async function stopAllServers( shouldSaveAutoStartProp: boolean ) {
 		if ( shouldSaveAutoStartProp ) {
 			args.push( '--auto-start' );
 		}
-		const [ emitter ] = executeCliCommand( args, { output: 'ignore' } );
+		const [ emitter ] = executeCliCommand( args );
 		emitter.on( 'success', () => resolve() );
 		emitter.on( 'failure', () => resolve() );
 		emitter.on( 'error', () => resolve() );

--- a/src/tests/execute-wp-cli.test.ts
+++ b/src/tests/execute-wp-cli.test.ts
@@ -30,18 +30,17 @@ function simulateCliResponse( {
 	stdout = '',
 	stderr = '',
 	exitCode = 0,
-	emitSuccess = true,
 }: {
 	stdout?: string;
 	stderr?: string;
 	exitCode?: number;
-	emitSuccess?: boolean;
 } ) {
 	setImmediate( () => {
-		const result: CliCommandResult = { stdout, stderr, exitCode };
-		if ( emitSuccess ) {
-			mockEventEmitter.emit( exitCode === 0 ? 'success' : 'failure', { result } );
-		}
+		// We are intentionally excluding the `error` prop for simplicity, since none of the tests need it
+		const payload: { result: CliCommandResult } = {
+			result: { stdout, stderr },
+		};
+		mockEventEmitter.emit( exitCode === 0 ? 'success' : 'failure', payload );
 	} );
 }
 
@@ -102,14 +101,14 @@ describe( 'SiteServer.executeWpCliCommand', () => {
 					} );
 				}, timeout );
 
-				emitter.on( 'success', ( { result }: { result?: CliCommandResult } ) => {
+				emitter.on( 'success', ( { result } ) => {
 					clearTimeout( timeoutId );
-					resolve( result ?? { stdout: '', stderr: '', exitCode: 0 } );
+					resolve( { stdout: result.stdout, stderr: result.stderr, exitCode: 0 } );
 				} );
 
-				emitter.on( 'failure', ( { result }: { result?: CliCommandResult } ) => {
+				emitter.on( 'failure', ( { result } ) => {
 					clearTimeout( timeoutId );
-					resolve( result ?? { stdout: '', stderr: '', exitCode: 1 } );
+					resolve( { stdout: result.stdout, stderr: result.stderr, exitCode: 1 } );
 				} );
 
 				emitter.on( 'error', ( { error }: { error: Error } ) => {
@@ -174,14 +173,6 @@ describe( 'SiteServer.executeWpCliCommand', () => {
 			const result = await resultPromise;
 
 			expect( result.stderr ).toBe( 'Error: command not found' );
-		} );
-
-		it( 'should capture exitCode from CLI process', async () => {
-			const resultPromise = executeWpCliCommand( 'plugin list' );
-			simulateCliResponse( { exitCode: 42 } );
-			const result = await resultPromise;
-
-			expect( result.exitCode ).toBe( 42 );
 		} );
 
 		it( 'should capture all output values together', async () => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Related to STU-1260

## Proposed Changes

After the 1.7.0 launch, we've seen an increased number of `Failed to start server` and `Failed to create server` errors. We know this stems from the CLI launch, and the errors are captured in Sentry, but we don't record enough details to know exactly what's going on. 

This PR fixes that by:

1. Changing the `CliCommandEventEmitter`'s `failure` event to contain a new custom error class in the payload.
2. This custom error class (`CliCommandError`) captures the last error message sent over IPC (probably the most vital piece of information), stderr, stdout, the process's exit code, or the type of signal that interrupted the process. 
3. All site CLI commands now pass the `output: 'capture'` config to `executeCliCommand`. If something unexpected is printed to stderr or stdout in the child process, we will now capture it, too. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Add a line somewhere in `cli/commands/site/start.ts` that just throws an error, like `throw new Error( 'TEST ERROR' );`
2. Run `npm start`
3. Start a server
4. Ensure that you see the following in your terminal:

```
Sentry Logger [log]: Captured error event `[Last error message] Failed to start WordPress server: TEST ERROR
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
