### PR TITLE
Add safeguards for undefined sync state status (STU-1286)

### DIFF
--- a/src/hooks/sync-sites/tests/use-pull-push-states.test.ts
+++ b/src/hooks/sync-sites/tests/use-pull-push-states.test.ts
@@ -1,0 +1,84 @@
+import { renderHook, act } from '@testing-library/react';
+import { useState } from 'react';
+import {
+	usePullPushStates,
+	generateStateId,
+	type States,
+} from 'src/hooks/sync-sites/use-pull-push-states';
+
+type TestState = {
+	status: { key: string };
+	value: string;
+};
+
+function useStatesWrapper( initial: States< TestState > = {} ) {
+	const [ states, setStates ] = useState< States< TestState > >( initial );
+	const helpers = usePullPushStates< TestState >( states, setStates );
+	return { states, ...helpers };
+}
+
+describe( 'usePullPushStates', () => {
+	describe( 'updateState', () => {
+		it( 'should merge partial state into an existing entry', () => {
+			const key = generateStateId( 'site-1', 100 );
+			const initial: States< TestState > = {
+				[ key ]: { status: { key: 'in-progress' }, value: 'original' },
+			};
+			const { result } = renderHook( () => useStatesWrapper( initial ) );
+
+			act( () => {
+				result.current.updateState( 'site-1', 100, { value: 'updated' } );
+			} );
+
+			expect( result.current.states[ key ] ).toEqual( {
+				status: { key: 'in-progress' },
+				value: 'updated',
+			} );
+		} );
+
+		it( 'should create entry with partial state when key does not exist', () => {
+			const { result } = renderHook( () => useStatesWrapper() );
+
+			act( () => {
+				result.current.updateState( 'site-1', 100, { value: 'partial' } );
+			} );
+
+			const key = generateStateId( 'site-1', 100 );
+			// Entry is created but status is undefined - callers must handle this
+			expect( result.current.states[ key ] ).toBeDefined();
+			expect( result.current.states[ key ].status ).toBeUndefined();
+		} );
+	} );
+
+	describe( 'clearState', () => {
+		it( 'should remove an existing entry', () => {
+			const key = generateStateId( 'site-1', 100 );
+			const initial: States< TestState > = {
+				[ key ]: { status: { key: 'in-progress' }, value: 'test' },
+			};
+			const { result } = renderHook( () => useStatesWrapper( initial ) );
+
+			act( () => {
+				result.current.clearState( 'site-1', 100 );
+			} );
+
+			expect( result.current.states[ key ] ).toBeUndefined();
+		} );
+	} );
+
+	describe( 'getState', () => {
+		it( 'should return the state for a given key', () => {
+			const key = generateStateId( 'site-1', 100 );
+			const state = { status: { key: 'in-progress' }, value: 'test' };
+			const initial: States< TestState > = { [ key ]: state };
+			const { result } = renderHook( () => useStatesWrapper( initial ) );
+
+			expect( result.current.getState( 'site-1', 100 ) ).toEqual( state );
+		} );
+
+		it( 'should return undefined for a non-existent key', () => {
+			const { result } = renderHook( () => useStatesWrapper() );
+			expect( result.current.getState( 'site-1', 100 ) ).toBeUndefined();
+		} );
+	} );
+} );

--- a/src/hooks/sync-sites/use-sync-pull.ts
+++ b/src/hooks/sync-sites/use-sync-pull.ts
@@ -372,6 +372,14 @@ export function useSyncPull( {
 		const intervals: Record< string, NodeJS.Timeout > = {};
 
 		Object.entries( pullStates ).forEach( ( [ key, state ] ) => {
+			if ( ! state.status ) {
+				Sentry.captureMessage( 'Pull state missing status', {
+					level: 'warning',
+					extra: { stateKey: key, stateKeys: Object.keys( state ) },
+				} );
+				return;
+			}
+
 			if ( isKeyCancelled( state.status.key ) ) {
 				return;
 			}
@@ -389,7 +397,7 @@ export function useSyncPull( {
 	}, [ pullStates, fetchAndUpdateBackup, isKeyCancelled ] );
 
 	const isAnySitePulling = useMemo< boolean >( () => {
-		return Object.values( pullStates ).some( ( state ) => isKeyPulling( state.status.key ) );
+		return Object.values( pullStates ).some( ( state ) => isKeyPulling( state.status?.key ) );
 	}, [ pullStates, isKeyPulling ] );
 
 	const isSiteIdPulling = useCallback< IsSiteIdPulling >(
@@ -402,9 +410,9 @@ export function useSyncPull( {
 					return false;
 				}
 				if ( remoteSiteId !== undefined ) {
-					return isKeyPulling( state.status.key ) && state.remoteSiteId === remoteSiteId;
+					return isKeyPulling( state.status?.key ) && state.remoteSiteId === remoteSiteId;
 				}
-				return isKeyPulling( state.status.key );
+				return isKeyPulling( state.status?.key );
 			} );
 		},
 		[ pullStates, isKeyPulling ]

--- a/src/hooks/sync-sites/use-sync-push.ts
+++ b/src/hooks/sync-sites/use-sync-push.ts
@@ -388,6 +388,14 @@ export function useSyncPush( {
 		const intervals: Record< string, NodeJS.Timeout > = {};
 
 		Object.entries( pushStates ).forEach( ( [ key, state ] ) => {
+			if ( ! state.status ) {
+				Sentry.captureMessage( 'Push state missing status', {
+					level: 'warning',
+					extra: { stateKey: key, stateKeys: Object.keys( state ) },
+				} );
+				return;
+			}
+
 			if ( isKeyCancelled( state.status.key ) ) {
 				return;
 			}
@@ -446,7 +454,7 @@ export function useSyncPush( {
 		'sync-upload-progress',
 		( _event, payload: { selectedSiteId: string; remoteSiteId: number; progress: number } ) => {
 			const currentState = getPushState( payload.selectedSiteId, payload.remoteSiteId );
-			if ( currentState && isKeyUploading( currentState.status.key ) ) {
+			if ( currentState && isKeyUploading( currentState.status?.key ) ) {
 				const mappedProgress = mapUploadProgressToOverallProgress( payload.progress );
 
 				updatePushState( payload.selectedSiteId, payload.remoteSiteId, {
@@ -461,7 +469,7 @@ export function useSyncPush( {
 	);
 
 	const isAnySitePushing = useMemo< boolean >( () => {
-		return Object.values( pushStates ).some( ( state ) => isKeyPushing( state.status.key ) );
+		return Object.values( pushStates ).some( ( state ) => isKeyPushing( state.status?.key ) );
 	}, [ pushStates, isKeyPushing ] );
 
 	const isSiteIdPushing = useCallback< IsSiteIdPushing >(
@@ -474,9 +482,9 @@ export function useSyncPush( {
 					return false;
 				}
 				if ( remoteSiteId !== undefined ) {
-					return isKeyPushing( state.status.key ) && state.remoteSiteId === remoteSiteId;
+					return isKeyPushing( state.status?.key ) && state.remoteSiteId === remoteSiteId;
 				}
-				return isKeyPushing( state.status.key );
+				return isKeyPushing( state.status?.key );
 			} );
 		},
 		[ pushStates, isKeyPushing ]


### PR DESCRIPTION
## Summary
- Adds optional chaining (`?.`) on all `state.status.key` accesses in `use-sync-pull.ts` and `use-sync-push.ts` to prevent `TypeError: Cannot read properties of undefined (reading 'key')` crashes
- Adds Sentry warning when a state entry with missing `status` is detected, providing visibility into the root cause
- Adds unit tests for `usePullPushStates` documenting that partial updates on non-existent keys can create incomplete entries

Fixes [STU-1286](https://linear.app/a8c/issue/STU-1286)

## Test plan
- [ ] Pull a site from WordPress.com — verify it completes successfully
- [ ] Push a site to WordPress.com — verify it completes successfully
- [ ] Cancel a pull/push mid-operation — verify state clears properly
- [ ] Run `npm test -- src/hooks/sync-sites/tests/use-pull-push-states.test.ts` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)