### PR TITLE
Refactor slash command dispatch into a single declarative array

### DIFF
--- a/apps/cli/ai/plugin/skills/need-for-speed/SKILL.md
+++ b/apps/cli/ai/plugin/skills/need-for-speed/SKILL.md
@@ -12,7 +12,7 @@ Run a performance audit on a WordPress site to measure Core Web Vitals and page 
 
 1. Determine which site to audit. If the user hasn't specified, ask them or use the site from the current context.
 2. Ensure the site is running (use `site_start` if needed).
-3. Call `audit_performance` with the site name and path (defaults to `/`).
+3. Call `need_for_speed` with the site name and path (defaults to `/`).
 4. Analyze the results using the interpretation guide below.
 5. Present a clear summary with specific, actionable recommendations.
 

--- a/apps/cli/ai/slash-commands.ts
+++ b/apps/cli/ai/slash-commands.ts
@@ -1,28 +1,289 @@
-import { __ } from '@wordpress/i18n';
+import { readAuthToken } from '@studio/common/lib/shared-config';
+import { __, sprintf } from '@wordpress/i18n';
+import { AI_MODELS, type AiModelId } from 'cli/ai/agent';
+import { getAvailableAiProviders, isAiProviderReady } from 'cli/ai/auth';
+import { AI_PROVIDERS, type AiProviderId } from 'cli/ai/providers';
+import { captureCommandOutput } from 'cli/ai/tools';
+import { runCommand as runLoginCommand } from 'cli/commands/auth/login';
+import { runCommand as runLogoutCommand } from 'cli/commands/auth/logout';
+import { runCommand as runCreatePreviewCommand } from 'cli/commands/preview/create';
+import { runCommand as runUpdatePreviewCommand } from 'cli/commands/preview/update';
+import { getSnapshotsFromConfig, isSnapshotExpired } from 'cli/lib/snapshots';
+import { LoggerError } from 'cli/logger';
+import type { AiChatUI } from 'cli/ai/ui';
+
+export interface SlashCommandContext {
+	ui: AiChatUI;
+	currentModel: AiModelId;
+	currentProvider: AiProviderId;
+	showCapabilitiesOnConnect: boolean;
+	switchProvider( provider: AiProviderId, announce?: boolean ): Promise< void >;
+	prepareProviderSelection(
+		provider: AiProviderId,
+		options?: { force?: boolean }
+	): Promise< void >;
+	maybeAutoSwitchProvider(): Promise< void >;
+	persistSessionContext(): Promise< void >;
+}
+
+export type SlashCommandHandler = (
+	prompt: string,
+	ctx: SlashCommandContext
+) => Promise< 'continue' | 'break' >;
 
 export interface SlashCommandDef {
 	name: string;
 	description: string;
+	handler?: SlashCommandHandler;
 }
 
-export const AI_CHAT_BROWSER_COMMAND = '/browser';
-export const AI_CHAT_API_KEY_COMMAND = '/api-key';
-export const AI_CHAT_LOGIN_COMMAND = '/login';
-export const AI_CHAT_LOGOUT_COMMAND = '/logout';
-export const AI_CHAT_MODEL_COMMAND = '/model';
-export const AI_CHAT_PROVIDER_COMMAND = '/provider';
-export const AI_CHAT_PREVIEW_COMMAND = '/preview';
-export const AI_CHAT_EXIT_COMMAND = '/exit';
+function isPromptAbortError( error: unknown ): boolean {
+	return (
+		error instanceof Error &&
+		[ 'AbortPromptError', 'CancelPromptError', 'ExitPromptError' ].includes( error.name )
+	);
+}
 
 export const AI_CHAT_SLASH_COMMANDS: SlashCommandDef[] = [
-	{ name: 'browser', description: __( 'Open the active site in the browser' ) },
-	{ name: 'api-key', description: __( 'Set or update the Anthropic API key' ) },
-	{ name: 'login', description: __( 'Log in to WordPress.com' ) },
-	{ name: 'logout', description: __( 'Log out of WordPress.com' ) },
-	{ name: 'model', description: __( 'Switch the AI model' ) },
-	{ name: 'provider', description: __( 'Switch the AI provider' ) },
-	{ name: 'preview', description: __( 'Push the active site to WordPress.com as a preview' ) },
-	{ name: 'exit', description: __( 'Exit the chat' ) },
+	{
+		name: 'browser',
+		description: __( 'Open the active site in the browser' ),
+		handler: async ( _prompt, ctx ) => {
+			const opened = await ctx.ui.openActiveSiteInBrowser();
+			if ( ! opened ) {
+				ctx.ui.showInfo( __( 'No site selected. Use ↓ to select a site first.' ) );
+			}
+			return 'continue';
+		},
+	},
+	{
+		name: 'api-key',
+		description: __( 'Set or update the Anthropic API key' ),
+		handler: async ( _prompt, ctx ) => {
+			try {
+				await ctx.prepareProviderSelection( 'anthropic-api-key', { force: true } );
+				ctx.ui.showInfo( __( 'Anthropic API key updated.' ) );
+				if ( ctx.showCapabilitiesOnConnect ) {
+					ctx.showCapabilitiesOnConnect = false;
+					await ctx.switchProvider( 'anthropic-api-key' );
+					ctx.ui.showCapabilities();
+				}
+			} catch ( error ) {
+				if ( isPromptAbortError( error ) ) {
+					ctx.ui.showInfo( __( 'API key update canceled.' ) );
+					return 'continue';
+				}
+				if ( error instanceof LoggerError ) {
+					ctx.ui.showError( error.message );
+					return 'continue';
+				}
+				throw error;
+			}
+			return 'continue';
+		},
+	},
+	{
+		name: 'login',
+		description: __( 'Log in to WordPress.com' ),
+		handler: async ( _prompt, ctx ) => {
+			ctx.ui.stop();
+			await runLoginCommand();
+			ctx.ui.start();
+			if ( await isAiProviderReady( 'wpcom' ) ) {
+				const token = await readAuthToken();
+				if ( token ) {
+					ctx.ui.showSuccess(
+						sprintf(
+							/* translators: 1: display name, 2: email */
+							__( 'Logged in as %1$s (%2$s)' ),
+							token.displayName,
+							token.email
+						)
+					);
+					ctx.ui.setStatusMessage(
+						sprintf(
+							/* translators: %s: display name */
+							__( 'Logged in as %s' ),
+							token.displayName
+						)
+					);
+					if ( ctx.showCapabilitiesOnConnect ) {
+						ctx.showCapabilitiesOnConnect = false;
+						await ctx.switchProvider( 'wpcom' );
+						ctx.ui.showCapabilities();
+					}
+				}
+			} else {
+				ctx.ui.setStatusMessage( __( 'Login failed or canceled' ) );
+			}
+			return 'continue';
+		},
+	},
+	{
+		name: 'logout',
+		description: __( 'Log out of WordPress.com' ),
+		handler: async ( _prompt, ctx ) => {
+			ctx.ui.stop();
+			await runLogoutCommand();
+			ctx.ui.start();
+			ctx.ui.setStatusMessage( __( 'Logged out of WordPress.com' ) );
+			await ctx.maybeAutoSwitchProvider();
+			return 'continue';
+		},
+	},
+	{
+		name: 'model',
+		description: __( 'Switch the AI model' ),
+		handler: async ( _prompt, ctx ) => {
+			const modelOptions = ( Object.entries( AI_MODELS ) as [ AiModelId, string ][] ).map(
+				( [ id, label ] ) => ( {
+					label:
+						id === ctx.currentModel
+							? sprintf(
+									/* translators: %s: model name */
+									__( '%s (current)' ),
+									label
+							  )
+							: label,
+					description: id,
+				} )
+			);
+			const answer = await ctx.ui.askUser( [
+				{ question: __( 'Select a model' ), options: modelOptions },
+			] );
+			const selectedId = Object.values( answer )[ 0 ] as string;
+			const newModel = ( Object.entries( AI_MODELS ) as [ AiModelId, string ][] ).find(
+				( [ , label ] ) => selectedId.startsWith( label )
+			);
+			if ( newModel && newModel[ 0 ] !== ctx.currentModel ) {
+				ctx.currentModel = newModel[ 0 ];
+				ctx.ui.currentModel = ctx.currentModel;
+				ctx.ui.showInfo(
+					sprintf(
+						/* translators: %s: model name */
+						__( 'Switched to %s' ),
+						AI_MODELS[ ctx.currentModel ]
+					)
+				);
+				await ctx.persistSessionContext();
+			}
+			return 'continue';
+		},
+	},
+	{
+		name: 'provider',
+		description: __( 'Switch the AI provider' ),
+		handler: async ( _prompt, ctx ) => {
+			const availableProviders = await getAvailableAiProviders();
+			const providerOptions = availableProviders.map( ( id ) => ( {
+				label:
+					id === ctx.currentProvider
+						? sprintf(
+								/* translators: %s: provider name */
+								__( '%s (current)' ),
+								AI_PROVIDERS[ id ]
+						  )
+						: AI_PROVIDERS[ id ],
+				description: id,
+			} ) );
+			const answer = await ctx.ui.askUser( [
+				{ question: __( 'Select an AI provider' ), options: providerOptions },
+			] );
+			const selectedLabel = Object.values( answer )[ 0 ] as string;
+			const newProvider = availableProviders.find( ( id ) =>
+				selectedLabel.startsWith( AI_PROVIDERS[ id ] )
+			);
+			if ( newProvider && newProvider !== ctx.currentProvider ) {
+				try {
+					await ctx.prepareProviderSelection( newProvider );
+					await ctx.switchProvider( newProvider );
+				} catch ( error ) {
+					if ( isPromptAbortError( error ) ) {
+						ctx.ui.showInfo(
+							sprintf(
+								/* translators: %s: provider name */
+								__( 'Provider setup canceled. Kept %s.' ),
+								AI_PROVIDERS[ ctx.currentProvider ]
+							)
+						);
+						return 'continue';
+					}
+					if ( error instanceof LoggerError ) {
+						ctx.ui.showError( error.message );
+						return 'continue';
+					}
+					throw error;
+				}
+			}
+			return 'continue';
+		},
+	},
+	{
+		name: 'preview',
+		description: __( 'Push the active site to WordPress.com as a preview' ),
+		handler: async ( _prompt, ctx ) => {
+			const site = ctx.ui.activeSite;
+			if ( ! site ) {
+				ctx.ui.showInfo( __( 'No site selected. Use ↓ to select a site first.' ) );
+				return 'continue';
+			}
+
+			const token = await readAuthToken();
+			if ( ! token ) {
+				ctx.ui.showInfo( __( 'WordPress.com login required. Use /login to authenticate.' ) );
+				return 'continue';
+			}
+
+			try {
+				const snapshots = await getSnapshotsFromConfig( token.id, site.path );
+				const activeSnapshot = snapshots.find( ( s ) => ! isSnapshotExpired( s ) );
+
+				const isUpdate = Boolean( activeSnapshot );
+				ctx.ui.showProgress(
+					isUpdate
+						? __( 'Updating preview site… this may take a moment.' )
+						: __( 'Creating preview site… this may take a moment.' )
+				);
+				ctx.ui.setBusy( true );
+
+				const result = await captureCommandOutput( async () => {
+					if ( activeSnapshot ) {
+						await runUpdatePreviewCommand( site.path, activeSnapshot.url, false );
+					} else {
+						await runCreatePreviewCommand( site.path );
+					}
+				} );
+
+				ctx.ui.setBusy( false );
+
+				if ( result.exitCode ) {
+					ctx.ui.showError( result.consoleOutput || __( 'Failed to create preview site.' ) );
+				} else {
+					const updated = await getSnapshotsFromConfig( token.id, site.path );
+					const latest = updated.find( ( s ) => ! isSnapshotExpired( s ) );
+					if ( latest ) {
+						const previewUrl = `https://${ latest.url }`;
+						ctx.ui.showSuccess( __( 'Preview site ready!' ) + '\n\n   ' + previewUrl );
+					} else {
+						ctx.ui.showInfo( result.consoleOutput || __( 'Preview command completed.' ) );
+					}
+				}
+			} catch ( error ) {
+				ctx.ui.setBusy( false );
+				if ( error instanceof LoggerError ) {
+					ctx.ui.showError( error.message );
+				} else {
+					ctx.ui.showError( __( 'Failed to create preview site.' ) );
+				}
+			}
+			return 'continue';
+		},
+	},
+	{
+		name: 'exit',
+		description: __( 'Exit the chat' ),
+		handler: async () => 'break',
+	},
 	{ name: 'taxonomist', description: __( 'Optimize category taxonomy with AI' ) },
 	{ name: 'need-for-speed', description: __( 'Run a performance audit on a site' ) },
 ];

--- a/apps/cli/ai/system-prompt.ts
+++ b/apps/cli/ai/system-prompt.ts
@@ -137,7 +137,7 @@ Then continue with:
 - wp_cli: Run WP-CLI commands on a running site
 - validate_blocks: Validate block content for correctness on a running site (runs each block through its save() function in a real browser). Requires a site name or path. Call after every file write/edit that contains block content.
 - take_screenshot: Take a full-page screenshot of a URL (supports desktop and mobile viewports). Use this to visually check the site after building it.
-- audit_performance: Measure frontend performance metrics (TTFB, FCP, LCP, CLS, page weight, DOM size, JS/CSS/image/font asset breakdown) for a running site. Use this to identify performance bottlenecks and guide optimization.
+- need_for_speed: Measure frontend performance metrics (TTFB, FCP, LCP, CLS, page weight, DOM size, JS/CSS/image/font asset breakdown) for a running site. Use this to identify performance bottlenecks and guide optimization.
 - site_push: Push a local site to a WordPress.com site. Requires authentication (studio auth login). Specify the remote site URL or ID and sync options (all, sqls, uploads, plugins, themes, contents).
 - site_pull: Pull a WordPress.com site to a local site. Requires authentication. Specify the remote site URL or ID and sync options.
 - site_import: Import a backup file (.zip, .tar.gz, .sql, .wpress) into a local site.

--- a/apps/cli/ai/tools.ts
+++ b/apps/cli/ai/tools.ts
@@ -743,7 +743,7 @@ const installTaxonomyScriptsTool = tool(
 );
 
 const auditPerformanceTool = tool(
-	'audit_performance',
+	'need_for_speed',
 	'Measures frontend performance metrics for a WordPress site page. Returns Core Web Vitals ' +
 		'(TTFB, FCP, LCP, CLS), page weight, DOM size, request count, and a breakdown of JS, CSS, ' +
 		'image, and font assets. The site must be running. Use this to identify performance issues.',

--- a/apps/cli/commands/ai/index.ts
+++ b/apps/cli/commands/ai/index.ts
@@ -1,12 +1,6 @@
 import { readAuthToken } from '@studio/common/lib/shared-config';
 import { __, _n, sprintf } from '@wordpress/i18n';
-import {
-	AI_MODELS,
-	DEFAULT_MODEL,
-	startAiAgent,
-	type AiModelId,
-	type AskUserQuestion,
-} from 'cli/ai/agent';
+import { DEFAULT_MODEL, startAiAgent, type AiModelId, type AskUserQuestion } from 'cli/ai/agent';
 import {
 	getAvailableAiProviders,
 	isAiProviderReady,
@@ -21,24 +15,10 @@ import { resolveResumeSessionContext } from 'cli/ai/sessions/context';
 import { AiSessionRecorder } from 'cli/ai/sessions/recorder';
 import { replaySessionHistory } from 'cli/ai/sessions/replay';
 import { type LoadedAiSession, type TurnStatus } from 'cli/ai/sessions/types';
-import {
-	AI_CHAT_API_KEY_COMMAND,
-	AI_CHAT_BROWSER_COMMAND,
-	AI_CHAT_EXIT_COMMAND,
-	AI_CHAT_LOGIN_COMMAND,
-	AI_CHAT_LOGOUT_COMMAND,
-	AI_CHAT_MODEL_COMMAND,
-	AI_CHAT_PREVIEW_COMMAND,
-	AI_CHAT_PROVIDER_COMMAND,
-} from 'cli/ai/slash-commands';
-import { captureCommandOutput } from 'cli/ai/tools';
+import { AI_CHAT_SLASH_COMMANDS, type SlashCommandContext } from 'cli/ai/slash-commands';
 import { AiChatUI } from 'cli/ai/ui';
 import { runCommand as runLoginCommand } from 'cli/commands/auth/login';
-import { runCommand as runLogoutCommand } from 'cli/commands/auth/logout';
-import { runCommand as runCreatePreviewCommand } from 'cli/commands/preview/create';
-import { runCommand as runUpdatePreviewCommand } from 'cli/commands/preview/update';
 import { readCliConfig } from 'cli/lib/cli-config/core';
-import { getSnapshotsFromConfig, isSnapshotExpired } from 'cli/lib/snapshots';
 import { Logger, LoggerError, setProgressCallback } from 'cli/logger';
 import { StudioArgv } from 'cli/types';
 
@@ -475,230 +455,56 @@ export async function runCommand(
 		}
 	}
 
+	const slashCommandContext: SlashCommandContext = {
+		ui,
+		get currentModel() {
+			return currentModel;
+		},
+		set currentModel( value ) {
+			currentModel = value;
+		},
+		get currentProvider() {
+			return currentProvider;
+		},
+		get showCapabilitiesOnConnect() {
+			return showCapabilitiesOnConnect;
+		},
+		set showCapabilitiesOnConnect( value ) {
+			showCapabilitiesOnConnect = value;
+		},
+		switchProvider,
+		prepareProviderSelection,
+		maybeAutoSwitchProvider,
+		persistSessionContext,
+	};
+
+	// --- Main loop ---
 	try {
 		while ( true ) {
 			const prompt = await ui.waitForInput();
 			const trimmedPrompt = prompt.trim();
 
-			if ( trimmedPrompt === AI_CHAT_EXIT_COMMAND ) {
-				break;
-			}
-
-			if ( trimmedPrompt === AI_CHAT_BROWSER_COMMAND ) {
-				const opened = await ui.openActiveSiteInBrowser();
-				if ( ! opened ) {
-					ui.showInfo( __( 'No site selected. Use ↓ to select a site first.' ) );
-				}
-				continue;
-			}
-
-			if ( trimmedPrompt === AI_CHAT_PREVIEW_COMMAND ) {
-				const site = ui.activeSite;
-				if ( ! site ) {
-					ui.showInfo( __( 'No site selected. Use ↓ to select a site first.' ) );
-					continue;
-				}
-
-				const token = await readAuthToken();
-				if ( ! token ) {
-					ui.showInfo( __( 'WordPress.com login required. Use /login to authenticate.' ) );
-					continue;
-				}
-
-				try {
-					const snapshots = await getSnapshotsFromConfig( token.id, site.path );
-					const activeSnapshot = snapshots.find( ( s ) => ! isSnapshotExpired( s ) );
-
-					const isUpdate = Boolean( activeSnapshot );
-					ui.showProgress(
-						isUpdate
-							? __( 'Updating preview site… this may take a moment.' )
-							: __( 'Creating preview site… this may take a moment.' )
-					);
-					ui.setBusy( true );
-
-					const result = await captureCommandOutput( async () => {
-						if ( activeSnapshot ) {
-							await runUpdatePreviewCommand( site.path, activeSnapshot.url, false );
-						} else {
-							await runCreatePreviewCommand( site.path );
-						}
-					} );
-
-					ui.setBusy( false );
-
-					if ( result.exitCode ) {
-						ui.showError( result.consoleOutput || __( 'Failed to create preview site.' ) );
-					} else {
-						const updated = await getSnapshotsFromConfig( token.id, site.path );
-						const latest = updated.find( ( s ) => ! isSnapshotExpired( s ) );
-						if ( latest ) {
-							const previewUrl = `https://${ latest.url }`;
-							ui.showSuccess( __( 'Preview site ready!' ) + '\n\n   ' + previewUrl );
-						} else {
-							ui.showInfo( result.consoleOutput || __( 'Preview command completed.' ) );
-						}
-					}
-				} catch ( error ) {
-					ui.setBusy( false );
-					if ( error instanceof LoggerError ) {
-						ui.showError( error.message );
-					} else {
-						ui.showError( __( 'Failed to create preview site.' ) );
-					}
-				}
-				continue;
-			}
-
-			if ( trimmedPrompt === AI_CHAT_API_KEY_COMMAND ) {
-				try {
-					await prepareProviderSelection( 'anthropic-api-key', { force: true } );
-					ui.showInfo( __( 'Anthropic API key updated.' ) );
-					if ( showCapabilitiesOnConnect ) {
-						showCapabilitiesOnConnect = false;
-						await switchProvider( 'anthropic-api-key' );
-						ui.showCapabilities();
-					}
-				} catch ( error ) {
-					if ( isPromptAbortError( error ) ) {
-						ui.showInfo( __( 'API key update canceled.' ) );
-						continue;
-					}
-					if ( error instanceof LoggerError ) {
-						ui.showError( error.message );
-						continue;
-					}
-					throw error;
-				}
-				continue;
-			}
-
-			if ( trimmedPrompt === AI_CHAT_LOGIN_COMMAND ) {
-				ui.stop();
-				await runLoginCommand();
-				ui.start();
-				if ( await isAiProviderReady( 'wpcom' ) ) {
-					const token = await readAuthToken();
-					if ( token ) {
-						ui.showSuccess(
-							sprintf(
-								/* translators: 1: display name, 2: email */
-								__( 'Logged in as %1$s (%2$s)' ),
-								token.displayName,
-								token.email
-							)
-						);
-						ui.setStatusMessage(
-							sprintf(
-								/* translators: %s: display name */
-								__( 'Logged in as %s' ),
-								token.displayName
-							)
-						);
-						if ( showCapabilitiesOnConnect ) {
-							showCapabilitiesOnConnect = false;
-							await switchProvider( 'wpcom' );
-							ui.showCapabilities();
-						}
+			const cmd = AI_CHAT_SLASH_COMMANDS.find( ( c ) => `/${ c.name }` === trimmedPrompt );
+			if ( cmd ) {
+				if ( cmd.handler ) {
+					const result = await cmd.handler( prompt, slashCommandContext );
+					if ( result === 'break' ) {
+						break;
 					}
 				} else {
-					ui.setStatusMessage( __( 'Login failed or canceled' ) );
-				}
-				continue;
-			}
-
-			if ( trimmedPrompt === AI_CHAT_LOGOUT_COMMAND ) {
-				ui.stop();
-				await runLogoutCommand();
-				ui.start();
-				ui.setStatusMessage( __( 'Logged out of WordPress.com' ) );
-				await maybeAutoSwitchProvider();
-				continue;
-			}
-
-			if ( trimmedPrompt === AI_CHAT_MODEL_COMMAND ) {
-				const modelOptions = ( Object.entries( AI_MODELS ) as [ AiModelId, string ][] ).map(
-					( [ id, label ] ) => ( {
-						label:
-							id === currentModel
-								? sprintf(
-										/* translators: %s: model name */
-										__( '%s (current)' ),
-										label
-								  )
-								: label,
-						description: id,
-					} )
-				);
-				const answer = await ui.askUser( [
-					{ question: __( 'Select a model' ), options: modelOptions },
-				] );
-				const selectedId = Object.values( answer )[ 0 ] as string;
-				const newModel = ( Object.entries( AI_MODELS ) as [ AiModelId, string ][] ).find(
-					( [ , label ] ) => selectedId.startsWith( label )
-				);
-				if ( newModel && newModel[ 0 ] !== currentModel ) {
-					currentModel = newModel[ 0 ];
-					ui.currentModel = currentModel;
-					ui.showInfo(
-						sprintf(
-							/* translators: %s: model name */
-							__( 'Switched to %s' ),
-							AI_MODELS[ currentModel ]
-						)
-					);
-					await persistSessionContext();
-				}
-				continue;
-			}
-
-			if ( trimmedPrompt === AI_CHAT_PROVIDER_COMMAND ) {
-				const availableProviders = await getAvailableAiProviders();
-				const providerOptions = availableProviders.map( ( id ) => ( {
-					label:
-						id === currentProvider
-							? sprintf(
-									/* translators: %s: provider name */
-									__( '%s (current)' ),
-									AI_PROVIDERS[ id ]
-							  )
-							: AI_PROVIDERS[ id ],
-					description: id,
-				} ) );
-				const answer = await ui.askUser( [
-					{ question: __( 'Select an AI provider' ), options: providerOptions },
-				] );
-				const selectedLabel = Object.values( answer )[ 0 ] as string;
-				const newProvider = availableProviders.find( ( id ) =>
-					selectedLabel.startsWith( AI_PROVIDERS[ id ] )
-				);
-				if ( newProvider && newProvider !== currentProvider ) {
+					// Skill command — no handler, route to agent
+					await maybeAutoSwitchProvider();
+					ui.addUserMessage( prompt );
 					try {
-						await prepareProviderSelection( newProvider );
-						await switchProvider( newProvider );
+						await runAgentTurn( `Run the /${ cmd.name } skill using the Skill tool.` );
 					} catch ( error ) {
-						if ( isPromptAbortError( error ) ) {
-							ui.showInfo(
-								sprintf(
-									/* translators: %s: provider name */
-									__( 'Provider setup canceled. Kept %s.' ),
-									AI_PROVIDERS[ currentProvider ]
-								)
-							);
-							continue;
-						}
-						if ( error instanceof LoggerError ) {
-							ui.showError( error.message );
-							continue;
-						}
-						throw error;
+						handleAgentTurnError( error );
 					}
 				}
 				continue;
 			}
 
 			await maybeAutoSwitchProvider();
-
 			ui.addUserMessage( prompt );
 			try {
 				await runAgentTurn( prompt );


### PR DESCRIPTION
## Related issues

- Related to #3067

## How AI was used in this PR

All code was AI-generated and reviewed by a human. The refactor preserves exact handler behavior — each was moved verbatim and verified against the original.

## Proposed Changes

- Refactor slash commands into a single static `AI_CHAT_SLASH_COMMANDS` array in `slash-commands.ts` with handlers defined inline alongside each command's name and description
- Replace the scattered `if/else` chain and separate `AI_CHAT_*_COMMAND` constants in the main chat loop with a generic dispatch: commands with a `handler` run it, commands without one are automatically routed to the agent as skills
- Introduce a `SlashCommandContext` interface so handlers receive runtime state as a parameter rather than closing over local variables
- Adding a new skill now only requires adding `{ name, description }` to the array; adding a new built-in command just requires adding a `handler` alongside it
- Rename the `audit_performance` tool to `need_for_speed` to match the skill name

## Testing Instructions

- Build CLI: `npm run cli:build`
- Run `node apps/cli/dist/cli/main.mjs` and verify:
  - Built-in commands work: `/exit`, `/model`, `/browser`, `/login`, `/preview`
  - Skill commands trigger the Skill tool: `/need-for-speed`, `/taxonomist`
  - Autocomplete still shows all commands when typing `/`
- Run tests: `npm test -- apps/cli/commands/ai/tests/ai.test.ts`

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?