### PR TITLE
PoC: A2A server for agent-to-agent WordPress delegation

### DIFF
--- a/apps/cli/a2a-server/agent-card.ts
+++ b/apps/cli/a2a-server/agent-card.ts
@@ -1,0 +1,89 @@
+import type { AgentCard } from '@a2a-js/sdk';
+
+const DEFAULT_PORT = 41567;
+
+export function getPort(): number {
+	return parseInt( process.env.STUDIO_A2A_PORT ?? String( DEFAULT_PORT ), 10 );
+}
+
+export function buildAgentCard( port: number ): AgentCard {
+	return {
+		name: 'WordPress Studio Code',
+		description:
+			'AI agent for WordPress site management. Creates, configures, and designs local WordPress sites ' +
+			'using WordPress Playground (PHP WASM). Capabilities include site creation with bold visual design, ' +
+			'block-based content generation, WP-CLI execution, theme/plugin development, performance auditing, ' +
+			'screenshot verification, and WordPress.com preview deployment.',
+		url: `http://localhost:${ port }`,
+		protocolVersion: '0.3.0',
+		version: '1.0.0',
+		provider: {
+			organization: 'Automattic',
+			url: 'https://developer.wordpress.com/studio/',
+		},
+		capabilities: {
+			streaming: true,
+			pushNotifications: false,
+			stateTransitionHistory: true,
+		},
+		defaultInputModes: [ 'text' ],
+		defaultOutputModes: [ 'text' ],
+		skills: [
+			{
+				id: 'site-create',
+				name: 'Create WordPress Site',
+				description:
+					'Create a new local WordPress site with a custom theme, bold visual design, ' +
+					'block-based content, and scroll animations. Includes screenshot verification.',
+				tags: [ 'wordpress', 'site', 'create', 'design', 'theme' ],
+			},
+			{
+				id: 'site-manage',
+				name: 'Manage WordPress Sites',
+				description:
+					'Start, stop, delete, list, and get info about local WordPress sites. ' +
+					'Run WP-CLI commands. Import/export site backups.',
+				tags: [ 'wordpress', 'site', 'manage', 'wp-cli' ],
+			},
+			{
+				id: 'site-preview',
+				name: 'WordPress.com Preview',
+				description:
+					'Deploy a local site as a hosted preview on WordPress.com. ' +
+					'Create, update, list, and delete preview sites.',
+				tags: [ 'wordpress', 'preview', 'deploy', 'wordpress.com' ],
+			},
+			{
+				id: 'site-audit',
+				name: 'Performance Audit',
+				description:
+					'Measure Core Web Vitals (TTFB, FCP, LCP, CLS), page weight, DOM size, ' +
+					'and JS/CSS/image/font asset breakdown for a WordPress site.',
+				tags: [ 'wordpress', 'performance', 'audit', 'web-vitals' ],
+			},
+			{
+				id: 'site-screenshot',
+				name: 'Screenshot',
+				description:
+					'Take full-page screenshots of a WordPress site in desktop (1040x1248) ' +
+					'and mobile (390x844) viewports.',
+				tags: [ 'wordpress', 'screenshot', 'visual' ],
+			},
+			{
+				id: 'data-liberation',
+				name: 'Data Liberation',
+				description:
+					'Migrate content from Wix, Squarespace, Webflow, or Shopify into a WordPress site. ' +
+					'Extract, transform, and import content preserving structure and media.',
+				tags: [ 'wordpress', 'migration', 'import', 'wix', 'squarespace', 'webflow', 'shopify' ],
+			},
+			{
+				id: 'taxonomist',
+				name: 'Taxonomy Optimizer',
+				description:
+					'Analyze and optimize WordPress categories and tags for better content organization.',
+				tags: [ 'wordpress', 'taxonomy', 'categories', 'tags', 'seo' ],
+			},
+		],
+	};
+}

--- a/apps/cli/a2a-server/executor.ts
+++ b/apps/cli/a2a-server/executor.ts
@@ -1,5 +1,5 @@
 import { v4 as uuidv4 } from 'uuid';
-import { startAiAgent, type AiAgentConfig } from 'cli/ai/agent';
+import { startAiAgent, type AiAgentConfig, type AskUserQuestion } from 'cli/ai/agent';
 import type { Message } from '@a2a-js/sdk';
 import type {
 	AgentExecutor,
@@ -8,9 +8,10 @@ import type {
 } from '@a2a-js/sdk/server';
 import type { SDKMessage } from '@anthropic-ai/claude-agent-sdk';
 
-/**
- * Helper to create a well-formed A2A Message.
- */
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
 function agentMessage( text: string ): Message {
 	return {
 		kind: 'message',
@@ -20,20 +21,16 @@ function agentMessage( text: string ): Message {
 	};
 }
 
-/**
- * Extracts the user's text prompt from an A2A message.
- */
 function extractPrompt( ctx: RequestContext ): string {
 	const parts = ctx.userMessage.parts ?? [];
-	const textParts = parts
-		.filter( ( p ): p is { kind: 'text'; text: string } => p.kind === 'text' )
-		.map( ( p ) => p.text );
-	return textParts.join( '\n' ) || 'Hello';
+	return (
+		parts
+			.filter( ( p ): p is { kind: 'text'; text: string } => p.kind === 'text' )
+			.map( ( p ) => p.text )
+			.join( '\n' ) || 'Hello'
+	);
 }
 
-/**
- * Extracts displayable text from an SDK assistant message.
- */
 function extractAssistantText( message: SDKMessage ): string | null {
 	if ( message.type !== 'assistant' ) {
 		return null;
@@ -47,9 +44,6 @@ function extractAssistantText( message: SDKMessage ): string | null {
 	return texts.length > 0 ? texts.join( '\n' ) : null;
 }
 
-/**
- * Extracts tool use info from an SDK assistant message for status reporting.
- */
 function extractToolUse(
 	message: SDKMessage
 ): { name: string; input?: Record< string, unknown > } | null {
@@ -67,22 +61,181 @@ function extractToolUse(
 	return null;
 }
 
+// ---------------------------------------------------------------------------
+// Agent session — keeps a running agent alive across A2A execute() calls
+// ---------------------------------------------------------------------------
+
+type SessionEvent =
+	| { kind: 'text'; text: string }
+	| { kind: 'tool-use'; name: string }
+	| {
+			kind: 'question';
+			questions: AskUserQuestion[];
+			resolve: ( answers: Record< string, string > ) => void;
+	  }
+	| { kind: 'result'; success: boolean; text: string }
+	| { kind: 'error'; message: string }
+	| { kind: 'done' };
+
+/**
+ * Wraps a running Studio Code agent and exposes its output as an async event
+ * queue. The agent runs in the background; events are drained by the executor
+ * on each A2A execute() call.
+ *
+ * When the agent asks a question (via onAskUser), the session stores the
+ * pending resolve function. The executor publishes `input-required` to A2A
+ * and returns. When the client sends a continuation, the executor resolves
+ * the pending question and resumes draining.
+ */
+class AgentSession {
+	private events: SessionEvent[] = [];
+	private waitResolve: ( () => void ) | null = null;
+	private _finished = false;
+	private queryHandle: ReturnType< typeof startAiAgent > | null = null;
+
+	/** Pending question waiting for the client's answer. */
+	pendingQuestion: {
+		questions: AskUserQuestion[];
+		resolve: ( answers: Record< string, string > ) => void;
+	} | null = null;
+
+	aborted = false;
+
+	start( prompt: string ) {
+		const config: AiAgentConfig = {
+			prompt,
+			maxTurns: 50,
+			onAskUser: async ( questions ) => {
+				return new Promise< Record< string, string > >( ( resolve ) => {
+					this.push( { kind: 'question', questions, resolve } );
+				} );
+			},
+		};
+
+		this.queryHandle = startAiAgent( config );
+
+		// Run the agent in the background, pushing events to the queue
+		( async () => {
+			try {
+				for await ( const message of this.queryHandle! ) {
+					if ( this.aborted ) {
+						break;
+					}
+
+					const text = extractAssistantText( message );
+					if ( text ) {
+						this.push( { kind: 'text', text } );
+					}
+
+					const toolUse = extractToolUse( message );
+					if ( toolUse ) {
+						this.push( { kind: 'tool-use', name: toolUse.name } );
+					}
+
+					if ( message.type === 'result' ) {
+						const resultText =
+							message.subtype === 'success'
+								? message.result
+								: `Agent error: ${ message.subtype }`;
+						this.push( {
+							kind: 'result',
+							success: message.subtype === 'success',
+							text: resultText,
+						} );
+					}
+				}
+			} catch ( error ) {
+				const errorMessage = error instanceof Error ? error.message : String( error );
+				this.push( { kind: 'error', message: errorMessage } );
+			} finally {
+				this._finished = true;
+				this.push( { kind: 'done' } );
+			}
+		} )();
+	}
+
+	interrupt() {
+		this.aborted = true;
+		this.queryHandle?.interrupt();
+	}
+
+	get finished() {
+		return this._finished;
+	}
+
+	/** Wait for and return the next event, or null if done. */
+	async nextEvent(): Promise< SessionEvent | null > {
+		if ( this.events.length > 0 ) {
+			return this.events.shift()!;
+		}
+		if ( this._finished ) {
+			return null;
+		}
+		await new Promise< void >( ( resolve ) => {
+			this.waitResolve = resolve;
+		} );
+		return this.events.shift() ?? null;
+	}
+
+	private push( event: SessionEvent ) {
+		this.events.push( event );
+		if ( this.waitResolve ) {
+			const resolve = this.waitResolve;
+			this.waitResolve = null;
+			resolve();
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// A2A Executor
+// ---------------------------------------------------------------------------
+
 /**
  * A2A AgentExecutor that wraps the Studio Code AI agent.
  *
- * Each A2A task spawns a full Studio Code agent session. The agent runs
- * its own loop (Claude SDK → MCP tools → Playwright browser) and streams
- * results back through the A2A event bus.
+ * Each A2A context spawns a full Studio Code agent session. The session persists
+ * across execute() calls so that the agent can ask questions back to the calling
+ * agent (via A2A's input-required state) and resume when answers arrive.
  */
 export class StudioCodeExecutor implements AgentExecutor {
-	private activeTasks = new Map< string, { abort: () => void } >();
+	private sessions = new Map< string, AgentSession >();
 
 	async execute( ctx: RequestContext, bus: ExecutionEventBus ): Promise< void > {
-		const { taskId, contextId, userMessage, task } = ctx;
-		const prompt = extractPrompt( ctx );
+		const { taskId, contextId, userMessage } = ctx;
+		const userText = extractPrompt( ctx );
 
-		// Create task if new
-		if ( ! task ) {
+		let session = this.sessions.get( contextId );
+
+		if ( session?.pendingQuestion ) {
+			// Continuation — the client is answering a pending question.
+			// Resolve the promise so the agent can continue.
+			const { questions, resolve } = session.pendingQuestion;
+			session.pendingQuestion = null;
+
+			const answers: Record< string, string > = {};
+			for ( const q of questions ) {
+				answers[ q.question ] = userText;
+			}
+			resolve( answers );
+
+			// Report that we're working again
+			bus.publish( {
+				kind: 'status-update',
+				taskId,
+				contextId,
+				final: false,
+				status: {
+					state: 'working',
+					timestamp: new Date().toISOString(),
+					message: agentMessage( 'Resuming...' ),
+				},
+			} );
+		} else if ( ! session ) {
+			// New task — create session and start the agent
+			session = new AgentSession();
+			this.sessions.set( contextId, session );
+
 			bus.publish( {
 				kind: 'task',
 				id: taskId,
@@ -93,80 +246,66 @@ export class StudioCodeExecutor implements AgentExecutor {
 				},
 				history: [ userMessage ],
 			} );
+
+			bus.publish( {
+				kind: 'status-update',
+				taskId,
+				contextId,
+				final: false,
+				status: {
+					state: 'working',
+					timestamp: new Date().toISOString(),
+					message: agentMessage( 'Starting Studio Code agent...' ),
+				},
+			} );
+
+			session.start( userText );
 		}
 
-		// Report working
-		bus.publish( {
-			kind: 'status-update',
-			taskId,
-			contextId,
-			final: false,
-			status: {
-				state: 'working',
-				timestamp: new Date().toISOString(),
-				message: agentMessage( 'Starting Studio Code agent...' ),
-			},
-		} );
+		// Drain events until the agent finishes or asks a question
+		await this.drainEvents( session, taskId, contextId, bus );
+	}
 
-		let aborted = false;
-		const agentConfig: AiAgentConfig = {
-			prompt,
-			maxTurns: 50,
-			// In A2A mode, auto-approve tool calls within trusted roots.
-			// The agent's security model still gates filesystem access.
-			onAskUser: async ( questions ) => {
-				// Report that we need input, with the questions as context
-				const questionText = questions
-					.map( ( q ) => {
-						const opts = q.options.map( ( o ) => o.label ).join( ', ' );
-						return `${ q.question } (${ opts })`;
-					} )
-					.join( '\n' );
-
+	private async drainEvents(
+		session: AgentSession,
+		taskId: string,
+		contextId: string,
+		bus: ExecutionEventBus
+	): Promise< void > {
+		while ( true ) {
+			const event = await session.nextEvent();
+			if ( ! event ) {
 				bus.publish( {
 					kind: 'status-update',
 					taskId,
 					contextId,
-					final: false,
+					final: true,
 					status: {
-						state: 'input-required',
+						state: session.aborted ? 'canceled' : 'completed',
 						timestamp: new Date().toISOString(),
-						message: agentMessage( questionText ),
 					},
 				} );
+				this.sessions.delete( contextId );
+				bus.finished();
+				return;
+			}
 
-				// For now, auto-approve with defaults. A full implementation would
-				// wait for the A2A client to send a continuation message.
-				const answers: Record< string, string > = {};
-				for ( const q of questions ) {
-					answers[ q.question ] = q.options[ 0 ]?.label ?? 'yes';
-				}
-				return answers;
-			},
-		};
-
-		const queryHandle = startAiAgent( agentConfig );
-
-		// Track for cancellation
-		this.activeTasks.set( taskId, {
-			abort: () => {
-				aborted = true;
-				queryHandle.interrupt();
-			},
-		} );
-
-		const collectedText: string[] = [];
-
-		try {
-			for await ( const message of queryHandle ) {
-				if ( aborted ) {
+			switch ( event.kind ) {
+				case 'text':
+					bus.publish( {
+						kind: 'status-update',
+						taskId,
+						contextId,
+						final: false,
+						status: {
+							state: 'working',
+							timestamp: new Date().toISOString(),
+							message: agentMessage( event.text ),
+						},
+					} );
 					break;
-				}
 
-				// Extract assistant text for streaming
-				const text = extractAssistantText( message );
-				if ( text ) {
-					collectedText.push( text );
+				case 'tool-use':
 					bus.publish( {
 						kind: 'status-update',
 						taskId,
@@ -175,34 +314,44 @@ export class StudioCodeExecutor implements AgentExecutor {
 						status: {
 							state: 'working',
 							timestamp: new Date().toISOString(),
-							message: agentMessage( text ),
+							message: agentMessage( `Using tool: ${ event.name }` ),
 						},
 					} );
-				}
+					break;
 
-				// Report tool usage as status updates
-				const toolUse = extractToolUse( message );
-				if ( toolUse ) {
+				case 'question': {
+					// Format questions for the calling agent
+					const questionText = event.questions
+						.map( ( q ) => {
+							const opts = q.options.map( ( o ) => o.label ).join( ', ' );
+							return opts ? `${ q.question }\nOptions: ${ opts }` : q.question;
+						} )
+						.join( '\n\n' );
+
+					// Store the resolver so the next execute() call can feed the answer
+					session.pendingQuestion = {
+						questions: event.questions,
+						resolve: event.resolve,
+					};
+
+					// Tell the client we need input, then return.
+					// The next execute() call will resolve the question and resume.
 					bus.publish( {
 						kind: 'status-update',
 						taskId,
 						contextId,
 						final: false,
 						status: {
-							state: 'working',
+							state: 'input-required',
 							timestamp: new Date().toISOString(),
-							message: agentMessage( `Using tool: ${ toolUse.name }` ),
+							message: agentMessage( questionText ),
 						},
 					} );
+					bus.finished();
+					return;
 				}
 
-				// Handle result messages
-				if ( message.type === 'result' ) {
-					const finalText =
-						message.subtype === 'success'
-							? message.result
-							: `Agent error: ${ message.subtype }`;
-
+				case 'result':
 					bus.publish( {
 						kind: 'artifact-update',
 						taskId,
@@ -210,75 +359,50 @@ export class StudioCodeExecutor implements AgentExecutor {
 						artifact: {
 							artifactId: uuidv4(),
 							name: 'Agent Response',
-							parts: [ { kind: 'text', text: finalText } ],
+							parts: [ { kind: 'text', text: event.text } ],
 						},
 					} );
-
 					bus.publish( {
 						kind: 'status-update',
 						taskId,
 						contextId,
 						final: true,
 						status: {
-							state: message.subtype === 'success' ? 'completed' : 'failed',
+							state: event.success ? 'completed' : 'failed',
 							timestamp: new Date().toISOString(),
 						},
 					} );
+					this.sessions.delete( contextId );
 					bus.finished();
 					return;
-				}
+
+				case 'error':
+					bus.publish( {
+						kind: 'status-update',
+						taskId,
+						contextId,
+						final: true,
+						status: {
+							state: 'failed',
+							timestamp: new Date().toISOString(),
+							message: agentMessage( `Agent failed: ${ event.message }` ),
+						},
+					} );
+					this.sessions.delete( contextId );
+					bus.finished();
+					return;
+
+				case 'done':
+					this.sessions.delete( contextId );
+					bus.finished();
+					return;
 			}
-
-			// If we reach here without a result message, the agent finished normally
-			const finalOutput =
-				collectedText.length > 0
-					? collectedText.join( '\n\n' )
-					: 'Agent completed without output.';
-
-			bus.publish( {
-				kind: 'artifact-update',
-				taskId,
-				contextId,
-				artifact: {
-					artifactId: uuidv4(),
-					name: 'Agent Response',
-					parts: [ { kind: 'text', text: finalOutput } ],
-				},
-			} );
-
-			bus.publish( {
-				kind: 'status-update',
-				taskId,
-				contextId,
-				final: true,
-				status: {
-					state: aborted ? 'canceled' : 'completed',
-					timestamp: new Date().toISOString(),
-				},
-			} );
-		} catch ( error ) {
-			const errorMessage = error instanceof Error ? error.message : String( error );
-			bus.publish( {
-				kind: 'status-update',
-				taskId,
-				contextId,
-				final: true,
-				status: {
-					state: 'failed',
-					timestamp: new Date().toISOString(),
-					message: agentMessage( `Agent failed: ${ errorMessage }` ),
-				},
-			} );
-		} finally {
-			this.activeTasks.delete( taskId );
-			bus.finished();
 		}
 	}
 
 	async cancelTask( taskId: string ): Promise< void > {
-		const active = this.activeTasks.get( taskId );
-		if ( active ) {
-			active.abort();
+		for ( const session of this.sessions.values() ) {
+			session.interrupt();
 		}
 	}
 }

--- a/apps/cli/a2a-server/executor.ts
+++ b/apps/cli/a2a-server/executor.ts
@@ -1,0 +1,284 @@
+import { v4 as uuidv4 } from 'uuid';
+import { startAiAgent, type AiAgentConfig } from 'cli/ai/agent';
+import type { Message } from '@a2a-js/sdk';
+import type {
+	AgentExecutor,
+	ExecutionEventBus,
+	RequestContext,
+} from '@a2a-js/sdk/server';
+import type { SDKMessage } from '@anthropic-ai/claude-agent-sdk';
+
+/**
+ * Helper to create a well-formed A2A Message.
+ */
+function agentMessage( text: string ): Message {
+	return {
+		kind: 'message',
+		messageId: uuidv4(),
+		role: 'agent',
+		parts: [ { kind: 'text', text } ],
+	};
+}
+
+/**
+ * Extracts the user's text prompt from an A2A message.
+ */
+function extractPrompt( ctx: RequestContext ): string {
+	const parts = ctx.userMessage.parts ?? [];
+	const textParts = parts
+		.filter( ( p ): p is { kind: 'text'; text: string } => p.kind === 'text' )
+		.map( ( p ) => p.text );
+	return textParts.join( '\n' ) || 'Hello';
+}
+
+/**
+ * Extracts displayable text from an SDK assistant message.
+ */
+function extractAssistantText( message: SDKMessage ): string | null {
+	if ( message.type !== 'assistant' ) {
+		return null;
+	}
+	const texts: string[] = [];
+	for ( const block of message.message.content ) {
+		if ( block.type === 'text' && block.text ) {
+			texts.push( block.text );
+		}
+	}
+	return texts.length > 0 ? texts.join( '\n' ) : null;
+}
+
+/**
+ * Extracts tool use info from an SDK assistant message for status reporting.
+ */
+function extractToolUse(
+	message: SDKMessage
+): { name: string; input?: Record< string, unknown > } | null {
+	if ( message.type !== 'assistant' ) {
+		return null;
+	}
+	for ( const block of message.message.content ) {
+		if ( block.type === 'tool_use' ) {
+			return {
+				name: ( block as { name: string } ).name,
+				input: ( block as { input?: Record< string, unknown > } ).input,
+			};
+		}
+	}
+	return null;
+}
+
+/**
+ * A2A AgentExecutor that wraps the Studio Code AI agent.
+ *
+ * Each A2A task spawns a full Studio Code agent session. The agent runs
+ * its own loop (Claude SDK → MCP tools → Playwright browser) and streams
+ * results back through the A2A event bus.
+ */
+export class StudioCodeExecutor implements AgentExecutor {
+	private activeTasks = new Map< string, { abort: () => void } >();
+
+	async execute( ctx: RequestContext, bus: ExecutionEventBus ): Promise< void > {
+		const { taskId, contextId, userMessage, task } = ctx;
+		const prompt = extractPrompt( ctx );
+
+		// Create task if new
+		if ( ! task ) {
+			bus.publish( {
+				kind: 'task',
+				id: taskId,
+				contextId,
+				status: {
+					state: 'submitted',
+					timestamp: new Date().toISOString(),
+				},
+				history: [ userMessage ],
+			} );
+		}
+
+		// Report working
+		bus.publish( {
+			kind: 'status-update',
+			taskId,
+			contextId,
+			final: false,
+			status: {
+				state: 'working',
+				timestamp: new Date().toISOString(),
+				message: agentMessage( 'Starting Studio Code agent...' ),
+			},
+		} );
+
+		let aborted = false;
+		const agentConfig: AiAgentConfig = {
+			prompt,
+			maxTurns: 50,
+			// In A2A mode, auto-approve tool calls within trusted roots.
+			// The agent's security model still gates filesystem access.
+			onAskUser: async ( questions ) => {
+				// Report that we need input, with the questions as context
+				const questionText = questions
+					.map( ( q ) => {
+						const opts = q.options.map( ( o ) => o.label ).join( ', ' );
+						return `${ q.question } (${ opts })`;
+					} )
+					.join( '\n' );
+
+				bus.publish( {
+					kind: 'status-update',
+					taskId,
+					contextId,
+					final: false,
+					status: {
+						state: 'input-required',
+						timestamp: new Date().toISOString(),
+						message: agentMessage( questionText ),
+					},
+				} );
+
+				// For now, auto-approve with defaults. A full implementation would
+				// wait for the A2A client to send a continuation message.
+				const answers: Record< string, string > = {};
+				for ( const q of questions ) {
+					answers[ q.question ] = q.options[ 0 ]?.label ?? 'yes';
+				}
+				return answers;
+			},
+		};
+
+		const queryHandle = startAiAgent( agentConfig );
+
+		// Track for cancellation
+		this.activeTasks.set( taskId, {
+			abort: () => {
+				aborted = true;
+				queryHandle.interrupt();
+			},
+		} );
+
+		const collectedText: string[] = [];
+
+		try {
+			for await ( const message of queryHandle ) {
+				if ( aborted ) {
+					break;
+				}
+
+				// Extract assistant text for streaming
+				const text = extractAssistantText( message );
+				if ( text ) {
+					collectedText.push( text );
+					bus.publish( {
+						kind: 'status-update',
+						taskId,
+						contextId,
+						final: false,
+						status: {
+							state: 'working',
+							timestamp: new Date().toISOString(),
+							message: agentMessage( text ),
+						},
+					} );
+				}
+
+				// Report tool usage as status updates
+				const toolUse = extractToolUse( message );
+				if ( toolUse ) {
+					bus.publish( {
+						kind: 'status-update',
+						taskId,
+						contextId,
+						final: false,
+						status: {
+							state: 'working',
+							timestamp: new Date().toISOString(),
+							message: agentMessage( `Using tool: ${ toolUse.name }` ),
+						},
+					} );
+				}
+
+				// Handle result messages
+				if ( message.type === 'result' ) {
+					const finalText =
+						message.subtype === 'success'
+							? message.result
+							: `Agent error: ${ message.subtype }`;
+
+					bus.publish( {
+						kind: 'artifact-update',
+						taskId,
+						contextId,
+						artifact: {
+							artifactId: uuidv4(),
+							name: 'Agent Response',
+							parts: [ { kind: 'text', text: finalText } ],
+						},
+					} );
+
+					bus.publish( {
+						kind: 'status-update',
+						taskId,
+						contextId,
+						final: true,
+						status: {
+							state: message.subtype === 'success' ? 'completed' : 'failed',
+							timestamp: new Date().toISOString(),
+						},
+					} );
+					bus.finished();
+					return;
+				}
+			}
+
+			// If we reach here without a result message, the agent finished normally
+			const finalOutput =
+				collectedText.length > 0
+					? collectedText.join( '\n\n' )
+					: 'Agent completed without output.';
+
+			bus.publish( {
+				kind: 'artifact-update',
+				taskId,
+				contextId,
+				artifact: {
+					artifactId: uuidv4(),
+					name: 'Agent Response',
+					parts: [ { kind: 'text', text: finalOutput } ],
+				},
+			} );
+
+			bus.publish( {
+				kind: 'status-update',
+				taskId,
+				contextId,
+				final: true,
+				status: {
+					state: aborted ? 'canceled' : 'completed',
+					timestamp: new Date().toISOString(),
+				},
+			} );
+		} catch ( error ) {
+			const errorMessage = error instanceof Error ? error.message : String( error );
+			bus.publish( {
+				kind: 'status-update',
+				taskId,
+				contextId,
+				final: true,
+				status: {
+					state: 'failed',
+					timestamp: new Date().toISOString(),
+					message: agentMessage( `Agent failed: ${ errorMessage }` ),
+				},
+			} );
+		} finally {
+			this.activeTasks.delete( taskId );
+			bus.finished();
+		}
+	}
+
+	async cancelTask( taskId: string ): Promise< void > {
+		const active = this.activeTasks.get( taskId );
+		if ( active ) {
+			active.abort();
+		}
+	}
+}

--- a/apps/cli/a2a-server/index.ts
+++ b/apps/cli/a2a-server/index.ts
@@ -1,0 +1,67 @@
+import express from 'express';
+import type { Request, Response } from 'express';
+import { AGENT_CARD_PATH } from '@a2a-js/sdk';
+import { DefaultRequestHandler, InMemoryTaskStore } from '@a2a-js/sdk/server';
+import { jsonRpcHandler, restHandler, UserBuilder } from '@a2a-js/sdk/server/express';
+import { buildAgentCard, getPort } from './agent-card.js';
+import { StudioCodeExecutor } from './executor.js';
+
+const port = getPort();
+const agentCard = buildAgentCard( port );
+const taskStore = new InMemoryTaskStore();
+const executor = new StudioCodeExecutor();
+const handler = new DefaultRequestHandler( agentCard, taskStore, executor );
+
+const userBuilder = UserBuilder.noAuthentication;
+
+const app = express();
+// Do NOT add express.json() globally — the A2A SDK handlers parse request bodies themselves.
+// Adding it would consume the stream before the handlers can read it.
+
+// Agent Card discovery
+// Express 5 doesn't match dot-prefixed segments (`.well-known`) with app.get(),
+// so we use a manual middleware that checks req.path.
+app.use( ( req: Request, res: Response, next ) => {
+	if ( req.method === 'GET' && req.path === `/${ AGENT_CARD_PATH }` ) {
+		res.json( agentCard );
+		return;
+	}
+	next();
+} );
+
+// Health check
+app.get( '/health', ( _req: Request, res: Response ) => {
+	res.json( { status: 'ok', agent: agentCard.name, version: agentCard.version } );
+} );
+
+// A2A JSON-RPC at /jsonrpc (standard) and / (for clients that POST to root)
+app.post( '/jsonrpc', jsonRpcHandler( { requestHandler: handler, userBuilder } ) );
+app.post( '/', jsonRpcHandler( { requestHandler: handler, userBuilder } ) );
+
+// A2A REST endpoints at root — Gemini CLI uses {agent_url}/message/stream etc.
+app.use( '/', restHandler( { requestHandler: handler, userBuilder } ) );
+
+const server = app.listen( port, () => {
+	const cardUrl = `http://localhost:${ port }/${ AGENT_CARD_PATH }`;
+	console.log( `\nWordPress Studio Code A2A Server` );
+	console.log( `================================` );
+	console.log( `Agent Card: ${ cardUrl }` );
+	console.log( `Health:     http://localhost:${ port }/health` );
+	console.log( '' );
+	console.log( `To connect from Gemini CLI, create ~/.gemini/agents/studio-code.md:` );
+	console.log( '' );
+	console.log( `  ---` );
+	console.log( `  kind: remote` );
+	console.log( `  name: studio-code` );
+	console.log( `  agent_card_url: ${ cardUrl }` );
+	console.log( `  ---` );
+	console.log( '' );
+} );
+
+process.on( 'SIGINT', () => {
+	console.log( '\nShutting down...' );
+	server.close( () => process.exit( 0 ) );
+} );
+process.on( 'SIGTERM', () => {
+	server.close( () => process.exit( 0 ) );
+} );

--- a/apps/cli/index.ts
+++ b/apps/cli/index.ts
@@ -95,6 +95,21 @@ async function main() {
 	const studioCodeCommandBuilder = async ( aiYargs: StudioArgv ) => {
 		const { registerCommand: registerAiCommand } = await import( 'cli/commands/ai' );
 		registerAiCommand( aiYargs );
+		aiYargs.command( {
+			command: 'serve',
+			describe: __( 'Start A2A server for agent-to-agent communication' ),
+			builder: ( serveYargs: StudioArgv ) => {
+				return serveYargs.option( 'port', {
+					type: 'number',
+					description: __( 'Port to listen on' ),
+					default: 41567,
+				} );
+			},
+			handler: async ( argv ) => {
+				process.env.STUDIO_A2A_PORT = String( ( argv as { port?: number } ).port ?? 41567 );
+				await import( 'cli/a2a-server/index.js' );
+			},
+		} );
 		aiYargs.command( 'sessions', __( 'Manage code sessions' ), async ( sessionsYargs ) => {
 			const [
 				{ registerCommand: registerAiSessionsDeleteCommand },

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -53,9 +53,13 @@
 		"yargs": "^18.0.0",
 		"yargs-parser": "^22.0.0",
 		"yauzl": "^3.3.0",
-		"zod": "^4.3.6"
+		"zod": "^4.3.6",
+		"@a2a-js/sdk": "^0.3.13",
+		"express": "^5.1.0",
+		"uuid": "^11.1.0"
 	},
 	"scripts": {
+		"a2a:serve": "node dist/cli/a2a-server.mjs",
 		"build": "vite build --config ./vite.config.dev.ts",
 		"build:prod": "vite build --config ./vite.config.prod.ts",
 		"build:npm": "vite build --config ./vite.config.npm.ts",
@@ -69,6 +73,8 @@
 	"devDependencies": {
 		"@studio/common": "file:../../tools/common",
 		"@types/archiver": "^6.0.4",
+		"@types/express": "^5.0.0",
+		"@types/uuid": "^10.0.0",
 		"@types/http-proxy": "^1.17.17",
 		"@types/node-forge": "^1.3.14",
 		"@types/yargs": "^17.0.35",

--- a/apps/cli/vite.config.base.ts
+++ b/apps/cli/vite.config.base.ts
@@ -29,6 +29,7 @@ export const baseConfig = defineConfig( {
 		lib: {
 			entry: {
 				main: resolve( __dirname, 'index.ts' ),
+				'a2a-server': resolve( __dirname, 'a2a-server/index.ts' ),
 				'process-manager-daemon': resolve( __dirname, 'process-manager-daemon.ts' ),
 				'proxy-daemon': resolve( __dirname, 'proxy-daemon.ts' ),
 				'wordpress-server-child': resolve( __dirname, 'wordpress-server-child.ts' ),

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
 			"hasInstallScript": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
+				"@a2a-js/sdk": "^0.3.13",
 				"@anthropic-ai/claude-agent-sdk": "^0.2.45",
 				"@inquirer/prompts": "^8.3.2",
 				"@mariozechner/pi-tui": "^0.54.0",
@@ -69,6 +70,7 @@
 				"atomically": "^2.1.1",
 				"chalk": "^5.6.2",
 				"cli-table3": "^0.6.5",
+				"express": "^5.1.0",
 				"fs-extra": "^11.3.4",
 				"http-proxy": "^1.18.1",
 				"node-forge": "^1.3.3",
@@ -78,6 +80,7 @@
 				"semver": "^7.7.4",
 				"tar": "^7.5.13",
 				"trash": "^10.0.1",
+				"uuid": "^11.1.0",
 				"yargs": "^18.0.0",
 				"yargs-parser": "^22.0.0",
 				"yauzl": "^3.3.0",
@@ -89,8 +92,10 @@
 			"devDependencies": {
 				"@studio/common": "file:../../tools/common",
 				"@types/archiver": "^6.0.4",
+				"@types/express": "^5.0.0",
 				"@types/http-proxy": "^1.17.17",
 				"@types/node-forge": "^1.3.14",
+				"@types/uuid": "^10.0.0",
 				"@types/yargs": "^17.0.35",
 				"glob": "^13.0.6",
 				"vite": "^7.3.1",
@@ -428,6 +433,43 @@
 				}
 			}
 		},
+		"apps/cli/node_modules/accepts": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+			"integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+			"license": "MIT",
+			"dependencies": {
+				"mime-types": "^3.0.0",
+				"negotiator": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"apps/cli/node_modules/body-parser": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+			"integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+			"license": "MIT",
+			"dependencies": {
+				"bytes": "^3.1.2",
+				"content-type": "^1.0.5",
+				"debug": "^4.4.3",
+				"http-errors": "^2.0.0",
+				"iconv-lite": "^0.7.0",
+				"on-finished": "^2.4.1",
+				"qs": "^6.14.1",
+				"raw-body": "^3.0.1",
+				"type-is": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
 		"apps/cli/node_modules/chardet": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz",
@@ -441,6 +483,130 @@
 			"license": "ISC",
 			"engines": {
 				"node": ">= 12"
+			}
+		},
+		"apps/cli/node_modules/content-disposition": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+			"integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"apps/cli/node_modules/cookie-signature": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+			"integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.6.0"
+			}
+		},
+		"apps/cli/node_modules/encodeurl": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+			"integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"apps/cli/node_modules/express": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+			"integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+			"license": "MIT",
+			"dependencies": {
+				"accepts": "^2.0.0",
+				"body-parser": "^2.2.1",
+				"content-disposition": "^1.0.0",
+				"content-type": "^1.0.5",
+				"cookie": "^0.7.1",
+				"cookie-signature": "^1.2.1",
+				"debug": "^4.4.0",
+				"depd": "^2.0.0",
+				"encodeurl": "^2.0.0",
+				"escape-html": "^1.0.3",
+				"etag": "^1.8.1",
+				"finalhandler": "^2.1.0",
+				"fresh": "^2.0.0",
+				"http-errors": "^2.0.0",
+				"merge-descriptors": "^2.0.0",
+				"mime-types": "^3.0.0",
+				"on-finished": "^2.4.1",
+				"once": "^1.4.0",
+				"parseurl": "^1.3.3",
+				"proxy-addr": "^2.0.7",
+				"qs": "^6.14.0",
+				"range-parser": "^1.2.1",
+				"router": "^2.2.0",
+				"send": "^1.1.0",
+				"serve-static": "^2.2.0",
+				"statuses": "^2.0.1",
+				"type-is": "^2.0.1",
+				"vary": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"apps/cli/node_modules/finalhandler": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+			"integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.4.0",
+				"encodeurl": "^2.0.0",
+				"escape-html": "^1.0.3",
+				"on-finished": "^2.4.1",
+				"parseurl": "^1.3.3",
+				"statuses": "^2.0.1"
+			},
+			"engines": {
+				"node": ">= 18.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"apps/cli/node_modules/fresh": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+			"integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"apps/cli/node_modules/http-errors": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+			"integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+			"license": "MIT",
+			"dependencies": {
+				"depd": "~2.0.0",
+				"inherits": "~2.0.4",
+				"setprototypeof": "~1.2.0",
+				"statuses": "~2.0.2",
+				"toidentifier": "~1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
 			}
 		},
 		"apps/cli/node_modules/iconv-lite": {
@@ -459,6 +625,52 @@
 				"url": "https://opencollective.com/express"
 			}
 		},
+		"apps/cli/node_modules/media-typer": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+			"integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"apps/cli/node_modules/merge-descriptors": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+			"integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"apps/cli/node_modules/mime-db": {
+			"version": "1.54.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+			"integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"apps/cli/node_modules/mime-types": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+			"integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+			"license": "MIT",
+			"dependencies": {
+				"mime-db": "^1.54.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
 		"apps/cli/node_modules/mute-stream": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-3.0.0.tgz",
@@ -466,6 +678,90 @@
 			"license": "ISC",
 			"engines": {
 				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"apps/cli/node_modules/negotiator": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+			"integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"apps/cli/node_modules/qs": {
+			"version": "6.15.1",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+			"integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"side-channel": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=0.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"apps/cli/node_modules/raw-body": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+			"integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+			"license": "MIT",
+			"dependencies": {
+				"bytes": "~3.1.2",
+				"http-errors": "~2.0.1",
+				"iconv-lite": "~0.7.0",
+				"unpipe": "~1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.10"
+			}
+		},
+		"apps/cli/node_modules/send": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+			"integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.4.3",
+				"encodeurl": "^2.0.0",
+				"escape-html": "^1.0.3",
+				"etag": "^1.8.1",
+				"fresh": "^2.0.0",
+				"http-errors": "^2.0.1",
+				"mime-types": "^3.0.2",
+				"ms": "^2.1.3",
+				"on-finished": "^2.4.1",
+				"range-parser": "^1.2.1",
+				"statuses": "^2.0.2"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"apps/cli/node_modules/serve-static": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+			"integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+			"license": "MIT",
+			"dependencies": {
+				"encodeurl": "^2.0.0",
+				"escape-html": "^1.0.3",
+				"parseurl": "^1.3.3",
+				"send": "^1.2.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
 			}
 		},
 		"apps/cli/node_modules/signal-exit": {
@@ -478,6 +774,42 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"apps/cli/node_modules/statuses": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+			"integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"apps/cli/node_modules/type-is": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+			"integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+			"license": "MIT",
+			"dependencies": {
+				"content-type": "^1.0.5",
+				"media-typer": "^1.1.0",
+				"mime-types": "^3.0.0"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"apps/cli/node_modules/uuid": {
+			"version": "11.1.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+			"integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"license": "MIT",
+			"bin": {
+				"uuid": "dist/esm/bin/uuid"
 			}
 		},
 		"apps/studio": {
@@ -1055,6 +1387,47 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@a2a-js/sdk": {
+			"version": "0.3.13",
+			"resolved": "https://registry.npmjs.org/@a2a-js/sdk/-/sdk-0.3.13.tgz",
+			"integrity": "sha512-BZr0f9JVNQs3GKOM9xINWCh6OKIJWZFPyqqVqTym5mxO2Eemc6I/0zL7zWnljHzGdaf5aZQyQN5xa6PSH62q+A==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"uuid": "^11.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@bufbuild/protobuf": "^2.10.2",
+				"@grpc/grpc-js": "^1.11.0",
+				"express": "^4.21.2 || ^5.1.0"
+			},
+			"peerDependenciesMeta": {
+				"@bufbuild/protobuf": {
+					"optional": true
+				},
+				"@grpc/grpc-js": {
+					"optional": true
+				},
+				"express": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@a2a-js/sdk/node_modules/uuid": {
+			"version": "11.1.0",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+			"integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"license": "MIT",
+			"bin": {
+				"uuid": "dist/esm/bin/uuid"
 			}
 		},
 		"node_modules/@adobe/css-tools": {
@@ -10456,6 +10829,17 @@
 				"@babel/types": "^7.28.2"
 			}
 		},
+		"node_modules/@types/body-parser": {
+			"version": "1.19.6",
+			"resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+			"integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/connect": "*",
+				"@types/node": "*"
+			}
+		},
 		"node_modules/@types/btoa-lite": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/@types/btoa-lite/-/btoa-lite-1.0.2.tgz",
@@ -10536,6 +10920,31 @@
 				"@types/estree": "*"
 			}
 		},
+		"node_modules/@types/express": {
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
+			"integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/body-parser": "*",
+				"@types/express-serve-static-core": "^5.0.0",
+				"@types/serve-static": "^2"
+			}
+		},
+		"node_modules/@types/express-serve-static-core": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.1.tgz",
+			"integrity": "sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*",
+				"@types/qs": "*",
+				"@types/range-parser": "*",
+				"@types/send": "*"
+			}
+		},
 		"node_modules/@types/follow-redirects": {
 			"version": "1.14.4",
 			"dev": true,
@@ -10572,6 +10981,13 @@
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
 			"integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/http-errors": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+			"integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -10703,6 +11119,20 @@
 			"version": "15.7.15",
 			"license": "MIT"
 		},
+		"node_modules/@types/qs": {
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.0.tgz",
+			"integrity": "sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/range-parser": {
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+			"integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@types/react": {
 			"version": "18.3.27",
 			"license": "MIT",
@@ -10739,6 +11169,27 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@types/send": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+			"integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*"
+			}
+		},
+		"node_modules/@types/serve-static": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-2.2.0.tgz",
+			"integrity": "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/http-errors": "*",
+				"@types/node": "*"
+			}
+		},
 		"node_modules/@types/shell-quote": {
 			"version": "1.7.5",
 			"dev": true,
@@ -10759,6 +11210,13 @@
 		},
 		"node_modules/@types/use-sync-external-store": {
 			"version": "0.0.6",
+			"license": "MIT"
+		},
+		"node_modules/@types/uuid": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+			"integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@types/winreg": {


### PR DESCRIPTION
## Related issues

- Related to agent interoperability and multi-agent delegation

## How AI was used in this PR

Claude Opus generated the A2A server wrapper, agent card, and executor. Miguel tested the integration end-to-end with Gemini CLI successfully delegating WordPress site creation to Studio Code's full agent runtime.

## Proposed Changes

Wraps Studio Code as an [A2A (Agent-to-Agent) protocol](https://a2a-protocol.org/) server, enabling external AI agents to delegate WordPress tasks to Studio Code's full agent runtime.

- **New command**: `studio code serve [--port 41567]` — starts an A2A server
- **Agent Card** at `/.well-known/agent-card.json` — describes Studio Code's capabilities (7 skills: site creation, management, preview, performance audit, screenshot, data liberation, taxonomy optimization)
- **Executor** wraps `startAiAgent()` — each A2A task spawns a full Studio Code session with all tools (Playwright browser, MCP servers, block validation, etc.)
- **Streaming** — agent progress (text output, tool usage) streams back as A2A status updates

### How it works

```
External Agent (Gemini CLI, etc.)
    ↓ A2A protocol (JSON-RPC / REST + SSE)
Studio Code A2A Server (Express)
    ↓ startAiAgent()
Claude Agent SDK → MCP Tools → Playwright → WordPress
    ↑ streams results back
```

### Why A2A?

A2A is the [AAIF](https://www.linuxfoundation.org/press/linux-foundation-announces-the-formation-of-the-agentic-ai-foundation)-governed protocol for agent-to-agent communication (complementary to MCP which handles agent-to-tools). Gemini CLI already supports A2A clients natively. This PoC validates that Studio Code can be exposed as a delegatable agent — not just a set of tools, but the full agent brain with its WordPress knowledge, design philosophy, security model, and tool orchestration.

### Tested with Gemini CLI

Gemini CLI config (`~/.gemini/agents/studio-code.md`):
```yaml
---
kind: remote
name: studio-code
agent_card_url: http://localhost:41567/.well-known/agent-card.json
---
```

Gemini successfully delegates WordPress tasks to Studio Code's agent runtime.

### What's next (not in this PoC)

- [ ] Authentication (currently `noAuthentication`)
- [ ] Interactive approval flow (currently auto-approves with defaults; should use A2A's `input-required` state)
- [ ] Session persistence in A2A mode
- [ ] Multi-task concurrency (currently `InMemoryTaskStore`)
- [ ] Claude Code A2A support (when available — Anthropic co-founded AAIF but hasn't shipped A2A client support yet)

## Testing Instructions

1. Build: `npm run cli:build`
2. Start server: `node apps/cli/dist/cli/main.mjs code serve`
3. Verify agent card: `curl http://localhost:41567/.well-known/agent-card.json`
4. Verify health: `curl http://localhost:41567/health`
5. (Optional) Connect from Gemini CLI:
   - Create `~/.gemini/agents/studio-code.md` with the config above
   - Run `/agents list` in Gemini CLI to verify discovery
   - Ask Gemini to create a WordPress site

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?

🤖 Generated with [Claude Code](https://claude.com/claude-code)