### PR TITLE
Add Claude integration to workflows

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,31 @@
+name: Claude
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  id-token: write
+
+jobs:
+  claude:
+    runs-on: ubuntu-latest
+    if: |
+      (github.event_name == 'issue_comment' || github.event_name == 'pull_request_review_comment') &&
+      contains(github.event.comment.body, '@claude') &&
+      github.event.comment.user.login == 'matticbot'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run Claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Related issues

- Related post showing the wpcom flow: pb6Nl-kJH-p2
- Related to 209871-ghe-Automattic/wpcom

## How AI was used in this PR

- Review the new workflow
- Produce a detailed PR description

## Proposed Changes

This PR adds a GitHub Actions workflow that will later be invoked by TeamCity automation to start Claude-driven implementation work from a PR/issue comment. The workflow is the same as the one [used on Calypso](https://github.com/Automattic/wp-calypso/pull/109557).

- Add a new `Claude` GitHub Action workflow to run `anthropics/claude-code-action@v1`.
- Triggering mechanism:
  - Runs on `issue_comment.created` and `pull_request_review_comment.created`.
  - Only runs when the comment body contains `@claude`.
  - Only runs when the commenter is `matticbot`. This is intentional, for TeamCity automation to post the “start work” comment + context.

## Testing Instructions

- Visual review should suffice
- We can test the flow after this PR is merged, using 209871-ghe-Automattic/wpcom

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors? (N/A)