### PR TITLE
Fix missing aria-level on heading role in site settings

### DIFF
--- a/apps/studio/src/components/content-tab-settings.tsx
+++ b/apps/studio/src/components/content-tab-settings.tsx
@@ -1,5 +1,10 @@
 import { decodePassword } from '@studio/common/lib/passwords';
-import { DropdownMenu, MenuGroup, Button } from '@wordpress/components';
+import {
+	DropdownMenu,
+	MenuGroup,
+	Button,
+	__experimentalHeading as Heading,
+} from '@wordpress/components';
 import { moreVertical } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { PropsWithChildren } from 'react';
@@ -58,9 +63,9 @@ export function ContentTabSettings( { selectedSite }: ContentTabSettingsProps ) 
 	return (
 		<div className="p-8 ltr:pr-4 rtl:pl-4">
 			<div className="flex justify-between items-center mb-4">
-				<h3 role="heading" className="text-black text-sm font-semibold">
+				<Heading level={ 3 } className="text-black text-sm font-semibold">
 					{ __( 'Site details' ) }
-				</h3>
+				</Heading>
 				<div className="flex items-center gap-1">
 					<EditSiteDetails currentWpVersion={ wpVersion } onSave={ refreshWpVersion } />
 					<DropdownMenu


### PR DESCRIPTION
## Related issues

- Related to STU-1307

## Proposed Changes

- Improve accessibility issue found by React Doctor, where the explicit `role="heading"` was missing the required `aria-level` prop, which is an accessibility violation (`jsx-a11y/role-has-required-aria-props`)
This PR fixes the error by using the `Heading` component from `@wordpress/components`. It could also be fixed by simply removing `role="heading"`, but we preferred to go one step further and use a WordPress component instead a plain h3.

## Testing Instructions

Visual regressions:

- Start the app with `npm start`
- Navigate to a site's Settings tab
- Verify the "Site details" heading renders correctly with no visual regression

Tests:

- Run `npm test -- src/components/tests/content-tab-settings.test.tsx` — all 7 tests pass, including the one that checks `getByRole('heading', { name: 'Site details' })`

React Doctor:

- Run `npx -y react-doctor`
- Observe the error doesn't appear anymore:
```
  ✗ `heading` role is missing required aria props `aria-level`.
    Add missing aria props `aria-level` to the element with `heading` role.
```

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors? (Tests pass, no errors)