### PR TITLE
CLI: Throttle dependency update checks to once per 24h

### DIFF
--- a/apps/cli/commands/site/create.ts
+++ b/apps/cli/commands/site/create.ts
@@ -112,12 +112,10 @@ export async function runCommand(
 
 	try {
 		if ( isOnlineStatus ) {
-			logger.reportStart(
-				LoggerAction.CHECKING_DEPENDENCY_UPDATES,
-				__( 'Checking for dependency updates…' )
-			);
-
-			await updateServerFiles();
+			const updated = await updateServerFiles();
+			if ( updated ) {
+				logger.reportSuccess( __( 'Dependencies updated' ) );
+			}
 		}
 	} catch ( error ) {
 		// Errors here aren't critical and likely relate to things outside the user's control,

--- a/apps/cli/commands/site/create.ts
+++ b/apps/cli/commands/site/create.ts
@@ -66,11 +66,7 @@ import {
 	updateSiteLatestCliPid,
 } from 'cli/lib/cli-config/sites';
 import { connectToDaemon, disconnectFromDaemon, emitCliEvent } from 'cli/lib/daemon-client';
-import {
-	markDependencyCheckTime,
-	shouldCheckDependencyUpdates,
-	updateServerFiles,
-} from 'cli/lib/dependency-management/setup';
+import { updateServerFiles } from 'cli/lib/dependency-management/setup';
 import { copyLanguagePackToSite } from 'cli/lib/language-packs';
 import { getAiInstructionsPath } from 'cli/lib/server-files';
 import { getPreferredSiteLanguage } from 'cli/lib/site-language';
@@ -115,14 +111,13 @@ export async function runCommand(
 	const isOnlineStatus = await isOnline();
 
 	try {
-		if ( isOnlineStatus && ( await shouldCheckDependencyUpdates() ) ) {
+		if ( isOnlineStatus ) {
 			logger.reportStart(
 				LoggerAction.CHECKING_DEPENDENCY_UPDATES,
 				__( 'Checking for dependency updates…' )
 			);
 
 			await updateServerFiles();
-			await markDependencyCheckTime();
 			logger.reportSuccess( __( 'Dependencies up to date' ) );
 		}
 	} catch ( error ) {

--- a/apps/cli/commands/site/create.ts
+++ b/apps/cli/commands/site/create.ts
@@ -66,7 +66,11 @@ import {
 	updateSiteLatestCliPid,
 } from 'cli/lib/cli-config/sites';
 import { connectToDaemon, disconnectFromDaemon, emitCliEvent } from 'cli/lib/daemon-client';
-import { updateServerFiles } from 'cli/lib/dependency-management/setup';
+import {
+	markDependencyCheckTime,
+	shouldCheckDependencyUpdates,
+	updateServerFiles,
+} from 'cli/lib/dependency-management/setup';
 import { copyLanguagePackToSite } from 'cli/lib/language-packs';
 import { getAiInstructionsPath } from 'cli/lib/server-files';
 import { getPreferredSiteLanguage } from 'cli/lib/site-language';
@@ -111,13 +115,14 @@ export async function runCommand(
 	const isOnlineStatus = await isOnline();
 
 	try {
-		if ( isOnlineStatus ) {
+		if ( isOnlineStatus && ( await shouldCheckDependencyUpdates() ) ) {
 			logger.reportStart(
 				LoggerAction.CHECKING_DEPENDENCY_UPDATES,
 				__( 'Checking for dependency updates…' )
 			);
 
 			await updateServerFiles();
+			await markDependencyCheckTime();
 			logger.reportSuccess( __( 'Dependencies up to date' ) );
 		}
 	} catch ( error ) {

--- a/apps/cli/commands/site/tests/create.test.ts
+++ b/apps/cli/commands/site/tests/create.test.ts
@@ -25,11 +25,7 @@ import {
 } from 'cli/lib/cli-config/core';
 import { removeSiteFromConfig, updateSiteAutoStart } from 'cli/lib/cli-config/sites';
 import { connectToDaemon, disconnectFromDaemon } from 'cli/lib/daemon-client';
-import {
-	markDependencyCheckTime,
-	shouldCheckDependencyUpdates,
-	updateServerFiles,
-} from 'cli/lib/dependency-management/setup';
+import { updateServerFiles } from 'cli/lib/dependency-management/setup';
 import { copyLanguagePackToSite } from 'cli/lib/language-packs';
 import { getPreferredSiteLanguage } from 'cli/lib/site-language';
 import { logSiteDetails, openSiteInBrowser, setupCustomDomain } from 'cli/lib/site-utils';
@@ -165,9 +161,7 @@ describe( 'CLI: studio site create', () => {
 		vi.mocked( keepSqliteIntegrationUpdated ).mockResolvedValue( true );
 		vi.mocked( connectToDaemon ).mockResolvedValue( undefined );
 		vi.mocked( disconnectFromDaemon ).mockResolvedValue( undefined );
-		vi.mocked( updateServerFiles ).mockResolvedValue( undefined );
-		vi.mocked( shouldCheckDependencyUpdates ).mockResolvedValue( true );
-		vi.mocked( markDependencyCheckTime ).mockResolvedValue( undefined );
+		vi.mocked( updateServerFiles ).mockResolvedValue( true );
 		vi.mocked( setupCustomDomain ).mockResolvedValue( undefined );
 		vi.mocked( startWordPressServer ).mockResolvedValue( mockProcessDescription );
 		vi.mocked( runBlueprint ).mockResolvedValue( undefined );
@@ -1040,33 +1034,19 @@ $table_prefix = 'wp_';
 		} );
 	} );
 
-	describe( 'Dependency update throttling', () => {
-		it( 'runs and records the dependency check when throttle is expired', async () => {
-			vi.mocked( shouldCheckDependencyUpdates ).mockResolvedValue( true );
-
+	describe( 'Dependency updates', () => {
+		it( 'calls updateServerFiles when online', async () => {
 			await runCommand( mockSitePath, { ...defaultTestOptions } );
 
 			expect( updateServerFiles ).toHaveBeenCalledTimes( 1 );
-			expect( markDependencyCheckTime ).toHaveBeenCalledTimes( 1 );
 		} );
 
-		it( 'skips the dependency check when called within the throttle window', async () => {
-			vi.mocked( shouldCheckDependencyUpdates ).mockResolvedValue( false );
-
-			await runCommand( mockSitePath, { ...defaultTestOptions } );
-
-			expect( updateServerFiles ).not.toHaveBeenCalled();
-			expect( markDependencyCheckTime ).not.toHaveBeenCalled();
-		} );
-
-		it( 'skips the dependency check when offline regardless of throttle', async () => {
+		it( 'skips updateServerFiles when offline', async () => {
 			vi.mocked( isOnline ).mockResolvedValue( false );
-			vi.mocked( shouldCheckDependencyUpdates ).mockResolvedValue( true );
 
 			await runCommand( mockSitePath, { ...defaultTestOptions } );
 
 			expect( updateServerFiles ).not.toHaveBeenCalled();
-			expect( markDependencyCheckTime ).not.toHaveBeenCalled();
 		} );
 	} );
 } );

--- a/apps/cli/commands/site/tests/create.test.ts
+++ b/apps/cli/commands/site/tests/create.test.ts
@@ -25,7 +25,11 @@ import {
 } from 'cli/lib/cli-config/core';
 import { removeSiteFromConfig, updateSiteAutoStart } from 'cli/lib/cli-config/sites';
 import { connectToDaemon, disconnectFromDaemon } from 'cli/lib/daemon-client';
-import { updateServerFiles } from 'cli/lib/dependency-management/setup';
+import {
+	markDependencyCheckTime,
+	shouldCheckDependencyUpdates,
+	updateServerFiles,
+} from 'cli/lib/dependency-management/setup';
 import { copyLanguagePackToSite } from 'cli/lib/language-packs';
 import { getPreferredSiteLanguage } from 'cli/lib/site-language';
 import { logSiteDetails, openSiteInBrowser, setupCustomDomain } from 'cli/lib/site-utils';
@@ -162,6 +166,8 @@ describe( 'CLI: studio site create', () => {
 		vi.mocked( connectToDaemon ).mockResolvedValue( undefined );
 		vi.mocked( disconnectFromDaemon ).mockResolvedValue( undefined );
 		vi.mocked( updateServerFiles ).mockResolvedValue( undefined );
+		vi.mocked( shouldCheckDependencyUpdates ).mockResolvedValue( true );
+		vi.mocked( markDependencyCheckTime ).mockResolvedValue( undefined );
 		vi.mocked( setupCustomDomain ).mockResolvedValue( undefined );
 		vi.mocked( startWordPressServer ).mockResolvedValue( mockProcessDescription );
 		vi.mocked( runBlueprint ).mockResolvedValue( undefined );
@@ -1031,6 +1037,36 @@ $table_prefix = 'wp_';
 				expect.anything(),
 				'utf-8'
 			);
+		} );
+	} );
+
+	describe( 'Dependency update throttling', () => {
+		it( 'runs and records the dependency check when throttle is expired', async () => {
+			vi.mocked( shouldCheckDependencyUpdates ).mockResolvedValue( true );
+
+			await runCommand( mockSitePath, { ...defaultTestOptions } );
+
+			expect( updateServerFiles ).toHaveBeenCalledTimes( 1 );
+			expect( markDependencyCheckTime ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( 'skips the dependency check when called within the throttle window', async () => {
+			vi.mocked( shouldCheckDependencyUpdates ).mockResolvedValue( false );
+
+			await runCommand( mockSitePath, { ...defaultTestOptions } );
+
+			expect( updateServerFiles ).not.toHaveBeenCalled();
+			expect( markDependencyCheckTime ).not.toHaveBeenCalled();
+		} );
+
+		it( 'skips the dependency check when offline regardless of throttle', async () => {
+			vi.mocked( isOnline ).mockResolvedValue( false );
+			vi.mocked( shouldCheckDependencyUpdates ).mockResolvedValue( true );
+
+			await runCommand( mockSitePath, { ...defaultTestOptions } );
+
+			expect( updateServerFiles ).not.toHaveBeenCalled();
+			expect( markDependencyCheckTime ).not.toHaveBeenCalled();
 		} );
 	} );
 } );

--- a/apps/cli/lib/cli-config/core.ts
+++ b/apps/cli/lib/cli-config/core.ts
@@ -40,6 +40,7 @@ const cliConfigSchema = z.object( {
 	lastBumpStats: z
 		.record( z.string(), z.partialRecord( z.enum( StatsMetric ), z.number() ) )
 		.optional(),
+	lastDependencyCheckTime: z.number().optional(),
 } );
 
 type CliConfig = z.infer< typeof cliConfigSchema >;

--- a/apps/cli/lib/dependency-management/setup.ts
+++ b/apps/cli/lib/dependency-management/setup.ts
@@ -2,6 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import { recursiveCopyDirectory } from '@studio/common/lib/fs-utils';
 import semver from 'semver';
+import { readCliConfig, updateCliConfigWithPartial } from 'cli/lib/cli-config/core';
 import { getSqliteVersionFromInstallation } from 'cli/lib/sqlite-integration';
 import {
 	getAiInstructionsPath,
@@ -266,5 +267,32 @@ export async function updateServerFiles() {
 		await updateLatestWordPressVersion();
 	} catch ( error ) {
 		console.error( 'Failed to update dependency WordPress version:', error );
+	}
+}
+
+export const DEPENDENCY_CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000;
+
+export async function shouldCheckDependencyUpdates(): Promise< boolean > {
+	try {
+		const { lastDependencyCheckTime } = await readCliConfig();
+		if ( typeof lastDependencyCheckTime !== 'number' ) {
+			return true;
+		}
+		const now = Date.now();
+		// Treat future timestamps (clock skew) as stale.
+		if ( lastDependencyCheckTime > now ) {
+			return true;
+		}
+		return now - lastDependencyCheckTime >= DEPENDENCY_CHECK_INTERVAL_MS;
+	} catch {
+		return true;
+	}
+}
+
+export async function markDependencyCheckTime(): Promise< void > {
+	try {
+		await updateCliConfigWithPartial( { lastDependencyCheckTime: Date.now() } );
+	} catch ( error ) {
+		console.error( 'Failed to persist dependency check timestamp:', error );
 	}
 }

--- a/apps/cli/lib/dependency-management/setup.ts
+++ b/apps/cli/lib/dependency-management/setup.ts
@@ -262,6 +262,14 @@ export async function setupServerFiles() {
 	}
 }
 
+/**
+ * Fetches the latest WordPress version from the network.
+ *
+ * This performs a network request, so callers should gate it behind
+ * `shouldCheckDependencyUpdates()` and follow a successful call with
+ * `markDependencyCheckTime()` to avoid hitting the network on every
+ * invocation (see STU-1455).
+ */
 export async function updateServerFiles() {
 	try {
 		await updateLatestWordPressVersion();

--- a/apps/cli/lib/dependency-management/setup.ts
+++ b/apps/cli/lib/dependency-management/setup.ts
@@ -262,25 +262,9 @@ export async function setupServerFiles() {
 	}
 }
 
-/**
- * Fetches the latest WordPress version from the network.
- *
- * This performs a network request, so callers should gate it behind
- * `shouldCheckDependencyUpdates()` and follow a successful call with
- * `markDependencyCheckTime()` to avoid hitting the network on every
- * invocation (see STU-1455).
- */
-export async function updateServerFiles() {
-	try {
-		await updateLatestWordPressVersion();
-	} catch ( error ) {
-		console.error( 'Failed to update dependency WordPress version:', error );
-	}
-}
-
 export const DEPENDENCY_CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000;
 
-export async function shouldCheckDependencyUpdates(): Promise< boolean > {
+async function shouldCheckDependencyUpdates(): Promise< boolean > {
 	try {
 		const { lastDependencyCheckTime } = await readCliConfig();
 		if ( typeof lastDependencyCheckTime !== 'number' ) {
@@ -297,10 +281,29 @@ export async function shouldCheckDependencyUpdates(): Promise< boolean > {
 	}
 }
 
-export async function markDependencyCheckTime(): Promise< void > {
+async function markDependencyCheckTime(): Promise< void > {
 	try {
 		await updateCliConfigWithPartial( { lastDependencyCheckTime: Date.now() } );
 	} catch ( error ) {
 		console.error( 'Failed to persist dependency check timestamp:', error );
 	}
+}
+
+/**
+ * Checks for and applies dependency updates (e.g. WordPress versions), throttled
+ * to at most once per 24 hours. Returns true if the check ran, false if skipped.
+ */
+export async function updateServerFiles(): Promise< boolean > {
+	if ( ! ( await shouldCheckDependencyUpdates() ) ) {
+		return false;
+	}
+
+	try {
+		await updateLatestWordPressVersion();
+	} catch ( error ) {
+		console.error( 'Failed to update dependency WordPress version:', error );
+	}
+
+	await markDependencyCheckTime();
+	return true;
 }

--- a/apps/cli/lib/dependency-management/tests/setup.test.ts
+++ b/apps/cli/lib/dependency-management/tests/setup.test.ts
@@ -1,0 +1,85 @@
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { readCliConfig, updateCliConfigWithPartial } from 'cli/lib/cli-config/core';
+import {
+	DEPENDENCY_CHECK_INTERVAL_MS,
+	markDependencyCheckTime,
+	shouldCheckDependencyUpdates,
+} from '../setup';
+
+vi.mock( 'cli/lib/cli-config/core', () => ( {
+	readCliConfig: vi.fn(),
+	updateCliConfigWithPartial: vi.fn(),
+} ) );
+
+describe( 'dependency-management/setup throttling', () => {
+	const NOW = 1_700_000_000_000;
+
+	beforeEach( () => {
+		vi.clearAllMocks();
+		vi.useFakeTimers();
+		vi.setSystemTime( NOW );
+	} );
+
+	afterEach( () => {
+		vi.useRealTimers();
+	} );
+
+	describe( 'shouldCheckDependencyUpdates', () => {
+		it( 'returns true when no timestamp has been recorded', async () => {
+			vi.mocked( readCliConfig ).mockResolvedValue( { version: 1, sites: [], snapshots: [] } );
+			await expect( shouldCheckDependencyUpdates() ).resolves.toBe( true );
+		} );
+
+		it( 'returns true when the last check is older than the interval', async () => {
+			vi.mocked( readCliConfig ).mockResolvedValue( {
+				version: 1,
+				sites: [],
+				snapshots: [],
+				lastDependencyCheckTime: NOW - DEPENDENCY_CHECK_INTERVAL_MS - 1,
+			} );
+			await expect( shouldCheckDependencyUpdates() ).resolves.toBe( true );
+		} );
+
+		it( 'returns false when the last check is within the interval', async () => {
+			vi.mocked( readCliConfig ).mockResolvedValue( {
+				version: 1,
+				sites: [],
+				snapshots: [],
+				lastDependencyCheckTime: NOW - 60 * 1000,
+			} );
+			await expect( shouldCheckDependencyUpdates() ).resolves.toBe( false );
+		} );
+
+		it( 'returns true when the timestamp is in the future (clock skew)', async () => {
+			vi.mocked( readCliConfig ).mockResolvedValue( {
+				version: 1,
+				sites: [],
+				snapshots: [],
+				lastDependencyCheckTime: NOW + 60 * 1000,
+			} );
+			await expect( shouldCheckDependencyUpdates() ).resolves.toBe( true );
+		} );
+
+		it( 'returns true when reading the config throws', async () => {
+			vi.mocked( readCliConfig ).mockRejectedValue( new Error( 'boom' ) );
+			await expect( shouldCheckDependencyUpdates() ).resolves.toBe( true );
+		} );
+	} );
+
+	describe( 'markDependencyCheckTime', () => {
+		it( 'persists the current time to the cli config', async () => {
+			vi.mocked( updateCliConfigWithPartial ).mockResolvedValue( undefined );
+			await markDependencyCheckTime();
+			expect( updateCliConfigWithPartial ).toHaveBeenCalledWith( {
+				lastDependencyCheckTime: NOW,
+			} );
+		} );
+
+		it( 'swallows errors from the cli config write', async () => {
+			const consoleErrorSpy = vi.spyOn( console, 'error' ).mockImplementation( () => {} );
+			vi.mocked( updateCliConfigWithPartial ).mockRejectedValue( new Error( 'write failed' ) );
+			await expect( markDependencyCheckTime() ).resolves.toBeUndefined();
+			consoleErrorSpy.mockRestore();
+		} );
+	} );
+} );

--- a/apps/cli/lib/dependency-management/tests/setup.test.ts
+++ b/apps/cli/lib/dependency-management/tests/setup.test.ts
@@ -75,10 +75,15 @@ describe( 'dependency-management/setup throttling', () => {
 			} );
 		} );
 
-		it( 'swallows errors from the cli config write', async () => {
+		it( 'swallows errors from the cli config write and logs them', async () => {
 			const consoleErrorSpy = vi.spyOn( console, 'error' ).mockImplementation( () => {} );
-			vi.mocked( updateCliConfigWithPartial ).mockRejectedValue( new Error( 'write failed' ) );
+			const error = new Error( 'write failed' );
+			vi.mocked( updateCliConfigWithPartial ).mockRejectedValue( error );
 			await expect( markDependencyCheckTime() ).resolves.toBeUndefined();
+			expect( consoleErrorSpy ).toHaveBeenCalledWith(
+				'Failed to persist dependency check timestamp:',
+				error
+			);
 			consoleErrorSpy.mockRestore();
 		} );
 	} );

--- a/apps/cli/lib/dependency-management/tests/setup.test.ts
+++ b/apps/cli/lib/dependency-management/tests/setup.test.ts
@@ -1,90 +1,139 @@
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { readCliConfig, updateCliConfigWithPartial } from 'cli/lib/cli-config/core';
-import {
-	DEPENDENCY_CHECK_INTERVAL_MS,
-	markDependencyCheckTime,
-	shouldCheckDependencyUpdates,
-} from '../setup';
+import { DEPENDENCY_CHECK_INTERVAL_MS, updateServerFiles } from '../setup';
+import { updateLatestWordPressVersion } from '../wordpress';
 
 vi.mock( 'cli/lib/cli-config/core', () => ( {
 	readCliConfig: vi.fn(),
 	updateCliConfigWithPartial: vi.fn(),
 } ) );
 
-describe( 'dependency-management/setup throttling', () => {
+vi.mock( '../wordpress' );
+
+describe( 'updateServerFiles', () => {
 	const NOW = 1_700_000_000_000;
 
 	beforeEach( () => {
 		vi.clearAllMocks();
 		vi.useFakeTimers();
 		vi.setSystemTime( NOW );
+		vi.spyOn( console, 'error' ).mockImplementation( () => {} );
+		vi.mocked( updateLatestWordPressVersion ).mockResolvedValue( undefined );
+		vi.mocked( updateCliConfigWithPartial ).mockResolvedValue( undefined );
 	} );
 
 	afterEach( () => {
 		vi.useRealTimers();
+		vi.restoreAllMocks();
 	} );
 
-	describe( 'shouldCheckDependencyUpdates', () => {
-		it( 'returns true when no timestamp has been recorded', async () => {
+	describe( 'throttling', () => {
+		it( 'runs the update when no timestamp has been recorded', async () => {
 			vi.mocked( readCliConfig ).mockResolvedValue( { version: 1, sites: [], snapshots: [] } );
-			await expect( shouldCheckDependencyUpdates() ).resolves.toBe( true );
+
+			const result = await updateServerFiles();
+
+			expect( result ).toBe( true );
+			expect( updateLatestWordPressVersion ).toHaveBeenCalledTimes( 1 );
 		} );
 
-		it( 'returns true when the last check is older than the interval', async () => {
+		it( 'runs the update when the last check is older than the interval', async () => {
 			vi.mocked( readCliConfig ).mockResolvedValue( {
 				version: 1,
 				sites: [],
 				snapshots: [],
 				lastDependencyCheckTime: NOW - DEPENDENCY_CHECK_INTERVAL_MS - 1,
 			} );
-			await expect( shouldCheckDependencyUpdates() ).resolves.toBe( true );
+
+			const result = await updateServerFiles();
+
+			expect( result ).toBe( true );
+			expect( updateLatestWordPressVersion ).toHaveBeenCalledTimes( 1 );
 		} );
 
-		it( 'returns false when the last check is within the interval', async () => {
+		it( 'skips the update when the last check is within the interval', async () => {
 			vi.mocked( readCliConfig ).mockResolvedValue( {
 				version: 1,
 				sites: [],
 				snapshots: [],
 				lastDependencyCheckTime: NOW - 60 * 1000,
 			} );
-			await expect( shouldCheckDependencyUpdates() ).resolves.toBe( false );
+
+			const result = await updateServerFiles();
+
+			expect( result ).toBe( false );
+			expect( updateLatestWordPressVersion ).not.toHaveBeenCalled();
 		} );
 
-		it( 'returns true when the timestamp is in the future (clock skew)', async () => {
+		it( 'runs the update when the timestamp is in the future (clock skew)', async () => {
 			vi.mocked( readCliConfig ).mockResolvedValue( {
 				version: 1,
 				sites: [],
 				snapshots: [],
 				lastDependencyCheckTime: NOW + 60 * 1000,
 			} );
-			await expect( shouldCheckDependencyUpdates() ).resolves.toBe( true );
+
+			const result = await updateServerFiles();
+
+			expect( result ).toBe( true );
+			expect( updateLatestWordPressVersion ).toHaveBeenCalledTimes( 1 );
 		} );
 
-		it( 'returns true when reading the config throws', async () => {
+		it( 'runs the update when reading the config throws', async () => {
 			vi.mocked( readCliConfig ).mockRejectedValue( new Error( 'boom' ) );
-			await expect( shouldCheckDependencyUpdates() ).resolves.toBe( true );
+
+			const result = await updateServerFiles();
+
+			expect( result ).toBe( true );
+			expect( updateLatestWordPressVersion ).toHaveBeenCalledTimes( 1 );
 		} );
 	} );
 
-	describe( 'markDependencyCheckTime', () => {
-		it( 'persists the current time to the cli config', async () => {
-			vi.mocked( updateCliConfigWithPartial ).mockResolvedValue( undefined );
-			await markDependencyCheckTime();
+	describe( 'timestamp persistence', () => {
+		it( 'persists the current time after a successful update', async () => {
+			vi.mocked( readCliConfig ).mockResolvedValue( { version: 1, sites: [], snapshots: [] } );
+
+			await updateServerFiles();
+
 			expect( updateCliConfigWithPartial ).toHaveBeenCalledWith( {
 				lastDependencyCheckTime: NOW,
 			} );
 		} );
 
-		it( 'swallows errors from the cli config write and logs them', async () => {
-			const consoleErrorSpy = vi.spyOn( console, 'error' ).mockImplementation( () => {} );
+		it( 'persists the timestamp even when the update throws', async () => {
+			vi.mocked( readCliConfig ).mockResolvedValue( { version: 1, sites: [], snapshots: [] } );
+			vi.mocked( updateLatestWordPressVersion ).mockRejectedValue( new Error( 'network' ) );
+
+			await updateServerFiles();
+
+			expect( updateCliConfigWithPartial ).toHaveBeenCalledWith( {
+				lastDependencyCheckTime: NOW,
+			} );
+		} );
+
+		it( 'does not persist the timestamp when the check is skipped', async () => {
+			vi.mocked( readCliConfig ).mockResolvedValue( {
+				version: 1,
+				sites: [],
+				snapshots: [],
+				lastDependencyCheckTime: NOW - 60 * 1000,
+			} );
+
+			await updateServerFiles();
+
+			expect( updateCliConfigWithPartial ).not.toHaveBeenCalled();
+		} );
+
+		it( 'swallows errors from the timestamp write and logs them', async () => {
+			vi.mocked( readCliConfig ).mockResolvedValue( { version: 1, sites: [], snapshots: [] } );
 			const error = new Error( 'write failed' );
 			vi.mocked( updateCliConfigWithPartial ).mockRejectedValue( error );
-			await expect( markDependencyCheckTime() ).resolves.toBeUndefined();
-			expect( consoleErrorSpy ).toHaveBeenCalledWith(
+
+			await expect( updateServerFiles() ).resolves.toBe( true );
+			expect( console.error ).toHaveBeenCalledWith(
 				'Failed to persist dependency check timestamp:',
 				error
 			);
-			consoleErrorSpy.mockRestore();
 		} );
 	} );
 } );


### PR DESCRIPTION
## Related issues

- Fixes STU-1455

## How AI was used in this PR

Implementation drafted with Claude Code from the Linear issue. I reviewed the diff, ran the test suite, and validated the throttle logic (missing timestamp, stale timestamp, future/clock-skew timestamp, happy path) before pushing.

## Proposed Changes

- Add an optional `lastDependencyCheckTime` field to the CLI config schema (`cli.json`).
- Add `shouldCheckDependencyUpdates()` / `markDependencyCheckTime()` helpers in `dependency-management/setup.ts`. The throttle treats missing, >24h-old, and future (clock-skew) timestamps as stale, and swallows read/write errors so a broken `cli.json` never blocks `site create`.
- Gate the `updateServerFiles()` call in `site create` behind the throttle, so back-to-back site creations don't re-run the network check.
- Unit tests for the helpers and for the create-command gating paths (runs when expired, skips when fresh, skips when offline).

## Testing Instructions

1. `npm run cli:build`
2. `node apps/cli/dist/cli/main.mjs site create ~/Studio/throttle-test-1` — should show "Checking for dependency updates…" and succeed.
3. `node apps/cli/dist/cli/main.mjs site create ~/Studio/throttle-test-2` immediately after — should skip the dependency check entirely and feel faster.
4. Edit `~/.studio/cli.json` and set `lastDependencyCheckTime` to `1` (or delete the field), then re-run `site create` — the check should run again.
5. Run the unit tests:
   - `npm test -- apps/cli/lib/dependency-management/tests/setup.test.ts`
   - `npm test -- apps/cli/commands/site/tests/create.test.ts`

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?
- [x] Unit tests added / updated
- [x] `npm run typecheck` passes