### PR TITLE
Studio: Ensure Edit site modal takes full height

### DIFF
--- a/apps/studio/src/modules/site-settings/edit-site-details.tsx
+++ b/apps/studio/src/modules/site-settings/edit-site-details.tsx
@@ -290,8 +290,8 @@ const EditSiteDetails = ( { currentWpVersion, onSave }: EditSiteDetailsProps ) =
 					) }
 				>
 					<form onSubmit={ onSiteEdit }>
-						<TabPanel
-							className="w-full [&>[role=tabpanel]]:h-64 [&>[role=tabpanel]]:overflow-auto"
+					<TabPanel
+						className="w-full"
 							tabs={ [
 								{ name: 'general', title: __( 'General' ) },
 								{ name: 'debugging', title: __( 'Debugging' ) },
@@ -302,7 +302,7 @@ const EditSiteDetails = ( { currentWpVersion, onSave }: EditSiteDetailsProps ) =
 							orientation="horizontal"
 						>
 							{ ( { name } ) => (
-								<div className="mt-6 px-8 flex flex-col">
+								<div className="mt-6 px-8 pb-8 flex flex-col">
 									{ name === 'general' && (
 										<>
 											<label className="flex flex-col gap-1.5 leading-4 mb-6">


### PR DESCRIPTION
## Related issues

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

N/A 

This is something that I noticed while working on an unrelated PR. 

## How AI was used in this PR

<!--
Help reviewers understand what to look for and verify that you've reviewed the code yourself.
-->

Not used

## Proposed Changes

This PR ensures that the `Edit site` modal takes the full height:

<img width="1195" height="703" alt="Screenshot 2026-03-27 at 11 37 49 AM" src="https://github.com/user-attachments/assets/d733c498-a5a7-4623-8592-d1264095b158" />

**Before**

<img width="1201" height="704" alt="Screenshot 2026-03-27 at 11 48 14 AM" src="https://github.com/user-attachments/assets/6eb33ecf-e174-4aa8-a25f-fc5ff389f883" />

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
* Navigate to the `Settings` tab
* Click on the `Manage site skills`
* Confirm that when the modal opens, it takes the full height instead of being cropped

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
