### PR TITLE
Enforce minimum node version in the CLI

### DIFF
--- a/apps/cli/globals.d.ts
+++ b/apps/cli/globals.d.ts
@@ -1,6 +1,7 @@
 declare const __ENABLE_CLI_TELEMETRY__: boolean;
 declare const __IS_PACKAGED_FOR_NPM__: boolean;
 declare const __STUDIO_CLI_VERSION__: string;
+declare const __MINIMUM_NODE_VERSION__: string;
 
 declare module 'wpcom-xhr-request';
 declare module '@wp-playground/blueprints/blueprint-schema-validator';

--- a/apps/cli/index.ts
+++ b/apps/cli/index.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 import { suppressPunycodeWarning } from '@studio/common/lib/suppress-punycode-warning';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import semver from 'semver';
 import yargs from 'yargs';
 import { registerCommand as registerExportCommand } from 'cli/commands/export';
@@ -19,7 +19,13 @@ const version = __STUDIO_CLI_VERSION__;
 
 if ( semver.lt( process.version, __MINIMUM_NODE_VERSION__ ) ) {
 	console.error(
-		`Studio CLI requires Node.js ${ __MINIMUM_NODE_VERSION__ } or newer. Current version: ${ process.version }.`
+		sprintf(
+			__(
+				'Studio CLI requires Node.js %s or newer. You are running %s.\nUpgrade Node.js and run this command again.\nDownload: https://nodejs.org/en/download'
+			),
+			__MINIMUM_NODE_VERSION__,
+			process.version
+		)
 	);
 	process.exit( 1 );
 }

--- a/apps/cli/index.ts
+++ b/apps/cli/index.ts
@@ -1,6 +1,7 @@
 import path from 'node:path';
 import { suppressPunycodeWarning } from '@studio/common/lib/suppress-punycode-warning';
 import { __ } from '@wordpress/i18n';
+import semver from 'semver';
 import yargs from 'yargs';
 import { registerCommand as registerExportCommand } from 'cli/commands/export';
 import { registerCommand as registerImportCommand } from 'cli/commands/import';
@@ -15,6 +16,13 @@ import { untildify } from 'cli/lib/utils';
 import { StudioArgv } from 'cli/types';
 
 const version = __STUDIO_CLI_VERSION__;
+
+if ( semver.lt( process.version, __MINIMUM_NODE_VERSION__ ) ) {
+	console.error(
+		`Studio CLI requires Node.js ${ __MINIMUM_NODE_VERSION__ } or newer. Current version: ${ process.version }.`
+	);
+	process.exit( 1 );
+}
 
 suppressPunycodeWarning();
 

--- a/apps/cli/index.ts
+++ b/apps/cli/index.ts
@@ -17,23 +17,23 @@ import { StudioArgv } from 'cli/types';
 
 const version = __STUDIO_CLI_VERSION__;
 
-if ( semver.lt( process.version, __MINIMUM_NODE_VERSION__ ) ) {
-	console.error(
-		sprintf(
-			__(
-				'Studio CLI requires Node.js %s or newer. You are running %s.\nUpgrade Node.js and run this command again.\nDownload: https://nodejs.org/en/download'
-			),
-			__MINIMUM_NODE_VERSION__,
-			process.version
-		)
-	);
-	process.exit( 1 );
-}
-
 suppressPunycodeWarning();
 
 async function main() {
 	const yargsLocale = await loadTranslations();
+
+	if ( semver.lt( process.version, __MINIMUM_NODE_VERSION__ ) ) {
+		console.error(
+			sprintf(
+				__(
+					'Studio CLI requires Node.js %s or newer. You are running %s.\nUpgrade Node.js and run this command again.\nDownload: https://nodejs.org/en/download'
+				),
+				__MINIMUM_NODE_VERSION__,
+				process.version
+			)
+		);
+		process.exit( 1 );
+	}
 
 	const studioArgv: StudioArgv = yargs( process.argv.slice( 2 ) )
 		.scriptName( 'studio' )

--- a/apps/cli/vite.config.base.ts
+++ b/apps/cli/vite.config.base.ts
@@ -1,7 +1,8 @@
-import { readFileSync } from 'fs';
 import { resolve } from 'path';
+import semver from 'semver';
 import { defineConfig } from 'vite';
 import { viteStaticCopy } from 'vite-plugin-static-copy';
+import packageJson from './package.json';
 
 const nodeBuiltinExternals: RegExp[] = [
 	/^node:/,
@@ -10,8 +11,20 @@ const nodeBuiltinExternals: RegExp[] = [
 	/^dns\/promises$/,
 ];
 
-const packageJson = JSON.parse( readFileSync( resolve( __dirname, 'package.json' ), 'utf-8' ) );
 const packageJsonDependencies = Object.keys( packageJson.dependencies || {} );
+const minimumNodeVersionRange = packageJson.engines?.node;
+
+if ( typeof minimumNodeVersionRange !== 'string' || minimumNodeVersionRange.length === 0 ) {
+	throw new Error( 'apps/cli/package.json must define engines.node as a non-empty string.' );
+}
+
+const minimumNodeVersion = semver.minVersion( minimumNodeVersionRange )?.version;
+
+if ( ! minimumNodeVersion ) {
+	throw new Error(
+		`Invalid engines.node range in apps/cli/package.json: ${ minimumNodeVersionRange }`
+	);
+}
 
 export const baseConfig = defineConfig( {
 	plugins: [
@@ -78,5 +91,6 @@ export const baseConfig = defineConfig( {
 	},
 	define: {
 		__STUDIO_CLI_VERSION__: JSON.stringify( packageJson.version ),
+		__MINIMUM_NODE_VERSION__: JSON.stringify( minimumNodeVersion ),
 	},
 } );


### PR DESCRIPTION
## Related issues

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

N/A

## How AI was used in this PR

<!--
Help reviewers understand what to look for and verify that you've reviewed the code yourself.
-->

To iteratively implement this thing until it was simple enough to my liking. 

## Proposed Changes

- Extract `engines.node` from `apps/cli/package.json` in `apps/cli/index.ts` and use semver to ensure that the current Node runtime satisfies that version constraint. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. `npm run cli:build`
2. `nvm install lts/iron` (v20)
3. `nvm use lts/iron`
4. `node apps/cli/dist/cli/main.mjs site list`
5. Ensure that an error message is printed
6. `nvm use`
7. `node apps/cli/dist/cli/main.mjs site list`
8. Ensure that NO error message is printed

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
