### PR TITLE
CLI: Truncate cwd in welcome header on narrow terminals

### DIFF
--- a/apps/cli/ai/ui.ts
+++ b/apps/cli/ai/ui.ts
@@ -1262,7 +1262,7 @@ export class AiChatUI implements AiOutputAdapter {
 		const b = chalk.blue;
 
 		// WordPress logo in block characters, widened to avoid vertical stretching in terminals.
-		const logo = [
+		const logoLines = [
 			'    ▄█▛▀▀▀▀█▙▖',
 			' ▗▟█        ▗██▄',
 			'▄███▛ ▝▜██  ▝███▙',
@@ -1271,27 +1271,48 @@ export class AiChatUI implements AiOutputAdapter {
 			'▀▙▖ ▜█▄▟ ▝█▙▄▌ ▄▛',
 			' ▝▜▄▝██▌  ▀██▗▟▀',
 			'    ▀██▙▄▄▄█▛▘',
-		].map( ( s ) => b( s ) );
+		];
+		const logo = logoLines.map( ( s ) => b( s ) );
+		const logoWidth = Math.max( ...logoLines.map( ( s ) => s.length ) );
+
+		// Lay out logo on the left, info on the right (vertically centered)
+		const gap = 4;
+		const leading = 1;
+		const termWidth = process.stdout.columns ?? 80;
+		const availableInfoWidth = Math.max( 0, termWidth - leading - logoWidth - gap );
+
+		// Truncate the cwd with a leading ellipsis (preserving the meaningful
+		// suffix) when the terminal is too narrow, otherwise the welcome wraps
+		// and visually breaks the logo layout.
+		const baseInfo = `${ AI_MODELS[ this.currentModel ] } · ${
+			AI_PROVIDERS[ this.currentProvider ]
+		}`;
+		const sep = ' · ';
+		let secondLine: string;
+		if ( baseInfo.length + sep.length + displayCwd.length <= availableInfoWidth ) {
+			secondLine = `${ baseInfo }${ sep }${ displayCwd }`;
+		} else {
+			const pathBudget = availableInfoWidth - baseInfo.length - sep.length;
+			if ( pathBudget >= 4 ) {
+				secondLine = `${ baseInfo }${ sep }…${ displayCwd.slice( -( pathBudget - 1 ) ) }`;
+			} else {
+				secondLine = baseInfo;
+			}
+		}
 
 		const info = [
 			chalk.bold( 'WordPress Studio' ) + ( version ? chalk.dim( ` v${ version }` ) : '' ),
-			chalk.dim(
-				`${ AI_MODELS[ this.currentModel ] } · ${
-					AI_PROVIDERS[ this.currentProvider ]
-				} · ${ displayCwd }`
-			),
+			chalk.dim( secondLine ),
 			'',
 			chalk.dim.italic( __( 'Code is Poetry' ) ),
 		];
 
-		// Lay out logo on the left, info on the right (vertically centered)
-		const gap = 4;
 		const infoStartRow = Math.max( 0, Math.floor( ( logo.length - info.length ) / 2 ) );
 
 		const lines = logo.map( ( logoLine, i ) => {
 			const infoIndex = i - infoStartRow;
 			const infoText = infoIndex >= 0 && infoIndex < info.length ? info[ infoIndex ] : '';
-			return ' ' + logoLine + ' '.repeat( gap ) + infoText;
+			return ' '.repeat( leading ) + logoLine + ' '.repeat( gap ) + infoText;
 		} );
 
 		this.messages.addChild( new Text( '\n' + lines.join( '\n' ) + '\n', 0, 0 ) );


### PR DESCRIPTION
## Related issues

- Related to: small-terminal layout glitch in the AI chat CLI welcome screen.

## How AI was used in this PR

The fix was implemented with Claude Code. The diff is small and self-contained — please verify the truncation thresholds and behavior in your own narrow terminal.

## Proposed Changes

- Measure the terminal width when rendering the welcome header in `apps/cli/ai/ui.ts`.
- If the `model · provider · cwd` line doesn't fit next to the WordPress logo, truncate the cwd with a leading ellipsis (e.g. `…orktrees/eloquent-ride-bd2a9e`) so the meaningful suffix stays visible.
- If even a short ellipsised path doesn't fit, drop the cwd entirely and show only `model · provider`.
- The logo's max width is now derived from the strings rather than hardcoded, so it stays correct if the logo is ever changed.

Before this change, on a narrow terminal the cwd wrapped onto subsequent lines and visually broke the logo layout (see screenshot in the issue / discussion).

## Testing Instructions

1. `npm run cli:build`
2. Resize your terminal to ~60–70 columns wide.
3. Run `node apps/cli/dist/cli/main.mjs` (or whichever entrypoint launches the AI chat UI) from a directory with a long absolute path (e.g. a worktree under `~/Workspace/.../worktrees/long-name-xxxxx`).
4. Confirm the WordPress logo renders cleanly on the left and the cwd is shown with a leading ellipsis on the right.
5. Resize the terminal wider — the full path should reappear once it fits.
6. Resize very narrow — the path should drop entirely, leaving only `model · provider`.

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?