### PR TITLE
Use light mode as the default color scheme

### DIFF
--- a/apps/studio/e2e/appearance.test.ts
+++ b/apps/studio/e2e/appearance.test.ts
@@ -34,8 +34,8 @@ test.describe( 'Appearance', () => {
 		// Preferences tab should be active by default with appearance radio group visible
 		await expect( settings.appearanceRadioGroup ).toBeVisible();
 
-		// Default should be System
-		await expect( settings.getAppearanceOption( 'System' ) ).toHaveAttribute(
+		// Default should be Light
+		await expect( settings.getAppearanceOption( 'Light' ) ).toHaveAttribute(
 			'aria-checked',
 			'true'
 		);
@@ -54,9 +54,9 @@ test.describe( 'Appearance', () => {
 		);
 		expect( isLight ).toBe( false );
 
-		// Switch back to System
-		await settings.selectColorScheme( 'System' );
-		await expect( settings.getAppearanceOption( 'System' ) ).toHaveAttribute(
+		// Switch back to Light
+		await settings.selectColorScheme( 'Light' );
+		await expect( settings.getAppearanceOption( 'Light' ) ).toHaveAttribute(
 			'aria-checked',
 			'true'
 		);
@@ -100,8 +100,8 @@ test.describe( 'Appearance', () => {
 			'true'
 		);
 
-		// Reset to System for other tests
-		await settingsAfterRestart.selectColorScheme( 'System' );
+		// Reset to Light for other tests
+		await settingsAfterRestart.selectColorScheme( 'Light' );
 		await settingsAfterRestart.close();
 	} );
 } );

--- a/apps/studio/e2e/appearance.test.ts
+++ b/apps/studio/e2e/appearance.test.ts
@@ -40,37 +40,33 @@ test.describe( 'Appearance', () => {
 			'true'
 		);
 
-		// Switch to Dark
+		// Switch to Dark and save
 		await settings.selectColorScheme( 'Dark' );
+		await settings.save();
 		const isDark = await session.electronApp.evaluate(
 			( { nativeTheme } ) => nativeTheme.shouldUseDarkColors
 		);
 		expect( isDark ).toBe( true );
 
-		// Switch to Light
-		await settings.selectColorScheme( 'Light' );
+		// Switch to Light and save
+		await openSettings( session.mainWindow );
+		const settingsLight = new UserSettingsModal( session.mainWindow );
+		await expect( settingsLight.locator ).toBeVisible( { timeout: 10_000 } );
+		await settingsLight.selectColorScheme( 'Light' );
+		await settingsLight.save();
 		const isLight = await session.electronApp.evaluate(
 			( { nativeTheme } ) => nativeTheme.shouldUseDarkColors
 		);
 		expect( isLight ).toBe( false );
-
-		// Switch back to Light
-		await settings.selectColorScheme( 'Light' );
-		await expect( settings.getAppearanceOption( 'Light' ) ).toHaveAttribute(
-			'aria-checked',
-			'true'
-		);
-
-		await settings.close();
 	} );
 
 	test( 'persists color scheme across app restart', async () => {
-		// Select Dark
+		// Select Dark and save
 		await openSettings( session.mainWindow );
 		const settings = new UserSettingsModal( session.mainWindow );
 		await expect( settings.locator ).toBeVisible( { timeout: 10_000 } );
 		await settings.selectColorScheme( 'Dark' );
-		await settings.close();
+		await settings.save();
 
 		// Restart the app
 		await session.restart();
@@ -102,6 +98,6 @@ test.describe( 'Appearance', () => {
 
 		// Reset to Light for other tests
 		await settingsAfterRestart.selectColorScheme( 'Light' );
-		await settingsAfterRestart.close();
+		await settingsAfterRestart.save();
 	} );
 } );

--- a/apps/studio/src/ipc-handlers.ts
+++ b/apps/studio/src/ipc-handlers.ts
@@ -139,6 +139,7 @@ export {
 	getUserEditor,
 	getUserLocale,
 	getUserTerminal,
+	previewColorScheme,
 	saveColorScheme,
 	saveUserEditor,
 	saveUserLocale,

--- a/apps/studio/src/main-window.ts
+++ b/apps/studio/src/main-window.ts
@@ -64,7 +64,7 @@ export async function createMainWindow(): Promise< BrowserWindow > {
 	}
 
 	const userData = await loadUserData();
-	nativeTheme.themeSource = userData.colorScheme ?? 'system';
+	nativeTheme.themeSource = userData.colorScheme ?? 'light';
 
 	const savedBounds = await loadWindowBounds();
 	let windowOptions: BrowserWindowConstructorOptions = {

--- a/apps/studio/src/modules/user-settings/components/preferences-tab.tsx
+++ b/apps/studio/src/modules/user-settings/components/preferences-tab.tsx
@@ -1,8 +1,9 @@
 import { SupportedLocale } from '@studio/common/lib/locale';
 import { useI18n } from '@wordpress/react-i18n';
-import { useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import Button from 'src/components/button';
 import { isWindowsStore } from 'src/lib/app-globals';
+import { getIpcApi } from 'src/lib/get-ipc-api';
 import { ColorSchemePicker } from 'src/modules/user-settings/components/color-scheme-picker';
 import { EditorPicker } from 'src/modules/user-settings/components/editor-picker';
 import { LanguagePicker } from 'src/modules/user-settings/components/language-picker';
@@ -44,7 +45,34 @@ export const PreferencesTab = ( { onClose }: { onClose: () => void } ) => {
 	const [ dirtyTerminal, setDirtyTerminal ] = useState< SupportedTerminal >();
 	const [ dirtyIsCliInstalled, setDirtyIsCliInstalled ] = useState< boolean >();
 
+	const wasSavedRef = useRef( false );
+	const dirtyColorSchemeRef = useRef( dirtyColorScheme );
+	const savedColorSchemeRef = useRef( colorScheme );
+
+	useEffect( () => {
+		dirtyColorSchemeRef.current = dirtyColorScheme;
+	}, [ dirtyColorScheme ] );
+
+	useEffect( () => {
+		savedColorSchemeRef.current = colorScheme;
+	}, [ colorScheme ] );
+
+	// Revert color scheme preview on unmount if not saved (handles Escape, click outside)
+	useEffect( () => {
+		return () => {
+			if ( ! wasSavedRef.current && dirtyColorSchemeRef.current ) {
+				void getIpcApi().previewColorScheme( savedColorSchemeRef.current ?? 'light' );
+			}
+		};
+	}, [] );
+
+	const handleColorSchemeChange = useCallback( ( scheme: 'system' | 'light' | 'dark' ) => {
+		setDirtyColorScheme( scheme );
+		void getIpcApi().previewColorScheme( scheme );
+	}, [] );
+
 	const savePreferences = async () => {
+		wasSavedRef.current = true;
 		if ( dirtyColorScheme ) {
 			await saveColorSchemePreference( dirtyColorScheme );
 		}
@@ -79,7 +107,7 @@ export const PreferencesTab = ( { onClose }: { onClose: () => void } ) => {
 
 	return (
 		<>
-			<ColorSchemePicker value={ colorSchemeSelection } onChange={ setDirtyColorScheme } />
+			<ColorSchemePicker value={ colorSchemeSelection } onChange={ handleColorSchemeChange } />
 			<LanguagePicker value={ localeSelection } onChange={ setDirtyLocale } />
 			<div className="grid grid-cols-2 gap-3">
 				<EditorPicker

--- a/apps/studio/src/modules/user-settings/components/preferences-tab.tsx
+++ b/apps/studio/src/modules/user-settings/components/preferences-tab.tsx
@@ -38,12 +38,16 @@ export const PreferencesTab = ( { onClose }: { onClose: () => void } ) => {
 	const [ saveTerminal ] = useSaveUserTerminalMutation();
 	const [ saveCliIsInstalled ] = useSaveStudioCliIsInstalledMutation();
 
+	const [ dirtyColorScheme, setDirtyColorScheme ] = useState< 'system' | 'light' | 'dark' >();
 	const [ dirtyLocale, setDirtyLocale ] = useState< SupportedLocale >();
 	const [ dirtyEditor, setDirtyEditor ] = useState< SupportedEditor | null >();
 	const [ dirtyTerminal, setDirtyTerminal ] = useState< SupportedTerminal >();
 	const [ dirtyIsCliInstalled, setDirtyIsCliInstalled ] = useState< boolean >();
 
 	const savePreferences = async () => {
+		if ( dirtyColorScheme ) {
+			await saveColorSchemePreference( dirtyColorScheme );
+		}
 		if ( dirtyLocale ) {
 			await dispatch( saveUserLocale( dirtyLocale ) );
 		}
@@ -59,12 +63,14 @@ export const PreferencesTab = ( { onClose }: { onClose: () => void } ) => {
 		onClose();
 	};
 
+	const colorSchemeSelection = dirtyColorScheme ?? colorScheme ?? 'light';
 	const localeSelection = dirtyLocale ?? savedLocale ?? 'en';
 	const editorSelection = dirtyEditor ?? editor ?? 'vscode';
 	const terminalSelection = dirtyTerminal ?? terminal ?? 'terminal';
 	const isCliInstalledSelection = dirtyIsCliInstalled ?? isCliInstalled ?? false;
 
 	const hasChanges = [
+		[ dirtyColorScheme, colorScheme ],
 		[ dirtyLocale, savedLocale ],
 		[ dirtyEditor, editor ],
 		[ dirtyTerminal, terminal ],
@@ -73,10 +79,7 @@ export const PreferencesTab = ( { onClose }: { onClose: () => void } ) => {
 
 	return (
 		<>
-			<ColorSchemePicker
-				value={ colorScheme ?? 'light' }
-				onChange={ ( value ) => saveColorSchemePreference( value ) }
-			/>
+			<ColorSchemePicker value={ colorSchemeSelection } onChange={ setDirtyColorScheme } />
 			<LanguagePicker value={ localeSelection } onChange={ setDirtyLocale } />
 			<div className="grid grid-cols-2 gap-3">
 				<EditorPicker

--- a/apps/studio/src/modules/user-settings/components/preferences-tab.tsx
+++ b/apps/studio/src/modules/user-settings/components/preferences-tab.tsx
@@ -74,7 +74,7 @@ export const PreferencesTab = ( { onClose }: { onClose: () => void } ) => {
 	return (
 		<>
 			<ColorSchemePicker
-				value={ colorScheme ?? 'system' }
+				value={ colorScheme ?? 'light' }
 				onChange={ ( value ) => saveColorSchemePreference( value ) }
 			/>
 			<LanguagePicker value={ localeSelection } onChange={ setDirtyLocale } />

--- a/apps/studio/src/modules/user-settings/lib/ipc-handlers.ts
+++ b/apps/studio/src/modules/user-settings/lib/ipc-handlers.ts
@@ -67,6 +67,13 @@ export async function getUserEditor(): Promise< SupportedEditor | null > {
 	return userData.preferredEditor ?? getDefaultInstalledEditor();
 }
 
+export async function previewColorScheme(
+	_event: IpcMainInvokeEvent,
+	colorScheme: 'system' | 'light' | 'dark'
+) {
+	nativeTheme.themeSource = colorScheme;
+}
+
 export async function saveColorScheme(
 	event: IpcMainInvokeEvent,
 	colorScheme: 'system' | 'light' | 'dark'

--- a/apps/studio/src/modules/user-settings/lib/ipc-handlers.ts
+++ b/apps/studio/src/modules/user-settings/lib/ipc-handlers.ts
@@ -77,7 +77,9 @@ export async function saveColorScheme(
 
 export async function getColorScheme(): Promise< 'system' | 'light' | 'dark' > {
 	const userData = await loadUserData();
-	return userData.colorScheme ?? 'light';
+	const colorScheme = userData.colorScheme ?? 'light';
+	nativeTheme.themeSource = colorScheme;
+	return colorScheme;
 }
 
 export function showUserSettings( event: IpcMainInvokeEvent, tabName?: UserSettingsTabName ) {

--- a/apps/studio/src/modules/user-settings/lib/ipc-handlers.ts
+++ b/apps/studio/src/modules/user-settings/lib/ipc-handlers.ts
@@ -77,7 +77,7 @@ export async function saveColorScheme(
 
 export async function getColorScheme(): Promise< 'system' | 'light' | 'dark' > {
 	const userData = await loadUserData();
-	return userData.colorScheme ?? 'system';
+	return userData.colorScheme ?? 'light';
 }
 
 export function showUserSettings( event: IpcMainInvokeEvent, tabName?: UserSettingsTabName ) {

--- a/apps/studio/src/preload.ts
+++ b/apps/studio/src/preload.ts
@@ -141,6 +141,7 @@ const api: IpcApi = {
 	saveUserTerminal: ( preferredTerminal ) =>
 		ipcRendererInvoke( 'saveUserTerminal', preferredTerminal ),
 	getUserTerminal: () => ipcRendererInvoke( 'getUserTerminal' ),
+	previewColorScheme: ( colorScheme ) => ipcRendererInvoke( 'previewColorScheme', colorScheme ),
 	saveColorScheme: ( colorScheme ) => ipcRendererInvoke( 'saveColorScheme', colorScheme ),
 	getColorScheme: () => ipcRendererInvoke( 'getColorScheme' ),
 	getUserEditor: () => ipcRendererInvoke( 'getUserEditor' ),

--- a/apps/studio/src/tests/main-window.test.ts
+++ b/apps/studio/src/tests/main-window.test.ts
@@ -75,7 +75,7 @@ vi.mock( 'electron', () => {
 			showMessageBox: vi.fn(),
 		},
 		nativeTheme: {
-			themeSource: 'system',
+			themeSource: 'light',
 		},
 		screen: {
 			getAllDisplays: vi.fn().mockReturnValue( [] ),


### PR DESCRIPTION
## Related issues

- Fixes STU-1429

## How AI was used in this PR

Claude Code identified all locations where the default color scheme was set to `system` and changed them to `light`. It also identified that the color scheme picker was saving immediately on click (unlike other preferences), and aligned it with the dirty state + Save button pattern. It then added live preview support so theme changes are visible immediately while still requiring Save to persist.

## Proposed Changes

- Change the default color scheme from `system` to `light` so new users always get light mode regardless of their OS dark mode setting
- Align the color scheme picker with the dirty state pattern used by other preferences (editor, terminal, locale) — changes are now local until the user clicks Save
- Add live preview: selecting a color scheme immediately applies the theme visually, but Save is required to persist the change
- Cancel, Escape, changing tab, or clicking outside the modal reverts the theme to the previously saved value
- Add `previewColorScheme` IPC handler that applies `nativeTheme.themeSource` without persisting to disk
- Sync `nativeTheme.themeSource` when reading the color scheme preference to ensure consistency

## Testing Instructions

- Start the app with `npm start`
- Remove the `colorScheme` entry from `~/Library/Application Support/Studio/appdata-v1.json` (or use a fresh install)
- Verify the app starts in light mode
- Open Settings → General and verify "Light" is selected by default
- Change appearance to "Dark", verify the app immediately switches to dark mode (live preview)
- Click Cancel, verify the app reverts to light mode
- Reopen Settings, change to "Dark" again, verify live preview applies
- Press Escape, verify the app reverts to light mode
- Reopen Settings, change to "Dark", click Save, verify the app stays in dark mode
- Reopen Settings, verify "Dark" is still selected
- Change to "Light", click outside the modal to dismiss, verify the app stays in dark mode (reverted)
- Change to "Light", click Save, verify it persists


<!--- https://github.com/user-attachments/assets/0c78ec74-90d8-4a93-8d9f-c544f8d678b7 !-->



https://github.com/user-attachments/assets/6cf982e7-6eed-4ee6-aac7-f1c2b4af33b3



## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?