### PR TITLE
Fix copy for php and wp version mismatch

### DIFF
--- a/apps/studio/src/modules/sync/components/sync-dialog.tsx
+++ b/apps/studio/src/modules/sync/components/sync-dialog.tsx
@@ -451,7 +451,7 @@ export function SyncDialog( {
 						<Notice status="warning" isDismissible={ false } className="mb-4">
 							<p data-testid="push-version-mismatch-notice">
 								{ __(
-									'Your Studio site is using a different WordPress or PHP version than your WordPress.com site. The remote site will keep on using the newest supported versions.'
+									'Your Studio site is using a different WordPress or PHP version than your remote site. The remote site will keep using the newest supported versions.'
 								) }
 							</p>
 						</Notice>


### PR DESCRIPTION
## Proposed Changes

We should not mention wordpress.com in the version mismatch notice (Sync dialog), since it's used for both wpcom and Pressable.

The new notice:
<img width="592" height="87" alt="Screenshot 2026-04-07 at 15 51 38" src="https://github.com/user-attachments/assets/8f338090-83bf-4c1a-95fb-726f994e85ec" />


## Testing Instructions
Visual review should suffice