### PR TITLE
Fix performance test to support old structure for both build and test runner paths

### DIFF
--- a/tools/compare-perf/performance.ts
+++ b/tools/compare-perf/performance.ts
@@ -86,11 +86,21 @@ async function runTestSuite(
 	runKey: string,
 	branchDir: string
 ) {
-	const outDir = path.join( branchDir, 'apps', 'studio', 'out' );
+	// Support both monorepo (apps/studio/out) and old structure (out)
+	const monorepoOutDir = path.join( branchDir, 'apps', 'studio', 'out' );
+	const oldOutDir = path.join( branchDir, 'out' );
+	const outDir = fs.existsSync( monorepoOutDir ) ? monorepoOutDir : oldOutDir;
+
 	if ( ! fs.existsSync( outDir ) ) {
 		throw new Error( `Could not find packaged Studio build output at: ${ outDir }` );
 	}
-	const testRunnerOutDir = path.join( testRunnerDir, 'apps', 'studio', 'out' );
+
+	// Test runner may also use either structure depending on --tests-branch
+	const testRunnerMonorepoOutDir = path.join( testRunnerDir, 'apps', 'studio', 'out' );
+	const testRunnerOldOutDir = path.join( testRunnerDir, 'out' );
+	const testRunnerOutDir = fs.existsSync( path.join( testRunnerDir, 'apps', 'studio' ) )
+		? testRunnerMonorepoOutDir
+		: testRunnerOldOutDir;
 
 	if ( fs.existsSync( testRunnerOutDir ) ) {
 		fs.rmSync( testRunnerOutDir, { recursive: true } );


### PR DESCRIPTION
## Related issues

- Completes the performance test backward compatibility fixes

## Proposed Changes

- Makes both `outDir` and `testRunnerOutDir` conditional to support monorepo vs old structure
- `outDir` checks if `apps/studio/out` exists, falls back to `out`
- `testRunnerOutDir` checks if `apps/studio` directory exists to determine structure
- This ensures performance tests work when comparing commits across the monorepo migration boundary

## Testing Instructions

- Run performance comparison between a monorepo commit and a pre-monorepo commit:
  ```bash
  npm run compare:perf perf 44012f244faaac682d4473ee6f176ddaa8bcf34c 58c52bfee7e585614ced202f43f217a01f94f029 --tests-branch trunk --rounds 1
  ```
- Verify both builds succeed and tests run

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?