### PR TITLE
Fix About window not loading after `vite-plugin-static-copy` update

### DIFF
--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -14,20 +14,7 @@ console.log( 'Sentry environment:', isDevEnvironment ? 'development' : 'producti
 
 export default defineConfig( {
 	main: {
-		plugins: [
-			viteStaticCopy( {
-				targets: [
-					{
-						src: 'src/about-menu/about-menu.html',
-						dest: '.',
-					},
-					{
-						src: 'src/about-menu/studio-app-icon.png',
-						dest: '.',
-					},
-				],
-			} ),
-		],
+		plugins: [],
 		resolve: {
 			alias: {
 				src: resolve( 'src' ),
@@ -94,6 +81,14 @@ export default defineConfig( {
 					{
 						src: 'node_modules/@rive-app/canvas/rive_fallback.wasm',
 						dest: 'assets',
+					},
+					{
+						src: 'src/about-menu/about-menu.html',
+						dest: '.',
+					},
+					{
+						src: 'src/about-menu/studio-app-icon.png',
+						dest: '.',
 					},
 				],
 			} ),

--- a/src/about-menu/open-about-menu.ts
+++ b/src/about-menu/open-about-menu.ts
@@ -7,6 +7,15 @@ import { shellOpenExternalWrapper } from 'src/lib/shell-open-external-wrapper';
 
 let aboutWindow: BrowserWindow | null = null;
 
+function getAboutPath(): string {
+	if ( ! app.isPackaged ) {
+		// In development, load directly from source
+		return path.join( __dirname, '..', '..', 'src', 'about-menu', 'about-menu.html' );
+	}
+	// In production, load from renderer output
+	return path.join( __dirname, '..', 'renderer', 'about-menu.html' );
+}
+
 export function escapeSingleQuotes( str: string ) {
 	return str.replace( /\\/g, '\\\\' ).replace( /'/g, "\\'" );
 }
@@ -25,7 +34,7 @@ function getPlatformLabel(): string {
 }
 
 export function openAboutWindow() {
-	const aboutPath = path.join( __dirname, 'about-menu.html' );
+	const aboutPath = getAboutPath();
 
 	if ( aboutWindow ) {
 		aboutWindow.focus();

--- a/src/about-menu/open-about-menu.ts
+++ b/src/about-menu/open-about-menu.ts
@@ -10,8 +10,8 @@ let aboutWindow: BrowserWindow | null = null;
 
 function getAboutPath(): string {
 	return process.env.NODE_ENV === 'development'
-		? path.join( getResourcesPath(), 'src/about-menu/about-menu.html' )
-		: path.join( getResourcesPath(), 'dist/renderer/about-menu.html' );
+		? path.join( getResourcesPath(), 'src', 'about-menu', 'about-menu.html' )
+		: path.join( getResourcesPath(), 'dist', 'renderer', 'about-menu.html' );
 }
 
 export function escapeSingleQuotes( str: string ) {

--- a/src/about-menu/open-about-menu.ts
+++ b/src/about-menu/open-about-menu.ts
@@ -4,16 +4,14 @@ import * as Sentry from '@sentry/electron/renderer';
 import { __ } from '@wordpress/i18n';
 import { ABOUT_WINDOW_HEIGHT, ABOUT_WINDOW_WIDTH } from 'src/constants';
 import { shellOpenExternalWrapper } from 'src/lib/shell-open-external-wrapper';
+import { getResourcesPath } from 'src/storage/paths';
 
 let aboutWindow: BrowserWindow | null = null;
 
 function getAboutPath(): string {
-	if ( ! app.isPackaged ) {
-		// In development, load directly from source
-		return path.join( __dirname, '..', '..', 'src', 'about-menu', 'about-menu.html' );
-	}
-	// In production, load from renderer output
-	return path.join( __dirname, '..', 'renderer', 'about-menu.html' );
+	return process.env.NODE_ENV === 'development'
+		? path.join( getResourcesPath(), 'src/about-menu/about-menu.html' )
+		: path.join( getResourcesPath(), 'dist/renderer/about-menu.html' );
 }
 
 export function escapeSingleQuotes( str: string ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-1263

## Proposed Changes

`vite-plugin-static-copy` 3.1.5 changed to only copy files for client environments, which broke the About window since it was configured in the main process build config.

- Move static copy targets for `about-menu.html` and `studio-app-icon.png` from main to renderer config
- Update path logic in `open-about-menu.ts` to handle both development (load from source) and production (load from renderer output) environments

## Testing Instructions

1. Run `npm start`
2. Open Studio → About WordPress Studio
3. Verify the About window displays correctly with the icon, version, and links

4. Run `npm run make` then launch the packaged app
5. Open Studio → About WordPress Studio
6. Verify the About window displays correctly

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?