### PR TITLE
Attempt to remove incompatible binaries when signing

### DIFF
--- a/apps/studio/forge.config.ts
+++ b/apps/studio/forge.config.ts
@@ -176,6 +176,45 @@ const config: ForgeConfig = {
 			// rerun `npm ci` from the repo root to reset the dependency tree after packaging.
 			await execAsync( 'npm run cli:package' );
 
+			// Remove native binaries for other platforms from CLI's node_modules.
+			// Some packages ship binaries for all platforms which causes code-signing failures
+			// on Windows when signtool encounters non-PE binaries (e.g., darwin .node files).
+			console.log( `Removing native binaries for other platforms from CLI bundle...` );
+			const cliNodeModules = path.join( repoRoot, 'apps', 'cli', 'dist', 'cli', 'node_modules' );
+
+			// Clean up @anthropic-ai/claude-agent-sdk vendor binaries (uses {arch}-{platform} format)
+			const claudeVendorDir = path.join( cliNodeModules, '@anthropic-ai', 'claude-agent-sdk', 'vendor' );
+			const platformSuffix = `-${ platform }`;
+			if ( fs.existsSync( claudeVendorDir ) ) {
+				for ( const toolDir of fs.readdirSync( claudeVendorDir ) ) {
+					const toolPath = path.join( claudeVendorDir, toolDir );
+					if ( fs.statSync( toolPath ).isDirectory() ) {
+						for ( const archPlatformDir of fs.readdirSync( toolPath ) ) {
+							if ( ! archPlatformDir.endsWith( platformSuffix ) ) {
+								const dirToRemove = path.join( toolPath, archPlatformDir );
+								fs.rmSync( dirToRemove, { recursive: true, force: true } );
+								console.log( `Removed claude-agent-sdk/vendor/${ toolDir }/${ archPlatformDir }` );
+							}
+						}
+					}
+				}
+			}
+
+			// Clean up koffi binaries (uses {platform}_{arch} format)
+			const koffiBuildDir = path.join( cliNodeModules, 'koffi', 'build', 'koffi' );
+			const platformPrefix = `${ platform }_`;
+			if ( fs.existsSync( koffiBuildDir ) ) {
+				for ( const platformArchDir of fs.readdirSync( koffiBuildDir ) ) {
+					if ( ! platformArchDir.startsWith( platformPrefix ) ) {
+						const dirToRemove = path.join( koffiBuildDir, platformArchDir );
+						if ( fs.statSync( dirToRemove ).isDirectory() ) {
+							fs.rmSync( dirToRemove, { recursive: true, force: true } );
+							console.log( `Removed koffi/build/koffi/${ platformArchDir }` );
+						}
+					}
+				}
+			}
+
 			console.log('Downloading language packs ...');
 			await execAsync( 'npm run download-language-packs' );
 


### PR DESCRIPTION
Experimental as an attempt to see if we can get a successful Windows build since https://github.com/Automattic/studio/pull/2632.

## Summary

Fixed Windows code-signing failures in CI by removing native binaries for non-target platforms before packaging.

## Problem

Commit 417375c introduced the `studio ai` CLI command which added two new dependencies that ship native binaries for all platforms:
- `@anthropic-ai/claude-agent-sdk` - contains ripgrep and tree-sitter binaries in `vendor/{tool}/{arch}-{platform}/`
- `koffi` (transitive dep via `@mariozechner/pi-tui`) - contains FFI binaries in `build/koffi/{platform}_{arch}/`

Windows code-signing (signtool) fails when it encounters non-Windows binaries (e.g., darwin `.node` files) because they're not valid PE files.

## Solution

Added cleanup logic in the `prePackage` hook in `apps/studio/forge.config.ts` that runs after `cli:package` builds the CLI bundle. It removes platform-specific binary directories that don't match the target platform:

- For `claude-agent-sdk`: removes directories not ending with `-{platform}` (e.g., keeps only `*-win32` on Windows)
- For `koffi`: removes directories not starting with `{platform}_` (e.g., keeps only `win32_*` on Windows)

The initial approach tried to add `ignore` patterns in `packagerConfig` to exclude binaries for other platforms. This didn't work because of how Electron Forge handles `extraResource` vs the main app bundle:

**How `ignore` works:**
- The `ignore` patterns in `packagerConfig` filter what gets copied into the app's main directory (and ASAR archive)
- They apply to the source files being packaged from the project root

**How `extraResource` works:**
- Items listed in `extraResource` are copied directly to the `resources/` folder of the packaged app
- They bypass the `ignore` filter entirely - they're a separate copy operation

The CLI is added as an extraResource:
```javascript
extraResource: [
    // ...
    path.join( repoRoot, 'apps', 'cli', 'dist', 'cli' ),
],
```

So the CLI bundle (including its `node_modules` with the native binaries) gets copied wholesale to `resources/cli/` without any filtering. That's why we needed to clean up the binaries in the `prePackage` hook *before* the extraResource copy happens, rather than relying on ignore patterns.


## How AI was used in this PR

<!--
Help reviewers understand what to look for and verify that you've reviewed the code yourself.
-->

Claude completely drove these code changes by supplying it the Buildkite logs with the error.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Ensure that the optional Windows and Mac builds succeed

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?
