### PR TITLE
Generate SSL certificate eagerly when HTTPS is enabled

### DIFF
--- a/apps/cli/commands/site/set.ts
+++ b/apps/cli/commands/site/set.ts
@@ -16,6 +16,7 @@ import {
 } from '@studio/common/lib/wordpress-version-utils';
 import { SiteCommandLoggerAction as LoggerAction } from '@studio/common/logger-actions';
 import { __, sprintf } from '@wordpress/i18n';
+import { generateSiteCertificate } from 'cli/lib/certificate-manager';
 import {
 	lockCliConfig,
 	readCliConfig,
@@ -248,6 +249,12 @@ export async function runCommand( sitePath: string, options: SetCommandOptions )
 			logger.reportStart( LoggerAction.ADD_DOMAIN_TO_HOSTS, __( 'Updating hosts file…' ) );
 			await updateDomainInHosts( oldDomain, domain, site.port );
 			logger.reportSuccess( __( 'Hosts file updated' ) );
+		}
+
+		if ( httpsChanged && https && site.customDomain ) {
+			logger.reportStart( LoggerAction.GENERATE_CERT, __( 'Generating SSL certificates…' ) );
+			await generateSiteCertificate( site.customDomain );
+			logger.reportSuccess( __( 'SSL certificates generated' ) );
 		}
 
 		logger.reportStart( LoggerAction.START_DAEMON, __( 'Starting process daemon…' ) );


### PR DESCRIPTION
## Related issues

- Fixes STU-1476

## How AI was used in this PR

Claude Code was used to explore the codebase, identify the root cause, and implement the fix. The change was reviewed and validated by the author.

## Proposed Changes

- Generate the SSL certificate immediately when HTTPS is toggled on via `site set`, rather than deferring it to site start. Previously, `generateSiteCertificate` was only called inside `setupCustomDomain` during site restart, so enabling HTTPS on a stopped site would show the "Trust Certificate" nudge with no certificate file to trust.

## Testing Instructions

- Have a clean Studio install (or clear `~/.studio/certificates/`)
- Create a site with a custom domain but without HTTPS
- Stop the site
- Edit the site and enable HTTPS
- Verify the certificate is generated immediately (check `~/.studio/certificates/domains/`)
- Go to site Settings tab — the "Trust Certificate" nudge should now work correctly

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?