### PR TITLE
CLI code agent: prompt user to retry on transient API errors

### DIFF
--- a/apps/cli/ai/agent.ts
+++ b/apps/cli/ai/agent.ts
@@ -42,8 +42,15 @@ const pathApprovalSession = createPathApprovalSession();
 // are unhandled because they originate inside the SDK cleanup path rather
 // than propagating through the async iterator. Without this handler,
 // Node.js terminates the process on unhandled rejections.
+const SDK_INTERRUPT_CLEANUP_ERRORS = [
+	'Query closed',
+	'ProcessTransport is not ready for writing',
+];
 process.on( 'unhandledRejection', ( reason ) => {
-	if ( reason instanceof Error && reason.message.includes( 'Query closed' ) ) {
+	if (
+		reason instanceof Error &&
+		SDK_INTERRUPT_CLEANUP_ERRORS.some( ( msg ) => reason.message.includes( msg ) )
+	) {
 		return;
 	}
 	throw reason;

--- a/apps/cli/ai/output-adapter.ts
+++ b/apps/cli/ai/output-adapter.ts
@@ -5,7 +5,7 @@ import type { AiProviderId } from 'cli/ai/providers';
 import type { SiteInfo } from 'cli/ai/ui';
 
 export type HandleMessageResult =
-	| { type: 'result'; sessionId: string; success: boolean }
+	| { type: 'result'; sessionId: string; success: boolean; interrupted?: boolean }
 	| { type: 'max_turns'; sessionId: string; numTurns: number; costUsd?: number };
 
 export interface AiOutputAdapter {
@@ -125,7 +125,7 @@ export class JsonAdapter implements AiOutputAdapter {
 			return {
 				type: 'result',
 				sessionId: message.session_id,
-				success: message.subtype === 'success',
+				success: ! message.is_error,
 			};
 		}
 

--- a/apps/cli/ai/providers.ts
+++ b/apps/cli/ai/providers.ts
@@ -74,6 +74,12 @@ function createBaseEnvironment(): Record< string, string > {
 	delete env.ANTHROPIC_CUSTOM_HEADERS;
 	delete env.CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS;
 
+	// Fail fast on transient API errors so the user-mediated retry prompt can
+	// intervene instead of the SDK burning through its default 10 retries.
+	if ( ! env.CLAUDE_CODE_MAX_RETRIES ) {
+		env.CLAUDE_CODE_MAX_RETRIES = '1';
+	}
+
 	return env;
 }
 

--- a/apps/cli/ai/ui.ts
+++ b/apps/cli/ai/ui.ts
@@ -2137,29 +2137,17 @@ export class AiChatUI implements AiOutputAdapter {
 			}
 			case 'result': {
 				this.hideLoader();
-				if ( message.subtype === 'success' ) {
-					const thinkingSec = Math.round( ( this.nowMs() - this.turnStartTime ) / 1000 );
-					if ( ! this.hasShownResponseMarker ) {
-						this.messages.addChild(
-							new Text( '\n ' + chalk.blue( '⏺' ) + ' ' + __( 'Done' ), 0, 0 )
-						);
-					}
-					this.showInfo(
-						sprintf(
-							/* translators: 1: seconds spent thinking, 2: number of turns */
-							_n(
-								'Thought for %1$ds · %2$d turn',
-								'Thought for %1$ds · %2$d turns',
-								message.num_turns
-							),
-							thinkingSec,
-							message.num_turns
-						)
-					);
-					return { type: 'result', sessionId: message.session_id, success: true };
+
+				// Max-turns exhaustion has dedicated upstream handling (prompts user to continue).
+				if ( message.subtype === 'error_max_turns' ) {
+					return {
+						type: 'max_turns',
+						sessionId: message.session_id,
+						numTurns: message.num_turns,
+					};
 				}
 
-				// User-initiated interruption: show friendly message instead of error
+				// User-initiated interruption: friendly message, suppress retry prompt.
 				if ( this.wasInterrupted ) {
 					const thinkingSec = Math.round( ( this.nowMs() - this.turnStartTime ) / 1000 );
 					this.messages.addChild(
@@ -2176,36 +2164,62 @@ export class AiChatUI implements AiOutputAdapter {
 							thinkingSec
 						)
 					);
+					return {
+						type: 'result',
+						sessionId: message.session_id,
+						success: false,
+						interrupted: true,
+					};
+				}
+
+				// is_error is the authoritative failure signal. A message can have
+				// subtype='success' and still carry is_error=true (e.g. API 504 after
+				// the SDK exhausts retries and emits the error text as the result).
+				if ( message.is_error ) {
+					const parts: string[] = [];
+					if ( 'errors' in message && message.errors?.length ) {
+						parts.push( ...message.errors );
+					}
+					if ( 'result' in message && typeof message.result === 'string' && message.result ) {
+						parts.push( message.result );
+					} else if ( message.subtype && message.subtype !== 'success' ) {
+						parts.push( `(${ message.subtype })` );
+					}
+					if ( 'permission_denials' in message && message.permission_denials?.length ) {
+						for ( const denial of message.permission_denials ) {
+							parts.push(
+								sprintf(
+									/* translators: %s: tool name */
+									__( 'Permission denied: %s' ),
+									denial.tool_name
+								)
+							);
+						}
+					}
+					this.showError( parts.length > 0 ? parts.join( '\n' ) : __( 'Unknown error' ) );
 					return { type: 'result', sessionId: message.session_id, success: false };
 				}
 
-				// Build detailed error message
-				const parts: string[] = [];
-				if ( 'errors' in message && message.errors?.length ) {
-					parts.push( ...message.errors );
+				// Genuine success.
+				const thinkingSec = Math.round( ( this.nowMs() - this.turnStartTime ) / 1000 );
+				if ( ! this.hasShownResponseMarker ) {
+					this.messages.addChild(
+						new Text( '\n ' + chalk.blue( '⏺' ) + ' ' + __( 'Done' ), 0, 0 )
+					);
 				}
-				if ( message.subtype === 'error_max_turns' ) {
-					return {
-						type: 'max_turns',
-						sessionId: message.session_id,
-						numTurns: message.num_turns,
-					};
-				} else if ( message.subtype ) {
-					parts.push( `(${ message.subtype })` );
-				}
-				if ( 'permission_denials' in message && message.permission_denials?.length ) {
-					for ( const denial of message.permission_denials ) {
-						parts.push(
-							sprintf(
-								/* translators: %s: tool name */
-								__( 'Permission denied: %s' ),
-								denial.tool_name
-							)
-						);
-					}
-				}
-				this.showError( parts.length > 0 ? parts.join( '\n' ) : __( 'Unknown error' ) );
-				return { type: 'result', sessionId: message.session_id, success: false };
+				this.showInfo(
+					sprintf(
+						/* translators: 1: seconds spent thinking, 2: number of turns */
+						_n(
+							'Thought for %1$ds · %2$d turn',
+							'Thought for %1$ds · %2$d turns',
+							message.num_turns
+						),
+						thinkingSec,
+						message.num_turns
+					)
+				);
+				return { type: 'result', sessionId: message.session_id, success: true };
 			}
 			case 'system': {
 				if ( message.subtype === 'status' && message.status === 'compacting' ) {

--- a/apps/cli/commands/ai/index.ts
+++ b/apps/cli/commands/ai/index.ts
@@ -358,8 +358,11 @@ export async function runCommand( options: {
 		return answers;
 	}
 
+	const MAX_RETRY_ATTEMPTS = 4;
+
 	async function runAgentTurn(
-		prompt: string
+		prompt: string,
+		retryAttempt = 0
 	): Promise< { status: TurnStatus; usage?: { numTurns: number; costUsd?: number } } > {
 		const env = await resolveAiEnvironment( currentProvider );
 		ui.beginAgentTurn();
@@ -425,6 +428,8 @@ export async function runCommand( options: {
 							numTurns: result.numTurns,
 						};
 						turnStatus = 'max_turns';
+					} else if ( result.interrupted ) {
+						turnStatus = 'interrupted';
 					} else {
 						turnStatus = result.success ? 'success' : 'error';
 					}
@@ -432,7 +437,13 @@ export async function runCommand( options: {
 			}
 		} catch ( error ) {
 			turnStatus = 'error';
-			throw error;
+			// In JSON mode there's no interactive retry, so re-throw and let
+			// the caller record the error. In interactive mode, fall through
+			// so the post-loop retry prompt offers the user a chance to retry.
+			if ( isJsonMode ) {
+				throw error;
+			}
+			ui.showError( getErrorMessage( error ) );
 		} finally {
 			await persist( ( recorder ) => recorder.recordTurnClosed( turnStatus ) );
 			ui.endAgentTurn();
@@ -459,6 +470,33 @@ export async function runCommand( options: {
 			if ( choice === 'yes' ) {
 				ui.addUserMessage( 'Continue' );
 				return runAgentTurn( 'Continue from where you left off.' );
+			}
+		}
+
+		if ( turnStatus === 'error' && ! isJsonMode ) {
+			if ( retryAttempt >= MAX_RETRY_ATTEMPTS ) {
+				ui.showInfo(
+					__( 'The server has not recovered after multiple attempts. Please try again later.' )
+				);
+			} else {
+				const answer = await ui.askUser( [
+					{
+						question: __( 'There was a hiccup on the server. Do you want to continue?' ),
+						options: [
+							{ label: 'Yes', description: __( 'Continue from where you left off' ) },
+							{ label: 'No', description: __( 'Stop here' ) },
+						],
+					},
+				] );
+				const choice = Object.values( answer )[ 0 ]?.toLowerCase();
+				if ( choice === 'yes' ) {
+					ui.showInfo( __( 'Retrying…' ) );
+					// If the SDK threw before emitting any result, sessionId is
+					// still whatever it was before this turn; without one to resume,
+					// replay the original prompt instead.
+					const retryPrompt = sessionId ? 'Continue from where you left off.' : prompt;
+					return runAgentTurn( retryPrompt, retryAttempt + 1 );
+				}
 			}
 		}
 

--- a/apps/cli/commands/ai/index.ts
+++ b/apps/cli/commands/ai/index.ts
@@ -484,7 +484,10 @@ export async function runCommand( options: {
 						question: __( 'There was a hiccup on the server. Do you want to continue?' ),
 						options: [
 							{ label: 'Yes', description: __( 'Continue from where you left off' ) },
-							{ label: 'No', description: __( 'Stop here' ) },
+							{
+								label: 'No',
+								description: __( 'Stop so I can give different instructions' ),
+							},
 						],
 					},
 				] );


### PR DESCRIPTION
## Related issues

- STU-1578

## How AI was used in this PR

AI was used throughout: investigating the Claude Agent SDK's streaming/non-streaming fallback, retry, and timeout defaults; identifying the mis-classification bug where `{subtype:"success", is_error:true}` result messages were treated as successful turns; and implementing the retry-prompt + SDK retry-cap + ESC crash-fix changes. Every edit was reviewed against the session-file evidence supplied by me, and all changes pass lint, typecheck, and the existing 88 AI tests.

## Proposed Changes

- **Detect transient API failures correctly** (`apps/cli/ai/ui.ts`, `apps/cli/ai/output-adapter.ts`): route result messages on `message.is_error` instead of `message.subtype`. The SDK can emit `{subtype:"success", is_error:true}` (e.g. after exhausting retries on a 504), and this was previously mis-classified as success.
- **User-mediated retry prompt** (`apps/cli/commands/ai/index.ts`): on `is_error:true` or a thrown transport error, the code agent now asks "There was a hiccup on the server. Do you want to continue?". `Yes` resumes the session with `"Continue from where you left off."`; `No` stops.
- **Bounded retries**: capped at 4 user-prompted attempts per turn. After that, the CLI shows "The server has not recovered after multiple attempts. Please try again later." instead of prompting again.
- **Fail-fast SDK retries** (`apps/cli/ai/providers.ts`): set `CLAUDE_CODE_MAX_RETRIES=1` in the provider env so each failed attempt errors in ~1-2 min instead of burning the SDK's default 10 retries (~29 min). Respects a user-supplied override.
- **Interrupt-cleanup safety** (`apps/cli/ai/agent.ts`): the existing `unhandledRejection` handler that swallowed `Query closed` now also swallows `ProcessTransport is not ready for writing`. Both come from the SDK's cleanup path on ESC; without this, pressing ESC during a tool call crashes the CLI.
- **Interrupt vs. error distinction** (`apps/cli/ai/output-adapter.ts`, `apps/cli/ai/ui.ts`): `HandleMessageResult` now carries an `interrupted` flag so user-initiated ESC does not trigger the retry prompt.

## Error recovery flow

### State machine

```mermaid
flowchart TD
    Start([User sends prompt]) --> Turn[runAgentTurn]
    Turn --> SDKCall[SDK → AI proxy]
    SDKCall --> SDKResult{Response ok?}
    SDKResult -->|Yes| Success([Turn succeeds])
    SDKResult -->|Transient failure<br/>504 / timeout / etc.| SDKRetry[SDK retries once<br/>CLAUDE_CODE_MAX_RETRIES=1]
    SDKRetry --> SDKCall2[SDK → AI proxy]
    SDKCall2 --> SDKResult2{Response ok?}
    SDKResult2 -->|Yes| Success
    SDKResult2 -->|Still failing| Detect{is_error: true<br/>OR<br/>thrown error?}
    Detect -->|No| Success
    Detect -->|Yes| CheckCap{retryAttempt<br/>≥ 4?}
    CheckCap -->|Yes| GiveUp([Show 'try again later'<br/>return to input])
    CheckCap -->|No| Prompt[/Prompt user:<br/>'There was a hiccup<br/>on the server.<br/>Do you want to continue?'/]
    Prompt -->|No| Stop([Return to input])
    Prompt -->|Yes| Resume[Resume session<br/>with same sessionId<br/>retryAttempt++]
    Resume --> Turn

    classDef success fill:#d4edda,stroke:#28a745,color:#000
    classDef error fill:#f8d7da,stroke:#dc3545,color:#000
    classDef prompt fill:#fff3cd,stroke:#ffc107,color:#000
    class Success success
    class GiveUp,Stop error
    class Prompt prompt
```

### Concrete recovery (server-side hiccup that clears on its own)

```mermaid
sequenceDiagram
    participant U as User
    participant CLI as Studio CLI
    participant SDK as Agent SDK
    participant Proxy as AI Proxy

    U->>CLI: Send prompt
    CLI->>SDK: Start turn (attempt 1)
    SDK->>Proxy: POST /v1/messages (stream)
    Proxy--xSDK: 504 Gateway Timeout
    Note over SDK: CLAUDE_CODE_MAX_RETRIES=1<br/>one quick retry
    SDK->>Proxy: POST /v1/messages (retry)
    Proxy--xSDK: 504 again
    SDK-->>CLI: result: is_error=true<br/>(~1–2 min elapsed)
    CLI->>U: 'Hiccup on the server.<br/>Do you want to continue?'
    Note over U,Proxy: User pauses to read.<br/>Server recovers in the meantime.
    U->>CLI: Yes
    CLI->>SDK: Resume session<br/>'Continue from where you left off.'<br/>(attempt 2)
    SDK->>Proxy: POST /v1/messages
    Proxy-->>SDK: 200 stream OK
    SDK-->>CLI: Assistant messages + tool calls
    CLI->>U: Turn completes
```

### Recovery when the server stays down

Each failed attempt ends in ~1–2 min thanks to the SDK retry cap. After four prompted retries (attempts 2 → 5 counted from the user's POV), the CLI stops prompting and shows "The server has not recovered after multiple attempts. Please try again later." Total time elapsed: bounded at roughly 5–10 min instead of the previous ~40 mins (10 SDK retries × streaming + non-streaming paths).

## Testing Instructions

Prerequisite: `npm run cli:build` (the CLI must be rebuilt to pick up the changes).

### Happy path
1. Run `node apps/cli/dist/cli/main.mjs code`.
2. Ask the agent anything simple (e.g. "Create a site called Test"). Turn should complete normally with no retry prompt.

### Retry prompt (transient error)
1. Sandbox the `public-api`
2. Introduce a temporary failure on the AI proxy — e.g. set a low cURL timeout so streaming fails, you can add the following to your `0-sandbox.php` `add_filter( 'wpcom_ai_api_proxy_request_timeout', fn() => 1 );`.
3. Run the code agent and send any prompt. You can check the logs in c66b35b8fcfd51720a0e77cff6a88441-logstash
4. Expect: turn ends with an error banner, then the prompt "There was a hiccup on the server. Do you want to continue?" with `Yes` / `No`.
5. Choose `Yes` → turn re-runs as "Continue from where you left off." with session preserved.
6. Keep failing → after the 4th retry attempt the CLI shows "The server has not recovered after multiple attempts. Please try again later." and does not prompt again.

### Fast-fail retries
1. With the proxy intentionally failing, confirm the retry prompt appears in ~4-6 min (previously ~40 min due to SDK default of 10 retries).

### ESC during tool call (no crash)
1. Start a long-running tool call (e.g. ask the agent to take a screenshot, or anything that triggers `mcp__studio__take_screenshot`).
2. Press ESC mid-tool.
3. Expect: "Interrupted / Ran for Xs before interruption" shown, no retry prompt, CLI returns to the input prompt. Previously this could crash with `Error: ProcessTransport is not ready for writing`.

### JSON mode
1. `node apps/cli/dist/cli/main.mjs code --json "ping"` with a failing proxy.
2. Expect `turn.completed` with `status: "error"` (not `"success"`). Previously the adapter reported `"success"` when the SDK emitted `{subtype:"success", is_error:true}`.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors? (lint + typecheck + 88 AI tests pass)