### PR TITLE
Add Slack notification on trunk build failure

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -6,6 +6,12 @@
 env:
   IMAGE_ID: $IMAGE_ID
 
+notify:
+  - slack:
+      channels:
+        - "C056D54B98U"
+    if: build.state == 'passed'
+
 steps:
   - label: Lint
     agents:


### PR DESCRIPTION
## Related issues

N/A

## How AI was used in this PR

Claude Code added the pipeline-level `notify` block to the Buildkite pipeline.

## Proposed Changes

- Add a pipeline-level Slack notification to `#studio` (channel `C056D54B98U`) when a trunk build fails
- Condition is temporarily set to `build.state == 'passed'` (no branch restriction) to verify the Slack message format in a PR build before switching to the final `build.branch == 'trunk' && build.state == 'failed'` condition

## Testing Instructions

- Push to this branch and let CI run
- A Slack message should appear in the firehose channel when the build passes
- Once the message format is confirmed, update the condition to `build.branch == 'trunk' && build.state == 'failed'` before merging

## Pre-merge Checklist

- [ ] Update `if` condition back to `build.branch == 'trunk' && build.state == 'failed'` before merging
- [ ] Have you checked for TypeScript, React or other console errors?