### PR TITLE
Studio: Fix color of Learn more links in the dark mode

### DIFF
--- a/apps/studio/src/components/learn-more.tsx
+++ b/apps/studio/src/components/learn-more.tsx
@@ -1,5 +1,6 @@
 import { useI18n } from '@wordpress/react-i18n';
 import Button from 'src/components/button';
+import { cx } from 'src/lib/cx';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 import { getLocalizedLink, type DocsLinkKey } from 'src/lib/get-localized-link';
 import { useI18nLocale } from 'src/stores';
@@ -15,7 +16,7 @@ function MoreLink( { docsLinksKey, className, label }: LinkProps & { label: stri
 
 	return (
 		<Button
-			className={ className }
+			className={ cx( 'learn-more-link', className ) }
 			onClick={ ( e: React.MouseEvent ) => {
 				e.stopPropagation();
 

--- a/apps/studio/src/index.css
+++ b/apps/studio/src/index.css
@@ -446,6 +446,14 @@ div:has( > progress ) > div:first-child {
 		color: var( --color-frame-theme );
 	}
 
+	/* External doc links (Learn more / Learn how) always render in theme blue */
+	.components-button.is-link.learn-more-link:not( .is-destructive ) {
+		color: var( --color-frame-theme );
+	}
+	.components-button.is-link.learn-more-link:not( .is-destructive ):hover {
+		color: var( --color-frame-theme-hover );
+	}
+
 	/* Button SVG icons */
 	.components-button svg {
 		fill: var( --color-frame-text );


### PR DESCRIPTION
## Related issues

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Fixes STU-1427

## How AI was used in this PR

It helped me to identify where the code should be placed.

## Proposed Changes

This PR ensures that `Learn more` links remain the blue color in the dark mode:

<img width="782" height="91" alt="Screenshot 2026-03-20 at 10 35 57 AM" src="https://github.com/user-attachments/assets/8a9a9ab9-feaf-45ff-8abd-3a90d6687d6b" />


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
* Start Studio with `npm start`
* Navigate to the `Import/Export` tab
* Confirm that the `Learn more` link remains blue

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
