### PR TITLE
Add Zed and Antigravity editor support

### DIFF
--- a/src/ipc-types.d.ts
+++ b/src/ipc-types.d.ts
@@ -42,12 +42,14 @@ interface StartedSiteDetails extends StoppedSiteDetails {
 type SiteDetails = StartedSiteDetails | StoppedSiteDetails;
 
 type InstalledApps = {
+	antigravity: boolean;
 	vscode: boolean;
 	phpstorm: boolean;
 	webstorm: boolean;
 	windsurf: boolean;
 	cursor: boolean;
 	sublime: boolean;
+	zed: boolean;
 	terminal: boolean;
 	iterm: boolean;
 	warp: boolean;

--- a/src/lib/is-installed.ts
+++ b/src/lib/is-installed.ts
@@ -39,30 +39,38 @@ function getLocalProgramsPath(): string {
 // Define installation paths for each IDE by platform
 const installationPaths: Record< string, PlatformPaths > = {
 	darwin: {
+		antigravity: [ 'Antigravity.app' ],
 		vscode: [ 'Visual Studio Code.app' ],
 		phpstorm: [ 'PhpStorm.app' ],
 		cursor: [ 'Cursor.app' ],
 		windsurf: [ 'Windsurf.app' ],
 		webstorm: [ 'WebStorm.app' ],
 		sublime: [ 'Sublime Text.app' ],
+		zed: [ 'Zed.app' ],
 		iterm: [ 'iTerm.app' ],
 		terminal: [ 'Terminal.app' ],
 		warp: [ 'Warp.app' ],
 		ghostty: [ 'Ghostty.app' ],
 	},
 	linux: {
+		antigravity: [ '/usr/bin/antigravity' ],
 		vscode: [ '/usr/bin/code' ],
 		phpstorm: [ '/usr/bin/phpstorm' ],
 		cursor: [ '/usr/bin/cursor' ],
 		windsurf: [ '/usr/bin/windsurf' ],
 		webstorm: [ '/usr/bin/webstorm' ],
 		sublime: [ '/usr/bin/subl' ],
+		zed: [ '/usr/bin/zed' ],
 		iterm: [],
 		terminal: [],
 		warp: [ '/usr/bin/warp' ],
 		ghostty: [],
 	},
 	win32: {
+		antigravity: [
+			path.win32.join( getLocalProgramsPath(), 'Antigravity' ),
+			path.win32.join( getProgramFilesPath(), 'Google\\Antigravity' ),
+		],
 		vscode: [
 			path.win32.join( getProgramFilesPath(), 'Microsoft VS Code' ),
 			path.win32.join( getLocalProgramsPath(), 'Microsoft VS Code' ),
@@ -88,6 +96,7 @@ const installationPaths: Record< string, PlatformPaths > = {
 			path.win32.join( getProgramFilesPath(), 'Sublime Text 4' ),
 			path.win32.join( getProgramFilesPath(), 'Sublime Text 3' ),
 		],
+		zed: [ path.win32.join( getLocalProgramsPath(), 'Zed' ) ],
 		iterm: [],
 		terminal: [],
 		warp: [

--- a/src/modules/user-settings/components/tests/terminal-picker.test.tsx
+++ b/src/modules/user-settings/components/tests/terminal-picker.test.tsx
@@ -48,12 +48,14 @@ describe( 'TerminalPicker', () => {
 		store.dispatch(
 			installedAppsApi.util.updateQueryData( 'getInstalledApps', undefined, () => {
 				return {
+					antigravity: false,
 					vscode: false,
 					phpstorm: false,
 					webstorm: false,
 					windsurf: false,
 					cursor: false,
 					sublime: false,
+					zed: false,
 					terminal: true,
 					iterm: true,
 					warp: false,
@@ -77,12 +79,14 @@ describe( 'TerminalPicker', () => {
 			installedAppsApi.util.updateQueryData( 'getInstalledApps', undefined, () => {
 				return {
 					// Editor properties
+					antigravity: false,
 					vscode: false,
 					phpstorm: false,
 					webstorm: false,
 					windsurf: false,
 					cursor: false,
 					sublime: false,
+					zed: false,
 					// Terminal properties
 					terminal: true,
 					iterm: true,

--- a/src/modules/user-settings/lib/editor.ts
+++ b/src/modules/user-settings/lib/editor.ts
@@ -1,12 +1,14 @@
 import { __ } from '@wordpress/i18n';
 
 export const SUPPORTED_EDITORS = [
+	'antigravity',
 	'cursor',
 	'vscode',
 	'phpstorm',
 	'windsurf',
 	'webstorm',
 	'sublime',
+	'zed',
 ] as const;
 export type SupportedEditor = ( typeof SUPPORTED_EDITORS )[ number ];
 
@@ -18,6 +20,16 @@ export type SupportedEditorConfig = {
 };
 
 export const supportedEditorConfig: Record< SupportedEditor, SupportedEditorConfig > = {
+	antigravity: {
+		// translators: "Antigravity" is the brand name for an IDE and does not need to be translated
+		label: __( 'Antigravity' ),
+		url: ( path: string ) => `antigravity://file/${ path }?windowId=_blank`,
+		macOSBundleId: 'com.google.antigravity',
+		winPaths: [
+			'%LOCALAPPDATA%\\Programs\\Antigravity\\Antigravity.exe',
+			'%PROGRAMFILES%\\Google\\Antigravity\\Antigravity.exe',
+		],
+	},
 	vscode: {
 		// translators: "VS Code" is the brand name for an IDE and does not need to be translated
 		label: __( 'VS Code' ),
@@ -79,5 +91,12 @@ export const supportedEditorConfig: Record< SupportedEditor, SupportedEditorConf
 			'%PROGRAMFILES%\\Sublime Text 4\\sublime_text.exe',
 			'%PROGRAMFILES%\\Sublime Text 3\\sublime_text.exe',
 		],
+	},
+	zed: {
+		// translators: "Zed" is the brand name for an IDE and does not need to be translated
+		label: __( 'Zed' ),
+		url: ( path: string ) => `zed://file/${ path }`,
+		macOSBundleId: 'dev.zed.Zed',
+		winPaths: [ '%LOCALAPPDATA%\\Programs\\Zed\\zed.exe' ],
 	},
 };

--- a/src/modules/user-settings/lib/ipc-handlers.ts
+++ b/src/modules/user-settings/lib/ipc-handlers.ts
@@ -10,12 +10,14 @@ import { loadUserData, updateAppdata } from 'src/storage/user-data';
 
 export function getInstalledAppsAndTerminals(): InstalledApps {
 	return {
+		antigravity: isInstalled( 'antigravity' ),
 		vscode: isInstalled( 'vscode' ),
 		phpstorm: isInstalled( 'phpstorm' ),
 		webstorm: isInstalled( 'webstorm' ),
 		windsurf: isInstalled( 'windsurf' ),
 		cursor: isInstalled( 'cursor' ),
 		sublime: isInstalled( 'sublime' ),
+		zed: isInstalled( 'zed' ),
 		terminal: true, // Terminal.app is always available on macOS
 		iterm: isInstalled( 'iterm' ),
 		warp: isInstalled( 'warp' ),

--- a/src/stores/tests/installed-apps-api.test.ts
+++ b/src/stores/tests/installed-apps-api.test.ts
@@ -41,12 +41,14 @@ const createTestStore = () => {
 const createMockInstalledApps = (
 	installedApps: Partial< InstalledApps > = {}
 ): InstalledApps => ( {
+	antigravity: false,
 	vscode: false,
 	phpstorm: false,
 	webstorm: false,
 	windsurf: false,
 	cursor: false,
 	sublime: false,
+	zed: false,
 	terminal: false,
 	iterm: false,
 	warp: false,
@@ -220,9 +222,16 @@ describe( 'Installed Apps API', () => {
 				const mockInstalledApps = createMockInstalledApps( { vscode: true, cursor: true } );
 				const result = selectUninstalledEditors( mockInstalledApps );
 
-				expect( result ).toHaveLength( 4 );
+				expect( result ).toHaveLength( 6 );
 				expect( result.map( ( [ editor ] ) => editor ) ).toEqual(
-					expect.arrayContaining( [ 'phpstorm', 'windsurf', 'webstorm', 'sublime' ] )
+					expect.arrayContaining( [
+						'antigravity',
+						'phpstorm',
+						'windsurf',
+						'webstorm',
+						'sublime',
+						'zed',
+					] )
 				);
 			} );
 
@@ -230,7 +239,7 @@ describe( 'Installed Apps API', () => {
 				const mockInstalledApps = createMockInstalledApps();
 				const result = selectUninstalledEditors( mockInstalledApps );
 
-				expect( result ).toHaveLength( 6 );
+				expect( result ).toHaveLength( 8 );
 			} );
 		} );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Supersedes #2111

## Proposed Changes

- Add [Zed](https://zed.dev/) editor support (fast, Rust-based editor now available on all platforms)
- Add [Google Antigravity](https://antigravity.google/) editor support (Google's AI-powered IDE)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Install Zed and/or Antigravity on your machine
- Open Studio settings and change preferred editor to Zed/Antigravity and save
- Navigate to a site Overview tab and confirm the option to open in your selected editor appears
- Clicking the button works as expected and opens the editor on the site root

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?