### PR TITLE
Fix push cancellation error dialog

### DIFF
--- a/apps/studio/src/hooks/sync-sites/use-sync-push.ts
+++ b/apps/studio/src/hooks/sync-sites/use-sync-push.ts
@@ -284,7 +284,7 @@ export function useSyncPush( {
 				} );
 				( { archivePath, archiveSizeInBytes } = result );
 			} catch ( error ) {
-				if ( error instanceof Error && error.message === 'Export aborted' ) {
+				if ( error instanceof Error && error.message.includes( 'Export aborted' ) ) {
 					updatePushState( selectedSite.id, remoteSiteId, {
 						status: pushStatesProgressInfo.cancelled,
 					} );
@@ -353,7 +353,7 @@ export function useSyncPush( {
 					throw response;
 				}
 			} catch ( error ) {
-				if ( error instanceof Error && error.message === 'Export aborted' ) {
+				if ( error instanceof Error && error.message.includes( 'Export aborted' ) ) {
 					updatePushState( selectedSite.id, remoteSiteId, {
 						status: pushStatesProgressInfo.cancelled,
 					} );


### PR DESCRIPTION
## Related issues

- Fixes STU-1087

## Proposed Changes

- Use `.includes('Export aborted')` instead of `=== 'Export aborted'` when checking for push cancellation errors in the renderer process.
- Electron IPC wraps error messages as `"Error invoking remote method '...': Error: <message>"`, so the strict equality check never matched the wrapped message. This caused cancelling a push during the export phase to show an error dialog and report to Sentry, instead of gracefully handling the cancellation.
- This is consistent with other IPC error checks in the codebase (e.g., `use-site-details.tsx` uses `.includes()` for the same reason).

## Testing Instructions

1. Connect a local site to a WordPress.com site
2. Start a Push operation
3. Immediately cancel the push while it's in the "Creating backup" (export) phase
4. Verify that the push is cancelled gracefully with a "Push cancelled" notification — no error dialog should appear

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?