### PR TITLE
Show compaction status in CLI code agent UI

### DIFF
--- a/apps/cli/ai/ui.ts
+++ b/apps/cli/ai/ui.ts
@@ -2207,6 +2207,15 @@ export class AiChatUI implements AiOutputAdapter {
 				this.showError( parts.length > 0 ? parts.join( '\n' ) : __( 'Unknown error' ) );
 				return { type: 'result', sessionId: message.session_id, success: false };
 			}
+			case 'system': {
+				if ( message.subtype === 'status' && message.status === 'compacting' ) {
+					this.showLoader( __( 'Compacting conversation history…' ) );
+				} else if ( message.subtype === 'compact_boundary' ) {
+					this.hideLoader();
+					this.showInfo( __( 'Conversation history compacted' ) );
+				}
+				return undefined;
+			}
 		}
 		return undefined;
 	}


### PR DESCRIPTION
## Related issues

- Related to context window management in `studio code`

## How AI was used in this PR

AI was used to investigate how the Claude Agent SDK handles context compaction, identify the gap in the UI layer, and write the fix.

## Proposed Changes

- Handle `system` message type in `AiChatUI.handleMessage()` — previously only `assistant`, `user`, and `result` were handled
- Show a loader ("Compacting conversation history...") when the SDK begins auto-compaction
- Show an info message ("Conversation history compacted") when compaction completes

The Claude Agent SDK automatically compacts conversation history when the context window fills up, emitting `SDKStatusMessage` (status: `compacting`) and `SDKCompactBoundaryMessage` (subtype: `compact_boundary`). These system messages were silently dropped, leaving users with an unexplained pause during long conversations.

## Testing Instructions

- Run `studio code` and have a long conversation that fills the context window
- Verify that a "Compacting conversation history..." loader appears during compaction
- Verify that a "Conversation history compacted" info message appears after

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?