### PR TITLE
Fix Installed labels in the dark mode

### DIFF
--- a/apps/studio/src/components/ai-settings-modal.tsx
+++ b/apps/studio/src/components/ai-settings-modal.tsx
@@ -114,8 +114,8 @@ function AgentInstructionsPanel( { siteId }: { siteId: string } ) {
 										{ config.displayName }
 									</span>
 									{ status.exists && (
-										<span className="inline-flex items-center gap-1 text-[11px] text-[#1a6928] bg-[#ceead6] dark:text-[#6ee7a0] dark:bg-[#1a3a24] px-2 py-0.5 rounded-full">
-											<Icon icon={ check } size={ 12 } />
+										<span className="inline-flex items-center gap-1 text-[11px] text-green-900 bg-green-50 dark:!text-green-300 dark:bg-green-950 px-2 py-0.5 rounded-full">
+											<Icon className="dark:fill-green-300" icon={ check } size={ 12 } />
 											{ __( 'Installed' ) }
 										</span>
 									) }

--- a/apps/studio/src/components/ai-settings-modal.tsx
+++ b/apps/studio/src/components/ai-settings-modal.tsx
@@ -76,8 +76,8 @@ function AgentInstructionsPanel( { siteId }: { siteId: string } ) {
 		<div className="flex flex-col gap-4">
 			<div className="flex items-center justify-between">
 				<div>
-					<h3 className="text-sm font-medium text-gray-900">{ __( 'Agent instructions' ) }</h3>
-					<p className="text-xs text-gray-500 mt-0.5">
+					<h3 className="text-sm font-medium text-frame-text">{ __( 'Agent instructions' ) }</h3>
+					<p className="text-xs text-frame-text-secondary mt-0.5">
 						{ __( 'Install instructions so agents know how to use Studio' ) }
 					</p>
 				</div>
@@ -94,7 +94,7 @@ function AgentInstructionsPanel( { siteId }: { siteId: string } ) {
 			</div>
 
 			{ error && (
-				<div className="bg-red-50 border border-red-200 text-red-700 px-3 py-2 rounded text-sm">
+				<div className="bg-frame-surface border border-frame-error/30 text-frame-error px-3 py-2 rounded text-sm">
 					{ error }
 				</div>
 			) }
@@ -110,15 +110,19 @@ function AgentInstructionsPanel( { siteId }: { siteId: string } ) {
 						>
 							<div className="flex-1 min-w-0 pr-3">
 								<div className="flex items-center gap-2">
-									<span className="text-sm font-medium text-gray-900">{ config.displayName }</span>
+									<span className="text-sm font-medium text-frame-text">
+										{ config.displayName }
+									</span>
 									{ status.exists && (
-										<span className="inline-flex items-center gap-1 text-[11px] text-green-700 bg-green-50 px-2 py-0.5 rounded-full">
+										<span className="inline-flex items-center gap-1 text-[11px] text-[#1a6928] bg-[#ceead6] dark:text-[#6ee7a0] dark:bg-[#1a3a24] px-2 py-0.5 rounded-full">
 											<Icon icon={ check } size={ 12 } />
 											{ __( 'Installed' ) }
 										</span>
 									) }
 								</div>
-								<div className="text-xs text-gray-500">{ __( config.description ) }</div>
+								<div className="text-xs text-frame-text-secondary">
+									{ __( config.description ) }
+								</div>
 							</div>
 							<div className="flex items-center gap-2 flex-shrink-0">
 								{ status.exists && (
@@ -199,15 +203,15 @@ function WordPressSkillsPanel( { siteId }: { siteId: string } ) {
 		<div className="flex flex-col gap-4">
 			<div className="flex items-center justify-between">
 				<div>
-					<h3 className="text-sm font-medium text-gray-900">{ __( 'WordPress skills' ) }</h3>
-					<p className="text-xs text-gray-500 mt-0.5">
+					<h3 className="text-sm font-medium text-frame-text">{ __( 'WordPress skills' ) }</h3>
+					<p className="text-xs text-frame-text-secondary mt-0.5">
 						{ __( 'WordPress development skills for AI agents' ) }
 					</p>
 				</div>
 			</div>
 
 			{ error && (
-				<div className="bg-red-50 border border-red-200 text-red-700 px-3 py-2 rounded text-sm">
+				<div className="bg-frame-surface border border-frame-error/30 text-frame-error px-3 py-2 rounded text-sm">
 					{ error }
 				</div>
 			) }
@@ -216,22 +220,22 @@ function WordPressSkillsPanel( { siteId }: { siteId: string } ) {
 				<div className="flex items-center justify-between px-3 py-2.5">
 					<div className="flex-1 min-w-0 pr-3">
 						<div className="flex items-center gap-2">
-							<span className="text-sm font-medium text-gray-900">
+							<span className="text-sm font-medium text-frame-text">
 								{ __( 'WordPress Skills' ) }
 							</span>
 							{ allInstalled && (
-								<span className="inline-flex items-center gap-1 text-[11px] text-green-700 bg-green-50 px-2 py-0.5 rounded-full">
+								<span className="inline-flex items-center gap-1 text-[11px] text-[#1a6928] bg-[#ceead6] dark:text-[#6ee7a0] dark:bg-[#1a3a24] px-2 py-0.5 rounded-full">
 									<Icon icon={ check } size={ 12 } />
 									{ __( 'Installed' ) }
 								</span>
 							) }
 							{ ! allInstalled && installedCount > 0 && (
-								<span className="inline-flex items-center gap-1 text-[11px] text-orange-700 bg-orange-50 px-2 py-0.5 rounded-full">
+								<span className="inline-flex items-center gap-1 text-[11px] text-frame-text-secondary bg-frame-surface px-2 py-0.5 rounded-full">
 									{ `${ installedCount }/${ BUNDLED_SKILLS.length }` }
 								</span>
 							) }
 						</div>
-						<div className="text-xs text-gray-500">
+						<div className="text-xs text-frame-text-secondary">
 							{ __( 'Plugins, blocks, themes, REST API, and WP-CLI skills' ) }
 						</div>
 					</div>


### PR DESCRIPTION
## Related issues

- Fixes https://github.com/Automattic/studio/issues/2865

## Proposed Changes

- Improve installed labels and ai settings in dark mode

## Testing Instructions

- Start the app with `ENABLE_AGENT_SUITE=true npm start`
- Navigate to `Assistant` tab
- Open the settings from the three dots by the input field
- Verify the "Installed" labels are readable in both light and dark mode
- Verify headings, descriptions, and error states also render correctly in both modes

| Before | After | Light |
|--------|--------|----|
| <img width="1012" height="712" alt="Screenshot 2026-03-20 at 14 04 45" src="https://github.com/user-attachments/assets/bbd5de72-cf46-49a0-b889-0cc37e143b56" /> |<img width="1012" height="712" alt="Screenshot 2026-03-20 at 14 40 11" src="https://github.com/user-attachments/assets/31877073-1aaa-4f9d-b33d-342e3c9630a0" /> | <img width="1012" height="712" alt="Screenshot 2026-03-20 at 14 05 56" src="https://github.com/user-attachments/assets/5c1cb8c3-ce72-4df1-a222-4f94077c3d38" /> |


## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?