### PR TITLE
Update STUDIO.md to CLI site start

### DIFF
--- a/apps/cli/commands/site/start.ts
+++ b/apps/cli/commands/site/start.ts
@@ -1,3 +1,4 @@
+import { updateManagedInstructionFiles } from '@studio/common/lib/agent-skills';
 import { SiteCommandLoggerAction as LoggerAction } from '@studio/common/logger-actions';
 import { __ } from '@wordpress/i18n';
 import {
@@ -6,6 +7,7 @@ import {
 	updateSiteLatestCliPid,
 } from 'cli/lib/cli-config/sites';
 import { connectToDaemon, disconnectFromDaemon } from 'cli/lib/daemon-client';
+import { getAiInstructionsPath } from 'cli/lib/server-files';
 import { logSiteDetails, openSiteInBrowser, setupCustomDomain } from 'cli/lib/site-utils';
 import { keepSqliteIntegrationUpdated } from 'cli/lib/sqlite-integration';
 import { isServerRunning, startWordPressServer } from 'cli/lib/wordpress-server-manager';
@@ -51,6 +53,15 @@ export async function runCommand(
 		);
 		await keepSqliteIntegrationUpdated( sitePath );
 		logger.reportSuccess( __( 'SQLite integration configured as needed' ) );
+
+		try {
+			await updateManagedInstructionFiles( sitePath, getAiInstructionsPath() );
+		} catch ( error ) {
+			logger.reportError(
+				new LoggerError( __( 'Failed to update AI instructions. Proceeding anyway…' ), error ),
+				false
+			);
+		}
 
 		logger.reportStart( LoggerAction.START_SITE, __( 'Starting WordPress server…' ) );
 		try {

--- a/apps/studio/src/ipc-handlers.ts
+++ b/apps/studio/src/ipc-handlers.ts
@@ -21,7 +21,6 @@ import {
 	installAiInstructionsToSite,
 	installSkillToSite,
 	removeSkillFromSite,
-	updateManagedInstructionFiles,
 } from '@studio/common/lib/agent-skills';
 import { validateBlueprintData } from '@studio/common/lib/blueprint-validation';
 import { parseCliError, errorMessageContains } from '@studio/common/lib/cli-error';
@@ -597,13 +596,6 @@ export async function startServer( event: IpcMainInvokeEvent, id: string ): Prom
 	if ( server.details.running ) {
 		void loadThemeDetails( event, id );
 	}
-
-	// Keep managed instruction files (STUDIO.md, CLAUDE.md) up-to-date
-	void updateManagedInstructionFiles( server.details.path, getAiInstructionsPath() ).catch(
-		( error ) => {
-			console.error( '[ai-instructions] Failed to update managed instruction files:', error );
-		}
-	);
 
 	console.log( `Server started for '${ server.details.name }'` );
 }

--- a/tools/common/lib/agent-skills.ts
+++ b/tools/common/lib/agent-skills.ts
@@ -7,7 +7,7 @@ import { isErrnoException } from './is-errno-exception';
  * Managed instruction files that are always kept up-to-date on server start.
  * These are overwritten with the bundled version whenever they already exist in a site.
  */
-const MANAGED_INSTRUCTION_FILES = [ 'STUDIO.md', 'CLAUDE.md' ];
+const MANAGED_INSTRUCTION_FILES = [ 'STUDIO.md' ];
 
 /**
  * Install all bundled AI instructions and skills from a source directory into a site.

--- a/tools/common/lib/tests/agent-skills.test.ts
+++ b/tools/common/lib/tests/agent-skills.test.ts
@@ -319,7 +319,7 @@ describe( 'updateManagedInstructionFiles', () => {
 		vi.mocked( fs.copyFile ).mockResolvedValue( undefined );
 	} );
 
-	it( 'updates STUDIO.md and CLAUDE.md when both exist in the site', async () => {
+	it( 'updates STUDIO.md when it exists in the site', async () => {
 		vi.mocked( pathExists ).mockResolvedValue( true );
 
 		await updateManagedInstructionFiles( SITE_PATH, BUNDLED_PATH );
@@ -328,11 +328,7 @@ describe( 'updateManagedInstructionFiles', () => {
 			path.join( BUNDLED_PATH, 'STUDIO.md' ),
 			path.join( SITE_PATH, 'STUDIO.md' )
 		);
-		expect( fs.copyFile ).toHaveBeenCalledWith(
-			path.join( BUNDLED_PATH, 'CLAUDE.md' ),
-			path.join( SITE_PATH, 'CLAUDE.md' )
-		);
-		expect( fs.copyFile ).toHaveBeenCalledTimes( 2 );
+		expect( fs.copyFile ).toHaveBeenCalledTimes( 1 );
 	} );
 
 	it( 'skips files that do not exist in the site', async () => {


### PR DESCRIPTION
## Related issues

- Related to the AI instructions feature flag removal effort

## How AI was used in this PR

Claude Code assisted with identifying where `updateManagedInstructionFiles` was called and generating the code changes. All changes were reviewed manually.

## Proposed Changes

- Move `updateManagedInstructionFiles` from Electron main process (`ipc-handlers.ts`) to CLI site start command (`start.ts`), so CLI-managed sites also get updated STUDIO.md on every start
- Remove `CLAUDE.md` from managed instruction files — only `STUDIO.md` is now auto-updated on site start (CLAUDE.md is user-editable)
- Update tests to reflect the narrower managed files list

## Testing Instructions

- Build the CLI: `npm run cli:build`
- Create a site: `node apps/cli/dist/cli/main.js site create --path /tmp/test-site`
- Verify STUDIO.md exists in the site root
- Modify STUDIO.md content manually
- Stop and restart the site: `node apps/cli/dist/cli/main.js site start --path /tmp/test-site`
- Modify manually STUDIO.md, keep the file but update its content.
- Verify STUDIO.md was restored to the bundled version

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?