### PR TITLE
Fix Studio CLI yargs locale strings displaying in English

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -41,12 +41,13 @@ const cliAppdataProvider: AppdataProvider< LastBumpStatsData > = {
 };
 
 async function main() {
-	const yargsLocale = await loadTranslations();
+	const { yargsLocale, yargsLocaleData } = await loadTranslations();
 
 	const studioArgv: StudioArgv = yargs( process.argv.slice( 2 ) )
 		.scriptName( 'studio' )
 		.usage( __( 'WordPress Studio CLI' ) )
 		.locale( yargsLocale )
+		.updateLocale( yargsLocaleData ?? {} )
 		.version( version )
 		.option( 'avoid-telemetry', {
 			type: 'boolean',

--- a/cli/lib/i18n.ts
+++ b/cli/lib/i18n.ts
@@ -6,6 +6,46 @@ import {
 	isSupportedLocale,
 } from 'common/lib/locale';
 import { readAppdata } from 'cli/lib/appdata';
+// Yargs locale files imported directly so they're inlined in the bundle.
+// y18n's file-based locale resolution breaks after Vite bundling because the
+// resolved directory path no longer matches the actual location of locale files.
+import yargsLocaleDe from '../../node_modules/yargs/locales/de.json';
+import yargsLocaleEs from '../../node_modules/yargs/locales/es.json';
+import yargsLocaleFr from '../../node_modules/yargs/locales/fr.json';
+import yargsLocaleHe from '../../node_modules/yargs/locales/he.json';
+import yargsLocaleHu from '../../node_modules/yargs/locales/hu.json';
+import yargsLocaleId from '../../node_modules/yargs/locales/id.json';
+import yargsLocaleIt from '../../node_modules/yargs/locales/it.json';
+import yargsLocaleJa from '../../node_modules/yargs/locales/ja.json';
+import yargsLocaleKo from '../../node_modules/yargs/locales/ko.json';
+import yargsLocaleNl from '../../node_modules/yargs/locales/nl.json';
+import yargsLocalePl from '../../node_modules/yargs/locales/pl.json';
+import yargsLocalePtBR from '../../node_modules/yargs/locales/pt_BR.json';
+import yargsLocaleRu from '../../node_modules/yargs/locales/ru.json';
+import yargsLocaleTr from '../../node_modules/yargs/locales/tr.json';
+import yargsLocaleUkUA from '../../node_modules/yargs/locales/uk_UA.json';
+import yargsLocaleZhCN from '../../node_modules/yargs/locales/zh_CN.json';
+import yargsLocaleZhTW from '../../node_modules/yargs/locales/zh_TW.json';
+
+const yargsLocaleDataMap: Partial< Record< SupportedLocale, Record< string, unknown > > > = {
+	de: yargsLocaleDe,
+	es: yargsLocaleEs,
+	fr: yargsLocaleFr,
+	he: yargsLocaleHe,
+	hu: yargsLocaleHu,
+	id: yargsLocaleId,
+	it: yargsLocaleIt,
+	ja: yargsLocaleJa,
+	ko: yargsLocaleKo,
+	nl: yargsLocaleNl,
+	pl: yargsLocalePl,
+	'pt-br': yargsLocalePtBR,
+	ru: yargsLocaleRu,
+	tr: yargsLocaleTr,
+	uk: yargsLocaleUkUA,
+	'zh-cn': yargsLocaleZhCN,
+	'zh-tw': yargsLocaleZhTW,
+};
 
 async function getLocaleFromAppdata(): Promise< SupportedLocale | undefined > {
 	try {
@@ -28,6 +68,8 @@ function mapToYargsLocale( locale: SupportedLocale ): string {
 	switch ( locale ) {
 		case 'pt-br':
 			return 'pt_BR';
+		case 'uk':
+			return 'uk_UA';
 		case 'zh-cn':
 			return 'zh_CN';
 		case 'zh-tw':
@@ -43,7 +85,10 @@ export async function getAppLocale(): Promise< SupportedLocale > {
 	return appdataLocale || envLocale || DEFAULT_LOCALE;
 }
 
-export async function loadTranslations() {
+export async function loadTranslations(): Promise< {
+	yargsLocale: string;
+	yargsLocaleData: Record< string, unknown > | undefined;
+} > {
 	const locale = await getAppLocale();
 	const translations = getLocaleData( locale )?.messages;
 
@@ -53,5 +98,8 @@ export async function loadTranslations() {
 		defaultI18n.resetLocaleData();
 	}
 
-	return mapToYargsLocale( locale );
+	return {
+		yargsLocale: mapToYargsLocale( locale ),
+		yargsLocaleData: yargsLocaleDataMap[ locale ],
+	};
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -7988,6 +7988,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "Apache-2.0 AND MIT",
 			"optional": true,
 			"os": [
@@ -8004,6 +8005,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "Apache-2.0 AND MIT",
 			"optional": true,
 			"os": [
@@ -8020,6 +8022,7 @@
 			"cpu": [
 				"arm"
 			],
+			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -8036,6 +8039,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "Apache-2.0 AND MIT",
 			"optional": true,
 			"os": [
@@ -8052,6 +8056,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "Apache-2.0 AND MIT",
 			"optional": true,
 			"os": [
@@ -8068,6 +8073,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "Apache-2.0 AND MIT",
 			"optional": true,
 			"os": [
@@ -8084,6 +8090,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "Apache-2.0 AND MIT",
 			"optional": true,
 			"os": [
@@ -8100,6 +8107,7 @@
 			"cpu": [
 				"arm64"
 			],
+			"dev": true,
 			"license": "Apache-2.0 AND MIT",
 			"optional": true,
 			"os": [
@@ -8116,6 +8124,7 @@
 			"cpu": [
 				"ia32"
 			],
+			"dev": true,
 			"license": "Apache-2.0 AND MIT",
 			"optional": true,
 			"os": [
@@ -8132,6 +8141,7 @@
 			"cpu": [
 				"x64"
 			],
+			"dev": true,
 			"license": "Apache-2.0 AND MIT",
 			"optional": true,
 			"os": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -7988,7 +7988,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "Apache-2.0 AND MIT",
 			"optional": true,
 			"os": [
@@ -8005,7 +8004,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "Apache-2.0 AND MIT",
 			"optional": true,
 			"os": [
@@ -8022,7 +8020,6 @@
 			"cpu": [
 				"arm"
 			],
-			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -8039,7 +8036,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "Apache-2.0 AND MIT",
 			"optional": true,
 			"os": [
@@ -8056,7 +8052,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "Apache-2.0 AND MIT",
 			"optional": true,
 			"os": [
@@ -8073,7 +8068,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "Apache-2.0 AND MIT",
 			"optional": true,
 			"os": [
@@ -8090,7 +8084,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "Apache-2.0 AND MIT",
 			"optional": true,
 			"os": [
@@ -8107,7 +8100,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"dev": true,
 			"license": "Apache-2.0 AND MIT",
 			"optional": true,
 			"os": [
@@ -8124,7 +8116,6 @@
 			"cpu": [
 				"ia32"
 			],
-			"dev": true,
 			"license": "Apache-2.0 AND MIT",
 			"optional": true,
 			"os": [
@@ -8141,7 +8132,6 @@
 			"cpu": [
 				"x64"
 			],
-			"dev": true,
 			"license": "Apache-2.0 AND MIT",
 			"optional": true,
 			"os": [


### PR DESCRIPTION
## Related issues

- Fixes STU-1232

## Proposed Changes

- Import yargs locale JSON files directly into the bundle to bypass y18n's broken path resolution
- Use `yargs.updateLocale()` to apply inline locale data instead of relying on filesystem-based locale loading
- Add missing `uk` -> `uk_UA` locale mapping in `mapToYargsLocale()`
- Return locale data from `loadTranslations()` for yargs to use

## Testing Instructions

Set a non-English locale in Studio UI and run `studio --help`:

**Portuguese (Brazil):**
```
studio --help
```
Verify "Comandos:", "Opções:", "Exibe ajuda" appear (not "Commands:", "Options:", "Show help")

**Ukrainian:**
```
studio --help
```
Verify "Команди:", "Опції:", "Показати довідку" appear

**Chinese (Simplified):**
```
studio --help
```
Verify Chinese characters appear for yargs strings

**English:**
Verify fallback to English still works correctly.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?