### PR TITLE
Update `studio code` command description

### DIFF
--- a/apps/cli/index.ts
+++ b/apps/cli/index.ts
@@ -201,7 +201,11 @@ async function main() {
 			} );
 			aiYargs.version( false );
 		};
-		studioArgv.command( 'code', __( 'AI agent for building WordPress' ), studioCodeCommandBuilder );
+		studioArgv.command(
+			'code',
+			__( 'AI agent for building WordPress sites' ),
+			studioCodeCommandBuilder
+		);
 		studioArgv.command( 'ai', false, studioCodeCommandBuilder );
 	}
 	const { registerCommand: registerMcpCommand } = await import( 'cli/commands/mcp' );


### PR DESCRIPTION
## Related issues

- Related to STU-1526
- Follow-up of https://github.com/Automattic/studio/pull/3002#issuecomment-4206030280

## Proposed Changes

- I feel the _"AI agent for building WordPress"_ description was missing something. I suggest adding `sites`, so it would look like: _"AI agent for building WordPress sites"_.

## Testing Instructions

1. Build the CLI: `npm run cli:build`
2. Run `node apps/cli/dist/cli/main.mjs --help`
3. Verify the `code` command description reads "AI agent for building WordPress sites".

<img width="683" height="288" alt="Screenshot 2026-04-08 at 15 27 06" src="https://github.com/user-attachments/assets/88006f30-64fe-4d7d-bf33-b7d606ced3fe" />

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors? (Tests pass, no errors)