### PR TITLE
Fix About window path

### DIFF
--- a/src/about-menu/open-about-menu.ts
+++ b/src/about-menu/open-about-menu.ts
@@ -4,14 +4,14 @@ import * as Sentry from '@sentry/electron/renderer';
 import { __ } from '@wordpress/i18n';
 import { ABOUT_WINDOW_HEIGHT, ABOUT_WINDOW_WIDTH } from 'src/constants';
 import { shellOpenExternalWrapper } from 'src/lib/shell-open-external-wrapper';
-import { getResourcesPath } from 'src/storage/paths';
 
 let aboutWindow: BrowserWindow | null = null;
 
 function getAboutPath(): string {
-	return process.env.NODE_ENV === 'development'
-		? path.join( getResourcesPath(), 'src', 'about-menu', 'about-menu.html' )
-		: path.join( getResourcesPath(), 'dist', 'renderer', 'about-menu.html' );
+	if ( process.env.NODE_ENV === 'development' ) {
+		return path.join( __dirname, '../../src/about-menu/about-menu.html' );
+	}
+	return path.join( __dirname, '../renderer/about-menu.html' );
 }
 
 export function escapeSingleQuotes( str: string ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Related to STU-1263

## Proposed Changes

- fix path for the About window source

## Testing Instructions

1. Run `npm start`
2. Open Studio → About WordPress Studio
3. Verify the About window displays correctly with the icon, version, and links

4. Run `npm run make` then launch the packaged app
5. Open Studio → About WordPress Studio
6. Verify the About window displays correctly

The change should work on both macOS and Windows.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?