### PR TITLE
Fix code_freeze lane committing beta bump to wrong branch

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -211,11 +211,12 @@ lane :code_freeze do |version:, skip_confirm: false, github_username: nil|
 
   push_to_git_remote(set_upstream: true)
 
-  # Create backmerge PR from the release branch to MAIN_BRANCH so that the strings bundle is uploaded to GlotPress
-  create_backmerge_pr(source_branch: branch_name, github_username: github_username)
-
   # Create the first beta (bumps version, commits, pushes, tags, triggers build)
   new_beta_release(version: version, skip_confirm: skip_confirm)
+
+  # Create backmerge PR from the release branch to MAIN_BRANCH so that the pot strings bundle is uploaded to GlotPress once it hits trunk
+  # Important: this must come after new_beta_release because the backmerge action switches branches.
+  create_backmerge_pr(source_branch: branch_name, github_username: github_username)
 
   UI.success("Code freeze complete! Created #{branch_name} with first beta")
 end
@@ -311,7 +312,6 @@ lane :publish_release do |version:, skip_confirm: false, github_username: nil|
     name: "v#{version}"
   )
 
-  # Create backmerge PR with intermediate branch to handle conflicts
   create_backmerge_pr(source_branch: release_branch, github_username: github_username)
 
   Fastlane::Helper::GitHelper.delete_remote_branch_if_exists!(release_branch)


### PR DESCRIPTION
Relates to AINFRA-2108

## Summary

- Move `create_backmerge_pr` after `new_beta_release` in the `code_freeze` lane to fix the beta version bump being committed to the backmerge branch instead of the release branch

## Root cause

The `create_release_backmerge_pull_request` action (from release-toolkit) creates a `merge/release-X.Y.Z-into-trunk` intermediate branch and leaves git HEAD checked out on it. When `new_beta_release` subsequently runs `bump_version_commit_and_push`, it commits the version bump to the **backmerge branch** instead of the **release branch**.

The triggered build correctly targets `release/X.Y.Z`, but that branch never receives the beta bump commit, so it builds the wrong version.

## Fix

Move `create_backmerge_pr` to after `new_beta_release` in `code_freeze`. The backmerge action's branch switch no longer matters since it happens after the beta bump and build trigger.

## Pre-merge Checklist

- [x] Changes are tested locally


🤖 Generated with [Claude Code](https://claude.com/claude-code)