### PR TITLE
Update sync tooltip to use plan-agnostic language

### DIFF
--- a/apps/studio/src/modules/sync/components/sync-sites-modal-selector.tsx
+++ b/apps/studio/src/modules/sync/components/sync-sites-modal-selector.tsx
@@ -361,7 +361,7 @@ function SiteItem( {
 			{ needsUpgrade && (
 				<div className="a8c-body-small text-frame-text-secondary shrink-0 text-right">
 					<Tooltip
-						text={ __( 'Sync support is available only with Business plan and above' ) }
+						text={ __( 'Sync support is available on selected plans only' ) }
 						placement="bottom"
 					>
 						<Button


### PR DESCRIPTION
## Related issues

- STU-1516

## How AI was used in this PR

Claude Code was used to locate and update the tooltip string.

## Proposed Changes

I proposed updating the sync tooltip text from "Sync support is available only with Business plan and above" to "Sync support is available on selected plans only".

We are adding support for Sync to other plans, which is handled on the API side, so it would be great to avoid plan-related logic on the Studio side.

## Testing Instructions

- Open the sync sites modal selector
- Hover over the upgrade link for a site that needs a plan upgrade
- Verify the tooltip reads "Sync support is available on selected plans only"

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?