### PR TITLE
Replace AI assistant tab with agent UI

### DIFF
--- a/apps/cli/ai/agent.ts
+++ b/apps/cli/ai/agent.ts
@@ -1,6 +1,8 @@
-import { query, type Query } from '@anthropic-ai/claude-agent-sdk';
+import { query, type Query as QueryType } from '@anthropic-ai/claude-agent-sdk';
 import { buildSystemPrompt } from 'cli/ai/system-prompt';
 import { createStudioTools } from 'cli/ai/tools';
+
+export type Query = QueryType;
 
 export interface AskUserQuestion {
 	question: string;

--- a/apps/cli/commands/ai.ts
+++ b/apps/cli/commands/ai.ts
@@ -1,7 +1,14 @@
 import { execFileSync } from 'child_process';
 import { password } from '@inquirer/prompts';
 import { __ } from '@wordpress/i18n';
-import { AI_MODELS, DEFAULT_MODEL, startAiAgent, type AiModelId } from 'cli/ai/agent';
+import {
+	AI_MODELS,
+	DEFAULT_MODEL,
+	startAiAgent,
+	type AiModelId,
+	type AskUserQuestion,
+	type Query,
+} from 'cli/ai/agent';
 import {
 	AI_CHAT_BROWSER_COMMAND,
 	AI_CHAT_EXIT_COMMAND,
@@ -11,6 +18,10 @@ import { AiChatUI } from 'cli/ai/ui';
 import { getAnthropicApiKey, saveAnthropicApiKey } from 'cli/lib/appdata';
 import { Logger, LoggerError, setProgressCallback } from 'cli/logger';
 import { StudioArgv } from 'cli/types';
+import type {
+	ParentToChildMessage,
+	ChildToParentMessage,
+} from '@studio/common/types/agent-messages';
 
 const logger = new Logger< string >();
 
@@ -55,6 +66,119 @@ async function resolveApiKey(): Promise< string | undefined > {
 
 	await saveAnthropicApiKey( apiKey );
 	return apiKey;
+}
+
+function sendToParent( message: ChildToParentMessage ): void {
+	if ( process.send ) {
+		process.send( message );
+	}
+}
+
+/**
+ * Pipe mode: communicate with parent process via IPC instead of TUI.
+ * Used when the desktop app spawns `studio ai --pipe` as a child process.
+ */
+async function runPipeMode(): Promise< void > {
+	// Use API key from environment (passed by parent) or resolve from saved config
+	const apiKey = process.env.ANTHROPIC_API_KEY || ( await getAnthropicApiKey() ) || undefined;
+
+	let sessionId: string | undefined;
+	let currentQuery: Query | null = null;
+	let askUserResolve: ( ( answers: Record< string, string > ) => void ) | null = null;
+
+	// Wire up progress messages to IPC
+	setProgressCallback( ( message ) => {
+		sendToParent( {
+			type: 'agent-message',
+			message: {
+				type: 'user',
+				tool_use_result: { content: [ { type: 'text', text: `Progress: ${ message }` } ] },
+			},
+		} );
+	} );
+
+	process.on( 'message', ( msg: ParentToChildMessage ) => {
+		switch ( msg.type ) {
+			case 'prompt':
+				void handlePrompt(
+					msg.prompt,
+					msg.model as AiModelId | undefined,
+					msg.resume,
+					msg.siteContext
+				);
+				break;
+			case 'ask-user-response':
+				if ( askUserResolve ) {
+					const resolve = askUserResolve;
+					askUserResolve = null;
+					resolve( msg.answers );
+				}
+				break;
+			case 'interrupt':
+				if ( currentQuery ) {
+					void currentQuery.interrupt();
+				}
+				break;
+		}
+	} );
+
+	async function handlePrompt(
+		prompt: string,
+		model?: AiModelId,
+		resume?: string,
+		siteContext?: { name: string; path: string; running: boolean }
+	): Promise< void > {
+		// Prepend site context the same way the TUI does
+		let enrichedPrompt = prompt;
+		if ( siteContext ) {
+			enrichedPrompt = `[Active site: "${ siteContext.name }" at ${ siteContext.path }${
+				siteContext.running ? ' (running)' : ' (stopped)'
+			}]\n\n${ prompt }`;
+		}
+
+		const onAskUser = async (
+			questions: AskUserQuestion[]
+		): Promise< Record< string, string > > => {
+			sendToParent( { type: 'ask-user', questions } );
+			return new Promise( ( resolve ) => {
+				askUserResolve = resolve;
+			} );
+		};
+
+		const agentQuery = startAiAgent( {
+			prompt: enrichedPrompt,
+			apiKey,
+			model: model ?? DEFAULT_MODEL,
+			resume: resume ?? sessionId,
+			onAskUser,
+		} );
+		currentQuery = agentQuery;
+
+		try {
+			for await ( const message of agentQuery ) {
+				// Forward each SDK message to parent as-is (they are plain JSON-serializable objects)
+				sendToParent( {
+					type: 'agent-message',
+					message:
+						message as unknown as import('@studio/common/types/agent-messages').SerializedAgentMessage,
+				} );
+
+				// Extract session ID from result messages
+				if ( message.type === 'result' ) {
+					sessionId = message.session_id;
+				}
+			}
+		} catch ( error ) {
+			sendToParent( {
+				type: 'error',
+				message: error instanceof Error ? error.message : String( error ),
+			} );
+		} finally {
+			currentQuery = null;
+		}
+	}
+
+	sendToParent( { type: 'ready' } );
 }
 
 export async function runCommand(): Promise< void > {
@@ -183,13 +307,23 @@ export const registerCommand = ( yargs: StudioArgv ) => {
 		command: 'ai',
 		describe: __( 'AI-powered WordPress assistant' ),
 		builder: ( yargs ) => {
-			return yargs.option( 'path', {
-				hidden: true,
-			} );
+			return yargs
+				.option( 'path', {
+					hidden: true,
+				} )
+				.option( 'pipe', {
+					type: 'boolean' as const,
+					hidden: true,
+					default: false,
+				} );
 		},
-		handler: async () => {
+		handler: async ( argv ) => {
 			try {
-				await runCommand();
+				if ( argv.pipe ) {
+					await runPipeMode();
+				} else {
+					await runCommand();
+				}
 			} catch ( error ) {
 				if ( error instanceof LoggerError ) {
 					logger.reportError( error );

--- a/apps/studio/src/components/content-tab-agent.tsx
+++ b/apps/studio/src/components/content-tab-agent.tsx
@@ -1,0 +1,283 @@
+import { useI18n } from '@wordpress/react-i18n';
+import { useCallback, useEffect, useRef } from 'react';
+import Button from 'src/components/button';
+import { useAgentEvents } from 'src/hooks/use-agent-events';
+import { cx } from 'src/lib/cx';
+import { getIpcApi } from 'src/lib/get-ipc-api';
+import { useAppDispatch, useRootSelector } from 'src/stores';
+import { agentActions, type AgentUIMessage } from 'src/stores/agent-slice';
+
+function AgentTextMessage( { message }: { message: AgentUIMessage & { type: 'assistant-text' } } ) {
+	return (
+		<div className="px-4 py-2">
+			<div className="prose prose-sm max-w-none whitespace-pre-wrap">{ message.text }</div>
+		</div>
+	);
+}
+
+function AgentToolCall( { message }: { message: AgentUIMessage & { type: 'tool-call' } } ) {
+	const isRunning = ! message.endTime;
+	const elapsed = message.endTime
+		? ( ( message.endTime - message.startTime ) / 1000 ).toFixed( 1 )
+		: null;
+
+	return (
+		<div className="px-4 py-1">
+			<div className="flex items-center gap-2 text-sm text-gray-500">
+				<span
+					className={ cx(
+						'inline-block w-2 h-2 rounded-full',
+						isRunning && 'bg-yellow-500 animate-pulse',
+						! isRunning && message.isError && 'bg-red-500',
+						! isRunning && ! message.isError && 'bg-green-500'
+					) }
+				/>
+				<span className="font-medium">{ message.displayName }</span>
+				{ message.detail && <span className="text-gray-400">{ message.detail }</span> }
+				{ elapsed && <span className="text-gray-400">{ elapsed }s</span> }
+			</div>
+			{ message.resultPreview && ! isRunning && (
+				<details className="mt-1 ml-4">
+					<summary className="text-xs text-gray-400 cursor-pointer">Show result</summary>
+					<pre className="mt-1 text-xs text-gray-500 bg-gray-100 p-2 rounded overflow-x-auto max-h-48 overflow-y-auto">
+						{ message.resultPreview }
+					</pre>
+				</details>
+			) }
+		</div>
+	);
+}
+
+function AgentScreenshot( { message }: { message: AgentUIMessage & { type: 'tool-screenshot' } } ) {
+	return (
+		<div className="px-4 py-2">
+			<img
+				src={ `data:${ message.mimeType };base64,${ message.imageData }` }
+				alt="Screenshot"
+				className="max-w-full rounded border border-gray-200 shadow-sm"
+				style={ { maxHeight: '400px' } }
+			/>
+		</div>
+	);
+}
+
+function UserPrompt( { message }: { message: AgentUIMessage & { type: 'user-prompt' } } ) {
+	return (
+		<div className="px-4 py-2 flex justify-end">
+			<div className="bg-blue-50 text-gray-800 px-3 py-2 rounded-lg max-w-[80%] whitespace-pre-wrap text-sm">
+				{ message.text }
+			</div>
+		</div>
+	);
+}
+
+function AgentError( { message }: { message: AgentUIMessage & { type: 'error' } } ) {
+	return (
+		<div className="px-4 py-2">
+			<div className="text-red-600 text-sm bg-red-50 px-3 py-2 rounded">{ message.message }</div>
+		</div>
+	);
+}
+
+function TurnComplete( { message }: { message: AgentUIMessage & { type: 'turn-complete' } } ) {
+	return (
+		<div className="px-4 py-1 text-center">
+			<span className="text-xs text-gray-400">
+				{ message.durationSec }s &middot; { message.numTurns } turns &middot; $
+				{ message.costUsd.toFixed( 4 ) }
+			</span>
+		</div>
+	);
+}
+
+function AgentMessageItem( { message }: { message: AgentUIMessage } ) {
+	switch ( message.type ) {
+		case 'user-prompt':
+			return <UserPrompt message={ message } />;
+		case 'assistant-text':
+			return <AgentTextMessage message={ message } />;
+		case 'tool-call':
+			return <AgentToolCall message={ message } />;
+		case 'tool-screenshot':
+			return <AgentScreenshot message={ message } />;
+		case 'error':
+			return <AgentError message={ message } />;
+		case 'turn-complete':
+			return <TurnComplete message={ message } />;
+	}
+}
+
+function AgentAskUser( {
+	questions,
+	onAnswer,
+}: {
+	questions: Array< {
+		question: string;
+		options: Array< { label: string; description: string } >;
+	} >;
+	onAnswer: ( answers: Record< string, string > ) => void;
+} ) {
+	const handleOptionClick = ( question: string, label: string ) => {
+		onAnswer( { [ question ]: label } );
+	};
+
+	return (
+		<div className="px-4 py-2">
+			{ questions.map( ( q ) => (
+				<div key={ q.question } className="mb-2">
+					<p className="text-sm font-medium mb-1">{ q.question }</p>
+					<div className="flex gap-2 flex-wrap">
+						{ q.options.map( ( opt ) => (
+							<Button
+								key={ opt.label }
+								variant="secondary"
+								onClick={ () => handleOptionClick( q.question, opt.label ) }
+							>
+								{ opt.label }
+							</Button>
+						) ) }
+					</div>
+				</div>
+			) ) }
+		</div>
+	);
+}
+
+function AgentInput( { selectedSite }: { selectedSite: SiteDetails } ) {
+	const { __ } = useI18n();
+	const dispatch = useAppDispatch();
+	const inputText = useRootSelector( ( state ) => state.agent.inputText );
+	const status = useRootSelector( ( state ) => state.agent.status );
+	const currentModel = useRootSelector( ( state ) => state.agent.currentModel );
+	const textareaRef = useRef< HTMLTextAreaElement >( null );
+
+	const isProcessing = status === 'thinking' || status === 'tool-running';
+
+	const handleSubmit = useCallback( () => {
+		const trimmed = inputText.trim();
+		if ( ! trimmed || isProcessing ) {
+			return;
+		}
+		dispatch( agentActions.addUserPrompt( trimmed ) );
+		dispatch( agentActions.setInputText( '' ) );
+
+		void getIpcApi().startAgentTurn( trimmed, {
+			model: currentModel,
+			siteContext: {
+				name: selectedSite.name,
+				path: selectedSite.path,
+				running: selectedSite.running,
+			},
+		} );
+	}, [ inputText, isProcessing, dispatch, currentModel, selectedSite ] );
+
+	const handleKeyDown = useCallback(
+		( e: React.KeyboardEvent ) => {
+			if ( e.key === 'Enter' && ! e.shiftKey ) {
+				e.preventDefault();
+				handleSubmit();
+			}
+		},
+		[ handleSubmit ]
+	);
+
+	const handleStop = useCallback( () => {
+		void getIpcApi().interruptAgent();
+	}, [] );
+
+	return (
+		<div className="border-t border-gray-200 bg-white p-3">
+			<div className="flex items-end gap-2">
+				<textarea
+					ref={ textareaRef }
+					className="flex-1 resize-none border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+					rows={ 1 }
+					placeholder={ isProcessing ? __( 'Agent is working…' ) : __( 'Ask the agent anything…' ) }
+					value={ inputText }
+					onChange={ ( e ) => dispatch( agentActions.setInputText( e.target.value ) ) }
+					onKeyDown={ handleKeyDown }
+					disabled={ isProcessing }
+					style={ { maxHeight: '120px' } }
+				/>
+				{ isProcessing ? (
+					<Button variant="secondary" onClick={ handleStop }>
+						{ __( 'Stop' ) }
+					</Button>
+				) : (
+					<Button variant="primary" onClick={ handleSubmit } disabled={ ! inputText.trim() }>
+						{ __( 'Send' ) }
+					</Button>
+				) }
+			</div>
+			<div className="flex items-center justify-between mt-1">
+				<span className="text-xs text-gray-400">
+					{ isProcessing
+						? status === 'tool-running'
+							? __( 'Running tool…' )
+							: __( 'Thinking…' )
+						: '' }
+				</span>
+				<button
+					className="text-xs text-gray-400 hover:text-gray-600"
+					onClick={ () => {
+						dispatch( agentActions.clearConversation() );
+						void getIpcApi().resetAgentSession();
+					} }
+				>
+					{ __( 'New conversation' ) }
+				</button>
+			</div>
+		</div>
+	);
+}
+
+export function ContentTabAgent( { selectedSite }: { selectedSite: SiteDetails } ) {
+	useAgentEvents();
+
+	const messages = useRootSelector( ( state ) => state.agent.messages );
+	const pendingQuestions = useRootSelector( ( state ) => state.agent.pendingQuestions );
+	const status = useRootSelector( ( state ) => state.agent.status );
+	const dispatch = useAppDispatch();
+	const messagesEndRef = useRef< HTMLDivElement >( null );
+
+	// Auto-scroll to bottom when new messages arrive
+	useEffect( () => {
+		messagesEndRef.current?.scrollIntoView( { behavior: 'smooth' } );
+	}, [ messages, pendingQuestions ] );
+
+	const handleAskUserAnswer = useCallback(
+		( answers: Record< string, string > ) => {
+			dispatch( agentActions.askUserAnswered() );
+			void getIpcApi().respondToAgentQuestion( answers );
+		},
+		[ dispatch ]
+	);
+
+	return (
+		<div className="flex flex-col h-full bg-white">
+			{ /* Message area */ }
+			<div className="flex-1 overflow-y-auto" style={ { scrollbarWidth: 'thin' } }>
+				{ messages.length === 0 && (
+					<div className="flex items-center justify-center h-full text-gray-400 text-sm">
+						Start a conversation with the AI agent
+					</div>
+				) }
+				{ messages.map( ( msg, i ) => (
+					<AgentMessageItem key={ i } message={ msg } />
+				) ) }
+				{ pendingQuestions && (
+					<AgentAskUser questions={ pendingQuestions } onAnswer={ handleAskUserAnswer } />
+				) }
+				{ ( status === 'thinking' || status === 'tool-running' ) &&
+					messages.length > 0 &&
+					messages[ messages.length - 1 ].type !== 'tool-call' && (
+						<div className="px-4 py-2 text-sm text-gray-400 animate-pulse">Thinking…</div>
+					) }
+				<div ref={ messagesEndRef } />
+			</div>
+
+			{ /* Input area */ }
+			<AgentInput selectedSite={ selectedSite } />
+		</div>
+	);
+}

--- a/apps/studio/src/components/site-content-tabs.tsx
+++ b/apps/studio/src/components/site-content-tabs.tsx
@@ -1,6 +1,7 @@
 import { TabPanel } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
 import { useEffect, useRef, useState } from 'react';
+import { ContentTabAgent } from 'src/components/content-tab-agent';
 import { ContentTabAssistant } from 'src/components/content-tab-assistant';
 import { ContentTabImportExport } from 'src/components/content-tab-import-export';
 import { ContentTabOverview } from 'src/components/content-tab-overview';
@@ -11,6 +12,7 @@ import { SiteIsBeingCreated } from 'src/components/site-is-being-created';
 import { MIN_WIDTH_CLASS_TO_MEASURE } from 'src/constants';
 import { TabName } from 'src/hooks/use-content-tabs';
 import { useEffectiveTab } from 'src/hooks/use-effective-tab';
+import { useFeatureFlags } from 'src/hooks/use-feature-flags';
 import { useImportExport } from 'src/hooks/use-import-export';
 import { useSiteDetails } from 'src/hooks/use-site-details';
 import { cx } from 'src/lib/cx';
@@ -21,6 +23,7 @@ export function SiteContentTabs() {
 	const { importState } = useImportExport();
 	const { effectiveTab, selectedTab, setSelectedTab, tabs } = useEffectiveTab();
 	const { __ } = useI18n();
+	const { enableStudioAi } = useFeatureFlags();
 
 	// Remount: Avoid focus loss on user tab changes (no remount),
 	// but remount on programmatic changes and site switches so initial tab/content state resets.
@@ -107,7 +110,12 @@ export function SiteContentTabs() {
 						{ name === 'previews' && <ContentTabPreviews selectedSite={ selectedSite } /> }
 						{ name === 'sync' && <ContentTabSync selectedSite={ selectedSite } /> }
 						{ name === 'settings' && <ContentTabSettings selectedSite={ selectedSite } /> }
-						{ name === 'assistant' && <ContentTabAssistant selectedSite={ selectedSite } /> }
+						{ name === 'assistant' &&
+							( enableStudioAi ? (
+								<ContentTabAgent selectedSite={ selectedSite } />
+							) : (
+								<ContentTabAssistant selectedSite={ selectedSite } />
+							) ) }
 						{ name === 'import-export' && <ContentTabImportExport selectedSite={ selectedSite } /> }
 					</div>
 				) }

--- a/apps/studio/src/hooks/use-agent-events.ts
+++ b/apps/studio/src/hooks/use-agent-events.ts
@@ -1,0 +1,31 @@
+import { useEffect } from 'react';
+import { useAppDispatch } from 'src/stores';
+import { agentActions } from 'src/stores/agent-slice';
+
+/**
+ * Subscribe to agent IPC events from the main process and dispatch Redux actions.
+ * Should be called once in the top-level agent tab component.
+ */
+export function useAgentEvents() {
+	const dispatch = useAppDispatch();
+
+	useEffect( () => {
+		const unsubs = [
+			window.ipcListener.subscribe( 'agent-message', ( _event, { message } ) => {
+				dispatch( agentActions.agentMessageReceived( message ) );
+			} ),
+			window.ipcListener.subscribe( 'agent-ask-user', ( _event, { questions } ) => {
+				dispatch( agentActions.askUserReceived( questions ) );
+			} ),
+			window.ipcListener.subscribe( 'agent-error', ( _event, { message } ) => {
+				dispatch( agentActions.agentErrorReceived( message ) );
+			} ),
+		];
+
+		return () => {
+			for ( const unsub of unsubs ) {
+				unsub();
+			}
+		};
+	}, [ dispatch ] );
+}

--- a/apps/studio/src/ipc-handlers.ts
+++ b/apps/studio/src/ipc-handlers.ts
@@ -75,6 +75,10 @@ import {
 	installInstructionFile,
 	type InstructionFileStatus,
 } from 'src/modules/agent-instructions/lib/instructions';
+import {
+	getAgentProcessManager,
+	destroyAgentProcessManager,
+} from 'src/modules/ai-agent/lib/agent-process-manager';
 import { editSiteViaCli, EditSiteOptions } from 'src/modules/cli/lib/cli-site-editor';
 import { isStudioCliInstalled } from 'src/modules/cli/lib/ipc-handlers';
 import { STABLE_BIN_DIR_PATH } from 'src/modules/cli/lib/windows-installation-manager';
@@ -134,6 +138,36 @@ export {
 	saveUserTerminal,
 	showUserSettings,
 } from 'src/modules/user-settings/lib/ipc-handlers';
+
+export async function startAgentTurn(
+	_event: IpcMainInvokeEvent,
+	prompt: string,
+	options: {
+		model?: string;
+		resume?: string;
+		siteContext?: { name: string; path: string; running: boolean };
+	} = {}
+): Promise< void > {
+	const manager = getAgentProcessManager();
+	await manager.sendPrompt( prompt, options );
+}
+
+export async function interruptAgent( _event: IpcMainInvokeEvent ): Promise< void > {
+	const manager = getAgentProcessManager();
+	manager.interrupt();
+}
+
+export async function respondToAgentQuestion(
+	_event: IpcMainInvokeEvent,
+	answers: Record< string, string >
+): Promise< void > {
+	const manager = getAgentProcessManager();
+	manager.respondToQuestion( answers );
+}
+
+export async function resetAgentSession( _event: IpcMainInvokeEvent ): Promise< void > {
+	destroyAgentProcessManager();
+}
 
 export async function getAgentInstructionsStatus(
 	_event: IpcMainInvokeEvent,

--- a/apps/studio/src/ipc-types.d.ts
+++ b/apps/studio/src/ipc-types.d.ts
@@ -89,6 +89,7 @@ type IpcApi = {
 interface FeatureFlags {
 	enableBlueprints: boolean;
 	enableAgentSuite: boolean;
+	enableStudioAi: boolean;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type

--- a/apps/studio/src/ipc-utils.ts
+++ b/apps/studio/src/ipc-utils.ts
@@ -6,6 +6,7 @@ import { PreviewCommandLoggerAction } from '@studio/common/logger-actions';
 import { ImportExportEventData } from 'src/lib/import-export/handle-events';
 import { StoredToken } from 'src/lib/oauth';
 import { getMainWindow } from 'src/main-window';
+import type { SerializedAgentMessage } from '@studio/common/types/agent-messages';
 import type { UserData } from 'src/storage/storage-types';
 
 type SnapshotEventData = {
@@ -63,6 +64,17 @@ export interface IpcEvents {
 	'user-data-error': [ string ];
 	'refresh-app-globals': [ void ];
 	'beta-features-updated': [ void ];
+	'agent-message': [ { message: SerializedAgentMessage } ];
+	'agent-ask-user': [
+		{
+			questions: Array< {
+				question: string;
+				options: Array< { label: string; description: string } >;
+			} >;
+		},
+	];
+	'agent-ready': [ void ];
+	'agent-error': [ { message: string } ];
 }
 
 export async function sendIpcEventToRenderer< T extends keyof IpcEvents >(

--- a/apps/studio/src/lib/feature-flags.ts
+++ b/apps/studio/src/lib/feature-flags.ts
@@ -18,6 +18,12 @@ export const FEATURE_FLAGS: Record< keyof FeatureFlags, FeatureFlagDefinition > 
 		flag: 'enableAgentSuite',
 		default: false,
 	},
+	enableStudioAi: {
+		label: 'Enable Studio AI',
+		env: 'ENABLE_STUDIO_AI',
+		flag: 'enableStudioAi',
+		default: false,
+	},
 } as const;
 
 export function getFeatureFlagFromEnv( flag: keyof FeatureFlags ): boolean {

--- a/apps/studio/src/modules/ai-agent/lib/agent-process-manager.ts
+++ b/apps/studio/src/modules/ai-agent/lib/agent-process-manager.ts
@@ -1,0 +1,181 @@
+import { ChildProcess } from 'node:child_process';
+import { sendIpcEventToRenderer } from 'src/ipc-utils';
+import { executeCliCommand } from 'src/modules/cli/lib/execute-command';
+import type {
+	ChildToParentMessage,
+	ParentToChildMessage,
+	SerializedAgentMessage,
+} from '@studio/common/types/agent-messages';
+
+/**
+ * Manages a long-lived `studio ai --pipe` child process.
+ * The child process communicates via Node IPC (process.send / process.on('message')).
+ */
+class AgentProcessManager {
+	private childProcess: ChildProcess | null = null;
+	private ready = false;
+	private readyPromise: Promise< void > | null = null;
+
+	/**
+	 * Ensure the agent child process is running and ready.
+	 */
+	async ensureProcess(): Promise< void > {
+		if ( this.childProcess && ! this.childProcess.killed ) {
+			if ( this.ready ) {
+				return;
+			}
+			if ( this.readyPromise ) {
+				return this.readyPromise;
+			}
+		}
+
+		this.readyPromise = new Promise< void >( ( resolve, reject ) => {
+			// Set ENABLE_STUDIO_AI so the ai command is registered in the child process.
+			// executeCliCommand spreads process.env into the child, so setting it here is enough.
+			process.env.ENABLE_STUDIO_AI = 'true';
+
+			const [ emitter, child ] = executeCliCommand( [ 'ai', '--pipe' ], {
+				output: 'capture',
+				logPrefix: 'ai-agent',
+			} );
+			this.childProcess = child;
+			this.ready = false;
+
+			child.on( 'message', ( msg: unknown ) => {
+				this.handleChildMessage( msg as ChildToParentMessage );
+			} );
+
+			child.on( 'error', ( error ) => {
+				console.error( '[ai-agent] Child process error:', error );
+				void sendIpcEventToRenderer( 'agent-error', {
+					message: error.message,
+				} );
+				reject( error );
+			} );
+
+			child.on( 'close', ( code, signal ) => {
+				console.log( `[ai-agent] Child process closed: code=${ code } signal=${ signal }` );
+				this.childProcess = null;
+				this.ready = false;
+				this.readyPromise = null;
+			} );
+
+			// Listen for 'ready' message
+			const onReady = ( msg: unknown ) => {
+				const typed = msg as ChildToParentMessage;
+				if ( typed.type === 'ready' ) {
+					this.ready = true;
+					resolve();
+				}
+			};
+			child.on( 'message', onReady );
+
+			emitter.on( 'failure', ( { error } ) => {
+				reject( error );
+			} );
+
+			// Timeout if agent doesn't send 'ready' within 30s
+			setTimeout( () => {
+				if ( ! this.ready ) {
+					reject( new Error( 'Agent process timed out waiting for ready signal' ) );
+					this.destroy();
+				}
+			}, 30000 );
+		} );
+
+		return this.readyPromise;
+	}
+
+	private handleChildMessage( msg: ChildToParentMessage ): void {
+		switch ( msg.type ) {
+			case 'agent-message':
+				void sendIpcEventToRenderer( 'agent-message', {
+					message: msg.message as SerializedAgentMessage,
+				} );
+				break;
+			case 'ask-user':
+				void sendIpcEventToRenderer( 'agent-ask-user', {
+					questions: msg.questions,
+				} );
+				break;
+			case 'error':
+				void sendIpcEventToRenderer( 'agent-error', {
+					message: msg.message,
+				} );
+				break;
+			case 'ready':
+				// Already handled in ensureProcess
+				break;
+		}
+	}
+
+	private sendToChild( msg: ParentToChildMessage ): void {
+		if ( this.childProcess && ! this.childProcess.killed && this.childProcess.connected ) {
+			this.childProcess.send( msg );
+		}
+	}
+
+	/**
+	 * Send a prompt to the agent.
+	 */
+	async sendPrompt(
+		prompt: string,
+		options: {
+			model?: string;
+			resume?: string;
+			siteContext?: { name: string; path: string; running: boolean };
+		} = {}
+	): Promise< void > {
+		await this.ensureProcess();
+		this.sendToChild( {
+			type: 'prompt',
+			prompt,
+			model: options.model,
+			resume: options.resume,
+			siteContext: options.siteContext,
+		} );
+	}
+
+	/**
+	 * Interrupt the current agent turn.
+	 */
+	interrupt(): void {
+		this.sendToChild( { type: 'interrupt' } );
+	}
+
+	/**
+	 * Respond to an ask-user question from the agent.
+	 */
+	respondToQuestion( answers: Record< string, string > ): void {
+		this.sendToChild( { type: 'ask-user-response', answers } );
+	}
+
+	/**
+	 * Kill the child process and reset state.
+	 */
+	destroy(): void {
+		if ( this.childProcess && ! this.childProcess.killed ) {
+			this.childProcess.kill();
+		}
+		this.childProcess = null;
+		this.ready = false;
+		this.readyPromise = null;
+	}
+}
+
+// Singleton instance
+let agentProcessManager: AgentProcessManager | null = null;
+
+export function getAgentProcessManager(): AgentProcessManager {
+	if ( ! agentProcessManager ) {
+		agentProcessManager = new AgentProcessManager();
+	}
+	return agentProcessManager;
+}
+
+export function destroyAgentProcessManager(): void {
+	if ( agentProcessManager ) {
+		agentProcessManager.destroy();
+		agentProcessManager = null;
+	}
+}

--- a/apps/studio/src/preload.ts
+++ b/apps/studio/src/preload.ts
@@ -161,6 +161,10 @@ const api: IpcApi = {
 		ipcRendererInvoke( 'getAgentInstructionsStatus', siteId ),
 	installAgentInstructions: ( siteId, options ) =>
 		ipcRendererInvoke( 'installAgentInstructions', siteId, options ),
+	startAgentTurn: ( prompt, options ) => ipcRendererInvoke( 'startAgentTurn', prompt, options ),
+	interruptAgent: () => ipcRendererInvoke( 'interruptAgent' ),
+	respondToAgentQuestion: ( answers ) => ipcRendererInvoke( 'respondToAgentQuestion', answers ),
+	resetAgentSession: () => ipcRendererInvoke( 'resetAgentSession' ),
 };
 
 contextBridge.exposeInMainWorld( 'ipcApi', api );

--- a/apps/studio/src/stores/agent-slice.ts
+++ b/apps/studio/src/stores/agent-slice.ts
@@ -1,0 +1,269 @@
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
+import { getToolDisplayName, getToolDetail } from '@studio/common/types/agent-messages';
+import type {
+	SerializedAgentMessage,
+	AgentToolUseBlock,
+} from '@studio/common/types/agent-messages';
+
+export type AgentUIMessage =
+	| { type: 'user-prompt'; text: string; timestamp: number }
+	| { type: 'assistant-text'; text: string; timestamp: number }
+	| {
+			type: 'tool-call';
+			id: string;
+			name: string;
+			displayName: string;
+			detail: string;
+			input: Record< string, unknown >;
+			startTime: number;
+			endTime?: number;
+			isError?: boolean;
+			resultPreview?: string;
+	  }
+	| { type: 'tool-screenshot'; imageData: string; mimeType: string; timestamp: number }
+	| { type: 'error'; message: string; timestamp: number }
+	| {
+			type: 'turn-complete';
+			numTurns: number;
+			costUsd: number;
+			durationSec: number;
+			timestamp: number;
+	  };
+
+export type AgentStatus = 'idle' | 'thinking' | 'tool-running' | 'asking-user' | 'error';
+
+interface AgentState {
+	status: AgentStatus;
+	sessionId: string | null;
+	messages: AgentUIMessage[];
+	pendingQuestions: Array< {
+		question: string;
+		options: Array< { label: string; description: string } >;
+	} > | null;
+	inputText: string;
+	currentModel: string;
+	turnStartTime: number | null;
+	lastToolId: string | null;
+}
+
+const initialState: AgentState = {
+	status: 'idle',
+	sessionId: null,
+	messages: [],
+	pendingQuestions: null,
+	inputText: '',
+	currentModel: 'claude-sonnet-4-6',
+	turnStartTime: null,
+	lastToolId: null,
+};
+
+const agentSlice = createSlice( {
+	name: 'agent',
+	initialState,
+	reducers: {
+		addUserPrompt( state, action: PayloadAction< string > ) {
+			state.messages.push( {
+				type: 'user-prompt',
+				text: action.payload,
+				timestamp: Date.now(),
+			} );
+			state.status = 'thinking';
+			state.turnStartTime = Date.now();
+		},
+
+		agentMessageReceived( state, action: PayloadAction< SerializedAgentMessage > ) {
+			const msg = action.payload;
+
+			switch ( msg.type ) {
+				case 'assistant': {
+					for ( const block of msg.message.content ) {
+						if ( block.type === 'text' && block.text ) {
+							// Append text to the last assistant-text message if consecutive,
+							// otherwise create a new one
+							const lastMsg = state.messages[ state.messages.length - 1 ];
+							if ( lastMsg && lastMsg.type === 'assistant-text' ) {
+								lastMsg.text += ( lastMsg.text.endsWith( '\n' ) ? '' : '\n' ) + block.text;
+							} else {
+								state.messages.push( {
+									type: 'assistant-text',
+									text: block.text,
+									timestamp: Date.now(),
+								} );
+							}
+							state.status = 'thinking';
+						} else if ( block.type === 'tool_use' ) {
+							const toolBlock = block as AgentToolUseBlock;
+							state.status = 'tool-running';
+							state.lastToolId = toolBlock.id;
+							state.messages.push( {
+								type: 'tool-call',
+								id: toolBlock.id,
+								name: toolBlock.name,
+								displayName: getToolDisplayName( toolBlock.name ),
+								detail: getToolDetail( toolBlock.name, toolBlock.input ),
+								input: toolBlock.input,
+								startTime: Date.now(),
+							} );
+						}
+					}
+					break;
+				}
+
+				case 'user': {
+					// This is a tool result message
+					const result = msg.tool_use_result;
+					if ( ! result || typeof result !== 'object' ) {
+						break;
+					}
+
+					// Find the matching tool-call and update it
+					const toolCallIndex = findLastToolCallIndex( state.messages, state.lastToolId );
+					if ( toolCallIndex >= 0 ) {
+						const toolCall = state.messages[ toolCallIndex ];
+						if ( toolCall.type === 'tool-call' ) {
+							toolCall.endTime = Date.now();
+							toolCall.isError = result.isError === true;
+
+							// Extract text preview from result content
+							const textContent = result.content
+								?.filter( ( c ) => c.type === 'text' && c.text )
+								.map( ( c ) => c.text )
+								.join( '\n' );
+							if ( textContent ) {
+								toolCall.resultPreview =
+									textContent.length > 500 ? textContent.slice( 0, 497 ) + '…' : textContent;
+							}
+
+							// Extract images (screenshots)
+							const imageContent = result.content?.filter(
+								( c ) => c.type === 'image' && c.data && c.mimeType
+							);
+							if ( imageContent ) {
+								for ( const img of imageContent ) {
+									if ( img.data && img.mimeType ) {
+										state.messages.push( {
+											type: 'tool-screenshot',
+											imageData: img.data,
+											mimeType: img.mimeType,
+											timestamp: Date.now(),
+										} );
+									}
+								}
+							}
+						}
+					}
+					state.status = 'thinking';
+					break;
+				}
+
+				case 'result': {
+					if ( msg.subtype === 'success' ) {
+						const duration = state.turnStartTime
+							? Math.round( ( Date.now() - state.turnStartTime ) / 1000 )
+							: 0;
+						state.messages.push( {
+							type: 'turn-complete',
+							numTurns: msg.num_turns,
+							costUsd: msg.total_cost_usd,
+							durationSec: duration,
+							timestamp: Date.now(),
+						} );
+					} else if ( msg.subtype === 'error_max_turns' ) {
+						state.messages.push( {
+							type: 'error',
+							message: `Reached turn limit (${ msg.num_turns } turns). You can continue the conversation.`,
+							timestamp: Date.now(),
+						} );
+					} else {
+						const errorParts: string[] = [];
+						if ( msg.errors?.length ) {
+							errorParts.push( ...msg.errors );
+						}
+						if ( msg.permission_denials?.length ) {
+							for ( const denial of msg.permission_denials ) {
+								errorParts.push( `Permission denied: ${ denial.tool_name }` );
+							}
+						}
+						state.messages.push( {
+							type: 'error',
+							message: errorParts.length > 0 ? errorParts.join( '\n' ) : 'Unknown error',
+							timestamp: Date.now(),
+						} );
+					}
+					state.sessionId = msg.session_id;
+					state.status = 'idle';
+					state.turnStartTime = null;
+					state.lastToolId = null;
+					break;
+				}
+			}
+		},
+
+		askUserReceived(
+			state,
+			action: PayloadAction<
+				Array< {
+					question: string;
+					options: Array< { label: string; description: string } >;
+				} >
+			>
+		) {
+			state.pendingQuestions = action.payload;
+			state.status = 'asking-user';
+		},
+
+		askUserAnswered( state ) {
+			state.pendingQuestions = null;
+			state.status = 'thinking';
+		},
+
+		agentErrorReceived( state, action: PayloadAction< string > ) {
+			state.messages.push( {
+				type: 'error',
+				message: action.payload,
+				timestamp: Date.now(),
+			} );
+			state.status = 'error';
+		},
+
+		setInputText( state, action: PayloadAction< string > ) {
+			state.inputText = action.payload;
+		},
+
+		setModel( state, action: PayloadAction< string > ) {
+			state.currentModel = action.payload;
+		},
+
+		clearConversation( state ) {
+			state.messages = [];
+			state.sessionId = null;
+			state.status = 'idle';
+			state.pendingQuestions = null;
+			state.turnStartTime = null;
+			state.lastToolId = null;
+		},
+	},
+} );
+
+function findLastToolCallIndex( messages: AgentUIMessage[], toolId: string | null ): number {
+	if ( ! toolId ) {
+		// Fall back to finding the last unresolved tool-call
+		for ( let i = messages.length - 1; i >= 0; i-- ) {
+			const msg = messages[ i ];
+			if ( msg.type === 'tool-call' && ! msg.endTime ) {
+				return i;
+			}
+		}
+		return -1;
+	}
+	for ( let i = messages.length - 1; i >= 0; i-- ) {
+		const msg = messages[ i ];
+		if ( msg.type === 'tool-call' && msg.id === toolId ) {
+			return i;
+		}
+	}
+	return -1;
+}
+
+export const agentActions = agentSlice.actions;
+export const agentReducer = agentSlice.reducer;

--- a/apps/studio/src/stores/index.ts
+++ b/apps/studio/src/stores/index.ts
@@ -13,6 +13,7 @@ import {
 	PushStateProgressInfo,
 } from 'src/hooks/use-sync-states-progress-info';
 import { getIpcApi } from 'src/lib/get-ipc-api';
+import { agentReducer } from 'src/stores/agent-slice';
 import { appVersionApi } from 'src/stores/app-version-api';
 import { betaFeaturesReducer, loadBetaFeatures } from 'src/stores/beta-features-slice';
 import { certificateTrustApi } from 'src/stores/certificate-trust-api';
@@ -40,6 +41,7 @@ import { wordpressVersionsApi } from './wordpress-versions-api';
 import type { SupportedLocale } from '@studio/common/lib/locale';
 
 export type RootState = {
+	agent: ReturnType< typeof agentReducer >;
 	appVersionApi: ReturnType< typeof appVersionApi.reducer >;
 	betaFeatures: ReturnType< typeof betaFeaturesReducer >;
 	chat: ReturnType< typeof chatReducer >;
@@ -323,6 +325,7 @@ startAppListening( {
 } );
 
 export const rootReducer = combineReducers( {
+	agent: agentReducer,
 	appVersionApi: appVersionApi.reducer,
 	betaFeatures: betaFeaturesReducer,
 	chat: chatReducer,

--- a/package-lock.json
+++ b/package-lock.json
@@ -9290,7 +9290,6 @@
 			"os": [
 				"darwin"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -9307,7 +9306,6 @@
 			"os": [
 				"darwin"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -9324,7 +9322,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -9341,7 +9338,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -9358,7 +9354,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -9375,7 +9370,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -9392,7 +9386,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -9409,7 +9402,6 @@
 			"os": [
 				"win32"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -9426,7 +9418,6 @@
 			"os": [
 				"win32"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -9443,7 +9434,6 @@
 			"os": [
 				"win32"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}

--- a/tools/common/types/agent-messages.ts
+++ b/tools/common/types/agent-messages.ts
@@ -1,0 +1,180 @@
+/**
+ * Serializable agent message types for IPC between CLI child process and Electron main/renderer.
+ * These mirror the relevant parts of SDKMessage from @anthropic-ai/claude-agent-sdk
+ * so the renderer can understand agent messages without importing the SDK.
+ */
+
+export interface AgentTextBlock {
+	type: 'text';
+	text: string;
+}
+
+export interface AgentToolUseBlock {
+	type: 'tool_use';
+	id: string;
+	name: string;
+	input: Record< string, unknown >;
+}
+
+export interface AgentAssistantMessage {
+	type: 'assistant';
+	message: {
+		content: Array< AgentTextBlock | AgentToolUseBlock >;
+	};
+}
+
+export interface AgentToolResultContent {
+	type: string;
+	text?: string;
+	data?: string;
+	mimeType?: string;
+}
+
+export interface AgentToolResultMessage {
+	type: 'user';
+	tool_use_result?: {
+		content?: AgentToolResultContent[];
+		isError?: boolean;
+	};
+}
+
+export interface AgentResultMessage {
+	type: 'result';
+	subtype: string;
+	session_id: string;
+	num_turns: number;
+	total_cost_usd: number;
+	errors?: string[];
+	permission_denials?: Array< { tool_name: string } >;
+}
+
+export type SerializedAgentMessage =
+	| AgentAssistantMessage
+	| AgentToolResultMessage
+	| AgentResultMessage;
+
+/**
+ * IPC messages from parent (Electron main) to child (CLI ai --pipe).
+ */
+export interface AgentPromptMessage {
+	type: 'prompt';
+	prompt: string;
+	model?: string;
+	resume?: string;
+	siteContext?: {
+		name: string;
+		path: string;
+		running: boolean;
+	};
+}
+
+export interface AgentAskUserResponseMessage {
+	type: 'ask-user-response';
+	answers: Record< string, string >;
+}
+
+export interface AgentInterruptMessage {
+	type: 'interrupt';
+}
+
+export type ParentToChildMessage =
+	| AgentPromptMessage
+	| AgentAskUserResponseMessage
+	| AgentInterruptMessage;
+
+/**
+ * IPC messages from child (CLI ai --pipe) to parent (Electron main).
+ */
+export interface ChildAgentMessageEvent {
+	type: 'agent-message';
+	message: SerializedAgentMessage;
+}
+
+export interface ChildAskUserEvent {
+	type: 'ask-user';
+	questions: Array< {
+		question: string;
+		options: Array< { label: string; description: string } >;
+	} >;
+}
+
+export interface ChildReadyEvent {
+	type: 'ready';
+}
+
+export interface ChildErrorEvent {
+	type: 'error';
+	message: string;
+}
+
+export type ChildToParentMessage =
+	| ChildAgentMessageEvent
+	| ChildAskUserEvent
+	| ChildReadyEvent
+	| ChildErrorEvent;
+
+/**
+ * Tool display names and detail extraction for rendering in the UI.
+ */
+export const TOOL_DISPLAY_NAMES: Record< string, string > = {
+	mcp__studio__site_create: 'Create site',
+	mcp__studio__site_list: 'List sites',
+	mcp__studio__site_info: 'Get site info',
+	mcp__studio__site_start: 'Start site',
+	mcp__studio__site_stop: 'Stop site',
+	mcp__studio__site_delete: 'Delete site',
+	mcp__studio__wp_cli: 'Run WP-CLI',
+	mcp__studio__validate_blocks: 'Validate blocks',
+	mcp__studio__take_screenshot: 'Take screenshot',
+	Read: 'Read',
+	Write: 'Write',
+	Edit: 'Edit',
+	Bash: 'Run',
+	Glob: 'Search',
+	Grep: 'Search',
+};
+
+export function getToolDisplayName( name: string ): string {
+	return TOOL_DISPLAY_NAMES[ name ] ?? name;
+}
+
+export function getToolDetail( name: string, input: Record< string, unknown > ): string {
+	switch ( name ) {
+		case 'mcp__studio__site_create':
+			return typeof input.name === 'string' ? input.name : '';
+		case 'mcp__studio__site_info':
+		case 'mcp__studio__site_start':
+		case 'mcp__studio__site_stop':
+		case 'mcp__studio__site_delete':
+			return typeof input.nameOrPath === 'string' ? input.nameOrPath : '';
+		case 'mcp__studio__wp_cli':
+			return typeof input.command === 'string' ? `wp ${ input.command }` : '';
+		case 'mcp__studio__validate_blocks':
+			if ( typeof input.filePath === 'string' ) {
+				return input.filePath.split( '/' ).slice( -2 ).join( '/' );
+			}
+			return 'inline content';
+		case 'mcp__studio__take_screenshot':
+			return typeof input.url === 'string' ? input.url : '';
+		case 'Read':
+		case 'Write':
+		case 'Edit': {
+			const filePath = input.file_path ?? input.path;
+			if ( typeof filePath === 'string' ) {
+				return filePath.split( '/' ).slice( -2 ).join( '/' );
+			}
+			return '';
+		}
+		case 'Bash':
+			return typeof input.command === 'string'
+				? input.command.length > 60
+					? input.command.slice( 0, 57 ) + '…'
+					: input.command
+				: '';
+		case 'Grep':
+		case 'Glob':
+			return typeof input.pattern === 'string' ? input.pattern : '';
+		default:
+			return '';
+	}
+}


### PR DESCRIPTION
## Related issues

- Relates to the agent suite feature for the desktop app

## How AI was used in this PR

This PR implements Option A from the architectural exploration: spawn the studio ai CLI command as a child process from the desktop app using --pipe IPC mode. The implementation includes new IPC handlers, Redux state management, React UI components, and an agent process manager.

## Proposed Changes

- Added `--pipe` option to `studio ai` CLI command for IPC-based communication (instead of TUI)
- Created `AgentProcessManager` singleton to spawn/manage the CLI child process and forward messages to the renderer
- Created Redux slice (`agent-slice`) to manage agent UI state (messages, status, pending questions)
- Created `ContentTabAgent` React component with full agent UI (messages, tool calls, screenshots, user input)
- Added 4 new IPC handlers (`startAgentTurn`, `interruptAgent`, `respondToAgentQuestion`, `resetAgentSession`)
- Added 4 new IPC events for bi-directional communication (`agent-message`, `agent-ask-user`, `agent-ready`, `agent-error`)
- Created shared message types (`tools/common/types/agent-messages.ts`) for serializing agent SDK messages
- Added `enableStudioAi` feature flag to control whether the new agent tab or old assistant chat is shown
- Renderer → IPC → Main process spawns CLI → CLI forwards agent messages back → Renderer updates UI

## Testing Instructions

1. Build the CLI: `npm run cli:build`
2. Set feature flag and start app: `ENABLE_STUDIO_AI=true npm start`
3. Open a site and navigate to the Assistant tab
4. Type a prompt and watch the agent respond with tool calls and results
5. Try interrupting a turn, asking follow-up questions, and starting new conversations

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
- [x] All 1258 tests pass
- [x] TypeScript type checking passes
- [x] ESLint passes with no errors