### PR TITLE
Fix picospinner migration issues, clean up `Logger` API

### DIFF
--- a/apps/cli/commands/preview/create.ts
+++ b/apps/cli/commands/preview/create.ts
@@ -32,7 +32,6 @@ export async function runCommand( siteFolder: string, name?: string ): Promise< 
 				__( 'Authentication required. Please log in with `studio auth login`.' )
 			);
 		}
-		logger.reportSuccess( __( 'Validation successful' ), true );
 
 		logger.reportStart( LoggerAction.ARCHIVE, __( 'Creating archive…' ) );
 		await archiveSiteContent( siteFolder, archivePath );

--- a/apps/cli/commands/preview/delete.ts
+++ b/apps/cli/commands/preview/delete.ts
@@ -52,7 +52,6 @@ export async function runCommand( mode: Mode, host: string | undefined ): Promis
 					)
 				);
 			}
-			logger.reportSuccess( __( 'Validation successful' ), true );
 
 			logger.reportStart( LoggerAction.DELETE, __( 'Deleting…' ) );
 			if ( ! isSnapshotExpired( snapshotToDelete ) ) {

--- a/apps/cli/commands/preview/list.ts
+++ b/apps/cli/commands/preview/list.ts
@@ -37,7 +37,6 @@ export async function runCommand(
 				__( 'Authentication required. Please log in with `studio auth login`.' )
 			);
 		}
-		logger.reportSuccess( __( 'Validation successful' ), true );
 
 		logger.reportStart( LoggerAction.LOAD, __( 'Loading preview sites…' ) );
 		const snapshots = await getSnapshotsFromConfig( token.id, siteFolder );

--- a/apps/cli/commands/preview/tests/create.test.ts
+++ b/apps/cli/commands/preview/tests/create.test.ts
@@ -120,11 +120,10 @@ describe( 'Preview Create Command', () => {
 
 		expect( getSiteByFolder ).toHaveBeenCalledWith( mockFolder );
 		expect( mockReportStart.mock.calls[ 0 ] ).toEqual( [ 'validate', 'Validating…' ] );
-		expect( mockReportSuccess.mock.calls[ 0 ] ).toEqual( [ 'Validation successful', true ] );
 
 		expect( archiveSiteContent ).toHaveBeenCalledWith( mockFolder, mockArchivePath );
 		expect( mockReportStart.mock.calls[ 1 ] ).toEqual( [ 'archive', 'Creating archive…' ] );
-		expect( mockReportSuccess.mock.calls[ 1 ] ).toEqual( [ 'Archive created' ] );
+		expect( mockReportSuccess.mock.calls[ 0 ] ).toEqual( [ 'Archive created' ] );
 
 		expect( uploadArchive ).toHaveBeenCalledWith(
 			mockArchivePath,
@@ -132,11 +131,11 @@ describe( 'Preview Create Command', () => {
 			'6.8.1'
 		);
 		expect( mockReportStart.mock.calls[ 2 ] ).toEqual( [ 'upload', 'Uploading archive…' ] );
-		expect( mockReportSuccess.mock.calls[ 2 ] ).toEqual( [ 'Archive uploaded' ] );
+		expect( mockReportSuccess.mock.calls[ 1 ] ).toEqual( [ 'Archive uploaded' ] );
 
 		expect( waitForSiteReady ).toHaveBeenCalledWith( mockAtomicSiteId, mockAuthToken.accessToken );
 		expect( mockReportStart.mock.calls[ 3 ] ).toEqual( [ 'ready', 'Creating preview site…' ] );
-		expect( mockReportSuccess.mock.calls[ 3 ] ).toEqual( [
+		expect( mockReportSuccess.mock.calls[ 2 ] ).toEqual( [
 			`Preview site available at: https://${ mockSiteUrl }`,
 		] );
 
@@ -151,7 +150,7 @@ describe( 'Preview Create Command', () => {
 			'appdata',
 			'Saving preview site to Studio…',
 		] );
-		expect( mockReportSuccess.mock.calls[ 4 ] ).toEqual( [ 'Preview site saved to Studio' ] );
+		expect( mockReportSuccess.mock.calls[ 3 ] ).toEqual( [ 'Preview site saved to Studio' ] );
 
 		expect( cleanup ).toHaveBeenCalledWith( mockArchivePath );
 	} );

--- a/apps/cli/commands/preview/tests/delete.test.ts
+++ b/apps/cli/commands/preview/tests/delete.test.ts
@@ -92,9 +92,8 @@ describe( 'Preview Delete Command', () => {
 		} );
 
 		expect( mockReportStart.mock.calls[ 0 ] ).toEqual( [ 'validate', 'Validating…' ] );
-		expect( mockReportSuccess.mock.calls[ 0 ] ).toEqual( [ 'Validation successful', true ] );
 		expect( mockReportStart.mock.calls[ 1 ] ).toEqual( [ 'delete', 'Deleting…' ] );
-		expect( mockReportSuccess.mock.calls[ 1 ] ).toEqual( [ 'Deletion successful' ] );
+		expect( mockReportSuccess.mock.calls[ 0 ] ).toEqual( [ 'Deletion successful' ] );
 	} );
 
 	it( 'should handle authentication errors', async () => {
@@ -128,7 +127,7 @@ describe( 'Preview Delete Command', () => {
 			event: SNAPSHOT_EVENTS.DELETED,
 			data: { snapshotUrl: mockSiteUrl },
 		} );
-		expect( mockReportSuccess.mock.calls[ 1 ] ).toEqual( [ 'Deletion successful' ] );
+		expect( mockReportSuccess.mock.calls[ 0 ] ).toEqual( [ 'Deletion successful' ] );
 	} );
 
 	it( 'should handle delete preview site errors', async () => {

--- a/apps/cli/commands/preview/tests/list.test.ts
+++ b/apps/cli/commands/preview/tests/list.test.ts
@@ -100,9 +100,8 @@ describe( 'Preview List Command', () => {
 
 		expect( getSnapshotsFromConfig ).toHaveBeenCalledWith( mockAuthToken.id, mockFolder );
 		expect( mockReportStart.mock.calls[ 0 ] ).toEqual( [ 'validate', 'Validating…' ] );
-		expect( mockReportSuccess.mock.calls[ 0 ] ).toEqual( [ 'Validation successful', true ] );
 		expect( mockReportStart.mock.calls[ 1 ] ).toEqual( [ 'load', 'Loading preview sites…' ] );
-		expect( mockReportSuccess.mock.calls[ 1 ] ).toEqual( [ 'Found 2 preview sites' ] );
+		expect( mockReportSuccess.mock.calls[ 0 ] ).toEqual( [ 'Found 2 preview sites' ] );
 	} );
 
 	it( 'should handle validation errors', async () => {
@@ -119,8 +118,7 @@ describe( 'Preview List Command', () => {
 		await runCommand( mockFolder, 'table' );
 
 		expect( mockReportStart.mock.calls[ 0 ] ).toEqual( [ 'validate', 'Validating…' ] );
-		expect( mockReportSuccess.mock.calls[ 0 ] ).toEqual( [ 'Validation successful', true ] );
 		expect( mockReportStart.mock.calls[ 1 ] ).toEqual( [ 'load', 'Loading preview sites…' ] );
-		expect( mockReportSuccess.mock.calls[ 1 ] ).toEqual( [ 'No preview sites found' ] );
+		expect( mockReportSuccess.mock.calls[ 0 ] ).toEqual( [ 'No preview sites found' ] );
 	} );
 } );

--- a/apps/cli/commands/preview/tests/update.test.ts
+++ b/apps/cli/commands/preview/tests/update.test.ts
@@ -102,11 +102,10 @@ describe( 'Preview Update Command', () => {
 		await runCommand( mockFolder, mockSiteUrl, false );
 		expect( getSiteByFolder ).toHaveBeenCalledWith( mockFolder );
 		expect( mockReportStart.mock.calls[ 0 ] ).toEqual( [ 'validate', 'Validating…' ] );
-		expect( mockReportSuccess.mock.calls[ 0 ] ).toEqual( [ 'Validation successful', true ] );
 
 		expect( archiveSiteContent ).toHaveBeenCalledWith( mockFolder, mockArchivePath );
 		expect( mockReportStart.mock.calls[ 1 ] ).toEqual( [ 'archive', 'Creating archive…' ] );
-		expect( mockReportSuccess.mock.calls[ 1 ] ).toEqual( [ 'Archive created' ] );
+		expect( mockReportSuccess.mock.calls[ 0 ] ).toEqual( [ 'Archive created' ] );
 
 		expect( uploadArchive ).toHaveBeenCalledWith(
 			mockArchivePath,
@@ -115,11 +114,11 @@ describe( 'Preview Update Command', () => {
 			mockSnapshot.atomicSiteId
 		);
 		expect( mockReportStart.mock.calls[ 2 ] ).toEqual( [ 'upload', 'Uploading archive…' ] );
-		expect( mockReportSuccess.mock.calls[ 2 ] ).toEqual( [ 'Archive uploaded' ] );
+		expect( mockReportSuccess.mock.calls[ 1 ] ).toEqual( [ 'Archive uploaded' ] );
 
 		expect( waitForSiteReady ).toHaveBeenCalledWith( mockAtomicSiteId, mockAuthToken.accessToken );
 		expect( mockReportStart.mock.calls[ 3 ] ).toEqual( [ 'ready', 'Updating preview site…' ] );
-		expect( mockReportSuccess.mock.calls[ 3 ] ).toEqual( [
+		expect( mockReportSuccess.mock.calls[ 2 ] ).toEqual( [
 			`Preview site available at: https://${ mockSiteUrl }`,
 		] );
 
@@ -128,7 +127,7 @@ describe( 'Preview Update Command', () => {
 			'appdata',
 			'Saving preview site to Studio…',
 		] );
-		expect( mockReportSuccess.mock.calls[ 4 ] ).toEqual( [ 'Preview site saved to Studio' ] );
+		expect( mockReportSuccess.mock.calls[ 3 ] ).toEqual( [ 'Preview site saved to Studio' ] );
 	} );
 
 	it( 'should use current directory when no folder is specified', async () => {

--- a/apps/cli/commands/preview/update.ts
+++ b/apps/cli/commands/preview/update.ts
@@ -70,8 +70,6 @@ export async function runCommand(
 			throw new LoggerError( __( 'Cannot update an expired preview site.' ) );
 		}
 
-		logger.reportSuccess( __( 'Validation successful' ), true );
-
 		logger.reportStart( LoggerAction.ARCHIVE, __( 'Creating archive…' ) );
 		await archiveSiteContent( siteFolder, archivePath );
 		logger.reportSuccess( __( 'Archive created' ) );

--- a/apps/cli/commands/pull.ts
+++ b/apps/cli/commands/pull.ts
@@ -70,7 +70,6 @@ export async function runCommand(
 		logger.reportStart( LoggerAction.FETCH_REMOTE_SITES, __( 'Fetching WordPress.com sites…' ) );
 		const remoteSites = await fetchSyncableSites( token.accessToken );
 		logger.spinner.stop();
-		logger.reportSuccess( sprintf( __( 'Found %d sites' ), remoteSites.length ), true );
 
 		let remoteSite;
 		if ( siteIdentifier ) {

--- a/apps/cli/commands/push.ts
+++ b/apps/cli/commands/push.ts
@@ -57,7 +57,6 @@ export async function runCommand(
 	logger.reportStart( LoggerAction.FETCH_REMOTE_SITES, __( 'Fetching WordPress.com sites…' ) );
 	const remoteSites = await fetchSyncableSites( token.accessToken );
 	logger.spinner.stop();
-	logger.reportSuccess( sprintf( __( 'Found %d sites' ), remoteSites.length ), true );
 
 	let remoteSite;
 	if ( remoteSiteIdentifier ) {

--- a/apps/cli/commands/site/create.ts
+++ b/apps/cli/commands/site/create.ts
@@ -118,17 +118,13 @@ export async function runCommand(
 			);
 
 			await updateServerFiles();
-			logger.reportSuccess( __( 'Dependencies up to date' ) );
 		}
 	} catch ( error ) {
 		// Errors here aren't critical and likely relate to things outside the user's control,
-		// like network issues or bad API responses. Report them in development, and silently
-		// clear the spinner in production so creation can continue.
+		// like network issues or bad API responses. Report them only in development.
 		if ( process.env.NODE_ENV !== 'production' ) {
 			const loggerError = new LoggerError( 'Failed to update dependencies', error );
 			logger.reportError( loggerError, false );
-		} else {
-			logger.reportSuccess( __( 'Dependencies up to date' ), true );
 		}
 	}
 

--- a/apps/cli/logger.ts
+++ b/apps/cli/logger.ts
@@ -58,7 +58,7 @@ export class Logger< T extends string > {
 		if ( canSend() ) {
 			process.send!( { action, status: 'inprogress', message } );
 		} else if ( progressCallback ) {
-			progressCallback!( message );
+			progressCallback( message );
 		} else {
 			this.spinner.setText( message );
 			if ( ! this.spinner.running ) {
@@ -71,7 +71,7 @@ export class Logger< T extends string > {
 		if ( canSend() ) {
 			process.send!( { action: this.currentAction, status: 'inprogress', message } );
 		} else if ( progressCallback ) {
-			progressCallback!( message, true );
+			progressCallback( message, true );
 		} else {
 			if ( ! this.spinner.running ) {
 				this.spinner.start();
@@ -84,7 +84,7 @@ export class Logger< T extends string > {
 		if ( canSend() ) {
 			process.send!( { action: this.currentAction, status: 'success', message } );
 		} else if ( progressCallback ) {
-			progressCallback!( message );
+			progressCallback( message );
 		} else {
 			if ( ! this.spinner.running ) {
 				this.spinner.start();
@@ -99,7 +99,7 @@ export class Logger< T extends string > {
 		if ( canSend() ) {
 			process.send!( { action: this.currentAction, status: 'warning', message } );
 		} else if ( progressCallback ) {
-			progressCallback!( message );
+			progressCallback( message );
 		} else {
 			if ( ! this.spinner.running ) {
 				this.spinner.start();
@@ -116,7 +116,7 @@ export class Logger< T extends string > {
 		if ( canSend() ) {
 			process.send!( { action: this.currentAction, status: 'fail', message: error.message } );
 		} else if ( progressCallback ) {
-			progressCallback!( error.message );
+			progressCallback( error.message );
 		} else {
 			if ( ! this.spinner.running ) {
 				this.spinner.start();

--- a/apps/cli/logger.ts
+++ b/apps/cli/logger.ts
@@ -57,44 +57,38 @@ export class Logger< T extends string > {
 
 		if ( canSend() ) {
 			process.send!( { action, status: 'inprogress', message } );
-			return;
-		}
-		if ( progressCallback ) {
+		} else if ( progressCallback ) {
 			progressCallback!( message );
-			return;
+		} else {
+			this.spinner.setText( message );
+			if ( ! this.spinner.running ) {
+				this.spinner.start();
+			}
 		}
-		this.spinner.setText( message );
-		this.spinner.start();
 	}
 
 	public reportProgress( message: string ) {
 		if ( canSend() ) {
 			process.send!( { action: this.currentAction, status: 'inprogress', message } );
-			return;
-		}
-
-		if ( progressCallback ) {
+		} else if ( progressCallback ) {
 			progressCallback!( message, true );
-			return;
-		}
-
-		// Update the spinner text and force render
-		this.spinner.setText( message );
-		if ( ! this.spinner.running ) {
-			this.spinner.start();
 		} else {
-			this.spinner.refresh();
+			if ( ! this.spinner.running ) {
+				this.spinner.start();
+			}
+			this.spinner.setText( message );
 		}
 	}
 
-	public reportSuccess( message: string, shouldClearSpinner = false ) {
+	public reportSuccess( message: string ) {
 		if ( canSend() ) {
 			process.send!( { action: this.currentAction, status: 'success', message } );
 		} else if ( progressCallback ) {
 			progressCallback!( message );
-		} else if ( shouldClearSpinner ) {
-			this.spinner.stop();
 		} else {
+			if ( ! this.spinner.running ) {
+				this.spinner.start();
+			}
 			this.spinner.succeed( message );
 		}
 
@@ -104,13 +98,14 @@ export class Logger< T extends string > {
 	public reportWarning( message: string ) {
 		if ( canSend() ) {
 			process.send!( { action: this.currentAction, status: 'warning', message } );
-			return;
-		}
-		if ( progressCallback ) {
+		} else if ( progressCallback ) {
 			progressCallback!( message );
-			return;
+		} else {
+			if ( ! this.spinner.running ) {
+				this.spinner.start();
+			}
+			this.spinner.warn( message );
 		}
-		this.spinner.warn( message );
 	}
 
 	public reportError( error: LoggerError, isFatal = true ) {
@@ -123,6 +118,9 @@ export class Logger< T extends string > {
 		} else if ( progressCallback ) {
 			progressCallback!( error.message );
 		} else {
+			if ( ! this.spinner.running ) {
+				this.spinner.start();
+			}
 			this.spinner.fail( error.message );
 		}
 


### PR DESCRIPTION
## Related issues

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "Fixes" keyword and use "Related to" instead.
-->

- Related to https://github.com/Automattic/studio/pull/3035

## How AI was used in this PR

<!--
Help reviewers understand what to look for and verify that you've reviewed the code yourself.
-->

Not at all. 

## Proposed Changes

https://github.com/Automattic/studio/pull/3035 migrated from the ora library to picospinner. There are some subtle differences in how these two libraries behave that weren't addressed there, and this PR tackles them.

1. `picospinner` throws if we call `.start()` when the spinner is already running. https://github.com/Automattic/studio/pull/3093 fixed that for the `site create` command specifically, but this PR generalizes the fix so we can safely call any `Logger` method without worrying about a crash. 
2. With ora, the `Logger.reportSuccess` method would log a new success line. This behavior disappeared in https://github.com/Automattic/studio/pull/3035, which removed some messages from the logging output. This PR brings back that behavior.

Lastly, I removed the `shouldClearSpinner` argument from the `Logger.reportSuccess` method. This was introduced in https://github.com/Automattic/studio/pull/1306 to address some CfT feedback on the first version of the CLI, but the better solution is to just not call `Logger.reportSuccess` at all (which is what we've been doing in most new code we've added since then).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. `npm run cli:build`
2. `node apps/cli/dist/cli/main.mjs export --path PATH_TO_SITE` and ensure the command completes successfully
3. `node apps/cli/dist/cli/main.mjs preview create --path PATH_TO_SITE` and ensure the command completes successfully
4. `node apps/cli/dist/cli/main.mjs site create` and ensure the command completes successfully

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Have you checked for TypeScript, React or other console errors?
