### PR TITLE
Studio: Borders don't have correct colors in dark mode

### DIFF
--- a/apps/studio/src/index.css
+++ b/apps/studio/src/index.css
@@ -436,6 +436,14 @@ div:has( > progress ) > div:first-child {
 		background: var( --color-frame-tab-active );
 	}
 
+	/* Secondary button — use the same border token as the rest of the UI.
+	   !important is required because the WP components <link> is appended to the
+	   DOM after the app CSS, so it wins same-specificity battles regardless of order.
+	   :not(:focus-visible) preserves the keyboard-focus ring. */
+	.components-button.is-secondary:not( :focus-visible ) {
+		box-shadow: inset 0 0 0 1px var( --color-frame-border ) !important;
+	}
+
 	/* Buttons — tertiary/link get secondary text, hover brightens */
 	.components-button.is-tertiary,
 	.components-button.is-link:not( .is-destructive ) {

--- a/apps/studio/src/index.css
+++ b/apps/studio/src/index.css
@@ -436,10 +436,7 @@ div:has( > progress ) > div:first-child {
 		background: var( --color-frame-tab-active );
 	}
 
-	/* Secondary button — use the same border token as the rest of the UI.
-	   !important is required because the WP components <link> is appended to the
-	   DOM after the app CSS, so it wins same-specificity battles regardless of order.
-	   :not(:focus-visible) preserves the keyboard-focus ring. */
+	/* Secondary button border — !important overrides WP CSS loaded after app CSS. */
 	.components-button.is-secondary:not( :focus-visible ) {
 		box-shadow: inset 0 0 0 1px var( --color-frame-border ) !important;
 	}


### PR DESCRIPTION
## Related issues

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Fixes STU-1430

## How AI was used in this PR

<!--
Help reviewers understand what to look for and verify that you've reviewed the code yourself.
-->
I used it to check what options we have before deciding on the solution.


## Proposed Changes

This PR makes sure that the borders on buttons such as `Site Editor` etc. stay consistent in both light and dark modes. Before:

<img width="534" height="206" alt="Screenshot 2026-03-24 at 2 12 39 PM" src="https://github.com/user-attachments/assets/c844f592-7666-49cc-a06b-9a91cb1e14d6" />

After:

<img width="534" height="206" alt="Screenshot 2026-03-24 at 2 12 39 PM" src="https://github.com/user-attachments/assets/527609a7-bbbc-4b9b-9288-0e982b0abfff" />


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
* Start Studio with `npm start`
* Navigate to `Overview` tab
* Ensure that you are using the dark mode
* Confirm the borders have correct light gray color

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
