### PR TITLE
Fix AI TUI crash when pressing ESC during agent turn

### DIFF
--- a/apps/cli/ai/agent.ts
+++ b/apps/cli/ai/agent.ts
@@ -31,6 +31,18 @@ export type AiModelId = keyof typeof AI_MODELS;
 export const DEFAULT_MODEL: AiModelId = 'claude-sonnet-4-6';
 const pathApprovalSession = createPathApprovalSession();
 
+// The Claude Agent SDK rejects internal pending promises (e.g. control
+// responses) when an agent turn is interrupted via ESC. These rejections
+// are unhandled because they originate inside the SDK cleanup path rather
+// than propagating through the async iterator. Without this handler,
+// Node.js terminates the process on unhandled rejections.
+process.on( 'unhandledRejection', ( reason ) => {
+	if ( reason instanceof Error && reason.message.includes( 'Query closed' ) ) {
+		return;
+	}
+	throw reason;
+} );
+
 /**
  * Start the AI agent and return the Query object.
  * Caller can iterate messages with `for await` and call `interrupt()` to stop.


### PR DESCRIPTION
## Related issues

- Fixes STU-1498

## How AI was used in this PR

Claude assisted with debugging and identifying the root cause. But I needed to iterate multiple times finding different approaches until the current approach worked.

## Proposed Changes

- Add an `unhandledRejection` handler in `apps/cli/ai/agent.ts` to catch expected SDK rejections during ESC interruption

When the user presses ESC to interrupt an AI agent turn, the Claude Agent SDK rejects internal pending promises (e.g. control responses) during its cleanup path. These rejections are unhandled because they originate inside the SDK rather than propagating through the async iterator. Without a handler, Node.js terminates the process on unhandled rejections, crashing the TUI.

The handler only suppresses `"Query closed"` errors — all other unhandled rejections are re-thrown.

## Testing Instructions

- Run `npm run cli:build && node apps/cli/dist/cli/main.mjs ai`
- Send a prompt to the AI agent
- Press ESC multiple times rapidly while the agent is responding
- Verify the turn is interrupted cleanly and the TUI returns to the prompt input
- Verify you can send another prompt after the interruption

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?