### PR TITLE
Remove ENABLE_STUDIO_AI feature flag and release studio code command

### DIFF
--- a/apps/cli/globals.d.ts
+++ b/apps/cli/globals.d.ts
@@ -1,5 +1,4 @@
 declare const __ENABLE_CLI_TELEMETRY__: boolean;
-declare const __ENABLE_STUDIO_AI__: boolean;
 declare const __IS_PACKAGED_FOR_NPM__: boolean;
 declare const __STUDIO_CLI_VERSION__: string;
 

--- a/apps/cli/index.ts
+++ b/apps/cli/index.ts
@@ -186,46 +186,44 @@ async function main() {
 		.demandCommand( 1, __( 'You must provide a valid command' ) )
 		.strict();
 
-	if ( __ENABLE_STUDIO_AI__ ) {
-		const studioCodeCommandBuilder = async ( aiYargs: StudioArgv ) => {
-			const { registerCommand: registerAiCommand } = await import( 'cli/commands/ai' );
-			registerAiCommand( aiYargs );
-			aiYargs.command( 'sessions', __( 'Manage code sessions' ), async ( sessionsYargs ) => {
-				const [
-					{ registerCommand: registerAiSessionsListCommand },
-					{ registerCommand: registerAiSessionsResumeCommand },
-					{ registerCommand: registerAiSessionsDeleteCommand },
-				] = await Promise.all( [
-					import( 'cli/commands/ai/sessions/list' ),
-					import( 'cli/commands/ai/sessions/resume' ),
-					import( 'cli/commands/ai/sessions/delete' ),
-				] );
+	const studioCodeCommandBuilder = async ( aiYargs: StudioArgv ) => {
+		const { registerCommand: registerAiCommand } = await import( 'cli/commands/ai' );
+		registerAiCommand( aiYargs );
+		aiYargs.command( 'sessions', __( 'Manage code sessions' ), async ( sessionsYargs ) => {
+			const [
+				{ registerCommand: registerAiSessionsListCommand },
+				{ registerCommand: registerAiSessionsResumeCommand },
+				{ registerCommand: registerAiSessionsDeleteCommand },
+			] = await Promise.all( [
+				import( 'cli/commands/ai/sessions/list' ),
+				import( 'cli/commands/ai/sessions/resume' ),
+				import( 'cli/commands/ai/sessions/delete' ),
+			] );
 
-				sessionsYargs
-					.option( 'path', {
-						hidden: true,
-					} )
-					.option( 'session-persistence', {
-						type: 'boolean',
-						default: true,
-						description: __( 'Record this code session to disk' ),
-					} );
-				registerAiSessionsListCommand( sessionsYargs );
-				registerAiSessionsResumeCommand( sessionsYargs );
-				registerAiSessionsDeleteCommand( sessionsYargs );
-				sessionsYargs
-					.version( false )
-					.demandCommand( 1, __( 'You must provide a valid code sessions command' ) );
-			} );
-			aiYargs.version( false );
-		};
-		studioArgv.command(
-			'code',
-			__( 'AI agent for building WordPress sites' ),
-			studioCodeCommandBuilder
-		);
-		studioArgv.command( 'ai', false, studioCodeCommandBuilder );
-	}
+			sessionsYargs
+				.option( 'path', {
+					hidden: true,
+				} )
+				.option( 'session-persistence', {
+					type: 'boolean',
+					default: true,
+					description: __( 'Record this code session to disk' ),
+				} );
+			registerAiSessionsListCommand( sessionsYargs );
+			registerAiSessionsResumeCommand( sessionsYargs );
+			registerAiSessionsDeleteCommand( sessionsYargs );
+			sessionsYargs
+				.version( false )
+				.demandCommand( 1, __( 'You must provide a valid code sessions command' ) );
+		} );
+		aiYargs.version( false );
+	};
+	studioArgv.command(
+		'code',
+		__( 'AI agent for building WordPress sites' ),
+		studioCodeCommandBuilder
+	);
+	studioArgv.command( 'ai', false, studioCodeCommandBuilder );
 
 	await studioArgv.argv;
 }

--- a/apps/cli/vite.config.base.ts
+++ b/apps/cli/vite.config.base.ts
@@ -77,7 +77,6 @@ export const baseConfig = defineConfig( {
 		mainFields: [ 'main' ],
 	},
 	define: {
-		__ENABLE_STUDIO_AI__: false,
 		__STUDIO_CLI_VERSION__: JSON.stringify( packageJson.version ),
 	},
 } );

--- a/apps/cli/vite.config.dev.ts
+++ b/apps/cli/vite.config.dev.ts
@@ -18,7 +18,6 @@ export default mergeConfig(
 		define: {
 			__IS_PACKAGED_FOR_NPM__: false,
 			__ENABLE_CLI_TELEMETRY__: false,
-			__ENABLE_STUDIO_AI__: true,
 		},
 	} )
 );


### PR DESCRIPTION
## Related issues

- Fixes STU-1445

## How AI was used in this PR

Claude removed the feature flag wrapper and associated build config entries. All changes were reviewed before committing.

## Proposed Changes

- Remove the `__ENABLE_STUDIO_AI__` feature flag guard from `apps/cli/index.ts`, making the `studio code` command always available
- Remove the `__ENABLE_STUDIO_AI__` define from `vite.config.base.ts` (production) and `vite.config.dev.ts` (dev)
- Remove the `__ENABLE_STUDIO_AI__` type declaration from `globals.d.ts`

## Testing Instructions

1. Build the CLI: `npm run cli:build:prod`
2. Run `node apps/cli/dist/cli/main.mjs --help` and verify the command code is in the list
3. Run `node apps/cli/dist/cli/main.mjs code --help` and verify the command is registered

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?