### PR TITLE
Studio: Fix backup extraction progress exceeding 100%

### DIFF
--- a/src/lib/import-export/import/handlers/backup-handler-tar-gz.ts
+++ b/src/lib/import-export/import/handlers/backup-handler-tar-gz.ts
@@ -73,13 +73,15 @@ export class BackupHandlerTarGz extends EventEmitter implements BackupHandler {
 							this.emit( ImportEvents.BACKUP_EXTRACT_WARNING, { message } );
 						},
 						onReadEntry: ( entry ) => {
-							currentFile = entry.path;
-							processedFiles++;
-							this.emit( ImportEvents.BACKUP_EXTRACT_FILE_START, {
-								currentFile,
-								processedFiles,
-								totalFiles,
-							} as BackupExtractProgressEventData );
+							if ( isFileAllowed( entry.path ) ) {
+								currentFile = entry.path;
+								processedFiles++;
+								this.emit( ImportEvents.BACKUP_EXTRACT_FILE_START, {
+									currentFile,
+									processedFiles,
+									totalFiles,
+								} as BackupExtractProgressEventData );
+							}
 						},
 					} )
 				)


### PR DESCRIPTION
## Related issues

- Fixes STU-1280

## Proposed Changes

- Fixed backup extraction progress exceeding 100% for tar.gz archives by ensuring processedFiles only counts files that pass the isFileAllowed() filter
- Added isFileAllowed() check in the onReadEntry callback to match how totalFiles is counted in listFiles()
- Progress indicator now correctly stays at or below 100% during extraction

### Production

https://github.com/user-attachments/assets/657d81cc-b03e-4152-85f0-c29d625cbba6


### This branch


https://github.com/user-attachments/assets/eb5a099a-dc45-4a4f-8fa1-502cd0724281



## Testing Instructions

To reproduce the original bug and verify the fix:

1. On `trunk` or using production, open Studio, navigate to the Import tab, and import the backup on the linked task STU-1280
2.  Observe progress exceeding 100% (e.g., 132%, 342%)
3. On this branch: Import the same backup and verify progress stays at or below 100%
4. Test with regular backups without excluded files to ensure normal extraction still works correctly

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
