### PR TITLE
Update SQLite Database Integration to v2.2.22

### DIFF
--- a/apps/cli/lib/dependency-management/setup.ts
+++ b/apps/cli/lib/dependency-management/setup.ts
@@ -66,7 +66,10 @@ async function copyBundledSqlite() {
 	const isBundledVersionNewer =
 		installedSqliteVersion && semver.gt( bundledSqliteVersion, installedSqliteVersion );
 	if ( ! isSqliteInstalled || isBundledVersionNewer ) {
-		await recursiveCopyDirectory( bundledSqlitePath, getSqlitePluginPath() );
+		if ( isSqliteInstalled ) {
+			await fs.promises.rm( installedSqlitePath, { recursive: true, force: true } );
+		}
+		await recursiveCopyDirectory( bundledSqlitePath, installedSqlitePath );
 	}
 }
 

--- a/apps/studio/src/constants.ts
+++ b/apps/studio/src/constants.ts
@@ -75,9 +75,9 @@ export const WP_CLI_IMPORT_EXPORT_RESPONSE_TIMEOUT =
 	WP_CLI_IMPORT_EXPORT_RESPONSE_TIMEOUT_IN_HRS * 60 * 60 * 1000; // 6hr
 
 // SQLite
-const SQLITE_DATABASE_INTEGRATION_VERSION = 'v2.2.20';
+const SQLITE_DATABASE_INTEGRATION_VERSION = 'v2.2.22';
 
-export const SQLITE_DATABASE_INTEGRATION_RELEASE_URL = `https://github.com/WordPress/sqlite-database-integration/archive/refs/tags/${ SQLITE_DATABASE_INTEGRATION_VERSION }.zip`;
+export const SQLITE_DATABASE_INTEGRATION_RELEASE_URL = `https://github.com/WordPress/sqlite-database-integration/releases/download/${ SQLITE_DATABASE_INTEGRATION_VERSION }/plugin-sqlite-database-integration.zip`;
 
 // IPC handlers that don't return anything (i.e. that are called with `ipcRenderer.send`)
 export const IPC_VOID_HANDLERS = < const >[

--- a/scripts/download-wp-server-files.ts
+++ b/scripts/download-wp-server-files.ts
@@ -1,14 +1,14 @@
 import os from 'os';
 import path from 'path';
-import fs from 'fs-extra';
-import { extractZip } from '../tools/common/lib/extract-zip';
-import { getLatestSQLiteCommandRelease } from '../apps/studio/src/lib/sqlite-command-release';
-import { SQLITE_DATABASE_INTEGRATION_RELEASE_URL } from '../apps/studio/src/constants';
 import {
 	PHPMYADMIN_DOWNLOAD_URL,
 	PHPMYADMIN_VERSION,
 	getPhpMyAdminInstallSteps,
 } from '@wp-playground/tools';
+import fs from 'fs-extra';
+import { SQLITE_DATABASE_INTEGRATION_RELEASE_URL } from '../apps/studio/src/constants';
+import { getLatestSQLiteCommandRelease } from '../apps/studio/src/lib/sqlite-command-release';
+import { extractZip } from '../tools/common/lib/extract-zip';
 
 const WP_SERVER_FILES_PATH = path.join( __dirname, '..', 'wp-files' );
 
@@ -81,26 +81,19 @@ async function downloadFile( file: FileToDownload ): Promise< void > {
 		fs.moveSync( zipPath, path.join( extractedPath, 'wp-cli.phar' ), { overwrite: true } );
 	} else if ( name === 'sqlite' ) {
 		/**
-		 * The SQLite database integration plugin is extracted
-		 * into a folder with the version number like sqlite-database-integration-1.0.0
-		 * We need to move the contents of that folder to the sqlite-database-integration folder
+		 * The SQLite database integration plugin zip extracts into a folder named
+		 * plugin-sqlite-database-integration (CI-built asset format). We rename it
+		 * to sqlite-database-integration which is the name expected by the rest of the app.
 		 */
 		console.log( `[${ name }] Extracting files from zip ...` );
 		await extractZip( zipPath, extractedPath );
 
-		const files = fs.readdirSync( extractedPath );
-		const sqliteFolder = files.find( ( file ) =>
-			file.startsWith( 'sqlite-database-integration-' )
-		);
-
-		if ( sqliteFolder ) {
-			const sourcePath = path.join( extractedPath, sqliteFolder );
-			const targetPath = path.join( extractedPath, 'sqlite-database-integration' );
-			if ( fs.existsSync( targetPath ) ) {
-				fs.rmSync( targetPath, { recursive: true, force: true } );
-			}
-			fs.moveSync( sourcePath, targetPath );
+		const sourcePath = path.join( extractedPath, 'plugin-sqlite-database-integration' );
+		const targetPath = path.join( extractedPath, 'sqlite-database-integration' );
+		if ( fs.existsSync( targetPath ) ) {
+			fs.rmSync( targetPath, { recursive: true, force: true } );
 		}
+		fs.moveSync( sourcePath, targetPath );
 	} else if ( name === 'phpmyadmin' ) {
 		/**
 		 * phpMyAdmin is extracted into a folder like phpMyAdmin-5.2.3-english.
@@ -155,4 +148,4 @@ async function downloadFiles() {
 	}
 }
 
-downloadFiles();
+void downloadFiles();


### PR DESCRIPTION
## Related issues

- N/A

## How AI was used in this PR

Claude Code assisted with implementation.

## Proposed Changes

- Bump SQLite Database Integration version from v2.2.20 to v2.2.22
- Switch release download URL to the new CI-built asset format (`/releases/download/` instead of `/archive/refs/tags/`), which produces a zip with a `plugin-sqlite-database-integration` folder instead of a versioned `sqlite-database-integration-<version>` folder
- Update `download-wp-server-files.ts` to rename `plugin-sqlite-database-integration` → `sqlite-database-integration` on extraction
- Fix `copyBundledSqlite()` in `setup.ts` to remove the existing install directory before copying a newer version, preventing stale files from old releases from lingering

## Testing Instructions

- Run `npm install` — should download the new zip and extract it correctly to `wp-files/sqlite-database-integration`
- Run `npm run cli:build`
- Run `node apps/cli/dist/cli/main.mjs site list` — verify `~/.studio/server-files/sqlite-database-integration/load.php` now reports Version 2.2.22
- Verify no stale files remain from previous versions in the sqlite directory
- Start site, confirm the site and phpMyAdmin work fine

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?