### PR TITLE
Remove assistant message bullets in CLI chat

### DIFF
--- a/apps/cli/ai/ui.ts
+++ b/apps/cli/ai/ui.ts
@@ -1426,20 +1426,17 @@ export class AiChatUI {
 		this.updateHints();
 		this.currentMarkdown = null;
 		this.currentResponseText = '';
+		this.hasShownResponseMarker = false;
 		this.pendingTodoRenders.clear();
 		this.pendingTodoRenderOrder = [];
 	}
 
 	showOnboarding(): void {
-		const text =
-			' ' +
-			chalk.blue( '⏺' ) +
-			' ' +
-			sprintf(
-				/* translators: %s: product name (WordPress Studio) */
-				__( "Hello, I'm %s, your local WordPress agent and builder." ),
-				chalk.bold( 'WordPress Studio' )
-			);
+		const text = sprintf(
+			/* translators: %s: product name (WordPress Studio) */
+			__( "Hello, I'm %s, your local WordPress agent and builder." ),
+			chalk.bold( 'WordPress Studio' )
+		);
 
 		this.messages.addChild( new Text( '\n' + text + '\n', 0, 0 ) );
 		this.tui.requestRender();
@@ -1451,10 +1448,7 @@ export class AiChatUI {
 		const separator = d( ' ─'.padEnd( 80, '─' ) );
 
 		const lines = [
-			' ' +
-				chalk.blue( '⏺' ) +
-				' ' +
-				__( "Great, you're connected now! Let me tell you what I can do:" ),
+			__( "Great, you're connected now! Let me tell you what I can do:" ),
 			'',
 			'  ' + b( __( 'Local Sites Management' ) ),
 			'',
@@ -2053,9 +2047,7 @@ export class AiChatUI {
 							this.currentResponseText += '\n';
 						}
 						this.currentResponseText += block.text;
-						this.currentMarkdown!.setText(
-							'\n' + chalk.blue( '⏺' ) + ' ' + this.currentResponseText
-						);
+						this.currentMarkdown!.setText( '\n' + this.currentResponseText );
 						this.tui.requestRender();
 					} else if ( block.type === 'tool_use' ) {
 						this.toolStartTime = this.nowMs();
@@ -2119,6 +2111,7 @@ export class AiChatUI {
 				// creates a fresh visual block (mirrors askUser / endAgentTurn).
 				this.currentMarkdown = null;
 				this.currentResponseText = '';
+				this.hasShownResponseMarker = false;
 				return undefined;
 			}
 			case 'result': {
@@ -2126,9 +2119,7 @@ export class AiChatUI {
 				if ( message.subtype === 'success' ) {
 					const thinkingSec = Math.round( ( this.nowMs() - this.turnStartTime ) / 1000 );
 					if ( ! this.hasShownResponseMarker ) {
-						this.messages.addChild(
-							new Text( '\n ' + chalk.blue( '⏺' ) + ' ' + __( 'Done' ), 0, 0 )
-						);
+						this.messages.addChild( new Text( '\n' + __( 'Done' ), 0, 0 ) );
 					}
 					this.showInfo(
 						sprintf(
@@ -2148,13 +2139,7 @@ export class AiChatUI {
 				// User-initiated interruption: show friendly message instead of error
 				if ( this.wasInterrupted ) {
 					const thinkingSec = Math.round( ( this.nowMs() - this.turnStartTime ) / 1000 );
-					this.messages.addChild(
-						new Text(
-							'\n ' + chalk.yellow( '⏺' ) + ' ' + chalk.yellow( __( 'Interrupted' ) ),
-							0,
-							0
-						)
-					);
+					this.messages.addChild( new Text( '\n' + chalk.yellow( __( 'Interrupted' ) ), 0, 0 ) );
 					this.showInfo(
 						sprintf(
 							/* translators: %d: number of seconds */


### PR DESCRIPTION
We already distinguish the user and assistant-authored messages, with the highlight on user messages. I don't think we need both the bullet and the highlight. 

Before: 
<img width="1848" height="1446" alt="screenshot-2026-04-09 at 13 04 07@2x" src="https://github.com/user-attachments/assets/a442faa0-436b-4905-9616-5161785f6378" />

After: 
<img width="1848" height="1446" alt="screenshot-2026-04-09 at 13 03 17@2x" src="https://github.com/user-attachments/assets/52a8d0d4-f160-4851-a546-b2d06052f0ef" />

## How AI was used in this PR

Used AI to locate the CLI transcript renderer that prepends the leading bullet and to prepare a narrow patch for that code path. The final diff was reviewed manually.

## Proposed Changes

- remove the leading `⏺` prefix from assistant-authored CLI chat messages
- keep tool and status indicators unchanged so only assistant prose is affected
- remove the same leading bullet treatment from the onboarding and fallback `Done` / `Interrupted` assistant text paths for consistency

## Testing Instructions

- Run `PATH=/Users/richtabor/.nvm/versions/node/v24.13.1/bin:$PATH npx eslint --fix apps/cli/ai/ui.ts`
- Run `PATH=/Users/richtabor/.nvm/versions/node/v24.13.1/bin:$PATH npm test -- apps/cli/ai/tests/ui.test.ts`
- Run `PATH=/Users/richtabor/.nvm/versions/node/v24.13.1/bin:$PATH npm run typecheck`
- Start the Studio CLI AI chat and confirm assistant responses no longer render with a leading `⏺` bullet

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
