### PR TITLE
CLI: Add Opus 4.7 support to code agent with max effort thinking

### DIFF
--- a/apps/cli/ai/agent.ts
+++ b/apps/cli/ai/agent.ts
@@ -30,6 +30,7 @@ export interface AiAgentConfig {
 export const AI_MODELS = {
 	'claude-sonnet-4-6': 'Sonnet 4.6',
 	'claude-opus-4-6': 'Opus 4.6',
+	'claude-opus-4-7': 'Opus 4.7',
 } as const;
 
 export type AiModelId = keyof typeof AI_MODELS;
@@ -143,6 +144,7 @@ export function startAiAgent( config: AiAgentConfig ): Query {
 			},
 			plugins: [ { type: 'local' as const, path: path.resolve( import.meta.dirname, 'plugin' ) } ],
 			model,
+			...( model.startsWith( 'claude-opus-' ) ? { effort: 'max' as const } : {} ),
 			resume,
 		},
 	} );

--- a/apps/cli/ai/agent.ts
+++ b/apps/cli/ai/agent.ts
@@ -144,7 +144,6 @@ export function startAiAgent( config: AiAgentConfig ): Query {
 			},
 			plugins: [ { type: 'local' as const, path: path.resolve( import.meta.dirname, 'plugin' ) } ],
 			model,
-			...( model.startsWith( 'claude-opus-' ) ? { effort: 'max' as const } : {} ),
 			resume,
 		},
 	} );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1419,6 +1419,7 @@
 			"integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.29.0",
 				"@babel/generator": "^7.29.0",
@@ -3152,6 +3153,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			},
@@ -3173,6 +3175,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -4649,6 +4652,7 @@
 			"resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
 			"integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@babel/runtime": "^7.18.3",
 				"@emotion/babel-plugin": "^11.13.5",
@@ -6046,6 +6050,7 @@
 		"node_modules/@inquirer/prompts": {
 			"version": "7.10.1",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@inquirer/checkbox": "^4.3.2",
 				"@inquirer/confirm": "^5.1.21",
@@ -7522,6 +7527,7 @@
 			"resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.2.tgz",
 			"integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@octokit/auth-token": "^4.0.0",
 				"@octokit/graphql": "^7.1.0",
@@ -7863,6 +7869,7 @@
 		"node_modules/@opentelemetry/api": {
 			"version": "1.9.0",
 			"license": "Apache-2.0",
+			"peer": true,
 			"engines": {
 				"node": ">=8.0.0"
 			}
@@ -7884,6 +7891,7 @@
 			"resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.6.0.tgz",
 			"integrity": "sha512-L8UyDwqpTcbkIK5cgwDRDYDoEhQoj8wp8BwsO19w3LB1Z41yEQm2VJyNfAi9DrLP/YTqXqWpKHyZfR9/tFYo1Q==",
 			"license": "Apache-2.0",
+			"peer": true,
 			"engines": {
 				"node": "^18.19.0 || >=20.6.0"
 			},
@@ -7896,6 +7904,7 @@
 			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.6.0.tgz",
 			"integrity": "sha512-HLM1v2cbZ4TgYN6KEOj+Bbj8rAKriOdkF9Ed3tG25FoprSiQl7kYc+RRT6fUZGOvx0oMi5U67GoFdT+XUn8zEg==",
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"@opentelemetry/semantic-conventions": "^1.29.0"
 			},
@@ -8319,6 +8328,7 @@
 			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.6.0.tgz",
 			"integrity": "sha512-D4y/+OGe3JSuYUCBxtH5T9DSAWNcvCb/nQWIga8HNtXTVPQn59j0nTBAgaAXxUVBDl40mG3Tc76b46wPlZaiJQ==",
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"@opentelemetry/core": "2.6.0",
 				"@opentelemetry/semantic-conventions": "^1.29.0"
@@ -8335,6 +8345,7 @@
 			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.6.0.tgz",
 			"integrity": "sha512-g/OZVkqlxllgFM7qMKqbPV9c1DUPhQ7d4n3pgZFcrnrNft9eJXZM2TNHTPYREJBrtNdRytYyvwjgL5geDKl3EQ==",
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"@opentelemetry/core": "2.6.0",
 				"@opentelemetry/resources": "2.6.0",
@@ -8352,6 +8363,7 @@
 			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
 			"integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
 			"license": "Apache-2.0",
+			"peer": true,
 			"engines": {
 				"node": ">=14"
 			}
@@ -10019,6 +10031,7 @@
 			"devOptional": true,
 			"hasInstallScript": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"dependencies": {
 				"@swc/counter": "^0.1.3",
 				"@swc/types": "^0.1.24"
@@ -10406,8 +10419,7 @@
 		"node_modules/@types/aria-query": {
 			"version": "5.0.4",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/@types/aws-lambda": {
 			"version": "8.10.161",
@@ -10657,6 +10669,7 @@
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.11.tgz",
 			"integrity": "sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"undici-types": "~6.21.0"
 			}
@@ -10702,6 +10715,7 @@
 		"node_modules/@types/react": {
 			"version": "18.3.27",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@types/prop-types": "*",
 				"csstype": "^3.2.2"
@@ -10833,6 +10847,7 @@
 			"integrity": "sha512-k4eNDan0EIMTT/dUKc/g+rsJ6wcHYhNPdY19VoX/EOtaAG8DLtKCykhrUnuHPYvinn5jhAPgD2Qw9hXBwrahsw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/scope-manager": "8.57.1",
 				"@typescript-eslint/types": "8.57.1",
@@ -11021,6 +11036,7 @@
 			"integrity": "sha512-XUNSJ/lEVFttPMMoDVA2r2bwrl8/oPx8cURtczkSEswY5T3AeLmCy+EKWQNdL4u0MmAHOjcWrqJp2cdvgjn8dQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.9.1",
 				"@typescript-eslint/scope-manager": "8.57.1",
@@ -11480,6 +11496,7 @@
 			"integrity": "sha512-sTSDtVM1GOevRGsCNhp1mBUHKo9Qlc55+HCreFT4fe99AHxl1QQNXSL3uj4Pkjh5yEuWZIx8E2tVC94nnBZECQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@vitest/utils": "4.1.0",
 				"fflate": "^0.8.2",
@@ -12946,6 +12963,7 @@
 		"node_modules/acorn": {
 			"version": "8.15.0",
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -13798,6 +13816,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"baseline-browser-mapping": "^2.9.0",
 				"caniuse-lite": "^1.0.30001759",
@@ -15276,8 +15295,7 @@
 		"node_modules/dom-accessibility-api": {
 			"version": "0.5.16",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/dot-case": {
 			"version": "3.0.4",
@@ -16529,6 +16547,7 @@
 		"node_modules/eslint": {
 			"version": "9.39.2",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.8.0",
 				"@eslint-community/regexpp": "^4.12.1",
@@ -16589,6 +16608,7 @@
 			"integrity": "sha512-iI1f+D2ViGn+uvv5HuHVUamg8ll4tN+JRHGc6IJi4TP9Kl976C57fzPXgseXNs8v0iA8aSJpHsTWjDb9QJamGQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"eslint-config-prettier": "bin/cli.js"
 			},
@@ -16658,6 +16678,7 @@
 			"integrity": "sha512-J5gx7sN6DTm0LRT//eP3rVVQ2Yi4hrX0B+DbWxa5er8PZ6JjLo9GUBwogIFvEDdwJaSqZplpQT+haK/cXhb7VQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/types": "^8.34.0",
 				"comment-parser": "^1.4.1",
@@ -17149,6 +17170,7 @@
 			"resolved": "https://registry.npmjs.org/express/-/express-4.22.0.tgz",
 			"integrity": "sha512-c2iPh3xp5vvCLgaHK03+mWLFPhox7j1LwyxcZwFVApEv5i0X+IjPpbT50SJJwwLpdBVfp45AkK/v+AFgv/XlfQ==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"accepts": "~1.3.8",
 				"array-flatten": "1.1.1",
@@ -18555,6 +18577,7 @@
 			"resolved": "https://registry.npmjs.org/hono/-/hono-4.12.7.tgz",
 			"integrity": "sha512-jq9l1DM0zVIvsm3lv9Nw9nlJnMNPOcAtsbsgiUhWcFzPE99Gvo6yRTlszSLLYacMeQ6quHD6hMfId8crVHvexw==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=16.9.0"
 			}
@@ -20157,7 +20180,6 @@
 			"version": "1.5.0",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"lz-string": "bin/bin.js"
 			}
@@ -22407,6 +22429,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"nanoid": "^3.3.11",
 				"picocolors": "^1.1.1",
@@ -22676,6 +22699,7 @@
 			"version": "3.0.3",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"prettier": "bin/prettier.cjs"
 			},
@@ -22703,7 +22727,6 @@
 			"version": "27.5.1",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"ansi-regex": "^5.0.1",
 				"ansi-styles": "^5.0.0",
@@ -22717,7 +22740,6 @@
 			"version": "5.2.0",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			},
@@ -22728,8 +22750,7 @@
 		"node_modules/pretty-format/node_modules/react-is": {
 			"version": "17.0.2",
 			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/proc-log": {
 			"version": "2.0.1",
@@ -22973,6 +22994,7 @@
 		"node_modules/react": {
 			"version": "18.3.1",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"loose-envify": "^1.1.0"
 			},
@@ -23018,6 +23040,7 @@
 		"node_modules/react-dom": {
 			"version": "18.3.1",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"loose-envify": "^1.1.0",
 				"scheduler": "^0.23.2"
@@ -23062,6 +23085,7 @@
 		"node_modules/react-redux": {
 			"version": "9.2.0",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@types/use-sync-external-store": "^0.0.6",
 				"use-sync-external-store": "^1.4.0"
@@ -23278,7 +23302,8 @@
 		},
 		"node_modules/redux": {
 			"version": "5.0.1",
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/redux-thunk": {
 			"version": "3.1.0",
@@ -23643,6 +23668,7 @@
 			"integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@types/estree": "1.0.8"
 			},
@@ -23813,6 +23839,7 @@
 			"version": "8.17.1",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
 				"fast-uri": "^3.0.1",
@@ -25213,6 +25240,7 @@
 			"version": "4.0.3",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -25458,6 +25486,7 @@
 		"node_modules/ts-node": {
 			"version": "10.9.2",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@cspotcode/source-map-support": "^0.8.0",
 				"@tsconfig/node10": "^1.0.7",
@@ -25502,7 +25531,8 @@
 		},
 		"node_modules/tslib": {
 			"version": "2.8.1",
-			"license": "0BSD"
+			"license": "0BSD",
+			"peer": true
 		},
 		"node_modules/tunnel-agent": {
 			"version": "0.6.0",
@@ -25579,6 +25609,7 @@
 		"node_modules/typescript": {
 			"version": "5.9.3",
 			"license": "Apache-2.0",
+			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -26076,6 +26107,7 @@
 			"version": "7.3.1",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.27.0",
 				"fdir": "^6.5.0",
@@ -26711,6 +26743,7 @@
 			"version": "4.0.3",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -26724,6 +26757,7 @@
 			"integrity": "sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@vitest/expect": "4.1.0",
 				"@vitest/mocker": "4.1.0",
@@ -26883,6 +26917,7 @@
 			"version": "5.104.1",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@types/eslint-scope": "^3.7.7",
 				"@types/estree": "^1.0.8",
@@ -27478,6 +27513,7 @@
 			"resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
 			"integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
 			"license": "MIT",
+			"peer": true,
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
 			}
@@ -27644,6 +27680,7 @@
 			"integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
 			"devOptional": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"undici-types": "~7.18.0"
 			}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1419,7 +1419,6 @@
 			"integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.29.0",
 				"@babel/generator": "^7.29.0",
@@ -3153,7 +3152,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			},
@@ -3175,7 +3173,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -4652,7 +4649,6 @@
 			"resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
 			"integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@babel/runtime": "^7.18.3",
 				"@emotion/babel-plugin": "^11.13.5",
@@ -6050,7 +6046,6 @@
 		"node_modules/@inquirer/prompts": {
 			"version": "7.10.1",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@inquirer/checkbox": "^4.3.2",
 				"@inquirer/confirm": "^5.1.21",
@@ -7527,7 +7522,6 @@
 			"resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.2.tgz",
 			"integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@octokit/auth-token": "^4.0.0",
 				"@octokit/graphql": "^7.1.0",
@@ -7869,7 +7863,6 @@
 		"node_modules/@opentelemetry/api": {
 			"version": "1.9.0",
 			"license": "Apache-2.0",
-			"peer": true,
 			"engines": {
 				"node": ">=8.0.0"
 			}
@@ -7891,7 +7884,6 @@
 			"resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.6.0.tgz",
 			"integrity": "sha512-L8UyDwqpTcbkIK5cgwDRDYDoEhQoj8wp8BwsO19w3LB1Z41yEQm2VJyNfAi9DrLP/YTqXqWpKHyZfR9/tFYo1Q==",
 			"license": "Apache-2.0",
-			"peer": true,
 			"engines": {
 				"node": "^18.19.0 || >=20.6.0"
 			},
@@ -7904,7 +7896,6 @@
 			"resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.6.0.tgz",
 			"integrity": "sha512-HLM1v2cbZ4TgYN6KEOj+Bbj8rAKriOdkF9Ed3tG25FoprSiQl7kYc+RRT6fUZGOvx0oMi5U67GoFdT+XUn8zEg==",
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"@opentelemetry/semantic-conventions": "^1.29.0"
 			},
@@ -8328,7 +8319,6 @@
 			"resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.6.0.tgz",
 			"integrity": "sha512-D4y/+OGe3JSuYUCBxtH5T9DSAWNcvCb/nQWIga8HNtXTVPQn59j0nTBAgaAXxUVBDl40mG3Tc76b46wPlZaiJQ==",
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"@opentelemetry/core": "2.6.0",
 				"@opentelemetry/semantic-conventions": "^1.29.0"
@@ -8345,7 +8335,6 @@
 			"resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.6.0.tgz",
 			"integrity": "sha512-g/OZVkqlxllgFM7qMKqbPV9c1DUPhQ7d4n3pgZFcrnrNft9eJXZM2TNHTPYREJBrtNdRytYyvwjgL5geDKl3EQ==",
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"@opentelemetry/core": "2.6.0",
 				"@opentelemetry/resources": "2.6.0",
@@ -8363,7 +8352,6 @@
 			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
 			"integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
 			"license": "Apache-2.0",
-			"peer": true,
 			"engines": {
 				"node": ">=14"
 			}
@@ -10031,7 +10019,6 @@
 			"devOptional": true,
 			"hasInstallScript": true,
 			"license": "Apache-2.0",
-			"peer": true,
 			"dependencies": {
 				"@swc/counter": "^0.1.3",
 				"@swc/types": "^0.1.24"
@@ -10419,7 +10406,8 @@
 		"node_modules/@types/aria-query": {
 			"version": "5.0.4",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/@types/aws-lambda": {
 			"version": "8.10.161",
@@ -10669,7 +10657,6 @@
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.11.tgz",
 			"integrity": "sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"undici-types": "~6.21.0"
 			}
@@ -10715,7 +10702,6 @@
 		"node_modules/@types/react": {
 			"version": "18.3.27",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@types/prop-types": "*",
 				"csstype": "^3.2.2"
@@ -10847,7 +10833,6 @@
 			"integrity": "sha512-k4eNDan0EIMTT/dUKc/g+rsJ6wcHYhNPdY19VoX/EOtaAG8DLtKCykhrUnuHPYvinn5jhAPgD2Qw9hXBwrahsw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/scope-manager": "8.57.1",
 				"@typescript-eslint/types": "8.57.1",
@@ -11036,7 +11021,6 @@
 			"integrity": "sha512-XUNSJ/lEVFttPMMoDVA2r2bwrl8/oPx8cURtczkSEswY5T3AeLmCy+EKWQNdL4u0MmAHOjcWrqJp2cdvgjn8dQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.9.1",
 				"@typescript-eslint/scope-manager": "8.57.1",
@@ -11496,7 +11480,6 @@
 			"integrity": "sha512-sTSDtVM1GOevRGsCNhp1mBUHKo9Qlc55+HCreFT4fe99AHxl1QQNXSL3uj4Pkjh5yEuWZIx8E2tVC94nnBZECQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@vitest/utils": "4.1.0",
 				"fflate": "^0.8.2",
@@ -12963,7 +12946,6 @@
 		"node_modules/acorn": {
 			"version": "8.15.0",
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -13816,7 +13798,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"baseline-browser-mapping": "^2.9.0",
 				"caniuse-lite": "^1.0.30001759",
@@ -15295,7 +15276,8 @@
 		"node_modules/dom-accessibility-api": {
 			"version": "0.5.16",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/dot-case": {
 			"version": "3.0.4",
@@ -16547,7 +16529,6 @@
 		"node_modules/eslint": {
 			"version": "9.39.2",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.8.0",
 				"@eslint-community/regexpp": "^4.12.1",
@@ -16608,7 +16589,6 @@
 			"integrity": "sha512-iI1f+D2ViGn+uvv5HuHVUamg8ll4tN+JRHGc6IJi4TP9Kl976C57fzPXgseXNs8v0iA8aSJpHsTWjDb9QJamGQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"eslint-config-prettier": "bin/cli.js"
 			},
@@ -16678,7 +16658,6 @@
 			"integrity": "sha512-J5gx7sN6DTm0LRT//eP3rVVQ2Yi4hrX0B+DbWxa5er8PZ6JjLo9GUBwogIFvEDdwJaSqZplpQT+haK/cXhb7VQ==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/types": "^8.34.0",
 				"comment-parser": "^1.4.1",
@@ -17170,7 +17149,6 @@
 			"resolved": "https://registry.npmjs.org/express/-/express-4.22.0.tgz",
 			"integrity": "sha512-c2iPh3xp5vvCLgaHK03+mWLFPhox7j1LwyxcZwFVApEv5i0X+IjPpbT50SJJwwLpdBVfp45AkK/v+AFgv/XlfQ==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"accepts": "~1.3.8",
 				"array-flatten": "1.1.1",
@@ -18577,7 +18555,6 @@
 			"resolved": "https://registry.npmjs.org/hono/-/hono-4.12.7.tgz",
 			"integrity": "sha512-jq9l1DM0zVIvsm3lv9Nw9nlJnMNPOcAtsbsgiUhWcFzPE99Gvo6yRTlszSLLYacMeQ6quHD6hMfId8crVHvexw==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=16.9.0"
 			}
@@ -20180,6 +20157,7 @@
 			"version": "1.5.0",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"lz-string": "bin/bin.js"
 			}
@@ -22429,7 +22407,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"nanoid": "^3.3.11",
 				"picocolors": "^1.1.1",
@@ -22699,7 +22676,6 @@
 			"version": "3.0.3",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"prettier": "bin/prettier.cjs"
 			},
@@ -22727,6 +22703,7 @@
 			"version": "27.5.1",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"ansi-regex": "^5.0.1",
 				"ansi-styles": "^5.0.0",
@@ -22740,6 +22717,7 @@
 			"version": "5.2.0",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=10"
 			},
@@ -22750,7 +22728,8 @@
 		"node_modules/pretty-format/node_modules/react-is": {
 			"version": "17.0.2",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/proc-log": {
 			"version": "2.0.1",
@@ -22994,7 +22973,6 @@
 		"node_modules/react": {
 			"version": "18.3.1",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"loose-envify": "^1.1.0"
 			},
@@ -23040,7 +23018,6 @@
 		"node_modules/react-dom": {
 			"version": "18.3.1",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"loose-envify": "^1.1.0",
 				"scheduler": "^0.23.2"
@@ -23085,7 +23062,6 @@
 		"node_modules/react-redux": {
 			"version": "9.2.0",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@types/use-sync-external-store": "^0.0.6",
 				"use-sync-external-store": "^1.4.0"
@@ -23302,8 +23278,7 @@
 		},
 		"node_modules/redux": {
 			"version": "5.0.1",
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/redux-thunk": {
 			"version": "3.1.0",
@@ -23668,7 +23643,6 @@
 			"integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@types/estree": "1.0.8"
 			},
@@ -23839,7 +23813,6 @@
 			"version": "8.17.1",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
 				"fast-uri": "^3.0.1",
@@ -25240,7 +25213,6 @@
 			"version": "4.0.3",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -25486,7 +25458,6 @@
 		"node_modules/ts-node": {
 			"version": "10.9.2",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@cspotcode/source-map-support": "^0.8.0",
 				"@tsconfig/node10": "^1.0.7",
@@ -25531,8 +25502,7 @@
 		},
 		"node_modules/tslib": {
 			"version": "2.8.1",
-			"license": "0BSD",
-			"peer": true
+			"license": "0BSD"
 		},
 		"node_modules/tunnel-agent": {
 			"version": "0.6.0",
@@ -25609,7 +25579,6 @@
 		"node_modules/typescript": {
 			"version": "5.9.3",
 			"license": "Apache-2.0",
-			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -26107,7 +26076,6 @@
 			"version": "7.3.1",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"esbuild": "^0.27.0",
 				"fdir": "^6.5.0",
@@ -26743,7 +26711,6 @@
 			"version": "4.0.3",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -26757,7 +26724,6 @@
 			"integrity": "sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@vitest/expect": "4.1.0",
 				"@vitest/mocker": "4.1.0",
@@ -26917,7 +26883,6 @@
 			"version": "5.104.1",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@types/eslint-scope": "^3.7.7",
 				"@types/estree": "^1.0.8",
@@ -27513,7 +27478,6 @@
 			"resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
 			"integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
 			"license": "MIT",
-			"peer": true,
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
 			}
@@ -27680,7 +27644,6 @@
 			"integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
 			"devOptional": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"undici-types": "~7.18.0"
 			}


### PR DESCRIPTION
## Related issues

- Related to support for the newly released Opus 4.7 model in the CLI code agent.

## How AI was used in this PR

Claude Code (running on Opus 4.7) located the model registry and wired itself in. I reviewed the two-line diff in `agent.ts`.

## Proposed Changes

- Add `claude-opus-4-7` (label: "Opus 4.7") to `AI_MODELS` in `apps/cli/ai/agent.ts`. The `/model` picker, status line, session-resume validator, and `AiModelId` type all derive from this object and pick up the new entry automatically.
- Pass `effort: 'max'` to the Agent SDK `query()` when the selected model is any Opus variant (matches `claude-opus-*`). Sonnet stays on the SDK default (`'high'`) since `'max'` is currently documented as Opus-only.

## Testing Instructions

- `npm run cli:build`
- Launch the CLI code agent and run `/model` — confirm "Opus 4.7" appears, select it, and verify the status line switches to "Opus 4.7".
- Send a prompt and confirm Opus 4.7 responds. (Max-effort thinking should take effect; unverified whether the SDK fully supports `'max'` on 4.7 yet — if the API errors, we can narrow the gate to `claude-opus-4-6`.)

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?