### PR TITLE
Fix regressions around deleting preview sites

### DIFF
--- a/apps/cli/ai/tests/tools.test.ts
+++ b/apps/cli/ai/tests/tools.test.ts
@@ -1,6 +1,9 @@
 import { vi } from 'vitest';
 import { runCommand as runCreatePreviewCommand } from 'cli/commands/preview/create';
-import { runCommand as runDeletePreviewCommand } from 'cli/commands/preview/delete';
+import {
+	Mode as PreviewDeleteMode,
+	runCommand as runDeletePreviewCommand,
+} from 'cli/commands/preview/delete';
 import { runCommand as runListPreviewCommand } from 'cli/commands/preview/list';
 import { runCommand as runUpdatePreviewCommand } from 'cli/commands/preview/update';
 import { readCliConfig } from 'cli/lib/cli-config/core';
@@ -20,9 +23,13 @@ vi.mock( 'cli/commands/preview/create', () => ( {
 	runCommand: vi.fn(),
 } ) );
 
-vi.mock( 'cli/commands/preview/delete', () => ( {
-	runCommand: vi.fn(),
-} ) );
+vi.mock( import( 'cli/commands/preview/delete' ), async ( importActual ) => {
+	const actual = await importActual();
+	return {
+		Mode: actual.Mode,
+		runCommand: vi.fn(),
+	};
+} );
 
 vi.mock( 'cli/commands/preview/list', () => ( {
 	runCommand: vi.fn(),
@@ -180,7 +187,10 @@ describe( 'Studio AI MCP tools', () => {
 			null
 		);
 
-		expect( runDeletePreviewCommand ).toHaveBeenCalledWith( 'demo.wordpress.com' );
+		expect( runDeletePreviewCommand ).toHaveBeenCalledWith(
+			PreviewDeleteMode.DELETE_SINGLE_SNAPSHOT,
+			'demo.wordpress.com'
+		);
 		expect( result.isError ).toBe( true );
 		expect( getTextContent( result ) ).toBe( 'Failed to delete preview site' );
 	} );

--- a/apps/cli/ai/tools.ts
+++ b/apps/cli/ai/tools.ts
@@ -6,7 +6,10 @@ import { z } from 'zod/v4';
 import { validateBlocks, type ValidationReport } from 'cli/ai/block-validator';
 import { getSharedBrowser } from 'cli/ai/browser-utils';
 import { runCommand as runCreatePreviewCommand } from 'cli/commands/preview/create';
-import { runCommand as runDeletePreviewCommand } from 'cli/commands/preview/delete';
+import {
+	Mode as PreviewDeleteMode,
+	runCommand as runDeletePreviewCommand,
+} from 'cli/commands/preview/delete';
 import { runCommand as runListPreviewCommand } from 'cli/commands/preview/list';
 import { runCommand as runUpdatePreviewCommand } from 'cli/commands/preview/update';
 import { runCommand as runCreateSiteCommand } from 'cli/commands/site/create';
@@ -426,7 +429,7 @@ const deletePreviewTool = tool(
 	async ( args ) => {
 		const normalizedHost = normalizeHostname( args.host );
 		return runPreviewCommand(
-			() => runDeletePreviewCommand( normalizedHost ),
+			() => runDeletePreviewCommand( PreviewDeleteMode.DELETE_SINGLE_SNAPSHOT, normalizedHost ),
 			`Preview site "${ normalizedHost }" deleted.`,
 			'Failed to delete preview site'
 		);

--- a/apps/cli/commands/_events.ts
+++ b/apps/cli/commands/_events.ts
@@ -90,8 +90,8 @@ function emitAuthEvent( event: AUTH_EVENTS, token?: AuthEvent[ 'token' ] ): void
 
 const emitDeletedAllSnapshotsEvent = sequential(
 	async ( event: SNAPSHOT_EVENTS.DELETED_ALL ): Promise< void > => {
-		const outgoingEvent: SnapshotEvent = { event };
-		logger.reportKeyValuePair( 'snapshot-event', JSON.stringify( outgoingEvent ) );
+		const payload: SnapshotEvent = { event };
+		logger.reportKeyValuePair( 'snapshot-event', JSON.stringify( payload ) );
 	}
 );
 
@@ -103,12 +103,12 @@ const emitSingleSnapshotEvent = sequential(
 		const cliConfig = await readCliConfig();
 
 		const snapshot = cliConfig.snapshots.find( ( s ) => s.url === snapshotUrl );
-		const outgoingEvent: SnapshotEvent = {
+		const payload: SnapshotEvent = {
 			event,
 			snapshotUrl,
 			snapshot: snapshot ?? undefined,
 		};
-		logger.reportKeyValuePair( 'snapshot-event', JSON.stringify( outgoingEvent ) );
+		logger.reportKeyValuePair( 'snapshot-event', JSON.stringify( payload ) );
 	}
 );
 

--- a/apps/cli/commands/_events.ts
+++ b/apps/cli/commands/_events.ts
@@ -18,6 +18,7 @@ import {
 	SiteEvent,
 	SnapshotEvent,
 	AuthEvent,
+	SnapshotSocketEvent,
 } from '@studio/common/lib/cli-events';
 import { isEmptyDir } from '@studio/common/lib/fs-utils';
 import { sequential } from '@studio/common/lib/sequential';
@@ -91,16 +92,24 @@ function emitAuthEvent( event: AUTH_EVENTS, token?: AuthEvent[ 'token' ] ): void
 }
 
 const emitSnapshotEvent = sequential(
-	async ( event: SNAPSHOT_EVENTS, snapshotUrl: string ): Promise< void > => {
+	async ( incomingEvent: SnapshotSocketEvent ): Promise< void > => {
+		if ( incomingEvent.event === SNAPSHOT_EVENTS.DELETED_ALL ) {
+			const outgoingEvent: SnapshotEvent = {
+				event: SNAPSHOT_EVENTS.DELETED_ALL,
+			};
+			logger.reportKeyValuePair( 'snapshot-event', JSON.stringify( outgoingEvent ) );
+			return;
+		}
+
 		const cliConfig = await readCliConfig();
-		const snapshot = cliConfig.snapshots.find( ( s ) => s.url === snapshotUrl );
-		const payload: SnapshotEvent = {
-			event,
-			snapshotUrl,
+
+		const snapshot = cliConfig.snapshots.find( ( s ) => s.url === incomingEvent.data.snapshotUrl );
+		const outgoingEvent: SnapshotEvent = {
+			event: incomingEvent.event,
+			snapshotUrl: incomingEvent.data.snapshotUrl,
 			snapshot: snapshot ?? undefined,
 		};
-
-		logger.reportKeyValuePair( 'snapshot-event', JSON.stringify( payload ) );
+		logger.reportKeyValuePair( 'snapshot-event', JSON.stringify( outgoingEvent ) );
 	}
 );
 
@@ -116,7 +125,7 @@ export async function runCommand(): Promise< void > {
 
 			const snapshotParsed = snapshotSocketEventSchema.safeParse( packet );
 			if ( snapshotParsed.success ) {
-				void emitSnapshotEvent( snapshotParsed.data.event, snapshotParsed.data.data.snapshotUrl );
+				void emitSnapshotEvent( snapshotParsed.data );
 				return;
 			}
 

--- a/apps/cli/commands/_events.ts
+++ b/apps/cli/commands/_events.ts
@@ -12,13 +12,10 @@ import {
 	SITE_EVENTS,
 	SNAPSHOT_EVENTS,
 	siteDetailsSchema,
-	siteSocketEventSchema,
-	snapshotSocketEventSchema,
-	authSocketEventSchema,
+	socketEventSchema,
 	SiteEvent,
 	SnapshotEvent,
 	AuthEvent,
-	SnapshotSocketEvent,
 } from '@studio/common/lib/cli-events';
 import { isEmptyDir } from '@studio/common/lib/fs-utils';
 import { sequential } from '@studio/common/lib/sequential';
@@ -91,22 +88,24 @@ function emitAuthEvent( event: AUTH_EVENTS, token?: AuthEvent[ 'token' ] ): void
 	logger.reportKeyValuePair( 'auth-event', JSON.stringify( payload ) );
 }
 
-const emitSnapshotEvent = sequential(
-	async ( incomingEvent: SnapshotSocketEvent ): Promise< void > => {
-		if ( incomingEvent.event === SNAPSHOT_EVENTS.DELETED_ALL ) {
-			const outgoingEvent: SnapshotEvent = {
-				event: SNAPSHOT_EVENTS.DELETED_ALL,
-			};
-			logger.reportKeyValuePair( 'snapshot-event', JSON.stringify( outgoingEvent ) );
-			return;
-		}
+const emitDeletedAllSnapshotsEvent = sequential(
+	async ( event: SNAPSHOT_EVENTS.DELETED_ALL ): Promise< void > => {
+		const outgoingEvent: SnapshotEvent = { event };
+		logger.reportKeyValuePair( 'snapshot-event', JSON.stringify( outgoingEvent ) );
+	}
+);
 
+const emitSingleSnapshotEvent = sequential(
+	async (
+		event: SNAPSHOT_EVENTS.CREATED | SNAPSHOT_EVENTS.UPDATED | SNAPSHOT_EVENTS.DELETED,
+		snapshotUrl: string
+	): Promise< void > => {
 		const cliConfig = await readCliConfig();
 
-		const snapshot = cliConfig.snapshots.find( ( s ) => s.url === incomingEvent.data.snapshotUrl );
+		const snapshot = cliConfig.snapshots.find( ( s ) => s.url === snapshotUrl );
 		const outgoingEvent: SnapshotEvent = {
-			event: incomingEvent.event,
-			snapshotUrl: incomingEvent.data.snapshotUrl,
+			event,
+			snapshotUrl,
 			snapshot: snapshot ?? undefined,
 		};
 		logger.reportKeyValuePair( 'snapshot-event', JSON.stringify( outgoingEvent ) );
@@ -117,25 +116,29 @@ export async function runCommand(): Promise< void > {
 	const eventsSocketServer = new SocketServer( SITE_EVENTS_SOCKET_PATH, 2500 );
 	eventsSocketServer.on( 'message', ( { message: packet } ) => {
 		try {
-			const authParsed = authSocketEventSchema.safeParse( packet );
-			if ( authParsed.success ) {
-				emitAuthEvent( authParsed.data.event, authParsed.data.data.token );
-				return;
-			}
+			const parsed = socketEventSchema.parse( packet );
 
-			const snapshotParsed = snapshotSocketEventSchema.safeParse( packet );
-			if ( snapshotParsed.success ) {
-				void emitSnapshotEvent( snapshotParsed.data );
-				return;
-			}
+			switch ( parsed.event ) {
+				case AUTH_EVENTS.LOGIN:
+				case AUTH_EVENTS.LOGOUT:
+					void emitAuthEvent( parsed.event, parsed.data.token );
+					break;
 
-			const parsedPacket = siteSocketEventSchema.parse( packet );
-			if (
-				parsedPacket.event === SITE_EVENTS.CREATED ||
-				parsedPacket.event === SITE_EVENTS.UPDATED ||
-				parsedPacket.event === SITE_EVENTS.DELETED
-			) {
-				void emitSiteEvent( parsedPacket.event, parsedPacket.data.siteId );
+				case SNAPSHOT_EVENTS.CREATED:
+				case SNAPSHOT_EVENTS.UPDATED:
+				case SNAPSHOT_EVENTS.DELETED:
+					void emitSingleSnapshotEvent( parsed.event, parsed.data.snapshotUrl );
+					break;
+
+				case SNAPSHOT_EVENTS.DELETED_ALL:
+					void emitDeletedAllSnapshotsEvent( parsed.event );
+					break;
+
+				case SITE_EVENTS.CREATED:
+				case SITE_EVENTS.UPDATED:
+				case SITE_EVENTS.DELETED:
+					void emitSiteEvent( parsed.event, parsed.data.siteId );
+					break;
 			}
 		} catch ( error ) {
 			// Do nothing

--- a/apps/cli/commands/preview/delete.ts
+++ b/apps/cli/commands/preview/delete.ts
@@ -2,44 +2,71 @@ import { SNAPSHOT_EVENTS } from '@studio/common/lib/cli-events';
 import { readAuthToken } from '@studio/common/lib/shared-config';
 import { PreviewCommandLoggerAction as LoggerAction } from '@studio/common/logger-actions';
 import { __ } from '@wordpress/i18n';
-import { deleteSnapshot } from 'cli/lib/api';
+import { deleteAllSnapshots, deleteSnapshot } from 'cli/lib/api';
+import { deleteAllSnapshotsForUserFromConfig } from 'cli/lib/cli-config/snapshots';
 import { emitCliEvent } from 'cli/lib/daemon-client';
 import { deleteSnapshotFromConfig, getSnapshotsFromConfig } from 'cli/lib/snapshots';
 import { normalizeHostname } from 'cli/lib/utils';
 import { Logger, LoggerError } from 'cli/logger';
 import { StudioArgv } from 'cli/types';
 
-export async function runCommand( host: string ): Promise< void > {
+export enum Mode {
+	DELETE_SINGLE_SNAPSHOT,
+	DELETE_ALL_SNAPSHOT,
+}
+
+export async function runCommand(
+	mode: Mode.DELETE_SINGLE_SNAPSHOT,
+	host: string
+): Promise< void >;
+export async function runCommand(
+	mode: Mode.DELETE_ALL_SNAPSHOT,
+	host: undefined
+): Promise< void >;
+export async function runCommand( mode: Mode, host: string | undefined ): Promise< void > {
 	const logger = new Logger< LoggerAction >();
 
 	try {
-		logger.reportStart( LoggerAction.VALIDATE, __( 'Validating…' ) );
 		const token = await readAuthToken();
 		if ( ! token ) {
 			throw new LoggerError(
 				__( 'Authentication required. Please log in with `studio auth login`.' )
 			);
 		}
-		const snapshots = await getSnapshotsFromConfig( token.id );
-		const snapshotToDelete = snapshots.find( ( s ) => s.url === host );
-		if ( ! snapshotToDelete ) {
-			throw new LoggerError(
-				__(
-					'Preview site not found. ' +
-						'Use the `studio preview list` command to see available preview sites.'
-				)
-			);
-		}
-		logger.reportSuccess( __( 'Validation successful' ), true );
 
-		logger.reportStart( LoggerAction.DELETE, __( 'Deleting…' ) );
-		await deleteSnapshot( snapshotToDelete.atomicSiteId, token.accessToken );
-		await deleteSnapshotFromConfig( snapshotToDelete.url );
-		await emitCliEvent( {
-			event: SNAPSHOT_EVENTS.DELETED,
-			data: { snapshotUrl: snapshotToDelete.url },
-		} );
-		logger.reportSuccess( __( 'Deletion successful' ) );
+		const snapshots = await getSnapshotsFromConfig( token.id );
+
+		if ( mode === Mode.DELETE_SINGLE_SNAPSHOT ) {
+			logger.reportStart( LoggerAction.VALIDATE, __( 'Validating…' ) );
+
+			const snapshotToDelete = snapshots.find( ( s ) => s.url === host );
+			if ( ! snapshotToDelete ) {
+				throw new LoggerError(
+					__(
+						'Preview site not found. ' +
+							'Use the `studio preview list` command to see available preview sites.'
+					)
+				);
+			}
+			logger.reportSuccess( __( 'Validation successful' ), true );
+
+			logger.reportStart( LoggerAction.DELETE, __( 'Deleting…' ) );
+			await deleteSnapshot( snapshotToDelete.atomicSiteId, token.accessToken );
+			await deleteSnapshotFromConfig( snapshotToDelete.url );
+			await emitCliEvent( {
+				event: SNAPSHOT_EVENTS.DELETED,
+				data: { snapshotUrl: snapshotToDelete.url },
+			} );
+			logger.reportSuccess( __( 'Deletion successful' ) );
+		} else {
+			logger.reportStart( LoggerAction.DELETE_ALL, __( 'Deleting all preview sites…' ) );
+
+			await deleteAllSnapshots( token.accessToken );
+			await deleteAllSnapshotsForUserFromConfig( token.id );
+			await emitCliEvent( { event: SNAPSHOT_EVENTS.DELETED_ALL } );
+
+			logger.reportSuccess( __( 'Deletion successful' ) );
+		}
 	} catch ( error ) {
 		if ( error instanceof LoggerError ) {
 			logger.reportError( error );
@@ -52,22 +79,36 @@ export async function runCommand( host: string ): Promise< void > {
 
 export const registerCommand = ( yargs: StudioArgv ) => {
 	return yargs.command( {
-		command: 'delete <host>',
-		describe: __( 'Delete a preview site' ),
+		command: 'delete [host] [--all]',
+		describe: __( 'Delete preview site(s)' ),
 		builder: ( yargs ) => {
 			return yargs
+				.option( 'all', {
+					type: 'boolean',
+					describe: __( 'Delete all preview sites for your user' ),
+					default: false,
+				} )
 				.positional( 'host', {
 					type: 'string',
 					description: __( 'Hostname of the preview site to delete' ),
-					demandOption: true,
+				} )
+				.check( ( argv ) => {
+					if ( ! argv.all && ! argv.host ) {
+						throw new Error( __( 'Hostname is required unless --all is passed.' ) );
+					}
+					return true;
 				} )
 				.option( 'path', {
 					hidden: true,
 				} );
 		},
 		handler: async ( argv ) => {
-			const normalizedHost = normalizeHostname( argv.host );
-			await runCommand( normalizedHost );
+			if ( argv.all ) {
+				await runCommand( Mode.DELETE_ALL_SNAPSHOT, undefined );
+			} else if ( argv.host ) {
+				const normalizedHost = normalizeHostname( argv.host );
+				await runCommand( Mode.DELETE_SINGLE_SNAPSHOT, normalizedHost );
+			}
 		},
 	} );
 };

--- a/apps/cli/commands/preview/tests/delete.test.ts
+++ b/apps/cli/commands/preview/tests/delete.test.ts
@@ -11,7 +11,7 @@ import {
 	mockReportWarning,
 	mockReportKeyValuePair,
 } from 'cli/tests/test-utils';
-import { runCommand } from '../delete';
+import { Mode, runCommand } from '../delete';
 
 vi.mock( import( '@studio/common/lib/shared-config' ), async ( importOriginal ) => ( {
 	...( await importOriginal() ),
@@ -67,7 +67,7 @@ describe( 'Preview Delete Command', () => {
 	} );
 
 	it( 'should complete the preview deletion process successfully', async () => {
-		await runCommand( mockSiteUrl );
+		await runCommand( Mode.DELETE_SINGLE_SNAPSHOT, mockSiteUrl );
 
 		expect( readAuthToken ).toHaveBeenCalled();
 		expect( getSnapshotsFromConfig ).toHaveBeenCalledWith( mockAuthToken.id );
@@ -83,7 +83,7 @@ describe( 'Preview Delete Command', () => {
 	it( 'should handle authentication errors', async () => {
 		vi.mocked( readAuthToken ).mockResolvedValue( null );
 
-		await runCommand( mockSiteUrl );
+		await runCommand( Mode.DELETE_SINGLE_SNAPSHOT, mockSiteUrl );
 
 		expect( mockReportError ).toHaveBeenCalled();
 		expect( mockReportError ).toHaveBeenCalledWith( expect.any( LoggerError ) );
@@ -93,7 +93,7 @@ describe( 'Preview Delete Command', () => {
 	it( 'should handle snapshot not found errors', async () => {
 		vi.mocked( getSnapshotsFromConfig ).mockResolvedValue( [] );
 
-		await runCommand( mockSiteUrl );
+		await runCommand( Mode.DELETE_SINGLE_SNAPSHOT, mockSiteUrl );
 
 		expect( mockReportError ).toHaveBeenCalled();
 		expect( mockReportError ).toHaveBeenCalledWith( expect.any( LoggerError ) );
@@ -106,7 +106,7 @@ describe( 'Preview Delete Command', () => {
 			throw new LoggerError( errorMessage );
 		} );
 
-		await runCommand( mockSiteUrl );
+		await runCommand( Mode.DELETE_SINGLE_SNAPSHOT, mockSiteUrl );
 
 		expect( mockReportError ).toHaveBeenCalled();
 		expect( mockReportError ).toHaveBeenCalledWith( expect.any( LoggerError ) );
@@ -119,7 +119,7 @@ describe( 'Preview Delete Command', () => {
 			throw new LoggerError( errorMessage );
 		} );
 
-		await runCommand( mockSiteUrl );
+		await runCommand( Mode.DELETE_SINGLE_SNAPSHOT, mockSiteUrl );
 
 		expect( mockReportError ).toHaveBeenCalled();
 		expect( mockReportError ).toHaveBeenCalledWith( expect.any( LoggerError ) );

--- a/apps/cli/commands/preview/tests/delete.test.ts
+++ b/apps/cli/commands/preview/tests/delete.test.ts
@@ -1,6 +1,9 @@
+import { SNAPSHOT_EVENTS } from '@studio/common/lib/cli-events';
 import { readAuthToken } from '@studio/common/lib/shared-config';
 import { vi } from 'vitest';
-import { deleteSnapshot } from 'cli/lib/api';
+import { deleteAllSnapshots, deleteSnapshot } from 'cli/lib/api';
+import { deleteAllSnapshotsForUserFromConfig } from 'cli/lib/cli-config/snapshots';
+import { emitCliEvent } from 'cli/lib/daemon-client';
 import { getSnapshotsFromConfig, deleteSnapshotFromConfig } from 'cli/lib/snapshots';
 import { LoggerError } from 'cli/logger';
 import {
@@ -18,6 +21,8 @@ vi.mock( import( '@studio/common/lib/shared-config' ), async ( importOriginal ) 
 	readAuthToken: vi.fn(),
 } ) );
 vi.mock( 'cli/lib/api' );
+vi.mock( 'cli/lib/cli-config/snapshots' );
+vi.mock( 'cli/lib/daemon-client' );
 vi.mock( 'cli/lib/snapshots' );
 vi.mock( 'cli/logger', () => ( {
 	Logger: class {
@@ -58,8 +63,11 @@ describe( 'Preview Delete Command', () => {
 
 		vi.mocked( readAuthToken ).mockResolvedValue( mockAuthToken );
 		vi.mocked( getSnapshotsFromConfig ).mockResolvedValue( [ mockSnapshot ] );
+		vi.mocked( deleteAllSnapshots ).mockResolvedValue( undefined );
 		vi.mocked( deleteSnapshot ).mockResolvedValue( undefined );
+		vi.mocked( deleteAllSnapshotsForUserFromConfig ).mockResolvedValue( undefined );
 		vi.mocked( deleteSnapshotFromConfig ).mockResolvedValue( undefined );
+		vi.mocked( emitCliEvent ).mockResolvedValue( undefined );
 	} );
 
 	afterEach( () => {
@@ -73,6 +81,10 @@ describe( 'Preview Delete Command', () => {
 		expect( getSnapshotsFromConfig ).toHaveBeenCalledWith( mockAuthToken.id );
 		expect( deleteSnapshot ).toHaveBeenCalledWith( mockAtomicSiteId, mockAuthToken.accessToken );
 		expect( deleteSnapshotFromConfig ).toHaveBeenCalledWith( mockSiteUrl );
+		expect( emitCliEvent ).toHaveBeenCalledWith( {
+			event: SNAPSHOT_EVENTS.DELETED,
+			data: { snapshotUrl: mockSiteUrl },
+		} );
 
 		expect( mockReportStart.mock.calls[ 0 ] ).toEqual( [ 'validate', 'Validating…' ] );
 		expect( mockReportSuccess.mock.calls[ 0 ] ).toEqual( [ 'Validation successful', true ] );
@@ -123,5 +135,29 @@ describe( 'Preview Delete Command', () => {
 
 		expect( mockReportError ).toHaveBeenCalled();
 		expect( mockReportError ).toHaveBeenCalledWith( expect.any( LoggerError ) );
+	} );
+
+	it( 'should complete deleting all preview sites successfully', async () => {
+		await runCommand( Mode.DELETE_ALL_SNAPSHOT, undefined );
+
+		expect( readAuthToken ).toHaveBeenCalled();
+		expect( deleteAllSnapshots ).toHaveBeenCalledWith( mockAuthToken.accessToken );
+		expect( deleteAllSnapshotsForUserFromConfig ).toHaveBeenCalledWith( mockAuthToken.id );
+		expect( emitCliEvent ).toHaveBeenCalledWith( { event: SNAPSHOT_EVENTS.DELETED_ALL } );
+		expect( deleteSnapshot ).not.toHaveBeenCalled();
+		expect( deleteSnapshotFromConfig ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should handle delete all preview sites errors', async () => {
+		const errorMessage = 'Failed to delete all preview sites';
+		vi.mocked( deleteAllSnapshots ).mockImplementation( () => {
+			throw new LoggerError( errorMessage );
+		} );
+
+		await runCommand( Mode.DELETE_ALL_SNAPSHOT, undefined );
+
+		expect( mockReportError ).toHaveBeenCalled();
+		expect( mockReportError ).toHaveBeenCalledWith( expect.any( LoggerError ) );
+		expect( deleteAllSnapshotsForUserFromConfig ).not.toHaveBeenCalled();
 	} );
 } );

--- a/apps/cli/lib/api.ts
+++ b/apps/cli/lib/api.ts
@@ -136,6 +136,19 @@ export async function deleteSnapshot( atomicSiteId: number, token: string ): Pro
 	}
 }
 
+export async function deleteAllSnapshots( token: string ): Promise< void > {
+	const wpcom = wpcomFactory( token, wpcomXhrRequest );
+
+	try {
+		await wpcom.req.post( {
+			path: '/jurassic-ninja/delete/all',
+			apiNamespace: 'wpcom/v2',
+		} );
+	} catch ( error ) {
+		throw new LoggerError( __( 'Failed to delete all preview sites' ), error );
+	}
+}
+
 export async function validateAccessToken( token: string ): Promise< void > {
 	const wpcom = wpcomFactory( token, wpcomXhrRequest );
 	try {

--- a/apps/cli/lib/cli-config/snapshots.ts
+++ b/apps/cli/lib/cli-config/snapshots.ts
@@ -106,6 +106,21 @@ export async function deleteSnapshotFromConfig( snapshotUrl: string ): Promise< 
 	}
 }
 
+export async function deleteAllSnapshotsForUserFromConfig( userId: number ): Promise< void > {
+	try {
+		await lockCliConfig();
+		const config = await readCliConfig();
+		const filtered = config.snapshots.filter( ( s ) => s.userId !== userId );
+		if ( filtered.length === config.snapshots.length ) {
+			return;
+		}
+		config.snapshots = filtered;
+		await saveCliConfig( config );
+	} finally {
+		await unlockCliConfig();
+	}
+}
+
 export async function setSnapshotInConfig(
 	snapshotUrl: string,
 	updates: { name?: string }

--- a/apps/cli/lib/daemon-client.ts
+++ b/apps/cli/lib/daemon-client.ts
@@ -341,6 +341,7 @@ const eventsSocketClient = new SocketRequestClient( SITE_EVENTS_SOCKET_PATH );
 type CliEventPayload =
 	| { event: SITE_EVENTS; data: { siteId: string } }
 	| { event: SNAPSHOT_EVENTS; data: { snapshotUrl: string } }
+	| { event: SNAPSHOT_EVENTS.DELETED_ALL }
 	| { event: AUTH_EVENTS; data: { token?: StoredAuthToken } };
 
 /**

--- a/apps/cli/lib/daemon-client.ts
+++ b/apps/cli/lib/daemon-client.ts
@@ -4,14 +4,8 @@ import { EventEmitter } from 'events';
 import fs from 'fs';
 import path from 'path';
 import { LOCKFILE_STALE_TIME, LOCKFILE_WAIT_TIME } from '@studio/common/constants';
-import {
-	type AUTH_EVENTS,
-	type SITE_EVENTS,
-	type SNAPSHOT_EVENTS,
-} from '@studio/common/lib/cli-events';
 import { isErrnoException } from '@studio/common/lib/is-errno-exception';
 import { lockFileAsync, unlockFileAsync } from '@studio/common/lib/lockfile';
-import { type StoredAuthToken } from '@studio/common/lib/shared-config';
 import { z } from 'zod';
 import {
 	PROCESS_MANAGER_EVENTS_SOCKET_PATH,
@@ -31,6 +25,7 @@ import {
 	ManagerMessage,
 	childMessageFromProcessManagerSchema,
 } from 'cli/lib/types/wordpress-server-ipc';
+import type { SocketEvent } from '@studio/common/lib/cli-events';
 
 const PROXY_PROCESS_NAME = 'studio-proxy';
 const CONNECTION_TIMEOUT_MS = 10_000;
@@ -338,16 +333,10 @@ export async function stopProcess( processName: string ): Promise< void > {
 
 const eventsSocketClient = new SocketRequestClient( SITE_EVENTS_SOCKET_PATH );
 
-type CliEventPayload =
-	| { event: SITE_EVENTS; data: { siteId: string } }
-	| { event: SNAPSHOT_EVENTS; data: { snapshotUrl: string } }
-	| { event: SNAPSHOT_EVENTS.DELETED_ALL }
-	| { event: AUTH_EVENTS; data: { token?: StoredAuthToken } };
-
 /**
  * Emit a CLI event via the events socket, for the `_events` command server to receive.
  */
-export async function emitCliEvent( payload: CliEventPayload ): Promise< void > {
+export async function emitCliEvent( payload: SocketEvent ): Promise< void > {
 	try {
 		await eventsSocketClient.send( payload );
 	} catch {

--- a/apps/studio/src/ipc-handlers.ts
+++ b/apps/studio/src/ipc-handlers.ts
@@ -127,6 +127,7 @@ export {
 export {
 	createSnapshot,
 	deleteSnapshot,
+	deleteAllSnapshots,
 	fetchSnapshots,
 	setSnapshot,
 	updateSnapshot,

--- a/apps/studio/src/ipc-utils.ts
+++ b/apps/studio/src/ipc-utils.ts
@@ -33,7 +33,7 @@ export interface IpcEvents {
 	'on-site-create-progress': [ { siteId: string; message: string } ];
 	'site-context-menu-action': [ { action: string; siteId: string } ];
 	'site-event': [ SiteEvent ];
-	'snapshot-changed': [ SnapshotEvent ];
+	'snapshot-event': [ SnapshotEvent ];
 	'sync-upload-network-paused': [ { error: string; selectedSiteId: string; remoteSiteId: number } ];
 	'sync-upload-resumed': [ { selectedSiteId: string; remoteSiteId: number } ];
 	'sync-upload-progress': [ { selectedSiteId: string; remoteSiteId: number; progress: number } ];

--- a/apps/studio/src/modules/cli/lib/cli-events-subscriber.ts
+++ b/apps/studio/src/modules/cli/lib/cli-events-subscriber.ts
@@ -96,7 +96,7 @@ export async function startCliEventsSubscriber(): Promise< void > {
 
 			const snapshotParsed = cliSnapshotEventSchema.safeParse( data );
 			if ( snapshotParsed.success ) {
-				void sendIpcEventToRenderer( 'snapshot-changed', snapshotParsed.data.value );
+				void sendIpcEventToRenderer( 'snapshot-event', snapshotParsed.data.value );
 				return;
 			}
 

--- a/apps/studio/src/modules/preview-site/components/create-preview-button.tsx
+++ b/apps/studio/src/modules/preview-site/components/create-preview-button.tsx
@@ -24,7 +24,7 @@ interface CreatePreviewButtonProps {
 export function CreatePreviewButton( { onClick, selectedSite, user }: CreatePreviewButtonProps ) {
 	const { __, _n } = useI18n();
 	const activeOperationsForAnySite = useRootSelector(
-		snapshotSelectors.selectActiveOperationsForAnySite
+		snapshotSelectors.selectActiveCreateUpdateOperationsForAnySite
 	);
 	const activeOperationsForCurrentSite = useRootSelector( ( state ) =>
 		snapshotSelectors.selectActiveCreateOperationForSite( state, selectedSite.id )

--- a/apps/studio/src/modules/preview-site/components/preview-site-row.tsx
+++ b/apps/studio/src/modules/preview-site/components/preview-site-row.tsx
@@ -15,7 +15,7 @@ import { getIpcApi } from 'src/lib/get-ipc-api';
 import { DeleteProgressRow } from 'src/modules/preview-site/components/delete-progress-row';
 import { PreviewActionButtonsMenu } from 'src/modules/preview-site/components/preview-action-buttons-menu';
 import { useAppDispatch, useRootSelector } from 'src/stores';
-import { snapshotActions, snapshotSelectors } from 'src/stores/snapshot-slice';
+import { snapshotSelectors, snapshotThunks } from 'src/stores/snapshot-slice';
 import { useGetSnapshotStatus } from 'src/stores/wpcom-api';
 
 interface PreviewSiteRowProps {
@@ -179,9 +179,10 @@ export function PreviewSiteRow( {
 							<Button
 								variant="link"
 								onClick={ () => {
-									dispatch(
-										snapshotActions.deleteSnapshotLocally( {
-											atomicSiteId: snapshot.atomicSiteId,
+									void dispatch(
+										snapshotThunks.deleteSnapshot( {
+											hostname: snapshot.url,
+											optimistic: true,
 										} )
 									);
 								} }

--- a/apps/studio/src/modules/preview-site/lib/ipc-handlers.ts
+++ b/apps/studio/src/modules/preview-site/lib/ipc-handlers.ts
@@ -68,6 +68,15 @@ export async function deleteSnapshot( event: IpcMainInvokeEvent, hostname: strin
 	return executePreviewCliCommand( [ 'preview', 'delete', hostname ], parentWindow );
 }
 
+export async function deleteAllSnapshots() {
+	return new Promise< void >( ( resolve, reject ) => {
+		const [ cliEventEmitter ] = executeCliCommand( [ 'preview', 'delete', '--all' ] );
+		cliEventEmitter.on( 'error', ( error ) => reject( error ) );
+		cliEventEmitter.on( 'failure', ( error ) => reject( error ) );
+		cliEventEmitter.on( 'success', () => resolve() );
+	} );
+}
+
 export async function setSnapshot(
 	event: IpcMainInvokeEvent,
 	hostname: string,

--- a/apps/studio/src/preload.ts
+++ b/apps/studio/src/preload.ts
@@ -58,6 +58,7 @@ const api: IpcApi = {
 	updateSnapshot: ( siteFolder, hostname ) =>
 		ipcRendererInvoke( 'updateSnapshot', siteFolder, hostname ),
 	deleteSnapshot: ( hostname ) => ipcRendererInvoke( 'deleteSnapshot', hostname ),
+	deleteAllSnapshots: () => ipcRendererInvoke( 'deleteAllSnapshots' ),
 	setSnapshot: ( hostname, options ) => ipcRendererInvoke( 'setSnapshot', hostname, options ),
 	getLastSeenVersion: () => ipcRendererInvoke( 'getLastSeenVersion' ),
 	saveLastSeenVersion: ( version ) => ipcRendererInvoke( 'saveLastSeenVersion', version ),

--- a/apps/studio/src/stores/index.ts
+++ b/apps/studio/src/stores/index.ts
@@ -18,7 +18,7 @@ import onboardingReducer from 'src/stores/onboarding-slice';
 import {
 	reducer as snapshotReducer,
 	refreshSnapshots,
-	updateSnapshotLocally,
+	snapshotActions,
 } from 'src/stores/snapshot-slice';
 import { syncReducer, syncOperationsActions } from 'src/stores/sync';
 import { connectedSitesApi, connectedSitesReducer } from 'src/stores/sync/connected-sites';
@@ -86,14 +86,15 @@ startAppListening( {
 
 // Save snapshot changes to CLI config via preview set command
 startAppListening( {
-	actionCreator: updateSnapshotLocally,
+	actionCreator: snapshotActions.updateSnapshotLocally,
 	async effect( action, listenerApi ) {
-		const { atomicSiteId, snapshot } = action.payload;
-		const previous = listenerApi
-			.getOriginalState()
-			.snapshot.snapshots.find( ( s ) => s.atomicSiteId === atomicSiteId );
-		if ( previous?.url && snapshot.name !== undefined && snapshot.name !== previous.name ) {
-			await getIpcApi().setSnapshot( previous.url, { name: snapshot.name } );
+		const state = listenerApi.getState();
+		const snapshot = state.snapshot.snapshots.find(
+			( snapshot ) => snapshot.atomicSiteId === action.payload.atomicSiteId
+		);
+
+		if ( snapshot && snapshot.name ) {
+			await getIpcApi().setSnapshot( snapshot.url, { name: snapshot.name } );
 		}
 	},
 } );

--- a/apps/studio/src/stores/snapshot-slice.ts
+++ b/apps/studio/src/stores/snapshot-slice.ts
@@ -13,7 +13,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { LIMIT_OF_ZIP_SITES_PER_USER } from 'src/constants';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 import { RootState, store } from 'src/stores/index';
-import { getWpcomClient, wpcomApi } from 'src/stores/wpcom-api';
+import { wpcomApi } from 'src/stores/wpcom-api';
 import type { UUID } from 'crypto';
 
 type BaseOperation = {

--- a/apps/studio/src/stores/snapshot-slice.ts
+++ b/apps/studio/src/stores/snapshot-slice.ts
@@ -13,7 +13,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { LIMIT_OF_ZIP_SITES_PER_USER } from 'src/constants';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 import { RootState, store } from 'src/stores/index';
-import { wpcomApi } from 'src/stores/wpcom-api';
+import { getWpcomClient, wpcomApi } from 'src/stores/wpcom-api';
 import type { UUID } from 'crypto';
 
 type BaseOperation = {
@@ -38,6 +38,7 @@ type UpdateOperation = BaseOperation & {
 type DeleteOperation = BaseOperation & {
 	snapshotUrl: string;
 	type: 'delete';
+	optimistic?: boolean;
 };
 
 type BulkOperation = Omit< BaseOperation, 'progress' > & {
@@ -90,7 +91,7 @@ const updateSnapshot = createTypedAsyncThunk<
 
 const deleteSnapshot = createTypedAsyncThunk(
 	'snapshot/deleteSnapshot',
-	async ( { hostname }: { hostname: string } ) => {
+	async ( { hostname }: { hostname: string; optimistic?: boolean } ) => {
 		const { operationId } = await getIpcApi().deleteSnapshot( hostname );
 		return { operationId };
 	}
@@ -131,7 +132,7 @@ const deleteAllSnapshotsForUser = createTypedAsyncThunk<
 	return { operations, bulkOperationId };
 } );
 
-export const updateSnapshotLocally = createAction< {
+const updateSnapshotLocally = createAction< {
 	atomicSiteId: number;
 	snapshot: Partial< Omit< Snapshot, 'atomicSiteId' > >;
 } >( 'snapshot/updateSnapshot' );
@@ -144,6 +145,9 @@ const snapshotSlice = createSlice( {
 			state.snapshots = state.snapshots.filter(
 				( snapshot ) => snapshot.atomicSiteId !== action.payload.atomicSiteId
 			);
+		},
+		deleteAllSnapshots: ( state ) => {
+			state.snapshots = [];
 		},
 		addSnapshot: ( state, action: PayloadAction< { snapshot: Snapshot } > ) => {
 			state.snapshots.push( action.payload.snapshot );
@@ -194,6 +198,7 @@ const snapshotSlice = createSlice( {
 					snapshotUrl: action.meta.arg.hostname,
 					status: 'pending',
 					type: 'delete',
+					optimistic: action.meta.arg.optimistic ?? false,
 				};
 			} )
 			.addMatcher(
@@ -263,10 +268,14 @@ const snapshotSlice = createSlice( {
 	},
 } );
 
-const selectActiveOperationsForAnySite = createSelector(
+const selectActiveCreateUpdateOperationsForAnySite = createSelector(
 	[ ( state: RootState ) => state.snapshot.operations ],
 	( operations ) =>
-		Object.values( operations ).filter( ( operation ) => operation.status === 'pending' )
+		Object.values( operations ).filter(
+			( operation ) =>
+				( operation.type === 'update' || operation.type === 'create' ) &&
+				operation.status === 'pending'
+		)
 );
 
 const selectSnapshotsBySite = createSelector(
@@ -291,25 +300,39 @@ const selectSnapshotsBySiteAndUser = createSelector(
 		( state: RootState ) => state.snapshot.snapshots,
 		( state: RootState, localSiteId: string ) => localSiteId,
 		( state: RootState, localSiteId: string, userId: number ) => userId,
+		( state: RootState ) => state.snapshot.operations,
 	],
-	( snapshots = [], localSiteId, userId ) =>
-		snapshots.filter(
-			( snapshot ) => snapshot.localSiteId === localSiteId && snapshot.userId === userId
-		)
+	( snapshots = [], localSiteId, userId, operations ) =>
+		snapshots
+			.filter( ( snapshot ) => snapshot.localSiteId === localSiteId && snapshot.userId === userId )
+			// Filter out any snapshots that are currently being deleted optimistically
+			.filter(
+				( snapshot ) =>
+					! Object.values( operations ).some(
+						( operation ) =>
+							operation.snapshotUrl === snapshot.url &&
+							operation.type === 'delete' &&
+							operation.optimistic
+					)
+			)
 );
 
 // Optimistically update the snapshot usage count and schedule a re-fetch.
 // There's a risk that more sites are deleted locally than the count returned by the
 // API, because expired sites are preserved locally. Therefore, we need to ensure
 // the count is non-negative.
-function updateSnapshotUsageCount( countDiff: number ) {
-	if ( countDiff === 0 ) {
+function updateSnapshotUsageCount( countDiff: number, isAbsolute = false ) {
+	if ( countDiff === 0 && ! isAbsolute ) {
 		return;
 	}
 
 	store.dispatch(
 		wpcomApi.util.updateQueryData( 'getSnapshotUsage', undefined, ( data ) => {
-			data.siteCount = Math.max( 0, data.siteCount + countDiff );
+			if ( isAbsolute ) {
+				data.siteCount = countDiff;
+			} else {
+				data.siteCount = Math.max( 0, data.siteCount + countDiff );
+			}
 		} )
 	);
 
@@ -371,7 +394,7 @@ function isBulkOperationSettled( bulkOperation: BulkOperation ) {
 	} );
 }
 
-window.ipcListener.subscribe( 'snapshot-changed', ( _, snapshotEvent ) => {
+window.ipcListener.subscribe( 'snapshot-event', ( _, snapshotEvent ) => {
 	const { event: eventType, snapshot, snapshotUrl } = snapshotEvent;
 
 	if ( eventType === SNAPSHOT_EVENTS.DELETED ) {
@@ -383,6 +406,12 @@ window.ipcListener.subscribe( 'snapshot-changed', ( _, snapshotEvent ) => {
 			);
 			updateSnapshotUsageCount( -1 );
 		}
+		return;
+	}
+
+	if ( eventType === SNAPSHOT_EVENTS.DELETED_ALL ) {
+		store.dispatch( snapshotSlice.actions.deleteAllSnapshots() );
+		updateSnapshotUsageCount( 0, true );
 		return;
 	}
 
@@ -522,7 +551,9 @@ window.ipcListener.subscribe( 'snapshot-success', ( event, payload ) => {
 			body: sprintf( __( "Preview site '%s' has been updated." ), snapshotUrl ),
 		} );
 	} else if ( operation.type === 'delete' ) {
-		if ( ! bulkOperation ) {
+		if ( operation.optimistic ) {
+			// Do nothing
+		} else if ( ! bulkOperation ) {
 			getIpcApi().showNotification( {
 				title: operation.snapshotName,
 				body: sprintf( __( "Preview site '%s' has been deleted." ), snapshotUrl ),
@@ -542,7 +573,7 @@ export const snapshotActions = {
 };
 export const snapshotSelectors = {
 	...snapshotSlice.selectors,
-	selectActiveOperationsForAnySite,
+	selectActiveCreateUpdateOperationsForAnySite,
 	selectSnapshotsBySite,
 	selectSnapshotsByUser,
 	selectSnapshotsBySiteAndUser,

--- a/apps/studio/src/stores/snapshot-slice.ts
+++ b/apps/studio/src/stores/snapshot-slice.ts
@@ -395,7 +395,15 @@ function isBulkOperationSettled( bulkOperation: BulkOperation ) {
 }
 
 window.ipcListener.subscribe( 'snapshot-event', ( _, snapshotEvent ) => {
-	const { event: eventType, snapshot, snapshotUrl } = snapshotEvent;
+	const { event: eventType } = snapshotEvent;
+
+	if ( eventType === SNAPSHOT_EVENTS.DELETED_ALL ) {
+		store.dispatch( snapshotSlice.actions.deleteAllSnapshots() );
+		updateSnapshotUsageCount( 0, true );
+		return;
+	}
+
+	const { snapshot, snapshotUrl } = snapshotEvent;
 
 	if ( eventType === SNAPSHOT_EVENTS.DELETED ) {
 		const state = store.getState();
@@ -406,12 +414,6 @@ window.ipcListener.subscribe( 'snapshot-event', ( _, snapshotEvent ) => {
 			);
 			updateSnapshotUsageCount( -1 );
 		}
-		return;
-	}
-
-	if ( eventType === SNAPSHOT_EVENTS.DELETED_ALL ) {
-		store.dispatch( snapshotSlice.actions.deleteAllSnapshots() );
-		updateSnapshotUsageCount( 0, true );
 		return;
 	}
 

--- a/apps/studio/src/stores/wpcom-api.ts
+++ b/apps/studio/src/stores/wpcom-api.ts
@@ -4,6 +4,7 @@ import { DAY_MS } from '@studio/common/constants';
 import wpcomFactory from '@studio/common/lib/wpcom-factory';
 import wpcomXhrRequest from '@studio/common/lib/wpcom-xhr-request-factory';
 import { z } from 'zod';
+import { getIpcApi } from 'src/lib/get-ipc-api';
 import { withOfflineCheck, withOfflineCheckMutation } from 'src/stores/utils/with-offline-check';
 import type { BaseQueryFn, FetchBaseQueryError } from '@reduxjs/toolkit/query';
 import type { WPCOM } from 'wpcom/types';
@@ -178,11 +179,12 @@ export const wpcomApi = createApi( {
 			keepUnusedDataFor: 60 * 60,
 		} ),
 		deleteAllSnapshots: builder.mutation< void, void >( {
-			query: () => ( {
-				path: '/jurassic-ninja/delete/all',
-				apiNamespace: 'wpcom/v2',
-				method: 'POST',
-			} ),
+			queryFn: async () => {
+				await getIpcApi().deleteAllSnapshots();
+				return { data: undefined };
+			},
+			// We don't invalidate the `SnapshotUsage` tag because the API won't return the correct data
+			// until we've waited a few seconds. `snapshot-slice.ts` handles the invalidation.
 		} ),
 	} ),
 } );

--- a/tools/common/lib/cli-events.ts
+++ b/tools/common/lib/cli-events.ts
@@ -90,14 +90,14 @@ export type AuthEvent = z.infer< typeof authEventSchema >;
 /**
  * Socket-level schemas for events sent between daemon-client and the _events command.
  */
-export const siteSocketEventSchema = z.object( {
-	event: z.string(),
+const siteSocketEventSchema = z.object( {
+	event: z.enum( SITE_EVENTS ),
 	data: z.object( {
 		siteId: z.string(),
 	} ),
 } );
 
-export const snapshotSocketEventSchema = z.union( [
+const snapshotSocketEventSchema = z.union( [
 	z.object( {
 		event: z.literal( SNAPSHOT_EVENTS.DELETED_ALL ),
 	} ),
@@ -108,14 +108,20 @@ export const snapshotSocketEventSchema = z.union( [
 		} ),
 	} ),
 ] );
-export type SnapshotSocketEvent = z.infer< typeof snapshotSocketEventSchema >;
 
-export const authSocketEventSchema = z.object( {
+const authSocketEventSchema = z.object( {
 	event: z.enum( AUTH_EVENTS ),
 	data: z.object( {
 		token: authTokenSchema.optional(),
 	} ),
 } );
+
+export const socketEventSchema = z.union( [
+	siteSocketEventSchema,
+	snapshotSocketEventSchema,
+	authSocketEventSchema,
+] );
+export type SocketEvent = z.infer< typeof socketEventSchema >;
 
 /**
  * CLI stdout key-value pair schemas for events parsed by Studio's cli-events-subscriber.

--- a/tools/common/lib/cli-events.ts
+++ b/tools/common/lib/cli-events.ts
@@ -55,6 +55,7 @@ export enum SNAPSHOT_EVENTS {
 	CREATED = 'snapshot-created',
 	UPDATED = 'snapshot-updated',
 	DELETED = 'snapshot-deleted',
+	DELETED_ALL = 'snapshot-deleted-all',
 }
 
 export const siteEventSchema = z.object( {

--- a/tools/common/lib/cli-events.ts
+++ b/tools/common/lib/cli-events.ts
@@ -67,11 +67,16 @@ export const siteEventSchema = z.object( {
 
 export type SiteEvent = z.infer< typeof siteEventSchema >;
 
-export const snapshotEventSchema = z.object( {
-	event: z.enum( SNAPSHOT_EVENTS ),
-	snapshot: snapshotSchema.optional(),
-	snapshotUrl: z.string(),
-} );
+export const snapshotEventSchema = z.union( [
+	z.object( {
+		event: z.literal( SNAPSHOT_EVENTS.DELETED_ALL ),
+	} ),
+	z.object( {
+		event: z.enum( SNAPSHOT_EVENTS ),
+		snapshot: snapshotSchema.optional(),
+		snapshotUrl: z.string(),
+	} ),
+] );
 
 export type SnapshotEvent = z.infer< typeof snapshotEventSchema >;
 
@@ -92,12 +97,18 @@ export const siteSocketEventSchema = z.object( {
 	} ),
 } );
 
-export const snapshotSocketEventSchema = z.object( {
-	event: z.enum( SNAPSHOT_EVENTS ),
-	data: z.object( {
-		snapshotUrl: z.string(),
+export const snapshotSocketEventSchema = z.union( [
+	z.object( {
+		event: z.literal( SNAPSHOT_EVENTS.DELETED_ALL ),
 	} ),
-} );
+	z.object( {
+		event: z.enum( SNAPSHOT_EVENTS ),
+		data: z.object( {
+			snapshotUrl: z.string(),
+		} ),
+	} ),
+] );
+export type SnapshotSocketEvent = z.infer< typeof snapshotSocketEventSchema >;
 
 export const authSocketEventSchema = z.object( {
 	event: z.enum( AUTH_EVENTS ),

--- a/tools/common/logger-actions.ts
+++ b/tools/common/logger-actions.ts
@@ -12,6 +12,7 @@ export enum PreviewCommandLoggerAction {
 	ARCHIVE = 'archive',
 	LOAD = 'load',
 	DELETE = 'delete',
+	DELETE_ALL = 'deleteAll',
 	UPLOAD = 'upload',
 	READY = 'ready',
 	APPDATA = 'appdata',


### PR DESCRIPTION
## Related issues

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

- Fixes STU-1459

## How AI was used in this PR

<!--
Help reviewers understand what to look for and verify that you've reviewed the code yourself.
-->

Only to update `delete.test.ts`.

## Proposed Changes

https://github.com/Automattic/studio/pull/2807 introduced two regressions:

- The "Delete all preview sites" button in the settings modal stopped working. 
- The "Clear" button on deleted preview site rows didn't persist the chance to the config file. 

The app no longer has direct access to the config file where the snapshots live (`cli.json`), so the old strategy for the "Delete all preview sites" button of simply emptying the `snapshots` array in the config file no longer works.

I considered iterating over the snapshots and deleting them from `snapshot-slice.ts` with a "bulk operation". That's how we used to do it before https://github.com/Automattic/studio/pull/1950/, but that PR improved on what we had, so ideally we want to keep that behavior.

In the end, my solution was to:

1. Add an `--all` option to the `preview delete` CLI command. 
2. Adjust the app to spawn a `preview delete --all` command when the user clicks the "Delete all preview sites" button.
3. To fix the "Clear" button issue, I made it so each click triggers a `preview delete <url>` command. I added an `optimistic` prop to those actions so the sites disappear immediately from the UI, without the progress bar we normally show for delete operations. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. `npm start`
2. Create a preview site
3. Open the settings modal and go to the Account tab
4. Delete all preview sites
5. Ensure that it works as expected
6. Create another preview site
7. Open `~/.studio/cli.json`
8. Edit the `date` field for the snapshot. Change it to `Date.now() - 604800000 * 2` (two weeks ago)
9. Reload the Studio UI
10. Go to the Previews tab
11. Ensure that the Clear button is visible and that it works as expected
12. Reload the Studio UI
13. Ensure that the clear action was persisted and that the preview site is no longer there

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
