### PR TITLE
Convert AI feature flag to build-time exclusion

### DIFF
--- a/apps/cli/globals.d.ts
+++ b/apps/cli/globals.d.ts
@@ -1,1 +1,2 @@
 declare const __STUDIO_CLI_VERSION__: string;
+declare const __ENABLE_STUDIO_AI__: boolean;

--- a/apps/cli/index.ts
+++ b/apps/cli/index.ts
@@ -9,7 +9,6 @@ import { StatsGroup, StatsMetric } from '@studio/common/types/stats';
 import { __ } from '@wordpress/i18n';
 import yargs from 'yargs';
 import { commandHandler as eventsCommandHandler } from 'cli/commands/_events';
-import { registerCommand as registerAiCommand } from 'cli/commands/ai';
 import { registerCommand as registerAuthLoginCommand } from 'cli/commands/auth/login';
 import { registerCommand as registerAuthLogoutCommand } from 'cli/commands/auth/logout';
 import { registerCommand as registerAuthStatusCommand } from 'cli/commands/auth/status';
@@ -129,7 +128,8 @@ async function main() {
 		.demandCommand( 1, __( 'You must provide a valid command' ) )
 		.strict();
 
-	if ( process.env.ENABLE_STUDIO_AI === 'true' ) {
+	if ( __ENABLE_STUDIO_AI__ ) {
+		const { registerCommand: registerAiCommand } = await import( 'cli/commands/ai' );
 		registerAiCommand( studioArgv );
 	}
 

--- a/apps/cli/vite.config.ts
+++ b/apps/cli/vite.config.ts
@@ -11,6 +11,7 @@ const distCliNodeModulesPath = resolve( __dirname, 'dist/cli/node_modules' );
 const packageVersion = JSON.parse(
 	readFileSync( resolve( __dirname, '..', 'studio', 'package.json' ), 'utf-8' )
 ).version;
+const enableStudioAi = process.env.ENABLE_STUDIO_AI === 'true';
 
 export default defineConfig( {
 	plugins: [
@@ -54,6 +55,34 @@ export default defineConfig( {
 							}
 						},
 					},
+					...( enableStudioAi
+						? []
+						: [
+								{
+									// When the AI feature is disabled at build time, remove AI-specific
+									// dependencies from dist to reduce the installer size by ~500MB.
+									name: 'prune-ai-deps',
+									apply: 'build' as const,
+									closeBundle() {
+										const aiPackages = [
+											'@anthropic-ai/',
+											'@mariozechner/',
+											'@wordpress/block-library/',
+											'@wordpress/blocks/',
+											'jsdom/',
+											'playwright/',
+											'playwright-core/',
+										];
+
+										for ( const pkg of aiPackages ) {
+											const pkgPath = resolve( distCliNodeModulesPath, pkg );
+											if ( existsSync( pkgPath ) ) {
+												rmSync( pkgPath, { recursive: true, force: true } );
+											}
+										}
+									},
+								},
+						  ] ),
 			  ]
 			: [] ),
 	],
@@ -129,5 +158,6 @@ export default defineConfig( {
 	},
 	define: {
 		__STUDIO_CLI_VERSION__: JSON.stringify( packageVersion ),
+		__ENABLE_STUDIO_AI__: JSON.stringify( enableStudioAi ),
 	},
 } );

--- a/apps/cli/vite.config.ts
+++ b/apps/cli/vite.config.ts
@@ -61,14 +61,16 @@ export default defineConfig( {
 								{
 									// When the AI feature is disabled at build time, remove AI-specific
 									// dependencies from dist to reduce the installer size by ~500MB.
+									// The AI command uses @anthropic-ai/claude-agent-sdk, @mariozechner/pi-tui,
+									// playwright, jsdom, and @wordpress/block-library (which pulls in a large
+									// transitive @wordpress/* tree). Only @wordpress/i18n and @wordpress/hooks
+									// are needed by the non-AI CLI code.
 									name: 'prune-ai-deps',
 									apply: 'build' as const,
 									closeBundle() {
 										const aiPackages = [
 											'@anthropic-ai/',
 											'@mariozechner/',
-											'@wordpress/block-library/',
-											'@wordpress/blocks/',
 											'jsdom/',
 											'playwright/',
 											'playwright-core/',
@@ -78,6 +80,21 @@ export default defineConfig( {
 											const pkgPath = resolve( distCliNodeModulesPath, pkg );
 											if ( existsSync( pkgPath ) ) {
 												rmSync( pkgPath, { recursive: true, force: true } );
+											}
+										}
+
+										// Prune @wordpress/* packages except i18n and hooks (needed by the CLI).
+										// All other @wordpress/* packages are transitive deps of block-library.
+										const wpKeep = new Set( [ 'i18n', 'hooks' ] );
+										const wpDir = resolve( distCliNodeModulesPath, '@wordpress' );
+										if ( existsSync( wpDir ) ) {
+											for ( const entry of globSync( '*', { cwd: wpDir } ) ) {
+												if ( ! wpKeep.has( entry ) ) {
+													rmSync( resolve( wpDir, entry ), {
+														recursive: true,
+														force: true,
+													} );
+												}
 											}
 										}
 									},

--- a/package-lock.json
+++ b/package-lock.json
@@ -9290,7 +9290,6 @@
 			"os": [
 				"darwin"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -9307,7 +9306,6 @@
 			"os": [
 				"darwin"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -9324,7 +9322,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -9341,7 +9338,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -9358,7 +9354,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -9375,7 +9370,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -9392,7 +9386,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -9409,7 +9402,6 @@
 			"os": [
 				"win32"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -9426,7 +9418,6 @@
 			"os": [
 				"win32"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -9443,7 +9434,6 @@
 			"os": [
 				"win32"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}


### PR DESCRIPTION
## Related issues

- Related to https://github.com/Automattic/studio/pull/2632#pullrequestreview-3903639364

## How AI was used in this PR

AI was used to explore the codebase structure, understand the feature flag implementation, and design the build-time exclusion approach. All code was reviewed and verified to work correctly.

## Proposed Changes

- Convert the `ENABLE_STUDIO_AI` environment variable from a runtime check to a build-time configuration
- Remove static import of the AI command at the top of `apps/cli/index.ts`
- Use dynamic `import()` guarded by the build-time constant so the AI code is dead-code-eliminated when disabled
- Add a post-build plugin in `apps/cli/vite.config.ts` that prunes AI-specific node_modules when the flag is disabled
- Add TypeScript declaration for the new `__ENABLE_STUDIO_AI__` global in `apps/cli/globals.d.ts`

## Testing Instructions

1. **Build with AI disabled (default)**: `npm run cli:build` — verify that AI-specific dependencies are not in `dist/cli/node_modules`
2. **Build with AI enabled**: `ENABLE_STUDIO_AI=true npm run cli:build` — verify the `studio ai` command works
3. **Run tests**: All 275 CLI tests pass with no regressions
4. **Verify bundle size**: Check `dist/cli/node_modules` size is ~500MB smaller than before when AI is disabled

## Pre-merge Checklist

- [x] No TypeScript errors (pre-existing TS6305 errors unrelated to these changes)
- [x] ESLint passes on modified files
- [x] All 275 CLI tests pass
- [x] Code reviewed for correctness