### PR TITLE
Output `.mjs` files when building CLI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ WordPress Studio - Electron desktop app for managing local WordPress sites. Buil
 
 ## Essential Commands
 
-**Dev/Build**: `npm start` | `npm run cli:build` | `node apps/cli/dist/cli/main.js`
+**Dev/Build**: `npm start` | `npm run cli:build` | `node apps/cli/dist/cli/main.mjs`
 **Test**: `npm test [-- path/to/test.test.ts]` | `npm run e2e`
 **Quality**: `npx eslint --fix <files>` (lint and format ONLY modified files)
 **IMPORTANT - Post-Change Verification**: After applying code changes, always run the linter and format modified files (`npx eslint --fix <files>`), the type checker (`npm run typecheck`) and run relevant tests (`npm test [-- path/to/test]`) before considering the work complete.
@@ -14,7 +14,7 @@ WordPress Studio - Electron desktop app for managing local WordPress sites. Buil
 
 ## CLI Commands
 
-**MUST** build CLI before testing: `npm run cli:build && node apps/cli/dist/cli/main.js <command>`
+**MUST** build CLI before testing: `npm run cli:build && node apps/cli/dist/cli/main.mjs <command>`
 - **Auth**: `auth login|logout|status` - WordPress.com OAuth (tokens valid 2 weeks)
 - **Preview Sites**: See `apps/cli/commands/preview/`
 - **Local Sites**: See `apps/cli/commands/site/`

--- a/apps/cli/lib/daemon-client.ts
+++ b/apps/cli/lib/daemon-client.ts
@@ -152,7 +152,7 @@ async function waitForDaemonReady() {
 }
 
 function spawnDaemonProcess() {
-	const daemonScriptPath = path.resolve( import.meta.dirname, 'process-manager-daemon.js' );
+	const daemonScriptPath = path.resolve( import.meta.dirname, 'process-manager-daemon.mjs' );
 	const daemonProcess = spawn( process.execPath, [ daemonScriptPath ], {
 		detached: true,
 		stdio: 'ignore',
@@ -272,7 +272,7 @@ export async function sendMessageToProcess(
 }
 
 export async function startProxyProcess(): Promise< ProcessDescription > {
-	const proxyDaemonPath = path.resolve( import.meta.dirname, 'proxy-daemon.js' );
+	const proxyDaemonPath = path.resolve( import.meta.dirname, 'proxy-daemon.mjs' );
 
 	return startProcess( PROXY_PROCESS_NAME, proxyDaemonPath );
 }

--- a/apps/cli/lib/tests/wordpress-server-manager.test.ts
+++ b/apps/cli/lib/tests/wordpress-server-manager.test.ts
@@ -115,7 +115,7 @@ describe( 'WordPress Server Manager', () => {
 
 			expect( vi.mocked( daemonClient.startProcess ) ).toHaveBeenCalledWith(
 				'studio-site-test-site-id',
-				expect.stringContaining( 'wordpress-server-child.js' )
+				expect.stringContaining( 'wordpress-server-child.mjs' )
 			);
 
 			expect( result ).toEqual( mockProcessDescription );

--- a/apps/cli/lib/wordpress-server-manager.ts
+++ b/apps/cli/lib/wordpress-server-manager.ts
@@ -60,7 +60,10 @@ export async function startWordPressServer(
 	logger: Logger< string >,
 	options?: StartServerOptions
 ): Promise< ProcessDescription > {
-	const wordPressServerChildPath = path.resolve( import.meta.dirname, 'wordpress-server-child.js' );
+	const wordPressServerChildPath = path.resolve(
+		import.meta.dirname,
+		'wordpress-server-child.mjs'
+	);
 	const processName = getProcessName( site.id );
 
 	const serverConfig: ServerConfig = {
@@ -338,7 +341,10 @@ export async function runBlueprint(
 	logger: Logger< string >,
 	options: RunBlueprintOptions
 ): Promise< void > {
-	const wordPressServerChildPath = path.resolve( import.meta.dirname, 'wordpress-server-child.js' );
+	const wordPressServerChildPath = path.resolve(
+		import.meta.dirname,
+		'wordpress-server-child.mjs'
+	);
 	const processName = getProcessName( site.id );
 
 	const serverConfig: ServerConfig = {

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -7,11 +7,10 @@
 	"license": "GPL-2.0-or-later",
 	"type": "module",
 	"bin": {
-		"studio": "dist/cli/main.js"
+		"studio": "dist/cli/main.mjs"
 	},
 	"files": [
-		"dist/cli/*.js",
-		"dist/cli/wp-files/",
+		"dist/cli/",
 		"patches/",
 		"scripts/"
 	],
@@ -25,6 +24,7 @@
 	},
 	"dependencies": {
 		"@anthropic-ai/claude-agent-sdk": "^0.2.45",
+		"@inquirer/prompts": "^8.3.2",
 		"@mariozechner/pi-tui": "^0.54.0",
 		"@modelcontextprotocol/sdk": "^1.27.1",
 		"@php-wasm/node": "3.1.13",

--- a/apps/cli/vite.config.base.ts
+++ b/apps/cli/vite.config.base.ts
@@ -40,7 +40,8 @@ export const baseConfig = defineConfig( {
 		rollupOptions: {
 			output: {
 				format: 'es',
-				entryFileNames: '[name].js',
+				entryFileNames: '[name].mjs',
+				chunkFileNames: '[name]-[hash].mjs',
 			},
 			external: ( id ) => {
 				// Bundle the `@wp-playground/blueprints/blueprint-schema-validator` module since we've defined

--- a/apps/cli/vite.config.npm.ts
+++ b/apps/cli/vite.config.npm.ts
@@ -8,8 +8,8 @@ export default mergeConfig(
 			sourcemap: false,
 			rollupOptions: {
 				output: {
-					// Add shebang to main.js so it can be executed directly as a CLI.
-					banner: ( chunk ) => ( chunk.fileName === 'main.js' ? '#!/usr/bin/env node' : '' ),
+					// Add shebang to main.mjs so it can be executed directly as a CLI.
+					banner: ( chunk ) => ( chunk.fileName === 'main.mjs' ? '#!/usr/bin/env node' : '' ),
 				},
 			},
 		},

--- a/apps/studio/bin/studio-cli-launcher.js
+++ b/apps/studio/bin/studio-cli-launcher.js
@@ -19,9 +19,9 @@ const exeDir = path.dirname( process.execPath );
 // Paths relative to bin directory (mirrors studio-cli.bat layout):
 // resources/bin/studio-cli.exe  <- this file
 // resources/bin/node.exe        <- bundled Node
-// resources/cli/main.js         <- CLI entry point
+// resources/cli/main.mjs        <- CLI entry point
 const nodeExe = path.join( exeDir, 'node.exe' );
-const cliScript = path.join( exeDir, '..', 'cli', 'main.js' );
+const cliScript = path.join( exeDir, '..', 'cli', 'main.mjs' );
 
 if ( ! fs.existsSync( nodeExe ) ) {
 	process.stderr.write( 'Error: Node.js runtime not found at: ' + nodeExe + '\n' );

--- a/apps/studio/bin/studio-cli.bat
+++ b/apps/studio/bin/studio-cli.bat
@@ -9,7 +9,7 @@ rem Set code page to UTF-8
 chcp 65001 >nul
 
 set BUNDLED_NODE_EXECUTABLE=%~dp0node.exe
-set "CLI_SCRIPT=%~dp0..\cli\main.js"
+set "CLI_SCRIPT=%~dp0..\cli\main.mjs"
 
 rem Prevent node from printing warnings about NODE_OPTIONS being ignored
 set NODE_OPTIONS=
@@ -18,7 +18,7 @@ if exist "%BUNDLED_NODE_EXECUTABLE%" (
 	"!BUNDLED_NODE_EXECUTABLE!" --experimental-wasm-jspi "!CLI_SCRIPT!" %*
 ) else (
 	if not exist "!CLI_SCRIPT!" (
-		set "CLI_SCRIPT=%~dp0..\dist\cli\main.js"
+		set "CLI_SCRIPT=%~dp0..\dist\cli\main.mjs"
 	)
 	node --experimental-wasm-jspi "!CLI_SCRIPT!" %*
 )

--- a/apps/studio/bin/studio-cli.sh
+++ b/apps/studio/bin/studio-cli.sh
@@ -4,7 +4,7 @@
 BIN_DIR=$(dirname "$(realpath "$0")")
 BUNDLED_NODE_EXECUTABLE="$BIN_DIR/node"
 CONTENTS_DIR=$(dirname "$(dirname "$BIN_DIR")")
-CLI_SCRIPT="$CONTENTS_DIR/Resources/cli/main.js"
+CLI_SCRIPT="$CONTENTS_DIR/Resources/cli/main.mjs"
 
 if [ -x "$BUNDLED_NODE_EXECUTABLE" ]; then
 	# Prevent node from printing warnings about NODE_OPTIONS being ignored
@@ -15,7 +15,7 @@ else
 	# and look for the CLI JS bundle in the `./dist` directory
 	if ! [ -f "$CLI_SCRIPT" ]; then
 		STUDIO_DIR=$(dirname "$(dirname "$(realpath "$0")")")
-		CLI_SCRIPT="$(dirname "$STUDIO_DIR")/cli/dist/cli/main.js"
+		CLI_SCRIPT="$(dirname "$STUDIO_DIR")/cli/dist/cli/main.mjs"
 	fi
 
 	# Prevent node from printing warnings about NODE_OPTIONS being ignored

--- a/apps/studio/src/renderer.ts
+++ b/apps/studio/src/renderer.ts
@@ -11,7 +11,7 @@
  *
  * https://electronjs.org/docs/tutorial/security
  *
- * To enable Node.js integration in this file, open up `main.js` and enable the `nodeIntegration`
+ * To enable Node.js integration in this file, open up `main.mjs` and enable the `nodeIntegration`
  * flag:
  *
  * ```

--- a/apps/studio/src/storage/paths.ts
+++ b/apps/studio/src/storage/paths.ts
@@ -61,8 +61,8 @@ export function getResourcesPath(): string {
 
 export function getCliPath(): string {
 	return process.env.NODE_ENV === 'development'
-		? path.join( getResourcesPath(), '..', 'cli', 'dist', 'cli', 'main.js' )
-		: path.join( getResourcesPath(), 'cli', 'main.js' );
+		? path.join( getResourcesPath(), '..', 'cli', 'dist', 'cli', 'main.mjs' )
+		: path.join( getResourcesPath(), 'cli', 'main.mjs' );
 }
 
 export function getBundledNodeBinaryPath(): string {

--- a/docs/code-contributions.md
+++ b/docs/code-contributions.md
@@ -70,10 +70,10 @@ The CLI is built separately from the Electron app. There are two commands to be 
 - `npm run cli:build` runs a one-time build.
 - `npm run cli:watch` watches the source files and rebuilds automatically.
 
-Both commands output a `apps/cli/dist/cli/main.js` file. To test the newly built CLI code, run the following command:
+Both commands output a `apps/cli/dist/cli/main.mjs` file. To test the newly built CLI code, run the following command:
 
 ```
-node apps/cli/dist/cli/main.js
+node apps/cli/dist/cli/main.mjs
 ```
 
 ### Project Structure

--- a/docs/testing-with-local-playground.md
+++ b/docs/testing-with-local-playground.md
@@ -82,7 +82,7 @@ npm install
 
 ```bash
 npm run cli:build
-node apps/cli/dist/cli/main.js site create --name test-site
+node apps/cli/dist/cli/main.mjs site create --name test-site
 ```
 
 ### 6. Start Studio (optional)

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@anthropic-ai/claude-agent-sdk": "^0.2.45",
+				"@inquirer/prompts": "^8.3.2",
 				"@mariozechner/pi-tui": "^0.54.0",
 				"@modelcontextprotocol/sdk": "^1.27.1",
 				"@php-wasm/node": "3.1.13",
@@ -78,7 +79,7 @@
 				"zod": "^4.3.6"
 			},
 			"bin": {
-				"studio": "dist/cli/main.js"
+				"studio": "dist/cli/main.mjs"
 			},
 			"devDependencies": {
 				"@studio/common": "file:../../tools/common",
@@ -91,6 +92,386 @@
 			},
 			"engines": {
 				"node": ">=22.0.0"
+			}
+		},
+		"apps/cli/node_modules/@inquirer/ansi": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.4.tgz",
+			"integrity": "sha512-DpcZrQObd7S0R/U3bFdkcT5ebRwbTTC4D3tCc1vsJizmgPLxNJBo+AAFmrZwe8zk30P2QzgzGWZ3Q9uJwWuhIg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+			}
+		},
+		"apps/cli/node_modules/@inquirer/checkbox": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.1.2.tgz",
+			"integrity": "sha512-PubpMPO2nJgMufkoB3P2wwxNXEMUXnBIKi/ACzDUYfaoPuM7gSTmuxJeMscoLVEsR4qqrCMf5p0SiYGWnVJ8kw==",
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/ansi": "^2.0.4",
+				"@inquirer/core": "^11.1.7",
+				"@inquirer/figures": "^2.0.4",
+				"@inquirer/type": "^4.0.4"
+			},
+			"engines": {
+				"node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"apps/cli/node_modules/@inquirer/confirm": {
+			"version": "6.0.10",
+			"resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.0.10.tgz",
+			"integrity": "sha512-tiNyA73pgpQ0FQ7axqtoLUe4GDYjNCDcVsbgcA5anvwg2z6i+suEngLKKJrWKJolT//GFPZHwN30binDIHgSgQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/core": "^11.1.7",
+				"@inquirer/type": "^4.0.4"
+			},
+			"engines": {
+				"node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"apps/cli/node_modules/@inquirer/core": {
+			"version": "11.1.7",
+			"resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.1.7.tgz",
+			"integrity": "sha512-1BiBNDk9btIwYIzNZpkikIHXWeNzNncJePPqwDyVMhXhD1ebqbpn1mKGctpoqAbzywZfdG0O4tvmsGIcOevAPQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/ansi": "^2.0.4",
+				"@inquirer/figures": "^2.0.4",
+				"@inquirer/type": "^4.0.4",
+				"cli-width": "^4.1.0",
+				"fast-wrap-ansi": "^0.2.0",
+				"mute-stream": "^3.0.0",
+				"signal-exit": "^4.1.0"
+			},
+			"engines": {
+				"node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"apps/cli/node_modules/@inquirer/editor": {
+			"version": "5.0.10",
+			"resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.0.10.tgz",
+			"integrity": "sha512-VJx4XyaKea7t8hEApTw5dxeIyMtWXre2OiyJcICCRZI4hkoHsMoCnl/KbUnJJExLbH9csLLHMVR144ZhFE1CwA==",
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/core": "^11.1.7",
+				"@inquirer/external-editor": "^2.0.4",
+				"@inquirer/type": "^4.0.4"
+			},
+			"engines": {
+				"node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"apps/cli/node_modules/@inquirer/expand": {
+			"version": "5.0.10",
+			"resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.0.10.tgz",
+			"integrity": "sha512-fC0UHJPXsTRvY2fObiwuQYaAnHrp3aDqfwKUJSdfpgv18QUG054ezGbaRNStk/BKD5IPijeMKWej8VV8O5Q/eQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/core": "^11.1.7",
+				"@inquirer/type": "^4.0.4"
+			},
+			"engines": {
+				"node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"apps/cli/node_modules/@inquirer/external-editor": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-2.0.4.tgz",
+			"integrity": "sha512-Prenuv9C1PHj2Itx0BcAOVBTonz02Hc2Nd2DbU67PdGUaqn0nPCnV34oDyyoaZHnmfRxkpuhh/u51ThkrO+RdA==",
+			"license": "MIT",
+			"dependencies": {
+				"chardet": "^2.1.1",
+				"iconv-lite": "^0.7.2"
+			},
+			"engines": {
+				"node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"apps/cli/node_modules/@inquirer/figures": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.4.tgz",
+			"integrity": "sha512-eLBsjlS7rPS3WEhmOmh1znQ5IsQrxWzxWDxO51e4urv+iVrSnIHbq4zqJIOiyNdYLa+BVjwOtdetcQx1lWPpiQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+			}
+		},
+		"apps/cli/node_modules/@inquirer/input": {
+			"version": "5.0.10",
+			"resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.0.10.tgz",
+			"integrity": "sha512-nvZ6qEVeX/zVtZ1dY2hTGDQpVGD3R7MYPLODPgKO8Y+RAqxkrP3i/3NwF3fZpLdaMiNuK0z2NaYIx9tPwiSegQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/core": "^11.1.7",
+				"@inquirer/type": "^4.0.4"
+			},
+			"engines": {
+				"node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"apps/cli/node_modules/@inquirer/number": {
+			"version": "4.0.10",
+			"resolved": "https://registry.npmjs.org/@inquirer/number/-/number-4.0.10.tgz",
+			"integrity": "sha512-Ht8OQstxiS3APMGjHV0aYAjRAysidWdwurWEo2i8yI5xbhOBWqizT0+MU1S2GCcuhIBg+3SgWVjEoXgfhY+XaA==",
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/core": "^11.1.7",
+				"@inquirer/type": "^4.0.4"
+			},
+			"engines": {
+				"node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"apps/cli/node_modules/@inquirer/password": {
+			"version": "5.0.10",
+			"resolved": "https://registry.npmjs.org/@inquirer/password/-/password-5.0.10.tgz",
+			"integrity": "sha512-QbNyvIE8q2GTqKLYSsA8ATG+eETo+m31DSR0+AU7x3d2FhaTWzqQek80dj3JGTo743kQc6mhBR0erMjYw5jQ0A==",
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/ansi": "^2.0.4",
+				"@inquirer/core": "^11.1.7",
+				"@inquirer/type": "^4.0.4"
+			},
+			"engines": {
+				"node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"apps/cli/node_modules/@inquirer/prompts": {
+			"version": "8.3.2",
+			"resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.3.2.tgz",
+			"integrity": "sha512-yFroiSj2iiBFlm59amdTvAcQFvWS6ph5oKESls/uqPBect7rTU2GbjyZO2DqxMGuIwVA8z0P4K6ViPcd/cp+0w==",
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/checkbox": "^5.1.2",
+				"@inquirer/confirm": "^6.0.10",
+				"@inquirer/editor": "^5.0.10",
+				"@inquirer/expand": "^5.0.10",
+				"@inquirer/input": "^5.0.10",
+				"@inquirer/number": "^4.0.10",
+				"@inquirer/password": "^5.0.10",
+				"@inquirer/rawlist": "^5.2.6",
+				"@inquirer/search": "^4.1.6",
+				"@inquirer/select": "^5.1.2"
+			},
+			"engines": {
+				"node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"apps/cli/node_modules/@inquirer/rawlist": {
+			"version": "5.2.6",
+			"resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.2.6.tgz",
+			"integrity": "sha512-jfw0MLJ5TilNsa9zlJ6nmRM0ZFVZhhTICt4/6CU2Dv1ndY7l3sqqo1gIYZyMMDw0LvE1u1nzJNisfHEhJIxq5w==",
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/core": "^11.1.7",
+				"@inquirer/type": "^4.0.4"
+			},
+			"engines": {
+				"node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"apps/cli/node_modules/@inquirer/search": {
+			"version": "4.1.6",
+			"resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.1.6.tgz",
+			"integrity": "sha512-3/6kTRae98hhDevENScy7cdFEuURnSpM3JbBNg8yfXLw88HgTOl+neUuy/l9W0No5NzGsLVydhBzTIxZP7yChQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/core": "^11.1.7",
+				"@inquirer/figures": "^2.0.4",
+				"@inquirer/type": "^4.0.4"
+			},
+			"engines": {
+				"node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"apps/cli/node_modules/@inquirer/select": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.1.2.tgz",
+			"integrity": "sha512-kTK8YIkHV+f02y7bWCh7E0u2/11lul5WepVTclr3UMBtBr05PgcZNWfMa7FY57ihpQFQH/spLMHTcr0rXy50tA==",
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/ansi": "^2.0.4",
+				"@inquirer/core": "^11.1.7",
+				"@inquirer/figures": "^2.0.4",
+				"@inquirer/type": "^4.0.4"
+			},
+			"engines": {
+				"node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"apps/cli/node_modules/@inquirer/type": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.4.tgz",
+			"integrity": "sha512-PamArxO3cFJZoOzspzo6cxVlLeIftyBsZw/S9bKY5DzxqJVZgjoj1oP8d0rskKtp7sZxBycsoer1g6UeJV1BBA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"apps/cli/node_modules/chardet": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz",
+			"integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
+			"license": "MIT"
+		},
+		"apps/cli/node_modules/cli-width": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+			"integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+			"license": "ISC",
+			"engines": {
+				"node": ">= 12"
+			}
+		},
+		"apps/cli/node_modules/iconv-lite": {
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+			"integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+			"license": "MIT",
+			"dependencies": {
+				"safer-buffer": ">= 2.1.2 < 3.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"apps/cli/node_modules/mute-stream": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-3.0.0.tgz",
+			"integrity": "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==",
+			"license": "ISC",
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"apps/cli/node_modules/signal-exit": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"apps/studio": {

--- a/tools/benchmark-site-editor/README.md
+++ b/tools/benchmark-site-editor/README.md
@@ -122,7 +122,7 @@ With `--install-plugins`, the benchmark installs the same set of plugins used by
 ## Prerequisites
 
 - **Dependencies**: Run `npm install` from the repo root to install all workspace dependencies
-- **Studio CLI**: Built automatically if `dist/cli/main.js` doesn't exist (`npm run cli:build`)
+- **Studio CLI**: Built automatically if `dist/cli/main.mjs` doesn't exist (`npm run cli:build`)
 - **Playwright**: Chromium is installed automatically during setup
 
 ## Output

--- a/tools/benchmark-site-editor/benchmark.ts
+++ b/tools/benchmark-site-editor/benchmark.ts
@@ -40,7 +40,7 @@ import { measureSiteEditor, METRIC_NAMES, type MeasurementResult } from './measu
 // ---------------------------------------------------------------------------
 
 const STUDIO_ROOT = path.resolve( import.meta.dirname, '../..' );
-const STUDIO_CLI_PATH = path.resolve( STUDIO_ROOT, 'apps/cli/dist/cli/main.js' );
+const STUDIO_CLI_PATH = path.resolve( STUDIO_ROOT, 'apps/cli/dist/cli/main.mjs' );
 const PLAYGROUND_CLI_BIN =
 	process.platform === 'win32' ? 'wp-playground-cli.cmd' : 'wp-playground-cli';
 const PLAYGROUND_CLI_PATH = path.resolve(


### PR DESCRIPTION
## Related issues

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

- Fixes https://github.com/Automattic/studio/issues/2941

## How AI was used in this PR

<!--
Help reviewers understand what to look for and verify that you've reviewed the code yourself.
-->

For small directed tasks and for discussing Node's CJS/ESM loading behavior. 

## Proposed Changes

https://github.com/Automattic/studio/pull/2818 made Vite output ESM code in the CLI build, and updated `apps/cli/package.json` to contain a `type: module` field, which makes Node always interpret the code as ESM. However, this `package.json` file is not included in the CLI bundled with the app. 

Node.js follows this logic ([docs](https://nodejs.org/docs/latest-v24.x/api/esm.html#enabling)) when determining whether to interpret the code as CommonJS or ESM:

> Authors can tell Node.js to interpret JavaScript as an ES module via the .mjs file extension, the package.json "type" field with a value "module" […]
>
> Inversely, authors can explicitly tell Node.js to interpret JavaScript as CommonJS via the .cjs file extension, the package.json "type" field with a value "commonjs" […]
>
> When code lacks explicit markers for either module system, Node.js will inspect the source code of a module to look for ES module syntax. If such syntax is found, Node.js will run the code as an ES module; otherwise it will run the module as CommonJS. See Determining module system for more details.

In our testing, v1.7.7 of Studio and the CLI worked fine on Windows. That's because we didn't provide an explicit CJS/ESM signal to Node.js, so it inspected the source code to look for ES module syntax (which it found).

However, if a user places a `package.json` file in their home folder, that becomes the nearest `package.json` file for the CLI, which is the strongest signal to Node.js about which module system to use. I have reproduced this issue, and I suspect it's what caused the problem described in https://github.com/Automattic/studio/issues/2941.

This PR fixes the issue by outputting `.mjs` files in the CLI build. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Download and install the Windows dev build
2. In your Windows home directory, run `npm init -y`
3. Close Studio and open it again
4. Ensure that your site list loads as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
