### PR TITLE
Fix app menu opening at cursor position instead of button position on touch

### DIFF
--- a/apps/studio/src/components/windows-titlebar.tsx
+++ b/apps/studio/src/components/windows-titlebar.tsx
@@ -31,8 +31,12 @@ export default function WindowsTitlebar( {
 		>
 			<Button
 				variant="icon"
-				onClick={ () => {
-					getIpcApi().popupAppMenu();
+				onClick={ ( e: React.MouseEvent< HTMLButtonElement > ) => {
+					const rect = e.currentTarget.getBoundingClientRect();
+					getIpcApi().popupAppMenu( {
+						x: Math.round( rect.left ),
+						y: Math.round( rect.bottom ),
+					} );
 				} }
 				className="!px-3 !py-2 app-no-drag-region"
 			>

--- a/apps/studio/src/ipc-handlers.ts
+++ b/apps/studio/src/ipc-handlers.ts
@@ -1152,8 +1152,11 @@ export async function setupAppMenu(
 	await setupMenu( config );
 }
 
-export async function popupAppMenu( _event: IpcMainInvokeEvent ) {
-	await popupMenu();
+export async function popupAppMenu(
+	_event: IpcMainInvokeEvent,
+	position?: { x: number; y: number }
+) {
+	await popupMenu( position );
 }
 
 export async function promptWindowsSpeedUpSites(

--- a/apps/studio/src/menu.ts
+++ b/apps/studio/src/menu.ts
@@ -57,10 +57,10 @@ export function removeMenu() {
 	Menu.setApplicationMenu( null );
 }
 
-export async function popupMenu() {
+export async function popupMenu( position?: { x: number; y: number } ) {
 	const window = await getMainWindow();
 	const menu = await getAppMenu( window );
-	menu.popup();
+	menu.popup( { window: window ?? undefined, ...position } );
 }
 
 async function buildBetaFeaturesMenu(): Promise< MenuItemConstructorOptions[] > {

--- a/apps/studio/src/preload.ts
+++ b/apps/studio/src/preload.ts
@@ -109,7 +109,7 @@ const api: IpcApi = {
 	showNotification: ( options ) => ipcRendererSend( 'showNotification', options ),
 	logRendererMessage: ( level, ...args ) => ipcRendererSend( 'logRendererMessage', level, ...args ),
 	setupAppMenu: ( config ) => ipcRendererInvoke( 'setupAppMenu', config ),
-	popupAppMenu: () => ipcRendererSend( 'popupAppMenu' ),
+	popupAppMenu: ( position ) => ipcRendererSend( 'popupAppMenu', position ),
 	openCertificate: () => ipcRendererSend( 'openCertificate' ),
 	promptWindowsSpeedUpSites: ( ...args ) =>
 		ipcRendererInvoke( 'promptWindowsSpeedUpSites', ...args ),


### PR DESCRIPTION
## Related issues

- Fixes https://linear.app/a8c/issue/STU-162

## How AI was used in this PR

This PR was generated with Claude Code. I reviewed the code and the fix is correct.

## Proposed Changes

- Pass the menu button's bounding rect position (`x`, `y`) to `menu.popup()` so the context menu always opens anchored to the bottom-left of the button, regardless of where the touch/cursor lands
- Without coordinates, Electron positions the menu at the current cursor location, which on touch differs from the button's visual position

## Testing Instructions

- On a Windows touch device, tap the Studio menu icon (hamburger) in the title bar
- The context menu should open at the menu button, not at the touch point

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?