### PR TITLE
Fix app-size metrics prefix in CodeVitals logging

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -64,9 +64,7 @@ steps:
       queue: mac
     command: bash .buildkite/commands/run-metrics-tests.sh
     artifact_paths:
-      - artifacts/**/*.json
-      - artifacts/**/*.results.json
-      - artifacts/**/*.summary.json
+      - tools/metrics/artifacts/**/*.json
     plugins: [$CI_TOOLKIT_PLUGIN, $NVM_PLUGIN]
     if: build.branch == 'trunk' || (build.pull_request.base_branch == 'trunk' && !build.pull_request.draft)
     notify:

--- a/tools/compare-perf/log-to-codevitals.ts
+++ b/tools/compare-perf/log-to-codevitals.ts
@@ -16,7 +16,7 @@ const resultsFiles = [
 	},
 	{
 		file: 'app-size.summary.json',
-		metricsPrefix: 'app-size-',
+		metricsPrefix: '',
 	},
 ];
 


### PR DESCRIPTION
## Related issues

- Follow-up to #2774

## Proposed Changes

- Remove the `app-size-` prefix from `app-size.summary.json` in `log-to-codevitals.ts`

The metric keys `appSizeMac` / `appSizeWin` are already self-describing, so the prefix was causing them to be logged to CodeVitals as `app-size-appSizeMac` instead of the intended `appSizeMac`.

## Testing Instructions

Let's just merge and test if the builds go through.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?