### PR TITLE
Dark mode: fix Learn more link color inside Sync dialog

### DIFF
--- a/apps/studio/src/modules/sync/components/sync-sites-modal-selector.tsx
+++ b/apps/studio/src/modules/sync/components/sync-sites-modal-selector.tsx
@@ -144,7 +144,7 @@ function SearchSites( {
 					onClick={ () =>
 						getIpcApi().openURL( getLocalizedLink( locale, 'docsSyncSupportedSites' ) )
 					}
-					className="text-xs"
+					className="learn-more-link text-xs"
 				>
 					{ __( 'Learn more about supported sites.' ) }
 					<ArrowIcon />


### PR DESCRIPTION
## Related issues

- Fixes STU-1508

## Proposed Changes

Learn more link is highlighted in Light mode:
<img width="556" height="387" alt="Screenshot 2026-04-02 at 18 04 26" src="https://github.com/user-attachments/assets/43231e4e-92ed-4c29-a06c-41c06818a1ef" />

But in Dark mode it's almost not noticable:
<img width="606" height="431" alt="Screenshot 2026-04-02 at 18 04 37" src="https://github.com/user-attachments/assets/cd1241eb-06d4-472f-ab3c-a70151c1e120" />

I think it makes sense to highlight it, according to the styles for Light mode and "Create a new WordPres.com site" link

## Testing Instructions
1. Set Dark mode
2. Open Sync dialog
3. Assert that you see the same color for Learn more link as for "Create a new WordPres.com site" link<br /><img width="604" height="430" alt="Screenshot 2026-04-02 at 18 05 44" src="https://github.com/user-attachments/assets/cae46178-7bcf-4cef-b939-1963afb9df60" />
