### PR TITLE
Rename JSON keys to camelCase in site status output

### DIFF
--- a/cli/commands/site/status.ts
+++ b/cli/commands/site/status.ts
@@ -35,25 +35,33 @@ export async function runCommand( siteFolder: string, format: 'table' | 'json' )
 
 		const siteData: {
 			key: string;
+			jsonKey: string;
 			value: string | undefined;
 			type?: string;
 			hidden?: boolean;
 		}[] = [
-			{ key: __( 'Site URL' ), value: new URL( siteUrl ).toString(), type: 'url' },
+			{
+				key: __( 'Site URL' ),
+				jsonKey: 'siteUrl',
+				value: new URL( siteUrl ).toString(),
+				type: 'url',
+			},
 			{
 				key: __( 'Auto-login URL' ),
+				jsonKey: 'autoLoginUrl',
 				value: autoLoginUrl.toString(),
 				type: 'url',
 				hidden: ! isOnline,
 			},
-			{ key: __( 'Site Path' ), value: sitePath },
-			{ key: __( 'Status' ), value: status },
-			{ key: __( 'PHP version' ), value: site.phpVersion },
-			{ key: __( 'WP version' ), value: wpVersion },
-			{ key: __( 'Xdebug' ), value: xdebugStatus },
-			{ key: __( 'Admin username' ), value: 'admin' },
+			{ key: __( 'Site Path' ), jsonKey: 'sitePath', value: sitePath },
+			{ key: __( 'Status' ), jsonKey: 'status', value: status },
+			{ key: __( 'PHP version' ), jsonKey: 'phpVersion', value: site.phpVersion },
+			{ key: __( 'WP version' ), jsonKey: 'wpVersion', value: wpVersion },
+			{ key: __( 'Xdebug' ), jsonKey: 'xdebug', value: xdebugStatus },
+			{ key: __( 'Admin username' ), jsonKey: 'adminUsername', value: 'admin' },
 			{
 				key: __( 'Admin password' ),
+				jsonKey: 'adminPassword',
 				value: site.adminPassword ? decodePassword( site.adminPassword ) : undefined,
 			},
 		].filter( ( { value, hidden } ) => value && ! hidden );
@@ -74,7 +82,9 @@ export async function runCommand( siteFolder: string, format: 'table' | 'json' )
 
 			console.table( table.toString() );
 		} else {
-			const logData = Object.fromEntries( siteData.map( ( { key, value } ) => [ key, value ] ) );
+			const logData = Object.fromEntries(
+				siteData.map( ( { jsonKey, value } ) => [ jsonKey, value ] )
+			);
 
 			console.log( JSON.stringify( logData, null, 2 ) );
 		}

--- a/cli/commands/site/tests/status.test.ts
+++ b/cli/commands/site/tests/status.test.ts
@@ -79,14 +79,14 @@ describe( 'CLI: studio site status', () => {
 			expect( consoleSpy ).toHaveBeenCalledWith(
 				JSON.stringify(
 					{
-						'Site URL': 'http://localhost:8080/',
-						'Site Path': '/path/to/site',
-						Status: '🔴 Offline',
-						'PHP version': '8.0',
-						'WP version': '6.4',
-						Xdebug: 'Disabled',
-						'Admin username': 'admin',
-						'Admin password': 'password123',
+						siteUrl: 'http://localhost:8080/',
+						sitePath: '/path/to/site',
+						status: '🔴 Offline',
+						phpVersion: '8.0',
+						wpVersion: '6.4',
+						xdebug: 'Disabled',
+						adminUsername: 'admin',
+						adminPassword: 'password123',
 					},
 					null,
 					2
@@ -111,15 +111,15 @@ describe( 'CLI: studio site status', () => {
 			expect( consoleSpy ).toHaveBeenCalledWith(
 				JSON.stringify(
 					{
-						'Site URL': 'http://localhost:8080/',
-						'Auto-login URL': 'http://localhost:8080/studio-auto-login?redirect_to=%2Fwp-admin%2F',
-						'Site Path': '/path/to/site',
-						Status: '🟢 Online',
-						'PHP version': '8.0',
-						'WP version': '6.4',
-						Xdebug: 'Disabled',
-						'Admin username': 'admin',
-						'Admin password': 'password123',
+						siteUrl: 'http://localhost:8080/',
+						autoLoginUrl: 'http://localhost:8080/studio-auto-login?redirect_to=%2Fwp-admin%2F',
+						sitePath: '/path/to/site',
+						status: '🟢 Online',
+						phpVersion: '8.0',
+						wpVersion: '6.4',
+						xdebug: 'Disabled',
+						adminUsername: 'admin',
+						adminPassword: 'password123',
 					},
 					null,
 					2
@@ -153,12 +153,12 @@ describe( 'CLI: studio site status', () => {
 			expect( consoleSpy ).toHaveBeenCalledWith(
 				JSON.stringify(
 					{
-						'Site URL': 'http://localhost:8080/',
-						'Site Path': '/path/to/site',
-						Status: '🔴 Offline',
-						'WP version': '6.4',
-						Xdebug: 'Disabled',
-						'Admin username': 'admin',
+						siteUrl: 'http://localhost:8080/',
+						sitePath: '/path/to/site',
+						status: '🔴 Offline',
+						wpVersion: '6.4',
+						xdebug: 'Disabled',
+						adminUsername: 'admin',
 					},
 					null,
 					2


### PR DESCRIPTION
## Related issues

- Fixes STU-1271

## Proposed Changes

- Add `toCamelCase` helper function to `cli/lib/utils.ts` for converting space and hyphen-separated strings to camelCase
- Apply the conversion to JSON output in `site status --format=json` (e.g., `"Site URL"` → `"siteUrl"`, `"Auto-login URL"` → `"autoLoginUrl"`)
- Table format remains unchanged with human-readable keys
- Update test expectations to validate camelCase JSON keys

## Testing Instructions

1. Run unit tests: `npm test -- cli/lib/tests/utils.test.ts cli/commands/site/tests/status.test.ts`
2. Build CLI: `npm run cli:build`
3. Test JSON output: `node dist/cli/main.js site status --format=json` (keys should be camelCase)
4. Verify table format: `node dist/cli/main.js site status --format=table` (keys should remain human-readable)
5. Cross-platform testing completed on macOS and Windows ARM64

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?