### PR TITLE
Fix Prettier lint error in ipc-handlers import

### DIFF
--- a/apps/studio/src/ipc-handlers.ts
+++ b/apps/studio/src/ipc-handlers.ts
@@ -17,10 +17,7 @@ import https from 'node:https';
 import os from 'os';
 import nodePath from 'path';
 import * as Sentry from '@sentry/electron/main';
-import {
-	installSkillToSite,
-	removeSkillFromSite,
-} from '@studio/common/lib/agent-skills';
+import { installSkillToSite, removeSkillFromSite } from '@studio/common/lib/agent-skills';
 import { validateBlueprintData } from '@studio/common/lib/blueprint-validation';
 import { parseCliError, errorMessageContains } from '@studio/common/lib/cli-error';
 import {


### PR DESCRIPTION
## Related issues

- p1774369907803099-slack-C06DRMD6VPZ

## How AI was used in this PR

Claude Code applied the `--fix` suggestion from Prettier to collapse a multi-line import into a single line. I reviewed the change and tested

## Proposed Changes

- Collapse the multi-line `installSkillToSite, removeSkillFromSite` import into a single line to satisfy Prettier formatting rules.

## Testing Instructions

- Run `npm run lint` and verify no errors.
- CI should pass

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?