### PR TITLE
Widen AI welcome logo to avoid vertical stretching

### DIFF
--- a/apps/cli/ai/ui.ts
+++ b/apps/cli/ai/ui.ts
@@ -633,17 +633,17 @@ export class AiChatUI {
 
 		const b = chalk.blue;
 
-		// W logo in block characters
+		// WordPress logo in block characters, widened to avoid vertical stretching in terminals.
 		const logo = [
-			'  ▗▟▛▀▀▜▙▖',
-			' ▟▌     ▗█▙',
-			'▟██▘▝██ ▝██▙',
-			'▌▐█▖ ▐█▌ ▐▌▐',
-			'▌ ▜▙ ▐██ ▐▘▐',
-			'▜▖▝█▄▌▝█▄▌▗▛',
-			' ▜▖▜█  ▜█▗▛',
-			'  ▝▜█▄▄▟▛▘',
-		].map( ( s ) => b( s.padEnd( 12, ' ' ) ) );
+			'    ▄█▛▀▀▀▀█▙▖',
+			' ▗▟█        ▗██▄',
+			'▄███▛ ▝▜██  ▝███▙',
+			'█ ▐█▙   ███  ▐█ ▐',
+			'█  ▀█▄  ███▌ ▐▛ ▐',
+			'▀▙▖ ▜█▄▟ ▝█▙▄▌ ▄▛',
+			' ▝▜▄▝██▌  ▀██▗▟▀',
+			'    ▀██▙▄▄▄█▛▘',
+		].map( ( s ) => b( s ) );
 
 		const info = [
 			chalk.bold( 'WordPress Studio' ) + ( version ? chalk.dim( ` v${ version }` ) : '' ),


### PR DESCRIPTION
The previous logo was squished, this attempts making it a bit wider.

Testing:
* build `npm run cli:build`
* run the CLI `ENABLE_STUDIO_AI=true node apps/cli/dist/cli/main.js ai`

Ideally it should look better than before:

<img width="453" height="196" alt="image" src="https://github.com/user-attachments/assets/4e4626be-f909-471a-9fed-3a62c24ca8f9" />
