### PR TITLE
Add Studio user id to Studio About window

### DIFF
--- a/apps/studio/src/about-menu/about-menu.html
+++ b/apps/studio/src/about-menu/about-menu.html
@@ -42,7 +42,6 @@
 				background: rgba( 246, 246, 246, 0.84 );
 				cursor: default;
 				margin: 0;
-				max-height: 284px;
 				display: flex;
 				justify-content: center;
 				align-items: center;
@@ -101,6 +100,7 @@
 			<img src="./studio-app-icon.png" alt="Studio App Icon" width="64" height="64" />
 			<p class="studio-name" id="studio-by-wpcom">WordPress Studio</p>
 			<p class="version"><span id="version-text">x.y.z (...)</span></p>
+			<p class="version"><span id="user-id-text"></span></p>
 			<p class="links">
 				<a href="https://github.com/Automattic/studio" target="_blank">GitHub</a>
 				<span class="separator">&middot;</span>

--- a/apps/studio/src/about-menu/open-about-menu.ts
+++ b/apps/studio/src/about-menu/open-about-menu.ts
@@ -1,9 +1,10 @@
 import { BrowserWindow, app } from 'electron';
 import path from 'path';
 import * as Sentry from '@sentry/electron/renderer';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { ABOUT_WINDOW_HEIGHT, ABOUT_WINDOW_WIDTH } from 'src/constants';
 import { shellOpenExternalWrapper } from 'src/lib/shell-open-external-wrapper';
+import { loadUserData } from 'src/storage/user-data';
 
 let aboutWindow: BrowserWindow | null = null;
 
@@ -61,7 +62,7 @@ export function openAboutWindow() {
 	// Read package.json and pass version to about window
 	const packageJson = app.getVersion();
 
-	aboutWindow.webContents.on( 'dom-ready', () => {
+	aboutWindow.webContents.on( 'dom-ready', async () => {
 		if ( aboutWindow ) {
 			//When updating these strings, make sure to update the corresponding strings in the about-menu.html file
 			const versionText = escapeSingleQuotes( `${ packageJson } (${ getPlatformLabel() })` );
@@ -72,10 +73,21 @@ export function openAboutWindow() {
 			const demoSitesText = escapeSingleQuotes( __( 'Preview sites powered by' ) );
 			const localSitesText = escapeSingleQuotes( __( 'Local sites powered by' ) );
 
+			let userIdText = '';
+			try {
+				const userData = await loadUserData();
+				if ( userData.sentryUserId ) {
+					userIdText = escapeSingleQuotes( sprintf( __( 'User ID: %s' ), userData.sentryUserId ) );
+				}
+			} catch {
+				// Non-critical, leave empty
+			}
+
 			const script = `
 				document.title = '${ aboutStudioText }';
 				document.getElementById('studio-by-wpcom').innerText = '${ studioByWpcomText }';
 				document.getElementById('version-text').innerText = '${ versionText }';
+				document.getElementById('user-id-text').innerText = '${ userIdText }';
 				document.getElementById('share-feedback').innerText = '${ shareFeedbackText }';
 				document.getElementById('release-notes').innerText = '${ releasesText }';
 				document.getElementById('demo-sites').innerText = '${ demoSitesText }';

--- a/apps/studio/src/constants.ts
+++ b/apps/studio/src/constants.ts
@@ -16,8 +16,8 @@ export const SYNC_PUSH_SIZE_LIMIT_BYTES = SYNC_PUSH_SIZE_LIMIT_GB * 1024 * 1024 
 export const AUTO_UPDATE_INTERVAL_MS = 60 * 60 * 1000;
 export const MACOS_TRAFFIC_LIGHT_POSITION = { x: 20, y: 20 };
 export const WINDOWS_TITLEBAR_HEIGHT = 32;
-export const ABOUT_WINDOW_WIDTH = 300;
-export const ABOUT_WINDOW_HEIGHT = 350;
+export const ABOUT_WINDOW_WIDTH = 310;
+export const ABOUT_WINDOW_HEIGHT = 380;
 export const TELEX_HOSTNAME = 'telex.automattic.ai';
 export const TELEX_UTM_PARAMS = {
 	utm_source: 'studio',


### PR DESCRIPTION
## Related issues

- Fixes STU-1464

## Proposed Changes
Right now we need to ask user to find appdata-v1.json and find their sentryUserId to share with us for debugging. With the new Studio version it will be even more complicated since it will depend on the Studio version, either appdata-v1.json or app.json. Especially, it complicates things for less tech users and in general provides not the best experience.

I propose to add it to the About dialog, alongside Studio version:
<img width="273" height="337" alt="Screenshot 2026-03-25 at 17 35 15" src="https://github.com/user-attachments/assets/996d0568-0f0f-470f-a247-154d6afb1968" />


## Testing Instructions
1. `npm start`
2. Open about dialog - Click on `Electron` -> `About WordPress Studio`
3. Open /Users/<USERNAME>/.studio/app.json 
4. Assert that `sentryUserId` app.json equals `User ID` inside About dialog