### PR TITLE
Remove useEffect state resets in WelcomeComponent and AIInput

### DIFF
--- a/apps/studio/src/components/ai-input.tsx
+++ b/apps/studio/src/components/ai-input.tsx
@@ -64,25 +64,17 @@ const UnforwardedAIInput = (
 	const typingTimeout = useRef< NodeJS.Timeout >();
 	const thinkingTimeout = useRef< NodeJS.Timeout[] >( [] );
 
-	const { RiveComponent, setInputState } = useAiIcon();
+	const { RiveComponent } = useAiIcon( {
+		inactive: disabled,
+		thinking: isAssistantThinking,
+		typing: isTyping,
+	} );
 
 	useEffect( () => {
 		if ( ! disabled && inputRef && 'current' in inputRef && inputRef.current ) {
 			inputRef.current?.focus();
 		}
 	}, [ disabled, inputRef ] );
-
-	useEffect( () => {
-		setInputState( 'inactive', disabled );
-	}, [ setInputState, disabled ] );
-
-	useEffect( () => {
-		setInputState( 'thinking', isAssistantThinking );
-	}, [ setInputState, isAssistantThinking ] );
-
-	useEffect( () => {
-		setInputState( 'typing', isTyping );
-	}, [ setInputState, isTyping ] );
 
 	useEffect(
 		() => () => {

--- a/apps/studio/src/components/content-tab-assistant.tsx
+++ b/apps/studio/src/components/content-tab-assistant.tsx
@@ -498,6 +498,7 @@ export function ContentTabAssistant( { selectedSite }: ContentTabAssistantProps 
 					{ isAuthenticated ? (
 						<>
 							<WelcomeComponent
+								key={ selectedSite.id }
 								onExampleClick={ ( prompt ) => {
 									submitPrompt( prompt );
 									inputRef.current?.focus();
@@ -505,7 +506,6 @@ export function ContentTabAssistant( { selectedSite }: ContentTabAssistantProps 
 								showExamplePrompts={ messages.length === 0 }
 								messages={ data?.messages ?? [] }
 								examplePrompts={ data?.example_prompts ?? [] }
-								siteId={ selectedSite.id }
 								disabled={ disabled }
 								isLoading={ isLoading }
 							/>

--- a/apps/studio/src/components/welcome-message-prompt.tsx
+++ b/apps/studio/src/components/welcome-message-prompt.tsx
@@ -1,6 +1,6 @@
 import { __ } from '@wordpress/i18n';
 import { arrowRight } from '@wordpress/icons';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useRef, useState } from 'react';
 import Button from 'src/components/button';
 import { cx } from 'src/lib/cx';
 
@@ -22,7 +22,6 @@ interface WelcomeComponentProps {
 	showExamplePrompts: boolean;
 	messages: string[];
 	examplePrompts: string[];
-	siteId: string;
 	disabled?: boolean;
 	isLoading?: boolean;
 }
@@ -76,7 +75,7 @@ export const ExampleMessagePrompt = ( {
 
 const WelcomeComponent = React.forwardRef< HTMLDivElement, WelcomeComponentProps >(
 	(
-		{ onExampleClick, showExamplePrompts, messages, examplePrompts, siteId, disabled, isLoading },
+		{ onExampleClick, showExamplePrompts, messages, examplePrompts, disabled, isLoading },
 		ref
 	) => {
 		const [ showMore, setShowMore ] = useState( false );
@@ -84,10 +83,6 @@ const WelcomeComponent = React.forwardRef< HTMLDivElement, WelcomeComponentProps
 
 		// Determine the prompts to display (either first 3 or all)
 		const displayedPrompts = showMore ? examplePrompts : examplePrompts.slice( 0, 3 );
-
-		useEffect( () => {
-			setShowMore( false );
-		}, [ siteId ] );
 
 		const handleShowMore = () => {
 			setShowMore( true );

--- a/apps/studio/src/hooks/use-ai-icon.ts
+++ b/apps/studio/src/hooks/use-ai-icon.ts
@@ -1,9 +1,15 @@
 import { RuntimeLoader } from '@rive-app/canvas';
 import { useRive, useStateMachineInput } from '@rive-app/react-canvas';
-import { useCallback, useEffect } from '@wordpress/element';
+import { useEffect } from '@wordpress/element';
 import aiImage from '../../assets/ai-icon.riv';
 
-const useAiIcon = () => {
+interface AiIconStates {
+	inactive?: boolean;
+	thinking?: boolean;
+	typing?: boolean;
+}
+
+const useAiIcon = ( states: AiIconStates = {} ) => {
 	const stateMachineName = 'State Machine A';
 
 	// Configure Rive to use local WASM files
@@ -29,26 +35,30 @@ const useAiIcon = () => {
 		};
 	}, [ rive ] );
 
-	const setInputState = useCallback(
-		( stateName: 'inactive' | 'thinking' | 'typing', value: boolean ) => {
-			if ( stateName === 'inactive' && inactiveInput ) {
-				// eslint-disable-next-line react-hooks/immutability
-				inactiveInput.value = value;
-			} else if ( stateName === 'thinking' && thinkingInput ) {
-				// eslint-disable-next-line react-hooks/immutability
-				thinkingInput.value = value;
-			} else if ( stateName === 'typing' && typingInput ) {
-				// eslint-disable-next-line react-hooks/immutability
-				typingInput.value = value;
-			}
-		},
-		[ inactiveInput, thinkingInput, typingInput ]
-	);
+	useEffect( () => {
+		if ( inactiveInput ) {
+			// eslint-disable-next-line react-hooks/immutability
+			inactiveInput.value = states.inactive ?? false;
+		}
+	}, [ inactiveInput, states.inactive ] );
+
+	useEffect( () => {
+		if ( thinkingInput ) {
+			// eslint-disable-next-line react-hooks/immutability
+			thinkingInput.value = states.thinking ?? false;
+		}
+	}, [ thinkingInput, states.thinking ] );
+
+	useEffect( () => {
+		if ( typingInput ) {
+			// eslint-disable-next-line react-hooks/immutability
+			typingInput.value = states.typing ?? false;
+		}
+	}, [ typingInput, states.typing ] );
 
 	return {
 		rive,
 		RiveComponent,
-		setInputState,
 	};
 };
 


### PR DESCRIPTION
## Related issues

- Fixes STU-1307

## Proposed Changes

- Replace `useEffect`-based state reset of `showMore` in `WelcomeComponent` with a `key={selectedSite.id}` prop on the parent, so React remounts the component with fresh state when the site changes
- Refactor `useAiIcon` hook to accept `{ inactive, thinking, typing }` state values as parameters, moving Rive animation synchronization into the hook itself
- Remove three `useEffect` sync calls from `AIInput` that were flagged as "state reset in useEffect" by react-doctor
- Remove the now-unused `siteId` prop from `WelcomeComponent`

## Testing Instructions

- Start the app with `npm start`
- Switch between sites and verify the welcome message "More suggestions" button resets properly
- Open the Assistant tab, type a message, and verify the AI icon animates correctly (typing, thinking, inactive states)
- Run `npm test -- src/components/tests/ai-input.test.tsx src/components/tests/content-tab-assistant.test.tsx` — all 23 tests pass
- No visual regression observed

React Doctor

- Run `npx -y react-doctor`
- Observe the error doesn't appear anymore:
```
✗ State reset in useEffect — use a key prop to reset component state when props change (4)
    For derived state, compute inline: `const x = fn(dep)`. For state resets on prop change, use a key prop: `<Component key={prop} />`
```



https://github.com/user-attachments/assets/e47798f9-be91-44ee-8df9-5017fd7d0781


## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors? (Tests pass, no errors)