### PR TITLE
apps/ui: add site dropdown to the session header

### DIFF
--- a/apps/ui/src/components/menu/style.module.css
+++ b/apps/ui/src/components/menu/style.module.css
@@ -1,7 +1,11 @@
 /* Styling mirrors @wordpress/components Popover: neutral-strong surface,
-   neutral stroke, medium radius, medium elevation shadow. */
+   neutral stroke, medium radius, medium elevation shadow.
+   Z-index follows @wordpress/ui's convention (tooltip/dialog): a CSS variable
+   with `initial` as the default. This lets sibling layers like tooltips
+   stack naturally above the menu by DOM order — a hardcoded z-index would
+   trap the tooltip (which also resolves to `initial`) underneath. */
 .positioner {
-	z-index: 20;
+	z-index: var(--wp-ui-menu-z-index, initial);
 	outline: none;
 }
 

--- a/apps/ui/src/components/session-view/index.tsx
+++ b/apps/ui/src/components/session-view/index.tsx
@@ -4,7 +4,9 @@ import { getToolDetail, getToolDisplayName } from '@studio/common/ai/tools';
 import { __ } from '@wordpress/i18n';
 import { useLayoutEffect, useMemo, useRef } from 'react';
 import { Markdown } from '@/components/markdown';
+import { SiteDropdown } from '@/components/site-dropdown';
 import { useSession } from '@/data/queries/use-sessions';
+import { useSites } from '@/data/queries/use-sites';
 import { useFullscreen } from '@/hooks/use-fullscreen';
 import { useSidebarCollapsed } from '@/hooks/use-sidebar-collapsed';
 import styles from './style.module.css';
@@ -93,9 +95,12 @@ function SessionHeader( { summary }: { summary: AiSessionSummary } ) {
 	const siteName = summary.ownerSiteName;
 	const sidebarCollapsed = useSidebarCollapsed();
 	const isFullscreen = useFullscreen();
+	const { data: sites } = useSites();
 	if ( ! siteName ) {
 		return null;
 	}
+
+	const site = sites?.find( ( candidate ) => candidate.path === summary.ownerSitePath );
 
 	// When the sidebar is collapsed the floating toggle button lives in the
 	// main area. Reserve a no-drag spacer at the left so the header's drag
@@ -110,9 +115,15 @@ function SessionHeader( { summary }: { summary: AiSessionSummary } ) {
 	return (
 		<div className={ styles.header }>
 			{ toggleSpacerClass ? <span className={ toggleSpacerClass } aria-hidden="true" /> : null }
-			<span className={ styles.headerSite }>{ siteName }</span>
-			<span className={ styles.headerDot } aria-hidden="true" />
-			<span className={ styles.headerEnv }>{ __( 'Local' ) }</span>
+			{ site ? (
+				<SiteDropdown site={ site } />
+			) : (
+				<>
+					<span className={ styles.headerSite }>{ siteName }</span>
+					<span className={ styles.headerDot } aria-hidden="true" />
+					<span className={ styles.headerEnv }>{ __( 'Local' ) }</span>
+				</>
+			) }
 		</div>
 	);
 }

--- a/apps/ui/src/components/site-dropdown/index.tsx
+++ b/apps/ui/src/components/site-dropdown/index.tsx
@@ -1,0 +1,179 @@
+import { __ } from '@wordpress/i18n';
+import { chevronDownSmall, external } from '@wordpress/icons';
+import { Button, Icon, IconButton } from '@wordpress/ui';
+import { forwardRef, useMemo } from 'react';
+import * as Menu from '@/components/menu';
+import { useConnector } from '@/data/core';
+import { useConnectedWpcomSites } from '@/data/queries/use-connected-wpcom-sites';
+import { useSnapshots } from '@/data/queries/use-snapshots';
+import styles from './style.module.css';
+import type { SiteDetails, Snapshot, SyncSite } from '@/data/core';
+import type { ComponentProps, ElementRef } from 'react';
+
+function stripProtocol( url: string ): string {
+	return url.replace( /^https?:\/\//, '' ).replace( /\/$/, '' );
+}
+
+type TriggerProps = Omit< ComponentProps< 'button' >, 'children' > & {
+	siteName: string;
+};
+
+const DropdownTrigger = forwardRef< ElementRef< 'button' >, TriggerProps >(
+	function DropdownTrigger( { siteName, className, ...props }, ref ) {
+		return (
+			<button
+				ref={ ref }
+				type="button"
+				className={ `${ styles.trigger } ${ className ?? '' }` }
+				{ ...props }
+			>
+				<span className={ styles.triggerSite }>{ siteName }</span>
+				<span className={ styles.triggerDot } aria-hidden="true" />
+				<span className={ styles.triggerEnv }>{ __( 'Local' ) }</span>
+				<Icon icon={ chevronDownSmall } size={ 18 } />
+			</button>
+		);
+	}
+);
+
+function PopoverRow( {
+	label,
+	sublabel,
+	action,
+}: {
+	label: React.ReactNode;
+	sublabel?: React.ReactNode;
+	action?: React.ReactNode;
+} ) {
+	return (
+		<div className={ styles.row }>
+			<div className={ styles.rowText }>
+				<div className={ styles.rowLabel }>{ label }</div>
+				{ sublabel ? <div className={ styles.rowSublabel }>{ sublabel }</div> : null }
+			</div>
+			{ action ? <div className={ styles.rowAction }>{ action }</div> : null }
+		</div>
+	);
+}
+
+type Props = {
+	site: SiteDetails;
+};
+
+function ensureProtocol( url: string ): string {
+	return /^https?:\/\//.test( url ) ? url : `https://${ url }`;
+}
+
+function pickLiveSite( connectedSites: SyncSite[] | undefined ): SyncSite | undefined {
+	if ( ! connectedSites || connectedSites.length === 0 ) {
+		return undefined;
+	}
+	// Prefer the production (non-staging) site; fall back to anything connected
+	// so a staging-only link is still surfaced rather than silently dropped.
+	return connectedSites.find( ( site ) => ! site.isStaging ) ?? connectedSites[ 0 ];
+}
+
+function pickLatestSnapshot(
+	snapshots: Snapshot[] | undefined,
+	siteId: string
+): Snapshot | undefined {
+	if ( ! snapshots ) {
+		return undefined;
+	}
+	// `date` is a unix timestamp; the most recent snapshot wins.
+	return snapshots
+		.filter( ( snapshot ) => snapshot.localSiteId === siteId )
+		.reduce< Snapshot | undefined >( ( latest, candidate ) => {
+			if ( ! latest || candidate.date > latest.date ) {
+				return candidate;
+			}
+			return latest;
+		}, undefined );
+}
+
+export function SiteDropdown( { site }: Props ) {
+	const connector = useConnector();
+	const localUrl = site.url;
+	const { data: snapshots } = useSnapshots();
+	const { data: connectedSites } = useConnectedWpcomSites( site.id );
+	const previewSnapshot = useMemo(
+		() => pickLatestSnapshot( snapshots, site.id ),
+		[ snapshots, site.id ]
+	);
+	const liveSite = useMemo( () => pickLiveSite( connectedSites ), [ connectedSites ] );
+
+	const openExternal = ( url: string ) => {
+		void connector.openExternalUrl( url );
+	};
+
+	return (
+		<Menu.Root modal={ false }>
+			<Menu.Trigger render={ <DropdownTrigger siteName={ site.name } /> } />
+			<Menu.Popup side="bottom" align="start" className={ styles.popup }>
+				<div className={ styles.rows }>
+					<PopoverRow
+						label={ __( 'Local site' ) }
+						sublabel={ localUrl ? stripProtocol( localUrl ) : __( 'Not running' ) }
+						action={
+							localUrl ? (
+								<IconButton
+									variant="minimal"
+									tone="neutral"
+									size="small"
+									icon={ external }
+									label={ __( 'Open local site' ) }
+									onClick={ () => openExternal( localUrl ) }
+								/>
+							) : null
+						}
+					/>
+
+					<PopoverRow
+						label={ __( 'Live site' ) }
+						sublabel={ liveSite ? stripProtocol( liveSite.url ) : __( 'Not yet published' ) }
+						action={
+							liveSite ? (
+								<IconButton
+									variant="minimal"
+									tone="neutral"
+									size="small"
+									icon={ external }
+									label={ __( 'Open live site' ) }
+									onClick={ () => openExternal( ensureProtocol( liveSite.url ) ) }
+								/>
+							) : (
+								<span className={ styles.emDash }>—</span>
+							)
+						}
+					/>
+
+					{ previewSnapshot ? (
+						<PopoverRow
+							label={ __( 'Preview site' ) }
+							sublabel={ stripProtocol( previewSnapshot.url ) }
+							action={
+								<IconButton
+									variant="minimal"
+									tone="neutral"
+									size="small"
+									icon={ external }
+									label={ __( 'Open preview site' ) }
+									onClick={ () => openExternal( ensureProtocol( previewSnapshot.url ) ) }
+								/>
+							}
+						/>
+					) : null }
+				</div>
+
+				<div className={ styles.footer }>
+					<Button variant="outline" tone="neutral" size="compact" className={ styles.footerButton }>
+						{ __( 'Preview' ) }
+					</Button>
+					<Button variant="solid" tone="brand" size="compact" className={ styles.footerButton }>
+						{ __( 'Publish…' ) }
+					</Button>
+				</div>
+			</Menu.Popup>
+		</Menu.Root>
+	);
+}

--- a/apps/ui/src/components/site-dropdown/style.module.css
+++ b/apps/ui/src/components/site-dropdown/style.module.css
@@ -1,0 +1,102 @@
+.trigger {
+	display: inline-flex;
+	align-items: center;
+	gap: var(--wpds-dimension-padding-sm);
+	background: transparent;
+	border: 0;
+	padding: var(--wpds-dimension-padding-xs) var(--wpds-dimension-padding-sm);
+	margin: 0;
+	border-radius: var(--wpds-border-radius-sm);
+	font: inherit;
+	font-size: var(--wpds-font-size-sm);
+	color: var(--wpds-color-fg-content-neutral);
+	cursor: var(--wpds-cursor-control);
+	-webkit-app-region: no-drag;
+}
+
+.trigger:hover,
+.trigger[data-popup-open] {
+	background: var(--wpds-color-bg-surface-neutral);
+}
+
+.triggerSite {
+	font-weight: 600;
+}
+
+.triggerDot {
+	width: 6px;
+	height: 6px;
+	border-radius: 50%;
+	background-color: var(--wpds-color-fg-content-success, #16a34a);
+	flex-shrink: 0;
+	/* Matches the session header's dot spacing: extra room around the dot only. */
+	margin: 0 var(--wpds-dimension-padding-xs);
+}
+
+.triggerEnv {
+	color: var(--wpds-color-fg-content-neutral-weak);
+}
+
+.popup {
+	min-width: 320px;
+	padding: 0;
+	gap: 0;
+}
+
+.rows {
+	display: flex;
+	flex-direction: column;
+	padding: var(--wpds-dimension-padding-sm) 0;
+}
+
+.row {
+	display: flex;
+	align-items: center;
+	gap: var(--wpds-dimension-padding-md);
+	padding: var(--wpds-dimension-padding-sm) var(--wpds-dimension-padding-lg);
+	min-height: 44px;
+}
+
+.rowText {
+	flex: 1;
+	min-width: 0;
+	display: flex;
+	flex-direction: column;
+}
+
+.rowLabel {
+	font-size: var(--wpds-font-size-sm);
+	font-weight: 500;
+	color: var(--wpds-color-fg-content-neutral);
+}
+
+.rowSublabel {
+	margin-top: 2px;
+	font-size: var(--wpds-font-size-xs);
+	color: var(--wpds-color-fg-content-neutral-weak);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.rowAction {
+	flex-shrink: 0;
+	color: var(--wpds-color-fg-content-accent);
+	font-size: var(--wpds-font-size-sm);
+}
+
+.emDash {
+	color: var(--wpds-color-fg-content-neutral-weak);
+	font-size: var(--wpds-font-size-md);
+}
+
+.footer {
+	display: flex;
+	gap: var(--wpds-dimension-padding-sm);
+	padding: 0 var(--wpds-dimension-padding-lg) var(--wpds-dimension-padding-md);
+}
+
+.footerButton {
+	flex: 1;
+	justify-content: center;
+}

--- a/apps/ui/src/data/core/connectors/ipc/index.ts
+++ b/apps/ui/src/data/core/connectors/ipc/index.ts
@@ -5,6 +5,8 @@ import type {
 	Connector,
 	LoadedAiSession,
 	SiteDetails,
+	Snapshot,
+	SyncSite,
 } from '../../types';
 
 /**
@@ -75,6 +77,16 @@ export function createIpcConnector(): Connector {
 
 		async stopSite( id ) {
 			await ipcApi.stopServer( id );
+		},
+
+		// Preview snapshots
+		async getSnapshots(): Promise< Snapshot[] > {
+			return ( await ipcApi.fetchSnapshots() ) as Snapshot[];
+		},
+
+		// Connected WPCom sites
+		async getConnectedWpcomSites( localSiteId: string ): Promise< SyncSite[] > {
+			return ( await ipcApi.getConnectedWpcomSites( localSiteId ) ) as SyncSite[];
 		},
 
 		// AI sessions

--- a/apps/ui/src/data/core/index.ts
+++ b/apps/ui/src/data/core/index.ts
@@ -8,4 +8,6 @@ export type {
 	Connector,
 	LoadedAiSession,
 	SiteDetails,
+	Snapshot,
+	SyncSite,
 } from './types';

--- a/apps/ui/src/data/core/types.ts
+++ b/apps/ui/src/data/core/types.ts
@@ -1,10 +1,14 @@
 import type { AiSessionSummary, LoadedAiSession } from '@studio/common/ai/sessions/types';
+import type { Snapshot } from '@studio/common/types/snapshot';
+import type { SyncSite } from '@studio/common/types/sync';
 
 export type {
 	AiSessionSummary,
 	LoadedAiSession,
 	AiSessionEvent,
 } from '@studio/common/ai/sessions/types';
+export type { Snapshot } from '@studio/common/types/snapshot';
+export type { SyncSite } from '@studio/common/types/sync';
 
 export interface SiteDetails {
 	id: string;
@@ -48,6 +52,12 @@ export interface Connector {
 	deleteSite( id: string ): Promise< void >;
 	startSite( id: string ): Promise< void >;
 	stopSite( id: string ): Promise< void >;
+
+	// Preview snapshots (WordPress.com hosted previews of local sites)
+	getSnapshots(): Promise< Snapshot[] >;
+
+	// Connected WordPress.com live sites for a given local site
+	getConnectedWpcomSites( localSiteId: string ): Promise< SyncSite[] >;
 
 	// AI sessions (shared with the CLI — stored as JSONL on disk)
 	getSessions(): Promise< AiSessionSummary[] >;

--- a/apps/ui/src/data/queries/use-connected-wpcom-sites.ts
+++ b/apps/ui/src/data/queries/use-connected-wpcom-sites.ts
@@ -1,0 +1,13 @@
+import { useQuery } from '@tanstack/react-query';
+import { useConnector } from '@/data/core';
+
+export const connectedWpcomSitesQueryKey = ( localSiteId: string ) =>
+	[ 'connected-wpcom-sites', localSiteId ] as const;
+
+export function useConnectedWpcomSites( localSiteId: string ) {
+	const connector = useConnector();
+	return useQuery( {
+		queryKey: connectedWpcomSitesQueryKey( localSiteId ),
+		queryFn: () => connector.getConnectedWpcomSites( localSiteId ),
+	} );
+}

--- a/apps/ui/src/data/queries/use-snapshots.ts
+++ b/apps/ui/src/data/queries/use-snapshots.ts
@@ -1,0 +1,12 @@
+import { useQuery } from '@tanstack/react-query';
+import { useConnector } from '@/data/core';
+
+export const SNAPSHOTS_QUERY_KEY = [ 'snapshots' ] as const;
+
+export function useSnapshots() {
+	const connector = useConnector();
+	return useQuery( {
+		queryKey: SNAPSHOTS_QUERY_KEY,
+		queryFn: () => connector.getSnapshots(),
+	} );
+}


### PR DESCRIPTION
## Related issues

- Related to the `apps/ui` design-mock rollout

## How AI was used in this PR

Claude scaffolded the `SiteDropdown` component and associated connector methods, query hooks, and styles. I iterated on the design (dropped the redundant card header, tightened subtitle spacing, wired the Live site row to real connected-WPCom data) and root-caused the tooltip stacking bug.

## Proposed Changes

- New `components/site-dropdown/` rendered in the session header in place of the flat site/environment label. The trigger keeps the `{site name} • Local` layout and adds a chevron; the popup is a card with rows for **Local site**, **Live site**, and (conditional) **Preview site**, plus Preview / Publish… footer buttons.
- Each row surfaces an Open-external `IconButton` that delegates to `connector.openExternalUrl` — local URL for the local row, connected WPCom URL for the live row, snapshot URL for the preview row.
- Connector surface additions:
  - `getSnapshots()` — wraps the existing `fetchSnapshots` IPC handler. Backed by a new `useSnapshots` query.
  - `getConnectedWpcomSites(localSiteId)` — wraps the existing `getConnectedWpcomSites` IPC handler. Backed by a new `useConnectedWpcomSites` query. Live-site row prefers the production site and falls back to the first connected site so staging-only links are still surfaced.
- Preview / Publish buttons are visual-only for now. Wiring them to the push/snapshot flows needs progress UI and an operations slice, which `apps/ui` doesn't have yet — tracked for a follow-up.
- **Bugfix**: `components/menu` positioner hardcoded `z-index: 20`, which trapped tooltips from `@wordpress/ui` (their `z-index: var(--wp-ui-tooltip-z-index, initial)`) underneath an open popup. Switched to the same convention (`var(--wp-ui-menu-z-index, initial)`) so both default to `initial` and stack naturally by DOM order. Tooltips on the in-popup icon buttons now render on top as expected.

## Testing Instructions

1. `npm start` and open the new UI surface.
2. Open a session attached to a local site. Confirm the header shows the site name / dot / Local / chevron and clicking it opens the popup.
3. **Local site row**: the site's local URL is listed; clicking the external-link icon opens it in the default browser.
4. **Live site row**: if the site has a connected WordPress.com site (visible in the old app's Sync tab), the row shows the live URL and its external-link icon opens it. Otherwise the row reads "Not yet published" with an em-dash.
5. **Preview site row**: if the site has snapshots (old app's Preview tab), the most recent snapshot URL appears with an external-link icon. Otherwise the row is omitted.
6. Hover an icon button inside the popup — its tooltip should render above the popup, not behind it.
7. Close via outside click / Escape and reopen. Preview / Publish… buttons are visual placeholders (no-op).

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors? `npm run typecheck` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)