### PR TITLE
apps/ui: add user menu to the sidebar bottom

### DIFF
--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -10,6 +10,7 @@
 		"preview": "vite preview"
 	},
 	"dependencies": {
+		"@base-ui/react": "^1.3.0",
 		"@studio/common": "file:../../tools/common",
 		"@tanstack/query-sync-storage-persister": "^5.96.2",
 		"@tanstack/react-query": "^5.75.5",

--- a/apps/ui/src/components/menu/index.tsx
+++ b/apps/ui/src/components/menu/index.tsx
@@ -1,0 +1,94 @@
+import { Menu as BaseMenu } from '@base-ui/react/menu';
+import { forwardRef } from 'react';
+import styles from './style.module.css';
+import type { ComponentPropsWithoutRef, ElementRef, ReactNode } from 'react';
+
+export const Root = BaseMenu.Root;
+export const Trigger = BaseMenu.Trigger;
+export const RadioGroup = BaseMenu.RadioGroup;
+
+type PopupProps = {
+	children: ReactNode;
+	/** Side relative to the trigger. Defaults to `top` (opens upward). */
+	side?: 'top' | 'right' | 'bottom' | 'left';
+	align?: 'start' | 'center' | 'end';
+	sideOffset?: number;
+	alignOffset?: number;
+	className?: string;
+};
+
+/**
+ * Wraps Portal + Positioner + Popup so consumers only need one component.
+ * Styled to match @wordpress/components `Popover`: surface-strong background,
+ * neutral stroke, elevation-md, radius-md.
+ */
+export function Popup( {
+	children,
+	side = 'top',
+	align = 'start',
+	sideOffset = 4,
+	alignOffset,
+	className,
+}: PopupProps ) {
+	return (
+		<BaseMenu.Portal>
+			<BaseMenu.Positioner
+				side={ side }
+				align={ align }
+				sideOffset={ sideOffset }
+				alignOffset={ alignOffset }
+				className={ styles.positioner }
+			>
+				<BaseMenu.Popup className={ `${ styles.popup } ${ className ?? '' }` }>
+					{ children }
+				</BaseMenu.Popup>
+			</BaseMenu.Positioner>
+		</BaseMenu.Portal>
+	);
+}
+
+type ItemProps = ComponentPropsWithoutRef< typeof BaseMenu.Item >;
+
+export const Item = forwardRef< ElementRef< typeof BaseMenu.Item >, ItemProps >( function Item(
+	{ className, children, ...props },
+	ref
+) {
+	return (
+		<BaseMenu.Item ref={ ref } className={ `${ styles.item } ${ className ?? '' }` } { ...props }>
+			{ children }
+		</BaseMenu.Item>
+	);
+} );
+
+type RadioItemProps = ComponentPropsWithoutRef< typeof BaseMenu.RadioItem >;
+
+export const RadioItem = forwardRef< ElementRef< typeof BaseMenu.RadioItem >, RadioItemProps >(
+	function RadioItem( { className, children, ...props }, ref ) {
+		return (
+			<BaseMenu.RadioItem
+				ref={ ref }
+				className={ `${ styles.item } ${ styles.radioItem } ${ className ?? '' }` }
+				{ ...props }
+			>
+				<span className={ styles.indicator } aria-hidden="true">
+					<BaseMenu.RadioItemIndicator className={ styles.indicatorMark } keepMounted>
+						<svg width="16" height="16" viewBox="0 0 24 24" fill="none">
+							<path
+								d="M5 12l5 5L20 7"
+								stroke="currentColor"
+								strokeWidth="2"
+								strokeLinecap="round"
+								strokeLinejoin="round"
+							/>
+						</svg>
+					</BaseMenu.RadioItemIndicator>
+				</span>
+				<span className={ styles.itemLabel }>{ children }</span>
+			</BaseMenu.RadioItem>
+		);
+	}
+);
+
+export function Separator( { className }: { className?: string } ) {
+	return <BaseMenu.Separator className={ `${ styles.separator } ${ className ?? '' }` } />;
+}

--- a/apps/ui/src/components/menu/style.module.css
+++ b/apps/ui/src/components/menu/style.module.css
@@ -1,0 +1,81 @@
+/* Styling mirrors @wordpress/components Popover: neutral-strong surface,
+   neutral stroke, medium radius, medium elevation shadow. */
+.positioner {
+	z-index: 20;
+	outline: none;
+}
+
+.popup {
+	min-width: 160px;
+	padding: var(--wpds-dimension-padding-xs);
+	background: var(--wpds-color-bg-surface-neutral-strong);
+	border: 1px solid var(--wpds-color-stroke-surface-neutral);
+	border-radius: var(--wpds-border-radius-md);
+	box-shadow: var(--wpds-elevation-md);
+	color: var(--wpds-color-fg-content-neutral);
+	display: flex;
+	flex-direction: column;
+	gap: var(--wpds-dimension-padding-xs);
+}
+
+.item {
+	display: flex;
+	align-items: center;
+	gap: var(--wpds-dimension-gap-sm);
+	padding: var(--wpds-dimension-padding-xs) var(--wpds-dimension-padding-sm);
+	border-radius: var(--wpds-border-radius-sm);
+	color: var(--wpds-color-fg-content-neutral);
+	font-size: var(--wpds-font-size-sm);
+	line-height: var(--wpds-font-line-height-sm);
+	cursor: var(--wpds-cursor-control);
+	outline: none;
+	user-select: none;
+}
+
+.item[data-highlighted],
+.item:hover {
+	background: var(--wpds-color-bg-surface-neutral);
+}
+
+.item[data-disabled] {
+	color: var(--wpds-color-fg-interactive-neutral-disabled);
+	cursor: not-allowed;
+}
+
+.radioItem {
+	padding-inline-start: var(--wpds-dimension-padding-xs);
+}
+
+.indicator {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 18px;
+	height: 18px;
+	flex-shrink: 0;
+	color: var(--wpds-color-fg-content-neutral);
+}
+
+.indicatorMark {
+	display: inline-flex;
+	opacity: 0;
+}
+
+.indicatorMark[data-checked] {
+	opacity: 1;
+}
+
+.itemLabel {
+	flex: 1;
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.separator {
+	height: 1px;
+	margin: var(--wpds-dimension-padding-xs) 0;
+	background: var(--wpds-color-stroke-surface-neutral);
+	border: 0;
+}

--- a/apps/ui/src/components/menu/style.module.css
+++ b/apps/ui/src/components/menu/style.module.css
@@ -9,7 +9,7 @@
 	min-width: 160px;
 	padding: var(--wpds-dimension-padding-xs);
 	background: var(--wpds-color-bg-surface-neutral-strong);
-	border: 1px solid var(--wpds-color-stroke-surface-neutral);
+	border: var(--wpds-border-width-xs) solid var(--wpds-color-stroke-surface-neutral-weak);
 	border-radius: var(--wpds-border-radius-md);
 	box-shadow: var(--wpds-elevation-md);
 	color: var(--wpds-color-fg-content-neutral);

--- a/apps/ui/src/components/project-list/index.tsx
+++ b/apps/ui/src/components/project-list/index.tsx
@@ -119,7 +119,7 @@ function ProjectSection( {
 						<Button
 							variant="minimal"
 							tone="neutral"
-							size="compact"
+							size="small"
 							className={ styles.projectTrigger }
 						>
 							<Button.Icon icon={ open ? chevronDown : chevronRight } size={ 16 } />
@@ -163,7 +163,7 @@ export function ProjectList() {
 	return (
 		<div className={ styles.root }>
 			<Stack direction="row" align="center" justify="flex-end" className={ styles.header }>
-				<Button variant="minimal" tone="neutral" size="compact">
+				<Button variant="minimal" tone="neutral" size="small">
 					<Button.Icon icon={ plus } size={ 16 } />
 					<span>{ __( 'Add site' ) }</span>
 				</Button>

--- a/apps/ui/src/components/project-list/style.module.css
+++ b/apps/ui/src/components/project-list/style.module.css
@@ -93,24 +93,25 @@
 }
 
 .sessionLink {
-	display: block;
-	padding: var(--wpds-dimension-padding-xs) var(--wpds-dimension-padding-sm)
-		var(--wpds-dimension-padding-xs) var(--wpds-dimension-padding-xl);
+	display: flex;
+	align-items: center;
+	height: 24px;
+	padding: 0 var(--wpds-dimension-padding-sm) 0 var(--wpds-dimension-padding-2xl);
 	color: var(--wpds-color-fg-content-neutral);
 	text-decoration: none;
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
 	font-size: var(--wpds-font-size-sm);
-	border-radius: var(--wpds-dimension-radius-sm);
+	border-radius: var(--wpds-border-radius-sm);
 }
 
 .sessionLink:hover {
 	color: var(--wpds-color-fg-content-neutral);
-	background-color: var(--wpds-color-bg-surface-neutral);
+	background-color: var(--wpds-color-bg-interactive-neutral-weak-active);
 }
 
 .sessionLinkActive {
 	color: var(--wpds-color-fg-content-neutral);
-	background-color: var(--wpds-color-bg-surface-neutral);
+	background-color: var(--wpds-color-bg-interactive-neutral-weak-active);
 }

--- a/apps/ui/src/components/project-list/style.module.css
+++ b/apps/ui/src/components/project-list/style.module.css
@@ -9,12 +9,6 @@
 	padding: var(--wpds-dimension-padding-xs) 0;
 }
 
-.header svg,
-.projectTrigger svg,
-.projectAction svg {
-	transform: scale(0.75);
-}
-
 .projects {
 	display: flex;
 	flex-direction: column;

--- a/apps/ui/src/components/sidebar-layout/index.tsx
+++ b/apps/ui/src/components/sidebar-layout/index.tsx
@@ -1,4 +1,5 @@
 import { ProjectList } from '@/components/project-list';
+import { UserMenu } from '@/components/user-menu';
 import styles from './style.module.css';
 import type { ReactNode } from 'react';
 
@@ -6,7 +7,10 @@ export function SidebarLayout( { children }: { children: ReactNode } ) {
 	return (
 		<div className={ styles.root }>
 			<aside className={ styles.sidebar }>
-				<ProjectList />
+				<div className={ styles.sidebarContent }>
+					<ProjectList />
+				</div>
+				<UserMenu />
 			</aside>
 			<main className={ styles.main }>{ children }</main>
 		</div>

--- a/apps/ui/src/components/sidebar-layout/style.module.css
+++ b/apps/ui/src/components/sidebar-layout/style.module.css
@@ -9,6 +9,12 @@
 	background-color: var(--wpds-color-bg-surface-neutral-weak);
 	display: flex;
 	flex-direction: column;
+	overflow: hidden;
+}
+
+.sidebarContent {
+	flex: 1;
+	min-height: 0;
 	overflow-y: auto;
 }
 

--- a/apps/ui/src/components/user-menu/index.tsx
+++ b/apps/ui/src/components/user-menu/index.tsx
@@ -1,0 +1,139 @@
+import { __ } from '@wordpress/i18n';
+import { Button, IconButton } from '@wordpress/ui';
+import * as Menu from '@/components/menu';
+import { useConnector } from '@/data/core';
+import { useAuthUser, useLogin, useLogout } from '@/data/queries/use-auth-user';
+import { useColorScheme, useSaveColorScheme } from '@/data/queries/use-color-scheme';
+import { usePrefersColorScheme } from '@/hooks/use-prefers-color-scheme';
+import styles from './style.module.css';
+import type { ColorScheme } from '@/data/core';
+
+const WPCOM_PROFILE_URL = 'https://wordpress.com/me';
+const DOCS_URL = 'https://developer.wordpress.com/docs/developer-tools/studio/';
+const REPORT_ISSUE_URL = 'https://github.com/Automattic/studio/issues/new/choose';
+
+const sunIcon = (
+	<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+		<circle cx="12" cy="12" r="4" stroke="currentColor" strokeWidth="1.5" />
+		<path
+			d="M12 3v2M12 19v2M3 12h2M19 12h2M5.6 5.6l1.4 1.4M17 17l1.4 1.4M5.6 18.4L7 17M17 7l1.4-1.4"
+			stroke="currentColor"
+			strokeWidth="1.5"
+			strokeLinecap="round"
+		/>
+	</svg>
+);
+
+const moonIcon = (
+	<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+		<path
+			d="M20 14.5A8 8 0 019.5 4a8 8 0 1010.5 10.5z"
+			stroke="currentColor"
+			strokeWidth="1.5"
+			strokeLinejoin="round"
+		/>
+	</svg>
+);
+
+const userIcon = (
+	<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+		<circle cx="12" cy="8" r="3.5" stroke="currentColor" strokeWidth="1.5" />
+		<path
+			d="M5 20c0-3.5 3-6 7-6s7 2.5 7 6"
+			stroke="currentColor"
+			strokeWidth="1.5"
+			strokeLinecap="round"
+		/>
+	</svg>
+);
+
+export function UserMenu() {
+	const connector = useConnector();
+	const { data: user } = useAuthUser();
+	const { data: savedScheme } = useColorScheme();
+	const saveColorScheme = useSaveColorScheme();
+	const login = useLogin();
+	const logout = useLogout();
+	const effectiveScheme = usePrefersColorScheme();
+
+	const currentScheme: ColorScheme = savedScheme ?? 'system';
+	const themeIsDark =
+		savedScheme === 'dark' || ( savedScheme !== 'light' && effectiveScheme === 'dark' );
+
+	const openLink = ( url: string ) => {
+		void connector.openExternalUrl( url );
+	};
+
+	return (
+		<div className={ styles.root }>
+			<div className={ styles.row }>
+				{ user ? (
+					<Menu.Root modal={ false }>
+						<Menu.Trigger
+							render={
+								<Button
+									variant="minimal"
+									tone="neutral"
+									size="small"
+									className={ styles.userTrigger }
+								>
+									<Button.Icon icon={ userIcon } size={ 16 } />
+									<span className={ styles.userName }>{ user.displayName }</span>
+								</Button>
+							}
+						/>
+						<Menu.Popup side="top" align="start" className={ styles.popup }>
+							<div className={ styles.email } title={ user.email }>
+								{ user.email }
+							</div>
+							<Menu.Item onClick={ () => openLink( WPCOM_PROFILE_URL ) }>
+								{ __( 'Edit profile' ) }
+							</Menu.Item>
+							<Menu.Item onClick={ () => openLink( DOCS_URL ) }>
+								{ __( 'Documentation' ) }
+							</Menu.Item>
+							<Menu.Item onClick={ () => openLink( REPORT_ISSUE_URL ) }>
+								{ __( 'Report an issue' ) }
+							</Menu.Item>
+							<Menu.Separator />
+							<Menu.Item onClick={ () => logout.mutate() }>{ __( 'Log out' ) }</Menu.Item>
+						</Menu.Popup>
+					</Menu.Root>
+				) : (
+					<Button
+						variant="minimal"
+						tone="neutral"
+						size="small"
+						className={ styles.loginButton }
+						onClick={ () => login.mutate() }
+					>
+						{ __( 'Log in with WordPress.com' ) }
+					</Button>
+				) }
+				<Menu.Root modal={ false }>
+					<Menu.Trigger
+						render={
+							<IconButton
+								variant="minimal"
+								tone="neutral"
+								size="small"
+								icon={ themeIsDark ? sunIcon : moonIcon }
+								label={ __( 'Appearance' ) }
+							/>
+						}
+					/>
+					<Menu.Popup side="top" align="end">
+						<Menu.RadioGroup
+							value={ currentScheme }
+							onValueChange={ ( value ) => saveColorScheme.mutate( value as ColorScheme ) }
+						>
+							<Menu.RadioItem value="system">{ __( 'System' ) }</Menu.RadioItem>
+							<Menu.RadioItem value="light">{ __( 'Light' ) }</Menu.RadioItem>
+							<Menu.RadioItem value="dark">{ __( 'Dark' ) }</Menu.RadioItem>
+						</Menu.RadioGroup>
+					</Menu.Popup>
+				</Menu.Root>
+			</div>
+		</div>
+	);
+}

--- a/apps/ui/src/components/user-menu/style.module.css
+++ b/apps/ui/src/components/user-menu/style.module.css
@@ -3,10 +3,6 @@
 		var(--wpds-dimension-padding-lg);
 }
 
-.root svg {
-	transform: scale(0.75);
-}
-
 .row {
 	display: flex;
 	align-items: center;

--- a/apps/ui/src/components/user-menu/style.module.css
+++ b/apps/ui/src/components/user-menu/style.module.css
@@ -1,0 +1,52 @@
+.root {
+	padding: var(--wpds-dimension-padding-sm) var(--wpds-dimension-padding-md)
+		var(--wpds-dimension-padding-lg);
+}
+
+.root svg {
+	transform: scale(0.75);
+}
+
+.row {
+	display: flex;
+	align-items: center;
+	gap: var(--wpds-dimension-padding-xs);
+	opacity: 0.65;
+}
+
+.row:hover,
+.row:focus-within {
+	opacity: 1;
+}
+
+.userTrigger {
+	flex: 1;
+	justify-content: flex-start;
+	min-width: 0;
+	font-weight: var(--wpds-font-weight-regular);
+}
+
+.userName {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	min-width: 0;
+}
+
+.loginButton {
+	flex: 1;
+	justify-content: flex-start;
+}
+
+.popup {
+	min-width: 220px;
+}
+
+.email {
+	padding: var(--wpds-dimension-padding-xs) var(--wpds-dimension-padding-sm);
+	font-size: var(--wpds-font-size-xs);
+	color: var(--wpds-color-fg-content-neutral-weak);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}

--- a/apps/ui/src/data/core/connectors/ipc/index.ts
+++ b/apps/ui/src/data/core/connectors/ipc/index.ts
@@ -1,6 +1,7 @@
 import type {
 	AiSessionSummary,
 	AuthUser,
+	ColorScheme,
 	Connector,
 	LoadedAiSession,
 	SiteDetails,
@@ -92,6 +93,20 @@ export function createIpcConnector(): Connector {
 		// Locale
 		async getUserLocale(): Promise< string | undefined > {
 			return ipcApi.getUserLocale();
+		},
+
+		// Color scheme
+		async getColorScheme(): Promise< ColorScheme > {
+			return ipcApi.getColorScheme();
+		},
+
+		async saveColorScheme( scheme: ColorScheme ): Promise< void > {
+			await ipcApi.saveColorScheme( scheme );
+		},
+
+		// External links
+		async openExternalUrl( url: string ): Promise< void > {
+			ipcApi.openURL( url );
 		},
 	};
 }

--- a/apps/ui/src/data/core/index.ts
+++ b/apps/ui/src/data/core/index.ts
@@ -4,6 +4,7 @@ export type {
 	AiSessionEvent,
 	AiSessionSummary,
 	AuthUser,
+	ColorScheme,
 	Connector,
 	LoadedAiSession,
 	SiteDetails,

--- a/apps/ui/src/data/core/types.ts
+++ b/apps/ui/src/data/core/types.ts
@@ -56,4 +56,13 @@ export interface Connector {
 
 	// Locale
 	getUserLocale(): Promise< string | undefined >;
+
+	// Color scheme
+	getColorScheme(): Promise< ColorScheme >;
+	saveColorScheme( scheme: ColorScheme ): Promise< void >;
+
+	// External links
+	openExternalUrl( url: string ): Promise< void >;
 }
+
+export type ColorScheme = 'system' | 'light' | 'dark';

--- a/apps/ui/src/data/queries/use-auth-user.ts
+++ b/apps/ui/src/data/queries/use-auth-user.ts
@@ -1,0 +1,30 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useConnector } from '@/data/core';
+
+export const AUTH_USER_QUERY_KEY = [ 'auth-user' ] as const;
+
+export function useAuthUser() {
+	const connector = useConnector();
+	return useQuery( {
+		queryKey: AUTH_USER_QUERY_KEY,
+		queryFn: () => connector.getAuthUser(),
+	} );
+}
+
+export function useLogin() {
+	const connector = useConnector();
+	const queryClient = useQueryClient();
+	return useMutation( {
+		mutationFn: () => connector.authenticate(),
+		onSuccess: () => queryClient.invalidateQueries( { queryKey: AUTH_USER_QUERY_KEY } ),
+	} );
+}
+
+export function useLogout() {
+	const connector = useConnector();
+	const queryClient = useQueryClient();
+	return useMutation( {
+		mutationFn: () => connector.logout(),
+		onSuccess: () => queryClient.invalidateQueries( { queryKey: AUTH_USER_QUERY_KEY } ),
+	} );
+}

--- a/apps/ui/src/data/queries/use-color-scheme.ts
+++ b/apps/ui/src/data/queries/use-color-scheme.ts
@@ -1,0 +1,24 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useConnector } from '@/data/core';
+import type { ColorScheme } from '@/data/core';
+
+export const COLOR_SCHEME_QUERY_KEY = [ 'color-scheme' ] as const;
+
+export function useColorScheme() {
+	const connector = useConnector();
+	return useQuery( {
+		queryKey: COLOR_SCHEME_QUERY_KEY,
+		queryFn: () => connector.getColorScheme(),
+	} );
+}
+
+export function useSaveColorScheme() {
+	const connector = useConnector();
+	const queryClient = useQueryClient();
+	return useMutation( {
+		mutationFn: ( scheme: ColorScheme ) => connector.saveColorScheme( scheme ),
+		onSuccess: ( _data, scheme ) => {
+			queryClient.setQueryData( COLOR_SCHEME_QUERY_KEY, scheme );
+		},
+	} );
+}

--- a/apps/ui/src/index.css
+++ b/apps/ui/src/index.css
@@ -33,3 +33,11 @@ button:focus:not(:focus-visible),
 [role="button"]:focus:not(:focus-visible) {
 	outline: none;
 }
+
+/* Default icons inside buttons and menu items to 75% scale — WP UI's Icon
+   primitive draws at 16px, which reads a bit large for dense sidebars and
+   menus. Scope is tight enough to leave content/illustration SVGs alone. */
+button svg,
+[role^="menuitem"] svg {
+	transform: scale(0.75);
+}

--- a/apps/ui/src/index.css
+++ b/apps/ui/src/index.css
@@ -1,3 +1,8 @@
+:root {
+	/* Default is 2px; 4px reads a bit softer. */
+	--wpds-border-radius-sm: 4px;
+}
+
 body {
 	margin: 0;
 	padding: 0;
@@ -7,12 +12,24 @@ body {
 	background-color: var(--wpds-color-bg-surface-neutral-strong);
 	color: var(--wpds-color-fg-content-neutral);
 	color-scheme: light dark;
-	-webkit-app-region: drag; /* Electron: make the window draggable */
+	-webkit-app-region: drag;
 }
 
+/* Interactive elements opt out of the window drag region.
+   `[data-base-ui-portal] *` covers the @base-ui Menu portal subtree —
+   items render as divs, so we can't rely on the button/link selectors. */
 button,
 a,
 input,
-[role="button"] {
+[role="button"],
+[data-base-ui-portal],
+[data-base-ui-portal] * {
 	-webkit-app-region: no-drag;
+}
+
+/* Show the focus ring only on keyboard focus, overriding @wordpress/ui's
+   :focus-based outline. Unlayered CSS wins over WP UI's cascade layers. */
+button:focus:not(:focus-visible),
+[role="button"]:focus:not(:focus-visible) {
+	outline: none;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1060,6 +1060,7 @@
 			"name": "@studio/ui",
 			"version": "0.1.0",
 			"dependencies": {
+				"@base-ui/react": "^1.3.0",
 				"@studio/common": "file:../../tools/common",
 				"@tanstack/query-sync-storage-persister": "^5.96.2",
 				"@tanstack/react-query": "^5.75.5",


### PR DESCRIPTION
## Related issues

- Related to the new apps/ui shell introduced in #2986.

## How AI was used in this PR

Claude Code drafted the initial component structure from the existing `user-settings` module in `apps/studio/`, then iterated with me on design, token usage, and the Electron drag-region bug around React-portal-mounted menus. Review the component boundaries and the drag-region CSS rule in particular.

## Proposed Changes

Adds a **UserMenu** at the bottom of the `apps/ui` sidebar:

- **Row:** Gravatar-free user icon + display name (signed in) or "Log in with WordPress.com" (signed out), with an appearance toggle on the right.
- **User dropdown** (click name/avatar): email, Edit profile, Documentation, Report an issue, Log out. All external links or one-shot actions — no new modals/screens.
- **Appearance dropdown** (click sun/moon): System / Light / Dark radio items. Reuses the existing `getColorScheme`/`saveColorScheme` IPC — no new storage. `usePrefersColorScheme` already reacts because Electron's `nativeTheme.themeSource` drives the media query.

Introduces a reusable **`Menu` component** (`apps/ui/src/components/menu/`) wrapping `@base-ui/react/menu`:

- `Menu.Root`, `Menu.Trigger`, `Menu.Popup`, `Menu.Item`, `Menu.RadioItem`, `Menu.RadioGroup`, `Menu.Separator`.
- `Menu.Popup` bundles Portal + Positioner so consumers get the right default (opens upward, side=top, align=start) in one component.
- Styled to match `@wordpress/components` `Popover`: `--wpds-color-bg-surface-neutral-strong` surface, `--wpds-color-stroke-surface-neutral` border, `--wpds-border-radius-md`, `--wpds-elevation-md`.
- Radio items include a keep-mounted check indicator so labels stay aligned whether or not they're selected.

Connector additions in `apps/ui/src/data/core/types.ts`:

- `getColorScheme` / `saveColorScheme` / `openExternalUrl`, implemented in the IPC connector against existing preload handlers.

Small polish on the existing `ProjectList`:

- All buttons → `size="small"` (were mixed `compact`/`small`).
- Session link hover switched from `--wpds-color-bg-surface-neutral` to `--wpds-color-bg-interactive-neutral-weak-active` — same token as WP UI's minimal+neutral `Button` hover, so session links and site titles read identically.
- Session items now have a fixed 24px height matching the small button, deeper indent (`--wpds-dimension-padding-2xl`), and fixed a dead `--wpds-dimension-radius-sm` typo (correct token is `--wpds-border-radius-sm`).

Global tweaks in `apps/ui/src/index.css`:

- Bumped `--wpds-border-radius-sm` from 2px → 4px so buttons read a bit softer.
- Focus ring only shows on `:focus-visible`, not on click-focus.

### Electron drag-region quirk

The menu popover mounts via a React portal into `<body>`. Electron's drag-region map is computed at paint time and was swallowing pointer events on the dynamically-mounted popup — this was visible as "can't hover/click menu items unless DevTools is open," because opening DevTools forces a recompute.

Fixed by adding a `no-drag` rule covering `[data-base-ui-portal] *` (base-ui's namespaced `data-portal` attribute). That one selector covers the whole portal subtree — positioner, popup, items, focus guards — without relying on each individual role-based selector.

### Deps

- Adds `@base-ui/react ^1.3.0` as a direct dep of `@studio/ui` (already a transitive dep of `@wordpress/ui`).

## Testing Instructions

Run the new UI via:

\`\`\`sh
npm run start:new
\`\`\`

- [x] The sidebar has a user row at the bottom with the signed-in user's display name + a sun/moon icon on the right.
- [x] Click the user name → popover with email, Edit profile, Documentation, Report an issue, Log out. Each opens an external URL or logs out.
- [x] Click the sun/moon → popover with System / Light / Dark, check mark on the active option.
  - Pick "Dark" → window (and the old Studio app if open) both go dark, preference persists across restarts.
  - Pick "System" → follows OS light/dark.
- [x] Logged-out state: sidebar shows "Log in with WordPress.com" in place of the user row.
- [x] Hover + keyboard navigation work on both menus (arrow keys, Escape, return focus to trigger on close).
- [x] Window dragging still works by clicking empty sidebar space.
- [x] Menu hover/click works *without* opening DevTools (this was the Electron drag-region regression).
- [x] Session links and site titles share the same hover background.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?

🤖 Generated with [Claude Code](https://claude.com/claude-code)