### PR TITLE
Fix pulling if there is no rewindId

### DIFF
--- a/apps/studio/src/modules/sync/components/sync-dialog.tsx
+++ b/apps/studio/src/modules/sync/components/sync-dialog.tsx
@@ -200,7 +200,7 @@ export function SyncDialog( {
 		syncToText = localSite.name;
 		tooltipNoRewindId = createInterpolateElement(
 			__(
-				'Selecting individual items to pull will be enabled automatically once your first backup is complete.<br/>Wait a few minutes or run a full sync in the meantime.'
+				'Your site is being prepared for syncing. This usually takes a few minutes — please try again shortly.'
 			),
 			{ br: <br /> }
 		);
@@ -475,19 +475,22 @@ export function SyncDialog( {
 								<Button variant="link" onClick={ onRequestClose }>
 									{ __( 'Cancel' ) }
 								</Button>
-								<Button
-									variant="primary"
-									onClick={ handleSubmit }
-									disabled={
-										isSubmitDisabled ||
-										isLoadingRewindId ||
-										isPushSelectionOverLimit ||
-										isSizeCheckLoading
-									}
-									data-testid={ `sync-dialog-${ type }-button` }
-								>
-									{ syncTexts.submit }
-								</Button>
+								<Tooltip text={ tooltipNoRewindId } disabled={ ! isErrorRewindId }>
+									<Button
+										variant="primary"
+										onClick={ handleSubmit }
+										disabled={
+											isSubmitDisabled ||
+											isLoadingRewindId ||
+											isErrorRewindId ||
+											isPushSelectionOverLimit ||
+											isSizeCheckLoading
+										}
+										data-testid={ `sync-dialog-${ type }-button` }
+									>
+										{ syncTexts.submit }
+									</Button>
+								</Tooltip>
 							</div>
 						</div>
 					</div>

--- a/apps/studio/src/modules/sync/components/sync-dialog.tsx
+++ b/apps/studio/src/modules/sync/components/sync-dialog.tsx
@@ -200,7 +200,7 @@ export function SyncDialog( {
 		syncToText = localSite.name;
 		tooltipNoRewindId = createInterpolateElement(
 			__(
-				'Your site is being prepared for syncing. This usually takes a few minutes — please try again shortly.'
+				'Selecting individual items to pull will be enabled automatically once your first backup is complete.<br/>Wait a few minutes or run a full sync in the meantime.'
 			),
 			{ br: <br /> }
 		);
@@ -257,9 +257,6 @@ export function SyncDialog( {
 
 	const handleSubmit = () => {
 		if ( type === 'pull' ) {
-			if ( ! rewindId ) {
-				return;
-			}
 			onPull( treeState );
 		} else {
 			onPush( treeState );
@@ -475,22 +472,20 @@ export function SyncDialog( {
 								<Button variant="link" onClick={ onRequestClose }>
 									{ __( 'Cancel' ) }
 								</Button>
-								<Tooltip text={ tooltipNoRewindId } disabled={ ! isErrorRewindId }>
-									<Button
-										variant="primary"
-										onClick={ handleSubmit }
-										disabled={
-											isSubmitDisabled ||
-											isLoadingRewindId ||
-											isErrorRewindId ||
-											isPushSelectionOverLimit ||
-											isSizeCheckLoading
-										}
-										data-testid={ `sync-dialog-${ type }-button` }
-									>
-										{ syncTexts.submit }
-									</Button>
-								</Tooltip>
+								<Button
+									variant="primary"
+									onClick={ handleSubmit }
+									disabled={
+										isSubmitDisabled ||
+										isLoadingRewindId ||
+										isErrorRewindId ||
+										isPushSelectionOverLimit ||
+										isSizeCheckLoading
+									}
+									data-testid={ `sync-dialog-${ type }-button` }
+								>
+									{ syncTexts.submit }
+								</Button>
 							</div>
 						</div>
 					</div>

--- a/apps/studio/src/modules/sync/components/sync-dialog.tsx
+++ b/apps/studio/src/modules/sync/components/sync-dialog.tsx
@@ -478,7 +478,6 @@ export function SyncDialog( {
 									disabled={
 										isSubmitDisabled ||
 										isLoadingRewindId ||
-										isErrorRewindId ||
 										isPushSelectionOverLimit ||
 										isSizeCheckLoading
 									}


### PR DESCRIPTION
Fixes STU-1517

## Proposed Changes
Follow up to https://github.com/Automattic/studio/pull/1672

The case from user - pfHvTO-19v-p2
The user had a site when they didn't have rewindId and they constantly clicked Pull button w/o any response from it.
With this PR we are fixing pulling if no rewindId.

## Testing Instructions
1. Sandbox your API
2. Add custom code to return an error in the /studio-app/sync/get-latest-rewind-id endpoint.
3. Run `npm start`
4. Go to the Sync tab
5. Connect a site
6. Click pull
7. Assert that it started