### PR TITLE
CI: Run E2E tests on `windows` queue, too

### DIFF
--- a/.buildkite/commands/run-e2e-tests.sh
+++ b/.buildkite/commands/run-e2e-tests.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-MATRIX=${1:-}
+PLATFORM=${1:-}
+ARCH=${2:-}
 
 if .buildkite/commands/should-skip-job.sh --job-type validation; then
   exit 0
@@ -12,8 +13,19 @@ bash .buildkite/commands/install-node-dependencies.sh
 
 export IS_DEV_BUILD=true
 
-echo '--- :package: Package app for testing'
-npm run package
+echo "--- :package: Package app for testing ($PLATFORM-$ARCH)"
+case "$PLATFORM" in
+  mac)
+    npm run make:macos-"$ARCH"
+    ;;
+  windows)
+    npm run make:windows-"$ARCH"
+    ;;
+  *)
+    echo "Unknown platform: $PLATFORM"
+    exit 1
+    ;;
+esac
 
 echo '--- :playwright: Run End To End Tests'
 echo 'Installing Playwright browsers...'

--- a/.buildkite/commands/run-e2e-tests.sh
+++ b/.buildkite/commands/run-e2e-tests.sh
@@ -32,7 +32,12 @@ esac
 # `make` creates signed distributables (installers), which requires code signing setup.
 # `package` creates an unsigned app bundle, sufficient for E2E testing.
 echo "--- :package: Package app for testing ($PLATFORM-$ARCH)"
-npx electron-vite build --outDir=dist && npx electron-forge package --arch="$ARCH" --platform="$FORGE_PLATFORM"
+npx electron-vite build --outDir=dist
+npx electron-forge package --arch="$ARCH" --platform="$FORGE_PLATFORM"
+
+# This empty echo prevents the next one from being swallowed.
+# See https://buildkite.com/automattic/studio/builds/11098/steps/canvas?jid=019c2287-365e-49c6-b0ba-f7c1d06bc5f5#019c2287-365e-49c6-b0ba-f7c1d06bc5f5/L392
+echo ''
 
 echo '--- :playwright: Run End To End Tests'
 
@@ -44,8 +49,8 @@ if [ "$PLATFORM" = "mac" ] && [ "$ARCH" = "x64" ]; then
   arch_prefix=(arch -x86_64)
 fi
 
-echo 'Installing Playwright browsers...'
+echo '~~~ Installing Playwright browsers...'
 ${arch_prefix[@]+"${arch_prefix[@]}"} npx playwright install
 
-echo 'Running Playwright tests...'
+echo '~~~ Running Playwright tests...'
 ${arch_prefix[@]+"${arch_prefix[@]}"} npx playwright test

--- a/.buildkite/commands/run-e2e-tests.sh
+++ b/.buildkite/commands/run-e2e-tests.sh
@@ -14,19 +14,25 @@ bash .buildkite/commands/install-node-dependencies.sh
 
 export IS_DEV_BUILD=true
 
-echo "--- :package: Package app for testing ($PLATFORM-$ARCH)"
+# Map platform names to electron-forge platform values
 case "$PLATFORM" in
   mac)
-    npm run make:macos-"$ARCH"
+    FORGE_PLATFORM="darwin"
     ;;
   windows)
-    npm run make:windows-"$ARCH"
+    FORGE_PLATFORM="win32"
     ;;
   *)
     echo "Unknown platform: $PLATFORM"
     exit 1
     ;;
 esac
+
+# Use `electron-forge package` instead of `npm run make:*` for E2E tests.
+# `make` creates signed distributables (installers), which requires code signing setup.
+# `package` creates an unsigned app bundle, sufficient for E2E testing.
+echo "--- :package: Package app for testing ($PLATFORM-$ARCH)"
+npx electron-vite build --outDir=dist && npx electron-forge package --arch="$ARCH" --platform="$FORGE_PLATFORM"
 
 echo '--- :playwright: Run End To End Tests'
 echo 'Installing Playwright browsers...'

--- a/.buildkite/commands/run-e2e-tests.sh
+++ b/.buildkite/commands/run-e2e-tests.sh
@@ -37,15 +37,15 @@ npx electron-vite build --outDir=dist && npx electron-forge package --arch="$ARC
 echo '--- :playwright: Run End To End Tests'
 
 # For mac-x64 on Apple Silicon: install Rosetta and run under x86_64 arch
-arch_prefix=''
+arch_prefix=()
 if [ "$PLATFORM" = "mac" ] && [ "$ARCH" = "x64" ]; then
-  echo '~~~ Installing Rosetta for x64 emulation...'
-  softwareupdate --install-rosetta --agree-to-license
-  arch_prefix='arch -x86_64 '
+  echo 'Installing Rosetta for x64 emulation...'
+  softwareupdate --install-rosetta --agree-to-license || true
+  arch_prefix=(arch -x86_64)
 fi
 
-echo '~~~ Installing Playwright browsers...'
-"${arch_prefix}npx playwright install"
+echo 'Installing Playwright browsers...'
+${arch_prefix[@]+"${arch_prefix[@]}"} npx playwright install
 
-echo '~~~ Running Playwright tests...'
-"${arch_prefix}npx playwright test"
+echo 'Running Playwright tests...'
+${arch_prefix[@]+"${arch_prefix[@]}"} npx playwright test

--- a/.buildkite/commands/run-e2e-tests.sh
+++ b/.buildkite/commands/run-e2e-tests.sh
@@ -35,7 +35,21 @@ echo "--- :package: Package app for testing ($PLATFORM-$ARCH)"
 npx electron-vite build --outDir=dist && npx electron-forge package --arch="$ARCH" --platform="$FORGE_PLATFORM"
 
 echo '--- :playwright: Run End To End Tests'
-echo 'Installing Playwright browsers...'
-npx playwright install
-echo 'Running Playwright tests...'
-npx playwright test
+
+# For mac-x64 on Apple Silicon: install Rosetta and run under x86_64 arch
+if [ "$PLATFORM" = "mac" ] && [ "$ARCH" = "x64" ]; then
+  echo 'Installing Rosetta for x64 emulation...'
+  softwareupdate --install-rosetta --agree-to-license || true
+
+  echo 'Installing Playwright browsers (x64)...'
+  arch -x86_64 npx playwright install
+
+  echo 'Running Playwright tests (x64 via Rosetta)...'
+  arch -x86_64 npx playwright test
+else
+  echo 'Installing Playwright browsers...'
+  npx playwright install
+
+  echo 'Running Playwright tests...'
+  npx playwright test
+fi

--- a/.buildkite/commands/run-e2e-tests.sh
+++ b/.buildkite/commands/run-e2e-tests.sh
@@ -35,22 +35,10 @@ echo "--- :package: Package app for testing ($PLATFORM-$ARCH)"
 npx electron-vite build --outDir=dist
 npx electron-forge package --arch="$ARCH" --platform="$FORGE_PLATFORM"
 
-# This empty echo prevents the next one from being swallowed.
-# See https://buildkite.com/automattic/studio/builds/11098/steps/canvas?jid=019c2287-365e-49c6-b0ba-f7c1d06bc5f5#019c2287-365e-49c6-b0ba-f7c1d06bc5f5/L392
-echo ''
-
 echo '--- :playwright: Run End To End Tests'
 
-# For mac-x64 on Apple Silicon: install Rosetta and run under x86_64 arch
-arch_prefix=()
-if [ "$PLATFORM" = "mac" ] && [ "$ARCH" = "x64" ]; then
-  echo 'Installing Rosetta for x64 emulation...'
-  softwareupdate --install-rosetta --agree-to-license || true
-  arch_prefix=(arch -x86_64)
-fi
+echo 'Installing Playwright browsers...'
+npx playwright install
 
-echo '~~~ Installing Playwright browsers...'
-${arch_prefix[@]+"${arch_prefix[@]}"} npx playwright install
-
-echo '~~~ Running Playwright tests...'
-${arch_prefix[@]+"${arch_prefix[@]}"} npx playwright test
+echo 'Running Playwright tests...'
+npx playwright test

--- a/.buildkite/commands/run-e2e-tests.sh
+++ b/.buildkite/commands/run-e2e-tests.sh
@@ -4,10 +4,9 @@ set -euo pipefail
 PLATFORM=${1:-}
 ARCH=${2:-}
 
-# TODO: Re-enable once implementation has been verified. See AINFRA-1888
-# if .buildkite/commands/should-skip-job.sh --job-type validation; then
-#   exit 0
-# fi
+if .buildkite/commands/should-skip-job.sh --job-type validation; then
+  exit 0
+fi
 
 echo '--- :package: Install deps'
 bash .buildkite/commands/install-node-dependencies.sh

--- a/.buildkite/commands/run-e2e-tests.sh
+++ b/.buildkite/commands/run-e2e-tests.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-PLATFORM=${1:-}
-ARCH=${2:-}
+PLATFORM=${1:?Expected platform to be provided as first parameter}
+ARCH=${2:?Expected architecture to be provided as second parameter}
 
 if .buildkite/commands/should-skip-job.sh --job-type validation; then
   exit 0

--- a/.buildkite/commands/run-e2e-tests.sh
+++ b/.buildkite/commands/run-e2e-tests.sh
@@ -4,9 +4,10 @@ set -euo pipefail
 PLATFORM=${1:-}
 ARCH=${2:-}
 
-if .buildkite/commands/should-skip-job.sh --job-type validation; then
-  exit 0
-fi
+# TODO: Re-enable once implementation has been verified. See AINFRA-1888
+# if .buildkite/commands/should-skip-job.sh --job-type validation; then
+#   exit 0
+# fi
 
 echo '--- :package: Install deps'
 bash .buildkite/commands/install-node-dependencies.sh

--- a/.buildkite/commands/run-e2e-tests.sh
+++ b/.buildkite/commands/run-e2e-tests.sh
@@ -37,19 +37,15 @@ npx electron-vite build --outDir=dist && npx electron-forge package --arch="$ARC
 echo '--- :playwright: Run End To End Tests'
 
 # For mac-x64 on Apple Silicon: install Rosetta and run under x86_64 arch
+arch_prefix=''
 if [ "$PLATFORM" = "mac" ] && [ "$ARCH" = "x64" ]; then
-  echo 'Installing Rosetta for x64 emulation...'
-  softwareupdate --install-rosetta --agree-to-license || true
-
-  echo 'Installing Playwright browsers (x64)...'
-  arch -x86_64 npx playwright install
-
-  echo 'Running Playwright tests (x64 via Rosetta)...'
-  arch -x86_64 npx playwright test
-else
-  echo 'Installing Playwright browsers...'
-  npx playwright install
-
-  echo 'Running Playwright tests...'
-  npx playwright test
+  echo '~~~ Installing Rosetta for x64 emulation...'
+  softwareupdate --install-rosetta --agree-to-license
+  arch_prefix='arch -x86_64 '
 fi
+
+echo '~~~ Installing Playwright browsers...'
+"${arch_prefix}npx playwright install"
+
+echo '~~~ Running Playwright tests...'
+"${arch_prefix}npx playwright test"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -36,41 +36,39 @@ steps:
   # - windows-x64: Native on x64 agents
   # - windows-arm64: Skipped via matrix adjustment
   #   x64 Windows cannot run arm64 binaries (no emulation layer exists)
-  - group: E2E Tests
-    steps:
-      - label: "E2E Tests on {{matrix.platform}}-{{matrix.arch}}"
-        key: e2e_tests
-        command: bash .buildkite/commands/run-e2e-tests.sh "{{matrix.platform}}" "{{matrix.arch}}"
-        artifact_paths:
-          - test-results/**/*.zip
-          - test-results/**/*.png
-          - test-results/**/*error-context.md
-        plugins: [$CI_TOOLKIT_PLUGIN, $NVM_PLUGIN]
-        agents:
-          queue: "{{matrix.platform}}"
-        env:
-          # See https://playwright.dev/docs/ci#debugging-browser-launches
-          DEBUG: "pw:browser"
-        matrix:
-          setup:
-            platform:
-              - mac
-              - windows
-            arch:
-              - x64
-              - arm64
-          adjustments:
-            - with:
-                platform: windows
-                arch: arm64
-              skip: true
-        # TODO: Re-enable after validating E2E tests on all platforms (AINFRA-1888)
-        # Skip E2E tests on draft PRs to save CI resources
-        # Tests will run automatically when PR is marked ready for review
-        # if: build.branch == 'trunk' || build.tag =~ /^v[0-9]+/ || !build.pull_request.draft
-        notify:
-          - github_commit_status:
-              context: E2E Tests
+  - label: E2E Tests on {{matrix.platform}}-{{matrix.arch}}
+    key: e2e_tests
+    command: bash .buildkite/commands/run-e2e-tests.sh "{{matrix.platform}}" "{{matrix.arch}}"
+    artifact_paths:
+      - test-results/**/*.zip
+      - test-results/**/*.png
+      - test-results/**/*error-context.md
+    plugins: [$CI_TOOLKIT_PLUGIN, $NVM_PLUGIN]
+    agents:
+      queue: "{{matrix.platform}}"
+    env:
+      # See https://playwright.dev/docs/ci#debugging-browser-launches
+      DEBUG: "pw:browser"
+    matrix:
+      setup:
+        platform:
+          - mac
+          - windows
+        arch:
+          - x64
+          - arm64
+      adjustments:
+        - with:
+            platform: windows
+            arch: arm64
+          skip: true
+    # TODO: Re-enable after validating E2E tests on all platforms (AINFRA-1888)
+    # Skip E2E tests on draft PRs to save CI resources
+    # Tests will run automatically when PR is marked ready for review
+    # if: build.branch == 'trunk' || build.tag =~ /^v[0-9]+/ || !build.pull_request.draft
+    notify:
+      - github_commit_status:
+          context: E2E Tests
 
   - label: ":chart_with_upwards_trend: Performance Metrics"
     key: metrics

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -50,9 +50,10 @@ steps:
     matrix:
       - mac
       - windows
+    # TODO: Re-enable after validating E2E tests on all platforms (AINFRA-1888)
     # Skip E2E tests on draft PRs to save CI resources
     # Tests will run automatically when PR is marked ready for review
-    if: build.branch == 'trunk' || build.tag =~ /^v[0-9]+/ || !build.pull_request.draft
+    # if: build.branch == 'trunk' || build.tag =~ /^v[0-9]+/ || !build.pull_request.draft
     notify:
       - github_commit_status:
           context: E2E Tests

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -50,21 +50,16 @@ steps:
       # See https://playwright.dev/docs/ci#debugging-browser-launches
       DEBUG: "pw:browser"
     matrix:
-      setup:
-        platform:
-          - mac
-          - windows
-        arch:
-          - x64
-          - arm64
+      # More details on this setup at https://github.com/Automattic/studio/pull/2530#discussion_r2763853223
+      #
+      # TL;DR: we're bending the syntax to limit the combinations.
+      setup: { platform: [_], arch: [_] }
       adjustments:
-        - with:
-            platform: mac
-            arch: x64
-          skip: true
-        - with:
-            platform: windows
-            arch: arm64
+        # Combinations to run
+        - with: { platform: mac, arch: arm64 }
+        - with: { platform: windows, arch: x64 }
+        # Skip the dummy value used to initiate the syntax.
+        - with: { platform: _, arch: _ }
           skip: true
     # Skip E2E tests on draft PRs to save CI resources
     # Tests will run automatically when PR is marked ready for review

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -38,7 +38,7 @@ steps:
   #   x64 Windows cannot run arm64 binaries (no emulation layer exists)
   - group: E2E Tests
     steps:
-      - label: E2E Tests on {{matrix.platform}}-{{matrix.arch}}
+      - label: "E2E Tests on {{matrix.platform}}-{{matrix.arch}}"
         key: e2e_tests
         command: bash .buildkite/commands/run-e2e-tests.sh "{{matrix.platform}}" "{{matrix.arch}}"
         artifact_paths:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -66,7 +66,6 @@ steps:
             platform: windows
             arch: arm64
           skip: true
-    # TODO: Re-enable after validating E2E tests on all platforms (AINFRA-1888)
     # Skip E2E tests on draft PRs to save CI resources
     # Tests will run automatically when PR is marked ready for review
     # if: build.branch == 'trunk' || build.tag =~ /^v[0-9]+/ || !build.pull_request.draft

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -36,39 +36,41 @@ steps:
   # - windows-x64: Native on x64 agents
   # - windows-arm64: Skipped via matrix adjustment
   #   x64 Windows cannot run arm64 binaries (no emulation layer exists)
-  - label: E2E Tests on {{matrix.platform}}-{{matrix.arch}}
-    key: e2e_tests
-    command: bash .buildkite/commands/run-e2e-tests.sh "{{matrix.platform}}" "{{matrix.arch}}"
-    artifact_paths:
-      - test-results/**/*.zip
-      - test-results/**/*.png
-      - test-results/**/*error-context.md
-    plugins: [$CI_TOOLKIT_PLUGIN, $NVM_PLUGIN]
-    agents:
-      queue: "{{matrix.platform}}"
-    env:
-      # See https://playwright.dev/docs/ci#debugging-browser-launches
-      DEBUG: "pw:browser"
-    matrix:
-      setup:
-        platform:
-          - mac
-          - windows
-        arch:
-          - x64
-          - arm64
-      adjustments:
-        - with:
-            platform: windows
-            arch: arm64
-          skip: true
-    # TODO: Re-enable after validating E2E tests on all platforms (AINFRA-1888)
-    # Skip E2E tests on draft PRs to save CI resources
-    # Tests will run automatically when PR is marked ready for review
-    # if: build.branch == 'trunk' || build.tag =~ /^v[0-9]+/ || !build.pull_request.draft
-    notify:
-      - github_commit_status:
-          context: E2E Tests
+  - group: E2E Tests
+    steps:
+      - label: E2E Tests on {{matrix.platform}}-{{matrix.arch}}
+        key: e2e_tests
+        command: bash .buildkite/commands/run-e2e-tests.sh "{{matrix.platform}}" "{{matrix.arch}}"
+        artifact_paths:
+          - test-results/**/*.zip
+          - test-results/**/*.png
+          - test-results/**/*error-context.md
+        plugins: [$CI_TOOLKIT_PLUGIN, $NVM_PLUGIN]
+        agents:
+          queue: "{{matrix.platform}}"
+        env:
+          # See https://playwright.dev/docs/ci#debugging-browser-launches
+          DEBUG: "pw:browser"
+        matrix:
+          setup:
+            platform:
+              - mac
+              - windows
+            arch:
+              - x64
+              - arm64
+          adjustments:
+            - with:
+                platform: windows
+                arch: arm64
+              skip: true
+        # TODO: Re-enable after validating E2E tests on all platforms (AINFRA-1888)
+        # Skip E2E tests on draft PRs to save CI resources
+        # Tests will run automatically when PR is marked ready for review
+        # if: build.branch == 'trunk' || build.tag =~ /^v[0-9]+/ || !build.pull_request.draft
+        notify:
+          - github_commit_status:
+              context: E2E Tests
 
   - label: ":chart_with_upwards_trend: Performance Metrics"
     key: metrics

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -30,8 +30,12 @@ steps:
       - github_commit_status:
           context: Unit Tests
 
-  # E2E tests run on all supported platform/architecture combinations.
-  # Builds for the target arch; runs on mac/windows queues (arm64 agents can run x64 via emulation).
+  # E2E tests run on supported platform/architecture combinations.
+  # - mac-x64: Runs via Rosetta on Apple Silicon agents
+  # - mac-arm64: Native on Apple Silicon agents
+  # - windows-x64: Native on x64 agents
+  # - windows-arm64: Skipped via matrix adjustment
+  #   x64 Windows cannot run arm64 binaries (no emulation layer exists)
   - label: E2E Tests on {{matrix.platform}}-{{matrix.arch}}
     key: e2e_tests
     command: bash .buildkite/commands/run-e2e-tests.sh "{{matrix.platform}}" "{{matrix.arch}}"
@@ -53,6 +57,11 @@ steps:
         arch:
           - x64
           - arm64
+      adjustments:
+        - with:
+            platform: windows
+            arch: arm64
+          skip: true
     # TODO: Re-enable after validating E2E tests on all platforms (AINFRA-1888)
     # Skip E2E tests on draft PRs to save CI resources
     # Tests will run automatically when PR is marked ready for review

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -31,11 +31,11 @@ steps:
           context: Unit Tests
 
   # E2E tests run on supported platform/architecture combinations.
-  # - mac-x64: Runs via Rosetta on Apple Silicon agents
   # - mac-arm64: Native on Apple Silicon agents
   # - windows-x64: Native on x64 agents
-  # - windows-arm64: Skipped via matrix adjustment
-  #   x64 Windows cannot run arm64 binaries (no emulation layer exists)
+  # Skipped via matrix adjustments:
+  # - mac-x64: https://linear.app/a8c/issue/AINFRA-1904
+  # - windows-arm64: x64 Windows cannot run arm64 binaries (no emulation layer)
   - label: E2E Tests on {{matrix.platform}}-{{matrix.arch}}
     key: e2e_tests
     command: bash .buildkite/commands/run-e2e-tests.sh "{{matrix.platform}}" "{{matrix.arch}}"
@@ -58,6 +58,10 @@ steps:
           - x64
           - arm64
       adjustments:
+        - with:
+            platform: mac
+            arch: x64
+          skip: true
         - with:
             platform: windows
             arch: arm64

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -30,26 +30,29 @@ steps:
       - github_commit_status:
           context: Unit Tests
 
-  # Notice that we use the queue name (matrix value) in the label.
-  # We could have added values for queue and label, but that would have resulted in 'macOS + windows' and 'Windows + mac' combinations, which we don't want.
-  # Buildkite offers an option to remove those combinations, but the overhead in code readability did not seem worth the visual effect in the build page.
-  # See https://buildkite.com/docs/pipelines/build-matrix#removing-combinations-from-the-build-matrix
-  - label: E2E Tests on {{matrix}}
+  # E2E tests run on all supported platform/architecture combinations.
+  # Builds for the target arch; runs on mac/windows queues (arm64 agents can run x64 via emulation).
+  - label: E2E Tests on {{matrix.platform}}-{{matrix.arch}}
     key: e2e_tests
-    command: bash .buildkite/commands/run-e2e-tests.sh "{{matrix}}"
+    command: bash .buildkite/commands/run-e2e-tests.sh "{{matrix.platform}}" "{{matrix.arch}}"
     artifact_paths:
       - test-results/**/*.zip
       - test-results/**/*.png
       - test-results/**/*error-context.md
     plugins: [$CI_TOOLKIT_PLUGIN, $NVM_PLUGIN]
     agents:
-      queue: "{{matrix}}"
+      queue: "{{matrix.platform}}"
     env:
       # See https://playwright.dev/docs/ci#debugging-browser-launches
       DEBUG: "pw:browser"
     matrix:
-      - mac
-      - windows
+      setup:
+        platform:
+          - mac
+          - windows
+        arch:
+          - x64
+          - arm64
     # TODO: Re-enable after validating E2E tests on all platforms (AINFRA-1888)
     # Skip E2E tests on draft PRs to save CI resources
     # Tests will run automatically when PR is marked ready for review

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -68,7 +68,7 @@ steps:
           skip: true
     # Skip E2E tests on draft PRs to save CI resources
     # Tests will run automatically when PR is marked ready for review
-    # if: build.branch == 'trunk' || build.tag =~ /^v[0-9]+/ || !build.pull_request.draft
+    if: build.branch == 'trunk' || build.tag =~ /^v[0-9]+/ || !build.pull_request.draft
     notify:
       - github_commit_status:
           context: E2E Tests


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- https://linear.app/a8c/issue/AINFRA-1903/run-e2e-on-windows-queue-alongside-mac

## Proposed Changes

- Sets up Buildkite matrix to run E2E tests on the `windows` queue, alongside the already established `mac` run
- Leaves the implementation open for further additions (see discussion in https://github.com/Automattic/studio/pull/2518#discussion_r2760549088)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Refer to the green CI run from https://buildkite.com/automattic/studio/builds/11139/steps/canvas, which run before the commit where I restored the job skip checks that prevent E2E from running when nothing relevant changed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors? — N.A.
