### PR TITLE
Remove pulse animation from import/export tab content

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -242,7 +242,6 @@
 			"resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.2.tgz",
 			"integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@octokit/auth-token": "^4.0.0",
 				"@octokit/graphql": "^7.1.0",

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -242,6 +242,7 @@
 			"resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.2.tgz",
 			"integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@octokit/auth-token": "^4.0.0",
 				"@octokit/graphql": "^7.1.0",

--- a/src/components/content-tab-import-export.tsx
+++ b/src/components/content-tab-import-export.tsx
@@ -250,8 +250,7 @@ const ImportSite = ( {
 		clearImportFileInput();
 	};
 
-	const startLoadingCursorClassName =
-		loadingServer[ selectedSite.id ] && 'cursor-wait';
+	const startLoadingCursorClassName = loadingServer[ selectedSite.id ] && 'cursor-wait';
 
 	const isImporting = currentProgress?.progress < 100 && ! isThisSiteSyncing;
 	const isImported = currentProgress?.progress === 100 && ! isDraggingOver && ! isThisSiteSyncing;

--- a/src/components/content-tab-import-export.tsx
+++ b/src/components/content-tab-import-export.tsx
@@ -251,7 +251,7 @@ const ImportSite = ( {
 	};
 
 	const startLoadingCursorClassName =
-		loadingServer[ selectedSite.id ] && 'animate-pulse duration-100 cursor-wait';
+		loadingServer[ selectedSite.id ] && 'cursor-wait';
 
 	const isImporting = currentProgress?.progress < 100 && ! isThisSiteSyncing;
 	const isImported = currentProgress?.progress === 100 && ! isDraggingOver && ! isThisSiteSyncing;

--- a/src/components/content-tab-import-export.tsx
+++ b/src/components/content-tab-import-export.tsx
@@ -299,6 +299,7 @@ const ImportSite = ( {
 										className={ cx( startLoadingCursorClassName ) }
 										variant="primary"
 										onClick={ openSite }
+										disabled={ !! loadingServer[ selectedSite.id ] }
 									>
 										{ __( 'Open site ↗' ) }
 									</Button>


### PR DESCRIPTION
## Related issues

- Fixes STU-1292

## Proposed Changes

On the Import/Export tab, the Import content (heading, description, and drop zone) was visually pulsing during site startup. This happened because the `animate-pulse` class was applied `ImportSite` component whenever the server was loading.

This PR removes the `animate-pulse duration-100` from the loading class, keeping only `cursor-wait` as a subtle, non-intrusive loading indicator.

## Testing Instructions

- Start the app with `npm start`
- Select a site and navigate to the Import/Export tab
- Start the site
- Check that the Import/Export section UI remains visually stable 
- Check that the cursor still changes to a wait cursor during server startup

Trunk:

https://github.com/user-attachments/assets/d317d1ab-e80b-4741-9e7c-3208ce0691dd

This branch:

https://github.com/user-attachments/assets/dd880a58-36be-4591-b403-75f2cbc264b4



## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors? (Tests pass, no errors)