### PR TITLE
apps/ui: start/stop controls and live server status indicator

### DIFF
--- a/apps/ui/src/app.tsx
+++ b/apps/ui/src/app.tsx
@@ -4,6 +4,7 @@ import { defaultI18n } from '@wordpress/i18n';
 import { I18nProvider } from '@wordpress/react-i18n';
 import { privateApis } from '@wordpress/theme';
 import { ConnectorProvider, queryClient } from '@/data/core';
+import { useSyncSitesWithEvents } from '@/data/queries/use-sites';
 import { usePrefersColorScheme } from '@/hooks/use-prefers-color-scheme';
 import { unlock } from '@/lock-unlock';
 import { createAppRouter } from '@/router/router';
@@ -17,6 +18,11 @@ interface AppProps {
 	connector: Connector;
 }
 
+function SiteEventsBridge() {
+	useSyncSitesWithEvents();
+	return null;
+}
+
 export function App( { connector }: AppProps ) {
 	const router = createAppRouter( { queryClient, connector } );
 	const colorScheme = usePrefersColorScheme();
@@ -25,6 +31,7 @@ export function App( { connector }: AppProps ) {
 	return (
 		<ConnectorProvider connector={ connector }>
 			<QueryClientProvider client={ queryClient }>
+				<SiteEventsBridge />
 				<I18nProvider i18n={ defaultI18n }>
 					<ThemeProvider isRoot color={ themeColor } density="compact">
 						<RouterProvider router={ router } />

--- a/apps/ui/src/components/project-list/index.tsx
+++ b/apps/ui/src/components/project-list/index.tsx
@@ -36,10 +36,7 @@ function deriveSubtitle( site: SiteDetails ): string | undefined {
 	if ( site.url ) {
 		return stripProtocol( site.url );
 	}
-	// When a site is stopped the main process strips `url` from the details,
-	// but `port` is preserved. Surfacing `localhost:<port>` keeps the subtitle
-	// stable across start/stop toggles instead of flipping to the folder
-	// basename (which often mirrors the site name).
+	// Main process strips `url` when the site is stopped but keeps `port`.
 	if ( site.port > 0 ) {
 		return `localhost:${ site.port }`;
 	}

--- a/apps/ui/src/components/project-list/index.tsx
+++ b/apps/ui/src/components/project-list/index.tsx
@@ -4,9 +4,16 @@ import { moreHorizontal, plus } from '@wordpress/icons';
 import { IconButton } from '@wordpress/ui';
 import { clsx } from 'clsx';
 import { useMemo, useState } from 'react';
+import * as Menu from '@/components/menu';
 import { SidebarButton } from '@/components/sidebar-button';
 import { useSessions } from '@/data/queries/use-sessions';
-import { useSites } from '@/data/queries/use-sites';
+import {
+	useIsSiteStarting,
+	useIsSiteStopping,
+	useSites,
+	useStartSite,
+	useStopSite,
+} from '@/data/queries/use-sites';
 import { formatRelativeTime } from '@/lib/format-relative-time';
 import styles from './style.module.css';
 import type { AiSessionSummary, SiteDetails } from '@/data/core';
@@ -28,6 +35,13 @@ function stripProtocol( url: string ): string {
 function deriveSubtitle( site: SiteDetails ): string | undefined {
 	if ( site.url ) {
 		return stripProtocol( site.url );
+	}
+	// When a site is stopped the main process strips `url` from the details,
+	// but `port` is preserved. Surfacing `localhost:<port>` keeps the subtitle
+	// stable across start/stop toggles instead of flipping to the folder
+	// basename (which often mirrors the site name).
+	if ( site.port > 0 ) {
+		return `localhost:${ site.port }`;
 	}
 	const basename = site.path.split( /[\\/]/ ).filter( Boolean ).pop();
 	return basename;
@@ -115,6 +129,42 @@ function SessionItem( { session }: { session: AiSessionSummary } ) {
 	);
 }
 
+function ProjectActionsMenu( { site }: { site: SiteDetails } ) {
+	const startSite = useStartSite();
+	const stopSite = useStopSite();
+	const isStarting = useIsSiteStarting( site.id );
+	const isStopping = useIsSiteStopping( site.id );
+	const busy = isStarting || isStopping;
+
+	return (
+		<Menu.Root modal={ false }>
+			<Menu.Trigger
+				render={
+					<IconButton
+						variant="minimal"
+						tone="neutral"
+						size="small"
+						icon={ moreHorizontal }
+						label={ __( 'Project actions' ) }
+						className={ styles.projectAction }
+					/>
+				}
+			/>
+			<Menu.Popup side="bottom" align="start">
+				{ site.running ? (
+					<Menu.Item disabled={ busy } onClick={ () => stopSite.mutate( site.id ) }>
+						{ __( 'Stop site' ) }
+					</Menu.Item>
+				) : (
+					<Menu.Item disabled={ busy } onClick={ () => startSite.mutate( site.id ) }>
+						{ isStarting ? __( 'Starting…' ) : __( 'Start site' ) }
+					</Menu.Item>
+				) }
+			</Menu.Popup>
+		</Menu.Root>
+	);
+}
+
 function ProjectSection( {
 	group,
 	isUnassigned,
@@ -151,14 +201,7 @@ function ProjectSection( {
 				</div>
 				{ group.site ? (
 					<div className={ styles.projectActions }>
-						<IconButton
-							variant="minimal"
-							tone="neutral"
-							size="small"
-							icon={ moreHorizontal }
-							label={ __( 'Project actions' ) }
-							className={ styles.projectAction }
-						/>
+						<ProjectActionsMenu site={ group.site } />
 						<IconButton
 							variant="minimal"
 							tone="neutral"

--- a/apps/ui/src/components/project-list/index.tsx
+++ b/apps/ui/src/components/project-list/index.tsx
@@ -15,6 +15,7 @@ import {
 	useStopSite,
 } from '@/data/queries/use-sites';
 import { formatRelativeTime } from '@/lib/format-relative-time';
+import { getSiteDisplayUrl } from '@/lib/get-site-url';
 import styles from './style.module.css';
 import type { AiSessionSummary, SiteDetails } from '@/data/core';
 
@@ -28,20 +29,11 @@ type ProjectGroup = {
 	sessions: AiSessionSummary[];
 };
 
-function stripProtocol( url: string ): string {
-	return url.replace( /^https?:\/\//, '' ).replace( /\/$/, '' );
-}
-
 function deriveSubtitle( site: SiteDetails ): string | undefined {
-	if ( site.url ) {
-		return stripProtocol( site.url );
+	if ( site.customDomain || site.port > 0 ) {
+		return getSiteDisplayUrl( site );
 	}
-	// Main process strips `url` when the site is stopped but keeps `port`.
-	if ( site.port > 0 ) {
-		return `localhost:${ site.port }`;
-	}
-	const basename = site.path.split( /[\\/]/ ).filter( Boolean ).pop();
-	return basename;
+	return site.path.split( /[\\/]/ ).filter( Boolean ).pop();
 }
 
 function groupSessionsByOwner(

--- a/apps/ui/src/components/project-list/style.module.css
+++ b/apps/ui/src/components/project-list/style.module.css
@@ -86,7 +86,8 @@
 
 .projectActive .projectAction,
 .projectHeader:hover .projectAction,
-.projectHeader:focus-within .projectAction {
+.projectHeader:focus-within .projectAction,
+.projectAction[data-popup-open] {
 	opacity: 1;
 }
 

--- a/apps/ui/src/components/site-dropdown/index.tsx
+++ b/apps/ui/src/components/site-dropdown/index.tsx
@@ -1,14 +1,23 @@
 import { __ } from '@wordpress/i18n';
 import { chevronDownSmall, external } from '@wordpress/icons';
 import { Button, Icon, IconButton } from '@wordpress/ui';
+import { clsx } from 'clsx';
 import { forwardRef, useMemo } from 'react';
 import * as Menu from '@/components/menu';
 import { useConnector } from '@/data/core';
 import { useConnectedWpcomSites } from '@/data/queries/use-connected-wpcom-sites';
+import {
+	useIsSiteStarting,
+	useIsSiteStopping,
+	useStartSite,
+	useStopSite,
+} from '@/data/queries/use-sites';
 import { useSnapshots } from '@/data/queries/use-snapshots';
 import styles from './style.module.css';
 import type { SiteDetails, Snapshot, SyncSite } from '@/data/core';
 import type { ComponentProps, ElementRef } from 'react';
+
+type SiteStatus = 'running' | 'stopped' | 'transitioning';
 
 function stripProtocol( url: string ): string {
 	return url.replace( /^https?:\/\//, '' ).replace( /\/$/, '' );
@@ -16,10 +25,12 @@ function stripProtocol( url: string ): string {
 
 type TriggerProps = Omit< ComponentProps< 'button' >, 'children' > & {
 	siteName: string;
+	status: SiteStatus;
+	statusLabel: string;
 };
 
 const DropdownTrigger = forwardRef< ElementRef< 'button' >, TriggerProps >(
-	function DropdownTrigger( { siteName, className, ...props }, ref ) {
+	function DropdownTrigger( { siteName, status, statusLabel, className, ...props }, ref ) {
 		return (
 			<button
 				ref={ ref }
@@ -28,7 +39,11 @@ const DropdownTrigger = forwardRef< ElementRef< 'button' >, TriggerProps >(
 				{ ...props }
 			>
 				<span className={ styles.triggerSite }>{ siteName }</span>
-				<span className={ styles.triggerDot } aria-hidden="true" />
+				<span
+					className={ clsx( styles.triggerDot, styles[ `triggerDot_${ status }` ] ) }
+					role="img"
+					aria-label={ statusLabel }
+				/>
 				<span className={ styles.triggerEnv }>{ __( 'Local' ) }</span>
 				<Icon icon={ chevronDownSmall } size={ 18 } />
 			</button>
@@ -102,29 +117,82 @@ export function SiteDropdown( { site }: Props ) {
 	);
 	const liveSite = useMemo( () => pickLiveSite( connectedSites ), [ connectedSites ] );
 
+	const startSite = useStartSite();
+	const stopSite = useStopSite();
+	const isStarting = useIsSiteStarting( site.id );
+	const isStopping = useIsSiteStopping( site.id );
+	const status: SiteStatus =
+		isStarting || isStopping ? 'transitioning' : site.running ? 'running' : 'stopped';
+
+	const statusLabel =
+		status === 'running'
+			? __( 'Site is running' )
+			: status === 'transitioning'
+			? isStopping
+				? __( 'Site is stopping' )
+				: __( 'Site is starting' )
+			: __( 'Site is stopped' );
+
+	const stoppedUrl = site.port > 0 ? `localhost:${ site.port }` : undefined;
+	const localSublabel =
+		status === 'transitioning'
+			? isStopping
+				? __( 'Stopping…' )
+				: __( 'Starting…' )
+			: localUrl
+			? stripProtocol( localUrl )
+			: stoppedUrl ?? __( 'Not running' );
+
 	const openExternal = ( url: string ) => {
 		void connector.openExternalUrl( url );
 	};
 
+	const toggleServer = () => {
+		if ( status === 'transitioning' ) {
+			return;
+		}
+		if ( site.running ) {
+			stopSite.mutate( site.id );
+		} else {
+			startSite.mutate( site.id );
+		}
+	};
+
 	return (
 		<Menu.Root modal={ false }>
-			<Menu.Trigger render={ <DropdownTrigger siteName={ site.name } /> } />
+			<Menu.Trigger
+				render={
+					<DropdownTrigger siteName={ site.name } status={ status } statusLabel={ statusLabel } />
+				}
+			/>
 			<Menu.Popup side="bottom" align="start" className={ styles.popup }>
 				<div className={ styles.rows }>
 					<PopoverRow
 						label={ __( 'Local site' ) }
-						sublabel={ localUrl ? stripProtocol( localUrl ) : __( 'Not running' ) }
+						sublabel={ localSublabel }
 						action={
-							localUrl ? (
-								<IconButton
+							<div className={ styles.localActions }>
+								<Button
 									variant="minimal"
 									tone="neutral"
 									size="small"
-									icon={ external }
-									label={ __( 'Open local site' ) }
-									onClick={ () => openExternal( localUrl ) }
-								/>
-							) : null
+									loading={ status === 'transitioning' }
+									loadingAnnouncement={ isStopping ? __( 'Stopping' ) : __( 'Starting' ) }
+									onClick={ toggleServer }
+								>
+									{ site.running ? __( 'Stop' ) : __( 'Start' ) }
+								</Button>
+								{ localUrl ? (
+									<IconButton
+										variant="minimal"
+										tone="neutral"
+										size="small"
+										icon={ external }
+										label={ __( 'Open local site' ) }
+										onClick={ () => openExternal( localUrl ) }
+									/>
+								) : null }
+							</div>
 						}
 					/>
 
@@ -141,9 +209,7 @@ export function SiteDropdown( { site }: Props ) {
 									label={ __( 'Open live site' ) }
 									onClick={ () => openExternal( ensureProtocol( liveSite.url ) ) }
 								/>
-							) : (
-								<span className={ styles.emDash }>—</span>
-							)
+							) : null
 						}
 					/>
 

--- a/apps/ui/src/components/site-dropdown/index.tsx
+++ b/apps/ui/src/components/site-dropdown/index.tsx
@@ -13,6 +13,7 @@ import {
 	useStopSite,
 } from '@/data/queries/use-sites';
 import { useSnapshots } from '@/data/queries/use-snapshots';
+import { getSiteDisplayUrl, getSiteUrl } from '@/lib/get-site-url';
 import styles from './style.module.css';
 import type { SiteDetails, Snapshot, SyncSite } from '@/data/core';
 import type { ComponentProps, ElementRef } from 'react';
@@ -108,7 +109,6 @@ function pickLatestSnapshot(
 
 export function SiteDropdown( { site }: Props ) {
 	const connector = useConnector();
-	const localUrl = site.url;
 	const { data: snapshots } = useSnapshots();
 	const { data: connectedSites } = useConnectedWpcomSites( site.id );
 	const previewSnapshot = useMemo(
@@ -133,15 +133,12 @@ export function SiteDropdown( { site }: Props ) {
 				: __( 'Site is starting' )
 			: __( 'Site is stopped' );
 
-	const stoppedUrl = site.port > 0 ? `localhost:${ site.port }` : undefined;
 	const localSublabel =
 		status === 'transitioning'
 			? isStopping
 				? __( 'Stopping…' )
 				: __( 'Starting…' )
-			: localUrl
-			? stripProtocol( localUrl )
-			: stoppedUrl ?? __( 'Not running' );
+			: getSiteDisplayUrl( site );
 
 	const openExternal = ( url: string ) => {
 		void connector.openExternalUrl( url );
@@ -182,14 +179,14 @@ export function SiteDropdown( { site }: Props ) {
 								>
 									{ site.running ? __( 'Stop' ) : __( 'Start' ) }
 								</Button>
-								{ localUrl ? (
+								{ site.running ? (
 									<IconButton
 										variant="minimal"
 										tone="neutral"
 										size="small"
 										icon={ external }
 										label={ __( 'Open local site' ) }
-										onClick={ () => openExternal( localUrl ) }
+										onClick={ () => openExternal( getSiteUrl( site ) ) }
 									/>
 								) : null }
 							</div>

--- a/apps/ui/src/components/site-dropdown/style.module.css
+++ b/apps/ui/src/components/site-dropdown/style.module.css
@@ -27,10 +27,35 @@
 	width: 6px;
 	height: 6px;
 	border-radius: 50%;
-	background-color: var(--wpds-color-fg-content-success, #16a34a);
 	flex-shrink: 0;
 	/* Matches the session header's dot spacing: extra room around the dot only. */
 	margin: 0 var(--wpds-dimension-padding-xs);
+}
+
+/* Hardcoded traffic-light colors: the design tokens for fg-content-success
+   resolve to a very dark green (#002900) that reads as black at 6px, and
+   there are no fg-content-critical / fg-content-accent tokens to lean on. */
+.triggerDot_running {
+	background-color: #16a34a;
+}
+
+.triggerDot_stopped {
+	background-color: #dc2626;
+}
+
+.triggerDot_transitioning {
+	background-color: #2563eb;
+	animation: siteDotBlink 1s ease-in-out infinite;
+}
+
+@keyframes siteDotBlink {
+	0%,
+	100% {
+		opacity: 1;
+	}
+	50% {
+		opacity: 0.25;
+	}
 }
 
 .triggerEnv {
@@ -41,6 +66,23 @@
 	min-width: 320px;
 	padding: 0;
 	gap: 0;
+}
+
+/* Base UI's FloatingFocusManager moves focus to the first tabbable element
+   when the popup opens via mouse, which gives us a :focus state without
+   matching :focus-visible. The global rule in index.css already suppresses
+   the outline ring for that case, but @wordpress/ui's Button also paints a
+   filled background + border on plain :focus (same declaration as
+   :hover/:active) — the global rule doesn't touch those, so neutralize
+   them here. Border has to be reset alongside background, otherwise the
+   1px active-tone border stays behind and reads as an outline.
+
+   `color` is intentionally NOT reset — resetting it would clobber the
+   loading state's `color: transparent` and leave the label visible while
+   the spinner runs. */
+.popup button:focus:not(:focus-visible) {
+	background-color: var(--wp-ui-button-background-color);
+	border-color: var(--wp-ui-button-border-color);
 }
 
 .rows {
@@ -66,13 +108,15 @@
 
 .rowLabel {
 	font-size: var(--wpds-font-size-sm);
+	line-height: 1.2;
 	font-weight: 500;
 	color: var(--wpds-color-fg-content-neutral);
 }
 
 .rowSublabel {
-	margin-top: 2px;
+	margin-top: 4px;
 	font-size: var(--wpds-font-size-xs);
+	line-height: 1.2;
 	color: var(--wpds-color-fg-content-neutral-weak);
 	overflow: hidden;
 	text-overflow: ellipsis;
@@ -85,9 +129,10 @@
 	font-size: var(--wpds-font-size-sm);
 }
 
-.emDash {
-	color: var(--wpds-color-fg-content-neutral-weak);
-	font-size: var(--wpds-font-size-md);
+.localActions {
+	display: flex;
+	align-items: center;
+	gap: var(--wpds-dimension-padding-xs);
 }
 
 .footer {

--- a/apps/ui/src/components/site-dropdown/style.module.css
+++ b/apps/ui/src/components/site-dropdown/style.module.css
@@ -32,9 +32,8 @@
 	margin: 0 var(--wpds-dimension-padding-xs);
 }
 
-/* Hardcoded traffic-light colors: the design tokens for fg-content-success
-   resolve to a very dark green (#002900) that reads as black at 6px, and
-   there are no fg-content-critical / fg-content-accent tokens to lean on. */
+/* Hardcoded because `--wpds-color-fg-content-success` is #002900 (reads as
+   black at 6px) and the critical/accent equivalents don't exist. */
 .triggerDot_running {
 	background-color: #16a34a;
 }
@@ -68,18 +67,9 @@
 	gap: 0;
 }
 
-/* Base UI's FloatingFocusManager moves focus to the first tabbable element
-   when the popup opens via mouse, which gives us a :focus state without
-   matching :focus-visible. The global rule in index.css already suppresses
-   the outline ring for that case, but @wordpress/ui's Button also paints a
-   filled background + border on plain :focus (same declaration as
-   :hover/:active) — the global rule doesn't touch those, so neutralize
-   them here. Border has to be reset alongside background, otherwise the
-   1px active-tone border stays behind and reads as an outline.
-
-   `color` is intentionally NOT reset — resetting it would clobber the
-   loading state's `color: transparent` and leave the label visible while
-   the spinner runs. */
+/* Neutralize @wordpress/ui's Button :focus background+border when focus
+   lands programmatically (popup open). Outline is handled globally. Do not
+   reset `color` — it would clobber .is-loading's transparent label. */
 .popup button:focus:not(:focus-visible) {
 	background-color: var(--wp-ui-button-background-color);
 	border-color: var(--wp-ui-button-border-color);

--- a/apps/ui/src/data/core/connectors/ipc/index.ts
+++ b/apps/ui/src/data/core/connectors/ipc/index.ts
@@ -134,5 +134,11 @@ export function createIpcConnector(): Connector {
 				( _event: unknown, fullscreen: boolean ) => listener( fullscreen )
 			);
 		},
+
+		onSiteEvent( listener ) {
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			const ipcListener = ( window as any ).ipcListener;
+			return ipcListener.subscribe( 'site-event', () => listener() );
+		},
 	};
 }

--- a/apps/ui/src/data/core/types.ts
+++ b/apps/ui/src/data/core/types.ts
@@ -78,6 +78,10 @@ export interface Connector {
 	// to reclaim the space we normally leave for them).
 	isFullscreen(): Promise< boolean >;
 	onFullscreenChange( listener: ( fullscreen: boolean ) => void ): () => void;
+
+	// Fires whenever a site is created, updated, started, stopped, or deleted.
+	// Consumers typically invalidate cached site data in response.
+	onSiteEvent( listener: () => void ): () => void;
 }
 
 export type ColorScheme = 'system' | 'light' | 'dark';

--- a/apps/ui/src/data/core/types.ts
+++ b/apps/ui/src/data/core/types.ts
@@ -17,6 +17,8 @@ export interface SiteDetails {
 	port: number;
 	running: boolean;
 	url?: string;
+	customDomain?: string;
+	enableHttps?: boolean;
 	phpVersion: string;
 	themeDetails?: {
 		name: string;

--- a/apps/ui/src/data/queries/use-sites.ts
+++ b/apps/ui/src/data/queries/use-sites.ts
@@ -33,11 +33,8 @@ export function useDeleteSite() {
 	} );
 }
 
-// Fold the query invalidation (and its refetch) into the mutationFn so the
-// mutation stays `isPending` until the sites query actually reflects the new
-// running state. Otherwise there's a window between the IPC call resolving
-// and the refetch landing where the button flips back to enabled while the
-// main process is still finishing the transition.
+// Invalidation is awaited inside `mutationFn` (not `onSettled`) so
+// `isPending` stays true until `site.running` reflects the new state.
 export function useStartSite() {
 	const connector = useConnector();
 	const queryClient = useQueryClient();

--- a/apps/ui/src/data/queries/use-sites.ts
+++ b/apps/ui/src/data/queries/use-sites.ts
@@ -1,7 +1,11 @@
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useIsMutating, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useEffect } from 'react';
 import { useConnector } from '@/data/core';
 
 export const SITES_QUERY_KEY = [ 'sites' ] as const;
+
+const START_SITE_MUTATION_KEY = [ 'startSite' ] as const;
+const STOP_SITE_MUTATION_KEY = [ 'stopSite' ] as const;
 
 export function useSites() {
 	const connector = useConnector();
@@ -27,4 +31,63 @@ export function useDeleteSite() {
 		mutationFn: ( id: string ) => connector.deleteSite( id ),
 		onSuccess: () => queryClient.invalidateQueries( { queryKey: SITES_QUERY_KEY } ),
 	} );
+}
+
+// Fold the query invalidation (and its refetch) into the mutationFn so the
+// mutation stays `isPending` until the sites query actually reflects the new
+// running state. Otherwise there's a window between the IPC call resolving
+// and the refetch landing where the button flips back to enabled while the
+// main process is still finishing the transition.
+export function useStartSite() {
+	const connector = useConnector();
+	const queryClient = useQueryClient();
+	return useMutation( {
+		mutationKey: START_SITE_MUTATION_KEY,
+		mutationFn: async ( id: string ) => {
+			await connector.startSite( id );
+			await queryClient.invalidateQueries( { queryKey: SITES_QUERY_KEY } );
+		},
+	} );
+}
+
+export function useStopSite() {
+	const connector = useConnector();
+	const queryClient = useQueryClient();
+	return useMutation( {
+		mutationKey: STOP_SITE_MUTATION_KEY,
+		mutationFn: async ( id: string ) => {
+			await connector.stopSite( id );
+			await queryClient.invalidateQueries( { queryKey: SITES_QUERY_KEY } );
+		},
+	} );
+}
+
+function useIsSiteMutating( siteId: string | undefined, mutationKey: readonly string[] ): boolean {
+	const count = useIsMutating( {
+		mutationKey,
+		predicate: ( mutation ) => mutation.state.variables === siteId,
+	} );
+	return count > 0;
+}
+
+export function useIsSiteStarting( siteId: string | undefined ): boolean {
+	return useIsSiteMutating( siteId, START_SITE_MUTATION_KEY );
+}
+
+export function useIsSiteStopping( siteId: string | undefined ): boolean {
+	return useIsSiteMutating( siteId, STOP_SITE_MUTATION_KEY );
+}
+
+/**
+ * Keeps the cached site list in sync with main-process events (site created,
+ * updated, started, stopped, deleted). Mount once near the app root.
+ */
+export function useSyncSitesWithEvents(): void {
+	const connector = useConnector();
+	const queryClient = useQueryClient();
+	useEffect( () => {
+		return connector.onSiteEvent( () => {
+			void queryClient.invalidateQueries( { queryKey: SITES_QUERY_KEY } );
+		} );
+	}, [ connector, queryClient ] );
 }

--- a/apps/ui/src/lib/get-site-url.ts
+++ b/apps/ui/src/lib/get-site-url.ts
@@ -1,0 +1,18 @@
+import type { SiteDetails } from '@/data/core';
+
+// Mirrors apps/studio/src/lib/get-site-url.ts. Computes the site URL from
+// the site object so callers don't depend on `site.url` (which the main
+// process strips when the server is stopped).
+export function getSiteUrl( site: SiteDetails ): string {
+	if ( site.customDomain ) {
+		const protocol = site.enableHttps ? 'https' : 'http';
+		return `${ protocol }://${ site.customDomain }`;
+	}
+	return `http://localhost:${ site.port }`;
+}
+
+export function getSiteDisplayUrl( site: SiteDetails ): string {
+	return getSiteUrl( site )
+		.replace( /^https?:\/\//, '' )
+		.replace( /\/$/, '' );
+}


### PR DESCRIPTION
## Related issues

- Related to #

## How AI was used in this PR

Claude Code scaffolded the mutations, dropdown wiring, and styles. I drove the design decisions (where the start/stop lives, how status is surfaced, fallback URL when stopped) and iterated on the focus/loading state bugs as they came up — each fix is explained in the commit message and code comments so the reasoning is reviewable rather than buried in chat.

## Proposed Changes

- **Sidebar project actions menu**: the moreHorizontal button on each project now opens a menu with **Start site** / **Stop site**, disabled while the transition is in-flight.
- **Site dropdown on the session header** gets a **Start / Stop** button on the "Local site" row (uses `Button`'s built-in `loading` state so it shows a spinner, hides the label, and announces "Starting" / "Stopping" to AT).
- **Status dot** on the site dropdown trigger reflects the real server state: green (running), red (stopped), blue blinking (transitioning). Hardcoded colors because ` --wpds-color-fg-content-success` resolves to `#002900` (reads as black at 6px) and the `critical` / `accent` equivalents don't exist.
- **Data layer**: new `useStartSite` / `useStopSite` mutations with keyed per-site pending detection via `useIsSiteStarting` / `useIsSiteStopping`; the sites query invalidation is folded into the `mutationFn` itself so `isPending` stays true until `site.running` actually reflects the new state (otherwise the button briefly flipped back to enabled between the IPC resolving and the refetch landing).
- **Connector**: new `onSiteEvent` subscription on the existing `site-event` IPC channel wires into a `<SiteEventsBridge />` at the app root so cached sites stay in sync when the main process emits changes.
- **Subtitle stability**: the sidebar subtitle and the dropdown's "Local site" sublabel fall back to `localhost:<port>` when the site is stopped. The main process strips `url` on stop but keeps `port`, so the previous folder-basename fallback was often showing the site title — stable `localhost:<port>` avoids that flicker.
- **Focus ergonomics inside the popup**: Base UI's `FloatingFocusManager` programmatically focuses the first tabbable element when the popup opens. `@wordpress/ui`'s Button paints a filled background + active border on plain `:focus` (not just `:hover`/`:active`), which made the Start button visibly "selected" after a mouse click on the trigger. A scoped `.popup button:focus:not(:focus-visible)` rule neutralizes both. `color` is deliberately left alone so `.is-loading { color: transparent }` still hides the label. The outline ring is handled by the pre-existing global rule in `index.css`.

## Testing Instructions

1. Open the new UI (`apps/ui`) and pick a project with at least one session.
2. In the sidebar, hover the project row and open the "Project actions" menu — click **Start site** / **Stop site** and verify the site transitions. Open the menu again and confirm the item disables while the server is transitioning.
3. In the session header, open the site dropdown:
   - Dot is **green** when running, **red** when stopped, and **blue blinking** while starting/stopping.
   - **Local site** row shows the live URL when running, `localhost:<port>` when stopped, and **Starting… / Stopping…** during transitions.
   - Click **Start** / **Stop** — the button displays the spinner, is disabled for the whole transition, and stays disabled until the sites list actually reports the new running state.
4. Click the ⋯ trigger to open the popup with a mouse — the Start/Stop button should not appear highlighted/outlined just from being in the popup. Keyboard-focusing the same button via Tab should still show the standard focus ring.
5. Sidebar subtitle under the project name should stay URL-shaped (`localhost:<port>`) when the site is stopped, not flip to the folder basename.

## Pre-merge Checklist

- [x] Have you checked for TypeScript, React or other console errors? (`apps/ui` typecheck passes cleanly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)