### PR TITLE
Track more CLI bump stats

### DIFF
--- a/apps/cli/commands/site/create.ts
+++ b/apps/cli/commands/site/create.ts
@@ -785,7 +785,7 @@ export const registerCommand = ( yargs: StudioArgv ) => {
 			try {
 				await runCommand( sitePath, config );
 
-				if ( ! argv.avoidTelemetry ) {
+				if ( __ENABLE_CLI_TELEMETRY__ && ! argv.avoidTelemetry ) {
 					bumpStat(
 						__IS_PACKAGED_FOR_NPM__
 							? StatsGroup.STUDIO_CLI_SITE_CREATE_NPM

--- a/apps/cli/commands/site/create.ts
+++ b/apps/cli/commands/site/create.ts
@@ -52,6 +52,7 @@ import {
 	type BlueprintV1Declaration,
 	type StepDefinition,
 } from '@wp-playground/blueprints';
+import { bumpStat, getPlatformMetric } from 'cli/lib/bump-stat';
 import {
 	lockCliConfig,
 	readCliConfig,
@@ -73,6 +74,7 @@ import { generateSiteName } from 'cli/lib/site-name';
 import { getDefaultSitePath } from 'cli/lib/site-paths';
 import { logSiteDetails, openSiteInBrowser, setupCustomDomain } from 'cli/lib/site-utils';
 import { keepSqliteIntegrationUpdated } from 'cli/lib/sqlite-integration';
+import { StatsGroup } from 'cli/lib/types/bump-stats';
 import { untildify } from 'cli/lib/utils';
 import { ValidationError } from 'cli/lib/validation-error';
 import { runBlueprint, startWordPressServer } from 'cli/lib/wordpress-server-manager';
@@ -782,6 +784,15 @@ export const registerCommand = ( yargs: StudioArgv ) => {
 
 			try {
 				await runCommand( sitePath, config );
+
+				if ( ! argv.avoidTelemetry ) {
+					bumpStat(
+						__IS_PACKAGED_FOR_NPM__
+							? StatsGroup.STUDIO_CLI_SITE_CREATE_NPM
+							: StatsGroup.STUDIO_CLI_SITE_CREATE_APP,
+						getPlatformMetric()
+					);
+				}
 			} catch ( error ) {
 				if ( error instanceof LoggerError ) {
 					logger.reportError( error );

--- a/apps/cli/index.ts
+++ b/apps/cli/index.ts
@@ -8,7 +8,12 @@ import { registerCommand as registerImportCommand } from 'cli/commands/import';
 import { registerCommand as registerMcpCommand } from 'cli/commands/mcp';
 import { registerCommand as registerPullCommand } from 'cli/commands/pull';
 import { registerCommand as registerPushCommand } from 'cli/commands/push';
-import { bumpAggregatedUniqueStat, getPlatformMetric } from 'cli/lib/bump-stat';
+import {
+	bumpAggregatedUniqueStat,
+	bumpStat,
+	getInstallTypeLaunchStatGroups,
+	getPlatformMetric,
+} from 'cli/lib/bump-stat';
 import { setupServerFiles } from 'cli/lib/dependency-management/setup';
 import { loadTranslations } from 'cli/lib/i18n';
 import { StatsGroup, StatsMetric } from 'cli/lib/types/bump-stats';
@@ -61,29 +66,32 @@ async function main() {
 		} )
 		.middleware( async ( argv ) => {
 			if ( __ENABLE_CLI_TELEMETRY__ && ! argv.avoidTelemetry ) {
-				try {
-					await bumpAggregatedUniqueStat(
-						StatsGroup.STUDIO_CLI_USAGE_UNIQUE,
-						StatsMetric.SUCCESS,
-						'weekly'
-					);
+				const platformMetric = getPlatformMetric();
+				const launchGroups = getInstallTypeLaunchStatGroups();
 
-					if ( __IS_PACKAGED_FOR_NPM__ ) {
-						await bumpAggregatedUniqueStat(
-							StatsGroup.STUDIO_CLI_WEEKLY_UNIQUE_NPM,
-							getPlatformMetric(),
-							'weekly'
-						);
-					} else {
-						await bumpAggregatedUniqueStat(
-							StatsGroup.STUDIO_CLI_WEEKLY_UNIQUE_APP,
-							getPlatformMetric(),
-							'weekly'
-						);
-					}
-				} catch ( error ) {
-					console.error( 'Failed to bump stat:', error );
-				}
+				bumpStat( launchGroups.totalLaunches, platformMetric );
+
+				bumpAggregatedUniqueStat( launchGroups.firstLaunch, platformMetric, 'forever' ).catch( () =>
+					console.error( 'Failed to bump stat:', launchGroups.firstLaunch )
+				);
+
+				// STUDIO_CLI_USAGE_UNIQUE and launchGroups.weeklyUnique are equivalent, apart from tracking
+				// different metrics. For now, we keep both for backward compatibility.
+				bumpAggregatedUniqueStat(
+					StatsGroup.STUDIO_CLI_USAGE_UNIQUE,
+					StatsMetric.SUCCESS,
+					'weekly'
+				).catch( () =>
+					console.error( 'Failed to bump stat:', StatsGroup.STUDIO_CLI_USAGE_UNIQUE )
+				);
+
+				bumpAggregatedUniqueStat( launchGroups.weeklyUnique, platformMetric, 'weekly' ).catch( () =>
+					console.error( 'Failed to bump stat:', launchGroups.weeklyUnique )
+				);
+
+				bumpAggregatedUniqueStat( launchGroups.monthlyUnique, platformMetric, 'monthly' ).catch(
+					() => console.error( 'Failed to bump stat:', launchGroups.monthlyUnique )
+				);
 			}
 		} )
 		.middleware( async () => {

--- a/apps/cli/lib/bump-stat.ts
+++ b/apps/cli/lib/bump-stat.ts
@@ -53,3 +53,28 @@ export function getPlatformMetric(): StatsMetric {
 			return StatsMetric.UNKNOWN_PLATFORM;
 	}
 }
+
+type InstallTypeLaunchStatGroups = {
+	weeklyUnique: StatsGroup;
+	monthlyUnique: StatsGroup;
+	firstLaunch: StatsGroup;
+	totalLaunches: StatsGroup;
+};
+
+export function getInstallTypeLaunchStatGroups(): InstallTypeLaunchStatGroups {
+	if ( __IS_PACKAGED_FOR_NPM__ ) {
+		return {
+			weeklyUnique: StatsGroup.STUDIO_CLI_WEEKLY_UNIQUE_NPM,
+			monthlyUnique: StatsGroup.STUDIO_CLI_MONTHLY_UNIQUE_NPM,
+			firstLaunch: StatsGroup.STUDIO_CLI_FIRST_LAUNCH_NPM,
+			totalLaunches: StatsGroup.STUDIO_CLI_TOTAL_LAUNCHES_NPM,
+		};
+	}
+
+	return {
+		weeklyUnique: StatsGroup.STUDIO_CLI_WEEKLY_UNIQUE_APP,
+		monthlyUnique: StatsGroup.STUDIO_CLI_MONTHLY_UNIQUE_APP,
+		firstLaunch: StatsGroup.STUDIO_CLI_FIRST_LAUNCH_APP,
+		totalLaunches: StatsGroup.STUDIO_CLI_TOTAL_LAUNCHES_APP,
+	};
+}

--- a/apps/cli/lib/types/bump-stats.ts
+++ b/apps/cli/lib/types/bump-stats.ts
@@ -2,6 +2,14 @@ export enum StatsGroup {
 	STUDIO_CLI_USAGE_UNIQUE = 'studio-cli-usage-unique',
 	STUDIO_CLI_WEEKLY_UNIQUE_NPM = 'studio-cli-weekly-unq-npm',
 	STUDIO_CLI_WEEKLY_UNIQUE_APP = 'studio-cli-weekly-unq-app',
+	STUDIO_CLI_MONTHLY_UNIQUE_NPM = 'studio-cli-mon-unq-npm',
+	STUDIO_CLI_MONTHLY_UNIQUE_APP = 'studio-cli-mon-unq-app',
+	STUDIO_CLI_FIRST_LAUNCH_NPM = 'studio-cli-lch-1st-npm',
+	STUDIO_CLI_FIRST_LAUNCH_APP = 'studio-cli-lch-1st-app',
+	STUDIO_CLI_TOTAL_LAUNCHES_NPM = 'studio-cli-lch-tot-npm',
+	STUDIO_CLI_TOTAL_LAUNCHES_APP = 'studio-cli-lch-tot-app',
+	STUDIO_CLI_SITE_CREATE_NPM = 'studio-cli-site-crt-npm',
+	STUDIO_CLI_SITE_CREATE_APP = 'studio-cli-site-crt-app',
 }
 
 export enum StatsMetric {

--- a/apps/cli/vite.config.base.ts
+++ b/apps/cli/vite.config.base.ts
@@ -90,7 +90,9 @@ export const baseConfig = defineConfig( {
 		mainFields: [ 'main' ],
 	},
 	define: {
-		__STUDIO_CLI_VERSION__: JSON.stringify( packageJson.version ),
+		__ENABLE_CLI_TELEMETRY__: false,
+		__IS_PACKAGED_FOR_NPM__: false,
 		__MINIMUM_NODE_VERSION__: JSON.stringify( minimumNodeVersion ),
+		__STUDIO_CLI_VERSION__: JSON.stringify( packageJson.version ),
 	},
 } );

--- a/apps/cli/vite.config.dev.ts
+++ b/apps/cli/vite.config.dev.ts
@@ -15,9 +15,5 @@ export default mergeConfig(
 				],
 			} ),
 		],
-		define: {
-			__IS_PACKAGED_FOR_NPM__: false,
-			__ENABLE_CLI_TELEMETRY__: false,
-		},
 	} )
 );

--- a/apps/studio/src/lib/tests/bump-stats.test.ts
+++ b/apps/studio/src/lib/tests/bump-stats.test.ts
@@ -1,33 +1,37 @@
-import fs from 'fs';
 import { AggregateInterval } from '@studio/common/lib/bump-stat';
 import { waitFor } from '@testing-library/react';
-import { readFile, writeFile } from 'atomically';
-import { vol } from 'memfs';
 import { vi } from 'vitest';
+import { loadUserData, lockAppdata, saveUserData, unlockAppdata } from 'src/storage/user-data';
 import { bumpStat, bumpAggregatedUniqueStat, StatsGroup, StatsMetric } from '../bump-stats';
 
-vi.mock( 'atomically', () => ( {
-	readFile: vi.fn(),
-	writeFile: vi.fn(),
+vi.mock( 'src/storage/user-data', () => ( {
+	loadUserData: vi.fn(),
+	saveUserData: vi.fn(),
+	lockAppdata: vi.fn(),
+	unlockAppdata: vi.fn(),
 } ) );
-
-vi.mock( 'fs' );
 
 // Store original fetch to restore later
 const originalFetch = global.fetch;
 
 const originalEnv = { ...process.env };
+const EMPTY_USER_DATA = { version: 1 as const, siteMetadata: {}, lastBumpStats: {} };
+let mockUserData = structuredClone( EMPTY_USER_DATA );
 
 beforeEach( () => {
-	vol.reset();
-	vi.mocked( fs.existsSync ).mockReturnValue( true );
+	vi.clearAllMocks();
+	mockUserData = structuredClone( EMPTY_USER_DATA );
+	vi.mocked( lockAppdata ).mockResolvedValue( undefined );
+	vi.mocked( unlockAppdata ).mockResolvedValue( undefined );
+	vi.mocked( loadUserData ).mockImplementation( async () => structuredClone( mockUserData ) );
+	vi.mocked( saveUserData ).mockImplementation( async ( userData ) => {
+		mockUserData = structuredClone( userData );
+	} );
 } );
 
 afterEach( () => {
 	vi.spyOn( Date, 'now' ).mockRestore();
 	vi.spyOn( console, 'info' ).mockRestore();
-	vi.mocked( readFile ).mockRestore();
-	vi.mocked( writeFile ).mockRestore();
 	global.fetch = originalFetch;
 	process.env = { ...originalEnv };
 } );
@@ -138,18 +142,23 @@ describe( 'bumpAggregatedUniqueStat', () => {
 	test( 'bump stat when it has never been recorded before', async () => {
 		const mockRequest = mockBumpStatRequest( StatsGroup.STUDIO_APP_LAUNCH, StatsMetric.SUCCESS );
 
-		vi.mocked( readFile ).mockResolvedValue(
-			Buffer.from(
-				JSON.stringify( {
-					lastBumpStats: {},
-					sites: [],
-				} )
-			)
-		);
+		mockUserData.lastBumpStats = {};
 
 		await bumpAggregatedUniqueStat( StatsGroup.STUDIO_APP_LAUNCH, StatsMetric.SUCCESS, 'weekly' );
 
 		await waitFor( () => expect( mockRequest.isDone() ).toBe( true ) );
+	} );
+
+	test( "don't bump forever stat when it has already been recorded", async () => {
+		mockUserData.lastBumpStats = {
+			[ StatsGroup.STUDIO_APP_LAUNCH ]: {
+				[ StatsMetric.SUCCESS ]: Date.UTC( 2024, 0, 1 ),
+			},
+		};
+
+		await bumpAggregatedUniqueStat( StatsGroup.STUDIO_APP_LAUNCH, StatsMetric.SUCCESS, 'forever' );
+
+		expect( saveUserData ).not.toHaveBeenCalled();
 	} );
 
 	test.each< [ AggregateInterval, number, number ] >( [
@@ -162,18 +171,11 @@ describe( 'bumpAggregatedUniqueStat', () => {
 			mockCurrentTime( currentTime );
 
 			const mockRequest = mockBumpStatRequest( StatsGroup.STUDIO_APP_LAUNCH, StatsMetric.SUCCESS );
-			vi.mocked( readFile ).mockResolvedValue(
-				Buffer.from(
-					JSON.stringify( {
-						lastBumpStats: {
-							[ StatsGroup.STUDIO_APP_LAUNCH ]: {
-								[ StatsMetric.SUCCESS ]: lastBumpTime,
-							},
-						},
-						sites: [],
-					} )
-				)
-			);
+			mockUserData.lastBumpStats = {
+				[ StatsGroup.STUDIO_APP_LAUNCH ]: {
+					[ StatsMetric.SUCCESS ]: lastBumpTime,
+				},
+			};
 
 			await bumpAggregatedUniqueStat(
 				StatsGroup.STUDIO_APP_LAUNCH,
@@ -183,8 +185,8 @@ describe( 'bumpAggregatedUniqueStat', () => {
 
 			await waitFor( () => expect( mockRequest.isDone() ).toBe( true ) );
 
-			expect( writeFile ).toHaveBeenCalled();
-			const savedData = JSON.parse( vi.mocked( writeFile ).mock.calls[ 0 ][ 1 ] as string );
+			expect( saveUserData ).toHaveBeenCalled();
+			const savedData = vi.mocked( saveUserData ).mock.calls[ 0 ][ 0 ];
 			expect( savedData ).toMatchObject( {
 				lastBumpStats: {
 					[ StatsGroup.STUDIO_APP_LAUNCH ]: {
@@ -206,18 +208,11 @@ describe( 'bumpAggregatedUniqueStat', () => {
 
 			// Don't create a nock mock so that we get errors if a network request is made
 
-			vi.mocked( readFile ).mockResolvedValue(
-				Buffer.from(
-					JSON.stringify( {
-						lastBumpStats: {
-							[ StatsGroup.STUDIO_APP_LAUNCH ]: {
-								[ StatsMetric.SUCCESS ]: lastBumpTime,
-							},
-						},
-						sites: [],
-					} )
-				)
-			);
+			mockUserData.lastBumpStats = {
+				[ StatsGroup.STUDIO_APP_LAUNCH ]: {
+					[ StatsMetric.SUCCESS ]: lastBumpTime,
+				},
+			};
 
 			await bumpAggregatedUniqueStat(
 				StatsGroup.STUDIO_APP_LAUNCH,
@@ -225,7 +220,7 @@ describe( 'bumpAggregatedUniqueStat', () => {
 				aggregateBy
 			);
 
-			expect( writeFile ).not.toHaveBeenCalled();
+			expect( saveUserData ).not.toHaveBeenCalled();
 		}
 	);
 } );

--- a/apps/studio/src/lib/tests/bump-stats.test.ts
+++ b/apps/studio/src/lib/tests/bump-stats.test.ts
@@ -1,6 +1,7 @@
 import { AggregateInterval } from '@studio/common/lib/bump-stat';
 import { waitFor } from '@testing-library/react';
 import { vi } from 'vitest';
+import { EMPTY_USER_DATA } from 'src/storage/storage-types';
 import { loadUserData, lockAppdata, saveUserData, unlockAppdata } from 'src/storage/user-data';
 import { bumpStat, bumpAggregatedUniqueStat, StatsGroup, StatsMetric } from '../bump-stats';
 
@@ -15,7 +16,6 @@ vi.mock( 'src/storage/user-data', () => ( {
 const originalFetch = global.fetch;
 
 const originalEnv = { ...process.env };
-const EMPTY_USER_DATA = { version: 1 as const, siteMetadata: {}, lastBumpStats: {} };
 let mockUserData = structuredClone( EMPTY_USER_DATA );
 
 beforeEach( () => {

--- a/tools/common/lib/bump-stat.ts
+++ b/tools/common/lib/bump-stat.ts
@@ -5,7 +5,7 @@ import { isSameDay, isSameMonth, isSameWeek } from 'date-fns';
 const MAX_GROUP_LENGTH = 27;
 const MAX_STAT_LENGTH = 32;
 
-export type AggregateInterval = 'daily' | 'weekly' | 'monthly';
+export type AggregateInterval = 'daily' | 'weekly' | 'monthly' | 'forever';
 
 // Returns true if we attempted to bump the stat
 export function __bumpStat( group: string, stat: string, bumpInDev = false ) {
@@ -71,6 +71,11 @@ export async function __bumpAggregatedUniqueStat(
 	if ( lastBump === null ) {
 		__bumpStat( group, stat, bumpInDev );
 		await updateLastBump( group, stat, provider );
+		return;
+	}
+
+	// `forever` is suitable for stats like "first launch"
+	if ( aggregateBy === 'forever' ) {
 		return;
 	}
 


### PR DESCRIPTION
## Related issues

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

- Fixes STU-1547

## How AI was used in this PR

<!--
Help reviewers understand what to look for and verify that you've reviewed the code yourself.
-->

Codex handled the entire implementation, helping me multitask (for better or worse). I reviewed the code iteratively and made several prompts to reach a solution that was simple enough to my liking. 

## Proposed Changes

This PR adds new bump stats to track the following CLI activities:

- Monthly active users
- First launch
- Total launches
- Site creation

As always, bump stats are anonymous. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Apply the following diff

```diff
diff --git a/tools/common/lib/bump-stat.ts b/tools/common/lib/bump-stat.ts
index a13ff1eb..427cc8da 100644
--- a/tools/common/lib/bump-stat.ts
+++ b/tools/common/lib/bump-stat.ts
@@ -23,9 +23,9 @@ export function __bumpStat( group: string, stat: string, bumpInDev = false ) {
                return false;
        }

-       if ( process.env.E2E || ( process.env.NODE_ENV === 'development' && ! bumpInDev ) ) {
+       if ( true ) {
                console.info( `Would have bumped stat: ${ group }=${ stat }` );
-               return false;
+               return true;
        }

        // Fire and forget POST request
```

2. `npm run cli:build:prod`
3. `node apps/cli/dist/cli/main.mjs site list`
4. Ensure that the output contains the following:

```
Would have bumped stat: studio-cli-lch-tot-app=darwin
Would have bumped stat: studio-cli-lch-1st-app=darwin
Would have bumped stat: studio-cli-mon-unq-app=darwin
```

5. `node apps/cli/dist/cli/main.mjs site list`
6. Ensure that the output only contains:

```
Would have bumped stat: studio-cli-lch-tot-app=darwin
```

7. `node apps/cli/dist/cli/main.mjs site create` and go through all the steps
8. Ensure that the output contains the following:

```
Would have bumped stat: studio-cli-site-crt-app=darwin
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
