### PR TITLE
Switch e2e plugin search test from Contact Form 7 to Jetpack Protect

### DIFF
--- a/apps/studio/e2e/site-navigation.test.ts
+++ b/apps/studio/e2e/site-navigation.test.ts
@@ -264,7 +264,7 @@ test.describe( 'Site Navigation', () => {
 
 		// Search for a plugin
 		const searchInput = page.locator( '#search-plugins' );
-		await searchInput.fill( 'Contact Form 7' );
+		await searchInput.fill( 'Jetpack Protect' );
 		await searchInput.press( 'Enter' );
 
 		// Wait for search results
@@ -273,8 +273,8 @@ test.describe( 'Site Navigation', () => {
 		// Wait for the search spinner to disappear (indicates API response received)
 		await expect( page.locator( '.spinner' ) ).toBeHidden( { timeout: 30_000 } );
 
-		// Find Contact Form 7 plugin
-		const pluginResult = page.locator( '.plugin-card-contact-form-7' ).first();
+		// Find Jetpack Protect plugin
+		const pluginResult = page.locator( '.plugin-card-jetpack-protect' ).first();
 		await expect( pluginResult ).toBeVisible( { timeout: 30_000 } );
 
 		// Install the plugin


### PR DESCRIPTION
## Related issues

- N/A

## Proposed Changes

- Replace Contact Form 7 with Jetpack Protect in the `adds new plugin` e2e test, as Contact Form 7 stopped appearing in WordPress plugin search results, causing the test to fail reliably

## Testing Instructions

- Run the e2e test: `npm run e2e` and verify the `adds new plugin` test passes

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?