### PR TITLE
Add reusable CLI debug logging utility

### DIFF
--- a/apps/cli/lib/debug-log.ts
+++ b/apps/cli/lib/debug-log.ts
@@ -1,0 +1,62 @@
+import { appendFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+export interface DebugLogOptions {
+	defaultFilename: string;
+	enabledEnvVar: string;
+	logFileEnvVar?: string;
+	scope?: string;
+}
+
+export interface DebugLogEntry {
+	event: string;
+	payload?: unknown;
+	scope?: string;
+	timestamp: string;
+}
+
+export interface DebugLogger {
+	enabled: boolean;
+	log: ( event: string, payload?: unknown ) => void;
+	path: string;
+}
+
+function isEnabled( value: string | undefined ): boolean {
+	if ( ! value ) {
+		return false;
+	}
+
+	const normalized = value.trim().toLowerCase();
+	return normalized === '1' || normalized === 'true';
+}
+
+export function createDebugLogger( options: DebugLogOptions ): DebugLogger {
+	const enabled = isEnabled( process.env[ options.enabledEnvVar ] );
+	const path =
+		process.env[ options.logFileEnvVar ?? `${ options.enabledEnvVar }_FILE` ] ??
+		join( tmpdir(), options.defaultFilename );
+
+	return {
+		enabled,
+		path,
+		log: ( event, payload ) => {
+			if ( ! enabled ) {
+				return;
+			}
+
+			const entry: DebugLogEntry = {
+				timestamp: new Date().toISOString(),
+				scope: options.scope,
+				event,
+				payload,
+			};
+
+			try {
+				appendFileSync( path, JSON.stringify( entry ) + '\n' );
+			} catch {
+				return;
+			}
+		},
+	};
+}

--- a/apps/cli/lib/tests/debug-log.test.ts
+++ b/apps/cli/lib/tests/debug-log.test.ts
@@ -1,0 +1,120 @@
+import { appendFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock( 'fs', () => {
+	const mockedModule = {
+		appendFileSync: vi.fn(),
+	};
+	return {
+		...mockedModule,
+		default: mockedModule,
+	};
+} );
+
+vi.mock( 'os', () => {
+	const mockedModule = {
+		tmpdir: vi.fn(),
+	};
+	return {
+		...mockedModule,
+		default: mockedModule,
+	};
+} );
+
+describe( 'createDebugLogger', () => {
+	const originalEnv = { ...process.env };
+
+	beforeEach( () => {
+		vi.resetModules();
+		vi.clearAllMocks();
+		process.env = { ...originalEnv };
+		vi.mocked( tmpdir ).mockReturnValue( '/tmp/studio-tests' );
+		vi.useFakeTimers();
+		vi.setSystemTime( new Date( '2026-03-12T10:00:00.000Z' ) );
+	} );
+
+	afterEach( () => {
+		process.env = { ...originalEnv };
+		vi.useRealTimers();
+	} );
+
+	it( 'uses the default tmpdir path and skips writes when disabled', async () => {
+		delete process.env.STUDIO_AI_DEBUG;
+
+		const { createDebugLogger } = await import( '../debug-log' );
+		const logger = createDebugLogger( {
+			enabledEnvVar: 'STUDIO_AI_DEBUG',
+			defaultFilename: 'studio-ai-debug.log',
+			scope: 'todo-rendering',
+		} );
+
+		logger.log( 'todo_tool_use_received', { input: 'test' } );
+
+		expect( logger.enabled ).toBe( false );
+		expect( logger.path ).toBe( '/tmp/studio-tests/studio-ai-debug.log' );
+		expect( appendFileSync ).not.toHaveBeenCalled();
+	} );
+
+	it( 'writes JSONL entries when enabled', async () => {
+		process.env.STUDIO_AI_DEBUG = ' TRUE ';
+
+		const { createDebugLogger } = await import( '../debug-log' );
+		const logger = createDebugLogger( {
+			enabledEnvVar: 'STUDIO_AI_DEBUG',
+			defaultFilename: 'studio-ai-debug.log',
+			scope: 'todo-rendering',
+		} );
+
+		logger.log( 'todo_tool_use_received', { input: 'test' } );
+
+		expect( logger.enabled ).toBe( true );
+		expect( appendFileSync ).toHaveBeenCalledWith(
+			'/tmp/studio-tests/studio-ai-debug.log',
+			JSON.stringify( {
+				timestamp: '2026-03-12T10:00:00.000Z',
+				scope: 'todo-rendering',
+				event: 'todo_tool_use_received',
+				payload: { input: 'test' },
+			} ) + '\n'
+		);
+	} );
+
+	it( 'uses the derived file override env var by default', async () => {
+		process.env.STUDIO_AI_DEBUG = '1';
+		process.env.STUDIO_AI_DEBUG_FILE = '/tmp/custom-debug.log';
+
+		const { createDebugLogger } = await import( '../debug-log' );
+		const logger = createDebugLogger( {
+			enabledEnvVar: 'STUDIO_AI_DEBUG',
+			defaultFilename: 'studio-ai-debug.log',
+		} );
+
+		logger.log( 'todo_tool_use_received' );
+
+		expect( logger.path ).toBe( '/tmp/custom-debug.log' );
+		expect( appendFileSync ).toHaveBeenCalledWith(
+			'/tmp/custom-debug.log',
+			JSON.stringify( {
+				timestamp: '2026-03-12T10:00:00.000Z',
+				scope: undefined,
+				event: 'todo_tool_use_received',
+				payload: undefined,
+			} ) + '\n'
+		);
+	} );
+
+	it( 'uses an explicit log file env var override when provided', async () => {
+		process.env.STUDIO_AI_DEBUG = '1';
+		process.env.STUDIO_AI_LOG_PATH = '/tmp/explicit-debug.log';
+
+		const { createDebugLogger } = await import( '../debug-log' );
+		const logger = createDebugLogger( {
+			enabledEnvVar: 'STUDIO_AI_DEBUG',
+			defaultFilename: 'studio-ai-debug.log',
+			logFileEnvVar: 'STUDIO_AI_LOG_PATH',
+		} );
+
+		expect( logger.path ).toBe( '/tmp/explicit-debug.log' );
+	} );
+} );

--- a/apps/cli/lib/tests/debug-log.test.ts
+++ b/apps/cli/lib/tests/debug-log.test.ts
@@ -1,5 +1,6 @@
 import { appendFileSync } from 'fs';
 import { tmpdir } from 'os';
+import { join } from 'path';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock( 'fs', () => {
@@ -52,7 +53,7 @@ describe( 'createDebugLogger', () => {
 		logger.log( 'todo_tool_use_received', { input: 'test' } );
 
 		expect( logger.enabled ).toBe( false );
-		expect( logger.path ).toBe( '/tmp/studio-tests/studio-ai-debug.log' );
+		expect( logger.path ).toBe( join( '/tmp/studio-tests', 'studio-ai-debug.log' ) );
 		expect( appendFileSync ).not.toHaveBeenCalled();
 	} );
 
@@ -70,7 +71,7 @@ describe( 'createDebugLogger', () => {
 
 		expect( logger.enabled ).toBe( true );
 		expect( appendFileSync ).toHaveBeenCalledWith(
-			'/tmp/studio-tests/studio-ai-debug.log',
+			join( '/tmp/studio-tests', 'studio-ai-debug.log' ),
 			JSON.stringify( {
 				timestamp: '2026-03-12T10:00:00.000Z',
 				scope: 'todo-rendering',

--- a/apps/studio/src/stores/provider-constants-slice.ts
+++ b/apps/studio/src/stores/provider-constants-slice.ts
@@ -1,4 +1,4 @@
-import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { createSlice } from '@reduxjs/toolkit';
 import {
 	DEFAULT_PHP_VERSION,
 	DEFAULT_WORDPRESS_VERSION,


### PR DESCRIPTION
## How AI was used in this PR

I used Codex to scaffold the utility module, then reviewed the API shape and verified the branch with lint, typecheck, a CLI build, and targeted CLI tests.

## Proposed Changes

- add a small JSONL debug logger factory at `apps/cli/lib/debug-log.ts`
- support env-gated enablement and optional log-file overrides
- add direct unit tests for the debug logger behavior
- fix an unrelated lint warning on the branch in `provider-constants-slice.ts`

## Redundancy Check

- checked the existing CLI `Logger` in `apps/cli/logger.ts`; it is a user-facing progress/error channel for spinners, IPC status, and loader text, not a persisted debug trace sink
- checked the `studio ai` command path; progress is wired into the TUI loader, so using the existing logger for raw debug payloads would mix internal tracing into the chat UI
- checked the desktop app logging in `apps/studio/src/logging.ts`; that is Electron-side rotating console/file logging and is not a reusable standalone CLI debug facility
- checked existing site `debug.log` support; that captures PHP/WordPress runtime issues, not CLI or agent-tool execution traces
- conclusion: this utility adds value for the AI CLI context because it provides opt-in, file-backed, structured JSONL tracing without interfering with the interactive terminal UI

## Potential Follow-ups

- if we want a single logging abstraction later, move this JSONL debug sink behind `apps/cli/logger.ts` instead of keeping a separate helper
- if adopted more broadly, define a clearer split between user-facing progress logging and internal structured debug logging in the CLI layer
- if we expect wider use, consider standardizing log locations and naming instead of per-feature env vars

## Testing Instructions

- Run `npx eslint --fix apps/cli/lib/debug-log.ts apps/cli/lib/tests/debug-log.test.ts apps/studio/src/stores/provider-constants-slice.ts`
- Run `npm test -- apps/cli/lib/tests`
- Run `npm run typecheck`
- Run `npm run cli:build`
- Example usage:
  - `const debugLog = createDebugLogger( { enabledEnvVar: "STUDIO_AI_DEBUG", defaultFilename: "studio-ai-debug.log", scope: "todo-rendering" } );`
  - `debugLog.log( "todo_tool_use_received", { input } );`
- To enable logging at runtime:
  - `STUDIO_AI_DEBUG=1`
- To override the output path:
  - `STUDIO_AI_DEBUG_FILE=/tmp/studio-ai-debug.log`

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
