### PR TITLE
Show real-time progress feedback during push/pull from Studio Code

### DIFF
--- a/apps/cli/ai/tests/tools.test.ts
+++ b/apps/cli/ai/tests/tools.test.ts
@@ -209,37 +209,36 @@ describe( 'Studio AI MCP tools', () => {
 		const previousCallback = vi.fn();
 		setProgressCallback( previousCallback );
 
-		// preview_create internally calls captureCommandOutput which should forward progress
 		vi.mocked( runCreatePreviewCommand ).mockImplementation( async () => {
 			const currentCallback = getProgressCallback();
 			currentCallback?.( 'Creating preview…' );
-			currentCallback?.( 'Almost done…' );
 		} );
 
 		await getTool( 'preview_create' ).handler( { nameOrPath: 'My Site' } as never, null );
 
 		expect( previousCallback ).toHaveBeenCalledWith( 'Creating preview…' );
-		expect( previousCallback ).toHaveBeenCalledWith( 'Almost done…' );
 	} );
 
-	it( 'deduplicates consecutive identical progress messages', async () => {
+	it( 'throttles rapid progress messages and flushes the last one', async () => {
 		const previousCallback = vi.fn();
 		setProgressCallback( previousCallback );
 
 		vi.mocked( runCreatePreviewCommand ).mockImplementation( async () => {
 			const currentCallback = getProgressCallback();
-			currentCallback?.( 'Uploading… (3%)' );
-			currentCallback?.( 'Uploading… (3%)' );
-			currentCallback?.( 'Uploading… (3%)' );
-			currentCallback?.( 'Uploading… (4%)' );
-			currentCallback?.( 'Uploading… (4%)' );
+			// First message goes through immediately
+			currentCallback?.( 'Extracting… (1/100)' );
+			// These are all within the throttle window so they get buffered
+			currentCallback?.( 'Extracting… (2/100)' );
+			currentCallback?.( 'Extracting… (3/100)' );
+			currentCallback?.( 'Extracting… (4/100)' );
 		} );
 
 		await getTool( 'preview_create' ).handler( { nameOrPath: 'My Site' } as never, null );
 
+		// First message forwarded immediately, last pending message flushed on completion
 		expect( previousCallback ).toHaveBeenCalledTimes( 2 );
-		expect( previousCallback ).toHaveBeenCalledWith( 'Uploading… (3%)' );
-		expect( previousCallback ).toHaveBeenCalledWith( 'Uploading… (4%)' );
+		expect( previousCallback ).toHaveBeenCalledWith( 'Extracting… (1/100)' );
+		expect( previousCallback ).toHaveBeenCalledWith( 'Extracting… (4/100)' );
 	} );
 
 	it( 'rejects shell syntax in wp_cli post content before dispatching to WP-CLI', async () => {

--- a/apps/cli/ai/tests/tools.test.ts
+++ b/apps/cli/ai/tests/tools.test.ts
@@ -205,6 +205,43 @@ describe( 'Studio AI MCP tools', () => {
 		expect( getProgressCallback() ).toBe( previousCallback );
 	} );
 
+	it( 'forwards progress messages to the previous callback during command execution', async () => {
+		const previousCallback = vi.fn();
+		setProgressCallback( previousCallback );
+
+		// preview_create internally calls captureCommandOutput which should forward progress
+		vi.mocked( runCreatePreviewCommand ).mockImplementation( async () => {
+			const currentCallback = getProgressCallback();
+			currentCallback?.( 'Creating preview…' );
+			currentCallback?.( 'Almost done…' );
+		} );
+
+		await getTool( 'preview_create' ).handler( { nameOrPath: 'My Site' } as never, null );
+
+		expect( previousCallback ).toHaveBeenCalledWith( 'Creating preview…' );
+		expect( previousCallback ).toHaveBeenCalledWith( 'Almost done…' );
+	} );
+
+	it( 'deduplicates consecutive identical progress messages', async () => {
+		const previousCallback = vi.fn();
+		setProgressCallback( previousCallback );
+
+		vi.mocked( runCreatePreviewCommand ).mockImplementation( async () => {
+			const currentCallback = getProgressCallback();
+			currentCallback?.( 'Uploading… (3%)' );
+			currentCallback?.( 'Uploading… (3%)' );
+			currentCallback?.( 'Uploading… (3%)' );
+			currentCallback?.( 'Uploading… (4%)' );
+			currentCallback?.( 'Uploading… (4%)' );
+		} );
+
+		await getTool( 'preview_create' ).handler( { nameOrPath: 'My Site' } as never, null );
+
+		expect( previousCallback ).toHaveBeenCalledTimes( 2 );
+		expect( previousCallback ).toHaveBeenCalledWith( 'Uploading… (3%)' );
+		expect( previousCallback ).toHaveBeenCalledWith( 'Uploading… (4%)' );
+	} );
+
 	it( 'rejects shell syntax in wp_cli post content before dispatching to WP-CLI', async () => {
 		vi.mocked( isServerRunning ).mockResolvedValue( {
 			name: 'site-123',

--- a/apps/cli/ai/tests/tools.test.ts
+++ b/apps/cli/ai/tests/tools.test.ts
@@ -212,33 +212,13 @@ describe( 'Studio AI MCP tools', () => {
 		vi.mocked( runCreatePreviewCommand ).mockImplementation( async () => {
 			const currentCallback = getProgressCallback();
 			currentCallback?.( 'Creating preview…' );
+			currentCallback?.( 'Almost done…' );
 		} );
 
 		await getTool( 'preview_create' ).handler( { nameOrPath: 'My Site' } as never, null );
 
 		expect( previousCallback ).toHaveBeenCalledWith( 'Creating preview…' );
-	} );
-
-	it( 'throttles rapid progress messages and flushes the last one', async () => {
-		const previousCallback = vi.fn();
-		setProgressCallback( previousCallback );
-
-		vi.mocked( runCreatePreviewCommand ).mockImplementation( async () => {
-			const currentCallback = getProgressCallback();
-			// First message goes through immediately
-			currentCallback?.( 'Extracting… (1/100)' );
-			// These are all within the throttle window so they get buffered
-			currentCallback?.( 'Extracting… (2/100)' );
-			currentCallback?.( 'Extracting… (3/100)' );
-			currentCallback?.( 'Extracting… (4/100)' );
-		} );
-
-		await getTool( 'preview_create' ).handler( { nameOrPath: 'My Site' } as never, null );
-
-		// First message forwarded immediately, last pending message flushed on completion
-		expect( previousCallback ).toHaveBeenCalledTimes( 2 );
-		expect( previousCallback ).toHaveBeenCalledWith( 'Extracting… (1/100)' );
-		expect( previousCallback ).toHaveBeenCalledWith( 'Extracting… (4/100)' );
+		expect( previousCallback ).toHaveBeenCalledWith( 'Almost done…' );
 	} );
 
 	it( 'rejects shell syntax in wp_cli post content before dispatching to WP-CLI', async () => {

--- a/apps/cli/ai/tests/tools.test.ts
+++ b/apps/cli/ai/tests/tools.test.ts
@@ -217,8 +217,8 @@ describe( 'Studio AI MCP tools', () => {
 
 		await getTool( 'preview_create' ).handler( { nameOrPath: 'My Site' } as never, null );
 
-		expect( previousCallback ).toHaveBeenCalledWith( 'Creating preview…' );
-		expect( previousCallback ).toHaveBeenCalledWith( 'Almost done…' );
+		expect( previousCallback ).toHaveBeenCalledWith( 'Creating preview…', undefined );
+		expect( previousCallback ).toHaveBeenCalledWith( 'Almost done…', undefined );
 	} );
 
 	it( 'rejects shell syntax in wp_cli post content before dispatching to WP-CLI', async () => {

--- a/apps/cli/ai/tools.ts
+++ b/apps/cli/ai/tools.ts
@@ -194,22 +194,9 @@ export async function captureCommandOutput( fn: () => Promise< void > ): Promise
 		consoleOutput += args.map( String ).join( ' ' ) + '\n';
 	};
 	process.exitCode = undefined;
-	let lastForwardedTime = 0;
-	let pendingMessage: string | null = null;
-	const PROGRESS_THROTTLE_MS = 3000;
 	setProgressCallback( ( message ) => {
 		progressMessages.push( message );
-		if ( ! previousCallback ) {
-			return;
-		}
-		const now = Date.now();
-		if ( now - lastForwardedTime >= PROGRESS_THROTTLE_MS ) {
-			lastForwardedTime = now;
-			pendingMessage = null;
-			previousCallback( message );
-		} else {
-			pendingMessage = message;
-		}
+		previousCallback?.( message );
 	} );
 
 	try {
@@ -217,9 +204,6 @@ export async function captureCommandOutput( fn: () => Promise< void > ): Promise
 	} catch ( error ) {
 		thrownError = error;
 	} finally {
-		if ( pendingMessage && previousCallback ) {
-			previousCallback( pendingMessage );
-		}
 		console.log = originalConsoleLog;
 		console.table = originalConsoleTable;
 		setProgressCallback( previousCallback );

--- a/apps/cli/ai/tools.ts
+++ b/apps/cli/ai/tools.ts
@@ -194,8 +194,13 @@ export async function captureCommandOutput( fn: () => Promise< void > ): Promise
 		consoleOutput += args.map( String ).join( ' ' ) + '\n';
 	};
 	process.exitCode = undefined;
+	let lastForwardedMessage = '';
 	setProgressCallback( ( message ) => {
 		progressMessages.push( message );
+		if ( previousCallback && message !== lastForwardedMessage ) {
+			lastForwardedMessage = message;
+			previousCallback( message );
+		}
 	} );
 
 	try {

--- a/apps/cli/ai/tools.ts
+++ b/apps/cli/ai/tools.ts
@@ -194,12 +194,21 @@ export async function captureCommandOutput( fn: () => Promise< void > ): Promise
 		consoleOutput += args.map( String ).join( ' ' ) + '\n';
 	};
 	process.exitCode = undefined;
-	let lastForwardedMessage = '';
+	let lastForwardedTime = 0;
+	let pendingMessage: string | null = null;
+	const PROGRESS_THROTTLE_MS = 3000;
 	setProgressCallback( ( message ) => {
 		progressMessages.push( message );
-		if ( previousCallback && message !== lastForwardedMessage ) {
-			lastForwardedMessage = message;
+		if ( ! previousCallback ) {
+			return;
+		}
+		const now = Date.now();
+		if ( now - lastForwardedTime >= PROGRESS_THROTTLE_MS ) {
+			lastForwardedTime = now;
+			pendingMessage = null;
 			previousCallback( message );
+		} else {
+			pendingMessage = message;
 		}
 	} );
 
@@ -208,6 +217,9 @@ export async function captureCommandOutput( fn: () => Promise< void > ): Promise
 	} catch ( error ) {
 		thrownError = error;
 	} finally {
+		if ( pendingMessage && previousCallback ) {
+			previousCallback( pendingMessage );
+		}
 		console.log = originalConsoleLog;
 		console.table = originalConsoleTable;
 		setProgressCallback( previousCallback );

--- a/apps/cli/ai/tools.ts
+++ b/apps/cli/ai/tools.ts
@@ -194,9 +194,9 @@ export async function captureCommandOutput( fn: () => Promise< void > ): Promise
 		consoleOutput += args.map( String ).join( ' ' ) + '\n';
 	};
 	process.exitCode = undefined;
-	setProgressCallback( ( message ) => {
+	setProgressCallback( ( message, update ) => {
 		progressMessages.push( message );
-		previousCallback?.( message );
+		previousCallback?.( message, update );
 	} );
 
 	try {

--- a/apps/cli/ai/ui.ts
+++ b/apps/cli/ai/ui.ts
@@ -1749,6 +1749,7 @@ export class AiChatUI {
 	private showToolUse( toolLabel: string ): void {
 		this.showLoader( this.randomThinkingMessage() );
 		this.stopToolDotBlink();
+		this.lastProgressText = null;
 		this.toolDotLabel = toolLabel;
 		this.toolDotText = new Text( '\n ' + '⏺' + ' ' + toolLabel, 0, 0 );
 		this.messages.addChild( this.toolDotText );

--- a/apps/cli/ai/ui.ts
+++ b/apps/cli/ai/ui.ts
@@ -1321,11 +1321,19 @@ export class AiChatUI {
 		this.tui.requestRender();
 	}
 
+	private lastProgressText: Text | null = null;
+
 	setLoaderMessage( message: string ): void {
 		if ( ! message ) {
 			return;
 		}
-		this.messages.addChild( new Text( '   ' + chalk.dim( '⎿ ' ) + chalk.dim( message ), 0, 0 ) );
+		const formatted = '   ' + chalk.dim( '⎿ ' ) + chalk.dim( message );
+		if ( this.lastProgressText ) {
+			this.lastProgressText.setText( formatted );
+		} else {
+			this.lastProgressText = new Text( formatted, 0, 0 );
+			this.messages.addChild( this.lastProgressText );
+		}
 		this.tui.requestRender();
 	}
 
@@ -1354,6 +1362,7 @@ export class AiChatUI {
 			this.loader.stop();
 			this.tui.removeChild( this.loader );
 			this.loaderVisible = false;
+			this.lastProgressText = null;
 			this.tui.requestRender();
 		}
 	}

--- a/apps/cli/ai/ui.ts
+++ b/apps/cli/ai/ui.ts
@@ -1323,12 +1323,12 @@ export class AiChatUI {
 
 	private lastProgressText: Text | null = null;
 
-	setLoaderMessage( message: string ): void {
+	setLoaderMessage( message: string, update?: boolean ): void {
 		if ( ! message ) {
 			return;
 		}
 		const formatted = '   ' + chalk.dim( '⎿ ' ) + chalk.dim( message );
-		if ( this.lastProgressText ) {
+		if ( update && this.lastProgressText ) {
 			this.lastProgressText.setText( formatted );
 		} else {
 			this.lastProgressText = new Text( formatted, 0, 0 );

--- a/apps/cli/commands/ai/index.ts
+++ b/apps/cli/commands/ai/index.ts
@@ -157,9 +157,9 @@ export async function runCommand(
 		);
 	}
 
-	setProgressCallback( ( message ) => {
+	setProgressCallback( ( message, update ) => {
 		const timestamp = new Date().toISOString();
-		ui.setLoaderMessage( message );
+		ui.setLoaderMessage( message, update );
 		void persist( ( recorder ) => recorder.recordToolProgress( message, timestamp ) );
 	} );
 

--- a/apps/cli/commands/pull.ts
+++ b/apps/cli/commands/pull.ts
@@ -136,7 +136,7 @@ export async function runCommand(
 
 			// Backup phase: 0-50%
 			const backupProgress = Math.round( status.percent * 0.5 );
-			logger.spinner.text = sprintf( __( 'Creating remote backup… (%d%%)' ), backupProgress );
+			logger.reportProgress( sprintf( __( 'Creating remote backup… (%d%%)' ), backupProgress ) );
 
 			await new Promise( ( resolve ) => setTimeout( resolve, SYNC_POLL_INTERVAL_MS ) );
 		}

--- a/apps/cli/commands/push.ts
+++ b/apps/cli/commands/push.ts
@@ -156,7 +156,7 @@ export async function runCommand(
 			onProgress: ( percent ) => {
 				// Upload phase: 20-40%
 				const progress = Math.round( 20 + percent * 0.2 );
-				logger.spinner.text = sprintf( __( 'Uploading archive… (%d%%)' ), progress );
+				logger.reportProgress( sprintf( __( 'Uploading archive… (%d%%)' ), progress ) );
 			},
 		} );
 
@@ -183,7 +183,7 @@ export async function runCommand(
 		}
 
 		// Initiate import: 40%
-		logger.spinner.text = sprintf( __( 'Initiating import… (%d%%)' ), 40 );
+		logger.reportProgress( sprintf( __( 'Initiating import… (%d%%)' ), 40 ) );
 		await initiateImport( token.accessToken, remoteSite.id, attachmentId, {
 			optionsToSync,
 			specificSelectionPaths,
@@ -237,7 +237,7 @@ export async function runCommand(
 				stalledAttempts++;
 			}
 
-			logger.spinner.text = sprintf( '%s (%d%%)', statusMessage, roundedProgress );
+			logger.reportProgress( sprintf( '%s (%d%%)', statusMessage, roundedProgress ) );
 
 			await new Promise( ( resolve ) => setTimeout( resolve, SYNC_POLL_INTERVAL_MS ) );
 		}

--- a/apps/cli/logger.ts
+++ b/apps/cli/logger.ts
@@ -2,7 +2,7 @@ import ora, { Ora } from 'ora';
 
 const isIpcMode = Boolean( process.send );
 
-type ProgressCallback = ( message: string ) => void;
+type ProgressCallback = ( message: string, update?: boolean ) => void;
 let progressCallback: ProgressCallback | null = null;
 
 export function setProgressCallback( callback: ProgressCallback | null ): void {
@@ -73,7 +73,7 @@ export class Logger< T extends string > {
 		}
 
 		if ( progressCallback ) {
-			progressCallback!( message );
+			progressCallback!( message, true );
 			return;
 		}
 


### PR DESCRIPTION
## Related issues

- Fixes STU-1558

## How AI was used in this PR

Claude identified the root causes and implemented the fix. I reviewed and tested the changes.

## Proposed Changes

- **Forward progress messages to the agent UI**: `captureCommandOutput` now forwards progress messages to the previous callback instead of silently collecting them, so the agent UI receives live updates during push/pull operations.
- **Route progress through the callback system**: Push and pull commands were using `logger.spinner.text` (terminal-only) for progress updates. Switched to `logger.reportProgress()` which routes through the callback system and falls back to the spinner in terminal mode.
- **Update progress in place**: `setLoaderMessage` in the agent UI now updates a single `Text` node in place (via `setText`) instead of appending a new child for every progress message, matching how the terminal spinner works.
- **Distinguish phases from progress updates**: Added an `update` flag to the progress callback. `reportProgress` passes `update: true` to update the current line in place, while `reportStart`/`reportSuccess`/`emitProgress` create new lines — so phase changes (e.g., "Uploading…" → "Backing up remote site…") still appear as separate lines.

## Testing Instructions

- Open Studio Code and push a local site to WordPress.com (e.g., "Push my site to example.com")
- Verify progress messages appear in real-time with percentage updates
- Verify phase changes (uploading → initiating import → backing up → applying changes) appear as separate lines
- Verify percentage updates within a phase update in place (not flooding new lines)
- Pull a site and verify backup/download progress is also shown
- Run `studio push` / `studio pull` from the CLI terminal and verify the spinner still works as before

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?