### PR TITLE
CLI: fix --skip-site-details argument for starting site which is already running

### DIFF
--- a/cli/commands/site/start.ts
+++ b/cli/commands/site/start.ts
@@ -33,7 +33,9 @@ export async function runCommand(
 			if ( ! skipBrowser ) {
 				await openSiteInBrowser( site );
 			}
-			logSiteDetails( site );
+			if ( ! skipLogDetails ) {
+				logSiteDetails( site );
+			}
 			return;
 		}
 


### PR DESCRIPTION
## Related issues

- Fixes STU-1272

## Proposed Changes
If a site is already running and we execute `node dist/cli/main.js site start  --skip-log-details` - the `--skip-log-details` argument is ignored.

## Testing Instructions
1. Run `node dist/cli/main.js site start --path=<PATH> --skip-log-details`
2. Assert taht you don't see<br /><img width="290" height="51" alt="Screenshot 2026-01-31 at 16 33 25" src="https://github.com/user-attachments/assets/f7a97179-6f0a-417e-8d77-3d34beac24cf" />
3. Run again `node dist/cli/main.js site start --path=<PATH> --skip-log-details`
4. Assert taht you don't see (before if was anyway printed)<br /><img width="290" height="51" alt="Screenshot 2026-01-31 at 16 33 25" src="https://github.com/user-attachments/assets/f7a97179-6f0a-417e-8d77-3d34beac24cf" />