### PR TITLE
Add visual annotation browser with Agentation

### DIFF
--- a/apps/cli/ai/agent.ts
+++ b/apps/cli/ai/agent.ts
@@ -73,11 +73,14 @@ export function startAiAgent( config: AiAgentConfig ): Query {
 		studio: isRemoteSite
 			? createRemoteSiteTools( wpcomAccessToken, activeSite.wpcomSiteId! )
 			: createStudioTools(),
+		agentation: {
+			command: 'npx',
+			args: [ '--yes', 'agentation-mcp', 'server' ],
+		},
 	};
 
 	const allowedTools = isRemoteSite ? [ ...ALLOWED_TOOLS_REMOTE ] : [ ...ALLOWED_TOOLS ];
 
-	// Build site-aware system prompt
 	const systemPromptOptions = isRemoteSite
 		? {
 				remoteSite: {

--- a/apps/cli/ai/agentation-inject.ts
+++ b/apps/cli/ai/agentation-inject.ts
@@ -1,0 +1,63 @@
+/**
+ * Opens a headed Playwright browser on a Studio site with the Agentation
+ * annotation toolbar injected via dynamic imports from esm.sh.
+ *
+ * Uses ?deps= pinning to ensure a single React instance shared with Agentation.
+ */
+
+const AGENTATION_ENDPOINT = 'http://localhost:4747';
+
+type Browser = Awaited< ReturnType< ( typeof import('playwright') )[ 'chromium' ][ 'launch' ] > >;
+type Page = Awaited< ReturnType< Browser[ 'newPage' ] > >;
+
+let agentationBrowser: Browser | null = null;
+let agentationPage: Page | null = null;
+
+export async function openAgentationBrowser( siteUrl: string ): Promise< string > {
+	if ( agentationBrowser && agentationPage ) {
+		try {
+			await agentationPage.evaluate( () => true );
+			return 'Agentation browser is already open. The user can annotate elements.';
+		} catch {
+			agentationBrowser = null;
+			agentationPage = null;
+		}
+	}
+
+	const { chromium } = await import( 'playwright' );
+	agentationBrowser = await chromium.launch( {
+		headless: false,
+		args: [ '--ignore-certificate-errors' ],
+	} );
+
+	agentationPage = await agentationBrowser.newPage( {
+		viewport: { width: 1440, height: 900 },
+		ignoreHTTPSErrors: true,
+	} );
+
+	await agentationPage.goto( siteUrl, {
+		waitUntil: 'domcontentloaded',
+		timeout: 30_000,
+	} );
+
+	await agentationPage.waitForLoadState( 'networkidle', { timeout: 10_000 } ).catch( () => {} );
+
+	const injectScript = [
+		'import("https://esm.sh/react@18").then(function(R) {',
+		'return import("https://esm.sh/react-dom@18/client?deps=react@18").then(function(RD) {',
+		'return import("https://esm.sh/agentation@3?deps=react@18,react-dom@18").then(function(Ag) {',
+		'var c = document.createElement("div"); c.id = "__agentation-root"; document.body.appendChild(c);',
+		'RD.createRoot(c).render(R.default.createElement(Ag.PageFeedbackToolbarCSS,',
+		'{ endpoint: "' + AGENTATION_ENDPOINT + '" }));',
+		'}); }); });',
+	].join( ' ' );
+
+	await agentationPage.evaluate( injectScript );
+
+	agentationPage.on( 'close', () => {
+		agentationBrowser = null;
+		agentationPage = null;
+	} );
+
+	return `Agentation browser opened at ${ siteUrl }. Click the circle icon in the bottom-right to annotate elements.`;
+}

--- a/apps/cli/ai/plugin/skills/annotate/SKILL.md
+++ b/apps/cli/ai/plugin/skills/annotate/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: annotate
+description: Open a browser with visual annotation tools. The user clicks elements on their site and leaves feedback — the agent reads annotations and makes changes. Use this when the user wants to point at specific elements to fix, tweak, or redesign.
+user-invokable: true
+---
+
+# Visual Annotations
+
+Open a browser where the user can click elements on their WordPress site and annotate them with feedback. You read those annotations and make the requested changes.
+
+## On Startup
+
+When the user invokes this skill, introduce yourself:
+
+> **Visual Annotations** — I'll open your site in a browser with an annotation toolbar. Click any element, type your feedback, and I'll fix it.
+
+Then identify the target site. If there's an active site, use it. If there are multiple, ask which one.
+
+## Workflow
+
+### 1. Clear old annotations
+
+Before opening the browser, dismiss all pending annotations from previous sessions so you start fresh. Use `agentation_get_all_pending`, then `agentation_dismiss` on each one.
+
+### 2. Open the browser
+
+Call `site_info` to get the site URL — do NOT guess the URL or port.
+
+Use the `open_annotation_browser` tool with the site URL. This opens a headed Playwright browser with the Agentation toolbar injected.
+
+Tell the user:
+> The browser is open. Click the **circle icon** in the bottom-right corner to activate the toolbar, then click any element to annotate it. Let me know when you're done.
+
+### 3. Read annotations
+
+Use `agentation_get_all_pending` to get unresolved annotations. Filter results:
+- **Only** act on annotations whose `url` matches the current site URL
+- **Only** act on annotations the user just created in this session — check timestamps and ignore old ones
+- Ask the user to confirm the list before making changes if there are annotations you didn't expect
+
+Each annotation includes:
+- **CSS selector / elementPath** — use to find the element in the theme or via WP-CLI
+- **Computed styles** — current CSS values (colors, sizes, spacing)
+- **nearbyText** — visible text content of the element
+- **User feedback (comment)** — what the user wants changed
+
+### 4. Make changes
+
+For each annotation:
+1. Use `agentation_acknowledge_annotation` to signal you're working on it
+2. **Identify what to change:**
+   - Use the CSS selector to find the element in theme templates or stylesheets
+   - Use `wp_cli` with `post list --post_type=wp_template --format=json` to check if it's in a template override
+   - Use `wp_cli` with `eval "echo wp_get_custom_css();"` to check existing custom CSS
+3. **Apply the change using the right approach:**
+   - For style changes (colors, sizes, spacing): use Global Styles custom CSS with the selector from the annotation
+   - For content changes (text, headings, block structure): edit the template or post content via WP-CLI
+   - For block-level changes: identify the WordPress block type from the HTML structure (look for `wp-block-*` classes) and modify accordingly
+4. Take a screenshot to verify the change looks correct
+5. Use `agentation_resolve_annotation` with a summary of what was changed
+
+### 5. Verify
+
+After all annotations are addressed, take a screenshot and confirm with the user.
+
+## Making changes the WordPress way
+
+Always prefer WordPress APIs over direct file edits or custom plugins.
+
+### CSS / design changes
+
+Use **Global Styles custom CSS** — never create throwaway plugins:
+```
+wp eval 'echo wp_get_custom_css();'   → read current custom CSS
+wp eval 'wp_update_custom_css_post("CSS HERE");'   → update custom CSS
+```
+
+### Template changes
+
+Create **template overrides via the database**, not file edits:
+```
+wp post create --post_type=wp_template --post_name="theme-slug//template-name" --post_content="BLOCK MARKUP" --post_status=publish
+```
+
+### When to use what
+
+- **Tweaking an existing site**: Prefer Global Styles custom CSS and template overrides in the database — these are non-destructive and easy to revert
+- **Building a theme or new site**: Edit theme files directly — that's the job. Follow Studio's existing guidelines for block themes (theme.json, templates/, style.css)
+- **Never**: Modify WordPress core files

--- a/apps/cli/ai/slash-commands.ts
+++ b/apps/cli/ai/slash-commands.ts
@@ -284,6 +284,7 @@ export const AI_CHAT_SLASH_COMMANDS: SlashCommandDef[] = [
 		description: __( 'Exit the chat' ),
 		handler: async () => 'break',
 	},
+	{ name: 'annotate', description: __( 'Annotate site elements visually in a browser' ) },
 	{ name: 'taxonomist', description: __( 'Optimize category taxonomy with AI' ) },
 	{ name: 'need-for-speed', description: __( 'Run a performance audit on a site' ) },
 ];

--- a/apps/cli/ai/tools.ts
+++ b/apps/cli/ai/tools.ts
@@ -3,6 +3,7 @@ import path from 'path';
 import { tool, createSdkMcpServer } from '@anthropic-ai/claude-agent-sdk';
 import { DEFAULT_PHP_VERSION } from '@studio/common/constants';
 import { z } from 'zod/v4';
+import { openAgentationBrowser } from 'cli/ai/agentation-inject';
 import { validateBlocks, type ValidationReport } from 'cli/ai/block-validator';
 import { getSharedBrowser } from 'cli/ai/browser-utils';
 import { auditPerformance } from 'cli/ai/performance-audit';
@@ -942,6 +943,29 @@ const exportSiteTool = tool(
 	}
 );
 
+const openAnnotationBrowserTool = tool(
+	'open_annotation_browser',
+	'Opens a headed browser on a site with the Agentation annotation toolbar. ' +
+		'The user can click elements and add visual feedback. Use agentation MCP tools to read annotations afterward.',
+	{
+		url: z.string().describe( 'The site URL to open (e.g., "http://localhost:8881")' ),
+	},
+	async ( args ) => {
+		try {
+			emitProgress( `Opening annotation browser at ${ args.url }…` );
+			const message = await openAgentationBrowser( args.url );
+			emitProgress( 'Annotation browser ready' );
+			return textResult( message );
+		} catch ( error ) {
+			return errorResult(
+				`Failed to open annotation browser: ${
+					error instanceof Error ? error.message : String( error )
+				}`
+			);
+		}
+	}
+);
+
 export const studioToolDefinitions = [
 	createSiteTool,
 	listSitesTool,
@@ -962,6 +986,7 @@ export const studioToolDefinitions = [
 	pullSiteTool,
 	importSiteTool,
 	exportSiteTool,
+	openAnnotationBrowserTool,
 ];
 
 export function createStudioTools() {

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -69,6 +69,7 @@
 	},
 	"devDependencies": {
 		"@studio/common": "file:../../tools/common",
+		"agentation-mcp": "^1.2.0",
 		"@types/archiver": "^7.0.0",
 		"@types/http-proxy": "^1.17.17",
 		"@types/node-forge": "^1.3.14",


### PR DESCRIPTION
## Summary

Adds `/annotate` skill to Studio Code. Users type `/annotate`, a browser opens with the Agentation annotation toolbar, they click elements and leave feedback, and the agent reads those annotations and makes changes.

Tested end-to-end: user annotated "make this red", "change this to H2" → agent read annotations, applied changes via Global Styles custom CSS and WP-CLI.

Alternative approach to the custom element picker in #2936 — instead of building a custom UI, this injects [Agentation](https://www.agentation.com)'s React toolbar into a Playwright browser using esm.sh CDN with `?deps=` pinning for a single React instance.

## How it works

1. `agentation-mcp` bundled as dependency — launches HTTP (localhost:4747) + MCP servers
2. `/annotate` skill clears old annotations, opens headed Playwright browser via `open_annotation_browser` tool
3. Agentation React component injected via dynamic `import()` from esm.sh CDN
4. User clicks elements, adds feedback in the browser
5. Agent reads annotations with `agentation_get_all_pending` (CSS selectors, computed styles, text)
6. Agent makes WordPress changes (Global Styles CSS, template overrides, WP-CLI) and resolves annotations

## Changes

- **`apps/cli/ai/agentation-inject.ts`** (new) — Opens headed Playwright browser, injects Agentation via esm.sh dynamic imports
- **`apps/cli/ai/tools.ts`** — New `open_annotation_browser` tool
- **`apps/cli/ai/plugin/skills/annotate/SKILL.md`** (new) — `/annotate` skill with guided workflow and WordPress-native change patterns
- **`apps/cli/ai/slash-commands.ts`** — Register `/annotate` command
- **`apps/cli/ai/agent.ts`** — Agentation MCP server added alongside Studio tools
- **`apps/cli/package.json`** — `agentation-mcp` dependency

## Testing

1. `npm install && npm run cli:build`
2. `node apps/cli/dist/cli/main.mjs code`
3. Select a running site, type `/annotate`
4. Click the circle icon (bottom-right), click elements, add feedback
5. Type "done" — agent reads and applies changes

## Quality gates

- [x] ESLint: pass
- [x] TypeScript: pass
- [x] Tests: 72/72 pass
- [x] End-to-end: annotations synced and applied to WordPress site