### PR TITLE
Add `/browser` slash command to AI chat

### DIFF
--- a/apps/cli/ai/slash-commands.ts
+++ b/apps/cli/ai/slash-commands.ts
@@ -3,10 +3,12 @@ export interface SlashCommandDef {
 	description: string;
 }
 
+export const AI_CHAT_BROWSER_COMMAND = '/browser';
 export const AI_CHAT_MODEL_COMMAND = '/model';
 export const AI_CHAT_EXIT_COMMAND = '/exit';
 
 export const AI_CHAT_SLASH_COMMANDS: SlashCommandDef[] = [
+	{ name: 'browser', description: 'Open the active site in the browser' },
 	{ name: 'model', description: 'Switch the AI model' },
 	{ name: 'exit', description: 'Exit the chat' },
 ];

--- a/apps/cli/ai/ui.ts
+++ b/apps/cli/ai/ui.ts
@@ -273,6 +273,7 @@ export class AiChatUI {
 	private toolDotVisible = true;
 	private toolDotLabel = '';
 	private _activeSite: SiteInfo | null = null;
+	private _activeSiteData: SiteData | null = null;
 	currentModel: AiModelId = DEFAULT_MODEL;
 
 	private readonly thinkingMessages = [
@@ -538,6 +539,7 @@ export class AiChatUI {
 		const site = this.sitePickerItems[ index ];
 		if ( site ) {
 			this._activeSite = site;
+			this._activeSiteData = this.sitePickerSiteData[ index ] ?? null;
 			this.editor.activeSiteName = site.name;
 			this.messages.addChild(
 				new Text( chalk.hex( '#8839ef' )( ' ✻ Selected site: ' + site.name ) + '\n', 0, 0 )
@@ -556,6 +558,22 @@ export class AiChatUI {
 		if ( url ) {
 			await openBrowser( url );
 		}
+	}
+
+	async openActiveSiteInBrowser(): Promise< boolean > {
+		if ( ! this._activeSiteData ) {
+			return false;
+		}
+		// Re-read appdata to get the current site state (port/domain may have changed)
+		const appdata = await readAppdata();
+		const freshSiteData = appdata.sites?.find( ( s ) => s.name === this._activeSite?.name );
+		const siteData = freshSiteData ?? this._activeSiteData;
+		const url = getSiteUrl( siteData );
+		if ( url ) {
+			await openBrowser( url );
+			return true;
+		}
+		return false;
 	}
 
 	private closeSitePicker(): void {

--- a/apps/cli/commands/ai.ts
+++ b/apps/cli/commands/ai.ts
@@ -2,7 +2,11 @@ import { execFileSync } from 'child_process';
 import { password } from '@inquirer/prompts';
 import { __ } from '@wordpress/i18n';
 import { AI_MODELS, DEFAULT_MODEL, startAiAgent, type AiModelId } from 'cli/ai/agent';
-import { AI_CHAT_EXIT_COMMAND, AI_CHAT_MODEL_COMMAND } from 'cli/ai/slash-commands';
+import {
+	AI_CHAT_BROWSER_COMMAND,
+	AI_CHAT_EXIT_COMMAND,
+	AI_CHAT_MODEL_COMMAND,
+} from 'cli/ai/slash-commands';
 import { AiChatUI } from 'cli/ai/ui';
 import { getAnthropicApiKey, saveAnthropicApiKey } from 'cli/lib/appdata';
 import { Logger, LoggerError, setProgressCallback } from 'cli/logger';
@@ -133,6 +137,14 @@ export async function runCommand(): Promise< void > {
 
 			if ( trimmedPrompt === AI_CHAT_EXIT_COMMAND ) {
 				break;
+			}
+
+			if ( trimmedPrompt === AI_CHAT_BROWSER_COMMAND ) {
+				const opened = await ui.openActiveSiteInBrowser();
+				if ( ! opened ) {
+					ui.showInfo( 'No site selected. Use ↓ to select a site first.' );
+				}
+				continue;
 			}
 
 			if ( trimmedPrompt === AI_CHAT_MODEL_COMMAND ) {


### PR DESCRIPTION
 ## Related issues

Follow-up to #2632, similar to #2744

  ## How AI was used in this PR

  Claude Code agent generated the implementation; reviewed and adjusted by human.

  ## Proposed Changes

  - Add `/browser` slash command that opens the active site in the default browser
  - Register the command in the slash command autocomplete list in the prompt editor
  - Store `SiteData` alongside `SiteInfo` when a site is selected, so the URL can be resolved later
  - Re-read appdata when `/browser` is invoked to get the current site state (port/domain may have changed since
  selection)
  - Show a helpful message when no site is selected

  ## Testing Instructions

  - Build CLI: `npm run cli:build`
  - Run: `node apps/cli/dist/cli/main.js ai`
  - Type `/browser` without selecting a site — should show "No site selected" message
  - Press `↓` to open the site picker and select a running site
  - Type `/browser` — should open the site in your default browser
  - Type `/b` — should show `/browser` in the autocomplete suggestions
  - Verify `/exit` and `/model` still work.

  ## Pre-merge Checklist

  - [x] Have you checked for TypeScript, React or other console errors?