### PR TITLE
Add /preview slash command to push active site to WordPress.com

### DIFF
--- a/apps/cli/ai/slash-commands.ts
+++ b/apps/cli/ai/slash-commands.ts
@@ -11,6 +11,7 @@ export const AI_CHAT_LOGIN_COMMAND = '/login';
 export const AI_CHAT_LOGOUT_COMMAND = '/logout';
 export const AI_CHAT_MODEL_COMMAND = '/model';
 export const AI_CHAT_PROVIDER_COMMAND = '/provider';
+export const AI_CHAT_PREVIEW_COMMAND = '/preview';
 export const AI_CHAT_EXIT_COMMAND = '/exit';
 
 export const AI_CHAT_SLASH_COMMANDS: SlashCommandDef[] = [
@@ -20,6 +21,7 @@ export const AI_CHAT_SLASH_COMMANDS: SlashCommandDef[] = [
 	{ name: 'logout', description: __( 'Log out of WordPress.com' ) },
 	{ name: 'model', description: __( 'Switch the AI model' ) },
 	{ name: 'provider', description: __( 'Switch the AI provider' ) },
+	{ name: 'preview', description: __( 'Push the active site to WordPress.com as a preview' ) },
 	{ name: 'exit', description: __( 'Exit the chat' ) },
 	{ name: 'taxonomist', description: __( 'Optimize category taxonomy with AI' ) },
 	{ name: 'need-for-speed', description: __( 'Run a performance audit on a site' ) },

--- a/apps/cli/ai/tools.ts
+++ b/apps/cli/ai/tools.ts
@@ -168,7 +168,7 @@ async function captureConsoleOutput( fn: () => Promise< void > ): Promise< strin
 	return captured.trim();
 }
 
-async function captureCommandOutput( fn: () => Promise< void > ): Promise< {
+export async function captureCommandOutput( fn: () => Promise< void > ): Promise< {
 	consoleOutput: string;
 	progressOutput: string;
 	exitCode: number | undefined;

--- a/apps/cli/ai/ui.ts
+++ b/apps/cli/ai/ui.ts
@@ -1603,7 +1603,7 @@ export class AiChatUI {
 	}
 
 	showProgress( message: string ): void {
-		this.messages.addChild( new Text( '\n ' + chalk.yellow( '⏺' ) + ' ' + message + '\n', 0, 0 ) );
+		this.messages.addChild( new Text( '\n ' + '⏺' + ' ' + message + '\n', 0, 0 ) );
 		this.tui.requestRender();
 	}
 

--- a/apps/cli/ai/ui.ts
+++ b/apps/cli/ai/ui.ts
@@ -79,6 +79,7 @@ class PromptEditor implements Component, Focusable {
 	private _focused = false;
 	private isEmpty = true;
 	activeSiteName: string | null = null;
+	busyMessage: string | null = null;
 	hints: string[] = [];
 	statusMessage: string | null = null;
 	showBottomBar = true;
@@ -146,11 +147,13 @@ class PromptEditor implements Component, Focusable {
 		const emptyPrefix = ' '.repeat( promptWidth );
 		const result = editorLines.map( ( line, i ) => {
 			if ( i === 0 ) {
-				// Top border with active site name on the right
+				// Top border with active site name and optional busy indicator
 				if ( this.activeSiteName && borderWidth > 4 ) {
-					const label = ` ${ this.activeSiteName } `;
+					const busySuffix = this.busyMessage ? ` ${ this.busyMessage }` : '';
+					const label = ` ${ this.activeSiteName }${ busySuffix } `;
 					const trailing = Math.min( 3, borderWidth );
-					const leading = Math.max( 0, borderWidth - label.length - trailing );
+					const labelWidth = visibleWidth( label );
+					const leading = Math.max( 0, borderWidth - labelWidth - trailing );
 					return (
 						' ' +
 						bc( '─'.repeat( leading ) ) +
@@ -1599,9 +1602,39 @@ export class AiChatUI {
 		this.tui.requestRender();
 	}
 
+	showProgress( message: string ): void {
+		this.messages.addChild( new Text( '\n ' + chalk.yellow( '⏺' ) + ' ' + message + '\n', 0, 0 ) );
+		this.tui.requestRender();
+	}
+
 	setStatusMessage( message: string | null ): void {
 		this.editor.statusMessage = message;
 		this.tui.requestRender();
+	}
+
+	private busyTimer: ReturnType< typeof setInterval > | null = null;
+	private busyFrameIndex = 0;
+	private static readonly BUSY_FRAMES = [ '⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏' ];
+
+	setBusy( active: boolean ): void {
+		if ( this.busyTimer ) {
+			clearInterval( this.busyTimer );
+			this.busyTimer = null;
+		}
+
+		if ( active ) {
+			this.busyFrameIndex = 0;
+			this.editor.busyMessage = AiChatUI.BUSY_FRAMES[ 0 ];
+			this.tui.requestRender();
+			this.busyTimer = setInterval( () => {
+				this.busyFrameIndex = ( this.busyFrameIndex + 1 ) % AiChatUI.BUSY_FRAMES.length;
+				this.editor.busyMessage = AiChatUI.BUSY_FRAMES[ this.busyFrameIndex ];
+				this.tui.requestRender();
+			}, 80 );
+		} else {
+			this.editor.busyMessage = null;
+			this.tui.requestRender();
+		}
 	}
 
 	private showFilePreview( toolName: string, input: Record< string, unknown > ): void {

--- a/apps/cli/commands/ai/index.ts
+++ b/apps/cli/commands/ai/index.ts
@@ -429,8 +429,8 @@ export async function runCommand(
 					const isUpdate = Boolean( activeSnapshot );
 					ui.showProgress(
 						isUpdate
-							? __( 'Updating preview site… this may take a few minutes.' )
-							: __( 'Creating preview site… this may take a few minutes.' )
+							? __( 'Updating preview site… this may take a moment.' )
+							: __( 'Creating preview site… this may take a moment.' )
 					);
 					ui.setBusy( true );
 
@@ -450,13 +450,8 @@ export async function runCommand(
 						const updated = await getSnapshotsFromConfig( token.id, site.path );
 						const latest = updated.find( ( s ) => ! isSnapshotExpired( s ) );
 						if ( latest ) {
-							ui.showSuccess(
-								sprintf(
-									/* translators: %s: preview site URL */
-									__( 'Preview site ready: https://%s' ),
-									latest.url
-								)
-							);
+							const previewUrl = `https://${ latest.url }`;
+							ui.showSuccess( __( 'Preview site ready!' ) + '\n\n   ' + previewUrl );
 						} else {
 							ui.showInfo( result.consoleOutput || __( 'Preview command completed.' ) );
 						}

--- a/apps/cli/commands/ai/index.ts
+++ b/apps/cli/commands/ai/index.ts
@@ -28,12 +28,17 @@ import {
 	AI_CHAT_LOGIN_COMMAND,
 	AI_CHAT_LOGOUT_COMMAND,
 	AI_CHAT_MODEL_COMMAND,
+	AI_CHAT_PREVIEW_COMMAND,
 	AI_CHAT_PROVIDER_COMMAND,
 } from 'cli/ai/slash-commands';
+import { captureCommandOutput } from 'cli/ai/tools';
 import { AiChatUI } from 'cli/ai/ui';
 import { runCommand as runLoginCommand } from 'cli/commands/auth/login';
 import { runCommand as runLogoutCommand } from 'cli/commands/auth/logout';
+import { runCommand as runCreatePreviewCommand } from 'cli/commands/preview/create';
+import { runCommand as runUpdatePreviewCommand } from 'cli/commands/preview/update';
 import { readCliConfig } from 'cli/lib/cli-config/core';
+import { getSnapshotsFromConfig, isSnapshotExpired } from 'cli/lib/snapshots';
 import { Logger, LoggerError, setProgressCallback } from 'cli/logger';
 import { StudioArgv } from 'cli/types';
 
@@ -400,6 +405,69 @@ export async function runCommand(
 				const opened = await ui.openActiveSiteInBrowser();
 				if ( ! opened ) {
 					ui.showInfo( __( 'No site selected. Use ↓ to select a site first.' ) );
+				}
+				continue;
+			}
+
+			if ( trimmedPrompt === AI_CHAT_PREVIEW_COMMAND ) {
+				const site = ui.activeSite;
+				if ( ! site ) {
+					ui.showInfo( __( 'No site selected. Use ↓ to select a site first.' ) );
+					continue;
+				}
+
+				const token = await readAuthToken();
+				if ( ! token ) {
+					ui.showInfo( __( 'WordPress.com login required. Use /login to authenticate.' ) );
+					continue;
+				}
+
+				try {
+					const snapshots = await getSnapshotsFromConfig( token.id, site.path );
+					const activeSnapshot = snapshots.find( ( s ) => ! isSnapshotExpired( s ) );
+
+					const isUpdate = Boolean( activeSnapshot );
+					ui.showProgress(
+						isUpdate
+							? __( 'Updating preview site… this may take a few minutes.' )
+							: __( 'Creating preview site… this may take a few minutes.' )
+					);
+					ui.setBusy( true );
+
+					const result = await captureCommandOutput( async () => {
+						if ( activeSnapshot ) {
+							await runUpdatePreviewCommand( site.path, activeSnapshot.url, false );
+						} else {
+							await runCreatePreviewCommand( site.path );
+						}
+					} );
+
+					ui.setBusy( false );
+
+					if ( result.exitCode ) {
+						ui.showError( result.consoleOutput || __( 'Failed to create preview site.' ) );
+					} else {
+						const updated = await getSnapshotsFromConfig( token.id, site.path );
+						const latest = updated.find( ( s ) => ! isSnapshotExpired( s ) );
+						if ( latest ) {
+							ui.showSuccess(
+								sprintf(
+									/* translators: %s: preview site URL */
+									__( 'Preview site ready: https://%s' ),
+									latest.url
+								)
+							);
+						} else {
+							ui.showInfo( result.consoleOutput || __( 'Preview command completed.' ) );
+						}
+					}
+				} catch ( error ) {
+					ui.setBusy( false );
+					if ( error instanceof LoggerError ) {
+						ui.showError( error.message );
+					} else {
+						ui.showError( __( 'Failed to create preview site.' ) );
+					}
 				}
 				continue;
 			}


### PR DESCRIPTION
Adds a /preview command that creates or updates a WordPress.com preview site for the currently selected local site. Automatically detects existing non-expired previews and updates them instead of creating duplicates.

Also adds a busy spinner indicator in the prompt border next to the site name, a yellow-dot progress message style, and a green-dot success message style to the UI.

<img width="1206" height="202" alt="image" src="https://github.com/user-attachments/assets/e9ee2cb0-bcfa-4165-9a39-57125afefa89" />
