### PR TITLE
Add splash screen on launch to improve perceived startup time

### DIFF
--- a/apps/studio/__mocks__/electron.ts
+++ b/apps/studio/__mocks__/electron.ts
@@ -61,6 +61,12 @@ BrowserWindow.prototype.on = vi.fn( ( event: string, handler: ( ...args: any[] )
 	}
 	eventHandlers[ event ].push( handler );
 } );
+BrowserWindow.prototype.once = vi.fn( ( event: string, handler: ( ...args: any[] ) => void ) => {
+	if ( ! eventHandlers[ event ] ) {
+		eventHandlers[ event ] = [];
+	}
+	eventHandlers[ event ].push( handler );
+} );
 BrowserWindow.prototype.emit = vi.fn( ( event: string, ...args: any[] ) => {
 	const handlers = eventHandlers[ event ] || [];
 	handlers.forEach( ( handler ) => handler( ...args ) );

--- a/apps/studio/e2e/e2e-helpers.ts
+++ b/apps/studio/e2e/e2e-helpers.ts
@@ -143,22 +143,31 @@ export class E2ESession {
 	}
 
 	private async waitForMainWindow( timeout: number ): Promise< Page > {
-		const deadline = Date.now() + timeout;
+		const isMainWindow = async ( win: Page ) => ( await win.title() ) === 'WordPress Studio';
 
-		// Check any already-open windows first.
+		// Register the event listener before checking existing windows to avoid a
+		// race where the main window opens between the two operations.
+		const nextWindowPromise = this.electronApp.waitForEvent( 'window', { timeout } );
+
+		// If the main window is already open (e.g. splash closed quickly), return it.
 		for ( const win of this.electronApp.windows() ) {
-			if ( ( await win.title() ) === 'WordPress Studio' ) {
+			if ( await isMainWindow( win ) ) {
 				return win;
 			}
 		}
 
-		// Wait for new windows until we find the main one or time out.
-		while ( Date.now() < deadline ) {
-			const remaining = deadline - Date.now();
-			const win = await this.electronApp.waitForEvent( 'window', { timeout: remaining } );
-			if ( ( await win.title() ) === 'WordPress Studio' ) {
+		// Otherwise wait for incoming windows, skipping the splash.
+		const deadline = Date.now() + timeout;
+		let win = await nextWindowPromise;
+		while ( true ) {
+			if ( await isMainWindow( win ) ) {
 				return win;
 			}
+			const remaining = deadline - Date.now();
+			if ( remaining <= 0 ) {
+				break;
+			}
+			win = await this.electronApp.waitForEvent( 'window', { timeout: remaining } );
 		}
 
 		throw new Error( 'Timed out waiting for the main WordPress Studio window' );

--- a/apps/studio/e2e/e2e-helpers.ts
+++ b/apps/studio/e2e/e2e-helpers.ts
@@ -138,7 +138,30 @@ export class E2ESession {
 
 		this.startCapturingMainProcessLogs();
 
-		this.mainWindow = await this.electronApp.firstWindow( { timeout: 60_000 } );
+		// firstWindow() may return the splash screen. Wait for the main app window instead.
+		this.mainWindow = await this.waitForMainWindow( 60_000 );
+	}
+
+	private async waitForMainWindow( timeout: number ): Promise< Page > {
+		const deadline = Date.now() + timeout;
+
+		// Check any already-open windows first.
+		for ( const win of this.electronApp.windows() ) {
+			if ( ( await win.title() ) === 'WordPress Studio' ) {
+				return win;
+			}
+		}
+
+		// Wait for new windows until we find the main one or time out.
+		while ( Date.now() < deadline ) {
+			const remaining = deadline - Date.now();
+			const win = await this.electronApp.waitForEvent( 'window', { timeout: remaining } );
+			if ( ( await win.title() ) === 'WordPress Studio' ) {
+				return win;
+			}
+		}
+
+		throw new Error( 'Timed out waiting for the main WordPress Studio window' );
 	}
 
 	async reportMainProcessLogsOnFailure( testInfo: TestInfo ) {

--- a/apps/studio/electron.vite.config.ts
+++ b/apps/studio/electron.vite.config.ts
@@ -94,6 +94,10 @@ export default defineConfig({
 						src: normalizePath( resolve( __dirname, 'src/about-menu/studio-app-icon.png' ) ),
 						dest: '.',
 					},
+					{
+						src: normalizePath( resolve( __dirname, 'src/about-menu/splash.html' ) ),
+						dest: '.',
+					},
 				],
 			} ),
 			// Sentry must be the last plugin

--- a/apps/studio/src/about-menu/splash.html
+++ b/apps/studio/src/about-menu/splash.html
@@ -1,0 +1,53 @@
+<!doctype html>
+<html>
+	<head>
+		<meta charset="UTF-8" />
+		<style>
+			* {
+				margin: 0;
+				padding: 0;
+				box-sizing: border-box;
+			}
+
+			html,
+			body {
+				width: 100%;
+				height: 100%;
+				background: transparent;
+				-webkit-app-region: drag;
+				overflow: hidden;
+			}
+
+			.splash {
+				width: 380px;
+				height: 280px;
+				background: rgba( 30, 30, 30, 0.95 );
+				border-radius: 12px;
+				display: flex;
+				flex-direction: column;
+				align-items: center;
+				justify-content: center;
+				gap: 20px;
+				box-shadow: 0 20px 60px rgba( 0, 0, 0, 0.5 );
+			}
+
+			img {
+				width: 80px;
+				height: 80px;
+				object-fit: contain;
+			}
+
+			p {
+				color: rgba( 255, 255, 255, 0.6 );
+				font-family: 'Segoe UI', system-ui, -apple-system, sans-serif;
+				font-size: 13px;
+			}
+		</style>
+	</head>
+	<body>
+		<div class="splash">
+			<img src="./studio-app-icon.png" alt="WordPress Studio" />
+			<p>Starting WordPress Studio&hellip;</p>
+		</div>
+	</body>
+</html>

--- a/apps/studio/src/index.ts
+++ b/apps/studio/src/index.ts
@@ -49,6 +49,7 @@ import { isStudioCliInstalled } from 'src/modules/cli/lib/ipc-handlers';
 import { autoInstallMacOSCliIfNeeded } from 'src/modules/cli/lib/macos-installation-manager';
 import { autoInstallWindowsCliIfNeeded } from 'src/modules/cli/lib/windows-installation-manager';
 import { getRunningSiteCount, SiteServer, stopAllServers } from 'src/site-server';
+import { createSplashWindow, destroySplashWindow } from 'src/splash-window';
 import {
 	loadUserData,
 	lockAppdata,
@@ -245,6 +246,8 @@ async function appBoot() {
 	}
 
 	app.on( 'ready', async () => {
+		createSplashWindow();
+
 		const locale = await getUserLocaleWithFallback();
 		if ( process.env.NODE_ENV === 'development' ) {
 			await installExtension( REACT_DEVELOPER_TOOLS );
@@ -317,7 +320,7 @@ async function appBoot() {
 		await SiteServer.fetchAll();
 		await startCliEventsSubscriber();
 
-		await createMainWindow();
+		await createMainWindow( destroySplashWindow );
 
 		const userData = await loadUserData();
 		// Bump stats for the first time the app runs - this is when no lastBumpStats are available

--- a/apps/studio/src/main-window.ts
+++ b/apps/studio/src/main-window.ts
@@ -59,7 +59,7 @@ function isValidWindowBounds( bounds: WindowBounds ): boolean {
 	} );
 }
 
-export async function createMainWindow(): Promise< BrowserWindow > {
+export async function createMainWindow( onReadyToShow?: () => void ): Promise< BrowserWindow > {
 	if ( mainWindow && ! mainWindow.isDestroyed() ) {
 		return mainWindow;
 	}
@@ -74,6 +74,7 @@ export async function createMainWindow(): Promise< BrowserWindow > {
 		backgroundColor: 'rgba(30, 30, 30, 1)',
 		minHeight: MAIN_MIN_HEIGHT,
 		minWidth: MAIN_MIN_WIDTH,
+		show: false,
 		webPreferences: {
 			preload: path.join( __dirname, '../preload/preload.js' ),
 			webSecurity: process.env.NODE_ENV !== 'development',
@@ -92,6 +93,11 @@ export async function createMainWindow(): Promise< BrowserWindow > {
 	}
 
 	mainWindow = new BrowserWindow( windowOptions );
+
+	mainWindow.once( 'ready-to-show', () => {
+		onReadyToShow?.();
+		mainWindow?.show();
+	} );
 
 	// Restore fullscreen state if it was saved
 	if ( savedBounds?.isFullScreen ) {

--- a/apps/studio/src/splash-window.ts
+++ b/apps/studio/src/splash-window.ts
@@ -1,0 +1,37 @@
+import { BrowserWindow } from 'electron';
+import path from 'path';
+
+let splashWindow: BrowserWindow | null = null;
+
+export function createSplashWindow(): void {
+	splashWindow = new BrowserWindow( {
+		width: 380,
+		height: 280,
+		frame: false,
+		transparent: true,
+		alwaysOnTop: true,
+		resizable: false,
+		skipTaskbar: true,
+		webPreferences: {
+			nodeIntegration: false,
+			contextIsolation: true,
+		},
+	} );
+
+	const splashPath =
+		process.env.NODE_ENV === 'development'
+			? path.join( __dirname, '../../src/about-menu/splash.html' )
+			: path.join( __dirname, '../renderer/splash.html' );
+
+	void splashWindow.loadFile( splashPath );
+
+	splashWindow.once( 'closed', () => {
+		splashWindow = null;
+	} );
+}
+
+export function destroySplashWindow(): void {
+	if ( splashWindow && ! splashWindow.isDestroyed() ) {
+		splashWindow.close();
+	}
+}

--- a/apps/studio/src/tests/index.test.ts
+++ b/apps/studio/src/tests/index.test.ts
@@ -10,6 +10,7 @@ import { createMainWindow, getMainWindow } from 'src/main-window';
 vi.mock( 'fs' );
 vi.mock( 'file-stream-rotator' );
 vi.mock( 'src/main-window' );
+vi.mock( 'src/splash-window' );
 vi.mock( 'src/updates' );
 vi.mock( '@sentry/electron/main', () => ( {
 	init: vi.fn(),

--- a/apps/studio/src/tests/main-window.test.ts
+++ b/apps/studio/src/tests/main-window.test.ts
@@ -38,6 +38,13 @@ vi.mock( 'electron', () => {
 			mockEventHandlers.get( event )!.push( handler );
 		} );
 
+		once = vi.fn().mockImplementation( ( event: string, handler: ( ...args: any[] ) => void ) => {
+			if ( ! mockEventHandlers.has( event ) ) {
+				mockEventHandlers.set( event, [] );
+			}
+			mockEventHandlers.get( event )!.push( handler );
+		} );
+
 		webContents = {
 			isDestroyed: vi.fn().mockReturnValue( false ),
 			send: vi.fn(),


### PR DESCRIPTION
## Related issues

- Fixes STU-1492

## How AI was used in this PR

This PR was developed with Claude Code assistance. The implementation was reviewed and tested manually.

## Proposed Changes

- Add a frameless splash screen window (`splash-window.ts`) that appears immediately when the app is ready, before heavy initialization (migrations, `SiteServer.fetchAll`, CLI events subscriber)
- Add `splash.html` with the Studio logo on a dark background, shown while the app loads
- Pass `destroySplashWindow` as an `onReadyToShow` callback to `createMainWindow` so the splash closes at the exact moment the main window is ready to paint — no gap, no overlap
- Add `show: false` to the main window options to prevent white flash before React renders

## Testing Instructions

- Launch Studio on Windows and verify a splash screen with the Studio logo appears immediately, staying visible until the main window is ready
- Launch Studio on macOS and verify the same behaviour (also fixes the white flash on first paint)
- Verify the splash closes cleanly when the main window appears, with no gap between them

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?