### PR TITLE
Filter out internal Automattic sites from CLI wp.com sites list

### DIFF
--- a/apps/cli/lib/api.ts
+++ b/apps/cli/lib/api.ts
@@ -192,6 +192,7 @@ const wpComSitesResponseSchema = z.object( {
 			name: z.string(),
 			URL: z.string(),
 			is_deleted: z.boolean().optional(),
+			is_a8c: z.boolean().optional(),
 		} )
 	),
 } );
@@ -205,14 +206,14 @@ export async function getWpComSites( token: string ): Promise< WpComSiteInfo[] >
 				path: '/me/sites',
 			},
 			{
-				fields: 'ID,name,URL,is_deleted',
+				fields: 'ID,name,URL,is_deleted,is_a8c',
 				filter: 'atomic,wpcom',
 				site_activity: 'active',
 			}
 		);
 		const result = wpComSitesResponseSchema.parse( rawResponse );
 		return result.sites
-			.filter( ( site ) => ! site.is_deleted )
+			.filter( ( site ) => ! site.is_deleted && ! site.is_a8c )
 			.map( ( site ) => ( {
 				id: site.ID,
 				name: site.name,


### PR DESCRIPTION
## Related issues

- Related to parity between Electron app and CLI site listing

## How AI was used in this PR

AI identified the discrepancy between the Electron app and CLI filtering logic and made the change. The change was reviewed by a human.

## Proposed Changes

- Add `is_a8c` field to the CLI's `/me/sites` API request and Zod schema
- Filter out `is_a8c` sites from the CLI's wp.com sites list, matching the Electron app's existing behavior in `transform-sites.ts`

## Testing Instructions

- Run `studio ai`, log in, and switch to the remote sites tab (→ arrow key)
- Verify that internal Automattic sites (is_a8c) no longer appear in the list
- Verify that normal wp.com sites still appear correctly

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?