### PR TITLE
Fix Preview site and Push size validation to exclude archived-out directories

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@ WordPress Studio - Electron desktop app for managing local WordPress sites. Buil
 **Dev/Build**: `npm start` | `npm run cli:build` | `node dist/cli/main.js`
 **Test**: `npm test [-- path/to/test.test.ts]` | `npm run e2e`
 **Quality**: `npm run lint` | `npx prettier --write <files>` (format ONLY modified files)
+**IMPORTANT - Post-Change Verification**: After applying code changes, always run the linter (`npm run lint`), format modified files (`npx prettier --write <files>`), and run relevant tests (`npm test [-- path/to/test]`) before considering the work complete.
 **Package**: `npm run make` (builds installers for current platform)
 
 **IMPORTANT - Hot Reload**: Renderer auto-reloads, Main process needs restart (or `rs` in terminal). Changes to Main process IPC handlers require full restart.

--- a/cli/lib/archive.ts
+++ b/cli/lib/archive.ts
@@ -2,6 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import { __ } from '@wordpress/i18n';
 import archiver, { EntryData } from 'archiver';
+import { isExcludedFromArchive } from 'common/lib/fs-utils';
 import { LoggerError } from 'cli/logger';
 
 const ZIP_COMPRESSION_LEVEL = 9;
@@ -29,7 +30,7 @@ export async function archiveSiteContent(
 			path.join( siteFolder, 'wp-content' ),
 			'wp-content',
 			( entry: EntryData ) => {
-				if ( entry.name.includes( '.git' ) || entry.name.includes( 'node_modules' ) ) {
+				if ( isExcludedFromArchive( entry.name ) ) {
 					return false;
 				}
 				return entry;

--- a/cli/lib/tests/validation.test.ts
+++ b/cli/lib/tests/validation.test.ts
@@ -1,13 +1,13 @@
 import fs from 'fs';
 import path from 'path';
-import { calculateDirectorySize, isWordPressDirectory } from 'common/lib/fs-utils';
+import { calculateDirectorySizeForArchive, isWordPressDirectory } from 'common/lib/fs-utils';
 import { vi } from 'vitest';
 import { validateSiteSize } from 'cli/lib/validation';
 import { LoggerError } from 'cli/logger';
 vi.mock( 'fs' );
 vi.mock( 'path' );
 vi.mock( 'common/lib/fs-utils', () => ( {
-	calculateDirectorySize: vi.fn(),
+	calculateDirectorySizeForArchive: vi.fn(),
 	isWordPressDirectory: vi.fn(),
 } ) );
 
@@ -19,25 +19,29 @@ describe( 'Validation Module', () => {
 		vi.mocked( path.join ).mockImplementation( ( ...args ) => args.join( '/' ) );
 		vi.mocked( fs.existsSync ).mockReturnValue( true );
 		vi.mocked( isWordPressDirectory ).mockReturnValue( true );
-		vi.mocked( calculateDirectorySize ).mockResolvedValue( 1024 * 1024 * 1024 ); // 1GB
+		vi.mocked( calculateDirectorySizeForArchive ).mockResolvedValue( 1024 * 1024 * 1024 ); // 1GB
 	} );
 
 	describe( 'validateSiteSize', () => {
 		it( 'should throw an error if the site exceeds size limit', async () => {
-			vi.mocked( calculateDirectorySize ).mockResolvedValue( 3 * 1024 * 1024 * 1024 ); // 3GB
+			vi.mocked( calculateDirectorySizeForArchive ).mockResolvedValue( 3 * 1024 * 1024 * 1024 ); // 3GB
 
 			await expect( validateSiteSize( mockSiteFolder ) ).rejects.toThrow( LoggerError );
 			await expect( validateSiteSize( mockSiteFolder ) ).rejects.toThrow(
 				'Your site exceeds the 2 GB size limit. Please, consider removing unnecessary media files, plugins, or themes from wp-content.'
 			);
-			expect( calculateDirectorySize ).toHaveBeenCalledWith( mockSiteFolder + '/wp-content' );
+			expect( calculateDirectorySizeForArchive ).toHaveBeenCalledWith(
+				mockSiteFolder + '/wp-content'
+			);
 		} );
 
 		it( 'should return true for a valid WordPress site within size limit', async () => {
-			vi.mocked( calculateDirectorySize ).mockResolvedValue( 1024 * 1024 * 1024 ); // 1GB
+			vi.mocked( calculateDirectorySizeForArchive ).mockResolvedValue( 1024 * 1024 * 1024 ); // 1GB
 
 			expect( await validateSiteSize( mockSiteFolder ) ).toBe( true );
-			expect( calculateDirectorySize ).toHaveBeenCalledWith( mockSiteFolder + '/wp-content' );
+			expect( calculateDirectorySizeForArchive ).toHaveBeenCalledWith(
+				mockSiteFolder + '/wp-content'
+			);
 		} );
 	} );
 } );

--- a/cli/lib/validation.ts
+++ b/cli/lib/validation.ts
@@ -1,12 +1,12 @@
 import path from 'path';
 import { __, sprintf } from '@wordpress/i18n';
 import { DEMO_SITE_SIZE_LIMIT_BYTES, DEMO_SITE_SIZE_LIMIT_GB } from 'common/constants';
-import { calculateDirectorySize } from 'common/lib/fs-utils';
+import { calculateDirectorySizeForArchive } from 'common/lib/fs-utils';
 import { LoggerError } from 'cli/logger';
 
 export async function validateSiteSize( siteFolder: string ): Promise< true > {
 	const wpContentPath = path.join( siteFolder, 'wp-content' );
-	const wpContentSize = await calculateDirectorySize( wpContentPath );
+	const wpContentSize = await calculateDirectorySizeForArchive( wpContentPath );
 
 	if ( wpContentSize > DEMO_SITE_SIZE_LIMIT_BYTES ) {
 		throw new LoggerError(

--- a/common/lib/fs-utils.ts
+++ b/common/lib/fs-utils.ts
@@ -2,13 +2,20 @@ import fs, { promises as fsPromises } from 'fs';
 import path from 'path';
 import { isErrnoException } from './is-errno-exception';
 
+const ARCHIVE_EXCLUDED_DIRECTORIES = [ '.git', 'node_modules' ];
+
+export function isExcludedFromArchive( name: string ): boolean {
+	return ARCHIVE_EXCLUDED_DIRECTORIES.some( ( excluded ) => name.includes( excluded ) );
+}
+
 /**
  * Calculates the total size of a directory by recursively traversing its contents.
+ * Excludes directories that are not included in archives (e.g., .git, node_modules).
  *
  * @param directoryPath - The path to the directory to calculate the size of
  * @returns A promise that resolves to the total size in bytes
  */
-export function calculateDirectorySize( directoryPath: string ): Promise< number > {
+export function calculateDirectorySizeForArchive( directoryPath: string ): Promise< number > {
 	return new Promise( ( resolve, reject ) => {
 		let totalSize = 0;
 
@@ -21,6 +28,9 @@ export function calculateDirectorySize( directoryPath: string ): Promise< number
 						const filePath = path.join( dirPath, file.name );
 						try {
 							if ( file.isDirectory() ) {
+								if ( isExcludedFromArchive( file.name ) ) {
+									return;
+								}
 								await calculateSize( filePath );
 							} else {
 								const stats = await fsPromises.stat( filePath );

--- a/src/ipc-handlers.ts
+++ b/src/ipc-handlers.ts
@@ -22,7 +22,7 @@ import { validateBlueprintData } from 'common/lib/blueprint-validation';
 import { bumpStat } from 'common/lib/bump-stat';
 import { parseCliError, errorMessageContains } from 'common/lib/cli-error';
 import {
-	calculateDirectorySize,
+	calculateDirectorySizeForArchive,
 	isWordPressDirectory,
 	arePathsEqual,
 	isEmptyDir,
@@ -1145,7 +1145,7 @@ export function getDirectorySize( _event: IpcMainInvokeEvent, siteId: string, su
 	if ( ! site ) {
 		throw new Error( 'Site not found.' );
 	}
-	return calculateDirectorySize( nodePath.join( site.details.path, ...subdir ) );
+	return calculateDirectorySizeForArchive( nodePath.join( site.details.path, ...subdir ) );
 }
 
 export function getFileSize( _event: IpcMainInvokeEvent, siteId: string, filePath: string[] ) {


### PR DESCRIPTION
## Related issues

- Related to STU-1303

## Proposed Changes

- Extract archive exclusion logic (`.git`, `node_modules`) into a shared `isExcludedFromArchive` function in `common/lib/fs-utils.ts`
- Apply exclusions in `calculateDirectorySizeForArchive` (renamed from `calculateDirectorySize`) so size validation matches what actually gets archived
- Use the shared function in `cli/lib/archive.ts` instead of inline string checks
- Add post-change verification instructions to `AGENTS.md`

## Testing Instructions

- Create a local WordPress site with a plugin that contains a large `node_modules` directory inside `wp-content/plugins/`. For example, you can clone the [Gutenberg repo](https://github.com/WordPress/gutenberg) into` wp-content/plugins` and run `nvm use && npm install` there
- Ensure the total `wp-content` size exceeds 2GB but the size without `node_modules`/`.git` is under 2GB
- Attempt to create a preview site — it should no longer be rejected by the size validation
- Connect the site to a WordPress.com site
- Push the local site, and check the size reported is the expected one (without `node_modules`)
- Check that if the site contains large files, the validation still applies as expected

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?