### PR TITLE
Remove cost display from AI command output

### DIFF
--- a/apps/cli/ai/ui.ts
+++ b/apps/cli/ai/ui.ts
@@ -1810,7 +1810,7 @@ export class AiChatUI {
 		message: SDKMessage
 	):
 		| { sessionId: string; success: boolean; maxTurnsReached?: undefined }
-		| { sessionId: string; maxTurnsReached: true; numTurns: number; costUsd: number }
+		| { sessionId: string; maxTurnsReached: true; numTurns: number }
 		| undefined {
 		switch ( message.type ) {
 			case 'assistant': {
@@ -1906,11 +1906,7 @@ export class AiChatUI {
 					if ( ! this.hasShownResponseMarker ) {
 						this.messages.addChild( new Text( '\n ' + chalk.blue( '⏺' ) + ' Done', 0, 0 ) );
 					}
-					this.showInfo(
-						`Thought for ${ thinkingSec }s · ${
-							message.num_turns
-						} turns · $${ message.total_cost_usd.toFixed( 4 ) }`
-					);
+					this.showInfo( `Thought for ${ thinkingSec }s · ${ message.num_turns } turns` );
 					return { sessionId: message.session_id, success: true };
 				}
 
@@ -1934,7 +1930,6 @@ export class AiChatUI {
 						sessionId: message.session_id,
 						maxTurnsReached: true,
 						numTurns: message.num_turns,
-						costUsd: message.total_cost_usd,
 					};
 				} else if ( message.subtype ) {
 					parts.push( `(${ message.subtype })` );

--- a/apps/cli/ai/ui.ts
+++ b/apps/cli/ai/ui.ts
@@ -22,6 +22,7 @@ import {
 	truncateToWidth,
 } from '@mariozechner/pi-tui';
 import { readAuthToken } from '@studio/common/lib/shared-config';
+import { _n, sprintf } from '@wordpress/i18n';
 import chalk from 'chalk';
 import { AI_MODELS, DEFAULT_MODEL, type AiModelId, type AskUserQuestion } from 'cli/ai/agent';
 import { AI_PROVIDERS, DEFAULT_AI_PROVIDER, type AiProviderId } from 'cli/ai/providers';
@@ -1906,7 +1907,18 @@ export class AiChatUI {
 					if ( ! this.hasShownResponseMarker ) {
 						this.messages.addChild( new Text( '\n ' + chalk.blue( '⏺' ) + ' Done', 0, 0 ) );
 					}
-					this.showInfo( `Thought for ${ thinkingSec }s · ${ message.num_turns } turns` );
+					this.showInfo(
+						sprintf(
+							/* translators: 1: seconds spent thinking, 2: number of turns */
+							_n(
+								'Thought for %1$ds · %2$d turn',
+								'Thought for %1$ds · %2$d turns',
+								message.num_turns
+							),
+							thinkingSec,
+							message.num_turns
+						)
+					);
 					return { sessionId: message.session_id, success: true };
 				}
 

--- a/apps/cli/commands/ai/index.ts
+++ b/apps/cli/commands/ai/index.ts
@@ -295,7 +295,7 @@ export async function runCommand(
 			void agentQuery.interrupt();
 		};
 
-		let maxTurnsResult: { numTurns: number; costUsd: number } | undefined;
+		let maxTurnsResult: { numTurns: number } | undefined;
 		let turnStatus: TurnStatus = 'interrupted';
 
 		try {
@@ -310,7 +310,6 @@ export async function runCommand(
 					if ( 'maxTurnsReached' in result && result.maxTurnsReached ) {
 						maxTurnsResult = {
 							numTurns: result.numTurns,
-							costUsd: result.costUsd,
 						};
 						turnStatus = 'max_turns';
 					} else {
@@ -327,9 +326,7 @@ export async function runCommand(
 		}
 
 		if ( maxTurnsResult ) {
-			ui.showInfo(
-				`Used ${ maxTurnsResult.numTurns } turns · $${ maxTurnsResult.costUsd.toFixed( 4 ) }`
-			);
+			ui.showInfo( `Used ${ maxTurnsResult.numTurns } turns` );
 			const answer = await ui.askUser( [
 				{
 					question: 'Reached the turn limit. Continue?',

--- a/apps/cli/commands/ai/index.ts
+++ b/apps/cli/commands/ai/index.ts
@@ -1,5 +1,5 @@
 import { readAuthToken } from '@studio/common/lib/shared-config';
-import { __ } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 import {
 	AI_MODELS,
 	DEFAULT_MODEL,
@@ -326,7 +326,13 @@ export async function runCommand(
 		}
 
 		if ( maxTurnsResult ) {
-			ui.showInfo( `Used ${ maxTurnsResult.numTurns } turns` );
+			ui.showInfo(
+				sprintf(
+					/* translators: %d: number of turns used */
+					_n( 'Used %d turn', 'Used %d turns', maxTurnsResult.numTurns ),
+					maxTurnsResult.numTurns
+				)
+			);
 			const answer = await ui.askUser( [
 				{
 					question: 'Reached the turn limit. Continue?',


### PR DESCRIPTION
## Related issues

Closes STU-1440

## How AI was used in this PR

AI-assisted implementation. Changes reviewed manually.

## Proposed Changes

- Remove the USD cost (`$X.XXXX`) from the AI command's success and max-turns status messages
- Clean up the now-unused `costUsd` field from types and return values

## Testing Instructions

- Run `studio ai` and complete a prompt
- Verify the status line shows `Thought for Xs · N turns` without a cost suffix
- Trigger the max-turns limit and verify it shows `Used N turns` without cost

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?