### PR TITLE
Bundle WordPress translation files with download retry and failure handling

### DIFF
--- a/cli/commands/site/create.ts
+++ b/cli/commands/site/create.ts
@@ -44,6 +44,7 @@ import {
 	updateSiteAutoStart,
 	updateSiteLatestCliPid,
 } from 'cli/lib/appdata';
+import { copyLanguagePackToSite } from 'cli/lib/language-packs';
 import { connect, disconnect, emitSiteEvent } from 'cli/lib/pm2-manager';
 import { getServerFilesPath } from 'cli/lib/server-files';
 import { getPreferredSiteLanguage } from 'cli/lib/site-language';
@@ -190,10 +191,33 @@ export async function runCommand(
 
 		const setupSteps: StepDefinition[] = [];
 
-		if ( isOnlineStatus ) {
-			const siteLanguage = await getPreferredSiteLanguage( options.wpVersion );
+		const siteLanguage = await getPreferredSiteLanguage( options.wpVersion );
 
-			if ( siteLanguage && siteLanguage !== DEFAULT_LOCALE ) {
+		if ( siteLanguage && siteLanguage !== DEFAULT_LOCALE ) {
+			// For the 'latest' WP version, try using bundled language packs first to avoid
+			// a network round-trip. Fall back to the Playground setSiteLanguage step for
+			// non-latest versions or when bundled packs aren't available.
+			let usedBundledPacks = false;
+			if ( options.wpVersion === DEFAULT_WORDPRESS_VERSION ) {
+				usedBundledPacks = await copyLanguagePackToSite( sitePath, siteLanguage );
+			}
+
+			if ( usedBundledPacks ) {
+				setupSteps.push(
+					{
+						step: 'defineWpConfigConsts',
+						consts: {
+							WPLANG: siteLanguage,
+						},
+					},
+					{
+						step: 'setSiteOptions',
+						options: {
+							WPLANG: siteLanguage,
+						},
+					}
+				);
+			} else if ( isOnlineStatus ) {
 				setupSteps.push(
 					{
 						step: 'setSiteLanguage',

--- a/cli/commands/site/create.ts
+++ b/cli/commands/site/create.ts
@@ -197,12 +197,12 @@ export async function runCommand(
 			// For the 'latest' WP version, try using bundled language packs first to avoid
 			// a network round-trip. Fall back to the Playground setSiteLanguage step for
 			// non-latest versions or when bundled packs aren't available.
-			let usedBundledPacks = false;
+			let isUsingBundledLanguagePacks = false;
 			if ( options.wpVersion === DEFAULT_WORDPRESS_VERSION ) {
-				usedBundledPacks = await copyLanguagePackToSite( sitePath, siteLanguage );
+				isUsingBundledLanguagePacks = await copyLanguagePackToSite( sitePath, siteLanguage );
 			}
 
-			if ( usedBundledPacks ) {
+			if ( isUsingBundledLanguagePacks ) {
 				setupSteps.push(
 					{
 						step: 'defineWpConfigConsts',

--- a/cli/commands/site/tests/create.test.ts
+++ b/cli/commands/site/tests/create.test.ts
@@ -24,6 +24,7 @@ import {
 	updateSiteAutoStart,
 	SiteData,
 } from 'cli/lib/appdata';
+import { copyLanguagePackToSite } from 'cli/lib/language-packs';
 import { connect, disconnect } from 'cli/lib/pm2-manager';
 import { getServerFilesPath } from 'cli/lib/server-files';
 import { getPreferredSiteLanguage } from 'cli/lib/site-language';
@@ -60,6 +61,7 @@ vi.mock( 'cli/lib/appdata', async () => {
 		getSiteUrl: vi.fn( ( site ) => `http://localhost:${ site.port }` ),
 	};
 } );
+vi.mock( 'cli/lib/language-packs' );
 vi.mock( 'cli/lib/pm2-manager' );
 vi.mock( 'cli/lib/server-files', () => ( {
 	getServerFilesPath: vi.fn( () => '/test/server-files' ),
@@ -158,6 +160,7 @@ describe( 'CLI: studio site create', () => {
 		);
 		vi.mocked( isOnline ).mockResolvedValue( true );
 		vi.mocked( getPreferredSiteLanguage ).mockResolvedValue( 'en' );
+		vi.mocked( copyLanguagePackToSite ).mockResolvedValue( false );
 	} );
 
 	afterEach( () => {
@@ -609,6 +612,99 @@ describe( 'CLI: studio site create', () => {
 			expect( startWordPressServer ).not.toHaveBeenCalled();
 			expect( consoleLogSpy ).toHaveBeenCalledWith( 'Site created successfully' );
 			expect( disconnect ).toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'Language Packs', () => {
+		it( 'should use bundled language packs and skip setSiteLanguage for latest WP version', async () => {
+			vi.mocked( getPreferredSiteLanguage ).mockResolvedValue( 'sv_SE' );
+			vi.mocked( copyLanguagePackToSite ).mockResolvedValue( true );
+
+			await runCommand( mockSitePath, { ...defaultTestOptions } );
+
+			expect( copyLanguagePackToSite ).toHaveBeenCalledWith( mockSitePath, 'sv_SE' );
+			expect( startWordPressServer ).toHaveBeenCalledWith(
+				expect.anything(),
+				expect.any( Logger ),
+				expect.objectContaining( {
+					blueprint: expect.objectContaining( {
+						steps: expect.arrayContaining( [
+							expect.objectContaining( {
+								step: 'defineWpConfigConsts',
+								consts: { WPLANG: 'sv_SE' },
+							} ),
+							expect.objectContaining( {
+								step: 'setSiteOptions',
+								options: { WPLANG: 'sv_SE' },
+							} ),
+						] ),
+					} ),
+				} )
+			);
+			// Should NOT include setSiteLanguage step
+			const calls = vi.mocked( startWordPressServer ).mock.calls;
+			const blueprintSteps = ( calls[ 0 ][ 2 ] as { blueprint?: Blueprint } )?.blueprint
+				?.steps as StepDefinition[];
+			expect( blueprintSteps.some( ( s ) => s.step === 'setSiteLanguage' ) ).toBe( false );
+		} );
+
+		it( 'should fall back to setSiteLanguage when bundled packs are not available', async () => {
+			vi.mocked( getPreferredSiteLanguage ).mockResolvedValue( 'sv_SE' );
+			vi.mocked( copyLanguagePackToSite ).mockResolvedValue( false );
+
+			await runCommand( mockSitePath, { ...defaultTestOptions } );
+
+			expect( startWordPressServer ).toHaveBeenCalledWith(
+				expect.anything(),
+				expect.any( Logger ),
+				expect.objectContaining( {
+					blueprint: expect.objectContaining( {
+						steps: expect.arrayContaining( [
+							expect.objectContaining( {
+								step: 'setSiteLanguage',
+								language: 'sv_SE',
+							} ),
+							expect.objectContaining( {
+								step: 'setSiteOptions',
+								options: { WPLANG: 'sv_SE' },
+							} ),
+						] ),
+					} ),
+				} )
+			);
+		} );
+
+		it( 'should use setSiteLanguage for non-latest WP versions', async () => {
+			vi.mocked( getPreferredSiteLanguage ).mockResolvedValue( 'sv_SE' );
+
+			await runCommand( mockSitePath, {
+				...defaultTestOptions,
+				wpVersion: '6.5',
+			} );
+
+			expect( copyLanguagePackToSite ).not.toHaveBeenCalled();
+			expect( startWordPressServer ).toHaveBeenCalledWith(
+				expect.anything(),
+				expect.any( Logger ),
+				expect.objectContaining( {
+					blueprint: expect.objectContaining( {
+						steps: expect.arrayContaining( [
+							expect.objectContaining( {
+								step: 'setSiteLanguage',
+								language: 'sv_SE',
+							} ),
+						] ),
+					} ),
+				} )
+			);
+		} );
+
+		it( 'should not set language when locale is English', async () => {
+			vi.mocked( getPreferredSiteLanguage ).mockResolvedValue( 'en' );
+
+			await runCommand( mockSitePath, { ...defaultTestOptions } );
+
+			expect( copyLanguagePackToSite ).not.toHaveBeenCalled();
 		} );
 	} );
 

--- a/cli/lib/language-packs.ts
+++ b/cli/lib/language-packs.ts
@@ -1,0 +1,75 @@
+import fs from 'fs';
+import path from 'path';
+import { pathExists } from 'common/lib/fs-utils';
+import { getLanguagePacksPath } from 'cli/lib/server-files';
+
+/**
+ * Filters files in a directory that match a given WordPress locale.
+ * Matches .l10n.php files ({locale}.l10n.php, {domain}-{locale}.l10n.php)
+ * and .json files ({locale}-{hash}.json).
+ */
+function filterLocaleFiles( files: string[], wpLocale: string ): string[] {
+	return files.filter( ( file ) => {
+		const name = path.basename( file );
+		return (
+			name === `${ wpLocale }.l10n.php` ||
+			name.endsWith( `-${ wpLocale }.l10n.php` ) ||
+			( name.startsWith( `${ wpLocale }-` ) && name.endsWith( '.json' ) )
+		);
+	} );
+}
+
+/**
+ * Copies matching locale files from a source directory to a destination directory.
+ */
+async function copyLocaleFiles(
+	sourceDir: string,
+	destDir: string,
+	wpLocale: string
+): Promise< number > {
+	if ( ! ( await pathExists( sourceDir ) ) ) {
+		return 0;
+	}
+	const allFiles = await fs.promises.readdir( sourceDir );
+	const localeFiles = filterLocaleFiles( allFiles, wpLocale );
+	if ( localeFiles.length === 0 ) {
+		return 0;
+	}
+	await fs.promises.mkdir( destDir, { recursive: true } );
+	for ( const file of localeFiles ) {
+		await fs.promises.copyFile( path.join( sourceDir, file ), path.join( destDir, file ) );
+	}
+	return localeFiles.length;
+}
+
+/**
+ * Copies bundled WordPress language pack files for a given locale into a site's
+ * wp-content/languages/ directory, including core, plugin, and theme translations.
+ * Returns true if files were copied successfully.
+ */
+export async function copyLanguagePackToSite(
+	sitePath: string,
+	wpLocale: string
+): Promise< boolean > {
+	const languagePacksDir = getLanguagePacksPath();
+	if ( ! ( await pathExists( languagePacksDir ) ) ) {
+		return false;
+	}
+
+	const destBase = path.join( sitePath, 'wp-content', 'languages' );
+
+	let totalCopied = 0;
+	totalCopied += await copyLocaleFiles( languagePacksDir, destBase, wpLocale );
+	totalCopied += await copyLocaleFiles(
+		path.join( languagePacksDir, 'plugins' ),
+		path.join( destBase, 'plugins' ),
+		wpLocale
+	);
+	totalCopied += await copyLocaleFiles(
+		path.join( languagePacksDir, 'themes' ),
+		path.join( destBase, 'themes' ),
+		wpLocale
+	);
+
+	return totalCopied > 0;
+}

--- a/cli/lib/server-files.ts
+++ b/cli/lib/server-files.ts
@@ -15,3 +15,7 @@ export function getWpCliPharPath(): string {
 export function getSqliteCommandPath(): string {
 	return path.join( getServerFilesPath(), SQLITE_COMMAND_FOLDER );
 }
+
+export function getLanguagePacksPath(): string {
+	return path.join( getServerFilesPath(), 'language-packs' );
+}

--- a/common/lib/wp-locales.ts
+++ b/common/lib/wp-locales.ts
@@ -8,6 +8,7 @@ export const WP_LOCALES = [
 	'es_ES',
 	'fr_FR',
 	'he_IL',
+	'hu_HU',
 	'id_ID',
 	'it_IT',
 	'ja',

--- a/common/lib/wp-locales.ts
+++ b/common/lib/wp-locales.ts
@@ -1,0 +1,25 @@
+/**
+ * WordPress locale codes for all non-English locales supported by Studio.
+ * Used for downloading and installing WordPress core language packs.
+ */
+export const WP_LOCALES = [
+	'ar',
+	'de_DE',
+	'es_ES',
+	'fr_FR',
+	'he_IL',
+	'id_ID',
+	'it_IT',
+	'ja',
+	'ko_KR',
+	'nl_NL',
+	'pl_PL',
+	'pt_BR',
+	'ru_RU',
+	'sv_SE',
+	'tr_TR',
+	'vi',
+	'uk',
+	'zh_CN',
+	'zh_TW',
+];

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -138,7 +138,7 @@ const config: ForgeConfig = {
 			}
 
 			console.log( 'Downloading language packs ...' );
-			await execAsync( 'npm run download:language-packs' );
+			await execAsync( 'npm run download-language-packs' );
 
 			console.log( 'Building CLI ...' );
 			await execAsync( 'npm run cli:build' );

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -137,6 +137,9 @@ const config: ForgeConfig = {
 				if ( isErrnoException( err ) && err.code !== 'ENOENT' ) throw err;
 			}
 
+			console.log( 'Downloading language packs ...' );
+			await execAsync( 'npm run download:language-packs' );
+
 			console.log( 'Building CLI ...' );
 			await execAsync( 'npm run cli:build' );
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
 		"e2e": "npx playwright install && npx playwright test",
 		"test:metrics": "npx playwright test --config=./metrics/playwright.metrics.config.ts",
 		"make-pot": "node ./scripts/make-pot.mjs",
-		"download:language-packs": "ts-node ./scripts/download-language-packs.ts"
+		"download-language-packs": "ts-node ./scripts/download-language-packs.ts"
 	},
 	"devDependencies": {
 		"@automattic/color-studio": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
 		"test:watch": "vitest",
 		"e2e": "npx playwright install && npx playwright test",
 		"test:metrics": "npx playwright test --config=./metrics/playwright.metrics.config.ts",
-		"make-pot": "node ./scripts/make-pot.mjs"
+		"make-pot": "node ./scripts/make-pot.mjs",
+		"download:language-packs": "ts-node ./scripts/download-language-packs.ts"
 	},
 	"devDependencies": {
 		"@automattic/color-studio": "^4.1.0",

--- a/scripts/download-language-packs.ts
+++ b/scripts/download-language-packs.ts
@@ -6,6 +6,41 @@ import { WP_LOCALES } from '../common/lib/wp-locales';
 
 const WP_SERVER_FILES_PATH = path.join( __dirname, '..', 'wp-files' );
 
+const MAX_RETRIES = 3;
+const INITIAL_RETRY_DELAY_MS = 1000;
+
+async function fetchWithRetry( url: string ): Promise< Response > {
+	for ( let attempt = 1; attempt <= MAX_RETRIES; attempt++ ) {
+		try {
+			const response = await fetch( url );
+			if ( response.ok ) {
+				return response;
+			}
+			if ( attempt < MAX_RETRIES ) {
+				const delay = INITIAL_RETRY_DELAY_MS * Math.pow( 2, attempt - 1 );
+				console.warn(
+					`[language-packs] Request failed (status ${ response.status }), retrying in ${ delay }ms (attempt ${ attempt }/${ MAX_RETRIES })...`
+				);
+				await new Promise( ( resolve ) => setTimeout( resolve, delay ) );
+				continue;
+			}
+			throw new Error( `HTTP ${ response.status }` );
+		} catch ( error ) {
+			if ( attempt < MAX_RETRIES ) {
+				const delay = INITIAL_RETRY_DELAY_MS * Math.pow( 2, attempt - 1 );
+				console.warn(
+					`[language-packs] Request failed (${ error instanceof Error ? error.message : error }), retrying in ${ delay }ms (attempt ${ attempt }/${ MAX_RETRIES })...`
+				);
+				await new Promise( ( resolve ) => setTimeout( resolve, delay ) );
+				continue;
+			}
+			throw error;
+		}
+	}
+	// This should never be reached, but TypeScript needs it.
+	throw new Error( 'Unexpected: exceeded max retries' );
+}
+
 interface TranslationEntry {
 	language: string;
 	package: string;
@@ -44,10 +79,7 @@ async function downloadTranslationsFromApi(
 	destPath: string,
 	label: string
 ): Promise< void > {
-	const response = await fetch( apiUrl );
-	if ( ! response.ok ) {
-		throw new Error( `Failed to fetch ${ label } translations API (status ${ response.status })` );
-	}
+	const response = await fetchWithRetry( apiUrl );
 	const data: TranslationsApiResponse = await response.json();
 
 	const translationsToDownload = data.translations.filter( ( t ) =>
@@ -62,13 +94,7 @@ async function downloadTranslationsFromApi(
 
 	for ( const translation of translationsToDownload ) {
 		const { language, package: packageUrl } = translation;
-		const zipResponse = await fetch( packageUrl );
-		if ( ! zipResponse.ok ) {
-			console.error(
-				`[language-packs] Failed to download ${ label }/${ language } (status ${ zipResponse.status }), skipping`
-			);
-			continue;
-		}
+		const zipResponse = await fetchWithRetry( packageUrl );
 
 		const safeLabel = label.replace( /\//g, '-' );
 		const zipPath = path.join( os.tmpdir(), `wp-language-${ safeLabel }-${ language }.zip` );

--- a/scripts/download-language-packs.ts
+++ b/scripts/download-language-packs.ts
@@ -9,36 +9,34 @@ const WP_SERVER_FILES_PATH = path.join( __dirname, '..', 'wp-files' );
 const MAX_RETRIES = 3;
 const INITIAL_RETRY_DELAY_MS = 1000;
 
-async function fetchWithRetry( url: string ): Promise< Response > {
-	for ( let attempt = 1; attempt <= MAX_RETRIES; attempt++ ) {
-		try {
-			const response = await fetch( url );
-			if ( response.ok ) {
-				return response;
-			}
-			if ( attempt < MAX_RETRIES ) {
-				const delay = INITIAL_RETRY_DELAY_MS * Math.pow( 2, attempt - 1 );
-				console.warn(
-					`[language-packs] Request failed (status ${ response.status }), retrying in ${ delay }ms (attempt ${ attempt }/${ MAX_RETRIES })...`
-				);
-				await new Promise( ( resolve ) => setTimeout( resolve, delay ) );
-				continue;
-			}
+async function fetchWithRetry( url: string, attempt = 1 ): Promise< Response > {
+	try {
+		const response = await fetch( url );
+		if ( response.ok ) {
+			return response;
+		}
+		if ( attempt >= MAX_RETRIES ) {
 			throw new Error( `HTTP ${ response.status }` );
-		} catch ( error ) {
-			if ( attempt < MAX_RETRIES ) {
-				const delay = INITIAL_RETRY_DELAY_MS * Math.pow( 2, attempt - 1 );
-				console.warn(
-					`[language-packs] Request failed (${ error instanceof Error ? error.message : error }), retrying in ${ delay }ms (attempt ${ attempt }/${ MAX_RETRIES })...`
-				);
-				await new Promise( ( resolve ) => setTimeout( resolve, delay ) );
-				continue;
-			}
+		}
+		const delay = INITIAL_RETRY_DELAY_MS * Math.pow( 2, attempt - 1 );
+		console.warn(
+			`[language-packs] Request failed (status ${ response.status }), retrying in ${ delay }ms (attempt ${ attempt }/${ MAX_RETRIES })...`
+		);
+		await new Promise( ( resolve ) => setTimeout( resolve, delay ) );
+		return fetchWithRetry( url, attempt + 1 );
+	} catch ( error ) {
+		if ( attempt >= MAX_RETRIES ) {
 			throw error;
 		}
+		const delay = INITIAL_RETRY_DELAY_MS * Math.pow( 2, attempt - 1 );
+		console.warn(
+			`[language-packs] Request failed (${
+				error instanceof Error ? error.message : error
+			}), retrying in ${ delay }ms (attempt ${ attempt }/${ MAX_RETRIES })...`
+		);
+		await new Promise( ( resolve ) => setTimeout( resolve, delay ) );
+		return fetchWithRetry( url, attempt + 1 );
 	}
-	// This should never be reached, but TypeScript needs it.
-	throw new Error( 'Unexpected: exceeded max retries' );
 }
 
 interface TranslationEntry {

--- a/scripts/download-language-packs.ts
+++ b/scripts/download-language-packs.ts
@@ -1,0 +1,135 @@
+import os from 'os';
+import path from 'path';
+import fs from 'fs-extra';
+import { extractZip } from '../common/lib/extract-zip';
+import { WP_LOCALES } from '../common/lib/wp-locales';
+
+const WP_SERVER_FILES_PATH = path.join( __dirname, '..', 'wp-files' );
+
+interface TranslationEntry {
+	language: string;
+	package: string;
+}
+
+interface TranslationsApiResponse {
+	translations: TranslationEntry[];
+}
+
+// Known single-file plugins whose directory name doesn't match the WordPress.org slug.
+const SINGLE_FILE_PLUGIN_SLUGS: Record< string, string > = {
+	'hello.php': 'hello-dolly',
+};
+
+function getBundledSlugs( contentDir: string ): string[] {
+	const entries = fs.readdirSync( contentDir, { withFileTypes: true } );
+	const slugs: string[] = [];
+	for ( const entry of entries ) {
+		if ( entry.name === 'index.php' ) {
+			continue;
+		}
+		if ( entry.isDirectory() ) {
+			slugs.push( entry.name );
+		} else if ( SINGLE_FILE_PLUGIN_SLUGS[ entry.name ] ) {
+			slugs.push( SINGLE_FILE_PLUGIN_SLUGS[ entry.name ] );
+		}
+	}
+	return slugs;
+}
+
+async function downloadTranslationsFromApi(
+	apiUrl: string,
+	destPath: string,
+	label: string
+): Promise< void > {
+	const response = await fetch( apiUrl );
+	if ( ! response.ok ) {
+		throw new Error( `Failed to fetch ${ label } translations API (status ${ response.status })` );
+	}
+	const data: TranslationsApiResponse = await response.json();
+
+	const translationsToDownload = data.translations.filter( ( t ) =>
+		WP_LOCALES.includes( t.language )
+	);
+
+	console.log(
+		`[language-packs] Downloading ${ label } (${ translationsToDownload.length } locales) ...`
+	);
+
+	await fs.ensureDir( destPath );
+
+	for ( const translation of translationsToDownload ) {
+		const { language, package: packageUrl } = translation;
+		const zipResponse = await fetch( packageUrl );
+		if ( ! zipResponse.ok ) {
+			console.error(
+				`[language-packs] Failed to download ${ label }/${ language } (status ${ zipResponse.status }), skipping`
+			);
+			continue;
+		}
+
+		const safeLabel = label.replace( /\//g, '-' );
+		const zipPath = path.join( os.tmpdir(), `wp-language-${ safeLabel }-${ language }.zip` );
+		const buffer = Buffer.from( await zipResponse.arrayBuffer() );
+		await fs.writeFile( zipPath, buffer );
+		await extractZip( zipPath, destPath );
+		await fs.remove( zipPath );
+	}
+}
+
+async function removePoAndMoFiles( dirPath: string ): Promise< void > {
+	const entries = await fs.readdir( dirPath, { withFileTypes: true } );
+	for ( const entry of entries ) {
+		const fullPath = path.join( dirPath, entry.name );
+		if ( entry.isDirectory() ) {
+			await removePoAndMoFiles( fullPath );
+		} else if ( entry.name.endsWith( '.po' ) || entry.name.endsWith( '.mo' ) ) {
+			await fs.remove( fullPath );
+		}
+	}
+}
+
+async function downloadLanguagePacks(): Promise< void > {
+	const languagesPath = path.join( WP_SERVER_FILES_PATH, 'latest', 'languages' );
+	const wpContentPath = path.join( WP_SERVER_FILES_PATH, 'latest', 'wordpress', 'wp-content' );
+
+	// Core translations
+	await downloadTranslationsFromApi(
+		'https://api.wordpress.org/translations/core/1.0/',
+		languagesPath,
+		'core translations'
+	);
+
+	// Plugin translations
+	const pluginSlugs = getBundledSlugs( path.join( wpContentPath, 'plugins' ) );
+	for ( const slug of pluginSlugs ) {
+		await downloadTranslationsFromApi(
+			`https://api.wordpress.org/translations/plugins/1.0/?slug=${ slug }`,
+			path.join( languagesPath, 'plugins' ),
+			`plugin translations: ${ slug }`
+		);
+	}
+
+	// Theme translations
+	const themeSlugs = getBundledSlugs( path.join( wpContentPath, 'themes' ) );
+	for ( const slug of themeSlugs ) {
+		await downloadTranslationsFromApi(
+			`https://api.wordpress.org/translations/themes/1.0/?slug=${ slug }`,
+			path.join( languagesPath, 'themes' ),
+			`theme translations: ${ slug }`
+		);
+	}
+
+	// Remove .po and .mo files — WordPress 6.5+ uses .l10n.php and .json files.
+	await removePoAndMoFiles( languagesPath );
+
+	console.log( '[language-packs] Files extracted' );
+}
+
+downloadLanguagePacks()
+	.then( () => {
+		console.log( '[language-packs] Done' );
+	} )
+	.catch( ( err ) => {
+		console.error( '[language-packs] Error downloading language packs:', err );
+		process.exit( 1 );
+	} );

--- a/scripts/download-language-packs.ts
+++ b/scripts/download-language-packs.ts
@@ -20,6 +20,9 @@ const SINGLE_FILE_PLUGIN_SLUGS: Record< string, string > = {
 	'hello.php': 'hello-dolly',
 };
 
+// Older bundled themes that aren't worth downloading translations for.
+const SKIPPED_THEME_SLUGS = [ 'twentytwentythree', 'twentytwentyfour' ];
+
 function getBundledSlugs( contentDir: string ): string[] {
 	const entries = fs.readdirSync( contentDir, { withFileTypes: true } );
 	const slugs: string[] = [];
@@ -109,8 +112,10 @@ async function downloadLanguagePacks(): Promise< void > {
 		);
 	}
 
-	// Theme translations
-	const themeSlugs = getBundledSlugs( path.join( wpContentPath, 'themes' ) );
+	// Theme translations (skip older bundled themes)
+	const themeSlugs = getBundledSlugs( path.join( wpContentPath, 'themes' ) ).filter(
+		( slug ) => ! SKIPPED_THEME_SLUGS.includes( slug )
+	);
 	for ( const slug of themeSlugs ) {
 		await downloadTranslationsFromApi(
 			`https://api.wordpress.org/translations/themes/1.0/?slug=${ slug }`,

--- a/scripts/download-language-packs.ts
+++ b/scripts/download-language-packs.ts
@@ -150,8 +150,6 @@ async function downloadLanguagePacks(): Promise< void > {
 
 	// Remove .po and .mo files — WordPress 6.5+ uses .l10n.php and .json files.
 	await removePoAndMoFiles( languagesPath );
-
-	console.log( '[language-packs] Files extracted' );
 }
 
 downloadLanguagePacks()

--- a/scripts/download-wp-server-files.ts
+++ b/scripts/download-wp-server-files.ts
@@ -2,7 +2,6 @@ import os from 'os';
 import path from 'path';
 import fs from 'fs-extra';
 import { extractZip } from '../common/lib/extract-zip';
-import { WP_LOCALES } from '../common/lib/wp-locales';
 import { getLatestSQLiteCommandRelease } from '../src/lib/sqlite-command-release';
 import { SQLITE_DATABASE_INTEGRATION_RELEASE_URL } from '../src/constants';
 
@@ -100,125 +99,6 @@ async function downloadFile( file: FileToDownload ): Promise< void > {
 	await fs.remove( zipPath );
 }
 
-interface TranslationEntry {
-	language: string;
-	package: string;
-}
-
-interface TranslationsApiResponse {
-	translations: TranslationEntry[];
-}
-
-// Known single-file plugins whose directory name doesn't match the WordPress.org slug.
-const SINGLE_FILE_PLUGIN_SLUGS: Record< string, string > = {
-	'hello.php': 'hello-dolly',
-};
-
-function getBundledSlugs( contentDir: string ): string[] {
-	const entries = fs.readdirSync( contentDir, { withFileTypes: true } );
-	const slugs: string[] = [];
-	for ( const entry of entries ) {
-		if ( entry.name === 'index.php' ) {
-			continue;
-		}
-		if ( entry.isDirectory() ) {
-			slugs.push( entry.name );
-		} else if ( SINGLE_FILE_PLUGIN_SLUGS[ entry.name ] ) {
-			slugs.push( SINGLE_FILE_PLUGIN_SLUGS[ entry.name ] );
-		}
-	}
-	return slugs;
-}
-
-async function downloadTranslationsFromApi(
-	apiUrl: string,
-	destPath: string,
-	label: string
-): Promise< void > {
-	const response = await fetch( apiUrl );
-	if ( ! response.ok ) {
-		throw new Error( `Failed to fetch ${ label } translations API (status ${ response.status })` );
-	}
-	const data: TranslationsApiResponse = await response.json();
-
-	const translationsToDownload = data.translations.filter( ( t ) =>
-		WP_LOCALES.includes( t.language )
-	);
-
-	console.log(
-		`[language-packs] Downloading ${ label } (${ translationsToDownload.length } locales) ...`
-	);
-
-	await fs.ensureDir( destPath );
-
-	for ( const translation of translationsToDownload ) {
-		const { language, package: packageUrl } = translation;
-		const zipResponse = await fetch( packageUrl );
-		if ( ! zipResponse.ok ) {
-			console.error(
-				`[language-packs] Failed to download ${ label }/${ language } (status ${ zipResponse.status }), skipping`
-			);
-			continue;
-		}
-
-		const safeLabel = label.replace( /\//g, '-' );
-		const zipPath = path.join( os.tmpdir(), `wp-language-${ safeLabel }-${ language }.zip` );
-		const buffer = Buffer.from( await zipResponse.arrayBuffer() );
-		await fs.writeFile( zipPath, buffer );
-		await extractZip( zipPath, destPath );
-		await fs.remove( zipPath );
-	}
-}
-
-async function removePoAndMoFiles( dirPath: string ): Promise< void > {
-	const entries = await fs.readdir( dirPath, { withFileTypes: true } );
-	for ( const entry of entries ) {
-		const fullPath = path.join( dirPath, entry.name );
-		if ( entry.isDirectory() ) {
-			await removePoAndMoFiles( fullPath );
-		} else if ( entry.name.endsWith( '.po' ) || entry.name.endsWith( '.mo' ) ) {
-			await fs.remove( fullPath );
-		}
-	}
-}
-
-async function downloadLanguagePacks(): Promise< void > {
-	const languagesPath = path.join( WP_SERVER_FILES_PATH, 'latest', 'languages' );
-	const wpContentPath = path.join( WP_SERVER_FILES_PATH, 'latest', 'wordpress', 'wp-content' );
-
-	// Core translations
-	await downloadTranslationsFromApi(
-		'https://api.wordpress.org/translations/core/1.0/',
-		languagesPath,
-		'core translations'
-	);
-
-	// Plugin translations
-	const pluginSlugs = getBundledSlugs( path.join( wpContentPath, 'plugins' ) );
-	for ( const slug of pluginSlugs ) {
-		await downloadTranslationsFromApi(
-			`https://api.wordpress.org/translations/plugins/1.0/?slug=${ slug }`,
-			path.join( languagesPath, 'plugins' ),
-			`plugin translations: ${ slug }`
-		);
-	}
-
-	// Theme translations
-	const themeSlugs = getBundledSlugs( path.join( wpContentPath, 'themes' ) );
-	for ( const slug of themeSlugs ) {
-		await downloadTranslationsFromApi(
-			`https://api.wordpress.org/translations/themes/1.0/?slug=${ slug }`,
-			path.join( languagesPath, 'themes' ),
-			`theme translations: ${ slug }`
-		);
-	}
-
-	// Remove .po and .mo files — WordPress 6.5+ uses .l10n.php and .json files.
-	await removePoAndMoFiles( languagesPath );
-
-	console.log( '[language-packs] Files extracted' );
-}
-
 async function downloadFiles() {
 	for ( const file of FILES_TO_DOWNLOAD ) {
 		try {
@@ -227,13 +107,6 @@ async function downloadFiles() {
 			console.error( err );
 			process.exit( 1 );
 		}
-	}
-
-	try {
-		await downloadLanguagePacks();
-	} catch ( err ) {
-		console.error( '[language-packs] Error downloading language packs:', err );
-		process.exit( 1 );
 	}
 }
 

--- a/scripts/download-wp-server-files.ts
+++ b/scripts/download-wp-server-files.ts
@@ -2,6 +2,7 @@ import os from 'os';
 import path from 'path';
 import fs from 'fs-extra';
 import { extractZip } from '../common/lib/extract-zip';
+import { WP_LOCALES } from '../common/lib/wp-locales';
 import { getLatestSQLiteCommandRelease } from '../src/lib/sqlite-command-release';
 import { SQLITE_DATABASE_INTEGRATION_RELEASE_URL } from '../src/constants';
 
@@ -99,6 +100,125 @@ async function downloadFile( file: FileToDownload ): Promise< void > {
 	await fs.remove( zipPath );
 }
 
+interface TranslationEntry {
+	language: string;
+	package: string;
+}
+
+interface TranslationsApiResponse {
+	translations: TranslationEntry[];
+}
+
+// Known single-file plugins whose directory name doesn't match the WordPress.org slug.
+const SINGLE_FILE_PLUGIN_SLUGS: Record< string, string > = {
+	'hello.php': 'hello-dolly',
+};
+
+function getBundledSlugs( contentDir: string ): string[] {
+	const entries = fs.readdirSync( contentDir, { withFileTypes: true } );
+	const slugs: string[] = [];
+	for ( const entry of entries ) {
+		if ( entry.name === 'index.php' ) {
+			continue;
+		}
+		if ( entry.isDirectory() ) {
+			slugs.push( entry.name );
+		} else if ( SINGLE_FILE_PLUGIN_SLUGS[ entry.name ] ) {
+			slugs.push( SINGLE_FILE_PLUGIN_SLUGS[ entry.name ] );
+		}
+	}
+	return slugs;
+}
+
+async function downloadTranslationsFromApi(
+	apiUrl: string,
+	destPath: string,
+	label: string
+): Promise< void > {
+	const response = await fetch( apiUrl );
+	if ( ! response.ok ) {
+		throw new Error( `Failed to fetch ${ label } translations API (status ${ response.status })` );
+	}
+	const data: TranslationsApiResponse = await response.json();
+
+	const translationsToDownload = data.translations.filter( ( t ) =>
+		WP_LOCALES.includes( t.language )
+	);
+
+	console.log(
+		`[language-packs] Downloading ${ label } (${ translationsToDownload.length } locales) ...`
+	);
+
+	await fs.ensureDir( destPath );
+
+	for ( const translation of translationsToDownload ) {
+		const { language, package: packageUrl } = translation;
+		const zipResponse = await fetch( packageUrl );
+		if ( ! zipResponse.ok ) {
+			console.error(
+				`[language-packs] Failed to download ${ label }/${ language } (status ${ zipResponse.status }), skipping`
+			);
+			continue;
+		}
+
+		const safeLabel = label.replace( /\//g, '-' );
+		const zipPath = path.join( os.tmpdir(), `wp-language-${ safeLabel }-${ language }.zip` );
+		const buffer = Buffer.from( await zipResponse.arrayBuffer() );
+		await fs.writeFile( zipPath, buffer );
+		await extractZip( zipPath, destPath );
+		await fs.remove( zipPath );
+	}
+}
+
+async function removePoAndMoFiles( dirPath: string ): Promise< void > {
+	const entries = await fs.readdir( dirPath, { withFileTypes: true } );
+	for ( const entry of entries ) {
+		const fullPath = path.join( dirPath, entry.name );
+		if ( entry.isDirectory() ) {
+			await removePoAndMoFiles( fullPath );
+		} else if ( entry.name.endsWith( '.po' ) || entry.name.endsWith( '.mo' ) ) {
+			await fs.remove( fullPath );
+		}
+	}
+}
+
+async function downloadLanguagePacks(): Promise< void > {
+	const languagesPath = path.join( WP_SERVER_FILES_PATH, 'latest', 'languages' );
+	const wpContentPath = path.join( WP_SERVER_FILES_PATH, 'latest', 'wordpress', 'wp-content' );
+
+	// Core translations
+	await downloadTranslationsFromApi(
+		'https://api.wordpress.org/translations/core/1.0/',
+		languagesPath,
+		'core translations'
+	);
+
+	// Plugin translations
+	const pluginSlugs = getBundledSlugs( path.join( wpContentPath, 'plugins' ) );
+	for ( const slug of pluginSlugs ) {
+		await downloadTranslationsFromApi(
+			`https://api.wordpress.org/translations/plugins/1.0/?slug=${ slug }`,
+			path.join( languagesPath, 'plugins' ),
+			`plugin translations: ${ slug }`
+		);
+	}
+
+	// Theme translations
+	const themeSlugs = getBundledSlugs( path.join( wpContentPath, 'themes' ) );
+	for ( const slug of themeSlugs ) {
+		await downloadTranslationsFromApi(
+			`https://api.wordpress.org/translations/themes/1.0/?slug=${ slug }`,
+			path.join( languagesPath, 'themes' ),
+			`theme translations: ${ slug }`
+		);
+	}
+
+	// Remove .po and .mo files — WordPress 6.5+ uses .l10n.php and .json files.
+	await removePoAndMoFiles( languagesPath );
+
+	console.log( '[language-packs] Files extracted' );
+}
+
 async function downloadFiles() {
 	for ( const file of FILES_TO_DOWNLOAD ) {
 		try {
@@ -107,6 +227,13 @@ async function downloadFiles() {
 			console.error( err );
 			process.exit( 1 );
 		}
+	}
+
+	try {
+		await downloadLanguagePacks();
+	} catch ( err ) {
+		console.error( '[language-packs] Error downloading language packs:', err );
+		process.exit( 1 );
 	}
 }
 

--- a/src/lib/server-files-paths.ts
+++ b/src/lib/server-files-paths.ts
@@ -64,3 +64,10 @@ export function getWpCliFolderPath(): string {
 export function getWpCliPath(): string {
 	return path.join( getWpCliFolderPath(), 'wp-cli.phar' );
 }
+
+/**
+ * The path where bundled WordPress language packs are stored.
+ */
+export function getLanguagePacksPath(): string {
+	return path.join( getBasePath(), 'language-packs' );
+}

--- a/src/setup-wp-server-files.ts
+++ b/src/setup-wp-server-files.ts
@@ -3,7 +3,12 @@ import fs from 'fs-extra';
 import semver from 'semver';
 import { recursiveCopyDirectory } from 'common/lib/fs-utils';
 import { updateLatestWPCliVersion } from 'src/lib/download-utils';
-import { getWordPressVersionPath, getSqlitePath, getWpCliPath } from 'src/lib/server-files-paths';
+import {
+	getLanguagePacksPath,
+	getWordPressVersionPath,
+	getSqlitePath,
+	getWpCliPath,
+} from 'src/lib/server-files-paths';
 import {
 	getSqliteCommandPath,
 	updateLatestSQLiteCommandVersion,
@@ -108,12 +113,38 @@ async function copyBundledTranslations() {
 	await fs.copyFile( bundledTranslationsPath, installedTranslationsPath );
 }
 
+async function copyBundledLanguagePacks() {
+	const bundledLanguagePacksPath = path.join(
+		getResourcesPath(),
+		'wp-files',
+		'latest',
+		'languages'
+	);
+	if ( ! ( await fs.pathExists( bundledLanguagePacksPath ) ) ) {
+		return;
+	}
+	const installedLanguagePacksPath = getLanguagePacksPath();
+	await fs.ensureDir( installedLanguagePacksPath );
+	await recursiveCopyDirectory( bundledLanguagePacksPath, installedLanguagePacksPath );
+}
+
 export async function setupWPServerFiles() {
-	await copyBundledLatestWPVersion();
-	await copyBundledSqlite();
-	await copyBundledWPCLI();
-	await copyBundledSQLiteCommand();
-	await copyBundledTranslations();
+	const steps: Array< [ string, () => Promise< void > ] > = [
+		[ 'WordPress version', copyBundledLatestWPVersion ],
+		[ 'SQLite integration', copyBundledSqlite ],
+		[ 'WP-CLI', copyBundledWPCLI ],
+		[ 'SQLite command', copyBundledSQLiteCommand ],
+		[ 'translations', copyBundledTranslations ],
+		[ 'language packs', copyBundledLanguagePacks ],
+	];
+
+	for ( const [ name, step ] of steps ) {
+		try {
+			await step();
+		} catch ( error ) {
+			console.error( `Failed to set up bundled ${ name }:`, error );
+		}
+	}
 }
 
 /**


### PR DESCRIPTION
## Related issues

Closes STU-1250
Related to STU-980

## Context

#2558 bundled WordPress translation files for faster site creation but was reverted in #2572 due to CI build failures — `ConnectTimeoutError` when downloading ~114 translation ZIP files sequentially from `downloads.wordpress.org` during `npm install`. The root cause was that language pack downloads ran on every `npm install` via `postinstall`.

Related discussion: p1770812916266539-slack-C06DRMD6VPZ.

## What changed from the original PR

This PR re-applies #2558 with the following fixes:

- **Language pack downloads moved out of `postinstall`** into a standalone script (`scripts/download-language-packs.ts`) that runs during `npm run make` via the forge `prePackage` hook.
- **`npm install` no longer downloads language packs**
- **Retry with exponential backoff** — failed HTTP requests are retried up to 3 times with exponential backoff (1s, 2s, 4s) to handle transient network issues like `ConnectTimeoutError`.
- **Download failure is fatal during `make`** — if a download still fails after retries, the build fails, ensuring all translations are included in the release.
- **`npm run download-language-packs`** available as a standalone command for manual use.
- **Skips translations for older bundled themes** (twentytwentythree, twentytwentyfour) to reduce download count.

## Proposed Changes (from original PR)

- Download WordPress core, plugin, and theme translation files at build time for all 19 supported non-English locales.
- At app startup, copy bundled language packs from app resources to the runtime `server-files/language-packs/` directory.
- During site creation for the latest WP version, copy locale-specific `.l10n.php` and `.json` files directly into the site's `wp-content/languages/` directory and set `WPLANG` via blueprint steps (`defineWpConfigConsts` + `setSiteOptions`) — no network round-trip needed.
- Fall back to the original `setSiteLanguage` blueprint step for non-latest WP versions or when bundled packs are unavailable.
- Auto-detect bundled plugins and themes from the extracted WordPress installation for translation downloads.
- Only bundle `.l10n.php` and `.json` files (WordPress 6.5+ format), skipping `.po` and `.mo` to reduce size (~29MB vs ~82MB).
- Make `setupWPServerFiles` resilient so individual step failures don't prevent subsequent steps from running.

## Testing Instructions

### Testing the built app

1. Build the app with `npm run make`.
2. Open the content of the built app:

<img width="582" height="222" alt="CleanShot 2026-02-12 at 12 01 41@2x" src="https://github.com/user-attachments/assets/f63e33a8-91ba-459b-b81c-739eced5ff9d" />

3. Ensure the translation files are bundled: `Studio.app/Contents/Resources/wp-files/latest/languages`:

<img width="512" height="406" alt="CleanShot 2026-02-12 at 12 10 47@2x" src="https://github.com/user-attachments/assets/a0599a9f-f71e-4923-a02d-dbdc57909e5a" />

4. Set the locale in the app settings to a non-English language (e.g. Swedish).
5. Create a new site and verify:
   - Site creation completes without downloading translations from WordPress.org. → To test this, you can go offline. Also, the site creation process should take about 3 - 4 seconds less than when testing with the current `trunk`.
   - The WP Admin is displayed in the selected language.
   - Plugin and theme translations are present.
   - You should also find translations in the site's `wp-content`.
6. Ensure you are online. Create a site with a non-latest WP version (e.g. 6.5) and verify it falls back to downloading translations. → The process should take 3 - 4 seconds longer compared to creating site with the latest WP version.
7. Again as with the previous site, everything in WP Admin should be translated, including themes and plugins.
8. Switch the locale to English.
9. Create a site and verify no translations appear in the site's `wp-content`.

### Testing the dev environment

10. Run `npm install`.
11. Head over to your project root and confirm there is no `languages` directory present in `wp-files/latest`.
12. Run `npm run download-language-packs` and verify language packs are downloaded. You can find them in the project root: `wp-files/latest/languages`.
13. Run `npm start` and set the locale in the app settings to a non-English language (e.g. Swedish).
14. You can follow similar steps as with testing the built app (steps 5 - 9).
15. Run `npm test` and verify all tests pass.

## Pre-merge Checklist
- [ ] Have you checked for TypeScript, React or other console errors?