### PR TITLE
Update --json mode exit handling, type safety, and adapter consistency

### DIFF
--- a/apps/cli/ai/output-adapter.ts
+++ b/apps/cli/ai/output-adapter.ts
@@ -5,8 +5,8 @@ import type { AiProviderId } from 'cli/ai/providers';
 import type { SiteInfo } from 'cli/ai/ui';
 
 export type HandleMessageResult =
-	| { sessionId: string; success: boolean; maxTurnsReached?: undefined }
-	| { sessionId: string; maxTurnsReached: true; numTurns: number; costUsd?: number };
+	| { type: 'result'; sessionId: string; success: boolean }
+	| { type: 'max_turns'; sessionId: string; numTurns: number; costUsd?: number };
 
 export interface AiOutputAdapter {
 	currentProvider: AiProviderId;
@@ -73,8 +73,8 @@ export class JsonAdapter implements AiOutputAdapter {
 		// No-op in JSON mode
 	}
 
-	showProgress( _message: string ): void {
-		// No-op in JSON mode
+	showProgress( message: string ): void {
+		emitEvent( { type: 'progress', timestamp: new Date().toISOString(), message } );
 	}
 
 	setBusy( _active: boolean ): void {
@@ -113,21 +113,20 @@ export class JsonAdapter implements AiOutputAdapter {
 		emitEvent( { type: 'message', timestamp: new Date().toISOString(), message } );
 
 		if ( message.type === 'result' ) {
-			if ( message.subtype === 'success' ) {
-				this.sessionId = message.session_id;
-				return { sessionId: message.session_id, success: true };
-			}
+			this.sessionId = message.session_id;
 			if ( message.subtype === 'error_max_turns' ) {
-				this.sessionId = message.session_id;
 				return {
+					type: 'max_turns',
 					sessionId: message.session_id,
-					maxTurnsReached: true,
 					numTurns: message.num_turns,
 					costUsd: message.total_cost_usd,
 				};
 			}
-			this.sessionId = message.session_id;
-			return { sessionId: message.session_id, success: false };
+			return {
+				type: 'result',
+				sessionId: message.session_id,
+				success: message.subtype === 'success',
+			};
 		}
 
 		return undefined;
@@ -161,10 +160,11 @@ export class JsonAdapter implements AiOutputAdapter {
 		} );
 		this.emitTurnCompleted( 'paused' );
 		await this.onBeforeExit?.();
-		process.exit( 0 );
+		process.exitCode = 0;
 
-		// Unreachable, but satisfies TypeScript
-		return {};
+		// Return a never-resolving promise to halt execution while letting
+		// the event loop drain naturally (flushes stdout, completes async I/O).
+		return new Promise< Record< string, string > >( () => {} );
 	}
 
 	openActiveSiteInBrowser(): Promise< boolean > {

--- a/apps/cli/ai/ui.ts
+++ b/apps/cli/ai/ui.ts
@@ -37,7 +37,7 @@ import { getSiteUrl } from 'cli/lib/cli-config/sites';
 import { getSitesRunningStatus, isSiteRunning } from 'cli/lib/site-utils';
 import type { SDKMessage } from '@anthropic-ai/claude-agent-sdk';
 import type { TodoWriteInput } from '@anthropic-ai/claude-agent-sdk/sdk-tools';
-import type { AiOutputAdapter } from 'cli/ai/output-adapter';
+import type { AiOutputAdapter, HandleMessageResult } from 'cli/ai/output-adapter';
 
 const SITE_PICKER_TAB_LOCAL = 'local' as const;
 const SITE_PICKER_TAB_REMOTE = 'remote' as const;
@@ -2028,12 +2028,7 @@ export class AiChatUI implements AiOutputAdapter {
 	 * Process an SDK message and update the UI.
 	 * Returns session result when the agent turn is complete.
 	 */
-	handleMessage(
-		message: SDKMessage
-	):
-		| { sessionId: string; success: boolean; maxTurnsReached?: undefined }
-		| { sessionId: string; maxTurnsReached: true; numTurns: number }
-		| undefined {
+	handleMessage( message: SDKMessage ): HandleMessageResult | undefined {
 		switch ( message.type ) {
 			case 'assistant': {
 				for ( const block of message.message.content ) {
@@ -2143,7 +2138,7 @@ export class AiChatUI implements AiOutputAdapter {
 							message.num_turns
 						)
 					);
-					return { sessionId: message.session_id, success: true };
+					return { type: 'result', sessionId: message.session_id, success: true };
 				}
 
 				// User-initiated interruption: show friendly message instead of error
@@ -2163,7 +2158,7 @@ export class AiChatUI implements AiOutputAdapter {
 							thinkingSec
 						)
 					);
-					return { sessionId: message.session_id, success: false };
+					return { type: 'result', sessionId: message.session_id, success: false };
 				}
 
 				// Build detailed error message
@@ -2173,8 +2168,8 @@ export class AiChatUI implements AiOutputAdapter {
 				}
 				if ( message.subtype === 'error_max_turns' ) {
 					return {
+						type: 'max_turns',
 						sessionId: message.session_id,
-						maxTurnsReached: true,
 						numTurns: message.num_turns,
 					};
 				} else if ( message.subtype ) {
@@ -2192,7 +2187,7 @@ export class AiChatUI implements AiOutputAdapter {
 					}
 				}
 				this.showError( parts.length > 0 ? parts.join( '\n' ) : __( 'Unknown error' ) );
-				return { sessionId: message.session_id, success: false };
+				return { type: 'result', sessionId: message.session_id, success: false };
 			}
 		}
 		return undefined;

--- a/apps/cli/commands/ai/index.ts
+++ b/apps/cli/commands/ai/index.ts
@@ -427,7 +427,7 @@ export async function runCommand( options: {
 					sessionId = result.sessionId;
 					await persist( ( recorder ) => recorder.recordAgentSessionId( result.sessionId ) );
 
-					if ( 'maxTurnsReached' in result && result.maxTurnsReached ) {
+					if ( result.type === 'max_turns' ) {
 						maxTurnsResult = {
 							numTurns: result.numTurns,
 						};
@@ -477,20 +477,18 @@ export async function runCommand( options: {
 
 	// JSON mode: single turn, then exit
 	if ( isJsonMode && options.initialMessage ) {
-		let exitCode = 0;
 		try {
 			ui.addUserMessage( options.initialMessage );
 			const result = await runAgentTurn( options.initialMessage );
 			const jsonStatus = result.status === 'interrupted' ? 'error' : result.status;
 			( ui as JsonAdapter ).emitTurnCompleted( jsonStatus, result.usage );
 		} catch ( error ) {
-			exitCode = 1;
+			process.exitCode = 1;
 			handleAgentTurnError( error );
 			( ui as JsonAdapter ).emitTurnCompleted( 'error' );
 		} finally {
 			await persistQueue;
 			ui.stop();
-			process.exit( exitCode );
 		}
 		return;
 	}
@@ -505,8 +503,12 @@ export async function runCommand( options: {
 		}
 	}
 
+	if ( ! ( ui instanceof AiChatUI ) ) {
+		throw new Error( 'Interactive mode requires AiChatUI adapter' );
+	}
+
 	const slashCommandContext: SlashCommandContext = {
-		ui: ui as AiChatUI,
+		ui,
 		get currentModel() {
 			return currentModel;
 		},

--- a/apps/cli/commands/ai/tests/ai.test.ts
+++ b/apps/cli/commands/ai/tests/ai.test.ts
@@ -495,6 +495,7 @@ describe( 'CLI: studio code --json mode', () => {
 
 	afterEach( () => {
 		process.stdout.write = originalWrite;
+		process.exitCode = undefined;
 	} );
 
 	function buildParser(): StudioArgv {
@@ -551,7 +552,7 @@ describe( 'CLI: studio code --json mode', () => {
 				autoApprove: true,
 			} )
 		);
-		expect( process.exit ).toHaveBeenCalledWith( 0 );
+		expect( process.exitCode ).not.toBe( 1 );
 	} );
 
 	it( 'streams SDK messages as NDJSON', async () => {
@@ -623,7 +624,7 @@ describe( 'CLI: studio code --json mode', () => {
 			type: 'turn.completed',
 			status: 'error',
 		} );
-		expect( process.exit ).toHaveBeenCalledWith( 1 );
+		expect( process.exitCode ).toBe( 1 );
 	} );
 
 	it( 'does not call autoApprove in interactive mode', async () => {


### PR DESCRIPTION
## Related issues

- Related to #3012 (CLI AI: Add `--json` flag for headless NDJSON output)

## Proposed Changes

- Replace `process.exit()` with `process.exitCode` in JSON mode single-turn path and `JsonAdapter.askUser()` so the event loop drains naturally — stdout flushes and async session persistence completes before the process terminates
- Refactor `HandleMessageResult` from a fragile optional-undefined union to a proper discriminated union with a `type` field (`'result' | 'max_turns'`)
- Make `JsonAdapter.showProgress()` emit `progress` NDJSON events consistently with `setLoaderMessage()` instead of silently discarding input
- Replace unsafe `ui as AiChatUI` cast with a runtime `instanceof` guard that throws a clear error if the adapter isn't `AiChatUI`

## Testing Instructions

1. Build the CLI: `npm run cli:build`
2. Run in JSON mode and verify NDJSON events stream correctly and the process exits cleanly:
   ```bash
   node apps/cli/dist/cli/main.mjs code "hello" --json
   ```
3. Verify error exit code is set on failure (e.g., with invalid API key)
4. Run tests: `npm test -- apps/cli/commands/ai/tests/ai.test.ts`

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?