### PR TITLE
Fix: PM2 start for paths with spaces

### DIFF
--- a/cli/lib/pm2-manager.ts
+++ b/cli/lib/pm2-manager.ts
@@ -188,40 +188,6 @@ export function sendMessageToProcess(
 	} );
 }
 
-function ensurePm2ScriptPath( scriptPath: string, processName: string ): string {
-	if ( ! scriptPath.includes( ' ' ) ) {
-		return scriptPath;
-	}
-
-	const linksDir = path.join( STUDIO_PM2_HOME, 'links' );
-	if ( ! fs.existsSync( linksDir ) ) {
-		fs.mkdirSync( linksDir, { recursive: true } );
-	}
-
-	const ext = path.extname( scriptPath ) || '.js';
-	const linkPath = path.join( linksDir, `${ processName }${ ext }` );
-
-	try {
-		if ( fs.existsSync( linkPath ) ) {
-			fs.unlinkSync( linkPath );
-		}
-	} catch {
-		// ignore
-	}
-
-	try {
-		fs.symlinkSync( scriptPath, linkPath );
-		return linkPath;
-	} catch {
-		try {
-			fs.copyFileSync( scriptPath, linkPath );
-			return linkPath;
-		} catch {
-			return scriptPath;
-		}
-	}
-}
-
 export async function startProxyProcess(): Promise< ProcessDescription > {
 	const proxyDaemonPath = path.resolve( __dirname, 'proxy-daemon.js' );
 	const env: Record< string, string > = {
@@ -264,11 +230,10 @@ export async function startProcess(
 	args: string[] = []
 ): Promise< ProcessDescription > {
 	return new Promise( ( resolve, reject ) => {
-		const resolvedScriptPath = ensurePm2ScriptPath( scriptPath, processName );
 		const processConfig: StartOptions = {
 			name: processName,
 			interpreter: process.execPath,
-			script: resolvedScriptPath,
+			script: scriptPath,
 			exec_mode: 'fork',
 			autorestart: false,
 			args,

--- a/cli/lib/pm2-manager.ts
+++ b/cli/lib/pm2-manager.ts
@@ -188,6 +188,40 @@ export function sendMessageToProcess(
 	} );
 }
 
+function ensurePm2ScriptPath( scriptPath: string, processName: string ): string {
+	if ( ! scriptPath.includes( ' ' ) ) {
+		return scriptPath;
+	}
+
+	const linksDir = path.join( STUDIO_PM2_HOME, 'links' );
+	if ( ! fs.existsSync( linksDir ) ) {
+		fs.mkdirSync( linksDir, { recursive: true } );
+	}
+
+	const ext = path.extname( scriptPath ) || '.js';
+	const linkPath = path.join( linksDir, `${ processName }${ ext }` );
+
+	try {
+		if ( fs.existsSync( linkPath ) ) {
+			fs.unlinkSync( linkPath );
+		}
+	} catch {
+		// ignore
+	}
+
+	try {
+		fs.symlinkSync( scriptPath, linkPath );
+		return linkPath;
+	} catch {
+		try {
+			fs.copyFileSync( scriptPath, linkPath );
+			return linkPath;
+		} catch {
+			return scriptPath;
+		}
+	}
+}
+
 export async function startProxyProcess(): Promise< ProcessDescription > {
 	const proxyDaemonPath = path.resolve( __dirname, 'proxy-daemon.js' );
 	const env: Record< string, string > = {
@@ -230,10 +264,11 @@ export async function startProcess(
 	args: string[] = []
 ): Promise< ProcessDescription > {
 	return new Promise( ( resolve, reject ) => {
+		const resolvedScriptPath = ensurePm2ScriptPath( scriptPath, processName );
 		const processConfig: StartOptions = {
 			name: processName,
 			interpreter: process.execPath,
-			script: scriptPath,
+			script: resolvedScriptPath,
 			exec_mode: 'fork',
 			autorestart: false,
 			args,

--- a/cli/patches/pm2+6.0.14.patch
+++ b/cli/patches/pm2+6.0.14.patch
@@ -1,3 +1,16 @@
+diff --git a/node_modules/pm2/lib/Common.js b/node_modules/pm2/lib/Common.js
+index 24a1d13..086da0d 100644
+--- a/node_modules/pm2/lib/Common.js
++++ b/node_modules/pm2/lib/Common.js
+@@ -723,7 +723,7 @@ Common.verifyConfs = function(appConfs) {
+      * If command is like pm2 start "python xx.py --ok"
+      * Then automatically start the script with bash -c and set a name eq to command
+      */
+-    if (app.script && app.script.indexOf(' ') > -1 && cst.IS_WINDOWS === false) {
++    if (app.script && app.script.indexOf(' ') > -1 && cst.IS_WINDOWS === false && !fs.existsSync(app.script)) {
+       var _script = app.script;
+ 
+       if (which('bash')) {
 diff --git a/node_modules/pm2/types/index.d.ts b/node_modules/pm2/types/index.d.ts
 index 77280f5..092273a 100644
 --- a/node_modules/pm2/types/index.d.ts


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes #2482 

## Proposed Changes

- Work around PM2 treating space-containing script paths as shell commands by linking the CLI child script to a space-free path before starting it.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- - Run `studio site create` from a path that includes spaces (e.g., “WP Studio.app”) and confirm the WordPress server starts.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
