### PR TITLE
Add studio-ai binary for direct AI command access

### DIFF
--- a/apps/cli/ai.ts
+++ b/apps/cli/ai.ts
@@ -1,0 +1,108 @@
+import path from 'node:path';
+import { suppressPunycodeWarning } from '@studio/common/lib/suppress-punycode-warning';
+import { __ } from '@wordpress/i18n';
+import yargs from 'yargs';
+import { bumpAggregatedUniqueStat, getPlatformMetric } from 'cli/lib/bump-stat';
+import { setupServerFiles } from 'cli/lib/dependency-management/setup';
+import { loadTranslations } from 'cli/lib/i18n';
+import { StatsGroup, StatsMetric } from 'cli/lib/types/bump-stats';
+import { untildify } from 'cli/lib/utils';
+import { StudioArgv } from 'cli/types';
+
+const version = __STUDIO_CLI_VERSION__;
+
+suppressPunycodeWarning();
+
+async function main() {
+	const yargsLocale = await loadTranslations();
+
+	const studioAiArgv: StudioArgv = yargs( process.argv.slice( 2 ) )
+		.scriptName( 'studio-ai' )
+		.usage( __( 'AI-powered WordPress assistant' ) )
+		.locale( yargsLocale )
+		.version( version )
+		.option( 'avoid-telemetry', {
+			type: 'boolean',
+			hidden: true,
+		} )
+		.option( 'path', {
+			type: 'string',
+			normalize: true,
+			default: process.cwd(),
+			defaultDescription: __( 'Current directory' ),
+			description: __( 'Path to the WordPress files' ),
+			coerce: ( value ) => {
+				return path.resolve( untildify( value ) );
+			},
+		} )
+		.middleware( async () => {
+			const { runMigrations } = await import( '@studio/common/lib/migration' );
+			const { migrations } = await import( 'cli/migrations' );
+			await runMigrations( migrations );
+		} )
+		.middleware( async ( argv ) => {
+			if ( __ENABLE_CLI_TELEMETRY__ && ! argv.avoidTelemetry ) {
+				try {
+					await bumpAggregatedUniqueStat(
+						StatsGroup.STUDIO_CLI_USAGE_UNIQUE,
+						StatsMetric.SUCCESS,
+						'weekly'
+					);
+
+					if ( __IS_PACKAGED_FOR_NPM__ ) {
+						await bumpAggregatedUniqueStat(
+							StatsGroup.STUDIO_CLI_WEEKLY_UNIQUE_NPM,
+							getPlatformMetric(),
+							'weekly'
+						);
+					} else {
+						await bumpAggregatedUniqueStat(
+							StatsGroup.STUDIO_CLI_WEEKLY_UNIQUE_APP,
+							getPlatformMetric(),
+							'weekly'
+						);
+					}
+				} catch ( error ) {
+					console.error( 'Failed to bump stat:', error );
+				}
+			}
+		} )
+		.middleware( async () => {
+			await setupServerFiles();
+		} );
+
+	const { registerCommand: registerAiCommand } = await import( 'cli/commands/ai' );
+	registerAiCommand( studioAiArgv );
+
+	studioAiArgv.command( 'sessions', __( 'Manage AI sessions' ), async ( sessionsYargs ) => {
+		const [
+			{ registerCommand: registerAiSessionsListCommand },
+			{ registerCommand: registerAiSessionsResumeCommand },
+			{ registerCommand: registerAiSessionsDeleteCommand },
+		] = await Promise.all( [
+			import( 'cli/commands/ai/sessions/list' ),
+			import( 'cli/commands/ai/sessions/resume' ),
+			import( 'cli/commands/ai/sessions/delete' ),
+		] );
+
+		sessionsYargs
+			.option( 'path', {
+				hidden: true,
+			} )
+			.option( 'session-persistence', {
+				type: 'boolean',
+				default: true,
+				description: __( 'Record this AI chat session to disk' ),
+			} );
+		registerAiSessionsListCommand( sessionsYargs );
+		registerAiSessionsResumeCommand( sessionsYargs );
+		registerAiSessionsDeleteCommand( sessionsYargs );
+		sessionsYargs
+			.version( false )
+			.demandCommand( 1, __( 'You must provide a valid ai sessions command' ) );
+	} );
+
+	await studioAiArgv.argv;
+}
+
+void main();

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -7,7 +7,8 @@
 	"license": "GPL-2.0-or-later",
 	"type": "module",
 	"bin": {
-		"studio": "dist/cli/main.mjs"
+		"studio": "dist/cli/main.mjs",
+		"studio-ai": "dist/cli/ai-main.mjs"
 	},
 	"files": [
 		"dist/cli/",

--- a/apps/cli/vite.config.base.ts
+++ b/apps/cli/vite.config.base.ts
@@ -28,6 +28,7 @@ export const baseConfig = defineConfig( {
 		lib: {
 			entry: {
 				main: resolve( __dirname, 'index.ts' ),
+				'ai-main': resolve( __dirname, 'ai.ts' ),
 				'process-manager-daemon': resolve( __dirname, 'process-manager-daemon.ts' ),
 				'proxy-daemon': resolve( __dirname, 'proxy-daemon.ts' ),
 				'wordpress-server-child': resolve( __dirname, 'wordpress-server-child.ts' ),

--- a/apps/cli/vite.config.npm.ts
+++ b/apps/cli/vite.config.npm.ts
@@ -29,7 +29,6 @@ export default mergeConfig(
 		},
 		define: {
 			__ENABLE_CLI_TELEMETRY__: true,
-			__ENABLE_STUDIO_AI__: true,
 			__IS_PACKAGED_FOR_NPM__: true,
 		},
 	} )

--- a/apps/cli/vite.config.npm.ts
+++ b/apps/cli/vite.config.npm.ts
@@ -1,20 +1,35 @@
 import { defineConfig, mergeConfig } from 'vite';
+import { viteStaticCopy } from 'vite-plugin-static-copy';
 import { baseConfig } from './vite.config.base';
+
+const cliBinaries = [ 'main.mjs', 'ai-main.mjs' ];
 
 export default mergeConfig(
 	baseConfig,
 	defineConfig( {
+		plugins: [
+			viteStaticCopy( {
+				targets: [
+					{
+						src: 'ai/plugin',
+						dest: '.',
+					},
+				],
+			} ),
+		],
 		build: {
 			sourcemap: false,
 			rollupOptions: {
 				output: {
-					// Add shebang to main.mjs so it can be executed directly as a CLI.
-					banner: ( chunk ) => ( chunk.fileName === 'main.mjs' ? '#!/usr/bin/env node' : '' ),
+					// Add shebang to CLI binaries so they can be executed directly.
+					banner: ( chunk ) =>
+						cliBinaries.includes( chunk.fileName ) ? '#!/usr/bin/env node' : '',
 				},
 			},
 		},
 		define: {
 			__ENABLE_CLI_TELEMETRY__: true,
+			__ENABLE_STUDIO_AI__: true,
 			__IS_PACKAGED_FOR_NPM__: true,
 		},
 	} )


### PR DESCRIPTION
## Related issues

- Fixes STU-1502

## How AI was used in this PR

Claude Code was used to implement the feature based on the Linear issue spec. All changes were reviewed before committing.

## Proposed Changes

This approach installs both studio and studio-ai at the same time, to follow the example shared in the Linear issue: `npm install -g wp-studio && studio-ai`

- Add a new `studio-ai` binary entry point (`apps/cli/ai.ts`) that launches the AI assistant directly, as an alternative to `studio ai`
- Register the new entry point in the Vite build config so it gets compiled to `ai-main.mjs`
- Update the npm Vite config to add shebang, enable AI flag, and copy the AI plugin for npm distribution
- Add `studio-ai` to the `bin` field in `package.json`

After `npm install -g wp-studio`, users can run either `studio ai` or `studio-ai` — both work identically.

We can iterate in the final name later.

## Testing Instructions

1. Build the CLI: `npm run cli:build`
2. Verify `node apps/cli/dist/cli/ai-main.mjs` works
   - Should show `studio-ai` as script name with AI command as default and `sessions` sub-command
3. Verify `studio ai` still works: ` node apps/cli/dist/cli/main.mjs ai`
4. Verify sessions sub-command: `node apps/cli/dist/cli/ai-main.mjs sessions list`
5. Run `npm run typecheck` — should pass


<img width="774" height="336" alt="Screenshot 2026-04-06 at 19 16 55" src="https://github.com/user-attachments/assets/9048edc6-35bf-4008-a891-8f3fc0059483" />


## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?