### PR TITLE
Fix flaky blueprint plugin activate E2E test

### DIFF
--- a/apps/studio/e2e/blueprints.test.ts
+++ b/apps/studio/e2e/blueprints.test.ts
@@ -169,8 +169,9 @@ test.describe( 'Blueprints', () => {
 		const pluginsUrl = wpAdminUrl + '/plugins.php';
 		await page.goto( getUrlWithAutoLogin( pluginsUrl ) );
 		// Be more specific - look for the active Hello Dolly plugin
+		// Use a generous timeout to account for auto-login redirect + page load
 		const pluginRow = page.locator( 'tr[data-slug="hello-dolly"].active' );
-		await expect( pluginRow ).toBeVisible();
+		await expect( pluginRow ).toBeVisible( { timeout: 60_000 } );
 	} );
 
 	test( 'create site with Blueprint that runs PHP code', async ( { page } ) => {


### PR DESCRIPTION
## Related issues

- Related to "E2E Tests on windows-x64" failing. It was going through after rerun.

## Proposed Changes

- Increase the `toBeVisible()` timeout from the default 30s to 60s for the active plugin row assertion in the "create site with Blueprint that activates a plugin" E2E test
- The `getUrlWithAutoLogin()` helper causes a redirect chain (auto-login page → `plugins.php`), which can exceed 30s on slower CI runners, causing intermittent failures

## Testing Instructions

- Run `npm run e2e` and confirm the blueprint tests pass consistently
- The specific test is: `Blueprints › create site with Blueprint that activates a plugin`

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?