### PR TITLE
Add site import command with streaming migration and SQLite db-apply

### DIFF
--- a/apps/cli/commands/site/import.ts
+++ b/apps/cli/commands/site/import.ts
@@ -105,6 +105,142 @@ function disableErrorDisplayInWpConfig( documentRoot: string ): void {
 }
 
 /**
+ * Ensures wp-config.php has all required constants for running
+ * under Studio with SQLite.
+ *
+ * Managed WordPress hosts like SiteGround and WordPress.com Atomic
+ * inject DB credentials at the server level, so wp-config.php
+ * may only contain comments about DB_HOST/DB_USER/DB_PASSWORD
+ * without actually defining them. WordPress requires these
+ * constants to exist (even with SQLite, where db.php intercepts
+ * before MySQL connects) or it redirects to setup-config.php.
+ *
+ * WP_CONTENT_DIR is set explicitly because Atomic sites use
+ * symlinks for wp-load.php that make __DIR__ resolve to the
+ * shared WP core directory. Without this, WordPress would look
+ * for wp-content (and db.php) in the core dir instead of the
+ * site's document root — exactly what the Atomic platform does
+ * with `define( 'WP_CONTENT_DIR', realpath('/srv/htdocs/wp-content') )`.
+ */
+function ensureRequiredConstantsInWpConfig( documentRoot: string ): void {
+	const wpConfigPath = path.join( documentRoot, 'wp-config.php' );
+	if ( ! fs.existsSync( wpConfigPath ) ) {
+		return;
+	}
+
+	let content = fs.readFileSync( wpConfigPath, 'utf-8' );
+
+	// DB placeholder constants — values don't matter for SQLite,
+	// but WordPress requires them to be defined.
+	const requiredConstants: Record< string, string > = {
+		DB_NAME: 'wordpress',
+		DB_USER: 'root',
+		DB_PASSWORD: 'root',
+		DB_HOST: 'localhost',
+	};
+
+	for ( const [ name, value ] of Object.entries( requiredConstants ) ) {
+		const definePattern = new RegExp( `define\\s*\\(\\s*['"]${ name }['"]` );
+		if ( ! definePattern.test( content ) ) {
+			// Insert before "That's all, stop editing" or before ABSPATH
+			const insertBefore = content.match(
+				/\/\*.*(?:stop editing|ABSPATH).*\*\/|if\s*\(\s*!\s*defined\s*\(\s*'ABSPATH'\s*\)/
+			);
+			const insertLine = `define( '${ name }', '${ value }' );\n`;
+			if ( insertBefore ) {
+				content = content.replace( insertBefore[ 0 ], insertLine + insertBefore[ 0 ] );
+			} else {
+				content = content.replace( /(require_once.*wp-settings\.php)/, insertLine + '$1' );
+			}
+		}
+	}
+
+	// WP_CONTENT_DIR must point to the document root's wp-content,
+	// not wherever __DIR__ resolves to (which may be a symlink target).
+	// Using __DIR__ here works because wp-config.php is a real file
+	// in the document root (or a symlink that resolves back to it).
+	if ( ! /define\s*\(\s*['"]WP_CONTENT_DIR['"]/.test( content ) ) {
+		const insertBefore = content.match(
+			/\/\*.*(?:stop editing|ABSPATH).*\*\/|if\s*\(\s*!\s*defined\s*\(\s*'ABSPATH'\s*\)/
+		);
+		const insertLine = `define( 'WP_CONTENT_DIR', __DIR__ . '/wp-content' );\n`;
+		if ( insertBefore ) {
+			content = content.replace( insertBefore[ 0 ], insertLine + insertBefore[ 0 ] );
+		} else {
+			content = content.replace( /(require_once.*wp-settings\.php)/, insertLine + '$1' );
+		}
+	}
+
+	fs.writeFileSync( wpConfigPath, content );
+}
+
+/**
+ * Detects WordPress.com Atomic site structure and creates a
+ * wp-config.php symlink in the WordPress core directory.
+ *
+ * Atomic sites use symlinks to share a single WordPress core install:
+ *   htdocs/__wp__ → ../wordpress/core/latest → 6.9.4/
+ *   htdocs/wp-load.php → __wp__/wp-load.php
+ *
+ * When PHP resolves __DIR__ inside the symlinked wp-load.php, it gets
+ * the core directory (e.g. wordpress/core/6.9.4/), not htdocs/.
+ * WordPress then looks for wp-config.php in __DIR__ — the core
+ * directory — and fails because wp-config.php lives in htdocs/.
+ *
+ * On the actual Atomic platform this works because their preload
+ * scripts run before wp-load.php. For Playground we solve it by
+ * placing a wp-config.php symlink in the core directory that points
+ * back to the document root's wp-config.php.
+ */
+function createAtomicWpConfigSymlink( sitePath: string, documentRoot: string ): boolean {
+	const wpSymlinkPath = path.join( documentRoot, '__wp__' );
+	const wpLoadPath = path.join( documentRoot, 'wp-load.php' );
+
+	// Check for the Atomic structure: __wp__ symlink and wp-load.php symlink
+	let wpLoadStat;
+	try {
+		wpLoadStat = fs.lstatSync( wpLoadPath );
+	} catch {
+		return false;
+	}
+
+	if ( ! wpLoadStat.isSymbolicLink() || ! fs.existsSync( wpSymlinkPath ) ) {
+		return false;
+	}
+
+	let wpLoadLinkTarget;
+	try {
+		wpLoadLinkTarget = fs.readlinkSync( wpLoadPath );
+	} catch {
+		return false;
+	}
+
+	// Verify wp-load.php points through __wp__
+	if ( ! wpLoadLinkTarget.startsWith( '__wp__/' ) ) {
+		return false;
+	}
+
+	// Resolve the real directory where wp-load.php lives.
+	// This follows all symlinks to get the actual filesystem path.
+	const realWpLoadPath = fs.realpathSync( wpLoadPath );
+	const wpCoreDir = path.dirname( realWpLoadPath );
+
+	// Don't overwrite an existing wp-config.php in the core directory
+	const coreWpConfigPath = path.join( wpCoreDir, 'wp-config.php' );
+	if ( fs.existsSync( coreWpConfigPath ) ) {
+		return true;
+	}
+
+	// Compute a relative symlink path from the core directory back to
+	// the document root's wp-config.php
+	const wpConfigRealPath = path.join( documentRoot, 'wp-config.php' );
+	const relativePath = path.relative( wpCoreDir, wpConfigRealPath );
+
+	fs.symlinkSync( relativePath, coreWpConfigPath );
+	return true;
+}
+
+/**
  * Parses a PHP serialized array of strings, e.g.:
  *   a:2:{i:0;s:19:"akismet/akismet.php";i:1;s:33:"sg-security/sg-security.php";}
  * Returns the string values as a plain array.
@@ -355,6 +491,23 @@ export async function runCommand( url: string, secret: string, name: string ): P
 		// Disable error display in wp-config.php so PHP errors from
 		// incompatible plugins don't leak into the browser.
 		disableErrorDisplayInWpConfig( documentRoot );
+
+		// Ensure DB constants are defined in wp-config.php. Managed
+		// hosts inject these at the server level, so the imported
+		// wp-config.php may not define them. WordPress requires all
+		// four even with SQLite (db.php intercepts before MySQL
+		// connects, but the constants must exist).
+		ensureRequiredConstantsInWpConfig( documentRoot );
+
+		// WordPress.com Atomic sites use symlinks to share a single
+		// WP core install. wp-load.php symlinks into the core dir,
+		// and PHP's __DIR__ resolves to there — so WordPress looks
+		// for wp-config.php in the core dir instead of the document
+		// root. Create a wp-config.php symlink in the core dir
+		// pointing back to the document root's wp-config.php.
+		if ( createAtomicWpConfigSymlink( sitePath, documentRoot ) ) {
+			logger.reportSuccess( 'Configured WordPress.com Atomic symlinks' );
+		}
 
 		logger.reportSuccess( `Site "${ siteName }" created` );
 

--- a/apps/cli/commands/site/import.ts
+++ b/apps/cli/commands/site/import.ts
@@ -21,6 +21,7 @@
  * the same command resumes from where it left off. The importer.phar
  * natively supports resuming partial file and database downloads.
  */
+import { spawnSync } from 'child_process';
 import crypto from 'crypto';
 import fs from 'fs';
 import path from 'path';
@@ -79,6 +80,95 @@ function decodeStateValue( value: string ): string {
 		return Buffer.from( value.slice( 7 ), 'base64' ).toString( 'utf-8' );
 	}
 	return value;
+}
+
+/**
+ * Patches wp-config.php to disable error display. Remote sites may have
+ * WP_DEBUG enabled or ini_set('display_errors', '1'). Studio controls
+ * these via Blueprint constants at runtime, but errors that occur very
+ * early in the PHP bootstrap (before WordPress applies its settings)
+ * can still leak through. Injecting @ini_set('display_errors', '0')
+ * right after the opening <?php tag catches those early errors.
+ */
+function disableErrorDisplayInWpConfig( documentRoot: string ): void {
+	const wpConfigPath = path.join( documentRoot, 'wp-config.php' );
+	if ( ! fs.existsSync( wpConfigPath ) ) {
+		return;
+	}
+
+	let content = fs.readFileSync( wpConfigPath, 'utf-8' );
+
+	// Inject display_errors = off right after the opening <?php tag
+	content = content.replace( /^<\?php\s*/, "<?php\n@ini_set('display_errors', '0');\n" );
+
+	fs.writeFileSync( wpConfigPath, content );
+}
+
+/**
+ * Parses a PHP serialized array of strings, e.g.:
+ *   a:2:{i:0;s:19:"akismet/akismet.php";i:1;s:33:"sg-security/sg-security.php";}
+ * Returns the string values as a plain array.
+ */
+function parsePhpSerializedStringArray( serialized: string ): string[] {
+	const items: string[] = [];
+	// Match each s:LENGTH:"VALUE"; entry
+	const regex = /s:(\d+):"([\s\S]*?)";/g;
+	let match;
+	while ( ( match = regex.exec( serialized ) ) !== null ) {
+		items.push( match[ 2 ] );
+	}
+	return items;
+}
+
+/**
+ * Serializes a plain array of strings into PHP serialized format, e.g.:
+ *   a:2:{i:0;s:19:"akismet/akismet.php";i:1;s:9:"hello.php";}
+ */
+function serializePhpStringArray( items: string[] ): string {
+	const entries = items.map( ( val, i ) => `i:${ i };s:${ val.length }:"${ val }";` ).join( '' );
+	return `a:${ items.length }:{${ entries }}`;
+}
+
+/**
+ * Deactivates a plugin by editing the active_plugins option directly
+ * in the SQLite database. This avoids loading WordPress/PHP which
+ * could itself fail due to the problematic plugin.
+ */
+function deactivatePluginInSqlite(
+	dbPath: string,
+	tablePrefix: string,
+	pluginSlug: string
+): boolean {
+	const optionName = 'active_plugins';
+	const table = `${ tablePrefix }options`;
+
+	// Read the current active_plugins value
+	const readResult = spawnSync( 'sqlite3', [
+		dbPath,
+		`SELECT option_value FROM ${ table } WHERE option_name = '${ optionName }';`,
+	] );
+	if ( readResult.status !== 0 || ! readResult.stdout ) {
+		return false;
+	}
+
+	const serialized = readResult.stdout.toString().trim();
+	const plugins = parsePhpSerializedStringArray( serialized );
+	const filtered = plugins.filter( ( p ) => ! p.startsWith( pluginSlug + '/' ) );
+
+	if ( filtered.length === plugins.length ) {
+		// Plugin was not active
+		return false;
+	}
+
+	const newSerialized = serializePhpStringArray( filtered );
+	// Use parameterized update via stdin to avoid shell quoting issues
+	// with the serialized PHP string.
+	const sql = `UPDATE ${ table } SET option_value = '${ newSerialized.replace(
+		/'/g,
+		"''"
+	) }' WHERE option_name = '${ optionName }';`;
+	const writeResult = spawnSync( 'sqlite3', [ dbPath ], { input: sql } );
+	return writeResult.status === 0;
 }
 
 /**
@@ -262,6 +352,10 @@ export async function runCommand( url: string, secret: string, name: string ): P
 		// mu-plugin to redirect WordPress to the SQLite database.
 		await installSqliteIntegration( documentRoot );
 
+		// Disable error display in wp-config.php so PHP errors from
+		// incompatible plugins don't leak into the browser.
+		disableErrorDisplayInWpConfig( documentRoot );
+
 		logger.reportSuccess( `Site "${ siteName }" created` );
 
 		// ── Step 5: Apply database directly to SQLite ──────────────
@@ -301,7 +395,22 @@ export async function runCommand( url: string, secret: string, name: string ): P
 
 		logger.reportSuccess( __( 'Database imported' ) );
 
-		// ── Step 6: Register site ───────────────────────────────────
+		// ── Step 6: Deactivate hosting-specific plugins ─────────────
+		// The sg-security plugin (SiteGround Security) logs every visit
+		// during WordPress boot, triggering NOT NULL constraint errors
+		// in the SQLite translator that prevent the site from starting.
+		// Deactivate it directly in the SQLite database to avoid loading
+		// WordPress/PHP, which could itself fail due to the plugin.
+		const sqliteDbPath = path.join( documentRoot, 'wp-content', 'database', '.ht.sqlite' );
+		const tablePrefix = preflight.table_prefix || 'wp_';
+		if ( deactivatePluginInSqlite( sqliteDbPath, tablePrefix, 'sg-security' ) ) {
+			logger.reportSuccess( 'Deactivated sg-security plugin' );
+		}
+		if ( deactivatePluginInSqlite( sqliteDbPath, tablePrefix, 'sg-cachepress' ) ) {
+			logger.reportSuccess( 'Deactivated sg-cachepress plugin' );
+		}
+
+		// ── Step 7: Register site ───────────────────────────────────
 		const siteDetails: SiteData = {
 			id: siteId,
 			name: siteName,

--- a/apps/cli/commands/site/import.ts
+++ b/apps/cli/commands/site/import.ts
@@ -32,6 +32,7 @@ import { SITE_EVENTS } from '@studio/common/lib/site-events';
 import { sortSites } from '@studio/common/lib/sort-sites';
 import { ImportCommandLoggerAction as LoggerAction } from '@studio/common/logger-actions';
 import { __ } from '@wordpress/i18n';
+import chalk from 'chalk';
 import {
 	getAppdataDirectory,
 	lockAppdata,
@@ -49,6 +50,39 @@ import { Logger, LoggerError } from 'cli/logger';
 import { StudioArgv } from 'cli/types';
 
 const logger = new Logger< LoggerAction >();
+
+const PLUGIN_INSTALL_HINT =
+	'Make sure the streaming-site-migration plugin is installed and activated.\n' +
+	'Download the latest version from:\n' +
+	'https://github.com/adamziel/streaming-site-migration/releases/latest';
+
+/**
+ * Draws a red-bordered box around a message for terminal display.
+ */
+function redBox( message: string ): string {
+	const lines = message.split( '\n' );
+	const maxLen = Math.max( ...lines.map( ( l ) => l.length ) );
+	const top = chalk.red( '┌' + '─'.repeat( maxLen + 2 ) + '┐' );
+	const bottom = chalk.red( '└' + '─'.repeat( maxLen + 2 ) + '┘' );
+	const body = lines
+		.map( ( line ) => chalk.red( '│' ) + ' ' + line.padEnd( maxLen ) + ' ' + chalk.red( '│' ) )
+		.join( '\n' );
+	return `${ top }\n${ body }\n${ bottom }`;
+}
+
+/**
+ * An import error that separates the user-facing message from
+ * technical details. The handler shows the details only when
+ * --verbose is set.
+ */
+class ImportError extends LoggerError {
+	technicalDetails: string;
+
+	constructor( userMessage: string, technicalDetails: string ) {
+		super( userMessage );
+		this.technicalDetails = technicalDetails;
+	}
+}
 
 /**
  * Extracts JSON from importer.phar output, tolerating PHP warnings
@@ -401,20 +435,52 @@ export async function runCommand( url: string, secret: string, name: string ): P
 
 			// /state and /docroot are virtual mount points inside PHP WASM,
 			// mapped to stateDir and sitePath by the child process.
-			const preflightResult = await runImporterCommandUntilComplete( stateDir, sitePath, [
-				'preflight',
-				apiUrl,
-				`--secret=${ secret }`,
-				'--no-adaptive',
-				'--state-dir=/state',
-				'--docroot=/docroot',
-			] );
+			let preflightResult: ImporterResult;
+			try {
+				preflightResult = await runImporterCommandUntilComplete( stateDir, sitePath, [
+					'preflight',
+					apiUrl,
+					`--secret=${ secret }`,
+					'--no-adaptive',
+					'--state-dir=/state',
+					'--docroot=/docroot',
+				] );
+			} catch ( preflightError ) {
+				const details =
+					preflightError instanceof Error ? preflightError.message : String( preflightError );
+				throw new ImportError(
+					__( 'Could not connect to the remote site.' ) + '\n\n' + PLUGIN_INSTALL_HINT,
+					details
+				);
+			}
 
-			const envelope = parseImporterJson( preflightResult );
+			let envelope;
+			try {
+				envelope = parseImporterJson( preflightResult );
+			} catch {
+				throw new ImportError(
+					__( 'The remote site did not respond with a recognized format.' ) +
+						'\n\n' +
+						PLUGIN_INSTALL_HINT,
+					`stdout: ${ preflightResult.stdout }\nstderr: ${ preflightResult.stderr }`
+				);
+			}
 			const preflightData = envelope.data ?? envelope;
 
 			if ( ! preflightData.ok ) {
-				throw new LoggerError( preflightData.error || __( 'Remote site preflight check failed.' ) );
+				const errorDetail = preflightData.error || '';
+				// The importer returns "Invalid JSON: ..." when the remote
+				// site responds with HTML instead of the expected API JSON.
+				// This typically means the export plugin isn't installed.
+				const isJsonParseError = /^Invalid JSON\b/i.test( errorDetail );
+				const userMessage = isJsonParseError
+					? __( 'The remote site responded with HTML instead of the expected export API.' )
+					: __( 'Remote site preflight check failed.' );
+
+				throw new ImportError(
+					userMessage + '\n\n' + PLUGIN_INSTALL_HINT,
+					preflightResult.stdout.trim() + '\n' + preflightResult.stderr.trim()
+				);
 			}
 
 			preflight = {
@@ -647,13 +713,27 @@ export const registerCommand = ( yargs: StudioArgv ) => {
 					type: 'string',
 					describe: __( 'Local site name' ),
 					demandOption: true,
+				} )
+				.option( 'verbose', {
+					type: 'boolean',
+					describe: __( 'Show detailed error information' ),
+					default: false,
 				} );
 		},
 		handler: async ( argv ) => {
+			const verbose = argv.verbose as boolean;
 			try {
 				await runCommand( argv.url as string, argv.secret as string, argv.name as string );
 			} catch ( error ) {
-				if ( error instanceof LoggerError ) {
+				if ( error instanceof ImportError ) {
+					logger.spinner.fail( __( 'Import failed' ) );
+					console.error( '\n' + redBox( error.message ) );
+					if ( verbose && error.technicalDetails ) {
+						console.error( '\n' + chalk.dim( error.technicalDetails ) );
+					} else if ( error.technicalDetails ) {
+						console.error( chalk.dim( '\nRun with --verbose for detailed error output.' ) );
+					}
+				} else if ( error instanceof LoggerError ) {
 					logger.reportError( error );
 				} else {
 					logger.reportError( new LoggerError( __( 'Failed to import site' ), error ) );

--- a/apps/cli/commands/site/import.ts
+++ b/apps/cli/commands/site/import.ts
@@ -1,0 +1,378 @@
+/**
+ * CLI command: studio site import
+ *
+ * Imports a remote WordPress site into a local Studio site using the
+ * streaming site migration protocol. Delegates all protocol work to
+ * importer.phar (run via PHP WASM), then sets up the imported files
+ * as a Studio site with SQLite and URL rewriting.
+ *
+ * The import flow:
+ *   1. Preflight – verify the remote plugin is reachable (cached, runs once)
+ *   2. files-sync – download all WordPress files via importer.phar
+ *   3. db-sync – download the SQL dump via importer.phar
+ *   4. Create a Studio site from the downloaded files
+ *   5. Apply the database dump directly to SQLite via db-apply,
+ *      rewriting URLs (http + https variants → localhost) in the same pass
+ *
+ * Resumption: import state is persisted in the Studio appdata directory,
+ * keyed by URL. If the command dies mid-import, re-running the same
+ * command will resume from where it left off. The importer.phar natively
+ * supports resuming partial file and database downloads.
+ */
+import crypto from 'crypto';
+import fs from 'fs';
+import path from 'path';
+import { DEFAULT_PHP_VERSION } from '@studio/common/constants';
+import { isEmptyDir, pathExists, recursiveCopyDirectory } from '@studio/common/lib/fs-utils';
+import { portFinder } from '@studio/common/lib/port-finder';
+import { SITE_EVENTS } from '@studio/common/lib/site-events';
+import { sortSites } from '@studio/common/lib/sort-sites';
+import { ImportCommandLoggerAction as LoggerAction } from '@studio/common/logger-actions';
+import { __ } from '@wordpress/i18n';
+import {
+	getAppdataDirectory,
+	lockAppdata,
+	readAppdata,
+	removeSiteFromAppdata,
+	saveAppdata,
+	SiteData,
+	unlockAppdata,
+} from 'cli/lib/appdata';
+import { emitSiteEvent } from 'cli/lib/daemon-client';
+import { getDefaultSitePath } from 'cli/lib/generate-site-name';
+import { runImporterCommandUntilComplete, ImporterResult } from 'cli/lib/import/migration-client';
+import { getServerFilesPath } from 'cli/lib/server-files';
+import { keepSqliteIntegrationUpdated } from 'cli/lib/sqlite-integration';
+import { Logger, LoggerError } from 'cli/logger';
+import { StudioArgv } from 'cli/types';
+
+const logger = new Logger< LoggerAction >();
+
+/**
+ * Extracts JSON from importer.phar output, tolerating PHP warnings
+ * that may appear before the JSON payload.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function parseImporterJson( result: ImporterResult ): any {
+	const raw = result.stdout.trim();
+	try {
+		return JSON.parse( raw );
+	} catch {
+		// stdout may contain PHP warnings before the JSON object
+		const jsonStart = raw.indexOf( '{' );
+		if ( jsonStart >= 0 ) {
+			return JSON.parse( raw.slice( jsonStart ) );
+		}
+		throw new LoggerError(
+			`importer.phar did not return valid JSON.\nstdout: ${ raw }\nstderr: ${ result.stderr }`
+		);
+	}
+}
+
+export async function runCommand( url: string, secret: string, name: string ): Promise< void > {
+	const apiUrl = url.replace( /\/+$/, '' ) + '/?site-export-api';
+	const siteName = name;
+	let sitePath: string | undefined;
+	let siteId: string | undefined;
+
+	// Ensure we have the latest importer.phar (older versions don't support db-apply)
+	const cachedPharPath = path.join( getAppdataDirectory(), 'importer.phar' );
+	try {
+		fs.unlinkSync( cachedPharPath );
+	} catch {
+		// File may not exist yet
+	}
+
+	// Use a persistent import directory so the phar can resume partial
+	// downloads if the command is interrupted and re-run. The hash
+	// includes both URL and name so the same site can be imported
+	// under different names without collisions.
+	const importDirHash = crypto
+		.createHash( 'sha256' )
+		.update( `${ url }\n${ siteName }` )
+		.digest( 'hex' )
+		.slice( 0, 12 );
+	const importDir = path.join( getAppdataDirectory(), 'imports', importDirHash );
+	const stateDir = path.join( importDir, 'state' );
+	const docroot = path.join( importDir, 'docroot' );
+	fs.mkdirSync( stateDir, { recursive: true } );
+	fs.mkdirSync( docroot, { recursive: true } );
+
+	const isResume = fs.readdirSync( stateDir ).length > 0;
+	if ( isResume ) {
+		console.log( `Resuming previous import for ${ url }` );
+		console.log( '' );
+	}
+
+	console.log( `Importing "${ siteName }" from ${ url }` );
+	console.log( `Import directory: ${ importDir }` );
+	console.log( '' );
+
+	try {
+		// ── Step 1: Preflight ────────────────────────────────────────
+		// Cache the preflight result in the state directory so we only
+		// hit the remote once. On resume, read the cached result.
+		const preflightCachePath = path.join( stateDir, 'preflight.json' );
+		let preflight: {
+			siteurl?: string;
+			wp_version?: string;
+			php_version?: string;
+			table_prefix?: string;
+		};
+
+		if ( fs.existsSync( preflightCachePath ) ) {
+			preflight = JSON.parse( fs.readFileSync( preflightCachePath, 'utf-8' ) );
+			logger.reportSuccess(
+				`Connected – WordPress ${ preflight.wp_version || 'unknown' }, ` +
+					`PHP ${ preflight.php_version || 'unknown' }`
+			);
+		} else {
+			logger.reportStart( LoggerAction.PREFLIGHT, __( 'Connecting to remote site…' ) );
+
+			// /state and /docroot are virtual mount points inside PHP WASM,
+			// mapped to stateDir and docroot by the child process.
+			const preflightResult = await runImporterCommandUntilComplete( stateDir, docroot, [
+				'preflight',
+				apiUrl,
+				`--secret=${ secret }`,
+				'--no-adaptive',
+				'--state-dir=/state',
+				'--docroot=/docroot',
+			] );
+
+			const envelope = parseImporterJson( preflightResult );
+			const preflightData = envelope.data ?? envelope;
+
+			if ( ! preflightData.ok ) {
+				throw new LoggerError( preflightData.error || __( 'Remote site preflight check failed.' ) );
+			}
+
+			preflight = {
+				siteurl: preflightData.database?.wp?.siteurl || undefined,
+				wp_version: preflightData.database?.wp?.wp_version || undefined,
+				php_version: preflightData.php?.version || undefined,
+				table_prefix: preflightData.database?.wp?.table_prefix || undefined,
+			};
+			fs.writeFileSync( preflightCachePath, JSON.stringify( preflight ) );
+
+			logger.reportSuccess(
+				`Connected – WordPress ${ preflight.wp_version || 'unknown' }, ` +
+					`PHP ${ preflight.php_version || 'unknown' }`
+			);
+		}
+
+		const remoteUrl = preflight.siteurl || url;
+		const remoteHost = new URL( remoteUrl ).host;
+
+		// ── Step 2: Download files ──────────────────────────────────
+		logger.reportStart( LoggerAction.DOWNLOAD_FILES, __( 'Downloading files…' ) );
+
+		await runImporterCommandUntilComplete(
+			stateDir,
+			docroot,
+			[
+				'files-sync',
+				apiUrl,
+				`--secret=${ secret }`,
+				'--no-adaptive',
+				'--state-dir=/state',
+				'--docroot=/docroot',
+			],
+			( progress ) => logger.reportProgress( progress )
+		);
+
+		logger.reportSuccess( __( 'Files downloaded' ) );
+
+		// ── Step 3: Download database ───────────────────────────────
+		logger.reportStart( LoggerAction.DOWNLOAD_SQL, __( 'Downloading database…' ) );
+
+		await runImporterCommandUntilComplete(
+			stateDir,
+			docroot,
+			[
+				'db-sync',
+				apiUrl,
+				`--secret=${ secret }`,
+				'--sql-output=file',
+				'--no-adaptive',
+				'--state-dir=/state',
+				'--docroot=/docroot',
+			],
+			( progress ) => logger.reportProgress( progress )
+		);
+
+		logger.reportSuccess( __( 'Database downloaded' ) );
+
+		// ── Step 4: Create Studio site from downloaded files ────────
+		logger.reportStart( LoggerAction.CREATE_SITE, `Creating site "${ siteName }"…` );
+
+		sitePath = getDefaultSitePath( siteName );
+		siteId = crypto.randomUUID();
+
+		if ( ( await pathExists( sitePath ) ) && ! ( await isEmptyDir( sitePath ) ) ) {
+			throw new LoggerError( __( 'Site directory already exists and is not empty.' ) );
+		}
+
+		// Copy bundled WordPress as the base
+		const bundledWPPath = path.join( getServerFilesPath(), 'wordpress-versions', 'latest' );
+		if ( ! ( await pathExists( bundledWPPath ) ) ) {
+			throw new LoggerError( __( 'Bundled WordPress files not found. Please reinstall Studio.' ) );
+		}
+		fs.mkdirSync( sitePath, { recursive: true } );
+		await recursiveCopyDirectory( bundledWPPath, sitePath );
+
+		// Overlay downloaded wp-content onto the fresh site
+		const downloadedWpContent = path.join( docroot, 'wp-content' );
+		if ( fs.existsSync( downloadedWpContent ) ) {
+			await recursiveCopyDirectory( downloadedWpContent, path.join( sitePath, 'wp-content' ) );
+		}
+
+		// Install SQLite integration
+		await keepSqliteIntegrationUpdated( sitePath );
+
+		logger.reportSuccess( `Site "${ siteName }" created` );
+
+		// ── Step 5: Apply database directly to SQLite ──────────────
+		// Allocate the port early so we can rewrite URLs during db-apply.
+		const appdata = await readAppdata();
+		for ( const site of appdata.sites ) {
+			portFinder.addUnavailablePort( site.port );
+		}
+		const port = await portFinder.getOpenPort();
+		const localUrl = `http://localhost:${ port }`;
+
+		logger.reportStart( LoggerAction.IMPORT_SQL, __( 'Importing database…' ) );
+
+		// Create the database directory so db-apply can write
+		// the SQLite file to wp-content/database/.ht.sqlite.
+		const dbDir = path.join( sitePath, 'wp-content', 'database' );
+		fs.mkdirSync( dbDir, { recursive: true } );
+
+		// Use importer.phar's db-apply to convert the MySQL dump
+		// directly into a SQLite database and rewrite URLs in one pass.
+		// The importer handles base64 decoding and SQL translation internally.
+		await runImporterCommandUntilComplete( stateDir, sitePath, [
+			'db-apply',
+			apiUrl,
+			`--secret=${ secret }`,
+			'--state-dir=/state',
+			'--docroot=/docroot',
+			'--target-engine=sqlite',
+			'--target-sqlite-path=/docroot/wp-content/database/.ht.sqlite',
+			'--rewrite-url',
+			`https://${ remoteHost }`,
+			localUrl,
+			'--rewrite-url',
+			`http://${ remoteHost }`,
+			localUrl,
+		] );
+
+		logger.reportSuccess( __( 'Database imported' ) );
+
+		// ── Step 6: Register site ───────────────────────────────────
+		const siteDetails: SiteData = {
+			id: siteId,
+			name: siteName,
+			path: sitePath,
+			port,
+			phpVersion: DEFAULT_PHP_VERSION,
+			adminPassword: 'password',
+			running: false,
+			isWpAutoUpdating: true,
+			enableHttps: false,
+		};
+
+		try {
+			await lockAppdata();
+			const userData = await readAppdata();
+			userData.sites.push( siteDetails );
+			sortSites( userData.sites );
+			await saveAppdata( userData );
+		} finally {
+			await unlockAppdata();
+		}
+
+		// ── Clean up import state ───────────────────────────────────
+		fs.rmSync( importDir, { recursive: true, force: true } );
+
+		// ── Done ────────────────────────────────────────────────────
+		siteDetails.url = localUrl;
+
+		console.log( '' );
+		console.log( `Site "${ siteName }" imported successfully!` );
+		console.log( '' );
+		console.log( __( 'Site URL: ' ), localUrl );
+		console.log( __( 'WP Admin: ' ), `${ localUrl }/wp-admin/` );
+		console.log( `Start the site with: studio site start --path "${ sitePath }"` );
+		console.log( '' );
+
+		logger.reportKeyValuePair( 'id', siteDetails.id );
+
+		await emitSiteEvent( SITE_EVENTS.CREATED, { siteId: siteDetails.id } );
+	} catch ( error ) {
+		// Don't clean up the import directory on failure — it allows
+		// the user to re-run the same command to resume.
+		console.log( '' );
+		console.log( 'To resume this import, re-run the same command:' );
+		console.log( `  studio site import --url ${ url } --secret <secret> --name "${ siteName }"` );
+		console.log( '' );
+
+		if ( siteId ) {
+			try {
+				await removeSiteFromAppdata( siteId );
+			} catch {
+				// Best-effort cleanup
+			}
+		}
+		if ( sitePath && ( await pathExists( sitePath ) ) ) {
+			try {
+				fs.rmSync( sitePath, { recursive: true, force: true } );
+			} catch {
+				// Best-effort cleanup
+			}
+		}
+
+		if ( error instanceof LoggerError ) {
+			throw error;
+		}
+		throw new LoggerError( __( 'Failed to import site' ), error );
+	} finally {
+		setTimeout( () => process.exit( 0 ), 10 );
+	}
+}
+
+export const registerCommand = ( yargs: StudioArgv ) => {
+	return yargs.command( {
+		command: 'import',
+		describe: __( 'Import a remote WordPress site' ),
+		builder: ( yargs ) => {
+			return yargs
+				.option( 'url', {
+					type: 'string',
+					describe: __( 'URL of the remote WordPress site' ),
+					demandOption: true,
+				} )
+				.option( 'secret', {
+					type: 'string',
+					describe: __( 'Shared HMAC secret configured in the migration plugin' ),
+					demandOption: true,
+				} )
+				.option( 'name', {
+					type: 'string',
+					describe: __( 'Local site name' ),
+					demandOption: true,
+				} );
+		},
+		handler: async ( argv ) => {
+			try {
+				await runCommand( argv.url as string, argv.secret as string, argv.name as string );
+			} catch ( error ) {
+				if ( error instanceof LoggerError ) {
+					logger.reportError( error );
+				} else {
+					logger.reportError( new LoggerError( __( 'Failed to import site' ), error ) );
+				}
+			}
+		},
+	} );
+};

--- a/apps/cli/commands/site/import.ts
+++ b/apps/cli/commands/site/import.ts
@@ -7,23 +7,25 @@
  * as a Studio site with SQLite and URL rewriting.
  *
  * The import flow:
- *   1. Preflight – verify the remote plugin is reachable (cached, runs once)
- *   2. files-sync – download all WordPress files via importer.phar
- *   3. db-sync – download the SQL dump via importer.phar
- *   4. Create a Studio site from the downloaded files
- *   5. Apply the database dump directly to SQLite via db-apply,
+ *   1. Create the site directory upfront (not yet a Studio site)
+ *   2. Preflight – verify the remote plugin is reachable (cached, runs once)
+ *   3. files-sync – download all WordPress files directly into the site dir
+ *   4. db-sync – download the SQL dump via importer.phar
+ *   5. Find the WordPress document root (wp-config.php location)
+ *   6. Apply the database dump directly to SQLite via db-apply,
  *      rewriting URLs (http + https variants → localhost) in the same pass
+ *   7. Register the site in Studio with the document root as the path
  *
  * Resumption: import state is persisted in the Studio appdata directory,
- * keyed by URL. If the command dies mid-import, re-running the same
- * command will resume from where it left off. The importer.phar natively
- * supports resuming partial file and database downloads.
+ * keyed by URL. The site directory is preserved on failure so re-running
+ * the same command resumes from where it left off. The importer.phar
+ * natively supports resuming partial file and database downloads.
  */
 import crypto from 'crypto';
 import fs from 'fs';
 import path from 'path';
 import { DEFAULT_PHP_VERSION } from '@studio/common/constants';
-import { isEmptyDir, pathExists, recursiveCopyDirectory } from '@studio/common/lib/fs-utils';
+import { isEmptyDir, pathExists } from '@studio/common/lib/fs-utils';
 import { portFinder } from '@studio/common/lib/port-finder';
 import { SITE_EVENTS } from '@studio/common/lib/site-events';
 import { sortSites } from '@studio/common/lib/sort-sites';
@@ -41,8 +43,7 @@ import {
 import { emitSiteEvent } from 'cli/lib/daemon-client';
 import { getDefaultSitePath } from 'cli/lib/generate-site-name';
 import { runImporterCommandUntilComplete, ImporterResult } from 'cli/lib/import/migration-client';
-import { getServerFilesPath } from 'cli/lib/server-files';
-import { keepSqliteIntegrationUpdated } from 'cli/lib/sqlite-integration';
+import { installSqliteIntegration } from 'cli/lib/sqlite-integration';
 import { Logger, LoggerError } from 'cli/logger';
 import { StudioArgv } from 'cli/types';
 
@@ -69,10 +70,43 @@ function parseImporterJson( result: ImporterResult ): any {
 	}
 }
 
+/**
+ * Decodes a value from the importer's state JSON. Values may be plain
+ * strings or base64-encoded with a "base64:" prefix.
+ */
+function decodeStateValue( value: string ): string {
+	if ( value.startsWith( 'base64:' ) ) {
+		return Buffer.from( value.slice( 7 ), 'base64' ).toString( 'utf-8' );
+	}
+	return value;
+}
+
+/**
+ * Reads the import state file (.import-state.json) to determine the
+ * local WordPress document root. The importer preserves the full
+ * remote directory structure within the docroot, so a remote WordPress
+ * root at /home/user/site/htdocs becomes sitePath/home/user/site/htdocs
+ * locally. We read wp_detect.roots[0].path from the preflight data to
+ * find that path.
+ */
+function getDocumentRootFromState( stateDir: string, sitePath: string ): string {
+	const stateFile = path.join( stateDir, '.import-state.json' );
+	const state = JSON.parse( fs.readFileSync( stateFile, 'utf-8' ) );
+
+	const wpRootEncoded = state.preflight?.data?.wp_detect?.roots?.[ 0 ]?.path;
+	if ( ! wpRootEncoded ) {
+		return sitePath;
+	}
+
+	const remoteWpRoot = decodeStateValue( wpRootEncoded )
+		.replace( /^\/+/, '' )
+		.replace( /\/+$/, '' );
+	return remoteWpRoot ? path.join( sitePath, remoteWpRoot ) : sitePath;
+}
+
 export async function runCommand( url: string, secret: string, name: string ): Promise< void > {
 	const apiUrl = url.replace( /\/+$/, '' ) + '/?site-export-api';
 	const siteName = name;
-	let sitePath: string | undefined;
 	let siteId: string | undefined;
 
 	// Ensure we have the latest importer.phar (older versions don't support db-apply)
@@ -94,18 +128,28 @@ export async function runCommand( url: string, secret: string, name: string ): P
 		.slice( 0, 12 );
 	const importDir = path.join( getAppdataDirectory(), 'imports', importDirHash );
 	const stateDir = path.join( importDir, 'state' );
-	const docroot = path.join( importDir, 'docroot' );
 	fs.mkdirSync( stateDir, { recursive: true } );
-	fs.mkdirSync( docroot, { recursive: true } );
+
+	// Create the site directory upfront so files-sync can download
+	// directly into it. On resume, the directory already has partial
+	// files and the importer picks up where it left off.
+	const sitePath = getDefaultSitePath( siteName );
 
 	const isResume = fs.readdirSync( stateDir ).length > 0;
+
+	if ( ! isResume && ( await pathExists( sitePath ) ) && ! ( await isEmptyDir( sitePath ) ) ) {
+		throw new LoggerError( __( 'Site directory already exists and is not empty.' ) );
+	}
+
+	fs.mkdirSync( sitePath, { recursive: true } );
+
 	if ( isResume ) {
 		console.log( `Resuming previous import for ${ url }` );
 		console.log( '' );
 	}
 
 	console.log( `Importing "${ siteName }" from ${ url }` );
-	console.log( `Import directory: ${ importDir }` );
+	console.log( `Site directory: ${ sitePath }` );
 	console.log( '' );
 
 	try {
@@ -130,8 +174,8 @@ export async function runCommand( url: string, secret: string, name: string ): P
 			logger.reportStart( LoggerAction.PREFLIGHT, __( 'Connecting to remote site…' ) );
 
 			// /state and /docroot are virtual mount points inside PHP WASM,
-			// mapped to stateDir and docroot by the child process.
-			const preflightResult = await runImporterCommandUntilComplete( stateDir, docroot, [
+			// mapped to stateDir and sitePath by the child process.
+			const preflightResult = await runImporterCommandUntilComplete( stateDir, sitePath, [
 				'preflight',
 				apiUrl,
 				`--secret=${ secret }`,
@@ -169,7 +213,7 @@ export async function runCommand( url: string, secret: string, name: string ): P
 
 		await runImporterCommandUntilComplete(
 			stateDir,
-			docroot,
+			sitePath,
 			[
 				'files-sync',
 				apiUrl,
@@ -188,7 +232,7 @@ export async function runCommand( url: string, secret: string, name: string ): P
 
 		await runImporterCommandUntilComplete(
 			stateDir,
-			docroot,
+			sitePath,
 			[
 				'db-sync',
 				apiUrl,
@@ -203,32 +247,20 @@ export async function runCommand( url: string, secret: string, name: string ): P
 
 		logger.reportSuccess( __( 'Database downloaded' ) );
 
-		// ── Step 4: Create Studio site from downloaded files ────────
+		// ── Step 4: Find document root and set up SQLite ────────────
+		// The importer's state file records where WordPress lives on the
+		// remote server relative to the document root. Use that to
+		// determine the local WordPress root within sitePath.
+		const documentRoot = getDocumentRootFromState( stateDir, sitePath );
+
 		logger.reportStart( LoggerAction.CREATE_SITE, `Creating site "${ siteName }"…` );
 
-		sitePath = getDefaultSitePath( siteName );
 		siteId = crypto.randomUUID();
 
-		if ( ( await pathExists( sitePath ) ) && ! ( await isEmptyDir( sitePath ) ) ) {
-			throw new LoggerError( __( 'Site directory already exists and is not empty.' ) );
-		}
-
-		// Copy bundled WordPress as the base
-		const bundledWPPath = path.join( getServerFilesPath(), 'wordpress-versions', 'latest' );
-		if ( ! ( await pathExists( bundledWPPath ) ) ) {
-			throw new LoggerError( __( 'Bundled WordPress files not found. Please reinstall Studio.' ) );
-		}
-		fs.mkdirSync( sitePath, { recursive: true } );
-		await recursiveCopyDirectory( bundledWPPath, sitePath );
-
-		// Overlay downloaded wp-content onto the fresh site
-		const downloadedWpContent = path.join( docroot, 'wp-content' );
-		if ( fs.existsSync( downloadedWpContent ) ) {
-			await recursiveCopyDirectory( downloadedWpContent, path.join( sitePath, 'wp-content' ) );
-		}
-
-		// Install SQLite integration
-		await keepSqliteIntegrationUpdated( sitePath );
+		// Install the SQLite integration drop-in. The remote site uses
+		// MySQL, so we must unconditionally install db.php and the
+		// mu-plugin to redirect WordPress to the SQLite database.
+		await installSqliteIntegration( documentRoot );
 
 		logger.reportSuccess( `Site "${ siteName }" created` );
 
@@ -245,13 +277,13 @@ export async function runCommand( url: string, secret: string, name: string ): P
 
 		// Create the database directory so db-apply can write
 		// the SQLite file to wp-content/database/.ht.sqlite.
-		const dbDir = path.join( sitePath, 'wp-content', 'database' );
+		const dbDir = path.join( documentRoot, 'wp-content', 'database' );
 		fs.mkdirSync( dbDir, { recursive: true } );
 
 		// Use importer.phar's db-apply to convert the MySQL dump
 		// directly into a SQLite database and rewrite URLs in one pass.
 		// The importer handles base64 decoding and SQL translation internally.
-		await runImporterCommandUntilComplete( stateDir, sitePath, [
+		await runImporterCommandUntilComplete( stateDir, documentRoot, [
 			'db-apply',
 			apiUrl,
 			`--secret=${ secret }`,
@@ -273,7 +305,7 @@ export async function runCommand( url: string, secret: string, name: string ): P
 		const siteDetails: SiteData = {
 			id: siteId,
 			name: siteName,
-			path: sitePath,
+			path: documentRoot,
 			port,
 			phpVersion: DEFAULT_PHP_VERSION,
 			adminPassword: 'password',
@@ -303,7 +335,7 @@ export async function runCommand( url: string, secret: string, name: string ): P
 		console.log( '' );
 		console.log( __( 'Site URL: ' ), localUrl );
 		console.log( __( 'WP Admin: ' ), `${ localUrl }/wp-admin/` );
-		console.log( `Start the site with: studio site start --path "${ sitePath }"` );
+		console.log( `Start the site with: studio site start --path "${ documentRoot }"` );
 		console.log( '' );
 
 		logger.reportKeyValuePair( 'id', siteDetails.id );
@@ -324,14 +356,6 @@ export async function runCommand( url: string, secret: string, name: string ): P
 				// Best-effort cleanup
 			}
 		}
-		if ( sitePath && ( await pathExists( sitePath ) ) ) {
-			try {
-				fs.rmSync( sitePath, { recursive: true, force: true } );
-			} catch {
-				// Best-effort cleanup
-			}
-		}
-
 		if ( error instanceof LoggerError ) {
 			throw error;
 		}

--- a/apps/cli/importer-child.ts
+++ b/apps/cli/importer-child.ts
@@ -1,0 +1,123 @@
+/**
+ * Importer Child Process
+ *
+ * Runs importer.phar via PHP WASM in an isolated child process so that
+ * the parent's event loop stays responsive for Ctrl+C handling and
+ * progress reporting. The parent communicates via IPC messages.
+ *
+ * Protocol:
+ *   Parent → Child:  { type: 'run', stateDir, docroot, tmpDir, args }
+ *   Child → Parent:  { type: 'result', stdout, stderr, exitCode }
+ *   Child → Parent:  { type: 'error', message }
+ */
+import { rootCertificates } from 'node:tls';
+import { loadNodeRuntime, createNodeFsMountHandler } from '@php-wasm/node';
+import { PHP, setPhpIniEntries, ProcessIdAllocator } from '@php-wasm/universal';
+import { createSpawnHandler } from '@php-wasm/util';
+import { LatestSupportedPHPVersion } from '@studio/common/types/php-versions';
+
+const processIdAllocator = new ProcessIdAllocator();
+
+function createNoopSpawnHandler() {
+	return createSpawnHandler( async ( args, processApi ) => {
+		await new Promise( ( resolve ) => setTimeout( resolve, 1 ) );
+		processApi.exit( 1 );
+	} );
+}
+
+function sendAndFlush( msg: Record< string, unknown > ): Promise< void > {
+	return new Promise< void >( ( resolve ) => {
+		process.send!( msg, () => resolve() );
+	} );
+}
+
+interface RunMessage {
+	type: 'run';
+	pharPath: string;
+	stateDir: string;
+	docroot: string;
+	tmpDir: string;
+	args: string[];
+}
+
+async function runImporter( msg: RunMessage ) {
+	const { pharPath, stateDir, docroot, tmpDir, args } = msg;
+
+	const id = await loadNodeRuntime( LatestSupportedPHPVersion, {
+		followSymlinks: true,
+		emscriptenOptions: {
+			processId: processIdAllocator.claim(),
+		},
+	} );
+	const php = new PHP( id );
+
+	// Collect the result or error BEFORE calling php.exit(), because
+	// php.exit() terminates the process via process.exit().
+	try {
+		await php.setSapiName( 'cli' );
+
+		php.mkdir( '/state' );
+		await php.mount( '/state', createNodeFsMountHandler( stateDir ) );
+		php.mkdir( '/docroot' );
+		await php.mount( '/docroot', createNodeFsMountHandler( docroot ) );
+
+		// Mount /tmp to a persistent host directory so that the
+		// importer's batch files survive process restarts. Without
+		// this, temp files like the download batch are lost when
+		// php.exit() calls process.exit(), causing the importer to
+		// re-download the same files on every resume iteration.
+		await php.mount( '/tmp', createNodeFsMountHandler( tmpDir ) );
+		await php.mount( '/tmp/importer.phar', createNodeFsMountHandler( pharPath ) );
+
+		php.writeFile( '/tmp/ca-bundle.crt', rootCertificates.join( '\n' ) );
+		await setPhpIniEntries( php, {
+			'openssl.cafile': '/tmp/ca-bundle.crt',
+			allow_url_fopen: 1,
+			memory_limit: '512M',
+			error_reporting: String( 32767 & ~8192 ),
+			display_errors: 'stderr',
+			log_errors: 0,
+		} );
+
+		await php.setSpawnHandler( createNoopSpawnHandler() );
+
+		const response = await php.cli( [ 'php', '/tmp/importer.phar', ...args ] );
+
+		const [ stdout, stderr, exitCode ] = await Promise.all( [
+			response.stdoutText,
+			response.stderrText,
+			response.exitCode,
+		] );
+
+		await sendAndFlush( { type: 'result', stdout, stderr, exitCode } );
+	} catch ( error ) {
+		await sendAndFlush( {
+			type: 'error',
+			message: error instanceof Error ? error.message : String( error ),
+		} );
+	}
+
+	// php.exit() calls process.exit() internally, so this must come
+	// after the IPC message has been flushed.
+	php.exit();
+}
+
+process.on( 'message', async ( msg: RunMessage ) => {
+	if ( msg.type !== 'run' ) {
+		return;
+	}
+	try {
+		await runImporter( msg );
+	} catch ( error ) {
+		// Last resort — if something fails before PHP is even loaded
+		try {
+			await sendAndFlush( {
+				type: 'error',
+				message: error instanceof Error ? error.message : String( error ),
+			} );
+		} catch {
+			// IPC channel may be closed
+		}
+		process.exit( 1 );
+	}
+} );

--- a/apps/cli/index.ts
+++ b/apps/cli/index.ts
@@ -19,6 +19,7 @@ import { registerCommand as registerListCommand } from 'cli/commands/preview/lis
 import { registerCommand as registerUpdateCommand } from 'cli/commands/preview/update';
 import { registerCommand as registerSiteCreateCommand } from 'cli/commands/site/create';
 import { registerCommand as registerSiteDeleteCommand } from 'cli/commands/site/delete';
+import { registerCommand as registerSiteImportCommand } from 'cli/commands/site/import';
 import { registerCommand as registerSiteListCommand } from 'cli/commands/site/list';
 import { registerCommand as registerSiteSetCommand } from 'cli/commands/site/set';
 import { registerCommand as registerSiteStartCommand } from 'cli/commands/site/start';
@@ -98,6 +99,7 @@ async function main() {
 		.command( 'site', __( 'Manage sites' ), ( sitesYargs ) => {
 			registerSiteStatusCommand( sitesYargs );
 			registerSiteCreateCommand( sitesYargs );
+			registerSiteImportCommand( sitesYargs );
 			registerSiteListCommand( sitesYargs );
 			registerSiteStartCommand( sitesYargs );
 			registerSiteStopCommand( sitesYargs );

--- a/apps/cli/lib/import/migration-client.ts
+++ b/apps/cli/lib/import/migration-client.ts
@@ -1,0 +1,282 @@
+/**
+ * Migration Client – thin wrapper around importer.phar
+ *
+ * Downloads and runs the streaming-site-migration CLI tool via PHP WASM
+ * in a child process. The child process isolates PHP WASM execution so
+ * the main process stays responsive for Ctrl+C and progress reporting.
+ *
+ * Progress is reported by reading the importer's remote file index
+ * (.import-remote-index.jsonl) for totals and scanning the docroot
+ * for downloaded file counts. The progress line updates continuously
+ * across resume iterations (exit code 2) without interruption.
+ *
+ * See https://github.com/adamziel/streaming-site-migration
+ */
+import { fork, ChildProcess } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { getAppdataDirectory } from 'cli/lib/appdata';
+
+const IMPORTER_PHAR_URL =
+	'https://github.com/adamziel/streaming-site-migration/releases/latest/download/importer.phar';
+
+export interface ImporterResult {
+	stdout: string;
+	stderr: string;
+	exitCode: number;
+}
+
+/**
+ * Returns file count and total size of all files in a directory tree.
+ */
+function getDirectoryStats( dir: string ): { files: number; bytes: number } {
+	let files = 0;
+	let bytes = 0;
+	try {
+		for ( const entry of fs.readdirSync( dir, { withFileTypes: true } ) ) {
+			const fullPath = path.join( dir, entry.name );
+			if ( entry.isDirectory() ) {
+				const sub = getDirectoryStats( fullPath );
+				files += sub.files;
+				bytes += sub.bytes;
+			} else {
+				try {
+					files++;
+					bytes += fs.statSync( fullPath ).size;
+				} catch {
+					// File may have been moved/deleted mid-scan
+				}
+			}
+		}
+	} catch {
+		// Directory may not exist yet
+	}
+	return { files, bytes };
+}
+
+/**
+ * Reads the importer's remote file index (.import-remote-index.jsonl)
+ * to get the total number of files and their combined size. Each line
+ * is a JSON object with { path, size, type, ctime, ... }.
+ *
+ * Returns null if the index file doesn't exist yet (indexing phase
+ * hasn't started or hasn't written anything).
+ */
+function readRemoteIndex( stateDir: string ): { files: number; bytes: number } | null {
+	const indexPath = path.join( stateDir, '.import-remote-index.jsonl' );
+	let content: string;
+	try {
+		content = fs.readFileSync( indexPath, 'utf-8' );
+	} catch {
+		return null;
+	}
+
+	let files = 0;
+	let bytes = 0;
+	for ( const line of content.split( '\n' ) ) {
+		if ( ! line.trim() ) {
+			continue;
+		}
+		try {
+			const entry = JSON.parse( line );
+			if ( entry.type === 'file' ) {
+				files++;
+				bytes += entry.size || 0;
+			}
+		} catch {
+			continue;
+		}
+	}
+
+	return files > 0 ? { files, bytes } : null;
+}
+
+function formatBytes( bytes: number ): string {
+	if ( bytes < 1024 ) {
+		return `${ bytes } B`;
+	}
+	if ( bytes < 1024 * 1024 ) {
+		return `${ ( bytes / 1024 ).toFixed( 0 ) } KB`;
+	}
+	return `${ ( bytes / ( 1024 * 1024 ) ).toFixed( 1 ) } MB`;
+}
+
+/**
+ * Runs an importer.phar command, automatically re-running on exit
+ * code 2 (partial completion / needs resume). Reports real-time
+ * progress by reading the importer's state files and scanning the
+ * docroot directory.
+ *
+ * During files-sync, progress shows "X/Y files · A.B/C.D MB" by
+ * reading the remote file index (.import-remote-index.jsonl) for
+ * totals and scanning the docroot for downloaded counts. For other
+ * commands, shows simple downloaded size.
+ *
+ * Downloads importer.phar on first use. Runs PHP WASM in a forked
+ * child process so the main event loop stays responsive for Ctrl+C
+ * and progress reporting.
+ */
+export async function runImporterCommandUntilComplete(
+	stateDir: string,
+	docroot: string,
+	args: string[],
+	onProgress?: ( output: string ) => void
+): Promise< ImporterResult > {
+	// Download importer.phar if not already cached
+	const pharPath = path.join( getAppdataDirectory(), 'importer.phar' );
+	if ( ! fs.existsSync( pharPath ) ) {
+		const response = await fetch( IMPORTER_PHAR_URL, { redirect: 'follow' } );
+		if ( ! response.ok ) {
+			throw new Error( `Failed to download importer.phar: ${ response.status }` );
+		}
+		const buffer = Buffer.from( await response.arrayBuffer() );
+		fs.writeFileSync( pharPath, buffer );
+	}
+
+	// Create a persistent tmp directory alongside state/ and docroot/
+	// so that the importer's temp files (batch downloads) survive
+	// process restarts between resume iterations.
+	const tmpDir = path.join( path.dirname( stateDir ), 'tmp' );
+	fs.mkdirSync( tmpDir, { recursive: true } );
+
+	const childPath = path.resolve( __dirname, 'importer-child.js' );
+	let lastResult: ImporterResult;
+	const label = args[ 0 ] || 'Importing';
+
+	// Poll the importer's state files and docroot every second to
+	// report progress. For files-sync, reads the remote file index
+	// to show "X/Y files · A.B/C.D MB". Detects stalls after 3
+	// ticks of no growth.
+	const startTime = Date.now();
+	let lastBytes = 0;
+	let stallTicks = 0;
+	const progressTimer = onProgress
+		? setInterval( () => {
+				const downloaded = getDirectoryStats( docroot );
+				const stateStats = getDirectoryStats( stateDir );
+				const totalBytes = downloaded.bytes + stateStats.bytes;
+
+				const elapsed = Math.round( ( Date.now() - startTime ) / 1000 );
+				const mins = Math.floor( elapsed / 60 );
+				const secs = elapsed % 60;
+				const timeStr = mins > 0 ? `${ mins }m ${ secs }s` : `${ secs }s`;
+
+				// Detect stalls: if size hasn't changed for a few ticks,
+				// show a "processing" hint so the user knows it's not stuck.
+				if ( totalBytes === lastBytes ) {
+					stallTicks++;
+				} else {
+					stallTicks = 0;
+					lastBytes = totalBytes;
+				}
+
+				const stallHint = stallTicks >= 3 ? ' · processing' : '';
+
+				// For files-sync, try to read the remote file index to
+				// show detailed "X/Y files · A.B/C.D MB" progress.
+				const remoteIndex = label === 'files-sync' ? readRemoteIndex( stateDir ) : null;
+
+				if ( remoteIndex ) {
+					const fileProg = `${ downloaded.files }/${ remoteIndex.files } files`;
+					const sizeProg = `${ formatBytes( downloaded.bytes ) }/${ formatBytes(
+						remoteIndex.bytes
+					) }`;
+					onProgress( `${ label } · ${ fileProg } · ${ sizeProg }${ stallHint } · ${ timeStr }` );
+				} else {
+					onProgress(
+						`${ label } · ${ formatBytes( totalBytes ) } downloaded${ stallHint } · ${ timeStr }`
+					);
+				}
+		  }, 1000 )
+		: undefined;
+
+	try {
+		do {
+			// Run a single importer.phar invocation in a child process.
+			// PHP WASM blocks the event loop, so forking keeps the parent
+			// responsive for signal handling and progress reporting.
+			lastResult = await new Promise< ImporterResult >( ( resolve, reject ) => {
+				const child: ChildProcess = fork( childPath, [], {
+					stdio: [ 'pipe', 'pipe', 'pipe', 'ipc' ],
+				} );
+				let settled = false;
+
+				// Collect the child's stderr so we can include it in crash diagnostics
+				const childStderrChunks: string[] = [];
+				child.stderr?.on( 'data', ( chunk: Buffer ) => {
+					childStderrChunks.push( chunk.toString() );
+				} );
+
+				// Forward Ctrl+C to the child process
+				const sigintHandler = () => {
+					child.kill( 'SIGKILL' );
+					process.exit( 130 );
+				};
+				process.on( 'SIGINT', sigintHandler );
+
+				const cleanup = () => process.removeListener( 'SIGINT', sigintHandler );
+
+				child.on(
+					'message',
+					( msg: {
+						type: string;
+						stdout?: string;
+						stderr?: string;
+						exitCode?: number;
+						message?: string;
+					} ) => {
+						cleanup();
+						settled = true;
+						if ( msg.type === 'result' ) {
+							resolve( {
+								stdout: msg.stdout || '',
+								stderr: msg.stderr || '',
+								exitCode: msg.exitCode ?? 1,
+							} );
+						} else if ( msg.type === 'error' ) {
+							reject( new Error( msg.message || 'importer child process error' ) );
+						}
+					}
+				);
+
+				child.on( 'error', ( err ) => {
+					cleanup();
+					if ( ! settled ) {
+						settled = true;
+						reject( err );
+					}
+				} );
+
+				child.on( 'exit', ( code ) => {
+					cleanup();
+					if ( ! settled ) {
+						settled = true;
+						const childStderr = childStderrChunks.join( '' ).trim();
+						const details = childStderr
+							? `Child process stderr:\n${ childStderr }`
+							: 'No error details available';
+						reject(
+							new Error( `importer child process exited with code ${ code }. ${ details }` )
+						);
+					}
+				} );
+
+				child.send( { type: 'run', pharPath, stateDir, docroot, tmpDir, args } );
+			} );
+
+			if ( lastResult.exitCode === 1 ) {
+				const details = [ lastResult.stderr, lastResult.stdout ].filter( Boolean ).join( '\n' );
+				throw new Error( details || 'importer.phar failed' );
+			}
+
+			// Exit code 2 = partial completion, will resume.
+			// Progress timer keeps running — no status line interruption.
+		} while ( lastResult.exitCode === 2 );
+
+		return lastResult;
+	} finally {
+		if ( progressTimer ) {
+			clearInterval( progressTimer );
+		}
+	}
+}

--- a/apps/cli/lib/import/sql-processor.ts
+++ b/apps/cli/lib/import/sql-processor.ts
@@ -1,0 +1,73 @@
+/**
+ * SQL Processor for Imported Database Dumps
+ *
+ * The streaming site migration protocol encodes all SQL values using
+ * MySQL's FROM_BASE64() function to avoid charset corruption during
+ * transfer. Studio uses SQLite (via the WordPress SQLite Database
+ * Integration plugin), which does not support FROM_BASE64().
+ *
+ * This processor decodes every FROM_BASE64('...') call into a plain
+ * SQL string literal, and optionally renames the table prefix so the
+ * imported tables match the local WordPress configuration.
+ */
+
+/**
+ * Decodes a base64 string and returns a properly escaped SQL literal.
+ * If the decoded bytes are valid UTF-8, they become a quoted string
+ * with single quotes escaped. Binary data falls back to X'hex' syntax.
+ */
+function decodeBase64ToSqlLiteral( base64Value: string ): string {
+	const buffer = Buffer.from( base64Value, 'base64' );
+	const decoded = buffer.toString( 'utf-8' );
+
+	// Verify the buffer round-trips through UTF-8 encoding. If it
+	// doesn't, the original data contains bytes that are not valid
+	// UTF-8 and we must use a hex literal instead.
+	if ( Buffer.from( decoded, 'utf-8' ).equals( buffer ) ) {
+		const escaped = decoded.replace( /'/g, "''" );
+		return `'${ escaped }'`;
+	}
+
+	return `X'${ buffer.toString( 'hex' ) }'`;
+}
+
+/**
+ * Processes a raw SQL dump from the migration API into SQL that is
+ * compatible with the WordPress SQLite integration layer.
+ *
+ * Two transformations are applied:
+ *
+ * 1. CONVERT(FROM_BASE64('...') USING utf8mb4) → 'decoded_value'
+ * 2. FROM_BASE64('...') → 'decoded_value'
+ *
+ * The CONVERT form appears for JSON columns where MySQL requires an
+ * explicit charset annotation. Both are decoded to plain literals.
+ */
+export function processImportedSql( sql: string ): string {
+	// First pass: handle CONVERT(FROM_BASE64('...') USING utf8mb4)
+	let processed = sql.replace(
+		/CONVERT\(FROM_BASE64\('([^']+)'\)\s+USING\s+utf8mb4\)/g,
+		( _, base64 ) => decodeBase64ToSqlLiteral( base64 )
+	);
+
+	// Second pass: handle remaining FROM_BASE64('...')
+	processed = processed.replace( /FROM_BASE64\('([^']+)'\)/g, ( _, base64 ) =>
+		decodeBase64ToSqlLiteral( base64 )
+	);
+
+	return processed;
+}
+
+/**
+ * Renames table references in SQL statements from one prefix to
+ * another. Only touches backtick-quoted identifiers to avoid
+ * accidentally modifying data values.
+ */
+export function renameTablePrefix( sql: string, oldPrefix: string, newPrefix: string ): string {
+	if ( oldPrefix === newPrefix ) {
+		return sql;
+	}
+
+	const escapedOldPrefix = oldPrefix.replace( /[.*+?^${}()|[\]\\]/g, '\\$&' );
+	return sql.replace( new RegExp( '`' + escapedOldPrefix, 'g' ), '`' + newPrefix );
+}

--- a/apps/cli/lib/import/tests/sql-processor.test.ts
+++ b/apps/cli/lib/import/tests/sql-processor.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import { processImportedSql, renameTablePrefix } from 'cli/lib/import/sql-processor';
+
+describe( 'processImportedSql', () => {
+	it( 'decodes FROM_BASE64 values to string literals', () => {
+		// 'MQ==' is base64 for '1', 'c2l0ZW5hbWU=' is 'sitename'
+		const input =
+			"INSERT INTO `wp_options` VALUES (FROM_BASE64('MQ=='),FROM_BASE64('c2l0ZW5hbWU='));";
+		const result = processImportedSql( input );
+		expect( result ).toBe( "INSERT INTO `wp_options` VALUES ('1','sitename');" );
+	} );
+
+	it( 'handles CONVERT(FROM_BASE64(...) USING utf8mb4)', () => {
+		// 'dGVzdA==' is base64 for 'test'
+		const input = "INSERT INTO `wp_posts` VALUES (CONVERT(FROM_BASE64('dGVzdA==') USING utf8mb4));";
+		const result = processImportedSql( input );
+		expect( result ).toBe( "INSERT INTO `wp_posts` VALUES ('test');" );
+	} );
+
+	it( 'escapes single quotes in decoded values', () => {
+		// "it's" in base64 is 'aXQncw=='
+		const encoded = Buffer.from( "it's" ).toString( 'base64' );
+		const input = `INSERT INTO t VALUES (FROM_BASE64('${ encoded }'));`;
+		const result = processImportedSql( input );
+		expect( result ).toBe( "INSERT INTO t VALUES ('it''s');" );
+	} );
+
+	it( 'preserves NULL values', () => {
+		const input = "INSERT INTO t VALUES (NULL,FROM_BASE64('MQ=='));";
+		const result = processImportedSql( input );
+		expect( result ).toBe( "INSERT INTO t VALUES (NULL,'1');" );
+	} );
+
+	it( 'handles DROP TABLE and CREATE TABLE statements unchanged', () => {
+		const input = 'DROP TABLE IF EXISTS `wp_options`;';
+		const result = processImportedSql( input );
+		expect( result ).toBe( input );
+	} );
+
+	it( 'handles multi-line SQL with mixed statements', () => {
+		const input = [
+			'DROP TABLE IF EXISTS `wp_options`;',
+			'CREATE TABLE `wp_options` (option_id INT, option_name VARCHAR(255));',
+			"INSERT INTO `wp_options` VALUES (FROM_BASE64('MQ=='),FROM_BASE64('dGVzdA=='));",
+		].join( '\n' );
+
+		const result = processImportedSql( input );
+		expect( result ).toContain( "VALUES ('1','test')" );
+		expect( result ).toContain( 'DROP TABLE IF EXISTS' );
+		expect( result ).toContain( 'CREATE TABLE' );
+	} );
+
+	it( 'handles binary data with hex literals', () => {
+		// Create a buffer with invalid UTF-8 bytes
+		const binaryData = Buffer.from( [ 0xff, 0xfe, 0x00, 0x01 ] );
+		const encoded = binaryData.toString( 'base64' );
+		const input = `INSERT INTO t VALUES (FROM_BASE64('${ encoded }'));`;
+		const result = processImportedSql( input );
+		expect( result ).toBe( "INSERT INTO t VALUES (X'fffe0001');" );
+	} );
+} );
+
+describe( 'renameTablePrefix', () => {
+	it( 'renames table prefix in backtick-quoted identifiers', () => {
+		const input = 'DROP TABLE IF EXISTS `wp123_options`;';
+		const result = renameTablePrefix( input, 'wp123_', 'wp_' );
+		expect( result ).toBe( 'DROP TABLE IF EXISTS `wp_options`;' );
+	} );
+
+	it( 'renames prefix in INSERT statements', () => {
+		const input = "INSERT INTO `custom_posts` VALUES ('1','hello');";
+		const result = renameTablePrefix( input, 'custom_', 'wp_' );
+		expect( result ).toBe( "INSERT INTO `wp_posts` VALUES ('1','hello');" );
+	} );
+
+	it( 'does nothing when prefixes match', () => {
+		const input = "INSERT INTO `wp_options` VALUES ('1');";
+		const result = renameTablePrefix( input, 'wp_', 'wp_' );
+		expect( result ).toBe( input );
+	} );
+
+	it( 'does not modify unquoted text containing the prefix', () => {
+		// The prefix only appears in a string value, not a backtick-quoted identifier
+		const input = "INSERT INTO `wp_options` VALUES ('wp123_something');";
+		const result = renameTablePrefix( input, 'wp123_', 'wp_' );
+		// Only the table name should change, not the value
+		expect( result ).toBe( "INSERT INTO `wp_options` VALUES ('wp123_something');" );
+	} );
+} );

--- a/apps/cli/lib/wordpress-server-manager.ts
+++ b/apps/cli/lib/wordpress-server-manager.ts
@@ -4,6 +4,7 @@
  * Manages WordPress server processes via process manager daemon. Each site runs in a separate
  * process that spawns Playground CLI.
  */
+import fs from 'fs';
 import path from 'path';
 import {
 	PLAYGROUND_CLI_ACTIVITY_CHECK_INTERVAL,
@@ -21,11 +22,38 @@ import {
 	type DaemonBusEventMap,
 	sendMessageToProcess,
 } from 'cli/lib/daemon-client';
+import { PROCESS_MANAGER_LOGS_DIR } from 'cli/lib/daemon-paths';
 import { ProcessDescription } from 'cli/lib/types/process-manager-ipc';
 import { ServerConfig, ManagerMessagePayload } from 'cli/lib/types/wordpress-server-ipc';
 import { Logger } from 'cli/logger';
 
 export const SITE_PROCESS_PREFIX = 'studio-site-';
+
+/**
+ * Read the last 50 lines from both stdout and stderr logs of a process.
+ * Playground often writes errors to stdout (not stderr), so we need both.
+ */
+function readProcessLogs( processName: string ): string {
+	const logFiles = [
+		{ label: 'stderr', file: path.join( PROCESS_MANAGER_LOGS_DIR, `${ processName }-error.log` ) },
+		{ label: 'stdout', file: path.join( PROCESS_MANAGER_LOGS_DIR, `${ processName }-out.log` ) },
+	];
+
+	const sections: string[] = [];
+	for ( const { label, file } of logFiles ) {
+		try {
+			const log = fs.readFileSync( file, 'utf-8' ).trim();
+			if ( log ) {
+				const tail = log.split( '\n' ).slice( -50 ).join( '\n' );
+				sections.push( `${ label } (${ file }):\n${ tail }` );
+			}
+		} catch {
+			// Log file may not exist or be unreadable
+		}
+	}
+
+	return sections.length > 0 ? `\n\n${ sections.join( '\n\n' ) }` : '';
+}
 
 // Get an abort signal that's triggered on SIGINT/SIGTERM. This is useful for aborting and cleaning
 // up async operations.
@@ -220,7 +248,8 @@ export async function sendMessage(
 
 		processEventHandler = ( event ) => {
 			if ( event.process.name === processName && event.event === 'exit' ) {
-				reject( new Error( 'WordPress server process exited unexpectedly' ) );
+				const details = readProcessLogs( processName );
+				reject( new Error( `WordPress server process exited unexpectedly${ details }` ) );
 			}
 		};
 

--- a/apps/cli/process-manager-daemon.ts
+++ b/apps/cli/process-manager-daemon.ts
@@ -181,8 +181,8 @@ export class ProcessManagerDaemon {
 		const { stdoutLogPath, stderrLogPath } = getProcessLogPaths( processName );
 		const stdoutStream = createWriteStream( stdoutLogPath, { flags: 'a' } );
 		const stderrStream = createWriteStream( stderrLogPath, { flags: 'a' } );
-		// Node.js >=24 supports the JSPI (JavaScript Promises Integration) API
-		const doesCurrentNodeSupportJspi = semver.gte( process.version, '24.0.0' );
+		// Node.js >=23 supports the JSPI (JavaScript Promises Integration) API
+		const doesCurrentNodeSupportJspi = semver.gte( process.version, '23.0.0' );
 		const execArgv = doesCurrentNodeSupportJspi ? [ '--experimental-wasm-jspi' ] : undefined;
 		const child = fork( scriptPath, args, {
 			execPath: process.execPath,

--- a/apps/cli/vite.config.ts
+++ b/apps/cli/vite.config.ts
@@ -64,6 +64,7 @@ export default defineConfig( {
 				'process-manager-daemon': resolve( __dirname, 'process-manager-daemon.ts' ),
 				'proxy-daemon': resolve( __dirname, 'proxy-daemon.ts' ),
 				'wordpress-server-child': resolve( __dirname, 'wordpress-server-child.ts' ),
+				'importer-child': resolve( __dirname, 'importer-child.ts' ),
 			},
 			name: 'StudioCLI',
 			formats: [ 'cjs' ],

--- a/apps/cli/wordpress-server-child.ts
+++ b/apps/cli/wordpress-server-child.ts
@@ -30,7 +30,6 @@ import { WordPressInstallMode } from '@wp-playground/wordpress';
 import { z } from 'zod';
 import { sanitizeRunCLIArgs } from 'cli/lib/cli-args-sanitizer';
 import { getSqliteCommandPath, getWpCliPharPath } from 'cli/lib/server-files';
-import { isSqliteIntegrationInstalled } from 'cli/lib/sqlite-integration';
 import {
 	ServerConfig,
 	managerMessageSchema,
@@ -113,24 +112,24 @@ async function setAdminCredentials(
 
 /**
  * Gets the WordPress installation mode based on whether WordPress files
- * and SQLite integration are present.
+ * are already present in the site directory.
+ *
+ * When WordPress files exist we use 'do-not-attempt-installing' so that
+ * Playground doesn't try to download or install WordPress on top of
+ * existing files. This is especially important for imported sites where
+ * the WordPress installation is already complete and the database is
+ * already set up.
  *
  * @param sitePath - The path to the site
  * @returns The WordPressInstallMode to use for the site
  */
-async function getWordPressInstallMode( sitePath: string ): Promise< WordPressInstallMode > {
+function getWordPressInstallMode( sitePath: string ): WordPressInstallMode {
 	const hasWordPress = isWordPressDirectory( sitePath );
-	const hasSqlite = await isSqliteIntegrationInstalled( sitePath );
 
 	if ( ! hasWordPress ) {
 		return 'download-and-install';
 	}
 
-	if ( hasSqlite ) {
-		return 'install-from-existing-files-if-needed';
-	}
-
-	// We don't want playground to attempt installing WordPress when site is using MySQL.
 	return 'do-not-attempt-installing';
 }
 
@@ -146,7 +145,7 @@ async function getBaseRunCLIArgs(
 	command: RunCLIArgs[ 'command' ],
 	config: ServerConfig
 ): Promise< RunCLIArgs > {
-	const wordpressInstallMode = await getWordPressInstallMode( config.sitePath );
+	const wordpressInstallMode = getWordPressInstallMode( config.sitePath );
 
 	await cleanupLegacyMuPlugins( config.sitePath );
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -82,9 +82,533 @@
 				"vite-plugin-static-copy": "^3.1.5"
 			}
 		},
+		"apps/cli/node_modules/@php-wasm/cli-util": {
+			"version": "3.1.11",
+			"resolved": "https://registry.npmjs.org/@php-wasm/cli-util/-/cli-util-3.1.11.tgz",
+			"integrity": "sha512-/v/S007ZZfTmDyYOReKtUnhiOWZi1EZdLrDiSPCmYms3XFNeJDUBWEkDshcwMxuDaA4Ce2ciF0QsM+yuY9vY9g==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/util": "3.1.11",
+				"fast-xml-parser": "^5.5.1",
+				"jsonc-parser": "3.3.1"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"apps/cli/node_modules/@php-wasm/logger": {
+			"version": "3.1.11",
+			"resolved": "https://registry.npmjs.org/@php-wasm/logger/-/logger-3.1.11.tgz",
+			"integrity": "sha512-wGKmMpA8gvoLFEjG9jzm7E2BEAaq4LU9yMjMkzKwYE0RUivV1000Cnw+m+79/d4Bua0ouoCLab5+IFFJrfxYpw==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/node-polyfills": "3.1.11"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"apps/cli/node_modules/@php-wasm/node": {
+			"version": "3.1.11",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node/-/node-3.1.11.tgz",
+			"integrity": "sha512-qqJuQMm/Ey4Cv2h6F6q7Rj33KMo5z+33s2CABwRnS7fgzGBSQzB7vq4L2pScqVmvfRXnW1lFoUgFARojOOThkA==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/cli-util": "3.1.11",
+				"@php-wasm/logger": "3.1.11",
+				"@php-wasm/node-7-4": "3.1.11",
+				"@php-wasm/node-8-0": "3.1.11",
+				"@php-wasm/node-8-1": "3.1.11",
+				"@php-wasm/node-8-2": "3.1.11",
+				"@php-wasm/node-8-3": "3.1.11",
+				"@php-wasm/node-8-4": "3.1.11",
+				"@php-wasm/node-8-5": "3.1.11",
+				"@php-wasm/node-polyfills": "3.1.11",
+				"@php-wasm/universal": "3.1.11",
+				"@php-wasm/util": "3.1.11",
+				"@wp-playground/common": "3.1.11",
+				"express": "4.22.0",
+				"fast-xml-parser": "^5.5.1",
+				"fs-ext-extra-prebuilt": "2.2.7",
+				"ini": "4.1.2",
+				"jsonc-parser": "3.3.1",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.3",
+				"yargs": "17.7.2"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"apps/cli/node_modules/@php-wasm/node-7-4": {
+			"version": "3.1.11",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-7-4/-/node-7-4-3.1.11.tgz",
+			"integrity": "sha512-WGX0nOv6JsTXY+I0FqAB8wQLeQc8pAYbUg4LXEQnACZWPL9mdAvwk++XkScWQ5zfwUtrTq9TwpAXcyf3xRrIxQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.1.11",
+				"ini": "4.1.2",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.3"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"apps/cli/node_modules/@php-wasm/node-8-0": {
+			"version": "3.1.11",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-0/-/node-8-0-3.1.11.tgz",
+			"integrity": "sha512-92E8kydq6RmxYnFGXGTursqT/8doRND8fQoqerj4uJ4oMtPIBXREyBMAye4/ss3ls9IXSRbZKYQ03NptozcYfA==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.1.11",
+				"ini": "4.1.2",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.3"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"apps/cli/node_modules/@php-wasm/node-8-1": {
+			"version": "3.1.11",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-1/-/node-8-1-3.1.11.tgz",
+			"integrity": "sha512-fP7OWc0V7Hs1AEcr0cP8d49twJLSDwdHUyFwTuD7uPY+u9KrPW8ZrhR8+j2pmPrU0qMO5x+oPP1u8MFgNpWHOQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.1.11",
+				"ini": "4.1.2",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.3"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"apps/cli/node_modules/@php-wasm/node-8-2": {
+			"version": "3.1.11",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-2/-/node-8-2-3.1.11.tgz",
+			"integrity": "sha512-T72JABgcbo6OujFaVfKb+eJpgZgcTK5vmUoNDWZFvu7NvH9wSRkmnlas+HcqO2inEja0BvQbz7WWcDHUTj9rPQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.1.11",
+				"ini": "4.1.2",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.3"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"apps/cli/node_modules/@php-wasm/node-8-3": {
+			"version": "3.1.11",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-3/-/node-8-3-3.1.11.tgz",
+			"integrity": "sha512-KFOVw3E0ThCGN6pmdS16FIgHzbAVNLVrV4QkCvKmvPENMfKLOaJAwC3jN8qK4eE/j5jWqAZIQPsOPwVKkHziDw==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.1.11",
+				"ini": "4.1.2",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.3"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"apps/cli/node_modules/@php-wasm/node-8-4": {
+			"version": "3.1.11",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-4/-/node-8-4-3.1.11.tgz",
+			"integrity": "sha512-fSKp8C+rcORGHBQJRtrFkNfTmIsjtfMcuT81jWIs71zG2v1C0yIfEPdpRqHv6UVJVFToUb1ClEGY+dfqO9mXYA==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.1.11",
+				"ini": "4.1.2",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.3"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"apps/cli/node_modules/@php-wasm/node-8-5": {
+			"version": "3.1.11",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-5/-/node-8-5-3.1.11.tgz",
+			"integrity": "sha512-ystaL0/ab7GyQCReNFWpC2LPKa3u2gUXlMi0g/2CZDD4kavnzksuI/jAHhwnmTnZePbEam23rvdyq77ndC1TFw==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.1.11",
+				"ini": "4.1.2",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.3"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"apps/cli/node_modules/@php-wasm/node-polyfills": {
+			"version": "3.1.11",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-polyfills/-/node-polyfills-3.1.11.tgz",
+			"integrity": "sha512-Gu3wS1gWkyGSW/K+RQNT4OfjeapeYdL5bqOQ+/MEfvkaeMRDdzdOvmPcIfLbDBhZOSh6jAA7nT87Ri2LmeqYzQ==",
+			"license": "GPL-2.0-or-later"
+		},
+		"apps/cli/node_modules/@php-wasm/node/node_modules/yargs": {
+			"version": "17.7.2",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+			"integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+			"license": "MIT",
+			"dependencies": {
+				"cliui": "^8.0.1",
+				"escalade": "^3.1.1",
+				"get-caller-file": "^2.0.5",
+				"require-directory": "^2.1.1",
+				"string-width": "^4.2.3",
+				"y18n": "^5.0.5",
+				"yargs-parser": "^21.1.1"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"apps/cli/node_modules/@php-wasm/node/node_modules/yargs-parser": {
+			"version": "21.1.1",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+			"integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"apps/cli/node_modules/@php-wasm/progress": {
+			"version": "3.1.11",
+			"resolved": "https://registry.npmjs.org/@php-wasm/progress/-/progress-3.1.11.tgz",
+			"integrity": "sha512-/zsH+ZvBxq+Qlb2ffNvvjmiqaB6Fwo8+O3Py+WUznxIuQ/3Ckci+5cWyBtYQ6qtAGFSRADl41Qg9n6RmWBUL7w==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/logger": "3.1.11",
+				"@php-wasm/node-polyfills": "3.1.11"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"apps/cli/node_modules/@php-wasm/scopes": {
+			"version": "3.1.11",
+			"resolved": "https://registry.npmjs.org/@php-wasm/scopes/-/scopes-3.1.11.tgz",
+			"integrity": "sha512-WyI1PHYA4vHmb2DHO6M2e8ydY1brfMRjRf1Z5FYhfyh7G2FEAJbOyoY/VenBOCw0dE04vkWU4LRuVwkFrO8+Ow==",
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"apps/cli/node_modules/@php-wasm/stream-compression": {
+			"version": "3.1.11",
+			"resolved": "https://registry.npmjs.org/@php-wasm/stream-compression/-/stream-compression-3.1.11.tgz",
+			"integrity": "sha512-R9wfu3Zx083m8WTlWN888iZ9ub2nhZXGi5LVjfIQCd2UPuRbhFuOHiiyvnoHnZFyMZnzI12/MhuoPHuWv6NPew==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/node-polyfills": "3.1.11",
+				"@php-wasm/util": "3.1.11"
+			}
+		},
+		"apps/cli/node_modules/@php-wasm/universal": {
+			"version": "3.1.11",
+			"resolved": "https://registry.npmjs.org/@php-wasm/universal/-/universal-3.1.11.tgz",
+			"integrity": "sha512-n+fGHL9wqLf6NBWsPdDbF7USY20FBZgBIJvUoi620xNQdakhZ425tCM7bEVBE+lcOY6/l4rFCIdSbY+HoJwg7w==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/logger": "3.1.11",
+				"@php-wasm/node-polyfills": "3.1.11",
+				"@php-wasm/progress": "3.1.11",
+				"@php-wasm/stream-compression": "3.1.11",
+				"@php-wasm/util": "3.1.11",
+				"ini": "4.1.2"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"apps/cli/node_modules/@php-wasm/util": {
+			"version": "3.1.11",
+			"resolved": "https://registry.npmjs.org/@php-wasm/util/-/util-3.1.11.tgz",
+			"integrity": "sha512-9n/s609DDF03+M4DWbvf+BCaHGAGt56xOxceV91mQA1X0c+iLgBCYG2oLgOvs1Cl+anYxiVbsLUZBfjAxKLcbQ==",
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"apps/cli/node_modules/@php-wasm/web-service-worker": {
+			"version": "3.1.11",
+			"resolved": "https://registry.npmjs.org/@php-wasm/web-service-worker/-/web-service-worker-3.1.11.tgz",
+			"integrity": "sha512-8qCh2Y5ZrLw1EP+s5iYCBE4HnBcB0HjudGPNLs2azYRZHOo5C3Xjc+VI5BDdfyLEZl3AOg5y6dE0dk2ur2WCeg==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/scopes": "3.1.11",
+				"@php-wasm/universal": "3.1.11",
+				"ini": "4.1.2"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"apps/cli/node_modules/@wp-playground/blueprints": {
+			"version": "3.1.11",
+			"resolved": "https://registry.npmjs.org/@wp-playground/blueprints/-/blueprints-3.1.11.tgz",
+			"integrity": "sha512-9YeNYIKR+/LvWPnC38sorT9XJkMBz1B/Rb71kDQ5HemS8OvueyTofBc763kjQP3bumC5nr+38nMyXTNUkDuayQ==",
+			"dependencies": {
+				"@php-wasm/logger": "3.1.11",
+				"@php-wasm/node": "3.1.11",
+				"@php-wasm/node-polyfills": "3.1.11",
+				"@php-wasm/progress": "3.1.11",
+				"@php-wasm/scopes": "3.1.11",
+				"@php-wasm/stream-compression": "3.1.11",
+				"@php-wasm/universal": "3.1.11",
+				"@php-wasm/util": "3.1.11",
+				"@php-wasm/web-service-worker": "3.1.11",
+				"@wp-playground/common": "3.1.11",
+				"@wp-playground/storage": "3.1.11",
+				"@wp-playground/wordpress": "3.1.11",
+				"@zip.js/zip.js": "2.7.57",
+				"ajv": "8.12.0",
+				"async-lock": "1.4.1",
+				"clean-git-ref": "2.0.1",
+				"crc-32": "1.2.2",
+				"diff3": "0.0.4",
+				"express": "4.22.0",
+				"fast-xml-parser": "^5.5.1",
+				"fs-ext-extra-prebuilt": "2.2.7",
+				"ignore": "5.3.2",
+				"ini": "4.1.2",
+				"jsonc-parser": "3.3.1",
+				"minimisted": "2.0.1",
+				"octokit": "3.1.2",
+				"pako": "1.0.10",
+				"pify": "2.3.0",
+				"readable-stream": "3.6.2",
+				"sha.js": "2.4.12",
+				"simple-get": "4.0.1",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.3",
+				"yargs": "17.7.2"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"apps/cli/node_modules/@wp-playground/blueprints/node_modules/yargs": {
+			"version": "17.7.2",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+			"integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+			"license": "MIT",
+			"dependencies": {
+				"cliui": "^8.0.1",
+				"escalade": "^3.1.1",
+				"get-caller-file": "^2.0.5",
+				"require-directory": "^2.1.1",
+				"string-width": "^4.2.3",
+				"y18n": "^5.0.5",
+				"yargs-parser": "^21.1.1"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"apps/cli/node_modules/@wp-playground/blueprints/node_modules/yargs-parser": {
+			"version": "21.1.1",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+			"integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"apps/cli/node_modules/@wp-playground/common": {
+			"version": "3.1.11",
+			"resolved": "https://registry.npmjs.org/@wp-playground/common/-/common-3.1.11.tgz",
+			"integrity": "sha512-1/5yts2ExzfVxHqK4oz9dr9Jxeuh99zhAO5ClH3zROo/7gRXKWHZWoQXNLZnPJ3RlMqYzIzHzmozhyx29rtizQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.1.11",
+				"@php-wasm/util": "3.1.11",
+				"ini": "4.1.2"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"apps/cli/node_modules/@wp-playground/storage": {
+			"version": "3.1.11",
+			"resolved": "https://registry.npmjs.org/@wp-playground/storage/-/storage-3.1.11.tgz",
+			"integrity": "sha512-OxDlLInbRzpceMYO2CVm3hYb1MnZqJZfr444+l3QhOJEqOo6n3WAwb/8MxRbqmfokkKGbO3YGnGQrF6u+RNhWQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/stream-compression": "3.1.11",
+				"@php-wasm/universal": "3.1.11",
+				"@php-wasm/util": "3.1.11",
+				"@zip.js/zip.js": "2.7.57",
+				"async-lock": "^1.4.1",
+				"clean-git-ref": "^2.0.1",
+				"crc-32": "^1.2.0",
+				"diff3": "0.0.3",
+				"ignore": "^5.1.4",
+				"ini": "4.1.2",
+				"minimisted": "^2.0.0",
+				"octokit": "3.1.2",
+				"pako": "^1.0.10",
+				"pify": "^4.0.1",
+				"readable-stream": "^3.4.0",
+				"sha.js": "^2.4.9",
+				"simple-get": "^4.0.1"
+			}
+		},
+		"apps/cli/node_modules/@wp-playground/storage/node_modules/diff3": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/diff3/-/diff3-0.0.3.tgz",
+			"integrity": "sha512-iSq8ngPOt0K53A6eVr4d5Kn6GNrM2nQZtC740pzIriHtn4pOQ2lyzEXQMBeVcWERN0ye7fhBsk9PbLLQOnUx/g==",
+			"license": "MIT"
+		},
+		"apps/cli/node_modules/@wp-playground/storage/node_modules/pify": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+			"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"apps/cli/node_modules/@wp-playground/wordpress": {
+			"version": "3.1.11",
+			"resolved": "https://registry.npmjs.org/@wp-playground/wordpress/-/wordpress-3.1.11.tgz",
+			"integrity": "sha512-G4sahkT4WQoCtCww0ve9GyQ+QVji7qd+6TOsuMI3iFaYgyYGIKKV4Yjx/KEOZEYKRY8BuZH6AKZpjrmu75CBxg==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/logger": "3.1.11",
+				"@php-wasm/node": "3.1.11",
+				"@php-wasm/universal": "3.1.11",
+				"@php-wasm/util": "3.1.11",
+				"@wp-playground/common": "3.1.11",
+				"express": "4.22.0",
+				"fast-xml-parser": "^5.5.1",
+				"fs-ext-extra-prebuilt": "2.2.7",
+				"ini": "4.1.2",
+				"jsonc-parser": "3.3.1",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.3",
+				"yargs": "17.7.2"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"apps/cli/node_modules/@wp-playground/wordpress/node_modules/yargs": {
+			"version": "17.7.2",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+			"integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+			"license": "MIT",
+			"dependencies": {
+				"cliui": "^8.0.1",
+				"escalade": "^3.1.1",
+				"get-caller-file": "^2.0.5",
+				"require-directory": "^2.1.1",
+				"string-width": "^4.2.3",
+				"y18n": "^5.0.5",
+				"yargs-parser": "^21.1.1"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"apps/cli/node_modules/@wp-playground/wordpress/node_modules/yargs-parser": {
+			"version": "21.1.1",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+			"integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"apps/cli/node_modules/ajv": {
+			"version": "8.12.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+			"integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+			"license": "MIT",
+			"dependencies": {
+				"fast-deep-equal": "^3.1.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2",
+				"uri-js": "^4.2.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"apps/cli/node_modules/cliui": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+			"integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+			"license": "ISC",
+			"dependencies": {
+				"string-width": "^4.2.0",
+				"strip-ansi": "^6.0.1",
+				"wrap-ansi": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"apps/cli/node_modules/ini": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
+			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"apps/cli/node_modules/json-schema-traverse": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+			"license": "MIT"
+		},
+		"apps/cli/node_modules/pako": {
+			"version": "1.0.10",
+			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.10.tgz",
+			"integrity": "sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw==",
+			"license": "(MIT AND Zlib)"
+		},
+		"apps/cli/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"apps/studio": {
 			"name": "studio-app",
-			"version": "1.7.6-beta2",
+			"version": "1.7.5",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@automattic/generate-password": "^0.1.0",
@@ -160,7 +684,7 @@
 				"@types/winreg": "^1.2.36",
 				"@types/yauzl": "^2.10.3",
 				"@vitejs/plugin-react": "^5.1.4",
-				"@wp-playground/blueprints": "3.1.11",
+				"@wp-playground/blueprints": "3.1.5",
 				"electron": "^40.8.0",
 				"electron-devtools-installer": "^4.0.0",
 				"electron-vite": "^5.0.0",
@@ -7044,6 +7568,451 @@
 			}
 		},
 		"node_modules/@php-wasm/cli-util": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/@php-wasm/cli-util/-/cli-util-3.1.5.tgz",
+			"integrity": "sha512-FU1MMy1+/FpGn/6uk4MLKPHS+fp6v84ILVdqF5uUlav0eZVDOntJ8B8wmA7i4UP6gvbtsWJNHVduBLBadzNVNQ==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/util": "3.1.5",
+				"fast-xml-parser": "^5.3.4",
+				"jsonc-parser": "3.3.1"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@php-wasm/logger": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/@php-wasm/logger/-/logger-3.1.5.tgz",
+			"integrity": "sha512-gDUh+LdU/SVNW8gQu+9yPjEhuJtQGSMnyWq6PIlL5a0er/nsalL3q86NZvTRHz0trZwGkTXGuFwK2UaXOILQ4g==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/node-polyfills": "3.1.5"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@php-wasm/node": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node/-/node-3.1.5.tgz",
+			"integrity": "sha512-BcJgj/Dr9KGlsA9MT6fUk81VQ/KDRV2Ye/FK9FAn6hL3LoOj08kORxa16ougO9p6Yjy/6tKMu09a+jSMGOLkZg==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/cli-util": "3.1.5",
+				"@php-wasm/logger": "3.1.5",
+				"@php-wasm/node-7-4": "3.1.5",
+				"@php-wasm/node-8-0": "3.1.5",
+				"@php-wasm/node-8-1": "3.1.5",
+				"@php-wasm/node-8-2": "3.1.5",
+				"@php-wasm/node-8-3": "3.1.5",
+				"@php-wasm/node-8-4": "3.1.5",
+				"@php-wasm/node-8-5": "3.1.5",
+				"@php-wasm/node-polyfills": "3.1.5",
+				"@php-wasm/universal": "3.1.5",
+				"@php-wasm/util": "3.1.5",
+				"@wp-playground/common": "3.1.5",
+				"express": "4.22.0",
+				"fast-xml-parser": "^5.3.4",
+				"fs-ext-extra-prebuilt": "2.2.7",
+				"ini": "4.1.2",
+				"jsonc-parser": "3.3.1",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.3",
+				"yargs": "17.7.2"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@php-wasm/node-7-4": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-7-4/-/node-7-4-3.1.5.tgz",
+			"integrity": "sha512-/lBVaytuT6b/F3GrlSF6Ig6xYII99FLw0wHDjRl6PoWNHXHllB5CE3kOrRDyXQHiIEFoqNUwWQrP8MkUpZrUCw==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.1.5",
+				"ini": "4.1.2",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.3"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@php-wasm/node-7-4/node_modules/ini": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
+			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@php-wasm/node-8-0": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-0/-/node-8-0-3.1.5.tgz",
+			"integrity": "sha512-ZhHAwUf9doh/Oft23nzaY3No0qPd3DY8GoDDe7pI9Nk4+KghtkOxt2siWroPbeLaRf20oFwChGeozp7n6w5/rg==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.1.5",
+				"ini": "4.1.2",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.3"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@php-wasm/node-8-0/node_modules/ini": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
+			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@php-wasm/node-8-1": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-1/-/node-8-1-3.1.5.tgz",
+			"integrity": "sha512-EMmxxA1e+qnrF+pRWL9KiE9vwf4A8UzzQeSF0wpbZGbvzVrraXo0XagBQi4jbdEk65xOTNkXhpOYsmfA7Gf2cw==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.1.5",
+				"ini": "4.1.2",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.3"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@php-wasm/node-8-1/node_modules/ini": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
+			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@php-wasm/node-8-2": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-2/-/node-8-2-3.1.5.tgz",
+			"integrity": "sha512-poasM88l8ii/bQ6DZklpM6Of4WMPLH+SOcCqpO+QPVaLFWSvgNwFfpmRF9jwI3FkY+pfWwSH/HWWiei4+D3+sQ==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.1.5",
+				"ini": "4.1.2",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.3"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@php-wasm/node-8-2/node_modules/ini": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
+			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@php-wasm/node-8-3": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-3/-/node-8-3-3.1.5.tgz",
+			"integrity": "sha512-nuZopXnQRp+gLdt6hBk5GPvfnMQ0hfdEiEHZuKZ2lmVaNjC8CVOTbGX4JXusuPxv4t5kEpBm8ya8P0XYX9uJWg==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.1.5",
+				"ini": "4.1.2",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.3"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@php-wasm/node-8-3/node_modules/ini": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
+			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@php-wasm/node-8-4": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-4/-/node-8-4-3.1.5.tgz",
+			"integrity": "sha512-gZQa1dKCmL8b8weFhIiQ/vmV4alEfDlkUmsZWEsUj6nz2/xSY68rexCXlOUhAeU8457LGr5kbMZfXN8FfvYzog==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.1.5",
+				"ini": "4.1.2",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.3"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@php-wasm/node-8-4/node_modules/ini": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
+			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@php-wasm/node-8-5": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-5/-/node-8-5-3.1.5.tgz",
+			"integrity": "sha512-P08HjGPv1ZssKCsQYoCeeAVGX5fo7WaX/cpGJsDQKAJPA7xlvjztxfTo0Ydasfl4/BqX0oBcgqPWLoCoxBC3kw==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.1.5",
+				"ini": "4.1.2",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.3"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@php-wasm/node-8-5/node_modules/ini": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
+			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@php-wasm/node-polyfills": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-polyfills/-/node-polyfills-3.1.5.tgz",
+			"integrity": "sha512-zGvYRZcwMWPBAneL7x4HBaCnvGAoTIxF8OZFox6Yob3HntYyFVC+GkIfV5WkamtxpALNWY+qR6yJ+a2XXIVgbw==",
+			"dev": true,
+			"license": "GPL-2.0-or-later"
+		},
+		"node_modules/@php-wasm/node/node_modules/cliui": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+			"integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"string-width": "^4.2.0",
+				"strip-ansi": "^6.0.1",
+				"wrap-ansi": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@php-wasm/node/node_modules/ini": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
+			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@php-wasm/node/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@php-wasm/node/node_modules/yargs": {
+			"version": "17.7.2",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+			"integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"cliui": "^8.0.1",
+				"escalade": "^3.1.1",
+				"get-caller-file": "^2.0.5",
+				"require-directory": "^2.1.1",
+				"string-width": "^4.2.3",
+				"y18n": "^5.0.5",
+				"yargs-parser": "^21.1.1"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@php-wasm/node/node_modules/yargs-parser": {
+			"version": "21.1.1",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+			"integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@php-wasm/progress": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/@php-wasm/progress/-/progress-3.1.5.tgz",
+			"integrity": "sha512-pWjF/sGGs2PQy+ZQUxCIQUMd6/QyShpUwXaaylMeeV1xVUuzrBXrW0l73uQ31Ss3eOLHWedGogv3lVy3Rgpcfw==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/logger": "3.1.5",
+				"@php-wasm/node-polyfills": "3.1.5"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@php-wasm/scopes": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/@php-wasm/scopes/-/scopes-3.1.5.tgz",
+			"integrity": "sha512-1t1v2eCm02thCYsGSv3aqNvdC4W49Ml5vCk3a939ZOFrOIWHotRvLdn0ATWsqGWo+O/DK/pS3SB9xZWuXa5CGg==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@php-wasm/stream-compression": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/@php-wasm/stream-compression/-/stream-compression-3.1.5.tgz",
+			"integrity": "sha512-n6S+7Fg+uKtM8EnwKQm8UK9HH1MIKF0blNRT2Gj8nvpeMU7aC/wIOuXLKzFm2d9rflFS7BxmnvXcrny0ZIwclg==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/node-polyfills": "3.1.5",
+				"@php-wasm/util": "3.1.5"
+			}
+		},
+		"node_modules/@php-wasm/universal": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/@php-wasm/universal/-/universal-3.1.5.tgz",
+			"integrity": "sha512-IDc12RAc+fAQn1s3gWrN3haaHd0wLZpC42wYWx/7Ku5eNV4nU9Ax471r2DCftpV9cyOfYzEWB55ZOO81rKHKXA==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/logger": "3.1.5",
+				"@php-wasm/node-polyfills": "3.1.5",
+				"@php-wasm/progress": "3.1.5",
+				"@php-wasm/stream-compression": "3.1.5",
+				"@php-wasm/util": "3.1.5",
+				"ini": "4.1.2"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@php-wasm/universal/node_modules/ini": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
+			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@php-wasm/util": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/@php-wasm/util/-/util-3.1.5.tgz",
+			"integrity": "sha512-IWNH2ArQafy1C6FvBjDsM94QsMJeG1yN6iWH/8upjVrUBgXoI0GzH5y9gswmLSf1fiOh+bYZxVBjXEuRICM1HA==",
+			"dev": true,
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@php-wasm/web-service-worker": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/@php-wasm/web-service-worker/-/web-service-worker-3.1.5.tgz",
+			"integrity": "sha512-R9PNKxDEkgwKEjQK/Fy8J8I4Wklzf8cPrq9Ui0uJJZ0vLBzc4lOV+Ya+BbclHZIT0kJjkkwq8dlmBh9/IuaQ6w==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/scopes": "3.1.5"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@php-wasm/xdebug-bridge": {
+			"version": "3.1.11",
+			"resolved": "https://registry.npmjs.org/@php-wasm/xdebug-bridge/-/xdebug-bridge-3.1.11.tgz",
+			"integrity": "sha512-Hk4rHJjlk/z765+0UVGbGUFnJC0/r0A7OgOVMnIzXKNODpwV8S7WoC1M8BUCAbPUl3VpK4mboglb6An7PvktVg==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/logger": "3.1.11",
+				"@php-wasm/node": "3.1.11",
+				"@php-wasm/universal": "3.1.11",
+				"@wp-playground/common": "3.1.11",
+				"express": "4.22.0",
+				"fast-xml-parser": "^5.5.1",
+				"fs-ext-extra-prebuilt": "2.2.7",
+				"ini": "4.1.2",
+				"jsonc-parser": "3.3.1",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.3",
+				"xml2js": "0.6.2",
+				"yargs": "17.7.2"
+			},
+			"bin": {
+				"xdebug-bridge": "xdebug-bridge.js"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@php-wasm/xdebug-bridge/node_modules/@php-wasm/cli-util": {
 			"version": "3.1.11",
 			"resolved": "https://registry.npmjs.org/@php-wasm/cli-util/-/cli-util-3.1.11.tgz",
 			"integrity": "sha512-/v/S007ZZfTmDyYOReKtUnhiOWZi1EZdLrDiSPCmYms3XFNeJDUBWEkDshcwMxuDaA4Ce2ciF0QsM+yuY9vY9g==",
@@ -7058,7 +8027,7 @@
 				"npm": ">=10.2.3"
 			}
 		},
-		"node_modules/@php-wasm/logger": {
+		"node_modules/@php-wasm/xdebug-bridge/node_modules/@php-wasm/logger": {
 			"version": "3.1.11",
 			"resolved": "https://registry.npmjs.org/@php-wasm/logger/-/logger-3.1.11.tgz",
 			"integrity": "sha512-wGKmMpA8gvoLFEjG9jzm7E2BEAaq4LU9yMjMkzKwYE0RUivV1000Cnw+m+79/d4Bua0ouoCLab5+IFFJrfxYpw==",
@@ -7071,7 +8040,7 @@
 				"npm": ">=10.2.3"
 			}
 		},
-		"node_modules/@php-wasm/node": {
+		"node_modules/@php-wasm/xdebug-bridge/node_modules/@php-wasm/node": {
 			"version": "3.1.11",
 			"resolved": "https://registry.npmjs.org/@php-wasm/node/-/node-3.1.11.tgz",
 			"integrity": "sha512-qqJuQMm/Ey4Cv2h6F6q7Rj33KMo5z+33s2CABwRnS7fgzGBSQzB7vq4L2pScqVmvfRXnW1lFoUgFARojOOThkA==",
@@ -7104,7 +8073,7 @@
 				"npm": ">=10.2.3"
 			}
 		},
-		"node_modules/@php-wasm/node-7-4": {
+		"node_modules/@php-wasm/xdebug-bridge/node_modules/@php-wasm/node-7-4": {
 			"version": "3.1.11",
 			"resolved": "https://registry.npmjs.org/@php-wasm/node-7-4/-/node-7-4-3.1.11.tgz",
 			"integrity": "sha512-WGX0nOv6JsTXY+I0FqAB8wQLeQc8pAYbUg4LXEQnACZWPL9mdAvwk++XkScWQ5zfwUtrTq9TwpAXcyf3xRrIxQ==",
@@ -7120,16 +8089,7 @@
 				"npm": ">=10.2.3"
 			}
 		},
-		"node_modules/@php-wasm/node-7-4/node_modules/ini": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
-			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
-			"license": "ISC",
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@php-wasm/node-8-0": {
+		"node_modules/@php-wasm/xdebug-bridge/node_modules/@php-wasm/node-8-0": {
 			"version": "3.1.11",
 			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-0/-/node-8-0-3.1.11.tgz",
 			"integrity": "sha512-92E8kydq6RmxYnFGXGTursqT/8doRND8fQoqerj4uJ4oMtPIBXREyBMAye4/ss3ls9IXSRbZKYQ03NptozcYfA==",
@@ -7145,16 +8105,7 @@
 				"npm": ">=10.2.3"
 			}
 		},
-		"node_modules/@php-wasm/node-8-0/node_modules/ini": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
-			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
-			"license": "ISC",
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@php-wasm/node-8-1": {
+		"node_modules/@php-wasm/xdebug-bridge/node_modules/@php-wasm/node-8-1": {
 			"version": "3.1.11",
 			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-1/-/node-8-1-3.1.11.tgz",
 			"integrity": "sha512-fP7OWc0V7Hs1AEcr0cP8d49twJLSDwdHUyFwTuD7uPY+u9KrPW8ZrhR8+j2pmPrU0qMO5x+oPP1u8MFgNpWHOQ==",
@@ -7170,16 +8121,7 @@
 				"npm": ">=10.2.3"
 			}
 		},
-		"node_modules/@php-wasm/node-8-1/node_modules/ini": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
-			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
-			"license": "ISC",
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@php-wasm/node-8-2": {
+		"node_modules/@php-wasm/xdebug-bridge/node_modules/@php-wasm/node-8-2": {
 			"version": "3.1.11",
 			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-2/-/node-8-2-3.1.11.tgz",
 			"integrity": "sha512-T72JABgcbo6OujFaVfKb+eJpgZgcTK5vmUoNDWZFvu7NvH9wSRkmnlas+HcqO2inEja0BvQbz7WWcDHUTj9rPQ==",
@@ -7195,16 +8137,7 @@
 				"npm": ">=10.2.3"
 			}
 		},
-		"node_modules/@php-wasm/node-8-2/node_modules/ini": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
-			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
-			"license": "ISC",
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@php-wasm/node-8-3": {
+		"node_modules/@php-wasm/xdebug-bridge/node_modules/@php-wasm/node-8-3": {
 			"version": "3.1.11",
 			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-3/-/node-8-3-3.1.11.tgz",
 			"integrity": "sha512-KFOVw3E0ThCGN6pmdS16FIgHzbAVNLVrV4QkCvKmvPENMfKLOaJAwC3jN8qK4eE/j5jWqAZIQPsOPwVKkHziDw==",
@@ -7220,16 +8153,7 @@
 				"npm": ">=10.2.3"
 			}
 		},
-		"node_modules/@php-wasm/node-8-3/node_modules/ini": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
-			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
-			"license": "ISC",
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@php-wasm/node-8-4": {
+		"node_modules/@php-wasm/xdebug-bridge/node_modules/@php-wasm/node-8-4": {
 			"version": "3.1.11",
 			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-4/-/node-8-4-3.1.11.tgz",
 			"integrity": "sha512-fSKp8C+rcORGHBQJRtrFkNfTmIsjtfMcuT81jWIs71zG2v1C0yIfEPdpRqHv6UVJVFToUb1ClEGY+dfqO9mXYA==",
@@ -7245,16 +8169,7 @@
 				"npm": ">=10.2.3"
 			}
 		},
-		"node_modules/@php-wasm/node-8-4/node_modules/ini": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
-			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
-			"license": "ISC",
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@php-wasm/node-8-5": {
+		"node_modules/@php-wasm/xdebug-bridge/node_modules/@php-wasm/node-8-5": {
 			"version": "3.1.11",
 			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-5/-/node-8-5-3.1.11.tgz",
 			"integrity": "sha512-ystaL0/ab7GyQCReNFWpC2LPKa3u2gUXlMi0g/2CZDD4kavnzksuI/jAHhwnmTnZePbEam23rvdyq77ndC1TFw==",
@@ -7270,84 +8185,13 @@
 				"npm": ">=10.2.3"
 			}
 		},
-		"node_modules/@php-wasm/node-8-5/node_modules/ini": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
-			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
-			"license": "ISC",
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@php-wasm/node-polyfills": {
+		"node_modules/@php-wasm/xdebug-bridge/node_modules/@php-wasm/node-polyfills": {
 			"version": "3.1.11",
 			"resolved": "https://registry.npmjs.org/@php-wasm/node-polyfills/-/node-polyfills-3.1.11.tgz",
 			"integrity": "sha512-Gu3wS1gWkyGSW/K+RQNT4OfjeapeYdL5bqOQ+/MEfvkaeMRDdzdOvmPcIfLbDBhZOSh6jAA7nT87Ri2LmeqYzQ==",
 			"license": "GPL-2.0-or-later"
 		},
-		"node_modules/@php-wasm/node/node_modules/cliui": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-			"integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-			"license": "ISC",
-			"dependencies": {
-				"string-width": "^4.2.0",
-				"strip-ansi": "^6.0.1",
-				"wrap-ansi": "^7.0.0"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/@php-wasm/node/node_modules/ini": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
-			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
-			"license": "ISC",
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@php-wasm/node/node_modules/strip-ansi": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^5.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/@php-wasm/node/node_modules/yargs": {
-			"version": "17.7.2",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-			"integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-			"license": "MIT",
-			"dependencies": {
-				"cliui": "^8.0.1",
-				"escalade": "^3.1.1",
-				"get-caller-file": "^2.0.5",
-				"require-directory": "^2.1.1",
-				"string-width": "^4.2.3",
-				"y18n": "^5.0.5",
-				"yargs-parser": "^21.1.1"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/@php-wasm/node/node_modules/yargs-parser": {
-			"version": "21.1.1",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-			"integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-			"license": "ISC",
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/@php-wasm/progress": {
+		"node_modules/@php-wasm/xdebug-bridge/node_modules/@php-wasm/progress": {
 			"version": "3.1.11",
 			"resolved": "https://registry.npmjs.org/@php-wasm/progress/-/progress-3.1.11.tgz",
 			"integrity": "sha512-/zsH+ZvBxq+Qlb2ffNvvjmiqaB6Fwo8+O3Py+WUznxIuQ/3Ckci+5cWyBtYQ6qtAGFSRADl41Qg9n6RmWBUL7w==",
@@ -7361,17 +8205,7 @@
 				"npm": ">=10.2.3"
 			}
 		},
-		"node_modules/@php-wasm/scopes": {
-			"version": "3.1.11",
-			"resolved": "https://registry.npmjs.org/@php-wasm/scopes/-/scopes-3.1.11.tgz",
-			"integrity": "sha512-WyI1PHYA4vHmb2DHO6M2e8ydY1brfMRjRf1Z5FYhfyh7G2FEAJbOyoY/VenBOCw0dE04vkWU4LRuVwkFrO8+Ow==",
-			"license": "GPL-2.0-or-later",
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
-		"node_modules/@php-wasm/stream-compression": {
+		"node_modules/@php-wasm/xdebug-bridge/node_modules/@php-wasm/stream-compression": {
 			"version": "3.1.11",
 			"resolved": "https://registry.npmjs.org/@php-wasm/stream-compression/-/stream-compression-3.1.11.tgz",
 			"integrity": "sha512-R9wfu3Zx083m8WTlWN888iZ9ub2nhZXGi5LVjfIQCd2UPuRbhFuOHiiyvnoHnZFyMZnzI12/MhuoPHuWv6NPew==",
@@ -7381,7 +8215,7 @@
 				"@php-wasm/util": "3.1.11"
 			}
 		},
-		"node_modules/@php-wasm/universal": {
+		"node_modules/@php-wasm/xdebug-bridge/node_modules/@php-wasm/universal": {
 			"version": "3.1.11",
 			"resolved": "https://registry.npmjs.org/@php-wasm/universal/-/universal-3.1.11.tgz",
 			"integrity": "sha512-n+fGHL9wqLf6NBWsPdDbF7USY20FBZgBIJvUoi620xNQdakhZ425tCM7bEVBE+lcOY6/l4rFCIdSbY+HoJwg7w==",
@@ -7399,16 +8233,7 @@
 				"npm": ">=10.2.3"
 			}
 		},
-		"node_modules/@php-wasm/universal/node_modules/ini": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
-			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
-			"license": "ISC",
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@php-wasm/util": {
+		"node_modules/@php-wasm/xdebug-bridge/node_modules/@php-wasm/util": {
 			"version": "3.1.11",
 			"resolved": "https://registry.npmjs.org/@php-wasm/util/-/util-3.1.11.tgz",
 			"integrity": "sha512-9n/s609DDF03+M4DWbvf+BCaHGAGt56xOxceV91mQA1X0c+iLgBCYG2oLgOvs1Cl+anYxiVbsLUZBfjAxKLcbQ==",
@@ -7417,52 +8242,15 @@
 				"npm": ">=10.2.3"
 			}
 		},
-		"node_modules/@php-wasm/web-service-worker": {
+		"node_modules/@php-wasm/xdebug-bridge/node_modules/@wp-playground/common": {
 			"version": "3.1.11",
-			"resolved": "https://registry.npmjs.org/@php-wasm/web-service-worker/-/web-service-worker-3.1.11.tgz",
-			"integrity": "sha512-8qCh2Y5ZrLw1EP+s5iYCBE4HnBcB0HjudGPNLs2azYRZHOo5C3Xjc+VI5BDdfyLEZl3AOg5y6dE0dk2ur2WCeg==",
+			"resolved": "https://registry.npmjs.org/@wp-playground/common/-/common-3.1.11.tgz",
+			"integrity": "sha512-1/5yts2ExzfVxHqK4oz9dr9Jxeuh99zhAO5ClH3zROo/7gRXKWHZWoQXNLZnPJ3RlMqYzIzHzmozhyx29rtizQ==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/scopes": "3.1.11",
 				"@php-wasm/universal": "3.1.11",
+				"@php-wasm/util": "3.1.11",
 				"ini": "4.1.2"
-			},
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
-		"node_modules/@php-wasm/web-service-worker/node_modules/ini": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
-			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
-			"license": "ISC",
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@php-wasm/xdebug-bridge": {
-			"version": "3.1.11",
-			"resolved": "https://registry.npmjs.org/@php-wasm/xdebug-bridge/-/xdebug-bridge-3.1.11.tgz",
-			"integrity": "sha512-Hk4rHJjlk/z765+0UVGbGUFnJC0/r0A7OgOVMnIzXKNODpwV8S7WoC1M8BUCAbPUl3VpK4mboglb6An7PvktVg==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/logger": "3.1.11",
-				"@php-wasm/node": "3.1.11",
-				"@php-wasm/universal": "3.1.11",
-				"@wp-playground/common": "3.1.11",
-				"express": "4.22.0",
-				"fast-xml-parser": "^5.5.1",
-				"fs-ext-extra-prebuilt": "2.2.7",
-				"ini": "4.1.2",
-				"jsonc-parser": "3.3.1",
-				"wasm-feature-detect": "1.8.0",
-				"ws": "8.18.3",
-				"xml2js": "0.6.2",
-				"yargs": "17.7.2"
-			},
-			"bin": {
-				"xdebug-bridge": "xdebug-bridge.js"
 			},
 			"engines": {
 				"node": ">=20.10.0",
@@ -10775,22 +11563,23 @@
 			}
 		},
 		"node_modules/@wp-playground/blueprints": {
-			"version": "3.1.11",
-			"resolved": "https://registry.npmjs.org/@wp-playground/blueprints/-/blueprints-3.1.11.tgz",
-			"integrity": "sha512-9YeNYIKR+/LvWPnC38sorT9XJkMBz1B/Rb71kDQ5HemS8OvueyTofBc763kjQP3bumC5nr+38nMyXTNUkDuayQ==",
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/@wp-playground/blueprints/-/blueprints-3.1.5.tgz",
+			"integrity": "sha512-vdjM9V+dcqUj9fYB6Thau2ZwjfTlDZEhFU7glc/xM8/qSm2XvyYNumVWamCf6Xh6AqAxSNyKQl2XPwVGOMZVNw==",
+			"dev": true,
 			"dependencies": {
-				"@php-wasm/logger": "3.1.11",
-				"@php-wasm/node": "3.1.11",
-				"@php-wasm/node-polyfills": "3.1.11",
-				"@php-wasm/progress": "3.1.11",
-				"@php-wasm/scopes": "3.1.11",
-				"@php-wasm/stream-compression": "3.1.11",
-				"@php-wasm/universal": "3.1.11",
-				"@php-wasm/util": "3.1.11",
-				"@php-wasm/web-service-worker": "3.1.11",
-				"@wp-playground/common": "3.1.11",
-				"@wp-playground/storage": "3.1.11",
-				"@wp-playground/wordpress": "3.1.11",
+				"@php-wasm/logger": "3.1.5",
+				"@php-wasm/node": "3.1.5",
+				"@php-wasm/node-polyfills": "3.1.5",
+				"@php-wasm/progress": "3.1.5",
+				"@php-wasm/scopes": "3.1.5",
+				"@php-wasm/stream-compression": "3.1.5",
+				"@php-wasm/universal": "3.1.5",
+				"@php-wasm/util": "3.1.5",
+				"@php-wasm/web-service-worker": "3.1.5",
+				"@wp-playground/common": "3.1.5",
+				"@wp-playground/storage": "3.1.5",
+				"@wp-playground/wordpress": "3.1.5",
 				"@zip.js/zip.js": "2.7.57",
 				"ajv": "8.12.0",
 				"async-lock": "1.4.1",
@@ -10798,7 +11587,7 @@
 				"crc-32": "1.2.2",
 				"diff3": "0.0.4",
 				"express": "4.22.0",
-				"fast-xml-parser": "^5.5.1",
+				"fast-xml-parser": "^5.3.4",
 				"fs-ext-extra-prebuilt": "2.2.7",
 				"ignore": "5.3.2",
 				"ini": "4.1.2",
@@ -10823,6 +11612,7 @@
 			"version": "8.12.0",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
 			"integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"fast-deep-equal": "^3.1.1",
@@ -10839,6 +11629,7 @@
 			"version": "8.0.1",
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
 			"integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"string-width": "^4.2.0",
@@ -10853,6 +11644,7 @@
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
 			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
+			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -10862,18 +11654,21 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
 			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@wp-playground/blueprints/node_modules/pako": {
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.10.tgz",
 			"integrity": "sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw==",
+			"dev": true,
 			"license": "(MIT AND Zlib)"
 		},
 		"node_modules/@wp-playground/blueprints/node_modules/strip-ansi": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
 			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ansi-regex": "^5.0.1"
@@ -10886,6 +11681,7 @@
 			"version": "17.7.2",
 			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
 			"integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"cliui": "^8.0.1",
@@ -10904,6 +11700,7 @@
 			"version": "21.1.1",
 			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
 			"integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": ">=12"
@@ -10956,6 +11753,386 @@
 			},
 			"bin": {
 				"wp-playground-cli": "wp-playground.js"
+			}
+		},
+		"node_modules/@wp-playground/cli/node_modules/@php-wasm/cli-util": {
+			"version": "3.1.11",
+			"resolved": "https://registry.npmjs.org/@php-wasm/cli-util/-/cli-util-3.1.11.tgz",
+			"integrity": "sha512-/v/S007ZZfTmDyYOReKtUnhiOWZi1EZdLrDiSPCmYms3XFNeJDUBWEkDshcwMxuDaA4Ce2ciF0QsM+yuY9vY9g==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/util": "3.1.11",
+				"fast-xml-parser": "^5.5.1",
+				"jsonc-parser": "3.3.1"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@wp-playground/cli/node_modules/@php-wasm/logger": {
+			"version": "3.1.11",
+			"resolved": "https://registry.npmjs.org/@php-wasm/logger/-/logger-3.1.11.tgz",
+			"integrity": "sha512-wGKmMpA8gvoLFEjG9jzm7E2BEAaq4LU9yMjMkzKwYE0RUivV1000Cnw+m+79/d4Bua0ouoCLab5+IFFJrfxYpw==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/node-polyfills": "3.1.11"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@wp-playground/cli/node_modules/@php-wasm/node": {
+			"version": "3.1.11",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node/-/node-3.1.11.tgz",
+			"integrity": "sha512-qqJuQMm/Ey4Cv2h6F6q7Rj33KMo5z+33s2CABwRnS7fgzGBSQzB7vq4L2pScqVmvfRXnW1lFoUgFARojOOThkA==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/cli-util": "3.1.11",
+				"@php-wasm/logger": "3.1.11",
+				"@php-wasm/node-7-4": "3.1.11",
+				"@php-wasm/node-8-0": "3.1.11",
+				"@php-wasm/node-8-1": "3.1.11",
+				"@php-wasm/node-8-2": "3.1.11",
+				"@php-wasm/node-8-3": "3.1.11",
+				"@php-wasm/node-8-4": "3.1.11",
+				"@php-wasm/node-8-5": "3.1.11",
+				"@php-wasm/node-polyfills": "3.1.11",
+				"@php-wasm/universal": "3.1.11",
+				"@php-wasm/util": "3.1.11",
+				"@wp-playground/common": "3.1.11",
+				"express": "4.22.0",
+				"fast-xml-parser": "^5.5.1",
+				"fs-ext-extra-prebuilt": "2.2.7",
+				"ini": "4.1.2",
+				"jsonc-parser": "3.3.1",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.3",
+				"yargs": "17.7.2"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@wp-playground/cli/node_modules/@php-wasm/node-7-4": {
+			"version": "3.1.11",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-7-4/-/node-7-4-3.1.11.tgz",
+			"integrity": "sha512-WGX0nOv6JsTXY+I0FqAB8wQLeQc8pAYbUg4LXEQnACZWPL9mdAvwk++XkScWQ5zfwUtrTq9TwpAXcyf3xRrIxQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.1.11",
+				"ini": "4.1.2",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.3"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@wp-playground/cli/node_modules/@php-wasm/node-8-0": {
+			"version": "3.1.11",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-0/-/node-8-0-3.1.11.tgz",
+			"integrity": "sha512-92E8kydq6RmxYnFGXGTursqT/8doRND8fQoqerj4uJ4oMtPIBXREyBMAye4/ss3ls9IXSRbZKYQ03NptozcYfA==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.1.11",
+				"ini": "4.1.2",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.3"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@wp-playground/cli/node_modules/@php-wasm/node-8-1": {
+			"version": "3.1.11",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-1/-/node-8-1-3.1.11.tgz",
+			"integrity": "sha512-fP7OWc0V7Hs1AEcr0cP8d49twJLSDwdHUyFwTuD7uPY+u9KrPW8ZrhR8+j2pmPrU0qMO5x+oPP1u8MFgNpWHOQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.1.11",
+				"ini": "4.1.2",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.3"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@wp-playground/cli/node_modules/@php-wasm/node-8-2": {
+			"version": "3.1.11",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-2/-/node-8-2-3.1.11.tgz",
+			"integrity": "sha512-T72JABgcbo6OujFaVfKb+eJpgZgcTK5vmUoNDWZFvu7NvH9wSRkmnlas+HcqO2inEja0BvQbz7WWcDHUTj9rPQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.1.11",
+				"ini": "4.1.2",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.3"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@wp-playground/cli/node_modules/@php-wasm/node-8-3": {
+			"version": "3.1.11",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-3/-/node-8-3-3.1.11.tgz",
+			"integrity": "sha512-KFOVw3E0ThCGN6pmdS16FIgHzbAVNLVrV4QkCvKmvPENMfKLOaJAwC3jN8qK4eE/j5jWqAZIQPsOPwVKkHziDw==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.1.11",
+				"ini": "4.1.2",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.3"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@wp-playground/cli/node_modules/@php-wasm/node-8-4": {
+			"version": "3.1.11",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-4/-/node-8-4-3.1.11.tgz",
+			"integrity": "sha512-fSKp8C+rcORGHBQJRtrFkNfTmIsjtfMcuT81jWIs71zG2v1C0yIfEPdpRqHv6UVJVFToUb1ClEGY+dfqO9mXYA==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.1.11",
+				"ini": "4.1.2",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.3"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@wp-playground/cli/node_modules/@php-wasm/node-8-5": {
+			"version": "3.1.11",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-5/-/node-8-5-3.1.11.tgz",
+			"integrity": "sha512-ystaL0/ab7GyQCReNFWpC2LPKa3u2gUXlMi0g/2CZDD4kavnzksuI/jAHhwnmTnZePbEam23rvdyq77ndC1TFw==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.1.11",
+				"ini": "4.1.2",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.3"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@wp-playground/cli/node_modules/@php-wasm/node-polyfills": {
+			"version": "3.1.11",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-polyfills/-/node-polyfills-3.1.11.tgz",
+			"integrity": "sha512-Gu3wS1gWkyGSW/K+RQNT4OfjeapeYdL5bqOQ+/MEfvkaeMRDdzdOvmPcIfLbDBhZOSh6jAA7nT87Ri2LmeqYzQ==",
+			"license": "GPL-2.0-or-later"
+		},
+		"node_modules/@wp-playground/cli/node_modules/@php-wasm/progress": {
+			"version": "3.1.11",
+			"resolved": "https://registry.npmjs.org/@php-wasm/progress/-/progress-3.1.11.tgz",
+			"integrity": "sha512-/zsH+ZvBxq+Qlb2ffNvvjmiqaB6Fwo8+O3Py+WUznxIuQ/3Ckci+5cWyBtYQ6qtAGFSRADl41Qg9n6RmWBUL7w==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/logger": "3.1.11",
+				"@php-wasm/node-polyfills": "3.1.11"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@wp-playground/cli/node_modules/@php-wasm/scopes": {
+			"version": "3.1.11",
+			"resolved": "https://registry.npmjs.org/@php-wasm/scopes/-/scopes-3.1.11.tgz",
+			"integrity": "sha512-WyI1PHYA4vHmb2DHO6M2e8ydY1brfMRjRf1Z5FYhfyh7G2FEAJbOyoY/VenBOCw0dE04vkWU4LRuVwkFrO8+Ow==",
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@wp-playground/cli/node_modules/@php-wasm/stream-compression": {
+			"version": "3.1.11",
+			"resolved": "https://registry.npmjs.org/@php-wasm/stream-compression/-/stream-compression-3.1.11.tgz",
+			"integrity": "sha512-R9wfu3Zx083m8WTlWN888iZ9ub2nhZXGi5LVjfIQCd2UPuRbhFuOHiiyvnoHnZFyMZnzI12/MhuoPHuWv6NPew==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/node-polyfills": "3.1.11",
+				"@php-wasm/util": "3.1.11"
+			}
+		},
+		"node_modules/@wp-playground/cli/node_modules/@php-wasm/universal": {
+			"version": "3.1.11",
+			"resolved": "https://registry.npmjs.org/@php-wasm/universal/-/universal-3.1.11.tgz",
+			"integrity": "sha512-n+fGHL9wqLf6NBWsPdDbF7USY20FBZgBIJvUoi620xNQdakhZ425tCM7bEVBE+lcOY6/l4rFCIdSbY+HoJwg7w==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/logger": "3.1.11",
+				"@php-wasm/node-polyfills": "3.1.11",
+				"@php-wasm/progress": "3.1.11",
+				"@php-wasm/stream-compression": "3.1.11",
+				"@php-wasm/util": "3.1.11",
+				"ini": "4.1.2"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@wp-playground/cli/node_modules/@php-wasm/util": {
+			"version": "3.1.11",
+			"resolved": "https://registry.npmjs.org/@php-wasm/util/-/util-3.1.11.tgz",
+			"integrity": "sha512-9n/s609DDF03+M4DWbvf+BCaHGAGt56xOxceV91mQA1X0c+iLgBCYG2oLgOvs1Cl+anYxiVbsLUZBfjAxKLcbQ==",
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@wp-playground/cli/node_modules/@php-wasm/web-service-worker": {
+			"version": "3.1.11",
+			"resolved": "https://registry.npmjs.org/@php-wasm/web-service-worker/-/web-service-worker-3.1.11.tgz",
+			"integrity": "sha512-8qCh2Y5ZrLw1EP+s5iYCBE4HnBcB0HjudGPNLs2azYRZHOo5C3Xjc+VI5BDdfyLEZl3AOg5y6dE0dk2ur2WCeg==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/scopes": "3.1.11",
+				"@php-wasm/universal": "3.1.11",
+				"ini": "4.1.2"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@wp-playground/cli/node_modules/@wp-playground/blueprints": {
+			"version": "3.1.11",
+			"resolved": "https://registry.npmjs.org/@wp-playground/blueprints/-/blueprints-3.1.11.tgz",
+			"integrity": "sha512-9YeNYIKR+/LvWPnC38sorT9XJkMBz1B/Rb71kDQ5HemS8OvueyTofBc763kjQP3bumC5nr+38nMyXTNUkDuayQ==",
+			"dependencies": {
+				"@php-wasm/logger": "3.1.11",
+				"@php-wasm/node": "3.1.11",
+				"@php-wasm/node-polyfills": "3.1.11",
+				"@php-wasm/progress": "3.1.11",
+				"@php-wasm/scopes": "3.1.11",
+				"@php-wasm/stream-compression": "3.1.11",
+				"@php-wasm/universal": "3.1.11",
+				"@php-wasm/util": "3.1.11",
+				"@php-wasm/web-service-worker": "3.1.11",
+				"@wp-playground/common": "3.1.11",
+				"@wp-playground/storage": "3.1.11",
+				"@wp-playground/wordpress": "3.1.11",
+				"@zip.js/zip.js": "2.7.57",
+				"ajv": "8.12.0",
+				"async-lock": "1.4.1",
+				"clean-git-ref": "2.0.1",
+				"crc-32": "1.2.2",
+				"diff3": "0.0.4",
+				"express": "4.22.0",
+				"fast-xml-parser": "^5.5.1",
+				"fs-ext-extra-prebuilt": "2.2.7",
+				"ignore": "5.3.2",
+				"ini": "4.1.2",
+				"jsonc-parser": "3.3.1",
+				"minimisted": "2.0.1",
+				"octokit": "3.1.2",
+				"pako": "1.0.10",
+				"pify": "2.3.0",
+				"readable-stream": "3.6.2",
+				"sha.js": "2.4.12",
+				"simple-get": "4.0.1",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.3",
+				"yargs": "17.7.2"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@wp-playground/cli/node_modules/@wp-playground/common": {
+			"version": "3.1.11",
+			"resolved": "https://registry.npmjs.org/@wp-playground/common/-/common-3.1.11.tgz",
+			"integrity": "sha512-1/5yts2ExzfVxHqK4oz9dr9Jxeuh99zhAO5ClH3zROo/7gRXKWHZWoQXNLZnPJ3RlMqYzIzHzmozhyx29rtizQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.1.11",
+				"@php-wasm/util": "3.1.11",
+				"ini": "4.1.2"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@wp-playground/cli/node_modules/@wp-playground/storage": {
+			"version": "3.1.11",
+			"resolved": "https://registry.npmjs.org/@wp-playground/storage/-/storage-3.1.11.tgz",
+			"integrity": "sha512-OxDlLInbRzpceMYO2CVm3hYb1MnZqJZfr444+l3QhOJEqOo6n3WAwb/8MxRbqmfokkKGbO3YGnGQrF6u+RNhWQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/stream-compression": "3.1.11",
+				"@php-wasm/universal": "3.1.11",
+				"@php-wasm/util": "3.1.11",
+				"@zip.js/zip.js": "2.7.57",
+				"async-lock": "^1.4.1",
+				"clean-git-ref": "^2.0.1",
+				"crc-32": "^1.2.0",
+				"diff3": "0.0.3",
+				"ignore": "^5.1.4",
+				"ini": "4.1.2",
+				"minimisted": "^2.0.0",
+				"octokit": "3.1.2",
+				"pako": "^1.0.10",
+				"pify": "^4.0.1",
+				"readable-stream": "^3.4.0",
+				"sha.js": "^2.4.9",
+				"simple-get": "^4.0.1"
+			}
+		},
+		"node_modules/@wp-playground/cli/node_modules/@wp-playground/storage/node_modules/diff3": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/diff3/-/diff3-0.0.3.tgz",
+			"integrity": "sha512-iSq8ngPOt0K53A6eVr4d5Kn6GNrM2nQZtC740pzIriHtn4pOQ2lyzEXQMBeVcWERN0ye7fhBsk9PbLLQOnUx/g==",
+			"license": "MIT"
+		},
+		"node_modules/@wp-playground/cli/node_modules/@wp-playground/storage/node_modules/pify": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+			"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/@wp-playground/cli/node_modules/@wp-playground/wordpress": {
+			"version": "3.1.11",
+			"resolved": "https://registry.npmjs.org/@wp-playground/wordpress/-/wordpress-3.1.11.tgz",
+			"integrity": "sha512-G4sahkT4WQoCtCww0ve9GyQ+QVji7qd+6TOsuMI3iFaYgyYGIKKV4Yjx/KEOZEYKRY8BuZH6AKZpjrmu75CBxg==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/logger": "3.1.11",
+				"@php-wasm/node": "3.1.11",
+				"@php-wasm/universal": "3.1.11",
+				"@php-wasm/util": "3.1.11",
+				"@wp-playground/common": "3.1.11",
+				"express": "4.22.0",
+				"fast-xml-parser": "^5.5.1",
+				"fs-ext-extra-prebuilt": "2.2.7",
+				"ini": "4.1.2",
+				"jsonc-parser": "3.3.1",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.3",
+				"yargs": "17.7.2"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
 			}
 		},
 		"node_modules/@wp-playground/cli/node_modules/ajv": {
@@ -11063,13 +12240,14 @@
 			}
 		},
 		"node_modules/@wp-playground/common": {
-			"version": "3.1.11",
-			"resolved": "https://registry.npmjs.org/@wp-playground/common/-/common-3.1.11.tgz",
-			"integrity": "sha512-1/5yts2ExzfVxHqK4oz9dr9Jxeuh99zhAO5ClH3zROo/7gRXKWHZWoQXNLZnPJ3RlMqYzIzHzmozhyx29rtizQ==",
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/@wp-playground/common/-/common-3.1.5.tgz",
+			"integrity": "sha512-4VrwEwsSK2+PxfNu3KvvnOajQaR8kEJT9fSxWSbT7Lds+TF/m+opjnT+OtVl7dVhHB4rCVNn5rWmwwFeiDHIiA==",
+			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/universal": "3.1.11",
-				"@php-wasm/util": "3.1.11",
+				"@php-wasm/universal": "3.1.5",
+				"@php-wasm/util": "3.1.5",
 				"ini": "4.1.2"
 			},
 			"engines": {
@@ -11081,20 +12259,22 @@
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
 			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
+			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
 			}
 		},
 		"node_modules/@wp-playground/storage": {
-			"version": "3.1.11",
-			"resolved": "https://registry.npmjs.org/@wp-playground/storage/-/storage-3.1.11.tgz",
-			"integrity": "sha512-OxDlLInbRzpceMYO2CVm3hYb1MnZqJZfr444+l3QhOJEqOo6n3WAwb/8MxRbqmfokkKGbO3YGnGQrF6u+RNhWQ==",
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/@wp-playground/storage/-/storage-3.1.5.tgz",
+			"integrity": "sha512-PYb4XeEmkEf/nvelApgPu+04v3sPLPBSuYqHHU3tNNV0a+kjQUNb/1RHeOIFi5vMmkO9QxdxxyndCEYlI6pCSQ==",
+			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/stream-compression": "3.1.11",
-				"@php-wasm/universal": "3.1.11",
-				"@php-wasm/util": "3.1.11",
+				"@php-wasm/stream-compression": "3.1.5",
+				"@php-wasm/universal": "3.1.5",
+				"@php-wasm/util": "3.1.5",
 				"@zip.js/zip.js": "2.7.57",
 				"async-lock": "^1.4.1",
 				"clean-git-ref": "^2.0.1",
@@ -11115,12 +12295,14 @@
 			"version": "0.0.3",
 			"resolved": "https://registry.npmjs.org/diff3/-/diff3-0.0.3.tgz",
 			"integrity": "sha512-iSq8ngPOt0K53A6eVr4d5Kn6GNrM2nQZtC740pzIriHtn4pOQ2lyzEXQMBeVcWERN0ye7fhBsk9PbLLQOnUx/g==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@wp-playground/storage/node_modules/ini": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
 			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
+			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -11130,6 +12312,7 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
 			"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
@@ -11161,6 +12344,386 @@
 				"readable-stream": "3.6.2",
 				"sha.js": "2.4.12",
 				"simple-get": "4.0.1",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.3",
+				"yargs": "17.7.2"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@wp-playground/tools/node_modules/@php-wasm/cli-util": {
+			"version": "3.1.11",
+			"resolved": "https://registry.npmjs.org/@php-wasm/cli-util/-/cli-util-3.1.11.tgz",
+			"integrity": "sha512-/v/S007ZZfTmDyYOReKtUnhiOWZi1EZdLrDiSPCmYms3XFNeJDUBWEkDshcwMxuDaA4Ce2ciF0QsM+yuY9vY9g==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/util": "3.1.11",
+				"fast-xml-parser": "^5.5.1",
+				"jsonc-parser": "3.3.1"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@wp-playground/tools/node_modules/@php-wasm/logger": {
+			"version": "3.1.11",
+			"resolved": "https://registry.npmjs.org/@php-wasm/logger/-/logger-3.1.11.tgz",
+			"integrity": "sha512-wGKmMpA8gvoLFEjG9jzm7E2BEAaq4LU9yMjMkzKwYE0RUivV1000Cnw+m+79/d4Bua0ouoCLab5+IFFJrfxYpw==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/node-polyfills": "3.1.11"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@wp-playground/tools/node_modules/@php-wasm/node": {
+			"version": "3.1.11",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node/-/node-3.1.11.tgz",
+			"integrity": "sha512-qqJuQMm/Ey4Cv2h6F6q7Rj33KMo5z+33s2CABwRnS7fgzGBSQzB7vq4L2pScqVmvfRXnW1lFoUgFARojOOThkA==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/cli-util": "3.1.11",
+				"@php-wasm/logger": "3.1.11",
+				"@php-wasm/node-7-4": "3.1.11",
+				"@php-wasm/node-8-0": "3.1.11",
+				"@php-wasm/node-8-1": "3.1.11",
+				"@php-wasm/node-8-2": "3.1.11",
+				"@php-wasm/node-8-3": "3.1.11",
+				"@php-wasm/node-8-4": "3.1.11",
+				"@php-wasm/node-8-5": "3.1.11",
+				"@php-wasm/node-polyfills": "3.1.11",
+				"@php-wasm/universal": "3.1.11",
+				"@php-wasm/util": "3.1.11",
+				"@wp-playground/common": "3.1.11",
+				"express": "4.22.0",
+				"fast-xml-parser": "^5.5.1",
+				"fs-ext-extra-prebuilt": "2.2.7",
+				"ini": "4.1.2",
+				"jsonc-parser": "3.3.1",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.3",
+				"yargs": "17.7.2"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@wp-playground/tools/node_modules/@php-wasm/node-7-4": {
+			"version": "3.1.11",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-7-4/-/node-7-4-3.1.11.tgz",
+			"integrity": "sha512-WGX0nOv6JsTXY+I0FqAB8wQLeQc8pAYbUg4LXEQnACZWPL9mdAvwk++XkScWQ5zfwUtrTq9TwpAXcyf3xRrIxQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.1.11",
+				"ini": "4.1.2",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.3"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@wp-playground/tools/node_modules/@php-wasm/node-8-0": {
+			"version": "3.1.11",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-0/-/node-8-0-3.1.11.tgz",
+			"integrity": "sha512-92E8kydq6RmxYnFGXGTursqT/8doRND8fQoqerj4uJ4oMtPIBXREyBMAye4/ss3ls9IXSRbZKYQ03NptozcYfA==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.1.11",
+				"ini": "4.1.2",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.3"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@wp-playground/tools/node_modules/@php-wasm/node-8-1": {
+			"version": "3.1.11",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-1/-/node-8-1-3.1.11.tgz",
+			"integrity": "sha512-fP7OWc0V7Hs1AEcr0cP8d49twJLSDwdHUyFwTuD7uPY+u9KrPW8ZrhR8+j2pmPrU0qMO5x+oPP1u8MFgNpWHOQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.1.11",
+				"ini": "4.1.2",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.3"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@wp-playground/tools/node_modules/@php-wasm/node-8-2": {
+			"version": "3.1.11",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-2/-/node-8-2-3.1.11.tgz",
+			"integrity": "sha512-T72JABgcbo6OujFaVfKb+eJpgZgcTK5vmUoNDWZFvu7NvH9wSRkmnlas+HcqO2inEja0BvQbz7WWcDHUTj9rPQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.1.11",
+				"ini": "4.1.2",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.3"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@wp-playground/tools/node_modules/@php-wasm/node-8-3": {
+			"version": "3.1.11",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-3/-/node-8-3-3.1.11.tgz",
+			"integrity": "sha512-KFOVw3E0ThCGN6pmdS16FIgHzbAVNLVrV4QkCvKmvPENMfKLOaJAwC3jN8qK4eE/j5jWqAZIQPsOPwVKkHziDw==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.1.11",
+				"ini": "4.1.2",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.3"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@wp-playground/tools/node_modules/@php-wasm/node-8-4": {
+			"version": "3.1.11",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-4/-/node-8-4-3.1.11.tgz",
+			"integrity": "sha512-fSKp8C+rcORGHBQJRtrFkNfTmIsjtfMcuT81jWIs71zG2v1C0yIfEPdpRqHv6UVJVFToUb1ClEGY+dfqO9mXYA==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.1.11",
+				"ini": "4.1.2",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.3"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@wp-playground/tools/node_modules/@php-wasm/node-8-5": {
+			"version": "3.1.11",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-5/-/node-8-5-3.1.11.tgz",
+			"integrity": "sha512-ystaL0/ab7GyQCReNFWpC2LPKa3u2gUXlMi0g/2CZDD4kavnzksuI/jAHhwnmTnZePbEam23rvdyq77ndC1TFw==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.1.11",
+				"ini": "4.1.2",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.3"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@wp-playground/tools/node_modules/@php-wasm/node-polyfills": {
+			"version": "3.1.11",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-polyfills/-/node-polyfills-3.1.11.tgz",
+			"integrity": "sha512-Gu3wS1gWkyGSW/K+RQNT4OfjeapeYdL5bqOQ+/MEfvkaeMRDdzdOvmPcIfLbDBhZOSh6jAA7nT87Ri2LmeqYzQ==",
+			"license": "GPL-2.0-or-later"
+		},
+		"node_modules/@wp-playground/tools/node_modules/@php-wasm/progress": {
+			"version": "3.1.11",
+			"resolved": "https://registry.npmjs.org/@php-wasm/progress/-/progress-3.1.11.tgz",
+			"integrity": "sha512-/zsH+ZvBxq+Qlb2ffNvvjmiqaB6Fwo8+O3Py+WUznxIuQ/3Ckci+5cWyBtYQ6qtAGFSRADl41Qg9n6RmWBUL7w==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/logger": "3.1.11",
+				"@php-wasm/node-polyfills": "3.1.11"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@wp-playground/tools/node_modules/@php-wasm/scopes": {
+			"version": "3.1.11",
+			"resolved": "https://registry.npmjs.org/@php-wasm/scopes/-/scopes-3.1.11.tgz",
+			"integrity": "sha512-WyI1PHYA4vHmb2DHO6M2e8ydY1brfMRjRf1Z5FYhfyh7G2FEAJbOyoY/VenBOCw0dE04vkWU4LRuVwkFrO8+Ow==",
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@wp-playground/tools/node_modules/@php-wasm/stream-compression": {
+			"version": "3.1.11",
+			"resolved": "https://registry.npmjs.org/@php-wasm/stream-compression/-/stream-compression-3.1.11.tgz",
+			"integrity": "sha512-R9wfu3Zx083m8WTlWN888iZ9ub2nhZXGi5LVjfIQCd2UPuRbhFuOHiiyvnoHnZFyMZnzI12/MhuoPHuWv6NPew==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/node-polyfills": "3.1.11",
+				"@php-wasm/util": "3.1.11"
+			}
+		},
+		"node_modules/@wp-playground/tools/node_modules/@php-wasm/universal": {
+			"version": "3.1.11",
+			"resolved": "https://registry.npmjs.org/@php-wasm/universal/-/universal-3.1.11.tgz",
+			"integrity": "sha512-n+fGHL9wqLf6NBWsPdDbF7USY20FBZgBIJvUoi620xNQdakhZ425tCM7bEVBE+lcOY6/l4rFCIdSbY+HoJwg7w==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/logger": "3.1.11",
+				"@php-wasm/node-polyfills": "3.1.11",
+				"@php-wasm/progress": "3.1.11",
+				"@php-wasm/stream-compression": "3.1.11",
+				"@php-wasm/util": "3.1.11",
+				"ini": "4.1.2"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@wp-playground/tools/node_modules/@php-wasm/util": {
+			"version": "3.1.11",
+			"resolved": "https://registry.npmjs.org/@php-wasm/util/-/util-3.1.11.tgz",
+			"integrity": "sha512-9n/s609DDF03+M4DWbvf+BCaHGAGt56xOxceV91mQA1X0c+iLgBCYG2oLgOvs1Cl+anYxiVbsLUZBfjAxKLcbQ==",
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@wp-playground/tools/node_modules/@php-wasm/web-service-worker": {
+			"version": "3.1.11",
+			"resolved": "https://registry.npmjs.org/@php-wasm/web-service-worker/-/web-service-worker-3.1.11.tgz",
+			"integrity": "sha512-8qCh2Y5ZrLw1EP+s5iYCBE4HnBcB0HjudGPNLs2azYRZHOo5C3Xjc+VI5BDdfyLEZl3AOg5y6dE0dk2ur2WCeg==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/scopes": "3.1.11",
+				"@php-wasm/universal": "3.1.11",
+				"ini": "4.1.2"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@wp-playground/tools/node_modules/@wp-playground/blueprints": {
+			"version": "3.1.11",
+			"resolved": "https://registry.npmjs.org/@wp-playground/blueprints/-/blueprints-3.1.11.tgz",
+			"integrity": "sha512-9YeNYIKR+/LvWPnC38sorT9XJkMBz1B/Rb71kDQ5HemS8OvueyTofBc763kjQP3bumC5nr+38nMyXTNUkDuayQ==",
+			"dependencies": {
+				"@php-wasm/logger": "3.1.11",
+				"@php-wasm/node": "3.1.11",
+				"@php-wasm/node-polyfills": "3.1.11",
+				"@php-wasm/progress": "3.1.11",
+				"@php-wasm/scopes": "3.1.11",
+				"@php-wasm/stream-compression": "3.1.11",
+				"@php-wasm/universal": "3.1.11",
+				"@php-wasm/util": "3.1.11",
+				"@php-wasm/web-service-worker": "3.1.11",
+				"@wp-playground/common": "3.1.11",
+				"@wp-playground/storage": "3.1.11",
+				"@wp-playground/wordpress": "3.1.11",
+				"@zip.js/zip.js": "2.7.57",
+				"ajv": "8.12.0",
+				"async-lock": "1.4.1",
+				"clean-git-ref": "2.0.1",
+				"crc-32": "1.2.2",
+				"diff3": "0.0.4",
+				"express": "4.22.0",
+				"fast-xml-parser": "^5.5.1",
+				"fs-ext-extra-prebuilt": "2.2.7",
+				"ignore": "5.3.2",
+				"ini": "4.1.2",
+				"jsonc-parser": "3.3.1",
+				"minimisted": "2.0.1",
+				"octokit": "3.1.2",
+				"pako": "1.0.10",
+				"pify": "2.3.0",
+				"readable-stream": "3.6.2",
+				"sha.js": "2.4.12",
+				"simple-get": "4.0.1",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.3",
+				"yargs": "17.7.2"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@wp-playground/tools/node_modules/@wp-playground/common": {
+			"version": "3.1.11",
+			"resolved": "https://registry.npmjs.org/@wp-playground/common/-/common-3.1.11.tgz",
+			"integrity": "sha512-1/5yts2ExzfVxHqK4oz9dr9Jxeuh99zhAO5ClH3zROo/7gRXKWHZWoQXNLZnPJ3RlMqYzIzHzmozhyx29rtizQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/universal": "3.1.11",
+				"@php-wasm/util": "3.1.11",
+				"ini": "4.1.2"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@wp-playground/tools/node_modules/@wp-playground/storage": {
+			"version": "3.1.11",
+			"resolved": "https://registry.npmjs.org/@wp-playground/storage/-/storage-3.1.11.tgz",
+			"integrity": "sha512-OxDlLInbRzpceMYO2CVm3hYb1MnZqJZfr444+l3QhOJEqOo6n3WAwb/8MxRbqmfokkKGbO3YGnGQrF6u+RNhWQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/stream-compression": "3.1.11",
+				"@php-wasm/universal": "3.1.11",
+				"@php-wasm/util": "3.1.11",
+				"@zip.js/zip.js": "2.7.57",
+				"async-lock": "^1.4.1",
+				"clean-git-ref": "^2.0.1",
+				"crc-32": "^1.2.0",
+				"diff3": "0.0.3",
+				"ignore": "^5.1.4",
+				"ini": "4.1.2",
+				"minimisted": "^2.0.0",
+				"octokit": "3.1.2",
+				"pako": "^1.0.10",
+				"pify": "^4.0.1",
+				"readable-stream": "^3.4.0",
+				"sha.js": "^2.4.9",
+				"simple-get": "^4.0.1"
+			}
+		},
+		"node_modules/@wp-playground/tools/node_modules/@wp-playground/storage/node_modules/diff3": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/diff3/-/diff3-0.0.3.tgz",
+			"integrity": "sha512-iSq8ngPOt0K53A6eVr4d5Kn6GNrM2nQZtC740pzIriHtn4pOQ2lyzEXQMBeVcWERN0ye7fhBsk9PbLLQOnUx/g==",
+			"license": "MIT"
+		},
+		"node_modules/@wp-playground/tools/node_modules/@wp-playground/storage/node_modules/pify": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+			"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/@wp-playground/tools/node_modules/@wp-playground/wordpress": {
+			"version": "3.1.11",
+			"resolved": "https://registry.npmjs.org/@wp-playground/wordpress/-/wordpress-3.1.11.tgz",
+			"integrity": "sha512-G4sahkT4WQoCtCww0ve9GyQ+QVji7qd+6TOsuMI3iFaYgyYGIKKV4Yjx/KEOZEYKRY8BuZH6AKZpjrmu75CBxg==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/logger": "3.1.11",
+				"@php-wasm/node": "3.1.11",
+				"@php-wasm/universal": "3.1.11",
+				"@php-wasm/util": "3.1.11",
+				"@wp-playground/common": "3.1.11",
+				"express": "4.22.0",
+				"fast-xml-parser": "^5.5.1",
+				"fs-ext-extra-prebuilt": "2.2.7",
+				"ini": "4.1.2",
+				"jsonc-parser": "3.3.1",
 				"wasm-feature-detect": "1.8.0",
 				"ws": "8.18.3",
 				"yargs": "17.7.2"
@@ -11261,18 +12824,19 @@
 			}
 		},
 		"node_modules/@wp-playground/wordpress": {
-			"version": "3.1.11",
-			"resolved": "https://registry.npmjs.org/@wp-playground/wordpress/-/wordpress-3.1.11.tgz",
-			"integrity": "sha512-G4sahkT4WQoCtCww0ve9GyQ+QVji7qd+6TOsuMI3iFaYgyYGIKKV4Yjx/KEOZEYKRY8BuZH6AKZpjrmu75CBxg==",
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/@wp-playground/wordpress/-/wordpress-3.1.5.tgz",
+			"integrity": "sha512-knqsGwmsc1UMCpcsXhtLf7rlRws7tXMU47R5TN4/mXwu881lwNqw7GRnur6jB0w/fV6XBi6hrIqpKlHVymHppQ==",
+			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/logger": "3.1.11",
-				"@php-wasm/node": "3.1.11",
-				"@php-wasm/universal": "3.1.11",
-				"@php-wasm/util": "3.1.11",
-				"@wp-playground/common": "3.1.11",
+				"@php-wasm/logger": "3.1.5",
+				"@php-wasm/node": "3.1.5",
+				"@php-wasm/universal": "3.1.5",
+				"@php-wasm/util": "3.1.5",
+				"@wp-playground/common": "3.1.5",
 				"express": "4.22.0",
-				"fast-xml-parser": "^5.5.1",
+				"fast-xml-parser": "^5.3.4",
 				"fs-ext-extra-prebuilt": "2.2.7",
 				"ini": "4.1.2",
 				"jsonc-parser": "3.3.1",
@@ -11289,6 +12853,7 @@
 			"version": "8.0.1",
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
 			"integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"string-width": "^4.2.0",
@@ -11303,6 +12868,7 @@
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
 			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
+			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -11312,6 +12878,7 @@
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
 			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ansi-regex": "^5.0.1"
@@ -11324,6 +12891,7 @@
 			"version": "17.7.2",
 			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
 			"integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"cliui": "^8.0.1",
@@ -11342,6 +12910,7 @@
 			"version": "21.1.1",
 			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
 			"integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": ">=12"
@@ -16003,9 +17572,9 @@
 			}
 		},
 		"node_modules/fast-xml-builder": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.3.tgz",
-			"integrity": "sha512-1o60KoFw2+LWKQu3IdcfcFlGTW4dpqEWmjhYec6H82AYZU2TVBXep6tMl8Z1Y+wM+ZrzCwe3BZ9Vyd9N2rIvmg==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.2.tgz",
+			"integrity": "sha512-NJAmiuVaJEjVa7TjLZKlYd7RqmzOC91EtPFXHvlTcqBVo50Qh7XV5IwvXi1c7NRz2Q/majGX9YLcwJtWgHjtkA==",
 			"funding": [
 				{
 					"type": "github",
@@ -16018,9 +17587,9 @@
 			}
 		},
 		"node_modules/fast-xml-parser": {
-			"version": "5.5.4",
-			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.4.tgz",
-			"integrity": "sha512-Af+qOX93cedUddGag8E54wEuVojVgPE/LS9rpRoJNcnRxImttjCoGnBzpphOym8Vu+xSbXNTtBzx7FOodYFyzQ==",
+			"version": "5.5.3",
+			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.3.tgz",
+			"integrity": "sha512-Ymnuefk6VzAhT3SxLzVUw+nMio/wB1NGypHkgetwtXcK1JfryaHk4DWQFGVwQ9XgzyS5iRZ7C2ZGI4AMsdMZ6A==",
 			"funding": [
 				{
 					"type": "github",
@@ -16029,7 +17598,7 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"fast-xml-builder": "^1.1.3",
+				"fast-xml-builder": "^1.1.2",
 				"path-expression-matcher": "^1.1.3",
 				"strnum": "^2.1.2"
 			},
@@ -20927,6 +22496,7 @@
 		},
 		"node_modules/pako": {
 			"version": "1.0.11",
+			"dev": true,
 			"license": "(MIT AND Zlib)"
 		},
 		"node_modules/param-case": {
@@ -22923,9 +24493,9 @@
 			"license": "MIT"
 		},
 		"node_modules/sax": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/sax/-/sax-1.5.0.tgz",
-			"integrity": "sha512-21IYA3Q5cQf089Z6tgaUTr7lDAyzoTPx5HRtbhsME8Udispad8dC/+sziTNugOEx54ilvatQ9YCzl4KQLPcRHA==",
+			"version": "1.4.4",
+			"resolved": "https://registry.npmjs.org/sax/-/sax-1.4.4.tgz",
+			"integrity": "sha512-1n3r/tGXO6b6VXMdFT54SHzT9ytu9yr7TaELowdYpMqY/Ao7EnlQGmAQ1+RatX7Tkkdm6hONI2owqNx2aZj5Sw==",
 			"license": "BlueOak-1.0.0",
 			"engines": {
 				"node": ">=11.0.0"
@@ -26839,12 +28409,10 @@
 				"@wp-playground/cli": "3.1.11",
 				"chalk": "^5.3.0",
 				"playwright": "^1.58.1",
-				"ts-node": "^10.9.2",
-				"yargs": "^17.7.2"
+				"ts-node": "^10.9.2"
 			},
 			"devDependencies": {
 				"@types/node": "^25.3.5",
-				"@types/yargs": "^17.0.33",
 				"typescript": "^5.0.0"
 			}
 		},
@@ -26858,65 +28426,12 @@
 				"undici-types": "~7.18.0"
 			}
 		},
-		"tools/benchmark-site-editor/node_modules/cliui": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-			"integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-			"license": "ISC",
-			"dependencies": {
-				"string-width": "^4.2.0",
-				"strip-ansi": "^6.0.1",
-				"wrap-ansi": "^7.0.0"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"tools/benchmark-site-editor/node_modules/strip-ansi": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^5.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"tools/benchmark-site-editor/node_modules/undici-types": {
 			"version": "7.18.2",
 			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
 			"integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"tools/benchmark-site-editor/node_modules/yargs": {
-			"version": "17.7.2",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-			"integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-			"license": "MIT",
-			"dependencies": {
-				"cliui": "^8.0.1",
-				"escalade": "^3.1.1",
-				"get-caller-file": "^2.0.5",
-				"require-directory": "^2.1.1",
-				"string-width": "^4.2.3",
-				"y18n": "^5.0.5",
-				"yargs-parser": "^21.1.1"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"tools/benchmark-site-editor/node_modules/yargs-parser": {
-			"version": "21.1.1",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-			"integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-			"license": "ISC",
-			"engines": {
-				"node": ">=12"
-			}
 		},
 		"tools/common": {
 			"name": "@studio/common",
@@ -26938,7 +28453,7 @@
 				"@types/fs-extra": "^11.0.4",
 				"@types/lockfile": "^1.0.4",
 				"@types/yauzl": "^2.10.3",
-				"@wp-playground/blueprints": "3.1.11"
+				"@wp-playground/blueprints": "3.1.5"
 			}
 		},
 		"tools/compare-perf": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "studio",
-	"version": "1.7.4",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
@@ -82,533 +81,9 @@
 				"vite-plugin-static-copy": "^3.1.5"
 			}
 		},
-		"apps/cli/node_modules/@php-wasm/cli-util": {
-			"version": "3.1.11",
-			"resolved": "https://registry.npmjs.org/@php-wasm/cli-util/-/cli-util-3.1.11.tgz",
-			"integrity": "sha512-/v/S007ZZfTmDyYOReKtUnhiOWZi1EZdLrDiSPCmYms3XFNeJDUBWEkDshcwMxuDaA4Ce2ciF0QsM+yuY9vY9g==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/util": "3.1.11",
-				"fast-xml-parser": "^5.5.1",
-				"jsonc-parser": "3.3.1"
-			},
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
-		"apps/cli/node_modules/@php-wasm/logger": {
-			"version": "3.1.11",
-			"resolved": "https://registry.npmjs.org/@php-wasm/logger/-/logger-3.1.11.tgz",
-			"integrity": "sha512-wGKmMpA8gvoLFEjG9jzm7E2BEAaq4LU9yMjMkzKwYE0RUivV1000Cnw+m+79/d4Bua0ouoCLab5+IFFJrfxYpw==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/node-polyfills": "3.1.11"
-			},
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
-		"apps/cli/node_modules/@php-wasm/node": {
-			"version": "3.1.11",
-			"resolved": "https://registry.npmjs.org/@php-wasm/node/-/node-3.1.11.tgz",
-			"integrity": "sha512-qqJuQMm/Ey4Cv2h6F6q7Rj33KMo5z+33s2CABwRnS7fgzGBSQzB7vq4L2pScqVmvfRXnW1lFoUgFARojOOThkA==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/cli-util": "3.1.11",
-				"@php-wasm/logger": "3.1.11",
-				"@php-wasm/node-7-4": "3.1.11",
-				"@php-wasm/node-8-0": "3.1.11",
-				"@php-wasm/node-8-1": "3.1.11",
-				"@php-wasm/node-8-2": "3.1.11",
-				"@php-wasm/node-8-3": "3.1.11",
-				"@php-wasm/node-8-4": "3.1.11",
-				"@php-wasm/node-8-5": "3.1.11",
-				"@php-wasm/node-polyfills": "3.1.11",
-				"@php-wasm/universal": "3.1.11",
-				"@php-wasm/util": "3.1.11",
-				"@wp-playground/common": "3.1.11",
-				"express": "4.22.0",
-				"fast-xml-parser": "^5.5.1",
-				"fs-ext-extra-prebuilt": "2.2.7",
-				"ini": "4.1.2",
-				"jsonc-parser": "3.3.1",
-				"wasm-feature-detect": "1.8.0",
-				"ws": "8.18.3",
-				"yargs": "17.7.2"
-			},
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
-		"apps/cli/node_modules/@php-wasm/node-7-4": {
-			"version": "3.1.11",
-			"resolved": "https://registry.npmjs.org/@php-wasm/node-7-4/-/node-7-4-3.1.11.tgz",
-			"integrity": "sha512-WGX0nOv6JsTXY+I0FqAB8wQLeQc8pAYbUg4LXEQnACZWPL9mdAvwk++XkScWQ5zfwUtrTq9TwpAXcyf3xRrIxQ==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/universal": "3.1.11",
-				"ini": "4.1.2",
-				"wasm-feature-detect": "1.8.0",
-				"ws": "8.18.3"
-			},
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
-		"apps/cli/node_modules/@php-wasm/node-8-0": {
-			"version": "3.1.11",
-			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-0/-/node-8-0-3.1.11.tgz",
-			"integrity": "sha512-92E8kydq6RmxYnFGXGTursqT/8doRND8fQoqerj4uJ4oMtPIBXREyBMAye4/ss3ls9IXSRbZKYQ03NptozcYfA==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/universal": "3.1.11",
-				"ini": "4.1.2",
-				"wasm-feature-detect": "1.8.0",
-				"ws": "8.18.3"
-			},
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
-		"apps/cli/node_modules/@php-wasm/node-8-1": {
-			"version": "3.1.11",
-			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-1/-/node-8-1-3.1.11.tgz",
-			"integrity": "sha512-fP7OWc0V7Hs1AEcr0cP8d49twJLSDwdHUyFwTuD7uPY+u9KrPW8ZrhR8+j2pmPrU0qMO5x+oPP1u8MFgNpWHOQ==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/universal": "3.1.11",
-				"ini": "4.1.2",
-				"wasm-feature-detect": "1.8.0",
-				"ws": "8.18.3"
-			},
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
-		"apps/cli/node_modules/@php-wasm/node-8-2": {
-			"version": "3.1.11",
-			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-2/-/node-8-2-3.1.11.tgz",
-			"integrity": "sha512-T72JABgcbo6OujFaVfKb+eJpgZgcTK5vmUoNDWZFvu7NvH9wSRkmnlas+HcqO2inEja0BvQbz7WWcDHUTj9rPQ==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/universal": "3.1.11",
-				"ini": "4.1.2",
-				"wasm-feature-detect": "1.8.0",
-				"ws": "8.18.3"
-			},
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
-		"apps/cli/node_modules/@php-wasm/node-8-3": {
-			"version": "3.1.11",
-			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-3/-/node-8-3-3.1.11.tgz",
-			"integrity": "sha512-KFOVw3E0ThCGN6pmdS16FIgHzbAVNLVrV4QkCvKmvPENMfKLOaJAwC3jN8qK4eE/j5jWqAZIQPsOPwVKkHziDw==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/universal": "3.1.11",
-				"ini": "4.1.2",
-				"wasm-feature-detect": "1.8.0",
-				"ws": "8.18.3"
-			},
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
-		"apps/cli/node_modules/@php-wasm/node-8-4": {
-			"version": "3.1.11",
-			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-4/-/node-8-4-3.1.11.tgz",
-			"integrity": "sha512-fSKp8C+rcORGHBQJRtrFkNfTmIsjtfMcuT81jWIs71zG2v1C0yIfEPdpRqHv6UVJVFToUb1ClEGY+dfqO9mXYA==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/universal": "3.1.11",
-				"ini": "4.1.2",
-				"wasm-feature-detect": "1.8.0",
-				"ws": "8.18.3"
-			},
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
-		"apps/cli/node_modules/@php-wasm/node-8-5": {
-			"version": "3.1.11",
-			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-5/-/node-8-5-3.1.11.tgz",
-			"integrity": "sha512-ystaL0/ab7GyQCReNFWpC2LPKa3u2gUXlMi0g/2CZDD4kavnzksuI/jAHhwnmTnZePbEam23rvdyq77ndC1TFw==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/universal": "3.1.11",
-				"ini": "4.1.2",
-				"wasm-feature-detect": "1.8.0",
-				"ws": "8.18.3"
-			},
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
-		"apps/cli/node_modules/@php-wasm/node-polyfills": {
-			"version": "3.1.11",
-			"resolved": "https://registry.npmjs.org/@php-wasm/node-polyfills/-/node-polyfills-3.1.11.tgz",
-			"integrity": "sha512-Gu3wS1gWkyGSW/K+RQNT4OfjeapeYdL5bqOQ+/MEfvkaeMRDdzdOvmPcIfLbDBhZOSh6jAA7nT87Ri2LmeqYzQ==",
-			"license": "GPL-2.0-or-later"
-		},
-		"apps/cli/node_modules/@php-wasm/node/node_modules/yargs": {
-			"version": "17.7.2",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-			"integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-			"license": "MIT",
-			"dependencies": {
-				"cliui": "^8.0.1",
-				"escalade": "^3.1.1",
-				"get-caller-file": "^2.0.5",
-				"require-directory": "^2.1.1",
-				"string-width": "^4.2.3",
-				"y18n": "^5.0.5",
-				"yargs-parser": "^21.1.1"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"apps/cli/node_modules/@php-wasm/node/node_modules/yargs-parser": {
-			"version": "21.1.1",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-			"integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-			"license": "ISC",
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"apps/cli/node_modules/@php-wasm/progress": {
-			"version": "3.1.11",
-			"resolved": "https://registry.npmjs.org/@php-wasm/progress/-/progress-3.1.11.tgz",
-			"integrity": "sha512-/zsH+ZvBxq+Qlb2ffNvvjmiqaB6Fwo8+O3Py+WUznxIuQ/3Ckci+5cWyBtYQ6qtAGFSRADl41Qg9n6RmWBUL7w==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/logger": "3.1.11",
-				"@php-wasm/node-polyfills": "3.1.11"
-			},
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
-		"apps/cli/node_modules/@php-wasm/scopes": {
-			"version": "3.1.11",
-			"resolved": "https://registry.npmjs.org/@php-wasm/scopes/-/scopes-3.1.11.tgz",
-			"integrity": "sha512-WyI1PHYA4vHmb2DHO6M2e8ydY1brfMRjRf1Z5FYhfyh7G2FEAJbOyoY/VenBOCw0dE04vkWU4LRuVwkFrO8+Ow==",
-			"license": "GPL-2.0-or-later",
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
-		"apps/cli/node_modules/@php-wasm/stream-compression": {
-			"version": "3.1.11",
-			"resolved": "https://registry.npmjs.org/@php-wasm/stream-compression/-/stream-compression-3.1.11.tgz",
-			"integrity": "sha512-R9wfu3Zx083m8WTlWN888iZ9ub2nhZXGi5LVjfIQCd2UPuRbhFuOHiiyvnoHnZFyMZnzI12/MhuoPHuWv6NPew==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/node-polyfills": "3.1.11",
-				"@php-wasm/util": "3.1.11"
-			}
-		},
-		"apps/cli/node_modules/@php-wasm/universal": {
-			"version": "3.1.11",
-			"resolved": "https://registry.npmjs.org/@php-wasm/universal/-/universal-3.1.11.tgz",
-			"integrity": "sha512-n+fGHL9wqLf6NBWsPdDbF7USY20FBZgBIJvUoi620xNQdakhZ425tCM7bEVBE+lcOY6/l4rFCIdSbY+HoJwg7w==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/logger": "3.1.11",
-				"@php-wasm/node-polyfills": "3.1.11",
-				"@php-wasm/progress": "3.1.11",
-				"@php-wasm/stream-compression": "3.1.11",
-				"@php-wasm/util": "3.1.11",
-				"ini": "4.1.2"
-			},
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
-		"apps/cli/node_modules/@php-wasm/util": {
-			"version": "3.1.11",
-			"resolved": "https://registry.npmjs.org/@php-wasm/util/-/util-3.1.11.tgz",
-			"integrity": "sha512-9n/s609DDF03+M4DWbvf+BCaHGAGt56xOxceV91mQA1X0c+iLgBCYG2oLgOvs1Cl+anYxiVbsLUZBfjAxKLcbQ==",
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
-		"apps/cli/node_modules/@php-wasm/web-service-worker": {
-			"version": "3.1.11",
-			"resolved": "https://registry.npmjs.org/@php-wasm/web-service-worker/-/web-service-worker-3.1.11.tgz",
-			"integrity": "sha512-8qCh2Y5ZrLw1EP+s5iYCBE4HnBcB0HjudGPNLs2azYRZHOo5C3Xjc+VI5BDdfyLEZl3AOg5y6dE0dk2ur2WCeg==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/scopes": "3.1.11",
-				"@php-wasm/universal": "3.1.11",
-				"ini": "4.1.2"
-			},
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
-		"apps/cli/node_modules/@wp-playground/blueprints": {
-			"version": "3.1.11",
-			"resolved": "https://registry.npmjs.org/@wp-playground/blueprints/-/blueprints-3.1.11.tgz",
-			"integrity": "sha512-9YeNYIKR+/LvWPnC38sorT9XJkMBz1B/Rb71kDQ5HemS8OvueyTofBc763kjQP3bumC5nr+38nMyXTNUkDuayQ==",
-			"dependencies": {
-				"@php-wasm/logger": "3.1.11",
-				"@php-wasm/node": "3.1.11",
-				"@php-wasm/node-polyfills": "3.1.11",
-				"@php-wasm/progress": "3.1.11",
-				"@php-wasm/scopes": "3.1.11",
-				"@php-wasm/stream-compression": "3.1.11",
-				"@php-wasm/universal": "3.1.11",
-				"@php-wasm/util": "3.1.11",
-				"@php-wasm/web-service-worker": "3.1.11",
-				"@wp-playground/common": "3.1.11",
-				"@wp-playground/storage": "3.1.11",
-				"@wp-playground/wordpress": "3.1.11",
-				"@zip.js/zip.js": "2.7.57",
-				"ajv": "8.12.0",
-				"async-lock": "1.4.1",
-				"clean-git-ref": "2.0.1",
-				"crc-32": "1.2.2",
-				"diff3": "0.0.4",
-				"express": "4.22.0",
-				"fast-xml-parser": "^5.5.1",
-				"fs-ext-extra-prebuilt": "2.2.7",
-				"ignore": "5.3.2",
-				"ini": "4.1.2",
-				"jsonc-parser": "3.3.1",
-				"minimisted": "2.0.1",
-				"octokit": "3.1.2",
-				"pako": "1.0.10",
-				"pify": "2.3.0",
-				"readable-stream": "3.6.2",
-				"sha.js": "2.4.12",
-				"simple-get": "4.0.1",
-				"wasm-feature-detect": "1.8.0",
-				"ws": "8.18.3",
-				"yargs": "17.7.2"
-			},
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
-		"apps/cli/node_modules/@wp-playground/blueprints/node_modules/yargs": {
-			"version": "17.7.2",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-			"integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-			"license": "MIT",
-			"dependencies": {
-				"cliui": "^8.0.1",
-				"escalade": "^3.1.1",
-				"get-caller-file": "^2.0.5",
-				"require-directory": "^2.1.1",
-				"string-width": "^4.2.3",
-				"y18n": "^5.0.5",
-				"yargs-parser": "^21.1.1"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"apps/cli/node_modules/@wp-playground/blueprints/node_modules/yargs-parser": {
-			"version": "21.1.1",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-			"integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-			"license": "ISC",
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"apps/cli/node_modules/@wp-playground/common": {
-			"version": "3.1.11",
-			"resolved": "https://registry.npmjs.org/@wp-playground/common/-/common-3.1.11.tgz",
-			"integrity": "sha512-1/5yts2ExzfVxHqK4oz9dr9Jxeuh99zhAO5ClH3zROo/7gRXKWHZWoQXNLZnPJ3RlMqYzIzHzmozhyx29rtizQ==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/universal": "3.1.11",
-				"@php-wasm/util": "3.1.11",
-				"ini": "4.1.2"
-			},
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
-		"apps/cli/node_modules/@wp-playground/storage": {
-			"version": "3.1.11",
-			"resolved": "https://registry.npmjs.org/@wp-playground/storage/-/storage-3.1.11.tgz",
-			"integrity": "sha512-OxDlLInbRzpceMYO2CVm3hYb1MnZqJZfr444+l3QhOJEqOo6n3WAwb/8MxRbqmfokkKGbO3YGnGQrF6u+RNhWQ==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/stream-compression": "3.1.11",
-				"@php-wasm/universal": "3.1.11",
-				"@php-wasm/util": "3.1.11",
-				"@zip.js/zip.js": "2.7.57",
-				"async-lock": "^1.4.1",
-				"clean-git-ref": "^2.0.1",
-				"crc-32": "^1.2.0",
-				"diff3": "0.0.3",
-				"ignore": "^5.1.4",
-				"ini": "4.1.2",
-				"minimisted": "^2.0.0",
-				"octokit": "3.1.2",
-				"pako": "^1.0.10",
-				"pify": "^4.0.1",
-				"readable-stream": "^3.4.0",
-				"sha.js": "^2.4.9",
-				"simple-get": "^4.0.1"
-			}
-		},
-		"apps/cli/node_modules/@wp-playground/storage/node_modules/diff3": {
-			"version": "0.0.3",
-			"resolved": "https://registry.npmjs.org/diff3/-/diff3-0.0.3.tgz",
-			"integrity": "sha512-iSq8ngPOt0K53A6eVr4d5Kn6GNrM2nQZtC740pzIriHtn4pOQ2lyzEXQMBeVcWERN0ye7fhBsk9PbLLQOnUx/g==",
-			"license": "MIT"
-		},
-		"apps/cli/node_modules/@wp-playground/storage/node_modules/pify": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-			"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"apps/cli/node_modules/@wp-playground/wordpress": {
-			"version": "3.1.11",
-			"resolved": "https://registry.npmjs.org/@wp-playground/wordpress/-/wordpress-3.1.11.tgz",
-			"integrity": "sha512-G4sahkT4WQoCtCww0ve9GyQ+QVji7qd+6TOsuMI3iFaYgyYGIKKV4Yjx/KEOZEYKRY8BuZH6AKZpjrmu75CBxg==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/logger": "3.1.11",
-				"@php-wasm/node": "3.1.11",
-				"@php-wasm/universal": "3.1.11",
-				"@php-wasm/util": "3.1.11",
-				"@wp-playground/common": "3.1.11",
-				"express": "4.22.0",
-				"fast-xml-parser": "^5.5.1",
-				"fs-ext-extra-prebuilt": "2.2.7",
-				"ini": "4.1.2",
-				"jsonc-parser": "3.3.1",
-				"wasm-feature-detect": "1.8.0",
-				"ws": "8.18.3",
-				"yargs": "17.7.2"
-			},
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
-		"apps/cli/node_modules/@wp-playground/wordpress/node_modules/yargs": {
-			"version": "17.7.2",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-			"integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-			"license": "MIT",
-			"dependencies": {
-				"cliui": "^8.0.1",
-				"escalade": "^3.1.1",
-				"get-caller-file": "^2.0.5",
-				"require-directory": "^2.1.1",
-				"string-width": "^4.2.3",
-				"y18n": "^5.0.5",
-				"yargs-parser": "^21.1.1"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"apps/cli/node_modules/@wp-playground/wordpress/node_modules/yargs-parser": {
-			"version": "21.1.1",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-			"integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-			"license": "ISC",
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"apps/cli/node_modules/ajv": {
-			"version": "8.12.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-			"integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-			"license": "MIT",
-			"dependencies": {
-				"fast-deep-equal": "^3.1.1",
-				"json-schema-traverse": "^1.0.0",
-				"require-from-string": "^2.0.2",
-				"uri-js": "^4.2.2"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/epoberezkin"
-			}
-		},
-		"apps/cli/node_modules/cliui": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-			"integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-			"license": "ISC",
-			"dependencies": {
-				"string-width": "^4.2.0",
-				"strip-ansi": "^6.0.1",
-				"wrap-ansi": "^7.0.0"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"apps/cli/node_modules/ini": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
-			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
-			"license": "ISC",
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"apps/cli/node_modules/json-schema-traverse": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-			"license": "MIT"
-		},
-		"apps/cli/node_modules/pako": {
-			"version": "1.0.10",
-			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.10.tgz",
-			"integrity": "sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw==",
-			"license": "(MIT AND Zlib)"
-		},
-		"apps/cli/node_modules/strip-ansi": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^5.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"apps/studio": {
 			"name": "studio-app",
-			"version": "1.7.5",
+			"version": "1.7.6-beta2",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@automattic/generate-password": "^0.1.0",
@@ -684,7 +159,7 @@
 				"@types/winreg": "^1.2.36",
 				"@types/yauzl": "^2.10.3",
 				"@vitejs/plugin-react": "^5.1.4",
-				"@wp-playground/blueprints": "3.1.5",
+				"@wp-playground/blueprints": "3.1.11",
 				"electron": "^40.8.0",
 				"electron-devtools-installer": "^4.0.0",
 				"electron-vite": "^5.0.0",
@@ -706,8 +181,6 @@
 		},
 		"apps/studio/node_modules/@inquirer/ansi": {
 			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.3.tgz",
-			"integrity": "sha512-g44zhR3NIKVs0zUesa4iMzExmZpLUdTLRMCStqX3GE5NT6VkPcxQGJ+uC8tDgBUC/vB1rUhUd55cOf++4NZcmw==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
@@ -715,8 +188,6 @@
 		},
 		"apps/studio/node_modules/@inquirer/checkbox": {
 			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.1.0.tgz",
-			"integrity": "sha512-/HjF1LN0a1h4/OFsbGKHNDtWICFU/dqXCdym719HFTyJo9IG7Otr+ziGWc9S0iQuohRZllh+WprSgd5UW5Fw0g==",
 			"license": "MIT",
 			"dependencies": {
 				"@inquirer/ansi": "^2.0.3",
@@ -738,8 +209,6 @@
 		},
 		"apps/studio/node_modules/@inquirer/confirm": {
 			"version": "6.0.8",
-			"resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.0.8.tgz",
-			"integrity": "sha512-Di6dgmiZ9xCSUxWUReWTqDtbhXCuG2MQm2xmgSAIruzQzBqNf49b8E07/vbCYY506kDe8BiwJbegXweG8M1klw==",
 			"license": "MIT",
 			"dependencies": {
 				"@inquirer/core": "^11.1.5",
@@ -759,8 +228,6 @@
 		},
 		"apps/studio/node_modules/@inquirer/core": {
 			"version": "11.1.5",
-			"resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.1.5.tgz",
-			"integrity": "sha512-QQPAX+lka8GyLcZ7u7Nb1h6q72iZ/oy0blilC3IB2nSt1Qqxp7akt94Jqhi/DzARuN3Eo9QwJRvtl4tmVe4T5A==",
 			"license": "MIT",
 			"dependencies": {
 				"@inquirer/ansi": "^2.0.3",
@@ -785,8 +252,6 @@
 		},
 		"apps/studio/node_modules/@inquirer/editor": {
 			"version": "5.0.8",
-			"resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.0.8.tgz",
-			"integrity": "sha512-sLcpbb9B3XqUEGrj1N66KwhDhEckzZ4nI/W6SvLXyBX8Wic3LDLENlWRvkOGpCPoserabe+MxQkpiMoI8irvyA==",
 			"license": "MIT",
 			"dependencies": {
 				"@inquirer/core": "^11.1.5",
@@ -807,8 +272,6 @@
 		},
 		"apps/studio/node_modules/@inquirer/expand": {
 			"version": "5.0.8",
-			"resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.0.8.tgz",
-			"integrity": "sha512-QieW3F1prNw3j+hxO7/NKkG1pk3oz7pOB6+5Upwu3OIwADfPX0oZVppsqlL+Vl/uBHHDSOBY0BirLctLnXwGGg==",
 			"license": "MIT",
 			"dependencies": {
 				"@inquirer/core": "^11.1.5",
@@ -828,8 +291,6 @@
 		},
 		"apps/studio/node_modules/@inquirer/external-editor": {
 			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-2.0.3.tgz",
-			"integrity": "sha512-LgyI7Agbda74/cL5MvA88iDpvdXI2KuMBCGRkbCl2Dg1vzHeOgs+s0SDcXV7b+WZJrv2+ERpWSM65Fpi9VfY3w==",
 			"license": "MIT",
 			"dependencies": {
 				"chardet": "^2.1.1",
@@ -849,8 +310,6 @@
 		},
 		"apps/studio/node_modules/@inquirer/figures": {
 			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.3.tgz",
-			"integrity": "sha512-y09iGt3JKoOCBQ3w4YrSJdokcD8ciSlMIWsD+auPu+OZpfxLuyz+gICAQ6GCBOmJJt4KEQGHuZSVff2jiNOy7g==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
@@ -858,8 +317,6 @@
 		},
 		"apps/studio/node_modules/@inquirer/input": {
 			"version": "5.0.8",
-			"resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.0.8.tgz",
-			"integrity": "sha512-p0IJslw0AmedLEkOU+yrEX3Aj2RTpQq7ZOf8nc1DIhjzaxRWrrgeuE5Kyh39fVRgtcACaMXx/9WNo8+GjgBOfw==",
 			"license": "MIT",
 			"dependencies": {
 				"@inquirer/core": "^11.1.5",
@@ -879,8 +336,6 @@
 		},
 		"apps/studio/node_modules/@inquirer/number": {
 			"version": "4.0.8",
-			"resolved": "https://registry.npmjs.org/@inquirer/number/-/number-4.0.8.tgz",
-			"integrity": "sha512-uGLiQah9A0F9UIvJBX52m0CnqtLaym0WpT9V4YZrjZ+YRDKZdwwoEPz06N6w8ChE2lrnsdyhY9sL+Y690Kh9gQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@inquirer/core": "^11.1.5",
@@ -900,8 +355,6 @@
 		},
 		"apps/studio/node_modules/@inquirer/password": {
 			"version": "5.0.8",
-			"resolved": "https://registry.npmjs.org/@inquirer/password/-/password-5.0.8.tgz",
-			"integrity": "sha512-zt1sF4lYLdvPqvmvHdmjOzuUUjuCQ897pdUCO8RbXMUDKXJTTyOQgtn23le+jwcb+MpHl3VAFvzIdxRAf6aPlA==",
 			"license": "MIT",
 			"dependencies": {
 				"@inquirer/ansi": "^2.0.3",
@@ -922,8 +375,6 @@
 		},
 		"apps/studio/node_modules/@inquirer/prompts": {
 			"version": "8.3.0",
-			"resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.3.0.tgz",
-			"integrity": "sha512-JAj66kjdH/F1+B7LCigjARbwstt3SNUOSzMdjpsvwJmzunK88gJeXmcm95L9nw1KynvFVuY4SzXh/3Y0lvtgSg==",
 			"license": "MIT",
 			"dependencies": {
 				"@inquirer/checkbox": "^5.1.0",
@@ -951,8 +402,6 @@
 		},
 		"apps/studio/node_modules/@inquirer/rawlist": {
 			"version": "5.2.4",
-			"resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.2.4.tgz",
-			"integrity": "sha512-fTuJ5Cq9W286isLxwj6GGyfTjx1Zdk4qppVEPexFuA6yioCCXS4V1zfKroQqw7QdbDPN73xs2DiIAlo55+kBqg==",
 			"license": "MIT",
 			"dependencies": {
 				"@inquirer/core": "^11.1.5",
@@ -972,8 +421,6 @@
 		},
 		"apps/studio/node_modules/@inquirer/search": {
 			"version": "4.1.4",
-			"resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.1.4.tgz",
-			"integrity": "sha512-9yPTxq7LPmYjrGn3DRuaPuPbmC6u3fiWcsE9ggfLcdgO/ICHYgxq7mEy1yJ39brVvgXhtOtvDVjDh9slJxE4LQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@inquirer/core": "^11.1.5",
@@ -994,8 +441,6 @@
 		},
 		"apps/studio/node_modules/@inquirer/select": {
 			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.1.0.tgz",
-			"integrity": "sha512-OyYbKnchS1u+zRe14LpYrN8S0wH1vD0p2yKISvSsJdH2TpI87fh4eZdWnpdbrGauCRWDph3NwxRmM4Pcm/hx1Q==",
 			"license": "MIT",
 			"dependencies": {
 				"@inquirer/ansi": "^2.0.3",
@@ -1017,8 +462,6 @@
 		},
 		"apps/studio/node_modules/@inquirer/type": {
 			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.3.tgz",
-			"integrity": "sha512-cKZN7qcXOpj1h+1eTTcGDVLaBIHNMT1Rz9JqJP5MnEJ0JhgVWllx7H/tahUp5YEK1qaByH2Itb8wLG/iScD5kw==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
@@ -1034,8 +477,6 @@
 		},
 		"apps/studio/node_modules/@wordpress/dataviews": {
 			"version": "13.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/dataviews/-/dataviews-13.0.0.tgz",
-			"integrity": "sha512-E1Xp2VOQD2xtoz83tBVaXFd0OV5liaVlK1mDIcLSn54fGMtsyirR31hFHmrCm3vdspWPOKQh5QFdpkc2b0kCiQ==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@ariakit/react": "^0.4.21",
@@ -1071,8 +512,6 @@
 		},
 		"apps/studio/node_modules/@wordpress/dataviews/node_modules/date-fns": {
 			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
-			"integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
 			"license": "MIT",
 			"funding": {
 				"type": "github",
@@ -1081,8 +520,6 @@
 		},
 		"apps/studio/node_modules/@wordpress/theme": {
 			"version": "0.8.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/theme/-/theme-0.8.0.tgz",
-			"integrity": "sha512-xXGjWNFHICBuMNfjCjTui5ChkiKmmPTJtsF5tPXnUBXJaw43xxGlL0y7lpCNPJQxz+NPMJ01KlGfxhRsHXjKrQ==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/element": "^6.41.0",
@@ -1107,8 +544,6 @@
 		},
 		"apps/studio/node_modules/@wordpress/ui": {
 			"version": "0.8.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/ui/-/ui-0.8.0.tgz",
-			"integrity": "sha512-tAlCQ3uO+rnqPwVFzPEmSUqyADk3Gp0KnnSrYGzBadjEx474hattHsLkyhGHi+DD5Txx94b582gDcL9w9siHVQ==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@base-ui/react": "^1.2.0",
@@ -1134,14 +569,10 @@
 		},
 		"apps/studio/node_modules/chardet": {
 			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz",
-			"integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
 			"license": "MIT"
 		},
 		"apps/studio/node_modules/cli-width": {
 			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
-			"integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
 			"license": "ISC",
 			"engines": {
 				"node": ">= 12"
@@ -1149,8 +580,6 @@
 		},
 		"apps/studio/node_modules/iconv-lite": {
 			"version": "0.7.2",
-			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
-			"integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
 			"license": "MIT",
 			"dependencies": {
 				"safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -1165,8 +594,6 @@
 		},
 		"apps/studio/node_modules/mute-stream": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-3.0.0.tgz",
-			"integrity": "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==",
 			"license": "ISC",
 			"engines": {
 				"node": "^20.17.0 || >=22.9.0"
@@ -1174,8 +601,6 @@
 		},
 		"apps/studio/node_modules/signal-exit": {
 			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
 			"license": "ISC",
 			"engines": {
 				"node": ">=14"
@@ -1202,8 +627,6 @@
 		},
 		"node_modules/@anthropic-ai/claude-agent-sdk": {
 			"version": "0.2.45",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.45.tgz",
-			"integrity": "sha512-AKH2hKoJNyjLf9ThAttKqbmCjUFg7qs/8+LR/UTVX20fCLn359YH9WrQc6dAiAfi8RYNA+mWwrNYCAq+Sdo5Ag==",
 			"license": "SEE LICENSE IN README.md",
 			"engines": {
 				"node": ">=18.0.0"
@@ -1224,14 +647,10 @@
 		},
 		"node_modules/@ariakit/core": {
 			"version": "0.4.18",
-			"resolved": "https://registry.npmjs.org/@ariakit/core/-/core-0.4.18.tgz",
-			"integrity": "sha512-9urEa+GbZTSyredq3B/3thQjTcSZSUC68XctwCkJNH/xNfKN5O+VThiem2rcJxpsGw8sRUQenhagZi0yB4foyg==",
 			"license": "MIT"
 		},
 		"node_modules/@ariakit/react": {
 			"version": "0.4.21",
-			"resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.21.tgz",
-			"integrity": "sha512-UjP99Y7cWxA5seRECEE0RPZFImkLGFIWPflp65t0BVZwlMw4wp9OJZRHMrnkEkKl5KBE2NR/gbbzwHc6VNGzsA==",
 			"license": "MIT",
 			"dependencies": {
 				"@ariakit/react-core": "0.4.21"
@@ -1247,8 +666,6 @@
 		},
 		"node_modules/@ariakit/react-core": {
 			"version": "0.4.21",
-			"resolved": "https://registry.npmjs.org/@ariakit/react-core/-/react-core-0.4.21.tgz",
-			"integrity": "sha512-rUI9uB/gT3mROFja/ka7/JukkdljIZR3eq3BGiQqX4Ni/KBMDvPK8FvVLnC0TGzWcqNY2bbfve8QllvHzuw4fQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@ariakit/core": "0.4.18",
@@ -1474,8 +891,6 @@
 		},
 		"node_modules/@babel/code-frame": {
 			"version": "7.29.0",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-			"integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/helper-validator-identifier": "^7.28.5",
@@ -1488,8 +903,6 @@
 		},
 		"node_modules/@babel/compat-data": {
 			"version": "7.29.0",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
-			"integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -1498,8 +911,6 @@
 		},
 		"node_modules/@babel/core": {
 			"version": "7.29.0",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-			"integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1537,8 +948,6 @@
 		},
 		"node_modules/@babel/generator": {
 			"version": "7.29.1",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-			"integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/parser": "^7.29.0",
@@ -1564,8 +973,6 @@
 		},
 		"node_modules/@babel/helper-compilation-targets": {
 			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-			"integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1675,8 +1082,6 @@
 		},
 		"node_modules/@babel/helper-module-imports": {
 			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-			"integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/traverse": "^7.28.6",
@@ -1688,8 +1093,6 @@
 		},
 		"node_modules/@babel/helper-module-transforms": {
 			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-			"integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1804,8 +1207,6 @@
 		},
 		"node_modules/@babel/helpers": {
 			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
-			"integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1818,8 +1219,6 @@
 		},
 		"node_modules/@babel/parser": {
 			"version": "7.29.0",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
-			"integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/types": "^7.29.0"
@@ -3011,8 +2410,6 @@
 		},
 		"node_modules/@babel/runtime": {
 			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
-			"integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
@@ -3020,8 +2417,6 @@
 		},
 		"node_modules/@babel/template": {
 			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-			"integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/code-frame": "^7.28.6",
@@ -3034,8 +2429,6 @@
 		},
 		"node_modules/@babel/traverse": {
 			"version": "7.29.0",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-			"integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/code-frame": "^7.29.0",
@@ -3052,8 +2445,6 @@
 		},
 		"node_modules/@babel/types": {
 			"version": "7.29.0",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-			"integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/helper-string-parser": "^7.27.1",
@@ -3065,8 +2456,6 @@
 		},
 		"node_modules/@base-ui/react": {
 			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.2.0.tgz",
-			"integrity": "sha512-O6aEQHcm+QyGTFY28xuwRD3SEJGZOBDpyjN2WvpfWYFVhg+3zfXPysAILqtM0C1kWC82MccOE/v1j+GHXE4qIw==",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/runtime": "^7.28.6",
@@ -3096,8 +2485,6 @@
 		},
 		"node_modules/@base-ui/react/node_modules/@floating-ui/react-dom": {
 			"version": "2.1.7",
-			"resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.7.tgz",
-			"integrity": "sha512-0tLRojf/1Go2JgEVm+3Frg9A3IW8bJgKgdO0BN5RkF//ufuz2joZM63Npau2ff3J6lUVYgDSNzNkR+aH3IVfjg==",
 			"license": "MIT",
 			"dependencies": {
 				"@floating-ui/dom": "^1.7.5"
@@ -3109,8 +2496,6 @@
 		},
 		"node_modules/@base-ui/utils": {
 			"version": "0.2.5",
-			"resolved": "https://registry.npmjs.org/@base-ui/utils/-/utils-0.2.5.tgz",
-			"integrity": "sha512-oYC7w0gp76RI5MxprlGLV0wze0SErZaRl3AAkeP3OnNB/UBMb6RqNf6ZSIlxOc9Qp68Ab3C2VOcJQyRs7Xc7Vw==",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/runtime": "^7.28.6",
@@ -3493,8 +2878,6 @@
 		},
 		"node_modules/@electron-forge/cli/node_modules/chalk": {
 			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3648,8 +3031,6 @@
 		},
 		"node_modules/@electron-forge/core-utils/node_modules/chalk": {
 			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3678,8 +3059,6 @@
 		},
 		"node_modules/@electron-forge/core/node_modules/chalk": {
 			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4131,8 +3510,6 @@
 		},
 		"node_modules/@electron/node-gyp": {
 			"version": "10.2.0-electron.1",
-			"resolved": "git+ssh://git@github.com/electron/node-gyp.git#06b29aafb7708acef8b3669835c8a7857ebc92d2",
-			"integrity": "sha512-CrYo6TntjpoMO1SHjl5Pa/JoUsECNqNdB7Kx49WLQpWzPw53eEITJ2Hs9fh/ryUYDn4pxZz11StaBYBrLFJdqg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4368,8 +3745,6 @@
 		},
 		"node_modules/@electron/rebuild/node_modules/chalk": {
 			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4568,8 +3943,6 @@
 		},
 		"node_modules/@electron/windows-sign": {
 			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@electron/windows-sign/-/windows-sign-1.2.2.tgz",
-			"integrity": "sha512-dfZeox66AvdPtb2lD8OsIIQh12Tp0GNCRUDfBHIKGpbmopZto2/A8nSpYYLoedPIHpqkeblZ/k8OV0Gy7PYuyQ==",
 			"dev": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
@@ -4586,44 +3959,8 @@
 				"node": ">=14.14"
 			}
 		},
-		"node_modules/@emnapi/core": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.8.1.tgz",
-			"integrity": "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"@emnapi/wasi-threads": "1.1.0",
-				"tslib": "^2.4.0"
-			}
-		},
-		"node_modules/@emnapi/runtime": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
-			"integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"tslib": "^2.4.0"
-			}
-		},
-		"node_modules/@emnapi/wasi-threads": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
-			"integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"tslib": "^2.4.0"
-			}
-		},
 		"node_modules/@emotion/babel-plugin": {
 			"version": "11.13.5",
-			"resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz",
-			"integrity": "sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/helper-module-imports": "^7.16.7",
@@ -4641,14 +3978,10 @@
 		},
 		"node_modules/@emotion/babel-plugin/node_modules/convert-source-map": {
 			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
-			"integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
 			"license": "MIT"
 		},
 		"node_modules/@emotion/babel-plugin/node_modules/source-map": {
 			"version": "0.5.7",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-			"integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.10.0"
@@ -4656,8 +3989,6 @@
 		},
 		"node_modules/@emotion/cache": {
 			"version": "11.14.0",
-			"resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.14.0.tgz",
-			"integrity": "sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==",
 			"license": "MIT",
 			"dependencies": {
 				"@emotion/memoize": "^0.9.0",
@@ -4669,8 +4000,6 @@
 		},
 		"node_modules/@emotion/css": {
 			"version": "11.13.5",
-			"resolved": "https://registry.npmjs.org/@emotion/css/-/css-11.13.5.tgz",
-			"integrity": "sha512-wQdD0Xhkn3Qy2VNcIzbLP9MR8TafI0MJb7BEAXKp+w4+XqErksWR4OXomuDzPsN4InLdGhVe6EYcn2ZIUCpB8w==",
 			"license": "MIT",
 			"dependencies": {
 				"@emotion/babel-plugin": "^11.13.5",
@@ -4682,14 +4011,10 @@
 		},
 		"node_modules/@emotion/hash": {
 			"version": "0.9.2",
-			"resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.2.tgz",
-			"integrity": "sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==",
 			"license": "MIT"
 		},
 		"node_modules/@emotion/is-prop-valid": {
 			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.4.0.tgz",
-			"integrity": "sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==",
 			"license": "MIT",
 			"dependencies": {
 				"@emotion/memoize": "^0.9.0"
@@ -4697,14 +4022,10 @@
 		},
 		"node_modules/@emotion/memoize": {
 			"version": "0.9.0",
-			"resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.9.0.tgz",
-			"integrity": "sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==",
 			"license": "MIT"
 		},
 		"node_modules/@emotion/react": {
 			"version": "11.14.0",
-			"resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
-			"integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/runtime": "^7.18.3",
@@ -4727,8 +4048,6 @@
 		},
 		"node_modules/@emotion/serialize": {
 			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.3.3.tgz",
-			"integrity": "sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==",
 			"license": "MIT",
 			"dependencies": {
 				"@emotion/hash": "^0.9.2",
@@ -4740,14 +4059,10 @@
 		},
 		"node_modules/@emotion/sheet": {
 			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.4.0.tgz",
-			"integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==",
 			"license": "MIT"
 		},
 		"node_modules/@emotion/styled": {
 			"version": "11.14.1",
-			"resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.1.tgz",
-			"integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/runtime": "^7.18.3",
@@ -4769,14 +4084,10 @@
 		},
 		"node_modules/@emotion/unitless": {
 			"version": "0.10.0",
-			"resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.10.0.tgz",
-			"integrity": "sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==",
 			"license": "MIT"
 		},
 		"node_modules/@emotion/use-insertion-effect-with-fallbacks": {
 			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.2.0.tgz",
-			"integrity": "sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg==",
 			"license": "MIT",
 			"peerDependencies": {
 				"react": ">=16.8.0"
@@ -4784,83 +4095,11 @@
 		},
 		"node_modules/@emotion/utils": {
 			"version": "1.4.2",
-			"resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.4.2.tgz",
-			"integrity": "sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==",
 			"license": "MIT"
 		},
 		"node_modules/@emotion/weak-memoize": {
 			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
-			"integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==",
 			"license": "MIT"
-		},
-		"node_modules/@esbuild/aix-ppc64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
-			"integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
-			"cpu": [
-				"ppc64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"aix"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/android-arm": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
-			"integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/android-arm64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
-			"integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/android-x64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
-			"integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"engines": {
-				"node": ">=18"
-			}
 		},
 		"node_modules/@esbuild/darwin-arm64": {
 			"version": "0.25.12",
@@ -4872,363 +4111,6 @@
 			"optional": true,
 			"os": [
 				"darwin"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/darwin-x64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
-			"integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/freebsd-arm64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
-			"integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"freebsd"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/freebsd-x64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
-			"integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"freebsd"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/linux-arm": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
-			"integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/linux-arm64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
-			"integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/linux-ia32": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
-			"integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
-			"cpu": [
-				"ia32"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/linux-loong64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
-			"integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
-			"cpu": [
-				"loong64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/linux-mips64el": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
-			"integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
-			"cpu": [
-				"mips64el"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/linux-ppc64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
-			"integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
-			"cpu": [
-				"ppc64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/linux-riscv64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
-			"integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
-			"cpu": [
-				"riscv64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/linux-s390x": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
-			"integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
-			"cpu": [
-				"s390x"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/linux-x64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
-			"integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/netbsd-arm64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
-			"integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"netbsd"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/netbsd-x64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
-			"integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"netbsd"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/openbsd-arm64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
-			"integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"openbsd"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/openbsd-x64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
-			"integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"openbsd"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/openharmony-arm64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
-			"integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"openharmony"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/sunos-x64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
-			"integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"sunos"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/win32-arm64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
-			"integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/win32-ia32": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
-			"integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
-			"cpu": [
-				"ia32"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@esbuild/win32-x64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
-			"integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
 			],
 			"engines": {
 				"node": ">=18"
@@ -5340,8 +4222,6 @@
 		},
 		"node_modules/@fastify/otel": {
 			"version": "0.16.0",
-			"resolved": "https://registry.npmjs.org/@fastify/otel/-/otel-0.16.0.tgz",
-			"integrity": "sha512-2304BdM5Q/kUvQC9qJO1KZq3Zn1WWsw+WWkVmFEaj1UE2hEIiuFqrPeglQOwEtw/ftngisqfQ3v70TWMmwhhHA==",
 			"funding": [
 				{
 					"type": "github",
@@ -5365,8 +4245,6 @@
 		},
 		"node_modules/@fastify/otel/node_modules/@opentelemetry/api-logs": {
 			"version": "0.208.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.208.0.tgz",
-			"integrity": "sha512-CjruKY9V6NMssL/T1kAFgzosF1v9o6oeN+aX5JB/C/xPNtmgIJqcXHG7fA82Ou1zCpWGl4lROQUKwUNE1pMCyg==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/api": "^1.3.0"
@@ -5377,8 +4255,6 @@
 		},
 		"node_modules/@fastify/otel/node_modules/@opentelemetry/instrumentation": {
 			"version": "0.208.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.208.0.tgz",
-			"integrity": "sha512-Eju0L4qWcQS+oXxi6pgh7zvE2byogAkcsVv0OjHF/97iOz1N/aKE6etSGowYkie+YA1uo6DNwdSxaaNnLvcRlA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/api-logs": "0.208.0",
@@ -5394,8 +4270,6 @@
 		},
 		"node_modules/@fastify/otel/node_modules/balanced-match": {
 			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
 			"license": "MIT",
 			"engines": {
 				"node": "18 || 20 || >=22"
@@ -5403,8 +4277,6 @@
 		},
 		"node_modules/@fastify/otel/node_modules/brace-expansion": {
 			"version": "5.0.4",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-			"integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^4.0.2"
@@ -5415,8 +4287,6 @@
 		},
 		"node_modules/@fastify/otel/node_modules/minimatch": {
 			"version": "10.2.4",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-			"integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
 			"license": "BlueOak-1.0.0",
 			"dependencies": {
 				"brace-expansion": "^5.0.2"
@@ -5544,8 +4414,6 @@
 		},
 		"node_modules/@img/sharp-darwin-arm64": {
 			"version": "0.33.5",
-			"resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
-			"integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -5564,32 +4432,8 @@
 				"@img/sharp-libvips-darwin-arm64": "1.0.4"
 			}
 		},
-		"node_modules/@img/sharp-darwin-x64": {
-			"version": "0.33.5",
-			"resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
-			"integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
-			"cpu": [
-				"x64"
-			],
-			"license": "Apache-2.0",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/libvips"
-			},
-			"optionalDependencies": {
-				"@img/sharp-libvips-darwin-x64": "1.0.4"
-			}
-		},
 		"node_modules/@img/sharp-libvips-darwin-arm64": {
 			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
-			"integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
 			"cpu": [
 				"arm64"
 			],
@@ -5598,231 +4442,6 @@
 			"os": [
 				"darwin"
 			],
-			"funding": {
-				"url": "https://opencollective.com/libvips"
-			}
-		},
-		"node_modules/@img/sharp-libvips-darwin-x64": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
-			"integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
-			"cpu": [
-				"x64"
-			],
-			"license": "LGPL-3.0-or-later",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"funding": {
-				"url": "https://opencollective.com/libvips"
-			}
-		},
-		"node_modules/@img/sharp-libvips-linux-arm": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
-			"integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
-			"cpu": [
-				"arm"
-			],
-			"license": "LGPL-3.0-or-later",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"funding": {
-				"url": "https://opencollective.com/libvips"
-			}
-		},
-		"node_modules/@img/sharp-libvips-linux-arm64": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
-			"integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
-			"cpu": [
-				"arm64"
-			],
-			"license": "LGPL-3.0-or-later",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"funding": {
-				"url": "https://opencollective.com/libvips"
-			}
-		},
-		"node_modules/@img/sharp-libvips-linux-x64": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
-			"integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
-			"cpu": [
-				"x64"
-			],
-			"license": "LGPL-3.0-or-later",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"funding": {
-				"url": "https://opencollective.com/libvips"
-			}
-		},
-		"node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
-			"integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
-			"cpu": [
-				"arm64"
-			],
-			"license": "LGPL-3.0-or-later",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"funding": {
-				"url": "https://opencollective.com/libvips"
-			}
-		},
-		"node_modules/@img/sharp-libvips-linuxmusl-x64": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
-			"integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
-			"cpu": [
-				"x64"
-			],
-			"license": "LGPL-3.0-or-later",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"funding": {
-				"url": "https://opencollective.com/libvips"
-			}
-		},
-		"node_modules/@img/sharp-linux-arm": {
-			"version": "0.33.5",
-			"resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
-			"integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
-			"cpu": [
-				"arm"
-			],
-			"license": "Apache-2.0",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/libvips"
-			},
-			"optionalDependencies": {
-				"@img/sharp-libvips-linux-arm": "1.0.5"
-			}
-		},
-		"node_modules/@img/sharp-linux-arm64": {
-			"version": "0.33.5",
-			"resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
-			"integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
-			"cpu": [
-				"arm64"
-			],
-			"license": "Apache-2.0",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/libvips"
-			},
-			"optionalDependencies": {
-				"@img/sharp-libvips-linux-arm64": "1.0.4"
-			}
-		},
-		"node_modules/@img/sharp-linux-x64": {
-			"version": "0.33.5",
-			"resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
-			"integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
-			"cpu": [
-				"x64"
-			],
-			"license": "Apache-2.0",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/libvips"
-			},
-			"optionalDependencies": {
-				"@img/sharp-libvips-linux-x64": "1.0.4"
-			}
-		},
-		"node_modules/@img/sharp-linuxmusl-arm64": {
-			"version": "0.33.5",
-			"resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
-			"integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
-			"cpu": [
-				"arm64"
-			],
-			"license": "Apache-2.0",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/libvips"
-			},
-			"optionalDependencies": {
-				"@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
-			}
-		},
-		"node_modules/@img/sharp-linuxmusl-x64": {
-			"version": "0.33.5",
-			"resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
-			"integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
-			"cpu": [
-				"x64"
-			],
-			"license": "Apache-2.0",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/libvips"
-			},
-			"optionalDependencies": {
-				"@img/sharp-libvips-linuxmusl-x64": "1.0.4"
-			}
-		},
-		"node_modules/@img/sharp-win32-x64": {
-			"version": "0.33.5",
-			"resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
-			"integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
-			"cpu": [
-				"x64"
-			],
-			"license": "Apache-2.0 AND LGPL-3.0-or-later",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-			},
 			"funding": {
 				"url": "https://opencollective.com/libvips"
 			}
@@ -6321,8 +4940,6 @@
 		},
 		"node_modules/@kwsites/file-exists": {
 			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
-			"integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
 			"license": "MIT",
 			"dependencies": {
 				"debug": "^4.1.1"
@@ -6330,8 +4947,6 @@
 		},
 		"node_modules/@kwsites/promise-deferred": {
 			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
-			"integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==",
 			"license": "MIT"
 		},
 		"node_modules/@listr2/prompt-adapter-inquirer": {
@@ -6390,8 +5005,6 @@
 		},
 		"node_modules/@mariozechner/pi-tui": {
 			"version": "0.54.0",
-			"resolved": "https://registry.npmjs.org/@mariozechner/pi-tui/-/pi-tui-0.54.0.tgz",
-			"integrity": "sha512-bvFlUohdxDvKcFeQM2xsd5twCGKWxVaYSlHCFljIW0KqMC4vU+/Ts4A1i9iDnm6Xe/MlueKvC0V09YeC8fLIHA==",
 			"license": "MIT",
 			"dependencies": {
 				"@types/mime-types": "^2.1.4",
@@ -6407,8 +5020,6 @@
 		},
 		"node_modules/@mariozechner/pi-tui/node_modules/mime-db": {
 			"version": "1.54.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-			"integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.6"
@@ -6416,8 +5027,6 @@
 		},
 		"node_modules/@mariozechner/pi-tui/node_modules/mime-types": {
 			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
-			"integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
 			"license": "MIT",
 			"dependencies": {
 				"mime-db": "^1.54.0"
@@ -6428,19 +5037,6 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/express"
-			}
-		},
-		"node_modules/@napi-rs/wasm-runtime": {
-			"version": "0.2.12",
-			"resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
-			"integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"@emnapi/core": "^1.4.3",
-				"@emnapi/runtime": "^1.4.3",
-				"@tybys/wasm-util": "^0.10.0"
 			}
 		},
 		"node_modules/@nicolo-ribaudo/chokidar-2": {
@@ -6528,8 +5124,6 @@
 		},
 		"node_modules/@octokit/app": {
 			"version": "14.1.0",
-			"resolved": "https://registry.npmjs.org/@octokit/app/-/app-14.1.0.tgz",
-			"integrity": "sha512-g3uEsGOQCBl1+W1rgfwoRFUIR6PtvB2T1E4RpygeUU5LrLvlOqcxrt5lfykIeRpUPpupreGJUYl70fqMDXdTpw==",
 			"license": "MIT",
 			"dependencies": {
 				"@octokit/auth-app": "^6.0.0",
@@ -6546,8 +5140,6 @@
 		},
 		"node_modules/@octokit/auth-app": {
 			"version": "6.1.4",
-			"resolved": "https://registry.npmjs.org/@octokit/auth-app/-/auth-app-6.1.4.tgz",
-			"integrity": "sha512-QkXkSOHZK4dA5oUqY5Dk3S+5pN2s1igPjEASNQV8/vgJgW034fQWR16u7VsNOK/EljA00eyjYF5mWNxWKWhHRQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@octokit/auth-oauth-app": "^7.1.0",
@@ -6566,14 +5158,10 @@
 		},
 		"node_modules/@octokit/auth-app/node_modules/@octokit/openapi-types": {
 			"version": "24.2.0",
-			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
-			"integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
 			"license": "MIT"
 		},
 		"node_modules/@octokit/auth-app/node_modules/@octokit/types": {
 			"version": "13.10.0",
-			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
-			"integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
 			"license": "MIT",
 			"dependencies": {
 				"@octokit/openapi-types": "^24.2.0"
@@ -6582,8 +5170,6 @@
 		"node_modules/@octokit/auth-app/node_modules/lru-cache": {
 			"name": "@wolfy1339/lru-cache",
 			"version": "11.0.2-patch.1",
-			"resolved": "https://registry.npmjs.org/@wolfy1339/lru-cache/-/lru-cache-11.0.2-patch.1.tgz",
-			"integrity": "sha512-BgYZfL2ADCXKOw2wJtkM3slhHotawWkgIRRxq4wEybnZQPjvAp71SPX35xepMykTw8gXlzWcWPTY31hlbnRsDA==",
 			"license": "ISC",
 			"engines": {
 				"node": "18 >=18.20 || 20 || >=22"
@@ -6591,8 +5177,6 @@
 		},
 		"node_modules/@octokit/auth-oauth-app": {
 			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/@octokit/auth-oauth-app/-/auth-oauth-app-7.1.0.tgz",
-			"integrity": "sha512-w+SyJN/b0l/HEb4EOPRudo7uUOSW51jcK1jwLa+4r7PA8FPFpoxEnHBHMITqCsc/3Vo2qqFjgQfz/xUUvsSQnA==",
 			"license": "MIT",
 			"dependencies": {
 				"@octokit/auth-oauth-device": "^6.1.0",
@@ -6609,14 +5193,10 @@
 		},
 		"node_modules/@octokit/auth-oauth-app/node_modules/@octokit/openapi-types": {
 			"version": "24.2.0",
-			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
-			"integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
 			"license": "MIT"
 		},
 		"node_modules/@octokit/auth-oauth-app/node_modules/@octokit/types": {
 			"version": "13.10.0",
-			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
-			"integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
 			"license": "MIT",
 			"dependencies": {
 				"@octokit/openapi-types": "^24.2.0"
@@ -6624,8 +5204,6 @@
 		},
 		"node_modules/@octokit/auth-oauth-device": {
 			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/@octokit/auth-oauth-device/-/auth-oauth-device-6.1.0.tgz",
-			"integrity": "sha512-FNQ7cb8kASufd6Ej4gnJ3f1QB5vJitkoV1O0/g6e6lUsQ7+VsSNRHRmFScN2tV4IgKA12frrr/cegUs0t+0/Lw==",
 			"license": "MIT",
 			"dependencies": {
 				"@octokit/oauth-methods": "^4.1.0",
@@ -6639,14 +5217,10 @@
 		},
 		"node_modules/@octokit/auth-oauth-device/node_modules/@octokit/openapi-types": {
 			"version": "24.2.0",
-			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
-			"integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
 			"license": "MIT"
 		},
 		"node_modules/@octokit/auth-oauth-device/node_modules/@octokit/types": {
 			"version": "13.10.0",
-			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
-			"integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
 			"license": "MIT",
 			"dependencies": {
 				"@octokit/openapi-types": "^24.2.0"
@@ -6654,8 +5228,6 @@
 		},
 		"node_modules/@octokit/auth-oauth-user": {
 			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/@octokit/auth-oauth-user/-/auth-oauth-user-4.1.0.tgz",
-			"integrity": "sha512-FrEp8mtFuS/BrJyjpur+4GARteUCrPeR/tZJzD8YourzoVhRics7u7we/aDcKv+yywRNwNi/P4fRi631rG/OyQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@octokit/auth-oauth-device": "^6.1.0",
@@ -6671,14 +5243,10 @@
 		},
 		"node_modules/@octokit/auth-oauth-user/node_modules/@octokit/openapi-types": {
 			"version": "24.2.0",
-			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
-			"integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
 			"license": "MIT"
 		},
 		"node_modules/@octokit/auth-oauth-user/node_modules/@octokit/types": {
 			"version": "13.10.0",
-			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
-			"integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
 			"license": "MIT",
 			"dependencies": {
 				"@octokit/openapi-types": "^24.2.0"
@@ -6686,8 +5254,6 @@
 		},
 		"node_modules/@octokit/auth-token": {
 			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
-			"integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==",
 			"license": "MIT",
 			"engines": {
 				"node": ">= 18"
@@ -6695,8 +5261,6 @@
 		},
 		"node_modules/@octokit/auth-unauthenticated": {
 			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/@octokit/auth-unauthenticated/-/auth-unauthenticated-5.0.1.tgz",
-			"integrity": "sha512-oxeWzmBFxWd+XolxKTc4zr+h3mt+yofn4r7OfoIkR/Cj/o70eEGmPsFbueyJE2iBAGpjgTnEOKM3pnuEGVmiqg==",
 			"license": "MIT",
 			"dependencies": {
 				"@octokit/request-error": "^5.0.0",
@@ -6708,8 +5272,6 @@
 		},
 		"node_modules/@octokit/core": {
 			"version": "5.2.2",
-			"resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.2.tgz",
-			"integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
 			"license": "MIT",
 			"dependencies": {
 				"@octokit/auth-token": "^4.0.0",
@@ -6726,14 +5288,10 @@
 		},
 		"node_modules/@octokit/core/node_modules/@octokit/openapi-types": {
 			"version": "24.2.0",
-			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
-			"integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
 			"license": "MIT"
 		},
 		"node_modules/@octokit/core/node_modules/@octokit/types": {
 			"version": "13.10.0",
-			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
-			"integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
 			"license": "MIT",
 			"dependencies": {
 				"@octokit/openapi-types": "^24.2.0"
@@ -6741,8 +5299,6 @@
 		},
 		"node_modules/@octokit/endpoint": {
 			"version": "9.0.6",
-			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.6.tgz",
-			"integrity": "sha512-H1fNTMA57HbkFESSt3Y9+FBICv+0jFceJFPWDePYlR/iMGrwM5ph+Dd4XRQs+8X+PUFURLQgX9ChPfhJ/1uNQw==",
 			"license": "MIT",
 			"dependencies": {
 				"@octokit/types": "^13.1.0",
@@ -6754,14 +5310,10 @@
 		},
 		"node_modules/@octokit/endpoint/node_modules/@octokit/openapi-types": {
 			"version": "24.2.0",
-			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
-			"integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
 			"license": "MIT"
 		},
 		"node_modules/@octokit/endpoint/node_modules/@octokit/types": {
 			"version": "13.10.0",
-			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
-			"integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
 			"license": "MIT",
 			"dependencies": {
 				"@octokit/openapi-types": "^24.2.0"
@@ -6769,8 +5321,6 @@
 		},
 		"node_modules/@octokit/graphql": {
 			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.1.1.tgz",
-			"integrity": "sha512-3mkDltSfcDUoa176nlGoA32RGjeWjl3K7F/BwHwRMJUW/IteSa4bnSV8p2ThNkcIcZU2umkZWxwETSSCJf2Q7g==",
 			"license": "MIT",
 			"dependencies": {
 				"@octokit/request": "^8.4.1",
@@ -6783,14 +5333,10 @@
 		},
 		"node_modules/@octokit/graphql/node_modules/@octokit/openapi-types": {
 			"version": "24.2.0",
-			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
-			"integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
 			"license": "MIT"
 		},
 		"node_modules/@octokit/graphql/node_modules/@octokit/types": {
 			"version": "13.10.0",
-			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
-			"integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
 			"license": "MIT",
 			"dependencies": {
 				"@octokit/openapi-types": "^24.2.0"
@@ -6798,8 +5344,6 @@
 		},
 		"node_modules/@octokit/oauth-app": {
 			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/@octokit/oauth-app/-/oauth-app-6.1.0.tgz",
-			"integrity": "sha512-nIn/8eUJ/BKUVzxUXd5vpzl1rwaVxMyYbQkNZjHrF7Vk/yu98/YDF/N2KeWO7uZ0g3b5EyiFXFkZI8rJ+DH1/g==",
 			"license": "MIT",
 			"dependencies": {
 				"@octokit/auth-oauth-app": "^7.0.0",
@@ -6817,8 +5361,6 @@
 		},
 		"node_modules/@octokit/oauth-authorization-url": {
 			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/@octokit/oauth-authorization-url/-/oauth-authorization-url-6.0.2.tgz",
-			"integrity": "sha512-CdoJukjXXxqLNK4y/VOiVzQVjibqoj/xHgInekviUJV73y/BSIcwvJ/4aNHPBPKcPWFnd4/lO9uqRV65jXhcLA==",
 			"license": "MIT",
 			"engines": {
 				"node": ">= 18"
@@ -6826,8 +5368,6 @@
 		},
 		"node_modules/@octokit/oauth-methods": {
 			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/@octokit/oauth-methods/-/oauth-methods-4.1.0.tgz",
-			"integrity": "sha512-4tuKnCRecJ6CG6gr0XcEXdZtkTDbfbnD5oaHBmLERTjTMZNi2CbfEHZxPU41xXLDG4DfKf+sonu00zvKI9NSbw==",
 			"license": "MIT",
 			"dependencies": {
 				"@octokit/oauth-authorization-url": "^6.0.2",
@@ -6842,14 +5382,10 @@
 		},
 		"node_modules/@octokit/oauth-methods/node_modules/@octokit/openapi-types": {
 			"version": "24.2.0",
-			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
-			"integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
 			"license": "MIT"
 		},
 		"node_modules/@octokit/oauth-methods/node_modules/@octokit/types": {
 			"version": "13.10.0",
-			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
-			"integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
 			"license": "MIT",
 			"dependencies": {
 				"@octokit/openapi-types": "^24.2.0"
@@ -6857,14 +5393,10 @@
 		},
 		"node_modules/@octokit/openapi-types": {
 			"version": "20.0.0",
-			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
-			"integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==",
 			"license": "MIT"
 		},
 		"node_modules/@octokit/plugin-paginate-graphql": {
 			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-graphql/-/plugin-paginate-graphql-4.0.1.tgz",
-			"integrity": "sha512-R8ZQNmrIKKpHWC6V2gum4x9LG2qF1RxRjo27gjQcG3j+vf2tLsEfE7I/wRWEPzYMaenr1M+qDAtNcwZve1ce1A==",
 			"license": "MIT",
 			"engines": {
 				"node": ">= 18"
@@ -6875,8 +5407,6 @@
 		},
 		"node_modules/@octokit/plugin-paginate-rest": {
 			"version": "9.2.2",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-9.2.2.tgz",
-			"integrity": "sha512-u3KYkGF7GcZnSD/3UP0S7K5XUFT2FkOQdcfXZGZQPGv3lm4F2Xbf71lvjldr8c1H3nNbF+33cLEkWYbokGWqiQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@octokit/types": "^12.6.0"
@@ -6890,8 +5420,6 @@
 		},
 		"node_modules/@octokit/plugin-rest-endpoint-methods": {
 			"version": "10.4.1",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-10.4.1.tgz",
-			"integrity": "sha512-xV1b+ceKV9KytQe3zCVqjg+8GTGfDYwaT1ATU5isiUyVtlVAO3HNdzpS4sr4GBx4hxQ46s7ITtZrAsxG22+rVg==",
 			"license": "MIT",
 			"dependencies": {
 				"@octokit/types": "^12.6.0"
@@ -6905,8 +5433,6 @@
 		},
 		"node_modules/@octokit/plugin-retry": {
 			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-6.1.0.tgz",
-			"integrity": "sha512-WrO3bvq4E1Xh1r2mT9w6SDFg01gFmP81nIG77+p/MqW1JeXXgL++6umim3t6x0Zj5pZm3rXAN+0HEjmmdhIRig==",
 			"license": "MIT",
 			"dependencies": {
 				"@octokit/request-error": "^5.0.0",
@@ -6922,14 +5448,10 @@
 		},
 		"node_modules/@octokit/plugin-retry/node_modules/@octokit/openapi-types": {
 			"version": "24.2.0",
-			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
-			"integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
 			"license": "MIT"
 		},
 		"node_modules/@octokit/plugin-retry/node_modules/@octokit/types": {
 			"version": "13.10.0",
-			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
-			"integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
 			"license": "MIT",
 			"dependencies": {
 				"@octokit/openapi-types": "^24.2.0"
@@ -6937,8 +5459,6 @@
 		},
 		"node_modules/@octokit/plugin-throttling": {
 			"version": "8.2.0",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-8.2.0.tgz",
-			"integrity": "sha512-nOpWtLayKFpgqmgD0y3GqXafMFuKcA4tRPZIfu7BArd2lEZeb1988nhWhwx4aZWmjDmUfdgVf7W+Tt4AmvRmMQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@octokit/types": "^12.2.0",
@@ -6953,8 +5473,6 @@
 		},
 		"node_modules/@octokit/request": {
 			"version": "8.4.1",
-			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.4.1.tgz",
-			"integrity": "sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw==",
 			"license": "MIT",
 			"dependencies": {
 				"@octokit/endpoint": "^9.0.6",
@@ -6968,8 +5486,6 @@
 		},
 		"node_modules/@octokit/request-error": {
 			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.1.1.tgz",
-			"integrity": "sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g==",
 			"license": "MIT",
 			"dependencies": {
 				"@octokit/types": "^13.1.0",
@@ -6982,14 +5498,10 @@
 		},
 		"node_modules/@octokit/request-error/node_modules/@octokit/openapi-types": {
 			"version": "24.2.0",
-			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
-			"integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
 			"license": "MIT"
 		},
 		"node_modules/@octokit/request-error/node_modules/@octokit/types": {
 			"version": "13.10.0",
-			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
-			"integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
 			"license": "MIT",
 			"dependencies": {
 				"@octokit/openapi-types": "^24.2.0"
@@ -6997,14 +5509,10 @@
 		},
 		"node_modules/@octokit/request/node_modules/@octokit/openapi-types": {
 			"version": "24.2.0",
-			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
-			"integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
 			"license": "MIT"
 		},
 		"node_modules/@octokit/request/node_modules/@octokit/types": {
 			"version": "13.10.0",
-			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
-			"integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
 			"license": "MIT",
 			"dependencies": {
 				"@octokit/openapi-types": "^24.2.0"
@@ -7012,8 +5520,6 @@
 		},
 		"node_modules/@octokit/types": {
 			"version": "12.6.0",
-			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
-			"integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
 			"license": "MIT",
 			"dependencies": {
 				"@octokit/openapi-types": "^20.0.0"
@@ -7021,8 +5527,6 @@
 		},
 		"node_modules/@octokit/webhooks": {
 			"version": "12.3.2",
-			"resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-12.3.2.tgz",
-			"integrity": "sha512-exj1MzVXoP7xnAcAB3jZ97pTvVPkQF9y6GA/dvYC47HV7vLv+24XRS6b/v/XnyikpEuvMhugEXdGtAlU086WkQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@octokit/request-error": "^5.0.0",
@@ -7036,8 +5540,6 @@
 		},
 		"node_modules/@octokit/webhooks-methods": {
 			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/@octokit/webhooks-methods/-/webhooks-methods-4.1.0.tgz",
-			"integrity": "sha512-zoQyKw8h9STNPqtm28UGOYFE7O6D4Il8VJwhAtMHFt2C4L0VQT1qGKLeefUOqHNs1mNRYSadVv7x0z8U2yyeWQ==",
 			"license": "MIT",
 			"engines": {
 				"node": ">= 18"
@@ -7045,8 +5547,6 @@
 		},
 		"node_modules/@octokit/webhooks-types": {
 			"version": "7.6.1",
-			"resolved": "https://registry.npmjs.org/@octokit/webhooks-types/-/webhooks-types-7.6.1.tgz",
-			"integrity": "sha512-S8u2cJzklBC0FgTwWVLaM8tMrDuDMVE4xiTK4EYXM9GntyvrdbSoxqDQa+Fh57CCNApyIpyeqPhhFEmHPfrXgw==",
 			"license": "MIT"
 		},
 		"node_modules/@opentelemetry/api": {
@@ -7058,8 +5558,6 @@
 		},
 		"node_modules/@opentelemetry/api-logs": {
 			"version": "0.211.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.211.0.tgz",
-			"integrity": "sha512-swFdZq8MCdmdR22jTVGQDhwqDzcI4M10nhjXkLr1EsIzXgZBqm4ZlmmcWsg3TSNf+3mzgOiqveXmBLZuDi2Lgg==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/api": "^1.3.0"
@@ -7070,8 +5568,6 @@
 		},
 		"node_modules/@opentelemetry/context-async-hooks": {
 			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.6.0.tgz",
-			"integrity": "sha512-L8UyDwqpTcbkIK5cgwDRDYDoEhQoj8wp8BwsO19w3LB1Z41yEQm2VJyNfAi9DrLP/YTqXqWpKHyZfR9/tFYo1Q==",
 			"license": "Apache-2.0",
 			"engines": {
 				"node": "^18.19.0 || >=20.6.0"
@@ -7082,8 +5578,6 @@
 		},
 		"node_modules/@opentelemetry/core": {
 			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.6.0.tgz",
-			"integrity": "sha512-HLM1v2cbZ4TgYN6KEOj+Bbj8rAKriOdkF9Ed3tG25FoprSiQl7kYc+RRT6fUZGOvx0oMi5U67GoFdT+XUn8zEg==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/semantic-conventions": "^1.29.0"
@@ -7097,8 +5591,6 @@
 		},
 		"node_modules/@opentelemetry/instrumentation": {
 			"version": "0.211.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.211.0.tgz",
-			"integrity": "sha512-h0nrZEC/zvI994nhg7EgQ8URIHt0uDTwN90r3qQUdZORS455bbx+YebnGeEuFghUT0HlJSrLF4iHw67f+odY+Q==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/api-logs": "0.211.0",
@@ -7114,8 +5606,6 @@
 		},
 		"node_modules/@opentelemetry/instrumentation-amqplib": {
 			"version": "0.58.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-amqplib/-/instrumentation-amqplib-0.58.0.tgz",
-			"integrity": "sha512-fjpQtH18J6GxzUZ+cwNhWUpb71u+DzT7rFkg5pLssDGaEber91Y2WNGdpVpwGivfEluMlNMZumzjEqfg8DeKXQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/core": "^2.0.0",
@@ -7131,8 +5621,6 @@
 		},
 		"node_modules/@opentelemetry/instrumentation-connect": {
 			"version": "0.54.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-connect/-/instrumentation-connect-0.54.0.tgz",
-			"integrity": "sha512-43RmbhUhqt3uuPnc16cX6NsxEASEtn8z/cYV8Zpt6EP4p2h9s4FNuJ4Q9BbEQ2C0YlCCB/2crO1ruVz/hWt8fA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/core": "^2.0.0",
@@ -7149,8 +5637,6 @@
 		},
 		"node_modules/@opentelemetry/instrumentation-dataloader": {
 			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dataloader/-/instrumentation-dataloader-0.28.0.tgz",
-			"integrity": "sha512-ExXGBp0sUj8yhm6Znhf9jmuOaGDsYfDES3gswZnKr4MCqoBWQdEFn6EoDdt5u+RdbxQER+t43FoUihEfTSqsjA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/instrumentation": "^0.211.0"
@@ -7164,8 +5650,6 @@
 		},
 		"node_modules/@opentelemetry/instrumentation-express": {
 			"version": "0.59.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-express/-/instrumentation-express-0.59.0.tgz",
-			"integrity": "sha512-pMKV/qnHiW/Q6pmbKkxt0eIhuNEtvJ7sUAyee192HErlr+a1Jx+FZ3WjfmzhQL1geewyGEiPGkmjjAgNY8TgDA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/core": "^2.0.0",
@@ -7181,8 +5665,6 @@
 		},
 		"node_modules/@opentelemetry/instrumentation-fs": {
 			"version": "0.30.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fs/-/instrumentation-fs-0.30.0.tgz",
-			"integrity": "sha512-n3Cf8YhG7reaj5dncGlRIU7iT40bxPOjsBEA5Bc1a1g6e9Qvb+JFJ7SEiMlPbUw4PBmxE3h40ltE8LZ3zVt6OA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/core": "^2.0.0",
@@ -7197,8 +5679,6 @@
 		},
 		"node_modules/@opentelemetry/instrumentation-generic-pool": {
 			"version": "0.54.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-generic-pool/-/instrumentation-generic-pool-0.54.0.tgz",
-			"integrity": "sha512-8dXMBzzmEdXfH/wjuRvcJnUFeWzZHUnExkmFJ2uPfa31wmpyBCMxO59yr8f/OXXgSogNgi/uPo9KW9H7LMIZ+g==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/instrumentation": "^0.211.0"
@@ -7212,8 +5692,6 @@
 		},
 		"node_modules/@opentelemetry/instrumentation-graphql": {
 			"version": "0.58.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.58.0.tgz",
-			"integrity": "sha512-+yWVVY7fxOs3j2RixCbvue8vUuJ1inHxN2q1sduqDB0Wnkr4vOzVKRYl/Zy7B31/dcPS72D9lo/kltdOTBM3bQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/instrumentation": "^0.211.0"
@@ -7227,8 +5705,6 @@
 		},
 		"node_modules/@opentelemetry/instrumentation-hapi": {
 			"version": "0.57.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-hapi/-/instrumentation-hapi-0.57.0.tgz",
-			"integrity": "sha512-Os4THbvls8cTQTVA8ApLfZZztuuqGEeqog0XUnyRW7QVF0d/vOVBEcBCk1pazPFmllXGEdNbbat8e2fYIWdFbw==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/core": "^2.0.0",
@@ -7244,8 +5720,6 @@
 		},
 		"node_modules/@opentelemetry/instrumentation-http": {
 			"version": "0.211.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.211.0.tgz",
-			"integrity": "sha512-n0IaQ6oVll9PP84SjbOCwDjaJasWRHi6BLsbMLiT6tNj7QbVOkuA5sk/EfZczwI0j5uTKl1awQPivO/ldVtsqA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/core": "2.5.0",
@@ -7262,8 +5736,6 @@
 		},
 		"node_modules/@opentelemetry/instrumentation-http/node_modules/@opentelemetry/core": {
 			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.5.0.tgz",
-			"integrity": "sha512-ka4H8OM6+DlUhSAZpONu0cPBtPPTQKxbxVzC4CzVx5+K4JnroJVBtDzLAMx4/3CDTJXRvVFhpFjtl4SaiTNoyQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/semantic-conventions": "^1.29.0"
@@ -7277,8 +5749,6 @@
 		},
 		"node_modules/@opentelemetry/instrumentation-ioredis": {
 			"version": "0.59.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-ioredis/-/instrumentation-ioredis-0.59.0.tgz",
-			"integrity": "sha512-875UxzBHWkW+P4Y45SoFM2AR8f8TzBMD8eO7QXGCyFSCUMP5s9vtt/BS8b/r2kqLyaRPK6mLbdnZznK3XzQWvw==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/instrumentation": "^0.211.0",
@@ -7294,8 +5764,6 @@
 		},
 		"node_modules/@opentelemetry/instrumentation-kafkajs": {
 			"version": "0.20.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-kafkajs/-/instrumentation-kafkajs-0.20.0.tgz",
-			"integrity": "sha512-yJXOuWZROzj7WmYCUiyT27tIfqBrVtl1/TwVbQyWPz7rL0r1Lu7kWjD0PiVeTCIL6CrIZ7M2s8eBxsTAOxbNvw==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/instrumentation": "^0.211.0",
@@ -7310,8 +5778,6 @@
 		},
 		"node_modules/@opentelemetry/instrumentation-knex": {
 			"version": "0.55.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-knex/-/instrumentation-knex-0.55.0.tgz",
-			"integrity": "sha512-FtTL5DUx5Ka/8VK6P1VwnlUXPa3nrb7REvm5ddLUIeXXq4tb9pKd+/ThB1xM/IjefkRSN3z8a5t7epYw1JLBJQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/instrumentation": "^0.211.0",
@@ -7326,8 +5792,6 @@
 		},
 		"node_modules/@opentelemetry/instrumentation-koa": {
 			"version": "0.59.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-koa/-/instrumentation-koa-0.59.0.tgz",
-			"integrity": "sha512-K9o2skADV20Skdu5tG2bogPKiSpXh4KxfLjz6FuqIVvDJNibwSdu5UvyyBzRVp1rQMV6UmoIk6d3PyPtJbaGSg==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/core": "^2.0.0",
@@ -7343,8 +5807,6 @@
 		},
 		"node_modules/@opentelemetry/instrumentation-lru-memoizer": {
 			"version": "0.55.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-lru-memoizer/-/instrumentation-lru-memoizer-0.55.0.tgz",
-			"integrity": "sha512-FDBfT7yDGcspN0Cxbu/k8A0Pp1Jhv/m7BMTzXGpcb8ENl3tDj/51U65R5lWzUH15GaZA15HQ5A5wtafklxYj7g==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/instrumentation": "^0.211.0"
@@ -7358,8 +5820,6 @@
 		},
 		"node_modules/@opentelemetry/instrumentation-mongodb": {
 			"version": "0.64.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.64.0.tgz",
-			"integrity": "sha512-pFlCJjweTqVp7B220mCvCld1c1eYKZfQt1p3bxSbcReypKLJTwat+wbL2YZoX9jPi5X2O8tTKFEOahO5ehQGsA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/instrumentation": "^0.211.0",
@@ -7374,8 +5834,6 @@
 		},
 		"node_modules/@opentelemetry/instrumentation-mongoose": {
 			"version": "0.57.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongoose/-/instrumentation-mongoose-0.57.0.tgz",
-			"integrity": "sha512-MthiekrU/BAJc5JZoZeJmo0OTX6ycJMiP6sMOSRTkvz5BrPMYDqaJos0OgsLPL/HpcgHP7eo5pduETuLguOqcg==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/core": "^2.0.0",
@@ -7391,8 +5849,6 @@
 		},
 		"node_modules/@opentelemetry/instrumentation-mysql": {
 			"version": "0.57.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.57.0.tgz",
-			"integrity": "sha512-HFS/+FcZ6Q7piM7Il7CzQ4VHhJvGMJWjx7EgCkP5AnTntSN5rb5Xi3TkYJHBKeR27A0QqPlGaCITi93fUDs++Q==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/instrumentation": "^0.211.0",
@@ -7408,8 +5864,6 @@
 		},
 		"node_modules/@opentelemetry/instrumentation-mysql2": {
 			"version": "0.57.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.57.0.tgz",
-			"integrity": "sha512-nHSrYAwF7+aV1E1V9yOOP9TchOodb6fjn4gFvdrdQXiRE7cMuffyLLbCZlZd4wsspBzVwOXX8mpURdRserAhNA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/instrumentation": "^0.211.0",
@@ -7425,8 +5879,6 @@
 		},
 		"node_modules/@opentelemetry/instrumentation-pg": {
 			"version": "0.63.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.63.0.tgz",
-			"integrity": "sha512-dKm/ODNN3GgIQVlbD6ZPxwRc3kleLf95hrRWXM+l8wYo+vSeXtEpQPT53afEf6VFWDVzJK55VGn8KMLtSve/cg==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/core": "^2.0.0",
@@ -7445,8 +5897,6 @@
 		},
 		"node_modules/@opentelemetry/instrumentation-redis": {
 			"version": "0.59.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis/-/instrumentation-redis-0.59.0.tgz",
-			"integrity": "sha512-JKv1KDDYA2chJ1PC3pLP+Q9ISMQk6h5ey+99mB57/ARk0vQPGZTTEb4h4/JlcEpy7AYT8HIGv7X6l+br03Neeg==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/instrumentation": "^0.211.0",
@@ -7462,8 +5912,6 @@
 		},
 		"node_modules/@opentelemetry/instrumentation-tedious": {
 			"version": "0.30.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-tedious/-/instrumentation-tedious-0.30.0.tgz",
-			"integrity": "sha512-bZy9Q8jFdycKQ2pAsyuHYUHNmCxCOGdG6eg1Mn75RvQDccq832sU5OWOBnc12EFUELI6icJkhR7+EQKMBam2GA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/instrumentation": "^0.211.0",
@@ -7479,8 +5927,6 @@
 		},
 		"node_modules/@opentelemetry/instrumentation-undici": {
 			"version": "0.21.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-undici/-/instrumentation-undici-0.21.0.tgz",
-			"integrity": "sha512-gok0LPUOTz2FQ1YJMZzaHcOzDFyT64XJ8M9rNkugk923/p6lDGms/cRW1cqgqp6N6qcd6K6YdVHwPEhnx9BWbw==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/core": "^2.0.0",
@@ -7496,8 +5942,6 @@
 		},
 		"node_modules/@opentelemetry/redis-common": {
 			"version": "0.38.2",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/redis-common/-/redis-common-0.38.2.tgz",
-			"integrity": "sha512-1BCcU93iwSRZvDAgwUxC/DV4T/406SkMfxGqu5ojc3AvNI+I9GhV7v0J1HljsczuuhcnFLYqD5VmwVXfCGHzxA==",
 			"license": "Apache-2.0",
 			"engines": {
 				"node": "^18.19.0 || >=20.6.0"
@@ -7505,8 +5949,6 @@
 		},
 		"node_modules/@opentelemetry/resources": {
 			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.6.0.tgz",
-			"integrity": "sha512-D4y/+OGe3JSuYUCBxtH5T9DSAWNcvCb/nQWIga8HNtXTVPQn59j0nTBAgaAXxUVBDl40mG3Tc76b46wPlZaiJQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/core": "2.6.0",
@@ -7521,8 +5963,6 @@
 		},
 		"node_modules/@opentelemetry/sdk-trace-base": {
 			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.6.0.tgz",
-			"integrity": "sha512-g/OZVkqlxllgFM7qMKqbPV9c1DUPhQ7d4n3pgZFcrnrNft9eJXZM2TNHTPYREJBrtNdRytYyvwjgL5geDKl3EQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/core": "2.6.0",
@@ -7538,8 +5978,6 @@
 		},
 		"node_modules/@opentelemetry/semantic-conventions": {
 			"version": "1.40.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
-			"integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=14"
@@ -7547,8 +5985,6 @@
 		},
 		"node_modules/@opentelemetry/sql-common": {
 			"version": "0.41.2",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/sql-common/-/sql-common-0.41.2.tgz",
-			"integrity": "sha512-4mhWm3Z8z+i508zQJ7r6Xi7y4mmoJpdvH0fZPFRkWrdp5fq7hhZ2HhYokEOLkfqSMgPR4Z9EyB3DBkbKGOqZiQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/core": "^2.0.0"
@@ -7568,451 +6004,6 @@
 			}
 		},
 		"node_modules/@php-wasm/cli-util": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/@php-wasm/cli-util/-/cli-util-3.1.5.tgz",
-			"integrity": "sha512-FU1MMy1+/FpGn/6uk4MLKPHS+fp6v84ILVdqF5uUlav0eZVDOntJ8B8wmA7i4UP6gvbtsWJNHVduBLBadzNVNQ==",
-			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/util": "3.1.5",
-				"fast-xml-parser": "^5.3.4",
-				"jsonc-parser": "3.3.1"
-			},
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
-		"node_modules/@php-wasm/logger": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/@php-wasm/logger/-/logger-3.1.5.tgz",
-			"integrity": "sha512-gDUh+LdU/SVNW8gQu+9yPjEhuJtQGSMnyWq6PIlL5a0er/nsalL3q86NZvTRHz0trZwGkTXGuFwK2UaXOILQ4g==",
-			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/node-polyfills": "3.1.5"
-			},
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
-		"node_modules/@php-wasm/node": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/@php-wasm/node/-/node-3.1.5.tgz",
-			"integrity": "sha512-BcJgj/Dr9KGlsA9MT6fUk81VQ/KDRV2Ye/FK9FAn6hL3LoOj08kORxa16ougO9p6Yjy/6tKMu09a+jSMGOLkZg==",
-			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/cli-util": "3.1.5",
-				"@php-wasm/logger": "3.1.5",
-				"@php-wasm/node-7-4": "3.1.5",
-				"@php-wasm/node-8-0": "3.1.5",
-				"@php-wasm/node-8-1": "3.1.5",
-				"@php-wasm/node-8-2": "3.1.5",
-				"@php-wasm/node-8-3": "3.1.5",
-				"@php-wasm/node-8-4": "3.1.5",
-				"@php-wasm/node-8-5": "3.1.5",
-				"@php-wasm/node-polyfills": "3.1.5",
-				"@php-wasm/universal": "3.1.5",
-				"@php-wasm/util": "3.1.5",
-				"@wp-playground/common": "3.1.5",
-				"express": "4.22.0",
-				"fast-xml-parser": "^5.3.4",
-				"fs-ext-extra-prebuilt": "2.2.7",
-				"ini": "4.1.2",
-				"jsonc-parser": "3.3.1",
-				"wasm-feature-detect": "1.8.0",
-				"ws": "8.18.3",
-				"yargs": "17.7.2"
-			},
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
-		"node_modules/@php-wasm/node-7-4": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/@php-wasm/node-7-4/-/node-7-4-3.1.5.tgz",
-			"integrity": "sha512-/lBVaytuT6b/F3GrlSF6Ig6xYII99FLw0wHDjRl6PoWNHXHllB5CE3kOrRDyXQHiIEFoqNUwWQrP8MkUpZrUCw==",
-			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/universal": "3.1.5",
-				"ini": "4.1.2",
-				"wasm-feature-detect": "1.8.0",
-				"ws": "8.18.3"
-			},
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
-		"node_modules/@php-wasm/node-7-4/node_modules/ini": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
-			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@php-wasm/node-8-0": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-0/-/node-8-0-3.1.5.tgz",
-			"integrity": "sha512-ZhHAwUf9doh/Oft23nzaY3No0qPd3DY8GoDDe7pI9Nk4+KghtkOxt2siWroPbeLaRf20oFwChGeozp7n6w5/rg==",
-			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/universal": "3.1.5",
-				"ini": "4.1.2",
-				"wasm-feature-detect": "1.8.0",
-				"ws": "8.18.3"
-			},
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
-		"node_modules/@php-wasm/node-8-0/node_modules/ini": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
-			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@php-wasm/node-8-1": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-1/-/node-8-1-3.1.5.tgz",
-			"integrity": "sha512-EMmxxA1e+qnrF+pRWL9KiE9vwf4A8UzzQeSF0wpbZGbvzVrraXo0XagBQi4jbdEk65xOTNkXhpOYsmfA7Gf2cw==",
-			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/universal": "3.1.5",
-				"ini": "4.1.2",
-				"wasm-feature-detect": "1.8.0",
-				"ws": "8.18.3"
-			},
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
-		"node_modules/@php-wasm/node-8-1/node_modules/ini": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
-			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@php-wasm/node-8-2": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-2/-/node-8-2-3.1.5.tgz",
-			"integrity": "sha512-poasM88l8ii/bQ6DZklpM6Of4WMPLH+SOcCqpO+QPVaLFWSvgNwFfpmRF9jwI3FkY+pfWwSH/HWWiei4+D3+sQ==",
-			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/universal": "3.1.5",
-				"ini": "4.1.2",
-				"wasm-feature-detect": "1.8.0",
-				"ws": "8.18.3"
-			},
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
-		"node_modules/@php-wasm/node-8-2/node_modules/ini": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
-			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@php-wasm/node-8-3": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-3/-/node-8-3-3.1.5.tgz",
-			"integrity": "sha512-nuZopXnQRp+gLdt6hBk5GPvfnMQ0hfdEiEHZuKZ2lmVaNjC8CVOTbGX4JXusuPxv4t5kEpBm8ya8P0XYX9uJWg==",
-			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/universal": "3.1.5",
-				"ini": "4.1.2",
-				"wasm-feature-detect": "1.8.0",
-				"ws": "8.18.3"
-			},
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
-		"node_modules/@php-wasm/node-8-3/node_modules/ini": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
-			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@php-wasm/node-8-4": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-4/-/node-8-4-3.1.5.tgz",
-			"integrity": "sha512-gZQa1dKCmL8b8weFhIiQ/vmV4alEfDlkUmsZWEsUj6nz2/xSY68rexCXlOUhAeU8457LGr5kbMZfXN8FfvYzog==",
-			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/universal": "3.1.5",
-				"ini": "4.1.2",
-				"wasm-feature-detect": "1.8.0",
-				"ws": "8.18.3"
-			},
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
-		"node_modules/@php-wasm/node-8-4/node_modules/ini": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
-			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@php-wasm/node-8-5": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-5/-/node-8-5-3.1.5.tgz",
-			"integrity": "sha512-P08HjGPv1ZssKCsQYoCeeAVGX5fo7WaX/cpGJsDQKAJPA7xlvjztxfTo0Ydasfl4/BqX0oBcgqPWLoCoxBC3kw==",
-			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/universal": "3.1.5",
-				"ini": "4.1.2",
-				"wasm-feature-detect": "1.8.0",
-				"ws": "8.18.3"
-			},
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
-		"node_modules/@php-wasm/node-8-5/node_modules/ini": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
-			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@php-wasm/node-polyfills": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/@php-wasm/node-polyfills/-/node-polyfills-3.1.5.tgz",
-			"integrity": "sha512-zGvYRZcwMWPBAneL7x4HBaCnvGAoTIxF8OZFox6Yob3HntYyFVC+GkIfV5WkamtxpALNWY+qR6yJ+a2XXIVgbw==",
-			"dev": true,
-			"license": "GPL-2.0-or-later"
-		},
-		"node_modules/@php-wasm/node/node_modules/cliui": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-			"integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"string-width": "^4.2.0",
-				"strip-ansi": "^6.0.1",
-				"wrap-ansi": "^7.0.0"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/@php-wasm/node/node_modules/ini": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
-			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@php-wasm/node/node_modules/strip-ansi": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^5.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/@php-wasm/node/node_modules/yargs": {
-			"version": "17.7.2",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-			"integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"cliui": "^8.0.1",
-				"escalade": "^3.1.1",
-				"get-caller-file": "^2.0.5",
-				"require-directory": "^2.1.1",
-				"string-width": "^4.2.3",
-				"y18n": "^5.0.5",
-				"yargs-parser": "^21.1.1"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/@php-wasm/node/node_modules/yargs-parser": {
-			"version": "21.1.1",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-			"integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/@php-wasm/progress": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/@php-wasm/progress/-/progress-3.1.5.tgz",
-			"integrity": "sha512-pWjF/sGGs2PQy+ZQUxCIQUMd6/QyShpUwXaaylMeeV1xVUuzrBXrW0l73uQ31Ss3eOLHWedGogv3lVy3Rgpcfw==",
-			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/logger": "3.1.5",
-				"@php-wasm/node-polyfills": "3.1.5"
-			},
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
-		"node_modules/@php-wasm/scopes": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/@php-wasm/scopes/-/scopes-3.1.5.tgz",
-			"integrity": "sha512-1t1v2eCm02thCYsGSv3aqNvdC4W49Ml5vCk3a939ZOFrOIWHotRvLdn0ATWsqGWo+O/DK/pS3SB9xZWuXa5CGg==",
-			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
-		"node_modules/@php-wasm/stream-compression": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/@php-wasm/stream-compression/-/stream-compression-3.1.5.tgz",
-			"integrity": "sha512-n6S+7Fg+uKtM8EnwKQm8UK9HH1MIKF0blNRT2Gj8nvpeMU7aC/wIOuXLKzFm2d9rflFS7BxmnvXcrny0ZIwclg==",
-			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/node-polyfills": "3.1.5",
-				"@php-wasm/util": "3.1.5"
-			}
-		},
-		"node_modules/@php-wasm/universal": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/@php-wasm/universal/-/universal-3.1.5.tgz",
-			"integrity": "sha512-IDc12RAc+fAQn1s3gWrN3haaHd0wLZpC42wYWx/7Ku5eNV4nU9Ax471r2DCftpV9cyOfYzEWB55ZOO81rKHKXA==",
-			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/logger": "3.1.5",
-				"@php-wasm/node-polyfills": "3.1.5",
-				"@php-wasm/progress": "3.1.5",
-				"@php-wasm/stream-compression": "3.1.5",
-				"@php-wasm/util": "3.1.5",
-				"ini": "4.1.2"
-			},
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
-		"node_modules/@php-wasm/universal/node_modules/ini": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
-			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@php-wasm/util": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/@php-wasm/util/-/util-3.1.5.tgz",
-			"integrity": "sha512-IWNH2ArQafy1C6FvBjDsM94QsMJeG1yN6iWH/8upjVrUBgXoI0GzH5y9gswmLSf1fiOh+bYZxVBjXEuRICM1HA==",
-			"dev": true,
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
-		"node_modules/@php-wasm/web-service-worker": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/@php-wasm/web-service-worker/-/web-service-worker-3.1.5.tgz",
-			"integrity": "sha512-R9PNKxDEkgwKEjQK/Fy8J8I4Wklzf8cPrq9Ui0uJJZ0vLBzc4lOV+Ya+BbclHZIT0kJjkkwq8dlmBh9/IuaQ6w==",
-			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/scopes": "3.1.5"
-			},
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
-		"node_modules/@php-wasm/xdebug-bridge": {
-			"version": "3.1.11",
-			"resolved": "https://registry.npmjs.org/@php-wasm/xdebug-bridge/-/xdebug-bridge-3.1.11.tgz",
-			"integrity": "sha512-Hk4rHJjlk/z765+0UVGbGUFnJC0/r0A7OgOVMnIzXKNODpwV8S7WoC1M8BUCAbPUl3VpK4mboglb6An7PvktVg==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/logger": "3.1.11",
-				"@php-wasm/node": "3.1.11",
-				"@php-wasm/universal": "3.1.11",
-				"@wp-playground/common": "3.1.11",
-				"express": "4.22.0",
-				"fast-xml-parser": "^5.5.1",
-				"fs-ext-extra-prebuilt": "2.2.7",
-				"ini": "4.1.2",
-				"jsonc-parser": "3.3.1",
-				"wasm-feature-detect": "1.8.0",
-				"ws": "8.18.3",
-				"xml2js": "0.6.2",
-				"yargs": "17.7.2"
-			},
-			"bin": {
-				"xdebug-bridge": "xdebug-bridge.js"
-			},
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
-		"node_modules/@php-wasm/xdebug-bridge/node_modules/@php-wasm/cli-util": {
 			"version": "3.1.11",
 			"resolved": "https://registry.npmjs.org/@php-wasm/cli-util/-/cli-util-3.1.11.tgz",
 			"integrity": "sha512-/v/S007ZZfTmDyYOReKtUnhiOWZi1EZdLrDiSPCmYms3XFNeJDUBWEkDshcwMxuDaA4Ce2ciF0QsM+yuY9vY9g==",
@@ -8027,7 +6018,7 @@
 				"npm": ">=10.2.3"
 			}
 		},
-		"node_modules/@php-wasm/xdebug-bridge/node_modules/@php-wasm/logger": {
+		"node_modules/@php-wasm/logger": {
 			"version": "3.1.11",
 			"resolved": "https://registry.npmjs.org/@php-wasm/logger/-/logger-3.1.11.tgz",
 			"integrity": "sha512-wGKmMpA8gvoLFEjG9jzm7E2BEAaq4LU9yMjMkzKwYE0RUivV1000Cnw+m+79/d4Bua0ouoCLab5+IFFJrfxYpw==",
@@ -8040,7 +6031,7 @@
 				"npm": ">=10.2.3"
 			}
 		},
-		"node_modules/@php-wasm/xdebug-bridge/node_modules/@php-wasm/node": {
+		"node_modules/@php-wasm/node": {
 			"version": "3.1.11",
 			"resolved": "https://registry.npmjs.org/@php-wasm/node/-/node-3.1.11.tgz",
 			"integrity": "sha512-qqJuQMm/Ey4Cv2h6F6q7Rj33KMo5z+33s2CABwRnS7fgzGBSQzB7vq4L2pScqVmvfRXnW1lFoUgFARojOOThkA==",
@@ -8073,7 +6064,7 @@
 				"npm": ">=10.2.3"
 			}
 		},
-		"node_modules/@php-wasm/xdebug-bridge/node_modules/@php-wasm/node-7-4": {
+		"node_modules/@php-wasm/node-7-4": {
 			"version": "3.1.11",
 			"resolved": "https://registry.npmjs.org/@php-wasm/node-7-4/-/node-7-4-3.1.11.tgz",
 			"integrity": "sha512-WGX0nOv6JsTXY+I0FqAB8wQLeQc8pAYbUg4LXEQnACZWPL9mdAvwk++XkScWQ5zfwUtrTq9TwpAXcyf3xRrIxQ==",
@@ -8089,7 +6080,16 @@
 				"npm": ">=10.2.3"
 			}
 		},
-		"node_modules/@php-wasm/xdebug-bridge/node_modules/@php-wasm/node-8-0": {
+		"node_modules/@php-wasm/node-7-4/node_modules/ini": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
+			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@php-wasm/node-8-0": {
 			"version": "3.1.11",
 			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-0/-/node-8-0-3.1.11.tgz",
 			"integrity": "sha512-92E8kydq6RmxYnFGXGTursqT/8doRND8fQoqerj4uJ4oMtPIBXREyBMAye4/ss3ls9IXSRbZKYQ03NptozcYfA==",
@@ -8105,7 +6105,16 @@
 				"npm": ">=10.2.3"
 			}
 		},
-		"node_modules/@php-wasm/xdebug-bridge/node_modules/@php-wasm/node-8-1": {
+		"node_modules/@php-wasm/node-8-0/node_modules/ini": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
+			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@php-wasm/node-8-1": {
 			"version": "3.1.11",
 			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-1/-/node-8-1-3.1.11.tgz",
 			"integrity": "sha512-fP7OWc0V7Hs1AEcr0cP8d49twJLSDwdHUyFwTuD7uPY+u9KrPW8ZrhR8+j2pmPrU0qMO5x+oPP1u8MFgNpWHOQ==",
@@ -8121,7 +6130,16 @@
 				"npm": ">=10.2.3"
 			}
 		},
-		"node_modules/@php-wasm/xdebug-bridge/node_modules/@php-wasm/node-8-2": {
+		"node_modules/@php-wasm/node-8-1/node_modules/ini": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
+			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@php-wasm/node-8-2": {
 			"version": "3.1.11",
 			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-2/-/node-8-2-3.1.11.tgz",
 			"integrity": "sha512-T72JABgcbo6OujFaVfKb+eJpgZgcTK5vmUoNDWZFvu7NvH9wSRkmnlas+HcqO2inEja0BvQbz7WWcDHUTj9rPQ==",
@@ -8137,7 +6155,16 @@
 				"npm": ">=10.2.3"
 			}
 		},
-		"node_modules/@php-wasm/xdebug-bridge/node_modules/@php-wasm/node-8-3": {
+		"node_modules/@php-wasm/node-8-2/node_modules/ini": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
+			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@php-wasm/node-8-3": {
 			"version": "3.1.11",
 			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-3/-/node-8-3-3.1.11.tgz",
 			"integrity": "sha512-KFOVw3E0ThCGN6pmdS16FIgHzbAVNLVrV4QkCvKmvPENMfKLOaJAwC3jN8qK4eE/j5jWqAZIQPsOPwVKkHziDw==",
@@ -8153,7 +6180,16 @@
 				"npm": ">=10.2.3"
 			}
 		},
-		"node_modules/@php-wasm/xdebug-bridge/node_modules/@php-wasm/node-8-4": {
+		"node_modules/@php-wasm/node-8-3/node_modules/ini": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
+			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@php-wasm/node-8-4": {
 			"version": "3.1.11",
 			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-4/-/node-8-4-3.1.11.tgz",
 			"integrity": "sha512-fSKp8C+rcORGHBQJRtrFkNfTmIsjtfMcuT81jWIs71zG2v1C0yIfEPdpRqHv6UVJVFToUb1ClEGY+dfqO9mXYA==",
@@ -8169,7 +6205,16 @@
 				"npm": ">=10.2.3"
 			}
 		},
-		"node_modules/@php-wasm/xdebug-bridge/node_modules/@php-wasm/node-8-5": {
+		"node_modules/@php-wasm/node-8-4/node_modules/ini": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
+			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@php-wasm/node-8-5": {
 			"version": "3.1.11",
 			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-5/-/node-8-5-3.1.11.tgz",
 			"integrity": "sha512-ystaL0/ab7GyQCReNFWpC2LPKa3u2gUXlMi0g/2CZDD4kavnzksuI/jAHhwnmTnZePbEam23rvdyq77ndC1TFw==",
@@ -8185,79 +6230,22 @@
 				"npm": ">=10.2.3"
 			}
 		},
-		"node_modules/@php-wasm/xdebug-bridge/node_modules/@php-wasm/node-polyfills": {
+		"node_modules/@php-wasm/node-8-5/node_modules/ini": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
+			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@php-wasm/node-polyfills": {
 			"version": "3.1.11",
 			"resolved": "https://registry.npmjs.org/@php-wasm/node-polyfills/-/node-polyfills-3.1.11.tgz",
 			"integrity": "sha512-Gu3wS1gWkyGSW/K+RQNT4OfjeapeYdL5bqOQ+/MEfvkaeMRDdzdOvmPcIfLbDBhZOSh6jAA7nT87Ri2LmeqYzQ==",
 			"license": "GPL-2.0-or-later"
 		},
-		"node_modules/@php-wasm/xdebug-bridge/node_modules/@php-wasm/progress": {
-			"version": "3.1.11",
-			"resolved": "https://registry.npmjs.org/@php-wasm/progress/-/progress-3.1.11.tgz",
-			"integrity": "sha512-/zsH+ZvBxq+Qlb2ffNvvjmiqaB6Fwo8+O3Py+WUznxIuQ/3Ckci+5cWyBtYQ6qtAGFSRADl41Qg9n6RmWBUL7w==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/logger": "3.1.11",
-				"@php-wasm/node-polyfills": "3.1.11"
-			},
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
-		"node_modules/@php-wasm/xdebug-bridge/node_modules/@php-wasm/stream-compression": {
-			"version": "3.1.11",
-			"resolved": "https://registry.npmjs.org/@php-wasm/stream-compression/-/stream-compression-3.1.11.tgz",
-			"integrity": "sha512-R9wfu3Zx083m8WTlWN888iZ9ub2nhZXGi5LVjfIQCd2UPuRbhFuOHiiyvnoHnZFyMZnzI12/MhuoPHuWv6NPew==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/node-polyfills": "3.1.11",
-				"@php-wasm/util": "3.1.11"
-			}
-		},
-		"node_modules/@php-wasm/xdebug-bridge/node_modules/@php-wasm/universal": {
-			"version": "3.1.11",
-			"resolved": "https://registry.npmjs.org/@php-wasm/universal/-/universal-3.1.11.tgz",
-			"integrity": "sha512-n+fGHL9wqLf6NBWsPdDbF7USY20FBZgBIJvUoi620xNQdakhZ425tCM7bEVBE+lcOY6/l4rFCIdSbY+HoJwg7w==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/logger": "3.1.11",
-				"@php-wasm/node-polyfills": "3.1.11",
-				"@php-wasm/progress": "3.1.11",
-				"@php-wasm/stream-compression": "3.1.11",
-				"@php-wasm/util": "3.1.11",
-				"ini": "4.1.2"
-			},
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
-		"node_modules/@php-wasm/xdebug-bridge/node_modules/@php-wasm/util": {
-			"version": "3.1.11",
-			"resolved": "https://registry.npmjs.org/@php-wasm/util/-/util-3.1.11.tgz",
-			"integrity": "sha512-9n/s609DDF03+M4DWbvf+BCaHGAGt56xOxceV91mQA1X0c+iLgBCYG2oLgOvs1Cl+anYxiVbsLUZBfjAxKLcbQ==",
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
-		"node_modules/@php-wasm/xdebug-bridge/node_modules/@wp-playground/common": {
-			"version": "3.1.11",
-			"resolved": "https://registry.npmjs.org/@wp-playground/common/-/common-3.1.11.tgz",
-			"integrity": "sha512-1/5yts2ExzfVxHqK4oz9dr9Jxeuh99zhAO5ClH3zROo/7gRXKWHZWoQXNLZnPJ3RlMqYzIzHzmozhyx29rtizQ==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/universal": "3.1.11",
-				"@php-wasm/util": "3.1.11",
-				"ini": "4.1.2"
-			},
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
-		"node_modules/@php-wasm/xdebug-bridge/node_modules/cliui": {
+		"node_modules/@php-wasm/node/node_modules/cliui": {
 			"version": "8.0.1",
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
 			"integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
@@ -8271,7 +6259,7 @@
 				"node": ">=12"
 			}
 		},
-		"node_modules/@php-wasm/xdebug-bridge/node_modules/ini": {
+		"node_modules/@php-wasm/node/node_modules/ini": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
 			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
@@ -8280,7 +6268,7 @@
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
 			}
 		},
-		"node_modules/@php-wasm/xdebug-bridge/node_modules/strip-ansi": {
+		"node_modules/@php-wasm/node/node_modules/strip-ansi": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
 			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
@@ -8292,7 +6280,7 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/@php-wasm/xdebug-bridge/node_modules/yargs": {
+		"node_modules/@php-wasm/node/node_modules/yargs": {
 			"version": "17.7.2",
 			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
 			"integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
@@ -8310,10 +6298,182 @@
 				"node": ">=12"
 			}
 		},
-		"node_modules/@php-wasm/xdebug-bridge/node_modules/yargs-parser": {
+		"node_modules/@php-wasm/node/node_modules/yargs-parser": {
 			"version": "21.1.1",
 			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
 			"integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@php-wasm/progress": {
+			"version": "3.1.11",
+			"resolved": "https://registry.npmjs.org/@php-wasm/progress/-/progress-3.1.11.tgz",
+			"integrity": "sha512-/zsH+ZvBxq+Qlb2ffNvvjmiqaB6Fwo8+O3Py+WUznxIuQ/3Ckci+5cWyBtYQ6qtAGFSRADl41Qg9n6RmWBUL7w==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/logger": "3.1.11",
+				"@php-wasm/node-polyfills": "3.1.11"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@php-wasm/scopes": {
+			"version": "3.1.11",
+			"resolved": "https://registry.npmjs.org/@php-wasm/scopes/-/scopes-3.1.11.tgz",
+			"integrity": "sha512-WyI1PHYA4vHmb2DHO6M2e8ydY1brfMRjRf1Z5FYhfyh7G2FEAJbOyoY/VenBOCw0dE04vkWU4LRuVwkFrO8+Ow==",
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@php-wasm/stream-compression": {
+			"version": "3.1.11",
+			"resolved": "https://registry.npmjs.org/@php-wasm/stream-compression/-/stream-compression-3.1.11.tgz",
+			"integrity": "sha512-R9wfu3Zx083m8WTlWN888iZ9ub2nhZXGi5LVjfIQCd2UPuRbhFuOHiiyvnoHnZFyMZnzI12/MhuoPHuWv6NPew==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/node-polyfills": "3.1.11",
+				"@php-wasm/util": "3.1.11"
+			}
+		},
+		"node_modules/@php-wasm/universal": {
+			"version": "3.1.11",
+			"resolved": "https://registry.npmjs.org/@php-wasm/universal/-/universal-3.1.11.tgz",
+			"integrity": "sha512-n+fGHL9wqLf6NBWsPdDbF7USY20FBZgBIJvUoi620xNQdakhZ425tCM7bEVBE+lcOY6/l4rFCIdSbY+HoJwg7w==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/logger": "3.1.11",
+				"@php-wasm/node-polyfills": "3.1.11",
+				"@php-wasm/progress": "3.1.11",
+				"@php-wasm/stream-compression": "3.1.11",
+				"@php-wasm/util": "3.1.11",
+				"ini": "4.1.2"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@php-wasm/universal/node_modules/ini": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
+			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@php-wasm/util": {
+			"version": "3.1.11",
+			"resolved": "https://registry.npmjs.org/@php-wasm/util/-/util-3.1.11.tgz",
+			"integrity": "sha512-9n/s609DDF03+M4DWbvf+BCaHGAGt56xOxceV91mQA1X0c+iLgBCYG2oLgOvs1Cl+anYxiVbsLUZBfjAxKLcbQ==",
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@php-wasm/web-service-worker": {
+			"version": "3.1.11",
+			"resolved": "https://registry.npmjs.org/@php-wasm/web-service-worker/-/web-service-worker-3.1.11.tgz",
+			"integrity": "sha512-8qCh2Y5ZrLw1EP+s5iYCBE4HnBcB0HjudGPNLs2azYRZHOo5C3Xjc+VI5BDdfyLEZl3AOg5y6dE0dk2ur2WCeg==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/scopes": "3.1.11",
+				"@php-wasm/universal": "3.1.11",
+				"ini": "4.1.2"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@php-wasm/web-service-worker/node_modules/ini": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
+			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@php-wasm/xdebug-bridge": {
+			"version": "3.1.11",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@php-wasm/logger": "3.1.11",
+				"@php-wasm/node": "3.1.11",
+				"@php-wasm/universal": "3.1.11",
+				"@wp-playground/common": "3.1.11",
+				"express": "4.22.0",
+				"fast-xml-parser": "^5.5.1",
+				"fs-ext-extra-prebuilt": "2.2.7",
+				"ini": "4.1.2",
+				"jsonc-parser": "3.3.1",
+				"wasm-feature-detect": "1.8.0",
+				"ws": "8.18.3",
+				"xml2js": "0.6.2",
+				"yargs": "17.7.2"
+			},
+			"bin": {
+				"xdebug-bridge": "xdebug-bridge.js"
+			},
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
+		"node_modules/@php-wasm/xdebug-bridge/node_modules/cliui": {
+			"version": "8.0.1",
+			"license": "ISC",
+			"dependencies": {
+				"string-width": "^4.2.0",
+				"strip-ansi": "^6.0.1",
+				"wrap-ansi": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@php-wasm/xdebug-bridge/node_modules/ini": {
+			"version": "4.1.2",
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@php-wasm/xdebug-bridge/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@php-wasm/xdebug-bridge/node_modules/yargs": {
+			"version": "17.7.2",
+			"license": "MIT",
+			"dependencies": {
+				"cliui": "^8.0.1",
+				"escalade": "^3.1.1",
+				"get-caller-file": "^2.0.5",
+				"require-directory": "^2.1.1",
+				"string-width": "^4.2.3",
+				"y18n": "^5.0.5",
+				"yargs-parser": "^21.1.1"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@php-wasm/xdebug-bridge/node_modules/yargs-parser": {
+			"version": "21.1.1",
 			"license": "ISC",
 			"engines": {
 				"node": ">=12"
@@ -8330,8 +6490,6 @@
 		},
 		"node_modules/@pkgr/core": {
 			"version": "0.2.9",
-			"resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz",
-			"integrity": "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -8343,8 +6501,6 @@
 		},
 		"node_modules/@playwright/test": {
 			"version": "1.58.2",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
-			"integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -8364,8 +6520,6 @@
 		},
 		"node_modules/@prisma/instrumentation": {
 			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@prisma/instrumentation/-/instrumentation-7.2.0.tgz",
-			"integrity": "sha512-Rh9Z4x5kEj1OdARd7U18AtVrnL6rmLSI0qYShaB4W7Wx5BKbgzndWF+QnuzMb7GLfVdlT5aYCXoPQVYuYtVu0g==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/instrumentation": "^0.207.0"
@@ -8376,8 +6530,6 @@
 		},
 		"node_modules/@prisma/instrumentation/node_modules/@opentelemetry/api-logs": {
 			"version": "0.207.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.207.0.tgz",
-			"integrity": "sha512-lAb0jQRVyleQQGiuuvCOTDVspc14nx6XJjP4FspJ1sNARo3Regq4ZZbrc3rN4b1TYSuUCvgH+UXUPug4SLOqEQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/api": "^1.3.0"
@@ -8388,8 +6540,6 @@
 		},
 		"node_modules/@prisma/instrumentation/node_modules/@opentelemetry/instrumentation": {
 			"version": "0.207.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.207.0.tgz",
-			"integrity": "sha512-y6eeli9+TLKnznrR8AZlQMSJT7wILpXH+6EYq5Vf/4Ao+huI7EedxQHwRgVUOMLFbe7VFDvHJrX9/f4lcwnJsA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/api-logs": "0.207.0",
@@ -8443,8 +6593,6 @@
 		},
 		"node_modules/@rolldown/pluginutils": {
 			"version": "1.0.0-rc.3",
-			"resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
-			"integrity": "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -8673,9 +6821,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-linux-x64-gnu": {
-			"version": "4.57.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.57.1.tgz",
-			"integrity": "sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==",
+			"version": "4.59.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
+			"integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
 			"cpu": [
 				"x64"
 			],
@@ -8742,9 +6890,9 @@
 			]
 		},
 		"node_modules/@rollup/rollup-win32-x64-msvc": {
-			"version": "4.57.1",
-			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.57.1.tgz",
-			"integrity": "sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==",
+			"version": "4.59.0",
+			"resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
+			"integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
 			"cpu": [
 				"x64"
 			],
@@ -8761,8 +6909,6 @@
 		},
 		"node_modules/@sentry-internal/browser-utils": {
 			"version": "10.42.0",
-			"resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-10.42.0.tgz",
-			"integrity": "sha512-HCEICKvepxN4/6NYfnMMMlppcSwIEwtS66X6d1/mwaHdi2ivw0uGl52p7Nfhda/lIJArbrkWprxl0WcjZajhQA==",
 			"license": "MIT",
 			"dependencies": {
 				"@sentry/core": "10.42.0"
@@ -8773,8 +6919,6 @@
 		},
 		"node_modules/@sentry-internal/feedback": {
 			"version": "10.42.0",
-			"resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-10.42.0.tgz",
-			"integrity": "sha512-lpPcHsog10MVYFTWE0Pf8vQRqQWwZHJpkVl2FEb9/HDdHFyTBUhCVoWo1KyKaG7GJl9AVKMAg7bp9SSNArhFNQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@sentry/core": "10.42.0"
@@ -8785,8 +6929,6 @@
 		},
 		"node_modules/@sentry-internal/replay": {
 			"version": "10.42.0",
-			"resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-10.42.0.tgz",
-			"integrity": "sha512-Zh3EoaH39x2lqVY1YyVB2vJEyCIrT+YLUQxYl1yvP0MJgLxaR6akVjkgxbSUJahan4cX5DxpZiEHfzdlWnYPyQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@sentry-internal/browser-utils": "10.42.0",
@@ -8798,8 +6940,6 @@
 		},
 		"node_modules/@sentry-internal/replay-canvas": {
 			"version": "10.42.0",
-			"resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-10.42.0.tgz",
-			"integrity": "sha512-am3m1Fj8ihoPfoYo41Qq4KeCAAICn4bySso8Oepu9dMNe9Lcnsf+reMRS2qxTPg3pZDc4JEMOcLyNCcgnAfrHw==",
 			"license": "MIT",
 			"dependencies": {
 				"@sentry-internal/replay": "10.42.0",
@@ -8811,8 +6951,6 @@
 		},
 		"node_modules/@sentry/babel-plugin-component-annotate": {
 			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/@sentry/babel-plugin-component-annotate/-/babel-plugin-component-annotate-5.1.1.tgz",
-			"integrity": "sha512-x2wEpBHwsTyTF2rWsLKJlzrRF1TTIGOfX+ngdE+Yd5DBkoS58HwQv824QOviPGQRla4/ypISqAXzjdDPL/zalg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -8821,8 +6959,6 @@
 		},
 		"node_modules/@sentry/browser": {
 			"version": "10.42.0",
-			"resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.42.0.tgz",
-			"integrity": "sha512-iXxYjXNEBwY1MH4lDSDZZUNjzPJDK7/YLwVIJq/3iBYpIQVIhaJsoJnf3clx9+NfJ8QFKyKfcvgae61zm+hgTA==",
 			"license": "MIT",
 			"dependencies": {
 				"@sentry-internal/browser-utils": "10.42.0",
@@ -8837,8 +6973,6 @@
 		},
 		"node_modules/@sentry/bundler-plugin-core": {
 			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/@sentry/bundler-plugin-core/-/bundler-plugin-core-5.1.1.tgz",
-			"integrity": "sha512-F+itpwR9DyQR7gEkrXd2tigREPTvtF5lC8qu6e4anxXYRTui1+dVR0fXNwjpyAZMhIesLfXRN7WY7ggdj7hi0Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -8856,8 +6990,6 @@
 		},
 		"node_modules/@sentry/bundler-plugin-core/node_modules/balanced-match": {
 			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -8866,8 +6998,6 @@
 		},
 		"node_modules/@sentry/bundler-plugin-core/node_modules/brace-expansion": {
 			"version": "5.0.4",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-			"integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -8879,8 +7009,6 @@
 		},
 		"node_modules/@sentry/bundler-plugin-core/node_modules/glob": {
 			"version": "13.0.6",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-			"integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
 			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"dependencies": {
@@ -8897,8 +7025,6 @@
 		},
 		"node_modules/@sentry/bundler-plugin-core/node_modules/lru-cache": {
 			"version": "11.2.6",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
-			"integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
 			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"engines": {
@@ -8907,8 +7033,6 @@
 		},
 		"node_modules/@sentry/bundler-plugin-core/node_modules/minimatch": {
 			"version": "10.2.4",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-			"integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
 			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"dependencies": {
@@ -8923,8 +7047,6 @@
 		},
 		"node_modules/@sentry/bundler-plugin-core/node_modules/minipass": {
 			"version": "7.1.3",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
-			"integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
 			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"engines": {
@@ -8933,8 +7055,6 @@
 		},
 		"node_modules/@sentry/bundler-plugin-core/node_modules/path-scurry": {
 			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
-			"integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
 			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"dependencies": {
@@ -8950,8 +7070,6 @@
 		},
 		"node_modules/@sentry/cli": {
 			"version": "2.58.5",
-			"resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-2.58.5.tgz",
-			"integrity": "sha512-tavJ7yGUZV+z3Ct2/ZB6mg339i08sAk6HDkgqmSRuQEu2iLS5sl9HIvuXfM6xjv8fwlgFOSy++WNABNAcGHUbg==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "FSL-1.1-MIT",
@@ -8981,8 +7099,6 @@
 		},
 		"node_modules/@sentry/cli-darwin": {
 			"version": "2.58.5",
-			"resolved": "https://registry.npmjs.org/@sentry/cli-darwin/-/cli-darwin-2.58.5.tgz",
-			"integrity": "sha512-lYrNzenZFJftfwSya7gwrHGxtE+Kob/e1sr9lmHMFOd4utDlmq0XFDllmdZAMf21fxcPRI1GL28ejZ3bId01fQ==",
 			"dev": true,
 			"license": "FSL-1.1-MIT",
 			"optional": true,
@@ -8993,139 +7109,8 @@
 				"node": ">=10"
 			}
 		},
-		"node_modules/@sentry/cli-linux-arm": {
-			"version": "2.58.5",
-			"resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm/-/cli-linux-arm-2.58.5.tgz",
-			"integrity": "sha512-KtHweSIomYL4WVDrBrYSYJricKAAzxUgX86kc6OnlikbyOhoK6Fy8Vs6vwd52P6dvWPjgrMpUYjW2M5pYXQDUw==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"license": "FSL-1.1-MIT",
-			"optional": true,
-			"os": [
-				"linux",
-				"freebsd",
-				"android"
-			],
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/@sentry/cli-linux-arm64": {
-			"version": "2.58.5",
-			"resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm64/-/cli-linux-arm64-2.58.5.tgz",
-			"integrity": "sha512-/4gywFeBqRB6tR/iGMRAJ3HRqY6Z7Yp4l8ZCbl0TDLAfHNxu7schEw4tSnm2/Hh9eNMiOVy4z58uzAWlZXAYBQ==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "FSL-1.1-MIT",
-			"optional": true,
-			"os": [
-				"linux",
-				"freebsd",
-				"android"
-			],
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/@sentry/cli-linux-i686": {
-			"version": "2.58.5",
-			"resolved": "https://registry.npmjs.org/@sentry/cli-linux-i686/-/cli-linux-i686-2.58.5.tgz",
-			"integrity": "sha512-G7261dkmyxqlMdyvyP06b+RTIVzp1gZNgglj5UksxSouSUqRd/46W/2pQeOMPhloDYo9yLtCN2YFb3Mw4aUsWw==",
-			"cpu": [
-				"x86",
-				"ia32"
-			],
-			"dev": true,
-			"license": "FSL-1.1-MIT",
-			"optional": true,
-			"os": [
-				"linux",
-				"freebsd",
-				"android"
-			],
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/@sentry/cli-linux-x64": {
-			"version": "2.58.5",
-			"resolved": "https://registry.npmjs.org/@sentry/cli-linux-x64/-/cli-linux-x64-2.58.5.tgz",
-			"integrity": "sha512-rP04494RSmt86xChkQ+ecBNRYSPbyXc4u0IA7R7N1pSLCyO74e5w5Al+LnAq35cMfVbZgz5Sm0iGLjyiUu4I1g==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "FSL-1.1-MIT",
-			"optional": true,
-			"os": [
-				"linux",
-				"freebsd",
-				"android"
-			],
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/@sentry/cli-win32-arm64": {
-			"version": "2.58.5",
-			"resolved": "https://registry.npmjs.org/@sentry/cli-win32-arm64/-/cli-win32-arm64-2.58.5.tgz",
-			"integrity": "sha512-AOJ2nCXlQL1KBaCzv38m3i2VmSHNurUpm7xVKd6yAHX+ZoVBI8VT0EgvwmtJR2TY2N2hNCC7UrgRmdUsQ152bA==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "FSL-1.1-MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/@sentry/cli-win32-i686": {
-			"version": "2.58.5",
-			"resolved": "https://registry.npmjs.org/@sentry/cli-win32-i686/-/cli-win32-i686-2.58.5.tgz",
-			"integrity": "sha512-EsuboLSOnlrN7MMPJ1eFvfMDm+BnzOaSWl8eYhNo8W/BIrmNgpRUdBwnWn9Q2UOjJj5ZopukmsiMYtU/D7ml9g==",
-			"cpu": [
-				"x86",
-				"ia32"
-			],
-			"dev": true,
-			"license": "FSL-1.1-MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/@sentry/cli-win32-x64": {
-			"version": "2.58.5",
-			"resolved": "https://registry.npmjs.org/@sentry/cli-win32-x64/-/cli-win32-x64-2.58.5.tgz",
-			"integrity": "sha512-IZf+XIMiQwj+5NzqbOQfywlOitmCV424Vtf9c+ep61AaVScUFD1TSrQbOcJJv5xGxhlxNOMNgMeZhdexdzrKZg==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "FSL-1.1-MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/@sentry/core": {
 			"version": "10.42.0",
-			"resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.42.0.tgz",
-			"integrity": "sha512-L4rMrXMqUKBanpjpMT+TuAVk6xAijz6AWM6RiEYpohAr7SGcCEc1/T0+Ep1eLV8+pwWacfU27OvELIyNeOnGzA==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
@@ -9133,8 +7118,6 @@
 		},
 		"node_modules/@sentry/electron": {
 			"version": "7.10.0",
-			"resolved": "https://registry.npmjs.org/@sentry/electron/-/electron-7.10.0.tgz",
-			"integrity": "sha512-RwifPIBQds31giWL5KF87R/owzcVamMcXkL2ctoe/ybsxV861cbNhXxba/XCI6YmYOGIaixqiCAasxeZ+mx1SA==",
 			"license": "MIT",
 			"dependencies": {
 				"@sentry/browser": "10.42.0",
@@ -9152,8 +7135,6 @@
 		},
 		"node_modules/@sentry/node": {
 			"version": "10.42.0",
-			"resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.42.0.tgz",
-			"integrity": "sha512-ZZfU3Fnni7Aj0lTX4e3QpY3UxK4FGuzfM20316UAJycBGnripm+sDHwcekPMGfLnk/FrN9wa1atspVlHvOI0WQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@fastify/otel": "0.16.0",
@@ -9198,8 +7179,6 @@
 		},
 		"node_modules/@sentry/node-core": {
 			"version": "10.42.0",
-			"resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.42.0.tgz",
-			"integrity": "sha512-9tf3fPV6M071aps72D+PEtdQPTuj+SuqO2+PpTfdPP5ZL4TTKYo3VK0li76SL+5wGdTFGV5qmsokHq9IRBA0iA==",
 			"license": "MIT",
 			"dependencies": {
 				"@sentry/core": "10.42.0",
@@ -9244,8 +7223,6 @@
 		},
 		"node_modules/@sentry/opentelemetry": {
 			"version": "10.42.0",
-			"resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.42.0.tgz",
-			"integrity": "sha512-5vsYz683iihzlIj3sT1+tEixf0awwXK86a+aYsnMHrTXJDrkBDq4U0ZT+yxdPfJlkaxRtYycFR08SXr2pSm7Eg==",
 			"license": "MIT",
 			"dependencies": {
 				"@sentry/core": "10.42.0"
@@ -9263,8 +7240,6 @@
 		},
 		"node_modules/@sentry/react": {
 			"version": "10.43.0",
-			"resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.43.0.tgz",
-			"integrity": "sha512-shvErEpJ41i0Q3lIZl0CDWYQ7m8yHLi7ECG0gFvN8zf8pEdl5grQIOoe3t/GIUzcpCcor16F148ATmKJJypc/Q==",
 			"license": "MIT",
 			"dependencies": {
 				"@sentry/browser": "10.43.0",
@@ -9279,8 +7254,6 @@
 		},
 		"node_modules/@sentry/react/node_modules/@sentry-internal/browser-utils": {
 			"version": "10.43.0",
-			"resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-10.43.0.tgz",
-			"integrity": "sha512-8zYTnzhAPvNkVH1Irs62wl0J/c+0QcJ62TonKnzpSFUUD3V5qz8YDZbjIDGfxy+1EB9fO0sxtddKCzwTHF/MbQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@sentry/core": "10.43.0"
@@ -9291,8 +7264,6 @@
 		},
 		"node_modules/@sentry/react/node_modules/@sentry-internal/feedback": {
 			"version": "10.43.0",
-			"resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-10.43.0.tgz",
-			"integrity": "sha512-YoXuwluP6eOcQxTeTtaWb090++MrLyWOVsUTejzUQQ6LFL13Jwt+bDPF1kvBugMq4a7OHw/UNKQfd6//rZMn2g==",
 			"license": "MIT",
 			"dependencies": {
 				"@sentry/core": "10.43.0"
@@ -9303,8 +7274,6 @@
 		},
 		"node_modules/@sentry/react/node_modules/@sentry-internal/replay": {
 			"version": "10.43.0",
-			"resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-10.43.0.tgz",
-			"integrity": "sha512-khCXlGrlH1IU7P5zCEAJFestMeH97zDVCekj8OsNNDtN/1BmCJ46k6Xi0EqAUzdJgrOLJeLdoYdgtiIjovZ8Sg==",
 			"license": "MIT",
 			"dependencies": {
 				"@sentry-internal/browser-utils": "10.43.0",
@@ -9316,8 +7285,6 @@
 		},
 		"node_modules/@sentry/react/node_modules/@sentry-internal/replay-canvas": {
 			"version": "10.43.0",
-			"resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-10.43.0.tgz",
-			"integrity": "sha512-ZIw1UNKOFXo1LbPCJPMAx9xv7D8TMZQusLDUgb6BsPQJj0igAuwd7KRGTkjjgnrwBp2O/sxcQFRhQhknWk7QPg==",
 			"license": "MIT",
 			"dependencies": {
 				"@sentry-internal/replay": "10.43.0",
@@ -9329,8 +7296,6 @@
 		},
 		"node_modules/@sentry/react/node_modules/@sentry/browser": {
 			"version": "10.43.0",
-			"resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.43.0.tgz",
-			"integrity": "sha512-2V3I3sXi3SMeiZpKixd9ztokSgK27cmvsD9J5oyOyjhGLTW/6QKCwHbKnluMgQMXq20nixQk5zN4wRjRUma3sg==",
 			"license": "MIT",
 			"dependencies": {
 				"@sentry-internal/browser-utils": "10.43.0",
@@ -9345,8 +7310,6 @@
 		},
 		"node_modules/@sentry/react/node_modules/@sentry/core": {
 			"version": "10.43.0",
-			"resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.43.0.tgz",
-			"integrity": "sha512-l0SszQAPiQGWl/ferw8GP3ALyHXiGiRKJaOvNmhGO+PrTQyZTZ6OYyPnGijAFRg58dE1V3RCH/zw5d2xSUIiNg==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
@@ -9354,8 +7317,6 @@
 		},
 		"node_modules/@sentry/rollup-plugin": {
 			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/@sentry/rollup-plugin/-/rollup-plugin-5.1.1.tgz",
-			"integrity": "sha512-1d5NkdRR6aKWBP7czkY8sFFWiKnfmfRpQOj+m9bJTsyTjbMiEQJst6315w5pCVlRItPhBqpAraqAhutZFgvyVg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -9371,8 +7332,6 @@
 		},
 		"node_modules/@sentry/vite-plugin": {
 			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/@sentry/vite-plugin/-/vite-plugin-5.1.1.tgz",
-			"integrity": "sha512-i6NWUDi2SDikfSUeMJvJTRdwEKYSfTd+mvBO2Ja51S1YK+hnickBuDfD+RvPerIXLuyRu3GamgNPbNqgCGUg/Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -9385,8 +7344,6 @@
 		},
 		"node_modules/@sindresorhus/df": {
 			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/@sindresorhus/df/-/df-3.1.1.tgz",
-			"integrity": "sha512-SME/vtXaJcnQ/HpeV6P82Egy+jThn11IKfwW8+/XVoRD0rmPHVTeKMtww1oWdVnMykzVPjmrDN9S8NBndPEHCQ==",
 			"license": "MIT",
 			"dependencies": {
 				"execa": "^2.0.1"
@@ -9397,8 +7354,6 @@
 		},
 		"node_modules/@sindresorhus/df/node_modules/execa": {
 			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/execa/-/execa-2.1.0.tgz",
-			"integrity": "sha512-Y/URAVapfbYy2Xp/gb6A0E7iR8xeqOCXsuuaoMn7A5PzrXUK84E1gyiEfq0wQd/GHA6GsoHWwhNq8anb0mleIw==",
 			"license": "MIT",
 			"dependencies": {
 				"cross-spawn": "^7.0.0",
@@ -9417,8 +7372,6 @@
 		},
 		"node_modules/@sindresorhus/df/node_modules/get-stream": {
 			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-			"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
 			"license": "MIT",
 			"dependencies": {
 				"pump": "^3.0.0"
@@ -9432,8 +7385,6 @@
 		},
 		"node_modules/@sindresorhus/df/node_modules/is-stream": {
 			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-			"integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -9444,8 +7395,6 @@
 		},
 		"node_modules/@sindresorhus/df/node_modules/npm-run-path": {
 			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-3.1.0.tgz",
-			"integrity": "sha512-Dbl4A/VfiVGLgQv29URL9xshU8XDY1GeLy+fsaZ1AA8JDSfjvr5P5+pzRbWqRSBxk6/DW7MIh8lTM/PaGnP2kg==",
 			"license": "MIT",
 			"dependencies": {
 				"path-key": "^3.0.0"
@@ -9456,8 +7405,6 @@
 		},
 		"node_modules/@sindresorhus/df/node_modules/p-finally": {
 			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
-			"integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -9476,8 +7423,6 @@
 		},
 		"node_modules/@sindresorhus/merge-streams": {
 			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
-			"integrity": "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
@@ -9496,8 +7441,6 @@
 		},
 		"node_modules/@stroncium/procfs": {
 			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@stroncium/procfs/-/procfs-1.2.1.tgz",
-			"integrity": "sha512-X1Iui3FUNZP18EUvysTHxt+Avu2nlVzyf90YM8OYgP6SGzTzzX/0JgObfO1AQQDzuZtNNz29bVh8h5R97JrjxA==",
 			"license": "CC0-1.0",
 			"engines": {
 				"node": ">=8"
@@ -9554,150 +7497,7 @@
 			"os": [
 				"darwin"
 			],
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/@swc/core-darwin-x64": {
-			"version": "1.13.5",
-			"resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.13.5.tgz",
-			"integrity": "sha512-ILd38Fg/w23vHb0yVjlWvQBoE37ZJTdlLHa8LRCFDdX4WKfnVBiblsCU9ar4QTMNdeTBEX9iUF4IrbNWhaF1Ng==",
-			"cpu": [
-				"x64"
-			],
-			"license": "Apache-2.0 AND MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/@swc/core-linux-arm-gnueabihf": {
-			"version": "1.13.5",
-			"resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.13.5.tgz",
-			"integrity": "sha512-Q6eS3Pt8GLkXxqz9TAw+AUk9HpVJt8Uzm54MvPsqp2yuGmY0/sNaPPNVqctCX9fu/Nu8eaWUen0si6iEiCsazQ==",
-			"cpu": [
-				"arm"
-			],
-			"license": "Apache-2.0",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/@swc/core-linux-arm64-gnu": {
-			"version": "1.13.5",
-			"resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.13.5.tgz",
-			"integrity": "sha512-aNDfeN+9af+y+M2MYfxCzCy/VDq7Z5YIbMqRI739o8Ganz6ST+27kjQFd8Y/57JN/hcnUEa9xqdS3XY7WaVtSw==",
-			"cpu": [
-				"arm64"
-			],
-			"license": "Apache-2.0 AND MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/@swc/core-linux-arm64-musl": {
-			"version": "1.13.5",
-			"resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.13.5.tgz",
-			"integrity": "sha512-9+ZxFN5GJag4CnYnq6apKTnnezpfJhCumyz0504/JbHLo+Ue+ZtJnf3RhyA9W9TINtLE0bC4hKpWi8ZKoETyOQ==",
-			"cpu": [
-				"arm64"
-			],
-			"license": "Apache-2.0 AND MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/@swc/core-linux-x64-gnu": {
-			"version": "1.13.5",
-			"resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.13.5.tgz",
-			"integrity": "sha512-WD530qvHrki8Ywt/PloKUjaRKgstQqNGvmZl54g06kA+hqtSE2FTG9gngXr3UJxYu/cNAjJYiBifm7+w4nbHbA==",
-			"cpu": [
-				"x64"
-			],
-			"license": "Apache-2.0 AND MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/@swc/core-linux-x64-musl": {
-			"version": "1.13.5",
-			"resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.13.5.tgz",
-			"integrity": "sha512-Luj8y4OFYx4DHNQTWjdIuKTq2f5k6uSXICqx+FSabnXptaOBAbJHNbHT/06JZh6NRUouaf0mYXN0mcsqvkhd7Q==",
-			"cpu": [
-				"x64"
-			],
-			"license": "Apache-2.0 AND MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/@swc/core-win32-arm64-msvc": {
-			"version": "1.13.5",
-			"resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.13.5.tgz",
-			"integrity": "sha512-cZ6UpumhF9SDJvv4DA2fo9WIzlNFuKSkZpZmPG1c+4PFSEMy5DFOjBSllCvnqihCabzXzpn6ykCwBmHpy31vQw==",
-			"cpu": [
-				"arm64"
-			],
-			"license": "Apache-2.0 AND MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/@swc/core-win32-ia32-msvc": {
-			"version": "1.13.5",
-			"resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.13.5.tgz",
-			"integrity": "sha512-C5Yi/xIikrFUzZcyGj9L3RpKljFvKiDMtyDzPKzlsDrKIw2EYY+bF88gB6oGY5RGmv4DAX8dbnpRAqgFD0FMEw==",
-			"cpu": [
-				"ia32"
-			],
-			"license": "Apache-2.0 AND MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/@swc/core-win32-x64-msvc": {
-			"version": "1.13.5",
-			"resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.13.5.tgz",
-			"integrity": "sha512-YrKdMVxbYmlfybCSbRtrilc6UA8GF5aPmGKBdPvjrarvsmf4i7ZHGCEnLtfOMd3Lwbs2WUZq3WdMbozYeLU93Q==",
-			"cpu": [
-				"x64"
-			],
-			"license": "Apache-2.0 AND MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
+			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -9802,8 +7602,6 @@
 		},
 		"node_modules/@testing-library/react": {
 			"version": "16.3.2",
-			"resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
-			"integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -9850,8 +7648,6 @@
 		},
 		"node_modules/@tsconfig/node10": {
 			"version": "1.0.12",
-			"resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
-			"integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
 			"license": "MIT"
 		},
 		"node_modules/@tsconfig/node12": {
@@ -9865,17 +7661,6 @@
 		"node_modules/@tsconfig/node16": {
 			"version": "1.0.4",
 			"license": "MIT"
-		},
-		"node_modules/@tybys/wasm-util": {
-			"version": "0.10.1",
-			"resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-			"integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"tslib": "^2.4.0"
-			}
 		},
 		"node_modules/@types/appdmg": {
 			"version": "0.5.5",
@@ -9902,8 +7687,6 @@
 		},
 		"node_modules/@types/aws-lambda": {
 			"version": "8.10.160",
-			"resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.160.tgz",
-			"integrity": "sha512-uoO4QVQNWFPJMh26pXtmtrRfGshPUSpMZGUyUQY20FhfHEElEBOPKgVmFs1z+kbpyBsRs2JnoOPT7++Z4GA9pA==",
 			"license": "MIT"
 		},
 		"node_modules/@types/babel__core": {
@@ -9945,8 +7728,6 @@
 		},
 		"node_modules/@types/btoa-lite": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@types/btoa-lite/-/btoa-lite-1.0.2.tgz",
-			"integrity": "sha512-ZYbcE2x7yrvNFJiU7xJGrpF/ihpkM7zKgw8bha3LNJSesvTtUNxbpzaT7WXBIryf6jovisrxTBvymxMeLLj1Mg==",
 			"license": "MIT"
 		},
 		"node_modules/@types/cacheable-request": {
@@ -9962,8 +7743,6 @@
 		},
 		"node_modules/@types/chai": {
 			"version": "5.2.3",
-			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
-			"integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -9973,8 +7752,6 @@
 		},
 		"node_modules/@types/connect": {
 			"version": "3.4.38",
-			"resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
-			"integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
 			"license": "MIT",
 			"dependencies": {
 				"@types/node": "*"
@@ -9989,8 +7766,6 @@
 		},
 		"node_modules/@types/deep-eql": {
 			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
-			"integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -10042,8 +7817,6 @@
 		},
 		"node_modules/@types/glob": {
 			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-8.1.0.tgz",
-			"integrity": "sha512-IO+MJPVhoqz+28h1qLAcBEH2+xHMK6MTyHJc7MTnnYb6wsoLR29POVGJ7LycmVXIqyy/4/2ShP5sUwTXuOwb/w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -10068,8 +7841,6 @@
 		},
 		"node_modules/@types/http-cache-semantics": {
 			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
-			"integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -10100,8 +7871,6 @@
 		},
 		"node_modules/@types/jsonwebtoken": {
 			"version": "9.0.10",
-			"resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz",
-			"integrity": "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==",
 			"license": "MIT",
 			"dependencies": {
 				"@types/ms": "*",
@@ -10130,14 +7899,10 @@
 		},
 		"node_modules/@types/mime-types": {
 			"version": "2.1.4",
-			"resolved": "https://registry.npmjs.org/@types/mime-types/-/mime-types-2.1.4.tgz",
-			"integrity": "sha512-lfU4b34HOri+kAY5UheuFMWPDOI+OPceBSHZKp69gEyTL/mmJ4cnU6Y/rlme3UL3GyOn6Y42hyIEw0/q8sWx5w==",
 			"license": "MIT"
 		},
 		"node_modules/@types/minimatch": {
 			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
-			"integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -10159,8 +7924,6 @@
 		},
 		"node_modules/@types/mysql": {
 			"version": "2.15.27",
-			"resolved": "https://registry.npmjs.org/@types/mysql/-/mysql-2.15.27.tgz",
-			"integrity": "sha512-YfWiV16IY0OeBfBCk8+hXKmdTKrKlwKN1MNKAPBu5JYxLwBEZl7QzeEpGnlZb3VMGJrrGmB84gXiH+ofs/TezA==",
 			"license": "MIT",
 			"dependencies": {
 				"@types/node": "*"
@@ -10168,8 +7931,6 @@
 		},
 		"node_modules/@types/node": {
 			"version": "22.19.11",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.11.tgz",
-			"integrity": "sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w==",
 			"license": "MIT",
 			"dependencies": {
 				"undici-types": "~6.21.0"
@@ -10185,14 +7946,10 @@
 		},
 		"node_modules/@types/parse-json": {
 			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
-			"integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
 			"license": "MIT"
 		},
 		"node_modules/@types/pg": {
 			"version": "8.15.6",
-			"resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.15.6.tgz",
-			"integrity": "sha512-NoaMtzhxOrubeL/7UZuNTrejB4MPAJ0RpxZqXQf2qXuVlTPuG6Y8p4u9dKRaue4yjmC7ZhzVO2/Yyyn25znrPQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@types/node": "*",
@@ -10202,8 +7959,6 @@
 		},
 		"node_modules/@types/pg-pool": {
 			"version": "2.0.7",
-			"resolved": "https://registry.npmjs.org/@types/pg-pool/-/pg-pool-2.0.7.tgz",
-			"integrity": "sha512-U4CwmGVQcbEuqpyju8/ptOKg6gEC+Tqsvj2xS9o1g71bUh8twxnC6ZL5rZKCsGN0iyH0CwgUyc9VR5owNQF9Ng==",
 			"license": "MIT",
 			"dependencies": {
 				"@types/pg": "*"
@@ -10256,8 +8011,6 @@
 		},
 		"node_modules/@types/tedious": {
 			"version": "4.0.14",
-			"resolved": "https://registry.npmjs.org/@types/tedious/-/tedious-4.0.14.tgz",
-			"integrity": "sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==",
 			"license": "MIT",
 			"dependencies": {
 				"@types/node": "*"
@@ -10547,34 +8300,6 @@
 			"version": "1.3.0",
 			"license": "ISC"
 		},
-		"node_modules/@unrs/resolver-binding-android-arm-eabi": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz",
-			"integrity": "sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"android"
-			]
-		},
-		"node_modules/@unrs/resolver-binding-android-arm64": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.11.1.tgz",
-			"integrity": "sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"android"
-			]
-		},
 		"node_modules/@unrs/resolver-binding-darwin-arm64": {
 			"version": "1.11.1",
 			"cpu": [
@@ -10585,233 +8310,6 @@
 			"optional": true,
 			"os": [
 				"darwin"
-			]
-		},
-		"node_modules/@unrs/resolver-binding-darwin-x64": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.11.1.tgz",
-			"integrity": "sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			]
-		},
-		"node_modules/@unrs/resolver-binding-freebsd-x64": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.11.1.tgz",
-			"integrity": "sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"freebsd"
-			]
-		},
-		"node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.11.1.tgz",
-			"integrity": "sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.11.1.tgz",
-			"integrity": "sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz",
-			"integrity": "sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@unrs/resolver-binding-linux-arm64-musl": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz",
-			"integrity": "sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz",
-			"integrity": "sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==",
-			"cpu": [
-				"ppc64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz",
-			"integrity": "sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==",
-			"cpu": [
-				"riscv64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz",
-			"integrity": "sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==",
-			"cpu": [
-				"riscv64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.11.1.tgz",
-			"integrity": "sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==",
-			"cpu": [
-				"s390x"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@unrs/resolver-binding-linux-x64-gnu": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz",
-			"integrity": "sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@unrs/resolver-binding-linux-x64-musl": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz",
-			"integrity": "sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			]
-		},
-		"node_modules/@unrs/resolver-binding-wasm32-wasi": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.11.1.tgz",
-			"integrity": "sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==",
-			"cpu": [
-				"wasm32"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"@napi-rs/wasm-runtime": "^0.2.11"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.11.1.tgz",
-			"integrity": "sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			]
-		},
-		"node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.11.1.tgz",
-			"integrity": "sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==",
-			"cpu": [
-				"ia32"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			]
-		},
-		"node_modules/@unrs/resolver-binding-win32-x64-msvc": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz",
-			"integrity": "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
 			]
 		},
 		"node_modules/@use-gesture/core": {
@@ -10830,8 +8328,6 @@
 		},
 		"node_modules/@vitejs/plugin-react": {
 			"version": "5.1.4",
-			"resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.1.4.tgz",
-			"integrity": "sha512-VIcFLdRi/VYRU8OL/puL7QXMYafHmqOnwTZY50U1JPlCNj30PxCMx65c494b1K9be9hX83KVt0+gTEwTWLqToA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -10851,8 +8347,6 @@
 		},
 		"node_modules/@vitest/expect": {
 			"version": "4.0.18",
-			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
-			"integrity": "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -10869,8 +8363,6 @@
 		},
 		"node_modules/@vitest/mocker": {
 			"version": "4.0.18",
-			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.18.tgz",
-			"integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -10896,8 +8388,6 @@
 		},
 		"node_modules/@vitest/pretty-format": {
 			"version": "4.0.18",
-			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
-			"integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -10909,8 +8399,6 @@
 		},
 		"node_modules/@vitest/runner": {
 			"version": "4.0.18",
-			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.18.tgz",
-			"integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -10923,8 +8411,6 @@
 		},
 		"node_modules/@vitest/snapshot": {
 			"version": "4.0.18",
-			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.18.tgz",
-			"integrity": "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -10938,8 +8424,6 @@
 		},
 		"node_modules/@vitest/spy": {
 			"version": "4.0.18",
-			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
-			"integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
 			"dev": true,
 			"license": "MIT",
 			"funding": {
@@ -10948,8 +8432,6 @@
 		},
 		"node_modules/@vitest/ui": {
 			"version": "4.0.18",
-			"resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-4.0.18.tgz",
-			"integrity": "sha512-CGJ25bc8fRi8Lod/3GHSvXRKi7nBo3kxh0ApW4yCjmrWmRmlT53B5E08XRSZRliygG0aVNxLrBEqPYdz/KcCtQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -10970,8 +8452,6 @@
 		},
 		"node_modules/@vitest/utils": {
 			"version": "4.0.18",
-			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
-			"integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -10984,8 +8464,6 @@
 		},
 		"node_modules/@vscode/sudo-prompt": {
 			"version": "9.3.2",
-			"resolved": "https://registry.npmjs.org/@vscode/sudo-prompt/-/sudo-prompt-9.3.2.tgz",
-			"integrity": "sha512-gcXoCN00METUNFeQOFJ+C9xUI0DKB+0EGMVg7wbVYRHBw2Eq3fKisDZOkRdOz3kqXRKOENMfShPOmypw1/8nOw==",
 			"license": "MIT"
 		},
 		"node_modules/@webassemblyjs/ast": {
@@ -11121,8 +8599,6 @@
 		},
 		"node_modules/@wordpress/a11y": {
 			"version": "4.41.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.41.0.tgz",
-			"integrity": "sha512-OMv/whQt3eTftN1EIZ1FjbuYQUATzFKUEv+qE8mvfOWTX2wEcVIXrSDJa8iL+h+lpIbsWiwxFYiRlyXSmzVqkQ==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/dom-ready": "^4.41.0",
@@ -11135,8 +8611,6 @@
 		},
 		"node_modules/@wordpress/base-styles": {
 			"version": "6.17.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-6.17.0.tgz",
-			"integrity": "sha512-6o4Tp9rrGaa2ExnkCjvBZl9CVETFptb6NWtpikrkhGC2HtCSFhXWMzYheK0t+4xSJcssrpm6BMSAQGGGFm6+Tg==",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -11145,8 +8619,6 @@
 		},
 		"node_modules/@wordpress/components": {
 			"version": "32.3.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-32.3.0.tgz",
-			"integrity": "sha512-wGDbN2rXEqTTDRHKA+Yn0Gi/dTiLfVK7u/YPAfkQXzvuV4qMGzOz2sSdxQPKmvmogWa6EA0i8Udo9dBYqG1Nig==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@ariakit/react": "^0.4.21",
@@ -11214,8 +8686,6 @@
 		},
 		"node_modules/@wordpress/compose": {
 			"version": "7.41.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.41.0.tgz",
-			"integrity": "sha512-V7z/lz4SdiucDH24eXHp7LeF0LVEkrTYuLLcSkoayZTiimrQnNx0HlZFRVSWIEJ0FrwjVIoFFVCs6gITIZScSQ==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@types/mousetrap": "^1.6.8",
@@ -11241,8 +8711,6 @@
 		},
 		"node_modules/@wordpress/data": {
 			"version": "10.41.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.41.0.tgz",
-			"integrity": "sha512-yNp46WoSLkvqSMKKnJZ9xA1n02ITDqASObV5leVNoKnajiUAZbRSR6fBrapacUAg2kYFeGlhBg7IAEFJrwMuqg==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/compose": "^7.41.0",
@@ -11270,8 +8738,6 @@
 		},
 		"node_modules/@wordpress/date": {
 			"version": "5.41.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.41.0.tgz",
-			"integrity": "sha512-cfFvqlTiLDyhMtTqTMxmujvFfohz6tUxIBVMji5xc2hHyv0z/8XZw1Z0JiGpEr3blBXp/Y0R3E60EQ4G83iU7Q==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/deprecated": "^4.41.0",
@@ -11285,8 +8751,6 @@
 		},
 		"node_modules/@wordpress/deprecated": {
 			"version": "4.41.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.41.0.tgz",
-			"integrity": "sha512-AyrWS5AcVqjtzDIPCTmwZCtcXadBhjmlG7HRVtREHD6UX+FkaWMUjkmMOA8i33ExpwEjJ9GK2M/u0b7yhZxSPQ==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/hooks": "^4.41.0"
@@ -11298,8 +8762,6 @@
 		},
 		"node_modules/@wordpress/dom": {
 			"version": "4.41.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.41.0.tgz",
-			"integrity": "sha512-0E0Ps4p9TyiPR0Z6f0L4VmSD9agQBtQ0GIUrijZ9MTArBKbUm7NAUdrJNkbZOg5+AdtmTDjiqxTzwF70EBJhRw==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/deprecated": "^4.41.0"
@@ -11311,8 +8773,6 @@
 		},
 		"node_modules/@wordpress/dom-ready": {
 			"version": "4.41.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.41.0.tgz",
-			"integrity": "sha512-cxYJYa4UOmmn4LZibNAREz0RnMmiv2LNxPZl6OcxnZAv8X2fwhU6bbUO//avdhar1cki2bdntISawsc0Rcf0xg==",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -11321,8 +8781,6 @@
 		},
 		"node_modules/@wordpress/element": {
 			"version": "6.41.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.41.0.tgz",
-			"integrity": "sha512-1rM2MhP2epOfsqOz2spOaGmCU/ZtwHdLEF5GkCNEih+Mt2v+oM1xWbSNvt8RoP7Fz7DepBfaDpl6rkVYZgAwkQ==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@types/react": "^18.3.27",
@@ -11340,8 +8798,6 @@
 		},
 		"node_modules/@wordpress/escape-html": {
 			"version": "3.41.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.41.0.tgz",
-			"integrity": "sha512-xkif63w2OwcOZiJ+YKOmbuUnXAH0PM7YExA6UdQwxDGunED8L/4BY9f0nTEnDN9wFiUCYnqF4MIvMnWEnPwzUA==",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -11350,8 +8806,6 @@
 		},
 		"node_modules/@wordpress/hooks": {
 			"version": "4.41.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.41.0.tgz",
-			"integrity": "sha512-WDbLcLA3DOcjDGNLcxHZTPyhltWd/75G2hxFphe/hzcJUNmgysDTSSXO/bBrIWf6rwWD6TS3ejCaGC9J6DwYiw==",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -11360,8 +8814,6 @@
 		},
 		"node_modules/@wordpress/html-entities": {
 			"version": "4.41.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.41.0.tgz",
-			"integrity": "sha512-Q+3VNVZiHqzWgrhNNsqrOp+LWt1cDANcP46VuJ6cOOKazA1vA2JcR/0QEoa7HrYCS+KdCCFdwuUpbjQfw2wgrQ==",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -11370,8 +8822,6 @@
 		},
 		"node_modules/@wordpress/i18n": {
 			"version": "6.14.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.14.0.tgz",
-			"integrity": "sha512-Rl0zS9eZYxixCpRfQ5pdvStyp9BxZsRgqjE1Ad55ZQl7V8Xv92s/4UG/0FlkBk1wbnrKCmHaaD9lfJJeqEGg0Q==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@tannin/sprintf": "^1.3.2",
@@ -11390,8 +8840,6 @@
 		},
 		"node_modules/@wordpress/icons": {
 			"version": "11.8.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-11.8.0.tgz",
-			"integrity": "sha512-ZMNHApHMmPLpNnNLfPLRf6XWoPhZFNKFKdpMlhA6Lx04J1hLVyLRz8PuM+1o3ByxD2ZiExfSRhdmI+7VvEg6DA==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/element": "^6.41.0",
@@ -11408,8 +8856,6 @@
 		},
 		"node_modules/@wordpress/is-shallow-equal": {
 			"version": "5.41.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.41.0.tgz",
-			"integrity": "sha512-1LK5Kr/PoAiBgSxNJysZx3I1cW7MffF8bNnKiauK0+pDhHl1sbDky3rc1wkhQ3QHRrHWscDlVJ7nr01bjQAOFw==",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -11418,8 +8864,6 @@
 		},
 		"node_modules/@wordpress/keycodes": {
 			"version": "4.41.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.41.0.tgz",
-			"integrity": "sha512-eOdoULyTKXk33CSUxIKTNPRvHvymox1uapyrKFy45rSh+hXMIWhgN/p3jrEfZkZyBS3KTvbVmK5S/wv5OeRfaQ==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/i18n": "^6.14.0"
@@ -11431,8 +8875,6 @@
 		},
 		"node_modules/@wordpress/primitives": {
 			"version": "4.41.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.41.0.tgz",
-			"integrity": "sha512-ohPpBUkjkYQPki6Nl2BneFYapJE5xpxONVJfGMg0FGBqvzbuyR8pmGeH4PVfQGeGJ4xUwSdNcxfQ6nzyoT4bLA==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/element": "^6.41.0",
@@ -11448,8 +8890,6 @@
 		},
 		"node_modules/@wordpress/priority-queue": {
 			"version": "3.41.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.41.0.tgz",
-			"integrity": "sha512-vOUvDin0/rHkHxyaF8ccuL/AToLOUKxJOP0WDI+Ne6VrBthTYC+xAhHhA1AEWV5SyJkpoOx74W6DQK4mLNabdA==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"requestidlecallback": "^0.3.0"
@@ -11461,8 +8901,6 @@
 		},
 		"node_modules/@wordpress/private-apis": {
 			"version": "1.41.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.41.0.tgz",
-			"integrity": "sha512-5bVOGCJGJyD+5IhGtdLxLBsbJd+B1Ohx93COLbqMY4pGAnhNifNgt1rgsYWUjqHVLh80EnvL4HQeMzEncydNLA==",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -11471,8 +8909,6 @@
 		},
 		"node_modules/@wordpress/react-i18n": {
 			"version": "4.41.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/react-i18n/-/react-i18n-4.41.0.tgz",
-			"integrity": "sha512-Ud5wSVsFXwZxAC11VRbCGPnjR2RgnMwNQ3BNIB+wsbd8ENxvyUKdLBskWLGrBeDECvwMjK7L4lguigq3dYlYZQ==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/element": "^6.41.0",
@@ -11486,8 +8922,6 @@
 		},
 		"node_modules/@wordpress/redux-routine": {
 			"version": "5.41.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.41.0.tgz",
-			"integrity": "sha512-Zqwb8gkls/2EpiiLqnrrCiWKl9cTDD43ewpOamvel6pbdiB5MKDzGJCmz8UW6aL/PpqiVcoom5KMseY8PhoraQ==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"is-plain-object": "^5.0.0",
@@ -11504,8 +8938,6 @@
 		},
 		"node_modules/@wordpress/rich-text": {
 			"version": "7.41.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-7.41.0.tgz",
-			"integrity": "sha512-JJn63a5XXqrQkKBiJX22zkmuDo7Mk7es35I5y5aP3dsVpNyMHLujXk3CjaMVtZ3ye6j20jjOXWoR0KLViiREQw==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/a11y": "^4.41.0",
@@ -11531,8 +8963,6 @@
 		},
 		"node_modules/@wordpress/undo-manager": {
 			"version": "1.41.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.41.0.tgz",
-			"integrity": "sha512-z7HgqaBeL24NZe3vvaj9VE3W9ODUEhclkpCwIiMawaA5d5RIOzR9SIEwG4wY01jnOro/GXXSmbvku51SbZyB2Q==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/is-shallow-equal": "^5.41.0"
@@ -11544,8 +8974,6 @@
 		},
 		"node_modules/@wordpress/warning": {
 			"version": "3.41.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.41.0.tgz",
-			"integrity": "sha512-WhyGL1y6y18cZwOQeCOI9K+kWc8F9KAni9YQKZVYSriazbSPNOQGWpUdeKZVGbimBEjEspK7FQBE4pUW3q+D8w==",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -11553,23 +8981,22 @@
 			}
 		},
 		"node_modules/@wp-playground/blueprints": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/@wp-playground/blueprints/-/blueprints-3.1.5.tgz",
-			"integrity": "sha512-vdjM9V+dcqUj9fYB6Thau2ZwjfTlDZEhFU7glc/xM8/qSm2XvyYNumVWamCf6Xh6AqAxSNyKQl2XPwVGOMZVNw==",
-			"dev": true,
+			"version": "3.1.11",
+			"resolved": "https://registry.npmjs.org/@wp-playground/blueprints/-/blueprints-3.1.11.tgz",
+			"integrity": "sha512-9YeNYIKR+/LvWPnC38sorT9XJkMBz1B/Rb71kDQ5HemS8OvueyTofBc763kjQP3bumC5nr+38nMyXTNUkDuayQ==",
 			"dependencies": {
-				"@php-wasm/logger": "3.1.5",
-				"@php-wasm/node": "3.1.5",
-				"@php-wasm/node-polyfills": "3.1.5",
-				"@php-wasm/progress": "3.1.5",
-				"@php-wasm/scopes": "3.1.5",
-				"@php-wasm/stream-compression": "3.1.5",
-				"@php-wasm/universal": "3.1.5",
-				"@php-wasm/util": "3.1.5",
-				"@php-wasm/web-service-worker": "3.1.5",
-				"@wp-playground/common": "3.1.5",
-				"@wp-playground/storage": "3.1.5",
-				"@wp-playground/wordpress": "3.1.5",
+				"@php-wasm/logger": "3.1.11",
+				"@php-wasm/node": "3.1.11",
+				"@php-wasm/node-polyfills": "3.1.11",
+				"@php-wasm/progress": "3.1.11",
+				"@php-wasm/scopes": "3.1.11",
+				"@php-wasm/stream-compression": "3.1.11",
+				"@php-wasm/universal": "3.1.11",
+				"@php-wasm/util": "3.1.11",
+				"@php-wasm/web-service-worker": "3.1.11",
+				"@wp-playground/common": "3.1.11",
+				"@wp-playground/storage": "3.1.11",
+				"@wp-playground/wordpress": "3.1.11",
 				"@zip.js/zip.js": "2.7.57",
 				"ajv": "8.12.0",
 				"async-lock": "1.4.1",
@@ -11577,7 +9004,7 @@
 				"crc-32": "1.2.2",
 				"diff3": "0.0.4",
 				"express": "4.22.0",
-				"fast-xml-parser": "^5.3.4",
+				"fast-xml-parser": "^5.5.1",
 				"fs-ext-extra-prebuilt": "2.2.7",
 				"ignore": "5.3.2",
 				"ini": "4.1.2",
@@ -11600,9 +9027,6 @@
 		},
 		"node_modules/@wp-playground/blueprints/node_modules/ajv": {
 			"version": "8.12.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-			"integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"fast-deep-equal": "^3.1.1",
@@ -11617,9 +9041,6 @@
 		},
 		"node_modules/@wp-playground/blueprints/node_modules/cliui": {
 			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-			"integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"string-width": "^4.2.0",
@@ -11632,9 +9053,6 @@
 		},
 		"node_modules/@wp-playground/blueprints/node_modules/ini": {
 			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
-			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
-			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -11642,23 +9060,14 @@
 		},
 		"node_modules/@wp-playground/blueprints/node_modules/json-schema-traverse": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@wp-playground/blueprints/node_modules/pako": {
 			"version": "1.0.10",
-			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.10.tgz",
-			"integrity": "sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw==",
-			"dev": true,
 			"license": "(MIT AND Zlib)"
 		},
 		"node_modules/@wp-playground/blueprints/node_modules/strip-ansi": {
 			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ansi-regex": "^5.0.1"
@@ -11669,9 +9078,6 @@
 		},
 		"node_modules/@wp-playground/blueprints/node_modules/yargs": {
 			"version": "17.7.2",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-			"integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"cliui": "^8.0.1",
@@ -11688,9 +9094,6 @@
 		},
 		"node_modules/@wp-playground/blueprints/node_modules/yargs-parser": {
 			"version": "21.1.1",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-			"integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": ">=12"
@@ -11698,8 +9101,6 @@
 		},
 		"node_modules/@wp-playground/cli": {
 			"version": "3.1.11",
-			"resolved": "https://registry.npmjs.org/@wp-playground/cli/-/cli-3.1.11.tgz",
-			"integrity": "sha512-HErM8+U+HIWxFL1IhVokb1tTuBwXdL0b4GpiVEX0S7xj1eClPrVVOpYvP6CQzh+VSN3SWADAR/IL/YV0z8o0/g==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@php-wasm/cli-util": "3.1.11",
@@ -11745,307 +9146,93 @@
 				"wp-playground-cli": "wp-playground.js"
 			}
 		},
-		"node_modules/@wp-playground/cli/node_modules/@php-wasm/cli-util": {
-			"version": "3.1.11",
-			"resolved": "https://registry.npmjs.org/@php-wasm/cli-util/-/cli-util-3.1.11.tgz",
-			"integrity": "sha512-/v/S007ZZfTmDyYOReKtUnhiOWZi1EZdLrDiSPCmYms3XFNeJDUBWEkDshcwMxuDaA4Ce2ciF0QsM+yuY9vY9g==",
-			"license": "GPL-2.0-or-later",
+		"node_modules/@wp-playground/cli/node_modules/ajv": {
+			"version": "8.12.0",
+			"license": "MIT",
 			"dependencies": {
-				"@php-wasm/util": "3.1.11",
-				"fast-xml-parser": "^5.5.1",
-				"jsonc-parser": "3.3.1"
+				"fast-deep-equal": "^3.1.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2",
+				"uri-js": "^4.2.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/@wp-playground/cli/node_modules/cliui": {
+			"version": "8.0.1",
+			"license": "ISC",
+			"dependencies": {
+				"string-width": "^4.2.0",
+				"strip-ansi": "^6.0.1",
+				"wrap-ansi": "^7.0.0"
 			},
 			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
+				"node": ">=12"
 			}
 		},
-		"node_modules/@wp-playground/cli/node_modules/@php-wasm/logger": {
-			"version": "3.1.11",
-			"resolved": "https://registry.npmjs.org/@php-wasm/logger/-/logger-3.1.11.tgz",
-			"integrity": "sha512-wGKmMpA8gvoLFEjG9jzm7E2BEAaq4LU9yMjMkzKwYE0RUivV1000Cnw+m+79/d4Bua0ouoCLab5+IFFJrfxYpw==",
-			"license": "GPL-2.0-or-later",
+		"node_modules/@wp-playground/cli/node_modules/fs-extra": {
+			"version": "11.1.1",
+			"license": "MIT",
 			"dependencies": {
-				"@php-wasm/node-polyfills": "3.1.11"
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^6.0.1",
+				"universalify": "^2.0.0"
 			},
 			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
+				"node": ">=14.14"
 			}
 		},
-		"node_modules/@wp-playground/cli/node_modules/@php-wasm/node": {
-			"version": "3.1.11",
-			"resolved": "https://registry.npmjs.org/@php-wasm/node/-/node-3.1.11.tgz",
-			"integrity": "sha512-qqJuQMm/Ey4Cv2h6F6q7Rj33KMo5z+33s2CABwRnS7fgzGBSQzB7vq4L2pScqVmvfRXnW1lFoUgFARojOOThkA==",
-			"license": "GPL-2.0-or-later",
+		"node_modules/@wp-playground/cli/node_modules/ini": {
+			"version": "4.1.2",
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@wp-playground/cli/node_modules/json-schema-traverse": {
+			"version": "1.0.0",
+			"license": "MIT"
+		},
+		"node_modules/@wp-playground/cli/node_modules/pako": {
+			"version": "1.0.10",
+			"license": "(MIT AND Zlib)"
+		},
+		"node_modules/@wp-playground/cli/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"license": "MIT",
 			"dependencies": {
-				"@php-wasm/cli-util": "3.1.11",
-				"@php-wasm/logger": "3.1.11",
-				"@php-wasm/node-7-4": "3.1.11",
-				"@php-wasm/node-8-0": "3.1.11",
-				"@php-wasm/node-8-1": "3.1.11",
-				"@php-wasm/node-8-2": "3.1.11",
-				"@php-wasm/node-8-3": "3.1.11",
-				"@php-wasm/node-8-4": "3.1.11",
-				"@php-wasm/node-8-5": "3.1.11",
-				"@php-wasm/node-polyfills": "3.1.11",
-				"@php-wasm/universal": "3.1.11",
-				"@php-wasm/util": "3.1.11",
-				"@wp-playground/common": "3.1.11",
-				"express": "4.22.0",
-				"fast-xml-parser": "^5.5.1",
-				"fs-ext-extra-prebuilt": "2.2.7",
-				"ini": "4.1.2",
-				"jsonc-parser": "3.3.1",
-				"wasm-feature-detect": "1.8.0",
-				"ws": "8.18.3",
-				"yargs": "17.7.2"
+				"ansi-regex": "^5.0.1"
 			},
 			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
+				"node": ">=8"
 			}
 		},
-		"node_modules/@wp-playground/cli/node_modules/@php-wasm/node-7-4": {
-			"version": "3.1.11",
-			"resolved": "https://registry.npmjs.org/@php-wasm/node-7-4/-/node-7-4-3.1.11.tgz",
-			"integrity": "sha512-WGX0nOv6JsTXY+I0FqAB8wQLeQc8pAYbUg4LXEQnACZWPL9mdAvwk++XkScWQ5zfwUtrTq9TwpAXcyf3xRrIxQ==",
-			"license": "GPL-2.0-or-later",
+		"node_modules/@wp-playground/cli/node_modules/yargs": {
+			"version": "17.7.2",
+			"license": "MIT",
 			"dependencies": {
-				"@php-wasm/universal": "3.1.11",
-				"ini": "4.1.2",
-				"wasm-feature-detect": "1.8.0",
-				"ws": "8.18.3"
+				"cliui": "^8.0.1",
+				"escalade": "^3.1.1",
+				"get-caller-file": "^2.0.5",
+				"require-directory": "^2.1.1",
+				"string-width": "^4.2.3",
+				"y18n": "^5.0.5",
+				"yargs-parser": "^21.1.1"
 			},
 			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
+				"node": ">=12"
 			}
 		},
-		"node_modules/@wp-playground/cli/node_modules/@php-wasm/node-8-0": {
-			"version": "3.1.11",
-			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-0/-/node-8-0-3.1.11.tgz",
-			"integrity": "sha512-92E8kydq6RmxYnFGXGTursqT/8doRND8fQoqerj4uJ4oMtPIBXREyBMAye4/ss3ls9IXSRbZKYQ03NptozcYfA==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/universal": "3.1.11",
-				"ini": "4.1.2",
-				"wasm-feature-detect": "1.8.0",
-				"ws": "8.18.3"
-			},
+		"node_modules/@wp-playground/cli/node_modules/yargs-parser": {
+			"version": "21.1.1",
+			"license": "ISC",
 			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
+				"node": ">=12"
 			}
 		},
-		"node_modules/@wp-playground/cli/node_modules/@php-wasm/node-8-1": {
-			"version": "3.1.11",
-			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-1/-/node-8-1-3.1.11.tgz",
-			"integrity": "sha512-fP7OWc0V7Hs1AEcr0cP8d49twJLSDwdHUyFwTuD7uPY+u9KrPW8ZrhR8+j2pmPrU0qMO5x+oPP1u8MFgNpWHOQ==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/universal": "3.1.11",
-				"ini": "4.1.2",
-				"wasm-feature-detect": "1.8.0",
-				"ws": "8.18.3"
-			},
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
-		"node_modules/@wp-playground/cli/node_modules/@php-wasm/node-8-2": {
-			"version": "3.1.11",
-			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-2/-/node-8-2-3.1.11.tgz",
-			"integrity": "sha512-T72JABgcbo6OujFaVfKb+eJpgZgcTK5vmUoNDWZFvu7NvH9wSRkmnlas+HcqO2inEja0BvQbz7WWcDHUTj9rPQ==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/universal": "3.1.11",
-				"ini": "4.1.2",
-				"wasm-feature-detect": "1.8.0",
-				"ws": "8.18.3"
-			},
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
-		"node_modules/@wp-playground/cli/node_modules/@php-wasm/node-8-3": {
-			"version": "3.1.11",
-			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-3/-/node-8-3-3.1.11.tgz",
-			"integrity": "sha512-KFOVw3E0ThCGN6pmdS16FIgHzbAVNLVrV4QkCvKmvPENMfKLOaJAwC3jN8qK4eE/j5jWqAZIQPsOPwVKkHziDw==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/universal": "3.1.11",
-				"ini": "4.1.2",
-				"wasm-feature-detect": "1.8.0",
-				"ws": "8.18.3"
-			},
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
-		"node_modules/@wp-playground/cli/node_modules/@php-wasm/node-8-4": {
-			"version": "3.1.11",
-			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-4/-/node-8-4-3.1.11.tgz",
-			"integrity": "sha512-fSKp8C+rcORGHBQJRtrFkNfTmIsjtfMcuT81jWIs71zG2v1C0yIfEPdpRqHv6UVJVFToUb1ClEGY+dfqO9mXYA==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/universal": "3.1.11",
-				"ini": "4.1.2",
-				"wasm-feature-detect": "1.8.0",
-				"ws": "8.18.3"
-			},
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
-		"node_modules/@wp-playground/cli/node_modules/@php-wasm/node-8-5": {
-			"version": "3.1.11",
-			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-5/-/node-8-5-3.1.11.tgz",
-			"integrity": "sha512-ystaL0/ab7GyQCReNFWpC2LPKa3u2gUXlMi0g/2CZDD4kavnzksuI/jAHhwnmTnZePbEam23rvdyq77ndC1TFw==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/universal": "3.1.11",
-				"ini": "4.1.2",
-				"wasm-feature-detect": "1.8.0",
-				"ws": "8.18.3"
-			},
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
-		"node_modules/@wp-playground/cli/node_modules/@php-wasm/node-polyfills": {
-			"version": "3.1.11",
-			"resolved": "https://registry.npmjs.org/@php-wasm/node-polyfills/-/node-polyfills-3.1.11.tgz",
-			"integrity": "sha512-Gu3wS1gWkyGSW/K+RQNT4OfjeapeYdL5bqOQ+/MEfvkaeMRDdzdOvmPcIfLbDBhZOSh6jAA7nT87Ri2LmeqYzQ==",
-			"license": "GPL-2.0-or-later"
-		},
-		"node_modules/@wp-playground/cli/node_modules/@php-wasm/progress": {
-			"version": "3.1.11",
-			"resolved": "https://registry.npmjs.org/@php-wasm/progress/-/progress-3.1.11.tgz",
-			"integrity": "sha512-/zsH+ZvBxq+Qlb2ffNvvjmiqaB6Fwo8+O3Py+WUznxIuQ/3Ckci+5cWyBtYQ6qtAGFSRADl41Qg9n6RmWBUL7w==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/logger": "3.1.11",
-				"@php-wasm/node-polyfills": "3.1.11"
-			},
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
-		"node_modules/@wp-playground/cli/node_modules/@php-wasm/scopes": {
-			"version": "3.1.11",
-			"resolved": "https://registry.npmjs.org/@php-wasm/scopes/-/scopes-3.1.11.tgz",
-			"integrity": "sha512-WyI1PHYA4vHmb2DHO6M2e8ydY1brfMRjRf1Z5FYhfyh7G2FEAJbOyoY/VenBOCw0dE04vkWU4LRuVwkFrO8+Ow==",
-			"license": "GPL-2.0-or-later",
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
-		"node_modules/@wp-playground/cli/node_modules/@php-wasm/stream-compression": {
-			"version": "3.1.11",
-			"resolved": "https://registry.npmjs.org/@php-wasm/stream-compression/-/stream-compression-3.1.11.tgz",
-			"integrity": "sha512-R9wfu3Zx083m8WTlWN888iZ9ub2nhZXGi5LVjfIQCd2UPuRbhFuOHiiyvnoHnZFyMZnzI12/MhuoPHuWv6NPew==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/node-polyfills": "3.1.11",
-				"@php-wasm/util": "3.1.11"
-			}
-		},
-		"node_modules/@wp-playground/cli/node_modules/@php-wasm/universal": {
-			"version": "3.1.11",
-			"resolved": "https://registry.npmjs.org/@php-wasm/universal/-/universal-3.1.11.tgz",
-			"integrity": "sha512-n+fGHL9wqLf6NBWsPdDbF7USY20FBZgBIJvUoi620xNQdakhZ425tCM7bEVBE+lcOY6/l4rFCIdSbY+HoJwg7w==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/logger": "3.1.11",
-				"@php-wasm/node-polyfills": "3.1.11",
-				"@php-wasm/progress": "3.1.11",
-				"@php-wasm/stream-compression": "3.1.11",
-				"@php-wasm/util": "3.1.11",
-				"ini": "4.1.2"
-			},
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
-		"node_modules/@wp-playground/cli/node_modules/@php-wasm/util": {
-			"version": "3.1.11",
-			"resolved": "https://registry.npmjs.org/@php-wasm/util/-/util-3.1.11.tgz",
-			"integrity": "sha512-9n/s609DDF03+M4DWbvf+BCaHGAGt56xOxceV91mQA1X0c+iLgBCYG2oLgOvs1Cl+anYxiVbsLUZBfjAxKLcbQ==",
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
-		"node_modules/@wp-playground/cli/node_modules/@php-wasm/web-service-worker": {
-			"version": "3.1.11",
-			"resolved": "https://registry.npmjs.org/@php-wasm/web-service-worker/-/web-service-worker-3.1.11.tgz",
-			"integrity": "sha512-8qCh2Y5ZrLw1EP+s5iYCBE4HnBcB0HjudGPNLs2azYRZHOo5C3Xjc+VI5BDdfyLEZl3AOg5y6dE0dk2ur2WCeg==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/scopes": "3.1.11",
-				"@php-wasm/universal": "3.1.11",
-				"ini": "4.1.2"
-			},
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
-		"node_modules/@wp-playground/cli/node_modules/@wp-playground/blueprints": {
-			"version": "3.1.11",
-			"resolved": "https://registry.npmjs.org/@wp-playground/blueprints/-/blueprints-3.1.11.tgz",
-			"integrity": "sha512-9YeNYIKR+/LvWPnC38sorT9XJkMBz1B/Rb71kDQ5HemS8OvueyTofBc763kjQP3bumC5nr+38nMyXTNUkDuayQ==",
-			"dependencies": {
-				"@php-wasm/logger": "3.1.11",
-				"@php-wasm/node": "3.1.11",
-				"@php-wasm/node-polyfills": "3.1.11",
-				"@php-wasm/progress": "3.1.11",
-				"@php-wasm/scopes": "3.1.11",
-				"@php-wasm/stream-compression": "3.1.11",
-				"@php-wasm/universal": "3.1.11",
-				"@php-wasm/util": "3.1.11",
-				"@php-wasm/web-service-worker": "3.1.11",
-				"@wp-playground/common": "3.1.11",
-				"@wp-playground/storage": "3.1.11",
-				"@wp-playground/wordpress": "3.1.11",
-				"@zip.js/zip.js": "2.7.57",
-				"ajv": "8.12.0",
-				"async-lock": "1.4.1",
-				"clean-git-ref": "2.0.1",
-				"crc-32": "1.2.2",
-				"diff3": "0.0.4",
-				"express": "4.22.0",
-				"fast-xml-parser": "^5.5.1",
-				"fs-ext-extra-prebuilt": "2.2.7",
-				"ignore": "5.3.2",
-				"ini": "4.1.2",
-				"jsonc-parser": "3.3.1",
-				"minimisted": "2.0.1",
-				"octokit": "3.1.2",
-				"pako": "1.0.10",
-				"pify": "2.3.0",
-				"readable-stream": "3.6.2",
-				"sha.js": "2.4.12",
-				"simple-get": "4.0.1",
-				"wasm-feature-detect": "1.8.0",
-				"ws": "8.18.3",
-				"yargs": "17.7.2"
-			},
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
-		"node_modules/@wp-playground/cli/node_modules/@wp-playground/common": {
+		"node_modules/@wp-playground/common": {
 			"version": "3.1.11",
 			"resolved": "https://registry.npmjs.org/@wp-playground/common/-/common-3.1.11.tgz",
 			"integrity": "sha512-1/5yts2ExzfVxHqK4oz9dr9Jxeuh99zhAO5ClH3zROo/7gRXKWHZWoQXNLZnPJ3RlMqYzIzHzmozhyx29rtizQ==",
@@ -12060,7 +9247,16 @@
 				"npm": ">=10.2.3"
 			}
 		},
-		"node_modules/@wp-playground/cli/node_modules/@wp-playground/storage": {
+		"node_modules/@wp-playground/common/node_modules/ini": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
+			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@wp-playground/storage": {
 			"version": "3.1.11",
 			"resolved": "https://registry.npmjs.org/@wp-playground/storage/-/storage-3.1.11.tgz",
 			"integrity": "sha512-OxDlLInbRzpceMYO2CVm3hYb1MnZqJZfr444+l3QhOJEqOo6n3WAwb/8MxRbqmfokkKGbO3YGnGQrF6u+RNhWQ==",
@@ -12085,214 +9281,16 @@
 				"simple-get": "^4.0.1"
 			}
 		},
-		"node_modules/@wp-playground/cli/node_modules/@wp-playground/storage/node_modules/diff3": {
-			"version": "0.0.3",
-			"resolved": "https://registry.npmjs.org/diff3/-/diff3-0.0.3.tgz",
-			"integrity": "sha512-iSq8ngPOt0K53A6eVr4d5Kn6GNrM2nQZtC740pzIriHtn4pOQ2lyzEXQMBeVcWERN0ye7fhBsk9PbLLQOnUx/g==",
-			"license": "MIT"
-		},
-		"node_modules/@wp-playground/cli/node_modules/@wp-playground/storage/node_modules/pify": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-			"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/@wp-playground/cli/node_modules/@wp-playground/wordpress": {
-			"version": "3.1.11",
-			"resolved": "https://registry.npmjs.org/@wp-playground/wordpress/-/wordpress-3.1.11.tgz",
-			"integrity": "sha512-G4sahkT4WQoCtCww0ve9GyQ+QVji7qd+6TOsuMI3iFaYgyYGIKKV4Yjx/KEOZEYKRY8BuZH6AKZpjrmu75CBxg==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/logger": "3.1.11",
-				"@php-wasm/node": "3.1.11",
-				"@php-wasm/universal": "3.1.11",
-				"@php-wasm/util": "3.1.11",
-				"@wp-playground/common": "3.1.11",
-				"express": "4.22.0",
-				"fast-xml-parser": "^5.5.1",
-				"fs-ext-extra-prebuilt": "2.2.7",
-				"ini": "4.1.2",
-				"jsonc-parser": "3.3.1",
-				"wasm-feature-detect": "1.8.0",
-				"ws": "8.18.3",
-				"yargs": "17.7.2"
-			},
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
-		"node_modules/@wp-playground/cli/node_modules/ajv": {
-			"version": "8.12.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-			"integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-			"license": "MIT",
-			"dependencies": {
-				"fast-deep-equal": "^3.1.1",
-				"json-schema-traverse": "^1.0.0",
-				"require-from-string": "^2.0.2",
-				"uri-js": "^4.2.2"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/epoberezkin"
-			}
-		},
-		"node_modules/@wp-playground/cli/node_modules/cliui": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-			"integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-			"license": "ISC",
-			"dependencies": {
-				"string-width": "^4.2.0",
-				"strip-ansi": "^6.0.1",
-				"wrap-ansi": "^7.0.0"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/@wp-playground/cli/node_modules/fs-extra": {
-			"version": "11.1.1",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.1.tgz",
-			"integrity": "sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==",
-			"license": "MIT",
-			"dependencies": {
-				"graceful-fs": "^4.2.0",
-				"jsonfile": "^6.0.1",
-				"universalify": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=14.14"
-			}
-		},
-		"node_modules/@wp-playground/cli/node_modules/ini": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
-			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
-			"license": "ISC",
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@wp-playground/cli/node_modules/json-schema-traverse": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-			"license": "MIT"
-		},
-		"node_modules/@wp-playground/cli/node_modules/pako": {
-			"version": "1.0.10",
-			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.10.tgz",
-			"integrity": "sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw==",
-			"license": "(MIT AND Zlib)"
-		},
-		"node_modules/@wp-playground/cli/node_modules/strip-ansi": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^5.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/@wp-playground/cli/node_modules/yargs": {
-			"version": "17.7.2",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-			"integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-			"license": "MIT",
-			"dependencies": {
-				"cliui": "^8.0.1",
-				"escalade": "^3.1.1",
-				"get-caller-file": "^2.0.5",
-				"require-directory": "^2.1.1",
-				"string-width": "^4.2.3",
-				"y18n": "^5.0.5",
-				"yargs-parser": "^21.1.1"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/@wp-playground/cli/node_modules/yargs-parser": {
-			"version": "21.1.1",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-			"integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-			"license": "ISC",
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/@wp-playground/common": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/@wp-playground/common/-/common-3.1.5.tgz",
-			"integrity": "sha512-4VrwEwsSK2+PxfNu3KvvnOajQaR8kEJT9fSxWSbT7Lds+TF/m+opjnT+OtVl7dVhHB4rCVNn5rWmwwFeiDHIiA==",
-			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/universal": "3.1.5",
-				"@php-wasm/util": "3.1.5",
-				"ini": "4.1.2"
-			},
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
-		"node_modules/@wp-playground/common/node_modules/ini": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
-			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@wp-playground/storage": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/@wp-playground/storage/-/storage-3.1.5.tgz",
-			"integrity": "sha512-PYb4XeEmkEf/nvelApgPu+04v3sPLPBSuYqHHU3tNNV0a+kjQUNb/1RHeOIFi5vMmkO9QxdxxyndCEYlI6pCSQ==",
-			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/stream-compression": "3.1.5",
-				"@php-wasm/universal": "3.1.5",
-				"@php-wasm/util": "3.1.5",
-				"@zip.js/zip.js": "2.7.57",
-				"async-lock": "^1.4.1",
-				"clean-git-ref": "^2.0.1",
-				"crc-32": "^1.2.0",
-				"diff3": "0.0.3",
-				"ignore": "^5.1.4",
-				"ini": "4.1.2",
-				"minimisted": "^2.0.0",
-				"octokit": "3.1.2",
-				"pako": "^1.0.10",
-				"pify": "^4.0.1",
-				"readable-stream": "^3.4.0",
-				"sha.js": "^2.4.9",
-				"simple-get": "^4.0.1"
-			}
-		},
 		"node_modules/@wp-playground/storage/node_modules/diff3": {
 			"version": "0.0.3",
 			"resolved": "https://registry.npmjs.org/diff3/-/diff3-0.0.3.tgz",
 			"integrity": "sha512-iSq8ngPOt0K53A6eVr4d5Kn6GNrM2nQZtC740pzIriHtn4pOQ2lyzEXQMBeVcWERN0ye7fhBsk9PbLLQOnUx/g==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@wp-playground/storage/node_modules/ini": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
 			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
-			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -12302,7 +9300,6 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
 			"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
@@ -12310,8 +9307,6 @@
 		},
 		"node_modules/@wp-playground/tools": {
 			"version": "3.1.11",
-			"resolved": "https://registry.npmjs.org/@wp-playground/tools/-/tools-3.1.11.tgz",
-			"integrity": "sha512-qcKLqakGVc4i+GW8wdWVx/Q9kQHD5/PNs6TwHqHZoaRHtlocVKUuO5qkFwerxqCXzOkxVXjpst51SgQ6py1PfQ==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wp-playground/blueprints": "3.1.11",
@@ -12343,362 +9338,81 @@
 				"npm": ">=10.2.3"
 			}
 		},
-		"node_modules/@wp-playground/tools/node_modules/@php-wasm/cli-util": {
-			"version": "3.1.11",
-			"resolved": "https://registry.npmjs.org/@php-wasm/cli-util/-/cli-util-3.1.11.tgz",
-			"integrity": "sha512-/v/S007ZZfTmDyYOReKtUnhiOWZi1EZdLrDiSPCmYms3XFNeJDUBWEkDshcwMxuDaA4Ce2ciF0QsM+yuY9vY9g==",
-			"license": "GPL-2.0-or-later",
+		"node_modules/@wp-playground/tools/node_modules/ajv": {
+			"version": "8.12.0",
+			"license": "MIT",
 			"dependencies": {
-				"@php-wasm/util": "3.1.11",
-				"fast-xml-parser": "^5.5.1",
-				"jsonc-parser": "3.3.1"
+				"fast-deep-equal": "^3.1.1",
+				"json-schema-traverse": "^1.0.0",
+				"require-from-string": "^2.0.2",
+				"uri-js": "^4.2.2"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/epoberezkin"
+			}
+		},
+		"node_modules/@wp-playground/tools/node_modules/cliui": {
+			"version": "8.0.1",
+			"license": "ISC",
+			"dependencies": {
+				"string-width": "^4.2.0",
+				"strip-ansi": "^6.0.1",
+				"wrap-ansi": "^7.0.0"
 			},
 			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
+				"node": ">=12"
 			}
 		},
-		"node_modules/@wp-playground/tools/node_modules/@php-wasm/logger": {
-			"version": "3.1.11",
-			"resolved": "https://registry.npmjs.org/@php-wasm/logger/-/logger-3.1.11.tgz",
-			"integrity": "sha512-wGKmMpA8gvoLFEjG9jzm7E2BEAaq4LU9yMjMkzKwYE0RUivV1000Cnw+m+79/d4Bua0ouoCLab5+IFFJrfxYpw==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/node-polyfills": "3.1.11"
-			},
+		"node_modules/@wp-playground/tools/node_modules/ini": {
+			"version": "4.1.2",
+			"license": "ISC",
 			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
 			}
 		},
-		"node_modules/@wp-playground/tools/node_modules/@php-wasm/node": {
-			"version": "3.1.11",
-			"resolved": "https://registry.npmjs.org/@php-wasm/node/-/node-3.1.11.tgz",
-			"integrity": "sha512-qqJuQMm/Ey4Cv2h6F6q7Rj33KMo5z+33s2CABwRnS7fgzGBSQzB7vq4L2pScqVmvfRXnW1lFoUgFARojOOThkA==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/cli-util": "3.1.11",
-				"@php-wasm/logger": "3.1.11",
-				"@php-wasm/node-7-4": "3.1.11",
-				"@php-wasm/node-8-0": "3.1.11",
-				"@php-wasm/node-8-1": "3.1.11",
-				"@php-wasm/node-8-2": "3.1.11",
-				"@php-wasm/node-8-3": "3.1.11",
-				"@php-wasm/node-8-4": "3.1.11",
-				"@php-wasm/node-8-5": "3.1.11",
-				"@php-wasm/node-polyfills": "3.1.11",
-				"@php-wasm/universal": "3.1.11",
-				"@php-wasm/util": "3.1.11",
-				"@wp-playground/common": "3.1.11",
-				"express": "4.22.0",
-				"fast-xml-parser": "^5.5.1",
-				"fs-ext-extra-prebuilt": "2.2.7",
-				"ini": "4.1.2",
-				"jsonc-parser": "3.3.1",
-				"wasm-feature-detect": "1.8.0",
-				"ws": "8.18.3",
-				"yargs": "17.7.2"
-			},
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
-		"node_modules/@wp-playground/tools/node_modules/@php-wasm/node-7-4": {
-			"version": "3.1.11",
-			"resolved": "https://registry.npmjs.org/@php-wasm/node-7-4/-/node-7-4-3.1.11.tgz",
-			"integrity": "sha512-WGX0nOv6JsTXY+I0FqAB8wQLeQc8pAYbUg4LXEQnACZWPL9mdAvwk++XkScWQ5zfwUtrTq9TwpAXcyf3xRrIxQ==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/universal": "3.1.11",
-				"ini": "4.1.2",
-				"wasm-feature-detect": "1.8.0",
-				"ws": "8.18.3"
-			},
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
-		"node_modules/@wp-playground/tools/node_modules/@php-wasm/node-8-0": {
-			"version": "3.1.11",
-			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-0/-/node-8-0-3.1.11.tgz",
-			"integrity": "sha512-92E8kydq6RmxYnFGXGTursqT/8doRND8fQoqerj4uJ4oMtPIBXREyBMAye4/ss3ls9IXSRbZKYQ03NptozcYfA==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/universal": "3.1.11",
-				"ini": "4.1.2",
-				"wasm-feature-detect": "1.8.0",
-				"ws": "8.18.3"
-			},
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
-		"node_modules/@wp-playground/tools/node_modules/@php-wasm/node-8-1": {
-			"version": "3.1.11",
-			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-1/-/node-8-1-3.1.11.tgz",
-			"integrity": "sha512-fP7OWc0V7Hs1AEcr0cP8d49twJLSDwdHUyFwTuD7uPY+u9KrPW8ZrhR8+j2pmPrU0qMO5x+oPP1u8MFgNpWHOQ==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/universal": "3.1.11",
-				"ini": "4.1.2",
-				"wasm-feature-detect": "1.8.0",
-				"ws": "8.18.3"
-			},
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
-		"node_modules/@wp-playground/tools/node_modules/@php-wasm/node-8-2": {
-			"version": "3.1.11",
-			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-2/-/node-8-2-3.1.11.tgz",
-			"integrity": "sha512-T72JABgcbo6OujFaVfKb+eJpgZgcTK5vmUoNDWZFvu7NvH9wSRkmnlas+HcqO2inEja0BvQbz7WWcDHUTj9rPQ==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/universal": "3.1.11",
-				"ini": "4.1.2",
-				"wasm-feature-detect": "1.8.0",
-				"ws": "8.18.3"
-			},
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
-		"node_modules/@wp-playground/tools/node_modules/@php-wasm/node-8-3": {
-			"version": "3.1.11",
-			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-3/-/node-8-3-3.1.11.tgz",
-			"integrity": "sha512-KFOVw3E0ThCGN6pmdS16FIgHzbAVNLVrV4QkCvKmvPENMfKLOaJAwC3jN8qK4eE/j5jWqAZIQPsOPwVKkHziDw==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/universal": "3.1.11",
-				"ini": "4.1.2",
-				"wasm-feature-detect": "1.8.0",
-				"ws": "8.18.3"
-			},
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
-		"node_modules/@wp-playground/tools/node_modules/@php-wasm/node-8-4": {
-			"version": "3.1.11",
-			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-4/-/node-8-4-3.1.11.tgz",
-			"integrity": "sha512-fSKp8C+rcORGHBQJRtrFkNfTmIsjtfMcuT81jWIs71zG2v1C0yIfEPdpRqHv6UVJVFToUb1ClEGY+dfqO9mXYA==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/universal": "3.1.11",
-				"ini": "4.1.2",
-				"wasm-feature-detect": "1.8.0",
-				"ws": "8.18.3"
-			},
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
-		"node_modules/@wp-playground/tools/node_modules/@php-wasm/node-8-5": {
-			"version": "3.1.11",
-			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-5/-/node-8-5-3.1.11.tgz",
-			"integrity": "sha512-ystaL0/ab7GyQCReNFWpC2LPKa3u2gUXlMi0g/2CZDD4kavnzksuI/jAHhwnmTnZePbEam23rvdyq77ndC1TFw==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/universal": "3.1.11",
-				"ini": "4.1.2",
-				"wasm-feature-detect": "1.8.0",
-				"ws": "8.18.3"
-			},
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
-		"node_modules/@wp-playground/tools/node_modules/@php-wasm/node-polyfills": {
-			"version": "3.1.11",
-			"resolved": "https://registry.npmjs.org/@php-wasm/node-polyfills/-/node-polyfills-3.1.11.tgz",
-			"integrity": "sha512-Gu3wS1gWkyGSW/K+RQNT4OfjeapeYdL5bqOQ+/MEfvkaeMRDdzdOvmPcIfLbDBhZOSh6jAA7nT87Ri2LmeqYzQ==",
-			"license": "GPL-2.0-or-later"
-		},
-		"node_modules/@wp-playground/tools/node_modules/@php-wasm/progress": {
-			"version": "3.1.11",
-			"resolved": "https://registry.npmjs.org/@php-wasm/progress/-/progress-3.1.11.tgz",
-			"integrity": "sha512-/zsH+ZvBxq+Qlb2ffNvvjmiqaB6Fwo8+O3Py+WUznxIuQ/3Ckci+5cWyBtYQ6qtAGFSRADl41Qg9n6RmWBUL7w==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/logger": "3.1.11",
-				"@php-wasm/node-polyfills": "3.1.11"
-			},
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
-		"node_modules/@wp-playground/tools/node_modules/@php-wasm/scopes": {
-			"version": "3.1.11",
-			"resolved": "https://registry.npmjs.org/@php-wasm/scopes/-/scopes-3.1.11.tgz",
-			"integrity": "sha512-WyI1PHYA4vHmb2DHO6M2e8ydY1brfMRjRf1Z5FYhfyh7G2FEAJbOyoY/VenBOCw0dE04vkWU4LRuVwkFrO8+Ow==",
-			"license": "GPL-2.0-or-later",
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
-		"node_modules/@wp-playground/tools/node_modules/@php-wasm/stream-compression": {
-			"version": "3.1.11",
-			"resolved": "https://registry.npmjs.org/@php-wasm/stream-compression/-/stream-compression-3.1.11.tgz",
-			"integrity": "sha512-R9wfu3Zx083m8WTlWN888iZ9ub2nhZXGi5LVjfIQCd2UPuRbhFuOHiiyvnoHnZFyMZnzI12/MhuoPHuWv6NPew==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/node-polyfills": "3.1.11",
-				"@php-wasm/util": "3.1.11"
-			}
-		},
-		"node_modules/@wp-playground/tools/node_modules/@php-wasm/universal": {
-			"version": "3.1.11",
-			"resolved": "https://registry.npmjs.org/@php-wasm/universal/-/universal-3.1.11.tgz",
-			"integrity": "sha512-n+fGHL9wqLf6NBWsPdDbF7USY20FBZgBIJvUoi620xNQdakhZ425tCM7bEVBE+lcOY6/l4rFCIdSbY+HoJwg7w==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/logger": "3.1.11",
-				"@php-wasm/node-polyfills": "3.1.11",
-				"@php-wasm/progress": "3.1.11",
-				"@php-wasm/stream-compression": "3.1.11",
-				"@php-wasm/util": "3.1.11",
-				"ini": "4.1.2"
-			},
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
-		"node_modules/@wp-playground/tools/node_modules/@php-wasm/util": {
-			"version": "3.1.11",
-			"resolved": "https://registry.npmjs.org/@php-wasm/util/-/util-3.1.11.tgz",
-			"integrity": "sha512-9n/s609DDF03+M4DWbvf+BCaHGAGt56xOxceV91mQA1X0c+iLgBCYG2oLgOvs1Cl+anYxiVbsLUZBfjAxKLcbQ==",
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
-		"node_modules/@wp-playground/tools/node_modules/@php-wasm/web-service-worker": {
-			"version": "3.1.11",
-			"resolved": "https://registry.npmjs.org/@php-wasm/web-service-worker/-/web-service-worker-3.1.11.tgz",
-			"integrity": "sha512-8qCh2Y5ZrLw1EP+s5iYCBE4HnBcB0HjudGPNLs2azYRZHOo5C3Xjc+VI5BDdfyLEZl3AOg5y6dE0dk2ur2WCeg==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/scopes": "3.1.11",
-				"@php-wasm/universal": "3.1.11",
-				"ini": "4.1.2"
-			},
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
-		"node_modules/@wp-playground/tools/node_modules/@wp-playground/blueprints": {
-			"version": "3.1.11",
-			"resolved": "https://registry.npmjs.org/@wp-playground/blueprints/-/blueprints-3.1.11.tgz",
-			"integrity": "sha512-9YeNYIKR+/LvWPnC38sorT9XJkMBz1B/Rb71kDQ5HemS8OvueyTofBc763kjQP3bumC5nr+38nMyXTNUkDuayQ==",
-			"dependencies": {
-				"@php-wasm/logger": "3.1.11",
-				"@php-wasm/node": "3.1.11",
-				"@php-wasm/node-polyfills": "3.1.11",
-				"@php-wasm/progress": "3.1.11",
-				"@php-wasm/scopes": "3.1.11",
-				"@php-wasm/stream-compression": "3.1.11",
-				"@php-wasm/universal": "3.1.11",
-				"@php-wasm/util": "3.1.11",
-				"@php-wasm/web-service-worker": "3.1.11",
-				"@wp-playground/common": "3.1.11",
-				"@wp-playground/storage": "3.1.11",
-				"@wp-playground/wordpress": "3.1.11",
-				"@zip.js/zip.js": "2.7.57",
-				"ajv": "8.12.0",
-				"async-lock": "1.4.1",
-				"clean-git-ref": "2.0.1",
-				"crc-32": "1.2.2",
-				"diff3": "0.0.4",
-				"express": "4.22.0",
-				"fast-xml-parser": "^5.5.1",
-				"fs-ext-extra-prebuilt": "2.2.7",
-				"ignore": "5.3.2",
-				"ini": "4.1.2",
-				"jsonc-parser": "3.3.1",
-				"minimisted": "2.0.1",
-				"octokit": "3.1.2",
-				"pako": "1.0.10",
-				"pify": "2.3.0",
-				"readable-stream": "3.6.2",
-				"sha.js": "2.4.12",
-				"simple-get": "4.0.1",
-				"wasm-feature-detect": "1.8.0",
-				"ws": "8.18.3",
-				"yargs": "17.7.2"
-			},
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
-		"node_modules/@wp-playground/tools/node_modules/@wp-playground/common": {
-			"version": "3.1.11",
-			"resolved": "https://registry.npmjs.org/@wp-playground/common/-/common-3.1.11.tgz",
-			"integrity": "sha512-1/5yts2ExzfVxHqK4oz9dr9Jxeuh99zhAO5ClH3zROo/7gRXKWHZWoQXNLZnPJ3RlMqYzIzHzmozhyx29rtizQ==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/universal": "3.1.11",
-				"@php-wasm/util": "3.1.11",
-				"ini": "4.1.2"
-			},
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
-		"node_modules/@wp-playground/tools/node_modules/@wp-playground/storage": {
-			"version": "3.1.11",
-			"resolved": "https://registry.npmjs.org/@wp-playground/storage/-/storage-3.1.11.tgz",
-			"integrity": "sha512-OxDlLInbRzpceMYO2CVm3hYb1MnZqJZfr444+l3QhOJEqOo6n3WAwb/8MxRbqmfokkKGbO3YGnGQrF6u+RNhWQ==",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/stream-compression": "3.1.11",
-				"@php-wasm/universal": "3.1.11",
-				"@php-wasm/util": "3.1.11",
-				"@zip.js/zip.js": "2.7.57",
-				"async-lock": "^1.4.1",
-				"clean-git-ref": "^2.0.1",
-				"crc-32": "^1.2.0",
-				"diff3": "0.0.3",
-				"ignore": "^5.1.4",
-				"ini": "4.1.2",
-				"minimisted": "^2.0.0",
-				"octokit": "3.1.2",
-				"pako": "^1.0.10",
-				"pify": "^4.0.1",
-				"readable-stream": "^3.4.0",
-				"sha.js": "^2.4.9",
-				"simple-get": "^4.0.1"
-			}
-		},
-		"node_modules/@wp-playground/tools/node_modules/@wp-playground/storage/node_modules/diff3": {
-			"version": "0.0.3",
-			"resolved": "https://registry.npmjs.org/diff3/-/diff3-0.0.3.tgz",
-			"integrity": "sha512-iSq8ngPOt0K53A6eVr4d5Kn6GNrM2nQZtC740pzIriHtn4pOQ2lyzEXQMBeVcWERN0ye7fhBsk9PbLLQOnUx/g==",
+		"node_modules/@wp-playground/tools/node_modules/json-schema-traverse": {
+			"version": "1.0.0",
 			"license": "MIT"
 		},
-		"node_modules/@wp-playground/tools/node_modules/@wp-playground/storage/node_modules/pify": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-			"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+		"node_modules/@wp-playground/tools/node_modules/pako": {
+			"version": "1.0.10",
+			"license": "(MIT AND Zlib)"
+		},
+		"node_modules/@wp-playground/tools/node_modules/strip-ansi": {
+			"version": "6.0.1",
 			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
 			"engines": {
-				"node": ">=6"
+				"node": ">=8"
 			}
 		},
-		"node_modules/@wp-playground/tools/node_modules/@wp-playground/wordpress": {
+		"node_modules/@wp-playground/tools/node_modules/yargs": {
+			"version": "17.7.2",
+			"license": "MIT",
+			"dependencies": {
+				"cliui": "^8.0.1",
+				"escalade": "^3.1.1",
+				"get-caller-file": "^2.0.5",
+				"require-directory": "^2.1.1",
+				"string-width": "^4.2.3",
+				"y18n": "^5.0.5",
+				"yargs-parser": "^21.1.1"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@wp-playground/tools/node_modules/yargs-parser": {
+			"version": "21.1.1",
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@wp-playground/wordpress": {
 			"version": "3.1.11",
 			"resolved": "https://registry.npmjs.org/@wp-playground/wordpress/-/wordpress-3.1.11.tgz",
 			"integrity": "sha512-G4sahkT4WQoCtCww0ve9GyQ+QVji7qd+6TOsuMI3iFaYgyYGIKKV4Yjx/KEOZEYKRY8BuZH6AKZpjrmu75CBxg==",
@@ -12723,127 +9437,10 @@
 				"npm": ">=10.2.3"
 			}
 		},
-		"node_modules/@wp-playground/tools/node_modules/ajv": {
-			"version": "8.12.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-			"integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-			"license": "MIT",
-			"dependencies": {
-				"fast-deep-equal": "^3.1.1",
-				"json-schema-traverse": "^1.0.0",
-				"require-from-string": "^2.0.2",
-				"uri-js": "^4.2.2"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/epoberezkin"
-			}
-		},
-		"node_modules/@wp-playground/tools/node_modules/cliui": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-			"integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-			"license": "ISC",
-			"dependencies": {
-				"string-width": "^4.2.0",
-				"strip-ansi": "^6.0.1",
-				"wrap-ansi": "^7.0.0"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/@wp-playground/tools/node_modules/ini": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
-			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
-			"license": "ISC",
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@wp-playground/tools/node_modules/json-schema-traverse": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-			"license": "MIT"
-		},
-		"node_modules/@wp-playground/tools/node_modules/pako": {
-			"version": "1.0.10",
-			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.10.tgz",
-			"integrity": "sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw==",
-			"license": "(MIT AND Zlib)"
-		},
-		"node_modules/@wp-playground/tools/node_modules/strip-ansi": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^5.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/@wp-playground/tools/node_modules/yargs": {
-			"version": "17.7.2",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-			"integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-			"license": "MIT",
-			"dependencies": {
-				"cliui": "^8.0.1",
-				"escalade": "^3.1.1",
-				"get-caller-file": "^2.0.5",
-				"require-directory": "^2.1.1",
-				"string-width": "^4.2.3",
-				"y18n": "^5.0.5",
-				"yargs-parser": "^21.1.1"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/@wp-playground/tools/node_modules/yargs-parser": {
-			"version": "21.1.1",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-			"integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-			"license": "ISC",
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/@wp-playground/wordpress": {
-			"version": "3.1.5",
-			"resolved": "https://registry.npmjs.org/@wp-playground/wordpress/-/wordpress-3.1.5.tgz",
-			"integrity": "sha512-knqsGwmsc1UMCpcsXhtLf7rlRws7tXMU47R5TN4/mXwu881lwNqw7GRnur6jB0w/fV6XBi6hrIqpKlHVymHppQ==",
-			"dev": true,
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@php-wasm/logger": "3.1.5",
-				"@php-wasm/node": "3.1.5",
-				"@php-wasm/universal": "3.1.5",
-				"@php-wasm/util": "3.1.5",
-				"@wp-playground/common": "3.1.5",
-				"express": "4.22.0",
-				"fast-xml-parser": "^5.3.4",
-				"fs-ext-extra-prebuilt": "2.2.7",
-				"ini": "4.1.2",
-				"jsonc-parser": "3.3.1",
-				"wasm-feature-detect": "1.8.0",
-				"ws": "8.18.3",
-				"yargs": "17.7.2"
-			},
-			"engines": {
-				"node": ">=20.10.0",
-				"npm": ">=10.2.3"
-			}
-		},
 		"node_modules/@wp-playground/wordpress/node_modules/cliui": {
 			"version": "8.0.1",
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
 			"integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"string-width": "^4.2.0",
@@ -12858,7 +9455,6 @@
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
 			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
-			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -12868,7 +9464,6 @@
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
 			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ansi-regex": "^5.0.1"
@@ -12881,7 +9476,6 @@
 			"version": "17.7.2",
 			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
 			"integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"cliui": "^8.0.1",
@@ -12900,7 +9494,6 @@
 			"version": "21.1.1",
 			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
 			"integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": ">=12"
@@ -12926,8 +9519,6 @@
 		},
 		"node_modules/@yao-pkg/pkg": {
 			"version": "6.14.1",
-			"resolved": "https://registry.npmjs.org/@yao-pkg/pkg/-/pkg-6.14.1.tgz",
-			"integrity": "sha512-kTtxr+r9/pi+POcuuJN9q2YRs1Ekp7iwsgU3du1XO6ozwjlp+F31ZF19WS2ZDIloWYGCvfbURrrXMgQJpWZb+Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -12959,8 +9550,6 @@
 		},
 		"node_modules/@yao-pkg/pkg-fetch": {
 			"version": "3.5.32",
-			"resolved": "https://registry.npmjs.org/@yao-pkg/pkg-fetch/-/pkg-fetch-3.5.32.tgz",
-			"integrity": "sha512-hS8zzze5VVyVAciZoNX4q3ZmCdn0gi34P2SElk4PFbzkA4LPs7qBJ3LhUKb4d4KGw1HVkFJJOMgGomH7cMqQ5Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -12978,8 +9567,6 @@
 		},
 		"node_modules/@yao-pkg/pkg-fetch/node_modules/cliui": {
 			"version": "7.0.4",
-			"resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-			"integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
@@ -12990,8 +9577,6 @@
 		},
 		"node_modules/@yao-pkg/pkg-fetch/node_modules/strip-ansi": {
 			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -13003,8 +9588,6 @@
 		},
 		"node_modules/@yao-pkg/pkg-fetch/node_modules/yargs": {
 			"version": "16.2.0",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-			"integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -13022,8 +9605,6 @@
 		},
 		"node_modules/@yao-pkg/pkg-fetch/node_modules/yargs-parser": {
 			"version": "20.2.9",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-			"integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
 			"dev": true,
 			"license": "ISC",
 			"engines": {
@@ -13032,8 +9613,6 @@
 		},
 		"node_modules/@yao-pkg/pkg/node_modules/@esbuild/darwin-arm64": {
 			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
-			"integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
 			"cpu": [
 				"arm64"
 			],
@@ -13047,61 +9626,8 @@
 				"node": ">=18"
 			}
 		},
-		"node_modules/@yao-pkg/pkg/node_modules/@esbuild/netbsd-arm64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
-			"integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"netbsd"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@yao-pkg/pkg/node_modules/@esbuild/openbsd-arm64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
-			"integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"openbsd"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@yao-pkg/pkg/node_modules/@esbuild/openharmony-arm64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
-			"integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"openharmony"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
 		"node_modules/@yao-pkg/pkg/node_modules/esbuild": {
 			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
-			"integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -13142,8 +9668,6 @@
 		},
 		"node_modules/@yao-pkg/pkg/node_modules/picomatch": {
 			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -13160,8 +9684,6 @@
 		},
 		"node_modules/@zip.js/zip.js": {
 			"version": "2.7.57",
-			"resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.7.57.tgz",
-			"integrity": "sha512-BtonQ1/jDnGiMed6OkV6rZYW78gLmLswkHOzyMrMb+CAR7CZO8phOHO6c2qw6qb1g1betN7kwEHhhZk30dv+NA==",
 			"license": "BSD-3-Clause",
 			"engines": {
 				"bun": ">=0.7.0",
@@ -13197,8 +9719,6 @@
 		},
 		"node_modules/acorn-import-attributes": {
 			"version": "1.9.5",
-			"resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
-			"integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
 			"license": "MIT",
 			"peerDependencies": {
 				"acorn": "^8"
@@ -13608,8 +10128,6 @@
 		},
 		"node_modules/assertion-error": {
 			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
-			"integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -13622,8 +10140,6 @@
 		},
 		"node_modules/async-lock": {
 			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/async-lock/-/async-lock-1.4.1.tgz",
-			"integrity": "sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ==",
 			"license": "MIT"
 		},
 		"node_modules/asynckit": {
@@ -13673,8 +10189,6 @@
 		},
 		"node_modules/babel-plugin-macros": {
 			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
-			"integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/runtime": "^7.12.5",
@@ -13744,8 +10258,6 @@
 		},
 		"node_modules/bare-events": {
 			"version": "2.8.2",
-			"resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
-			"integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
 			"license": "Apache-2.0",
 			"peerDependencies": {
 				"bare-abort-controller": "*"
@@ -13758,8 +10270,6 @@
 		},
 		"node_modules/bare-fs": {
 			"version": "4.5.3",
-			"resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.5.3.tgz",
-			"integrity": "sha512-9+kwVx8QYvt3hPWnmb19tPnh38c6Nihz8Lx3t0g9+4GoIf3/fTgYwM4Z6NxgI+B9elLQA7mLE9PpqcWtOMRDiQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
@@ -13784,8 +10294,6 @@
 		},
 		"node_modules/bare-os": {
 			"version": "3.6.2",
-			"resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.6.2.tgz",
-			"integrity": "sha512-T+V1+1srU2qYNBmJCXZkUY5vQ0B4FSlL3QDROnKQYOqeiQR8UbjNHlPa+TIbM4cuidiN9GaTaOZgSEgsvPbh5A==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
@@ -13795,8 +10303,6 @@
 		},
 		"node_modules/bare-path": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
-			"integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
@@ -13806,8 +10312,6 @@
 		},
 		"node_modules/bare-stream": {
 			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.7.0.tgz",
-			"integrity": "sha512-oyXQNicV1y8nc2aKffH+BUHFRXmx6VrPzlnaEvMhram0nPBrKcEdcyBg5r08D0i8VxngHFAiVyn1QKXpSG0B8A==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
@@ -13829,8 +10333,6 @@
 		},
 		"node_modules/bare-url": {
 			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.3.2.tgz",
-			"integrity": "sha512-ZMq4gd9ngV5aTMa5p9+UfY0b3skwhHELaDkhEHetMdX0LRkW9kzaym4oo/Eh+Ghm0CCDuMTsRIGM/ytUc1ZYmw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
@@ -13875,8 +10377,6 @@
 		},
 		"node_modules/before-after-hook": {
 			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
-			"integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
 			"license": "Apache-2.0"
 		},
 		"node_modules/benchmark-site-editor": {
@@ -13960,8 +10460,6 @@
 		},
 		"node_modules/bottleneck": {
 			"version": "2.19.5",
-			"resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
-			"integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==",
 			"license": "MIT"
 		},
 		"node_modules/bplist-creator": {
@@ -14024,8 +10522,6 @@
 		},
 		"node_modules/btoa-lite": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/btoa-lite/-/btoa-lite-1.0.0.tgz",
-			"integrity": "sha512-gvW7InbIyF8AicrqWoptdW08pUxuhq8BEgowNajy9RhiE86fmGAGl+bLKo6oB8QP0CkqHLowfN0oJdKC/J6LbA==",
 			"license": "MIT"
 		},
 		"node_modules/buffer": {
@@ -14060,8 +10556,6 @@
 		},
 		"node_modules/buffer-equal-constant-time": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-			"integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/buffer-from": {
@@ -14383,8 +10877,6 @@
 		},
 		"node_modules/chai": {
 			"version": "6.2.2",
-			"resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
-			"integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -14393,8 +10885,6 @@
 		},
 		"node_modules/chalk": {
 			"version": "5.6.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-			"integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
 			"license": "MIT",
 			"engines": {
 				"node": "^12.17.0 || ^14.13 || >=16.0.0"
@@ -14509,8 +10999,6 @@
 		},
 		"node_modules/chunkify": {
 			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/chunkify/-/chunkify-5.0.0.tgz",
-			"integrity": "sha512-G8dj/3/Gm+1yL4oWSdwIxihZWFlgC4V2zYtIApacI0iPIRKBHlBGOGAiDUBZgrj4H8MBA8g8fPFwnJrWF3wl7Q==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
@@ -14535,14 +11023,10 @@
 		},
 		"node_modules/cjs-module-lexer": {
 			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
-			"integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
 			"license": "MIT"
 		},
 		"node_modules/clean-git-ref": {
 			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/clean-git-ref/-/clean-git-ref-2.0.1.tgz",
-			"integrity": "sha512-bLSptAy2P0s6hU4PzuIMKmMJJSE6gLXGH1cntDu7bWJUksvuM+7ReOK61mozULErYvP6a15rnYl0zFDef+pyPw==",
 			"license": "Apache-2.0"
 		},
 		"node_modules/clean-stack": {
@@ -14745,8 +11229,6 @@
 		},
 		"node_modules/colorjs.io": {
 			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/colorjs.io/-/colorjs.io-0.6.1.tgz",
-			"integrity": "sha512-8lyR2wHzuIykCpqHKgluGsqQi5iDm3/a2IgP2GBZrasn2sBRkE4NOGsglZxWLs/jZQoNkmA/KM/8NV16rLUdBg==",
 			"license": "MIT",
 			"funding": {
 				"type": "opencollective",
@@ -14966,8 +11448,6 @@
 		},
 		"node_modules/cosmiconfig": {
 			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
-			"integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
 			"license": "MIT",
 			"dependencies": {
 				"@types/parse-json": "^4.0.0",
@@ -14982,8 +11462,6 @@
 		},
 		"node_modules/cosmiconfig/node_modules/yaml": {
 			"version": "1.10.2",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-			"integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
 			"license": "ISC",
 			"engines": {
 				"node": ">= 6"
@@ -15229,8 +11707,6 @@
 		},
 		"node_modules/deep-extend": {
 			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-			"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -15318,8 +11794,6 @@
 		},
 		"node_modules/deprecation": {
 			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
-			"integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
 			"license": "ISC"
 		},
 		"node_modules/dequal": {
@@ -15416,8 +11890,6 @@
 		},
 		"node_modules/dotenv": {
 			"version": "16.6.1",
-			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
-			"integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
 			"dev": true,
 			"license": "BSD-2-Clause",
 			"engines": {
@@ -15451,8 +11923,6 @@
 		},
 		"node_modules/duplexer2": {
 			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
-			"integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
@@ -15461,15 +11931,11 @@
 		},
 		"node_modules/duplexer2/node_modules/isarray": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
 			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/duplexer2/node_modules/readable-stream": {
 			"version": "2.3.8",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-			"integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -15484,8 +11950,6 @@
 		},
 		"node_modules/duplexer2/node_modules/string_decoder": {
 			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -15499,8 +11963,6 @@
 		},
 		"node_modules/ecdsa-sig-formatter": {
 			"version": "1.0.11",
-			"resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
-			"integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"safe-buffer": "^5.0.1"
@@ -15512,8 +11974,6 @@
 		},
 		"node_modules/electron": {
 			"version": "40.8.0",
-			"resolved": "https://registry.npmjs.org/electron/-/electron-40.8.0.tgz",
-			"integrity": "sha512-WoPq0Nr9Yx3g7T6VnJXdwa/rr2+VRyH3a+K+ezfMKBlf6WjxE/LmhMQabKbb6yjm9RbZhJBRcYyoLph421O2mQ==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -15539,8 +11999,6 @@
 		},
 		"node_modules/electron-installer-common": {
 			"version": "0.10.4",
-			"resolved": "https://registry.npmjs.org/electron-installer-common/-/electron-installer-common-0.10.4.tgz",
-			"integrity": "sha512-8gMNPXfAqUE5CfXg8RL0vXpLE9HAaPkgLXVoHE3BMUzogMWenf4LmwQ27BdCUrEhkjrKl+igs2IHJibclR3z3Q==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
@@ -15772,8 +12230,6 @@
 		},
 		"node_modules/electron-to-chromium": {
 			"version": "1.5.286",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.286.tgz",
-			"integrity": "sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==",
 			"dev": true,
 			"license": "ISC"
 		},
@@ -15807,8 +12263,6 @@
 		},
 		"node_modules/electron-winstaller": {
 			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/electron-winstaller/-/electron-winstaller-5.4.0.tgz",
-			"integrity": "sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -15881,8 +12335,6 @@
 		},
 		"node_modules/electron/node_modules/@types/node": {
 			"version": "24.10.13",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.13.tgz",
-			"integrity": "sha512-oH72nZRfDv9lADUBSo104Aq7gPHpQZc4BTx38r9xf9pg5LfP6EzSyH2n7qFmmxRQXh7YlUXODcYsg6PuTDSxGg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -15920,8 +12372,6 @@
 		},
 		"node_modules/electron/node_modules/undici-types": {
 			"version": "7.16.0",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-			"integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -16120,8 +12570,6 @@
 		},
 		"node_modules/equivalent-key-map": {
 			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/equivalent-key-map/-/equivalent-key-map-0.2.2.tgz",
-			"integrity": "sha512-xvHeyCDbZzkpN4VHQj/n+j2lOwL0VWszG30X4cOrc9Y7Tuo2qCdZK/0AMod23Z5dCtNUbaju6p0rwOhHUk05ew==",
 			"license": "MIT"
 		},
 		"node_modules/err-code": {
@@ -16219,8 +12667,6 @@
 		},
 		"node_modules/es-module-lexer": {
 			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
-			"integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -16320,380 +12766,6 @@
 				"@esbuild/win32-x64": "0.25.12"
 			}
 		},
-		"node_modules/esbuild/node_modules/@esbuild/aix-ppc64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
-			"integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
-			"cpu": [
-				"ppc64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"aix"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/esbuild/node_modules/@esbuild/android-arm": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
-			"integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/esbuild/node_modules/@esbuild/android-arm64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
-			"integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/esbuild/node_modules/@esbuild/android-x64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
-			"integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/esbuild/node_modules/@esbuild/darwin-x64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
-			"integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/esbuild/node_modules/@esbuild/freebsd-arm64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
-			"integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"freebsd"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/esbuild/node_modules/@esbuild/freebsd-x64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
-			"integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"freebsd"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/esbuild/node_modules/@esbuild/linux-arm": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
-			"integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/esbuild/node_modules/@esbuild/linux-arm64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
-			"integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/esbuild/node_modules/@esbuild/linux-ia32": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
-			"integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
-			"cpu": [
-				"ia32"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/esbuild/node_modules/@esbuild/linux-loong64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
-			"integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
-			"cpu": [
-				"loong64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/esbuild/node_modules/@esbuild/linux-mips64el": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
-			"integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
-			"cpu": [
-				"mips64el"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/esbuild/node_modules/@esbuild/linux-ppc64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
-			"integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
-			"cpu": [
-				"ppc64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/esbuild/node_modules/@esbuild/linux-riscv64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
-			"integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
-			"cpu": [
-				"riscv64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/esbuild/node_modules/@esbuild/linux-s390x": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
-			"integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
-			"cpu": [
-				"s390x"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/esbuild/node_modules/@esbuild/linux-x64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
-			"integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/esbuild/node_modules/@esbuild/netbsd-x64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
-			"integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"netbsd"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/esbuild/node_modules/@esbuild/openbsd-x64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
-			"integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"openbsd"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/esbuild/node_modules/@esbuild/sunos-x64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
-			"integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"sunos"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/esbuild/node_modules/@esbuild/win32-arm64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
-			"integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/esbuild/node_modules/@esbuild/win32-ia32": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
-			"integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
-			"cpu": [
-				"ia32"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/esbuild/node_modules/@esbuild/win32-x64": {
-			"version": "0.25.12",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
-			"integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
 		"node_modules/escalade": {
 			"version": "3.2.0",
 			"license": "MIT",
@@ -16774,8 +12846,6 @@
 		},
 		"node_modules/eslint-config-prettier": {
 			"version": "9.1.2",
-			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.2.tgz",
-			"integrity": "sha512-iI1f+D2ViGn+uvv5HuHVUamg8ll4tN+JRHGc6IJi4TP9Kl976C57fzPXgseXNs8v0iA8aSJpHsTWjDb9QJamGQ==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {
@@ -16967,8 +13037,6 @@
 		},
 		"node_modules/eslint-plugin-prettier": {
 			"version": "5.5.5",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.5.tgz",
-			"integrity": "sha512-hscXkbqUZ2sPithAuLm5MXL+Wph+U7wHngPBv9OMWwlP8iaflyxpjTYZkmdgB4/vPIhemRlBEoLrH7UC1n7aUw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -17053,8 +13121,6 @@
 		},
 		"node_modules/eslint/node_modules/chalk": {
 			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
 			"license": "MIT",
 			"dependencies": {
 				"ansi-styles": "^4.1.0",
@@ -17175,8 +13241,6 @@
 		},
 		"node_modules/estree-walker": {
 			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -17211,8 +13275,6 @@
 		},
 		"node_modules/events-universal": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
-			"integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"bare-events": "^2.7.0"
@@ -17298,8 +13360,6 @@
 		},
 		"node_modules/expand-template": {
 			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
-			"integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
 			"dev": true,
 			"license": "(MIT OR WTFPL)",
 			"engines": {
@@ -17321,8 +13381,6 @@
 		},
 		"node_modules/express": {
 			"version": "4.22.0",
-			"resolved": "https://registry.npmjs.org/express/-/express-4.22.0.tgz",
-			"integrity": "sha512-c2iPh3xp5vvCLgaHK03+mWLFPhox7j1LwyxcZwFVApEv5i0X+IjPpbT50SJJwwLpdBVfp45AkK/v+AFgv/XlfQ==",
 			"license": "MIT",
 			"dependencies": {
 				"accepts": "~1.3.8",
@@ -17475,8 +13533,6 @@
 		},
 		"node_modules/fast-diff": {
 			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
-			"integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
 			"dev": true,
 			"license": "Apache-2.0"
 		},
@@ -17486,8 +13542,6 @@
 		},
 		"node_modules/fast-glob": {
 			"version": "3.3.3",
-			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
-			"integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
 			"license": "MIT",
 			"dependencies": {
 				"@nodelib/fs.stat": "^2.0.2",
@@ -17524,14 +13578,10 @@
 		},
 		"node_modules/fast-string-truncated-width": {
 			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
-			"integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
 			"license": "MIT"
 		},
 		"node_modules/fast-string-width": {
 			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
-			"integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
 			"license": "MIT",
 			"dependencies": {
 				"fast-string-truncated-width": "^3.0.2"
@@ -17554,8 +13604,6 @@
 		},
 		"node_modules/fast-wrap-ansi": {
 			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.0.tgz",
-			"integrity": "sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==",
 			"license": "MIT",
 			"dependencies": {
 				"fast-string-width": "^3.0.2"
@@ -17563,8 +13611,6 @@
 		},
 		"node_modules/fast-xml-builder": {
 			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.2.tgz",
-			"integrity": "sha512-NJAmiuVaJEjVa7TjLZKlYd7RqmzOC91EtPFXHvlTcqBVo50Qh7XV5IwvXi1c7NRz2Q/majGX9YLcwJtWgHjtkA==",
 			"funding": [
 				{
 					"type": "github",
@@ -17578,8 +13624,6 @@
 		},
 		"node_modules/fast-xml-parser": {
 			"version": "5.5.3",
-			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.3.tgz",
-			"integrity": "sha512-Ymnuefk6VzAhT3SxLzVUw+nMio/wB1NGypHkgetwtXcK1JfryaHk4DWQFGVwQ9XgzyS5iRZ7C2ZGI4AMsdMZ6A==",
 			"funding": [
 				{
 					"type": "github",
@@ -17724,8 +13768,6 @@
 		},
 		"node_modules/find-root": {
 			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
-			"integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
 			"license": "MIT"
 		},
 		"node_modules/find-up": {
@@ -17893,8 +13935,6 @@
 		},
 		"node_modules/forwarded-parse": {
 			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/forwarded-parse/-/forwarded-parse-2.1.2.tgz",
-			"integrity": "sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==",
 			"license": "MIT"
 		},
 		"node_modules/framer-motion": {
@@ -17931,15 +13971,11 @@
 		},
 		"node_modules/fs-constants": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-			"integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
 			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/fs-ext-extra-prebuilt": {
 			"version": "2.2.7",
-			"resolved": "https://registry.npmjs.org/fs-ext-extra-prebuilt/-/fs-ext-extra-prebuilt-2.2.7.tgz",
-			"integrity": "sha512-Q7rayYRBDIvDF01HWOwSSjoaP+05N1g+o3BXL1Zf8Frw2JkjSmi4EtvCBITuW30l6hB2m2TW1pehdh8wyU/+gw==",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {
@@ -17951,8 +13987,6 @@
 		},
 		"node_modules/fs-extra": {
 			"version": "11.3.3",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.3.tgz",
-			"integrity": "sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg==",
 			"license": "MIT",
 			"dependencies": {
 				"graceful-fs": "^4.2.0",
@@ -17989,7 +14023,6 @@
 		},
 		"node_modules/fs-xattr": {
 			"version": "0.3.1",
-			"hasInstallScript": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -18243,8 +14276,6 @@
 		},
 		"node_modules/github-from-package": {
 			"version": "0.0.0",
-			"resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-			"integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -18340,8 +14371,6 @@
 		},
 		"node_modules/globby": {
 			"version": "14.1.0",
-			"resolved": "https://registry.npmjs.org/globby/-/globby-14.1.0.tgz",
-			"integrity": "sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA==",
 			"license": "MIT",
 			"dependencies": {
 				"@sindresorhus/merge-streams": "^2.1.0",
@@ -18360,8 +14389,6 @@
 		},
 		"node_modules/globby/node_modules/ignore": {
 			"version": "7.0.5",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-			"integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
 			"license": "MIT",
 			"engines": {
 				"node": ">= 4"
@@ -18369,8 +14396,6 @@
 		},
 		"node_modules/globby/node_modules/path-type": {
 			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/path-type/-/path-type-6.0.0.tgz",
-			"integrity": "sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
@@ -18673,8 +14698,6 @@
 		},
 		"node_modules/hoist-non-react-statics": {
 			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
-			"integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"react-is": "^16.7.0"
@@ -18871,8 +14894,6 @@
 		},
 		"node_modules/import-in-the-middle": {
 			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-2.0.6.tgz",
-			"integrity": "sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"acorn": "^8.15.0",
@@ -18930,8 +14951,6 @@
 		},
 		"node_modules/inline-style-parser": {
 			"version": "0.2.7",
-			"resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
-			"integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
 			"license": "MIT"
 		},
 		"node_modules/inquirer": {
@@ -19147,8 +15166,6 @@
 		},
 		"node_modules/into-stream": {
 			"version": "9.1.0",
-			"resolved": "https://registry.npmjs.org/into-stream/-/into-stream-9.1.0.tgz",
-			"integrity": "sha512-DRsRnQrbzdFjaQ1oe4C6/EIUymIOEix1qROEJTF9dbMq+M4Zrm6VaLp6SD/B9IsiEjPZuBSnWWFN+udajugdWA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -19419,8 +15436,6 @@
 		},
 		"node_modules/is-inside-container": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
-			"integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
 			"license": "MIT",
 			"dependencies": {
 				"is-docker": "^3.0.0"
@@ -19437,8 +15452,6 @@
 		},
 		"node_modules/is-inside-container/node_modules/is-docker": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
-			"integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
 			"license": "MIT",
 			"bin": {
 				"is-docker": "cli.js"
@@ -19528,8 +15541,6 @@
 		},
 		"node_modules/is-path-inside": {
 			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
-			"integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=12"
@@ -19552,8 +15563,6 @@
 		},
 		"node_modules/is-promise": {
 			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
-			"integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
 			"license": "MIT"
 		},
 		"node_modules/is-property": {
@@ -19920,8 +15929,6 @@
 		},
 		"node_modules/jsonc-parser": {
 			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
-			"integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
 			"license": "MIT"
 		},
 		"node_modules/jsonfile": {
@@ -19952,8 +15959,6 @@
 		},
 		"node_modules/jsonwebtoken": {
 			"version": "9.0.3",
-			"resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
-			"integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
 			"license": "MIT",
 			"dependencies": {
 				"jws": "^4.0.1",
@@ -20020,8 +16025,6 @@
 		},
 		"node_modules/jwa": {
 			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
-			"integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
 			"license": "MIT",
 			"dependencies": {
 				"buffer-equal-constant-time": "^1.0.1",
@@ -20031,8 +16034,6 @@
 		},
 		"node_modules/jws": {
 			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
-			"integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
 			"license": "MIT",
 			"dependencies": {
 				"jwa": "^2.0.1",
@@ -20056,8 +16057,6 @@
 		},
 		"node_modules/koffi": {
 			"version": "2.15.1",
-			"resolved": "https://registry.npmjs.org/koffi/-/koffi-2.15.1.tgz",
-			"integrity": "sha512-mnc0C0crx/xMSljb5s9QbnLrlFHprioFO1hkXyuSuO/QtbpLDa0l/uM21944UfQunMKmp3/r789DTDxVyyH6aA==",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"funding": {
@@ -20317,38 +16316,26 @@
 		},
 		"node_modules/lodash.includes": {
 			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
-			"integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
 			"license": "MIT"
 		},
 		"node_modules/lodash.isboolean": {
 			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
-			"integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
 			"license": "MIT"
 		},
 		"node_modules/lodash.isinteger": {
 			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
-			"integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
 			"license": "MIT"
 		},
 		"node_modules/lodash.isnumber": {
 			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
-			"integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
 			"license": "MIT"
 		},
 		"node_modules/lodash.isplainobject": {
 			"version": "4.0.6",
-			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-			"integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
 			"license": "MIT"
 		},
 		"node_modules/lodash.isstring": {
 			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-			"integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
 			"license": "MIT"
 		},
 		"node_modules/lodash.merge": {
@@ -20362,8 +16349,6 @@
 		},
 		"node_modules/lodash.once": {
 			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-			"integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
 			"license": "MIT"
 		},
 		"node_modules/lodash.throttle": {
@@ -20395,8 +16380,6 @@
 		},
 		"node_modules/log-symbols/node_modules/chalk": {
 			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -20553,7 +16536,6 @@
 		},
 		"node_modules/macos-alias": {
 			"version": "0.2.12",
-			"hasInstallScript": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -20565,8 +16547,6 @@
 		},
 		"node_modules/magic-string": {
 			"version": "0.30.21",
-			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
-			"integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -20632,8 +16612,6 @@
 		},
 		"node_modules/marked": {
 			"version": "15.0.12",
-			"resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
-			"integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
 			"license": "MIT",
 			"bin": {
 				"marked": "bin/marked.js"
@@ -21557,8 +17535,6 @@
 		},
 		"node_modules/minimisted": {
 			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/minimisted/-/minimisted-2.0.1.tgz",
-			"integrity": "sha512-1oPjfuLQa2caorJUM8HV8lGgWCc0qqAO1MNv/k05G4qslmsndV/5WdNZrqCiyqiz3wohia2Ij2B7w2Dr7/IyrA==",
 			"license": "MIT",
 			"dependencies": {
 				"minimist": "^1.2.5"
@@ -21670,21 +17646,15 @@
 		},
 		"node_modules/mkdirp-classic": {
 			"version": "0.5.3",
-			"resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-			"integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
 			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/module-details-from-path": {
 			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
-			"integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
 			"license": "MIT"
 		},
 		"node_modules/moment": {
 			"version": "2.30.1",
-			"resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
-			"integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
 			"license": "MIT",
 			"engines": {
 				"node": "*"
@@ -21692,8 +17662,6 @@
 		},
 		"node_modules/moment-timezone": {
 			"version": "0.5.48",
-			"resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.48.tgz",
-			"integrity": "sha512-f22b8LV1gbTO2ms2j2z13MuPogNoh5UzxL3nzNAYKGraILnbGc9NEE6dyiiiLv46DGRb8A4kg8UKWLjPthxBHw==",
 			"license": "MIT",
 			"dependencies": {
 				"moment": "^2.29.4"
@@ -21715,8 +17683,6 @@
 		},
 		"node_modules/mount-point": {
 			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/mount-point/-/mount-point-3.0.0.tgz",
-			"integrity": "sha512-jAhfD7ZCG+dbESZjcY1SdFVFqSJkh/yGbdsifHcPkvuLRO5ugK0Ssmd9jdATu29BTd4JiN+vkpMzVvsUgP3SZA==",
 			"license": "MIT",
 			"dependencies": {
 				"@sindresorhus/df": "^1.0.1",
@@ -21729,8 +17695,6 @@
 		},
 		"node_modules/mount-point/node_modules/@sindresorhus/df": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@sindresorhus/df/-/df-1.0.1.tgz",
-			"integrity": "sha512-1Hyp7NQnD/u4DSxR2DGW78TF9k7R0wZ8ev0BpMAIzA6yTQSHqNb5wTuvtcPYf4FWbVse2rW7RgDsyL8ua2vXHw==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -21742,8 +17706,6 @@
 		},
 		"node_modules/move-file": {
 			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/move-file/-/move-file-4.1.0.tgz",
-			"integrity": "sha512-YE06K9XLIvMlqSfoZTl32qvbZLPgL70Za41wS8pEhsSOhy71xz2fn8J07nuz/LEEtPSuUzLUFGAJSx499eKDSw==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=20"
@@ -21783,8 +17745,6 @@
 		},
 		"node_modules/multistream": {
 			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/multistream/-/multistream-4.1.0.tgz",
-			"integrity": "sha512-J1XDiAmmNpRCBfIWJv+n0ymC4ABcf/Pl+5YvC5B/D2f/2+8PtHvCNxMPKiQcZyi922Hq69J2YOpb1pTywfifyw==",
 			"dev": true,
 			"funding": [
 				{
@@ -21853,8 +17813,6 @@
 		},
 		"node_modules/napi-build-utils": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
-			"integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -21973,8 +17931,6 @@
 		},
 		"node_modules/node-forge": {
 			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.3.tgz",
-			"integrity": "sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg==",
 			"license": "(BSD-3-Clause OR GPL-2.0)",
 			"engines": {
 				"node": ">= 6.13.0"
@@ -21982,8 +17938,6 @@
 		},
 		"node_modules/node-int64": {
 			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
-			"integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -22169,8 +18123,6 @@
 		},
 		"node_modules/obug": {
 			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
-			"integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
 			"dev": true,
 			"funding": [
 				"https://github.com/sponsors/sxzz",
@@ -22180,8 +18132,6 @@
 		},
 		"node_modules/octokit": {
 			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/octokit/-/octokit-3.1.2.tgz",
-			"integrity": "sha512-MG5qmrTL5y8KYwFgE1A4JWmgfQBaIETE/lOlfwNYx1QOtCQHGVxkRJmdUJltFc1HVn73d61TlMhMyNTOtMl+ng==",
 			"license": "MIT",
 			"dependencies": {
 				"@octokit/app": "^14.0.2",
@@ -22377,8 +18327,6 @@
 		},
 		"node_modules/os-homedir": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-			"integrity": "sha512-B5JU3cabzk8c67mRRd3ECmROafjYMXbuzlwtqdM8IbS8ktlTix8aFGb2bAGKrSRIlnfKwovGUUr72JUPyOb6kQ==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -22486,7 +18434,6 @@
 		},
 		"node_modules/pako": {
 			"version": "1.0.11",
-			"dev": true,
 			"license": "(MIT AND Zlib)"
 		},
 		"node_modules/param-case": {
@@ -22554,8 +18501,6 @@
 		},
 		"node_modules/parse-json": {
 			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
-			"integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/code-frame": "^7.0.0",
@@ -22625,8 +18570,6 @@
 		},
 		"node_modules/patch-package/node_modules/chalk": {
 			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -22693,8 +18636,6 @@
 		},
 		"node_modules/path-expression-matcher": {
 			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.1.3.tgz",
-			"integrity": "sha512-qdVgY8KXmVdJZRSS1JdEPOKPdTiEK/pi0RkcT2sw1RhXxohdujUlJFPuS1TSkevZ9vzd3ZlL7ULl1MHGTApKzQ==",
 			"funding": [
 				{
 					"type": "github",
@@ -22762,8 +18703,6 @@
 		},
 		"node_modules/path-type": {
 			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-			"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -22771,8 +18710,6 @@
 		},
 		"node_modules/pathe": {
 			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-			"integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -22795,8 +18732,6 @@
 		},
 		"node_modules/pg-int8": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
-			"integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
 			"license": "ISC",
 			"engines": {
 				"node": ">=4.0.0"
@@ -22804,14 +18739,10 @@
 		},
 		"node_modules/pg-protocol": {
 			"version": "1.13.0",
-			"resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
-			"integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
 			"license": "MIT"
 		},
 		"node_modules/pg-types": {
 			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
-			"integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
 			"license": "MIT",
 			"dependencies": {
 				"pg-int8": "1.0.1",
@@ -22847,8 +18778,6 @@
 		},
 		"node_modules/pinkie": {
 			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-			"integrity": "sha512-MnUuEycAemtSaeFSjXKW/aroV7akBbY+Sv+RkyqFjgAe73F+MR0TBWKBRDkmfWq/HiFmdavfZ1G7h4SPZXaCSg==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -22856,8 +18785,6 @@
 		},
 		"node_modules/pinkie-promise": {
 			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-			"integrity": "sha512-0Gni6D4UcLTbv9c57DfxDGdr41XfgUjqWZu492f0cIGr16zDU06BWP/RAEvOuo7CQ0CNjHaLlM59YJJFm3NWlw==",
 			"license": "MIT",
 			"dependencies": {
 				"pinkie": "^2.0.0"
@@ -22876,8 +18803,6 @@
 		},
 		"node_modules/playwright": {
 			"version": "1.58.2",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
-			"integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"playwright-core": "1.58.2"
@@ -22894,8 +18819,6 @@
 		},
 		"node_modules/playwright-core": {
 			"version": "1.58.2",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
-			"integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
 			"license": "Apache-2.0",
 			"bin": {
 				"playwright-core": "cli.js"
@@ -22906,9 +18829,6 @@
 		},
 		"node_modules/playwright/node_modules/fsevents": {
 			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-			"hasInstallScript": true,
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -23078,8 +18998,6 @@
 		},
 		"node_modules/postgres-array": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
-			"integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=4"
@@ -23087,8 +19005,6 @@
 		},
 		"node_modules/postgres-bytea": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
-			"integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -23096,8 +19012,6 @@
 		},
 		"node_modules/postgres-date": {
 			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
-			"integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -23105,8 +19019,6 @@
 		},
 		"node_modules/postgres-interval": {
 			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
-			"integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
 			"license": "MIT",
 			"dependencies": {
 				"xtend": "^4.0.0"
@@ -23139,8 +19051,6 @@
 		},
 		"node_modules/powershell-utils": {
 			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.2.0.tgz",
-			"integrity": "sha512-ZlsFlG7MtSFCoc5xreOvBAozCJ6Pf06opgJjh9ONEv418xpZSAzNjstD36C6+JwOnfSqOW/9uDkqKjezTdxZhw==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=20"
@@ -23151,8 +19061,6 @@
 		},
 		"node_modules/prebuild-install": {
 			"version": "7.1.3",
-			"resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
-			"integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -23178,15 +19086,11 @@
 		},
 		"node_modules/prebuild-install/node_modules/chownr": {
 			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-			"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
 			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/prebuild-install/node_modules/tar-fs": {
 			"version": "2.1.4",
-			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
-			"integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -23198,8 +19102,6 @@
 		},
 		"node_modules/prebuild-install/node_modules/tar-stream": {
 			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-			"integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -23237,8 +19139,6 @@
 		},
 		"node_modules/prettier-linter-helpers": {
 			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.1.tgz",
-			"integrity": "sha512-SxToR7P8Y2lWmv/kTzVLC1t/GDI2WGjMwNhLLE9qtH8Q13C+aEmuRlzDst4Up4s0Wc8sF2M+J57iB3cMLqftfg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -23355,15 +19255,11 @@
 		},
 		"node_modules/proxy-from-env": {
 			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-			"integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
 			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/ps-man": {
 			"version": "1.1.8",
-			"resolved": "https://registry.npmjs.org/ps-man/-/ps-man-1.1.8.tgz",
-			"integrity": "sha512-ZKDPZwHLYVWIk/Q75N7jCFbuQyokSg2+3WBlt8l35S/uBvxoc+LiRUbb3RUt83pwW82dzwiCpoQIHd9PAxUzHg==",
 			"license": "MIT"
 		},
 		"node_modules/psl": {
@@ -23477,8 +19373,6 @@
 		},
 		"node_modules/rc": {
 			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-			"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
 			"dev": true,
 			"license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
 			"dependencies": {
@@ -23493,15 +19387,11 @@
 		},
 		"node_modules/rc/node_modules/ini": {
 			"version": "1.3.8",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-			"integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
 			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/rc/node_modules/strip-json-comments": {
 			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-			"integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -23574,8 +19464,6 @@
 		},
 		"node_modules/react-is": {
 			"version": "16.13.1",
-			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
 			"license": "MIT"
 		},
 		"node_modules/react-markdown": {
@@ -24000,8 +19888,6 @@
 		},
 		"node_modules/rememo": {
 			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/rememo/-/rememo-4.0.2.tgz",
-			"integrity": "sha512-NVfSP9NstE3QPNs/TnegQY0vnJnstKQSpcrsI2kBTB3dB2PkdfKdTa+abbjMIDqpc63fE5LfjLgfMst0ULMFxQ==",
 			"license": "MIT"
 		},
 		"node_modules/remove-accents": {
@@ -24018,8 +19904,6 @@
 		},
 		"node_modules/requestidlecallback": {
 			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/requestidlecallback/-/requestidlecallback-0.3.0.tgz",
-			"integrity": "sha512-TWHFkT7S9p7IxLC5A1hYmAYQx2Eb9w1skrXmQ+dS1URyvR8tenMLl4lHbqEOUnpEYxNKpkVMXUgknVpBZWXXfQ==",
 			"license": "MIT"
 		},
 		"node_modules/require-directory": {
@@ -24038,8 +19922,6 @@
 		},
 		"node_modules/require-in-the-middle": {
 			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-8.0.1.tgz",
-			"integrity": "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==",
 			"license": "MIT",
 			"dependencies": {
 				"debug": "^4.3.5",
@@ -24125,8 +20007,6 @@
 		},
 		"node_modules/resolve.exports": {
 			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.3.tgz",
-			"integrity": "sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -24181,8 +20061,6 @@
 		},
 		"node_modules/rimraf": {
 			"version": "6.1.3",
-			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.1.3.tgz",
-			"integrity": "sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==",
 			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"dependencies": {
@@ -24201,8 +20079,6 @@
 		},
 		"node_modules/rimraf/node_modules/balanced-match": {
 			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -24211,8 +20087,6 @@
 		},
 		"node_modules/rimraf/node_modules/brace-expansion": {
 			"version": "5.0.4",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-			"integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -24224,8 +20098,6 @@
 		},
 		"node_modules/rimraf/node_modules/glob": {
 			"version": "13.0.6",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-			"integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
 			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"dependencies": {
@@ -24242,8 +20114,6 @@
 		},
 		"node_modules/rimraf/node_modules/lru-cache": {
 			"version": "11.2.6",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
-			"integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
 			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"engines": {
@@ -24252,8 +20122,6 @@
 		},
 		"node_modules/rimraf/node_modules/minimatch": {
 			"version": "10.2.4",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-			"integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
 			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"dependencies": {
@@ -24268,8 +20136,6 @@
 		},
 		"node_modules/rimraf/node_modules/minipass": {
 			"version": "7.1.3",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
-			"integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
 			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"engines": {
@@ -24278,8 +20144,6 @@
 		},
 		"node_modules/rimraf/node_modules/path-scurry": {
 			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
-			"integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
 			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"dependencies": {
@@ -24412,14 +20276,10 @@
 		},
 		"node_modules/rungen": {
 			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/rungen/-/rungen-0.3.2.tgz",
-			"integrity": "sha512-zWl10xu2D7zoR8zSC2U6bg5bYF6T/Wk7rxwp8IPaJH7f0Ge21G03kNHVgHR7tyVkSSfAOG0Rqf/Cl38JftSmtw==",
 			"license": "MIT"
 		},
 		"node_modules/rxjs": {
 			"version": "7.8.2",
-			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
-			"integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^2.1.0"
@@ -24484,8 +20344,6 @@
 		},
 		"node_modules/sax": {
 			"version": "1.4.4",
-			"resolved": "https://registry.npmjs.org/sax/-/sax-1.4.4.tgz",
-			"integrity": "sha512-1n3r/tGXO6b6VXMdFT54SHzT9ytu9yr7TaELowdYpMqY/Ao7EnlQGmAQ1+RatX7Tkkdm6hONI2owqNx2aZj5Sw==",
 			"license": "BlueOak-1.0.0",
 			"engines": {
 				"node": ">=11.0.0"
@@ -24564,8 +20422,6 @@
 		},
 		"node_modules/semver": {
 			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
 			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver.js"
@@ -24730,8 +20586,6 @@
 		},
 		"node_modules/sha.js": {
 			"version": "2.4.12",
-			"resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.12.tgz",
-			"integrity": "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==",
 			"license": "(MIT AND BSD-3-Clause)",
 			"dependencies": {
 				"inherits": "^2.0.4",
@@ -24750,8 +20604,6 @@
 		},
 		"node_modules/sha.js/node_modules/safe-buffer": {
 			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
 			"funding": [
 				{
 					"type": "github",
@@ -24911,8 +20763,6 @@
 		},
 		"node_modules/simple-git": {
 			"version": "3.31.1",
-			"resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.31.1.tgz",
-			"integrity": "sha512-oiWP4Q9+kO8q9hHqkX35uuHmxiEbZNTrZ5IPxgMGrJwN76pzjm/jabkZO0ItEcqxAincqGAzL3QHSaHt4+knBg==",
 			"license": "MIT",
 			"dependencies": {
 				"@kwsites/file-exists": "^1.1.1",
@@ -24939,8 +20789,6 @@
 		},
 		"node_modules/slash": {
 			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
-			"integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=14.16"
@@ -25164,8 +21012,6 @@
 		},
 		"node_modules/stream-meter": {
 			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/stream-meter/-/stream-meter-1.0.4.tgz",
-			"integrity": "sha512-4sOEtrbgFotXwnEuzzsQBYEV1elAeFSO8rSGeTwabuX1RRn/kEq9JVH7I0MRBhKVRR0sJkr0M0QCH7yOLf9fhQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -25174,15 +21020,11 @@
 		},
 		"node_modules/stream-meter/node_modules/isarray": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
 			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/stream-meter/node_modules/readable-stream": {
 			"version": "2.3.8",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-			"integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -25197,8 +21039,6 @@
 		},
 		"node_modules/stream-meter/node_modules/string_decoder": {
 			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -25207,8 +21047,6 @@
 		},
 		"node_modules/streamx": {
 			"version": "2.23.0",
-			"resolved": "https://registry.npmjs.org/streamx/-/streamx-2.23.0.tgz",
-			"integrity": "sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==",
 			"license": "MIT",
 			"dependencies": {
 				"events-universal": "^1.0.0",
@@ -25398,8 +21236,6 @@
 		},
 		"node_modules/strip-final-newline": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
-			"integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
@@ -25447,8 +21283,6 @@
 		},
 		"node_modules/strnum": {
 			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.2.tgz",
-			"integrity": "sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==",
 			"funding": [
 				{
 					"type": "github",
@@ -25478,8 +21312,6 @@
 		},
 		"node_modules/style-to-object": {
 			"version": "1.0.14",
-			"resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
-			"integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
 			"license": "MIT",
 			"dependencies": {
 				"inline-style-parser": "0.2.7"
@@ -25487,8 +21319,6 @@
 		},
 		"node_modules/stylis": {
 			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
-			"integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==",
 			"license": "MIT"
 		},
 		"node_modules/sucrase": {
@@ -25612,8 +21442,6 @@
 		},
 		"node_modules/supports-color": {
 			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 			"license": "MIT",
 			"dependencies": {
 				"has-flag": "^4.0.0"
@@ -25639,8 +21467,6 @@
 		},
 		"node_modules/synckit": {
 			"version": "0.11.12",
-			"resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.12.tgz",
-			"integrity": "sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -25655,8 +21481,6 @@
 		},
 		"node_modules/tabbable": {
 			"version": "6.4.0",
-			"resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
-			"integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
 			"license": "MIT"
 		},
 		"node_modules/tailwindcss": {
@@ -25716,8 +21540,6 @@
 		},
 		"node_modules/tar": {
 			"version": "7.5.11",
-			"resolved": "https://registry.npmjs.org/tar/-/tar-7.5.11.tgz",
-			"integrity": "sha512-ChjMH33/KetonMTAtpYdgUFr0tbz69Fp2v7zWxQfYZX4g5ZN2nOBXm1R2xyA+lMIKrLKIoKAwFj93jE/avX9cQ==",
 			"license": "BlueOak-1.0.0",
 			"dependencies": {
 				"@isaacs/fs-minipass": "^4.0.0",
@@ -25732,8 +21554,6 @@
 		},
 		"node_modules/tar-fs": {
 			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.1.tgz",
-			"integrity": "sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -25906,8 +21726,6 @@
 		},
 		"node_modules/text-decoder": {
 			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.3.tgz",
-			"integrity": "sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"b4a": "^1.6.4"
@@ -25953,8 +21771,6 @@
 		},
 		"node_modules/tinyexec": {
 			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
-			"integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -26005,8 +21821,6 @@
 		},
 		"node_modules/tinyrainbow": {
 			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
-			"integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -26040,8 +21854,6 @@
 		},
 		"node_modules/to-buffer": {
 			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz",
-			"integrity": "sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==",
 			"license": "MIT",
 			"dependencies": {
 				"isarray": "^2.0.5",
@@ -26054,8 +21866,6 @@
 		},
 		"node_modules/to-buffer/node_modules/safe-buffer": {
 			"version": "5.2.1",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
 			"funding": [
 				{
 					"type": "github",
@@ -26137,8 +21947,6 @@
 		},
 		"node_modules/trash": {
 			"version": "10.1.0",
-			"resolved": "https://registry.npmjs.org/trash/-/trash-10.1.0.tgz",
-			"integrity": "sha512-gOs9Hd1XMiJfORccP8KJNDmrSJ7YqO1CNt9lGOiBiydyBJab7Eaefkc/wj50b8lTtpB/4/VgezREs9NULOm42A==",
 			"license": "MIT",
 			"dependencies": {
 				"@stroncium/procfs": "^1.2.1",
@@ -26160,8 +21968,6 @@
 		},
 		"node_modules/trash/node_modules/p-map": {
 			"version": "7.0.4",
-			"resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.4.tgz",
-			"integrity": "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
@@ -26302,8 +22108,6 @@
 		},
 		"node_modules/tunnel-agent": {
 			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-			"integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -26521,8 +22325,6 @@
 		},
 		"node_modules/unicorn-magic": {
 			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
-			"integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
@@ -26652,8 +22454,6 @@
 		},
 		"node_modules/universal-github-app-jwt": {
 			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/universal-github-app-jwt/-/universal-github-app-jwt-1.2.0.tgz",
-			"integrity": "sha512-dncpMpnsKBk0eetwfN8D8OUHGfiDhhJ+mtsbMl+7PfW7mYjiH8LIcqRmYMtzYLgSh47HjfdBtrBwIQ/gizKR3g==",
 			"license": "MIT",
 			"dependencies": {
 				"@types/jsonwebtoken": "^9.0.0",
@@ -26662,8 +22462,6 @@
 		},
 		"node_modules/universal-user-agent": {
 			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
-			"integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==",
 			"license": "ISC"
 		},
 		"node_modules/universalify": {
@@ -26744,8 +22542,6 @@
 		},
 		"node_modules/unzipper": {
 			"version": "0.12.3",
-			"resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.12.3.tgz",
-			"integrity": "sha512-PZ8hTS+AqcGxsaQntl3IRBw65QrBI6lxzqDEL7IAo/XCEqRTKGfOX56Vea5TH9SZczRVxuzk1re04z/YjuYCJA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -26844,8 +22640,6 @@
 		},
 		"node_modules/user-home": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
-			"integrity": "sha512-KMWqdlOcjCYdtIJpicDSFBQ8nFwS2i9sslAd6f4+CBGcU4gist2REnr2fxj2YocvJFxSF3ZOHLYLVZnUxv4BZQ==",
 			"license": "MIT",
 			"dependencies": {
 				"os-homedir": "^1.0.0"
@@ -27091,74 +22885,6 @@
 				"vite": "^2 || ^3 || ^4 || ^5 || ^6 || ^7"
 			}
 		},
-		"node_modules/vite/node_modules/@esbuild/aix-ppc64": {
-			"version": "0.27.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.1.tgz",
-			"integrity": "sha512-HHB50pdsBX6k47S4u5g/CaLjqS3qwaOVE5ILsq64jyzgMhLuCuZ8rGzM9yhsAjfjkbgUPMzZEPa7DAp7yz6vuA==",
-			"cpu": [
-				"ppc64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"aix"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/android-arm": {
-			"version": "0.27.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.1.tgz",
-			"integrity": "sha512-kFqa6/UcaTbGm/NncN9kzVOODjhZW8e+FRdSeypWe6j33gzclHtwlANs26JrupOntlcWmB0u8+8HZo8s7thHvg==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/android-arm64": {
-			"version": "0.27.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.1.tgz",
-			"integrity": "sha512-45fuKmAJpxnQWixOGCrS+ro4Uvb4Re9+UTieUY2f8AEc+t7d4AaZ6eUJ3Hva7dtrxAAWHtlEFsXFMAgNnGU9uQ==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/android-x64": {
-			"version": "0.27.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.1.tgz",
-			"integrity": "sha512-LBEpOz0BsgMEeHgenf5aqmn/lLNTFXVfoWMUox8CtWWYK9X4jmQzWjoGoNb8lmAYml/tQ/Ysvm8q7szu7BoxRQ==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"android"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
 		"node_modules/vite/node_modules/@esbuild/darwin-arm64": {
 			"version": "0.27.1",
 			"cpu": [
@@ -27169,363 +22895,6 @@
 			"optional": true,
 			"os": [
 				"darwin"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/darwin-x64": {
-			"version": "0.27.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.1.tgz",
-			"integrity": "sha512-+3ELd+nTzhfWb07Vol7EZ+5PTbJ/u74nC6iv4/lwIU99Ip5uuY6QoIf0Hn4m2HoV0qcnRivN3KSqc+FyCHjoVQ==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
-			"version": "0.27.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.1.tgz",
-			"integrity": "sha512-/8Rfgns4XD9XOSXlzUDepG8PX+AVWHliYlUkFI3K3GB6tqbdjYqdhcb4BKRd7C0BhZSoaCxhv8kTcBrcZWP+xg==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"freebsd"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/freebsd-x64": {
-			"version": "0.27.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.1.tgz",
-			"integrity": "sha512-GITpD8dK9C+r+5yRT/UKVT36h/DQLOHdwGVwwoHidlnA168oD3uxA878XloXebK4Ul3gDBBIvEdL7go9gCUFzQ==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"freebsd"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/linux-arm": {
-			"version": "0.27.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.1.tgz",
-			"integrity": "sha512-ieMID0JRZY/ZeCrsFQ3Y3NlHNCqIhTprJfDgSB3/lv5jJZ8FX3hqPyXWhe+gvS5ARMBJ242PM+VNz/ctNj//eA==",
-			"cpu": [
-				"arm"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/linux-arm64": {
-			"version": "0.27.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.1.tgz",
-			"integrity": "sha512-W9//kCrh/6in9rWIBdKaMtuTTzNj6jSeG/haWBADqLLa9P8O5YSRDzgD5y9QBok4AYlzS6ARHifAb75V6G670Q==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/linux-ia32": {
-			"version": "0.27.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.1.tgz",
-			"integrity": "sha512-VIUV4z8GD8rtSVMfAj1aXFahsi/+tcoXXNYmXgzISL+KB381vbSTNdeZHHHIYqFyXcoEhu9n5cT+05tRv13rlw==",
-			"cpu": [
-				"ia32"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/linux-loong64": {
-			"version": "0.27.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.1.tgz",
-			"integrity": "sha512-l4rfiiJRN7sTNI//ff65zJ9z8U+k6zcCg0LALU5iEWzY+a1mVZ8iWC1k5EsNKThZ7XCQ6YWtsZ8EWYm7r1UEsg==",
-			"cpu": [
-				"loong64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/linux-mips64el": {
-			"version": "0.27.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.1.tgz",
-			"integrity": "sha512-U0bEuAOLvO/DWFdygTHWY8C067FXz+UbzKgxYhXC0fDieFa0kDIra1FAhsAARRJbvEyso8aAqvPdNxzWuStBnA==",
-			"cpu": [
-				"mips64el"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/linux-ppc64": {
-			"version": "0.27.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.1.tgz",
-			"integrity": "sha512-NzdQ/Xwu6vPSf/GkdmRNsOfIeSGnh7muundsWItmBsVpMoNPVpM61qNzAVY3pZ1glzzAxLR40UyYM23eaDDbYQ==",
-			"cpu": [
-				"ppc64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/linux-riscv64": {
-			"version": "0.27.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.1.tgz",
-			"integrity": "sha512-7zlw8p3IApcsN7mFw0O1Z1PyEk6PlKMu18roImfl3iQHTnr/yAfYv6s4hXPidbDoI2Q0pW+5xeoM4eTCC0UdrQ==",
-			"cpu": [
-				"riscv64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/linux-s390x": {
-			"version": "0.27.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.1.tgz",
-			"integrity": "sha512-cGj5wli+G+nkVQdZo3+7FDKC25Uh4ZVwOAK6A06Hsvgr8WqBBuOy/1s+PUEd/6Je+vjfm6stX0kmib5b/O2Ykw==",
-			"cpu": [
-				"s390x"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/linux-x64": {
-			"version": "0.27.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.1.tgz",
-			"integrity": "sha512-z3H/HYI9MM0HTv3hQZ81f+AKb+yEoCRlUby1F80vbQ5XdzEMyY/9iNlAmhqiBKw4MJXwfgsh7ERGEOhrM1niMA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"linux"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/netbsd-arm64": {
-			"version": "0.27.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.1.tgz",
-			"integrity": "sha512-wzC24DxAvk8Em01YmVXyjl96Mr+ecTPyOuADAvjGg+fyBpGmxmcr2E5ttf7Im8D0sXZihpxzO1isus8MdjMCXQ==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"netbsd"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/netbsd-x64": {
-			"version": "0.27.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.1.tgz",
-			"integrity": "sha512-1YQ8ybGi2yIXswu6eNzJsrYIGFpnlzEWRl6iR5gMgmsrR0FcNoV1m9k9sc3PuP5rUBLshOZylc9nqSgymI+TYg==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"netbsd"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/openbsd-arm64": {
-			"version": "0.27.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.1.tgz",
-			"integrity": "sha512-5Z+DzLCrq5wmU7RDaMDe2DVXMRm2tTDvX2KU14JJVBN2CT/qov7XVix85QoJqHltpvAOZUAc3ndU56HSMWrv8g==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"openbsd"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/openbsd-x64": {
-			"version": "0.27.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.1.tgz",
-			"integrity": "sha512-Q73ENzIdPF5jap4wqLtsfh8YbYSZ8Q0wnxplOlZUOyZy7B4ZKW8DXGWgTCZmF8VWD7Tciwv5F4NsRf6vYlZtqg==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"openbsd"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/openharmony-arm64": {
-			"version": "0.27.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.1.tgz",
-			"integrity": "sha512-ajbHrGM/XiK+sXM0JzEbJAen+0E+JMQZ2l4RR4VFwvV9JEERx+oxtgkpoKv1SevhjavK2z2ReHk32pjzktWbGg==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"openharmony"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/sunos-x64": {
-			"version": "0.27.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.1.tgz",
-			"integrity": "sha512-IPUW+y4VIjuDVn+OMzHc5FV4GubIwPnsz6ubkvN8cuhEqH81NovB53IUlrlBkPMEPxvNnf79MGBoz8rZ2iW8HA==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"sunos"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/win32-arm64": {
-			"version": "0.27.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.1.tgz",
-			"integrity": "sha512-RIVRWiljWA6CdVu8zkWcRmGP7iRRIIwvhDKem8UMBjPql2TXM5PkDVvvrzMtj1V+WFPB4K7zkIGM7VzRtFkjdg==",
-			"cpu": [
-				"arm64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/win32-ia32": {
-			"version": "0.27.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.1.tgz",
-			"integrity": "sha512-2BR5M8CPbptC1AK5JbJT1fWrHLvejwZidKx3UMSF0ecHMa+smhi16drIrCEggkgviBwLYd5nwrFLSl5Kho96RQ==",
-			"cpu": [
-				"ia32"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/vite/node_modules/@esbuild/win32-x64": {
-			"version": "0.27.1",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.1.tgz",
-			"integrity": "sha512-d5X6RMYv6taIymSk8JBP+nxv8DQAMY6A51GPgusqLdK9wBz5wWIXy1KjTck6HnjE9hqJzJRdk+1p/t5soSbCtw==",
-			"cpu": [
-				"x64"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
 			],
 			"engines": {
 				"node": ">=18"
@@ -27600,8 +22969,6 @@
 		},
 		"node_modules/vitest": {
 			"version": "4.0.18",
-			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
-			"integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -27678,8 +23045,6 @@
 		},
 		"node_modules/vitest/node_modules/picomatch": {
 			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -27702,8 +23067,6 @@
 		},
 		"node_modules/wasm-feature-detect": {
 			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/wasm-feature-detect/-/wasm-feature-detect-1.8.0.tgz",
-			"integrity": "sha512-zksaLKM2fVlnB5jQQDqKXXwYHLQUVH9es+5TOOHwGOVJOCeRBCiPjwSg+3tN2AdTCzjgli4jijCH290kXb/zWQ==",
 			"license": "Apache-2.0"
 		},
 		"node_modules/watchpack": {
@@ -28136,8 +23499,6 @@
 		},
 		"node_modules/wsl-utils": {
 			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.4.0.tgz",
-			"integrity": "sha512-9YmF+2sFEd+T7TkwlmE337F0IVzfDvDknhtpBQxxXzEOfgPphGlFYpyx0cTuCIFj8/p+sqwBYAeGxOMNSzPPDA==",
 			"license": "MIT",
 			"dependencies": {
 				"is-wsl": "^3.1.0",
@@ -28152,8 +23513,6 @@
 		},
 		"node_modules/wsl-utils/node_modules/is-wsl": {
 			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
-			"integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
 			"license": "MIT",
 			"dependencies": {
 				"is-inside-container": "^1.0.0"
@@ -28167,8 +23526,6 @@
 		},
 		"node_modules/wsl-utils/node_modules/powershell-utils": {
 			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
-			"integrity": "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=20"
@@ -28179,8 +23536,6 @@
 		},
 		"node_modules/xdg-basedir": {
 			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
-			"integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -28188,8 +23543,6 @@
 		},
 		"node_modules/xdg-trashdir": {
 			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/xdg-trashdir/-/xdg-trashdir-3.1.0.tgz",
-			"integrity": "sha512-N1XQngeqMBoj9wM4ZFadVV2MymImeiFfYD+fJrNlcVcOHsJFFQe7n3b+aBoTPwARuq2HQxukfzVpQmAk1gN4sQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@sindresorhus/df": "^3.1.1",
@@ -28211,8 +23564,6 @@
 		},
 		"node_modules/xml2js": {
 			"version": "0.6.2",
-			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
-			"integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
 			"license": "MIT",
 			"dependencies": {
 				"sax": ">=0.6.0",
@@ -28224,8 +23575,6 @@
 		},
 		"node_modules/xml2js/node_modules/xmlbuilder": {
 			"version": "11.0.1",
-			"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
-			"integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=4.0"
@@ -28385,13 +23734,6 @@
 				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
-		"packages/eslint-plugin-studio": {
-			"version": "1.0.0",
-			"extraneous": true,
-			"dependencies": {
-				"eslint": "^9.0.0"
-			}
-		},
 		"tools/benchmark-site-editor": {
 			"version": "0.0.1",
 			"license": "GPLv2",
@@ -28399,29 +23741,80 @@
 				"@wp-playground/cli": "3.1.11",
 				"chalk": "^5.3.0",
 				"playwright": "^1.58.1",
-				"ts-node": "^10.9.2"
+				"ts-node": "^10.9.2",
+				"yargs": "^17.7.2"
 			},
 			"devDependencies": {
 				"@types/node": "^25.3.5",
+				"@types/yargs": "^17.0.33",
 				"typescript": "^5.0.0"
 			}
 		},
 		"tools/benchmark-site-editor/node_modules/@types/node": {
 			"version": "25.3.5",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.5.tgz",
-			"integrity": "sha512-oX8xrhvpiyRCQkG1MFchB09f+cXftgIXb3a7UUa4Y3wpmZPw5tyZGTLWhlESOLq1Rq6oDlc8npVU2/9xiCuXMA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"undici-types": "~7.18.0"
 			}
 		},
+		"tools/benchmark-site-editor/node_modules/cliui": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+			"integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+			"license": "ISC",
+			"dependencies": {
+				"string-width": "^4.2.0",
+				"strip-ansi": "^6.0.1",
+				"wrap-ansi": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"tools/benchmark-site-editor/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"tools/benchmark-site-editor/node_modules/undici-types": {
 			"version": "7.18.2",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-			"integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"tools/benchmark-site-editor/node_modules/yargs": {
+			"version": "17.7.2",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+			"integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+			"license": "MIT",
+			"dependencies": {
+				"cliui": "^8.0.1",
+				"escalade": "^3.1.1",
+				"get-caller-file": "^2.0.5",
+				"require-directory": "^2.1.1",
+				"string-width": "^4.2.3",
+				"y18n": "^5.0.5",
+				"yargs-parser": "^21.1.1"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"tools/benchmark-site-editor/node_modules/yargs-parser": {
+			"version": "21.1.1",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+			"integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=12"
+			}
 		},
 		"tools/common": {
 			"name": "@studio/common",
@@ -28443,7 +23836,7 @@
 				"@types/fs-extra": "^11.0.4",
 				"@types/lockfile": "^1.0.4",
 				"@types/yauzl": "^2.10.3",
-				"@wp-playground/blueprints": "3.1.5"
+				"@wp-playground/blueprints": "3.1.11"
 			}
 		},
 		"tools/compare-perf": {
@@ -28463,8 +23856,6 @@
 		},
 		"tools/compare-perf/node_modules/@types/node": {
 			"version": "25.3.5",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.5.tgz",
-			"integrity": "sha512-oX8xrhvpiyRCQkG1MFchB09f+cXftgIXb3a7UUa4Y3wpmZPw5tyZGTLWhlESOLq1Rq6oDlc8npVU2/9xiCuXMA==",
 			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
@@ -28473,8 +23864,6 @@
 		},
 		"tools/compare-perf/node_modules/chalk": {
 			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
 			"license": "MIT",
 			"dependencies": {
 				"ansi-styles": "^4.1.0",
@@ -28489,8 +23878,6 @@
 		},
 		"tools/compare-perf/node_modules/commander": {
 			"version": "13.1.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
-			"integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
@@ -28498,8 +23885,6 @@
 		},
 		"tools/compare-perf/node_modules/inquirer": {
 			"version": "12.11.1",
-			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-12.11.1.tgz",
-			"integrity": "sha512-9VF7mrY+3OmsAfjH3yKz/pLbJ5z22E23hENKw3/LNSaA/sAt3v49bDRY+Ygct1xwuKT+U+cBfTzjCPySna69Qw==",
 			"license": "MIT",
 			"dependencies": {
 				"@inquirer/ansi": "^1.0.2",
@@ -28524,8 +23909,6 @@
 		},
 		"tools/compare-perf/node_modules/mute-stream": {
 			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
-			"integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
 			"license": "ISC",
 			"engines": {
 				"node": "^18.17.0 || >=20.5.0"
@@ -28533,8 +23916,6 @@
 		},
 		"tools/compare-perf/node_modules/run-async": {
 			"version": "4.0.6",
-			"resolved": "https://registry.npmjs.org/run-async/-/run-async-4.0.6.tgz",
-			"integrity": "sha512-IoDlSLTs3Yq593mb3ZoKWKXMNu3UpObxhgA/Xuid5p4bbfi2jdY1Hj0m1K+0/tEuQTxIGMhQDqGjKb7RuxGpAQ==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.12.0"
@@ -28542,8 +23923,6 @@
 		},
 		"tools/compare-perf/node_modules/undici-types": {
 			"version": "7.18.2",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-			"integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
 			"devOptional": true,
 			"license": "MIT"
 		},

--- a/package-lock.json
+++ b/package-lock.json
@@ -9554,7 +9554,6 @@
 			"os": [
 				"darwin"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -9571,7 +9570,6 @@
 			"os": [
 				"darwin"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -9588,7 +9586,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -9605,7 +9602,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -9622,7 +9618,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -9639,7 +9634,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -9656,7 +9650,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -9673,7 +9666,6 @@
 			"os": [
 				"win32"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -9690,7 +9682,6 @@
 			"os": [
 				"win32"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -9707,7 +9698,6 @@
 			"os": [
 				"win32"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}

--- a/tools/common/logger-actions.ts
+++ b/tools/common/logger-actions.ts
@@ -40,3 +40,13 @@ export enum SiteCommandLoggerAction {
 	DELETE_PREVIEW_SITES = 'deletePreviewSites',
 	DELETE_FILES = 'deleteFiles',
 }
+
+export enum ImportCommandLoggerAction {
+	PREFLIGHT = 'preflight',
+	CREATE_SITE = 'createSite',
+	DOWNLOAD_FILES = 'downloadFiles',
+	DOWNLOAD_SQL = 'downloadSql',
+	START_SITE = 'startSite',
+	IMPORT_SQL = 'importSql',
+	URL_REWRITE = 'urlRewrite',
+}


### PR DESCRIPTION
🚧  Work in progress  🚧 

## Proposed Changes

Adds a `studio site import` command that synchronizes a remote WordPress site into the local Studio instance.

### Usage

```
# Build the CLI first
npm run cli:build

# Import a site (requires streaming-site-migration plugin on the remote)
node apps/cli/dist/cli/main.js site import \
  --url https://example.com \
  --secret the-hmac-secret-from-the-plugin \
  --name "My imported site"

# If interrupted, re-run the exact same command to resume
node apps/cli/dist/cli/main.js site import \
  --url https://example.com \
  --secret the-hmac-secret-from-the-plugin \
  --name "My imported site"

# After import, start the site
node apps/cli/dist/cli/main.js site start --path ~/Studio/my-imported-site
```

## Implementation

This command uses the [streaming-site-migration](https://github.com/adamziel/streaming-site-migration) tool. It requires the remote site to install an exporter plugin and then uses the `importer.phar` tool to download the files, the database, and rewrite the URLs in the content to match the Studio site's URL.

### Custom site structure

Regular Studio sites are stored in`~/Studio/site-name` and then you get `wp-config.php`, `wp-content` etc. Imported Studio sites reproduce the hosting account directory structure from the remote site. For example, my blog that I've imported from WordPress.com has the following directories in it:

```
./wordpress
./wordpress/core
./wordpress/plugins
./wordpress/themes
./srv
./srv/wordpress
./srv/htdocs
./srv/htdocs/wp-config.php
...
```

That's the same as what the live site uses. Is it unexpected and inconvenient? Yes. We preserve it, because there are symlinks and `require` statements referring to paths outside of the document root, such as `../wordpress/core/latest`. Some symlinks form recursive loops. That directory structure may also be reflected in `wp_options` and other database tables.

**Is there a way to normalize it into your regular WordPress directory structure in the general case?** I don't see any. Here's the list of problems:

1. `is_symlink()` checks in the codebase would be affected.
2. We'd need to update all the affected paths in all the PHP files and database entries. I don't know how to do that reliably, e.g. PHP scripts often constructs paths dynamically (`require "../themes" . $theme_dir . "/functions.php"`).  Updating URLs is much easier – `https://` is a very specific hint, most URLs are in the block markup, and we can miss some of them without generating a fatal error on every page.
3. Flattening a directory tree is a lossy operation. We couldn't reliably do repeated syncs or push the updated site back to the remote host. When a symlinked file changes, there is no way to decide whether, on the remote site, we should update the symlink target or replace the symlink with a copy of the updated file.

**But is there a way to normalize that directory structure on a host-by-host basis?** Probably, at least for some hosts. We could probably do it for WordPress.com sites, but more research is needed to confirm that.

### Special handling for managed hosting environments

Each webhosts is configured differently. Some of those configurations are not easily compatible with a local environment. The import command applies a few host-specific corrections to account for that:

- **WordPress.com Atomic**: Creates wp-config.php symlinks in the shared WP core directory so WordPress can find its config when `__DIR__` resolves to the core dir instead of the document root
- **SiteGround**: Deactivates the `sg-security` and `sg-cachepress` plugins. They could work with more effort, but for now they're deactivated.
- **Managed hosts in general**: Injects placeholder DB_* constants when wp-config.php doesn't define them (managed hosts inject credentials at the server level)

Those corrections are applied by the code shipped in this PR. This isn't perfect as they are relevant to every user of the importer tool. Therefore, they will be upstreamed to https://github.com/adamziel/streaming-site-migration, but that's out of scope of this PR.

## Blockers for merging

This PR is functional but has several rough edges that should be addressed before merging:

- [ ] **Assess how the custom directory structure would affect the rest of Studio.** I assume it would affect sync. Would it break any existing features?
- [x] Check why do the imported wp.com sites have a `wp-admin` directory in `htdocs`. This is unexpected.
- [ ] Replace ad-hoc PHP code manipulation with parsing. `wp-config.php` manipulation is done with regex in TypeScript. `serializePhpStringArray` and `deactivatePluginInSqlite` reimplement PHP serialization in TypeScript`. This should use proper PHP parsing. Playground already ships tools for that, we just need to use them.
- [ ] Test coverage for the import command.
- [ ] Improve progress messages. The number of total files and MBs downloaded tends to go up and then down. It shouldn't. Let's make it reliable and stable.

### Follow-up work

These items can be handled independently of merging this PR:

- [ ] Upstream the host-specific site corrections to https://github.com/adamziel/streaming-site-migration/.
- [x] Explore flattening the imported site structure for WP.com sites.
- [ ] **importer.phar is re-downloaded on every import** — The cached phar is deleted at the start of each import to ensure the latest version. The importer script could be either bundled with Studio or cached based on the remote ETag.
- [ ] Provide more progress updates during the database import as it can take a while.
- [x] Profile and speed-up the database import. Why is it not faster? Is it the URL rewriting?
- [ ] `disableErrorDisplayInWpConfig` is a workaround — Injecting `@ini_set('display_errors', '0')` into wp-config.php works around the fact that Studio's Blueprint constants are applied after early PHP bootstrap errors can leak through. This should be handled at the platform level (e.g., via php.ini entries in the WASM runtime) rather than modifying the imported site's files.

## Testing Instructions

1. Install the [streaming-site-migration plugin](https://github.com/adamziel/streaming-site-migration/releases/tag/v0.1.9) on a remote WordPress site
7. Run: `studio site import --url <site-url> --secret <hmac-secret> --name "My imported site"`
8. Verify the import completes and the site appears in `studio site list`
9. Start the site with `studio site start` and verify it loads correctly
10. Test resumption: interrupt an import mid-download and re-run the same command

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?