### PR TITLE
Settings: Move from modal to chrome surface

### DIFF
--- a/apps/studio/src/components/app.tsx
+++ b/apps/studio/src/components/app.tsx
@@ -1,7 +1,4 @@
-import {
-	__experimentalVStack as VStack,
-	__experimentalHStack as HStack,
-} from '@wordpress/components';
+import { __experimentalVStack as VStack } from '@wordpress/components';
 import { useEffect } from 'react';
 import MacTitlebar from 'src/components/mac-titlebar';
 import MainSidebar from 'src/components/main-sidebar';
@@ -12,6 +9,7 @@ import WindowsTitlebar from 'src/components/windows-titlebar';
 import { useListenDeepLinkConnection } from 'src/hooks/sync-sites/use-listen-deep-link-connection';
 import { useAuth } from 'src/hooks/use-auth';
 import { useLocalizationSupport } from 'src/hooks/use-localization-support';
+import { useSettingsPanel } from 'src/hooks/use-settings-panel';
 import { useSidebarVisibility } from 'src/hooks/use-sidebar-visibility';
 import { useSiteDetails } from 'src/hooks/use-site-details';
 import { isWindows } from 'src/lib/app-globals';
@@ -19,7 +17,7 @@ import { cx } from 'src/lib/cx';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 import { Onboarding } from 'src/modules/onboarding';
 import { useOnboarding } from 'src/modules/onboarding/hooks/use-onboarding';
-import { UserSettings } from 'src/modules/user-settings';
+import { SettingsPanel } from 'src/modules/user-settings/components/settings-panel';
 import { WhatsNewModal, useWhatsNew } from 'src/modules/whats-new';
 import { useAppDispatch, useRootSelector } from 'src/stores';
 import { selectOnboardingLoading } from 'src/stores/onboarding-slice';
@@ -31,6 +29,7 @@ export default function App() {
 	const { needsOnboarding } = useOnboarding();
 	const isOnboardingLoading = useRootSelector( selectOnboardingLoading );
 	const { isSidebarVisible, toggleSidebar } = useSidebarVisibility();
+	const { isSettingsOpen } = useSettingsPanel();
 	const { showWhatsNew, closeWhatsNew } = useWhatsNew();
 	const { sites: localSites, loadingSites } = useSiteDetails();
 	const isEmpty = ! loadingSites && ! localSites.length;
@@ -84,23 +83,35 @@ export default function App() {
 						</MacTitlebar>
 					) }
 
-					<HStack spacing="0" alignment="left" className="flex-grow">
+					<div className={ cx(
+						'relative flex-grow flex overflow-hidden transition-[padding] duration-300',
+						! isSidebarVisible && ! isSettingsOpen && 'ltr:pl-chrome rtl:pr-chrome'
+					) }>
+						{ /* Settings surface: lives behind sidebar + frame on the chrome */ }
+						{ isSettingsOpen && <SettingsPanel /> }
+
 						<MainSidebar
 							className={ cx(
-								'h-full transition-all duration-500',
-								isSidebarVisible ? 'basis-52 flex-shrink-0' : 'basis-0 !min-w-[10px]'
+								'relative z-[1] h-full basis-52 flex-shrink-0 bg-chrome transition-[transform,margin] duration-300 ease-[cubic-bezier(0.16,1,0.3,1)]',
+								isSettingsOpen
+									? 'settings-slide-left'
+									: isSidebarVisible
+										? 'translate-x-0 ml-0'
+										: '-translate-x-full -ml-52'
 							) }
 						/>
 						<main
 							data-testid="site-content"
-							className="bg-frame text-frame-text h-full flex-grow rounded-chrome overflow-hidden z-10"
+							className={ cx(
+								'relative z-[1] bg-frame text-frame-text h-full flex-grow rounded-chrome overflow-hidden settings-slideable',
+								isSettingsOpen && 'settings-slide-right'
+							) }
 						>
 							<SiteContentTabs />
 						</main>
-					</HStack>
+					</div>
 				</VStack>
 			) }
-			<UserSettings />
 			<WhatsNewModal showModal={ shouldShowWhatsNew } onClose={ closeWhatsNew } />
 		</>
 	);

--- a/apps/studio/src/components/main-sidebar.tsx
+++ b/apps/studio/src/components/main-sidebar.tsx
@@ -17,7 +17,7 @@ export default function MainSidebar( { className }: MainSidebarProps ) {
 		<div
 			data-testid="main-sidebar"
 			className={ cx(
-				'text-chrome-inverted relative',
+				'text-chrome-inverted relative overflow-hidden',
 				isMac() && 'pt-[10px]',
 				! isMac() && 'pt-[38px]',
 				className

--- a/apps/studio/src/components/root.tsx
+++ b/apps/studio/src/components/root.tsx
@@ -12,6 +12,7 @@ import { WordPressStyles } from 'src/components/wordpress-styles';
 import { ContentTabsProvider } from 'src/hooks/use-content-tabs';
 import { FeatureFlagsProvider } from 'src/hooks/use-feature-flags';
 import { ImportExportProvider } from 'src/hooks/use-import-export';
+import { SettingsPanelProvider } from 'src/hooks/use-settings-panel';
 import { SiteDetailsProvider } from 'src/hooks/use-site-details';
 import { ThemeDetailsProvider } from 'src/hooks/use-theme-details';
 import { OnboardingProvider } from 'src/modules/onboarding/hooks/use-onboarding';
@@ -42,7 +43,9 @@ const Root = () => {
 										<ThemeDetailsProvider>
 											<OnboardingProvider>
 												<ImportExportProvider>
-													<App />
+													<SettingsPanelProvider>
+														<App />
+													</SettingsPanelProvider>
 												</ImportExportProvider>
 											</OnboardingProvider>
 										</ThemeDetailsProvider>

--- a/apps/studio/src/components/top-bar.tsx
+++ b/apps/studio/src/components/top-bar.tsx
@@ -8,6 +8,8 @@ import { Tooltip } from 'src/components/tooltip';
 import { WordPressLogo } from 'src/components/wordpress-logo';
 import { useAuth } from 'src/hooks/use-auth';
 import { useOffline } from 'src/hooks/use-offline';
+import { useSettingsPanel } from 'src/hooks/use-settings-panel';
+import { cx } from 'src/lib/cx';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 import { getLocalizedLink } from 'src/lib/get-localized-link';
 import { useI18nLocale } from 'src/stores';
@@ -73,10 +75,11 @@ function Authentication() {
 	const { __ } = useI18n();
 	const { isAuthenticated, user } = useAuth();
 	const isOffline = useOffline();
+	const { openSettings } = useSettingsPanel();
 	if ( isAuthenticated ) {
 		return (
 			<Button
-				onClick={ () => getIpcApi().showUserSettings() }
+				onClick={ () => openSettings( 'account' ) }
 				aria-label={ __( 'Open account settings' ) }
 				variant="icon"
 				className="text-white hover:!text-white !px-1 py-1 !h-6 gap-2"
@@ -109,9 +112,10 @@ function Authentication() {
 
 function SettingsButton() {
 	const { __ } = useI18n();
+	const { openSettings } = useSettingsPanel();
 	return (
 		<Button
-			onClick={ () => getIpcApi().showUserSettings( 'general' ) }
+			onClick={ () => openSettings( 'general' ) }
 			aria-label={ __( 'Open settings' ) }
 			variant="icon"
 			data-testid="settings-button"
@@ -124,6 +128,7 @@ function SettingsButton() {
 export default function TopBar( { onToggleSidebar }: TopBarProps ) {
 	const { __ } = useI18n();
 	const locale = useI18nLocale();
+	const { isSettingsOpen } = useSettingsPanel();
 
 	const openDocs = () => {
 		getIpcApi().openURL( getLocalizedLink( locale, 'docsStudio' ) );
@@ -131,12 +136,22 @@ export default function TopBar( { onToggleSidebar }: TopBarProps ) {
 
 	return (
 		<div className="flex justify-between items-center text-white px-2 pb-2 pt-1.5">
-			<div className="flex items-center space-x-1.5 rtl:space-x-reverse">
+			<div
+				className={ cx(
+					'flex items-center space-x-1.5 rtl:space-x-reverse settings-topbar-fade',
+					isSettingsOpen && 'is-settings-open'
+				) }
+			>
 				<ToggleSidebar onToggleSidebar={ onToggleSidebar } />
 				<OfflineIndicator />
 			</div>
 
-			<div className="app-no-drag-region flex items-center space-x-1.5 rtl:space-x-reverse">
+			<div
+				className={ cx(
+					'app-no-drag-region flex items-center space-x-1.5 rtl:space-x-reverse settings-topbar-fade',
+					isSettingsOpen && 'is-settings-open'
+				) }
+			>
 				<Authentication />
 				<SettingsButton />
 				<Tooltip text={ __( 'Get help' ) } placement="bottom-start">

--- a/apps/studio/src/hooks/use-settings-panel.tsx
+++ b/apps/studio/src/hooks/use-settings-panel.tsx
@@ -1,0 +1,50 @@
+import { createContext, useCallback, useContext, useState } from 'react';
+import { useIpcListener } from 'src/hooks/use-ipc-listener';
+import { UserSettingsTabName } from 'src/modules/user-settings/user-settings-types';
+
+interface SettingsPanelContext {
+	isSettingsOpen: boolean;
+	settingsTab: UserSettingsTabName;
+	openSettings: ( tab?: UserSettingsTabName ) => void;
+	closeSettings: () => void;
+}
+
+const Context = createContext< SettingsPanelContext >( {
+	isSettingsOpen: false,
+	settingsTab: 'general',
+	openSettings: () => {},
+	closeSettings: () => {},
+} );
+
+export function SettingsPanelProvider( { children }: { children: React.ReactNode } ) {
+	const [ isSettingsOpen, setIsSettingsOpen ] = useState( false );
+	const [ settingsTab, setSettingsTab ] = useState< UserSettingsTabName >( 'general' );
+
+	const openSettings = useCallback( ( tab?: UserSettingsTabName ) => {
+		setSettingsTab( tab ?? 'general' );
+		setIsSettingsOpen( true );
+	}, [] );
+
+	const closeSettings = useCallback( () => {
+		setIsSettingsOpen( false );
+		setSettingsTab( 'general' );
+	}, [] );
+
+	useIpcListener( 'user-settings', ( _event, { tabName } ) => {
+		if ( isSettingsOpen ) {
+			closeSettings();
+		} else {
+			openSettings( tabName as UserSettingsTabName | undefined );
+		}
+	} );
+
+	return (
+		<Context.Provider value={ { isSettingsOpen, settingsTab, openSettings, closeSettings } }>
+			{ children }
+		</Context.Provider>
+	);
+}
+
+export function useSettingsPanel() {
+	return useContext( Context );
+}

--- a/apps/studio/src/index.css
+++ b/apps/studio/src/index.css
@@ -4,6 +4,14 @@
 @tailwind utilities;
 
 :root {
+	/* Chrome surface tokens (the dark app shell behind sidebar + frame) */
+	--color-chrome-bg: rgba( 30, 30, 30, 1 );
+	--color-chrome-fg: #fff;
+	--color-chrome-fg-muted: rgba( 255, 255, 255, 0.5 );
+	--color-chrome-hover: rgba( 255, 255, 255, 0.08 );
+	--color-chrome-active: rgba( 255, 255, 255, 0.12 );
+	--color-chrome-border: rgba( 255, 255, 255, 0.1 );
+
 	--color-frame-bg: #fff;
 	--color-frame-text: #1e1e1e;
 	--color-frame-text-secondary: #757575;
@@ -74,6 +82,55 @@ body {
 
 .app-no-drag-region {
 	-webkit-app-region: no-drag;
+}
+
+/* Settings chrome surface: remap tokens to work on dark chrome background */
+.settings-chrome-surface {
+	/* Studio frame tokens */
+	--color-frame-bg: rgba( 255, 255, 255, 0.06 );
+	--color-frame-text: #fff;
+	--color-frame-text-secondary: rgba( 255, 255, 255, 0.5 );
+	--color-frame-border: rgba( 255, 255, 255, 0.12 );
+	--color-frame-surface: rgba( 255, 255, 255, 0.06 );
+	--color-frame-surface-alt: rgba( 255, 255, 255, 0.1 );
+	--color-frame-theme: #6b8aff;
+	--color-frame-theme-hover: #8da6ff;
+	--color-frame-code-text: #e0e0e0;
+	--color-frame-tab-active: #fff;
+
+	/* WordPress component tokens */
+	--wp-components-color-background: rgba( 255, 255, 255, 0.08 );
+	--wp-components-color-foreground: #fff;
+	--wp-components-color-foreground-inverted: #1e1e1e;
+	--wp-components-color-accent: #6b8aff;
+	--wp-components-color-accent-inverted: #fff;
+	--wp-components-color-accent-darker-10: #8da6ff;
+	--wp-components-color-accent-darker-20: #8da6ff;
+	--wp-admin-theme-color: #6b8aff;
+	--wp-admin-theme-color-darker-10: #8da6ff;
+	--wp-admin-theme-color-darker-20: #8da6ff;
+}
+
+/* Settings chrome surface transitions */
+.settings-slideable {
+	transition: transform 300ms cubic-bezier( 0.16, 1, 0.3, 1 );
+}
+
+.settings-slide-left {
+	transform: translateX( calc( -100% - 16px ) );
+}
+
+.settings-slideable.settings-slide-right {
+	transform: translateX( calc( 100% + 16px ) );
+}
+
+.settings-topbar-fade {
+	transition: opacity 200ms ease;
+}
+
+.settings-topbar-fade.is-settings-open {
+	opacity: 0;
+	pointer-events: none;
 }
 
 h1,

--- a/apps/studio/src/modules/user-settings/components/settings-panel.tsx
+++ b/apps/studio/src/modules/user-settings/components/settings-panel.tsx
@@ -1,0 +1,139 @@
+import { Icon, cog, people, tool, close as closeIcon } from '@wordpress/icons';
+import { useI18n } from '@wordpress/react-i18n';
+import { useCallback, useEffect, useMemo } from 'react';
+import { useAuth } from 'src/hooks/use-auth';
+import { useFeatureFlags } from 'src/hooks/use-feature-flags';
+import { useOffline } from 'src/hooks/use-offline';
+import { useSettingsPanel } from 'src/hooks/use-settings-panel';
+import { cx } from 'src/lib/cx';
+import { getIpcApi } from 'src/lib/get-ipc-api';
+import { McpSettings } from 'src/modules/mcp/components/mcp-settings';
+import { AccountTab } from 'src/modules/user-settings/components/account-tab';
+import { PreferencesTab } from 'src/modules/user-settings/components/preferences-tab';
+import { SkillsTab } from 'src/modules/user-settings/components/skills-tab';
+import { UserSettingsTabName } from 'src/modules/user-settings/user-settings-types';
+import { useRootSelector } from 'src/stores';
+import { snapshotSelectors } from 'src/stores/snapshot-slice';
+import { useDeleteAllSnapshots, useGetSnapshotUsage } from 'src/stores/wpcom-api';
+
+interface NavItem {
+	name: UserSettingsTabName;
+	label: string;
+	icon: JSX.Element;
+}
+
+export function SettingsPanel() {
+	const { __ } = useI18n();
+	const { enableAgentSuite } = useFeatureFlags();
+	const { settingsTab, closeSettings, openSettings } = useSettingsPanel();
+	const { user } = useAuth();
+	const isOffline = useOffline();
+
+	const snapshotsByUser = useRootSelector( ( state ) =>
+		snapshotSelectors.selectSnapshotsByUser( state, user?.id ?? 0 )
+	);
+	const snapshotQuota = useRootSelector( ( state ) => state.snapshot.snapshotQuota );
+	const { data: snapshotUsage, isLoading: isLoadingSnapshotUsage } = useGetSnapshotUsage();
+	const definitiveSnapshotCount = snapshotUsage?.siteCount ?? snapshotsByUser?.length ?? 0;
+	const [ deleteAllSnapshots, { isLoading: isDeletingAllSnapshots } ] = useDeleteAllSnapshots();
+
+	const onRemoveSnapshots = useCallback( async () => {
+		const CANCEL_BUTTON_INDEX = 0;
+		const DELETE_BUTTON_INDEX = 1;
+
+		const { response } = await getIpcApi().showMessageBox( {
+			type: 'warning',
+			message: __( 'Delete all preview sites' ),
+			detail: __(
+				'All preview sites that exist for your WordPress.com account, along with all posts, pages, comments, and media, will be lost.'
+			),
+			buttons: [ __( 'Cancel' ), __( 'Delete all' ) ],
+			cancelId: CANCEL_BUTTON_INDEX,
+		} );
+
+		if ( response === DELETE_BUTTON_INDEX ) {
+			try {
+				await deleteAllSnapshots().unwrap();
+			} catch ( error ) {
+				await getIpcApi().showMessageBox( {
+					type: 'warning',
+					message: __( 'Failed to delete all preview sites' ),
+					detail: __( 'An error occurred while deleting all preview sites. Please try again.' ),
+					buttons: [ __( 'OK' ) ],
+				} );
+			}
+		}
+	}, [ __, deleteAllSnapshots ] );
+
+	const navItems: NavItem[] = useMemo( () => {
+		const items: NavItem[] = [ { name: 'general', label: __( 'General' ), icon: cog } ];
+		if ( enableAgentSuite ) {
+			items.push( { name: 'skills', label: __( 'Skills' ), icon: tool } );
+		}
+		items.push( { name: 'account', label: __( 'Account' ), icon: people } );
+		if ( enableAgentSuite ) {
+			items.push( { name: 'mcp', label: __( 'MCP' ), icon: tool } );
+		}
+		return items;
+	}, [ __, enableAgentSuite ] );
+
+	// Escape key closes settings
+	useEffect( () => {
+		const onKeyDown = ( e: KeyboardEvent ) => {
+			if ( e.key === 'Escape' ) {
+				closeSettings();
+			}
+		};
+		document.addEventListener( 'keydown', onKeyDown );
+		return () => document.removeEventListener( 'keydown', onKeyDown );
+	}, [ closeSettings ] );
+
+	return (
+		<div className="absolute inset-0 z-0 flex items-start justify-center text-chrome-fg [&_svg]:fill-current app-no-drag-region overflow-y-auto pt-10 pb-3">
+			<div className="flex gap-8 w-full max-w-[840px] px-6">
+				{ /* Left nav */ }
+				<nav className="w-[160px] flex-shrink-0 flex flex-col gap-1 sticky top-0">
+					<button
+						onClick={ closeSettings }
+						className="flex items-center gap-3 px-3 py-2 rounded-md text-sm text-left transition-colors text-chrome-fg-muted hover:text-chrome-fg hover:bg-chrome-hover mb-2"
+					>
+						<Icon icon={ closeIcon } size={ 20 } />
+						{ __( 'Close' ) }
+					</button>
+					{ navItems.map( ( item ) => (
+						<button
+							key={ item.name }
+							onClick={ () => openSettings( item.name ) }
+							className={ cx(
+								'flex items-center gap-3 px-3 py-2 rounded-md text-sm text-left transition-colors',
+								settingsTab === item.name
+									? 'bg-chrome-active text-chrome-fg'
+									: 'text-chrome-fg-muted hover:text-chrome-fg hover:bg-chrome-hover'
+							) }
+						>
+							<Icon icon={ item.icon } size={ 20 } />
+							{ item.label }
+						</button>
+					) ) }
+				</nav>
+
+				{ /* Content area */ }
+				<div className="flex-1 min-w-0 settings-chrome-surface flex gap-4 flex-col">
+					{ settingsTab === 'general' && <PreferencesTab onClose={ closeSettings } /> }
+					{ settingsTab === 'skills' && <SkillsTab /> }
+					{ settingsTab === 'mcp' && <McpSettings /> }
+					{ settingsTab === 'account' && (
+						<AccountTab
+							loadingDeletingAllSnapshots={ isDeletingAllSnapshots }
+							activeSnapshotCount={ definitiveSnapshotCount }
+							isLoadingSnapshotUsage={ isLoadingSnapshotUsage }
+							isOffline={ isOffline }
+							snapshotQuota={ snapshotQuota }
+							onRemoveSnapshots={ onRemoveSnapshots }
+						/>
+					) }
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/apps/studio/tailwind.config.js
+++ b/apps/studio/tailwind.config.js
@@ -147,8 +147,13 @@ module.exports = {
 		extend: {
 			colors: {
 				...a8cToTailwindColors,
-				chrome: 'rgba(30, 30, 30, 1)',
-				'chrome-inverted': '#fff',
+				chrome: 'var(--color-chrome-bg)',
+				'chrome-fg': 'var(--color-chrome-fg)',
+				'chrome-fg-muted': 'var(--color-chrome-fg-muted)',
+				'chrome-hover': 'var(--color-chrome-hover)',
+				'chrome-active': 'var(--color-chrome-active)',
+				'chrome-border': 'var(--color-chrome-border)',
+				'chrome-inverted': 'var(--color-chrome-fg)',
 				'development-bg': 'hsl(200, 95%, 85%)',
 				'development-text': 'hsl(200, 95%, 28%)',
 				'circle-env-production': '#069e08',


### PR DESCRIPTION
<img width="949" height="863" alt="image" src="https://github.com/user-attachments/assets/70d74b8e-e567-46e8-80db-2ad7a12b1e9a" />

## Proposed Changes

Right now, app settings live in a small floating modal. It works, but it's cramped — and as we add more settings (AI agents, skills, MCP, and whatever comes next), that modal is going to feel increasingly inadequate.

This PR moves settings out of the modal and onto a full-screen "chrome surface." The chrome is the dark background area behind the sidebar and content frame — it's always been there, we just haven't used it for anything interactive before.

When you open settings, the sidebar slides left and the content frame slides right, revealing the settings panel underneath. It gets the full viewport to breathe. Closing settings reverses the animation and everything slides back into place.

### What's here:

- **`SettingsPanelProvider`** — shared context for settings open/close state, replaces the old IPC-listener + local state approach
- **`SettingsPanel`** — new two-column layout (nav + content) rendered directly on the chrome surface, reusing all existing tab components
- **Chrome surface design tokens** — `--color-chrome-*` CSS custom properties and matching Tailwind utilities, plus a `.settings-chrome-surface` class that remaps both Studio and WordPress component tokens for dark-background rendering
- **Choreographed transitions** — sidebar, frame, and topbar elements animate in coordination using matched easing curves
- **Sidebar toggle refactor** — now uses `transform` + negative `margin` instead of width transitions, which eliminates text reflow during collapse

### What's NOT here:

- Tests haven't been updated for the new component structure
- The old `UserSettings` modal component still exists (unused) — can be removed once this direction is confirmed
- Windows testing — the titlebar spacing may need platform-specific adjustments

### Future thinking:

- **New site flow** could get a similar treatment. It currently uses a white surface, but sliding the chrome open for that flow too would give us a consistent interaction pattern for full-screen tasks.
- **Chrome theming** — the chrome color is hardcoded dark right now. Down the road we could make it theme-aware (lighter in light mode) or even let users pick a custom color to personalize their Studio. The token architecture in this PR is set up to support that.

## How AI was used in this PR

This was a vibe-coded exploration with Claude Code. I directed the design and interaction decisions, Claude helped implement.

## Testing Instructions

- Open settings via the gear icon, `Cmd+,`, or the "Howdy, [name]" button
- Verify sidebar and frame slide away smoothly, settings panel appears on the dark surface
- Close via the Close button, `Escape`, or `Cmd+,` again — everything should slide back
- Toggle the sidebar off, then open settings — sidebar should be fully hidden, no footer leaking
- Check all settings tabs (General, Account, and Skills/MCP if feature-flagged) render correctly on the dark surface
- Verify select dropdowns, toggles, progress bars, and buttons have proper dark-surface styling

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?