### PR TITLE
Add /grab command with AI Canvas for visual element selection

### DIFF
--- a/apps/ai-canvas/index.html
+++ b/apps/ai-canvas/index.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<title>Studio AI Canvas</title>
+		<style>
+			*,
+			*::before,
+			*::after {
+				margin: 0;
+				padding: 0;
+				box-sizing: border-box;
+			}
+			html,
+			body,
+			#root {
+				width: 100%;
+				height: 100%;
+				overflow: hidden;
+				font-family: system-ui, -apple-system, sans-serif;
+			}
+		</style>
+	</head>
+	<body>
+		<div id="root"></div>
+		<script type="module" src="src/main.tsx"></script>
+	</body>
+</html>

--- a/apps/ai-canvas/package.json
+++ b/apps/ai-canvas/package.json
@@ -1,0 +1,19 @@
+{
+	"name": "@studio/ai-canvas",
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"build": "vite build",
+		"dev": "vite"
+	},
+	"devDependencies": {
+		"@types/react": "^19.1.8",
+		"@types/react-dom": "^19.1.6",
+		"@vitejs/plugin-react": "^4.5.2",
+		"react": "^19.1.0",
+		"react-dom": "^19.1.0",
+		"typescript": "^5.9.3",
+		"vite": "^7.3.1",
+		"vite-plugin-singlefile": "^2.0.3"
+	}
+}

--- a/apps/ai-canvas/src/components/App.tsx
+++ b/apps/ai-canvas/src/components/App.tsx
@@ -1,0 +1,55 @@
+import { useCallback, useRef, useState } from 'react';
+import { useIframePicker } from '../hooks/use-iframe-picker';
+import { Banner } from './Banner';
+import { ConfirmationModal } from './ConfirmationModal';
+import { HighlightOverlay } from './HighlightOverlay';
+import { SiteIframe } from './SiteIframe';
+import { Tooltip } from './Tooltip';
+import type { PickedElement } from '../lib/types';
+
+export function App() {
+	const iframeRef = useRef< HTMLIFrameElement | null >( null );
+	const [ iframeReady, setIframeReady ] = useState( false );
+	const [ lastSelected, setLastSelected ] = useState< PickedElement | null >( null );
+
+	const handleSelected = useCallback( ( element: PickedElement ) => {
+		setLastSelected( element );
+	}, [] );
+
+	const {
+		highlightRect,
+		tooltipInfo,
+		selected,
+		grabAnother,
+	} = useIframePicker( iframeRef, iframeReady, handleSelected );
+
+	const handleIframeReady = useCallback( () => {
+		setIframeReady( true );
+	}, [] );
+
+	const handleGrabAnother = useCallback( () => {
+		grabAnother();
+		setLastSelected( null );
+	}, [ grabAnother ] );
+
+	return (
+		<>
+			<Banner selected={ selected } />
+			<SiteIframe iframeRef={ iframeRef } onReady={ handleIframeReady } />
+			{ ! selected && <HighlightOverlay rect={ highlightRect } /> }
+			{ ! selected && tooltipInfo && (
+				<Tooltip
+					label={ tooltipInfo.label }
+					top={ tooltipInfo.rect.top }
+					left={ tooltipInfo.rect.left }
+				/>
+			) }
+			{ selected && lastSelected && (
+				<ConfirmationModal
+					element={ lastSelected }
+					onGrabAnother={ handleGrabAnother }
+				/>
+			) }
+		</>
+	);
+}

--- a/apps/ai-canvas/src/components/Banner.tsx
+++ b/apps/ai-canvas/src/components/Banner.tsx
@@ -1,0 +1,28 @@
+interface BannerProps {
+	selected: boolean;
+}
+
+export function Banner( { selected }: BannerProps ) {
+	return (
+		<div
+			style={ {
+				position: 'fixed',
+				top: 0,
+				left: 0,
+				right: 0,
+				backgroundColor: selected ? '#1a7e3c' : '#3858e9',
+				color: '#fff',
+				fontSize: '14px',
+				fontFamily: 'system-ui, -apple-system, sans-serif',
+				padding: '10px 16px',
+				zIndex: 2147483647,
+				textAlign: 'center',
+				boxShadow: '0 2px 8px rgba(0,0,0,0.15)',
+			} }
+		>
+			{ selected
+				? 'Element selected \u2014 return to the CLI to use it in your prompt'
+				: 'Click an element to select it \u2014 press Escape to cancel' }
+		</div>
+	);
+}

--- a/apps/ai-canvas/src/components/ConfirmationModal.tsx
+++ b/apps/ai-canvas/src/components/ConfirmationModal.tsx
@@ -1,0 +1,81 @@
+import { getFriendlyDescription } from '../lib/friendly-names';
+import type { PickedElement } from '../lib/types';
+
+interface ConfirmationModalProps {
+	element: PickedElement;
+	onGrabAnother: () => void;
+}
+
+const btnStyle: React.CSSProperties = {
+	padding: '8px 18px',
+	borderRadius: 6,
+	border: 'none',
+	fontSize: 13,
+	fontWeight: 500,
+	cursor: 'pointer',
+	fontFamily: 'system-ui, -apple-system, sans-serif',
+};
+
+export function ConfirmationModal( { element, onGrabAnother }: ConfirmationModalProps ) {
+	const summary = getFriendlyDescription( element.tagName, element.wpBlockType, element.innerText );
+
+	return (
+		<div
+			style={ {
+				position: 'fixed',
+				top: 0,
+				left: 0,
+				right: 0,
+				bottom: 0,
+				backgroundColor: 'rgba(0, 0, 0, 0.4)',
+				zIndex: 2147483647,
+				display: 'flex',
+				justifyContent: 'center',
+				alignItems: 'center',
+			} }
+		>
+			<div
+				style={ {
+					backgroundColor: '#fff',
+					borderRadius: 12,
+					boxShadow: '0 8px 32px rgba(0,0,0,0.25)',
+					padding: '20px 24px',
+					fontFamily: 'system-ui, -apple-system, sans-serif',
+					fontSize: 14,
+					color: '#1e1e1e',
+					minWidth: 340,
+					maxWidth: 500,
+				} }
+			>
+				<div style={ { marginBottom: 8, fontWeight: 600, fontSize: 15, lineHeight: 1.4 } }>
+					Element selected
+				</div>
+				<div
+					style={ {
+						marginBottom: 12,
+						padding: '10px 12px',
+						backgroundColor: '#f5f5f5',
+						borderRadius: 6,
+						fontSize: 13,
+						color: '#444',
+						lineHeight: 1.4,
+					} }
+				>
+					{ summary }
+				</div>
+				<div style={ { marginBottom: 16, fontSize: 12, color: '#888', lineHeight: 1.4 } }>
+					Return to the CLI to use this selection in your next prompt.
+				</div>
+				<div style={ { display: 'flex', gap: 10, justifyContent: 'flex-end' } }>
+					<button
+						type="button"
+						style={ { ...btnStyle, backgroundColor: '#e0e0e0', color: '#333' } }
+						onClick={ onGrabAnother }
+					>
+						Grab another element
+					</button>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/apps/ai-canvas/src/components/HighlightOverlay.tsx
+++ b/apps/ai-canvas/src/components/HighlightOverlay.tsx
@@ -1,0 +1,29 @@
+import type { HighlightRect } from '../lib/types';
+
+interface HighlightOverlayProps {
+	rect: HighlightRect | null;
+}
+
+export function HighlightOverlay( { rect }: HighlightOverlayProps ) {
+	if ( ! rect ) {
+		return null;
+	}
+
+	return (
+		<div
+			style={ {
+				position: 'fixed',
+				pointerEvents: 'none',
+				top: rect.top,
+				left: rect.left,
+				width: rect.width,
+				height: rect.height,
+				border: '2px solid #3858e9',
+				backgroundColor: 'rgba(56, 88, 233, 0.08)',
+				borderRadius: 3,
+				zIndex: 2147483646,
+				transition: 'top 0.05s, left 0.05s, width 0.05s, height 0.05s',
+			} }
+		/>
+	);
+}

--- a/apps/ai-canvas/src/components/SiteIframe.tsx
+++ b/apps/ai-canvas/src/components/SiteIframe.tsx
@@ -1,0 +1,33 @@
+import { useCallback } from 'react';
+
+const BANNER_HEIGHT = 40;
+
+interface SiteIframeProps {
+	iframeRef: React.RefObject< HTMLIFrameElement | null >;
+	onReady: () => void;
+}
+
+export function SiteIframe( { iframeRef, onReady }: SiteIframeProps ) {
+	const handleLoad = useCallback( () => {
+		onReady();
+	}, [ onReady ] );
+
+	return (
+		<iframe
+			ref={ iframeRef }
+			src="/"
+			title="Site preview"
+			onLoad={ handleLoad }
+			style={ {
+				position: 'fixed',
+				top: BANNER_HEIGHT,
+				left: 0,
+				right: 0,
+				bottom: 0,
+				width: '100%',
+				height: `calc(100% - ${ BANNER_HEIGHT }px)`,
+				border: 'none',
+			} }
+		/>
+	);
+}

--- a/apps/ai-canvas/src/components/Tooltip.tsx
+++ b/apps/ai-canvas/src/components/Tooltip.tsx
@@ -1,0 +1,28 @@
+interface TooltipProps {
+	label: string;
+	top: number;
+	left: number;
+}
+
+export function Tooltip( { label, top, left }: TooltipProps ) {
+	return (
+		<div
+			style={ {
+				position: 'fixed',
+				pointerEvents: 'none',
+				top,
+				left,
+				backgroundColor: '#1e1e1e',
+				color: '#fff',
+				fontSize: 12,
+				fontFamily: 'system-ui, -apple-system, sans-serif',
+				padding: '3px 8px',
+				borderRadius: 4,
+				zIndex: 2147483647,
+				whiteSpace: 'nowrap',
+			} }
+		>
+			{ label }
+		</div>
+	);
+}

--- a/apps/ai-canvas/src/hooks/use-iframe-picker.ts
+++ b/apps/ai-canvas/src/hooks/use-iframe-picker.ts
@@ -1,0 +1,149 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { captureElement, detectWpBlockType } from '../lib/dom-utils';
+import type { HighlightRect, PickedElement } from '../lib/types';
+
+declare global {
+	interface Window {
+		__studioOnElementSelected?: ( data: PickedElement ) => void;
+	}
+}
+
+interface TooltipInfo {
+	label: string;
+	rect: HighlightRect;
+}
+
+interface UseIframePickerResult {
+	highlightRect: HighlightRect | null;
+	tooltipInfo: TooltipInfo | null;
+	selected: boolean;
+	grabAnother: () => void;
+}
+
+export function useIframePicker(
+	iframeRef: React.RefObject< HTMLIFrameElement | null >,
+	enabled: boolean,
+	onSelected: ( element: PickedElement ) => void
+): UseIframePickerResult {
+	const [ highlightRect, setHighlightRect ] = useState< HighlightRect | null >( null );
+	const [ tooltipInfo, setTooltipInfo ] = useState< TooltipInfo | null >( null );
+	const [ selected, setSelected ] = useState( false );
+	const selectedRef = useRef( false );
+	const hoveredElRef = useRef< Element | null >( null );
+	const onSelectedRef = useRef( onSelected );
+	onSelectedRef.current = onSelected;
+
+	const grabAnother = useCallback( () => {
+		selectedRef.current = false;
+		setSelected( false );
+		setHighlightRect( null );
+		setTooltipInfo( null );
+		hoveredElRef.current = null;
+	}, [] );
+
+	const mapRectToParent = useCallback(
+		( elementRect: DOMRect ): HighlightRect => {
+			const iframe = iframeRef.current;
+			if ( ! iframe ) {
+				return { top: 0, left: 0, width: 0, height: 0 };
+			}
+			const iframeRect = iframe.getBoundingClientRect();
+			return {
+				top: iframeRect.top + elementRect.top,
+				left: iframeRect.left + elementRect.left,
+				width: elementRect.width,
+				height: elementRect.height,
+			};
+		},
+		[ iframeRef ]
+	);
+
+	const buildTooltipLabel = useCallback( ( el: Element ): string => {
+		let label = el.tagName.toLowerCase();
+		if ( el.id ) {
+			label += '#' + el.id;
+		}
+		const wpBlock = detectWpBlockType( el );
+		if ( wpBlock ) {
+			label += ' (' + wpBlock + ')';
+		} else if ( el.className && typeof el.className === 'string' ) {
+			const shortClass = el.className.split( /\s+/ ).slice( 0, 2 ).join( '.' );
+			if ( shortClass ) {
+				label += '.' + shortClass;
+			}
+		}
+		return label;
+	}, [] );
+
+	useEffect( () => {
+		const iframe = iframeRef.current;
+		if ( ! enabled || ! iframe ) {
+			return;
+		}
+
+		const doc = iframe.contentDocument;
+		if ( ! doc ) {
+			return;
+		}
+
+		const onMouseMove = ( e: MouseEvent ) => {
+			if ( selectedRef.current ) {
+				return;
+			}
+			const el = doc.elementFromPoint( e.clientX, e.clientY );
+			if ( ! el || el === doc.documentElement || el === doc.body ) {
+				setHighlightRect( null );
+				setTooltipInfo( null );
+				hoveredElRef.current = null;
+				return;
+			}
+
+			hoveredElRef.current = el;
+			const rect = el.getBoundingClientRect();
+			const mapped = mapRectToParent( rect );
+			setHighlightRect( mapped );
+
+			const label = buildTooltipLabel( el );
+			const tooltipY = mapped.top > 30 ? mapped.top - 26 : mapped.top + mapped.height + 4;
+			setTooltipInfo( {
+				label,
+				rect: { top: tooltipY, left: mapped.left, width: 0, height: 0 },
+			} );
+		};
+
+		const onClick = ( e: MouseEvent ) => {
+			if ( selectedRef.current ) {
+				return;
+			}
+			e.preventDefault();
+			e.stopPropagation();
+			e.stopImmediatePropagation();
+
+			const el = hoveredElRef.current || doc.elementFromPoint( e.clientX, e.clientY );
+			if ( ! el ) {
+				return;
+			}
+
+			const captured = captureElement( el );
+
+			// Send selection to CLI via Playwright's exposeFunction bridge.
+			window.__studioOnElementSelected?.( captured );
+
+			selectedRef.current = true;
+			setSelected( true );
+			setHighlightRect( null );
+			setTooltipInfo( null );
+			onSelectedRef.current( captured );
+		};
+
+		doc.addEventListener( 'mousemove', onMouseMove, true );
+		doc.addEventListener( 'click', onClick, true );
+
+		return () => {
+			doc.removeEventListener( 'mousemove', onMouseMove, true );
+			doc.removeEventListener( 'click', onClick, true );
+		};
+	}, [ iframeRef, enabled, mapRectToParent, buildTooltipLabel ] );
+
+	return { highlightRect, tooltipInfo, selected, grabAnother };
+}

--- a/apps/ai-canvas/src/lib/dom-utils.ts
+++ b/apps/ai-canvas/src/lib/dom-utils.ts
@@ -1,0 +1,101 @@
+import type { PickedElement } from './types';
+
+export function detectWpBlockType( el: Element ): string | null {
+	if ( el instanceof HTMLElement && el.dataset.type ) {
+		return el.dataset.type;
+	}
+	let current: Element | null = el;
+	for ( let i = 0; i < 5 && current && current !== current.ownerDocument.body; i++ ) {
+		if ( current.className && typeof current.className === 'string' ) {
+			const match = current.className.match( /wp-block-([a-z0-9-]+)/ );
+			if ( match ) {
+				return 'core/' + match[ 1 ];
+			}
+		}
+		current = current.parentElement;
+	}
+	return null;
+}
+
+export function generateSelector( el: Element ): string {
+	const parts: string[] = [];
+	let current: Element | null = el;
+	while ( current && current !== current.ownerDocument.body && current !== current.ownerDocument.documentElement ) {
+		let part = current.tagName.toLowerCase();
+		if ( current.id ) {
+			parts.unshift( part + '#' + current.id );
+			break;
+		}
+		const parent = current.parentElement;
+		if ( parent ) {
+			const siblings = Array.from( parent.children ).filter( ( c ) => c.tagName === current!.tagName );
+			if ( siblings.length > 1 ) {
+				const index = siblings.indexOf( current ) + 1;
+				part += ':nth-child(' + index + ')';
+			}
+		}
+		parts.unshift( part );
+		current = current.parentElement;
+	}
+	return parts.join( ' > ' );
+}
+
+export function getKeyStyles( el: Element ): Record< string, string > {
+	const computed = el.ownerDocument.defaultView!.getComputedStyle( el );
+	const keys = [
+		'fontSize', 'fontWeight', 'fontFamily', 'color', 'backgroundColor',
+		'padding', 'margin', 'display', 'position', 'width', 'height',
+		'textAlign', 'lineHeight', 'borderRadius',
+	];
+	const styles: Record< string, string > = {};
+	for ( const key of keys ) {
+		const val = computed.getPropertyValue(
+			key.replace( /[A-Z]/g, ( m ) => '-' + m.toLowerCase() )
+		);
+		if (
+			val && val !== 'auto' && val !== 'normal' && val !== 'none' &&
+			val !== '0px' && val !== 'rgba(0, 0, 0, 0)' && val !== 'transparent'
+		) {
+			styles[ key ] = val;
+		}
+	}
+	return styles;
+}
+
+export function getAncestors( el: Element ): string[] {
+	const chain: string[] = [];
+	let current = el.parentElement;
+	while ( current && current !== current.ownerDocument.documentElement ) {
+		let label = current.tagName.toLowerCase();
+		if ( current.id ) {
+			label += '#' + current.id;
+		} else if ( current.className && typeof current.className === 'string' ) {
+			const cls = current.className.split( /\s+/ )[ 0 ];
+			if ( cls ) {
+				label += '.' + cls;
+			}
+		}
+		chain.unshift( label );
+		current = current.parentElement;
+	}
+	return chain;
+}
+
+export function captureElement( el: Element ): PickedElement {
+	const rect = el.getBoundingClientRect();
+	return {
+		tagName: el.tagName,
+		selector: generateSelector( el ),
+		outerHTML: el.outerHTML.slice( 0, 2000 ),
+		innerText: ( ( el as HTMLElement ).innerText || '' ).slice( 0, 500 ),
+		computedStyles: getKeyStyles( el ),
+		boundingRect: {
+			x: Math.round( rect.x ),
+			y: Math.round( rect.y ),
+			width: Math.round( rect.width ),
+			height: Math.round( rect.height ),
+		},
+		wpBlockType: detectWpBlockType( el ),
+		ancestors: getAncestors( el ),
+	};
+}

--- a/apps/ai-canvas/src/lib/friendly-names.ts
+++ b/apps/ai-canvas/src/lib/friendly-names.ts
@@ -1,0 +1,44 @@
+const FRIENDLY_NAMES: Record< string, string > = {
+	h1: 'Heading',
+	h2: 'Heading',
+	h3: 'Heading',
+	h4: 'Heading',
+	h5: 'Heading',
+	h6: 'Heading',
+	p: 'Paragraph',
+	a: 'Link',
+	img: 'Image',
+	button: 'Button',
+	input: 'Input field',
+	nav: 'Navigation',
+	header: 'Header',
+	footer: 'Footer',
+	section: 'Section',
+	div: 'Block',
+	span: 'Text',
+	ul: 'List',
+	ol: 'List',
+	li: 'List item',
+	form: 'Form',
+	table: 'Table',
+	video: 'Video',
+	audio: 'Audio',
+};
+
+export function getFriendlyDescription( tagName: string, wpBlockType: string | null, innerText: string ): string {
+	const tag = tagName.toLowerCase();
+	let description = FRIENDLY_NAMES[ tag ] || tag.toUpperCase() + ' element';
+
+	if ( wpBlockType ) {
+		const blockLabel = wpBlockType.replace( 'core/', '' ).replace( /-/g, ' ' );
+		description = blockLabel.charAt( 0 ).toUpperCase() + blockLabel.slice( 1 ) + ' block';
+	}
+
+	const textPreview = innerText.slice( 0, 100 ).trim();
+	if ( textPreview ) {
+		const ellipsis = innerText.length > 100 ? '\u2026' : '';
+		return `${ description }: \u201C${ textPreview }${ ellipsis }\u201D`;
+	}
+
+	return description;
+}

--- a/apps/ai-canvas/src/lib/types.ts
+++ b/apps/ai-canvas/src/lib/types.ts
@@ -1,0 +1,19 @@
+export interface PickedElement {
+	tagName: string;
+	selector: string;
+	outerHTML: string;
+	innerText: string;
+	computedStyles: Record< string, string >;
+	boundingRect: { x: number; y: number; width: number; height: number };
+	wpBlockType: string | null;
+	ancestors: string[];
+}
+
+export interface HighlightRect {
+	top: number;
+	left: number;
+	width: number;
+	height: number;
+}
+
+export type PickerState = 'loading' | 'picking' | 'confirming' | 'done';

--- a/apps/ai-canvas/src/main.tsx
+++ b/apps/ai-canvas/src/main.tsx
@@ -1,0 +1,4 @@
+import { createRoot } from 'react-dom/client';
+import { App } from './components/App';
+
+createRoot( document.getElementById( 'root' )! ).render( <App /> );

--- a/apps/ai-canvas/tsconfig.json
+++ b/apps/ai-canvas/tsconfig.json
@@ -1,0 +1,17 @@
+{
+	"compilerOptions": {
+		"target": "ES2022",
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"lib": ["ES2022", "DOM", "DOM.Iterable"],
+		"jsx": "react-jsx",
+		"strict": true,
+		"esModuleInterop": true,
+		"skipLibCheck": true,
+		"forceConsistentCasingInFileNames": true,
+		"resolveJsonModule": true,
+		"isolatedModules": true,
+		"noEmit": true
+	},
+	"include": ["src"]
+}

--- a/apps/ai-canvas/vite.config.ts
+++ b/apps/ai-canvas/vite.config.ts
@@ -1,0 +1,13 @@
+import react from '@vitejs/plugin-react';
+import { defineConfig } from 'vite';
+import { viteSingleFile } from 'vite-plugin-singlefile';
+
+export default defineConfig( {
+	plugins: [ react(), viteSingleFile() ],
+	root: __dirname,
+	build: {
+		outDir: 'dist',
+		target: 'chrome120',
+		minify: 'esbuild',
+	},
+} );

--- a/apps/cli/ai/element-picker.ts
+++ b/apps/cli/ai/element-picker.ts
@@ -1,0 +1,159 @@
+/**
+ * Element picker — opens a headed Playwright browser with the AI Canvas app,
+ * which renders the site in an iframe and lets the user select DOM elements.
+ *
+ * The browser stays open and selections flow back to the CLI asynchronously
+ * via Playwright's exposeFunction bridge. No blocking — the user can select
+ * elements at any time, even while a prompt is running.
+ */
+
+import { readFileSync } from 'fs';
+import { dirname, resolve } from 'path';
+import { fileURLToPath } from 'url';
+
+const __pickDirname = dirname( fileURLToPath( import.meta.url ) );
+
+export interface PickedElement {
+	tagName: string;
+	selector: string;
+	outerHTML: string;
+	innerText: string;
+	computedStyles: Record< string, string >;
+	boundingRect: { x: number; y: number; width: number; height: number };
+	wpBlockType: string | null;
+	ancestors: string[];
+}
+
+type Browser = Awaited< ReturnType< typeof import('playwright').chromium.launch > >;
+type Page = Awaited< ReturnType< Browser[ 'newPage' ] > >;
+
+export type SelectionCallback = ( element: PickedElement ) => void;
+
+export class ElementPicker {
+	private browser: Browser | null = null;
+	private page: Page | null = null;
+	private currentSiteUrl: string | null = null;
+	private _latestSelection: PickedElement | null = null;
+	private selectionCallback: SelectionCallback | null = null;
+
+	/**
+	 * The most recent element the user selected in the browser.
+	 * Updated asynchronously whenever the user clicks an element.
+	 */
+	get latestSelection(): PickedElement | null {
+		return this._latestSelection;
+	}
+
+	/**
+	 * Clear the stored selection (e.g. after consuming it in a prompt).
+	 */
+	clearSelection(): void {
+		this._latestSelection = null;
+	}
+
+	/**
+	 * Open the browser with the AI Canvas. Non-blocking — returns immediately
+	 * after the browser is ready. Selections arrive via the callback.
+	 *
+	 * If the browser is already open for the same site, this is a no-op.
+	 * If the site changed, reopens with the new site.
+	 */
+	async open( siteUrl: string, onSelection: SelectionCallback ): Promise< void > {
+		this.selectionCallback = onSelection;
+
+		if ( this.currentSiteUrl === siteUrl && ( await this.isAlive() ) ) {
+			// Browser already open for this site — nothing to do.
+			return;
+		}
+
+		await this.closeBrowser();
+		await this.openBrowser( siteUrl );
+	}
+
+	/**
+	 * Whether the browser is currently open and alive.
+	 */
+	get isOpen(): boolean {
+		return this.browser !== null && this.page !== null;
+	}
+
+	/**
+	 * Close the browser. Call when the AI session ends.
+	 */
+	async close(): Promise< void > {
+		await this.closeBrowser();
+	}
+
+	private handleSelection( data: PickedElement ): void {
+		this._latestSelection = data;
+		this.selectionCallback?.( data );
+	}
+
+	private async isAlive(): Promise< boolean > {
+		if ( ! this.browser || ! this.page ) {
+			return false;
+		}
+		try {
+			await this.page.evaluate( () => true );
+			return true;
+		} catch {
+			this.browser = null;
+			this.page = null;
+			this.currentSiteUrl = null;
+			return false;
+		}
+	}
+
+	private async openBrowser( siteUrl: string ): Promise< void > {
+		const canvasHtmlPath = resolve( __pickDirname, 'ai-canvas', 'dist', 'index.html' );
+		const canvasHtml = readFileSync( canvasHtmlPath, 'utf-8' );
+
+		const { chromium } = await import( 'playwright' );
+		this.browser = await chromium.launch( {
+			headless: false,
+			args: [ '--ignore-certificate-errors' ],
+		} );
+
+		this.page = await this.browser.newPage( {
+			viewport: { width: 1280, height: 900 },
+			ignoreHTTPSErrors: true,
+		} );
+
+		this.currentSiteUrl = siteUrl;
+
+		// Expose a function the React app can call to send selections back to Node.
+		await this.page.exposeFunction( '__studioOnElementSelected', ( data: PickedElement ) => {
+			this.handleSelection( data );
+		} );
+
+		// Intercept requests to /__studio-canvas/ and serve the built React app.
+		await this.page.route( '**/__studio-canvas/**', async ( route ) => {
+			await route.fulfill( {
+				status: 200,
+				contentType: 'text/html',
+				body: canvasHtml,
+			} );
+		} );
+
+		await this.page.goto( `${ siteUrl }/__studio-canvas/`, {
+			waitUntil: 'domcontentloaded',
+			timeout: 30_000,
+		} );
+
+		// Clean up if the user closes the browser window.
+		this.page.on( 'close', () => {
+			this.browser = null;
+			this.page = null;
+			this.currentSiteUrl = null;
+		} );
+	}
+
+	private async closeBrowser(): Promise< void > {
+		if ( this.browser ) {
+			await this.browser.close().catch( () => {} );
+			this.browser = null;
+			this.page = null;
+			this.currentSiteUrl = null;
+		}
+	}
+}

--- a/apps/cli/ai/slash-commands.ts
+++ b/apps/cli/ai/slash-commands.ts
@@ -9,9 +9,11 @@ export const AI_CHAT_LOGIN_COMMAND = '/login';
 export const AI_CHAT_LOGOUT_COMMAND = '/logout';
 export const AI_CHAT_MODEL_COMMAND = '/model';
 export const AI_CHAT_PROVIDER_COMMAND = '/provider';
+export const AI_CHAT_GRAB_COMMAND = '/grab';
 export const AI_CHAT_EXIT_COMMAND = '/exit';
 
 export const AI_CHAT_SLASH_COMMANDS: SlashCommandDef[] = [
+	{ name: 'grab', description: 'Select an element on the site to give the AI context' },
 	{ name: 'browser', description: 'Open the active site in the browser' },
 	{ name: 'api-key', description: 'Set or update the Anthropic API key' },
 	{ name: 'login', description: 'Log in to WordPress.com' },

--- a/apps/cli/ai/ui.ts
+++ b/apps/cli/ai/ui.ts
@@ -77,6 +77,7 @@ class PromptEditor implements Component, Focusable {
 	private _focused = false;
 	private isEmpty = true;
 	activeSiteName: string | null = null;
+	selectedElementLabel: string | null = null;
 	hints: string[] = [];
 	statusMessage: string | null = null;
 	showBottomBar = true;
@@ -159,6 +160,17 @@ class PromptEditor implements Component, Focusable {
 				return ' ' + bc( '─'.repeat( borderWidth ) );
 			}
 			if ( i === bottomBorderIndex ) {
+				if ( this.selectedElementLabel && borderWidth > 4 ) {
+					const label = ` ${ this.selectedElementLabel } `;
+					const trailing = Math.min( 3, borderWidth );
+					const leading = Math.max( 0, borderWidth - label.length - trailing );
+					return (
+						' ' +
+						bc( '─'.repeat( leading ) ) +
+						chalk.hex( '#1a7e3c' )( label ) +
+						bc( '─'.repeat( trailing ) )
+					);
+				}
 				return ' ' + bc( '─'.repeat( borderWidth ) );
 			}
 			if ( this.isEmpty && i === 1 ) {
@@ -1422,6 +1434,11 @@ export class AiChatUI {
 
 	setStatusMessage( message: string | null ): void {
 		this.editor.statusMessage = message;
+		this.tui.requestRender();
+	}
+
+	setSelectedElementLabel( label: string | null ): void {
+		this.editor.selectedElementLabel = label;
 		this.tui.requestRender();
 	}
 

--- a/apps/cli/commands/ai/index.ts
+++ b/apps/cli/commands/ai/index.ts
@@ -16,6 +16,7 @@ import {
 	resolveUnavailableAiProvider,
 	saveSelectedAiProvider,
 } from 'cli/ai/auth';
+import { ElementPicker, type PickedElement } from 'cli/ai/element-picker';
 import { AI_PROVIDERS, type AiProviderId } from 'cli/ai/providers';
 import { resolveResumeSessionContext } from 'cli/ai/sessions/context';
 import { AiSessionRecorder } from 'cli/ai/sessions/recorder';
@@ -28,12 +29,14 @@ import {
 	AI_CHAT_LOGIN_COMMAND,
 	AI_CHAT_LOGOUT_COMMAND,
 	AI_CHAT_MODEL_COMMAND,
+	AI_CHAT_GRAB_COMMAND,
 	AI_CHAT_PROVIDER_COMMAND,
 } from 'cli/ai/slash-commands';
 import { AiChatUI } from 'cli/ai/ui';
 import { runCommand as runLoginCommand } from 'cli/commands/auth/login';
 import { runCommand as runLogoutCommand } from 'cli/commands/auth/logout';
 import { readCliConfig } from 'cli/lib/cli-config/core';
+import { getSiteUrl } from 'cli/lib/cli-config/sites';
 import { Logger, LoggerError, setProgressCallback } from 'cli/logger';
 import { StudioArgv } from 'cli/types';
 
@@ -218,6 +221,9 @@ export async function runCommand(
 		}
 	}
 
+	let pendingElementContext: PickedElement | null = null;
+	const elementPicker = new ElementPicker();
+
 	const { anthropicApiKey } = await readCliConfig();
 	if ( currentProvider === 'anthropic-api-key' && ! anthropicApiKey ) {
 		ui.showInfo( 'No Anthropic API key saved. Use /provider to enter one.' );
@@ -271,6 +277,22 @@ export async function runCommand(
 			enrichedPrompt = `[Active site: "${ site.name }" at ${ site.path }${
 				site.running ? ' (running)' : ' (stopped)'
 			}]\n\n${ prompt }`;
+		}
+
+		if ( pendingElementContext ) {
+			const el = pendingElementContext;
+			enrichedPrompt +=
+				`\n\n[Selected element on the page:\n` +
+				`  tag: <${ el.tagName.toLowerCase() }>\n` +
+				`  selector: "${ el.selector }"\n` +
+				`  wp_block_type: ${ el.wpBlockType ?? 'none' }\n` +
+				`  html: ${ el.outerHTML.slice( 0, 2000 ) }\n` +
+				`  text: "${ el.innerText.slice( 0, 500 ) }"\n` +
+				`  styles: ${ JSON.stringify( el.computedStyles ) }\n` +
+				`  ancestors: ${ el.ancestors.join( ' > ' ) }\n` +
+				`]`;
+			pendingElementContext = null;
+			ui.setSelectedElementLabel( null );
 		}
 
 		await persistSessionContext();
@@ -360,6 +382,56 @@ export async function runCommand(
 				const opened = await ui.openActiveSiteInBrowser();
 				if ( ! opened ) {
 					ui.showInfo( 'No site selected. Use ↓ to select a site first.' );
+				}
+				continue;
+			}
+
+			if ( trimmedPrompt === AI_CHAT_GRAB_COMMAND ) {
+				const site = ui.activeSite;
+				if ( ! site ) {
+					ui.showInfo( 'No site selected. Use ↓ to select a site first.' );
+					continue;
+				}
+				if ( ! site.running ) {
+					ui.showInfo( 'Site is not running. Start it first.' );
+					continue;
+				}
+
+				// Resolve URL: remote sites have url directly, local sites need config lookup.
+				let siteUrl = site.url;
+				if ( ! siteUrl ) {
+					const config = await readCliConfig();
+					const siteData = config.sites?.find( ( s ) => s.name === site.name );
+					if ( siteData ) {
+						siteUrl = getSiteUrl( siteData );
+					}
+				}
+				if ( ! siteUrl ) {
+					ui.showInfo( 'Could not determine site URL.' );
+					continue;
+				}
+
+				try {
+					await elementPicker.open( siteUrl, ( picked ) => {
+						pendingElementContext = picked;
+						const preview = picked.innerText.slice( 0, 40 ).trim();
+						const tag = picked.tagName.toLowerCase();
+						const shortLabel = preview
+							? `<${ tag }> "${ preview }${ picked.innerText.length > 40 ? '…' : '' }"`
+							: `<${ tag }> ${ picked.selector }`;
+						ui.setSelectedElementLabel( shortLabel );
+					} );
+					if ( ! elementPicker.isOpen ) {
+						ui.showError( 'Failed to open browser.' );
+					} else {
+						ui.showInfo(
+							'Browser opened — click any element to select it. You can keep chatting.'
+						);
+					}
+				} catch ( error ) {
+					ui.showError(
+						`Failed to open browser: ${ error instanceof Error ? error.message : String( error ) }`
+					);
 				}
 				continue;
 			}
@@ -472,6 +544,7 @@ export async function runCommand(
 			}
 		}
 	} finally {
+		await elementPicker.close();
 		await persistQueue;
 		ui.stop();
 		process.exit( 0 );

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -12,6 +12,7 @@
 	"files": [
 		"dist/cli/*.js",
 		"dist/cli/wp-files/",
+		"dist/cli/ai-canvas/",
 		"patches/",
 		"scripts/"
 	],
@@ -52,9 +53,10 @@
 		"zod": "^4.3.6"
 	},
 	"scripts": {
-		"build": "vite build --config ./vite.config.dev.ts",
-		"build:prod": "vite build --config ./vite.config.prod.ts",
-		"build:npm": "vite build --config ./vite.config.npm.ts",
+		"build:ai-canvas": "cd ../ai-canvas && npm run build",
+		"build": "npm run build:ai-canvas && vite build --config ./vite.config.dev.ts",
+		"build:prod": "npm run build:ai-canvas && vite build --config ./vite.config.prod.ts",
+		"build:npm": "npm run build:ai-canvas && vite build --config ./vite.config.npm.ts",
 		"install:bundle": "npm install --omit=dev --no-package-lock --no-progress --install-links --no-workspaces && patch-package && node ../../scripts/remove-fs-ext-other-platform-binaries.mjs",
 		"package": "npm run install:bundle && npm run build:prod",
 		"watch": "vite build --config ./vite.config.dev.ts --watch",

--- a/apps/cli/vite.config.dev.ts
+++ b/apps/cli/vite.config.dev.ts
@@ -12,6 +12,10 @@ export default mergeConfig(
 						src: 'ai/plugin',
 						dest: '.',
 					},
+					{
+						src: '../../apps/ai-canvas/dist',
+						dest: 'ai-canvas',
+					},
 				],
 			} ),
 		],

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,107 @@
 				"web-streams-polyfill": "^4.2.0"
 			}
 		},
+		"apps/ai-canvas": {
+			"name": "@studio/ai-canvas",
+			"devDependencies": {
+				"@types/react": "^19.1.8",
+				"@types/react-dom": "^19.1.6",
+				"@vitejs/plugin-react": "^4.5.2",
+				"react": "^19.1.0",
+				"react-dom": "^19.1.0",
+				"typescript": "^5.9.3",
+				"vite": "^7.3.1",
+				"vite-plugin-singlefile": "^2.0.3"
+			}
+		},
+		"apps/ai-canvas/node_modules/@rolldown/pluginutils": {
+			"version": "1.0.0-beta.27",
+			"resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+			"integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"apps/ai-canvas/node_modules/@types/react": {
+			"version": "19.2.14",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+			"integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"csstype": "^3.2.2"
+			}
+		},
+		"apps/ai-canvas/node_modules/@types/react-dom": {
+			"version": "19.2.3",
+			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+			"integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+			"dev": true,
+			"license": "MIT",
+			"peerDependencies": {
+				"@types/react": "^19.2.0"
+			}
+		},
+		"apps/ai-canvas/node_modules/@vitejs/plugin-react": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+			"integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/core": "^7.28.0",
+				"@babel/plugin-transform-react-jsx-self": "^7.27.1",
+				"@babel/plugin-transform-react-jsx-source": "^7.27.1",
+				"@rolldown/pluginutils": "1.0.0-beta.27",
+				"@types/babel__core": "^7.20.5",
+				"react-refresh": "^0.17.0"
+			},
+			"engines": {
+				"node": "^14.18.0 || >=16.0.0"
+			},
+			"peerDependencies": {
+				"vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+			}
+		},
+		"apps/ai-canvas/node_modules/react": {
+			"version": "19.2.4",
+			"resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
+			"integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"apps/ai-canvas/node_modules/react-dom": {
+			"version": "19.2.4",
+			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
+			"integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"scheduler": "^0.27.0"
+			},
+			"peerDependencies": {
+				"react": "^19.2.4"
+			}
+		},
+		"apps/ai-canvas/node_modules/react-refresh": {
+			"version": "0.17.0",
+			"resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+			"integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"apps/ai-canvas/node_modules/scheduler": {
+			"version": "0.27.0",
+			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+			"integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"apps/cli": {
 			"name": "wp-studio",
 			"version": "1.7.7-beta1",
@@ -9199,6 +9300,10 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/@studio/ai-canvas": {
+			"resolved": "apps/ai-canvas",
+			"link": true
+		},
 		"node_modules/@studio/common": {
 			"resolved": "tools/common",
 			"link": true
@@ -9250,6 +9355,7 @@
 			"os": [
 				"darwin"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -9266,6 +9372,7 @@
 			"os": [
 				"darwin"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -9282,6 +9389,7 @@
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -9298,6 +9406,7 @@
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -9314,6 +9423,7 @@
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -9330,6 +9440,7 @@
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -9346,6 +9457,7 @@
 			"os": [
 				"linux"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -9362,6 +9474,7 @@
 			"os": [
 				"win32"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -9378,6 +9491,7 @@
 			"os": [
 				"win32"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -9394,6 +9508,7 @@
 			"os": [
 				"win32"
 			],
+			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -25120,6 +25235,23 @@
 				"yaml": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/vite-plugin-singlefile": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/vite-plugin-singlefile/-/vite-plugin-singlefile-2.3.2.tgz",
+			"integrity": "sha512-b8SxCi/gG7K298oJDcKOuZeU6gf6wIcCJAaEqUmmZXdjfuONlkyNyWZC3tEbN6QockRCNUd3it9eGTtpHGoYmg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"micromatch": "^4.0.8"
+			},
+			"engines": {
+				"node": ">18.0.0"
+			},
+			"peerDependencies": {
+				"rollup": "^4.59.0",
+				"vite": "^5.4.11 || ^6.0.0 || ^7.0.0 || ^8.0.0"
 			}
 		},
 		"node_modules/vite-plugin-static-copy": {


### PR DESCRIPTION
## Related issues

- STU-1474

## How AI was used in this PR

This feature was largely AI-assisted (vibe-coded). The architecture, component structure, and integration were designed collaboratively with Claude. All code has been reviewed by the author.

## Proposed Changes

- Add new `apps/ai-canvas` React app workspace that renders a WordPress site in an iframe with element picker UI (hover highlights, tooltips, confirmation modal)
- Add `/grab` slash command to the CLI `ai` chat that opens a headed Playwright browser with the AI Canvas, letting users visually select DOM elements
- Selections flow asynchronously back to the CLI via Playwright's `exposeFunction` bridge — the browser stays open while the user continues chatting
- Selected element context (HTML, CSS, selector, WP block type, ancestors) is automatically attached to the next AI prompt
- Show the current selection label in the TUI prompt editor's bottom border

## Testing Instructions

- Build the CLI: `npm run cli:build`
- Run `node apps/cli/dist/cli/main.js ai`, select a running site
- Type `/grab` — a browser window should open showing the site in an iframe
- Hover over elements — blue highlight and tooltip should follow the cursor
- Click an element — confirmation modal appears with a friendly summary
- Return to the CLI — the selected element label appears in the prompt area
- Type a prompt — the element context should be included and the AI should reference it
- The browser stays open for additional selections between prompts

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?