### PR TITLE
Studio Settings: Reorder tabs and align description styling with MCP tab

### DIFF
--- a/apps/studio/src/lib/get-localized-link.ts
+++ b/apps/studio/src/lib/get-localized-link.ts
@@ -40,6 +40,9 @@ const DOCS_LINKS = {
 	docsMcp: {
 		en: 'https://developer.wordpress.com/docs/developer-tools/studio/mcp/',
 	},
+	docsSkills: {
+		en: 'https://developer.wordpress.com/docs/developer-tools/studio/agent-skills/',
+	},
 } satisfies Record< `docs${ string }`, TranslatedLink >;
 
 const BLOG_LINKS = {

--- a/apps/studio/src/modules/user-settings/components/skills-tab.tsx
+++ b/apps/studio/src/modules/user-settings/components/skills-tab.tsx
@@ -1,6 +1,6 @@
 import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
-import { moreVertical } from '@wordpress/icons';
 import { createInterpolateElement } from '@wordpress/element';
+import { moreVertical } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import Button from 'src/components/button';

--- a/apps/studio/src/modules/user-settings/components/skills-tab.tsx
+++ b/apps/studio/src/modules/user-settings/components/skills-tab.tsx
@@ -86,7 +86,7 @@ export function SkillsTab() {
 
 	return (
 		<div className="flex flex-col gap-4 pb-2">
-			<p className="text-xs text-frame-text-secondary text-center">
+			<p className="a8c-body-small m-0">
 				{ __(
 					'Agents can decide to use skills to help them accomplish specialized tasks. Select the skills that will be placed in all existing and new sites.'
 				) }

--- a/apps/studio/src/modules/user-settings/components/skills-tab.tsx
+++ b/apps/studio/src/modules/user-settings/components/skills-tab.tsx
@@ -1,8 +1,10 @@
 import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
 import { moreVertical } from '@wordpress/icons';
+import { createInterpolateElement } from '@wordpress/element';
 import { useI18n } from '@wordpress/react-i18n';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import Button from 'src/components/button';
+import { LearnMoreLink } from 'src/components/learn-more';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 import { type SkillStatus } from 'src/modules/agent-instructions/lib/skills-constants';
 
@@ -86,8 +88,13 @@ export function SkillsTab() {
 	return (
 		<div className="flex flex-col gap-4 pb-2">
 			<p className="a8c-body-small m-0">
-				{ __(
-					'Select the skills that will be placed in all existing and new sites. Agents can decide to use skills to help them accomplish specialized tasks.'
+				{ createInterpolateElement(
+					__(
+						'Select the skills that will be placed in all existing and new sites. Agents can decide to use skills to help them accomplish specialized tasks. <learn_more_link />'
+					),
+					{
+						learn_more_link: <LearnMoreLink docsLinksKey="docsSkills" />,
+					}
 				) }
 			</p>
 

--- a/apps/studio/src/modules/user-settings/components/skills-tab.tsx
+++ b/apps/studio/src/modules/user-settings/components/skills-tab.tsx
@@ -3,7 +3,6 @@ import { moreVertical } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import Button from 'src/components/button';
-import { InstalledBadge } from 'src/components/installed-badge';
 import { getIpcApi } from 'src/lib/get-ipc-api';
 import { type SkillStatus } from 'src/modules/agent-instructions/lib/skills-constants';
 
@@ -111,10 +110,7 @@ export function SkillsTab() {
 							className="flex items-center justify-between px-3 py-2.5 border-b border-frame-border last:border-b-0"
 						>
 							<div className="flex-1 min-w-0 pr-3">
-								<div className="flex items-center gap-2">
-									<span className="text-sm font-medium text-frame-text">{ skill.displayName }</span>
-									<InstalledBadge />
-								</div>
+								<div className="text-sm font-medium text-frame-text">{ skill.displayName }</div>
 								<div className="text-xs text-frame-text-secondary">{ skill.description }</div>
 							</div>
 							<DropdownMenu

--- a/apps/studio/src/modules/user-settings/components/skills-tab.tsx
+++ b/apps/studio/src/modules/user-settings/components/skills-tab.tsx
@@ -88,7 +88,7 @@ export function SkillsTab() {
 		<div className="flex flex-col gap-4 pb-2">
 			<p className="a8c-body-small m-0">
 				{ __(
-					'Agents can decide to use skills to help them accomplish specialized tasks. Select the skills that will be placed in all existing and new sites.'
+					'Select the skills that will be placed in all existing and new sites. Agents can decide to use skills to help them accomplish specialized tasks.'
 				) }
 			</p>
 

--- a/apps/studio/src/modules/user-settings/components/user-settings.tsx
+++ b/apps/studio/src/modules/user-settings/components/user-settings.tsx
@@ -81,19 +81,17 @@ export default function UserSettings() {
 			},
 		];
 
-		if ( enableAgentSuite ) {
-			result.push( {
-				name: 'skills',
-				title: __( 'Skills' ),
-			} );
-		}
-
 		result.push( {
 			name: 'account',
 			title: __( 'Account' ),
 		} );
 
 		if ( enableAgentSuite ) {
+			result.push( {
+				name: 'skills',
+				title: __( 'Skills' ),
+			} );
+
 			result.push( {
 				name: 'mcp',
 				title: __( 'MCP' ),


### PR DESCRIPTION
## Related issues

- Related to https://github.com/Automattic/studio/pull/2880

## Proposed Changes

- Update Skills tab description to use `a8c-body-small` class for left-aligned text matching the MCP tab typography
- Reorder tab sentence to lead with the actionable instruction
- Move Skills tab after Account tab to group agent-related tabs (Skills, MCP) together

## Testing Instructions

- Start the app with `ENABLE_AGENT_SUITE=true npm start`
- Open Settings (Cmd+,)
- Observe the tabs in the following order: General, Account, Skills, MCP
- Navigate to the Skills tab and verify the description text is left-aligned and uses the same typography as the MCP tab

<img width="1021" height="712" alt="Screenshot 2026-03-26 at 09 47 20" src="https://github.com/user-attachments/assets/002b6320-47af-469e-916c-4752f88e89af" />

https://github.com/user-attachments/assets/f7af8c94-c424-452f-a017-28718cfb4695

(Video outdated. Now it doesn't have the installed badge)


## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?