### PR TITLE
Hide .studio directory on Windows

### DIFF
--- a/apps/cli/lib/cli-config/core.ts
+++ b/apps/cli/lib/cli-config/core.ts
@@ -6,6 +6,7 @@ import {
 	LOCKFILE_WAIT_TIME,
 } from '@studio/common/constants';
 import { siteDetailsSchema } from '@studio/common/lib/cli-events';
+import { hideDirectoryOnWindows } from '@studio/common/lib/hide-dir-windows';
 import { lockFileAsync, unlockFileAsync } from '@studio/common/lib/lockfile';
 import { getCliConfigPath, getConfigDirectory } from '@studio/common/lib/well-known-paths';
 import { snapshotSchema } from '@studio/common/types/snapshot';
@@ -96,6 +97,7 @@ export async function saveCliConfig( config: CliConfig ): Promise< void > {
 		const configDir = getConfigDirectory();
 		if ( ! fs.existsSync( configDir ) ) {
 			fs.mkdirSync( configDir, { recursive: true } );
+			await hideDirectoryOnWindows( configDir );
 		}
 
 		const configPath = getCliConfigPath();

--- a/apps/cli/migrations/01-hide-studio-dir-windows.ts
+++ b/apps/cli/migrations/01-hide-studio-dir-windows.ts
@@ -1,0 +1,30 @@
+/**
+ * Hides the `~/.studio` directory on Windows by setting the "hidden" file attribute.
+ *
+ * On macOS and Linux, directories starting with `.` are hidden by convention.
+ * On Windows, directories need the explicit "hidden" attribute set via `attrib +H`.
+ */
+
+import fs from 'node:fs';
+import {
+	hideDirectoryOnWindows,
+	isDirectoryHiddenOnWindows,
+} from '@studio/common/lib/hide-dir-windows';
+import { getConfigDirectory } from '@studio/common/lib/well-known-paths';
+import type { Migration } from '@studio/common/lib/migration';
+
+export const hideStudioDirWindows: Migration = {
+	needsToRun: async () => {
+		if ( process.platform !== 'win32' ) {
+			return false;
+		}
+		const configDir = getConfigDirectory();
+		if ( ! fs.existsSync( configDir ) ) {
+			return false;
+		}
+		return ! ( await isDirectoryHiddenOnWindows( configDir ) );
+	},
+	run: async () => {
+		await hideDirectoryOnWindows( getConfigDirectory() );
+	},
+};

--- a/apps/cli/migrations/index.ts
+++ b/apps/cli/migrations/index.ts
@@ -1,4 +1,8 @@
 import { checkStudioCompatibilityForInitialMigration } from './00-check-studio-compatibility';
+import { hideStudioDirWindows } from './01-hide-studio-dir-windows';
 import type { Migration } from '@studio/common/lib/migration';
 
-export const migrations: Migration[] = [ checkStudioCompatibilityForInitialMigration ];
+export const migrations: Migration[] = [
+	checkStudioCompatibilityForInitialMigration,
+	hideStudioDirWindows,
+];

--- a/tools/common/lib/hide-dir-windows.ts
+++ b/tools/common/lib/hide-dir-windows.ts
@@ -1,0 +1,38 @@
+import { execFile } from 'child_process';
+
+/**
+ * Sets the "hidden" attribute on a directory on Windows using `attrib +H`.
+ * No-op on non-Windows platforms.
+ */
+export async function hideDirectoryOnWindows( dirPath: string ): Promise< void > {
+	if ( process.platform !== 'win32' ) {
+		return;
+	}
+	return new Promise( ( resolve ) => {
+		execFile( 'attrib', [ '+H', dirPath ], () => {
+			resolve();
+		} );
+	} );
+}
+
+/**
+ * Returns true if the directory has the "hidden" attribute set on Windows.
+ * Always returns false on non-Windows platforms.
+ */
+export async function isDirectoryHiddenOnWindows( dirPath: string ): Promise< boolean > {
+	if ( process.platform !== 'win32' ) {
+		return false;
+	}
+	return new Promise( ( resolve ) => {
+		execFile( 'attrib', [ dirPath ], ( error, stdout ) => {
+			if ( error ) {
+				resolve( false );
+				return;
+			}
+			// attrib output format: "     H  C:\path\to\dir"
+			// The attributes appear before the path, H indicates hidden
+			const attributes = stdout.substring( 0, stdout.indexOf( dirPath ) );
+			resolve( attributes.includes( 'H' ) );
+		} );
+	} );
+}

--- a/tools/common/lib/hide-dir-windows.ts
+++ b/tools/common/lib/hide-dir-windows.ts
@@ -1,4 +1,5 @@
 import { execFile } from 'child_process';
+import path from 'path';
 
 /**
  * Sets the "hidden" attribute on a directory on Windows using `attrib +H`.
@@ -23,15 +24,16 @@ export async function isDirectoryHiddenOnWindows( dirPath: string ): Promise< bo
 	if ( process.platform !== 'win32' ) {
 		return false;
 	}
+	const resolvedPath = path.resolve( dirPath );
 	return new Promise( ( resolve ) => {
-		execFile( 'attrib', [ dirPath ], ( error, stdout ) => {
+		execFile( 'attrib', [ resolvedPath ], ( error, stdout ) => {
 			if ( error ) {
 				resolve( false );
 				return;
 			}
 			// attrib output format: "     H  C:\path\to\dir"
 			// The attributes appear before the path, H indicates hidden
-			const attributes = stdout.substring( 0, stdout.indexOf( dirPath ) );
+			const attributes = stdout.substring( 0, stdout.indexOf( resolvedPath ) );
 			resolve( attributes.includes( 'H' ) );
 		} );
 	} );

--- a/tools/common/lib/shared-config.ts
+++ b/tools/common/lib/shared-config.ts
@@ -4,6 +4,7 @@ import { readFile, writeFile } from 'atomically';
 import { z } from 'zod';
 import { LOCKFILE_STALE_TIME, LOCKFILE_WAIT_TIME, SHARED_CONFIG_LOCKFILE_NAME } from '../constants';
 import { authTokenSchema, type StoredAuthToken } from './auth-token-schema';
+import { hideDirectoryOnWindows } from './hide-dir-windows';
 import { lockFileAsync, unlockFileAsync } from './lockfile';
 import { getConfigDirectory, getSharedConfigPath } from './well-known-paths';
 
@@ -68,6 +69,7 @@ export async function saveSharedConfig( config: SharedConfig ): Promise< void > 
 	const configDir = getConfigDirectory();
 	if ( ! fs.existsSync( configDir ) ) {
 		fs.mkdirSync( configDir, { recursive: true } );
+		await hideDirectoryOnWindows( configDir );
 	}
 
 	const configPath = getSharedConfigPath();


### PR DESCRIPTION
## Related issues

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

- Fixes STU-1536

## How AI was used in this PR

<!--
Help reviewers understand what to look for and verify that you've reviewed the code yourself.
-->

Implementation was AI-assisted with manual review and direction on architecture decisions (migration placement, error handling strategy).

## Proposed Changes

- Add `hideDirectoryOnWindows` and `isDirectoryHiddenOnWindows` utility functions in `tools/common/lib/hide-dir-windows.ts` using `attrib +H`
- Add CLI migration (`01-hide-studio-dir-windows`) to hide the `.studio` directory for existing Windows installations
- Call `hideDirectoryOnWindows` after directory creation in `saveSharedConfig` and `saveCliConfig` so new installations get a hidden directory by default

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- On a Windows machine with an existing `~/.studio` directory visible in Explorer, launch Studio
- After startup, verify `~/.studio` is now hidden in Explorer (may need to refresh)
- Delete `~/.studio`, launch Studio again, and verify the newly created directory is hidden from the start
- On macOS/Linux, verify no behavioral changes (the utility functions are no-ops on non-Windows)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Have you checked for TypeScript, React or other console errors?