### PR TITLE
Fix What's New current step icon color in dark mode

### DIFF
--- a/apps/studio/src/index.css
+++ b/apps/studio/src/index.css
@@ -464,6 +464,11 @@ div:has( > progress ) > div:first-child {
 		fill: var( --color-frame-text );
 	}
 
+	/* What's new step */
+	[aria-current='step'] .components-button svg {
+		fill: var( --color-frame-theme );
+	}
+
 	/* Primary button — force dark-mode theme blue */
 	.components-button.is-primary {
 		background-color: var( --color-frame-theme );


### PR DESCRIPTION
## Related issues

- N/A

## Proposed Changes

- Fix the "What's New" stepper current step color in Dark mode.

## Testing Instructions

- Start the app with `npm start`
- Toggle dark mode from Studio settings
- Open the What's New modal by clicking Help > What's new
- Verify the current step icon uses a different color.

| Before | After |
|--------|--------|
|  <img width="1021" height="712" alt="Screenshot 2026-03-26 at 13 57 45" src="https://github.com/user-attachments/assets/dfda5249-17d4-46a8-a806-e934ec629653" /> | <img width="1021" height="712" alt="Screenshot 2026-03-26 at 13 47 55" src="https://github.com/user-attachments/assets/bad7dfec-bde8-4d88-85ab-ca4a828baae3" /> |



## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors? (Tests pass, no errors)