### PR TITLE
Auto-install Playwright Chromium for MCP tools

### DIFF
--- a/apps/cli/ai/browser-utils.ts
+++ b/apps/cli/ai/browser-utils.ts
@@ -6,13 +6,17 @@
  * backend could be added behind the same interface.
  */
 
+import { execFile } from 'child_process';
 import { existsSync } from 'fs';
+import { createRequire } from 'module';
 import os from 'os';
+import { promisify } from 'util';
 
 type Browser = Awaited< ReturnType< ( typeof import('playwright') )[ 'chromium' ][ 'launch' ] > >;
 type Page = Awaited< ReturnType< Browser[ 'newPage' ] > >;
 type Chromium = Awaited< typeof import( 'playwright' ) >[ 'chromium' ];
 type ChromiumLaunchOptions = Parameters< Chromium[ 'launch' ] >[ 0 ];
+type InstallBrowserFn = () => Promise< void >;
 
 const DEFAULT_BROWSER_ARGS = [ '--ignore-certificate-errors' ];
 const SUPPORTED_CHANNELS = [
@@ -31,6 +35,8 @@ const ENV_EXECUTABLE_KEYS = [
 const ENV_CHANNEL_KEYS = [ 'STUDIO_MCP_BROWSER_CHANNEL', 'PLAYWRIGHT_CHROMIUM_CHANNEL' ] as const;
 
 let browserPromise: Promise< Browser > | null = null;
+const execFileAsync = promisify( execFile );
+const require = createRequire( import.meta.url );
 
 function getEnvValue( keys: readonly string[] ): string | undefined {
 	for ( const key of keys ) {
@@ -78,9 +84,15 @@ function getCandidateExecutablePaths(
 		...( systemCandidatesByPlatform[ os.platform() ] ?? [] ),
 	];
 
-	return [ ...new Set( candidates.filter( Boolean ) ) ].filter( ( candidate ): candidate is string =>
-		existsSync( candidate )
+	const definedCandidates = [ ...new Set( candidates ) ].filter(
+		( candidate ): candidate is string => Boolean( candidate )
 	);
+
+	return definedCandidates.filter( ( candidate ) => existsSync( candidate ) );
+}
+
+function hasExternalBrowserOverride(): boolean {
+	return Boolean( getEnvValue( ENV_EXECUTABLE_KEYS ) || getEnvValue( ENV_CHANNEL_KEYS ) );
 }
 
 function getChannelCandidates(): Array< ( typeof SUPPORTED_CHANNELS )[ number ] > {
@@ -134,6 +146,47 @@ function describeLaunchOptions( options: ChromiumLaunchOptions ): string {
 	return 'playwright-default';
 }
 
+async function installPlaywrightChromium(): Promise< void > {
+	const cliPath = require.resolve( 'playwright/cli' );
+
+	await execFileAsync( process.execPath, [ cliPath, 'install', 'chromium' ], {
+		env: {
+			...process.env,
+			CI: process.env.CI ?? '1',
+		},
+		maxBuffer: 10 * 1024 * 1024,
+	} );
+}
+
+export async function ensurePlaywrightChromiumInstalled(
+	chromium: Pick< Chromium, 'executablePath' >,
+	installBrowser: InstallBrowserFn = installPlaywrightChromium
+): Promise< string | null > {
+	if ( hasExternalBrowserOverride() ) {
+		return null;
+	}
+
+	const executablePath = chromium.executablePath();
+	if ( existsSync( executablePath ) ) {
+		return null;
+	}
+
+	try {
+		await installBrowser();
+	} catch ( error ) {
+		return (
+			'Studio MCP could not auto-install Playwright Chromium. ' +
+			`${ error instanceof Error ? error.message : String( error ) }`
+		);
+	}
+
+	if ( ! existsSync( chromium.executablePath() ) ) {
+		return 'Studio MCP attempted to install Playwright Chromium, but the browser executable is still unavailable.';
+	}
+
+	return null;
+}
+
 /**
  * Returns (and lazily launches) a shared Chromium browser instance.
  * The browser is cleaned up automatically on process exit.
@@ -142,6 +195,7 @@ export async function getSharedBrowser(): Promise< Browser > {
 	if ( ! browserPromise ) {
 		browserPromise = ( async () => {
 			const { chromium } = await import( 'playwright' );
+			const installError = await ensurePlaywrightChromiumInstalled( chromium );
 			const launchCandidates = getChromiumLaunchCandidates( chromium );
 			const launchErrors: string[] = [];
 			let browser: Browser | undefined;
@@ -160,11 +214,16 @@ export async function getSharedBrowser(): Promise< Browser > {
 			}
 
 			if ( ! browser ) {
+				const repairGuidance =
+					installError ??
+					'If Playwright Chromium is missing, run `studio mcp` again with network access so Studio can install it automatically.';
+
 				throw new Error(
 					'Unable to launch a browser for Studio MCP screenshot/validation tools. ' +
 						`Tried ${ launchCandidates.map( describeLaunchOptions ).join( ', ' ) }. ` +
 						'Set STUDIO_MCP_BROWSER_EXECUTABLE_PATH to a local Chrome/Chromium-compatible browser, ' +
 						'or STUDIO_MCP_BROWSER_CHANNEL to a Playwright-supported channel like "chrome". ' +
+						`${ repairGuidance } ` +
 						`Launch errors: ${ launchErrors.join( ' | ' ) }`
 				);
 			}

--- a/apps/cli/ai/browser-utils.ts
+++ b/apps/cli/ai/browser-utils.ts
@@ -8,8 +8,8 @@
 
 import { execFile } from 'child_process';
 import { existsSync } from 'fs';
-import { createRequire } from 'module';
 import os from 'os';
+import { fileURLToPath } from 'url';
 import { promisify } from 'util';
 
 type Browser = Awaited< ReturnType< ( typeof import('playwright') )[ 'chromium' ][ 'launch' ] > >;
@@ -42,7 +42,6 @@ const ENV_CHANNEL_KEYS = [ 'STUDIO_MCP_BROWSER_CHANNEL', 'PLAYWRIGHT_CHROMIUM_CH
 
 let browserPromise: Promise< Browser > | null = null;
 const execFileAsync = promisify( execFile );
-const require = createRequire( import.meta.url );
 const SYSTEM_BROWSER_CANDIDATES_BY_PLATFORM: Record< string, string[] > = {
 	darwin: [
 		'/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
@@ -138,7 +137,7 @@ export function buildChromiumLaunchAttempts(
 }
 
 async function installPlaywrightChromium(): Promise< void > {
-	const cliPath = require.resolve( 'playwright/cli' );
+	const cliPath = fileURLToPath( import.meta.resolve( 'playwright/cli' ) );
 
 	await execFileAsync( process.execPath, [ cliPath, 'install', 'chromium' ], {
 		env: {

--- a/apps/cli/ai/browser-utils.ts
+++ b/apps/cli/ai/browser-utils.ts
@@ -6,10 +6,133 @@
  * backend could be added behind the same interface.
  */
 
+import { existsSync } from 'fs';
+import os from 'os';
+
 type Browser = Awaited< ReturnType< ( typeof import('playwright') )[ 'chromium' ][ 'launch' ] > >;
 type Page = Awaited< ReturnType< Browser[ 'newPage' ] > >;
+type Chromium = Awaited< typeof import( 'playwright' ) >[ 'chromium' ];
+type ChromiumLaunchOptions = Parameters< Chromium[ 'launch' ] >[ 0 ];
+
+const DEFAULT_BROWSER_ARGS = [ '--ignore-certificate-errors' ];
+const SUPPORTED_CHANNELS = [
+	'chrome',
+	'chrome-beta',
+	'chrome-dev',
+	'msedge',
+	'msedge-beta',
+	'msedge-dev',
+] as const;
+const ENV_EXECUTABLE_KEYS = [
+	'STUDIO_MCP_BROWSER_EXECUTABLE_PATH',
+	'PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH',
+	'CHROME_EXECUTABLE_PATH',
+] as const;
+const ENV_CHANNEL_KEYS = [ 'STUDIO_MCP_BROWSER_CHANNEL', 'PLAYWRIGHT_CHROMIUM_CHANNEL' ] as const;
 
 let browserPromise: Promise< Browser > | null = null;
+
+function getEnvValue( keys: readonly string[] ): string | undefined {
+	for ( const key of keys ) {
+		const value = process.env[ key ]?.trim();
+		if ( value ) {
+			return value;
+		}
+	}
+}
+
+function getCandidateExecutablePaths(
+	chromium: Pick< Chromium, 'executablePath' >
+): string[] {
+	const systemCandidatesByPlatform: Record< string, string[] > = {
+		darwin: [
+			'/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+			'/Applications/Chromium.app/Contents/MacOS/Chromium',
+			'/Applications/Google Chrome Beta.app/Contents/MacOS/Google Chrome Beta',
+			'/Applications/Google Chrome Dev.app/Contents/MacOS/Google Chrome Dev',
+			'/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge',
+			'/Applications/Brave Browser.app/Contents/MacOS/Brave Browser',
+		],
+		linux: [
+			'/usr/bin/google-chrome',
+			'/usr/bin/google-chrome-stable',
+			'/usr/bin/chromium',
+			'/usr/bin/chromium-browser',
+			'/snap/bin/chromium',
+			'/usr/bin/microsoft-edge',
+			'/usr/bin/brave-browser',
+		],
+		win32: [
+			'C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe',
+			'C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe',
+			'C:\\Program Files\\Chromium\\Application\\chrome.exe',
+			'C:\\Program Files (x86)\\Chromium\\Application\\chrome.exe',
+			'C:\\Program Files\\Microsoft\\Edge\\Application\\msedge.exe',
+			'C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe',
+		],
+	};
+
+	const candidates = [
+		getEnvValue( ENV_EXECUTABLE_KEYS ),
+		chromium.executablePath(),
+		...( systemCandidatesByPlatform[ os.platform() ] ?? [] ),
+	];
+
+	return [ ...new Set( candidates.filter( Boolean ) ) ].filter( ( candidate ): candidate is string =>
+		existsSync( candidate )
+	);
+}
+
+function getChannelCandidates(): Array< ( typeof SUPPORTED_CHANNELS )[ number ] > {
+	const configuredChannel = getEnvValue( ENV_CHANNEL_KEYS );
+	const channels = configuredChannel
+		? [ configuredChannel, ...SUPPORTED_CHANNELS ]
+		: [ ...SUPPORTED_CHANNELS ];
+
+	return [ ...new Set( channels ) ].filter(
+		( channel ): channel is ( typeof SUPPORTED_CHANNELS )[ number ] =>
+			SUPPORTED_CHANNELS.includes( channel as ( typeof SUPPORTED_CHANNELS )[ number ] )
+	);
+}
+
+export function getChromiumLaunchCandidates(
+	chromium: Pick< Chromium, 'executablePath' >
+): ChromiumLaunchOptions[] {
+	const executableCandidates = getCandidateExecutablePaths( chromium ).map( ( executablePath ) => ( {
+		args: DEFAULT_BROWSER_ARGS,
+		executablePath,
+	} ) );
+	const channelCandidates = getChannelCandidates().map( ( channel ) => ( {
+		args: DEFAULT_BROWSER_ARGS,
+		channel,
+	} ) );
+
+	return [
+		...executableCandidates,
+		...channelCandidates,
+		{
+			args: DEFAULT_BROWSER_ARGS,
+		},
+	];
+}
+
+export function getPreferredChromiumLaunchOptions(
+	chromium: Pick< Chromium, 'executablePath' >
+): ChromiumLaunchOptions {
+	return getChromiumLaunchCandidates( chromium )[ 0 ] ?? {
+		args: DEFAULT_BROWSER_ARGS,
+	};
+}
+
+function describeLaunchOptions( options: ChromiumLaunchOptions ): string {
+	if ( options?.executablePath ) {
+		return `executablePath=${ options.executablePath }`;
+	}
+	if ( options?.channel ) {
+		return `channel=${ options.channel }`;
+	}
+	return 'playwright-default';
+}
 
 /**
  * Returns (and lazily launches) a shared Chromium browser instance.
@@ -19,9 +142,32 @@ export async function getSharedBrowser(): Promise< Browser > {
 	if ( ! browserPromise ) {
 		browserPromise = ( async () => {
 			const { chromium } = await import( 'playwright' );
-			const browser = await chromium.launch( {
-				args: [ '--ignore-certificate-errors' ],
-			} );
+			const launchCandidates = getChromiumLaunchCandidates( chromium );
+			const launchErrors: string[] = [];
+			let browser: Browser | undefined;
+
+			for ( const options of launchCandidates ) {
+				try {
+					browser = await chromium.launch( options );
+					break;
+				} catch ( error ) {
+					launchErrors.push(
+						`${ describeLaunchOptions( options ) }: ${
+							error instanceof Error ? error.message : String( error )
+						}`
+					);
+				}
+			}
+
+			if ( ! browser ) {
+				throw new Error(
+					'Unable to launch a browser for Studio MCP screenshot/validation tools. ' +
+						`Tried ${ launchCandidates.map( describeLaunchOptions ).join( ', ' ) }. ` +
+						'Set STUDIO_MCP_BROWSER_EXECUTABLE_PATH to a local Chrome/Chromium-compatible browser, ' +
+						'or STUDIO_MCP_BROWSER_CHANNEL to a Playwright-supported channel like "chrome". ' +
+						`Launch errors: ${ launchErrors.join( ' | ' ) }`
+				);
+			}
 
 			const cleanup = () => {
 				browser.close().catch( () => {} );

--- a/apps/cli/ai/browser-utils.ts
+++ b/apps/cli/ai/browser-utils.ts
@@ -128,6 +128,7 @@ export async function getSharedBrowser(): Promise< Browser > {
 	}
 	return browserPromise;
 }
+
 /**
  * Close the shared browser instance (if any) so the Node.js event loop can
  * drain and the process can exit naturally without calling process.exit().

--- a/apps/cli/ai/browser-utils.ts
+++ b/apps/cli/ai/browser-utils.ts
@@ -9,6 +9,7 @@
 import { execFile } from 'child_process';
 import { existsSync } from 'fs';
 import os from 'os';
+import path from 'path';
 import { fileURLToPath } from 'url';
 import { promisify } from 'util';
 
@@ -93,6 +94,19 @@ function getBrowserOverrides(): BrowserOverrides {
 	};
 }
 
+function describeLaunchAttempt( attempt: ChromiumLaunchOptions | undefined ): string {
+	if ( ! attempt ) {
+		return 'undefined';
+	}
+	if ( attempt.executablePath ) {
+		return `executablePath=${ attempt.executablePath }`;
+	}
+	if ( attempt.channel ) {
+		return `channel=${ attempt.channel }`;
+	}
+	return 'playwright-default';
+}
+
 export function buildChromiumLaunchAttempts(
 	chromium: Pick< Chromium, 'executablePath' >,
 	overrides: BrowserOverrides = getBrowserOverrides()
@@ -137,7 +151,8 @@ export function buildChromiumLaunchAttempts(
 }
 
 async function installPlaywrightChromium(): Promise< void > {
-	const cliPath = fileURLToPath( import.meta.resolve( 'playwright/cli' ) );
+	const packageJsonPath = fileURLToPath( import.meta.resolve( 'playwright/package.json' ) );
+	const cliPath = path.join( path.dirname( packageJsonPath ), 'cli.js' );
 
 	await execFileAsync( process.execPath, [ cliPath, 'install', 'chromium' ], {
 		env: {
@@ -196,11 +211,7 @@ export async function getSharedBrowser(): Promise< Browser > {
 				if ( ! attempt ) {
 					continue;
 				}
-				const attemptedTarget = attempt.executablePath
-					? `executablePath=${ attempt.executablePath }`
-					: attempt.channel
-					? `channel=${ attempt.channel }`
-					: 'playwright-default';
+				const attemptedTarget = describeLaunchAttempt( attempt );
 
 				try {
 					browser = await chromium.launch( attempt );

--- a/apps/cli/ai/browser-utils.ts
+++ b/apps/cli/ai/browser-utils.ts
@@ -14,9 +14,15 @@ import { promisify } from 'util';
 
 type Browser = Awaited< ReturnType< ( typeof import('playwright') )[ 'chromium' ][ 'launch' ] > >;
 type Page = Awaited< ReturnType< Browser[ 'newPage' ] > >;
-type Chromium = Awaited< typeof import( 'playwright' ) >[ 'chromium' ];
+type Chromium = Awaited< typeof import('playwright') >[ 'chromium' ];
 type ChromiumLaunchOptions = Parameters< Chromium[ 'launch' ] >[ 0 ];
 type InstallBrowserFn = () => Promise< void >;
+type SupportedChannel = ( typeof SUPPORTED_CHANNELS )[ number ];
+type BrowserOverrides = {
+	executablePath?: string;
+	configuredChannel?: string;
+	channel?: SupportedChannel;
+};
 
 const DEFAULT_BROWSER_ARGS = [ '--ignore-certificate-errors' ];
 const SUPPORTED_CHANNELS = [
@@ -37,8 +43,35 @@ const ENV_CHANNEL_KEYS = [ 'STUDIO_MCP_BROWSER_CHANNEL', 'PLAYWRIGHT_CHROMIUM_CH
 let browserPromise: Promise< Browser > | null = null;
 const execFileAsync = promisify( execFile );
 const require = createRequire( import.meta.url );
+const SYSTEM_BROWSER_CANDIDATES_BY_PLATFORM: Record< string, string[] > = {
+	darwin: [
+		'/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+		'/Applications/Chromium.app/Contents/MacOS/Chromium',
+		'/Applications/Google Chrome Beta.app/Contents/MacOS/Google Chrome Beta',
+		'/Applications/Google Chrome Dev.app/Contents/MacOS/Google Chrome Dev',
+		'/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge',
+		'/Applications/Brave Browser.app/Contents/MacOS/Brave Browser',
+	],
+	linux: [
+		'/usr/bin/google-chrome',
+		'/usr/bin/google-chrome-stable',
+		'/usr/bin/chromium',
+		'/usr/bin/chromium-browser',
+		'/snap/bin/chromium',
+		'/usr/bin/microsoft-edge',
+		'/usr/bin/brave-browser',
+	],
+	win32: [
+		'C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe',
+		'C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe',
+		'C:\\Program Files\\Chromium\\Application\\chrome.exe',
+		'C:\\Program Files (x86)\\Chromium\\Application\\chrome.exe',
+		'C:\\Program Files\\Microsoft\\Edge\\Application\\msedge.exe',
+		'C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe',
+	],
+};
 
-function getEnvValue( keys: readonly string[] ): string | undefined {
+function getFirstEnvValue( keys: readonly string[] ): string | undefined {
 	for ( const key of keys ) {
 		const value = process.env[ key ]?.trim();
 		if ( value ) {
@@ -47,103 +80,61 @@ function getEnvValue( keys: readonly string[] ): string | undefined {
 	}
 }
 
-function getCandidateExecutablePaths(
-	chromium: Pick< Chromium, 'executablePath' >
-): string[] {
-	const systemCandidatesByPlatform: Record< string, string[] > = {
-		darwin: [
-			'/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
-			'/Applications/Chromium.app/Contents/MacOS/Chromium',
-			'/Applications/Google Chrome Beta.app/Contents/MacOS/Google Chrome Beta',
-			'/Applications/Google Chrome Dev.app/Contents/MacOS/Google Chrome Dev',
-			'/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge',
-			'/Applications/Brave Browser.app/Contents/MacOS/Brave Browser',
-		],
-		linux: [
-			'/usr/bin/google-chrome',
-			'/usr/bin/google-chrome-stable',
-			'/usr/bin/chromium',
-			'/usr/bin/chromium-browser',
-			'/snap/bin/chromium',
-			'/usr/bin/microsoft-edge',
-			'/usr/bin/brave-browser',
-		],
-		win32: [
-			'C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe',
-			'C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe',
-			'C:\\Program Files\\Chromium\\Application\\chrome.exe',
-			'C:\\Program Files (x86)\\Chromium\\Application\\chrome.exe',
-			'C:\\Program Files\\Microsoft\\Edge\\Application\\msedge.exe',
-			'C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe',
-		],
-	};
+function getBrowserOverrides(): BrowserOverrides {
+	const executablePath = getFirstEnvValue( ENV_EXECUTABLE_KEYS );
+	const configuredChannel = getFirstEnvValue( ENV_CHANNEL_KEYS );
+	const channel = SUPPORTED_CHANNELS.includes( configuredChannel as SupportedChannel )
+		? ( configuredChannel as SupportedChannel )
+		: undefined;
 
-	const candidates = [
-		getEnvValue( ENV_EXECUTABLE_KEYS ),
-		chromium.executablePath(),
-		...( systemCandidatesByPlatform[ os.platform() ] ?? [] ),
-	];
-
-	const definedCandidates = [ ...new Set( candidates ) ].filter(
-		( candidate ): candidate is string => Boolean( candidate )
-	);
-
-	return definedCandidates.filter( ( candidate ) => existsSync( candidate ) );
-}
-
-function hasExternalBrowserOverride(): boolean {
-	return Boolean( getEnvValue( ENV_EXECUTABLE_KEYS ) || getEnvValue( ENV_CHANNEL_KEYS ) );
-}
-
-function getChannelCandidates(): Array< ( typeof SUPPORTED_CHANNELS )[ number ] > {
-	const configuredChannel = getEnvValue( ENV_CHANNEL_KEYS );
-	const channels = configuredChannel
-		? [ configuredChannel, ...SUPPORTED_CHANNELS ]
-		: [ ...SUPPORTED_CHANNELS ];
-
-	return [ ...new Set( channels ) ].filter(
-		( channel ): channel is ( typeof SUPPORTED_CHANNELS )[ number ] =>
-			SUPPORTED_CHANNELS.includes( channel as ( typeof SUPPORTED_CHANNELS )[ number ] )
-	);
-}
-
-export function getChromiumLaunchCandidates(
-	chromium: Pick< Chromium, 'executablePath' >
-): ChromiumLaunchOptions[] {
-	const executableCandidates = getCandidateExecutablePaths( chromium ).map( ( executablePath ) => ( {
-		args: DEFAULT_BROWSER_ARGS,
+	return {
 		executablePath,
-	} ) );
-	const channelCandidates = getChannelCandidates().map( ( channel ) => ( {
-		args: DEFAULT_BROWSER_ARGS,
+		configuredChannel,
 		channel,
-	} ) );
-
-	return [
-		...executableCandidates,
-		...channelCandidates,
-		{
-			args: DEFAULT_BROWSER_ARGS,
-		},
-	];
-}
-
-export function getPreferredChromiumLaunchOptions(
-	chromium: Pick< Chromium, 'executablePath' >
-): ChromiumLaunchOptions {
-	return getChromiumLaunchCandidates( chromium )[ 0 ] ?? {
-		args: DEFAULT_BROWSER_ARGS,
 	};
 }
 
-function describeLaunchOptions( options: ChromiumLaunchOptions ): string {
-	if ( options?.executablePath ) {
-		return `executablePath=${ options.executablePath }`;
+export function buildChromiumLaunchAttempts(
+	chromium: Pick< Chromium, 'executablePath' >,
+	overrides: BrowserOverrides = getBrowserOverrides()
+): ChromiumLaunchOptions[] {
+	const attempts: ChromiumLaunchOptions[] = [];
+	const seen = new Set< string >();
+
+	const addExecutableAttempt = ( executablePath?: string ) => {
+		if ( ! executablePath || ! existsSync( executablePath ) || seen.has( executablePath ) ) {
+			return;
+		}
+		seen.add( executablePath );
+		attempts.push( {
+			args: DEFAULT_BROWSER_ARGS,
+			executablePath,
+		} );
+	};
+
+	addExecutableAttempt( overrides.executablePath );
+	addExecutableAttempt( chromium.executablePath() );
+
+	for ( const executablePath of SYSTEM_BROWSER_CANDIDATES_BY_PLATFORM[ os.platform() ] ?? [] ) {
+		addExecutableAttempt( executablePath );
 	}
-	if ( options?.channel ) {
-		return `channel=${ options.channel }`;
+
+	for ( const channel of [ overrides.channel, ...SUPPORTED_CHANNELS ] ) {
+		if ( ! channel || seen.has( channel ) ) {
+			continue;
+		}
+		seen.add( channel );
+		attempts.push( {
+			args: DEFAULT_BROWSER_ARGS,
+			channel,
+		} );
 	}
-	return 'playwright-default';
+
+	attempts.push( {
+		args: DEFAULT_BROWSER_ARGS,
+	} );
+
+	return attempts;
 }
 
 async function installPlaywrightChromium(): Promise< void > {
@@ -160,9 +151,10 @@ async function installPlaywrightChromium(): Promise< void > {
 
 export async function ensurePlaywrightChromiumInstalled(
 	chromium: Pick< Chromium, 'executablePath' >,
+	overrides: BrowserOverrides = getBrowserOverrides(),
 	installBrowser: InstallBrowserFn = installPlaywrightChromium
 ): Promise< string | null > {
-	if ( hasExternalBrowserOverride() ) {
+	if ( overrides.executablePath || overrides.configuredChannel ) {
 		return null;
 	}
 
@@ -195,20 +187,28 @@ export async function getSharedBrowser(): Promise< Browser > {
 	if ( ! browserPromise ) {
 		browserPromise = ( async () => {
 			const { chromium } = await import( 'playwright' );
-			const installError = await ensurePlaywrightChromiumInstalled( chromium );
-			const launchCandidates = getChromiumLaunchCandidates( chromium );
+			const overrides = getBrowserOverrides();
+			const installError = await ensurePlaywrightChromiumInstalled( chromium, overrides );
+			const launchCandidates = buildChromiumLaunchAttempts( chromium, overrides );
 			const launchErrors: string[] = [];
 			let browser: Browser | undefined;
 
-			for ( const options of launchCandidates ) {
+			for ( const attempt of launchCandidates ) {
+				if ( ! attempt ) {
+					continue;
+				}
+				const attemptedTarget = attempt.executablePath
+					? `executablePath=${ attempt.executablePath }`
+					: attempt.channel
+					? `channel=${ attempt.channel }`
+					: 'playwright-default';
+
 				try {
-					browser = await chromium.launch( options );
+					browser = await chromium.launch( attempt );
 					break;
 				} catch ( error ) {
 					launchErrors.push(
-						`${ describeLaunchOptions( options ) }: ${
-							error instanceof Error ? error.message : String( error )
-						}`
+						`${ attemptedTarget }: ${ error instanceof Error ? error.message : String( error ) }`
 					);
 				}
 			}
@@ -220,7 +220,9 @@ export async function getSharedBrowser(): Promise< Browser > {
 
 				throw new Error(
 					'Unable to launch a browser for Studio MCP screenshot/validation tools. ' +
-						`Tried ${ launchCandidates.map( describeLaunchOptions ).join( ', ' ) }. ` +
+						`Tried ${ launchErrors
+							.map( ( error ) => error.split( ': ', 1 )[ 0 ] )
+							.join( ', ' ) }. ` +
 						'Set STUDIO_MCP_BROWSER_EXECUTABLE_PATH to a local Chrome/Chromium-compatible browser, ' +
 						'or STUDIO_MCP_BROWSER_CHANNEL to a Playwright-supported channel like "chrome". ' +
 						`${ repairGuidance } ` +

--- a/apps/cli/ai/browser-utils.ts
+++ b/apps/cli/ai/browser-utils.ts
@@ -8,7 +8,6 @@
 
 import { execFile } from 'child_process';
 import { existsSync } from 'fs';
-import os from 'os';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { promisify } from 'util';
@@ -18,128 +17,22 @@ type Page = Awaited< ReturnType< Browser[ 'newPage' ] > >;
 type Chromium = Awaited< typeof import('playwright') >[ 'chromium' ];
 type ChromiumLaunchOptions = Parameters< Chromium[ 'launch' ] >[ 0 ];
 type InstallBrowserFn = () => Promise< void >;
-type SupportedChannel = ( typeof SUPPORTED_CHANNELS )[ number ];
-type BrowserOverrides = {
-	executablePath?: string;
-	configuredChannel?: string;
-	channel?: SupportedChannel;
-};
 
 const DEFAULT_BROWSER_ARGS = [ '--ignore-certificate-errors' ];
-const SUPPORTED_CHANNELS = [
-	'chrome',
-	'chrome-beta',
-	'chrome-dev',
-	'msedge',
-	'msedge-beta',
-	'msedge-dev',
-] as const;
-const ENV_EXECUTABLE_KEYS = [
-	'STUDIO_MCP_BROWSER_EXECUTABLE_PATH',
-	'PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH',
-	'CHROME_EXECUTABLE_PATH',
-] as const;
-const ENV_CHANNEL_KEYS = [ 'STUDIO_MCP_BROWSER_CHANNEL', 'PLAYWRIGHT_CHROMIUM_CHANNEL' ] as const;
 
 let browserPromise: Promise< Browser > | null = null;
 const execFileAsync = promisify( execFile );
-const SYSTEM_BROWSER_CANDIDATES_BY_PLATFORM: Record< string, string[] > = {
-	darwin: [
-		'/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
-		'/Applications/Chromium.app/Contents/MacOS/Chromium',
-		'/Applications/Google Chrome Beta.app/Contents/MacOS/Google Chrome Beta',
-		'/Applications/Google Chrome Dev.app/Contents/MacOS/Google Chrome Dev',
-		'/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge',
-		'/Applications/Brave Browser.app/Contents/MacOS/Brave Browser',
-	],
-	linux: [
-		'/usr/bin/google-chrome',
-		'/usr/bin/google-chrome-stable',
-		'/usr/bin/chromium',
-		'/usr/bin/chromium-browser',
-		'/snap/bin/chromium',
-		'/usr/bin/microsoft-edge',
-		'/usr/bin/brave-browser',
-	],
-	win32: [
-		'C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe',
-		'C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe',
-		'C:\\Program Files\\Chromium\\Application\\chrome.exe',
-		'C:\\Program Files (x86)\\Chromium\\Application\\chrome.exe',
-		'C:\\Program Files\\Microsoft\\Edge\\Application\\msedge.exe',
-		'C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe',
-	],
-};
-
-function getFirstEnvValue( keys: readonly string[] ): string | undefined {
-	for ( const key of keys ) {
-		const value = process.env[ key ]?.trim();
-		if ( value ) {
-			return value;
-		}
-	}
-}
-
-function getBrowserOverrides(): BrowserOverrides {
-	const executablePath = getFirstEnvValue( ENV_EXECUTABLE_KEYS );
-	const configuredChannel = getFirstEnvValue( ENV_CHANNEL_KEYS );
-	const channel = SUPPORTED_CHANNELS.includes( configuredChannel as SupportedChannel )
-		? ( configuredChannel as SupportedChannel )
-		: undefined;
-
-	return {
-		executablePath,
-		configuredChannel,
-		channel,
-	};
-}
-
-function describeLaunchAttempt( attempt: ChromiumLaunchOptions | undefined ): string {
-	if ( ! attempt ) {
-		return 'undefined';
-	}
-	if ( attempt.executablePath ) {
-		return `executablePath=${ attempt.executablePath }`;
-	}
-	if ( attempt.channel ) {
-		return `channel=${ attempt.channel }`;
-	}
-	return 'playwright-default';
-}
 
 export function buildChromiumLaunchAttempts(
-	chromium: Pick< Chromium, 'executablePath' >,
-	overrides: BrowserOverrides = getBrowserOverrides()
+	chromium: Pick< Chromium, 'executablePath' >
 ): ChromiumLaunchOptions[] {
 	const attempts: ChromiumLaunchOptions[] = [];
-	const seen = new Set< string >();
+	const executablePath = chromium.executablePath();
 
-	const addExecutableAttempt = ( executablePath?: string ) => {
-		if ( ! executablePath || ! existsSync( executablePath ) || seen.has( executablePath ) ) {
-			return;
-		}
-		seen.add( executablePath );
+	if ( executablePath && existsSync( executablePath ) ) {
 		attempts.push( {
 			args: DEFAULT_BROWSER_ARGS,
 			executablePath,
-		} );
-	};
-
-	addExecutableAttempt( overrides.executablePath );
-	addExecutableAttempt( chromium.executablePath() );
-
-	for ( const executablePath of SYSTEM_BROWSER_CANDIDATES_BY_PLATFORM[ os.platform() ] ?? [] ) {
-		addExecutableAttempt( executablePath );
-	}
-
-	for ( const channel of [ overrides.channel, ...SUPPORTED_CHANNELS ] ) {
-		if ( ! channel || seen.has( channel ) ) {
-			continue;
-		}
-		seen.add( channel );
-		attempts.push( {
-			args: DEFAULT_BROWSER_ARGS,
-			channel,
 		} );
 	}
 
@@ -165,13 +58,8 @@ async function installPlaywrightChromium(): Promise< void > {
 
 export async function ensurePlaywrightChromiumInstalled(
 	chromium: Pick< Chromium, 'executablePath' >,
-	overrides: BrowserOverrides = getBrowserOverrides(),
 	installBrowser: InstallBrowserFn = installPlaywrightChromium
 ): Promise< string | null > {
-	if ( overrides.executablePath || overrides.configuredChannel ) {
-		return null;
-	}
-
 	const executablePath = chromium.executablePath();
 	if ( existsSync( executablePath ) ) {
 		return null;
@@ -201,25 +89,14 @@ export async function getSharedBrowser(): Promise< Browser > {
 	if ( ! browserPromise ) {
 		browserPromise = ( async () => {
 			const { chromium } = await import( 'playwright' );
-			const overrides = getBrowserOverrides();
-			const installError = await ensurePlaywrightChromiumInstalled( chromium, overrides );
-			const launchCandidates = buildChromiumLaunchAttempts( chromium, overrides );
 			const launchErrors: string[] = [];
-			let browser: Browser | undefined;
+			let browser = await tryLaunchChromium( chromium, launchErrors );
+			let installError: string | null = null;
 
-			for ( const attempt of launchCandidates ) {
-				if ( ! attempt ) {
-					continue;
-				}
-				const attemptedTarget = describeLaunchAttempt( attempt );
-
-				try {
-					browser = await chromium.launch( attempt );
-					break;
-				} catch ( error ) {
-					launchErrors.push(
-						`${ attemptedTarget }: ${ error instanceof Error ? error.message : String( error ) }`
-					);
+			if ( ! browser ) {
+				installError = await ensurePlaywrightChromiumInstalled( chromium );
+				if ( ! installError ) {
+					browser = await tryLaunchChromium( chromium, launchErrors );
 				}
 			}
 
@@ -233,8 +110,6 @@ export async function getSharedBrowser(): Promise< Browser > {
 						`Tried ${ launchErrors
 							.map( ( error ) => error.split( ': ', 1 )[ 0 ] )
 							.join( ', ' ) }. ` +
-						'Set STUDIO_MCP_BROWSER_EXECUTABLE_PATH to a local Chrome/Chromium-compatible browser, ' +
-						'or STUDIO_MCP_BROWSER_CHANNEL to a Playwright-supported channel like "chrome". ' +
 						`${ repairGuidance } ` +
 						`Launch errors: ${ launchErrors.join( ' | ' ) }`
 				);
@@ -253,7 +128,6 @@ export async function getSharedBrowser(): Promise< Browser > {
 	}
 	return browserPromise;
 }
-
 /**
  * Close the shared browser instance (if any) so the Node.js event loop can
  * drain and the process can exit naturally without calling process.exit().
@@ -263,6 +137,28 @@ export async function closeSharedBrowser(): Promise< void > {
 		const browser = await browserPromise;
 		await browser.close().catch( () => {} );
 		browserPromise = null;
+	}
+}
+
+async function tryLaunchChromium(
+	chromium: Pick< Chromium, 'launch' | 'executablePath' >,
+	launchErrors: string[]
+): Promise< Browser | undefined > {
+	for ( const attempt of buildChromiumLaunchAttempts( chromium ) ) {
+		if ( ! attempt ) {
+			continue;
+		}
+		const attemptedTarget = attempt.executablePath
+			? `executablePath=${ attempt.executablePath }`
+			: 'playwright-default';
+
+		try {
+			return await chromium.launch( attempt );
+		} catch ( error ) {
+			launchErrors.push(
+				`${ attemptedTarget }: ${ error instanceof Error ? error.message : String( error ) }`
+			);
+		}
 	}
 }
 

--- a/apps/cli/ai/tests/browser-utils.test.ts
+++ b/apps/cli/ai/tests/browser-utils.test.ts
@@ -54,19 +54,6 @@ describe( 'browser-utils', () => {
 		} );
 	} );
 
-	it( 'includes configured channels as fallbacks for external environments', () => {
-		vi.stubEnv( 'STUDIO_MCP_BROWSER_CHANNEL', 'chrome' );
-
-		const options = buildChromiumLaunchAttempts( {
-			executablePath: () => '/missing/chromium',
-		} );
-
-		expect( options ).toContainEqual( {
-			args: [ '--ignore-certificate-errors' ],
-			channel: 'chrome',
-		} );
-	} );
-
 	it( 'tries to install Playwright Chromium when the managed browser is missing', async () => {
 		const installBrowser = vi.fn().mockResolvedValue( undefined );
 		let installed = false;
@@ -75,7 +62,6 @@ describe( 'browser-utils', () => {
 			{
 				executablePath: () => ( installed ? process.execPath : '/missing/chromium' ),
 			},
-			{},
 			async () => {
 				installed = true;
 				await installBrowser();
@@ -91,7 +77,6 @@ describe( 'browser-utils', () => {
 			{
 				executablePath: () => '/missing/chromium',
 			},
-			{},
 			async () => {
 				throw new Error( 'network unavailable' );
 			}
@@ -101,21 +86,22 @@ describe( 'browser-utils', () => {
 		expect( error ).toContain( 'network unavailable' );
 	} );
 
-	it( 'skips Playwright auto-install when an explicit browser override is configured', async () => {
-		vi.stubEnv( 'STUDIO_MCP_BROWSER_CHANNEL', 'chrome' );
+	it( 'still auto-installs Playwright Chromium when an override path is configured but unavailable', async () => {
+		vi.stubEnv( 'STUDIO_MCP_BROWSER_EXECUTABLE_PATH', '/missing/custom-chromium' );
 		const installBrowser = vi.fn().mockResolvedValue( undefined );
+		let installed = false;
 
 		const error = await ensurePlaywrightChromiumInstalled(
 			{
-				executablePath: () => '/missing/chromium',
+				executablePath: () => ( installed ? process.execPath : '/missing/chromium' ),
 			},
-			{
-				configuredChannel: 'chrome',
-			},
-			installBrowser
+			async () => {
+				installed = true;
+				await installBrowser();
+			}
 		);
 
 		expect( error ).toBeNull();
-		expect( installBrowser ).not.toHaveBeenCalled();
+		expect( installBrowser ).toHaveBeenCalledTimes( 1 );
 	} );
 } );

--- a/apps/cli/ai/tests/browser-utils.test.ts
+++ b/apps/cli/ai/tests/browser-utils.test.ts
@@ -1,9 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import {
-	ensurePlaywrightChromiumInstalled,
-	getChromiumLaunchCandidates,
-	getPreferredChromiumLaunchOptions,
-} from '../browser-utils';
+import { buildChromiumLaunchAttempts, ensurePlaywrightChromiumInstalled } from '../browser-utils';
 
 describe( 'browser-utils', () => {
 	beforeEach( () => {
@@ -17,9 +13,9 @@ describe( 'browser-utils', () => {
 	it( 'prefers the resolved Chromium executable when it exists', () => {
 		const executablePath = '/bin/sh';
 
-		const options = getPreferredChromiumLaunchOptions( {
+		const options = buildChromiumLaunchAttempts( {
 			executablePath: () => executablePath,
-		} );
+		} )[ 0 ];
 
 		expect( options ).toEqual( {
 			args: [ '--ignore-certificate-errors' ],
@@ -28,7 +24,7 @@ describe( 'browser-utils', () => {
 	} );
 
 	it( 'always includes a default Playwright launch fallback', () => {
-		const candidates = getChromiumLaunchCandidates( {
+		const candidates = buildChromiumLaunchAttempts( {
 			executablePath: () => '/missing/chromium',
 		} );
 
@@ -38,9 +34,9 @@ describe( 'browser-utils', () => {
 	} );
 
 	it( 'can resolve another local browser when Playwright executable is unavailable', () => {
-		const options = getPreferredChromiumLaunchOptions( {
+		const options = buildChromiumLaunchAttempts( {
 			executablePath: () => '/missing/chromium',
-		} );
+		} )[ 0 ];
 
 		expect( options?.args ).toEqual( [ '--ignore-certificate-errors' ] );
 	} );
@@ -48,9 +44,9 @@ describe( 'browser-utils', () => {
 	it( 'prefers an explicit MCP browser executable path override', () => {
 		vi.stubEnv( 'STUDIO_MCP_BROWSER_EXECUTABLE_PATH', '/bin/sh' );
 
-		const options = getPreferredChromiumLaunchOptions( {
+		const options = buildChromiumLaunchAttempts( {
 			executablePath: () => '/missing/chromium',
-		} );
+		} )[ 0 ];
 
 		expect( options ).toEqual( {
 			args: [ '--ignore-certificate-errors' ],
@@ -61,7 +57,7 @@ describe( 'browser-utils', () => {
 	it( 'includes configured channels as fallbacks for external environments', () => {
 		vi.stubEnv( 'STUDIO_MCP_BROWSER_CHANNEL', 'chrome' );
 
-		const options = getChromiumLaunchCandidates( {
+		const options = buildChromiumLaunchAttempts( {
 			executablePath: () => '/missing/chromium',
 		} );
 
@@ -79,6 +75,7 @@ describe( 'browser-utils', () => {
 			{
 				executablePath: () => ( installed ? '/bin/sh' : '/missing/chromium' ),
 			},
+			{},
 			async () => {
 				installed = true;
 				await installBrowser();
@@ -94,6 +91,7 @@ describe( 'browser-utils', () => {
 			{
 				executablePath: () => '/missing/chromium',
 			},
+			{},
 			async () => {
 				throw new Error( 'network unavailable' );
 			}
@@ -110,6 +108,9 @@ describe( 'browser-utils', () => {
 		const error = await ensurePlaywrightChromiumInstalled(
 			{
 				executablePath: () => '/missing/chromium',
+			},
+			{
+				configuredChannel: 'chrome',
 			},
 			installBrowser
 		);

--- a/apps/cli/ai/tests/browser-utils.test.ts
+++ b/apps/cli/ai/tests/browser-utils.test.ts
@@ -11,7 +11,7 @@ describe( 'browser-utils', () => {
 	} );
 
 	it( 'prefers the resolved Chromium executable when it exists', () => {
-		const executablePath = '/bin/sh';
+		const executablePath = process.execPath;
 
 		const options = buildChromiumLaunchAttempts( {
 			executablePath: () => executablePath,
@@ -42,7 +42,7 @@ describe( 'browser-utils', () => {
 	} );
 
 	it( 'prefers an explicit MCP browser executable path override', () => {
-		vi.stubEnv( 'STUDIO_MCP_BROWSER_EXECUTABLE_PATH', '/bin/sh' );
+		vi.stubEnv( 'STUDIO_MCP_BROWSER_EXECUTABLE_PATH', process.execPath );
 
 		const options = buildChromiumLaunchAttempts( {
 			executablePath: () => '/missing/chromium',
@@ -50,7 +50,7 @@ describe( 'browser-utils', () => {
 
 		expect( options ).toEqual( {
 			args: [ '--ignore-certificate-errors' ],
-			executablePath: '/bin/sh',
+			executablePath: process.execPath,
 		} );
 	} );
 
@@ -73,7 +73,7 @@ describe( 'browser-utils', () => {
 
 		const error = await ensurePlaywrightChromiumInstalled(
 			{
-				executablePath: () => ( installed ? '/bin/sh' : '/missing/chromium' ),
+				executablePath: () => ( installed ? process.execPath : '/missing/chromium' ),
 			},
 			{},
 			async () => {

--- a/apps/cli/ai/tests/browser-utils.test.ts
+++ b/apps/cli/ai/tests/browser-utils.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+	getChromiumLaunchCandidates,
+	getPreferredChromiumLaunchOptions,
+} from '../browser-utils';
+
+describe( 'browser-utils', () => {
+	beforeEach( () => {
+		vi.unstubAllEnvs();
+	} );
+
+	afterEach( () => {
+		vi.unstubAllEnvs();
+	} );
+
+	it( 'prefers the resolved Chromium executable when it exists', () => {
+		const executablePath = '/bin/sh';
+
+		const options = getPreferredChromiumLaunchOptions( {
+			executablePath: () => executablePath,
+		} );
+
+		expect( options ).toEqual( {
+			args: [ '--ignore-certificate-errors' ],
+			executablePath,
+		} );
+	} );
+
+	it( 'always includes a default Playwright launch fallback', () => {
+		const candidates = getChromiumLaunchCandidates( {
+			executablePath: () => '/missing/chromium',
+		} );
+
+		expect( candidates.at( -1 ) ).toEqual( {
+			args: [ '--ignore-certificate-errors' ],
+		} );
+	} );
+
+	it( 'can resolve another local browser when Playwright executable is unavailable', () => {
+		const options = getPreferredChromiumLaunchOptions( {
+			executablePath: () => '/missing/chromium',
+		} );
+
+		expect( options?.args ).toEqual( [ '--ignore-certificate-errors' ] );
+	} );
+
+	it( 'prefers an explicit MCP browser executable path override', () => {
+		vi.stubEnv( 'STUDIO_MCP_BROWSER_EXECUTABLE_PATH', '/bin/sh' );
+
+		const options = getPreferredChromiumLaunchOptions( {
+			executablePath: () => '/missing/chromium',
+		} );
+
+		expect( options ).toEqual( {
+			args: [ '--ignore-certificate-errors' ],
+			executablePath: '/bin/sh',
+		} );
+	} );
+
+	it( 'includes configured channels as fallbacks for external environments', () => {
+		vi.stubEnv( 'STUDIO_MCP_BROWSER_CHANNEL', 'chrome' );
+
+		const options = getChromiumLaunchCandidates( {
+			executablePath: () => '/missing/chromium',
+		} );
+
+		expect( options ).toContainEqual( {
+			args: [ '--ignore-certificate-errors' ],
+			channel: 'chrome',
+		} );
+	} );
+} );

--- a/apps/cli/ai/tests/browser-utils.test.ts
+++ b/apps/cli/ai/tests/browser-utils.test.ts
@@ -41,19 +41,6 @@ describe( 'browser-utils', () => {
 		expect( options?.args ).toEqual( [ '--ignore-certificate-errors' ] );
 	} );
 
-	it( 'prefers an explicit MCP browser executable path override', () => {
-		vi.stubEnv( 'STUDIO_MCP_BROWSER_EXECUTABLE_PATH', process.execPath );
-
-		const options = buildChromiumLaunchAttempts( {
-			executablePath: () => '/missing/chromium',
-		} )[ 0 ];
-
-		expect( options ).toEqual( {
-			args: [ '--ignore-certificate-errors' ],
-			executablePath: process.execPath,
-		} );
-	} );
-
 	it( 'tries to install Playwright Chromium when the managed browser is missing', async () => {
 		const installBrowser = vi.fn().mockResolvedValue( undefined );
 		let installed = false;
@@ -86,8 +73,7 @@ describe( 'browser-utils', () => {
 		expect( error ).toContain( 'network unavailable' );
 	} );
 
-	it( 'still auto-installs Playwright Chromium when an override path is configured but unavailable', async () => {
-		vi.stubEnv( 'STUDIO_MCP_BROWSER_EXECUTABLE_PATH', '/missing/custom-chromium' );
+	it( 'still auto-installs Playwright Chromium after a default launch fallback fails', async () => {
 		const installBrowser = vi.fn().mockResolvedValue( undefined );
 		let installed = false;
 

--- a/apps/cli/ai/tests/browser-utils.test.ts
+++ b/apps/cli/ai/tests/browser-utils.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+	ensurePlaywrightChromiumInstalled,
 	getChromiumLaunchCandidates,
 	getPreferredChromiumLaunchOptions,
 } from '../browser-utils';
@@ -68,5 +69,52 @@ describe( 'browser-utils', () => {
 			args: [ '--ignore-certificate-errors' ],
 			channel: 'chrome',
 		} );
+	} );
+
+	it( 'tries to install Playwright Chromium when the managed browser is missing', async () => {
+		const installBrowser = vi.fn().mockResolvedValue( undefined );
+		let installed = false;
+
+		const error = await ensurePlaywrightChromiumInstalled(
+			{
+				executablePath: () => ( installed ? '/bin/sh' : '/missing/chromium' ),
+			},
+			async () => {
+				installed = true;
+				await installBrowser();
+			}
+		);
+
+		expect( error ).toBeNull();
+		expect( installBrowser ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'returns a helpful error when auto-install fails', async () => {
+		const error = await ensurePlaywrightChromiumInstalled(
+			{
+				executablePath: () => '/missing/chromium',
+			},
+			async () => {
+				throw new Error( 'network unavailable' );
+			}
+		);
+
+		expect( error ).toContain( 'auto-install Playwright Chromium' );
+		expect( error ).toContain( 'network unavailable' );
+	} );
+
+	it( 'skips Playwright auto-install when an explicit browser override is configured', async () => {
+		vi.stubEnv( 'STUDIO_MCP_BROWSER_CHANNEL', 'chrome' );
+		const installBrowser = vi.fn().mockResolvedValue( undefined );
+
+		const error = await ensurePlaywrightChromiumInstalled(
+			{
+				executablePath: () => '/missing/chromium',
+			},
+			installBrowser
+		);
+
+		expect( error ).toBeNull();
+		expect( installBrowser ).not.toHaveBeenCalled();
 	} );
 } );


### PR DESCRIPTION
Fixes: https://linear.app/a8c/issue/STU-1531/make-playwright-browser-dependency-install-more-robust

## Summary

I struck a problem with an external MCP client (Codex) could not get the take_screenshot tool to work as it got stuck in a missing chromium loop - I found it very hard to reproduce though, but this PR makes changes to:

- verify Playwright Chromium is available before Studio MCP launches the shared browser
- auto-install Playwright Chromium when the managed browser is missing
- keep explicit executable and channel overrides for environments that need a custom browser path
- add focused tests for install and override behavior

## Problem
The `take_screenshot` and `validate_blocks` MCP tools run inside the Studio CLI MCP server and depend on the shared Playwright browser launcher.

When Studio MCP is available but Playwright's managed Chromium browser is missing, those tools can fail even though the site itself is healthy. This is especially relevant for MCP consumers because the screenshot and validation tools need a working browser runtime inside Studio, not just in the calling agent.

## What changed
This update adds a repair-first flow for Studio MCP browser startup:
- if the user has explicitly configured `STUDIO_MCP_BROWSER_EXECUTABLE_PATH` or `STUDIO_MCP_BROWSER_CHANNEL`, Studio respects that configuration
- otherwise, Studio checks whether Playwright's managed Chromium executable exists
- if it is missing, Studio runs `playwright install chromium` from the CLI runtime before launching the shared browser
- after the install attempt, Studio continues with the existing browser launch candidates and returns clearer guidance if launch still fails

This keeps the default MCP path aligned with a Studio-managed Playwright browser while preserving explicit overrides for locked-down or unusual environments.

## Why this approach
This makes the MCP screenshot and validation tools more reliable because it:
- addresses the missing-browser case directly
- keeps behavior more reproducible across machines
- preserves an explicit override path when users need to point Studio at a different browser
- gives clearer diagnostics when repair is not possible

## Test instructions
### Automated
- `npx vitest run apps/cli/ai/tests/browser-utils.test.ts --config apps/cli/vitest.config.ts`
- `npx tsc -p apps/cli/tsconfig.json --noEmit`

### Manual
1. Start from a Studio environment where the Playwright Chromium cache is missing.
2. Run the Studio MCP server and invoke `take_screenshot` or `validate_blocks` without any browser override env vars set.
3. Confirm Studio attempts to install Playwright Chromium and then proceeds with the MCP tool.
4. Repeat with `STUDIO_MCP_BROWSER_CHANNEL=chrome` or `STUDIO_MCP_BROWSER_EXECUTABLE_PATH=...` set and confirm Studio skips the auto-install path and uses the configured override.
5. Simulate a failed install or offline environment and confirm the MCP error explains that auto-install failed and points the user at the override options.

If you don't have an MCP client handy, you can still smoke test the install path from the repo root:

1. Run `npm run cli:build`.
2. Run `node --input-type=module`.
3. Paste the script below into the REPL.
4. Confirm the first check shows the Playwright-managed executable is missing, the install step downloads Chromium into `/tmp/studio-empty-playwright`, and the browser launches successfully from that managed path.

```js
import { execFileSync } from 'node:child_process';
import { existsSync, mkdirSync, rmSync } from 'node:fs';
import path from 'node:path';
import { fileURLToPath } from 'node:url';

const browserPath = '/tmp/studio-empty-playwright';

rmSync(browserPath, { recursive: true, force: true });
mkdirSync(browserPath, { recursive: true });
process.env.PLAYWRIGHT_BROWSERS_PATH = browserPath;

const { chromium } = await import('playwright');

const executablePathBefore = chromium.executablePath();
console.log('Before install:', {
  executablePath: executablePathBefore,
  exists: existsSync(executablePathBefore),
});

if (!existsSync(executablePathBefore)) {
  const packageJsonPath = fileURLToPath(import.meta.resolve('playwright/package.json'));
  const cliPath = path.join(path.dirname(packageJsonPath), 'cli.js');

  execFileSync(process.execPath, [cliPath, 'install', 'chromium'], {
    stdio: 'inherit',
    env: {
      ...process.env,
      CI: process.env.CI ?? '1',
    },
  });
}

const executablePathAfter = chromium.executablePath();
console.log('After install:', {
  executablePath: executablePathAfter,
  exists: existsSync(executablePathAfter),
});

const browser = await chromium.launch({
  executablePath: executablePathAfter,
  args: ['--ignore-certificate-errors'],
});

console.log('Launched browser version:', browser.version());
await browser.close();
```