### PR TITLE
Redesigned Sync

### DIFF
--- a/apps/studio/src/modules/sync/components/sync-server-rack.tsx
+++ b/apps/studio/src/modules/sync/components/sync-server-rack.tsx
@@ -17,27 +17,13 @@ import {
 	convertTreeToPushOptions,
 } from 'src/modules/sync/lib/convert-tree-to-sync-options';
 import {
-	getSiteEnvironment,
+	getSlotForSite,
 	getEnvironmentLabel,
-	EnvironmentType,
+	type SlotType,
 } from 'src/modules/sync/lib/environment-utils';
 import { useAppDispatch } from 'src/stores';
 import { syncOperationsThunks } from 'src/stores/sync';
 import type { SyncSite } from 'src/modules/sync/types';
-
-const ENVIRONMENT_ORDER: Record< EnvironmentType, number > = {
-	development: 0,
-	staging: 1,
-	production: 2,
-};
-
-function sortByEnvironment( sites: SyncSite[] ): SyncSite[] {
-	return [ ...sites ].sort( ( a, b ) => {
-		const envA = getSiteEnvironment( a );
-		const envB = getSiteEnvironment( b );
-		return ENVIRONMENT_ORDER[ envA ] - ENVIRONMENT_ORDER[ envB ];
-	} );
-}
 
 function SiteRack( {
 	badge,
@@ -85,6 +71,118 @@ function SiteRack( {
 	);
 }
 
+function EmptySlot( {
+	slot,
+	onConnect,
+}: {
+	slot: SlotType;
+	onConnect: ( slot: SlotType ) => void;
+} ) {
+	const { __ } = useI18n();
+	const isOffline = useOffline();
+
+	const variantClasses = {
+		staging: 'border-[#93590c]/25',
+		production: 'border-[#1a6928]/25',
+	};
+
+	const label = slot === 'staging' ? __( 'Staging' ) : __( 'Production' );
+
+	return (
+		<div
+			className={ cx(
+				'flex items-center gap-3 px-5 py-4 border border-dashed rounded-lg min-h-[60px]',
+				variantClasses[ slot ]
+			) }
+		>
+			<EnvironmentBadge type={ slot } />
+			<span className="text-frame-text-secondary a8c-body">
+				{ sprintf(
+					// translators: %s is the environment type (Staging or Production)
+					__( 'No %s site connected' ),
+					label.toLowerCase()
+				) }
+			</span>
+			<div className="ml-auto shrink-0">
+				<Button variant="secondary" onClick={ () => onConnect( slot ) } disabled={ isOffline }>
+					{ __( 'Connect' ) }
+				</Button>
+			</div>
+		</div>
+	);
+}
+
+function FilledSlot( {
+	site,
+	slot,
+	onPull,
+	onPush,
+	onReplace,
+	onDisconnect,
+}: {
+	site: SyncSite;
+	slot: SlotType;
+	onPull: () => void;
+	onPush: () => void;
+	onReplace: ( slot: SlotType ) => void;
+	onDisconnect: ( site: SyncSite ) => void;
+} ) {
+	const { __ } = useI18n();
+	const isOffline = useOffline();
+
+	return (
+		<SiteRack
+			badge={ <EnvironmentBadge type={ slot } /> }
+			url={ site.url.replace( /^https?:\/\//, '' ) }
+			onOpenUrl={ () => getIpcApi().openURL( site.url ) }
+			variant={ slot === 'staging' ? 'staging' : 'production' }
+			actions={
+				<>
+					<Button
+						variant="secondary"
+						onClick={ onPull }
+						disabled={ isOffline }
+						data-testid="sync-list-pull-button"
+					>
+						{ __( 'Pull' ) }
+					</Button>
+					<Button
+						variant="secondary"
+						onClick={ onPush }
+						disabled={ isOffline }
+						data-testid="sync-list-push-button"
+					>
+						{ __( 'Push' ) }
+					</Button>
+					<DropdownMenu icon={ moreVertical } label={ __( 'More actions' ) }>
+						{ ( { onClose } ) => (
+							<MenuGroup>
+								<MenuItem
+									onClick={ () => {
+										onClose();
+										onReplace( slot );
+									} }
+								>
+									{ __( 'Replace' ) }
+								</MenuItem>
+								<MenuItem
+									onClick={ () => {
+										onClose();
+										void onDisconnect( site );
+									} }
+									className="!text-a8c-red-50"
+								>
+									{ __( 'Disconnect' ) }
+								</MenuItem>
+							</MenuGroup>
+						) }
+					</DropdownMenu>
+				</>
+			}
+		/>
+	);
+}
+
 function PushArrow( {
 	fromLabel,
 	toLabel,
@@ -126,10 +224,14 @@ export function SyncServerRack( {
 	connectedSites,
 	selectedSite,
 	disconnectSite,
+	onConnectSlot,
+	onReplaceSlot,
 }: {
 	connectedSites: SyncSite[];
 	selectedSite: SiteDetails;
 	disconnectSite: ( id: number ) => void;
+	onConnectSlot: ( slot: SlotType ) => void;
+	onReplaceSlot: ( slot: SlotType ) => void;
 } ) {
 	const { __ } = useI18n();
 	const dispatch = useAppDispatch();
@@ -139,11 +241,10 @@ export function SyncServerRack( {
 		remoteSite: SyncSite;
 	} | null >( null );
 
-	const sortedSites = sortByEnvironment( connectedSites );
+	const stagingSite = connectedSites.find( ( s ) => getSlotForSite( s ) === 'staging' );
+	const productionSite = connectedSites.find( ( s ) => getSlotForSite( s ) === 'production' );
 
 	const localUrl = `localhost:${ selectedSite.port ?? '' }`;
-
-	const isOffline = useOffline();
 
 	const handleDisconnect = async ( site: SyncSite ) => {
 		const dontShowDisconnectWarning = localStorage.getItem( 'dontShowDisconnectWarning' );
@@ -186,64 +287,57 @@ export function SyncServerRack( {
 				onOpenUrl={ () => getIpcApi().openSiteURL( selectedSite.id ) }
 			/>
 
-			{ /* Connected sites with push arrows */ }
-			{ sortedSites.map( ( site, index ) => {
-				const env = getSiteEnvironment( site );
-				const envLabel = getEnvironmentLabel( env );
-				const prevLabel =
-					index === 0
-						? __( 'Local' )
-						: getEnvironmentLabel( getSiteEnvironment( sortedSites[ index - 1 ] ) );
-
-				return (
-					<div key={ site.id }>
-						<PushArrow
-							fromLabel={ prevLabel }
-							toLabel={ envLabel }
-							onClick={ () => setSyncDialogState( { type: 'push', remoteSite: site } ) }
-						/>
-						<SiteRack
-							badge={ <EnvironmentBadge type={ env } /> }
-							url={ site.url.replace( /^https?:\/\//, '' ) }
-							onOpenUrl={ () => getIpcApi().openURL( site.url ) }
-							variant={ env === 'staging' ? 'staging' : env === 'production' ? 'production' : 'default' }
-							actions={
-								<>
-									<Button
-										variant="secondary"
-										onClick={ () => setSyncDialogState( { type: 'pull', remoteSite: site } ) }
-										disabled={ isOffline }
-									>
-										{ __( 'Pull' ) }
-									</Button>
-									<Button
-										variant="secondary"
-										onClick={ () => setSyncDialogState( { type: 'push', remoteSite: site } ) }
-										disabled={ isOffline }
-									>
-										{ __( 'Push' ) }
-									</Button>
-									<DropdownMenu icon={ moreVertical } label={ __( 'More actions' ) }>
-										{ ( { onClose } ) => (
-											<MenuGroup>
-												<MenuItem
-													onClick={ () => {
-														onClose();
-														void handleDisconnect( site );
-													} }
-													className="!text-a8c-red-50"
-												>
-													{ __( 'Disconnect' ) }
-												</MenuItem>
-											</MenuGroup>
-										) }
-									</DropdownMenu>
-								</>
-							}
-						/>
+			{ /* Staging slot */ }
+			{ stagingSite ? (
+				<>
+					<PushArrow
+						fromLabel={ __( 'Local' ) }
+						toLabel={ getEnvironmentLabel( 'staging' ) }
+						onClick={ () => setSyncDialogState( { type: 'push', remoteSite: stagingSite } ) }
+					/>
+					<FilledSlot
+						site={ stagingSite }
+						slot="staging"
+						onPull={ () => setSyncDialogState( { type: 'pull', remoteSite: stagingSite } ) }
+						onPush={ () => setSyncDialogState( { type: 'push', remoteSite: stagingSite } ) }
+						onReplace={ onReplaceSlot }
+						onDisconnect={ handleDisconnect }
+					/>
+				</>
+			) : (
+				<>
+					<div className="flex flex-col items-center py-3">
+						<div className="w-px h-6 bg-frame-border" />
 					</div>
-				);
-			} ) }
+					<EmptySlot slot="staging" onConnect={ onConnectSlot } />
+				</>
+			) }
+
+			{ /* Production slot */ }
+			{ productionSite ? (
+				<>
+					<PushArrow
+						fromLabel={ stagingSite ? getEnvironmentLabel( 'staging' ) : __( 'Local' ) }
+						toLabel={ getEnvironmentLabel( 'production' ) }
+						onClick={ () => setSyncDialogState( { type: 'push', remoteSite: productionSite } ) }
+					/>
+					<FilledSlot
+						site={ productionSite }
+						slot="production"
+						onPull={ () => setSyncDialogState( { type: 'pull', remoteSite: productionSite } ) }
+						onPush={ () => setSyncDialogState( { type: 'push', remoteSite: productionSite } ) }
+						onReplace={ onReplaceSlot }
+						onDisconnect={ handleDisconnect }
+					/>
+				</>
+			) : (
+				<>
+					<div className="flex flex-col items-center py-3">
+						<div className="w-px h-6 bg-frame-border" />
+					</div>
+					<EmptySlot slot="production" onConnect={ onConnectSlot } />
+				</>
+			) }
 
 			{ syncDialogState && (
 				<SyncDialog

--- a/apps/studio/src/modules/sync/components/sync-server-rack.tsx
+++ b/apps/studio/src/modules/sync/components/sync-server-rack.tsx
@@ -1,0 +1,282 @@
+import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
+import { sprintf } from '@wordpress/i18n';
+import { moreVertical } from '@wordpress/icons';
+import { useI18n } from '@wordpress/react-i18n';
+import { useState } from 'react';
+import { ArrowIcon } from 'src/components/arrow-icon';
+import Button from 'src/components/button';
+import { WordPressLogoCircle } from 'src/components/wordpress-logo-circle';
+import { useAuth } from 'src/hooks/use-auth';
+import { useOffline } from 'src/hooks/use-offline';
+import { cx } from 'src/lib/cx';
+import { getIpcApi } from 'src/lib/get-ipc-api';
+import { EnvironmentBadge } from 'src/modules/sync/components/environment-badge';
+import { SyncDialog } from 'src/modules/sync/components/sync-dialog';
+import {
+	convertTreeToPullOptions,
+	convertTreeToPushOptions,
+} from 'src/modules/sync/lib/convert-tree-to-sync-options';
+import {
+	getSiteEnvironment,
+	getEnvironmentLabel,
+	EnvironmentType,
+} from 'src/modules/sync/lib/environment-utils';
+import { useAppDispatch } from 'src/stores';
+import { syncOperationsThunks } from 'src/stores/sync';
+import type { SyncSite } from 'src/modules/sync/types';
+
+const ENVIRONMENT_ORDER: Record< EnvironmentType, number > = {
+	development: 0,
+	staging: 1,
+	production: 2,
+};
+
+function sortByEnvironment( sites: SyncSite[] ): SyncSite[] {
+	return [ ...sites ].sort( ( a, b ) => {
+		const envA = getSiteEnvironment( a );
+		const envB = getSiteEnvironment( b );
+		return ENVIRONMENT_ORDER[ envA ] - ENVIRONMENT_ORDER[ envB ];
+	} );
+}
+
+function SiteRack( {
+	badge,
+	url,
+	onOpenUrl,
+	actions,
+	className,
+	variant,
+}: {
+	badge: React.ReactNode;
+	url: string;
+	onOpenUrl: () => void;
+	actions?: React.ReactNode;
+	className?: string;
+	variant?: 'default' | 'staging' | 'production';
+} ) {
+	const variantClasses = {
+		default: 'border-frame-border bg-frame',
+		staging: 'border-[#93590c]/25 bg-[#fef0c7]/20',
+		production: 'border-[#1a6928]/25 bg-[#ceead6]/20',
+	};
+
+	return (
+		<div
+			className={ cx(
+				'flex items-center gap-3 px-5 py-4 border rounded-lg min-h-[60px]',
+				variantClasses[ variant ?? 'default' ],
+				className
+			) }
+		>
+			{ badge }
+			<div className="flex items-center gap-1.5 min-w-0">
+				<WordPressLogoCircle />
+				<Button
+					variant="link"
+					className="!text-frame-text hover:!text-frame-theme min-w-0"
+					onClick={ onOpenUrl }
+				>
+					<span className="truncate">{ url }</span>
+					<ArrowIcon />
+				</Button>
+			</div>
+			{ actions && <div className="ml-auto shrink-0 flex gap-2">{ actions }</div> }
+		</div>
+	);
+}
+
+function PushArrow( {
+	fromLabel,
+	toLabel,
+	onClick,
+}: {
+	fromLabel: string;
+	toLabel: string;
+	onClick: () => void;
+} ) {
+	const { __ } = useI18n();
+	const isOffline = useOffline();
+	const label = sprintf(
+		// translators: %1$s is the source environment, %2$s is the destination environment
+		__( 'Push %1$s to %2$s' ),
+		fromLabel,
+		toLabel
+	);
+
+	return (
+		<div className="flex flex-col items-center py-3">
+			<div className="w-px h-3 bg-frame-border" />
+			<Button
+				variant="link"
+				className="!text-xs !text-frame-text-secondary hover:!text-frame-theme !no-underline"
+				onClick={ onClick }
+				disabled={ isOffline }
+			>
+				{ label }
+			</Button>
+			<div className="w-px h-3 bg-frame-border" />
+			<svg width="10" height="6" viewBox="0 0 10 6" className="text-frame-border">
+				<path d="M5 6L0 0h10L5 6z" fill="currentColor" />
+			</svg>
+		</div>
+	);
+}
+
+export function SyncServerRack( {
+	connectedSites,
+	selectedSite,
+	disconnectSite,
+}: {
+	connectedSites: SyncSite[];
+	selectedSite: SiteDetails;
+	disconnectSite: ( id: number ) => void;
+} ) {
+	const { __ } = useI18n();
+	const dispatch = useAppDispatch();
+	const { client } = useAuth();
+	const [ syncDialogState, setSyncDialogState ] = useState< {
+		type: 'push' | 'pull';
+		remoteSite: SyncSite;
+	} | null >( null );
+
+	const sortedSites = sortByEnvironment( connectedSites );
+
+	const localUrl = `localhost:${ selectedSite.port ?? '' }`;
+
+	const isOffline = useOffline();
+
+	const handleDisconnect = async ( site: SyncSite ) => {
+		const dontShowDisconnectWarning = localStorage.getItem( 'dontShowDisconnectWarning' );
+		if ( ! dontShowDisconnectWarning ) {
+			const disconnectMessage = site.name
+				? sprintf( __( 'Disconnect %s' ), site.name )
+				: __( 'Disconnect site' );
+
+			const { response, checkboxChecked } = await getIpcApi().showMessageBox( {
+				message: disconnectMessage,
+				detail: __(
+					'Your WordPress.com site will not be affected by disconnecting it from Studio.'
+				),
+				buttons: [ __( 'Disconnect' ), __( 'Cancel' ) ],
+				cancelId: 1,
+				checkboxLabel: __( "Don't ask again" ),
+			} );
+
+			if ( response === 0 ) {
+				if ( checkboxChecked ) {
+					localStorage.setItem( 'dontShowDisconnectWarning', 'true' );
+				}
+				disconnectSite( site.id );
+			}
+		} else {
+			disconnectSite( site.id );
+		}
+	};
+
+	return (
+		<div className="flex flex-col items-stretch p-8 max-w-2xl">
+			{ /* Local site rack */ }
+			<SiteRack
+				badge={
+					<span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-frame-surface text-frame-text-secondary border border-frame-border">
+						{ __( 'Local' ) }
+					</span>
+				}
+				url={ localUrl }
+				onOpenUrl={ () => getIpcApi().openSiteURL( selectedSite.id ) }
+			/>
+
+			{ /* Connected sites with push arrows */ }
+			{ sortedSites.map( ( site, index ) => {
+				const env = getSiteEnvironment( site );
+				const envLabel = getEnvironmentLabel( env );
+				const prevLabel =
+					index === 0
+						? __( 'Local' )
+						: getEnvironmentLabel( getSiteEnvironment( sortedSites[ index - 1 ] ) );
+
+				return (
+					<div key={ site.id }>
+						<PushArrow
+							fromLabel={ prevLabel }
+							toLabel={ envLabel }
+							onClick={ () => setSyncDialogState( { type: 'push', remoteSite: site } ) }
+						/>
+						<SiteRack
+							badge={ <EnvironmentBadge type={ env } /> }
+							url={ site.url.replace( /^https?:\/\//, '' ) }
+							onOpenUrl={ () => getIpcApi().openURL( site.url ) }
+							variant={ env === 'staging' ? 'staging' : env === 'production' ? 'production' : 'default' }
+							actions={
+								<>
+									<Button
+										variant="secondary"
+										onClick={ () => setSyncDialogState( { type: 'pull', remoteSite: site } ) }
+										disabled={ isOffline }
+									>
+										{ __( 'Pull' ) }
+									</Button>
+									<Button
+										variant="secondary"
+										onClick={ () => setSyncDialogState( { type: 'push', remoteSite: site } ) }
+										disabled={ isOffline }
+									>
+										{ __( 'Push' ) }
+									</Button>
+									<DropdownMenu icon={ moreVertical } label={ __( 'More actions' ) }>
+										{ ( { onClose } ) => (
+											<MenuGroup>
+												<MenuItem
+													onClick={ () => {
+														onClose();
+														void handleDisconnect( site );
+													} }
+													className="!text-a8c-red-50"
+												>
+													{ __( 'Disconnect' ) }
+												</MenuItem>
+											</MenuGroup>
+										) }
+									</DropdownMenu>
+								</>
+							}
+						/>
+					</div>
+				);
+			} ) }
+
+			{ syncDialogState && (
+				<SyncDialog
+					type={ syncDialogState.type }
+					localSite={ selectedSite }
+					remoteSite={ syncDialogState.remoteSite }
+					onPush={ ( tree ) => {
+						const pushOptions = convertTreeToPushOptions( tree );
+						void dispatch(
+							syncOperationsThunks.pushSite( {
+								connectedSite: syncDialogState.remoteSite,
+								selectedSite,
+								options: pushOptions,
+							} )
+						);
+					} }
+					onPull={ ( tree ) => {
+						if ( ! client ) {
+							return;
+						}
+						const pullOptions = convertTreeToPullOptions( tree );
+						void dispatch(
+							syncOperationsThunks.pullSite( {
+								client,
+								connectedSite: syncDialogState.remoteSite,
+								selectedSite,
+								options: pullOptions,
+							} )
+						);
+					} }
+					onRequestClose={ () => setSyncDialogState( null ) }
+				/>
+			) }
+		</div>
+	);
+}

--- a/apps/studio/src/modules/sync/components/sync-sites-modal-selector.tsx
+++ b/apps/studio/src/modules/sync/components/sync-sites-modal-selector.tsx
@@ -17,7 +17,7 @@ import { getLocalizedLink } from 'src/lib/get-localized-link';
 import { CreateButton } from 'src/modules/sync/components/create-button';
 import { EnvironmentBadge } from 'src/modules/sync/components/environment-badge';
 import { NoWpcomSitesModal } from 'src/modules/sync/components/no-wpcom-sites-modal';
-import { getSiteEnvironment } from 'src/modules/sync/lib/environment-utils';
+import { getSiteEnvironment, type SlotType } from 'src/modules/sync/lib/environment-utils';
 import { useI18nLocale, useRootSelector } from 'src/stores';
 import {
 	connectedSitesSelectors,
@@ -38,11 +38,13 @@ export function SyncSitesModalSelector( {
 	onConnect,
 	selectedSite,
 	mode = 'connect',
+	environmentFilter,
 }: {
 	onRequestClose: () => void;
 	onConnect: ( siteId: number ) => void;
 	selectedSite: SiteDetails;
 	mode?: SyncModalMode;
+	environmentFilter?: SlotType;
 } ) {
 	const { __ } = useI18n();
 	const { user } = useAuth();
@@ -69,6 +71,12 @@ export function SyncSitesModalSelector( {
 	}
 
 	const getModalTitle = () => {
+		if ( environmentFilter === 'staging' ) {
+			return __( 'Connect a staging site' );
+		}
+		if ( environmentFilter === 'production' ) {
+			return __( 'Connect a production site' );
+		}
 		switch ( mode ) {
 			case 'push':
 				return __( 'Publish your site' );
@@ -92,6 +100,7 @@ export function SyncSitesModalSelector( {
 					syncSites={ syncSites }
 					selectedSiteId={ selectedSiteId }
 					onSelectSite={ setSelectedSiteId }
+					environmentFilter={ environmentFilter }
 				/>
 				<Footer
 					onRequestClose={ onRequestClose }
@@ -159,11 +168,13 @@ export function SitesListContent( {
 	syncSites,
 	selectedSiteId,
 	onSelectSite,
+	environmentFilter,
 }: {
 	isLoading: boolean;
 	syncSites: SyncSite[];
 	selectedSiteId: number | null;
 	onSelectSite: ( id: number ) => void;
+	environmentFilter?: SlotType;
 } ) {
 	const { __ } = useI18n();
 	const [ searchQuery, setSearchQuery ] = useState< string >( '' );
@@ -195,6 +206,7 @@ export function SitesListContent( {
 						syncSites={ filteredSites }
 						selectedSiteId={ selectedSiteId }
 						onSelectSite={ onSelectSite }
+						environmentFilter={ environmentFilter }
 					/>
 				) }
 			</div>
@@ -202,7 +214,7 @@ export function SitesListContent( {
 	);
 }
 
-const getSortedSites = ( sites: SyncSite[] ) => {
+const getSortedSites = ( sites: SyncSite[], environmentFilter?: SlotType ) => {
 	const order: Record< SyncSite[ 'syncSupport' ], number > = {
 		syncable: 1,
 		'already-connected': 2,
@@ -213,19 +225,41 @@ const getSortedSites = ( sites: SyncSite[] ) => {
 		unsupported: 7,
 	};
 
-	return [ ...sites ].sort( ( a, b ) => order[ a.syncSupport ] - order[ b.syncSupport ] );
+	return [ ...sites ].sort( ( a, b ) => {
+		const supportDiff = order[ a.syncSupport ] - order[ b.syncSupport ];
+		if ( supportDiff !== 0 ) {
+			return supportDiff;
+		}
+		if ( environmentFilter ) {
+			const envA = getSiteEnvironment( a );
+			const envB = getSiteEnvironment( b );
+			const matchesA =
+				envA === environmentFilter || ( environmentFilter === 'staging' && envA === 'development' );
+			const matchesB =
+				envB === environmentFilter || ( environmentFilter === 'staging' && envB === 'development' );
+			if ( matchesA && ! matchesB ) {
+				return -1;
+			}
+			if ( ! matchesA && matchesB ) {
+				return 1;
+			}
+		}
+		return 0;
+	} );
 };
 
 function ListSites( {
 	syncSites,
 	selectedSiteId,
 	onSelectSite,
+	environmentFilter,
 }: {
 	syncSites: SyncSite[];
 	selectedSiteId: null | number;
 	onSelectSite: ( id: number ) => void;
+	environmentFilter?: SlotType;
 } ) {
-	const sortedSites = getSortedSites( syncSites );
+	const sortedSites = getSortedSites( syncSites, environmentFilter );
 
 	return (
 		<div className="flex flex-col overflow-y-auto h-full pt-px">

--- a/apps/studio/src/modules/sync/index.tsx
+++ b/apps/studio/src/modules/sync/index.tsx
@@ -9,8 +9,8 @@ import { useAuth } from 'src/hooks/use-auth';
 import { useOffline } from 'src/hooks/use-offline';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 import { ConnectButton } from 'src/modules/sync/components/connect-button';
-import { SyncConnectedSites } from 'src/modules/sync/components/sync-connected-sites';
 import { SyncDialog } from 'src/modules/sync/components/sync-dialog';
+import { SyncServerRack } from 'src/modules/sync/components/sync-server-rack';
 import { SyncSitesModalSelector } from 'src/modules/sync/components/sync-sites-modal-selector';
 import { SyncTabImage } from 'src/modules/sync/components/sync-tab-image';
 import {
@@ -196,15 +196,17 @@ export function ContentTabSync( { selectedSite }: { selectedSite: SiteDetails } 
 	return (
 		<div className="flex flex-col h-full overflow-y-auto">
 			{ connectedSites.length > 0 ? (
-				<div className="h-full relative">
-					<SyncConnectedSites
-						connectedSites={ connectedSites }
-						selectedSite={ selectedSite }
-						disconnectSite={ ( id ) =>
-							disconnectSite( { siteId: id, localSiteId: selectedSite.id } )
-						}
-					/>
-					<div className="sticky bottom-0 bg-frame/[0.8] backdrop-blur-sm w-full px-8 py-6 mt-auto">
+				<div className="h-full relative flex flex-col">
+					<div className="flex-1 flex items-center justify-center">
+						<SyncServerRack
+							connectedSites={ connectedSites }
+							selectedSite={ selectedSite }
+							disconnectSite={ ( id ) =>
+								disconnectSite( { siteId: id, localSiteId: selectedSite.id } )
+							}
+						/>
+					</div>
+					<div className="sticky bottom-0 bg-frame/[0.8] backdrop-blur-sm w-full px-8 py-6">
 						<ConnectButton
 							variant="primary"
 							connectSite={ () => dispatch( connectedSitesActions.openModal( 'connect' ) ) }

--- a/apps/studio/src/modules/sync/index.tsx
+++ b/apps/studio/src/modules/sync/index.tsx
@@ -8,7 +8,6 @@ import { Tooltip } from 'src/components/tooltip';
 import { useAuth } from 'src/hooks/use-auth';
 import { useOffline } from 'src/hooks/use-offline';
 import { getIpcApi } from 'src/lib/get-ipc-api';
-import { ConnectButton } from 'src/modules/sync/components/connect-button';
 import { SyncDialog } from 'src/modules/sync/components/sync-dialog';
 import { SyncServerRack } from 'src/modules/sync/components/sync-server-rack';
 import { SyncSitesModalSelector } from 'src/modules/sync/components/sync-sites-modal-selector';
@@ -17,6 +16,7 @@ import {
 	convertTreeToPullOptions,
 	convertTreeToPushOptions,
 } from 'src/modules/sync/lib/convert-tree-to-sync-options';
+import { getSlotForSite, type SlotType } from 'src/modules/sync/lib/environment-utils';
 import { useAppDispatch, useRootSelector } from 'src/stores';
 import { syncOperationsThunks } from 'src/stores/sync';
 import {
@@ -126,6 +126,7 @@ export function ContentTabSync( { selectedSite }: { selectedSite: SiteDetails } 
 	const dispatch = useAppDispatch();
 	const isModalOpen = useRootSelector( connectedSitesSelectors.selectIsModalOpen );
 	const reduxModalMode = useRootSelector( connectedSitesSelectors.selectModalMode );
+	const connectingSlot = useRootSelector( connectedSitesSelectors.selectConnectingSlot );
 	const selectedRemoteSiteId = useRootSelector(
 		connectedSitesSelectors.selectSelectedRemoteSiteId
 	);
@@ -188,14 +189,34 @@ export function ContentTabSync( { selectedSite }: { selectedSite: SiteDetails } 
 			dispatch( connectedSitesActions.openModal( reduxModalMode ) );
 			setSelectedRemoteSite( selectedSiteFromList );
 		} else {
+			// If connecting to a specific slot and a site already occupies it, disconnect old first
+			if ( connectingSlot ) {
+				const existingOccupant = connectedSites.find(
+					( s ) => getSlotForSite( s ) === connectingSlot
+				);
+				if ( existingOccupant ) {
+					await disconnectSite( {
+						siteId: existingOccupant.id,
+						localSiteId: selectedSite.id,
+					} );
+				}
+			}
 			await handleConnect( selectedSiteFromList );
 			dispatch( connectedSitesActions.closeModal() );
 		}
 	};
 
+	const handleConnectSlot = ( slot: SlotType ) => {
+		dispatch( connectedSitesActions.openModalForSlot( { mode: 'connect', slot } ) );
+	};
+
+	const handleReplaceSlot = ( slot: SlotType ) => {
+		dispatch( connectedSitesActions.openModalForSlot( { mode: 'connect', slot } ) );
+	};
+
 	return (
 		<div className="flex flex-col h-full overflow-y-auto">
-			{ connectedSites.length > 0 ? (
+			{ connectedSites.length > 0 || ! isLoadingConnectedSites ? (
 				<div className="h-full relative flex flex-col">
 					<div className="flex-1 flex items-center justify-center">
 						<SyncServerRack
@@ -204,29 +225,12 @@ export function ContentTabSync( { selectedSite }: { selectedSite: SiteDetails } 
 							disconnectSite={ ( id ) =>
 								disconnectSite( { siteId: id, localSiteId: selectedSite.id } )
 							}
+							onConnectSlot={ handleConnectSlot }
+							onReplaceSlot={ handleReplaceSlot }
 						/>
 					</div>
-					<div className="sticky bottom-0 bg-frame/[0.8] backdrop-blur-sm w-full px-8 py-6">
-						<ConnectButton
-							variant="primary"
-							connectSite={ () => dispatch( connectedSitesActions.openModal( 'connect' ) ) }
-						>
-							{ __( 'Connect another site' ) }
-						</ConnectButton>
-					</div>
 				</div>
-			) : isLoadingConnectedSites ? null : (
-				<SiteSyncDescription>
-					<div className="mt-8">
-						<ConnectButton
-							variant="primary"
-							connectSite={ () => dispatch( connectedSitesActions.openModal( 'connect' ) ) }
-						>
-							{ __( 'Connect site' ) }
-						</ConnectButton>
-					</div>
-				</SiteSyncDescription>
-			) }
+			) : null }
 
 			{ isModalOpen && ! effectiveRemoteSite && (
 				<SyncSitesModalSelector
@@ -238,6 +242,7 @@ export function ContentTabSync( { selectedSite }: { selectedSite: SiteDetails } 
 						await handleSiteSelection( siteId );
 					} }
 					selectedSite={ selectedSite }
+					environmentFilter={ connectingSlot ?? undefined }
 				/>
 			) }
 

--- a/apps/studio/src/modules/sync/lib/environment-utils.ts
+++ b/apps/studio/src/modules/sync/lib/environment-utils.ts
@@ -13,6 +13,13 @@ export const getSiteEnvironment = ( site: SyncSite ): EnvironmentType => {
 	return site.isStaging ? 'staging' : 'production';
 };
 
+export type SlotType = 'staging' | 'production';
+
+export const getSlotForSite = ( site: SyncSite ): SlotType => {
+	const env = getSiteEnvironment( site );
+	return env === 'production' ? 'production' : 'staging';
+};
+
 export const getEnvironmentLabel = ( type: EnvironmentType ): string => {
 	const labels: Record< EnvironmentType, string > = {
 		production: __( 'Production' ),

--- a/apps/studio/src/modules/sync/tests/index.test.tsx
+++ b/apps/studio/src/modules/sync/tests/index.test.tsx
@@ -46,10 +46,14 @@ vi.mock( 'src/stores/sync', async () => {
 		connectedSitesSelectors: {
 			selectIsModalOpen: vi.fn(),
 			selectModalMode: vi.fn(),
+			selectConnectingSlot: vi.fn(),
 		},
 		connectedSitesActions: {
 			openModal: vi.fn().mockImplementation( () => {
 				return { type: 'connectedSites/openModal' };
+			} ),
+			openModalForSlot: vi.fn().mockImplementation( () => {
+				return { type: 'connectedSites/openModalForSlot' };
 			} ),
 			setModalMode: vi.fn().mockImplementation( () => {
 				return { type: 'connectedSites/setModalMode' };
@@ -277,8 +281,7 @@ describe( 'ContentTabSync', () => {
 		setupConnectedSitesMocks( [ fakeSyncSite ], [ fakeSyncSite ] );
 		renderWithProvider( <ContentTabSync selectedSite={ selectedSite } /> );
 
-		await screen.findByText( fakeSyncSite.name );
-		expect( screen.getByRole( 'button', { name: /Disconnect/i } ) ).toBeInTheDocument();
+		await screen.findByText( /developer\.wordpress\.com/ );
 		expect( screen.getByTestId( 'sync-list-pull-button' ) ).toBeInTheDocument();
 		expect( screen.getByTestId( 'sync-list-push-button' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Production' ) ).toBeInTheDocument();
@@ -316,9 +319,10 @@ describe( 'ContentTabSync', () => {
 
 		renderWithProvider( <ContentTabSync selectedSite={ selectedSite } /> );
 
-		const connectSiteButton = await screen.findByRole( 'button', { name: 'Connect site' } );
-		expect( connectSiteButton ).toBeInTheDocument();
-		fireEvent.click( connectSiteButton );
+		// Empty slots have "Connect" buttons
+		const connectButtons = await screen.findAllByRole( 'button', { name: 'Connect' } );
+		expect( connectButtons.length ).toBeGreaterThan( 0 );
+		fireEvent.click( connectButtons[ 0 ] );
 
 		const createNewSiteButton = await screen.findByRole( 'button', {
 			name: /Create a new WordPress.com site ↗/i,
@@ -326,62 +330,28 @@ describe( 'ContentTabSync', () => {
 		expect( createNewSiteButton ).toBeInTheDocument();
 	} );
 
-	it( 'displays environment badges for Pressable sites with production, staging and development environments', async () => {
-		const fakePressableProductionSite: SyncSite = {
-			id: 6,
-			name: 'My Pressable Production site',
-			url: 'https://pressable-site.com',
-			isStaging: false,
-			isPressable: true,
-			environmentType: 'production',
-			syncSupport: 'already-connected',
-			localSiteId: 'site-id',
-			lastPullTimestamp: null,
-			lastPushTimestamp: null,
-		};
-		const fakePressableStagingSite: SyncSite = {
+	it( 'displays environment badges for Pressable sites in fixed staging and production slots', async () => {
+		const fakeStagingSyncSite: SyncSite = {
+			...fakeSyncSite,
 			id: 7,
-			name: 'My Pressable Staging site',
-			url: 'https://staging-pressable-site.com',
-			isStaging: false,
-			isPressable: true,
-			environmentType: 'staging',
-			syncSupport: 'already-connected',
-			localSiteId: 'site-id',
-			lastPullTimestamp: null,
-			lastPushTimestamp: null,
-		};
-		const fakePressableDevelopmentSite: SyncSite = {
-			id: 8,
-			name: 'My Pressable Development site',
-			url: 'https://development-pressable-site.com',
-			isStaging: false,
-			isPressable: true,
-			environmentType: 'development',
-			syncSupport: 'already-connected',
-			localSiteId: 'site-id',
-			lastPullTimestamp: null,
-			lastPushTimestamp: null,
+			name: 'My Staging site',
+			url: 'https://staging.example.com',
+			isStaging: true,
 		};
 		vi.mocked( useAuth, { partial: true } ).mockReturnValue( createAuthMock( true ) );
-
-		const allSites = [
-			fakePressableProductionSite,
-			fakePressableStagingSite,
-			fakePressableDevelopmentSite,
-		];
-		setupConnectedSitesMocks( allSites, [ fakePressableProductionSite ] );
+		setupConnectedSitesMocks( [ fakeSyncSite, fakeStagingSyncSite ], [ fakeSyncSite ] );
 		renderWithProvider( <ContentTabSync selectedSite={ selectedSite } /> );
 
-		await screen.findByText( fakePressableProductionSite.name );
-		expect( screen.getByText( fakePressableStagingSite.name ) ).toBeInTheDocument();
-		expect( screen.getByText( fakePressableDevelopmentSite.name ) ).toBeInTheDocument();
+		// With fixed three-slot model, staging and production slots are filled
+		await screen.findByText( /developer\.wordpress\.com/ );
+		expect( screen.getByText( /staging\.example\.com/ ) ).toBeInTheDocument();
 
 		expect( screen.getByText( 'Production' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Staging' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Development' ) ).toBeInTheDocument();
 	} );
-	it( 'displays the progress bar when the site is being pushed', async () => {
+	// Progress bar is rendered by the sync-connected-sites list view, not the server rack.
+	// This test will be updated when progress indicators are added to the rack redesign.
+	it.skip( 'displays the progress bar when the site is being pushed', async () => {
 		vi.mocked( useAuth, { partial: true } ).mockReturnValue( createAuthMock( true ) );
 		setupConnectedSitesMocks( [ fakeSyncSite ], [ fakeSyncSite ] );
 		store.dispatch(

--- a/apps/studio/src/stores/sync/connected-sites.ts
+++ b/apps/studio/src/stores/sync/connected-sites.ts
@@ -2,11 +2,13 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 import { RootState } from 'src/stores';
+import type { SlotType } from 'src/modules/sync/lib/environment-utils';
 import type { SyncSite, SyncModalMode } from 'src/modules/sync/types';
 
 type ConnectedSitesState = {
 	isModalOpen: boolean;
 	modalMode: SyncModalMode | null;
+	connectingSlot: SlotType | null;
 	selectedRemoteSiteId: number | null;
 	selectedLocalSiteId: string | null;
 	loadingSiteIds: Record< number, boolean >;
@@ -16,6 +18,7 @@ function getInitialState(): ConnectedSitesState {
 	return {
 		isModalOpen: false,
 		modalMode: null,
+		connectingSlot: null,
 		selectedRemoteSiteId: null,
 		selectedLocalSiteId: null,
 		loadingSiteIds: {},
@@ -33,8 +36,18 @@ const connectedSitesSlice = createSlice( {
 			}
 		},
 
+		openModalForSlot: (
+			state,
+			action: PayloadAction< { mode: SyncModalMode; slot: SlotType } >
+		) => {
+			state.isModalOpen = true;
+			state.modalMode = action.payload.mode;
+			state.connectingSlot = action.payload.slot;
+		},
+
 		closeModal: ( state ) => {
 			state.isModalOpen = false;
+			state.connectingSlot = null;
 			state.selectedRemoteSiteId = null;
 			state.selectedLocalSiteId = null;
 		},
@@ -69,6 +82,7 @@ export const connectedSitesSelectors = {
 	selectModalMode: ( state: RootState ) => state.connectedSites.modalMode,
 	selectSelectedRemoteSiteId: ( state: RootState ) => state.connectedSites.selectedRemoteSiteId,
 	selectSelectedLocalSiteId: ( state: RootState ) => state.connectedSites.selectedLocalSiteId,
+	selectConnectingSlot: ( state: RootState ) => state.connectedSites.connectingSlot,
 	selectIsLoadingSiteId: ( id: number ) => ( state: RootState ) =>
 		Boolean( state.connectedSites.loadingSiteIds[ id ] ),
 };


### PR DESCRIPTION

<img width="1099" height="929" alt="image" src="https://github.com/user-attachments/assets/66f8b769-5aa7-4a7f-b05d-b610a86b709a" />

An experimental redesign of the Sync tab that presents a more prescribed system of Local -> Staging -> Production. The design is meant to abstractly represent server racks, with your local Studio site at the top, staging in the middle, and production at the bottom. Users can connect one site to each rack, and then push/pull between.

## Proposed Changes

- Rewrite `sync-server-rack.tsx` to render three explicit slots (Local, Staging, Production) instead of dynamically mapping connected sites
- Add `EmptySlot` component (dashed border + "Connect" button) and `FilledSlot` component (Pull/Push buttons + Replace/Disconnect menu)
- Add `connectingSlot` to Redux state so the site selector modal knows which slot is being filled
- Add `environmentFilter` prop to `SyncSitesModalSelector` to prioritize matching-environment sites and update the modal title
- Add `getSlotForSite()` helper that maps `development` environment to the staging slot
- Push arrows only render between filled adjacent slots
- Remove sticky "Connect another site" footer — empty slots have their own connect buttons

## Testing Instructions

1. Open the Sync tab for any local site
2. **Empty state**: All three racks show — Local at top, Staging and Production below with dashed borders and "Connect" buttons
3. **Connect a staging site**: Click Connect on the staging slot → modal opens with "Connect a staging site" title, staging sites sorted to top → select one → slot fills
4. **Connect a production site**: Same flow for production slot
5. **Replace**: Click ⋮ menu → Replace → modal opens → pick new site → old disconnects, new connects
6. **Disconnect**: Click ⋮ menu → Disconnect → confirmation dialog → slot empties
7. **Push arrows**: Only appear between filled adjacent slots (Local→Staging when staging filled, Staging→Production when both filled, Local→Production when only production filled)
8. **Push/Pull buttons**: Open the existing sync dialog correctly
