### PR TITLE
Simplify site-spec step to name and layout only

### DIFF
--- a/apps/cli/ai/plugin/skills/site-spec/SKILL.md
+++ b/apps/cli/ai/plugin/skills/site-spec/SKILL.md
@@ -1,16 +1,16 @@
 ---
 name: site-spec
-description: Gather user preferences before building a WordPress site. Asks about purpose, audience, brand personality, aesthetic direction, colors, and content structure. Run this before creating any new site.
+description: Gather the site name and layout preference before building a WordPress site. Run this before creating any new site.
 user-invokable: true
 ---
 
 # Site Spec Discovery
 
-Before creating a new WordPress site, gather the user's preferences through a short interactive discovery phase. This produces a **Site Spec** that guides all subsequent design and development decisions.
+Before creating a new WordPress site, gather the user's basic preferences through a short interactive discovery phase. This produces a **Site Spec** that guides all subsequent design and development decisions.
 
 ## How to Run
 
-Gather preferences through 3-4 rounds, building on previous answers. Keep it concise — no more than 6-7 questions total.
+Gather preferences through 2 rounds. Keep it concise.
 
 **AskUserQuestion constraints**: Each call supports 1-4 questions, each with 2-4 options. An "Other" free-form option is automatically provided by the system — do NOT add one yourself. Keep option labels short (1-5 words). Only use AskUserQuestion for questions that have meaningful predefined options. For open-ended questions (like asking for a name), just ask in your text output — the user will type their answer in the prompt.
 
@@ -18,54 +18,18 @@ Gather preferences through 3-4 rounds, building on previous answers. Keep it con
 
 Ask the user for their business/site name in your text output. **Stop here and wait for their reply** — do NOT call any tools or continue to the next round. The user needs a chance to type their answer in the prompt.
 
-### Round 2 — Purpose & Audience
+### Round 2 — Layout
 
 After the user provides the name, use AskUserQuestion for:
-- What is this site for? (e.g., business type, portfolio, blog, community, e-commerce, agency, restaurant, etc.)
-- Who is the target audience? (e.g., professionals, consumers, creatives, developers, local community, etc.)
-
-### Round 3 — Brand & Aesthetic Direction
-
-Adapt based on previous answers. Ask about:
-- What tone or personality should the site convey? (e.g., professional, playful, minimalist, bold, luxurious, raw, editorial, retro, organic, etc.)
-- Any reference sites or brands you admire? Or styles you want to avoid?
-
-### Round 4 — Visual & Structural Preferences
-
-Adapt based on previous answers. Ask about:
-- Color preferences or existing brand colors? (or let the user say "surprise me")
 - One-page site or multi-page site? (e.g., single scrollable page with sections vs. separate pages for each area)
-- What pages/sections do you need? (e.g., homepage, about, services, blog, contact, shop, gallery, etc.) — adapt the phrasing based on the one-page vs. multi-page answer
 
-## Synthesize the Site Spec
+## After Gathering Answers
 
-After gathering answers, produce a concise **Site Spec** document:
-
-```
-Site Spec: [Site Name]
-- Purpose: [what the site is for]
-- Audience: [who it's for]
-- Tone: [personality/voice]
-- Aesthetic direction: [visual style, references]
-- Color palette: [colors or direction]
-- Layout: [one-page or multi-page]
-- Pages/Structure: [list of pages or sections and key features]
-- Key differentiator: [the one thing that makes this site memorable]
-```
-
-Show the spec to the user, then use AskUserQuestion to ask for confirmation (e.g., "Ready to build this site?" with options like "Yes, let's go" / "I'd like to adjust something"). Do NOT just print a text question and wait — always use the AskUserQuestion tool for confirmation so the user gets interactive options.
-
-## After Confirmation
-
-1. Call `site_create` with an appropriate name derived from the spec.
-2. Save the site spec to `{site_path}/.agents/site-spec.md` using the Write tool, so it persists for future sessions.
-3. Use the spec to guide ALL subsequent design decisions — theme, typography, colors, layout, content tone, and page structure.
+Call `site_create` with the provided name and use the layout preference to guide all subsequent design decisions.
 
 ## When to Skip Discovery
 
 Do NOT ask questions if:
-- The user already provided an answer for that specific question in the initial prompt. (e.g., "build me a dark minimalist portfolio for a photographer with these 5 pages using navy and gold colors"). Instead, synthesize the spec directly from their request and confirm.
+- The user already provided the name and layout preference in the initial prompt. Proceed directly with site creation.
 - The user says "just build something" or "surprise me". Pick a bold creative direction yourself and proceed.
 - The user explicitly asks to skip the setup or says they don't want questions.
-
-In all skip cases, still synthesize and show a Site Spec before creating the site.

--- a/apps/cli/ai/system-prompt.ts
+++ b/apps/cli/ai/system-prompt.ts
@@ -12,7 +12,7 @@ IMPORTANT: For any generated content for the site, these three principles are ma
 
 For any request that involves a WordPress site, you MUST first determine which site to use:
 
-- **"Create" / "build" / "make" a site**: Run the \`site-spec\` skill to gather the user's preferences FIRST. Only call site_create AFTER you have a confirmed site spec. Do NOT call site_list first. Do NOT reuse or repurpose any existing site. Every new project gets a fresh site.
+- **"Create" / "build" / "make" a site**: Run the \`site-spec\` skill to gather the site name and layout preference FIRST, then proceed with site creation. Do NOT call site_list first. Do NOT reuse or repurpose any existing site. Every new project gets a fresh site.
 - **User names a specific existing site**: Call site_list to find it.
 - **User doesn't specify**: Ask the user whether to create a new site or use an existing one.
 - **Resuming work on an existing site**: Use site_info to get details and continue working.

--- a/apps/cli/ai/system-prompt.ts
+++ b/apps/cli/ai/system-prompt.ts
@@ -15,7 +15,7 @@ For any request that involves a WordPress site, you MUST first determine which s
 - **"Create" / "build" / "make" a site**: Run the \`site-spec\` skill to gather the user's preferences FIRST. Only call site_create AFTER you have a confirmed site spec. Do NOT call site_list first. Do NOT reuse or repurpose any existing site. Every new project gets a fresh site.
 - **User names a specific existing site**: Call site_list to find it.
 - **User doesn't specify**: Ask the user whether to create a new site or use an existing one.
-- **Resuming work on an existing site**: After getting site info, check if \`{site_path}/.agents/site-spec.md\` exists. If it does, read it and use it to guide your design decisions.
+- **Resuming work on an existing site**: Use site_info to get details and continue working.
 
 Then continue with:
 


### PR DESCRIPTION
## Related issues

-

## How AI was used in this PR

AI-assisted codebase exploration and refactoring to simplify the site-spec skill.

## Proposed Changes

- Trimmed the site-spec skill from 4 rounds (name, purpose/audience, brand/aesthetic, visual/structural) to 2 rounds (name and layout)
- Removed the synthesize and confirmation steps
- Removed the step that saved the site spec to `.agents/site-spec.md`
- Updated system-prompt.ts to remove reference to reading the saved site-spec.md file on resume

## Testing Instructions

- Run `npm run cli:build && node apps/cli/dist/cli/main.js ai` and test creating a new site
- Verify that the AI now only asks for the site name and whether it's a one-page or multi-page site
- Confirm that site creation proceeds directly after gathering these two inputs

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?