### PR TITLE
Fix JSPI detection using runtime feature check

### DIFF
--- a/apps/cli/lib/run-wp-cli-command.ts
+++ b/apps/cli/lib/run-wp-cli-command.ts
@@ -8,11 +8,11 @@ import {
 	ProcessIdAllocator,
 } from '@php-wasm/universal';
 import { createSpawnHandler } from '@php-wasm/util';
+import { isJspiAvailable } from '@studio/common/lib/jspi';
 import { cleanupLegacyMuPlugins, getMuPlugins } from '@studio/common/lib/mu-plugins';
 import { LatestSupportedPHPVersion } from '@studio/common/types/php-versions';
 import { __ } from '@wordpress/i18n';
 import { setupPlatformLevelMuPlugins } from '@wp-playground/wordpress';
-import { isJspiAvailable } from '@studio/common/lib/jspi';
 import { getSqliteCommandPath, getWpCliPharPath } from 'cli/lib/server-files';
 
 const processIdAllocator = new ProcessIdAllocator();

--- a/apps/cli/lib/run-wp-cli-command.ts
+++ b/apps/cli/lib/run-wp-cli-command.ts
@@ -12,7 +12,7 @@ import { cleanupLegacyMuPlugins, getMuPlugins } from '@studio/common/lib/mu-plug
 import { LatestSupportedPHPVersion } from '@studio/common/types/php-versions';
 import { __ } from '@wordpress/i18n';
 import { setupPlatformLevelMuPlugins } from '@wp-playground/wordpress';
-import semver from 'semver';
+import { isJspiAvailable } from '@studio/common/lib/jspi';
 import { getSqliteCommandPath, getWpCliPharPath } from 'cli/lib/server-files';
 
 const processIdAllocator = new ProcessIdAllocator();
@@ -48,11 +48,10 @@ export async function runWpCliCommand(
 	phpVersion: SupportedPHPVersion,
 	args: string[]
 ): Promise< [ StreamedPHPResponse, exitPhp: () => void ] > {
-	const doesCurrentNodeSupportJspi = semver.gte( process.version, '24.0.0' );
 	const id = await loadNodeRuntime( phpVersion, {
 		followSymlinks: true,
-		withRedis: doesCurrentNodeSupportJspi,
-		withMemcached: doesCurrentNodeSupportJspi,
+		withRedis: isJspiAvailable,
+		withMemcached: isJspiAvailable,
 		emscriptenOptions: {
 			processId: processIdAllocator.claim(),
 		},

--- a/apps/cli/lib/run-wp-cli-command.ts
+++ b/apps/cli/lib/run-wp-cli-command.ts
@@ -8,7 +8,7 @@ import {
 	ProcessIdAllocator,
 } from '@php-wasm/universal';
 import { createSpawnHandler } from '@php-wasm/util';
-import { isJspiAvailable } from '@studio/common/lib/jspi';
+import { IS_JSPI_AVAILABLE } from '@studio/common/lib/jspi';
 import { cleanupLegacyMuPlugins, getMuPlugins } from '@studio/common/lib/mu-plugins';
 import { LatestSupportedPHPVersion } from '@studio/common/types/php-versions';
 import { __ } from '@wordpress/i18n';
@@ -50,8 +50,8 @@ export async function runWpCliCommand(
 ): Promise< [ StreamedPHPResponse, exitPhp: () => void ] > {
 	const id = await loadNodeRuntime( phpVersion, {
 		followSymlinks: true,
-		withRedis: isJspiAvailable,
-		withMemcached: isJspiAvailable,
+		withRedis: IS_JSPI_AVAILABLE,
+		withMemcached: IS_JSPI_AVAILABLE,
 		emscriptenOptions: {
 			processId: processIdAllocator.claim(),
 		},

--- a/apps/cli/wordpress-server-child.ts
+++ b/apps/cli/wordpress-server-child.ts
@@ -13,6 +13,7 @@
 import { dirname } from 'path';
 import { DEFAULT_PHP_VERSION } from '@studio/common/constants';
 import { isWordPressDirectory } from '@studio/common/lib/fs-utils';
+import { isJspiAvailable } from '@studio/common/lib/jspi';
 import { cleanupLegacyMuPlugins, getMuPlugins } from '@studio/common/lib/mu-plugins';
 import { decodePassword } from '@studio/common/lib/passwords';
 import { formatPlaygroundCliMessage } from '@studio/common/lib/playground-cli-messages';
@@ -28,7 +29,6 @@ import {
 } from '@wp-playground/storage';
 import { WordPressInstallMode } from '@wp-playground/wordpress';
 import fs from 'fs-extra';
-import semver from 'semver';
 import { z } from 'zod';
 import { sanitizeRunCLIArgs } from 'cli/lib/cli-args-sanitizer';
 import { rewriteWpCliPostContentToFile } from 'cli/lib/rewrite-wp-cli-post-content';
@@ -234,7 +234,6 @@ async function getBaseRunCLIArgs(
 		} );
 	}
 
-	const doesCurrentNodeSupportJspi = semver.gte( process.version, '24.0.0' );
 	const args: RunCLIArgs = {
 		command,
 		internalCookieStore: false,
@@ -246,8 +245,8 @@ async function getBaseRunCLIArgs(
 		'site-url': config.absoluteUrl || `http://localhost:${ config.port }`,
 		blueprint: blueprintBundle,
 		wordpressInstallMode,
-		redis: doesCurrentNodeSupportJspi,
-		memcached: doesCurrentNodeSupportJspi,
+		redis: isJspiAvailable,
+		memcached: isJspiAvailable,
 	};
 
 	if ( config.wpVersion ) {

--- a/apps/cli/wordpress-server-child.ts
+++ b/apps/cli/wordpress-server-child.ts
@@ -13,7 +13,7 @@
 import { dirname } from 'path';
 import { DEFAULT_PHP_VERSION } from '@studio/common/constants';
 import { isWordPressDirectory } from '@studio/common/lib/fs-utils';
-import { isJspiAvailable } from '@studio/common/lib/jspi';
+import { IS_JSPI_AVAILABLE } from '@studio/common/lib/jspi';
 import { cleanupLegacyMuPlugins, getMuPlugins } from '@studio/common/lib/mu-plugins';
 import { decodePassword } from '@studio/common/lib/passwords';
 import { formatPlaygroundCliMessage } from '@studio/common/lib/playground-cli-messages';
@@ -245,8 +245,8 @@ async function getBaseRunCLIArgs(
 		'site-url': config.absoluteUrl || `http://localhost:${ config.port }`,
 		blueprint: blueprintBundle,
 		wordpressInstallMode,
-		redis: isJspiAvailable,
-		memcached: isJspiAvailable,
+		redis: IS_JSPI_AVAILABLE,
+		memcached: IS_JSPI_AVAILABLE,
 	};
 
 	if ( config.wpVersion ) {

--- a/apps/studio/bin/studio-cli.bat
+++ b/apps/studio/bin/studio-cli.bat
@@ -15,12 +15,12 @@ rem Prevent node from printing warnings about NODE_OPTIONS being ignored
 set NODE_OPTIONS=
 
 if exist "%BUNDLED_NODE_EXECUTABLE%" (
-	"!BUNDLED_NODE_EXECUTABLE!" "!CLI_SCRIPT!" %*
+	"!BUNDLED_NODE_EXECUTABLE!" --experimental-wasm-jspi "!CLI_SCRIPT!" %*
 ) else (
 	if not exist "!CLI_SCRIPT!" (
 		set "CLI_SCRIPT=%~dp0..\dist\cli\main.js"
 	)
-	node "!CLI_SCRIPT!" %*
+	node --experimental-wasm-jspi "!CLI_SCRIPT!" %*
 )
 
 set "EXIT_CODE=!ERRORLEVEL!"

--- a/apps/studio/bin/studio-cli.sh
+++ b/apps/studio/bin/studio-cli.sh
@@ -9,7 +9,7 @@ CLI_SCRIPT="$CONTENTS_DIR/Resources/cli/main.js"
 if [ -x "$BUNDLED_NODE_EXECUTABLE" ]; then
 	# Prevent node from printing warnings about NODE_OPTIONS being ignored
 	unset NODE_OPTIONS
-	exec "$BUNDLED_NODE_EXECUTABLE" "$CLI_SCRIPT" "$@"
+	exec "$BUNDLED_NODE_EXECUTABLE" --experimental-wasm-jspi "$CLI_SCRIPT" "$@"
 else
 	# If the default script path is not found, assume that this script lives in the development directory
 	# and look for the CLI JS bundle in the `./dist` directory
@@ -20,5 +20,5 @@ else
 
 	# Prevent node from printing warnings about NODE_OPTIONS being ignored
 	unset NODE_OPTIONS
-	exec node "$CLI_SCRIPT" "$@"
+	exec node --experimental-wasm-jspi "$CLI_SCRIPT" "$@"
 fi

--- a/tools/common/lib/jspi.ts
+++ b/tools/common/lib/jspi.ts
@@ -1,0 +1,11 @@
+/**
+ * Checks whether the WebAssembly JavaScript Promise Integration (JSPI) API
+ * is available in the current runtime.
+ *
+ * JSPI is required for Redis and memcached PHP extensions in WordPress
+ * Playground. It's a stage-3 proposal currently gated behind Node's
+ * `--experimental-wasm-jspi` flag. Once it ships unflagged, this helper
+ * will return `true` automatically — no code changes needed.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const isJspiAvailable = typeof ( WebAssembly as any ).promising === 'function';

--- a/tools/common/lib/jspi.ts
+++ b/tools/common/lib/jspi.ts
@@ -7,5 +7,4 @@
  * flag. Once it ships unflagged, this helper will return `true`
  * automatically — no code changes needed.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const isJspiAvailable = typeof ( WebAssembly as any ).promising === 'function';
+export const IS_JSPI_AVAILABLE = 'Suspending' in WebAssembly;

--- a/tools/common/lib/jspi.ts
+++ b/tools/common/lib/jspi.ts
@@ -3,9 +3,9 @@
  * is available in the current runtime.
  *
  * JSPI is required for Redis and memcached PHP extensions in WordPress
- * Playground. It's a stage-3 proposal currently gated behind Node's
- * `--experimental-wasm-jspi` flag. Once it ships unflagged, this helper
- * will return `true` automatically — no code changes needed.
+ * Playground. It's currently gated behind Node's `--experimental-wasm-jspi`
+ * flag. Once it ships unflagged, this helper will return `true`
+ * automatically — no code changes needed.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const isJspiAvailable = typeof ( WebAssembly as any ).promising === 'function';


### PR DESCRIPTION
### Related issues
- Related to #2900
- Related to STU-1366

### How AI was used in this PR
Claude Code helped to investigate, reproduce, and fix the bug. I have reviewed the code, iterated over it and confirmed it works as expected.

### Proposed Changes
- Replace `semver.gte(process.version, '24.0.0')` with a runtime check for `WebAssembly.promising` to detect JSPI availability. The version check assumed Node 24+ has JSPI enabled by default, but it still requires the `--experimental-wasm-jspi` flag. This caused "Redis extension requires JSPI" errors when running CLI commands directly without the flag.
- Remove unused `semver` imports from `run-wp-cli-command.ts` and `wordpress-server-child.ts`.

### Testing Instructions
1. Build the CLI: `npm run cli:build`
2. Run without the JSPI flag (should succeed without Redis/memcached errors):
   ```
   node apps/cli/dist/cli/main.js site set --wp=6.9.1 --path ~/Studio/<site>
   ```
3. Run with the JSPI flag (should succeed with Redis/memcached enabled):
   ```
   node --experimental-wasm-jspi apps/cli/dist/cli/main.js site set --wp=6.9.1 --path ~/Studio/<site>
   ```
4. Try to reproduce the issue with the current `trunk` (the process should fail with an error):
   ```
   node apps/cli/dist/cli/main.js site set --wp=6.9.1 --path ~/Studio/<site>
   ```

### Pre-merge Checklist
- [x] Have you checked for TypeScript, React or other console errors?