### PR TITLE
Fix Performance Metrics broken import

### DIFF
--- a/tools/metrics/playwright.metrics.config.ts
+++ b/tools/metrics/playwright.metrics.config.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import { defineConfig } from '@playwright/test';
-import baseConfig from '../playwright.config';
+import baseConfig from '../../playwright.config';
 
 process.env.ARTIFACTS_PATH ??= path.join( __dirname, 'artifacts' );
 


### PR DESCRIPTION
## Related issues

Related to #2565

## Proposed Changes

- Update import path from `../playwright.config` to `../../playwright.config` to point to the correct location

## Testing Instructions

- Run `npm run test:metrics -- --list` to verify the config resolves correctly and tests are listed
- Performance Metrics job should be green

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?