### PR TITLE
Hide hidden files in DMG volume

### DIFF
--- a/forge.config.ts
+++ b/forge.config.ts
@@ -110,6 +110,10 @@ const config: ForgeConfig = {
 									}/Studio.app`,
 								},
 								{ x: 533, y: 354, type: 'link', path: '/Applications' },
+								{ x: 900, y: 900, type: 'position', path: '.background' },
+								{ x: 900, y: 900, type: 'position', path: '.DS_Store' },
+								{ x: 900, y: 900, type: 'position', path: '.Trashes' },
+								{ x: 900, y: 900, type: 'position', path: '.VolumeIcon.icns' },
 							],
 							additionalDMGOptions: {
 								window: {

--- a/scripts/make-dmg.mjs
+++ b/scripts/make-dmg.mjs
@@ -31,6 +31,10 @@ const dmgSpecs = {
 	contents: [
 		{ type: 'file', path: appPath, x: 533, y: 122 },
 		{ type: 'link', path: '/Applications', x: 533, y: 354 },
+		{ type: 'position', path: '.background', x: 900, y: 900 },
+		{ type: 'position', path: '.DS_Store', x: 900, y: 900 },
+		{ type: 'position', path: '.Trashes', x: 900, y: 900 },
+		{ type: 'position', path: '.VolumeIcon.icns', x: 900, y: 900 },
 	],
 };
 


### PR DESCRIPTION
## Related issues

- Fixes [STU-1294](https://linear.app/a8c/issue/STU-1294/studio-hidden-icons-are-too-visible-when-dmg-volume-mounts)

## Proposed Changes

- Position `.background`, and `.VolumeIcon.icns` outside the visible DMG window area so they don't appear when macOS is configured to show hidden files
- Uses appdmg's `type: "position"` to move hidden files to coordinates (900, 900), well outside the 710x502 window
- If the user scrolls the window the icons might be visible.

## Testing Instructions

- Build a DMG with `nvm use && npm run make:dmg-arm64` (or x64)
- Mount the DMG with hidden files enabled (Toggle it by pressing `cmd+shift+.`)
- Verify `.background` and `.VolumeIcon.icns` are no longer visible in the DMG window
- Verify the app icon and Applications link still display correctly
- Restore Finder settings (Toggle it by pressing `cmd+shift+.`)

| Before | After |
|--------|--------|
|  <img width="822" height="636" alt="Screenshot 2026-02-12 at 22 32 24" src="https://github.com/user-attachments/assets/d084a18b-059f-4566-a2be-af39edbeb516" /> | <img width="822" height="636" alt="Screenshot 2026-02-12 at 22 55 55" src="https://github.com/user-attachments/assets/cfba8c34-a5b3-42e9-a6f7-77c0e0903b23" /> |

If the user has hidden files disabled, the window won’t scroll. If the user has hidden files enabled, the hidden files will appear in a corner outside the default view, and you’ll need to scroll to see them. You can toggle between these two modes by pressing `cmd+shift+.`.


https://github.com/user-attachments/assets/b2d9abc6-893d-41f6-96a6-519d50e4f29b



## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors? (Tests pass, no errors)