### PR TITLE
Fix release notes previous tag selection and filtering

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,4 @@
+changelog:
+  exclude:
+    labels:
+      - Releases

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -704,7 +704,7 @@ def find_previous_stable_release_tag(version:)
   target_version = Gem::Version.new(version)
   matching_tags = sh('git', 'tag', '--list', 'v*').lines.filter_map do |tag|
     tag = tag.strip
-    match = tag.match(/^v(\d+(?:\.\d+)*)$/)
+    match = tag.match(/^v(\d+\.\d+\.\d+)$/)
     next if match.nil?
 
     tag_version = Gem::Version.new(match[1])

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -697,11 +697,35 @@ def extract_release_notes(version:)
   end
 end
 
+# Find the latest stable release tag lower than the target version, regardless of reachability from HEAD.
+def find_previous_stable_release_tag(version:)
+  sh('git', 'fetch', '--tags', '--force')
+
+  target_version = Gem::Version.new(version)
+  matching_tags = sh('git', 'tag', '--list', 'v*').lines.filter_map do |tag|
+    tag = tag.strip
+    match = tag.match(/^v(\d+(?:\.\d+)*)$/)
+    next if match.nil?
+
+    tag_version = Gem::Version.new(match[1])
+    next unless tag_version < target_version
+
+    [tag, tag_version]
+  end
+
+  previous_tag = matching_tags.max_by(&:last)&.first
+
+  UI.important("No previous stable tag found before #{version}") if previous_tag.nil?
+
+  previous_tag
+end
+
 # Generate a draft release notes section from merged PRs and prepend it to RELEASE-NOTES.txt.
 # Uses GitHub's generate-notes API to list PRs since the last published release.
 def update_release_notes_draft(version:)
-  # Find the latest stable (non-beta) release tag reachable from HEAD.
-  previous_tag = find_previous_tag(pattern: 'v*', exclude: '*beta*')
+  # Find the latest stable release tag lower than the target version.
+  # The latest published release tag is not always reachable from trunk before its backmerge PR lands.
+  previous_tag = find_previous_stable_release_tag(version: version)
 
   changelog = get_prs_between_tags(
     repository: GITHUB_REPO,


### PR DESCRIPTION
## Related issues

- Fixes AINFRA-2276

## How AI was used in this PR

- Used Codex to investigate the release note generation issue. Then directed its implementation of a Fastlane tag-selection fix, and add GitHub release note filtering configuration. Reviewed all the resulting changes manually.

## Proposed Changes

I noticed on the [generated 1.7.8 release notes](https://github.com/Automattic/studio/pull/3024) that `v1.7.4` was being considered the previous version instead of `v1.7.5`. This is likely due to the fact that the `v1.7.5` tag isn’t necessarily on `trunk`. So I've implemented the following improvements:
 
- Select the previous stable release tag by semantic version instead of `git describe` reachability from `trunk`
- Add `.github/release.yml` to exclude `Releases`-labeled PRs from GitHub-generated release notes

## Testing Instructions

- Confirm the helper resolves `v1.7.5` as the previous stable tag for target version `1.7.8`
- Optionally generate draft release notes and verify `Releases`-labeled PRs are excluded from the generated GitHub notes

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
