### PR TITLE
Studio: Re-selecting the same file doesn't trigger the import

### DIFF
--- a/apps/studio/src/components/content-tab-import-export.tsx
+++ b/apps/studio/src/components/content-tab-import-export.tsx
@@ -229,8 +229,8 @@ const ImportSite = ( {
 		if ( ! file ) {
 			return;
 		}
+		clearImportFileInput();
 		void importConfirmation( async () => {
-			clearImportFileInput();
 			await importFile( file, selectedSite );
 		} );
 	};


### PR DESCRIPTION
## Related issues

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Fixes STU-1381

## How AI was used in this PR

Not used, it is a simple fix

## Proposed Changes

This PR ensures that when you use an `Import` option in Studio and select the same file after cancelling the import with that file once, the state is reset and the import can be initiated. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
* Start Studio with `npm start`
* Navigate to `Import` tab
* Select a file for import
* Cancel import
* Select the same file for import again
* Confirm that the import can be started 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
