### PR TITLE
Fix build size increase by using schema validator subpath import

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -242,6 +242,7 @@
 			"resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.2.tgz",
 			"integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@octokit/auth-token": "^4.0.0",
 				"@octokit/graphql": "^7.1.0",

--- a/common/lib/blueprint-validation.ts
+++ b/common/lib/blueprint-validation.ts
@@ -1,5 +1,6 @@
 import { __, sprintf } from '@wordpress/i18n';
-import { Blueprint, validateBlueprint } from '@wp-playground/blueprints';
+import validateBlueprintSchema from '@wp-playground/blueprints/blueprint-schema-validator';
+import type { Blueprint } from '@wp-playground/blueprints';
 
 interface UnsupportedFeature {
 	type: 'step' | 'property';
@@ -131,21 +132,19 @@ export type BlueprintValidationResult = BlueprintValidationError | BlueprintVali
 export async function validateBlueprintData(
 	blueprintJson: unknown
 ): Promise< BlueprintValidationResult > {
-	const result = validateBlueprint( blueprintJson as object );
+	const isValid = validateBlueprintSchema( blueprintJson );
 
-	if ( ! result.valid ) {
-		const firstError = result.errors?.[ 0 ] as
-			| {
-					instancePath?: string;
-					message?: string;
-					params?: { additionalProperty?: string };
-			  }
-			| undefined;
-		const errorPath = firstError?.instancePath || '/';
-		const additionalProp = firstError?.params?.additionalProperty;
+	if ( ! isValid && validateBlueprintSchema.errors ) {
+		const firstError = validateBlueprintSchema.errors[ 0 ];
+		// The schema validator uses ajv v8 internally (instancePath, additionalProperty)
+		// but ships with ajv v6 types (dataPath, ErrorParameters).
+		type RuntimeError = { instancePath?: string; params?: { additionalProperty?: string } };
+		const error = firstError as unknown as RuntimeError;
+		const errorPath = error.instancePath || '/';
+		const additionalProp = error.params?.additionalProperty;
 		const errorMessage = additionalProp
 			? sprintf( __( '"%s" is not a valid Blueprint property' ), additionalProp )
-			: firstError?.message || __( 'Invalid blueprint' );
+			: firstError.message || __( 'Invalid blueprint' );
 
 		return {
 			valid: false,

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -21,6 +21,9 @@ export default defineConfig( {
 				common: resolve( 'common' ),
 				cli: resolve( 'cli' ),
 				vendor: resolve( 'vendor' ),
+				'@wp-playground/blueprints/blueprint-schema-validator': resolve(
+					'node_modules/@wp-playground/blueprints/blueprint-schema-validator.js'
+				),
 			},
 		},
 		define: {
@@ -39,7 +42,6 @@ export default defineConfig( {
 				},
 				external: [
 					/^@php-wasm\/.*/,
-					/^@wp-playground\/.*/,
 				],
 			},
 		},

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,6 @@
 				"@wordpress/dataviews": "^11.3.0",
 				"@wordpress/i18n": "^6.9.0",
 				"@wordpress/icons": "^11.4.0",
-				"@wp-playground/blueprints": "^3.0.46",
 				"archiver": "^6.0.2",
 				"atomically": "^2.1.0",
 				"cli-table3": "^0.6.5",
@@ -96,6 +95,7 @@
 				"@wordpress/components": "^32.1.0",
 				"@wordpress/element": "^6.39.0",
 				"@wordpress/react-i18n": "^4.39.0",
+				"@wp-playground/blueprints": "^3.0.46",
 				"electron": "^39.2.7",
 				"electron-devtools-installer": "^4.0.0",
 				"electron-playwright-helpers": "^2.1.0",
@@ -421,6 +421,7 @@
 			"version": "7.28.5",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.27.1",
 				"@babel/generator": "^7.28.5",
@@ -2129,6 +2130,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			},
@@ -2150,6 +2152,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -3478,6 +3481,7 @@
 		"node_modules/@emotion/react": {
 			"version": "11.11.3",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@babel/runtime": "^7.18.3",
 				"@emotion/babel-plugin": "^11.11.0",
@@ -4049,6 +4053,7 @@
 		"node_modules/@inquirer/prompts": {
 			"version": "7.10.1",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@inquirer/checkbox": "^4.3.2",
 				"@inquirer/confirm": "^5.1.21",
@@ -4438,6 +4443,7 @@
 		},
 		"node_modules/@octokit/app": {
 			"version": "14.1.0",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@octokit/auth-app": "^6.0.0",
@@ -4454,6 +4460,7 @@
 		},
 		"node_modules/@octokit/auth-app": {
 			"version": "6.1.4",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@octokit/auth-oauth-app": "^7.1.0",
@@ -4472,10 +4479,12 @@
 		},
 		"node_modules/@octokit/auth-app/node_modules/@octokit/openapi-types": {
 			"version": "24.2.0",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@octokit/auth-app/node_modules/@octokit/types": {
 			"version": "13.10.0",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@octokit/openapi-types": "^24.2.0"
@@ -4484,6 +4493,7 @@
 		"node_modules/@octokit/auth-app/node_modules/lru-cache": {
 			"name": "@wolfy1339/lru-cache",
 			"version": "11.0.2-patch.1",
+			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": "18 >=18.20 || 20 || >=22"
@@ -4491,6 +4501,7 @@
 		},
 		"node_modules/@octokit/auth-oauth-app": {
 			"version": "7.1.0",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@octokit/auth-oauth-device": "^6.1.0",
@@ -4507,10 +4518,12 @@
 		},
 		"node_modules/@octokit/auth-oauth-app/node_modules/@octokit/openapi-types": {
 			"version": "24.2.0",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@octokit/auth-oauth-app/node_modules/@octokit/types": {
 			"version": "13.10.0",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@octokit/openapi-types": "^24.2.0"
@@ -4518,6 +4531,7 @@
 		},
 		"node_modules/@octokit/auth-oauth-device": {
 			"version": "6.1.0",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@octokit/oauth-methods": "^4.1.0",
@@ -4531,10 +4545,12 @@
 		},
 		"node_modules/@octokit/auth-oauth-device/node_modules/@octokit/openapi-types": {
 			"version": "24.2.0",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@octokit/auth-oauth-device/node_modules/@octokit/types": {
 			"version": "13.10.0",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@octokit/openapi-types": "^24.2.0"
@@ -4542,6 +4558,7 @@
 		},
 		"node_modules/@octokit/auth-oauth-user": {
 			"version": "4.1.0",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@octokit/auth-oauth-device": "^6.1.0",
@@ -4557,10 +4574,12 @@
 		},
 		"node_modules/@octokit/auth-oauth-user/node_modules/@octokit/openapi-types": {
 			"version": "24.2.0",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@octokit/auth-oauth-user/node_modules/@octokit/types": {
 			"version": "13.10.0",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@octokit/openapi-types": "^24.2.0"
@@ -4568,6 +4587,7 @@
 		},
 		"node_modules/@octokit/auth-token": {
 			"version": "4.0.0",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 18"
@@ -4575,6 +4595,7 @@
 		},
 		"node_modules/@octokit/auth-unauthenticated": {
 			"version": "5.0.1",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@octokit/request-error": "^5.0.0",
@@ -4586,7 +4607,9 @@
 		},
 		"node_modules/@octokit/core": {
 			"version": "5.2.2",
+			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@octokit/auth-token": "^4.0.0",
 				"@octokit/graphql": "^7.1.0",
@@ -4602,10 +4625,12 @@
 		},
 		"node_modules/@octokit/core/node_modules/@octokit/openapi-types": {
 			"version": "24.2.0",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@octokit/core/node_modules/@octokit/types": {
 			"version": "13.10.0",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@octokit/openapi-types": "^24.2.0"
@@ -4613,6 +4638,7 @@
 		},
 		"node_modules/@octokit/endpoint": {
 			"version": "9.0.6",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@octokit/types": "^13.1.0",
@@ -4624,10 +4650,12 @@
 		},
 		"node_modules/@octokit/endpoint/node_modules/@octokit/openapi-types": {
 			"version": "24.2.0",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@octokit/endpoint/node_modules/@octokit/types": {
 			"version": "13.10.0",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@octokit/openapi-types": "^24.2.0"
@@ -4635,6 +4663,7 @@
 		},
 		"node_modules/@octokit/graphql": {
 			"version": "7.1.1",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@octokit/request": "^8.4.1",
@@ -4647,10 +4676,12 @@
 		},
 		"node_modules/@octokit/graphql/node_modules/@octokit/openapi-types": {
 			"version": "24.2.0",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@octokit/graphql/node_modules/@octokit/types": {
 			"version": "13.10.0",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@octokit/openapi-types": "^24.2.0"
@@ -4658,6 +4689,7 @@
 		},
 		"node_modules/@octokit/oauth-app": {
 			"version": "6.1.0",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@octokit/auth-oauth-app": "^7.0.0",
@@ -4675,6 +4707,7 @@
 		},
 		"node_modules/@octokit/oauth-authorization-url": {
 			"version": "6.0.2",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 18"
@@ -4682,6 +4715,7 @@
 		},
 		"node_modules/@octokit/oauth-methods": {
 			"version": "4.1.0",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@octokit/oauth-authorization-url": "^6.0.2",
@@ -4696,10 +4730,12 @@
 		},
 		"node_modules/@octokit/oauth-methods/node_modules/@octokit/openapi-types": {
 			"version": "24.2.0",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@octokit/oauth-methods/node_modules/@octokit/types": {
 			"version": "13.10.0",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@octokit/openapi-types": "^24.2.0"
@@ -4707,10 +4743,12 @@
 		},
 		"node_modules/@octokit/openapi-types": {
 			"version": "20.0.0",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@octokit/plugin-paginate-graphql": {
 			"version": "4.0.1",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 18"
@@ -4721,6 +4759,7 @@
 		},
 		"node_modules/@octokit/plugin-paginate-rest": {
 			"version": "9.2.2",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@octokit/types": "^12.6.0"
@@ -4734,6 +4773,7 @@
 		},
 		"node_modules/@octokit/plugin-rest-endpoint-methods": {
 			"version": "10.4.1",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@octokit/types": "^12.6.0"
@@ -4747,6 +4787,7 @@
 		},
 		"node_modules/@octokit/plugin-retry": {
 			"version": "6.1.0",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@octokit/request-error": "^5.0.0",
@@ -4762,10 +4803,12 @@
 		},
 		"node_modules/@octokit/plugin-retry/node_modules/@octokit/openapi-types": {
 			"version": "24.2.0",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@octokit/plugin-retry/node_modules/@octokit/types": {
 			"version": "13.10.0",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@octokit/openapi-types": "^24.2.0"
@@ -4773,6 +4816,7 @@
 		},
 		"node_modules/@octokit/plugin-throttling": {
 			"version": "8.2.0",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@octokit/types": "^12.2.0",
@@ -4787,6 +4831,7 @@
 		},
 		"node_modules/@octokit/request": {
 			"version": "8.4.1",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@octokit/endpoint": "^9.0.6",
@@ -4800,6 +4845,7 @@
 		},
 		"node_modules/@octokit/request-error": {
 			"version": "5.1.1",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@octokit/types": "^13.1.0",
@@ -4812,10 +4858,12 @@
 		},
 		"node_modules/@octokit/request-error/node_modules/@octokit/openapi-types": {
 			"version": "24.2.0",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@octokit/request-error/node_modules/@octokit/types": {
 			"version": "13.10.0",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@octokit/openapi-types": "^24.2.0"
@@ -4823,10 +4871,12 @@
 		},
 		"node_modules/@octokit/request/node_modules/@octokit/openapi-types": {
 			"version": "24.2.0",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@octokit/request/node_modules/@octokit/types": {
 			"version": "13.10.0",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@octokit/openapi-types": "^24.2.0"
@@ -4834,6 +4884,7 @@
 		},
 		"node_modules/@octokit/types": {
 			"version": "12.6.0",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@octokit/openapi-types": "^20.0.0"
@@ -4841,6 +4892,7 @@
 		},
 		"node_modules/@octokit/webhooks": {
 			"version": "12.3.2",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@octokit/request-error": "^5.0.0",
@@ -4854,6 +4906,7 @@
 		},
 		"node_modules/@octokit/webhooks-methods": {
 			"version": "4.1.0",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 18"
@@ -4861,11 +4914,13 @@
 		},
 		"node_modules/@octokit/webhooks-types": {
 			"version": "7.6.1",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@opentelemetry/api": {
 			"version": "1.9.0",
 			"license": "Apache-2.0",
+			"peer": true,
 			"engines": {
 				"node": ">=8.0.0"
 			}
@@ -4883,6 +4938,7 @@
 		"node_modules/@opentelemetry/context-async-hooks": {
 			"version": "1.30.1",
 			"license": "Apache-2.0",
+			"peer": true,
 			"engines": {
 				"node": ">=14"
 			},
@@ -4893,6 +4949,7 @@
 		"node_modules/@opentelemetry/core": {
 			"version": "1.30.1",
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"@opentelemetry/semantic-conventions": "1.28.0"
 			},
@@ -4913,6 +4970,7 @@
 		"node_modules/@opentelemetry/instrumentation": {
 			"version": "0.57.2",
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"@opentelemetry/api-logs": "0.57.2",
 				"@types/shimmer": "^1.2.0",
@@ -5268,6 +5326,7 @@
 		"node_modules/@opentelemetry/resources": {
 			"version": "1.30.1",
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"@opentelemetry/core": "1.30.1",
 				"@opentelemetry/semantic-conventions": "1.28.0"
@@ -5289,6 +5348,7 @@
 		"node_modules/@opentelemetry/sdk-trace-base": {
 			"version": "1.30.1",
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"@opentelemetry/core": "1.30.1",
 				"@opentelemetry/resources": "1.30.1",
@@ -5311,6 +5371,7 @@
 		"node_modules/@opentelemetry/semantic-conventions": {
 			"version": "1.37.0",
 			"license": "Apache-2.0",
+			"peer": true,
 			"engines": {
 				"node": ">=14"
 			}
@@ -5337,6 +5398,7 @@
 		},
 		"node_modules/@peculiar/asn1-cms": {
 			"version": "2.6.0",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@peculiar/asn1-schema": "^2.6.0",
@@ -5348,6 +5410,7 @@
 		},
 		"node_modules/@peculiar/asn1-csr": {
 			"version": "2.6.0",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@peculiar/asn1-schema": "^2.6.0",
@@ -5358,6 +5421,7 @@
 		},
 		"node_modules/@peculiar/asn1-ecc": {
 			"version": "2.6.0",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@peculiar/asn1-schema": "^2.6.0",
@@ -5368,6 +5432,7 @@
 		},
 		"node_modules/@peculiar/asn1-pfx": {
 			"version": "2.6.0",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@peculiar/asn1-cms": "^2.6.0",
@@ -5380,6 +5445,7 @@
 		},
 		"node_modules/@peculiar/asn1-pkcs8": {
 			"version": "2.6.0",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@peculiar/asn1-schema": "^2.6.0",
@@ -5390,6 +5456,7 @@
 		},
 		"node_modules/@peculiar/asn1-pkcs9": {
 			"version": "2.6.0",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@peculiar/asn1-cms": "^2.6.0",
@@ -5404,6 +5471,7 @@
 		},
 		"node_modules/@peculiar/asn1-rsa": {
 			"version": "2.6.0",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@peculiar/asn1-schema": "^2.6.0",
@@ -5414,6 +5482,7 @@
 		},
 		"node_modules/@peculiar/asn1-schema": {
 			"version": "2.6.0",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"asn1js": "^3.0.6",
@@ -5423,6 +5492,7 @@
 		},
 		"node_modules/@peculiar/asn1-x509": {
 			"version": "2.6.0",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@peculiar/asn1-schema": "^2.6.0",
@@ -5433,6 +5503,7 @@
 		},
 		"node_modules/@peculiar/asn1-x509-attr": {
 			"version": "2.6.0",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@peculiar/asn1-schema": "^2.6.0",
@@ -5443,6 +5514,7 @@
 		},
 		"node_modules/@peculiar/x509": {
 			"version": "1.14.3",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@peculiar/asn1-cms": "^2.6.0",
@@ -5463,6 +5535,7 @@
 		},
 		"node_modules/@php-wasm/fs-journal": {
 			"version": "3.0.46",
+			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@php-wasm/logger": "3.0.46",
@@ -5485,6 +5558,7 @@
 		},
 		"node_modules/@php-wasm/fs-journal/node_modules/cliui": {
 			"version": "8.0.1",
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"string-width": "^4.2.0",
@@ -5497,6 +5571,7 @@
 		},
 		"node_modules/@php-wasm/fs-journal/node_modules/debug": {
 			"version": "2.6.9",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ms": "2.0.0"
@@ -5504,6 +5579,7 @@
 		},
 		"node_modules/@php-wasm/fs-journal/node_modules/encodeurl": {
 			"version": "2.0.0",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.8"
@@ -5511,6 +5587,7 @@
 		},
 		"node_modules/@php-wasm/fs-journal/node_modules/express": {
 			"version": "4.22.0",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"accepts": "~1.3.8",
@@ -5555,6 +5632,7 @@
 		},
 		"node_modules/@php-wasm/fs-journal/node_modules/ini": {
 			"version": "4.1.2",
+			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -5562,10 +5640,12 @@
 		},
 		"node_modules/@php-wasm/fs-journal/node_modules/ms": {
 			"version": "2.0.0",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@php-wasm/fs-journal/node_modules/safe-buffer": {
 			"version": "5.2.1",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -5584,6 +5664,7 @@
 		},
 		"node_modules/@php-wasm/fs-journal/node_modules/strip-ansi": {
 			"version": "6.0.1",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ansi-regex": "^5.0.1"
@@ -5594,6 +5675,7 @@
 		},
 		"node_modules/@php-wasm/fs-journal/node_modules/yargs": {
 			"version": "17.7.2",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"cliui": "^8.0.1",
@@ -5610,6 +5692,7 @@
 		},
 		"node_modules/@php-wasm/fs-journal/node_modules/yargs-parser": {
 			"version": "21.1.1",
+			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": ">=12"
@@ -5617,6 +5700,7 @@
 		},
 		"node_modules/@php-wasm/logger": {
 			"version": "3.0.46",
+			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@php-wasm/node-polyfills": "3.0.46"
@@ -5631,6 +5715,7 @@
 		},
 		"node_modules/@php-wasm/node": {
 			"version": "3.0.46",
+			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@php-wasm/logger": "3.0.46",
@@ -5661,6 +5746,7 @@
 		},
 		"node_modules/@php-wasm/node-7-4": {
 			"version": "3.0.46",
+			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@php-wasm/universal": "3.0.46",
@@ -5678,6 +5764,7 @@
 		},
 		"node_modules/@php-wasm/node-7-4/node_modules/ini": {
 			"version": "4.1.2",
+			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -5685,6 +5772,7 @@
 		},
 		"node_modules/@php-wasm/node-8-0": {
 			"version": "3.0.46",
+			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@php-wasm/universal": "3.0.46",
@@ -5702,6 +5790,7 @@
 		},
 		"node_modules/@php-wasm/node-8-0/node_modules/ini": {
 			"version": "4.1.2",
+			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -5709,6 +5798,7 @@
 		},
 		"node_modules/@php-wasm/node-8-1": {
 			"version": "3.0.46",
+			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@php-wasm/universal": "3.0.46",
@@ -5726,6 +5816,7 @@
 		},
 		"node_modules/@php-wasm/node-8-1/node_modules/ini": {
 			"version": "4.1.2",
+			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -5733,6 +5824,7 @@
 		},
 		"node_modules/@php-wasm/node-8-2": {
 			"version": "3.0.46",
+			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@php-wasm/universal": "3.0.46",
@@ -5750,6 +5842,7 @@
 		},
 		"node_modules/@php-wasm/node-8-2/node_modules/ini": {
 			"version": "4.1.2",
+			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -5757,6 +5850,7 @@
 		},
 		"node_modules/@php-wasm/node-8-3": {
 			"version": "3.0.46",
+			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@php-wasm/universal": "3.0.46",
@@ -5774,6 +5868,7 @@
 		},
 		"node_modules/@php-wasm/node-8-3/node_modules/ini": {
 			"version": "4.1.2",
+			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -5781,6 +5876,7 @@
 		},
 		"node_modules/@php-wasm/node-8-4": {
 			"version": "3.0.46",
+			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@php-wasm/universal": "3.0.46",
@@ -5798,6 +5894,7 @@
 		},
 		"node_modules/@php-wasm/node-8-4/node_modules/ini": {
 			"version": "4.1.2",
+			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -5805,6 +5902,7 @@
 		},
 		"node_modules/@php-wasm/node-8-5": {
 			"version": "3.0.46",
+			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@php-wasm/universal": "3.0.46",
@@ -5822,6 +5920,7 @@
 		},
 		"node_modules/@php-wasm/node-8-5/node_modules/ini": {
 			"version": "4.1.2",
+			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -5829,6 +5928,7 @@
 		},
 		"node_modules/@php-wasm/node-polyfills": {
 			"version": "3.0.46",
+			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"optionalDependencies": {
 				"fs-ext": "2.1.1"
@@ -5836,6 +5936,7 @@
 		},
 		"node_modules/@php-wasm/node/node_modules/cliui": {
 			"version": "8.0.1",
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"string-width": "^4.2.0",
@@ -5848,6 +5949,7 @@
 		},
 		"node_modules/@php-wasm/node/node_modules/debug": {
 			"version": "2.6.9",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ms": "2.0.0"
@@ -5855,6 +5957,7 @@
 		},
 		"node_modules/@php-wasm/node/node_modules/encodeurl": {
 			"version": "2.0.0",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.8"
@@ -5862,6 +5965,7 @@
 		},
 		"node_modules/@php-wasm/node/node_modules/express": {
 			"version": "4.22.0",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"accepts": "~1.3.8",
@@ -5906,6 +6010,7 @@
 		},
 		"node_modules/@php-wasm/node/node_modules/ini": {
 			"version": "4.1.2",
+			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -5913,10 +6018,12 @@
 		},
 		"node_modules/@php-wasm/node/node_modules/ms": {
 			"version": "2.0.0",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@php-wasm/node/node_modules/safe-buffer": {
 			"version": "5.2.1",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -5935,6 +6042,7 @@
 		},
 		"node_modules/@php-wasm/node/node_modules/strip-ansi": {
 			"version": "6.0.1",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ansi-regex": "^5.0.1"
@@ -5945,6 +6053,7 @@
 		},
 		"node_modules/@php-wasm/node/node_modules/yargs": {
 			"version": "17.7.2",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"cliui": "^8.0.1",
@@ -5961,6 +6070,7 @@
 		},
 		"node_modules/@php-wasm/node/node_modules/yargs-parser": {
 			"version": "21.1.1",
+			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": ">=12"
@@ -5968,6 +6078,7 @@
 		},
 		"node_modules/@php-wasm/progress": {
 			"version": "3.0.46",
+			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@php-wasm/logger": "3.0.46",
@@ -5983,6 +6094,7 @@
 		},
 		"node_modules/@php-wasm/scopes": {
 			"version": "3.0.46",
+			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=20.18.3",
@@ -5994,6 +6106,7 @@
 		},
 		"node_modules/@php-wasm/stream-compression": {
 			"version": "3.0.46",
+			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@php-wasm/node-polyfills": "3.0.46",
@@ -6005,6 +6118,7 @@
 		},
 		"node_modules/@php-wasm/universal": {
 			"version": "3.0.46",
+			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@php-wasm/logger": "3.0.46",
@@ -6024,6 +6138,7 @@
 		},
 		"node_modules/@php-wasm/universal/node_modules/ini": {
 			"version": "4.1.2",
+			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -6031,6 +6146,7 @@
 		},
 		"node_modules/@php-wasm/util": {
 			"version": "3.0.46",
+			"dev": true,
 			"engines": {
 				"node": ">=20.18.3",
 				"npm": ">=10.1.0"
@@ -6041,6 +6157,7 @@
 		},
 		"node_modules/@php-wasm/web": {
 			"version": "3.0.46",
+			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@php-wasm/fs-journal": "3.0.46",
@@ -6073,6 +6190,7 @@
 		},
 		"node_modules/@php-wasm/web-7-4": {
 			"version": "3.0.46",
+			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@php-wasm/universal": "3.0.46",
@@ -6089,6 +6207,7 @@
 		},
 		"node_modules/@php-wasm/web-7-4/node_modules/ini": {
 			"version": "4.1.2",
+			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -6096,6 +6215,7 @@
 		},
 		"node_modules/@php-wasm/web-8-0": {
 			"version": "3.0.46",
+			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@php-wasm/universal": "3.0.46",
@@ -6112,6 +6232,7 @@
 		},
 		"node_modules/@php-wasm/web-8-0/node_modules/ini": {
 			"version": "4.1.2",
+			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -6119,6 +6240,7 @@
 		},
 		"node_modules/@php-wasm/web-8-1": {
 			"version": "3.0.46",
+			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@php-wasm/universal": "3.0.46",
@@ -6135,6 +6257,7 @@
 		},
 		"node_modules/@php-wasm/web-8-1/node_modules/ini": {
 			"version": "4.1.2",
+			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -6142,6 +6265,7 @@
 		},
 		"node_modules/@php-wasm/web-8-2": {
 			"version": "3.0.46",
+			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@php-wasm/universal": "3.0.46",
@@ -6158,6 +6282,7 @@
 		},
 		"node_modules/@php-wasm/web-8-2/node_modules/ini": {
 			"version": "4.1.2",
+			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -6165,6 +6290,7 @@
 		},
 		"node_modules/@php-wasm/web-8-3": {
 			"version": "3.0.46",
+			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@php-wasm/universal": "3.0.46",
@@ -6181,6 +6307,7 @@
 		},
 		"node_modules/@php-wasm/web-8-3/node_modules/ini": {
 			"version": "4.1.2",
+			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -6188,6 +6315,7 @@
 		},
 		"node_modules/@php-wasm/web-8-4": {
 			"version": "3.0.46",
+			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@php-wasm/universal": "3.0.46",
@@ -6204,6 +6332,7 @@
 		},
 		"node_modules/@php-wasm/web-8-4/node_modules/ini": {
 			"version": "4.1.2",
+			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -6211,6 +6340,7 @@
 		},
 		"node_modules/@php-wasm/web-8-5": {
 			"version": "3.0.46",
+			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@php-wasm/universal": "3.0.46",
@@ -6227,6 +6357,7 @@
 		},
 		"node_modules/@php-wasm/web-8-5/node_modules/ini": {
 			"version": "4.1.2",
+			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -6234,6 +6365,7 @@
 		},
 		"node_modules/@php-wasm/web-service-worker": {
 			"version": "3.0.46",
+			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@php-wasm/scopes": "3.0.46"
@@ -6248,6 +6380,7 @@
 		},
 		"node_modules/@php-wasm/web/node_modules/cliui": {
 			"version": "8.0.1",
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"string-width": "^4.2.0",
@@ -6260,6 +6393,7 @@
 		},
 		"node_modules/@php-wasm/web/node_modules/debug": {
 			"version": "2.6.9",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ms": "2.0.0"
@@ -6267,6 +6401,7 @@
 		},
 		"node_modules/@php-wasm/web/node_modules/encodeurl": {
 			"version": "2.0.0",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.8"
@@ -6274,6 +6409,7 @@
 		},
 		"node_modules/@php-wasm/web/node_modules/express": {
 			"version": "4.22.0",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"accepts": "~1.3.8",
@@ -6318,6 +6454,7 @@
 		},
 		"node_modules/@php-wasm/web/node_modules/ini": {
 			"version": "4.1.2",
+			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -6325,10 +6462,12 @@
 		},
 		"node_modules/@php-wasm/web/node_modules/ms": {
 			"version": "2.0.0",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@php-wasm/web/node_modules/safe-buffer": {
 			"version": "5.2.1",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -6347,6 +6486,7 @@
 		},
 		"node_modules/@php-wasm/web/node_modules/strip-ansi": {
 			"version": "6.0.1",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ansi-regex": "^5.0.1"
@@ -6357,6 +6497,7 @@
 		},
 		"node_modules/@php-wasm/web/node_modules/yargs": {
 			"version": "17.7.2",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"cliui": "^8.0.1",
@@ -6373,6 +6514,7 @@
 		},
 		"node_modules/@php-wasm/web/node_modules/yargs-parser": {
 			"version": "21.1.1",
+			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": ">=12"
@@ -7306,6 +7448,7 @@
 			"devOptional": true,
 			"hasInstallScript": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"@swc/counter": "^0.1.3",
 				"@swc/types": "^0.1.24"
@@ -7369,7 +7512,8 @@
 		"node_modules/@swc/wasm": {
 			"version": "1.13.5",
 			"devOptional": true,
-			"license": "Apache-2.0"
+			"license": "Apache-2.0",
+			"peer": true
 		},
 		"node_modules/@szmarczak/http-timer": {
 			"version": "4.0.6",
@@ -7533,11 +7677,11 @@
 		"node_modules/@types/aria-query": {
 			"version": "5.0.4",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/@types/aws-lambda": {
 			"version": "8.10.160",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@types/babel__core": {
@@ -7579,6 +7723,7 @@
 		},
 		"node_modules/@types/btoa-lite": {
 			"version": "1.0.2",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@types/cacheable-request": {
@@ -7709,6 +7854,7 @@
 		},
 		"node_modules/@types/jsonwebtoken": {
 			"version": "9.0.10",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@types/ms": "*",
@@ -7767,6 +7913,7 @@
 		"node_modules/@types/node": {
 			"version": "22.19.7",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"undici-types": "~6.21.0"
 			}
@@ -7806,6 +7953,7 @@
 		"node_modules/@types/react": {
 			"version": "18.3.27",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@types/prop-types": "*",
 				"csstype": "^3.2.2"
@@ -7814,6 +7962,7 @@
 		"node_modules/@types/react-dom": {
 			"version": "18.3.7",
 			"license": "MIT",
+			"peer": true,
 			"peerDependencies": {
 				"@types/react": "^18.0.0"
 			}
@@ -7933,6 +8082,7 @@
 			"version": "8.53.1",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/scope-manager": "8.53.1",
 				"@typescript-eslint/types": "8.53.1",
@@ -8257,6 +8407,7 @@
 			"version": "2.1.8",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@vitest/utils": "2.1.8",
 				"fflate": "^0.8.2",
@@ -8913,6 +9064,7 @@
 		},
 		"node_modules/@wp-playground/blueprints": {
 			"version": "3.0.46",
+			"dev": true,
 			"dependencies": {
 				"@php-wasm/logger": "3.0.46",
 				"@php-wasm/node": "3.0.46",
@@ -8957,6 +9109,7 @@
 		},
 		"node_modules/@wp-playground/blueprints/node_modules/ajv": {
 			"version": "8.12.0",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"fast-deep-equal": "^3.1.1",
@@ -8971,6 +9124,7 @@
 		},
 		"node_modules/@wp-playground/blueprints/node_modules/cliui": {
 			"version": "8.0.1",
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"string-width": "^4.2.0",
@@ -8983,6 +9137,7 @@
 		},
 		"node_modules/@wp-playground/blueprints/node_modules/debug": {
 			"version": "2.6.9",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ms": "2.0.0"
@@ -8990,6 +9145,7 @@
 		},
 		"node_modules/@wp-playground/blueprints/node_modules/encodeurl": {
 			"version": "2.0.0",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.8"
@@ -8997,6 +9153,7 @@
 		},
 		"node_modules/@wp-playground/blueprints/node_modules/express": {
 			"version": "4.22.0",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"accepts": "~1.3.8",
@@ -9041,6 +9198,7 @@
 		},
 		"node_modules/@wp-playground/blueprints/node_modules/ini": {
 			"version": "4.1.2",
+			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -9048,18 +9206,22 @@
 		},
 		"node_modules/@wp-playground/blueprints/node_modules/json-schema-traverse": {
 			"version": "1.0.0",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@wp-playground/blueprints/node_modules/ms": {
 			"version": "2.0.0",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@wp-playground/blueprints/node_modules/pako": {
 			"version": "1.0.10",
+			"dev": true,
 			"license": "(MIT AND Zlib)"
 		},
 		"node_modules/@wp-playground/blueprints/node_modules/safe-buffer": {
 			"version": "5.2.1",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -9078,6 +9240,7 @@
 		},
 		"node_modules/@wp-playground/blueprints/node_modules/strip-ansi": {
 			"version": "6.0.1",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ansi-regex": "^5.0.1"
@@ -9088,6 +9251,7 @@
 		},
 		"node_modules/@wp-playground/blueprints/node_modules/yargs": {
 			"version": "17.7.2",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"cliui": "^8.0.1",
@@ -9104,6 +9268,7 @@
 		},
 		"node_modules/@wp-playground/blueprints/node_modules/yargs-parser": {
 			"version": "21.1.1",
+			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": ">=12"
@@ -9111,6 +9276,7 @@
 		},
 		"node_modules/@wp-playground/common": {
 			"version": "3.0.46",
+			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@php-wasm/universal": "3.0.46",
@@ -9127,6 +9293,7 @@
 		},
 		"node_modules/@wp-playground/common/node_modules/ini": {
 			"version": "4.1.2",
+			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -9134,6 +9301,7 @@
 		},
 		"node_modules/@wp-playground/storage": {
 			"version": "3.0.46",
+			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@php-wasm/stream-compression": "3.0.46",
@@ -9166,6 +9334,7 @@
 		},
 		"node_modules/@wp-playground/storage/node_modules/cliui": {
 			"version": "8.0.1",
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"string-width": "^4.2.0",
@@ -9178,6 +9347,7 @@
 		},
 		"node_modules/@wp-playground/storage/node_modules/debug": {
 			"version": "2.6.9",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ms": "2.0.0"
@@ -9185,10 +9355,12 @@
 		},
 		"node_modules/@wp-playground/storage/node_modules/diff3": {
 			"version": "0.0.3",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@wp-playground/storage/node_modules/encodeurl": {
 			"version": "2.0.0",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.8"
@@ -9196,6 +9368,7 @@
 		},
 		"node_modules/@wp-playground/storage/node_modules/express": {
 			"version": "4.22.0",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"accepts": "~1.3.8",
@@ -9240,6 +9413,7 @@
 		},
 		"node_modules/@wp-playground/storage/node_modules/ini": {
 			"version": "4.1.2",
+			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -9247,10 +9421,12 @@
 		},
 		"node_modules/@wp-playground/storage/node_modules/ms": {
 			"version": "2.0.0",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@wp-playground/storage/node_modules/pify": {
 			"version": "4.0.1",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
@@ -9258,6 +9434,7 @@
 		},
 		"node_modules/@wp-playground/storage/node_modules/safe-buffer": {
 			"version": "5.2.1",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -9276,6 +9453,7 @@
 		},
 		"node_modules/@wp-playground/storage/node_modules/strip-ansi": {
 			"version": "6.0.1",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ansi-regex": "^5.0.1"
@@ -9286,6 +9464,7 @@
 		},
 		"node_modules/@wp-playground/storage/node_modules/yargs": {
 			"version": "17.7.2",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"cliui": "^8.0.1",
@@ -9302,6 +9481,7 @@
 		},
 		"node_modules/@wp-playground/storage/node_modules/yargs-parser": {
 			"version": "21.1.1",
+			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": ">=12"
@@ -9309,6 +9489,7 @@
 		},
 		"node_modules/@wp-playground/wordpress": {
 			"version": "3.0.46",
+			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@php-wasm/logger": "3.0.46",
@@ -9332,6 +9513,7 @@
 		},
 		"node_modules/@wp-playground/wordpress/node_modules/cliui": {
 			"version": "8.0.1",
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"string-width": "^4.2.0",
@@ -9344,6 +9526,7 @@
 		},
 		"node_modules/@wp-playground/wordpress/node_modules/debug": {
 			"version": "2.6.9",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ms": "2.0.0"
@@ -9351,6 +9534,7 @@
 		},
 		"node_modules/@wp-playground/wordpress/node_modules/encodeurl": {
 			"version": "2.0.0",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.8"
@@ -9358,6 +9542,7 @@
 		},
 		"node_modules/@wp-playground/wordpress/node_modules/express": {
 			"version": "4.22.0",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"accepts": "~1.3.8",
@@ -9402,6 +9587,7 @@
 		},
 		"node_modules/@wp-playground/wordpress/node_modules/ini": {
 			"version": "4.1.2",
+			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -9409,10 +9595,12 @@
 		},
 		"node_modules/@wp-playground/wordpress/node_modules/ms": {
 			"version": "2.0.0",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@wp-playground/wordpress/node_modules/safe-buffer": {
 			"version": "5.2.1",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -9431,6 +9619,7 @@
 		},
 		"node_modules/@wp-playground/wordpress/node_modules/strip-ansi": {
 			"version": "6.0.1",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ansi-regex": "^5.0.1"
@@ -9441,6 +9630,7 @@
 		},
 		"node_modules/@wp-playground/wordpress/node_modules/yargs": {
 			"version": "17.7.2",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"cliui": "^8.0.1",
@@ -9457,6 +9647,7 @@
 		},
 		"node_modules/@wp-playground/wordpress/node_modules/yargs-parser": {
 			"version": "21.1.1",
+			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": ">=12"
@@ -9487,6 +9678,7 @@
 		},
 		"node_modules/@zip.js/zip.js": {
 			"version": "2.7.57",
+			"dev": true,
 			"license": "BSD-3-Clause",
 			"engines": {
 				"bun": ">=0.7.0",
@@ -9513,6 +9705,7 @@
 		"node_modules/acorn": {
 			"version": "8.15.0",
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -9576,6 +9769,7 @@
 		},
 		"node_modules/aggregate-error": {
 			"version": "3.1.0",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"clean-stack": "^2.0.0",
@@ -9961,6 +10155,7 @@
 		},
 		"node_modules/asn1js": {
 			"version": "3.0.7",
+			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"pvtsutils": "^1.3.6",
@@ -9985,6 +10180,7 @@
 		},
 		"node_modules/async-lock": {
 			"version": "1.4.1",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/asynckit": {
@@ -10017,6 +10213,7 @@
 		},
 		"node_modules/available-typed-arrays": {
 			"version": "1.0.7",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"possible-typed-array-names": "^1.0.0"
@@ -10138,6 +10335,7 @@
 		},
 		"node_modules/before-after-hook": {
 			"version": "2.2.3",
+			"dev": true,
 			"license": "Apache-2.0"
 		},
 		"node_modules/binary-extensions": {
@@ -10217,6 +10415,7 @@
 		},
 		"node_modules/bottleneck": {
 			"version": "2.19.5",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/bplist-creator": {
@@ -10264,6 +10463,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"baseline-browser-mapping": "^2.9.0",
 				"caniuse-lite": "^1.0.30001759",
@@ -10280,6 +10480,7 @@
 		},
 		"node_modules/btoa-lite": {
 			"version": "1.0.0",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/buffer": {
@@ -10314,6 +10515,7 @@
 		},
 		"node_modules/buffer-equal-constant-time": {
 			"version": "1.0.1",
+			"dev": true,
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/buffer-from": {
@@ -10333,6 +10535,7 @@
 		},
 		"node_modules/bytestreamjs": {
 			"version": "2.0.1",
+			"dev": true,
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=6.0.0"
@@ -10542,6 +10745,7 @@
 		},
 		"node_modules/call-bind": {
 			"version": "1.0.8",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"call-bind-apply-helpers": "^1.0.0",
@@ -10807,10 +11011,12 @@
 		},
 		"node_modules/clean-git-ref": {
 			"version": "2.0.1",
+			"dev": true,
 			"license": "Apache-2.0"
 		},
 		"node_modules/clean-stack": {
 			"version": "2.2.0",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
@@ -11193,6 +11399,7 @@
 		},
 		"node_modules/cookie": {
 			"version": "0.7.2",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.6"
@@ -11460,6 +11667,7 @@
 		},
 		"node_modules/decompress-response": {
 			"version": "6.0.0",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"mimic-response": "^3.1.0"
@@ -11473,6 +11681,7 @@
 		},
 		"node_modules/decompress-response/node_modules/mimic-response": {
 			"version": "3.1.0",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=10"
@@ -11521,6 +11730,7 @@
 		},
 		"node_modules/define-data-property": {
 			"version": "1.1.4",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"es-define-property": "^1.0.0",
@@ -11570,6 +11780,7 @@
 		},
 		"node_modules/deprecation": {
 			"version": "2.3.1",
+			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/dequal": {
@@ -11634,6 +11845,7 @@
 		},
 		"node_modules/diff3": {
 			"version": "0.0.4",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/dir-compare": {
@@ -11653,8 +11865,7 @@
 		"node_modules/dom-accessibility-api": {
 			"version": "0.5.16",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/dot-case": {
 			"version": "3.0.4",
@@ -11704,6 +11915,7 @@
 		},
 		"node_modules/ecdsa-sig-formatter": {
 			"version": "1.0.11",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"safe-buffer": "^5.0.1"
@@ -12527,6 +12739,7 @@
 		"node_modules/eslint": {
 			"version": "9.39.2",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.8.0",
 				"@eslint-community/regexpp": "^4.12.1",
@@ -12584,6 +12797,7 @@
 		"node_modules/eslint-config-prettier": {
 			"version": "10.1.8",
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"eslint-config-prettier": "bin/cli.js"
 			},
@@ -12696,6 +12910,7 @@
 			"version": "2.32.0",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@rtsao/scc": "^1.1.0",
 				"array-includes": "^3.1.9",
@@ -13428,6 +13643,7 @@
 		},
 		"node_modules/finalhandler": {
 			"version": "1.3.2",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"debug": "2.6.9",
@@ -13444,6 +13660,7 @@
 		},
 		"node_modules/finalhandler/node_modules/debug": {
 			"version": "2.6.9",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ms": "2.0.0"
@@ -13451,6 +13668,7 @@
 		},
 		"node_modules/finalhandler/node_modules/encodeurl": {
 			"version": "2.0.0",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.8"
@@ -13458,10 +13676,12 @@
 		},
 		"node_modules/finalhandler/node_modules/ms": {
 			"version": "2.0.0",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/finalhandler/node_modules/statuses": {
 			"version": "2.0.2",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.8"
@@ -13561,6 +13781,7 @@
 		},
 		"node_modules/for-each": {
 			"version": "0.3.5",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"is-callable": "^1.2.7"
@@ -13672,6 +13893,7 @@
 		},
 		"node_modules/fs-ext": {
 			"version": "2.1.1",
+			"dev": true,
 			"hasInstallScript": true,
 			"optional": true,
 			"dependencies": {
@@ -14128,6 +14350,7 @@
 		},
 		"node_modules/has-property-descriptors": {
 			"version": "1.0.2",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"es-define-property": "^1.0.0"
@@ -14575,6 +14798,7 @@
 		},
 		"node_modules/indent-string": {
 			"version": "4.0.0",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -14942,6 +15166,7 @@
 		},
 		"node_modules/is-callable": {
 			"version": "1.2.7",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
@@ -15260,6 +15485,7 @@
 		},
 		"node_modules/is-typed-array": {
 			"version": "1.1.15",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"which-typed-array": "^1.1.16"
@@ -15335,6 +15561,7 @@
 		},
 		"node_modules/isarray": {
 			"version": "2.0.5",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/isbinaryfile": {
@@ -15562,6 +15789,7 @@
 		},
 		"node_modules/jsonwebtoken": {
 			"version": "9.0.3",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"jws": "^4.0.1",
@@ -15628,6 +15856,7 @@
 		},
 		"node_modules/jwa": {
 			"version": "2.0.1",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"buffer-equal-constant-time": "^1.0.1",
@@ -15637,6 +15866,7 @@
 		},
 		"node_modules/jws": {
 			"version": "4.0.1",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"jwa": "^2.0.1",
@@ -15927,26 +16157,32 @@
 		},
 		"node_modules/lodash.includes": {
 			"version": "4.3.0",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/lodash.isboolean": {
 			"version": "3.0.3",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/lodash.isinteger": {
 			"version": "4.0.4",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/lodash.isnumber": {
 			"version": "3.0.3",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/lodash.isplainobject": {
 			"version": "4.0.6",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/lodash.isstring": {
 			"version": "4.0.1",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/lodash.merge": {
@@ -15960,6 +16196,7 @@
 		},
 		"node_modules/lodash.once": {
 			"version": "4.1.1",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/lodash.throttle": {
@@ -16130,7 +16367,6 @@
 			"version": "1.5.0",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"lz-string": "bin/bin.js"
 			}
@@ -17126,6 +17362,7 @@
 		},
 		"node_modules/minimist": {
 			"version": "1.2.8",
+			"devOptional": true,
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -17133,6 +17370,7 @@
 		},
 		"node_modules/minimisted": {
 			"version": "2.0.1",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"minimist": "^1.2.5"
@@ -17655,6 +17893,7 @@
 		},
 		"node_modules/octokit": {
 			"version": "3.1.2",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@octokit/app": "^14.0.2",
@@ -17961,6 +18200,7 @@
 		},
 		"node_modules/pako": {
 			"version": "1.0.11",
+			"dev": true,
 			"license": "(MIT AND Zlib)"
 		},
 		"node_modules/param-case": {
@@ -18279,6 +18519,7 @@
 		},
 		"node_modules/pify": {
 			"version": "2.3.0",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -18294,6 +18535,7 @@
 		},
 		"node_modules/pkijs": {
 			"version": "3.3.3",
+			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"@noble/hashes": "1.4.0",
@@ -18309,6 +18551,7 @@
 		},
 		"node_modules/pkijs/node_modules/@noble/hashes": {
 			"version": "1.4.0",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 16"
@@ -18372,6 +18615,7 @@
 		},
 		"node_modules/possible-typed-array-names": {
 			"version": "1.0.0",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
@@ -18395,6 +18639,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"nanoid": "^3.3.11",
 				"picocolors": "^1.1.1",
@@ -18580,6 +18825,7 @@
 			"version": "3.0.3",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"prettier": "bin/prettier.cjs"
 			},
@@ -18605,7 +18851,6 @@
 			"version": "27.5.1",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"ansi-regex": "^5.0.1",
 				"ansi-styles": "^5.0.0",
@@ -18619,7 +18864,6 @@
 			"version": "5.2.0",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			},
@@ -18630,8 +18874,7 @@
 		"node_modules/pretty-format/node_modules/react-is": {
 			"version": "17.0.2",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/proc-log": {
 			"version": "2.0.1",
@@ -18740,6 +18983,7 @@
 		},
 		"node_modules/pvtsutils": {
 			"version": "1.3.6",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"tslib": "^2.8.1"
@@ -18747,6 +18991,7 @@
 		},
 		"node_modules/pvutils": {
 			"version": "1.1.5",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=16.0.0"
@@ -18851,6 +19096,7 @@
 		"node_modules/react": {
 			"version": "18.3.1",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"loose-envify": "^1.1.0"
 			},
@@ -18896,6 +19142,7 @@
 		"node_modules/react-dom": {
 			"version": "18.3.1",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"loose-envify": "^1.1.0",
 				"scheduler": "^0.23.2"
@@ -18935,6 +19182,7 @@
 		"node_modules/react-redux": {
 			"version": "9.2.0",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@types/use-sync-external-store": "^0.0.6",
 				"use-sync-external-store": "^1.4.0"
@@ -19149,7 +19397,8 @@
 		},
 		"node_modules/redux": {
 			"version": "5.0.1",
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/redux-thunk": {
 			"version": "3.1.0",
@@ -19160,6 +19409,7 @@
 		},
 		"node_modules/reflect-metadata": {
 			"version": "0.2.2",
+			"dev": true,
 			"license": "Apache-2.0"
 		},
 		"node_modules/reflect.getprototypeof": {
@@ -19354,6 +19604,7 @@
 		},
 		"node_modules/require-directory": {
 			"version": "2.1.1",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -19361,6 +19612,7 @@
 		},
 		"node_modules/require-from-string": {
 			"version": "2.0.2",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -19600,6 +19852,7 @@
 			"version": "4.50.2",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@types/estree": "1.0.8"
 			},
@@ -19798,6 +20051,7 @@
 			"version": "8.17.1",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
 				"fast-uri": "^3.0.1",
@@ -19831,6 +20085,7 @@
 		},
 		"node_modules/selfsigned": {
 			"version": "5.5.0",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@peculiar/x509": "^1.14.2",
@@ -19955,6 +20210,7 @@
 		},
 		"node_modules/set-function-length": {
 			"version": "1.2.2",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"define-data-property": "^1.1.4",
@@ -20006,6 +20262,7 @@
 		},
 		"node_modules/sha.js": {
 			"version": "2.4.12",
+			"dev": true,
 			"license": "(MIT AND BSD-3-Clause)",
 			"dependencies": {
 				"inherits": "^2.0.4",
@@ -20024,6 +20281,7 @@
 		},
 		"node_modules/sha.js/node_modules/safe-buffer": {
 			"version": "5.2.1",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -20146,6 +20404,7 @@
 		},
 		"node_modules/simple-concat": {
 			"version": "1.0.1",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -20164,6 +20423,7 @@
 		},
 		"node_modules/simple-get": {
 			"version": "4.0.1",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -21129,6 +21389,7 @@
 			"version": "4.0.3",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -21190,6 +21451,7 @@
 		},
 		"node_modules/to-buffer": {
 			"version": "1.2.2",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"isarray": "^2.0.5",
@@ -21202,6 +21464,7 @@
 		},
 		"node_modules/to-buffer/node_modules/safe-buffer": {
 			"version": "5.2.1",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -21414,6 +21677,7 @@
 		},
 		"node_modules/tsyringe": {
 			"version": "4.10.0",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"tslib": "^1.9.3"
@@ -21424,6 +21688,7 @@
 		},
 		"node_modules/tsyringe/node_modules/tslib": {
 			"version": "1.14.1",
+			"dev": true,
 			"license": "0BSD"
 		},
 		"node_modules/tus-js-client": {
@@ -21475,6 +21740,7 @@
 		},
 		"node_modules/typed-array-buffer": {
 			"version": "1.0.3",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"call-bound": "^1.0.3",
@@ -21545,6 +21811,7 @@
 		"node_modules/typescript": {
 			"version": "5.9.3",
 			"license": "Apache-2.0",
+			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -21753,6 +22020,7 @@
 		},
 		"node_modules/universal-github-app-jwt": {
 			"version": "1.2.0",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@types/jsonwebtoken": "^9.0.0",
@@ -21761,6 +22029,7 @@
 		},
 		"node_modules/universal-user-agent": {
 			"version": "6.0.1",
+			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/universalify": {
@@ -21801,6 +22070,7 @@
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"napi-postinstall": "^0.3.0"
 			},
@@ -22039,6 +22309,7 @@
 			"version": "7.3.1",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.27.0",
 				"fdir": "^6.5.0",
@@ -22380,6 +22651,7 @@
 			"version": "4.0.3",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -22391,6 +22663,7 @@
 			"version": "2.1.8",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@vitest/expect": "2.1.8",
 				"@vitest/mocker": "2.1.8",
@@ -22540,6 +22813,7 @@
 			"version": "5.4.21",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.21.3",
 				"postcss": "^8.4.43",
@@ -22607,6 +22881,7 @@
 		},
 		"node_modules/wasm-feature-detect": {
 			"version": "1.8.0",
+			"dev": true,
 			"license": "Apache-2.0"
 		},
 		"node_modules/watchpack": {
@@ -22850,6 +23125,7 @@
 		},
 		"node_modules/which-typed-array": {
 			"version": "1.1.19",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"available-typed-arrays": "^1.0.7",
@@ -22968,6 +23244,7 @@
 		},
 		"node_modules/wrap-ansi": {
 			"version": "7.0.0",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ansi-styles": "^4.0.0",
@@ -23011,6 +23288,7 @@
 		},
 		"node_modules/wrap-ansi/node_modules/strip-ansi": {
 			"version": "6.0.1",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ansi-regex": "^5.0.1"
@@ -23025,6 +23303,7 @@
 		},
 		"node_modules/ws": {
 			"version": "8.18.3",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=10.0.0"
@@ -23192,6 +23471,7 @@
 		"node_modules/zod": {
 			"version": "4.3.5",
 			"license": "MIT",
+			"peer": true,
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
 			}

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
 		"@wordpress/components": "^32.1.0",
 		"@wordpress/element": "^6.39.0",
 		"@wordpress/react-i18n": "^4.39.0",
+		"@wp-playground/blueprints": "^3.0.46",
 		"electron": "^39.2.7",
 		"electron-devtools-installer": "^4.0.0",
 		"electron-playwright-helpers": "^2.1.0",
@@ -154,7 +155,6 @@
 		"wpcom": "^7.1.1",
 		"wpcom-xhr-request": "^1.3.0",
 		"yargs": "^18.0.0",
-		"@wp-playground/blueprints": "^3.0.46",
 		"yargs-parser": "^22.0.0",
 		"yauzl": "^3.2.0",
 		"zod": "^4.0.0"

--- a/vite.cli.config.ts
+++ b/vite.cli.config.ts
@@ -81,6 +81,10 @@ export default defineConfig( {
 			src: resolve( __dirname, 'src' ),
 			vendor: resolve( __dirname, 'vendor' ),
 			common: resolve( __dirname, 'common' ),
+			'@wp-playground/blueprints/blueprint-schema-validator': resolve(
+				__dirname,
+				'node_modules/@wp-playground/blueprints/blueprint-schema-validator.js'
+			),
 		},
 		conditions: [ 'node' ],
 		mainFields: [ 'main' ],

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -44,6 +44,10 @@ export default defineConfig( {
 			src: path.resolve( __dirname, './src' ),
 			vendor: path.resolve( __dirname, './vendor' ),
 			common: path.resolve( __dirname, './common' ),
+			'@wp-playground/blueprints/blueprint-schema-validator': path.resolve(
+				__dirname,
+				'./node_modules/@wp-playground/blueprints/blueprint-schema-validator.js'
+			),
 		},
 	},
 } );


### PR DESCRIPTION
## Related issues

- N/A

## Proposed Changes

- Move `@wp-playground/blueprints` back to devDependencies (it's only needed at build time, not runtime)
- Import the lightweight schema validator directly (`blueprint-schema-validator.js`) instead of the full `validateBlueprint` export
- Add Vite resolve aliases to bypass the package's exports restriction and allow direct file imports
- Remove `@wp-playground/*` from external patterns in `electron.vite.config.ts` (only `@php-wasm/*` needs to stay external for the CLI)

This allows the schema validator to be bundled directly into the main process (pure JS, no dependencies) while keeping the WASM-heavy packages out of the packaged app.

## Testing Instructions

- Run `npm run cli:build` to verify CLI builds
- Run `npm test -- common/lib/tests/blueprint-validation.test.ts` to verify schema validation still works (11 tests)
- Run `SKIP_DMG=1 npm run make` to verify packaged app builds
- Check packaged app size: should be ~1.9GB (down from ~3GB)
- Verify no @php-wasm WASM files in asar: `npx asar list out/Studio-darwin-arm64/Studio.app/Contents/Resources/app.asar | grep -c @php-wasm` should return 0 files

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?