### PR TITLE
Use abort timeout for github latest-release fetch

### DIFF
--- a/apps/cli/lib/dependency-management/utils.ts
+++ b/apps/cli/lib/dependency-management/utils.ts
@@ -47,6 +47,7 @@ export async function fetchLatestGithubRelease( repo: string ) {
 
 	const response = await fetch( `https://api.github.com/repos/${ repo }/releases/latest`, {
 		headers,
+		signal: AbortSignal.timeout( 5000 ),
 	} );
 
 	if ( ! response.ok ) {


### PR DESCRIPTION
## Related issues

- Part to STU-1491

## How AI was used in this PR

Assisted with the investigation. The approach is my decision.

## Proposed Changes

During the issue I faced that sometimes requests can hang for a long time and it freezes site creation flow.
To avoid long-hanging requests, I am adding a 5 seconds timeout to abort them.

## Testing Instructions
1. Apply the next diff:
``` diff
diff --git a/apps/cli/lib/dependency-management/setup.ts b/apps/cli/lib/dependency-management/setup.ts
index 493772c5..789ea511 100644
--- a/apps/cli/lib/dependency-management/setup.ts
+++ b/apps/cli/lib/dependency-management/setup.ts
@@ -269,7 +269,8 @@ export async function updateServerFiles() {
                [ 'WP-CLI', updateLatestWpCliVersion ],
                [ 'SQLite integration', updateLatestSqliteCommandVersion ],
        ];
-
+       const startedAt = performance.now();
+       console.log('started', startedAt);
        await Promise.all(
                steps.map( ( [ name, step ] ) =>
                        step().catch( ( error ) => {
@@ -277,4 +278,6 @@ export async function updateServerFiles() {
                        } )
                )
        );
+       console.log('ended', performance.now() - startedAt);
 }
```
2. Add `10.0.0.0 api.github.com` to hosts
3. Run Studio
4. Create a site
5. Look at terminal and assert that you see `ended ~5043.083166`