### PR TITLE
Exclude wp-config.php from push backups to remote sites

### DIFF
--- a/src/lib/import-export/export/exporters/default-exporter.ts
+++ b/src/lib/import-export/export/exporters/default-exporter.ts
@@ -126,7 +126,9 @@ export class DefaultExporter extends EventEmitter implements Exporter {
 		this.archiveBuilder.pipe( output );
 
 		try {
-			this.addWpConfig();
+			if ( ! this.options.excludeWpConfig ) {
+				this.addWpConfig();
+			}
 			await this.addWpContent();
 			await this.addDatabase();
 			const studioJsonPath = await this.createStudioJsonFile();

--- a/src/lib/import-export/export/types.ts
+++ b/src/lib/import-export/export/types.ts
@@ -8,6 +8,7 @@ export interface ExportOptions {
 	phpVersion: string;
 	splitDatabaseDumpByTable?: boolean;
 	specificSelectionPaths?: string[];
+	excludeWpConfig?: boolean;
 }
 
 export type ExportOptionsIncludes = 'wpContent' | 'database';

--- a/src/lib/import-export/tests/export/exporters/default-exporter.test.ts
+++ b/src/lib/import-export/tests/export/exporters/default-exporter.test.ts
@@ -571,6 +571,65 @@ platformTestSuite( 'DefaultExporter', ( { normalize } ) => {
 		);
 	} );
 
+	it( 'should not add wp-config.php when excludeWpConfig is true', async () => {
+		const options = {
+			...mockOptions,
+			includes: {
+				database: false,
+				wpContent: false,
+			},
+			excludeWpConfig: true,
+		};
+
+		const exporter = new DefaultExporter( options );
+		await exporter.export();
+
+		expect( mockArchiver.file ).not.toHaveBeenCalledWith(
+			normalize( '/path/to/site/wp-config.php' ),
+			{ name: 'wp-config.php' }
+		);
+		// meta.json should still be added
+		expect( mockArchiver.file ).toHaveBeenCalledWith(
+			normalize( '/tmp/studio_export_123/meta.json' ),
+			{ name: 'meta.json' }
+		);
+	} );
+
+	it( 'should add wp-config.php when excludeWpConfig is false', async () => {
+		const options = {
+			...mockOptions,
+			includes: {
+				database: false,
+				wpContent: false,
+			},
+			excludeWpConfig: false,
+		};
+
+		const exporter = new DefaultExporter( options );
+		await exporter.export();
+
+		expect( mockArchiver.file ).toHaveBeenCalledWith( normalize( '/path/to/site/wp-config.php' ), {
+			name: 'wp-config.php',
+		} );
+	} );
+
+	it( 'should add wp-config.php when excludeWpConfig is not specified (default behavior)', async () => {
+		const options = {
+			...mockOptions,
+			includes: {
+				database: false,
+				wpContent: false,
+			},
+		};
+
+		const exporter = new DefaultExporter( options );
+		await exporter.export();
+
+		expect( mockArchiver.file ).toHaveBeenCalledWith( normalize( '/path/to/site/wp-config.php' ), {
+			name: 'wp-config.php',
+		} );
+	} );
+
 	it( 'should initialize backup object with correct structure when creating a new exporter', () => {
 		const testOptions: ExportOptions = {
 			site: {

--- a/src/modules/sync/lib/ipc-handlers.ts
+++ b/src/modules/sync/lib/ipc-handlers.ts
@@ -190,6 +190,7 @@ export async function exportSiteForPush(
 			phpVersion: site.details.phpVersion,
 			splitDatabaseDumpByTable: true,
 			specificSelectionPaths: configuration?.specificSelectionPaths,
+			excludeWpConfig: true,
 		};
 
 		const onEvent = () => {};


### PR DESCRIPTION
When pushing a site to WordPress.com or Pressable, the backup now excludes wp-config.php to prevent overwriting the remote site's configuration. Manual exports still include wp-config.php for portability.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-1257

## Proposed Changes

-

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

-

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
