### PR TITLE
Studio: Add time display over pull and push completed notification

### DIFF
--- a/apps/studio/src/modules/sync/components/sync-connected-sites.tsx
+++ b/apps/studio/src/modules/sync/components/sync-connected-sites.tsx
@@ -203,6 +203,7 @@ const SyncConnectedSitesSectionItem = ( {
 		cancelPush,
 		pauseUpload,
 		resumeUpload,
+		getLastSyncTimeText,
 	} = useSyncSites();
 	const { importState } = useImportExport();
 	const {
@@ -335,9 +336,16 @@ const SyncConnectedSitesSectionItem = ( {
 					) }
 					{ hasPullFinished && (
 						<div className="transition-all duration-300 ease-in-out">
-							<ClearAction onClick={ () => clearPullState( selectedSite.id, connectedSite.id ) }>
-								{ __( 'Pull complete' ) }
-							</ClearAction>
+							<DynamicTooltip
+								getTooltipText={ () =>
+									getLastSyncTimeText( connectedSite.lastPullTimestamp, 'pull' )
+								}
+								placement="top-start"
+							>
+								<ClearAction onClick={ () => clearPullState( selectedSite.id, connectedSite.id ) }>
+									{ __( 'Pull complete' ) }
+								</ClearAction>
+							</DynamicTooltip>
 						</div>
 					) }
 					{ pushState?.status && isUploadingNetworkPaused && (
@@ -465,9 +473,16 @@ const SyncConnectedSitesSectionItem = ( {
 
 					{ pushState?.status && hasPushFinished && (
 						<div className="transition-all duration-300 ease-in-out">
-							<ClearAction onClick={ () => clearPushState( selectedSite.id, connectedSite.id ) }>
-								{ pushState.status.message }
-							</ClearAction>
+							<DynamicTooltip
+								getTooltipText={ () =>
+									getLastSyncTimeText( connectedSite.lastPushTimestamp, 'push' )
+								}
+								placement="top-start"
+							>
+								<ClearAction onClick={ () => clearPushState( selectedSite.id, connectedSite.id ) }>
+									{ pushState.status.message }
+								</ClearAction>
+							</DynamicTooltip>
 						</div>
 					) }
 					{ ! isPulling &&


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Fixes STU-1259

## Proposed Changes

This PR adds time display over `Push completed` and `Pull completed` as Tooltip so that the user knows when it was completed. This works similarly to the tooltip over `Push` and `Pull` buttons:

<img width="350" height="106" alt="Screenshot 2026-02-24 at 12 13 38 PM" src="https://github.com/user-attachments/assets/c6ba4267-4862-48a0-8bf0-498d5291be04" />

<img width="503" height="162" alt="Screenshot 2026-02-24 at 12 10 44 PM" src="https://github.com/user-attachments/assets/e7248244-d724-4f3b-92e3-19eedde75473" />

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
* Navigate to the `Sync` tab and connect a site
* Once connected, start the `Push` process
* Observe that once push is completed, you can see the tooltip with when the site was last pushed over `Push completed` text
* Start the `Pull` process 
* Observe that you can see time notification over `Pull completed` text

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
