### PR TITLE
Fix account settings button opening general tab instead of account

### DIFF
--- a/apps/studio/src/components/top-bar.tsx
+++ b/apps/studio/src/components/top-bar.tsx
@@ -76,7 +76,7 @@ function Authentication() {
 	if ( isAuthenticated ) {
 		return (
 			<Button
-				onClick={ () => getIpcApi().showUserSettings() }
+				onClick={ () => getIpcApi().showUserSettings( 'account' ) }
 				aria-label={ __( 'Open account settings' ) }
 				variant="icon"
 				className="text-white hover:!text-white !px-1 py-1 !h-6 gap-2"


### PR DESCRIPTION
## Related issues

- N/A

## How AI was used in this PR

<!-- Help reviewers understand what to look for and verify that you've reviewed the code yourself. -->

I used AI to fix the issue.

## Proposed Changes

I propose to pass `'account'` explicitly to `showUserSettings()` in the top bar's authenticated user button. It seems as regression introduced at some point.

## Testing Instructions

1. Log in to Studio with a WordPress.com account
2. Click the "Howdy, {name}" / Gravatar button in the top bar
3. Verify the Settings modal opens on the **Account** tab (previously opened on General)
4. Click the cog (⚙) button — verify it still opens on the **General** tab

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?