### PR TITLE
Fix AI TUI selected-site updates

### DIFF
--- a/apps/cli/ai/tests/ui.test.ts
+++ b/apps/cli/ai/tests/ui.test.ts
@@ -3,6 +3,7 @@ import { AiChatUI } from 'cli/ai/ui';
 import { openBrowser } from 'cli/lib/browser';
 import { readCliConfig } from 'cli/lib/cli-config/core';
 import { getSiteUrl } from 'cli/lib/cli-config/sites';
+import { isSiteRunning } from 'cli/lib/site-utils';
 
 vi.mock( 'cli/lib/cli-config/core', async ( importOriginal ) => {
 	const actual = await importOriginal< typeof import('cli/lib/cli-config/core') >();
@@ -22,6 +23,10 @@ vi.mock( 'cli/lib/cli-config/sites', async ( importOriginal ) => {
 
 vi.mock( 'cli/lib/browser', () => ( {
 	openBrowser: vi.fn(),
+} ) );
+
+vi.mock( 'cli/lib/site-utils', () => ( {
+	isSiteRunning: vi.fn(),
 } ) );
 
 describe( 'AiChatUI.openActiveSiteInBrowser', () => {
@@ -60,5 +65,154 @@ describe( 'AiChatUI.openActiveSiteInBrowser', () => {
 		expect( readCliConfig ).toHaveBeenCalledTimes( 1 );
 		expect( openBrowser ).toHaveBeenCalledWith( 'http://localhost:8080' );
 		expect( ui._activeSiteData ).toEqual( siteData );
+	} );
+} );
+
+describe( 'AiChatUI auto site selection', () => {
+	beforeEach( () => {
+		vi.clearAllMocks();
+	} );
+
+	function createUiStub() {
+		const ui = Object.create( AiChatUI.prototype ) as {
+			autoSelectSiteFromToolResult: (
+				toolName: string,
+				toolInput: Record< string, unknown >
+			) => Promise< void >;
+			setActiveSite: (
+				site: { name: string; path: string; running: boolean },
+				options?: { announce?: boolean; emitEvent?: boolean }
+			) => void;
+			[ key: string ]: unknown;
+		};
+		ui._activeSite = null;
+		ui._activeSiteData = null;
+		ui.editor = { activeSiteName: null, invalidate: vi.fn() };
+		ui.messages = { addChild: vi.fn() };
+		ui.tui = { requestRender: vi.fn() };
+		ui.siteSelectedCallback = vi.fn();
+		return ui;
+	}
+
+	it( 'selects a created site after site_create succeeds', async () => {
+		const ui = createUiStub();
+		const siteData = {
+			name: 'toto',
+			path: '/Users/test/Studio/toto',
+			port: 8881,
+		};
+
+		vi.mocked( readCliConfig ).mockResolvedValue( {
+			sites: [ siteData ],
+		} as never );
+		vi.mocked( isSiteRunning ).mockResolvedValue( false );
+
+		await ui.autoSelectSiteFromToolResult( 'mcp__studio__site_create', { name: 'toto' } );
+
+		expect( ui._activeSite ).toMatchObject( {
+			name: 'toto',
+			path: '/Users/test/Studio/toto',
+			running: true,
+		} );
+		expect( ui.editor ).toMatchObject( { activeSiteName: 'toto' } );
+		expect( ui.siteSelectedCallback ).toHaveBeenCalledWith(
+			expect.objectContaining( { name: 'toto', path: '/Users/test/Studio/toto', running: true } )
+		);
+	} );
+
+	it( 'selects the acted-on site after site_stop succeeds', async () => {
+		const ui = createUiStub();
+		const siteData = {
+			name: 'tata',
+			path: '/Users/test/Studio/tata',
+			port: 8882,
+		};
+		ui._activeSite = {
+			name: 'other-site',
+			path: '/Users/test/Studio/other-site',
+			running: true,
+		};
+
+		vi.mocked( readCliConfig ).mockResolvedValue( {
+			sites: [ siteData ],
+		} as never );
+		vi.mocked( isSiteRunning ).mockResolvedValue( true );
+
+		await ui.autoSelectSiteFromToolResult( 'mcp__studio__site_stop', { nameOrPath: 'tata' } );
+
+		expect( ui._activeSite ).toMatchObject( {
+			name: 'tata',
+			path: '/Users/test/Studio/tata',
+			running: false,
+		} );
+		expect( ui.editor ).toMatchObject( { activeSiteName: 'tata' } );
+		expect( ui.siteSelectedCallback ).toHaveBeenCalledWith(
+			expect.objectContaining( { name: 'tata', path: '/Users/test/Studio/tata', running: false } )
+		);
+	} );
+
+	it( 'invalidates the prompt editor when selecting a site', () => {
+		const ui = createUiStub();
+
+		ui.setActiveSite( {
+			name: 'Riad site',
+			path: '/Users/test/Studio/riad-site',
+			running: true,
+		} );
+
+		expect( ui.editor as { activeSiteName: string | null } ).toMatchObject( {
+			activeSiteName: 'Riad site',
+		} );
+		expect(
+			( ui.editor as { invalidate: ReturnType< typeof vi.fn > } ).invalidate
+		).toHaveBeenCalledTimes( 1 );
+	} );
+} );
+
+describe( 'AiChatUI.handleMessage', () => {
+	beforeEach( () => {
+		vi.clearAllMocks();
+	} );
+
+	it( 'falls back to the latest pending tool call when tool results have no parent id', () => {
+		const ui = Object.create( AiChatUI.prototype ) as {
+			handleMessage: ( message: unknown ) => void;
+			[ key: string ]: unknown;
+		};
+		const showToolResult = vi.fn();
+
+		ui.pendingToolCalls = new Map( [
+			[
+				'tool-1',
+				{
+					name: 'mcp__studio__site_stop',
+					input: { nameOrPath: 'aura' },
+				},
+			],
+		] );
+		ui.pendingTodoRenders = new Map();
+		ui.pendingTodoRenderOrder = [];
+		ui.showTodoToolResult = vi.fn();
+		ui.showToolResult = showToolResult;
+		ui.currentMarkdown = null;
+		ui.currentResponseText = '';
+
+		ui.handleMessage( {
+			type: 'user',
+			parent_tool_use_id: null,
+			tool_use_result: {
+				content: 'Site "aura" stopped.',
+			},
+			message: {
+				content: [],
+			},
+		} );
+
+		expect( showToolResult ).toHaveBeenCalledWith(
+			expect.objectContaining( { parent_tool_use_id: null } ),
+			'mcp__studio__site_stop',
+			{ nameOrPath: 'aura' }
+		);
+		expect( ui.pendingToolCalls ).toEqual( new Map() );
 	} );
 } );

--- a/apps/cli/ai/ui.ts
+++ b/apps/cli/ai/ui.ts
@@ -552,6 +552,10 @@ export class AiChatUI {
 		return this._activeSite;
 	}
 
+	private refreshPromptChrome(): void {
+		this.editor.invalidate();
+	}
+
 	set onSiteSelected( fn: ( ( site: SiteInfo ) => void ) | null ) {
 		this.siteSelectedCallback = fn;
 	}
@@ -960,6 +964,7 @@ export class AiChatUI {
 		const { announce = true, emitEvent = true } = options;
 		this._activeSite = site;
 		this.editor.activeSiteName = site.name;
+		this.refreshPromptChrome();
 		const suffix = site.remote ? ' (WordPress.com)' : '';
 		const label = ` ✻ Selected site: ${ site.name }${ suffix }`;
 		if ( announce ) {
@@ -975,6 +980,7 @@ export class AiChatUI {
 		this._activeSite = null;
 		this._activeSiteData = null;
 		this.editor.activeSiteName = null;
+		this.refreshPromptChrome();
 		this.messages.addChild( new Text( chalk.dim( ' ✻ Site deselected' ) + '\n', 0, 0 ) );
 		this.tui.requestRender();
 	}
@@ -1007,72 +1013,67 @@ export class AiChatUI {
 		return a.path === b.path || a.name.toLowerCase() === b.name.toLowerCase();
 	}
 
+	private async selectLocalSiteFromTool(
+		nameOrPath: string,
+		options: { running?: boolean } = {}
+	): Promise< void > {
+		const site = await this.findSiteFromAppdata( nameOrPath );
+		if ( ! site ) {
+			return;
+		}
+
+		if ( typeof options.running === 'boolean' ) {
+			site.running = options.running;
+		}
+
+		if ( this.isSameSite( this._activeSite, site ) ) {
+			this._activeSite = site;
+			this.editor.activeSiteName = site.name;
+			this.refreshPromptChrome();
+			this.tui.requestRender();
+			return;
+		}
+
+		this.setActiveSite( site );
+	}
+
 	private async autoSelectSiteFromToolResult(
 		toolName: string,
 		toolInput: Record< string, unknown > | null
 	): Promise< void > {
 		switch ( toolName ) {
 			case 'mcp__studio__site_create': {
-				// site_create tool input has { name: string }
 				const name = toolInput?.name;
 				if ( typeof name === 'string' ) {
-					const site = await this.findSiteFromAppdata( name );
-					if ( site ) {
-						site.running = true; // site_create auto-starts the site
-						this.setActiveSite( site );
-					}
+					await this.selectLocalSiteFromTool( name, { running: true } );
 				}
 				break;
 			}
+			case 'mcp__studio__site_info':
 			case 'mcp__studio__site_start': {
 				const nameOrPath = toolInput?.nameOrPath;
 				if ( typeof nameOrPath === 'string' ) {
-					const site = await this.findSiteFromAppdata( nameOrPath );
-					if ( site ) {
-						site.running = true;
-						if ( this.isSameSite( this._activeSite, site ) ) {
-							this._activeSite = site; // Update running status in-place
-						} else {
-							this.setActiveSite( site );
-						}
-					}
+					await this.selectLocalSiteFromTool( nameOrPath, {
+						running: toolName === 'mcp__studio__site_start' ? true : undefined,
+					} );
 				}
 				break;
 			}
 			case 'mcp__studio__wp_cli':
 			case 'mcp__studio__preview_create':
 			case 'mcp__studio__preview_list':
-			case 'mcp__studio__preview_update': {
+			case 'mcp__studio__preview_update':
+			case 'mcp__studio__validate_blocks': {
 				const nameOrPath = toolInput?.nameOrPath;
 				if ( typeof nameOrPath === 'string' ) {
-					if (
-						! this._activeSite ||
-						! this.isSameSite( this._activeSite, {
-							name: nameOrPath,
-							path: nameOrPath,
-							running: true,
-						} )
-					) {
-						const site = await this.findSiteFromAppdata( nameOrPath );
-						if ( site ) {
-							this.setActiveSite( site );
-						}
-					}
+					await this.selectLocalSiteFromTool( nameOrPath );
 				}
 				break;
 			}
 			case 'mcp__studio__site_stop': {
 				const nameOrPath = toolInput?.nameOrPath;
-				if (
-					typeof nameOrPath === 'string' &&
-					this._activeSite &&
-					this.isSameSite( this._activeSite, {
-						name: nameOrPath,
-						path: nameOrPath,
-						running: false,
-					} )
-				) {
-					this._activeSite = { ...this._activeSite, running: false };
+				if ( typeof nameOrPath === 'string' ) {
+					await this.selectLocalSiteFromTool( nameOrPath, { running: false } );
 				}
 				break;
 			}
@@ -1632,6 +1633,28 @@ export class AiChatUI {
 		return pendingTodoRender;
 	}
 
+	private consumeLatestPendingToolCall(): {
+		id: string;
+		name: string;
+		input: Record< string, unknown >;
+	} | null {
+		let latestPendingToolCall: {
+			id: string;
+			name: string;
+			input: Record< string, unknown >;
+		} | null = null;
+
+		for ( const [ id, toolCall ] of this.pendingToolCalls.entries() ) {
+			latestPendingToolCall = { id, ...toolCall };
+		}
+
+		if ( latestPendingToolCall ) {
+			this.pendingToolCalls.delete( latestPendingToolCall.id );
+		}
+
+		return latestPendingToolCall;
+	}
+
 	private renderToolResultText(
 		content: string | Array< { type: string; text?: string } >,
 		toolName?: string
@@ -1892,7 +1915,8 @@ export class AiChatUI {
 				} else if ( ! toolCallId && this.pendingTodoRenderOrder.length > 0 ) {
 					this.showTodoToolResult( message, this.pendingTodoRenderOrder[ 0 ] );
 				} else {
-					this.showToolResult( message, toolCall?.name, toolCall?.input );
+					const fallbackToolCall = toolCall ?? this.consumeLatestPendingToolCall();
+					this.showToolResult( message, fallbackToolCall?.name, fallbackToolCall?.input );
 				}
 				// Close the current markdown block so the next assistant text
 				// creates a fresh visual block (mirrors askUser / endAgentTurn).


### PR DESCRIPTION
## Related issues

STU-1493

## How AI was used in this PR

AI drafted the implementation and the targeted UI regression tests. I reviewed the final diff, adjusted the approach during validation, and reran lint, tests, and typecheck before opening this PR.

## Proposed Changes

- restore automatic TUI site selection after successful AI site actions like create, start, stop, preview, WP-CLI, and validate-blocks
- fall back to the latest pending tool call when a tool result arrives without a `parent_tool_use_id`, so site-targeted actions still update selection
- refresh the prompt chrome when the selected site changes and add focused Vitest coverage for the selection and routing regressions

## Testing Instructions

- Run `npm test -- apps/cli/ai/tests/ui.test.ts apps/cli/commands/ai/tests/sessions.test.ts apps/cli/commands/ai/tests/ai.test.ts`
- Run `npm run typecheck`
- In `studio ai`, ask the agent to create a site, stop a different site, and select a site manually; confirm the selected site updates in the TUI each time

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?
