### PR TITLE
More efficient dependency management in CLI

### DIFF
--- a/apps/cli/lib/dependency-management/setup.ts
+++ b/apps/cli/lib/dependency-management/setup.ts
@@ -18,6 +18,49 @@ import { areDirectoriesDifferentBySizeAndMtime } from './utils';
 import { getWordPressVersionFromInstallation, updateLatestWordPressVersion } from './wordpress';
 import { updateLatestWpCliVersion } from './wp-cli';
 
+type VersionReader = () => Promise< semver.SemVer | null >;
+
+async function copyBundledDependencyIfNewerOrMissing( {
+	sourceDirectoryPath,
+	targetDirectoryPath,
+	readSourceVersion,
+	readTargetVersion,
+}: {
+	sourceDirectoryPath: string;
+	targetDirectoryPath: string;
+	readSourceVersion: VersionReader;
+	readTargetVersion: VersionReader;
+} ) {
+	if ( ! fs.existsSync( sourceDirectoryPath ) ) {
+		return;
+	}
+
+	let bundledVersion: Awaited< ReturnType< VersionReader > >;
+
+	try {
+		bundledVersion = await readSourceVersion();
+		if ( ! bundledVersion ) {
+			return;
+		}
+	} catch {
+		// Do nothing if the bundled version cannot be read
+		return;
+	}
+
+	try {
+		const serverFilesVersion = await readTargetVersion();
+		const isBundledVersionNewer =
+			serverFilesVersion && semver.gt( bundledVersion, serverFilesVersion );
+
+		if ( ! serverFilesVersion || isBundledVersionNewer ) {
+			await recursiveCopyDirectory( sourceDirectoryPath, targetDirectoryPath );
+		}
+	} catch {
+		// Fall back to copying the bundled version if the server files version cannot be read
+		await recursiveCopyDirectory( sourceDirectoryPath, targetDirectoryPath );
+	}
+}
+
 // Compare the WordPress version in the bundled `wp-files/latest/wordpress` directory (that ships
 // with the CLI) to `~/.studio/server-files/wordpress-versions/latest`. If the bundled directory is
 // newer, rename the old `wordpress-versions/latest` directory to `wordpress-versions/$VERSION` and
@@ -27,7 +70,7 @@ async function copyBundledLatestWpVersion() {
 	const bundledWpVersion = await getWordPressVersionFromInstallation( bundledWpVersionPath );
 	const bundledWpSemver = semver.coerce( bundledWpVersion );
 
-	if ( ! bundledWpVersion || ! bundledWpSemver ) {
+	if ( ! bundledWpSemver ) {
 		return;
 	}
 
@@ -51,24 +94,20 @@ const SQLITE_FILENAME = 'sqlite-database-integration';
 
 async function copyBundledSqlite() {
 	const bundledSqlitePath = path.join( getWpFilesPath(), SQLITE_FILENAME );
-	const bundledSqliteVersion = semver.coerce(
-		await getSqliteVersionFromInstallation( bundledSqlitePath ),
-		{ includePrerelease: true }
-	);
-	if ( ! bundledSqliteVersion ) {
-		return;
-	}
 	const installedSqlitePath = getSqlitePluginPath();
-	const isSqliteInstalled = fs.existsSync( installedSqlitePath );
-	const installedSqliteVersion = semver.coerce(
-		await getSqliteVersionFromInstallation( installedSqlitePath ),
-		{ includePrerelease: true }
-	);
-	const isBundledVersionNewer =
-		installedSqliteVersion && semver.gt( bundledSqliteVersion, installedSqliteVersion );
-	if ( ! isSqliteInstalled || isBundledVersionNewer ) {
-		await recursiveCopyDirectory( bundledSqlitePath, getSqlitePluginPath() );
-	}
+
+	await copyBundledDependencyIfNewerOrMissing( {
+		sourceDirectoryPath: bundledSqlitePath,
+		targetDirectoryPath: installedSqlitePath,
+		readSourceVersion: async () =>
+			semver.coerce( await getSqliteVersionFromInstallation( bundledSqlitePath ), {
+				includePrerelease: true,
+			} ),
+		readTargetVersion: async () =>
+			semver.coerce( await getSqliteVersionFromInstallation( installedSqlitePath ), {
+				includePrerelease: true,
+			} ),
+	} );
 }
 
 async function copyBundledWpCli() {
@@ -81,33 +120,18 @@ async function copyBundledWpCli() {
 }
 
 async function copyBundledSqliteCommand() {
-	const bundledSqliteCommandPath = path.join( getWpFilesPath(), 'sqlite-command' );
-	if ( ! fs.existsSync( bundledSqliteCommandPath ) ) {
-		return;
-	}
-
-	const bundledVersionFilePath = path.join( bundledSqliteCommandPath, 'version' );
-	const bundledVersion = semver.coerce( fs.readFileSync( bundledVersionFilePath, 'utf8' ) );
-
-	if ( ! bundledVersion ) {
-		return;
-	}
-
-	try {
-		const serverFilesVersionFilePath = path.join( getSqliteCommandPath(), 'version' );
-		const serverFilesVersion = semver.coerce(
-			fs.readFileSync( serverFilesVersionFilePath, 'utf8' )
-		);
-		const isBundledVersionNewer =
-			serverFilesVersion && semver.gt( bundledVersion, serverFilesVersion );
-
-		if ( ! serverFilesVersion || isBundledVersionNewer ) {
-			await recursiveCopyDirectory( bundledSqliteCommandPath, getSqliteCommandPath() );
-		}
-	} catch {
-		// Fall back to copying the bundled version if the server files version cannot be read
-		await recursiveCopyDirectory( bundledSqliteCommandPath, getSqliteCommandPath() );
-	}
+	await copyBundledDependencyIfNewerOrMissing( {
+		sourceDirectoryPath: path.join( getWpFilesPath(), 'sqlite-command' ),
+		targetDirectoryPath: getSqliteCommandPath(),
+		readSourceVersion: async () => {
+			const versionFilePath = path.join( getWpFilesPath(), 'sqlite-command', 'version' );
+			return semver.coerce( fs.readFileSync( versionFilePath, 'utf8' ) );
+		},
+		readTargetVersion: async () => {
+			const versionFilePath = path.join( getSqliteCommandPath(), 'version' );
+			return semver.coerce( fs.readFileSync( versionFilePath, 'utf8' ) );
+		},
+	} );
 }
 
 async function copyBundledTranslations() {
@@ -143,35 +167,20 @@ async function copyBundledAiInstructions() {
 }
 
 async function copyBundledPhpMyAdmin() {
-	const bundledPath = path.join( getWpFilesPath(), 'phpmyadmin' );
-	if ( ! fs.existsSync( bundledPath ) ) {
-		return;
-	}
-
-	const bundledComposerFilePath = path.join( bundledPath, 'composer.json' );
-	const bundledComposerFile = JSON.parse( fs.readFileSync( bundledComposerFilePath, 'utf8' ) );
-	const bundledVersion = semver.coerce( bundledComposerFile.version );
-
-	if ( ! bundledVersion ) {
-		return;
-	}
-
-	try {
-		const serverFilesComposerFilePath = path.join( getPhpMyAdminPath(), 'composer.json' );
-		const serverFilesComposerFile = JSON.parse(
-			fs.readFileSync( serverFilesComposerFilePath, 'utf8' )
-		);
-		const serverFilesVersion = semver.coerce( serverFilesComposerFile.version );
-		const isBundledVersionNewer =
-			serverFilesVersion && semver.gt( bundledVersion, serverFilesVersion );
-
-		if ( ! serverFilesVersion || isBundledVersionNewer ) {
-			await recursiveCopyDirectory( bundledPath, getPhpMyAdminPath() );
-		}
-	} catch {
-		// Fall back to copying the bundled version if the server files version cannot be read
-		await recursiveCopyDirectory( bundledPath, getPhpMyAdminPath() );
-	}
+	await copyBundledDependencyIfNewerOrMissing( {
+		sourceDirectoryPath: path.join( getWpFilesPath(), 'phpmyadmin' ),
+		targetDirectoryPath: getPhpMyAdminPath(),
+		readSourceVersion: async () => {
+			const composerFilePath = path.join( getWpFilesPath(), 'phpmyadmin', 'composer.json' );
+			const composerFile = JSON.parse( fs.readFileSync( composerFilePath, 'utf8' ) );
+			return semver.coerce( composerFile.version );
+		},
+		readTargetVersion: async () => {
+			const composerFilePath = path.join( getPhpMyAdminPath(), 'composer.json' );
+			const composerFile = JSON.parse( fs.readFileSync( composerFilePath, 'utf8' ) );
+			return semver.coerce( composerFile.version );
+		},
+	} );
 }
 
 async function copyBundledLanguagePacks() {

--- a/apps/cli/lib/dependency-management/setup.ts
+++ b/apps/cli/lib/dependency-management/setup.ts
@@ -14,6 +14,7 @@ import {
 	getWpFilesPath,
 } from '../server-files';
 import { updateLatestSqliteCommandVersion } from './sqlite-command';
+import { areDirectoriesDifferentBySizeAndMtime } from './utils';
 import { getWordPressVersionFromInstallation, updateLatestWordPressVersion } from './wordpress';
 import { updateLatestWpCliVersion } from './wp-cli';
 
@@ -71,8 +72,8 @@ async function copyBundledSqlite() {
 }
 
 async function copyBundledWpCli() {
-	const bundledWpCLIInstalled = fs.existsSync( getWpCliPharPath() );
-	if ( bundledWpCLIInstalled ) {
+	const isServerFilesWpCliInstalled = fs.existsSync( getWpCliPharPath() );
+	if ( isServerFilesWpCliInstalled ) {
 		return;
 	}
 	const bundledWpCLIPath = path.join( getWpFilesPath(), 'wp-cli', 'wp-cli.phar' );
@@ -84,8 +85,29 @@ async function copyBundledSqliteCommand() {
 	if ( ! fs.existsSync( bundledSqliteCommandPath ) ) {
 		return;
 	}
-	// Always copy to ensure files are complete and up-to-date
-	await recursiveCopyDirectory( bundledSqliteCommandPath, getSqliteCommandPath() );
+
+	const bundledVersionFilePath = path.join( bundledSqliteCommandPath, 'version' );
+	const bundledVersion = semver.coerce( fs.readFileSync( bundledVersionFilePath, 'utf8' ) );
+
+	if ( ! bundledVersion ) {
+		return;
+	}
+
+	try {
+		const serverFilesVersionFilePath = path.join( getSqliteCommandPath(), 'version' );
+		const serverFilesVersion = semver.coerce(
+			fs.readFileSync( serverFilesVersionFilePath, 'utf8' )
+		);
+		const isBundledVersionNewer =
+			serverFilesVersion && semver.gt( bundledVersion, serverFilesVersion );
+
+		if ( ! serverFilesVersion || isBundledVersionNewer ) {
+			await recursiveCopyDirectory( bundledSqliteCommandPath, getSqliteCommandPath() );
+		}
+	} catch {
+		// Fall back to copying the bundled version if the server files version cannot be read
+		await recursiveCopyDirectory( bundledSqliteCommandPath, getSqliteCommandPath() );
+	}
 }
 
 async function copyBundledTranslations() {
@@ -110,7 +132,14 @@ async function copyBundledAiInstructions() {
 	if ( ! fs.existsSync( bundledAiInstructionsPath ) ) {
 		return;
 	}
-	await recursiveCopyDirectory( bundledAiInstructionsPath, getAiInstructionsPath() );
+
+	const isBundledVersionDifferent = await areDirectoriesDifferentBySizeAndMtime(
+		bundledAiInstructionsPath,
+		getAiInstructionsPath()
+	);
+	if ( isBundledVersionDifferent ) {
+		await recursiveCopyDirectory( bundledAiInstructionsPath, getAiInstructionsPath() );
+	}
 }
 
 async function copyBundledPhpMyAdmin() {
@@ -118,8 +147,31 @@ async function copyBundledPhpMyAdmin() {
 	if ( ! fs.existsSync( bundledPath ) ) {
 		return;
 	}
-	// Always copy to ensure files are complete and up-to-date
-	await recursiveCopyDirectory( bundledPath, getPhpMyAdminPath() );
+
+	const bundledComposerFilePath = path.join( bundledPath, 'composer.json' );
+	const bundledComposerFile = JSON.parse( fs.readFileSync( bundledComposerFilePath, 'utf8' ) );
+	const bundledVersion = semver.coerce( bundledComposerFile.version );
+
+	if ( ! bundledVersion ) {
+		return;
+	}
+
+	try {
+		const serverFilesComposerFilePath = path.join( getPhpMyAdminPath(), 'composer.json' );
+		const serverFilesComposerFile = JSON.parse(
+			fs.readFileSync( serverFilesComposerFilePath, 'utf8' )
+		);
+		const serverFilesVersion = semver.coerce( serverFilesComposerFile.version );
+		const isBundledVersionNewer =
+			serverFilesVersion && semver.gt( bundledVersion, serverFilesVersion );
+
+		if ( ! serverFilesVersion || isBundledVersionNewer ) {
+			await recursiveCopyDirectory( bundledPath, getPhpMyAdminPath() );
+		}
+	} catch {
+		// Fall back to copying the bundled version if the server files version cannot be read
+		await recursiveCopyDirectory( bundledPath, getPhpMyAdminPath() );
+	}
 }
 
 async function copyBundledLanguagePacks() {
@@ -129,7 +181,14 @@ async function copyBundledLanguagePacks() {
 	}
 	const installedLanguagePacksPath = getLanguagePacksPath();
 	await fs.promises.mkdir( installedLanguagePacksPath, { recursive: true } );
-	await recursiveCopyDirectory( bundledLanguagePacksPath, installedLanguagePacksPath );
+
+	const isBundledVersionDifferent = await areDirectoriesDifferentBySizeAndMtime(
+		bundledLanguagePacksPath,
+		installedLanguagePacksPath
+	);
+	if ( isBundledVersionDifferent ) {
+		await recursiveCopyDirectory( bundledLanguagePacksPath, installedLanguagePacksPath );
+	}
 }
 
 export async function setupServerFiles() {

--- a/apps/cli/lib/dependency-management/setup.ts
+++ b/apps/cli/lib/dependency-management/setup.ts
@@ -35,28 +35,28 @@ async function copyBundledDependencyIfNewerOrMissing( {
 		return;
 	}
 
-	let bundledVersion: Awaited< ReturnType< VersionReader > >;
+	let sourceVersion: Awaited< ReturnType< VersionReader > >;
 
 	try {
-		bundledVersion = await readSourceVersion();
-		if ( ! bundledVersion ) {
+		sourceVersion = await readSourceVersion();
+		if ( ! sourceVersion ) {
 			return;
 		}
 	} catch {
-		// Do nothing if the bundled version cannot be read
+		// Do nothing if the source version cannot be read
 		return;
 	}
 
 	try {
-		const serverFilesVersion = await readTargetVersion();
-		const isBundledVersionNewer =
-			serverFilesVersion && semver.gt( bundledVersion, serverFilesVersion );
+		const targetVersion = await readTargetVersion();
+		const isSourceVersionNewer = targetVersion && semver.gt( sourceVersion, targetVersion );
 
-		if ( ! serverFilesVersion || isBundledVersionNewer ) {
+		if ( ! targetVersion || isSourceVersionNewer ) {
 			await recursiveCopyDirectory( sourceDirectoryPath, targetDirectoryPath );
 		}
 	} catch {
-		// Fall back to copying the bundled version if the server files version cannot be read
+		// The error is likely because of a missing or corrupted target directory, in which case we
+		// copy the source directory to the target directory
 		await recursiveCopyDirectory( sourceDirectoryPath, targetDirectoryPath );
 	}
 }
@@ -111,12 +111,16 @@ async function copyBundledSqlite() {
 }
 
 async function copyBundledWpCli() {
-	const isServerFilesWpCliInstalled = fs.existsSync( getWpCliPharPath() );
-	if ( isServerFilesWpCliInstalled ) {
-		return;
-	}
 	const bundledWpCLIPath = path.join( getWpFilesPath(), 'wp-cli', 'wp-cli.phar' );
-	await fs.promises.copyFile( bundledWpCLIPath, getWpCliPharPath() );
+	const sourceStats = await fs.promises.lstat( bundledWpCLIPath );
+	const targetStats = await fs.promises.lstat( getWpCliPharPath() );
+
+	if ( sourceStats.size !== targetStats.size || sourceStats.mtimeMs !== targetStats.mtimeMs ) {
+		await fs.promises.cp( bundledWpCLIPath, getWpCliPharPath(), {
+			mode: fs.constants.COPYFILE_FICLONE,
+			preserveTimestamps: true,
+		} );
+	}
 }
 
 async function copyBundledSqliteCommand() {
@@ -148,7 +152,15 @@ async function copyBundledTranslations() {
 		'available-site-translations.json'
 	);
 
-	await fs.promises.copyFile( bundledTranslationsPath, installedTranslationsPath );
+	const sourceStats = await fs.promises.lstat( bundledTranslationsPath );
+	const targetStats = await fs.promises.lstat( installedTranslationsPath );
+
+	if ( sourceStats.size !== targetStats.size || sourceStats.mtimeMs !== targetStats.mtimeMs ) {
+		await fs.promises.cp( bundledTranslationsPath, installedTranslationsPath, {
+			mode: fs.constants.COPYFILE_FICLONE,
+			preserveTimestamps: true,
+		} );
+	}
 }
 
 async function copyBundledAiInstructions() {

--- a/apps/cli/lib/dependency-management/setup.ts
+++ b/apps/cli/lib/dependency-management/setup.ts
@@ -20,7 +20,7 @@ import { updateLatestWpCliVersion } from './wp-cli';
 
 type VersionReader = () => Promise< semver.SemVer | null >;
 
-async function copyBundledDependencyIfNewerOrMissing( {
+async function copySourceDirectoryIfNewerOrMissing( {
 	sourceDirectoryPath,
 	targetDirectoryPath,
 	readSourceVersion,
@@ -36,6 +36,7 @@ async function copyBundledDependencyIfNewerOrMissing( {
 	}
 
 	let sourceVersion: Awaited< ReturnType< VersionReader > >;
+	let shouldCopy = false;
 
 	try {
 		sourceVersion = await readSourceVersion();
@@ -50,13 +51,19 @@ async function copyBundledDependencyIfNewerOrMissing( {
 	try {
 		const targetVersion = await readTargetVersion();
 		const isSourceVersionNewer = targetVersion && semver.gt( sourceVersion, targetVersion );
-
-		if ( ! targetVersion || isSourceVersionNewer ) {
-			await recursiveCopyDirectory( sourceDirectoryPath, targetDirectoryPath );
-		}
+		shouldCopy = Boolean( ! targetVersion || isSourceVersionNewer );
 	} catch {
 		// The error is likely because of a missing or corrupted target directory, in which case we
 		// copy the source directory to the target directory
+		shouldCopy = true;
+	}
+
+	if ( shouldCopy ) {
+		try {
+			await fs.promises.rm( targetDirectoryPath, { recursive: true, force: true } );
+		} catch {
+			// Do nothing if the target directory is missing or corrupted
+		}
 		await recursiveCopyDirectory( sourceDirectoryPath, targetDirectoryPath );
 	}
 }
@@ -93,30 +100,39 @@ async function copyBundledLatestWpVersion() {
 const SQLITE_FILENAME = 'sqlite-database-integration';
 
 async function copyBundledSqlite() {
-	const bundledSqlitePath = path.join( getWpFilesPath(), SQLITE_FILENAME );
-	const installedSqlitePath = getSqlitePluginPath();
+	const sourceSqlitePath = path.join( getWpFilesPath(), SQLITE_FILENAME );
+	const targetSqlitePath = getSqlitePluginPath();
 
-	await copyBundledDependencyIfNewerOrMissing( {
-		sourceDirectoryPath: bundledSqlitePath,
-		targetDirectoryPath: installedSqlitePath,
+	await copySourceDirectoryIfNewerOrMissing( {
+		sourceDirectoryPath: sourceSqlitePath,
+		targetDirectoryPath: targetSqlitePath,
 		readSourceVersion: async () =>
-			semver.coerce( await getSqliteVersionFromInstallation( bundledSqlitePath ), {
+			semver.coerce( await getSqliteVersionFromInstallation( sourceSqlitePath ), {
 				includePrerelease: true,
 			} ),
 		readTargetVersion: async () =>
-			semver.coerce( await getSqliteVersionFromInstallation( installedSqlitePath ), {
+			semver.coerce( await getSqliteVersionFromInstallation( targetSqlitePath ), {
 				includePrerelease: true,
 			} ),
 	} );
 }
 
 async function copyBundledWpCli() {
-	const bundledWpCLIPath = path.join( getWpFilesPath(), 'wp-cli', 'wp-cli.phar' );
-	const sourceStats = await fs.promises.lstat( bundledWpCLIPath );
-	const targetStats = await fs.promises.lstat( getWpCliPharPath() );
+	const sourceWpCLIPath = path.join( getWpFilesPath(), 'wp-cli', 'wp-cli.phar' );
+	const sourceStats = await fs.promises.lstat( sourceWpCLIPath );
+	let shouldCopy = false;
 
-	if ( sourceStats.size !== targetStats.size || sourceStats.mtimeMs !== targetStats.mtimeMs ) {
-		await fs.promises.cp( bundledWpCLIPath, getWpCliPharPath(), {
+	try {
+		const targetStats = await fs.promises.lstat( getWpCliPharPath() );
+		shouldCopy =
+			sourceStats.size !== targetStats.size ||
+			Math.floor( sourceStats.mtimeMs ) !== Math.floor( targetStats.mtimeMs );
+	} catch {
+		shouldCopy = true;
+	}
+
+	if ( shouldCopy ) {
+		await fs.promises.cp( sourceWpCLIPath, getWpCliPharPath(), {
 			mode: fs.constants.COPYFILE_FICLONE,
 			preserveTimestamps: true,
 		} );
@@ -124,7 +140,7 @@ async function copyBundledWpCli() {
 }
 
 async function copyBundledSqliteCommand() {
-	await copyBundledDependencyIfNewerOrMissing( {
+	await copySourceDirectoryIfNewerOrMissing( {
 		sourceDirectoryPath: path.join( getWpFilesPath(), 'sqlite-command' ),
 		targetDirectoryPath: getSqliteCommandPath(),
 		readSourceVersion: async () => {
@@ -139,24 +155,30 @@ async function copyBundledSqliteCommand() {
 }
 
 async function copyBundledTranslations() {
-	const bundledTranslationsPath = path.join(
+	const sourceTranslationsPath = path.join(
 		getWpFilesPath(),
 		'latest',
 		'available-site-translations.json'
 	);
-	if ( ! fs.existsSync( bundledTranslationsPath ) ) {
-		return;
-	}
-	const installedTranslationsPath = path.join(
+	const targetTranslationsPath = path.join(
 		getWordPressVersionPath( 'latest' ),
 		'available-site-translations.json'
 	);
 
-	const sourceStats = await fs.promises.lstat( bundledTranslationsPath );
-	const targetStats = await fs.promises.lstat( installedTranslationsPath );
+	const sourceStats = await fs.promises.lstat( sourceTranslationsPath );
+	let shouldCopy = false;
 
-	if ( sourceStats.size !== targetStats.size || sourceStats.mtimeMs !== targetStats.mtimeMs ) {
-		await fs.promises.cp( bundledTranslationsPath, installedTranslationsPath, {
+	try {
+		const targetStats = await fs.promises.lstat( targetTranslationsPath );
+		shouldCopy =
+			sourceStats.size !== targetStats.size ||
+			Math.floor( sourceStats.mtimeMs ) !== Math.floor( targetStats.mtimeMs );
+	} catch {
+		shouldCopy = true;
+	}
+
+	if ( shouldCopy ) {
+		await fs.promises.cp( sourceTranslationsPath, targetTranslationsPath, {
 			mode: fs.constants.COPYFILE_FICLONE,
 			preserveTimestamps: true,
 		} );
@@ -164,22 +186,27 @@ async function copyBundledTranslations() {
 }
 
 async function copyBundledAiInstructions() {
-	const bundledAiInstructionsPath = path.join( getWpFilesPath(), 'skills' );
-	if ( ! fs.existsSync( bundledAiInstructionsPath ) ) {
+	const sourceAiInstructionsPath = path.join( getWpFilesPath(), 'skills' );
+	if ( ! fs.existsSync( sourceAiInstructionsPath ) ) {
 		return;
 	}
 
-	const isBundledVersionDifferent = await areDirectoriesDifferentBySizeAndMtime(
-		bundledAiInstructionsPath,
+	const isSourceDirectoryDifferent = await areDirectoriesDifferentBySizeAndMtime(
+		sourceAiInstructionsPath,
 		getAiInstructionsPath()
 	);
-	if ( isBundledVersionDifferent ) {
-		await recursiveCopyDirectory( bundledAiInstructionsPath, getAiInstructionsPath() );
+	if ( isSourceDirectoryDifferent ) {
+		try {
+			await fs.promises.rm( getAiInstructionsPath(), { recursive: true, force: true } );
+		} catch {
+			// Do nothing if the target directory is missing or corrupted
+		}
+		await recursiveCopyDirectory( sourceAiInstructionsPath, getAiInstructionsPath() );
 	}
 }
 
 async function copyBundledPhpMyAdmin() {
-	await copyBundledDependencyIfNewerOrMissing( {
+	await copySourceDirectoryIfNewerOrMissing( {
 		sourceDirectoryPath: path.join( getWpFilesPath(), 'phpmyadmin' ),
 		targetDirectoryPath: getPhpMyAdminPath(),
 		readSourceVersion: async () => {
@@ -196,19 +223,22 @@ async function copyBundledPhpMyAdmin() {
 }
 
 async function copyBundledLanguagePacks() {
-	const bundledLanguagePacksPath = path.join( getWpFilesPath(), 'latest', 'languages' );
-	if ( ! fs.existsSync( bundledLanguagePacksPath ) ) {
+	const sourceLanguagePacksPath = path.join( getWpFilesPath(), 'latest', 'languages' );
+	if ( ! fs.existsSync( sourceLanguagePacksPath ) ) {
 		return;
 	}
-	const installedLanguagePacksPath = getLanguagePacksPath();
-	await fs.promises.mkdir( installedLanguagePacksPath, { recursive: true } );
-
-	const isBundledVersionDifferent = await areDirectoriesDifferentBySizeAndMtime(
-		bundledLanguagePacksPath,
-		installedLanguagePacksPath
+	const targetLanguagePacksPath = getLanguagePacksPath();
+	const isSourceDirectoryDifferent = await areDirectoriesDifferentBySizeAndMtime(
+		sourceLanguagePacksPath,
+		targetLanguagePacksPath
 	);
-	if ( isBundledVersionDifferent ) {
-		await recursiveCopyDirectory( bundledLanguagePacksPath, installedLanguagePacksPath );
+	if ( isSourceDirectoryDifferent ) {
+		try {
+			await fs.promises.rm( targetLanguagePacksPath, { recursive: true, force: true } );
+		} catch {
+			// Do nothing if the target directory is missing or corrupted
+		}
+		await recursiveCopyDirectory( sourceLanguagePacksPath, targetLanguagePacksPath );
 	}
 }
 

--- a/apps/cli/lib/dependency-management/utils.ts
+++ b/apps/cli/lib/dependency-management/utils.ts
@@ -56,3 +56,73 @@ export async function fetchLatestGithubRelease( repo: string ) {
 
 	return partialGithubReleaseSchema.parse( rawResponse );
 }
+
+type FileMetadata = {
+	mtimeMs: number;
+	size: number;
+};
+
+async function collectDirectoryMetadata(
+	directoryPath: string,
+	basePath = directoryPath
+): Promise< Map< string, FileMetadata > > {
+	const files = new Map< string, FileMetadata >();
+	const entries = await fs.promises.readdir( directoryPath, { withFileTypes: true } );
+
+	for ( const entry of entries ) {
+		const fullPath = path.join( directoryPath, entry.name );
+
+		if ( entry.isDirectory() ) {
+			const nestedFiles = await collectDirectoryMetadata( fullPath, basePath );
+			for ( const [ key, value ] of nestedFiles ) {
+				files.set( key, value );
+			}
+			continue;
+		}
+
+		if ( ! entry.isFile() ) {
+			continue;
+		}
+
+		const relativePath = path.relative( basePath, fullPath );
+		const stats = await fs.promises.lstat( fullPath );
+		files.set( relativePath, { size: stats.size, mtimeMs: Math.floor( stats.mtimeMs ) } );
+	}
+
+	return files;
+}
+
+// Returns true when source and target have any file-level differences by relative path, size, or mtime.
+export async function areDirectoriesDifferentBySizeAndMtime(
+	sourceDirectoryPath: string,
+	targetDirectoryPath: string
+): Promise< boolean > {
+	if ( ! fs.existsSync( sourceDirectoryPath ) || ! fs.existsSync( targetDirectoryPath ) ) {
+		return true;
+	}
+
+	const [ sourceFiles, targetFiles ] = await Promise.all( [
+		collectDirectoryMetadata( sourceDirectoryPath ),
+		collectDirectoryMetadata( targetDirectoryPath ),
+	] );
+
+	if ( sourceFiles.size !== targetFiles.size ) {
+		return true;
+	}
+
+	for ( const [ relativePath, sourceMetadata ] of sourceFiles ) {
+		const targetMetadata = targetFiles.get( relativePath );
+		if ( ! targetMetadata ) {
+			return true;
+		}
+
+		if (
+			sourceMetadata.size !== targetMetadata.size ||
+			sourceMetadata.mtimeMs !== targetMetadata.mtimeMs
+		) {
+			return true;
+		}
+	}
+
+	return false;
+}

--- a/apps/cli/lib/dependency-management/utils.ts
+++ b/apps/cli/lib/dependency-management/utils.ts
@@ -2,6 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import { Writable } from 'stream';
 import { isErrnoException } from '@studio/common/lib/is-errno-exception';
+import ignore from 'ignore';
 import { z } from 'zod';
 
 export async function downloadFile( url: string, destinationPath: string ): Promise< void > {
@@ -57,6 +58,9 @@ export async function fetchLatestGithubRelease( repo: string ) {
 	return partialGithubReleaseSchema.parse( rawResponse );
 }
 
+const IGNORE_PATTERNS = [ '.DS_Store', 'Thumbs.db' ];
+const IGNORE_INSTANCE = ignore().add( IGNORE_PATTERNS );
+
 type FileMetadata = {
 	mtimeMs: number;
 	size: number;
@@ -71,6 +75,11 @@ async function collectDirectoryMetadata(
 
 	for ( const entry of entries ) {
 		const fullPath = path.join( directoryPath, entry.name );
+		const relativePath = path.relative( basePath, fullPath );
+
+		if ( IGNORE_INSTANCE.ignores( relativePath ) ) {
+			continue;
+		}
 
 		if ( entry.isDirectory() ) {
 			const nestedFiles = await collectDirectoryMetadata( fullPath, basePath );
@@ -84,7 +93,6 @@ async function collectDirectoryMetadata(
 			continue;
 		}
 
-		const relativePath = path.relative( basePath, fullPath );
 		const stats = await fs.promises.lstat( fullPath );
 		files.set( relativePath, { size: stats.size, mtimeMs: Math.floor( stats.mtimeMs ) } );
 	}

--- a/apps/cli/vite.config.base.ts
+++ b/apps/cli/vite.config.base.ts
@@ -20,6 +20,7 @@ export const baseConfig = defineConfig( {
 				{
 					src: '../../wp-files',
 					dest: '.',
+					preserveTimestamps: true,
 				},
 			],
 		} ),

--- a/tools/common/lib/fs-utils.ts
+++ b/tools/common/lib/fs-utils.ts
@@ -117,7 +117,10 @@ export async function recursiveCopyDirectory(
 				return recursiveCopyDirectory( sourcePath, destinationPath );
 			}
 			if ( entry.isFile() ) {
-				return fsPromises.copyFile( sourcePath, destinationPath );
+				return fsPromises.cp( sourcePath, destinationPath, {
+					mode: fs.constants.COPYFILE_FICLONE,
+					preserveTimestamps: true,
+				} );
 			}
 		} )
 	);


### PR DESCRIPTION
## Related issues

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

- Related to p1775567333482379/1775561944.426079-slack-C06DRMD6VPZ

## How AI was used in this PR

<!--
Help reviewers understand what to look for and verify that you've reviewed the code yourself.
-->

With directed tasks and for multiple rounds of reviews. 

## Proposed Changes

https://github.com/Automattic/studio/pull/2873 moved the site dependencies ("server files") so they're managed by the CLI instead of by Studio. Most of the `wp-files` ➡️ `server-files` copying logic remained the same, but a big difference is that `setupServerFiles` is now called on every CLI invocation. Previously, it was only called when Studio started (and maybe when starting a site). This meant that `wp-files/phpmyadmin`, `wp-files/sqlite-command`, `wp-files/latest/languages`, and `wp-files/skills` were copied every time the CLI ran, which is quite expensive.

This PR adds version-comparison logic to `copyBundledSqliteCommand` and `copyBundledPhpMyAdmin`. `copyBundledTranslations` and `copyBundledLanguagePacks` get an rsync-like algorithm that recursively compares the source and target directories, looking for new files, and then comparing filesize+mtime. `copyBundledWpCli` and `copyBundledTranslations` get an equivalent algorithm, but we compare just a single file.

I've also updated `recursiveCopyDirectory` to preserve timestamps when copying files, and to use copy-on-write for additional performance benefits (when the file system supports it).

Lastly, the Vite build now preserves the file timestamps in the `wp-files` directory it copies to the `dist` directory. Without this change, the dependency setup logic would always copy the files again after running a CLI build. 

`setupServerFiles` takes ~55ms on this branch, compared to ~520ms on trunk. In other words, a 10x speedup. This overhead applies to every single CLI invocation, so there's still room for improvement here. The lowest hanging fruit would be to generate some kind of version file for the `wp-files/latest/languages` directory that we can use for comparison instead of having to iterate over the complete directory. This would be much faster. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. `npm run cli:build`
2. `rm ~/.studio/server-files/language-packs/pt_BR.l10n.php`
3. `node apps/cli/dist/cli/main.mjs site list`
4. `ls ~/.studio/server-files/language-packs/pt_BR.l10n.php`
5. Ensure the files exists again

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?