### PR TITLE
Add dev-only Open Appdata option in Help menu

### DIFF
--- a/apps/studio/src/menu.ts
+++ b/apps/studio/src/menu.ts
@@ -178,6 +178,16 @@ async function getAppMenu(
 								label: __( 'Feature Flags' ),
 								submenu: featureFlagsMenu,
 							},
+							{
+								label: __( 'Open Appdata File (dev only)' ),
+								click: async () => {
+									const appdataPath = getUserDataFilePath();
+									const err = await shell.openPath( appdataPath );
+									if ( err ) {
+										console.error( `Error opening appdata file: ${ appdataPath } ${ err }` );
+									}
+								},
+							},
 					  ]
 					: [] ),
 				{ type: 'separator' },
@@ -338,20 +348,6 @@ async function getAppMenu(
 						}
 					},
 				},
-				...( process.env.NODE_ENV === 'development'
-					? [
-							{
-								label: __( 'Open Appdata File' ),
-								click: async () => {
-									const appdataPath = getUserDataFilePath();
-									const err = await shell.openPath( appdataPath );
-									if ( err ) {
-										console.error( `Error opening appdata file: ${ appdataPath } ${ err }` );
-									}
-								},
-							},
-					  ]
-					: [] ),
 				{ type: 'separator' },
 				{
 					label: __( 'Report an Issue' ),

--- a/apps/studio/src/menu.ts
+++ b/apps/studio/src/menu.ts
@@ -29,6 +29,7 @@ import { shellOpenExternalWrapper } from 'src/lib/shell-open-external-wrapper';
 import { promptWindowsSpeedUpSites } from 'src/lib/windows-helpers';
 import { getLogsFilePath } from 'src/logging';
 import { getMainWindow } from 'src/main-window';
+import { getUserDataFilePath } from 'src/storage/paths';
 import { isUpdateReadyToInstall, manualCheckForUpdates } from 'src/updates';
 
 export async function setupMenu( config: {
@@ -337,6 +338,20 @@ async function getAppMenu(
 						}
 					},
 				},
+				...( process.env.NODE_ENV === 'development'
+					? [
+							{
+								label: __( 'Open Appdata File' ),
+								click: async () => {
+									const appdataPath = getUserDataFilePath();
+									const err = await shell.openPath( appdataPath );
+									if ( err ) {
+										console.error( `Error opening appdata file: ${ appdataPath } ${ err }` );
+									}
+								},
+							},
+					  ]
+					: [] ),
 				{ type: 'separator' },
 				{
 					label: __( 'Report an Issue' ),

--- a/apps/studio/src/menu.ts
+++ b/apps/studio/src/menu.ts
@@ -175,10 +175,6 @@ async function getAppMenu(
 				...( process.env.NODE_ENV === 'development'
 					? [
 							{
-								label: __( 'Feature Flags' ),
-								submenu: featureFlagsMenu,
-							},
-							{
 								label: __( 'Open Appdata File (dev only)' ),
 								click: async () => {
 									const appdataPath = getUserDataFilePath();
@@ -187,6 +183,10 @@ async function getAppMenu(
 										console.error( `Error opening appdata file: ${ appdataPath } ${ err }` );
 									}
 								},
+							},
+							{
+								label: __( 'Feature Flags' ),
+								submenu: featureFlagsMenu,
 							},
 					  ]
 					: [] ),


### PR DESCRIPTION
## Related issues

- N/A

## How AI was used in this PR

One shot prompt, tested manually

## Proposed Changes

- Added "Open Appdata File" menu item in the Help menu
- Menu item only appears in development mode (`NODE_ENV === 'development'`)
- Clicking the menu item opens `appdata-v1.json` file with the system's default application
- Added import of `getUserDataFilePath` from storage paths module

<img width="888" height="597" alt="image" src="https://github.com/user-attachments/assets/0023f8bb-8bf3-449a-8771-b93b49bb2afe" />

## Testing Instructions

1. Run Studio in development mode (`npm start`)
2. Open the Help menu
3. Verify "Open Appdata File" menu item appears (below "Open Application Logs")
4. Click on "Open Appdata File"
5. Verify the appdata-v1.json file opens in your default editor
6. Build for production and verify the menu item does NOT appear in Help menu

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?