### PR TITLE
Fix Windows import/export sqlite-command error

### DIFF
--- a/src/setup-wp-server-files.ts
+++ b/src/setup-wp-server-files.ts
@@ -6,7 +6,6 @@ import { getWordPressVersionPath, getSqlitePath, getWpCliPath } from 'src/lib/se
 import {
 	getSqliteCommandPath,
 	updateLatestSQLiteCommandVersion,
-	getSQLiteCommandVersion,
 } from 'src/lib/sqlite-command-versions';
 import { getSqliteVersionFromInstallation } from 'src/lib/sqlite-versions';
 import {
@@ -83,21 +82,11 @@ async function copyBundledWPCLI() {
 
 async function copyBundledSQLiteCommand() {
 	const bundledSqliteCommandPath = path.join( getResourcesPath(), 'wp-files', 'sqlite-command' );
-	const bundledSqliteCommandVersion = await getSQLiteCommandVersion( bundledSqliteCommandPath );
-	if ( ! bundledSqliteCommandVersion ) {
+	if ( ! ( await fs.pathExists( bundledSqliteCommandPath ) ) ) {
 		return;
 	}
-	const installedSqliteCommandPath = getSqliteCommandPath();
-	const isSqliteCommandInstalled = await fs.pathExists( installedSqliteCommandPath );
-
-	const installedSqliteCommandVersion = await getSQLiteCommandVersion( installedSqliteCommandPath );
-	const isBundledVersionNewer =
-		installedSqliteCommandVersion &&
-		semver.gt( bundledSqliteCommandVersion, installedSqliteCommandVersion );
-	if ( ! isSqliteCommandInstalled || isBundledVersionNewer ) {
-		console.log( `Copying bundled SQLite command version ${ bundledSqliteCommandVersion }…` );
-		await fs.copy( bundledSqliteCommandPath, installedSqliteCommandPath );
-	}
+	// Always copy to ensure files are complete and up-to-date
+	await fs.copy( bundledSqliteCommandPath, getSqliteCommandPath() );
 }
 
 async function copyBundledTranslations() {


### PR DESCRIPTION
## Related issues

- Fixes STU-1273

## Proposed Changes

- Simplify `copyBundledSQLiteCommand()` to always copy files on app startup
- Remove version-checking logic that could skip copying when files were incomplete
- Remove unused `getSQLiteCommandVersion` import

**Root cause:** A previous incomplete copy left the `version` file but not `command.php`. Since versions matched, the copy was skipped, leaving import/export broken.

**Fix:** Always copy sqlite-command files on startup (~200KB, negligible overhead). This ensures files are always complete and self-heals any corruption.

## Testing Instructions

1. On Windows, check current state:
   ```powershell
   dir "$env:APPDATA\Studio\server-files\sqlite-command"
   ```
2. If `command.php` is missing (reproducing the bug), note the incomplete state
3. Build and run the fix
4. Verify files are now complete:
   ```powershell
   dir "$env:APPDATA\Studio\server-files\sqlite-command"
   ```
5. Test import/export functionality works

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?