### PR TITLE
apps/ui: align sidebar with new design mock

### DIFF
--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -22,6 +22,7 @@
 		"@wordpress/react-i18n": "^4.41.0",
 		"@wordpress/theme": "0.10.0",
 		"@wordpress/ui": "0.10.0",
+		"clsx": "^2.1.1",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0"
 	},

--- a/apps/ui/src/components/gravatar/index.tsx
+++ b/apps/ui/src/components/gravatar/index.tsx
@@ -1,0 +1,60 @@
+import { useEffect, useState } from 'react';
+import styles from './style.module.css';
+
+const DEFAULT_LIGHT = 'https://s0.wp.com/i/studio-app/profile-icon.png';
+const DEFAULT_DARK = 'https://s0.wp.com/i/studio-app/profile-icon-black.png';
+
+async function sha256Hex( input: string ): Promise< string > {
+	const digest = await crypto.subtle.digest( 'SHA-256', new TextEncoder().encode( input ) );
+	return Array.from( new Uint8Array( digest ) )
+		.map( ( b ) => b.toString( 16 ).padStart( 2, '0' ) )
+		.join( '' );
+}
+
+function useGravatarUrl( email: string | undefined, isDark: boolean ): string | undefined {
+	const [ url, setUrl ] = useState< string | undefined >( undefined );
+
+	useEffect( () => {
+		if ( ! email ) {
+			setUrl( undefined );
+			return;
+		}
+		let cancelled = false;
+		const fallback = isDark ? DEFAULT_DARK : DEFAULT_LIGHT;
+		void sha256Hex( email.trim().toLowerCase() ).then( ( hash ) => {
+			if ( cancelled ) {
+				return;
+			}
+			setUrl( `https://www.gravatar.com/avatar/${ hash }?d=${ encodeURIComponent( fallback ) }` );
+		} );
+		return () => {
+			cancelled = true;
+		};
+	}, [ email, isDark ] );
+
+	return url;
+}
+
+type GravatarProps = {
+	email: string;
+	isDark: boolean;
+};
+
+export function Gravatar( { email, isDark }: GravatarProps ) {
+	const url = useGravatarUrl( email, isDark );
+	const [ errored, setErrored ] = useState( false );
+
+	if ( ! url || errored ) {
+		return <span aria-hidden="true" className={ styles.root } />;
+	}
+
+	return (
+		<img
+			aria-hidden="true"
+			className={ styles.root }
+			src={ url }
+			alt=""
+			onError={ () => setErrored( true ) }
+		/>
+	);
+}

--- a/apps/ui/src/components/gravatar/style.module.css
+++ b/apps/ui/src/components/gravatar/style.module.css
@@ -1,0 +1,9 @@
+.root {
+	display: inline-block;
+	width: 20px;
+	height: 20px;
+	border-radius: 50%;
+	flex-shrink: 0;
+	object-fit: cover;
+	background-color: var(--wpds-color-bg-surface-neutral);
+}

--- a/apps/ui/src/components/project-list/index.tsx
+++ b/apps/ui/src/components/project-list/index.tsx
@@ -4,6 +4,7 @@ import { moreHorizontal, plus } from '@wordpress/icons';
 import { IconButton } from '@wordpress/ui';
 import { clsx } from 'clsx';
 import { useMemo, useState } from 'react';
+import { SidebarButton } from '@/components/sidebar-button';
 import { useSessions } from '@/data/queries/use-sessions';
 import { useSites } from '@/data/queries/use-sites';
 import { formatRelativeTime } from '@/lib/format-relative-time';
@@ -95,15 +96,21 @@ function SessionItem( { session }: { session: AiSessionSummary } ) {
 
 	return (
 		<li className={ styles.sessionItem }>
-			<Link
-				to="/sessions/$sessionId"
-				params={ { sessionId: session.id } }
+			<SidebarButton
 				className={ styles.sessionLink }
-				activeProps={ { className: clsx( styles.sessionLink, styles.sessionLinkActive ) } }
+				render={
+					<Link
+						to="/sessions/$sessionId"
+						params={ { sessionId: session.id } }
+						activeProps={ {
+							className: clsx( styles.sessionLink, styles.sessionLinkActive ),
+						} }
+					/>
+				}
 			>
 				<span className={ styles.sessionLabel }>{ label }</span>
 				<span className={ styles.sessionTime }>{ formatRelativeTime( session.updatedAt ) }</span>
-			</Link>
+			</SidebarButton>
 		</li>
 	);
 }
@@ -131,14 +138,13 @@ function ProjectSection( {
 		>
 			<header className={ styles.projectHeader }>
 				<div className={ styles.projectText }>
-					<button
-						type="button"
+					<SidebarButton
 						className={ styles.projectToggle }
 						onClick={ onToggle }
 						aria-expanded={ isOpen }
 					>
 						<span className={ styles.projectName }>{ group.label }</span>
-					</button>
+					</SidebarButton>
 					{ group.subtitle ? (
 						<span className={ styles.projectSubtitle }>{ group.subtitle }</span>
 					) : null }

--- a/apps/ui/src/components/project-list/index.tsx
+++ b/apps/ui/src/components/project-list/index.tsx
@@ -1,10 +1,12 @@
-import { Link } from '@tanstack/react-router';
+import { Link, useParams } from '@tanstack/react-router';
 import { __ } from '@wordpress/i18n';
-import { chevronDown, chevronRight, plus } from '@wordpress/icons';
-import { Button, Collapsible, IconButton } from '@wordpress/ui';
+import { moreHorizontal, plus } from '@wordpress/icons';
+import { IconButton } from '@wordpress/ui';
+import { clsx } from 'clsx';
 import { useMemo, useState } from 'react';
 import { useSessions } from '@/data/queries/use-sessions';
 import { useSites } from '@/data/queries/use-sites';
+import { formatRelativeTime } from '@/lib/format-relative-time';
 import styles from './style.module.css';
 import type { AiSessionSummary, SiteDetails } from '@/data/core';
 
@@ -14,8 +16,21 @@ type ProjectGroup = {
 	key: string;
 	site?: SiteDetails;
 	label: string;
+	subtitle?: string;
 	sessions: AiSessionSummary[];
 };
+
+function stripProtocol( url: string ): string {
+	return url.replace( /^https?:\/\//, '' ).replace( /\/$/, '' );
+}
+
+function deriveSubtitle( site: SiteDetails ): string | undefined {
+	if ( site.url ) {
+		return stripProtocol( site.url );
+	}
+	const basename = site.path.split( /[\\/]/ ).filter( Boolean ).pop();
+	return basename;
+}
 
 function groupSessionsByOwner(
 	sites: SiteDetails[] | undefined,
@@ -26,9 +41,6 @@ function groupSessionsByOwner(
 	const unassigned: AiSessionSummary[] = [];
 
 	for ( const session of sessions ?? [] ) {
-		// A session is "assigned" only if its owner path still matches a known site.
-		// Orphans (site deleted/renamed, empty path, or never selected one) fall through
-		// to the Unassigned bucket so they stay reachable.
 		if ( ! session.ownerSitePath || ! knownSitePaths.has( session.ownerSitePath ) ) {
 			unassigned.push( session );
 			continue;
@@ -46,13 +58,12 @@ function groupSessionsByOwner(
 		key: site.id,
 		site,
 		label: site.name,
+		subtitle: deriveSubtitle( site ),
 		sessions: sessionsByPath.get( site.path ) ?? [],
 	} ) );
 
 	// Sort site-groups by the newest session's updatedAt so the most recently
-	// used project lands at the top (and gets expanded on launch). Sessions are
-	// already sorted newest-first, so sessions[0] is each project's MRU. Projects
-	// with no sessions drop to the bottom.
+	// used project lands at the top. Projects with no sessions drop to the bottom.
 	groups.sort( ( a, b ) => {
 		const aTimestamp = a.sessions[ 0 ]?.updatedAt;
 		const bTimestamp = b.sessions[ 0 ]?.updatedAt;
@@ -88,9 +99,10 @@ function SessionItem( { session }: { session: AiSessionSummary } ) {
 				to="/sessions/$sessionId"
 				params={ { sessionId: session.id } }
 				className={ styles.sessionLink }
-				activeProps={ { className: `${ styles.sessionLink } ${ styles.sessionLinkActive }` } }
+				activeProps={ { className: clsx( styles.sessionLink, styles.sessionLinkActive ) } }
 			>
-				{ label }
+				<span className={ styles.sessionLabel }>{ label }</span>
+				<span className={ styles.sessionTime }>{ formatRelativeTime( session.updatedAt ) }</span>
 			</Link>
 		</li>
 	);
@@ -98,67 +110,114 @@ function SessionItem( { session }: { session: AiSessionSummary } ) {
 
 function ProjectSection( {
 	group,
-	defaultOpen,
 	isUnassigned,
+	isActive,
+	isOpen,
+	onToggle,
 }: {
 	group: ProjectGroup;
-	defaultOpen: boolean;
 	isUnassigned: boolean;
+	isActive: boolean;
+	isOpen: boolean;
+	onToggle: () => void;
 } ) {
-	const [ open, setOpen ] = useState( defaultOpen );
-
 	return (
-		<Collapsible.Root
-			open={ open }
-			onOpenChange={ setOpen }
-			className={ `${ styles.project } ${ isUnassigned ? styles.unassigned : '' }` }
+		<section
+			className={ clsx(
+				styles.project,
+				isUnassigned && styles.unassigned,
+				isActive && styles.projectActive
+			) }
 		>
-			<div className={ styles.projectRow }>
-				<Collapsible.Trigger
-					render={
-						<Button
+			<header className={ styles.projectHeader }>
+				<div className={ styles.projectText }>
+					<button
+						type="button"
+						className={ styles.projectToggle }
+						onClick={ onToggle }
+						aria-expanded={ isOpen }
+					>
+						<span className={ styles.projectName }>{ group.label }</span>
+					</button>
+					{ group.subtitle ? (
+						<span className={ styles.projectSubtitle }>{ group.subtitle }</span>
+					) : null }
+				</div>
+				{ group.site ? (
+					<div className={ styles.projectActions }>
+						<IconButton
 							variant="minimal"
 							tone="neutral"
 							size="small"
-							className={ styles.projectTrigger }
-						>
-							<Button.Icon icon={ open ? chevronDown : chevronRight } size={ 16 } />
-
-							<span className={ styles.projectName }>{ group.label }</span>
-						</Button>
-					}
-				/>
-				{ group.site ? (
-					<IconButton
-						variant="minimal"
-						tone="neutral"
-						size="small"
-						icon={ plus }
-						label={ __( 'New session' ) }
-						className={ styles.projectAction }
-					/>
+							icon={ moreHorizontal }
+							label={ __( 'Project actions' ) }
+							className={ styles.projectAction }
+						/>
+						<IconButton
+							variant="minimal"
+							tone="neutral"
+							size="small"
+							icon={ plus }
+							label={ __( 'New session' ) }
+							className={ styles.projectAction }
+						/>
+					</div>
 				) : null }
-			</div>
-			<Collapsible.Panel>
-				{ group.sessions.length === 0 ? (
-					<p className={ styles.empty }>{ __( 'No sessions' ) }</p>
-				) : (
-					<ul className={ styles.sessionList }>
-						{ group.sessions.map( ( session ) => (
-							<SessionItem key={ session.id } session={ session } />
-						) ) }
-					</ul>
-				) }
-			</Collapsible.Panel>
-		</Collapsible.Root>
+			</header>
+			{ isOpen && group.sessions.length > 0 ? (
+				<ul className={ styles.sessionList }>
+					{ group.sessions.map( ( session ) => (
+						<SessionItem key={ session.id } session={ session } />
+					) ) }
+				</ul>
+			) : null }
+		</section>
 	);
+}
+
+function findActiveProjectKey(
+	groups: ProjectGroup[],
+	activeSessionId: string | undefined
+): string | undefined {
+	if ( ! activeSessionId ) {
+		return undefined;
+	}
+	for ( const group of groups ) {
+		if ( group.sessions.some( ( session ) => session.id === activeSessionId ) ) {
+			return group.key;
+		}
+	}
+	return undefined;
 }
 
 export function ProjectList() {
 	const { data: sites, isLoading: sitesLoading } = useSites();
 	const { data: sessions, isLoading: sessionsLoading } = useSessions();
+	const params = useParams( { strict: false } ) as { sessionId?: string };
+	const activeSessionId = params.sessionId;
 
 	const groups = useMemo( () => groupSessionsByOwner( sites, sessions ), [ sites, sessions ] );
+	const activeProjectKey = useMemo(
+		() => findActiveProjectKey( groups, activeSessionId ),
+		[ groups, activeSessionId ]
+	);
+
+	// Expansion is derived: by default the active project (or, if none, the
+	// MRU project — first in the list) is open. Manual toggles are stored as
+	// overrides so the user's explicit choice wins until they toggle again.
+	const mruKey = groups[ 0 ]?.key;
+	const [ overrides, setOverrides ] = useState< Record< string, boolean > >( {} );
+
+	const isOpen = ( key: string ): boolean => {
+		if ( key in overrides ) {
+			return overrides[ key ];
+		}
+		return key === activeProjectKey || ( ! activeProjectKey && key === mruKey );
+	};
+
+	const toggleProject = ( key: string ) => {
+		setOverrides( ( prev ) => ( { ...prev, [ key ]: ! isOpen( key ) } ) );
+	};
 
 	return (
 		<div className={ styles.root }>
@@ -168,17 +227,16 @@ export function ProjectList() {
 				<p className={ styles.empty }>{ __( 'No projects yet' ) }</p>
 			) : (
 				<div className={ styles.projects }>
-					{ groups.map( ( group, index ) => {
-						const isUnassigned = group.key === UNASSIGNED_KEY;
-						return (
-							<ProjectSection
-								key={ group.key }
-								group={ group }
-								isUnassigned={ isUnassigned }
-								defaultOpen={ ! isUnassigned && index === 0 && group.sessions.length > 0 }
-							/>
-						);
-					} ) }
+					{ groups.map( ( group ) => (
+						<ProjectSection
+							key={ group.key }
+							group={ group }
+							isUnassigned={ group.key === UNASSIGNED_KEY }
+							isActive={ group.key === activeProjectKey }
+							isOpen={ isOpen( group.key ) }
+							onToggle={ () => toggleProject( group.key ) }
+						/>
+					) ) }
 				</div>
 			) }
 		</div>

--- a/apps/ui/src/components/project-list/style.module.css
+++ b/apps/ui/src/components/project-list/style.module.css
@@ -36,16 +36,9 @@
 
 .projectToggle {
 	max-width: 100%;
-	display: inline-flex;
-	align-items: center;
-	margin: 0;
+	height: auto;
 	padding: 0 var(--wpds-dimension-padding-sm);
-	background: transparent;
-	border: 0;
-	border-radius: var(--wpds-border-radius-sm);
-	cursor: var(--wpds-cursor-control);
-	text-align: start;
-	font-family: inherit;
+	font-weight: inherit;
 }
 
 .projectName {
@@ -124,19 +117,17 @@
 
 .sessionLink {
 	position: relative;
-	display: flex;
-	align-items: center;
-	gap: var(--wpds-dimension-padding-sm);
+	width: 100%;
 	height: 26px;
 	padding: 0 var(--wpds-dimension-padding-sm) 0 var(--wpds-dimension-padding-lg);
 	color: var(--wpds-color-fg-content-neutral-weak);
-	text-decoration: none;
 	font-size: var(--wpds-font-size-sm);
-	border-radius: var(--wpds-border-radius-sm);
-	min-width: 0;
+	font-weight: var(--wpds-font-weight-regular);
 }
 
-.sessionLink::before {
+/* Use ::after so we don't collide with the Button primitive's ::before
+   (which it uses for the loading spinner). */
+.sessionLink::after {
 	content: '';
 	position: absolute;
 	left: var(--wpds-dimension-padding-sm);
@@ -161,16 +152,16 @@
 	opacity: 0.55;
 }
 
-.sessionLink:hover {
+.sessionLink:hover,
+.sessionLink:focus-visible {
 	color: var(--wpds-color-fg-content-neutral);
 }
 
 .sessionLinkActive,
 .sessionLinkActive:hover {
 	color: var(--wpds-color-fg-content-neutral);
-	background: transparent;
 }
 
-.sessionLinkActive::before {
+.sessionLinkActive::after {
 	background: var(--wpds-color-fg-content-neutral);
 }

--- a/apps/ui/src/components/project-list/style.module.css
+++ b/apps/ui/src/components/project-list/style.module.css
@@ -1,5 +1,6 @@
 .root {
-	padding: var(--wpds-dimension-padding-md);
+	padding: 0 calc(var(--wpds-dimension-padding-xl) + var(--wpds-dimension-padding-sm))
+		var(--wpds-dimension-padding-xl);
 	display: flex;
 	flex-direction: column;
 	gap: var(--wpds-dimension-padding-sm);
@@ -8,7 +9,7 @@
 .projects {
 	display: flex;
 	flex-direction: column;
-	gap: var(--wpds-dimension-padding-xs);
+	gap: var(--wpds-dimension-padding-xl);
 }
 
 .project {
@@ -16,55 +17,94 @@
 	flex-direction: column;
 }
 
-.projectRow {
-	position: relative;
-}
-
-.projectTrigger {
-	width: 100%;
-	justify-content: flex-start;
+.projectHeader {
+	display: flex;
+	align-items: flex-start;
+	gap: var(--wpds-dimension-padding-xs);
 	min-width: 0;
-	padding-inline-end: var(--wpds-dimension-padding-xl);
-	opacity: 0.65;
+	margin-bottom: var(--wpds-dimension-padding-xs);
+	padding-right: var(--wpds-dimension-padding-sm);
 }
 
-.projectTrigger:hover,
-.projectTrigger:focus-visible {
-	opacity: 1;
+.projectText {
+	flex: 1;
+	min-width: 0;
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+}
+
+.projectToggle {
+	max-width: 100%;
+	display: inline-flex;
+	align-items: center;
+	margin: 0;
+	padding: 0 var(--wpds-dimension-padding-sm);
+	background: transparent;
+	border: 0;
+	border-radius: var(--wpds-border-radius-sm);
+	cursor: var(--wpds-cursor-control);
+	text-align: start;
+	font-family: inherit;
+}
+
+.projectName {
+	font-size: var(--wpds-font-size-md);
+	line-height: 1.2;
+	font-weight: var(--wpds-font-weight-regular);
+	color: var(--wpds-color-fg-content-neutral-weak);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	max-width: 100%;
+}
+
+.projectToggle:hover .projectName {
+	color: var(--wpds-color-fg-content-neutral);
+}
+
+.projectActive .projectName {
+	color: var(--wpds-color-fg-content-neutral);
+	font-weight: 600;
+}
+
+.projectSubtitle {
+	font-size: var(--wpds-font-size-xs);
+	line-height: 1;
+	color: var(--wpds-color-fg-content-neutral-weak);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	max-width: 100%;
+	opacity: 0.55;
+	padding: 0 var(--wpds-dimension-padding-sm);
+	margin-top: 4px;
+}
+
+.projectActions {
+	display: flex;
+	align-items: center;
+	flex-shrink: 0;
+	padding-top: 2px;
 }
 
 .projectAction {
-	position: absolute;
-	inset-inline-end: 0;
-	top: 50%;
-	transform: translateY(-50%);
 	opacity: 0;
 	transition: opacity 100ms ease;
 }
 
-.projectRow:hover .projectAction,
-.projectRow:focus-within .projectAction {
+.projectActive .projectAction,
+.projectHeader:hover .projectAction,
+.projectHeader:focus-within .projectAction {
 	opacity: 1;
 }
 
-.projectName {
-	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
-	min-width: 0;
-	font-size: var(--wpds-font-size-sm);
-	font-weight: var(--wpds-font-weight-regular);
-}
-
 .unassigned {
-	margin-top: var(--wpds-dimension-padding-md);
-	padding-top: var(--wpds-dimension-padding-md);
-	border-top: 1px solid var(--wpds-color-stroke-surface-neutral);
+	margin-top: var(--wpds-dimension-padding-sm);
 }
 
 .empty {
-	padding: var(--wpds-dimension-padding-xs) var(--wpds-dimension-padding-sm)
-		var(--wpds-dimension-padding-xs) var(--wpds-dimension-padding-xl);
+	padding: var(--wpds-dimension-padding-xs) var(--wpds-dimension-padding-sm);
 	color: var(--wpds-color-fg-content-neutral-weak);
 	font-size: var(--wpds-font-size-sm);
 	margin: 0;
@@ -83,25 +123,54 @@
 }
 
 .sessionLink {
+	position: relative;
 	display: flex;
 	align-items: center;
-	height: 24px;
-	padding: 0 var(--wpds-dimension-padding-sm) 0 var(--wpds-dimension-padding-2xl);
-	color: var(--wpds-color-fg-content-neutral);
+	gap: var(--wpds-dimension-padding-sm);
+	height: 26px;
+	padding: 0 var(--wpds-dimension-padding-sm) 0 var(--wpds-dimension-padding-lg);
+	color: var(--wpds-color-fg-content-neutral-weak);
 	text-decoration: none;
+	font-size: var(--wpds-font-size-sm);
+	border-radius: var(--wpds-border-radius-sm);
+	min-width: 0;
+}
+
+.sessionLink::before {
+	content: '';
+	position: absolute;
+	left: var(--wpds-dimension-padding-sm);
+	top: 4px;
+	bottom: 4px;
+	width: 1px;
+	background: transparent;
+}
+
+.sessionLabel {
+	flex: 1;
+	min-width: 0;
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
-	font-size: var(--wpds-font-size-sm);
-	border-radius: var(--wpds-border-radius-sm);
+}
+
+.sessionTime {
+	flex-shrink: 0;
+	font-size: 10px;
+	color: var(--wpds-color-fg-content-neutral-weak);
+	opacity: 0.55;
 }
 
 .sessionLink:hover {
 	color: var(--wpds-color-fg-content-neutral);
-	background-color: var(--wpds-color-bg-interactive-neutral-weak-active);
 }
 
-.sessionLinkActive {
+.sessionLinkActive,
+.sessionLinkActive:hover {
 	color: var(--wpds-color-fg-content-neutral);
-	background-color: var(--wpds-color-bg-interactive-neutral-weak-active);
+	background: transparent;
+}
+
+.sessionLinkActive::before {
+	background: var(--wpds-color-fg-content-neutral);
 }

--- a/apps/ui/src/components/project-list/style.module.css
+++ b/apps/ui/src/components/project-list/style.module.css
@@ -37,8 +37,6 @@
 .projectToggle {
 	max-width: 100%;
 	height: auto;
-	padding: 0 var(--wpds-dimension-padding-sm);
-	font-weight: inherit;
 }
 
 .projectName {
@@ -116,7 +114,6 @@
 }
 
 .sessionLink {
-	position: relative;
 	width: 100%;
 	height: 26px;
 	padding: 0 var(--wpds-dimension-padding-sm) 0 var(--wpds-dimension-padding-lg);
@@ -157,8 +154,7 @@
 	color: var(--wpds-color-fg-content-neutral);
 }
 
-.sessionLinkActive,
-.sessionLinkActive:hover {
+.sessionLinkActive {
 	color: var(--wpds-color-fg-content-neutral);
 }
 

--- a/apps/ui/src/components/sidebar-button/index.tsx
+++ b/apps/ui/src/components/sidebar-button/index.tsx
@@ -1,7 +1,8 @@
 import { Button } from '@wordpress/ui';
 import { clsx } from 'clsx';
+import { forwardRef } from 'react';
 import styles from './style.module.css';
-import type { ComponentProps } from 'react';
+import type { ComponentProps, ElementRef } from 'react';
 
 type Props = Omit< ComponentProps< typeof Button >, 'variant' | 'tone' | 'size' >;
 
@@ -10,15 +11,21 @@ type Props = Omit< ComponentProps< typeof Button >, 'variant' | 'tone' | 'size' 
  * Pins the minimal/neutral/small preset and neutralizes the primitive's
  * centering, min-width, border, and hover background so consumers only
  * need to supply their own dimensions, colors, and active state.
+ *
+ * Uses forwardRef so Base UI primitives (e.g. `Menu.Trigger`) can attach
+ * their internal ref to the underlying button element.
  */
-export function SidebarButton( { className, ...props }: Props ) {
-	return (
-		<Button
-			variant="minimal"
-			tone="neutral"
-			size="small"
-			className={ clsx( styles.root, className ) }
-			{ ...props }
-		/>
-	);
-}
+export const SidebarButton = forwardRef< ElementRef< typeof Button >, Props >(
+	function SidebarButton( { className, ...props }, ref ) {
+		return (
+			<Button
+				ref={ ref }
+				variant="minimal"
+				tone="neutral"
+				size="small"
+				className={ clsx( styles.root, className ) }
+				{ ...props }
+			/>
+		);
+	}
+);

--- a/apps/ui/src/components/sidebar-button/index.tsx
+++ b/apps/ui/src/components/sidebar-button/index.tsx
@@ -1,0 +1,24 @@
+import { Button } from '@wordpress/ui';
+import { clsx } from 'clsx';
+import styles from './style.module.css';
+import type { ComponentProps } from 'react';
+
+type Props = Omit< ComponentProps< typeof Button >, 'variant' | 'tone' | 'size' >;
+
+/**
+ * Thin wrapper around @wordpress/ui's `Button` for sidebar list rows.
+ * Pins the minimal/neutral/small preset and neutralizes the primitive's
+ * centering, min-width, border, and hover background so consumers only
+ * need to supply their own dimensions, colors, and active state.
+ */
+export function SidebarButton( { className, ...props }: Props ) {
+	return (
+		<Button
+			variant="minimal"
+			tone="neutral"
+			size="small"
+			className={ clsx( styles.root, className ) }
+			{ ...props }
+		/>
+	);
+}

--- a/apps/ui/src/components/sidebar-button/style.module.css
+++ b/apps/ui/src/components/sidebar-button/style.module.css
@@ -1,0 +1,11 @@
+.root {
+	justify-content: flex-start;
+	min-width: 0;
+	border-color: transparent;
+}
+
+.root:hover,
+.root:focus-visible {
+	background-color: transparent;
+	border-color: transparent;
+}

--- a/apps/ui/src/components/sidebar-button/style.module.css
+++ b/apps/ui/src/components/sidebar-button/style.module.css
@@ -1,11 +1,11 @@
+/* Neutralize the @wordpress/ui Button primitive's centering, min-width,
+   solid border, and hover/active/focus background. Declaring these at the
+   base level (outside @layer wp-ui-components) beats Button's layered
+   state rules for any :hover / :active / :focus, so no state-specific
+   overrides are needed here. */
 .root {
 	justify-content: flex-start;
 	min-width: 0;
-	border-color: transparent;
-}
-
-.root:hover,
-.root:focus-visible {
 	background-color: transparent;
 	border-color: transparent;
 }

--- a/apps/ui/src/components/sidebar-header/index.tsx
+++ b/apps/ui/src/components/sidebar-header/index.tsx
@@ -3,14 +3,8 @@ import { comment, download, globe, plus } from '@wordpress/icons';
 import { Icon, IconButton } from '@wordpress/ui';
 import * as Menu from '@/components/menu';
 import { useFullscreen } from '@/hooks/use-fullscreen';
+import { drawerIcon } from '@/lib/icons';
 import styles from './style.module.css';
-
-const drawerIcon = (
-	<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
-		<rect x="4" y="5" width="16" height="14" rx="1.5" stroke="currentColor" strokeWidth="1.5" />
-		<line x1="9.5" y1="5" x2="9.5" y2="19" stroke="currentColor" strokeWidth="1.5" />
-	</svg>
-);
 
 type Props = {
 	onToggleSidebar: () => void;

--- a/apps/ui/src/components/sidebar-header/style.module.css
+++ b/apps/ui/src/components/sidebar-header/style.module.css
@@ -5,7 +5,7 @@
 	/* Leave room for macOS traffic lights at {20, 20} plus a visible gap.
 	   min-height is tuned so the flex-centered content lines up with the
 	   vertical center of the traffic lights. */
-	padding: var(--wpds-dimension-padding-sm) var(--wpds-dimension-padding-md)
+	padding: var(--wpds-dimension-padding-sm) var(--wpds-dimension-padding-xl)
 		var(--wpds-dimension-padding-sm) 94px;
 	min-height: 46px;
 }
@@ -13,7 +13,7 @@
 /* In macOS fullscreen the traffic lights are hidden, so reclaim the
    padding that was reserved for them. */
 .fullscreen {
-	padding-left: var(--wpds-dimension-padding-md);
+	padding-left: var(--wpds-dimension-padding-xl);
 }
 
 .title {

--- a/apps/ui/src/components/sidebar-layout/index.tsx
+++ b/apps/ui/src/components/sidebar-layout/index.tsx
@@ -1,19 +1,15 @@
 import { __ } from '@wordpress/i18n';
 import { IconButton } from '@wordpress/ui';
+import { clsx } from 'clsx';
 import { useState } from 'react';
 import { ProjectList } from '@/components/project-list';
 import { SidebarHeader } from '@/components/sidebar-header';
+import { SidebarNav } from '@/components/sidebar-nav';
 import { UserMenu } from '@/components/user-menu';
 import { useFullscreen } from '@/hooks/use-fullscreen';
+import { drawerIcon } from '@/lib/icons';
 import styles from './style.module.css';
 import type { ReactNode } from 'react';
-
-const drawerIcon = (
-	<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
-		<rect x="4" y="5" width="16" height="14" rx="1.5" stroke="currentColor" strokeWidth="1.5" />
-		<line x1="9.5" y1="5" x2="9.5" y2="19" stroke="currentColor" strokeWidth="1.5" />
-	</svg>
-);
 
 export function SidebarLayout( { children }: { children: ReactNode } ) {
 	const [ collapsed, setCollapsed ] = useState( false );
@@ -21,9 +17,10 @@ export function SidebarLayout( { children }: { children: ReactNode } ) {
 
 	return (
 		<div className={ styles.root }>
-			<aside className={ `${ styles.sidebar } ${ collapsed ? styles.sidebarCollapsed : '' }` }>
+			<aside className={ clsx( styles.sidebar, collapsed && styles.sidebarCollapsed ) }>
 				<SidebarHeader onToggleSidebar={ () => setCollapsed( true ) } />
 				<div className={ styles.sidebarContent }>
+					<SidebarNav />
 					<ProjectList />
 				</div>
 				<UserMenu />
@@ -31,9 +28,10 @@ export function SidebarLayout( { children }: { children: ReactNode } ) {
 			<main className={ styles.main }>
 				{ collapsed ? (
 					<div
-						className={ `${ styles.floatingToggle } ${
-							isFullscreen ? styles.floatingToggleFullscreen : ''
-						}` }
+						className={ clsx(
+							styles.floatingToggle,
+							isFullscreen && styles.floatingToggleFullscreen
+						) }
 					>
 						<IconButton
 							variant="minimal"

--- a/apps/ui/src/components/sidebar-layout/style.module.css
+++ b/apps/ui/src/components/sidebar-layout/style.module.css
@@ -4,9 +4,10 @@
 }
 
 .sidebar {
-	width: 260px;
+	width: 320px;
 	flex-shrink: 0;
 	background-color: var(--wpds-color-bg-surface-neutral-weak);
+	border-right: 1px solid var(--wpds-color-stroke-surface-neutral);
 	display: flex;
 	flex-direction: column;
 	overflow: hidden;

--- a/apps/ui/src/components/sidebar-nav/index.tsx
+++ b/apps/ui/src/components/sidebar-nav/index.tsx
@@ -3,6 +3,7 @@ import { __ } from '@wordpress/i18n';
 import { category, cog, comment } from '@wordpress/icons';
 import { Icon } from '@wordpress/ui';
 import { clsx } from 'clsx';
+import { SidebarButton } from '@/components/sidebar-button';
 import styles from './style.module.css';
 import type { ComponentProps } from 'react';
 
@@ -28,21 +29,22 @@ export function SidebarNav() {
 			<ul className={ styles.list }>
 				{ items.map( ( item ) => (
 					<li key={ item.key }>
-						{ item.to ? (
-							<Link
-								to={ item.to }
-								className={ styles.item }
-								activeProps={ { className: clsx( styles.item, styles.itemActive ) } }
-							>
-								<Icon icon={ item.icon } size={ 16 } />
-								<span>{ item.label }</span>
-							</Link>
-						) : (
-							<button type="button" className={ styles.item }>
-								<Icon icon={ item.icon } size={ 16 } />
-								<span>{ item.label }</span>
-							</button>
-						) }
+						<SidebarButton
+							className={ styles.item }
+							render={
+								item.to ? (
+									<Link
+										to={ item.to }
+										activeProps={ {
+											className: clsx( styles.item, styles.itemActive ),
+										} }
+									/>
+								) : undefined
+							}
+						>
+							<Icon icon={ item.icon } size={ 16 } />
+							<span>{ item.label }</span>
+						</SidebarButton>
 					</li>
 				) ) }
 			</ul>

--- a/apps/ui/src/components/sidebar-nav/index.tsx
+++ b/apps/ui/src/components/sidebar-nav/index.tsx
@@ -1,0 +1,51 @@
+import { Link } from '@tanstack/react-router';
+import { __ } from '@wordpress/i18n';
+import { category, cog, comment } from '@wordpress/icons';
+import { Icon } from '@wordpress/ui';
+import { clsx } from 'clsx';
+import styles from './style.module.css';
+import type { ComponentProps } from 'react';
+
+type NavItem = {
+	key: string;
+	label: string;
+	icon: ComponentProps< typeof Icon >[ 'icon' ];
+	to?: ComponentProps< typeof Link >[ 'to' ];
+};
+
+function getItems(): NavItem[] {
+	return [
+		{ key: 'chat', label: __( 'Chat' ), icon: comment, to: '/dashboard' },
+		{ key: 'settings', label: __( 'Settings' ), icon: cog },
+		{ key: 'skills', label: __( 'Skills' ), icon: category },
+	];
+}
+
+export function SidebarNav() {
+	const items = getItems();
+	return (
+		<nav className={ styles.root }>
+			<ul className={ styles.list }>
+				{ items.map( ( item ) => (
+					<li key={ item.key }>
+						{ item.to ? (
+							<Link
+								to={ item.to }
+								className={ styles.item }
+								activeProps={ { className: clsx( styles.item, styles.itemActive ) } }
+							>
+								<Icon icon={ item.icon } size={ 16 } />
+								<span>{ item.label }</span>
+							</Link>
+						) : (
+							<button type="button" className={ styles.item }>
+								<Icon icon={ item.icon } size={ 16 } />
+								<span>{ item.label }</span>
+							</button>
+						) }
+					</li>
+				) ) }
+			</ul>
+		</nav>
+	);
+}

--- a/apps/ui/src/components/sidebar-nav/style.module.css
+++ b/apps/ui/src/components/sidebar-nav/style.module.css
@@ -1,0 +1,44 @@
+.root {
+	padding: var(--wpds-dimension-padding-xs) var(--wpds-dimension-padding-xl)
+		calc(var(--wpds-dimension-padding-xl) + var(--wpds-dimension-padding-md));
+}
+
+.list {
+	list-style: none;
+	padding: 0;
+	margin: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+}
+
+.item {
+	display: flex;
+	align-items: center;
+	gap: var(--wpds-dimension-padding-sm);
+	width: 100%;
+	height: 26px;
+	padding: 0 var(--wpds-dimension-padding-sm);
+	background: transparent;
+	border: 0;
+	border-radius: var(--wpds-border-radius-sm);
+	color: var(--wpds-color-fg-content-neutral-weak);
+	font-size: var(--wpds-font-size-sm);
+	font-weight: var(--wpds-font-weight-regular);
+	font-family: inherit;
+	text-align: start;
+	text-decoration: none;
+	cursor: var(--wpds-cursor-control);
+}
+
+.item:hover,
+.item:focus-visible {
+	color: var(--wpds-color-fg-content-neutral);
+}
+
+.itemActive,
+.itemActive:hover {
+	background: var(--wpds-color-bg-interactive-neutral-weak-active);
+	color: var(--wpds-color-fg-content-neutral);
+	font-weight: var(--wpds-font-weight-medium);
+}

--- a/apps/ui/src/components/sidebar-nav/style.module.css
+++ b/apps/ui/src/components/sidebar-nav/style.module.css
@@ -13,22 +13,12 @@
 }
 
 .item {
-	display: flex;
-	align-items: center;
-	gap: var(--wpds-dimension-padding-sm);
 	width: 100%;
 	height: 26px;
 	padding: 0 var(--wpds-dimension-padding-sm);
-	background: transparent;
-	border: 0;
-	border-radius: var(--wpds-border-radius-sm);
 	color: var(--wpds-color-fg-content-neutral-weak);
 	font-size: var(--wpds-font-size-sm);
 	font-weight: var(--wpds-font-weight-regular);
-	font-family: inherit;
-	text-align: start;
-	text-decoration: none;
-	cursor: var(--wpds-cursor-control);
 }
 
 .item:hover,
@@ -38,7 +28,6 @@
 
 .itemActive,
 .itemActive:hover {
-	background: var(--wpds-color-bg-interactive-neutral-weak-active);
 	color: var(--wpds-color-fg-content-neutral);
 	font-weight: var(--wpds-font-weight-medium);
 }

--- a/apps/ui/src/components/sidebar-nav/style.module.css
+++ b/apps/ui/src/components/sidebar-nav/style.module.css
@@ -26,8 +26,7 @@
 	color: var(--wpds-color-fg-content-neutral);
 }
 
-.itemActive,
-.itemActive:hover {
+.itemActive {
 	color: var(--wpds-color-fg-content-neutral);
 	font-weight: var(--wpds-font-weight-medium);
 }

--- a/apps/ui/src/components/user-menu/index.tsx
+++ b/apps/ui/src/components/user-menu/index.tsx
@@ -1,7 +1,8 @@
 import { __ } from '@wordpress/i18n';
-import { Button, IconButton } from '@wordpress/ui';
+import { IconButton } from '@wordpress/ui';
 import { Gravatar } from '@/components/gravatar';
 import * as Menu from '@/components/menu';
+import { SidebarButton } from '@/components/sidebar-button';
 import { useConnector } from '@/data/core';
 import { useAuthUser, useLogin, useLogout } from '@/data/queries/use-auth-user';
 import { useColorScheme, useSaveColorScheme } from '@/data/queries/use-color-scheme';
@@ -38,15 +39,10 @@ export function UserMenu() {
 					<Menu.Root modal={ false }>
 						<Menu.Trigger
 							render={
-								<Button
-									variant="minimal"
-									tone="neutral"
-									size="small"
-									className={ styles.userTrigger }
-								>
+								<SidebarButton className={ styles.userTrigger }>
 									<Gravatar email={ user.email } isDark={ themeIsDark } />
 									<span className={ styles.userName }>{ user.displayName }</span>
-								</Button>
+								</SidebarButton>
 							}
 						/>
 						<Menu.Popup side="top" align="start" className={ styles.popup }>
@@ -67,15 +63,9 @@ export function UserMenu() {
 						</Menu.Popup>
 					</Menu.Root>
 				) : (
-					<Button
-						variant="minimal"
-						tone="neutral"
-						size="small"
-						className={ styles.loginButton }
-						onClick={ () => login.mutate() }
-					>
+					<SidebarButton className={ styles.loginButton } onClick={ () => login.mutate() }>
 						{ __( 'Log in with WordPress.com' ) }
-					</Button>
+					</SidebarButton>
 				) }
 				<Menu.Root modal={ false }>
 					<Menu.Trigger

--- a/apps/ui/src/components/user-menu/index.tsx
+++ b/apps/ui/src/components/user-menu/index.tsx
@@ -1,51 +1,18 @@
 import { __ } from '@wordpress/i18n';
 import { Button, IconButton } from '@wordpress/ui';
+import { Gravatar } from '@/components/gravatar';
 import * as Menu from '@/components/menu';
 import { useConnector } from '@/data/core';
 import { useAuthUser, useLogin, useLogout } from '@/data/queries/use-auth-user';
 import { useColorScheme, useSaveColorScheme } from '@/data/queries/use-color-scheme';
 import { usePrefersColorScheme } from '@/hooks/use-prefers-color-scheme';
+import { moonIcon, sunIcon } from '@/lib/icons';
 import styles from './style.module.css';
 import type { ColorScheme } from '@/data/core';
 
 const WPCOM_PROFILE_URL = 'https://wordpress.com/me';
 const DOCS_URL = 'https://developer.wordpress.com/docs/developer-tools/studio/';
 const REPORT_ISSUE_URL = 'https://github.com/Automattic/studio/issues/new/choose';
-
-const sunIcon = (
-	<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
-		<circle cx="12" cy="12" r="4" stroke="currentColor" strokeWidth="1.5" />
-		<path
-			d="M12 3v2M12 19v2M3 12h2M19 12h2M5.6 5.6l1.4 1.4M17 17l1.4 1.4M5.6 18.4L7 17M17 7l1.4-1.4"
-			stroke="currentColor"
-			strokeWidth="1.5"
-			strokeLinecap="round"
-		/>
-	</svg>
-);
-
-const moonIcon = (
-	<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
-		<path
-			d="M20 14.5A8 8 0 019.5 4a8 8 0 1010.5 10.5z"
-			stroke="currentColor"
-			strokeWidth="1.5"
-			strokeLinejoin="round"
-		/>
-	</svg>
-);
-
-const userIcon = (
-	<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
-		<circle cx="12" cy="8" r="3.5" stroke="currentColor" strokeWidth="1.5" />
-		<path
-			d="M5 20c0-3.5 3-6 7-6s7 2.5 7 6"
-			stroke="currentColor"
-			strokeWidth="1.5"
-			strokeLinecap="round"
-		/>
-	</svg>
-);
 
 export function UserMenu() {
 	const connector = useConnector();
@@ -77,7 +44,7 @@ export function UserMenu() {
 									size="small"
 									className={ styles.userTrigger }
 								>
-									<Button.Icon icon={ userIcon } size={ 16 } />
+									<Gravatar email={ user.email } isDark={ themeIsDark } />
 									<span className={ styles.userName }>{ user.displayName }</span>
 								</Button>
 							}
@@ -117,6 +84,7 @@ export function UserMenu() {
 								variant="minimal"
 								tone="neutral"
 								size="small"
+								className={ styles.themeToggle }
 								icon={ themeIsDark ? sunIcon : moonIcon }
 								label={ __( 'Appearance' ) }
 							/>

--- a/apps/ui/src/components/user-menu/style.module.css
+++ b/apps/ui/src/components/user-menu/style.module.css
@@ -23,10 +23,7 @@
 
 .userTrigger {
 	flex: 1;
-	justify-content: flex-start;
-	min-width: 0;
 	font-weight: var(--wpds-font-weight-regular);
-	gap: var(--wpds-dimension-padding-sm);
 }
 
 .userName {
@@ -38,7 +35,6 @@
 
 .loginButton {
 	flex: 1;
-	justify-content: flex-start;
 }
 
 .popup {

--- a/apps/ui/src/components/user-menu/style.module.css
+++ b/apps/ui/src/components/user-menu/style.module.css
@@ -1,5 +1,5 @@
 .root {
-	padding: var(--wpds-dimension-padding-sm) var(--wpds-dimension-padding-md)
+	padding: var(--wpds-dimension-padding-sm) var(--wpds-dimension-padding-xl)
 		var(--wpds-dimension-padding-lg);
 }
 
@@ -7,12 +7,18 @@
 	display: flex;
 	align-items: center;
 	gap: var(--wpds-dimension-padding-xs);
-	opacity: 0.65;
 }
 
-.row:hover,
-.row:focus-within {
-	opacity: 1;
+.userName,
+.themeToggle {
+	color: var(--wpds-color-fg-content-neutral-weak);
+}
+
+.row:hover .userName,
+.row:hover .themeToggle,
+.row:focus-within .userName,
+.row:focus-within .themeToggle {
+	color: var(--wpds-color-fg-content-neutral);
 }
 
 .userTrigger {
@@ -20,6 +26,7 @@
 	justify-content: flex-start;
 	min-width: 0;
 	font-weight: var(--wpds-font-weight-regular);
+	gap: var(--wpds-dimension-padding-sm);
 }
 
 .userName {

--- a/apps/ui/src/index.css
+++ b/apps/ui/src/index.css
@@ -28,16 +28,20 @@ input,
 }
 
 /* Show the focus ring only on keyboard focus, overriding @wordpress/ui's
-   :focus-based outline. Unlayered CSS wins over WP UI's cascade layers. */
+   :focus-based outline. Unlayered CSS wins over WP UI's cascade layers.
+   `a` covers Button primitives rendered as links via its `render` prop. */
 button:focus:not(:focus-visible),
+a:focus:not(:focus-visible),
 [role="button"]:focus:not(:focus-visible) {
 	outline: none;
 }
 
 /* Default icons inside buttons and menu items to 75% scale — WP UI's Icon
    primitive draws at 16px, which reads a bit large for dense sidebars and
-   menus. Scope is tight enough to leave content/illustration SVGs alone. */
+   menus. `a svg` covers Button primitives rendered as links via their
+   `render` prop. */
 button svg,
+a svg,
 [role^="menuitem"] svg {
 	transform: scale(0.75);
 }

--- a/apps/ui/src/lib/format-relative-time.ts
+++ b/apps/ui/src/lib/format-relative-time.ts
@@ -1,0 +1,43 @@
+import { __, _n, sprintf } from '@wordpress/i18n';
+
+const MINUTE = 60_000;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+
+export function formatRelativeTime( iso: string ): string {
+	const now = Date.now();
+	const then = Date.parse( iso );
+	if ( Number.isNaN( then ) ) {
+		return '';
+	}
+	const diff = Math.max( 0, now - then );
+
+	if ( diff < MINUTE ) {
+		return __( 'just now' );
+	}
+	if ( diff < HOUR ) {
+		const minutes = Math.floor( diff / MINUTE );
+		return sprintf(
+			/* translators: %d: minutes */
+			_n( '%dm ago', '%dm ago', minutes ),
+			minutes
+		);
+	}
+	if ( diff < DAY ) {
+		const hours = Math.floor( diff / HOUR );
+		return sprintf(
+			/* translators: %d: hours */
+			_n( '%dh ago', '%dh ago', hours ),
+			hours
+		);
+	}
+	if ( diff < 2 * DAY ) {
+		return __( 'yesterday' );
+	}
+	const days = Math.floor( diff / DAY );
+	return sprintf(
+		/* translators: %d: days */
+		_n( '%d day ago', '%d days ago', days ),
+		days
+	);
+}

--- a/apps/ui/src/lib/icons.tsx
+++ b/apps/ui/src/lib/icons.tsx
@@ -1,0 +1,29 @@
+export const drawerIcon = (
+	<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+		<rect x="4" y="5" width="16" height="14" rx="1.5" stroke="currentColor" strokeWidth="1.5" />
+		<line x1="9.5" y1="5" x2="9.5" y2="19" stroke="currentColor" strokeWidth="1.5" />
+	</svg>
+);
+
+export const sunIcon = (
+	<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+		<circle cx="12" cy="12" r="4" stroke="currentColor" strokeWidth="1.5" />
+		<path
+			d="M12 3v2M12 19v2M3 12h2M19 12h2M5.6 5.6l1.4 1.4M17 17l1.4 1.4M5.6 18.4L7 17M17 7l1.4-1.4"
+			stroke="currentColor"
+			strokeWidth="1.5"
+			strokeLinecap="round"
+		/>
+	</svg>
+);
+
+export const moonIcon = (
+	<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+		<path
+			d="M20 14.5A8 8 0 019.5 4a8 8 0 1010.5 10.5z"
+			stroke="currentColor"
+			strokeWidth="1.5"
+			strokeLinejoin="round"
+		/>
+	</svg>
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1072,6 +1072,7 @@
 				"@wordpress/react-i18n": "^4.41.0",
 				"@wordpress/theme": "0.10.0",
 				"@wordpress/ui": "0.10.0",
+				"clsx": "^2.1.1",
 				"react": "^18.2.0",
 				"react-dom": "^18.2.0"
 			},


### PR DESCRIPTION
## Related issues

- Related to the apps/ui sidebar design pass.

## How AI was used in this PR

Built interactively via Claude Code against a supplied design mock, iterating on spacing, colors, indent, active-state styling, and component extraction until the sidebar matched the target. Verified with `npm run typecheck` and `vite build`; the user confirmed visual correctness screenshot-by-screenshot in Electron. Two bugs I would have missed without the user: the `opacity` trick on the user-menu row was fading the Gravatar image, and the session `sessionTime` was getting its opacity bumped on hover/active (user wanted it always dim).

## Proposed Changes

- **Sidebar navigation** — new `SidebarNav` with Chat / Settings / Skills. Chat links to `/dashboard`; the two others are placeholders until routes exist.
- **Project list** — derived expansion state (MRU or active-session's project is open by default, user toggles override). Project header now shows a dimmed domain under the site name; only the active project's `…` / `+` row actions stay visible. Session rows get a relative-time column and a thin left bar on the active row.
- **User menu** — generic user icon replaced by a real `<Gravatar>` resolved from `sha256(email.toLowerCase())` with the Studio profile icons as fallback. Dimming is now color-based (`fg-content-neutral-weak` on text/icon only), so the Gravatar image isn't faded.
- **Layout** — sidebar 260 → 320 px, horizontal gutter doubled (`md` → `xl`), right border added, extra breathing room between nav and project list.
- **Cleanup / extractions** — added `clsx` as a direct dep and switched class concatenations to it; extracted `components/gravatar`, `lib/format-relative-time.ts`, and `lib/icons.tsx` (also removes a duplicated `drawerIcon` literal between sidebar-header and sidebar-layout).

## Testing Instructions

- Start the Electron app (`npm run start:new`) while signed in to Wordpress.com. Confirm:
  - Top-left shows **Studio** + `+` + collapse toggle, aligned past the macOS traffic lights.
  - **Chat** nav is active when on `/dashboard` or a session route; Settings and Skills render as dim inert rows.
  - The most-recently-used project (or the one containing the active session) is expanded on launch. Clicking another project's title toggles it open/closed; clicking the domain line does *not* toggle (it is outside the button).
  - Active session row shows a 1px left bar aligned with the project title's left edge, darker label, no background fill.
  - Bottom-left shows a Gravatar for your wpcom email + display name + theme toggle; hovering the row brightens the text/icon but not the avatar.
- Collapse / re-open the sidebar using the drawer icon — the floating toggle in the main area should keep its position in both normal and macOS-fullscreen modes.
- Switch between light and dark color schemes from the theme menu — Gravatar fallback image should swap (light uses `profile-icon.png`, dark uses `profile-icon-black.png`).

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors? (`npm run typecheck` clean; `vite build` clean.)
- [ ] Cross-platform manual QA (macOS verified by author; please spot-check Windows traffic-light padding / fullscreen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)