### PR TITLE
Add update notifier to CLI

### DIFF
--- a/apps/cli/index.ts
+++ b/apps/cli/index.ts
@@ -26,9 +26,7 @@ const version = __STUDIO_CLI_VERSION__;
 suppressPunycodeWarning();
 
 async function main() {
-	// Start update check and register exit handler for the update banner.
-	// Uses a synchronous exit handler so the banner shows even for --version.
-	setupUpdateNotifier( version );
+	await setupUpdateNotifier( version );
 
 	const yargsLocale = await loadTranslations();
 

--- a/apps/cli/index.ts
+++ b/apps/cli/index.ts
@@ -17,6 +17,7 @@ import {
 import { setupServerFiles } from 'cli/lib/dependency-management/setup';
 import { loadTranslations } from 'cli/lib/i18n';
 import { StatsGroup, StatsMetric } from 'cli/lib/types/bump-stats';
+import { setupUpdateNotifier } from 'cli/lib/update-notifier';
 import { untildify } from 'cli/lib/utils';
 import { StudioArgv } from 'cli/types';
 
@@ -25,6 +26,10 @@ const version = __STUDIO_CLI_VERSION__;
 suppressPunycodeWarning();
 
 async function main() {
+	// Start update check and register exit handler for the update banner.
+	// Uses a synchronous exit handler so the banner shows even for --version.
+	setupUpdateNotifier( version );
+
 	const yargsLocale = await loadTranslations();
 
 	if ( semver.lt( process.version, __MINIMUM_NODE_VERSION__ ) ) {

--- a/apps/cli/lib/cli-config/core.ts
+++ b/apps/cli/lib/cli-config/core.ts
@@ -31,6 +31,11 @@ const CLI_CONFIG_VERSION = 1;
 // read this file, and any updates to this schema may require updating the `version` field.
 export const aiProviderSchema = z.enum( [ 'wpcom', 'anthropic-api-key' ] );
 
+export const updateCheckSchema = z.object( {
+	lastChecked: z.number(),
+	latestVersion: z.string(),
+} );
+
 const cliConfigSchema = z.object( {
 	version: z.literal( CLI_CONFIG_VERSION ),
 	sites: z.array( siteSchema ).default( () => [] ),
@@ -40,6 +45,7 @@ const cliConfigSchema = z.object( {
 	lastBumpStats: z
 		.record( z.string(), z.partialRecord( z.enum( StatsMetric ), z.number() ) )
 		.optional(),
+	updateCheck: updateCheckSchema.optional(),
 } );
 
 type CliConfig = z.infer< typeof cliConfigSchema >;

--- a/apps/cli/lib/tests/update-notifier.test.ts
+++ b/apps/cli/lib/tests/update-notifier.test.ts
@@ -1,0 +1,54 @@
+/* eslint-disable no-control-regex */
+import { type MockInstance, vi } from 'vitest';
+import { formatUpdateBanner, setupUpdateNotifier } from 'cli/lib/update-notifier';
+
+describe( 'formatUpdateBanner', () => {
+	it( 'should include version numbers', () => {
+		const banner = formatUpdateBanner( '1.7.8', '1.8.0' );
+		const plain = banner.replace( /\u001B\[[0-9;]*m/g, '' );
+		expect( plain ).toContain( '1.7.8' );
+		expect( plain ).toContain( '1.8.0' );
+	} );
+
+	it( 'should include the npm update command', () => {
+		const banner = formatUpdateBanner( '1.7.8', '1.8.0' );
+		const plain = banner.replace( /\u001B\[[0-9;]*m/g, '' );
+		expect( plain ).toContain( 'npm update -g wp-studio' );
+	} );
+
+	it( 'should include the changelog URL', () => {
+		const banner = formatUpdateBanner( '1.7.8', '1.8.0' );
+		const plain = banner.replace( /\u001B\[[0-9;]*m/g, '' );
+		expect( plain ).toContain(
+			'https://developer.wordpress.com/docs/developer-tools/studio/changelog/'
+		);
+	} );
+
+	it( 'should be wrapped in a box', () => {
+		const banner = formatUpdateBanner( '1.0.0', '2.0.0' );
+		const plain = banner.replace( /\u001B\[[0-9;]*m/g, '' );
+		expect( plain ).toContain( '╭' );
+		expect( plain ).toContain( '╰' );
+		expect( plain ).toContain( '│' );
+	} );
+} );
+
+describe( 'setupUpdateNotifier', () => {
+	const originalSend = process.send;
+	let stderrWriteSpy: MockInstance;
+
+	beforeEach( () => {
+		stderrWriteSpy = vi.spyOn( process.stderr, 'write' ).mockImplementation( () => true );
+	} );
+
+	afterEach( () => {
+		process.send = originalSend;
+		stderrWriteSpy.mockRestore();
+	} );
+
+	it( 'should not show banner when in IPC mode', () => {
+		process.send = vi.fn();
+		setupUpdateNotifier( '1.0.0' );
+		expect( stderrWriteSpy ).not.toHaveBeenCalled();
+	} );
+} );

--- a/apps/cli/lib/tests/update-notifier.test.ts
+++ b/apps/cli/lib/tests/update-notifier.test.ts
@@ -10,18 +10,18 @@ describe( 'formatUpdateBanner', () => {
 		expect( plain ).toContain( '1.8.0' );
 	} );
 
-	it( 'should include the npm update command', () => {
-		const banner = formatUpdateBanner( '1.7.8', '1.8.0' );
-		const plain = banner.replace( /\u001B\[[0-9;]*m/g, '' );
-		expect( plain ).toContain( 'npm update -g wp-studio' );
-	} );
-
 	it( 'should include the changelog URL', () => {
 		const banner = formatUpdateBanner( '1.7.8', '1.8.0' );
 		const plain = banner.replace( /\u001B\[[0-9;]*m/g, '' );
 		expect( plain ).toContain(
 			'https://developer.wordpress.com/docs/developer-tools/studio/changelog/'
 		);
+	} );
+
+	it( 'should include the npm update command', () => {
+		const banner = formatUpdateBanner( '1.7.8', '1.8.0' );
+		const plain = banner.replace( /\u001B\[[0-9;]*m/g, '' );
+		expect( plain ).toContain( 'npm update -g wp-studio' );
 	} );
 
 	it( 'should be wrapped in a box', () => {

--- a/apps/cli/lib/tests/update-notifier.test.ts
+++ b/apps/cli/lib/tests/update-notifier.test.ts
@@ -46,9 +46,9 @@ describe( 'setupUpdateNotifier', () => {
 		stderrWriteSpy.mockRestore();
 	} );
 
-	it( 'should not show banner when in IPC mode', () => {
+	it( 'should not show banner when in IPC mode', async () => {
 		process.send = vi.fn();
-		setupUpdateNotifier( '1.0.0' );
+		await setupUpdateNotifier( '1.0.0' );
 		expect( stderrWriteSpy ).not.toHaveBeenCalled();
 	} );
 } );

--- a/apps/cli/lib/update-notifier.ts
+++ b/apps/cli/lib/update-notifier.ts
@@ -2,19 +2,27 @@ import fs from 'fs';
 import path from 'path';
 import { getConfigDirectory } from '@studio/common/lib/well-known-paths';
 import { __, sprintf } from '@wordpress/i18n';
+import { writeFile } from 'atomically';
 import chalk from 'chalk';
 import semver from 'semver';
+import { z } from 'zod';
 
 const UPDATE_CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24 hours
-const FETCH_TIMEOUT_MS = 5000;
+const FETCH_TIMEOUT_MS = 3000;
 const NPM_REGISTRY_URL = 'https://registry.npmjs.org/wp-studio/latest';
 const CHANGELOG_URL = 'https://developer.wordpress.com/docs/developer-tools/studio/changelog/';
 const CACHE_FILE_NAME = 'cli-update-check.json';
 
-interface UpdateCheckCache {
-	lastChecked: number;
-	latestVersion: string;
-}
+const updateCheckCacheSchema = z.object( {
+	lastChecked: z.number(),
+	latestVersion: z.string(),
+} );
+
+type UpdateCheckCache = z.infer< typeof updateCheckCacheSchema >;
+
+const npmRegistryResponseSchema = z.object( {
+	version: z.string(),
+} );
 
 function getCacheFilePath(): string {
 	return path.join( getConfigDirectory(), CACHE_FILE_NAME );
@@ -23,23 +31,20 @@ function getCacheFilePath(): string {
 function readCache(): UpdateCheckCache | null {
 	try {
 		const content = fs.readFileSync( getCacheFilePath(), 'utf8' );
-		const data = JSON.parse( content );
-		if ( typeof data.lastChecked === 'number' && typeof data.latestVersion === 'string' ) {
-			return data as UpdateCheckCache;
-		}
+		return updateCheckCacheSchema.parse( JSON.parse( content ) );
 	} catch {
 		// Cache doesn't exist or is invalid
 	}
 	return null;
 }
 
-function writeCache( cache: UpdateCheckCache ): void {
+async function writeCache( cache: UpdateCheckCache ): Promise< void > {
 	try {
 		const configDir = getConfigDirectory();
 		if ( ! fs.existsSync( configDir ) ) {
 			fs.mkdirSync( configDir, { recursive: true } );
 		}
-		fs.writeFileSync( getCacheFilePath(), JSON.stringify( cache ), 'utf8' );
+		await writeFile( getCacheFilePath(), JSON.stringify( cache ), { encoding: 'utf8' } );
 	} catch {
 		// Non-critical, ignore write failures
 	}
@@ -60,8 +65,8 @@ async function fetchLatestVersion(): Promise< string | null > {
 			return null;
 		}
 
-		const data = ( await response.json() ) as { version?: string };
-		return typeof data.version === 'string' ? data.version : null;
+		const data = npmRegistryResponseSchema.parse( await response.json() );
+		return data.version;
 	} catch {
 		return null;
 	}
@@ -93,7 +98,7 @@ export function setupUpdateNotifier( currentVersion: string ): void {
 		// Fire and forget -- the result will be cached for the next invocation
 		void fetchLatestVersion().then( ( version ) => {
 			if ( version ) {
-				writeCache( { lastChecked: now, latestVersion: version } );
+				void writeCache( { lastChecked: now, latestVersion: version } );
 			}
 		} );
 	}
@@ -118,11 +123,13 @@ export function formatUpdateBanner( currentVersion: string, latestVersion: strin
 		chalk.dim( currentVersion ),
 		chalk.green( latestVersion )
 	);
+
 	const commandLine = sprintf(
 		/* translators: %s is the npm command to run */
 		__( 'Run %s to update' ),
 		chalk.cyan( 'npm update -g wp-studio' )
 	);
+
 	const changelogLine = sprintf(
 		/* translators: %s is the changelog URL */
 		__( 'Changelog: %s' ),

--- a/apps/cli/lib/update-notifier.ts
+++ b/apps/cli/lib/update-notifier.ts
@@ -19,7 +19,7 @@ const npmRegistryResponseSchema = z.object( {
 
 /**
  * Reads the updateCheck field from cli.json synchronously.
- * Uses a direct fs.readFileSync + JSON.parse to avoid the async readCliConfig path,
+ * Uses a direct fs.readFileSync + zod parse to avoid the async readCliConfig path,
  * so the banner can be printed before any command output.
  */
 function readUpdateCheck(): UpdateCheck | null {
@@ -31,14 +31,6 @@ function readUpdateCheck(): UpdateCheck | null {
 		// File doesn't exist, field missing, or invalid
 	}
 	return null;
-}
-
-async function saveUpdateCheck( updateCheck: UpdateCheck ): Promise< void > {
-	try {
-		await updateCliConfigWithPartial( { updateCheck } );
-	} catch {
-		// Non-critical, ignore write failures
-	}
 }
 
 async function fetchLatestVersion(): Promise< string | null > {
@@ -71,13 +63,12 @@ function hasJsonFlag(): boolean {
  * Checks for available updates and displays a banner at the top of output.
  *
  * Reads the updateCheck field from cli.json synchronously so the banner prints
- * immediately, before any command output. A background fetch refreshes the cached
- * data for the next invocation when it is stale or missing (same pattern as npm's
- * update-notifier).
+ * immediately, before any command output. If the cache is stale or missing,
+ * fetches the latest version from the npm registry and saves it to cli.json.
  *
  * The banner is suppressed in IPC mode or when --json flag is used.
  */
-export function setupUpdateNotifier( currentVersion: string ): void {
+export async function setupUpdateNotifier( currentVersion: string ): Promise< void > {
 	if ( Boolean( process.send ) || hasJsonFlag() ) {
 		return;
 	}
@@ -85,26 +76,30 @@ export function setupUpdateNotifier( currentVersion: string ): void {
 	const updateCheck = readUpdateCheck();
 	const now = Date.now();
 
-	// Start a background fetch if cache is stale or missing
+	// Fetch and cache if stale or missing (up to FETCH_TIMEOUT_MS)
 	if ( ! updateCheck || now - updateCheck.lastChecked >= UPDATE_CHECK_INTERVAL_MS ) {
-		// Fire and forget -- the result will be cached for the next invocation
-		void fetchLatestVersion().then( ( version ) => {
-			if ( version ) {
-				void saveUpdateCheck( { lastChecked: now, latestVersion: version } );
+		const version = await fetchLatestVersion();
+		if ( version ) {
+			try {
+				await updateCliConfigWithPartial( {
+					updateCheck: { lastChecked: now, latestVersion: version },
+				} );
+			} catch {
+				// Non-critical, ignore write failures
 			}
-		} );
+		}
 	}
 
-	// Show the banner immediately from cache (before any command output).
-	// On the first run the cache won't exist yet, so the banner won't show
-	// until the next invocation.
+	// Read again in case we just updated the cache on the first run
+	const latestCheck = readUpdateCheck();
+
 	if (
-		updateCheck &&
-		semver.valid( updateCheck.latestVersion ) &&
+		latestCheck &&
+		semver.valid( latestCheck.latestVersion ) &&
 		semver.valid( currentVersion ) &&
-		semver.gt( updateCheck.latestVersion, currentVersion )
+		semver.gt( latestCheck.latestVersion, currentVersion )
 	) {
-		process.stderr.write( formatUpdateBanner( currentVersion, updateCheck.latestVersion ) );
+		process.stderr.write( formatUpdateBanner( currentVersion, latestCheck.latestVersion ) );
 	}
 }
 

--- a/apps/cli/lib/update-notifier.ts
+++ b/apps/cli/lib/update-notifier.ts
@@ -1,0 +1,153 @@
+import fs from 'fs';
+import path from 'path';
+import { getConfigDirectory } from '@studio/common/lib/well-known-paths';
+import { __, sprintf } from '@wordpress/i18n';
+import chalk from 'chalk';
+import semver from 'semver';
+
+const UPDATE_CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24 hours
+const FETCH_TIMEOUT_MS = 5000;
+const NPM_REGISTRY_URL = 'https://registry.npmjs.org/wp-studio/latest';
+const CHANGELOG_URL = 'https://developer.wordpress.com/docs/developer-tools/studio/changelog/';
+const CACHE_FILE_NAME = 'cli-update-check.json';
+
+interface UpdateCheckCache {
+	lastChecked: number;
+	latestVersion: string;
+}
+
+function getCacheFilePath(): string {
+	return path.join( getConfigDirectory(), CACHE_FILE_NAME );
+}
+
+function readCache(): UpdateCheckCache | null {
+	try {
+		const content = fs.readFileSync( getCacheFilePath(), 'utf8' );
+		const data = JSON.parse( content );
+		if ( typeof data.lastChecked === 'number' && typeof data.latestVersion === 'string' ) {
+			return data as UpdateCheckCache;
+		}
+	} catch {
+		// Cache doesn't exist or is invalid
+	}
+	return null;
+}
+
+function writeCache( cache: UpdateCheckCache ): void {
+	try {
+		const configDir = getConfigDirectory();
+		if ( ! fs.existsSync( configDir ) ) {
+			fs.mkdirSync( configDir, { recursive: true } );
+		}
+		fs.writeFileSync( getCacheFilePath(), JSON.stringify( cache ), 'utf8' );
+	} catch {
+		// Non-critical, ignore write failures
+	}
+}
+
+async function fetchLatestVersion(): Promise< string | null > {
+	try {
+		const controller = new AbortController();
+		const timeout = setTimeout( () => controller.abort(), FETCH_TIMEOUT_MS );
+
+		const response = await fetch( NPM_REGISTRY_URL, {
+			signal: controller.signal,
+			headers: { Accept: 'application/json' },
+		} );
+		clearTimeout( timeout );
+
+		if ( ! response.ok ) {
+			return null;
+		}
+
+		const data = ( await response.json() ) as { version?: string };
+		return typeof data.version === 'string' ? data.version : null;
+	} catch {
+		return null;
+	}
+}
+
+function hasJsonFlag(): boolean {
+	return process.argv.includes( '--json' );
+}
+
+/**
+ * Checks for available updates and displays a banner at the top of output.
+ *
+ * Reads from a local cache file synchronously so the banner prints immediately,
+ * before any command output. A background fetch refreshes the cache for the next
+ * invocation when it is stale or missing (same pattern as npm's update-notifier).
+ *
+ * The banner is suppressed in IPC mode or when --json flag is used.
+ */
+export function setupUpdateNotifier( currentVersion: string ): void {
+	if ( Boolean( process.send ) || hasJsonFlag() ) {
+		return;
+	}
+
+	const cache = readCache();
+	const now = Date.now();
+
+	// Start a background fetch if cache is stale or missing
+	if ( ! cache || now - cache.lastChecked >= UPDATE_CHECK_INTERVAL_MS ) {
+		// Fire and forget -- the result will be cached for the next invocation
+		void fetchLatestVersion().then( ( version ) => {
+			if ( version ) {
+				writeCache( { lastChecked: now, latestVersion: version } );
+			}
+		} );
+	}
+
+	// Show the banner immediately from cache (before any command output).
+	// On the first run the cache won't exist yet, so the banner won't show
+	// until the next invocation.
+	if (
+		cache &&
+		semver.valid( cache.latestVersion ) &&
+		semver.valid( currentVersion ) &&
+		semver.gt( cache.latestVersion, currentVersion )
+	) {
+		process.stderr.write( formatUpdateBanner( currentVersion, cache.latestVersion ) );
+	}
+}
+
+export function formatUpdateBanner( currentVersion: string, latestVersion: string ): string {
+	const updateLine = sprintf(
+		/* translators: 1: current version, 2: latest version */
+		__( 'Update available: %1$s → %2$s' ),
+		chalk.dim( currentVersion ),
+		chalk.green( latestVersion )
+	);
+	const commandLine = sprintf(
+		/* translators: %s is the npm command to run */
+		__( 'Run %s to update' ),
+		chalk.cyan( 'npm update -g wp-studio' )
+	);
+	const changelogLine = sprintf(
+		/* translators: %s is the changelog URL */
+		__( 'Changelog: %s' ),
+		chalk.cyan( CHANGELOG_URL )
+	);
+
+	const lines = [ '', updateLine, commandLine, '', changelogLine, '' ];
+
+	// Calculate box width based on longest line (strip ANSI for measurement)
+	// eslint-disable-next-line no-control-regex
+	const ansiPattern = new RegExp( '\u001B\\[[0-9;]*m', 'g' );
+	const stripAnsi = ( str: string ) => str.replace( ansiPattern, '' );
+	const maxLen = Math.max( ...lines.map( ( l ) => stripAnsi( l ).length ) );
+	const padding = 2;
+	const innerWidth = maxLen + padding * 2;
+
+	const top = chalk.yellow( `╭${ '─'.repeat( innerWidth ) }╮` );
+	const bottom = chalk.yellow( `╰${ '─'.repeat( innerWidth ) }╯` );
+	const side = chalk.yellow( '│' );
+
+	const paddedLines = lines.map( ( line ) => {
+		const visibleLen = stripAnsi( line ).length;
+		const rightPad = innerWidth - padding - visibleLen;
+		return `${ side }${ ' '.repeat( padding ) }${ line }${ ' '.repeat( rightPad ) }${ side }`;
+	} );
+
+	return [ '', top, ...paddedLines, bottom, '' ].join( '\n' );
+}

--- a/apps/cli/lib/update-notifier.ts
+++ b/apps/cli/lib/update-notifier.ts
@@ -69,7 +69,7 @@ function hasJsonFlag(): boolean {
  * The banner is suppressed in IPC mode or when --json flag is used.
  */
 export async function setupUpdateNotifier( currentVersion: string ): Promise< void > {
-	if ( Boolean( process.send ) || hasJsonFlag() ) {
+	if ( ! __IS_PACKAGED_FOR_NPM__ || Boolean( process.send ) || hasJsonFlag() ) {
 		return;
 	}
 

--- a/apps/cli/lib/update-notifier.ts
+++ b/apps/cli/lib/update-notifier.ts
@@ -1,50 +1,41 @@
 import fs from 'fs';
-import path from 'path';
-import { getConfigDirectory } from '@studio/common/lib/well-known-paths';
+import { getCliConfigPath } from '@studio/common/lib/well-known-paths';
 import { __, sprintf } from '@wordpress/i18n';
-import { writeFile } from 'atomically';
 import chalk from 'chalk';
 import semver from 'semver';
 import { z } from 'zod';
+import { updateCheckSchema, updateCliConfigWithPartial } from 'cli/lib/cli-config/core';
 
 const UPDATE_CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24 hours
 const FETCH_TIMEOUT_MS = 3000;
 const NPM_REGISTRY_URL = 'https://registry.npmjs.org/wp-studio/latest';
 const CHANGELOG_URL = 'https://developer.wordpress.com/docs/developer-tools/studio/changelog/';
-const CACHE_FILE_NAME = 'cli-update-check.json';
 
-const updateCheckCacheSchema = z.object( {
-	lastChecked: z.number(),
-	latestVersion: z.string(),
-} );
-
-type UpdateCheckCache = z.infer< typeof updateCheckCacheSchema >;
+type UpdateCheck = z.infer< typeof updateCheckSchema >;
 
 const npmRegistryResponseSchema = z.object( {
 	version: z.string(),
 } );
 
-function getCacheFilePath(): string {
-	return path.join( getConfigDirectory(), CACHE_FILE_NAME );
-}
-
-function readCache(): UpdateCheckCache | null {
+/**
+ * Reads the updateCheck field from cli.json synchronously.
+ * Uses a direct fs.readFileSync + JSON.parse to avoid the async readCliConfig path,
+ * so the banner can be printed before any command output.
+ */
+function readUpdateCheck(): UpdateCheck | null {
 	try {
-		const content = fs.readFileSync( getCacheFilePath(), 'utf8' );
-		return updateCheckCacheSchema.parse( JSON.parse( content ) );
+		const content = fs.readFileSync( getCliConfigPath(), 'utf8' );
+		const data = JSON.parse( content );
+		return updateCheckSchema.parse( data?.updateCheck );
 	} catch {
-		// Cache doesn't exist or is invalid
+		// File doesn't exist, field missing, or invalid
 	}
 	return null;
 }
 
-async function writeCache( cache: UpdateCheckCache ): Promise< void > {
+async function saveUpdateCheck( updateCheck: UpdateCheck ): Promise< void > {
 	try {
-		const configDir = getConfigDirectory();
-		if ( ! fs.existsSync( configDir ) ) {
-			fs.mkdirSync( configDir, { recursive: true } );
-		}
-		await writeFile( getCacheFilePath(), JSON.stringify( cache ), { encoding: 'utf8' } );
+		await updateCliConfigWithPartial( { updateCheck } );
 	} catch {
 		// Non-critical, ignore write failures
 	}
@@ -79,9 +70,10 @@ function hasJsonFlag(): boolean {
 /**
  * Checks for available updates and displays a banner at the top of output.
  *
- * Reads from a local cache file synchronously so the banner prints immediately,
- * before any command output. A background fetch refreshes the cache for the next
- * invocation when it is stale or missing (same pattern as npm's update-notifier).
+ * Reads the updateCheck field from cli.json synchronously so the banner prints
+ * immediately, before any command output. A background fetch refreshes the cached
+ * data for the next invocation when it is stale or missing (same pattern as npm's
+ * update-notifier).
  *
  * The banner is suppressed in IPC mode or when --json flag is used.
  */
@@ -90,15 +82,15 @@ export function setupUpdateNotifier( currentVersion: string ): void {
 		return;
 	}
 
-	const cache = readCache();
+	const updateCheck = readUpdateCheck();
 	const now = Date.now();
 
 	// Start a background fetch if cache is stale or missing
-	if ( ! cache || now - cache.lastChecked >= UPDATE_CHECK_INTERVAL_MS ) {
+	if ( ! updateCheck || now - updateCheck.lastChecked >= UPDATE_CHECK_INTERVAL_MS ) {
 		// Fire and forget -- the result will be cached for the next invocation
 		void fetchLatestVersion().then( ( version ) => {
 			if ( version ) {
-				void writeCache( { lastChecked: now, latestVersion: version } );
+				void saveUpdateCheck( { lastChecked: now, latestVersion: version } );
 			}
 		} );
 	}
@@ -107,12 +99,12 @@ export function setupUpdateNotifier( currentVersion: string ): void {
 	// On the first run the cache won't exist yet, so the banner won't show
 	// until the next invocation.
 	if (
-		cache &&
-		semver.valid( cache.latestVersion ) &&
+		updateCheck &&
+		semver.valid( updateCheck.latestVersion ) &&
 		semver.valid( currentVersion ) &&
-		semver.gt( cache.latestVersion, currentVersion )
+		semver.gt( updateCheck.latestVersion, currentVersion )
 	) {
-		process.stderr.write( formatUpdateBanner( currentVersion, cache.latestVersion ) );
+		process.stderr.write( formatUpdateBanner( currentVersion, updateCheck.latestVersion ) );
 	}
 }
 

--- a/apps/cli/lib/update-notifier.ts
+++ b/apps/cli/lib/update-notifier.ts
@@ -139,7 +139,7 @@ export function formatUpdateBanner( currentVersion: string, latestVersion: strin
 
 	const paddedLines = lines.map( ( line ) => {
 		const visibleLen = stripAnsi( line ).length;
-		const rightPad = innerWidth - padding - visibleLen;
+		const rightPad = Math.max( 0, innerWidth - padding - visibleLen );
 		return `${ side }${ ' '.repeat( padding ) }${ line }${ ' '.repeat( rightPad ) }${ side }`;
 	} );
 

--- a/apps/cli/vitest.config.ts
+++ b/apps/cli/vitest.config.ts
@@ -5,6 +5,9 @@ import sharedConfig from '../../vitest.shared';
 export default mergeConfig(
 	sharedConfig,
 	defineProject( {
+		define: {
+			__IS_PACKAGED_FOR_NPM__: true,
+		},
 		test: {
 			name: 'cli',
 			include: [ '**/*.test.{ts,tsx}' ],


### PR DESCRIPTION
## Related issues

- Fixes STU-1449

## How AI was used in this PR

Claude authored the implementation and tests based on design decisions made collaboratively. All code was reviewed and tested manually.

## Proposed Changes

- Add an update notifier that checks the npm registry for newer versions of `wp-studio` and displays a banner at the top of CLI output
- The banner includes the current/latest version, the `npm update` command, and a link to the changelog at https://developer.wordpress.com/docs/developer-tools/studio/changelog/
- Results are cached locally for 24 hours to avoid repeated network calls
- The banner is suppressed in IPC mode (when CLI is spawned by the desktop app) and when `--json` flag is used

## Testing Instructions

- Build the CLI: `npm run cli:build`
- Temporarily set the version in `apps/cli/package.json` to an old version (e.g., `1.0.0`), rebuild, then run any command twice:
  - First run populates the cache
  - Second run displays the update banner at the top of output
- Verify the banner shows for `--version`, `site list`, and other commands
- Verify the banner does NOT show when using `--json` flag
- Restore the version back to the original value after testing

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?