### PR TITLE
Use sidebar chrome color for onboarding left panel in dark mode

### DIFF
--- a/apps/studio/src/modules/onboarding/index.tsx
+++ b/apps/studio/src/modules/onboarding/index.tsx
@@ -15,7 +15,7 @@ const GradientBox = () => {
 			className="gap-0 flex flex-col font-normal text-[42px] leading-[42px] text-white"
 		>
 			<div className="flex flex-col gap-1 relative self-stretch pb-1">
-				<div className="absolute inset-0 bg-gradient-to-b from-[var(--color-frame-theme)] to-[var(--color-frame-theme)]/60"></div>
+				<div className="absolute inset-0 bg-gradient-to-b from-[var(--color-frame-theme)] to-[var(--color-frame-theme)]/60 dark:from-chrome dark:to-chrome/60"></div>
 				<p>{ __( 'Imagine' ) }</p>
 				<p>{ __( 'Create' ) }</p>
 				<p>{ __( 'Design' ) }</p>
@@ -49,7 +49,7 @@ export function Onboarding() {
 
 	return (
 		<div className="flex flex-row flex-grow" data-testid="onboarding">
-			<div className="w-1/2 bg-frame-theme pb-[50px] pt-[46px] px-[50px] flex flex-col justify-between">
+			<div className="w-1/2 bg-frame-theme dark:bg-chrome pb-[50px] pt-[46px] px-[50px] flex flex-col justify-between">
 				<div className="flex justify-start items-center gap-1 mt-6">
 					<StudioLogo className="fill-white" />
 				</div>


### PR DESCRIPTION
## Related issues

- Fixes STU-1433

## How AI was used in this PR

Claude identified the relevant Tailwind color tokens and applied `dark:bg-chrome` and `dark:from-chrome`/`dark:to-chrome` variants to the onboarding left panel. Changes were reviewed before committing.

## Proposed Changes

This is not too critical as the default color is light, so currently users won't see the onboarding on dark mode, but it's better to keep improving the dark mode screens.
- Update the onboarding screen for dark mode by changing the left panel blue to black.



## Testing Instructions

- Remove the `"onboardingCompleted": true` and set `"colorScheme": "dark"` in `~/Library/Application\ Support/Studio/appdata-v1.json`
- Remove all your sites to see the onboarding screen
- Start the app with `npm start`
- Verify the left panel background is dark (`#1E1E1E`) instead of blue
- Switch to light mode and verify the left panel is still blue as before

| Before | After |
|--------|--------|
| <img width="1012" height="712" alt="Screenshot 2026-03-20 at 13 18 38" src="https://github.com/user-attachments/assets/3353cda7-6bd6-435b-b8bb-2db86907ec81" /> | <img width="1012" height="712" alt="Screenshot 2026-03-20 at 13 23 05" src="https://github.com/user-attachments/assets/08f7d186-6802-486f-a1e9-8842ea33dd97" /> |  


## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?