### PR TITLE
Replace single appdata menu item with config files submenu

### DIFF
--- a/apps/studio/src/menu.ts
+++ b/apps/studio/src/menu.ts
@@ -7,6 +7,11 @@ import {
 	MenuItem,
 	shell,
 } from 'electron';
+import {
+	getAppConfigPath,
+	getCliConfigPath,
+	getSharedConfigPath,
+} from '@studio/common/lib/well-known-paths';
 import { __ } from '@wordpress/i18n';
 import { openAboutWindow } from 'src/about-menu/open-about-menu';
 import { BUG_REPORT_URL, FEATURE_REQUEST_URL } from 'src/constants';
@@ -29,7 +34,6 @@ import { shellOpenExternalWrapper } from 'src/lib/shell-open-external-wrapper';
 import { promptWindowsSpeedUpSites } from 'src/lib/windows-helpers';
 import { getLogsFilePath } from 'src/logging';
 import { getMainWindow } from 'src/main-window';
-import { getUserDataFilePath } from 'src/storage/paths';
 import { isUpdateReadyToInstall, manualCheckForUpdates } from 'src/updates';
 
 export async function setupMenu( config: {
@@ -175,14 +179,39 @@ async function getAppMenu(
 				...( process.env.NODE_ENV === 'development'
 					? [
 							{
-								label: __( 'Open Appdata File (dev only)' ),
-								click: async () => {
-									const appdataPath = getUserDataFilePath();
-									const err = await shell.openPath( appdataPath );
-									if ( err ) {
-										console.error( `Error opening appdata file: ${ appdataPath } ${ err }` );
-									}
-								},
+								label: __( 'Open Config Files (dev only)' ),
+								submenu: [
+									{
+										label: __( 'App Config (app.json)' ),
+										click: async () => {
+											const configPath = getAppConfigPath();
+											const err = await shell.openPath( configPath );
+											if ( err ) {
+												console.error( `Error opening config file: ${ configPath } ${ err }` );
+											}
+										},
+									},
+									{
+										label: __( 'Shared Config (shared.json)' ),
+										click: async () => {
+											const configPath = getSharedConfigPath();
+											const err = await shell.openPath( configPath );
+											if ( err ) {
+												console.error( `Error opening config file: ${ configPath } ${ err }` );
+											}
+										},
+									},
+									{
+										label: __( 'CLI Config (cli.json)' ),
+										click: async () => {
+											const configPath = getCliConfigPath();
+											const err = await shell.openPath( configPath );
+											if ( err ) {
+												console.error( `Error opening config file: ${ configPath } ${ err }` );
+											}
+										},
+									},
+								],
 							},
 							{
 								label: __( 'Feature Flags' ),


### PR DESCRIPTION
## Related issues

- N/A

## How AI was used in this PR

AI-assisted implementation, code reviewed by author.

## Proposed Changes

- Replace the single "Open Appdata File (dev only)" dev menu item with an "Open Config Files (dev only)" submenu
- Add three submenu entries for the new config file structure: App Config (`app.json`), Shared Config (`shared.json`), and CLI Config (`cli.json`)
- Update imports from `getUserDataFilePath` to use `getAppConfigPath`, `getSharedConfigPath`, and `getCliConfigPath` from `@studio/common/lib/well-known-paths`

## Testing Instructions

- Run `npm start` to launch Studio in development mode
- Open the app menu (Studio menu on macOS)
- Verify "Open Config Files (dev only)" appears as a submenu with three items
- Click each submenu item and confirm the correct config file opens

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?