### PR TITLE
Replace useEffect event handler with derived state in sync tab

### DIFF
--- a/apps/studio/src/hooks/sync-sites/use-listen-deep-link-connection.ts
+++ b/apps/studio/src/hooks/sync-sites/use-listen-deep-link-connection.ts
@@ -46,6 +46,7 @@ export function useListenDeepLinkConnection() {
 				// Only auto-open push dialog if explicitly requested (e.g., from "Publish site" button)
 				if ( autoOpenPush ) {
 					dispatch( connectedSitesActions.setSelectedRemoteSiteId( remoteSiteId ) );
+					dispatch( connectedSitesActions.openModal( 'push' ) );
 				}
 			}
 		}

--- a/apps/studio/src/modules/sync/index.tsx
+++ b/apps/studio/src/modules/sync/index.tsx
@@ -1,6 +1,6 @@
 import { check, Icon } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
-import { PropsWithChildren, useEffect, useState } from 'react';
+import { PropsWithChildren, useMemo } from 'react';
 import { ArrowIcon } from 'src/components/arrow-icon';
 import Button from 'src/components/button';
 import offlineIcon from 'src/components/offline-icon';
@@ -144,19 +144,10 @@ export function ContentTabSync( { selectedSite }: { selectedSite: SiteDetails } 
 		userId: user?.id,
 	} );
 
-	const [ selectedRemoteSite, setSelectedRemoteSite ] = useState< SyncSite | null >( null );
-
-	// Auto-select remote site when set via Redux (e.g., from deep link connection)
-	useEffect( () => {
-		if ( selectedRemoteSiteId ) {
-			const siteToSelect = syncSites.find( ( site ) => site.id === selectedRemoteSiteId );
-			if ( siteToSelect ) {
-				setSelectedRemoteSite( siteToSelect );
-				dispatch( connectedSitesActions.openModal( 'push' ) );
-				dispatch( connectedSitesActions.clearSelectedRemoteSiteId() );
-			}
-		}
-	}, [ selectedRemoteSiteId, syncSites, dispatch ] );
+	const selectedRemoteSite = useMemo(
+		() => syncSites.find( ( site ) => site.id === selectedRemoteSiteId ) ?? null,
+		[ syncSites, selectedRemoteSiteId ]
+	);
 
 	if ( ! isAuthenticated ) {
 		return <NoAuthSyncTab />;
@@ -185,7 +176,7 @@ export function ContentTabSync( { selectedSite }: { selectedSite: SiteDetails } 
 
 		if ( reduxModalMode === 'push' || reduxModalMode === 'pull' ) {
 			dispatch( connectedSitesActions.openModal( reduxModalMode ) );
-			setSelectedRemoteSite( selectedSiteFromList );
+			dispatch( connectedSitesActions.setSelectedRemoteSiteId( selectedSiteFromList.id ) );
 		} else {
 			await handleConnect( selectedSiteFromList );
 			dispatch( connectedSitesActions.closeModal() );
@@ -254,7 +245,6 @@ export function ContentTabSync( { selectedSite }: { selectedSite: SiteDetails } 
 						void pullSite( selectedRemoteSite, selectedSite, pullOptions );
 					} }
 					onRequestClose={ () => {
-						setSelectedRemoteSite( null );
 						dispatch( connectedSitesActions.closeModal() );
 					} }
 				/>


### PR DESCRIPTION
## Related issues

- Fixes STU-1307

## Proposed Changes

The `useEffect` in `ContentTabSync` was simulating an event handler — reacting to Redux state changes (`selectedRemoteSiteId`) as a signal to find a site, set local state, open a modal, and clear the signal. This is an anti-pattern flagged by `react-doctor/no-effect-event-handler`.

**Fix:**
- **Replaced `useState` + `useEffect` with `useMemo`**: `selectedRemoteSite` is now derived directly from `syncSites` + `selectedRemoteSiteId` (Redux state), eliminating the need for local state and the effect.
- **Moved `openModal('push')` into the actual event handler**: The deep link handler (`useListenDeepLinkConnection`) now dispatches `openModal('push')` directly alongside `setSelectedRemoteSiteId`, instead of relying on an effect in the consumer component to react to the Redux signal.
- **Replaced local `setSelectedRemoteSite` calls with Redux dispatches**: `handleSiteSelection` now dispatches `setSelectedRemoteSiteId` to Redux, and `onRequestClose` relies on `closeModal()` which already clears the ID.

## Testing Instructions

1. Start the app with `npm start`
3. Connect a site via the Sync tab — verify the site selector modal and push/pull dialogs work correctly
4. Test the deep link connection flow (e.g., "Publish site" button) — verify the push dialog auto-opens with the correct site selected
5. Close dialogs and verify state resets properly

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors? (Tests pass, no errors)