### PR TITLE
Replace eslint-plugin-import with eslint-plugin-import-x

### DIFF
--- a/apps/studio/src/index.ts
+++ b/apps/studio/src/index.ts
@@ -62,7 +62,7 @@ import {
 	updateAppdata,
 } from 'src/storage/user-data';
 import { getAutoUpdaterState, setupUpdates } from 'src/updates';
-// eslint-disable-next-line import/order
+// eslint-disable-next-line import-x/order
 import packageJson from '../package.json';
 
 // Helper function to get the actual URL for validation

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -71,6 +71,8 @@ export default defineConfig(
 				},
 			],
 			'import-x/no-named-as-default-member': 'off',
+			// @wp-playground/blueprints ships blueprint-schema-validator outside its package.json exports map
+			'import-x/no-unresolved': [ 'error', { ignore: [ '@wp-playground/blueprints/blueprint-schema-validator' ] } ],
 			'import-x/order': [
 				'error',
 				{

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,5 +1,5 @@
 import { defineConfig, globalIgnores } from 'eslint/config';
-import pluginImport from 'eslint-plugin-import';
+import pluginImport from 'eslint-plugin-import-x';
 import pluginStudio from 'eslint-plugin-studio';
 import pluginPrettier from 'eslint-plugin-prettier/recommended';
 import globals from 'globals';
@@ -42,7 +42,7 @@ export default defineConfig(
 			},
 		},
 		settings: {
-			'import/resolver': {
+			'import-x/resolver': {
 				typescript: {
 					alwaysTryTypes: true,
 					project: [
@@ -70,8 +70,8 @@ export default defineConfig(
 					varsIgnorePattern: '^_',
 				},
 			],
-			'import/no-named-as-default-member': 'off',
-			'import/order': [
+			'import-x/no-named-as-default-member': 'off',
+			'import-x/order': [
 				'error',
 				{
 					'newlines-between': 'never',

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
 				"eslint": "^9.39.2",
 				"eslint-config-prettier": "^9.1.2",
 				"eslint-import-resolver-typescript": "^4.4.4",
-				"eslint-plugin-import": "^2.32.0",
+				"eslint-plugin-import-x": "4.15.2",
 				"eslint-plugin-jest-dom": "^5.5.0",
 				"eslint-plugin-prettier": "^5.5.5",
 				"eslint-plugin-react-hooks": "^7.0.1",
@@ -8390,7 +8390,9 @@
 		"node_modules/@rtsao/scc": {
 			"version": "1.1.0",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@sentry-internal/browser-utils": {
 			"version": "10.42.0",
@@ -9733,7 +9735,9 @@
 		"node_modules/@types/json5": {
 			"version": "0.0.29",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@types/jsonfile": {
 			"version": "6.1.4",
@@ -12358,6 +12362,8 @@
 			"version": "1.0.2",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"call-bound": "^1.0.3",
 				"is-array-buffer": "^3.0.5"
@@ -12377,6 +12383,8 @@
 			"version": "3.1.9",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"call-bind": "^1.0.8",
 				"call-bound": "^1.0.4",
@@ -12398,6 +12406,8 @@
 			"version": "1.2.6",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"call-bind": "^1.0.8",
 				"call-bound": "^1.0.4",
@@ -12418,6 +12428,8 @@
 			"version": "1.3.3",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"call-bind": "^1.0.8",
 				"define-properties": "^1.2.1",
@@ -12435,6 +12447,8 @@
 			"version": "1.3.3",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"call-bind": "^1.0.8",
 				"define-properties": "^1.2.1",
@@ -12452,6 +12466,8 @@
 			"version": "1.0.4",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"array-buffer-byte-length": "^1.0.1",
 				"call-bind": "^1.0.8",
@@ -13652,6 +13668,16 @@
 				"node": ">=16"
 			}
 		},
+		"node_modules/comment-parser": {
+			"version": "1.4.5",
+			"resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.5.tgz",
+			"integrity": "sha512-aRDkn3uyIlCFfk5NUA+VdwMmMsh8JGhc4hapfV4yxymHGQ3BVskMQfoXGpCo5IoBuQ9tS5iiVKhCpTcB4pW4qw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 12.0.0"
+			}
+		},
 		"node_modules/compare-perf": {
 			"resolved": "tools/compare-perf",
 			"link": true
@@ -14000,6 +14026,8 @@
 			"version": "1.0.2",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"call-bound": "^1.0.3",
 				"es-errors": "^1.3.0",
@@ -14016,6 +14044,8 @@
 			"version": "1.0.2",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"call-bound": "^1.0.3",
 				"es-errors": "^1.3.0",
@@ -14032,6 +14062,8 @@
 			"version": "1.0.1",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"call-bound": "^1.0.2",
 				"es-errors": "^1.3.0",
@@ -14169,6 +14201,7 @@
 			"version": "1.2.1",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
 			"dependencies": {
 				"define-data-property": "^1.0.1",
 				"has-property-descriptors": "^1.0.0",
@@ -15023,6 +15056,8 @@
 			"version": "1.24.0",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"array-buffer-byte-length": "^1.0.2",
 				"arraybuffer.prototype.slice": "^1.0.4",
@@ -15134,6 +15169,8 @@
 			"version": "1.1.0",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"hasown": "^2.0.2"
 			},
@@ -15145,6 +15182,8 @@
 			"version": "1.3.0",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"is-callable": "^1.2.7",
 				"is-date-object": "^1.0.5",
@@ -15695,6 +15734,8 @@
 			"version": "0.3.9",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"debug": "^3.2.7",
 				"is-core-module": "^2.13.0",
@@ -15705,6 +15746,8 @@
 			"version": "3.2.7",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"ms": "^2.1.1"
 			}
@@ -15746,6 +15789,8 @@
 			"version": "2.12.1",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"debug": "^3.2.7"
 			},
@@ -15762,6 +15807,8 @@
 			"version": "3.2.7",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"ms": "^2.1.1"
 			}
@@ -15770,6 +15817,8 @@
 			"version": "2.32.0",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@rtsao/scc": "^1.1.0",
 				"array-includes": "^3.1.9",
@@ -15798,10 +15847,98 @@
 				"eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9"
 			}
 		},
+		"node_modules/eslint-plugin-import-x": {
+			"version": "4.15.2",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-import-x/-/eslint-plugin-import-x-4.15.2.tgz",
+			"integrity": "sha512-J5gx7sN6DTm0LRT//eP3rVVQ2Yi4hrX0B+DbWxa5er8PZ6JjLo9GUBwogIFvEDdwJaSqZplpQT+haK/cXhb7VQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@typescript-eslint/types": "^8.34.0",
+				"comment-parser": "^1.4.1",
+				"debug": "^4.4.1",
+				"eslint-import-context": "^0.1.8",
+				"is-glob": "^4.0.3",
+				"minimatch": "^9.0.3 || ^10.0.1",
+				"semver": "^7.7.2",
+				"stable-hash-x": "^0.1.1",
+				"unrs-resolver": "^1.9.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint-plugin-import-x"
+			},
+			"peerDependencies": {
+				"@typescript-eslint/utils": "^8.0.0",
+				"eslint": "^8.57.0 || ^9.0.0",
+				"eslint-import-resolver-node": "*"
+			},
+			"peerDependenciesMeta": {
+				"@typescript-eslint/utils": {
+					"optional": true
+				},
+				"eslint-import-resolver-node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/eslint-plugin-import-x/node_modules/balanced-match": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/eslint-plugin-import-x/node_modules/brace-expansion": {
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
+			"integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^4.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/eslint-plugin-import-x/node_modules/minimatch": {
+			"version": "10.2.4",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+			"integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"brace-expansion": "^5.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/eslint-plugin-import-x/node_modules/stable-hash-x": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/stable-hash-x/-/stable-hash-x-0.1.1.tgz",
+			"integrity": "sha512-l0x1D6vhnsNUGPFVDx45eif0y6eedVC8nm5uACTrVFJFtl2mLRW17aWtVyxFCpn5t94VUPkjU8vSLwIuwwqtJQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
 		"node_modules/eslint-plugin-import/node_modules/debug": {
 			"version": "3.2.7",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"ms": "^2.1.1"
 			}
@@ -15810,6 +15947,8 @@
 			"version": "2.1.0",
 			"dev": true,
 			"license": "Apache-2.0",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"esutils": "^2.0.2"
 			},
@@ -15821,6 +15960,8 @@
 			"version": "6.3.1",
 			"dev": true,
 			"license": "ISC",
+			"optional": true,
+			"peer": true,
 			"bin": {
 				"semver": "bin/semver.js"
 			}
@@ -16949,6 +17090,8 @@
 			"version": "1.1.8",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"call-bind": "^1.0.8",
 				"call-bound": "^1.0.3",
@@ -16968,6 +17111,8 @@
 			"version": "1.2.3",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
@@ -17133,6 +17278,8 @@
 			"version": "1.1.0",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"call-bound": "^1.0.3",
 				"es-errors": "^1.3.0",
@@ -17250,6 +17397,7 @@
 			"version": "1.0.4",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
 			"dependencies": {
 				"define-properties": "^1.2.1",
 				"gopd": "^1.0.1"
@@ -17357,6 +17505,8 @@
 			"version": "1.0.2",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
@@ -17382,6 +17532,8 @@
 			"version": "1.2.0",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"dunder-proto": "^1.0.0"
 			},
@@ -18060,6 +18212,8 @@
 			"version": "1.1.0",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"es-errors": "^1.3.0",
 				"hasown": "^2.0.2",
@@ -18128,6 +18282,8 @@
 			"version": "3.0.5",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"call-bind": "^1.0.8",
 				"call-bound": "^1.0.3",
@@ -18148,6 +18304,8 @@
 			"version": "2.1.0",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"call-bound": "^1.0.3",
 				"get-proto": "^1.0.1",
@@ -18165,6 +18323,8 @@
 			"version": "1.1.0",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"has-bigints": "^1.0.2"
 			},
@@ -18190,6 +18350,8 @@
 			"version": "1.2.1",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"call-bound": "^1.0.2",
 				"has-tostringtag": "^1.0.2"
@@ -18236,6 +18398,8 @@
 			"version": "1.0.2",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"call-bound": "^1.0.2",
 				"get-intrinsic": "^1.2.6",
@@ -18252,6 +18416,8 @@
 			"version": "1.1.0",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"call-bound": "^1.0.2",
 				"has-tostringtag": "^1.0.2"
@@ -18296,6 +18462,8 @@
 			"version": "1.1.1",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"call-bound": "^1.0.3"
 			},
@@ -18317,6 +18485,8 @@
 			"version": "1.1.0",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"call-bound": "^1.0.3",
 				"get-proto": "^1.0.0",
@@ -18400,6 +18570,8 @@
 			"version": "2.0.3",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">= 0.4"
 			},
@@ -18428,6 +18600,8 @@
 			"version": "2.0.3",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">= 0.4"
 			},
@@ -18446,6 +18620,8 @@
 			"version": "1.1.1",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"call-bound": "^1.0.3",
 				"has-tostringtag": "^1.0.2"
@@ -18496,6 +18672,8 @@
 			"version": "1.2.1",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"call-bound": "^1.0.2",
 				"gopd": "^1.2.0",
@@ -18513,6 +18691,8 @@
 			"version": "2.0.3",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">= 0.4"
 			},
@@ -18524,6 +18704,8 @@
 			"version": "1.0.4",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"call-bound": "^1.0.3"
 			},
@@ -18546,6 +18728,8 @@
 			"version": "1.1.1",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"call-bound": "^1.0.3",
 				"has-tostringtag": "^1.0.2"
@@ -18561,6 +18745,8 @@
 			"version": "1.1.1",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"call-bound": "^1.0.2",
 				"has-symbols": "^1.1.0",
@@ -18601,6 +18787,8 @@
 			"version": "2.0.2",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">= 0.4"
 			},
@@ -18612,6 +18800,8 @@
 			"version": "1.1.1",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"call-bound": "^1.0.3"
 			},
@@ -18626,6 +18816,8 @@
 			"version": "2.0.4",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"call-bound": "^1.0.3",
 				"get-intrinsic": "^1.2.6"
@@ -21050,6 +21242,8 @@
 			"version": "4.1.7",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"call-bind": "^1.0.8",
 				"call-bound": "^1.0.3",
@@ -21069,6 +21263,8 @@
 			"version": "2.0.8",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"call-bind": "^1.0.7",
 				"define-properties": "^1.2.1",
@@ -21086,6 +21282,8 @@
 			"version": "1.0.3",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"call-bind": "^1.0.7",
 				"define-properties": "^1.2.1",
@@ -21099,6 +21297,8 @@
 			"version": "1.2.1",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"call-bind": "^1.0.8",
 				"call-bound": "^1.0.3",
@@ -21340,6 +21540,8 @@
 			"version": "1.0.1",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"get-intrinsic": "^1.2.6",
 				"object-keys": "^1.1.1",
@@ -22785,6 +22987,8 @@
 			"version": "1.0.10",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"call-bind": "^1.0.8",
 				"define-properties": "^1.2.1",
@@ -22822,6 +23026,8 @@
 			"version": "1.5.4",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"call-bind": "^1.0.8",
 				"define-properties": "^1.2.1",
@@ -23408,6 +23614,8 @@
 			"version": "1.1.3",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"call-bind": "^1.0.8",
 				"call-bound": "^1.0.2",
@@ -23430,6 +23638,8 @@
 			"version": "1.0.0",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"es-errors": "^1.3.0",
 				"isarray": "^2.0.5"
@@ -23445,6 +23655,8 @@
 			"version": "1.1.0",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"call-bound": "^1.0.2",
 				"es-errors": "^1.3.0",
@@ -23675,6 +23887,8 @@
 			"version": "2.0.2",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"define-data-property": "^1.1.4",
 				"es-errors": "^1.3.0",
@@ -23689,6 +23903,8 @@
 			"version": "1.0.0",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"dunder-proto": "^1.0.1",
 				"es-errors": "^1.3.0",
@@ -24127,6 +24343,8 @@
 			"version": "1.1.0",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"es-errors": "^1.3.0",
 				"internal-slot": "^1.1.0"
@@ -24273,6 +24491,8 @@
 			"version": "1.2.10",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"call-bind": "^1.0.8",
 				"call-bound": "^1.0.2",
@@ -24293,6 +24513,8 @@
 			"version": "1.0.9",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"call-bind": "^1.0.8",
 				"call-bound": "^1.0.2",
@@ -24310,6 +24532,8 @@
 			"version": "1.0.8",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"call-bind": "^1.0.7",
 				"define-properties": "^1.2.1",
@@ -25251,6 +25475,8 @@
 			"version": "3.15.0",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@types/json5": "^0.0.29",
 				"json5": "^1.0.2",
@@ -25262,6 +25488,8 @@
 			"version": "1.0.2",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"minimist": "^1.2.0"
 			},
@@ -25273,6 +25501,8 @@
 			"version": "3.0.0",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=4"
 			}
@@ -25357,6 +25587,8 @@
 			"version": "1.0.3",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"call-bind": "^1.0.8",
 				"for-each": "^0.3.3",
@@ -25375,6 +25607,8 @@
 			"version": "1.0.4",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"available-typed-arrays": "^1.0.7",
 				"call-bind": "^1.0.8",
@@ -25395,6 +25629,8 @@
 			"version": "1.0.7",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"call-bind": "^1.0.7",
 				"for-each": "^0.3.3",
@@ -25447,6 +25683,8 @@
 			"version": "1.1.0",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"call-bound": "^1.0.3",
 				"has-bigints": "^1.0.2",
@@ -26863,6 +27101,8 @@
 			"version": "1.1.1",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"is-bigint": "^1.1.0",
 				"is-boolean-object": "^1.2.1",
@@ -26881,6 +27121,8 @@
 			"version": "1.2.1",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"call-bound": "^1.0.2",
 				"function.prototype.name": "^1.1.6",
@@ -26907,6 +27149,8 @@
 			"version": "1.0.2",
 			"dev": true,
 			"license": "MIT",
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"is-map": "^2.0.3",
 				"is-set": "^2.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
 				"eslint": "^9.39.2",
 				"eslint-config-prettier": "^9.1.2",
 				"eslint-import-resolver-typescript": "^4.4.4",
-				"eslint-plugin-import-x": "4.15.2",
+				"eslint-plugin-import-x": "^4.15.2",
 				"eslint-plugin-jest-dom": "^5.5.0",
 				"eslint-plugin-prettier": "^5.5.5",
 				"eslint-plugin-react-hooks": "^7.0.1",
@@ -8387,13 +8387,6 @@
 				"win32"
 			]
 		},
-		"node_modules/@rtsao/scc": {
-			"version": "1.1.0",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true
-		},
 		"node_modules/@sentry-internal/browser-utils": {
 			"version": "10.42.0",
 			"resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-10.42.0.tgz",
@@ -9191,7 +9184,6 @@
 			"os": [
 				"darwin"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -9208,7 +9200,6 @@
 			"os": [
 				"darwin"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -9225,7 +9216,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -9242,7 +9232,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -9259,7 +9248,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -9276,7 +9264,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -9293,7 +9280,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -9310,7 +9296,6 @@
 			"os": [
 				"win32"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -9327,7 +9312,6 @@
 			"os": [
 				"win32"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -9344,7 +9328,6 @@
 			"os": [
 				"win32"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -9732,13 +9715,6 @@
 			"version": "7.0.15",
 			"license": "MIT"
 		},
-		"node_modules/@types/json5": {
-			"version": "0.0.29",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true
-		},
 		"node_modules/@types/jsonfile": {
 			"version": "6.1.4",
 			"dev": true,
@@ -9952,15 +9928,17 @@
 			}
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "8.53.1",
+			"version": "8.57.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.57.1.tgz",
+			"integrity": "sha512-Gn3aqnvNl4NGc6x3/Bqk1AOn0thyTU9bqDRhiRnUWezgvr2OnhYCWCgC8zXXRVqBsIL1pSDt7T9nJUe0oM0kDQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/regexpp": "^4.12.2",
-				"@typescript-eslint/scope-manager": "8.53.1",
-				"@typescript-eslint/type-utils": "8.53.1",
-				"@typescript-eslint/utils": "8.53.1",
-				"@typescript-eslint/visitor-keys": "8.53.1",
+				"@typescript-eslint/scope-manager": "8.57.1",
+				"@typescript-eslint/type-utils": "8.57.1",
+				"@typescript-eslint/utils": "8.57.1",
+				"@typescript-eslint/visitor-keys": "8.57.1",
 				"ignore": "^7.0.5",
 				"natural-compare": "^1.4.0",
 				"ts-api-utils": "^2.4.0"
@@ -9973,13 +9951,15 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"@typescript-eslint/parser": "^8.53.1",
-				"eslint": "^8.57.0 || ^9.0.0",
+				"@typescript-eslint/parser": "^8.57.1",
+				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
 				"typescript": ">=4.8.4 <6.0.0"
 			}
 		},
 		"node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
 			"version": "7.0.5",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+			"integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -9987,14 +9967,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "8.53.1",
+			"version": "8.57.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.57.1.tgz",
+			"integrity": "sha512-k4eNDan0EIMTT/dUKc/g+rsJ6wcHYhNPdY19VoX/EOtaAG8DLtKCykhrUnuHPYvinn5jhAPgD2Qw9hXBwrahsw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "8.53.1",
-				"@typescript-eslint/types": "8.53.1",
-				"@typescript-eslint/typescript-estree": "8.53.1",
-				"@typescript-eslint/visitor-keys": "8.53.1",
+				"@typescript-eslint/scope-manager": "8.57.1",
+				"@typescript-eslint/types": "8.57.1",
+				"@typescript-eslint/typescript-estree": "8.57.1",
+				"@typescript-eslint/visitor-keys": "8.57.1",
 				"debug": "^4.4.3"
 			},
 			"engines": {
@@ -10005,17 +9987,19 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"eslint": "^8.57.0 || ^9.0.0",
+				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
 				"typescript": ">=4.8.4 <6.0.0"
 			}
 		},
 		"node_modules/@typescript-eslint/project-service": {
-			"version": "8.53.1",
+			"version": "8.57.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.57.1.tgz",
+			"integrity": "sha512-vx1F37BRO1OftsYlmG9xay1TqnjNVlqALymwWVuYTdo18XuKxtBpCj1QlzNIEHlvlB27osvXFWptYiEWsVdYsg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/tsconfig-utils": "^8.53.1",
-				"@typescript-eslint/types": "^8.53.1",
+				"@typescript-eslint/tsconfig-utils": "^8.57.1",
+				"@typescript-eslint/types": "^8.57.1",
 				"debug": "^4.4.3"
 			},
 			"engines": {
@@ -10030,12 +10014,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "8.53.1",
+			"version": "8.57.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.57.1.tgz",
+			"integrity": "sha512-hs/QcpCwlwT2L5S+3fT6gp0PabyGk4Q0Rv2doJXA0435/OpnSR3VRgvrp8Xdoc3UAYSg9cyUjTeFXZEPg/3OKg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.53.1",
-				"@typescript-eslint/visitor-keys": "8.53.1"
+				"@typescript-eslint/types": "8.57.1",
+				"@typescript-eslint/visitor-keys": "8.57.1"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -10046,7 +10032,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/tsconfig-utils": {
-			"version": "8.53.1",
+			"version": "8.57.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.57.1.tgz",
+			"integrity": "sha512-0lgOZB8cl19fHO4eI46YUx2EceQqhgkPSuCGLlGi79L2jwYY1cxeYc1Nae8Aw1xjgW3PKVDLlr3YJ6Bxx8HkWg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -10061,13 +10049,15 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "8.53.1",
+			"version": "8.57.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.57.1.tgz",
+			"integrity": "sha512-+Bwwm0ScukFdyoJsh2u6pp4S9ktegF98pYUU0hkphOOqdMB+1sNQhIz8y5E9+4pOioZijrkfNO/HUJVAFFfPKA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.53.1",
-				"@typescript-eslint/typescript-estree": "8.53.1",
-				"@typescript-eslint/utils": "8.53.1",
+				"@typescript-eslint/types": "8.57.1",
+				"@typescript-eslint/typescript-estree": "8.57.1",
+				"@typescript-eslint/utils": "8.57.1",
 				"debug": "^4.4.3",
 				"ts-api-utils": "^2.4.0"
 			},
@@ -10079,12 +10069,14 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"eslint": "^8.57.0 || ^9.0.0",
+				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
 				"typescript": ">=4.8.4 <6.0.0"
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "8.53.1",
+			"version": "8.57.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.57.1.tgz",
+			"integrity": "sha512-S29BOBPJSFUiblEl6RzPPjJt6w25A6XsBqRVDt53tA/tlL8q7ceQNZHTjPeONt/3S7KRI4quk+yP9jK2WjBiPQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -10096,16 +10088,18 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "8.53.1",
+			"version": "8.57.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.57.1.tgz",
+			"integrity": "sha512-ybe2hS9G6pXpqGtPli9Gx9quNV0TWLOmh58ADlmZe9DguLq0tiAKVjirSbtM1szG6+QH6rVXyU6GTLQbWnMY+g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/project-service": "8.53.1",
-				"@typescript-eslint/tsconfig-utils": "8.53.1",
-				"@typescript-eslint/types": "8.53.1",
-				"@typescript-eslint/visitor-keys": "8.53.1",
+				"@typescript-eslint/project-service": "8.57.1",
+				"@typescript-eslint/tsconfig-utils": "8.57.1",
+				"@typescript-eslint/types": "8.57.1",
+				"@typescript-eslint/visitor-keys": "8.57.1",
 				"debug": "^4.4.3",
-				"minimatch": "^9.0.5",
+				"minimatch": "^10.2.2",
 				"semver": "^7.7.3",
 				"tinyglobby": "^0.2.15",
 				"ts-api-utils": "^2.4.0"
@@ -10121,37 +10115,56 @@
 				"typescript": ">=4.8.4 <6.0.0"
 			}
 		},
+		"node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
 		"node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-			"version": "2.0.2",
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
+			"integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"balanced-match": "^1.0.0"
+				"balanced-match": "^4.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-			"version": "9.0.5",
+			"version": "10.2.4",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+			"integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
 			"dev": true,
-			"license": "ISC",
+			"license": "BlueOak-1.0.0",
 			"dependencies": {
-				"brace-expansion": "^2.0.1"
+				"brace-expansion": "^5.0.2"
 			},
 			"engines": {
-				"node": ">=16 || 14 >=14.17"
+				"node": "18 || 20 || >=22"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "8.53.1",
+			"version": "8.57.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.57.1.tgz",
+			"integrity": "sha512-XUNSJ/lEVFttPMMoDVA2r2bwrl8/oPx8cURtczkSEswY5T3AeLmCy+EKWQNdL4u0MmAHOjcWrqJp2cdvgjn8dQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.9.1",
-				"@typescript-eslint/scope-manager": "8.53.1",
-				"@typescript-eslint/types": "8.53.1",
-				"@typescript-eslint/typescript-estree": "8.53.1"
+				"@typescript-eslint/scope-manager": "8.57.1",
+				"@typescript-eslint/types": "8.57.1",
+				"@typescript-eslint/typescript-estree": "8.57.1"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -10161,17 +10174,19 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"eslint": "^8.57.0 || ^9.0.0",
+				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
 				"typescript": ">=4.8.4 <6.0.0"
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "8.53.1",
+			"version": "8.57.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.57.1.tgz",
+			"integrity": "sha512-YWnmJkXbofiz9KbnbbwuA2rpGkFPLbAIetcCNO6mJ8gdhdZ/v7WDXsoGFAJuM6ikUFKTlSQnjWnVO4ux+UzS6A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.53.1",
-				"eslint-visitor-keys": "^4.2.1"
+				"@typescript-eslint/types": "8.57.1",
+				"eslint-visitor-keys": "^5.0.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -10182,11 +10197,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-			"version": "4.2.1",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+			"integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+				"node": "^20.19.0 || ^22.13.0 || >=24"
 			},
 			"funding": {
 				"url": "https://opencollective.com/eslint"
@@ -12358,131 +12375,9 @@
 				"dequal": "^2.0.3"
 			}
 		},
-		"node_modules/array-buffer-byte-length": {
-			"version": "1.0.2",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"call-bound": "^1.0.3",
-				"is-array-buffer": "^3.0.5"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/array-flatten": {
 			"version": "1.1.1",
 			"license": "MIT"
-		},
-		"node_modules/array-includes": {
-			"version": "3.1.9",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"call-bind": "^1.0.8",
-				"call-bound": "^1.0.4",
-				"define-properties": "^1.2.1",
-				"es-abstract": "^1.24.0",
-				"es-object-atoms": "^1.1.1",
-				"get-intrinsic": "^1.3.0",
-				"is-string": "^1.1.1",
-				"math-intrinsics": "^1.1.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/array.prototype.findlastindex": {
-			"version": "1.2.6",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"call-bind": "^1.0.8",
-				"call-bound": "^1.0.4",
-				"define-properties": "^1.2.1",
-				"es-abstract": "^1.23.9",
-				"es-errors": "^1.3.0",
-				"es-object-atoms": "^1.1.1",
-				"es-shim-unscopables": "^1.1.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/array.prototype.flat": {
-			"version": "1.3.3",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"call-bind": "^1.0.8",
-				"define-properties": "^1.2.1",
-				"es-abstract": "^1.23.5",
-				"es-shim-unscopables": "^1.0.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/array.prototype.flatmap": {
-			"version": "1.3.3",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"call-bind": "^1.0.8",
-				"define-properties": "^1.2.1",
-				"es-abstract": "^1.23.5",
-				"es-shim-unscopables": "^1.0.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/arraybuffer.prototype.slice": {
-			"version": "1.0.4",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"array-buffer-byte-length": "^1.0.1",
-				"call-bind": "^1.0.8",
-				"define-properties": "^1.2.1",
-				"es-abstract": "^1.23.5",
-				"es-errors": "^1.3.0",
-				"get-intrinsic": "^1.2.6",
-				"is-array-buffer": "^3.0.4"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
 		},
 		"node_modules/asap": {
 			"version": "2.0.6",
@@ -14022,60 +13917,6 @@
 				"node": ">=18"
 			}
 		},
-		"node_modules/data-view-buffer": {
-			"version": "1.0.2",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"call-bound": "^1.0.3",
-				"es-errors": "^1.3.0",
-				"is-data-view": "^1.0.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/data-view-byte-length": {
-			"version": "1.0.2",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"call-bound": "^1.0.3",
-				"es-errors": "^1.3.0",
-				"is-data-view": "^1.0.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/inspect-js"
-			}
-		},
-		"node_modules/data-view-byte-offset": {
-			"version": "1.0.1",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"call-bound": "^1.0.2",
-				"es-errors": "^1.3.0",
-				"is-data-view": "^1.0.1"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/date-fns": {
 			"version": "3.6.0",
 			"license": "MIT",
@@ -15052,75 +14893,6 @@
 				"is-arrayish": "^0.2.1"
 			}
 		},
-		"node_modules/es-abstract": {
-			"version": "1.24.0",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"array-buffer-byte-length": "^1.0.2",
-				"arraybuffer.prototype.slice": "^1.0.4",
-				"available-typed-arrays": "^1.0.7",
-				"call-bind": "^1.0.8",
-				"call-bound": "^1.0.4",
-				"data-view-buffer": "^1.0.2",
-				"data-view-byte-length": "^1.0.2",
-				"data-view-byte-offset": "^1.0.1",
-				"es-define-property": "^1.0.1",
-				"es-errors": "^1.3.0",
-				"es-object-atoms": "^1.1.1",
-				"es-set-tostringtag": "^2.1.0",
-				"es-to-primitive": "^1.3.0",
-				"function.prototype.name": "^1.1.8",
-				"get-intrinsic": "^1.3.0",
-				"get-proto": "^1.0.1",
-				"get-symbol-description": "^1.1.0",
-				"globalthis": "^1.0.4",
-				"gopd": "^1.2.0",
-				"has-property-descriptors": "^1.0.2",
-				"has-proto": "^1.2.0",
-				"has-symbols": "^1.1.0",
-				"hasown": "^2.0.2",
-				"internal-slot": "^1.1.0",
-				"is-array-buffer": "^3.0.5",
-				"is-callable": "^1.2.7",
-				"is-data-view": "^1.0.2",
-				"is-negative-zero": "^2.0.3",
-				"is-regex": "^1.2.1",
-				"is-set": "^2.0.3",
-				"is-shared-array-buffer": "^1.0.4",
-				"is-string": "^1.1.1",
-				"is-typed-array": "^1.1.15",
-				"is-weakref": "^1.1.1",
-				"math-intrinsics": "^1.1.0",
-				"object-inspect": "^1.13.4",
-				"object-keys": "^1.1.1",
-				"object.assign": "^4.1.7",
-				"own-keys": "^1.0.1",
-				"regexp.prototype.flags": "^1.5.4",
-				"safe-array-concat": "^1.1.3",
-				"safe-push-apply": "^1.0.0",
-				"safe-regex-test": "^1.1.0",
-				"set-proto": "^1.0.0",
-				"stop-iteration-iterator": "^1.1.0",
-				"string.prototype.trim": "^1.2.10",
-				"string.prototype.trimend": "^1.0.9",
-				"string.prototype.trimstart": "^1.0.8",
-				"typed-array-buffer": "^1.0.3",
-				"typed-array-byte-length": "^1.0.3",
-				"typed-array-byte-offset": "^1.0.4",
-				"typed-array-length": "^1.0.7",
-				"unbox-primitive": "^1.1.0",
-				"which-typed-array": "^1.1.19"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/es-define-property": {
 			"version": "1.0.1",
 			"license": "MIT",
@@ -15163,37 +14935,6 @@
 			},
 			"engines": {
 				"node": ">= 0.4"
-			}
-		},
-		"node_modules/es-shim-unscopables": {
-			"version": "1.1.0",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"hasown": "^2.0.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
-		"node_modules/es-to-primitive": {
-			"version": "1.3.0",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"is-callable": "^1.2.7",
-				"is-date-object": "^1.0.5",
-				"is-symbol": "^1.0.4"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/es6-error": {
@@ -15730,28 +15471,6 @@
 				}
 			}
 		},
-		"node_modules/eslint-import-resolver-node": {
-			"version": "0.3.9",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"debug": "^3.2.7",
-				"is-core-module": "^2.13.0",
-				"resolve": "^1.22.4"
-			}
-		},
-		"node_modules/eslint-import-resolver-node/node_modules/debug": {
-			"version": "3.2.7",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"ms": "^2.1.1"
-			}
-		},
 		"node_modules/eslint-import-resolver-typescript": {
 			"version": "4.4.4",
 			"dev": true,
@@ -15783,68 +15502,6 @@
 				"eslint-plugin-import-x": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/eslint-module-utils": {
-			"version": "2.12.1",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"debug": "^3.2.7"
-			},
-			"engines": {
-				"node": ">=4"
-			},
-			"peerDependenciesMeta": {
-				"eslint": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/eslint-module-utils/node_modules/debug": {
-			"version": "3.2.7",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"ms": "^2.1.1"
-			}
-		},
-		"node_modules/eslint-plugin-import": {
-			"version": "2.32.0",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@rtsao/scc": "^1.1.0",
-				"array-includes": "^3.1.9",
-				"array.prototype.findlastindex": "^1.2.6",
-				"array.prototype.flat": "^1.3.3",
-				"array.prototype.flatmap": "^1.3.3",
-				"debug": "^3.2.7",
-				"doctrine": "^2.1.0",
-				"eslint-import-resolver-node": "^0.3.9",
-				"eslint-module-utils": "^2.12.1",
-				"hasown": "^2.0.2",
-				"is-core-module": "^2.16.1",
-				"is-glob": "^4.0.3",
-				"minimatch": "^3.1.2",
-				"object.fromentries": "^2.0.8",
-				"object.groupby": "^1.0.3",
-				"object.values": "^1.2.1",
-				"semver": "^6.3.1",
-				"string.prototype.trimend": "^1.0.9",
-				"tsconfig-paths": "^3.15.0"
-			},
-			"engines": {
-				"node": ">=4"
-			},
-			"peerDependencies": {
-				"eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9"
 			}
 		},
 		"node_modules/eslint-plugin-import-x": {
@@ -15931,39 +15588,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=12.0.0"
-			}
-		},
-		"node_modules/eslint-plugin-import/node_modules/debug": {
-			"version": "3.2.7",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"ms": "^2.1.1"
-			}
-		},
-		"node_modules/eslint-plugin-import/node_modules/doctrine": {
-			"version": "2.1.0",
-			"dev": true,
-			"license": "Apache-2.0",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"esutils": "^2.0.2"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/eslint-plugin-import/node_modules/semver": {
-			"version": "6.3.1",
-			"dev": true,
-			"license": "ISC",
-			"optional": true,
-			"peer": true,
-			"bin": {
-				"semver": "bin/semver.js"
 			}
 		},
 		"node_modules/eslint-plugin-jest-dom": {
@@ -17086,37 +16710,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/function.prototype.name": {
-			"version": "1.1.8",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"call-bind": "^1.0.8",
-				"call-bound": "^1.0.3",
-				"define-properties": "^1.2.1",
-				"functions-have-names": "^1.2.3",
-				"hasown": "^2.0.2",
-				"is-callable": "^1.2.7"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/functions-have-names": {
-			"version": "1.2.3",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/galactus": {
 			"version": "1.0.0",
 			"dev": true,
@@ -17272,24 +16865,6 @@
 			},
 			"engines": {
 				"node": ">=6"
-			}
-		},
-		"node_modules/get-symbol-description": {
-			"version": "1.1.0",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"call-bound": "^1.0.3",
-				"es-errors": "^1.3.0",
-				"get-intrinsic": "^1.2.6"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/get-tsconfig": {
@@ -17501,16 +17076,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/has-bigints": {
-			"version": "1.0.2",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/has-flag": {
 			"version": "4.0.0",
 			"license": "MIT",
@@ -17523,22 +17088,6 @@
 			"license": "MIT",
 			"dependencies": {
 				"es-define-property": "^1.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/has-proto": {
-			"version": "1.2.0",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"dunder-proto": "^1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -18208,21 +17757,6 @@
 			"version": "1.14.1",
 			"license": "0BSD"
 		},
-		"node_modules/internal-slot": {
-			"version": "1.1.0",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"es-errors": "^1.3.0",
-				"hasown": "^2.0.2",
-				"side-channel": "^1.1.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
 		"node_modules/interpret": {
 			"version": "3.1.1",
 			"dev": true,
@@ -18278,62 +17812,9 @@
 				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
-		"node_modules/is-array-buffer": {
-			"version": "3.0.5",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"call-bind": "^1.0.8",
-				"call-bound": "^1.0.3",
-				"get-intrinsic": "^1.2.6"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/is-arrayish": {
 			"version": "0.2.1",
 			"license": "MIT"
-		},
-		"node_modules/is-async-function": {
-			"version": "2.1.0",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"call-bound": "^1.0.3",
-				"get-proto": "^1.0.1",
-				"has-tostringtag": "^1.0.2",
-				"safe-regex-test": "^1.1.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/is-bigint": {
-			"version": "1.1.0",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"has-bigints": "^1.0.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
 		},
 		"node_modules/is-binary-path": {
 			"version": "2.1.0",
@@ -18344,23 +17825,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/is-boolean-object": {
-			"version": "1.2.1",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"call-bound": "^1.0.2",
-				"has-tostringtag": "^1.0.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/is-bun-module": {
@@ -18386,41 +17850,6 @@
 			"license": "MIT",
 			"dependencies": {
 				"hasown": "^2.0.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/is-data-view": {
-			"version": "1.0.2",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"call-bound": "^1.0.2",
-				"get-intrinsic": "^1.2.6",
-				"is-typed-array": "^1.1.13"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/is-date-object": {
-			"version": "1.1.0",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"call-bound": "^1.0.2",
-				"has-tostringtag": "^1.0.2"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -18458,46 +17887,11 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/is-finalizationregistry": {
-			"version": "1.1.1",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"call-bound": "^1.0.3"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/is-fullwidth-code-point": {
 			"version": "3.0.0",
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/is-generator-function": {
-			"version": "1.1.0",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"call-bound": "^1.0.3",
-				"get-proto": "^1.0.0",
-				"has-tostringtag": "^1.0.2",
-				"safe-regex-test": "^1.1.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/is-glob": {
@@ -18566,19 +17960,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/is-map": {
-			"version": "2.0.3",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/is-my-ip-valid": {
 			"version": "1.0.1",
 			"license": "MIT",
@@ -18596,41 +17977,11 @@
 				"xtend": "^4.0.0"
 			}
 		},
-		"node_modules/is-negative-zero": {
-			"version": "2.0.3",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/is-number": {
 			"version": "7.0.0",
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.12.0"
-			}
-		},
-		"node_modules/is-number-object": {
-			"version": "1.1.1",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"call-bound": "^1.0.3",
-				"has-tostringtag": "^1.0.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/is-path-inside": {
@@ -18668,95 +18019,12 @@
 			"license": "MIT",
 			"optional": true
 		},
-		"node_modules/is-regex": {
-			"version": "1.2.1",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"call-bound": "^1.0.2",
-				"gopd": "^1.2.0",
-				"has-tostringtag": "^1.0.2",
-				"hasown": "^2.0.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/is-set": {
-			"version": "2.0.3",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/is-shared-array-buffer": {
-			"version": "1.0.4",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"call-bound": "^1.0.3"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/is-stream": {
 			"version": "1.1.0",
 			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/is-string": {
-			"version": "1.1.1",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"call-bound": "^1.0.3",
-				"has-tostringtag": "^1.0.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/is-symbol": {
-			"version": "1.1.1",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"call-bound": "^1.0.2",
-				"has-symbols": "^1.1.0",
-				"safe-regex-test": "^1.1.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/is-typed-array": {
@@ -18781,52 +18049,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/is-weakmap": {
-			"version": "2.0.2",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/is-weakref": {
-			"version": "1.1.1",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"call-bound": "^1.0.3"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/is-weakset": {
-			"version": "2.0.4",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"call-bound": "^1.0.3",
-				"get-intrinsic": "^1.2.6"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/is-wsl": {
@@ -21238,80 +20460,6 @@
 				"node": ">= 0.4"
 			}
 		},
-		"node_modules/object.assign": {
-			"version": "4.1.7",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"call-bind": "^1.0.8",
-				"call-bound": "^1.0.3",
-				"define-properties": "^1.2.1",
-				"es-object-atoms": "^1.0.0",
-				"has-symbols": "^1.1.0",
-				"object-keys": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/object.fromentries": {
-			"version": "2.0.8",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"call-bind": "^1.0.7",
-				"define-properties": "^1.2.1",
-				"es-abstract": "^1.23.2",
-				"es-object-atoms": "^1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/object.groupby": {
-			"version": "1.0.3",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"call-bind": "^1.0.7",
-				"define-properties": "^1.2.1",
-				"es-abstract": "^1.23.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
-		"node_modules/object.values": {
-			"version": "1.2.1",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"call-bind": "^1.0.8",
-				"call-bound": "^1.0.3",
-				"define-properties": "^1.2.1",
-				"es-object-atoms": "^1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/obug": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
@@ -21534,24 +20682,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/own-keys": {
-			"version": "1.0.1",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"get-intrinsic": "^1.2.6",
-				"object-keys": "^1.1.1",
-				"safe-push-apply": "^1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/p-cancelable": {
@@ -22983,29 +22113,6 @@
 				"redux": "^5.0.0"
 			}
 		},
-		"node_modules/reflect.getprototypeof": {
-			"version": "1.0.10",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"call-bind": "^1.0.8",
-				"define-properties": "^1.2.1",
-				"es-abstract": "^1.23.9",
-				"es-errors": "^1.3.0",
-				"es-object-atoms": "^1.0.0",
-				"get-intrinsic": "^1.2.7",
-				"get-proto": "^1.0.1",
-				"which-builtin-type": "^1.2.1"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/regenerate": {
 			"version": "1.4.2",
 			"dev": true,
@@ -23020,27 +22127,6 @@
 			},
 			"engines": {
 				"node": ">=4"
-			}
-		},
-		"node_modules/regexp.prototype.flags": {
-			"version": "1.5.4",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"call-bind": "^1.0.8",
-				"define-properties": "^1.2.1",
-				"es-errors": "^1.3.0",
-				"get-proto": "^1.0.1",
-				"gopd": "^1.2.0",
-				"set-function-name": "^2.0.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/regexpu-core": {
@@ -23610,64 +22696,9 @@
 				"tslib": "^2.1.0"
 			}
 		},
-		"node_modules/safe-array-concat": {
-			"version": "1.1.3",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"call-bind": "^1.0.8",
-				"call-bound": "^1.0.2",
-				"get-intrinsic": "^1.2.6",
-				"has-symbols": "^1.1.0",
-				"isarray": "^2.0.5"
-			},
-			"engines": {
-				"node": ">=0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/safe-buffer": {
 			"version": "5.1.2",
 			"license": "MIT"
-		},
-		"node_modules/safe-push-apply": {
-			"version": "1.0.0",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"es-errors": "^1.3.0",
-				"isarray": "^2.0.5"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/safe-regex-test": {
-			"version": "1.1.0",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"call-bound": "^1.0.2",
-				"es-errors": "^1.3.0",
-				"is-regex": "^1.2.1"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
 		},
 		"node_modules/safer-buffer": {
 			"version": "2.1.2",
@@ -23878,37 +22909,6 @@
 				"get-intrinsic": "^1.2.4",
 				"gopd": "^1.0.1",
 				"has-property-descriptors": "^1.0.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
-		"node_modules/set-function-name": {
-			"version": "2.0.2",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"define-data-property": "^1.1.4",
-				"es-errors": "^1.3.0",
-				"functions-have-names": "^1.2.3",
-				"has-property-descriptors": "^1.0.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
-		"node_modules/set-proto": {
-			"version": "1.0.0",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"dunder-proto": "^1.0.1",
-				"es-errors": "^1.3.0",
-				"es-object-atoms": "^1.0.0"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -24339,20 +23339,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/stop-iteration-iterator": {
-			"version": "1.1.0",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"es-errors": "^1.3.0",
-				"internal-slot": "^1.1.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
 		"node_modules/stream-buffers": {
 			"version": "2.2.0",
 			"license": "Unlicense",
@@ -24485,65 +23471,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/string.prototype.trim": {
-			"version": "1.2.10",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"call-bind": "^1.0.8",
-				"call-bound": "^1.0.2",
-				"define-data-property": "^1.1.4",
-				"define-properties": "^1.2.1",
-				"es-abstract": "^1.23.5",
-				"es-object-atoms": "^1.0.0",
-				"has-property-descriptors": "^1.0.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/string.prototype.trimend": {
-			"version": "1.0.9",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"call-bind": "^1.0.8",
-				"call-bound": "^1.0.2",
-				"define-properties": "^1.2.1",
-				"es-object-atoms": "^1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/string.prototype.trimstart": {
-			"version": "1.0.8",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"call-bind": "^1.0.7",
-				"define-properties": "^1.2.1",
-				"es-object-atoms": "^1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/stringify-entities": {
@@ -25471,42 +24398,6 @@
 			"version": "4.1.3",
 			"license": "MIT"
 		},
-		"node_modules/tsconfig-paths": {
-			"version": "3.15.0",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@types/json5": "^0.0.29",
-				"json5": "^1.0.2",
-				"minimist": "^1.2.6",
-				"strip-bom": "^3.0.0"
-			}
-		},
-		"node_modules/tsconfig-paths/node_modules/json5": {
-			"version": "1.0.2",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"minimist": "^1.2.0"
-			},
-			"bin": {
-				"json5": "lib/cli.js"
-			}
-		},
-		"node_modules/tsconfig-paths/node_modules/strip-bom": {
-			"version": "3.0.0",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/tslib": {
 			"version": "2.8.1",
 			"license": "0BSD"
@@ -25583,69 +24474,6 @@
 				"node": ">= 0.4"
 			}
 		},
-		"node_modules/typed-array-byte-length": {
-			"version": "1.0.3",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"call-bind": "^1.0.8",
-				"for-each": "^0.3.3",
-				"gopd": "^1.2.0",
-				"has-proto": "^1.2.0",
-				"is-typed-array": "^1.1.14"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/typed-array-byte-offset": {
-			"version": "1.0.4",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"available-typed-arrays": "^1.0.7",
-				"call-bind": "^1.0.8",
-				"for-each": "^0.3.3",
-				"gopd": "^1.2.0",
-				"has-proto": "^1.2.0",
-				"is-typed-array": "^1.1.15",
-				"reflect.getprototypeof": "^1.0.9"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/typed-array-length": {
-			"version": "1.0.7",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"call-bind": "^1.0.7",
-				"for-each": "^0.3.3",
-				"gopd": "^1.0.1",
-				"is-typed-array": "^1.1.13",
-				"possible-typed-array-names": "^1.0.0",
-				"reflect.getprototypeof": "^1.0.6"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/typescript": {
 			"version": "5.9.3",
 			"license": "Apache-2.0",
@@ -25658,14 +24486,16 @@
 			}
 		},
 		"node_modules/typescript-eslint": {
-			"version": "8.53.1",
+			"version": "8.57.1",
+			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.57.1.tgz",
+			"integrity": "sha512-fLvZWf+cAGw3tqMCYzGIU6yR8K+Y9NT2z23RwOjlNFF2HwSB3KhdEFI5lSBv8tNmFkkBShSjsCjzx1vahZfISA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/eslint-plugin": "8.53.1",
-				"@typescript-eslint/parser": "8.53.1",
-				"@typescript-eslint/typescript-estree": "8.53.1",
-				"@typescript-eslint/utils": "8.53.1"
+				"@typescript-eslint/eslint-plugin": "8.57.1",
+				"@typescript-eslint/parser": "8.57.1",
+				"@typescript-eslint/typescript-estree": "8.57.1",
+				"@typescript-eslint/utils": "8.57.1"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -25675,27 +24505,8 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"eslint": "^8.57.0 || ^9.0.0",
+				"eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
 				"typescript": ">=4.8.4 <6.0.0"
-			}
-		},
-		"node_modules/unbox-primitive": {
-			"version": "1.1.0",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"call-bound": "^1.0.3",
-				"has-bigints": "^1.0.2",
-				"has-symbols": "^1.1.0",
-				"which-boxed-primitive": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/undici-types": {
@@ -27095,73 +25906,6 @@
 			},
 			"engines": {
 				"node": ">= 8"
-			}
-		},
-		"node_modules/which-boxed-primitive": {
-			"version": "1.1.1",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"is-bigint": "^1.1.0",
-				"is-boolean-object": "^1.2.1",
-				"is-number-object": "^1.1.1",
-				"is-string": "^1.1.1",
-				"is-symbol": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/which-builtin-type": {
-			"version": "1.2.1",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"call-bound": "^1.0.2",
-				"function.prototype.name": "^1.1.6",
-				"has-tostringtag": "^1.0.2",
-				"is-async-function": "^2.0.0",
-				"is-date-object": "^1.1.0",
-				"is-finalizationregistry": "^1.1.0",
-				"is-generator-function": "^1.0.10",
-				"is-regex": "^1.2.1",
-				"is-weakref": "^1.0.2",
-				"isarray": "^2.0.5",
-				"which-boxed-primitive": "^1.1.0",
-				"which-collection": "^1.0.2",
-				"which-typed-array": "^1.1.16"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/which-collection": {
-			"version": "1.0.2",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"is-map": "^2.0.3",
-				"is-set": "^2.0.3",
-				"is-weakmap": "^2.0.2",
-				"is-weakset": "^2.0.3"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/which-typed-array": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
 				"prettier": "npm:wp-prettier@3.0.3",
 				"ts-node": "^10.9.2",
 				"typescript": "~5.9.3",
-				"typescript-eslint": "^8.53.0",
+				"typescript-eslint": "^8.57.1",
 				"vitest": "^4.0.18",
 				"web-streams-polyfill": "^4.2.0"
 			},

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
 		"eslint": "^9.39.2",
 		"eslint-config-prettier": "^9.1.2",
 		"eslint-import-resolver-typescript": "^4.4.4",
-		"eslint-plugin-import-x": "4.15.2",
+		"eslint-plugin-import-x": "^4.15.2",
 		"eslint-plugin-jest-dom": "^5.5.0",
 		"eslint-plugin-prettier": "^5.5.5",
 		"eslint-plugin-react-hooks": "^7.0.1",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
 		"prettier": "npm:wp-prettier@3.0.3",
 		"ts-node": "^10.9.2",
 		"typescript": "~5.9.3",
-		"typescript-eslint": "^8.53.0",
+		"typescript-eslint": "^8.57.1",
 		"vitest": "^4.0.18",
 		"web-streams-polyfill": "^4.2.0"
 	}

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
 		"eslint": "^9.39.2",
 		"eslint-config-prettier": "^9.1.2",
 		"eslint-import-resolver-typescript": "^4.4.4",
-		"eslint-plugin-import": "^2.32.0",
+		"eslint-plugin-import-x": "4.15.2",
 		"eslint-plugin-jest-dom": "^5.5.0",
 		"eslint-plugin-prettier": "^5.5.5",
 		"eslint-plugin-react-hooks": "^7.0.1",

--- a/tools/common/lib/bump-stat.ts
+++ b/tools/common/lib/bump-stat.ts
@@ -1,5 +1,5 @@
-import { AggregateInterval, StatsGroup, StatsMetric } from '@studio/common/types/stats';
 import { isSameDay, isSameMonth, isSameWeek } from 'date-fns';
+import { AggregateInterval, StatsGroup, StatsMetric } from '@studio/common/types/stats';
 
 // Database columns are varchar(32). Group limit is 27 to account for the '-a11n' suffix
 // added by the backend for Automattic requests (27 + 5 = 32).

--- a/tools/common/lib/domains.ts
+++ b/tools/common/lib/domains.ts
@@ -1,5 +1,5 @@
-import { DEFAULT_CUSTOM_DOMAIN_SUFFIX } from '@studio/common/constants';
 import { __ } from '@wordpress/i18n';
+import { DEFAULT_CUSTOM_DOMAIN_SUFFIX } from '@studio/common/constants';
 import { sanitizeFolderName } from './sanitize-folder-name';
 
 const DOMAIN_PATTERN =

--- a/tools/common/lib/generate-site-name.ts
+++ b/tools/common/lib/generate-site-name.ts
@@ -1,7 +1,7 @@
 import path from 'path';
+import { __ } from '@wordpress/i18n';
 import { isEmptyDir, pathExists } from '@studio/common/lib/fs-utils';
 import { sanitizeFolderName } from '@studio/common/lib/sanitize-folder-name';
-import { __ } from '@wordpress/i18n';
 
 function getDefaultSiteName(): string {
 	return __( 'My WordPress Website' );

--- a/tools/common/lib/tests/cache-function-ttl.test.ts
+++ b/tools/common/lib/tests/cache-function-ttl.test.ts
@@ -1,5 +1,5 @@
-import { cacheFunctionTTL, clearCache } from '@studio/common/lib/cache-function-ttl';
 import { vi } from 'vitest';
+import { cacheFunctionTTL, clearCache } from '@studio/common/lib/cache-function-ttl';
 
 describe( 'cacheFunctionTTL', () => {
 	beforeEach( () => {

--- a/tools/common/lib/tests/generate-site-name.test.ts
+++ b/tools/common/lib/tests/generate-site-name.test.ts
@@ -1,5 +1,5 @@
-import { isEmptyDir, pathExists } from '@studio/common/lib/fs-utils';
 import { vi } from 'vitest';
+import { isEmptyDir, pathExists } from '@studio/common/lib/fs-utils';
 import { generateNumberedName, generateSiteName } from '../generate-site-name';
 
 vi.mock( '@studio/common/lib/fs-utils' );

--- a/tools/common/lib/wordpress-versions.ts
+++ b/tools/common/lib/wordpress-versions.ts
@@ -1,9 +1,9 @@
+import { z } from 'zod';
 import { MINIMUM_WORDPRESS_VERSION } from '@studio/common/constants';
 import {
 	isWordPressBetaVersion,
 	isWordPressDevVersion,
 } from '@studio/common/lib/wordpress-version-utils';
-import { z } from 'zod';
 
 const WP_API_BASE_URL = 'https://api.wordpress.org/core/version-check/1.7/';
 


### PR DESCRIPTION
## Related issues

I'm exploring the possibility of replacing `eslint-plugin-import` with `eslint-plugin-import-x`. The first one looks unmaintained, whereas the fork authors maintain theirs and have even made it lighter.

https://www.npmjs.com/package/eslint-plugin-import
https://www.npmjs.com/package/eslint-plugin-import-x

## How AI was used in this PR

Claude Code performed the migration: updated package.json, eslint.config.mjs rule prefixes/settings key, and fixed the inline eslint-disable comment in index.ts.

## Proposed Changes

- Replace `eslint-plugin-import` with `eslint-plugin-import-x` (actively maintained ESLint 9/10-compatible fork)
- Update `eslint.config.mjs`: import alias, `flatConfigs.*` calls unchanged (same API), rule prefixes `import/` → `import-x/`, settings key `import/resolver` → `import-x/resolver`
- Update inline `// eslint-disable-next-line import/order` → `import-x/order` in `apps/studio/src/index.ts`
- Pinned to `4.15.2` (last version with loose `@typescript-eslint/utils@^8.0.0` peer dep, compatible with our current `typescript-eslint@^8.53.0`)

## Testing Instructions

- `npx eslint apps/studio/src` — no errors
- `npm run typecheck` — clean
- `npm test` — 1277 tests passing

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?