### PR TITLE
Add .deployignore entry to 1.7.8 release notes

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@ Unreleased
 =====
 * Released studio code command #3002
 * Added push/pull and import/export commands to the CLI #3010
+* Added .deployignore support for Preview Sites #2924
 * Redesigned titlebar: window title, button sizing, offline indicator #2675
 * Improved rendering correct error and buttons when pull failed #2964
 * Fixed SSL certificate trust nudge on non-English Windows #2932

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,7 +5,7 @@ Unreleased
 =====
 * Released studio code command #3002
 * Added push/pull and import/export commands to the CLI #3010
-* Added .deployignore support for Preview Sites #2924
+* Added .deployignore support for Preview Sites to exclude files from deploys #2924
 * Redesigned titlebar: window title, button sizing, offline indicator #2675
 * Improved rendering correct error and buttons when pull failed #2964
 * Fixed SSL certificate trust nudge on non-English Windows #2932


### PR DESCRIPTION
### Related issues
- Related to #2924
- Related discussion: p1776177845028109-slack-C0ASQG4MR5Y

### Proposed Changes
- Add missing `.deployignore` support entry to the 1.7.8 section of `RELEASE-NOTES.txt`. The feature shipped in 1.7.8 via #2924 but wasn't included in the in-repo changelog.

### Testing Instructions
Visual review is enough.

### Pre-merge Checklist
- [ ] Have you checked for TypeScript, React or other console errors?