### PR TITLE
Add optional Artifact Signing for Windows builds

### DIFF
--- a/.buildkite/commands/build-for-windows.ps1
+++ b/.buildkite/commands/build-for-windows.ps1
@@ -28,7 +28,7 @@ if ($Architecture -notin $VALID_ARCHITECTURES) {
     Exit 1
 }
 
-If ($env:USE_AZURE_TRUSTED_SIGNING) {
+If (@('1', 'true') -contains ($env:USE_AZURE_TRUSTED_SIGNING ?? '').Trim().ToLower()) {
     Write-Host "--- :lock: Setting up Azure Trusted Signing"
     $setupScript = (Get-Command setup_azure_trusted_signing.ps1 -ErrorAction Stop).Source
     & $setupScript

--- a/.buildkite/commands/build-for-windows.ps1
+++ b/.buildkite/commands/build-for-windows.ps1
@@ -28,9 +28,16 @@ if ($Architecture -notin $VALID_ARCHITECTURES) {
     Exit 1
 }
 
-# setup_windows_code_signing.ps1 comes from CI Toolkit Plugin
-& "setup_windows_code_signing.ps1"
-If ($LastExitCode -ne 0) { Exit $LastExitCode }
+If ($env:USE_AZURE_TRUSTED_SIGNING) {
+    Write-Host "--- :lock: Setting up Azure Trusted Signing"
+    $setupScript = (Get-Command setup_azure_trusted_signing.ps1 -ErrorAction Stop).Source
+    & $setupScript
+    If ($LastExitCode -ne 0) { Exit $LastExitCode }
+} Else {
+    # setup_windows_code_signing.ps1 comes from CI Toolkit Plugin
+    & "setup_windows_code_signing.ps1"
+    If ($LastExitCode -ne 0) { Exit $LastExitCode }
+}
 
 Write-Host "--- :npm: Installing Node dependencies"
 bash .buildkite/commands/install-node-dependencies.sh

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -138,6 +138,8 @@ steps:
       - label: 🔨 Windows Dev Build - {{matrix}}
         agents:
           queue: windows
+        env:
+          USE_AZURE_TRUSTED_SIGNING: 1
         command: powershell -File .buildkite/commands/build-for-windows.ps1 -BuildType dev -Architecture {{matrix}}
         artifact_paths:
           - apps\studio\out\**\studio-setup.exe

--- a/.buildkite/release-build-and-distribute.yml
+++ b/.buildkite/release-build-and-distribute.yml
@@ -68,6 +68,8 @@ steps:
       - label: 🔨 Windows Release Build - {{matrix}}
         agents:
           queue: windows
+        env:
+          USE_AZURE_TRUSTED_SIGNING: 1
         command: |
           bash .buildkite/commands/checkout-release-branch.sh "${RELEASE_VERSION}"
           powershell -File .buildkite/commands/build-for-windows.ps1 -BuildType release -Architecture {{matrix}}

--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -5,7 +5,7 @@
 
 # The ~> modifier is not currently used, but we check for it just in case
 XCODE_VERSION=$(sed -E -n 's/^(~> )?(.*)/xcode-\2/p' .xcode-version)
-CI_TOOLKIT_VERSION='6.0.1'
+CI_TOOLKIT_VERSION='add-azure-trusted-signing'
 NVM_PLUGIN_VERSION='0.6.0'
 
 export IMAGE_ID="$XCODE_VERSION"

--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -5,7 +5,7 @@
 
 # The ~> modifier is not currently used, but we check for it just in case
 XCODE_VERSION=$(sed -E -n 's/^(~> )?(.*)/xcode-\2/p' .xcode-version)
-CI_TOOLKIT_VERSION='4411dd924c08dea251702db5760e741c9d81eff2'
+CI_TOOLKIT_VERSION='6.1.0'
 NVM_PLUGIN_VERSION='0.6.0'
 
 export IMAGE_ID="$XCODE_VERSION"

--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -5,7 +5,7 @@
 
 # The ~> modifier is not currently used, but we check for it just in case
 XCODE_VERSION=$(sed -E -n 's/^(~> )?(.*)/xcode-\2/p' .xcode-version)
-CI_TOOLKIT_VERSION='add-azure-trusted-signing'
+CI_TOOLKIT_VERSION='4411dd924c08dea251702db5760e741c9d81eff2'
 NVM_PLUGIN_VERSION='0.6.0'
 
 export IMAGE_ID="$XCODE_VERSION"

--- a/apps/studio/forge.config.ts
+++ b/apps/studio/forge.config.ts
@@ -9,6 +9,7 @@ import { isErrnoException } from '@studio/common/lib/is-errno-exception';
 import { exec } from 'child_process';
 import { exec as pkgExec } from '@yao-pkg/pkg';
 import type { ForgeConfig } from '@electron-forge/shared-types';
+import { windowsSign } from './windowsSign';
 
 const repoRoot = path.resolve( __dirname, '../..' );
 
@@ -22,6 +23,7 @@ const config: ForgeConfig = {
 		],
 		executableName: process.platform === 'linux' ? 'studio' : undefined,
 		icon: path.join( __dirname, 'assets', 'studio-app-icon' ),
+		windowsSign,
 		osxSign: {
 			optionsForFile: ( filePath ) => {
 				// The bundled Node binary requires specific entitlements for V8 JIT compilation.
@@ -95,9 +97,16 @@ const config: ForgeConfig = {
 
 				setupExe: 'studio-setup.exe',
 
-				// CI code-signing setup writes certificate.pfx at the repository root.
-				certificateFile: path.join( repoRoot, 'certificate.pfx' ),
-				certificatePassword: process.env.WINDOWS_CODE_SIGNING_CERT_PASSWORD,
+				// Azure mode: use the custom signing hook that calls signtool
+				// with Azure Trusted Signing parameters.
+				// PFX mode: use the local certificate file and password.
+				...( windowsSign
+					? { windowsSign }
+					: {
+							certificateFile: path.join( repoRoot, 'certificate.pfx' ),
+							certificatePassword: process.env.WINDOWS_CODE_SIGNING_CERT_PASSWORD,
+					  }
+				),
 			},
 			[ 'win32' ]
 		),

--- a/apps/studio/windowsSign.ts
+++ b/apps/studio/windowsSign.ts
@@ -1,0 +1,32 @@
+import path from 'path';
+import type { WindowsSignOptions } from '@electron/packager';
+
+// Azure Trusted Signing configuration for Windows code signing.
+//
+// Uses a custom hook module because the default @electron/windows-sign
+// dual-signs (SHA1 + SHA256), but Azure only supports SHA256.
+// The hook calls signtool directly with SHA256-only parameters.
+//
+// Controlled by the USE_AZURE_TRUSTED_SIGNING env var:
+// - Unset/falsy: returns undefined, letting Forge use PFX certificate signing.
+// - Set: returns the Azure signing hook config, or throws if the
+//   required Azure env vars are missing.
+function getWindowsSign(): WindowsSignOptions | undefined {
+	if ( ! process.env.USE_AZURE_TRUSTED_SIGNING ) {
+		return undefined;
+	}
+
+	if ( ! process.env.AZURE_CODE_SIGNING_DLIB || ! process.env.AZURE_METADATA_JSON ) {
+		throw new Error(
+			'USE_AZURE_TRUSTED_SIGNING is set but Azure signing env vars ' +
+				'(AZURE_CODE_SIGNING_DLIB, AZURE_METADATA_JSON) are missing. ' +
+				'Did setup_azure_trusted_signing.ps1 run?'
+		);
+	}
+
+	return {
+		hookModulePath: path.resolve( __dirname, '..', '..', 'scripts', 'azure-sign-hook.js' ),
+	};
+}
+
+export const windowsSign = getWindowsSign();

--- a/apps/studio/windowsSign.ts
+++ b/apps/studio/windowsSign.ts
@@ -20,10 +20,10 @@ function getWindowsSign(): WindowsSignOptions | undefined {
 		return undefined;
 	}
 
-	if ( ! process.env.AZURE_CODE_SIGNING_DLIB || ! process.env.AZURE_METADATA_JSON ) {
+	if ( ! process.env.AZURE_CODE_SIGNING_DLIB || ! process.env.AZURE_METADATA_JSON || ! process.env.SIGNTOOL_PATH ) {
 		throw new Error(
 			'USE_AZURE_TRUSTED_SIGNING is set but Azure signing env vars ' +
-				'(AZURE_CODE_SIGNING_DLIB, AZURE_METADATA_JSON) are missing. ' +
+				'(AZURE_CODE_SIGNING_DLIB, AZURE_METADATA_JSON, SIGNTOOL_PATH) are missing. ' +
 				'Did setup_azure_trusted_signing.ps1 run?'
 		);
 	}

--- a/apps/studio/windowsSign.ts
+++ b/apps/studio/windowsSign.ts
@@ -8,11 +8,15 @@ import type { WindowsSignOptions } from '@electron/packager';
 // The hook calls signtool directly with SHA256-only parameters.
 //
 // Controlled by the USE_AZURE_TRUSTED_SIGNING env var:
-// - Unset/falsy: returns undefined, letting Forge use PFX certificate signing.
-// - Set: returns the Azure signing hook config, or throws if the
+// - Unset or not '1'/'true': returns undefined, letting Forge use PFX certificate signing.
+// - '1' or 'true': returns the Azure signing hook config, or throws if the
 //   required Azure env vars are missing.
 function getWindowsSign(): WindowsSignOptions | undefined {
-	if ( ! process.env.USE_AZURE_TRUSTED_SIGNING ) {
+	const useAzureSigning = [ '1', 'true' ].includes(
+		( process.env.USE_AZURE_TRUSTED_SIGNING ?? '' ).trim().toLowerCase()
+	);
+
+	if ( ! useAzureSigning ) {
 		return undefined;
 	}
 

--- a/scripts/azure-sign-hook.js
+++ b/scripts/azure-sign-hook.js
@@ -1,0 +1,28 @@
+// Custom signing hook for @electron/windows-sign.
+// Azure Trusted Signing only supports SHA256; the default dual-sign
+// (sha1 + sha256) fails because there's no local cert for sha1.
+// This hook calls signtool directly with SHA256-only parameters.
+
+/* eslint-disable @typescript-eslint/no-require-imports */
+
+const { execFileSync } = require( 'child_process' );
+const path = require( 'path' );
+const {
+	assertAzureSigningEnv,
+	getAzureSignArgs,
+	getAzureSigningConfig,
+} = require( './azure-signing.cjs' );
+
+// @electron/windows-sign includes .ps1 shim scripts from node_modules/.bin
+// in its file list. These are text files that don't need code signing.
+const SKIP_EXTENSIONS = new Set( [ '.ps1', '.vbs', '.wsf' ] );
+
+module.exports = function ( fileToSign ) {
+	if ( SKIP_EXTENSIONS.has( path.extname( fileToSign ).toLowerCase() ) ) {
+		return;
+	}
+	assertAzureSigningEnv();
+	const { signtoolPath } = getAzureSigningConfig();
+
+	execFileSync( signtoolPath, getAzureSignArgs( fileToSign ), { stdio: 'inherit' } );
+};

--- a/scripts/azure-signing.cjs
+++ b/scripts/azure-signing.cjs
@@ -1,0 +1,59 @@
+const REQUIRED_ENV_VARS = [
+	'AZURE_CODE_SIGNING_DLIB',
+	'AZURE_METADATA_JSON',
+	'SIGNTOOL_PATH'
+];
+
+const DEFAULTS = {
+	fileDigestAlgorithm: 'SHA256',
+	timestampDigestAlgorithm: 'SHA256',
+	timestampServer: 'http://timestamp.acs.microsoft.com',
+};
+
+function getAzureSigningConfig() {
+	return {
+		signtoolPath: process.env.SIGNTOOL_PATH,
+		dlib: process.env.AZURE_CODE_SIGNING_DLIB,
+		metadata: process.env.AZURE_METADATA_JSON,
+		fileDigestAlgorithm: process.env.AZURE_FILE_DIGEST || DEFAULTS.fileDigestAlgorithm,
+		timestampDigestAlgorithm:
+			process.env.AZURE_TIMESTAMP_DIGEST || DEFAULTS.timestampDigestAlgorithm,
+		timestampServer: process.env.AZURE_TIMESTAMP_SERVER || DEFAULTS.timestampServer,
+	};
+}
+
+function assertAzureSigningEnv() {
+	for ( const envVar of REQUIRED_ENV_VARS ) {
+		if ( ! process.env[ envVar ] ) {
+			throw new Error( `Required env var ${ envVar } is not set!` );
+		}
+	}
+}
+
+function getAzureSignArgs( fileToSign, extraArgs = [] ) {
+	const { dlib, metadata, fileDigestAlgorithm, timestampDigestAlgorithm, timestampServer } =
+		getAzureSigningConfig();
+
+	return [
+		'sign',
+		'/v',
+		...extraArgs,
+		'/fd',
+		fileDigestAlgorithm,
+		'/tr',
+		timestampServer,
+		'/td',
+		timestampDigestAlgorithm,
+		'/dlib',
+		dlib,
+		'/dmdf',
+		metadata,
+		fileToSign,
+	];
+}
+
+module.exports = {
+	assertAzureSigningEnv,
+	getAzureSignArgs,
+	getAzureSigningConfig,
+};

--- a/scripts/package-appx.mjs
+++ b/scripts/package-appx.mjs
@@ -217,6 +217,14 @@ if ( useAzureSigning ) {
 			stdio: 'inherit',
 		} );
 		console.log( `Signed ${ appxFile } successfully.` );
+
+		// Rename to remove misleading "unsigned" from the filename
+		const renamedFile = appxFile.replace( ' unsigned', '' );
+		if ( renamedFile !== appxFile ) {
+			const renamedPath = path.join( appxOutputPathSigned, renamedFile );
+			await fs.rename( appxPath, renamedPath );
+			console.log( `Renamed to ${ renamedFile }` );
+		}
 	}
 } else {
 	// PFX certificate signing

--- a/scripts/package-appx.mjs
+++ b/scripts/package-appx.mjs
@@ -5,7 +5,9 @@ import { fileURLToPath } from 'url';
 import convertToWindowsStore from 'electron2appx';
 import packageJson from '../apps/studio/package.json' with { type: 'json' };
 
-const useAzureSigning = Boolean( process.env.USE_AZURE_TRUSTED_SIGNING );
+const useAzureSigning = [ '1', 'true' ].includes(
+	process.env.USE_AZURE_TRUSTED_SIGNING?.trim().toLowerCase()
+);
 
 console.log( '--- :electron: Packaging AppX' );
 

--- a/scripts/package-appx.mjs
+++ b/scripts/package-appx.mjs
@@ -182,9 +182,9 @@ await convertToWindowsStore( {
 	outputDirectory: appxOutputPathUnsigned,
 } );
 
-// Create sideload AppX — signing method depends on USE_AZURE_TRUSTED_SIGNING.
+// Create signed AppX (used for local testing via sideloading)
 const appxOutputPathSigned = path.resolve( outPath, `${ appxName }-${ architecture }-signed` );
-console.log( `~~~ Creating .appx for sideloading at ${ appxOutputPathSigned }...` );
+console.log( `~~~ Creating signed .appx for local testing at ${ appxOutputPathSigned }...` );
 
 if ( useAzureSigning ) {
 	const sideloadPublisher =

--- a/scripts/package-appx.mjs
+++ b/scripts/package-appx.mjs
@@ -1,15 +1,30 @@
+import { execFileSync } from 'child_process';
 import fs from 'fs/promises';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import convertToWindowsStore from 'electron2appx';
 import packageJson from '../apps/studio/package.json' with { type: 'json' };
 
+const useAzureSigning = Boolean( process.env.USE_AZURE_TRUSTED_SIGNING );
+
 console.log( '--- :electron: Packaging AppX' );
 
-console.log( '~~~ Verifying WINDOWS_CODE_SIGNING_CERT_PASSWORD env var...' );
-if ( ! process.env.WINDOWS_CODE_SIGNING_CERT_PASSWORD ) {
-	console.error( 'Required env var WINDOWS_CODE_SIGNING_CERT_PASSWORD is not set!' );
-	process.exit( 1 );
+if ( useAzureSigning ) {
+	const azureSigning = await import( './azure-signing.cjs' );
+	const { assertAzureSigningEnv } = azureSigning.default;
+	console.log( '~~~ Verifying Azure Trusted Signing env vars...' );
+	try {
+		assertAzureSigningEnv();
+	} catch ( error ) {
+		console.error( error instanceof Error ? error.message : error );
+		process.exit( 1 );
+	}
+} else {
+	console.log( '~~~ Verifying WINDOWS_CODE_SIGNING_CERT_PASSWORD env var...' );
+	if ( ! process.env.WINDOWS_CODE_SIGNING_CERT_PASSWORD ) {
+		console.error( 'Required env var WINDOWS_CODE_SIGNING_CERT_PASSWORD is not set!' );
+		process.exit( 1 );
+	}
 }
 
 const __dirname = path.dirname( fileURLToPath( import.meta.url ) );
@@ -167,14 +182,50 @@ await convertToWindowsStore( {
 	outputDirectory: appxOutputPathUnsigned,
 } );
 
-// Create signed AppX
+// Create sideload AppX — signing method depends on USE_AZURE_TRUSTED_SIGNING.
 const appxOutputPathSigned = path.resolve( outPath, `${ appxName }-${ architecture }-signed` );
-console.log( `~~~ Creating signed .appx for local testing at ${ appxOutputPathSigned }...` );
+console.log( `~~~ Creating .appx for sideloading at ${ appxOutputPathSigned }...` );
 
-await convertToWindowsStore( {
-	...sharedOptions,
-	publisher: 'CN=&quot;Automattic, Inc.&quot;, O=&quot;Automattic, Inc.&quot;, S=California, C=US',
-	devCert: 'certificate.pfx',
-	certPass: process.env.WINDOWS_CODE_SIGNING_CERT_PASSWORD,
-	outputDirectory: appxOutputPathSigned,
-} );
+if ( useAzureSigning ) {
+	const sideloadPublisher =
+		'CN=Automattic Inc., O=Automattic Inc., L=San Francisco, S=California, C=US';
+
+	// Build unsigned, then sign with Azure Trusted Signing via signtool.
+	await convertToWindowsStore( {
+		...sharedOptions,
+		publisher: sideloadPublisher,
+		devCert: 'nil',
+		outputDirectory: appxOutputPathSigned,
+	} );
+
+	console.log( '~~~ Signing sideload .appx with Azure Trusted Signing...' );
+	const azureSigning = await import( './azure-signing.cjs' );
+	const { getAzureSignArgs, getAzureSigningConfig } = azureSigning.default;
+	const appxFiles = ( await fs.readdir( appxOutputPathSigned ) ).filter( ( f ) =>
+		f.endsWith( '.appx' )
+	);
+	if ( appxFiles.length === 0 ) {
+		console.error( 'No .appx file found to sign!' );
+		process.exit( 1 );
+	}
+
+	for ( const appxFile of appxFiles ) {
+		const appxPath = path.join( appxOutputPathSigned, appxFile );
+		console.log( `Signing ${ appxPath }...` );
+		const { signtoolPath } = getAzureSigningConfig();
+		execFileSync( signtoolPath, getAzureSignArgs( appxPath, [ '/debug' ] ), {
+			stdio: 'inherit',
+		} );
+		console.log( `Signed ${ appxFile } successfully.` );
+	}
+} else {
+	// PFX certificate signing
+	await convertToWindowsStore( {
+		...sharedOptions,
+		publisher:
+			'CN=&quot;Automattic, Inc.&quot;, O=&quot;Automattic, Inc.&quot;, S=California, C=US',
+		devCert: 'certificate.pfx',
+		certPass: process.env.WINDOWS_CODE_SIGNING_CERT_PASSWORD,
+		outputDirectory: appxOutputPathSigned,
+	} );
+}

--- a/scripts/package-appx.mjs
+++ b/scripts/package-appx.mjs
@@ -6,7 +6,7 @@ import convertToWindowsStore from 'electron2appx';
 import packageJson from '../apps/studio/package.json' with { type: 'json' };
 
 const useAzureSigning = [ '1', 'true' ].includes(
-	process.env.USE_AZURE_TRUSTED_SIGNING?.trim().toLowerCase()
+	( process.env.USE_AZURE_TRUSTED_SIGNING ?? '' ).trim().toLowerCase()
 );
 
 console.log( '--- :electron: Packaging AppX' );


### PR DESCRIPTION
## Related issues

- AINFRA-2233
- #2709

## How AI was used in this PR

Implementation planned and written with Claude Code (Opus 4.6).
All code reviewed by @mokagio before committing.

## Proposed Changes

Takes the work from #2709 and puts it behind a toggle env var.
The idea being that we can switch back to the previous signing implementation if something turns out to be wrong once released in the wild.

- Add Azure Trusted Signing utilities (`azure-signing.cjs`, `azure-sign-hook.js`) for SHA256-only signing via signtool
- Add `windowsSign.ts` module gated on `USE_AZURE_TRUSTED_SIGNING` env var — returns Azure hook config when set, `undefined` (PFX fallback) otherwise
- Wire `windowsSign` into `forge.config.ts` for both `packagerConfig` and `MakerSquirrel`
- Add conditional signing setup in `build-for-windows.ps1` (Azure or PFX based on toggle)
- Add conditional signing in `package-appx.mjs` for sideload AppX
- Update CI toolkit version to include `setup_azure_trusted_signing.ps1`
- Set `USE_AZURE_TRUSTED_SIGNING=1` in both dev and release Windows build jobs in the pipeline

To revert to PFX signing, remove the `USE_AZURE_TRUSTED_SIGNING` env var from the pipeline YAML files.

## Testing Instructions

I created #2996 to test the changes here and verify that both build paths work.

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors? - N.A.

*Posted by Claude Code (Opus 4.6) on behalf of @mokagio with approval.*