### PR TITLE
Update package-lock.json after devEngines migration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,10 +42,6 @@
 				"typescript-eslint": "^8.57.1",
 				"vitest": "^4.0.18",
 				"web-streams-polyfill": "^4.2.0"
-			},
-			"engines": {
-				"node": ">=22.0.0",
-				"npm": ">=11.0.0"
 			}
 		},
 		"apps/cli": {


### PR DESCRIPTION
## Related issues

- Follows up on #2837

## Proposed Changes

Regenerates `package-lock.json` after the `engines` → `devEngines` migration in #2837. Running `npm install` after that change removes the stale `engines` block from the lockfile since `devEngines` is not recorded there.

## Testing Instructions

- Run `nvm use && npm install` and verify no changes to `package-lock.json`

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors? (Tests pass, no errors)