### PR TITLE
Add /tmp as a trusted root for the AI CLI

### DIFF
--- a/apps/cli/ai/security.ts
+++ b/apps/cli/ai/security.ts
@@ -39,7 +39,7 @@ export const ALLOWED_TOOLS = [
 	'AskUserQuestion',
 ] as const;
 
-// Tools that should not manipulate files outside of ~/Studio without permission (write access)
+// Tools that should not manipulate files outside trusted roots without permission (write access)
 const PATH_GATED_TOOLS = [ 'Write', 'Edit', 'Bash', 'NotebookEdit' ] as const;
 const PATH_INPUT_KEYS = [ 'path', 'file_path', 'filePath' ] as const;
 
@@ -48,11 +48,18 @@ const APPROVE_SESSION_LABEL = 'Allow for this session';
 const DENY_LABEL = 'Deny';
 
 export const STUDIO_ROOT = path.resolve( STUDIO_SITES_ROOT );
-const STUDIO_ROOT_PREFIX = STUDIO_ROOT.endsWith( path.sep )
-	? STUDIO_ROOT
-	: `${ STUDIO_ROOT }${ path.sep }`;
+export const TMP_ROOT = path.resolve( os.tmpdir() );
+const TRUSTED_TEMP_ROOT_CANDIDATES = [ TMP_ROOT, '/tmp' ];
+export const TRUSTED_TEMP_ROOTS = Array.from(
+	new Set( TRUSTED_TEMP_ROOT_CANDIDATES.map( ( trustedRoot ) => path.resolve( trustedRoot ) ) )
+);
 
-export const ACCESS_DENIED_MESSAGE = `Access denied outside ${ STUDIO_ROOT }`;
+const TRUSTED_ROOTS = [ STUDIO_ROOT, ...TRUSTED_TEMP_ROOTS ];
+const TRUSTED_ROOT_PREFIXES = TRUSTED_ROOTS.map( ( trustedRoot ) =>
+	trustedRoot.endsWith( path.sep ) ? trustedRoot : `${ trustedRoot }${ path.sep }`
+);
+
+export const ACCESS_DENIED_MESSAGE = 'Access denied outside trusted directories';
 
 export interface PathApprovalSession {
 	hasApprovedPath: ( toolName: string, requestedPath: string ) => boolean;
@@ -73,9 +80,12 @@ export function resolveToolPath( rawPath: string ): string {
 		: path.resolve( STUDIO_ROOT, expandedPath );
 }
 
-export function isPathWithinStudioRoot( filePath: string ): boolean {
+export function isPathWithinTrustedRoot( filePath: string ): boolean {
 	const normalizedPath = resolveToolPath( filePath );
-	return normalizedPath === STUDIO_ROOT || normalizedPath.startsWith( STUDIO_ROOT_PREFIX );
+	return TRUSTED_ROOTS.some(
+		( trustedRoot, index ) =>
+			normalizedPath === trustedRoot || normalizedPath.startsWith( TRUSTED_ROOT_PREFIXES[ index ] )
+	);
 }
 
 function getToolInputPaths( input: Record< string, unknown > ): string[] {
@@ -85,16 +95,16 @@ function getToolInputPaths( input: Record< string, unknown > ): string[] {
 		.filter( ( value ) => value.trim().length > 0 );
 }
 
-export function findFirstPathOutsideStudioRoot(
+export function findFirstPathOutsideTrustedRoots(
 	input: Record< string, unknown >,
 	blockedPath?: string
 ): string | undefined {
-	if ( blockedPath && ! isPathWithinStudioRoot( blockedPath ) ) {
+	if ( blockedPath && ! isPathWithinTrustedRoot( blockedPath ) ) {
 		return blockedPath;
 	}
 
 	for ( const toolPath of getToolInputPaths( input ) ) {
-		if ( ! isPathWithinStudioRoot( toolPath ) ) {
+		if ( ! isPathWithinTrustedRoot( toolPath ) ) {
 			return toolPath;
 		}
 	}
@@ -152,7 +162,7 @@ export function getPathGatedPermissionRequest( {
 	blockedPath?: string;
 	suggestions?: PermissionUpdate[];
 } ): PathGatedPermissionRequest | undefined {
-	const outsidePath = findFirstPathOutsideStudioRoot( input, blockedPath );
+	const outsidePath = findFirstPathOutsideTrustedRoots( input, blockedPath );
 	if ( ! outsidePath || ! isPathGatedTool( toolName ) ) {
 		return undefined;
 	}
@@ -186,7 +196,7 @@ export async function askForPathGatedToolApproval( {
 			options: [
 				{
 					label: APPROVE_ONCE_LABEL,
-					description: `Run ${ toolName } outside ${ STUDIO_ROOT } for this step.`,
+					description: `Run ${ toolName } outside trusted directories for this step.`,
 				},
 				{
 					label: APPROVE_SESSION_LABEL,
@@ -194,7 +204,7 @@ export async function askForPathGatedToolApproval( {
 				},
 				{
 					label: DENY_LABEL,
-					description: 'Keep filesystem access restricted to Studio sites.',
+					description: 'Keep filesystem access restricted to trusted directories.',
 				},
 			],
 		},

--- a/apps/cli/ai/tests/security.test.ts
+++ b/apps/cli/ai/tests/security.test.ts
@@ -4,12 +4,13 @@ import { vi } from 'vitest';
 import {
 	ACCESS_DENIED_MESSAGE,
 	STUDIO_ROOT,
+	TMP_ROOT,
 	askForPathGatedToolApproval,
 	createPathApprovalSession,
-	findFirstPathOutsideStudioRoot,
+	findFirstPathOutsideTrustedRoots,
 	getPathGatedPermissionRequest,
 	isPathGatedTool,
-	isPathWithinStudioRoot,
+	isPathWithinTrustedRoot,
 	promptForApproval,
 	resolveToolPath,
 	type AskUserQuestion,
@@ -40,18 +41,33 @@ describe( 'AI security helpers', () => {
 		);
 	} );
 
-	it( 'identifies paths inside and outside of the Studio root', () => {
-		expect( isPathWithinStudioRoot( 'example-site/wp-config.php' ) ).toBe( true );
-		expect( isPathWithinStudioRoot( path.resolve( STUDIO_ROOT, 'example-site' ) ) ).toBe( true );
-		expect( isPathWithinStudioRoot( path.resolve( os.homedir(), 'Downloads/outside.txt' ) ) ).toBe(
+	it( 'identifies paths inside trusted roots and outside paths', () => {
+		expect( isPathWithinTrustedRoot( 'example-site/wp-config.php' ) ).toBe( true );
+		expect( isPathWithinTrustedRoot( path.resolve( STUDIO_ROOT, 'example-site' ) ) ).toBe( true );
+		expect( isPathWithinTrustedRoot( path.resolve( TMP_ROOT, 'studio-ai-temp.txt' ) ) ).toBe(
+			true
+		);
+		expect( isPathWithinTrustedRoot( path.resolve( os.homedir(), 'Downloads/outside.txt' ) ) ).toBe(
 			false
 		);
 	} );
 
-	it( 'prefers blockedPath when it is outside the Studio root', () => {
+	it( 'does not treat temporary directory paths as outside', () => {
+		const tempPath = path.resolve( TMP_ROOT, 'studio-ai-temp.txt' );
+
+		expect( findFirstPathOutsideTrustedRoots( { path: tempPath } ) ).toBeUndefined();
+	} );
+
+	it( 'does not treat /tmp paths as outside', () => {
+		expect(
+			findFirstPathOutsideTrustedRoots( { path: '/tmp/studio-ai-temp.txt' } )
+		).toBeUndefined();
+	} );
+
+	it( 'prefers blockedPath when it is outside trusted roots', () => {
 		const outsidePath = path.resolve( os.homedir(), 'Downloads/outside.txt' );
 		expect(
-			findFirstPathOutsideStudioRoot(
+			findFirstPathOutsideTrustedRoots(
 				{ path: path.resolve( STUDIO_ROOT, 'inside.txt' ) },
 				outsidePath
 			)


### PR DESCRIPTION
Recreated from #2849 (fork PR) so CI can run.

Original author: @jverneaut

## Proposed Changes

- Expanded AI CLI trusted path scope to include temp directories used by site creation (`os.tmpdir()` and `/tmp`) so writes there do not trigger approval prompts.
- Renamed security helper naming from `StudioRoot` to `TrustedRoot` terminology to reflect current behavior.
- Updated access-denied message to generic wording: `Access denied outside trusted directories`.

## Testing Instructions

- `npm install && npm run cli:build`
- `ENABLE_STUDIO_AI=true node apps/cli/dist/cli/main.js ai`
- Manually validate:
  - allowed operations under ~/Studio
  - denied operations targeting paths outside ~/Studio
  - Trigger an AI operation writing to `/tmp/...` during site setup-related workflow.
  - Confirm no approval prompt appears for that temp path.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?