### PR TITLE
Batch site running status checks in site picker

### DIFF
--- a/apps/cli/ai/ui.ts
+++ b/apps/cli/ai/ui.ts
@@ -34,7 +34,7 @@ import { getWpComSites } from 'cli/lib/api';
 import { openBrowser } from 'cli/lib/browser';
 import { readCliConfig, type SiteData } from 'cli/lib/cli-config/core';
 import { getSiteUrl } from 'cli/lib/cli-config/sites';
-import { isSiteRunning } from 'cli/lib/site-utils';
+import { getSitesRunningStatus, isSiteRunning } from 'cli/lib/site-utils';
 import type { SDKMessage } from '@anthropic-ai/claude-agent-sdk';
 import type { TodoWriteInput } from '@anthropic-ai/claude-agent-sdk/sdk-tools';
 
@@ -790,13 +790,12 @@ export class AiChatUI {
 		}
 
 		this.sitePickerSiteData = sites;
-		this.sitePickerItems = await Promise.all(
-			sites.map( async ( site ) => ( {
-				name: site.name,
-				path: site.path,
-				running: await isSiteRunning( site ),
-			} ) )
-		);
+		const runningStatus = await getSitesRunningStatus( sites );
+		this.sitePickerItems = sites.map( ( site ) => ( {
+			name: site.name,
+			path: site.path,
+			running: runningStatus.get( site.id ) ?? false,
+		} ) );
 		this.sitePickerVisible = true;
 		this.editor.showBottomBar = false;
 		this.sitePickerContainer = new Container();

--- a/apps/cli/commands/site/tests/list.test.ts
+++ b/apps/cli/commands/site/tests/list.test.ts
@@ -1,6 +1,6 @@
 import { vi } from 'vitest';
 import { readCliConfig } from 'cli/lib/cli-config/core';
-import { connectToDaemon, disconnectFromDaemon } from 'cli/lib/daemon-client';
+import { connectToDaemon, disconnectFromDaemon, listProcesses } from 'cli/lib/daemon-client';
 import { isServerRunning } from 'cli/lib/wordpress-server-manager';
 import { mockReportKeyValuePair } from 'cli/tests/test-utils';
 import { runCommand } from '../list';
@@ -63,6 +63,7 @@ describe( 'CLI: studio site list', () => {
 		vi.mocked( connectToDaemon ).mockResolvedValue( undefined );
 		vi.mocked( disconnectFromDaemon ).mockResolvedValue( undefined );
 		vi.mocked( isServerRunning ).mockResolvedValue( undefined );
+		vi.mocked( listProcesses ).mockResolvedValue( [] );
 	} );
 
 	afterEach( () => {

--- a/apps/cli/lib/daemon-client.ts
+++ b/apps/cli/lib/daemon-client.ts
@@ -245,7 +245,7 @@ const daemonListProcessesSuccessResponseSchema = z.object( {
 
 // Cache the process list returned from the process manager for a very short time to make multiple
 // calls in quick succession more efficient
-async function listProcesses() {
+export async function listProcesses() {
 	await connectToDaemon();
 	const response = await sendDaemonRequest( {
 		type: 'list-processes',

--- a/apps/cli/lib/site-utils.ts
+++ b/apps/cli/lib/site-utils.ts
@@ -5,9 +5,14 @@ import { openBrowser } from 'cli/lib/browser';
 import { generateSiteCertificate } from 'cli/lib/certificate-manager';
 import { readCliConfig, SiteData } from 'cli/lib/cli-config/core';
 import { getSiteUrl } from 'cli/lib/cli-config/sites';
-import { isProxyProcessRunning, startProxyProcess, stopProxyProcess } from 'cli/lib/daemon-client';
+import {
+	isProxyProcessRunning,
+	listProcesses,
+	startProxyProcess,
+	stopProxyProcess,
+} from 'cli/lib/daemon-client';
 import { addDomainToHosts } from 'cli/lib/hosts-file';
-import { isServerRunning } from 'cli/lib/wordpress-server-manager';
+import { isServerRunning, SITE_PROCESS_PREFIX } from 'cli/lib/wordpress-server-manager';
 import { Logger, LoggerError } from 'cli/logger';
 
 /**
@@ -130,3 +135,37 @@ export const isSiteRunning = async ( site: SiteData ): Promise< boolean > => {
 		processInfo.pid === site.latestCliPid
 	);
 };
+
+/**
+ * Check running status for multiple sites with a single daemon call.
+ */
+export async function getSitesRunningStatus(
+	sites: SiteData[]
+): Promise< Map< string, boolean > > {
+	const result = new Map< string, boolean >();
+
+	let processes: Awaited< ReturnType< typeof listProcesses > > = [];
+	try {
+		processes = await listProcesses();
+	} catch {
+		// Daemon not running — all sites are stopped.
+		for ( const site of sites ) {
+			result.set( site.id, false );
+		}
+		return result;
+	}
+
+	for ( const site of sites ) {
+		const processName = SITE_PROCESS_PREFIX + site.id;
+		const processInfo = processes.find( ( p ) => p.name === processName && p.status === 'online' );
+		const running = !! (
+			processInfo &&
+			'pid' in processInfo &&
+			site.latestCliPid !== undefined &&
+			processInfo.pid === site.latestCliPid
+		);
+		result.set( site.id, running );
+	}
+
+	return result;
+}

--- a/apps/cli/lib/site-utils.ts
+++ b/apps/cli/lib/site-utils.ts
@@ -127,13 +127,8 @@ export async function stopProxyIfNoSitesNeedIt(
 }
 
 export const isSiteRunning = async ( site: SiteData ): Promise< boolean > => {
-	const processInfo = await isServerRunning( site.id );
-	return !! (
-		processInfo &&
-		processInfo.status === 'online' &&
-		site.latestCliPid !== undefined &&
-		processInfo.pid === site.latestCliPid
-	);
+	const status = await getSitesRunningStatus( [ site ] );
+	return status.get( site.id ) ?? false;
 };
 
 /**


### PR DESCRIPTION
The site picker was making a separate daemon IPC round-trip for each site to check if it was running. With multiple sites this caused a noticeable delay when opening the picker.

Fetch the process list once with a single daemon call and resolve running status for all sites against it.