### PR TITLE
CLI: ensure Studio root exists before starting code agent

### DIFF
--- a/apps/cli/ai/agent.ts
+++ b/apps/cli/ai/agent.ts
@@ -1,3 +1,4 @@
+import fs from 'fs';
 import path from 'path';
 import { query, type Query } from '@anthropic-ai/claude-agent-sdk';
 import {
@@ -86,6 +87,10 @@ export function startAiAgent( config: AiAgentConfig ): Query {
 				},
 		  }
 		: undefined;
+
+	if ( ! fs.existsSync( STUDIO_ROOT ) ) {
+		fs.mkdirSync( STUDIO_ROOT, { recursive: true } );
+	}
 
 	return query( {
 		prompt,

--- a/apps/cli/ai/tests/agent.test.ts
+++ b/apps/cli/ai/tests/agent.test.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
-import { beforeEach, describe, expect, it, vi, type MockInstance } from 'vitest';
 import { query } from '@anthropic-ai/claude-agent-sdk';
+import { beforeEach, describe, expect, it, vi, type MockInstance } from 'vitest';
 import { startAiAgent } from 'cli/ai/agent';
 import { STUDIO_ROOT } from 'cli/ai/security';
 

--- a/apps/cli/ai/tests/agent.test.ts
+++ b/apps/cli/ai/tests/agent.test.ts
@@ -1,0 +1,79 @@
+import fs from 'fs';
+import { beforeEach, describe, expect, it, vi, type MockInstance } from 'vitest';
+import { query } from '@anthropic-ai/claude-agent-sdk';
+import { startAiAgent } from 'cli/ai/agent';
+import { STUDIO_ROOT } from 'cli/ai/security';
+
+vi.mock( '@anthropic-ai/claude-agent-sdk', () => ( {
+	query: vi.fn(),
+} ) );
+
+vi.mock( 'cli/ai/system-prompt', () => ( {
+	buildSystemPrompt: vi.fn().mockReturnValue( 'test system prompt' ),
+} ) );
+
+vi.mock( 'cli/ai/tools', () => ( {
+	createRemoteSiteTools: vi.fn().mockReturnValue( { type: 'remote-tools' } ),
+	createStudioTools: vi.fn().mockReturnValue( { type: 'local-tools' } ),
+} ) );
+
+describe( 'AI agent startup', () => {
+	const mockQuery = {
+		interrupt: vi.fn(),
+		[ Symbol.asyncIterator ]() {
+			return {
+				next: async () => ( {
+					done: true as const,
+					value: undefined,
+				} ),
+			};
+		},
+	};
+	let existsSyncSpy: MockInstance;
+	let mkdirSyncSpy: MockInstance;
+
+	beforeEach( () => {
+		vi.resetAllMocks();
+		existsSyncSpy = vi.spyOn( fs, 'existsSync' ).mockReturnValue( true );
+		mkdirSyncSpy = vi.spyOn( fs, 'mkdirSync' ).mockReturnValue( undefined );
+		vi.mocked( query ).mockReturnValue( mockQuery as never );
+	} );
+
+	it( 'creates the Studio root before starting the agent when it is missing', () => {
+		existsSyncSpy.mockReturnValue( false );
+
+		const result = startAiAgent( {
+			prompt: 'Generate a website',
+		} );
+
+		expect( existsSyncSpy ).toHaveBeenCalledWith( STUDIO_ROOT );
+		expect( mkdirSyncSpy ).toHaveBeenCalledWith( STUDIO_ROOT, { recursive: true } );
+		expect( query ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				prompt: 'Generate a website',
+				options: expect.objectContaining( {
+					cwd: STUDIO_ROOT,
+				} ),
+			} )
+		);
+		expect( result ).toBe( mockQuery );
+	} );
+
+	it( 'does not recreate the Studio root when it already exists', () => {
+		const result = startAiAgent( {
+			prompt: 'Generate a website',
+		} );
+
+		expect( existsSyncSpy ).toHaveBeenCalledWith( STUDIO_ROOT );
+		expect( mkdirSyncSpy ).not.toHaveBeenCalled();
+		expect( query ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				prompt: 'Generate a website',
+				options: expect.objectContaining( {
+					cwd: STUDIO_ROOT,
+				} ),
+			} )
+		);
+		expect( result ).toBe( mockQuery );
+	} );
+} );


### PR DESCRIPTION
## Related issues

- No linked issue.

## How AI was used in this PR

- Used Codex to draft the small fix and focused test coverage, then reviewed the final diff before opening the PR.

## Proposed Changes

- Ensure `startAiAgent()` checks whether `~/Studio` exists before launching the Claude SDK.
- Create the Studio root directory when it is missing so `studio code` can use it as `cwd` on first run.
- Add a focused agent unit test covering both the missing-directory and already-exists cases.

## Testing Instructions

- Remove or rename `~/Studio`.
- Run `studio code`.
- Confirm the command starts normally instead of failing with the misleading Claude executable error.

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?