### PR TITLE
Bundle WordPress translation files for faster site creation

### DIFF
--- a/cli/commands/site/create.ts
+++ b/cli/commands/site/create.ts
@@ -202,9 +202,6 @@ export async function runCommand(
 			}
 
 			if ( usedBundledPacks ) {
-				// Bundled core translations are already on disk. Use defineWpConfigConsts
-				// to set WPLANG in wp-config.php (matching what setSiteLanguage does)
-				// and setSiteOptions to persist it in the database.
 				setupSteps.push(
 					{
 						step: 'defineWpConfigConsts',

--- a/cli/commands/site/create.ts
+++ b/cli/commands/site/create.ts
@@ -43,6 +43,7 @@ import {
 	updateSiteAutoStart,
 	updateSiteLatestCliPid,
 } from 'cli/lib/appdata';
+import { copyLanguagePackToSite } from 'cli/lib/language-packs';
 import { connect, disconnect, emitSiteEvent } from 'cli/lib/pm2-manager';
 import { getServerFilesPath } from 'cli/lib/server-files';
 import { getPreferredSiteLanguage } from 'cli/lib/site-language';
@@ -189,10 +190,36 @@ export async function runCommand(
 
 		const setupSteps: StepDefinition[] = [];
 
-		if ( isOnlineStatus ) {
-			const siteLanguage = await getPreferredSiteLanguage( options.wpVersion );
+		const siteLanguage = await getPreferredSiteLanguage( options.wpVersion );
 
-			if ( siteLanguage && siteLanguage !== DEFAULT_LOCALE ) {
+		if ( siteLanguage && siteLanguage !== DEFAULT_LOCALE ) {
+			// For the 'latest' WP version, try using bundled language packs first to avoid
+			// a network round-trip. Fall back to the Playground setSiteLanguage step for
+			// non-latest versions or when bundled packs aren't available.
+			let usedBundledPacks = false;
+			if ( options.wpVersion === DEFAULT_WORDPRESS_VERSION ) {
+				usedBundledPacks = await copyLanguagePackToSite( sitePath, siteLanguage );
+			}
+
+			if ( usedBundledPacks ) {
+				// Bundled core translations are already on disk. Use defineWpConfigConsts
+				// to set WPLANG in wp-config.php (matching what setSiteLanguage does)
+				// and setSiteOptions to persist it in the database.
+				setupSteps.push(
+					{
+						step: 'defineWpConfigConsts',
+						consts: {
+							WPLANG: siteLanguage,
+						},
+					},
+					{
+						step: 'setSiteOptions',
+						options: {
+							WPLANG: siteLanguage,
+						},
+					}
+				);
+			} else if ( isOnlineStatus ) {
 				setupSteps.push(
 					{
 						step: 'setSiteLanguage',

--- a/cli/commands/site/tests/create.test.ts
+++ b/cli/commands/site/tests/create.test.ts
@@ -23,6 +23,7 @@ import {
 	updateSiteAutoStart,
 	SiteData,
 } from 'cli/lib/appdata';
+import { copyLanguagePackToSite } from 'cli/lib/language-packs';
 import { connect, disconnect } from 'cli/lib/pm2-manager';
 import { getServerFilesPath } from 'cli/lib/server-files';
 import { getPreferredSiteLanguage } from 'cli/lib/site-language';
@@ -59,6 +60,7 @@ vi.mock( 'cli/lib/appdata', async () => {
 		getSiteUrl: vi.fn( ( site ) => `http://localhost:${ site.port }` ),
 	};
 } );
+vi.mock( 'cli/lib/language-packs' );
 vi.mock( 'cli/lib/pm2-manager' );
 vi.mock( 'cli/lib/server-files', () => ( {
 	getServerFilesPath: vi.fn( () => '/test/server-files' ),
@@ -157,6 +159,7 @@ describe( 'CLI: studio site create', () => {
 		);
 		vi.mocked( isOnline ).mockResolvedValue( true );
 		vi.mocked( getPreferredSiteLanguage ).mockResolvedValue( 'en' );
+		vi.mocked( copyLanguagePackToSite ).mockResolvedValue( false );
 	} );
 
 	afterEach( () => {
@@ -608,6 +611,99 @@ describe( 'CLI: studio site create', () => {
 			expect( startWordPressServer ).not.toHaveBeenCalled();
 			expect( consoleLogSpy ).toHaveBeenCalledWith( 'Site created successfully' );
 			expect( disconnect ).toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'Language Packs', () => {
+		it( 'should use bundled language packs and skip setSiteLanguage for latest WP version', async () => {
+			vi.mocked( getPreferredSiteLanguage ).mockResolvedValue( 'sv_SE' );
+			vi.mocked( copyLanguagePackToSite ).mockResolvedValue( true );
+
+			await runCommand( mockSitePath, { ...defaultTestOptions } );
+
+			expect( copyLanguagePackToSite ).toHaveBeenCalledWith( mockSitePath, 'sv_SE' );
+			expect( startWordPressServer ).toHaveBeenCalledWith(
+				expect.anything(),
+				expect.any( Logger ),
+				expect.objectContaining( {
+					blueprint: expect.objectContaining( {
+						steps: expect.arrayContaining( [
+							expect.objectContaining( {
+								step: 'defineWpConfigConsts',
+								consts: { WPLANG: 'sv_SE' },
+							} ),
+							expect.objectContaining( {
+								step: 'setSiteOptions',
+								options: { WPLANG: 'sv_SE' },
+							} ),
+						] ),
+					} ),
+				} )
+			);
+			// Should NOT include setSiteLanguage step
+			const calls = vi.mocked( startWordPressServer ).mock.calls;
+			const blueprintSteps = ( calls[ 0 ][ 2 ] as { blueprint?: Blueprint } )?.blueprint
+				?.steps as StepDefinition[];
+			expect( blueprintSteps.some( ( s ) => s.step === 'setSiteLanguage' ) ).toBe( false );
+		} );
+
+		it( 'should fall back to setSiteLanguage when bundled packs are not available', async () => {
+			vi.mocked( getPreferredSiteLanguage ).mockResolvedValue( 'sv_SE' );
+			vi.mocked( copyLanguagePackToSite ).mockResolvedValue( false );
+
+			await runCommand( mockSitePath, { ...defaultTestOptions } );
+
+			expect( startWordPressServer ).toHaveBeenCalledWith(
+				expect.anything(),
+				expect.any( Logger ),
+				expect.objectContaining( {
+					blueprint: expect.objectContaining( {
+						steps: expect.arrayContaining( [
+							expect.objectContaining( {
+								step: 'setSiteLanguage',
+								language: 'sv_SE',
+							} ),
+							expect.objectContaining( {
+								step: 'setSiteOptions',
+								options: { WPLANG: 'sv_SE' },
+							} ),
+						] ),
+					} ),
+				} )
+			);
+		} );
+
+		it( 'should use setSiteLanguage for non-latest WP versions', async () => {
+			vi.mocked( getPreferredSiteLanguage ).mockResolvedValue( 'sv_SE' );
+
+			await runCommand( mockSitePath, {
+				...defaultTestOptions,
+				wpVersion: '6.5',
+			} );
+
+			expect( copyLanguagePackToSite ).not.toHaveBeenCalled();
+			expect( startWordPressServer ).toHaveBeenCalledWith(
+				expect.anything(),
+				expect.any( Logger ),
+				expect.objectContaining( {
+					blueprint: expect.objectContaining( {
+						steps: expect.arrayContaining( [
+							expect.objectContaining( {
+								step: 'setSiteLanguage',
+								language: 'sv_SE',
+							} ),
+						] ),
+					} ),
+				} )
+			);
+		} );
+
+		it( 'should not set language when locale is English', async () => {
+			vi.mocked( getPreferredSiteLanguage ).mockResolvedValue( 'en' );
+
+			await runCommand( mockSitePath, { ...defaultTestOptions } );
+
+			expect( copyLanguagePackToSite ).not.toHaveBeenCalled();
 		} );
 	} );
 

--- a/cli/lib/language-packs.ts
+++ b/cli/lib/language-packs.ts
@@ -1,0 +1,45 @@
+import fs from 'fs';
+import path from 'path';
+import { pathExists } from 'common/lib/fs-utils';
+import { getLanguagePacksPath } from 'cli/lib/server-files';
+
+/**
+ * Copies bundled WordPress core language pack files for a given locale into a site's
+ * wp-content/languages/ directory. Returns true if files were copied successfully.
+ */
+export async function copyLanguagePackToSite(
+	sitePath: string,
+	wpLocale: string
+): Promise< boolean > {
+	const languagePacksDir = getLanguagePacksPath();
+	if ( ! ( await pathExists( languagePacksDir ) ) ) {
+		return false;
+	}
+
+	// Language pack files follow WordPress naming: {locale}.mo, admin-{locale}.mo, etc.
+	const allFiles = await fs.promises.readdir( languagePacksDir );
+	const localeFiles = allFiles.filter( ( file ) => {
+		const name = path.basename( file );
+		return (
+			name === `${ wpLocale }.mo` ||
+			name === `${ wpLocale }.po` ||
+			name === `${ wpLocale }.l10n.php` ||
+			name.endsWith( `-${ wpLocale }.mo` ) ||
+			name.endsWith( `-${ wpLocale }.po` ) ||
+			name.endsWith( `-${ wpLocale }.l10n.php` )
+		);
+	} );
+
+	if ( localeFiles.length === 0 ) {
+		return false;
+	}
+
+	const destDir = path.join( sitePath, 'wp-content', 'languages' );
+	await fs.promises.mkdir( destDir, { recursive: true } );
+
+	for ( const file of localeFiles ) {
+		await fs.promises.copyFile( path.join( languagePacksDir, file ), path.join( destDir, file ) );
+	}
+
+	return true;
+}

--- a/cli/lib/language-packs.ts
+++ b/cli/lib/language-packs.ts
@@ -4,8 +4,48 @@ import { pathExists } from 'common/lib/fs-utils';
 import { getLanguagePacksPath } from 'cli/lib/server-files';
 
 /**
- * Copies bundled WordPress core language pack files for a given locale into a site's
- * wp-content/languages/ directory. Returns true if files were copied successfully.
+ * Filters files in a directory that match a given WordPress locale.
+ * Matches .l10n.php files ({locale}.l10n.php, {domain}-{locale}.l10n.php)
+ * and .json files ({locale}-{hash}.json).
+ */
+function filterLocaleFiles( files: string[], wpLocale: string ): string[] {
+	return files.filter( ( file ) => {
+		const name = path.basename( file );
+		return (
+			name === `${ wpLocale }.l10n.php` ||
+			name.endsWith( `-${ wpLocale }.l10n.php` ) ||
+			( name.startsWith( `${ wpLocale }-` ) && name.endsWith( '.json' ) )
+		);
+	} );
+}
+
+/**
+ * Copies matching locale files from a source directory to a destination directory.
+ */
+async function copyLocaleFiles(
+	sourceDir: string,
+	destDir: string,
+	wpLocale: string
+): Promise< number > {
+	if ( ! ( await pathExists( sourceDir ) ) ) {
+		return 0;
+	}
+	const allFiles = await fs.promises.readdir( sourceDir );
+	const localeFiles = filterLocaleFiles( allFiles, wpLocale );
+	if ( localeFiles.length === 0 ) {
+		return 0;
+	}
+	await fs.promises.mkdir( destDir, { recursive: true } );
+	for ( const file of localeFiles ) {
+		await fs.promises.copyFile( path.join( sourceDir, file ), path.join( destDir, file ) );
+	}
+	return localeFiles.length;
+}
+
+/**
+ * Copies bundled WordPress language pack files for a given locale into a site's
+ * wp-content/languages/ directory, including core, plugin, and theme translations.
+ * Returns true if files were copied successfully.
  */
 export async function copyLanguagePackToSite(
 	sitePath: string,
@@ -16,30 +56,20 @@ export async function copyLanguagePackToSite(
 		return false;
 	}
 
-	// Language pack files follow WordPress naming conventions.
-	// We only bundle .l10n.php and .json files (WordPress 6.5+ format).
-	// .l10n.php: {locale}.l10n.php, {domain}-{locale}.l10n.php
-	// .json: {locale}-{hash}.json
-	const allFiles = await fs.promises.readdir( languagePacksDir );
-	const localeFiles = allFiles.filter( ( file ) => {
-		const name = path.basename( file );
-		return (
-			name === `${ wpLocale }.l10n.php` ||
-			name.endsWith( `-${ wpLocale }.l10n.php` ) ||
-			( name.startsWith( `${ wpLocale }-` ) && name.endsWith( '.json' ) )
-		);
-	} );
+	const destBase = path.join( sitePath, 'wp-content', 'languages' );
 
-	if ( localeFiles.length === 0 ) {
-		return false;
-	}
+	let totalCopied = 0;
+	totalCopied += await copyLocaleFiles( languagePacksDir, destBase, wpLocale );
+	totalCopied += await copyLocaleFiles(
+		path.join( languagePacksDir, 'plugins' ),
+		path.join( destBase, 'plugins' ),
+		wpLocale
+	);
+	totalCopied += await copyLocaleFiles(
+		path.join( languagePacksDir, 'themes' ),
+		path.join( destBase, 'themes' ),
+		wpLocale
+	);
 
-	const destDir = path.join( sitePath, 'wp-content', 'languages' );
-	await fs.promises.mkdir( destDir, { recursive: true } );
-
-	for ( const file of localeFiles ) {
-		await fs.promises.copyFile( path.join( languagePacksDir, file ), path.join( destDir, file ) );
-	}
-
-	return true;
+	return totalCopied > 0;
 }

--- a/cli/lib/language-packs.ts
+++ b/cli/lib/language-packs.ts
@@ -16,17 +16,17 @@ export async function copyLanguagePackToSite(
 		return false;
 	}
 
-	// Language pack files follow WordPress naming: {locale}.mo, admin-{locale}.mo, etc.
+	// Language pack files follow WordPress naming conventions.
+	// We only bundle .l10n.php and .json files (WordPress 6.5+ format).
+	// .l10n.php: {locale}.l10n.php, {domain}-{locale}.l10n.php
+	// .json: {locale}-{hash}.json
 	const allFiles = await fs.promises.readdir( languagePacksDir );
 	const localeFiles = allFiles.filter( ( file ) => {
 		const name = path.basename( file );
 		return (
-			name === `${ wpLocale }.mo` ||
-			name === `${ wpLocale }.po` ||
 			name === `${ wpLocale }.l10n.php` ||
-			name.endsWith( `-${ wpLocale }.mo` ) ||
-			name.endsWith( `-${ wpLocale }.po` ) ||
-			name.endsWith( `-${ wpLocale }.l10n.php` )
+			name.endsWith( `-${ wpLocale }.l10n.php` ) ||
+			( name.startsWith( `${ wpLocale }-` ) && name.endsWith( '.json' ) )
 		);
 	} );
 

--- a/cli/lib/server-files.ts
+++ b/cli/lib/server-files.ts
@@ -15,3 +15,7 @@ export function getWpCliPharPath(): string {
 export function getSqliteCommandPath(): string {
 	return path.join( getServerFilesPath(), SQLITE_COMMAND_FOLDER );
 }
+
+export function getLanguagePacksPath(): string {
+	return path.join( getServerFilesPath(), 'language-packs' );
+}

--- a/common/lib/locale.ts
+++ b/common/lib/locale.ts
@@ -43,3 +43,29 @@ export function isSupportedLocale( locale: string | undefined ): locale is Suppo
 	}
 	return supportedLocales.includes( locale as SupportedLocale );
 }
+
+/**
+ * Maps Studio locale codes to their corresponding WordPress locale codes.
+ * Used for downloading and installing WordPress core language packs.
+ */
+export const studioToWpLocaleMap: Partial< Record< SupportedLocale, string > > = {
+	ar: 'ar',
+	de: 'de_DE',
+	es: 'es_ES',
+	fr: 'fr_FR',
+	he: 'he_IL',
+	id: 'id_ID',
+	it: 'it_IT',
+	ja: 'ja',
+	ko: 'ko_KR',
+	nl: 'nl_NL',
+	pl: 'pl_PL',
+	'pt-br': 'pt_BR',
+	ru: 'ru_RU',
+	sv: 'sv_SE',
+	tr: 'tr_TR',
+	vi: 'vi',
+	uk: 'uk',
+	'zh-cn': 'zh_CN',
+	'zh-tw': 'zh_TW',
+};

--- a/common/lib/locale.ts
+++ b/common/lib/locale.ts
@@ -43,29 +43,3 @@ export function isSupportedLocale( locale: string | undefined ): locale is Suppo
 	}
 	return supportedLocales.includes( locale as SupportedLocale );
 }
-
-/**
- * Maps Studio locale codes to their corresponding WordPress locale codes.
- * Used for downloading and installing WordPress core language packs.
- */
-export const studioToWpLocaleMap: Partial< Record< SupportedLocale, string > > = {
-	ar: 'ar',
-	de: 'de_DE',
-	es: 'es_ES',
-	fr: 'fr_FR',
-	he: 'he_IL',
-	id: 'id_ID',
-	it: 'it_IT',
-	ja: 'ja',
-	ko: 'ko_KR',
-	nl: 'nl_NL',
-	pl: 'pl_PL',
-	'pt-br': 'pt_BR',
-	ru: 'ru_RU',
-	sv: 'sv_SE',
-	tr: 'tr_TR',
-	vi: 'vi',
-	uk: 'uk',
-	'zh-cn': 'zh_CN',
-	'zh-tw': 'zh_TW',
-};

--- a/common/lib/wp-locales.ts
+++ b/common/lib/wp-locales.ts
@@ -22,4 +22,4 @@ export const WP_LOCALES = [
 	'uk',
 	'zh_CN',
 	'zh_TW',
-] as const;
+];

--- a/common/lib/wp-locales.ts
+++ b/common/lib/wp-locales.ts
@@ -1,0 +1,25 @@
+/**
+ * WordPress locale codes for all non-English locales supported by Studio.
+ * Used for downloading and installing WordPress core language packs.
+ */
+export const WP_LOCALES = [
+	'ar',
+	'de_DE',
+	'es_ES',
+	'fr_FR',
+	'he_IL',
+	'id_ID',
+	'it_IT',
+	'ja',
+	'ko_KR',
+	'nl_NL',
+	'pl_PL',
+	'pt_BR',
+	'ru_RU',
+	'sv_SE',
+	'tr_TR',
+	'vi',
+	'uk',
+	'zh_CN',
+	'zh_TW',
+] as const;

--- a/scripts/download-wp-server-files.ts
+++ b/scripts/download-wp-server-files.ts
@@ -166,7 +166,8 @@ async function downloadTranslationsFromApi(
 			continue;
 		}
 
-		const zipPath = path.join( os.tmpdir(), `wp-language-${ label }-${ language }.zip` );
+		const safeLabel = label.replace( /\//g, '-' );
+		const zipPath = path.join( os.tmpdir(), `wp-language-${ safeLabel }-${ language }.zip` );
 		const buffer = Buffer.from( await zipResponse.arrayBuffer() );
 		await fs.writeFile( zipPath, buffer );
 		await extractZip( zipPath, destPath );

--- a/scripts/download-wp-server-files.ts
+++ b/scripts/download-wp-server-files.ts
@@ -131,14 +131,18 @@ interface TranslationsApiResponse {
 	translations: TranslationEntry[];
 }
 
-async function downloadLanguagePacks(): Promise< void > {
-	const languagesPath = path.join( WP_SERVER_FILES_PATH, 'latest', 'languages' );
-	await fs.ensureDir( languagesPath );
+// Plugins and themes bundled with the default WordPress installation.
+const BUNDLED_PLUGINS = [ 'akismet' ];
+const BUNDLED_THEMES = [ 'twentytwentyfive', 'twentytwentyfour', 'twentytwentythree' ];
 
-	console.log( '[language-packs] Fetching available translations ...' );
-	const response = await fetch( 'https://api.wordpress.org/translations/core/1.0/' );
+async function downloadTranslationsFromApi(
+	apiUrl: string,
+	destPath: string,
+	label: string
+): Promise< void > {
+	const response = await fetch( apiUrl );
 	if ( ! response.ok ) {
-		throw new Error( `Failed to fetch translations API (status ${ response.status })` );
+		throw new Error( `Failed to fetch ${ label } translations API (status ${ response.status })` );
 	}
 	const data: TranslationsApiResponse = await response.json();
 
@@ -147,36 +151,71 @@ async function downloadLanguagePacks(): Promise< void > {
 	);
 
 	console.log(
-		`[language-packs] Downloading ${ translationsToDownload.length } language packs ...`
+		`[language-packs] ${ label }: downloading ${ translationsToDownload.length } locale(s)`
 	);
+
+	await fs.ensureDir( destPath );
 
 	for ( const translation of translationsToDownload ) {
 		const { language, package: packageUrl } = translation;
-		console.log( `[language-packs] Downloading ${ language } ...` );
-
 		const zipResponse = await fetch( packageUrl );
 		if ( ! zipResponse.ok ) {
 			console.error(
-				`[language-packs] Failed to download ${ language } (status ${ zipResponse.status }), skipping`
+				`[language-packs] Failed to download ${ label }/${ language } (status ${ zipResponse.status }), skipping`
 			);
 			continue;
 		}
 
-		const zipPath = path.join( os.tmpdir(), `wp-language-${ language }.zip` );
+		const zipPath = path.join( os.tmpdir(), `wp-language-${ label }-${ language }.zip` );
 		const buffer = Buffer.from( await zipResponse.arrayBuffer() );
 		await fs.writeFile( zipPath, buffer );
-		await extractZip( zipPath, languagesPath );
+		await extractZip( zipPath, destPath );
 		await fs.remove( zipPath );
+	}
+}
+
+async function removePoAndMoFiles( dirPath: string ): Promise< void > {
+	const entries = await fs.readdir( dirPath, { withFileTypes: true } );
+	for ( const entry of entries ) {
+		const fullPath = path.join( dirPath, entry.name );
+		if ( entry.isDirectory() ) {
+			await removePoAndMoFiles( fullPath );
+		} else if ( entry.name.endsWith( '.po' ) || entry.name.endsWith( '.mo' ) ) {
+			await fs.remove( fullPath );
+		}
+	}
+}
+
+async function downloadLanguagePacks(): Promise< void > {
+	const languagesPath = path.join( WP_SERVER_FILES_PATH, 'latest', 'languages' );
+
+	// Core translations
+	await downloadTranslationsFromApi(
+		'https://api.wordpress.org/translations/core/1.0/',
+		languagesPath,
+		'core'
+	);
+
+	// Plugin translations
+	for ( const slug of BUNDLED_PLUGINS ) {
+		await downloadTranslationsFromApi(
+			`https://api.wordpress.org/translations/plugins/1.0/?slug=${ slug }`,
+			path.join( languagesPath, 'plugins' ),
+			`plugin/${ slug }`
+		);
+	}
+
+	// Theme translations
+	for ( const slug of BUNDLED_THEMES ) {
+		await downloadTranslationsFromApi(
+			`https://api.wordpress.org/translations/themes/1.0/?slug=${ slug }`,
+			path.join( languagesPath, 'themes' ),
+			`theme/${ slug }`
+		);
 	}
 
 	// Remove .po and .mo files — WordPress 6.5+ uses .l10n.php and .json files.
-	// This reduces the language packs size by ~65%.
-	const allFiles = await fs.readdir( languagesPath );
-	for ( const file of allFiles ) {
-		if ( file.endsWith( '.po' ) || file.endsWith( '.mo' ) ) {
-			await fs.remove( path.join( languagesPath, file ) );
-		}
-	}
+	await removePoAndMoFiles( languagesPath );
 
 	console.log( '[language-packs] All language packs downloaded' );
 }

--- a/scripts/download-wp-server-files.ts
+++ b/scripts/download-wp-server-files.ts
@@ -2,29 +2,7 @@ import os from 'os';
 import path from 'path';
 import fs from 'fs-extra';
 import { extractZip } from '../common/lib/extract-zip';
-// WordPress locale codes for all non-English locales supported by Studio.
-// Keep in sync with studioToWpLocaleMap in common/lib/locale.ts.
-const WP_LOCALES = [
-	'ar',
-	'de_DE',
-	'es_ES',
-	'fr_FR',
-	'he_IL',
-	'id_ID',
-	'it_IT',
-	'ja',
-	'ko_KR',
-	'nl_NL',
-	'pl_PL',
-	'pt_BR',
-	'ru_RU',
-	'sv_SE',
-	'tr_TR',
-	'vi',
-	'uk',
-	'zh_CN',
-	'zh_TW',
-];
+import { WP_LOCALES } from '../common/lib/wp-locales';
 import { getLatestSQLiteCommandRelease } from '../src/lib/sqlite-command-release';
 import { SQLITE_DATABASE_INTEGRATION_RELEASE_URL } from '../src/constants';
 

--- a/scripts/download-wp-server-files.ts
+++ b/scripts/download-wp-server-files.ts
@@ -2,7 +2,29 @@ import os from 'os';
 import path from 'path';
 import fs from 'fs-extra';
 import { extractZip } from '../common/lib/extract-zip';
-import { studioToWpLocaleMap } from '../common/lib/locale';
+// WordPress locale codes for all non-English locales supported by Studio.
+// Keep in sync with studioToWpLocaleMap in common/lib/locale.ts.
+const WP_LOCALES = [
+	'ar',
+	'de_DE',
+	'es_ES',
+	'fr_FR',
+	'he_IL',
+	'id_ID',
+	'it_IT',
+	'ja',
+	'ko_KR',
+	'nl_NL',
+	'pl_PL',
+	'pt_BR',
+	'ru_RU',
+	'sv_SE',
+	'tr_TR',
+	'vi',
+	'uk',
+	'zh_CN',
+	'zh_TW',
+];
 import { getLatestSQLiteCommandRelease } from '../src/lib/sqlite-command-release';
 import { SQLITE_DATABASE_INTEGRATION_RELEASE_URL } from '../src/constants';
 
@@ -120,9 +142,8 @@ async function downloadLanguagePacks(): Promise< void > {
 	}
 	const data: TranslationsApiResponse = await response.json();
 
-	const wpLocales = Object.values( studioToWpLocaleMap );
 	const translationsToDownload = data.translations.filter( ( t ) =>
-		wpLocales.includes( t.language )
+		WP_LOCALES.includes( t.language )
 	);
 
 	console.log(
@@ -146,6 +167,15 @@ async function downloadLanguagePacks(): Promise< void > {
 		await fs.writeFile( zipPath, buffer );
 		await extractZip( zipPath, languagesPath );
 		await fs.remove( zipPath );
+	}
+
+	// Remove .po and .mo files — WordPress 6.5+ uses .l10n.php and .json files.
+	// This reduces the language packs size by ~65%.
+	const allFiles = await fs.readdir( languagesPath );
+	for ( const file of allFiles ) {
+		if ( file.endsWith( '.po' ) || file.endsWith( '.mo' ) ) {
+			await fs.remove( path.join( languagesPath, file ) );
+		}
 	}
 
 	console.log( '[language-packs] All language packs downloaded' );

--- a/scripts/download-wp-server-files.ts
+++ b/scripts/download-wp-server-files.ts
@@ -109,9 +109,26 @@ interface TranslationsApiResponse {
 	translations: TranslationEntry[];
 }
 
-// Plugins and themes bundled with the default WordPress installation.
-const BUNDLED_PLUGINS = [ 'akismet', 'hello-dolly' ];
-const BUNDLED_THEMES = [ 'twentytwentyfive', 'twentytwentyfour', 'twentytwentythree' ];
+// Known single-file plugins whose directory name doesn't match the WordPress.org slug.
+const SINGLE_FILE_PLUGIN_SLUGS: Record< string, string > = {
+	'hello.php': 'hello-dolly',
+};
+
+function getBundledSlugs( contentDir: string ): string[] {
+	const entries = fs.readdirSync( contentDir, { withFileTypes: true } );
+	const slugs: string[] = [];
+	for ( const entry of entries ) {
+		if ( entry.name === 'index.php' ) {
+			continue;
+		}
+		if ( entry.isDirectory() ) {
+			slugs.push( entry.name );
+		} else if ( SINGLE_FILE_PLUGIN_SLUGS[ entry.name ] ) {
+			slugs.push( SINGLE_FILE_PLUGIN_SLUGS[ entry.name ] );
+		}
+	}
+	return slugs;
+}
 
 async function downloadTranslationsFromApi(
 	apiUrl: string,
@@ -167,6 +184,7 @@ async function removePoAndMoFiles( dirPath: string ): Promise< void > {
 
 async function downloadLanguagePacks(): Promise< void > {
 	const languagesPath = path.join( WP_SERVER_FILES_PATH, 'latest', 'languages' );
+	const wpContentPath = path.join( WP_SERVER_FILES_PATH, 'latest', 'wordpress', 'wp-content' );
 
 	// Core translations
 	await downloadTranslationsFromApi(
@@ -176,7 +194,8 @@ async function downloadLanguagePacks(): Promise< void > {
 	);
 
 	// Plugin translations
-	for ( const slug of BUNDLED_PLUGINS ) {
+	const pluginSlugs = getBundledSlugs( path.join( wpContentPath, 'plugins' ) );
+	for ( const slug of pluginSlugs ) {
 		await downloadTranslationsFromApi(
 			`https://api.wordpress.org/translations/plugins/1.0/?slug=${ slug }`,
 			path.join( languagesPath, 'plugins' ),
@@ -185,7 +204,8 @@ async function downloadLanguagePacks(): Promise< void > {
 	}
 
 	// Theme translations
-	for ( const slug of BUNDLED_THEMES ) {
+	const themeSlugs = getBundledSlugs( path.join( wpContentPath, 'themes' ) );
+	for ( const slug of themeSlugs ) {
 		await downloadTranslationsFromApi(
 			`https://api.wordpress.org/translations/themes/1.0/?slug=${ slug }`,
 			path.join( languagesPath, 'themes' ),

--- a/scripts/download-wp-server-files.ts
+++ b/scripts/download-wp-server-files.ts
@@ -110,7 +110,7 @@ interface TranslationsApiResponse {
 }
 
 // Plugins and themes bundled with the default WordPress installation.
-const BUNDLED_PLUGINS = [ 'akismet' ];
+const BUNDLED_PLUGINS = [ 'akismet', 'hello-dolly' ];
 const BUNDLED_THEMES = [ 'twentytwentyfive', 'twentytwentyfour', 'twentytwentythree' ];
 
 async function downloadTranslationsFromApi(

--- a/scripts/download-wp-server-files.ts
+++ b/scripts/download-wp-server-files.ts
@@ -2,6 +2,7 @@ import os from 'os';
 import path from 'path';
 import fs from 'fs-extra';
 import { extractZip } from '../common/lib/extract-zip';
+import { studioToWpLocaleMap } from '../common/lib/locale';
 import { getLatestSQLiteCommandRelease } from '../src/lib/sqlite-command-release';
 import { SQLITE_DATABASE_INTEGRATION_RELEASE_URL } from '../src/constants';
 
@@ -99,6 +100,57 @@ async function downloadFile( file: FileToDownload ): Promise< void > {
 	await fs.remove( zipPath );
 }
 
+interface TranslationEntry {
+	language: string;
+	package: string;
+}
+
+interface TranslationsApiResponse {
+	translations: TranslationEntry[];
+}
+
+async function downloadLanguagePacks(): Promise< void > {
+	const languagesPath = path.join( WP_SERVER_FILES_PATH, 'latest', 'languages' );
+	await fs.ensureDir( languagesPath );
+
+	console.log( '[language-packs] Fetching available translations ...' );
+	const response = await fetch( 'https://api.wordpress.org/translations/core/1.0/' );
+	if ( ! response.ok ) {
+		throw new Error( `Failed to fetch translations API (status ${ response.status })` );
+	}
+	const data: TranslationsApiResponse = await response.json();
+
+	const wpLocales = Object.values( studioToWpLocaleMap );
+	const translationsToDownload = data.translations.filter( ( t ) =>
+		wpLocales.includes( t.language )
+	);
+
+	console.log(
+		`[language-packs] Downloading ${ translationsToDownload.length } language packs ...`
+	);
+
+	for ( const translation of translationsToDownload ) {
+		const { language, package: packageUrl } = translation;
+		console.log( `[language-packs] Downloading ${ language } ...` );
+
+		const zipResponse = await fetch( packageUrl );
+		if ( ! zipResponse.ok ) {
+			console.error(
+				`[language-packs] Failed to download ${ language } (status ${ zipResponse.status }), skipping`
+			);
+			continue;
+		}
+
+		const zipPath = path.join( os.tmpdir(), `wp-language-${ language }.zip` );
+		const buffer = Buffer.from( await zipResponse.arrayBuffer() );
+		await fs.writeFile( zipPath, buffer );
+		await extractZip( zipPath, languagesPath );
+		await fs.remove( zipPath );
+	}
+
+	console.log( '[language-packs] All language packs downloaded' );
+}
+
 async function downloadFiles() {
 	for ( const file of FILES_TO_DOWNLOAD ) {
 		try {
@@ -107,6 +159,13 @@ async function downloadFiles() {
 			console.error( err );
 			process.exit( 1 );
 		}
+	}
+
+	try {
+		await downloadLanguagePacks();
+	} catch ( err ) {
+		console.error( '[language-packs] Error downloading language packs:', err );
+		process.exit( 1 );
 	}
 }
 

--- a/scripts/download-wp-server-files.ts
+++ b/scripts/download-wp-server-files.ts
@@ -129,7 +129,7 @@ async function downloadTranslationsFromApi(
 	);
 
 	console.log(
-		`[language-packs] ${ label }: downloading ${ translationsToDownload.length } locale(s)`
+		`[language-packs] Downloading ${ label } (${ translationsToDownload.length } locales) ...`
 	);
 
 	await fs.ensureDir( destPath );
@@ -172,7 +172,7 @@ async function downloadLanguagePacks(): Promise< void > {
 	await downloadTranslationsFromApi(
 		'https://api.wordpress.org/translations/core/1.0/',
 		languagesPath,
-		'core'
+		'core translations'
 	);
 
 	// Plugin translations
@@ -180,7 +180,7 @@ async function downloadLanguagePacks(): Promise< void > {
 		await downloadTranslationsFromApi(
 			`https://api.wordpress.org/translations/plugins/1.0/?slug=${ slug }`,
 			path.join( languagesPath, 'plugins' ),
-			`plugin/${ slug }`
+			`plugin translations: ${ slug }`
 		);
 	}
 
@@ -189,14 +189,14 @@ async function downloadLanguagePacks(): Promise< void > {
 		await downloadTranslationsFromApi(
 			`https://api.wordpress.org/translations/themes/1.0/?slug=${ slug }`,
 			path.join( languagesPath, 'themes' ),
-			`theme/${ slug }`
+			`theme translations: ${ slug }`
 		);
 	}
 
 	// Remove .po and .mo files — WordPress 6.5+ uses .l10n.php and .json files.
 	await removePoAndMoFiles( languagesPath );
 
-	console.log( '[language-packs] All language packs downloaded' );
+	console.log( '[language-packs] Files extracted' );
 }
 
 async function downloadFiles() {

--- a/src/lib/server-files-paths.ts
+++ b/src/lib/server-files-paths.ts
@@ -64,3 +64,10 @@ export function getWpCliFolderPath(): string {
 export function getWpCliPath(): string {
 	return path.join( getWpCliFolderPath(), 'wp-cli.phar' );
 }
+
+/**
+ * The path where bundled WordPress language packs are stored.
+ */
+export function getLanguagePacksPath(): string {
+	return path.join( getBasePath(), 'language-packs' );
+}

--- a/src/setup-wp-server-files.ts
+++ b/src/setup-wp-server-files.ts
@@ -3,7 +3,12 @@ import fs from 'fs-extra';
 import semver from 'semver';
 import { recursiveCopyDirectory } from 'common/lib/fs-utils';
 import { updateLatestWPCliVersion } from 'src/lib/download-utils';
-import { getWordPressVersionPath, getSqlitePath, getWpCliPath } from 'src/lib/server-files-paths';
+import {
+	getLanguagePacksPath,
+	getWordPressVersionPath,
+	getSqlitePath,
+	getWpCliPath,
+} from 'src/lib/server-files-paths';
 import {
 	getSqliteCommandPath,
 	updateLatestSQLiteCommandVersion,
@@ -108,12 +113,38 @@ async function copyBundledTranslations() {
 	await fs.copyFile( bundledTranslationsPath, installedTranslationsPath );
 }
 
+async function copyBundledLanguagePacks() {
+	const bundledLanguagePacksPath = path.join(
+		getResourcesPath(),
+		'wp-files',
+		'latest',
+		'languages'
+	);
+	if ( ! ( await fs.pathExists( bundledLanguagePacksPath ) ) ) {
+		return;
+	}
+	const installedLanguagePacksPath = getLanguagePacksPath();
+	await fs.ensureDir( installedLanguagePacksPath );
+	await recursiveCopyDirectory( bundledLanguagePacksPath, installedLanguagePacksPath );
+}
+
 export async function setupWPServerFiles() {
-	await copyBundledLatestWPVersion();
-	await copyBundledSqlite();
-	await copyBundledWPCLI();
-	await copyBundledSQLiteCommand();
-	await copyBundledTranslations();
+	const steps: Array< [ string, () => Promise< void > ] > = [
+		[ 'WordPress version', copyBundledLatestWPVersion ],
+		[ 'SQLite integration', copyBundledSqlite ],
+		[ 'WP-CLI', copyBundledWPCLI ],
+		[ 'SQLite command', copyBundledSQLiteCommand ],
+		[ 'translations', copyBundledTranslations ],
+		[ 'language packs', copyBundledLanguagePacks ],
+	];
+
+	for ( const [ name, step ] of steps ) {
+		try {
+			await step();
+		} catch ( error ) {
+			console.error( `Failed to set up bundled ${ name }:`, error );
+		}
+	}
 }
 
 /**


### PR DESCRIPTION
## Related issues

Closes STU-1250
Related to STU-980

## Proposed Changes

The PR proposes to bundle WordPress core, plugin and theme translation files. This saves about 3 - 4 seconds in localized site creation time while adding only about 29 MB to the app bundle and additional time when running `npm install`.

Feel free to check the comments with the background in the related task (STU-1250).

- Download WordPress core, plugin, and theme translation files at build time via `scripts/download-wp-server-files.ts` for all 19 supported non-English locales.
- At app startup, copy bundled language packs from app resources to the runtime `server-files/language-packs/` directory.
- During site creation for the latest WP version, copy locale-specific `.l10n.php` and `.json` files directly into the site's `wp-content/languages/` directory and set `WPLANG` via blueprint steps (`defineWpConfigConsts` + `setSiteOptions`) — no network round-trip needed.
- Fall back to the original `setSiteLanguage` blueprint step for non-latest WP versions or when bundled packs are unavailable.
- Auto-detect bundled plugins and themes from the extracted WordPress installation for translation downloads.
- Only bundle `.l10n.php` and `.json` files (WordPress 6.5+ format), skipping `.po` and `.mo` to reduce size (~29MB vs ~82MB).
- Make `setupWPServerFiles` resilient so individual step failures don't prevent subsequent steps from running.

## Testing Instructions
1. Run `npm install` and verify language packs are downloaded without errors. You can find them in the project root: `wp-files/latest/languages`, `wp-files/latest/languages/plugins` and `wp-files/latest/languages/themes`.
<img width="1620" height="258" alt="CleanShot 2026-02-10 at 13 49 40@2x" src="https://github.com/user-attachments/assets/0a73cd1d-6076-4413-9315-634f1e102506" />

2. Run `npm start` and set your system locale to a non-English language (e.g. Swedish).
3. Create a new site and verify:
   - Site creation completes without downloading translations from WordPress.org → It should take similar time as when creating an English site (6 - 8 seconds vs 11 - 12 seconds in my tests).
   - The WordPress admin is displayed in the selected language.
   - Plugin and theme translations are present (please note that some locales are missing translations for certain plugins and themes).
4. Create a site with a non-latest WP version (e.g. 6.5) and verify it falls back to downloading translations → The site creation should take about 3 - 4 seconds longer.
5. Create a site with English locale and verify everything is going well there too. There should be no translations in `wp-content`.
6. Run `npm test -- cli/commands/site/tests/create.test.ts` and verify all tests pass.

## Pre-merge Checklist
- [ ] Have you checked for TypeScript, React or other console errors?