### PR TITLE
Rename 'Open site' to 'Open local site' in header

### DIFF
--- a/apps/studio/src/components/header.tsx
+++ b/apps/studio/src/components/header.tsx
@@ -55,8 +55,8 @@ export default function Header() {
 							disabled={ isLoading }
 						>
 							{
-								// translators: "Open site" refers to the action, like "to open site"
-								__( 'Open site' )
+								// translators: "Open local site" refers to the action of opening the local site in a browser
+								__( 'Open local site' )
 							}
 							<ArrowIcon />
 						</Button>


### PR DESCRIPTION
## Related issues

- Related to pfHvTO-16h-p2

## Proposed Changes

<img width="262" height="74" alt="image" src="https://github.com/user-attachments/assets/4c450c00-36c7-4024-b1cb-dd4f3d2a36a1" />

- Change "Open site" to "Open local site" in the site header to better distinguish it from remote/synced sites

## Testing Instructions

1. `npm start`
2. Select any site
3. Verify the header link now reads "Open local site ↗"

🤖 Generated with [Claude Code](https://claude.com/claude-code)