### PR TITLE
Fix toggle sidebar icon alignment after Add Site modal

### DIFF
--- a/apps/studio/src/constants.ts
+++ b/apps/studio/src/constants.ts
@@ -14,6 +14,7 @@ export const UPDATED_MESSAGE_DURATION_MS = 60000; // 1 minute
 export const SYNC_PUSH_SIZE_LIMIT_GB = 5;
 export const SYNC_PUSH_SIZE_LIMIT_BYTES = SYNC_PUSH_SIZE_LIMIT_GB * 1024 * 1024 * 1024; // 5GB
 export const AUTO_UPDATE_INTERVAL_MS = 60 * 60 * 1000;
+export const MACOS_TRAFFIC_LIGHT_POSITION = { x: 20, y: 20 };
 export const WINDOWS_TITLEBAR_HEIGHT = 32;
 export const ABOUT_WINDOW_WIDTH = 300;
 export const ABOUT_WINDOW_HEIGHT = 350;

--- a/apps/studio/src/ipc-handlers.ts
+++ b/apps/studio/src/ipc-handlers.ts
@@ -37,7 +37,7 @@ import { isWordPressDevVersion } from '@studio/common/lib/wordpress-version-util
 import { Snapshot } from '@studio/common/types/snapshot';
 import { StatsGroup, StatsMetric } from '@studio/common/types/stats';
 import { __, sprintf, LocaleData, defaultI18n } from '@wordpress/i18n';
-import { MAIN_MIN_WIDTH, SIDEBAR_WIDTH } from 'src/constants';
+import { MACOS_TRAFFIC_LIGHT_POSITION, MAIN_MIN_WIDTH, SIDEBAR_WIDTH } from 'src/constants';
 import { sendIpcEventToRendererWithWindow } from 'src/ipc-utils';
 import { getBetaFeatures as getBetaFeaturesFromLib } from 'src/lib/beta-features';
 import { getImporterMetric, getBlueprintMetric } from 'src/lib/bump-stats/lib';
@@ -1539,5 +1539,8 @@ export async function setWindowControlVisibility( event: IpcMainInvokeEvent, vis
 	const parentWindow = BrowserWindow.fromWebContents( event.sender );
 	if ( parentWindow && process.platform === 'darwin' ) {
 		parentWindow.setWindowButtonVisibility( visible );
+		if ( visible ) {
+			parentWindow.setWindowButtonPosition( MACOS_TRAFFIC_LIGHT_POSITION );
+		}
 	}
 }

--- a/apps/studio/src/main-window.ts
+++ b/apps/studio/src/main-window.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import { portFinder } from '@studio/common/lib/port-finder';
 import {
 	DEFAULT_WIDTH,
+	MACOS_TRAFFIC_LIGHT_POSITION,
 	MAIN_MIN_HEIGHT,
 	MAIN_MIN_WIDTH,
 	WINDOWS_TITLEBAR_HEIGHT,
@@ -161,7 +162,7 @@ function getOSWindowOptions(): Partial< BrowserWindowConstructorOptions > {
 			return {
 				frame: false,
 				titleBarStyle: 'hidden',
-				trafficLightPosition: { x: 20, y: 20 },
+				trafficLightPosition: MACOS_TRAFFIC_LIGHT_POSITION,
 			};
 
 		case 'win32':


### PR DESCRIPTION
## Related issues

- Fixes STU-1309

## Proposed Changes

- Fix the traffic light position when hiding them, for example, after the Add Site modal opens.

Long explanation:

- Extract the macOS traffic light position (`{ x: 20, y: 20 }`) into a shared `MACOS_TRAFFIC_LIGHT_POSITION` constant in `constants.ts`
- Use the constant in `main-window.ts` instead of the hardcoded literal
- After calling `setWindowButtonVisibility(true)` in the `setWindowControlVisibility` IPC handler, restore the custom position via `setWindowButtonPosition(MACOS_TRAFFIC_LIGHT_POSITION)` — this fixes the alignment shift caused by Electron not preserving the custom `trafficLightPosition` when re-showing window buttons

## Testing Instructions

- Start the app with `npm start` on MacOS
- Click "Add Site" to open the modal, or press `cmd+n`
- Close the modal without creating a site, or press `esc`
- Verify the macOS traffic lights (red/yellow/green) and the "Toggle sidebar" icon remain in their correct position — they should not shift

**Before**


https://github.com/user-attachments/assets/fb233989-116f-4b3f-940b-89341611a1ed


**After**

https://github.com/user-attachments/assets/85a8248d-ee19-4109-942f-a7b2604d9ff7



## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors? (Tests pass, no errors)