### PR TITLE
Add support for Blueprints defineSiteUrl

### DIFF
--- a/common/lib/blueprint-settings.ts
+++ b/common/lib/blueprint-settings.ts
@@ -1,5 +1,10 @@
 import type { Blueprint } from '@wp-playground/blueprints';
-import type { BlueprintSiteSettings } from 'common/types/site-settings';
+
+type BlueprintSiteSettings = Partial<
+	Pick< StoppedSiteDetails, 'phpVersion' | 'customDomain' | 'enableHttps' >
+> & {
+	wpVersion?: string;
+};
 
 /**
  * Extracts form-relevant values from a blueprint.

--- a/common/lib/blueprint-settings.ts
+++ b/common/lib/blueprint-settings.ts
@@ -1,0 +1,75 @@
+import type { Blueprint } from '@wp-playground/blueprints';
+import type { BlueprintSiteSettings } from 'common/types/site-settings';
+
+/**
+ * Extracts form-relevant values from a blueprint.
+ */
+export function extractFormValuesFromBlueprint( blueprintJson: Blueprint ): BlueprintSiteSettings {
+	const values: BlueprintSiteSettings = {};
+
+	if ( blueprintJson.preferredVersions ) {
+		if ( blueprintJson.preferredVersions.php && blueprintJson.preferredVersions.php !== 'latest' ) {
+			values.phpVersion = blueprintJson.preferredVersions.php;
+		}
+		if ( blueprintJson.preferredVersions.wp && blueprintJson.preferredVersions.wp !== 'latest' ) {
+			values.wpVersion = blueprintJson.preferredVersions.wp;
+		}
+	}
+
+	if ( blueprintJson.steps && Array.isArray( blueprintJson.steps ) ) {
+		const defineSiteUrlStep = blueprintJson.steps.find(
+			( step: { step?: string } ) => step.step === 'defineSiteUrl'
+		);
+		if ( defineSiteUrlStep?.siteUrl ) {
+			try {
+				const url = new URL( defineSiteUrlStep.siteUrl );
+				values.customDomain = url.hostname;
+				values.enableHttps = url.protocol === 'https:';
+			} catch {
+				// Invalid URL, skip
+			}
+		}
+	}
+
+	return values;
+}
+
+/**
+ * Updates a blueprint with form values. Only updates properties that already exist.
+ */
+export function updateBlueprintWithFormValues(
+	blueprintJson: Blueprint,
+	formValues: BlueprintSiteSettings
+): Blueprint {
+	const updated = { ...blueprintJson };
+
+	// Update preferred versions (only if they already exist)
+	if ( updated.preferredVersions ) {
+		updated.preferredVersions = { ...updated.preferredVersions };
+
+		if ( updated.preferredVersions.php !== undefined && formValues.phpVersion ) {
+			updated.preferredVersions.php = formValues.phpVersion;
+		}
+		if ( updated.preferredVersions.wp !== undefined && formValues.wpVersion ) {
+			updated.preferredVersions.wp = formValues.wpVersion;
+		}
+	}
+
+	// Update defineSiteUrl step (only if it already exists)
+	if ( updated.steps && Array.isArray( updated.steps ) ) {
+		const stepIndex = updated.steps.findIndex(
+			( step: { step?: string } ) => step.step === 'defineSiteUrl'
+		);
+
+		if ( stepIndex >= 0 && formValues.customDomain ) {
+			const protocol = formValues.enableHttps ? 'https' : 'http';
+			updated.steps = [ ...updated.steps ];
+			updated.steps[ stepIndex ] = {
+				...updated.steps[ stepIndex ],
+				siteUrl: `${ protocol }://${ formValues.customDomain }`,
+			};
+		}
+	}
+
+	return updated;
+}

--- a/common/lib/blueprint-validation.ts
+++ b/common/lib/blueprint-validation.ts
@@ -54,8 +54,6 @@ function getUnsupportedFeatureInfo( name: string ): UnsupportedFeature | undefin
 	);
 }
 
-export type { Blueprint as BlueprintData } from '@wp-playground/blueprints';
-
 export type BlueprintPreferredVersions = {
 	php?: string;
 	wp?: string;

--- a/common/lib/blueprint-validation.ts
+++ b/common/lib/blueprint-validation.ts
@@ -1,4 +1,5 @@
 import { __ } from '@wordpress/i18n';
+import { Blueprint } from '@wp-playground/blueprints';
 import validateBlueprintSchema from '@wp-playground/blueprints/blueprint-schema-validator';
 
 interface UnsupportedFeature {
@@ -20,13 +21,6 @@ const UNSUPPORTED_BLUEPRINT_FEATURES: UnsupportedFeature[] = [
 		type: 'step',
 		name: 'login',
 		reason: __( 'Studio automatically creates and logs in the admin user during site creation.' ),
-	},
-	{
-		type: 'step',
-		name: 'defineSiteUrl',
-		reason: __(
-			'Custom site URLs in blueprints are ignored. You can set a custom site URL on the Settings tab.'
-		),
 	},
 ];
 
@@ -60,17 +54,14 @@ function getUnsupportedFeatureInfo( name: string ): UnsupportedFeature | undefin
 	);
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type BlueprintData = Record< string, any >;
+export type { Blueprint as BlueprintData } from '@wp-playground/blueprints';
 
 export type BlueprintPreferredVersions = {
 	php?: string;
 	wp?: string;
 };
 
-export function scanBlueprintForUnsupportedFeatures(
-	blueprint: BlueprintData
-): UnsupportedFeature[] {
+export function scanBlueprintForUnsupportedFeatures( blueprint: Blueprint ): UnsupportedFeature[] {
 	const foundUnsupported: UnsupportedFeature[] = [];
 
 	if ( blueprint.steps && Array.isArray( blueprint.steps ) ) {
@@ -100,8 +91,8 @@ export function scanBlueprintForUnsupportedFeatures(
 }
 
 export function filterUnsupportedBlueprintFeatures(
-	blueprint: BlueprintData | undefined
-): BlueprintData | undefined {
+	blueprint: Blueprint | undefined
+): Blueprint | undefined {
 	if ( ! blueprint ) {
 		return undefined;
 	}
@@ -163,7 +154,7 @@ export async function validateBlueprintData(
 		};
 	}
 
-	const unsupportedFeatures = scanBlueprintForUnsupportedFeatures( blueprintJson as BlueprintData );
+	const unsupportedFeatures = scanBlueprintForUnsupportedFeatures( blueprintJson as Blueprint );
 	const warnings = unsupportedFeatures.map( ( feature ) => ( {
 		feature: feature.name,
 		reason: feature.reason,

--- a/common/lib/tests/blueprint-settings.test.ts
+++ b/common/lib/tests/blueprint-settings.test.ts
@@ -1,4 +1,7 @@
-import { extractFormValuesFromBlueprint, updateBlueprintWithFormValues } from '../blueprint-settings';
+import {
+	extractFormValuesFromBlueprint,
+	updateBlueprintWithFormValues,
+} from '../blueprint-settings';
 
 describe( 'blueprint-settings', () => {
 	describe( 'extractFormValuesFromBlueprint', () => {
@@ -78,14 +81,14 @@ describe( 'blueprint-settings', () => {
 			expect( result.enableHttps ).toBe( false );
 		} );
 
-		it( 'should preserve port in custom domain', () => {
+		it( 'should strip port from custom domain', () => {
 			const blueprint = {
 				steps: [ { step: 'defineSiteUrl', siteUrl: 'https://mysite.local:8443' } ],
 			};
 
 			const result = extractFormValuesFromBlueprint( blueprint );
 
-			expect( result.customDomain ).toBe( 'mysite.local:8443' );
+			expect( result.customDomain ).toBe( 'mysite.local' );
 			expect( result.enableHttps ).toBe( true );
 		} );
 
@@ -106,7 +109,7 @@ describe( 'blueprint-settings', () => {
 					php: '8.0',
 					wp: '6.4',
 				},
-				steps: [ { step: 'defineSiteUrl', siteUrl: 'https://dev.local:9000' } ],
+				steps: [ { step: 'defineSiteUrl', siteUrl: 'https://dev.local' } ],
 			};
 
 			const result = extractFormValuesFromBlueprint( blueprint );
@@ -114,7 +117,7 @@ describe( 'blueprint-settings', () => {
 			expect( result ).toEqual( {
 				phpVersion: '8.0',
 				wpVersion: '6.4',
-				customDomain: 'dev.local:9000',
+				customDomain: 'dev.local',
 				enableHttps: true,
 			} );
 		} );
@@ -124,7 +127,9 @@ describe( 'blueprint-settings', () => {
 				steps: 'not-an-array',
 			};
 
-			const result = extractFormValuesFromBlueprint( blueprint as unknown as Parameters< typeof extractFormValuesFromBlueprint >[ 0 ] );
+			const result = extractFormValuesFromBlueprint(
+				blueprint as unknown as Parameters< typeof extractFormValuesFromBlueprint >[ 0 ]
+			);
 
 			expect( result.customDomain ).toBeUndefined();
 		} );
@@ -297,7 +302,10 @@ describe( 'blueprint-settings', () => {
 				steps: [
 					{ step: 'login' },
 					{ step: 'defineSiteUrl', siteUrl: 'http://old.local' },
-					{ step: 'installPlugin', pluginData: { resource: 'wordpress.org/plugins', slug: 'akismet' } },
+					{
+						step: 'installPlugin',
+						pluginData: { resource: 'wordpress.org/plugins', slug: 'akismet' },
+					},
 				],
 			};
 
@@ -308,8 +316,14 @@ describe( 'blueprint-settings', () => {
 
 			expect( result.steps ).toHaveLength( 3 );
 			expect( result.steps?.[ 0 ] ).toEqual( { step: 'login' } );
-			expect( result.steps?.[ 1 ] ).toEqual( { step: 'defineSiteUrl', siteUrl: 'https://new.local' } );
-			expect( result.steps?.[ 2 ] ).toEqual( { step: 'installPlugin', pluginData: { resource: 'wordpress.org/plugins', slug: 'akismet' } } );
+			expect( result.steps?.[ 1 ] ).toEqual( {
+				step: 'defineSiteUrl',
+				siteUrl: 'https://new.local',
+			} );
+			expect( result.steps?.[ 2 ] ).toEqual( {
+				step: 'installPlugin',
+				pluginData: { resource: 'wordpress.org/plugins', slug: 'akismet' },
+			} );
 		} );
 	} );
 } );

--- a/common/lib/tests/blueprint-settings.test.ts
+++ b/common/lib/tests/blueprint-settings.test.ts
@@ -1,0 +1,315 @@
+import { extractFormValuesFromBlueprint, updateBlueprintWithFormValues } from '../blueprint-settings';
+
+describe( 'blueprint-settings', () => {
+	describe( 'extractFormValuesFromBlueprint', () => {
+		it( 'should return empty object for empty blueprint', () => {
+			const result = extractFormValuesFromBlueprint( {} );
+
+			expect( result ).toEqual( {} );
+		} );
+
+		it( 'should extract PHP version from preferredVersions', () => {
+			const blueprint = {
+				preferredVersions: {
+					php: '8.2',
+				},
+			};
+
+			const result = extractFormValuesFromBlueprint( blueprint );
+
+			expect( result.phpVersion ).toBe( '8.2' );
+		} );
+
+		it( 'should extract WP version from preferredVersions', () => {
+			const blueprint = {
+				preferredVersions: {
+					wp: '6.5',
+				},
+			};
+
+			const result = extractFormValuesFromBlueprint( blueprint );
+
+			expect( result.wpVersion ).toBe( '6.5' );
+		} );
+
+		it( 'should ignore "latest" PHP version', () => {
+			const blueprint = {
+				preferredVersions: {
+					php: 'latest',
+				},
+			};
+
+			const result = extractFormValuesFromBlueprint( blueprint );
+
+			expect( result.phpVersion ).toBeUndefined();
+		} );
+
+		it( 'should ignore "latest" WP version', () => {
+			const blueprint = {
+				preferredVersions: {
+					wp: 'latest',
+				},
+			};
+
+			const result = extractFormValuesFromBlueprint( blueprint );
+
+			expect( result.wpVersion ).toBeUndefined();
+		} );
+
+		it( 'should extract custom domain from defineSiteUrl step with https', () => {
+			const blueprint = {
+				steps: [ { step: 'defineSiteUrl', siteUrl: 'https://mysite.local' } ],
+			};
+
+			const result = extractFormValuesFromBlueprint( blueprint );
+
+			expect( result.customDomain ).toBe( 'mysite.local' );
+			expect( result.enableHttps ).toBe( true );
+		} );
+
+		it( 'should extract custom domain from defineSiteUrl step with http', () => {
+			const blueprint = {
+				steps: [ { step: 'defineSiteUrl', siteUrl: 'http://mysite.local' } ],
+			};
+
+			const result = extractFormValuesFromBlueprint( blueprint );
+
+			expect( result.customDomain ).toBe( 'mysite.local' );
+			expect( result.enableHttps ).toBe( false );
+		} );
+
+		it( 'should preserve port in custom domain', () => {
+			const blueprint = {
+				steps: [ { step: 'defineSiteUrl', siteUrl: 'https://mysite.local:8443' } ],
+			};
+
+			const result = extractFormValuesFromBlueprint( blueprint );
+
+			expect( result.customDomain ).toBe( 'mysite.local:8443' );
+			expect( result.enableHttps ).toBe( true );
+		} );
+
+		it( 'should handle invalid URL in defineSiteUrl gracefully', () => {
+			const blueprint = {
+				steps: [ { step: 'defineSiteUrl', siteUrl: 'not-a-valid-url' } ],
+			};
+
+			const result = extractFormValuesFromBlueprint( blueprint );
+
+			expect( result.customDomain ).toBeUndefined();
+			expect( result.enableHttps ).toBeUndefined();
+		} );
+
+		it( 'should extract all values from a complete blueprint', () => {
+			const blueprint = {
+				preferredVersions: {
+					php: '8.0',
+					wp: '6.4',
+				},
+				steps: [ { step: 'defineSiteUrl', siteUrl: 'https://dev.local:9000' } ],
+			};
+
+			const result = extractFormValuesFromBlueprint( blueprint );
+
+			expect( result ).toEqual( {
+				phpVersion: '8.0',
+				wpVersion: '6.4',
+				customDomain: 'dev.local:9000',
+				enableHttps: true,
+			} );
+		} );
+
+		it( 'should ignore steps array that is not an array', () => {
+			const blueprint = {
+				steps: 'not-an-array',
+			};
+
+			const result = extractFormValuesFromBlueprint( blueprint as unknown as Parameters< typeof extractFormValuesFromBlueprint >[ 0 ] );
+
+			expect( result.customDomain ).toBeUndefined();
+		} );
+
+		it( 'should handle defineSiteUrl step without siteUrl property', () => {
+			const blueprint = {
+				steps: [ { step: 'defineSiteUrl' } ],
+			};
+
+			const result = extractFormValuesFromBlueprint( blueprint );
+
+			expect( result.customDomain ).toBeUndefined();
+		} );
+	} );
+
+	describe( 'updateBlueprintWithFormValues', () => {
+		it( 'should return unchanged blueprint when no form values provided', () => {
+			const blueprint = {
+				meta: { title: 'Test' },
+			};
+
+			const result = updateBlueprintWithFormValues( blueprint, {} );
+
+			expect( result ).toEqual( blueprint );
+		} );
+
+		it( 'should update PHP version when preferredVersions exists', () => {
+			const blueprint = {
+				preferredVersions: {
+					php: '8.0',
+				},
+			};
+
+			const result = updateBlueprintWithFormValues( blueprint, { phpVersion: '8.2' } );
+
+			expect( result.preferredVersions?.php ).toBe( '8.2' );
+		} );
+
+		it( 'should update WP version when preferredVersions exists', () => {
+			const blueprint = {
+				preferredVersions: {
+					wp: '6.4',
+				},
+			};
+
+			const result = updateBlueprintWithFormValues( blueprint, { wpVersion: '6.5' } );
+
+			expect( result.preferredVersions?.wp ).toBe( '6.5' );
+		} );
+
+		it( 'should not add preferredVersions if it does not exist', () => {
+			const blueprint = {
+				meta: { title: 'Test' },
+			};
+
+			const result = updateBlueprintWithFormValues( blueprint, { phpVersion: '8.2' } );
+
+			expect( result.preferredVersions ).toBeUndefined();
+		} );
+
+		it( 'should not update PHP version if it was not in original blueprint', () => {
+			const blueprint = {
+				preferredVersions: {
+					wp: '6.4',
+				},
+			};
+
+			const result = updateBlueprintWithFormValues( blueprint, { phpVersion: '8.2' } );
+
+			expect( result.preferredVersions?.php ).toBeUndefined();
+		} );
+
+		it( 'should update defineSiteUrl step with https', () => {
+			const blueprint = {
+				steps: [ { step: 'defineSiteUrl', siteUrl: 'http://old.local' } ],
+			};
+
+			const result = updateBlueprintWithFormValues( blueprint, {
+				customDomain: 'new.local',
+				enableHttps: true,
+			} );
+
+			expect( result.steps?.[ 0 ] ).toEqual( {
+				step: 'defineSiteUrl',
+				siteUrl: 'https://new.local',
+			} );
+		} );
+
+		it( 'should update defineSiteUrl step with http', () => {
+			const blueprint = {
+				steps: [ { step: 'defineSiteUrl', siteUrl: 'https://old.local' } ],
+			};
+
+			const result = updateBlueprintWithFormValues( blueprint, {
+				customDomain: 'new.local',
+				enableHttps: false,
+			} );
+
+			expect( result.steps?.[ 0 ] ).toEqual( {
+				step: 'defineSiteUrl',
+				siteUrl: 'http://new.local',
+			} );
+		} );
+
+		it( 'should preserve port in domain when updating', () => {
+			const blueprint = {
+				steps: [ { step: 'defineSiteUrl', siteUrl: 'http://old.local' } ],
+			};
+
+			const result = updateBlueprintWithFormValues( blueprint, {
+				customDomain: 'new.local:8443',
+				enableHttps: true,
+			} );
+
+			expect( result.steps?.[ 0 ] ).toEqual( {
+				step: 'defineSiteUrl',
+				siteUrl: 'https://new.local:8443',
+			} );
+		} );
+
+		it( 'should not add defineSiteUrl step if it does not exist', () => {
+			const blueprint = {
+				steps: [ { step: 'login' } ],
+			};
+
+			const result = updateBlueprintWithFormValues( blueprint, {
+				customDomain: 'new.local',
+				enableHttps: true,
+			} );
+
+			expect( result.steps ).toHaveLength( 1 );
+			expect( result.steps?.[ 0 ] ).toEqual( { step: 'login' } );
+		} );
+
+		it( 'should not update defineSiteUrl if customDomain is not provided', () => {
+			const blueprint = {
+				steps: [ { step: 'defineSiteUrl', siteUrl: 'http://old.local' } ],
+			};
+
+			const result = updateBlueprintWithFormValues( blueprint, { enableHttps: true } );
+
+			expect( result.steps?.[ 0 ] ).toEqual( {
+				step: 'defineSiteUrl',
+				siteUrl: 'http://old.local',
+			} );
+		} );
+
+		it( 'should not mutate the original blueprint', () => {
+			const blueprint = {
+				preferredVersions: {
+					php: '8.0',
+					wp: '6.4',
+				},
+				steps: [ { step: 'defineSiteUrl', siteUrl: 'http://old.local' } ],
+			};
+			const originalBlueprint = JSON.parse( JSON.stringify( blueprint ) );
+
+			updateBlueprintWithFormValues( blueprint, {
+				phpVersion: '8.2',
+				wpVersion: '6.5',
+				customDomain: 'new.local',
+				enableHttps: true,
+			} );
+
+			expect( blueprint ).toEqual( originalBlueprint );
+		} );
+
+		it( 'should handle blueprint with multiple steps', () => {
+			const blueprint = {
+				steps: [
+					{ step: 'login' },
+					{ step: 'defineSiteUrl', siteUrl: 'http://old.local' },
+					{ step: 'installPlugin', pluginData: { resource: 'wordpress.org/plugins', slug: 'akismet' } },
+				],
+			};
+
+			const result = updateBlueprintWithFormValues( blueprint, {
+				customDomain: 'new.local',
+				enableHttps: true,
+			} );
+
+			expect( result.steps ).toHaveLength( 3 );
+			expect( result.steps?.[ 0 ] ).toEqual( { step: 'login' } );
+			expect( result.steps?.[ 1 ] ).toEqual( { step: 'defineSiteUrl', siteUrl: 'https://new.local' } );
+			expect( result.steps?.[ 2 ] ).toEqual( { step: 'installPlugin', pluginData: { resource: 'wordpress.org/plugins', slug: 'akismet' } } );
+		} );
+	} );
+} );

--- a/common/types/site-settings.ts
+++ b/common/types/site-settings.ts
@@ -1,0 +1,6 @@
+export interface BlueprintSiteSettings {
+	phpVersion?: string;
+	wpVersion?: string;
+	customDomain?: string;
+	enableHttps?: boolean;
+}

--- a/common/types/site-settings.ts
+++ b/common/types/site-settings.ts
@@ -1,6 +1,0 @@
-export interface BlueprintSiteSettings {
-	phpVersion?: string;
-	wpVersion?: string;
-	customDomain?: string;
-	enableHttps?: boolean;
-}

--- a/src/components/no-studio-sites/index.tsx
+++ b/src/components/no-studio-sites/index.tsx
@@ -11,6 +11,8 @@ export function NoStudioSites() {
 		setDeeplinkWpVersion,
 		setBlueprintPreferredVersions,
 		setBlueprintDeeplinkWarnings,
+		setBlueprintSuggestedDomain,
+		setBlueprintSuggestedHttps,
 		setIsDeeplinkFlow,
 	} = addSiteProps;
 
@@ -21,6 +23,8 @@ export function NoStudioSites() {
 		setWpVersion: setDeeplinkWpVersion,
 		setBlueprintPreferredVersions,
 		setBlueprintDeeplinkWarnings,
+		setBlueprintSuggestedDomain,
+		setBlueprintSuggestedHttps,
 		setIsDeeplinkFlow,
 	} );
 

--- a/src/hooks/use-add-site.ts
+++ b/src/hooks/use-add-site.ts
@@ -67,6 +67,7 @@ export function useAddSite() {
 	const [ blueprintSuggestedDomain, setBlueprintSuggestedDomain ] = useState<
 		string | undefined
 	>();
+	const [ blueprintSuggestedHttps, setBlueprintSuggestedHttps ] = useState< boolean | undefined >();
 	const [ isDeeplinkFlow, setIsDeeplinkFlow ] = useState( false );
 	const [ existingDomainNames, setExistingDomainNames ] = useState< string[] >( [] );
 
@@ -80,6 +81,7 @@ export function useAddSite() {
 		setBlueprintPreferredVersions( undefined );
 		setBlueprintDeeplinkWarnings( undefined );
 		setBlueprintSuggestedDomain( undefined );
+		setBlueprintSuggestedHttps( undefined );
 	}, [] );
 
 	// For blueprint deeplinks - we need temporary state for PHP/WP versions
@@ -94,6 +96,7 @@ export function useAddSite() {
 		setBlueprintPreferredVersions( undefined );
 		setBlueprintDeeplinkWarnings( undefined );
 		setBlueprintSuggestedDomain( undefined );
+		setBlueprintSuggestedHttps( undefined );
 		setSelectedRemoteSite( undefined );
 		setDeeplinkPhpVersion( defaultPhpVersion as AllowedPHPVersion );
 		setDeeplinkWpVersion( defaultWordPressVersion );
@@ -322,6 +325,8 @@ export function useAddSite() {
 			setBlueprintDeeplinkWarnings,
 			blueprintSuggestedDomain,
 			setBlueprintSuggestedDomain,
+			blueprintSuggestedHttps,
+			setBlueprintSuggestedHttps,
 			selectedRemoteSite,
 			setSelectedRemoteSite,
 			existingDomainNames,
@@ -347,6 +352,7 @@ export function useAddSite() {
 			blueprintPreferredVersions,
 			blueprintDeeplinkWarnings,
 			blueprintSuggestedDomain,
+			blueprintSuggestedHttps,
 			selectedRemoteSite,
 			existingDomainNames,
 			loadAllCustomDomains,

--- a/src/hooks/use-add-site.ts
+++ b/src/hooks/use-add-site.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/electron/renderer';
 import { useI18n } from '@wordpress/react-i18n';
 import { useCallback, useMemo, useState } from 'react';
+import { updateBlueprintWithFormValues } from 'common/lib/blueprint-settings';
 import { BlueprintValidationWarning } from 'common/lib/blueprint-validation';
 import { generateCustomDomainFromSiteName } from 'common/lib/domains';
 import { useSyncSites } from 'src/hooks/sync-sites';
@@ -63,6 +64,9 @@ export function useAddSite() {
 	const [ blueprintDeeplinkWarnings, setBlueprintDeeplinkWarnings ] = useState<
 		BlueprintValidationWarning[] | undefined
 	>();
+	const [ blueprintSuggestedDomain, setBlueprintSuggestedDomain ] = useState<
+		string | undefined
+	>();
 	const [ isDeeplinkFlow, setIsDeeplinkFlow ] = useState( false );
 	const [ existingDomainNames, setExistingDomainNames ] = useState< string[] >( [] );
 
@@ -75,6 +79,7 @@ export function useAddSite() {
 		setSelectedBlueprint( undefined );
 		setBlueprintPreferredVersions( undefined );
 		setBlueprintDeeplinkWarnings( undefined );
+		setBlueprintSuggestedDomain( undefined );
 	}, [] );
 
 	// For blueprint deeplinks - we need temporary state for PHP/WP versions
@@ -88,6 +93,7 @@ export function useAddSite() {
 		setSelectedBlueprint( undefined );
 		setBlueprintPreferredVersions( undefined );
 		setBlueprintDeeplinkWarnings( undefined );
+		setBlueprintSuggestedDomain( undefined );
 		setSelectedRemoteSite( undefined );
 		setDeeplinkPhpVersion( defaultPhpVersion as AllowedPHPVersion );
 		setDeeplinkWpVersion( defaultWordPressVersion );
@@ -229,13 +235,25 @@ export function useAddSite() {
 				// For import/sync workflows, the respective handlers will start the server
 				const shouldSkipStart = !! fileForImport || !! selectedRemoteSite;
 
+				const enableHttps = formValues.useCustomDomain ? formValues.enableHttps : false;
+				let updatedBlueprint: Blueprint | undefined;
+				if ( selectedBlueprint?.blueprint ) {
+					const updatedJson = updateBlueprintWithFormValues( selectedBlueprint.blueprint, {
+						phpVersion: formValues.phpVersion,
+						wpVersion: formValues.wpVersion,
+						customDomain: usedCustomDomain,
+						enableHttps,
+					} );
+					updatedBlueprint = { ...selectedBlueprint, blueprint: updatedJson };
+				}
+
 				await createSite(
 					formValues.sitePath,
 					formValues.siteName,
 					formValues.wpVersion,
 					usedCustomDomain,
-					formValues.useCustomDomain ? formValues.enableHttps : false,
-					selectedBlueprint,
+					enableHttps,
+					updatedBlueprint ?? selectedBlueprint,
 					formValues.phpVersion,
 					async ( newSite ) => {
 						if ( fileForImport ) {
@@ -302,6 +320,8 @@ export function useAddSite() {
 			setBlueprintPreferredVersions,
 			blueprintDeeplinkWarnings,
 			setBlueprintDeeplinkWarnings,
+			blueprintSuggestedDomain,
+			setBlueprintSuggestedDomain,
 			selectedRemoteSite,
 			setSelectedRemoteSite,
 			existingDomainNames,
@@ -326,6 +346,7 @@ export function useAddSite() {
 			selectedBlueprint,
 			blueprintPreferredVersions,
 			blueprintDeeplinkWarnings,
+			blueprintSuggestedDomain,
 			selectedRemoteSite,
 			existingDomainNames,
 			loadAllCustomDomains,

--- a/src/modules/add-site/components/create-site-form.tsx
+++ b/src/modules/add-site/components/create-site-form.tsx
@@ -41,6 +41,8 @@ export interface CreateSiteFormProps {
 	blueprintPreferredVersions?: BlueprintPreferredVersions;
 	/** Blueprint suggested domain from defineSiteUrl step */
 	blueprintSuggestedDomain?: string;
+	/** Blueprint suggested HTTPS setting from defineSiteUrl step */
+	blueprintSuggestedHttps?: boolean;
 	/** Called when form is submitted */
 	onSubmit: ( values: CreateSiteFormValues ) => void;
 	/** Called when form validity changes */
@@ -154,6 +156,7 @@ export const CreateSiteForm = ( {
 	existingDomainNames = [],
 	blueprintPreferredVersions,
 	blueprintSuggestedDomain,
+	blueprintSuggestedHttps,
 	onSubmit,
 	onValidityChange,
 	formRef,
@@ -215,8 +218,11 @@ export const CreateSiteForm = ( {
 		}
 		setUseCustomDomain( true );
 		setCustomDomain( blueprintSuggestedDomain );
+		if ( blueprintSuggestedHttps !== undefined ) {
+			setEnableHttps( blueprintSuggestedHttps );
+		}
 		setAdvancedSettingsVisible( true );
-	}, [ blueprintSuggestedDomain ] );
+	}, [ blueprintSuggestedDomain, blueprintSuggestedHttps ] );
 
 	useEffect( () => {
 		if ( useCustomDomain && isCertificateTrusted ) {

--- a/src/modules/add-site/components/create-site-form.tsx
+++ b/src/modules/add-site/components/create-site-form.tsx
@@ -39,6 +39,8 @@ export interface CreateSiteFormProps {
 	existingDomainNames?: string[];
 	/** Blueprint preferred versions for warning display */
 	blueprintPreferredVersions?: BlueprintPreferredVersions;
+	/** Blueprint suggested domain from defineSiteUrl step */
+	blueprintSuggestedDomain?: string;
 	/** Called when form is submitted */
 	onSubmit: ( values: CreateSiteFormValues ) => void;
 	/** Called when form validity changes */
@@ -151,6 +153,7 @@ export const CreateSiteForm = ( {
 	onSiteNameChange,
 	existingDomainNames = [],
 	blueprintPreferredVersions,
+	blueprintSuggestedDomain,
 	onSubmit,
 	onValidityChange,
 	formRef,
@@ -205,6 +208,15 @@ export const CreateSiteForm = ( {
 			setWpVersion( defaultValues.wpVersion );
 		}
 	}, [ defaultValues.phpVersion, defaultValues.wpVersion ] );
+
+	useEffect( () => {
+		if ( hasUserInteracted.current || ! blueprintSuggestedDomain ) {
+			return;
+		}
+		setUseCustomDomain( true );
+		setCustomDomain( blueprintSuggestedDomain );
+		setAdvancedSettingsVisible( true );
+	}, [ blueprintSuggestedDomain ] );
 
 	useEffect( () => {
 		if ( useCustomDomain && isCertificateTrusted ) {

--- a/src/modules/add-site/components/create-site.tsx
+++ b/src/modules/add-site/components/create-site.tsx
@@ -21,6 +21,7 @@ export interface CreateSiteProps {
 	existingDomainNames?: string[];
 	blueprintPreferredVersions?: BlueprintPreferredVersions;
 	blueprintSuggestedDomain?: string;
+	blueprintSuggestedHttps?: boolean;
 	originalDefaultVersions?: {
 		phpVersion?: AllowedPHPVersion;
 		wpVersion?: string;
@@ -37,6 +38,7 @@ export default function CreateSite( {
 	existingDomainNames = [],
 	blueprintPreferredVersions,
 	blueprintSuggestedDomain,
+	blueprintSuggestedHttps,
 	onSubmit,
 	onValidityChange,
 	formRef,
@@ -56,6 +58,7 @@ export default function CreateSite( {
 				existingDomainNames={ existingDomainNames }
 				blueprintPreferredVersions={ blueprintPreferredVersions }
 				blueprintSuggestedDomain={ blueprintSuggestedDomain }
+				blueprintSuggestedHttps={ blueprintSuggestedHttps }
 				onSubmit={ onSubmit }
 				onValidityChange={ onValidityChange }
 				formRef={ formRef }

--- a/src/modules/add-site/components/create-site.tsx
+++ b/src/modules/add-site/components/create-site.tsx
@@ -20,6 +20,7 @@ export interface CreateSiteProps {
 	onSiteNameChange: ( name: string ) => Promise< PathValidationResult >;
 	existingDomainNames?: string[];
 	blueprintPreferredVersions?: BlueprintPreferredVersions;
+	blueprintSuggestedDomain?: string;
 	originalDefaultVersions?: {
 		phpVersion?: AllowedPHPVersion;
 		wpVersion?: string;
@@ -35,6 +36,7 @@ export default function CreateSite( {
 	onSiteNameChange,
 	existingDomainNames = [],
 	blueprintPreferredVersions,
+	blueprintSuggestedDomain,
 	onSubmit,
 	onValidityChange,
 	formRef,
@@ -53,6 +55,7 @@ export default function CreateSite( {
 				onSiteNameChange={ onSiteNameChange }
 				existingDomainNames={ existingDomainNames }
 				blueprintPreferredVersions={ blueprintPreferredVersions }
+				blueprintSuggestedDomain={ blueprintSuggestedDomain }
 				onSubmit={ onSubmit }
 				onValidityChange={ onValidityChange }
 				formRef={ formRef }

--- a/src/modules/add-site/hooks/tests/use-blueprint-deeplink.test.tsx
+++ b/src/modules/add-site/hooks/tests/use-blueprint-deeplink.test.tsx
@@ -179,7 +179,7 @@ describe( 'useBlueprintDeeplink', () => {
 			} );
 		} );
 
-		expect( mockSetBlueprintSuggestedDomain ).toHaveBeenCalledWith( 'mysite.local:8443' );
+		expect( mockSetBlueprintSuggestedDomain ).toHaveBeenCalledWith( 'mysite.local' );
 		expect( mockSetBlueprintSuggestedHttps ).toHaveBeenCalledWith( true );
 	} );
 

--- a/src/modules/add-site/hooks/tests/use-blueprint-deeplink.test.tsx
+++ b/src/modules/add-site/hooks/tests/use-blueprint-deeplink.test.tsx
@@ -21,6 +21,8 @@ describe( 'useBlueprintDeeplink', () => {
 	const mockSetWpVersion = vi.fn();
 	const mockSetBlueprintPreferredVersions = vi.fn();
 	const mockSetBlueprintDeeplinkWarnings = vi.fn();
+	const mockSetBlueprintSuggestedDomain = vi.fn();
+	const mockSetBlueprintSuggestedHttps = vi.fn();
 	const mockSetIsDeeplinkFlow = vi.fn();
 	let ipcCallback: Parameters< typeof useIpcListener >[ 1 ];
 
@@ -34,6 +36,8 @@ describe( 'useBlueprintDeeplink', () => {
 					setWpVersion: mockSetWpVersion,
 					setBlueprintPreferredVersions: mockSetBlueprintPreferredVersions,
 					setBlueprintDeeplinkWarnings: mockSetBlueprintDeeplinkWarnings,
+					setBlueprintSuggestedDomain: mockSetBlueprintSuggestedDomain,
+					setBlueprintSuggestedHttps: mockSetBlueprintSuggestedHttps,
 					setIsDeeplinkFlow: mockSetIsDeeplinkFlow,
 				} ),
 			{ wrapper }
@@ -154,6 +158,75 @@ describe( 'useBlueprintDeeplink', () => {
 		} );
 		expect( mockSetPhpVersion ).not.toHaveBeenCalled();
 		expect( mockSetWpVersion ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should set domain and HTTPS from defineSiteUrl step', async () => {
+		const mockBlueprintData = {
+			steps: [ { step: 'defineSiteUrl', siteUrl: 'https://mysite.local:8443' } ],
+		};
+
+		const mockReadBlueprintFile = vi.fn().mockResolvedValue( mockBlueprintData );
+		vi.mocked( getIpcApi, { partial: true } ).mockReturnValue( {
+			readBlueprintFile: mockReadBlueprintFile,
+		} );
+
+		renderBlueprintDeeplinkHook();
+
+		await act( async () => {
+			await ipcCallback!( createMock< IpcRendererEvent >( {} ), {
+				blueprintPath: '/path/to/blueprint.json',
+				warnings: [],
+			} );
+		} );
+
+		expect( mockSetBlueprintSuggestedDomain ).toHaveBeenCalledWith( 'mysite.local:8443' );
+		expect( mockSetBlueprintSuggestedHttps ).toHaveBeenCalledWith( true );
+	} );
+
+	it( 'should set HTTPS to false when defineSiteUrl uses http', async () => {
+		const mockBlueprintData = {
+			steps: [ { step: 'defineSiteUrl', siteUrl: 'http://mysite.local' } ],
+		};
+
+		const mockReadBlueprintFile = vi.fn().mockResolvedValue( mockBlueprintData );
+		vi.mocked( getIpcApi, { partial: true } ).mockReturnValue( {
+			readBlueprintFile: mockReadBlueprintFile,
+		} );
+
+		renderBlueprintDeeplinkHook();
+
+		await act( async () => {
+			await ipcCallback!( createMock< IpcRendererEvent >( {} ), {
+				blueprintPath: '/path/to/blueprint.json',
+				warnings: [],
+			} );
+		} );
+
+		expect( mockSetBlueprintSuggestedDomain ).toHaveBeenCalledWith( 'mysite.local' );
+		expect( mockSetBlueprintSuggestedHttps ).toHaveBeenCalledWith( false );
+	} );
+
+	it( 'should not set domain/HTTPS when no defineSiteUrl step', async () => {
+		const mockBlueprintData = {
+			steps: [ { step: 'login' } ],
+		};
+
+		const mockReadBlueprintFile = vi.fn().mockResolvedValue( mockBlueprintData );
+		vi.mocked( getIpcApi, { partial: true } ).mockReturnValue( {
+			readBlueprintFile: mockReadBlueprintFile,
+		} );
+
+		renderBlueprintDeeplinkHook();
+
+		await act( async () => {
+			await ipcCallback!( createMock< IpcRendererEvent >( {} ), {
+				blueprintPath: '/path/to/blueprint.json',
+				warnings: [],
+			} );
+		} );
+
+		expect( mockSetBlueprintSuggestedDomain ).not.toHaveBeenCalled();
+		expect( mockSetBlueprintSuggestedHttps ).not.toHaveBeenCalled();
 	} );
 
 	it( 'should not process event when site is processing', async () => {

--- a/src/modules/add-site/hooks/use-blueprint-deeplink.ts
+++ b/src/modules/add-site/hooks/use-blueprint-deeplink.ts
@@ -1,5 +1,6 @@
 import { useI18n } from '@wordpress/react-i18n';
 import { useCallback } from 'react';
+import { extractFormValuesFromBlueprint } from 'common/lib/blueprint-settings';
 import {
 	BlueprintValidationWarning,
 	BlueprintPreferredVersions,
@@ -20,6 +21,7 @@ interface UseBlueprintDeeplinkOptions {
 	setWpVersion: ( version: string ) => void;
 	setBlueprintPreferredVersions: ( versions: BlueprintPreferredVersions | undefined ) => void;
 	setBlueprintDeeplinkWarnings: ( warnings: BlueprintValidationWarning[] | undefined ) => void;
+	setBlueprintSuggestedDomain: ( domain: string | undefined ) => void;
 	setIsDeeplinkFlow: ( isDeeplink: boolean ) => void;
 	onModalOpen?: () => void;
 }
@@ -33,6 +35,7 @@ export function useBlueprintDeeplink( options: UseBlueprintDeeplinkOptions ): vo
 		setWpVersion,
 		setBlueprintPreferredVersions,
 		setBlueprintDeeplinkWarnings,
+		setBlueprintSuggestedDomain,
 		setIsDeeplinkFlow,
 		onModalOpen,
 	} = options;
@@ -69,15 +72,21 @@ export function useBlueprintDeeplink( options: UseBlueprintDeeplinkOptions ): vo
 
 					setSelectedBlueprint( fileBlueprint );
 
+					const formValues = extractFormValuesFromBlueprint( blueprintJson );
+
 					if ( blueprintJson.preferredVersions ) {
-						const preferredVersions = blueprintJson.preferredVersions as BlueprintPreferredVersions;
-						setBlueprintPreferredVersions( preferredVersions );
-						if ( preferredVersions.php && preferredVersions.php !== 'latest' ) {
-							setPhpVersion( preferredVersions.php );
-						}
-						if ( preferredVersions.wp && preferredVersions.wp !== 'latest' ) {
-							setWpVersion( preferredVersions.wp );
-						}
+						setBlueprintPreferredVersions(
+							blueprintJson.preferredVersions as BlueprintPreferredVersions
+						);
+					}
+					if ( formValues.phpVersion ) {
+						setPhpVersion( formValues.phpVersion );
+					}
+					if ( formValues.wpVersion ) {
+						setWpVersion( formValues.wpVersion );
+					}
+					if ( formValues.customDomain ) {
+						setBlueprintSuggestedDomain( formValues.customDomain );
 					}
 
 					setBlueprintDeeplinkWarnings( warnings );
@@ -94,6 +103,7 @@ export function useBlueprintDeeplink( options: UseBlueprintDeeplinkOptions ): vo
 				setWpVersion,
 				setBlueprintPreferredVersions,
 				setBlueprintDeeplinkWarnings,
+				setBlueprintSuggestedDomain,
 				setIsDeeplinkFlow,
 				onModalOpen,
 			]

--- a/src/modules/add-site/hooks/use-blueprint-deeplink.ts
+++ b/src/modules/add-site/hooks/use-blueprint-deeplink.ts
@@ -22,6 +22,7 @@ interface UseBlueprintDeeplinkOptions {
 	setBlueprintPreferredVersions: ( versions: BlueprintPreferredVersions | undefined ) => void;
 	setBlueprintDeeplinkWarnings: ( warnings: BlueprintValidationWarning[] | undefined ) => void;
 	setBlueprintSuggestedDomain: ( domain: string | undefined ) => void;
+	setBlueprintSuggestedHttps: ( https: boolean | undefined ) => void;
 	setIsDeeplinkFlow: ( isDeeplink: boolean ) => void;
 	onModalOpen?: () => void;
 }
@@ -36,6 +37,7 @@ export function useBlueprintDeeplink( options: UseBlueprintDeeplinkOptions ): vo
 		setBlueprintPreferredVersions,
 		setBlueprintDeeplinkWarnings,
 		setBlueprintSuggestedDomain,
+		setBlueprintSuggestedHttps,
 		setIsDeeplinkFlow,
 		onModalOpen,
 	} = options;
@@ -87,6 +89,7 @@ export function useBlueprintDeeplink( options: UseBlueprintDeeplinkOptions ): vo
 					}
 					if ( formValues.customDomain ) {
 						setBlueprintSuggestedDomain( formValues.customDomain );
+						setBlueprintSuggestedHttps( formValues.enableHttps );
 					}
 
 					setBlueprintDeeplinkWarnings( warnings );
@@ -104,6 +107,7 @@ export function useBlueprintDeeplink( options: UseBlueprintDeeplinkOptions ): vo
 				setBlueprintPreferredVersions,
 				setBlueprintDeeplinkWarnings,
 				setBlueprintSuggestedDomain,
+				setBlueprintSuggestedHttps,
 				setIsDeeplinkFlow,
 				onModalOpen,
 			]

--- a/src/modules/add-site/index.tsx
+++ b/src/modules/add-site/index.tsx
@@ -4,6 +4,7 @@ import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { MINIMUM_WORDPRESS_VERSION } from 'common/constants';
+import { extractFormValuesFromBlueprint } from 'common/lib/blueprint-settings';
 import { BlueprintPreferredVersions } from 'common/lib/blueprint-validation';
 import { SupportedPHPVersionsList } from 'common/types/php-versions';
 import Button from 'src/components/button';
@@ -67,6 +68,8 @@ interface NavigationContentProps {
 	blueprintPreferredVersions?: BlueprintPreferredVersions;
 	setBlueprintPreferredVersions?: ( versions: BlueprintPreferredVersions | undefined ) => void;
 	blueprintDeeplinkWarnings?: import('common/lib/blueprint-validation').BlueprintValidationWarning[];
+	blueprintSuggestedDomain?: string;
+	setBlueprintSuggestedDomain?: ( domain: string | undefined ) => void;
 	selectedRemoteSite?: SyncSite;
 	setSelectedRemoteSite: ( site?: SyncSite ) => void;
 	isDeeplinkFlow: boolean;
@@ -94,6 +97,8 @@ function NavigationContent( props: NavigationContentProps ) {
 		blueprintPreferredVersions,
 		setBlueprintPreferredVersions,
 		blueprintDeeplinkWarnings,
+		blueprintSuggestedDomain,
+		setBlueprintSuggestedDomain,
 		selectedRemoteSite,
 		setSelectedRemoteSite,
 		isDeeplinkFlow,
@@ -202,31 +207,44 @@ function NavigationContent( props: NavigationContentProps ) {
 		setSelectedRemoteSite,
 	] );
 
+	const applyBlueprintFormValues = useCallback(
+		( blueprint?: Blueprint ) => {
+			setSelectedBlueprint( blueprint );
+
+			if ( ! blueprint?.blueprint ) {
+				setBlueprintPreferredVersions?.( undefined );
+				setBlueprintSuggestedDomain?.( undefined );
+				return;
+			}
+
+			const formValues = extractFormValuesFromBlueprint( blueprint.blueprint );
+
+			if ( blueprint.blueprint.preferredVersions ) {
+				setBlueprintPreferredVersions?.( blueprint.blueprint.preferredVersions );
+			} else {
+				setBlueprintPreferredVersions?.( undefined );
+			}
+
+			setBlueprintSuggestedDomain?.( formValues.customDomain );
+		},
+		[ setSelectedBlueprint, setBlueprintPreferredVersions, setBlueprintSuggestedDomain ]
+	);
+
 	const handleBlueprintChange = useCallback(
 		( blueprintId: string ) => {
 			const blueprint = blueprintsData?.blueprints.find(
 				( b: Blueprint ) => b.slug === blueprintId
 			);
-			setSelectedBlueprint( blueprint );
-			if ( blueprint?.blueprint?.preferredVersions ) {
-				setBlueprintPreferredVersions?.( blueprint.blueprint.preferredVersions );
-			} else {
-				setBlueprintPreferredVersions?.( undefined );
-			}
+			applyBlueprintFormValues( blueprint );
 		},
-		[ blueprintsData?.blueprints, setSelectedBlueprint, setBlueprintPreferredVersions ]
+		[ blueprintsData?.blueprints, applyBlueprintFormValues ]
 	);
 
 	const handleFileBlueprintSelect = useCallback(
 		( blueprint: Blueprint ) => {
-			setSelectedBlueprint( blueprint );
-			if ( blueprint?.blueprint?.preferredVersions ) {
-				setBlueprintPreferredVersions?.( blueprint.blueprint.preferredVersions );
-			} else {
-				setBlueprintPreferredVersions?.( undefined );
-			}
+			applyBlueprintFormValues( blueprint );
 		},
-		[ setSelectedBlueprint, setBlueprintPreferredVersions ]
+		[ applyBlueprintFormValues ]
 	);
 
 	// Build default values with blueprint preferred versions applied
@@ -281,6 +299,7 @@ function NavigationContent( props: NavigationContentProps ) {
 					{ ...createSiteProps }
 					defaultValues={ defaultValuesWithBlueprint }
 					blueprintPreferredVersions={ blueprintPreferredVersions }
+					blueprintSuggestedDomain={ blueprintSuggestedDomain }
 				/>
 			</Navigator.Screen>
 			<Navigator.Screen className="flex-1" path="/create">
@@ -297,6 +316,7 @@ function NavigationContent( props: NavigationContentProps ) {
 					{ ...createSiteProps }
 					defaultValues={ defaultValuesWithBlueprint }
 					blueprintPreferredVersions={ blueprintPreferredVersions }
+					blueprintSuggestedDomain={ blueprintSuggestedDomain }
 				/>
 			</Navigator.Screen>
 			<Navigator.Screen className="flex-1" path="/backup">
@@ -381,6 +401,8 @@ export function AddSiteModalContent( {
 		blueprintPreferredVersions,
 		setBlueprintPreferredVersions,
 		blueprintDeeplinkWarnings,
+		blueprintSuggestedDomain,
+		setBlueprintSuggestedDomain,
 		selectedRemoteSite,
 		setSelectedRemoteSite,
 		existingDomainNames,
@@ -482,6 +504,8 @@ export function AddSiteModalContent( {
 				blueprintPreferredVersions={ blueprintPreferredVersions }
 				setBlueprintPreferredVersions={ setBlueprintPreferredVersions }
 				blueprintDeeplinkWarnings={ blueprintDeeplinkWarnings }
+				blueprintSuggestedDomain={ blueprintSuggestedDomain }
+				setBlueprintSuggestedDomain={ setBlueprintSuggestedDomain }
 				selectedRemoteSite={ selectedRemoteSite }
 				setSelectedRemoteSite={ setSelectedRemoteSite }
 				isDeeplinkFlow={ isDeeplinkFlow }
@@ -517,6 +541,7 @@ export default function AddSiteModal( { className }: AddSiteModalProps ) {
 		setDeeplinkWpVersion,
 		setBlueprintPreferredVersions,
 		setBlueprintDeeplinkWarnings,
+		setBlueprintSuggestedDomain,
 		setIsDeeplinkFlow,
 	} = addSiteProps;
 
@@ -539,6 +564,7 @@ export default function AddSiteModal( { className }: AddSiteModalProps ) {
 		setWpVersion: setDeeplinkWpVersion,
 		setBlueprintPreferredVersions,
 		setBlueprintDeeplinkWarnings,
+		setBlueprintSuggestedDomain,
 		setIsDeeplinkFlow,
 		onModalOpen: openModal,
 	} );

--- a/src/modules/add-site/index.tsx
+++ b/src/modules/add-site/index.tsx
@@ -70,6 +70,8 @@ interface NavigationContentProps {
 	blueprintDeeplinkWarnings?: import('common/lib/blueprint-validation').BlueprintValidationWarning[];
 	blueprintSuggestedDomain?: string;
 	setBlueprintSuggestedDomain?: ( domain: string | undefined ) => void;
+	blueprintSuggestedHttps?: boolean;
+	setBlueprintSuggestedHttps?: ( https: boolean | undefined ) => void;
 	selectedRemoteSite?: SyncSite;
 	setSelectedRemoteSite: ( site?: SyncSite ) => void;
 	isDeeplinkFlow: boolean;
@@ -99,6 +101,8 @@ function NavigationContent( props: NavigationContentProps ) {
 		blueprintDeeplinkWarnings,
 		blueprintSuggestedDomain,
 		setBlueprintSuggestedDomain,
+		blueprintSuggestedHttps,
+		setBlueprintSuggestedHttps,
 		selectedRemoteSite,
 		setSelectedRemoteSite,
 		isDeeplinkFlow,
@@ -214,6 +218,7 @@ function NavigationContent( props: NavigationContentProps ) {
 			if ( ! blueprint?.blueprint ) {
 				setBlueprintPreferredVersions?.( undefined );
 				setBlueprintSuggestedDomain?.( undefined );
+				setBlueprintSuggestedHttps?.( undefined );
 				return;
 			}
 
@@ -226,8 +231,14 @@ function NavigationContent( props: NavigationContentProps ) {
 			}
 
 			setBlueprintSuggestedDomain?.( formValues.customDomain );
+			setBlueprintSuggestedHttps?.( formValues.enableHttps );
 		},
-		[ setSelectedBlueprint, setBlueprintPreferredVersions, setBlueprintSuggestedDomain ]
+		[
+			setSelectedBlueprint,
+			setBlueprintPreferredVersions,
+			setBlueprintSuggestedDomain,
+			setBlueprintSuggestedHttps,
+		]
 	);
 
 	const handleBlueprintChange = useCallback(
@@ -300,6 +311,7 @@ function NavigationContent( props: NavigationContentProps ) {
 					defaultValues={ defaultValuesWithBlueprint }
 					blueprintPreferredVersions={ blueprintPreferredVersions }
 					blueprintSuggestedDomain={ blueprintSuggestedDomain }
+					blueprintSuggestedHttps={ blueprintSuggestedHttps }
 				/>
 			</Navigator.Screen>
 			<Navigator.Screen className="flex-1" path="/create">
@@ -317,6 +329,7 @@ function NavigationContent( props: NavigationContentProps ) {
 					defaultValues={ defaultValuesWithBlueprint }
 					blueprintPreferredVersions={ blueprintPreferredVersions }
 					blueprintSuggestedDomain={ blueprintSuggestedDomain }
+					blueprintSuggestedHttps={ blueprintSuggestedHttps }
 				/>
 			</Navigator.Screen>
 			<Navigator.Screen className="flex-1" path="/backup">
@@ -403,6 +416,8 @@ export function AddSiteModalContent( {
 		blueprintDeeplinkWarnings,
 		blueprintSuggestedDomain,
 		setBlueprintSuggestedDomain,
+		blueprintSuggestedHttps,
+		setBlueprintSuggestedHttps,
 		selectedRemoteSite,
 		setSelectedRemoteSite,
 		existingDomainNames,
@@ -506,6 +521,8 @@ export function AddSiteModalContent( {
 				blueprintDeeplinkWarnings={ blueprintDeeplinkWarnings }
 				blueprintSuggestedDomain={ blueprintSuggestedDomain }
 				setBlueprintSuggestedDomain={ setBlueprintSuggestedDomain }
+				blueprintSuggestedHttps={ blueprintSuggestedHttps }
+				setBlueprintSuggestedHttps={ setBlueprintSuggestedHttps }
 				selectedRemoteSite={ selectedRemoteSite }
 				setSelectedRemoteSite={ setSelectedRemoteSite }
 				isDeeplinkFlow={ isDeeplinkFlow }
@@ -542,6 +559,7 @@ export default function AddSiteModal( { className }: AddSiteModalProps ) {
 		setBlueprintPreferredVersions,
 		setBlueprintDeeplinkWarnings,
 		setBlueprintSuggestedDomain,
+		setBlueprintSuggestedHttps,
 		setIsDeeplinkFlow,
 	} = addSiteProps;
 
@@ -565,6 +583,7 @@ export default function AddSiteModal( { className }: AddSiteModalProps ) {
 		setBlueprintPreferredVersions,
 		setBlueprintDeeplinkWarnings,
 		setBlueprintSuggestedDomain,
+		setBlueprintSuggestedHttps,
 		setIsDeeplinkFlow,
 		onModalOpen: openModal,
 	} );


### PR DESCRIPTION
## Related issues

- Fixes https://linear.app/a8c/issue/STU-830

## Proposed Changes

- Extract `defineSiteUrl` from blueprint steps to pre-populate the custom domain field
- Create bidirectional mapping utilities between blueprint settings and form values (`extractFormValuesFromBlueprint` / `updateBlueprintWithFormValues`)
- Add `BlueprintSiteSettings` type for shared settings between blueprints and forms
- Pre-populate custom domain from `defineSiteUrl` step and expand advanced settings
- Pre-populate HTTPS toggle based on the protocol in `defineSiteUrl` (https vs http)
- Update blueprint with final user selections before site creation (only updates existing properties)

## Testing Instructions

### Test 1: HTTPS URL in blueprint
1. Create a blueprint file with a `defineSiteUrl` step using **https**:
```json
{
  "steps": [
    {
      "step": "defineSiteUrl",
      "siteUrl": "https://mysite.local"
    }
  ]
}
```

2. Open Studio and go to Add Site → Start from Blueprint → Choose Blueprint file
3. Upload the blueprint file
4. Verify:
   - Custom domain field shows `mysite.local`
   - Advanced settings are expanded
   - **HTTPS toggle is ON**
5. Create the site and verify it works with HTTPS

### Test 2: HTTP URL in blueprint
1. Create a blueprint file with a `defineSiteUrl` step using **http**:
```json
{
  "steps": [
    {
      "step": "defineSiteUrl",
      "siteUrl": "http://mysite.local"
    }
  ]
}
```

2. Upload the blueprint file
3. Verify:
   - Custom domain field shows `mysite.local`
   - **HTTPS toggle is OFF**

### Test 3: URL with port (port is stripped)
1. Create a blueprint file with a port in the URL:
```json
{
  "steps": [
    {
      "step": "defineSiteUrl",
      "siteUrl": "https://mysite.local:8443"
    }
  ]
}
```

2. Upload the blueprint file
3. Verify custom domain field shows `mysite.local` (port is stripped - domain validation doesn't support ports)

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?