### PR TITLE
Sort studio code command alphabetically among CLI commands

### DIFF
--- a/apps/cli/index.ts
+++ b/apps/cli/index.ts
@@ -92,6 +92,45 @@ async function main() {
 			authYargs.version( false ).demandCommand( 1, __( 'You must provide a valid auth command' ) );
 		} );
 
+	const studioCodeCommandBuilder = async ( aiYargs: StudioArgv ) => {
+		const { registerCommand: registerAiCommand } = await import( 'cli/commands/ai' );
+		registerAiCommand( aiYargs );
+		aiYargs.command( 'sessions', __( 'Manage code sessions' ), async ( sessionsYargs ) => {
+			const [
+				{ registerCommand: registerAiSessionsDeleteCommand },
+				{ registerCommand: registerAiSessionsListCommand },
+				{ registerCommand: registerAiSessionsResumeCommand },
+			] = await Promise.all( [
+				import( 'cli/commands/ai/sessions/delete' ),
+				import( 'cli/commands/ai/sessions/list' ),
+				import( 'cli/commands/ai/sessions/resume' ),
+			] );
+
+			sessionsYargs
+				.option( 'path', {
+					hidden: true,
+				} )
+				.option( 'session-persistence', {
+					type: 'boolean',
+					default: true,
+					description: __( 'Record this code session to disk' ),
+				} );
+			registerAiSessionsDeleteCommand( sessionsYargs );
+			registerAiSessionsListCommand( sessionsYargs );
+			registerAiSessionsResumeCommand( sessionsYargs );
+			sessionsYargs
+				.version( false )
+				.demandCommand( 1, __( 'You must provide a valid code sessions command' ) );
+		} );
+		aiYargs.version( false );
+	};
+	studioArgv.command(
+		'code',
+		__( 'AI agent for building WordPress sites' ),
+		studioCodeCommandBuilder
+	);
+	studioArgv.command( 'ai', false, studioCodeCommandBuilder );
+
 	registerExportCommand( studioArgv );
 	registerImportCommand( studioArgv );
 	registerMcpCommand( studioArgv );
@@ -185,45 +224,6 @@ async function main() {
 		} )
 		.demandCommand( 1, __( 'You must provide a valid command' ) )
 		.strict();
-
-	const studioCodeCommandBuilder = async ( aiYargs: StudioArgv ) => {
-		const { registerCommand: registerAiCommand } = await import( 'cli/commands/ai' );
-		registerAiCommand( aiYargs );
-		aiYargs.command( 'sessions', __( 'Manage code sessions' ), async ( sessionsYargs ) => {
-			const [
-				{ registerCommand: registerAiSessionsListCommand },
-				{ registerCommand: registerAiSessionsResumeCommand },
-				{ registerCommand: registerAiSessionsDeleteCommand },
-			] = await Promise.all( [
-				import( 'cli/commands/ai/sessions/list' ),
-				import( 'cli/commands/ai/sessions/resume' ),
-				import( 'cli/commands/ai/sessions/delete' ),
-			] );
-
-			sessionsYargs
-				.option( 'path', {
-					hidden: true,
-				} )
-				.option( 'session-persistence', {
-					type: 'boolean',
-					default: true,
-					description: __( 'Record this code session to disk' ),
-				} );
-			registerAiSessionsListCommand( sessionsYargs );
-			registerAiSessionsResumeCommand( sessionsYargs );
-			registerAiSessionsDeleteCommand( sessionsYargs );
-			sessionsYargs
-				.version( false )
-				.demandCommand( 1, __( 'You must provide a valid code sessions command' ) );
-		} );
-		aiYargs.version( false );
-	};
-	studioArgv.command(
-		'code',
-		__( 'AI agent for building WordPress sites' ),
-		studioCodeCommandBuilder
-	);
-	studioArgv.command( 'ai', false, studioCodeCommandBuilder );
 
 	await studioArgv.argv;
 }


### PR DESCRIPTION
## Related issues

- Related to #3021

## How AI was used in this PR

~Copilot~ **Claude!** assisted with moving the code command registration block to its alphabetical position in the CLI entry point.

## Proposed Changes

- Moved the `code` command registration in `apps/cli/index.ts` so that top-level CLI commands appear in alphabetical order: `auth → code → export → import → mcp → preview → pull → push → site → wp`
- Previously, `code` was registered at the very end of the file, after all other commands

## Testing Instructions

1. Build the CLI: `npm run cli:build`
2. Run `node apps/cli/dist/cli/main.mjs --help`
3. Verify commands are listed alphabetically: auth, code, export, import, mcp, preview, pull, push, site, wp
4. Run `node apps/cli/dist/cli/main.mjs code sessions --help` to verify the code command and its sessions subcommand still work

<img width="779" height="409" alt="Screenshot 2026-04-09 at 14 16 38" src="https://github.com/user-attachments/assets/9e8fbf29-e758-4d0d-8ac0-d7462c169efd" />
<img width="756" height="349" alt="Screenshot 2026-04-09 at 14 16 24" src="https://github.com/user-attachments/assets/19d210e5-2e57-4dcd-8ef5-19da035f1e21" />


## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?