### PR TITLE
Add .npmrc with ignore-scripts to mitigate supply chain attacks

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true


### PR DESCRIPTION
## Related issues

- N/A

## How AI was used in this PR

AI was used to verify that no existing preinstall or postinstall scripts are in use across the project.

## Proposed Changes

- Adds an `.npmrc` file with `ignore-scripts=true` to disable automatic execution of preinstall/postinstall scripts during `npm install`.

This is a security hardening measure to mitigate supply chain attacks via malicious npm package lifecycle scripts. Currently, the project does not use any preinstall or postinstall scripts, so this change should have no impact on the existing workflow.

For more context on why this matters:
- [npm ignore-scripts best practices as security mitigation for malicious packages](https://www.nodejs-security.com/blog/npm-ignore-scripts-best-practices-as-security-mitigation-for-malicious-packages)
- [Shai Hulud postmortem (trigger.dev supply chain attack)](https://trigger.dev/blog/shai-hulud-postmortem)

## Testing Instructions

- CI should pass

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?