### PR TITLE
Fix dark mode scrollbar

### DIFF
--- a/apps/studio/src/index.css
+++ b/apps/studio/src/index.css
@@ -25,6 +25,7 @@
 
 @media ( prefers-color-scheme: dark ) {
 	:root {
+		color-scheme: dark;
 		--color-frame-bg: #2f2f2f;
 		--color-frame-text: #e0e0e0;
 		--color-frame-text-secondary: #949494;
@@ -167,9 +168,9 @@ div:has( > progress ) > div:first-child {
 
 /* Customize srollbar thumb appearance for the sites sidebar and tab panel */
 .sites-scrollbar::-webkit-scrollbar-thumb {
-	background: #ffffff26;
+	background: var( --color-frame-scrollbar-thumb );
 	border-radius: 10px;
-	border: 2px solid rgba( 30, 30, 30, 1 );
+	border: 2px solid var( --color-frame-scrollbar-border );
 }
 .components-tab-panel__tab-content::-webkit-scrollbar-thumb,
 .assistant-textarea::-webkit-scrollbar-thumb {
@@ -180,7 +181,7 @@ div:has( > progress ) > div:first-child {
 
 /* Add hover effect to thumb appearance on the scrollbar */
 .sites-scrollbar::-webkit-scrollbar-thumb:hover {
-	background: rgba( 255, 255, 255, 0.5 );
+	background: var( --color-frame-scrollbar-thumb-hover );
 }
 .components-tab-panel__tab-content::-webkit-scrollbar-thumb:hover,
 .assistant-textarea::-webkit-scrollbar-thumb:hover {


### PR DESCRIPTION
## Related issues

- Fixes STU-1426

## How AI was used in this PR

AI identified the root cause and wrote the CSS fix. Changes were visually verified by the developer before/after.

## Proposed Changes

> [!NOTE]
> I wasn't able to replicate the issue mentioned in Linear, but I still improved the layout of the scrollbar. 

- Add `color-scheme: dark` to the dark mode media query so the browser renders native UI elements (scrollbars, form controls) with dark styling
- Replace hardcoded color values in `.sites-scrollbar` with existing CSS custom properties (`--color-frame-scrollbar-thumb`, `--color-frame-scrollbar-border`, `--color-frame-scrollbar-thumb-hover`) for consistency with other scrollbar styles

| trunk | now |
|--------|--------|
| <img width="2272" height="1990" alt="image" src="https://github.com/user-attachments/assets/69f4dd01-f838-4286-99a3-2fe3bb6692a9" /> | <img width="2272" height="1990" alt="image" src="https://github.com/user-attachments/assets/b781542d-6f23-4e1a-ac70-b73124f11973" /> | 

## Testing Instructions

- Switch Studio to dark mode (Settings > Appearance > Dark, or set macOS to dark mode with Studio on "System")
- Navigate to the Settings tab for any site
- Resize the window to trigger scrollbars
- Verify scrollbars match the dark theme (no white background)
- Also check the sidebar site list scrollbar and any modals with scrollable content

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?