### PR TITLE
Fix start:test isolated config after split-config refactor

### DIFF
--- a/apps/studio/src/storage/paths.ts
+++ b/apps/studio/src/storage/paths.ts
@@ -16,9 +16,6 @@ try {
 }
 
 export function getUserDataFilePath(): string {
-	if ( process.env.DEV_APP_DATA_PATH ) {
-		return process.env.DEV_APP_DATA_PATH;
-	}
 	return getAppConfigPath();
 }
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
 	],
 	"scripts": {
 		"start": "npm -w studio-app run start",
-		"start:test": "DEV_APP_DATA_PATH=/tmp/studio-test-appdata.json npm -w studio-app run start",
+		"start:test": "DEV_CONFIG_DIR=/tmp/studio-test npm -w studio-app run start",
 		"start-wayland": "npm -w studio-app run start-wayland",
 		"postinstall": "patch-package --patch-dir apps/cli/patches && patch-package --patch-dir apps/studio/patches && node ./scripts/remove-fs-ext-other-platform-binaries.mjs && ts-node ./scripts/download-wp-server-files.ts && node ./scripts/download-available-site-translations.mjs && ts-node ./scripts/download-agent-skills.ts",
 		"package": "ts-node ./scripts/package-in-isolation.ts package",

--- a/tools/common/lib/well-known-paths.ts
+++ b/tools/common/lib/well-known-paths.ts
@@ -3,6 +3,9 @@ import path from 'path';
 import { APP_CONFIG_LOCKFILE_NAME } from '../constants';
 
 export function getConfigDirectory(): string {
+	if ( process.env.DEV_CONFIG_DIR ) {
+		return process.env.DEV_CONFIG_DIR;
+	}
 	if ( process.env.E2E && process.env.E2E_SHARED_CONFIG_PATH ) {
 		return process.env.E2E_SHARED_CONFIG_PATH;
 	}


### PR DESCRIPTION
## Related issues

- Fixes STU-1462

## How AI was used in this PR

Claude Code was used to investigate the root cause and implement the fix.

## Proposed Changes

This PR adds `DEV_CONFIG_DIR` env var support to `getConfigDirectory()` in `tools/common/lib/well-known-paths.ts`, redirecting the entire `~/.studio/` config directory when set.

The config refactor split the single appdata file into three files (`app.json`, `cli.json`, `shared.json`). The old `DEV_APP_DATA_PATH` only redirected `app.json` — `cli.json` (sites, snapshots) and `shared.json` (auth) still pointed at `~/.studio/`, so real developer sites could appear in the test instance.

## Testing Instructions

1. Run `npm run start:test` — app should open with no sites and no auth
2. Confirm `/tmp/studio-test/` is created with the isolated config files
3. Confirm `~/.studio/cli.json` and `~/.studio/shared.json` are unchanged after the session
4. Run `npm start` and confirm your real sites still appear normally

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?