### PR TITLE
Fix CLI dev path references to use apps/cli/dist/cli/main.js

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ WordPress Studio - Electron desktop app for managing local WordPress sites. Buil
 
 ## CLI Commands
 
-**MUST** build CLI before testing: `npm run cli:build && node dist/cli/main.js <command>`
+**MUST** build CLI before testing: `npm run cli:build && node apps/cli/dist/cli/main.js <command>`
 - **Auth**: `auth login|logout|status` - WordPress.com OAuth (tokens valid 2 weeks)
 - **Preview Sites**: See `apps/cli/commands/preview/`
 - **Local Sites**: See `apps/cli/commands/site/`

--- a/apps/studio/bin/studio-cli.sh
+++ b/apps/studio/bin/studio-cli.sh
@@ -14,8 +14,8 @@ else
 	# If the default script path is not found, assume that this script lives in the development directory
 	# and look for the CLI JS bundle in the `./dist` directory
 	if ! [ -f "$CLI_SCRIPT" ]; then
-		SCRIPT_DIR=$(dirname "$(dirname "$(realpath "$0")")")
-		CLI_SCRIPT="$SCRIPT_DIR/dist/cli/main.js"
+		STUDIO_DIR=$(dirname "$(dirname "$(realpath "$0")")")
+		CLI_SCRIPT="$(dirname "$STUDIO_DIR")/cli/dist/cli/main.js"
 	fi
 
 	# Prevent node from printing warnings about NODE_OPTIONS being ignored

--- a/docs/code-contributions.md
+++ b/docs/code-contributions.md
@@ -70,10 +70,10 @@ The CLI is built separately from the Electron app. There are two commands to be 
 - `npm run cli:build` runs a one-time build.
 - `npm run cli:watch` watches the source files and rebuilds automatically.
 
-Both commands output a `dist/cli/main.js` file. To test the newly built CLI code, run the following command:
+Both commands output a `apps/cli/dist/cli/main.js` file. To test the newly built CLI code, run the following command:
 
 ```
-node dist/cli/main.js
+node apps/cli/dist/cli/main.js
 ```
 
 ### Project Structure

--- a/docs/testing-with-local-playground.md
+++ b/docs/testing-with-local-playground.md
@@ -82,7 +82,7 @@ npm install
 
 ```bash
 npm run cli:build
-node dist/cli/main.js site create --name test-site
+node apps/cli/dist/cli/main.js site create --name test-site
 ```
 
 ### 6. Start Studio (optional)


### PR DESCRIPTION
## Related issues

- N/A

## How AI was used in this PR

Claude Code identified and updated all stale path references.

## Proposed Changes

- Update CLI dev path from `dist/cli/main.js` to `apps/cli/dist/cli/main.js` across docs, AGENTS.md, and the dev-mode fallback in `studio-cli.sh`

## Testing Instructions

- Run `npm run cli:build` and verify the output lands at `apps/cli/dist/cli/main.js`
- Run `node apps/cli/dist/cli/main.js --help` to confirm the CLI works from that path

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?