### PR TITLE
Set WP_SQLITE_AST_DRIVER constant when running wp CLI commands without running server

### DIFF
--- a/apps/cli/lib/run-wp-cli-command.ts
+++ b/apps/cli/lib/run-wp-cli-command.ts
@@ -61,6 +61,8 @@ export async function runWpCliCommand(
 	try {
 		await php.setSapiName( 'cli' );
 
+		php.defineConstant( 'WP_SQLITE_AST_DRIVER', true );
+
 		php.mkdir( '/wordpress' );
 		await php.mount( '/wordpress', createNodeFsMountHandler( siteFolder ) );
 


### PR DESCRIPTION
## Related issues

- N/A

## How AI was used in this PR

I debugged the SQLite plugin issue popping up in Studio CLI when running `wp` command and identified an issue. Then, used Claude Code to implement the fix.

## Proposed Changes

- Set `WP_SQLITE_AST_DRIVER: true` in `runWpCliCommand()` via `php.defineConstant()` to match what the WordPress server sets via blueprint constants on startup

When a Studio site server is running, `wp` CLI commands are forwarded to the already-running playground instance which has `WP_SQLITE_AST_DRIVER: true` active (set via blueprint constants in `wordpress-server-child.ts`). When no server is running, `runWpCliCommand` spawns a fresh PHP-WASM instance without a blueprint - so the constant was never set, causing the SQLite AST driver to be skipped.

## Testing Instructions

1. Stop any running Studio server for a local site
2. Run a `wp` CLI command against that site: `node apps/cli/dist/cli/main.mjs wp plugin list --path=<site-path>`
3. Confirm the command succeeds

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?
