### PR TITLE
Ensure that language packs are bundled in CLI `wp-files`

### DIFF
--- a/apps/studio/forge.config.ts
+++ b/apps/studio/forge.config.ts
@@ -161,6 +161,9 @@ const config: ForgeConfig = {
 			// may need to rerun `npm ci` from the repo root to reset the dependency tree after packaging.
 			await execAsync( 'npm run app:install:bundle' );
 
+			console.log( 'Downloading language packs ...' );
+			await execAsync( 'npm run download-language-packs' );
+
 			console.log( 'Building CLI (with bundled node_modules) ...' );
 			// NOTE: The `cli:package` script mutates the `apps/cli/node_modules` directory. You may need to
 			// rerun `npm ci` from the repo root to reset the dependency tree after packaging.
@@ -173,7 +176,12 @@ const config: ForgeConfig = {
 			const cliNodeModules = path.join( repoRoot, 'apps', 'cli', 'dist', 'cli', 'node_modules' );
 
 			// Clean up @anthropic-ai/claude-agent-sdk vendor binaries (uses {arch}-{platform} format)
-			const claudeVendorDir = path.join( cliNodeModules, '@anthropic-ai', 'claude-agent-sdk', 'vendor' );
+			const claudeVendorDir = path.join(
+				cliNodeModules,
+				'@anthropic-ai',
+				'claude-agent-sdk',
+				'vendor'
+			);
 			const platformSuffix = `-${ platform }`;
 			if ( fs.existsSync( claudeVendorDir ) ) {
 				for ( const toolDir of fs.readdirSync( claudeVendorDir ) ) {
@@ -204,9 +212,6 @@ const config: ForgeConfig = {
 					}
 				}
 			}
-
-			console.log('Downloading language packs ...');
-			await execAsync( 'npm run download-language-packs' );
 
 			console.log( `Downloading Node.js binary for ${ platform }-${ arch }...` );
 			await execAsync(


### PR DESCRIPTION
## Related issues

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

N/A

## How AI was used in this PR

<!--
Help reviewers understand what to look for and verify that you've reviewed the code yourself.
-->

Not at all. 

## Proposed Changes

WordPress language packs come bundled in the `wp-files/latest/languages` directory. Most of the `wp-files` directory is generated by the `download-wp-server-files.ts` script, but the language packs are only downloaded when the app is packaged (see https://github.com/Automattic/studio/pull/2575). 

This becomes troublesome with our recent change of shipping the `wp-files` directory with the CLI instead of with the app, because `forge.config` was running the CLI build script (which copies the `wp-files` directory to the output) before downloading the language packs. This resulted in the language packs not being included in the distributed output.

This PR changes the execution order so that the language packs are downloaded before the CLI is built.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Remove the `wp-files` directory from the project root (if you have it)
2. Run `npm i`
3. Run `npm run package`
4. Once finished, ensure that `apps/studio/out/Studio-darwin-arm64/Studio.app/Contents/Resources/cli/wp-files/latest` contains a `languages` directory

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
