### PR TITLE
Fix React performance and accessibility issues from react-doctor

### DIFF
--- a/apps/studio/src/components/welcome-message-prompt.tsx
+++ b/apps/studio/src/components/welcome-message-prompt.tsx
@@ -109,7 +109,7 @@ const WelcomeComponent = React.forwardRef< HTMLDivElement, WelcomeComponentProps
 				<div className="flex flex-col">
 					{ messages.map( ( message, index ) => (
 						<WelcomeMessagePrompt
-							key={ index }
+							key={ message }
 							id={ `message-welcome-${ index }` }
 							className="welcome-message"
 							ref={ index === messages.length - 1 ? lastMessageRef : null }
@@ -123,9 +123,8 @@ const WelcomeComponent = React.forwardRef< HTMLDivElement, WelcomeComponentProps
 					{ showExamplePrompts && (
 						<div className="flex-grow">
 							{ displayedPrompts.map( ( prompt, index ) => (
-								<div key={ index } className="flex items-center">
+								<div key={ prompt } className="flex items-center">
 									<ExampleMessagePrompt
-										key={ index }
 										className="example-prompt"
 										onClick={ () => onExampleClick( prompt ) }
 										disabled={ disabled }

--- a/apps/studio/src/modules/add-site/components/create-site-form.tsx
+++ b/apps/studio/src/modules/add-site/components/create-site-form.tsx
@@ -152,11 +152,13 @@ function FormPathInputComponent( {
 	);
 }
 
+const EMPTY_STRING_ARRAY: string[] = [];
+
 export const CreateSiteForm = ( {
 	defaultValues = {},
 	onSelectPath,
 	onSiteNameChange,
-	existingDomainNames = [],
+	existingDomainNames = EMPTY_STRING_ARRAY,
 	blueprintPreferredVersions,
 	blueprintSuggestedDomain,
 	blueprintSuggestedHttps,

--- a/apps/studio/src/modules/add-site/components/create-site-form.tsx
+++ b/apps/studio/src/modules/add-site/components/create-site-form.tsx
@@ -152,13 +152,11 @@ function FormPathInputComponent( {
 	);
 }
 
-const EMPTY_STRING_ARRAY: string[] = [];
-
 export const CreateSiteForm = ( {
 	defaultValues = {},
 	onSelectPath,
 	onSiteNameChange,
-	existingDomainNames = EMPTY_STRING_ARRAY,
+	existingDomainNames,
 	blueprintPreferredVersions,
 	blueprintSuggestedDomain,
 	blueprintSuggestedHttps,
@@ -242,7 +240,7 @@ export const CreateSiteForm = ( {
 			const generatedDomainName = generateCustomDomainFromSiteName( siteName );
 			const domainToValidate = customDomain ?? generatedDomainName;
 			setCustomDomainError(
-				getDomainNameValidationError( useCustomDomain, domainToValidate, existingDomainNames )
+				getDomainNameValidationError( useCustomDomain, domainToValidate, existingDomainNames || [] )
 			);
 		} else {
 			setCustomDomainError( '' );

--- a/apps/studio/src/modules/add-site/components/create-site.tsx
+++ b/apps/studio/src/modules/add-site/components/create-site.tsx
@@ -31,11 +31,13 @@ export interface CreateSiteProps {
 	formRef?: RefObject< HTMLFormElement >;
 }
 
+const EMPTY_STRING_ARRAY: string[] = [];
+
 export default function CreateSite( {
 	defaultValues,
 	onSelectPath,
 	onSiteNameChange,
-	existingDomainNames = [],
+	existingDomainNames = EMPTY_STRING_ARRAY,
 	blueprintPreferredVersions,
 	blueprintSuggestedDomain,
 	blueprintSuggestedHttps,

--- a/apps/studio/src/modules/add-site/components/create-site.tsx
+++ b/apps/studio/src/modules/add-site/components/create-site.tsx
@@ -31,13 +31,11 @@ export interface CreateSiteProps {
 	formRef?: RefObject< HTMLFormElement >;
 }
 
-const EMPTY_STRING_ARRAY: string[] = [];
-
 export default function CreateSite( {
 	defaultValues,
 	onSelectPath,
 	onSiteNameChange,
-	existingDomainNames = EMPTY_STRING_ARRAY,
+	existingDomainNames,
 	blueprintPreferredVersions,
 	blueprintSuggestedDomain,
 	blueprintSuggestedHttps,

--- a/apps/studio/src/modules/site-settings/edit-site-details.tsx
+++ b/apps/studio/src/modules/site-settings/edit-site-details.tsx
@@ -63,7 +63,7 @@ const EditSiteDetails = ( { currentWpVersion, onSave }: EditSiteDetailsProps ) =
 				: currentWpVersion,
 		[ selectedSite, currentWpVersion, defaultWordPressVersion ]
 	);
-	const [ selectedWpVersion, setSelectedWpVersion ] = useState( getEffectiveWpVersion() );
+	const [ selectedWpVersion, setSelectedWpVersion ] = useState( () => getEffectiveWpVersion() );
 	const [ useCustomDomain, setUseCustomDomain ] = useState( Boolean( selectedSite?.customDomain ) );
 	const [ customDomain, setCustomDomain ] = useState< string | null >(
 		selectedSite?.customDomain ?? null

--- a/apps/studio/src/modules/sync/components/sync-sites-modal-selector.tsx
+++ b/apps/studio/src/modules/sync/components/sync-sites-modal-selector.tsx
@@ -265,6 +265,7 @@ function SiteItem( {
 				isSelected && 'bg-a8c-blue-50 text-white border-a8c-blue-50',
 				! isSelected && 'text-black border-a8c-gray-0',
 				! isSelected && isSyncable && 'hover:bg-a8c-blue-5',
+				isSyncable ? 'cursor-pointer' : 'cursor-default',
 				isSyncable &&
 					'focus:outline-none focus:ring-1 focus:ring-a8c-blue-50 focus:relative focus:z-10'
 			) }

--- a/apps/studio/src/modules/sync/components/sync-sites-modal-selector.tsx
+++ b/apps/studio/src/modules/sync/components/sync-sites-modal-selector.tsx
@@ -265,9 +265,9 @@ function SiteItem( {
 				isSelected && 'bg-a8c-blue-50 text-white border-a8c-blue-50',
 				! isSelected && 'text-black border-a8c-gray-0',
 				! isSelected && isSyncable && 'hover:bg-a8c-blue-5',
-				isSyncable ? 'cursor-pointer' : 'cursor-default',
-				isSyncable &&
-					'focus:outline-none focus:ring-1 focus:ring-a8c-blue-50 focus:relative focus:z-10'
+				isSyncable
+					? 'cursor-pointer focus:outline-none focus:ring-1 focus:ring-a8c-blue-50 focus:relative focus:z-10'
+					: 'cursor-default'
 			) }
 			role="button"
 			aria-disabled={ ! isSyncable }

--- a/apps/studio/src/modules/sync/components/sync-sites-modal-selector.tsx
+++ b/apps/studio/src/modules/sync/components/sync-sites-modal-selector.tsx
@@ -268,7 +268,8 @@ function SiteItem( {
 				isSyncable &&
 					'focus:outline-none focus:ring-1 focus:ring-a8c-blue-50 focus:relative focus:z-10'
 			) }
-			role={ isSyncable ? 'button' : undefined }
+			role="button"
+			aria-disabled={ ! isSyncable }
 			tabIndex={ isSyncable ? 0 : -1 }
 			onKeyDown={ ( e: React.KeyboardEvent ) => {
 				if ( ( e.code === 'Space' || e.code === 'Enter' ) && isSyncable ) {


### PR DESCRIPTION
## Related issues

- Related to STU-1307

## Proposed Changes

Address last set of warnings from react-doctor static analysis, except big refactors:

- Use lazy state initializer in `edit-site-details.tsx` to avoid calling `getEffectiveWpVersion()` on every render
- Extract default `[]` prop value to module-level constant in `create-site.tsx` and `create-site-form.tsx` to prevent new array reference each render
- Replace array index keys with content-based keys in `welcome-message-prompt.tsx` for stable React reconciliation when `showMore` toggles
- Always set `role="button"` with `aria-disabled` on sync site selector items instead of conditionally omitting the role

## Testing Instructions

- Start the app with `npm start`
- Verify the Add Site modal works correctly (creates sites with expected domain names)
- Verify the AI chat welcome screen renders prompts and "show more" toggle works
- Verify the Sync modal site selector shows sites and allows selection
- Verify site settings can be edited (WordPress version selector)

React doctor:

- Run `npx -y react-doctor`
- Confirm that the following four warnings don't appear anymore:

<img width="794" height="71" alt="image" src="https://github.com/user-attachments/assets/dee32f8e-476c-47a0-9d2f-25d900a33914" />

<img width="790" height="149" alt="image" src="https://github.com/user-attachments/assets/b9bf2dbc-232e-4468-9b3b-606c1efd0482" />


## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors? (Tests pass, no errors)