### PR TITLE
Add ToS and Privacy Policy to onboarding screen

### DIFF
--- a/apps/studio/src/components/tests/onboarding.test.tsx
+++ b/apps/studio/src/components/tests/onboarding.test.tsx
@@ -35,10 +35,12 @@ vi.mock( 'src/stores/app-version-api', async () => {
 } );
 
 const mockSaveOnboarding = vi.fn();
+const mockOpenURL = vi.fn();
 
 vi.mock( 'src/lib/get-ipc-api', () => ( {
 	getIpcApi: vi.fn( () => ( {
 		saveOnboarding: mockSaveOnboarding,
+		openURL: mockOpenURL,
 	} ) ),
 } ) );
 
@@ -100,6 +102,30 @@ describe( 'Onboarding Component', () => {
 		await user.hover( logIn );
 
 		expect( screen.queryByText( "You're currently offline." ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'renders the Terms of Service and Privacy Policy links', () => {
+		renderWithProvider( <Onboarding /> );
+
+		expect( screen.getByTestId( 'onboarding-legal' ) ).toBeVisible();
+		expect( screen.getByRole( 'button', { name: 'Terms of Service' } ) ).toBeVisible();
+		expect( screen.getByRole( 'button', { name: 'Privacy Policy' } ) ).toBeVisible();
+	} );
+
+	it( 'opens the Terms of Service URL when the link is clicked', async () => {
+		renderWithProvider( <Onboarding /> );
+
+		await user.click( screen.getByRole( 'button', { name: 'Terms of Service' } ) );
+
+		expect( mockOpenURL ).toHaveBeenCalledWith( 'https://wordpress.com/tos/' );
+	} );
+
+	it( 'opens the Privacy Policy URL when the link is clicked', async () => {
+		renderWithProvider( <Onboarding /> );
+
+		await user.click( screen.getByRole( 'button', { name: 'Privacy Policy' } ) );
+
+		expect( mockOpenURL ).toHaveBeenCalledWith( 'https://automattic.com/privacy/' );
 	} );
 
 	it( 'should save the current app version when onboarding completes', async () => {

--- a/apps/studio/src/lib/get-localized-link.ts
+++ b/apps/studio/src/lib/get-localized-link.ts
@@ -62,6 +62,12 @@ const A8C_LINKS = {
 	a8cAiGuidelines: {
 		en: 'https://automattic.com/ai-guidelines/',
 	},
+	a8cPrivacyPolicy: {
+		en: 'https://automattic.com/privacy/',
+	},
+	a8cTos: {
+		en: 'https://wordpress.com/tos/',
+	},
 } satisfies Record< `a8c${ string }`, TranslatedLink >;
 
 const LINKS = {

--- a/apps/studio/src/modules/onboarding/components/connect-to-wpcom.tsx
+++ b/apps/studio/src/modules/onboarding/components/connect-to-wpcom.tsx
@@ -1,4 +1,5 @@
 import { __experimentalHeading as Heading, Icon } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
 import { check } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { ArrowIcon } from 'src/components/arrow-icon';
@@ -8,16 +9,19 @@ import { Tooltip } from 'src/components/tooltip';
 import { useAuth } from 'src/hooks/use-auth';
 import { useOffline } from 'src/hooks/use-offline';
 import { getIpcApi } from 'src/lib/get-ipc-api';
+import { getLocalizedLink } from 'src/lib/get-localized-link';
+import { useI18nLocale } from 'src/stores';
 
 export function OnboardingConnectToWpcom( { onSkip }: { onSkip: () => void } ) {
 	const { __ } = useI18n();
 	const isOffline = useOffline();
 	const offlineMessage = __( "You're currently offline." );
 	const { authenticate } = useAuth();
+	const locale = useI18nLocale();
 
 	return (
-		<div className="h-full flex flex-col">
-			<div className="flex flex-col gap-4 my-auto text-pretty">
+		<div className="h-full min-h-0 flex flex-col">
+			<div className="flex flex-col gap-4 flex-1 justify-center text-pretty min-h-0">
 				<Heading data-testid="onboarding-welcome-title" className="a8c-subtitle text-xl">
 					{ __( 'Welcome to WordPress Studio' ) }
 				</Heading>
@@ -90,6 +94,35 @@ export function OnboardingConnectToWpcom( { onSkip }: { onSkip: () => void } ) {
 						</Button>
 					</div>
 				</Tooltip>
+			</div>
+
+			<div
+				data-testid="onboarding-legal"
+				className="text-frame-text-secondary text-xs leading-5 shrink-0 pt-10"
+			>
+				{ createInterpolateElement(
+					__(
+						'By continuing, you agree to our <tos_link>Terms of Service</tos_link> and have read our <privacy_link>Privacy Policy</privacy_link>.'
+					),
+					{
+						tos_link: (
+							<Button
+								className="!p-0 text-frame-theme hover:opacity-80 h-auto !text-xs underline"
+								variant="link"
+								onClick={ () => getIpcApi().openURL( getLocalizedLink( locale, 'a8cTos' ) ) }
+							/>
+						),
+						privacy_link: (
+							<Button
+								className="!p-0 text-frame-theme hover:opacity-80 h-auto !text-xs underline"
+								variant="link"
+								onClick={ () =>
+									getIpcApi().openURL( getLocalizedLink( locale, 'a8cPrivacyPolicy' ) )
+								}
+							/>
+						),
+					}
+				) }
 			</div>
 		</div>
 	);

--- a/apps/studio/src/modules/onboarding/components/connect-to-wpcom.tsx
+++ b/apps/studio/src/modules/onboarding/components/connect-to-wpcom.tsx
@@ -107,14 +107,14 @@ export function OnboardingConnectToWpcom( { onSkip }: { onSkip: () => void } ) {
 					{
 						tos_link: (
 							<Button
-								className="!p-0 text-frame-theme hover:opacity-80 h-auto !text-xs underline"
+								className="learn-more-link !p-0 h-auto !text-xs"
 								variant="link"
 								onClick={ () => getIpcApi().openURL( getLocalizedLink( locale, 'a8cTos' ) ) }
 							/>
 						),
 						privacy_link: (
 							<Button
-								className="!p-0 text-frame-theme hover:opacity-80 h-auto !text-xs underline"
+								className="learn-more-link !p-0 h-auto !text-xs"
 								variant="link"
 								onClick={ () =>
 									getIpcApi().openURL( getLocalizedLink( locale, 'a8cPrivacyPolicy' ) )


### PR DESCRIPTION
## Related issues

- Fixes STU-1469

## How AI was used in this PR

AI assisted with code writing. I adjusted result and fixed a few things.

## Proposed Changes

Legal asked to add ToS and Privacy Policy p4H3ND-22K-p2#comment-4350

## Testing Instructions
1. Remove app.json from `.studio` (Setting `onboardingCompleted` to `false` didn't work for me. Maybe there were some local nuances. So you can try it.)
2. Assert that you see ToS and Privacy Policy at the bottom
<img width="537" height="740" alt="Screenshot 2026-04-15 at 12 09 09" src="https://github.com/user-attachments/assets/b5707ea4-2a75-42cf-8f02-a369fc2965d9" />
