### PR TITLE
Fix AI agent message display between tool calls

### DIFF
--- a/apps/cli/ai/ui.ts
+++ b/apps/cli/ai/ui.ts
@@ -1479,6 +1479,10 @@ export class AiChatUI {
 				} else {
 					this.showToolResult( message, toolCall?.name, toolCall?.input );
 				}
+				// Close the current markdown block so the next assistant text
+				// creates a fresh visual block (mirrors askUser / endAgentTurn).
+				this.currentMarkdown = null;
+				this.currentResponseText = '';
 				return undefined;
 			}
 			case 'result': {


### PR DESCRIPTION
## Related issues

Related to AI chat functionality

## How AI was used in this PR

AI helped identify the root cause by analyzing the message handling flow in the CLI chat UI and design the minimal fix.

## Proposed Changes

- Reset `currentMarkdown` state when tool results arrive so each assistant reply between tool calls creates a fresh visual block
- Prevents the first assistant message from being updated/overwritten as the agent loop progresses

## Testing Instructions

1. Run the AI command: `npm run cli:build && node apps/cli/dist/cli/main.js ai`
2. Ask the agent to perform a task with tool calls (e.g., "read package.json and summarize it")
3. Verify each assistant reply between tool calls appears as a separate block with its own blue dot marker
4. Confirm text within a single assistant message still concatenates correctly

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?