### PR TITLE
Fix blueprint local resource resolution when creating sites from the app

### DIFF
--- a/apps/cli/commands/site/create.ts
+++ b/apps/cli/commands/site/create.ts
@@ -587,6 +587,10 @@ export const registerCommand = ( yargs: StudioArgv ) => {
 					type: 'string',
 					describe: __( 'Path or URL to Blueprint JSON file' ),
 				} )
+				.option( 'original-blueprint-path', {
+					type: 'string',
+					hidden: true,
+				} )
 				.option( 'admin-username', {
 					type: 'string',
 					describe: __( 'Admin username (defaults to "admin")' ),
@@ -767,6 +771,12 @@ export const registerCommand = ( yargs: StudioArgv ) => {
 						uri,
 						contents: readBlueprint( uri ),
 					};
+
+					// When invoked by the desktop app, the blueprint contents come from a temp file
+					// but resources should be resolved relative to the original file location.
+					if ( argv.originalBlueprintPath ) {
+						config.blueprint.uri = path.resolve( argv.originalBlueprintPath );
+					}
 				}
 			}
 

--- a/apps/studio/src/ipc-handlers.ts
+++ b/apps/studio/src/ipc-handlers.ts
@@ -439,6 +439,7 @@ export async function createSite(
 				enableHttps,
 				siteId,
 				blueprint: blueprint?.blueprint,
+				originalBlueprintPath: blueprint?.filePath,
 				adminUsername,
 				adminPassword,
 				adminEmail,

--- a/apps/studio/src/modules/add-site/components/blueprints.tsx
+++ b/apps/studio/src/modules/add-site/components/blueprints.tsx
@@ -36,6 +36,7 @@ interface Blueprint {
 		};
 		[ key: string ]: unknown;
 	};
+	filePath?: string;
 }
 
 interface DataViewBlueprint extends Blueprint {
@@ -225,6 +226,7 @@ export function AddSiteBlueprintSelector( {
 					image: '', // No image for file-based blueprints
 					playground_url: '', // No playground URL for file-based blueprints
 					blueprint: blueprintJson, // The actual blueprint JSON
+					filePath: getIpcApi().getPathForFile( file ),
 				};
 
 				setUploadedFileName( null );

--- a/apps/studio/src/modules/cli/lib/cli-site-creator.ts
+++ b/apps/studio/src/modules/cli/lib/cli-site-creator.ts
@@ -35,6 +35,7 @@ export interface CreateSiteOptions {
 	enableHttps?: boolean;
 	siteId?: string;
 	blueprint?: Blueprint;
+	originalBlueprintPath?: string;
 	adminUsername?: string;
 	adminPassword?: string;
 	adminEmail?: string;
@@ -50,6 +51,9 @@ export async function createSiteViaCli( options: CreateSiteOptions ): Promise< C
 		blueprintTempPath = path.join( os.tmpdir(), `studio-blueprint-${ Date.now() }.json` );
 		fs.writeFileSync( blueprintTempPath, JSON.stringify( options.blueprint ) );
 		args.push( '--blueprint', blueprintTempPath );
+		if ( options.originalBlueprintPath ) {
+			args.push( '--original-blueprint-path', options.originalBlueprintPath );
+		}
 	}
 
 	return new Promise( ( resolve, reject ) => {

--- a/apps/studio/src/stores/wpcom-api.ts
+++ b/apps/studio/src/stores/wpcom-api.ts
@@ -67,6 +67,7 @@ const blueprintSchema = z.object( {
 	image: z.string(),
 	playground_url: z.string(),
 	blueprint: z.record( z.string(), z.unknown() ),
+	filePath: z.string().optional(),
 } );
 
 export type Blueprint = z.infer< typeof blueprintSchema >;


### PR DESCRIPTION
## Related issues

- Fixes STU-1458

## How AI was used in this PR

Claude was used to trace the blueprint path flow across renderer → IPC → CLI, identify the root cause (temp file losing original directory context), and implement the fix. All code was reviewed and tested manually.

## Proposed Changes

- Capture Blueprint full filesystem path when a user selects a blueprint file
- Thread `originalBlueprintPath` through `createSite` IPC → `SiteServer.create()` → `createSiteViaCli()`
- Pass `--original-blueprint-path` new hidden CLI parameter so the CLI uses the original directory for resolving relative resources (e.g. `./koinonia.zip`)

## Testing Instructions

1. Download a blueprint JSON file and a theme zip from the Linear issue (e.g. `koinonia.zip`) to the same directory (e.g. `~/Downloads/`). 
```json
{
  "$schema": "https://playground.wordpress.net/blueprint-schema.json",
  "login": true,
  "siteOptions": {
    "blogname": "Koinonia"
  },
  "steps": [
    {
      "step": "resetData"
    },
    {
      "step": "installTheme",
      "themeData": {
        "resource": "bundled",
        "path": "./koinonia.zip"
      },
      "options": {
        "activate": true
      }
    }
  ]
}
```
3. Start the app with `npm start`
4. Create a new site using the file picker to select the blueprint.json local file
5. Verify the theme installs correctly (the `installTheme` step resolves the local zip)
6. Verify normal blueprint flows still work (gallery blueprints, deeplink blueprints)


https://github.com/user-attachments/assets/f26804ed-8836-460f-a6bd-c89840e938b9


## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?