### PR TITLE
Improve todo rendering in the AI CLI

### DIFF
--- a/apps/cli/ai/todo-stream.ts
+++ b/apps/cli/ai/todo-stream.ts
@@ -72,19 +72,44 @@ function repeatChange( change: TodoChange, count: number ): TodoChange[] {
 }
 
 export function normalizeTodoSnapshot( todos: TodoEntry[] ): TodoEntry[] {
-	return [ ...todos ]
-		.map( ( todo ) => ( {
-			content: todo.content,
-			status: todo.status,
-			activeForm: todo.activeForm,
-		} ) )
-		.sort( compareTodoEntries );
+	return [ ...todos ].map( ( todo ) => ( {
+		content: todo.content,
+		status: todo.status,
+		activeForm: todo.activeForm,
+	} ) );
+}
+
+function buildChangeOrder( todos: TodoEntry[] ): Map< string, number > {
+	const order = new Map< string, number >();
+
+	todos.forEach( ( todo, index ) => {
+		const identity = buildIdentityKey( todo );
+		if ( ! order.has( identity ) ) {
+			order.set( identity, index );
+		}
+	} );
+
+	return order;
+}
+
+function sortTodoChangesByOrder(
+	changes: TodoChange[],
+	changeOrder: Map< string, number >
+): TodoChange[] {
+	return changes.sort(
+		( left, right ) =>
+			( changeOrder.get( buildIdentityKey( left ) ) ?? Number.MAX_SAFE_INTEGER ) -
+				( changeOrder.get( buildIdentityKey( right ) ) ?? Number.MAX_SAFE_INTEGER ) ||
+			left.content.localeCompare( right.content ) ||
+			left.activeForm.localeCompare( right.activeForm )
+	);
 }
 
 export function diffTodoSnapshot( previous: TodoEntry[], next: TodoEntry[] ): TodoDiff {
 	const snapshot = normalizeTodoSnapshot( next );
 	const previousCounts = buildCounts( normalizeTodoSnapshot( previous ) );
 	const nextCounts = buildCounts( snapshot );
+	const changeOrder = buildChangeOrder( snapshot );
 	const identities = new Set( [ ...previousCounts.keys(), ...nextCounts.keys() ] );
 	const added: TodoChange[] = [];
 	const completed: TodoChange[] = [];
@@ -112,22 +137,14 @@ export function diffTodoSnapshot( previous: TodoEntry[], next: TodoEntry[] ): To
 		added.push( ...repeatChange( entry, addedCount ) );
 	}
 
-	added.sort(
-		( left, right ) =>
-			left.content.localeCompare( right.content ) ||
-			left.activeForm.localeCompare( right.activeForm )
-	);
-	completed.sort(
-		( left, right ) =>
-			left.content.localeCompare( right.content ) ||
-			left.activeForm.localeCompare( right.activeForm )
-	);
+	sortTodoChangesByOrder( added, changeOrder );
+	sortTodoChangesByOrder( completed, changeOrder );
 
 	return {
 		added,
 		completed,
 		hasVisibleChanges: added.length > 0 || completed.length > 0,
-		signature: JSON.stringify( snapshot ),
+		signature: JSON.stringify( [ ...snapshot ].sort( compareTodoEntries ) ),
 		snapshot,
 	};
 }

--- a/apps/cli/ai/todo-stream.ts
+++ b/apps/cli/ai/todo-stream.ts
@@ -1,0 +1,133 @@
+import type { TodoWriteInput } from '@anthropic-ai/claude-agent-sdk/sdk-tools';
+
+export type TodoEntry = TodoWriteInput[ 'todos' ][ number ];
+
+export interface TodoChange {
+	content: string;
+	activeForm: string;
+}
+
+export interface TodoDiff {
+	added: TodoChange[];
+	completed: TodoChange[];
+	hasVisibleChanges: boolean;
+	signature: string;
+	snapshot: TodoEntry[];
+}
+
+interface TodoCounts {
+	total: number;
+	completed: number;
+	incomplete: number;
+	entry: TodoChange;
+}
+
+function compareTodoEntries( left: TodoEntry, right: TodoEntry ): number {
+	return (
+		left.content.localeCompare( right.content ) ||
+		left.activeForm.localeCompare( right.activeForm ) ||
+		left.status.localeCompare( right.status )
+	);
+}
+
+function buildIdentityKey( todo: TodoChange ): string {
+	return JSON.stringify( [ todo.content, todo.activeForm ] );
+}
+
+function buildCounts( todos: TodoEntry[] ): Map< string, TodoCounts > {
+	const counts = new Map< string, TodoCounts >();
+
+	for ( const todo of todos ) {
+		const identity = buildIdentityKey( todo );
+		const existing = counts.get( identity );
+
+		if ( existing ) {
+			existing.total += 1;
+			if ( todo.status === 'completed' ) {
+				existing.completed += 1;
+			}
+			continue;
+		}
+
+		counts.set( identity, {
+			total: 1,
+			completed: todo.status === 'completed' ? 1 : 0,
+			incomplete: 0,
+			entry: {
+				content: todo.content,
+				activeForm: todo.activeForm,
+			},
+		} );
+	}
+
+	for ( const value of counts.values() ) {
+		value.incomplete = value.total - value.completed;
+	}
+
+	return counts;
+}
+
+function repeatChange( change: TodoChange, count: number ): TodoChange[] {
+	return Array.from( { length: count }, () => ( { ...change } ) );
+}
+
+export function normalizeTodoSnapshot( todos: TodoEntry[] ): TodoEntry[] {
+	return [ ...todos ]
+		.map( ( todo ) => ( {
+			content: todo.content,
+			status: todo.status,
+			activeForm: todo.activeForm,
+		} ) )
+		.sort( compareTodoEntries );
+}
+
+export function diffTodoSnapshot( previous: TodoEntry[], next: TodoEntry[] ): TodoDiff {
+	const snapshot = normalizeTodoSnapshot( next );
+	const previousCounts = buildCounts( normalizeTodoSnapshot( previous ) );
+	const nextCounts = buildCounts( snapshot );
+	const identities = new Set( [ ...previousCounts.keys(), ...nextCounts.keys() ] );
+	const added: TodoChange[] = [];
+	const completed: TodoChange[] = [];
+
+	for ( const identity of identities ) {
+		const previousCount = previousCounts.get( identity );
+		const nextCount = nextCounts.get( identity );
+		const previousTotal = previousCount?.total ?? 0;
+		const nextTotal = nextCount?.total ?? 0;
+		const previousCompleted = previousCount?.completed ?? 0;
+		const nextCompleted = nextCount?.completed ?? 0;
+		const previousIncomplete = previousCount?.incomplete ?? 0;
+		const completedCount = Math.min(
+			previousIncomplete,
+			Math.max( nextCompleted - previousCompleted, 0 )
+		);
+		const addedCount = Math.max( nextTotal - previousTotal, 0 );
+		const entry = nextCount?.entry ?? previousCount?.entry;
+
+		if ( ! entry ) {
+			continue;
+		}
+
+		completed.push( ...repeatChange( entry, completedCount ) );
+		added.push( ...repeatChange( entry, addedCount ) );
+	}
+
+	added.sort(
+		( left, right ) =>
+			left.content.localeCompare( right.content ) ||
+			left.activeForm.localeCompare( right.activeForm )
+	);
+	completed.sort(
+		( left, right ) =>
+			left.content.localeCompare( right.content ) ||
+			left.activeForm.localeCompare( right.activeForm )
+	);
+
+	return {
+		added,
+		completed,
+		hasVisibleChanges: added.length > 0 || completed.length > 0,
+		signature: JSON.stringify( snapshot ),
+		snapshot,
+	};
+}

--- a/apps/cli/ai/todo-stream.ts
+++ b/apps/cli/ai/todo-stream.ts
@@ -18,7 +18,6 @@ export interface TodoDiff {
 interface TodoCounts {
 	total: number;
 	completed: number;
-	incomplete: number;
 	entry: TodoChange;
 }
 
@@ -34,6 +33,7 @@ function buildIdentityKey( todo: TodoChange ): string {
 	return JSON.stringify( [ todo.content, todo.activeForm ] );
 }
 
+// in_progress is deliberately grouped with pending (not completed) for diffing purposes.
 function buildCounts( todos: TodoEntry[] ): Map< string, TodoCounts > {
 	const counts = new Map< string, TodoCounts >();
 
@@ -52,16 +52,11 @@ function buildCounts( todos: TodoEntry[] ): Map< string, TodoCounts > {
 		counts.set( identity, {
 			total: 1,
 			completed: todo.status === 'completed' ? 1 : 0,
-			incomplete: 0,
 			entry: {
 				content: todo.content,
 				activeForm: todo.activeForm,
 			},
 		} );
-	}
-
-	for ( const value of counts.values() ) {
-		value.incomplete = value.total - value.completed;
 	}
 
 	return counts;
@@ -71,8 +66,8 @@ function repeatChange( change: TodoChange, count: number ): TodoChange[] {
 	return Array.from( { length: count }, () => ( { ...change } ) );
 }
 
-export function normalizeTodoSnapshot( todos: TodoEntry[] ): TodoEntry[] {
-	return [ ...todos ].map( ( todo ) => ( {
+function normalizeTodoSnapshot( todos: TodoEntry[] ): TodoEntry[] {
+	return todos.map( ( todo ) => ( {
 		content: todo.content,
 		status: todo.status,
 		activeForm: todo.activeForm,
@@ -92,11 +87,8 @@ function buildChangeOrder( todos: TodoEntry[] ): Map< string, number > {
 	return order;
 }
 
-function sortTodoChangesByOrder(
-	changes: TodoChange[],
-	changeOrder: Map< string, number >
-): TodoChange[] {
-	return changes.sort(
+function sortTodoChangesByOrder( changes: TodoChange[], changeOrder: Map< string, number > ): void {
+	changes.sort(
 		( left, right ) =>
 			( changeOrder.get( buildIdentityKey( left ) ) ?? Number.MAX_SAFE_INTEGER ) -
 				( changeOrder.get( buildIdentityKey( right ) ) ?? Number.MAX_SAFE_INTEGER ) ||
@@ -105,6 +97,12 @@ function sortTodoChangesByOrder(
 	);
 }
 
+/**
+ * Compute the diff between two todo snapshots. This is a forward-progress-only view:
+ * only additions and completions are reported. Removals (todos dropped from next) and
+ * regressions (completed → pending) are intentionally invisible — the UI only shows
+ * forward momentum. The signature is order-insensitive so pure reorders are also suppressed.
+ */
 export function diffTodoSnapshot( previous: TodoEntry[], next: TodoEntry[] ): TodoDiff {
 	const snapshot = normalizeTodoSnapshot( next );
 	const previousCounts = buildCounts( normalizeTodoSnapshot( previous ) );
@@ -121,9 +119,8 @@ export function diffTodoSnapshot( previous: TodoEntry[], next: TodoEntry[] ): To
 		const nextTotal = nextCount?.total ?? 0;
 		const previousCompleted = previousCount?.completed ?? 0;
 		const nextCompleted = nextCount?.completed ?? 0;
-		const previousIncomplete = previousCount?.incomplete ?? 0;
 		const completedCount = Math.min(
-			previousIncomplete,
+			previousTotal - previousCompleted,
 			Math.max( nextCompleted - previousCompleted, 0 )
 		);
 		const addedCount = Math.max( nextTotal - previousTotal, 0 );

--- a/apps/cli/ai/ui.ts
+++ b/apps/cli/ai/ui.ts
@@ -18,7 +18,12 @@ import {
 import chalk from 'chalk';
 import { AI_MODELS, DEFAULT_MODEL, type AiModelId, type AskUserQuestion } from 'cli/ai/agent';
 import { AI_CHAT_SLASH_COMMANDS, type SlashCommandDef } from 'cli/ai/slash-commands';
-import { diffTodoSnapshot, type TodoChange, type TodoEntry } from 'cli/ai/todo-stream';
+import {
+	diffTodoSnapshot,
+	type TodoChange,
+	type TodoDiff,
+	type TodoEntry,
+} from 'cli/ai/todo-stream';
 import { getSiteUrl, readAppdata, type SiteData } from 'cli/lib/appdata';
 import { openBrowser } from 'cli/lib/browser';
 import { isSiteRunning } from 'cli/lib/site-utils';
@@ -270,7 +275,7 @@ interface ToolUseResultContent {
 }
 
 interface PendingTodoRender {
-	diff: ReturnType< typeof diffTodoSnapshot >;
+	diff: TodoDiff;
 	toolLabel: string;
 	shouldRender: boolean;
 }
@@ -304,14 +309,19 @@ function formatTodoAction( action: 'added' | 'completed', todo: TodoChange ): st
 	return `${ verb }: ${ todo.content }`;
 }
 
+/**
+ * Format a single todo snapshot line for display.
+ * in_progress uses activeForm (present-tense "working on it" phrasing),
+ * while pending/completed use content (the canonical description).
+ */
 function formatTodoSnapshotLine( todo: TodoEntry ): string {
 	switch ( todo.status ) {
 		case 'completed':
 			return `${ chalk.green( '✓' ) } ${ chalk.dim( chalk.strikethrough( todo.content ) ) }`;
 		case 'in_progress':
-			return `${ chalk.yellow( '◐' ) } ${ todo.activeForm }`;
+			return `${ chalk.yellow( '◐' ) } ${ chalk.dim( todo.activeForm ) }`;
 		default:
-			return `${ chalk.dim( '○' ) } ${ todo.content }`;
+			return `${ chalk.dim( '○' ) } ${ chalk.dim( todo.content ) }`;
 	}
 }
 
@@ -326,7 +336,6 @@ export class AiChatUI {
 	private loaderVisible = false;
 	private editorVisible = false;
 	private interruptCallback: ( () => void ) | null = null;
-	private lastToolName: string | null = null;
 	private hasShownResponseMarker = false;
 	private turnStartTime = 0;
 	private toolStartTime: number | null = null;
@@ -987,6 +996,9 @@ export class AiChatUI {
 
 	/**
 	 * End an agent turn: hide loader, clean up response state.
+	 * todoSnapshot, latestTodoSnapshot, and lastRenderedTodoSignature are deliberately
+	 * preserved across turns so the next turn's diff is computed against the latest
+	 * known state, rendering only genuinely new changes.
 	 */
 	endAgentTurn(): void {
 		this.hideLoader();
@@ -1192,11 +1204,14 @@ export class AiChatUI {
 			...pendingTodoRender.diff.completed.map( ( todo ) => ( {
 				text: formatTodoAction( 'completed', todo ),
 			} ) ),
-			{ text: 'Todo list:', dim: true },
-			...pendingTodoRender.diff.snapshot.map( ( todo ) => ( {
-				text: formatTodoSnapshotLine( todo ),
-				dim: true,
-			} ) ),
+			...( pendingTodoRender.diff.snapshot.length > 0
+				? [
+						{ text: 'Todo list:', dim: true } as RenderableToolLine,
+						...pendingTodoRender.diff.snapshot.map( ( todo ) => ( {
+							text: formatTodoSnapshotLine( todo ),
+						} ) ),
+				  ]
+				: [] ),
 		];
 		const formatted = lines
 			.map(
@@ -1217,25 +1232,10 @@ export class AiChatUI {
 		this.latestTodoSnapshot = latestPendingSnapshot ?? this.todoSnapshot;
 	}
 
-	private consumePendingTodoRender( toolUseId?: string | null ): PendingTodoRender | null {
-		if ( toolUseId ) {
-			const pendingTodoRender = this.pendingTodoRenders.get( toolUseId );
-			if ( pendingTodoRender ) {
-				this.pendingTodoRenders.delete( toolUseId );
-				this.pendingTodoRenderOrder = this.pendingTodoRenderOrder.filter(
-					( id ) => id !== toolUseId
-				);
-				return pendingTodoRender;
-			}
-		}
-
-		const nextToolUseId = this.pendingTodoRenderOrder.shift();
-		if ( ! nextToolUseId ) {
-			return null;
-		}
-
-		const pendingTodoRender = this.pendingTodoRenders.get( nextToolUseId ) ?? null;
-		this.pendingTodoRenders.delete( nextToolUseId );
+	private consumePendingTodoRender( toolUseId: string ): PendingTodoRender | null {
+		const pendingTodoRender = this.pendingTodoRenders.get( toolUseId ) ?? null;
+		this.pendingTodoRenders.delete( toolUseId );
+		this.pendingTodoRenderOrder = this.pendingTodoRenderOrder.filter( ( id ) => id !== toolUseId );
 		return pendingTodoRender;
 	}
 
@@ -1296,10 +1296,8 @@ export class AiChatUI {
 		this.tui.requestRender();
 	}
 
-	private showTodoToolResult(
-		message: SDKMessage & { type: 'user' },
-		toolUseId?: string | null
-	): void {
+	private showTodoToolResult( message: SDKMessage & { type: 'user' }, toolUseId: string ): void {
+		this.stopToolDotBlink();
 		const typedResult = this.getToolResultContent( message );
 		const pendingTodoRender = this.consumePendingTodoRender( toolUseId );
 
@@ -1309,9 +1307,10 @@ export class AiChatUI {
 		}
 
 		const isError = typedResult.isError === true;
-		this.finalizeToolUseLine( isError, pendingTodoRender.toolLabel );
 
 		if ( isError ) {
+			// Errors always finalize the tool-use line (showToolUse may or may not have been called)
+			this.finalizeToolUseLine( true, pendingTodoRender.toolLabel );
 			this.syncLatestTodoSnapshot();
 			if ( typedResult.content !== undefined ) {
 				this.renderToolResultText( typedResult.content, 'TodoWrite' );
@@ -1324,10 +1323,12 @@ export class AiChatUI {
 		this.syncLatestTodoSnapshot();
 
 		if ( ! pendingTodoRender.shouldRender ) {
+			// No showToolUse was called for suppressed renders, so don't touch toolStartTime
 			this.tui.requestRender();
 			return;
 		}
 
+		this.finalizeToolUseLine( false, pendingTodoRender.toolLabel );
 		this.lastRenderedTodoSignature = pendingTodoRender.diff.signature;
 		this.renderTodoUpdate( pendingTodoRender );
 		this.tui.requestRender();
@@ -1413,7 +1414,6 @@ export class AiChatUI {
 						);
 						this.tui.requestRender();
 					} else if ( block.type === 'tool_use' ) {
-						this.lastToolName = block.name;
 						this.toolStartTime = Date.now();
 						const typedBlock = block as {
 							id: string;
@@ -1461,16 +1461,15 @@ export class AiChatUI {
 				if ( toolCallId ) {
 					this.pendingToolCalls.delete( toolCallId );
 				}
-				if (
-					this.lastToolName === 'TodoWrite' &&
-					( ( toolCallId && this.pendingTodoRenders.has( toolCallId ) ) ||
-						this.pendingTodoRenderOrder.length > 0 )
-				) {
+				// Direct ID match, or fallback for SDK-internal tools (e.g. TodoWrite)
+				// where parent_tool_use_id may be null.
+				if ( toolCallId && this.pendingTodoRenders.has( toolCallId ) ) {
 					this.showTodoToolResult( message, toolCallId );
+				} else if ( ! toolCallId && this.pendingTodoRenderOrder.length > 0 ) {
+					this.showTodoToolResult( message, this.pendingTodoRenderOrder[ 0 ] );
 				} else {
 					this.showToolResult( message, toolCall?.name, toolCall?.input );
 				}
-				this.lastToolName = null;
 				return undefined;
 			}
 			case 'result': {

--- a/apps/cli/ai/ui.ts
+++ b/apps/cli/ai/ui.ts
@@ -18,10 +18,12 @@ import {
 import chalk from 'chalk';
 import { AI_MODELS, DEFAULT_MODEL, type AiModelId, type AskUserQuestion } from 'cli/ai/agent';
 import { AI_CHAT_SLASH_COMMANDS, type SlashCommandDef } from 'cli/ai/slash-commands';
+import { diffTodoSnapshot, type TodoChange, type TodoEntry } from 'cli/ai/todo-stream';
 import { getSiteUrl, readAppdata, type SiteData } from 'cli/lib/appdata';
 import { openBrowser } from 'cli/lib/browser';
 import { isSiteRunning } from 'cli/lib/site-utils';
 import type { SDKMessage } from '@anthropic-ai/claude-agent-sdk';
+import type { TodoWriteInput } from '@anthropic-ai/claude-agent-sdk/sdk-tools';
 
 export interface SiteInfo {
 	name: string;
@@ -262,6 +264,57 @@ function formatToolName( name: string, input?: Record< string, unknown > ): stri
 	return chalk.bold( displayName );
 }
 
+interface ToolUseResultContent {
+	content?: string | Array< { type: string; text?: string } >;
+	isError?: boolean;
+}
+
+interface PendingTodoRender {
+	diff: ReturnType< typeof diffTodoSnapshot >;
+	toolLabel: string;
+	shouldRender: boolean;
+}
+
+interface RenderableToolLine {
+	text: string;
+	dim?: boolean;
+}
+
+function isTodoWriteInput( input: unknown ): input is TodoWriteInput {
+	if (
+		! input ||
+		typeof input !== 'object' ||
+		! Array.isArray( ( input as TodoWriteInput ).todos )
+	) {
+		return false;
+	}
+
+	return ( input as TodoWriteInput ).todos.every(
+		( todo ) =>
+			typeof todo === 'object' &&
+			todo !== null &&
+			typeof todo.content === 'string' &&
+			typeof todo.activeForm === 'string' &&
+			( todo.status === 'pending' || todo.status === 'in_progress' || todo.status === 'completed' )
+	);
+}
+
+function formatTodoAction( action: 'added' | 'completed', todo: TodoChange ): string {
+	const verb = action === 'added' ? 'Added todo' : 'Completed todo';
+	return `${ verb }: ${ todo.content }`;
+}
+
+function formatTodoSnapshotLine( todo: TodoEntry ): string {
+	switch ( todo.status ) {
+		case 'completed':
+			return `${ chalk.green( '✓' ) } ${ chalk.dim( chalk.strikethrough( todo.content ) ) }`;
+		case 'in_progress':
+			return `${ chalk.yellow( '◐' ) } ${ todo.activeForm }`;
+		default:
+			return `${ chalk.dim( '○' ) } ${ todo.content }`;
+	}
+}
+
 export class AiChatUI {
 	private tui: TUI;
 	private editor: PromptEditor;
@@ -281,6 +334,11 @@ export class AiChatUI {
 	private toolDotTimer: ReturnType< typeof setInterval > | null = null;
 	private toolDotVisible = true;
 	private toolDotLabel = '';
+	private todoSnapshot: TodoEntry[] = [];
+	private latestTodoSnapshot: TodoEntry[] = [];
+	private lastRenderedTodoSignature: string | null = null;
+	private pendingTodoRenders = new Map< string, PendingTodoRender >();
+	private pendingTodoRenderOrder: string[] = [];
 	private _activeSite: SiteInfo | null = null;
 	private expandablePreview: ExpandablePreview | null = null;
 	private _inAgentTurn = false;
@@ -920,6 +978,11 @@ export class AiChatUI {
 		this.currentResponseText = '';
 		this.hasShownResponseMarker = false;
 		this.turnStartTime = Date.now();
+		this.todoSnapshot = [];
+		this.latestTodoSnapshot = [];
+		this.lastRenderedTodoSignature = null;
+		this.pendingTodoRenders.clear();
+		this.pendingTodoRenderOrder = [];
 	}
 
 	/**
@@ -935,6 +998,8 @@ export class AiChatUI {
 		this.updateHints();
 		this.currentMarkdown = null;
 		this.currentResponseText = '';
+		this.pendingTodoRenders.clear();
+		this.pendingTodoRenderOrder = [];
 	}
 
 	showError( message: string ): void {
@@ -1073,59 +1138,124 @@ export class AiChatUI {
 		}
 	}
 
-	private showToolResult(
-		message: SDKMessage & { type: 'user' },
-		toolName?: string,
-		toolInput?: Record< string, unknown > | null
-	): void {
+	private showToolUse( toolLabel: string ): void {
+		this.showLoader( this.randomThinkingMessage() );
 		this.stopToolDotBlink();
+		this.toolDotLabel = toolLabel;
+		this.toolDotText = new Text( '\n ' + '⏺' + ' ' + toolLabel, 0, 0 );
+		this.messages.addChild( this.toolDotText );
+		this.toolDotVisible = true;
+		this.toolDotTimer = setInterval( () => {
+			if ( ! this.toolDotText ) {
+				return;
+			}
+			this.toolDotVisible = ! this.toolDotVisible;
+			const dot = this.toolDotVisible ? '⏺' : ' ';
+			this.toolDotText.setText( '\n ' + dot + ' ' + toolLabel );
+			this.tui.requestRender();
+		}, 500 );
+	}
+
+	private getToolResultContent(
+		message: SDKMessage & { type: 'user' }
+	): ToolUseResultContent | null {
 		const result = message.tool_use_result;
 		if ( ! result || typeof result !== 'object' ) {
-			this.toolDotText = null;
-			return;
-		}
-		const typedResult = result as {
-			content?: string | Array< { type: string; text?: string } >;
-			isError?: boolean;
-		};
-		const isError = typedResult.isError === true;
-
-		// Auto-select the site that was operated on
-		if ( ! isError && toolName && toolInput ) {
-			void this.autoSelectSiteFromToolResult( toolName, toolInput );
+			return null;
 		}
 
-		// Show elapsed time
+		return result as ToolUseResultContent;
+	}
+
+	private finalizeToolUseLine( isError: boolean, label: string ): void {
 		const elapsed = this.toolStartTime ? Date.now() - this.toolStartTime : 0;
 		this.toolStartTime = null;
 		const elapsedStr = elapsed > 0 ? chalk.dim( ` (${ ( elapsed / 1000 ).toFixed( 1 ) }s)` ) : '';
 		const statusIcon = isError ? chalk.red( '⏺' ) : '⏺';
-		const label = this.toolDotLabel;
 
-		// Update the existing tool-use line in place
 		if ( this.toolDotText ) {
 			this.toolDotText.setText( '\n ' + statusIcon + ' ' + label + elapsedStr );
 			this.toolDotText = null;
+			return;
 		}
 
-		const content = typedResult.content;
+		if ( isError ) {
+			this.messages.addChild( new Text( '\n ' + statusIcon + ' ' + label + elapsedStr, 0, 0 ) );
+		}
+	}
+
+	private renderTodoUpdate( pendingTodoRender: PendingTodoRender ): void {
+		const lines: RenderableToolLine[] = [
+			...pendingTodoRender.diff.added.map( ( todo ) => ( {
+				text: formatTodoAction( 'added', todo ),
+			} ) ),
+			...pendingTodoRender.diff.completed.map( ( todo ) => ( {
+				text: formatTodoAction( 'completed', todo ),
+			} ) ),
+			{ text: 'Todo list:', dim: true },
+			...pendingTodoRender.diff.snapshot.map( ( todo ) => ( {
+				text: formatTodoSnapshotLine( todo ),
+				dim: true,
+			} ) ),
+		];
+		const formatted = lines
+			.map(
+				( line ) => '   ' + chalk.dim( '⎿ ' ) + ( line.dim ? chalk.dim( line.text ) : line.text )
+			)
+			.join( '\n' );
+		this.messages.addChild( new Text( formatted, 0, 0 ) );
+	}
+
+	private syncLatestTodoSnapshot(): void {
+		let latestPendingSnapshot: TodoEntry[] | null = null;
+		for ( const toolUseId of this.pendingTodoRenderOrder ) {
+			const pendingTodoRender = this.pendingTodoRenders.get( toolUseId );
+			if ( pendingTodoRender ) {
+				latestPendingSnapshot = pendingTodoRender.diff.snapshot;
+			}
+		}
+		this.latestTodoSnapshot = latestPendingSnapshot ?? this.todoSnapshot;
+	}
+
+	private consumePendingTodoRender( toolUseId?: string | null ): PendingTodoRender | null {
+		if ( toolUseId ) {
+			const pendingTodoRender = this.pendingTodoRenders.get( toolUseId );
+			if ( pendingTodoRender ) {
+				this.pendingTodoRenders.delete( toolUseId );
+				this.pendingTodoRenderOrder = this.pendingTodoRenderOrder.filter(
+					( id ) => id !== toolUseId
+				);
+				return pendingTodoRender;
+			}
+		}
+
+		const nextToolUseId = this.pendingTodoRenderOrder.shift();
+		if ( ! nextToolUseId ) {
+			return null;
+		}
+
+		const pendingTodoRender = this.pendingTodoRenders.get( nextToolUseId ) ?? null;
+		this.pendingTodoRenders.delete( nextToolUseId );
+		return pendingTodoRender;
+	}
+
+	private renderToolResultText(
+		content: string | Array< { type: string; text?: string } >,
+		toolName?: string
+	): void {
 		let text: string;
 		if ( typeof content === 'string' ) {
 			text = content;
-		} else if ( Array.isArray( content ) ) {
+		} else {
 			text = content
 				.filter( ( block ) => block.type === 'text' && block.text )
 				.map( ( block ) => block.text )
 				.join( '\n' );
-		} else {
-			this.tui.requestRender();
-			return;
 		}
 		if ( ! text ) {
-			this.tui.requestRender();
 			return;
 		}
-		// Use a larger limit for validation results so they're fully visible
+
 		const maxLength = toolName === 'mcp__studio__validate_blocks' ? 2000 : 500;
 		const truncated = text.length > maxLength ? text.slice( 0, maxLength ) + '…' : text;
 		const resultLines = truncated.split( '\n' );
@@ -1133,6 +1263,73 @@ export class AiChatUI {
 			.map( ( line ) => '   ' + chalk.dim( '⎿ ' ) + chalk.dim( line ) )
 			.join( '\n' );
 		this.messages.addChild( new Text( formatted, 0, 0 ) );
+	}
+
+	private showToolResult(
+		message: SDKMessage & { type: 'user' },
+		toolName?: string,
+		toolInput?: Record< string, unknown > | null
+	): void {
+		this.stopToolDotBlink();
+		const typedResult = this.getToolResultContent( message );
+		if ( ! typedResult ) {
+			this.toolDotText = null;
+			return;
+		}
+		const isError = typedResult.isError === true;
+
+		// Auto-select the site that was operated on
+		if ( ! isError && toolName && toolInput ) {
+			void this.autoSelectSiteFromToolResult( toolName, toolInput );
+		}
+
+		const label = this.toolDotLabel;
+
+		this.finalizeToolUseLine( isError, label );
+
+		const content = typedResult.content;
+		if ( content === undefined ) {
+			this.tui.requestRender();
+			return;
+		}
+		this.renderToolResultText( content, toolName );
+		this.tui.requestRender();
+	}
+
+	private showTodoToolResult(
+		message: SDKMessage & { type: 'user' },
+		toolUseId?: string | null
+	): void {
+		const typedResult = this.getToolResultContent( message );
+		const pendingTodoRender = this.consumePendingTodoRender( toolUseId );
+
+		if ( ! typedResult || ! pendingTodoRender ) {
+			this.toolDotText = null;
+			return;
+		}
+
+		const isError = typedResult.isError === true;
+		this.finalizeToolUseLine( isError, pendingTodoRender.toolLabel );
+
+		if ( isError ) {
+			this.syncLatestTodoSnapshot();
+			if ( typedResult.content !== undefined ) {
+				this.renderToolResultText( typedResult.content, 'TodoWrite' );
+			}
+			this.tui.requestRender();
+			return;
+		}
+
+		this.todoSnapshot = pendingTodoRender.diff.snapshot;
+		this.syncLatestTodoSnapshot();
+
+		if ( ! pendingTodoRender.shouldRender ) {
+			this.tui.requestRender();
+			return;
+		}
+
+		this.lastRenderedTodoSignature = pendingTodoRender.diff.signature;
+		this.renderTodoUpdate( pendingTodoRender );
 		this.tui.requestRender();
 	}
 
@@ -1229,21 +1426,23 @@ export class AiChatUI {
 							input: input ?? {},
 						} );
 						const toolLabel = formatToolName( block.name, input );
-						this.showLoader( this.randomThinkingMessage() );
-						this.stopToolDotBlink();
-						this.toolDotLabel = toolLabel;
-						this.toolDotText = new Text( '\n ' + '⏺' + ' ' + toolLabel, 0, 0 );
-						this.messages.addChild( this.toolDotText );
-						this.toolDotVisible = true;
-						this.toolDotTimer = setInterval( () => {
-							if ( ! this.toolDotText ) {
-								return;
+						if ( block.name === 'TodoWrite' && isTodoWriteInput( input ) ) {
+							const diff = diffTodoSnapshot( this.latestTodoSnapshot, input.todos );
+							const shouldRender =
+								diff.hasVisibleChanges && diff.signature !== this.lastRenderedTodoSignature;
+							this.pendingTodoRenders.set( typedBlock.id, {
+								diff,
+								toolLabel,
+								shouldRender,
+							} );
+							this.pendingTodoRenderOrder.push( typedBlock.id );
+							this.latestTodoSnapshot = diff.snapshot;
+							if ( shouldRender ) {
+								this.showToolUse( toolLabel );
 							}
-							this.toolDotVisible = ! this.toolDotVisible;
-							const dot = this.toolDotVisible ? '⏺' : ' ';
-							this.toolDotText.setText( '\n ' + dot + ' ' + toolLabel );
-							this.tui.requestRender();
-						}, 500 );
+						} else {
+							this.showToolUse( toolLabel );
+						}
 						if ( ( block.name === 'Write' || block.name === 'Edit' ) && input ) {
 							this.showFilePreview( block.name, input );
 						}
@@ -1262,7 +1461,15 @@ export class AiChatUI {
 				if ( toolCallId ) {
 					this.pendingToolCalls.delete( toolCallId );
 				}
-				this.showToolResult( message, toolCall?.name, toolCall?.input );
+				if (
+					this.lastToolName === 'TodoWrite' &&
+					( ( toolCallId && this.pendingTodoRenders.has( toolCallId ) ) ||
+						this.pendingTodoRenderOrder.length > 0 )
+				) {
+					this.showTodoToolResult( message, toolCallId );
+				} else {
+					this.showToolResult( message, toolCall?.name, toolCall?.input );
+				}
 				this.lastToolName = null;
 				return undefined;
 			}


### PR DESCRIPTION
## Related issues

- Related to todo tool behavior improvements

## How AI was used in this PR

I used Codex to implement the initial renderer changes, then iterated against live CLI output and debug logs to correct result pairing and preserve the agent's incoming todo order.

## Proposed Changes

- render `TodoWrite` updates in the CLI stream when the agent adds or completes todos
- suppress repeated sequential todo snapshots that do not add or complete anything visible
- keep the agent's incoming todo order in the rendered list instead of alphabetizing it
- render completed todos with a checkmark and terminal strikethrough

## Testing Instructions

- Run `npx eslint --fix apps/cli/ai/ui.ts apps/cli/ai/todo-stream.ts`
- Run `npm run typecheck`
- Run `npm run cli:build`
- Start the AI CLI and use this prompt (replace "Sublime" with a site local in your testing env"):
  - `Using a todo list. On the site Sublime: 1. Inspect the site - 2. Discover active plugins - 3. Summarize findings`
- Expected stream behavior (note `~` chars represent strikethroughs - see screenshot for example):

```text
● Update todo list (0.0s)
  ⎿ Added todo: Inspect the Sublime site
  ⎿ Added todo: Discover active plugins
  ⎿ Added todo: Summarize findings
  ⎿ Todo list:
  ⎿ ◐ Inspecting the Sublime site
  ⎿ ○ Discover active plugins
  ⎿ ○ Summarize findings

● Update todo list (0.0s)
  ⎿ Completed todo: Inspect the Sublime site
  ⎿ Todo list:
  ⎿ ✓ ~Inspect the Sublime site~
  ⎿ ◐ Discovering active plugins
  ⎿ ○ Summarize findings

● Update todo list (0.0s)
  ⎿ Completed todo: Discover active plugins
  ⎿ Todo list:
  ⎿ ✓ ~Inspect the Sublime site~
  ⎿ ✓ ~Discover active plugins~
  ⎿ ◐ Summarizing findings
```
<img width="816" height="296" alt="CleanShot 2026-03-12 at 10 12 17@2x" src="https://github.com/user-attachments/assets/c0c50a46-48a7-4c28-9d23-221ae0989912" />

- Also verify that `in_progress`-only transitions without an add or completion stay silent, and repeated sequential todo snapshots do not render twice.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?