### PR TITLE
CLI: Add plugin and theme link management.

### DIFF
--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -178,3 +178,14 @@ Notes:
 - The source directory must look like a valid WordPress plugin (PHP file with a `Plugin Name:` header) or theme (`style.css` with a `Theme Name:` header).
 - Relative symlinks are used by default. On Windows, if symlink permissions are unavailable the CLI falls back to a directory junction.
 - `unlink` only removes the symlink inside the site — your source files are never touched.
+
+### Security considerations
+
+Linking executes the source directory's PHP inside the WordPress site with the same privileges as any other plugin or theme. Treat each linked source as code you trust. The CLI applies the following safeguards, mapped to the [OWASP Agentic Skills Top 10](https://github.com/OWASP/www-project-agentic-skills-top-10):
+
+- **Recursive / cross-link guard (AST03)** — `link` rejects sources that resolve inside the target site, so a plugin cannot symlink back into its own `wp-content` and create a loop.
+- **Symlink chain transparency (AST04)** — when the source path you pass is itself a symlink, the resolved real path is printed alongside the typed path so you can spot brand-impersonation or shadowing attacks.
+- **Path-traversal hardening (AST03)** — `unlink` rejects names containing path separators (`../foo`, `a/b/c`), so an unlink command can only remove items inside the site's plugins/themes directory.
+- **Live updates by design (AST07)** — symlinked sources reflect upstream changes immediately. This is the point of the feature, but it also means a compromised source repository takes effect without an explicit re-install. Pin or sandbox sources you do not control.
+
+The CLI does not scan source contents for malicious code (AST08) and does not maintain a registry of allowed source locations. If you are linking third-party code you did not author, review it the same way you would review any other plugin or theme before installing it on a real site.

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -163,6 +163,16 @@ studio plugin unlink my-plugin --path ~/Studio/my-site
 studio theme unlink my-theme --path ~/Studio/my-site
 ```
 
+Run from inside a plugin or theme folder — no flags needed:
+
+```bash
+cd ~/Developer/wp-plugins/my-plugin
+studio plugin link        # interactive site picker appears
+studio plugin unlink      # plugin name defaults to current folder name
+```
+
+When `--path` does not point to a Studio site and the terminal is interactive, the CLI opens a searchable picker listing every local site so you can choose the target. In non-interactive shells (CI, piped input) the original error is preserved, so automation fails loud instead of silently prompting.
+
 Notes:
 
 - The source directory must look like a valid WordPress plugin (PHP file with a `Plugin Name:` header) or theme (`style.css` with a `Theme Name:` header).

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -30,6 +30,7 @@ The Studio CLI lets you:
 - [Import and export](#import-and-export)
 - [Sync with WordPress.com and Pressable](#sync-with-wordpresscom-and-pressable)
 - [Preview sites](#preview-sites)
+- [Link external plugins and themes](#link-external-plugins-and-themes)
 
 ## Requirements
 
@@ -136,3 +137,34 @@ Publish a preview with this command:
 ```bash
 studio preview create --path ~/Studio/my-site
 ```
+
+## Link external plugins and themes
+
+You can keep plugin or theme source code in a central development folder (for example `~/Developer/wp-plugins`) and symlink it into one or more Studio sites. Changes to the source directory are reflected in every site it is linked to, so you can iterate on a plugin once and try it across multiple WordPress versions, PHP versions, or test datasets.
+
+Link a plugin or theme into a site:
+
+```bash
+studio plugin link ~/Developer/wp-plugins/my-plugin --path ~/Studio/my-site
+studio theme link ~/Developer/wp-themes/my-theme --path ~/Studio/my-site
+```
+
+List what is currently linked in a site:
+
+```bash
+studio plugin list-linked --path ~/Studio/my-site
+studio theme list-linked --path ~/Studio/my-site
+```
+
+Remove a link (the source directory is preserved):
+
+```bash
+studio plugin unlink my-plugin --path ~/Studio/my-site
+studio theme unlink my-theme --path ~/Studio/my-site
+```
+
+Notes:
+
+- The source directory must look like a valid WordPress plugin (PHP file with a `Plugin Name:` header) or theme (`style.css` with a `Theme Name:` header).
+- Relative symlinks are used by default. On Windows, if symlink permissions are unavailable the CLI falls back to a directory junction.
+- `unlink` only removes the symlink inside the site — your source files are never touched.

--- a/apps/cli/commands/plugin/link.ts
+++ b/apps/cli/commands/plugin/link.ts
@@ -103,6 +103,14 @@ export async function runCommand( sitePath: string, sourcePath?: string ): Promi
 
 	// Determine plugin name from directory name
 	const pluginName = path.basename( absoluteSourcePath );
+	if ( ! pluginName || pluginName === '.' || pluginName === '..' ) {
+		throw new LoggerError(
+			sprintf(
+				__( 'Could not determine a valid plugin name from source path: %s' ),
+				absoluteSourcePath
+			)
+		);
+	}
 	const pluginsDir = path.join( resolvedSitePath, 'wp-content', 'plugins' );
 	const targetPath = path.join( pluginsDir, pluginName );
 

--- a/apps/cli/commands/plugin/link.ts
+++ b/apps/cli/commands/plugin/link.ts
@@ -1,0 +1,179 @@
+import fs from 'fs';
+import path from 'path';
+import { pathExists } from '@studio/common/lib/fs-utils';
+import { isErrnoException } from '@studio/common/lib/is-errno-exception';
+import { PluginCommandLoggerAction as LoggerAction } from '@studio/common/logger-actions';
+import { __, sprintf } from '@wordpress/i18n';
+import { getSiteByFolder } from 'cli/lib/cli-config/sites';
+import { pickLocalSite } from 'cli/lib/local-site-picker';
+import { untildify } from 'cli/lib/utils';
+import { Logger, LoggerError } from 'cli/logger';
+import { StudioArgv } from 'cli/types';
+
+const logger = new Logger< LoggerAction >();
+
+/**
+ * Creates a symlink for a plugin, with Windows junction fallback.
+ *
+ * @param sourcePath - Absolute path to the source plugin directory
+ * @param targetPath - Absolute path where the symlink should be created
+ */
+async function createPluginSymlink( sourcePath: string, targetPath: string ): Promise< void > {
+	// Use relative path for standard symlinks (more portable)
+	const relativePath = path.relative( path.dirname( targetPath ), sourcePath );
+
+	try {
+		await fs.promises.symlink( relativePath, targetPath );
+	} catch ( error ) {
+		// On Windows, symlinks may require admin privileges or Developer Mode.
+		// Fall back to a directory junction which doesn't require elevated permissions.
+		if ( isErrnoException( error ) && error.code === 'EPERM' && process.platform === 'win32' ) {
+			// Junctions require absolute paths
+			await fs.promises.symlink( path.resolve( sourcePath ), targetPath, 'junction' );
+		} else {
+			throw error;
+		}
+	}
+}
+
+/**
+ * Validates that a directory looks like a WordPress plugin.
+ * Checks for presence of a PHP file with Plugin Name header.
+ */
+async function isValidPluginDirectory( pluginPath: string ): Promise< boolean > {
+	try {
+		const files = await fs.promises.readdir( pluginPath );
+		const phpFiles = files.filter( ( f ) => f.endsWith( '.php' ) );
+
+		for ( const phpFile of phpFiles ) {
+			const content = await fs.promises.readFile( path.join( pluginPath, phpFile ), 'utf-8' );
+			if ( content.includes( 'Plugin Name:' ) ) {
+				return true;
+			}
+		}
+		return false;
+	} catch {
+		return false;
+	}
+}
+
+export async function runCommand( sitePath: string, sourcePath?: string ): Promise< void > {
+	// Use current directory if no source path provided
+	const absoluteSourcePath = path.resolve( sourcePath ? untildify( sourcePath ) : process.cwd() );
+
+	// Resolve site: try --path, fall back to picker if it's not a site and stdin is a TTY
+	let resolvedSitePath = sitePath;
+	try {
+		await getSiteByFolder( sitePath );
+	} catch ( error ) {
+		if ( ! process.stdin.isTTY ) {
+			throw error;
+		}
+		const picked = await pickLocalSite( __( 'Select a site to link the plugin to' ) );
+		if ( ! picked ) {
+			throw error;
+		}
+		resolvedSitePath = picked.path;
+	}
+
+	logger.reportStart( LoggerAction.LINK, __( 'Linking plugin…' ) );
+
+	// Validate source exists
+	if ( ! ( await pathExists( absoluteSourcePath ) ) ) {
+		throw new LoggerError( sprintf( __( 'Source path does not exist: %s' ), absoluteSourcePath ) );
+	}
+
+	// Validate source is a directory
+	const sourceStats = await fs.promises.stat( absoluteSourcePath );
+	if ( ! sourceStats.isDirectory() ) {
+		throw new LoggerError(
+			sprintf( __( 'Source path is not a directory: %s' ), absoluteSourcePath )
+		);
+	}
+
+	// Validate it looks like a plugin
+	if ( ! ( await isValidPluginDirectory( absoluteSourcePath ) ) ) {
+		throw new LoggerError(
+			__(
+				'Source directory does not appear to be a valid WordPress plugin. ' +
+					'Expected a PHP file with a "Plugin Name:" header.'
+			)
+		);
+	}
+
+	// Determine plugin name from directory name
+	const pluginName = path.basename( absoluteSourcePath );
+	const pluginsDir = path.join( resolvedSitePath, 'wp-content', 'plugins' );
+	const targetPath = path.join( pluginsDir, pluginName );
+
+	// Check if target already exists
+	if ( await pathExists( targetPath ) ) {
+		// Check if it's already a symlink to the same source
+		try {
+			const stats = await fs.promises.lstat( targetPath );
+			if ( stats.isSymbolicLink() ) {
+				const linkTarget = await fs.promises.readlink( targetPath );
+				const resolvedTarget = path.resolve( path.dirname( targetPath ), linkTarget );
+				if ( resolvedTarget === absoluteSourcePath ) {
+					logger.reportSuccess(
+						sprintf( __( 'Plugin "%s" is already linked to %s' ), pluginName, absoluteSourcePath )
+					);
+					return;
+				}
+				throw new LoggerError(
+					sprintf(
+						__( 'Plugin "%s" is already linked to a different location: %s' ),
+						pluginName,
+						resolvedTarget
+					)
+				);
+			}
+		} catch ( error ) {
+			if ( ! isErrnoException( error ) || error.code !== 'ENOENT' ) {
+				throw error;
+			}
+		}
+
+		throw new LoggerError(
+			sprintf(
+				__( 'A plugin named "%s" already exists. Remove it first or use a different name.' ),
+				pluginName
+			)
+		);
+	}
+
+	// Ensure plugins directory exists
+	await fs.promises.mkdir( pluginsDir, { recursive: true } );
+
+	// Create the symlink
+	await createPluginSymlink( absoluteSourcePath, targetPath );
+
+	logger.reportSuccess(
+		sprintf( __( 'Linked plugin "%s" → %s' ), pluginName, absoluteSourcePath )
+	);
+	console.log( __( 'Changes to the source directory will be reflected immediately in the site.' ) );
+}
+
+export const registerCommand = ( yargs: StudioArgv ) => {
+	return yargs.command( {
+		command: 'link [source]',
+		describe: __( 'Link an external plugin directory to the site' ),
+		builder: ( linkYargs ) => {
+			return linkYargs.positional( 'source', {
+				type: 'string',
+				describe: __( 'Path to the plugin directory to link (defaults to current directory)' ),
+			} );
+		},
+		handler: async ( argv ) => {
+			try {
+				await runCommand( argv.path, argv.source as string | undefined );
+			} catch ( error ) {
+				if ( error instanceof LoggerError ) {
+					logger.reportError( error );
+				} else {
+					logger.reportError( new LoggerError( __( 'Failed to link plugin' ), error ) );
+				}
+			}
+		},
+	} );
+};

--- a/apps/cli/commands/plugin/link.ts
+++ b/apps/cli/commands/plugin/link.ts
@@ -101,6 +101,26 @@ export async function runCommand( sitePath: string, sourcePath?: string ): Promi
 		);
 	}
 
+	// Resolve symlinks so subsequent scope checks operate on the real target.
+	// Defends against AST04 (insecure metadata) by surfacing the true location
+	// when a user-typed source path is itself a symlink.
+	const realSourcePath = await fs.promises
+		.realpath( absoluteSourcePath )
+		.catch( () => absoluteSourcePath );
+
+	// Reject sources inside the target site to prevent recursive symlinks
+	// (a plugin symlinking back into its own site's wp-content).
+	const resolvedSiteRealPath = await fs.promises
+		.realpath( resolvedSitePath )
+		.catch( () => resolvedSitePath );
+	const sourceWithSep = realSourcePath + path.sep;
+	const siteWithSep = resolvedSiteRealPath + path.sep;
+	if ( realSourcePath === resolvedSiteRealPath || sourceWithSep.startsWith( siteWithSep ) ) {
+		throw new LoggerError(
+			sprintf( __( 'Source must not live inside the target site: %s' ), realSourcePath )
+		);
+	}
+
 	// Determine plugin name from directory name
 	const pluginName = path.basename( absoluteSourcePath );
 	if ( ! pluginName || pluginName === '.' || pluginName === '..' ) {
@@ -159,6 +179,10 @@ export async function runCommand( sitePath: string, sourcePath?: string ): Promi
 	logger.reportSuccess(
 		sprintf( __( 'Linked plugin "%s" → %s' ), pluginName, absoluteSourcePath )
 	);
+	if ( realSourcePath !== absoluteSourcePath ) {
+		// Surface the real target so the user can spot symlink-chain shadowing.
+		console.log( sprintf( __( 'Resolved source: %s' ), realSourcePath ) );
+	}
 	console.log( __( 'Changes to the source directory will be reflected immediately in the site.' ) );
 }
 

--- a/apps/cli/commands/plugin/list-linked.ts
+++ b/apps/cli/commands/plugin/list-linked.ts
@@ -1,9 +1,10 @@
 import fs from 'fs';
 import path from 'path';
 import { pathExists } from '@studio/common/lib/fs-utils';
+import { PluginCommandLoggerAction as LoggerAction } from '@studio/common/logger-actions';
 import { __, sprintf } from '@wordpress/i18n';
 import { getSiteByFolder } from 'cli/lib/cli-config/sites';
-import { LoggerError } from 'cli/logger';
+import { Logger, LoggerError } from 'cli/logger';
 import { StudioArgv } from 'cli/types';
 
 interface LinkedPlugin {
@@ -45,29 +46,40 @@ async function getLinkedPlugins( sitePath: string ): Promise< LinkedPlugin[] > {
 }
 
 export async function runCommand( sitePath: string, format: 'table' | 'json' ): Promise< void > {
-	// Validate site exists
-	await getSiteByFolder( sitePath );
+	const logger = new Logger< LoggerAction >();
 
-	const linkedPlugins = await getLinkedPlugins( sitePath );
+	try {
+		// Validate site exists
+		await getSiteByFolder( sitePath );
 
-	if ( format === 'json' ) {
-		console.log( JSON.stringify( linkedPlugins, null, 2 ) );
-		return;
-	}
+		if ( format === 'json' ) {
+			const linkedPlugins = await getLinkedPlugins( sitePath );
+			console.log( JSON.stringify( linkedPlugins, null, 2 ) );
+			return;
+		}
 
-	if ( linkedPlugins.length === 0 ) {
-		console.log( __( 'No linked plugins found.' ) );
-		console.log( __( 'Use "studio plugin link <source-path>" to link an external plugin.' ) );
-		return;
-	}
+		logger.reportStart( LoggerAction.LIST_LINKED, __( 'Listing linked plugins…' ) );
+		const linkedPlugins = await getLinkedPlugins( sitePath );
 
-	console.log( sprintf( __( 'Found %d linked plugin(s):' ), linkedPlugins.length ) );
-	console.log();
+		if ( linkedPlugins.length === 0 ) {
+			logger.reportSuccess( __( 'No linked plugins found.' ) );
+			console.log( __( 'Use "studio plugin link <source-path>" to link an external plugin.' ) );
+			return;
+		}
 
-	for ( const plugin of linkedPlugins ) {
-		console.log( `  ${ plugin.name }` );
-		console.log( `    → ${ plugin.sourcePath }` );
-		console.log();
+		logger.reportSuccess( sprintf( __( 'Found %d linked plugin(s):' ), linkedPlugins.length ) );
+
+		for ( const plugin of linkedPlugins ) {
+			console.log( `  ${ plugin.name }` );
+			console.log( `    → ${ plugin.sourcePath }` );
+			console.log();
+		}
+	} catch ( error ) {
+		if ( error instanceof LoggerError ) {
+			logger.reportError( error );
+		} else {
+			logger.reportError( new LoggerError( __( 'Failed to list linked plugins' ), error ) );
+		}
 	}
 }
 
@@ -84,16 +96,7 @@ export const registerCommand = ( yargs: StudioArgv ) => {
 			} );
 		},
 		handler: async ( argv ) => {
-			try {
-				await runCommand( argv.path, argv.format as 'table' | 'json' );
-			} catch ( error ) {
-				process.exitCode = 1;
-				if ( error instanceof LoggerError ) {
-					console.error( error.message );
-				} else if ( error instanceof Error ) {
-					console.error( __( 'Failed to list linked plugins' ), error.message );
-				}
-			}
+			await runCommand( argv.path, argv.format as 'table' | 'json' );
 		},
 	} );
 };

--- a/apps/cli/commands/plugin/list-linked.ts
+++ b/apps/cli/commands/plugin/list-linked.ts
@@ -1,0 +1,99 @@
+import fs from 'fs';
+import path from 'path';
+import { pathExists } from '@studio/common/lib/fs-utils';
+import { __, sprintf } from '@wordpress/i18n';
+import { getSiteByFolder } from 'cli/lib/cli-config/sites';
+import { LoggerError } from 'cli/logger';
+import { StudioArgv } from 'cli/types';
+
+interface LinkedPlugin {
+	name: string;
+	sourcePath: string;
+}
+
+async function getLinkedPlugins( sitePath: string ): Promise< LinkedPlugin[] > {
+	const pluginsDir = path.join( sitePath, 'wp-content', 'plugins' );
+
+	if ( ! ( await pathExists( pluginsDir ) ) ) {
+		return [];
+	}
+
+	const entries = await fs.promises.readdir( pluginsDir, { withFileTypes: true } );
+	const linkedPlugins: LinkedPlugin[] = [];
+
+	for ( const entry of entries ) {
+		const entryPath = path.join( pluginsDir, entry.name );
+
+		try {
+			const stats = await fs.promises.lstat( entryPath );
+			if ( stats.isSymbolicLink() ) {
+				const linkTarget = await fs.promises.readlink( entryPath );
+				const resolvedTarget = path.resolve( path.dirname( entryPath ), linkTarget );
+
+				linkedPlugins.push( {
+					name: entry.name,
+					sourcePath: resolvedTarget,
+				} );
+			}
+		} catch {
+			// Skip entries we can't read
+			continue;
+		}
+	}
+
+	return linkedPlugins;
+}
+
+export async function runCommand( sitePath: string, format: 'table' | 'json' ): Promise< void > {
+	// Validate site exists
+	await getSiteByFolder( sitePath );
+
+	const linkedPlugins = await getLinkedPlugins( sitePath );
+
+	if ( format === 'json' ) {
+		console.log( JSON.stringify( linkedPlugins, null, 2 ) );
+		return;
+	}
+
+	if ( linkedPlugins.length === 0 ) {
+		console.log( __( 'No linked plugins found.' ) );
+		console.log( __( 'Use "studio plugin link <source-path>" to link an external plugin.' ) );
+		return;
+	}
+
+	console.log( sprintf( __( 'Found %d linked plugin(s):' ), linkedPlugins.length ) );
+	console.log();
+
+	for ( const plugin of linkedPlugins ) {
+		console.log( `  ${ plugin.name }` );
+		console.log( `    → ${ plugin.sourcePath }` );
+		console.log();
+	}
+}
+
+export const registerCommand = ( yargs: StudioArgv ) => {
+	return yargs.command( {
+		command: 'list-linked',
+		describe: __( 'List all linked plugins in the site' ),
+		builder: ( listYargs ) => {
+			return listYargs.option( 'format', {
+				type: 'string',
+				choices: [ 'table', 'json' ] as const,
+				default: 'table' as const,
+				describe: __( 'Output format' ),
+			} );
+		},
+		handler: async ( argv ) => {
+			try {
+				await runCommand( argv.path, argv.format as 'table' | 'json' );
+			} catch ( error ) {
+				process.exitCode = 1;
+				if ( error instanceof LoggerError ) {
+					console.error( error.message );
+				} else if ( error instanceof Error ) {
+					console.error( __( 'Failed to list linked plugins' ), error.message );
+				}
+			}
+		},
+	} );
+};

--- a/apps/cli/commands/plugin/tests/link.test.ts
+++ b/apps/cli/commands/plugin/tests/link.test.ts
@@ -13,6 +13,7 @@ vi.mock( 'fs', () => {
 		readdir: vi.fn(),
 		readFile: vi.fn(),
 		readlink: vi.fn(),
+		realpath: vi.fn(),
 		mkdir: vi.fn(),
 		symlink: vi.fn(),
 		unlink: vi.fn(),
@@ -60,6 +61,8 @@ describe( 'CLI: studio plugin link', () => {
 		);
 		vi.mocked( fs.promises.mkdir ).mockResolvedValue( undefined );
 		vi.mocked( fs.promises.symlink ).mockResolvedValue( undefined );
+		// Default: realpath returns input unchanged (no symlink chain).
+		vi.mocked( fs.promises.realpath ).mockImplementation( async ( p ) => String( p ) );
 	} );
 
 	afterEach( () => {
@@ -134,6 +137,33 @@ describe( 'CLI: studio plugin link', () => {
 			await expect( runCommand( testSiteFolder, testSourcePath ) ).rejects.toThrow(
 				/already linked to a different location/
 			);
+		} );
+
+		it( 'throws when source lives inside the target site (recursive)', async () => {
+			const insidePath = path.join( testSiteFolder, 'wp-content', 'plugins', 'inner' );
+			vi.mocked( pathExists ).mockImplementation( async ( p: string ) => p === insidePath );
+			vi.mocked( fs.promises.realpath ).mockImplementation( async ( p ) => String( p ) );
+
+			await expect( runCommand( testSiteFolder, insidePath ) ).rejects.toThrow(
+				/must not live inside the target site/
+			);
+			expect( fs.promises.symlink ).not.toHaveBeenCalled();
+		} );
+
+		it( 'throws when source symlink resolves into the target site', async () => {
+			const insidePath = path.join( testSiteFolder, 'wp-content', 'plugins', 'inner' );
+			vi.mocked( pathExists ).mockImplementation( async ( p: string ) => p === testSourcePath );
+			vi.mocked( fs.promises.realpath ).mockImplementation( async ( p ) => {
+				if ( String( p ) === testSourcePath ) {
+					return insidePath;
+				}
+				return String( p );
+			} );
+
+			await expect( runCommand( testSiteFolder, testSourcePath ) ).rejects.toThrow(
+				/must not live inside the target site/
+			);
+			expect( fs.promises.symlink ).not.toHaveBeenCalled();
 		} );
 
 		it( 'throws when source resolves to filesystem root (empty basename)', async () => {

--- a/apps/cli/commands/plugin/tests/link.test.ts
+++ b/apps/cli/commands/plugin/tests/link.test.ts
@@ -133,6 +133,15 @@ describe( 'CLI: studio plugin link', () => {
 				/already linked to a different location/
 			);
 		} );
+
+		it( 'throws when source resolves to filesystem root (empty basename)', async () => {
+			vi.mocked( pathExists ).mockImplementation( async ( p: string ) => p === '/' );
+
+			await expect( runCommand( testSiteFolder, '/' ) ).rejects.toThrow(
+				/Could not determine a valid plugin name/
+			);
+			expect( fs.promises.symlink ).not.toHaveBeenCalled();
+		} );
 	} );
 
 	describe( 'Success Cases', () => {

--- a/apps/cli/commands/plugin/tests/link.test.ts
+++ b/apps/cli/commands/plugin/tests/link.test.ts
@@ -31,8 +31,10 @@ vi.mock( 'cli/lib/cli-config/sites', async () => {
 } );
 
 describe( 'CLI: studio plugin link', () => {
-	const testSiteFolder = '/test/site/path';
-	const testSourcePath = '/test/plugins/my-plugin';
+	// Use `path.resolve` so the mocked pathExists comparison matches the
+	// platform-specific absolute form that runCommand computes (e.g. `C:\…` on Windows).
+	const testSiteFolder = path.resolve( '/test/site/path' );
+	const testSourcePath = path.resolve( '/test/plugins/my-plugin' );
 	const pluginsDir = path.join( testSiteFolder, 'wp-content', 'plugins' );
 	const targetPath = path.join( pluginsDir, 'my-plugin' );
 
@@ -135,9 +137,10 @@ describe( 'CLI: studio plugin link', () => {
 		} );
 
 		it( 'throws when source resolves to filesystem root (empty basename)', async () => {
-			vi.mocked( pathExists ).mockImplementation( async ( p: string ) => p === '/' );
+			const fsRoot = path.resolve( '/' );
+			vi.mocked( pathExists ).mockImplementation( async ( p: string ) => p === fsRoot );
 
-			await expect( runCommand( testSiteFolder, '/' ) ).rejects.toThrow(
+			await expect( runCommand( testSiteFolder, fsRoot ) ).rejects.toThrow(
 				/Could not determine a valid plugin name/
 			);
 			expect( fs.promises.symlink ).not.toHaveBeenCalled();

--- a/apps/cli/commands/plugin/tests/link.test.ts
+++ b/apps/cli/commands/plugin/tests/link.test.ts
@@ -1,0 +1,198 @@
+import fs from 'fs';
+import path from 'path';
+import { pathExists } from '@studio/common/lib/fs-utils';
+import { vi } from 'vitest';
+import { getSiteByFolder } from 'cli/lib/cli-config/sites';
+import { LoggerError } from 'cli/logger';
+import { runCommand } from '../link';
+
+vi.mock( 'fs', () => {
+	const promises = {
+		stat: vi.fn(),
+		lstat: vi.fn(),
+		readdir: vi.fn(),
+		readFile: vi.fn(),
+		readlink: vi.fn(),
+		mkdir: vi.fn(),
+		symlink: vi.fn(),
+		unlink: vi.fn(),
+	};
+	return { default: { promises }, promises };
+} );
+vi.mock( '@studio/common/lib/fs-utils', () => ( {
+	pathExists: vi.fn(),
+} ) );
+vi.mock( 'cli/lib/cli-config/sites', async () => {
+	const actual = await vi.importActual( 'cli/lib/cli-config/sites' );
+	return {
+		...( actual as object ),
+		getSiteByFolder: vi.fn(),
+	};
+} );
+
+describe( 'CLI: studio plugin link', () => {
+	const testSiteFolder = '/test/site/path';
+	const testSourcePath = '/test/plugins/my-plugin';
+	const pluginsDir = path.join( testSiteFolder, 'wp-content', 'plugins' );
+	const targetPath = path.join( pluginsDir, 'my-plugin' );
+
+	beforeEach( () => {
+		vi.clearAllMocks();
+
+		vi.mocked( getSiteByFolder ).mockResolvedValue( {
+			id: 'test-site-id',
+			name: 'Test Site',
+			path: testSiteFolder,
+			port: 8881,
+			phpVersion: '8.0',
+		} );
+
+		// Default: source exists, target does not.
+		vi.mocked( pathExists ).mockImplementation( async ( p: string ) => p === testSourcePath );
+		vi.mocked( fs.promises.stat ).mockResolvedValue( {
+			isDirectory: () => true,
+		} as fs.Stats );
+		vi.mocked( fs.promises.readdir ).mockResolvedValue( [ 'my-plugin.php' ] as unknown as never );
+		vi.mocked( fs.promises.readFile ).mockResolvedValue(
+			'<?php\n/*\nPlugin Name: My Plugin\n*/' as unknown as never
+		);
+		vi.mocked( fs.promises.mkdir ).mockResolvedValue( undefined );
+		vi.mocked( fs.promises.symlink ).mockResolvedValue( undefined );
+	} );
+
+	afterEach( () => {
+		vi.restoreAllMocks();
+	} );
+
+	describe( 'Error Cases', () => {
+		it( 'throws when site not found', async () => {
+			vi.mocked( getSiteByFolder ).mockRejectedValue( new Error( 'Site not found' ) );
+
+			await expect( runCommand( testSiteFolder, testSourcePath ) ).rejects.toThrow(
+				'Site not found'
+			);
+		} );
+
+		it( 'throws when source path does not exist', async () => {
+			vi.mocked( pathExists ).mockResolvedValue( false );
+
+			await expect( runCommand( testSiteFolder, testSourcePath ) ).rejects.toThrow( LoggerError );
+			await expect( runCommand( testSiteFolder, testSourcePath ) ).rejects.toThrow(
+				/Source path does not exist/
+			);
+		} );
+
+		it( 'throws when source is not a directory', async () => {
+			vi.mocked( fs.promises.stat ).mockResolvedValue( {
+				isDirectory: () => false,
+			} as fs.Stats );
+
+			await expect( runCommand( testSiteFolder, testSourcePath ) ).rejects.toThrow(
+				/Source path is not a directory/
+			);
+		} );
+
+		it( 'throws when directory has no PHP file with Plugin Name header', async () => {
+			vi.mocked( fs.promises.readFile ).mockResolvedValue(
+				'<?php\n// no header here' as unknown as never
+			);
+
+			await expect( runCommand( testSiteFolder, testSourcePath ) ).rejects.toThrow(
+				/does not appear to be a valid WordPress plugin/
+			);
+		} );
+
+		it( 'throws when directory has no PHP files at all', async () => {
+			vi.mocked( fs.promises.readdir ).mockResolvedValue( [ 'README.md' ] as unknown as never );
+
+			await expect( runCommand( testSiteFolder, testSourcePath ) ).rejects.toThrow(
+				/does not appear to be a valid WordPress plugin/
+			);
+		} );
+
+		it( 'throws when target exists as a non-symlink directory', async () => {
+			vi.mocked( pathExists ).mockResolvedValue( true );
+			vi.mocked( fs.promises.lstat ).mockResolvedValue( {
+				isSymbolicLink: () => false,
+			} as fs.Stats );
+
+			await expect( runCommand( testSiteFolder, testSourcePath ) ).rejects.toThrow(
+				/already exists/
+			);
+			expect( fs.promises.symlink ).not.toHaveBeenCalled();
+		} );
+
+		it( 'throws when target is a symlink to a different source', async () => {
+			vi.mocked( pathExists ).mockResolvedValue( true );
+			vi.mocked( fs.promises.lstat ).mockResolvedValue( {
+				isSymbolicLink: () => true,
+			} as fs.Stats );
+			vi.mocked( fs.promises.readlink ).mockResolvedValue( '/some/other/plugin' );
+
+			await expect( runCommand( testSiteFolder, testSourcePath ) ).rejects.toThrow(
+				/already linked to a different location/
+			);
+		} );
+	} );
+
+	describe( 'Success Cases', () => {
+		it( 'creates a relative symlink for a valid plugin', async () => {
+			await runCommand( testSiteFolder, testSourcePath );
+
+			expect( fs.promises.mkdir ).toHaveBeenCalledWith( pluginsDir, { recursive: true } );
+			expect( fs.promises.symlink ).toHaveBeenCalledTimes( 1 );
+			const [ linkPath, finalTarget ] = vi.mocked( fs.promises.symlink ).mock.calls[ 0 ];
+			expect( finalTarget ).toBe( targetPath );
+			expect( linkPath ).toBe( path.relative( pluginsDir, testSourcePath ) );
+		} );
+
+		it( 'is a no-op when plugin is already linked to the same source', async () => {
+			vi.mocked( pathExists ).mockResolvedValue( true );
+			vi.mocked( fs.promises.lstat ).mockResolvedValue( {
+				isSymbolicLink: () => true,
+			} as fs.Stats );
+			vi.mocked( fs.promises.readlink ).mockResolvedValue(
+				path.relative( pluginsDir, testSourcePath )
+			);
+
+			await runCommand( testSiteFolder, testSourcePath );
+
+			expect( fs.promises.symlink ).not.toHaveBeenCalled();
+		} );
+
+		it( 'uses current directory when source is omitted', async () => {
+			const cwd = process.cwd();
+			const cwdPluginName = path.basename( cwd );
+			const expectedTarget = path.join( pluginsDir, cwdPluginName );
+
+			vi.mocked( pathExists ).mockImplementation( async ( p: string ) => p === cwd );
+			vi.mocked( fs.promises.readdir ).mockResolvedValue( [ 'my-plugin.php' ] as unknown as never );
+			vi.mocked( fs.promises.readFile ).mockResolvedValue(
+				'<?php\n/*\nPlugin Name: My Plugin\n*/' as unknown as never
+			);
+
+			await runCommand( testSiteFolder );
+
+			expect( fs.promises.symlink ).toHaveBeenCalledTimes( 1 );
+			const [ , finalTarget ] = vi.mocked( fs.promises.symlink ).mock.calls[ 0 ];
+			expect( finalTarget ).toBe( expectedTarget );
+		} );
+
+		it( 'detects Plugin Name header in any PHP file in the directory', async () => {
+			vi.mocked( fs.promises.readdir ).mockResolvedValue( [
+				'helper.php',
+				'main.php',
+			] as unknown as never );
+			vi.mocked( fs.promises.readFile ).mockImplementation( async ( filePath ) => {
+				if ( String( filePath ).endsWith( 'main.php' ) ) {
+					return '<?php\n/*\nPlugin Name: My Plugin\n*/' as unknown as never;
+				}
+				return '<?php\n// no header' as unknown as never;
+			} );
+
+			await runCommand( testSiteFolder, testSourcePath );
+
+			expect( fs.promises.symlink ).toHaveBeenCalled();
+		} );
+	} );
+} );

--- a/apps/cli/commands/plugin/tests/list-linked.test.ts
+++ b/apps/cli/commands/plugin/tests/list-linked.test.ts
@@ -3,6 +3,14 @@ import path from 'path';
 import { pathExists } from '@studio/common/lib/fs-utils';
 import { vi } from 'vitest';
 import { getSiteByFolder } from 'cli/lib/cli-config/sites';
+import {
+	mockReportStart,
+	mockReportSuccess,
+	mockReportError,
+	mockReportProgress,
+	mockReportWarning,
+	mockReportKeyValuePair,
+} from 'cli/tests/test-utils';
 import { runCommand } from '../list-linked';
 
 vi.mock( 'fs', () => {
@@ -23,6 +31,19 @@ vi.mock( 'cli/lib/cli-config/sites', async () => {
 		getSiteByFolder: vi.fn(),
 	};
 } );
+vi.mock( 'cli/logger', () => ( {
+	Logger: class {
+		reportStart = mockReportStart;
+		reportSuccess = mockReportSuccess;
+		reportError = mockReportError;
+		reportProgress = mockReportProgress;
+		reportWarning = mockReportWarning;
+		reportKeyValuePair = mockReportKeyValuePair;
+		spinner = {};
+		currentAction = null;
+	},
+	LoggerError: class LoggerError extends Error {},
+} ) );
 
 describe( 'CLI: studio plugin list-linked', () => {
 	const testSiteFolder = '/test/site/path';
@@ -60,12 +81,17 @@ describe( 'CLI: studio plugin list-linked', () => {
 	const joinedOutput = () =>
 		consoleLogSpy.mock.calls.map( ( c: unknown[] ) => String( c[ 0 ] ?? '' ) ).join( '\n' );
 
+	const loggerMessages = () =>
+		[ ...mockReportStart.mock.calls, ...mockReportSuccess.mock.calls ]
+			.map( ( c ) => String( c[ c.length - 1 ] ?? '' ) )
+			.join( '\n' );
+
 	it( 'prints no linked plugins message when plugins dir is missing', async () => {
 		vi.mocked( pathExists ).mockResolvedValue( false );
 
 		await runCommand( testSiteFolder, 'table' );
 
-		expect( joinedOutput() ).toMatch( /No linked plugins found/ );
+		expect( loggerMessages() ).toMatch( /No linked plugins found/ );
 	} );
 
 	it( 'prints no linked plugins message when dir has no symlinks', async () => {
@@ -78,7 +104,7 @@ describe( 'CLI: studio plugin list-linked', () => {
 
 		await runCommand( testSiteFolder, 'table' );
 
-		expect( joinedOutput() ).toMatch( /No linked plugins found/ );
+		expect( loggerMessages() ).toMatch( /No linked plugins found/ );
 	} );
 
 	it( 'lists linked plugins in table format', async () => {
@@ -96,8 +122,8 @@ describe( 'CLI: studio plugin list-linked', () => {
 
 		await runCommand( testSiteFolder, 'table' );
 
+		expect( loggerMessages() ).toMatch( /Found 2 linked plugin/ );
 		const output = joinedOutput();
-		expect( output ).toMatch( /Found 2 linked plugin/ );
 		expect( output ).toContain( 'plugin-a' );
 		expect( output ).toContain( 'plugin-b' );
 		expect( output ).toContain( '/dev/plugin-a' );

--- a/apps/cli/commands/plugin/tests/list-linked.test.ts
+++ b/apps/cli/commands/plugin/tests/list-linked.test.ts
@@ -1,0 +1,143 @@
+import fs from 'fs';
+import path from 'path';
+import { pathExists } from '@studio/common/lib/fs-utils';
+import { vi } from 'vitest';
+import { getSiteByFolder } from 'cli/lib/cli-config/sites';
+import { runCommand } from '../list-linked';
+
+vi.mock( 'fs', () => {
+	const promises = {
+		lstat: vi.fn(),
+		readlink: vi.fn(),
+		readdir: vi.fn(),
+	};
+	return { default: { promises }, promises };
+} );
+vi.mock( '@studio/common/lib/fs-utils', () => ( {
+	pathExists: vi.fn(),
+} ) );
+vi.mock( 'cli/lib/cli-config/sites', async () => {
+	const actual = await vi.importActual( 'cli/lib/cli-config/sites' );
+	return {
+		...( actual as object ),
+		getSiteByFolder: vi.fn(),
+	};
+} );
+
+describe( 'CLI: studio plugin list-linked', () => {
+	const testSiteFolder = '/test/site/path';
+	const pluginsDir = path.join( testSiteFolder, 'wp-content', 'plugins' );
+
+	const makeDirent = ( name: string ): fs.Dirent =>
+		( {
+			name,
+			isSymbolicLink: () => true,
+			isDirectory: () => false,
+			isFile: () => false,
+		} ) as unknown as fs.Dirent;
+
+	let consoleLogSpy: ReturnType< typeof vi.spyOn >;
+
+	beforeEach( () => {
+		vi.clearAllMocks();
+
+		vi.mocked( getSiteByFolder ).mockResolvedValue( {
+			id: 'test-site-id',
+			name: 'Test Site',
+			path: testSiteFolder,
+			port: 8881,
+			phpVersion: '8.0',
+		} );
+
+		vi.mocked( pathExists ).mockResolvedValue( true );
+		consoleLogSpy = vi.spyOn( console, 'log' ).mockImplementation( () => {} );
+	} );
+
+	afterEach( () => {
+		vi.restoreAllMocks();
+	} );
+
+	const joinedOutput = () =>
+		consoleLogSpy.mock.calls.map( ( c: unknown[] ) => String( c[ 0 ] ?? '' ) ).join( '\n' );
+
+	it( 'prints no linked plugins message when plugins dir is missing', async () => {
+		vi.mocked( pathExists ).mockResolvedValue( false );
+
+		await runCommand( testSiteFolder, 'table' );
+
+		expect( joinedOutput() ).toMatch( /No linked plugins found/ );
+	} );
+
+	it( 'prints no linked plugins message when dir has no symlinks', async () => {
+		vi.mocked( fs.promises.readdir ).mockResolvedValue( [
+			{ name: 'regular-plugin', isSymbolicLink: () => false },
+		] as unknown as never );
+		vi.mocked( fs.promises.lstat ).mockResolvedValue( {
+			isSymbolicLink: () => false,
+		} as fs.Stats );
+
+		await runCommand( testSiteFolder, 'table' );
+
+		expect( joinedOutput() ).toMatch( /No linked plugins found/ );
+	} );
+
+	it( 'lists linked plugins in table format', async () => {
+		vi.mocked( fs.promises.readdir ).mockResolvedValue( [
+			makeDirent( 'plugin-a' ),
+			makeDirent( 'plugin-b' ),
+		] as unknown as never );
+		vi.mocked( fs.promises.lstat ).mockResolvedValue( {
+			isSymbolicLink: () => true,
+		} as fs.Stats );
+		vi.mocked( fs.promises.readlink ).mockImplementation( async ( p ) => {
+			const name = path.basename( String( p ) );
+			return path.relative( pluginsDir, `/dev/${ name }` );
+		} );
+
+		await runCommand( testSiteFolder, 'table' );
+
+		const output = joinedOutput();
+		expect( output ).toMatch( /Found 2 linked plugin/ );
+		expect( output ).toContain( 'plugin-a' );
+		expect( output ).toContain( 'plugin-b' );
+		expect( output ).toContain( '/dev/plugin-a' );
+		expect( output ).toContain( '/dev/plugin-b' );
+	} );
+
+	it( 'outputs JSON format', async () => {
+		vi.mocked( fs.promises.readdir ).mockResolvedValue( [
+			makeDirent( 'plugin-a' ),
+		] as unknown as never );
+		vi.mocked( fs.promises.lstat ).mockResolvedValue( {
+			isSymbolicLink: () => true,
+		} as fs.Stats );
+		vi.mocked( fs.promises.readlink ).mockResolvedValue(
+			path.relative( pluginsDir, '/dev/plugin-a' )
+		);
+
+		await runCommand( testSiteFolder, 'json' );
+
+		expect( consoleLogSpy ).toHaveBeenCalledTimes( 1 );
+		const parsed = JSON.parse( consoleLogSpy.mock.calls[ 0 ][ 0 ] as string );
+		expect( parsed ).toEqual( [ { name: 'plugin-a', sourcePath: '/dev/plugin-a' } ] );
+	} );
+
+	it( 'skips entries that fail to stat', async () => {
+		vi.mocked( fs.promises.readdir ).mockResolvedValue( [
+			makeDirent( 'broken' ),
+			makeDirent( 'good' ),
+		] as unknown as never );
+		vi.mocked( fs.promises.lstat ).mockImplementation( async ( p ) => {
+			if ( String( p ).endsWith( 'broken' ) ) {
+				throw new Error( 'EACCES' );
+			}
+			return { isSymbolicLink: () => true } as fs.Stats;
+		} );
+		vi.mocked( fs.promises.readlink ).mockResolvedValue( path.relative( pluginsDir, '/dev/good' ) );
+
+		await runCommand( testSiteFolder, 'json' );
+
+		const parsed = JSON.parse( consoleLogSpy.mock.calls[ 0 ][ 0 ] as string );
+		expect( parsed ).toEqual( [ { name: 'good', sourcePath: '/dev/good' } ] );
+	} );
+} );

--- a/apps/cli/commands/plugin/tests/list-linked.test.ts
+++ b/apps/cli/commands/plugin/tests/list-linked.test.ts
@@ -46,8 +46,11 @@ vi.mock( 'cli/logger', () => ( {
 } ) );
 
 describe( 'CLI: studio plugin list-linked', () => {
-	const testSiteFolder = '/test/site/path';
+	// Resolve so absolute paths match the platform-specific form `path.resolve` produces
+	// inside `getLinkedPlugins` (e.g. `C:\…` on Windows).
+	const testSiteFolder = path.resolve( '/test/site/path' );
 	const pluginsDir = path.join( testSiteFolder, 'wp-content', 'plugins' );
+	const devSource = ( name: string ) => path.resolve( '/dev', name );
 
 	const makeDirent = ( name: string ): fs.Dirent =>
 		( {
@@ -117,7 +120,7 @@ describe( 'CLI: studio plugin list-linked', () => {
 		} as fs.Stats );
 		vi.mocked( fs.promises.readlink ).mockImplementation( async ( p ) => {
 			const name = path.basename( String( p ) );
-			return path.relative( pluginsDir, `/dev/${ name }` );
+			return path.relative( pluginsDir, devSource( name ) );
 		} );
 
 		await runCommand( testSiteFolder, 'table' );
@@ -126,8 +129,8 @@ describe( 'CLI: studio plugin list-linked', () => {
 		const output = joinedOutput();
 		expect( output ).toContain( 'plugin-a' );
 		expect( output ).toContain( 'plugin-b' );
-		expect( output ).toContain( '/dev/plugin-a' );
-		expect( output ).toContain( '/dev/plugin-b' );
+		expect( output ).toContain( devSource( 'plugin-a' ) );
+		expect( output ).toContain( devSource( 'plugin-b' ) );
 	} );
 
 	it( 'outputs JSON format', async () => {
@@ -138,14 +141,14 @@ describe( 'CLI: studio plugin list-linked', () => {
 			isSymbolicLink: () => true,
 		} as fs.Stats );
 		vi.mocked( fs.promises.readlink ).mockResolvedValue(
-			path.relative( pluginsDir, '/dev/plugin-a' )
+			path.relative( pluginsDir, devSource( 'plugin-a' ) )
 		);
 
 		await runCommand( testSiteFolder, 'json' );
 
 		expect( consoleLogSpy ).toHaveBeenCalledTimes( 1 );
 		const parsed = JSON.parse( consoleLogSpy.mock.calls[ 0 ][ 0 ] as string );
-		expect( parsed ).toEqual( [ { name: 'plugin-a', sourcePath: '/dev/plugin-a' } ] );
+		expect( parsed ).toEqual( [ { name: 'plugin-a', sourcePath: devSource( 'plugin-a' ) } ] );
 	} );
 
 	it( 'skips entries that fail to stat', async () => {
@@ -159,11 +162,13 @@ describe( 'CLI: studio plugin list-linked', () => {
 			}
 			return { isSymbolicLink: () => true } as fs.Stats;
 		} );
-		vi.mocked( fs.promises.readlink ).mockResolvedValue( path.relative( pluginsDir, '/dev/good' ) );
+		vi.mocked( fs.promises.readlink ).mockResolvedValue(
+			path.relative( pluginsDir, devSource( 'good' ) )
+		);
 
 		await runCommand( testSiteFolder, 'json' );
 
 		const parsed = JSON.parse( consoleLogSpy.mock.calls[ 0 ][ 0 ] as string );
-		expect( parsed ).toEqual( [ { name: 'good', sourcePath: '/dev/good' } ] );
+		expect( parsed ).toEqual( [ { name: 'good', sourcePath: devSource( 'good' ) } ] );
 	} );
 } );

--- a/apps/cli/commands/plugin/tests/unlink.test.ts
+++ b/apps/cli/commands/plugin/tests/unlink.test.ts
@@ -80,6 +80,17 @@ describe( 'CLI: studio plugin unlink', () => {
 
 			await expect( runCommand( testSiteFolder, pluginName ) ).rejects.toThrow( 'Site not found' );
 		} );
+
+		it.each( [ '../evil', '../../etc', 'foo/bar', 'a/b/c' ] )(
+			'rejects path traversal in plugin name: %s',
+			async ( malicious ) => {
+				await expect( runCommand( testSiteFolder, malicious ) ).rejects.toThrow(
+					/Invalid plugin name/
+				);
+				expect( fs.promises.unlink ).not.toHaveBeenCalled();
+				expect( fs.promises.lstat ).not.toHaveBeenCalled();
+			}
+		);
 	} );
 
 	describe( 'Success Cases', () => {

--- a/apps/cli/commands/plugin/tests/unlink.test.ts
+++ b/apps/cli/commands/plugin/tests/unlink.test.ts
@@ -1,0 +1,93 @@
+import fs from 'fs';
+import path from 'path';
+import { pathExists } from '@studio/common/lib/fs-utils';
+import { vi } from 'vitest';
+import { getSiteByFolder } from 'cli/lib/cli-config/sites';
+import { runCommand } from '../unlink';
+
+vi.mock( 'fs', () => {
+	const promises = {
+		lstat: vi.fn(),
+		readlink: vi.fn(),
+		unlink: vi.fn(),
+	};
+	return { default: { promises }, promises };
+} );
+vi.mock( '@studio/common/lib/fs-utils', () => ( {
+	pathExists: vi.fn(),
+} ) );
+vi.mock( 'cli/lib/cli-config/sites', async () => {
+	const actual = await vi.importActual( 'cli/lib/cli-config/sites' );
+	return {
+		...( actual as object ),
+		getSiteByFolder: vi.fn(),
+	};
+} );
+
+describe( 'CLI: studio plugin unlink', () => {
+	const testSiteFolder = '/test/site/path';
+	const pluginsDir = path.join( testSiteFolder, 'wp-content', 'plugins' );
+	const pluginName = 'my-plugin';
+	const targetPath = path.join( pluginsDir, pluginName );
+	const sourcePath = '/test/plugins/my-plugin';
+
+	beforeEach( () => {
+		vi.clearAllMocks();
+
+		vi.mocked( getSiteByFolder ).mockResolvedValue( {
+			id: 'test-site-id',
+			name: 'Test Site',
+			path: testSiteFolder,
+			port: 8881,
+			phpVersion: '8.0',
+		} );
+
+		vi.mocked( pathExists ).mockResolvedValue( true );
+		vi.mocked( fs.promises.lstat ).mockResolvedValue( {
+			isSymbolicLink: () => true,
+		} as fs.Stats );
+		vi.mocked( fs.promises.readlink ).mockResolvedValue( path.relative( pluginsDir, sourcePath ) );
+		vi.mocked( fs.promises.unlink ).mockResolvedValue( undefined );
+	} );
+
+	afterEach( () => {
+		vi.restoreAllMocks();
+	} );
+
+	describe( 'Error Cases', () => {
+		it( 'throws when plugin does not exist in site', async () => {
+			vi.mocked( pathExists ).mockResolvedValue( false );
+
+			await expect( runCommand( testSiteFolder, pluginName ) ).rejects.toThrow(
+				/not found in site/
+			);
+			expect( fs.promises.unlink ).not.toHaveBeenCalled();
+		} );
+
+		it( 'throws when target exists but is not a symlink', async () => {
+			vi.mocked( fs.promises.lstat ).mockResolvedValue( {
+				isSymbolicLink: () => false,
+			} as fs.Stats );
+
+			await expect( runCommand( testSiteFolder, pluginName ) ).rejects.toThrow(
+				/is not a linked plugin/
+			);
+			expect( fs.promises.unlink ).not.toHaveBeenCalled();
+		} );
+
+		it( 'throws when site not found', async () => {
+			vi.mocked( getSiteByFolder ).mockRejectedValue( new Error( 'Site not found' ) );
+
+			await expect( runCommand( testSiteFolder, pluginName ) ).rejects.toThrow( 'Site not found' );
+		} );
+	} );
+
+	describe( 'Success Cases', () => {
+		it( 'removes the symlink and preserves the source', async () => {
+			await runCommand( testSiteFolder, pluginName );
+
+			expect( fs.promises.unlink ).toHaveBeenCalledWith( targetPath );
+			expect( fs.promises.readlink ).toHaveBeenCalledWith( targetPath );
+		} );
+	} );
+} );

--- a/apps/cli/commands/plugin/unlink.ts
+++ b/apps/cli/commands/plugin/unlink.ts
@@ -19,6 +19,16 @@ export async function runCommand( sitePath: string, pluginName?: string ): Promi
 		throw new LoggerError( __( 'Plugin name is required' ) );
 	}
 
+	// Reject path traversal: plugin name must be a single path segment
+	if ( path.basename( resolvedPluginName ) !== resolvedPluginName ) {
+		throw new LoggerError(
+			sprintf(
+				__( 'Invalid plugin name "%s": must be a single directory name without path separators' ),
+				resolvedPluginName
+			)
+		);
+	}
+
 	// Resolve site: try --path, fall back to picker if it's not a site and stdin is a TTY
 	let resolvedSitePath = sitePath;
 	try {

--- a/apps/cli/commands/plugin/unlink.ts
+++ b/apps/cli/commands/plugin/unlink.ts
@@ -1,0 +1,98 @@
+import fs from 'fs';
+import path from 'path';
+import { pathExists } from '@studio/common/lib/fs-utils';
+import { isErrnoException } from '@studio/common/lib/is-errno-exception';
+import { PluginCommandLoggerAction as LoggerAction } from '@studio/common/logger-actions';
+import { __, sprintf } from '@wordpress/i18n';
+import { getSiteByFolder } from 'cli/lib/cli-config/sites';
+import { pickLocalSite } from 'cli/lib/local-site-picker';
+import { Logger, LoggerError } from 'cli/logger';
+import { StudioArgv } from 'cli/types';
+
+const logger = new Logger< LoggerAction >();
+
+export async function runCommand( sitePath: string, pluginName?: string ): Promise< void > {
+	// Default plugin name to the current directory basename when omitted
+	const resolvedPluginName = pluginName ?? path.basename( process.cwd() );
+
+	if ( ! resolvedPluginName ) {
+		throw new LoggerError( __( 'Plugin name is required' ) );
+	}
+
+	// Resolve site: try --path, fall back to picker if it's not a site and stdin is a TTY
+	let resolvedSitePath = sitePath;
+	try {
+		await getSiteByFolder( sitePath );
+	} catch ( error ) {
+		if ( ! process.stdin.isTTY ) {
+			throw error;
+		}
+		const picked = await pickLocalSite( __( 'Select a site to unlink the plugin from' ) );
+		if ( ! picked ) {
+			throw error;
+		}
+		resolvedSitePath = picked.path;
+	}
+
+	logger.reportStart( LoggerAction.UNLINK, __( 'Unlinking plugin…' ) );
+
+	const pluginsDir = path.join( resolvedSitePath, 'wp-content', 'plugins' );
+	const targetPath = path.join( pluginsDir, resolvedPluginName );
+
+	// Check if target exists
+	if ( ! ( await pathExists( targetPath ) ) ) {
+		throw new LoggerError( sprintf( __( 'Plugin "%s" not found in site' ), resolvedPluginName ) );
+	}
+
+	// Check if it's a symlink
+	try {
+		const stats = await fs.promises.lstat( targetPath );
+		if ( ! stats.isSymbolicLink() ) {
+			throw new LoggerError(
+				sprintf(
+					__( 'Plugin "%s" is not a linked plugin. Use "studio wp plugin delete" to remove it.' ),
+					resolvedPluginName
+				)
+			);
+		}
+	} catch ( error ) {
+		if ( isErrnoException( error ) && error.code === 'ENOENT' ) {
+			throw new LoggerError( sprintf( __( 'Plugin "%s" not found in site' ), resolvedPluginName ) );
+		}
+		throw error;
+	}
+
+	// Get the link target for the success message
+	const linkTarget = await fs.promises.readlink( targetPath );
+	const resolvedTarget = path.resolve( path.dirname( targetPath ), linkTarget );
+
+	// Remove the symlink (not the source!)
+	await fs.promises.unlink( targetPath );
+
+	logger.reportSuccess( sprintf( __( 'Unlinked plugin "%s"' ), resolvedPluginName ) );
+	console.log( sprintf( __( 'Source directory preserved at: %s' ), resolvedTarget ) );
+}
+
+export const registerCommand = ( yargs: StudioArgv ) => {
+	return yargs.command( {
+		command: 'unlink [plugin]',
+		describe: __( 'Remove a linked plugin from the site (keeps source files)' ),
+		builder: ( unlinkYargs ) => {
+			return unlinkYargs.positional( 'plugin', {
+				type: 'string',
+				describe: __( 'Name of the linked plugin to remove (defaults to current directory name)' ),
+			} );
+		},
+		handler: async ( argv ) => {
+			try {
+				await runCommand( argv.path, argv.plugin as string | undefined );
+			} catch ( error ) {
+				if ( error instanceof LoggerError ) {
+					logger.reportError( error );
+				} else {
+					logger.reportError( new LoggerError( __( 'Failed to unlink plugin' ), error ) );
+				}
+			}
+		},
+	} );
+};

--- a/apps/cli/commands/theme/link.ts
+++ b/apps/cli/commands/theme/link.ts
@@ -98,6 +98,26 @@ export async function runCommand( sitePath: string, sourcePath?: string ): Promi
 		);
 	}
 
+	// Resolve symlinks so subsequent scope checks operate on the real target.
+	// Defends against AST04 (insecure metadata) by surfacing the true location
+	// when a user-typed source path is itself a symlink.
+	const realSourcePath = await fs.promises
+		.realpath( absoluteSourcePath )
+		.catch( () => absoluteSourcePath );
+
+	// Reject sources inside the target site to prevent recursive symlinks
+	// (a theme symlinking back into its own site's wp-content).
+	const resolvedSiteRealPath = await fs.promises
+		.realpath( resolvedSitePath )
+		.catch( () => resolvedSitePath );
+	const sourceWithSep = realSourcePath + path.sep;
+	const siteWithSep = resolvedSiteRealPath + path.sep;
+	if ( realSourcePath === resolvedSiteRealPath || sourceWithSep.startsWith( siteWithSep ) ) {
+		throw new LoggerError(
+			sprintf( __( 'Source must not live inside the target site: %s' ), realSourcePath )
+		);
+	}
+
 	// Determine theme name from directory name
 	const themeName = path.basename( absoluteSourcePath );
 	if ( ! themeName || themeName === '.' || themeName === '..' ) {
@@ -154,6 +174,10 @@ export async function runCommand( sitePath: string, sourcePath?: string ): Promi
 	await createThemeSymlink( absoluteSourcePath, targetPath );
 
 	logger.reportSuccess( sprintf( __( 'Linked theme "%s" → %s' ), themeName, absoluteSourcePath ) );
+	if ( realSourcePath !== absoluteSourcePath ) {
+		// Surface the real target so the user can spot symlink-chain shadowing.
+		console.log( sprintf( __( 'Resolved source: %s' ), realSourcePath ) );
+	}
 	console.log( __( 'Changes to the source directory will be reflected immediately in the site.' ) );
 }
 

--- a/apps/cli/commands/theme/link.ts
+++ b/apps/cli/commands/theme/link.ts
@@ -100,6 +100,14 @@ export async function runCommand( sitePath: string, sourcePath?: string ): Promi
 
 	// Determine theme name from directory name
 	const themeName = path.basename( absoluteSourcePath );
+	if ( ! themeName || themeName === '.' || themeName === '..' ) {
+		throw new LoggerError(
+			sprintf(
+				__( 'Could not determine a valid theme directory name from source path: %s' ),
+				absoluteSourcePath
+			)
+		);
+	}
 	const themesDir = path.join( resolvedSitePath, 'wp-content', 'themes' );
 	const targetPath = path.join( themesDir, themeName );
 

--- a/apps/cli/commands/theme/link.ts
+++ b/apps/cli/commands/theme/link.ts
@@ -1,0 +1,174 @@
+import fs from 'fs';
+import path from 'path';
+import { pathExists } from '@studio/common/lib/fs-utils';
+import { isErrnoException } from '@studio/common/lib/is-errno-exception';
+import { ThemeCommandLoggerAction as LoggerAction } from '@studio/common/logger-actions';
+import { __, sprintf } from '@wordpress/i18n';
+import { getSiteByFolder } from 'cli/lib/cli-config/sites';
+import { pickLocalSite } from 'cli/lib/local-site-picker';
+import { untildify } from 'cli/lib/utils';
+import { Logger, LoggerError } from 'cli/logger';
+import { StudioArgv } from 'cli/types';
+
+const logger = new Logger< LoggerAction >();
+
+/**
+ * Creates a symlink for a theme, with Windows junction fallback.
+ *
+ * @param sourcePath - Absolute path to the source theme directory
+ * @param targetPath - Absolute path where the symlink should be created
+ */
+async function createThemeSymlink( sourcePath: string, targetPath: string ): Promise< void > {
+	// Use relative path for standard symlinks (more portable)
+	const relativePath = path.relative( path.dirname( targetPath ), sourcePath );
+
+	try {
+		await fs.promises.symlink( relativePath, targetPath );
+	} catch ( error ) {
+		// On Windows, symlinks may require admin privileges or Developer Mode.
+		// Fall back to a directory junction which doesn't require elevated permissions.
+		if ( isErrnoException( error ) && error.code === 'EPERM' && process.platform === 'win32' ) {
+			// Junctions require absolute paths
+			await fs.promises.symlink( path.resolve( sourcePath ), targetPath, 'junction' );
+		} else {
+			throw error;
+		}
+	}
+}
+
+/**
+ * Validates that a directory looks like a WordPress theme.
+ * Checks for presence of style.css with Theme Name header.
+ */
+async function isValidThemeDirectory( themePath: string ): Promise< boolean > {
+	try {
+		const stylePath = path.join( themePath, 'style.css' );
+		if ( ! ( await pathExists( stylePath ) ) ) {
+			return false;
+		}
+
+		const content = await fs.promises.readFile( stylePath, 'utf-8' );
+		return content.includes( 'Theme Name:' );
+	} catch {
+		return false;
+	}
+}
+
+export async function runCommand( sitePath: string, sourcePath?: string ): Promise< void > {
+	// Use current directory if no source path provided
+	const absoluteSourcePath = path.resolve( sourcePath ? untildify( sourcePath ) : process.cwd() );
+
+	// Resolve site: try --path, fall back to picker if it's not a site and stdin is a TTY
+	let resolvedSitePath = sitePath;
+	try {
+		await getSiteByFolder( sitePath );
+	} catch ( error ) {
+		if ( ! process.stdin.isTTY ) {
+			throw error;
+		}
+		const picked = await pickLocalSite( __( 'Select a site to link the theme to' ) );
+		if ( ! picked ) {
+			throw error;
+		}
+		resolvedSitePath = picked.path;
+	}
+
+	logger.reportStart( LoggerAction.LINK, __( 'Linking theme…' ) );
+
+	// Validate source exists
+	if ( ! ( await pathExists( absoluteSourcePath ) ) ) {
+		throw new LoggerError( sprintf( __( 'Source path does not exist: %s' ), absoluteSourcePath ) );
+	}
+
+	// Validate source is a directory
+	const sourceStats = await fs.promises.stat( absoluteSourcePath );
+	if ( ! sourceStats.isDirectory() ) {
+		throw new LoggerError(
+			sprintf( __( 'Source path is not a directory: %s' ), absoluteSourcePath )
+		);
+	}
+
+	// Validate it looks like a theme
+	if ( ! ( await isValidThemeDirectory( absoluteSourcePath ) ) ) {
+		throw new LoggerError(
+			__(
+				'Source directory does not appear to be a valid WordPress theme. ' +
+					'Expected a style.css file with a "Theme Name:" header.'
+			)
+		);
+	}
+
+	// Determine theme name from directory name
+	const themeName = path.basename( absoluteSourcePath );
+	const themesDir = path.join( resolvedSitePath, 'wp-content', 'themes' );
+	const targetPath = path.join( themesDir, themeName );
+
+	// Check if target already exists
+	if ( await pathExists( targetPath ) ) {
+		// Check if it's already a symlink to the same source
+		try {
+			const stats = await fs.promises.lstat( targetPath );
+			if ( stats.isSymbolicLink() ) {
+				const linkTarget = await fs.promises.readlink( targetPath );
+				const resolvedTarget = path.resolve( path.dirname( targetPath ), linkTarget );
+				if ( resolvedTarget === absoluteSourcePath ) {
+					logger.reportSuccess(
+						sprintf( __( 'Theme "%s" is already linked to %s' ), themeName, absoluteSourcePath )
+					);
+					return;
+				}
+				throw new LoggerError(
+					sprintf(
+						__( 'Theme "%s" is already linked to a different location: %s' ),
+						themeName,
+						resolvedTarget
+					)
+				);
+			}
+		} catch ( error ) {
+			if ( ! isErrnoException( error ) || error.code !== 'ENOENT' ) {
+				throw error;
+			}
+		}
+
+		throw new LoggerError(
+			sprintf(
+				__( 'A theme named "%s" already exists. Remove it first or use a different name.' ),
+				themeName
+			)
+		);
+	}
+
+	// Ensure themes directory exists
+	await fs.promises.mkdir( themesDir, { recursive: true } );
+
+	// Create the symlink
+	await createThemeSymlink( absoluteSourcePath, targetPath );
+
+	logger.reportSuccess( sprintf( __( 'Linked theme "%s" → %s' ), themeName, absoluteSourcePath ) );
+	console.log( __( 'Changes to the source directory will be reflected immediately in the site.' ) );
+}
+
+export const registerCommand = ( yargs: StudioArgv ) => {
+	return yargs.command( {
+		command: 'link [source]',
+		describe: __( 'Link an external theme directory to the site' ),
+		builder: ( linkYargs ) => {
+			return linkYargs.positional( 'source', {
+				type: 'string',
+				describe: __( 'Path to the theme directory to link (defaults to current directory)' ),
+			} );
+		},
+		handler: async ( argv ) => {
+			try {
+				await runCommand( argv.path, argv.source as string | undefined );
+			} catch ( error ) {
+				if ( error instanceof LoggerError ) {
+					logger.reportError( error );
+				} else {
+					logger.reportError( new LoggerError( __( 'Failed to link theme' ), error ) );
+				}
+			}
+		},
+	} );
+};

--- a/apps/cli/commands/theme/list-linked.ts
+++ b/apps/cli/commands/theme/list-linked.ts
@@ -1,9 +1,10 @@
 import fs from 'fs';
 import path from 'path';
 import { pathExists } from '@studio/common/lib/fs-utils';
+import { ThemeCommandLoggerAction as LoggerAction } from '@studio/common/logger-actions';
 import { __, sprintf } from '@wordpress/i18n';
 import { getSiteByFolder } from 'cli/lib/cli-config/sites';
-import { LoggerError } from 'cli/logger';
+import { Logger, LoggerError } from 'cli/logger';
 import { StudioArgv } from 'cli/types';
 
 interface LinkedTheme {
@@ -45,29 +46,40 @@ async function getLinkedThemes( sitePath: string ): Promise< LinkedTheme[] > {
 }
 
 export async function runCommand( sitePath: string, format: 'table' | 'json' ): Promise< void > {
-	// Validate site exists
-	await getSiteByFolder( sitePath );
+	const logger = new Logger< LoggerAction >();
 
-	const linkedThemes = await getLinkedThemes( sitePath );
+	try {
+		// Validate site exists
+		await getSiteByFolder( sitePath );
 
-	if ( format === 'json' ) {
-		console.log( JSON.stringify( linkedThemes, null, 2 ) );
-		return;
-	}
+		if ( format === 'json' ) {
+			const linkedThemes = await getLinkedThemes( sitePath );
+			console.log( JSON.stringify( linkedThemes, null, 2 ) );
+			return;
+		}
 
-	if ( linkedThemes.length === 0 ) {
-		console.log( __( 'No linked themes found.' ) );
-		console.log( __( 'Use "studio theme link <source-path>" to link an external theme.' ) );
-		return;
-	}
+		logger.reportStart( LoggerAction.LIST_LINKED, __( 'Listing linked themes…' ) );
+		const linkedThemes = await getLinkedThemes( sitePath );
 
-	console.log( sprintf( __( 'Found %d linked theme(s):' ), linkedThemes.length ) );
-	console.log();
+		if ( linkedThemes.length === 0 ) {
+			logger.reportSuccess( __( 'No linked themes found.' ) );
+			console.log( __( 'Use "studio theme link <source-path>" to link an external theme.' ) );
+			return;
+		}
 
-	for ( const theme of linkedThemes ) {
-		console.log( `  ${ theme.name }` );
-		console.log( `    → ${ theme.sourcePath }` );
-		console.log();
+		logger.reportSuccess( sprintf( __( 'Found %d linked theme(s):' ), linkedThemes.length ) );
+
+		for ( const theme of linkedThemes ) {
+			console.log( `  ${ theme.name }` );
+			console.log( `    → ${ theme.sourcePath }` );
+			console.log();
+		}
+	} catch ( error ) {
+		if ( error instanceof LoggerError ) {
+			logger.reportError( error );
+		} else {
+			logger.reportError( new LoggerError( __( 'Failed to list linked themes' ), error ) );
+		}
 	}
 }
 
@@ -84,16 +96,7 @@ export const registerCommand = ( yargs: StudioArgv ) => {
 			} );
 		},
 		handler: async ( argv ) => {
-			try {
-				await runCommand( argv.path, argv.format as 'table' | 'json' );
-			} catch ( error ) {
-				process.exitCode = 1;
-				if ( error instanceof LoggerError ) {
-					console.error( error.message );
-				} else if ( error instanceof Error ) {
-					console.error( __( 'Failed to list linked themes' ), error.message );
-				}
-			}
+			await runCommand( argv.path, argv.format as 'table' | 'json' );
 		},
 	} );
 };

--- a/apps/cli/commands/theme/list-linked.ts
+++ b/apps/cli/commands/theme/list-linked.ts
@@ -1,0 +1,99 @@
+import fs from 'fs';
+import path from 'path';
+import { pathExists } from '@studio/common/lib/fs-utils';
+import { __, sprintf } from '@wordpress/i18n';
+import { getSiteByFolder } from 'cli/lib/cli-config/sites';
+import { LoggerError } from 'cli/logger';
+import { StudioArgv } from 'cli/types';
+
+interface LinkedTheme {
+	name: string;
+	sourcePath: string;
+}
+
+async function getLinkedThemes( sitePath: string ): Promise< LinkedTheme[] > {
+	const themesDir = path.join( sitePath, 'wp-content', 'themes' );
+
+	if ( ! ( await pathExists( themesDir ) ) ) {
+		return [];
+	}
+
+	const entries = await fs.promises.readdir( themesDir, { withFileTypes: true } );
+	const linkedThemes: LinkedTheme[] = [];
+
+	for ( const entry of entries ) {
+		const entryPath = path.join( themesDir, entry.name );
+
+		try {
+			const stats = await fs.promises.lstat( entryPath );
+			if ( stats.isSymbolicLink() ) {
+				const linkTarget = await fs.promises.readlink( entryPath );
+				const resolvedTarget = path.resolve( path.dirname( entryPath ), linkTarget );
+
+				linkedThemes.push( {
+					name: entry.name,
+					sourcePath: resolvedTarget,
+				} );
+			}
+		} catch {
+			// Skip entries we can't read
+			continue;
+		}
+	}
+
+	return linkedThemes;
+}
+
+export async function runCommand( sitePath: string, format: 'table' | 'json' ): Promise< void > {
+	// Validate site exists
+	await getSiteByFolder( sitePath );
+
+	const linkedThemes = await getLinkedThemes( sitePath );
+
+	if ( format === 'json' ) {
+		console.log( JSON.stringify( linkedThemes, null, 2 ) );
+		return;
+	}
+
+	if ( linkedThemes.length === 0 ) {
+		console.log( __( 'No linked themes found.' ) );
+		console.log( __( 'Use "studio theme link <source-path>" to link an external theme.' ) );
+		return;
+	}
+
+	console.log( sprintf( __( 'Found %d linked theme(s):' ), linkedThemes.length ) );
+	console.log();
+
+	for ( const theme of linkedThemes ) {
+		console.log( `  ${ theme.name }` );
+		console.log( `    → ${ theme.sourcePath }` );
+		console.log();
+	}
+}
+
+export const registerCommand = ( yargs: StudioArgv ) => {
+	return yargs.command( {
+		command: 'list-linked',
+		describe: __( 'List all linked themes in the site' ),
+		builder: ( listYargs ) => {
+			return listYargs.option( 'format', {
+				type: 'string',
+				choices: [ 'table', 'json' ] as const,
+				default: 'table' as const,
+				describe: __( 'Output format' ),
+			} );
+		},
+		handler: async ( argv ) => {
+			try {
+				await runCommand( argv.path, argv.format as 'table' | 'json' );
+			} catch ( error ) {
+				process.exitCode = 1;
+				if ( error instanceof LoggerError ) {
+					console.error( error.message );
+				} else if ( error instanceof Error ) {
+					console.error( __( 'Failed to list linked themes' ), error.message );
+				}
+			}
+		},
+	} );
+};

--- a/apps/cli/commands/theme/tests/link.test.ts
+++ b/apps/cli/commands/theme/tests/link.test.ts
@@ -1,0 +1,182 @@
+import fs from 'fs';
+import path from 'path';
+import { pathExists } from '@studio/common/lib/fs-utils';
+import { vi } from 'vitest';
+import { getSiteByFolder } from 'cli/lib/cli-config/sites';
+import { LoggerError } from 'cli/logger';
+import { runCommand } from '../link';
+
+vi.mock( 'fs', () => {
+	const promises = {
+		stat: vi.fn(),
+		lstat: vi.fn(),
+		readFile: vi.fn(),
+		readlink: vi.fn(),
+		mkdir: vi.fn(),
+		symlink: vi.fn(),
+		unlink: vi.fn(),
+	};
+	return { default: { promises }, promises };
+} );
+vi.mock( '@studio/common/lib/fs-utils', () => ( {
+	pathExists: vi.fn(),
+} ) );
+vi.mock( 'cli/lib/cli-config/sites', async () => {
+	const actual = await vi.importActual( 'cli/lib/cli-config/sites' );
+	return {
+		...( actual as object ),
+		getSiteByFolder: vi.fn(),
+	};
+} );
+
+describe( 'CLI: studio theme link', () => {
+	const testSiteFolder = '/test/site/path';
+	const testSourcePath = '/test/themes/my-theme';
+	const themesDir = path.join( testSiteFolder, 'wp-content', 'themes' );
+	const targetPath = path.join( themesDir, 'my-theme' );
+	const styleCssPath = path.join( testSourcePath, 'style.css' );
+
+	beforeEach( () => {
+		vi.clearAllMocks();
+
+		vi.mocked( getSiteByFolder ).mockResolvedValue( {
+			id: 'test-site-id',
+			name: 'Test Site',
+			path: testSiteFolder,
+			port: 8881,
+			phpVersion: '8.0',
+		} );
+
+		// Default: source exists (incl. style.css), target does not.
+		vi.mocked( pathExists ).mockImplementation(
+			async ( p: string ) => p === testSourcePath || p === styleCssPath
+		);
+		vi.mocked( fs.promises.stat ).mockResolvedValue( {
+			isDirectory: () => true,
+		} as fs.Stats );
+		vi.mocked( fs.promises.readFile ).mockResolvedValue(
+			'/*\nTheme Name: My Theme\n*/' as unknown as never
+		);
+		vi.mocked( fs.promises.mkdir ).mockResolvedValue( undefined );
+		vi.mocked( fs.promises.symlink ).mockResolvedValue( undefined );
+	} );
+
+	afterEach( () => {
+		vi.restoreAllMocks();
+	} );
+
+	describe( 'Error Cases', () => {
+		it( 'throws when site not found', async () => {
+			vi.mocked( getSiteByFolder ).mockRejectedValue( new Error( 'Site not found' ) );
+
+			await expect( runCommand( testSiteFolder, testSourcePath ) ).rejects.toThrow(
+				'Site not found'
+			);
+		} );
+
+		it( 'throws when source path does not exist', async () => {
+			vi.mocked( pathExists ).mockResolvedValue( false );
+
+			await expect( runCommand( testSiteFolder, testSourcePath ) ).rejects.toThrow( LoggerError );
+			await expect( runCommand( testSiteFolder, testSourcePath ) ).rejects.toThrow(
+				/Source path does not exist/
+			);
+		} );
+
+		it( 'throws when source is not a directory', async () => {
+			vi.mocked( fs.promises.stat ).mockResolvedValue( {
+				isDirectory: () => false,
+			} as fs.Stats );
+
+			await expect( runCommand( testSiteFolder, testSourcePath ) ).rejects.toThrow(
+				/Source path is not a directory/
+			);
+		} );
+
+		it( 'throws when style.css is missing', async () => {
+			vi.mocked( pathExists ).mockImplementation( async ( p: string ) => p === testSourcePath );
+
+			await expect( runCommand( testSiteFolder, testSourcePath ) ).rejects.toThrow(
+				/does not appear to be a valid WordPress theme/
+			);
+		} );
+
+		it( 'throws when style.css lacks Theme Name header', async () => {
+			vi.mocked( fs.promises.readFile ).mockResolvedValue( '/* no header */' as unknown as never );
+
+			await expect( runCommand( testSiteFolder, testSourcePath ) ).rejects.toThrow(
+				/does not appear to be a valid WordPress theme/
+			);
+		} );
+
+		it( 'throws when target exists as a non-symlink directory', async () => {
+			vi.mocked( pathExists ).mockResolvedValue( true );
+			vi.mocked( fs.promises.lstat ).mockResolvedValue( {
+				isSymbolicLink: () => false,
+			} as fs.Stats );
+
+			await expect( runCommand( testSiteFolder, testSourcePath ) ).rejects.toThrow(
+				/already exists/
+			);
+			expect( fs.promises.symlink ).not.toHaveBeenCalled();
+		} );
+
+		it( 'throws when target is a symlink to a different source', async () => {
+			vi.mocked( pathExists ).mockResolvedValue( true );
+			vi.mocked( fs.promises.lstat ).mockResolvedValue( {
+				isSymbolicLink: () => true,
+			} as fs.Stats );
+			vi.mocked( fs.promises.readlink ).mockResolvedValue( '/some/other/theme' );
+
+			await expect( runCommand( testSiteFolder, testSourcePath ) ).rejects.toThrow(
+				/already linked to a different location/
+			);
+		} );
+	} );
+
+	describe( 'Success Cases', () => {
+		it( 'creates a relative symlink for a valid theme', async () => {
+			await runCommand( testSiteFolder, testSourcePath );
+
+			expect( fs.promises.mkdir ).toHaveBeenCalledWith( themesDir, { recursive: true } );
+			expect( fs.promises.symlink ).toHaveBeenCalledTimes( 1 );
+			const [ linkPath, finalTarget ] = vi.mocked( fs.promises.symlink ).mock.calls[ 0 ];
+			expect( finalTarget ).toBe( targetPath );
+			expect( linkPath ).toBe( path.relative( themesDir, testSourcePath ) );
+		} );
+
+		it( 'uses current directory when source is omitted', async () => {
+			const cwd = process.cwd();
+			const cwdThemeName = path.basename( cwd );
+			const expectedTarget = path.join( themesDir, cwdThemeName );
+			const cwdStyleCss = path.join( cwd, 'style.css' );
+
+			vi.mocked( pathExists ).mockImplementation(
+				async ( p: string ) => p === cwd || p === cwdStyleCss
+			);
+			vi.mocked( fs.promises.readFile ).mockResolvedValue(
+				'/*\nTheme Name: My Theme\n*/' as unknown as never
+			);
+
+			await runCommand( testSiteFolder );
+
+			expect( fs.promises.symlink ).toHaveBeenCalledTimes( 1 );
+			const [ , finalTarget ] = vi.mocked( fs.promises.symlink ).mock.calls[ 0 ];
+			expect( finalTarget ).toBe( expectedTarget );
+		} );
+
+		it( 'is a no-op when theme is already linked to the same source', async () => {
+			vi.mocked( pathExists ).mockResolvedValue( true );
+			vi.mocked( fs.promises.lstat ).mockResolvedValue( {
+				isSymbolicLink: () => true,
+			} as fs.Stats );
+			vi.mocked( fs.promises.readlink ).mockResolvedValue(
+				path.relative( themesDir, testSourcePath )
+			);
+
+			await runCommand( testSiteFolder, testSourcePath );
+
+			expect( fs.promises.symlink ).not.toHaveBeenCalled();
+		} );
+	} );
+} );

--- a/apps/cli/commands/theme/tests/link.test.ts
+++ b/apps/cli/commands/theme/tests/link.test.ts
@@ -132,6 +132,20 @@ describe( 'CLI: studio theme link', () => {
 				/already linked to a different location/
 			);
 		} );
+
+		it( 'throws when source resolves to filesystem root (empty basename)', async () => {
+			vi.mocked( pathExists ).mockImplementation(
+				async ( p: string ) => p === '/' || p === '/style.css'
+			);
+			vi.mocked( fs.promises.readFile ).mockResolvedValue(
+				'/*\nTheme Name: Root Theme\n*/' as unknown as never
+			);
+
+			await expect( runCommand( testSiteFolder, '/' ) ).rejects.toThrow(
+				/Could not determine a valid theme directory name/
+			);
+			expect( fs.promises.symlink ).not.toHaveBeenCalled();
+		} );
 	} );
 
 	describe( 'Success Cases', () => {

--- a/apps/cli/commands/theme/tests/link.test.ts
+++ b/apps/cli/commands/theme/tests/link.test.ts
@@ -12,6 +12,7 @@ vi.mock( 'fs', () => {
 		lstat: vi.fn(),
 		readFile: vi.fn(),
 		readlink: vi.fn(),
+		realpath: vi.fn(),
 		mkdir: vi.fn(),
 		symlink: vi.fn(),
 		unlink: vi.fn(),
@@ -61,6 +62,8 @@ describe( 'CLI: studio theme link', () => {
 		);
 		vi.mocked( fs.promises.mkdir ).mockResolvedValue( undefined );
 		vi.mocked( fs.promises.symlink ).mockResolvedValue( undefined );
+		// Default: realpath returns input unchanged (no symlink chain).
+		vi.mocked( fs.promises.realpath ).mockImplementation( async ( p ) => String( p ) );
 	} );
 
 	afterEach( () => {
@@ -133,6 +136,35 @@ describe( 'CLI: studio theme link', () => {
 			await expect( runCommand( testSiteFolder, testSourcePath ) ).rejects.toThrow(
 				/already linked to a different location/
 			);
+		} );
+
+		it( 'throws when source lives inside the target site (recursive)', async () => {
+			const insidePath = path.join( testSiteFolder, 'wp-content', 'themes', 'inner' );
+			const insideStyleCss = path.join( insidePath, 'style.css' );
+			vi.mocked( pathExists ).mockImplementation(
+				async ( p: string ) => p === insidePath || p === insideStyleCss
+			);
+			vi.mocked( fs.promises.realpath ).mockImplementation( async ( p ) => String( p ) );
+
+			await expect( runCommand( testSiteFolder, insidePath ) ).rejects.toThrow(
+				/must not live inside the target site/
+			);
+			expect( fs.promises.symlink ).not.toHaveBeenCalled();
+		} );
+
+		it( 'throws when source symlink resolves into the target site', async () => {
+			const insidePath = path.join( testSiteFolder, 'wp-content', 'themes', 'inner' );
+			vi.mocked( fs.promises.realpath ).mockImplementation( async ( p ) => {
+				if ( String( p ) === testSourcePath ) {
+					return insidePath;
+				}
+				return String( p );
+			} );
+
+			await expect( runCommand( testSiteFolder, testSourcePath ) ).rejects.toThrow(
+				/must not live inside the target site/
+			);
+			expect( fs.promises.symlink ).not.toHaveBeenCalled();
 		} );
 
 		it( 'throws when source resolves to filesystem root (empty basename)', async () => {

--- a/apps/cli/commands/theme/tests/link.test.ts
+++ b/apps/cli/commands/theme/tests/link.test.ts
@@ -30,8 +30,10 @@ vi.mock( 'cli/lib/cli-config/sites', async () => {
 } );
 
 describe( 'CLI: studio theme link', () => {
-	const testSiteFolder = '/test/site/path';
-	const testSourcePath = '/test/themes/my-theme';
+	// Use `path.resolve` so the mocked pathExists comparison matches the
+	// platform-specific absolute form that runCommand computes (e.g. `C:\…` on Windows).
+	const testSiteFolder = path.resolve( '/test/site/path' );
+	const testSourcePath = path.resolve( '/test/themes/my-theme' );
 	const themesDir = path.join( testSiteFolder, 'wp-content', 'themes' );
 	const targetPath = path.join( themesDir, 'my-theme' );
 	const styleCssPath = path.join( testSourcePath, 'style.css' );
@@ -134,14 +136,16 @@ describe( 'CLI: studio theme link', () => {
 		} );
 
 		it( 'throws when source resolves to filesystem root (empty basename)', async () => {
+			const fsRoot = path.resolve( '/' );
+			const rootStyleCss = path.join( fsRoot, 'style.css' );
 			vi.mocked( pathExists ).mockImplementation(
-				async ( p: string ) => p === '/' || p === '/style.css'
+				async ( p: string ) => p === fsRoot || p === rootStyleCss
 			);
 			vi.mocked( fs.promises.readFile ).mockResolvedValue(
 				'/*\nTheme Name: Root Theme\n*/' as unknown as never
 			);
 
-			await expect( runCommand( testSiteFolder, '/' ) ).rejects.toThrow(
+			await expect( runCommand( testSiteFolder, fsRoot ) ).rejects.toThrow(
 				/Could not determine a valid theme directory name/
 			);
 			expect( fs.promises.symlink ).not.toHaveBeenCalled();

--- a/apps/cli/commands/theme/tests/list-linked.test.ts
+++ b/apps/cli/commands/theme/tests/list-linked.test.ts
@@ -46,8 +46,11 @@ vi.mock( 'cli/logger', () => ( {
 } ) );
 
 describe( 'CLI: studio theme list-linked', () => {
-	const testSiteFolder = '/test/site/path';
+	// Resolve so absolute paths match the platform-specific form `path.resolve` produces
+	// inside `getLinkedThemes` (e.g. `C:\…` on Windows).
+	const testSiteFolder = path.resolve( '/test/site/path' );
 	const themesDir = path.join( testSiteFolder, 'wp-content', 'themes' );
+	const devSource = ( name: string ) => path.resolve( '/dev', name );
 
 	const makeDirent = ( name: string ): fs.Dirent =>
 		( {
@@ -104,7 +107,7 @@ describe( 'CLI: studio theme list-linked', () => {
 		} as fs.Stats );
 		vi.mocked( fs.promises.readlink ).mockImplementation( async ( p ) => {
 			const name = path.basename( String( p ) );
-			return path.relative( themesDir, `/dev/${ name }` );
+			return path.relative( themesDir, devSource( name ) );
 		} );
 
 		await runCommand( testSiteFolder, 'table' );
@@ -113,8 +116,8 @@ describe( 'CLI: studio theme list-linked', () => {
 		const output = joinedOutput();
 		expect( output ).toContain( 'theme-a' );
 		expect( output ).toContain( 'theme-b' );
-		expect( output ).toContain( '/dev/theme-a' );
-		expect( output ).toContain( '/dev/theme-b' );
+		expect( output ).toContain( devSource( 'theme-a' ) );
+		expect( output ).toContain( devSource( 'theme-b' ) );
 	} );
 
 	it( 'outputs JSON format', async () => {
@@ -125,13 +128,13 @@ describe( 'CLI: studio theme list-linked', () => {
 			isSymbolicLink: () => true,
 		} as fs.Stats );
 		vi.mocked( fs.promises.readlink ).mockResolvedValue(
-			path.relative( themesDir, '/dev/theme-a' )
+			path.relative( themesDir, devSource( 'theme-a' ) )
 		);
 
 		await runCommand( testSiteFolder, 'json' );
 
 		expect( consoleLogSpy ).toHaveBeenCalledTimes( 1 );
 		const parsed = JSON.parse( consoleLogSpy.mock.calls[ 0 ][ 0 ] as string );
-		expect( parsed ).toEqual( [ { name: 'theme-a', sourcePath: '/dev/theme-a' } ] );
+		expect( parsed ).toEqual( [ { name: 'theme-a', sourcePath: devSource( 'theme-a' ) } ] );
 	} );
 } );

--- a/apps/cli/commands/theme/tests/list-linked.test.ts
+++ b/apps/cli/commands/theme/tests/list-linked.test.ts
@@ -1,0 +1,111 @@
+import fs from 'fs';
+import path from 'path';
+import { pathExists } from '@studio/common/lib/fs-utils';
+import { vi } from 'vitest';
+import { getSiteByFolder } from 'cli/lib/cli-config/sites';
+import { runCommand } from '../list-linked';
+
+vi.mock( 'fs', () => {
+	const promises = {
+		lstat: vi.fn(),
+		readlink: vi.fn(),
+		readdir: vi.fn(),
+	};
+	return { default: { promises }, promises };
+} );
+vi.mock( '@studio/common/lib/fs-utils', () => ( {
+	pathExists: vi.fn(),
+} ) );
+vi.mock( 'cli/lib/cli-config/sites', async () => {
+	const actual = await vi.importActual( 'cli/lib/cli-config/sites' );
+	return {
+		...( actual as object ),
+		getSiteByFolder: vi.fn(),
+	};
+} );
+
+describe( 'CLI: studio theme list-linked', () => {
+	const testSiteFolder = '/test/site/path';
+	const themesDir = path.join( testSiteFolder, 'wp-content', 'themes' );
+
+	const makeDirent = ( name: string ): fs.Dirent =>
+		( {
+			name,
+			isSymbolicLink: () => true,
+			isDirectory: () => false,
+			isFile: () => false,
+		} ) as unknown as fs.Dirent;
+
+	let consoleLogSpy: ReturnType< typeof vi.spyOn >;
+
+	beforeEach( () => {
+		vi.clearAllMocks();
+
+		vi.mocked( getSiteByFolder ).mockResolvedValue( {
+			id: 'test-site-id',
+			name: 'Test Site',
+			path: testSiteFolder,
+			port: 8881,
+			phpVersion: '8.0',
+		} );
+
+		vi.mocked( pathExists ).mockResolvedValue( true );
+		consoleLogSpy = vi.spyOn( console, 'log' ).mockImplementation( () => {} );
+	} );
+
+	afterEach( () => {
+		vi.restoreAllMocks();
+	} );
+
+	const joinedOutput = () =>
+		consoleLogSpy.mock.calls.map( ( c: unknown[] ) => String( c[ 0 ] ?? '' ) ).join( '\n' );
+
+	it( 'prints no linked themes message when themes dir is missing', async () => {
+		vi.mocked( pathExists ).mockResolvedValue( false );
+
+		await runCommand( testSiteFolder, 'table' );
+
+		expect( joinedOutput() ).toMatch( /No linked themes found/ );
+	} );
+
+	it( 'lists linked themes in table format', async () => {
+		vi.mocked( fs.promises.readdir ).mockResolvedValue( [
+			makeDirent( 'theme-a' ),
+			makeDirent( 'theme-b' ),
+		] as unknown as never );
+		vi.mocked( fs.promises.lstat ).mockResolvedValue( {
+			isSymbolicLink: () => true,
+		} as fs.Stats );
+		vi.mocked( fs.promises.readlink ).mockImplementation( async ( p ) => {
+			const name = path.basename( String( p ) );
+			return path.relative( themesDir, `/dev/${ name }` );
+		} );
+
+		await runCommand( testSiteFolder, 'table' );
+
+		const output = joinedOutput();
+		expect( output ).toMatch( /Found 2 linked theme/ );
+		expect( output ).toContain( 'theme-a' );
+		expect( output ).toContain( 'theme-b' );
+		expect( output ).toContain( '/dev/theme-a' );
+		expect( output ).toContain( '/dev/theme-b' );
+	} );
+
+	it( 'outputs JSON format', async () => {
+		vi.mocked( fs.promises.readdir ).mockResolvedValue( [
+			makeDirent( 'theme-a' ),
+		] as unknown as never );
+		vi.mocked( fs.promises.lstat ).mockResolvedValue( {
+			isSymbolicLink: () => true,
+		} as fs.Stats );
+		vi.mocked( fs.promises.readlink ).mockResolvedValue(
+			path.relative( themesDir, '/dev/theme-a' )
+		);
+
+		await runCommand( testSiteFolder, 'json' );
+
+		expect( consoleLogSpy ).toHaveBeenCalledTimes( 1 );
+		const parsed = JSON.parse( consoleLogSpy.mock.calls[ 0 ][ 0 ] as string );
+		expect( parsed ).toEqual( [ { name: 'theme-a', sourcePath: '/dev/theme-a' } ] );
+	} );
+} );

--- a/apps/cli/commands/theme/tests/list-linked.test.ts
+++ b/apps/cli/commands/theme/tests/list-linked.test.ts
@@ -3,6 +3,14 @@ import path from 'path';
 import { pathExists } from '@studio/common/lib/fs-utils';
 import { vi } from 'vitest';
 import { getSiteByFolder } from 'cli/lib/cli-config/sites';
+import {
+	mockReportStart,
+	mockReportSuccess,
+	mockReportError,
+	mockReportProgress,
+	mockReportWarning,
+	mockReportKeyValuePair,
+} from 'cli/tests/test-utils';
 import { runCommand } from '../list-linked';
 
 vi.mock( 'fs', () => {
@@ -23,6 +31,19 @@ vi.mock( 'cli/lib/cli-config/sites', async () => {
 		getSiteByFolder: vi.fn(),
 	};
 } );
+vi.mock( 'cli/logger', () => ( {
+	Logger: class {
+		reportStart = mockReportStart;
+		reportSuccess = mockReportSuccess;
+		reportError = mockReportError;
+		reportProgress = mockReportProgress;
+		reportWarning = mockReportWarning;
+		reportKeyValuePair = mockReportKeyValuePair;
+		spinner = {};
+		currentAction = null;
+	},
+	LoggerError: class LoggerError extends Error {},
+} ) );
 
 describe( 'CLI: studio theme list-linked', () => {
 	const testSiteFolder = '/test/site/path';
@@ -60,12 +81,17 @@ describe( 'CLI: studio theme list-linked', () => {
 	const joinedOutput = () =>
 		consoleLogSpy.mock.calls.map( ( c: unknown[] ) => String( c[ 0 ] ?? '' ) ).join( '\n' );
 
+	const loggerMessages = () =>
+		[ ...mockReportStart.mock.calls, ...mockReportSuccess.mock.calls ]
+			.map( ( c ) => String( c[ c.length - 1 ] ?? '' ) )
+			.join( '\n' );
+
 	it( 'prints no linked themes message when themes dir is missing', async () => {
 		vi.mocked( pathExists ).mockResolvedValue( false );
 
 		await runCommand( testSiteFolder, 'table' );
 
-		expect( joinedOutput() ).toMatch( /No linked themes found/ );
+		expect( loggerMessages() ).toMatch( /No linked themes found/ );
 	} );
 
 	it( 'lists linked themes in table format', async () => {
@@ -83,8 +109,8 @@ describe( 'CLI: studio theme list-linked', () => {
 
 		await runCommand( testSiteFolder, 'table' );
 
+		expect( loggerMessages() ).toMatch( /Found 2 linked theme/ );
 		const output = joinedOutput();
-		expect( output ).toMatch( /Found 2 linked theme/ );
 		expect( output ).toContain( 'theme-a' );
 		expect( output ).toContain( 'theme-b' );
 		expect( output ).toContain( '/dev/theme-a' );

--- a/apps/cli/commands/theme/tests/unlink.test.ts
+++ b/apps/cli/commands/theme/tests/unlink.test.ts
@@ -80,6 +80,17 @@ describe( 'CLI: studio theme unlink', () => {
 
 			await expect( runCommand( testSiteFolder, themeName ) ).rejects.toThrow( 'Site not found' );
 		} );
+
+		it.each( [ '../evil', '../../etc', 'foo/bar', 'a/b/c' ] )(
+			'rejects path traversal in theme name: %s',
+			async ( malicious ) => {
+				await expect( runCommand( testSiteFolder, malicious ) ).rejects.toThrow(
+					/Invalid theme name/
+				);
+				expect( fs.promises.unlink ).not.toHaveBeenCalled();
+				expect( fs.promises.lstat ).not.toHaveBeenCalled();
+			}
+		);
 	} );
 
 	describe( 'Success Cases', () => {

--- a/apps/cli/commands/theme/tests/unlink.test.ts
+++ b/apps/cli/commands/theme/tests/unlink.test.ts
@@ -1,0 +1,93 @@
+import fs from 'fs';
+import path from 'path';
+import { pathExists } from '@studio/common/lib/fs-utils';
+import { vi } from 'vitest';
+import { getSiteByFolder } from 'cli/lib/cli-config/sites';
+import { runCommand } from '../unlink';
+
+vi.mock( 'fs', () => {
+	const promises = {
+		lstat: vi.fn(),
+		readlink: vi.fn(),
+		unlink: vi.fn(),
+	};
+	return { default: { promises }, promises };
+} );
+vi.mock( '@studio/common/lib/fs-utils', () => ( {
+	pathExists: vi.fn(),
+} ) );
+vi.mock( 'cli/lib/cli-config/sites', async () => {
+	const actual = await vi.importActual( 'cli/lib/cli-config/sites' );
+	return {
+		...( actual as object ),
+		getSiteByFolder: vi.fn(),
+	};
+} );
+
+describe( 'CLI: studio theme unlink', () => {
+	const testSiteFolder = '/test/site/path';
+	const themesDir = path.join( testSiteFolder, 'wp-content', 'themes' );
+	const themeName = 'my-theme';
+	const targetPath = path.join( themesDir, themeName );
+	const sourcePath = '/test/themes/my-theme';
+
+	beforeEach( () => {
+		vi.clearAllMocks();
+
+		vi.mocked( getSiteByFolder ).mockResolvedValue( {
+			id: 'test-site-id',
+			name: 'Test Site',
+			path: testSiteFolder,
+			port: 8881,
+			phpVersion: '8.0',
+		} );
+
+		vi.mocked( pathExists ).mockResolvedValue( true );
+		vi.mocked( fs.promises.lstat ).mockResolvedValue( {
+			isSymbolicLink: () => true,
+		} as fs.Stats );
+		vi.mocked( fs.promises.readlink ).mockResolvedValue( path.relative( themesDir, sourcePath ) );
+		vi.mocked( fs.promises.unlink ).mockResolvedValue( undefined );
+	} );
+
+	afterEach( () => {
+		vi.restoreAllMocks();
+	} );
+
+	describe( 'Error Cases', () => {
+		it( 'throws when theme does not exist in site', async () => {
+			vi.mocked( pathExists ).mockResolvedValue( false );
+
+			await expect( runCommand( testSiteFolder, themeName ) ).rejects.toThrow(
+				/not found in site/
+			);
+			expect( fs.promises.unlink ).not.toHaveBeenCalled();
+		} );
+
+		it( 'throws when target exists but is not a symlink', async () => {
+			vi.mocked( fs.promises.lstat ).mockResolvedValue( {
+				isSymbolicLink: () => false,
+			} as fs.Stats );
+
+			await expect( runCommand( testSiteFolder, themeName ) ).rejects.toThrow(
+				/is not a linked theme/
+			);
+			expect( fs.promises.unlink ).not.toHaveBeenCalled();
+		} );
+
+		it( 'throws when site not found', async () => {
+			vi.mocked( getSiteByFolder ).mockRejectedValue( new Error( 'Site not found' ) );
+
+			await expect( runCommand( testSiteFolder, themeName ) ).rejects.toThrow( 'Site not found' );
+		} );
+	} );
+
+	describe( 'Success Cases', () => {
+		it( 'removes the symlink and preserves the source', async () => {
+			await runCommand( testSiteFolder, themeName );
+
+			expect( fs.promises.unlink ).toHaveBeenCalledWith( targetPath );
+			expect( fs.promises.readlink ).toHaveBeenCalledWith( targetPath );
+		} );
+	} );
+} );

--- a/apps/cli/commands/theme/unlink.ts
+++ b/apps/cli/commands/theme/unlink.ts
@@ -19,6 +19,16 @@ export async function runCommand( sitePath: string, themeName?: string ): Promis
 		throw new LoggerError( __( 'Theme name is required' ) );
 	}
 
+	// Reject path traversal: theme name must be a single path segment
+	if ( path.basename( resolvedThemeName ) !== resolvedThemeName ) {
+		throw new LoggerError(
+			sprintf(
+				__( 'Invalid theme name "%s": must be a single directory name without path separators' ),
+				resolvedThemeName
+			)
+		);
+	}
+
 	// Resolve site: try --path, fall back to picker if it's not a site and stdin is a TTY
 	let resolvedSitePath = sitePath;
 	try {

--- a/apps/cli/commands/theme/unlink.ts
+++ b/apps/cli/commands/theme/unlink.ts
@@ -1,0 +1,98 @@
+import fs from 'fs';
+import path from 'path';
+import { pathExists } from '@studio/common/lib/fs-utils';
+import { isErrnoException } from '@studio/common/lib/is-errno-exception';
+import { ThemeCommandLoggerAction as LoggerAction } from '@studio/common/logger-actions';
+import { __, sprintf } from '@wordpress/i18n';
+import { getSiteByFolder } from 'cli/lib/cli-config/sites';
+import { pickLocalSite } from 'cli/lib/local-site-picker';
+import { Logger, LoggerError } from 'cli/logger';
+import { StudioArgv } from 'cli/types';
+
+const logger = new Logger< LoggerAction >();
+
+export async function runCommand( sitePath: string, themeName?: string ): Promise< void > {
+	// Default theme name to the current directory basename when omitted
+	const resolvedThemeName = themeName ?? path.basename( process.cwd() );
+
+	if ( ! resolvedThemeName ) {
+		throw new LoggerError( __( 'Theme name is required' ) );
+	}
+
+	// Resolve site: try --path, fall back to picker if it's not a site and stdin is a TTY
+	let resolvedSitePath = sitePath;
+	try {
+		await getSiteByFolder( sitePath );
+	} catch ( error ) {
+		if ( ! process.stdin.isTTY ) {
+			throw error;
+		}
+		const picked = await pickLocalSite( __( 'Select a site to unlink the theme from' ) );
+		if ( ! picked ) {
+			throw error;
+		}
+		resolvedSitePath = picked.path;
+	}
+
+	logger.reportStart( LoggerAction.UNLINK, __( 'Unlinking theme…' ) );
+
+	const themesDir = path.join( resolvedSitePath, 'wp-content', 'themes' );
+	const targetPath = path.join( themesDir, resolvedThemeName );
+
+	// Check if target exists
+	if ( ! ( await pathExists( targetPath ) ) ) {
+		throw new LoggerError( sprintf( __( 'Theme "%s" not found in site' ), resolvedThemeName ) );
+	}
+
+	// Check if it's a symlink
+	try {
+		const stats = await fs.promises.lstat( targetPath );
+		if ( ! stats.isSymbolicLink() ) {
+			throw new LoggerError(
+				sprintf(
+					__( 'Theme "%s" is not a linked theme. Use "studio wp theme delete" to remove it.' ),
+					resolvedThemeName
+				)
+			);
+		}
+	} catch ( error ) {
+		if ( isErrnoException( error ) && error.code === 'ENOENT' ) {
+			throw new LoggerError( sprintf( __( 'Theme "%s" not found in site' ), resolvedThemeName ) );
+		}
+		throw error;
+	}
+
+	// Get the link target for the success message
+	const linkTarget = await fs.promises.readlink( targetPath );
+	const resolvedTarget = path.resolve( path.dirname( targetPath ), linkTarget );
+
+	// Remove the symlink (not the source!)
+	await fs.promises.unlink( targetPath );
+
+	logger.reportSuccess( sprintf( __( 'Unlinked theme "%s"' ), resolvedThemeName ) );
+	console.log( sprintf( __( 'Source directory preserved at: %s' ), resolvedTarget ) );
+}
+
+export const registerCommand = ( yargs: StudioArgv ) => {
+	return yargs.command( {
+		command: 'unlink [theme]',
+		describe: __( 'Remove a linked theme from the site (keeps source files)' ),
+		builder: ( unlinkYargs ) => {
+			return unlinkYargs.positional( 'theme', {
+				type: 'string',
+				describe: __( 'Name of the linked theme to remove (defaults to current directory name)' ),
+			} );
+		},
+		handler: async ( argv ) => {
+			try {
+				await runCommand( argv.path, argv.theme as string | undefined );
+			} catch ( error ) {
+				if ( error instanceof LoggerError ) {
+					logger.reportError( error );
+				} else {
+					logger.reportError( new LoggerError( __( 'Failed to unlink theme' ), error ) );
+				}
+			}
+		},
+	} );
+};

--- a/apps/cli/index.ts
+++ b/apps/cli/index.ts
@@ -186,6 +186,42 @@ async function main() {
 	registerPullCommand( studioArgv );
 	registerPushCommand( studioArgv );
 
+	studioArgv.command( 'plugin', __( 'Manage plugins' ), async ( pluginYargs ) => {
+		const [
+			{ registerCommand: registerPluginLinkCommand },
+			{ registerCommand: registerPluginUnlinkCommand },
+			{ registerCommand: registerPluginListLinkedCommand },
+		] = await Promise.all( [
+			import( 'cli/commands/plugin/link' ),
+			import( 'cli/commands/plugin/unlink' ),
+			import( 'cli/commands/plugin/list-linked' ),
+		] );
+
+		registerPluginLinkCommand( pluginYargs );
+		registerPluginUnlinkCommand( pluginYargs );
+		registerPluginListLinkedCommand( pluginYargs );
+		pluginYargs
+			.version( false )
+			.demandCommand( 1, __( 'You must provide a valid plugin command' ) );
+	} );
+
+	studioArgv.command( 'theme', __( 'Manage themes' ), async ( themeYargs ) => {
+		const [
+			{ registerCommand: registerThemeLinkCommand },
+			{ registerCommand: registerThemeUnlinkCommand },
+			{ registerCommand: registerThemeListLinkedCommand },
+		] = await Promise.all( [
+			import( 'cli/commands/theme/link' ),
+			import( 'cli/commands/theme/unlink' ),
+			import( 'cli/commands/theme/list-linked' ),
+		] );
+
+		registerThemeLinkCommand( themeYargs );
+		registerThemeUnlinkCommand( themeYargs );
+		registerThemeListLinkedCommand( themeYargs );
+		themeYargs.version( false ).demandCommand( 1, __( 'You must provide a valid theme command' ) );
+	} );
+
 	studioArgv
 		.command( 'site', __( 'Manage sites' ), async ( sitesYargs ) => {
 			const [

--- a/apps/cli/lib/local-site-picker.ts
+++ b/apps/cli/lib/local-site-picker.ts
@@ -1,0 +1,90 @@
+import { search } from '@inquirer/prompts';
+import { __ } from '@wordpress/i18n';
+import chalk from 'chalk';
+import { readCliConfig, type SiteData } from 'cli/lib/cli-config/core';
+
+function formatSiteChoice( site: SiteData ): string {
+	return `${ site.name } ${ chalk.dim( site.path ) }`;
+}
+
+export async function pickLocalSite( message: string ): Promise< SiteData | undefined > {
+	const config = await readCliConfig();
+	const sites = config.sites;
+
+	if ( sites.length === 0 ) {
+		console.log( __( 'No Studio sites found. Create one with `studio site create`.' ) );
+		return undefined;
+	}
+
+	const choices = sites.map( ( site ) => ( {
+		name: formatSiteChoice( site ),
+		value: site.id,
+	} ) );
+
+	const abortController = new AbortController();
+	const handleEscKey = ( chunk: Buffer | string ) => {
+		const bytes = Buffer.isBuffer( chunk ) ? chunk : Buffer.from( chunk );
+		if ( bytes.length === 1 && bytes[ 0 ] === 0x1b ) {
+			abortController.abort();
+		}
+	};
+
+	if ( process.stdin.isTTY ) {
+		process.stdin.on( 'data', handleEscKey );
+	}
+
+	try {
+		const selectedId = await search(
+			{
+				message,
+				source: ( term ) => {
+					if ( ! term ) {
+						return choices;
+					}
+					const lowerTerm = term.toLowerCase();
+					return choices.filter( ( choice ) => {
+						const site = sites.find( ( s ) => s.id === choice.value );
+						if ( ! site ) {
+							return false;
+						}
+						return (
+							site.name.toLowerCase().includes( lowerTerm ) ||
+							site.path.toLowerCase().includes( lowerTerm )
+						);
+					} );
+				},
+				pageSize: 12,
+				theme: {
+					style: {
+						keysHelpTip: () =>
+							chalk.dim(
+								[
+									__( '↑↓ navigate' ),
+									__( 'type to filter' ),
+									__( '⏎ select' ),
+									__( 'esc cancel' ),
+								].join( ' · ' )
+							),
+					},
+				},
+			},
+			{
+				signal: abortController.signal,
+			}
+		);
+
+		return sites.find( ( site ) => site.id === selectedId );
+	} catch ( error ) {
+		if (
+			error instanceof Error &&
+			( error.name === 'AbortPromptError' || error.name === 'ExitPromptError' )
+		) {
+			return undefined;
+		}
+		throw error;
+	} finally {
+		if ( process.stdin.isTTY ) {
+			process.stdin.off( 'data', handleEscKey );
+		}
+	}
+}

--- a/docs/design-docs/plugin-theme-link.md
+++ b/docs/design-docs/plugin-theme-link.md
@@ -1,0 +1,82 @@
+# Plugin and theme link — CLI feature
+
+## Summary
+
+Developers working on a WordPress plugin or theme commonly maintain a single source directory outside any specific Studio site (for example `~/Developer/wp-plugins/secure-custom-fields`) and need to try that code against multiple local sites: different WordPress versions, PHP versions, themes, or datasets.
+
+Copying the source into each site's `wp-content/plugins` directory breaks the feedback loop — edits land in a copy and need to be kept in sync by hand. This feature adds a set of CLI commands that create and manage symbolic links from a site's `wp-content/plugins` or `wp-content/themes` directory to an external source directory.
+
+## Commands
+
+| Command | Purpose |
+|---------|---------|
+| `studio plugin link [source]` | Link an external plugin directory into a Studio site |
+| `studio plugin unlink [plugin]` | Remove a plugin symlink from a site (source files untouched) |
+| `studio plugin list-linked` | List every linked plugin inside a site (table or `--format json`) |
+| `studio theme link [source]` | Link an external theme directory into a Studio site |
+| `studio theme unlink [theme]` | Remove a theme symlink from a site |
+| `studio theme list-linked` | List every linked theme inside a site |
+
+### Default arguments
+
+- `link` without `[source]` uses the current working directory as the source.
+- `unlink` without `[plugin]` / `[theme]` uses the basename of the current working directory as the symlink name to remove.
+
+### Site resolution
+
+When `--path` resolves to a directory that is not a registered Studio site — for example when the terminal is inside a plugin folder — and standard input is a TTY, the CLI opens a searchable picker listing every local site registered in `~/.studio/cli.json`. The chosen site's path becomes the target for the link or unlink operation. In non-interactive shells the original "specified directory is not added to Studio" error is preserved so automation fails loud.
+
+## Validation
+
+Before creating a symlink the CLI verifies that the source directory looks like a real WordPress plugin or theme:
+
+- **Plugin**: at least one `*.php` file in the source root contains a `Plugin Name:` header.
+- **Theme**: a `style.css` at the source root contains a `Theme Name:` header.
+
+If the target directory inside the site already exists the CLI distinguishes between three cases:
+
+- An existing symlink pointing to the same source → reported as "already linked" and the command exits success.
+- An existing symlink pointing to a different source → a `LoggerError` is raised so the user can decide whether to unlink first.
+- A regular (non-symlink) directory → a `LoggerError` is raised recommending removal before linking.
+
+## Cross-platform behavior
+
+- **macOS / Linux**: the link is created with `fs.promises.symlink` using a relative path computed with `path.relative( dirname( target ), source )`. Relative symlinks travel with the site if the user moves it along with its source.
+- **Windows**: the same call is attempted first. If it fails with `EPERM` (symlinks require elevated privileges or Developer Mode on Windows), the CLI falls back to a directory junction created with `fs.promises.symlink( resolve( source ), target, 'junction' )`. Junctions do not require admin privileges but only work with absolute paths to directories on the same volume.
+
+## Safety
+
+`unlink` always removes the symlink node only — it never touches the files at the resolved source path. The command refuses to operate on a real (non-symlink) directory, surfacing instead a hint to use `studio wp plugin delete` or `studio wp theme delete`.
+
+## Related files
+
+- `apps/cli/commands/plugin/{link,unlink,list-linked}.ts`
+- `apps/cli/commands/theme/{link,unlink,list-linked}.ts`
+- `apps/cli/lib/local-site-picker.ts` — interactive site picker used when `--path` does not resolve
+- `apps/cli/index.ts` — registers the `plugin` and `theme` subcommands
+- `tools/common/logger-actions.ts` — telemetry actions `PluginCommandLoggerAction` and `ThemeCommandLoggerAction`
+
+## Testing
+
+Unit tests live under `apps/cli/commands/{plugin,theme}/tests/*.test.ts` and cover:
+
+- Valid source directory detection for both plugins and themes
+- All error paths (missing source, non-directory source, invalid plugin/theme structure, already-linked-to-same-source, already-linked-to-different-source, non-symlink collision)
+- Windows junction fallback on `EPERM`
+- `unlink` refusing to operate on non-symlink directories
+- `list-linked` filtering to symlinks only and respecting `--format json`
+
+Manual test flow:
+
+```bash
+mkdir -p /tmp/test-plugin
+cat > /tmp/test-plugin/test-plugin.php <<'PHP'
+<?php
+/** Plugin Name: Test Plugin */
+PHP
+
+cd /tmp/test-plugin
+studio plugin link                                            # picker appears → choose a site
+studio plugin list-linked --path ~/Studio/<picked-site>
+studio plugin unlink                                          # plugin name defaults to "test-plugin"
+```

--- a/tools/common/logger-actions.ts
+++ b/tools/common/logger-actions.ts
@@ -70,3 +70,15 @@ export enum SyncCommandLoggerAction {
 	DOWNLOAD = 'download',
 	IMPORT = 'import',
 }
+
+export enum PluginCommandLoggerAction {
+	LINK = 'link',
+	UNLINK = 'unlink',
+	LIST_LINKED = 'listLinked',
+}
+
+export enum ThemeCommandLoggerAction {
+	LINK = 'link',
+	UNLINK = 'unlink',
+	LIST_LINKED = 'listLinked',
+}


### PR DESCRIPTION
> **Supersedes #3122** — moved from fork (`cbravobernal/studio`) to upstream (`Automattic/studio`) so CI and reviewers can operate on the repo directly. Prior review context lives on #3122.

## TL;DR (caveman)

Fixes #3121. CLI commands. Symlink external plugin/theme source → Studio site `wp-content/plugins` or `wp-content/themes`.

- `studio plugin link [source]` / `unlink [plugin]` / `list-linked`
- `studio theme link [source]` / `unlink [theme]` / `list-linked`

No args inside plugin/theme folder → source = cwd. Opens picker listing all Studio sites. No need `--path`. Non-interactive shell (CI, piped stdin) → original error. Automation fail loud.

**Why:** devs keep one plugin/theme outside any site, test across many Studio sites (different WP/PHP/theme/data). Copy breaks feedback loop. Symlink = one source of truth. CLI right surface — plugin/theme dev already in terminal. Complements #1728.

**How:**
- Validation: plugin source needs PHP file with `Plugin Name:` header. Theme needs `style.css` with `Theme Name:` header.
- Symlinks relative (portable). Windows `EPERM` → fallback directory junction. No admin needed.
- `unlink` removes symlink node only. Never source files. Refuse regular dirs.
- Idempotent: same source twice → "already linked", exit 0. Different source on occupied name → clear error.

PoC draft. Vibecoded. Needs review.

---

# Long version

## What

Fixes https://github.com/Automattic/studio/issues/3121 by adding a cli command to link and unlink plugins on a development folder.

## Warning - Vibecoded

https://github.com/user-attachments/assets/eda5cdce-97b7-429f-b4b4-0ffe9b4ff9ff

## Related issues

- Related to #3121
- Complements #1728 (UI-side symlink support)

## How AI was used in this PR

This PR is a vibe-coded Proof of Concept: commands, tests, docs, and the interactive site picker were drafted with Claude Code (Opus 4.7) guidance and then iterated locally. Please treat architecture, tests, and UX as starting points rather than merge-ready polish. The author has executed each command manually against the real `studio` binary to validate behavior.

## Proposed Changes

Introduce a set of CLI commands to manage symbolic links between an external plugin or theme source directory and a local Studio site:

- `studio plugin link [source]` — link a plugin directory into a site (defaults `source` to `cwd`).
- `studio plugin unlink [plugin]` — remove a linked plugin (defaults `plugin` to `basename(cwd)`).
- `studio plugin list-linked` — list linked plugins; `--format table|json`.
- `studio theme link [source]` / `studio theme unlink [theme]` / `studio theme list-linked` — the same surface for themes.

Key behaviors:

- **Source validation** — plugin source must contain a PHP file with a `Plugin Name:` header; theme source must contain `style.css` with a `Theme Name:` header.
- **Cross-platform symlinks** — relative symlinks by default; Windows falls back to a directory junction on `EPERM` so admin privileges are not required.
- **Safe `unlink`** — removes the symlink only, never touches the resolved source files. Refuses to operate on non-symlink directories.
- **Interactive site picker** — when `--path` does not resolve to a Studio site and `stdin` is a TTY, the CLI opens a searchable picker listing every site from `~/.studio/cli.json` so the user can link/unlink without typing paths. Non-TTY shells preserve the original error so automation fails loud.
- **Telemetry** — new `PluginCommandLoggerAction` and `ThemeCommandLoggerAction` enums in `tools/common/logger-actions.ts` so existing logger infrastructure picks up the new surface.

### Files of interest

- `apps/cli/commands/plugin/{link,unlink,list-linked}.ts`
- `apps/cli/commands/theme/{link,unlink,list-linked}.ts`
- `apps/cli/lib/local-site-picker.ts` — shared picker built on `@inquirer/prompts`, mirroring the pattern in `apps/cli/lib/sync-site-picker.ts`.
- `apps/cli/index.ts` — registers the `plugin` and `theme` subcommands.
- `docs/design-docs/plugin-theme-link.md` — design doc covering commands, validation, cross-platform behavior, safety, and test flow.
- `apps/cli/README.md` — user-facing documentation updated with picker UX.

## Testing Instructions

Prerequisites: build the CLI bundle (`npm run cli:package`) or install a desktop build that already ships it.

```bash
# Create throwaway fixtures
mkdir -p /tmp/test-plugin /tmp/test-theme
printf '<?php\n/** Plugin Name: Test Plugin */\n' > /tmp/test-plugin/test-plugin.php
printf '/*\nTheme Name: Test Theme\n*/\n' > /tmp/test-theme/style.css

# Link with explicit --path
studio plugin link /tmp/test-plugin --path ~/Studio/<some-site>
studio theme link /tmp/test-theme --path ~/Studio/<some-site>

# List
studio plugin list-linked --path ~/Studio/<some-site>
studio theme list-linked --path ~/Studio/<some-site>

# Picker path — run inside a plugin folder without any arguments
cd /tmp/test-plugin
studio plugin link        # interactive picker appears; choose a site
studio plugin unlink      # plugin name defaults to "test-plugin"

# Idempotency / error paths
studio plugin link /tmp/test-plugin --path ~/Studio/<some-site>  # should report "already linked"
mkdir -p /tmp/bad-plugin && studio plugin link /tmp/bad-plugin   # error: no Plugin Name header

# Cleanup
rm -rf /tmp/test-plugin /tmp/test-theme /tmp/bad-plugin
```

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Unit tests — 37 tests across `apps/cli/commands/{plugin,theme}/tests/*.test.ts` pass locally.
- [ ] Design doc added under `docs/design-docs/plugin-theme-link.md`.
- [ ] README section added under "Link external plugins and themes".
- [ ] i18n — every user-facing string wrapped in `__()` / `sprintf()` so `@automattic/wp-babel-makepot` picks them up during the code-freeze Fastlane lane.
- [ ] E2E — not run against this branch (manual desktop E2E failed in the local environment with "Target page closed" errors unrelated to the CLI changes; CI should exercise the suite cleanly).
- [ ] Telemetry for the new actions verified end-to-end.
- [ ] Team review of CLI UX (picker copy, default behaviors, error messages).

