### PR TITLE
Emit `deleted` site event when removing empty site

### DIFF
--- a/apps/cli/commands/_events.ts
+++ b/apps/cli/commands/_events.ts
@@ -64,6 +64,7 @@ async function emitAllSitesStatus(): Promise< void > {
 	for ( const site of cliConfig.sites ) {
 		if ( site.path && ( await isEmptyDir( site.path ).catch( () => true ) ) ) {
 			await removeSiteFromConfig( site.id );
+			await emitSiteEvent( SITE_EVENTS.DELETED, site.id );
 			continue;
 		}
 		await emitSiteEvent( SITE_EVENTS.UPDATED, site.id );


### PR DESCRIPTION
## Related issues

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

- N/A

## How AI was used in this PR

<!--
Help reviewers understand what to look for and verify that you've reviewed the code yourself.
-->

N/A

## Proposed Changes

https://github.com/Automattic/studio/pull/2836 moved the "if site directory is empty, delete it from the config" logic from Studio to the CLI. This PR fixes a small glitch in that logic: it wasn't emitting `SITE_EVENTS.DELETED` events, so sites disappeared from the config but not from the Studio sidebar. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Before starting the app, remove or rename one of your site directories
2. `npm start`
3. Ensure that the site does not appear in the Studio sidebar

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
