### PR TITLE
Remove Windows binary size tracking from metrics job

### DIFF
--- a/tools/metrics/metric-config.ts
+++ b/tools/metrics/metric-config.ts
@@ -11,7 +11,6 @@ const timeFormatter = ( value: number ) => `${ value } ms`;
 
 export const METRIC_CONFIG: Record< string, MetricConfig > = {
 	appSizeMac: { label: 'App Size (Mac)', format: sizeFormatter, threshold: BYTES_PER_MB },
-	appSizeWin: { label: 'App Size (Win)', format: sizeFormatter, threshold: BYTES_PER_MB },
 };
 
 const DEFAULT_METRIC_CONFIG: MetricConfig = { label: '', format: timeFormatter, threshold: 50 };

--- a/tools/metrics/tests/app-size.test.ts
+++ b/tools/metrics/tests/app-size.test.ts
@@ -10,16 +10,11 @@ test.describe( 'App Size Metrics', () => {
 		const results: Record< string, number > = {};
 
 		const macDir = path.join( outDir, 'Studio-darwin-arm64', 'Studio.app' );
-		const winDir = path.join( outDir, 'Studio-win32-x64' );
 
 		if ( fs.existsSync( macDir ) ) {
 			results.appSizeMac = getDirSize( macDir );
-		} else if ( fs.existsSync( winDir ) ) {
-			results.appSizeWin = getDirSize( winDir );
 		} else {
-			throw new Error(
-				`Could not find packaged app directory under ${ outDir }. Run 'npm run package' first.`
-			);
+			throw new Error( `Could not find packaged app at ${ macDir }. Run 'npm run package' first.` );
 		}
 
 		await testInfo.attach( 'results', {


### PR DESCRIPTION
## Related issues

N/A

## How AI was used in this PR

Claude identified and cleaned up the dead code after the human pointed out the issue.

## Proposed Changes

- Remove `appSizeWin` metric from `metric-config.ts` — the Performance Metrics CI job runs exclusively on Mac agents, so this metric was never reported
- Simplify `app-size.test.ts` to only check for the Mac build directory, removing the unreachable Windows `else if` branch and updating the error message to be more specific

## Testing Instructions

- No functional change — this removes dead code that was never executed in CI
- The `appSizeMac` metric continues to be tracked as before

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?