### PR TITLE
Add /login and /logout slash commands to AI chat

### DIFF
--- a/apps/cli/ai/slash-commands.ts
+++ b/apps/cli/ai/slash-commands.ts
@@ -4,11 +4,15 @@ export interface SlashCommandDef {
 }
 
 export const AI_CHAT_BROWSER_COMMAND = '/browser';
+export const AI_CHAT_LOGIN_COMMAND = '/login';
+export const AI_CHAT_LOGOUT_COMMAND = '/logout';
 export const AI_CHAT_MODEL_COMMAND = '/model';
 export const AI_CHAT_EXIT_COMMAND = '/exit';
 
 export const AI_CHAT_SLASH_COMMANDS: SlashCommandDef[] = [
 	{ name: 'browser', description: 'Open the active site in the browser' },
+	{ name: 'login', description: 'Log in to WordPress.com' },
+	{ name: 'logout', description: 'Log out of WordPress.com' },
 	{ name: 'model', description: 'Switch the AI model' },
 	{ name: 'exit', description: 'Exit the chat' },
 ];

--- a/apps/cli/ai/slash-commands.ts
+++ b/apps/cli/ai/slash-commands.ts
@@ -3,10 +3,12 @@ export interface SlashCommandDef {
 	description: string;
 }
 
+export const AI_CHAT_BROWSER_COMMAND = '/browser';
 export const AI_CHAT_MODEL_COMMAND = '/model';
 export const AI_CHAT_EXIT_COMMAND = '/exit';
 
 export const AI_CHAT_SLASH_COMMANDS: SlashCommandDef[] = [
+	{ name: 'browser', description: 'Open the active site in the browser' },
 	{ name: 'model', description: 'Switch the AI model' },
 	{ name: 'exit', description: 'Exit the chat' },
 ];

--- a/apps/cli/ai/ui.ts
+++ b/apps/cli/ai/ui.ts
@@ -273,6 +273,7 @@ export class AiChatUI {
 	private toolDotVisible = true;
 	private toolDotLabel = '';
 	private _activeSite: SiteInfo | null = null;
+	private _activeSiteData: SiteData | null = null;
 	currentModel: AiModelId = DEFAULT_MODEL;
 
 	private readonly thinkingMessages = [
@@ -538,6 +539,7 @@ export class AiChatUI {
 		const site = this.sitePickerItems[ index ];
 		if ( site ) {
 			this._activeSite = site;
+			this._activeSiteData = this.sitePickerSiteData[ index ] ?? null;
 			this.editor.activeSiteName = site.name;
 			this.messages.addChild(
 				new Text( chalk.hex( '#8839ef' )( ' ✻ Selected site: ' + site.name ) + '\n', 0, 0 )
@@ -556,6 +558,22 @@ export class AiChatUI {
 		if ( url ) {
 			await openBrowser( url );
 		}
+	}
+
+	async openActiveSiteInBrowser(): Promise< boolean > {
+		if ( ! this._activeSiteData ) {
+			return false;
+		}
+		// Re-read appdata to get the current site state (port/domain may have changed)
+		const appdata = await readAppdata();
+		const freshSiteData = appdata.sites?.find( ( s ) => s.name === this._activeSite?.name );
+		const siteData = freshSiteData ?? this._activeSiteData;
+		const url = getSiteUrl( siteData );
+		if ( url ) {
+			await openBrowser( url );
+			return true;
+		}
+		return false;
 	}
 
 	private closeSitePicker(): void {

--- a/apps/cli/commands/ai.ts
+++ b/apps/cli/commands/ai.ts
@@ -5,10 +5,14 @@ import { AI_MODELS, DEFAULT_MODEL, startAiAgent, type AiModelId } from 'cli/ai/a
 import {
 	AI_CHAT_BROWSER_COMMAND,
 	AI_CHAT_EXIT_COMMAND,
+	AI_CHAT_LOGIN_COMMAND,
+	AI_CHAT_LOGOUT_COMMAND,
 	AI_CHAT_MODEL_COMMAND,
 } from 'cli/ai/slash-commands';
 import { AiChatUI } from 'cli/ai/ui';
-import { getAnthropicApiKey, saveAnthropicApiKey } from 'cli/lib/appdata';
+import { runCommand as runLoginCommand } from 'cli/commands/auth/login';
+import { runCommand as runLogoutCommand } from 'cli/commands/auth/logout';
+import { getAnthropicApiKey, getAuthToken, saveAnthropicApiKey } from 'cli/lib/appdata';
 import { Logger, LoggerError, setProgressCallback } from 'cli/logger';
 import { StudioArgv } from 'cli/types';
 
@@ -64,6 +68,13 @@ export async function runCommand(): Promise< void > {
 	setProgressCallback( ( message ) => ui.setLoaderMessage( message ) );
 	ui.start();
 	ui.showWelcome();
+
+	try {
+		const token = await getAuthToken();
+		ui.showInfo( __( 'Logged in as ' ) + token.displayName + ' (' + token.email + ')' );
+	} catch {
+		ui.showInfo( __( 'Not logged in to WordPress.com. Use /login to authenticate.' ) );
+	}
 
 	let sessionId: string | undefined;
 	let currentModel: AiModelId = DEFAULT_MODEL;
@@ -144,6 +155,26 @@ export async function runCommand(): Promise< void > {
 				if ( ! opened ) {
 					ui.showInfo( 'No site selected. Use ↓ to select a site first.' );
 				}
+				continue;
+			}
+
+			if ( trimmedPrompt === AI_CHAT_LOGIN_COMMAND ) {
+				ui.stop();
+				await runLoginCommand();
+				ui.start();
+				try {
+					const token = await getAuthToken();
+					ui.showInfo( __( 'Logged in as ' ) + token.displayName + ' (' + token.email + ')' );
+				} catch {
+					// Login may have failed or been cancelled
+				}
+				continue;
+			}
+
+			if ( trimmedPrompt === AI_CHAT_LOGOUT_COMMAND ) {
+				ui.stop();
+				await runLogoutCommand();
+				ui.start();
 				continue;
 			}
 

--- a/apps/cli/commands/ai.ts
+++ b/apps/cli/commands/ai.ts
@@ -166,7 +166,7 @@ export async function runCommand(): Promise< void > {
 					const token = await getAuthToken();
 					ui.showInfo( `Logged in as ${ token.displayName } (${ token.email })` );
 				} catch {
-					// Login may have failed or been cancelled
+					ui.showInfo( 'Login failed or cancelled.' );
 				}
 				continue;
 			}

--- a/apps/cli/commands/ai.ts
+++ b/apps/cli/commands/ai.ts
@@ -166,7 +166,7 @@ export async function runCommand(): Promise< void > {
 					const token = await getAuthToken();
 					ui.showInfo( `Logged in as ${ token.displayName } (${ token.email })` );
 				} catch {
-					ui.showInfo( 'Login failed or cancelled.' );
+					ui.showInfo( 'Login failed or canceled.' );
 				}
 				continue;
 			}

--- a/apps/cli/commands/ai.ts
+++ b/apps/cli/commands/ai.ts
@@ -71,9 +71,9 @@ export async function runCommand(): Promise< void > {
 
 	try {
 		const token = await getAuthToken();
-		ui.showInfo( __( 'Logged in as ' ) + token.displayName + ' (' + token.email + ')' );
+		ui.showInfo( `Logged in as ${ token.displayName } (${ token.email })` );
 	} catch {
-		ui.showInfo( __( 'Not logged in to WordPress.com. Use /login to authenticate.' ) );
+		ui.showInfo( 'Not logged in to WordPress.com. Use /login to authenticate.' );
 	}
 
 	let sessionId: string | undefined;
@@ -164,7 +164,7 @@ export async function runCommand(): Promise< void > {
 				ui.start();
 				try {
 					const token = await getAuthToken();
-					ui.showInfo( __( 'Logged in as ' ) + token.displayName + ' (' + token.email + ')' );
+					ui.showInfo( `Logged in as ${ token.displayName } (${ token.email })` );
 				} catch {
 					// Login may have failed or been cancelled
 				}
@@ -175,6 +175,7 @@ export async function runCommand(): Promise< void > {
 				ui.stop();
 				await runLogoutCommand();
 				ui.start();
+				ui.showInfo( 'Logged out of WordPress.com.' );
 				continue;
 			}
 

--- a/apps/cli/commands/ai.ts
+++ b/apps/cli/commands/ai.ts
@@ -2,7 +2,11 @@ import { execFileSync } from 'child_process';
 import { password } from '@inquirer/prompts';
 import { __ } from '@wordpress/i18n';
 import { AI_MODELS, DEFAULT_MODEL, startAiAgent, type AiModelId } from 'cli/ai/agent';
-import { AI_CHAT_EXIT_COMMAND, AI_CHAT_MODEL_COMMAND } from 'cli/ai/slash-commands';
+import {
+	AI_CHAT_BROWSER_COMMAND,
+	AI_CHAT_EXIT_COMMAND,
+	AI_CHAT_MODEL_COMMAND,
+} from 'cli/ai/slash-commands';
 import { AiChatUI } from 'cli/ai/ui';
 import { getAnthropicApiKey, saveAnthropicApiKey } from 'cli/lib/appdata';
 import { Logger, LoggerError, setProgressCallback } from 'cli/logger';
@@ -133,6 +137,14 @@ export async function runCommand(): Promise< void > {
 
 			if ( trimmedPrompt === AI_CHAT_EXIT_COMMAND ) {
 				break;
+			}
+
+			if ( trimmedPrompt === AI_CHAT_BROWSER_COMMAND ) {
+				const opened = await ui.openActiveSiteInBrowser();
+				if ( ! opened ) {
+					ui.showInfo( 'No site selected. Use ↓ to select a site first.' );
+				}
+				continue;
 			}
 
 			if ( trimmedPrompt === AI_CHAT_MODEL_COMMAND ) {


### PR DESCRIPTION
## Related issues

- Related to #2632

## How AI was used in this PR

This PR was authored with Claude Code. All code has been reviewed and verified.

## Proposed Changes

- Add `/login` slash command that delegates to the existing `auth login` flow, then confirms login with name and email
- Add `/logout` slash command that delegates to the existing `auth logout` flow
- Show WordPress.com auth status on AI chat startup (logged in as name/email, or prompt to use /login)

Not logged in:
<img width="704" height="214" alt="Screenshot 2026-03-11 at 12 10 38 PM" src="https://github.com/user-attachments/assets/0a50f6c1-e3f3-4445-86c2-03152e5c3abc" />

Logged in:
<img width="755" height="211" alt="SCR-20260311-kzeg" src="https://github.com/user-attachments/assets/6f163710-928d-448d-be26-37dd601ade6e" />


## Testing Instructions

- Build CLI: `npm run cli:build`
- Run: `ENABLE_STUDIO_AI=true node apps/cli/dist/cli/main.js ai`
- Verify auth status message appears after the welcome banner
- Type `/login` and complete the WordPress.com OAuth flow — confirm "Logged in as Name (email)" appears
- Type `/logout` and confirm successful logout message
- Restart and verify it shows "Not logged in" message

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?

🤖 Generated with [Claude Code](https://claude.com/claude-code)