### PR TITLE
Fix sidebar top padding on Windows

### DIFF
--- a/apps/studio/src/components/main-sidebar.tsx
+++ b/apps/studio/src/components/main-sidebar.tsx
@@ -16,12 +16,7 @@ export default function MainSidebar( { className }: MainSidebarProps ) {
 	return (
 		<div
 			data-testid="main-sidebar"
-			className={ cx(
-				'text-chrome-inverted relative',
-				isMac() && 'pt-[10px]',
-				! isMac() && 'pt-[38px]',
-				className
-			) }
+			className={ cx( 'text-chrome-inverted relative pt-[10px]', className ) }
 		>
 			{ ! localSites.length ? (
 				<div className="flex h-full px-[20px] justify-center items-center app-no-drag-region text-center text-[12px] text-a8c-gray-50">


### PR DESCRIPTION
## Proposed Changes
I don't know why we didn't notice it before, but on Windows we have huge gap at the top of main sidebar. I checked - we always had it. I propose to align it with macOS, since it feels like something is broken and I don't see a reson to have different padding top.

<img width="944" height="541" alt="Screenshot 2026-04-09 at 14 08 04" src="https://github.com/user-attachments/assets/e8012ccc-3d5d-456c-a2d8-8f3e45a96502" />

Fix sidebar top padding on Windows

## Testing Instructions
Run Studio on MacOS and Windows and assert that top padding looks good
<img width="1056" height="588" alt="Screenshot 2026-04-09 at 13 57 43" src="https://github.com/user-attachments/assets/acf85c30-6d7f-4a85-ad11-48d81695f6d1" />
<img width="1024" height="587" alt="Screenshot 2026-04-09 at 14 08 46" src="https://github.com/user-attachments/assets/b54050be-5423-4130-a7b9-1fc7b9c0d395" />
