### PR TITLE
Update release notes for 1.7.6

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -10,12 +10,11 @@ Unreleased
 * Improved deeplink connection speed #2375
 * Fixed site processes opening terminals on Windows #2794
 * Fixed removing sites when site folder is already removed #2705
-* Fixed Open in… IDE to respect user's preferred editor #2730
+* Fixed Open file in IDE to respect user's preferred editor #2730
 * Fixed re-selecting the same file not triggering the import #2768
 * Fixed unsafe type assertions #2719
 * Renamed VS Code labels to Visual Studio Code #2693
-* Replaced pm2 with a homegrown process manager daemon #2712
-* Replaced pm2-axon with a homegrown solution #2690
+* Replaced pm2 and pm2-axon with homegrown solutions for process management #2712, #2690
 * Updated multiple dependencies, including Electron, Sentry, WordPress packages, and PHP-WASM
 
 1.7.5

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,134 +3,20 @@ Unreleased
 
 1.7.6
 =====
-* Update release notes for 1.7.4 #2591
-* Bundle WordPress translation files with download retry and failure handling #2575
-* Bump the wp-playground-php-wasm group with 29 updates #2585
-* Bump the testing group with 11 updates #2569
-* Timeout `site stop --all` after 6s when quitting #2475
-* Add Blueprint details step to blueprint selection flow #2571
-* Bump the electron group with 5 updates #2566
-* Bump tar from 7.5.2 to 7.5.8 #2601
-* Disable Copy and Delete in context menu when any site is being added #2596
-* Fix Preview site and Push size validation to exclude archived-out directories #2598
-* Add Site Editor performance benchmark across environments #2600
-* Add default Blueprint description from steps #2602
-* Update @php-wasm and @wp-playground packages from 3.0.53 to 3.1.1 #2610
-* Fix Studio CLI yargs locale strings displaying in English #2609
-* Bump nokogiri from 1.19.0 to 1.19.1 #2613
-* Adopt monorepo structure #2565
-* Patch fs-ext-extra-prebuilt to remove other-platform binaries on install #2615
-* Bump the electron group with 5 updates #2622
-* Use JSX children syntax instead of children prop in tests #2621
-* Remove useEffect state resets in WelcomeComponent and AIInput #2619
-* Fix performance tests to support pre-monorepo commits #2627
-* Fix performance test to support old structure for both build and test runner paths #2629
-* Bump @types/node from 20.19.33 to 25.3.0 in the typescript group #2624
-* Fix missing aria-level on heading role in site settings #2618
-* Add JSPI support for PHP WASM extensions #2560
-* Studio: Fix toBeInDocument warnings in tests #2628
-* Bump the wordpress group with 29 updates #2623
-* Bump the sentry group with 12 updates #2626
-* Document how to trigger E2E and performance tests on PR review #2635
-* Fix flaky blueprint plugin activate E2E test #2634
-* Fix push cancellation error dialog #2633
-* Add @yao-pkg/pkg to dependabot allow list #2639
-* Add Redis and Memcached support #2554
-* Add drag-and-drop site reordering with sortOrder persistence #2498
-* Exclude @php-wasm packages from app.asar bundle #2641
-* Bump @inquirer/prompts from 7.10.1 to 8.3.0 in the inquirer group #2647
-* Remove PHP-WASM web builds from output #2644
-* Add WP_DEBUG_LOG and WP_DEBUG_DISPLAY toggles #2553
-* Fix toggle sidebar icon alignment after Add Site modal #2636
-* Studio: Add time display over pull and push completed notification #2653
-* Bump electron-to-chromium from 1.5.286 to 1.5.302 in the electron group #2642
-* Fix CLI uninstall on Windows not removing bin directory #2608
-* Fix React performance and accessibility issues from react-doctor #2654
-* Remove dead code: unused exports, types, and files #2620
-* Add open debug log file button in Settings #2649
-* Bump the wp-playground-php-wasm group with 33 updates #2643
-* Add "Open Application Logs" to Help menu #2656
-* Delete legacy mu-plugin files that lived in site filesystem #2655
-* [Tooling] Add Buildkite release pipelines and fastlane lanes for ReleasesV2 #2583
-* Add initial .pot file and extract pot generation to a reusable lane #2658
-* Fix code_freeze lane committing beta bump to wrong branch #2668
-* Only remove `@php-wasm/\d-\d` packages #2670
-* Merge release/1.7.5 into trunk #2669
-* Add Dependabot auto-merge workflow for patch and minor dev updates #2573
-* Lint and format with a single command in `AGENTS.md` #2661
-* Switch e2e plugin search test from Contact Form 7 to Jetpack Protect #2674
-* Bump rollup from 4.50.2 to 4.59.0 #2672
-* Add Proof of Concept PR guidance for large exploratory contributions #2662
-* Improve welcome screen shown in offline mode #2666
-* Remove test output pollution from jsdom and Redux #2664
-* Make site create CLI command interactive #2657
-* Bump the typescript group with 2 updates #2678
-* Bump electron from 40.6.0 to 40.6.1 in the electron group #2677
-* Studio: Add feature flag for the new Agents tab #2671
-* Add trailing slash to wp-admin URLs to prevent redirect #2680
-* Bump the sentry group with 19 updates #2679
-* Add support for Blueprints login #2527
-* Studio: Allow hidden files import within wp-content #2663
-* Update WordPress Playground dependencies to 3.1.3 #2687
-* Prefill admin email and make it mandatory #2681
-* Attach app logs to E2E stdout when tests fail #2686
-* Include AI acknowledgement in GitHub PR template #2691
-* Move pull and push states from SyncSitesProvider to a new Redux slice #2037
-* Log stdout/stderr on forge prePackage hook failures #2688
-* [Tooling] Make beta releases self-contained with translations and backmerge #2676
-* Always kill PM2 daemon when running `site stop --all` #2683
-* Studio: Resolve type error for blueprint steps #2694
-* Update WordPress Playground dependencies 3.1.4 in trunk #2703
-* Bump tar from 7.5.9 to 7.5.10 #2708
-* Add React Doctor CI Buildkite job #2659
-* Studio Agents Suite: Add starter agents.md file and ship it to site root #2684
-* Rename VS Code labels to Visual Studio Code #2693
-* Bump the electron group with 2 updates #2714
-* Bump @types/node from 25.3.2 to 25.3.5 in the typescript group #2716
-* Allow enableMultisite blueprint step #2470
-* Studio Agents Suite: Add multisite info to agents.md #2721
-* Remove en-dash substitution from GitHub release build names #2722
-* Fix removing sites when site folder is already removed #2705
-* Merge release/1.7.5 into trunk #2723
-* Replace pm2-axon with homegrown solution #2690
-* Add admin credentials to interactive site creation flow #2682
-* Remove react-doctor CI job #2726
-* Fix Typescript errors and clean up TS configs #2685
-* Experiment to speed up deeplink connection from WP.com #2375
-* [Tooling] Update GitHub release title format from "vX.Y.Z" to "Version X.Y.Z" #2728
-* Bump @sentry/react from 10.40.0 to 10.42.0 in the sentry group #2717
-* Bump the wordpress group with 28 updates #2715
-* Remove express dependency #2732
-* Update release notes for 1.7.5 mentioning Blueprint and admin credentials #2736
-* Bump the sentry group with 7 updates #2735
-* Add DEV_APP_DATA_PATH env var for isolated appdata JSON #2713
-* Replace pm2 with homegrown process manager daemon #2712
-* Bump the wp-playground-php-wasm group with 24 updates #2733
-* Studio: Add AGENTS.md management #2698
-* Add Studio CLI skill for agent-assisted site management #2700
-* Bump tar from 7.5.10 to 7.5.11 #2742
-* Add `studio ai` CLI command with interactive AI agent #2632
-* Add /exit slash command to AI chat #2744
-* Fix studio ai /exit command hanging #2746
-* Add `/browser` slash command to AI chat #2747
-* Fix "space to open" command during site selection #2748
-* Fix some unsafe type assertions #2719
-* Move block validation from jsdom/Node.js to Playwright browser #2761
-* Attempt to remove incompatible binaries when signing #2766
-* Auto-select sites in AI CLI based on agent tool usage #2745
-* AI: Remove esc to interrupt from site selection #2750
-* Add /login and /logout slash commands to AI chat #2749
-* Fix openFileInIDE to respect user's preferred editor #2730
-* Fix CLI dev path references to use apps/cli/dist/cli/main.js #2756
-* Add file content preview and diff viewer to studio ai TUI #2754
-* Improve todo rendering in the AI CLI #2772
-* Studio: Re-selecting the same file doesn't trigger the import #2768
-* @mikaoelitiana made their first contribution in https://github.com/Automattic/studio/pull/2498
-* @wpmobilebot made their first contribution in https://github.com/Automattic/studio/pull/2669
-* @nerrad made their first contribution in https://github.com/Automattic/studio/pull/2744
-* @tyxla made their first contribution in https://github.com/Automattic/studio/pull/2747
-* @taipeicoder made their first contribution in https://github.com/Automattic/studio/pull/2749
-**Full Changelog**: https://github.com/Automattic/studio/compare/v1.7.4...v1.7.6
+* Added enableMultisite Blueprint step support #2470
+* Added admin credentials to interactive CLI site creation flow #2682
+* Prefilled admin email and made it mandatory during site creation #2681
+* Improved app quit reliability by always killing PM2 daemon on site stop #2683
+* Improved deeplink connection speed #2375
+* Fixed site processes opening terminals on Windows #2794
+* Fixed removing sites when site folder is already removed #2705
+* Fixed Open in… IDE to respect user's preferred editor #2730
+* Fixed re-selecting the same file not triggering the import #2768
+* Fixed unsafe type assertions #2719
+* Renamed VS Code labels to Visual Studio Code #2693
+* Replaced pm2 with a homegrown process manager daemon #2712
+* Replaced pm2-axon with a homegrown solution #2690
+* Updated multiple dependencies, including Electron, Sentry, WordPress packages, and PHP-WASM
 
 1.7.5
 =====


### PR DESCRIPTION
## Summary
- Replace auto-generated PR dump with curated, user-facing release notes for 1.7.6
- Notes cover changes since v1.7.5, excluding items behind feature flags and internal/CI changes

## Test plan
- Review release notes in `RELEASE-NOTES.txt` for accuracy and completeness
