### PR TITLE
Disable Copy and Delete in context menu when any site is being added

### DIFF
--- a/src/components/site-menu.tsx
+++ b/src/components/site-menu.tsx
@@ -129,7 +129,8 @@ function ButtonToRun( site: SiteDetails ) {
 	);
 }
 function SiteItem( { site }: { site: SiteDetails } ) {
-	const { selectedSite, setSelectedSiteId, loadingServer, isSiteDeleting } = useSiteDetails();
+	const { sites, selectedSite, setSelectedSiteId, loadingServer, isSiteDeleting } =
+		useSiteDetails();
 	const isSelected = site === selectedSite;
 	const { isSiteImporting, isSiteExporting } = useImportExport();
 	const { isSiteIdPulling, isSiteIdPushing } = useSyncSites();
@@ -160,6 +161,7 @@ function SiteItem( { site }: { site: SiteDetails } ) {
 		const ipcApi = getIpcApi();
 		const isLoading = loadingServer[ site.id ] || false;
 		const isAddingSite = site.isAddingSite || false;
+		const isAnySiteAdding = sites.some( ( s ) => s.isAddingSite );
 		const finderLabel = isWindows() ? __( 'File Explorer' ) : __( 'Finder' );
 		const editorLabel =
 			editor && supportedEditorConfig[ editor ] ? supportedEditorConfig[ editor ].label : null;
@@ -170,6 +172,7 @@ function SiteItem( { site }: { site: SiteDetails } ) {
 			isRunning: site.running,
 			isLoading,
 			isAddingSite,
+			isAnySiteAdding,
 			isSyncing,
 			finderLabel,
 			editorLabel,

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -1190,6 +1190,7 @@ export function showSiteContextMenu(
 		isRunning: boolean;
 		isLoading: boolean;
 		isAddingSite: boolean;
+		isAnySiteAdding: boolean;
 		isSyncing: boolean;
 		finderLabel: string;
 		editorLabel: string | null;
@@ -1201,6 +1202,7 @@ export function showSiteContextMenu(
 		isRunning,
 		isLoading,
 		isAddingSite,
+		isAnySiteAdding,
 		isSyncing,
 		finderLabel,
 		editorLabel,
@@ -1369,7 +1371,7 @@ export function showSiteContextMenu(
 	menu.append(
 		new MenuItem( {
 			label: __( 'Copy site…' ),
-			enabled: ! isLoading && ! isAddingSite,
+			enabled: ! isLoading && ! isAnySiteAdding,
 			click: () => {
 				sendIpcEventToRendererWithWindow(
 					BrowserWindow.fromWebContents( event.sender ),
@@ -1386,7 +1388,7 @@ export function showSiteContextMenu(
 	menu.append(
 		new MenuItem( {
 			label: __( 'Delete site…' ),
-			enabled: ! isLoading && ! isAddingSite && ! isSyncing,
+			enabled: ! isLoading && ! isAnySiteAdding && ! isSyncing,
 			click: () => {
 				sendIpcEventToRendererWithWindow(
 					BrowserWindow.fromWebContents( event.sender ),

--- a/src/tests/show-site-context-menu.test.ts
+++ b/src/tests/show-site-context-menu.test.ts
@@ -41,6 +41,7 @@ describe( 'showSiteContextMenu', () => {
 
 	const baseContext = {
 		siteId: 'test-site-id',
+		isAnySiteAdding: false,
 		finderLabel: 'Finder',
 		editorLabel: 'VS Code',
 		terminalLabel: 'Terminal',
@@ -91,6 +92,7 @@ describe( 'showSiteContextMenu', () => {
 				isRunning: true,
 				isLoading: false,
 				isAddingSite: true,
+				isAnySiteAdding: true,
 				isSyncing: false,
 			} );
 
@@ -117,11 +119,45 @@ describe( 'showSiteContextMenu', () => {
 				isRunning: false,
 				isLoading: false,
 				isAddingSite: true,
+				isAnySiteAdding: true,
 				isSyncing: false,
 			} );
 
 			const startItem = menuItems.find( ( item ) => item.label === 'Start' );
 			expect( startItem?.enabled ).toBe( false );
+		} );
+	} );
+
+	describe( 'when another site is being added', () => {
+		it( 'should disable Copy and Delete but keep other items enabled', () => {
+			showSiteContextMenu( mockIpcMainInvokeEvent, {
+				...baseContext,
+				isRunning: true,
+				isLoading: false,
+				isAddingSite: false,
+				isAnySiteAdding: true,
+				isSyncing: false,
+			} );
+
+			const stopItem = menuItems.find( ( item ) => item.label === 'Stop' );
+			const openSiteItem = menuItems.find( ( item ) => item.label === 'Open site' );
+			const wpAdminItem = menuItems.find( ( item ) => item.label === 'WP admin' );
+			const finderItem = menuItems.find( ( item ) => item.label === 'Open in Finder' );
+			const editorItem = menuItems.find( ( item ) => item.label === 'Open in VS Code' );
+			const terminalItem = menuItems.find( ( item ) => item.label === 'Open in Terminal' );
+			const editItem = menuItems.find( ( item ) => item.label === 'Edit site…' );
+			const copyItem = menuItems.find( ( item ) => item.label === 'Copy site…' );
+			const deleteItem = menuItems.find( ( item ) => item.label === 'Delete site…' );
+
+			expect( stopItem?.enabled ).toBe( true );
+			expect( openSiteItem?.enabled ).toBe( true );
+			expect( wpAdminItem?.enabled ).toBe( true );
+			expect( finderItem?.enabled ).toBe( true );
+			expect( editorItem?.enabled ).toBe( true );
+			expect( terminalItem?.enabled ).toBe( true );
+			expect( editItem?.enabled ).toBe( true );
+			expect( copyItem?.enabled ).toBe( false );
+			expect( deleteItem?.enabled ).toBe( false );
 		} );
 	} );
 


### PR DESCRIPTION
## Related issues

- Fixes STU-1298

## Proposed Changes

The Settings tab disables "Copy site" and "Delete site" for **all** sites when any site is being created (`sites.some(site => site.isAddingSite)`), but the right-click context menu only checked `site.isAddingSite` for the individual site. This created an inconsistency where right-clicking Site B while Site A was being created showed Copy/Delete as enabled.

- Added `isAnySiteAdding` (computed from `sites.some(s => s.isAddingSite)`) in the renderer and pass it to the main process via `showSiteContextMenu()`
- Use `isAnySiteAdding` instead of `isAddingSite` for the "Copy site" and "Delete site" enabled conditions
- Per-site `isAddingSite` continues to be used for all other menu items (Start, Stop, Open, etc.)

## Testing Instructions

1. Start the app with `npm start`
2. Create a new site
3. While the site is being created, right-click another existing site in the left sidebar
4. Verify "Copy site…" and "Delete site…" are greyed out and disabled
5. Verify other menu items (Stop, Open site, WP admin, etc.) remain enabled
6. Once site creation completes, verify all menu items return to normal

https://github.com/user-attachments/assets/4b0fd42a-d7bc-43b6-bce4-3d2dfe16daae




## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors? (Tests pass, no errors)