### PR TITLE
Fix TypeScript error in AiOutputAdapter setLoaderMessage

### DIFF
--- a/apps/cli/ai/output-adapter.ts
+++ b/apps/cli/ai/output-adapter.ts
@@ -27,7 +27,7 @@ export interface AiOutputAdapter {
 	showInfo( message: string ): void;
 	showError( message: string ): void;
 	setStatusMessage( message: string | null ): void;
-	setLoaderMessage( message: string ): void;
+	setLoaderMessage( message: string, update?: boolean ): void;
 
 	beginAgentTurn(): void;
 	endAgentTurn(): void;
@@ -93,7 +93,7 @@ export class JsonAdapter implements AiOutputAdapter {
 		// No-op in JSON mode
 	}
 
-	setLoaderMessage( message: string ): void {
+	setLoaderMessage( message: string, _update?: boolean ): void {
 		emitEvent( { type: 'progress', timestamp: new Date().toISOString(), message } );
 	}
 


### PR DESCRIPTION
## Related issues

- Related to #3012

## Proposed Changes

- Add missing optional `update` parameter to the `setLoaderMessage` method in the `AiOutputAdapter` interface and `JsonAdapter` class to match the `UI` class implementation and call site in `commands/ai/index.ts:153`.

## Testing Instructions

- Run `npm run typecheck` and verify no TypeScript error at `commands/ai/index.ts:153:33` ("Expected 1 arguments, but got 2").

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?