### PR TITLE
Add ability to start all stopped sites

### DIFF
--- a/src/components/running-sites.tsx
+++ b/src/components/running-sites.tsx
@@ -4,34 +4,45 @@ import Button from 'src/components/button';
 import { useSiteDetails } from 'src/hooks/use-site-details';
 import { cx } from 'src/lib/cx';
 
+const linkButtonClassName = cx(
+	'[&.is-link]:text-white [&.is-link:disabled]:hover:text-white [&.is-link:not(:disabled)]:hover:text-a8c-gray-10 [&.is-link]:text-right text-xxs leading-4 !mb-0 items-start'
+);
+
 export function RunningSites() {
 	const { __, _n } = useI18n();
-	const { sites, stopAllRunningSites } = useSiteDetails();
+	const { sites, stopAllRunningSites, startAllStoppedSites, loadingServer } = useSiteDetails();
 
 	const runningSites = sites.filter( ( site ) => site.running );
+	const realSites = sites.filter( ( site ) => ! site.isAddingSite );
+	const hasLoadingSites = Object.values( loadingServer ).some( Boolean );
+	const anyRunning = runningSites.length > 0;
+
+	if ( realSites.length === 0 ) {
+		return null;
+	}
 
 	return (
-		<>
-			{ runningSites.length > 0 && (
-				<div className="flex flex-row px-5 pb-1 justify-between align-center self-stretch opacity-70">
-					<p className="text-xxs leading-4">
-						{ sprintf(
-							_n( '%d site running', '%d sites running', runningSites.length ),
-							runningSites.length
-						) }
-					</p>
-					<Button
-						disabled={ runningSites.length === 0 }
-						className={ cx(
-							'[&.is-link]:text-white [&.is-link:disabled]:hover:text-white [&.is-link:not(:disabled)]:hover:text-a8c-gray-10 [&.is-link]:text-right text-xxs leading-4 !mb-0 items-start'
-						) }
-						onClick={ stopAllRunningSites }
-						variant="link"
-					>
-						{ runningSites.length === 1 ? __( 'Stop' ) : __( 'Stop all' ) }
-					</Button>
-				</div>
+		<div className="flex flex-row px-5 pb-1 justify-between align-center self-stretch opacity-70">
+			<p className="text-xxs leading-4">
+				{ sprintf(
+					_n( '%d site running', '%d sites running', runningSites.length ),
+					runningSites.length
+				) }
+			</p>
+			{ anyRunning ? (
+				<Button className={ linkButtonClassName } onClick={ stopAllRunningSites } variant="link">
+					{ runningSites.length === 1 ? __( 'Stop' ) : __( 'Stop all' ) }
+				</Button>
+			) : (
+				<Button
+					disabled={ hasLoadingSites }
+					className={ linkButtonClassName }
+					onClick={ startAllStoppedSites }
+					variant="link"
+				>
+					{ realSites.length === 1 ? __( 'Start' ) : __( 'Start all' ) }
+				</Button>
 			) }
-		</>
+		</div>
 	);
 }

--- a/src/components/running-sites.tsx
+++ b/src/components/running-sites.tsx
@@ -24,10 +24,12 @@ export function RunningSites() {
 	return (
 		<div className="flex flex-row px-5 pb-1 justify-between align-center self-stretch opacity-70">
 			<p className="text-xxs leading-4">
-				{ sprintf(
-					_n( '%d site running', '%d sites running', runningSites.length ),
-					runningSites.length
-				) }
+				{ anyRunning
+					? sprintf(
+							_n( '%d site running', '%d sites running', runningSites.length ),
+							runningSites.length
+					  )
+					: __( 'No sites running' ) }
 			</p>
 			{ anyRunning ? (
 				<Button className={ linkButtonClassName } onClick={ stopAllRunningSites } variant="link">

--- a/src/components/tests/running-sites.test.tsx
+++ b/src/components/tests/running-sites.test.tsx
@@ -71,7 +71,7 @@ describe( 'RunningSites', () => {
 		mockSiteDetails( { sites: [ stoppedSite( '1' ), stoppedSite( '2' ) ] } );
 		render( <RunningSites /> );
 		expect( screen.getByText( 'Start all' ) ).toBeInTheDocument();
-		expect( screen.getByText( '0 sites running' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'No sites running' ) ).toBeInTheDocument();
 	} );
 
 	it( 'should show "Start" when a single site is stopped', () => {

--- a/src/components/tests/running-sites.test.tsx
+++ b/src/components/tests/running-sites.test.tsx
@@ -1,0 +1,137 @@
+import { render, screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import { vi } from 'vitest';
+import { RunningSites } from 'src/components/running-sites';
+import { useSiteDetails } from 'src/hooks/use-site-details';
+import { createMock } from 'src/lib/test-utils';
+
+vi.mock( 'src/hooks/use-site-details' );
+
+vi.mock( '@wordpress/react-i18n', () => ( {
+	useI18n: () => ( {
+		__: ( text: string ) => text,
+		_n: ( single: string, plural: string, count: number ) => ( count === 1 ? single : plural ),
+	} ),
+} ) );
+
+const mockStopAllRunningSites = vi.fn();
+const mockStartAllStoppedSites = vi.fn();
+
+function mockSiteDetails( overrides: Partial< ReturnType< typeof useSiteDetails > > ) {
+	vi.mocked( useSiteDetails ).mockReturnValue(
+		createMock< ReturnType< typeof useSiteDetails > >( {
+			sites: [],
+			stopAllRunningSites: mockStopAllRunningSites,
+			startAllStoppedSites: mockStartAllStoppedSites,
+			loadingServer: {},
+			...overrides,
+		} )
+	);
+}
+
+const runningSite = ( id: string ) => ( {
+	id,
+	name: `Site ${ id }`,
+	path: `/path/${ id }`,
+	port: 8881,
+	phpVersion: '8.3',
+	running: true as const,
+	url: `http://localhost:8881`,
+} );
+
+const stoppedSite = ( id: string ) => ( {
+	id,
+	name: `Site ${ id }`,
+	path: `/path/${ id }`,
+	port: 8881,
+	phpVersion: '8.3',
+	running: false as const,
+} );
+
+describe( 'RunningSites', () => {
+	beforeEach( () => {
+		vi.clearAllMocks();
+	} );
+
+	it( 'should render nothing when there are no sites', () => {
+		mockSiteDetails( { sites: [] } );
+		const { container } = render( <RunningSites /> );
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	it( 'should render nothing when all sites are being added', () => {
+		mockSiteDetails( {
+			sites: [ { ...stoppedSite( '1' ), isAddingSite: true } ],
+		} );
+		const { container } = render( <RunningSites /> );
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	it( 'should show "Start all" when no sites are running', () => {
+		mockSiteDetails( { sites: [ stoppedSite( '1' ), stoppedSite( '2' ) ] } );
+		render( <RunningSites /> );
+		expect( screen.getByText( 'Start all' ) ).toBeInTheDocument();
+		expect( screen.getByText( '0 sites running' ) ).toBeInTheDocument();
+	} );
+
+	it( 'should show "Start" when a single site is stopped', () => {
+		mockSiteDetails( { sites: [ stoppedSite( '1' ) ] } );
+		render( <RunningSites /> );
+		expect( screen.getByText( 'Start' ) ).toBeInTheDocument();
+	} );
+
+	it( 'should call startAllStoppedSites when Start all is clicked', async () => {
+		mockSiteDetails( { sites: [ stoppedSite( '1' ), stoppedSite( '2' ) ] } );
+		render( <RunningSites /> );
+		const user = userEvent.setup();
+		await user.click( screen.getByText( 'Start all' ) );
+		expect( mockStartAllStoppedSites ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'should disable Start all while sites are loading', () => {
+		mockSiteDetails( {
+			sites: [ stoppedSite( '1' ), stoppedSite( '2' ) ],
+			loadingServer: { '1': true },
+		} );
+		render( <RunningSites /> );
+		expect( screen.getByText( 'Start all' ).closest( 'button' ) ).toBeDisabled();
+	} );
+
+	it( 'should show "Stop" for a single running site', () => {
+		mockSiteDetails( { sites: [ runningSite( '1' ) ] } );
+		render( <RunningSites /> );
+		expect( screen.getByText( 'Stop' ) ).toBeInTheDocument();
+		expect( screen.getByText( '1 site running' ) ).toBeInTheDocument();
+	} );
+
+	it( 'should show "Stop all" for multiple running sites', () => {
+		mockSiteDetails( { sites: [ runningSite( '1' ), runningSite( '2' ) ] } );
+		render( <RunningSites /> );
+		expect( screen.getByText( 'Stop all' ) ).toBeInTheDocument();
+		expect( screen.getByText( '2 sites running' ) ).toBeInTheDocument();
+	} );
+
+	it( 'should call stopAllRunningSites when Stop all is clicked', async () => {
+		mockSiteDetails( { sites: [ runningSite( '1' ), runningSite( '2' ) ] } );
+		render( <RunningSites /> );
+		const user = userEvent.setup();
+		await user.click( screen.getByText( 'Stop all' ) );
+		expect( mockStopAllRunningSites ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'should show "Stop all" in mixed state (some running, some stopped)', () => {
+		mockSiteDetails( { sites: [ runningSite( '1' ), stoppedSite( '2' ) ] } );
+		render( <RunningSites /> );
+		expect( screen.getByText( 'Stop' ) ).toBeInTheDocument();
+		expect( screen.getByText( '1 site running' ) ).toBeInTheDocument();
+		expect( screen.queryByText( 'Start' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'should exclude isAddingSite sites from real sites count', () => {
+		mockSiteDetails( {
+			sites: [ { ...stoppedSite( '1' ), isAddingSite: true }, stoppedSite( '2' ) ],
+		} );
+		render( <RunningSites /> );
+		expect( screen.getByText( 'Start' ) ).toBeInTheDocument();
+	} );
+} );

--- a/src/hooks/tests/use-site-details.test.tsx
+++ b/src/hooks/tests/use-site-details.test.tsx
@@ -107,6 +107,67 @@ describe( 'useSiteDetails', () => {
 		} );
 	} );
 
+	describe( 'startAllStoppedSites', () => {
+		it( 'should start all stopped sites', async () => {
+			const sitesWithMixedState = [
+				{
+					...mockSites[ 0 ],
+					running: true as const,
+					autoStart: false,
+					url: 'http://localhost:1234',
+				},
+				{ ...mockSites[ 1 ], running: false as const, autoStart: false },
+				{ ...mockSites[ 2 ], running: false as const, autoStart: false },
+			];
+			vi.mocked( getIpcApi, { partial: true } ).mockReturnValue( {
+				getSiteDetails: vi.fn().mockResolvedValue( sitesWithMixedState ),
+				startServer: vi.fn( () => Promise.resolve() ),
+			} );
+
+			const { result } = renderHook( () => useSiteDetails(), { wrapper } );
+
+			await waitFor( () => {
+				expect( result.current.loadingSites ).toBe( false );
+			} );
+
+			vi.mocked( getIpcApi().startServer ).mockClear();
+
+			await act( async () => {
+				await result.current.startAllStoppedSites();
+			} );
+
+			expect( getIpcApi().startServer ).toHaveBeenCalledWith( 'site-2' );
+			expect( getIpcApi().startServer ).toHaveBeenCalledWith( 'site-3' );
+			expect( getIpcApi().startServer ).not.toHaveBeenCalledWith( 'site-1' );
+		} );
+
+		it( 'should not start sites that are being added', async () => {
+			const sitesWithAdding = [
+				{ ...mockSites[ 0 ], running: false as const, autoStart: false },
+				{ ...mockSites[ 1 ], running: false as const, autoStart: false, isAddingSite: true },
+			];
+			vi.mocked( getIpcApi, { partial: true } ).mockReturnValue( {
+				getSiteDetails: vi.fn().mockResolvedValue( sitesWithAdding ),
+				startServer: vi.fn( () => Promise.resolve() ),
+			} );
+
+			const { result } = renderHook( () => useSiteDetails(), { wrapper } );
+
+			await waitFor( () => {
+				expect( result.current.loadingSites ).toBe( false );
+			} );
+
+			vi.mocked( getIpcApi().startServer ).mockClear();
+
+			await act( async () => {
+				await result.current.startAllStoppedSites();
+			} );
+
+			expect( getIpcApi().startServer ).toHaveBeenCalledWith( 'site-1' );
+			expect( getIpcApi().startServer ).not.toHaveBeenCalledWith( 'site-2' );
+		} );
+	} );
+
 	describe( 'site deletion selection behavior', () => {
 		it( 'should select first site when deleting the currently selected site', async () => {
 			const { result } = renderHook( () => useSiteDetails(), { wrapper } );

--- a/src/hooks/use-site-details.tsx
+++ b/src/hooks/use-site-details.tsx
@@ -39,6 +39,7 @@ interface SiteDetailsContext {
 	startServer: ( id: string ) => Promise< void >;
 	stopServer: ( id: string ) => Promise< void >;
 	stopAllRunningSites: () => Promise< void >;
+	startAllStoppedSites: () => Promise< void >;
 	deleteSite: ( id: string, removeLocal: boolean ) => Promise< void >;
 	loadingServer: Record< string, boolean >;
 	loadingSites: boolean;
@@ -61,6 +62,7 @@ const defaultContext: SiteDetailsContext = {
 	startServer: async () => undefined,
 	stopServer: async () => undefined,
 	stopAllRunningSites: async () => undefined,
+	startAllStoppedSites: async () => undefined,
 	deleteSite: async () => undefined,
 	loadingServer: {},
 	loadingSites: true,
@@ -501,6 +503,11 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 		await getIpcApi().stopAllServers();
 	}, [] );
 
+	const startAllStoppedSites = useCallback( async () => {
+		const stoppedSites = sites.filter( ( site ) => ! site.running && ! site.isAddingSite );
+		await Promise.allSettled( stoppedSites.map( ( site ) => startServer( site.id ) ) );
+	}, [ sites, startServer ] );
+
 	const [ isEditModalOpen, setIsEditModalOpen ] = useState( false );
 	const selectedSite = sites.find( ( site ) => site.id === selectedSiteId ) || firstSite;
 
@@ -519,6 +526,7 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 			startServer,
 			stopServer,
 			stopAllRunningSites,
+			startAllStoppedSites,
 			loadingServer,
 			deleteSite: onDeleteSite,
 			isDeleting: selectedSiteId ? isDeleting[ selectedSiteId ] : false,
@@ -539,6 +547,7 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 			startServer,
 			stopServer,
 			stopAllRunningSites,
+			startAllStoppedSites,
 			loadingServer,
 			onDeleteSite,
 			selectedSiteId,


### PR DESCRIPTION
## Related issues

- Fixes STU-84

## Proposed Changes

I propose to add an ability to start all stopped sites. I kept "Start all" only for case in which no sites are running, and "Stop all" for all other cases to keep UI simple.

<img width="230" height="137" alt="CleanShot 2026-02-06 at 14 01 29" src="https://github.com/user-attachments/assets/94025752-99cc-499f-be1c-0e32e9c3e0d7" />

<img width="223" height="131" alt="CleanShot 2026-02-06 at 14 01 47" src="https://github.com/user-attachments/assets/54fe8ab3-08bd-4a8e-9ec6-4049d4e56168" />

<img width="227" height="131" alt="CleanShot 2026-02-06 at 14 02 24" src="https://github.com/user-attachments/assets/3761e512-f731-4c18-934c-d2b0fb511d48" />

## Testing Instructions

1. Create 2+ sites in the app
2. Stop all sites — verify "Start all" button appears in sidebar
3. Click "Start all" — verify all sites start
4. Stop some sites — verify "Stop all" button is shown and "Start" is disabled