### PR TITLE
Refactor and clean up site deletion logic in app

### DIFF
--- a/apps/studio/src/hooks/use-site-details.tsx
+++ b/apps/studio/src/hooks/use-site-details.tsx
@@ -191,7 +191,7 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 			}
 
 			try {
-				setIsDeleting( ( loading ) => ( { ...loading, [ siteId ]: true } ) );
+				setIsDeleting( ( prev ) => ( { ...prev, [ siteId ]: true } ) );
 
 				await getIpcApi().deleteSite( siteId, shouldDeleteFiles );
 
@@ -215,7 +215,7 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 				console.error( 'Error during site deletion:', error );
 				throw error;
 			} finally {
-				setIsDeleting( ( loading ) => ( { ...loading, [ siteId ]: false } ) );
+				setIsDeleting( ( prev ) => ( { ...prev, [ siteId ]: false } ) );
 			}
 
 			// No need to update the `sites` state. That's handled in the `site-event` listener.

--- a/apps/studio/src/hooks/use-site-details.tsx
+++ b/apps/studio/src/hooks/use-site-details.tsx
@@ -11,14 +11,10 @@ import {
 	useRef,
 	useState,
 } from 'react';
-import { useAuth } from 'src/hooks/use-auth';
 import { useContentTabs } from 'src/hooks/use-content-tabs';
 import { useIpcListener } from 'src/hooks/use-ipc-listener';
-import { useOffline } from 'src/hooks/use-offline';
 import { simplifyErrorForDisplay } from 'src/lib/error-formatting';
 import { getIpcApi } from 'src/lib/get-ipc-api';
-import { useAppDispatch } from 'src/stores';
-import { snapshotThunks } from 'src/stores/snapshot-slice';
 import type { Blueprint } from 'src/stores/wpcom-api';
 
 interface SiteDetailsContext {
@@ -114,61 +110,6 @@ function useSelectedSite( firstSiteId: string | null ) {
 	};
 }
 
-function useDeleteSite() {
-	const [ isLoading, setIsLoading ] = useState< Record< string, boolean > >( {} );
-	const dispatch = useAppDispatch();
-	const isOffline = useOffline();
-	const { isAuthenticated } = useAuth();
-
-	const deleteSite = useCallback(
-		async ( siteId: string, removeLocal: boolean ): Promise< void > => {
-			if ( ! siteId ) {
-				return;
-			}
-
-			const shouldDeletePreviewSites = ! isOffline && isAuthenticated;
-
-			const allSiteRemovePromises = shouldDeletePreviewSites
-				? dispatch( snapshotThunks.deleteAllSnapshotsForSite( { siteId } ) )
-				: Promise.resolve();
-
-			try {
-				setIsLoading( ( loading ) => ( { ...loading, [ siteId ]: true } ) );
-
-				await getIpcApi().deleteSite( siteId, removeLocal );
-
-				if ( shouldDeletePreviewSites ) {
-					await allSiteRemovePromises;
-				}
-
-				// After site is deleted successfully, clean up wpcom connections
-				try {
-					const connectedSites = await getIpcApi().getConnectedWpcomSites( siteId );
-					const connectedSiteIds = connectedSites.map( ( site ) => site.id );
-					if ( connectedSiteIds.length > 0 ) {
-						await getIpcApi().disconnectWpcomSites( [
-							{
-								siteIds: connectedSiteIds,
-								localSiteId: siteId,
-							},
-						] );
-					}
-				} catch ( error ) {
-					// If disconnection fails, log but don't fail the deletion
-					console.error( 'Failed to disconnect wpcom sites:', error );
-				}
-			} catch ( error ) {
-				console.error( 'Error during site deletion:', error );
-				throw error;
-			} finally {
-				setIsLoading( ( loading ) => ( { ...loading, [ siteId ]: false } ) );
-			}
-		},
-		[ dispatch, isOffline, isAuthenticated ]
-	);
-	return { deleteSite, isLoading };
-}
-
 export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 	const { Provider } = siteDetailsContext;
 
@@ -187,7 +128,7 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 	);
 	const { selectedSiteId, setSelectedSiteId } = useSelectedSite( firstSite?.id );
 	const [ uploadingSites, setUploadingSites ] = useState< { [ siteId: string ]: boolean } >( {} );
-	const { deleteSite, isLoading: isDeleting } = useDeleteSite();
+	const [ isDeleting, setIsDeleting ] = useState< Record< string, boolean > >( {} );
 	const { setSelectedTab, selectedTab } = useContentTabs();
 
 	useIpcListener( 'on-site-create-progress', ( _, { siteId, message } ) => {
@@ -244,12 +185,42 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 	}, [] );
 
 	const onDeleteSite = useCallback(
-		async ( id: string, removeLocal: boolean ) => {
-			await deleteSite( id, removeLocal );
+		async ( siteId: string, shouldDeleteFiles: boolean ) => {
+			if ( ! siteId ) {
+				return;
+			}
+
+			try {
+				setIsDeleting( ( loading ) => ( { ...loading, [ siteId ]: true } ) );
+
+				await getIpcApi().deleteSite( siteId, shouldDeleteFiles );
+
+				// After site is deleted successfully, clean up wpcom connections
+				try {
+					const connectedSites = await getIpcApi().getConnectedWpcomSites( siteId );
+					const connectedSiteIds = connectedSites.map( ( site ) => site.id );
+					if ( connectedSiteIds.length > 0 ) {
+						await getIpcApi().disconnectWpcomSites( [
+							{
+								siteIds: connectedSiteIds,
+								localSiteId: siteId,
+							},
+						] );
+					}
+				} catch ( error ) {
+					// If disconnection fails, log but don't fail the deletion
+					console.error( 'Failed to disconnect wpcom sites:', error );
+				}
+			} catch ( error ) {
+				console.error( 'Error during site deletion:', error );
+				throw error;
+			} finally {
+				setIsDeleting( ( loading ) => ( { ...loading, [ siteId ]: false } ) );
+			}
+
+			// No need to update the `sites` state. That's handled in the `site-event` listener.
+
 			const newSites = await getIpcApi().getSiteDetails();
-			setSites( sortSites( newSites ) );
-			// Use functional update to access current selectedSiteId value
-			// Tab reset is handled in SiteContentTabs when it detects the previous site was deleted
 			setSelectedSiteId( ( currentSelectedId ) => {
 				const selectedSiteStillExists = newSites.some( ( site ) => site.id === currentSelectedId );
 				if ( ! selectedSiteStillExists ) {
@@ -258,7 +229,7 @@ export function SiteDetailsProvider( { children }: SiteDetailsProviderProps ) {
 				return currentSelectedId;
 			} );
 		},
-		[ deleteSite, setSelectedSiteId ]
+		[ setSelectedSiteId ]
 	);
 
 	const createSite = useCallback(

--- a/apps/studio/src/stores/snapshot-slice.ts
+++ b/apps/studio/src/stores/snapshot-slice.ts
@@ -3,7 +3,6 @@ import {
 	createAsyncThunk,
 	createSelector,
 	createSlice,
-	isAnyOf,
 	PayloadAction,
 } from '@reduxjs/toolkit';
 import { SNAPSHOT_EVENTS } from '@studio/common/lib/cli-events';
@@ -41,14 +40,7 @@ type DeleteOperation = BaseOperation & {
 	optimistic?: boolean;
 };
 
-type BulkOperation = Omit< BaseOperation, 'progress' > & {
-	operationIds: UUID[];
-	siteId?: string;
-	type: 'bulk';
-	userId?: number;
-};
-
-export type SnapshotOperation = CreateOperation | UpdateOperation | DeleteOperation | BulkOperation;
+export type SnapshotOperation = CreateOperation | UpdateOperation | DeleteOperation;
 
 type SnapshotState = {
 	operations: Record< UUID, SnapshotOperation >;
@@ -96,41 +88,6 @@ const deleteSnapshot = createTypedAsyncThunk(
 		return { operationId };
 	}
 );
-
-async function deleteMultipleSnapshots(
-	snapshots: Snapshot[]
-): Promise< [ url: string, operationId: UUID ][] > {
-	return await Promise.all(
-		snapshots.map( async ( snapshot ) => {
-			const { operationId } = await getIpcApi().deleteSnapshot( snapshot.url );
-			return [ snapshot.url, operationId ];
-		} )
-	);
-}
-
-const deleteAllSnapshotsForSite = createTypedAsyncThunk<
-	{ operations: [ url: string, operationId: UUID ][]; bulkOperationId: UUID },
-	{ siteId: string }
->( 'snapshot/deleteAllSnapshotsForSite', async ( { siteId }, thunkAPI ) => {
-	const state = thunkAPI.getState();
-	const snapshots = snapshotSelectors.selectSnapshotsBySite( state, siteId );
-	const operations = await deleteMultipleSnapshots( snapshots );
-	const bulkOperationId = window.crypto.randomUUID();
-
-	return { operations, bulkOperationId };
-} );
-
-const deleteAllSnapshotsForUser = createTypedAsyncThunk<
-	{ operations: [ url: string, operationId: UUID ][]; bulkOperationId: UUID },
-	{ userId: number }
->( 'snapshot/deleteAllSnapshotsForUser', async ( { userId }, thunkAPI ) => {
-	const state = thunkAPI.getState();
-	const snapshots = snapshotSelectors.selectSnapshotsByUser( state, userId );
-	const operations = await deleteMultipleSnapshots( snapshots );
-	const bulkOperationId = window.crypto.randomUUID();
-
-	return { operations, bulkOperationId };
-} );
 
 const updateSnapshotLocally = createAction< {
 	atomicSiteId: number;
@@ -200,47 +157,9 @@ const snapshotSlice = createSlice( {
 					type: 'delete',
 					optimistic: action.meta.arg.optimistic ?? false,
 				};
-			} )
-			.addMatcher(
-				isAnyOf( deleteAllSnapshotsForSite.fulfilled, deleteAllSnapshotsForUser.fulfilled ),
-				( state, action ) => {
-					if ( ! action.payload.operations.length ) {
-						return;
-					}
-
-					const bulkOperation: BulkOperation = {
-						error: null,
-						operationIds: action.payload.operations.map( ( [ _, operationId ] ) => operationId ),
-						status: 'pending',
-						type: 'bulk',
-					};
-
-					if ( 'siteId' in action.meta.arg ) {
-						bulkOperation.siteId = action.meta.arg.siteId;
-					} else if ( 'userId' in action.meta.arg ) {
-						bulkOperation.userId = action.meta.arg.userId;
-					}
-
-					state.operations[ action.payload.bulkOperationId ] = bulkOperation;
-
-					action.payload.operations.forEach( ( [ url, operationId ] ) => {
-						state.operations[ operationId ] = {
-							error: null,
-							progress: 0,
-							snapshotUrl: url,
-							status: 'pending',
-							type: 'delete',
-						};
-					} );
-				}
-			);
+			} );
 	},
 	selectors: {
-		selectActiveBulkOperationForUser: ( state, userId: number ): BulkOperation | undefined =>
-			Object.values( state.operations ).find(
-				( operation ): operation is BulkOperation =>
-					operation.status === 'pending' && operation.type === 'bulk' && operation.userId === userId
-			),
 		selectActiveCreateOperationForSite: ( state, siteId: string ): CreateOperation | undefined =>
 			Object.values( state.operations ).find(
 				( operation ): operation is CreateOperation =>
@@ -268,6 +187,9 @@ const snapshotSlice = createSlice( {
 	},
 } );
 
+// We use the `createSelector` API here to memoize the result. Whenever a selector returns a
+// reference type (array, object, etc), it's good to use `createSelector` to avoid unnecessary
+// React re-renders.
 const selectActiveCreateUpdateOperationsForAnySite = createSelector(
 	[ ( state: RootState ) => state.snapshot.operations ],
 	( operations ) =>
@@ -371,27 +293,6 @@ function getOperationProgress( action: PreviewCommandLoggerAction ): [ string, n
 function getOperation( operationId: UUID ) {
 	const state = store.getState();
 	return state.snapshot.operations[ operationId ];
-}
-
-function getAssociatedBulkOperation( targetOperationId: UUID ): [ UUID, BulkOperation ] | [] {
-	const state = store.getState();
-	// `Object.entries()` always returns a string type for the key, but we know the type is actually constrained to UUID
-	const entries = Object.entries( state.snapshot.operations ) as [ UUID, SnapshotOperation ][];
-
-	for ( const [ operationId, operation ] of entries ) {
-		if ( operation.type === 'bulk' && operation.operationIds.includes( targetOperationId ) ) {
-			return [ operationId, operation ];
-		}
-	}
-
-	return [];
-}
-
-function isBulkOperationSettled( bulkOperation: BulkOperation ) {
-	return bulkOperation.operationIds.every( ( operationId ) => {
-		const operation = getOperation( operationId );
-		return operation && operation.status !== 'pending';
-	} );
 }
 
 window.ipcListener.subscribe( 'snapshot-event', ( _, snapshotEvent ) => {
@@ -528,18 +429,6 @@ window.ipcListener.subscribe( 'snapshot-success', ( event, payload ) => {
 		} )
 	);
 
-	const [ bulkOperationId, bulkOperation ] = getAssociatedBulkOperation( payload.operationId );
-	const bulkOperationIsSettled = bulkOperation && isBulkOperationSettled( bulkOperation );
-
-	if ( bulkOperationId && bulkOperationIsSettled ) {
-		store.dispatch(
-			snapshotActions.updateOperation( {
-				operationId: bulkOperationId,
-				operation: { status: 'fulfilled' },
-			} )
-		);
-	}
-
 	const { snapshotUrl = '' } = operation;
 
 	if ( operation.type === 'create' ) {
@@ -553,17 +442,10 @@ window.ipcListener.subscribe( 'snapshot-success', ( event, payload ) => {
 			body: sprintf( __( "Preview site '%s' has been updated." ), snapshotUrl ),
 		} );
 	} else if ( operation.type === 'delete' ) {
-		if ( operation.optimistic ) {
-			// Do nothing
-		} else if ( ! bulkOperation ) {
+		if ( ! operation.optimistic ) {
 			getIpcApi().showNotification( {
 				title: operation.snapshotName,
 				body: sprintf( __( "Preview site '%s' has been deleted." ), snapshotUrl ),
-			} );
-		} else if ( bulkOperationIsSettled ) {
-			getIpcApi().showNotification( {
-				title: __( 'Delete Successful' ),
-				body: __( 'All preview sites have been deleted.' ),
 			} );
 		}
 	}
@@ -584,7 +466,5 @@ export const snapshotThunks = {
 	createSnapshot,
 	updateSnapshot,
 	deleteSnapshot,
-	deleteAllSnapshotsForSite,
-	deleteAllSnapshotsForUser,
 };
 export const reducer = snapshotSlice.reducer;


### PR DESCRIPTION
## Related issues

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

- Fixes STU-1466

## How AI was used in this PR

<!--
Help reviewers understand what to look for and verify that you've reviewed the code yourself.
-->

Not at all. 

## Proposed Changes

When we originally implemented Redux state handling for preview sites, `snapshot-slice.ts` also handled bulk delete operations. https://github.com/Automattic/studio/pull/1950 removed the need for the `deleteAllSnapshotsForUser` operation by introducing a `/delete/all` API endpoint, which we called with an RTK Query mutation. Later, the `site delete` CLI command also removed the need for the `deleteAllSnapshotsForSite` operation. However, the `onDeleteSite` hook continued dispatching that action, even though the CLI already handles preview site deletion. 

This PR cleans up `snapshot-slice.ts` by removing the entire "bulk operations" concept. This also means the app defers to the CLI for deleting preview sites when a local site is deleted. 

Lastly, I changed the `sites` state "reset" after a site is deleted, so we only rely on the `SITE_EVENTS.DELETED` event handler. This will fix some glitches around cases where a site is being deleted while another is being added. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. `npm start`
2. Have a site with at least one preview site
3. Check your total preview site count in the settings modal
4. Delete the Studio site
5. Ensure that the operation completes successfully
6. Check your total preview site count in the settings modal and ensure that it has been decremented

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
