### PR TITLE
Remove en-dash substitution from GitHub release build names

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -753,8 +753,7 @@ def create_draft_github_release(version:, release_tag:, builds:)
     build = builds[key]
     next unless build&.dig(:cdn_url)
 
-    label = build[:name].sub(' - ', ' \u2013 ') # Use en-dash like existing releases
-    "[#{label}](#{build[:cdn_url]})"
+    "[#{build[:name]}](#{build[:cdn_url]})"
   end
 
   body = notes


### PR DESCRIPTION
## Proposed Changes

- Remove the en-dash (`–`) substitution for hyphens (`-`) in build names when creating draft GitHub releases. The original build names are used as-is.

## Testing Instructions

- In the next release verify that GitHub release draft creation uses build names without en-dash substitution.
