### PR TITLE
Improve AskUserQuestion CLI interactions

### DIFF
--- a/apps/cli/ai/tests/ui.test.ts
+++ b/apps/cli/ai/tests/ui.test.ts
@@ -1,3 +1,5 @@
+import { SelectList } from '@mariozechner/pi-tui';
+import stripAnsi from 'strip-ansi';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { AiChatUI } from 'cli/ai/ui';
 import { openBrowser } from 'cli/lib/browser';
@@ -214,5 +216,549 @@ describe( 'AiChatUI.handleMessage', () => {
 			{ nameOrPath: 'aura' }
 		);
 		expect( ui.pendingToolCalls ).toEqual( new Map() );
+	} );
+} );
+
+describe( 'AiChatUI.askUser', () => {
+	it( 'skips remaining option questions when cancelled', async () => {
+		const ui = Object.create( AiChatUI.prototype ) as {
+			askUser: (
+				questions: Array< {
+					question: string;
+					options: Array< { label: string; description: string } >;
+					allowFreeForm?: boolean;
+				} >
+			) => Promise< Record< string, string > >;
+			[ key: string ]: unknown;
+		};
+
+		ui.hideLoader = vi.fn();
+		ui.hideEditor = vi.fn();
+		ui.showLoader = vi.fn();
+		ui.renderOptionPicker = vi.fn();
+		ui.randomThinkingMessage = vi.fn().mockReturnValue( 'Thinking…' );
+		ui.messages = { addChild: vi.fn() };
+		ui.tui = {
+			addChild: vi.fn(),
+			removeChild: vi.fn(),
+			requestRender: vi.fn(),
+		};
+
+		const answersPromise = ui.askUser( [
+			{
+				question: 'Which layout?',
+				options: [
+					{ label: 'Business', description: 'Business site' },
+					{ label: 'Portfolio', description: 'Portfolio site' },
+				],
+				allowFreeForm: true,
+			},
+		] );
+
+		const selectList = ui.optionPickerSelectList as { onCancel?: () => void } | null;
+		expect( ui.renderOptionPicker ).toHaveBeenCalledTimes( 1 );
+		expect( selectList?.onCancel ).toBeTypeOf( 'function' );
+		selectList?.onCancel?.();
+
+		await expect( answersPromise ).resolves.toEqual( {} );
+		expect( ui.showLoader ).toHaveBeenCalledWith( 'Thinking…' );
+		expect( ui.askUserActive ).toBe( false );
+	} );
+
+	it( 'skips remaining text questions when cancelled', async () => {
+		const ui = Object.create( AiChatUI.prototype ) as {
+			askUser: (
+				questions: Array< {
+					question: string;
+					options: Array< { label: string; description: string } >;
+				} >
+			) => Promise< Record< string, string > >;
+			cancelAskUserQuestions: () => boolean;
+			[ key: string ]: unknown;
+		};
+
+		ui.hideLoader = vi.fn();
+		ui.showLoader = vi.fn();
+		ui.randomThinkingMessage = vi.fn().mockReturnValue( 'Thinking…' );
+		ui.messages = { addChild: vi.fn() };
+		ui.editor = { setText: vi.fn() };
+		ui.tui = {
+			addChild: vi.fn(),
+			removeChild: vi.fn(),
+			requestRender: vi.fn(),
+			setFocus: vi.fn(),
+		};
+
+		const answersPromise = ui.askUser( [
+			{
+				question: 'What should the site be called?',
+				options: [],
+			},
+		] );
+
+		expect( ui.submitResolve ).toBeTypeOf( 'function' );
+		expect( ui.cancelAskUserQuestions() ).toBe( true );
+
+		await expect( answersPromise ).resolves.toEqual( {} );
+		expect( ui.showLoader ).toHaveBeenCalledWith( 'Thinking…' );
+		expect( ui.askUserActive ).toBe( false );
+	} );
+} );
+
+describe( 'AiChatUI ask-user affordances', () => {
+	it( 'does not show an interrupt hint when idle', () => {
+		const ui = Object.create( AiChatUI.prototype ) as {
+			updateHints: () => void;
+			[ key: string ]: unknown;
+		};
+
+		ui.editor = { hints: [] };
+		ui._inAgentTurn = false;
+		ui.askUserActive = false;
+		ui.optionPickerVisible = false;
+		ui.activeExpandablePreview = null;
+		ui.interruptCallback = null;
+
+		ui.updateHints();
+
+		expect( ui.editor ).toMatchObject( {
+			hints: [ '↓ select site' ],
+		} );
+	} );
+
+	it( 'shows a submit-and-skip hint for free-form ask-user input', () => {
+		const ui = Object.create( AiChatUI.prototype ) as {
+			updateHints: () => void;
+			[ key: string ]: unknown;
+		};
+
+		ui.editor = { hints: [] };
+		ui._inAgentTurn = true;
+		ui.askUserActive = true;
+		ui.optionPickerVisible = false;
+		ui.activeExpandablePreview = null;
+
+		ui.updateHints();
+
+		expect( ui.editor ).toMatchObject( {
+			hints: [ 'enter to submit · esc to skip' ],
+		} );
+	} );
+
+	it( 'shows an interrupt hint during an agent turn', () => {
+		const ui = Object.create( AiChatUI.prototype ) as {
+			updateHints: () => void;
+			[ key: string ]: unknown;
+		};
+
+		ui.editor = { hints: [] };
+		ui._inAgentTurn = true;
+		ui.askUserActive = false;
+		ui.optionPickerVisible = false;
+		ui.activeExpandablePreview = null;
+		ui.interruptCallback = vi.fn();
+
+		ui.updateHints();
+
+		expect( ui.editor ).toMatchObject( {
+			hints: [ 'esc to interrupt' ],
+		} );
+	} );
+
+	it( 'shows a select-and-skip hint in the option picker', () => {
+		const addChild = vi.fn();
+		const ui = Object.create( AiChatUI.prototype ) as {
+			renderOptionPicker: () => void;
+			[ key: string ]: unknown;
+		};
+
+		ui.optionPickerContainer = {
+			clear: vi.fn(),
+			addChild,
+		};
+		ui.optionPickerSelectList = new SelectList(
+			[
+				{ value: 'Business', label: '1. Business' },
+				{ value: 'Portfolio', label: '2. Portfolio' },
+				{ value: '__other__', label: '3. Type something…' },
+			],
+			3,
+			{} as never
+		);
+		ui.optionPickerHasFreeForm = true;
+		ui.optionPickerItemCount = 3;
+		ui.optionPickerVisible = true;
+		ui.optionPickerOtherActive = false;
+		ui.optionPickerInput = null;
+		ui.tui = { requestRender: vi.fn() };
+
+		ui.renderOptionPicker();
+
+		const picker = addChild.mock.calls[ 0 ][ 0 ] as { text: string };
+		expect( picker.text ).toContain( '3. Type something…' );
+		expect( stripAnsi( picker.text ) ).toContain(
+			'tab/arrow keys to navigate · enter to select · esc to skip'
+		);
+	} );
+
+	it( 'replaces the free-form placeholder with inline input while typing', () => {
+		const addChild = vi.fn();
+		const ui = Object.create( AiChatUI.prototype ) as {
+			renderOptionPicker: () => void;
+			[ key: string ]: unknown;
+		};
+
+		ui.optionPickerContainer = {
+			clear: vi.fn(),
+			addChild,
+		};
+		const selectList = new SelectList(
+			[
+				{ value: 'Business', label: '1. Business' },
+				{ value: 'Portfolio', label: '2. Portfolio' },
+				{ value: '__other__', label: '3. Type something…' },
+			],
+			3,
+			{} as never
+		);
+		selectList.setSelectedIndex( 2 );
+		ui.optionPickerSelectList = selectList;
+		ui.optionPickerHasFreeForm = true;
+		ui.optionPickerItemCount = 3;
+		ui.optionPickerVisible = true;
+		ui.optionPickerOtherActive = true;
+		ui.optionPickerOtherValue = 'custom answer';
+		ui.optionPickerInput = {
+			getValue: vi.fn().mockReturnValue( 'custom answer' ),
+		};
+		ui.tui = { requestRender: vi.fn() };
+
+		ui.renderOptionPicker();
+
+		const picker = addChild.mock.calls[ 0 ][ 0 ] as { text: string };
+		const renderedText = stripAnsi( picker.text );
+		expect( renderedText ).toContain( '3. custom answer' );
+		expect( renderedText ).not.toContain( 'Type something…' );
+		expect( renderedText ).toContain(
+			'tab/arrow keys to navigate · enter to submit · esc to skip'
+		);
+	} );
+} );
+
+describe( 'AiChatUI ask-user tab navigation', () => {
+	it( 'moves the option picker selection with Tab and Shift+Tab', () => {
+		const ui = Object.create( AiChatUI.prototype ) as {
+			handleOptionPickerTabNavigation: ( data: string ) => boolean;
+			[ key: string ]: unknown;
+		};
+
+		ui.optionPickerSelectList = new SelectList(
+			[
+				{ value: 'Business', label: '1. Business' },
+				{ value: 'Portfolio', label: '2. Portfolio' },
+			],
+			2,
+			{} as never
+		);
+		ui.optionPickerHasFreeForm = false;
+		ui.optionPickerOtherActive = false;
+		ui.renderOptionPicker = vi.fn();
+
+		expect( ui.handleOptionPickerTabNavigation( '\t' ) ).toBe( true );
+		expect( ( ui.optionPickerSelectList as SelectList ).getSelectedItem()?.value ).toBe(
+			'Portfolio'
+		);
+
+		expect( ui.handleOptionPickerTabNavigation( '\u001b[Z' ) ).toBe( true );
+		expect( ( ui.optionPickerSelectList as SelectList ).getSelectedItem()?.value ).toBe(
+			'Business'
+		);
+	} );
+
+	it( 'preserves free-form input when tabbing away and back', () => {
+		const ui = Object.create( AiChatUI.prototype ) as {
+			handleOptionPickerTabNavigation: ( data: string ) => boolean;
+			[ key: string ]: unknown;
+		};
+
+		ui.optionPickerSelectList = new SelectList(
+			[
+				{ value: 'Business', label: '1. Business' },
+				{ value: '__other__', label: '2. Type something…' },
+			],
+			2,
+			{} as never
+		);
+		( ui.optionPickerSelectList as SelectList ).setSelectedIndex( 1 );
+		ui.optionPickerHasFreeForm = true;
+		ui.optionPickerOtherActive = true;
+		ui.optionPickerOtherValue = '';
+		ui.optionPickerInput = {
+			getValue: vi.fn().mockReturnValue( 'custom answer' ),
+		};
+		ui.renderOptionPicker = vi.fn();
+
+		expect( ui.handleOptionPickerTabNavigation( '\t' ) ).toBe( true );
+		expect( ui.optionPickerOtherValue ).toBe( 'custom answer' );
+		expect( ( ui.optionPickerSelectList as SelectList ).getSelectedItem()?.value ).toBe(
+			'Business'
+		);
+
+		expect( ui.handleOptionPickerTabNavigation( '\t' ) ).toBe( true );
+		expect( ( ui.optionPickerSelectList as SelectList ).getSelectedItem()?.value ).toBe(
+			'__other__'
+		);
+		const restoredInput = ui.optionPickerInput as { getValue: () => string; cursor: number } | null;
+		expect( restoredInput?.getValue() ).toBe( 'custom answer' );
+		expect( restoredInput?.cursor ).toBe( 'custom answer'.length );
+	} );
+
+	it( 'activates the Other input when Tab lands on it', () => {
+		const ui = Object.create( AiChatUI.prototype ) as {
+			handleOptionPickerTabNavigation: ( data: string ) => boolean;
+			[ key: string ]: unknown;
+		};
+
+		ui.optionPickerSelectList = new SelectList(
+			[
+				{ value: 'Business', label: '1. Business' },
+				{ value: '__other__', label: '2. Type something…' },
+			],
+			2,
+			{} as never
+		);
+		ui.optionPickerHasFreeForm = true;
+		ui.optionPickerOtherActive = false;
+		ui.activateOptionPickerOther = vi.fn();
+		ui.renderOptionPicker = vi.fn();
+
+		expect( ui.handleOptionPickerTabNavigation( '\t' ) ).toBe( true );
+		expect( ui.activateOptionPickerOther ).toHaveBeenCalledTimes( 1 );
+		expect( ( ui.optionPickerSelectList as SelectList ).getSelectedItem()?.value ).toBe(
+			'__other__'
+		);
+	} );
+
+	it( 'preserves free-form input when moving away with arrow keys', () => {
+		const ui = Object.create( AiChatUI.prototype ) as {
+			handleActiveOptionPickerOtherNavigation: ( data: string ) => boolean;
+			[ key: string ]: unknown;
+		};
+
+		ui.optionPickerSelectList = new SelectList(
+			[
+				{ value: 'Business', label: '1. Business' },
+				{ value: '__other__', label: '2. Type something…' },
+			],
+			2,
+			{} as never
+		);
+		( ui.optionPickerSelectList as SelectList ).setSelectedIndex( 1 );
+		ui.optionPickerHasFreeForm = true;
+		ui.optionPickerOtherActive = true;
+		ui.optionPickerOtherValue = '';
+		ui.optionPickerInput = {
+			getValue: vi.fn().mockReturnValue( 'custom answer' ),
+		};
+		ui.renderOptionPicker = vi.fn();
+
+		expect( ui.handleActiveOptionPickerOtherNavigation( '\u001b[B' ) ).toBe( true );
+		expect( ui.optionPickerOtherValue ).toBe( 'custom answer' );
+		expect( ui.optionPickerOtherActive ).toBe( false );
+		expect( ( ui.optionPickerSelectList as SelectList ).getSelectedItem()?.value ).toBe(
+			'Business'
+		);
+	} );
+} );
+
+describe( 'AiChatUI ask-user free-form cleanup', () => {
+	it( 'captures the first typed character when switching to Other', () => {
+		const ui = Object.create( AiChatUI.prototype ) as {
+			handleActiveOptionPickerOtherInput: ( data: string ) => boolean;
+			[ key: string ]: unknown;
+		};
+
+		ui.optionPickerOtherActive = true;
+		ui.optionPickerSelectList = new SelectList(
+			[
+				{ value: 'Business', label: '1. Business' },
+				{ value: '__other__', label: '2. Type something…' },
+			],
+			2,
+			{} as never
+		);
+		ui.optionPickerOtherValue = '';
+		ui.handleActiveOptionPickerOtherNavigation = vi.fn().mockReturnValue( false );
+		ui.renderOptionPicker = vi.fn();
+		ui.optionPickerInput = {
+			handleInput: vi.fn(),
+			getValue: vi.fn().mockReturnValue( 'c' ),
+		};
+
+		expect( ui.handleActiveOptionPickerOtherInput( 'c' ) ).toBe( true );
+		expect( ui.optionPickerOtherValue ).toBe( 'c' );
+		expect( ui.renderOptionPicker ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'does not dereference the inline input after it closes itself', () => {
+		const ui = Object.create( AiChatUI.prototype ) as {
+			handleActiveOptionPickerOtherInput: ( data: string ) => boolean;
+			[ key: string ]: unknown;
+		};
+
+		const getValue = vi.fn().mockReturnValue( 'custom answer' );
+		const renderOptionPicker = vi.fn();
+
+		ui.optionPickerOtherActive = true;
+		ui.optionPickerSelectList = new SelectList(
+			[
+				{ value: 'Business', label: '1. Business' },
+				{ value: '__other__', label: '2. Type something…' },
+			],
+			2,
+			{} as never
+		);
+		ui.handleActiveOptionPickerOtherNavigation = vi.fn().mockReturnValue( false );
+		ui.renderOptionPicker = renderOptionPicker;
+		ui.optionPickerInput = {
+			handleInput: vi.fn( () => {
+				ui.optionPickerInput = null;
+				ui.optionPickerSelectList = null;
+			} ),
+			getValue,
+		};
+
+		expect( ui.handleActiveOptionPickerOtherInput( '\u001b' ) ).toBe( true );
+		expect( getValue ).not.toHaveBeenCalled();
+		expect( renderOptionPicker ).not.toHaveBeenCalled();
+	} );
+
+	it( 'clears the cached free-form value when the picker closes', () => {
+		const ui = Object.create( AiChatUI.prototype ) as {
+			closeOptionPicker: () => void;
+			[ key: string ]: unknown;
+		};
+
+		ui.optionPickerContainer = {};
+		ui.optionPickerVisible = true;
+		ui.optionPickerSelectList = new SelectList(
+			[
+				{ value: 'Business', label: '1. Business' },
+				{ value: '__other__', label: '2. Type something…' },
+			],
+			2,
+			{} as never
+		);
+		ui.optionPickerHasFreeForm = true;
+		ui.optionPickerItemCount = 2;
+		ui.optionPickerOtherActive = true;
+		ui.optionPickerOtherValue = 'custom answer';
+		ui.optionPickerInput = {
+			getValue: vi.fn().mockReturnValue( 'custom answer' ),
+		};
+		ui.tui = {
+			removeChild: vi.fn(),
+			requestRender: vi.fn(),
+		};
+
+		ui.closeOptionPicker();
+
+		expect( ui.optionPickerOtherActive ).toBe( false );
+		expect( ui.optionPickerInput ).toBeNull();
+		expect( ui.optionPickerOtherValue ).toBe( '' );
+	} );
+} );
+
+describe( 'AiChatUI ask-user result rendering', () => {
+	function createAskUserResultUi() {
+		const renderToolResultText = vi.fn();
+		const ui = Object.create( AiChatUI.prototype ) as {
+			showToolResult: (
+				message: unknown,
+				toolName?: string,
+				toolInput?: Record< string, unknown > | null
+			) => void;
+			[ key: string ]: unknown;
+		};
+
+		ui.stopToolDotBlink = vi.fn();
+		ui.getToolResultContent = vi.fn().mockReturnValue( {
+			content:
+				"User has answered your questions: . You can now continue with the user's answers in mind.",
+			isError: false,
+		} );
+		ui.finalizeToolUseLine = vi.fn();
+		ui.renderToolResultText = renderToolResultText;
+		ui.tui = { requestRender: vi.fn() };
+		ui.toolDotLabel = 'AskUserQuestion';
+		return { ui, renderToolResultText };
+	}
+
+	it( 'renders a short summary for a single answer', () => {
+		const { ui, renderToolResultText } = createAskUserResultUi();
+		ui.lastAskUserOutcome = {
+			answers: {
+				'One-page or multi-page site?': 'only need two pages, about and homepage',
+			},
+			skipped: false,
+		};
+
+		ui.showToolResult( { type: 'user' }, 'AskUserQuestion' );
+
+		expect( renderToolResultText ).toHaveBeenCalledWith(
+			'Answer: only need two pages, about and homepage',
+			'AskUserQuestion'
+		);
+		expect( ui.lastAskUserOutcome ).toBeNull();
+	} );
+
+	it( 'renders a compact list for multiple answers', () => {
+		const { ui, renderToolResultText } = createAskUserResultUi();
+		ui.lastAskUserOutcome = {
+			answers: {
+				'One-page or multi-page site?': 'Multi-page',
+				'What style should it have?': 'Clean and minimal',
+			},
+			skipped: false,
+		};
+
+		ui.showToolResult( { type: 'user' }, 'AskUserQuestion' );
+
+		expect( renderToolResultText ).toHaveBeenCalledWith(
+			'Answers\n- One-page or multi-page site?: Multi-page\n- What style should it have?: Clean and minimal',
+			'AskUserQuestion'
+		);
+		expect( ui.lastAskUserOutcome ).toBeNull();
+	} );
+
+	it( 'renders a skipped message instead of the empty SDK answer sentence', () => {
+		const { ui, renderToolResultText } = createAskUserResultUi();
+		ui.lastAskUserOutcome = {
+			answers: {},
+			skipped: true,
+		};
+
+		ui.showToolResult( { type: 'user' }, 'AskUserQuestion' );
+
+		expect( renderToolResultText ).toHaveBeenCalledWith( 'Skipped', 'AskUserQuestion' );
+		expect( ui.lastAskUserOutcome ).toBeNull();
+	} );
+
+	it( 'renders the skip state for partial answers', () => {
+		const { ui, renderToolResultText } = createAskUserResultUi();
+		ui.lastAskUserOutcome = {
+			answers: {
+				'One-page or multi-page site?': 'only need two pages, about and homepage',
+			},
+			skipped: true,
+		};
+
+		ui.showToolResult( { type: 'user' }, 'AskUserQuestion' );
+
+		expect( renderToolResultText ).toHaveBeenCalledWith(
+			'Answer: only need two pages, about and homepage\nSkipped remaining questions',
+			'AskUserQuestion'
+		);
+		expect( ui.lastAskUserOutcome ).toBeNull();
 	} );
 } );

--- a/apps/cli/ai/ui.ts
+++ b/apps/cli/ai/ui.ts
@@ -68,10 +68,46 @@ interface ExpandablePreview {
 	isExpanded: boolean;
 }
 
+interface AskUserOutcome {
+	answers: Record< string, string >;
+	skipped: boolean;
+}
+
+interface OptionPickerSelectState {
+	filteredItems: SelectItem[];
+	selectedIndex: number;
+	setSelectedIndex: ( index: number ) => void;
+	getSelectedItem: () => SelectItem | null;
+	onSelectionChange?: ( item: SelectItem ) => void;
+	handleInput: ( data: string ) => void;
+}
+
+const EMPTY_ASK_USER_RESULT_MESSAGE =
+	"User has answered your questions: . You can now continue with the user's answers in mind.";
+
 function formatToolOutputLines( lines: string[] ): string {
 	return lines
 		.map( ( line, index ) => `${ index === 0 ? '   ' + chalk.dim( '⎿ ' ) : '     ' }${ line }` )
 		.join( '\n' );
+}
+
+function formatAskUserResult( outcome: AskUserOutcome ): string {
+	const entries = Object.entries( outcome.answers );
+	if ( entries.length === 0 ) {
+		return __( 'Skipped' );
+	}
+
+	const answerSummary =
+		entries.length === 1
+			? sprintf( __( 'Answer: %s' ), entries[ 0 ][ 1 ] )
+			: [
+					__( 'Answers' ),
+					...entries.map( ( [ question, answer ] ) => `- ${ question }: ${ answer }` ),
+			  ].join( '\n' );
+
+	return outcome.skipped
+		? [ answerSummary, __( 'Skipped remaining questions' ) ].join( '\n' )
+		: answerSummary;
 }
 
 class PromptEditor implements Component, Focusable {
@@ -468,6 +504,7 @@ export class AiChatUI {
 		string,
 		{ name: string; input: Record< string, unknown > }
 	>();
+	private askUserActive = false;
 	currentModel: AiModelId = DEFAULT_MODEL;
 	currentProvider: AiProviderId = DEFAULT_AI_PROVIDER;
 
@@ -534,7 +571,10 @@ export class AiChatUI {
 	private optionPickerHasFreeForm = false;
 	private optionPickerItemCount = 0;
 	private optionPickerInput: Input | null = null;
+	private optionPickerOtherValue = '';
 	private static readonly OTHER_VALUE = '__other__';
+	private static readonly ASK_USER_CANCEL_VALUE = '__studio_ask_user_cancelled__';
+	private lastAskUserOutcome: AskUserOutcome | null = null;
 	private static readonly OPTION_PICKER_THEME: SelectListTheme = {
 		selectedPrefix: ( text: string ) => chalk.blue( text ),
 		selectedText: ( text: string ) => chalk.blue( text ),
@@ -663,7 +703,7 @@ export class AiChatUI {
 				resolve( trimmed );
 			}
 		};
-		// Ctrl+C to exit, Escape to interrupt/close picker, arrow keys for picker
+		// Ctrl+C to exit, Escape to interrupt/close picker, arrow/Tab keys for pickers
 		this.tui.addInputListener( ( data ) => {
 			// Ignore key release events (Kitty protocol sends press + release)
 			if ( isKeyRelease( data ) ) {
@@ -675,17 +715,11 @@ export class AiChatUI {
 			}
 			// Option picker navigation (must be checked before site picker)
 			if ( this.optionPickerSelectList ) {
+				if ( this.handleOptionPickerTabNavigation( data ) ) {
+					return { consume: true };
+				}
 				// When "Other" is active, let the inline input handle most keys
-				if ( this.optionPickerOtherActive && this.optionPickerInput ) {
-					if ( matchesKey( data, 'up' ) ) {
-						this.deactivateOptionPickerOther();
-						this.optionPickerSelectList.handleInput( data );
-						this.renderOptionPicker();
-						return { consume: true };
-					}
-					// Forward everything else to the inline input
-					this.optionPickerInput.handleInput( data );
-					this.renderOptionPicker();
+				if ( this.handleActiveOptionPickerOtherInput( data ) ) {
 					return { consume: true };
 				}
 
@@ -701,8 +735,7 @@ export class AiChatUI {
 				) {
 					this.optionPickerSelectList.setSelectedIndex( this.optionPickerItemCount - 1 );
 					this.activateOptionPickerOther();
-					this.optionPickerInput?.handleInput( data );
-					this.renderOptionPicker();
+					this.handleActiveOptionPickerOtherInput( data );
 					return { consume: true };
 				}
 
@@ -768,6 +801,9 @@ export class AiChatUI {
 				// Forward remaining input (up/down/enter) to SelectList
 				this.sitePickerSelectList.handleInput( data );
 				this.renderSitePicker();
+				return { consume: true };
+			}
+			if ( matchesKey( data, 'escape' ) && this.cancelAskUserQuestions() ) {
 				return { consume: true };
 			}
 			if ( matchesKey( data, 'escape' ) && this.interruptCallback ) {
@@ -1189,20 +1225,212 @@ export class AiChatUI {
 		this.optionPickerContainer.clear();
 
 		const width = ( process.stdout.columns ?? 80 ) - 1;
-		const lines = this.optionPickerSelectList.render( width );
-
-		// When "Other" is active, replace the last line with the inline input
-		if ( this.optionPickerOtherActive && this.optionPickerInput && lines.length > 0 ) {
-			const inputText = this.optionPickerInput.getValue();
-			const cursor = chalk.inverse( ' ' );
-			const display = inputText
-				? chalk.blue( inputText ) + cursor
-				: chalk.dim( __( 'Type your answer…' ) ) + cursor;
-			lines[ lines.length - 1 ] = `${ chalk.blue( '→' ) } ${ display }`;
-		}
-
+		const lines = this.renderOptionPickerLines( width );
+		lines.push( '', chalk.dim( this.getAskUserHintText() ) );
 		this.optionPickerContainer.addChild( new Text( lines.join( '\n' ), 1, 0 ) );
 		this.tui.requestRender();
+	}
+
+	private renderOptionPickerLines( width: number ): string[] {
+		const selectList = this.getOptionPickerSelectState();
+		if ( selectList.filteredItems.length === 0 ) {
+			return [ AiChatUI.OPTION_PICKER_THEME.noMatch( __( '  No matching commands' ) ) ];
+		}
+
+		return selectList.filteredItems.map( ( item, index ) =>
+			this.renderOptionPickerItemLine( item, index === selectList.selectedIndex, width )
+		);
+	}
+
+	private renderOptionPickerItemLine(
+		item: SelectItem,
+		isSelected: boolean,
+		width: number
+	): string {
+		if ( item.value === AiChatUI.OTHER_VALUE ) {
+			return this.renderOptionPickerFreeFormLine( isSelected, width );
+		}
+
+		const prefix = isSelected ? `${ AiChatUI.OPTION_PICKER_THEME.selectedPrefix( '→' ) } ` : '  ';
+		const prefixWidth = 2;
+		const label = item.label || item.value;
+		const description = item.description?.replace( /[\r\n]+/g, ' ' ).trim();
+
+		if ( description && width > 40 ) {
+			const maxValueWidth = Math.min( 30, width - prefixWidth - 4 );
+			const truncatedLabel = truncateToWidth( label, maxValueWidth, '' );
+			const spacing = ' '.repeat( Math.max( 1, 32 - visibleWidth( truncatedLabel ) ) );
+			const descriptionStart = prefixWidth + visibleWidth( truncatedLabel ) + spacing.length;
+			const remainingWidth = width - descriptionStart - 2;
+
+			if ( remainingWidth > 10 ) {
+				const truncatedDescription = truncateToWidth( description, remainingWidth, '' );
+				const styledDescription = isSelected
+					? chalk.blue( spacing + truncatedDescription )
+					: AiChatUI.OPTION_PICKER_THEME.description( spacing + truncatedDescription );
+
+				return truncateToWidth(
+					`${ prefix }${ this.renderOptionPickerLabel(
+						truncatedLabel,
+						isSelected
+					) }${ styledDescription }`,
+					width
+				);
+			}
+		}
+
+		const maxWidth = width - prefixWidth - 2;
+		return truncateToWidth(
+			`${ prefix }${ this.renderOptionPickerLabel(
+				truncateToWidth( label, maxWidth, '' ),
+				isSelected
+			) }`,
+			width
+		);
+	}
+
+	private renderOptionPickerFreeFormLine( isSelected: boolean, width: number ): string {
+		const prefix = isSelected ? `${ AiChatUI.OPTION_PICKER_THEME.selectedPrefix( '→' ) } ` : '  ';
+		const indexLabel = this.getOptionPickerIndexLabel( this.optionPickerItemCount );
+
+		if ( this.optionPickerOtherActive && this.optionPickerInput ) {
+			const cursor = chalk.inverse( ' ' );
+			const display = this.optionPickerOtherValue
+				? `${ chalk.blue( this.optionPickerOtherValue ) }${ cursor }`
+				: cursor;
+
+			return truncateToWidth( `${ prefix }${ indexLabel }${ display }`, width );
+		}
+
+		return truncateToWidth(
+			`${ prefix }${ indexLabel }${ chalk.dim( this.getOptionPickerFreeFormLabel() ) }`,
+			width
+		);
+	}
+
+	private renderOptionPickerLabel( label: string, isSelected: boolean ): string {
+		const match = label.match( /^(\d+\.\s)(.*)$/u );
+		if ( ! match ) {
+			return isSelected ? chalk.blue( label ) : label;
+		}
+
+		const [ , indexLabel, text ] = match;
+		return `${ this.renderOptionPickerIndexLabel( indexLabel ) }${
+			isSelected ? chalk.blue( text ) : text
+		}`;
+	}
+
+	private renderOptionPickerIndexLabel( indexLabel: string ): string {
+		return chalk.gray( indexLabel );
+	}
+
+	private getOptionPickerIndexLabel( index: number ): string {
+		return this.renderOptionPickerIndexLabel( `${ index }. ` );
+	}
+
+	private getOptionPickerSelectState(): OptionPickerSelectState {
+		return this.optionPickerSelectList as unknown as OptionPickerSelectState;
+	}
+
+	private handleActiveOptionPickerOtherNavigation( data: string ): boolean {
+		if (
+			! this.optionPickerOtherActive ||
+			! this.optionPickerInput ||
+			! this.optionPickerSelectList ||
+			( ! matchesKey( data, 'up' ) && ! matchesKey( data, 'down' ) )
+		) {
+			return false;
+		}
+
+		this.deactivateOptionPickerOther();
+		this.optionPickerSelectList.handleInput( data );
+		this.renderOptionPicker();
+		return true;
+	}
+
+	private handleActiveOptionPickerOtherInput( data: string ): boolean {
+		if ( ! this.optionPickerOtherActive || ! this.optionPickerInput ) {
+			return false;
+		}
+
+		if ( this.handleActiveOptionPickerOtherNavigation( data ) ) {
+			return true;
+		}
+
+		const input = this.optionPickerInput;
+		input.handleInput( data );
+
+		// Escape or submit may close the picker during handleInput().
+		if (
+			this.optionPickerInput !== input ||
+			! this.optionPickerInput ||
+			! this.optionPickerSelectList
+		) {
+			return true;
+		}
+
+		this.optionPickerOtherValue = this.optionPickerInput.getValue();
+		this.renderOptionPicker();
+		return true;
+	}
+
+	private getAskUserHintText(): string {
+		if ( ! this.optionPickerVisible ) {
+			return __( 'enter to submit · esc to skip' );
+		}
+
+		return this.optionPickerOtherActive
+			? __( 'tab/arrow keys to navigate · enter to submit · esc to skip' )
+			: __( 'tab/arrow keys to navigate · enter to select · esc to skip' );
+	}
+
+	private getOptionPickerFreeFormLabel(): string {
+		return __( 'Type something…' );
+	}
+
+	private handleOptionPickerTabNavigation( data: string ): boolean {
+		if ( ! this.optionPickerSelectList ) {
+			return false;
+		}
+
+		const direction = matchesKey( data, 'shift+tab' ) ? -1 : matchesKey( data, 'tab' ) ? 1 : 0;
+		if ( direction === 0 ) {
+			return false;
+		}
+
+		if ( this.optionPickerOtherActive ) {
+			this.deactivateOptionPickerOther();
+		}
+
+		this.moveOptionPickerSelection( direction );
+		if ( this.optionPickerHasFreeForm ) {
+			const selected = this.optionPickerSelectList.getSelectedItem();
+			if ( selected?.value === AiChatUI.OTHER_VALUE ) {
+				this.activateOptionPickerOther();
+			}
+		}
+
+		this.renderOptionPicker();
+		return true;
+	}
+
+	private moveOptionPickerSelection( direction: -1 | 1 ): void {
+		if ( ! this.optionPickerSelectList ) {
+			return;
+		}
+
+		const selectList = this.getOptionPickerSelectState();
+		const itemCount = selectList.filteredItems.length;
+		if ( itemCount === 0 ) {
+			return;
+		}
+
+		const nextIndex = ( selectList.selectedIndex + direction + itemCount ) % itemCount;
+		selectList.setSelectedIndex( nextIndex );
+		const selectedItem = selectList.getSelectedItem();
+		if ( selectedItem && selectList.onSelectionChange ) {
+			selectList.onSelectionChange( selectedItem );
+		}
 	}
 
 	private activateOptionPickerOther(): void {
@@ -1211,6 +1439,14 @@ export class AiChatUI {
 		}
 		this.optionPickerOtherActive = true;
 		this.optionPickerInput = new Input();
+		if ( this.optionPickerOtherValue ) {
+			this.optionPickerInput.setValue( this.optionPickerOtherValue );
+			( this.optionPickerInput as unknown as { cursor: number } ).cursor =
+				this.optionPickerOtherValue.length;
+		}
+		this.optionPickerInput.onEscape = () => {
+			this.cancelAskUserQuestions();
+		};
 		this.optionPickerInput.onSubmit = ( value: string ) => {
 			const trimmed = value.trim();
 			if ( trimmed && this.optionPickerResolve ) {
@@ -1223,6 +1459,9 @@ export class AiChatUI {
 	}
 
 	private deactivateOptionPickerOther(): void {
+		if ( this.optionPickerInput ) {
+			this.optionPickerOtherValue = this.optionPickerInput.getValue();
+		}
 		this.optionPickerOtherActive = false;
 		this.optionPickerInput = null;
 	}
@@ -1237,7 +1476,32 @@ export class AiChatUI {
 		this.optionPickerHasFreeForm = false;
 		this.optionPickerItemCount = 0;
 		this.deactivateOptionPickerOther();
+		this.optionPickerOtherValue = '';
 		this.tui.requestRender();
+	}
+
+	private cancelAskUserQuestions(): boolean {
+		if ( ! this.askUserActive ) {
+			return false;
+		}
+
+		if ( this.optionPickerResolve ) {
+			const resolve = this.optionPickerResolve;
+			this.optionPickerResolve = null;
+			this.closeOptionPicker();
+			resolve( AiChatUI.ASK_USER_CANCEL_VALUE );
+			return true;
+		}
+
+		if ( this.submitResolve ) {
+			const resolve = this.submitResolve;
+			this.submitResolve = null;
+			this.hideEditor();
+			resolve( AiChatUI.ASK_USER_CANCEL_VALUE );
+			return true;
+		}
+
+		return false;
 	}
 
 	start(): void {
@@ -1368,7 +1632,11 @@ export class AiChatUI {
 				this.activeExpandablePreview.isExpanded ? __( 'ctrl+o collapse' ) : __( 'ctrl+o expand' )
 			);
 		}
-		hints.push( __( 'esc to interrupt' ) );
+		if ( this.askUserActive ) {
+			hints.push( this.getAskUserHintText() );
+		} else if ( this._inAgentTurn || this.interruptCallback ) {
+			hints.push( __( 'esc to interrupt' ) );
+		}
 		this.editor.hints = hints;
 	}
 
@@ -1899,7 +2167,18 @@ export class AiChatUI {
 
 		this.finalizeToolUseLine( isError, label );
 
-		const content = typedResult.content;
+		let content = typedResult.content;
+		if ( toolName === 'AskUserQuestion' ) {
+			if ( this.lastAskUserOutcome ) {
+				content = formatAskUserResult( this.lastAskUserOutcome );
+			} else if (
+				typeof content === 'string' &&
+				content.trim() === EMPTY_ASK_USER_RESULT_MESSAGE
+			) {
+				content = __( 'Skipped' );
+			}
+			this.lastAskUserOutcome = null;
+		}
 		if ( content === undefined ) {
 			this.tui.requestRender();
 			return;
@@ -1958,68 +2237,88 @@ export class AiChatUI {
 		this.currentResponseText = '';
 
 		const answers: Record< string, string > = {};
+		let wasSkipped = false;
 
-		for ( const q of questions ) {
-			// Display the question
-			this.messages.addChild( new Text( '\n' + chalk.bold( q.question ), 1, 0 ) );
-			this.tui.requestRender();
-
-			if ( q.options.length > 0 ) {
-				// Use SelectList for option-based questions.
-				// When allowFreeForm is true, append an "Other" option with inline input.
-				this.hideEditor();
-				const selectItems: SelectItem[] = q.options.map( ( opt, i ) => ( {
-					value: opt.label,
-					label: `${ i + 1 }. ${ opt.label }`,
-					description: opt.description,
-				} ) );
-				this.optionPickerHasFreeForm = q.allowFreeForm === true;
-				if ( this.optionPickerHasFreeForm ) {
-					selectItems.push( {
-						value: AiChatUI.OTHER_VALUE,
-						label: __( 'Other (type my own)' ),
-					} );
-				}
-
-				this.optionPickerItemCount = selectItems.length;
-				const selectList = new SelectList(
-					selectItems,
-					selectItems.length,
-					AiChatUI.OPTION_PICKER_THEME
-				);
-
-				this.optionPickerSelectList = selectList;
-				this.optionPickerVisible = true;
-				this.optionPickerContainer = new Container();
-				this.tui.addChild( this.optionPickerContainer );
-				this.optionPickerContainer.addChild( this.optionPickerSelectList );
+		this.askUserActive = true;
+		try {
+			for ( const q of questions ) {
+				// Display the question
+				this.messages.addChild( new Text( '\n' + chalk.bold( q.question ), 1, 0 ) );
 				this.tui.requestRender();
 
-				const selected = await new Promise< string >( ( resolve ) => {
-					this.optionPickerResolve = resolve;
-					selectList.onSelect = ( item: SelectItem ) => {
-						if ( item.value === AiChatUI.OTHER_VALUE ) {
-							// "Other" selected via enter without typing — activate input
-							this.activateOptionPickerOther();
-							this.renderOptionPicker();
-							return;
-						}
-						this.optionPickerResolve = null;
-						this.closeOptionPicker();
-						resolve( item.value );
-					};
-				} );
+				if ( q.options.length > 0 ) {
+					// Use SelectList for option-based questions.
+					// When allowFreeForm is true, append an "Other" option with inline input.
+					this.hideEditor();
+					const selectItems: SelectItem[] = q.options.map( ( opt, i ) => ( {
+						value: opt.label,
+						label: `${ i + 1 }. ${ opt.label }`,
+						description: opt.description,
+					} ) );
+					this.optionPickerHasFreeForm = q.allowFreeForm === true;
+					if ( this.optionPickerHasFreeForm ) {
+						selectItems.push( {
+							value: AiChatUI.OTHER_VALUE,
+							label: `${ selectItems.length + 1 }. ${ this.getOptionPickerFreeFormLabel() }`,
+						} );
+					}
 
-				answers[ q.question ] = selected;
-			} else {
-				// Free-form text input
-				const answer = await this.waitForInput();
-				answers[ q.question ] = answer;
+					this.optionPickerItemCount = selectItems.length;
+					const selectList = new SelectList(
+						selectItems,
+						selectItems.length,
+						AiChatUI.OPTION_PICKER_THEME
+					);
+
+					this.optionPickerSelectList = selectList;
+					this.optionPickerVisible = true;
+					this.optionPickerContainer = new Container();
+					this.tui.addChild( this.optionPickerContainer );
+					this.renderOptionPicker();
+
+					const selected = await new Promise< string >( ( resolve ) => {
+						this.optionPickerResolve = resolve;
+						selectList.onCancel = () => {
+							this.cancelAskUserQuestions();
+						};
+						selectList.onSelect = ( item: SelectItem ) => {
+							if ( item.value === AiChatUI.OTHER_VALUE ) {
+								// "Other" selected via enter without typing — activate input
+								this.activateOptionPickerOther();
+								this.renderOptionPicker();
+								return;
+							}
+							this.optionPickerResolve = null;
+							this.closeOptionPicker();
+							resolve( item.value );
+						};
+					} );
+
+					if ( selected === AiChatUI.ASK_USER_CANCEL_VALUE ) {
+						wasSkipped = true;
+						break;
+					}
+
+					answers[ q.question ] = selected;
+				} else {
+					// Free-form text input
+					const answer = await this.waitForInput();
+					if ( answer === AiChatUI.ASK_USER_CANCEL_VALUE ) {
+						wasSkipped = true;
+						break;
+					}
+					answers[ q.question ] = answer;
+				}
 			}
+		} finally {
+			this.lastAskUserOutcome = {
+				answers: { ...answers },
+				skipped: wasSkipped,
+			};
+			this.askUserActive = false;
+			// Resume the agent turn with a fresh markdown block for subsequent text
+			this.showLoader( this.randomThinkingMessage() );
 		}
-
-		// Resume the agent turn with a fresh markdown block for subsequent text
-		this.showLoader( this.randomThinkingMessage() );
 		return answers;
 	}
 


### PR DESCRIPTION
## Proposed Changes

- Improve the AskUserQuestion TUI flow for option prompts by adding clearer navigation hints, Tab and arrow-key movement, inline custom-answer entry, and reliable escape-to-skip behavior
- Fix free-form option handling so custom answers preserve typed text across navigation, show the first typed character immediately, and avoid crashes when skipping from the inline input
- Shorten AskUserQuestion result rendering from the SDK boilerplate sentence to compact human-readable summaries, including explicit messaging when a user skips remaining questions
- Add focused UI tests covering cancellation, partial skips, free-form entry, inline input cleanup, and compact result rendering


https://github.com/user-attachments/assets/c09f4e14-e28a-4976-b460-de3efffb966b


## How AI was used in this PR

Used Codex to iterate on the AskUserQuestion CLI UX changes and tests, then reviewed the final diff and verification output before opening this PR.

## Testing Instructions

- Run `npx eslint --fix apps/cli/ai/ui.ts apps/cli/ai/tests/ui.test.ts`
- Run `npm run typecheck`
- Run `npm test -- apps/cli/ai/tests/ui.test.ts`

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
