### PR TITLE
Fix screenshot tool hanging on pages with lazy-loaded images

### DIFF
--- a/apps/cli/ai/tools.ts
+++ b/apps/cli/ai/tools.ts
@@ -639,9 +639,20 @@ const takeScreenshotTool = tool(
 
 				await page.goto( args.url, { waitUntil: 'networkidle', timeout: 15000 } );
 
-				// Wait for all images to finish loading
-				await page.evaluate( () =>
-					Promise.all(
+				// Scroll through the page to trigger lazy-loaded images, then wait
+				// for all images to finish loading.
+				await page.evaluate( async () => {
+					const delay = ( ms: number ) =>
+						new Promise< void >( ( resolve ) => setTimeout( resolve, ms ) );
+					const scrollHeight = document.body.scrollHeight;
+					const viewportHeight = window.innerHeight;
+					for ( let y = 0; y < scrollHeight; y += viewportHeight ) {
+						window.scrollTo( 0, y );
+						await delay( 100 );
+					}
+					window.scrollTo( 0, 0 );
+
+					await Promise.all(
 						Array.from( document.images )
 							.filter( ( img ) => ! img.complete )
 							.map(
@@ -651,8 +662,8 @@ const takeScreenshotTool = tool(
 										img.addEventListener( 'error', () => resolve() );
 									} )
 							)
-					)
-				);
+					);
+				} );
 
 				// Hide WordPress admin bar and scrollbars for cleaner screenshots
 				await page.addStyleTag( {


### PR DESCRIPTION
## Related issues

- Related to screenshot/validate_blocks tools timing out for some users

## How AI was used in this PR

Investigated the root cause of Playwright timeouts in AI tools. Debugging with `headless: false` revealed the browser was stuck waiting for lazy-loaded images that never load until scrolled into view.

## Proposed Changes

- Scroll through the full page before waiting for images to load, so that `loading="lazy"` images are triggered
- Scroll back to the top before capturing the screenshot
- This ensures `fullPage: true` screenshots include all images while not hanging indefinitely

## Testing Instructions

- Use the AI command's `take_screenshot` tool on a page with lazy-loaded images (most WordPress themes use them)
- Verify the screenshot completes without hanging and includes all images

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?