### PR TITLE
Revert: Performance: Parallelize recursive directory copying (#2409)

### DIFF
--- a/cli/commands/site/create.ts
+++ b/cli/commands/site/create.ts
@@ -15,7 +15,13 @@ import {
 	validateBlueprintData,
 } from 'common/lib/blueprint-validation';
 import { getDomainNameValidationError } from 'common/lib/domains';
-import { arePathsEqual, isEmptyDir, isWordPressDirectory, pathExists } from 'common/lib/fs-utils';
+import {
+	arePathsEqual,
+	isEmptyDir,
+	isWordPressDirectory,
+	pathExists,
+	recursiveCopyDirectory,
+} from 'common/lib/fs-utils';
 import { DEFAULT_LOCALE } from 'common/lib/locale';
 import { isOnline } from 'common/lib/network-utils';
 import { createPassword } from 'common/lib/passwords';
@@ -27,7 +33,6 @@ import {
 	isWordPressVersionAtLeast,
 } from 'common/lib/wordpress-version-utils';
 import { SiteCommandLoggerAction as LoggerAction } from 'common/logger-actions';
-import fse from 'fs-extra';
 import {
 	lockAppdata,
 	readAppdata,
@@ -157,7 +162,7 @@ export async function runCommand(
 			}
 
 			logger.reportStart( LoggerAction.SETUP_WORDPRESS, __( 'Copying bundled WordPress…' ) );
-			await fse.copy( bundledWPPath, sitePath );
+			await recursiveCopyDirectory( bundledWPPath, sitePath );
 			logger.reportSuccess( __( 'WordPress files copied' ) );
 		} else if ( ! isOnlineStatus ) {
 			throw new LoggerError(

--- a/cli/commands/site/tests/create.test.ts
+++ b/cli/commands/site/tests/create.test.ts
@@ -4,7 +4,13 @@ import {
 	filterUnsupportedBlueprintFeatures,
 	validateBlueprintData,
 } from 'common/lib/blueprint-validation';
-import { isEmptyDir, isWordPressDirectory, pathExists, arePathsEqual } from 'common/lib/fs-utils';
+import {
+	isEmptyDir,
+	isWordPressDirectory,
+	pathExists,
+	arePathsEqual,
+	recursiveCopyDirectory,
+} from 'common/lib/fs-utils';
 import { isOnline } from 'common/lib/network-utils';
 import { portFinder } from 'common/lib/port-finder';
 import { vi, type MockInstance } from 'vitest';
@@ -28,11 +34,6 @@ import { runCommand } from '../create';
 
 vi.mock( 'common/lib/fs-utils' );
 vi.mock( 'common/lib/network-utils' );
-vi.mock( 'fs-extra', () => ( {
-	default: {
-		copy: vi.fn().mockResolvedValue( undefined ),
-	},
-} ) );
 vi.mock( 'common/lib/port-finder', () => ( {
 	portFinder: {
 		addUnavailablePort: vi.fn(),
@@ -133,6 +134,7 @@ describe( 'CLI: studio site create', () => {
 		vi.mocked( isEmptyDir ).mockResolvedValue( true );
 		vi.mocked( isWordPressDirectory ).mockReturnValue( false );
 		vi.mocked( arePathsEqual ).mockImplementation( ( a, b ) => a === b );
+		vi.mocked( recursiveCopyDirectory ).mockResolvedValue( undefined );
 		vi.mocked( portFinder.getOpenPort ).mockResolvedValue( mockPort );
 		vi.mocked( readAppdata, { partial: true } ).mockResolvedValue( {
 			sites: [ ...mockAppdata.sites ],

--- a/common/lib/fs-utils.ts
+++ b/common/lib/fs-utils.ts
@@ -77,6 +77,26 @@ export async function pathExists( path: string ): Promise< boolean > {
 	}
 }
 
+export async function recursiveCopyDirectory(
+	source: string,
+	destination: string
+): Promise< void > {
+	await fsPromises.mkdir( destination, { recursive: true } );
+
+	const entries = await fsPromises.readdir( source, { withFileTypes: true } );
+
+	for ( const entry of entries ) {
+		const sourcePath = path.join( source, entry.name );
+		const destinationPath = path.join( destination, entry.name );
+
+		if ( entry.isDirectory() ) {
+			await recursiveCopyDirectory( sourcePath, destinationPath );
+		} else if ( entry.isFile() ) {
+			await fsPromises.copyFile( sourcePath, destinationPath );
+		}
+	}
+}
+
 export async function isEmptyDir( directory: string ): Promise< boolean > {
 	const stats = await fsPromises.stat( directory );
 	if ( ! stats.isDirectory() ) {

--- a/src/lib/wordpress-setup.ts
+++ b/src/lib/wordpress-setup.ts
@@ -4,8 +4,7 @@
  */
 
 import nodePath from 'path';
-import fs from 'fs-extra';
-import { pathExists } from 'common/lib/fs-utils';
+import { pathExists, recursiveCopyDirectory } from 'common/lib/fs-utils';
 import { getResourcesPath } from 'src/storage/paths';
 
 /**
@@ -19,5 +18,5 @@ export async function setupWordPressFilesOnly( path: string ): Promise< void > {
 		throw new Error( 'Bundled WordPress files not found. Please reinstall WordPress Studio.' );
 	}
 
-	await fs.copy( bundledWPPath, path );
+	await recursiveCopyDirectory( bundledWPPath, path );
 }

--- a/src/lib/wp-versions.ts
+++ b/src/lib/wp-versions.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 import fs from 'fs-extra';
 import semver from 'semver';
+import { recursiveCopyDirectory } from 'common/lib/fs-utils';
 import { downloadWordPress } from 'src/lib/download-utils';
 import { getWordPressVersionPath } from 'src/lib/server-files-paths';
 
@@ -67,7 +68,7 @@ export async function updateLatestWordPressVersion() {
 		const latestVersion = await getLatestWordPressVersion();
 		if ( installedVersion && latestVersion !== 'latest' && installedVersion !== latestVersion ) {
 			// We keep a copy of the latest installed version instead of removing it.
-			await fs.copy( latestVersionPath, getWordPressVersionPath( installedVersion ) );
+			await recursiveCopyDirectory( latestVersionPath, getWordPressVersionPath( installedVersion ) );
 			shouldOverwrite = true;
 		}
 	}

--- a/src/lib/wp-versions.ts
+++ b/src/lib/wp-versions.ts
@@ -68,7 +68,10 @@ export async function updateLatestWordPressVersion() {
 		const latestVersion = await getLatestWordPressVersion();
 		if ( installedVersion && latestVersion !== 'latest' && installedVersion !== latestVersion ) {
 			// We keep a copy of the latest installed version instead of removing it.
-			await recursiveCopyDirectory( latestVersionPath, getWordPressVersionPath( installedVersion ) );
+			await recursiveCopyDirectory(
+				latestVersionPath,
+				getWordPressVersionPath( installedVersion )
+			);
 			shouldOverwrite = true;
 		}
 	}

--- a/src/migrations/migrate-from-wp-now-folder.ts
+++ b/src/migrations/migrate-from-wp-now-folder.ts
@@ -1,7 +1,6 @@
 import { app } from 'electron';
 import path from 'path';
-import fs from 'fs-extra';
-import { pathExists } from 'common/lib/fs-utils';
+import { pathExists, recursiveCopyDirectory } from 'common/lib/fs-utils';
 import { getServerFilesPath } from 'src/storage/paths';
 import { loadUserData } from 'src/storage/user-data';
 
@@ -27,5 +26,5 @@ export async function needsToMigrateFromWpNowFolder() {
 }
 
 export async function migrateFromWpNowFolder() {
-	await fs.copy( wpNowPath, getServerFilesPath() );
+	await recursiveCopyDirectory( wpNowPath, getServerFilesPath() );
 }

--- a/src/setup-wp-server-files.ts
+++ b/src/setup-wp-server-files.ts
@@ -7,7 +7,6 @@ import { getWordPressVersionPath, getSqlitePath, getWpCliPath } from 'src/lib/se
 import {
 	getSqliteCommandPath,
 	updateLatestSQLiteCommandVersion,
-	getSQLiteCommandVersion,
 } from 'src/lib/sqlite-command-versions';
 import { getSqliteVersionFromInstallation } from 'src/lib/sqlite-versions';
 import {
@@ -84,21 +83,11 @@ async function copyBundledWPCLI() {
 
 async function copyBundledSQLiteCommand() {
 	const bundledSqliteCommandPath = path.join( getResourcesPath(), 'wp-files', 'sqlite-command' );
-	const bundledSqliteCommandVersion = await getSQLiteCommandVersion( bundledSqliteCommandPath );
-	if ( ! bundledSqliteCommandVersion ) {
+	if ( ! ( await fs.pathExists( bundledSqliteCommandPath ) ) ) {
 		return;
 	}
-	const installedSqliteCommandPath = getSqliteCommandPath();
-	const isSqliteCommandInstalled = await fs.pathExists( installedSqliteCommandPath );
-
-	const installedSqliteCommandVersion = await getSQLiteCommandVersion( installedSqliteCommandPath );
-	const isBundledVersionNewer =
-		installedSqliteCommandVersion &&
-		semver.gt( bundledSqliteCommandVersion, installedSqliteCommandVersion );
-	if ( ! isSqliteCommandInstalled || isBundledVersionNewer ) {
-		console.log( `Copying bundled SQLite command version ${ bundledSqliteCommandVersion }…` );
-		await recursiveCopyDirectory( bundledSqliteCommandPath, installedSqliteCommandPath );
-	}
+	// Always copy to ensure files are complete and up-to-date
+	await recursiveCopyDirectory( bundledSqliteCommandPath, getSqliteCommandPath() );
 }
 
 async function copyBundledTranslations() {

--- a/src/setup-wp-server-files.ts
+++ b/src/setup-wp-server-files.ts
@@ -1,11 +1,13 @@
 import path from 'path';
 import fs from 'fs-extra';
 import semver from 'semver';
+import { recursiveCopyDirectory } from 'common/lib/fs-utils';
 import { updateLatestWPCliVersion } from 'src/lib/download-utils';
 import { getWordPressVersionPath, getSqlitePath, getWpCliPath } from 'src/lib/server-files-paths';
 import {
 	getSqliteCommandPath,
 	updateLatestSQLiteCommandVersion,
+	getSQLiteCommandVersion,
 } from 'src/lib/sqlite-command-versions';
 import { getSqliteVersionFromInstallation } from 'src/lib/sqlite-versions';
 import {
@@ -40,7 +42,7 @@ export async function copyBundledLatestWPVersion() {
 			} );
 		}
 		console.log( `Copying bundled WP version ${ bundledWPVersion } as 'latest' version…` );
-		await fs.copy( bundledWPVersionPath, latestWPVersionPath );
+		await recursiveCopyDirectory( bundledWPVersionPath, latestWPVersionPath );
 	}
 }
 
@@ -67,7 +69,7 @@ async function copyBundledSqlite() {
 		installedSqliteVersion && semver.gt( bundledSqliteVersion, installedSqliteVersion );
 	if ( ! isSqliteInstalled || isBundledVersionNewer ) {
 		console.log( `Copying bundled SQLite version ${ bundledSqliteVersion }…` );
-		await fs.copy( bundledSqlitePath, getSqlitePath() );
+		await recursiveCopyDirectory( bundledSqlitePath, getSqlitePath() );
 	}
 }
 
@@ -82,11 +84,21 @@ async function copyBundledWPCLI() {
 
 async function copyBundledSQLiteCommand() {
 	const bundledSqliteCommandPath = path.join( getResourcesPath(), 'wp-files', 'sqlite-command' );
-	if ( ! ( await fs.pathExists( bundledSqliteCommandPath ) ) ) {
+	const bundledSqliteCommandVersion = await getSQLiteCommandVersion( bundledSqliteCommandPath );
+	if ( ! bundledSqliteCommandVersion ) {
 		return;
 	}
-	// Always copy to ensure files are complete and up-to-date
-	await fs.copy( bundledSqliteCommandPath, getSqliteCommandPath() );
+	const installedSqliteCommandPath = getSqliteCommandPath();
+	const isSqliteCommandInstalled = await fs.pathExists( installedSqliteCommandPath );
+
+	const installedSqliteCommandVersion = await getSQLiteCommandVersion( installedSqliteCommandPath );
+	const isBundledVersionNewer =
+		installedSqliteCommandVersion &&
+		semver.gt( bundledSqliteCommandVersion, installedSqliteCommandVersion );
+	if ( ! isSqliteCommandInstalled || isBundledVersionNewer ) {
+		console.log( `Copying bundled SQLite command version ${ bundledSqliteCommandVersion }…` );
+		await recursiveCopyDirectory( bundledSqliteCommandPath, installedSqliteCommandPath );
+	}
 }
 
 async function copyBundledTranslations() {


### PR DESCRIPTION
## Summary

- Reverts the changes from PR #2409
- Brings back the sequential `recursiveCopyDirectory` implementation
- Removes direct usage of `fs-extra`'s `copy` in favor of the custom implementation

The copy logic will be revisited in #2502.

## Related issues

- Reverts #2409

## Testing Instructions

1. Check out the PR branch and build the app with `npm install && npm start`.
2. Create several new sites.
3. The process should work correctly, the sites should get created and run without any issues.