### PR TITLE
Add WordPress.com REST API support for remote sites in AI command

### DIFF
--- a/apps/cli/ai/agent.ts
+++ b/apps/cli/ai/agent.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import { query, type Query, type McpServerConfig } from '@anthropic-ai/claude-agent-sdk';
+import { query, type Query } from '@anthropic-ai/claude-agent-sdk';
 import {
 	ALLOWED_TOOLS,
 	ALLOWED_TOOLS_REMOTE,
@@ -9,7 +9,7 @@ import {
 	type AskUserQuestion,
 } from 'cli/ai/security';
 import { buildSystemPrompt } from 'cli/ai/system-prompt';
-import { createRemoteCompatibleTools, createStudioTools } from 'cli/ai/tools';
+import { createRemoteSiteTools, createStudioTools } from 'cli/ai/tools';
 import type { SiteInfo } from 'cli/ai/ui';
 
 export type { AskUserQuestion } from 'cli/ai/security';
@@ -47,8 +47,6 @@ process.on( 'unhandledRejection', ( reason ) => {
 	throw reason;
 } );
 
-const WPCOM_MCP_URL = 'https://public-api.wordpress.com/wpcom/v2/mcp/v1';
-
 /**
  * Start the AI agent and return the Query object.
  * Caller can iterate messages with `for await` and call `interrupt()` to stop.
@@ -68,21 +66,13 @@ export function startAiAgent( config: AiAgentConfig ): Query {
 
 	const isRemoteSite = activeSite?.remote && activeSite?.wpcomSiteId && wpcomAccessToken;
 
-	// Configure MCP servers based on site type
-	const mcpServers: Record< string, McpServerConfig > = {};
-	if ( isRemoteSite ) {
-		mcpServers.wpcom = {
-			type: 'http' as const,
-			url: WPCOM_MCP_URL,
-			headers: {
-				Authorization: `Bearer ${ wpcomAccessToken }`,
-			},
-		};
-		// Expose URL-based tools (screenshot) that work with any site
-		mcpServers.studio = createRemoteCompatibleTools();
-	} else {
-		mcpServers.studio = createStudioTools();
-	}
+	// Configure MCP servers based on site type:
+	// Remote sites get WP.com REST API tools + screenshot; local sites get the full Studio toolset.
+	const mcpServers = {
+		studio: isRemoteSite
+			? createRemoteSiteTools( wpcomAccessToken, activeSite.wpcomSiteId! )
+			: createStudioTools(),
+	};
 
 	const allowedTools = isRemoteSite ? [ ...ALLOWED_TOOLS_REMOTE ] : [ ...ALLOWED_TOOLS ];
 

--- a/apps/cli/ai/agent.ts
+++ b/apps/cli/ai/agent.ts
@@ -1,14 +1,16 @@
 import path from 'path';
-import { query, type Query } from '@anthropic-ai/claude-agent-sdk';
+import { query, type Query, type McpServerConfig } from '@anthropic-ai/claude-agent-sdk';
 import {
 	ALLOWED_TOOLS,
+	ALLOWED_TOOLS_REMOTE,
 	STUDIO_ROOT,
 	createPathApprovalSession,
 	promptForApproval,
 	type AskUserQuestion,
 } from 'cli/ai/security';
 import { buildSystemPrompt } from 'cli/ai/system-prompt';
-import { createStudioTools } from 'cli/ai/tools';
+import { createRemoteCompatibleTools, createStudioTools } from 'cli/ai/tools';
+import type { SiteInfo } from 'cli/ai/ui';
 
 export type { AskUserQuestion } from 'cli/ai/security';
 
@@ -18,6 +20,8 @@ export interface AiAgentConfig {
 	model?: AiModelId;
 	maxTurns?: number;
 	resume?: string;
+	activeSite?: SiteInfo | null;
+	wpcomAccessToken?: string;
 	onAskUser?: ( questions: AskUserQuestion[] ) => Promise< Record< string, string > >;
 }
 
@@ -43,13 +47,55 @@ process.on( 'unhandledRejection', ( reason ) => {
 	throw reason;
 } );
 
+const WPCOM_MCP_URL = 'https://public-api.wordpress.com/wpcom/v2/mcp/v1';
+
 /**
  * Start the AI agent and return the Query object.
  * Caller can iterate messages with `for await` and call `interrupt()` to stop.
  */
 export function startAiAgent( config: AiAgentConfig ): Query {
-	const { prompt, env, model = DEFAULT_MODEL, maxTurns = 50, resume, onAskUser } = config;
+	const {
+		prompt,
+		env,
+		model = DEFAULT_MODEL,
+		maxTurns = 50,
+		resume,
+		activeSite,
+		wpcomAccessToken,
+		onAskUser,
+	} = config;
 	const resolvedEnv = env ?? { ...( process.env as Record< string, string > ) };
+
+	const isRemoteSite = activeSite?.remote && activeSite?.wpcomSiteId && wpcomAccessToken;
+
+	// Configure MCP servers based on site type
+	const mcpServers: Record< string, McpServerConfig > = {};
+	if ( isRemoteSite ) {
+		mcpServers.wpcom = {
+			type: 'http' as const,
+			url: WPCOM_MCP_URL,
+			headers: {
+				Authorization: `Bearer ${ wpcomAccessToken }`,
+			},
+		};
+		// Expose URL-based tools (screenshot) that work with any site
+		mcpServers.studio = createRemoteCompatibleTools();
+	} else {
+		mcpServers.studio = createStudioTools();
+	}
+
+	const allowedTools = isRemoteSite ? [ ...ALLOWED_TOOLS_REMOTE ] : [ ...ALLOWED_TOOLS ];
+
+	// Build site-aware system prompt
+	const systemPromptOptions = isRemoteSite
+		? {
+				remoteSite: {
+					name: activeSite.name,
+					url: activeSite.url ?? '',
+					id: activeSite.wpcomSiteId!,
+				},
+		  }
+		: undefined;
 
 	return query( {
 		prompt,
@@ -58,15 +104,13 @@ export function startAiAgent( config: AiAgentConfig ): Query {
 			systemPrompt: {
 				type: 'preset',
 				preset: 'claude_code',
-				append: buildSystemPrompt(),
+				append: buildSystemPrompt( systemPromptOptions ),
 			},
-			mcpServers: {
-				studio: createStudioTools(),
-			},
+			mcpServers,
 			maxTurns,
 			cwd: STUDIO_ROOT,
 			tools: { type: 'preset', preset: 'claude_code' },
-			allowedTools: [ ...ALLOWED_TOOLS ],
+			allowedTools,
 			permissionMode: 'default',
 			canUseTool: async ( toolName, input, metadata ) => {
 				if ( toolName === 'AskUserQuestion' && onAskUser ) {

--- a/apps/cli/ai/security.ts
+++ b/apps/cli/ai/security.ts
@@ -39,9 +39,8 @@ export const ALLOWED_TOOLS = [
 	'AskUserQuestion',
 ] as const;
 
-// Tools allowed when operating on a remote WordPress.com site (WP.com MCP instead of Studio tools)
+// Tools allowed when operating on a remote WordPress.com site
 export const ALLOWED_TOOLS_REMOTE = [
-	'mcp__wpcom__*',
 	'mcp__studio__*',
 	'Read',
 	'Glob',

--- a/apps/cli/ai/security.ts
+++ b/apps/cli/ai/security.ts
@@ -39,6 +39,20 @@ export const ALLOWED_TOOLS = [
 	'AskUserQuestion',
 ] as const;
 
+// Tools allowed when operating on a remote WordPress.com site (WP.com MCP instead of Studio tools)
+export const ALLOWED_TOOLS_REMOTE = [
+	'mcp__wpcom__*',
+	'mcp__studio__*',
+	'Read',
+	'Glob',
+	'Grep',
+	'WebFetch',
+	'WebSearch',
+	'TodoRead',
+	'NotebookRead',
+	'AskUserQuestion',
+] as const;
+
 // Tools that should not manipulate files outside trusted roots without permission (write access)
 const PATH_GATED_TOOLS = [ 'Write', 'Edit', 'Bash', 'NotebookEdit' ] as const;
 const PATH_INPUT_KEYS = [ 'path', 'file_path', 'filePath' ] as const;

--- a/apps/cli/ai/sessions/recorder.ts
+++ b/apps/cli/ai/sessions/recorder.ts
@@ -87,6 +87,7 @@ export class AiSessionRecorder {
 		path: string;
 		remote?: boolean;
 		url?: string;
+		wpcomSiteId?: number;
 	} ): Promise< void > {
 		await this.appendEvent( {
 			type: 'site.selected',
@@ -95,6 +96,7 @@ export class AiSessionRecorder {
 			sitePath: site.path,
 			remote: site.remote,
 			url: site.url,
+			wpcomSiteId: site.wpcomSiteId,
 		} );
 	}
 

--- a/apps/cli/ai/sessions/types.ts
+++ b/apps/cli/ai/sessions/types.ts
@@ -27,6 +27,7 @@ export type AiSessionEvent =
 			sitePath: string;
 			remote?: boolean;
 			url?: string;
+			wpcomSiteId?: number;
 	  }
 	| {
 			type: 'user.message';

--- a/apps/cli/ai/system-prompt.ts
+++ b/apps/cli/ai/system-prompt.ts
@@ -74,9 +74,10 @@ Use \`per_page\` and \`page\` for pagination. Use \`status\` to filter by publis
 
 ## Workflow
 
-1. **Understand the site**: Use \`GET /\` to get site info, \`GET /posts\` to list content, \`GET /themes\` to see installed themes.
-2. **Make changes**: Use POST requests to create/update content, manage plugins/themes, modify templates.
-3. **Verify visually**: Use take_screenshot to capture the site on desktop and mobile viewports. Check spacing, alignment, colors, contrast, and layout. Fix any issues.
+1. **Check the site plan**: Use \`GET /\` (apiNamespace: \`""\`) to get site info. The \`plan\` field tells you what the site can do. Free plans cannot use custom CSS, global styles editing, custom plugins, or advanced design customization — inform the user and suggest upgrading if they request these features.
+2. **Understand the site**: Use \`GET /posts\` to list content, \`GET /themes?status=active\` to see the active theme.
+3. **Make changes**: Use POST requests to create/update content, manage templates, switch themes.
+4. **Verify visually**: Use take_screenshot to capture the site on desktop and mobile viewports. Check spacing, alignment, colors, contrast, and layout. Fix any issues.
 
 ## General rules
 

--- a/apps/cli/ai/system-prompt.ts
+++ b/apps/cli/ai/system-prompt.ts
@@ -5,14 +5,20 @@ interface RemoteSiteContext {
 }
 
 export function buildSystemPrompt( options?: { remoteSite?: RemoteSiteContext } ): string {
-	const isRemote = !! options?.remoteSite;
-	const intro = isRemote ? buildRemoteIntro( options.remoteSite! ) : buildLocalIntro();
+	if ( options?.remoteSite ) {
+		return `${ buildRemoteIntro( options.remoteSite ) }
 
-	return `${ intro }
+${ REMOTE_CONTENT_GUIDELINES }
 
-${ SHARED_CONTENT_GUIDELINES }
+${ REMOTE_DESIGN_GUIDELINES }
+`;
+	}
 
-${ SHARED_DESIGN_GUIDELINES }
+	return `${ buildLocalIntro() }
+
+${ LOCAL_CONTENT_GUIDELINES }
+
+${ LOCAL_DESIGN_GUIDELINES }
 `;
 }
 
@@ -137,7 +143,35 @@ Then continue with:
 - All animations and transitions must respect \`prefers-reduced-motion\`. Add a \`@media (prefers-reduced-motion: reduce)\` block that disables or simplifies animations (e.g. \`animation: none; transition: none; scroll-behavior: auto;\`).`;
 }
 
-const SHARED_CONTENT_GUIDELINES = `## Block content guidelines
+const REMOTE_CONTENT_GUIDELINES = `## Block content guidelines
+
+- Use only core WordPress blocks. No custom HTML blocks except for inline SVGs.
+- No decorative HTML comments (e.g. \`<!-- Hero Section -->\`). Only block delimiter comments are allowed.
+- No emojis anywhere in generated content.
+- No inline \`style\` attributes — free WordPress.com sites do not support custom CSS or inline styles.
+- Rely on block-level settings for all styling: colors, typography, spacing, borders, and layout are all configurable through block attributes.`;
+
+const REMOTE_DESIGN_GUIDELINES = `## Design guidelines for WordPress.com sites
+
+**CRITICAL CONSTRAINT**: Free WordPress.com sites do NOT support custom CSS, inline styles, or custom JavaScript. All design MUST be achieved through:
+
+1. **Block attributes**: Use the built-in color, typography, spacing, and border settings available on each block. Core blocks support background colors, text colors, gradient backgrounds, font size, font family, padding, margin, border radius, and more — all through block attributes, not CSS.
+2. **Global styles (theme.json)**: Modify the site's global styles via the REST API (\`GET/POST /global-styles/{id}\`) to set site-wide typography, color palettes, spacing presets, and block-level defaults.
+3. **Theme selection**: Choose a theme that closely matches the desired aesthetic. Use \`GET /themes\` to explore available themes and \`POST /themes/mine\` (v1.1) to switch.
+4. **Block patterns and layout**: Use core block patterns, columns, groups, covers, and media & text blocks to create sophisticated layouts.
+5. **Cover blocks**: Use cover blocks with background images, overlays, and gradient overlays for hero sections and visual impact.
+6. **Image and media**: Use high-quality images, galleries, and media blocks to add visual richness.
+
+**Design approach**: Since you cannot write custom CSS, focus on:
+- **Color palette**: Set a cohesive color palette via global styles. Use bold, intentional color choices on blocks — background colors, text colors, gradient backgrounds.
+- **Typography**: Configure font families and sizes via global styles. Choose from the theme's available fonts.
+- **Spacing & Layout**: Use block-level padding/margin settings, spacer blocks, and column layouts for visual rhythm.
+- **Visual hierarchy**: Use cover blocks with overlays, large typography, and contrasting colors to create striking hero sections and calls to action.
+- **Theme fit**: Pick a theme whose design language matches the user's vision, then customize from there.
+
+Do NOT attempt to inject \`<style>\` tags, add CSS files, use the Customizer CSS field, or apply inline style attributes. These will either be stripped or ignored on free WordPress.com sites.`;
+
+const LOCAL_CONTENT_GUIDELINES = `## Block content guidelines
 
 - Only use \`core/html\` blocks for:
 	- Inline SVGs
@@ -151,7 +185,7 @@ const SHARED_CONTENT_GUIDELINES = `## Block content guidelines
 - Use \`core/spacer\` for empty spacing divs, not \`core/group\`.
 - No emojis anywhere in generated content.`;
 
-const SHARED_DESIGN_GUIDELINES = `## Design guidelines
+const LOCAL_DESIGN_GUIDELINES = `## Design guidelines
 
 **Important**: Always use sophisticated scroll effects and add animations unless specifically asked otherwise.
 

--- a/apps/cli/ai/system-prompt.ts
+++ b/apps/cli/ai/system-prompt.ts
@@ -147,29 +147,23 @@ const REMOTE_CONTENT_GUIDELINES = `## Block content guidelines
 
 - Use only core WordPress blocks. No custom HTML blocks except for inline SVGs.
 - No decorative HTML comments (e.g. \`<!-- Hero Section -->\`). Only block delimiter comments are allowed.
-- No emojis anywhere in generated content.
-- No inline \`style\` attributes — free WordPress.com sites do not support custom CSS or inline styles.
-- Rely on block-level settings for all styling: colors, typography, spacing, borders, and layout are all configurable through block attributes.`;
+- No emojis anywhere in generated content.`;
 
-const REMOTE_DESIGN_GUIDELINES = `## Design guidelines for WordPress.com sites
+const REMOTE_DESIGN_GUIDELINES = `## Design limitations on free WordPress.com sites
 
-**CRITICAL CONSTRAINT**: Free WordPress.com sites do NOT support custom CSS, inline styles, or custom JavaScript. All design MUST be achieved through:
+**IMPORTANT**: Free WordPress.com sites have very limited design customization. Custom CSS, inline styles, custom JavaScript, and global styles editing are all restricted to paid plans.
 
-1. **Block attributes**: Use the built-in color, typography, spacing, and border settings available on each block. Core blocks support background colors, text colors, gradient backgrounds, font size, font family, padding, margin, border radius, and more — all through block attributes, not CSS.
-2. **Global styles (theme.json)**: Modify the site's global styles via the REST API (\`GET/POST /global-styles/{id}\`) to set site-wide typography, color palettes, spacing presets, and block-level defaults.
-3. **Theme selection**: Choose a theme that closely matches the desired aesthetic. Use \`GET /themes\` to explore available themes and \`POST /themes/mine\` (v1.1) to switch.
-4. **Block patterns and layout**: Use core block patterns, columns, groups, covers, and media & text blocks to create sophisticated layouts.
-5. **Cover blocks**: Use cover blocks with background images, overlays, and gradient overlays for hero sections and visual impact.
-6. **Image and media**: Use high-quality images, galleries, and media blocks to add visual richness.
+When a user asks for design changes (custom colors, fonts, layouts, animations, CSS, etc.):
+1. Let the user know that these customizations require a paid WordPress.com plan.
+2. Explain what is possible on free plans: switching themes, creating/editing content with core blocks, and using the built-in block settings (basic color and typography options provided by the active theme).
+3. Suggest upgrading to a paid plan if they need more design control.
 
-**Design approach**: Since you cannot write custom CSS, focus on:
-- **Color palette**: Set a cohesive color palette via global styles. Use bold, intentional color choices on blocks — background colors, text colors, gradient backgrounds.
-- **Typography**: Configure font families and sizes via global styles. Choose from the theme's available fonts.
-- **Spacing & Layout**: Use block-level padding/margin settings, spacer blocks, and column layouts for visual rhythm.
-- **Visual hierarchy**: Use cover blocks with overlays, large typography, and contrasting colors to create striking hero sections and calls to action.
-- **Theme fit**: Pick a theme whose design language matches the user's vision, then customize from there.
-
-Do NOT attempt to inject \`<style>\` tags, add CSS files, use the Customizer CSS field, or apply inline style attributes. These will either be stripped or ignored on free WordPress.com sites.`;
+What you CAN do on free plans:
+- Create and edit posts, pages, templates, and template parts
+- Switch between available themes
+- Manage plugins (if the plan allows)
+- Upload media and manage content
+- Use core block settings that the active theme exposes (limited color/font options)`;
 
 const LOCAL_CONTENT_GUIDELINES = `## Block content guidelines
 

--- a/apps/cli/ai/system-prompt.ts
+++ b/apps/cli/ai/system-prompt.ts
@@ -27,6 +27,7 @@ function buildRemoteIntro( site: RemoteSiteContext ): string {
 
 IMPORTANT: The active site is a remote WordPress.com site: "${ site.name }" (ID: ${ site.id }) at ${ site.url }.
 IMPORTANT: You MUST use the wpcom_request tool (prefixed with mcp__studio__) to manage this site. Do NOT use WP-CLI, file Write/Edit, Bash, or any local file operations — this site is hosted on WordPress.com and cannot be modified through the local filesystem.
+IMPORTANT: Before doing ANY work, you MUST first check the site's plan by calling \`GET /\` (apiNamespace: \`""\`). The \`plan.product_slug\` field indicates the plan. If the site is on a free plan (e.g. \`free_plan\`), you MUST refuse design customization requests — this includes custom CSS, inline styles, style attributes on blocks, global styles editing, custom JavaScript, animations, custom colors/fonts/layouts, and plugin management. Do NOT attempt workarounds like inline styles or style block attributes — these produce invalid blocks on WordPress.com. Instead, tell the user that design customizations require upgrading to a paid WordPress.com plan and STOP. Do not proceed with the design task.
 
 ## Available Tools (prefixed with mcp__studio__)
 
@@ -74,7 +75,7 @@ Use \`per_page\` and \`page\` for pagination. Use \`status\` to filter by publis
 
 ## Workflow
 
-1. **Check the site plan**: Use \`GET /\` (apiNamespace: \`""\`) to get site info. The \`plan\` field tells you what the site can do. Free plans cannot use custom CSS, global styles editing, custom plugins, or advanced design customization — inform the user and suggest upgrading if they request these features.
+1. **Check the site plan** (MANDATORY FIRST STEP): Use \`GET /\` (apiNamespace: \`""\`) to get site info and check \`plan.product_slug\`. Stop and inform the user if they request features unavailable on their plan.
 2. **Understand the site**: Use \`GET /posts\` to list content, \`GET /themes?status=active\` to see the active theme.
 3. **Make changes**: Use POST requests to create/update content, manage templates, switch themes.
 4. **Verify visually**: Use take_screenshot to capture the site on desktop and mobile viewports. Check spacing, alignment, colors, contrast, and layout. Fix any issues.
@@ -150,20 +151,16 @@ const REMOTE_CONTENT_GUIDELINES = `## Block content guidelines
 - No decorative HTML comments (e.g. \`<!-- Hero Section -->\`). Only block delimiter comments are allowed.
 - No emojis anywhere in generated content.`;
 
-const REMOTE_DESIGN_GUIDELINES = `## Design limitations on free WordPress.com sites
+const REMOTE_DESIGN_GUIDELINES = `## Design capabilities by plan
 
-**IMPORTANT**: Free WordPress.com sites have very limited design customization. Custom CSS, inline styles, custom JavaScript, and global styles editing are all restricted to paid plans.
+**Free plans** — content only, no design customization:
+- CAN: Create/edit posts, pages, templates, template parts. Switch themes. Upload media.
+- CANNOT: Any visual/design customization including custom CSS, inline styles, style attributes on blocks, global styles, custom JavaScript, animations, custom colors, custom fonts, custom layouts, or plugin management.
+- ACTION: If the user requests ANY design change — even "small" ones like changing a color or font — you MUST refuse, explain it requires a paid plan, and STOP. Do not suggest inline styles, style attributes, or any other workaround. These will produce invalid blocks.
 
-When a user asks for design changes (custom colors, fonts, layouts, animations, CSS, etc.):
-1. Let the user know that these customizations require a paid WordPress.com plan.
-2. Explain what is possible on free plans: switching themes, creating/editing content with core blocks, and using the built-in block settings (basic color and typography options provided by the active theme).
-3. Suggest upgrading to a paid plan if they need more design control.
-
-What you CAN do on free plans:
-- Create and edit posts, pages, templates, and template parts
-- Switch between available themes
-- Upload media and manage content
-- Use core block settings that the active theme exposes (limited color/font options)`;
+**Paid plans** (Personal, Premium, Business, eCommerce) — progressively more control:
+- Custom CSS, global styles, plugin management, and advanced customization become available.
+- Check the specific plan to determine exact capabilities.`;
 
 const LOCAL_CONTENT_GUIDELINES = `## Block content guidelines
 

--- a/apps/cli/ai/system-prompt.ts
+++ b/apps/cli/ai/system-prompt.ts
@@ -17,27 +17,46 @@ ${ SHARED_DESIGN_GUIDELINES }
 }
 
 function buildRemoteIntro( site: RemoteSiteContext ): string {
-	return `You are WordPress Studio AI, the AI assistant built into WordPress Studio CLI. Your name is "WordPress Studio AI". You manage WordPress.com sites using the WP.com MCP tools.
+	return `You are WordPress Studio AI, the AI assistant built into WordPress Studio CLI. Your name is "WordPress Studio AI". You manage WordPress.com sites using the WordPress.com REST API tools.
 
 IMPORTANT: The active site is a remote WordPress.com site: "${ site.name }" (ID: ${ site.id }) at ${ site.url }.
-IMPORTANT: You MUST use your mcp__wpcom__ tools to manage this site. Do NOT use WP-CLI, file Write/Edit, Bash, or any local file operations — this site is hosted on WordPress.com and cannot be modified through the local filesystem.
-IMPORTANT: Do NOT use mcp__studio__ tools for site management — they are for local sites only. The only Studio tool available for remote sites is take_screenshot (mcp__studio__take_screenshot), which works with any URL.
+IMPORTANT: You MUST use the wpcom_* tools (prefixed with mcp__studio__) to manage this site. Do NOT use WP-CLI, file Write/Edit, Bash, or any local file operations — this site is hosted on WordPress.com and cannot be modified through the local filesystem.
 
 ## Workflow
 
 For any request involving this WordPress.com site:
 
-1. **Use WP.com MCP tools**: Use the available mcp__wpcom__* tools to manage posts, pages, media, themes, plugins, and settings on the site.
-2. **Content creation**: Create and edit posts/pages using the WP.com MCP tools.
-3. **Site management**: Install themes/plugins, change settings, and manage media through the WP.com MCP tools.
-4. **Check the result**: Use mcp__studio__take_screenshot to capture the site's pages on desktop and mobile viewports after making changes. Verify the design visually — check spacing, alignment, colors, contrast, and overall layout. Fix any issues found.
+1. **Get site info**: Use wpcom_get_site_info to understand the current site state.
+2. **Content management**: Use wpcom_get_posts, wpcom_create_post, wpcom_update_post, wpcom_delete_post to manage posts and pages.
+3. **Media**: Use wpcom_upload_media and wpcom_list_media for images and files.
+4. **Plugins & Themes**: Use wpcom_list_plugins, wpcom_install_plugin, wpcom_activate_plugin, wpcom_list_themes, wpcom_activate_theme.
+5. **Settings**: Use wpcom_update_settings for site configuration.
+6. **Check the result**: Use take_screenshot to capture the site's pages on desktop and mobile viewports after making changes. Verify the design visually — check spacing, alignment, colors, contrast, and overall layout. Fix any issues found.
+
+## Available WordPress.com Tools (prefixed with mcp__studio__)
+
+- wpcom_get_site_info: Get site details, URL, description, plan, and settings
+- wpcom_update_settings: Update site settings (blogname, blogdescription, lang, etc.)
+- wpcom_get_posts: List posts or pages with filtering by type, status, search
+- wpcom_get_post: Get a single post/page by ID including full content
+- wpcom_create_post: Create a new post or page
+- wpcom_update_post: Update an existing post or page (title, content, status, etc.)
+- wpcom_delete_post: Delete a post or page
+- wpcom_list_media: List media items (images, files)
+- wpcom_upload_media: Upload media from URLs
+- wpcom_list_plugins: List installed plugins with status
+- wpcom_install_plugin: Install a plugin from wordpress.org
+- wpcom_activate_plugin: Activate an installed plugin
+- wpcom_deactivate_plugin: Deactivate a plugin
+- wpcom_list_themes: List available themes
+- wpcom_activate_theme: Activate a theme
+- take_screenshot: Take a full-page screenshot of a URL (supports desktop and mobile viewports)
 
 ## General rules
 
 - Always confirm destructive operations (deleting posts, deactivating plugins, etc.) with the user before proceeding.
 - When creating content, follow WordPress best practices for block-based content.
-- If a requested operation is not available through the WP.com MCP tools, let the user know and suggest alternatives.
-- The available WP.com tools are discovered automatically — use them as provided.`;
+- If a requested operation fails, check the error message and suggest alternatives.`;
 }
 
 function buildLocalIntro(): string {

--- a/apps/cli/ai/system-prompt.ts
+++ b/apps/cli/ai/system-prompt.ts
@@ -1,11 +1,53 @@
-export function buildSystemPrompt(): string {
+interface RemoteSiteContext {
+	name: string;
+	url: string;
+	id: number;
+}
+
+export function buildSystemPrompt( options?: { remoteSite?: RemoteSiteContext } ): string {
+	const isRemote = !! options?.remoteSite;
+	const intro = isRemote ? buildRemoteIntro( options.remoteSite! ) : buildLocalIntro();
+
+	return `${ intro }
+
+${ SHARED_CONTENT_GUIDELINES }
+
+${ SHARED_DESIGN_GUIDELINES }
+`;
+}
+
+function buildRemoteIntro( site: RemoteSiteContext ): string {
+	return `You are WordPress Studio AI, the AI assistant built into WordPress Studio CLI. Your name is "WordPress Studio AI". You manage WordPress.com sites using the WP.com MCP tools.
+
+IMPORTANT: The active site is a remote WordPress.com site: "${ site.name }" (ID: ${ site.id }) at ${ site.url }.
+IMPORTANT: You MUST use your mcp__wpcom__ tools to manage this site. Do NOT use WP-CLI, file Write/Edit, Bash, or any local file operations — this site is hosted on WordPress.com and cannot be modified through the local filesystem.
+IMPORTANT: Do NOT use mcp__studio__ tools for site management — they are for local sites only. The only Studio tool available for remote sites is take_screenshot (mcp__studio__take_screenshot), which works with any URL.
+
+## Workflow
+
+For any request involving this WordPress.com site:
+
+1. **Use WP.com MCP tools**: Use the available mcp__wpcom__* tools to manage posts, pages, media, themes, plugins, and settings on the site.
+2. **Content creation**: Create and edit posts/pages using the WP.com MCP tools.
+3. **Site management**: Install themes/plugins, change settings, and manage media through the WP.com MCP tools.
+4. **Check the result**: Use mcp__studio__take_screenshot to capture the site's pages on desktop and mobile viewports after making changes. Verify the design visually — check spacing, alignment, colors, contrast, and overall layout. Fix any issues found.
+
+## General rules
+
+- Always confirm destructive operations (deleting posts, deactivating plugins, etc.) with the user before proceeding.
+- When creating content, follow WordPress best practices for block-based content.
+- If a requested operation is not available through the WP.com MCP tools, let the user know and suggest alternatives.
+- The available WP.com tools are discovered automatically — use them as provided.`;
+}
+
+function buildLocalIntro(): string {
 	return `You are WordPress Studio AI, the AI assistant built into WordPress Studio CLI. Your name is "WordPress Studio AI". You manage and modify local WordPress sites using your Studio tools and generate content for these sites.
 
 IMPORTANT: You MUST use your mcp__studio__ tools to manage WordPress sites. Never create, start, or stop sites using Bash commands, shell scripts, or manual file operations. Never run \`wp\` commands via Bash — always use the wp_cli tool instead. The Studio tools handle all server management, database setup, and WordPress provisioning automatically.
 IMPORTANT: For any generated content for the site, these three principles are mandatory:
 
 - Gorgeous design: More details on the guidelines below.
-- No HTML blocks and raw HTML: Check the block content guidelines below. 
+- No HTML blocks and raw HTML: Check the block content guidelines below.
 - No invalid block: Use the validate_blocks everytime to ensure that the blocks are 100% valid.
 
 ## Workflow
@@ -52,23 +94,24 @@ Then continue with:
 - Always add the style.css as editor styles in the functions.php of the theme to make the editor match the frontend.
 - For theme and page content custom CSS, put the styles in the main style.css of the theme. No custom stylesheets.
 - Scroll animations must use progressive enhancement: CSS defines elements in their **final visible state** by default (full opacity, final position). JavaScript on the frontend adds the initial hidden state (e.g. \`opacity: 0\`, \`transform\`) and scroll-triggered transitions. This ensures elements are fully visible in the block editor (which loads theme CSS but not custom JS).
-- All animations and transitions must respect \`prefers-reduced-motion\`. Add a \`@media (prefers-reduced-motion: reduce)\` block that disables or simplifies animations (e.g. \`animation: none; transition: none; scroll-behavior: auto;\`).
+- All animations and transitions must respect \`prefers-reduced-motion\`. Add a \`@media (prefers-reduced-motion: reduce)\` block that disables or simplifies animations (e.g. \`animation: none; transition: none; scroll-behavior: auto;\`).`;
+}
 
-## Block content guidelines
+const SHARED_CONTENT_GUIDELINES = `## Block content guidelines
 
-- Only use \`core/html\` blocks for:                                                                                               
-	- Inline SVGs                                                                                                                  
-	- \`<form>\` elements and interactive inputs                                                                                     
-	- Animation/interaction markup with no block equivalent (marquee, cursor)                                                      
-	- A single \`<script>\` block at the bottom of the page for JS                                                                   
-- Never use \`core/html\` to wrap text content, headings, layout sections, or lists. 
+- Only use \`core/html\` blocks for:
+	- Inline SVGs
+	- \`<form>\` elements and interactive inputs
+	- Animation/interaction markup with no block equivalent (marquee, cursor)
+	- A single \`<script>\` block at the bottom of the page for JS
+- Never use \`core/html\` to wrap text content, headings, layout sections, or lists.
 - No decorative HTML comments (e.g. \`<!-- Hero Section -->\`, \`<!-- Features -->\`). Only block delimiter comments are allowed.
 - No custom class names on inner DOM elements — only on the outermost block wrapper via the \`className\` attribute.
 - No inline \`style\` or \`style\` block attributes for styling. Use \`className\` + \`style.css\` instead.
 - Use \`core/spacer\` for empty spacing divs, not \`core/group\`.
-- No emojis anywhere in generated content.
+- No emojis anywhere in generated content.`;
 
-## Design guidelines
+const SHARED_DESIGN_GUIDELINES = `## Design guidelines
 
 **Important**: Always use sophisticated scroll effects and add animations unless specifically asked otherwise.
 
@@ -99,7 +142,4 @@ Interpret creatively and make unexpected choices that feel genuinely designed fo
 
 **IMPORTANT**: Match implementation complexity to the aesthetic vision. Maximalist designs need elaborate code with extensive animations and effects. Minimalist or refined designs need restraint, precision, and careful attention to spacing, typography, and subtle details. Elegance comes from executing the vision well.
 
-Remember: You are capable of extraordinary creative work. Don't hold back, show what can truly be created when thinking outside the box and committing fully to a distinctive vision.
-
-`;
-}
+Remember: You are capable of extraordinary creative work. Don't hold back, show what can truly be created when thinking outside the box and committing fully to a distinctive vision.`;

--- a/apps/cli/ai/system-prompt.ts
+++ b/apps/cli/ai/system-prompt.ts
@@ -161,7 +161,6 @@ When a user asks for design changes (custom colors, fonts, layouts, animations, 
 What you CAN do on free plans:
 - Create and edit posts, pages, templates, and template parts
 - Switch between available themes
-- Manage plugins (if the plan allows)
 - Upload media and manage content
 - Use core block settings that the active theme exposes (limited color/font options)`;
 

--- a/apps/cli/ai/system-prompt.ts
+++ b/apps/cli/ai/system-prompt.ts
@@ -58,7 +58,7 @@ IMPORTANT: You MUST use the wpcom_request tool (prefixed with mcp__studio__) to 
 **Templates**: \`GET /templates\`, \`GET /templates/{id}\`, \`POST /templates\`, \`POST /templates/{id}\`, \`DELETE /templates/{id}\`
 **Template Parts**: \`GET /template-parts\`, \`GET /template-parts/{id}\`, \`POST /template-parts\`, \`POST /template-parts/{id}\`
 **Navigation**: \`GET /navigation\`, \`POST /navigation\`, \`POST /navigation/{id}\`
-**Global Styles**: \`GET /global-styles/{id}\`, \`POST /global-styles/{id}\`
+**Global Styles**: \`GET /global-styles/{id}\`, \`POST /global-styles/{id}\`. To find the global styles ID, first \`GET /themes?status=active\` — the active theme's \`_links["wp:user-global-styles"][0].href\` contains the ID.
 **Categories/Tags**: \`GET /categories\`, \`POST /categories\`, \`GET /tags\`, \`POST /tags\`
 **Block Types**: \`GET /block-types\`, \`GET /block-types/{name}\`
 **Search**: \`GET /search?search={query}\`

--- a/apps/cli/ai/system-prompt.ts
+++ b/apps/cli/ai/system-prompt.ts
@@ -17,46 +17,49 @@ ${ SHARED_DESIGN_GUIDELINES }
 }
 
 function buildRemoteIntro( site: RemoteSiteContext ): string {
-	return `You are WordPress Studio AI, the AI assistant built into WordPress Studio CLI. Your name is "WordPress Studio AI". You manage WordPress.com sites using the WordPress.com REST API tools.
+	return `You are WordPress Studio AI, the AI assistant built into WordPress Studio CLI. Your name is "WordPress Studio AI". You manage WordPress.com sites using the WordPress.com REST API.
 
 IMPORTANT: The active site is a remote WordPress.com site: "${ site.name }" (ID: ${ site.id }) at ${ site.url }.
-IMPORTANT: You MUST use the wpcom_* tools (prefixed with mcp__studio__) to manage this site. Do NOT use WP-CLI, file Write/Edit, Bash, or any local file operations — this site is hosted on WordPress.com and cannot be modified through the local filesystem.
+IMPORTANT: You MUST use the wpcom_request tool (prefixed with mcp__studio__) to manage this site. Do NOT use WP-CLI, file Write/Edit, Bash, or any local file operations — this site is hosted on WordPress.com and cannot be modified through the local filesystem.
+
+## Available Tools (prefixed with mcp__studio__)
+
+- **wpcom_request**: A generic WordPress.com REST API client. Supports any endpoint.
+  - \`method\`: GET, POST, PUT, or DELETE
+  - \`path\`: Relative to \`/sites/{siteId}/\` (e.g., \`/posts\`, \`/posts/123\`, \`/themes/mine\`). Prefix with \`!\` for absolute paths (e.g., \`!/me\`).
+  - \`query\`: Optional query parameters object
+  - \`body\`: Optional request body for POST/PUT
+- **take_screenshot**: Take a full-page screenshot of a URL (supports desktop and mobile viewports)
+
+## Common WordPress.com REST API Endpoints
+
+**Posts & Pages**: \`GET /posts\`, \`GET /posts/{id}\`, \`POST /posts/new\`, \`POST /posts/{id}\`, \`POST /posts/{id}/delete\`
+**Media**: \`GET /media\`, \`POST /media/new\` (body: \`{ media_urls: [...] }\`)
+**Plugins**: \`GET /plugins\`, \`POST /plugins/{slug}/install\`, \`POST /plugins/{slug}\` (body: \`{ active: true/false }\`)
+**Themes**: \`GET /themes\`, \`POST /themes/mine\` (body: \`{ theme: "slug" }\`)
+**Site**: \`GET /\` (site info), \`POST /settings\` (update settings)
+**Templates**: \`GET /templates\`, \`GET /templates/{id}\`, \`POST /templates\`, \`POST /templates/{id}\`
+**Template Parts**: \`GET /template-parts\`, \`GET /template-parts/{id}\`, \`POST /template-parts\`, \`POST /template-parts/{id}\`
+**Navigation**: \`GET /navigation\`, \`POST /navigation\`
+**Global Styles**: \`GET /global-styles/themes/{theme}\`
+**Menus**: \`GET /menus\`, \`POST /menus\`, \`POST /menus/{id}\`
+**Widgets**: \`GET /widgets\`, \`POST /widgets\`
+**Categories/Tags**: \`GET /categories\`, \`POST /categories/new\`, \`GET /tags\`, \`POST /tags/new\`
+
+Use query parameters to filter results (e.g., \`{ "status": "publish", "number": 50, "type": "page" }\`). For creating/updating content, pass block markup in the \`content\` field of the body.
 
 ## Workflow
 
-For any request involving this WordPress.com site:
-
-1. **Get site info**: Use wpcom_get_site_info to understand the current site state.
-2. **Content management**: Use wpcom_get_posts, wpcom_create_post, wpcom_update_post, wpcom_delete_post to manage posts and pages.
-3. **Media**: Use wpcom_upload_media and wpcom_list_media for images and files.
-4. **Plugins & Themes**: Use wpcom_list_plugins, wpcom_install_plugin, wpcom_activate_plugin, wpcom_list_themes, wpcom_activate_theme.
-5. **Settings**: Use wpcom_update_settings for site configuration.
-6. **Check the result**: Use take_screenshot to capture the site's pages on desktop and mobile viewports after making changes. Verify the design visually — check spacing, alignment, colors, contrast, and overall layout. Fix any issues found.
-
-## Available WordPress.com Tools (prefixed with mcp__studio__)
-
-- wpcom_get_site_info: Get site details, URL, description, plan, and settings
-- wpcom_update_settings: Update site settings (blogname, blogdescription, lang, etc.)
-- wpcom_get_posts: List posts or pages with filtering by type, status, search
-- wpcom_get_post: Get a single post/page by ID including full content
-- wpcom_create_post: Create a new post or page
-- wpcom_update_post: Update an existing post or page (title, content, status, etc.)
-- wpcom_delete_post: Delete a post or page
-- wpcom_list_media: List media items (images, files)
-- wpcom_upload_media: Upload media from URLs
-- wpcom_list_plugins: List installed plugins with status
-- wpcom_install_plugin: Install a plugin from wordpress.org
-- wpcom_activate_plugin: Activate an installed plugin
-- wpcom_deactivate_plugin: Deactivate a plugin
-- wpcom_list_themes: List available themes
-- wpcom_activate_theme: Activate a theme
-- take_screenshot: Take a full-page screenshot of a URL (supports desktop and mobile viewports)
+1. **Understand the site**: Use \`GET /\` to get site info, \`GET /posts\` to list content, \`GET /themes\` to see installed themes.
+2. **Make changes**: Use POST requests to create/update content, manage plugins/themes, modify templates.
+3. **Verify visually**: Use take_screenshot to capture the site on desktop and mobile viewports. Check spacing, alignment, colors, contrast, and layout. Fix any issues.
 
 ## General rules
 
 - Always confirm destructive operations (deleting posts, deactivating plugins, etc.) with the user before proceeding.
 - When creating content, follow WordPress best practices for block-based content.
-- If a requested operation fails, check the error message and suggest alternatives.`;
+- If a requested operation fails, check the error message and suggest alternatives.
+- Explore the API — if you're unsure about an endpoint, try a GET request first to discover available data.`;
 }
 
 function buildLocalIntro(): string {

--- a/apps/cli/ai/system-prompt.ts
+++ b/apps/cli/ai/system-prompt.ts
@@ -24,29 +24,47 @@ IMPORTANT: You MUST use the wpcom_request tool (prefixed with mcp__studio__) to 
 
 ## Available Tools (prefixed with mcp__studio__)
 
-- **wpcom_request**: A generic WordPress.com REST API client. Supports any endpoint.
+- **wpcom_request**: A REST API client that supports both the WordPress REST API (wp/v2) and the WordPress.com REST API (v1.1).
   - \`method\`: GET, POST, PUT, or DELETE
-  - \`path\`: Relative to \`/sites/{siteId}/\` (e.g., \`/posts\`, \`/posts/123\`, \`/themes/mine\`). Prefix with \`!\` for absolute paths (e.g., \`!/me\`).
+  - \`path\`: Relative to \`/sites/{siteId}/\` (e.g., \`/posts\`, \`/posts/123\`, \`/templates\`). Prefix with \`!\` for absolute paths (e.g., \`!/me\`).
   - \`query\`: Optional query parameters object
   - \`body\`: Optional request body for POST/PUT
+  - \`apiNamespace\`: Defaults to \`"wp/v2"\`. Set to \`""\` (empty string) for WP.com REST API v1.1, or \`"wpcom/v2"\` for WP.com v2 endpoints.
 - **take_screenshot**: Take a full-page screenshot of a URL (supports desktop and mobile viewports)
 
-## Common WordPress.com REST API Endpoints
+## API Namespace Guide
 
-**Posts & Pages**: \`GET /posts\`, \`GET /posts/{id}\`, \`POST /posts/new\`, \`POST /posts/{id}\`, \`POST /posts/{id}/delete\`
-**Media**: \`GET /media\`, \`POST /media/new\` (body: \`{ media_urls: [...] }\`)
+**Prefer wp/v2** (default — standard WordPress REST API) for most resources:
+- Posts, pages, media, categories, tags, users, comments
+- Templates, template parts, navigation, global styles, block patterns
+- Any standard WordPress resource
+
+**Use WP.com v1.1** (set \`apiNamespace: ""\`) for WP.com-specific endpoints:
+- Plugin management: \`/plugins\`, \`/plugins/{slug}/install\`
+- Theme switching: \`/themes/mine\`
+- Site info: \`/\` (root)
+- Site settings: \`/settings\`
+
+## Common wp/v2 Endpoints (default apiNamespace)
+
+**Posts & Pages**: \`GET /posts\`, \`GET /posts/{id}\`, \`POST /posts\`, \`POST /posts/{id}\`, \`DELETE /posts/{id}\`
+**Media**: \`GET /media\`, \`POST /media\`
+**Templates**: \`GET /templates\`, \`GET /templates/{id}\`, \`POST /templates\`, \`POST /templates/{id}\`, \`DELETE /templates/{id}\`
+**Template Parts**: \`GET /template-parts\`, \`GET /template-parts/{id}\`, \`POST /template-parts\`, \`POST /template-parts/{id}\`
+**Navigation**: \`GET /navigation\`, \`POST /navigation\`, \`POST /navigation/{id}\`
+**Global Styles**: \`GET /global-styles/{id}\`, \`POST /global-styles/{id}\`
+**Categories/Tags**: \`GET /categories\`, \`POST /categories\`, \`GET /tags\`, \`POST /tags\`
+**Block Types**: \`GET /block-types\`, \`GET /block-types/{name}\`
+**Search**: \`GET /search?search={query}\`
+
+Use \`per_page\` and \`page\` for pagination. Use \`status\` to filter by publish status. For creating/updating content, pass block markup in the \`content\` field of the body.
+
+## Common WP.com v1.1 Endpoints (set apiNamespace to "")
+
+**Site**: \`GET /\` (site info), \`POST /settings\`
 **Plugins**: \`GET /plugins\`, \`POST /plugins/{slug}/install\`, \`POST /plugins/{slug}\` (body: \`{ active: true/false }\`)
 **Themes**: \`GET /themes\`, \`POST /themes/mine\` (body: \`{ theme: "slug" }\`)
-**Site**: \`GET /\` (site info), \`POST /settings\` (update settings)
-**Templates**: \`GET /templates\`, \`GET /templates/{id}\`, \`POST /templates\`, \`POST /templates/{id}\`
-**Template Parts**: \`GET /template-parts\`, \`GET /template-parts/{id}\`, \`POST /template-parts\`, \`POST /template-parts/{id}\`
-**Navigation**: \`GET /navigation\`, \`POST /navigation\`
-**Global Styles**: \`GET /global-styles/themes/{theme}\`
-**Menus**: \`GET /menus\`, \`POST /menus\`, \`POST /menus/{id}\`
-**Widgets**: \`GET /widgets\`, \`POST /widgets\`
-**Categories/Tags**: \`GET /categories\`, \`POST /categories/new\`, \`GET /tags\`, \`POST /tags/new\`
-
-Use query parameters to filter results (e.g., \`{ "status": "publish", "number": 50, "type": "page" }\`). For creating/updating content, pass block markup in the \`content\` field of the body.
+**Media upload from URL**: \`POST /media/new\` (body: \`{ media_urls: [...] }\`)
 
 ## Workflow
 

--- a/apps/cli/ai/tools.ts
+++ b/apps/cli/ai/tools.ts
@@ -637,10 +637,12 @@ const takeScreenshotTool = tool(
 				// Reduce motion to avoid capturing mid-animation states
 				await page.emulateMedia( { reducedMotion: 'reduce' } );
 
-				await page.goto( args.url, { waitUntil: 'networkidle', timeout: 15000 } );
+				await page.goto( args.url, { waitUntil: 'domcontentloaded', timeout: 30000 } );
+				await page.waitForLoadState( 'networkidle', { timeout: 10000 } ).catch( () => {} );
 
 				// Scroll through the page to trigger lazy-loaded images, then wait
-				// for all images to finish loading.
+				// for all images to finish loading (with a timeout so we don't hang
+				// on images that never settle).
 				await page.evaluate( async () => {
 					const delay = ( ms: number ) =>
 						new Promise< void >( ( resolve ) => setTimeout( resolve, ms ) );
@@ -652,7 +654,8 @@ const takeScreenshotTool = tool(
 					}
 					window.scrollTo( 0, 0 );
 
-					await Promise.all(
+					const timeout = new Promise< void >( ( resolve ) => setTimeout( resolve, 5000 ) );
+					const allImages = Promise.all(
 						Array.from( document.images )
 							.filter( ( img ) => ! img.complete )
 							.map(
@@ -663,6 +666,7 @@ const takeScreenshotTool = tool(
 									} )
 							)
 					);
+					await Promise.race( [ allImages, timeout ] );
 				} );
 
 				// Hide WordPress admin bar and scrollbars for cleaner screenshots
@@ -795,5 +799,16 @@ export function createStudioTools() {
 		name: 'studio',
 		version: '1.0.0',
 		tools: studioToolDefinitions,
+	} );
+}
+
+/** Subset of Studio tools that work with any URL (no local site required). */
+export const remoteCompatibleToolDefinitions = [ takeScreenshotTool ];
+
+export function createRemoteCompatibleTools() {
+	return createSdkMcpServer( {
+		name: 'studio',
+		version: '1.0.0',
+		tools: remoteCompatibleToolDefinitions,
 	} );
 }

--- a/apps/cli/ai/tools.ts
+++ b/apps/cli/ai/tools.ts
@@ -6,6 +6,7 @@ import { z } from 'zod/v4';
 import { validateBlocks, type ValidationReport } from 'cli/ai/block-validator';
 import { getSharedBrowser } from 'cli/ai/browser-utils';
 import { auditPerformance } from 'cli/ai/performance-audit';
+import { createWpcomToolDefinitions } from 'cli/ai/wpcom-tools';
 import { runCommand as runCreatePreviewCommand } from 'cli/commands/preview/create';
 import {
 	Mode as PreviewDeleteMode,
@@ -802,13 +803,15 @@ export function createStudioTools() {
 	} );
 }
 
-/** Subset of Studio tools that work with any URL (no local site required). */
-export const remoteCompatibleToolDefinitions = [ takeScreenshotTool ];
-
-export function createRemoteCompatibleTools() {
+/**
+ * Creates an MCP server for remote WordPress.com sites, combining WP.com REST API tools
+ * with URL-based tools (screenshot) that work with any site.
+ */
+export function createRemoteSiteTools( token: string, siteId: number ) {
+	const wpcomTools = createWpcomToolDefinitions( token, siteId );
 	return createSdkMcpServer( {
 		name: 'studio',
 		version: '1.0.0',
-		tools: remoteCompatibleToolDefinitions,
+		tools: [ ...wpcomTools, takeScreenshotTool ],
 	} );
 }

--- a/apps/cli/ai/ui.ts
+++ b/apps/cli/ai/ui.ts
@@ -56,6 +56,7 @@ export interface SiteInfo {
 	running: boolean;
 	remote?: boolean;
 	url?: string;
+	wpcomSiteId?: number;
 }
 
 const DEFAULT_COLLAPSE_THRESHOLD_LINES = 5;
@@ -828,6 +829,7 @@ export class AiChatUI {
 				running: false,
 				remote: true,
 				url: site.url,
+				wpcomSiteId: site.id,
 			} ) );
 			this.sitePickerRemoteLoading = false;
 			this.rebuildSitePickerList();

--- a/apps/cli/ai/wpcom-tools.ts
+++ b/apps/cli/ai/wpcom-tools.ts
@@ -37,9 +37,10 @@ export function createWpcomToolDefinitions( token: string, siteId: number ) {
 
 	const wpcomRequestTool = tool(
 		'wpcom_request',
-		`Makes a request to the WordPress.com REST API for site ${ siteId }. ` +
-			'Use this to manage posts, pages, templates, media, plugins, themes, settings, and any other site resource. ' +
-			'The path is relative to /sites/{siteId}/ — for example, pass "/posts" to call /sites/{siteId}/posts. ' +
+		`Makes a request to the WordPress REST API (wp/v2) or WordPress.com REST API (v1.1) for site ${ siteId }. ` +
+			'Defaults to the WordPress REST API (wp/v2). Use this to manage posts, pages, templates, template parts, ' +
+			'media, plugins, themes, settings, and any other site resource. ' +
+			'The path is relative to /sites/{siteId}/ — for example, pass "/posts" to call /wp/v2/sites/{siteId}/posts. ' +
 			'For non-site endpoints, start the path with "!" (e.g., "!/me") to use an absolute path.',
 		{
 			method: z
@@ -48,19 +49,28 @@ export function createWpcomToolDefinitions( token: string, siteId: number ) {
 			path: z
 				.string()
 				.describe(
-					'API path relative to /sites/{siteId}/, e.g. "/posts", "/posts/123", "/themes/mine". ' +
+					'API path relative to /sites/{siteId}/, e.g. "/posts", "/posts/123", "/templates", "/template-parts". ' +
 						'Prefix with "!" to use an absolute path (e.g. "!/me").'
 				),
 			query: z
 				.record( z.string(), z.unknown() )
 				.optional()
 				.describe(
-					'Query parameters as key-value pairs, e.g. { "number": 20, "status": "publish" }.'
+					'Query parameters as key-value pairs, e.g. { "per_page": 20, "status": "publish" }.'
 				),
 			body: z
 				.record( z.string(), z.unknown() )
 				.optional()
 				.describe( 'Request body for POST/PUT requests as key-value pairs.' ),
+			apiNamespace: z
+				.string()
+				.optional()
+				.describe(
+					'API namespace. Defaults to "wp/v2" (WordPress REST API). ' +
+						'Set to "wpcom/v2" for WordPress.com v2 endpoints, or omit/leave empty to fall back to WP.com REST API v1.1. ' +
+						'Use wp/v2 for standard WordPress resources (posts, pages, templates, media, users, etc.). ' +
+						'Use WP.com v1.1 (set apiNamespace to "") for WP.com-specific endpoints like /plugins, /themes/mine.'
+				),
 		},
 		async ( args ) => {
 			try {
@@ -72,27 +82,27 @@ export function createWpcomToolDefinitions( token: string, siteId: number ) {
 					fullPath = `/sites/${ siteId }${ relativePath }`;
 				}
 
+				// Default to wp/v2 namespace (WordPress REST API).
+				// An empty string means "use WP.com REST API v1.1" (no apiNamespace → isRestAPI=true in wpcom-xhr-request).
+				const apiNamespace = args.apiNamespace ?? 'wp/v2';
+				const queryParams: Record< string, unknown > = { ...( args.query ?? {} ) };
+				if ( apiNamespace ) {
+					queryParams.apiNamespace = apiNamespace;
+				}
+
 				let result: ApiResponse;
 				switch ( args.method ) {
 					case 'GET':
-						result = await wpcom.req.get< ApiResponse >( fullPath, args.query ?? {} );
+						result = await wpcom.req.get< ApiResponse >( fullPath, queryParams );
 						break;
 					case 'POST':
-						result = await wpcom.req.post< ApiResponse >(
-							fullPath,
-							args.query ?? {},
-							args.body ?? {}
-						);
+						result = await wpcom.req.post< ApiResponse >( fullPath, queryParams, args.body ?? {} );
 						break;
 					case 'PUT':
-						result = await wpcom.req.put< ApiResponse >(
-							fullPath,
-							args.query ?? {},
-							args.body ?? {}
-						);
+						result = await wpcom.req.put< ApiResponse >( fullPath, queryParams, args.body ?? {} );
 						break;
 					case 'DELETE':
-						result = await wpcom.req.del< ApiResponse >( fullPath, args.query ?? {} );
+						result = await wpcom.req.del< ApiResponse >( fullPath, queryParams );
 						break;
 				}
 

--- a/apps/cli/ai/wpcom-tools.ts
+++ b/apps/cli/ai/wpcom-tools.ts
@@ -1,0 +1,516 @@
+import { tool } from '@anthropic-ai/claude-agent-sdk';
+import wpcomFactory from '@studio/common/lib/wpcom-factory';
+import wpcomXhrRequest from '@studio/common/lib/wpcom-xhr-request-factory';
+import { z } from 'zod/v4';
+
+function errorResult( message: string ) {
+	return {
+		content: [ { type: 'text' as const, text: message } ],
+		isError: true,
+	};
+}
+
+function textResult( text: string ) {
+	return {
+		content: [ { type: 'text' as const, text } ],
+	};
+}
+
+function jsonResult( data: unknown ) {
+	return textResult( JSON.stringify( data, null, 2 ) );
+}
+
+function getErrorMessage( error: unknown ): string {
+	if ( error instanceof Error ) {
+		return error.message;
+	}
+	return String( error );
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type ApiResponse = any;
+
+/**
+ * Creates WP.com REST API tool definitions for managing a remote WordPress.com site.
+ * The wpcom client is created once and captured via closure by all tool handlers.
+ */
+export function createWpcomToolDefinitions( token: string, siteId: number ) {
+	const wpcom = wpcomFactory( token, wpcomXhrRequest );
+
+	const getPostsTool = tool(
+		'wpcom_get_posts',
+		'Lists posts or pages on the WordPress.com site. Returns ID, title, status, type, date, and URL for each item.',
+		{
+			type: z
+				.enum( [ 'post', 'page', 'any' ] )
+				.optional()
+				.describe( 'Post type to filter by. Defaults to "post".' ),
+			status: z
+				.enum( [ 'publish', 'draft', 'trash', 'any' ] )
+				.optional()
+				.describe( 'Post status to filter by. Defaults to "publish".' ),
+			number: z.number().optional().describe( 'Number of posts to return. Defaults to 20.' ),
+			search: z.string().optional().describe( 'Search query to filter posts.' ),
+		},
+		async ( args ) => {
+			try {
+				const query: Record< string, unknown > = {
+					number: args.number ?? 20,
+					fields: 'ID,title,status,type,date,URL,slug',
+				};
+				if ( args.type && args.type !== 'any' ) {
+					query.type = args.type;
+				}
+				if ( args.status ) {
+					query.status = args.status;
+				}
+				if ( args.search ) {
+					query.search = args.search;
+				}
+
+				const result = await wpcom.req.get< ApiResponse >( `/sites/${ siteId }/posts`, query );
+				const posts = ( result.posts ?? [] ).map(
+					( p: {
+						ID: number;
+						title: string;
+						status: string;
+						type: string;
+						date: string;
+						URL: string;
+						slug: string;
+					} ) => ( {
+						ID: p.ID,
+						title: p.title,
+						status: p.status,
+						type: p.type,
+						date: p.date,
+						URL: p.URL,
+						slug: p.slug,
+					} )
+				);
+				return jsonResult( { found: result.found, posts } );
+			} catch ( error ) {
+				return errorResult( `Failed to list posts: ${ getErrorMessage( error ) }` );
+			}
+		}
+	);
+
+	const getPostTool = tool(
+		'wpcom_get_post',
+		'Gets a single post or page by ID, including its full content.',
+		{
+			post_id: z.number().describe( 'The post ID.' ),
+		},
+		async ( args ) => {
+			try {
+				const result = await wpcom.req.get< ApiResponse >(
+					`/sites/${ siteId }/posts/${ args.post_id }`
+				);
+				return jsonResult( {
+					ID: result.ID,
+					title: result.title,
+					content: result.content,
+					excerpt: result.excerpt,
+					status: result.status,
+					type: result.type,
+					date: result.date,
+					URL: result.URL,
+					slug: result.slug,
+					featured_image: result.featured_image,
+				} );
+			} catch ( error ) {
+				return errorResult( `Failed to get post: ${ getErrorMessage( error ) }` );
+			}
+		}
+	);
+
+	const createPostTool = tool(
+		'wpcom_create_post',
+		'Creates a new post or page on the WordPress.com site.',
+		{
+			title: z.string().describe( 'The post title.' ),
+			content: z.string().optional().describe( 'The post content (HTML/block markup).' ),
+			status: z
+				.enum( [ 'publish', 'draft', 'private' ] )
+				.optional()
+				.describe( 'Post status. Defaults to "draft".' ),
+			type: z.enum( [ 'post', 'page' ] ).optional().describe( 'Post type. Defaults to "post".' ),
+			excerpt: z.string().optional().describe( 'The post excerpt.' ),
+			slug: z.string().optional().describe( 'URL slug for the post.' ),
+			featured_image: z.string().optional().describe( 'URL of the featured image.' ),
+		},
+		async ( args ) => {
+			try {
+				const body: Record< string, unknown > = {
+					title: args.title,
+					status: args.status ?? 'draft',
+					type: args.type ?? 'post',
+				};
+				if ( args.content !== undefined ) {
+					body.content = args.content;
+				}
+				if ( args.excerpt !== undefined ) {
+					body.excerpt = args.excerpt;
+				}
+				if ( args.slug !== undefined ) {
+					body.slug = args.slug;
+				}
+				if ( args.featured_image !== undefined ) {
+					body.featured_image = args.featured_image;
+				}
+
+				const result = await wpcom.req.post< ApiResponse >(
+					`/sites/${ siteId }/posts/new`,
+					{},
+					body
+				);
+				return jsonResult( {
+					ID: result.ID,
+					title: result.title,
+					status: result.status,
+					type: result.type,
+					URL: result.URL,
+					slug: result.slug,
+				} );
+			} catch ( error ) {
+				return errorResult( `Failed to create post: ${ getErrorMessage( error ) }` );
+			}
+		}
+	);
+
+	const updatePostTool = tool(
+		'wpcom_update_post',
+		'Updates an existing post or page on the WordPress.com site.',
+		{
+			post_id: z.number().describe( 'The post ID to update.' ),
+			title: z.string().optional().describe( 'New title.' ),
+			content: z.string().optional().describe( 'New content (HTML/block markup).' ),
+			status: z
+				.enum( [ 'publish', 'draft', 'private', 'trash' ] )
+				.optional()
+				.describe( 'New status.' ),
+			excerpt: z.string().optional().describe( 'New excerpt.' ),
+			slug: z.string().optional().describe( 'New URL slug.' ),
+			featured_image: z.string().optional().describe( 'URL of the new featured image.' ),
+		},
+		async ( args ) => {
+			try {
+				const body: Record< string, unknown > = {};
+				if ( args.title !== undefined ) {
+					body.title = args.title;
+				}
+				if ( args.content !== undefined ) {
+					body.content = args.content;
+				}
+				if ( args.status !== undefined ) {
+					body.status = args.status;
+				}
+				if ( args.excerpt !== undefined ) {
+					body.excerpt = args.excerpt;
+				}
+				if ( args.slug !== undefined ) {
+					body.slug = args.slug;
+				}
+				if ( args.featured_image !== undefined ) {
+					body.featured_image = args.featured_image;
+				}
+
+				const result = await wpcom.req.post< ApiResponse >(
+					`/sites/${ siteId }/posts/${ args.post_id }`,
+					{},
+					body
+				);
+				return jsonResult( {
+					ID: result.ID,
+					title: result.title,
+					status: result.status,
+					type: result.type,
+					URL: result.URL,
+					slug: result.slug,
+				} );
+			} catch ( error ) {
+				return errorResult( `Failed to update post: ${ getErrorMessage( error ) }` );
+			}
+		}
+	);
+
+	const deletePostTool = tool(
+		'wpcom_delete_post',
+		'Deletes a post or page on the WordPress.com site.',
+		{
+			post_id: z.number().describe( 'The post ID to delete.' ),
+		},
+		async ( args ) => {
+			try {
+				await wpcom.req.post< ApiResponse >( `/sites/${ siteId }/posts/${ args.post_id }/delete` );
+				return textResult( `Post ${ args.post_id } deleted.` );
+			} catch ( error ) {
+				return errorResult( `Failed to delete post: ${ getErrorMessage( error ) }` );
+			}
+		}
+	);
+
+	const listMediaTool = tool(
+		'wpcom_list_media',
+		'Lists media items on the WordPress.com site.',
+		{
+			number: z.number().optional().describe( 'Number of media items to return. Defaults to 20.' ),
+			mime_type: z
+				.string()
+				.optional()
+				.describe( 'Filter by MIME type, e.g. "image" or "image/jpeg".' ),
+		},
+		async ( args ) => {
+			try {
+				const query: Record< string, unknown > = {
+					number: args.number ?? 20,
+					fields: 'ID,URL,title,mime_type,date',
+				};
+				if ( args.mime_type ) {
+					query.mime_type = args.mime_type;
+				}
+
+				const result = await wpcom.req.get< ApiResponse >( `/sites/${ siteId }/media`, query );
+				const media = ( result.media ?? [] ).map(
+					( m: { ID: number; URL: string; title: string; mime_type: string; date: string } ) => ( {
+						ID: m.ID,
+						URL: m.URL,
+						title: m.title,
+						mime_type: m.mime_type,
+						date: m.date,
+					} )
+				);
+				return jsonResult( { found: result.found, media } );
+			} catch ( error ) {
+				return errorResult( `Failed to list media: ${ getErrorMessage( error ) }` );
+			}
+		}
+	);
+
+	const uploadMediaTool = tool(
+		'wpcom_upload_media',
+		'Uploads media to the WordPress.com site from one or more URLs.',
+		{
+			urls: z.array( z.string() ).describe( 'Array of URLs to upload as media.' ),
+		},
+		async ( args ) => {
+			try {
+				const result = await wpcom.req.post< ApiResponse >(
+					`/sites/${ siteId }/media/new`,
+					{},
+					{ media_urls: args.urls }
+				);
+				const media = ( result.media ?? [] ).map(
+					( m: { ID: number; URL: string; title: string } ) => ( {
+						ID: m.ID,
+						URL: m.URL,
+						title: m.title,
+					} )
+				);
+				return jsonResult( { media } );
+			} catch ( error ) {
+				return errorResult( `Failed to upload media: ${ getErrorMessage( error ) }` );
+			}
+		}
+	);
+
+	const listPluginsTool = tool(
+		'wpcom_list_plugins',
+		'Lists installed plugins on the WordPress.com site.',
+		{},
+		async () => {
+			try {
+				const result = await wpcom.req.get< ApiResponse >( `/sites/${ siteId }/plugins` );
+				const plugins = ( result.plugins ?? result ?? [] ).map(
+					( p: { slug: string; name: string; active: boolean; version: string } ) => ( {
+						slug: p.slug,
+						name: p.name,
+						active: p.active,
+						version: p.version,
+					} )
+				);
+				return jsonResult( { plugins } );
+			} catch ( error ) {
+				return errorResult( `Failed to list plugins: ${ getErrorMessage( error ) }` );
+			}
+		}
+	);
+
+	const installPluginTool = tool(
+		'wpcom_install_plugin',
+		'Installs a plugin on the WordPress.com site from the WordPress.org plugin directory.',
+		{
+			slug: z.string().describe( 'The plugin slug from wordpress.org (e.g. "woocommerce").' ),
+		},
+		async ( args ) => {
+			try {
+				const result = await wpcom.req.post< ApiResponse >(
+					`/sites/${ siteId }/plugins/${ args.slug }/install`,
+					{}
+				);
+				return jsonResult( {
+					slug: result.slug ?? args.slug,
+					name: result.name,
+					active: result.active,
+					version: result.version,
+				} );
+			} catch ( error ) {
+				return errorResult( `Failed to install plugin: ${ getErrorMessage( error ) }` );
+			}
+		}
+	);
+
+	const activatePluginTool = tool(
+		'wpcom_activate_plugin',
+		'Activates an installed plugin on the WordPress.com site.',
+		{
+			slug: z.string().describe( 'The plugin slug to activate.' ),
+		},
+		async ( args ) => {
+			try {
+				const result = await wpcom.req.post< ApiResponse >(
+					`/sites/${ siteId }/plugins/${ args.slug }`,
+					{},
+					{ active: true }
+				);
+				return textResult( `Plugin "${ result.name ?? args.slug }" activated.` );
+			} catch ( error ) {
+				return errorResult( `Failed to activate plugin: ${ getErrorMessage( error ) }` );
+			}
+		}
+	);
+
+	const deactivatePluginTool = tool(
+		'wpcom_deactivate_plugin',
+		'Deactivates a plugin on the WordPress.com site.',
+		{
+			slug: z.string().describe( 'The plugin slug to deactivate.' ),
+		},
+		async ( args ) => {
+			try {
+				const result = await wpcom.req.post< ApiResponse >(
+					`/sites/${ siteId }/plugins/${ args.slug }`,
+					{},
+					{ active: false }
+				);
+				return textResult( `Plugin "${ result.name ?? args.slug }" deactivated.` );
+			} catch ( error ) {
+				return errorResult( `Failed to deactivate plugin: ${ getErrorMessage( error ) }` );
+			}
+		}
+	);
+
+	const listThemesTool = tool(
+		'wpcom_list_themes',
+		'Lists available themes on the WordPress.com site.',
+		{},
+		async () => {
+			try {
+				const result = await wpcom.req.get< ApiResponse >( `/sites/${ siteId }/themes` );
+				const themes = ( result.themes ?? [] ).map(
+					( t: { id: string; name: string; active: boolean; version: string } ) => ( {
+						id: t.id,
+						name: t.name,
+						active: t.active,
+						version: t.version,
+					} )
+				);
+				return jsonResult( { themes } );
+			} catch ( error ) {
+				return errorResult( `Failed to list themes: ${ getErrorMessage( error ) }` );
+			}
+		}
+	);
+
+	const activateThemeTool = tool(
+		'wpcom_activate_theme',
+		'Activates a theme on the WordPress.com site.',
+		{
+			theme: z.string().describe( 'The theme slug to activate (e.g. "twentytwentyfive").' ),
+		},
+		async ( args ) => {
+			try {
+				const result = await wpcom.req.post< ApiResponse >(
+					`/sites/${ siteId }/themes/mine`,
+					{},
+					{ theme: args.theme }
+				);
+				return textResult( `Theme "${ result.name ?? args.theme }" activated.` );
+			} catch ( error ) {
+				return errorResult( `Failed to activate theme: ${ getErrorMessage( error ) }` );
+			}
+		}
+	);
+
+	const getSiteInfoTool = tool(
+		'wpcom_get_site_info',
+		'Gets detailed information about the WordPress.com site including name, URL, description, plan, and settings.',
+		{},
+		async () => {
+			try {
+				const result = await wpcom.req.get< ApiResponse >( `/sites/${ siteId }` );
+				return jsonResult( {
+					ID: result.ID,
+					name: result.name,
+					description: result.description,
+					URL: result.URL,
+					is_private: result.is_private,
+					lang: result.lang,
+					plan: result.plan,
+					options: {
+						blogname: result.options?.blogname,
+						blogdescription: result.options?.blogdescription,
+						timezone_string: result.options?.timezone_string,
+						admin_url: result.options?.admin_url,
+						software_version: result.options?.software_version,
+						default_post_format: result.options?.default_post_format,
+					},
+				} );
+			} catch ( error ) {
+				return errorResult( `Failed to get site info: ${ getErrorMessage( error ) }` );
+			}
+		}
+	);
+
+	const updateSettingsTool = tool(
+		'wpcom_update_settings',
+		'Updates site settings on the WordPress.com site. Common settings: blogname, blogdescription, lang, default_post_format, default_category.',
+		{
+			settings: z
+				.record( z.string(), z.unknown() )
+				.describe(
+					'Object of setting key-value pairs to update, e.g. { "blogname": "My Site", "blogdescription": "A great site" }.'
+				),
+		},
+		async ( args ) => {
+			try {
+				const result = await wpcom.req.post< ApiResponse >(
+					`/sites/${ siteId }/settings`,
+					{},
+					args.settings
+				);
+				return jsonResult( { updated: result.updated } );
+			} catch ( error ) {
+				return errorResult( `Failed to update settings: ${ getErrorMessage( error ) }` );
+			}
+		}
+	);
+
+	return [
+		getPostsTool,
+		getPostTool,
+		createPostTool,
+		updatePostTool,
+		deletePostTool,
+		listMediaTool,
+		uploadMediaTool,
+		listPluginsTool,
+		installPluginTool,
+		activatePluginTool,
+		deactivatePluginTool,
+		listThemesTool,
+		activateThemeTool,
+		getSiteInfoTool,
+		updateSettingsTool,
+	];
+}

--- a/apps/cli/ai/wpcom-tools.ts
+++ b/apps/cli/ai/wpcom-tools.ts
@@ -16,10 +16,6 @@ function textResult( text: string ) {
 	};
 }
 
-function jsonResult( data: unknown ) {
-	return textResult( JSON.stringify( data, null, 2 ) );
-}
-
 function getErrorMessage( error: unknown ): string {
 	if ( error instanceof Error ) {
 		return error.message;
@@ -31,486 +27,85 @@ function getErrorMessage( error: unknown ): string {
 type ApiResponse = any;
 
 /**
- * Creates WP.com REST API tool definitions for managing a remote WordPress.com site.
- * The wpcom client is created once and captured via closure by all tool handlers.
+ * Creates a generic WP.com REST API tool for managing a remote WordPress.com site.
+ * Instead of hardcoding individual endpoints, this provides a single flexible tool
+ * that can call any WP.com REST API endpoint. The AI agent determines the correct
+ * endpoints based on its knowledge of the WordPress.com REST API.
  */
 export function createWpcomToolDefinitions( token: string, siteId: number ) {
 	const wpcom = wpcomFactory( token, wpcomXhrRequest );
 
-	const getPostsTool = tool(
-		'wpcom_get_posts',
-		'Lists posts or pages on the WordPress.com site. Returns ID, title, status, type, date, and URL for each item.',
+	const wpcomRequestTool = tool(
+		'wpcom_request',
+		`Makes a request to the WordPress.com REST API for site ${ siteId }. ` +
+			'Use this to manage posts, pages, templates, media, plugins, themes, settings, and any other site resource. ' +
+			'The path is relative to /sites/{siteId}/ — for example, pass "/posts" to call /sites/{siteId}/posts. ' +
+			'For non-site endpoints, start the path with "!" (e.g., "!/me") to use an absolute path.',
 		{
-			type: z
-				.enum( [ 'post', 'page', 'any' ] )
-				.optional()
-				.describe( 'Post type to filter by. Defaults to "post".' ),
-			status: z
-				.enum( [ 'publish', 'draft', 'trash', 'any' ] )
-				.optional()
-				.describe( 'Post status to filter by. Defaults to "publish".' ),
-			number: z.number().optional().describe( 'Number of posts to return. Defaults to 20.' ),
-			search: z.string().optional().describe( 'Search query to filter posts.' ),
-		},
-		async ( args ) => {
-			try {
-				const query: Record< string, unknown > = {
-					number: args.number ?? 20,
-					fields: 'ID,title,status,type,date,URL,slug',
-				};
-				if ( args.type && args.type !== 'any' ) {
-					query.type = args.type;
-				}
-				if ( args.status ) {
-					query.status = args.status;
-				}
-				if ( args.search ) {
-					query.search = args.search;
-				}
-
-				const result = await wpcom.req.get< ApiResponse >( `/sites/${ siteId }/posts`, query );
-				const posts = ( result.posts ?? [] ).map(
-					( p: {
-						ID: number;
-						title: string;
-						status: string;
-						type: string;
-						date: string;
-						URL: string;
-						slug: string;
-					} ) => ( {
-						ID: p.ID,
-						title: p.title,
-						status: p.status,
-						type: p.type,
-						date: p.date,
-						URL: p.URL,
-						slug: p.slug,
-					} )
-				);
-				return jsonResult( { found: result.found, posts } );
-			} catch ( error ) {
-				return errorResult( `Failed to list posts: ${ getErrorMessage( error ) }` );
-			}
-		}
-	);
-
-	const getPostTool = tool(
-		'wpcom_get_post',
-		'Gets a single post or page by ID, including its full content.',
-		{
-			post_id: z.number().describe( 'The post ID.' ),
-		},
-		async ( args ) => {
-			try {
-				const result = await wpcom.req.get< ApiResponse >(
-					`/sites/${ siteId }/posts/${ args.post_id }`
-				);
-				return jsonResult( {
-					ID: result.ID,
-					title: result.title,
-					content: result.content,
-					excerpt: result.excerpt,
-					status: result.status,
-					type: result.type,
-					date: result.date,
-					URL: result.URL,
-					slug: result.slug,
-					featured_image: result.featured_image,
-				} );
-			} catch ( error ) {
-				return errorResult( `Failed to get post: ${ getErrorMessage( error ) }` );
-			}
-		}
-	);
-
-	const createPostTool = tool(
-		'wpcom_create_post',
-		'Creates a new post or page on the WordPress.com site.',
-		{
-			title: z.string().describe( 'The post title.' ),
-			content: z.string().optional().describe( 'The post content (HTML/block markup).' ),
-			status: z
-				.enum( [ 'publish', 'draft', 'private' ] )
-				.optional()
-				.describe( 'Post status. Defaults to "draft".' ),
-			type: z.enum( [ 'post', 'page' ] ).optional().describe( 'Post type. Defaults to "post".' ),
-			excerpt: z.string().optional().describe( 'The post excerpt.' ),
-			slug: z.string().optional().describe( 'URL slug for the post.' ),
-			featured_image: z.string().optional().describe( 'URL of the featured image.' ),
-		},
-		async ( args ) => {
-			try {
-				const body: Record< string, unknown > = {
-					title: args.title,
-					status: args.status ?? 'draft',
-					type: args.type ?? 'post',
-				};
-				if ( args.content !== undefined ) {
-					body.content = args.content;
-				}
-				if ( args.excerpt !== undefined ) {
-					body.excerpt = args.excerpt;
-				}
-				if ( args.slug !== undefined ) {
-					body.slug = args.slug;
-				}
-				if ( args.featured_image !== undefined ) {
-					body.featured_image = args.featured_image;
-				}
-
-				const result = await wpcom.req.post< ApiResponse >(
-					`/sites/${ siteId }/posts/new`,
-					{},
-					body
-				);
-				return jsonResult( {
-					ID: result.ID,
-					title: result.title,
-					status: result.status,
-					type: result.type,
-					URL: result.URL,
-					slug: result.slug,
-				} );
-			} catch ( error ) {
-				return errorResult( `Failed to create post: ${ getErrorMessage( error ) }` );
-			}
-		}
-	);
-
-	const updatePostTool = tool(
-		'wpcom_update_post',
-		'Updates an existing post or page on the WordPress.com site.',
-		{
-			post_id: z.number().describe( 'The post ID to update.' ),
-			title: z.string().optional().describe( 'New title.' ),
-			content: z.string().optional().describe( 'New content (HTML/block markup).' ),
-			status: z
-				.enum( [ 'publish', 'draft', 'private', 'trash' ] )
-				.optional()
-				.describe( 'New status.' ),
-			excerpt: z.string().optional().describe( 'New excerpt.' ),
-			slug: z.string().optional().describe( 'New URL slug.' ),
-			featured_image: z.string().optional().describe( 'URL of the new featured image.' ),
-		},
-		async ( args ) => {
-			try {
-				const body: Record< string, unknown > = {};
-				if ( args.title !== undefined ) {
-					body.title = args.title;
-				}
-				if ( args.content !== undefined ) {
-					body.content = args.content;
-				}
-				if ( args.status !== undefined ) {
-					body.status = args.status;
-				}
-				if ( args.excerpt !== undefined ) {
-					body.excerpt = args.excerpt;
-				}
-				if ( args.slug !== undefined ) {
-					body.slug = args.slug;
-				}
-				if ( args.featured_image !== undefined ) {
-					body.featured_image = args.featured_image;
-				}
-
-				const result = await wpcom.req.post< ApiResponse >(
-					`/sites/${ siteId }/posts/${ args.post_id }`,
-					{},
-					body
-				);
-				return jsonResult( {
-					ID: result.ID,
-					title: result.title,
-					status: result.status,
-					type: result.type,
-					URL: result.URL,
-					slug: result.slug,
-				} );
-			} catch ( error ) {
-				return errorResult( `Failed to update post: ${ getErrorMessage( error ) }` );
-			}
-		}
-	);
-
-	const deletePostTool = tool(
-		'wpcom_delete_post',
-		'Deletes a post or page on the WordPress.com site.',
-		{
-			post_id: z.number().describe( 'The post ID to delete.' ),
-		},
-		async ( args ) => {
-			try {
-				await wpcom.req.post< ApiResponse >( `/sites/${ siteId }/posts/${ args.post_id }/delete` );
-				return textResult( `Post ${ args.post_id } deleted.` );
-			} catch ( error ) {
-				return errorResult( `Failed to delete post: ${ getErrorMessage( error ) }` );
-			}
-		}
-	);
-
-	const listMediaTool = tool(
-		'wpcom_list_media',
-		'Lists media items on the WordPress.com site.',
-		{
-			number: z.number().optional().describe( 'Number of media items to return. Defaults to 20.' ),
-			mime_type: z
+			method: z
+				.enum( [ 'GET', 'POST', 'PUT', 'DELETE' ] )
+				.describe( 'HTTP method for the request.' ),
+			path: z
 				.string()
+				.describe(
+					'API path relative to /sites/{siteId}/, e.g. "/posts", "/posts/123", "/themes/mine". ' +
+						'Prefix with "!" to use an absolute path (e.g. "!/me").'
+				),
+			query: z
+				.record( z.string(), z.unknown() )
 				.optional()
-				.describe( 'Filter by MIME type, e.g. "image" or "image/jpeg".' ),
+				.describe(
+					'Query parameters as key-value pairs, e.g. { "number": 20, "status": "publish" }.'
+				),
+			body: z
+				.record( z.string(), z.unknown() )
+				.optional()
+				.describe( 'Request body for POST/PUT requests as key-value pairs.' ),
 		},
 		async ( args ) => {
 			try {
-				const query: Record< string, unknown > = {
-					number: args.number ?? 20,
-					fields: 'ID,URL,title,mime_type,date',
-				};
-				if ( args.mime_type ) {
-					query.mime_type = args.mime_type;
+				let fullPath: string;
+				if ( args.path.startsWith( '!' ) ) {
+					fullPath = args.path.slice( 1 );
+				} else {
+					const relativePath = args.path.startsWith( '/' ) ? args.path : `/${ args.path }`;
+					fullPath = `/sites/${ siteId }${ relativePath }`;
 				}
 
-				const result = await wpcom.req.get< ApiResponse >( `/sites/${ siteId }/media`, query );
-				const media = ( result.media ?? [] ).map(
-					( m: { ID: number; URL: string; title: string; mime_type: string; date: string } ) => ( {
-						ID: m.ID,
-						URL: m.URL,
-						title: m.title,
-						mime_type: m.mime_type,
-						date: m.date,
-					} )
-				);
-				return jsonResult( { found: result.found, media } );
+				let result: ApiResponse;
+				switch ( args.method ) {
+					case 'GET':
+						result = await wpcom.req.get< ApiResponse >( fullPath, args.query ?? {} );
+						break;
+					case 'POST':
+						result = await wpcom.req.post< ApiResponse >(
+							fullPath,
+							args.query ?? {},
+							args.body ?? {}
+						);
+						break;
+					case 'PUT':
+						result = await wpcom.req.put< ApiResponse >(
+							fullPath,
+							args.query ?? {},
+							args.body ?? {}
+						);
+						break;
+					case 'DELETE':
+						result = await wpcom.req.del< ApiResponse >( fullPath, args.query ?? {} );
+						break;
+				}
+
+				return textResult( JSON.stringify( result, null, 2 ) );
 			} catch ( error ) {
-				return errorResult( `Failed to list media: ${ getErrorMessage( error ) }` );
+				return errorResult(
+					`WP.com API request failed (${ args.method } ${ args.path }): ${ getErrorMessage(
+						error
+					) }`
+				);
 			}
 		}
 	);
 
-	const uploadMediaTool = tool(
-		'wpcom_upload_media',
-		'Uploads media to the WordPress.com site from one or more URLs.',
-		{
-			urls: z.array( z.string() ).describe( 'Array of URLs to upload as media.' ),
-		},
-		async ( args ) => {
-			try {
-				const result = await wpcom.req.post< ApiResponse >(
-					`/sites/${ siteId }/media/new`,
-					{},
-					{ media_urls: args.urls }
-				);
-				const media = ( result.media ?? [] ).map(
-					( m: { ID: number; URL: string; title: string } ) => ( {
-						ID: m.ID,
-						URL: m.URL,
-						title: m.title,
-					} )
-				);
-				return jsonResult( { media } );
-			} catch ( error ) {
-				return errorResult( `Failed to upload media: ${ getErrorMessage( error ) }` );
-			}
-		}
-	);
-
-	const listPluginsTool = tool(
-		'wpcom_list_plugins',
-		'Lists installed plugins on the WordPress.com site.',
-		{},
-		async () => {
-			try {
-				const result = await wpcom.req.get< ApiResponse >( `/sites/${ siteId }/plugins` );
-				const plugins = ( result.plugins ?? result ?? [] ).map(
-					( p: { slug: string; name: string; active: boolean; version: string } ) => ( {
-						slug: p.slug,
-						name: p.name,
-						active: p.active,
-						version: p.version,
-					} )
-				);
-				return jsonResult( { plugins } );
-			} catch ( error ) {
-				return errorResult( `Failed to list plugins: ${ getErrorMessage( error ) }` );
-			}
-		}
-	);
-
-	const installPluginTool = tool(
-		'wpcom_install_plugin',
-		'Installs a plugin on the WordPress.com site from the WordPress.org plugin directory.',
-		{
-			slug: z.string().describe( 'The plugin slug from wordpress.org (e.g. "woocommerce").' ),
-		},
-		async ( args ) => {
-			try {
-				const result = await wpcom.req.post< ApiResponse >(
-					`/sites/${ siteId }/plugins/${ args.slug }/install`,
-					{}
-				);
-				return jsonResult( {
-					slug: result.slug ?? args.slug,
-					name: result.name,
-					active: result.active,
-					version: result.version,
-				} );
-			} catch ( error ) {
-				return errorResult( `Failed to install plugin: ${ getErrorMessage( error ) }` );
-			}
-		}
-	);
-
-	const activatePluginTool = tool(
-		'wpcom_activate_plugin',
-		'Activates an installed plugin on the WordPress.com site.',
-		{
-			slug: z.string().describe( 'The plugin slug to activate.' ),
-		},
-		async ( args ) => {
-			try {
-				const result = await wpcom.req.post< ApiResponse >(
-					`/sites/${ siteId }/plugins/${ args.slug }`,
-					{},
-					{ active: true }
-				);
-				return textResult( `Plugin "${ result.name ?? args.slug }" activated.` );
-			} catch ( error ) {
-				return errorResult( `Failed to activate plugin: ${ getErrorMessage( error ) }` );
-			}
-		}
-	);
-
-	const deactivatePluginTool = tool(
-		'wpcom_deactivate_plugin',
-		'Deactivates a plugin on the WordPress.com site.',
-		{
-			slug: z.string().describe( 'The plugin slug to deactivate.' ),
-		},
-		async ( args ) => {
-			try {
-				const result = await wpcom.req.post< ApiResponse >(
-					`/sites/${ siteId }/plugins/${ args.slug }`,
-					{},
-					{ active: false }
-				);
-				return textResult( `Plugin "${ result.name ?? args.slug }" deactivated.` );
-			} catch ( error ) {
-				return errorResult( `Failed to deactivate plugin: ${ getErrorMessage( error ) }` );
-			}
-		}
-	);
-
-	const listThemesTool = tool(
-		'wpcom_list_themes',
-		'Lists available themes on the WordPress.com site.',
-		{},
-		async () => {
-			try {
-				const result = await wpcom.req.get< ApiResponse >( `/sites/${ siteId }/themes` );
-				const themes = ( result.themes ?? [] ).map(
-					( t: { id: string; name: string; active: boolean; version: string } ) => ( {
-						id: t.id,
-						name: t.name,
-						active: t.active,
-						version: t.version,
-					} )
-				);
-				return jsonResult( { themes } );
-			} catch ( error ) {
-				return errorResult( `Failed to list themes: ${ getErrorMessage( error ) }` );
-			}
-		}
-	);
-
-	const activateThemeTool = tool(
-		'wpcom_activate_theme',
-		'Activates a theme on the WordPress.com site.',
-		{
-			theme: z.string().describe( 'The theme slug to activate (e.g. "twentytwentyfive").' ),
-		},
-		async ( args ) => {
-			try {
-				const result = await wpcom.req.post< ApiResponse >(
-					`/sites/${ siteId }/themes/mine`,
-					{},
-					{ theme: args.theme }
-				);
-				return textResult( `Theme "${ result.name ?? args.theme }" activated.` );
-			} catch ( error ) {
-				return errorResult( `Failed to activate theme: ${ getErrorMessage( error ) }` );
-			}
-		}
-	);
-
-	const getSiteInfoTool = tool(
-		'wpcom_get_site_info',
-		'Gets detailed information about the WordPress.com site including name, URL, description, plan, and settings.',
-		{},
-		async () => {
-			try {
-				const result = await wpcom.req.get< ApiResponse >( `/sites/${ siteId }` );
-				return jsonResult( {
-					ID: result.ID,
-					name: result.name,
-					description: result.description,
-					URL: result.URL,
-					is_private: result.is_private,
-					lang: result.lang,
-					plan: result.plan,
-					options: {
-						blogname: result.options?.blogname,
-						blogdescription: result.options?.blogdescription,
-						timezone_string: result.options?.timezone_string,
-						admin_url: result.options?.admin_url,
-						software_version: result.options?.software_version,
-						default_post_format: result.options?.default_post_format,
-					},
-				} );
-			} catch ( error ) {
-				return errorResult( `Failed to get site info: ${ getErrorMessage( error ) }` );
-			}
-		}
-	);
-
-	const updateSettingsTool = tool(
-		'wpcom_update_settings',
-		'Updates site settings on the WordPress.com site. Common settings: blogname, blogdescription, lang, default_post_format, default_category.',
-		{
-			settings: z
-				.record( z.string(), z.unknown() )
-				.describe(
-					'Object of setting key-value pairs to update, e.g. { "blogname": "My Site", "blogdescription": "A great site" }.'
-				),
-		},
-		async ( args ) => {
-			try {
-				const result = await wpcom.req.post< ApiResponse >(
-					`/sites/${ siteId }/settings`,
-					{},
-					args.settings
-				);
-				return jsonResult( { updated: result.updated } );
-			} catch ( error ) {
-				return errorResult( `Failed to update settings: ${ getErrorMessage( error ) }` );
-			}
-		}
-	);
-
-	return [
-		getPostsTool,
-		getPostTool,
-		createPostTool,
-		updatePostTool,
-		deletePostTool,
-		listMediaTool,
-		uploadMediaTool,
-		listPluginsTool,
-		installPluginTool,
-		activatePluginTool,
-		deactivatePluginTool,
-		listThemesTool,
-		activateThemeTool,
-		getSiteInfoTool,
-		updateSettingsTool,
-	];
+	return [ wpcomRequestTool ];
 }

--- a/apps/cli/commands/ai/index.ts
+++ b/apps/cli/commands/ai/index.ts
@@ -162,6 +162,7 @@ export async function runCommand(
 				path: site.path,
 				remote: site.remote,
 				url: site.url,
+				wpcomSiteId: site.wpcomSiteId,
 			} )
 		);
 	};
@@ -369,15 +370,22 @@ export async function runCommand(
 		ui.beginAgentTurn();
 
 		// Prepend active site context to the prompt.
-		// Remote (WordPress.com) sites only have a URL; local sites have a filesystem path and running state.
+		// Remote (WordPress.com) sites only have a URL and site ID; local sites have a filesystem path and running state.
 		let enrichedPrompt = prompt;
 		const site = ui.activeSite;
 		if ( site?.remote && site?.url ) {
-			enrichedPrompt = `[Active site: "${ site.name }" at ${ site.url } (WordPress.com)]\n\n${ prompt }`;
+			enrichedPrompt = `[Active site: "${ site.name }" (ID: ${ site.wpcomSiteId }) at ${ site.url } (WordPress.com)]\n\n${ prompt }`;
 		} else if ( site ) {
 			enrichedPrompt = `[Active site: "${ site.name }" at ${ site.path }${
 				site.running ? ' (running)' : ' (stopped)'
 			}]\n\n${ prompt }`;
+		}
+
+		// Read the WP.com access token for remote sites
+		let wpcomAccessToken: string | undefined;
+		if ( site?.remote ) {
+			const token = await readAuthToken();
+			wpcomAccessToken = token?.accessToken;
 		}
 
 		await persistSessionContext();
@@ -395,6 +403,8 @@ export async function runCommand(
 			env,
 			model: currentModel,
 			resume: sessionId,
+			activeSite: site,
+			wpcomAccessToken,
 			onAskUser: ( questions ) => askUserAndPersistAnswers( questions ),
 		} );
 


### PR DESCRIPTION
## Related issues

- Related to remote site support in the AI command

## How AI was used in this PR

AI-assisted implementation. All code reviewed and tested manually.

## Proposed Changes

- When a remote WordPress.com site is selected in the AI command, the agent now gets a `wpcom_request` tool that can call any WordPress.com REST API endpoint, instead of using local Studio tools
- The `wpcom_request` tool is a generic REST API client — it takes a method, path, query, and body, and the agent determines the right endpoints based on its knowledge of the WordPress REST API
- Defaults to the WordPress REST API (`wp/v2`) for standard resources (posts, pages, templates, template parts, navigation, global styles, etc.), with fallback to WP.com REST API v1.1 for WP.com-specific endpoints (plugins, theme switching, site settings)
- Local sites continue using WP-CLI and file operations as before (no behavior change)
- System prompt is now fully site-aware with separate content/design guidelines for local vs remote:
  - Local: custom CSS, animations, scroll effects, theme files (unchanged)
  - Remote (free WP.com): informs users that design customizations require a paid plan, documents what's possible on free plans
- The `take_screenshot` tool is available for remote sites (works with any URL)
- `wpcomSiteId` is preserved through `SiteInfo`, prompt enrichment, and session recording
- Includes hints for non-obvious API patterns (e.g., discovering the global styles ID from the active theme's `_links`)

## Testing Instructions

- Select a local site in `studio ai` → verify it works as before (WP-CLI, file ops, Studio tools)
- Select a remote WordPress.com site → verify the agent uses `mcp__studio__wpcom_request` and can manage content, templates, and take screenshots
- Ask the agent to modify a block theme template on a remote site → verify it uses wp/v2 endpoints
- Ask the agent for design changes on a free WP.com site → verify it explains the paid plan limitation
- Verify the system prompt documents wp/v2 and v1.1 endpoints when a remote site is active

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?