### PR TITLE
Add default Blueprint description from steps

### DIFF
--- a/common/lib/blueprint-settings.ts
+++ b/common/lib/blueprint-settings.ts
@@ -1,3 +1,4 @@
+import { __, _n, sprintf } from '@wordpress/i18n';
 import type { Blueprint } from '@wp-playground/blueprints';
 
 type BlueprintSiteSettings = Partial<
@@ -107,4 +108,168 @@ export function updateBlueprintWithFormValues(
 	}
 
 	return updated;
+}
+
+/**
+ * Joins a list of items with commas and "and" for the last item.
+ * e.g. ["a", "b", "c"] → "a, b, and c"
+ */
+function joinWithAnd( items: string[] ): string {
+	if ( items.length === 0 ) {
+		return '';
+	}
+	if ( items.length === 1 ) {
+		return items[ 0 ];
+	}
+	if ( items.length === 2 ) {
+		return sprintf(
+			/* translators: Used to join two items, e.g. "3 plugins and 2 themes". %1$s is the first item, %2$s is the second item. */
+			__( '%1$s and %2$s' ),
+			items[ 0 ],
+			items[ 1 ]
+		);
+	}
+	const allButLast = items.slice( 0, -1 ).join( ', ' );
+	return sprintf(
+		/* translators: Used to join a comma-separated list with "and" before the last item. %1$s is the comma-separated items, %2$s is the last item. */
+		__( '%1$s, and %2$s' ),
+		allButLast,
+		items[ items.length - 1 ]
+	);
+}
+
+/**
+ * Generates a default description from a blueprint's steps array.
+ * Returns a human-readable summary like "Installs 3 plugins and 2 themes. Runs 1 block of PHP code."
+ */
+export function generateDefaultBlueprintDescription( blueprintJson: Blueprint ): string {
+	if ( ! blueprintJson.steps || ! Array.isArray( blueprintJson.steps ) ) {
+		return '';
+	}
+
+	const counts = {
+		plugins: 0,
+		themes: 0,
+		contentImports: 0,
+		phpCode: 0,
+		sqlQueries: 0,
+		wpCliCommands: 0,
+		siteConfig: 0,
+	};
+
+	for ( const step of blueprintJson.steps ) {
+		const stepName = ( step as { step?: string } ).step;
+		switch ( stepName ) {
+			case 'installPlugin':
+				counts.plugins++;
+				break;
+			case 'installTheme':
+				counts.themes++;
+				break;
+			case 'importWxr':
+			case 'importThemeStarterContent':
+			case 'importWordPressFiles':
+				counts.contentImports++;
+				break;
+			case 'runPHP':
+			case 'runPHPWithOptions':
+				counts.phpCode++;
+				break;
+			case 'runSql':
+				counts.sqlQueries++;
+				break;
+			case 'wp-cli':
+				counts.wpCliCommands++;
+				break;
+			case 'setSiteOptions':
+			case 'setSiteLanguage':
+			case 'defineWpConfigConsts':
+			case 'updateUserMeta':
+				counts.siteConfig++;
+				break;
+		}
+	}
+
+	const sentences: string[] = [];
+
+	// "Installs" sentence — plugins and/or themes
+	const installParts: string[] = [];
+	if ( counts.plugins > 0 ) {
+		installParts.push(
+			sprintf(
+				/* translators: %d is the number of plugins to install. */
+				_n( '%d plugin', '%d plugins', counts.plugins ),
+				counts.plugins
+			)
+		);
+	}
+	if ( counts.themes > 0 ) {
+		installParts.push(
+			sprintf(
+				/* translators: %d is the number of themes to install. */
+				_n( '%d theme', '%d themes', counts.themes ),
+				counts.themes
+			)
+		);
+	}
+	if ( installParts.length > 0 ) {
+		sentences.push(
+			sprintf(
+				/* translators: %s is a list of items to install, e.g. "3 plugins and 2 themes". */
+				__( 'Installs %s.' ),
+				joinWithAnd( installParts )
+			)
+		);
+	}
+
+	// "Imports content." sentence
+	if ( counts.contentImports > 0 ) {
+		sentences.push( __( 'Imports content.' ) );
+	}
+
+	// "Runs" sentence — PHP blocks, SQL queries, and/or WP-CLI commands
+	const runParts: string[] = [];
+	if ( counts.phpCode > 0 ) {
+		runParts.push(
+			sprintf(
+				/* translators: %d is the number of PHP code blocks to run. */
+				_n( '%d block of PHP code', '%d blocks of PHP code', counts.phpCode ),
+				counts.phpCode
+			)
+		);
+	}
+	if ( counts.sqlQueries > 0 ) {
+		runParts.push(
+			sprintf(
+				/* translators: %d is the number of SQL queries to run. */
+				_n( '%d SQL query', '%d SQL queries', counts.sqlQueries ),
+				counts.sqlQueries
+			)
+		);
+	}
+	if ( counts.wpCliCommands > 0 ) {
+		runParts.push(
+			sprintf(
+				/* translators: %d is the number of WP-CLI commands to run. */
+				_n( '%d WP-CLI command', '%d WP-CLI commands', counts.wpCliCommands ),
+				counts.wpCliCommands
+			)
+		);
+	}
+	if ( runParts.length > 0 ) {
+		sentences.push(
+			sprintf(
+				/* translators: %s is a list of items to run, e.g. "2 blocks of PHP code and 1 SQL query". */
+				__( 'Runs %s.' ),
+				joinWithAnd( runParts )
+			)
+		);
+	}
+
+	// "Applies site configuration." sentence
+	if ( counts.siteConfig > 0 ) {
+		sentences.push( __( 'Applies site configuration.' ) );
+	}
+
+	return sentences.join( ' ' );
 }

--- a/common/lib/tests/blueprint-settings.test.ts
+++ b/common/lib/tests/blueprint-settings.test.ts
@@ -1,5 +1,6 @@
 import {
 	extractFormValuesFromBlueprint,
+	generateDefaultBlueprintDescription,
 	updateBlueprintWithFormValues,
 } from '../blueprint-settings';
 
@@ -420,6 +421,114 @@ describe( 'blueprint-settings', () => {
 				step: 'setSiteOptions',
 				options: { blogname: 'New Name', blogdescription: 'A description' },
 			} );
+		} );
+	} );
+
+	describe( 'generateDefaultBlueprintDescription', () => {
+		it( 'should return empty string for empty blueprint', () => {
+			expect( generateDefaultBlueprintDescription( {} ) ).toBe( '' );
+		} );
+
+		it( 'should return empty string for missing steps', () => {
+			expect( generateDefaultBlueprintDescription( { meta: { title: 'Test' } } ) ).toBe( '' );
+		} );
+
+		it( 'should return empty string for non-array steps', () => {
+			const blueprint = { steps: 'not-an-array' };
+			expect(
+				generateDefaultBlueprintDescription(
+					blueprint as unknown as Parameters< typeof generateDefaultBlueprintDescription >[ 0 ]
+				)
+			).toBe( '' );
+		} );
+
+		it( 'should return empty string for steps with no recognized actions', () => {
+			expect( generateDefaultBlueprintDescription( { steps: [ { step: 'login' } ] } ) ).toBe( '' );
+		} );
+
+		it( 'should describe a single plugin', () => {
+			const blueprint = { steps: [ { step: 'installPlugin' } ] };
+			expect( generateDefaultBlueprintDescription( blueprint ) ).toBe( 'Installs 1 plugin.' );
+		} );
+
+		it( 'should describe multiple plugins', () => {
+			const blueprint = {
+				steps: [ { step: 'installPlugin' }, { step: 'installPlugin' }, { step: 'installPlugin' } ],
+			};
+			expect( generateDefaultBlueprintDescription( blueprint ) ).toBe( 'Installs 3 plugins.' );
+		} );
+
+		it( 'should describe plugins and themes combined', () => {
+			const blueprint = {
+				steps: [ { step: 'installPlugin' }, { step: 'installPlugin' }, { step: 'installTheme' } ],
+			};
+			expect( generateDefaultBlueprintDescription( blueprint ) ).toBe(
+				'Installs 2 plugins and 1 theme.'
+			);
+		} );
+
+		it( 'should describe content import steps', () => {
+			const blueprint = { steps: [ { step: 'importWxr' } ] };
+			expect( generateDefaultBlueprintDescription( blueprint ) ).toBe( 'Imports content.' );
+		} );
+
+		it( 'should describe a single PHP code block', () => {
+			const blueprint = { steps: [ { step: 'runPHP' } ] };
+			expect( generateDefaultBlueprintDescription( blueprint ) ).toBe(
+				'Runs 1 block of PHP code.'
+			);
+		} );
+
+		it( 'should describe PHP code, SQL queries, and WP-CLI commands combined', () => {
+			const blueprint = {
+				steps: [ { step: 'runPHP' }, { step: 'runSql' }, { step: 'wp-cli' } ],
+			};
+			expect( generateDefaultBlueprintDescription( blueprint ) ).toBe(
+				'Runs 1 block of PHP code, 1 SQL query, and 1 WP-CLI command.'
+			);
+		} );
+
+		it( 'should describe site configuration steps', () => {
+			const blueprint = {
+				steps: [ { step: 'setSiteOptions' }, { step: 'defineWpConfigConsts' } ],
+			};
+			expect( generateDefaultBlueprintDescription( blueprint ) ).toBe(
+				'Applies site configuration.'
+			);
+		} );
+
+		it( 'should describe a complex blueprint with all categories', () => {
+			const blueprint = {
+				steps: [
+					{ step: 'installPlugin' },
+					{ step: 'installPlugin' },
+					{ step: 'installPlugin' },
+					{ step: 'installTheme' },
+					{ step: 'installTheme' },
+					{ step: 'importWxr' },
+					{ step: 'runPHP' },
+					{ step: 'runSql' },
+					{ step: 'runSql' },
+					{ step: 'wp-cli' },
+					{ step: 'setSiteOptions' },
+					{ step: 'defineWpConfigConsts' },
+				],
+			};
+			expect( generateDefaultBlueprintDescription( blueprint ) ).toBe(
+				'Installs 3 plugins and 2 themes. Imports content. Runs 1 block of PHP code, 2 SQL queries, and 1 WP-CLI command. Applies site configuration.'
+			);
+		} );
+
+		it( 'should ignore unrecognized steps', () => {
+			const blueprint = {
+				steps: [
+					{ step: 'login' },
+					{ step: 'installPlugin' },
+					{ step: 'enableMultisite' },
+					{ step: 'defineSiteUrl' },
+				],
+			};
+			expect( generateDefaultBlueprintDescription( blueprint ) ).toBe( 'Installs 1 plugin.' );
 		} );
 	} );
 } );

--- a/src/modules/add-site/components/blueprints.tsx
+++ b/src/modules/add-site/components/blueprints.tsx
@@ -12,6 +12,7 @@ import { sprintf } from '@wordpress/i18n';
 import { Icon, external, upload } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { useCallback, useRef, useState, useMemo } from 'react';
+import { generateDefaultBlueprintDescription } from 'common/lib/blueprint-settings';
 import { BlueprintValidationWarning } from 'common/lib/blueprint-validation';
 import StudioButton from 'src/components/button';
 import { LearnMoreLink } from 'src/components/learn-more';
@@ -219,7 +220,8 @@ export function AddSiteBlueprintSelector( {
 				const fileBlueprint: Blueprint = {
 					slug: `file:${ file.name }`, // Use filename as part of the slug
 					title: blueprintJson.meta?.title || file.name.replace( '.json', '' ),
-					excerpt: blueprintJson.meta?.description || __( 'Blueprint loaded from file' ),
+					excerpt:
+						blueprintJson.meta?.description || generateDefaultBlueprintDescription( blueprintJson ),
 					image: '', // No image for file-based blueprints
 					playground_url: '', // No playground URL for file-based blueprints
 					blueprint: blueprintJson, // The actual blueprint JSON

--- a/src/modules/add-site/hooks/use-blueprint-deeplink.ts
+++ b/src/modules/add-site/hooks/use-blueprint-deeplink.ts
@@ -1,6 +1,9 @@
 import { useI18n } from '@wordpress/react-i18n';
 import { useCallback } from 'react';
-import { extractFormValuesFromBlueprint } from 'common/lib/blueprint-settings';
+import {
+	extractFormValuesFromBlueprint,
+	generateDefaultBlueprintDescription,
+} from 'common/lib/blueprint-settings';
 import {
 	BlueprintValidationWarning,
 	BlueprintPreferredVersions,
@@ -68,7 +71,8 @@ export function useBlueprintDeeplink( options: UseBlueprintDeeplinkOptions ): vo
 					const fileBlueprint: Blueprint = {
 						slug: `file:${ fileName }`,
 						title: blueprintMeta?.title || '',
-						excerpt: blueprintMeta?.description || '',
+						excerpt:
+							blueprintMeta?.description || generateDefaultBlueprintDescription( blueprintJson ),
 						image: '',
 						playground_url: '',
 						blueprint: blueprintJson,


### PR DESCRIPTION
## Related issues

- Resolves STU-1224

## Proposed Changes

The proposed changes add default Blueprint description when it is not present in the Blueprint JSON.

| Before | After |
|--------|--------|
| <img width="2560" height="1802" alt="CleanShot 2026-02-18 at 16 32 31@2x" src="https://github.com/user-attachments/assets/8ff6b1ca-bba8-41ac-840f-4cb596a3d6f5" /> | <img width="2560" height="1802" alt="CleanShot 2026-02-18 at 16 33 14@2x" src="https://github.com/user-attachments/assets/559f411c-b495-4d88-b90b-a0eb6c7ab163" /> | 

- Add `generateDefaultBlueprintDescription()` function in `common/lib/blueprint-settings.ts` that auto-generates a human-readable description from a blueprint's `steps` array (e.g. "Installs 3 plugins and 2 themes. Runs 1 block of PHP code.")
- Use the generated description as a fallback in the file-upload flow (`blueprints.tsx`) when `meta.description` is missing
- Use the generated description as a fallback in the deeplink flow (`use-blueprint-deeplink.ts`) when `meta.description` is missing
- Add comprehensive tests covering all step categories, singular/plural forms, combined groups, and edge cases

## Testing Instructions

1. Start the app with `npm start`
2. Go to Add Site → Start from a Blueprint
3. Upload a Blueprint JSON file that has **no** `meta.description` field but has steps (e.g. `installPlugin`, `installTheme`, `runPHP`, etc.). You can use the following example if you prefer: 3a723-pb.
4. Verify the Blueprint details step shows an auto-generated description like "Installs 2 plugins and 1 theme." instead of "Blueprint loaded from file"
5. Test with a Blueprint that **has** a `meta.description` — verify the custom description still takes priority
6. Test the deeplink flow (open a `studio://blueprint?blueprint=...` link) with a Blueprint without `meta.description` and verify the generated description appears. You can use the following example link if you wish:

```
wp-studio://add-site?blueprint=ewoJIm1ldGEiOiB7CgkJInRpdGxlIjogIktpdGNoZW4gU2luayBCbHVlcHJpbnQiLAoJCSJhdXRob3IiOiAidGVzdCIKCX0sCgkibGFuZGluZ1BhZ2UiOiAiL3dwLWFkbWluLyIsCgkicHJlZmVycmVkVmVyc2lvbnMiOiB7CgkJInBocCI6ICI4LjIiLAoJCSJ3cCI6ICJsYXRlc3QiCgl9LAoJInN0ZXBzIjogWwoJCXsKCQkJInN0ZXAiOiAiaW5zdGFsbFBsdWdpbiIsCgkJCSJwbHVnaW5EYXRhIjogewoJCQkJInJlc291cmNlIjogIndvcmRwcmVzcy5vcmcvcGx1Z2lucyIsCgkJCQkic2x1ZyI6ICJndXRlbmJlcmciCgkJCX0KCQl9LAoJCXsKCQkJInN0ZXAiOiAiaW5zdGFsbFBsdWdpbiIsCgkJCSJwbHVnaW5EYXRhIjogewoJCQkJInJlc291cmNlIjogIndvcmRwcmVzcy5vcmcvcGx1Z2lucyIsCgkJCQkic2x1ZyI6ICJjbGFzc2ljLWVkaXRvciIKCQkJfQoJCX0sCgkJewoJCQkic3RlcCI6ICJpbnN0YWxsVGhlbWUiLAoJCQkidGhlbWVEYXRhIjogewoJCQkJInJlc291cmNlIjogIndvcmRwcmVzcy5vcmcvdGhlbWVzIiwKCQkJCSJzbHVnIjogInR3ZW50eXNldmVudGVlbiIKCQkJfQoJCX0sCgkJewoJCQkic3RlcCI6ICJpbXBvcnRUaGVtZVN0YXJ0ZXJDb250ZW50IgoJCX0sCgkJewoJCQkic3RlcCI6ICJydW5QSFAiLAoJCQkiY29kZSI6ICI8P3BocCBmaWxlX3B1dF9jb250ZW50cygnL3dvcmRwcmVzcy93cC1jb250ZW50L2hlbGxvLnR4dCcsICdIZWxsbyBmcm9tIGJsdWVwcmludCcpOyA/PiIKCQl9LAoJCXsKCQkJInN0ZXAiOiAicnVuU3FsIiwKCQkJInNxbCI6IHsKCQkJCSJyZXNvdXJjZSI6ICJsaXRlcmFsIiwKCQkJCSJuYW1lIjogInNldHVwLnNxbCIsCgkJCQkiY29udGVudHMiOiAiVVBEQVRFIHdwX29wdGlvbnMgU0VUIG9wdGlvbl92YWx1ZSA9ICdLaXRjaGVuIFNpbmsgU2l0ZScgV0hFUkUgb3B0aW9uX25hbWUgPSAnYmxvZ2Rlc2NyaXB0aW9uJzsiCgkJCX0KCQl9LAoJCXsKCQkJInN0ZXAiOiAicnVuU3FsIiwKCQkJInNxbCI6IHsKCQkJCSJyZXNvdXJjZSI6ICJsaXRlcmFsIiwKCQkJCSJuYW1lIjogImNvbmZpZy5zcWwiLAoJCQkJImNvbnRlbnRzIjogIlVQREFURSB3cF9vcHRpb25zIFNFVCBvcHRpb25fdmFsdWUgPSAnJyBXSEVSRSBvcHRpb25fbmFtZSA9ICd0aHJlYWRfY29tbWVudHMnOyIKCQkJfQoJCX0sCgkJewoJCQkic3RlcCI6ICJzZXRTaXRlT3B0aW9ucyIsCgkJCSJvcHRpb25zIjogewoJCQkJImJsb2dkZXNjcmlwdGlvbiI6ICJBIGtpdGNoZW4gc2luayB0ZXN0IHNpdGUiCgkJCX0KCQl9LAoJCXsKCQkJInN0ZXAiOiAiZGVmaW5lV3BDb25maWdDb25zdHMiLAoJCQkiY29uc3RzIjogewoJCQkJIk1ZX0NVU1RPTV9DT05TVCI6ICJoZWxsby1mcm9tLWJsdWVwcmludCIKCQkJfQoJCX0KCV0KfQo=
```

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?