### PR TITLE
Add @yao-pkg/pkg to dependabot allow list

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -138,6 +138,9 @@ updates:
       - dependency-name: "resize-observer-polyfill"
       - dependency-name: "isomorphic-fetch"
 
+      # Binary packaging
+      - dependency-name: "@yao-pkg/*"
+
       # Dev tools
       - dependency-name: "prettier"
       - dependency-name: "postcss"


### PR DESCRIPTION
## Related issues
None

## Proposed Changes
- Adds `@yao-pkg/*` to the dependabot allow list — this package was the only dependency across all workspace packages (`apps/cli`, `apps/studio`, `tools/common`, root) not covered by an existing pattern.

## Testing Instructions
- No functional changes; verify the dependabot config is valid by checking the next scheduled dependabot run picks up `@yao-pkg/pkg` updates.

## Pre-merge Checklist
- [x] No code changes, config-only