### PR TITLE
MCP Settings: Replace setup guides with Learn more link to docs

### DIFF
--- a/apps/studio/src/lib/get-localized-link.ts
+++ b/apps/studio/src/lib/get-localized-link.ts
@@ -37,6 +37,9 @@ const DOCS_LINKS = {
 	docsSslInStudio: {
 		en: 'https://developer.wordpress.com/docs/developer-tools/studio/ssl-in-studio/',
 	},
+	docsMcp: {
+		en: 'https://developer.wordpress.com/docs/developer-tools/studio/mcp/',
+	},
 } satisfies Record< `docs${ string }`, TranslatedLink >;
 
 const BLOG_LINKS = {

--- a/apps/studio/src/modules/mcp/components/mcp-settings.tsx
+++ b/apps/studio/src/modules/mcp/components/mcp-settings.tsx
@@ -38,30 +38,6 @@ export function McpSettings() {
 					/>
 				</div>
 			</div>
-			<p className="a8c-body-small text-frame-text-secondary m-0">
-				{ __( 'Setup guides:' ) }{ ' ' }
-				<DocLink label={ __( 'Claude Code' ) } url="https://code.claude.com/docs/en/mcp" />
-				{ ', ' }
-				<DocLink
-					label={ __( 'Claude Desktop' ) }
-					url="https://modelcontextprotocol.io/quickstart/user"
-				/>
-				{ ', ' }
-				<DocLink label={ __( 'Codex' ) } url="https://developers.openai.com/codex/mcp" />
-				{ ', ' }
-				<DocLink
-					label={ __( 'Cursor' ) }
-					url="https://cursor.com/docs/mcp#installing-mcp-servers"
-				/>
-				{ ', ' }
-				<DocLink label={ __( 'Windsurf' ) } url="https://docs.windsurf.com/windsurf/cascade/mcp" />
-				{ ', ' }
-				<DocLink
-					label={ __( 'VS Code' ) }
-					url="https://code.visualstudio.com/docs/copilot/chat/mcp-servers"
-				/>
-				.
-			</p>
 		</div>
 	);
 }

--- a/apps/studio/src/modules/mcp/components/mcp-settings.tsx
+++ b/apps/studio/src/modules/mcp/components/mcp-settings.tsx
@@ -1,16 +1,8 @@
 import { getMcpServerConfigJson } from '@studio/common/lib/mcp-config';
+import { createInterpolateElement } from '@wordpress/element';
 import { useI18n } from '@wordpress/react-i18n';
-import Button from 'src/components/button';
 import { CopyTextButton } from 'src/components/copy-text-button';
-import { getIpcApi } from 'src/lib/get-ipc-api';
-
-function DocLink( { label, url }: { label: string; url: string } ) {
-	return (
-		<Button variant="link" onClick={ () => getIpcApi().openURL( url ) }>
-			{ label }
-		</Button>
-	);
-}
+import { LearnMoreLink } from 'src/components/learn-more';
 
 export function McpSettings() {
 	const { __ } = useI18n();
@@ -19,8 +11,13 @@ export function McpSettings() {
 	return (
 		<div className="flex flex-col gap-4">
 			<p className="a8c-body-small m-0">
-				{ __(
-					"Connect your AI coding assistant to the Studio MCP to let it create, configure and interact with your local WordPress sites. Copy the JSON configuration below and add it to your assistant's MCP settings."
+				{ createInterpolateElement(
+					__(
+						"Connect your AI coding assistant to the Studio MCP to let it create, configure and interact with your local WordPress sites. Copy the JSON configuration below and add it to your assistant's MCP settings. <learn_more_link />"
+					),
+					{
+						learn_more_link: <LearnMoreLink docsLinksKey="docsMcp" />,
+					}
 				) }
 			</p>
 			<div className="relative">


### PR DESCRIPTION
## Related issues

- Fixes STU-1436

## Proposed Changes

- Remove individual external setup guide links (Claude Code, Claude Desktop, Codex, Cursor, Windsurf, VS Code) from the MCP settings panel, in favor of Learn more link pointing to Studio docs
- Add `docsMcp` entry to the localized links registry

## Testing Instructions

- Start the app with `ENABLE_AGENT_SUITE=true npm start`
- Open Studio Settings → MCP
- Verify the description text ends with a "Learn more" link
- Click the link and verify it opens https://developer.wordpress.com/docs/developer-tools/studio/mcp/ (Currently is redirected to WPcom MCP, I'll update the link when we have it online)

| Before | After Light | After Dark |
|--------|--------| ---- |
| <img width="1012" height="712" alt="Screenshot 2026-03-25 at 15 05 48" src="https://github.com/user-attachments/assets/23dbc04b-01f4-4e3c-a8b4-6003e210f574" /> | <img width="1012" height="712" alt="Screenshot 2026-03-25 at 14 48 54" src="https://github.com/user-attachments/assets/dea20021-27b4-4f52-a5aa-4192324c2f61" /> |<img width="1012" height="712" alt="Screenshot 2026-03-25 at 14 47 33" src="https://github.com/user-attachments/assets/fe968478-7329-4453-8124-eb81f73639fa" /> |



## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?