### PR TITLE
Fix studio ai /exit command hanging

### DIFF
--- a/apps/cli/commands/ai.ts
+++ b/apps/cli/commands/ai.ts
@@ -162,6 +162,7 @@ export async function runCommand(): Promise< void > {
 		}
 	} finally {
 		ui.stop();
+		process.exit( 0 );
 	}
 }
 


### PR DESCRIPTION
## Related issues

- N/A

## How AI was used in this PR

AI identified the root cause and wrote the one-line fix.

## Proposed Changes

- Add `process.exit(0)` after `ui.stop()` in the `/exit` path. The TUI library keeps the event loop alive (raw stdin listeners/timers), so the process hangs after `/exit`. Ctrl+C already called `process.exit(0)` but the `/exit` slash command did not.

## Testing Instructions

- Run `studio ai`, then type `/exit` — process should return to the shell immediately.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?