### PR TITLE
Add site name to start site dialog error

### DIFF
--- a/src/components/assistant-anchor.tsx
+++ b/src/components/assistant-anchor.tsx
@@ -30,7 +30,7 @@ export default function Anchor( props: JSX.IntrinsicElements[ 'a' ] & ExtraProps
 					/^https?:\/\/localhost/.test( href ) && selectedSite && ! selectedSite.running;
 				if ( urlForStoppedSite ) {
 					speak( __( 'Starting the server before opening the site link' ) );
-					await startServer( selectedSite?.id );
+					await startServer( selectedSite );
 				}
 
 				const isTelexUrl = getHostnameFromUrl( href ) === TELEX_HOSTNAME;

--- a/src/components/content-tab-import-export.tsx
+++ b/src/components/content-tab-import-export.tsx
@@ -236,7 +236,7 @@ const ImportSite = ( {
 	const openSite = async () => {
 		if ( ! selectedSite.running ) {
 			speak( __( 'Starting the server before opening the site link' ) );
-			await startServer( selectedSite.id );
+			await startServer( selectedSite );
 		}
 		getIpcApi().openSiteURL( selectedSite.id, '', { autoLogin: false } );
 	};

--- a/src/components/content-tab-overview.tsx
+++ b/src/components/content-tab-overview.tsx
@@ -55,7 +55,7 @@ function CustomizeSection( {
 	const handleCustomizeClick = ( url: string ) => async () => {
 		if ( isLoading ) return;
 		if ( ! selectedSite.running ) {
-			await startServer( selectedSite.id );
+			await startServer( selectedSite );
 		}
 		getIpcApi().openSiteURL( selectedSite.id, url );
 	};
@@ -200,7 +200,7 @@ export function ContentTabOverview( { selectedSite }: ContentTabOverviewProps ) 
 		if ( isServerLoading ) return;
 
 		if ( ! selectedSite.running ) {
-			await startServer( selectedSite.id );
+			await startServer( selectedSite );
 		}
 		getIpcApi().openSiteURL( selectedSite.id, '', { autoLogin: false } );
 	};

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -14,7 +14,7 @@ export default function Header() {
 		if ( ! site || isLoading ) return;
 
 		if ( ! site.running ) {
-			await startServer( site.id );
+			await startServer( site );
 		}
 		getIpcApi().openSiteURL( site.id, '/wp-admin' );
 	};
@@ -23,7 +23,7 @@ export default function Header() {
 		if ( ! site || isLoading ) return;
 
 		if ( ! site.running ) {
-			await startServer( site.id );
+			await startServer( site );
 		}
 		getIpcApi().openSiteURL( site.id, '', { autoLogin: false } );
 	};

--- a/src/components/site-management-actions.tsx
+++ b/src/components/site-management-actions.tsx
@@ -8,7 +8,7 @@ import { useImportExport } from 'src/hooks/use-import-export';
 
 export interface SiteManagementActionProps {
 	onStop: ( id: string ) => Promise< void >;
-	onStart: ( id: string ) => Promise< void >;
+	onStart: ( site: SiteDetails ) => Promise< void >;
 	selectedSite?: SiteDetails | null;
 	loading: boolean;
 }
@@ -51,7 +51,7 @@ export const SiteManagementActions = ( {
 						if ( selectedSite.running ) {
 							void onStop( selectedSite.id );
 						} else {
-							void onStart( selectedSite.id );
+							void onStart( selectedSite );
 						}
 					} }
 					disabled={ disabled }

--- a/src/components/site-menu.tsx
+++ b/src/components/site-menu.tsx
@@ -21,12 +21,8 @@ interface SiteMenuProps {
 	className?: string;
 }
 
-function ButtonToRun( {
-	running,
-	id,
-	name,
-	enableXdebug,
-}: Pick< SiteDetails, 'running' | 'id' | 'name' | 'enableXdebug' > ) {
+function ButtonToRun( site: SiteDetails ) {
+	const { running, id, name, enableXdebug } = site;
 	const { startServer, stopServer, loadingServer } = useSiteDetails();
 	const siteStartedMessage = sprintf(
 		// translators: %s is the site name.
@@ -87,7 +83,7 @@ function ButtonToRun( {
 					if ( loadingServer[ id ] ) {
 						return;
 					}
-					return running ? stopServer( id ) : startServer( id );
+					return running ? stopServer( id ) : startServer( site );
 				} }
 				className="w-7 h-8 rounded-tr rounded-br group grid focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-a8c-blue-50"
 				aria-label={ sprintf( running ? __( 'stop %s site' ) : __( 'start %s site' ), name ) }
@@ -237,20 +233,20 @@ export default function SiteMenu( { className }: SiteMenuProps ) {
 				const ipcApi = getIpcApi();
 				switch ( actionData.action ) {
 					case 'start':
-						void startServer( site.id );
+						void startServer( site );
 						break;
 					case 'stop':
 						void stopServer( site.id );
 						break;
 					case 'open-site':
 						if ( ! site.running ) {
-							await startServer( site.id );
+							await startServer( site );
 						}
 						ipcApi.openSiteURL( site.id, '', { autoLogin: false } );
 						break;
 					case 'open-admin':
 						if ( ! site.running ) {
-							await startServer( site.id );
+							await startServer( site );
 						}
 						ipcApi.openSiteURL( site.id, '/wp-admin/' );
 						break;

--- a/src/components/tests/assistant-anchor.test.tsx
+++ b/src/components/tests/assistant-anchor.test.tsx
@@ -77,7 +77,9 @@ describe( 'Anchor', () => {
 		screen.getByRole( 'link' ).click();
 
 		expect( speak ).toHaveBeenCalledWith( 'Starting the server before opening the site link' );
-		expect( useSiteDetails().startServer ).toHaveBeenCalledWith( '1' );
+		expect( useSiteDetails().startServer ).toHaveBeenCalledWith(
+			expect.objectContaining( { id: '1', name: 'Test Site' } )
+		);
 
 		// Await asynchronous start server execution
 		await new Promise( process.nextTick );

--- a/src/components/tests/header.test.tsx
+++ b/src/components/tests/header.test.tsx
@@ -91,7 +91,7 @@ describe( 'Header', () => {
 			expect( screen.getByText( 'Start' ) ).toBeVisible();
 			expect( vi.mocked( getIpcApi )().showErrorMessageBox ).toHaveBeenCalledTimes( 1 );
 			expect( vi.mocked( getIpcApi )().showErrorMessageBox ).toHaveBeenCalledWith( {
-				title: 'Failed to start the site server',
+				title: "Failed to start 'test-1'",
 				message:
 					"Please verify your site's local path directory contains the standard WordPress installation files and try again. If this problem persists, please contact support.",
 				error,

--- a/src/components/tests/main-sidebar.test.tsx
+++ b/src/components/tests/main-sidebar.test.tsx
@@ -160,7 +160,7 @@ describe( 'MainSidebar Site Menu', () => {
 		expect( greenDotFirstSite ).toBeVisible();
 		await user.click( greenDotFirstSite );
 		expect( siteDetailsMocked.startServer ).toHaveBeenCalledWith(
-			'0e9e237b-335a-43fa-b439-9b078a618512'
+			expect.objectContaining( { id: '0e9e237b-335a-43fa-b439-9b078a618512', name: 'test-1' } )
 		);
 	} );
 

--- a/src/hooks/sync-sites/use-sync-pull.ts
+++ b/src/hooks/sync-sites/use-sync-pull.ts
@@ -247,7 +247,7 @@ export function useSyncPull( {
 
 				await getIpcApi().removeSyncBackup( remoteSiteId );
 
-				await startServer( selectedSite.id );
+				await startServer( selectedSite );
 
 				clearImportState( selectedSite.id );
 

--- a/src/hooks/tests/use-import-export.test.tsx
+++ b/src/hooks/tests/use-import-export.test.tsx
@@ -332,7 +332,7 @@ describe( 'useImportExport hook', () => {
 			} )
 		);
 		expect( useSiteDetails().startServer ).toHaveBeenCalledTimes( 1 );
-		expect( useSiteDetails().startServer ).toHaveBeenCalledWith( SITE_ID );
+		expect( useSiteDetails().startServer ).toHaveBeenCalledWith( selectedSite );
 	} );
 
 	it( 'shows error message when import fails with absolute path error', async () => {

--- a/src/hooks/tests/use-site-details.test.tsx
+++ b/src/hooks/tests/use-site-details.test.tsx
@@ -300,7 +300,7 @@ describe( 'useSiteDetails', () => {
 			);
 		} );
 
-		it( 'should fall back to generic title when site name is not found', async () => {
+		it( 'should display empty string in title when site is not found', async () => {
 			const { showErrorMessageBox } = setupStartServerError( new Error( 'Something went wrong' ) );
 
 			const { result } = renderHook( () => useSiteDetails(), { wrapper } );
@@ -317,7 +317,7 @@ describe( 'useSiteDetails', () => {
 
 			expect( showErrorMessageBox ).toHaveBeenCalledWith(
 				expect.objectContaining( {
-					title: 'Failed to start the site server',
+					title: "Failed to start 'site'",
 				} )
 			);
 		} );

--- a/src/hooks/tests/use-site-details.test.tsx
+++ b/src/hooks/tests/use-site-details.test.tsx
@@ -10,7 +10,7 @@ import { store } from 'src/stores';
 
 vi.mock( 'src/lib/get-ipc-api' );
 
-const mockSites = [
+const mockSites: SiteDetails[] = [
 	{
 		id: 'site-1',
 		name: 'Site 1',
@@ -194,7 +194,7 @@ describe( 'useSiteDetails', () => {
 			vi.mocked( getIpcApi().startServer ).mockClear();
 
 			await act( async () => {
-				await result.current.startServer( 'site-2' );
+				await result.current.startServer( mockSites[ 1 ] );
 			} );
 
 			expect( showErrorMessageBox ).toHaveBeenCalledWith(
@@ -218,7 +218,7 @@ describe( 'useSiteDetails', () => {
 			vi.mocked( getIpcApi().startServer ).mockClear();
 
 			await act( async () => {
-				await result.current.startServer( 'site-1' );
+				await result.current.startServer( mockSites[ 0 ] as SiteDetails );
 			} );
 
 			expect( showErrorMessageBox ).toHaveBeenCalledWith(
@@ -242,7 +242,7 @@ describe( 'useSiteDetails', () => {
 			vi.mocked( getIpcApi().startServer ).mockClear();
 
 			await act( async () => {
-				await result.current.startServer( 'site-3' );
+				await result.current.startServer( mockSites[ 2 ] as SiteDetails );
 			} );
 
 			expect( showErrorMessageBox ).toHaveBeenCalledWith(
@@ -266,7 +266,7 @@ describe( 'useSiteDetails', () => {
 			vi.mocked( getIpcApi().startServer ).mockClear();
 
 			await act( async () => {
-				await result.current.startServer( 'site-1' );
+				await result.current.startServer( mockSites[ 0 ] as SiteDetails );
 			} );
 
 			expect( showErrorMessageBox ).toHaveBeenCalledWith(
@@ -290,7 +290,7 @@ describe( 'useSiteDetails', () => {
 			vi.mocked( getIpcApi().startServer ).mockClear();
 
 			await act( async () => {
-				await result.current.startServer( 'site-2' );
+				await result.current.startServer( mockSites[ 1 ] as SiteDetails );
 			} );
 
 			expect( showErrorMessageBox ).toHaveBeenCalledWith(
@@ -300,7 +300,7 @@ describe( 'useSiteDetails', () => {
 			);
 		} );
 
-		it( 'should display empty string in title when site is not found', async () => {
+		it( 'should use site name in dialog title even if site has no name', async () => {
 			const { showErrorMessageBox } = setupStartServerError( new Error( 'Something went wrong' ) );
 
 			const { result } = renderHook( () => useSiteDetails(), { wrapper } );
@@ -312,12 +312,19 @@ describe( 'useSiteDetails', () => {
 			vi.mocked( getIpcApi().startServer ).mockClear();
 
 			await act( async () => {
-				await result.current.startServer( 'non-existent-id' );
+				await result.current.startServer( {
+					id: 'non-existent-id',
+					name: '',
+					path: '',
+					port: 0,
+					phpVersion: '',
+					running: false,
+				} );
 			} );
 
 			expect( showErrorMessageBox ).toHaveBeenCalledWith(
 				expect.objectContaining( {
-					title: "Failed to start 'site'",
+					title: "Failed to start ''",
 				} )
 			);
 		} );

--- a/src/hooks/tests/use-site-details.test.tsx
+++ b/src/hooks/tests/use-site-details.test.tsx
@@ -169,16 +169,21 @@ describe( 'useSiteDetails', () => {
 	} );
 
 	describe( 'startServer error handling', () => {
-		it( 'should include site name in error title for generic start failure', async () => {
+		function setupStartServerError( error: Error ) {
 			const showErrorMessageBox = vi.fn();
 			const stopServer = vi.fn( () => Promise.resolve() );
 			vi.mocked( getIpcApi, { partial: true } ).mockReturnValue( {
 				getSiteDetails: vi.fn().mockResolvedValue( mockSites ),
-				startServer: vi.fn( () => Promise.reject( new Error( 'Something went wrong' ) ) ),
+				startServer: vi.fn().mockRejectedValue( error ),
 				showErrorMessageBox,
 				stopServer,
 				getConnectedWpcomSites: vi.fn( () => Promise.resolve( [] ) ),
 			} );
+			return { showErrorMessageBox, stopServer };
+		}
+
+		it( 'should include site name in error title for generic start failure', async () => {
+			const { showErrorMessageBox } = setupStartServerError( new Error( 'Something went wrong' ) );
 
 			const { result } = renderHook( () => useSiteDetails(), { wrapper } );
 
@@ -200,15 +205,9 @@ describe( 'useSiteDetails', () => {
 		} );
 
 		it( 'should include site name in error title for WASM memory error', async () => {
-			const showErrorMessageBox = vi.fn();
-			const stopServer = vi.fn( () => Promise.resolve() );
-			vi.mocked( getIpcApi, { partial: true } ).mockReturnValue( {
-				getSiteDetails: vi.fn().mockResolvedValue( mockSites ),
-				startServer: vi.fn().mockRejectedValue( new Error( 'WASM_ERROR_NOT_ENOUGH_MEMORY' ) ),
-				showErrorMessageBox,
-				stopServer,
-				getConnectedWpcomSites: vi.fn( () => Promise.resolve( [] ) ),
-			} );
+			const { showErrorMessageBox } = setupStartServerError(
+				new Error( 'WASM_ERROR_NOT_ENOUGH_MEMORY' )
+			);
 
 			const { result } = renderHook( () => useSiteDetails(), { wrapper } );
 
@@ -230,15 +229,9 @@ describe( 'useSiteDetails', () => {
 		} );
 
 		it( 'should include site name in error title for port-in-use error', async () => {
-			const showErrorMessageBox = vi.fn();
-			const stopServer = vi.fn( () => Promise.resolve() );
-			vi.mocked( getIpcApi, { partial: true } ).mockReturnValue( {
-				getSiteDetails: vi.fn().mockResolvedValue( mockSites ),
-				startServer: vi.fn().mockRejectedValue( new Error( 'ERROR_PORT_IN_USE 8080' ) ),
-				showErrorMessageBox,
-				stopServer,
-				getConnectedWpcomSites: vi.fn( () => Promise.resolve( [] ) ),
-			} );
+			const { showErrorMessageBox } = setupStartServerError(
+				new Error( 'ERROR_PORT_IN_USE 8080' )
+			);
 
 			const { result } = renderHook( () => useSiteDetails(), { wrapper } );
 
@@ -260,15 +253,9 @@ describe( 'useSiteDetails', () => {
 		} );
 
 		it( 'should include site name in error title for proxy port-in-use error', async () => {
-			const showErrorMessageBox = vi.fn();
-			const stopServer = vi.fn( () => Promise.resolve() );
-			vi.mocked( getIpcApi, { partial: true } ).mockReturnValue( {
-				getSiteDetails: vi.fn().mockResolvedValue( mockSites ),
-				startServer: vi.fn().mockRejectedValue( new Error( 'PROXY_ERROR_PORT_IN_USE' ) ),
-				showErrorMessageBox,
-				stopServer,
-				getConnectedWpcomSites: vi.fn( () => Promise.resolve( [] ) ),
-			} );
+			const { showErrorMessageBox } = setupStartServerError(
+				new Error( 'PROXY_ERROR_PORT_IN_USE' )
+			);
 
 			const { result } = renderHook( () => useSiteDetails(), { wrapper } );
 
@@ -289,16 +276,32 @@ describe( 'useSiteDetails', () => {
 			);
 		} );
 
-		it( 'should fall back to generic title when site name is not found', async () => {
-			const showErrorMessageBox = vi.fn();
-			const stopServer = vi.fn( () => Promise.resolve() );
-			vi.mocked( getIpcApi, { partial: true } ).mockReturnValue( {
-				getSiteDetails: vi.fn().mockResolvedValue( mockSites ),
-				startServer: vi.fn( () => Promise.reject( new Error( 'Something went wrong' ) ) ),
-				showErrorMessageBox,
-				stopServer,
-				getConnectedWpcomSites: vi.fn( () => Promise.resolve( [] ) ),
+		it( 'should include site name in error title for proxy start failed error', async () => {
+			const { showErrorMessageBox } = setupStartServerError(
+				new Error( 'PROXY_ERROR_START_FAILED' )
+			);
+
+			const { result } = renderHook( () => useSiteDetails(), { wrapper } );
+
+			await waitFor( () => {
+				expect( result.current.loadingSites ).toBe( false );
 			} );
+
+			vi.mocked( getIpcApi().startServer ).mockClear();
+
+			await act( async () => {
+				await result.current.startServer( 'site-2' );
+			} );
+
+			expect( showErrorMessageBox ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					title: "Failed to initialize custom domains for 'Site 2'",
+				} )
+			);
+		} );
+
+		it( 'should fall back to generic title when site name is not found', async () => {
+			const { showErrorMessageBox } = setupStartServerError( new Error( 'Something went wrong' ) );
 
 			const { result } = renderHook( () => useSiteDetails(), { wrapper } );
 

--- a/src/hooks/tests/use-site-details.test.tsx
+++ b/src/hooks/tests/use-site-details.test.tsx
@@ -168,6 +168,158 @@ describe( 'useSiteDetails', () => {
 		} );
 	} );
 
+	describe( 'startServer error handling', () => {
+		it( 'should include site name in error title for generic start failure', async () => {
+			const showErrorMessageBox = vi.fn();
+			const stopServer = vi.fn( () => Promise.resolve() );
+			vi.mocked( getIpcApi, { partial: true } ).mockReturnValue( {
+				getSiteDetails: vi.fn().mockResolvedValue( mockSites ),
+				startServer: vi.fn( () => Promise.reject( new Error( 'Something went wrong' ) ) ),
+				showErrorMessageBox,
+				stopServer,
+				getConnectedWpcomSites: vi.fn( () => Promise.resolve( [] ) ),
+			} );
+
+			const { result } = renderHook( () => useSiteDetails(), { wrapper } );
+
+			await waitFor( () => {
+				expect( result.current.loadingSites ).toBe( false );
+			} );
+
+			vi.mocked( getIpcApi().startServer ).mockClear();
+
+			await act( async () => {
+				await result.current.startServer( 'site-2' );
+			} );
+
+			expect( showErrorMessageBox ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					title: "Failed to start 'Site 2'",
+				} )
+			);
+		} );
+
+		it( 'should include site name in error title for WASM memory error', async () => {
+			const showErrorMessageBox = vi.fn();
+			const stopServer = vi.fn( () => Promise.resolve() );
+			vi.mocked( getIpcApi, { partial: true } ).mockReturnValue( {
+				getSiteDetails: vi.fn().mockResolvedValue( mockSites ),
+				startServer: vi.fn().mockRejectedValue( new Error( 'WASM_ERROR_NOT_ENOUGH_MEMORY' ) ),
+				showErrorMessageBox,
+				stopServer,
+				getConnectedWpcomSites: vi.fn( () => Promise.resolve( [] ) ),
+			} );
+
+			const { result } = renderHook( () => useSiteDetails(), { wrapper } );
+
+			await waitFor( () => {
+				expect( result.current.loadingSites ).toBe( false );
+			} );
+
+			vi.mocked( getIpcApi().startServer ).mockClear();
+
+			await act( async () => {
+				await result.current.startServer( 'site-1' );
+			} );
+
+			expect( showErrorMessageBox ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					title: "Not enough memory to start 'Site 1'",
+				} )
+			);
+		} );
+
+		it( 'should include site name in error title for port-in-use error', async () => {
+			const showErrorMessageBox = vi.fn();
+			const stopServer = vi.fn( () => Promise.resolve() );
+			vi.mocked( getIpcApi, { partial: true } ).mockReturnValue( {
+				getSiteDetails: vi.fn().mockResolvedValue( mockSites ),
+				startServer: vi.fn().mockRejectedValue( new Error( 'ERROR_PORT_IN_USE 8080' ) ),
+				showErrorMessageBox,
+				stopServer,
+				getConnectedWpcomSites: vi.fn( () => Promise.resolve( [] ) ),
+			} );
+
+			const { result } = renderHook( () => useSiteDetails(), { wrapper } );
+
+			await waitFor( () => {
+				expect( result.current.loadingSites ).toBe( false );
+			} );
+
+			vi.mocked( getIpcApi().startServer ).mockClear();
+
+			await act( async () => {
+				await result.current.startServer( 'site-3' );
+			} );
+
+			expect( showErrorMessageBox ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					title: "Failed to start 'Site 3'",
+				} )
+			);
+		} );
+
+		it( 'should include site name in error title for proxy port-in-use error', async () => {
+			const showErrorMessageBox = vi.fn();
+			const stopServer = vi.fn( () => Promise.resolve() );
+			vi.mocked( getIpcApi, { partial: true } ).mockReturnValue( {
+				getSiteDetails: vi.fn().mockResolvedValue( mockSites ),
+				startServer: vi.fn().mockRejectedValue( new Error( 'PROXY_ERROR_PORT_IN_USE' ) ),
+				showErrorMessageBox,
+				stopServer,
+				getConnectedWpcomSites: vi.fn( () => Promise.resolve( [] ) ),
+			} );
+
+			const { result } = renderHook( () => useSiteDetails(), { wrapper } );
+
+			await waitFor( () => {
+				expect( result.current.loadingSites ).toBe( false );
+			} );
+
+			vi.mocked( getIpcApi().startServer ).mockClear();
+
+			await act( async () => {
+				await result.current.startServer( 'site-1' );
+			} );
+
+			expect( showErrorMessageBox ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					title: "Failed to initialize custom domains for 'Site 1'",
+				} )
+			);
+		} );
+
+		it( 'should fall back to generic title when site name is not found', async () => {
+			const showErrorMessageBox = vi.fn();
+			const stopServer = vi.fn( () => Promise.resolve() );
+			vi.mocked( getIpcApi, { partial: true } ).mockReturnValue( {
+				getSiteDetails: vi.fn().mockResolvedValue( mockSites ),
+				startServer: vi.fn( () => Promise.reject( new Error( 'Something went wrong' ) ) ),
+				showErrorMessageBox,
+				stopServer,
+				getConnectedWpcomSites: vi.fn( () => Promise.resolve( [] ) ),
+			} );
+
+			const { result } = renderHook( () => useSiteDetails(), { wrapper } );
+
+			await waitFor( () => {
+				expect( result.current.loadingSites ).toBe( false );
+			} );
+
+			vi.mocked( getIpcApi().startServer ).mockClear();
+
+			await act( async () => {
+				await result.current.startServer( 'non-existent-id' );
+			} );
+
+			expect( showErrorMessageBox ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					title: 'Failed to start the site server',
+				} )
+			);
+		} );
+	} );
+
 	describe( 'site deletion selection behavior', () => {
 		it( 'should select first site when deleting the currently selected site', async () => {
 			const { result } = renderHook( () => useSiteDetails(), { wrapper } );

--- a/src/hooks/use-import-export.tsx
+++ b/src/hooks/use-import-export.tsx
@@ -161,7 +161,7 @@ export const ImportExportProvider = ( { children }: { children: React.ReactNode 
 			} catch ( error ) {
 				await handleImportError( error );
 			} finally {
-				await startServer( selectedSite.id );
+				await startServer( selectedSite );
 			}
 		},
 		[ importState, startServer, stopServer, updateSite ]

--- a/src/hooks/use-site-details.tsx
+++ b/src/hooks/use-site-details.tsx
@@ -407,12 +407,10 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 			try {
 				await getIpcApi().startServer( id );
 			} catch ( error ) {
-				const siteName = sitesRef.current.find( ( site ) => site.id === id )?.name;
+				const siteName = sitesRef.current.find( ( site ) => site.id === id )?.name || __( 'site' );
 				if ( error instanceof Error && error.message.includes( 'PROXY_ERROR_PORT_IN_USE' ) ) {
 					getIpcApi().showErrorMessageBox( {
-						title: siteName
-							? sprintf( __( "Failed to initialize custom domains for '%s'" ), siteName )
-							: __( 'Studio failed to initialize custom domains' ),
+						title: sprintf( __( "Failed to initialize custom domains for '%s'" ), siteName ),
 						message: __(
 							'Studio needs to use port 80 and 443 to enable custom domains and SSL, but one of these ports are already in use by another app. Close any local development apps and restart Studio.'
 						),
@@ -423,9 +421,7 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 					error.message.includes( 'PROXY_ERROR_START_FAILED' )
 				) {
 					getIpcApi().showErrorMessageBox( {
-						title: siteName
-							? sprintf( __( "Failed to initialize custom domains for '%s'" ), siteName )
-							: __( 'Studio failed to initialize custom domains' ),
+						title: sprintf( __( "Failed to initialize custom domains for '%s'" ), siteName ),
 						message: __(
 							'Please restart Studio and try again. If this problem persists, please contact support.'
 						),
@@ -436,9 +432,7 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 					error.message.includes( 'WASM_ERROR_NOT_ENOUGH_MEMORY' )
 				) {
 					getIpcApi().showErrorMessageBox( {
-						title: siteName
-							? sprintf( __( "Not enough memory to start '%s'" ), siteName )
-							: __( 'Not enough memory to start the site server' ),
+						title: sprintf( __( "Not enough memory to start '%s'" ), siteName ),
 						message: __(
 							'Please stop some of your running sites first. If this problem persists, try closing other apps that might be using memory and try again.'
 						),
@@ -447,9 +441,7 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 				} else if ( error instanceof Error && error.message.includes( 'ERROR_PORT_IN_USE' ) ) {
 					const port = error.message.match( /\d+/ );
 					getIpcApi().showErrorMessageBox( {
-						title: siteName
-							? sprintf( __( "Failed to start '%s'" ), siteName )
-							: __( 'Failed to start the site server' ),
+						title: sprintf( __( "Failed to start '%s'" ), siteName ),
 						message: __(
 							`The site server failed to start because the port is already in use. Please close any local development apps that may be using port ${ port } and try again.`
 						),
@@ -458,9 +450,7 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 				} else {
 					const errorToShow = simplifyErrorForDisplay( error );
 					getIpcApi().showErrorMessageBox( {
-						title: siteName
-							? sprintf( __( "Failed to start '%s'" ), siteName )
-							: __( 'Failed to start the site server' ),
+						title: sprintf( __( "Failed to start '%s'" ), siteName ),
 						message: __(
 							"Please verify your site's local path directory contains the standard WordPress installation files and try again. If this problem persists, please contact support."
 						),

--- a/src/hooks/use-site-details.tsx
+++ b/src/hooks/use-site-details.tsx
@@ -551,17 +551,7 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 		[ sites, selectedTab, setSelectedSiteId, setSelectedTab, startServer ]
 	);
 
-	const autoStartSites = useCallback(
-		( sites: SiteDetails[] ) => {
-			for ( const site of sites ) {
-				if ( site.autoStart ) {
-					void startServer( site.id );
-				}
-			}
-		},
-		[ startServer ]
-	);
-
+	// Auto start sites that are set to auto start when the component mounts
 	useEffect( () => {
 		let cancel = false;
 		setLoadingSites( true );
@@ -571,7 +561,8 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 				if ( ! cancel ) {
 					setSites( data );
 					setLoadingSites( false );
-					autoStartSites( data );
+					const autoStartSites = data.filter( ( site ) => site.autoStart );
+					void Promise.all( autoStartSites.map( ( site ) => startServer( site.id ) ) );
 				}
 			} )
 			.catch( ( error ) => {
@@ -582,7 +573,8 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 		return () => {
 			cancel = true;
 		};
-	}, [ autoStartSites ] );
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [] );
 
 	const stopServer = useCallback(
 		async ( id: string ) => {

--- a/src/hooks/use-site-details.tsx
+++ b/src/hooks/use-site-details.tsx
@@ -6,7 +6,6 @@ import {
 	useContext,
 	useEffect,
 	useMemo,
-	useRef,
 	useState,
 } from 'react';
 import { SITE_EVENTS, SiteEvent } from 'common/lib/site-events';
@@ -39,7 +38,7 @@ interface SiteDetailsContext {
 		noStart?: boolean
 	) => Promise< SiteDetails | void >;
 	copySite: ( sourceSiteId: string ) => Promise< SiteDetails | void >;
-	startServer: ( id: string ) => Promise< void >;
+	startServer: ( site: SiteDetails ) => Promise< void >;
 	stopServer: ( id: string ) => Promise< void >;
 	stopAllRunningSites: () => Promise< void >;
 	startAllStoppedSites: () => Promise< void >;
@@ -397,13 +396,13 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 	}, [] );
 
 	const startServer = useCallback(
-		async ( id: string ) => {
+		async ( site: SiteDetails ) => {
+			const { id, name: siteName } = site;
 			toggleLoadingServerForSite( id );
 
 			try {
 				await getIpcApi().startServer( id );
 			} catch ( error ) {
-				const siteName = sites.find( ( site ) => site.id === id )?.name || __( 'site' );
 				if ( error instanceof Error && error.message.includes( 'PROXY_ERROR_PORT_IN_USE' ) ) {
 					getIpcApi().showErrorMessageBox( {
 						title: sprintf( __( "Failed to initialize custom domains for '%s'" ), siteName ),
@@ -459,7 +458,7 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 
 			toggleLoadingServerForSite( id );
 		},
-		[ toggleLoadingServerForSite, sites ]
+		[ toggleLoadingServerForSite ]
 	);
 
 	const copySite = useCallback(
@@ -537,7 +536,7 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 					body: __( sprintf( 'Your site %s was copied successfully', sourceSite.name ) ),
 				} );
 
-				void startServer( newSite.id );
+				void startServer( newSite );
 
 				return newSite;
 			} catch ( error ) {
@@ -558,7 +557,7 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 					setSites( data );
 					setLoadingSites( false );
 					const autoStartSites = data.filter( ( site ) => site.autoStart );
-					void Promise.all( autoStartSites.map( ( site ) => startServer( site.id ) ) );
+					void Promise.all( autoStartSites.map( ( site ) => startServer( site ) ) );
 				}
 			} )
 			.catch( ( error ) => {
@@ -587,7 +586,7 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 
 	const startAllStoppedSites = useCallback( async () => {
 		const stoppedSites = sites.filter( ( site ) => ! site.running && ! site.isAddingSite );
-		await Promise.allSettled( stoppedSites.map( ( site ) => startServer( site.id ) ) );
+		await Promise.allSettled( stoppedSites.map( ( site ) => startServer( site ) ) );
 	}, [ sites, startServer ] );
 
 	const [ isEditModalOpen, setIsEditModalOpen ] = useState( false );

--- a/src/hooks/use-site-details.tsx
+++ b/src/hooks/use-site-details.tsx
@@ -169,10 +169,6 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 	const { Provider } = siteDetailsContext;
 
 	const [ sites, setSites ] = useState< SiteDetails[] >( [] );
-	const sitesRef = useRef( sites );
-	useEffect( () => {
-		sitesRef.current = sites;
-	}, [ sites ] );
 	const [ loadingSites, setLoadingSites ] = useState< boolean >( true );
 	const [ siteCreationMessages, setSiteCreationMessages ] = useState< {
 		[ siteId: string ]: string;
@@ -407,7 +403,7 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 			try {
 				await getIpcApi().startServer( id );
 			} catch ( error ) {
-				const siteName = sitesRef.current.find( ( site ) => site.id === id )?.name || __( 'site' );
+				const siteName = sites.find( ( site ) => site.id === id )?.name || __( 'site' );
 				if ( error instanceof Error && error.message.includes( 'PROXY_ERROR_PORT_IN_USE' ) ) {
 					getIpcApi().showErrorMessageBox( {
 						title: sprintf( __( "Failed to initialize custom domains for '%s'" ), siteName ),
@@ -463,7 +459,7 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 
 			toggleLoadingServerForSite( id );
 		},
-		[ toggleLoadingServerForSite ]
+		[ toggleLoadingServerForSite, sites ]
 	);
 
 	const copySite = useCallback(

--- a/src/hooks/use-site-details.tsx
+++ b/src/hooks/use-site-details.tsx
@@ -402,9 +402,12 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 			try {
 				await getIpcApi().startServer( id );
 			} catch ( error ) {
+				const siteName = sites.find( ( site ) => site.id === id )?.name;
 				if ( error instanceof Error && error.message.includes( 'PROXY_ERROR_PORT_IN_USE' ) ) {
 					getIpcApi().showErrorMessageBox( {
-						title: __( 'Studio failed to initialize custom domains' ),
+						title: siteName
+							? sprintf( __( "Failed to initialize custom domains for '%s'" ), siteName )
+							: __( 'Studio failed to initialize custom domains' ),
 						message: __(
 							'Studio needs to use port 80 and 443 to enable custom domains and SSL, but one of these ports are already in use by another app. Close any local development apps and restart Studio.'
 						),
@@ -415,7 +418,9 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 					error.message.includes( 'PROXY_ERROR_START_FAILED' )
 				) {
 					getIpcApi().showErrorMessageBox( {
-						title: __( 'Studio failed to initialize custom domains' ),
+						title: siteName
+							? sprintf( __( "Failed to initialize custom domains for '%s'" ), siteName )
+							: __( 'Studio failed to initialize custom domains' ),
 						message: __(
 							'Please restart Studio and try again. If this problem persists, please contact support.'
 						),
@@ -426,7 +431,9 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 					error.message.includes( 'WASM_ERROR_NOT_ENOUGH_MEMORY' )
 				) {
 					getIpcApi().showErrorMessageBox( {
-						title: __( 'Not enough memory to start the site server' ),
+						title: siteName
+							? sprintf( __( "Not enough memory to start '%s'" ), siteName )
+							: __( 'Not enough memory to start the site server' ),
 						message: __(
 							'Please stop some of your running sites first. If this problem persists, try closing other apps that might be using memory and try again.'
 						),
@@ -435,7 +442,9 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 				} else if ( error instanceof Error && error.message.includes( 'ERROR_PORT_IN_USE' ) ) {
 					const port = error.message.match( /\d+/ );
 					getIpcApi().showErrorMessageBox( {
-						title: __( 'Failed to start the site server' ),
+						title: siteName
+							? sprintf( __( "Failed to start '%s'" ), siteName )
+							: __( 'Failed to start the site server' ),
 						message: __(
 							`The site server failed to start because the port is already in use. Please close any local development apps that may be using port ${ port } and try again.`
 						),
@@ -444,7 +453,9 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 				} else {
 					const errorToShow = simplifyErrorForDisplay( error );
 					getIpcApi().showErrorMessageBox( {
-						title: __( 'Failed to start the site server' ),
+						title: siteName
+							? sprintf( __( "Failed to start '%s'" ), siteName )
+							: __( 'Failed to start the site server' ),
 						message: __(
 							"Please verify your site's local path directory contains the standard WordPress installation files and try again. If this problem persists, please contact support."
 						),
@@ -457,7 +468,7 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 
 			toggleLoadingServerForSite( id );
 		},
-		[ toggleLoadingServerForSite ]
+		[ toggleLoadingServerForSite, sites ]
 	);
 
 	const copySite = useCallback(

--- a/src/hooks/use-site-details.tsx
+++ b/src/hooks/use-site-details.tsx
@@ -6,6 +6,7 @@ import {
 	useContext,
 	useEffect,
 	useMemo,
+	useRef,
 	useState,
 } from 'react';
 import { SITE_EVENTS, SiteEvent } from 'common/lib/site-events';
@@ -168,6 +169,10 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 	const { Provider } = siteDetailsContext;
 
 	const [ sites, setSites ] = useState< SiteDetails[] >( [] );
+	const sitesRef = useRef( sites );
+	useEffect( () => {
+		sitesRef.current = sites;
+	}, [ sites ] );
 	const [ loadingSites, setLoadingSites ] = useState< boolean >( true );
 	const [ siteCreationMessages, setSiteCreationMessages ] = useState< {
 		[ siteId: string ]: string;
@@ -402,7 +407,7 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 			try {
 				await getIpcApi().startServer( id );
 			} catch ( error ) {
-				const siteName = sites.find( ( site ) => site.id === id )?.name;
+				const siteName = sitesRef.current.find( ( site ) => site.id === id )?.name;
 				if ( error instanceof Error && error.message.includes( 'PROXY_ERROR_PORT_IN_USE' ) ) {
 					getIpcApi().showErrorMessageBox( {
 						title: siteName
@@ -468,7 +473,7 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 
 			toggleLoadingServerForSite( id );
 		},
-		[ toggleLoadingServerForSite, sites ]
+		[ toggleLoadingServerForSite ]
 	);
 
 	const copySite = useCallback(


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-1287

## Proposed Changes

- Adds the site name to error dialog title to all 5 errors when a site fails to start, helping users identify which site failed (especially useful during "Start all" or autostart sites on launch)
- Optimizes auto start sites to run it only on mounting the provider.
- Adds comprehensive unit tests for all error branches, with a shared `setupStartServerError` helper to reduce boilerplate
- Changes startSite parameter to receive the whole site to make easier to get the site name.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Automated
-  `npm test -- src/hooks/tests/use-site-details.test.tsx`

### Manual
- Create a site
- Add some code to make it fail at start, for example add these constants to wp-config.php
```
define( 'WP_ALLOW_MULTISITE', true );
define( 'MULTISITE', true );
```
- Start that specific site or start all the sites
- Observe that the alert appears, and confirm the site name is included in the title.

<img width="1012" height="712" alt="Screenshot 2026-02-11 at 20 02 28" src="https://github.com/user-attachments/assets/6308a7f2-0452-40f5-b988-1bf2d29f2697" />



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
