### PR TITLE
[Tooling] Upload CDN builds as drafts, publish in publish_release

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -274,7 +274,7 @@ lane :finalize_release do |version:, skip_confirm: false|
     Finalizing release #{version}. This will:
     - Bump version to #{version} (remove beta suffix)
     - Trigger a release build for all platforms (macOS, Windows), which will then:
-      - Upload build artifacts to the Apps CDN (as Internal, visible only to Automatticians)
+      - Upload build artifacts to the Apps CDN (as drafts, published later by publish_release)
       - Create a draft GitHub release with release notes and download links
       - Notify #dotcom-studio on Slack
   PROMPT
@@ -300,7 +300,7 @@ lane :publish_release do |version:, skip_confirm: false, github_username: nil|
 
   UI.important <<~PROMPT
     Publishing release #{version}. This will:
-    - Make CDN builds public (change visibility from Internal to External)
+    - Publish CDN builds (change post status from draft to publish)
     - Publish the draft GitHub release for v#{version}
     - Create a backmerge PR from `#{release_branch}` into `#{MAIN_BRANCH}`
     - Delete the `#{release_branch}` branch after creating the backmerge PR
@@ -585,7 +585,8 @@ def distribute_builds(
       arch: build[:arch],
       build_type: build_type,
       install_type: build[:install_type],
-      visibility: :internal,
+      visibility: :external,
+      post_status: release_tag&.match?(/beta/i) ? nil : 'draft',
       version: version,
       build_number: build_number,
       release_notes: release_notes,
@@ -823,10 +824,11 @@ def create_draft_github_release(version:, release_tag:, builds:)
   UI.success("Created draft GitHub release #{release_tag} with download links")
 end
 
-# Make CDN builds public by updating their visibility from Internal to External.
+# Publish CDN builds by changing their post status from draft to publish.
 #
-# Queries the Apps CDN API to find internal builds matching the version,
-# then calls {update_apps_cdn_build_metadata} for each to set visibility to External.
+# Queries the Apps CDN API to find draft builds matching the version,
+# then calls {update_apps_cdn_build_metadata} for each to set status to publish.
+# This is idempotent: if no drafts are found (already published), it logs a warning and returns.
 #
 # @param version [String] The version to publish (e.g., '1.7.5')
 #
@@ -835,26 +837,26 @@ def make_cdn_builds_public(version:)
   builds = list_apps_cdn_builds(
     site_id: WPCOM_STUDIO_SITE_ID,
     version: release_version,
-    visibility: :internal
+    post_status: 'draft'
   )
 
   if builds.empty?
-    UI.important("No internal CDN builds found for #{release_version}. They may have already been made public.")
+    UI.important("No draft CDN builds found for #{release_version}. They may have already been published.")
     return
   end
 
-  UI.message("Updating CDN build visibility to External for #{builds.size} builds...")
+  UI.message("Publishing #{builds.size} CDN build(s) for #{release_version}...")
 
   builds.each do |build|
-    UI.message("  Updating #{build[:title]} (post #{build[:post_id]})...")
+    UI.message("  Publishing #{build[:title]} (post #{build[:post_id]})...")
     update_apps_cdn_build_metadata(
       site_id: WPCOM_STUDIO_SITE_ID,
       post_id: build[:post_id],
-      visibility: :external
+      post_status: 'publish'
     )
   end
 
-  UI.success('All CDN builds are now public (External visibility)')
+  UI.success('All CDN builds are now published')
 end
 
 # Trigger a release build in Buildkite for the given version.

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -274,7 +274,7 @@ lane :finalize_release do |version:, skip_confirm: false|
     Finalizing release #{version}. This will:
     - Bump version to #{version} (remove beta suffix)
     - Trigger a release build for all platforms (macOS, Windows), which will then:
-      - Upload build artifacts to the Apps CDN
+      - Upload build artifacts to the Apps CDN (as Internal, visible only to Automatticians)
       - Create a draft GitHub release with release notes and download links
       - Notify #dotcom-studio on Slack
   PROMPT
@@ -300,11 +300,15 @@ lane :publish_release do |version:, skip_confirm: false, github_username: nil|
 
   UI.important <<~PROMPT
     Publishing release #{version}. This will:
+    - Make CDN builds public (change visibility from Internal to External)
     - Publish the draft GitHub release for v#{version}
     - Create a backmerge PR from `#{release_branch}` into `#{MAIN_BRANCH}`
     - Delete the `#{release_branch}` branch after creating the backmerge PR
   PROMPT
   next unless skip_confirm || UI.confirm('Continue?')
+
+  # Update CDN build visibility from Internal to External
+  make_cdn_builds_public(version: version)
 
   # Publish the draft GitHub release
   publish_github_release(
@@ -581,7 +585,7 @@ def distribute_builds(
       arch: build[:arch],
       build_type: build_type,
       install_type: build[:install_type],
-      visibility: 'external',
+      visibility: :internal,
       version: version,
       build_number: build_number,
       release_notes: release_notes,
@@ -817,6 +821,37 @@ def create_draft_github_release(version:, release_tag:, builds:)
   )
 
   UI.success("Created draft GitHub release #{release_tag} with download links")
+end
+
+# Make CDN builds public by updating their visibility from Internal to External.
+#
+# Queries the Apps CDN API to find internal builds matching the version,
+# then calls {update_apps_cdn_build_metadata} for each to set visibility to External.
+#
+# @param version [String] The version to publish (e.g., '1.7.5')
+#
+def make_cdn_builds_public(version:)
+  release_version = "v#{version}"
+  builds = list_apps_cdn_builds(
+    site_id: WPCOM_STUDIO_SITE_ID,
+    version: release_version,
+    visibility: :internal
+  )
+
+  UI.user_error!("No internal CDN builds found for #{release_version}. Cannot publish without updating CDN visibility.") if builds.empty?
+
+  UI.message("Updating CDN build visibility to External for #{builds.size} builds...")
+
+  builds.each do |build|
+    UI.message("  Updating #{build[:title]} (post #{build[:post_id]})...")
+    update_apps_cdn_build_metadata(
+      site_id: WPCOM_STUDIO_SITE_ID,
+      post_id: build[:post_id],
+      visibility: :external
+    )
+  end
+
+  UI.success('All CDN builds are now public (External visibility)')
 end
 
 # Trigger a release build in Buildkite for the given version.

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -838,7 +838,10 @@ def make_cdn_builds_public(version:)
     visibility: :internal
   )
 
-  UI.user_error!("No internal CDN builds found for #{release_version}. Cannot publish without updating CDN visibility.") if builds.empty?
+  if builds.empty?
+    UI.important("No internal CDN builds found for #{release_version}. They may have already been made public.")
+    return
+  end
 
   UI.message("Updating CDN build visibility to External for #{builds.size} builds...")
 


### PR DESCRIPTION
## Related issues

- This PR depends on the PRs:
  - wordpress-mobile/release-toolkit#701 (adds `update_apps_cdn_build_metadata` action)
  - wordpress-mobile/release-toolkit#702 (adds `list_apps_cdn_builds` action)
- Fixes AINFRA-2102

## How AI was used in this PR

Claude Code was used to implement the Fastfile changes based on a detailed plan I designed. I reviewed all generated code.

## Proposed Changes

- Upload all non-beta CDN builds as **drafts** with external visibility (previously published immediately), so they're not publicly accessible during the testing period
- Beta builds continue to be published immediately (no `post_status: 'draft'`)
- Add `make_cdn_builds_public` helper that queries the CDN API via `list_apps_cdn_builds` to find draft builds for the release version, then publishes each via `update_apps_cdn_build_metadata`
- Call `make_cdn_builds_public` in `publish_release` before publishing the GitHub release
- Update `finalize_release` prompt to mention the new draft behavior

### Why drafts instead of internal visibility?

Integration testing against the real CDN API revealed that posts with `visibility: internal` are completely hidden from all listing queries (by CDN plugin design), making it impossible to find and flip them later. The draft/publish approach works reliably and is idempotent — re-running when no drafts exist is a safe no-op.

## Testing Instructions

- Full end-to-end testing will happen during the next release cycle
- The draft→publish flow was manually verified against the real CDN API

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?

🤖 Generated with [Claude Code](https://claude.com/claude-code)