### PR TITLE
Fix path traversal (Wpress Slip) in .wpress extractor

### DIFF
--- a/apps/cli/lib/import-export/import/handlers/backup-handler-wpress.ts
+++ b/apps/cli/lib/import-export/import/handlers/backup-handler-wpress.ts
@@ -186,7 +186,10 @@ export class BackupHandlerWpress extends EventEmitter implements BackupHandler {
 			do {
 				header = await readHeader( inputFile );
 				if ( header ) {
-					fileNames.push( path.join( header.prefix, header.name ) );
+				const filePath = path.join( header.prefix, header.name );
+					if ( ! filePath.split( path.sep ).includes( '..' ) ) {
+						fileNames.push( filePath );
+					}
 					await inputFile.read( Buffer.alloc( header.size ), 0, header.size, null );
 				}
 			} while ( header );

--- a/apps/cli/lib/import-export/import/handlers/backup-handler-wpress.ts
+++ b/apps/cli/lib/import-export/import/handlers/backup-handler-wpress.ts
@@ -186,7 +186,7 @@ export class BackupHandlerWpress extends EventEmitter implements BackupHandler {
 			do {
 				header = await readHeader( inputFile );
 				if ( header ) {
-				const filePath = path.join( header.prefix, header.name );
+					const filePath = path.join( header.prefix, header.name );
 					if ( ! filePath.split( path.sep ).includes( '..' ) ) {
 						fileNames.push( filePath );
 					}

--- a/apps/cli/lib/import-export/import/handlers/backup-handler-wpress.ts
+++ b/apps/cli/lib/import-export/import/handlers/backup-handler-wpress.ts
@@ -77,6 +77,12 @@ async function readHeader( fd: fs.promises.FileHandle ): Promise< Header | null 
 	};
 }
 
+function isPathWithinDirectory( filePath: string, directory: string ): boolean {
+	const resolvedFile = path.resolve( filePath );
+	const resolvedDir = path.resolve( directory );
+	return resolvedFile.startsWith( resolvedDir + path.sep ) || resolvedFile === resolvedDir;
+}
+
 /**
  * Reads a block of data from a .wpress file and writes it to a file.
  *
@@ -86,6 +92,12 @@ async function readHeader( fd: fs.promises.FileHandle ): Promise< Header | null 
  */
 async function readBlockToFile( fd: fs.promises.FileHandle, header: Header, outputPath: string ) {
 	const outputFilePath = path.join( outputPath, header.prefix, header.name );
+
+	if ( ! isPathWithinDirectory( outputFilePath, outputPath ) ) {
+		await fd.read( Buffer.alloc( header.size ), 0, header.size, null );
+		return;
+	}
+
 	await fse.ensureDir( path.dirname( outputFilePath ) );
 	const outputStream = fs.createWriteStream( outputFilePath );
 

--- a/apps/studio/src/lib/import-export/import/handlers/backup-handler-wpress.ts
+++ b/apps/studio/src/lib/import-export/import/handlers/backup-handler-wpress.ts
@@ -191,7 +191,10 @@ export class BackupHandlerWpress extends EventEmitter implements BackupHandler {
 			do {
 				header = await readHeader( inputFile );
 				if ( header ) {
-					fileNames.push( path.join( header.prefix, header.name ) );
+					const filePath = path.join( header.prefix, header.name );
+					if ( ! filePath.split( path.sep ).includes( '..' ) ) {
+						fileNames.push( filePath );
+					}
 					await inputFile.read( Buffer.alloc( header.size ), 0, header.size, null );
 				}
 			} while ( header );

--- a/apps/studio/src/lib/import-export/import/handlers/backup-handler-wpress.ts
+++ b/apps/studio/src/lib/import-export/import/handlers/backup-handler-wpress.ts
@@ -77,6 +77,12 @@ async function readHeader( fd: fs.promises.FileHandle ): Promise< Header | null 
 	};
 }
 
+function isPathWithinDirectory( filePath: string, directory: string ): boolean {
+	const resolvedFile = path.resolve( filePath );
+	const resolvedDir = path.resolve( directory );
+	return resolvedFile.startsWith( resolvedDir + path.sep ) || resolvedFile === resolvedDir;
+}
+
 /**
  * Reads a block of data from a .wpress file and writes it to a file.
  *
@@ -86,6 +92,12 @@ async function readHeader( fd: fs.promises.FileHandle ): Promise< Header | null 
  */
 async function readBlockToFile( fd: fs.promises.FileHandle, header: Header, outputPath: string ) {
 	const outputFilePath = path.join( outputPath, header.prefix, header.name );
+
+	if ( ! isPathWithinDirectory( outputFilePath, outputPath ) ) {
+		await fd.read( Buffer.alloc( header.size ), 0, header.size, null );
+		return;
+	}
+
 	await fse.ensureDir( path.dirname( outputFilePath ) );
 	const outputStream = fs.createWriteStream( outputFilePath );
 

--- a/apps/studio/src/lib/import-export/tests/import/handlers/backup-handler-wpress.test.ts
+++ b/apps/studio/src/lib/import-export/tests/import/handlers/backup-handler-wpress.test.ts
@@ -5,8 +5,8 @@
  *   npm test -- backup-handler-wpress
  */
 import fs from 'fs';
-import path from 'path';
 import os from 'os';
+import path from 'path';
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { BackupHandlerWpress } from 'src/lib/import-export/import/handlers/backup-handler-wpress';
 
@@ -16,10 +16,10 @@ const HEADER_SIZE = 4377;
 
 function makeHeader( name: string, size: number, prefix: string ): Buffer {
 	const h = Buffer.alloc( HEADER_SIZE );
-	h.write( name,          0,   'utf8' );
+	h.write( name, 0, 'utf8' );
 	h.write( String( size ), 255, 'utf8' );
-	h.write( '0',           269, 'utf8' );
-	h.write( prefix,        281, 'utf8' );
+	h.write( '0', 269, 'utf8' );
+	h.write( prefix, 281, 'utf8' );
 	return h;
 }
 
@@ -57,7 +57,9 @@ describe( 'BackupHandlerWpress — path traversal protection', () => {
 	it( 'blocks a traversal entry with prefix=".."', async () => {
 		fs.writeFileSync(
 			archivePath,
-			buildWpress( [ { name: 'traversal-marker.txt', prefix: '..', content: 'should not land here\n' } ] )
+			buildWpress( [
+				{ name: 'traversal-marker.txt', prefix: '..', content: 'should not land here\n' },
+			] )
 		);
 
 		await handler.extractFiles( { path: archivePath }, extractDir );
@@ -69,7 +71,9 @@ describe( 'BackupHandlerWpress — path traversal protection', () => {
 	it( 'blocks a deep traversal targeting a specific path', async () => {
 		fs.writeFileSync(
 			archivePath,
-			buildWpress( [ { name: 'authorized_keys', prefix: '../../../.ssh', content: 'ssh-rsa AAAA...\n' } ] )
+			buildWpress( [
+				{ name: 'authorized_keys', prefix: '../../../.ssh', content: 'ssh-rsa AAAA...\n' },
+			] )
 		);
 
 		await handler.extractFiles( { path: archivePath }, extractDir );
@@ -81,8 +85,8 @@ describe( 'BackupHandlerWpress — path traversal protection', () => {
 		fs.writeFileSync(
 			archivePath,
 			buildWpress( [
-				{ name: 'evil.txt',     prefix: '..', content: 'bad\n' },
-				{ name: 'safe-file.txt', prefix: '',  content: 'good\n' },
+				{ name: 'evil.txt', prefix: '..', content: 'bad\n' },
+				{ name: 'safe-file.txt', prefix: '', content: 'good\n' },
 			] )
 		);
 
@@ -95,17 +99,23 @@ describe( 'BackupHandlerWpress — path traversal protection', () => {
 		fs.writeFileSync(
 			archivePath,
 			buildWpress( [
-				{ name: 'db.sql',        prefix: '',                              content: '-- dump\n'    },
-				{ name: 'photo.jpg',     prefix: 'wp-content/uploads',           content: 'img data'     },
-				{ name: 'my-plugin.php', prefix: 'wp-content/plugins/my-plugin', content: '<?php // ok'  },
+				{ name: 'db.sql', prefix: '', content: '-- dump\n' },
+				{ name: 'photo.jpg', prefix: 'wp-content/uploads', content: 'img data' },
+				{ name: 'my-plugin.php', prefix: 'wp-content/plugins/my-plugin', content: '<?php // ok' },
 			] )
 		);
 
 		await handler.extractFiles( { path: archivePath }, extractDir );
 
 		expect( fs.existsSync( path.join( extractDir, 'db.sql' ) ) ).toBe( true );
-		expect( fs.existsSync( path.join( extractDir, 'wp-content', 'uploads', 'photo.jpg' ) ) ).toBe( true );
-		expect( fs.existsSync( path.join( extractDir, 'wp-content', 'plugins', 'my-plugin', 'my-plugin.php' ) ) ).toBe( true );
+		expect( fs.existsSync( path.join( extractDir, 'wp-content', 'uploads', 'photo.jpg' ) ) ).toBe(
+			true
+		);
+		expect(
+			fs.existsSync(
+				path.join( extractDir, 'wp-content', 'plugins', 'my-plugin', 'my-plugin.php' )
+			)
+		).toBe( true );
 	} );
 } );
 
@@ -129,7 +139,7 @@ describe( 'BackupHandlerWpress — listFiles traversal filtering', () => {
 			archivePath,
 			buildWpress( [
 				{ name: 'traversal-marker.txt', prefix: '..', content: 'bad\n' },
-				{ name: 'database.sql',          prefix: '',   content: '-- ok\n' },
+				{ name: 'database.sql', prefix: '', content: '-- ok\n' },
 			] )
 		);
 

--- a/apps/studio/src/lib/import-export/tests/import/handlers/backup-handler-wpress.test.ts
+++ b/apps/studio/src/lib/import-export/tests/import/handlers/backup-handler-wpress.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Tests for the path traversal (Wpress Slip) fix in BackupHandlerWpress.
+ *
+ * Run with:
+ *   npm test -- backup-handler-wpress
+ */
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { BackupHandlerWpress } from 'src/lib/import-export/import/handlers/backup-handler-wpress';
+
+// ── .wpress builder ──────────────────────────────────────────────────────────
+
+const HEADER_SIZE = 4377;
+
+function makeHeader( name: string, size: number, prefix: string ): Buffer {
+	const h = Buffer.alloc( HEADER_SIZE );
+	h.write( name,          0,   'utf8' );
+	h.write( String( size ), 255, 'utf8' );
+	h.write( '0',           269, 'utf8' );
+	h.write( prefix,        281, 'utf8' );
+	return h;
+}
+
+function buildWpress( entries: { name: string; prefix: string; content: string }[] ): Buffer {
+	const parts: Buffer[] = [];
+	for ( const { name, prefix, content } of entries ) {
+		const data = Buffer.from( content, 'utf8' );
+		parts.push( makeHeader( name, data.length, prefix ) );
+		parts.push( data );
+	}
+	parts.push( Buffer.alloc( HEADER_SIZE ) ); // EOF marker
+	return Buffer.concat( parts );
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe( 'BackupHandlerWpress — path traversal protection', () => {
+	let tmpDir: string;
+	let extractDir: string;
+	let archivePath: string;
+	let handler: BackupHandlerWpress;
+
+	beforeEach( () => {
+		tmpDir = fs.mkdtempSync( path.join( os.tmpdir(), 'studio-wpress-test-' ) );
+		extractDir = path.join( tmpDir, 'extract' );
+		archivePath = path.join( tmpDir, 'test.wpress' );
+		fs.mkdirSync( extractDir );
+		handler = new BackupHandlerWpress();
+	} );
+
+	afterEach( () => {
+		fs.rmSync( tmpDir, { recursive: true, force: true } );
+	} );
+
+	it( 'blocks a traversal entry with prefix=".."', async () => {
+		fs.writeFileSync(
+			archivePath,
+			buildWpress( [ { name: 'traversal-marker.txt', prefix: '..', content: 'should not land here\n' } ] )
+		);
+
+		await handler.extractFiles( { path: archivePath }, extractDir );
+
+		// Must NOT appear one level above the extraction dir
+		expect( fs.existsSync( path.join( tmpDir, 'traversal-marker.txt' ) ) ).toBe( false );
+	} );
+
+	it( 'blocks a deep traversal targeting a specific path', async () => {
+		fs.writeFileSync(
+			archivePath,
+			buildWpress( [ { name: 'authorized_keys', prefix: '../../../.ssh', content: 'ssh-rsa AAAA...\n' } ] )
+		);
+
+		await handler.extractFiles( { path: archivePath }, extractDir );
+
+		expect( fs.existsSync( path.join( tmpDir, '.ssh', 'authorized_keys' ) ) ).toBe( false );
+	} );
+
+	it( 'extracts a safe entry that follows a blocked traversal entry', async () => {
+		fs.writeFileSync(
+			archivePath,
+			buildWpress( [
+				{ name: 'evil.txt',     prefix: '..', content: 'bad\n' },
+				{ name: 'safe-file.txt', prefix: '',  content: 'good\n' },
+			] )
+		);
+
+		await handler.extractFiles( { path: archivePath }, extractDir );
+
+		expect( fs.existsSync( path.join( extractDir, 'safe-file.txt' ) ) ).toBe( true );
+	} );
+
+	it( 'extracts all files from a legitimate archive', async () => {
+		fs.writeFileSync(
+			archivePath,
+			buildWpress( [
+				{ name: 'db.sql',        prefix: '',                              content: '-- dump\n'    },
+				{ name: 'photo.jpg',     prefix: 'wp-content/uploads',           content: 'img data'     },
+				{ name: 'my-plugin.php', prefix: 'wp-content/plugins/my-plugin', content: '<?php // ok'  },
+			] )
+		);
+
+		await handler.extractFiles( { path: archivePath }, extractDir );
+
+		expect( fs.existsSync( path.join( extractDir, 'db.sql' ) ) ).toBe( true );
+		expect( fs.existsSync( path.join( extractDir, 'wp-content', 'uploads', 'photo.jpg' ) ) ).toBe( true );
+		expect( fs.existsSync( path.join( extractDir, 'wp-content', 'plugins', 'my-plugin', 'my-plugin.php' ) ) ).toBe( true );
+	} );
+} );
+
+describe( 'BackupHandlerWpress — listFiles traversal filtering', () => {
+	let tmpDir: string;
+	let archivePath: string;
+	let handler: BackupHandlerWpress;
+
+	beforeEach( () => {
+		tmpDir = fs.mkdtempSync( path.join( os.tmpdir(), 'studio-wpress-list-test-' ) );
+		archivePath = path.join( tmpDir, 'test.wpress' );
+		handler = new BackupHandlerWpress();
+	} );
+
+	afterEach( () => {
+		fs.rmSync( tmpDir, { recursive: true, force: true } );
+	} );
+
+	it( 'excludes traversal entries from the file list', async () => {
+		fs.writeFileSync(
+			archivePath,
+			buildWpress( [
+				{ name: 'traversal-marker.txt', prefix: '..', content: 'bad\n' },
+				{ name: 'database.sql',          prefix: '',   content: '-- ok\n' },
+			] )
+		);
+
+		const files = await handler.listFiles( { path: archivePath } );
+
+		expect( files.some( ( f ) => f.includes( '..' ) ) ).toBe( false );
+		expect( files ).toContain( 'database.sql' );
+	} );
+} );

--- a/apps/studio/src/lib/import-export/tests/import/handlers/backup-handler-wpress.test.ts
+++ b/apps/studio/src/lib/import-export/tests/import/handlers/backup-handler-wpress.test.ts
@@ -62,7 +62,7 @@ describe( 'BackupHandlerWpress — path traversal protection', () => {
 			] )
 		);
 
-		await handler.extractFiles( { path: archivePath }, extractDir );
+		await handler.extractFiles( { path: archivePath, type: 'wpress' }, extractDir );
 
 		// Must NOT appear one level above the extraction dir
 		expect( fs.existsSync( path.join( tmpDir, 'traversal-marker.txt' ) ) ).toBe( false );
@@ -76,7 +76,7 @@ describe( 'BackupHandlerWpress — path traversal protection', () => {
 			] )
 		);
 
-		await handler.extractFiles( { path: archivePath }, extractDir );
+		await handler.extractFiles( { path: archivePath, type: 'wpress' }, extractDir );
 
 		expect( fs.existsSync( path.join( tmpDir, '.ssh', 'authorized_keys' ) ) ).toBe( false );
 	} );
@@ -90,7 +90,7 @@ describe( 'BackupHandlerWpress — path traversal protection', () => {
 			] )
 		);
 
-		await handler.extractFiles( { path: archivePath }, extractDir );
+		await handler.extractFiles( { path: archivePath, type: 'wpress' }, extractDir );
 
 		expect( fs.existsSync( path.join( extractDir, 'safe-file.txt' ) ) ).toBe( true );
 	} );
@@ -105,7 +105,7 @@ describe( 'BackupHandlerWpress — path traversal protection', () => {
 			] )
 		);
 
-		await handler.extractFiles( { path: archivePath }, extractDir );
+		await handler.extractFiles( { path: archivePath, type: 'wpress' }, extractDir );
 
 		expect( fs.existsSync( path.join( extractDir, 'db.sql' ) ) ).toBe( true );
 		expect( fs.existsSync( path.join( extractDir, 'wp-content', 'uploads', 'photo.jpg' ) ) ).toBe(
@@ -143,7 +143,7 @@ describe( 'BackupHandlerWpress — listFiles traversal filtering', () => {
 			] )
 		);
 
-		const files = await handler.listFiles( { path: archivePath } );
+		const files = await handler.listFiles( { path: archivePath, type: 'wpress' } );
 
 		expect( files.some( ( f ) => f.includes( '..' ) ) ).toBe( false );
 		expect( files ).toContain( 'database.sql' );


### PR DESCRIPTION
## Related issues

Reported via HackerOne (path traversal / Wpress Slip in `BackupHandlerWpress`).

## Proposed Changes

`readBlockToFile` joined `header.prefix` and `header.name` from the archive directly into the output path with no bounds check. A crafted `.wpress` file with `prefix=".."` could write files outside the extraction directory — anywhere the Studio user has write access (shell config, SSH keys, launch agents, etc.).

This is analogous to the Zip Slip class of vulnerabilities.

**Fix:** Add `isPathWithinDirectory()` using `path.resolve()` to check that the resolved output path stays within the extraction directory before writing. Traversal entries are silently skipped; their data bytes are consumed so the file cursor stays aligned for subsequent entries.

Both affected files patched identically:
- `apps/studio/src/lib/import-export/import/handlers/backup-handler-wpress.ts`
- `apps/cli/lib/import-export/import/handlers/backup-handler-wpress.ts`

The `.zip` and `.tar.gz` handlers are not affected (they delegate to `yauzl` / `tar` which handle this at the library level).

## Testing Instructions

- [ ] Craft a `.wpress` with `prefix=".."` (30-line Python script from the report). Import via Studio → verify no file appears outside the extraction directory.
- [ ] Import a legitimate `.wpress` backup → verify it extracts correctly and the import completes successfully.
- [ ] Confirm no regressions in normal import flow for `.zip` and `.tar.gz` formats.

## Pre-merge Checklist

- [x] Linter passes on modified files
- [x] TypeScript typecheck passes for `apps/studio` and `apps/cli`
- [ ] CI passes