### PR TITLE
Add WordPress.com remote sites to AI CLI site picker

### DIFF
--- a/apps/cli/ai/ui.ts
+++ b/apps/cli/ai/ui.ts
@@ -717,8 +717,8 @@ export class AiChatUI {
 	}
 
 	private sitePickerPageSize(): number {
-		// Reserve 3 lines for header, hints, and a margin; use at least 5 visible items
-		return Math.max( 5, ( process.stdout.rows ?? 24 ) - 3 );
+		// Reserve 4 lines for header, search, scroll info, and hints; use at least 5 visible items
+		return Math.max( 5, ( process.stdout.rows ?? 24 ) - 4 );
 	}
 
 	private renderSitePicker(): void {
@@ -800,15 +800,6 @@ export class AiChatUI {
 		const text = lines.join( '\n' );
 		this.sitePickerContainer.addChild( new Text( text, 0, 0 ) );
 		this.tui.requestRender();
-	}
-
-	private selectSite( index: number ): void {
-		const site = this.sitePickerItems[ index ];
-		if ( site ) {
-			this.setActiveSite( site );
-			this._activeSiteData = this.sitePickerSiteData[ index ] ?? null;
-		}
-		this.closeSitePicker();
 	}
 
 	private getVisibleWindow( totalItems: number ): { start: number; end: number } {

--- a/apps/cli/ai/ui.ts
+++ b/apps/cli/ai/ui.ts
@@ -668,7 +668,7 @@ export class AiChatUI {
 			this.sitePickerTab = SITE_PICKER_TAB_LOCAL;
 			this.renderSitePicker();
 			this.messages.addChild(
-				new Text( '\n' + chalk.dim( 'Not logged in. Use /login first.' ) + '\n', 1, 0 )
+				new Text( `\n${ chalk.dim( 'Not logged in. Use /login first.' ) }\n`, 1, 0 )
 			);
 			this.tui.requestRender();
 		}
@@ -708,10 +708,9 @@ export class AiChatUI {
 				originalIndex >= 0 ? this.sitePickerSiteData[ originalIndex ] ?? null : null;
 		}
 		this.editor.activeSiteName = site.name;
-		const label = site.remote
-			? ' ✻ Selected site: ' + site.name + ' (WordPress.com)'
-			: ' ✻ Selected site: ' + site.name;
-		this.messages.addChild( new Text( chalk.hex( '#8839ef' )( label ) + '\n', 0, 0 ) );
+		const suffix = site.remote ? ' (WordPress.com)' : '';
+		const label = ` ✻ Selected site: ${ site.name }${ suffix }`;
+		this.messages.addChild( new Text( `${ chalk.hex( '#8839ef' )( label ) }\n`, 0, 0 ) );
 		this.closeSitePicker();
 	}
 
@@ -769,7 +768,7 @@ export class AiChatUI {
 			const { start, end } = this.getVisibleWindow( filtered.length );
 			items = filtered.slice( start, end ).map( ( site, vi ) => {
 				const i = start + vi;
-				const url = site.url ? ' ' + chalk.dim( site.url ) : '';
+				const url = site.url ? ` ${ chalk.dim( site.url ) }` : '';
 				if ( i === this.sitePickerSelectedIndex ) {
 					return `  ${ chalk.blue( '❯' ) } ${ chalk.bold( site.name ) }${ url }`;
 				}

--- a/apps/cli/ai/ui.ts
+++ b/apps/cli/ai/ui.ts
@@ -558,13 +558,8 @@ export class AiChatUI {
 					}
 					return { consume: true };
 				}
-				if ( matchesKey( data, 'space' ) ) {
-					// Space opens browser unless a search is active, in which case it's a search character
-					if ( this.sitePickerQuery ) {
-						this.setSitePickerQuery( `${ this.sitePickerQuery } ` );
-					} else {
-						void this.openSelectedSite();
-					}
+				if ( matchesKey( data, 'tab' ) ) {
+					void this.openSelectedSite();
 					return { consume: true };
 				}
 				if ( matchesKey( data, 'right' ) && this.sitePickerTab === SITE_PICKER_TAB_LOCAL ) {
@@ -777,8 +772,8 @@ export class AiChatUI {
 			: '';
 
 		const hints = isLocal
-			? '  ↑↓ navigate · → remote sites · enter select · space open in browser · esc cancel'
-			: '  ↑↓ navigate · ← local sites · enter select · space open in browser · esc cancel';
+			? '  ↑↓ navigate · → remote sites · enter select · tab open in browser · esc cancel'
+			: '  ↑↓ navigate · ← local sites · enter select · tab open in browser · esc cancel';
 
 		const lines = [ header ];
 		if ( searchLine ) {

--- a/apps/cli/ai/ui.ts
+++ b/apps/cli/ai/ui.ts
@@ -636,10 +636,9 @@ export class AiChatUI {
 			return;
 		}
 
-		this.sitePickerTab = SITE_PICKER_TAB_REMOTE;
+		this.resetSitePickerTab( SITE_PICKER_TAB_REMOTE );
 		this.sitePickerRemoteLoading = true;
 		this.sitePickerRemoteItems = [];
-		this.sitePickerQuery = '';
 		this.renderSitePicker();
 
 		try {
@@ -655,23 +654,27 @@ export class AiChatUI {
 			this.sitePickerSelectedIndex = 0;
 			this.renderSitePicker();
 		} catch {
-			this.sitePickerRemoteLoading = false;
-			this.sitePickerRemoteItems = [];
 			this.showSitePickerError( 'Failed to load WordPress.com sites. Please try again.' );
 		}
 	}
 
 	private showSitePickerError( message: string ): void {
-		this.sitePickerTab = SITE_PICKER_TAB_LOCAL;
+		this.resetSitePickerTab( SITE_PICKER_TAB_LOCAL );
+		this.sitePickerRemoteItems = [];
 		this.renderSitePicker();
 		this.messages.addChild( new Text( `\n${ chalk.dim( message ) }\n`, 1, 0 ) );
 		this.tui.requestRender();
 	}
 
-	private switchToLocalSites(): void {
-		this.sitePickerTab = SITE_PICKER_TAB_LOCAL;
+	private resetSitePickerTab( tab: SitePickerTab ): void {
+		this.sitePickerTab = tab;
 		this.sitePickerSelectedIndex = 0;
 		this.sitePickerQuery = '';
+		this.sitePickerRemoteLoading = false;
+	}
+
+	private switchToLocalSites(): void {
+		this.resetSitePickerTab( SITE_PICKER_TAB_LOCAL );
 		this.renderSitePicker();
 	}
 
@@ -714,63 +717,60 @@ export class AiChatUI {
 		return Math.max( 5, ( process.stdout.rows ?? 24 ) - 4 );
 	}
 
+	private formatSiteRow( site: SiteInfo, index: number ): string {
+		const selected = index === this.sitePickerSelectedIndex;
+		const prefix = selected ? `  ${ chalk.blue( '❯' ) } ` : '    ';
+		const name = selected ? chalk.bold( site.name ) : site.name;
+		if ( site.remote ) {
+			const url = site.url ? ` ${ chalk.dim( site.url ) }` : '';
+			return `${ prefix }${ name }${ url }`;
+		}
+		const status = site.running ? `${ chalk.green( '●' ) } ` : '  ';
+		return `${ prefix }${ status }${ name }`;
+	}
+
+	// Returns the visible rows and scroll info for the current picker tab.
+	// Three modes: local list, remote loading, remote list.
+	private getSitePickerRows(): { items: string[]; scrollInfo: string } {
+		if ( ! ( this.sitePickerTab === SITE_PICKER_TAB_LOCAL ) && this.sitePickerRemoteLoading ) {
+			return { items: [ chalk.dim( '  Loading WordPress.com sites…' ) ], scrollInfo: '' };
+		}
+		const filtered = this.getFilteredSitePickerItems();
+		if ( filtered.length === 0 ) {
+			const emptyMessage =
+				this.sitePickerTab === SITE_PICKER_TAB_REMOTE && ! this.sitePickerQuery
+					? '  No WordPress.com sites found.'
+					: '  No matching sites.';
+			return { items: [ chalk.dim( emptyMessage ) ], scrollInfo: '' };
+		}
+		const { start, end } = this.getVisibleWindow( filtered.length );
+		const items = filtered
+			.slice( start, end )
+			.map( ( site, vi ) => this.formatSiteRow( site, start + vi ) );
+		const scrollInfo = this.getScrollInfo( filtered.length, start, end );
+		return { items, scrollInfo };
+	}
+
+	// Container doesn't expose a public clearChildren API, so we reach into
+	// the internal children array and remove items one at a time.
+	private clearContainer( container: Container ): void {
+		while ( ( container as Container & { children?: unknown[] } ).children?.length ) {
+			container.removeChild( ( container as Container & { children: Component[] } ).children[ 0 ] );
+		}
+	}
+
 	private renderSitePicker(): void {
 		if ( ! this.sitePickerContainer ) {
 			return;
 		}
-		// Clear previous children
-		while (
-			( this.sitePickerContainer as Container & { children?: unknown[] } ).children?.length
-		) {
-			this.sitePickerContainer.removeChild(
-				( this.sitePickerContainer as Container & { children: Component[] } ).children[ 0 ]
-			);
-		}
+		this.clearContainer( this.sitePickerContainer );
 
 		const isLocal = this.sitePickerTab === SITE_PICKER_TAB_LOCAL;
 		const localTab = isLocal ? chalk.bold( '[Local]' ) : chalk.dim( 'Local' );
 		const remoteTab = isLocal ? chalk.dim( 'WordPress.com' ) : chalk.bold( '[WordPress.com]' );
 		const header = `  ${ localTab }  ${ remoteTab }`;
 
-		const filtered = this.getFilteredSitePickerItems();
-
-		let items: string[];
-		let scrollInfo = '';
-		if ( isLocal ) {
-			if ( filtered.length === 0 ) {
-				items = [ chalk.dim( '  No matching sites.' ) ];
-			} else {
-				const { start, end } = this.getVisibleWindow( filtered.length );
-				items = filtered.slice( start, end ).map( ( site, vi ) => {
-					const i = start + vi;
-					const status = site.running ? chalk.green( '●' ) + ' ' : '  ';
-					if ( i === this.sitePickerSelectedIndex ) {
-						return `  ${ chalk.blue( '❯' ) } ${ status }${ chalk.bold( site.name ) }`;
-					}
-					return `    ${ status }${ site.name }`;
-				} );
-				scrollInfo = this.getScrollInfo( filtered.length, start, end );
-			}
-		} else if ( this.sitePickerRemoteLoading ) {
-			items = [ chalk.dim( '  Loading WordPress.com sites…' ) ];
-		} else if ( filtered.length === 0 ) {
-			items = [
-				chalk.dim(
-					this.sitePickerQuery ? '  No matching sites.' : '  No WordPress.com sites found.'
-				),
-			];
-		} else {
-			const { start, end } = this.getVisibleWindow( filtered.length );
-			items = filtered.slice( start, end ).map( ( site, vi ) => {
-				const i = start + vi;
-				const url = site.url ? ` ${ chalk.dim( site.url ) }` : '';
-				if ( i === this.sitePickerSelectedIndex ) {
-					return `  ${ chalk.blue( '❯' ) } ${ chalk.bold( site.name ) }${ url }`;
-				}
-				return `    ${ site.name }${ url }`;
-			} );
-			scrollInfo = this.getScrollInfo( filtered.length, start, end );
-		}
+		const { items, scrollInfo } = this.getSitePickerRows();
 
 		const searchLine = this.sitePickerQuery
 			? `  ${ chalk.dim( 'Search:' ) } ${ this.sitePickerQuery }`
@@ -1002,10 +1002,8 @@ export class AiChatUI {
 		this.sitePickerVisible = false;
 		this.sitePickerItems = [];
 		this.sitePickerSiteData = [];
-		this.sitePickerTab = SITE_PICKER_TAB_LOCAL;
 		this.sitePickerRemoteItems = [];
-		this.sitePickerRemoteLoading = false;
-		this.sitePickerQuery = '';
+		this.resetSitePickerTab( SITE_PICKER_TAB_LOCAL );
 		this.updateHints();
 		this.tui.requestRender();
 	}
@@ -1014,13 +1012,7 @@ export class AiChatUI {
 		if ( ! this.optionPickerContainer ) {
 			return;
 		}
-		while (
-			( this.optionPickerContainer as Container & { children?: unknown[] } ).children?.length
-		) {
-			this.optionPickerContainer.removeChild(
-				( this.optionPickerContainer as Container & { children: Component[] } ).children[ 0 ]
-			);
-		}
+		this.clearContainer( this.optionPickerContainer );
 
 		const items = this.optionPickerItems.map( ( opt, i ) => {
 			if ( i === this.optionPickerSelectedIndex ) {

--- a/apps/cli/ai/ui.ts
+++ b/apps/cli/ai/ui.ts
@@ -618,13 +618,6 @@ export class AiChatUI {
 	private async openSitePicker(): Promise< void > {
 		const appdata = await readAppdata();
 		const sites: SiteData[] = appdata.sites ?? [];
-		if ( sites.length === 0 ) {
-			this.messages.addChild(
-				new Text( chalk.dim( '  No sites found. Create one first.' ), 1, 0 )
-			);
-			this.tui.requestRender();
-			return;
-		}
 
 		this.sitePickerSiteData = sites;
 		this.sitePickerItems = await Promise.all(
@@ -643,14 +636,21 @@ export class AiChatUI {
 	}
 
 	private async switchToRemoteSites(): Promise< void > {
+		let token: Awaited< ReturnType< typeof getAuthToken > >;
 		try {
-			const token = await getAuthToken();
-			this.sitePickerTab = SITE_PICKER_TAB_REMOTE;
-			this.sitePickerRemoteLoading = true;
-			this.sitePickerRemoteItems = [];
-			this.sitePickerQuery = '';
-			this.renderSitePicker();
+			token = await getAuthToken();
+		} catch {
+			this.showSitePickerError( 'Not logged in. Use /login first.' );
+			return;
+		}
 
+		this.sitePickerTab = SITE_PICKER_TAB_REMOTE;
+		this.sitePickerRemoteLoading = true;
+		this.sitePickerRemoteItems = [];
+		this.sitePickerQuery = '';
+		this.renderSitePicker();
+
+		try {
 			const sites = await getWpComSites( token.accessToken );
 			this.sitePickerRemoteItems = sites.map( ( site ) => ( {
 				name: site.name,
@@ -665,13 +665,15 @@ export class AiChatUI {
 		} catch {
 			this.sitePickerRemoteLoading = false;
 			this.sitePickerRemoteItems = [];
-			this.sitePickerTab = SITE_PICKER_TAB_LOCAL;
-			this.renderSitePicker();
-			this.messages.addChild(
-				new Text( `\n${ chalk.dim( 'Not logged in. Use /login first.' ) }\n`, 1, 0 )
-			);
-			this.tui.requestRender();
+			this.showSitePickerError( 'Failed to load WordPress.com sites. Please try again.' );
 		}
+	}
+
+	private showSitePickerError( message: string ): void {
+		this.sitePickerTab = SITE_PICKER_TAB_LOCAL;
+		this.renderSitePicker();
+		this.messages.addChild( new Text( `\n${ chalk.dim( message ) }\n`, 1, 0 ) );
+		this.tui.requestRender();
 	}
 
 	private switchToLocalSites(): void {
@@ -870,7 +872,14 @@ export class AiChatUI {
 	}
 
 	private isSameSite( a: SiteInfo | null, b: SiteInfo ): boolean {
-		return !! a && ( a.name.toLowerCase() === b.name.toLowerCase() || a.path === b.path );
+		if ( ! a ) {
+			return false;
+		}
+		// Remote sites have no stable path, so never match them against local sites
+		if ( a.remote !== b.remote ) {
+			return false;
+		}
+		return a.path === b.path || a.name.toLowerCase() === b.name.toLowerCase();
 	}
 
 	private async autoSelectSiteFromToolResult(

--- a/apps/cli/ai/ui.ts
+++ b/apps/cli/ai/ui.ts
@@ -801,6 +801,7 @@ export class AiChatUI {
 		if ( scrollInfo ) {
 			lines.push( chalk.dim( `  ${ scrollInfo }` ) );
 		}
+		lines.push( '' );
 		lines.push( chalk.dim( hints ) );
 
 		const text = lines.join( '\n' );

--- a/apps/cli/ai/ui.ts
+++ b/apps/cli/ai/ui.ts
@@ -31,6 +31,10 @@ import { isSiteRunning } from 'cli/lib/site-utils';
 import type { SDKMessage } from '@anthropic-ai/claude-agent-sdk';
 import type { TodoWriteInput } from '@anthropic-ai/claude-agent-sdk/sdk-tools';
 
+const SITE_PICKER_TAB_LOCAL = 'local' as const;
+const SITE_PICKER_TAB_REMOTE = 'remote' as const;
+type SitePickerTab = typeof SITE_PICKER_TAB_LOCAL | typeof SITE_PICKER_TAB_REMOTE;
+
 export interface SiteInfo {
 	name: string;
 	path: string;
@@ -426,7 +430,7 @@ export class AiChatUI {
 	private sitePickerItems: SiteInfo[] = [];
 	private sitePickerSiteData: SiteData[] = [];
 	private sitePickerSelectedIndex = 0;
-	private sitePickerTab: 'local' | 'remote' = 'local';
+	private sitePickerTab: SitePickerTab = SITE_PICKER_TAB_LOCAL;
 	private sitePickerRemoteItems: SiteInfo[] = [];
 	private sitePickerRemoteLoading = false;
 	private sitePickerQuery = '';
@@ -565,11 +569,11 @@ export class AiChatUI {
 					}
 					return { consume: true };
 				}
-				if ( matchesKey( data, 'right' ) && this.sitePickerTab === 'local' ) {
+				if ( matchesKey( data, 'right' ) && this.sitePickerTab === SITE_PICKER_TAB_LOCAL ) {
 					void this.switchToRemoteSites();
 					return { consume: true };
 				}
-				if ( matchesKey( data, 'left' ) && this.sitePickerTab === 'remote' ) {
+				if ( matchesKey( data, 'left' ) && this.sitePickerTab === SITE_PICKER_TAB_REMOTE ) {
 					this.switchToLocalSites();
 					return { consume: true };
 				}
@@ -641,7 +645,7 @@ export class AiChatUI {
 	private async switchToRemoteSites(): Promise< void > {
 		try {
 			const token = await getAuthToken();
-			this.sitePickerTab = 'remote';
+			this.sitePickerTab = SITE_PICKER_TAB_REMOTE;
 			this.sitePickerRemoteLoading = true;
 			this.sitePickerRemoteItems = [];
 			this.sitePickerQuery = '';
@@ -661,7 +665,7 @@ export class AiChatUI {
 		} catch {
 			this.sitePickerRemoteLoading = false;
 			this.sitePickerRemoteItems = [];
-			this.sitePickerTab = 'local';
+			this.sitePickerTab = SITE_PICKER_TAB_LOCAL;
 			this.renderSitePicker();
 			this.messages.addChild(
 				new Text( '\n' + chalk.dim( 'Not logged in. Use /login first.' ) + '\n', 1, 0 )
@@ -671,7 +675,7 @@ export class AiChatUI {
 	}
 
 	private switchToLocalSites(): void {
-		this.sitePickerTab = 'local';
+		this.sitePickerTab = SITE_PICKER_TAB_LOCAL;
 		this.sitePickerSelectedIndex = 0;
 		this.sitePickerQuery = '';
 		this.renderSitePicker();
@@ -679,7 +683,9 @@ export class AiChatUI {
 
 	private getFilteredSitePickerItems(): SiteInfo[] {
 		const allItems =
-			this.sitePickerTab === 'remote' ? this.sitePickerRemoteItems : this.sitePickerItems;
+			this.sitePickerTab === SITE_PICKER_TAB_REMOTE
+				? this.sitePickerRemoteItems
+				: this.sitePickerItems;
 		if ( ! this.sitePickerQuery ) {
 			return allItems;
 		}
@@ -727,7 +733,7 @@ export class AiChatUI {
 			);
 		}
 
-		const isLocal = this.sitePickerTab === 'local';
+		const isLocal = this.sitePickerTab === SITE_PICKER_TAB_LOCAL;
 		const localTab = isLocal ? chalk.bold( '[Local]' ) : chalk.dim( 'Local' );
 		const remoteTab = isLocal ? chalk.dim( 'WordPress.com' ) : chalk.bold( '[WordPress.com]' );
 		const header = `  ${ localTab }  ${ remoteTab }`;
@@ -1004,7 +1010,7 @@ export class AiChatUI {
 		this.sitePickerVisible = false;
 		this.sitePickerItems = [];
 		this.sitePickerSiteData = [];
-		this.sitePickerTab = 'local';
+		this.sitePickerTab = SITE_PICKER_TAB_LOCAL;
 		this.sitePickerRemoteItems = [];
 		this.sitePickerRemoteLoading = false;
 		this.sitePickerQuery = '';

--- a/apps/cli/ai/ui.ts
+++ b/apps/cli/ai/ui.ts
@@ -24,7 +24,8 @@ import {
 	type TodoDiff,
 	type TodoEntry,
 } from 'cli/ai/todo-stream';
-import { getSiteUrl, readAppdata, type SiteData } from 'cli/lib/appdata';
+import { getWpComSites } from 'cli/lib/api';
+import { getAuthToken, getSiteUrl, readAppdata, type SiteData } from 'cli/lib/appdata';
 import { openBrowser } from 'cli/lib/browser';
 import { isSiteRunning } from 'cli/lib/site-utils';
 import type { SDKMessage } from '@anthropic-ai/claude-agent-sdk';
@@ -34,6 +35,8 @@ export interface SiteInfo {
 	name: string;
 	path: string;
 	running: boolean;
+	remote?: boolean;
+	url?: string;
 }
 
 const FILE_PREVIEW_MAX_LINES = 10;
@@ -423,6 +426,10 @@ export class AiChatUI {
 	private sitePickerItems: SiteInfo[] = [];
 	private sitePickerSiteData: SiteData[] = [];
 	private sitePickerSelectedIndex = 0;
+	private sitePickerTab: 'local' | 'remote' = 'local';
+	private sitePickerRemoteItems: SiteInfo[] = [];
+	private sitePickerRemoteLoading = false;
+	private sitePickerQuery = '';
 
 	get activeSite(): SiteInfo | null {
 		return this._activeSite;
@@ -531,23 +538,64 @@ export class AiChatUI {
 					return { consume: true };
 				}
 				if ( matchesKey( data, 'down' ) ) {
+					const filtered = this.getFilteredSitePickerItems();
 					this.sitePickerSelectedIndex = Math.min(
-						this.sitePickerItems.length - 1,
+						filtered.length - 1,
 						this.sitePickerSelectedIndex + 1
 					);
 					this.renderSitePicker();
 					return { consume: true };
 				}
 				if ( matchesKey( data, 'enter' ) ) {
-					this.selectSite( this.sitePickerSelectedIndex );
+					const filtered = this.getFilteredSitePickerItems();
+					const selectedItem = filtered[ this.sitePickerSelectedIndex ];
+					if ( selectedItem ) {
+						this.selectFilteredSite( selectedItem );
+					}
 					return { consume: true };
 				}
 				if ( matchesKey( data, 'space' ) ) {
-					void this.openSelectedSite();
+					// If there's an active search query, treat space as a search character
+					if ( this.sitePickerQuery ) {
+						this.sitePickerQuery += ' ';
+						this.sitePickerSelectedIndex = 0;
+						this.renderSitePicker();
+					} else {
+						void this.openSelectedSite();
+					}
+					return { consume: true };
+				}
+				if ( matchesKey( data, 'right' ) && this.sitePickerTab === 'local' ) {
+					void this.switchToRemoteSites();
+					return { consume: true };
+				}
+				if ( matchesKey( data, 'left' ) && this.sitePickerTab === 'remote' ) {
+					this.switchToLocalSites();
 					return { consume: true };
 				}
 				if ( matchesKey( data, 'escape' ) ) {
-					this.closeSitePicker();
+					if ( this.sitePickerQuery ) {
+						this.sitePickerQuery = '';
+						this.sitePickerSelectedIndex = 0;
+						this.renderSitePicker();
+					} else {
+						this.closeSitePicker();
+					}
+					return { consume: true };
+				}
+				if ( matchesKey( data, 'backspace' ) ) {
+					if ( this.sitePickerQuery ) {
+						this.sitePickerQuery = this.sitePickerQuery.slice( 0, -1 );
+						this.sitePickerSelectedIndex = 0;
+						this.renderSitePicker();
+					}
+					return { consume: true };
+				}
+				// Printable character — append to search query
+				if ( data.length === 1 && data >= ' ' && data <= '~' ) {
+					this.sitePickerQuery += data;
+					this.sitePickerSelectedIndex = 0;
+					this.renderSitePicker();
 					return { consume: true };
 				}
 				return { consume: true };
@@ -590,6 +638,82 @@ export class AiChatUI {
 		this.renderSitePicker();
 	}
 
+	private async switchToRemoteSites(): Promise< void > {
+		try {
+			const token = await getAuthToken();
+			this.sitePickerTab = 'remote';
+			this.sitePickerRemoteLoading = true;
+			this.sitePickerRemoteItems = [];
+			this.sitePickerQuery = '';
+			this.renderSitePicker();
+
+			const sites = await getWpComSites( token.accessToken );
+			this.sitePickerRemoteItems = sites.map( ( site ) => ( {
+				name: site.name,
+				path: '',
+				running: false,
+				remote: true,
+				url: site.url,
+			} ) );
+			this.sitePickerRemoteLoading = false;
+			this.sitePickerSelectedIndex = 0;
+			this.renderSitePicker();
+		} catch {
+			this.sitePickerRemoteLoading = false;
+			this.sitePickerRemoteItems = [];
+			this.sitePickerTab = 'local';
+			this.renderSitePicker();
+			this.messages.addChild(
+				new Text( '\n' + chalk.dim( 'Not logged in. Use /login first.' ) + '\n', 1, 0 )
+			);
+			this.tui.requestRender();
+		}
+	}
+
+	private switchToLocalSites(): void {
+		this.sitePickerTab = 'local';
+		this.sitePickerSelectedIndex = 0;
+		this.sitePickerQuery = '';
+		this.renderSitePicker();
+	}
+
+	private getFilteredSitePickerItems(): SiteInfo[] {
+		const allItems =
+			this.sitePickerTab === 'remote' ? this.sitePickerRemoteItems : this.sitePickerItems;
+		if ( ! this.sitePickerQuery ) {
+			return allItems;
+		}
+		const query = this.sitePickerQuery.toLowerCase();
+		return allItems.filter(
+			( site ) =>
+				site.name.toLowerCase().includes( query ) ||
+				( site.url && site.url.toLowerCase().includes( query ) )
+		);
+	}
+
+	private selectFilteredSite( site: SiteInfo ): void {
+		if ( site.remote ) {
+			this._activeSite = site;
+			this._activeSiteData = null;
+		} else {
+			const originalIndex = this.sitePickerItems.indexOf( site );
+			this._activeSite = site;
+			this._activeSiteData =
+				originalIndex >= 0 ? this.sitePickerSiteData[ originalIndex ] ?? null : null;
+		}
+		this.editor.activeSiteName = site.name;
+		const label = site.remote
+			? ' ✻ Selected site: ' + site.name + ' (WordPress.com)'
+			: ' ✻ Selected site: ' + site.name;
+		this.messages.addChild( new Text( chalk.hex( '#8839ef' )( label ) + '\n', 0, 0 ) );
+		this.closeSitePicker();
+	}
+
+	private sitePickerPageSize(): number {
+		// Reserve 3 lines for header, hints, and a margin; use at least 5 visible items
+		return Math.max( 5, ( process.stdout.rows ?? 24 ) - 3 );
+	}
+
 	private renderSitePicker(): void {
 		if ( ! this.sitePickerContainer ) {
 			return;
@@ -603,20 +727,70 @@ export class AiChatUI {
 			);
 		}
 
-		const header = chalk.dim( '  Select a site:' );
-		const items = this.sitePickerItems.map( ( site, i ) => {
-			const status = site.running ? chalk.green( '●' ) + ' ' : '  ';
-			if ( i === this.sitePickerSelectedIndex ) {
-				return `  ${ chalk.blue( '❯' ) } ${ status }${ chalk.bold( site.name ) }`;
-			}
-			return `    ${ status }${ site.name }`;
-		} );
+		const isLocal = this.sitePickerTab === 'local';
+		const localTab = isLocal ? chalk.bold( '[Local]' ) : chalk.dim( 'Local' );
+		const remoteTab = isLocal ? chalk.dim( 'WordPress.com' ) : chalk.bold( '[WordPress.com]' );
+		const header = `  ${ localTab }  ${ remoteTab }`;
 
-		const text = [
-			header,
-			...items,
-			chalk.dim( '  ↑↓ navigate · enter select · space open in browser · esc cancel' ),
-		].join( '\n' );
+		const filtered = this.getFilteredSitePickerItems();
+
+		let items: string[];
+		let scrollInfo = '';
+		if ( isLocal ) {
+			if ( filtered.length === 0 ) {
+				items = [ chalk.dim( '  No matching sites.' ) ];
+			} else {
+				const { start, end } = this.getVisibleWindow( filtered.length );
+				items = filtered.slice( start, end ).map( ( site, vi ) => {
+					const i = start + vi;
+					const status = site.running ? chalk.green( '●' ) + ' ' : '  ';
+					if ( i === this.sitePickerSelectedIndex ) {
+						return `  ${ chalk.blue( '❯' ) } ${ status }${ chalk.bold( site.name ) }`;
+					}
+					return `    ${ status }${ site.name }`;
+				} );
+				scrollInfo = this.getScrollInfo( filtered.length, start, end );
+			}
+		} else if ( this.sitePickerRemoteLoading ) {
+			items = [ chalk.dim( '  Loading WordPress.com sites…' ) ];
+		} else if ( filtered.length === 0 ) {
+			items = [
+				chalk.dim(
+					this.sitePickerQuery ? '  No matching sites.' : '  No WordPress.com sites found.'
+				),
+			];
+		} else {
+			const { start, end } = this.getVisibleWindow( filtered.length );
+			items = filtered.slice( start, end ).map( ( site, vi ) => {
+				const i = start + vi;
+				const url = site.url ? ' ' + chalk.dim( site.url ) : '';
+				if ( i === this.sitePickerSelectedIndex ) {
+					return `  ${ chalk.blue( '❯' ) } ${ chalk.bold( site.name ) }${ url }`;
+				}
+				return `    ${ site.name }${ url }`;
+			} );
+			scrollInfo = this.getScrollInfo( filtered.length, start, end );
+		}
+
+		const searchLine = this.sitePickerQuery
+			? `  ${ chalk.dim( 'Search:' ) } ${ this.sitePickerQuery }`
+			: '';
+
+		const hints = isLocal
+			? '  ↑↓ navigate · → remote sites · enter select · space open in browser · esc cancel'
+			: '  ↑↓ navigate · ← local sites · enter select · space open in browser · esc cancel';
+
+		const lines = [ header ];
+		if ( searchLine ) {
+			lines.push( searchLine );
+		}
+		lines.push( ...items );
+		if ( scrollInfo ) {
+			lines.push( chalk.dim( `  ${ scrollInfo }` ) );
+		}
+		lines.push( chalk.dim( hints ) );
+
+		const text = lines.join( '\n' );
 		this.sitePickerContainer.addChild( new Text( text, 0, 0 ) );
 		this.tui.requestRender();
 	}
@@ -628,6 +802,32 @@ export class AiChatUI {
 			this._activeSiteData = this.sitePickerSiteData[ index ] ?? null;
 		}
 		this.closeSitePicker();
+	}
+
+	private getVisibleWindow( totalItems: number ): { start: number; end: number } {
+		const pageSize = this.sitePickerPageSize();
+		if ( totalItems <= pageSize ) {
+			return { start: 0, end: totalItems };
+		}
+		// Keep the selected item visible with some padding from the edges
+		let start = this.sitePickerSelectedIndex - Math.floor( pageSize / 2 );
+		start = Math.max( 0, Math.min( start, totalItems - pageSize ) );
+		return { start, end: start + pageSize };
+	}
+
+	private getScrollInfo( totalItems: number, start: number, end: number ): string {
+		const pageSize = this.sitePickerPageSize();
+		if ( totalItems <= pageSize ) {
+			return '';
+		}
+		const parts: string[] = [];
+		if ( start > 0 ) {
+			parts.push( `↑ ${ start } more` );
+		}
+		if ( end < totalItems ) {
+			parts.push( `↓ ${ totalItems - end } more` );
+		}
+		return parts.join( '  ' );
 	}
 
 	private setActiveSite( site: SiteInfo ): void {
@@ -753,7 +953,20 @@ export class AiChatUI {
 	}
 
 	private async openSelectedSite(): Promise< void > {
-		const siteData = this.sitePickerSiteData[ this.sitePickerSelectedIndex ];
+		const filtered = this.getFilteredSitePickerItems();
+		const site = filtered[ this.sitePickerSelectedIndex ];
+		if ( ! site ) {
+			return;
+		}
+		if ( site.remote && site.url ) {
+			await openBrowser( site.url );
+			return;
+		}
+		if ( ! site.running ) {
+			return;
+		}
+		const originalIndex = this.sitePickerItems.indexOf( site );
+		const siteData = originalIndex >= 0 ? this.sitePickerSiteData[ originalIndex ] : undefined;
 		if ( ! siteData ) {
 			return;
 		}
@@ -764,6 +977,10 @@ export class AiChatUI {
 	}
 
 	async openActiveSiteInBrowser(): Promise< boolean > {
+		if ( this._activeSite?.remote && this._activeSite?.url ) {
+			await openBrowser( this._activeSite.url );
+			return true;
+		}
 		if ( ! this._activeSiteData ) {
 			return false;
 		}
@@ -787,6 +1004,10 @@ export class AiChatUI {
 		this.sitePickerVisible = false;
 		this.sitePickerItems = [];
 		this.sitePickerSiteData = [];
+		this.sitePickerTab = 'local';
+		this.sitePickerRemoteItems = [];
+		this.sitePickerRemoteLoading = false;
+		this.sitePickerQuery = '';
 		this.updateHints();
 		this.tui.requestRender();
 	}

--- a/apps/cli/ai/ui.ts
+++ b/apps/cli/ai/ui.ts
@@ -715,11 +715,29 @@ export class AiChatUI {
 	private formatSiteRow( site: SiteInfo, index: number ): string {
 		const selected = index === this.sitePickerSelectedIndex;
 		const prefix = selected ? `  ${ chalk.blue( '❯' ) } ` : '    ';
-		const name = selected ? chalk.bold( site.name ) : site.name;
 		if ( site.remote ) {
-			const url = site.url ? ` ${ chalk.dim( site.url ) }` : '';
+			const nameColumnWidth = 30;
+			const prefixWidth = 4; // "  ❯ " or "    "
+			const gap = 2;
+			const termWidth = process.stdout.columns ?? 80;
+			const urlColumnWidth = termWidth - prefixWidth - nameColumnWidth - gap;
+			const truncatedName =
+				site.name.length > nameColumnWidth
+					? site.name.slice( 0, nameColumnWidth - 1 ) + '…'
+					: site.name.padEnd( nameColumnWidth );
+			const name = selected ? chalk.bold( truncatedName ) : truncatedName;
+			const displayUrl = site.url ? site.url.replace( /^https?:\/\//, '' ) : '';
+			let url = '';
+			if ( displayUrl && urlColumnWidth > 3 ) {
+				const truncatedUrl =
+					displayUrl.length > urlColumnWidth
+						? displayUrl.slice( 0, urlColumnWidth - 1 ) + '…'
+						: displayUrl;
+				url = `  ${ chalk.dim( truncatedUrl ) }`;
+			}
 			return `${ prefix }${ name }${ url }`;
 		}
+		const name = selected ? chalk.bold( site.name ) : site.name;
 		const status = site.running ? `${ chalk.green( '●' ) } ` : '  ';
 		return `${ prefix }${ status }${ name }`;
 	}

--- a/apps/cli/ai/ui.ts
+++ b/apps/cli/ai/ui.ts
@@ -559,11 +559,9 @@ export class AiChatUI {
 					return { consume: true };
 				}
 				if ( matchesKey( data, 'space' ) ) {
-					// If there's an active search query, treat space as a search character
+					// Space opens browser unless a search is active, in which case it's a search character
 					if ( this.sitePickerQuery ) {
-						this.sitePickerQuery += ' ';
-						this.sitePickerSelectedIndex = 0;
-						this.renderSitePicker();
+						this.setSitePickerQuery( `${ this.sitePickerQuery } ` );
 					} else {
 						void this.openSelectedSite();
 					}
@@ -579,9 +577,7 @@ export class AiChatUI {
 				}
 				if ( matchesKey( data, 'escape' ) ) {
 					if ( this.sitePickerQuery ) {
-						this.sitePickerQuery = '';
-						this.sitePickerSelectedIndex = 0;
-						this.renderSitePicker();
+						this.setSitePickerQuery( '' );
 					} else {
 						this.closeSitePicker();
 					}
@@ -589,17 +585,13 @@ export class AiChatUI {
 				}
 				if ( matchesKey( data, 'backspace' ) ) {
 					if ( this.sitePickerQuery ) {
-						this.sitePickerQuery = this.sitePickerQuery.slice( 0, -1 );
-						this.sitePickerSelectedIndex = 0;
-						this.renderSitePicker();
+						this.setSitePickerQuery( this.sitePickerQuery.slice( 0, -1 ) );
 					}
 					return { consume: true };
 				}
 				// Printable character — append to search query
 				if ( data.length === 1 && data >= ' ' && data <= '~' ) {
-					this.sitePickerQuery += data;
-					this.sitePickerSelectedIndex = 0;
-					this.renderSitePicker();
+					this.setSitePickerQuery( `${ this.sitePickerQuery }${ data }` );
 					return { consume: true };
 				}
 				return { consume: true };
@@ -683,6 +675,12 @@ export class AiChatUI {
 		this.renderSitePicker();
 	}
 
+	private setSitePickerQuery( query: string ): void {
+		this.sitePickerQuery = query;
+		this.sitePickerSelectedIndex = 0;
+		this.renderSitePicker();
+	}
+
 	private getFilteredSitePickerItems(): SiteInfo[] {
 		const allItems =
 			this.sitePickerTab === SITE_PICKER_TAB_REMOTE
@@ -701,18 +699,13 @@ export class AiChatUI {
 
 	private selectFilteredSite( site: SiteInfo ): void {
 		if ( site.remote ) {
-			this._activeSite = site;
 			this._activeSiteData = null;
 		} else {
 			const originalIndex = this.sitePickerItems.indexOf( site );
-			this._activeSite = site;
 			this._activeSiteData =
 				originalIndex >= 0 ? this.sitePickerSiteData[ originalIndex ] ?? null : null;
 		}
-		this.editor.activeSiteName = site.name;
-		const suffix = site.remote ? ' (WordPress.com)' : '';
-		const label = ` ✻ Selected site: ${ site.name }${ suffix }`;
-		this.messages.addChild( new Text( `${ chalk.hex( '#8839ef' )( label ) }\n`, 0, 0 ) );
+		this.setActiveSite( site );
 		this.closeSitePicker();
 	}
 
@@ -831,9 +824,9 @@ export class AiChatUI {
 	private setActiveSite( site: SiteInfo ): void {
 		this._activeSite = site;
 		this.editor.activeSiteName = site.name;
-		this.messages.addChild(
-			new Text( chalk.hex( '#8839ef' )( ' ✻ Selected site: ' + site.name ) + '\n', 0, 0 )
-		);
+		const suffix = site.remote ? ' (WordPress.com)' : '';
+		const label = ` ✻ Selected site: ${ site.name }${ suffix }`;
+		this.messages.addChild( new Text( `${ chalk.hex( '#8839ef' )( label ) }\n`, 0, 0 ) );
 		this.tui.requestRender();
 	}
 

--- a/apps/cli/commands/ai.ts
+++ b/apps/cli/commands/ai.ts
@@ -85,7 +85,9 @@ export async function runCommand(): Promise< void > {
 		// Prepend active site context to the prompt
 		let enrichedPrompt = prompt;
 		const site = ui.activeSite;
-		if ( site ) {
+		if ( site?.remote && site?.url ) {
+			enrichedPrompt = `[Active site: "${ site.name }" at ${ site.url } (WordPress.com)]\n\n${ prompt }`;
+		} else if ( site ) {
 			enrichedPrompt = `[Active site: "${ site.name }" at ${ site.path }${
 				site.running ? ' (running)' : ' (stopped)'
 			}]\n\n${ prompt }`;

--- a/apps/cli/commands/ai.ts
+++ b/apps/cli/commands/ai.ts
@@ -82,7 +82,8 @@ export async function runCommand(): Promise< void > {
 	async function runAgentTurn( prompt: string ): Promise< void > {
 		ui.beginAgentTurn();
 
-		// Prepend active site context to the prompt
+		// Prepend active site context to the prompt.
+		// Remote (WordPress.com) sites only have a URL; local sites have a filesystem path and running state.
 		let enrichedPrompt = prompt;
 		const site = ui.activeSite;
 		if ( site?.remote && site?.url ) {

--- a/apps/cli/lib/api.ts
+++ b/apps/cli/lib/api.ts
@@ -166,6 +166,53 @@ export async function getUserInfo(
 	}
 }
 
+export interface WpComSiteInfo {
+	id: number;
+	name: string;
+	url: string;
+}
+
+const wpComSitesResponseSchema = z.object( {
+	sites: z.array(
+		z.object( {
+			ID: z.number(),
+			name: z.string(),
+			URL: z.string(),
+			is_deleted: z.boolean().optional(),
+		} )
+	),
+} );
+
+export async function getWpComSites( token: string ): Promise< WpComSiteInfo[] > {
+	const wpcom = wpcomFactory( token, wpcomXhrRequest );
+	try {
+		const rawResponse = await wpcom.req.get(
+			{
+				apiNamespace: 'rest/v1.2',
+				path: '/me/sites',
+			},
+			{
+				fields: 'ID,name,URL,is_deleted',
+				filter: 'atomic,wpcom',
+				site_activity: 'active',
+			}
+		);
+		const result = wpComSitesResponseSchema.parse( rawResponse );
+		return result.sites
+			.filter( ( site ) => ! site.is_deleted )
+			.map( ( site ) => ( {
+				id: site.ID,
+				name: site.name,
+				url: site.URL,
+			} ) );
+	} catch ( error ) {
+		if ( error instanceof z.ZodError ) {
+			throw new LoggerError( __( 'Invalid API response format' ), error );
+		}
+		throw new LoggerError( __( 'Failed to fetch WordPress.com sites' ), error );
+	}
+}
+
 export async function revokeAuthToken( token: string ): Promise< void > {
 	const wpcom = wpcomFactory( token, wpcomXhrRequest );
 	try {


### PR DESCRIPTION
## Related issues

- Related to AI chat site picker improvements

## How AI was used in this PR

This PR was largely AI-generated (Claude Code). All code has been reviewed, linted, and type-checked. Manual testing recommended.

## Proposed Changes

- Add a tabbed site picker (`[Local]` / `[WordPress.com]`) to the AI chat, navigable with `→`/`←` arrow keys
- Fetch WordPress.com sites via the `/me/sites` REST API when switching to the remote tab
- Add pagination with scroll indicators (`↑ N more` / `↓ N more`) for long site lists
- Add type-to-search filtering across both tabs (matches site name and URL)
- Enrich AI prompts with remote site context (name + URL) when a WordPress.com site is selected
- Support opening remote sites in browser via `tab` key or `/browser` command

## Testing Instructions

1. Build the CLI: `npm run cli:build`
2. Run: `ENABLE_STUDIO_AI=true node apps/cli/dist/cli/main.js ai`
3. Press `↓` to open the site picker — local sites tab appears
4. Press `→` to switch to WordPress.com tab (requires `/login` first)
5. Type to filter the site list, press `esc` to clear the search
6. Press `←` to switch back to local sites
7. Select a remote site with `enter` — verify the prompt shows `(WordPress.com)` context
8. Press `tab` on a remote site — verify it opens in the browser

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?