### PR TITLE
Fix database import failure after Playground 3.1.4 upgrade

### DIFF
--- a/apps/cli/lib/run-wp-cli-command.ts
+++ b/apps/cli/lib/run-wp-cli-command.ts
@@ -5,6 +5,7 @@ import {
 	SupportedPHPVersion,
 	PHP,
 	setPhpIniEntries,
+	ProcessIdAllocator,
 } from '@php-wasm/universal';
 import { createSpawnHandler } from '@php-wasm/util';
 import { cleanupLegacyMuPlugins, getMuPlugins } from '@studio/common/lib/mu-plugins';
@@ -13,6 +14,7 @@ import { __ } from '@wordpress/i18n';
 import { setupPlatformLevelMuPlugins } from '@wp-playground/wordpress';
 import { getSqliteCommandPath, getWpCliPharPath } from 'cli/lib/server-files';
 
+const processIdAllocator = new ProcessIdAllocator();
 const PLAYGROUND_INTERNAL_SHARED_FOLDER = '/internal/shared';
 
 /**
@@ -49,6 +51,9 @@ export async function runWpCliCommand(
 		followSymlinks: true,
 		withRedis: true,
 		withMemcached: true,
+		emscriptenOptions: {
+			processId: processIdAllocator.claim(),
+		},
 	} );
 	const php = new PHP( id );
 
@@ -106,6 +111,9 @@ export async function runGlobalWpCliCommand(
 		followSymlinks: true,
 		withRedis: true,
 		withMemcached: true,
+		emscriptenOptions: {
+			processId: processIdAllocator.claim(),
+		},
 	} );
 	const php = new PHP( id );
 


### PR DESCRIPTION
## Related issues

- Fixes STU-1374

## Proposed Changes

Playground 3.1.4 introduced a mandatory `processId` for PHP WASM initialization (used for file locking). The `loadNodeRuntime` calls in `run-wp-cli-command.ts` didn't provide this, causing `PHPLoader.processId must be set before init` errors during database import. This PR fixes wp-cli executions like sqlite import.

- Import `ProcessIdAllocator` from `@php-wasm/universal`
- Create a module-level allocator and pass unique `processId` via `emscriptenOptions` to both `loadNodeRuntime` calls

The site startup path (`runCLI` from `@wp-playground/cli`) is unaffected because it handles `processId` internally.

## Testing Instructions

1. Start the app with `npm start`
2. Create a site, add some content
3. Export the site
4. Import the backup into a new site
5. Verify the database import succeeds without errors

**Before**
<img width="1012" height="712" alt="Screenshot 2026-03-05 at 12 26 03" src="https://github.com/user-attachments/assets/130b9d6e-ae21-4eec-afba-bf96cc48f75a" />


**After**


https://github.com/user-attachments/assets/a8e50544-70f8-45b9-a433-c93fe2e49785



## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors? (Tests pass, no errors)