### PR TITLE
Add linux platform names map for nodejs.org download naming

### DIFF
--- a/scripts/download-node-binary.ts
+++ b/scripts/download-node-binary.ts
@@ -32,6 +32,7 @@ const arch = process.argv[ 3 ] || process.arch;
 const platformMap: Record< string, string > = {
 	darwin: 'darwin',
 	win32: 'win',
+	linux: 'linux',
 };
 
 // Map architecture names to nodejs.org download naming


### PR DESCRIPTION
## Related issues

Fixes this error while running `npm run package` on linux.

```
An unhandled rejection has occurred inside Forge:
Error: Command failed: npx ts-node /tmp/studio-package-tB8UAV/repo/scripts/download-node-binary.ts linux x64
Unsupported platform: linux
at genericNodeError (node:internal/errors:985:15)
    at wrappedFn (node:internal/errors:539:14)
    at ChildProcess.exithandler (node:child_process:417:12)
    at ChildProcess.emit (node:events:508:28)
    at ChildProcess.emit (node:domain:489:12)
    at maybeClose (node:internal/child_process:1101:16)
    at ChildProcess._handle.onexit (node:internal/child_process:305:5)
npm error Lifecycle script `package` failed with error:
npm error code 1
npm error path /tmp/studio-package-tB8UAV/repo/apps/studio
npm error workspace studio-app@1.7.7-beta1
npm error location /tmp/studio-package-tB8UAV/repo/apps/studio
npm error command failed
npm error command sh -c electron-vite build --config ./electron.vite.config.ts --outDir=dist && electron-forge package .
matias@matias-XPS16:~/dev/a8c/studio$ cd out/Studio-linux-x64
bash: cd: out/Studio-linux-x64: No such file or directory

```

The script only mapped darwin and win32, causing the build to fail with Unsupported platform: linux when running npm run make on a Linux machine. This blocked packaging Studio on Linux entirely.  


## Proposed Changes

- Add linux to the platform map in scripts/download-node-binary.ts so the script can download and bundle a Node.js binary when building on Linux.

## Testing Instructions

- Run `npm run package` on linux and verify that the node package is downloaded as expected
