### PR TITLE
Fix "space to open" command during site selection

### DIFF
--- a/apps/cli/ai/ui.ts
+++ b/apps/cli/ai/ui.ts
@@ -547,9 +547,8 @@ export class AiChatUI {
 	}
 
 	private async openSelectedSite(): Promise< void > {
-		const site = this.sitePickerItems[ this.sitePickerSelectedIndex ];
 		const siteData = this.sitePickerSiteData[ this.sitePickerSelectedIndex ];
-		if ( ! site?.running || ! siteData ) {
+		if ( ! siteData ) {
 			return;
 		}
 		const url = getSiteUrl( siteData );


### PR DESCRIPTION


## Proposed Changes

Currently, when selecting a site, the "space to open" doesn't work. This PR fixes it.

  ## How AI was used in this PR

  Claude Code agent generated the implementation; reviewed and adjusted by human.

## Testing Instructions

  - Build CLI: `npm run cli:build`
  - Run: `node apps/cli/dist/cli/main.js ai`
  - Make sure you have at least 2 sites.
  - Press ↓, highlight a running site, press space, should open that site in the browser

## Pre-merge Checklist

  - [x] Have you checked for TypeScript, React or other console errors?