### PR TITLE
Fix site thumbnail not displaying correctly for newly created sites

### DIFF
--- a/apps/studio/src/components/content-tab-overview.tsx
+++ b/apps/studio/src/components/content-tab-overview.tsx
@@ -15,7 +15,7 @@ import {
 	widget,
 } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { ArrowIcon } from 'src/components/arrow-icon';
 import { ButtonsSection, ButtonsSectionProps } from 'src/components/buttons-section';
 import { useSiteDetails } from 'src/hooks/use-site-details';
@@ -214,6 +214,10 @@ export function ContentTabOverview( { selectedSite }: ContentTabOverviewProps ) 
 	const loading = loadingThemeDetails || loadingThumbnails || initialLoading;
 	const isServerLoading = loadingServer[ selectedSite.id ];
 
+	useEffect( () => {
+		setIsThumbnailError( false );
+	}, [ thumbnailData ] );
+
 	const handleThumbnailClick = async () => {
 		if ( isServerLoading ) return;
 
@@ -222,16 +226,6 @@ export function ContentTabOverview( { selectedSite }: ContentTabOverviewProps ) 
 		}
 		getIpcApi().openSiteURL( selectedSite.id, '', { autoLogin: false } );
 	};
-
-	const thumbnailImage = (
-		<img
-			onError={ () => setIsThumbnailError( true ) }
-			onLoad={ () => setIsThumbnailError( false ) }
-			className="w-full h-full"
-			src={ thumbnailData || '' }
-			alt={ themeDetails?.name }
-		/>
-	);
 
 	return (
 		<div className="p-8 flex max-w-4xl">
@@ -266,13 +260,25 @@ export function ContentTabOverview( { selectedSite }: ContentTabOverviewProps ) 
 								{ __( 'Open site' ) }
 								<ArrowIcon />
 							</div>
-							{ isThumbnailError ? (
-								<div className="flex w-full items-center justify-center h-64 leading-5 text-frame-text-secondary text-center">
+							{ isThumbnailError && (
+								<div
+									className={ cx(
+										'flex w-full items-center justify-center h-64 leading-5 text-frame-text-secondary text-center'
+									) }
+								>
 									{ __( 'Preview unavailable' ) }
 								</div>
-							) : (
-								thumbnailImage
 							) }
+							<img
+								onError={ () => setIsThumbnailError( true ) }
+								onLoad={ () => setIsThumbnailError( false ) }
+								className={ cx(
+									'w-full h-full',
+									isThumbnailError && 'invisible absolute inset-0'
+								) }
+								src={ thumbnailData || '' }
+								alt={ themeDetails?.name }
+							/>
 						</button>
 					) }
 				</div>

--- a/apps/studio/src/components/content-tab-overview.tsx
+++ b/apps/studio/src/components/content-tab-overview.tsx
@@ -260,25 +260,19 @@ export function ContentTabOverview( { selectedSite }: ContentTabOverviewProps ) 
 								{ __( 'Open site' ) }
 								<ArrowIcon />
 							</div>
-							{ isThumbnailError && (
-								<div
-									className={ cx(
-										'flex w-full items-center justify-center h-64 leading-5 text-frame-text-secondary text-center'
-									) }
-								>
+							{ isThumbnailError ? (
+								<div className="flex w-full items-center justify-center h-64 leading-5 text-frame-text-secondary text-center">
 									{ __( 'Preview unavailable' ) }
 								</div>
+							) : (
+								<img
+									onError={ () => setIsThumbnailError( true ) }
+									onLoad={ () => setIsThumbnailError( false ) }
+									className="w-full h-full"
+									src={ thumbnailData || '' }
+									alt={ themeDetails?.name }
+								/>
 							) }
-							<img
-								onError={ () => setIsThumbnailError( true ) }
-								onLoad={ () => setIsThumbnailError( false ) }
-								className={ cx(
-									'w-full h-full',
-									isThumbnailError && 'invisible absolute inset-0'
-								) }
-								src={ thumbnailData || '' }
-								alt={ themeDetails?.name }
-							/>
 						</button>
 					) }
 				</div>

--- a/apps/studio/src/hooks/use-theme-details.tsx
+++ b/apps/studio/src/hooks/use-theme-details.tsx
@@ -68,6 +68,9 @@ export const ThemeDetailsProvider: React.FC< ThemeDetailsProviderProps > = ( { c
 
 	useIpcListener( 'thumbnail-loaded', ( _evt, { id, imageData } ) => {
 		setThumbnails( ( thumbnails ) => {
+			if ( imageData === thumbnails[ id ] ) {
+				return thumbnails;
+			}
 			return { ...thumbnails, [ id ]: imageData ?? undefined };
 		} );
 		setLoadingThumbnails( ( loadingThumbnails ) => {

--- a/apps/studio/src/modules/cli/lib/cli-events-subscriber.ts
+++ b/apps/studio/src/modules/cli/lib/cli-events-subscriber.ts
@@ -66,9 +66,6 @@ const handleSiteEvent = sequential( async ( event: SiteEvent ): Promise< void > 
 	}
 
 	void sendIpcEventToRenderer( 'site-event', event );
-	if ( running ) {
-		void captureSiteThumbnail( siteId, false );
-	}
 } );
 
 let subscriber: ReturnType< typeof executeCliCommand > | null = null;


### PR DESCRIPTION
## Related issues

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

- Fixes STU-1541

## How AI was used in this PR

<!--
Help reviewers understand what to look for and verify that you've reviewed the code yourself.
-->

To help quickly implement a fix after I had diagnosed the issue. 

## Proposed Changes

Since https://github.com/Automattic/studio/pull/2850, Studio generates site thumbnails much more frequently. This leads to a race condition when creating a new site, causing Studio to display `Preview unavailable` instead of the site thumbnail. This PR fixes that. 

More details: when the `thumbnailData` value changes rapidly in `ContentTabOverview`, the first base64-encoded image doesn't have time to load before the value changes again. This triggers an `error` event, which removes the `<img>` from the DOM and replaces it with the text `Preview unavailable`. When the `<img>` isn't in the DOM, it doesn't load, and so subsequent `thumbnailData` changes never make the image appear. 

This PR fixes the issue by simply resetting the `isThumbnailError` state whenever `thumbnailData` changes.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. `npm start`
2. Create a new site
3. Ensure that the site thumbnail displays correctly

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
