### PR TITLE
Move selectedSkills from app storage to shared config

### DIFF
--- a/apps/cli/commands/site/create.ts
+++ b/apps/cli/commands/site/create.ts
@@ -37,6 +37,7 @@ import {
 	hasDefaultDbBlock,
 	removeDbConstants,
 } from '@studio/common/lib/remove-default-db-constants';
+import { readSharedConfig } from '@studio/common/lib/shared-config';
 import { sortSites } from '@studio/common/lib/sort-sites';
 import { getServerFilesPath } from '@studio/common/lib/well-known-paths';
 import {
@@ -250,7 +251,9 @@ export async function runCommand(
 		);
 
 		try {
-			await installAiInstructionsToSite( sitePath, getAiInstructionsPath() );
+			const sharedConfig = await readSharedConfig();
+			const selectedSkills = sharedConfig.selectedSkills ?? [];
+			await installAiInstructionsToSite( sitePath, getAiInstructionsPath(), selectedSkills );
 		} catch ( error ) {
 			logger.reportError(
 				new LoggerError( __( 'Failed to install AI instructions. Proceeding anyway…' ), error ),

--- a/apps/studio/src/ipc-handlers.ts
+++ b/apps/studio/src/ipc-handlers.ts
@@ -18,7 +18,6 @@ import os from 'os';
 import nodePath from 'path';
 import * as Sentry from '@sentry/electron/main';
 import {
-	installAiInstructionsToSite,
 	installSkillToSite,
 	removeSkillFromSite,
 	updateManagedInstructionFiles,
@@ -59,7 +58,7 @@ import {
 	trustRootCA,
 } from 'src/lib/certificate-manager';
 import { simplifyErrorForDisplay } from 'src/lib/error-formatting';
-import { buildFeatureFlags, getFeatureFlagFromEnv } from 'src/lib/feature-flags';
+import { buildFeatureFlags } from 'src/lib/feature-flags';
 import { getImageData } from 'src/lib/get-image-data';
 import { exportBackup } from 'src/lib/import-export/export/export-manager';
 import { ExportOptions } from 'src/lib/import-export/export/types';
@@ -409,20 +408,6 @@ export async function createSite(
 		// If the site is running after creation, fetch theme details and update thumbnail
 		if ( server.details.running ) {
 			void loadThemeDetails( event, server.details.id );
-		}
-
-		// Install AI instructions and skills into the new site
-		if ( getFeatureFlagFromEnv( 'enableAgentSuite' ) ) {
-			const sharedConfig = await readSharedConfig();
-			const selectedSkills = sharedConfig.selectedSkills ?? [];
-			void installAiInstructionsToSite( path, getAiInstructionsPath(), selectedSkills ).catch(
-				( error ) => {
-					console.error(
-						'[ai-instructions] Failed to install AI instructions to new site:',
-						error
-					);
-				}
-			);
 		}
 
 		return server.details;

--- a/apps/studio/src/ipc-handlers.ts
+++ b/apps/studio/src/ipc-handlers.ts
@@ -248,7 +248,7 @@ export async function removeWordPressSkillFromAllSites(
 	} );
 
 	const sharedConfig = await readSharedConfig();
-	const updated = ( sharedConfig.selectedSkills ?? [] ).filter( ( id: string ) => id !== skillId );
+	const updated = ( sharedConfig.selectedSkills ?? [] ).filter( ( id ) => id !== skillId );
 	await updateSharedConfig( { selectedSkills: updated } );
 }
 

--- a/apps/studio/src/ipc-handlers.ts
+++ b/apps/studio/src/ipc-handlers.ts
@@ -39,7 +39,7 @@ import { isErrnoException } from '@studio/common/lib/is-errno-exception';
 import { getAuthenticationUrl } from '@studio/common/lib/oauth';
 import { decodePassword, encodePassword } from '@studio/common/lib/passwords';
 import { sanitizeFolderName } from '@studio/common/lib/sanitize-folder-name';
-import { updateSharedConfig } from '@studio/common/lib/shared-config';
+import { readSharedConfig, updateSharedConfig } from '@studio/common/lib/shared-config';
 import { isWordPressDevVersion } from '@studio/common/lib/wordpress-version-utils';
 import { __, sprintf, LocaleData, defaultI18n } from '@wordpress/i18n';
 import { MACOS_TRAFFIC_LIGHT_POSITION, MAIN_MIN_WIDTH, SIDEBAR_WIDTH } from 'src/constants';
@@ -96,7 +96,7 @@ import { supportedEditorConfig, SupportedEditor } from 'src/modules/user-setting
 import { getUserEditor, getUserTerminal } from 'src/modules/user-settings/lib/ipc-handlers';
 import { winFindEditorPath } from 'src/modules/user-settings/lib/win-editor-path';
 import { SiteServer, stopAllServers as triggerStopAllServers } from 'src/site-server';
-import { DEFAULT_SITE_PATH, getSiteThumbnailPath, getUserDataFilePath } from 'src/storage/paths';
+import { DEFAULT_SITE_PATH, getSiteThumbnailPath } from 'src/storage/paths';
 import {
 	loadUserData,
 	lockAppdata,
@@ -204,8 +204,8 @@ export async function installWordPressSkills(
 export async function getWordPressSkillsStatusAllSites(
 	_event: IpcMainInvokeEvent
 ): Promise< SkillStatus[] > {
-	const userData = await loadUserData();
-	const selectedSkills = userData.selectedSkills ?? [];
+	const sharedConfig = await readSharedConfig();
+	const selectedSkills = sharedConfig.selectedSkills ?? [];
 	return BUNDLED_SKILLS.map( ( skill ) => ( {
 		...skill,
 		installed: selectedSkills.includes( skill.id ),
@@ -229,15 +229,10 @@ export async function installWordPressSkillsToAllSites(
 		}
 	} );
 
-	try {
-		await lockAppdata();
-		const userData = await loadUserData();
-		const existing = userData.selectedSkills ?? [];
-		const merged = Array.from( new Set( [ ...existing, options.skillId ] ) );
-		await saveUserData( { ...userData, selectedSkills: merged } );
-	} finally {
-		await unlockAppdata();
-	}
+	const sharedConfig = await readSharedConfig();
+	const existing = sharedConfig.selectedSkills ?? [];
+	const merged = Array.from( new Set( [ ...existing, options.skillId ] ) );
+	await updateSharedConfig( { selectedSkills: merged } );
 }
 
 export async function removeWordPressSkillFromAllSites(
@@ -253,14 +248,9 @@ export async function removeWordPressSkillFromAllSites(
 		}
 	} );
 
-	try {
-		await lockAppdata();
-		const userData = await loadUserData();
-		const updated = ( userData.selectedSkills ?? [] ).filter( ( id ) => id !== skillId );
-		await saveUserData( { ...userData, selectedSkills: updated } );
-	} finally {
-		await unlockAppdata();
-	}
+	const sharedConfig = await readSharedConfig();
+	const updated = ( sharedConfig.selectedSkills ?? [] ).filter( ( id: string ) => id !== skillId );
+	await updateSharedConfig( { selectedSkills: updated } );
 }
 
 const DEBUG_LOG_MAX_LINES = 50;
@@ -423,8 +413,8 @@ export async function createSite(
 
 		// Install AI instructions and skills into the new site
 		if ( getFeatureFlagFromEnv( 'enableAgentSuite' ) ) {
-			const userData = await loadUserData();
-			const selectedSkills = userData.selectedSkills ?? [];
+			const sharedConfig = await readSharedConfig();
+			const selectedSkills = sharedConfig.selectedSkills ?? [];
 			void installAiInstructionsToSite( path, getAiInstructionsPath(), selectedSkills ).catch(
 				( error ) => {
 					console.error(

--- a/apps/studio/src/ipc-handlers.ts
+++ b/apps/studio/src/ipc-handlers.ts
@@ -96,7 +96,7 @@ import { supportedEditorConfig, SupportedEditor } from 'src/modules/user-setting
 import { getUserEditor, getUserTerminal } from 'src/modules/user-settings/lib/ipc-handlers';
 import { winFindEditorPath } from 'src/modules/user-settings/lib/win-editor-path';
 import { SiteServer, stopAllServers as triggerStopAllServers } from 'src/site-server';
-import { DEFAULT_SITE_PATH, getSiteThumbnailPath } from 'src/storage/paths';
+import { DEFAULT_SITE_PATH, getSiteThumbnailPath, getUserDataFilePath } from 'src/storage/paths';
 import {
 	loadUserData,
 	lockAppdata,

--- a/apps/studio/src/storage/storage-types.ts
+++ b/apps/studio/src/storage/storage-types.ts
@@ -32,7 +32,6 @@ export interface UserData {
 	colorScheme?: 'system' | 'light' | 'dark';
 	betaFeatures?: BetaFeatures;
 	stopSitesOnQuit?: boolean;
-	selectedSkills?: string[];
 }
 
 export interface PromptWindowsSpeedUpResult {

--- a/apps/studio/src/storage/user-data.ts
+++ b/apps/studio/src/storage/user-data.ts
@@ -71,8 +71,7 @@ type UserDataSafeKeys =
 	| 'preferredTerminal'
 	| 'preferredEditor'
 	| 'betaFeatures'
-	| 'colorScheme'
-	| 'selectedSkills';
+	| 'colorScheme';
 
 type PartialUserDataWithSafeKeysToUpdate = Partial< Pick< UserData, UserDataSafeKeys > >;
 

--- a/tools/common/lib/shared-config.ts
+++ b/tools/common/lib/shared-config.ts
@@ -28,6 +28,7 @@ export const sharedConfigSchema = z
 		version: z.literal( SHARED_CONFIG_VERSION ),
 		authToken: authTokenSchema.optional(),
 		locale: z.string().optional(),
+		selectedSkills: z.array( z.string() ).optional(),
 	} )
 	.loose();
 


### PR DESCRIPTION
## Related issues

- Related to #2880

## How AI was used in this PR

AI assisted with moving the `selectedSkills` storage location and removing the duplicate AI instructions installation from the IPC handler.

## Proposed Changes

The user-selected skills are saved in `shared.json` and used when running the Studio CLI `site create` command.  
Removed unnecessary code from the IPC handler.

## Testing Instructions

1. Start the app with `ENABLE_AGENT_SUITE=true npm start`
2. Go to AI settings, toggle skills on/off — verify selections persist and they are saved in ~/.studio/shared.json
3. Test CLI: `npm run cli:build && node apps/cli/dist/cli/main.js site create --path=path/to/your/site`
4. Verify skills are installed

https://github.com/user-attachments/assets/63ab12aa-7756-4a6c-bcdd-228444269027

https://github.com/user-attachments/assets/38de5d07-74f6-4fb4-acfd-a5b25c23c533




## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?