### PR TITLE
Prevent AI agent from running wp commands via Bash

### DIFF
--- a/apps/cli/ai/system-prompt.ts
+++ b/apps/cli/ai/system-prompt.ts
@@ -1,7 +1,7 @@
 export function buildSystemPrompt(): string {
 	return `You are WordPress Studio AI, the AI assistant built into WordPress Studio CLI. Your name is "WordPress Studio AI". You manage and modify local WordPress sites using your Studio tools and generate content for these sites.
 
-IMPORTANT: You MUST use your mcp__studio__ tools to manage WordPress sites. Never create, start, or stop sites using Bash commands, shell scripts, or manual file operations. The Studio tools handle all server management, database setup, and WordPress provisioning automatically.
+IMPORTANT: You MUST use your mcp__studio__ tools to manage WordPress sites. Never create, start, or stop sites using Bash commands, shell scripts, or manual file operations. Never run \`wp\` commands via Bash — always use the wp_cli tool instead. The Studio tools handle all server management, database setup, and WordPress provisioning automatically.
 IMPORTANT: For any generated content for the site, these three principles are mandatory:
 
 - Gorgeous design: More details on the guidelines below.


### PR DESCRIPTION
## Related issues

- Related to PHP deprecation warnings when AI agent runs WP-CLI commands

## How AI was used in this PR

Claude investigated the root cause of PHP deprecation warnings appearing during `studio ai` sessions and proposed the system prompt fix.

## Proposed Changes

- Add explicit instruction to the AI agent's system prompt to never run `wp` commands via the Bash tool, always using the `wp_cli` Studio tool instead.

The AI agent has access to both the `mcp__studio__wp_cli` tool (which runs commands through PHP-WASM) and the `Bash` tool. The existing system prompt prohibited using Bash for site management (create, start, stop) but didn't explicitly prohibit running `wp` CLI commands via Bash. When the agent chose Bash, it would invoke the system's WP-CLI binary, which can produce PHP deprecation warnings from outdated bundled dependencies.

## Testing Instructions

- Run `studio ai` and ask it to create a post or run other WP-CLI commands
- Verify the agent uses the `mcp__studio__wp_cli` tool instead of shelling out to the system `wp` binary via Bash
- Confirm no PHP deprecation warnings appear in the output

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?