### PR TITLE
Fix Windows build by pruning non-Windows vendor binaries from claude-agent-sdk

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -31,7 +31,7 @@
 	},
 	"scripts": {
 		"build": "vite build --config ./vite.config.ts",
-		"install:bundle": "npm install --omit=dev --no-package-lock --no-progress --install-links --no-workspaces && patch-package && node ../../scripts/remove-fs-ext-other-platform-binaries.mjs",
+		"install:bundle": "npm install --omit=dev --no-package-lock --no-progress --install-links --no-workspaces && patch-package && node ../../scripts/remove-fs-ext-other-platform-binaries.mjs && node ../../scripts/remove-other-platform-binaries.mjs",
 		"package": "npm run install:bundle && npm run build",
 		"watch": "vite build --config ./vite.config.ts --watch"
 	},

--- a/apps/cli/vite.config.ts
+++ b/apps/cli/vite.config.ts
@@ -54,38 +54,6 @@ export default defineConfig( {
 							}
 						},
 					},
-					{
-						// Remove directories named after foreign platforms from bundled
-						// node_modules. Packages like koffi and claude-agent-sdk ship
-						// prebuilt binaries (.node, executables, .so, .dylib) for every
-						// OS. Windows code-signing fails when signtool encounters
-						// non-PE binaries (e.g. macOS .node files or Linux ELF binaries).
-						name: 'prune-foreign-platform-binaries',
-						apply: 'build' as const,
-						closeBundle() {
-							const foreignPlatforms =
-								process.platform === 'win32'
-									? [ 'darwin', 'linux' ]
-									: process.platform === 'darwin'
-									? [ 'win32', 'linux' ]
-									: [ 'darwin', 'win32' ];
-
-							// Find directories whose name contains a foreign platform
-							// identifier (e.g. darwin_arm64/, arm64-darwin/, linux-x64/)
-							// and remove them entirely.
-							const patterns = foreignPlatforms.map( ( p ) => `**/*${ p }*/` );
-
-							for ( const pattern of patterns ) {
-								const matches = globSync( pattern, {
-									cwd: distCliNodeModulesPath,
-									absolute: true,
-								} );
-								for ( const match of matches ) {
-									rmSync( match, { recursive: true, force: true } );
-								}
-							}
-						},
-					},
 			  ]
 			: [] ),
 	],

--- a/apps/cli/vite.config.ts
+++ b/apps/cli/vite.config.ts
@@ -55,10 +55,11 @@ export default defineConfig( {
 						},
 					},
 					{
-						// Remove native binaries built for other platforms from bundled
+						// Remove directories named after foreign platforms from bundled
 						// node_modules. Packages like koffi and claude-agent-sdk ship
-						// prebuilt .node files for every OS. Windows code-signing fails
-						// when signtool encounters non-PE binaries (e.g. macOS .node).
+						// prebuilt binaries (.node, executables, .so, .dylib) for every
+						// OS. Windows code-signing fails when signtool encounters
+						// non-PE binaries (e.g. macOS .node files or Linux ELF binaries).
 						name: 'prune-foreign-platform-binaries',
 						apply: 'build' as const,
 						closeBundle() {
@@ -69,10 +70,10 @@ export default defineConfig( {
 									? [ 'win32', 'linux' ]
 									: [ 'darwin', 'win32' ];
 
-							// Match .node files whose path contains a foreign platform
-							// identifier as a directory component (e.g. darwin_arm64/,
-							// arm64-darwin/, linux-x64/).
-							const patterns = foreignPlatforms.map( ( p ) => `**/*${ p }*/**/*.node` );
+							// Find directories whose name contains a foreign platform
+							// identifier (e.g. darwin_arm64/, arm64-darwin/, linux-x64/)
+							// and remove them entirely.
+							const patterns = foreignPlatforms.map( ( p ) => `**/*${ p }*/` );
 
 							for ( const pattern of patterns ) {
 								const matches = globSync( pattern, {
@@ -80,7 +81,7 @@ export default defineConfig( {
 									absolute: true,
 								} );
 								for ( const match of matches ) {
-									rmSync( match, { force: true } );
+									rmSync( match, { recursive: true, force: true } );
 								}
 							}
 						},

--- a/apps/cli/vite.config.ts
+++ b/apps/cli/vite.config.ts
@@ -1,4 +1,4 @@
-import { existsSync, readdirSync, readFileSync, rmSync, statSync } from 'fs';
+import { existsSync, readFileSync, rmSync } from 'fs';
 import { dirname, join, resolve } from 'path';
 import { sync as globSync } from 'glob';
 import { defineConfig, normalizePath } from 'vite';
@@ -55,42 +55,32 @@ export default defineConfig( {
 						},
 					},
 					{
-						// Remove platform-specific vendor binaries from claude-agent-sdk that
-						// don't match the current build platform. The SDK bundles native binaries
-						// (ripgrep, tree-sitter) for all platforms, and Windows code-signing
-						// fails on non-PE files (e.g. macOS .node files).
-						name: 'prune-claude-agent-sdk-vendor',
+						// Remove native binaries built for other platforms from bundled
+						// node_modules. Packages like koffi and claude-agent-sdk ship
+						// prebuilt .node files for every OS. Windows code-signing fails
+						// when signtool encounters non-PE binaries (e.g. macOS .node).
+						name: 'prune-foreign-platform-binaries',
 						apply: 'build' as const,
 						closeBundle() {
-							const vendorPath = join(
-								distCliNodeModulesPath,
-								'@anthropic-ai',
-								'claude-agent-sdk',
-								'vendor'
-							);
-							if ( ! existsSync( vendorPath ) ) {
-								return;
-							}
+							const foreignPlatforms =
+								process.platform === 'win32'
+									? [ 'darwin', 'linux' ]
+									: process.platform === 'darwin'
+									? [ 'win32', 'linux' ]
+									: [ 'darwin', 'win32' ];
 
-							const platformMap: Record< string, string > = {
-								darwin: 'darwin',
-								win32: 'win32',
-								linux: 'linux',
-							};
-							const keepPlatform = platformMap[ process.platform ] || process.platform;
+							// Match .node files whose path contains a foreign platform
+							// identifier as a directory component (e.g. darwin_arm64/,
+							// arm64-darwin/, linux-x64/).
+							const patterns = foreignPlatforms.map( ( p ) => `**/*${ p }*/**/*.node` );
 
-							for ( const toolDir of readdirSync( vendorPath ) ) {
-								const toolPath = join( vendorPath, toolDir );
-								if ( ! statSync( toolPath ).isDirectory() ) {
-									continue;
-								}
-								for ( const platformDir of readdirSync( toolPath ) ) {
-									if ( ! platformDir.includes( keepPlatform ) ) {
-										rmSync( join( toolPath, platformDir ), {
-											recursive: true,
-											force: true,
-										} );
-									}
+							for ( const pattern of patterns ) {
+								const matches = globSync( pattern, {
+									cwd: distCliNodeModulesPath,
+									absolute: true,
+								} );
+								for ( const match of matches ) {
+									rmSync( match, { force: true } );
 								}
 							}
 						},

--- a/apps/cli/vite.config.ts
+++ b/apps/cli/vite.config.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, rmSync } from 'fs';
+import { existsSync, readdirSync, readFileSync, rmSync, statSync } from 'fs';
 import { dirname, join, resolve } from 'path';
 import { sync as globSync } from 'glob';
 import { defineConfig, normalizePath } from 'vite';
@@ -51,6 +51,47 @@ export default defineConfig( {
 
 							for ( const path of [ ...asyncifyPaths, ...webPaths ] ) {
 								rmSync( path, { recursive: true, force: true } );
+							}
+						},
+					},
+					{
+						// Remove platform-specific vendor binaries from claude-agent-sdk that
+						// don't match the current build platform. The SDK bundles native binaries
+						// (ripgrep, tree-sitter) for all platforms, and Windows code-signing
+						// fails on non-PE files (e.g. macOS .node files).
+						name: 'prune-claude-agent-sdk-vendor',
+						apply: 'build' as const,
+						closeBundle() {
+							const vendorPath = join(
+								distCliNodeModulesPath,
+								'@anthropic-ai',
+								'claude-agent-sdk',
+								'vendor'
+							);
+							if ( ! existsSync( vendorPath ) ) {
+								return;
+							}
+
+							const platformMap: Record< string, string > = {
+								darwin: 'darwin',
+								win32: 'win32',
+								linux: 'linux',
+							};
+							const keepPlatform = platformMap[ process.platform ] || process.platform;
+
+							for ( const toolDir of readdirSync( vendorPath ) ) {
+								const toolPath = join( vendorPath, toolDir );
+								if ( ! statSync( toolPath ).isDirectory() ) {
+									continue;
+								}
+								for ( const platformDir of readdirSync( toolPath ) ) {
+									if ( ! platformDir.includes( keepPlatform ) ) {
+										rmSync( join( toolPath, platformDir ), {
+											recursive: true,
+											force: true,
+										} );
+									}
+								}
 							}
 						},
 					},

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -18,7 +18,7 @@
 		"make:windows-arm64": "electron-vite build --config ./electron.vite.config.ts --outDir=dist && electron-forge make . --arch=arm64 --platform=win32",
 		"make:macos-x64": "electron-vite build --config ./electron.vite.config.ts --outDir=dist && SKIP_DMG=true FILE_ARCHITECTURE=x64 electron-forge make . --arch=x64 --platform=darwin",
 		"make:macos-arm64": "electron-vite build --config ./electron.vite.config.ts --outDir=dist && SKIP_DMG=true FILE_ARCHITECTURE=arm64 electron-forge make . --arch=arm64 --platform=darwin",
-		"install:bundle": "npm install --no-package-lock --no-progress --install-links --no-workspaces && patch-package && node ../../scripts/remove-fs-ext-other-platform-binaries.mjs",
+		"install:bundle": "npm install --no-package-lock --no-progress --install-links --no-workspaces && patch-package && node ../../scripts/remove-fs-ext-other-platform-binaries.mjs && node ../../scripts/remove-other-platform-binaries.mjs",
 		"package": "electron-vite build --config ./electron.vite.config.ts --outDir=dist && electron-forge package .",
 		"publish": "electron-forge publish .",
 		"start-wayland": "npm -w studio-cli run build && electron-forge start . -- --enable-features=UseOzonePlatform --ozone-platform=wayland"

--- a/scripts/remove-other-platform-binaries.mjs
+++ b/scripts/remove-other-platform-binaries.mjs
@@ -1,0 +1,49 @@
+/**
+ * Removes directories named after foreign platforms from node_modules.
+ *
+ * Many native packages (e.g. koffi, @anthropic-ai/claude-agent-sdk) ship
+ * prebuilt binaries for every OS inside platform-specific directories like
+ * `darwin_arm64/`, `arm64-darwin/`, `linux-x64/`, etc. Downstream tools such
+ * as Windows code-signing (signtool) will fail if they encounter binaries
+ * built for another OS. This script removes any directory whose name contains
+ * a foreign platform identifier.
+ *
+ * Usage: node scripts/remove-other-platform-binaries.mjs
+ *
+ * Resolves node_modules relative to process.cwd() so it works from any
+ * workspace (e.g. apps/studio or apps/cli).
+ */
+
+import { rmSync } from 'fs';
+import { join } from 'path';
+import { globSync } from 'glob';
+
+const nodeModulesPath = join( process.cwd(), 'node_modules' );
+
+const foreignPlatforms =
+	process.platform === 'win32'
+		? [ 'darwin', 'linux' ]
+		: process.platform === 'darwin'
+		? [ 'win32', 'linux' ]
+		: [ 'darwin', 'win32' ];
+
+const patterns = foreignPlatforms.map( ( p ) => `**/*${ p }*/` );
+
+let removedCount = 0;
+
+for ( const pattern of patterns ) {
+	const matches = globSync( pattern, {
+		cwd: nodeModulesPath,
+		absolute: true,
+	} );
+	for ( const match of matches ) {
+		try {
+			rmSync( match, { recursive: true, force: true } );
+			removedCount++;
+		} catch ( e ) {
+			console.log( `Could not remove ${ match }: ${ e.message }` );
+		}
+	}
+}
+
+console.log( `Removed ${ removedCount } foreign-platform directories from node_modules` );

--- a/scripts/remove-other-platform-binaries.mjs
+++ b/scripts/remove-other-platform-binaries.mjs
@@ -14,9 +14,8 @@
  * workspace (e.g. apps/studio or apps/cli).
  */
 
-import { rmSync } from 'fs';
+import { readdirSync, rmSync, statSync } from 'fs';
 import { join } from 'path';
-import { globSync } from 'glob';
 
 const nodeModulesPath = join( process.cwd(), 'node_modules' );
 
@@ -27,23 +26,46 @@ const foreignPlatforms =
 		? [ 'win32', 'linux' ]
 		: [ 'darwin', 'win32' ];
 
-const patterns = foreignPlatforms.map( ( p ) => `**/*${ p }*/` );
+function isForeignPlatformDir( name ) {
+	return foreignPlatforms.some( ( p ) => name.includes( p ) );
+}
 
 let removedCount = 0;
 
-for ( const pattern of patterns ) {
-	const matches = globSync( pattern, {
-		cwd: nodeModulesPath,
-		absolute: true,
-	} );
-	for ( const match of matches ) {
+function walk( dir ) {
+	let entries;
+	try {
+		entries = readdirSync( dir );
+	} catch {
+		return;
+	}
+
+	for ( const entry of entries ) {
+		const fullPath = join( dir, entry );
+		let stat;
 		try {
-			rmSync( match, { recursive: true, force: true } );
-			removedCount++;
-		} catch ( e ) {
-			console.log( `Could not remove ${ match }: ${ e.message }` );
+			stat = statSync( fullPath );
+		} catch {
+			continue;
+		}
+
+		if ( ! stat.isDirectory() ) {
+			continue;
+		}
+
+		if ( isForeignPlatformDir( entry ) ) {
+			try {
+				rmSync( fullPath, { recursive: true, force: true } );
+				removedCount++;
+			} catch ( e ) {
+				console.log( `Could not remove ${ fullPath }: ${ e.message }` );
+			}
+		} else {
+			walk( fullPath );
 		}
 	}
 }
+
+walk( nodeModulesPath );
 
 console.log( `Removed ${ removedCount } foreign-platform directories from node_modules` );


### PR DESCRIPTION
## Related issues

- Related to Windows build failure when code-signing AI agent SDK vendor binaries

## How AI was used in this PR

Claude analyzed the Windows build error, identified that signtool was attempting to sign macOS `.node` files from `@anthropic-ai/claude-agent-sdk/vendor/`, and designed a fix following the existing `prune-php-wasm` pattern.

## Proposed Changes

- Add a Vite plugin (`prune-claude-agent-sdk-vendor`) to `apps/cli/vite.config.ts` that removes platform-specific vendor binaries from the claude-agent-sdk that don't match the current build platform
- The SDK bundles native binaries (ripgrep, tree-sitter) for all platforms; on Windows builds, non-Windows platform directories (e.g., `arm64-darwin`) are now removed before code signing, preventing signtool from attempting to sign incompatible PE files

## Testing Instructions

- Windows CI builds should now complete successfully without signtool errors
- The plugin only runs during the CLI build when vendored binaries are present

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?