### PR TITLE
Expand Dependabot configuration with comprehensive package coverage

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -219,6 +219,7 @@ updates:
           - "react-*"
         exclude-patterns:
           - "react-redux"
+          - "react-markdown"
 
       inquirer:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -127,7 +127,6 @@ updates:
       - dependency-name: "tus-js-client"
 
       # Windows-specific
-      - dependency-name: "winreg"
       - dependency-name: "electron2appx"
 
       # macOS-specific

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,44 +4,272 @@
 version: 2
 
 updates:
-  # Enable version updates for npm
+  # Enable version updates for npm (covers both root and cli/ directories)
   - package-ecosystem: "npm"
-    # Look for `package.json` and `lock` files in the `root` directory
     directory: "/"
-    # Check the npm registry for updates every week
     schedule:
       interval: "weekly"
+
     allow:
+      # Automattic packages
       - dependency-name: "@automattic/*"
+
+      # Electron ecosystem
+      - dependency-name: "@electron/*"
       - dependency-name: "@electron-forge/*"
+      - dependency-name: "electron"
+      - dependency-name: "electron-*"
+
+      # WordPress ecosystem
       - dependency-name: "@wordpress/*"
+      - dependency-name: "wpcom"
+      - dependency-name: "wpcom-*"
+
+      # WordPress Playground & PHP WASM
       - dependency-name: "@wp-playground/*"
       - dependency-name: "@php-wasm/*"
+
+      # TypeScript ecosystem
+      - dependency-name: "typescript"
+      - dependency-name: "typescript-*"
       - dependency-name: "@types/*"
+      - dependency-name: "ts-*"
+      - dependency-name: "@tsconfig/*"
+
+      # ESLint ecosystem
       - dependency-name: "eslint"
       - dependency-name: "eslint-*"
       - dependency-name: "@eslint/*"
       - dependency-name: "typescript-eslint"
-      - dependency-name: "typescript"
-      - dependency-name: "ts-*"
+
+      # Testing ecosystem
       - dependency-name: "jest"
       - dependency-name: "jest-*"
-      - dependency-name: "patch-package"
       - dependency-name: "@playwright/*"
       - dependency-name: "electron-playwright-helpers"
+      - dependency-name: "vitest"
+      - dependency-name: "@vitest/*"
+      - dependency-name: "@testing-library/*"
+
+      # Build tools
       - dependency-name: "vite"
       - dependency-name: "vite-*"
       - dependency-name: "@vitejs/*"
       - dependency-name: "electron-vite"
-      - dependency-name: "mdast-util-to-hast"
+      - dependency-name: "@rollup/*"
+      - dependency-name: "rollup"
+
+      # Sentry monitoring
+      - dependency-name: "@sentry/*"
+
+      # Redux ecosystem
+      - dependency-name: "@reduxjs/*"
+      - dependency-name: "react-redux"
+
+      # React ecosystem
+      - dependency-name: "react"
+      - dependency-name: "react-*"
+      - dependency-name: "@rive-app/*"
+
+      # Inquirer CLI prompts
+      - dependency-name: "@inquirer/*"
+
+      # Compression & archiving
+      - dependency-name: "archiver"
+      - dependency-name: "compression"
+      - dependency-name: "compressible"
+      - dependency-name: "yauzl"
+      - dependency-name: "tar"
+
+      # HTTP & networking
+      - dependency-name: "express"
+      - dependency-name: "http-proxy"
+      - dependency-name: "hpagent"
+      - dependency-name: "follow-redirects"
+
+      # Process management
+      - dependency-name: "pm2"
+      - dependency-name: "pm2-*"
+
+      # Security & crypto
+      - dependency-name: "node-forge"
+
+      # Utilities
+      - dependency-name: "yargs"
+      - dependency-name: "yargs-*"
+      - dependency-name: "zod"
+      - dependency-name: "semver"
+      - dependency-name: "date-fns"
+      - dependency-name: "patch-package"
+      - dependency-name: "shell-quote"
+      - dependency-name: "fs-extra"
+      - dependency-name: "rimraf"
+      - dependency-name: "lockfile"
+      - dependency-name: "atomically"
+      - dependency-name: "file-stream-rotator"
+      - dependency-name: "strip-ansi"
+      - dependency-name: "trash"
+      - dependency-name: "cli-table3"
+      - dependency-name: "ora"
+      - dependency-name: "cross-port-killer"
+      - dependency-name: "fast-deep-equal"
+
+      # Markdown & content processing
+      - dependency-name: "react-markdown"
+      - dependency-name: "remark-*"
+      - dependency-name: "rehype-*"
+      - dependency-name: "mdast-*"
+
+      # Internationalization
+      - dependency-name: "@formatjs/*"
+
+      # File uploads
+      - dependency-name: "tus-js-client"
+
+      # Windows-specific
+      - dependency-name: "winreg"
+      - dependency-name: "electron2appx"
+
+      # macOS-specific
+      - dependency-name: "appdmg"
+      - dependency-name: "@vscode/sudo-prompt"
+
+      # Polyfills
+      - dependency-name: "web-streams-polyfill"
+      - dependency-name: "resize-observer-polyfill"
+      - dependency-name: "isomorphic-fetch"
+
+      # Dev tools
+      - dependency-name: "prettier"
+      - dependency-name: "postcss"
+      - dependency-name: "tailwindcss"
+      - dependency-name: "nock"
+      - dependency-name: "jsdom"
+      - dependency-name: "electron-devtools-installer"
+
     groups:
       electron-forge:
         patterns:
           - "@electron-forge/*"
+
+      electron:
+        patterns:
+          - "electron"
+          - "electron-*"
+          - "@electron/*"
+        exclude-patterns:
+          - "@electron-forge/*"
+
       wp-playground-php-wasm:
         patterns:
           - "@wp-playground/*"
           - "@php-wasm/*"
+
+      wordpress:
+        patterns:
+          - "@wordpress/*"
+          - "wpcom"
+          - "wpcom-*"
+
+      typescript:
+        patterns:
+          - "typescript"
+          - "typescript-*"
+          - "ts-*"
+          - "@types/*"
+          - "@tsconfig/*"
+        exclude-patterns:
+          - "typescript-eslint"
+
+      eslint:
+        patterns:
+          - "eslint"
+          - "eslint-*"
+          - "@eslint/*"
+          - "typescript-eslint"
+
+      testing:
+        patterns:
+          - "vitest"
+          - "@vitest/*"
+          - "@playwright/*"
+          - "electron-playwright-helpers"
+          - "@testing-library/*"
+          - "jest"
+          - "jest-*"
+
+      vite:
+        patterns:
+          - "vite"
+          - "vite-*"
+          - "@vitejs/*"
+          - "electron-vite"
+
+      sentry:
+        patterns:
+          - "@sentry/*"
+
+      redux:
+        patterns:
+          - "@reduxjs/*"
+          - "react-redux"
+
+      react:
+        patterns:
+          - "react"
+          - "react-*"
+        exclude-patterns:
+          - "react-redux"
+
+      inquirer:
+        patterns:
+          - "@inquirer/*"
+
+      http-networking:
+        patterns:
+          - "express"
+          - "http-proxy"
+          - "hpagent"
+          - "follow-redirects"
+
+      process-management:
+        patterns:
+          - "pm2"
+          - "pm2-*"
+
+      markdown:
+        patterns:
+          - "react-markdown"
+          - "remark-*"
+          - "rehype-*"
+          - "mdast-*"
+
+      compression:
+        patterns:
+          - "archiver"
+          - "compression"
+          - "compressible"
+          - "yauzl"
+          - "tar"
+
+      cli-utilities:
+        patterns:
+          - "yargs"
+          - "yargs-*"
+          - "ora"
+          - "cli-table3"
+          - "shell-quote"
+          - "strip-ansi"
+
+      file-utilities:
+        patterns:
+          - "fs-extra"
+          - "rimraf"
+          - "lockfile"
+          - "atomically"
+          - "file-stream-rotator"
+          - "trash"
+
     ignore:
       - dependency-name: "eslint-plugin-studio"
       - dependency-name: "winreg" # v1.2.5 has a known issue: https://github.com/fresc81/node-winreg/issues/65

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -158,6 +158,9 @@ updates:
           - "@electron/*"
         exclude-patterns:
           - "@electron-forge/*"
+          - "electron-vite"
+          - "electron-playwright-helpers"
+          - "electron-devtools-installer"
 
       wp-playground-php-wasm:
         patterns:


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- N/A

## Proposed Changes

Expands Dependabot to manage ~160+ packages (up from ~40) with logical grouping to reduce PR noise.

- **Allowed packages**: Added React, Redux, Electron core, testing tools, HTTP/networking, process management, compression, CLI utilities, file utilities, markdown
  processing, internationalization, platform-specific packages, and polyfills
- **Groups**: Expanded from 2 to 18 logical groups (electron, wordpress, typescript, eslint, testing, vite, sentry, redux, react, inquirer, http-networking,
  process-management, markdown, compression, cli-utilities, file-utilities)
- **Coverage**: Single npm entry at "/" covers both root and cli/ directories

If it works well, we may try enabling auto-merge.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- N/A

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
