### PR TITLE
Add performance audit skill and tool to AI command

### DIFF
--- a/apps/cli/ai/performance-audit.ts
+++ b/apps/cli/ai/performance-audit.ts
@@ -1,0 +1,258 @@
+/**
+ * Frontend performance audit module for WordPress sites.
+ *
+ * Uses the shared Playwright browser to measure Core Web Vitals and page
+ * composition metrics via the native Performance API and PerformanceObserver.
+ */
+
+import { getSharedBrowser } from 'cli/ai/browser-utils';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface AssetBreakdown {
+	count: number;
+	totalBytes: number;
+	urls: string[];
+}
+
+export interface AuditMetrics {
+	// Core Web Vitals timing (milliseconds)
+	ttfb: number;
+	fcp: number;
+	lcp: number;
+
+	// Layout stability (unitless score)
+	cls: number;
+
+	// Page composition
+	domElements: number;
+	totalRequests: number;
+	pageWeightBytes: number;
+
+	// Asset breakdown
+	scripts: AssetBreakdown;
+	stylesheets: AssetBreakdown;
+	images: { count: number; totalBytes: number };
+	fonts: { count: number; totalBytes: number };
+}
+
+export interface AuditResult {
+	url: string;
+	timestamp: string;
+	metrics: AuditMetrics | null;
+	error?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Injected observer script — runs before page navigation
+// ---------------------------------------------------------------------------
+
+/**
+ * This script is injected via addInitScript so that PerformanceObserver
+ * entries (FCP, LCP, CLS) are captured from the very start of page load.
+ */
+function observerSetupScript() {
+	const audit = { lcpValue: 0, clsValue: 0, fcpValue: 0 };
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	( window as any ).__auditMetrics = audit;
+
+	try {
+		// LCP — keep the latest entry's startTime
+		new PerformanceObserver( ( list ) => {
+			for ( const entry of list.getEntries() ) {
+				audit.lcpValue = entry.startTime;
+			}
+		} ).observe( { type: 'largest-contentful-paint', buffered: true } );
+	} catch {
+		// Observer not supported — metrics will stay 0
+	}
+
+	try {
+		// CLS — accumulate layout shifts that are not caused by user input
+		new PerformanceObserver( ( list ) => {
+			for ( const entry of list.getEntries() ) {
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+				if ( ! ( entry as any ).hadRecentInput ) {
+					// eslint-disable-next-line @typescript-eslint/no-explicit-any
+					audit.clsValue += ( entry as any ).value ?? 0;
+				}
+			}
+		} ).observe( { type: 'layout-shift', buffered: true } );
+	} catch {
+		// Observer not supported
+	}
+
+	try {
+		// FCP — first-contentful-paint entry
+		new PerformanceObserver( ( list ) => {
+			for ( const entry of list.getEntries() ) {
+				if ( entry.name === 'first-contentful-paint' ) {
+					audit.fcpValue = entry.startTime;
+				}
+			}
+		} ).observe( { type: 'paint', buffered: true } );
+	} catch {
+		// Observer not supported
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Metric collection — runs after page load
+// ---------------------------------------------------------------------------
+
+function collectMetricsScript(): AuditMetrics {
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	const audit = ( window as any ).__auditMetrics ?? { lcpValue: 0, clsValue: 0, fcpValue: 0 };
+
+	// Navigation timing
+	const navEntries = performance.getEntriesByType( 'navigation' );
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	const nav = navEntries[ 0 ] as any;
+	const ttfb = nav ? nav.responseStart - nav.requestStart : 0;
+
+	// Resource entries
+	const resources = performance.getEntriesByType( 'resource' );
+
+	function getSize( entry: PerformanceResourceTiming ): number {
+		return entry.transferSize || entry.encodedBodySize || 0;
+	}
+
+	function categorize( entry: PerformanceResourceTiming ): string {
+		const url = entry.name.toLowerCase();
+		const type = entry.initiatorType;
+		if ( type === 'script' || url.endsWith( '.js' ) || url.endsWith( '.mjs' ) ) {
+			return 'script';
+		}
+		if ( type === 'link' || type === 'css' || url.endsWith( '.css' ) ) {
+			return 'stylesheet';
+		}
+		if ( type === 'img' || /\.(png|jpe?g|gif|svg|webp|avif|ico)/.test( url ) ) {
+			return 'image';
+		}
+		if ( /\.(woff2?|ttf|otf|eot)/.test( url ) ) {
+			return 'font';
+		}
+		return 'other';
+	}
+
+	const scripts: { count: number; totalBytes: number; urls: string[] } = {
+		count: 0,
+		totalBytes: 0,
+		urls: [],
+	};
+	const stylesheets: { count: number; totalBytes: number; urls: string[] } = {
+		count: 0,
+		totalBytes: 0,
+		urls: [],
+	};
+	const images = { count: 0, totalBytes: 0 };
+	const fonts = { count: 0, totalBytes: 0 };
+	let pageWeightBytes = 0;
+
+	for ( const entry of resources ) {
+		const res = entry as PerformanceResourceTiming;
+		const size = getSize( res );
+		pageWeightBytes += size;
+
+		const category = categorize( res );
+		switch ( category ) {
+			case 'script':
+				scripts.count++;
+				scripts.totalBytes += size;
+				scripts.urls.push( res.name );
+				break;
+			case 'stylesheet':
+				stylesheets.count++;
+				stylesheets.totalBytes += size;
+				stylesheets.urls.push( res.name );
+				break;
+			case 'image':
+				images.count++;
+				images.totalBytes += size;
+				break;
+			case 'font':
+				fonts.count++;
+				fonts.totalBytes += size;
+				break;
+		}
+	}
+
+	// Add the document itself to page weight
+	if ( nav ) {
+		pageWeightBytes += getSize( nav );
+	}
+
+	return {
+		ttfb: Math.round( ttfb ),
+		fcp: Math.round( audit.fcpValue ),
+		lcp: Math.round( audit.lcpValue ),
+		cls: Math.round( audit.clsValue * 1000 ) / 1000,
+		domElements: document.querySelectorAll( '*' ).length,
+		totalRequests: resources.length,
+		pageWeightBytes,
+		scripts,
+		stylesheets,
+		images,
+		fonts,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+const AUDIT_VIEWPORT = { width: 1040, height: 1248 };
+
+/** Extra wait after networkidle for late LCP candidates and layout shifts. */
+const POST_LOAD_DELAY_MS = 2000;
+
+export async function auditPerformance( siteUrl: string, urlPath = '/' ): Promise< AuditResult > {
+	const targetUrl = `${ siteUrl.replace( /\/+$/, '' ) }${ urlPath }`;
+	const isAdminPath = urlPath.startsWith( '/wp-admin' );
+
+	try {
+		const browser = await getSharedBrowser();
+		const page = await browser.newPage( {
+			viewport: AUDIT_VIEWPORT,
+			ignoreHTTPSErrors: true,
+		} );
+
+		try {
+			// Inject observers before any navigation so FCP/LCP/CLS are captured from the start.
+			await page.addInitScript( observerSetupScript );
+
+			// For admin paths, go through auto-login first.
+			if ( isAdminPath ) {
+				const loginUrl = `${ siteUrl.replace(
+					/\/+$/,
+					''
+				) }/studio-auto-login?redirect_to=${ encodeURIComponent( urlPath ) }`;
+				await page.goto( loginUrl, { waitUntil: 'networkidle', timeout: 30_000 } );
+			} else {
+				await page.goto( targetUrl, { waitUntil: 'networkidle', timeout: 30_000 } );
+			}
+
+			// Wait for late LCP candidates and layout shifts to settle.
+			await page.waitForTimeout( POST_LOAD_DELAY_MS );
+
+			const metrics = await page.evaluate( collectMetricsScript );
+
+			return {
+				url: targetUrl,
+				timestamp: new Date().toISOString(),
+				metrics,
+			};
+		} finally {
+			await page.close();
+		}
+	} catch ( error ) {
+		return {
+			url: targetUrl,
+			timestamp: new Date().toISOString(),
+			metrics: null,
+			error: error instanceof Error ? error.message : String( error ),
+		};
+	}
+}

--- a/apps/cli/ai/plugin/skills/audit/SKILL.md
+++ b/apps/cli/ai/plugin/skills/audit/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: audit
+name: need-for-speed
 description: Run a frontend performance audit on a WordPress site and get actionable optimization recommendations.
 user-invokable: true
 ---

--- a/apps/cli/ai/plugin/skills/audit/SKILL.md
+++ b/apps/cli/ai/plugin/skills/audit/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: audit
+description: Run a frontend performance audit on a WordPress site and get actionable optimization recommendations.
+user-invokable: true
+---
+
+# Performance Audit
+
+Run a performance audit on a WordPress site to measure Core Web Vitals and page composition, then provide actionable recommendations.
+
+## How to Run
+
+1. Determine which site to audit. If the user hasn't specified, ask them or use the site from the current context.
+2. Ensure the site is running (use `site_start` if needed).
+3. Call `audit_performance` with the site name and path (defaults to `/`).
+4. Analyze the results using the interpretation guide below.
+5. Present a clear summary with specific, actionable recommendations.
+
+## Interpreting Results
+
+### Core Web Vitals Thresholds
+
+| Metric | Good | Needs Improvement | Poor |
+|--------|------|-------------------|------|
+| TTFB | < 800 ms | 800–1800 ms | > 1800 ms |
+| FCP | < 1800 ms | 1800–3000 ms | > 3000 ms |
+| LCP | < 2500 ms | 2500–4000 ms | > 4000 ms |
+| CLS | < 0.1 | 0.1–0.25 | > 0.25 |
+
+### Page Composition Benchmarks
+
+- **DOM elements**: Concern if > 1500
+- **Total page weight**: Concern if > 3 MB
+- **Total requests**: Concern if > 80
+- **Scripts**: Concern if > 20 scripts or > 500 KB total
+- **Stylesheets**: Concern if > 10 stylesheets or > 200 KB total
+
+## Common WordPress Recommendations
+
+Based on the metrics, suggest specific actions:
+
+- **High TTFB**: Enable page caching (e.g., `wp_cli: plugin install wp-super-cache --activate`), check for slow database queries, consider object caching.
+- **High LCP / FCP**: Check for render-blocking CSS/JS, add lazy loading for below-the-fold images, defer non-critical scripts.
+- **Large JS payload**: Identify heavy plugins from the scripts URL list, suggest deactivating unused plugins, check for jQuery dependency chains.
+- **Large CSS payload**: Look for unused theme stylesheets, check for multiple Google Fonts loads.
+- **Many HTTP requests**: Suggest reducing plugin count, enabling asset concatenation.
+- **High CLS**: Check for images without explicit width/height dimensions, ads or dynamic content injection, web fonts causing layout shifts.
+- **Large DOM**: Check theme template complexity, excessive nesting in block content, too many wrapper elements.
+
+## Important Notes
+
+- These are **synthetic measurements on a local dev server**. TTFB will be artificially low compared to production. Focus on relative comparisons (before/after changes) rather than absolute values.
+- CLS is measured during page load only, not during user interaction.
+- INP (Interaction to Next Paint) is not measured — it requires real user interaction patterns.
+- Page weight may undercount if some resources report 0 transfer size (e.g., service worker cached resources).

--- a/apps/cli/ai/slash-commands.ts
+++ b/apps/cli/ai/slash-commands.ts
@@ -22,5 +22,5 @@ export const AI_CHAT_SLASH_COMMANDS: SlashCommandDef[] = [
 	{ name: 'provider', description: __( 'Switch the AI provider' ) },
 	{ name: 'exit', description: __( 'Exit the chat' ) },
 	{ name: 'taxonomist', description: __( 'Optimize category taxonomy with AI' ) },
-	{ name: 'audit', description: __( 'Run a performance audit on a site' ) },
+	{ name: 'need-for-speed', description: __( 'Run a performance audit on a site' ) },
 ];

--- a/apps/cli/ai/slash-commands.ts
+++ b/apps/cli/ai/slash-commands.ts
@@ -22,4 +22,5 @@ export const AI_CHAT_SLASH_COMMANDS: SlashCommandDef[] = [
 	{ name: 'provider', description: __( 'Switch the AI provider' ) },
 	{ name: 'exit', description: __( 'Exit the chat' ) },
 	{ name: 'taxonomist', description: __( 'Optimize category taxonomy with AI' ) },
+	{ name: 'audit', description: __( 'Run a performance audit on a site' ) },
 ];

--- a/apps/cli/ai/system-prompt.ts
+++ b/apps/cli/ai/system-prompt.ts
@@ -41,6 +41,7 @@ Then continue with:
 - wp_cli: Run WP-CLI commands on a running site
 - validate_blocks: Validate block content for correctness on a running site (runs each block through its save() function in a real browser). Requires a site name or path. Call after every file write/edit that contains block content.
 - take_screenshot: Take a full-page screenshot of a URL (supports desktop and mobile viewports). Use this to visually check the site after building it.
+- audit_performance: Measure frontend performance metrics (TTFB, FCP, LCP, CLS, page weight, DOM size, JS/CSS/image/font asset breakdown) for a running site. Use this to identify performance bottlenecks and guide optimization.
 
 ## General rules
 

--- a/apps/cli/ai/tools.ts
+++ b/apps/cli/ai/tools.ts
@@ -5,6 +5,7 @@ import { DEFAULT_PHP_VERSION } from '@studio/common/constants';
 import { z } from 'zod/v4';
 import { validateBlocks, type ValidationReport } from 'cli/ai/block-validator';
 import { getSharedBrowser } from 'cli/ai/browser-utils';
+import { auditPerformance } from 'cli/ai/performance-audit';
 import { runCommand as runCreatePreviewCommand } from 'cli/commands/preview/create';
 import {
 	Mode as PreviewDeleteMode,
@@ -720,6 +721,46 @@ const installTaxonomyScriptsTool = tool(
 	}
 );
 
+const auditPerformanceTool = tool(
+	'audit_performance',
+	'Measures frontend performance metrics for a WordPress site page. Returns Core Web Vitals ' +
+		'(TTFB, FCP, LCP, CLS), page weight, DOM size, request count, and a breakdown of JS, CSS, ' +
+		'image, and font assets. The site must be running. Use this to identify performance issues.',
+	{
+		nameOrPath: z
+			.string()
+			.describe( 'The site name or file system path — the site must be running' ),
+		path: z
+			.string()
+			.optional()
+			.describe( 'URL path to audit (e.g., "/", "/about", "/wp-admin/"). Defaults to "/".' ),
+	},
+	async ( args ) => {
+		try {
+			const site = await resolveSite( args.nameOrPath );
+			const siteUrl = getSiteUrl( site );
+			const urlPath = args.path ?? '/';
+
+			emitProgress( `Auditing performance of ${ siteUrl }${ urlPath }…` );
+
+			const result = await auditPerformance( siteUrl, urlPath );
+
+			if ( result.error ) {
+				emitProgress( `Audit failed: ${ result.error.slice( 0, 80 ) }` );
+				return errorResult( `Performance audit failed: ${ result.error }` );
+			}
+
+			emitProgress( `Audit complete for ${ urlPath }` );
+
+			return textResult( JSON.stringify( result, null, 2 ) );
+		} catch ( error ) {
+			return errorResult(
+				`Performance audit failed: ${ error instanceof Error ? error.message : String( error ) }`
+			);
+		}
+	}
+);
+
 export const studioToolDefinitions = [
 	createSiteTool,
 	listSitesTool,
@@ -735,6 +776,7 @@ export const studioToolDefinitions = [
 	validateBlocksTool,
 	takeScreenshotTool,
 	installTaxonomyScriptsTool,
+	auditPerformanceTool,
 ];
 
 export function createStudioTools() {


### PR DESCRIPTION
## Related issues

Related STU-1482

## How AI was used in this PR

This PR was authored with AI assistance. All code has been reviewed for correctness, type safety, and adherence to existing patterns.

## Proposed Changes

- Add `audit_performance` MCP tool that measures Core Web Vitals (TTFB, FCP, LCP, CLS), page weight, DOM size, request count, and JS/CSS/image/font asset breakdowns for running WordPress sites
- Add `/need-for-speed` skill (SKILL.md) that guides the AI agent to interpret results against Web Vitals thresholds and provide WordPress-specific optimization recommendations
- Add `/need-for-speed` to the slash command autocomplete list
- Uses the existing shared Playwright browser and Performance API — no new dependencies

## Testing Instructions

- Run `npm run cli:build`
- Start a local site: `studio site start <site-name>`
- Run `studio ai` and type `/need-for-speed` — verify it appears in autocomplete
- The AI should audit the site's homepage and return performance metrics with recommendations

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?