### PR TITLE
Fix flaky edit-site-details test on Windows CI

### DIFF
--- a/apps/studio/src/modules/site-settings/tests/edit-site-details.test.tsx
+++ b/apps/studio/src/modules/site-settings/tests/edit-site-details.test.tsx
@@ -414,7 +414,9 @@ describe( 'EditSiteDetails', () => {
 		await user.click( saveButton );
 
 		// Check that controls are disabled during save
-		expect( screen.getByRole( 'button', { name: 'Saving…' } ) ).toBeInTheDocument();
+		await waitFor( () => {
+			expect( screen.getByRole( 'button', { name: 'Saving…' } ) ).toBeInTheDocument();
+		} );
 		expect( screen.getByLabelText( 'Site name' ) ).toBeDisabled();
 		expect( screen.getByLabelText( 'PHP version' ) ).toBeDisabled();
 		expect( screen.getByLabelText( 'WordPress version' ) ).toBeDisabled();


### PR DESCRIPTION
## Related issues

- Related to Build #14057 unit-tests-on-windows failure

## How AI was used in this PR

Claude identified the root cause from the CI log and applied the fix.

## Proposed Changes

- Wrap the `Saving…` button assertion in `waitFor()` in the "should disable form controls when site is being edited" test. The synchronous assertion was racing against React's state update, causing intermittent failures on Windows CI where the re-render hadn't completed before the check ran.

## Testing Instructions

- Run `npm test -- apps/studio/src/modules/site-settings/tests/edit-site-details.test.tsx` and confirm all 19 tests pass.
- Check that CI passes.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?