### PR TITLE
Fix add-site layout inconsistency

### DIFF
--- a/src/components/no-studio-sites/index.tsx
+++ b/src/components/no-studio-sites/index.tsx
@@ -31,8 +31,8 @@ export function NoStudioSites() {
 	} );
 
 	return (
-		<main className="bg-white h-full flex items-center justify-center overflow-hidden z-10">
-			<div className="h-full w-full pt-14 pb-4 max-w-[786px]">
+		<main className="bg-white h-full flex overflow-hidden z-10">
+			<div className="h-full w-full pt-14 px-6 pb-6">
 				<AddSiteModalContent addSiteProps={ addSiteProps } />
 			</div>
 		</main>

--- a/src/modules/add-site/index.tsx
+++ b/src/modules/add-site/index.tsx
@@ -537,7 +537,7 @@ export function AddSiteModalContent( {
 
 	return (
 		<Navigator
-			className={ className ?? 'w-full h-full app-no-drag-region' }
+			className={ className ?? 'w-full h-full app-no-drag-region [align-items:stretch]' }
 			initialPath={ initialNavigatorPath }
 		>
 			<NavigationContent

--- a/src/modules/add-site/index.tsx
+++ b/src/modules/add-site/index.tsx
@@ -537,7 +537,7 @@ export function AddSiteModalContent( {
 
 	return (
 		<Navigator
-			className={ className ?? 'w-full h-full app-no-drag-region [align-items:stretch]' }
+			className={ className ?? 'w-full h-full app-no-drag-region' }
 			initialPath={ initialNavigatorPath }
 		>
 			<NavigationContent


### PR DESCRIPTION
### Related issues
- Resolves STU-1295

### Proposed Changes
- Ensure the styling for the NoStudioSites container is the same as for the container when there are existing sites already.

| Before | After |
|--------|--------|
| <img width="2482" height="1974" alt="CleanShot 2026-02-13 at 14 26 27@2x" src="https://github.com/user-attachments/assets/c744dc40-ccba-4828-afe0-fcc27411861b" /> | <img width="2482" height="1974" alt="CleanShot 2026-02-13 at 14 26 07@2x" src="https://github.com/user-attachments/assets/9960f71f-85be-4850-a796-d1e17f9d063a" /> | 

### Testing Instructions
1. Remove all sites.
3. Select the `Start from a Blueprint` option. Verify the blueprint grid cards are the same width as when opening via the "Add site" button with existing sites.

### Pre-merge Checklist
- [ ] Have you checked for TypeScript, React or other console errors?