### PR TITLE
Add "Open Application Logs" to Help menu

### DIFF
--- a/apps/studio/src/menu.ts
+++ b/apps/studio/src/menu.ts
@@ -5,6 +5,7 @@ import {
 	BrowserWindow,
 	autoUpdater,
 	MenuItem,
+	shell,
 } from 'electron';
 import { __ } from '@wordpress/i18n';
 import { openAboutWindow } from 'src/about-menu/open-about-menu';
@@ -26,6 +27,7 @@ import { getLocalizedLink } from 'src/lib/get-localized-link';
 import { getUserLocaleWithFallback } from 'src/lib/locale-node';
 import { shellOpenExternalWrapper } from 'src/lib/shell-open-external-wrapper';
 import { promptWindowsSpeedUpSites } from 'src/lib/windows-helpers';
+import { getLogsFilePath } from 'src/logging';
 import { getMainWindow } from 'src/main-window';
 import { isUpdateReadyToInstall, manualCheckForUpdates } from 'src/updates';
 
@@ -325,6 +327,16 @@ async function getAppMenu(
 							},
 					  ]
 					: [] ),
+				{
+					label: __( 'Open Application Logs' ),
+					click: async () => {
+						const logFilePath = getLogsFilePath();
+						const err = await shell.openPath( logFilePath );
+						if ( err ) {
+							console.error( `Error opening logs file: ${ logFilePath } ${ err }` );
+						}
+					},
+				},
 				{ type: 'separator' },
 				{
 					label: __( 'Report an Issue' ),


### PR DESCRIPTION
## Related issues

- N/A (no existing Linear issue)

## Proposed Changes

I think it could be useful to make it easy for our users to access app logs in case they need to troubleshoot something - or if we need to ask them for the logs.

At the moment, it is possible to easily get to logs from error modals only (after some error is triggered already). What we could to is to add a menu item as follows. What do you think?

<img width="1060" height="384" alt="CleanShot 2026-02-24 at 17 08 24@2x" src="https://github.com/user-attachments/assets/dac67314-6a67-4900-a2f3-fae899474d7f" />

- Add an "Open Application Logs" menu item to the Help menu, placed before "Report an Issue"
- Clicking it opens the Studio log file (`current.log`) in the user's default text editor via `shell.openPath()`
- Uses the existing `getLogsFilePath()` utility from `src/logging`, following the same pattern as the error dialog's "Open Studio Logs" button

## Testing Instructions

1. Run `npm start`
2. Open the **Help** menu
3. Verify "Open Application Logs" appears between the Windows speed-up item (or the separator on macOS) and "Report an Issue"
4. Click "Open Application Logs"
5. Verify the Studio log file opens in your default text editor

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?