### PR TITLE
AI: Remove esc to interrupt from site selection

### DIFF
--- a/apps/cli/ai/ui.ts
+++ b/apps/cli/ai/ui.ts
@@ -583,7 +583,7 @@ export class AiChatUI {
 		this.sitePickerVisible = false;
 		this.sitePickerItems = [];
 		this.sitePickerSiteData = [];
-		this.editor.hints = [ '↓ select site', 'esc to interrupt' ];
+		this.editor.hints = [ '↓ select site' ];
 		this.tui.requestRender();
 	}
 
@@ -736,7 +736,7 @@ export class AiChatUI {
 	}
 
 	private updateHints(): void {
-		this.editor.hints = [ '↓ select site', 'esc to interrupt' ];
+		this.editor.hints = [ '↓ select site' ];
 	}
 
 	private showEditor(): void {


### PR DESCRIPTION
## What

In the AI command, currently we'll display "esc to interrupt" during site selection, but it doesn't do anything.

## Proposed Changes

This PR removes that, but keeps the "esc to interrupt" while the AI command is generating/working.

## Testing Instructions
  - Build CLI: `npm run cli:build`
  - Run: `ENABLE_STUDIO_AI=true node apps/cli/dist/cli/main.js ai`
  - Verify you no longer see "esc to interrupt" during site selection.
  - Verify that during generation you see "esc to interrupt"

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?

## Screenshots

Before:

<img width="338" height="256" alt="Screenshot 2026-03-11 at 12 13 13" src="https://github.com/user-attachments/assets/12a284f3-f3ea-4391-9e16-0de906a9b0b7" />


After:
<img width="348" height="259" alt="Screenshot 2026-03-11 at 12 14 04" src="https://github.com/user-attachments/assets/8ddb07d0-0483-4a07-8d33-50c17b98cebe" />

During generation:
<img width="183" height="113" alt="Screenshot 2026-03-11 at 12 14 53" src="https://github.com/user-attachments/assets/af168bb9-258b-4294-87bd-2e08f0d201ba" />
