### PR TITLE
Fix Blueprint Version Warning Comparison

### DIFF
--- a/src/modules/add-site/components/create-site-form.tsx
+++ b/src/modules/add-site/components/create-site-form.tsx
@@ -353,20 +353,11 @@ export const CreateSiteForm = ( {
 
 	const generatedDomainName = generateCustomDomainFromSiteName( siteName );
 
-	// Check if blueprint versions differ from original defaults (or current selections if no originals provided)
-	// This ensures the warning shows immediately when a Blueprint with different versions is selected
-	const phpVersionToCompare = originalDefaultVersions?.phpVersion ?? phpVersion;
-	const wpVersionToCompare = originalDefaultVersions?.wpVersion ?? wpVersion;
-
 	const showPhpVersionWarning =
-		blueprintPreferredVersions?.php &&
-		blueprintPreferredVersions.php !== 'latest' &&
-		blueprintPreferredVersions.php !== phpVersionToCompare;
+		blueprintPreferredVersions?.php && blueprintPreferredVersions.php !== phpVersion;
 
 	const showWpVersionWarning =
-		blueprintPreferredVersions?.wp &&
-		blueprintPreferredVersions.wp !== 'latest' &&
-		blueprintPreferredVersions.wp !== wpVersionToCompare;
+		blueprintPreferredVersions?.wp && blueprintPreferredVersions.wp !== wpVersion;
 
 	const showBlueprintVersionWarning = showPhpVersionWarning || showWpVersionWarning;
 	const warningCount = [ showPhpVersionWarning, showWpVersionWarning ].filter( Boolean ).length;
@@ -494,9 +485,9 @@ export const CreateSiteForm = ( {
 												<li>
 													{ sprintf(
 														/* translators: %1$s: recommended PHP version, %2$s: default PHP version */
-														__( 'PHP %s (default is %s)' ),
+														__( 'PHP %s (selected is %s)' ),
 														blueprintPreferredVersions?.php as string,
-														phpVersionToCompare
+														phpVersion
 													) }
 												</li>
 											) }
@@ -504,9 +495,9 @@ export const CreateSiteForm = ( {
 												<li>
 													{ sprintf(
 														/* translators: %1$s: recommended WordPress version, %2$s: default WordPress version */
-														__( 'WordPress %s (default is %s)' ),
+														__( 'WordPress %s (selected is %s)' ),
 														blueprintPreferredVersions?.wp as string,
-														wpVersionToCompare
+														wpVersion
 													) }
 												</li>
 											) }

--- a/src/modules/add-site/components/create-site-form.tsx
+++ b/src/modules/add-site/components/create-site-form.tsx
@@ -39,11 +39,6 @@ export interface CreateSiteFormProps {
 	existingDomainNames?: string[];
 	/** Blueprint preferred versions for warning display */
 	blueprintPreferredVersions?: BlueprintPreferredVersions;
-	/** Original default versions (before Blueprint override) for warning comparison */
-	originalDefaultVersions?: {
-		phpVersion?: AllowedPHPVersion;
-		wpVersion?: string;
-	};
 	/** Called when form is submitted */
 	onSubmit: ( values: CreateSiteFormValues ) => void;
 	/** Called when form validity changes */
@@ -156,7 +151,6 @@ export const CreateSiteForm = ( {
 	onSiteNameChange,
 	existingDomainNames = [],
 	blueprintPreferredVersions,
-	originalDefaultVersions,
 	onSubmit,
 	onValidityChange,
 	formRef,

--- a/src/modules/add-site/components/create-site.tsx
+++ b/src/modules/add-site/components/create-site.tsx
@@ -35,7 +35,6 @@ export default function CreateSite( {
 	onSiteNameChange,
 	existingDomainNames = [],
 	blueprintPreferredVersions,
-	originalDefaultVersions,
 	onSubmit,
 	onValidityChange,
 	formRef,
@@ -54,7 +53,6 @@ export default function CreateSite( {
 				onSiteNameChange={ onSiteNameChange }
 				existingDomainNames={ existingDomainNames }
 				blueprintPreferredVersions={ blueprintPreferredVersions }
-				originalDefaultVersions={ originalDefaultVersions }
 				onSubmit={ onSubmit }
 				onValidityChange={ onValidityChange }
 				formRef={ formRef }

--- a/src/modules/add-site/index.tsx
+++ b/src/modules/add-site/index.tsx
@@ -3,6 +3,7 @@ import { Navigator, useNavigator } from '@wordpress/components';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { MINIMUM_WORDPRESS_VERSION } from 'common/constants';
 import { BlueprintPreferredVersions } from 'common/lib/blueprint-validation';
 import { SupportedPHPVersionsList } from 'common/types/php-versions';
 import Button from 'src/components/button';
@@ -229,31 +230,27 @@ function NavigationContent( props: NavigationContentProps ) {
 	);
 
 	// Build default values with blueprint preferred versions applied
+	const { data: wpVersions = [] } = useGetWordPressVersions( {
+		minimumVersion: MINIMUM_WORDPRESS_VERSION,
+	} );
 	const defaultValuesWithBlueprint = useMemo( () => {
 		const values = { ...defaultValues };
 		if (
 			blueprintPreferredVersions?.php &&
-			blueprintPreferredVersions.php !== 'latest' &&
 			SupportedPHPVersionsList.includes( blueprintPreferredVersions.php )
 		) {
 			values.phpVersion = blueprintPreferredVersions.php as AllowedPHPVersion;
 		}
-		if ( blueprintPreferredVersions?.wp && blueprintPreferredVersions.wp !== 'latest' ) {
+		if (
+			blueprintPreferredVersions?.wp &&
+			wpVersions.some( ( v ) => v.value === blueprintPreferredVersions.wp )
+		) {
 			values.wpVersion = blueprintPreferredVersions.wp;
 		}
 		return values;
-	}, [ defaultValues, blueprintPreferredVersions ] );
+	}, [ defaultValues, blueprintPreferredVersions, wpVersions ] );
 
 	const formRef = useRef< HTMLFormElement >( null );
-
-	// Original default versions (before Blueprint override) for warning comparison
-	const originalDefaultVersions = useMemo(
-		() => ( {
-			phpVersion: defaultValues.phpVersion,
-			wpVersion: defaultValues.wpVersion,
-		} ),
-		[ defaultValues.phpVersion, defaultValues.wpVersion ]
-	);
 
 	const createSiteProps = {
 		onSelectPath,
@@ -284,7 +281,6 @@ function NavigationContent( props: NavigationContentProps ) {
 					{ ...createSiteProps }
 					defaultValues={ defaultValuesWithBlueprint }
 					blueprintPreferredVersions={ blueprintPreferredVersions }
-					originalDefaultVersions={ originalDefaultVersions }
 				/>
 			</Navigator.Screen>
 			<Navigator.Screen className="flex-1" path="/create">
@@ -301,7 +297,6 @@ function NavigationContent( props: NavigationContentProps ) {
 					{ ...createSiteProps }
 					defaultValues={ defaultValuesWithBlueprint }
 					blueprintPreferredVersions={ blueprintPreferredVersions }
-					originalDefaultVersions={ originalDefaultVersions }
 				/>
 			</Navigator.Screen>
 			<Navigator.Screen className="flex-1" path="/backup">

--- a/src/modules/add-site/tests/add-site.test.tsx
+++ b/src/modules/add-site/tests/add-site.test.tsx
@@ -577,7 +577,7 @@ describe( 'AddSite', () => {
 		).not.toBeInTheDocument();
 	} );
 
-	it( 'should show warning immediately when Blueprint preferred versions differ from defaults', async () => {
+	it( 'should show warning immediately when Blueprint preferred versions differ from selected versions', async () => {
 		const mockBlueprintData = {
 			data: {
 				blueprints: [
@@ -589,8 +589,8 @@ describe( 'AddSite', () => {
 						playground_url: '',
 						blueprint: {
 							preferredVersions: {
-								php: '8.1',
-								wp: '6.4.0',
+								php: '7.1',
+								wp: '6.2.0',
 							},
 						},
 					},
@@ -626,13 +626,12 @@ describe( 'AddSite', () => {
 		// Open advanced settings to access version selectors
 		await user.click( screen.getByRole( 'button', { name: 'Advanced settings' } ) );
 
-		// Warning should show immediately since Blueprint versions (8.1, 6.4.0) differ from defaults (8.3, latest)
-		// No need to change version - the fix ensures warning appears right away
 		await waitFor( () => {
 			expect(
 				screen.getByText( 'Version differs from Blueprint recommendation' )
 			).toBeInTheDocument();
-			expect( screen.getByText( 'PHP 8.1 (default is 8.3)' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'PHP 7.1 (selected is 8.3)' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'WordPress 6.2.0 (selected is latest)' ) ).toBeInTheDocument();
 		} );
 
 		// Warning indicator should show next to Advanced settings


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-1265

## Proposed Changes

- Respect the Blueprint preferred versions and prefill the dropdowns
- Display warning when the version in the selected version doesn't match Blueprint
  - This state could happen when the WP version is not in the supported versions
  - Or when the user changes the selected version manually
- Update warning text from "default is" to "selected is" for clarity
- Remove unnecessary originalDefaultVersions prop

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Run `npm start`

### Test 1: Warning appears when blueprint version uses unsupported WP version

[blueprint-unsupported-wp.json](https://github.com/user-attachments/files/24911605/blueprint-unsupported-wp.json)


1. Click "Add site"
2. Select "Start with a Blueprint"
3. Choose a blueprint that specifies `preferredVersions` (e.g., WP 5.8.1)
5. Observe the warning appears even if the advanced options are collapsed
6. Open the advance settings observe the whole warning

<img width="1032" height="712" alt="Screenshot 2026-01-28 at 13 16 59" src="https://github.com/user-attachments/assets/74c29e6c-e2f7-4674-ade3-a50a2ffa25af" />


### Test 2: Warning updates dynamically when user changes dropdown

[test-multiple-warnings-blueprint.json](https://github.com/user-attachments/files/24911609/test-multiple-warnings-blueprint.json)


1. Create a site with valid preferred Blueprint versions
2. Observe no warning appears
3. Change the PHP or WP version dropdown inside the advance settings
4. Observe the warning appears

<img width="1032" height="712" alt="Screenshot 2026-01-28 at 13 17 17" src="https://github.com/user-attachments/assets/98177eff-03c2-40e3-8acd-7ef50e90cf97" />


### Test 3: No supported PHP version

[blueprint-unsupported-php.json](https://github.com/user-attachments/files/24911583/blueprint-unsupported-php.json)

We didn't modify the logic, but I observed that if the PHP version is not supported, the flow displays an error validating the Blueprint in the previous step.

<img width="1032" height="712" alt="Screenshot 2026-01-28 at 13 17 34" src="https://github.com/user-attachments/assets/4ee7e1f1-9632-4eb6-9fba-2c70acf1f1bf" />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
