### PR TITLE
Studio: Fix dark mode onboarding screen

### DIFF
--- a/apps/studio/src/modules/onboarding/index.tsx
+++ b/apps/studio/src/modules/onboarding/index.tsx
@@ -15,7 +15,7 @@ const GradientBox = () => {
 			className="gap-0 flex flex-col font-normal text-[42px] leading-[42px] text-white"
 		>
 			<div className="flex flex-col gap-1 relative self-stretch pb-1">
-				<div className="absolute inset-0 bg-gradient-to-b from-[var(--color-frame-theme)] to-[var(--color-frame-theme)]/60 dark:from-chrome dark:to-chrome/60"></div>
+				<div className="absolute inset-0 bg-gradient-to-b from-[var(--color-frame-theme)] to-[var(--color-frame-theme)]/60"></div>
 				<p>{ __( 'Imagine' ) }</p>
 				<p>{ __( 'Create' ) }</p>
 				<p>{ __( 'Design' ) }</p>
@@ -49,7 +49,7 @@ export function Onboarding() {
 
 	return (
 		<div className="flex flex-row flex-grow" data-testid="onboarding">
-			<div className="w-1/2 bg-frame-theme dark:bg-chrome pb-[50px] pt-[46px] px-[50px] flex flex-col justify-between">
+			<div className="w-1/2 bg-frame-theme pb-[50px] pt-[46px] px-[50px] flex flex-col justify-between">
 				<div className="flex justify-start items-center gap-1 mt-6">
 					<StudioLogo className="fill-white" />
 				</div>


### PR DESCRIPTION
## Related issues

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

Fixes STU-1532

## How AI was used in this PR

It was used to suggest the fix.

## Proposed Changes

This PR ensures that the onboarding screen in the dark mode has light blue color instead of black color.

**Before**
<img width="719" height="552" alt="Screenshot 2026-04-09 at 1 55 08 PM" src="https://github.com/user-attachments/assets/0ad03fe1-a609-4a36-bdb6-912aec2e48b8" />

**After**

<img width="1496" height="663" alt="Screenshot 2026-04-09 at 1 51 42 PM" src="https://github.com/user-attachments/assets/72f58bef-8ad3-4f44-b861-68449c0d90b6" />

Light mode:

<img width="1495" height="672" alt="Screenshot 2026-04-09 at 1 52 58 PM" src="https://github.com/user-attachments/assets/cc0d7050-790e-4aba-a3a0-82d53fb10318" />


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull the changes from this branch
* Switch Studio to the dark mode
* Apply the following diff:

```
diff --git a/apps/studio/src/components/app.tsx b/apps/studio/src/components/app.tsx
index a6d845af2..6e38a7c3e 100644
--- a/apps/studio/src/components/app.tsx
+++ b/apps/studio/src/components/app.tsx
@@ -28,7 +28,8 @@ import 'src/index.css';
 
 export default function App() {
        useLocalizationSupport();
-       const { needsOnboarding } = useOnboarding();
+       const { needsOnboarding: _needsOnboarding } = useOnboarding();
+       const needsOnboarding = true || _needsOnboarding; // TEMP: force onboarding screen for preview
        const isOnboardingLoading = useRootSelector( selectOnboardingLoading );
        const { isSidebarVisible, toggleSidebar } = useSidebarVisibility();
        const { showWhatsNew, closeWhatsNew } = useWhatsNew();
```
* Start Studio with `npm start`
* Confirm that you can see the blue screen instead of black
* Test with the light mode and confirm it looks as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
