### PR TITLE
Remove PHP-WASM web builds from output

### DIFF
--- a/apps/cli/vite.config.ts
+++ b/apps/cli/vite.config.ts
@@ -33,9 +33,10 @@ export default defineConfig( {
 						],
 					} ),
 					{
-						// Remove asyncify PHP-WASM builds from dist. JSPI is a newer and faster technology, and
-						// there's no need for us to bundle both build formats. Removing asyncify saves ~250MB.
-						name: 'prune-php-wasm-asyncify',
+						// Remove unnecessary PHP-WASM binaries from dist: asyncify binaries for node and all web
+						// binaries. JSPI is a newer and faster than asyncify, and there's no need for us to bundle
+						// both build formats. Removing asyncify saves ~250MB.
+						name: 'prune-php-wasm',
 						apply: 'build' as const,
 						closeBundle() {
 							const asyncifyPaths = globSync( '@php-wasm/node-*/asyncify/', {
@@ -43,8 +44,13 @@ export default defineConfig( {
 								absolute: true,
 							} );
 
-							for ( const asyncifyPath of asyncifyPaths ) {
-								rmSync( asyncifyPath, { recursive: true, force: true } );
+							const webPaths = globSync( '@php-wasm/web-*/', {
+								cwd: distCliNodeModulesPath,
+								absolute: true,
+							} );
+
+							for ( const path of [ ...asyncifyPaths, ...webPaths ] ) {
+								rmSync( path, { recursive: true, force: true } );
 							}
 						},
 					},

--- a/apps/cli/vite.config.ts
+++ b/apps/cli/vite.config.ts
@@ -35,7 +35,7 @@ export default defineConfig( {
 					{
 						// Remove unnecessary PHP-WASM binaries from dist: asyncify binaries for node and all web
 						// binaries. JSPI is a newer and faster than asyncify, and there's no need for us to bundle
-						// both build formats. Removing asyncify saves ~250MB.
+						// both build formats. Removing asyncify saves ~250MB. Removing the web binaries saves ~400MB.
 						name: 'prune-php-wasm',
 						apply: 'build' as const,
 						closeBundle() {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- N/A

## Proposed Changes

This PR follows up https://github.com/Automattic/studio/pull/2641 by removing PHP-WASM web binaries from the packaged CLI output. Combined with that PR, the macOS application comes out at just 1,31 GB 👍

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

CI should pass. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
