### PR TITLE
Ensure CLI dependencies are installed during root npm install

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13965,6 +13965,7 @@
 		},
 		"node_modules/fs-xattr": {
 			"version": "0.3.1",
+			"hasInstallScript": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -16354,6 +16355,7 @@
 		},
 		"node_modules/macos-alias": {
 			"version": "0.2.12",
+			"hasInstallScript": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 		"prestart": "npm run cli:build",
 		"start": "electron-vite dev --outDir=dist --watch",
 		"start-wayland": "npm run prestart && electron-forge start -- --enable-features=UseOzonePlatform --ozone-platform=wayland .",
-		"postinstall": "npm install --prefix cli && patch-package && ts-node ./scripts/download-wp-server-files.ts && node ./scripts/download-available-site-translations.mjs && npx @electron/rebuild -o fs-ext",
+		"postinstall": "cd cli && npm install && cd .. && patch-package && ts-node ./scripts/download-wp-server-files.ts && node ./scripts/download-available-site-translations.mjs && npx @electron/rebuild -o fs-ext",
 		"package": "electron-vite build --outDir=dist && electron-forge package",
 		"make": "electron-vite build --outDir=dist && electron-forge make",
 		"make:windows-x64": "electron-vite build --outDir=dist && electron-forge make --arch=x64 --platform=win32",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 		"prestart": "npm run cli:build",
 		"start": "electron-vite dev --outDir=dist --watch",
 		"start-wayland": "npm run prestart && electron-forge start -- --enable-features=UseOzonePlatform --ozone-platform=wayland .",
-		"postinstall": "patch-package && ts-node ./scripts/download-wp-server-files.ts && node ./scripts/download-available-site-translations.mjs && npx @electron/rebuild -o fs-ext",
+		"postinstall": "npm install --prefix cli && patch-package && ts-node ./scripts/download-wp-server-files.ts && node ./scripts/download-available-site-translations.mjs && npx @electron/rebuild -o fs-ext",
 		"package": "electron-vite build --outDir=dist && electron-forge package",
 		"make": "electron-vite build --outDir=dist && electron-forge make",
 		"make:windows-x64": "electron-vite build --outDir=dist && electron-forge make --arch=x64 --platform=win32",


### PR DESCRIPTION
## Related issues

N/A

## Proposed Changes

- Added `npm install --prefix cli` to the root postinstall script
- This ensures CLI dependencies are automatically installed when developers run `npm install` in the root directory
- Aligns local development setup with CI pipeline behavior (which already handles this explicitly)

## Testing Instructions

1. Clone the repository fresh
2. Run `npm install` in the root directory
3. Verify that `cli/node_modules/` is populated with dependencies (e.g., `@wp-playground/*`, `pm2`, etc.)
4. Verify that `npm start` works without needing a separate `npm install` in the `cli/` directory
5. Cross-platform testing: Test on both macOS and Windows to ensure `npm install --prefix` works correctly on both

## Pre-merge Checklist

- [x] No TypeScript or console errors introduced