### PR TITLE
Fix site start/stop status by removing stale socket file

### DIFF
--- a/cli/commands/_events.ts
+++ b/cli/commands/_events.ts
@@ -6,6 +6,7 @@
  * stdout key-value pairs that Studio parses.
  *
  */
+import fs from 'fs';
 import { __ } from '@wordpress/i18n';
 import { sequential } from 'common/lib/sequential';
 import { SITE_EVENTS, siteDetailsSchema, SiteEvent } from 'common/lib/site-events';
@@ -137,6 +138,17 @@ export async function runCommand(): Promise< void > {
 				bindAbortController.signal.removeEventListener( 'abort', onAbort );
 				resolve();
 			} );
+
+			// Remove stale socket file before binding (Unix only).
+			// If Studio crashes or is killed, the socket file may be left behind,
+			// preventing the new _events process from binding.
+			if ( process.platform !== 'win32' ) {
+				try {
+					fs.unlinkSync( EVENTS_SOCKET_PATH );
+				} catch {
+					// File doesn't exist or can't be removed - that's fine
+				}
+			}
 
 			socket.bind( EVENTS_SOCKET_PATH, ( error: unknown ) => {
 				if ( error ) {


### PR DESCRIPTION
## Related issues

- Fixes STU-1278 STU-1255

## Proposed Changes

- Remove stale Unix socket file (`~/.studio/pm2/events.sock`) before binding in the `_events` command
- Only applies to Unix-based systems (macOS/Linux) since Windows named pipes are automatically cleaned up by the OS

**Root cause:** When Studio crashes or is force-killed, the socket file is left behind. On restart, the `_events` command cannot bind to this socket (EADDRINUSE), preventing site-event updates from flowing to the UI.

## Testing Instructions

1. Start Studio in dev mode (`npm start`)
2. Verify normal start/stop works - click Start/Stop on a site, status should update
3. Force-kill Studio without proper cleanup:
   ```bash
   pkill -9 -f "Electron.app"
   ```
4. Verify the stale socket file exists:
   ```bash
   ls -la ~/.studio/pm2/events.sock
   ```
5. Start Studio again (`npm start`)
6. Click Start/Stop on a site - status should update correctly (the fix removes the stale socket automatically)

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?