### PR TITLE
Fix dark mode visibility for error/success text in site list

### DIFF
--- a/apps/studio/src/components/clear-action.tsx
+++ b/apps/studio/src/components/clear-action.tsx
@@ -15,13 +15,13 @@ export function ClearAction( {
 } ) {
 	const { __ } = useI18n();
 	return (
-		<div
-			className={ cx(
-				'flex gap-4 items-center',
-				isError ? 'text-a8c-red-50' : 'text-a8c-green-50'
-			) }
-		>
-			<span className="flex items-center gap-2">
+		<div className="flex gap-4 items-center">
+			<span
+				className={ cx(
+					'flex items-center gap-2',
+					isError ? 'text-a8c-red-50' : 'text-a8c-green-50'
+				) }
+			>
 				{ isError ? <ErrorIcon /> : <CheckIcon /> }
 				{ children }
 			</span>

--- a/apps/studio/src/index.css
+++ b/apps/studio/src/index.css
@@ -396,7 +396,7 @@ div:has( > progress ) > div:first-child {
 		color: var( --color-frame-text );
 	}
 	:is( [data-testid='site-content'], .components-modal__frame, [data-fullscreen-modal] )
-		span:not( .components-button span, button span ) {
+		span:not( .components-button span, button span, .text-a8c-red-50, .text-a8c-green-50, .text-frame-error, .text-frame-running ) {
 		color: var( --color-frame-text );
 	}
 


### PR DESCRIPTION
## Related issues

- Fixes https://linear.app/a8c/issue/STU-1522/studio-push-error-in-the-site-list-is-not-distinct-in-the-dark-mode

## How AI was used in this PR

AI assisted with finding affected components and drafting the fix. All changes were reviewed and tested manually.

## Proposed Changes

- Exclude `.text-a8c-red-50`, `.text-a8c-green-50`, `.text-frame-error`, and `.text-frame-running` from the blanket dark mode `span` color override in `index.css`, so error/success text retains its color in dark mode
- Move the color class in `ClearAction` from the parent `<div>` to the `<span>` so it directly matches the CSS `:not()` exclusion

| Sync | Preview |
|--------|--------|
| <img width="1213" height="879" alt="image" src="https://github.com/user-attachments/assets/ab905c64-6eb6-4113-a7ea-4135c8847a28" /> | <img width="1213" height="879" alt="image" src="https://github.com/user-attachments/assets/c8f71609-e8a2-4520-b570-9b177be176cb" /> | 

## Testing Instructions

1. Connect a site to WordPress.com
2. Trigger a push or pull error (e.g. disconnect network mid-sync)
3. Verify the error text is red in both light and dark mode
4. Also check preview site "Failed" and "Deleted" states in dark mode

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?