### PR TITLE
Disable Redis/memcached when JSPI is unavailable

### DIFF
--- a/apps/cli/lib/run-wp-cli-command.ts
+++ b/apps/cli/lib/run-wp-cli-command.ts
@@ -12,6 +12,7 @@ import { cleanupLegacyMuPlugins, getMuPlugins } from '@studio/common/lib/mu-plug
 import { LatestSupportedPHPVersion } from '@studio/common/types/php-versions';
 import { __ } from '@wordpress/i18n';
 import { setupPlatformLevelMuPlugins } from '@wp-playground/wordpress';
+import semver from 'semver';
 import { getSqliteCommandPath, getWpCliPharPath } from 'cli/lib/server-files';
 
 const processIdAllocator = new ProcessIdAllocator();
@@ -47,10 +48,11 @@ export async function runWpCliCommand(
 	phpVersion: SupportedPHPVersion,
 	args: string[]
 ): Promise< [ StreamedPHPResponse, exitPhp: () => void ] > {
+	const doesCurrentNodeSupportJspi = semver.gte( process.version, '24.0.0' );
 	const id = await loadNodeRuntime( phpVersion, {
 		followSymlinks: true,
-		withRedis: true,
-		withMemcached: true,
+		withRedis: doesCurrentNodeSupportJspi,
+		withMemcached: doesCurrentNodeSupportJspi,
 		emscriptenOptions: {
 			processId: processIdAllocator.claim(),
 		},

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -16,7 +16,7 @@
 		"scripts/"
 	],
 	"engines": {
-		"node": ">=22.0.0"
+		"node": ">=24.0.0"
 	},
 	"repository": {
 		"type": "git",

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -16,7 +16,7 @@
 		"scripts/"
 	],
 	"engines": {
-		"node": ">=24.0.0"
+		"node": ">=22.0.0"
 	},
 	"repository": {
 		"type": "git",

--- a/apps/cli/wordpress-server-child.ts
+++ b/apps/cli/wordpress-server-child.ts
@@ -28,6 +28,7 @@ import {
 } from '@wp-playground/storage';
 import { WordPressInstallMode } from '@wp-playground/wordpress';
 import fs from 'fs-extra';
+import semver from 'semver';
 import { z } from 'zod';
 import { sanitizeRunCLIArgs } from 'cli/lib/cli-args-sanitizer';
 import { rewriteWpCliPostContentToFile } from 'cli/lib/rewrite-wp-cli-post-content';
@@ -233,6 +234,7 @@ async function getBaseRunCLIArgs(
 		} );
 	}
 
+	const doesCurrentNodeSupportJspi = semver.gte( process.version, '24.0.0' );
 	const args: RunCLIArgs = {
 		command,
 		internalCookieStore: false,
@@ -244,8 +246,8 @@ async function getBaseRunCLIArgs(
 		'site-url': config.absoluteUrl || `http://localhost:${ config.port }`,
 		blueprint: blueprintBundle,
 		wordpressInstallMode,
-		redis: true,
-		memcached: true,
+		redis: doesCurrentNodeSupportJspi,
+		memcached: doesCurrentNodeSupportJspi,
 	};
 
 	if ( config.wpVersion ) {


### PR DESCRIPTION
## Related issues

- STU-1366

## How AI was used in this PR

Claude Code was used to investigate, reproduce, and fix the bug. I have reviewed the code, iterated over it and confirm it works as expected.

## Proposed Changes

- Conditionally disable Redis and memcached PHP extensions when JSPI is unavailable (Node < 24) in `wordpress-server-child.ts` and `run-wp-cli-command.ts`

**Context:** The Redis and memcached extensions require JSPI (JavaScript Promise Integration), only available in Node.js 24+. On Node 22, enabling them crashes the WordPress server at startup:

> Error: The Redis extension requires JSPI (JavaScript Promise Integration) support.

The conditional disable uses the same `semver.gte(process.version, '24.0.0')` pattern already established in `process-manager-daemon.ts` for the `--experimental-wasm-jspi` flag.

The engine bump reflects the de facto requirement: the production build strips asyncify binaries (`vite.config.prod.ts`), the `.nvmrc` specifies Node 24.13.1, and Node 24 is the current Active LTS.

## Testing Instructions

1. On Node 22: `npm run cli:build && node apps/cli/dist/cli/main.js site create`
2. Run `cat $(ls -t ~/.studio/pm2/logs/*-out.log | head -1)` to see the logs and check:
  - Before fix: crash with Redis JSPI error is recorded
  
<img width="1496" height="658" alt="CleanShot 2026-03-25 at 12 20 48@2x" src="https://github.com/user-attachments/assets/3976b243-b8b6-49b6-ab7a-14158ab412fa" />
  
  - After fix: server starts and `Extensions` log line includes `intl` only (no `redis`/`memcached` mentioned), site works normally

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?