### PR TITLE
Add different MCP configuration options

### DIFF
--- a/apps/cli/commands/mcp.ts
+++ b/apps/cli/commands/mcp.ts
@@ -1,4 +1,8 @@
-import { getMcpServerConfigJson } from '@studio/common/lib/mcp-config';
+import {
+	getMcpServerConfigJson,
+	getMcpServerLaunchCommand,
+	MCP_SERVER_NAME,
+} from '@studio/common/lib/mcp-config';
 import { __ } from '@wordpress/i18n';
 import { startMcpStdioServer } from 'cli/ai/mcp-server';
 import { Logger, LoggerError } from 'cli/logger';
@@ -6,29 +10,51 @@ import { StudioArgv } from 'cli/types';
 
 const logger = new Logger< string >();
 
+function getClaudeDesktopConfigPath(): string {
+	switch ( process.platform ) {
+		case 'darwin':
+			return '~/Library/Application Support/Claude/claude_desktop_config.json';
+		case 'win32':
+			return '%APPDATA%\\Claude\\claude_desktop_config.json';
+		default:
+			return '';
+	}
+}
+
 function printInstallationInstructions(): void {
-	const config = getMcpServerConfigJson();
+	const mcpServersConfig = getMcpServerConfigJson();
+	const launchCommand = getMcpServerLaunchCommand();
+	const claudeDesktopPath = getClaudeDesktopConfigPath();
 
 	const lines = [
 		'',
 		__( 'WordPress Studio MCP Server' ),
 		'─'.repeat( 40 ),
 		'',
-		__( "Add the following to your AI assistant's MCP configuration:" ),
+		__( 'Run one of the following commands to add MCP support to your AI assistant:' ),
 		'',
-		'{',
-		'  "mcpServers": ' +
-			config
-				.split( '\n' )
-				.map( ( line, i ) => ( i === 0 ? line : '  ' + line ) )
-				.join( '\n' ),
-		'}',
+		`  ${ __( 'Claude Code' ) }`,
+		`    claude mcp add ${ MCP_SERVER_NAME } -- ${ launchCommand }`,
+		'',
+		`  ${ __( 'Codex' ) }`,
+		`    codex mcp add ${ MCP_SERVER_NAME } -- ${ launchCommand }`,
+		'',
+		__(
+			'For other AI assistants, add the following under the "mcpServers" key in their MCP configuration:'
+		),
+		'',
+		mcpServersConfig,
 		'',
 		__( 'Configuration file locations:' ),
 		'',
-		'  Claude Desktop',
-		'    macOS  ~/Library/Application\\ Support/Claude/claude_desktop_config.json',
-		'    Win    %APPDATA%\\Claude\\claude_desktop_config.json',
+		`  ${ __( 'Claude Desktop' ) }`,
+		`    ${ claudeDesktopPath }`,
+		'',
+		`  ${ __( 'Cursor' ) }`,
+		`    ${ __( 'Project' ) }  .cursor/mcp.json`,
+		`    ${ __( 'Global' ) }   ~/.cursor/mcp.json`,
+		'',
+		__( 'For other AI assistants, check their documentation for config file locations.' ),
 		'',
 	];
 

--- a/apps/cli/commands/mcp.ts
+++ b/apps/cli/commands/mcp.ts
@@ -34,7 +34,7 @@ function printInstallationInstructions(): void {
 		__( 'Run one of the following commands to add MCP support to your AI assistant:' ),
 		'',
 		`  ${ __( 'Claude Code' ) }`,
-		`    claude mcp add ${ MCP_SERVER_NAME } -- ${ launchCommand }`,
+		`    claude mcp add --scope user ${ MCP_SERVER_NAME } -- ${ launchCommand }`,
 		'',
 		`  ${ __( 'Codex' ) }`,
 		`    codex mcp add ${ MCP_SERVER_NAME } -- ${ launchCommand }`,

--- a/tools/common/lib/mcp-config.ts
+++ b/tools/common/lib/mcp-config.ts
@@ -3,9 +3,22 @@
  * AI assistant's settings. Shared between the CLI `studio mcp` command
  * and the Studio desktop Settings dialog.
  */
-export function getMcpServerConfig(): Record< string, { command: string; args: string[] } > {
+type McpServerConfig = {
+	command: string;
+	args: string[];
+};
+
+export const MCP_SERVER_NAME = 'wordpress-studio';
+
+export function getMcpServerLaunchCommand(): string {
+	const serverConfig = getMcpServerConfig()[ MCP_SERVER_NAME ];
+
+	return [ serverConfig.command, ...serverConfig.args ].join( ' ' );
+}
+
+export function getMcpServerConfig(): Record< string, McpServerConfig > {
 	return {
-		'wordpress-studio': {
+		[ MCP_SERVER_NAME ]: {
 			command: 'studio',
 			args: [ 'mcp' ],
 		},


### PR DESCRIPTION
## Related issues

- Fixes STU-1389

## How AI was used in this PR
AI assisted me.

## Proposed Changes
This PR provides more detailed information to make the MCP configuration instructions clearer.
<img width="814" height="541" alt="Screenshot 2026-03-18 at 19 53 09" src="https://github.com/user-attachments/assets/5d960dfc-38fa-4e02-8aef-af119f820937" />


## Testing Instructions
1. Run `claude mcp add --scope user wordpress-studio -- studio mcp`
2. Run `claude mcp list`
3. Assert that you see `wordpress-studio`
4. Run `codex mcp add wordpress-studio -- studio mcp`
5. Run `codex mcp list`
6. Assert that you see `wordpress-studio`
7. Run `npm run cli:build && node apps/cli/dist/cli/main.js mcp`
8. Assert that you see correct path for Claude Desktop (either `~/Library/...` for macOS or `%APPDATA%...` for Windows)
9. Assert that printed info looks good
10. You can also test configuration of Cursor and Claude Desktop to ensure that paths are good, but it's enough to validate that they are the same as in the decumentation - [Claude Desktop "Access Developer Settings"](https://modelcontextprotocol.io/docs/develop/connect-local-servers) and [Cursor documentation](https://cursor.com/docs/mcp#configuration-locations).