### PR TITLE
Add .sock cleanup to ensure Studio uses new _events after unclean shutdown

### DIFF
--- a/apps/cli/commands/_events.ts
+++ b/apps/cli/commands/_events.ts
@@ -10,6 +10,7 @@ import { sequential } from '@studio/common/lib/sequential';
 import { SITE_EVENTS, siteDetailsSchema, SiteEvent } from '@studio/common/lib/site-events';
 import { SiteCommandLoggerAction as LoggerAction } from '@studio/common/logger-actions';
 import { __ } from '@wordpress/i18n';
+import fs from 'fs';
 import { z } from 'zod';
 import { getSiteUrl, readAppdata, SiteData } from 'cli/lib/appdata';
 import {
@@ -106,6 +107,14 @@ export async function runCommand(): Promise< void > {
 
 	process.on( 'SIGINT', () => void cleanup() );
 	process.on( 'SIGTERM', () => void cleanup() );
+
+	// Remove any stale socket from a previous Studio session. Studio is single-instance,
+	// so any existing events.sock belongs to a dead session and must be replaced.
+	try {
+		fs.unlinkSync( SITE_EVENTS_SOCKET_PATH );
+	} catch ( err ) {
+		// ENOENT is fine — socket didn't exist. Any other error is unexpected but non-fatal.
+	}
 
 	try {
 		await eventsSocketServer.listen();

--- a/apps/cli/commands/_events.ts
+++ b/apps/cli/commands/_events.ts
@@ -6,11 +6,11 @@
  * stdout key-value pairs that Studio parses.
  */
 
+import fs from 'fs';
 import { sequential } from '@studio/common/lib/sequential';
 import { SITE_EVENTS, siteDetailsSchema, SiteEvent } from '@studio/common/lib/site-events';
 import { SiteCommandLoggerAction as LoggerAction } from '@studio/common/logger-actions';
 import { __ } from '@wordpress/i18n';
-import fs from 'fs';
 import { z } from 'zod';
 import { getSiteUrl, readAppdata, SiteData } from 'cli/lib/appdata';
 import {

--- a/apps/cli/commands/_events.ts
+++ b/apps/cli/commands/_events.ts
@@ -110,10 +110,12 @@ export async function runCommand(): Promise< void > {
 
 	// Remove any stale socket from a previous Studio session. Studio is single-instance,
 	// so any existing events.sock belongs to a dead session and must be replaced.
-	try {
-		fs.unlinkSync( SITE_EVENTS_SOCKET_PATH );
-	} catch ( err ) {
-		// ENOENT is fine — socket didn't exist. Any other error is unexpected but non-fatal.
+	if ( process.platform !== 'win32' ) {
+		try {
+			fs.unlinkSync( SITE_EVENTS_SOCKET_PATH );
+		} catch ( err ) {
+			// ENOENT is fine — socket didn't exist. Any other error is unexpected but non-fatal.
+		}
 	}
 
 	try {


### PR DESCRIPTION
## Related issues

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

- N/A

## How AI was used in this PR

<!--
Help reviewers understand what to look for and verify that you've reviewed the code yourself.
-->

I used it for debugging the issue and to add code that removes socket file. 

## Proposed Changes

I propose adding .sock cleanup to ensure Studio uses new _events after an unclean shutdown.

In the other case, when an old socket is not cleaned up after an unclean shutdown, Studio will reuse it.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Start Studio, start sites, confirm they are shown as running

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
