### PR TITLE
Tweak `getPrettyPath` behavior

### DIFF
--- a/cli/lib/tests/utils.test.ts
+++ b/cli/lib/tests/utils.test.ts
@@ -1,4 +1,5 @@
-import { normalizeHostname } from 'cli/lib/utils';
+import os from 'node:os';
+import { getPrettyPath, normalizeHostname } from 'cli/lib/utils';
 
 describe( 'normalizeHostname', () => {
 	it( 'should normalize a basic hostname', () => {
@@ -27,5 +28,59 @@ describe( 'normalizeHostname', () => {
 
 	it( 'should handle multiple transformations', () => {
 		expect( normalizeHostname( '  HTTPS://EXAMPLE.COM/  ' ) ).toBe( 'example.com' );
+	} );
+} );
+
+describe( 'getPrettyPath', () => {
+	afterEach( () => {
+		vi.restoreAllMocks();
+	} );
+
+	it( 'should replace current working directory with a dot on Posix', () => {
+		vi.spyOn( process, 'cwd' ).mockReturnValue( '/Users/george/Studio' );
+		vi.spyOn( process, 'platform', 'get' ).mockReturnValue( 'darwin' );
+		vi.spyOn( os, 'homedir' ).mockReturnValue( '/Users/george' );
+
+		expect( getPrettyPath( '/Users/george/Studio/my-site/index.php' ) ).toBe(
+			'./my-site/index.php'
+		);
+	} );
+
+	it( 'should not replace current working directory with a dot if at root', () => {
+		vi.spyOn( process, 'cwd' ).mockReturnValue( '/' );
+		vi.spyOn( process, 'platform', 'get' ).mockReturnValue( 'darwin' );
+		vi.spyOn( os, 'homedir' ).mockReturnValue( '/Users/george' );
+
+		expect( getPrettyPath( '/Users/jenny/Studio/my-site/index.php' ) ).toBe(
+			'/Users/jenny/Studio/my-site/index.php'
+		);
+	} );
+
+	it( 'should replace current working directory with a dot on Windows', () => {
+		vi.spyOn( process, 'cwd' ).mockReturnValue( 'C:\\Users\\george\\Studio' );
+		vi.spyOn( process, 'platform', 'get' ).mockReturnValue( 'win32' );
+		vi.spyOn( os, 'homedir' ).mockReturnValue( 'C:\\Users\\george' );
+
+		expect( getPrettyPath( 'C:\\Users\\george\\Studio\\index.php' ) ).toBe( '.\\index.php' );
+	} );
+
+	it( 'should replace home directory prefix with tilde on Posix', () => {
+		vi.spyOn( process, 'cwd' ).mockReturnValue( '/etc' );
+		vi.spyOn( process, 'platform', 'get' ).mockReturnValue( 'darwin' );
+		vi.spyOn( os, 'homedir' ).mockReturnValue( '/Users/george' );
+
+		expect( getPrettyPath( '/Users/george/Studio/my-site/index.php' ) ).toBe(
+			'~/Studio/my-site/index.php'
+		);
+	} );
+
+	it( 'should not replace home directory prefix with tilde on Windows', () => {
+		vi.spyOn( process, 'cwd' ).mockReturnValue( 'C:\\Windows' );
+		vi.spyOn( process, 'platform', 'get' ).mockReturnValue( 'win32' );
+		vi.spyOn( os, 'homedir' ).mockReturnValue( 'C:\\Users\\george' );
+
+		expect( getPrettyPath( 'C:\\Users\\george\\Studio\\index.php' ) ).toBe(
+			'C:\\Users\\george\\Studio\\index.php'
+		);
 	} );
 } );

--- a/cli/lib/utils.ts
+++ b/cli/lib/utils.ts
@@ -1,5 +1,5 @@
-import { parse as parsePath } from 'node:path';
 import os from 'node:os';
+import { parse as parsePath } from 'node:path';
 import { SupportedPHPVersion, SupportedPHPVersions } from '@php-wasm/universal';
 import { __, sprintf } from '@wordpress/i18n';
 import { z } from 'zod';

--- a/cli/lib/utils.ts
+++ b/cli/lib/utils.ts
@@ -1,3 +1,4 @@
+import { parse as parsePath } from 'node:path';
 import os from 'node:os';
 import { SupportedPHPVersion, SupportedPHPVersions } from '@php-wasm/universal';
 import { __, sprintf } from '@wordpress/i18n';
@@ -28,9 +29,19 @@ export function getColumnWidths( widthFactors: number[] ) {
 }
 
 export function getPrettyPath( path: string ): string {
-	return process.platform === 'win32'
-		? path
-		: path.replace( process.cwd(), '.' ).replace( os.homedir(), '~' );
+	const cwd = process.cwd();
+	const root = parsePath( cwd ).root;
+
+	// If cwd is system root, don't replace it. Otherwise `/Users/foo/bar` becomes `.Users/foo/bar`
+	if ( cwd !== root ) {
+		path = path.replace( cwd, '.' );
+	}
+
+	if ( process.platform === 'win32' ) {
+		return path;
+	}
+
+	return path.replace( os.homedir(), '~' );
 }
 
 // `~` is a shell construct on Posix platforms. The shell expands it to the user's home directory


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-1270

## Proposed Changes

When the current working directory is the system root, `getPrettyPath` replaces the initial `/` with a dot. `/Users/fredrik/Studio/hello` becomes `.Users/fredrik/Studio/hello`. This PR fixes that by replacing only the cwd portion of the path when cwd isn't the path root. 

I also took the opportunity to change the behavior on Windows so that cwd is replaced with `.` there, too. `~` is the only Posix-exclusive construct here. 

Lastly, I added some tests for good measure. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Code review should honestly suffice

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
