### PR TITLE
Add localWP WordPress site import support

### DIFF
--- a/apps/studio/src/hooks/use-add-site.ts
+++ b/apps/studio/src/hooks/use-add-site.ts
@@ -16,6 +16,7 @@ import { syncOperationsThunks } from 'src/stores/sync';
 import { useConnectSiteMutation } from 'src/stores/sync/connected-sites';
 import { Blueprint } from 'src/stores/wpcom-api';
 import type { BlueprintPreferredVersions } from '@studio/common/lib/blueprint-validation';
+import type { LocalWPSite } from 'src/lib/import-export/import/types';
 import type { SyncSite } from 'src/modules/sync/types';
 import type { SyncOption } from 'src/types';
 
@@ -57,6 +58,7 @@ export function useAddSite() {
 	const [ fileForImport, setFileForImport ] = useState< File | null >( null );
 	const [ selectedBlueprint, setSelectedBlueprint ] = useState< Blueprint | undefined >();
 	const [ selectedRemoteSite, setSelectedRemoteSite ] = useState< SyncSite | undefined >();
+	const [ selectedLocalWPSite, setSelectedLocalWPSite ] = useState< LocalWPSite | undefined >();
 	const [ blueprintPreferredVersions, setBlueprintPreferredVersions ] = useState<
 		BlueprintPreferredVersions | undefined
 	>();
@@ -105,6 +107,7 @@ export function useAddSite() {
 		setBlueprintSuggestedSiteName( undefined );
 		setBlueprintRequiresCustomDomain( false );
 		setSelectedRemoteSite( undefined );
+		setSelectedLocalWPSite( undefined );
 		setDeeplinkPhpVersion( DEFAULT_PHP_VERSION );
 		setDeeplinkWpVersion( DEFAULT_WORDPRESS_VERSION );
 		clearDeeplinkState();
@@ -243,7 +246,7 @@ export function useAddSite() {
 					usedCustomDomain = generateCustomDomainFromSiteName( formValues.siteName );
 				}
 				// For import/sync workflows, the respective handlers will start the server
-				const shouldSkipStart = !! fileForImport || !! selectedRemoteSite;
+				const shouldSkipStart = !! fileForImport || !! selectedRemoteSite || !! selectedLocalWPSite;
 
 				const enableHttps = formValues.useCustomDomain ? formValues.enableHttps : false;
 				let updatedBlueprint: Blueprint | undefined;
@@ -277,6 +280,23 @@ export function useAddSite() {
 							getIpcApi().showNotification( {
 								title: newSite.name,
 								body: __( 'Your new site was imported' ),
+							} );
+						} else if ( selectedLocalWPSite ) {
+							const importSource = await getIpcApi().prepareLocalWPImport(
+								selectedLocalWPSite.path,
+								selectedLocalWPSite.localWPId,
+								selectedLocalWPSite.mysqlVersion,
+								selectedLocalWPSite.mysqlPort
+							);
+							await importFile( importSource, newSite, {
+								showImportNotification: false,
+								isNewSite: true,
+							} );
+							clearImportState( newSite.id );
+
+							getIpcApi().showNotification( {
+								title: newSite.name,
+								body: __( 'Your site was imported from Local' ),
 							} );
 						} else if ( selectedRemoteSite && client ) {
 							await connectSite( { site: selectedRemoteSite, localSiteId: newSite.id } );
@@ -315,6 +335,7 @@ export function useAddSite() {
 			fileForImport,
 			importFile,
 			selectedBlueprint,
+			selectedLocalWPSite,
 			selectedRemoteSite,
 			connectSite,
 			setSelectedTab,
@@ -348,6 +369,8 @@ export function useAddSite() {
 			setBlueprintRequiresCustomDomain,
 			selectedRemoteSite,
 			setSelectedRemoteSite,
+			selectedLocalWPSite,
+			setSelectedLocalWPSite,
 			existingDomainNames,
 			loadAllCustomDomains,
 			isDeeplinkFlow,
@@ -373,6 +396,7 @@ export function useAddSite() {
 			blueprintSuggestedSiteName,
 			blueprintRequiresCustomDomain,
 			selectedRemoteSite,
+			selectedLocalWPSite,
 			existingDomainNames,
 			loadAllCustomDomains,
 			isDeeplinkFlow,

--- a/apps/studio/src/ipc-handlers.ts
+++ b/apps/studio/src/ipc-handlers.ts
@@ -1,4 +1,4 @@
-import { exec, ExecOptions } from 'child_process';
+import { exec, execFile, spawn, ExecOptions } from 'child_process';
 import {
 	BrowserWindow,
 	Menu,
@@ -64,7 +64,7 @@ import { exportBackup } from 'src/lib/import-export/export/export-manager';
 import { ExportOptions } from 'src/lib/import-export/export/types';
 import { ImportExportEventData } from 'src/lib/import-export/handle-events';
 import { defaultImporterOptions, importBackup } from 'src/lib/import-export/import/import-manager';
-import { BackupArchiveInfo } from 'src/lib/import-export/import/types';
+import { BackupArchiveInfo, LocalWPSite } from 'src/lib/import-export/import/types';
 import { getUserLocaleWithFallback } from 'src/lib/locale-node';
 import { setSentryWpcomUserIdMain } from 'src/lib/main-sentry-utils';
 import * as oauthClient from 'src/lib/oauth';
@@ -378,8 +378,22 @@ export async function importSite(
 		// Clear blueprint so it doesn't overwrite imported data on first start
 		site.meta.blueprint = undefined;
 
+		// For Local WP directory imports: fix the site URL (imported DB has the
+		// old Local WP domain) and deactivate plugins that may force HTTPS or
+		// use MySQL-specific features incompatible with Studio's SQLite environment.
+		if ( backupFile.type === 'directory' ) {
+			const siteUrl = `http://localhost:${ site.details.port }`;
+			await updateSiteUrlAfterImport( event, id, siteUrl );
+			// Clean up the prep directory (SQL dumps, symlinks) created by prepareLocalWPImport
+			await fsPromises.rm( backupFile.path, { recursive: true } ).catch( () => {} );
+		}
+
 		return site.details;
 	} catch ( e ) {
+		// Clean up the prep directory on failure too
+		if ( backupFile.type === 'directory' ) {
+			await fsPromises.rm( backupFile.path, { recursive: true } ).catch( () => {} );
+		}
 		bumpStat( StatsGroup.STUDIO_IMPORT, StatsMetric.FAILURE );
 		// Don't report validation errors to Sentry - these are expected user errors
 		if (
@@ -1737,4 +1751,357 @@ export async function updateSitesSortOrder(
 	} finally {
 		await unlockAppdata();
 	}
+}
+
+export async function getLocalWPSites( _event: IpcMainInvokeEvent ): Promise< LocalWPSite[] > {
+	const configPath = nodePath.join( app.getPath( 'appData' ), 'Local', 'sites.json' );
+
+	try {
+		const data = await fsPromises.readFile( configPath, 'utf-8' );
+		const parsed: unknown = JSON.parse( data );
+
+		if ( ! parsed || typeof parsed !== 'object' || Array.isArray( parsed ) ) {
+			return [];
+		}
+
+		const sitesConfig = parsed as Record< string, Record< string, unknown > >;
+		const sites: LocalWPSite[] = [];
+
+		for ( const [ id, site ] of Object.entries( sitesConfig ) ) {
+			if ( ! site || typeof site !== 'object' ) {
+				continue;
+			}
+
+			const rawPath = typeof site.path === 'string' ? site.path : '';
+			const sitePath = rawPath.replace( /^~/, os.homedir() );
+
+			// Ensure path is absolute to prevent path traversal
+			if ( ! sitePath || ! nodePath.isAbsolute( sitePath ) ) {
+				continue;
+			}
+
+			const wpContentPath = nodePath.join( sitePath, 'app', 'public', 'wp-content' );
+			if ( ! ( await pathExists( wpContentPath ) ) ) {
+				continue;
+			}
+
+			const services = site.services as Record< string, Record< string, unknown > > | undefined;
+			const mysqlVersion =
+				typeof services?.mysql?.version === 'string' ? services.mysql.version : undefined;
+			const mysqlPorts = services?.mysql?.ports as Record< string, number[] > | undefined;
+			const mysqlPort = mysqlPorts?.MYSQL?.[ 0 ];
+
+			sites.push( {
+				id: typeof site.id === 'string' ? site.id : id,
+				name: typeof site.name === 'string' ? site.name : nodePath.basename( sitePath ),
+				path: sitePath,
+				phpVersion: typeof services?.php?.version === 'string' ? services.php.version : '',
+				domain: typeof site.domain === 'string' ? site.domain : '',
+				localWPId: id,
+				mysqlVersion,
+				mysqlPort: typeof mysqlPort === 'number' ? mysqlPort : undefined,
+			} );
+		}
+
+		return sites;
+	} catch {
+		// Config file not found or invalid
+		return [];
+	}
+}
+
+export async function prepareLocalWPImport(
+	_event: IpcMainInvokeEvent,
+	sitePath: string,
+	localWPId: string,
+	mysqlVersion?: string,
+	mysqlPort?: number
+): Promise< BackupArchiveInfo > {
+	if ( ! nodePath.isAbsolute( sitePath ) ) {
+		throw new Error( 'Invalid site path.' );
+	}
+
+	// Verify sitePath is a known Local WP site to prevent a compromised
+	// renderer from pointing the import at arbitrary filesystem locations.
+	const knownSites = await getLocalWPSites( _event );
+	if ( ! knownSites.some( ( s ) => s.path === sitePath ) ) {
+		throw new Error( 'Site path does not match any known Local WP site.' );
+	}
+
+	// Validate IDs to prevent path traversal
+	const pathTraversalPattern = /[/\\]/;
+	if ( pathTraversalPattern.test( localWPId ) ) {
+		throw new Error( 'Invalid Local WP site ID.' );
+	}
+	if ( mysqlVersion && pathTraversalPattern.test( mysqlVersion ) ) {
+		throw new Error( 'Invalid MySQL version.' );
+	}
+
+	const localAppData = app.getPath( 'appData' );
+	const dataDir = nodePath.join( localAppData, 'Local', 'run', localWPId, 'mysql', 'data' );
+
+	if ( ! ( await pathExists( dataDir ) ) ) {
+		throw new Error( 'Could not find the MySQL data directory for this site.' );
+	}
+
+	// Find Local WP's bundled MySQL binaries
+	const mysqlServiceDir = nodePath.join( localAppData, 'Local', 'lightning-services' );
+	let mysqldBin = '';
+	let mysqldumpBin = '';
+
+	if ( mysqlVersion ) {
+		const candidates = [
+			nodePath.join(
+				mysqlServiceDir,
+				`mysql-${ mysqlVersion }`,
+				'bin',
+				`darwin-${ process.arch }`,
+				'bin'
+			),
+			nodePath.join( mysqlServiceDir, `mysql-${ mysqlVersion }`, 'bin', 'darwin', 'bin' ),
+		];
+		for ( const binDir of candidates ) {
+			if ( await pathExists( nodePath.join( binDir, 'mysqld' ) ) ) {
+				mysqldBin = nodePath.join( binDir, 'mysqld' );
+				mysqldumpBin = nodePath.join( binDir, 'mysqldump' );
+				break;
+			}
+		}
+	}
+
+	// Fallback: search for any available MySQL binary
+	if ( ! mysqldBin ) {
+		try {
+			const serviceDirs = await fsPromises.readdir( mysqlServiceDir );
+			for ( const dir of serviceDirs
+				.filter( ( d ) => d.startsWith( 'mysql-' ) )
+				.sort()
+				.reverse() ) {
+				const candidates = [
+					nodePath.join( mysqlServiceDir, dir, 'bin', `darwin-${ process.arch }`, 'bin' ),
+					nodePath.join( mysqlServiceDir, dir, 'bin', 'darwin', 'bin' ),
+				];
+				for ( const binDir of candidates ) {
+					if ( await pathExists( nodePath.join( binDir, 'mysqld' ) ) ) {
+						mysqldBin = nodePath.join( binDir, 'mysqld' );
+						mysqldumpBin = nodePath.join( binDir, 'mysqldump' );
+						break;
+					}
+				}
+				if ( mysqldBin ) {
+					break;
+				}
+			}
+		} catch {
+			// Could not read lightning-services directory
+		}
+	}
+
+	if ( ! mysqldBin || ! mysqldumpBin ) {
+		throw new Error(
+			'Could not find MySQL binaries from Local WP. Make sure Local WP is installed.'
+		);
+	}
+
+	const tmpDir = await fsPromises.mkdtemp( nodePath.join( os.tmpdir(), 'studio_local_prep' ) );
+	const tmpSqlDir = nodePath.join( tmpDir, 'app', 'sql' );
+	await fsPromises.mkdir( tmpSqlDir, { recursive: true } );
+
+	const mysqlBin = nodePath.join( nodePath.dirname( mysqldumpBin ), 'mysql' );
+
+	// Helper: list tables and dump each to a separate file using the given connection args
+	async function dumpDatabase( connectionArgs: string[] ) {
+		const tables = await new Promise< string[] >( ( resolve, reject ) => {
+			execFile(
+				mysqlBin,
+				[ ...connectionArgs, '-N', '-e', 'SHOW TABLES', 'local' ],
+				{ maxBuffer: 10 * 1024 * 1024 },
+				( error, stdout, stderr ) => {
+					if ( error ) {
+						reject( new Error( `Failed to list tables.\n${ stderr }` ) );
+						return;
+					}
+					resolve(
+						stdout
+							.split( '\n' )
+							.map( ( t ) => t.trim() )
+							.filter( Boolean )
+							.filter( ( t ) => ! /[/\\]/.test( t ) )
+					);
+				}
+			);
+		} );
+
+		for ( const table of tables ) {
+			const tableDumpPath = nodePath.join( tmpSqlDir, `${ table }.sql` );
+			await new Promise< void >( ( resolve, reject ) => {
+				// Stream mysqldump output directly to file instead of buffering
+				// in memory, since tables like wp_postmeta can be very large.
+				const dumpProcess = spawn(
+					mysqldumpBin,
+					[ ...connectionArgs, '--no-tablespaces', '--skip-extended-insert', 'local', table ],
+					{ stdio: [ 'ignore', 'pipe', 'pipe' ] }
+				);
+
+				const outStream = fs.createWriteStream( tableDumpPath );
+				dumpProcess.stdout?.pipe( outStream );
+
+				let stderrData = '';
+				dumpProcess.stderr?.on( 'data', ( data: Buffer ) => {
+					stderrData += data.toString();
+				} );
+
+				dumpProcess.on( 'close', ( code ) => {
+					if ( code !== 0 ) {
+						reject( new Error( `Failed to export table ${ table }.\n${ stderrData }` ) );
+					} else {
+						resolve();
+					}
+				} );
+				dumpProcess.on( 'error', reject );
+			} );
+		}
+	}
+
+	try {
+		// Try connecting to the site's running MySQL instance first (if Local WP is running).
+		// Fall back to starting a temporary MySQL server if the site isn't running.
+		let dumpSucceeded = false;
+
+		if ( mysqlPort ) {
+			try {
+				await dumpDatabase( [
+					`--host=127.0.0.1`,
+					`--port=${ mysqlPort }`,
+					'--user=root',
+					'--password=root',
+				] );
+				dumpSucceeded = true;
+			} catch {
+				// Site isn't running in Local WP — fall back to temporary server
+			}
+		}
+
+		if ( ! dumpSucceeded ) {
+			const socketPath = nodePath.join( tmpDir, 'mysql.sock' );
+			const pidFile = nodePath.join( tmpDir, 'mysql.pid' );
+
+			// Start a temporary MySQL server with the site's data directory.
+			// Uses --skip-networking (no TCP) and --skip-grant-tables (no auth).
+			// Cannot use --innodb-read-only because InnoDB may need to perform
+			// redo log recovery if MySQL wasn't shut down cleanly.
+			const mysqldProcess = spawn(
+				mysqldBin,
+				[
+					`--datadir=${ dataDir }`,
+					`--socket=${ socketPath }`,
+					'--port=0',
+					'--skip-networking',
+					`--pid-file=${ pidFile }`,
+					'--skip-grant-tables',
+				],
+				{ stdio: [ 'ignore', 'ignore', 'pipe' ] }
+			);
+
+			let mysqldStderr = '';
+			mysqldProcess.stderr?.on( 'data', ( data: Buffer ) => {
+				mysqldStderr += data.toString();
+			} );
+
+			// Wait for MySQL to be ready (socket file appears)
+			const maxWait = 20000;
+			const startTime = Date.now();
+			while ( Date.now() - startTime < maxWait ) {
+				if ( await pathExists( socketPath ) ) {
+					break;
+				}
+				await new Promise( ( r ) => setTimeout( r, 300 ) );
+			}
+
+			if ( ! ( await pathExists( socketPath ) ) ) {
+				mysqldProcess.kill();
+				throw new Error(
+					`MySQL server failed to start within the timeout period.\n${ mysqldStderr }`
+				);
+			}
+
+			try {
+				await dumpDatabase( [ `--socket=${ socketPath }`, '--user=root' ] );
+			} finally {
+				// Shut down the temporary MySQL server and wait for exit
+				await new Promise< void >( ( resolve ) => {
+					mysqldProcess.on( 'exit', resolve );
+					mysqldProcess.kill();
+					setTimeout( () => {
+						mysqldProcess.kill( 'SIGKILL' );
+						resolve();
+					}, 5000 );
+				} );
+			}
+		}
+
+		// Symlink the app/public directory so the DirectoryHandler picks up wp-content
+		const publicSrc = nodePath.join( sitePath, 'app', 'public' );
+		const publicDest = nodePath.join( tmpDir, 'app', 'public' );
+		if ( await pathExists( publicSrc ) ) {
+			await fsPromises.symlink( publicSrc, publicDest );
+		}
+
+		// Copy local-site.json if it exists
+		const metaFile = nodePath.join( sitePath, 'local-site.json' );
+		if ( await pathExists( metaFile ) ) {
+			await fsPromises.copyFile( metaFile, nodePath.join( tmpDir, 'local-site.json' ) );
+		}
+
+		return { path: tmpDir, type: 'directory' };
+	} catch ( e ) {
+		await fsPromises.rm( tmpDir, { recursive: true } ).catch( () => {} );
+		throw e;
+	}
+}
+
+async function updateSiteUrlAfterImport(
+	_event: IpcMainInvokeEvent,
+	siteId: string,
+	newUrl: string
+): Promise< void > {
+	// Validate URL format and restrict to HTTP(S) schemes
+	let parsedUrl;
+	try {
+		parsedUrl = new URL( newUrl );
+	} catch {
+		throw new Error( 'Invalid URL provided.' );
+	}
+	if ( parsedUrl.protocol !== 'http:' && parsedUrl.protocol !== 'https:' ) {
+		throw new Error( 'Invalid URL scheme. Only http and https are allowed.' );
+	}
+
+	const server = SiteServer.get( siteId );
+	if ( ! server ) {
+		throw new Error( 'Site not found.' );
+	}
+	const dbPath = nodePath.join( server.details.path, 'wp-content', 'database', '.ht.sqlite' );
+	if ( ! ( await pathExists( dbPath ) ) ) {
+		throw new Error( 'SQLite database not found.' );
+	}
+
+	const escapedUrl = newUrl.replace( /'/g, "''" );
+	const sql = [
+		`UPDATE wp_options SET option_value = '${ escapedUrl }' WHERE option_name = 'siteurl';`,
+		`UPDATE wp_options SET option_value = '${ escapedUrl }' WHERE option_name = 'home';`,
+		// Deactivate all plugins — imported plugins may force HTTPS,
+		// use MySQL-specific features, or otherwise break under Studio's
+		// SQLite/PHP-WASM environment. Users can reactivate from WP admin.
+		`UPDATE wp_options SET option_value = 'a:0:{}' WHERE option_name = 'active_plugins';`,
+	].join( ' ' );
+
+	await new Promise< void >( ( resolve, reject ) => {
+		execFile( 'sqlite3', [ dbPath, sql ], ( error, _stdout, stderr ) => {
+			if ( error ) {
+				reject( new Error( `Failed to update site settings: ${ stderr }` ) );
+				return;
+			}
+			resolve();
+		} );
+	} );
 }

--- a/apps/studio/src/lib/import-export/import/handlers/backup-handler-directory.ts
+++ b/apps/studio/src/lib/import-export/import/handlers/backup-handler-directory.ts
@@ -1,0 +1,119 @@
+import { EventEmitter } from 'events';
+import fs from 'fs';
+import path from 'path';
+import { ImportEvents } from 'src/lib/import-export/import/events';
+import {
+	BackupHandler,
+	isFileAllowed,
+} from 'src/lib/import-export/import/handlers/backup-handler-factory';
+import {
+	BackupArchiveInfo,
+	BackupExtractProgressEventData,
+} from 'src/lib/import-export/import/types';
+
+async function walkDirectory(
+	dir: string,
+	baseDir: string,
+	visited: Set< string > = new Set()
+): Promise< string[] > {
+	// Resolve to real path to detect circular symlinks
+	let realDir;
+	try {
+		realDir = await fs.promises.realpath( dir );
+	} catch {
+		return [];
+	}
+	if ( visited.has( realDir ) ) {
+		return [];
+	}
+	visited.add( realDir );
+
+	const files: string[] = [];
+	let entries;
+	try {
+		entries = await fs.promises.readdir( dir, { withFileTypes: true } );
+	} catch {
+		return files;
+	}
+	for ( const entry of entries ) {
+		const fullPath = path.join( dir, entry.name );
+
+		if ( entry.isSymbolicLink() ) {
+			// Follow symlinks only if they resolve to a directory
+			// (used by prepareLocalWPImport to link app/public)
+			try {
+				const resolved = await fs.promises.realpath( fullPath );
+				const stat = await fs.promises.stat( resolved );
+				if ( stat.isDirectory() ) {
+					files.push( ...( await walkDirectory( fullPath, baseDir, visited ) ) );
+				}
+			} catch {
+				// Skip broken or inaccessible symlinks
+			}
+			continue;
+		}
+
+		if ( entry.isDirectory() ) {
+			files.push( ...( await walkDirectory( fullPath, baseDir, visited ) ) );
+		} else if ( entry.isFile() ) {
+			const relativePath = path.relative( baseDir, fullPath );
+			if ( isFileAllowed( relativePath ) ) {
+				files.push( relativePath );
+			}
+		}
+	}
+	return files;
+}
+
+export class BackupHandlerDirectory extends EventEmitter implements BackupHandler {
+	async listFiles( backup: BackupArchiveInfo ): Promise< string[] > {
+		return walkDirectory( backup.path, backup.path );
+	}
+
+	async extractFiles( file: BackupArchiveInfo, extractionDirectory: string ): Promise< void > {
+		this.emit( ImportEvents.BACKUP_EXTRACT_START );
+
+		try {
+			const fileList = await this.listFiles( file );
+			const totalFiles = fileList.length;
+			let processedFiles = 0;
+
+			for ( const relativePath of fileList ) {
+				const sourcePath = path.join( file.path, relativePath );
+				const destPath = path.join( extractionDirectory, relativePath );
+
+				// Resolve symlinks to get the real source file
+				let realSourcePath;
+				try {
+					realSourcePath = await fs.promises.realpath( sourcePath );
+				} catch {
+					continue;
+				}
+
+				await fs.promises.mkdir( path.dirname( destPath ), { recursive: true } );
+
+				// Use hardlinks instead of copying to avoid duplicating large files
+				// (e.g. wp-content uploads). Falls back to copy if hardlink fails
+				// (cross-device or unsupported filesystem).
+				try {
+					await fs.promises.link( realSourcePath, destPath );
+				} catch {
+					await fs.promises.copyFile( realSourcePath, destPath );
+				}
+
+				processedFiles++;
+				this.emit( ImportEvents.BACKUP_EXTRACT_PROGRESS, {
+					progress: processedFiles / totalFiles,
+					processedFiles,
+					totalFiles,
+					currentFile: relativePath,
+				} as BackupExtractProgressEventData );
+			}
+
+			this.emit( ImportEvents.BACKUP_EXTRACT_COMPLETE );
+		} catch ( error ) {
+			this.emit( ImportEvents.BACKUP_EXTRACT_ERROR, { error } );
+			throw error;
+		}
+	}
+}

--- a/apps/studio/src/lib/import-export/import/handlers/backup-handler-factory.ts
+++ b/apps/studio/src/lib/import-export/import/handlers/backup-handler-factory.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from 'events';
+import { BackupHandlerDirectory } from 'src/lib/import-export/import/handlers/backup-handler-directory';
 import { BackupHandlerSql } from 'src/lib/import-export/import/handlers/backup-handler-sql';
 import { BackupHandlerTarGz } from 'src/lib/import-export/import/handlers/backup-handler-tar-gz';
 import { BackupHandlerWpress } from 'src/lib/import-export/import/handlers/backup-handler-wpress';
@@ -47,7 +48,9 @@ export class BackupHandlerFactory {
 	private static sqlExtensions = [ '.sql' ];
 
 	static create( file: BackupArchiveInfo ): BackupHandler | undefined {
-		if ( this.isZip( file ) ) {
+		if ( file.type === 'directory' ) {
+			return new BackupHandlerDirectory();
+		} else if ( this.isZip( file ) ) {
 			return new BackupHandlerZip();
 		} else if ( this.isTarGz( file ) ) {
 			return new BackupHandlerTarGz();

--- a/apps/studio/src/lib/import-export/import/types.ts
+++ b/apps/studio/src/lib/import-export/import/types.ts
@@ -23,6 +23,17 @@ export interface BackupArchiveInfo {
 
 export type NewImporter = new ( backup: BackupContents ) => Importer;
 
+export interface LocalWPSite {
+	id: string;
+	name: string;
+	path: string;
+	phpVersion: string;
+	domain: string;
+	localWPId: string;
+	mysqlVersion?: string;
+	mysqlPort?: number;
+}
+
 export interface BackupExtractProgressEventData {
 	progress: number;
 	processedFiles?: number;

--- a/apps/studio/src/modules/add-site/components/import-local.tsx
+++ b/apps/studio/src/modules/add-site/components/import-local.tsx
@@ -1,0 +1,131 @@
+import {
+	__experimentalVStack as VStack,
+	__experimentalHStack as HStack,
+	__experimentalHeading as Heading,
+	__experimentalText as Text,
+	Spinner,
+} from '@wordpress/components';
+import { useI18n } from '@wordpress/react-i18n';
+import { useCallback, useEffect, useState } from 'react';
+import { cx } from 'src/lib/cx';
+import { getIpcApi } from 'src/lib/get-ipc-api';
+import type { LocalWPSite } from 'src/lib/import-export/import/types';
+
+interface ImportLocalProps {
+	selectedSite?: LocalWPSite;
+	onSiteSelect: ( site?: LocalWPSite ) => void;
+}
+
+export default function ImportLocal( { selectedSite, onSiteSelect }: ImportLocalProps ) {
+	const { __ } = useI18n();
+	const [ sites, setSites ] = useState< LocalWPSite[] >( [] );
+	const [ isLoading, setIsLoading ] = useState( true );
+	const [ error, setError ] = useState< string | null >( null );
+
+	useEffect( () => {
+		let cancelled = false;
+		setIsLoading( true );
+		setError( null );
+		getIpcApi()
+			.getLocalWPSites()
+			.then( ( result ) => {
+				if ( ! cancelled ) {
+					setSites( result );
+					setIsLoading( false );
+				}
+			} )
+			.catch( () => {
+				if ( ! cancelled ) {
+					setError( __( 'Could not detect Local WP sites.' ) );
+					setIsLoading( false );
+				}
+			} );
+		return () => {
+			cancelled = true;
+		};
+	}, [ __ ] );
+
+	const handleSiteClick = useCallback(
+		( site: LocalWPSite ) => {
+			if ( selectedSite?.id === site.id ) {
+				onSiteSelect( undefined );
+			} else {
+				onSiteSelect( site );
+			}
+		},
+		[ selectedSite, onSiteSelect ]
+	);
+
+	return (
+		<VStack className="text-center w-full" alignment="top" spacing={ 0 }>
+			<Heading className="text-center text-[32px] text-frame-text mb-2" weight={ 500 }>
+				{ __( 'Import from Local' ) }
+			</Heading>
+			<Text className="text-[15px] font-light text-frame-text-secondary max-w-sm mb-6 mx-auto">
+				{ __( 'Select a site from Local WP to import into Studio.' ) }
+			</Text>
+
+			{ isLoading && (
+				<div className="flex justify-center py-12">
+					<Spinner />
+				</div>
+			) }
+
+			{ error && <Text className="text-red-500 text-sm">{ error }</Text> }
+
+			{ ! isLoading && ! error && sites.length === 0 && (
+				<VStack className="py-12 items-center" spacing={ 2 }>
+					<Text className="text-frame-text-secondary text-sm">
+						{ __( 'No Local WP sites found.' ) }
+					</Text>
+					<Text className="text-frame-text-secondary text-xs max-w-sm">
+						{ __( 'Make sure Local WP is installed and has sites configured.' ) }
+					</Text>
+				</VStack>
+			) }
+
+			{ ! isLoading && sites.length > 0 && (
+				<div className="w-full max-w-[460px] mx-auto max-h-[340px] overflow-y-auto">
+					<VStack spacing={ 2 }>
+						{ sites.map( ( site ) => {
+							const isSelected = selectedSite?.id === site.id;
+							return (
+								<HStack
+									key={ site.id }
+									as="button"
+									aria-label={ site.name }
+									aria-pressed={ isSelected }
+									className={ cx(
+										'w-full p-3 border rounded-lg text-left',
+										'rtl:text-right',
+										'transition-colors',
+										isSelected
+											? 'border-frame-theme bg-frame-surface'
+											: 'border-frame-border hover:border-frame-text-secondary hover:bg-frame-surface'
+									) }
+									alignment="center"
+									onClick={ () => handleSiteClick( site ) }
+									spacing={ 3 }
+								>
+									<VStack className="flex-1 gap-0.5 min-w-0">
+										<Text className="text-[14px] text-frame-text truncate" weight="500">
+											{ site.name }
+										</Text>
+										<Text className="text-[12px] text-frame-text-secondary truncate">
+											{ site.domain || site.path }
+										</Text>
+									</VStack>
+									{ site.phpVersion && (
+										<Text className="text-[11px] text-frame-text-secondary shrink-0">
+											{ `PHP ${ site.phpVersion }` }
+										</Text>
+									) }
+								</HStack>
+							);
+						} ) }
+					</VStack>
+				</div>
+			) }
+		</VStack>
+	);
+}

--- a/apps/studio/src/modules/add-site/components/options.tsx
+++ b/apps/studio/src/modules/add-site/components/options.tsx
@@ -4,7 +4,7 @@ import {
 	__experimentalHeading as Heading,
 	__experimentalText as Text,
 } from '@wordpress/components';
-import { Icon, plus, backup, chevronRight, chevronLeft, download } from '@wordpress/icons';
+import { Icon, plus, backup, chevronRight, chevronLeft, download, desktop } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { Tooltip } from 'src/components/tooltip';
 import { useFeatureFlags } from 'src/hooks/use-feature-flags';
@@ -17,7 +17,8 @@ export type AddSiteFlowType =
 	| 'blueprint'
 	| 'blueprintDeeplink'
 	| 'backup'
-	| 'pullRemote';
+	| 'pullRemote'
+	| 'importLocal';
 interface AddSiteOptionsProps {
 	onOptionSelect: ( option: AddSiteFlowType ) => void;
 }
@@ -130,6 +131,12 @@ export default function AddSiteOptions( { onOptionSelect }: AddSiteOptionsProps 
 				title={ __( 'Import from a backup' ) }
 				description={ __( 'Start a site from a backup' ) }
 				onClick={ () => onOptionSelect( 'backup' ) }
+			/>
+			<OptionButton
+				icon={ <Icon icon={ desktop } size={ 24 } fill="var(--color-frame-theme)" /> }
+				title={ __( 'Import from Local' ) }
+				description={ __( 'Import an existing site from Local WP' ) }
+				onClick={ () => onOptionSelect( 'importLocal' ) }
 			/>
 		</VStack>
 	);

--- a/apps/studio/src/modules/add-site/components/stepper.tsx
+++ b/apps/studio/src/modules/add-site/components/stepper.tsx
@@ -13,12 +13,14 @@ interface StepperProps {
 	onBlueprintDeeplinkContinue?: () => void;
 	onBackupContinue?: () => void;
 	onPullRemoteContinue?: () => void;
+	onImportLocalContinue?: () => void;
 	onCreateSubmit?: ( event: FormEvent ) => void;
 	canSubmitBlueprint?: boolean;
 	canSubmitBlueprintDetails?: boolean;
 	canSubmitBlueprintDeeplink?: boolean;
 	canSubmitBackup?: boolean;
 	canSubmitPullRemote?: boolean;
+	canSubmitImportLocal?: boolean;
 	canSubmitCreate?: boolean;
 }
 
@@ -30,12 +32,14 @@ export default function Stepper( {
 	onBlueprintDeeplinkContinue,
 	onBackupContinue,
 	onPullRemoteContinue,
+	onImportLocalContinue,
 	onCreateSubmit,
 	canSubmitBlueprint,
 	canSubmitBlueprintDetails,
 	canSubmitBlueprintDeeplink,
 	canSubmitBackup,
 	canSubmitPullRemote,
+	canSubmitImportLocal,
 	canSubmitCreate,
 }: StepperProps ) {
 	const { __ } = useI18n();
@@ -45,12 +49,14 @@ export default function Stepper( {
 		onBlueprintDeeplinkContinue,
 		onBackupContinue,
 		onPullRemoteContinue,
+		onImportLocalContinue,
 		onCreateSubmit,
 		canSubmitBlueprint,
 		canSubmitBlueprintDetails,
 		canSubmitBlueprintDeeplink,
 		canSubmitBackup,
 		canSubmitPullRemote,
+		canSubmitImportLocal,
 		canSubmitCreate,
 	} );
 

--- a/apps/studio/src/modules/add-site/hooks/use-stepper.ts
+++ b/apps/studio/src/modules/add-site/hooks/use-stepper.ts
@@ -20,12 +20,14 @@ interface StepperConfig {
 	onBlueprintDeeplinkContinue?: () => void;
 	onBackupContinue?: () => void;
 	onPullRemoteContinue?: () => void;
+	onImportLocalContinue?: () => void;
 	onCreateSubmit?: ( event: FormEvent ) => void;
 	canSubmitBlueprint?: boolean;
 	canSubmitBlueprintDetails?: boolean;
 	canSubmitBlueprintDeeplink?: boolean;
 	canSubmitBackup?: boolean;
 	canSubmitPullRemote?: boolean;
+	canSubmitImportLocal?: boolean;
 	canSubmitCreate?: boolean;
 }
 
@@ -75,6 +77,11 @@ export function useStepper( config?: StepperConfig ): UseStepper {
 			{ id: 'site-details', label: __( 'Site name & details' ), path: '/pullRemote/create' },
 		];
 
+		const importLocalSteps: StepperStep[] = [
+			{ id: 'select-local-site', label: __( 'Select a site' ), path: '/importLocal' },
+			{ id: 'site-details', label: __( 'Site name & details' ), path: '/importLocal/create' },
+		];
+
 		const blueprintDeeplinkSteps: StepperStep[] = [
 			{ id: 'blueprint-selected', label: __( 'Blueprint details' ), path: '/blueprint/deeplink' },
 			{
@@ -102,6 +109,13 @@ export function useStepper( config?: StepperConfig ): UseStepper {
 			return {
 				flow: 'backup',
 				steps: backupSteps,
+			};
+		}
+
+		if ( location.path?.startsWith( '/importLocal' ) ) {
+			return {
+				flow: 'importLocal',
+				steps: importLocalSteps,
 			};
 		}
 
@@ -178,6 +192,7 @@ export function useStepper( config?: StepperConfig ): UseStepper {
 			case '/blueprint/deeplink':
 			case '/backup':
 			case '/pullRemote':
+			case '/importLocal':
 				return {
 					label: __( 'Continue' ),
 					isVisible: true,
@@ -187,6 +202,7 @@ export function useStepper( config?: StepperConfig ): UseStepper {
 			case '/blueprint/deeplink/create':
 			case '/backup/create':
 			case '/pullRemote/create':
+			case '/importLocal/create':
 				return {
 					label: __( 'Add site' ),
 					isVisible: true,
@@ -216,11 +232,15 @@ export function useStepper( config?: StepperConfig ): UseStepper {
 			case '/pullRemote':
 				config?.onPullRemoteContinue?.();
 				break;
+			case '/importLocal':
+				config?.onImportLocalContinue?.();
+				break;
 			case '/create':
 			case '/blueprint/select/create':
 			case '/blueprint/deeplink/create':
 			case '/backup/create':
 			case '/pullRemote/create':
+			case '/importLocal/create':
 				config?.onCreateSubmit?.( { preventDefault: () => {} } as FormEvent );
 				break;
 		}
@@ -241,11 +261,14 @@ export function useStepper( config?: StepperConfig ): UseStepper {
 				return config?.canSubmitBackup ?? false;
 			case '/pullRemote':
 				return config?.canSubmitPullRemote ?? false;
+			case '/importLocal':
+				return config?.canSubmitImportLocal ?? false;
 			case '/create':
 			case '/blueprint/select/create':
 			case '/blueprint/deeplink/create':
 			case '/backup/create':
 			case '/pullRemote/create':
+			case '/importLocal/create':
 				return config?.canSubmitCreate ?? false;
 			default:
 				return false;

--- a/apps/studio/src/modules/add-site/index.tsx
+++ b/apps/studio/src/modules/add-site/index.tsx
@@ -31,11 +31,13 @@ import BlueprintDetails from './components/blueprint-details';
 import { AddSiteBlueprintSelector } from './components/blueprints';
 import CreateSite from './components/create-site';
 import ImportBackup from './components/import-backup';
+import ImportLocal from './components/import-local';
 import AddSiteOptions, { type AddSiteFlowType } from './components/options';
 import { PullRemoteSite } from './components/pull-remote-site';
 import Stepper from './components/stepper';
 import { useFindAvailableSiteName } from './hooks/use-find-available-site-name';
 import { applyBlueprintFormValues } from './lib/apply-blueprint-form-values';
+import type { LocalWPSite } from 'src/lib/import-export/import/types';
 
 type BlueprintsData = ReturnType< typeof useGetBlueprints >[ 'data' ];
 
@@ -86,6 +88,8 @@ interface NavigationContentProps {
 	setBlueprintRequiresCustomDomain: ( requires: boolean ) => void;
 	selectedRemoteSite?: SyncSite;
 	setSelectedRemoteSite: ( site?: SyncSite ) => void;
+	selectedLocalWPSite?: LocalWPSite;
+	setSelectedLocalWPSite: ( site?: LocalWPSite ) => void;
 	isDeeplinkFlow: boolean;
 	setIsDeeplinkFlow: ( isDeeplink: boolean ) => void;
 }
@@ -123,6 +127,8 @@ function NavigationContent( props: NavigationContentProps ) {
 		setBlueprintRequiresCustomDomain,
 		selectedRemoteSite,
 		setSelectedRemoteSite,
+		selectedLocalWPSite,
+		setSelectedLocalWPSite,
 		isDeeplinkFlow,
 		setIsDeeplinkFlow,
 	} = props;
@@ -144,6 +150,8 @@ function NavigationContent( props: NavigationContentProps ) {
 				goTo( '/backup' );
 			} else if ( option === 'pullRemote' ) {
 				goTo( '/pullRemote' );
+			} else if ( option === 'importLocal' ) {
+				goTo( '/importLocal' );
 			}
 		},
 		[ goTo ]
@@ -176,6 +184,7 @@ function NavigationContent( props: NavigationContentProps ) {
 
 	const findAvailableSiteName = useFindAvailableSiteName();
 	const [ remoteSiteName, setRemoteSiteName ] = useState( '' );
+	const [ localWPSiteName, setLocalWPSiteName ] = useState( '' );
 
 	const handlePullRemoteContinue = useCallback( async () => {
 		if ( selectedRemoteSite ) {
@@ -184,6 +193,14 @@ function NavigationContent( props: NavigationContentProps ) {
 			goTo( '/pullRemote/create' );
 		}
 	}, [ findAvailableSiteName, goTo, selectedRemoteSite ] );
+
+	const handleImportLocalContinue = useCallback( async () => {
+		if ( selectedLocalWPSite ) {
+			const availableName = await findAvailableSiteName( selectedLocalWPSite.name );
+			setLocalWPSiteName( availableName );
+			goTo( '/importLocal/create' );
+		}
+	}, [ findAvailableSiteName, goTo, selectedLocalWPSite ] );
 
 	const blueprints = useMemo(
 		() => blueprintsData?.blueprints.slice().reverse() || [],
@@ -210,12 +227,16 @@ function NavigationContent( props: NavigationContentProps ) {
 		} else if ( location.path === '/pullRemote/create' ) {
 			setRemoteSiteName( '' );
 			goTo( '/pullRemote' );
+		} else if ( location.path === '/importLocal/create' ) {
+			setLocalWPSiteName( '' );
+			goTo( '/importLocal' );
 		} else if (
 			location.path === '/backup' ||
 			location.path === '/blueprint/select' ||
 			location.path === '/blueprint/deeplink' ||
 			location.path === '/create' ||
-			location.path === '/pullRemote'
+			location.path === '/pullRemote' ||
+			location.path === '/importLocal'
 		) {
 			if ( location.path === '/backup' ) {
 				setFileForImport( null );
@@ -229,6 +250,10 @@ function NavigationContent( props: NavigationContentProps ) {
 			if ( location.path === '/pullRemote' ) {
 				setSelectedRemoteSite( undefined );
 				setRemoteSiteName( '' );
+			}
+			if ( location.path === '/importLocal' ) {
+				setSelectedLocalWPSite( undefined );
+				setLocalWPSiteName( '' );
 			}
 			goToFirstStep();
 		} else {
@@ -244,6 +269,7 @@ function NavigationContent( props: NavigationContentProps ) {
 		setBlueprintWarnings,
 		setSelectedRemoteSite,
 		setBlueprintSuggestedSiteName,
+		setSelectedLocalWPSite,
 	] );
 
 	const handleBlueprintFormValues = useCallback(
@@ -403,6 +429,15 @@ function NavigationContent( props: NavigationContentProps ) {
 					defaultValues={ { ...defaultValues, siteName: remoteSiteName } }
 				/>
 			</Navigator.Screen>
+			<Navigator.Screen className="flex-1" path="/importLocal">
+				<ImportLocal selectedSite={ selectedLocalWPSite } onSiteSelect={ setSelectedLocalWPSite } />
+			</Navigator.Screen>
+			<Navigator.Screen className="flex-1" path="/importLocal/create">
+				<CreateSite
+					{ ...createSiteProps }
+					defaultValues={ { ...defaultValues, siteName: localWPSiteName } }
+				/>
+			</Navigator.Screen>
 			<Stepper
 				currentPath={ location.path }
 				onBack={ handleBack }
@@ -411,6 +446,7 @@ function NavigationContent( props: NavigationContentProps ) {
 				onBlueprintDeeplinkContinue={ handleBlueprintDeeplinkContinue }
 				onBackupContinue={ handleBackupContinue }
 				onPullRemoteContinue={ handlePullRemoteContinue }
+				onImportLocalContinue={ handleImportLocalContinue }
 				onCreateSubmit={ () => {
 					formRef.current?.requestSubmit();
 				} }
@@ -419,6 +455,7 @@ function NavigationContent( props: NavigationContentProps ) {
 				canSubmitBlueprintDeeplink={ !! selectedBlueprint }
 				canSubmitBackup={ !! fileForImport }
 				canSubmitPullRemote={ !! selectedRemoteSite }
+				canSubmitImportLocal={ !! selectedLocalWPSite }
 				canSubmitCreate={ canSubmit }
 			/>
 		</>
@@ -476,6 +513,8 @@ export function AddSiteModalContent( {
 		setBlueprintRequiresCustomDomain,
 		selectedRemoteSite,
 		setSelectedRemoteSite,
+		selectedLocalWPSite,
+		setSelectedLocalWPSite,
 		existingDomainNames,
 		loadAllCustomDomains,
 		isDeeplinkFlow,
@@ -619,6 +658,8 @@ export function AddSiteModalContent( {
 				setBlueprintRequiresCustomDomain={ setBlueprintRequiresCustomDomain }
 				selectedRemoteSite={ selectedRemoteSite }
 				setSelectedRemoteSite={ setSelectedRemoteSite }
+				selectedLocalWPSite={ selectedLocalWPSite }
+				setSelectedLocalWPSite={ setSelectedLocalWPSite }
 				isDeeplinkFlow={ isDeeplinkFlow }
 				setIsDeeplinkFlow={ setIsDeeplinkFlow }
 				startOver={ startOver }

--- a/apps/studio/src/preload.ts
+++ b/apps/studio/src/preload.ts
@@ -156,6 +156,9 @@ const api: IpcApi = {
 	setWindowControlVisibility: ( visible ) =>
 		ipcRendererInvoke( 'setWindowControlVisibility', visible ),
 	updateSitesSortOrder: ( updates ) => ipcRendererInvoke( 'updateSitesSortOrder', updates ),
+	getLocalWPSites: () => ipcRendererInvoke( 'getLocalWPSites' ),
+	prepareLocalWPImport: ( sitePath, localWPId, mysqlVersion, mysqlPort ) =>
+		ipcRendererInvoke( 'prepareLocalWPImport', sitePath, localWPId, mysqlVersion, mysqlPort ),
 	isStudioCliInstalled: () => ipcRendererInvoke( 'isStudioCliInstalled' ),
 	installStudioCli: () => ipcRendererInvoke( 'installStudioCli' ),
 	uninstallStudioCli: () => ipcRendererInvoke( 'uninstallStudioCli' ),


### PR DESCRIPTION
## Related issues

- Fixes #

## How AI was used in this PR

AI was used to develop code, which I reviewed and tested across different LocalWP sites.

## Proposed Changes

- Add "Import from Local" option to the Add Site flow. Allows importing from LocalWP (https://localwp.com)
- Reads LocalWP's sites.json to detect sites.
- Exports database using LocalWP's MySQL.
- After import, update site URL to Studio's localhost address and deactivate plugins (which may rely on MySQL-specific features or force HTTPS). On complex sites, plugins would cause crashes. 

## Testing Instructions

- Install and configure sites via LocalWP (https://localwp.com) 
- Sites will be detected in Studio, import the site, and it will copy contents from LocalWP and configure.
- Test site loads as expected

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React, or other console errors?
