### PR TITLE
Fix 'Spinner is already running' error when creating sites via CLI

### DIFF
--- a/apps/cli/commands/site/create.ts
+++ b/apps/cli/commands/site/create.ts
@@ -118,13 +118,17 @@ export async function runCommand(
 			);
 
 			await updateServerFiles();
+			logger.reportSuccess( __( 'Dependencies up to date' ) );
 		}
 	} catch ( error ) {
-		// Swallow errors in production. They aren't critical and likely relate to things outside the
-		// user's control, like network issues or bad API responses.
+		// Errors here aren't critical and likely relate to things outside the user's control,
+		// like network issues or bad API responses. Report them in development, and silently
+		// clear the spinner in production so creation can continue.
 		if ( process.env.NODE_ENV !== 'production' ) {
 			const loggerError = new LoggerError( 'Failed to update dependencies', error );
-			logger.reportError( loggerError );
+			logger.reportError( loggerError, false );
+		} else {
+			logger.reportSuccess( __( 'Dependencies up to date' ), true );
 		}
 	}
 


### PR DESCRIPTION
## Related issues

- Related to STU-1473 (this fix addresses a bug exposed by the ora → picospinner migration)

## How AI was used in this PR

AI assisted with tracing the bug to its two contributing commits (`27a1545b` introduced the unbalanced `reportStart`; `e3c99cf8` made it observable by swapping ora for picospinner) and drafting the fix.

## Proposed Changes

- In `apps/cli/commands/site/create.ts`, the `runCommand()` dependency-check block called `logger.reportStart(CHECKING_DEPENDENCY_UPDATES, …)` but never called a matching `reportSuccess` on the happy path. Under ora, a second `start()` was a no-op; under picospinner, it throws `Spinner is already running.`, failing `site create` with a confusing error.
- Call `logger.reportSuccess(__('Dependencies up to date'))` after `updateServerFiles()` resolves.
- In the catch branch, use `logger.reportError(error, false)` in development (non-fatal, stops spinner) and a silent `logger.reportSuccess(…, true)` in production so the spinner is always cleared before the next `reportStart`.

## Testing Instructions

1. `npm run cli:build`
2. `node apps/cli/dist/cli/main.mjs site create --path ~/Studio/test-site-new`
3. Fill in the prompts (name, WP version, PHP version, etc.).
4. Confirm the site is created successfully and you see `✔ Dependencies up to date` followed by `✔ Site configuration validated` — no `Spinner is already running.` error.
5. To reproduce the pre-fix behaviour, check out trunk and run the same command — it fails on the happy (online) path.
6. `npm test -- apps/cli/commands/site/tests/create.test.ts --run` — 46/46 pass.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?