### PR TITLE
Fix Windows signing failure caused by foreign-platform native binaries

### DIFF
--- a/apps/studio/forge.config.ts
+++ b/apps/studio/forge.config.ts
@@ -75,6 +75,8 @@ const config: ForgeConfig = {
 			/^\/wp-files/,
 			/^\/apps\/cli\/dist\/cli/,
 			/^\/dist\/playground-cli/,
+			// Exclude foreign-platform native binaries (e.g. darwin .node files break Windows signing)
+			new RegExp( `[\\\\/](?:arm64|x64)-(?!${ process.platform }\\b)\\w+[\\\\/]` ),
 		],
 	},
 	rebuildConfig: {},


### PR DESCRIPTION
## Related issues

- Fixes Windows x64 dev build failure (build #12438)

## How AI was used in this PR

Claude analyzed the build log, identified the root cause (darwin `.node` files from `@anthropic-ai/claude-agent-sdk` being fed to Windows `signtool.exe`), and wrote the fix.

## Proposed Changes

- Add a dynamic `ignore` pattern to `packagerConfig` in `forge.config.ts` that excludes platform-variant directories (e.g. `arm64-darwin/`, `x64-linux/`) that don't match the current build platform
- This prevents foreign-platform native binaries from being bundled into the app, so they never reach Squirrel's signing step

**Root cause:** `@anthropic-ai/claude-agent-sdk` ships vendor binaries (ripgrep, tree-sitter-bash, etc.) for all platforms in `{arch}-{platform}` subdirectories. Squirrel tries to sign every `.node`/`.exe` it finds, and `signtool.exe` cannot sign macOS Mach-O binaries, causing the build to fail with exit code `4294967295`.

## Testing Instructions

- Trigger a Windows dev build and verify it completes successfully
- Verify macOS builds still work (the pattern is dynamic — on macOS it keeps `*-darwin` and excludes `*-win32`/`*-linux`)

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?