### PR TITLE
Studio: Fix toBeInDocument warnings in tests

### DIFF
--- a/apps/cli/commands/site/tests/create.test.ts
+++ b/apps/cli/commands/site/tests/create.test.ts
@@ -13,7 +13,7 @@ import {
 import { isOnline } from '@studio/common/lib/network-utils';
 import { portFinder } from '@studio/common/lib/port-finder';
 import { normalizeLineEndings } from '@studio/common/lib/remove-default-db-constants';
-import { Blueprint, StepDefinition } from '@wp-playground/blueprints';
+import { Blueprint, BlueprintV1Declaration, StepDefinition } from '@wp-playground/blueprints';
 import { vi, type MockInstance } from 'vitest';
 import {
 	lockAppdata,
@@ -334,8 +334,8 @@ describe( 'CLI: studio site create', () => {
 			const calls = vi.mocked( startWordPressServer ).mock.calls;
 			const blueprintCall = calls.find(
 				( call ) =>
-					( call[ 2 ] as { blueprint?: Blueprint } )?.blueprint?.steps?.some(
-						( step: StepDefinition ) => step.step === 'setSiteOptions'
+					( call[ 2 ] as { blueprint?: BlueprintV1Declaration } )?.blueprint?.steps?.some(
+						( step ) => typeof step === 'object' && step?.step === 'setSiteOptions'
 					)
 			);
 			expect( blueprintCall ).toBeUndefined();
@@ -489,7 +489,12 @@ describe( 'CLI: studio site create', () => {
 
 	describe( 'Blueprint Handling', () => {
 		const testBlueprint: Blueprint = {
-			steps: [ { step: 'installPlugin', pluginData: { slug: 'akismet' } } ],
+			steps: [
+				{
+					step: 'installPlugin',
+					pluginData: { resource: 'wordpress.org/plugins', slug: 'akismet' },
+				},
+			],
 		};
 
 		it( 'should apply Blueprint when provided', async () => {
@@ -643,8 +648,8 @@ describe( 'CLI: studio site create', () => {
 			);
 			// Should NOT include setSiteLanguage step
 			const calls = vi.mocked( startWordPressServer ).mock.calls;
-			const blueprintSteps = ( calls[ 0 ][ 2 ] as { blueprint?: Blueprint } )?.blueprint
-				?.steps as StepDefinition[];
+			const blueprintSteps = ( calls[ 0 ][ 2 ] as { blueprint?: BlueprintV1Declaration } )
+				?.blueprint?.steps as StepDefinition[];
 			expect( blueprintSteps.some( ( s ) => s.step === 'setSiteLanguage' ) ).toBe( false );
 		} );
 

--- a/apps/studio/src/custom-package-definitions.d.ts
+++ b/apps/studio/src/custom-package-definitions.d.ts
@@ -1,3 +1,5 @@
+/// <reference types="@testing-library/jest-dom/vitest" />
+
 declare module '*.png' {
 	const dataUri: string;
 	export default dataUri;

--- a/apps/studio/src/modules/sync/tests/index.test.tsx
+++ b/apps/studio/src/modules/sync/tests/index.test.tsx
@@ -140,7 +140,7 @@ describe( 'ContentTabSync', () => {
 		syncSites: SyncSite[] = []
 	) => {
 		// Update the IPC API mock to return the connected sites
-		const currentMock = vi.mocked( getIpcApi, { partial: true } )();
+		const currentMock = vi.mocked( getIpcApi )();
 		vi.mocked( currentMock.getConnectedWpcomSites, { partial: true } ).mockResolvedValue(
 			connectedSites
 		);

--- a/apps/studio/vitest.setup.ts
+++ b/apps/studio/vitest.setup.ts
@@ -1,6 +1,6 @@
 import { webcrypto } from 'crypto';
 import { TextEncoder, TextDecoder } from 'util';
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/vitest';
 import { configure } from '@testing-library/react';
 import 'isomorphic-fetch';
 import nock from 'nock';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

Currently, there is a type error in all tests:

<img width="828" height="178" alt="Screenshot 2026-02-20 at 10 55 02 AM" src="https://github.com/user-attachments/assets/b46e0b3e-f96b-4bcd-93e4-554309f8b925" />


## Proposed Changes

This PR fixes the error. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
* Navigate to `studio/apps/studio/src/modules/sync/tests/index.test.tsx` 
* Observe that there are no errors related to `toBeInDocument`
* You can check other test files containing `toBeInDocument` and confirm the issue does not happen there either

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
