### PR TITLE
Remove stale version field from package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,5 @@
 {
 	"name": "studio",
-	"version": "1.7.4",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {


### PR DESCRIPTION
## Related issues

- p1773334178020429-slack-C06DRMD6VPZ

## How AI was used in this PR

I created the change and tested it manually. I confirmed my investigation and created the PR with AI.

## Proposed Changes

Removes the stale `"version": "1.7.4"` field from the top level of `package-lock.json`. This field was accidentally introduced in #2632 when `npm install` regenerated the lockfile. Since the root `package.json` has no `version` field (the package is `"private": true`), this value in the lockfile is an artifact that can become stale across releases.

## Testing Instructions

- Run `nvm use && npm install` and verify `package-lock.json` doesn't reintroduce a top-level `version` field

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors? (Tests pass, no errors)