### PR TITLE
Fix removing sites when site folder is already removed

### DIFF
--- a/apps/cli/commands/site/delete.ts
+++ b/apps/cli/commands/site/delete.ts
@@ -1,3 +1,4 @@
+import fs from 'fs';
 import { arePathsEqual } from '@studio/common/lib/fs-utils';
 import { SITE_EVENTS } from '@studio/common/lib/site-events';
 import { SiteCommandLoggerAction as LoggerAction } from '@studio/common/logger-actions';
@@ -118,13 +119,17 @@ export async function runCommand(
 		}
 
 		if ( deleteFiles ) {
-			logger.reportStart( LoggerAction.DELETE_FILES, __( 'Moving site files to trash…' ) );
-			// We configure `trash` as an external module, since it includes a native macOS binary that Vite
-			// inlines as a base64 string, which produces a runtime error. Since `trash` is also an ESM-only
-			// module, we need to import it dynamically (since Rollup doesn't get a chance to process it)
-			const trash = ( await import( 'trash' ) ).default;
-			await trash( siteFolder );
-			logger.reportSuccess( __( 'Site files moved to trash' ) );
+			if ( fs.existsSync( siteFolder ) ) {
+				logger.reportStart( LoggerAction.DELETE_FILES, __( 'Moving site files to trash…' ) );
+				// We configure `trash` as an external module, since it includes a native macOS binary that Vite
+				// inlines as a base64 string, which produces a runtime error. Since `trash` is also an ESM-only
+				// module, we need to import it dynamically (since Rollup doesn't get a chance to process it)
+				const trash = ( await import( 'trash' ) ).default;
+				await trash( siteFolder );
+				logger.reportSuccess( __( 'Site files moved to trash' ) );
+			} else {
+				logger.reportSuccess( __( 'Site files already removed' ) );
+			}
 		}
 
 		await emitSiteEvent( SITE_EVENTS.DELETED, { siteId: site.id } );

--- a/apps/cli/commands/site/tests/delete.test.ts
+++ b/apps/cli/commands/site/tests/delete.test.ts
@@ -1,3 +1,4 @@
+import fs from 'fs';
 import { arePathsEqual } from '@studio/common/lib/fs-utils';
 import trash from 'trash';
 import { vi } from 'vitest';
@@ -117,6 +118,7 @@ describe( 'CLI: studio site delete', () => {
 		vi.mocked( deleteSnapshotFromAppdata ).mockResolvedValue( undefined );
 		vi.mocked( stopProxyIfNoSitesNeedIt ).mockResolvedValue( undefined );
 		vi.mocked( arePathsEqual ).mockImplementation( ( a: string, b: string ) => a === b );
+		vi.spyOn( fs, 'existsSync' ).mockReturnValue( true );
 	} );
 
 	afterEach( () => {
@@ -284,6 +286,19 @@ describe( 'CLI: studio site delete', () => {
 
 			expect( removeDomainFromHosts ).toHaveBeenCalledWith( 'example.local' );
 			expect( deleteSiteCertificate ).toHaveBeenCalledWith( 'example.local' );
+			expect( disconnect ).toHaveBeenCalled();
+		} );
+
+		it( 'should skip file deletion when site directory no longer exists', async () => {
+			vi.spyOn( fs, 'existsSync' ).mockReturnValue( false );
+			vi.mocked( getSnapshotsFromAppdata ).mockResolvedValue( [] );
+
+			await runCommand( testSiteFolder, true );
+
+			expect( saveAppdata ).toHaveBeenCalled();
+			const savedAppdata = vi.mocked( saveAppdata ).mock.calls[ 0 ][ 0 ];
+			expect( savedAppdata.sites ).toHaveLength( 0 );
+			expect( trash ).not.toHaveBeenCalled();
 			expect( disconnect ).toHaveBeenCalled();
 		} );
 

--- a/tools/common/lib/fs-utils.ts
+++ b/tools/common/lib/fs-utils.ts
@@ -64,8 +64,7 @@ export function isWordPressDirectory( projectPath: string ): boolean {
 // `fs.Stats.dev` signifies the device ID, and `fs.Stats.ino` signifies the inode number
 // that uniquely identifies the file or directory. This approach respects the current file
 // system's case sensitivity.
-// Falls back to string comparison when either path doesn't exist (e.g., deleted directories),
-// using case-insensitive comparison on macOS/Windows.
+// Falls back to string comparison when either path doesn't exist (e.g., deleted directories).
 export function arePathsEqual( path1: string, path2: string ) {
 	try {
 		const stats1 = fs.statSync( path.resolve( path1 ) );

--- a/tools/common/lib/fs-utils.ts
+++ b/tools/common/lib/fs-utils.ts
@@ -73,7 +73,7 @@ export function arePathsEqual( path1: string, path2: string ) {
 
 		return stats1.ino === stats2.ino && stats1.dev === stats2.dev;
 	} catch ( error ) {
-		return path.resolve( path1 ).toLowerCase() === path.resolve( path2 ).toLowerCase();
+		return path.resolve( path1 ) === path.resolve( path2 );
 	}
 }
 

--- a/tools/common/lib/fs-utils.ts
+++ b/tools/common/lib/fs-utils.ts
@@ -60,10 +60,12 @@ export function isWordPressDirectory( projectPath: string ): boolean {
 	);
 }
 
-// Compare paths in a case-insensitive manner. `fs.Stats.dev` signifies the device ID, and
-// `fs.Stats.ino` signifies the inode number that uniquely identifies the file or directory.
-// The benefit of this approach over converting the entire path to lowercase is that it respects
-// the current file system's case sensitivity.
+// Compare paths, preferring inode comparison when both paths exist on disk.
+// `fs.Stats.dev` signifies the device ID, and `fs.Stats.ino` signifies the inode number
+// that uniquely identifies the file or directory. This approach respects the current file
+// system's case sensitivity.
+// Falls back to string comparison when either path doesn't exist (e.g., deleted directories),
+// using case-insensitive comparison on macOS/Windows.
 export function arePathsEqual( path1: string, path2: string ) {
 	try {
 		const stats1 = fs.statSync( path.resolve( path1 ) );
@@ -71,7 +73,7 @@ export function arePathsEqual( path1: string, path2: string ) {
 
 		return stats1.ino === stats2.ino && stats1.dev === stats2.dev;
 	} catch ( error ) {
-		return false;
+		return path.resolve( path1 ).toLowerCase() === path.resolve( path2 ).toLowerCase();
 	}
 }
 


### PR DESCRIPTION
## Related issues
- Fixes STU-1319

## How AI was used in this PR
AI wrote code; I thoroughly reviewed it and did a few more iterations to polish the solution. I considered another solution (p1772624822355439/1772022345.939889-slack-C06DRMD6VPZ), but ultimately decided to go with this mutual  proposition from AI and Fredrik (p1772626864886569/1772022345.939889-slack-C06DRMD6VPZ).


## Proposed Changes
The issue - if user removed site folder manually, then `studio site delete` fails and the site remains in the `studio site list`.
This PR fixes delete command in thsi case.

## Testing Instructions
1. `npm run cli:build`
2. Create a site - `node apps/cli/dist/cli/main.js site create --path=~/Studio/qqq`
3. Remove site folder - `rm -rf ~/Studio/qqq`
4. Remove site via cli - `node apps/cli/dist/cli/main.js site delete --path=~/Studio/qqq --files`
5. Previously we got error. Now - `Site files already removed` is printed and no errors and `node apps/cli/dist/cli/main.js site list` shows that the site was removed from Studio

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?