### PR TITLE
Studio: Allow hidden files import within wp-content

### DIFF
--- a/apps/studio/src/lib/import-export/import/handlers/backup-handler-factory.ts
+++ b/apps/studio/src/lib/import-export/import/handlers/backup-handler-factory.ts
@@ -10,9 +10,8 @@ export interface BackupHandler extends Partial< EventEmitter > {
 }
 
 const EXCLUDED_FILES_PATTERNS = [
-	/^__MACOSX\/.*/, // MacOS meta folder
-	/^\..*/, // Unix hidden files at root
-	/\/\.(?!.*\.sqlite$).*/, // Unix hidden files at subfolders, except .sqlite files
+	/^__MACOSX\/.*/, // macOS resource fork folder in zip archives
+	/(^|\/)\.DS_Store$/, // macOS Finder metadata
 ];
 
 export function isFileAllowed( filePath: string ) {

--- a/apps/studio/src/lib/import-export/tests/import/handlers/backup-handler.test.ts
+++ b/apps/studio/src/lib/import-export/tests/import/handlers/backup-handler.test.ts
@@ -127,13 +127,18 @@ describe( 'BackupHandlerFactory', () => {
 			'index.php',
 			'.hidden-file',
 			'wp-content/.hidden-file',
+			'wp-content/.gitignore',
 			'wp-content/plugins/hello.php',
 			'wp-content/themes/twentytwentyfour/theme.json',
 			'wp-content/uploads/2024/07/image.png',
+			'wp-content/.DS_Store',
 			'__MACOSX/meta-file',
 		];
 		const expectedArchiveFiles = [
 			'index.php',
+			'.hidden-file',
+			'wp-content/.hidden-file',
+			'wp-content/.gitignore',
 			'wp-content/plugins/hello.php',
 			'wp-content/themes/twentytwentyfour/theme.json',
 			'wp-content/uploads/2024/07/image.png',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

Fixes https://linear.app/a8c/issue/STU-40/hidden-files-not-imported

## Proposed Changes

This PR ensures that you can import hidden files into Studio (such as `.gitignore`) if they are located within `wp-content` folder. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
* On Studio site A, add a hidden file to `wp-content` folder e.g. `.gitignore`
* Export site A through the `Export` option in the `Export/Import` tab
* Click on `Add site`
* Select `Import from a backup`
* Use the backup from site A
* Once the import is completed, open the new site in Finder and confirm that the hidden file is present in the `wp-content` directory

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
