### PR TITLE
Fix SQLite database connection error for existing sites after app update

### DIFF
--- a/tools/common/lib/sqlite-integration.ts
+++ b/tools/common/lib/sqlite-integration.ts
@@ -16,11 +16,18 @@ export abstract class SqliteIntegrationProvider {
 		return ( await fs.pathExists( sqliteSourcePath ) ) && ( await fs.pathExists( dbCopyPath ) );
 	}
 
-	// Returns true if site has db.php or no wp-config.php
 	async needsSqliteSetup( sitePath: string ): Promise< boolean > {
-		const hasDbPhp = await fs.pathExists( path.join( sitePath, 'wp-content', 'db.php' ) );
 		const hasWpConfig = await fs.pathExists( path.join( sitePath, 'wp-config.php' ) );
-		return hasDbPhp || ! hasWpConfig;
+		if ( ! hasWpConfig ) {
+			return true;
+		}
+		const wpContentPath = path.join( sitePath, 'wp-content' );
+		const hasSqlite = await Promise.all( [
+			fs.pathExists( path.join( wpContentPath, 'db.php' ) ),
+			fs.pathExists( path.join( wpContentPath, 'database', '.ht.sqlite' ) ),
+			fs.pathExists( path.join( wpContentPath, 'mu-plugins', this.getSqliteDirname() ) ),
+		] ).then( ( results ) => results.some( Boolean ) );
+		return hasSqlite;
 	}
 
 	async getSqliteVersionFromInstallation( sqliteMuPluginPath: string ): Promise< string > {

--- a/tools/common/lib/tests/sqlite-integration.test.ts
+++ b/tools/common/lib/tests/sqlite-integration.test.ts
@@ -49,12 +49,36 @@ platformTestSuite( 'SqliteIntegrationProvider', ( { normalize } ) => {
 			expect( result ).toBe( true );
 		} );
 
-		it( 'should return false when wp-config.php exists and db.php does not', async () => {
+		it( 'should return false when wp-config.php exists and no SQLite artifacts exist', async () => {
 			mockFs.__setFileContents( normalize( `${ MOCK_SITE_PATH }/wp-config.php` ), 'config' );
 
 			const result = await provider.needsSqliteSetup( MOCK_SITE_PATH );
 
 			expect( result ).toBe( false );
+		} );
+
+		it( 'should return true when wp-config.php exists and SQLite database exists but db.php is missing', async () => {
+			mockFs.__setFileContents( normalize( `${ MOCK_SITE_PATH }/wp-config.php` ), 'config' );
+			mockFs.__setFileContents(
+				normalize( `${ MOCK_SITE_PATH }/wp-content/database/.ht.sqlite` ),
+				'sqlite-data'
+			);
+
+			const result = await provider.needsSqliteSetup( MOCK_SITE_PATH );
+
+			expect( result ).toBe( true );
+		} );
+
+		it( 'should return true when wp-config.php exists and SQLite mu-plugin exists but db.php is missing', async () => {
+			mockFs.__setFileContents( normalize( `${ MOCK_SITE_PATH }/wp-config.php` ), 'config' );
+			mockFs.__setFileContents(
+				normalize( `${ MOCK_SITE_PATH }/wp-content/mu-plugins/${ SQLITE_DIRNAME }` ),
+				'dir'
+			);
+
+			const result = await provider.needsSqliteSetup( MOCK_SITE_PATH );
+
+			expect( result ).toBe( true );
 		} );
 
 		it( 'should return true when both files exist (db.php takes precedence)', async () => {


### PR DESCRIPTION
## Related issues

- Fixes https://github.com/Automattic/studio/issues/2611

## Proposed Changes

We received a report that site throw an error on v1.7.4. It seems `needsSqliteSetup()` only checked for `db.php` existence. When `db.php` was missing but `wp-config.php` existed, it assumed the site was non-SQLite and skipped setup entirely. I suggest making this check more flexible.

This PR broadens the SQLite detection by checking for **any** SQLite artifact:
- `wp-content/db.php` (existing check)
- `wp-content/database/.ht.sqlite` (SQLite database file)
- `wp-content/mu-plugins/sqlite-database-integration/` (SQLite plugin directory)

If any of these exist, the site is recognized as a SQLite site and `db.php`, or any other part is regenerated.
To make the site non SQLite all the parts should be removed.

## Testing Instructions

1. Start the app with `npm start`
2. Create a new site, verify it starts normally
3. Stop the site
4. Delete `wp-content/db.php` from the site directory
5. Start the site again — it should auto-regenerate `db.php` and start successfully
6. Run tests: `npx vitest run --config tools/common/vitest.config.ts sqlite-integration`

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors? (Tests pass, no errors)