### PR TITLE
Move block validation from jsdom/Node.js to Playwright browser

### DIFF
--- a/apps/cli/ai/block-validator.ts
+++ b/apps/cli/ai/block-validator.ts
@@ -1,23 +1,4 @@
-let initialized = false;
-let initError: string | null = null;
-
-function withSuppressedConsole< T >( fn: () => T ): T {
-	const orig = {
-		log: console.log,
-		info: console.info,
-		warn: console.warn,
-		error: console.error,
-	};
-	console.log = () => {};
-	console.info = () => {};
-	console.warn = () => {};
-	console.error = () => {};
-	try {
-		return fn();
-	} finally {
-		Object.assign( console, orig );
-	}
-}
+import { EditorPage } from 'cli/ai/browser-utils';
 
 interface BlockValidationResult {
 	blockName: string;
@@ -35,276 +16,180 @@ export interface ValidationReport {
 	error?: string;
 }
 
-/**
- * Set up jsdom globals so WordPress packages (especially hpq) can use DOM APIs.
- * Must be called before importing any @wordpress/* packages.
- */
-function setupDomEnvironment(): void {
-	const { JSDOM } = require( 'jsdom' );
-	const dom = new JSDOM( '<!DOCTYPE html><html><body></body></html>', {
-		// Suppress CSS parsing errors from @wordpress/ui CSS modules
-		pretendToBeVisual: false,
-	} );
+// Cache one EditorPage per site URL so repeated validations reuse the same
+// browser tab instead of navigating and loading the block editor each time.
+const editorPages = new Map< string, EditorPage >();
 
-	const g = global as Record< string, unknown >;
-
-	// Helper to set global properties, using Object.defineProperty for read-only ones
-	// (e.g., `navigator` is getter-only in Node.js 21+)
-	function setGlobal( key: string, value: unknown ): void {
-		try {
-			g[ key ] = value;
-		} catch {
-			Object.defineProperty( globalThis, key, {
-				value,
-				writable: true,
-				configurable: true,
-			} );
-		}
+function getEditorPage( siteUrl: string ): EditorPage {
+	let ep = editorPages.get( siteUrl );
+	if ( ! ep ) {
+		ep = new EditorPage( siteUrl );
+		editorPages.set( siteUrl, ep );
 	}
-
-	setGlobal( 'window', dom.window );
-	setGlobal( 'document', dom.window.document );
-	setGlobal( 'navigator', dom.window.navigator );
-	setGlobal( 'MutationObserver', dom.window.MutationObserver );
-	setGlobal( 'Node', dom.window.Node );
-	setGlobal( 'HTMLElement', dom.window.HTMLElement );
-	setGlobal( 'CustomEvent', dom.window.CustomEvent );
-	setGlobal( 'URL', dom.window.URL );
-	setGlobal( 'Element', dom.window.Element );
-
-	// Mock matchMedia (used by @wordpress/components and others)
-	if ( ! dom.window.matchMedia ) {
-		dom.window.matchMedia = () =>
-			( {
-				matches: false,
-				media: '',
-				onchange: null,
-				addListener: () => {},
-				removeListener: () => {},
-				addEventListener: () => {},
-				removeEventListener: () => {},
-				dispatchEvent: () => false,
-			} ) as unknown as MediaQueryList;
-	}
-
-	// Mock requestAnimationFrame / requestIdleCallback
-	if ( ! g.requestAnimationFrame ) {
-		g.requestAnimationFrame = ( cb: () => void ) => setTimeout( cb, 0 );
-		g.cancelAnimationFrame = ( id: number ) => clearTimeout( id );
-	}
-	if ( ! g.requestIdleCallback ) {
-		g.requestIdleCallback = ( cb: ( deadline: { timeRemaining: () => number } ) => void ) =>
-			setTimeout( () => cb( { timeRemaining: () => 50 } ), 0 );
-		g.cancelIdleCallback = ( id: number ) => clearTimeout( id );
-	}
-
-	// Some WP packages check for ResizeObserver
-	if ( ! g.ResizeObserver ) {
-		g.ResizeObserver = class {
-			observe() {}
-			unobserve() {}
-			disconnect() {}
-		};
-	}
-
-	// IntersectionObserver mock
-	if ( ! g.IntersectionObserver ) {
-		g.IntersectionObserver = class {
-			observe() {}
-			unobserve() {}
-			disconnect() {}
-		};
-	}
+	return ep;
 }
 
 /**
- * Lazy initialization: set up DOM environment and register blocks on first use.
+ * Validate WordPress block content using the site's own block editor in a
+ * real browser.
+ *
+ * Navigates to `post-new.php` (which loads wp.blocks with all registered
+ * blocks — core + plugins) and runs `wp.blocks.validateBlock()` for each
+ * parsed block. This is the same save-function comparison the Gutenberg
+ * editor performs on load.
  */
-function ensureInitialized(): void {
-	if ( initialized ) {
-		return;
-	}
+export async function validateBlocks(
+	content: string,
+	siteUrl: string
+): Promise< ValidationReport > {
+	const editorPage = getEditorPage( siteUrl );
 
 	try {
-		setupDomEnvironment();
-	} catch ( error ) {
-		initError = `Failed to set up DOM environment: ${
-			error instanceof Error ? error.stack || error.message : String( error )
-		}. Make sure 'jsdom' is installed.`;
-		initialized = true;
-		return;
-	}
+		const page = await editorPage.getPage();
 
-	// Suppress jsdom CSS parsing errors during @wordpress/block-library import
-	// (jsdom can't parse CSS modules used by @wordpress/ui and @wordpress/components)
-	const origError = console.error;
-	console.error = ( ...args: unknown[] ) => {
-		const msg = String( args[ 0 ] );
-		if ( msg.includes( 'Could not parse CSS stylesheet' ) ) {
-			return;
-		}
-		origError( ...args );
-	};
-
-	try {
-		const { registerCoreBlocks } = require( '@wordpress/block-library' );
-		registerCoreBlocks();
-	} catch ( error ) {
-		initError = `Failed to register core blocks: ${
-			error instanceof Error ? error.stack || error.message : String( error )
-		}. Make sure '@wordpress/block-library' is installed.`;
-	} finally {
-		console.error = origError;
-	}
-
-	// Verify that blocks were actually registered
-	if ( ! initError ) {
-		try {
-			const { getBlockTypes } = require( '@wordpress/blocks' );
-			const types = getBlockTypes();
-			if ( ! types || types.length === 0 ) {
-				initError = 'No block types were registered. Block validation will not work correctly.';
+		const report = await page.evaluate( ( html: string ) => {
+			/* eslint-disable @typescript-eslint/no-explicit-any */
+			const wpBlocks = ( window as any ).wp?.blocks;
+			if ( ! wpBlocks ) {
+				return {
+					totalBlocks: 0,
+					validBlocks: 0,
+					invalidBlocks: 0,
+					results: [] as any[],
+					error: 'wp.blocks is not available on this page.',
+				};
 			}
-		} catch {
-			initError = 'Failed to verify block registration.';
-		}
-	}
 
-	initialized = true;
-}
+			const blocks = wpBlocks.parse( html );
+			const results: any[] = [];
 
-function formatLogItem( item: { args?: unknown[] } ): string {
-	if ( ! item.args || item.args.length === 0 ) {
-		return '';
-	}
-
-	const formatStr = String( item.args[ 0 ] );
-
-	// Skip the verbose "Block validation failed for `name` (blockType)" message —
-	// we already show the block name and the per-attribute issues are more useful.
-	if ( formatStr.startsWith( 'Block validation failed' ) ) {
-		return '';
-	}
-
-	let message = formatStr;
-	let argIndex = 1;
-	message = message.replace( /%[so]/g, () => {
-		if ( argIndex < ( item.args?.length ?? 0 ) ) {
-			const val = item.args![ argIndex++ ];
-			if ( typeof val === 'object' ) {
-				return JSON.stringify( val ).slice( 0, 200 );
+			function extractIssues( validationIssues: any[] ): string[] {
+				const issues: string[] = [];
+				for ( const issue of validationIssues ) {
+					if ( issue?.args ) {
+						const msg = String( issue.args[ 0 ] || '' );
+						// Skip the verbose "Block validation failed for `name`" summary —
+						// the per-attribute messages that follow are more useful.
+						if ( ! msg.startsWith( 'Block validation failed' ) ) {
+							issues.push(
+								issue.args
+									.map( ( a: any ) =>
+										typeof a === 'object'
+											? JSON.stringify( a ).slice( 0, 200 )
+											: String( a ).slice( 0, 500 )
+									)
+									.join( ' ' )
+							);
+						}
+					}
+				}
+				return issues;
 			}
-			return String( val ).slice( 0, 500 );
-		}
-		return '';
-	} );
 
-	return message;
-}
+			function validateRecursive( block: any ) {
+				if ( ! block.name ) {
+					return;
+				}
+				if ( block.name === 'core/freeform' || block.name === 'core/missing' ) {
+					return;
+				}
 
-function tryGetSaveContent( block: {
-	name: string;
-	attributes: Record< string, unknown >;
-} ): string | undefined {
-	try {
-		const { getSaveContent, getBlockType } = require( '@wordpress/blocks' );
-		const blockType = getBlockType( block.name );
-		if ( blockType ) {
-			return getSaveContent( blockType, block.attributes );
-		}
-	} catch {
-		// If save content generation fails, skip
-	}
-	return undefined;
-}
+				const blockType = wpBlocks.getBlockType( block.name );
+				let issues: string[] = [];
+				let isValid = true;
+				let expectedContent: string | undefined;
 
-interface ParsedBlock {
-	name: string | null;
-	attributes: Record< string, unknown >;
-	originalContent?: string;
-	innerBlocks?: ParsedBlock[];
-}
+				if ( ! blockType ) {
+					isValid = false;
+					issues.push(
+						`Block type "${ block.name }" is not registered. ` +
+							'It may require a plugin that is not active.'
+					);
+				} else {
+					// validateBlock performs the save-function comparison.
+					// Handle both return formats:
+					//   WP 6.3+: { isValid: boolean, validationIssues: Array }
+					//   Older:   [boolean, Array]
+					const validation = wpBlocks.validateBlock( block, blockType );
 
-function validateBlockList( blocks: ParsedBlock[], results: BlockValidationResult[] ): void {
-	const { validateBlock } = require( '@wordpress/blocks' );
+					if ( Array.isArray( validation ) ) {
+						isValid = validation[ 0 ];
+						if ( ! isValid ) {
+							issues = extractIssues( validation[ 1 ] || [] );
+						}
+					} else {
+						isValid = validation.isValid;
+						if ( ! isValid ) {
+							issues = extractIssues( validation.validationIssues || [] );
+						}
+					}
 
-	for ( const block of blocks ) {
-		// Skip freeform blocks (raw HTML) and missing blocks (unregistered/PHP content)
-		if ( ! block.name || block.name === 'core/freeform' || block.name === 'core/missing' ) {
-			continue;
-		}
+					if ( ! isValid ) {
+						// Re-render expected HTML including inner blocks for comparison
+						try {
+							expectedContent = wpBlocks.getSaveContent(
+								blockType,
+								block.attributes,
+								block.innerBlocks
+							);
+						} catch {
+							// If re-rendering fails, skip expected content
+						}
+					}
+				}
 
-		try {
-			const [ isValid, logItems ] = validateBlock( block ) as [
-				boolean,
-				Array< { args?: unknown[] } >,
-			];
+				results.push( {
+					blockName: block.name,
+					isValid,
+					issues,
+					originalContent: block.originalContent || '',
+					expectedContent: isValid ? undefined : expectedContent,
+				} );
 
-			const issues: string[] = [];
-			for ( const item of logItems ) {
-				const msg = formatLogItem( item );
-				if ( msg ) {
-					issues.push( msg );
+				if ( block.innerBlocks ) {
+					for ( const inner of block.innerBlocks ) {
+						validateRecursive( inner );
+					}
 				}
 			}
 
-			results.push( {
-				blockName: block.name,
-				isValid,
-				issues,
-				originalContent: block.originalContent || '',
-				expectedContent: isValid
-					? undefined
-					: tryGetSaveContent( block as { name: string; attributes: Record< string, unknown > } ),
-			} );
-		} catch ( error ) {
-			results.push( {
-				blockName: block.name,
-				isValid: false,
-				issues: [
-					`Validation error: ${ error instanceof Error ? error.message : String( error ) }`,
-				],
-				originalContent: block.originalContent || '',
-			} );
-		}
+			for ( const block of blocks ) {
+				validateRecursive( block );
+			}
 
-		if ( block.innerBlocks && block.innerBlocks.length > 0 ) {
-			validateBlockList( block.innerBlocks, results );
-		}
-	}
-}
+			const validCount = results.filter( ( r: any ) => r.isValid ).length;
+			return {
+				totalBlocks: results.length,
+				validBlocks: validCount,
+				invalidBlocks: results.length - validCount,
+				results,
+			};
+			/* eslint-enable @typescript-eslint/no-explicit-any */
+		}, content );
 
-/**
- * Validate WordPress block content.
- * Parses the content into blocks and validates each one against its registered save() function.
- */
-export function validateBlocks( content: string ): ValidationReport {
-	ensureInitialized();
+		return report as ValidationReport;
+	} catch ( error ) {
+		// If navigation or evaluation failed, discard the cached page so the
+		// next call gets a fresh one.
+		await editorPage.close();
+		editorPages.delete( siteUrl );
 
-	if ( initError ) {
 		return {
 			totalBlocks: 0,
 			validBlocks: 0,
 			invalidBlocks: 0,
 			results: [],
-			error: initError,
+			error: `Block validation error: ${
+				error instanceof Error ? error.message : String( error )
+			}`,
 		};
 	}
+}
 
-	return withSuppressedConsole( () => {
-		const { parse } = require( '@wordpress/blocks' );
-		const blocks = parse( content ) as ParsedBlock[];
-		const results: BlockValidationResult[] = [];
-
-		validateBlockList( blocks, results );
-
-		const validCount = results.filter( ( r ) => r.isValid ).length;
-
-		return {
-			totalBlocks: results.length,
-			validBlocks: validCount,
-			invalidBlocks: results.length - validCount,
-			results,
-		};
-	} );
+/** Clean up all cached editor pages. */
+export async function cleanupValidatorPages(): Promise< void > {
+	for ( const ep of editorPages.values() ) {
+		await ep.close();
+	}
+	editorPages.clear();
 }

--- a/apps/cli/ai/browser-utils.ts
+++ b/apps/cli/ai/browser-utils.ts
@@ -1,0 +1,129 @@
+/**
+ * Shared browser management for AI tools.
+ *
+ * Provides a lazily-launched Playwright Chromium singleton used by both the
+ * screenshot tool and the block validator.  A future Electron BrowserWindow
+ * backend could be added behind the same interface.
+ */
+
+type Browser = Awaited< ReturnType< ( typeof import('playwright') )[ 'chromium' ][ 'launch' ] > >;
+type Page = Awaited< ReturnType< Browser[ 'newPage' ] > >;
+
+let browserPromise: Promise< Browser > | null = null;
+
+/**
+ * Returns (and lazily launches) a shared Chromium browser instance.
+ * The browser is cleaned up automatically on process exit.
+ */
+export async function getSharedBrowser(): Promise< Browser > {
+	if ( ! browserPromise ) {
+		browserPromise = ( async () => {
+			const { chromium } = require( 'playwright' ) as typeof import('playwright');
+			const browser = await chromium.launch( {
+				args: [ '--ignore-certificate-errors' ],
+			} );
+
+			const cleanup = () => {
+				browser.close().catch( () => {} );
+				browserPromise = null;
+			};
+			process.on( 'exit', cleanup );
+			process.on( 'SIGINT', cleanup );
+			process.on( 'SIGTERM', cleanup );
+
+			return browser;
+		} )();
+	}
+	return browserPromise;
+}
+
+/** Collect diagnostic info from the page to help debug editor load failures. */
+async function getPageDiagnostics( page: Page ): Promise< string > {
+	try {
+		const url = page.url();
+		const info = await page.evaluate( () => {
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			const wp = ( window as any ).wp;
+			return {
+				hasWp: typeof wp !== 'undefined',
+				hasWpBlocks: !! ( wp && wp.blocks ),
+				hasGetBlockTypes: !! ( wp && wp.blocks && typeof wp.blocks.getBlockTypes === 'function' ),
+				blockTypeCount: wp?.blocks?.getBlockTypes?.()?.length ?? 0,
+				title: document.title,
+				bodyClasses: document.body?.className?.slice( 0, 200 ) ?? '',
+			};
+		} );
+		return `url=${ url }, title="${ info.title }", wp=${ info.hasWp }, wp.blocks=${ info.hasWpBlocks }, getBlockTypes=${ info.hasGetBlockTypes }, blockTypes=${ info.blockTypeCount }, body="${ info.bodyClasses }"`;
+	} catch ( e ) {
+		return `(diagnostics failed: ${ e instanceof Error ? e.message : String( e ) })`;
+	}
+}
+
+/**
+ * A long-lived page that stays open on a site's block editor so repeated
+ * validation calls don't have to re-navigate and re-load all block scripts.
+ */
+export class EditorPage {
+	private page: Page | null = null;
+	private readonly siteUrl: string;
+
+	constructor( siteUrl: string ) {
+		this.siteUrl = siteUrl;
+	}
+
+	/** Get or create a page with the block editor loaded. */
+	async getPage(): Promise< Page > {
+		if ( this.page && ! this.page.isClosed() ) {
+			return this.page;
+		}
+
+		const browser = await getSharedBrowser();
+		const page = await browser.newPage( {
+			ignoreHTTPSErrors: true,
+		} );
+
+		const loginUrl = `${ this.siteUrl }/studio-auto-login?redirect_to=/wp-admin/post-new.php`;
+		await page.goto( loginUrl, { waitUntil: 'domcontentloaded', timeout: 30_000 } );
+
+		// Wait for the block editor scripts to be fully loaded and blocks registered.
+		// wp is set early as a global but wp.blocks is populated later, so every
+		// level must be checked to avoid "Cannot read properties of undefined".
+		try {
+			await page.waitForFunction(
+				() => {
+					try {
+						// eslint-disable-next-line @typescript-eslint/no-explicit-any
+						const wp = ( window as any ).wp;
+						return (
+							wp &&
+							wp.blocks &&
+							typeof wp.blocks.getBlockTypes === 'function' &&
+							wp.blocks.getBlockTypes().length > 0
+						);
+					} catch {
+						return false;
+					}
+				},
+				{ timeout: 30_000 }
+			);
+		} catch ( error ) {
+			const diag = await getPageDiagnostics( page );
+			await page.close();
+			throw new Error(
+				`Block editor failed to load (${ diag }): ${
+					error instanceof Error ? error.message : String( error )
+				}`
+			);
+		}
+
+		this.page = page;
+		return page;
+	}
+
+	async close(): Promise< void > {
+		if ( this.page && ! this.page.isClosed() ) {
+			await this.page.close();
+		}
+		this.page = null;
+	}
+}

--- a/apps/cli/ai/system-prompt.ts
+++ b/apps/cli/ai/system-prompt.ts
@@ -34,7 +34,7 @@ Then continue with:
 - site_stop: Stop a running site
 - site_delete: Delete a site from Studio and optionally move its files to trash
 - wp_cli: Run WP-CLI commands on a running site
-- validate_blocks: Validate a single file's block content for correctness (checks block markup matches expected save output). Call after every file write/edit that contains block content.
+- validate_blocks: Validate block content for correctness on a running site (runs each block through its save() function in a real browser). Requires a site name or path. Call after every file write/edit that contains block content.
 - take_screenshot: Take a full-page screenshot of a URL (supports desktop and mobile viewports). Use this to visually check the site after building it.
 
 ## General rules

--- a/apps/cli/ai/tools.ts
+++ b/apps/cli/ai/tools.ts
@@ -5,6 +5,7 @@ import { tool, createSdkMcpServer } from '@anthropic-ai/claude-agent-sdk';
 import { DEFAULT_PHP_VERSION } from '@studio/common/constants';
 import { z } from 'zod/v4';
 import { validateBlocks, type ValidationReport } from 'cli/ai/block-validator';
+import { getSharedBrowser } from 'cli/ai/browser-utils';
 import { runCommand as runCreateSiteCommand } from 'cli/commands/site/create';
 import { runCommand as runDeleteSiteCommand } from 'cli/commands/site/delete';
 import { runCommand as runListSitesCommand } from 'cli/commands/site/list';
@@ -313,12 +314,15 @@ const runWpCliTool = tool(
 	},
 	async ( args ) => {
 		try {
+			const site = await resolveSite( args.nameOrPath );
+
 			// Validate block content in post create/update commands before executing
 			if ( isPostContentCommand( args.command ) ) {
 				const postContent = extractPostContent( args.command );
 				if ( postContent && BLOCK_COMMENT_PATTERN.test( postContent ) ) {
 					emitProgress( 'Validating post content blocks…' );
-					const report = validateBlocks( postContent );
+					const siteUrl = getSiteUrl( site );
+					const report = await validateBlocks( postContent, siteUrl );
 					if ( report.invalidBlocks > 0 ) {
 						const lines = [
 							`Block validation failed: ${ report.invalidBlocks }/${ report.totalBlocks } blocks invalid. Fix the content before creating/updating the post.`,
@@ -330,8 +334,6 @@ const runWpCliTool = tool(
 					emitProgress( `Post content: all ${ report.totalBlocks } blocks valid` );
 				}
 			}
-
-			const site = await resolveSite( args.nameOrPath );
 
 			try {
 				await connectToDaemon();
@@ -378,10 +380,12 @@ const runWpCliTool = tool(
 
 const validateBlocksTool = tool(
 	'validate_blocks',
-	'Validates WordPress block content by parsing it and checking each block against its registered save() function. ' +
-		'Returns per-block validation results showing which blocks are valid and which have issues, ' +
-		'along with the expected HTML for invalid blocks so you can fix them.',
+	"Validates WordPress block content by running each block through its save() function in the site's block editor (real browser). " +
+		'The site must be running. Returns per-block validation results with expected HTML for invalid blocks.',
 	{
+		nameOrPath: z
+			.string()
+			.describe( 'The site name or file system path — the site must be running' ),
 		filePath: z
 			.string()
 			.optional()
@@ -407,11 +411,13 @@ const validateBlocksTool = tool(
 
 			emitProgress( `Validating blocks in ${ fileName }…` );
 
-			const report = validateBlocks( blockContent );
+			const site = await resolveSite( args.nameOrPath );
+			const siteUrl = getSiteUrl( site );
+			const report = await validateBlocks( blockContent, siteUrl );
 
 			if ( report.error ) {
 				emitProgress( `Validation failed for ${ fileName }: ${ report.error.slice( 0, 80 ) }` );
-				return errorResult( `Block validator initialization failed: ${ report.error }` );
+				return errorResult( `Block validation failed: ${ report.error }` );
 			}
 
 			// Update progress with result summary
@@ -442,33 +448,6 @@ const validateBlocksTool = tool(
 
 // --- Screenshot tool ---
 
-type Browser = Awaited< ReturnType< ( typeof import('playwright') )[ 'chromium' ][ 'launch' ] > >;
-
-let browserPromise: Promise< Browser > | null = null;
-
-async function getScreenshotBrowser() {
-	if ( ! browserPromise ) {
-		browserPromise = ( async () => {
-			const { chromium } = require( 'playwright' ) as typeof import('playwright');
-			const browser = await chromium.launch( {
-				args: [ '--ignore-certificate-errors' ],
-			} );
-
-			// Clean up browser when process exits
-			const cleanup = () => {
-				browser.close().catch( () => {} );
-				browserPromise = null;
-			};
-			process.on( 'exit', cleanup );
-			process.on( 'SIGINT', cleanup );
-			process.on( 'SIGTERM', cleanup );
-
-			return browser;
-		} )();
-	}
-	return browserPromise;
-}
-
 const VIEWPORTS = {
 	desktop: { width: 1040, height: 1248 },
 	mobile: { width: 390, height: 844 },
@@ -494,7 +473,7 @@ const takeScreenshotTool = tool(
 
 			emitProgress( `Taking ${ viewportType } screenshot of ${ args.url }…` );
 
-			const browser = await getScreenshotBrowser();
+			const browser = await getSharedBrowser();
 			const page = await browser.newPage( { viewport } );
 
 			try {

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -22,9 +22,6 @@
 		"node-forge": "^1.3.3",
 		"semver": "^7.7.4",
 		"trash": "^10.0.1",
-		"@wordpress/block-library": "^9.40.0",
-		"@wordpress/blocks": "^15.13.0",
-		"jsdom": "^24.0.0",
 		"playwright": "^1.52.0",
 		"yargs": "^18.0.0",
 		"yargs-parser": "^22.0.0"

--- a/apps/cli/vite.config.ts
+++ b/apps/cli/vite.config.ts
@@ -93,16 +93,8 @@ export default defineConfig( {
 				'@wp-playground/wordpress',
 				'@anthropic-ai/claude-agent-sdk',
 				'koffi',
-				// WordPress block validation packages (loaded at runtime from node_modules)
-				/^@wordpress\//,
-				'jsdom',
 				'playwright',
 				'playwright-core',
-				'hpq',
-				'simple-html-tokenizer',
-				'react',
-				'react-dom',
-				'react-is',
 			],
 			output: {
 				format: 'cjs',

--- a/tools/common/lib/mu-plugins.ts
+++ b/tools/common/lib/mu-plugins.ts
@@ -577,6 +577,7 @@ const LEGACY_MU_PLUGIN_FILENAMES = [
 	'0-redirect-to-siteurl-constant.php',
 	'0-sqlite-command.php',
 	'0-studio-admin-api.php',
+	'0-studio-block-validator.php',
 	'0-studio-cli-commands.php',
 	'0-suppress-dns-get-record-warnings.php',
 	'0-thumbnails.php',

--- a/tools/common/lib/mu-plugins.ts
+++ b/tools/common/lib/mu-plugins.ts
@@ -577,7 +577,6 @@ const LEGACY_MU_PLUGIN_FILENAMES = [
 	'0-redirect-to-siteurl-constant.php',
 	'0-sqlite-command.php',
 	'0-studio-admin-api.php',
-	'0-studio-block-validator.php',
 	'0-studio-cli-commands.php',
 	'0-suppress-dns-get-record-warnings.php',
 	'0-thumbnails.php',


### PR DESCRIPTION
Replace the client-side block validation (which required @wordpress/block-library, @wordpress/blocks, jsdom, and their transitive deps like React) with browser-based validation that loads the site's own block editor and runs wp.blocks.validateBlock() in a real browser context.

This provides full save-function comparison for all registered blocks (core + plugins), not just core blocks, while removing ~8 heavy dependencies from the CLI bundle.

## Related issues

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

- Fixes #

## How AI was used in this PR

<!--
Help reviewers understand what to look for and verify that you've reviewed the code yourself.
-->



## Proposed Changes

-

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

-

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
