### PR TITLE
Add CLI troubleshooting instructions to STUDIO.md

### DIFF
--- a/skills/STUDIO.md
+++ b/skills/STUDIO.md
@@ -50,6 +50,10 @@ studio site stop && studio site start --skip-browser
 
 ## Debugging
 
+**`studio` command not found:**
+
+If the `studio` command is not available in the terminal (e.g., "command not found" or "not recognized" errors), the Studio CLI is not installed. The user must open the WordPress Studio desktop app, go to **Settings → Studio CLI for terminal**, and enable the toggle to install it. Once installed, the user should open a new terminal window for the `studio` command to become available.
+
 **Enable WordPress debug logging:**
 ```bash
 studio site set --debug-log --debug-display


### PR DESCRIPTION
## Related issues

- Fixes STU-1483

## How AI was used in this PR

AI was used to draft the debugging instructions and create the PR.

## Proposed Changes

- Add a "studio command not found" troubleshooting entry to the Debugging section of `STUDIO.md`, instructing AI agents to guide users to enable the CLI toggle in Studio settings when the `studio` command is unavailable.

## Testing Instructions

1. Build and run the app with `npm start`
2. Start a site so the updated `STUDIO.md` gets deployed to the site directory
3. Uninstall the CLI from **Settings → Studio CLI for terminal**
4. Open a new terminal at the site path and confirm `studio` returns "command not found"
5. Use an AI agent (e.g. Claude Code) in that site directory — it should pick up the new instructions and guide you to re-enable the CLI toggle

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?