### PR TITLE
Remove redundant block validation from wp_cli tool

### DIFF
--- a/apps/cli/ai/tools.ts
+++ b/apps/cli/ai/tools.ts
@@ -433,31 +433,10 @@ const deletePreviewTool = tool(
 	}
 );
 
-const BLOCK_COMMENT_PATTERN = /<!-- wp:/;
-
-function extractPostContent( command: string ): string | undefined {
-	const args = splitCommandArgs( command );
-	for ( const arg of args ) {
-		if ( arg.startsWith( '--post_content=' ) ) {
-			return arg.slice( '--post_content='.length );
-		}
-	}
-	return undefined;
-}
-
-function isPostContentCommand( command: string ): boolean {
-	const trimmed = command.trimStart();
-	return (
-		( trimmed.startsWith( 'post create' ) || trimmed.startsWith( 'post update' ) ) &&
-		trimmed.includes( '--post_content=' )
-	);
-}
-
 // Note: wp.ts runCommand calls process.exit(), so we use the lower-level sendWpCliCommand directly.
 const runWpCliTool = tool(
 	'wp_cli',
 	'Runs a WP-CLI command on a specific WordPress site. The site must be running. ' +
-		'Post content (in post create/update with --post_content) is automatically validated for block correctness before execution. ' +
 		'Examples: "plugin install woocommerce --activate", "option get blogname", "user list".',
 	{
 		nameOrPath: z.string().describe( 'The site name or file system path to the site' ),
@@ -470,25 +449,6 @@ const runWpCliTool = tool(
 	async ( args ) => {
 		try {
 			const site = await resolveSite( args.nameOrPath );
-
-			// Validate block content in post create/update commands before executing
-			if ( isPostContentCommand( args.command ) ) {
-				const postContent = extractPostContent( args.command );
-				if ( postContent && BLOCK_COMMENT_PATTERN.test( postContent ) ) {
-					emitProgress( 'Validating post content blocks…' );
-					const siteUrl = getSiteUrl( site );
-					const report = await validateBlocks( postContent, siteUrl );
-					if ( report.invalidBlocks > 0 ) {
-						const lines = [
-							`Block validation failed: ${ report.invalidBlocks }/${ report.totalBlocks } blocks invalid. Fix the content before creating/updating the post.`,
-							'',
-							...formatInvalidBlocks( report ),
-						];
-						return errorResult( lines.join( '\n' ) );
-					}
-					emitProgress( `Post content: all ${ report.totalBlocks } blocks valid` );
-				}
-			}
 
 			try {
 				await connectToDaemon();


### PR DESCRIPTION
## Related issues

- Related to AI command block validation flow

## How AI was used in this PR

Claude identified the redundancy between automatic validation in `wp_cli` and the system prompt-driven `validate_blocks` flow, then removed the duplicate code.

## Proposed Changes

- Removed automatic block validation that ran inside the `wp_cli` tool before every `post create`/`post update` command
- Removed the helper functions (`extractPostContent`, `isPostContentCommand`, `BLOCK_COMMENT_PATTERN`) that were only used by this validation
- The system prompt already instructs the AI to call `validate_blocks` explicitly, making the automatic validation redundant and causing double validation in the happy path

## Testing Instructions

- Run the AI command to create a site and verify that block validation still happens via the `validate_blocks` tool (driven by the system prompt)
- Confirm that `wp post create` / `wp post update` commands execute without the automatic pre-validation step

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?