### PR TITLE
Improve CLI config migration prompt

### DIFF
--- a/apps/cli/lib/dependency-management/setup.ts
+++ b/apps/cli/lib/dependency-management/setup.ts
@@ -66,7 +66,6 @@ async function copyBundledSqlite() {
 	const isBundledVersionNewer =
 		installedSqliteVersion && semver.gt( bundledSqliteVersion, installedSqliteVersion );
 	if ( ! isSqliteInstalled || isBundledVersionNewer ) {
-		console.log( `Copying bundled SQLite version ${ bundledSqliteVersion }…` );
 		await recursiveCopyDirectory( bundledSqlitePath, getSqlitePluginPath() );
 	}
 }
@@ -145,13 +144,13 @@ export async function setupServerFiles() {
 		[ 'phpMyAdmin', copyBundledPhpMyAdmin ],
 	];
 
-	await Promise.all(
-		steps.map( ( [ name, step ] ) =>
-			step().catch( ( error ) => {
-				console.error( `Failed to set up dependency ${ name }:`, error );
-			} )
-		)
-	);
+	for ( const [ name, step ] of steps ) {
+		try {
+			await step();
+		} catch ( error ) {
+			console.error( `Failed to set up dependency ${ name }:`, error );
+		}
+	}
 }
 
 export async function updateServerFiles() {

--- a/apps/cli/migrations/00-check-studio-compatibility.ts
+++ b/apps/cli/migrations/00-check-studio-compatibility.ts
@@ -98,12 +98,12 @@ export const checkStudioCompatibilityForInitialMigration: Migration = {
 
 		console.log(
 			__(
-				"Old Studio config was found, but Studio doesn't appear to be installed. Reset this config and start clean? You can re-add site directories later.\n\nIf Studio is installed, open it, update it, then run the CLI again."
+				'Old Studio config was found, but Studio no longer appears to be installed.\nReset this config and start clean? You can re-add site directories later.\n\nIf Studio is installed, open it, update it, then run the CLI again.\n'
 			)
 		);
 
 		const shouldRenameOldConfigFile = await confirm( {
-			message: __( 'Reset config and start clean? (Choosing No will exit the CLI.' ),
+			message: __( 'Reset config and start clean? (Choosing No will exit the CLI)' ),
 			default: false,
 		} ).catch( () => false );
 
@@ -113,6 +113,7 @@ export const checkStudioCompatibilityForInitialMigration: Migration = {
 				path.join( getAppdataDirectory(), 'appdata-v1.deprecated.json' )
 			);
 		} else {
+			console.log( __( 'Exiting…' ) );
 			process.exit( 1 );
 		}
 	},

--- a/apps/cli/migrations/00-check-studio-compatibility.ts
+++ b/apps/cli/migrations/00-check-studio-compatibility.ts
@@ -57,14 +57,11 @@ function isStudioInstalled() {
 }
 
 /**
- * Checks compatibility between the standalone CLI and the installed Studio Desktop app.
+ * Ensures CLI/Studio config compatibility during initial migration.
  *
- * If Studio Desktop is installed (platform-specific appdata exists) but the shared
- * config at ~/.studio/app.json is missing, it means Studio hasn't been updated
- * to a version that supports the shared location. In that case, prompt the user
- * to update Studio.
- *
- * Always needs to run. Throws if incompatible.
+ * If `~/.studio/app.json` is missing but legacy appdata exists:
+ * - throw when Studio is installed (Studio must migrate first)
+ * - otherwise offer to reset the legacy config
  */
 export const checkStudioCompatibilityForInitialMigration: Migration = {
 	async needsToRun() {
@@ -84,14 +81,14 @@ export const checkStudioCompatibilityForInitialMigration: Migration = {
 		if ( await isStudioInstalled() ) {
 			throw new LoggerError(
 				__(
-					`It looks like you have Studio installed and you're trying to run a newer version of the CLI. Your config data needs to be updated to the new CLI-compatible format first. Please open Studio and update to the latest version before running the CLI.`
+					`Studio is installed, but your config needs a Studio update before this CLI can run. Open Studio, update it, then try again.`
 				)
 			);
 		}
 
 		console.log(
 			__(
-				'It looks like there are old Studio config files on your system, but the Studio app is not installed. Would you like to reset your config and start with a clean slate? You can always add your existing site directories to Studio again.\n\nIf we are wrong, and Studio is in fact installed, then please open Studio and update to the latest version before running the CLI.'
+				'Old Studio config files were found, but Studio does not appear to be installed. Start clean by resetting this config? You can re-add your site directories later.\n\nIf Studio is installed, open it, update it, then run the CLI again.'
 			)
 		);
 

--- a/apps/cli/migrations/00-check-studio-compatibility.ts
+++ b/apps/cli/migrations/00-check-studio-compatibility.ts
@@ -1,4 +1,4 @@
-import { exec } from 'child_process';
+import { execFile } from 'child_process';
 import fs from 'fs';
 import path from 'path';
 import { confirm } from '@inquirer/prompts';
@@ -9,13 +9,17 @@ import type { Migration } from '@studio/common/lib/migration';
 
 function isInstalledOnMacOs() {
 	return new Promise< boolean >( ( resolve, reject ) => {
-		exec( `mdfind "kMDItemCFBundleIdentifier == 'com.electron.studio'"`, ( error, stdout ) => {
-			if ( error ) {
-				reject( error );
-			} else {
-				resolve( stdout.trim() !== '' );
+		execFile(
+			'mdfind',
+			[ "kMDItemCFBundleIdentifier == 'com.electron.studio'" ],
+			( error, stdout ) => {
+				if ( error ) {
+					reject( error );
+				} else {
+					resolve( stdout.trim() !== '' );
+				}
 			}
-		} );
+		);
 	} );
 }
 
@@ -31,8 +35,14 @@ function isInstalledOnWindows() {
 	}
 
 	return new Promise< boolean >( ( resolve, reject ) => {
-		exec(
-			`powershell -NoProfile -Command 'Get-AppxPackage -Name "${ MICROSOFT_STORE_IDENTITY_NAME }" -ErrorAction SilentlyContinue'`,
+		execFile(
+			'powershell.exe',
+			[
+				'-NoProfile',
+				'-NonInteractive',
+				'-Command',
+				`Get-AppxPackage -Name "${ MICROSOFT_STORE_IDENTITY_NAME }" -ErrorAction SilentlyContinue`,
+			],
 			( error, stdout ) => {
 				if ( error ) {
 					reject( error );

--- a/apps/cli/migrations/00-check-studio-compatibility.ts
+++ b/apps/cli/migrations/00-check-studio-compatibility.ts
@@ -95,7 +95,7 @@ export const checkStudioCompatibilityForInitialMigration: Migration = {
 		const shouldRenameOldConfigFile = await confirm( {
 			message: __( 'Reset config and start clean? (Choosing No will exit the CLI.' ),
 			default: false,
-		} );
+		} ).catch( () => false );
 
 		if ( shouldRenameOldConfigFile ) {
 			fs.renameSync(

--- a/apps/cli/migrations/00-check-studio-compatibility.ts
+++ b/apps/cli/migrations/00-check-studio-compatibility.ts
@@ -1,10 +1,60 @@
+import { exec } from 'child_process';
 import fs from 'fs';
 import path from 'path';
+import { confirm } from '@inquirer/prompts';
 import { getAppConfigPath } from '@studio/common/lib/well-known-paths';
 import { __ } from '@wordpress/i18n';
 import { getAppdataDirectory } from 'cli/lib/server-files';
 import { LoggerError } from 'cli/logger';
 import type { Migration } from '@studio/common/lib/migration';
+
+function isInstalledOnMacOs() {
+	return new Promise< boolean >( ( resolve, reject ) => {
+		exec( `mdfind "kMDItemCFBundleIdentifier == 'com.electron.studio'"`, ( error, stdout ) => {
+			if ( error ) {
+				reject( error );
+			} else {
+				resolve( stdout.trim() !== '' );
+			}
+		} );
+	} );
+}
+
+const MICROSOFT_STORE_IDENTITY_NAME = '22490Automattic.StudiobyWordPress.com';
+
+function isInstalledOnWindows() {
+	const localAppData = process.env.LOCALAPPDATA;
+	if ( localAppData ) {
+		const studioExecutablePath = path.join( localAppData, 'studio_app', 'Studio.exe' );
+		if ( fs.existsSync( studioExecutablePath ) ) {
+			return Promise.resolve( true );
+		}
+	}
+
+	return new Promise< boolean >( ( resolve, reject ) => {
+		exec(
+			`powershell -NoProfile -Command 'Get-AppxPackage -Name "${ MICROSOFT_STORE_IDENTITY_NAME }" -ErrorAction SilentlyContinue'`,
+			( error, stdout ) => {
+				if ( error ) {
+					reject( error );
+				} else {
+					resolve( stdout.trim() !== '' );
+				}
+			}
+		);
+	} );
+}
+
+function isStudioInstalled() {
+	switch ( process.platform ) {
+		case 'darwin':
+			return isInstalledOnMacOs();
+		case 'win32':
+			return isInstalledOnWindows();
+		default:
+			return Promise.resolve( false );
+	}
+}
 
 /**
  * Checks compatibility between the standalone CLI and the installed Studio Desktop app.
@@ -26,11 +76,34 @@ export const checkStudioCompatibilityForInitialMigration: Migration = {
 		}
 
 		const oldAppdataPath = path.join( getAppdataDirectory(), 'appdata-v1.json' );
-		if ( fs.existsSync( oldAppdataPath ) ) {
+
+		if ( ! fs.existsSync( oldAppdataPath ) ) {
+			return;
+		}
+
+		if ( await isStudioInstalled() ) {
 			throw new LoggerError(
 				__(
-					'A newer version of Studio is required. Please update the Studio desktop app to continue using the CLI.'
+					`It looks like you have Studio installed and you're trying to run a newer version of the CLI. Your config data needs to be updated to the new CLI-compatible format first. Please open Studio and update to the latest version before running the CLI.`
 				)
+			);
+		}
+
+		console.log(
+			__(
+				'It looks like there are old Studio config files on your system, but the Studio app is not installed. Would you like to reset your config and start with a clean slate? You can always add your existing site directories to Studio again.\n\nIf we are wrong, and Studio is in fact installed, then please open Studio and update to the latest version before running the CLI.'
+			)
+		);
+
+		const shouldRenameOldConfigFile = await confirm( {
+			message: __( 'Start clean?' ),
+			default: false,
+		} );
+
+		if ( shouldRenameOldConfigFile ) {
+			fs.renameSync(
+				oldAppdataPath,
+				path.join( getAppdataDirectory(), 'appdata-v1.deprecated.json' )
 			);
 		}
 	},

--- a/apps/cli/migrations/00-check-studio-compatibility.ts
+++ b/apps/cli/migrations/00-check-studio-compatibility.ts
@@ -5,7 +5,6 @@ import { confirm } from '@inquirer/prompts';
 import { getAppConfigPath } from '@studio/common/lib/well-known-paths';
 import { __ } from '@wordpress/i18n';
 import { getAppdataDirectory } from 'cli/lib/server-files';
-import { LoggerError } from 'cli/logger';
 import type { Migration } from '@studio/common/lib/migration';
 
 function isInstalledOnMacOs() {
@@ -79,21 +78,22 @@ export const checkStudioCompatibilityForInitialMigration: Migration = {
 		}
 
 		if ( await isStudioInstalled() ) {
-			throw new LoggerError(
+			console.error(
 				__(
-					`Studio is installed, but your config needs a Studio update before this CLI can run. Open Studio, update it, then try again.`
+					`Studio is installed, but your config must be migrated by Studio before this CLI can run. Open Studio, update it, then try again.`
 				)
 			);
+			process.exit( 1 );
 		}
 
 		console.log(
 			__(
-				'Old Studio config files were found, but Studio does not appear to be installed. Start clean by resetting this config? You can re-add your site directories later.\n\nIf Studio is installed, open it, update it, then run the CLI again.'
+				"Old Studio config was found, but Studio doesn't appear to be installed. Reset this config and start clean? You can re-add site directories later.\n\nIf Studio is installed, open it, update it, then run the CLI again."
 			)
 		);
 
 		const shouldRenameOldConfigFile = await confirm( {
-			message: __( 'Start clean?' ),
+			message: __( 'Reset config and start clean? (Choosing No will exit the CLI.' ),
 			default: false,
 		} );
 
@@ -102,6 +102,8 @@ export const checkStudioCompatibilityForInitialMigration: Migration = {
 				oldAppdataPath,
 				path.join( getAppdataDirectory(), 'appdata-v1.deprecated.json' )
 			);
+		} else {
+			process.exit( 1 );
 		}
 	},
 };

--- a/apps/cli/migrations/00-check-studio-compatibility.ts
+++ b/apps/cli/migrations/00-check-studio-compatibility.ts
@@ -98,7 +98,7 @@ export const checkStudioCompatibilityForInitialMigration: Migration = {
 
 		console.log(
 			__(
-				'Old Studio config was found, but Studio no longer appears to be installed.\nReset this config and start clean? You can re-add site directories later.\n\nIf Studio is installed, open it, update it, then run the CLI again.\n'
+				'Old Studio config was found, but Studio no longer appears to be installed.\nReset this config and start clean? You can re-add site directories later.\n\nIf Studio is actually installed, open it, update it, then run the CLI again.\n'
 			)
 		);
 


### PR DESCRIPTION
## Related issues

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

- Related to p1774349350957349-slack-C06DRMD6VPZ

## How AI was used in this PR

<!--
Help reviewers understand what to look for and verify that you've reviewed the code yourself.
-->

To help refine the natural language phrasing and to generate initial implementations for the "is installed" checks.

## Proposed Changes

If the user is trying the npm version of the CLI and has old Studio config files on their computer but Studio isn't installed, this PR changes the CLI's behavior to offer to reset the config by renaming `appdata-v1.json` to `appdata-v1.deprecated.json`. This makes it so this "migration" gate won't get tripped up the next time the CLI launches. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

I'll test this more thoroughly, too, but start by reviewing the phrasing and the logic.

To test the behavior, do `npm run cli:build` and `node apps/cli/dist/cli/main.js site create`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?