### PR TITLE
Show friendly message when user interrupts AI agent

### DIFF
--- a/apps/cli/ai/ui.ts
+++ b/apps/cli/ai/ui.ts
@@ -336,6 +336,7 @@ export class AiChatUI {
 	private loaderVisible = false;
 	private editorVisible = false;
 	private interruptCallback: ( () => void ) | null = null;
+	private wasInterrupted = false;
 	private hasShownResponseMarker = false;
 	private turnStartTime = 0;
 	private toolStartTime: number | null = null;
@@ -553,6 +554,7 @@ export class AiChatUI {
 				return { consume: true };
 			}
 			if ( matchesKey( data, 'escape' ) && this.interruptCallback ) {
+				this.wasInterrupted = true;
 				this.interruptCallback();
 			}
 			if ( matchesKey( data, 'ctrl+o' ) && this.expandablePreview ) {
@@ -986,6 +988,7 @@ export class AiChatUI {
 		this.showLoader( this.randomThinkingMessage() );
 		this.currentResponseText = '';
 		this.hasShownResponseMarker = false;
+		this.wasInterrupted = false;
 		this.turnStartTime = Date.now();
 		this.todoSnapshot = [];
 		this.latestTodoSnapshot = [];
@@ -1485,6 +1488,16 @@ export class AiChatUI {
 						} turns · $${ message.total_cost_usd.toFixed( 4 ) }`
 					);
 					return { sessionId: message.session_id, success: true };
+				}
+
+				// User-initiated interruption: show friendly message instead of error
+				if ( this.wasInterrupted ) {
+					const thinkingSec = Math.round( ( Date.now() - this.turnStartTime ) / 1000 );
+					this.messages.addChild(
+						new Text( '\n ' + chalk.yellow( '⏺' ) + ' ' + chalk.yellow( 'Interrupted' ), 0, 0 )
+					);
+					this.showInfo( `Ran for ${ thinkingSec }s before interruption` );
+					return { sessionId: message.session_id, success: false };
 				}
 
 				// Build detailed error message


### PR DESCRIPTION
## Related issues

Fixes #

## How AI was used in this PR

AI Code assistant designed and implemented the change to improve user experience when interrupting the AI agent.

## Proposed Changes

- Track when the user presses Escape to interrupt the AI agent
- When interruption occurs, display a friendly yellow "Interrupted" message instead of the raw red SDK error
- Show how long the agent ran before interruption for transparency

## Testing Instructions

1. Run `npm run cli:build && node apps/cli/dist/cli/main.js ai`
2. Enter a prompt that takes a while to process
3. Press Escape during agent execution
4. Verify that a yellow "Interrupted" message appears with duration info instead of a red error

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?

Ran lint, typecheck, and verified the change works as expected.