### PR TITLE
Fix white border around scrollbar in light mode

### DIFF
--- a/apps/studio/src/index.css
+++ b/apps/studio/src/index.css
@@ -12,7 +12,6 @@
 	--color-frame-surface-alt: #dcdcde;
 	--color-frame-scrollbar-thumb: #7f7f7f;
 	--color-frame-scrollbar-thumb-hover: #484848;
-	--color-frame-scrollbar-border: #fff;
 	--color-frame-theme: #3858e9;
 	--color-frame-theme-hover: #2145e6;
 	--color-frame-code-text: #1d2327;
@@ -34,7 +33,6 @@
 		--color-frame-surface-alt: #474747;
 		--color-frame-scrollbar-thumb: #666666;
 		--color-frame-scrollbar-thumb-hover: #888888;
-		--color-frame-scrollbar-border: #2f2f2f;
 		--color-frame-theme: #6b8aff;
 		--color-frame-theme-hover: #8da6ff;
 		--color-frame-code-text: #e0e0e0;
@@ -169,14 +167,16 @@ div:has( > progress ) > div:first-child {
 /* Customize srollbar thumb appearance for the sites sidebar and tab panel */
 .sites-scrollbar::-webkit-scrollbar-thumb {
 	background: var( --color-frame-scrollbar-thumb );
+	background-clip: padding-box;
 	border-radius: 10px;
-	border: 2px solid var( --color-frame-scrollbar-border );
+	border: 2px solid transparent;
 }
 .components-tab-panel__tab-content::-webkit-scrollbar-thumb,
 .assistant-textarea::-webkit-scrollbar-thumb {
 	background: var( --color-frame-scrollbar-thumb );
+	background-clip: padding-box;
 	border-radius: 10px;
-	border: 2px solid var( --color-frame-scrollbar-border );
+	border: 2px solid transparent;
 }
 
 /* Add hover effect to thumb appearance on the scrollbar */


### PR DESCRIPTION
## Related issues

- Fixes STU-1546

## How AI was used in this PR

Claude Code identified the root cause (regression from #3003) and implemented the fix. Changes were reviewed and tested manually.

## Proposed Changes

- Replace `--color-frame-scrollbar-border` CSS variable with `border: 2px solid transparent` + `background-clip: padding-box` on scrollbar thumbs
- Remove the now-unused `--color-frame-scrollbar-border` variable from both light and dark mode
- This approach works regardless of background color, fixing the light mode issue without affecting dark mode

## Testing Instructions

1. Open Studio in **light mode** (System Preferences → Appearance → Light)
2. Create enough sites to trigger a scrollbar in the sidebar (or add fake sites to `~/.studio/cli.json`)
3. Verify the scrollbar thumb has **no visible white border** around it
4. Switch to **dark mode** and verify the scrollbar still looks correct
5. Check scrollbars in tab panel content areas and the assistant textarea as well

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?