### PR TITLE
Fix site sort order not preserved across app restarts

### DIFF
--- a/apps/studio/src/hooks/use-site-details.tsx
+++ b/apps/studio/src/hooks/use-site-details.tsx
@@ -247,7 +247,7 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 		async ( id: string, removeLocal: boolean ) => {
 			await deleteSite( id, removeLocal );
 			const newSites = await getIpcApi().getSiteDetails();
-			setSites( newSites );
+			setSites( sortSites( newSites ) );
 			// Use functional update to access current selectedSiteId value
 			// Tab reset is handled in SiteContentTabs when it detects the previous site was deleted
 			setSelectedSiteId( ( currentSelectedId ) => {
@@ -403,7 +403,7 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 	const updateSite = useCallback( async ( site: SiteDetails, wpVersion?: string ) => {
 		await getIpcApi().updateSite( site, wpVersion );
 		const updatedSites = await getIpcApi().getSiteDetails();
-		setSites( updatedSites );
+		setSites( sortSites( updatedSites ) );
 	}, [] );
 
 	const saveTimeoutRef = useRef< ReturnType< typeof setTimeout > >();
@@ -581,7 +581,7 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 			.getSiteDetails()
 			.then( async ( data ) => {
 				if ( ! cancel ) {
-					setSites( data );
+					setSites( sortSites( data ) );
 					setLoadingSites( false );
 					const autoStartSites = data.filter( ( site ) => site.autoStart );
 					void Promise.all( autoStartSites.map( ( site ) => startServer( site ) ) );


### PR DESCRIPTION
## Related issues

- N/A

## How AI was used in this PR

AI helped trace the data flow from `app.json` → IPC handler → renderer to identify where `sortSites()` was missing. The fix itself is straightforward.

## Proposed Changes

- Apply `sortSites()` to all `setSites()` calls that follow `getSiteDetails()` IPC responses in `use-site-details.tsx`

| Before | After |
|--------|--------|
| <img width="1123" height="748" alt="image" src="https://github.com/user-attachments/assets/33c099e5-653b-4b3c-bc7c-210e7b1eb4d3" /> | <img width="1123" height="748" alt="image" src="https://github.com/user-attachments/assets/02bd1a78-70c9-49f2-8d1d-902ca43e3f6a" /> | 

## Testing Instructions

- Reorder sites in the sidebar via drag-and-drop
- Restart the app
- Verify the sidebar preserves your custom order
- Delete a site and verify remaining sites stay in order
- Update a site setting and verify order is preserved

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?