### PR TITLE
Fix performance test script to run on Windows

### DIFF
--- a/metrics/playwright.metrics.config.ts
+++ b/metrics/playwright.metrics.config.ts
@@ -25,6 +25,6 @@ export default defineConfig( {
 		video: 'off',
 	},
 	expect: {
-		timeout: 30_000, // 30 seconds.
+		timeout: 60_000, // 60 seconds.
 	},
 } );

--- a/metrics/playwright.metrics.config.ts
+++ b/metrics/playwright.metrics.config.ts
@@ -25,6 +25,6 @@ export default defineConfig( {
 		video: 'off',
 	},
 	expect: {
-		timeout: 60_000, // 60 seconds.
+		timeout: 40_000, // 40 seconds.
 	},
 } );

--- a/metrics/tests/site-editor.test.ts
+++ b/metrics/tests/site-editor.test.ts
@@ -25,6 +25,7 @@ test.describe( 'Site Editor Load Metrics', () => {
 		} );
 
 		await session.cleanup();
+		setTimeout( () => process.exit( 0 ), 1000 );
 	} );
 
 	test( 'measure site editor load time', async () => {

--- a/metrics/tests/site-startup.test.ts
+++ b/metrics/tests/site-startup.test.ts
@@ -44,7 +44,7 @@ test.describe( 'Startup Metrics', () => {
 			await onboarding.closeWhatsNew();
 
 			siteContent = new SiteContent( session.mainWindow, siteName );
-			await expect( siteContent.runningButton ).toBeAttached( { timeout: 90_000 } );
+			await expect( siteContent.runningButton ).toBeAttached();
 			const endTime = Date.now();
 			const duration = endTime - startTime;
 			results.siteCreation = [ duration ];
@@ -57,13 +57,13 @@ test.describe( 'Startup Metrics', () => {
 				// Stop the site by clicking the Running button
 				await siteContent.runningButton.click();
 				const startButton = siteContent.locator.getByRole( 'button', { name: 'Start' } );
-				await expect( startButton ).toBeAttached( { timeout: 60_000 } );
+				await expect( startButton ).toBeAttached();
 
 				// Start timer
 				const startTime = Date.now();
 				await startButton.click();
 				// Wait for site to be running
-				await expect( siteContent.runningButton ).toBeAttached( { timeout: 60_000 } );
+				await expect( siteContent.runningButton ).toBeAttached();
 				const endTime = Date.now();
 				const duration = endTime - startTime;
 

--- a/metrics/tests/site-startup.test.ts
+++ b/metrics/tests/site-startup.test.ts
@@ -30,6 +30,7 @@ test.describe( 'Startup Metrics', () => {
 		} );
 
 		await session.cleanup();
+		setTimeout( () => process.exit( 0 ), 1000 );
 	} );
 
 	test( 'measure site creation and startup performance', async () => {

--- a/metrics/tests/site-startup.test.ts
+++ b/metrics/tests/site-startup.test.ts
@@ -44,7 +44,7 @@ test.describe( 'Startup Metrics', () => {
 			await onboarding.closeWhatsNew();
 
 			siteContent = new SiteContent( session.mainWindow, siteName );
-			await expect( siteContent.runningButton ).toBeAttached();
+			await expect( siteContent.runningButton ).toBeAttached( { timeout: 90_000 } );
 			const endTime = Date.now();
 			const duration = endTime - startTime;
 			results.siteCreation = [ duration ];
@@ -57,13 +57,13 @@ test.describe( 'Startup Metrics', () => {
 				// Stop the site by clicking the Running button
 				await siteContent.runningButton.click();
 				const startButton = siteContent.locator.getByRole( 'button', { name: 'Start' } );
-				await expect( startButton ).toBeAttached();
+				await expect( startButton ).toBeAttached( { timeout: 60_000 } );
 
 				// Start timer
 				const startTime = Date.now();
 				await startButton.click();
 				// Wait for site to be running
-				await expect( siteContent.runningButton ).toBeAttached();
+				await expect( siteContent.runningButton ).toBeAttached( { timeout: 60_000 } );
 				const endTime = Date.now();
 				const duration = endTime - startTime;
 

--- a/scripts/compare-perf/config.ts
+++ b/scripts/compare-perf/config.ts
@@ -7,7 +7,7 @@ const config = {
 	gitRepositoryURL: 'https://github.com/Automattic/studio.git',
 	setupTestRunner: 'npm ci && npx playwright install chromium',
 	testCommand: 'npm run test:metrics',
-	setupCommand: 'npm ci && npm ci --prefix cli && IS_DEV_BUILD=true npm run package',
+	setupCommand: 'npm ci && npm ci --prefix cli && npm run package',
 	testsPath: 'metrics/tests',
 	testFileSuffix: '.test.ts',
 	artifactsPath,

--- a/scripts/compare-perf/performance.ts
+++ b/scripts/compare-perf/performance.ts
@@ -139,7 +139,11 @@ export async function runPerformanceTests(
 		throw new Error( `Need at least two git refs to run` );
 	}
 
-	const baseDir = path.join( os.tmpdir(), 'studio-performance-tests' );
+	const tmpDir =
+		process.platform === 'win32'
+			? path.join( process.env.USERPROFILE || os.homedir(), 'AppData', 'Local', 'Temp' )
+			: os.tmpdir();
+	const baseDir = path.join( tmpDir, 'studio-performance-tests' );
 
 	if ( fs.existsSync( baseDir ) ) {
 		logAtIndent( 1, 'Removing existing files' );
@@ -178,10 +182,10 @@ export async function runPerformanceTests(
 
 	logAtIndent( 1, 'Setting up test runner' );
 
-	const testRunnerDir = path.join( baseDir + '/tests' );
+	const testRunnerDir = path.join( baseDir, 'tests' );
 
 	logAtIndent( 2, 'Copying source to:', formats.success( testRunnerDir ) );
-	await runShellScript( `cp -R  ${ sourceDir } ${ testRunnerDir }` );
+	fs.cpSync( sourceDir, testRunnerDir, { recursive: true } );
 
 	logAtIndent( 2, 'Checking out branch:', formats.success( testRunnerBranch ) );
 	await simpleGit( testRunnerDir ).raw( 'checkout', testRunnerBranch );
@@ -210,7 +214,7 @@ export async function runPerformanceTests(
 		const buildDir = path.join( envDir, 'app' );
 
 		logAtIndent( 3, 'Copying source to:', formats.success( buildDir ) );
-		await runShellScript( `cp -R ${ sourceDir } ${ buildDir }` );
+		fs.cpSync( sourceDir, buildDir, { recursive: true } );
 
 		logAtIndent( 3, 'Checking out:', formats.success( branch ) );
 		await simpleGit( buildDir ).raw( 'checkout', branch );
@@ -219,6 +223,7 @@ export async function runPerformanceTests(
 		await runShellScript( config.setupCommand, buildDir, {
 			GITHUB_TOKEN: process.env.GITHUB_TOKEN,
 			SKIP_WORKER_THREAD_BUILD: process.env.SKIP_WORKER_THREAD_BUILD,
+			IS_DEV_BUILD: 'true',
 		} );
 	}
 


### PR DESCRIPTION
## Related issues

Related to STU-1279
Related to STU-980

## Proposed Changes
- Replace Unix-specific `cp -R` commands with Node.js `fs.cpSync()` for cross-platform compatibility
- Fix inline environment variable syntax (`IS_DEV_BUILD=true cmd`) that doesn't work on Windows by passing it via the env object
- Fix Windows short path issues (e.g., `IVANOT~1` instead of `ivanottinger`) that cause Vite/Rollup build failures by using `USERPROFILE` environment variable instead of `os.tmpdir()`
- Increase default expect timeout for tests (30s → 40s) for slower Windows environment
- Force exit after test cleanup to avoid Playwright's worker teardown timeout

## Testing Instructions
1. On Windows, run:
   - `cd scripts/compare-perf`
   - `npm run compare -- perf <branch1> <branch2> --ci --tests-branch fix/performance-tests-for-windows`
     - For example: `npm run compare -- perf trunk fix/performance-tests-for-windows --ci --tests-branch fix/performance-tests-for-windows`
2. Verify the script completes without path-related or "Worker teardown timeout" errors.
4. Check that performance results are displayed correctly.
5. Repeat the steps on macOS. Everything should work well there too.

## Pre-merge Checklist
- [ ] Have you checked for TypeScript, React or other console errors?