### PR TITLE
Refetch Sync dialog on focus and add spinner

### DIFF
--- a/apps/studio/src/modules/add-site/components/pull-remote-site.tsx
+++ b/apps/studio/src/modules/add-site/components/pull-remote-site.tsx
@@ -139,7 +139,9 @@ export function PullRemoteSite( {
 	const {
 		data: syncSites = [],
 		isLoading,
+		isFetching,
 		isSuccess,
+		refetch: refetchWpComSites,
 	} = useGetWpComSitesQuery(
 		{
 			userId: user?.id,
@@ -167,9 +169,11 @@ export function PullRemoteSite( {
 					) : (
 						<SitesListContent
 							isLoading={ isLoading }
+							isFetching={ isFetching }
 							syncSites={ syncSites }
 							selectedSiteId={ selectedRemoteSite?.id || null }
 							onSelectSite={ handleSiteSelect }
+							refetchSites={ refetchWpComSites }
 						/>
 					) }
 				</VStack>

--- a/apps/studio/src/modules/sync/components/sync-sites-modal-selector.tsx
+++ b/apps/studio/src/modules/sync/components/sync-sites-modal-selector.tsx
@@ -58,7 +58,9 @@ export function SyncSitesModalSelector( {
 	const {
 		data: syncSites = [],
 		isLoading,
+		isFetching,
 		isSuccess,
+		refetch: refetchWpComSites,
 	} = useGetWpComSitesQuery(
 		{ connectedSiteIds, userId: user?.id },
 		{ refetchOnMountOrArgChange: true }
@@ -89,9 +91,11 @@ export function SyncSitesModalSelector( {
 			<div className="relative" data-testid="sync-sites-modal-selector">
 				<SitesListContent
 					isLoading={ isLoading }
+					isFetching={ isFetching }
 					syncSites={ syncSites }
 					selectedSiteId={ selectedSiteId }
 					onSelectSite={ setSelectedSiteId }
+					refetchSites={ refetchWpComSites }
 				/>
 				<Footer
 					onRequestClose={ onRequestClose }
@@ -156,17 +160,33 @@ function SearchSites( {
 
 export function SitesListContent( {
 	isLoading,
+	isFetching,
 	syncSites,
 	selectedSiteId,
 	onSelectSite,
+	refetchSites,
 }: {
 	isLoading: boolean;
+	isFetching: boolean;
 	syncSites: SyncSite[];
 	selectedSiteId: number | null;
 	onSelectSite: ( id: number ) => void;
+	refetchSites: () => void | Promise< unknown >;
 } ) {
 	const { __ } = useI18n();
+	const isOffline = useOffline();
 	const [ searchQuery, setSearchQuery ] = useState< string >( '' );
+
+	useEffect( () => {
+		if ( isOffline ) {
+			return;
+		}
+		const handleWindowFocus = () => {
+			void refetchSites();
+		};
+		window.addEventListener( 'focus', handleWindowFocus );
+		return () => window.removeEventListener( 'focus', handleWindowFocus );
+	}, [ isOffline, refetchSites ] );
 
 	const filteredSites = syncSites.filter( ( site ) => {
 		const searchQueryLower = searchQuery.toLowerCase();
@@ -180,22 +200,31 @@ export function SitesListContent( {
 		? sprintf( __( 'No sites found for "%s"' ), searchQuery )
 		: __( 'No sites found' );
 
+	const isRefetchingSites = isFetching && ! isLoading;
+
 	return (
 		<>
 			<SearchSites searchQuery={ searchQuery } setSearchQuery={ setSearchQuery } />
-			<div className="h-[calc(84vh-232px)]">
-				{ isLoading && (
+			<div className="relative h-[calc(84vh-232px)]">
+				{ isLoading ? (
 					<div className="flex justify-center items-center h-full">{ __( 'Loading sites…' ) }</div>
-				) }
-				{ ! isLoading && isEmpty && (
+				) : isEmpty ? (
 					<div className="flex justify-center items-center h-full">{ emptyMessage }</div>
-				) }
-				{ ! isLoading && ! isEmpty && (
+				) : (
 					<ListSites
 						syncSites={ filteredSites }
 						selectedSiteId={ selectedSiteId }
 						onSelectSite={ onSelectSite }
 					/>
+				) }
+				{ isRefetchingSites && (
+					<div
+						className="absolute inset-0 z-[1] flex items-center justify-center bg-frame/60 backdrop-blur-[1px]"
+						aria-busy="true"
+						aria-live="polite"
+					>
+						<span className="a8c-body text-frame-text">{ __( 'Refreshing sites…' ) }</span>
+					</div>
 				) }
 			</div>
 		</>

--- a/apps/studio/src/modules/sync/components/sync-sites-modal-selector.tsx
+++ b/apps/studio/src/modules/sync/components/sync-sites-modal-selector.tsx
@@ -219,7 +219,7 @@ export function SitesListContent( {
 				) }
 				{ isRefetchingSites && (
 					<div
-						className="absolute inset-0 z-[1] flex items-center justify-center bg-frame/60 backdrop-blur-[1px]"
+						className="absolute inset-0 z-[1] flex items-center justify-center bg-frame/60 backdrop-blur-[8px]"
 						aria-busy="true"
 						aria-live="polite"
 					>

--- a/apps/studio/src/modules/sync/components/sync-sites-modal-selector.tsx
+++ b/apps/studio/src/modules/sync/components/sync-sites-modal-selector.tsx
@@ -1,4 +1,4 @@
-import { Icon, SearchControl as SearchControlWp } from '@wordpress/components';
+import { Icon, SearchControl as SearchControlWp, Spinner } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import { useState, useEffect } from 'react';
@@ -207,7 +207,10 @@ export function SitesListContent( {
 			<SearchSites searchQuery={ searchQuery } setSearchQuery={ setSearchQuery } />
 			<div className="relative h-[calc(84vh-232px)]">
 				{ isLoading ? (
-					<div className="flex justify-center items-center h-full">{ __( 'Loading sites…' ) }</div>
+					<div className="flex justify-center items-center h-full">
+						<Spinner className="!mt-0 !mr-2" />
+						<span className="a8c-body text-frame-text">{ __( 'Loading…' ) }</span>
+					</div>
 				) : isEmpty ? (
 					<div className="flex justify-center items-center h-full">{ emptyMessage }</div>
 				) : (
@@ -217,15 +220,18 @@ export function SitesListContent( {
 						onSelectSite={ onSelectSite }
 					/>
 				) }
-				{ isRefetchingSites && (
-					<div
-						className="absolute inset-0 z-[1] flex items-center justify-center bg-frame/60 backdrop-blur-[8px]"
-						aria-busy="true"
-						aria-live="polite"
-					>
-						<span className="a8c-body text-frame-text">{ __( 'Refreshing sites…' ) }</span>
-					</div>
-				) }
+				<div
+					className={ `absolute inset-0 z-[1] flex items-center justify-center bg-frame/80 backdrop-blur-[8px] transition-opacity duration-200 ${
+						isRefetchingSites
+							? 'opacity-100'
+							: 'opacity-0 pointer-events-none'
+					}` }
+					aria-busy={ isRefetchingSites }
+					aria-live="polite"
+				>
+					<Spinner className="!mt-0 !mr-2" />
+					<span className="a8c-body text-frame-text">{ __( 'Refreshing…' ) }</span>
+				</div>
 			</div>
 		</>
 	);

--- a/apps/studio/src/modules/sync/components/sync-sites-modal-selector.tsx
+++ b/apps/studio/src/modules/sync/components/sync-sites-modal-selector.tsx
@@ -222,9 +222,7 @@ export function SitesListContent( {
 				) }
 				<div
 					className={ `absolute inset-0 z-[1] flex items-center justify-center bg-frame/80 backdrop-blur-[8px] transition-opacity duration-200 ${
-						isRefetchingSites
-							? 'opacity-100'
-							: 'opacity-0 pointer-events-none'
+						isRefetchingSites ? 'opacity-100' : 'opacity-0 pointer-events-none'
 					}` }
 					aria-busy={ isRefetchingSites }
 					aria-live="polite"


### PR DESCRIPTION
## Related issues

- Fixes STU-1507

## How AI was used in this PR
AI assisted me, but the implementation is mine. 

## Proposed Changes

1. The use case is - user opens Sync dialog, realizes that they need to connect Jetpack in Pressable, so they keep the dialog open and move to the browser to connect Jetpack to their site on Pressable. Then they return to Studio, don't see the just-connected site, and they restart Studio.

The solution - we need to refetch sites on the focus event, if the Sync dialog is opened in Studio.

2. Right now, when we reopen the Sync dialog - we take data from cache and start refetching, but we don't communicate that we are refetching them. That's why when a user reopens the Sync dialog, we have a flash of content after a few seconds. I had a case where I was selecting a site and ended up choosing the wrong one because of a flash of content.

The solution - we should communicate in UI that we are refetching sites.

## Testing Instructions
1. Opean Sync dialog and assert that you see `Loading sites`<br /><img width="632" height="445" alt="Screenshot 2026-04-02 at 17 36 51" src="https://github.com/user-attachments/assets/dde28a42-8c65-40bb-9783-2f33d5a4aa31" />
2. Close the dialog and open again
3. Assert that you see sites rendered from cache, but covered with blurred "Refreshing sites" spinner<br /><img width="633" height="448" alt="Screenshot 2026-04-02 at 17 38 32" src="https://github.com/user-attachments/assets/1aa7edda-f9e8-4373-ba11-f127caf5c1fb" />
4. Leave Studio and focus on another app on your laptop
5. Comeback and focus on Studio again
6. Assert that you see "Refreshing sites" spinner<br /><img width="633" height="448" alt="Screenshot 2026-04-02 at 17 38 32" src="https://github.com/user-attachments/assets/1aa7edda-f9e8-4373-ba11-f127caf5c1fb" />

