### PR TITLE
Remove Claude Code auth provider from AI command

### DIFF
--- a/apps/cli/ai/providers.ts
+++ b/apps/cli/ai/providers.ts
@@ -1,4 +1,3 @@
-import childProcess from 'child_process';
 import { password } from '@inquirer/prompts';
 import { readAuthToken } from '@studio/common/lib/shared-config';
 import { __ } from '@wordpress/i18n';
@@ -7,18 +6,13 @@ import { LoggerError } from 'cli/logger';
 
 export const AI_PROVIDERS = {
 	wpcom: 'WordPress.com',
-	'anthropic-claude': 'Anthropic · Claude auth',
 	'anthropic-api-key': 'Anthropic · API key',
 } as const;
 
 export type AiProviderId = keyof typeof AI_PROVIDERS;
 
 export const DEFAULT_AI_PROVIDER: AiProviderId = 'wpcom';
-export const AI_PROVIDER_PRIORITY: AiProviderId[] = [
-	'wpcom',
-	'anthropic-claude',
-	'anthropic-api-key',
-];
+export const AI_PROVIDER_PRIORITY: AiProviderId[] = [ 'wpcom', 'anthropic-api-key' ];
 
 const DEFAULT_WPCOM_AI_GATEWAY_BASE_URL = 'https://public-api.wordpress.com/wpcom/v2/ai-api-proxy';
 const WPCOM_AI_FEATURE_HEADER = 'studio-assistant-anthropic';
@@ -30,21 +24,6 @@ export interface AiProviderDefinition {
 	isReady: () => Promise< boolean >;
 	prepare: ( options?: { force?: boolean } ) => Promise< void >;
 	resolveEnv: () => Promise< Record< string, string > >;
-}
-
-export function hasClaudeCodeAuth(): boolean {
-	try {
-		const output = childProcess.execFileSync( 'claude', [ 'auth', 'status' ], {
-			encoding: 'utf8',
-			timeout: 5000,
-			stdio: [ 'pipe', 'pipe', 'pipe' ],
-		} );
-		return (
-			output.toLowerCase().includes( 'authenticated' ) || ! output.toLowerCase().includes( 'not' )
-		);
-	} catch {
-		return false;
-	}
 }
 
 async function resolveAnthropicApiKey( options?: {
@@ -124,30 +103,6 @@ const AI_PROVIDER_DEFINITIONS: Record< AiProviderId, AiProviderDefinition > = {
 			} );
 			env.CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS = '1';
 			return env;
-		},
-	},
-	'anthropic-claude': {
-		id: 'anthropic-claude',
-		autoFallbackWhenUnavailable: true,
-		isVisible: async () => hasClaudeCodeAuth(),
-		isReady: async () => hasClaudeCodeAuth(),
-		prepare: async () => {
-			if ( hasClaudeCodeAuth() ) {
-				return;
-			}
-
-			throw new LoggerError(
-				__( 'Claude auth is not available. Choose another provider with /provider.' )
-			);
-		},
-		resolveEnv: async () => {
-			if ( ! hasClaudeCodeAuth() ) {
-				throw new LoggerError(
-					__( 'Claude auth is not available. Choose another provider with /provider.' )
-				);
-			}
-
-			return createBaseEnvironment();
 		},
 	},
 	'anthropic-api-key': {

--- a/apps/cli/ai/tests/auth.test.ts
+++ b/apps/cli/ai/tests/auth.test.ts
@@ -1,4 +1,3 @@
-import childProcess from 'child_process';
 import { password } from '@inquirer/prompts';
 import { readAuthToken } from '@studio/common/lib/shared-config';
 import { vi } from 'vitest';
@@ -12,13 +11,6 @@ import {
 } from 'cli/ai/auth';
 import { readCliConfig, updateCliConfigWithPartial } from 'cli/lib/cli-config/core';
 import { LoggerError } from 'cli/logger';
-
-vi.mock( 'child_process', () => ( {
-	default: {
-		execFileSync: vi.fn(),
-	},
-	execFileSync: vi.fn(),
-} ) );
 
 vi.mock( '@inquirer/prompts', () => ( {
 	password: vi.fn(),
@@ -65,15 +57,6 @@ describe( 'AI auth helpers', () => {
 		expect( password ).not.toHaveBeenCalled();
 	} );
 
-	it( 'uses Claude auth when the Claude auth provider is selected', async () => {
-		vi.mocked( childProcess.execFileSync ).mockReturnValue( 'Authenticated' as never );
-
-		const env = await resolveAiEnvironment( 'anthropic-claude' );
-
-		expect( env.ANTHROPIC_API_KEY ).toBeUndefined();
-		expect( password ).not.toHaveBeenCalled();
-	} );
-
 	it( 'prompts for the API key immediately when preparing the API key provider', async () => {
 		vi.mocked( readCliConfig ).mockResolvedValue( { version: 1, sites: [], snapshots: [] } );
 		vi.mocked( password ).mockResolvedValue( 'prompted-key' );
@@ -101,17 +84,7 @@ describe( 'AI auth helpers', () => {
 		expect( updateCliConfigWithPartial ).toHaveBeenCalledWith( { anthropicApiKey: 'updated-key' } );
 	} );
 
-	it( 'lists Claude auth only when it is available', async () => {
-		vi.mocked( childProcess.execFileSync ).mockReturnValue( 'Authenticated' as never );
-		await expect( getAvailableAiProviders() ).resolves.toEqual( [
-			'wpcom',
-			'anthropic-claude',
-			'anthropic-api-key',
-		] );
-
-		vi.mocked( childProcess.execFileSync ).mockImplementation( () => {
-			throw new Error( 'not authenticated' );
-		} );
+	it( 'lists available providers', async () => {
 		await expect( getAvailableAiProviders() ).resolves.toEqual( [ 'wpcom', 'anthropic-api-key' ] );
 	} );
 
@@ -149,34 +122,6 @@ describe( 'AI auth helpers', () => {
 		expect( readAuthToken ).not.toHaveBeenCalled();
 	} );
 
-	it( 'falls back to default provider when saved Claude auth is no longer available', async () => {
-		vi.mocked( readCliConfig ).mockResolvedValue( {
-			version: 1,
-			sites: [],
-			snapshots: [],
-			aiProvider: 'anthropic-claude',
-		} );
-		vi.mocked( readAuthToken ).mockResolvedValue( null );
-		vi.mocked( childProcess.execFileSync ).mockImplementation( () => {
-			throw new Error( 'not authenticated' );
-		} );
-
-		await expect( resolveInitialAiProvider() ).resolves.toBe( 'wpcom' );
-	} );
-
-	it( 'falls back from saved WP.com provider when WordPress.com auth is unavailable and Claude auth is ready', async () => {
-		vi.mocked( readCliConfig ).mockResolvedValue( {
-			version: 1,
-			sites: [],
-			snapshots: [],
-			aiProvider: 'wpcom',
-		} );
-		vi.mocked( readAuthToken ).mockResolvedValue( null );
-		vi.mocked( childProcess.execFileSync ).mockReturnValue( 'Authenticated' as never );
-
-		await expect( resolveInitialAiProvider() ).resolves.toBe( 'anthropic-claude' );
-	} );
-
 	it( 'defaults to WP.com when no provider is saved and a valid WP.com token exists', async () => {
 		vi.mocked( readCliConfig ).mockResolvedValue( { version: 1, sites: [], snapshots: [] } );
 		vi.mocked( readAuthToken ).mockResolvedValue( {
@@ -194,19 +139,8 @@ describe( 'AI auth helpers', () => {
 	it( 'falls back to default provider when no other auth is available', async () => {
 		vi.mocked( readCliConfig ).mockResolvedValue( { version: 1, sites: [], snapshots: [] } );
 		vi.mocked( readAuthToken ).mockResolvedValue( null );
-		vi.mocked( childProcess.execFileSync ).mockImplementation( () => {
-			throw new Error( 'not authenticated' );
-		} );
 
 		await expect( resolveInitialAiProvider() ).resolves.toBe( 'wpcom' );
-	} );
-
-	it( 'defaults to Claude auth when no provider is saved and Claude auth is available', async () => {
-		vi.mocked( readCliConfig ).mockResolvedValue( { version: 1, sites: [], snapshots: [] } );
-		vi.mocked( readAuthToken ).mockResolvedValue( null );
-		vi.mocked( childProcess.execFileSync ).mockReturnValue( 'Authenticated' as never );
-
-		await expect( resolveInitialAiProvider() ).resolves.toBe( 'anthropic-claude' );
 	} );
 
 	it( 'reports WordPress.com readiness based on WP.com auth state', async () => {

--- a/apps/cli/lib/cli-config/core.ts
+++ b/apps/cli/lib/cli-config/core.ts
@@ -28,7 +28,7 @@ const CLI_CONFIG_VERSION = 1;
 
 // IMPORTANT: Always consider that independently installed versions of the CLI (from npm) may also
 // read this file, and any updates to this schema may require updating the `version` field.
-export const aiProviderSchema = z.enum( [ 'wpcom', 'anthropic-claude', 'anthropic-api-key' ] );
+export const aiProviderSchema = z.enum( [ 'wpcom', 'anthropic-api-key' ] );
 
 const cliConfigSchema = z.object( {
 	version: z.literal( CLI_CONFIG_VERSION ),


### PR DESCRIPTION
## Related issues

Closes STU-1448 

## How AI was used in this PR

Claude Code authored the changes. All modifications were reviewed and verified with typecheck and tests.

## Proposed Changes

- Remove the `anthropic-claude` provider definition, the `hasClaudeCodeAuth()` function, and the `child_process` import from `apps/cli/ai/providers.ts`
- Remove `anthropic-claude` from the config schema enum in `apps/cli/lib/cli-config/core.ts`
- Remove Claude-auth-specific tests and the `child_process` mock from `apps/cli/ai/tests/auth.test.ts`

## Testing Instructions

- Run `npm run typecheck` — passes cleanly
- Run `npm test -- apps/cli/ai/tests/auth.test.ts` — all 11 tests pass
- Start the AI command and verify `/provider` only shows WordPress.com and Anthropic · API key

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?