### PR TITLE
Remove feature flag from AI instructions install in CLI

### DIFF
--- a/apps/cli/commands/site/create.ts
+++ b/apps/cli/commands/site/create.ts
@@ -249,15 +249,13 @@ export async function runCommand(
 			isSqliteUpdated ? __( 'SQLite integration configured' ) : __( 'SQLite integration skipped' )
 		);
 
-		if ( process.env.ENABLE_AGENT_SUITE === 'true' ) {
-			try {
-				await installAiInstructionsToSite( sitePath, getAiInstructionsPath() );
-			} catch ( error ) {
-				logger.reportError(
-					new LoggerError( __( 'Failed to install AI instructions. Proceeding anyway…' ), error ),
-					false
-				);
-			}
+		try {
+			await installAiInstructionsToSite( sitePath, getAiInstructionsPath() );
+		} catch ( error ) {
+			logger.reportError(
+				new LoggerError( __( 'Failed to install AI instructions. Proceeding anyway…' ), error ),
+				false
+			);
 		}
 
 		logger.reportStart( LoggerAction.ASSIGN_PORT, __( 'Assigning port…' ) );

--- a/apps/studio/src/ipc-handlers.ts
+++ b/apps/studio/src/ipc-handlers.ts
@@ -18,7 +18,6 @@ import os from 'os';
 import nodePath from 'path';
 import * as Sentry from '@sentry/electron/main';
 import {
-	installAiInstructionsToSite,
 	installSkillToSite,
 	removeSkillFromSite,
 	updateManagedInstructionFiles,
@@ -58,7 +57,7 @@ import {
 	trustRootCA,
 } from 'src/lib/certificate-manager';
 import { simplifyErrorForDisplay } from 'src/lib/error-formatting';
-import { buildFeatureFlags, getFeatureFlagFromEnv } from 'src/lib/feature-flags';
+import { buildFeatureFlags } from 'src/lib/feature-flags';
 import { getImageData } from 'src/lib/get-image-data';
 import { exportBackup } from 'src/lib/import-export/export/export-manager';
 import { ExportOptions } from 'src/lib/import-export/export/types';
@@ -410,13 +409,6 @@ export async function createSite(
 		// If the site is running after creation, fetch theme details and update thumbnail
 		if ( server.details.running ) {
 			void loadThemeDetails( event, server.details.id );
-		}
-
-		// Install AI instructions and skills into the new site
-		if ( getFeatureFlagFromEnv( 'enableAgentSuite' ) ) {
-			void installAiInstructionsToSite( path, getAiInstructionsPath() ).catch( ( error ) => {
-				console.error( '[ai-instructions] Failed to install AI instructions to new site:', error );
-			} );
 		}
 
 		return server.details;


### PR DESCRIPTION
## Related issues

- Related to STU-1452

## How AI was used in this PR

Claude identified that the desktop app already installs AI instructions without a feature flag, while the CLI path was still gated behind `ENABLE_AGENT_SUITE`. The change was pair-programmed with Claude.

## Proposed Changes

- Remove the ENABLE_AGENT_SUITE feature flag wrapping `installAiInstructionsToSite()` in the CLI `site create` command
- AI instructions (AGENTS.md, CLAUDE.md, STUDIO.md) are now installed unconditionally when creating a site via CLI, or the desktop app.

## Testing Instructions

### From CLI

- Build the CLI: `npm run cli:build`
- Create a new site via CLI without setting `ENABLE_AGENT_SUITE`: `node apps/cli/dist/cli/main.js site create /tmp/test-site`
- Verify that `AGENTS.md`, `CLAUDE.md`, and `STUDIO.md` exist in the site root

### From Desktop

- Run `npm start`
- Create a new site
- Verify that `AGENTS.md`, `CLAUDE.md`, and `STUDIO.md` exist in the site root


https://github.com/user-attachments/assets/b6b9e937-b358-41a9-93b0-0eb92977fa41



## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?