### PR TITLE
Only remove `@php-wasm/\d-\d` packages

### DIFF
--- a/apps/cli/vite.config.ts
+++ b/apps/cli/vite.config.ts
@@ -44,7 +44,7 @@ export default defineConfig( {
 								absolute: true,
 							} );
 
-							const webPaths = globSync( '@php-wasm/web-*/', {
+							const webPaths = globSync( '@php-wasm/web-[0-9]-[0-9]/', {
 								cwd: distCliNodeModulesPath,
 								absolute: true,
 							} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Following up on https://github.com/Automattic/studio/pull/2644

## Proposed Changes

https://github.com/Automattic/studio/pull/2644 removed all `@php-wasm/web-*` packages from the packaged `cli/node_modules` directory. This turned out to be incorrect, because `@wp-playground/blueprints` depends on `@php-wasm/web-service-worker`, which shouldn't be removed the same as `@php-wasm/web-8-2`, for example.

This PR changes the glob that looks up which modules to remove so it only targets `@php-wasm/\d-\d`.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

First and foremost, CI should pass. Second, we should generate a dev build and ensure it can start sites as intended. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
