### PR TITLE
Replace custom site and option pickers with pi-tui SelectList

### DIFF
--- a/apps/cli/ai/ui.ts
+++ b/apps/cli/ai/ui.ts
@@ -7,6 +7,7 @@ import {
 	Loader,
 	Container,
 	CombinedAutocompleteProvider,
+	SelectList,
 	matchesKey,
 	isKeyRelease,
 	type Component,
@@ -14,7 +15,8 @@ import {
 	type EditorTheme,
 	type EditorOptions,
 	type MarkdownTheme,
-	truncateToWidth,
+	type SelectItem,
+	type SelectListTheme,
 	visibleWidth,
 } from '@mariozechner/pi-tui';
 import chalk from 'chalk';
@@ -33,6 +35,14 @@ import type { TodoWriteInput } from '@anthropic-ai/claude-agent-sdk/sdk-tools';
 const SITE_PICKER_TAB_LOCAL = 'local' as const;
 const SITE_PICKER_TAB_REMOTE = 'remote' as const;
 type SitePickerTab = typeof SITE_PICKER_TAB_LOCAL | typeof SITE_PICKER_TAB_REMOTE;
+
+const sitePickerTheme: SelectListTheme = {
+	selectedPrefix: ( text ) => chalk.blue( text ),
+	selectedText: ( text ) => chalk.bold( text ),
+	description: ( text ) => chalk.dim( text ),
+	scrollInfo: ( text ) => chalk.dim( text ),
+	noMatch: ( text ) => chalk.dim( text ),
+};
 
 export interface SiteInfo {
 	name: string;
@@ -67,6 +77,7 @@ class PromptEditor implements Component, Focusable {
 	slashCommands: SlashCommandDef[] = [];
 	slashCommandSelectedIndex = -1;
 	statusMessage: string | null = null;
+	showBottomBar = true;
 
 	get focused(): boolean {
 		return this._focused;
@@ -172,6 +183,9 @@ class PromptEditor implements Component, Focusable {
 		} );
 
 		// Below the bottom border: show suggestions or hint bar (with optional status on the right)
+		if ( ! this.showBottomBar ) {
+			return result;
+		}
 		if ( hasAutocomplete && this.slashCommands.length > 0 ) {
 			const matching = this.getMatchingSlashCommands();
 			const maxLen = Math.max( ...matching.map( ( c ) => c.name.length ) );
@@ -522,14 +536,14 @@ export class AiChatUI {
 	}
 	private optionPickerVisible = false;
 	private optionPickerContainer: Container | null = null;
-	private optionPickerItems: { label: string; description: string }[] = [];
-	private optionPickerSelectedIndex = 0;
+	private optionPickerSelectList: SelectList | null = null;
 	private optionPickerResolve: ( ( label: string ) => void ) | null = null;
 	private sitePickerVisible = false;
 	private sitePickerContainer: Container | null = null;
 	private sitePickerItems: SiteInfo[] = [];
 	private sitePickerSiteData: SiteData[] = [];
-	private sitePickerSelectedIndex = 0;
+	private sitePickerSelectList: SelectList | null = null;
+	private sitePickerItemMap: Map< string, SiteInfo > = new Map();
 	private sitePickerTab: SitePickerTab = SITE_PICKER_TAB_LOCAL;
 	private sitePickerRemoteItems: SiteInfo[] = [];
 	private sitePickerRemoteLoading = false;
@@ -604,29 +618,9 @@ export class AiChatUI {
 				process.exit( 0 );
 			}
 			// Option picker navigation (must be checked before site picker)
-			if ( this.optionPickerVisible ) {
-				if ( matchesKey( data, 'up' ) ) {
-					this.optionPickerSelectedIndex = Math.max( 0, this.optionPickerSelectedIndex - 1 );
-					this.renderOptionPicker();
-					return { consume: true };
-				}
-				if ( matchesKey( data, 'down' ) ) {
-					this.optionPickerSelectedIndex = Math.min(
-						this.optionPickerItems.length - 1,
-						this.optionPickerSelectedIndex + 1
-					);
-					this.renderOptionPicker();
-					return { consume: true };
-				}
-				if ( matchesKey( data, 'enter' ) ) {
-					const selected = this.optionPickerItems[ this.optionPickerSelectedIndex ];
-					this.closeOptionPicker();
-					if ( selected && this.optionPickerResolve ) {
-						this.optionPickerResolve( selected.label );
-						this.optionPickerResolve = null;
-					}
-					return { consume: true };
-				}
+			if ( this.optionPickerVisible && this.optionPickerSelectList ) {
+				this.optionPickerSelectList.handleInput( data );
+				this.tui.requestRender();
 				return { consume: true };
 			}
 			// Slash command menu navigation
@@ -689,29 +683,7 @@ export class AiChatUI {
 				return { consume: true };
 			}
 			// Site picker navigation
-			if ( this.sitePickerVisible ) {
-				if ( matchesKey( data, 'up' ) ) {
-					this.sitePickerSelectedIndex = Math.max( 0, this.sitePickerSelectedIndex - 1 );
-					this.renderSitePicker();
-					return { consume: true };
-				}
-				if ( matchesKey( data, 'down' ) ) {
-					const filtered = this.getFilteredSitePickerItems();
-					this.sitePickerSelectedIndex = Math.min(
-						filtered.length - 1,
-						this.sitePickerSelectedIndex + 1
-					);
-					this.renderSitePicker();
-					return { consume: true };
-				}
-				if ( matchesKey( data, 'enter' ) ) {
-					const filtered = this.getFilteredSitePickerItems();
-					const selectedItem = filtered[ this.sitePickerSelectedIndex ];
-					if ( selectedItem ) {
-						this.selectFilteredSite( selectedItem );
-					}
-					return { consume: true };
-				}
+			if ( this.sitePickerVisible && this.sitePickerSelectList ) {
 				if ( matchesKey( data, 'tab' ) ) {
 					void this.openSelectedSite();
 					return { consume: true };
@@ -743,6 +715,9 @@ export class AiChatUI {
 					this.setSitePickerQuery( `${ this.sitePickerQuery }${ data }` );
 					return { consume: true };
 				}
+				// Forward remaining input (up/down/enter) to SelectList
+				this.sitePickerSelectList.handleInput( data );
+				this.renderSitePicker();
 				return { consume: true };
 			}
 			if ( matchesKey( data, 'escape' ) && this.interruptCallback ) {
@@ -769,11 +744,11 @@ export class AiChatUI {
 				running: await isSiteRunning( site ),
 			} ) )
 		);
-		this.sitePickerSelectedIndex = 0;
 		this.sitePickerVisible = true;
-		this.updateHints();
+		this.editor.showBottomBar = false;
 		this.sitePickerContainer = new Container();
 		this.tui.addChild( this.sitePickerContainer );
+		this.rebuildSitePickerList();
 		this.renderSitePicker();
 	}
 
@@ -801,7 +776,7 @@ export class AiChatUI {
 				url: site.url,
 			} ) );
 			this.sitePickerRemoteLoading = false;
-			this.sitePickerSelectedIndex = 0;
+			this.rebuildSitePickerList();
 			this.renderSitePicker();
 		} catch {
 			this.showSitePickerError( 'Failed to load WordPress.com sites. Please try again.' );
@@ -811,6 +786,7 @@ export class AiChatUI {
 	private showSitePickerError( message: string ): void {
 		this.resetSitePickerTab( SITE_PICKER_TAB_LOCAL );
 		this.sitePickerRemoteItems = [];
+		this.rebuildSitePickerList();
 		this.renderSitePicker();
 		this.messages.addChild( new Text( `\n${ chalk.dim( message ) }\n`, 1, 0 ) );
 		this.tui.requestRender();
@@ -818,36 +794,20 @@ export class AiChatUI {
 
 	private resetSitePickerTab( tab: SitePickerTab ): void {
 		this.sitePickerTab = tab;
-		this.sitePickerSelectedIndex = 0;
 		this.sitePickerQuery = '';
 		this.sitePickerRemoteLoading = false;
 	}
 
 	private switchToLocalSites(): void {
 		this.resetSitePickerTab( SITE_PICKER_TAB_LOCAL );
+		this.rebuildSitePickerList();
 		this.renderSitePicker();
 	}
 
 	private setSitePickerQuery( query: string ): void {
 		this.sitePickerQuery = query;
-		this.sitePickerSelectedIndex = 0;
+		this.rebuildSitePickerList();
 		this.renderSitePicker();
-	}
-
-	private getFilteredSitePickerItems(): SiteInfo[] {
-		const allItems =
-			this.sitePickerTab === SITE_PICKER_TAB_REMOTE
-				? this.sitePickerRemoteItems
-				: this.sitePickerItems;
-		if ( ! this.sitePickerQuery ) {
-			return allItems;
-		}
-		const query = this.sitePickerQuery.toLowerCase();
-		return allItems.filter(
-			( site ) =>
-				site.name.toLowerCase().includes( query ) ||
-				( site.url && site.url.toLowerCase().includes( query ) )
-		);
 	}
 
 	private selectFilteredSite( site: SiteInfo ): void {
@@ -862,54 +822,50 @@ export class AiChatUI {
 		this.closeSitePicker();
 	}
 
-	private sitePickerPageSize(): number {
-		// Reserve 4 lines for header, search, scroll info, and hints; use at least 5 visible items
-		return Math.max( 5, ( process.stdout.rows ?? 24 ) - 4 );
-	}
-
-	private formatSiteRow( site: SiteInfo, index: number ): string {
-		const selected = index === this.sitePickerSelectedIndex;
-		const prefix = selected ? `  ${ chalk.blue( '〉' ) }` : '    ';
+	private siteInfoToSelectItem( site: SiteInfo ): SelectItem {
 		if ( site.remote ) {
-			const nameColumnWidth = 30;
-			const prefixWidth = 4; // "  〉(2 cols)" or "    "
-			const gap = 2;
-			const termWidth = process.stdout.columns ?? 80;
-			const urlColumnWidth = termWidth - prefixWidth - nameColumnWidth - gap;
-			const truncatedName = truncateToWidth( site.name, nameColumnWidth, '…', true );
-			const name = selected ? chalk.bold( truncatedName ) : truncatedName;
-			const displayUrl = site.url ? site.url.replace( /^https?:\/\//, '' ) : '';
-			let url = '';
-			if ( displayUrl && urlColumnWidth > 3 ) {
-				url = `  ${ chalk.dim( truncateToWidth( displayUrl, urlColumnWidth, '…' ) ) }`;
-			}
-			return `${ prefix }${ name }${ url }`;
+			return {
+				value: site.url ?? site.name,
+				label: site.name,
+				description: site.url?.replace( /^https?:\/\//, '' ),
+			};
 		}
-		const name = selected ? chalk.bold( site.name ) : site.name;
 		const status = site.running ? `${ chalk.green( '●' ) } ` : '  ';
-		return `${ prefix }${ status }${ name }`;
+		return {
+			value: site.path,
+			label: `${ status }${ site.name }`,
+		};
 	}
 
-	// Returns the visible rows and scroll info for the current picker tab.
-	// Three modes: local list, remote loading, remote list.
-	private getSitePickerRows(): { items: string[]; scrollInfo: string } {
-		if ( ! ( this.sitePickerTab === SITE_PICKER_TAB_LOCAL ) && this.sitePickerRemoteLoading ) {
-			return { items: [ chalk.dim( '  Loading WordPress.com sites…' ) ], scrollInfo: '' };
-		}
-		const filtered = this.getFilteredSitePickerItems();
-		if ( filtered.length === 0 ) {
-			const emptyMessage =
-				this.sitePickerTab === SITE_PICKER_TAB_REMOTE && ! this.sitePickerQuery
-					? '  No WordPress.com sites found.'
-					: '  No matching sites.';
-			return { items: [ chalk.dim( emptyMessage ) ], scrollInfo: '' };
-		}
-		const { start, end } = this.getVisibleWindow( filtered.length );
-		const items = filtered
-			.slice( start, end )
-			.map( ( site, vi ) => this.formatSiteRow( site, start + vi ) );
-		const scrollInfo = this.getScrollInfo( filtered.length, start, end );
-		return { items, scrollInfo };
+	private rebuildSitePickerList(): void {
+		const allItems =
+			this.sitePickerTab === SITE_PICKER_TAB_REMOTE
+				? this.sitePickerRemoteItems
+				: this.sitePickerItems;
+		const filtered = this.sitePickerQuery
+			? allItems.filter( ( site ) => {
+					const query = this.sitePickerQuery.toLowerCase();
+					return (
+						site.name.toLowerCase().includes( query ) ||
+						( site.url && site.url.toLowerCase().includes( query ) )
+					);
+			  } )
+			: allItems;
+		const selectItems = filtered.map( ( site ) => this.siteInfoToSelectItem( site ) );
+		this.sitePickerItemMap = new Map(
+			filtered.map( ( site, i ) => [ selectItems[ i ].value, site ] )
+		);
+		const maxVisible = Math.max( 5, ( process.stdout.rows ?? 24 ) - 4 );
+		this.sitePickerSelectList = new SelectList( selectItems, maxVisible, sitePickerTheme );
+		this.sitePickerSelectList.onSelect = ( item ) => {
+			const site = this.sitePickerItemMap.get( item.value );
+			if ( site ) {
+				this.selectFilteredSite( site );
+			}
+		};
+		this.sitePickerSelectList.onCancel = () => {
+			this.closeSitePicker();
+		};
 	}
 
 	private renderSitePicker(): void {
@@ -921,58 +877,37 @@ export class AiChatUI {
 		const isLocal = this.sitePickerTab === SITE_PICKER_TAB_LOCAL;
 		const localTab = isLocal ? chalk.bold( '[Local]' ) : chalk.dim( 'Local' );
 		const remoteTab = isLocal ? chalk.dim( 'WordPress.com' ) : chalk.bold( '[WordPress.com]' );
-		const header = `  ${ localTab }  ${ remoteTab }`;
-
-		const { items, scrollInfo } = this.getSitePickerRows();
+		const pad = ' ';
+		const header = `${ pad }${ localTab }  ${ remoteTab }`;
 
 		const searchLine = this.sitePickerQuery
-			? `  ${ chalk.dim( 'Search:' ) } ${ this.sitePickerQuery }`
+			? `${ pad }${ chalk.dim( 'Search:' ) } ${ this.sitePickerQuery }`
 			: '';
 
 		const hints = isLocal
-			? '  ↑↓ navigate · → remote sites · enter select · tab open in browser · esc cancel'
-			: '  ↑↓ navigate · ← local sites · enter select · tab open in browser · esc cancel';
+			? `${ pad }↑↓ navigate · → remote sites · enter select · tab open in browser · esc cancel`
+			: `${ pad }↑↓ navigate · ← local sites · enter select · tab open in browser · esc cancel`;
 
-		const lines = [ header ];
+		const lines = [ header, '' ];
 		if ( searchLine ) {
-			lines.push( searchLine );
+			lines.push( searchLine, '' );
 		}
-		lines.push( ...items );
-		if ( scrollInfo ) {
-			lines.push( chalk.dim( `  ${ scrollInfo }` ) );
+
+		if ( ! isLocal && this.sitePickerRemoteLoading ) {
+			lines.push( chalk.dim( `${ pad }  Loading WordPress.com sites…` ) );
+		} else if ( this.sitePickerSelectList ) {
+			const termWidth = process.stdout.columns ?? 80;
+			lines.push(
+				...this.sitePickerSelectList.render( termWidth - pad.length ).map( ( line ) => pad + line )
+			);
 		}
+
 		lines.push( '' );
 		lines.push( chalk.dim( hints ) );
 
 		const text = lines.join( '\n' );
 		this.sitePickerContainer.addChild( new Text( text, 0, 0 ) );
 		this.tui.requestRender();
-	}
-
-	private getVisibleWindow( totalItems: number ): { start: number; end: number } {
-		const pageSize = this.sitePickerPageSize();
-		if ( totalItems <= pageSize ) {
-			return { start: 0, end: totalItems };
-		}
-		// Keep the selected item visible with some padding from the edges
-		let start = this.sitePickerSelectedIndex - Math.floor( pageSize / 2 );
-		start = Math.max( 0, Math.min( start, totalItems - pageSize ) );
-		return { start, end: start + pageSize };
-	}
-
-	private getScrollInfo( totalItems: number, start: number, end: number ): string {
-		const pageSize = this.sitePickerPageSize();
-		if ( totalItems <= pageSize ) {
-			return '';
-		}
-		const parts: string[] = [];
-		if ( start > 0 ) {
-			parts.push( `↑ ${ start } more` );
-		}
-		if ( end < totalItems ) {
-			parts.push( `↓ ${ totalItems - end } more` );
-		}
-		return parts.join( '  ' );
 	}
 
 	private setActiveSite( site: SiteInfo ): void {
@@ -1108,8 +1043,8 @@ export class AiChatUI {
 	}
 
 	private async openSelectedSite(): Promise< void > {
-		const filtered = this.getFilteredSitePickerItems();
-		const site = filtered[ this.sitePickerSelectedIndex ];
+		const selectedItem = this.sitePickerSelectList?.getSelectedItem();
+		const site = selectedItem ? this.sitePickerItemMap.get( selectedItem.value ) : undefined;
 		if ( ! site ) {
 			return;
 		}
@@ -1160,26 +1095,11 @@ export class AiChatUI {
 		this.sitePickerItems = [];
 		this.sitePickerSiteData = [];
 		this.sitePickerRemoteItems = [];
+		this.sitePickerSelectList = null;
+		this.sitePickerItemMap = new Map();
 		this.resetSitePickerTab( SITE_PICKER_TAB_LOCAL );
+		this.editor.showBottomBar = true;
 		this.updateHints();
-		this.tui.requestRender();
-	}
-
-	private renderOptionPicker(): void {
-		if ( ! this.optionPickerContainer ) {
-			return;
-		}
-		this.optionPickerContainer.clear();
-
-		const items = this.optionPickerItems.map( ( opt, i ) => {
-			if ( i === this.optionPickerSelectedIndex ) {
-				return `  ${ chalk.blue( '〉' ) }${ i + 1 }. ${ chalk.blue( opt.label ) }`;
-			}
-			return `    ${ i + 1 }. ${ opt.label }`;
-		} );
-
-		const text = items.join( '\n' );
-		this.optionPickerContainer.addChild( new Text( text, 0, 0 ) );
 		this.tui.requestRender();
 	}
 
@@ -1189,7 +1109,7 @@ export class AiChatUI {
 			this.optionPickerContainer = null;
 		}
 		this.optionPickerVisible = false;
-		this.optionPickerItems = [];
+		this.optionPickerSelectList = null;
 		this.tui.requestRender();
 	}
 
@@ -1312,10 +1232,6 @@ export class AiChatUI {
 	}
 
 	private updateHints(): void {
-		if ( this.sitePickerVisible ) {
-			this.editor.hints = [];
-			return;
-		}
 		const hints: string[] = [];
 		if ( ! this._inAgentTurn ) {
 			hints.push( '↓ select site' );
@@ -1717,12 +1633,28 @@ export class AiChatUI {
 			if ( q.options.length > 0 ) {
 				// Use arrow-key option picker
 				this.hideEditor();
-				this.optionPickerItems = q.options;
-				this.optionPickerSelectedIndex = 0;
+				const selectItems = q.options.map( ( opt, i ) => ( {
+					value: opt.label,
+					label: `${ i + 1 }. ${ opt.label }`,
+					description: opt.description,
+				} ) );
+				this.optionPickerSelectList = new SelectList(
+					selectItems,
+					selectItems.length,
+					sitePickerTheme
+				);
+				this.optionPickerSelectList.onSelect = ( item ) => {
+					this.closeOptionPicker();
+					if ( this.optionPickerResolve ) {
+						this.optionPickerResolve( item.value );
+						this.optionPickerResolve = null;
+					}
+				};
 				this.optionPickerVisible = true;
 				this.optionPickerContainer = new Container();
 				this.tui.addChild( this.optionPickerContainer );
-				this.renderOptionPicker();
+				this.optionPickerContainer.addChild( this.optionPickerSelectList );
+				this.tui.requestRender();
 
 				const selected = await new Promise< string >( ( resolve ) => {
 					this.optionPickerResolve = resolve;

--- a/apps/cli/ai/ui.ts
+++ b/apps/cli/ai/ui.ts
@@ -753,6 +753,11 @@ export class AiChatUI {
 	}
 
 	private async switchToRemoteSites(): Promise< void > {
+		this.resetSitePickerTab( SITE_PICKER_TAB_REMOTE );
+		this.sitePickerRemoteLoading = true;
+		this.sitePickerRemoteItems = [];
+		this.renderSitePicker();
+
 		let token: Awaited< ReturnType< typeof getAuthToken > >;
 		try {
 			token = await getAuthToken();
@@ -760,11 +765,6 @@ export class AiChatUI {
 			this.showSitePickerError( 'Not logged in. Use /login first.' );
 			return;
 		}
-
-		this.resetSitePickerTab( SITE_PICKER_TAB_REMOTE );
-		this.sitePickerRemoteLoading = true;
-		this.sitePickerRemoteItems = [];
-		this.renderSitePicker();
 
 		try {
 			const sites = await getWpComSites( token.accessToken );


### PR DESCRIPTION
## Related issues

## How AI was used in this PR

AI explored the codebase, designed a refactoring plan to adopt pi-tui's SelectList component, and implemented the changes. The plan identified that SelectList already handles list rendering, scrolling, keyboard navigation, and selection — eliminating the need for custom implementations. AI built in custom logic for features SelectList doesn't cover (tab switching, contains-based filtering, browser-open-on-tab).

## Proposed Changes

- **Site picker**: Replaced ~100 lines of custom list rendering (`formatSiteRow`, `getSitePickerRows`, `getVisibleWindow`, `getScrollInfo`, `sitePickerPageSize`) with SelectList. Maintains custom tab switching (local/WordPress.com), contains-based search filtering, and tab-to-open-browser.
- **Option picker**: Replaced ~30 lines of manual up/down/enter navigation with SelectList's built-in handling.
- **Editor bottom bar**: Added `showBottomBar` flag to hide hint/status line while site picker is visible, reducing visual clutter.
- **Input routing**: Refactored to forward navigation keys (up/down/enter) to SelectList while keeping custom keys (tab/left/right/escape/backspace/chars) for site picker features.
- **Filtering**: Inlined `getFilteredSitePickerItems()` into `rebuildSitePickerList()` to avoid indirection; SelectList is recreated on every query change with pre-filtered items (working around SelectList's prefix-only filtering).

## Testing Instructions

1. Run `npm run cli:build && node apps/cli/dist/cli/main.js ai`
2. Press down arrow to open site picker
3. Verify navigation (up/down arrows move selection, → switches to WordPress.com, ← back to local)
4. Verify search (type letters to filter, backspace to delete, esc to clear query)
5. Verify selection (enter to select, tab to open in browser)
6. Verify visual alignment: `[Local]` tab and `→` indicator should align with prompt text
7. Verify spacing: empty line between tab header and list, between search line and list

## Pre-merge Checklist

- [x] TypeScript typecheck passes
- [x] Tests pass (21 tests in cli/ai)
- [x] Linting passes
- [x] Manual testing of site picker navigation, filtering, selection, and tab switching