### PR TITLE
[CI] Remove workaround for Buildkite's `matrix.setup`

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -33,9 +33,6 @@ steps:
   # E2E tests run on supported platform/architecture combinations.
   # - mac-arm64: Native on Apple Silicon agents
   # - windows-x64: Native on x64 agents
-  # Skipped via matrix adjustments:
-  # - mac-x64: https://linear.app/a8c/issue/AINFRA-1904
-  # - windows-arm64: x64 Windows cannot run arm64 binaries (no emulation layer)
   - label: E2E Tests on {{matrix.platform}}-{{matrix.arch}}
     key: e2e_tests
     command: bash .buildkite/commands/run-e2e-tests.sh "{{matrix.platform}}" "{{matrix.arch}}"
@@ -50,17 +47,10 @@ steps:
       # See https://playwright.dev/docs/ci#debugging-browser-launches
       DEBUG: "pw:browser"
     matrix:
-      # More details on this setup at https://github.com/Automattic/studio/pull/2530#discussion_r2763853223
-      #
-      # TL;DR: we're bending the syntax to limit the combinations.
-      setup: { platform: [_], arch: [_] }
+      setup: { platform: [], arch: [] }
       adjustments:
-        # Combinations to run
         - with: { platform: mac, arch: arm64 }
         - with: { platform: windows, arch: x64 }
-        # Skip the dummy value used to initiate the syntax.
-        - with: { platform: _, arch: _ }
-          skip: true
     # Skip E2E tests on draft PRs to save CI resources
     # Tests will run automatically when PR is marked ready for review
     if: build.branch == 'trunk' || build.tag =~ /^v[0-9]+/ || !build.pull_request.draft


### PR DESCRIPTION
## Related Issues

This is a follow-up on https://github.com/Automattic/studio/pull/2530 and [AINFRA-1903](https://linear.app/a8c/issue/AINFRA-1903/run-e2e-on-windows-queue-alongside-mac)

## Proposed Changes

Buildkite have told us they fixed their bug with empty `matrix.setup` so we should not need the workaround anymore

> Hey Oliver,
>
> I'm an engineer on the product team 👋
> 
> An update from us to let you know we've indeed confirmed this was a unintentional behaviour on our end (Great sleuthing through the bk/go-pipeline source code. So we're happy to inform that we've shipped a fix to enable matrix job creation through adjustments only.
>
> Using your above provided example pipeline, this will now result in the creation of two jobs with the following params:
> 
> Job #1 { arch: x86_64, platform: mac }
> Job #2 { arch: x64, platform: windows }
> Thanks again for the report and patience as we patched things up.
> 
> Let us know how you go 🙏
> 
> Jonathan

## Testing Instructions

Verify that the build on Buildkite creates 2 jobs for `E2E Tests on {platform}-{arch}`
<img width="290" height="65" alt="image" src="https://github.com/user-attachments/assets/5083537e-c0f1-487b-b5f4-6a20f4003323" />
<img width="535" height="153" alt="image" src="https://github.com/user-attachments/assets/2ce6554d-11b7-4acc-b294-fcc4b4b88735" />
