### PR TITLE
Include scripts in typecheck

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
 		"app:install:bundle": "npm -w studio-app run install:bundle",
 		"compare:perf": "npm -w compare-perf run compare",
 		"lint": "eslint {apps/cli,apps/studio/src,apps/studio/e2e,tools/common}",
-		"typecheck": "tsc -p scripts/tsconfig.json --noEmit && npm run typecheck --workspaces --if-present",
+		"typecheck": "npm run typecheck --workspaces --if-present && tsc -p scripts/tsconfig.json --noEmit",
 		"format": "npm run lint -- --fix",
 		"test": "vitest run",
 		"test:watch": "vitest",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
 		"app:install:bundle": "npm -w studio-app run install:bundle",
 		"compare:perf": "npm -w compare-perf run compare",
 		"lint": "eslint {apps/cli,apps/studio/src,apps/studio/e2e,tools/common}",
-		"typecheck": "npm run typecheck --workspaces --if-present",
+		"typecheck": "tsc -p scripts/tsconfig.json --noEmit && npm run typecheck --workspaces --if-present",
 		"format": "npm run lint -- --fix",
 		"test": "vitest run",
 		"test:watch": "vitest",

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,0 +1,12 @@
+{
+	"extends": "../tsconfig.base.json",
+	"compilerOptions": {
+		"baseUrl": "..",
+		"paths": {
+			"*": [ "node_modules/*" ],
+			"@studio/common/*": [ "tools/common/*" ]
+		}
+	},
+	"include": [ "**/*" ],
+	"exclude": [ "**/node_modules/**/*" ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,8 @@
 		"apps/studio/e2e/**/*",
 		"apps/cli/**/*",
 		"tools/common/**/*",
-		"./vitest.global-setup.ts"
+		"./vitest.global-setup.ts",
+		"scripts/**/*"
 	],
 	"exclude": [ "**/__mocks__/**/*", "**/node_modules/**/*", "**/dist/**/*", "**/out/**/*" ]
 }


### PR DESCRIPTION
## Related issues

- Related to AINFRA-2177

## How AI was used in this PR

- AI helped draft the initial implementation and commit message rationale. I reviewed the resulting config changes and validated the typecheck behavior manually.

## Proposed Changes

When working on #2709 , I run into some issues with the scripts in one of the iterations. The AI suggested adding typechecking for `scripts/` which makes sense to me. However, I might be missing something here, such as whether it's okay to have scripts not being workspaces, or the difference in rigor to apply between small bits of automation and the app itself, so **feel free to close this PR if the suggestion is not beneficial.**

- Add `scripts/tsconfig.json` so the repo scripts can be typechecked as their own TS project.
- Update the root `typecheck` script to run `tsc -p scripts/tsconfig.json --noEmit` before the workspace checks.
- Add `scripts/**/*` to the root `tsconfig.json` so editor tooling also includes those files.
- Document in the commit message why the root `tsconfig.json` change alone would not have enforced script typechecking.

## Testing Instructions

- Run `npx tsc -p scripts/tsconfig.json --noEmit` and confirm it passes.
- Run `npm run -s typecheck --workspaces --if-present` before the change and note that it does not typecheck `scripts/`.
- Run `npm run typecheck` after the change and confirm it now checks `scripts/` as well as the existing workspace projects.
- Optional: run `npx tsc -p tsconfig.json --noEmit` and confirm the existing `apps/cli` `import.meta` errors are still present, which is why the dedicated `scripts/tsconfig.json` is needed.

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?
