### PR TITLE
Add preview MCP tools to Studio AI

### DIFF
--- a/apps/cli/ai/system-prompt.ts
+++ b/apps/cli/ai/system-prompt.ts
@@ -33,6 +33,10 @@ Then continue with:
 - site_start: Start a stopped site
 - site_stop: Stop a running site
 - site_delete: Delete a site from Studio and optionally move its files to trash
+- preview_create: Create a hosted WordPress.com preview for a local site
+- preview_list: List hosted WordPress.com previews for a local site
+- preview_update: Update an existing hosted WordPress.com preview from a local site
+- preview_delete: Delete a hosted WordPress.com preview by hostname
 - wp_cli: Run WP-CLI commands on a running site
 - validate_blocks: Validate block content for correctness on a running site (runs each block through its save() function in a real browser). Requires a site name or path. Call after every file write/edit that contains block content.
 - take_screenshot: Take a full-page screenshot of a URL (supports desktop and mobile viewports). Use this to visually check the site after building it.

--- a/apps/cli/ai/system-prompt.ts
+++ b/apps/cli/ai/system-prompt.ts
@@ -33,9 +33,9 @@ Then continue with:
 - site_start: Start a stopped site
 - site_stop: Stop a running site
 - site_delete: Delete a site from Studio and optionally move its files to trash
-- preview_create: Create a hosted WordPress.com preview for a local site
+- preview_create: Create a hosted WordPress.com preview for a local site; this can take a few minutes, so tell the user to wait
 - preview_list: List hosted WordPress.com previews for a local site
-- preview_update: Update an existing hosted WordPress.com preview from a local site
+- preview_update: Update an existing hosted WordPress.com preview from a local site; this can take a few minutes, so tell the user to wait
 - preview_delete: Delete a hosted WordPress.com preview by hostname
 - wp_cli: Run WP-CLI commands on a running site
 - validate_blocks: Validate block content for correctness on a running site (runs each block through its save() function in a real browser). Requires a site name or path. Call after every file write/edit that contains block content.

--- a/apps/cli/ai/tests/tools.test.ts
+++ b/apps/cli/ai/tests/tools.test.ts
@@ -1,0 +1,177 @@
+import { vi } from 'vitest';
+import { runCommand as runCreatePreviewCommand } from 'cli/commands/preview/create';
+import { runCommand as runDeletePreviewCommand } from 'cli/commands/preview/delete';
+import { runCommand as runListPreviewCommand } from 'cli/commands/preview/list';
+import { runCommand as runUpdatePreviewCommand } from 'cli/commands/preview/update';
+import { getSiteByFolder, readAppdata } from 'cli/lib/appdata';
+import { studioToolDefinitions } from '../tools';
+
+vi.mock( 'cli/ai/block-validator', () => ( {
+	validateBlocks: vi.fn(),
+} ) );
+
+vi.mock( 'cli/ai/browser-utils', () => ( {
+	getSharedBrowser: vi.fn(),
+} ) );
+
+vi.mock( 'cli/commands/preview/create', () => ( {
+	runCommand: vi.fn(),
+} ) );
+
+vi.mock( 'cli/commands/preview/delete', () => ( {
+	runCommand: vi.fn(),
+} ) );
+
+vi.mock( 'cli/commands/preview/list', () => ( {
+	runCommand: vi.fn(),
+} ) );
+
+vi.mock( 'cli/commands/preview/update', () => ( {
+	runCommand: vi.fn(),
+} ) );
+
+vi.mock( 'cli/commands/site/create', () => ( {
+	runCommand: vi.fn(),
+} ) );
+
+vi.mock( 'cli/commands/site/delete', () => ( {
+	runCommand: vi.fn(),
+} ) );
+
+vi.mock( 'cli/commands/site/list', () => ( {
+	runCommand: vi.fn(),
+} ) );
+
+vi.mock( 'cli/commands/site/start', () => ( {
+	runCommand: vi.fn(),
+} ) );
+
+vi.mock( 'cli/commands/site/status', () => ( {
+	runCommand: vi.fn(),
+} ) );
+
+vi.mock( 'cli/commands/site/stop', () => ( {
+	Mode: { STOP_SINGLE_SITE: 'stop_single_site' },
+	runCommand: vi.fn(),
+} ) );
+
+vi.mock( 'cli/lib/appdata', async () => ( {
+	...( await vi.importActual( 'cli/lib/appdata' ) ),
+	getSiteByFolder: vi.fn(),
+	readAppdata: vi.fn(),
+} ) );
+
+vi.mock( 'cli/lib/daemon-client', () => ( {
+	connectToDaemon: vi.fn(),
+	disconnectFromDaemon: vi.fn(),
+} ) );
+
+vi.mock( 'cli/lib/wordpress-server-manager', () => ( {
+	isServerRunning: vi.fn(),
+	sendWpCliCommand: vi.fn(),
+} ) );
+
+describe( 'Studio AI MCP tools', () => {
+	const mockSite = {
+		id: 'site-123',
+		name: 'My Site',
+		path: '/sites/my-site',
+		adminPassword: 'password',
+		port: 8888,
+		phpVersion: '8.3',
+	};
+
+	const getTool = ( name: string ) => {
+		const tool = studioToolDefinitions.find( ( definition ) => definition.name === name );
+		expect( tool ).toBeDefined();
+		return tool as ( typeof studioToolDefinitions )[ number ];
+	};
+
+	const getTextContent = ( result: { content?: Array< { type: string; text?: string } > } ) => {
+		const firstContent = result.content?.[ 0 ];
+		return firstContent && 'text' in firstContent ? firstContent.text : undefined;
+	};
+
+	beforeEach( () => {
+		vi.resetAllMocks();
+		process.exitCode = undefined;
+		vi.mocked( readAppdata ).mockResolvedValue( {
+			sites: [ mockSite ],
+		} as Awaited< ReturnType< typeof readAppdata > > );
+		vi.mocked( getSiteByFolder ).mockResolvedValue( mockSite );
+	} );
+
+	it( 'includes preview tools in the MCP registry', () => {
+		expect( studioToolDefinitions.map( ( tool ) => tool.name ) ).toEqual(
+			expect.arrayContaining( [
+				'preview_create',
+				'preview_list',
+				'preview_update',
+				'preview_delete',
+			] )
+		);
+	} );
+
+	it( 'creates previews for a resolved local site', async () => {
+		const result = await getTool( 'preview_create' ).handler(
+			{ nameOrPath: 'My Site' } as never,
+			null
+		);
+
+		expect( runCreatePreviewCommand ).toHaveBeenCalledWith( '/sites/my-site' );
+		expect( result.isError ).toBeUndefined();
+		expect( getTextContent( result ) ).toContain( 'Preview site created for "My Site".' );
+	} );
+
+	it( 'lists previews as JSON for a resolved local site', async () => {
+		vi.mocked( runListPreviewCommand ).mockImplementation( async () => {
+			console.log( '[{"url":"https://demo.wordpress.com"}]' );
+		} );
+
+		const result = await getTool( 'preview_list' ).handler(
+			{ nameOrPath: 'My Site' } as never,
+			null
+		);
+
+		expect( runListPreviewCommand ).toHaveBeenCalledWith( '/sites/my-site', 'json' );
+		expect( result.isError ).toBeUndefined();
+		expect( getTextContent( result ) ).toBe( '[{"url":"https://demo.wordpress.com"}]' );
+	} );
+
+	it( 'updates previews with a normalized hostname', async () => {
+		const result = await getTool( 'preview_update' ).handler(
+			{
+				nameOrPath: 'My Site',
+				host: 'https://demo.wordpress.com/',
+				overwrite: true,
+			} as never,
+			null
+		);
+
+		expect( runUpdatePreviewCommand ).toHaveBeenCalledWith(
+			'/sites/my-site',
+			'demo.wordpress.com',
+			true
+		);
+		expect( result.isError ).toBeUndefined();
+		expect( getTextContent( result ) ).toContain(
+			'Preview site "demo.wordpress.com" updated from "My Site".'
+		);
+	} );
+
+	it( 'returns preview delete failures as tool errors', async () => {
+		vi.mocked( runDeletePreviewCommand ).mockImplementation( async () => {
+			process.exitCode = 1;
+			console.log( 'Failed to delete preview site' );
+		} );
+
+		const result = await getTool( 'preview_delete' ).handler(
+			{ host: 'https://demo.wordpress.com/' } as never,
+			null
+		);
+
+		expect( runDeletePreviewCommand ).toHaveBeenCalledWith( 'demo.wordpress.com' );
+		expect( result.isError ).toBe( true );
+		expect( getTextContent( result ) ).toBe( 'Failed to delete preview site' );
+	} );
+} );

--- a/apps/cli/ai/tests/tools.test.ts
+++ b/apps/cli/ai/tests/tools.test.ts
@@ -4,6 +4,7 @@ import { runCommand as runDeletePreviewCommand } from 'cli/commands/preview/dele
 import { runCommand as runListPreviewCommand } from 'cli/commands/preview/list';
 import { runCommand as runUpdatePreviewCommand } from 'cli/commands/preview/update';
 import { getSiteByFolder, readAppdata } from 'cli/lib/appdata';
+import { getProgressCallback, setProgressCallback } from 'cli/logger';
 import { studioToolDefinitions } from '../tools';
 
 vi.mock( 'cli/ai/block-validator', () => ( {
@@ -95,10 +96,15 @@ describe( 'Studio AI MCP tools', () => {
 	beforeEach( () => {
 		vi.resetAllMocks();
 		process.exitCode = undefined;
+		setProgressCallback( null );
 		vi.mocked( readAppdata ).mockResolvedValue( {
 			sites: [ mockSite ],
 		} as Awaited< ReturnType< typeof readAppdata > > );
 		vi.mocked( getSiteByFolder ).mockResolvedValue( mockSite );
+	} );
+
+	afterEach( () => {
+		setProgressCallback( null );
 	} );
 
 	it( 'includes preview tools in the MCP registry', () => {
@@ -173,5 +179,14 @@ describe( 'Studio AI MCP tools', () => {
 		expect( runDeletePreviewCommand ).toHaveBeenCalledWith( 'demo.wordpress.com' );
 		expect( result.isError ).toBe( true );
 		expect( getTextContent( result ) ).toBe( 'Failed to delete preview site' );
+	} );
+
+	it( 'restores the previous progress callback after running a preview tool', async () => {
+		const previousCallback = vi.fn();
+		setProgressCallback( previousCallback );
+
+		await getTool( 'preview_create' ).handler( { nameOrPath: 'My Site' } as never, null );
+
+		expect( getProgressCallback() ).toBe( previousCallback );
 	} );
 } );

--- a/apps/cli/ai/tools.ts
+++ b/apps/cli/ai/tools.ts
@@ -6,6 +6,10 @@ import { DEFAULT_PHP_VERSION } from '@studio/common/constants';
 import { z } from 'zod/v4';
 import { validateBlocks, type ValidationReport } from 'cli/ai/block-validator';
 import { getSharedBrowser } from 'cli/ai/browser-utils';
+import { runCommand as runCreatePreviewCommand } from 'cli/commands/preview/create';
+import { runCommand as runDeletePreviewCommand } from 'cli/commands/preview/delete';
+import { runCommand as runListPreviewCommand } from 'cli/commands/preview/list';
+import { runCommand as runUpdatePreviewCommand } from 'cli/commands/preview/update';
 import { runCommand as runCreateSiteCommand } from 'cli/commands/site/create';
 import { runCommand as runDeleteSiteCommand } from 'cli/commands/site/delete';
 import { runCommand as runListSitesCommand } from 'cli/commands/site/list';
@@ -14,8 +18,9 @@ import { runCommand as runStatusCommand } from 'cli/commands/site/status';
 import { runCommand as runStopSiteCommand, Mode as StopMode } from 'cli/commands/site/stop';
 import { getSiteByFolder, getSiteUrl, readAppdata, type SiteData } from 'cli/lib/appdata';
 import { connectToDaemon, disconnectFromDaemon } from 'cli/lib/daemon-client';
+import { normalizeHostname } from 'cli/lib/utils';
 import { isServerRunning, sendWpCliCommand } from 'cli/lib/wordpress-server-manager';
-import { emitProgress } from 'cli/logger';
+import { setProgressCallback, emitProgress } from 'cli/logger';
 
 const SITES_ROOT = path.join( os.homedir(), 'Studio' );
 
@@ -125,6 +130,53 @@ async function captureConsoleOutput( fn: () => Promise< void > ): Promise< strin
 		console.table = origTable;
 	}
 	return captured.trim();
+}
+
+async function captureCommandOutput( fn: () => Promise< void > ): Promise< {
+	consoleOutput: string;
+	progressOutput: string;
+	exitCode: number | undefined;
+} > {
+	let consoleOutput = '';
+	const progressMessages: string[] = [];
+	let thrownError: unknown;
+	const originalConsoleLog = console.log;
+	const originalConsoleTable = console.table;
+	const previousExitCode = process.exitCode;
+
+	console.log = ( ...args: unknown[] ) => {
+		consoleOutput += args.map( String ).join( ' ' ) + '\n';
+	};
+	console.table = ( ...args: unknown[] ) => {
+		consoleOutput += args.map( String ).join( ' ' ) + '\n';
+	};
+	process.exitCode = undefined;
+	setProgressCallback( ( message ) => {
+		progressMessages.push( message );
+	} );
+
+	try {
+		await fn();
+	} catch ( error ) {
+		thrownError = error;
+	} finally {
+		console.log = originalConsoleLog;
+		console.table = originalConsoleTable;
+		setProgressCallback( null );
+	}
+
+	const exitCode = process.exitCode;
+	process.exitCode = previousExitCode;
+
+	if ( thrownError ) {
+		throw thrownError;
+	}
+
+	return {
+		consoleOutput: consoleOutput.trim(),
+		progressOutput: progressMessages.join( '\n' ),
+		exitCode,
+	};
 }
 
 const createSiteTool = tool(
@@ -273,6 +325,140 @@ const deleteSiteTool = tool(
 		} catch ( error ) {
 			return errorResult(
 				`Failed to delete site: ${ error instanceof Error ? error.message : String( error ) }`
+			);
+		}
+	}
+);
+
+const createPreviewTool = tool(
+	'preview_create',
+	'Creates a WordPress.com preview site from a local Studio site. Requires WordPress.com authentication.',
+	{
+		nameOrPath: z.string().describe( 'The local site name or file system path to preview' ),
+	},
+	async ( args ) => {
+		try {
+			const site = await resolveSite( args.nameOrPath );
+			const result = await captureCommandOutput( () => runCreatePreviewCommand( site.path ) );
+			const output =
+				result.consoleOutput ||
+				result.progressOutput ||
+				`Preview site created for "${ site.name }".`;
+
+			if ( result.exitCode ) {
+				return errorResult( output );
+			}
+
+			return textResult( output );
+		} catch ( error ) {
+			return errorResult(
+				`Failed to create preview site: ${
+					error instanceof Error ? error.message : String( error )
+				}`
+			);
+		}
+	}
+);
+
+const listPreviewsTool = tool(
+	'preview_list',
+	'Lists WordPress.com preview sites associated with a local Studio site. Requires WordPress.com authentication.',
+	{
+		nameOrPath: z.string().describe( 'The local site name or file system path' ),
+	},
+	async ( args ) => {
+		try {
+			const site = await resolveSite( args.nameOrPath );
+			const result = await captureCommandOutput( () => runListPreviewCommand( site.path, 'json' ) );
+			const output =
+				result.consoleOutput ||
+				result.progressOutput ||
+				`No preview sites found for "${ site.name }".`;
+
+			if ( result.exitCode ) {
+				return errorResult( output );
+			}
+
+			return textResult( output );
+		} catch ( error ) {
+			return errorResult(
+				`Failed to list preview sites: ${
+					error instanceof Error ? error.message : String( error )
+				}`
+			);
+		}
+	}
+);
+
+const updatePreviewTool = tool(
+	'preview_update',
+	'Updates an existing WordPress.com preview site from a local Studio site. Requires WordPress.com authentication.',
+	{
+		nameOrPath: z.string().describe( 'The local site name or file system path' ),
+		host: z
+			.string()
+			.describe( 'The preview hostname or URL to update, for example "site.wordpress.com"' ),
+		overwrite: z
+			.boolean()
+			.optional()
+			.describe(
+				'Allow updating the preview from a different local directory. Defaults to false.'
+			),
+	},
+	async ( args ) => {
+		try {
+			const site = await resolveSite( args.nameOrPath );
+			const normalizedHost = normalizeHostname( args.host );
+			const result = await captureCommandOutput( () =>
+				runUpdatePreviewCommand( site.path, normalizedHost, args.overwrite ?? false )
+			);
+			const output =
+				result.consoleOutput ||
+				result.progressOutput ||
+				`Preview site "${ normalizedHost }" updated from "${ site.name }".`;
+
+			if ( result.exitCode ) {
+				return errorResult( output );
+			}
+
+			return textResult( output );
+		} catch ( error ) {
+			return errorResult(
+				`Failed to update preview site: ${
+					error instanceof Error ? error.message : String( error )
+				}`
+			);
+		}
+	}
+);
+
+const deletePreviewTool = tool(
+	'preview_delete',
+	'Deletes a WordPress.com preview site by hostname or URL. Requires WordPress.com authentication.',
+	{
+		host: z
+			.string()
+			.describe( 'The preview hostname or URL to delete, for example "site.wordpress.com"' ),
+	},
+	async ( args ) => {
+		try {
+			const normalizedHost = normalizeHostname( args.host );
+			const result = await captureCommandOutput( () => runDeletePreviewCommand( normalizedHost ) );
+			const output =
+				result.consoleOutput ||
+				result.progressOutput ||
+				`Preview site "${ normalizedHost }" deleted.`;
+
+			if ( result.exitCode ) {
+				return errorResult( output );
+			}
+
+			return textResult( output );
+		} catch ( error ) {
+			return errorResult(
+				`Failed to delete preview site: ${
+					error instanceof Error ? error.message : String( error )
+				}`
 			);
 		}
 	}
@@ -532,20 +718,26 @@ const takeScreenshotTool = tool(
 	}
 );
 
+export const studioToolDefinitions = [
+	createSiteTool,
+	listSitesTool,
+	getSiteInfoTool,
+	startSiteTool,
+	stopSiteTool,
+	deleteSiteTool,
+	createPreviewTool,
+	listPreviewsTool,
+	updatePreviewTool,
+	deletePreviewTool,
+	runWpCliTool,
+	validateBlocksTool,
+	takeScreenshotTool,
+];
+
 export function createStudioTools() {
 	return createSdkMcpServer( {
 		name: 'studio',
 		version: '1.0.0',
-		tools: [
-			createSiteTool,
-			listSitesTool,
-			getSiteInfoTool,
-			startSiteTool,
-			stopSiteTool,
-			deleteSiteTool,
-			runWpCliTool,
-			validateBlocksTool,
-			takeScreenshotTool,
-		],
+		tools: studioToolDefinitions,
 	} );
 }

--- a/apps/cli/ai/tools.ts
+++ b/apps/cli/ai/tools.ts
@@ -332,7 +332,7 @@ const deleteSiteTool = tool(
 
 const createPreviewTool = tool(
 	'preview_create',
-	'Creates a WordPress.com preview site from a local Studio site. Requires WordPress.com authentication.',
+	'Creates a WordPress.com preview site from a local Studio site. Requires WordPress.com authentication. This can take a few minutes, so tell the user to wait after starting it.',
 	{
 		nameOrPath: z.string().describe( 'The local site name or file system path to preview' ),
 	},
@@ -392,7 +392,7 @@ const listPreviewsTool = tool(
 
 const updatePreviewTool = tool(
 	'preview_update',
-	'Updates an existing WordPress.com preview site from a local Studio site. Requires WordPress.com authentication.',
+	'Updates an existing WordPress.com preview site from a local Studio site. Requires WordPress.com authentication. This can take a few minutes, so tell the user to wait after starting it.',
 	{
 		nameOrPath: z.string().describe( 'The local site name or file system path' ),
 		host: z

--- a/apps/cli/ai/tools.ts
+++ b/apps/cli/ai/tools.ts
@@ -20,7 +20,7 @@ import { getSiteByFolder, getSiteUrl, readAppdata, type SiteData } from 'cli/lib
 import { connectToDaemon, disconnectFromDaemon } from 'cli/lib/daemon-client';
 import { normalizeHostname } from 'cli/lib/utils';
 import { isServerRunning, sendWpCliCommand } from 'cli/lib/wordpress-server-manager';
-import { setProgressCallback, emitProgress } from 'cli/logger';
+import { getProgressCallback, setProgressCallback, emitProgress } from 'cli/logger';
 
 const SITES_ROOT = path.join( os.homedir(), 'Studio' );
 
@@ -142,6 +142,7 @@ async function captureCommandOutput( fn: () => Promise< void > ): Promise< {
 	let thrownError: unknown;
 	const originalConsoleLog = console.log;
 	const originalConsoleTable = console.table;
+	const previousCallback = getProgressCallback();
 	const previousExitCode = process.exitCode;
 
 	console.log = ( ...args: unknown[] ) => {
@@ -162,7 +163,7 @@ async function captureCommandOutput( fn: () => Promise< void > ): Promise< {
 	} finally {
 		console.log = originalConsoleLog;
 		console.table = originalConsoleTable;
-		setProgressCallback( null );
+		setProgressCallback( previousCallback );
 	}
 
 	const exitCode = process.exitCode;
@@ -177,6 +178,27 @@ async function captureCommandOutput( fn: () => Promise< void > ): Promise< {
 		progressOutput: progressMessages.join( '\n' ),
 		exitCode,
 	};
+}
+
+async function runPreviewCommand(
+	fn: () => Promise< void >,
+	fallbackMessage: string,
+	errorPrefix: string
+) {
+	try {
+		const result = await captureCommandOutput( fn );
+		const output = result.consoleOutput || result.progressOutput || fallbackMessage;
+
+		if ( result.exitCode ) {
+			return errorResult( output );
+		}
+
+		return textResult( output );
+	} catch ( error ) {
+		return errorResult(
+			`${ errorPrefix }: ${ error instanceof Error ? error.message : String( error ) }`
+		);
+	}
 }
 
 const createSiteTool = tool(
@@ -337,26 +359,14 @@ const createPreviewTool = tool(
 		nameOrPath: z.string().describe( 'The local site name or file system path to preview' ),
 	},
 	async ( args ) => {
-		try {
-			const site = await resolveSite( args.nameOrPath );
-			const result = await captureCommandOutput( () => runCreatePreviewCommand( site.path ) );
-			const output =
-				result.consoleOutput ||
-				result.progressOutput ||
-				`Preview site created for "${ site.name }".`;
-
-			if ( result.exitCode ) {
-				return errorResult( output );
-			}
-
-			return textResult( output );
-		} catch ( error ) {
-			return errorResult(
-				`Failed to create preview site: ${
-					error instanceof Error ? error.message : String( error )
-				}`
-			);
-		}
+		return runPreviewCommand(
+			async () => {
+				const site = await resolveSite( args.nameOrPath );
+				await runCreatePreviewCommand( site.path );
+			},
+			`Preview site created for "${ args.nameOrPath }".`,
+			'Failed to create preview site'
+		);
 	}
 );
 
@@ -367,26 +377,14 @@ const listPreviewsTool = tool(
 		nameOrPath: z.string().describe( 'The local site name or file system path' ),
 	},
 	async ( args ) => {
-		try {
-			const site = await resolveSite( args.nameOrPath );
-			const result = await captureCommandOutput( () => runListPreviewCommand( site.path, 'json' ) );
-			const output =
-				result.consoleOutput ||
-				result.progressOutput ||
-				`No preview sites found for "${ site.name }".`;
-
-			if ( result.exitCode ) {
-				return errorResult( output );
-			}
-
-			return textResult( output );
-		} catch ( error ) {
-			return errorResult(
-				`Failed to list preview sites: ${
-					error instanceof Error ? error.message : String( error )
-				}`
-			);
-		}
+		return runPreviewCommand(
+			async () => {
+				const site = await resolveSite( args.nameOrPath );
+				await runListPreviewCommand( site.path, 'json' );
+			},
+			`No preview sites found for "${ args.nameOrPath }".`,
+			'Failed to list preview sites'
+		);
 	}
 );
 
@@ -406,29 +404,15 @@ const updatePreviewTool = tool(
 			),
 	},
 	async ( args ) => {
-		try {
-			const site = await resolveSite( args.nameOrPath );
-			const normalizedHost = normalizeHostname( args.host );
-			const result = await captureCommandOutput( () =>
-				runUpdatePreviewCommand( site.path, normalizedHost, args.overwrite ?? false )
-			);
-			const output =
-				result.consoleOutput ||
-				result.progressOutput ||
-				`Preview site "${ normalizedHost }" updated from "${ site.name }".`;
-
-			if ( result.exitCode ) {
-				return errorResult( output );
-			}
-
-			return textResult( output );
-		} catch ( error ) {
-			return errorResult(
-				`Failed to update preview site: ${
-					error instanceof Error ? error.message : String( error )
-				}`
-			);
-		}
+		const normalizedHost = normalizeHostname( args.host );
+		return runPreviewCommand(
+			async () => {
+				const site = await resolveSite( args.nameOrPath );
+				await runUpdatePreviewCommand( site.path, normalizedHost, args.overwrite ?? false );
+			},
+			`Preview site "${ normalizedHost }" updated from "${ args.nameOrPath }".`,
+			'Failed to update preview site'
+		);
 	}
 );
 
@@ -441,26 +425,12 @@ const deletePreviewTool = tool(
 			.describe( 'The preview hostname or URL to delete, for example "site.wordpress.com"' ),
 	},
 	async ( args ) => {
-		try {
-			const normalizedHost = normalizeHostname( args.host );
-			const result = await captureCommandOutput( () => runDeletePreviewCommand( normalizedHost ) );
-			const output =
-				result.consoleOutput ||
-				result.progressOutput ||
-				`Preview site "${ normalizedHost }" deleted.`;
-
-			if ( result.exitCode ) {
-				return errorResult( output );
-			}
-
-			return textResult( output );
-		} catch ( error ) {
-			return errorResult(
-				`Failed to delete preview site: ${
-					error instanceof Error ? error.message : String( error )
-				}`
-			);
-		}
+		const normalizedHost = normalizeHostname( args.host );
+		return runPreviewCommand(
+			() => runDeletePreviewCommand( normalizedHost ),
+			`Preview site "${ normalizedHost }" deleted.`,
+			'Failed to delete preview site'
+		);
 	}
 );
 

--- a/apps/cli/ai/ui.ts
+++ b/apps/cli/ai/ui.ts
@@ -230,6 +230,10 @@ const toolDisplayNames: Record< string, string > = {
 	mcp__studio__site_start: 'Start site',
 	mcp__studio__site_stop: 'Stop site',
 	mcp__studio__site_delete: 'Delete site',
+	mcp__studio__preview_create: 'Create preview',
+	mcp__studio__preview_list: 'List previews',
+	mcp__studio__preview_update: 'Update preview',
+	mcp__studio__preview_delete: 'Delete preview',
 	mcp__studio__wp_cli: 'Run WP-CLI',
 	mcp__studio__validate_blocks: 'Validate blocks',
 	mcp__studio__take_screenshot: 'Take screenshot',
@@ -252,7 +256,12 @@ function getToolDetail( name: string, input: Record< string, unknown > ): string
 		case 'mcp__studio__site_start':
 		case 'mcp__studio__site_stop':
 		case 'mcp__studio__site_delete':
+		case 'mcp__studio__preview_create':
+		case 'mcp__studio__preview_list':
 			return typeof input.nameOrPath === 'string' ? input.nameOrPath : '';
+		case 'mcp__studio__preview_update':
+		case 'mcp__studio__preview_delete':
+			return typeof input.host === 'string' ? input.host : '';
 		case 'mcp__studio__wp_cli':
 			return typeof input.command === 'string' ? `wp ${ input.command }` : '';
 		case 'mcp__studio__validate_blocks':
@@ -1029,7 +1038,10 @@ export class AiChatUI {
 				}
 				break;
 			}
-			case 'mcp__studio__wp_cli': {
+			case 'mcp__studio__wp_cli':
+			case 'mcp__studio__preview_create':
+			case 'mcp__studio__preview_list':
+			case 'mcp__studio__preview_update': {
 				const nameOrPath = toolInput?.nameOrPath;
 				if ( typeof nameOrPath === 'string' ) {
 					if (

--- a/apps/cli/logger.ts
+++ b/apps/cli/logger.ts
@@ -9,6 +9,10 @@ export function setProgressCallback( callback: ProgressCallback | null ): void {
 	progressCallback = callback;
 }
 
+export function getProgressCallback(): ProgressCallback | null {
+	return progressCallback;
+}
+
 export function emitProgress( message: string ): void {
 	progressCallback?.( message );
 }


### PR DESCRIPTION
## Related issues

- None provided.

## How AI was used in this PR

- Used AI to draft the MCP wrappers and test updates, then reviewed the final diff and verification results manually.

## Proposed Changes

- Add `preview_create`, `preview_list`, `preview_update`, and `preview_delete` to the Studio AI MCP registry.
- Surface the new preview tools in the AI system prompt and CLI chat UI.
- Add focused tests for preview tool registration, hostname normalization, and error handling.

## Testing Instructions

- `npx eslint --fix apps/cli/ai/tools.ts apps/cli/ai/system-prompt.ts apps/cli/ai/ui.ts apps/cli/ai/tests/tools.test.ts`
- `npm run typecheck`
- `npm test -- apps/cli/ai/tests/tools.test.ts`

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
