### PR TITLE
Fix: Replace require() with dynamic import() for ESM compatibility

### DIFF
--- a/apps/cli/ai/browser-utils.ts
+++ b/apps/cli/ai/browser-utils.ts
@@ -18,7 +18,7 @@ let browserPromise: Promise< Browser > | null = null;
 export async function getSharedBrowser(): Promise< Browser > {
 	if ( ! browserPromise ) {
 		browserPromise = ( async () => {
-			const { chromium } = require( 'playwright' ) as typeof import('playwright');
+			const { chromium } = await import( 'playwright' );
 			const browser = await chromium.launch( {
 				args: [ '--ignore-certificate-errors' ],
 			} );

--- a/package-lock.json
+++ b/package-lock.json
@@ -9258,7 +9258,6 @@
 			"os": [
 				"darwin"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -9275,7 +9274,6 @@
 			"os": [
 				"darwin"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -9292,7 +9290,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -9309,7 +9306,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -9326,7 +9322,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -9343,7 +9338,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -9360,7 +9354,6 @@
 			"os": [
 				"linux"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -9377,7 +9370,6 @@
 			"os": [
 				"win32"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -9394,7 +9386,6 @@
 			"os": [
 				"win32"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -9411,7 +9402,6 @@
 			"os": [
 				"win32"
 			],
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9258,6 +9258,7 @@
 			"os": [
 				"darwin"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -9274,6 +9275,7 @@
 			"os": [
 				"darwin"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -9290,6 +9292,7 @@
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -9306,6 +9309,7 @@
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -9322,6 +9326,7 @@
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -9338,6 +9343,7 @@
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -9354,6 +9360,7 @@
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -9370,6 +9377,7 @@
 			"os": [
 				"win32"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -9386,6 +9394,7 @@
 			"os": [
 				"win32"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -9402,6 +9411,7 @@
 			"os": [
 				"win32"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}


### PR DESCRIPTION
## Related issues

Related to the ESM migration in PR #2818.

## How AI was used in this PR

Claude identified the root cause of the "require is not defined" error and provided the fix.

## Proposed Changes

- Changed `require('playwright')` to `await import('playwright')` in `apps/cli/ai/browser-utils.ts` (line 21) to be compatible with the ESM-only CLI build output
- This fixes the screenshot tool failure in the AI command

## Testing Instructions

1. Run `npm run cli:build` to verify the build succeeds
2. Test the AI screenshot tool to confirm it works: `node apps/cli/dist/cli/main.js ai`

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?