### PR TITLE
Add trailing slash to wp-admin URLs to prevent redirect

### DIFF
--- a/apps/studio/src/components/content-tab-settings.tsx
+++ b/apps/studio/src/components/content-tab-settings.tsx
@@ -207,12 +207,12 @@ export function ContentTabSettings( { selectedSite }: ContentTabSettingsProps ) 
 					</SettingsRow>
 					<SettingsRow label={ __( 'Admin URL' ) }>
 						<CopyTextButton
-							text={ `${ protocol }://${ domain }/wp-admin` }
-							label={ `${ domain }/wp-admin, ${ __( 'Copy wp-admin url to clipboard' ) }` }
+							text={ `${ protocol }://${ domain }/wp-admin/` }
+							label={ `${ domain }/wp-admin/, ${ __( 'Copy wp-admin url to clipboard' ) }` }
 							copyConfirmation={ __( 'Copied!' ) }
 							data-testid="copy-wp-admin-url"
 						>
-							{ `${ domain }/wp-admin` }
+							{ `${ domain }/wp-admin/` }
 						</CopyTextButton>
 					</SettingsRow>
 				</tbody>

--- a/apps/studio/src/components/header.tsx
+++ b/apps/studio/src/components/header.tsx
@@ -16,7 +16,7 @@ export default function Header() {
 		if ( ! site.running ) {
 			await startServer( site );
 		}
-		getIpcApi().openSiteURL( site.id, '/wp-admin' );
+		getIpcApi().openSiteURL( site.id, '/wp-admin/' );
 	};
 
 	const handleOpenSiteClick = async () => {

--- a/apps/studio/src/components/tests/content-tab-settings.test.tsx
+++ b/apps/studio/src/components/tests/content-tab-settings.test.tsx
@@ -163,9 +163,9 @@ describe( 'ContentTabSettings', () => {
 		expect( screen.getByText( '7.7.7' ) ).toBeVisible();
 		expect(
 			screen.getByRole( 'button', {
-				name: 'localhost:8881/wp-admin, Copy wp-admin url to clipboard',
+				name: 'localhost:8881/wp-admin/, Copy wp-admin url to clipboard',
 			} )
-		).toHaveTextContent( 'localhost:8881/wp-admin' );
+		).toHaveTextContent( 'localhost:8881/wp-admin/' );
 	} );
 
 	test( 'allows copying the site path', async () => {
@@ -206,12 +206,12 @@ describe( 'ContentTabSettings', () => {
 		expect( copyText ).toHaveBeenCalledWith( 'http://localhost:8881' );
 
 		const wpAdminButton = screen.getByRole( 'button', {
-			name: 'localhost:8881/wp-admin, Copy wp-admin url to clipboard',
+			name: 'localhost:8881/wp-admin/, Copy wp-admin url to clipboard',
 		} );
 		expect( wpAdminButton ).toBeVisible();
 		await user.click( wpAdminButton );
 		expect( copyText ).toHaveBeenCalledTimes( 2 );
-		expect( copyText ).toHaveBeenCalledWith( 'http://localhost:8881/wp-admin' );
+		expect( copyText ).toHaveBeenCalledWith( 'http://localhost:8881/wp-admin/' );
 	} );
 
 	test( 'allows copying the site password', async () => {


### PR DESCRIPTION
## Related issues

- N/A

## Proposed Changes

- Append trailing slash to `/wp-admin/` URLs in the settings tab, header WP Admin button, and copy-to-clipboard actions. WordPress redirects `/wp-admin` to `/wp-admin/`, so using the canonical URL avoids an unnecessary redirect.

> [!NOTE]
> This has been fixed in the playground repo as part of https://github.com/WordPress/wordpress-playground/pull/3301, so this code will not strictly be required after playground version is updated to v3.1.2, but it saves one redirect, so it can be kept after the upgrade.

## Testing Instructions

1. Open a running site in Studio.
2. Click the **WP Admin** button in the header — verify the browser opens `/wp-admin/` directly without a redirect.
3. Go to the **Settings** tab and copy the Admin URL — verify the copied URL ends with `/wp-admin/`.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?