### PR TITLE
Rename VS Code labels to Visual Studio Code

### DIFF
--- a/apps/studio/src/components/tests/content-tab-overview-shortcuts-section.test.tsx
+++ b/apps/studio/src/components/tests/content-tab-overview-shortcuts-section.test.tsx
@@ -64,7 +64,7 @@ describe( 'ShortcutsSection', () => {
 		store.dispatch( { type: 'test/resetState' } );
 	} );
 
-	it( 'opens site in VS Code when the user select VS Code and clicked the button', async () => {
+	it( 'opens site in Visual Studio Code when the user select Visual Studio Code and clicked the button', async () => {
 		// Mock the IPC API with getInstalledApps returning the installed apps
 		const openURLMock = vi.fn();
 		const openAppAtPathMock = vi.fn();
@@ -91,8 +91,8 @@ describe( 'ShortcutsSection', () => {
 			<ContentTabOverview selectedSite={ selectedSite } />
 		);
 
-		// Find and click the VS Code button
-		const vscodeButton = await waitFor( () => getByText( 'VS Code' ) );
+		// Find and click the Visual Studio Code button
+		const vscodeButton = await waitFor( () => getByText( 'Visual Studio Code' ) );
 		fireEvent.click( vscodeButton );
 
 		// Verify that openURL was called with the correct path
@@ -185,7 +185,7 @@ describe( 'ShortcutsSection', () => {
 		await findByLabelText( 'Terminal' );
 		await findByLabelText( 'Cursor' );
 
-		expect( queryByLabelText( 'VS Code' ) ).not.toBeInTheDocument();
+		expect( queryByLabelText( 'Visual Studio Code' ) ).not.toBeInTheDocument();
 		expect( queryByLabelText( 'PhpStorm' ) ).not.toBeInTheDocument();
 	} );
 } );

--- a/apps/studio/src/lib/shell-open-external-wrapper.ts
+++ b/apps/studio/src/lib/shell-open-external-wrapper.ts
@@ -23,9 +23,9 @@ export const shellOpenExternalWrapper = async ( url: string ) => {
 		let title = '';
 		let message = '';
 		if ( url.startsWith( 'vscode://file/' ) ) {
-			title = __( 'Failed to open VS Code' );
+			title = __( 'Failed to open Visual Studio Code' );
 			message = __(
-				'Studio is unable to open VS Code. Please ensure it is functioning correctly.'
+				'Studio is unable to open Visual Studio Code. Please ensure it is functioning correctly.'
 			);
 		} else if ( url.startsWith( 'phpstorm://open?file=' ) ) {
 			title = __( 'Failed to open PHP Storm' );

--- a/apps/studio/src/lib/tests/is-installed.test.ts
+++ b/apps/studio/src/lib/tests/is-installed.test.ts
@@ -80,17 +80,17 @@ describe( 'isInstalled', () => {
 			isInstalled = module.isInstalled;
 		} );
 
-		it( 'detects VS Code installed in system Applications', () => {
+		it( 'detects Visual Studio Code installed in system Applications', () => {
 			mockPaths = [ '/Applications/Visual Studio Code.app' ];
 			expect( isInstalled( 'vscode' ) ).toBe( true );
 		} );
 
-		it( 'detects VS Code installed in user Applications', () => {
+		it( 'detects Visual Studio Code installed in user Applications', () => {
 			mockPaths = [ '/mock/home/path/Applications/Visual Studio Code.app' ];
 			expect( isInstalled( 'vscode' ) ).toBe( true );
 		} );
 
-		it( 'returns false when VS Code is not installed', () => {
+		it( 'returns false when Visual Studio Code is not installed', () => {
 			mockPaths = [];
 			expect( isInstalled( 'vscode' ) ).toBe( false );
 		} );
@@ -112,12 +112,12 @@ describe( 'isInstalled', () => {
 			isInstalled = module.isInstalled;
 		} );
 
-		it( 'detects VS Code installed in Program Files', () => {
+		it( 'detects Visual Studio Code installed in Program Files', () => {
 			mockPaths = [ 'D:\\Program Files\\Microsoft VS Code' ];
 			expect( isInstalled( 'vscode' ) ).toBe( true );
 		} );
 
-		it( 'detects VS Code installed in Local Programs', () => {
+		it( 'detects Visual Studio Code installed in Local Programs', () => {
 			mockPaths = [ 'C:\\Users\\TestUser\\AppData\\Local\\Programs\\Microsoft VS Code' ];
 			expect( isInstalled( 'vscode' ) ).toBe( true );
 		} );

--- a/apps/studio/src/modules/user-settings/lib/editor.ts
+++ b/apps/studio/src/modules/user-settings/lib/editor.ts
@@ -31,8 +31,8 @@ export const supportedEditorConfig: Record< SupportedEditor, SupportedEditorConf
 		],
 	},
 	vscode: {
-		// translators: "VS Code" is the brand name for an IDE and does not need to be translated
-		label: __( 'VS Code' ),
+		// translators: "Visual Studio Code" is the brand name for an IDE and does not need to be translated
+		label: __( 'Visual Studio Code' ),
 		url: ( path: string ) => `vscode://file/${ path }?windowId=_blank`,
 		macOSBundleId: 'com.microsoft.VSCode',
 		winPaths: [

--- a/apps/studio/src/tests/show-site-context-menu.test.ts
+++ b/apps/studio/src/tests/show-site-context-menu.test.ts
@@ -73,7 +73,7 @@ describe( 'showSiteContextMenu', () => {
 		siteId: 'test-site-id',
 		isAnySiteAdding: false,
 		finderLabel: 'Finder',
-		editorLabel: 'VS Code',
+		editorLabel: 'Visual Studio Code',
 		terminalLabel: 'Terminal',
 	};
 
@@ -130,7 +130,7 @@ describe( 'showSiteContextMenu', () => {
 			const openSiteItem = menuItems.find( ( item ) => item.label === 'Open site' );
 			const wpAdminItem = menuItems.find( ( item ) => item.label === 'WP admin' );
 			const finderItem = menuItems.find( ( item ) => item.label === 'Open in Finder' );
-			const editorItem = menuItems.find( ( item ) => item.label === 'Open in VS Code' );
+			const editorItem = menuItems.find( ( item ) => item.label === 'Open in Visual Studio Code' );
 			const terminalItem = menuItems.find( ( item ) => item.label === 'Open in Terminal' );
 			const editItem = menuItems.find( ( item ) => item.label === 'Edit site…' );
 			const deleteItem = menuItems.find( ( item ) => item.label === 'Delete site…' );
@@ -173,7 +173,7 @@ describe( 'showSiteContextMenu', () => {
 			const openSiteItem = menuItems.find( ( item ) => item.label === 'Open site' );
 			const wpAdminItem = menuItems.find( ( item ) => item.label === 'WP admin' );
 			const finderItem = menuItems.find( ( item ) => item.label === 'Open in Finder' );
-			const editorItem = menuItems.find( ( item ) => item.label === 'Open in VS Code' );
+			const editorItem = menuItems.find( ( item ) => item.label === 'Open in Visual Studio Code' );
 			const terminalItem = menuItems.find( ( item ) => item.label === 'Open in Terminal' );
 			const editItem = menuItems.find( ( item ) => item.label === 'Edit site…' );
 			const copyItem = menuItems.find( ( item ) => item.label === 'Copy site…' );
@@ -296,8 +296,8 @@ describe( 'showSiteContextMenu', () => {
 			);
 		} );
 
-		it( 'should send open-editor action when Open in VS Code is clicked', () => {
-			const editorItem = menuItems.find( ( item ) => item.label === 'Open in VS Code' );
+		it( 'should send open-editor action when Open in Visual Studio Code is clicked', () => {
+			const editorItem = menuItems.find( ( item ) => item.label === 'Open in Visual Studio Code' );
 			editorItem?.click?.();
 
 			expect( sendIpcEventToRendererWithWindow ).toHaveBeenCalledWith(


### PR DESCRIPTION
## Related issues

- N/A

## How AI was used in this PR

Claude Code was used to identify all occurrences of "VS Code" and update them to "Visual Studio Code". 

## Proposed Changes

I propose changing the app name to one that is used on the app website and in the app itself:
- Update editor label from `VS Code` to `Visual Studio Code` in `editor.ts`
- Update error dialog title and message in `shell-open-external-wrapper.ts`
- Update all test references to match the new label

<img width="2024" height="1424" alt="CleanShot 2026-03-05 at 16 36 48@2x" src="https://github.com/user-attachments/assets/66830d0e-7702-4c97-a323-bf859adbc78c" />


## Testing Instructions

- Open a local site and check the editor shortcut button in the Overview tab — it should now read "Visual Studio Code"

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?