### PR TITLE
Clarify that Site Management refers to local sites in onboarding

### DIFF
--- a/apps/cli/ai/ui.ts
+++ b/apps/cli/ai/ui.ts
@@ -1455,18 +1455,18 @@ export class AiChatUI {
 				' ' +
 				__( "Great, you're connected now! Let me tell you what I can do:" ),
 			'',
-			'  ' + b( __( 'Site Management' ) ),
+			'  ' + b( __( 'Local Sites Management' ) ),
 			'',
 			'  - ' +
 				sprintf(
 					/* translators: %s: bold "Create" */
-					__( '%s new WordPress sites instantly (fully configured, ready to use)' ),
+					__( '%s new local WordPress sites instantly (fully configured, ready to use)' ),
 					b( __( 'Create' ) )
 				),
 			'  - ' +
 				sprintf(
 					/* translators: %s: bold "Start / stop" */
-					__( '%s existing sites' ),
+					__( '%s existing local sites' ),
 					b( __( 'Start / stop' ) )
 				),
 			'  - ' +


### PR DESCRIPTION
## Summary
- Rename 'Site Management' → 'Local Sites Management' in the onboarding capabilities list
- Add 'local' to clarify that site creation and start/stop refer to local WordPress sites
- Follows up on #2972