### PR TITLE
Clearing expired preview site shows unnecessary error

### DIFF
--- a/apps/cli/commands/preview/delete.ts
+++ b/apps/cli/commands/preview/delete.ts
@@ -55,7 +55,6 @@ export async function runCommand( mode: Mode, host: string | undefined ): Promis
 			logger.reportSuccess( __( 'Validation successful' ), true );
 
 			logger.reportStart( LoggerAction.DELETE, __( 'Deleting…' ) );
-			console.error( ' WHAT IS GOING ON HERE?', isSnapshotExpired( snapshotToDelete ) );
 			if ( ! isSnapshotExpired( snapshotToDelete ) ) {
 				await deleteSnapshot( snapshotToDelete.atomicSiteId, token.accessToken );
 			}

--- a/apps/cli/commands/preview/delete.ts
+++ b/apps/cli/commands/preview/delete.ts
@@ -5,7 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { deleteAllSnapshots, deleteSnapshot } from 'cli/lib/api';
 import { deleteAllSnapshotsForUserFromConfig } from 'cli/lib/cli-config/snapshots';
 import { emitCliEvent } from 'cli/lib/daemon-client';
-import { deleteSnapshotFromConfig, getSnapshotsFromConfig } from 'cli/lib/snapshots';
+import { deleteSnapshotFromConfig, getSnapshotsFromConfig, isSnapshotExpired } from 'cli/lib/snapshots';
 import { normalizeHostname } from 'cli/lib/utils';
 import { Logger, LoggerError } from 'cli/logger';
 import { StudioArgv } from 'cli/types';
@@ -51,7 +51,9 @@ export async function runCommand( mode: Mode, host: string | undefined ): Promis
 			logger.reportSuccess( __( 'Validation successful' ), true );
 
 			logger.reportStart( LoggerAction.DELETE, __( 'Deleting…' ) );
-			await deleteSnapshot( snapshotToDelete.atomicSiteId, token.accessToken );
+			if ( ! isSnapshotExpired( snapshotToDelete ) ) {
+				await deleteSnapshot( snapshotToDelete.atomicSiteId, token.accessToken );
+			}
 			await deleteSnapshotFromConfig( snapshotToDelete.url );
 			await emitCliEvent( {
 				event: SNAPSHOT_EVENTS.DELETED,

--- a/apps/cli/commands/preview/delete.ts
+++ b/apps/cli/commands/preview/delete.ts
@@ -5,7 +5,11 @@ import { __ } from '@wordpress/i18n';
 import { deleteAllSnapshots, deleteSnapshot } from 'cli/lib/api';
 import { deleteAllSnapshotsForUserFromConfig } from 'cli/lib/cli-config/snapshots';
 import { emitCliEvent } from 'cli/lib/daemon-client';
-import { deleteSnapshotFromConfig, getSnapshotsFromConfig, isSnapshotExpired } from 'cli/lib/snapshots';
+import {
+	deleteSnapshotFromConfig,
+	getSnapshotsFromConfig,
+	isSnapshotExpired,
+} from 'cli/lib/snapshots';
 import { normalizeHostname } from 'cli/lib/utils';
 import { Logger, LoggerError } from 'cli/logger';
 import { StudioArgv } from 'cli/types';
@@ -51,6 +55,7 @@ export async function runCommand( mode: Mode, host: string | undefined ): Promis
 			logger.reportSuccess( __( 'Validation successful' ), true );
 
 			logger.reportStart( LoggerAction.DELETE, __( 'Deleting…' ) );
+			console.error( ' WHAT IS GOING ON HERE?', isSnapshotExpired( snapshotToDelete ) );
 			if ( ! isSnapshotExpired( snapshotToDelete ) ) {
 				await deleteSnapshot( snapshotToDelete.atomicSiteId, token.accessToken );
 			}

--- a/apps/cli/commands/preview/tests/delete.test.ts
+++ b/apps/cli/commands/preview/tests/delete.test.ts
@@ -4,7 +4,7 @@ import { vi } from 'vitest';
 import { deleteAllSnapshots, deleteSnapshot } from 'cli/lib/api';
 import { deleteAllSnapshotsForUserFromConfig } from 'cli/lib/cli-config/snapshots';
 import { emitCliEvent } from 'cli/lib/daemon-client';
-import { getSnapshotsFromConfig, deleteSnapshotFromConfig } from 'cli/lib/snapshots';
+import { getSnapshotsFromConfig, deleteSnapshotFromConfig, isSnapshotExpired } from 'cli/lib/snapshots';
 import { LoggerError } from 'cli/logger';
 import {
 	mockReportStart,
@@ -68,6 +68,7 @@ describe( 'Preview Delete Command', () => {
 		vi.mocked( deleteAllSnapshotsForUserFromConfig ).mockResolvedValue( undefined );
 		vi.mocked( deleteSnapshotFromConfig ).mockResolvedValue( undefined );
 		vi.mocked( emitCliEvent ).mockResolvedValue( undefined );
+		vi.mocked( isSnapshotExpired ).mockReturnValue( false );
 	} );
 
 	afterEach( () => {
@@ -110,6 +111,20 @@ describe( 'Preview Delete Command', () => {
 		expect( mockReportError ).toHaveBeenCalled();
 		expect( mockReportError ).toHaveBeenCalledWith( expect.any( LoggerError ) );
 		expect( deleteSnapshot ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should skip the API call and succeed when the snapshot is expired', async () => {
+		vi.mocked( isSnapshotExpired ).mockReturnValue( true );
+
+		await runCommand( Mode.DELETE_SINGLE_SNAPSHOT, mockSiteUrl );
+
+		expect( deleteSnapshot ).not.toHaveBeenCalled();
+		expect( deleteSnapshotFromConfig ).toHaveBeenCalledWith( mockSiteUrl );
+		expect( emitCliEvent ).toHaveBeenCalledWith( {
+			event: SNAPSHOT_EVENTS.DELETED,
+			data: { snapshotUrl: mockSiteUrl },
+		} );
+		expect( mockReportSuccess.mock.calls[ 1 ] ).toEqual( [ 'Deletion successful' ] );
 	} );
 
 	it( 'should handle delete preview site errors', async () => {

--- a/apps/cli/commands/preview/tests/delete.test.ts
+++ b/apps/cli/commands/preview/tests/delete.test.ts
@@ -4,7 +4,11 @@ import { vi } from 'vitest';
 import { deleteAllSnapshots, deleteSnapshot } from 'cli/lib/api';
 import { deleteAllSnapshotsForUserFromConfig } from 'cli/lib/cli-config/snapshots';
 import { emitCliEvent } from 'cli/lib/daemon-client';
-import { getSnapshotsFromConfig, deleteSnapshotFromConfig, isSnapshotExpired } from 'cli/lib/snapshots';
+import {
+	getSnapshotsFromConfig,
+	deleteSnapshotFromConfig,
+	isSnapshotExpired,
+} from 'cli/lib/snapshots';
 import { LoggerError } from 'cli/logger';
 import {
 	mockReportStart,


### PR DESCRIPTION
## Related issues

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Fixes STU-1471

## How AI was used in this PR

<!--
Help reviewers understand what to look for and verify that you've reviewed the code yourself.
-->

I debated two different solutions with AI before picking an option. 

## Proposed Changes

This PR ensures that when an expired preview site is to be `Clear`, we are not making the API request. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

I was not able to reproduce the exact error shown in the issue but I think this approach should handle the issue:
* First create a preview site
* Next, navigate to https://developer.wordpress.com/docs/api/console/
* Run `wpcom/v2`, `POST`, `/jurassic-ninja`, `delete` 
* Fill in the site id for the preview site (you can find the site `id` in https://mc.a8c.com/tools/jn-report-card/ )
* Delete the preview site
* Navigate to the preview site in Studio
* Observe that it is now marked as expired
* Open the `Network` tab in the console
* Click on `Clear`
* Confirm that there are no errors and that the site clears
* Confirm that there is no network request 
* Confirm that the expires site is removed from `CLI config`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
