### PR TITLE
apps/ui: add sidebar header with Studio title, new-item menu, and collapse toggle

### DIFF
--- a/apps/ui/src/components/project-list/index.tsx
+++ b/apps/ui/src/components/project-list/index.tsx
@@ -1,7 +1,7 @@
 import { Link } from '@tanstack/react-router';
 import { __ } from '@wordpress/i18n';
 import { chevronDown, chevronRight, plus } from '@wordpress/icons';
-import { Button, Collapsible, IconButton, Stack } from '@wordpress/ui';
+import { Button, Collapsible, IconButton } from '@wordpress/ui';
 import { useMemo, useState } from 'react';
 import { useSessions } from '@/data/queries/use-sessions';
 import { useSites } from '@/data/queries/use-sites';
@@ -162,12 +162,6 @@ export function ProjectList() {
 
 	return (
 		<div className={ styles.root }>
-			<Stack direction="row" align="center" justify="flex-end" className={ styles.header }>
-				<Button variant="minimal" tone="neutral" size="small">
-					<Button.Icon icon={ plus } size={ 16 } />
-					<span>{ __( 'Add site' ) }</span>
-				</Button>
-			</Stack>
 			{ sitesLoading || sessionsLoading ? (
 				<p className={ styles.empty }>{ __( 'Loading…' ) }</p>
 			) : groups.length === 0 ? (
@@ -181,9 +175,7 @@ export function ProjectList() {
 								key={ group.key }
 								group={ group }
 								isUnassigned={ isUnassigned }
-								defaultOpen={
-									! isUnassigned && index === 0 && group.sessions.length > 0
-								}
+								defaultOpen={ ! isUnassigned && index === 0 && group.sessions.length > 0 }
 							/>
 						);
 					} ) }

--- a/apps/ui/src/components/project-list/style.module.css
+++ b/apps/ui/src/components/project-list/style.module.css
@@ -5,10 +5,6 @@
 	gap: var(--wpds-dimension-padding-sm);
 }
 
-.header {
-	padding: var(--wpds-dimension-padding-xs) 0;
-}
-
 .projects {
 	display: flex;
 	flex-direction: column;

--- a/apps/ui/src/components/sidebar-header/index.tsx
+++ b/apps/ui/src/components/sidebar-header/index.tsx
@@ -1,0 +1,63 @@
+import { __ } from '@wordpress/i18n';
+import { comment, download, globe, plus } from '@wordpress/icons';
+import { Icon, IconButton } from '@wordpress/ui';
+import * as Menu from '@/components/menu';
+import { useFullscreen } from '@/hooks/use-fullscreen';
+import styles from './style.module.css';
+
+const drawerIcon = (
+	<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+		<rect x="4" y="5" width="16" height="14" rx="1.5" stroke="currentColor" strokeWidth="1.5" />
+		<line x1="9.5" y1="5" x2="9.5" y2="19" stroke="currentColor" strokeWidth="1.5" />
+	</svg>
+);
+
+type Props = {
+	onToggleSidebar: () => void;
+};
+
+export function SidebarHeader( { onToggleSidebar }: Props ) {
+	const isFullscreen = useFullscreen();
+	return (
+		<div className={ `${ styles.root } ${ isFullscreen ? styles.fullscreen : '' }` }>
+			<span className={ styles.title }>{ __( 'Studio' ) }</span>
+			<div className={ styles.actions }>
+				<Menu.Root modal={ false }>
+					<Menu.Trigger
+						render={
+							<IconButton
+								variant="minimal"
+								tone="neutral"
+								size="small"
+								icon={ plus }
+								label={ __( 'Create new' ) }
+							/>
+						}
+					/>
+					<Menu.Popup side="bottom" align="start" className={ styles.popup }>
+						<Menu.Item>
+							<Icon icon={ comment } size={ 16 } />
+							<span>{ __( 'New chat' ) }</span>
+						</Menu.Item>
+						<Menu.Item>
+							<Icon icon={ globe } size={ 16 } />
+							<span>{ __( 'New site project' ) }</span>
+						</Menu.Item>
+						<Menu.Item>
+							<Icon icon={ download } size={ 16 } />
+							<span>{ __( 'Import from…' ) }</span>
+						</Menu.Item>
+					</Menu.Popup>
+				</Menu.Root>
+				<IconButton
+					variant="minimal"
+					tone="neutral"
+					size="small"
+					icon={ drawerIcon }
+					label={ __( 'Hide sidebar' ) }
+					onClick={ onToggleSidebar }
+				/>
+			</div>
+		</div>
+	);
+}

--- a/apps/ui/src/components/sidebar-header/style.module.css
+++ b/apps/ui/src/components/sidebar-header/style.module.css
@@ -1,0 +1,44 @@
+.root {
+	display: flex;
+	align-items: center;
+	gap: var(--wpds-dimension-padding-sm);
+	/* Leave room for macOS traffic lights at {20, 20} plus a visible gap.
+	   min-height is tuned so the flex-centered content lines up with the
+	   vertical center of the traffic lights. */
+	padding: var(--wpds-dimension-padding-sm) var(--wpds-dimension-padding-md)
+		var(--wpds-dimension-padding-sm) 94px;
+	min-height: 46px;
+}
+
+/* In macOS fullscreen the traffic lights are hidden, so reclaim the
+   padding that was reserved for them. */
+.fullscreen {
+	padding-left: var(--wpds-dimension-padding-md);
+}
+
+.title {
+	flex: 1;
+	min-width: 0;
+	font-size: var(--wpds-font-size-md);
+	font-weight: 600;
+	color: var(--wpds-color-fg-content-neutral);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.actions {
+	display: flex;
+	align-items: center;
+	gap: var(--wpds-dimension-padding-xs);
+	opacity: 0.65;
+}
+
+.actions:hover,
+.actions:focus-within {
+	opacity: 1;
+}
+
+.popup {
+	min-width: 200px;
+}

--- a/apps/ui/src/components/sidebar-layout/index.tsx
+++ b/apps/ui/src/components/sidebar-layout/index.tsx
@@ -1,18 +1,52 @@
+import { __ } from '@wordpress/i18n';
+import { IconButton } from '@wordpress/ui';
+import { useState } from 'react';
 import { ProjectList } from '@/components/project-list';
+import { SidebarHeader } from '@/components/sidebar-header';
 import { UserMenu } from '@/components/user-menu';
+import { useFullscreen } from '@/hooks/use-fullscreen';
 import styles from './style.module.css';
 import type { ReactNode } from 'react';
 
+const drawerIcon = (
+	<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+		<rect x="4" y="5" width="16" height="14" rx="1.5" stroke="currentColor" strokeWidth="1.5" />
+		<line x1="9.5" y1="5" x2="9.5" y2="19" stroke="currentColor" strokeWidth="1.5" />
+	</svg>
+);
+
 export function SidebarLayout( { children }: { children: ReactNode } ) {
+	const [ collapsed, setCollapsed ] = useState( false );
+	const isFullscreen = useFullscreen();
+
 	return (
 		<div className={ styles.root }>
-			<aside className={ styles.sidebar }>
+			<aside className={ `${ styles.sidebar } ${ collapsed ? styles.sidebarCollapsed : '' }` }>
+				<SidebarHeader onToggleSidebar={ () => setCollapsed( true ) } />
 				<div className={ styles.sidebarContent }>
 					<ProjectList />
 				</div>
 				<UserMenu />
 			</aside>
-			<main className={ styles.main }>{ children }</main>
+			<main className={ styles.main }>
+				{ collapsed ? (
+					<div
+						className={ `${ styles.floatingToggle } ${
+							isFullscreen ? styles.floatingToggleFullscreen : ''
+						}` }
+					>
+						<IconButton
+							variant="minimal"
+							tone="neutral"
+							size="small"
+							icon={ drawerIcon }
+							label={ __( 'Show sidebar' ) }
+							onClick={ () => setCollapsed( false ) }
+						/>
+					</div>
+				) : null }
+				{ children }
+			</main>
 		</div>
 	);
 }

--- a/apps/ui/src/components/sidebar-layout/style.module.css
+++ b/apps/ui/src/components/sidebar-layout/style.module.css
@@ -10,6 +10,11 @@
 	display: flex;
 	flex-direction: column;
 	overflow: hidden;
+	transition: width 150ms ease;
+}
+
+.sidebarCollapsed {
+	width: 0;
 }
 
 .sidebarContent {
@@ -21,4 +26,25 @@
 .main {
 	flex: 1;
 	overflow: auto;
+	position: relative;
+}
+
+.floatingToggle {
+	position: absolute;
+	top: 0;
+	left: 94px;
+	/* Mirror sidebar-header vertical box so the toggle button lands at the
+	   same y-coordinate as when it lives inside the open sidebar. */
+	display: flex;
+	align-items: center;
+	padding: var(--wpds-dimension-padding-sm) 0;
+	min-height: 46px;
+	z-index: 10;
+	-webkit-app-region: no-drag;
+}
+
+/* In macOS fullscreen the traffic lights are hidden, so the toggle can
+   sit at the main area's left edge. */
+.floatingToggleFullscreen {
+	left: var(--wpds-dimension-padding-md);
 }

--- a/apps/ui/src/data/core/connectors/ipc/index.ts
+++ b/apps/ui/src/data/core/connectors/ipc/index.ts
@@ -108,5 +108,19 @@ export function createIpcConnector(): Connector {
 		async openExternalUrl( url: string ): Promise< void > {
 			ipcApi.openURL( url );
 		},
+
+		// Window state
+		async isFullscreen(): Promise< boolean > {
+			return ipcApi.isFullscreen();
+		},
+
+		onFullscreenChange( listener ) {
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			const ipcListener = ( window as any ).ipcListener;
+			return ipcListener.subscribe(
+				'window-fullscreen-change',
+				( _event: unknown, fullscreen: boolean ) => listener( fullscreen )
+			);
+		},
 	};
 }

--- a/apps/ui/src/data/core/types.ts
+++ b/apps/ui/src/data/core/types.ts
@@ -63,6 +63,11 @@ export interface Connector {
 
 	// External links
 	openExternalUrl( url: string ): Promise< void >;
+
+	// Window state (macOS fullscreen hides traffic lights, so the UI needs
+	// to reclaim the space we normally leave for them).
+	isFullscreen(): Promise< boolean >;
+	onFullscreenChange( listener: ( fullscreen: boolean ) => void ): () => void;
 }
 
 export type ColorScheme = 'system' | 'light' | 'dark';

--- a/apps/ui/src/hooks/use-fullscreen.ts
+++ b/apps/ui/src/hooks/use-fullscreen.ts
@@ -1,0 +1,25 @@
+import { useEffect, useState } from 'react';
+import { useConnector } from '@/data/core';
+
+export function useFullscreen(): boolean {
+	const connector = useConnector();
+	const [ isFullscreen, setIsFullscreen ] = useState( false );
+
+	useEffect( () => {
+		let mounted = true;
+		void connector.isFullscreen().then( ( fullscreen ) => {
+			if ( mounted ) {
+				setIsFullscreen( fullscreen );
+			}
+		} );
+
+		const unsubscribe = connector.onFullscreenChange( setIsFullscreen );
+
+		return () => {
+			mounted = false;
+			unsubscribe();
+		};
+	}, [ connector ] );
+
+	return isFullscreen;
+}


### PR DESCRIPTION
<img width="410" height="228" alt="Screenshot 2026-04-18 at 11 15 31 PM" src="https://github.com/user-attachments/assets/ec198137-061d-4b05-8ab9-f13abe8ddfd0" />


## How AI was used in this PR

Built interactively with Claude Code. The human iterated on the visual design, pointing out alignment issues against screenshots and requesting fullscreen handling; AI produced the component structure, CSS tokens/padding math, and the Connector-level wiring for the fullscreen event.

## Proposed Changes

- New `apps/ui/src/components/sidebar-header/` with the "Studio" title, a "+" `IconButton` that opens a menu (New chat / New site project / Import from…), and a drawer-toggle button. Menu item handlers are intentionally left unwired — this PR focuses on the shell.
- `SidebarLayout` now owns a `collapsed` state. Collapsing animates the sidebar width to 0 and floats the toggle button into the main area at the same vertical y-coordinate it occupies when docked (same `min-height` + `padding-sm` + `align-items: center` box).
- Left padding reserves ~94px for macOS traffic lights in the sidebar header and the floating toggle.
- New `useFullscreen` hook reads the main process's existing `isFullscreen` IPC handler and subscribes to `window-fullscreen-change`. To keep the UI portable, it goes through two new methods on the `Connector` interface (`isFullscreen()` / `onFullscreenChange()`) rather than reaching into `window.ipcApi` from components. When fullscreen, both the header and the floating toggle drop their 94px reservation back to `padding-md` since the traffic lights are gone.
- Removes the now-redundant "+ Add site" header from `ProjectList` (superseded by the new header's "+" menu).

## Testing Instructions

- `npm run start:new` to run Electron with the new UI.
- Sidebar: confirm "Studio" is bold, vertically aligned with the macOS traffic lights, and that the "+" menu opens with the three items.
- Click the drawer-toggle icon: sidebar collapses smoothly. A floating toggle appears on the main area's top-left, at the same y-position. Clicking it reopens the sidebar.
- Enter macOS fullscreen (Ctrl+Cmd+F). The title and toggle should shift left to reclaim the traffic-light space; exit fullscreen to confirm it springs back.
- Try both light and dark color schemes.

## Pre-merge Checklist

- [ ] Have you checked for TypeScript, React or other console errors?