### PR TITLE
Performance: Parallelize recursive directory copying without `fs-copy`

### DIFF
--- a/common/lib/fs-utils.ts
+++ b/common/lib/fs-utils.ts
@@ -85,16 +85,19 @@ export async function recursiveCopyDirectory(
 
 	const entries = await fsPromises.readdir( source, { withFileTypes: true } );
 
-	for ( const entry of entries ) {
-		const sourcePath = path.join( source, entry.name );
-		const destinationPath = path.join( destination, entry.name );
+	await Promise.all(
+		entries.map( ( entry ) => {
+			const sourcePath = path.join( source, entry.name );
+			const destinationPath = path.join( destination, entry.name );
 
-		if ( entry.isDirectory() ) {
-			await recursiveCopyDirectory( sourcePath, destinationPath );
-		} else if ( entry.isFile() ) {
-			await fsPromises.copyFile( sourcePath, destinationPath );
-		}
-	}
+			if ( entry.isDirectory() ) {
+				return recursiveCopyDirectory( sourcePath, destinationPath );
+			}
+			if ( entry.isFile() ) {
+				return fsPromises.copyFile( sourcePath, destinationPath );
+			}
+		} )
+	);
 }
 
 export async function isEmptyDir( directory: string ): Promise< boolean > {

--- a/src/lib/wp-versions.ts
+++ b/src/lib/wp-versions.ts
@@ -68,7 +68,10 @@ export async function updateLatestWordPressVersion() {
 		const latestVersion = await getLatestWordPressVersion();
 		if ( installedVersion && latestVersion !== 'latest' && installedVersion !== latestVersion ) {
 			// We keep a copy of the latest installed version instead of removing it.
-			await recursiveCopyDirectory( latestVersionPath, getWordPressVersionPath( installedVersion ) );
+			await recursiveCopyDirectory(
+				latestVersionPath,
+				getWordPressVersionPath( installedVersion )
+			);
 			shouldOverwrite = true;
 		}
 	}

--- a/src/lib/wp-versions.ts
+++ b/src/lib/wp-versions.ts
@@ -68,10 +68,7 @@ export async function updateLatestWordPressVersion() {
 		const latestVersion = await getLatestWordPressVersion();
 		if ( installedVersion && latestVersion !== 'latest' && installedVersion !== latestVersion ) {
 			// We keep a copy of the latest installed version instead of removing it.
-			await recursiveCopyDirectory(
-				latestVersionPath,
-				getWordPressVersionPath( installedVersion )
-			);
+			await recursiveCopyDirectory( latestVersionPath, getWordPressVersionPath( installedVersion ) );
 			shouldOverwrite = true;
 		}
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Related to STU-980
- Related to https://github.com/Automattic/studio/pull/2409

## Proposed Changes

* parallelize recursive directory copying

Related discussion: https://github.com/Automattic/studio/pull/2409#issuecomment-3818788199

Here are the [performance test](https://github.com/Automattic/studio/tree/trunk/metrics) results - comparing current trunk with this branch:
  
```
  Site Creation Time on macOS (7 rounds)
  ┌────────┬─────────┬──────────────────┐
  │ Round  │  trunk  │ update/file-copy │
  ├────────┼─────────┼──────────────────┤
  │ 1      │ 7042 ms │ 6046 ms          │
  ├────────┼─────────┼──────────────────┤
  │ 2      │ 7040 ms │ 7032 ms          │
  ├────────┼─────────┼──────────────────┤
  │ 3      │ 7058 ms │ 6030 ms          │
  ├────────┼─────────┼──────────────────┤
  │ 4      │ 7050 ms │ 7040 ms          │
  ├────────┼─────────┼──────────────────┤
  │ 5      │ 8098 ms │ 7056 ms          │
  ├────────┼─────────┼──────────────────┤
  │ 6      │ 7051 ms │ 6041 ms          │
  ├────────┼─────────┼──────────────────┤
  │ 7      │ 7037 ms │ 6047 ms          │
  ├────────┼─────────┼──────────────────┤
  │ Median │ 7050 ms │ 6047 ms          │
  └────────┴─────────┴──────────────────┘
That is a -1003 ms (14.2% faster) improvement over current trunk.


 Site Creation Time on Windows via Parallels (5 rounds - as it took quite a long time, I decided to skip two rounds)
  ┌────────┬───────────┬──────────────────┐
  │ Round  │   trunk   │ update/file-copy │
  ├────────┼───────────┼──────────────────┤
  │ 1      │ 34,618 ms │ 32,651 ms        │
  ├────────┼───────────┼──────────────────┤
  │ 2      │ 32,572 ms │ 30,629 ms        │
  ├────────┼───────────┼──────────────────┤
  │ 3      │ 31,623 ms │ 31,652 ms        │
  ├────────┼───────────┼──────────────────┤
  │ 4      │ 32,639 ms │ 31,537 ms        │
  ├────────┼───────────┼──────────────────┤
  │ 5      │ 31,518 ms │ 31,624 ms        │
  ├────────┼───────────┼──────────────────┤
  │ Median │ 32,572 ms │ 31,624 ms        │
  └────────┴───────────┴──────────────────┘
That is a -948 ms (2.9% faster) improvement over current trunk.

```


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR branch and build the app with `npm install` && `npm start`.
2. Create several new sites.
3. The process should work correctly, the sites should get created and run without any issues.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
