### PR TITLE
Remove express dependency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -82,7 +82,6 @@ updates:
       - dependency-name: "tar"
 
       # HTTP & networking
-      - dependency-name: "express"
       - dependency-name: "http-proxy"
       - dependency-name: "hpagent"
       - dependency-name: "follow-redirects"
@@ -233,7 +232,6 @@ updates:
 
       http-networking:
         patterns:
-          - "express"
           - "http-proxy"
           - "hpagent"
           - "follow-redirects"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,7 @@ WordPress Studio - Electron desktop app for managing local WordPress sites. Buil
 ## Tech Stack
 
 **Frontend**: React 18, Redux Toolkit + RTK Query, @wordpress/components, TailwindCSS, TypeScript, Vite
-**Main**: Electron, express
+**Main**: Electron
 **CLI**: @wp-playground/cli, @php-wasm/node, @wp-playground/blueprints
 **Dev**: electron-vite, electron-forge, Vitest, Playwright
 **Other**: Sentry, wpcom, zod, yargs

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -51,7 +51,6 @@
 		"date-fns": "^3.3.1",
 		"electron-squirrel-startup": "^1.0.1",
 		"electron2appx": "2.1.2",
-		"express": "4.22.1",
 		"fast-deep-equal": "^3.1.3",
 		"file-stream-rotator": "^1.0.0",
 		"follow-redirects": "^1.15.11",

--- a/package-lock.json
+++ b/package-lock.json
@@ -109,7 +109,6 @@
 				"date-fns": "^3.3.1",
 				"electron-squirrel-startup": "^1.0.1",
 				"electron2appx": "2.1.2",
-				"express": "4.22.1",
 				"fast-deep-equal": "^3.1.3",
 				"file-stream-rotator": "^1.0.0",
 				"follow-redirects": "^1.15.11",
@@ -767,70 +766,6 @@
 				"node": ">= 12"
 			}
 		},
-		"apps/studio/node_modules/encodeurl": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
-			"integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
-		"apps/studio/node_modules/express": {
-			"version": "4.22.1",
-			"resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
-			"integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
-			"license": "MIT",
-			"dependencies": {
-				"accepts": "~1.3.8",
-				"array-flatten": "1.1.1",
-				"body-parser": "~1.20.3",
-				"content-disposition": "~0.5.4",
-				"content-type": "~1.0.4",
-				"cookie": "~0.7.1",
-				"cookie-signature": "~1.0.6",
-				"debug": "2.6.9",
-				"depd": "2.0.0",
-				"encodeurl": "~2.0.0",
-				"escape-html": "~1.0.3",
-				"etag": "~1.8.1",
-				"finalhandler": "~1.3.1",
-				"fresh": "~0.5.2",
-				"http-errors": "~2.0.0",
-				"merge-descriptors": "1.0.3",
-				"methods": "~1.1.2",
-				"on-finished": "~2.4.1",
-				"parseurl": "~1.3.3",
-				"path-to-regexp": "~0.1.12",
-				"proxy-addr": "~2.0.7",
-				"qs": "~6.14.0",
-				"range-parser": "~1.2.1",
-				"safe-buffer": "5.2.1",
-				"send": "~0.19.0",
-				"serve-static": "~1.16.2",
-				"setprototypeof": "1.2.0",
-				"statuses": "~2.0.1",
-				"type-is": "~1.6.18",
-				"utils-merge": "1.0.1",
-				"vary": "~1.1.2"
-			},
-			"engines": {
-				"node": ">= 0.10.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/express"
-			}
-		},
-		"apps/studio/node_modules/express/node_modules/debug": {
-			"version": "2.6.9",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-			"license": "MIT",
-			"dependencies": {
-				"ms": "2.0.0"
-			}
-		},
 		"apps/studio/node_modules/iconv-lite": {
 			"version": "0.7.2",
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
@@ -847,12 +782,6 @@
 				"url": "https://opencollective.com/express"
 			}
 		},
-		"apps/studio/node_modules/ms": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-			"license": "MIT"
-		},
 		"apps/studio/node_modules/mute-stream": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-3.0.0.tgz",
@@ -861,26 +790,6 @@
 			"engines": {
 				"node": "^20.17.0 || >=22.9.0"
 			}
-		},
-		"apps/studio/node_modules/safe-buffer": {
-			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"license": "MIT"
 		},
 		"apps/studio/node_modules/signal-exit": {
 			"version": "4.1.0",


### PR DESCRIPTION
## Related issues

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

- N/A

## How AI was used in this PR

<!--
Help reviewers understand what to look for and verify that you've reviewed the code yourself.
-->

I used AI to search for `express` usage to validate the changes.

## Proposed Changes

I propose removing `express` dependency from Studio app. While reviewing https://github.com/Automattic/studio/pull/2718 I noticed this is installed, but not even used.

We've added this dependency in https://github.com/Automattic/studio/pull/81, and it's unclear why. A possible explanation is that we wanted to update `express`, the other package dependency, from 4.18.2 to 4.19.2, and we added it as an explicit dependency in the main node. Now, all dependencies resolve to 4.22.0, so we should be good.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Confirm builds go through.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
