### PR TITLE
Fix flaky edit-site-details test on Windows CI (#3068 follow-up)

### DIFF
--- a/apps/studio/src/modules/site-settings/tests/edit-site-details.test.tsx
+++ b/apps/studio/src/modules/site-settings/tests/edit-site-details.test.tsx
@@ -395,9 +395,14 @@ describe( 'EditSiteDetails', () => {
 				isEditModalOpen: true,
 			} )
 		);
-		// Mock the updateSite to delay completion
+		let resolveUpdate: () => void = () => {
+			// Initial no-op reassigned when mockUpdateSite is invoked.
+		};
 		mockUpdateSite.mockImplementation(
-			() => new Promise( ( resolve ) => setTimeout( resolve, 100 ) )
+			() =>
+				new Promise< void >( ( resolve ) => {
+					resolveUpdate = resolve;
+				} )
 		);
 
 		renderWithProvider( <EditSiteDetails { ...defaultProps } /> );
@@ -421,6 +426,8 @@ describe( 'EditSiteDetails', () => {
 		expect( screen.getByLabelText( 'PHP version' ) ).toBeDisabled();
 		expect( screen.getByLabelText( 'WordPress version' ) ).toBeDisabled();
 		expect( screen.getByRole( 'button', { name: 'Cancel' } ) ).toBeDisabled();
+
+		resolveUpdate();
 
 		// Wait for the update to complete
 		await waitFor( () => {


### PR DESCRIPTION
## Related issues

- Follow-up to #3068

## How AI was used in this PR

Claude Code analyzed the Buildkite failure log, traced the race back to the `setTimeout(100)` mock in the test, explained why the `waitFor` added in #3068 was insufficient, and drafted the controllable-promise fix applied here.

## Proposed Changes

- Replace the `setTimeout`-based `mockUpdateSite` implementation in `edit-site-details.test.tsx` with an externally resolvable promise, so the save stays in flight until the test explicitly calls `resolveUpdate()` after the `toBeDisabled()` assertions have run.

### Why #3068 wasn't enough

#3068 wrapped the `'Saving…'` assertion in `waitFor` to give React time to render the saving state. That was necessary, but the underlying race was on the other side: the mocked `updateSite` resolved after 100ms, and on slow Windows runners the synchronous `toBeDisabled()` assertions that followed could run *after* the timer fired and `isEditingSite` had flipped back to `false`. The recent CI failure showed exactly that — the received `<input>` had `value="Test Site"` (the original), meaning the save had fully completed and the form had reset before the assertion executed.

Removing the timer altogether eliminates both ends of the race. The `waitFor` from #3068 is kept because it still serves its purpose (letting React flush the render that shows `'Saving…'`).

## Testing Instructions

- `npm test -- apps/studio/src/modules/site-settings/tests/edit-site-details.test.tsx` — all 19 tests should pass.
- The previously flaky test `should disable form controls when site is being edited` now holds the save promise open until the test releases it, so it should no longer depend on runner speed.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?