### PR TITLE
Add admin credentials to interactive site creation flow

### DIFF
--- a/apps/cli/commands/site/create.ts
+++ b/apps/cli/commands/site/create.ts
@@ -2,7 +2,7 @@ import crypto from 'crypto';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import { confirm, input, select } from '@inquirer/prompts';
+import { confirm, input, password, select } from '@inquirer/prompts';
 import { SupportedPHPVersions } from '@php-wasm/universal';
 import {
 	DEFAULT_PHP_VERSION,
@@ -565,6 +565,9 @@ export const registerCommand = ( yargs: StudioArgv ) => {
 			let phpVersion = argv.php;
 			let customDomain = argv.domain;
 			let enableHttps = !! argv.https;
+			let adminUsername = argv.adminUsername;
+			let adminPassword = argv.adminPassword;
+			let adminEmail = argv.adminEmail;
 
 			try {
 				if ( process.stdin.isTTY ) {
@@ -641,6 +644,32 @@ export const registerCommand = ( yargs: StudioArgv ) => {
 							default: false,
 						} );
 					}
+
+					if ( ! adminUsername ) {
+						adminUsername = await input( {
+							message: __( 'Admin username:' ),
+							default: 'admin',
+							validate: ( value ) => validateAdminUsername( value ) || true,
+						} );
+					}
+
+					if ( ! adminPassword ) {
+						adminPassword = await password( {
+							message: __( 'Admin password (leave empty to auto-generate):' ),
+							mask: true,
+						} );
+						if ( ! adminPassword ) {
+							adminPassword = undefined;
+						}
+					}
+
+					if ( ! adminEmail ) {
+						adminEmail = await input( {
+							message: __( 'Admin email:' ),
+							default: 'admin@localhost.com',
+							validate: ( value ) => validateAdminEmail( value ) || true,
+						} );
+					}
 				}
 			} catch {
 				// User cancelled the prompt (Ctrl+C)
@@ -658,9 +687,9 @@ export const registerCommand = ( yargs: StudioArgv ) => {
 				phpVersion,
 				customDomain,
 				enableHttps,
-				adminUsername: argv.adminUsername,
-				adminPassword: argv.adminPassword,
-				adminEmail: argv.adminEmail,
+				adminUsername,
+				adminPassword,
+				adminEmail,
 				noStart: ! argv.start,
 				skipBrowser: !! argv.skipBrowser,
 				skipLogDetails: !! argv.skipLogDetails,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

## Related issues

- Related to #2527

## Proposed Changes

- Add interactive prompts for admin username, password, and email during `studio site create`
- Username prompt shows "admin" as default and validates input
- Password prompt is masked with asterisks, allows empty input for auto-generation
- Email prompt shows "admin@localhost.com" as default
- Credentials still work via CLI flags when non-interactive mode is used
- All prompts respect precedence: CLI flags override interactive input

## Testing Instructions

- Run `studio site create` in interactive mode and verify:
  - You're prompted for admin username (after HTTPS setup)
  - You're prompted for admin password (masked input, press Enter to auto-generate)
  - You're prompted for admin email with default `admin@localhost.com`
  - Pressing Enter uses the default values
  - Invalid usernames show validation errors
  - Invalid emails show validation errors
- Run `studio site create --admin-username custom --admin-password secret` and verify:
  - Interactive prompts are skipped (flags are respected)
  - Site is created with provided credentials
- Test with Blueprints containing login credentials and verify they still work

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?