### PR TITLE
Fix locale data type annotation to resolve TS7056 serialization error

### DIFF
--- a/tools/common/translations/index.ts
+++ b/tools/common/translations/index.ts
@@ -19,7 +19,33 @@ import { locale_data as vi } from '@studio/common/translations/studio-vi.jed.jso
 import { locale_data as zhCN } from '@studio/common/translations/studio-zh-cn.jed.json';
 import { locale_data as zhTW } from '@studio/common/translations/studio-zh-tw.jed.json';
 
-export const localeDataDictionary = {
+type LocaleData = {
+	messages: Record< string, string[] | { domain: string; 'plural-forms': string; lang: string } >;
+};
+type SupportedLocale =
+	| 'ar'
+	| 'de'
+	| 'en'
+	| 'es'
+	| 'fr'
+	| 'he'
+	| 'hu'
+	| 'id'
+	| 'it'
+	| 'ja'
+	| 'ko'
+	| 'nl'
+	| 'pl'
+	| 'pt-br'
+	| 'ru'
+	| 'sv'
+	| 'tr'
+	| 'uk'
+	| 'vi'
+	| 'zh-cn'
+	| 'zh-tw';
+
+export const localeDataDictionary: Record< SupportedLocale, LocaleData | null > = {
 	ar,
 	de,
 	en: null,
@@ -41,4 +67,4 @@ export const localeDataDictionary = {
 	vi,
 	'zh-cn': zhCN,
 	'zh-tw': zhTW,
-} as const;
+};


### PR DESCRIPTION
## Related issues

- Fixes the TypeScript error: "The inferred type of this node exceeds the maximum length the compiler will serialize. An explicit type annotation is needed. (ts 7056)" in `tools/common/translations/index.ts`

## How AI was used in this PR

Claude suggested the fix approach (explicit type annotation with `SupportedLocale` union type). The implementation was reviewed and verified with `npm run typecheck`.

## Proposed Changes

- Add explicit `LocaleData` type matching the JED JSON structure (`{ messages: Record<...> }`)
- Add `SupportedLocale` union type for all supported locale keys
- Annotate `localeDataDictionary` with `Record<SupportedLocale, LocaleData | null>` instead of relying on `as const` inference
- Remove `as const` assertion that caused TypeScript to serialize the entire translation literal types

## Testing Instructions

- Run `npm run typecheck` — should pass with no errors
- Verify translations still work: `npm start`, change language in settings, confirm UI strings update

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?