### PR TITLE
Update GitHub release title format from 'vX.Y.Z' to 'Version X.Y.Z'

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -334,7 +334,7 @@ lane :publish_release do |version:, skip_confirm: false, github_username: nil|
   # Publish the draft GitHub release
   publish_github_release(
     repository: GITHUB_REPO,
-    name: "v#{version}"
+    name: "Version #{version}"
   )
 
   create_backmerge_pr(source_branch: release_branch, github_username: github_username)
@@ -766,6 +766,7 @@ def create_draft_github_release(version:, release_tag:, builds:)
   File.write(release_notes_path, body)
 
   base_version = version.sub(/-beta\d+$/, '')
+  release_name = "Version #{version}"
   create_github_release(
     repository: GITHUB_REPO,
     version: release_tag,
@@ -776,7 +777,14 @@ def create_draft_github_release(version:, release_tag:, builds:)
     is_draft: true
   )
 
-  UI.success("Created draft GitHub release #{release_tag} with download links")
+  # Update the release title from the default tag-based name to a human-readable format
+  github_token = get_required_env('GITHUB_TOKEN')
+  github_client = Octokit::Client.new(access_token: github_token)
+  releases = github_client.releases(GITHUB_REPO)
+  draft_release = releases.find { |r| r.name == release_tag }
+  github_client.update_release(draft_release.url, name: release_name) if draft_release
+
+  UI.success("Created draft GitHub release '#{release_name}' with download links")
 end
 
 # Trigger a release build in Buildkite for the given version.


### PR DESCRIPTION
## Related issues

- Fixes STU-1384

## Proposed Changes

- Changes the GitHub release display name from `v1.7.5` to `Version 1.7.5` for a more human-readable format
- The git tag remains unchanged as `v1.7.5`
- Updates both `create_draft_github_release` and `publish_release` lane to use the new name format
- After the release-toolkit creates the draft with the tag-based name, an Octokit API call renames it to the `Version X.Y.Z` format

## Testing Instructions

1. Review the diff in `fastlane/Fastfile`
2. Verify the `create_draft_github_release` method now sets `release_name = "Version #{version}"` and updates the draft release name via the GitHub API
3. Verify the `publish_release` lane now looks for the draft by `"Version #{version}"` instead of `"v#{version}"`

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors? (Tests pass, no errors)