### PR TITLE
apps/ui: render session conversation view in the main area

### DIFF
--- a/apps/cli/ai/sessions/replay.ts
+++ b/apps/cli/ai/sessions/replay.ts
@@ -1,3 +1,7 @@
+import {
+	filterEventsAfterLastClear,
+	isVisibleUserMessage,
+} from '@studio/common/ai/sessions/filter-events';
 import { AiChatUI } from 'cli/ai/ui';
 import type { SDKMessage } from '@anthropic-ai/claude-agent-sdk';
 import type { AiSessionEvent } from '@studio/common/ai/sessions/types';
@@ -6,14 +10,7 @@ export function replaySessionHistory( ui: AiChatUI, events: AiSessionEvent[] ): 
 	ui.prepareForReplay();
 	let isTurnOpen = false;
 
-	let lastClearedIndex = -1;
-	for ( let i = events.length - 1; i >= 0; i-- ) {
-		if ( events[ i ].type === 'session.cleared' ) {
-			lastClearedIndex = i;
-			break;
-		}
-	}
-	const eventsToReplay = lastClearedIndex >= 0 ? events.slice( lastClearedIndex + 1 ) : events;
+	const eventsToReplay = filterEventsAfterLastClear( events );
 
 	try {
 		for ( const event of eventsToReplay ) {
@@ -34,7 +31,7 @@ export function replaySessionHistory( ui: AiChatUI, events: AiSessionEvent[] ): 
 			}
 
 			if ( event.type === 'user.message' ) {
-				if ( event.source === 'ask_user' ) {
+				if ( ! isVisibleUserMessage( event ) ) {
 					continue;
 				}
 

--- a/apps/cli/ai/ui.ts
+++ b/apps/cli/ai/ui.ts
@@ -22,6 +22,7 @@ import {
 	truncateToWidth,
 	CURSOR_MARKER,
 } from '@mariozechner/pi-tui';
+import { getToolDetail, getToolDisplayName } from '@studio/common/ai/tools';
 import chalk from '@studio/common/lib/chalk';
 import { readAuthToken } from '@studio/common/lib/shared-config';
 import { __, _n, sprintf } from '@wordpress/i18n';
@@ -234,89 +235,13 @@ const editorTheme: EditorTheme = {
 	},
 };
 
-const toolDisplayNames: Record< string, string > = {
-	mcp__studio__site_create: __( 'Create site' ),
-	mcp__studio__site_list: __( 'List sites' ),
-	mcp__studio__site_info: __( 'Get site info' ),
-	mcp__studio__site_start: __( 'Start site' ),
-	mcp__studio__site_stop: __( 'Stop site' ),
-	mcp__studio__site_delete: __( 'Delete site' ),
-	mcp__studio__preview_create: __( 'Create preview' ),
-	mcp__studio__preview_list: __( 'List previews' ),
-	mcp__studio__preview_update: __( 'Update preview' ),
-	mcp__studio__preview_delete: __( 'Delete preview' ),
-	mcp__studio__wp_cli: __( 'Run WP-CLI' ),
-	mcp__studio__validate_blocks: __( 'Validate blocks' ),
-	mcp__studio__take_screenshot: __( 'Take screenshot' ),
-	Read: __( 'Read' ),
-	Write: __( 'Write' ),
-	Edit: __( 'Edit' ),
-	Bash: __( 'Run' ),
-	Glob: __( 'Search' ),
-	Grep: __( 'Search' ),
-	Skill: __( 'Load skill' ),
-	Task: __( 'Run task' ),
-	TodoWrite: __( 'Update todo list' ),
-};
-
-function getToolDetail( name: string, input: Record< string, unknown > ): string {
-	switch ( name ) {
-		case 'mcp__studio__site_create':
-			return typeof input.name === 'string' ? input.name : '';
-		case 'mcp__studio__site_info':
-		case 'mcp__studio__site_start':
-		case 'mcp__studio__site_stop':
-		case 'mcp__studio__site_delete':
-		case 'mcp__studio__preview_create':
-		case 'mcp__studio__preview_list':
-			return typeof input.nameOrPath === 'string' ? input.nameOrPath : '';
-		case 'mcp__studio__preview_update':
-		case 'mcp__studio__preview_delete':
-			return typeof input.host === 'string' ? input.host : '';
-		case 'mcp__studio__wp_cli':
-			return typeof input.command === 'string' ? `wp ${ input.command }` : '';
-		case 'mcp__studio__validate_blocks':
-			if ( typeof input.filePath === 'string' ) {
-				return input.filePath.split( '/' ).slice( -2 ).join( '/' );
-			}
-			return __( 'inline content' );
-		case 'mcp__studio__take_screenshot':
-			return typeof input.url === 'string' ? input.url : '';
-		case 'Read':
-		case 'Write':
-		case 'Edit': {
-			const filePath = input.file_path ?? input.path;
-			if ( typeof filePath === 'string' ) {
-				const parts = filePath.split( '/' );
-				return parts.slice( -2 ).join( '/' );
-			}
-			return '';
-		}
-		case 'Bash':
-			return typeof input.command === 'string'
-				? input.command.length > 60
-					? input.command.slice( 0, 57 ) + '…'
-					: input.command
-				: '';
-		case 'Skill':
-			return typeof input.skill === 'string' ? input.skill : '';
-		case 'Grep':
-		case 'Glob':
-			return typeof input.pattern === 'string' ? input.pattern : '';
-		default:
-			return '';
-	}
-}
-
 function formatToolName( name: string, input?: Record< string, unknown > ): string {
-	const displayName = toolDisplayNames[ name ] ?? name;
-	if ( input ) {
-		const detail = getToolDetail( name, input );
-		if ( detail ) {
-			return chalk.bold( displayName ) + ' ' + chalk.dim( '(' + detail + ')' );
-		}
+	const displayName = chalk.bold( getToolDisplayName( name ) );
+	const detail = getToolDetail( name, input );
+	if ( detail ) {
+		return displayName + ' ' + chalk.dim( '(' + detail + ')' );
 	}
-	return chalk.bold( displayName );
+	return displayName;
 }
 
 interface ToolUseResultContent {

--- a/apps/ui/package.json
+++ b/apps/ui/package.json
@@ -24,7 +24,9 @@
 		"@wordpress/ui": "0.10.0",
 		"clsx": "^2.1.1",
 		"react": "^18.2.0",
-		"react-dom": "^18.2.0"
+		"react-dom": "^18.2.0",
+		"react-markdown": "^10.1.0",
+		"remark-gfm": "^4.0.1"
 	},
 	"devDependencies": {
 		"@types/react": "^18.3.27",

--- a/apps/ui/src/components/markdown/index.tsx
+++ b/apps/ui/src/components/markdown/index.tsx
@@ -1,9 +1,12 @@
+import { useMemo } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import { useConnector } from '@/data/core';
 import styles from './style.module.css';
 import type { Components } from 'react-markdown';
+import type { MouseEvent } from 'react';
 
-const components: Components = {
+const baseComponents: Components = {
 	h1: ( { children } ) => <h1 className={ styles.h1 }>{ children }</h1>,
 	h2: ( { children } ) => <h2 className={ styles.h2 }>{ children }</h2>,
 	h3: ( { children } ) => <h3 className={ styles.h3 }>{ children }</h3>,
@@ -12,11 +15,6 @@ const components: Components = {
 	ul: ( { children } ) => <ul className={ styles.ul }>{ children }</ul>,
 	ol: ( { children } ) => <ol className={ styles.ol }>{ children }</ol>,
 	li: ( { children } ) => <li className={ styles.li }>{ children }</li>,
-	a: ( { children, href } ) => (
-		<a className={ styles.a } href={ href } target="_blank" rel="noreferrer noopener">
-			{ children }
-		</a>
-	),
 	blockquote: ( { children } ) => (
 		<blockquote className={ styles.blockquote }>{ children }</blockquote>
 	),
@@ -48,6 +46,36 @@ const components: Components = {
 };
 
 export function Markdown( { children }: { children: string } ) {
+	const connector = useConnector();
+
+	const components = useMemo< Components >( () => {
+		return {
+			...baseComponents,
+			// Electron swallows plain `target="_blank"` navigations — route clicks
+			// through the connector so links open in the system browser.
+			a: ( { children: linkChildren, href } ) => {
+				const handleClick = ( event: MouseEvent< HTMLAnchorElement > ) => {
+					if ( ! href ) {
+						return;
+					}
+					event.preventDefault();
+					void connector.openExternalUrl( href );
+				};
+				return (
+					<a
+						className={ styles.a }
+						href={ href }
+						onClick={ handleClick }
+						target="_blank"
+						rel="noreferrer noopener"
+					>
+						{ linkChildren }
+					</a>
+				);
+			},
+		};
+	}, [ connector ] );
+
 	return (
 		<div className={ styles.root }>
 			<ReactMarkdown remarkPlugins={ [ remarkGfm ] } components={ components }>

--- a/apps/ui/src/components/markdown/index.tsx
+++ b/apps/ui/src/components/markdown/index.tsx
@@ -1,0 +1,58 @@
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import styles from './style.module.css';
+import type { Components } from 'react-markdown';
+
+const components: Components = {
+	h1: ( { children } ) => <h1 className={ styles.h1 }>{ children }</h1>,
+	h2: ( { children } ) => <h2 className={ styles.h2 }>{ children }</h2>,
+	h3: ( { children } ) => <h3 className={ styles.h3 }>{ children }</h3>,
+	h4: ( { children } ) => <h4 className={ styles.h4 }>{ children }</h4>,
+	p: ( { children } ) => <p className={ styles.p }>{ children }</p>,
+	ul: ( { children } ) => <ul className={ styles.ul }>{ children }</ul>,
+	ol: ( { children } ) => <ol className={ styles.ol }>{ children }</ol>,
+	li: ( { children } ) => <li className={ styles.li }>{ children }</li>,
+	a: ( { children, href } ) => (
+		<a className={ styles.a } href={ href } target="_blank" rel="noreferrer noopener">
+			{ children }
+		</a>
+	),
+	blockquote: ( { children } ) => (
+		<blockquote className={ styles.blockquote }>{ children }</blockquote>
+	),
+	hr: () => <hr className={ styles.hr } />,
+	table: ( { children } ) => (
+		<div className={ styles.tableWrap }>
+			<table className={ styles.table }>{ children }</table>
+		</div>
+	),
+	th: ( { children } ) => <th className={ styles.th }>{ children }</th>,
+	td: ( { children } ) => <td className={ styles.td }>{ children }</td>,
+	code: ( { className, children, ...props } ) => {
+		// Inline code: no language class, no embedded newline.
+		const isInline = ! className && ! String( children ).includes( '\n' );
+		if ( isInline ) {
+			return (
+				<code className={ styles.codeInline } { ...props }>
+					{ children }
+				</code>
+			);
+		}
+		return (
+			<code className={ className } { ...props }>
+				{ children }
+			</code>
+		);
+	},
+	pre: ( { children } ) => <pre className={ styles.pre }>{ children }</pre>,
+};
+
+export function Markdown( { children }: { children: string } ) {
+	return (
+		<div className={ styles.root }>
+			<ReactMarkdown remarkPlugins={ [ remarkGfm ] } components={ components }>
+				{ children }
+			</ReactMarkdown>
+		</div>
+	);
+}

--- a/apps/ui/src/components/markdown/style.module.css
+++ b/apps/ui/src/components/markdown/style.module.css
@@ -1,0 +1,198 @@
+.root {
+	color: var(--wpds-color-fg-content-neutral);
+	font-size: var(--wpds-font-size-md);
+	line-height: 1.65;
+	/* Subtle opentype improvements — lining numerals in tables, contextual
+	   alternates in prose. Falls back silently on fonts that don't support them. */
+	font-feature-settings: "ss01", "cv11";
+}
+
+.root > *:first-child {
+	margin-top: 0;
+}
+
+.root > *:last-child {
+	margin-bottom: 0;
+}
+
+/* All spacing is em-based so blocks scale in proportion to the content size. */
+
+.p {
+	margin: 0 0 1em;
+}
+
+.h1,
+.h2,
+.h3,
+.h4 {
+	/* Headings introduce new sections: generous space above, tight space below
+	   so the heading feels coupled to the content it titles. */
+	margin: 1.8em 0 0.5em;
+	font-weight: 500;
+	line-height: 1.25;
+	letter-spacing: -0.01em;
+	color: var(--wpds-color-fg-content-neutral);
+}
+
+.h1 {
+	font-size: 1.5em;
+}
+
+.h2 {
+	font-size: 1.25em;
+}
+
+.h3 {
+	font-size: 1.1em;
+}
+
+.h4 {
+	font-size: 0.85em;
+	font-weight: 500;
+	letter-spacing: 0.06em;
+	text-transform: uppercase;
+	color: var(--wpds-color-fg-content-neutral-weak);
+}
+
+/* Tighten coupling when a heading immediately follows another heading. */
+.h1 + .h2,
+.h2 + .h3,
+.h3 + .h4 {
+	margin-top: 0.6em;
+}
+
+.ul,
+.ol {
+	margin: 0 0 1em;
+	padding-left: 1.5em;
+}
+
+.ul {
+	list-style-type: disc;
+}
+
+.ol {
+	list-style-type: decimal;
+}
+
+.li {
+	margin: 0.25em 0;
+}
+
+.li::marker {
+	color: var(--wpds-color-fg-content-neutral-weak);
+}
+
+.li > .p {
+	margin: 0;
+}
+
+.li > .p + .p {
+	margin-top: 0.5em;
+}
+
+.li > .ul,
+.li > .ol {
+	margin: 0.25em 0 0;
+}
+
+.a {
+	color: var(--wpds-color-fg-content-accent, #2563eb);
+	font-weight: 500;
+	text-decoration: underline;
+	text-decoration-thickness: 1px;
+	text-decoration-color: color-mix(in srgb, currentColor 35%, transparent);
+	text-underline-offset: 3px;
+}
+
+/* Unify all "bolded" emphasis at 500 for a lighter, more refined feel than
+   the browser default of 700. */
+.root strong,
+.root b {
+	font-weight: 500;
+}
+
+.a:hover,
+.a:focus-visible {
+	text-decoration-color: currentColor;
+}
+
+.blockquote {
+	margin: 0 0 1em;
+	padding: 0.25em 0 0.25em 1em;
+	border-left: 2px solid var(--wpds-color-stroke-surface-neutral);
+	color: var(--wpds-color-fg-content-neutral-weak);
+}
+
+.blockquote > *:last-child {
+	margin-bottom: 0;
+}
+
+.hr {
+	margin: 2em 0;
+	border: 0;
+	border-top: 1px solid var(--wpds-color-stroke-surface-neutral);
+}
+
+.codeInline {
+	padding: 0.1em 0.35em;
+	border-radius: 4px;
+	background-color: var(--wpds-color-bg-surface-neutral-weak);
+	font-family: var(--wpds-font-family-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+	font-size: 0.875em;
+	color: var(--wpds-color-fg-content-neutral);
+	/* Discourage code from breaking awkwardly across lines. */
+	white-space: nowrap;
+}
+
+.pre {
+	margin: 0.75em 0 1.25em;
+	padding: 0.875em 1em;
+	border-radius: var(--wpds-border-radius-md, 8px);
+	background-color: var(--wpds-color-bg-surface-neutral-weak);
+	font-family: var(--wpds-font-family-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+	font-size: 0.85em;
+	line-height: 1.55;
+	overflow-x: auto;
+}
+
+.pre > code {
+	background: none;
+	padding: 0;
+	border-radius: 0;
+	font-size: inherit;
+	color: inherit;
+	white-space: pre;
+}
+
+.tableWrap {
+	margin: 0 0 1em;
+	overflow-x: auto;
+	border: 1px solid var(--wpds-color-stroke-surface-neutral);
+	border-radius: var(--wpds-border-radius-md, 8px);
+}
+
+.table {
+	width: 100%;
+	border-collapse: collapse;
+	font-size: 0.9em;
+}
+
+.th,
+.td {
+	padding: 0.5em 0.75em;
+	border-bottom: 1px solid var(--wpds-color-stroke-surface-neutral);
+	text-align: left;
+	vertical-align: top;
+}
+
+.table tr:last-child .td,
+.table tr:last-child .th {
+	border-bottom: 0;
+}
+
+.th {
+	font-weight: 500;
+	color: var(--wpds-color-fg-content-neutral);
+	background-color: var(--wpds-color-bg-surface-neutral-weak);
+}

--- a/apps/ui/src/components/session-view/index.tsx
+++ b/apps/ui/src/components/session-view/index.tsx
@@ -1,3 +1,6 @@
+import { isAssistantSdkMessage, isTextBlock, isToolUseBlock } from '@studio/common/ai/sdk-messages';
+import { filterEventsAfterLastClear } from '@studio/common/ai/sessions/filter-events';
+import { getToolDetail, getToolDisplayName } from '@studio/common/ai/tools';
 import { __ } from '@wordpress/i18n';
 import { useEffect, useLayoutEffect, useMemo, useRef } from 'react';
 import { Markdown } from '@/components/markdown';
@@ -6,20 +9,6 @@ import { useFullscreen } from '@/hooks/use-fullscreen';
 import { useSidebarCollapsed } from '@/hooks/use-sidebar-collapsed';
 import styles from './style.module.css';
 import type { AiSessionEvent, AiSessionSummary, LoadedAiSession } from '@/data/core';
-
-type TextBlock = { type: 'text'; text: string };
-type ToolUseBlock = {
-	type: 'tool_use';
-	id: string;
-	name: string;
-	input?: Record< string, unknown >;
-};
-type ContentBlock = TextBlock | ToolUseBlock | { type: string };
-
-type AssistantSdkMessage = {
-	type: 'assistant';
-	message: { content: ContentBlock[] };
-};
 
 type RenderItem =
 	| { kind: 'user-text'; key: string; text: string }
@@ -33,89 +22,8 @@ type RenderItem =
 			options: Array< { label: string; description: string } >;
 	  };
 
-const TOOL_DISPLAY_NAMES: Record< string, string > = {
-	mcp__studio__site_create: 'create site',
-	mcp__studio__site_list: 'list sites',
-	mcp__studio__site_info: 'site info',
-	mcp__studio__site_start: 'start site',
-	mcp__studio__site_stop: 'stop site',
-	mcp__studio__site_delete: 'delete site',
-	mcp__studio__wp_cli: 'wp',
-	mcp__studio__take_screenshot: 'screenshot',
-	mcp__studio__validate_blocks: 'validate',
-	Read: 'read',
-	Write: 'write',
-	Edit: 'edit',
-	Bash: 'run',
-	Glob: 'search',
-	Grep: 'search',
-	Skill: 'skill',
-	Task: 'task',
-	TodoWrite: 'todos',
-	WebFetch: 'fetch',
-	WebSearch: 'search',
-};
-
-function getToolDisplayName( name: string ): string {
-	return TOOL_DISPLAY_NAMES[ name ] ?? name;
-}
-
-function getToolDetail( name: string, input?: Record< string, unknown > ): string {
-	if ( ! input ) {
-		return '';
-	}
-	switch ( name ) {
-		case 'Read':
-		case 'Write':
-		case 'Edit': {
-			const filePath = input.file_path ?? input.path;
-			if ( typeof filePath === 'string' ) {
-				return filePath.split( '/' ).slice( -2 ).join( '/' );
-			}
-			return '';
-		}
-		case 'Bash':
-			return typeof input.command === 'string' ? input.command : '';
-		case 'Grep':
-		case 'Glob':
-			return typeof input.pattern === 'string' ? input.pattern : '';
-		case 'Skill':
-			return typeof input.skill === 'string' ? input.skill : '';
-		case 'mcp__studio__wp_cli':
-			return typeof input.command === 'string' ? input.command : '';
-		case 'mcp__studio__site_info':
-		case 'mcp__studio__site_start':
-		case 'mcp__studio__site_stop':
-		case 'mcp__studio__site_delete':
-			return typeof input.nameOrPath === 'string' ? input.nameOrPath : '';
-		default:
-			return '';
-	}
-}
-
-function isAssistantSdkMessage( value: unknown ): value is AssistantSdkMessage {
-	if ( ! value || typeof value !== 'object' ) {
-		return false;
-	}
-	const outer = value as { type?: unknown; message?: unknown };
-	if ( outer.type !== 'assistant' ) {
-		return false;
-	}
-	const inner = outer.message as { content?: unknown } | undefined;
-	return !! inner && Array.isArray( inner.content );
-}
-
 function eventsToRenderItems( events: AiSessionEvent[] ): RenderItem[] {
-	// Honor session.cleared by dropping anything emitted before the last clear.
-	let lastClearedIndex = -1;
-	for ( let i = events.length - 1; i >= 0; i-- ) {
-		if ( events[ i ].type === 'session.cleared' ) {
-			lastClearedIndex = i;
-			break;
-		}
-	}
-	const relevant = lastClearedIndex >= 0 ? events.slice( lastClearedIndex + 1 ) : events;
-
+	const relevant = filterEventsAfterLastClear( events );
 	const items: RenderItem[] = [];
 
 	relevant.forEach( ( event, eventIndex ) => {
@@ -135,10 +43,9 @@ function eventsToRenderItems( events: AiSessionEvent[] ): RenderItem[] {
 				if ( ! isAssistantSdkMessage( event.message ) ) {
 					return;
 				}
-				const content = event.message.message.content;
-				content.forEach( ( block, blockIndex ) => {
-					if ( block.type === 'text' ) {
-						const text = ( block as TextBlock ).text?.trim();
+				event.message.message.content.forEach( ( block, blockIndex ) => {
+					if ( isTextBlock( block ) ) {
+						const text = block.text.trim();
 						if ( text ) {
 							items.push( {
 								kind: 'assistant-text',
@@ -146,13 +53,12 @@ function eventsToRenderItems( events: AiSessionEvent[] ): RenderItem[] {
 								text,
 							} );
 						}
-					} else if ( block.type === 'tool_use' ) {
-						const use = block as ToolUseBlock;
+					} else if ( isToolUseBlock( block ) ) {
 						items.push( {
 							kind: 'tool-use',
 							key: `${ eventIndex }:${ blockIndex }:tool`,
-							name: use.name,
-							input: use.input,
+							name: block.name,
+							input: block.input,
 						} );
 					}
 				} );

--- a/apps/ui/src/components/session-view/index.tsx
+++ b/apps/ui/src/components/session-view/index.tsx
@@ -2,7 +2,7 @@ import { isAssistantSdkMessage, isTextBlock, isToolUseBlock } from '@studio/comm
 import { filterEventsAfterLastClear } from '@studio/common/ai/sessions/filter-events';
 import { getToolDetail, getToolDisplayName } from '@studio/common/ai/tools';
 import { __ } from '@wordpress/i18n';
-import { useEffect, useLayoutEffect, useMemo, useRef } from 'react';
+import { useLayoutEffect, useMemo, useRef } from 'react';
 import { Markdown } from '@/components/markdown';
 import { useSession } from '@/data/queries/use-sessions';
 import { useFullscreen } from '@/hooks/use-fullscreen';
@@ -126,11 +126,7 @@ function UserTurn( { text }: { text: string } ) {
 }
 
 function AssistantText( { text }: { text: string } ) {
-	return (
-		<div className={ styles.turn }>
-			<Markdown>{ text }</Markdown>
-		</div>
-	);
+	return <Markdown>{ text }</Markdown>;
 }
 
 function ToolUseRow( { name, input }: { name: string; input?: Record< string, unknown > } ) {
@@ -219,23 +215,15 @@ export function SessionView( { sessionId }: { sessionId: string } ) {
 	const { data, isLoading, error } = useSession( sessionId );
 	const scrollRef = useRef< HTMLDivElement >( null );
 
-	// Jump to the bottom on first render for this session, before paint so the
-	// scroll lands on the latest message without a visible flash.
+	// Jump to the bottom when the session opens or changes. Run synchronously
+	// before paint to avoid a flash at the top, and re-pin after the next
+	// frame to catch late layout shifts (markdown finishing, fonts settling).
 	useLayoutEffect( () => {
-		const node = scrollRef.current;
-		if ( node ) {
-			node.scrollTop = node.scrollHeight;
-		}
-	}, [ sessionId, data ] );
-
-	// Scrollable content can also grow after the initial paint (e.g. markdown
-	// finishing render, images loading). Re-pin to the bottom briefly after
-	// mount so those late layout shifts don't leave the user mid-scroll.
-	useEffect( () => {
 		const node = scrollRef.current;
 		if ( ! node ) {
 			return;
 		}
+		node.scrollTop = node.scrollHeight;
 		const id = requestAnimationFrame( () => {
 			node.scrollTop = node.scrollHeight;
 		} );

--- a/apps/ui/src/components/session-view/index.tsx
+++ b/apps/ui/src/components/session-view/index.tsx
@@ -1,0 +1,361 @@
+import { __ } from '@wordpress/i18n';
+import { useEffect, useLayoutEffect, useMemo, useRef } from 'react';
+import { Markdown } from '@/components/markdown';
+import { useSession } from '@/data/queries/use-sessions';
+import { useFullscreen } from '@/hooks/use-fullscreen';
+import { useSidebarCollapsed } from '@/hooks/use-sidebar-collapsed';
+import styles from './style.module.css';
+import type { AiSessionEvent, AiSessionSummary, LoadedAiSession } from '@/data/core';
+
+type TextBlock = { type: 'text'; text: string };
+type ToolUseBlock = {
+	type: 'tool_use';
+	id: string;
+	name: string;
+	input?: Record< string, unknown >;
+};
+type ContentBlock = TextBlock | ToolUseBlock | { type: string };
+
+type AssistantSdkMessage = {
+	type: 'assistant';
+	message: { content: ContentBlock[] };
+};
+
+type RenderItem =
+	| { kind: 'user-text'; key: string; text: string }
+	| { kind: 'assistant-text'; key: string; text: string }
+	| { kind: 'tool-use'; key: string; name: string; input?: Record< string, unknown > }
+	| { kind: 'tool-progress'; key: string; message: string }
+	| {
+			kind: 'agent-question';
+			key: string;
+			question: string;
+			options: Array< { label: string; description: string } >;
+	  };
+
+const TOOL_DISPLAY_NAMES: Record< string, string > = {
+	mcp__studio__site_create: 'create site',
+	mcp__studio__site_list: 'list sites',
+	mcp__studio__site_info: 'site info',
+	mcp__studio__site_start: 'start site',
+	mcp__studio__site_stop: 'stop site',
+	mcp__studio__site_delete: 'delete site',
+	mcp__studio__wp_cli: 'wp',
+	mcp__studio__take_screenshot: 'screenshot',
+	mcp__studio__validate_blocks: 'validate',
+	Read: 'read',
+	Write: 'write',
+	Edit: 'edit',
+	Bash: 'run',
+	Glob: 'search',
+	Grep: 'search',
+	Skill: 'skill',
+	Task: 'task',
+	TodoWrite: 'todos',
+	WebFetch: 'fetch',
+	WebSearch: 'search',
+};
+
+function getToolDisplayName( name: string ): string {
+	return TOOL_DISPLAY_NAMES[ name ] ?? name;
+}
+
+function getToolDetail( name: string, input?: Record< string, unknown > ): string {
+	if ( ! input ) {
+		return '';
+	}
+	switch ( name ) {
+		case 'Read':
+		case 'Write':
+		case 'Edit': {
+			const filePath = input.file_path ?? input.path;
+			if ( typeof filePath === 'string' ) {
+				return filePath.split( '/' ).slice( -2 ).join( '/' );
+			}
+			return '';
+		}
+		case 'Bash':
+			return typeof input.command === 'string' ? input.command : '';
+		case 'Grep':
+		case 'Glob':
+			return typeof input.pattern === 'string' ? input.pattern : '';
+		case 'Skill':
+			return typeof input.skill === 'string' ? input.skill : '';
+		case 'mcp__studio__wp_cli':
+			return typeof input.command === 'string' ? input.command : '';
+		case 'mcp__studio__site_info':
+		case 'mcp__studio__site_start':
+		case 'mcp__studio__site_stop':
+		case 'mcp__studio__site_delete':
+			return typeof input.nameOrPath === 'string' ? input.nameOrPath : '';
+		default:
+			return '';
+	}
+}
+
+function isAssistantSdkMessage( value: unknown ): value is AssistantSdkMessage {
+	if ( ! value || typeof value !== 'object' ) {
+		return false;
+	}
+	const outer = value as { type?: unknown; message?: unknown };
+	if ( outer.type !== 'assistant' ) {
+		return false;
+	}
+	const inner = outer.message as { content?: unknown } | undefined;
+	return !! inner && Array.isArray( inner.content );
+}
+
+function eventsToRenderItems( events: AiSessionEvent[] ): RenderItem[] {
+	// Honor session.cleared by dropping anything emitted before the last clear.
+	let lastClearedIndex = -1;
+	for ( let i = events.length - 1; i >= 0; i-- ) {
+		if ( events[ i ].type === 'session.cleared' ) {
+			lastClearedIndex = i;
+			break;
+		}
+	}
+	const relevant = lastClearedIndex >= 0 ? events.slice( lastClearedIndex + 1 ) : events;
+
+	const items: RenderItem[] = [];
+
+	relevant.forEach( ( event, eventIndex ) => {
+		switch ( event.type ) {
+			case 'user.message': {
+				if ( event.source !== 'prompt' ) {
+					return;
+				}
+				items.push( {
+					kind: 'user-text',
+					key: `${ eventIndex }:user`,
+					text: event.text,
+				} );
+				return;
+			}
+			case 'sdk.message': {
+				if ( ! isAssistantSdkMessage( event.message ) ) {
+					return;
+				}
+				const content = event.message.message.content;
+				content.forEach( ( block, blockIndex ) => {
+					if ( block.type === 'text' ) {
+						const text = ( block as TextBlock ).text?.trim();
+						if ( text ) {
+							items.push( {
+								kind: 'assistant-text',
+								key: `${ eventIndex }:${ blockIndex }:text`,
+								text,
+							} );
+						}
+					} else if ( block.type === 'tool_use' ) {
+						const use = block as ToolUseBlock;
+						items.push( {
+							kind: 'tool-use',
+							key: `${ eventIndex }:${ blockIndex }:tool`,
+							name: use.name,
+							input: use.input,
+						} );
+					}
+				} );
+				return;
+			}
+			case 'tool.progress': {
+				items.push( {
+					kind: 'tool-progress',
+					key: `${ eventIndex }:progress`,
+					message: event.message,
+				} );
+				return;
+			}
+			case 'agent.question': {
+				items.push( {
+					kind: 'agent-question',
+					key: `${ eventIndex }:question`,
+					question: event.question,
+					options: event.options,
+				} );
+				return;
+			}
+			default:
+				return;
+		}
+	} );
+
+	return items;
+}
+
+function SessionHeader( { summary }: { summary: AiSessionSummary } ) {
+	const siteName = summary.ownerSiteName;
+	const sidebarCollapsed = useSidebarCollapsed();
+	const isFullscreen = useFullscreen();
+	if ( ! siteName ) {
+		return null;
+	}
+
+	// When the sidebar is collapsed the floating toggle button lives in the
+	// main area. Reserve a no-drag spacer at the left so the header's drag
+	// region doesn't sit under the button (Electron's drag-region stacking
+	// is unreliable when drag sits beneath a no-drag overlay).
+	const toggleSpacerClass = sidebarCollapsed
+		? isFullscreen
+			? styles.toggleSpacerFullscreen
+			: styles.toggleSpacer
+		: null;
+
+	return (
+		<div className={ styles.header }>
+			{ toggleSpacerClass ? <span className={ toggleSpacerClass } aria-hidden="true" /> : null }
+			<span className={ styles.headerSite }>{ siteName }</span>
+			<span className={ styles.headerDot } aria-hidden="true" />
+			<span className={ styles.headerEnv }>{ __( 'Local' ) }</span>
+		</div>
+	);
+}
+
+function UserTurn( { text }: { text: string } ) {
+	return (
+		<div className={ styles.userTurn }>
+			<div className={ styles.userText }>{ text }</div>
+		</div>
+	);
+}
+
+function AssistantText( { text }: { text: string } ) {
+	return (
+		<div className={ styles.turn }>
+			<Markdown>{ text }</Markdown>
+		</div>
+	);
+}
+
+function ToolUseRow( { name, input }: { name: string; input?: Record< string, unknown > } ) {
+	const label = getToolDisplayName( name );
+	const detail = getToolDetail( name, input );
+	return (
+		<div className={ styles.toolRow }>
+			<span className={ styles.toolLabel }>{ label }</span>
+			{ detail ? <span className={ styles.toolDetail }>{ detail }</span> : null }
+		</div>
+	);
+}
+
+function ToolProgressRow( { message }: { message: string } ) {
+	return (
+		<div className={ styles.toolRow }>
+			<span className={ styles.toolLabel }>{ __( 'working' ) }</span>
+			<span className={ styles.toolDetail }>{ message }</span>
+		</div>
+	);
+}
+
+function AgentQuestion( {
+	question,
+	options,
+}: {
+	question: string;
+	options: Array< { label: string; description: string } >;
+} ) {
+	return (
+		<div className={ styles.question }>
+			<p className={ styles.questionText }>{ question }</p>
+			{ options.length > 0 ? (
+				<ul className={ styles.questionOptions }>
+					{ options.map( ( option, index ) => (
+						<li key={ index }>
+							<button type="button" className={ styles.questionOption }>
+								{ option.label }
+							</button>
+						</li>
+					) ) }
+				</ul>
+			) : null }
+		</div>
+	);
+}
+
+function Conversation( { data }: { data: LoadedAiSession } ) {
+	const items = useMemo( () => eventsToRenderItems( data.events ), [ data.events ] );
+
+	return (
+		<div className={ styles.conversation }>
+			{ items.map( ( item ) => {
+				switch ( item.kind ) {
+					case 'user-text':
+						return <UserTurn key={ item.key } text={ item.text } />;
+					case 'assistant-text':
+						return <AssistantText key={ item.key } text={ item.text } />;
+					case 'tool-use':
+						return <ToolUseRow key={ item.key } name={ item.name } input={ item.input } />;
+					case 'tool-progress':
+						return <ToolProgressRow key={ item.key } message={ item.message } />;
+					case 'agent-question':
+						return (
+							<AgentQuestion key={ item.key } question={ item.question } options={ item.options } />
+						);
+					default:
+						return null;
+				}
+			} ) }
+		</div>
+	);
+}
+
+function Composer() {
+	return (
+		<div className={ styles.composer }>
+			<div className={ styles.composerInner }>
+				<div className={ styles.composerInput }>{ __( 'Set your next instruction…' ) }</div>
+			</div>
+		</div>
+	);
+}
+
+export function SessionView( { sessionId }: { sessionId: string } ) {
+	const { data, isLoading, error } = useSession( sessionId );
+	const scrollRef = useRef< HTMLDivElement >( null );
+
+	// Jump to the bottom on first render for this session, before paint so the
+	// scroll lands on the latest message without a visible flash.
+	useLayoutEffect( () => {
+		const node = scrollRef.current;
+		if ( node ) {
+			node.scrollTop = node.scrollHeight;
+		}
+	}, [ sessionId, data ] );
+
+	// Scrollable content can also grow after the initial paint (e.g. markdown
+	// finishing render, images loading). Re-pin to the bottom briefly after
+	// mount so those late layout shifts don't leave the user mid-scroll.
+	useEffect( () => {
+		const node = scrollRef.current;
+		if ( ! node ) {
+			return;
+		}
+		const id = requestAnimationFrame( () => {
+			node.scrollTop = node.scrollHeight;
+		} );
+		return () => cancelAnimationFrame( id );
+	}, [ sessionId, data ] );
+
+	if ( isLoading ) {
+		return <div className={ styles.state }>{ __( 'Loading session…' ) }</div>;
+	}
+
+	if ( error || ! data ) {
+		return (
+			<div className={ styles.state }>
+				<h1>{ __( 'Session not found' ) }</h1>
+				<p>{ sessionId }</p>
+			</div>
+		);
+	}
+
+	return (
+		<div className={ styles.root }>
+			<SessionHeader summary={ data.summary } />
+			<div ref={ scrollRef } className={ styles.scroll }>
+				<Conversation data={ data } />
+			</div>
+			<Composer />
+		</div>
+	);
+}

--- a/apps/ui/src/components/session-view/style.module.css
+++ b/apps/ui/src/components/session-view/style.module.css
@@ -1,0 +1,193 @@
+.root {
+	display: flex;
+	flex-direction: column;
+	height: 100%;
+	min-height: 0;
+}
+
+.state {
+	padding: var(--wpds-dimension-padding-xl);
+	color: var(--wpds-color-fg-content-neutral-weak);
+}
+
+.header {
+	display: flex;
+	align-items: center;
+	gap: var(--wpds-dimension-padding-sm);
+	padding: var(--wpds-dimension-padding-sm) var(--wpds-dimension-padding-2xl);
+	min-height: 46px;
+	font-size: var(--wpds-font-size-sm);
+	color: var(--wpds-color-fg-content-neutral);
+	-webkit-app-region: drag;
+}
+
+/* Spacers reserve a no-drag area at the header's left so the floating toggle
+   button (rendered by the sidebar layout) sits on top of no-drag pixels,
+   not on top of the header's drag region. Electron's drag-region stacking
+   is unreliable when drag sits beneath a no-drag overlay.
+   Non-fullscreen: 94px for macOS traffic lights + ~40px for the button.
+   Fullscreen: only the button needs clearance. */
+.toggleSpacer {
+	display: block;
+	flex-shrink: 0;
+	/* 94px traffic-light offset + 24px button, minus the header's extra left
+	   padding (xs). Flex gap on .header supplies the visible gap between
+	   the button and the title. */
+	width: calc(118px - var(--wpds-dimension-padding-xs));
+	height: 100%;
+	-webkit-app-region: no-drag;
+}
+
+.toggleSpacerFullscreen {
+	display: block;
+	flex-shrink: 0;
+	width: calc(var(--wpds-dimension-padding-md) + 24px - var(--wpds-dimension-padding-xs));
+	height: 100%;
+	-webkit-app-region: no-drag;
+}
+
+.headerSite {
+	font-weight: 600;
+}
+
+.headerDot {
+	width: 6px;
+	height: 6px;
+	border-radius: 50%;
+	background-color: var(--wpds-color-fg-content-success, #16a34a);
+	flex-shrink: 0;
+	/* Extra horizontal margin around the dot only — keeps the toggle-to-title
+	   gap at the header's base 8px while giving the site/dot/local grouping
+	   more breathing room. */
+	margin: 0 var(--wpds-dimension-padding-xs);
+}
+
+.headerEnv {
+	color: var(--wpds-color-fg-content-neutral-weak);
+}
+
+.scroll {
+	flex: 1;
+	min-height: 0;
+	overflow-y: auto;
+}
+
+.conversation {
+	max-width: 760px;
+	margin: 0 auto;
+	padding: var(--wpds-dimension-padding-xl) var(--wpds-dimension-padding-xl)
+		var(--wpds-dimension-padding-2xl);
+	display: flex;
+	flex-direction: column;
+	gap: var(--wpds-dimension-padding-lg);
+}
+
+.turn {
+	display: flex;
+	flex-direction: column;
+	gap: var(--wpds-dimension-padding-xs);
+}
+
+/* User bubbles act as turn anchors; give them generous breathing room above
+   and below so the user's prompt stands apart from the assistant response. */
+.userTurn {
+	display: flex;
+	flex-direction: column;
+	padding: var(--wpds-dimension-padding-xl) 0;
+}
+
+.userTurn:first-child {
+	padding-top: 0;
+}
+
+.userText {
+	align-self: flex-start;
+	padding: var(--wpds-dimension-padding-md) var(--wpds-dimension-padding-lg);
+	background-color: color-mix(in srgb, var(--wpds-color-fg-content-accent, #2563eb) 10%, transparent);
+	/* Keep the bottom-left tight so the bubble reads as originating from the
+	   speaker label above, and round the other corners generously. */
+	border-radius: 18px 18px 18px var(--wpds-border-radius-md, 8px);
+	max-width: 100%;
+	font-size: var(--wpds-font-size-md);
+	line-height: 1.55;
+	color: var(--wpds-color-fg-content-neutral);
+	white-space: pre-wrap;
+	word-wrap: break-word;
+}
+
+.toolRow {
+	display: grid;
+	grid-template-columns: 72px 1fr;
+	gap: var(--wpds-dimension-padding-md);
+	align-items: baseline;
+	font-family: var(--wpds-font-family-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+	font-size: var(--wpds-font-size-sm);
+	color: var(--wpds-color-fg-content-neutral-weak);
+	padding: 2px 0;
+}
+
+.toolLabel {
+	color: var(--wpds-color-fg-content-neutral-weak);
+	opacity: 0.7;
+}
+
+.toolDetail {
+	color: var(--wpds-color-fg-content-neutral);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.question {
+	display: flex;
+	flex-direction: column;
+	gap: var(--wpds-dimension-padding-sm);
+}
+
+.questionText {
+	margin: 0;
+	color: var(--wpds-color-fg-content-neutral);
+}
+
+.questionOptions {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+	display: flex;
+	flex-wrap: wrap;
+	gap: var(--wpds-dimension-padding-md);
+}
+
+.questionOption {
+	background: none;
+	border: none;
+	padding: 0;
+	color: var(--wpds-color-fg-content-accent, #2563eb);
+	font: inherit;
+	cursor: pointer;
+}
+
+.questionOption:hover,
+.questionOption:focus-visible {
+	text-decoration: underline;
+}
+
+.composer {
+	padding: 0 var(--wpds-dimension-padding-xl) var(--wpds-dimension-padding-xl);
+}
+
+.composerInner {
+	max-width: 760px;
+	margin: 0 auto;
+}
+
+.composerInput {
+	min-height: 88px;
+	padding: var(--wpds-dimension-padding-md);
+	border: 1px solid var(--wpds-color-stroke-surface-neutral);
+	border-radius: var(--wpds-border-radius-md, 8px);
+	background-color: var(--wpds-color-bg-surface-neutral-strong);
+	color: var(--wpds-color-fg-content-neutral-weak);
+	font-size: var(--wpds-font-size-md);
+	line-height: 1.5;
+}

--- a/apps/ui/src/components/session-view/style.module.css
+++ b/apps/ui/src/components/session-view/style.module.css
@@ -82,12 +82,6 @@
 	gap: var(--wpds-dimension-padding-lg);
 }
 
-.turn {
-	display: flex;
-	flex-direction: column;
-	gap: var(--wpds-dimension-padding-xs);
-}
-
 /* User bubbles act as turn anchors; give them generous breathing room above
    and below so the user's prompt stands apart from the assistant response. */
 .userTurn {

--- a/apps/ui/src/components/sidebar-header/style.module.css
+++ b/apps/ui/src/components/sidebar-header/style.module.css
@@ -5,9 +5,10 @@
 	/* Leave room for macOS traffic lights at {20, 20} plus a visible gap.
 	   min-height is tuned so the flex-centered content lines up with the
 	   vertical center of the traffic lights. */
-	padding: var(--wpds-dimension-padding-sm) var(--wpds-dimension-padding-xl)
+	padding: var(--wpds-dimension-padding-sm) var(--wpds-dimension-padding-2xl)
 		var(--wpds-dimension-padding-sm) 94px;
 	min-height: 46px;
+	-webkit-app-region: drag;
 }
 
 /* In macOS fullscreen the traffic lights are hidden, so reclaim the

--- a/apps/ui/src/components/sidebar-layout/index.tsx
+++ b/apps/ui/src/components/sidebar-layout/index.tsx
@@ -7,6 +7,7 @@ import { SidebarHeader } from '@/components/sidebar-header';
 import { SidebarNav } from '@/components/sidebar-nav';
 import { UserMenu } from '@/components/user-menu';
 import { useFullscreen } from '@/hooks/use-fullscreen';
+import { SidebarCollapsedContext } from '@/hooks/use-sidebar-collapsed';
 import { drawerIcon } from '@/lib/icons';
 import styles from './style.module.css';
 import type { ReactNode } from 'react';
@@ -16,35 +17,37 @@ export function SidebarLayout( { children }: { children: ReactNode } ) {
 	const isFullscreen = useFullscreen();
 
 	return (
-		<div className={ styles.root }>
-			<aside className={ clsx( styles.sidebar, collapsed && styles.sidebarCollapsed ) }>
-				<SidebarHeader onToggleSidebar={ () => setCollapsed( true ) } />
-				<div className={ styles.sidebarContent }>
-					<SidebarNav />
-					<ProjectList />
-				</div>
-				<UserMenu />
-			</aside>
-			<main className={ styles.main }>
-				{ collapsed ? (
-					<div
-						className={ clsx(
-							styles.floatingToggle,
-							isFullscreen && styles.floatingToggleFullscreen
-						) }
-					>
-						<IconButton
-							variant="minimal"
-							tone="neutral"
-							size="small"
-							icon={ drawerIcon }
-							label={ __( 'Show sidebar' ) }
-							onClick={ () => setCollapsed( false ) }
-						/>
+		<SidebarCollapsedContext.Provider value={ collapsed }>
+			<div className={ styles.root }>
+				<aside className={ clsx( styles.sidebar, collapsed && styles.sidebarCollapsed ) }>
+					<SidebarHeader onToggleSidebar={ () => setCollapsed( true ) } />
+					<div className={ styles.sidebarContent }>
+						<SidebarNav />
+						<ProjectList />
 					</div>
-				) : null }
-				{ children }
-			</main>
-		</div>
+					<UserMenu />
+				</aside>
+				<main className={ styles.main }>
+					{ collapsed ? (
+						<div
+							className={ clsx(
+								styles.floatingToggle,
+								isFullscreen && styles.floatingToggleFullscreen
+							) }
+						>
+							<IconButton
+								variant="minimal"
+								tone="neutral"
+								size="small"
+								icon={ drawerIcon }
+								label={ __( 'Show sidebar' ) }
+								onClick={ () => setCollapsed( false ) }
+							/>
+						</div>
+					) : null }
+					{ children }
+				</main>
+			</div>
+		</SidebarCollapsedContext.Provider>
 	);
 }

--- a/apps/ui/src/components/sidebar-layout/style.module.css
+++ b/apps/ui/src/components/sidebar-layout/style.module.css
@@ -41,7 +41,6 @@
 	padding: var(--wpds-dimension-padding-sm) 0;
 	min-height: 46px;
 	z-index: 10;
-	-webkit-app-region: no-drag;
 }
 
 /* In macOS fullscreen the traffic lights are hidden, so the toggle can

--- a/apps/ui/src/hooks/use-sidebar-collapsed.ts
+++ b/apps/ui/src/hooks/use-sidebar-collapsed.ts
@@ -1,0 +1,7 @@
+import { createContext, useContext } from 'react';
+
+export const SidebarCollapsedContext = createContext( false );
+
+export function useSidebarCollapsed(): boolean {
+	return useContext( SidebarCollapsedContext );
+}

--- a/apps/ui/src/index.css
+++ b/apps/ui/src/index.css
@@ -12,15 +12,17 @@ body {
 	background-color: var(--wpds-color-bg-surface-neutral-strong);
 	color: var(--wpds-color-fg-content-neutral);
 	color-scheme: light dark;
-	-webkit-app-region: drag;
 }
 
-/* Interactive elements opt out of the window drag region.
-   `[data-base-ui-portal] *` covers the @base-ui Menu portal subtree —
-   items render as divs, so we can't rely on the button/link selectors. */
+/* Interactive elements inside drag-region ancestors (title bars, section
+   headers) need to opt out so clicks and focus still land. Harmless where no
+   drag region is active. `[data-base-ui-portal] *` covers the @base-ui Menu
+   portal subtree — items render as divs, so we can't rely on the
+   button/link selectors. */
 button,
 a,
 input,
+textarea,
 [role="button"],
 [data-base-ui-portal],
 [data-base-ui-portal] * {

--- a/apps/ui/src/router/sessions.tsx
+++ b/apps/ui/src/router/sessions.tsx
@@ -1,40 +1,10 @@
 import { createRoute } from '@tanstack/react-router';
-import { __ } from '@wordpress/i18n';
-import { useSession } from '@/data/queries/use-sessions';
+import { SessionView } from '@/components/session-view';
 import { dashboardLayoutRoute } from './dashboard';
 
 function SessionDetail() {
 	const { sessionId } = sessionDetailRoute.useParams();
-	const { data, isLoading, error } = useSession( sessionId );
-
-	if ( isLoading ) {
-		return <div style={ { padding: 24 } }>{ __( 'Loading session…' ) }</div>;
-	}
-
-	if ( error || ! data ) {
-		return (
-			<div style={ { padding: 24 } }>
-				<h1>{ __( 'Session not found' ) }</h1>
-				<p>{ sessionId }</p>
-			</div>
-		);
-	}
-
-	const { summary, events } = data;
-
-	return (
-		<div style={ { padding: 24 } }>
-			<h1 style={ { marginBottom: 8 } }>
-				{ summary.firstPrompt?.trim() || __( '(No prompt yet)' ) }
-			</h1>
-			<p style={ { marginBottom: 24, color: 'var(--wpds-color-fg-content-neutral-weak)' } }>
-				{ summary.ownerSiteName ?? __( 'Unassigned' ) } · { events.length } { __( 'events' ) }
-			</p>
-			<p>
-				{ __( 'AI chat UI will live here. For now this screen just confirms the session loaded.' ) }
-			</p>
-		</div>
-	);
+	return <SessionView sessionId={ sessionId } />;
 }
 
 export const sessionDetailRoute = createRoute( {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1074,7 +1074,9 @@
 				"@wordpress/ui": "0.10.0",
 				"clsx": "^2.1.1",
 				"react": "^18.2.0",
-				"react-dom": "^18.2.0"
+				"react-dom": "^18.2.0",
+				"react-markdown": "^10.1.0",
+				"remark-gfm": "^4.0.1"
 			},
 			"devDependencies": {
 				"@types/react": "^18.3.27",

--- a/tools/common/ai/sdk-messages.ts
+++ b/tools/common/ai/sdk-messages.ts
@@ -1,0 +1,48 @@
+/**
+ * Minimal structural types + guards for the Claude Agent SDK messages that
+ * both the CLI and the UI care about. The CLI narrows further against the
+ * full SDK types it imports from `@anthropic-ai/claude-agent-sdk`; the UI
+ * only needs these structural shapes.
+ *
+ * Kept free of any SDK dependency so this module can live in `tools/common`
+ * without forcing the SDK into every consumer.
+ */
+
+export interface TextBlock {
+	type: 'text';
+	text: string;
+}
+
+export interface ToolUseBlock {
+	type: 'tool_use';
+	id: string;
+	name: string;
+	input?: Record< string, unknown >;
+}
+
+export type AssistantContentBlock = TextBlock | ToolUseBlock | { type: string };
+
+export interface AssistantSdkMessage {
+	type: 'assistant';
+	message: { content: AssistantContentBlock[] };
+}
+
+export function isAssistantSdkMessage( value: unknown ): value is AssistantSdkMessage {
+	if ( ! value || typeof value !== 'object' ) {
+		return false;
+	}
+	const outer = value as { type?: unknown; message?: unknown };
+	if ( outer.type !== 'assistant' ) {
+		return false;
+	}
+	const inner = outer.message as { content?: unknown } | undefined;
+	return !! inner && Array.isArray( inner.content );
+}
+
+export function isTextBlock( block: AssistantContentBlock ): block is TextBlock {
+	return block.type === 'text' && typeof ( block as TextBlock ).text === 'string';
+}
+
+export function isToolUseBlock( block: AssistantContentBlock ): block is ToolUseBlock {
+	return block.type === 'tool_use';
+}

--- a/tools/common/ai/sessions/filter-events.ts
+++ b/tools/common/ai/sessions/filter-events.ts
@@ -1,0 +1,26 @@
+import type { AiSessionEvent } from './types';
+
+/**
+ * Drop everything before the most recent `session.cleared` event — mirroring
+ * what the user sees in the CLI when they clear the conversation. Called by
+ * both the CLI replay loop and the UI session view so they agree on which
+ * events belong to the "current" conversation.
+ */
+export function filterEventsAfterLastClear( events: AiSessionEvent[] ): AiSessionEvent[] {
+	for ( let i = events.length - 1; i >= 0; i-- ) {
+		if ( events[ i ].type === 'session.cleared' ) {
+			return events.slice( i + 1 );
+		}
+	}
+	return events;
+}
+
+/**
+ * `ask_user` user messages are the agent's internal answers to its own
+ * questions and should not be rendered as user prompts in the transcript.
+ */
+export function isVisibleUserMessage(
+	event: Extract< AiSessionEvent, { type: 'user.message' } >
+): boolean {
+	return event.source === 'prompt';
+}

--- a/tools/common/ai/tools.ts
+++ b/tools/common/ai/tools.ts
@@ -1,0 +1,94 @@
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Human-facing display name for a tool, localized.
+ * Falls back to the raw tool name (e.g. an unknown MCP tool) so the UI/CLI
+ * always has something to show.
+ */
+export function getToolDisplayName( name: string ): string {
+	const displayNames: Record< string, string > = {
+		mcp__studio__site_create: __( 'Create site' ),
+		mcp__studio__site_list: __( 'List sites' ),
+		mcp__studio__site_info: __( 'Get site info' ),
+		mcp__studio__site_start: __( 'Start site' ),
+		mcp__studio__site_stop: __( 'Stop site' ),
+		mcp__studio__site_delete: __( 'Delete site' ),
+		mcp__studio__preview_create: __( 'Create preview' ),
+		mcp__studio__preview_list: __( 'List previews' ),
+		mcp__studio__preview_update: __( 'Update preview' ),
+		mcp__studio__preview_delete: __( 'Delete preview' ),
+		mcp__studio__wp_cli: __( 'Run WP-CLI' ),
+		mcp__studio__validate_blocks: __( 'Validate blocks' ),
+		mcp__studio__take_screenshot: __( 'Take screenshot' ),
+		Read: __( 'Read' ),
+		Write: __( 'Write' ),
+		Edit: __( 'Edit' ),
+		Bash: __( 'Run' ),
+		Glob: __( 'Search' ),
+		Grep: __( 'Search' ),
+		Skill: __( 'Load skill' ),
+		Task: __( 'Run task' ),
+		TodoWrite: __( 'Update todo list' ),
+	};
+	return displayNames[ name ] ?? name;
+}
+
+const BASH_DETAIL_MAX_LENGTH = 60;
+
+/**
+ * Short detail string extracted from a tool's input, suitable for display
+ * next to the tool name (e.g. a filename for Read/Write/Edit, a pattern for
+ * Grep/Glob, a truncated command for Bash). Returns `''` when no useful
+ * detail can be derived.
+ */
+export function getToolDetail( name: string, input?: Record< string, unknown > ): string {
+	if ( ! input ) {
+		return '';
+	}
+	switch ( name ) {
+		case 'mcp__studio__site_create':
+			return typeof input.name === 'string' ? input.name : '';
+		case 'mcp__studio__site_info':
+		case 'mcp__studio__site_start':
+		case 'mcp__studio__site_stop':
+		case 'mcp__studio__site_delete':
+		case 'mcp__studio__preview_create':
+		case 'mcp__studio__preview_list':
+			return typeof input.nameOrPath === 'string' ? input.nameOrPath : '';
+		case 'mcp__studio__preview_update':
+		case 'mcp__studio__preview_delete':
+			return typeof input.host === 'string' ? input.host : '';
+		case 'mcp__studio__wp_cli':
+			return typeof input.command === 'string' ? `wp ${ input.command }` : '';
+		case 'mcp__studio__validate_blocks':
+			if ( typeof input.filePath === 'string' ) {
+				return input.filePath.split( '/' ).slice( -2 ).join( '/' );
+			}
+			return __( 'inline content' );
+		case 'mcp__studio__take_screenshot':
+			return typeof input.url === 'string' ? input.url : '';
+		case 'Read':
+		case 'Write':
+		case 'Edit': {
+			const filePath = input.file_path ?? input.path;
+			if ( typeof filePath === 'string' ) {
+				return filePath.split( '/' ).slice( -2 ).join( '/' );
+			}
+			return '';
+		}
+		case 'Bash':
+			if ( typeof input.command !== 'string' ) {
+				return '';
+			}
+			return input.command.length > BASH_DETAIL_MAX_LENGTH
+				? input.command.slice( 0, BASH_DETAIL_MAX_LENGTH - 3 ) + '…'
+				: input.command;
+		case 'Skill':
+			return typeof input.skill === 'string' ? input.skill : '';
+		case 'Grep':
+		case 'Glob':
+			return typeof input.pattern === 'string' ? input.pattern : '';
+		default:
+			return '';
+	}
+}


### PR DESCRIPTION

## How AI was used in this PR

Built iteratively with Claude Code in auto mode, with explicit human direction on design/typography/spacing and architectural shape. Each visual decision was the author's; the AI wrote the component structure, CSS, the drag-region model inversion, and the shared-code extraction, then iterated on feedback.

## Proposed Changes

Implements the main-area session view — the big missing piece when a session is clicked in the sidebar — and factors the pieces that both the CLI and UI need into `@studio/common/ai`.

### Session view

- **New session view** (`apps/ui/src/components/session-view/`): header with site name + environment indicator, scrollable conversation body, placeholder composer at the bottom. The header reads `ownerSiteName` so it stays in sync with the sidebar grouping (sessions that switched sites mid-run no longer show a different site in the header vs. the sidebar).
- **Event rendering**: maps `user.message` (source=prompt) to the user bubble, `sdk.message` assistant text/tool_use blocks to assistant responses and inline tool rows, `tool.progress` to dimmed working rows, and `agent.question` to option buttons.
- **Markdown for assistant responses** (`apps/ui/src/components/markdown/`): `react-markdown` + `remark-gfm` with a custom component map and WPDS-token styling. Line-height 1.65, em-based vertical rhythm, heading coupling rules. Bold weight unified at 500 across `<strong>`, headings, table headers, and links. Links use a 35%-opacity underline that comes to full opacity on hover.
- **User bubble**: subtle accent-blue tint (`color-mix` at 10%), asymmetric corners (bottom-left tight, others rounded), extra vertical breathing room around each user turn.
- **Auto-scroll to bottom** on session open (`useLayoutEffect` + rAF follow-up).

### Shared code refactor (`@studio/common/ai/`)

Extracted what both the CLI playback UI and the apps/ui session view were duplicating:

- `tools/common/ai/tools.ts` — `getToolDisplayName()` + `getToolDetail()`. Pure string producers, no chalk/ANSI; the CLI wraps with its own formatting.
- `tools/common/ai/sdk-messages.ts` — minimal structural types and guards (`isAssistantSdkMessage`, `isTextBlock`, `isToolUseBlock`). Kept free of any SDK dependency so the UI can narrow blocks without importing `@anthropic-ai/claude-agent-sdk`.
- `tools/common/ai/sessions/filter-events.ts` — `filterEventsAfterLastClear()` + `isVisibleUserMessage()`, shared by the CLI replay loop and the UI session view.

The CLI's `apps/cli/ai/ui.ts` loses ~70 lines of duplicate tool metadata; its `formatToolName` now just delegates to the common helpers and wraps the result with chalk. The CLI's replay loop uses the shared filter helpers.

### Drag-region model inverted

- `apps/ui/src/index.css`: body no longer has `-webkit-app-region: drag` by default. Only explicit drag handles opt in (sidebar header, session header). Fixes a bug where the composer placeholder and other non-button interactive surfaces were swallowed by the body drag region, and removes the need to add `no-drag` rules to every new surface.
- `apps/ui/src/hooks/use-sidebar-collapsed.ts`: exposes collapsed state so the session header can render a no-drag spacer when the sidebar is collapsed, keeping the floating toggle button clickable (Electron drag-region stacking can misbehave when drag sits beneath a no-drag overlay).

### Header alignment

- Session header and sidebar header horizontal padding bumped from `xl` (20px) to `2xl` (24px) so title-to-edge spacing feels balanced against the header's vertical proportions.

## Testing Instructions

- `npm start`, then click any session in the sidebar.
- Verify the session header shows the correct owner site name (matches the sidebar group), the conversation renders with YOU bubbles and assistant markdown, tool use rows render compactly, and agent questions surface their options.
- Collapse the sidebar via the toggle. The floating toggle should remain clickable and sit flush with the site title (~8px gap). Re-open.
- Toggle macOS fullscreen — the header padding and toggle position should adapt (no traffic-light gap in fullscreen).
- Click into the composer placeholder area — no click swallowing from the window drag region.
- Open a long session — it should start scrolled to the bottom.
- Try markdown-heavy assistant responses: headings, nested lists, code blocks, inline code, tables, links. Links should have a soft underline that sharpens on hover.
- Switch color schemes (light/dark) — the bubble tint, markdown tokens, and link colors should all adapt via WPDS tokens.
- **CLI regression check**: `npm run cli:build && node apps/cli/dist/cli/main.mjs ai --resume <session-id>` — tool names in the transcript should still render bold with dimmed details in parentheses (the CLI's chalk formatting around the shared helpers).

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors?